### PR TITLE
fix: strip existing signature before codesign on arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,13 +349,22 @@ jobs:
 
           BINARY_PATH="packages/coding-agent/binaries/xcsh-darwin-${{ matrix.arch }}"
           if [ -f "$BINARY_PATH" ]; then
-            echo "Binary info:"
+            echo "=== Binary diagnostics ==="
             file "$BINARY_PATH"
             ls -la "$BINARY_PATH"
+            echo "Mach-O architectures:"
+            lipo -info "$BINARY_PATH" 2>&1 || true
+            echo "Existing signature state:"
+            codesign -dvvv "$BINARY_PATH" 2>&1 || true
+            echo "==========================="
 
             # Strip any existing (possibly malformed) signature from Bun-compiled binary
+            # Bun's --compile can produce binaries with signature blocks that codesign --force
+            # cannot replace — removing first ensures a clean slate
             echo "Stripping existing signature..."
-            codesign --remove-signature "$BINARY_PATH" || true
+            codesign --remove-signature "$BINARY_PATH" 2>&1 || true
+            echo "After strip:"
+            codesign -dvvv "$BINARY_PATH" 2>&1 || true
 
             codesign --force --options runtime \
               --entitlements scripts/entitlements.plist \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [check, native, test, install_methods]
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - os: macos-15-intel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,6 +349,14 @@ jobs:
 
           BINARY_PATH="packages/coding-agent/binaries/xcsh-darwin-${{ matrix.arch }}"
           if [ -f "$BINARY_PATH" ]; then
+            echo "Binary info:"
+            file "$BINARY_PATH"
+            ls -la "$BINARY_PATH"
+
+            # Strip any existing (possibly malformed) signature from Bun-compiled binary
+            echo "Stripping existing signature..."
+            codesign --remove-signature "$BINARY_PATH" || true
+
             codesign --force --options runtime \
               --entitlements scripts/entitlements.plist \
               --sign "$SIGNING_IDENTITY" \

--- a/.github/workflows/test-codesign.yml
+++ b/.github/workflows/test-codesign.yml
@@ -1,0 +1,169 @@
+name: Test macOS Code Signing
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-codesign:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            arch: arm64
+            label: "arm64-native"
+          - os: macos-15-intel
+            arch: x64
+            label: "x64-native"
+          - os: macos-15-intel
+            arch: arm64
+            label: "arm64-cross-on-intel"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3"
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2026-03-27
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-workspace-crates: true
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Build native addon
+        env:
+          TARGET_PLATFORM: darwin
+          TARGET_ARCH: ${{ matrix.arch }}
+        run: bun --cwd=packages/natives run embed:native
+
+      - name: "Test 1: Full build (all flags)"
+        id: test1
+        continue-on-error: true
+        run: |
+          echo "=== Test 1: bun build --compile --define PI_COMPILED=true --root . --external mupdf --target=bun-darwin-${{ matrix.arch }} ==="
+          bun build --compile \
+            --define PI_COMPILED=true \
+            --root . \
+            --external mupdf \
+            --target=bun-darwin-${{ matrix.arch }} \
+            ./packages/coding-agent/src/cli.ts \
+            --outfile /tmp/test1-xcsh
+          echo "--- file ---"
+          file /tmp/test1-xcsh
+          echo "--- lipo ---"
+          lipo -info /tmp/test1-xcsh 2>&1 || true
+          echo "--- existing signature ---"
+          codesign -dvvv /tmp/test1-xcsh 2>&1 || true
+          echo "--- codesign (direct, no strip) ---"
+          codesign --force --options runtime -s - --timestamp=none /tmp/test1-xcsh 2>&1 && echo "PASS: ad-hoc sign" || echo "FAIL: ad-hoc sign"
+          echo "--- codesign (strip then sign) ---"
+          codesign --remove-signature /tmp/test1-xcsh 2>&1 || true
+          codesign --force --options runtime -s - --timestamp=none /tmp/test1-xcsh 2>&1 && echo "PASS: strip+sign" || echo "FAIL: strip+sign"
+
+      - name: "Test 2: No --external mupdf"
+        id: test2
+        continue-on-error: true
+        run: |
+          echo "=== Test 2: without --external mupdf ==="
+          bun build --compile \
+            --define PI_COMPILED=true \
+            --root . \
+            --target=bun-darwin-${{ matrix.arch }} \
+            ./packages/coding-agent/src/cli.ts \
+            --outfile /tmp/test2-xcsh 2>&1 || { echo "BUILD FAILED (expected if mupdf import fails)"; exit 0; }
+          file /tmp/test2-xcsh
+          lipo -info /tmp/test2-xcsh 2>&1 || true
+          codesign -dvvv /tmp/test2-xcsh 2>&1 || true
+          codesign --force --options runtime -s - --timestamp=none /tmp/test2-xcsh 2>&1 && echo "PASS: ad-hoc sign" || echo "FAIL: ad-hoc sign"
+
+      - name: "Test 3: No --define, no --root, no --external"
+        id: test3
+        continue-on-error: true
+        run: |
+          echo "=== Test 3: minimal flags ==="
+          bun build --compile \
+            --target=bun-darwin-${{ matrix.arch }} \
+            ./packages/coding-agent/src/cli.ts \
+            --outfile /tmp/test3-xcsh 2>&1 || { echo "BUILD FAILED"; exit 0; }
+          file /tmp/test3-xcsh
+          lipo -info /tmp/test3-xcsh 2>&1 || true
+          codesign -dvvv /tmp/test3-xcsh 2>&1 || true
+          codesign --force --options runtime -s - --timestamp=none /tmp/test3-xcsh 2>&1 && echo "PASS: ad-hoc sign" || echo "FAIL: ad-hoc sign"
+
+      - name: "Test 4: No --target (native build)"
+        id: test4
+        continue-on-error: true
+        run: |
+          echo "=== Test 4: no --target (build for host arch) ==="
+          bun build --compile \
+            --define PI_COMPILED=true \
+            --root . \
+            --external mupdf \
+            ./packages/coding-agent/src/cli.ts \
+            --outfile /tmp/test4-xcsh 2>&1 || { echo "BUILD FAILED"; exit 0; }
+          file /tmp/test4-xcsh
+          lipo -info /tmp/test4-xcsh 2>&1 || true
+          codesign -dvvv /tmp/test4-xcsh 2>&1 || true
+          codesign --force --options runtime -s - --timestamp=none /tmp/test4-xcsh 2>&1 && echo "PASS: ad-hoc sign" || echo "FAIL: ad-hoc sign"
+
+      - name: "Test 5: Simple hello world binary"
+        id: test5
+        continue-on-error: true
+        run: |
+          echo "=== Test 5: simple binary (control test) ==="
+          echo 'console.log("hello")' > /tmp/hello.ts
+          bun build --compile \
+            --target=bun-darwin-${{ matrix.arch }} \
+            /tmp/hello.ts \
+            --outfile /tmp/test5-xcsh
+          file /tmp/test5-xcsh
+          lipo -info /tmp/test5-xcsh 2>&1 || true
+          codesign -dvvv /tmp/test5-xcsh 2>&1 || true
+          codesign --force --options runtime -s - --timestamp=none /tmp/test5-xcsh 2>&1 && echo "PASS: ad-hoc sign" || echo "FAIL: ad-hoc sign"
+
+      - name: "Test 6: Full build with strip-then-sign using entitlements"
+        id: test6
+        continue-on-error: true
+        run: |
+          echo "=== Test 6: full build + strip + sign with entitlements ==="
+          bun build --compile \
+            --define PI_COMPILED=true \
+            --root . \
+            --external mupdf \
+            --target=bun-darwin-${{ matrix.arch }} \
+            ./packages/coding-agent/src/cli.ts \
+            --outfile /tmp/test6-xcsh 2>&1 || { echo "BUILD FAILED"; exit 0; }
+          echo "--- before strip ---"
+          codesign -dvvv /tmp/test6-xcsh 2>&1 || true
+          echo "--- stripping ---"
+          codesign --remove-signature /tmp/test6-xcsh 2>&1 || true
+          echo "--- after strip ---"
+          codesign -dvvv /tmp/test6-xcsh 2>&1 || true
+          echo "--- signing with entitlements ---"
+          codesign --force --options runtime \
+            --entitlements scripts/entitlements.plist \
+            -s - --timestamp=none \
+            /tmp/test6-xcsh 2>&1 && echo "PASS: strip+entitlements sign" || echo "FAIL: strip+entitlements sign"
+          echo "--- verify ---"
+          codesign --verify --verbose /tmp/test6-xcsh 2>&1 || true
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "============================================"
+          echo "RESULTS for ${{ matrix.label }} (${{ matrix.os }}, ${{ matrix.arch }})"
+          echo "============================================"
+          echo "Test 1 (full flags, direct sign):       ${{ steps.test1.outcome }}"
+          echo "Test 2 (no --external mupdf):           ${{ steps.test2.outcome }}"
+          echo "Test 3 (minimal flags):                 ${{ steps.test3.outcome }}"
+          echo "Test 4 (no --target, native):           ${{ steps.test4.outcome }}"
+          echo "Test 5 (simple hello world):            ${{ steps.test5.outcome }}"
+          echo "Test 6 (full + strip + entitlements):   ${{ steps.test6.outcome }}"
+          echo "============================================"


### PR DESCRIPTION
## Summary

- Strips the malformed existing code signature from Bun-compiled arm64 binaries before re-signing
- Adds `file` and `ls` diagnostics to help debug binary format issues
- x64 signing works fine — only arm64 is affected by the malformed signature block

## Root cause

Bun's `--compile` flag produces arm64 Darwin binaries with a code signature block that `codesign --force` cannot replace, failing with "invalid or unsupported format for signature". Running `codesign --remove-signature` first strips the malformed block so a fresh signature can be applied.

Closes #45

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, next tag release shows both x64 and arm64 signed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)