### PR TITLE
fix(tui,changelog): fix 8 scrollback test failures and simplify changelog version display

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -350,9 +350,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			if (this.#changelogMarkdown) {
 				this.ui.addChild(new DynamicBorder());
 				if (settings.get("collapseChangelog")) {
-					const versionMatch = this.#changelogMarkdown.match(/##\s+\[?(\d+\.\d+\.\d+)\]?/);
-					const latestVersion = versionMatch ? versionMatch[1] : this.#version;
-					const condensedText = `Updated to v${latestVersion}. Use ${theme.bold("/changelog")} to view full changelog.`;
+					const condensedText = `Updated to v${this.#version}. Use ${theme.bold("/changelog")} to view full changelog.`;
 					this.ui.addChild(new Text(condensedText, 1, 0));
 				} else {
 					this.ui.addChild(new Text(theme.bold(theme.fg("contentAccent", "What's New")), 1, 0));

--- a/packages/tui/bunfig.toml
+++ b/packages/tui/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test/preload.ts"]


### PR DESCRIPTION
## Summary

Two fixes from the previous interrupted session:

1. **fix(tui): add bunfig.toml so bare `bun test` applies preload** — 8 scrollback/overlay tests fail when `bun test` is run inside tmux because the test preload script (which clears multiplexer env vars) only applied via `bun run test`. Adding `bunfig.toml` with `[test] preload` ensures it always applies. Closes #28.

2. **fix(changelog): use `this.#version` directly** — The collapsed changelog message parsed the version from markdown headings with a regex, falling back to `this.#version`. Since `this.#version` already has the correct value, the regex was unnecessary.

## Root Cause (issue #28)

`isMultiplexer` in `tui.ts:116` is a module-level constant evaluated at import time. Inside tmux, it's `true`, which causes `fullRender()` to skip `\x1b[3J` (scrollback clear) and skip height-change redraws entirely. The preload script clears `TMUX`/`STY`/`ZELLIJ` before the module loads, but only when invoked via `--preload` flag — which `bun test` alone doesn't apply.

## Test plan
- [x] `bun test` in `packages/tui/`: 343 pass, 0 fail (was 335/8 before fix)
- [x] `bun run test` in `packages/tui/`: 343 pass, 0 fail
- [x] `bun test test/` in `packages/coding-agent/`: 2355 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)