### PR TITLE
fix(ci): add Bun to verify-npm-install and replace setup-zig with direct install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   # Fast lint + type check (no Rust, no native build needed)
   check:
@@ -586,6 +589,9 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3"
       - name: Install xcsh via npm and verify native addon loads
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   # Fast lint + type check (no Rust, no native build needed)
   check:
@@ -88,9 +85,30 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3"
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
+      - name: Install Zig 0.15.2
+        shell: bash
+        run: |
+          ZIG_VERSION=0.15.2
+          case "$RUNNER_OS" in
+            Linux)  ZIG_OS=linux;  EXT=tar.xz ;;
+            macOS)  ZIG_OS=macos;  EXT=tar.xz ;;
+            Windows) ZIG_OS=windows; EXT=zip ;;
+          esac
+          case "$RUNNER_ARCH" in
+            X64)   ZIG_ARCH=x86_64 ;;
+            ARM64) ZIG_ARCH=aarch64 ;;
+          esac
+          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}.${EXT}"
+          echo "Downloading $URL"
+          if [ "$EXT" = "zip" ]; then
+            curl -sSfL "$URL" -o zig.zip
+            unzip -q zig.zip
+            rm zig.zip
+          else
+            curl -sSfL "$URL" | tar -xJ
+          fi
+          echo "$PWD/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}" >> "$GITHUB_PATH"
+          zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}/zig version
       - run: bun install --frozen-lockfile
       - name: Install cross-compilation toolchain
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -134,9 +152,30 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-workspace-crates: true
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
+      - name: Install Zig 0.15.2
+        shell: bash
+        run: |
+          ZIG_VERSION=0.15.2
+          case "$RUNNER_OS" in
+            Linux)  ZIG_OS=linux;  EXT=tar.xz ;;
+            macOS)  ZIG_OS=macos;  EXT=tar.xz ;;
+            Windows) ZIG_OS=windows; EXT=zip ;;
+          esac
+          case "$RUNNER_ARCH" in
+            X64)   ZIG_ARCH=x86_64 ;;
+            ARM64) ZIG_ARCH=aarch64 ;;
+          esac
+          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}.${EXT}"
+          echo "Downloading $URL"
+          if [ "$EXT" = "zip" ]; then
+            curl -sSfL "$URL" -o zig.zip
+            unzip -q zig.zip
+            rm zig.zip
+          else
+            curl -sSfL "$URL" | tar -xJ
+          fi
+          echo "$PWD/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}" >> "$GITHUB_PATH"
+          zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}/zig version
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:
@@ -181,9 +220,30 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-workspace-crates: true
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
+      - name: Install Zig 0.15.2
+        shell: bash
+        run: |
+          ZIG_VERSION=0.15.2
+          case "$RUNNER_OS" in
+            Linux)  ZIG_OS=linux;  EXT=tar.xz ;;
+            macOS)  ZIG_OS=macos;  EXT=tar.xz ;;
+            Windows) ZIG_OS=windows; EXT=zip ;;
+          esac
+          case "$RUNNER_ARCH" in
+            X64)   ZIG_ARCH=x86_64 ;;
+            ARM64) ZIG_ARCH=aarch64 ;;
+          esac
+          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}.${EXT}"
+          echo "Downloading $URL"
+          if [ "$EXT" = "zip" ]; then
+            curl -sSfL "$URL" -o zig.zip
+            unzip -q zig.zip
+            rm zig.zip
+          else
+            curl -sSfL "$URL" | tar -xJ
+          fi
+          echo "$PWD/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}" >> "$GITHUB_PATH"
+          zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}/zig version
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
             X64)   ZIG_ARCH=x86_64 ;;
             ARM64) ZIG_ARCH=aarch64 ;;
           esac
-          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}.${EXT}"
+          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}.${EXT}"
           echo "Downloading $URL"
           if [ "$EXT" = "zip" ]; then
             curl -sSfL "$URL" -o zig.zip
@@ -107,8 +107,8 @@ jobs:
           else
             curl -sSfL "$URL" | tar -xJ
           fi
-          echo "$PWD/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}" >> "$GITHUB_PATH"
-          zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}/zig version
+          echo "$PWD/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}" >> "$GITHUB_PATH"
+          zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}/zig version
       - run: bun install --frozen-lockfile
       - name: Install cross-compilation toolchain
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -165,7 +165,7 @@ jobs:
             X64)   ZIG_ARCH=x86_64 ;;
             ARM64) ZIG_ARCH=aarch64 ;;
           esac
-          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}.${EXT}"
+          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}.${EXT}"
           echo "Downloading $URL"
           if [ "$EXT" = "zip" ]; then
             curl -sSfL "$URL" -o zig.zip
@@ -174,8 +174,8 @@ jobs:
           else
             curl -sSfL "$URL" | tar -xJ
           fi
-          echo "$PWD/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}" >> "$GITHUB_PATH"
-          zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}/zig version
+          echo "$PWD/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}" >> "$GITHUB_PATH"
+          zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}/zig version
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:
@@ -233,7 +233,7 @@ jobs:
             X64)   ZIG_ARCH=x86_64 ;;
             ARM64) ZIG_ARCH=aarch64 ;;
           esac
-          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}.${EXT}"
+          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}.${EXT}"
           echo "Downloading $URL"
           if [ "$EXT" = "zip" ]; then
             curl -sSfL "$URL" -o zig.zip
@@ -242,8 +242,8 @@ jobs:
           else
             curl -sSfL "$URL" | tar -xJ
           fi
-          echo "$PWD/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}" >> "$GITHUB_PATH"
-          zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}/zig version
+          echo "$PWD/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}" >> "$GITHUB_PATH"
+          zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}/zig version
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:

--- a/.github/workflows/test-codesign.yml
+++ b/.github/workflows/test-codesign.yml
@@ -3,6 +3,9 @@ name: Test macOS Code Signing
 on:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test-codesign:
     strategy:

--- a/.github/workflows/test-codesign.yml
+++ b/.github/workflows/test-codesign.yml
@@ -3,9 +3,6 @@ name: Test macOS Code Signing
 on:
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   test-codesign:
     strategy:
@@ -32,9 +29,30 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-workspace-crates: true
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.2
+      - name: Install Zig 0.15.2
+        shell: bash
+        run: |
+          ZIG_VERSION=0.15.2
+          case "$RUNNER_OS" in
+            Linux)  ZIG_OS=linux;  EXT=tar.xz ;;
+            macOS)  ZIG_OS=macos;  EXT=tar.xz ;;
+            Windows) ZIG_OS=windows; EXT=zip ;;
+          esac
+          case "$RUNNER_ARCH" in
+            X64)   ZIG_ARCH=x86_64 ;;
+            ARM64) ZIG_ARCH=aarch64 ;;
+          esac
+          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}.${EXT}"
+          echo "Downloading $URL"
+          if [ "$EXT" = "zip" ]; then
+            curl -sSfL "$URL" -o zig.zip
+            unzip -q zig.zip
+            rm zig.zip
+          else
+            curl -sSfL "$URL" | tar -xJ
+          fi
+          echo "$PWD/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}" >> "$GITHUB_PATH"
+          zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}/zig version
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Build native addon from source

--- a/.github/workflows/test-codesign.yml
+++ b/.github/workflows/test-codesign.yml
@@ -42,7 +42,7 @@ jobs:
             X64)   ZIG_ARCH=x86_64 ;;
             ARM64) ZIG_ARCH=aarch64 ;;
           esac
-          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}.${EXT}"
+          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}.${EXT}"
           echo "Downloading $URL"
           if [ "$EXT" = "zip" ]; then
             curl -sSfL "$URL" -o zig.zip
@@ -51,8 +51,8 @@ jobs:
           else
             curl -sSfL "$URL" | tar -xJ
           fi
-          echo "$PWD/zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}" >> "$GITHUB_PATH"
-          zig-${ZIG_OS}-${ZIG_ARCH}-${ZIG_VERSION}/zig version
+          echo "$PWD/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}" >> "$GITHUB_PATH"
+          zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}/zig version
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Build native addon from source


### PR DESCRIPTION
## Summary
- Add `oven-sh/setup-bun@v2` to the `verify-npm-install` job so the npm-installed `xcsh` binary can execute (it requires Bun via its shebang)
- Replace `mlugg/setup-zig@v2` (stuck on `node20`, [upstream PR stalled](https://codeberg.org/mlugg/setup-zig/pulls/55)) with a cross-platform shell-based Zig 0.15.2 installer, eliminating the Node.js 20 deprecation warnings at the root cause
- Supports Linux, macOS, and Windows runners via `RUNNER_OS` / `RUNNER_ARCH` detection

## What was broken
The `verify-npm-install` job has failed on every tag release since v15.3.2:
```
/usr/bin/env: 'bun': No such file or directory
```
The npm package ships `src/cli.ts` with a `#!/usr/bin/env bun` shebang, but the job only set up Node.js.

Additionally, every CI run emitted Node.js 20 deprecation warnings from `mlugg/setup-zig@v2` with a June 2026 deadline.

## Test plan
- [ ] PR CI passes: native builds on Linux (the PR subset) work with shell-based zig install
- [ ] No Node.js 20 deprecation warnings in CI logs
- [ ] After merge + next tag push: `verify-npm-install` job succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)