### PR TITLE
fix(session): initialize #resolveObfuscator before first use in constructor

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -569,6 +569,7 @@ export class AgentSession {
 		this.#defaultSelectedMCPServerNames = new Set(config.defaultSelectedMCPServerNames ?? []);
 		this.#defaultSelectedMCPToolNames = new Set(config.defaultSelectedMCPToolNames ?? []);
 		this.#pruneSelectedMCPToolNames();
+		this.#resolveObfuscator = () => config.obfuscator;
 		const persistedSelectedMCPToolNames = this.buildDisplaySessionContext().selectedMCPToolNames;
 		const currentSelectedMCPToolNames = this.getSelectedMCPToolNames();
 		const persistInitialMCPToolSelection =
@@ -585,7 +586,6 @@ export class AgentSession {
 			this.#getConfiguredDefaultSelectedMCPToolNames(),
 		);
 		this.#ttsrManager = config.ttsrManager;
-		this.#resolveObfuscator = () => config.obfuscator;
 		this.agent.setAssistantMessageEventInterceptor((message, assistantMessageEvent) => {
 			const event: AgentEvent = {
 				type: "message_update",

--- a/packages/coding-agent/test/agent-session-obfuscator-init.test.ts
+++ b/packages/coding-agent/test/agent-session-obfuscator-init.test.ts
@@ -69,9 +69,7 @@ describe("AgentSession obfuscator initialization order", () => {
 			initialState: { model, systemPrompt: "Test", tools: [] },
 		});
 
-		const obfuscator = new SecretObfuscator([
-			{ type: "plain", content: "super-secret-token-12345" },
-		]);
+		const obfuscator = new SecretObfuscator([{ type: "plain", content: "super-secret-token-12345" }]);
 
 		// Construction must not throw even with an active obfuscator
 		session = new AgentSession({

--- a/packages/coding-agent/test/agent-session-obfuscator-init.test.ts
+++ b/packages/coding-agent/test/agent-session-obfuscator-init.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression test: #resolveObfuscator must be initialized before
+ * buildDisplaySessionContext() is called in the AgentSession constructor.
+ *
+ * Bug: commit e97439c79 changed #obfuscator (a value) to #resolveObfuscator
+ * (a function), but assigned it at line 588 — after buildDisplaySessionContext()
+ * is called at line 572. Calling undefined() throws TypeError.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@f5xc-salesdemos/pi-agent-core";
+import { getBundledModel } from "@f5xc-salesdemos/pi-ai";
+import { TempDir } from "@f5xc-salesdemos/pi-utils";
+import { ModelRegistry } from "@f5xc-salesdemos/xcsh/config/model-registry";
+import { Settings } from "@f5xc-salesdemos/xcsh/config/settings";
+import { AgentSession } from "@f5xc-salesdemos/xcsh/session/agent-session";
+import { AuthStorage } from "@f5xc-salesdemos/xcsh/session/auth-storage";
+import { SessionManager } from "@f5xc-salesdemos/xcsh/session/session-manager";
+import { SecretObfuscator } from "../src/secrets/obfuscator";
+
+describe("AgentSession obfuscator initialization order", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let session: AgentSession | undefined;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-obfuscator-init-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+			session = undefined;
+		}
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("constructs without throwing when no obfuscator is provided", () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: "Test", tools: [] },
+		});
+
+		// This should not throw — #resolveObfuscator must be initialized
+		// before buildDisplaySessionContext() is called in the constructor.
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+
+		// Verify buildDisplaySessionContext() works after construction too
+		const ctx = session.buildDisplaySessionContext();
+		expect(ctx).toBeDefined();
+	});
+
+	it("constructs without throwing when an obfuscator is provided", () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: "Test", tools: [] },
+		});
+
+		const obfuscator = new SecretObfuscator([
+			{ type: "plain", content: "super-secret-token-12345" },
+		]);
+
+		// Construction must not throw even with an active obfuscator
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry,
+			obfuscator,
+		});
+
+		const ctx = session.buildDisplaySessionContext();
+		expect(ctx).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Summary

- Commit e97439c79 refactored `#obfuscator` to `#resolveObfuscator` (a closure) but assigned it after `buildDisplaySessionContext()` already calls it in the AgentSession constructor, causing a `TypeError` crash on every session start in v15.12.0
- Moves the `#resolveObfuscator` assignment before its first use in the constructor
- Adds a regression test to verify the initialization order is correct

Closes #78

## Test plan

- [ ] CI checks pass
- [ ] Regression test `agent-session-obfuscator-init.test.ts` passes
- [ ] Manual verification: `new AgentSession(...)` no longer throws `TypeError` at construction