### PR TITLE
feat(tui): add left margin gutter with activity indicators

### DIFF
--- a/packages/coding-agent/src/modes/components/gutter-block.ts
+++ b/packages/coding-agent/src/modes/components/gutter-block.ts
@@ -1,0 +1,246 @@
+import { type Component, Container, type TUI } from "@f5xc-salesdemos/pi-tui";
+import { getSymbolTheme, theme } from "../theme/theme";
+
+const GUTTER_WIDTH = 2; // 1 char indicator + 1 char space
+const SPINNER_INTERVAL_MS = 80;
+const GUTTER_PAD = "  "; // 2 spaces for continuation lines
+
+export interface GutterConfig {
+	/** Indicator symbol shown when done (e.g. "●", "✻", "※") */
+	symbol: string;
+	/** Color function for active state (used for static active indicator) */
+	activeColorFn: (s: string) => string;
+	/** Color function for done state */
+	doneColorFn: (s: string) => string;
+	/** Whether to show spinner animation when active */
+	animated: boolean;
+}
+
+type GutterState = "active" | "done";
+
+/**
+ * GutterBlock wraps a child component and prepends a 2-character left gutter
+ * to every rendered line. The first line shows an indicator (optionally animated),
+ * continuation lines show 2 spaces.
+ */
+export class GutterBlock<T extends Component> implements Component {
+	#child: T;
+	#config: GutterConfig;
+	#state: GutterState;
+	#ui: TUI;
+
+	// Spinner state
+	#spinnerFrames: string[];
+	#currentFrame = 0;
+	#intervalId?: ReturnType<typeof setInterval>;
+
+	constructor(ui: TUI, child: T, config: GutterConfig, initialState: GutterState = "active") {
+		this.#child = child;
+		this.#config = config;
+		this.#state = initialState;
+		this.#ui = ui;
+		this.#spinnerFrames = getSymbolTheme().spinnerFrames;
+
+		if (initialState === "active" && config.animated) {
+			this.#startSpinner();
+		}
+	}
+
+	get child(): T {
+		return this.#child;
+	}
+
+	get state(): GutterState {
+		return this.#state;
+	}
+
+	setDone(): void {
+		if (this.#state === "done") return;
+		this.#state = "done";
+		this.#stopSpinner();
+		this.#ui.requestRender();
+	}
+
+	/** Switch to thinking mode: change symbol to ✻ and start animated spinner */
+	setThinkingMode(): void {
+		if (this.#state === "done") return;
+		this.#config = {
+			symbol: "✻",
+			activeColorFn: (s: string) => theme.fg("spinnerAccent", s),
+			doneColorFn: (s: string) => theme.fg("dim", s),
+			animated: true,
+		};
+		if (!this.#intervalId) {
+			this.#startSpinner();
+		}
+	}
+
+	/** Forward setExpanded to child if it supports it (duck-typed for isExpandable checks) */
+	setExpanded(expanded: boolean): void {
+		const child = this.#child as any;
+		if (typeof child.setExpanded === "function") {
+			child.setExpanded(expanded);
+		}
+	}
+
+	invalidate(): void {
+		this.#child.invalidate?.();
+	}
+
+	render(width: number): string[] {
+		const childLines = this.#child.render(Math.max(1, width - GUTTER_WIDTH));
+
+		if (childLines.length === 0) {
+			return [];
+		}
+
+		// Find the first non-empty line — most wrapped components start with a Spacer(1)
+		// that produces blank lines. Place the indicator on the first content line, not the spacer.
+		let firstContentIdx = 0;
+		for (let i = 0; i < childLines.length; i++) {
+			if (childLines[i].trim() !== "") {
+				firstContentIdx = i;
+				break;
+			}
+		}
+
+		const prefix = this.#buildGutterPrefix();
+		const result: string[] = [];
+		for (let i = 0; i < childLines.length; i++) {
+			result.push((i === firstContentIdx ? prefix : GUTTER_PAD) + childLines[i]);
+		}
+		return result;
+	}
+
+	dispose(): void {
+		this.#stopSpinner();
+	}
+
+	#buildGutterPrefix(): string {
+		if (this.#state === "done") {
+			return `${this.#config.doneColorFn(this.#config.symbol)} `;
+		}
+
+		if (this.#config.animated) {
+			const frame = this.#spinnerFrames[this.#currentFrame];
+			return `${this.#config.activeColorFn(frame)} `;
+		}
+
+		return `${this.#config.activeColorFn(this.#config.symbol)} `;
+	}
+
+	#startSpinner(): void {
+		this.#intervalId = setInterval(() => {
+			this.#currentFrame = (this.#currentFrame + 1) % this.#spinnerFrames.length;
+			this.#ui.requestRender();
+		}, SPINNER_INTERVAL_MS);
+	}
+
+	#stopSpinner(): void {
+		if (this.#intervalId) {
+			clearInterval(this.#intervalId);
+			this.#intervalId = undefined;
+		}
+	}
+}
+
+// ============================================================================
+// DisposableContainer — stops gutter timers on clear/remove
+// ============================================================================
+
+function disposeIfGutter(child: Component): void {
+	if (child instanceof GutterBlock) {
+		child.dispose();
+	}
+}
+
+/**
+ * Container subclass that disposes GutterBlock children when they are
+ * removed or the container is cleared. Prevents orphaned spinner timers.
+ */
+export class DisposableContainer extends Container {
+	override removeChild(component: Component): void {
+		disposeIfGutter(component);
+		super.removeChild(component);
+	}
+
+	override clear(): void {
+		for (const child of this.children) {
+			disposeIfGutter(child);
+		}
+		super.clear();
+	}
+}
+
+// ============================================================================
+// Factory functions
+// ============================================================================
+
+/** Animated ● gutter for active tool calls — spinner in spinnerAccent, done in dim */
+export function createToolGutter<T extends Component>(ui: TUI, child: T): GutterBlock<T> {
+	return new GutterBlock(ui, child, {
+		symbol: "●",
+		activeColorFn: (s: string) => theme.fg("spinnerAccent", s),
+		doneColorFn: (s: string) => theme.fg("dim", s),
+		animated: true,
+	});
+}
+
+/** Static ● gutter for assistant text — immediately in done state, white/text color */
+export function createTextGutter<T extends Component>(ui: TUI, child: T): GutterBlock<T> {
+	return new GutterBlock(
+		ui,
+		child,
+		{
+			symbol: "●",
+			activeColorFn: (s: string) => theme.fg("text", s),
+			doneColorFn: (s: string) => theme.fg("text", s),
+			animated: false,
+		},
+		"done",
+	);
+}
+
+/**
+ * ● gutter for streaming assistant messages — starts active (non-animated, white ●)
+ * so it can switch to thinking mode (✻ spinner) if thinking content arrives.
+ * Call setDone() when message_end fires.
+ */
+export function createStreamingAssistantGutter<T extends Component>(ui: TUI, child: T): GutterBlock<T> {
+	return new GutterBlock(
+		ui,
+		child,
+		{
+			symbol: "●",
+			activeColorFn: (s: string) => theme.fg("text", s),
+			doneColorFn: (s: string) => theme.fg("text", s),
+			animated: false,
+		},
+		"active",
+	);
+}
+
+/** Animated ✻ gutter for thinking — spinner in spinnerAccent, done in dim */
+export function createThinkingGutter<T extends Component>(ui: TUI, child: T): GutterBlock<T> {
+	return new GutterBlock(ui, child, {
+		symbol: "✻",
+		activeColorFn: (s: string) => theme.fg("spinnerAccent", s),
+		doneColorFn: (s: string) => theme.fg("dim", s),
+		animated: true,
+	});
+}
+
+/** Static ※ gutter for system/recap messages — immediately in done state, dim */
+export function createSystemGutter<T extends Component>(ui: TUI, child: T): GutterBlock<T> {
+	return new GutterBlock(
+		ui,
+		child,
+		{
+			symbol: "※",
+			activeColorFn: (s: string) => theme.fg("dim", s),
+			doneColorFn: (s: string) => theme.fg("dim", s),
+			animated: false,
+		},
+		"done",
+	);
+}

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -21,6 +21,7 @@ import { buildMemoryToolDeveloperInstructions, clearMemoryData, enqueueMemoryCon
 import { BashExecutionComponent } from "../../modes/components/bash-execution";
 import { BorderedLoader } from "../../modes/components/bordered-loader";
 import { DynamicBorder } from "../../modes/components/dynamic-border";
+import { createToolGutter } from "../../modes/components/gutter-block";
 import { PythonExecutionComponent } from "../../modes/components/python-execution";
 import { getMarkdownTheme, getSymbolTheme, theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext } from "../../modes/types";
@@ -691,12 +692,14 @@ export class CommandController {
 	async handleBashCommand(command: string, excludeFromContext = false): Promise<void> {
 		const isDeferred = this.ctx.session.isStreaming;
 		this.ctx.bashComponent = new BashExecutionComponent(command, this.ctx.ui, excludeFromContext);
+		let bashGutter: ReturnType<typeof createToolGutter> | undefined;
 
 		if (isDeferred) {
 			this.ctx.pendingMessagesContainer.addChild(this.ctx.bashComponent);
 			this.ctx.pendingBashComponents.push(this.ctx.bashComponent);
 		} else {
-			this.ctx.chatContainer.addChild(this.ctx.bashComponent);
+			bashGutter = createToolGutter(this.ctx.ui, this.ctx.bashComponent);
+			this.ctx.chatContainer.addChild(bashGutter);
 		}
 		this.ctx.ui.requestRender();
 
@@ -732,6 +735,7 @@ export class CommandController {
 			this.ctx.showError(`Bash command failed: ${error instanceof Error ? error.message : "Unknown error"}`);
 		}
 
+		bashGutter?.setDone();
 		this.ctx.bashComponent = undefined;
 		this.ctx.ui.requestRender();
 	}
@@ -739,12 +743,14 @@ export class CommandController {
 	async handlePythonCommand(code: string, excludeFromContext = false): Promise<void> {
 		const isDeferred = this.ctx.session.isStreaming;
 		this.ctx.pythonComponent = new PythonExecutionComponent(code, this.ctx.ui, excludeFromContext);
+		let pythonGutter: ReturnType<typeof createToolGutter> | undefined;
 
 		if (isDeferred) {
 			this.ctx.pendingMessagesContainer.addChild(this.ctx.pythonComponent);
 			this.ctx.pendingPythonComponents.push(this.ctx.pythonComponent);
 		} else {
-			this.ctx.chatContainer.addChild(this.ctx.pythonComponent);
+			pythonGutter = createToolGutter(this.ctx.ui, this.ctx.pythonComponent);
+			this.ctx.chatContainer.addChild(pythonGutter);
 		}
 		this.ctx.ui.requestRender();
 
@@ -773,6 +779,7 @@ export class CommandController {
 			this.ctx.showError(`Python execution failed: ${error instanceof Error ? error.message : "Unknown error"}`);
 		}
 
+		pythonGutter?.setDone();
 		this.ctx.pythonComponent = undefined;
 		this.ctx.ui.requestRender();
 	}

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -3,6 +3,12 @@ import type { AssistantMessage, ImageContent } from "@f5xc-salesdemos/pi-ai";
 import { Loader, TERMINAL, Text } from "@f5xc-salesdemos/pi-tui";
 import { settings } from "../../config/settings";
 import { AssistantMessageComponent } from "../../modes/components/assistant-message";
+import {
+	createStreamingAssistantGutter,
+	createSystemGutter,
+	createToolGutter,
+	type GutterBlock,
+} from "../../modes/components/gutter-block";
 import { ReadToolGroupComponent } from "../../modes/components/read-tool-group";
 import { TodoReminderComponent } from "../../modes/components/todo-reminder";
 import { ToolExecutionComponent } from "../../modes/components/tool-execution";
@@ -15,6 +21,7 @@ import type { ExitPlanModeDetails } from "../../tools";
 
 export class EventController {
 	#lastReadGroup: ReadToolGroupComponent | undefined = undefined;
+	#lastReadGroupGutter: GutterBlock<ReadToolGroupComponent> | undefined = undefined;
 	#lastThinkingCount = 0;
 	#renderedCustomMessages = new Set<string>();
 	#lastIntent: string | undefined = undefined;
@@ -23,6 +30,8 @@ export class EventController {
 	#readToolCallAssistantComponents = new Map<string, AssistantMessageComponent>();
 	#lastAssistantComponent: AssistantMessageComponent | undefined = undefined;
 	#idleCompactionTimer?: NodeJS.Timeout;
+	#pendingGutters = new Map<string, GutterBlock<any>>();
+	// streamingAssistantGutter is stored on ctx for cross-controller access (e.g. thinking toggle)
 	constructor(private ctx: InteractiveModeContext) {}
 
 	dispose(): void {
@@ -30,18 +39,40 @@ export class EventController {
 	}
 
 	#resetReadGroup(): void {
+		// Only clear the grouping state so the next reads start a new group.
+		// setDone() is handled by #cleanupReadGutter() when each read actually completes,
+		// so we never prematurely mark a group as done (e.g. read + edit patterns).
 		this.#lastReadGroup = undefined;
+		this.#lastReadGroupGutter = undefined;
 	}
 
-	#getReadGroup(): ReadToolGroupComponent {
+	#getReadGroup(toolCallId?: string): ReadToolGroupComponent {
 		if (!this.#lastReadGroup) {
 			this.ctx.chatContainer.addChild(new Text("", 0, 0));
 			const group = new ReadToolGroupComponent();
 			group.setExpanded(this.ctx.toolOutputExpanded);
-			this.ctx.chatContainer.addChild(group);
+			const gutter = createToolGutter(this.ctx.ui, group);
+			this.ctx.chatContainer.addChild(gutter);
 			this.#lastReadGroup = group;
+			this.#lastReadGroupGutter = gutter;
+		}
+		// Track the group gutter under each read tool ID so async completion can find it
+		if (toolCallId && this.#lastReadGroupGutter) {
+			this.#pendingGutters.set(toolCallId, this.#lastReadGroupGutter);
 		}
 		return this.#lastReadGroup;
+	}
+
+	/** Remove a read tool's gutter entry; setDone() if no other reads share the same group gutter */
+	#cleanupReadGutter(toolCallId: string): void {
+		const gutter = this.#pendingGutters.get(toolCallId);
+		this.#pendingGutters.delete(toolCallId);
+		if (gutter) {
+			const stillActive = Array.from(this.#pendingGutters.values()).some(g => g === gutter);
+			if (!stillActive) {
+				gutter.setDone();
+			}
+		}
 	}
 
 	#trackReadToolCall(toolCallId: string, args: unknown): void {
@@ -156,7 +187,11 @@ export class EventController {
 					this.#resetReadGroup();
 					this.ctx.streamingComponent = new AssistantMessageComponent(undefined, this.ctx.hideThinkingBlock);
 					this.ctx.streamingMessage = event.message;
-					this.ctx.chatContainer.addChild(this.ctx.streamingComponent);
+					this.ctx.streamingAssistantGutter = createStreamingAssistantGutter(
+						this.ctx.ui,
+						this.ctx.streamingComponent,
+					);
+					this.ctx.chatContainer.addChild(this.ctx.streamingAssistantGutter);
 					this.ctx.streamingComponent.updateContent(this.ctx.streamingMessage);
 					this.ctx.ui.requestRender();
 				}
@@ -173,6 +208,7 @@ export class EventController {
 					if (thinkingCount > this.#lastThinkingCount) {
 						this.#resetReadGroup();
 						this.#lastThinkingCount = thinkingCount;
+						this.ctx.streamingAssistantGutter?.setThinkingMode();
 					}
 
 					for (const content of this.ctx.streamingMessage.content) {
@@ -183,7 +219,7 @@ export class EventController {
 							if (component) {
 								component.updateArgs(content.arguments, content.id);
 							} else {
-								const group = this.#getReadGroup();
+								const group = this.#getReadGroup(content.id);
 								group.updateArgs(content.arguments, content.id);
 								this.ctx.pendingTools.set(content.id, group);
 							}
@@ -213,8 +249,10 @@ export class EventController {
 								this.ctx.sessionManager.getCwd(),
 							);
 							component.setExpanded(this.ctx.toolOutputExpanded);
-							this.ctx.chatContainer.addChild(component);
+							const gutter = createToolGutter(this.ctx.ui, component);
+							this.ctx.chatContainer.addChild(gutter);
 							this.ctx.pendingTools.set(content.id, component);
+							this.#pendingGutters.set(content.id, gutter);
 						} else {
 							const component = this.ctx.pendingTools.get(content.id);
 							if (component) {
@@ -265,6 +303,8 @@ export class EventController {
 					}
 					this.#lastAssistantComponent = this.ctx.streamingComponent;
 					this.#lastAssistantComponent.setUsageInfo(event.message.usage);
+					this.ctx.streamingAssistantGutter?.setDone();
+					this.ctx.streamingAssistantGutter = undefined;
 					this.ctx.streamingComponent = undefined;
 					this.ctx.streamingMessage = undefined;
 					this.ctx.statusLine.invalidate();
@@ -282,7 +322,7 @@ export class EventController {
 						if (component) {
 							component.updateArgs(event.args, event.toolCallId);
 						} else {
-							const group = this.#getReadGroup();
+							const group = this.#getReadGroup(event.toolCallId);
 							group.updateArgs(event.args, event.toolCallId);
 							this.ctx.pendingTools.set(event.toolCallId, group);
 						}
@@ -305,8 +345,10 @@ export class EventController {
 						this.ctx.sessionManager.getCwd(),
 					);
 					component.setExpanded(this.ctx.toolOutputExpanded);
-					this.ctx.chatContainer.addChild(component);
+					const gutter = createToolGutter(this.ctx.ui, component);
+					this.ctx.chatContainer.addChild(gutter);
 					this.ctx.pendingTools.set(event.toolCallId, component);
+					this.#pendingGutters.set(event.toolCallId, gutter);
 					this.ctx.ui.requestRender();
 				}
 				break;
@@ -324,6 +366,8 @@ export class EventController {
 						event.toolCallId,
 					);
 					if (isFinalAsyncState) {
+						this.#pendingGutters.get(event.toolCallId)?.setDone();
+						this.#pendingGutters.delete(event.toolCallId);
 						this.ctx.pendingTools.delete(event.toolCallId);
 						this.#backgroundToolCallIds.delete(event.toolCallId);
 					}
@@ -344,6 +388,7 @@ export class EventController {
 						if (asyncState === "running") {
 							this.#backgroundToolCallIds.add(event.toolCallId);
 						} else {
+							this.#cleanupReadGutter(event.toolCallId);
 							this.#backgroundToolCallIds.delete(event.toolCallId);
 							this.#clearReadToolCall(event.toolCallId);
 						}
@@ -351,7 +396,7 @@ export class EventController {
 					} else {
 						let component = this.ctx.pendingTools.get(event.toolCallId);
 						if (!component) {
-							const group = this.#getReadGroup();
+							const group = this.#getReadGroup(event.toolCallId);
 							const args = this.#readToolCallArgs.get(event.toolCallId);
 							if (args) {
 								group.updateArgs(args, event.toolCallId);
@@ -369,6 +414,7 @@ export class EventController {
 						if (isBackgroundRunning) {
 							this.#backgroundToolCallIds.add(event.toolCallId);
 						} else {
+							this.#cleanupReadGutter(event.toolCallId);
 							this.ctx.pendingTools.delete(event.toolCallId);
 							this.#backgroundToolCallIds.delete(event.toolCallId);
 							this.#clearReadToolCall(event.toolCallId);
@@ -388,6 +434,8 @@ export class EventController {
 						if (isBackgroundRunning) {
 							this.#backgroundToolCallIds.add(event.toolCallId);
 						} else {
+							this.#pendingGutters.get(event.toolCallId)?.setDone();
+							this.#pendingGutters.delete(event.toolCallId);
 							this.ctx.pendingTools.delete(event.toolCallId);
 							this.#backgroundToolCallIds.delete(event.toolCallId);
 						}
@@ -424,19 +472,24 @@ export class EventController {
 					this.ctx.statusContainer.clear();
 				}
 				if (this.ctx.streamingComponent) {
-					this.ctx.chatContainer.removeChild(this.ctx.streamingComponent);
+					this.ctx.chatContainer.removeChild(this.ctx.streamingAssistantGutter ?? this.ctx.streamingComponent);
+					this.ctx.streamingAssistantGutter?.dispose();
+					this.ctx.streamingAssistantGutter = undefined;
 					this.ctx.streamingComponent = undefined;
 					this.ctx.streamingMessage = undefined;
 				}
 				await this.ctx.flushPendingModelSwitch();
 				for (const toolCallId of Array.from(this.ctx.pendingTools.keys())) {
 					if (!this.#backgroundToolCallIds.has(toolCallId)) {
+						this.#pendingGutters.get(toolCallId)?.setDone();
+						this.#pendingGutters.delete(toolCallId);
 						this.ctx.pendingTools.delete(toolCallId);
 					}
 				}
 				this.#backgroundToolCallIds = new Set(
 					Array.from(this.#backgroundToolCallIds).filter(toolCallId => this.ctx.pendingTools.has(toolCallId)),
 				);
+				this.#resetReadGroup();
 				this.#readToolCallArgs.clear();
 				this.#readToolCallAssistantComponents.clear();
 				this.#lastAssistantComponent = undefined;
@@ -558,14 +611,14 @@ export class EventController {
 			case "ttsr_triggered": {
 				const component = new TtsrNotificationComponent(event.rules);
 				component.setExpanded(this.ctx.toolOutputExpanded);
-				this.ctx.chatContainer.addChild(component);
+				this.ctx.chatContainer.addChild(createSystemGutter(this.ctx.ui, component));
 				this.ctx.ui.requestRender();
 				break;
 			}
 
 			case "todo_reminder": {
 				const component = new TodoReminderComponent(event.todos, event.attempt, event.maxAttempts);
-				this.ctx.chatContainer.addChild(component);
+				this.ctx.chatContainer.addChild(createSystemGutter(this.ctx.ui, component));
 				this.ctx.ui.requestRender();
 				break;
 			}

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -4,6 +4,7 @@ import { sanitizeText } from "@f5xc-salesdemos/pi-natives";
 import type { AutocompleteProvider, SlashCommand } from "@f5xc-salesdemos/pi-tui";
 import { $env } from "@f5xc-salesdemos/pi-utils";
 import { settings } from "../../config/settings";
+import { createStreamingAssistantGutter } from "../../modes/components/gutter-block";
 import { createPromptActionAutocompleteProvider } from "../../modes/prompt-action-autocomplete";
 import { theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext } from "../../modes/types";
@@ -673,11 +674,18 @@ export class InputController {
 		this.ctx.chatContainer.clear();
 		this.ctx.rebuildChatFromMessages();
 
-		// If streaming, re-add the streaming component with updated visibility and re-render
+		// If streaming, recreate a fresh gutter (the old one was disposed by clear())
 		if (this.ctx.streamingComponent && this.ctx.streamingMessage) {
 			this.ctx.streamingComponent.setHideThinkingBlock(this.ctx.hideThinkingBlock);
 			this.ctx.streamingComponent.updateContent(this.ctx.streamingMessage);
-			this.ctx.chatContainer.addChild(this.ctx.streamingComponent);
+			const newGutter = createStreamingAssistantGutter(this.ctx.ui, this.ctx.streamingComponent);
+			// Restore thinking mode if the message has thinking content
+			const hasThinking = this.ctx.streamingMessage.content.some(c => c.type === "thinking" && c.thinking.trim());
+			if (hasThinking) {
+				newGutter.setThinkingMode();
+			}
+			this.ctx.streamingAssistantGutter = newGutter;
+			this.ctx.chatContainer.addChild(newGutter);
 		}
 
 		this.ctx.showStatus(`Thinking blocks: ${this.ctx.hideThinkingBlock ? "hidden" : "visible"}`);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -43,6 +43,7 @@ import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { AgentDashboard } from "../components/agent-dashboard";
 import { AssistantMessageComponent } from "../components/assistant-message";
 import { ExtensionDashboard } from "../components/extensions";
+import { GutterBlock } from "../components/gutter-block";
 import { HistorySearchComponent } from "../components/history-search";
 import { ModelSelectorComponent } from "../components/model-selector";
 import { OAuthSelectorComponent } from "../components/oauth-selector";
@@ -268,16 +269,18 @@ export class SelectorController {
 			// Settings with UI side effects
 			case "showImages":
 				for (const child of this.ctx.chatContainer.children) {
-					if (child instanceof ToolExecutionComponent) {
-						child.setShowImages(value as boolean);
+					const unwrapped = child instanceof GutterBlock ? child.child : child;
+					if (unwrapped instanceof ToolExecutionComponent) {
+						unwrapped.setShowImages(value as boolean);
 					}
 				}
 				break;
 			case "hideThinking":
 				this.ctx.hideThinkingBlock = value as boolean;
 				for (const child of this.ctx.chatContainer.children) {
-					if (child instanceof AssistantMessageComponent) {
-						child.setHideThinkingBlock(value as boolean);
+					const unwrapped = child instanceof GutterBlock ? child.child : child;
+					if (unwrapped instanceof AssistantMessageComponent) {
+						unwrapped.setHideThinkingBlock(value as boolean);
 					}
 				}
 				this.ctx.chatContainer.clear();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -44,6 +44,7 @@ import type { AssistantMessageComponent } from "./components/assistant-message";
 import type { BashExecutionComponent } from "./components/bash-execution";
 import { CustomEditor } from "./components/custom-editor";
 import { DynamicBorder } from "./components/dynamic-border";
+import { DisposableContainer, type GutterBlock } from "./components/gutter-block";
 import type { HookEditorComponent } from "./components/hook-editor";
 import type { HookInputComponent } from "./components/hook-input";
 import type { HookSelectorComponent } from "./components/hook-selector";
@@ -132,6 +133,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	pythonComponent: PythonExecutionComponent | undefined = undefined;
 	isPythonMode = false;
 	streamingComponent: AssistantMessageComponent | undefined = undefined;
+	streamingAssistantGutter: GutterBlock<AssistantMessageComponent> | undefined = undefined;
 	streamingMessage: AssistantMessage | undefined = undefined;
 	loadingAnimation: Loader | undefined = undefined;
 	autoCompactionLoader: Loader | undefined = undefined;
@@ -222,7 +224,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui = new TUI(new ProcessTerminal(), settings.get("showHardwareCursor"));
 		this.ui.setClearOnShrink(settings.get("clearOnShrink"));
 		setMermaidRenderCallback(() => this.ui.requestRender());
-		this.chatContainer = new Container();
+		this.chatContainer = new DisposableContainer();
 		this.pendingMessagesContainer = new Container();
 		this.statusContainer = new Container();
 		this.todoContainer = new Container();

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -18,6 +18,7 @@ import type { ExitPlanModeDetails, LspStartupServerInfo } from "../tools";
 import type { AssistantMessageComponent } from "./components/assistant-message";
 import type { BashExecutionComponent } from "./components/bash-execution";
 import type { CustomEditor } from "./components/custom-editor";
+import type { GutterBlock } from "./components/gutter-block";
 import type { HookEditorComponent } from "./components/hook-editor";
 import type { HookInputComponent } from "./components/hook-input";
 import type { HookSelectorComponent } from "./components/hook-selector";
@@ -96,6 +97,7 @@ export interface InteractiveModeContext {
 	pythonComponent: PythonExecutionComponent | undefined;
 	isPythonMode: boolean;
 	streamingComponent: AssistantMessageComponent | undefined;
+	streamingAssistantGutter: GutterBlock<AssistantMessageComponent> | undefined;
 	streamingMessage: AssistantMessage | undefined;
 	loadingAnimation: Loader | undefined;
 	autoCompactionLoader: Loader | undefined;

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -8,6 +8,12 @@ import { BranchSummaryMessageComponent } from "../../modes/components/branch-sum
 import { CompactionSummaryMessageComponent } from "../../modes/components/compaction-summary-message";
 import { CustomMessageComponent } from "../../modes/components/custom-message";
 import { DynamicBorder } from "../../modes/components/dynamic-border";
+import {
+	createSystemGutter,
+	createTextGutter,
+	createToolGutter,
+	GutterBlock,
+} from "../../modes/components/gutter-block";
 import { PythonExecutionComponent } from "../../modes/components/python-execution";
 import { ReadToolGroupComponent } from "../../modes/components/read-tool-group";
 import { SkillMessageComponent } from "../../modes/components/skill-message";
@@ -80,7 +86,9 @@ export class UiHelpers {
 				component.setComplete(message.exitCode, message.cancelled, {
 					truncation: message.meta?.truncation,
 				});
-				this.ctx.chatContainer.addChild(component);
+				const gutter = createToolGutter(this.ctx.ui, component);
+				gutter.setDone();
+				this.ctx.chatContainer.addChild(gutter);
 				break;
 			}
 			case "pythonExecution": {
@@ -91,7 +99,9 @@ export class UiHelpers {
 				component.setComplete(message.exitCode, message.cancelled, {
 					truncation: message.meta?.truncation,
 				});
-				this.ctx.chatContainer.addChild(component);
+				const gutter = createToolGutter(this.ctx.ui, component);
+				gutter.setDone();
+				this.ctx.chatContainer.addChild(gutter);
 				break;
 			}
 			case "hookMessage":
@@ -118,20 +128,20 @@ export class UiHelpers {
 						]
 							.filter(Boolean)
 							.join(" ");
-						this.ctx.chatContainer.addChild(new Text(line, 1, 0));
+						this.ctx.chatContainer.addChild(createSystemGutter(this.ctx.ui, new Text(line, 1, 0)));
 						break;
 					}
 					if (message.customType === SKILL_PROMPT_MESSAGE_TYPE) {
 						const component = new SkillMessageComponent(message as CustomMessage<SkillPromptDetails>);
 						component.setExpanded(this.ctx.toolOutputExpanded);
-						this.ctx.chatContainer.addChild(component);
+						this.ctx.chatContainer.addChild(createTextGutter(this.ctx.ui, component));
 						break;
 					}
 					const renderer = this.ctx.session.extensionRunner?.getMessageRenderer(message.customType);
 					// Both HookMessage and CustomMessage have the same structure, cast for compatibility
 					const component = new CustomMessageComponent(message as CustomMessage<unknown>, renderer);
 					component.setExpanded(this.ctx.toolOutputExpanded);
-					this.ctx.chatContainer.addChild(component);
+					this.ctx.chatContainer.addChild(createTextGutter(this.ctx.ui, component));
 				}
 				break;
 			}
@@ -139,14 +149,14 @@ export class UiHelpers {
 				this.ctx.chatContainer.addChild(new Spacer(1));
 				const component = new CompactionSummaryMessageComponent(message);
 				component.setExpanded(this.ctx.toolOutputExpanded);
-				this.ctx.chatContainer.addChild(component);
+				this.ctx.chatContainer.addChild(createSystemGutter(this.ctx.ui, component));
 				break;
 			}
 			case "branchSummary": {
 				this.ctx.chatContainer.addChild(new Spacer(1));
 				const component = new BranchSummaryMessageComponent(message);
 				component.setExpanded(this.ctx.toolOutputExpanded);
-				this.ctx.chatContainer.addChild(component);
+				this.ctx.chatContainer.addChild(createSystemGutter(this.ctx.ui, component));
 				break;
 			}
 			case "fileMention": {
@@ -167,7 +177,7 @@ export class UiHelpers {
 						"chromeAccent",
 						file.path,
 					)} ${theme.fg("dim", suffix)}`;
-					this.ctx.chatContainer.addChild(new Text(text, 0, 0));
+					this.ctx.chatContainer.addChild(createTextGutter(this.ctx.ui, new Text(text, 0, 0)));
 				}
 				break;
 			}
@@ -186,7 +196,7 @@ export class UiHelpers {
 			}
 			case "assistant": {
 				const assistantComponent = new AssistantMessageComponent(message, this.ctx.hideThinkingBlock);
-				this.ctx.chatContainer.addChild(assistantComponent);
+				this.ctx.chatContainer.addChild(createTextGutter(this.ctx.ui, assistantComponent));
 				break;
 			}
 			case "toolResult": {
@@ -220,6 +230,7 @@ export class UiHelpers {
 		let readGroup: ReadToolGroupComponent | null = null;
 		const readToolCallArgs = new Map<string, Record<string, unknown>>();
 		const readToolCallAssistantComponents = new Map<string, AssistantMessageComponent>();
+		const toolGutters = new Map<string, ReturnType<typeof createToolGutter>>();
 		const deferredMessages: AgentMessage[] = [];
 		for (const message of sessionContext.messages) {
 			// Defer compaction summaries so they render at the bottom (visible after scroll)
@@ -231,7 +242,8 @@ export class UiHelpers {
 			if (message.role === "assistant") {
 				this.ctx.addMessageToChat(message);
 				const lastChild = this.ctx.chatContainer.children[this.ctx.chatContainer.children.length - 1];
-				const assistantComponent = lastChild instanceof AssistantMessageComponent ? lastChild : undefined;
+				const unwrapped = lastChild instanceof GutterBlock ? lastChild.child : lastChild;
+				const assistantComponent = unwrapped instanceof AssistantMessageComponent ? unwrapped : undefined;
 				if (assistantComponent) {
 					assistantComponent.setUsageInfo(message.usage);
 				}
@@ -259,7 +271,9 @@ export class UiHelpers {
 							if (!readGroup) {
 								readGroup = new ReadToolGroupComponent();
 								readGroup.setExpanded(this.ctx.toolOutputExpanded);
-								this.ctx.chatContainer.addChild(readGroup);
+								const readGutter = createToolGutter(this.ctx.ui, readGroup);
+								readGutter.setDone();
+								this.ctx.chatContainer.addChild(readGutter);
 							}
 							readGroup.updateArgs(content.arguments, content.id);
 							readGroup.updateResult(
@@ -299,7 +313,8 @@ export class UiHelpers {
 						this.ctx.sessionManager.getCwd(),
 					);
 					component.setExpanded(this.ctx.toolOutputExpanded);
-					this.ctx.chatContainer.addChild(component);
+					const toolGutter = createToolGutter(this.ctx.ui, component);
+					this.ctx.chatContainer.addChild(toolGutter);
 
 					if (hasErrorStop && errorMessage) {
 						component.updateResult(
@@ -307,8 +322,11 @@ export class UiHelpers {
 							false,
 							content.id,
 						);
+						toolGutter.setDone();
 					} else {
+						// Tool result hasn't arrived yet — keep gutter active until completion
 						this.ctx.pendingTools.set(content.id, component);
+						toolGutters.set(content.id, toolGutter);
 					}
 				}
 			} else if (message.role === "toolResult") {
@@ -331,7 +349,9 @@ export class UiHelpers {
 						if (!readGroup) {
 							readGroup = new ReadToolGroupComponent();
 							readGroup.setExpanded(this.ctx.toolOutputExpanded);
-							this.ctx.chatContainer.addChild(readGroup);
+							const readGutter = createToolGutter(this.ctx.ui, readGroup);
+							readGutter.setDone();
+							this.ctx.chatContainer.addChild(readGutter);
 						}
 						const args = readToolCallArgs.get(message.toolCallId);
 						if (args) {
@@ -342,6 +362,8 @@ export class UiHelpers {
 					}
 					component.updateResult(message, false, message.toolCallId);
 					this.ctx.pendingTools.delete(message.toolCallId);
+					toolGutters.get(message.toolCallId)?.setDone();
+					toolGutters.delete(message.toolCallId);
 					readToolCallArgs.delete(message.toolCallId);
 					readToolCallAssistantComponents.delete(message.toolCallId);
 					continue;
@@ -352,6 +374,8 @@ export class UiHelpers {
 				if (component) {
 					component.updateResult(message, false, message.toolCallId);
 					this.ctx.pendingTools.delete(message.toolCallId);
+					toolGutters.get(message.toolCallId)?.setDone();
+					toolGutters.delete(message.toolCallId);
 				}
 			} else {
 				// All other messages use standard rendering
@@ -365,6 +389,11 @@ export class UiHelpers {
 		}
 
 		this.ctx.pendingTools.clear();
+		// Mark any remaining tool gutters as done (tools without results in history)
+		for (const gutter of toolGutters.values()) {
+			gutter.setDone();
+		}
+		toolGutters.clear();
 		this.ctx.ui.requestRender();
 	}
 
@@ -584,16 +613,22 @@ export class UiHelpers {
 		}
 	}
 
-	/** Move pending bash components from pending area to chat */
+	/** Move pending bash components from pending area to chat.
+	 *  These commands have already completed (handleBashCommand/handlePythonCommand await execution)
+	 *  so the gutter is immediately set to done. */
 	flushPendingBashComponents(): void {
 		for (const component of this.ctx.pendingBashComponents) {
 			this.ctx.pendingMessagesContainer.removeChild(component);
-			this.ctx.chatContainer.addChild(component);
+			const gutter = createToolGutter(this.ctx.ui, component);
+			gutter.setDone();
+			this.ctx.chatContainer.addChild(gutter);
 		}
 		this.ctx.pendingBashComponents = [];
 		for (const component of this.ctx.pendingPythonComponents) {
 			this.ctx.pendingMessagesContainer.removeChild(component);
-			this.ctx.chatContainer.addChild(component);
+			const gutter = createToolGutter(this.ctx.ui, component);
+			gutter.setDone();
+			this.ctx.chatContainer.addChild(gutter);
 		}
 		this.ctx.pendingPythonComponents = [];
 	}


### PR DESCRIPTION
## Summary
- Adds a Claude Code-style 2-character left margin gutter system to xcsh TUI output
- Column 0 shows activity indicators (● for tools/text, ✻ for thinking, ※ for system) with animated f5Red spinners for active operations
- `GutterBlock` wrapper component with `DisposableContainer` for timer lifecycle management
- Full integration across streaming, history replay, bash/python commands, and async tool completion

## Design
- Spec: `docs/superpowers/specs/2026-04-15-left-margin-gutter-design.md`
- Approach: GutterBlock wrapper component that prepends gutter prefix to child render output
- Existing bordered-box tool output style preserved; gutter adds metadata alongside it

## Test plan
- [ ] Start xcsh, send a message that triggers tool calls — verify spinner animation in gutter
- [ ] Confirm spinner stops and dim ● appears when tool completes
- [ ] Confirm assistant text shows white ● on first line
- [ ] Confirm thinking shows ✻ with spinner, transitions to dim ✻
- [ ] Confirm bordered boxes render correctly at reduced width (width - 2)
- [ ] Confirm user messages have no gutter prefix
- [ ] Toggle thinking visibility during streaming — verify gutter recreates correctly
- [ ] Toggle tool output expansion — verify setExpanded reaches wrapped components
- [ ] Run `bun run check:ts` — 9/9 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)