### PR TITLE
feat: content-driven welcome screen width

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -18,18 +18,24 @@ export class WelcomeComponent implements Component {
 	}
 
 	render(termWidth: number): string[] {
-		const maxWidth = 120;
-		const boxWidth = Math.min(maxWidth, Math.max(0, termWidth - 2));
-		if (boxWidth < 4) return [];
-		const dualContentWidth = boxWidth - 3;
 		const minLeftCol = 48;
 		const minRightCol = 20;
-		const desiredLeftCol = Math.min(50, Math.max(minLeftCol, Math.floor(dualContentWidth * 0.35)));
+		const preferredLeftCol = 50;
+
+		// Content-driven right column width
+		const naturalRight = this.#measureStatusWidth() + 1; // +1 right padding
+		const idealRight = Math.max(naturalRight, minRightCol);
+		const idealBox = preferredLeftCol + idealRight + 3; // 3 border chars: │ + │ + │
+		const boxWidth = Math.min(idealBox, Math.max(0, termWidth - 2));
+		if (boxWidth < 4) return [];
+
+		const dualContentWidth = boxWidth - 3;
+		// When terminal is narrower than ideal, shrink left column toward minLeftCol first
 		const dualLeftCol =
-			dualContentWidth >= minRightCol + 1
-				? Math.min(desiredLeftCol, dualContentWidth - minRightCol)
-				: Math.max(1, dualContentWidth - 1);
-		const dualRightCol = Math.max(1, dualContentWidth - dualLeftCol);
+			dualContentWidth >= preferredLeftCol + idealRight
+				? preferredLeftCol
+				: Math.max(minLeftCol, dualContentWidth - idealRight);
+		const dualRightCol = Math.max(0, dualContentWidth - dualLeftCol);
 		const showRightColumn = dualLeftCol >= minLeftCol && dualRightCol >= minRightCol;
 		const leftCol = showRightColumn ? dualLeftCol : boxWidth - 2;
 		const rightCol = showRightColumn ? dualRightCol : 0;
@@ -100,6 +106,14 @@ export class WelcomeComponent implements Component {
 		return lines;
 	}
 
+	#measureStatusWidth(): number {
+		const lines: string[] = [" Model Provider", ...this.#renderModelStatus()];
+		if (this.profileStatus) {
+			lines.push(" F5 XC Profile", ...this.#renderProfileStatus());
+		}
+		return Math.max(...lines.map(l => visibleWidth(l)));
+	}
+
 	#buildStatusLines(rightCol: number): string[] {
 		const lines: string[] = [];
 		const separatorWidth = Math.max(0, rightCol - 2);
@@ -150,12 +164,12 @@ export class WelcomeComponent implements Component {
 			case "auth_error":
 				return [
 					` ${theme.fg("error", "\u2717")} ${theme.fg("muted", n)} ${theme.fg("error", "\u2014 token invalid")}`,
-					`   ${theme.fg("dim", "Run /profile to update credentials")}`,
+					`   ${theme.fg("dim", "Run /profile to update")}`,
 				];
 			case "offline":
 				return [
 					` ${theme.fg("warning", "\u26A0")} ${theme.fg("muted", n)} ${theme.fg("warning", "\u2014 unreachable")}`,
-					`   ${theme.fg("dim", "Check network or run /profile to update")}`,
+					`   ${theme.fg("dim", "Check network, /profile")}`,
 				];
 			case "no_profile":
 				return [

--- a/packages/coding-agent/test/welcome-component.test.ts
+++ b/packages/coding-agent/test/welcome-component.test.ts
@@ -51,16 +51,20 @@ describe("WelcomeComponent", () => {
 		expect(out).toContain("production");
 	});
 
-	it("shows profile auth_error", () => {
+	it("shows profile auth_error with update hint", () => {
 		const ms: ModelStatus = { state: "connected", provider: "litellm", latencyMs: 100 };
 		const c = new WelcomeComponent("15.15.0", ms, { state: "auth_error", name: "prod" });
-		expect(renderPlain(c).join("\n")).toContain("token invalid");
+		const out = renderPlain(c).join("\n");
+		expect(out).toContain("token invalid");
+		expect(out).toContain("Run /profile to update");
 	});
 
-	it("shows profile offline", () => {
+	it("shows profile offline with network hint", () => {
 		const ms: ModelStatus = { state: "connected", provider: "litellm", latencyMs: 100 };
 		const c = new WelcomeComponent("15.15.0", ms, { state: "offline", name: "prod" });
-		expect(renderPlain(c).join("\n")).toContain("unreachable");
+		const out = renderPlain(c).join("\n");
+		expect(out).toContain("unreachable");
+		expect(out).toContain("Check network, /profile");
 	});
 
 	it("shows no_profile hint", () => {
@@ -77,5 +81,62 @@ describe("WelcomeComponent", () => {
 	it("returns empty for narrow terminal", () => {
 		const c = new WelcomeComponent("15.15.0", { state: "connected", provider: "litellm", latencyMs: 100 });
 		expect(c.render(3)).toEqual([]);
+	});
+
+	describe("content-driven width", () => {
+		const connected: ModelStatus = { state: "connected", provider: "anthropic", latencyMs: 100 };
+
+		function boxWidth(component: WelcomeComponent, termWidth = 120): number {
+			const lines = renderPlain(component, termWidth);
+			return lines.length > 0 ? lines[0].length : 0;
+		}
+
+		it("box is no wider than the content requires", () => {
+			const c = new WelcomeComponent("15.15.0", connected);
+			const width = boxWidth(c);
+			// Widest right-column line is ~33 chars ("✓ anthropic — connected (100ms)")
+			// Left column is 48-50, plus 3 borders = box should be well under 100
+			expect(width).toBeLessThan(100);
+		});
+
+		it("no_profile state widens box to fit hint text", () => {
+			const withoutProfile = new WelcomeComponent("15.15.0", connected);
+			const withNoProfile = new WelcomeComponent("15.15.0", connected, { state: "no_profile" });
+			// "Run /profile create <name> <url> <token>" is wider than "✓ anthropic — connected"
+			expect(boxWidth(withNoProfile)).toBeGreaterThan(boxWidth(withoutProfile));
+		});
+
+		it("profile auth_error hint is not truncated at 80 columns", () => {
+			const c = new WelcomeComponent("15.15.0", connected, { state: "auth_error", name: "prod" });
+			const lines = renderPlain(c, 80);
+			const hintLine = lines.find(l => l.includes("/profile to update"));
+			expect(hintLine).toBeDefined();
+			expect(hintLine).not.toContain("\u2026");
+		});
+
+		it("profile offline hint is not truncated at 80 columns", () => {
+			const c = new WelcomeComponent("15.15.0", connected, { state: "offline", name: "prod" });
+			const lines = renderPlain(c, 80);
+			const hintLine = lines.find(l => l.includes("Check network"));
+			expect(hintLine).toBeDefined();
+			expect(hintLine).not.toContain("\u2026");
+		});
+
+		it("no_profile hint is not truncated at 100 columns", () => {
+			const c = new WelcomeComponent("15.15.0", connected, { state: "no_profile" });
+			const out = renderPlain(c, 100).join("\n");
+			expect(out).toContain("Run /profile create <name> <url> <token>");
+			expect(out).not.toContain("\u2026");
+		});
+
+		it("long profile name caps at terminal width", () => {
+			const longName = "a]b-c_d".repeat(9); // 63 chars
+			const c = new WelcomeComponent("15.15.0", connected, { state: "connected", name: longName, latencyMs: 50 });
+			const width = boxWidth(c, 100);
+			// Box must not exceed terminal width - 2 (margin)
+			expect(width).toBeLessThanOrEqual(98);
+			// But should still render (not empty)
+			expect(width).toBeGreaterThan(0);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- Add `#measureStatusWidth()` method that measures actual max visible width of all status content lines before layout, replacing the hard-coded `maxWidth=120` proportional column split
- Refine `dualLeftCol` to prioritize right-column content width when terminal is narrower than ideal; shorten profile failure hint text to fit 80-col terminals without truncation
- Add 6 new TDD tests covering profile failure width scenarios (box width adapts to content, hints not truncated at 80 cols, long profile names cap at terminal width)

Closes #89

## Test plan

- [ ] CI checks pass
- [ ] Welcome screen box width drops from 120 to ~88 chars for typical connected state
- [ ] No hint text truncation at 80-col terminal width
- [ ] Long profile names cap box width at terminal width
- [ ] All 6 new tests pass alongside existing welcome component tests