### PR TITLE
test(coding-agent): add regression guard tests for vim throttle bypass and tui isMultiplexer

### DIFF
--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -341,3 +341,38 @@ describe("CI verify-npm-install uses version-pinned install with backoff (PR #93
 		expect(src).toContain("EXPECTED_VERSION: ${{ github.ref_name }}");
 	});
 });
+
+describe("vim ex-command onUpdate throttle bypass (commit 8f5b630ac)", () => {
+	it("vim.ts onKbdStep forces update when engine.inputMode is command or search mode", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/tools/vim.ts"), "utf8");
+		// Without these checks, all three prompt input modes throttle at 16ms and drop keystrokes
+		expect(src).toContain('engine.inputMode === "command"');
+		expect(src).toContain('engine.inputMode === "search-forward"');
+		expect(src).toContain('engine.inputMode === "search-backward"');
+	});
+
+	it("vim.ts emitUpdate is called with a truthy force flag in prompt input modes", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/tools/vim.ts"), "utf8");
+		// forcePrompt bypasses the FRAME_INTERVAL_MS throttle — must be passed to emitUpdate
+		expect(src).toContain("const forcePrompt =");
+		expect(src).toContain("emitUpdate(forcePrompt)");
+	});
+});
+
+describe("TUI isMultiplexer late-binding function for test isolation (commit be6d33f98)", () => {
+	it("tui.ts defines isMultiplexer as a function not a const", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../../tui/src/tui.ts"), "utf8");
+		// const isMultiplexer evaluates at import time — tests clearing TMUX/STY/ZELLIJ still see true
+		// function isMultiplexer() re-reads process.env on every call, enabling proper test isolation
+		expect(src).toContain("function isMultiplexer()");
+		expect(src).not.toContain("const isMultiplexer =");
+	});
+
+	it("tui.ts calls isMultiplexer() with parentheses at every usage site", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../../tui/src/tui.ts"), "utf8");
+		// Every reference must be a call — bare reference re-introduces the eager-evaluation bug
+		const allRefs = (src.match(/isMultiplexer/g) ?? []).length;
+		const callRefs = (src.match(/isMultiplexer\(\)/g) ?? []).length;
+		expect(callRefs).toBe(allRefs);
+	});
+});

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -113,7 +113,9 @@ function isTermuxSession(): boolean {
 }
 
 /** Detect terminal multiplexers where scrollback clearing and height-change redraws are hostile. */
-const isMultiplexer = Boolean(Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ);
+function isMultiplexer() {
+	return Boolean(Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ);
+}
 
 /**
  * Options for overlay positioning and sizing.
@@ -1011,7 +1013,7 @@ export class TUI extends Container {
 			this.#fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
 			// Skip clearing scrollback (3J) in multiplexers — users actively navigate scrollback history
-			if (clear) buffer += isMultiplexer ? "\x1b[2J\x1b[H" : "\x1b[2J\x1b[H\x1b[3J";
+			if (clear) buffer += isMultiplexer() ? "\x1b[2J\x1b[H" : "\x1b[2J\x1b[H\x1b[3J";
 			const reset = SEGMENT_RESET;
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";
@@ -1060,7 +1062,7 @@ export class TUI extends Container {
 		// Height changes normally need a full re-render to keep the visible viewport aligned,
 		// but Termux changes height when the software keyboard shows or hides.
 		// In that environment, a full redraw causes the entire history to replay on every toggle.
-		if (heightChanged && !isTermuxSession() && !isMultiplexer) {
+		if (heightChanged && !isTermuxSession() && !isMultiplexer()) {
 			logRedraw(`terminal height changed (${this.#previousHeight} -> ${height})`);
 			fullRender(true);
 			return;


### PR DESCRIPTION
## What

Add 4 regression guard tests covering two recent main-branch commits that lacked test coverage, and apply the `isMultiplexer` const-to-function conversion in `tui.ts` needed for test isolation.

## Why

Commits 8f5b630ac (vim throttle bypass in ex-command mode) and be6d33f98 (tui `isMultiplexer` testability) had no regression guard tests. A future upstream rebase could silently revert these fixes without CI detecting the regression.

Closes #732

## Testing

- All 54 regression guard tests pass (`bun test --filter regression-guard`)
- `bun run check:ts` clean (biome + tsgo, zero errors)
- No new test failures vs baseline

---

- [x] `bun run check:ts` passes
- [x] `bun test` -- no new failures vs baseline
- [x] Issue linked via `Closes #732`