### PR TITLE
feat(coding-agent): expose max_uses and user_location in web search tool schema

### DIFF
--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -40,6 +40,19 @@ export const webSearchSchema = Type.Object({
 	num_search_results: Type.Optional(Type.Number({ description: "Number of search results to retrieve" })),
 	allowed_domains: Type.Optional(Type.Array(Type.String(), { description: "Only return results from these domains" })),
 	blocked_domains: Type.Optional(Type.Array(Type.String(), { description: "Exclude results from these domains" })),
+	max_uses: Type.Optional(Type.Number({ description: "Maximum number of web searches per request" })),
+	user_location: Type.Optional(
+		Type.Object(
+			{
+				type: Type.Literal("approximate"),
+				city: Type.Optional(Type.String()),
+				region: Type.Optional(Type.String()),
+				country: Type.Optional(Type.String()),
+				timezone: Type.Optional(Type.String()),
+			},
+			{ description: "Approximate user location for localized results" },
+		),
+	),
 });
 
 export type SearchToolParams = {
@@ -54,6 +67,14 @@ export type SearchToolParams = {
 	num_search_results?: number;
 	allowed_domains?: string[];
 	blocked_domains?: string[];
+	max_uses?: number;
+	user_location?: {
+		type: "approximate";
+		city?: string;
+		region?: string;
+		country?: string;
+		timezone?: string;
+	};
 };
 
 export interface SearchQueryParams extends SearchToolParams {
@@ -180,6 +201,8 @@ async function executeSearch(
 				temperature: params.temperature,
 				allowedDomains: params.allowed_domains,
 				blockedDomains: params.blocked_domains,
+				maxUses: params.max_uses,
+				userLocation: params.user_location,
 			});
 
 			const text = formatForLLM(response);

--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -331,6 +331,8 @@ export class AnthropicProvider extends SearchProvider {
 			temperature: params.temperature,
 			allowed_domains: params.allowedDomains,
 			blocked_domains: params.blockedDomains,
+			max_uses: params.maxUses,
+			user_location: params.userLocation,
 		});
 	}
 }

--- a/packages/coding-agent/src/web/search/providers/base.ts
+++ b/packages/coding-agent/src/web/search/providers/base.ts
@@ -12,6 +12,14 @@ export interface SearchParams {
 	temperature?: number;
 	allowedDomains?: string[];
 	blockedDomains?: string[];
+	maxUses?: number;
+	userLocation?: {
+		type: "approximate";
+		city?: string;
+		region?: string;
+		country?: string;
+		timezone?: string;
+	};
 	googleSearch?: Record<string, unknown>;
 	codeExecution?: Record<string, unknown>;
 	urlContext?: Record<string, unknown>;


### PR DESCRIPTION
## What

Expose `max_uses` and `user_location` in the public web search tool schema, completing Anthropic `web_search_20250305` API feature parity.

## Why

PR #105 added `allowed_domains` and `blocked_domains` but left `max_uses` and `user_location` wired internally without public schema exposure. The A/B audit against the Anthropic API spec identified these as unreachable parameters.

All 6 API tool definition parameters now exposed end-to-end:
- `type`, `name` (hardcoded)
- `allowed_domains`, `blocked_domains` (PR #105)
- `max_uses`, `user_location` (this PR)

## Testing

- 104 web search tests pass, 0 failures
- `bun run check:ts` clean
- Local build verified with `xcsh search` subcommand

---

- [x] `bun run check` passes
- [x] `bun test` — no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)