### PR TITLE
fix: restore openai-compat discovery type — startup schema error for LiteLLM users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,10 +129,14 @@ The link steps resolve Bun `workspace:` protocol references. `build:ws` compiles
 Run immediately after setup, before writing any code:
 
 ```bash
-bun test 2>&1 | tee .worktree-test-baseline.txt
+bun test --max-concurrency 4 2>&1 | tee .worktree-test-baseline.txt
 ```
 
 This records pre-existing failures (e.g., missing ARM64 native modules). **Your work must never increase the failure count beyond this baseline.**
+
+> **OOM warning:** Never run the baseline capture without `--max-concurrency`.
+> The full suite (~3200 tests) at default concurrency (20) will exhaust RAM
+> and crash the container.
 
 ---
 
@@ -240,15 +244,37 @@ bun test --cwd packages/coding-agent --filter <name>  # scoped to package
 
 ### Resource-constrained environments
 
+Bun defaults to 20 concurrent tests, which can spike RAM past 10 GB and OOM-kill
+the container (no swap is configured). Always limit concurrency:
+
 ```bash
-bun test --max-concurrency 4    # safe for 4 GB containers
-bun test --max-concurrency 1    # sequential, minimal resources
+# Recommended defaults by available RAM
+bun test --max-concurrency 2    # <= 8 GB RAM (safe minimum)
+bun test --max-concurrency 4    # 8-16 GB RAM
+bun test --max-concurrency 8    # > 16 GB RAM
+
+# Low-memory mode: reduces GC pressure at the cost of throughput
+bun --smol test --max-concurrency 2
+
+# Sequential execution: lowest possible resource usage
+bun --smol test --max-concurrency 1
+
+# Bail on first failure to avoid wasting resources on a broken run
+bun test --max-concurrency 4 --bail 1
 ```
+
+**Rules for AI agents and CI:**
+- Never run `bun test` without `--max-concurrency`. The default of 20 will crash
+  containers with less than 16 GB RAM.
+- Prefer targeted tests (`--filter` or `--cwd`) over full-suite runs.
+- Use `--bail 1` during development to fail fast.
+- Use `--smol` when running the full suite in memory-constrained environments.
+- If a test run is killed (SIGKILL/OOM), reduce concurrency by half and retry.
 
 ### Comparing against baseline
 
 ```bash
-bun test 2>&1 | tee /tmp/current-test-results.txt
+bun test --max-concurrency 4 2>&1 | tee /tmp/current-test-results.txt
 
 BASELINE_FAILS=$(grep -o '[0-9]* fail' .worktree-test-baseline.txt | grep -o '[0-9]*' || echo 0)
 CURRENT_FAILS=$(grep -o '[0-9]* fail' /tmp/current-test-results.txt | grep -o '[0-9]*' || echo 0)
@@ -574,7 +600,7 @@ BRANCH="<type>/issue-<N>-<desc>"
 git worktree add ".worktrees/${BRANCH}" -b "${BRANCH}" origin/main
 cd ".worktrees/${BRANCH}"
 bun install && bun --cwd=packages/coding-agent link && bun --cwd=packages/ai link && bun run build:ws
-bun test 2>&1 | tee .worktree-test-baseline.txt
+bun test --max-concurrency 4 2>&1 | tee .worktree-test-baseline.txt
 
 # --- TDD Cycle ---
 bun test --cwd packages/<pkg> --filter <test>    # red

--- a/MISSED_ITEMS.md
+++ b/MISSED_ITEMS.md
@@ -1,0 +1,31 @@
+# Rebase Regression Audit — Missed Items
+
+Items found during line-by-line audit of pre-rebase fork (`1b3e09823`) vs current main.
+
+## Status
+
+| # | Item | Severity | Status |
+|---|------|----------|--------|
+| 1 | MCP startup message visible | CRITICAL | PENDING |
+| 2 | F5 XC profile auto-load removed | CRITICAL | PENDING |
+| 3 | LiteLLM discovery auto-wait removed | HIGH | PENDING |
+| 4 | SearchDb native integration removed | HIGH | ACCEPTED (upstream removed type) |
+| 5 | Python executor lifecycle features | HIGH | PENDING |
+| 6 | Bash async job integration (partial) | MEDIUM | PENDING VERIFICATION |
+| 7 | turbo.json removed | MEDIUM | ACCEPTED (upstream change) |
+| 8 | CI affected-only test paths | MEDIUM | ACCEPTED (upstream change) |
+| 9 | GitHub Copilot model definitions | LOW | ACCEPTED (upstream change) |
+| 10 | Prompt template changes | LOW | ACCEPTED (upstream improvements) |
+
+## Previously Restored (PRs #94, #95)
+
+- Theme defaults (xcsh-dark, xcsh-light, nerd, xcsh preset, powerline)
+- Feature flag defaults (memories, STT, GitHub, calc, Mermaid, etc.)
+- ProfileService obfuscator integration (sdk.ts)
+- SECRET_ENV_PATTERNS masking (bash.ts)
+- LiteLLM login handler (selector-controller.ts)
+- LiteLLM auto-config probe (model-registry.ts)
+- GutterBlock unwrapping (selector-controller.ts)
+- Preset-separator sync (selector-controller.ts)
+- Upstream PR #721 (anthropic litellm passthrough)
+- Vim throttle fix (ex-command onUpdate)

--- a/packages/ai/src/utils/anthropic-auth.ts
+++ b/packages/ai/src/utils/anthropic-auth.ts
@@ -1,12 +1,13 @@
 /**
  * Anthropic Authentication
  *
- * 5-tier auth resolution:
+ * 6-tier auth resolution:
  *   1. ANTHROPIC_SEARCH_API_KEY / ANTHROPIC_SEARCH_BASE_URL env vars
  *   2. ANTHROPIC_FOUNDRY_API_KEY override when Foundry mode is enabled
  *   3. OAuth credentials in ~/.xcsh/agent/agent.db (with expiry check)
  *   4. API key credentials in ~/.xcsh/agent/agent.db
  *   5. Generic Anthropic fallback (ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL)
+ *   6. LiteLLM passthrough (LITELLM_BASE_URL / LITELLM_API_KEY)
  */
 import { $env, getAgentDbPath } from "@f5xc-salesdemos/pi-utils";
 import { type AuthCredential, AuthCredentialStore } from "../auth-storage";
@@ -112,6 +113,7 @@ async function readAnthropicOAuthCredentials(store?: AuthCredentialStore): Promi
  *   3. OAuth in agent.db (with 5-minute expiry buffer)
  *   4. API key in agent.db
  *   5. ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL fallback
+ *   6. LiteLLM passthrough (LITELLM_BASE_URL / LITELLM_API_KEY)
  * @param store - Optional credential store (creates one from default db path if not provided)
  * @returns The first valid auth configuration found, or null if none available
  */
@@ -137,38 +139,47 @@ export async function findAnthropicAuth(store?: AuthCredentialStore): Promise<An
 		};
 	}
 
-	// Tiers 3-4 use the credential store; manage lifecycle once
-	const ownsStore = !store;
-	const effectiveStore = store ?? (await AuthCredentialStore.open(getAgentDbPath()));
+	// Tiers 3-4 use the credential store; wrapped in try/catch so DB
+	// failures (missing file, corruption, locking) never prevent the
+	// env-var fallback tiers from running.
+	let storeError: unknown;
 	try {
-		// 3. OAuth credentials in agent.db (with 5-minute expiry buffer)
-		const expiryBuffer = 5 * 60 * 1000; // 5 minutes
-		const now = Date.now();
-		const credentials = await readAnthropicOAuthCredentials(effectiveStore);
-		for (const credential of credentials) {
-			if (!credential.access) continue;
-			if (credential.expires > now + expiryBuffer) {
+		const ownsStore = !store;
+		const effectiveStore = store ?? (await AuthCredentialStore.open(getAgentDbPath()));
+		try {
+			// 3. OAuth credentials in agent.db (with 5-minute expiry buffer)
+			const expiryBuffer = 5 * 60 * 1000; // 5 minutes
+			const now = Date.now();
+			const credentials = await readAnthropicOAuthCredentials(effectiveStore);
+			for (const credential of credentials) {
+				if (!credential.access) continue;
+				if (credential.expires > now + expiryBuffer) {
+					return {
+						apiKey: credential.access,
+						baseUrl: DEFAULT_BASE_URL,
+						isOAuth: true,
+					};
+				}
+			}
+
+			// 4. API key credentials in agent.db
+			const storedApiKey = effectiveStore.getApiKey("anthropic");
+			if (storedApiKey) {
 				return {
-					apiKey: credential.access,
-					baseUrl: DEFAULT_BASE_URL,
-					isOAuth: true,
+					apiKey: storedApiKey,
+					baseUrl: resolveAnthropicBaseUrlFromEnv() ?? DEFAULT_BASE_URL,
+					isOAuth: isOAuthToken(storedApiKey),
 				};
 			}
+		} finally {
+			if (ownsStore) {
+				effectiveStore.close();
+			}
 		}
-
-		// 4. API key credentials in agent.db
-		const storedApiKey = effectiveStore.getApiKey("anthropic");
-		if (storedApiKey) {
-			return {
-				apiKey: storedApiKey,
-				baseUrl: resolveAnthropicBaseUrlFromEnv() ?? DEFAULT_BASE_URL,
-				isOAuth: isOAuthToken(storedApiKey),
-			};
-		}
-	} finally {
-		if (ownsStore) {
-			effectiveStore.close();
-		}
+	} catch (err) {
+		// DB unavailable — fall through to env-var tiers, but preserve the
+		// error so it can be surfaced if no later tier succeeds.
+		storeError = err;
 	}
 
 	// 5. Generic ANTHROPIC_API_KEY fallback
@@ -180,6 +191,24 @@ export async function findAnthropicAuth(store?: AuthCredentialStore): Promise<An
 			baseUrl: baseUrl ?? DEFAULT_BASE_URL,
 			isOAuth: isOAuthToken(apiKey),
 		};
+	}
+
+	// 6. Derive from litellm passthrough credentials
+	const litellmBaseUrl = $env.LITELLM_BASE_URL;
+	const litellmApiKey = $env.LITELLM_API_KEY;
+	if (litellmBaseUrl && litellmApiKey) {
+		const normalized = litellmBaseUrl.replace(/\/+$/, "").replace(/\/anthropic$/, "");
+		return {
+			apiKey: litellmApiKey,
+			baseUrl: `${normalized}/anthropic`,
+			isOAuth: false,
+		};
+	}
+
+	// No auth tier succeeded. If the credential store threw, surface
+	// that error so a broken DB isn't silently hidden as "unconfigured".
+	if (storeError) {
+		throw storeError;
 	}
 
 	return null;

--- a/packages/ai/test/anthropic-auth-litellm.test.ts
+++ b/packages/ai/test/anthropic-auth-litellm.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { AuthCredentialStore } from "../src/auth-storage";
+import { buildAnthropicUrl, findAnthropicAuth } from "../src/utils/anthropic-auth";
+
+async function withEnv(overrides: Record<string, string | undefined>, fn: () => void | Promise<void>): Promise<void> {
+	const previous = new Map<string, string | undefined>();
+	for (const key of Object.keys(overrides)) {
+		previous.set(key, Bun.env[key]);
+	}
+	try {
+		for (const [key, value] of Object.entries(overrides)) {
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+		await fn();
+	} finally {
+		for (const [key, value] of previous.entries()) {
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+	}
+}
+
+beforeEach(() => {
+	// Stub the credential store so tiers 3-4 never fire during these tests.
+	// Without this, a developer with real Anthropic credentials in agent.db
+	// would have tiers 3/4 win before the litellm tier (tier 6) is reached.
+	vi.spyOn(AuthCredentialStore, "open").mockResolvedValue({
+		getApiKey: () => undefined,
+		listAuthCredentials: () => [],
+		replaceAuthCredentialsForProvider: () => {},
+		close: () => {},
+	} as unknown as AuthCredentialStore);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("findAnthropicAuth litellm passthrough", () => {
+	it("derives Anthropic auth from LITELLM_BASE_URL + LITELLM_API_KEY when no Anthropic credentials exist", async () => {
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: "https://f5ai.pd.f5net.com",
+				LITELLM_API_KEY: "sk-litellm-test-key",
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).not.toBeNull();
+				expect(auth?.apiKey).toBe("sk-litellm-test-key");
+				expect(auth?.baseUrl).toBe("https://f5ai.pd.f5net.com/anthropic");
+				expect(auth?.isOAuth).toBe(false);
+				expect(buildAnthropicUrl(auth!)).toBe("https://f5ai.pd.f5net.com/anthropic/v1/messages?beta=true");
+			},
+		);
+	});
+
+	it("ANTHROPIC_API_KEY takes precedence over LITELLM_API_KEY", async () => {
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: "sk-ant-direct-key",
+				ANTHROPIC_BASE_URL: "https://api.anthropic.com",
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: "https://f5ai.pd.f5net.com",
+				LITELLM_API_KEY: "sk-litellm-test-key",
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).not.toBeNull();
+				expect(auth?.apiKey).toBe("sk-ant-direct-key");
+				expect(auth?.baseUrl).toBe("https://api.anthropic.com");
+			},
+		);
+	});
+
+	it("returns null when neither Anthropic nor litellm credentials exist", async () => {
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: undefined,
+				LITELLM_API_KEY: undefined,
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).toBeNull();
+			},
+		);
+	});
+
+	it("strips trailing slashes from LITELLM_BASE_URL before appending /anthropic", async () => {
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: "https://f5ai.pd.f5net.com/",
+				LITELLM_API_KEY: "sk-litellm-test-key",
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).not.toBeNull();
+				expect(auth?.baseUrl).toBe("https://f5ai.pd.f5net.com/anthropic");
+			},
+		);
+	});
+
+	it("does not double-append /anthropic if LITELLM_BASE_URL already ends with /anthropic", async () => {
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: "https://f5ai.pd.f5net.com/anthropic",
+				LITELLM_API_KEY: "sk-litellm-test-key",
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).not.toBeNull();
+				expect(auth?.baseUrl).toBe("https://f5ai.pd.f5net.com/anthropic");
+			},
+		);
+	});
+
+	it("requires both LITELLM_BASE_URL and LITELLM_API_KEY for litellm tier", async () => {
+		// Only base URL, no key
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: "https://f5ai.pd.f5net.com",
+				LITELLM_API_KEY: undefined,
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).toBeNull();
+			},
+		);
+
+		// Only key, no base URL
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: undefined,
+				LITELLM_API_KEY: "sk-litellm-test-key",
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).toBeNull();
+			},
+		);
+	});
+});

--- a/packages/ai/test/anthropic-auth-resilience.test.ts
+++ b/packages/ai/test/anthropic-auth-resilience.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { AuthCredentialStore } from "../src/auth-storage";
+import { findAnthropicAuth } from "../src/utils/anthropic-auth";
+
+async function withEnv(overrides: Record<string, string | undefined>, fn: () => void | Promise<void>): Promise<void> {
+	const previous = new Map<string, string | undefined>();
+	for (const key of Object.keys(overrides)) {
+		previous.set(key, Bun.env[key]);
+	}
+	try {
+		for (const [key, value] of Object.entries(overrides)) {
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+		await fn();
+	} finally {
+		for (const [key, value] of previous.entries()) {
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+	}
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("findAnthropicAuth resilience", () => {
+	it("falls back to ANTHROPIC_API_KEY when AuthCredentialStore.open throws", async () => {
+		vi.spyOn(AuthCredentialStore, "open").mockRejectedValue(new Error("DB corrupted"));
+
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: "sk-ant-fallback-key",
+				ANTHROPIC_BASE_URL: "https://api.anthropic.com",
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).not.toBeNull();
+				expect(auth?.apiKey).toBe("sk-ant-fallback-key");
+				expect(auth?.baseUrl).toBe("https://api.anthropic.com");
+			},
+		);
+	});
+
+	it("falls back to litellm credentials when AuthCredentialStore.open throws and no ANTHROPIC_API_KEY", async () => {
+		vi.spyOn(AuthCredentialStore, "open").mockRejectedValue(new Error("DB corrupted"));
+
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: "https://f5ai.pd.f5net.com",
+				LITELLM_API_KEY: "sk-litellm-test-key",
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth).not.toBeNull();
+				expect(auth?.apiKey).toBe("sk-litellm-test-key");
+				expect(auth?.baseUrl).toBe("https://f5ai.pd.f5net.com/anthropic");
+			},
+		);
+	});
+
+	it("re-throws store error when no later auth tier can succeed", async () => {
+		// If the DB is the only possible auth source and it fails, the error
+		// should be surfaced so the user knows why auth isn't working.
+		vi.spyOn(AuthCredentialStore, "open").mockRejectedValue(new Error("DB corrupted"));
+
+		await withEnv(
+			{
+				ANTHROPIC_API_KEY: undefined,
+				ANTHROPIC_BASE_URL: undefined,
+				ANTHROPIC_SEARCH_API_KEY: undefined,
+				ANTHROPIC_SEARCH_BASE_URL: undefined,
+				ANTHROPIC_OAUTH_TOKEN: undefined,
+				ANTHROPIC_FOUNDRY_API_KEY: undefined,
+				CLAUDE_CODE_USE_FOUNDRY: undefined,
+				LITELLM_BASE_URL: undefined,
+				LITELLM_API_KEY: undefined,
+			},
+			async () => {
+				await expect(findAnthropicAuth()).rejects.toThrow("DB corrupted");
+			},
+		);
+	});
+});

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -831,6 +831,29 @@ export class ModelRegistry {
 		this.#backgroundRefresh = refreshPromise;
 	}
 
+	/**
+	 * Await the in-flight background refresh if one is running.
+	 * Returns immediately if no background refresh is in progress.
+	 */
+	async awaitBackgroundRefresh(): Promise<void> {
+		if (this.#backgroundRefresh) {
+			await this.#backgroundRefresh;
+		}
+	}
+
+	/**
+	 * Check if any non-optional discoverable provider has no cached models yet.
+	 * Returns true on first run when the model cache is empty.
+	 */
+	hasUncachedDiscoverableProviders(): boolean {
+		for (const [, state] of this.#providerDiscoveryStates) {
+			if (state.status === "idle" && !state.optional) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	async refreshProvider(providerId: string, strategy: ModelRefreshStrategy = "online"): Promise<void> {
 		this.#reloadStaticModels();
 		for (const selector of this.#suppressedSelectors.keys()) {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -247,7 +247,12 @@ const ModelOverrideSchema = Type.Object({
 type ModelOverride = Static<typeof ModelOverrideSchema>;
 
 const ProviderDiscoverySchema = Type.Object({
-	type: Type.Union([Type.Literal("ollama"), Type.Literal("llama.cpp"), Type.Literal("lm-studio")]),
+	type: Type.Union([
+		Type.Literal("ollama"),
+		Type.Literal("llama.cpp"),
+		Type.Literal("lm-studio"),
+		Type.Literal("openai-compat"),
+	]),
 });
 
 const ProviderAuthSchema = Type.Union([Type.Literal("apiKey"), Type.Literal("none")]);
@@ -1308,6 +1313,8 @@ export class ModelRegistry {
 				return this.#discoverLlamaCppModels(providerConfig);
 			case "lm-studio":
 				return this.#discoverLmStudioModels(providerConfig);
+			case "openai-compat":
+				return this.#discoverOpenAICompatModels(providerConfig);
 		}
 	}
 
@@ -1663,6 +1670,53 @@ export class ModelRegistry {
 						supportsDeveloperRole: false,
 						supportsReasoningEffort: false,
 					},
+				}),
+			);
+		}
+		return this.#applyProviderModelOverrides(providerConfig.provider, discovered);
+	}
+
+	async #discoverOpenAICompatModels(providerConfig: DiscoveryProviderConfig): Promise<Model<Api>[]> {
+		const baseUrl = (providerConfig.baseUrl ?? "").replace(/\/+$/, "");
+		if (!baseUrl) {
+			throw new Error("openai-compat discovery requires a baseUrl");
+		}
+
+		const headers: Record<string, string> = { ...(providerConfig.headers ?? {}) };
+		const apiKey =
+			this.#customProviderApiKeys.get(providerConfig.provider) ??
+			(await this.#peekApiKeyForProvider(providerConfig.provider));
+		if (apiKey && apiKey !== DEFAULT_LOCAL_TOKEN && apiKey !== kNoAuth) {
+			headers.Authorization = `Bearer ${apiKey}`;
+		}
+
+		const modelsUrl = `${baseUrl}/models`;
+		const response = await fetch(modelsUrl, {
+			headers: { Accept: "application/json", ...headers },
+			signal: AbortSignal.timeout(3000),
+		});
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status} from ${modelsUrl}`);
+		}
+		const payload = (await response.json()) as { data?: Array<{ id: string }> };
+		const items = payload.data ?? [];
+		const discovered: Model<Api>[] = [];
+		for (const item of items) {
+			const id = item.id;
+			if (!id) continue;
+			discovered.push(
+				enrichModelThinking({
+					id,
+					name: id,
+					api: providerConfig.api,
+					provider: providerConfig.provider,
+					baseUrl,
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128000,
+					maxTokens: 8192,
+					headers,
 				}),
 			);
 		}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -624,6 +624,19 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 
 	const cwd = getProjectDir();
 	await logger.time("settings:init", Settings.init, { cwd });
+
+	// F5 XC profile loading — optional, never blocks startup.
+	// NOTE: This runs in the CLI path only. SDK consumers using createAgentSession()
+	// directly must call ProfileService.init(configDir).loadActive() themselves.
+	try {
+		const { ProfileService } = await import("./services/f5xc-profile");
+		const { getF5XCConfigDir } = await import("@f5xc-salesdemos/pi-utils");
+		const profileService = ProfileService.init(getF5XCConfigDir());
+		await profileService.loadActive();
+	} catch {
+		// F5 XC auth is optional — silently continue if anything fails
+	}
+
 	if (parsedArgs.mode === "rpc") {
 		applyRpcDefaultSettingOverrides();
 	}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -23,11 +23,11 @@ import {
 	prompt,
 	Snowflake,
 } from "@f5xc-salesdemos/pi-utils";
-import chalk from "chalk";
 import { AsyncJobManager, isBackgroundJobSupportEnabled } from "./async";
 import { createAutoresearchExtension } from "./autoresearch";
 import { loadCapability } from "./capability";
 import { type Rule, ruleCapability } from "./capability/rule";
+import { hasLiteLLMEnv } from "./config/auto-config";
 import { ModelRegistry } from "./config/model-registry";
 import { formatModelString, parseModelPattern, parseModelString, resolveModelRoleValue } from "./config/model-resolver";
 import { loadPromptTemplates as loadPromptTemplatesInternal, type PromptTemplate } from "./config/prompt-templates";
@@ -780,6 +780,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const modelMatchPreferences = {
 		usageOrder: settings.getStorage()?.getModelUsageOrder(),
 	};
+	// When LiteLLM is configured and no model cache exists yet (first run),
+	// await the background refresh so model discovery from the proxy completes
+	// before we select a default model. Bounded by the 3s probe timeout.
+	if (!options.modelRegistry && hasLiteLLMEnv() && modelRegistry.hasUncachedDiscoverableProviders()) {
+		await logger.time("awaitLiteLLMDiscovery", () => modelRegistry.awaitBackgroundRefresh());
+	}
+
 	const defaultRoleSpec = logger.time("resolveDefaultModelRole", () =>
 		resolveModelRoleValue(settings.getModelRole("default"), modelRegistry.getAvailable(), {
 			settings,
@@ -1069,8 +1076,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		if (enableMCP) {
 			const mcpResult = await logger.time("discoverAndLoadMCPTools", discoverAndLoadMCPTools, cwd, {
 				onConnecting: serverNames => {
-					if (options.hasUI && serverNames.length > 0) {
-						process.stderr.write(`${chalk.gray(`Connecting to MCP servers: ${serverNames.join(", ")}…`)}\n`);
+					if (serverNames.length > 0) {
+						logger.debug("Connecting to MCP servers", { servers: serverNames });
 					}
 				},
 				enableProjectConfig: settings.get("mcp.enableProjectConfig") ?? true,

--- a/packages/coding-agent/src/tools/vim.ts
+++ b/packages/coding-agent/src/tools/vim.ts
@@ -644,7 +644,19 @@ export class VimTool implements AgentTool<typeof vimSchema, VimToolDetails> {
 
 				await executeVimSteps(engine, steps, {
 					pauseLastStep: params.pause === true,
-					onKbdStep: emitUpdate ? () => emitUpdate() : undefined,
+					onKbdStep: emitUpdate
+						? () => {
+								// Force update in prompt modes (command/search) so every keystroke
+								// is reported to onUpdate — users need to see each character of
+								// their ex-command input, and throttling can cause intermediate
+								// states to be skipped under heavy event-loop load (CI).
+								const forcePrompt =
+									engine.inputMode === "command" ||
+									engine.inputMode === "search-forward" ||
+									engine.inputMode === "search-backward";
+								return emitUpdate(forcePrompt);
+							}
+						: undefined,
 					onInsertStep: emitUpdate ? () => emitUpdate(true) : undefined,
 				});
 

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -71,8 +71,12 @@ export async function resolveProviderChain(
 	const providers: SearchProvider[] = [];
 
 	if (preferredProvider !== "auto") {
-		if (await getSearchProvider(preferredProvider).isAvailable()) {
-			providers.push(getSearchProvider(preferredProvider));
+		try {
+			if (await getSearchProvider(preferredProvider).isAvailable()) {
+				providers.push(getSearchProvider(preferredProvider));
+			}
+		} catch {
+			// Preferred provider check failed; continue with fallback chain
 		}
 	}
 
@@ -80,8 +84,12 @@ export async function resolveProviderChain(
 		if (id === preferredProvider) continue;
 
 		const provider = getSearchProvider(id);
-		if (await provider.isAvailable()) {
-			providers.push(provider);
+		try {
+			if (await provider.isAvailable()) {
+				providers.push(provider);
+			}
+		} catch {
+			// Provider availability check failed; skip and continue
 		}
 	}
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1792,4 +1792,36 @@ describe("ModelRegistry", () => {
 			expect(llama?.input).toEqual(["text", "image"]);
 		});
 	});
+
+	describe("openai-compat discovery (LiteLLM proxy)", () => {
+		test("config with discovery.type openai-compat loads without schema error", () => {
+			writeRawModelsJson({
+				litellm: {
+					baseUrl: "http://localhost:4000",
+					apiKey: "test-key",
+					api: "openai-completions",
+					discovery: { type: "openai-compat" },
+				},
+			});
+			// If schema rejects openai-compat, ModelRegistry constructor throws ConfigError
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			expect(registry).toBeDefined();
+		});
+
+		test("openai-compat discovery fetches /models endpoint", async () => {
+			writeRawModelsJson({
+				litellm: {
+					baseUrl: "http://localhost:4000",
+					apiKey: "test-key",
+					api: "openai-completions",
+					discovery: { type: "openai-compat" },
+				},
+			});
+			using _hook = mockOpenAiCompatibleModels("http://localhost:4000/models", ["claude-3.5-sonnet", "gpt-4o"]);
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			await registry.refreshProvider("litellm", "online");
+			expect(registry.find("litellm", "claude-3.5-sonnet")).toBeDefined();
+			expect(registry.find("litellm", "gpt-4o")).toBeDefined();
+		});
+	});
 });

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -296,6 +296,35 @@ describe("Anthropic auth litellm passthrough (upstream PR #721)", () => {
 	});
 });
 
+// ─── LiteLLM openai-compat discovery schema ───────────────────────────────
+
+describe("LiteLLM openai-compat discovery schema (blocks xcsh startup for proxy users)", () => {
+	// When auto-config.ts generates models.yml it writes discovery.type: openai-compat.
+	// If the schema removes this literal, every LiteLLM user gets a startup error.
+	// This guard caught a regression introduced in the v17 rebase.
+	it("model-registry.ts schema includes openai-compat as valid discovery type", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/config/model-registry.ts"), "utf8");
+		expect(src).toContain('Type.Literal("openai-compat")');
+	});
+
+	it("model-registry.ts has #discoverOpenAICompatModels method", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/config/model-registry.ts"), "utf8");
+		expect(src).toContain("#discoverOpenAICompatModels");
+	});
+
+	it('model-registry.ts switch routes case "openai-compat" to discovery method', async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/config/model-registry.ts"), "utf8");
+		expect(src).toContain('case "openai-compat":');
+		expect(src).toContain("return this.#discoverOpenAICompatModels(providerConfig);");
+	});
+
+	it("auto-config.ts generates discovery.type: openai-compat (must stay in sync with schema)", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/config/auto-config.ts"), "utf8");
+		// If this fails, the generated models.yml would write a type the schema rejects
+		expect(src).toContain("type: openai-compat");
+	});
+});
+
 // ─── CI verify-npm-install backoff ────────────────────────────────────────
 
 describe("CI verify-npm-install uses version-pinned install with backoff (PR #93)", () => {

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Fork-Specific Regression Guard
+ *
+ * This test file exists to prevent rebase/merge regressions from silently
+ * breaking xcsh fork features. Each test locks in a deliberate divergence
+ * from upstream (can1357/oh-my-pi) that must be preserved.
+ *
+ * When adding a new fork feature, add a corresponding test here.
+ * When merging from upstream, CI will catch any accidental overwrites.
+ *
+ * History: v17.0.0 rebase reset ~20 files to upstream, wiping features
+ * introduced in PRs #48, #54, #60, #63, #68, #69, #75, #76, #77, #79,
+ * #81, #83, #85, #86, #90. This guard prevents that class of regression.
+ */
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { SETTINGS_SCHEMA } from "../src/config/settings-schema";
+import { STATUS_LINE_PRESETS } from "../src/modes/components/status-line/presets";
+
+// ─── Settings Schema Defaults ─────────────────────────────────────────────
+
+describe("fork settings schema defaults (PRs #48, #68, theme commits)", () => {
+	it("dark theme defaults to xcsh-dark (not upstream titanium)", () => {
+		expect(SETTINGS_SCHEMA["theme.dark"].default).toBe("xcsh-dark");
+	});
+
+	it("light theme defaults to xcsh-light (not upstream light)", () => {
+		expect(SETTINGS_SCHEMA["theme.light"].default).toBe("xcsh-light");
+	});
+
+	it("symbol preset defaults to nerd (not upstream unicode)", () => {
+		expect(SETTINGS_SCHEMA.symbolPreset.default).toBe("nerd");
+	});
+
+	it("status line preset defaults to xcsh (not upstream default)", () => {
+		expect(SETTINGS_SCHEMA["statusLine.preset"].default).toBe("xcsh");
+	});
+
+	it("status line separator defaults to powerline (not upstream powerline-thin)", () => {
+		expect(SETTINGS_SCHEMA["statusLine.separator"].default).toBe("powerline");
+	});
+
+	// PR #48 — "optimize default settings for modern terminals with Nerd Fonts"
+	it("memories enabled by default (PR #48)", () => {
+		expect(SETTINGS_SCHEMA["memories.enabled"].default).toBe(true);
+	});
+
+	it("STT enabled by default (PR #48)", () => {
+		expect(SETTINGS_SCHEMA["stt.enabled"].default).toBe(true);
+	});
+
+	it("Mermaid rendering enabled by default (PR #48)", () => {
+		expect(SETTINGS_SCHEMA["renderMermaid.enabled"].default).toBe(true);
+	});
+
+	it("calculator tool enabled by default (PR #48)", () => {
+		expect(SETTINGS_SCHEMA["calc.enabled"].default).toBe(true);
+	});
+
+	it("GitHub CLI tool enabled by default (PR #48)", () => {
+		expect(SETTINGS_SCHEMA["github.enabled"].default).toBe(true);
+	});
+
+	it("inspect_image enabled by default (PR #48)", () => {
+		expect(SETTINGS_SCHEMA["inspect_image.enabled"].default).toBe(true);
+	});
+
+	it("changelog collapsed by default (PR #48)", () => {
+		expect(SETTINGS_SCHEMA.collapseChangelog.default).toBe(true);
+	});
+
+	// PR #68 — "powerline defaults, handoff save"
+	it("compaction handoff saves to disk by default (PR #68)", () => {
+		expect(SETTINGS_SCHEMA["compaction.handoffSaveToDisk"].default).toBe(true);
+	});
+
+	// Exa is disabled by default — fork preference over upstream default of true
+	it("exa search disabled by default (fork preference)", () => {
+		expect(SETTINGS_SCHEMA["exa.enabled"].default).toBe(false);
+	});
+
+	it("exa enableSearch disabled by default (fork preference)", () => {
+		expect(SETTINGS_SCHEMA["exa.enableSearch"].default).toBe(false);
+	});
+
+	// statusLine.preset enum must include xcsh
+	it("xcsh is a valid statusLine.preset value", () => {
+		const presetDef = SETTINGS_SCHEMA["statusLine.preset"];
+		expect(presetDef.type).toBe("enum");
+		if (presetDef.type === "enum") {
+			expect(presetDef.values).toContain("xcsh");
+		}
+	});
+});
+
+// ─── XCsh Status Line Preset ──────────────────────────────────────────────
+
+describe("xcsh status line preset (PRs #76, #81)", () => {
+	it("xcsh preset exists in presets registry", () => {
+		const presets = STATUS_LINE_PRESETS;
+		expect(presets).toHaveProperty("xcsh");
+	});
+
+	it("xcsh preset uses powerline separator", () => {
+		const presets = STATUS_LINE_PRESETS;
+		expect(presets.xcsh.separator).toBe("powerline");
+	});
+
+	it("xcsh preset includes profile_f5xc in right segments", () => {
+		const presets = STATUS_LINE_PRESETS;
+		expect(presets.xcsh.rightSegments).toContain("profile_f5xc");
+	});
+
+	it("xcsh preset includes context_pct in left segments", () => {
+		const presets = STATUS_LINE_PRESETS;
+		expect(presets.xcsh.leftSegments).toContain("context_pct");
+	});
+});
+
+// ─── xcsh Theme Files ────────────────────────────────────────────────────
+
+describe("xcsh theme files (theme commit 032e0b8c0)", () => {
+	const themeDir = path.join(import.meta.dir, "../src/modes/theme/defaults");
+
+	it("xcsh-dark.json exists", async () => {
+		const stat = await fs.stat(path.join(themeDir, "xcsh-dark.json")).catch(() => null);
+		expect(stat).not.toBeNull();
+	});
+
+	it("xcsh-light.json exists", async () => {
+		const stat = await fs.stat(path.join(themeDir, "xcsh-light.json")).catch(() => null);
+		expect(stat).not.toBeNull();
+	});
+
+	it("xcsh-dark.json is valid JSON with content", async () => {
+		const raw = await fs.readFile(path.join(themeDir, "xcsh-dark.json"), "utf8");
+		const theme = JSON.parse(raw);
+		expect(Object.keys(theme).length).toBeGreaterThan(0);
+	});
+
+	it("xcsh-light.json is valid JSON with content", async () => {
+		const raw = await fs.readFile(path.join(themeDir, "xcsh-light.json"), "utf8");
+		const theme = JSON.parse(raw);
+		expect(Object.keys(theme).length).toBeGreaterThan(0);
+	});
+});
+
+// ─── Secret Masking Integration ───────────────────────────────────────────
+
+describe("bash tool secret masking (PR #77)", () => {
+	it("bash.ts imports SECRET_ENV_PATTERNS from secrets module", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/tools/bash.ts"), "utf8");
+		expect(src).toContain("SECRET_ENV_PATTERNS");
+		expect(src).toContain("SecretObfuscator");
+	});
+
+	it("bash.ts has module-level session obfuscator reference", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/tools/bash.ts"), "utf8");
+		expect(src).toContain("_sessionObfuscator");
+	});
+
+	it("bash.ts creates maskSecrets callback from session obfuscator", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/tools/bash.ts"), "utf8");
+		expect(src).toContain("maskSecrets");
+		expect(src).toContain("obfuscator");
+	});
+
+	it("bash.ts integrates setShellPwd for cwd tracking", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/tools/bash.ts"), "utf8");
+		expect(src).toContain("setShellPwd");
+	});
+});
+
+// ─── MCP Connection Message Suppression ──────────────────────────────────
+
+describe("MCP startup message suppression (fork preference)", () => {
+	it("sdk.ts uses logger.debug for MCP connection message (not stderr)", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/sdk.ts"), "utf8");
+		// Fork: silent debug logging
+		expect(src).toContain('logger.debug("Connecting to MCP servers"');
+		// Upstream: visible stderr output — must NOT be present
+		expect(src).not.toContain("process.stderr.write");
+	});
+
+	it("sdk.ts does not import chalk (no styled stderr output)", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/sdk.ts"), "utf8");
+		expect(src).not.toContain("import chalk");
+	});
+});
+
+// ─── F5 XC Profile Auto-Loading ───────────────────────────────────────────
+
+describe("F5 XC profile auto-loading at CLI startup (PR #69)", () => {
+	it("main.ts imports and calls ProfileService at startup", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/main.ts"), "utf8");
+		expect(src).toContain("f5xc-profile");
+		expect(src).toContain("ProfileService.init");
+		expect(src).toContain("loadActive");
+	});
+
+	it("main.ts imports getF5XCConfigDir for profile directory", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/main.ts"), "utf8");
+		expect(src).toContain("getF5XCConfigDir");
+	});
+});
+
+// ─── ProfileService Obfuscator Integration ────────────────────────────────
+
+describe("ProfileService obfuscator integration (PR #77)", () => {
+	it("sdk.ts collects profile-sensitive values for obfuscator", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/sdk.ts"), "utf8");
+		expect(src).toContain("getSensitiveProfileValues");
+	});
+
+	it("sdk.ts registers profile-change listener to refresh obfuscator secrets", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/sdk.ts"), "utf8");
+		expect(src).toContain("onProfileChange");
+		expect(src).toContain("addPlainSecrets");
+	});
+
+	it("sdk.ts passes additionalValues to obfuscator constructor", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/sdk.ts"), "utf8");
+		expect(src).toContain("additionalValues");
+	});
+});
+
+// ─── LiteLLM Integration ─────────────────────────────────────────────────
+
+describe("LiteLLM integration (PRs #51, #60, #63, #85)", () => {
+	it("sdk.ts awaits LiteLLM discovery on first run", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/sdk.ts"), "utf8");
+		expect(src).toContain("hasLiteLLMEnv");
+		expect(src).toContain("awaitBackgroundRefresh");
+		expect(src).toContain("hasUncachedDiscoverableProviders");
+	});
+
+	it("model-registry.ts has awaitBackgroundRefresh method", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/config/model-registry.ts"), "utf8");
+		expect(src).toContain("awaitBackgroundRefresh");
+		expect(src).toContain("hasUncachedDiscoverableProviders");
+	});
+
+	it("model-registry.ts probes LiteLLM config on first refresh", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/config/model-registry.ts"), "utf8");
+		expect(src).toContain("probeAndUpgradeLiteLLMConfig");
+		expect(src).toContain("startupHealthCheck");
+	});
+
+	it("selector-controller.ts has LiteLLM login handler (PR #85)", async () => {
+		const src = await fs.readFile(
+			path.join(import.meta.dir, "../src/modes/controllers/selector-controller.ts"),
+			"utf8",
+		);
+		expect(src).toContain("handleLiteLLMLogin");
+		expect(src).toContain("loginLiteLLM");
+	});
+
+	it("selector-controller.ts integrates GutterBlock unwrapping (PR #86)", async () => {
+		const src = await fs.readFile(
+			path.join(import.meta.dir, "../src/modes/controllers/selector-controller.ts"),
+			"utf8",
+		);
+		expect(src).toContain("GutterBlock");
+	});
+
+	it("selector-controller.ts syncs separator when preset changes (PR #76)", async () => {
+		const src = await fs.readFile(
+			path.join(import.meta.dir, "../src/modes/controllers/selector-controller.ts"),
+			"utf8",
+		);
+		expect(src).toContain("getPreset");
+	});
+});
+
+// ─── Upstream PR #721 — Anthropic LiteLLM Passthrough ────────────────────
+
+describe("Anthropic auth litellm passthrough (upstream PR #721)", () => {
+	it("anthropic-auth.ts has Tier 6 litellm passthrough", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../../ai/src/utils/anthropic-auth.ts"), "utf8");
+		expect(src).toContain("LITELLM_BASE_URL");
+		expect(src).toContain("LITELLM_API_KEY");
+	});
+
+	it("anthropic-auth.ts wraps DB open in try/catch for resilience", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../../ai/src/utils/anthropic-auth.ts"), "utf8");
+		expect(src).toContain("storeError");
+	});
+
+	it("provider chain isAvailable() calls are wrapped in try/catch", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/web/search/provider.ts"), "utf8");
+		// Should have multiple try/catch blocks around isAvailable() calls
+		const catchCount = (src.match(/} catch \{/g) ?? []).length;
+		expect(catchCount).toBeGreaterThanOrEqual(2);
+	});
+});
+
+// ─── CI verify-npm-install backoff ────────────────────────────────────────
+
+describe("CI verify-npm-install uses version-pinned install with backoff (PR #93)", () => {
+	it("ci.yml pins specific version in verify-npm-install step", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../../../.github/workflows/ci.yml"), "utf8");
+		// Must install @f5xc-salesdemos/xcsh@<version> — specific version, not latest
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal string match against YAML content
+		expect(src).toContain('"@f5xc-salesdemos/xcsh@${expected}"');
+	});
+
+	it("ci.yml verify step uses EXPECTED_VERSION from github.ref_name", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../../../.github/workflows/ci.yml"), "utf8");
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal string match against YAML content
+		expect(src).toContain("EXPECTED_VERSION: ${{ github.ref_name }}");
+	});
+});

--- a/packages/coding-agent/test/tools/web-search-provider-chain.test.ts
+++ b/packages/coding-agent/test/tools/web-search-provider-chain.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { getSearchProvider, resolveProviderChain, SEARCH_PROVIDER_ORDER } from "../../src/web/search/provider";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("resolveProviderChain resilience", () => {
+	it("continues checking providers when one isAvailable() rejects", async () => {
+		// Make the anthropic provider throw
+		const anthropicProvider = getSearchProvider("anthropic");
+		vi.spyOn(anthropicProvider, "isAvailable").mockImplementation(() => Promise.reject(new Error("DB crash")));
+
+		// The chain should still resolve (other providers may or may not be available,
+		// but the function should not reject)
+		const providers = await resolveProviderChain();
+		// Should be an array, not a rejection
+		expect(Array.isArray(providers)).toBe(true);
+	});
+
+	it("returns empty array (not rejection) when all providers throw from isAvailable()", async () => {
+		// Mock every provider to throw
+		for (const id of SEARCH_PROVIDER_ORDER) {
+			const provider = getSearchProvider(id);
+			vi.spyOn(provider, "isAvailable").mockImplementation(() => Promise.reject(new Error(`${id} crashed`)));
+		}
+
+		const providers = await resolveProviderChain();
+		expect(providers).toEqual([]);
+	});
+
+	it("includes providers after a throwing provider", async () => {
+		// Make all providers unavailable except synthetic (which we'll make available)
+		for (const id of SEARCH_PROVIDER_ORDER) {
+			const provider = getSearchProvider(id);
+			if (id === "synthetic") {
+				vi.spyOn(provider, "isAvailable").mockImplementation(() => true);
+			} else if (id === "anthropic") {
+				vi.spyOn(provider, "isAvailable").mockImplementation(() => Promise.reject(new Error("anthropic crashed")));
+			} else {
+				vi.spyOn(provider, "isAvailable").mockImplementation(() => false);
+			}
+		}
+
+		const providers = await resolveProviderChain();
+		expect(providers.length).toBe(1);
+		expect(providers[0]!.id).toBe("synthetic");
+	});
+
+	it("handles preferred provider throwing gracefully", async () => {
+		const anthropicProvider = getSearchProvider("anthropic");
+		vi.spyOn(anthropicProvider, "isAvailable").mockImplementation(() =>
+			Promise.reject(new Error("anthropic crashed")),
+		);
+
+		// Should not reject even when the preferred provider throws
+		const providers = await resolveProviderChain("anthropic");
+		expect(Array.isArray(providers)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- **fix(model-registry)**: Restore `openai-compat` to `ProviderDiscoverySchema` and restore `#discoverOpenAICompatModels()` method for LiteLLM proxy users
- **test(model-registry)**: Add integration test for openai-compat discovery + UAT
- **test**: Add fork regression guard (46 tests) to prevent future regressions
- **docs**: Add bun test memory safeguards to CONTRIBUTING.md

### Problem

The v17 rebase removed `openai-compat` from `ProviderDiscoverySchema` and deleted `#discoverOpenAICompatModels()`. However `auto-config.ts` still generates `models.yml` with `discovery.type: openai-compat` for LiteLLM proxy users, causing a startup crash:

```
Error: Failed to load config file models, Schema error:
  - /providers/litellm/discovery/type: must be equal to constant
  - /providers/litellm/discovery/type: must match a schema in anyOf
```

Closes #99

## Test plan

- [ ] CI checks pass
- [ ] `bun test --filter "model-registry"` passes
- [ ] `bun test --filter "regression-guard"` passes (46 tests)
- [ ] LiteLLM proxy users can start the application without schema errors