### PR TITLE
fix(tui): close and reopen OSC 8 hyperlinks at wrapped line boundaries

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -24,8 +24,22 @@ export function truncateToWidth(
 	return nativeTruncateToWidth(text, maxWidth, ellipsisKind, pad, getDefaultTabWidth());
 }
 
+const OSC8_RE = /\x1b\]8;;([^\x07]*)\x07/g;
+
+function fixOsc8Boundaries(lines: string[]): string[] {
+	let activeUrl: string | null = null;
+	return lines.map(line => {
+		const prefix = activeUrl !== null ? `\x1b]8;;${activeUrl}\x07` : "";
+		for (const match of line.matchAll(OSC8_RE)) {
+			activeUrl = match[1] === "" ? null : match[1];
+		}
+		const suffix = activeUrl !== null ? `\x1b]8;;\x07` : "";
+		return prefix + line + suffix;
+	});
+}
+
 export function wrapTextWithAnsi(text: string, width: number): string[] {
-	return nativeWrapTextWithAnsi(text, width, getDefaultTabWidth());
+	return fixOsc8Boundaries(nativeWrapTextWithAnsi(text, width, getDefaultTabWidth()));
 }
 
 export function extractSegments(

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1020,7 +1020,7 @@ bar`,
 			expect(output.includes("\x1b]8;;\x07")).toBeTruthy();
 		});
 
-		it("should keep wrapped URLs inside a single OSC 8 hyperlink span", () => {
+		it("should close and reopen OSC 8 hyperlinks at each wrapped line boundary", () => {
 			const markdown = new Markdown(
 				"Visit https://example.com/really/long/path/that/will/wrap/on/narrow/width for more",
 				0,
@@ -1030,14 +1030,11 @@ bar`,
 
 			const lines = markdown.render(32);
 			expect(lines.length).toBeGreaterThan(1);
-			const output = lines.join("\n");
-			const openMatches =
-				output.match(
-					/\x1b\]8;;https:\/\/example\.com\/really\/long\/path\/that\/will\/wrap\/on\/narrow\/width\x07/g,
-				) || [];
-			const closeMatches = output.match(/\x1b\]8;;\x07/g) || [];
-			expect(openMatches.length).toBe(1);
-			expect(closeMatches.length).toBeGreaterThan(0);
+			for (const line of lines) {
+				const opens = (line.match(/\x1b\]8;;https:\/\/[^\x07]+\x07/g) ?? []).length;
+				const closes = (line.match(/\x1b\]8;;\x07/g) ?? []).length;
+				expect(closes).toBeGreaterThanOrEqual(opens);
+			}
 		});
 
 		it("should show URL for explicit markdown links with different text", () => {

--- a/packages/tui/test/wrap-ansi.test.ts
+++ b/packages/tui/test/wrap-ansi.test.ts
@@ -160,4 +160,37 @@ describe("wrapTextWithAnsi", () => {
 			}
 		});
 	});
+
+	describe("OSC 8 hyperlink handling", () => {
+		it("should close and reopen OSC 8 at each wrapped line boundary", () => {
+			const url = "https://example.com/very/long/path/that/wraps";
+			const text = `prefix \x1b]8;;${url}\x07${url}\x1b]8;;\x07 suffix`;
+			const wrapped = wrapTextWithAnsi(text, 20);
+			expect(wrapped.length).toBeGreaterThan(1);
+			for (const line of wrapped) {
+				const opens = (line.match(/\x1b\]8;;[^\x07]+\x07/g) ?? []).length;
+				const closes = (line.match(/\x1b\]8;;\x07/g) ?? []).length;
+				expect(closes).toBeGreaterThanOrEqual(opens);
+			}
+		});
+
+		it("should not add OSC 8 sequences when input has none", () => {
+			const text = "plain text without any hyperlinks that is long enough to wrap at all";
+			const wrapped = wrapTextWithAnsi(text, 20);
+			for (const line of wrapped) {
+				expect(line.includes("\x1b]8;;")).toBe(false);
+			}
+		});
+
+		it("should handle multiple hyperlinks on the same wrapped line", () => {
+			const url1 = "https://a.com";
+			const url2 = "https://b.com";
+			const text = `\x1b]8;;${url1}\x07${url1}\x1b]8;;\x07 and \x1b]8;;${url2}\x07${url2}\x1b]8;;\x07 end`;
+			const wrapped = wrapTextWithAnsi(text, 20);
+			const full = wrapped.join("\n");
+			const opens = (full.match(/\x1b\]8;;[^\x07]+\x07/g) ?? []).length;
+			const closes = (full.match(/\x1b\]8;;\x07/g) ?? []).length;
+			expect(closes).toBeGreaterThanOrEqual(opens);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

- Adds `fixOsc8Boundaries()` post-processor in `packages/tui/src/utils.ts` that closes any open OSC 8 terminal hyperlink sequence at each wrapped line boundary and reopens it on the next continuation line
- Pipes this fix through `wrapTextWithAnsi` transparently — all callers benefit
- Updates the existing markdown test that was asserting the buggy single-span behavior
- Adds 3 new `wrap-ansi.test.ts` cases covering: boundary close/reopen, no-op on plain text, multiple hyperlinks

## Root Cause

The native Rust `nativeWrapTextWithAnsi` correctly handles SGR ANSI codes (color, underline) across line breaks but does not understand OSC 8 sequences (`\x1b]8;;URL\x07`). When a prose line containing a hyperlinked URL was wider than the terminal, the open OSC 8 was never closed at the line boundary — causing the terminal to render underline decoration across all continuation lines, producing sequential underscore artifacts under the `Sources:` line in web search responses.

## Test Plan

- [x] `bun test packages/tui/test/wrap-ansi.test.ts` — 12/12 pass
- [x] `bun test packages/tui/test/markdown.test.ts` — 48/48 pass
- [x] Red-green cycle verified: reverting fix causes new test to fail
- [x] `biome check .` — clean
- [x] Type check (`tsgo --noEmit`) — clean
- [x] Build (`bun run build`) — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)