### PR TITLE
fix: pass TARGET_VARIANTS matrix param to native build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
           CROSS_TARGET: ${{ matrix.target }}
           TARGET_PLATFORM: ${{ matrix.platform }}
           TARGET_ARCH: ${{ matrix.arch }}
+          TARGET_VARIANTS: ${{ matrix.variants }}
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- The CI matrix defines `variants: "baseline modern"` for x64 native builds, but the build step never passed it as the `TARGET_VARIANTS` env var
- Without it, `ci-build-native.ts` ran a single "default" build that auto-detected AVX2, expected a variant-tagged `.node` file, but napi-rs produced the untagged filename — causing the macOS Intel build to fail
- Adds `TARGET_VARIANTS: ${{ matrix.variants }}` to the build step env

Fixes the failure in [CI run #24168271533](https://github.com/f5xc-salesdemos/xcsh/actions/runs/24168271533/job/70534394131).

## Test plan
- [ ] CI `native (ubuntu-22.04, linux, x64, baseline modern)` passes with both baseline and modern variants built
- [ ] Tag push triggers macOS Intel build that now correctly builds baseline and modern variants separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)