### PR TITLE
fix: use RELEASE_TOKEN PAT in CI release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          token: ${{ secrets.RELEASE_TOKEN }}
           lfs: true
       - uses: oven-sh/setup-bun@v2
         with:
@@ -231,6 +232,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          token: ${{ secrets.RELEASE_TOKEN }}
           files: packages/coding-agent/binaries/*
           generate_release_notes: true
       - name: Publish to npm


### PR DESCRIPTION
## Summary

- Switch the release job in CI to use `secrets.RELEASE_TOKEN` PAT instead of the default `GITHUB_TOKEN`
- Applies to both the `actions/checkout@v4` step and the `softprops/action-gh-release@v2` step
- Ensures the release workflow continues to function once branch protections are enabled on `main`

Closes #3

## Test plan

- [ ] CI checks pass on this PR
- [ ] Verify the `RELEASE_TOKEN` secret is configured in the repository settings
- [ ] After merge, confirm the next release workflow succeeds with branch protections active