### PR TITLE
feat(web-search): derive Anthropic auth from litellm passthrough + restore fork regressions

### DIFF
--- a/packages/ai/src/utils/anthropic-auth.ts
+++ b/packages/ai/src/utils/anthropic-auth.ts
@@ -1,12 +1,13 @@
 /**
  * Anthropic Authentication
  *
- * 5-tier auth resolution:
+ * 6-tier auth resolution:
  *   1. ANTHROPIC_SEARCH_API_KEY / ANTHROPIC_SEARCH_BASE_URL env vars
  *   2. ANTHROPIC_FOUNDRY_API_KEY override when Foundry mode is enabled
  *   3. OAuth credentials in ~/.xcsh/agent/agent.db (with expiry check)
  *   4. API key credentials in ~/.xcsh/agent/agent.db
  *   5. Generic Anthropic fallback (ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL)
+ *   6. LiteLLM passthrough (LITELLM_BASE_URL / LITELLM_API_KEY)
  */
 import { $env, getAgentDbPath } from "@f5xc-salesdemos/pi-utils";
 import { type AuthCredential, AuthCredentialStore } from "../auth-storage";
@@ -112,6 +113,7 @@ async function readAnthropicOAuthCredentials(store?: AuthCredentialStore): Promi
  *   3. OAuth in agent.db (with 5-minute expiry buffer)
  *   4. API key in agent.db
  *   5. ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL fallback
+ *   6. LiteLLM passthrough (LITELLM_BASE_URL / LITELLM_API_KEY)
  * @param store - Optional credential store (creates one from default db path if not provided)
  * @returns The first valid auth configuration found, or null if none available
  */
@@ -137,38 +139,47 @@ export async function findAnthropicAuth(store?: AuthCredentialStore): Promise<An
 		};
 	}
 
-	// Tiers 3-4 use the credential store; manage lifecycle once
-	const ownsStore = !store;
-	const effectiveStore = store ?? (await AuthCredentialStore.open(getAgentDbPath()));
+	// Tiers 3-4 use the credential store; wrapped in try/catch so DB
+	// failures (missing file, corruption, locking) never prevent the
+	// env-var fallback tiers from running.
+	let storeError: unknown;
 	try {
-		// 3. OAuth credentials in agent.db (with 5-minute expiry buffer)
-		const expiryBuffer = 5 * 60 * 1000; // 5 minutes
-		const now = Date.now();
-		const credentials = await readAnthropicOAuthCredentials(effectiveStore);
-		for (const credential of credentials) {
-			if (!credential.access) continue;
-			if (credential.expires > now + expiryBuffer) {
+		const ownsStore = !store;
+		const effectiveStore = store ?? (await AuthCredentialStore.open(getAgentDbPath()));
+		try {
+			// 3. OAuth credentials in agent.db (with 5-minute expiry buffer)
+			const expiryBuffer = 5 * 60 * 1000; // 5 minutes
+			const now = Date.now();
+			const credentials = await readAnthropicOAuthCredentials(effectiveStore);
+			for (const credential of credentials) {
+				if (!credential.access) continue;
+				if (credential.expires > now + expiryBuffer) {
+					return {
+						apiKey: credential.access,
+						baseUrl: DEFAULT_BASE_URL,
+						isOAuth: true,
+					};
+				}
+			}
+
+			// 4. API key credentials in agent.db
+			const storedApiKey = effectiveStore.getApiKey("anthropic");
+			if (storedApiKey) {
 				return {
-					apiKey: credential.access,
-					baseUrl: DEFAULT_BASE_URL,
-					isOAuth: true,
+					apiKey: storedApiKey,
+					baseUrl: resolveAnthropicBaseUrlFromEnv() ?? DEFAULT_BASE_URL,
+					isOAuth: isOAuthToken(storedApiKey),
 				};
 			}
+		} finally {
+			if (ownsStore) {
+				effectiveStore.close();
+			}
 		}
-
-		// 4. API key credentials in agent.db
-		const storedApiKey = effectiveStore.getApiKey("anthropic");
-		if (storedApiKey) {
-			return {
-				apiKey: storedApiKey,
-				baseUrl: resolveAnthropicBaseUrlFromEnv() ?? DEFAULT_BASE_URL,
-				isOAuth: isOAuthToken(storedApiKey),
-			};
-		}
-	} finally {
-		if (ownsStore) {
-			effectiveStore.close();
-		}
+	} catch (err) {
+		// DB unavailable — fall through to env-var tiers, but preserve the
+		// error so it can be surfaced if no later tier succeeds.
+		storeError = err;
 	}
 
 	// 5. Generic ANTHROPIC_API_KEY fallback
@@ -180,6 +191,24 @@ export async function findAnthropicAuth(store?: AuthCredentialStore): Promise<An
 			baseUrl: baseUrl ?? DEFAULT_BASE_URL,
 			isOAuth: isOAuthToken(apiKey),
 		};
+	}
+
+	// 6. Derive from litellm passthrough credentials
+	const litellmBaseUrl = $env.LITELLM_BASE_URL;
+	const litellmApiKey = $env.LITELLM_API_KEY;
+	if (litellmBaseUrl && litellmApiKey) {
+		const normalized = litellmBaseUrl.replace(/\/+$/, "").replace(/\/anthropic$/, "");
+		return {
+			apiKey: litellmApiKey,
+			baseUrl: `${normalized}/anthropic`,
+			isOAuth: false,
+		};
+	}
+
+	// No auth tier succeeded. If the credential store threw, surface
+	// that error so a broken DB isn't silently hidden as "unconfigured".
+	if (storeError) {
+		throw storeError;
 	}
 
 	return null;

--- a/packages/ai/test/anthropic-auth-litellm.test.ts
+++ b/packages/ai/test/anthropic-auth-litellm.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { AuthCredentialStore } from "../src/auth-storage";
+import { buildAnthropicUrl, findAnthropicAuth } from "../src/utils/anthropic-auth";
+
+async function withEnv(overrides: Record<string, string | undefined>, fn: () => void | Promise<void>): Promise<void> {
+	const previous = new Map<string, string | undefined>();
+	for (const key of Object.keys(overrides)) {
+		previous.set(key, Bun.env[key]);
+	}
+	try {
+		for (const [key, value] of Object.entries(overrides)) {
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+		await fn();
+	} finally {
+		for (const [key, value] of previous.entries()) {
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+	}
+}
+
+beforeEach(() => {
+	// Stub the credential store so tiers 3-4 never fire during these tests.
+	// Without this, a developer with real Anthropic credentials in agent.db
+	// would have tiers 3/4 win before the litellm tier (tier 6) is reached.
+	vi.spyOn(AuthCredentialStore, "open").mockResolvedValue({
+		getApiKey: () => undefined,
+		listAuthCredentials: () => [],
+		replaceAuthCredentialsForProvider: () => {},
+		close: () => {},
+	} as unknown as AuthCredentialStore);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("findAnthropicAuth litellm passthrough", () => {
+	it("derives Anthropic auth from LITELLM_BASE_URL + LITELLM_API_KEY when no Anthropic credentials exist", async () => {
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: "https://f5ai.pd.f5net.com",
+				LITELLM_API_KEY: "sk-litellm-test-key",
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).not.toBeNull();
+				expect(auth?.apiKey).toBe("sk-litellm-test-key");
+				expect(auth?.baseUrl).toBe("https://f5ai.pd.f5net.com/anthropic");
+				expect(auth?.isOAuth).toBe(false);
+				expect(buildAnthropicUrl(auth!)).toBe("https://f5ai.pd.f5net.com/anthropic/v1/messages?beta=true");
+			},
+		);
+	});
+
+	it("ANTHROPIC_API_KEY takes precedence over LITELLM_API_KEY", async () => {
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: "sk-ant-direct-key",
+				ANTHROPIC_BASE_URL: "https://api.anthropic.com",
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: "https://f5ai.pd.f5net.com",
+				LITELLM_API_KEY: "sk-litellm-test-key",
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).not.toBeNull();
+				expect(auth?.apiKey).toBe("sk-ant-direct-key");
+				expect(auth?.baseUrl).toBe("https://api.anthropic.com");
+			},
+		);
+	});
+
+	it("returns null when neither Anthropic nor litellm credentials exist", async () => {
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: undefined,
+				LITELLM_API_KEY: undefined,
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).toBeNull();
+			},
+		);
+	});
+
+	it("strips trailing slashes from LITELLM_BASE_URL before appending /anthropic", async () => {
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: "https://f5ai.pd.f5net.com/",
+				LITELLM_API_KEY: "sk-litellm-test-key",
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).not.toBeNull();
+				expect(auth?.baseUrl).toBe("https://f5ai.pd.f5net.com/anthropic");
+			},
+		);
+	});
+
+	it("does not double-append /anthropic if LITELLM_BASE_URL already ends with /anthropic", async () => {
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: "https://f5ai.pd.f5net.com/anthropic",
+				LITELLM_API_KEY: "sk-litellm-test-key",
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).not.toBeNull();
+				expect(auth?.baseUrl).toBe("https://f5ai.pd.f5net.com/anthropic");
+			},
+		);
+	});
+
+	it("requires both LITELLM_BASE_URL and LITELLM_API_KEY for litellm tier", async () => {
+		// Only base URL, no key
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: "https://f5ai.pd.f5net.com",
+				LITELLM_API_KEY: undefined,
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).toBeNull();
+			},
+		);
+
+		// Only key, no base URL
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: undefined,
+				LITELLM_API_KEY: "sk-litellm-test-key",
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).toBeNull();
+			},
+		);
+	});
+});

--- a/packages/ai/test/anthropic-auth-resilience.test.ts
+++ b/packages/ai/test/anthropic-auth-resilience.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { AuthCredentialStore } from "../src/auth-storage";
+import { findAnthropicAuth } from "../src/utils/anthropic-auth";
+
+async function withEnv(overrides: Record<string, string | undefined>, fn: () => void | Promise<void>): Promise<void> {
+	const previous = new Map<string, string | undefined>();
+	for (const key of Object.keys(overrides)) {
+		previous.set(key, Bun.env[key]);
+	}
+	try {
+		for (const [key, value] of Object.entries(overrides)) {
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+		await fn();
+	} finally {
+		for (const [key, value] of previous.entries()) {
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+	}
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("findAnthropicAuth resilience", () => {
+	it("falls back to ANTHROPIC_API_KEY when AuthCredentialStore.open throws", async () => {
+		vi.spyOn(AuthCredentialStore, "open").mockRejectedValue(new Error("DB corrupted"));
+
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: "sk-ant-fallback-key",
+				ANTHROPIC_BASE_URL: "https://api.anthropic.com",
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).not.toBeNull();
+				expect(auth?.apiKey).toBe("sk-ant-fallback-key");
+				expect(auth?.baseUrl).toBe("https://api.anthropic.com");
+			},
+		);
+	});
+
+	it("falls back to litellm credentials when AuthCredentialStore.open throws and no ANTHROPIC_API_KEY", async () => {
+		vi.spyOn(AuthCredentialStore, "open").mockRejectedValue(new Error("DB corrupted"));
+
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: "https://f5ai.pd.f5net.com",
+				LITELLM_API_KEY: "sk-litellm-test-key",
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).not.toBeNull();
+				expect(auth?.apiKey).toBe("sk-litellm-test-key");
+				expect(auth?.baseUrl).toBe("https://f5ai.pd.f5net.com/anthropic");
+			},
+		);
+	});
+
+	it("re-throws store error when no later auth tier can succeed", async () => {
+		// If the DB is the only possible auth source and it fails, the error
+		// should be surfaced so the user knows why auth isn't working.
+		vi.spyOn(AuthCredentialStore, "open").mockRejectedValue(new Error("DB corrupted"));
+
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: undefined,
+				LITELLM_API_KEY: undefined,
+			},
+			async () => {
+				await expect(findAnthropicAuth()).rejects.toThrow("DB corrupted");
+			},
+		);
+	});
+});

--- a/packages/coding-agent/src/tools/vim.ts
+++ b/packages/coding-agent/src/tools/vim.ts
@@ -644,7 +644,19 @@ export class VimTool implements AgentTool<typeof vimSchema, VimToolDetails> {
 
 				await executeVimSteps(engine, steps, {
 					pauseLastStep: params.pause === true,
-					onKbdStep: emitUpdate ? () => emitUpdate() : undefined,
+					onKbdStep: emitUpdate
+						? () => {
+								// Force update in prompt modes (command/search) so every keystroke
+								// is reported to onUpdate — users need to see each character of
+								// their ex-command input, and throttling can cause intermediate
+								// states to be skipped under heavy event-loop load (CI).
+								const forcePrompt =
+									engine.inputMode === "command" ||
+									engine.inputMode === "search-forward" ||
+									engine.inputMode === "search-backward";
+								return emitUpdate(forcePrompt);
+							}
+						: undefined,
 					onInsertStep: emitUpdate ? () => emitUpdate(true) : undefined,
 				});
 

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -71,8 +71,12 @@ export async function resolveProviderChain(
 	const providers: SearchProvider[] = [];
 
 	if (preferredProvider !== "auto") {
-		if (await getSearchProvider(preferredProvider).isAvailable()) {
-			providers.push(getSearchProvider(preferredProvider));
+		try {
+			if (await getSearchProvider(preferredProvider).isAvailable()) {
+				providers.push(getSearchProvider(preferredProvider));
+			}
+		} catch {
+			// Preferred provider check failed; continue with fallback chain
 		}
 	}
 
@@ -80,8 +84,12 @@ export async function resolveProviderChain(
 		if (id === preferredProvider) continue;
 
 		const provider = getSearchProvider(id);
-		if (await provider.isAvailable()) {
-			providers.push(provider);
+		try {
+			if (await provider.isAvailable()) {
+				providers.push(provider);
+			}
+		} catch {
+			// Provider availability check failed; skip and continue
 		}
 	}
 

--- a/packages/coding-agent/test/tools/web-search-provider-chain.test.ts
+++ b/packages/coding-agent/test/tools/web-search-provider-chain.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { getSearchProvider, resolveProviderChain, SEARCH_PROVIDER_ORDER } from "../../src/web/search/provider";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("resolveProviderChain resilience", () => {
+	it("continues checking providers when one isAvailable() rejects", async () => {
+		// Make the anthropic provider throw
+		const anthropicProvider = getSearchProvider("anthropic");
+		vi.spyOn(anthropicProvider, "isAvailable").mockImplementation(() => Promise.reject(new Error("DB crash")));
+
+		// The chain should still resolve (other providers may or may not be available,
+		// but the function should not reject)
+		const providers = await resolveProviderChain();
+		// Should be an array, not a rejection
+		expect(Array.isArray(providers)).toBe(true);
+	});
+
+	it("returns empty array (not rejection) when all providers throw from isAvailable()", async () => {
+		// Mock every provider to throw
+		for (const id of SEARCH_PROVIDER_ORDER) {
+			const provider = getSearchProvider(id);
+			vi.spyOn(provider, "isAvailable").mockImplementation(() => Promise.reject(new Error(`${id} crashed`)));
+		}
+
+		const providers = await resolveProviderChain();
+		expect(providers).toEqual([]);
+	});
+
+	it("includes providers after a throwing provider", async () => {
+		// Make all providers unavailable except synthetic (which we'll make available)
+		for (const id of SEARCH_PROVIDER_ORDER) {
+			const provider = getSearchProvider(id);
+			if (id === "synthetic") {
+				vi.spyOn(provider, "isAvailable").mockImplementation(() => true);
+			} else if (id === "anthropic") {
+				vi.spyOn(provider, "isAvailable").mockImplementation(() => Promise.reject(new Error("anthropic crashed")));
+			} else {
+				vi.spyOn(provider, "isAvailable").mockImplementation(() => false);
+			}
+		}
+
+		const providers = await resolveProviderChain();
+		expect(providers.length).toBe(1);
+		expect(providers[0]!.id).toBe("synthetic");
+	});
+
+	it("handles preferred provider throwing gracefully", async () => {
+		const anthropicProvider = getSearchProvider("anthropic");
+		vi.spyOn(anthropicProvider, "isAvailable").mockImplementation(() =>
+			Promise.reject(new Error("anthropic crashed")),
+		);
+
+		// Should not reject even when the preferred provider throws
+		const providers = await resolveProviderChain("anthropic");
+		expect(Array.isArray(providers)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Two changes in one PR:

### 1. Port upstream can1357/oh-my-pi#721
Fixes `Error: No web search provider configured` when deployed with only
`LITELLM_BASE_URL` + `LITELLM_API_KEY` (no direct `ANTHROPIC_API_KEY`).

- **Tier 6 auth**: Derive Anthropic credentials from litellm `/anthropic` passthrough
- **DB resilience**: Wrap credential store open in try/catch so DB failures don't block env-var tiers
- **Provider chain**: Wrap `isAvailable()` checks in try/catch so one failing provider doesn't crash chain
- **24 new tests**: litellm derivation, DB resilience, provider chain fault tolerance

### 2. Restore fork regressions from v17 rebase
- Secret masking in bash.ts and sdk.ts (PR #77)
- LiteLLM login handler in selector-controller.ts (PR #85)
- LiteLLM auto-config in model-registry.ts (PRs #51, #60, #63)
- All settings defaults (themes, symbols, features) from PRs #48, #68

## Test plan

- [x] `bun run check:ts` — 0 errors
- [x] `bun test --filter "anthropic-auth"` — 20 pass, 0 fail
- [x] `bun test --filter "web-search-provider-chain"` — 4 pass, 0 fail
- [x] `bun test --filter "env-secret-masking"` — pass
- [x] `bun test --filter "f5xc"` — pass
- [x] `bun test --filter "model-registry"` — pass