### PR TITLE
fix: powerline preset defaults and enable handoff save

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -791,7 +791,7 @@ export const SETTINGS_SCHEMA = {
 
 	"compaction.handoffSaveToDisk": {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: {
 			tab: "context",
 			label: "Save Handoff Docs",

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -4,7 +4,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	default: {
 		leftSegments: ["pi", "model", "plan_mode", "path", "git", "pr", "context_pct", "token_total", "cost"],
 		rightSegments: [],
-		separator: "powerline-thin",
+		separator: "powerline",
 		segmentOptions: {
 			model: { showThinkingLevel: true },
 			path: { abbreviate: true, maxLength: 40, stripWorkPrefix: true },
@@ -25,7 +25,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	compact: {
 		leftSegments: ["model", "plan_mode", "git", "pr"],
 		rightSegments: ["cost", "context_pct"],
-		separator: "powerline-thin",
+		separator: "powerline",
 		segmentOptions: {
 			model: { showThinkingLevel: false },
 			git: { showBranch: true, showStaged: true, showUnstaged: true, showUntracked: false },
@@ -95,7 +95,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 		// User-defined - these are just defaults that get overridden
 		leftSegments: ["model", "plan_mode", "path", "git", "pr"],
 		rightSegments: ["token_total", "cost", "context_pct"],
-		separator: "powerline-thin",
+		separator: "powerline",
 		segmentOptions: {},
 	},
 };


### PR DESCRIPTION
## Summary
- Standardize separator from `powerline-thin` to `powerline` for default, compact, and custom presets — aligns them with the schema default and the xcsh/full/nerd presets
- Enable `compaction.handoffSaveToDisk` by default so auto-handoff documents are persisted to disk

## Test plan
- [ ] Rebuild and start xcsh with no user config — verify status line uses powerline separators
- [ ] Switch between presets in settings panel — confirm default/compact/custom all use powerline
- [ ] Verify Save Handoff Docs shows as enabled by default in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)