### PR TITLE
feat(coding-agent): add web_search.verbose setting for compact output

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1313,6 +1313,15 @@ export const SETTINGS_SCHEMA = {
 		default: true,
 		ui: { tab: "tools", label: "Web Search", description: "Enable the web_search tool for web searching" },
 	},
+	"web_search.verbose": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			label: "Web Search Verbose",
+			description: "Show detailed search panels (sources, metadata, tokens). When disabled, uses compact output.",
+		},
+	},
 
 	"browser.enabled": {
 		type: "boolean",

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -192,6 +192,7 @@ async function executeSearch(
 	for (const provider of providers) {
 		lastProvider = provider;
 		try {
+			const searchStart = performance.now();
 			const response = await provider.search({
 				query: params.query.replace(/202\d/g, String(new Date().getFullYear())), // LUL
 				limit: params.limit,
@@ -205,6 +206,7 @@ async function executeSearch(
 				maxUses: params.max_uses,
 				userLocation: params.user_location,
 			});
+			response.durationMs = performance.now() - searchStart;
 
 			const text = formatForLLM(response);
 

--- a/packages/coding-agent/src/web/search/render.ts
+++ b/packages/coding-agent/src/web/search/render.ts
@@ -6,6 +6,7 @@
 
 import type { Component } from "@f5xc-salesdemos/pi-tui";
 import { Text, visibleWidth, wrapTextWithAnsi } from "@f5xc-salesdemos/pi-tui";
+import { Settings } from "../../config/settings";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
 import type { Theme } from "../../modes/theme/theme";
 import {
@@ -24,6 +25,14 @@ import { renderStatusLine, renderTreeList } from "../../tui";
 import { CachedOutputBlock } from "../../tui/output-block";
 import { getSearchProvider } from "./provider";
 import type { SearchResponse } from "./types";
+
+function getVerboseSetting(): boolean {
+	try {
+		return Settings.instance.get("web_search.verbose");
+	} catch {
+		return false;
+	}
+}
 
 const MAX_COLLAPSED_ANSWER_LINES = PREVIEW_LIMITS.COLLAPSED_LINES;
 const MAX_EXPANDED_ANSWER_LINES = PREVIEW_LIMITS.EXPANDED_LINES;
@@ -90,6 +99,20 @@ export function renderSearchResult(
 	const response = details?.response;
 	if (!response) {
 		return renderFallbackText(rawText, options.expanded, theme);
+	}
+
+	const verbose = getVerboseSetting();
+	if (!verbose) {
+		const searches = response.usage?.searchRequests ?? 1;
+		const plural = searches !== 1 ? "es" : "";
+		const dur =
+			response.durationMs !== undefined
+				? response.durationMs >= 1000
+					? `${Math.round(response.durationMs / 1000)}s`
+					: `${Math.round(response.durationMs)}ms`
+				: "";
+		const line = `  \u23BF  Did ${searches} search${plural}${dur ? ` in ${dur}` : ""}`;
+		return new Text(theme.fg("dim", line), 0, 0);
 	}
 
 	const sources = Array.isArray(response.sources) ? response.sources : [];
@@ -288,6 +311,10 @@ export function renderSearchCall(
 	theme: Theme,
 ): Component {
 	const query = truncateToWidth(args.query ?? "", 80);
+	const verbose = getVerboseSetting();
+	if (!verbose) {
+		return new Text(`${theme.fg("text", `Web Search("${query}")`)}`, 0, 0);
+	}
 	const text = renderStatusLine({ icon: "pending", title: "Web Search", description: query }, theme);
 	return new Text(text, 0, 0);
 }

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -94,6 +94,8 @@ export interface SearchResponse {
 	requestId?: string;
 	/** Authentication mode used by the provider (e.g. oauth, api-key) */
 	authMode?: string;
+	/** Wall-clock duration of the search request in milliseconds */
+	durationMs?: number;
 }
 
 /** Provider-specific error with optional HTTP status */


### PR DESCRIPTION
## What

Add `web_search.verbose` setting (default: `false`) that toggles between compact and verbose web search output.

**Compact mode** (new default):
```
Web Search("FFIV stock price today")
  ⎿  Did 1 search in 4s
```

**Verbose mode** (existing behavior):
```
┌─── Web Search: Anthropic 10 sources ───┐
│ Query: ...                              │
├─── Answer ──────────────────────────────┤
│ ...                                     │
├─── Sources ─────────────────────────────┤
│ ...                                     │
├─── Metadata ────────────────────────────┤
│ Provider: Anthropic                     │
│ Model: claude-haiku-4-5                 │
│ Usage: in 2632 · out 294 · search 1     │
└─────────────────────────────────────────┘
```

## Why

Feature parity with Claude Code's output format. Extracted exact format from Claude Code binary (functions `GeO`, `L34`, `h34`). The verbose box is great for debugging but noisy during normal use.

## Testing

- 104 web search tests pass (--max-concurrency 2)
- bun run check:ts clean
- Live test: compact output shows "⎿  Did 1 search in 4s"
- Settings gracefully handles uninitialized state (CLI subcommand path)

---

- [x] \`bun run check\` passes
- [x] \`bun test\` — no new failures vs baseline