### PR TITLE
fix(lsp): suppress informational log noise in LSP startup warnings

### DIFF
--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -436,7 +436,14 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 
 			// Reject any pending requests — the server is gone, they will never complete.
 			if (client.pendingRequests.size > 0) {
-				const stderr = proc.peekStderr().trim();
+				// Strip informational log lines (e.g. marksman's [INF]/[DBG] prefix)
+				// — they are startup noise, not actionable errors.
+				const rawStderr = proc.peekStderr().trim();
+				const stderr = rawStderr
+					.split("\n")
+					.filter(line => !/^\[\d{2}:\d{2}:\d{2} (?:INF|DBG|VRB)\]/.test(line))
+					.join("\n")
+					.trim();
 				const code = proc.exitCode;
 				const err = new Error(
 					stderr ? `LSP server exited (code ${code}): ${stderr}` : `LSP server exited unexpectedly (code ${code})`,

--- a/packages/coding-agent/src/lsp/defaults.json
+++ b/packages/coding-agent/src/lsp/defaults.json
@@ -857,7 +857,8 @@
 		"rootMarkers": [
 			".marksman.toml",
 			".git"
-		]
+		],
+		"warmupTimeoutMs": 15000
 	},
 	"texlab": {
 		"command": "texlab",


### PR DESCRIPTION
## What

Two small fixes to LSP startup warnings:

1. Filter `[INF]`/`[DBG]`/`[VRB]` timestamped lines from `peekStderr()` before including them in error messages — these are server startup logs, not errors
2. Set `warmupTimeoutMs: 15000` for marksman — its .NET runtime needs longer than the 5s default to respond to `initialize` on arm64 with large workspaces

## Why

On startup, users see warnings like:

```
Warning: LSP startup failed for marksman: LSP server exited (code null): [19:50:13 INF] <LSP Entry> Starting Marksman LSP server...
[19:50:13 INF] <Folder> Loading folder documents: {"uri": "file:///workspace/xcsh"}. It will retry lazily on write.
```

The `[INF]` lines are marksman's own startup logs captured via `peekStderr()`. They appear in the warning because marksman is killed (SIGTERM → code null) when it doesn't respond to `initialize` within the 5s warmup timeout — not because it actually failed.

## Testing

- Confirmed `[INF]` pattern matches marksman's log format: `[HH:MM:SS INF]`
- `warmupTimeoutMs` is already in `ServerConfig` type and read at line 129 of `index.ts`

---

- [ ] `bun check` passes
- [ ] Tested locally
- [ ] CHANGELOG updated (if user-facing)