### PR TITLE
fix: correct off-by-one table column alignment in F5 XC profile commands

### DIFF
--- a/packages/coding-agent/src/services/f5xc-table.ts
+++ b/packages/coding-agent/src/services/f5xc-table.ts
@@ -44,18 +44,23 @@ export interface TableOptions {
 	dividerBefore?: number; // insert ├──┤ divider before this row index
 }
 
+// Measures the visible terminal column width of a string.
+// Delegates to Bun.stringWidth() which strips ANSI escape sequences and handles
+// Unicode wide characters — the same underlying function used by @f5xc-salesdemos/pi-tui.
+const visibleWidth = (s: string): number => (s ? Bun.stringWidth(s) : 0);
+
 export function renderF5XCTable(title: string, rows: TableRow[], options?: TableOptions): string {
-	// Calculate column widths from visible text (strip ANSI for width calc)
-	const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
-	const maxKey = Math.max(...rows.map(row => stripAnsi(row.key).length), 0);
-	const maxVal = Math.max(...rows.map(row => stripAnsi(row.value).length), 0);
-	const innerWidth = Math.max(maxKey + maxVal + 3, stripAnsi(title).length + 2, 40);
+	// Calculate column widths using visibleWidth (handles ANSI and Unicode)
+	const maxKey = Math.max(...rows.map(row => visibleWidth(row.key)), 0);
+	const maxVal = Math.max(...rows.map(row => visibleWidth(row.value)), 0);
+	// innerWidth = space + maxKey + 2-space separator + maxVal + space = maxKey + maxVal + 4
+	const innerWidth = Math.max(maxKey + maxVal + 4, visibleWidth(title) + 2, 40);
 
 	const lines: string[] = [];
 
 	// Top border: ╭─ title ──────╮
 	const titleText = ` ${title} `;
-	const titlePad = innerWidth - stripAnsi(titleText).length - 1;
+	const titlePad = innerWidth - visibleWidth(titleText) - 1;
 	lines.push(`${r(BOX.tl + BOX.h)}${BOLD}${titleText}${RESET}${r(BOX.h.repeat(Math.max(0, titlePad)) + BOX.tr)}`);
 
 	// Rows
@@ -63,13 +68,13 @@ export function renderF5XCTable(title: string, rows: TableRow[], options?: Table
 		// Optional divider
 		if (options?.dividerBefore === i) {
 			const divLabel = " Environment ";
-			const divPad = innerWidth - stripAnsi(divLabel).length - 1;
+			const divPad = innerWidth - visibleWidth(divLabel) - 1;
 			lines.push(`${r(BOX.lt + BOX.h)}${BOLD}${divLabel}${RESET}${r(BOX.h.repeat(Math.max(0, divPad)) + BOX.rt)}`);
 		}
 
 		const { key, value } = rows[i];
-		const keyPad = maxKey - stripAnsi(key).length;
-		const valPad = innerWidth - maxKey - stripAnsi(value).length - 3;
+		const keyPad = maxKey - visibleWidth(key);
+		const valPad = innerWidth - maxKey - visibleWidth(value) - 4;
 		lines.push(`${r(BOX.v)} ${key}${" ".repeat(keyPad)}  ${value}${" ".repeat(Math.max(0, valPad))} ${r(BOX.v)}`);
 	}
 

--- a/packages/coding-agent/test/f5xc-table.test.ts
+++ b/packages/coding-agent/test/f5xc-table.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { formatAuthIndicator, renderF5XCTable } from "../src/services/f5xc-table";
+
+const vw = (s: string) => (s ? Bun.stringWidth(s) : 0);
+
+describe("renderF5XCTable", () => {
+	it("all lines have equal visible width", () => {
+		const rows = [
+			{ key: "F5XC_TENANT", value: "my-org" },
+			{ key: "F5XC_API_URL", value: "https://my-org.console.ves.volterra.io" },
+			{ key: "Status", value: "\x1b[38;5;34m\u25CF\x1b[0m Connected (42ms)" },
+		];
+		const output = renderF5XCTable("test-profile", rows);
+		const lines = output.split("\n");
+		const widths = lines.map(l => vw(l));
+		expect(new Set(widths).size).toBe(1);
+	});
+
+	it("respects minimum inner width of 40", () => {
+		const rows = [{ key: "A", value: "B" }];
+		const output = renderF5XCTable("x", rows);
+		const firstLine = output.split("\n")[0];
+		// 40 inner chars + 2 border chars = 42 minimum visible width
+		expect(vw(firstLine)).toBeGreaterThanOrEqual(42);
+	});
+
+	it("handles ANSI-colored values without misalignment", () => {
+		const coloredValue = "\x1b[32m\u25CF Connected (100ms)\x1b[0m";
+		const rows = [
+			{ key: "Key", value: coloredValue },
+			{ key: "Other", value: "plain text" },
+		];
+		const output = renderF5XCTable("title", rows);
+		const lines = output.split("\n");
+		const widths = lines.map(l => vw(l));
+		expect(new Set(widths).size).toBe(1);
+	});
+
+	it("renders consistent widths with divider section", () => {
+		const rows = [
+			{ key: "F5XC_TENANT", value: "myorg" },
+			{ key: "Status", value: formatAuthIndicator("connected", 55) },
+			{ key: "F5XC_NAMESPACE", value: "default" },
+			{ key: "F5XC_CUSTOM_VAR", value: "some-value" },
+		];
+		const output = renderF5XCTable("myorg", rows, { dividerBefore: 2 });
+		const lines = output.split("\n");
+		const widths = lines.map(l => vw(l));
+		expect(new Set(widths).size).toBe(1);
+	});
+
+	it("handles long URLs without clipping the right border", () => {
+		const rows = [
+			{ key: "F5XC_API_URL", value: "https://very-long-tenant-name.console.ves.volterra.io/api" },
+			{ key: "F5XC_NAMESPACE", value: "default" },
+		];
+		const output = renderF5XCTable("long-tenant", rows);
+		const lines = output.split("\n");
+		const widths = lines.map(l => vw(l));
+		expect(new Set(widths).size).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

- Fixed off-by-one errors in `renderF5XCTable` where data rows rendered 1 character wider than top/bottom borders
- Corrected `innerWidth` formula from `+3` to `+4` to account for left padding + 2-space separator + right padding
- Corrected `valPad` formula from `-3` to `-4` for the same reason
- Replaced local regex-based `stripAnsi` with `Bun.stringWidth()` for proper ANSI/Unicode-aware width measurement
- Added 5 new tests verifying all rendered lines have equal visible width

Closes #70

## Test plan

- [ ] CI checks pass
- [ ] Verify table output alignment is consistent for all F5 XC profile commands
- [ ] New tests in `f5xc-table.test.ts` pass