### PR TITLE
fix(rebase): restore fork-specific features lost during upstream rebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,24 +649,52 @@ jobs:
         with:
           bun-version: "1.3"
       - name: Install xcsh via npm and verify native addon loads
+        env:
+          EXPECTED_VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          max_attempts=5
-          delay=15
+
+          # Strip leading 'v' from tag to get semver (v17.0.0 -> 17.0.0)
+          expected="${EXPECTED_VERSION#v}"
+          max_attempts=8
+          delay=10
+
+          echo "Expected version: $expected"
+
           for attempt in $(seq 1 $max_attempts); do
-            if npm install -g @f5xc-salesdemos/xcsh 2>&1; then
-              break
+            echo ""
+            echo "=== Attempt $attempt/$max_attempts (backoff: ${delay}s) ==="
+
+            # Clear any previously installed version
+            npm uninstall -g @f5xc-salesdemos/xcsh 2>/dev/null || true
+            npm cache clean --force 2>/dev/null || true
+
+            # Install the specific version to avoid stale CDN cache
+            if npm install -g "@f5xc-salesdemos/xcsh@${expected}" 2>&1; then
+              installed=$(xcsh --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+              echo "Installed version: $installed"
+
+              if [ "$installed" = "$expected" ]; then
+                echo "Version match confirmed."
+                echo "Checking xcsh --help..."
+                xcsh --help >/dev/null
+                echo "npm install verification passed"
+                exit 0
+              fi
+
+              echo "Version mismatch: got $installed, expected $expected"
+            else
+              echo "npm install failed (exit $?)"
             fi
+
             if [ "$attempt" -eq "$max_attempts" ]; then
-              echo "npm install failed after $max_attempts attempts"
+              echo "ERROR: verification failed after $max_attempts attempts"
+              echo "Last installed version: ${installed:-none}"
+              echo "Expected version: $expected"
               exit 1
             fi
-            echo "Attempt $attempt/$max_attempts failed — waiting ${delay}s for npm registry propagation..."
+
+            echo "Waiting ${delay}s for npm registry propagation..."
             sleep $delay
             delay=$((delay * 2))
           done
-          echo "Checking xcsh version..."
-          xcsh --version
-          echo "Checking xcsh help..."
-          xcsh --help >/dev/null
-          echo "npm install verification passed"

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -25,9 +25,10 @@ import {
 	unregisterCustomApis,
 	unregisterOAuthProviders,
 } from "@f5xc-salesdemos/pi-ai";
-import { isRecord, logger } from "@f5xc-salesdemos/pi-utils";
+import { $env, isRecord, logger } from "@f5xc-salesdemos/pi-utils";
 import { type Static, Type } from "@sinclair/typebox";
 import { type ConfigError, ConfigFile } from "../config";
+import { hasLiteLLMEnv, probeAndUpgradeLiteLLMConfig, startupHealthCheck } from "../config/auto-config";
 import { parseModelString, resolveProviderModelReference } from "../config/model-resolver";
 import { isValidThemeColor, type ThemeColor } from "../modes/theme/theme";
 import type { AuthStorage, OAuthCredential } from "../session/auth-storage";
@@ -766,6 +767,7 @@ export class ModelRegistry {
 	#suppressedSelectors: Map<string, number> = new Map();
 	#backgroundRefresh?: Promise<void>;
 	#lastDiscoveryWarnings: Map<string, string> = new Map();
+	#hasProbed = false;
 	// Runtime extension model overlays — persist across refresh() cycles so that
 	// models registered by extensions survive the model selector's offline reload.
 	#runtimeModelOverlays: CustomModelOverlay[] = [];
@@ -798,6 +800,14 @@ export class ModelRegistry {
 	 * Reload models from disk (built-in + custom from models.json).
 	 */
 	async refresh(strategy: ModelRefreshStrategy = "online-if-uncached"): Promise<void> {
+		// On first refresh, probe LiteLLM proxy and upgrade config with discovery if available
+		if (!this.#hasProbed && hasLiteLLMEnv()) {
+			this.#hasProbed = true;
+			const upgraded = await probeAndUpgradeLiteLLMConfig(this.#modelsConfigFile.path());
+			if (upgraded) {
+				this.#modelsConfigFile.invalidate();
+			}
+		}
 		this.#reloadStaticModels();
 		this.#suppressedSelectors.clear();
 		await this.#refreshRuntimeDiscoveries(strategy);
@@ -1041,7 +1051,22 @@ export class ModelRegistry {
 	}
 
 	#loadCustomModels(): CustomModelsResult {
-		const { value, error, status } = this.#modelsConfigFile.tryLoad();
+		let result = this.#modelsConfigFile.tryLoad();
+
+		// Self-healing: detect missing, corrupt, or drifted config and auto-repair from env vars
+		if (result.status !== "ok" || result.value) {
+			const repaired = startupHealthCheck(
+				result.status,
+				this.#modelsConfigFile.path(),
+				result.status === "ok" && result.value ? result.value.providers : undefined,
+			);
+			if (repaired) {
+				this.#modelsConfigFile.invalidate();
+				result = this.#modelsConfigFile.tryLoad();
+			}
+		}
+
+		const { value, error, status } = result;
 
 		if (status === "error") {
 			return {
@@ -1282,8 +1307,28 @@ export class ModelRegistry {
 	): Promise<Model<Api>[]> {
 		// Skip providers already handled by configured discovery (e.g. user-configured ollama with discovery.type)
 		const configuredDiscoveryProviders = new Set(this.#discoverableProviders.map(p => p.provider));
+
+		// When a LiteLLM proxy is configured, providers whose baseUrl points to the
+		// LiteLLM proxy are proxied through it. Their built-in discovery would query
+		// the proxy's model listing endpoint, which may return model IDs the proxy
+		// can't serve for chat. Skip them — the litellm discovery provider handles
+		// model listing instead. Providers with other custom baseUrls (not LiteLLM)
+		// still need built-in discovery to discover new models at their endpoint.
+		const liteLLMBaseUrl = hasLiteLLMEnv() ? $env.LITELLM_BASE_URL?.trim().replace(/\/+$/, "") : undefined;
+		const proxiedProviders = liteLLMBaseUrl
+			? new Set(
+					[...this.#providerOverrides.keys()].filter(id => {
+						const override = this.#providerOverrides.get(id);
+						return override?.baseUrl?.startsWith(liteLLMBaseUrl);
+					}),
+				)
+			: new Set<string>();
+
 		const managerOptions = (await this.#collectBuiltInModelManagerOptions()).filter(opts => {
 			if (configuredDiscoveryProviders.has(opts.providerId)) {
+				return false;
+			}
+			if (proxiedProviders.has(opts.providerId)) {
 				return false;
 			}
 			return providerFilter ? providerFilter.has(opts.providerId) : true;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -243,7 +243,7 @@ export const SETTINGS_SCHEMA = {
 	// Theme
 	"theme.dark": {
 		type: "string",
-		default: "titanium",
+		default: "xcsh-dark",
 		ui: {
 			tab: "appearance",
 			label: "Dark Theme",
@@ -254,7 +254,7 @@ export const SETTINGS_SCHEMA = {
 
 	"theme.light": {
 		type: "string",
-		default: "light",
+		default: "xcsh-light",
 		ui: {
 			tab: "appearance",
 			label: "Light Theme",
@@ -266,7 +266,7 @@ export const SETTINGS_SCHEMA = {
 	symbolPreset: {
 		type: "enum",
 		values: ["unicode", "nerd", "ascii"] as const,
-		default: "unicode",
+		default: "nerd",
 		ui: { tab: "appearance", label: "Symbol Preset", description: "Icon/symbol style", submenu: true },
 	},
 
@@ -284,7 +284,7 @@ export const SETTINGS_SCHEMA = {
 	"statusLine.preset": {
 		type: "enum",
 		values: ["default", "minimal", "compact", "full", "nerd", "ascii", "xcsh", "custom"] as const,
-		default: "default",
+		default: "xcsh",
 		ui: {
 			tab: "appearance",
 			label: "Status Line Preset",
@@ -296,7 +296,7 @@ export const SETTINGS_SCHEMA = {
 	"statusLine.separator": {
 		type: "enum",
 		values: ["powerline", "powerline-thin", "slash", "pipe", "block", "none", "ascii"] as const,
-		default: "powerline-thin",
+		default: "powerline",
 		ui: {
 			tab: "appearance",
 			label: "Status Line Separator",
@@ -664,7 +664,7 @@ export const SETTINGS_SCHEMA = {
 
 	collapseChangelog: {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: { tab: "interaction", label: "Collapse Changelog", description: "Show condensed changelog after updates" },
 	},
 
@@ -697,7 +697,7 @@ export const SETTINGS_SCHEMA = {
 	// Speech-to-text
 	"stt.enabled": {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: { tab: "interaction", label: "Speech-to-Text", description: "Enable speech-to-text input via microphone" },
 	},
 
@@ -785,7 +785,7 @@ export const SETTINGS_SCHEMA = {
 
 	"compaction.handoffSaveToDisk": {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: {
 			tab: "context",
 			label: "Save Handoff Docs",
@@ -855,7 +855,7 @@ export const SETTINGS_SCHEMA = {
 	// Memories
 	"memories.enabled": {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: {
 			tab: "context",
 			label: "Memories",
@@ -1243,7 +1243,7 @@ export const SETTINGS_SCHEMA = {
 
 	"renderMermaid.enabled": {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: {
 			tab: "tools",
 			label: "Render Mermaid",
@@ -1263,7 +1263,7 @@ export const SETTINGS_SCHEMA = {
 
 	"calc.enabled": {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: {
 			tab: "tools",
 			label: "Calculator",
@@ -1300,7 +1300,7 @@ export const SETTINGS_SCHEMA = {
 
 	"github.enabled": {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: {
 			tab: "tools",
 			label: "GitHub CLI",
@@ -1676,13 +1676,13 @@ export const SETTINGS_SCHEMA = {
 	// Exa
 	"exa.enabled": {
 		type: "boolean",
-		default: true,
+		default: false,
 		ui: { tab: "providers", label: "Exa", description: "Master toggle for all Exa search tools" },
 	},
 
 	"exa.enableSearch": {
 		type: "boolean",
-		default: true,
+		default: false,
 		ui: { tab: "providers", label: "Exa Search", description: "Basic search, deep search, code search, crawl" },
 	},
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1,11 +1,19 @@
+import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { ThinkingLevel } from "@f5xc-salesdemos/pi-agent-core";
-import { getOAuthProviders, type OAuthProvider } from "@f5xc-salesdemos/pi-ai";
+import { getOAuthProviders, loginLiteLLM, type OAuthProvider } from "@f5xc-salesdemos/pi-ai";
 import type { Component } from "@f5xc-salesdemos/pi-tui";
 import { Input, Loader, Spacer, Text } from "@f5xc-salesdemos/pi-tui";
-import { getAgentDbPath, getConfigDirName, getProjectDir } from "@f5xc-salesdemos/pi-utils";
+import { getAgentDbPath, getAgentDir, getConfigDirName, getProjectDir } from "@f5xc-salesdemos/pi-utils";
 import { invalidate as invalidateFsCache } from "../../capability/fs";
+import {
+	generateConfigYml,
+	generateModelsYml,
+	healConfigYmlModelRoles,
+	probeLiteLLMConnection,
+	readLiteLLMConfig,
+} from "../../config/auto-config";
 import { getRoleInfo } from "../../config/model-registry";
 import { formatModelSelectorValue } from "../../config/model-resolver";
 import { settings } from "../../config/settings";
@@ -36,6 +44,7 @@ import { setSessionTerminalTitle } from "../../utils/title-generator";
 import { AgentDashboard } from "../components/agent-dashboard";
 import { AssistantMessageComponent } from "../components/assistant-message";
 import { ExtensionDashboard } from "../components/extensions";
+import { GutterBlock } from "../components/gutter-block";
 import { HistorySearchComponent } from "../components/history-search";
 import { ModelSelectorComponent } from "../components/model-selector";
 import { OAuthSelectorComponent } from "../components/oauth-selector";
@@ -43,6 +52,7 @@ import { PluginSelectorComponent } from "../components/plugin-selector";
 import { SessionObserverOverlayComponent } from "../components/session-observer-overlay";
 import { SessionSelectorComponent } from "../components/session-selector";
 import { SettingsSelectorComponent } from "../components/settings-selector";
+import { getPreset } from "../components/status-line/presets";
 import { ToolExecutionComponent } from "../components/tool-execution";
 import { TreeSelectorComponent } from "../components/tree-selector";
 import { UserMessageSelectorComponent } from "../components/user-message-selector";
@@ -260,16 +270,18 @@ export class SelectorController {
 			// Settings with UI side effects
 			case "showImages":
 				for (const child of this.ctx.chatContainer.children) {
-					if (child instanceof ToolExecutionComponent) {
-						child.setShowImages(value as boolean);
+					const unwrapped = child instanceof GutterBlock ? child.child : child;
+					if (unwrapped instanceof ToolExecutionComponent) {
+						unwrapped.setShowImages(value as boolean);
 					}
 				}
 				break;
 			case "hideThinking":
 				this.ctx.hideThinkingBlock = value as boolean;
 				for (const child of this.ctx.chatContainer.children) {
-					if (child instanceof AssistantMessageComponent) {
-						child.setHideThinkingBlock(value as boolean);
+					const unwrapped = child instanceof GutterBlock ? child.child : child;
+					if (unwrapped instanceof AssistantMessageComponent) {
+						unwrapped.setHideThinkingBlock(value as boolean);
 					}
 				}
 				this.ctx.chatContainer.clear();
@@ -344,6 +356,14 @@ export class SelectorController {
 			case "statusLineGitShowUntracked":
 			case "statusLineTimeFormat":
 			case "statusLineTimeShowSeconds": {
+				// When selecting a non-custom preset, sync the preset's separator
+				// to the store so #resolveSettings picks it up correctly.
+				if (id === "statusLinePreset" && value !== "custom") {
+					const presetDef = getPreset(value as Parameters<typeof getPreset>[0]);
+					if (presetDef.separator) {
+						settings.set("statusLine.separator", presetDef.separator);
+					}
+				}
 				const statusLineSettings = {
 					preset: settings.get("statusLine.preset"),
 					leftSegments: settings.get("statusLine.leftSegments"),
@@ -828,7 +848,100 @@ export class SelectorController {
 		await this.showSessionSelector();
 	}
 
+	async #handleLiteLLMLogin(): Promise<void> {
+		this.ctx.showStatus("Configuring LiteLLM proxy…");
+
+		// Read existing config for idempotent defaults
+		const modelsPath = path.join(getAgentDir(), "models.yml");
+
+		try {
+			const existing = readLiteLLMConfig(modelsPath);
+			// Sequential prompts for base URL + API key
+			const result = await loginLiteLLM({
+				defaults: existing,
+				onPrompt: async prompt => {
+					this.ctx.chatContainer.addChild(new Spacer(1));
+					this.ctx.chatContainer.addChild(new Text(theme.fg("text", prompt.message), 1, 0));
+					if (prompt.placeholder) {
+						this.ctx.chatContainer.addChild(new Text(theme.fg("dim", `e.g., ${prompt.placeholder}`), 1, 0));
+					}
+					this.ctx.ui.requestRender();
+
+					const { promise, resolve } = Promise.withResolvers<string>();
+					const codeInput = new Input();
+					codeInput.onSubmit = () => {
+						const value = codeInput.getValue();
+						this.ctx.editorContainer.clear();
+						this.ctx.editorContainer.addChild(this.ctx.editor);
+						this.ctx.ui.setFocus(this.ctx.editor);
+						resolve(value);
+					};
+					this.ctx.editorContainer.clear();
+					this.ctx.editorContainer.addChild(codeInput);
+					this.ctx.ui.setFocus(codeInput);
+					return promise;
+				},
+			});
+
+			// Verification
+			this.ctx.chatContainer.addChild(new Spacer(1));
+			this.ctx.chatContainer.addChild(new Text(theme.fg("dim", `Connecting to ${result.baseUrl}…`), 1, 0));
+			this.ctx.ui.requestRender();
+
+			const probe = await probeLiteLLMConnection(result.baseUrl, result.apiKey);
+
+			if (probe.reachable) {
+				this.ctx.chatContainer.addChild(
+					new Text(
+						theme.fg("success", `${theme.status.success} OK — ${probe.models.length} models available`),
+						1,
+						0,
+					),
+				);
+			} else {
+				this.ctx.chatContainer.addChild(
+					new Text(theme.fg("error", `${theme.status.error} FAIL — ${probe.error ?? "connection failed"}`), 1, 0),
+				);
+				this.ctx.ui.requestRender();
+				return;
+			}
+
+			// Write models.yml with the literal API key so both providers work
+			// without requiring the LITELLM_API_KEY env var to be set
+			const yml = generateModelsYml(result.baseUrl, {
+				apiBasePath: probe.apiBasePath,
+				apiKeyLiteral: result.apiKey,
+			});
+			fs.mkdirSync(path.dirname(modelsPath), { recursive: true });
+			fs.writeFileSync(modelsPath, yml);
+
+			// Create/heal config.yml for model defaults
+			const configPath = path.join(path.dirname(modelsPath), "config.yml");
+			if (!fs.existsSync(configPath)) {
+				fs.writeFileSync(configPath, generateConfigYml());
+			}
+			healConfigYmlModelRoles(configPath);
+
+			// Force online refresh so the registry re-probes the new proxy
+			// instead of serving stale data from the in-process SQLite cache.
+			await this.ctx.session.modelRegistry.refresh("online");
+
+			this.ctx.chatContainer.addChild(new Spacer(1));
+			this.ctx.chatContainer.addChild(
+				new Text(theme.fg("success", `LiteLLM configuration saved to ${modelsPath}`), 1, 0),
+			);
+			this.ctx.ui.requestRender();
+		} catch (error: unknown) {
+			this.ctx.showError(`LiteLLM login failed: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
 	async #handleOAuthLogin(providerId: string): Promise<void> {
+		// LiteLLM has its own flow with config persistence
+		if (providerId === "litellm") {
+			return this.#handleLiteLLMLogin();
+		}
+
 		this.ctx.showStatus(`Logging in to ${providerId}…`);
 		const manualInput = this.ctx.oauthManualInput;
 		const useManualInput = CALLBACK_SERVER_PROVIDERS.has(providerId as OAuthProvider);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -88,6 +88,8 @@ import {
 	deobfuscateSessionContext,
 	loadSecrets,
 	obfuscateMessages,
+	SECRET_ENV_PATTERNS,
+	type SecretEntry,
 	SecretObfuscator,
 } from "./secrets";
 import { AgentSession } from "./session/agent-session";
@@ -701,16 +703,69 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 	// Load and create secret obfuscator early so resumed session state and prompt warnings
 	// reflect actual loaded secrets, not just the setting toggle.
+	// Env-based secrets are always collected (hardcoded masking — no opt-in required).
+	// File-based secrets (secrets.yml) remain opt-in behind the secrets.enabled setting.
 	let obfuscator: SecretObfuscator | undefined;
-	if (settings.get("secrets.enabled")) {
-		const fileEntries = await logger.time("loadSecrets", loadSecrets, cwd, agentDir);
-		const envEntries = collectEnvSecrets();
-		const allEntries = [...envEntries, ...fileEntries];
+	{
+		// Collect profile-sensitive values (profile loads before session in main.ts).
+		let profileSensitiveValues: string[] | undefined;
+		try {
+			const { ProfileService } = await import("./services/f5xc-profile");
+			profileSensitiveValues = ProfileService.getSensitiveProfileValues();
+		} catch {
+			// ProfileService not initialized — skip (SDK consumers, tests, etc.)
+		}
+		// Scan both process.env AND bash.environment (profile-injected values)
+		// for env vars matching sensitive name patterns.
+		const bashEnv = (settings.get("bash.environment") ?? {}) as Record<string, string>;
+		const envEntries = collectEnvSecrets({
+			additionalEnv: bashEnv,
+			additionalValues: profileSensitiveValues,
+		});
+		let fileEntries: SecretEntry[] = [];
+		if (settings.get("secrets.enabled")) {
+			fileEntries = await logger.time("loadSecrets", loadSecrets, cwd, agentDir);
+		}
+		// File entries MUST come first to preserve placeholder index stability
+		// for resumed sessions that persisted #HASH# tokens from secrets.yml.
+		const allEntries = [...fileEntries, ...envEntries];
 		if (allEntries.length > 0) {
 			obfuscator = new SecretObfuscator(allEntries);
 		}
 	}
 	const secretsEnabled = obfuscator?.hasSecrets() === true;
+
+	// Register profile-change listener to refresh obfuscator when /profile activate runs.
+	try {
+		const { ProfileService } = await import("./services/f5xc-profile");
+		ProfileService.onProfileChange(profile => {
+			const newValues: string[] = [profile.apiToken];
+			if (profile.sensitiveKeys && profile.env) {
+				for (const key of profile.sensitiveKeys) {
+					const v = profile.env[key];
+					if (v) newValues.push(v);
+				}
+			}
+			const bashEnv = (settings.get("bash.environment") ?? {}) as Record<string, string>;
+			for (const [name, value] of Object.entries(bashEnv)) {
+				if (value && SECRET_ENV_PATTERNS.test(name)) newValues.push(value);
+			}
+			if (obfuscator) {
+				obfuscator.addPlainSecrets(newValues);
+			} else {
+				// Obfuscator was undefined at session start (no secrets detected).
+				// Create one now so late profile activations are still masked.
+				const entries: SecretEntry[] = newValues
+					.filter(v => v.length > 0)
+					.map(v => ({ type: "plain" as const, content: v, mode: "obfuscate" as const }));
+				if (entries.length > 0) {
+					obfuscator = new SecretObfuscator(entries);
+				}
+			}
+		});
+	} catch {
+		// ProfileService not available — skip
+	}
 
 	// Check if session has existing data to restore
 	const existingSession = logger.time("loadSessionContext", () =>

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -7,13 +7,14 @@ import type {
 } from "@f5xc-salesdemos/pi-agent-core";
 import type { Component } from "@f5xc-salesdemos/pi-tui";
 import { ImageProtocol, TERMINAL, Text } from "@f5xc-salesdemos/pi-tui";
-import { $env, getProjectDir, isEnoent, prompt } from "@f5xc-salesdemos/pi-utils";
+import { $env, getProjectDir, isEnoent, prompt, setShellPwd } from "@f5xc-salesdemos/pi-utils";
 import { Type } from "@sinclair/typebox";
 import { type BashResult, executeBash } from "../exec/bash-executor";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
 import type { Theme } from "../modes/theme/theme";
 import bashDescription from "../prompts/tools/bash.md" with { type: "text" };
+import { SECRET_ENV_PATTERNS, type SecretObfuscator } from "../secrets";
 import { DEFAULT_MAX_BYTES, TailBuffer } from "../session/streaming-output";
 import { renderStatusLine } from "../tui";
 import { CachedOutputBlock } from "../tui/output-block";
@@ -29,6 +30,9 @@ import { formatToolWorkingDirectory, replaceTabs } from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
+
+// Module-level obfuscator reference for the renderer (set by BashTool constructor).
+let _sessionObfuscator: SecretObfuscator | undefined;
 
 export const BASH_DEFAULT_PREVIEW_LINES = 10;
 
@@ -137,11 +141,20 @@ function escapeBashEnvValueForDisplay(value: string): string {
 		.replaceAll("`", "\\`");
 }
 
-function formatBashEnvAssignments(env: Record<string, string> | undefined): string {
+function formatBashEnvAssignments(
+	env: Record<string, string> | undefined,
+	obfuscator?: import("../secrets/obfuscator").SecretObfuscator,
+): string {
 	if (!env || Object.keys(env).length === 0) return "";
 	return Object.entries(env)
 		.sort(([a], [b]) => a.localeCompare(b))
-		.map(([key, value]) => `${key}="${escapeBashEnvValueForDisplay(value)}"`)
+		.map(([key, value]) => {
+			// Mask if name matches hardcoded patterns OR if the obfuscator recognizes the value as a secret.
+			const isSensitiveName = SECRET_ENV_PATTERNS.test(key);
+			const isSensitiveValue = obfuscator?.hasSecrets() && obfuscator.obfuscate(value) !== value;
+			const display = isSensitiveName || isSensitiveValue ? "***" : escapeBashEnvValueForDisplay(value);
+			return `${key}="${display}"`;
+		})
 		.join(" ");
 }
 
@@ -241,6 +254,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 	readonly #autoBackgroundThresholdMs: number;
 
 	constructor(private readonly session: ToolSession) {
+		_sessionObfuscator = session.obfuscator;
 		this.#asyncEnabled = this.session.settings.get("async.enabled");
 		this.#autoBackgroundEnabled = this.session.settings.get("bash.autoBackground.enabled");
 		this.#autoBackgroundThresholdMs = Math.max(
@@ -338,6 +352,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		headLines?: number;
 		tailLines?: number;
 		resolvedEnv?: Record<string, string>;
+		maskSecrets?: (text: string) => string;
 		onUpdate?: AgentToolUpdateCallback<BashToolDetails>;
 		startBackgrounded: boolean;
 	}): ManagedBashJobHandle {
@@ -366,9 +381,11 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 						env: options.resolvedEnv,
 						artifactPath,
 						artifactId,
+						maskSecrets: options.maskSecrets,
 						onChunk: chunk => {
 							tailBuffer.append(chunk);
-							latestText = tailBuffer.text();
+							const preview = options.maskSecrets ? options.maskSecrets(tailBuffer.text()) : tailBuffer.text();
+							latestText = preview;
 							void reportProgress(latestText, { async: { state: "running", jobId, type: "bash" } });
 						},
 					});
@@ -539,6 +556,11 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		const timeoutSec = clampTimeout("bash", rawTimeout);
 		const timeoutMs = timeoutSec * 1000;
 
+		// Build secret masking callback from the session obfuscator (always-on for env secrets).
+		const obfuscator = this.session.obfuscator;
+		_sessionObfuscator = obfuscator; // Keep module-level ref fresh for renderer
+		const maskSecrets = obfuscator?.hasSecrets() ? (t: string) => obfuscator.obfuscate(t) : undefined;
+
 		if (asyncRequested) {
 			if (!this.session.asyncJobManager) {
 				throw new ToolError("Async job manager unavailable for this session.");
@@ -551,6 +573,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 				headLines,
 				tailLines,
 				resolvedEnv,
+				maskSecrets,
 				onUpdate,
 				startBackgrounded: true,
 			});
@@ -568,6 +591,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 				headLines,
 				tailLines,
 				resolvedEnv,
+				maskSecrets,
 				onUpdate,
 				startBackgrounded,
 			});
@@ -608,6 +632,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					env: resolvedEnv,
 					artifactPath,
 					artifactId,
+					maskSecrets,
 				})
 			: await executeBash(command, {
 					cwd: commandCwd,
@@ -617,16 +642,25 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					env: resolvedEnv,
 					artifactPath,
 					artifactId,
+					maskSecrets,
 					onChunk: chunk => {
 						tailBuffer.append(chunk);
 						if (onUpdate) {
+							const preview = maskSecrets ? maskSecrets(tailBuffer.text()) : tailBuffer.text();
 							onUpdate({
-								content: [{ type: "text", text: tailBuffer.text() }],
+								content: [{ type: "text", text: preview }],
 								details: {},
 							});
 						}
 					},
 				});
+		// Update working directory if the persistent shell changed it
+		if ("newCwd" in result && result.newCwd && result.newCwd !== this.session.cwd) {
+			this.session.cwd = result.newCwd;
+			setShellPwd(result.newCwd);
+			this.session.eventBus?.emit("cwd:changed", result.newCwd);
+		}
+
 		if (result.cancelled) {
 			if (signal?.aborted) {
 				throw new ToolAbortError(normalizeResultOutput(result) || "Command aborted");
@@ -671,7 +705,9 @@ function formatBashCommand(args: BashRenderArgs): string {
 	const prompt = "$";
 	const cwd = getProjectDir();
 	const displayWorkdir = formatToolWorkingDirectory(args.cwd, cwd);
-	const renderedCommand = [formatBashEnvAssignments(getBashEnvForDisplay(args)), command].filter(Boolean).join(" ");
+	const renderedCommand = [formatBashEnvAssignments(getBashEnvForDisplay(args), _sessionObfuscator), command]
+		.filter(Boolean)
+		.join(" ");
 	return displayWorkdir ? `${prompt} cd ${displayWorkdir} && ${renderedCommand}` : `${prompt} ${renderedCommand}`;
 }
 


### PR DESCRIPTION
## Summary

Restores all fork-specific features that were wiped when source files were reset
to upstream during the v17.0.0 rebase. All building blocks (auto-config.ts, secrets/,
f5xc-profile.ts) still existed — they just weren't being called from the reset files.

## Restorations

### CRITICAL: Secret masking (PR #77)
- `sdk.ts`: ProfileService integration for obfuscator refresh on `/profile activate`
- `bash.ts`: SECRET_ENV_PATTERNS masking, maskSecrets callback, _sessionObfuscator

### HIGH: LiteLLM integration (PRs #51, #60, #63, #85)
- `selector-controller.ts`: #handleLiteLLMLogin() method, GutterBlock, preset-sync
- `model-registry.ts`: LiteLLM auto-config probe, startup health check, proxy filtering

### MEDIUM: Default values (PRs #48, #68, theme commits)
- `settings-schema.ts`: xcsh-dark/light themes, nerd symbols, xcsh statusline preset,
  powerline separator, 7 feature flags (memories, STT, GitHub, calc, Mermaid, etc.)

## Test plan

- [x] `bun run check:ts` — 0 errors
- [x] `bun test --filter "env-secret-masking"` — 0 failures
- [x] `bun test --filter "f5xc"` — 0 failures
- [x] `bun test --filter "model-registry"` — 0 failures
- [x] `bun test --filter "config-spacing"` — 0 failures
- [x] Full coding-agent suite: 3054 pass, 400 skip, 2 fail (flaky vim + exa interaction)