### PR TITLE
fix(natives): detect compiled binary via PI_COMPILED global constant

### DIFF
--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -28,7 +28,18 @@ const userDataDir =
 	process.platform === "win32"
 		? path.join(process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local"), "xcsh")
 		: path.join(os.homedir(), ".local", "bin");
+// PI_COMPILED is replaced with `true` at compile time by bun build --define PI_COMPILED=true.
+// In non-compiled contexts the identifier is undefined, so wrap in try-catch.
+// The __filename checks are kept as a secondary heuristic but are unreliable
+// in Bun compiled binaries where __filename resolves to the original build path.
+let _piCompiledFlag = false;
+try {
+	_piCompiledFlag = !!PI_COMPILED;
+} catch {
+	// Not a compiled binary (PI_COMPILED is not defined)
+}
 const isCompiledBinary =
+	_piCompiledFlag ||
 	process.env.PI_COMPILED ||
 	__filename.includes("$bunfs") ||
 	__filename.includes("~BUN") ||

--- a/scripts/ci-release-build-binaries.ts
+++ b/scripts/ci-release-build-binaries.ts
@@ -94,12 +94,56 @@ async function resetArtifacts(): Promise<void> {
 	await $`bun --cwd=packages/stats scripts/generate-client-bundle.ts --reset`.cwd(repoRoot);
 }
 
+async function smokeTestHostBinary(): Promise<void> {
+	const hostPlatform = process.platform;
+	const hostArch = process.arch;
+	const hostTarget = targets.find((t) => t.platform === hostPlatform && t.arch === hostArch);
+	if (!hostTarget) {
+		console.log(`Skipping compiled binary smoke test (no target for ${hostPlatform}-${hostArch})`);
+		return;
+	}
+
+	const binaryPath = path.join(repoRoot, hostTarget.outfile);
+	try {
+		await fs.stat(binaryPath);
+	} catch {
+		console.log(`Skipping compiled binary smoke test (${hostTarget.outfile} not found)`);
+		return;
+	}
+
+	console.log(`Smoke-testing ${hostTarget.outfile}...`);
+	const result = Bun.spawnSync([binaryPath, "--version"], {
+		stdout: "pipe",
+		stderr: "pipe",
+		env: { ...Bun.env, HOME: await fs.mkdtemp(path.join(repoRoot, ".tmp-smoke-")), PI_DEV: "1" },
+	});
+
+	const stderr = result.stderr.toString();
+	if (result.exitCode !== 0) {
+		console.error(`FAIL: compiled binary exited with code ${result.exitCode}`);
+		console.error(stderr);
+		throw new Error("Compiled binary smoke test failed — native addon may not be embedded correctly");
+	}
+
+	const stdout = result.stdout.toString().trim();
+	console.log(`  ${stdout}`);
+	if (stderr.includes("Failed to load pi_natives")) {
+		console.error(`FAIL: compiled binary could not load native addon`);
+		console.error(stderr);
+		throw new Error("Compiled binary smoke test failed — native addon loading error detected");
+	}
+	console.log(`Smoke test passed for ${hostTarget.outfile}`);
+}
+
 async function main(): Promise<void> {
 	await fs.mkdir(binariesDir, { recursive: true });
 	await generateBundle();
 	try {
 		for (const target of targets) {
 			await buildBinary(target);
+		}
+		if (!isDryRun) {
+			await smokeTestHostBinary();
 		}
 	} finally {
 		await resetArtifacts();


### PR DESCRIPTION
## Summary

- Fix `isCompiledBinary` detection which was broken in all Bun compiled binaries, causing native addon loading to fail after `xcsh update`
- Add compiled binary smoke test to `ci-release-build-binaries.ts` that catches this class of regression before release

## Root Cause

In Bun compiled binaries, `__filename` resolves to the **original build-time path** (e.g., `/home/runner/work/xcsh/xcsh/packages/natives/native/index.js`), not a `$bunfs` path. This means all four detection methods in `isCompiledBinary` were failing:

| Detection | Why it fails |
|-----------|-------------|
| `process.env.PI_COMPILED` | Runtime env var — `--define PI_COMPILED=true` replaces the bare identifier, not member accesses |
| `__filename.includes("$bunfs")` | `__filename` is the build-time path in Bun compiled CJS modules |
| `__filename.includes("~BUN")` | Same reason |
| `__filename.includes("%7EBUN")` | Same reason |

**Result**: The native addon IS embedded in the binary, but the loader never activates the extraction logic, falling back to paths that don't exist on the user's machine.

This is the same root cause as can1357/oh-my-pi#651.

## Fix

Use the bare `PI_COMPILED` identifier which `--define PI_COMPILED=true` correctly replaces at compile time. Wrap in try-catch for non-compiled contexts where it's undefined:

```javascript
let _piCompiledFlag = false;
try { _piCompiledFlag = !!PI_COMPILED; } catch {}
```

## Test plan

- [x] Verified `__filename` behavior in Bun compiled binary: resolves to build-time path, not `$bunfs`
- [x] Verified bare `PI_COMPILED` is replaced by `--define`: `true` in compiled, ReferenceError (caught) in dev
- [x] Built compiled binary locally, tested `--version`: loads native addon successfully
- [x] `bun test packages/natives/test/native.test.ts`: 30 tests pass
- [x] New smoke test in `ci-release-build-binaries.ts` verifies host-platform binary after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)