### PR TITLE
fix(statusline): wire xcsh preset into settings UI and set as default

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -280,7 +280,7 @@ export const SETTINGS_SCHEMA = {
 	"statusLine.preset": {
 		type: "enum",
 		values: ["default", "minimal", "compact", "full", "nerd", "ascii", "xcsh", "custom"] as const,
-		default: "default",
+		default: "xcsh",
 		ui: {
 			tab: "appearance",
 			label: "Status Line Preset",

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -419,6 +419,7 @@ const OPTION_PROVIDERS: Partial<Record<SettingPath, OptionProvider>> = {
 		{ value: "full", label: "Full", description: "All segments including time" },
 		{ value: "nerd", label: "Nerd", description: "Maximum info with Nerd Font icons" },
 		{ value: "ascii", label: "ASCII", description: "No special characters" },
+		{ value: "xcsh", label: "XCSH", description: "Powerline with OS icon, path, git, plan mode" },
 		{ value: "custom", label: "Custom", description: "User-defined segments" },
 	],
 	// Status line separator


### PR DESCRIPTION
## Summary
- Added the missing `xcsh` entry to the settings UI dropdown in `settings-defs.ts` so users can select the xcsh statusline preset through the settings panel
- Changed the default `statusLine.preset` from `"default"` to `"xcsh"` in `settings-schema.ts` so new installations automatically use the powerline statusbar

## Test plan
- [ ] Verify the settings UI dropdown shows the XCSH option between ASCII and Custom
- [ ] Verify new installs default to the xcsh preset
- [ ] Verify selecting xcsh in the UI activates the powerline statusbar with OS icon, path, and git segments

🤖 Generated with [Claude Code](https://claude.com/claude-code)