### PR TITLE
feat: detect install method (npm/brew/bun/binary) in xcsh update

### DIFF
--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -2,7 +2,8 @@
  * Update CLI command handler.
  *
  * Handles `xcsh update` to check for and install updates.
- * Uses bun if available, otherwise downloads binary from GitHub releases.
+ * Auto-detects the installation method (npm, brew, bun, or standalone binary)
+ * and updates through the appropriate channel.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -60,14 +61,74 @@ function isPathInDirectory(filePath: string, directoryPath: string): boolean {
 	return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
 }
 
-type UpdateTarget = { method: "bun" } | { method: "binary"; path: string };
+export type InstallMethod = "npm" | "brew" | "bun" | "binary";
 
-function resolveUpdateMethod(ompPath: string, bunBinDir: string | undefined): "bun" | "binary" {
-	if (!bunBinDir) return "binary";
-	return isPathInDirectory(ompPath, bunBinDir) ? "bun" : "binary";
+type UpdateTarget =
+	| { method: "npm"; path: string }
+	| { method: "brew"; path: string }
+	| { method: "bun" }
+	| { method: "binary"; path: string };
+
+/**
+ * Detect how xcsh was installed by examining the binary path.
+ *
+ * Detection order:
+ * 1. bun  — binary is inside bun's global bin directory
+ * 2. npm  — binary is a symlink whose resolution chain contains "node_modules"
+ * 3. brew — binary path or realpath contains "Cellar" or "homebrew"
+ * 4. binary — fallback for standalone installs
+ */
+function detectInstallMethod(binPath: string, bunBinDir: string | undefined): InstallMethod {
+	// 1. Bun: binary lives inside bun's global bin dir
+	if (bunBinDir && isPathInDirectory(binPath, bunBinDir)) {
+		return "bun";
+	}
+
+	// 2. npm: binary is a symlink whose target chain contains node_modules
+	try {
+		const stats = fs.lstatSync(binPath);
+		if (stats.isSymbolicLink()) {
+			const linkTarget = fs.readlinkSync(binPath);
+			const resolvedTarget = path.resolve(path.dirname(binPath), linkTarget);
+			if (linkTarget.includes("node_modules") || resolvedTarget.includes("node_modules")) {
+				return "npm";
+			}
+			try {
+				const realPath = fs.realpathSync(binPath);
+				if (realPath.includes("node_modules")) {
+					return "npm";
+				}
+			} catch {
+				// realpath may fail if target doesn't exist
+			}
+		}
+	} catch {
+		// lstat/readlink may fail; fall through
+	}
+
+	// 3. brew: path or realpath contains Cellar or homebrew
+	const lowerBinPath = binPath.toLowerCase();
+	if (lowerBinPath.includes("/cellar/") || lowerBinPath.includes("/homebrew/")) {
+		return "brew";
+	}
+	try {
+		const realPath = fs.realpathSync(binPath).toLowerCase();
+		if (realPath.includes("/cellar/") || realPath.includes("/homebrew/")) {
+			return "brew";
+		}
+	} catch {
+		// realpath may fail; fall through
+	}
+
+	// 4. Standalone binary (fallback)
+	return "binary";
 }
 
-export function _resolveUpdateMethodForTest(ompPath: string, bunBinDir: string | undefined): "bun" | "binary" {
+function resolveUpdateMethod(ompPath: string, bunBinDir: string | undefined): InstallMethod {
+	return detectInstallMethod(ompPath, bunBinDir);
+}
+
+export function _resolveUpdateMethodForTest(ompPath: string, bunBinDir: string | undefined): InstallMethod {
 	return resolveUpdateMethod(ompPath, bunBinDir);
 }
 async function resolveUpdateTarget(): Promise<UpdateTarget> {
@@ -175,8 +236,9 @@ function resolveOmpPath(): string | undefined {
  */
 async function verifyInstalledVersion(
 	expectedVersion: string,
+	explicitPath?: string,
 ): Promise<{ ok: boolean; actual?: string; path?: string }> {
-	const ompPath = resolveOmpPath();
+	const ompPath = explicitPath ?? resolveOmpPath();
 	if (!ompPath) return { ok: false };
 	try {
 		const result = await $`${ompPath} --version`.quiet().nothrow();
@@ -194,8 +256,8 @@ async function verifyInstalledVersion(
 /**
  * Print post-update verification result.
  */
-async function printVerification(expectedVersion: string): Promise<void> {
-	const result = await verifyInstalledVersion(expectedVersion);
+async function printVerification(expectedVersion: string, explicitPath?: string): Promise<void> {
+	const result = await verifyInstalledVersion(expectedVersion, explicitPath);
 	if (result.ok) {
 		console.log(chalk.green(`\n${theme.status.success} Updated to ${expectedVersion}`));
 		return;
@@ -232,6 +294,34 @@ async function updateViaBun(expectedVersion: string): Promise<void> {
 }
 
 /**
+ * Update via npm package manager.
+ */
+async function updateViaNpm(expectedVersion: string): Promise<void> {
+	console.log(chalk.dim("Updating via npm..."));
+	const result = await $`npm install -g ${PACKAGE}@${expectedVersion}`.nothrow();
+	if (result.exitCode !== 0) {
+		throw new Error(`npm install failed with exit code ${result.exitCode}`);
+	}
+}
+
+/**
+ * Handle brew-installed xcsh.
+ *
+ * For corporate environments, brew-managed software must not be bypassed.
+ * Prints instructions instead of running brew upgrade automatically.
+ */
+function updateViaBrew(targetPath: string, expectedVersion: string): void {
+	console.log(
+		chalk.yellow(`\n${APP_NAME} at ${targetPath} was installed via Homebrew.`),
+	);
+	console.log(chalk.yellow("To update to " + expectedVersion + ", run:"));
+	console.log(chalk.cyan(`  brew upgrade ${APP_NAME}`));
+	console.log(
+		chalk.dim("\nThis ensures the update goes through your organization's Homebrew tap."),
+	);
+}
+
+/**
  * Download a release binary to a target path, replacing an existing file.
  */
 async function updateViaBinaryAt(targetPath: string, expectedVersion: string): Promise<void> {
@@ -261,7 +351,7 @@ async function updateViaBinaryAt(targetPath: string, expectedVersion: string): P
 		await fs.promises.rename(tempPath, targetPath);
 		await fs.promises.unlink(backupPath);
 
-		await printVerification(expectedVersion);
+		await printVerification(expectedVersion, targetPath);
 		console.log(chalk.dim(`Restart ${APP_NAME} to use the new version`));
 	} catch (err) {
 		if (fs.existsSync(backupPath) && !fs.existsSync(targetPath)) {
@@ -310,10 +400,22 @@ export async function runUpdateCommand(opts: { force: boolean; check: boolean })
 	// Choose update method based on the prioritized xcsh binary in PATH
 	try {
 		const target = await resolveUpdateTarget();
-		if (target.method === "bun") {
-			await updateViaBun(release.version);
-		} else {
-			await updateViaBinaryAt(target.path, release.version);
+		console.log(chalk.dim(`Install method: ${target.method}`));
+
+		switch (target.method) {
+			case "bun":
+				await updateViaBun(release.version);
+				break;
+			case "npm":
+				await updateViaNpm(release.version);
+				await printVerification(release.version);
+				break;
+			case "brew":
+				updateViaBrew(target.path, release.version);
+				return;
+			case "binary":
+				await updateViaBinaryAt(target.path, release.version);
+				break;
 		}
 	} catch (err) {
 		console.error(chalk.red(`Update failed: ${err}`));
@@ -333,6 +435,12 @@ ${chalk.bold("Usage:")}
 ${chalk.bold("Options:")}
   -c, --check   Check for updates without installing
   -f, --force   Force reinstall even if up to date
+
+${chalk.bold("Install methods (auto-detected):")}
+  npm           Installed via npm install -g
+  brew          Installed via Homebrew (prints upgrade instructions)
+  bun           Installed via bun install -g
+  binary        Standalone binary (direct download)
 
 ${chalk.bold("Examples:")}
   ${APP_NAME} update           Update to latest version

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { _resolveUpdateMethodForTest } from "../src/cli/update-cli";
 
 describe("update-cli install target detection", () => {
+	// --- Existing tests (bun and binary) ---
+
 	it("uses bun update when prioritized xcsh is inside bun global bin", () => {
 		const method = _resolveUpdateMethodForTest("/Users/test/.bun/bin/xcsh", "/Users/test/.bun/bin");
 
@@ -18,5 +23,91 @@ describe("update-cli install target detection", () => {
 		const method = _resolveUpdateMethodForTest("/Users/test/.local/bin/xcsh", undefined);
 
 		expect(method).toBe("binary");
+	});
+
+	// --- Brew detection (path-based) ---
+
+	it("uses brew update when path contains Cellar", () => {
+		const method = _resolveUpdateMethodForTest(
+			"/opt/homebrew/Cellar/xcsh/15.5.0/bin/xcsh",
+			undefined,
+		);
+
+		expect(method).toBe("brew");
+	});
+
+	it("uses brew update when path contains homebrew", () => {
+		const method = _resolveUpdateMethodForTest("/opt/homebrew/bin/xcsh", undefined);
+
+		expect(method).toBe("brew");
+	});
+
+	it("prefers bun over brew when binary is in bun global bin under homebrew", () => {
+		const method = _resolveUpdateMethodForTest(
+			"/opt/homebrew/.bun/bin/xcsh",
+			"/opt/homebrew/.bun/bin",
+		);
+
+		expect(method).toBe("bun");
+	});
+
+	// --- npm detection (symlink-based) ---
+
+	describe("npm detection via symlinks", () => {
+		let tmpDir: string;
+
+		beforeEach(() => {
+			tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-update-test-"));
+		});
+
+		afterEach(() => {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		});
+
+		it("uses npm update when binary is a symlink into node_modules", () => {
+			// Create a fake node_modules structure
+			const nodeModulesTarget = path.join(tmpDir, "node_modules", "@f5xc-salesdemos", "xcsh", "dist");
+			fs.mkdirSync(nodeModulesTarget, { recursive: true });
+			const targetFile = path.join(nodeModulesTarget, "xcsh");
+			fs.writeFileSync(targetFile, "");
+
+			// Create a symlink pointing into node_modules
+			const symlink = path.join(tmpDir, "xcsh");
+			fs.symlinkSync(
+				path.join("node_modules", "@f5xc-salesdemos", "xcsh", "dist", "xcsh"),
+				symlink,
+			);
+
+			const method = _resolveUpdateMethodForTest(symlink, undefined);
+
+			expect(method).toBe("npm");
+		});
+
+		it("uses npm update for chained symlinks resolving into node_modules", () => {
+			// Create node_modules target
+			const nodeModulesTarget = path.join(tmpDir, "lib", "node_modules", "@f5xc-salesdemos", "xcsh", "dist");
+			fs.mkdirSync(nodeModulesTarget, { recursive: true });
+			const targetFile = path.join(nodeModulesTarget, "xcsh");
+			fs.writeFileSync(targetFile, "");
+
+			// First symlink: usr/bin/xcsh -> lib/node_modules/.../xcsh
+			const binDir = path.join(tmpDir, "usr", "bin");
+			fs.mkdirSync(binDir, { recursive: true });
+			const firstLink = path.join(binDir, "xcsh");
+			fs.symlinkSync(
+				path.join(tmpDir, "lib", "node_modules", "@f5xc-salesdemos", "xcsh", "dist", "xcsh"),
+				firstLink,
+			);
+
+			// Second symlink: local/bin/xcsh -> usr/bin/xcsh
+			const localBinDir = path.join(tmpDir, "local", "bin");
+			fs.mkdirSync(localBinDir, { recursive: true });
+			const secondLink = path.join(localBinDir, "xcsh");
+			fs.symlinkSync(firstLink, secondLink);
+
+			const method = _resolveUpdateMethodForTest(secondLink, undefined);
+
+			expect(method).toBe("npm");
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- Auto-detect installation method by examining the binary path (symlinks, path patterns)
- **npm**: symlink resolves into `node_modules` → runs `npm install -g @f5xc-salesdemos/xcsh@VERSION`
- **brew**: path contains `Cellar` or `homebrew` → prints `brew upgrade xcsh` instructions (does not bypass corporate brew policy)
- **bun**: binary in bun's global bin dir → `bun install -g` (unchanged)
- **binary**: standalone file → downloads from GitHub releases (unchanged)
- Fix verification path mismatch: post-update check now verifies the exact binary that was updated, not a potentially-different PATH entry
- Print detected install method for transparency (`Install method: npm`)

## Context
The update command only knew about `bun` and `binary` methods. npm-installed xcsh (devcontainer) got the binary download path, which replaced the npm symlink with a standalone ELF — orphaning the npm package and creating version conflicts. Brew-installed xcsh (macOS corporate) also got the binary download path, bypassing corporate security policy requiring brew-managed software.

## Test plan
- [x] Existing 3 tests pass (bun/binary detection unchanged)
- [x] New brew detection tests (path containing `/Cellar/` and `/homebrew/`)
- [x] New npm detection tests (symlink into `node_modules/`, chained symlinks)
- [x] Priority test: bun wins over brew path patterns
- [ ] Manual: `xcsh update --check` shows detected install method

🤖 Generated with [Claude Code](https://claude.com/claude-code)