### PR TITLE
feat(statusline): customize xcsh preset with per-segment powerline colors

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -522,6 +522,14 @@ export class StatusLineComponent implements Component {
 
 			// Per-segment colored rendering
 			let output = "";
+
+			// Leading cap for right groups (left-pointing arrow before first segment)
+			if (direction === "right" && hasPowerline && separatorDef.endCaps) {
+				const firstBg = parts[0].bg;
+				const capFg = firstBg.replace("\x1b[48;", "\x1b[38;");
+				output += `\x1b[0m${capFg}${separatorDef.endCaps.left}`;
+			}
+
 			for (let i = 0; i < parts.length; i++) {
 				const seg = parts[i];
 				const nextBg = i < parts.length - 1 ? parts[i + 1].bg : null;
@@ -541,10 +549,11 @@ export class StatusLineComponent implements Component {
 				}
 			}
 			// End cap / trailing edge
-			if (hasPowerline) {
+			if (hasPowerline && direction === "left") {
+				// Right-pointing arrow after last left segment
 				const lastBg = parts[parts.length - 1].bg;
 				const endFg = lastBg.replace("\x1b[48;", "\x1b[38;");
-				output += `\x1b[0m${endFg}${sep}\x1b[0m`;
+				output += `\x1b[0m${endFg}${separatorDef.left}\x1b[0m`;
 			} else {
 				output += "\x1b[0m";
 			}

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -93,7 +93,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	xcsh: {
 		leftSegments: ["os_icon", "path", "git"],
-		rightSegments: ["plan_mode", "context_pct", "token_total", "cost", "profile_f5xc"],
+		rightSegments: ["plan_mode", "context_pct", "profile_f5xc"],
 		separator: "powerline",
 		segmentOptions: {
 			model: { showThinkingLevel: true },

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -99,7 +99,12 @@ const planModeSegment: StatusLineSegment = {
 		const label = status.paused ? "Plan ⏸" : "Plan";
 		const content = withIcon(theme.icon.plan, label);
 		const color = status.paused ? "warning" : "chromeAccent";
-		return { content: theme.fg(color, content), visible: true };
+		return {
+			content: theme.fg(color, content),
+			visible: true,
+			bg: theme.fgColorAsBg("statusLinePlanModeBg"),
+			fg: theme.getFgAnsi("statusLinePlanModeFg"),
+		};
 	},
 };
 
@@ -289,7 +294,12 @@ const contextPctSegment: StatusLineSegment = {
 		const color = getContextUsageThemeColor(getContextUsageLevel(pct, window));
 		const content = withIcon(theme.icon.context, theme.fg(color, text));
 
-		return { content, visible: true };
+		return {
+			content,
+			visible: true,
+			bg: theme.fgColorAsBg("statusLineContextPctBg"),
+			fg: theme.getFgAnsi("statusLineContextPctFg"),
+		};
 	},
 };
 
@@ -413,7 +423,13 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 		render() {
 			try {
 				const { renderF5XCProfileSegment } = require("../../../services/f5xc-profile-segment");
-				return renderF5XCProfileSegment();
+				const result = renderF5XCProfileSegment();
+				if (!result.visible) return result;
+				return {
+					...result,
+					bg: theme.fgColorAsBg("statusLineProfileF5xcBg"),
+					fg: theme.getFgAnsi("statusLineProfileF5xcFg"),
+				};
 			} catch {
 				return { content: "", visible: false };
 			}

--- a/packages/coding-agent/src/modes/theme/defaults/xcsh-dark.json
+++ b/packages/coding-agent/src/modes/theme/defaults/xcsh-dark.json
@@ -95,6 +95,12 @@
 		"statusLineGitDirtyFg": 0,
 		"statusLineGitUntrackedFg": 0,
 		"statusLineGitConflictFg": 7,
+		"statusLinePlanModeBg": 236,
+		"statusLinePlanModeFg": 117,
+		"statusLineContextPctBg": 238,
+		"statusLineContextPctFg": 252,
+		"statusLineProfileF5xcBg": 52,
+		"statusLineProfileF5xcFg": 231,
 		"pythonMode": "#f0c040",
 		"syntaxControl": "#569CD6"
 	},

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -898,6 +898,12 @@ const ThemeJsonSchema = Type.Object({
 		statusLineGitDirtyFg: Type.Optional(ColorValueSchema),
 		statusLineGitUntrackedFg: Type.Optional(ColorValueSchema),
 		statusLineGitConflictFg: Type.Optional(ColorValueSchema),
+		statusLinePlanModeBg: Type.Optional(ColorValueSchema),
+		statusLinePlanModeFg: Type.Optional(ColorValueSchema),
+		statusLineContextPctBg: Type.Optional(ColorValueSchema),
+		statusLineContextPctFg: Type.Optional(ColorValueSchema),
+		statusLineProfileF5xcBg: Type.Optional(ColorValueSchema),
+		statusLineProfileF5xcFg: Type.Optional(ColorValueSchema),
 	}),
 	export: Type.Optional(
 		Type.Object({
@@ -990,7 +996,13 @@ export type ThemeColor =
 	| "statusLineGitDirtyFg"
 	| "statusLineGitUntrackedFg"
 	| "statusLineGitConflictFg"
-	| "statusLineGitFg";
+	| "statusLineGitFg"
+	| "statusLinePlanModeBg"
+	| "statusLinePlanModeFg"
+	| "statusLineContextPctBg"
+	| "statusLineContextPctFg"
+	| "statusLineProfileF5xcBg"
+	| "statusLineProfileF5xcFg";
 
 /** Set of all valid ThemeColor string values for runtime validation */
 const THEME_COLOR_RECORD = {
@@ -1070,6 +1082,12 @@ const THEME_COLOR_RECORD = {
 	statusLineGitDirtyFg: true,
 	statusLineGitUntrackedFg: true,
 	statusLineGitConflictFg: true,
+	statusLinePlanModeBg: true,
+	statusLinePlanModeFg: true,
+	statusLineContextPctBg: true,
+	statusLineContextPctFg: true,
+	statusLineProfileF5xcBg: true,
+	statusLineProfileF5xcFg: true,
 } satisfies Record<ThemeColor, true>;
 
 const VALID_THEME_COLORS: ReadonlySet<string> = new Set(Object.keys(THEME_COLOR_RECORD));
@@ -1298,6 +1316,12 @@ export class Theme {
 		this.#fgColors.statusLineGitDirtyFg ??= this.#fgColors.statusLineGitFg;
 		this.#fgColors.statusLineGitUntrackedFg ??= this.#fgColors.statusLineGitFg;
 		this.#fgColors.statusLineGitConflictFg ??= this.#fgColors.statusLineGitFg;
+		this.#fgColors.statusLinePlanModeBg ??= this.#fgColors.muted;
+		this.#fgColors.statusLinePlanModeFg ??= this.#fgColors.text;
+		this.#fgColors.statusLineContextPctBg ??= this.#fgColors.muted;
+		this.#fgColors.statusLineContextPctFg ??= this.#fgColors.text;
+		this.#fgColors.statusLineProfileF5xcBg ??= this.#fgColors.muted;
+		this.#fgColors.statusLineProfileF5xcFg ??= this.#fgColors.text;
 		this.#fgColors.contentAccent ??= this.#fgColors.accent;
 		this.#bgColors = {} as Record<ThemeBg, string>;
 		for (const [key, value] of Object.entries(bgColors) as [ThemeBg, string | number][]) {


### PR DESCRIPTION
## What

- Remove `token_total` and `cost` segments from the xcsh preset right side
- Add per-segment bg/fg colors to `plan_mode`, `context_pct`, and `profile_f5xc` for a full powerline gradient look
- Fix right-side powerline cap rendering: add leading cap before first right segment, make trailing cap left-group-only

## Why

The xcsh statusline right side was flat (no per-segment colors) and included token/cost data that cluttered the display. This brings the right side in line with the left side's existing powerline treatment (os_icon→path→git each have distinct backgrounds), giving a cohesive branded appearance with F5 dark red anchoring the rightmost segment.

## Color palette (xcsh-dark theme)

| Segment | BG (ANSI 256) | FG |
|---|---|---|
| `plan_mode` | 236 (dark gray) | 117 (light cyan) |
| `context_pct` | 238 (med-dark gray) | 252 (light gray) |
| `profile_f5xc` | 52 (F5 dark red) | 231 (bright white) |

Themes other than xcsh-dark fall back to `muted` bg / `text` fg, preserving their existing flat appearance.

## Testing

- [ ] `bun test` passes with no new failures vs baseline (verified: 24 fail vs 25 baseline)
- [ ] Run `bun packages/coding-agent/src/cli.ts` from the worktree to visually verify powerline arrows and segment colors
- [ ] Verify `plan_mode` hides when not active, shows with cyan accent when active and amber when paused
- [ ] Verify `profile_f5xc` hides when not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)