### PR TITLE
feat(coding-agent): web search synthesis, max_uses default, and full API parity

### DIFF
--- a/packages/coding-agent/src/cli/web-search-cli.ts
+++ b/packages/coding-agent/src/cli/web-search-cli.ts
@@ -161,10 +161,14 @@ export async function runSearchCommand(cmd: SearchCommandArgs): Promise<void> {
 	process.stdout.write(`${component.render(width).join("\n")}\n`);
 
 	if (cmd.synthesize && result.details?.response && result.details.response.sources.length > 0) {
-		process.stderr.write(chalk.dim("\nSynthesizing response...\n"));
-		const synthesized = await synthesizeResponse(cmd.query, result.details.response, cmd.synthesizeModel);
-		if (synthesized) {
-			process.stdout.write(`\n${chalk.bold("Synthesized Answer:")}\n\n${synthesized}\n`);
+		try {
+			process.stderr.write(chalk.dim("\nSynthesizing response...\n"));
+			const synthesized = await synthesizeResponse(cmd.query, result.details.response, cmd.synthesizeModel);
+			if (synthesized) {
+				process.stdout.write(`\n${chalk.bold("Synthesized Answer:")}\n\n${synthesized}\n`);
+			}
+		} catch {
+			process.stderr.write(chalk.dim("Synthesis unavailable — showing raw search results only.\n"));
 		}
 	}
 

--- a/packages/coding-agent/src/cli/web-search-cli.ts
+++ b/packages/coding-agent/src/cli/web-search-cli.ts
@@ -4,13 +4,14 @@
  * Handles `xcsh q`/`xcsh web-search` subcommands for testing web search providers.
  */
 
-import { APP_NAME } from "@f5xc-salesdemos/pi-utils";
+import { buildAnthropicSearchHeaders, buildAnthropicUrl, findAnthropicAuth } from "@f5xc-salesdemos/pi-ai";
+import { $env, APP_NAME } from "@f5xc-salesdemos/pi-utils";
 import chalk from "chalk";
 import { initTheme, theme } from "../modes/theme/theme";
 import { runSearchQuery, type SearchQueryParams } from "../web/search/index";
 import { SEARCH_PROVIDER_ORDER } from "../web/search/provider";
 import { renderSearchResult } from "../web/search/render";
-import type { SearchProviderId } from "../web/search/types";
+import type { SearchProviderId, SearchResponse } from "../web/search/types";
 
 export interface SearchCommandArgs {
 	query: string;
@@ -18,6 +19,8 @@ export interface SearchCommandArgs {
 	recency?: "day" | "week" | "month" | "year";
 	limit?: number;
 	expanded: boolean;
+	synthesize: boolean;
+	synthesizeModel?: string;
 }
 
 const PROVIDERS: Array<SearchProviderId | "auto"> = ["auto", ...SEARCH_PROVIDER_ORDER];
@@ -36,6 +39,7 @@ export function parseSearchArgs(args: string[]): SearchCommandArgs | undefined {
 	const result: SearchCommandArgs = {
 		query: "",
 		expanded: true,
+		synthesize: true,
 	};
 
 	const positional: string[] = [];
@@ -50,6 +54,10 @@ export function parseSearchArgs(args: string[]): SearchCommandArgs | undefined {
 			result.limit = Number.parseInt(args[++i], 10);
 		} else if (arg === "--compact") {
 			result.expanded = false;
+		} else if (arg === "--no-synthesize") {
+			result.synthesize = false;
+		} else if (arg === "--model") {
+			result.synthesizeModel = args[++i];
 		} else if (!arg.startsWith("-")) {
 			positional.push(arg);
 		}
@@ -60,6 +68,54 @@ export function parseSearchArgs(args: string[]): SearchCommandArgs | undefined {
 	}
 
 	return result;
+}
+
+async function synthesizeResponse(
+	query: string,
+	searchResponse: SearchResponse,
+	model?: string,
+): Promise<string | undefined> {
+	const auth = await findAnthropicAuth();
+	if (!auth) return undefined;
+
+	const sourcesContext = searchResponse.sources
+		.map((s, i) => `[${i + 1}] ${s.title}\n    ${s.url}${s.snippet ? `\n    ${s.snippet}` : ""}`)
+		.join("\n");
+
+	const citationsContext =
+		searchResponse.citations?.map((c, i) => `[${i + 1}] ${c.title}: "${c.citedText}"`).join("\n") ?? "";
+
+	const synthesisPrompt = `Based on the following web search results for the query "${query}", provide a comprehensive, well-structured answer. Cite sources by number.
+
+## Search Results
+${searchResponse.answer ? `### Initial Answer\n${searchResponse.answer}\n` : ""}
+### Sources
+${sourcesContext}
+${citationsContext ? `\n### Citations\n${citationsContext}` : ""}
+
+Provide a thorough answer with key facts, numbers, and source citations.`;
+
+	const url = buildAnthropicUrl(auth);
+	const headers = buildAnthropicSearchHeaders(auth);
+	const selectedModel = model ?? $env.ANTHROPIC_SEARCH_MODEL ?? "claude-haiku-4-5";
+
+	const response = await fetch(url, {
+		method: "POST",
+		headers,
+		body: JSON.stringify({
+			model: selectedModel,
+			max_tokens: 4096,
+			messages: [{ role: "user", content: synthesisPrompt }],
+		}),
+	});
+
+	if (!response.ok) return undefined;
+
+	const data = (await response.json()) as { content?: Array<{ type: string; text?: string }> };
+	return data.content
+		?.filter(b => b.type === "text" && b.text)
+		.map(b => b.text)
+		.join("\n\n");
 }
 
 export async function runSearchCommand(cmd: SearchCommandArgs): Promise<void> {
@@ -104,6 +160,14 @@ export async function runSearchCommand(cmd: SearchCommandArgs): Promise<void> {
 	const width = Math.max(60, process.stdout.columns ?? 100);
 	process.stdout.write(`${component.render(width).join("\n")}\n`);
 
+	if (cmd.synthesize && result.details?.response && result.details.response.sources.length > 0) {
+		process.stderr.write(chalk.dim("\nSynthesizing response...\n"));
+		const synthesized = await synthesizeResponse(cmd.query, result.details.response, cmd.synthesizeModel);
+		if (synthesized) {
+			process.stdout.write(`\n${chalk.bold("Synthesized Answer:")}\n\n${synthesized}\n`);
+		}
+	}
+
 	if (result.details?.error) {
 		process.exitCode = 1;
 	}
@@ -124,6 +188,8 @@ ${chalk.bold("Options:")}
   --recency <value>   Recency filter (Brave/Perplexity): ${RECENCY_OPTIONS.join(", ")}
   -l, --limit <n>     Max results to return
   --compact           Render condensed output
+  --no-synthesize     Skip synthesis step (raw search only)
+  --model <name>      Model for synthesis (default: ANTHROPIC_SEARCH_MODEL or claude-haiku-4-5)
   -h, --help          Show this help
 
 ${chalk.bold("Examples:")}

--- a/packages/coding-agent/src/commands/web-search.ts
+++ b/packages/coding-agent/src/commands/web-search.ts
@@ -35,6 +35,7 @@ export default class Search extends Command {
 			recency: flags.recency as SearchCommandArgs["recency"],
 			limit: flags.limit,
 			expanded: !flags.compact,
+			synthesize: true,
 		};
 
 		await runSearchCommand(cmd);

--- a/packages/coding-agent/src/commands/web-search.ts
+++ b/packages/coding-agent/src/commands/web-search.ts
@@ -23,6 +23,8 @@ export default class Search extends Command {
 		recency: Flags.string({ description: "Recency filter", options: RECENCY }),
 		limit: Flags.integer({ char: "l", description: "Max results to return" }),
 		compact: Flags.boolean({ description: "Render condensed output" }),
+		"no-synthesize": Flags.boolean({ description: "Skip synthesis step (raw search only)" }),
+		model: Flags.string({ description: "Model for synthesis (default: claude-haiku-4-5)" }),
 	};
 
 	async run(): Promise<void> {
@@ -35,7 +37,8 @@ export default class Search extends Command {
 			recency: flags.recency as SearchCommandArgs["recency"],
 			limit: flags.limit,
 			expanded: !flags.compact,
-			synthesize: true,
+			synthesize: !flags["no-synthesize"],
+			synthesizeModel: flags.model,
 		};
 
 		await runSearchCommand(cmd);

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -168,9 +168,10 @@ async function executeSearch(
 	_toolCallId: string,
 	params: SearchQueryParams,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; details: SearchRenderDetails }> {
-	const hasDomainFilter = params.allowed_domains?.length || params.blocked_domains?.length;
+	const hasAnthropicOnlyParams =
+		params.allowed_domains?.length || params.blocked_domains?.length || params.max_uses || params.user_location;
 	const effectiveProvider =
-		hasDomainFilter && (!params.provider || params.provider === "auto") ? "anthropic" : params.provider;
+		hasAnthropicOnlyParams && (!params.provider || params.provider === "auto") ? "anthropic" : params.provider;
 	const providers =
 		effectiveProvider && effectiveProvider !== "auto"
 			? (await getSearchProvider(effectiveProvider).isAvailable())

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -40,6 +40,19 @@ export const webSearchSchema = Type.Object({
 	num_search_results: Type.Optional(Type.Number({ description: "Number of search results to retrieve" })),
 	allowed_domains: Type.Optional(Type.Array(Type.String(), { description: "Only return results from these domains" })),
 	blocked_domains: Type.Optional(Type.Array(Type.String(), { description: "Exclude results from these domains" })),
+	max_uses: Type.Optional(Type.Number({ description: "Maximum number of web searches per request" })),
+	user_location: Type.Optional(
+		Type.Object(
+			{
+				type: Type.Literal("approximate"),
+				city: Type.Optional(Type.String()),
+				region: Type.Optional(Type.String()),
+				country: Type.Optional(Type.String()),
+				timezone: Type.Optional(Type.String()),
+			},
+			{ description: "Approximate user location for localized results" },
+		),
+	),
 });
 
 export type SearchToolParams = {
@@ -54,6 +67,14 @@ export type SearchToolParams = {
 	num_search_results?: number;
 	allowed_domains?: string[];
 	blocked_domains?: string[];
+	max_uses?: number;
+	user_location?: {
+		type: "approximate";
+		city?: string;
+		region?: string;
+		country?: string;
+		timezone?: string;
+	};
 };
 
 export interface SearchQueryParams extends SearchToolParams {
@@ -180,6 +201,8 @@ async function executeSearch(
 				temperature: params.temperature,
 				allowedDomains: params.allowed_domains,
 				blockedDomains: params.blocked_domains,
+				maxUses: params.max_uses,
+				userLocation: params.user_location,
 			});
 
 			const text = formatForLLM(response);

--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -27,6 +27,7 @@ import { SearchProvider } from "./base";
 
 const DEFAULT_MODEL = "claude-haiku-4-5";
 const DEFAULT_MAX_TOKENS = 4096;
+const DEFAULT_MAX_USES = 8;
 const WEB_SEARCH_TOOL_NAME = "web_search";
 const WEB_SEARCH_TOOL_TYPE = "web_search_20250305";
 
@@ -132,7 +133,7 @@ async function callSearch(
 	};
 	if (toolConfig?.allowed_domains?.length) tool.allowed_domains = toolConfig.allowed_domains;
 	if (toolConfig?.blocked_domains?.length) tool.blocked_domains = toolConfig.blocked_domains;
-	if (toolConfig?.max_uses) tool.max_uses = toolConfig.max_uses;
+	tool.max_uses = toolConfig?.max_uses ?? DEFAULT_MAX_USES;
 	if (toolConfig?.user_location) tool.user_location = toolConfig.user_location;
 
 	const body: Record<string, unknown> = {

--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -331,6 +331,8 @@ export class AnthropicProvider extends SearchProvider {
 			temperature: params.temperature,
 			allowed_domains: params.allowedDomains,
 			blocked_domains: params.blockedDomains,
+			max_uses: params.maxUses,
+			user_location: params.userLocation,
 		});
 	}
 }

--- a/packages/coding-agent/src/web/search/providers/base.ts
+++ b/packages/coding-agent/src/web/search/providers/base.ts
@@ -12,6 +12,14 @@ export interface SearchParams {
 	temperature?: number;
 	allowedDomains?: string[];
 	blockedDomains?: string[];
+	maxUses?: number;
+	userLocation?: {
+		type: "approximate";
+		city?: string;
+		region?: string;
+		country?: string;
+		timezone?: string;
+	};
 	googleSearch?: Record<string, unknown>;
 	codeExecution?: Record<string, unknown>;
 	urlContext?: Record<string, unknown>;

--- a/packages/coding-agent/test/tools/web-search-anthropic.test.ts
+++ b/packages/coding-agent/test/tools/web-search-anthropic.test.ts
@@ -114,7 +114,7 @@ describe("searchAnthropic headers", () => {
 		expect(getHeaderCaseInsensitive(capturedRequest?.headers, "anthropic-beta")).toContain(WEB_SEARCH_BETA);
 		expect(getHeaderCaseInsensitive(capturedRequest?.headers, "x-api-key")).toBe("sk-ant-api-test");
 		expect(getHeaderCaseInsensitive(capturedRequest?.headers, "authorization")).toBeUndefined();
-		expect(capturedRequest?.body?.tools).toEqual([{ type: "web_search_20250305", name: "web_search" }]);
+		expect(capturedRequest?.body?.tools).toEqual([{ type: "web_search_20250305", name: "web_search", max_uses: 8 }]);
 	});
 
 	it("includes web-search beta header and sends OAuth token in Authorization mode", async () => {
@@ -140,6 +140,7 @@ describe("searchAnthropic headers", () => {
 				type: "web_search_20250305",
 				name: "web_search",
 				allowed_domains: ["example.com", "docs.example.com"],
+				max_uses: 8,
 			},
 		]);
 	});
@@ -155,6 +156,7 @@ describe("searchAnthropic headers", () => {
 				type: "web_search_20250305",
 				name: "web_search",
 				blocked_domains: ["spam.com"],
+				max_uses: 8,
 			},
 		]);
 	});
@@ -219,13 +221,13 @@ describe("searchAnthropic headers", () => {
 		expect((capturedRequest?.body?.tools as any[])?.[0]?.user_location).toEqual(location);
 	});
 
-	it("omits optional tool fields when no extra params provided", async () => {
+	it("sends default max_uses of 8 when no extra params provided", async () => {
 		process.env.ANTHROPIC_SEARCH_API_KEY = "sk-ant-api-test";
 		using _hook = mockFetch(makeAnthropicResponse());
 
 		await searchAnthropic({ query: "plain query" });
 
-		expect(capturedRequest?.body?.tools).toEqual([{ type: "web_search_20250305", name: "web_search" }]);
+		expect(capturedRequest?.body?.tools).toEqual([{ type: "web_search_20250305", name: "web_search", max_uses: 8 }]);
 	});
 
 	it("sends both allowed_domains and blocked_domains together", async () => {
@@ -249,7 +251,7 @@ describe("searchAnthropic headers", () => {
 
 		await searchAnthropic({ query: "test query", allowed_domains: [] });
 
-		expect(capturedRequest?.body?.tools).toEqual([{ type: "web_search_20250305", name: "web_search" }]);
+		expect(capturedRequest?.body?.tools).toEqual([{ type: "web_search_20250305", name: "web_search", max_uses: 8 }]);
 	});
 
 	it("does not send blocked_domains when array is empty", async () => {
@@ -258,7 +260,7 @@ describe("searchAnthropic headers", () => {
 
 		await searchAnthropic({ query: "test query", blocked_domains: [] });
 
-		expect(capturedRequest?.body?.tools).toEqual([{ type: "web_search_20250305", name: "web_search" }]);
+		expect(capturedRequest?.body?.tools).toEqual([{ type: "web_search_20250305", name: "web_search", max_uses: 8 }]);
 	});
 });
 


### PR DESCRIPTION
## What

- Add second-turn synthesis to `xcsh search` — searches, then asks the model to produce a comprehensive cited answer
- Default `max_uses: 8` matching Claude Code behavior (reverse-engineered from binary)
- Expose `max_uses` and `user_location` in public tool schema
- Route all Anthropic-only params (domains, max_uses, user_location) to Anthropic provider
- Wire `--no-synthesize` and `--model` flags in oclif command

## Why

Claude Code's web_search works as a two-turn pattern: search results feed back into the agent which synthesizes a response. xcsh search was single-turn only. This adds an explicit synthesis step that completes in ~9s vs Claude Code's ~127s for the same query.

Reverse engineering Claude Code's binary (`GeO` function) confirmed `max_uses: 8` is hardcoded.

## Testing

- 104 web search tests pass, 0 failures
- `bun run check:ts` clean
- Live test: `xcsh search "stock price of FFIV"` returns 10 sources + synthesized answer in 8.8s
- Live test: `xcsh search "site:nasdaq.com FFIV"` returns domain-scoped results
- Codex review: all 3 issues (P1 + 2x P2) fixed

---

- [x] `bun run check` passes
- [x] `bun test` — no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)