### PR TITLE
feat: sync 11 upstream commits from can1357/oh-my-pi

### DIFF
--- a/crates/pi-natives/src/chunk/edit.rs
+++ b/crates/pi-natives/src/chunk/edit.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use crate::chunk::{
 	indent::{
-		detect_file_indent_char, detect_file_indent_step, expand_indent,
+		denormalize_from_tabs, detect_file_indent_char, detect_file_indent_step,
 		normalize_leading_whitespace_char, reindent_inserted_block, strip_content_prefixes,
 	},
 	kind::ChunkKind,
@@ -706,7 +706,7 @@ fn normalize_inserted_content(
 	normalized = strip_content_prefixes(&normalized);
 	normalized = normalized
 		.split('\n')
-		.map(|line| expand_indent(line, file_indent_char, file_indent_step.unwrap_or(1)))
+		.map(|line| denormalize_from_tabs(line, file_indent_char, file_indent_step.unwrap_or(1)))
 		.collect::<Vec<_>>()
 		.join("\n");
 	if target_indent.is_empty() {

--- a/crates/pi-natives/src/chunk/indent.rs
+++ b/crates/pi-natives/src/chunk/indent.rs
@@ -74,7 +74,11 @@ pub fn count_indent_columns(whitespace: &str, space_step: usize) -> usize {
 		.sum()
 }
 
-pub fn compact_indent(line: &str, indent_char: char, indent_step: usize) -> String {
+pub fn normalize_to_tabs(line: &str, indent_char: char, indent_step: usize) -> String {
+	if indent_char == '\t' {
+		return line.to_owned();
+	}
+
 	let whitespace = leading_whitespace(line);
 	if whitespace.is_empty() {
 		return line.to_owned();
@@ -82,12 +86,16 @@ pub fn compact_indent(line: &str, indent_char: char, indent_step: usize) -> Stri
 
 	let step = indent_step.max(1);
 	let total_columns = count_indent_columns(whitespace, step);
-	let levels = total_columns / step;
-	let _ = indent_char;
-	format!("{}{}", " ".repeat(levels), &line[whitespace.len()..])
+	let tabs = total_columns / step;
+	let remainder = total_columns % step;
+	format!("{}{}{}", "\t".repeat(tabs), " ".repeat(remainder), &line[whitespace.len()..])
 }
 
-pub fn expand_indent(line: &str, file_indent_char: char, file_indent_step: usize) -> String {
+pub fn denormalize_from_tabs(
+	line: &str,
+	file_indent_char: char,
+	file_indent_step: usize,
+) -> String {
 	if file_indent_char != ' ' && file_indent_char != '\t' {
 		return line.to_owned();
 	}
@@ -98,13 +106,16 @@ pub fn expand_indent(line: &str, file_indent_char: char, file_indent_step: usize
 	}
 
 	let step = file_indent_step.max(1);
-	let levels = whitespace.chars().count();
-	let indent = if file_indent_char == '\t' {
-		"\t".repeat(levels)
-	} else {
-		" ".repeat(levels * step)
-	};
-	format!("{indent}{}", &line[whitespace.len()..])
+	let mut converted = String::with_capacity(whitespace.len() * step.max(1));
+	for ch in whitespace.chars() {
+		match ch {
+			'\t' if file_indent_char == '\t' => converted.push('\t'),
+			'\t' => converted.push_str(&file_indent_char.to_string().repeat(step)),
+			' ' => converted.push(' '),
+			_ => converted.push(ch),
+		}
+	}
+	format!("{converted}{}", &line[whitespace.len()..])
 }
 
 pub fn normalize_target_indent(target_indent: &str, sample_text: &str) -> String {
@@ -533,18 +544,18 @@ mod tests {
 	#[test]
 	fn canonical_indent_round_trips_common_profiles() {
 		let cases = [
-			("    value()", ' ', 4, " value()", "    value()"),
-			("      value()", ' ', 3, "  value()", "      value()"),
-			("  value()", ' ', 2, " value()", "  value()"),
-			("\tvalue()", '\t', 4, " value()", "\tvalue()"),
-			(" \t  value()", ' ', 4, " value()", "    value()"),
+			("    value()", ' ', 4, "\tvalue()", "    value()"),
+			("      value()", ' ', 3, "\t\tvalue()", "      value()"),
+			("  value()", ' ', 2, "\tvalue()", "  value()"),
+			("\tvalue()", '\t', 4, "\tvalue()", "\tvalue()"),
+			(" \t  value()", ' ', 4, "\t   value()", "       value()"),
 		];
 
 		for (input, indent_char, indent_step, canonical, restored) in cases {
-			let normalized = compact_indent(input, indent_char, indent_step);
+			let normalized = normalize_to_tabs(input, indent_char, indent_step);
 			assert_eq!(normalized, canonical, "unexpected canonical indent for {input:?}");
 			assert_eq!(
-				expand_indent(&normalized, indent_char, indent_step),
+				denormalize_from_tabs(&normalized, indent_char, indent_step),
 				restored,
 				"unexpected restored indent for {input:?}"
 			);
@@ -553,9 +564,9 @@ mod tests {
 
 	#[test]
 	fn reindent_inserted_block_preserves_relative_indentation() {
-		// The block already uses spaces after canonical content has been expanded
-		// back into the file's indent unit. Reindent should preserve those relative
-		// offsets while adding the target indent.
+		// Agent sends tab-based content: call(\n\talpha,\n\tbeta,\n)
+		// After denormalize_from_tabs (4 spaces/tab): call(\n    alpha,\n    beta,\n)
+		// Should add target indent to all lines, preserving relative offsets.
 		let input = "call(\n    alpha,\n    beta,\n)";
 		assert_eq!(
 			reindent_inserted_block(input, "    ", Some(4)),

--- a/crates/pi-natives/src/chunk/render.rs
+++ b/crates/pi-natives/src/chunk/render.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::{
 	chunk::{
-		indent::{compact_indent, detect_file_indent_char, detect_file_indent_step},
+		indent::{detect_file_indent_char, detect_file_indent_step, normalize_to_tabs},
 		state::{ChunkStateInner, mask_chunk_display_source},
 		types::{
 			ChunkAnchorStyle, ChunkFocusMode, ChunkNode, ChunkTree, RenderParams, VisibleLineRange,
@@ -34,7 +34,7 @@ fn normalize_rendered_line(
 	tab_replacement: &str,
 ) -> String {
 	match normalize_indent {
-		Some((indent_char, indent_step)) => compact_indent(line, indent_char, indent_step),
+		Some((indent_char, indent_step)) => normalize_to_tabs(line, indent_char, indent_step),
 		None => line.replace('\t', tab_replacement),
 	}
 }
@@ -897,7 +897,7 @@ pub fn hunk_indent_for_chunk(
 	};
 	let base = chunk_body_anchor_indent(&source_lines, chunk, tab_replacement, normalize_indent);
 	match normalize_indent {
-		Some(_) => format!("{base} "),
+		Some(_) => format!("{base}\t"),
 		None => format!("{base}{tab_replacement}"),
 	}
 }

--- a/crates/pi-natives/src/chunk/state.rs
+++ b/crates/pi-natives/src/chunk/state.rs
@@ -9,7 +9,7 @@ use regex::Regex;
 
 use super::{
 	build_chunk_tree,
-	indent::{compact_indent, detect_file_indent_char, detect_file_indent_step},
+	indent::{detect_file_indent_char, detect_file_indent_step, normalize_to_tabs},
 	resolve::{
 		ParsedSelector, chunk_region_range, format_region_ref, format_selector_tree,
 		resolve_chunk_selector, resolve_chunk_with_crc, split_selector_crc_and_region,
@@ -487,7 +487,9 @@ impl ChunkState {
 				.unwrap_or_default()
 				.split('\n')
 				.map(|line| match normalize_indent {
-					Some((indent_char, indent_step)) => compact_indent(line, indent_char, indent_step),
+					Some((indent_char, indent_step)) => {
+						normalize_to_tabs(line, indent_char, indent_step)
+					},
 					None => line.replace('\t', tab_replacement),
 				})
 				.collect::<Vec<_>>()

--- a/crates/pi-natives/src/chunk/types.rs
+++ b/crates/pi-natives/src/chunk/types.rs
@@ -287,8 +287,7 @@ pub struct RenderParams {
 	pub show_leaf_preview:    bool,
 	/// Replace tab characters in displayed previews (e.g. two spaces).
 	pub tab_replacement:      Option<String>,
-	/// When true, normalize displayed indentation to canonical single-space
-	/// indent.
+	/// When true, normalize displayed indentation to canonical tabs.
 	pub normalize_indent:     Option<bool>,
 
 	/// When set, restrict rendering to these chunks with their specified focus
@@ -315,8 +314,7 @@ pub struct ReadRenderParams {
 	pub absolute_line_range: Option<VisibleLineRange>,
 	/// Replace tabs in embedded previews.
 	pub tab_replacement:     Option<String>,
-	/// When true, normalize displayed indentation to canonical single-space
-	/// indent.
+	/// When true, normalize displayed indentation to canonical tabs.
 	pub normalize_indent:    Option<bool>,
 }
 

--- a/docs/porting-from-pi-mono.md
+++ b/docs/porting-from-pi-mono.md
@@ -5,7 +5,7 @@ Use it for any merge: single file, feature branch, or full release sync.
 
 ## Last Sync Point
 
-**Commit:** `b21b42d032919de2f2e6920a76fa9a37c3920c0a`
+**Commit:** `d350ea60e` (can1357/oh-my-pi) — upstream sync 2026-04-09
 **Date:** 2026-03-22
 
 Update this section after each sync; do not reuse the previous range.
@@ -13,7 +13,7 @@ Update this section after each sync; do not reuse the previous range.
 When starting a new sync, generate patches from this commit forward:
 
 ```bash
-git format-patch b21b42d032919de2f2e6920a76fa9a37c3920c0a..HEAD --stdout > changes.patch
+git format-patch d350ea60e..HEAD --stdout > changes.patch
 ```
 
 ## 0) Define the scope

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ollama discovery cache normalization so cached models upgrade to the OpenAI Responses transport after the provider change
+
 ## [14.0.0] - 2026-04-08
 ### Breaking Changes
 

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -602,14 +602,10 @@ export interface OllamaModelManagerConfig {
 	baseUrl?: string;
 }
 
-export function ollamaModelManagerOptions(
-	config?: OllamaModelManagerConfig,
-): ModelManagerOptions<"openai-responses"> {
+export function ollamaModelManagerOptions(config?: OllamaModelManagerConfig): ModelManagerOptions<"openai-responses"> {
 	const apiKey = config?.apiKey;
 	const baseUrl = normalizeOllamaBaseUrl(config?.baseUrl);
-	const references = createBundledReferenceMap<"openai-responses">(
-		"ollama" as Parameters<typeof getBundledModels>[0],
-	);
+	const references = createBundledReferenceMap<"openai-responses">("ollama" as Parameters<typeof getBundledModels>[0]);
 	return {
 		providerId: "ollama",
 		fetchDynamicModels: async () => {

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -225,7 +225,7 @@ function toOllamaNativeBaseUrl(baseUrl: string): string {
 	return baseUrl.endsWith("/v1") ? baseUrl.slice(0, -3) : baseUrl;
 }
 
-async function fetchOllamaNativeModels(baseUrl: string): Promise<Model<"openai-completions">[] | null> {
+async function fetchOllamaNativeModels(baseUrl: string): Promise<Model<"openai-responses">[] | null> {
 	const nativeBaseUrl = toOllamaNativeBaseUrl(baseUrl);
 	let response: Response;
 	try {
@@ -241,7 +241,7 @@ async function fetchOllamaNativeModels(baseUrl: string): Promise<Model<"openai-c
 	}
 	const payload = (await response.json()) as { models?: Array<{ name?: string; model?: string }> };
 	const entries = payload.models ?? [];
-	const models: Model<"openai-completions">[] = [];
+	const models: Model<"openai-responses">[] = [];
 	for (const entry of entries) {
 		const id = entry.model ?? entry.name;
 		if (!id) {
@@ -250,7 +250,7 @@ async function fetchOllamaNativeModels(baseUrl: string): Promise<Model<"openai-c
 		models.push({
 			id,
 			name: entry.name ?? id,
-			api: "openai-completions",
+			api: "openai-responses",
 			provider: "ollama",
 			baseUrl,
 			reasoning: false,
@@ -604,17 +604,17 @@ export interface OllamaModelManagerConfig {
 
 export function ollamaModelManagerOptions(
 	config?: OllamaModelManagerConfig,
-): ModelManagerOptions<"openai-completions"> {
+): ModelManagerOptions<"openai-responses"> {
 	const apiKey = config?.apiKey;
 	const baseUrl = normalizeOllamaBaseUrl(config?.baseUrl);
-	const references = createBundledReferenceMap<"openai-completions">(
+	const references = createBundledReferenceMap<"openai-responses">(
 		"ollama" as Parameters<typeof getBundledModels>[0],
 	);
 	return {
 		providerId: "ollama",
 		fetchDynamicModels: async () => {
 			const openAiCompatible = await fetchOpenAICompatibleModels({
-				api: "openai-completions",
+				api: "openai-responses",
 				provider: "ollama",
 				baseUrl,
 				apiKey,

--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -49,7 +49,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 
 	const isCerebras = provider === "cerebras" || baseUrl.includes("cerebras.ai");
 	const isZai = provider === "zai" || baseUrl.includes("api.z.ai");
-	const isKimiModel = model.id.includes("moonshotai/kimi");
+	const isKimiModel = model.id.includes("moonshotai/kimi") || /^kimi[-.]/i.test(model.id);
 	const isAlibaba = provider === "alibaba-coding-plan" || baseUrl.includes("dashscope");
 	const isQwen = model.id.toLowerCase().includes("qwen");
 

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -281,7 +281,6 @@ describe("openai-completions compatibility", () => {
 	});
 });
 
-
 describe("kimi model detection via detectCompat", () => {
 	function kimiOpenCodeModel(id: string): Model<"openai-completions"> {
 		return {

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -280,3 +280,91 @@ describe("openai-completions compatibility", () => {
 		expect(assistantObject ? Reflect.get(assistantObject, "reasoning_content") : undefined).toBeUndefined();
 	});
 });
+
+
+describe("kimi model detection via detectCompat", () => {
+	function kimiOpenCodeModel(id: string): Model<"openai-completions"> {
+		return {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			id,
+			reasoning: true,
+		};
+	}
+
+	it("requires reasoning_content for tool calls on kimi-k2.5 (opencode-go)", () => {
+		const compat = detectCompat(kimiOpenCodeModel("kimi-k2.5"));
+		expect(compat.requiresReasoningContentForToolCalls).toBe(true);
+		expect(compat.requiresAssistantContentForToolCalls).toBe(true);
+	});
+
+	it("injects reasoning_content placeholder when assistant with tool calls has no reasoning field", () => {
+		const model = kimiOpenCodeModel("kimi-k2.5");
+		const compat = detectCompat(model);
+		const toolCallMessage: AssistantMessage = {
+			role: "assistant",
+			content: [
+				// Thinking returned as plain text (as kimi-k2.5 on opencode-go does)
+				{ type: "text", text: "Let me research this." },
+				{
+					type: "toolCall",
+					id: "call_abc123",
+					name: "web_search",
+					arguments: { query: "beads gastownhall" },
+				},
+			],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+		const messages = convertMessages(model, { messages: [toolCallMessage] }, compat);
+		const assistant = messages.find(m => m.role === "assistant");
+		expect(assistant).toBeDefined();
+		const reasoningContent = Reflect.get(assistant as object, "reasoning_content");
+		expect(reasoningContent).toBeDefined();
+		expect(typeof reasoningContent).toBe("string");
+		expect((reasoningContent as string).length).toBeGreaterThan(0);
+	});
+
+	it("does not inject reasoning_content when model is not kimi", () => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			id: "some-other-model",
+		};
+		const compat = detectCompat(model);
+		expect(compat.requiresReasoningContentForToolCalls).toBe(false);
+	});
+
+	it.each(["kimi-k2.5", "kimi-k1.5", "kimi-k2-5"])("matches kimi model id: %s", id => {
+		const compat = detectCompat(kimiOpenCodeModel(id));
+		expect(compat.requiresReasoningContentForToolCalls).toBe(true);
+	});
+
+	it("still matches moonshotai/kimi via openrouter", () => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			id: "moonshotai/kimi-k2-5",
+			reasoning: true,
+		};
+		const compat = detectCompat(model);
+		expect(compat.requiresReasoningContentForToolCalls).toBe(true);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -258,6 +258,10 @@
 - `/autoresearch` toggles like `/plan` when empty; slash completion no longer suggests `off`/`clear` on an empty prefix after the command
 - Chunk-mode read/edit edge cases (zero-width gap replaces, stale batch diagnostics, grouped Go receivers, line-count headers, parse error locations)
 
+### Added
+
+- `/review` command now accepts inline args as custom instructions appended to the generated prompt for all structured review modes (PR-style, uncommitted, specific commit). When inline args are provided, option 4 (editor) is suppressed from the menu. The no-UI (Task tool) path forwards args as a focus hint.
+
 ## [13.19.0] - 2026-04-05
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed cached Ollama discovery rows so upgraded installs switch to the OpenAI Responses transport instead of staying on the old completions transport
+
 ## [14.0.2] - 2026-04-09
 ### Added
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -971,7 +971,7 @@ export class ModelRegistry {
 		if (!configuredProviders.has("ollama")) {
 			this.#discoverableProviders.push({
 				provider: "ollama",
-				api: "openai-completions",
+				api: "openai-responses",
 				baseUrl: Bun.env.OLLAMA_BASE_URL || "http://127.0.0.1:11434",
 				discovery: { type: "ollama" },
 				optional: true,

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -947,7 +947,10 @@ export class ModelRegistry {
 			}
 			const models = this.#applyProviderModelOverrides(
 				providerConfig.provider,
-				this.#applyProviderCompat(providerConfig.compat, cache.models),
+				this.#normalizeDiscoverableModels(
+					providerConfig,
+					this.#applyProviderCompat(providerConfig.compat, cache.models),
+				),
 			);
 			cachedModels.push(...models);
 			this.#providerDiscoveryStates.set(providerConfig.provider, {
@@ -965,6 +968,14 @@ export class ModelRegistry {
 	#applyProviderCompat(compat: Model<Api>["compat"] | undefined, models: Model<Api>[]): Model<Api>[] {
 		if (!compat) return models;
 		return models.map(model => ({ ...model, compat: mergeCompat(model.compat, compat) }));
+	}
+
+	#normalizeDiscoverableModels(providerConfig: DiscoveryProviderConfig, models: Model<Api>[]): Model<Api>[] {
+		if (providerConfig.provider !== "ollama" || providerConfig.api !== "openai-responses") {
+			return models;
+		}
+
+		return models.map(model => (model.api === "openai-completions" ? { ...model, api: "openai-responses" } : model));
 	}
 
 	#addImplicitDiscoverableProviders(configuredProviders: Set<string>): void {
@@ -1203,7 +1214,10 @@ export class ModelRegistry {
 		}
 		return this.#applyProviderModelOverrides(
 			providerId,
-			this.#applyProviderCompat(providerConfig.compat, result.models),
+			this.#normalizeDiscoverableModels(
+				providerConfig,
+				this.#applyProviderCompat(providerConfig.compat, result.models),
+			),
 		);
 	}
 

--- a/packages/coding-agent/src/edit/modes/chunk.ts
+++ b/packages/coding-agent/src/edit/modes/chunk.ts
@@ -312,7 +312,7 @@ export const chunkToolEditSchema = Type.Object({
 			"Chunk selector. Format: 'path@region' for insertions, 'path#CRC@region' for replace. Omit @region to target the full chunk. Valid regions: head, body, tail, decl.",
 	}),
 	content: Type.String({
-		description: "New content. Use one leading space per indent level; do not include the chunk's base padding.",
+		description: "New content. Use \\t for indentation. Do NOT include the chunk's base padding.",
 	}),
 });
 export const chunkEditParamsSchema = Type.Object(

--- a/packages/coding-agent/src/edit/modes/hashline.ts
+++ b/packages/coding-agent/src/edit/modes/hashline.ts
@@ -156,8 +156,8 @@ interface ExecuteHashlineModeOptions {
 	beginDeferredDiagnosticsForPath: (path: string) => WritethroughDeferredHandle;
 }
 
-export function hashlineParseText(edit: string[] | string | null): string[] {
-	if (edit === null) return [];
+export function hashlineParseText(edit: string[] | string | null | undefined): string[] {
+	if (edit == null) return [];
 	if (typeof edit === "string") {
 		const normalizedEdit = edit.endsWith("\n") ? edit.slice(0, -1) : edit;
 		edit = normalizedEdit.replaceAll("\r", "").split("\n");

--- a/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
@@ -224,23 +224,45 @@ function buildReviewPrompt(mode: string, stats: DiffStats, rawDiff: string): str
 	});
 }
 
+/**
+ * Append extra instructions to a review prompt, if any were provided.
+ * Returns the prompt unchanged when instructions is undefined.
+ */
+function appendInstructions(prompt: string, instructions: string | undefined): string {
+	if (!instructions) return prompt;
+	return `${prompt}\n\n### Additional Instructions\n\n${instructions}`;
+}
+
 export class ReviewCommand implements CustomCommand {
 	name = "review";
 	description = "Launch interactive code review";
 
 	constructor(private api: CustomCommandAPI) {}
 
-	async execute(_args: string[], ctx: HookCommandContext): Promise<string | undefined> {
+	async execute(args: string[], ctx: HookCommandContext): Promise<string | undefined> {
 		if (!ctx.hasUI) {
-			return "Use the Task tool to run the 'reviewer' agent to review recent code changes.";
+			const base = "Use the Task tool to run the 'reviewer' agent to review recent code changes.";
+			return args.length > 0 ? `${base} Focus: ${args.join(" ")}` : base;
 		}
 
-		const mode = await ctx.ui.select("Review Mode", [
-			"1. Review against a base branch (PR Style)",
-			"2. Review uncommitted changes",
-			"3. Review a specific commit",
-			"4. Custom review instructions",
-		]);
+		// Inline args act as additional instructions appended to the generated prompt.
+		// When present, skip option 4 (editor) — the args already provide the instructions.
+		const extraInstructions = args.length > 0 ? args.join(" ") : undefined;
+
+		const menuItems = extraInstructions
+			? [
+					"1. Review against a base branch (PR Style)",
+					"2. Review uncommitted changes",
+					"3. Review a specific commit",
+				]
+			: [
+					"1. Review against a base branch (PR Style)",
+					"2. Review uncommitted changes",
+					"3. Review a specific commit",
+					"4. Custom review instructions",
+				];
+
+		const mode = await ctx.ui.select("Review Mode", menuItems);
 
 		if (!mode) return undefined;
 
@@ -278,10 +300,13 @@ export class ReviewCommand implements CustomCommand {
 					return undefined;
 				}
 
-				return buildReviewPrompt(
-					`Reviewing changes between \`${baseBranch}\` and \`${currentBranch}\` (PR-style)`,
-					stats,
-					diffText,
+				return appendInstructions(
+					buildReviewPrompt(
+						`Reviewing changes between \`${baseBranch}\` and \`${currentBranch}\` (PR-style)`,
+						stats,
+						diffText,
+					),
+					extraInstructions,
 				);
 			}
 
@@ -318,7 +343,10 @@ export class ReviewCommand implements CustomCommand {
 					return undefined;
 				}
 
-				return buildReviewPrompt("Reviewing uncommitted changes (staged + unstaged)", stats, combinedDiff);
+				return appendInstructions(
+					buildReviewPrompt("Reviewing uncommitted changes (staged + unstaged)", stats, combinedDiff),
+					extraInstructions,
+				);
 			}
 
 			case 3: {
@@ -354,7 +382,10 @@ export class ReviewCommand implements CustomCommand {
 					return undefined;
 				}
 
-				return buildReviewPrompt(`Reviewing commit \`${hash}\``, stats, diffText);
+				return appendInstructions(
+					buildReviewPrompt(`Reviewing commit \`${hash}\``, stats, diffText),
+					extraInstructions,
+				);
 			}
 
 			case 4: {

--- a/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
@@ -197,7 +197,7 @@ const MAX_FILES_FOR_INLINE_DIFF = 20; // Don't include diff if more files than t
 /**
  * Build the full review prompt with diff stats and distribution guidance.
  */
-function buildReviewPrompt(mode: string, stats: DiffStats, rawDiff: string): string {
+function buildReviewPrompt(mode: string, stats: DiffStats, rawDiff: string, additionalInstructions?: string): string {
 	const agentCount = getRecommendedAgentCount(stats);
 	const skipDiff = rawDiff.length > MAX_DIFF_CHARS || stats.files.length > MAX_FILES_FOR_INLINE_DIFF;
 	const totalLines = stats.totalAdded + stats.totalRemoved;
@@ -221,16 +221,8 @@ function buildReviewPrompt(mode: string, stats: DiffStats, rawDiff: string): str
 		skipDiff,
 		rawDiff: rawDiff.trim(),
 		linesPerFile,
+		additionalInstructions,
 	});
-}
-
-/**
- * Append extra instructions to a review prompt, if any were provided.
- * Returns the prompt unchanged when instructions is undefined.
- */
-function appendInstructions(prompt: string, instructions: string | undefined): string {
-	if (!instructions) return prompt;
-	return `${prompt}\n\n### Additional Instructions\n\n${instructions}`;
 }
 
 export class ReviewCommand implements CustomCommand {
@@ -300,12 +292,10 @@ export class ReviewCommand implements CustomCommand {
 					return undefined;
 				}
 
-				return appendInstructions(
-					buildReviewPrompt(
-						`Reviewing changes between \`${baseBranch}\` and \`${currentBranch}\` (PR-style)`,
-						stats,
-						diffText,
-					),
+				return buildReviewPrompt(
+					`Reviewing changes between \`${baseBranch}\` and \`${currentBranch}\` (PR-style)`,
+					stats,
+					diffText,
 					extraInstructions,
 				);
 			}
@@ -343,8 +333,10 @@ export class ReviewCommand implements CustomCommand {
 					return undefined;
 				}
 
-				return appendInstructions(
-					buildReviewPrompt("Reviewing uncommitted changes (staged + unstaged)", stats, combinedDiff),
+				return buildReviewPrompt(
+					"Reviewing uncommitted changes (staged + unstaged)",
+					stats,
+					combinedDiff,
 					extraInstructions,
 				);
 			}
@@ -382,10 +374,7 @@ export class ReviewCommand implements CustomCommand {
 					return undefined;
 				}
 
-				return appendInstructions(
-					buildReviewPrompt(`Reviewing commit \`${hash}\``, stats, diffText),
-					extraInstructions,
-				);
+				return buildReviewPrompt(`Reviewing commit \`${hash}\``, stats, diffText, extraInstructions);
 			}
 
 			case 4: {
@@ -405,11 +394,12 @@ export class ReviewCommand implements CustomCommand {
 				if (reviewDiff) {
 					const stats = parseDiff(reviewDiff);
 					// Even if all files filtered, include the custom instructions
-					return `${buildReviewPrompt(
+					return buildReviewPrompt(
 						`Custom review: ${instructions.split("\n")[0].slice(0, 60)}…`,
 						stats,
 						reviewDiff,
-					)}\n\n### Additional Instructions\n\n${instructions}`;
+						instructions,
+					);
 				}
 
 				// No diff available, just pass instructions

--- a/packages/coding-agent/src/lsp/config.ts
+++ b/packages/coding-agent/src/lsp/config.ts
@@ -197,6 +197,21 @@ const LOCAL_BIN_PATHS: Array<{ markers: string[]; binDir: string }> = [
 	{ markers: ["go.mod", "go.sum"], binDir: "bin" },
 ];
 
+const WINDOWS_LOCAL_EXECUTABLE_EXTENSIONS = [".exe", ".cmd", ".bat"] as const;
+
+function resolveLocalCommand(basePath: string): string | null {
+	if (fs.existsSync(basePath)) return basePath;
+	if (process.platform !== "win32") return null;
+
+	// Package managers write Windows launchers with executable suffixes in node_modules/.bin.
+	for (const extension of WINDOWS_LOCAL_EXECUTABLE_EXTENSIONS) {
+		const candidate = `${basePath}${extension}`;
+		if (fs.existsSync(candidate)) return candidate;
+	}
+
+	return null;
+}
+
 /**
  * Resolve a command to an executable path.
  * Checks project-local bin directories first, then falls back to $PATH.
@@ -210,8 +225,9 @@ export function resolveCommand(command: string, cwd: string): string | null {
 	for (const { markers, binDir } of LOCAL_BIN_PATHS) {
 		if (hasRootMarkers(cwd, markers)) {
 			const localPath = path.join(cwd, binDir, command);
-			if (fs.existsSync(localPath)) {
-				return localPath;
+			const resolvedLocalPath = resolveLocalCommand(localPath);
+			if (resolvedLocalPath) {
+				return resolvedLocalPath;
 			}
 		}
 	}

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -43,6 +43,8 @@ export class SessionObserverOverlayComponent extends Container {
 	#observeKeys: KeyId[];
 	/** Cached parsed transcript per session file to avoid reparsing on every refresh */
 	#transcriptCache?: { path: string; bytesRead: number; entries: SessionMessageEntry[] };
+	/** Live stats text component, placed after transcript to avoid above-viewport diffs */
+	#statsText?: Text;
 
 	constructor(registry: SessionObserverRegistry, onDone: () => void, observeKeys: KeyId[]) {
 		super();
@@ -87,11 +89,13 @@ export class SessionObserverOverlayComponent extends Container {
 		this.#mode = "viewer";
 		this.children = [];
 		this.#viewerContainer = new Container();
+		this.#statsText = new Text("", 1, 0);
 		this.#refreshViewer();
 
 		this.addChild(new DynamicBorder());
 		this.addChild(this.#viewerContainer);
 		this.addChild(new Spacer(1));
+		this.addChild(this.#statsText);
 		this.addChild(new Text(theme.fg("dim", "Esc: back to picker  |  Ctrl+S: back to picker"), 1, 0));
 		this.addChild(new DynamicBorder());
 	}
@@ -133,16 +137,17 @@ export class SessionObserverOverlayComponent extends Container {
 		const session = sessions.find(s => s.id === this.#selectedSessionId);
 		if (!session) {
 			this.#viewerContainer.addChild(new Text(theme.fg("dim", "Session no longer available."), 1, 0));
+			this.#updateStats(undefined);
 			return;
 		}
 
 		this.#renderSessionHeader(session);
 		this.#renderSessionTranscript(session);
+		this.#updateStats(session);
 	}
 
 	#renderSessionHeader(session: ObservableSession): void {
 		const c = this.#viewerContainer;
-		const progress = session.progress;
 
 		// Header: label + status + [agent]
 		const statusColor = session.status === "active" ? "success" : session.status === "failed" ? "error" : "dim";
@@ -154,22 +159,26 @@ export class SessionObserverOverlayComponent extends Container {
 			c.addChild(new Text(theme.fg("muted", session.description), 1, 0));
 		}
 
-		// Stats from progress
-		if (progress) {
-			const stats: string[] = [];
-			if (progress.toolCount > 0) stats.push(`${formatNumber(progress.toolCount)} tools`);
-			if (progress.tokens > 0) stats.push(`${formatNumber(progress.tokens)} tokens`);
-			if (progress.durationMs > 0) stats.push(formatDuration(progress.durationMs));
-			if (stats.length > 0) {
-				c.addChild(new Text(theme.fg("dim", stats.join(theme.sep.dot)), 1, 0));
-			}
-		}
-
 		if (session.sessionFile) {
 			c.addChild(new Text(theme.fg("dim", `Session: ${shortenPath(session.sessionFile)}`), 1, 0));
 		}
 
 		c.addChild(new DynamicBorder());
+	}
+
+	/** Update live stats in-place (below transcript, within viewport). */
+	#updateStats(session: ObservableSession | undefined): void {
+		if (!this.#statsText) return;
+		const progress = session?.progress;
+		if (!progress) {
+			this.#statsText.setText("");
+			return;
+		}
+		const stats: string[] = [];
+		if (progress.toolCount > 0) stats.push(`${formatNumber(progress.toolCount)} tools`);
+		if (progress.tokens > 0) stats.push(`${formatNumber(progress.tokens)} tokens`);
+		if (progress.durationMs > 0) stats.push(formatDuration(progress.durationMs));
+		this.#statsText.setText(stats.length > 0 ? theme.fg("dim", stats.join(theme.sep.dot)) : "");
 	}
 
 	/** Incrementally read and parse the session JSONL, caching already-parsed entries. */

--- a/packages/coding-agent/src/prompts/review-request.md
+++ b/packages/coding-agent/src/prompts/review-request.md
@@ -62,3 +62,9 @@ _Full diff too large ({{len files}} files). Showing first ~{{linesPerFile}} line
 {{rawDiff}}
 </diff>
 {{/if}}
+
+{{#if additionalInstructions}}
+### Additional Instructions
+
+{{additionalInstructions}}
+{{/if}}

--- a/packages/coding-agent/src/prompts/tools/chunk-edit.md
+++ b/packages/coding-agent/src/prompts/tools/chunk-edit.md
@@ -7,9 +7,9 @@ Edits files via syntax-aware chunks. Run `read(path="file.ts")` first. The edit 
   - replacements: `chunk#CRC` or `chunk#CRC@region`
 - Without a `@region` it defaults to the entire chunk including leading trivia. Valid regions: `head`, `body`, `tail`, `decl`.
 - If the exact chunk path is unclear, run `read(path="file", sel="?")` and copy a selector from that listing.
-- Use a single leading space per indent level in `content`. Write content at indent-level 0 — the tool re-indents it to match the chunk's position in the file. For example, to replace `@body` of a method, write the body starting at column 0:
+- Use `\t` for indentation in `content`. Write content at indent-level 0 — the tool re-indents it to match the chunk's position in the file. For example, to replace `@body` of a method, write the body starting at column 0:
   ```
-  content: "if (x) {\n return true;\n}"
+  content: "if (x) {\n\treturn true;\n}"
   ```
   The tool adds the correct base indent automatically. Never manually pad with the chunk's own indentation.
 - `@region` only works on container chunks (classes, functions, impl blocks, sections). Do **not** use `@head`/`@body`/`@tail` on leaf chunks (enum variants, fields, single statements) — use the whole chunk instead.
@@ -19,6 +19,10 @@ Edits files via syntax-aware chunks. Run `read(path="file.ts")` first. The edit 
 
 <critical>
 You **MUST** use the narrowest region that covers your change. Replacing without a region replaces the **entire chunk including leading comments, decorators, and attributes** — omitting them from `content` deletes them.
+
+**`replace` is total, not surgical.** The `content` you supply becomes the *complete* new content for the targeted region. Everything in the original region that you omit from `content` is deleted. Before replacing `@body` on any chunk, verify the chunk does not contain children you intend to keep. If a chunk spans hundreds of lines and your change touches only a few, target a specific child chunk — not the parent.
+
+**Group chunks (`stmts_*`, `imports_*`, `decls_*`) are containers.** They hold many sibling items (test functions, import statements, declarations). Replacing `@body` on a group chunk replaces **all** of its children. To edit one item inside a group, target that item's own chunk path. If no child chunk exists, use the specific child's chunk selector from `read` output — do not replace the parent group.
 </critical>
 
 <regions>
@@ -108,9 +112,9 @@ Given this `read` output for `example.ts`:
 ```
 
 **Replace a whole chunk** (rename a function):
-```
-{ "sel": "fn_createCounter#PQQY", "op": "replace", "content": "function makeCounter(start: number): Counter {\n const c = new Counter();\n c.value = start;\n return c;\n}\n" }
-```
+~~~json
+{ "sel": "fn_createCounter#PQQY", "op": "replace", "content": "function makeCounter(start: number): Counter {\n\tconst c = new Counter();\n\tc.value = start;\n\treturn c;\n}\n" }
+~~~
 Result — the entire chunk is rewritten:
 ```
 function makeCounter(start: number): Counter {
@@ -158,9 +162,9 @@ function createCounter(initial: number): Counter {
 ```
 
 **Insert after a chunk** (`after`):
-```
-{ "sel": "enum_Status", "op": "after", "content": "\nfunction isActive(s: Status): boolean {\n return s === Status.Active;\n}\n" }
-```
+~~~json
+{ "sel": "enum_Status", "op": "after", "content": "\nfunction isActive(s: Status): boolean {\n\treturn s === Status.Active;\n}\n" }
+~~~
 Result — a new function appears after the enum:
 ```
 enum Status {
@@ -189,9 +193,9 @@ class Counter {
 ```
 
 **Append inside a container** (`@body` + `append`):
-```
-{ "sel": "class_Counter@body", "op": "append", "content": "\nreset(): void {\n this.value = 0;\n}\n" }
-```
+~~~json
+{ "sel": "class_Counter@body", "op": "append", "content": "\nreset(): void {\n\tthis.value = 0;\n}\n" }
+~~~
 Result — a new method is added at the end of the class body, before the closing `}`:
 ```
   toString(): string {
@@ -210,10 +214,10 @@ Result — a new method is added at the end of the class body, before the closin
 ```
 Result — the method is removed from the class.
 - Indentation rules (important):
-  - Use one leading space for each indent level in canonical chunk-edit content. The tool expands those levels to the file's actual style (2-space, 4-space, tabs, etc.).
+  - Use `\t` for each indent level. The tool converts tabs to the file's actual style (2-space, 4-space, etc.).
   - Do NOT include the chunk's base indentation — only indent relative to the region's opening level.
   - For `@body` of a function: write at column 0, e.g. `"return x;\n"`. The tool adds the correct base indent.
   - For `@head`: write at the chunk's own depth. A class member's head uses `"/** doc */\nstart(): void {"`.
-  - For a top-level item: start at zero indent. Write `"function foo() {\n return 1;\n}\n"`.
+  - For a top-level item: start at zero indent. Write `"function foo() {\n\treturn 1;\n}\n"`.
   - The tool strips common leading indentation from your content as a safety net, so accidental over-indentation is corrected.
 </examples>

--- a/packages/coding-agent/test/core/chunk-tree.test.ts
+++ b/packages/coding-agent/test/core/chunk-tree.test.ts
@@ -719,8 +719,8 @@ describe("formatChunkedRead", () => {
 
 		expect(result.text).toContain("worker.ts:class_Worker.fn_run·");
 		expect(result.text).toContain("class_Worker.fn_run#");
-		expect(result.text).toContain("6|  run(): void {");
-		expect(result.text).toContain("7|   console.log(this.name);");
+		expect(result.text).toContain("6| \trun(): void {");
+		expect(result.text).toContain("7| \t\tconsole.log(this.name);");
 		expect(result.text).toContain("console.log(this.name);");
 	});
 
@@ -739,8 +739,8 @@ describe("formatChunkedRead", () => {
 
 		expect(result.text).not.toContain("to expand ⋮");
 		expect(result.text).toContain("service.ts:class_Service.fn_handle·");
-		expect(result.text).toContain("3|   step(0);");
-		expect(result.text).toContain("27|   step(24);");
+		expect(result.text).toContain("3| \t\tstep(0);");
+		expect(result.text).toContain("27| \t\tstep(24);");
 		expect(result.text).toContain("done();");
 	});
 });
@@ -849,7 +849,7 @@ describe("addressable member rendering", () => {
 
 		expect(result.text).toContain("type_Handler#");
 		expect(result.text).toContain("3| type Handler interface {");
-		expect(result.text).toContain("4|  Handle(method, path string) Result");
+		expect(result.text).toContain("4| \tHandle(method, path string) Result");
 	});
 
 	test("renders Go receiver methods as top-level siblings", async () => {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Effort, type OpenAICompat, type ThinkingConfig } from "@f5xc-salesdemos/pi-ai";
+import { Effort, type Model, type OpenAICompat, type ThinkingConfig, writeModelCache } from "@f5xc-salesdemos/pi-ai";
 import { hookFetch, Snowflake } from "@f5xc-salesdemos/pi-utils";
 import { kNoAuth, MODEL_ROLES, ModelRegistry } from "@f5xc-salesdemos/xcsh/config/model-registry";
 import { _resetSettingsForTest, Settings } from "@f5xc-salesdemos/xcsh/config/settings";
@@ -11,6 +11,7 @@ import { AuthStorage } from "@f5xc-salesdemos/xcsh/session/auth-storage";
 describe("ModelRegistry", () => {
 	let tempDir: string;
 	let modelsJsonPath: string;
+	let cacheDbPath: string;
 	let authStorage: AuthStorage;
 
 	test("commit role includes a visible badge tag", () => {
@@ -23,6 +24,7 @@ describe("ModelRegistry", () => {
 		tempDir = path.join(os.tmpdir(), `pi-test-model-registry-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
 		modelsJsonPath = path.join(tempDir, "models.json");
+		cacheDbPath = path.join(tempDir, "models.db");
 		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
 	});
 
@@ -81,6 +83,10 @@ describe("ModelRegistry", () => {
 
 	function writeModelsJson(providers: Record<string, ProviderConfig>) {
 		fs.writeFileSync(modelsJsonPath, JSON.stringify({ providers }));
+	}
+
+	function writeCachedOllamaModels(models: Model<"openai-completions">[]) {
+		writeModelCache("ollama", Date.now(), models, true, cacheDbPath);
 	}
 
 	function getModelsForProvider(registry: ModelRegistry, provider: string) {
@@ -1135,6 +1141,38 @@ describe("ModelRegistry", () => {
 			const available = registry.getAvailable().filter(m => m.provider === "ollama");
 			expect(available.length).toBe(2);
 			expect(await registry.getApiKey(available[0])).toBe(kNoAuth);
+		});
+
+		test("normalizes cached ollama completions rows to responses on load", () => {
+			writeRawModelsJson({
+				ollama: {
+					baseUrl: "http://127.0.0.1:11434/v1",
+					api: "openai-responses",
+					auth: "none",
+					discovery: { type: "ollama" },
+				},
+			});
+			writeCachedOllamaModels([
+				{
+					id: "phi4-mini",
+					name: "phi4-mini",
+					api: "openai-completions",
+					provider: "ollama",
+					baseUrl: "http://127.0.0.1:11434/v1",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128000,
+					maxTokens: 8192,
+				},
+			]);
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const ollama = registry.find("ollama", "phi4-mini");
+
+			expect(ollama?.api).toBe("openai-responses");
+			expect(ollama?.baseUrl).toBe("http://127.0.0.1:11434/v1");
+			expect(registry.getProviderDiscoveryState("ollama")?.status).toBe("cached");
 		});
 
 		test("discovers ollama thinking capabilities from show metadata", async () => {

--- a/packages/coding-agent/test/prompts/review-request.test.ts
+++ b/packages/coding-agent/test/prompts/review-request.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+
+describe("review request prompt", () => {
+	it("renders the additional instructions block from the template", async () => {
+		const template = await Bun.file(new URL("../../src/prompts/review-request.md", import.meta.url)).text();
+
+		expect(template).toContain("{{#if additionalInstructions}}");
+		expect(template).toContain("### Additional Instructions");
+		expect(template).toContain("{{additionalInstructions}}");
+		expect(template).toContain("{{/if}}");
+	});
+
+	it("keeps the additional instructions suffix out of TypeScript", async () => {
+		const source = await Bun.file(
+			new URL("../../src/extensibility/custom-commands/bundled/review/index.ts", import.meta.url),
+		).text();
+
+		expect(source).not.toContain("### Additional Instructions");
+		expect(source).not.toContain("appendInstructions(");
+	});
+});

--- a/packages/coding-agent/test/tools/chunk-mode.test.ts
+++ b/packages/coding-agent/test/tools/chunk-mode.test.ts
@@ -108,7 +108,7 @@ describe("chunk mode tools", () => {
 		expect(text).not.toContain("to expand ⋮");
 		expect(text).toContain("server.ts:class_Server.fn_handleError·");
 		expect(text).toContain("let total = 0;");
-		expect(text).toContain("29|    total += 25;");
+		expect(text).toContain("29| \t\t\ttotal +=");
 		expect(text).toContain("return err.message + total;");
 	});
 

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -229,6 +229,30 @@ describe("lsp regressions", () => {
 		expect(resultText).not.toContain("\t");
 	});
 
+	it("detects Windows local .exe LSP shims in node_modules/.bin", async () => {
+		if (process.platform !== "win32") {
+			return;
+		}
+
+		const tempDir = TempDir.createSync("@omp-lsp-win32-bin-");
+		const whichSpy = vi.spyOn(Bun, "which").mockReturnValue(null);
+
+		try {
+			await Bun.write(path.join(tempDir.path(), "package.json"), "{}");
+			const binDir = path.join(tempDir.path(), "node_modules", ".bin");
+			await fs.promises.mkdir(binDir, { recursive: true });
+			const localTsServer = path.join(binDir, "typescript-language-server.exe");
+			await Bun.write(localTsServer, "");
+
+			const config = loadConfig(tempDir.path());
+			expect(config.servers["typescript-language-server"]?.resolvedCommand).toBe(localTsServer);
+			expect(whichSpy).not.toHaveBeenCalledWith("typescript-language-server");
+		} finally {
+			vi.restoreAllMocks();
+			tempDir.removeSync();
+		}
+	});
+
 	it("detects tlaplus files for LSP startup and language ids", async () => {
 		const tempDir = TempDir.createSync("@xcsh-lsp-tlaplus-");
 		const specPath = path.join(tempDir.path(), "Spec.tla");

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -1144,10 +1144,7 @@ export interface ReadRenderParams {
   absoluteLineRange?: VisibleLineRange
   /** Replace tabs in embedded previews. */
   tabReplacement?: string
-  /**
-   * When true, normalize displayed indentation to canonical single-space
-   * indent.
-   */
+  /** When true, normalize displayed indentation to canonical tabs. */
   normalizeIndent?: boolean
 }
 
@@ -1182,10 +1179,7 @@ export interface RenderParams {
   showLeafPreview: boolean
   /** Replace tab characters in displayed previews (e.g. two spaces). */
   tabReplacement?: string
-  /**
-   * When true, normalize displayed indentation to canonical single-space
-   * indent.
-   */
+  /** When true, normalize displayed indentation to canonical tabs. */
   normalizeIndent?: boolean
   /**
    * When set, restrict rendering to these chunks with their specified focus

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -242,7 +242,7 @@ function loadNative() {
 module.exports = loadNative();
 
 // --- generated const enum exports (do not edit) ---
-exports.AstMatchStrictness = {
+module.exports.AstMatchStrictness = {
   Cst: 'cst',
   Smart: 'smart',
   Ast: 'ast',
@@ -250,7 +250,7 @@ exports.AstMatchStrictness = {
   Signature: 'signature',
   Template: 'template',
 };
-exports.ChunkAnchorStyle = {
+module.exports.ChunkAnchorStyle = {
   Full: 'full',
   Kind: 'kind',
   Bare: 'bare',
@@ -258,7 +258,7 @@ exports.ChunkAnchorStyle = {
   KindOmit: 'kind-omit',
   None: 'none',
 };
-exports.ChunkEditOp = {
+module.exports.ChunkEditOp = {
   Replace: 'replace',
   Delete: 'delete',
   Before: 'before',
@@ -266,53 +266,53 @@ exports.ChunkEditOp = {
   Prepend: 'prepend',
   Append: 'append',
 };
-exports.ChunkFocusMode = {
+module.exports.ChunkFocusMode = {
   Expanded: 'expanded',
   Collapsed: 'collapsed',
   Container: 'container',
 };
-exports.ChunkReadStatus = {
+module.exports.ChunkReadStatus = {
   Ok: 'ok',
   NotFound: 'not_found',
   UnsupportedRegion: 'unsupported_region',
 };
-exports.ChunkRegion = {
+module.exports.ChunkRegion = {
   Head: 'head',
   Body: 'body',
   Tail: 'tail',
   Decl: 'decl',
 };
-exports.Ellipsis = {
+module.exports.Ellipsis = {
   Unicode: 0,
   Ascii: 1,
   Omit: 2,
 };
-exports.FileType = {
+module.exports.FileType = {
   File: 1,
   Dir: 2,
   Symlink: 3,
 };
-exports.GrepOutputMode = {
+module.exports.GrepOutputMode = {
   Content: 'content',
   Count: 'count',
   FilesWithMatches: 'filesWithMatches',
 };
-exports.ImageFormat = {
+module.exports.ImageFormat = {
   PNG: 0,
   JPEG: 1,
   WEBP: 2,
   GIF: 3,
 };
-exports.KeyEventType = {
+module.exports.KeyEventType = {
   Press: 1,
   Repeat: 2,
   Release: 3,
 };
-exports.MacOSAppearance = {
+module.exports.MacOSAppearance = {
   Dark: 'dark',
   Light: 'light',
 };
-exports.SamplingFilter = {
+module.exports.SamplingFilter = {
   Nearest: 1,
   Triangle: 2,
   CatmullRom: 3,

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -1,5 +1,4 @@
 {
-	"type": "module",
 	"name": "@f5xc-salesdemos/pi-natives",
 	"version": "14.2.2",
 	"description": "Native Rust bindings for grep, clipboard, image processing, syntax highlighting, PTY, and shell operations via N-API",

--- a/packages/natives/scripts/gen-enums.ts
+++ b/packages/natives/scripts/gen-enums.ts
@@ -38,7 +38,7 @@ for (;;) {
 	}
 
 	if (entries.length > 0) {
-		enums.push(`exports.${name} = {\n${entries.join("\n")}\n};`);
+		enums.push(`module.exports.${name} = {\n${entries.join("\n")}\n};`);
 	}
 }
 


### PR DESCRIPTION
## Summary

Cherry-picks 11 substantive commits from [can1357/oh-my-pi](https://github.com/can1357/oh-my-pi) (upstream was 20 commits ahead — 6 are merge commits, 2 cancel out, 1 is a version bump we skip).

## Upstream commits included

| Commit | Subject |
|--------|---------|
| `1315e32cc` | Fix Windows local LSP binary detection |
| `304b60eff` | Stop repetitive scrolling in session observer viewer |
| `efb64d97e` | Fix const enum exports lost after module.exports reassignment |
| `327e88e50` | Detect bare kimi-* model IDs for requiresReasoningContentForToolCalls |
| `95d14dcb1` | biome formatting for test file |
| `59b4e4891` | feat(review): support inline custom instructions in /review command |
| `810d3bd87` | refactor(review): render extra instructions from template |
| `5e91b80b6` | Use OpenAI Responses API for Ollama instead of Completions |
| `1c3e2d762` | Normalize cached Ollama discovery transport |
| `5550d5931` | Revert: restructured indentation (tab→space revert) |
| `d350ea60e` | Fix hashlineParseText to handle undefined values |

## Skipped upstream commits

- `24fcde4e1` + `8f21566c0` — Add TypeScript runtime then immediately revert (net zero)
- All 6 merge commits (redundant)
- `fd67efc04` — Version bump to 14.0.3 (we are at 14.2.2)

## Conflict resolutions

**`efb64d97e` (const enum exports fix):**
- `packages/natives/package.json`: Kept \`@f5xc-salesdemos/pi-natives\` name + v14.2.2, removed \`"type": "module"\` as upstream intended
- `packages/natives/native/index.js`: Our \`_piCompiledFlag\` PI_COMPILED detection preserved; upstream's \`module.exports.X\` fix applied to const enum section
- `packages/natives/scripts/gen-enums.ts`: Accepted upstream \`module.exports.X\` fix

**`1c3e2d762` (Ollama transport):**
- `test/model-registry.test.ts`: Kept \`@f5xc-salesdemos/*\` scoped imports, added upstream's new \`Model\` + \`writeModelCache\`

## Verification

- [x] \`cargo check\` — passes
- [x] All 30 native tests pass
- [x] \`xcsh --version\` → \`xcsh/14.2.2\` — loads without crash
- [x] All package names use \`@f5xc-salesdemos/*\` — no upstream names leaked
- [x] \`_piCompiledFlag\` PI_COMPILED detection intact
- [x] \`crates/tree-sitter-glimmer/\` vendored crate intact
- [x] F5 theme (#ca260a) intact
- [x] \`GH_TOKEN\` in CI auto-release step intact
- [x] Porting guide updated to new sync point \`d350ea60e\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)