### PR TITLE
perf(ci): split native build variants into parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,17 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ startsWith(github.ref, 'refs/tags/v') && fromJSON('[
-          {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"baseline modern","rust_checks":true},
+          {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"baseline","rust_checks":true},
+          {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"modern"},
           {"os":"ubuntu-22.04","platform":"linux","arch":"arm64","target":"aarch64-unknown-linux-gnu"},
-          {"os":"macos-15-intel","platform":"darwin","arch":"x64","variants":"baseline modern"},
+          {"os":"macos-15-intel","platform":"darwin","arch":"x64","variants":"baseline"},
+          {"os":"macos-15-intel","platform":"darwin","arch":"x64","variants":"modern"},
           {"os":"macos-14","platform":"darwin","arch":"arm64"},
-          {"os":"windows-latest","platform":"win32","arch":"x64","variants":"baseline modern"}
+          {"os":"windows-latest","platform":"win32","arch":"x64","variants":"baseline"},
+          {"os":"windows-latest","platform":"win32","arch":"x64","variants":"modern"}
           ]') || fromJSON('[
-          {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"baseline modern","rust_checks":true}
+          {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"baseline","rust_checks":true},
+          {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"modern"}
           ]') }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -76,7 +80,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.target }}
+          key: ${{ matrix.target }}${{ matrix.variants }}
           cache-workspace-crates: true
       - uses: oven-sh/setup-bun@v2
         with:
@@ -106,7 +110,7 @@ jobs:
       - name: Upload native addon(s)
         uses: actions/upload-artifact@v4
         with:
-          name: pi-natives-${{ matrix.platform }}-${{ matrix.arch }}
+          name: pi-natives-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.variants && format('-{0}', matrix.variants) || '' }}
           path: packages/natives/native/pi_natives.${{ matrix.platform }}-${{ matrix.arch }}*.node
           if-no-files-found: error
 


### PR DESCRIPTION
## Summary
- Split each `"baseline modern"` native build matrix entry into two separate entries so CPU variants build in parallel instead of sequentially
- Adds variant suffix to artifact names (`pi-natives-darwin-x64-baseline`, `pi-natives-darwin-x64-modern`) to prevent upload collisions
- Adds variant to Rust cache key to prevent parallel cache write conflicts
- Tag matrix goes from 5 → 8 jobs; PR/push matrix goes from 1 → 2 jobs

## Motivation
The v14.6.1 release was bottlenecked by the macOS Intel native build which took **32m35s** building both baseline and modern variants sequentially. Splitting into parallel jobs should cut this roughly in half.

## What's unchanged
- Release job download (`pattern: pi-natives-*` with `merge-multiple: true`) works without modification
- Native verify script checks files in directory, not artifact names
- Build scripts already handle single-variant `TARGET_VARIANTS` values
- Runtime loader (`packages/natives/native/index.js`) unchanged

## Test plan
- [ ] PR CI runs show the split matrix (2 linux-x64 jobs instead of 1)
- [ ] Both linux-x64 jobs pass and upload correctly named artifacts
- [ ] On tag push: all 8 native jobs pass, release job downloads/merges all artifacts, verify-natives passes
- [ ] Compare build times vs v14.6.1 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)