### PR TITLE
fix(coding-agent): persist web search tool label in compact mode

### DIFF
--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -292,7 +292,9 @@ export const webSearchCustomTool: CustomTool<typeof webSearchSchema, SearchRende
 	renderResult(result, options: RenderResultOptions, theme: Theme) {
 		return renderSearchResult(result, options, theme);
 	},
-};
+
+	mergeCallAndResult: true as const,
+} as CustomTool<typeof webSearchSchema, SearchRenderDetails> & { mergeCallAndResult: true };
 
 export function getSearchTools(): CustomTool<any, any>[] {
 	return [webSearchCustomTool];

--- a/packages/coding-agent/src/web/search/render.ts
+++ b/packages/coding-agent/src/web/search/render.ts
@@ -101,6 +101,10 @@ export function renderSearchResult(
 		return renderFallbackText(rawText, options.expanded, theme);
 	}
 
+	const searchQueries = Array.isArray(response.searchQueries)
+		? response.searchQueries.filter(item => typeof item === "string")
+		: [];
+
 	const verbose = getVerboseSetting();
 	if (!verbose) {
 		const searches = response.usage?.searchRequests ?? 1;
@@ -111,17 +115,20 @@ export function renderSearchResult(
 					? `${Math.round(response.durationMs / 1000)}s`
 					: `${Math.round(response.durationMs)}ms`
 				: "";
-		const line = `  \u23BF  Did ${searches} search${plural}${dur ? ` in ${dur}` : ""}`;
-		return new Text(theme.fg("dim", line), 0, 0);
+		const queryPreview = args?.query
+			? truncateToWidth(args.query, 80)
+			: searchQueries[0]
+				? truncateToWidth(searchQueries[0], 80)
+				: undefined;
+		const header = queryPreview ? `Web Search("${queryPreview}")` : "Web Search";
+		const summary = `  \u23BF  Did ${searches} search${plural}${dur ? ` in ${dur}` : ""}`;
+		return new Text(`${theme.fg("text", header)}\n${theme.fg("dim", summary)}`, 0, 0);
 	}
 
 	const sources = Array.isArray(response.sources) ? response.sources : [];
 	const sourceCount = sources.length;
 	const citations = Array.isArray(response.citations) ? response.citations : [];
 	const citationCount = citations.length;
-	const searchQueries = Array.isArray(response.searchQueries)
-		? response.searchQueries.filter(item => typeof item === "string")
-		: [];
 	const provider = response.provider;
 
 	// Get answer text

--- a/packages/coding-agent/test/tools/web-search-render.test.ts
+++ b/packages/coding-agent/test/tools/web-search-render.test.ts
@@ -114,6 +114,40 @@ describe("web search render — compact mode (verbose=false)", () => {
 			expect(text).toContain("Did 1 search");
 			expect(text).not.toContain("in ");
 		});
+
+		it("includes Web Search call header in compact result (mergeCallAndResult)", () => {
+			const response = makeSearchResponse({ durationMs: 4000 });
+			const component = renderSearchResult(makeResult(response), { expanded: false, isPartial: false }, theme!, {
+				query: "FFIV stock price",
+			});
+			const text = stripAnsi(component.render(100).join("\n"));
+			expect(text).toContain('Web Search("FFIV stock price")');
+			expect(text).toContain("Did 1 search in 4s");
+		});
+
+		it("uses searchQueries for header when args.query is absent", () => {
+			const response = makeSearchResponse({
+				durationMs: 2000,
+				searchQueries: ["FFIV F5 stock price today"],
+			});
+			const component = renderSearchResult(makeResult(response), { expanded: false, isPartial: false }, theme!);
+			const text = stripAnsi(component.render(100).join("\n"));
+			expect(text).toContain('Web Search("FFIV F5 stock price today")');
+		});
+
+		it("renders header and summary on separate lines", () => {
+			const response = makeSearchResponse({ durationMs: 3000 });
+			const component = renderSearchResult(makeResult(response), { expanded: false, isPartial: false }, theme!, {
+				query: "test",
+			});
+			const lines = component.render(100);
+			const stripped = lines.map(l => stripAnsi(l));
+			const headerLine = stripped.find(l => l.includes("Web Search"));
+			const summaryLine = stripped.find(l => l.includes("Did 1 search"));
+			expect(headerLine).toBeDefined();
+			expect(summaryLine).toBeDefined();
+			expect(headerLine).not.toBe(summaryLine);
+		});
 	});
 });
 


### PR DESCRIPTION
## What

Fix two visual bugs in compact web search mode:
1. `Web Search("query")` label was disappearing after results arrived
2. Result summary was orphaned without its header context

## Why

The `renderSearchResult` compact path returned only `⎿  Did 1 search in 3s` without the call header. Since `mergeCallAndResult` replaces the call component with the result, the header was lost. Claude Code keeps the header visible with a blue gutter dot after completion.

## Changes

- Add `mergeCallAndResult: true` to `webSearchCustomTool`
- Compact `renderSearchResult` now renders both lines: `Web Search("query")` + `⎿  Did N search[es] in Xs`
- Falls back to `searchQueries[0]` when `args.query` isn't available
- 3 new render tests

## Testing

- 117 web search tests pass (verified from main workspace where pi_natives works)
- `bun run check:ts` clean
- A/B comparison: output matches Claude Code format exactly
- Built binary tested: `./packages/coding-agent/dist/xcsh search "Fortinet FTNT stock price today" --no-synthesize`

---

- [x] \`bun run check\` passes
- [x] \`bun test --max-concurrency 2\` — 117 tests, 0 failures