### PR TITLE
fix(ci): add exponential backoff with version verification to npm install check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,24 +649,52 @@ jobs:
         with:
           bun-version: "1.3"
       - name: Install xcsh via npm and verify native addon loads
+        env:
+          EXPECTED_VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          max_attempts=5
-          delay=15
+
+          # Strip leading 'v' from tag to get semver (v17.0.0 -> 17.0.0)
+          expected="${EXPECTED_VERSION#v}"
+          max_attempts=8
+          delay=10
+
+          echo "Expected version: $expected"
+
           for attempt in $(seq 1 $max_attempts); do
-            if npm install -g @f5xc-salesdemos/xcsh 2>&1; then
-              break
+            echo ""
+            echo "=== Attempt $attempt/$max_attempts (backoff: ${delay}s) ==="
+
+            # Clear any previously installed version
+            npm uninstall -g @f5xc-salesdemos/xcsh 2>/dev/null || true
+            npm cache clean --force 2>/dev/null || true
+
+            # Install the specific version to avoid stale CDN cache
+            if npm install -g "@f5xc-salesdemos/xcsh@${expected}" 2>&1; then
+              installed=$(xcsh --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+              echo "Installed version: $installed"
+
+              if [ "$installed" = "$expected" ]; then
+                echo "Version match confirmed."
+                echo "Checking xcsh --help..."
+                xcsh --help >/dev/null
+                echo "npm install verification passed"
+                exit 0
+              fi
+
+              echo "Version mismatch: got $installed, expected $expected"
+            else
+              echo "npm install failed (exit $?)"
             fi
+
             if [ "$attempt" -eq "$max_attempts" ]; then
-              echo "npm install failed after $max_attempts attempts"
+              echo "ERROR: verification failed after $max_attempts attempts"
+              echo "Last installed version: ${installed:-none}"
+              echo "Expected version: $expected"
               exit 1
             fi
-            echo "Attempt $attempt/$max_attempts failed — waiting ${delay}s for npm registry propagation..."
+
+            echo "Waiting ${delay}s for npm registry propagation..."
             sleep $delay
             delay=$((delay * 2))
           done
-          echo "Checking xcsh version..."
-          xcsh --version
-          echo "Checking xcsh help..."
-          xcsh --help >/dev/null
-          echo "npm install verification passed"


### PR DESCRIPTION
## Summary

- verify-npm-install now installs the specific tag version instead of latest
- Verifies installed version matches expected before declaring success
- Clears npm cache between retries to avoid stale CDN hits
- 8 attempts with exponential backoff (10s, 20s, 40s... ~42min total window)

## Context

v17.0.0 release pipeline passed all stages except verify-npm-install, which installed
the stale v16.0.0 from npm CDN cache instead of the just-published v17.0.0. The install
"succeeded" but the binary crashed because the old version didn't have `setDefaultTabWidth`
exports that the new code depends on.

## Test plan

- [x] `bun run check:ts` passes
- Next tag push will exercise the new retry logic