### PR TITLE
fix(welcome): unify update + changelog notifications into the welcome screen (#114)

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,7 +933,6 @@ interruptMode: immediate
 
 shellPath: C:\\path\\to\\bash.exe
 hideThinkingBlock: false
-collapseChangelog: false
 
 disabledProviders: []
 disabledExtensions: []

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -662,12 +662,6 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
-	collapseChangelog: {
-		type: "boolean",
-		default: true,
-		ui: { tab: "interaction", label: "Collapse Changelog", description: "Show condensed changelog after updates" },
-	},
-
 	// Notifications
 	"completion.notify": {
 		type: "enum",

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -144,10 +144,12 @@ export async function submitInteractiveInput(
 	}
 }
 
+const INITIAL_UPDATE_CHECK_TIMEOUT_MS = 500;
+
 async function runInteractiveMode(
 	session: AgentSession,
 	version: string,
-	changelogMarkdown: string | undefined,
+	changelogStatus: { hasNew: boolean; version: string } | undefined,
 	notifs: (InteractiveModeNotify | null)[],
 	versionCheckPromise: Promise<string | undefined>,
 	initialMessages: string[],
@@ -158,10 +160,19 @@ async function runInteractiveMode(
 	initialMessage?: string,
 	initialImages?: ImageContent[],
 ): Promise<void> {
+	const initialUpdateVersion = await Promise.race([
+		versionCheckPromise.catch(() => undefined),
+		new Promise<string | undefined>(resolve => setTimeout(() => resolve(undefined), INITIAL_UPDATE_CHECK_TIMEOUT_MS)),
+	]);
+	const initialUpdateStatus = initialUpdateVersion
+		? { available: true, latestVersion: initialUpdateVersion }
+		: undefined;
+
 	const mode = new InteractiveMode(
 		session,
 		version,
-		changelogMarkdown,
+		changelogStatus,
+		initialUpdateStatus,
 		setExtensionUIContext,
 		lspServers,
 		mcpManager,
@@ -170,16 +181,18 @@ async function runInteractiveMode(
 
 	await mode.init();
 
-	versionCheckPromise
-		.then(newVersion => {
-			if (!settings.get("startup.checkUpdate")) {
-				return;
-			}
-			if (newVersion) {
-				mode.showNewVersionNotification(newVersion);
-			}
-		})
-		.catch(() => {});
+	if (!initialUpdateVersion) {
+		versionCheckPromise
+			.then(newVersion => {
+				if (!settings.get("startup.checkUpdate")) {
+					return;
+				}
+				if (newVersion) {
+					mode.setUpdateStatus({ available: true, latestVersion: newVersion });
+				}
+			})
+			.catch(() => {});
+	}
 
 	mode.renderInitialMessages();
 
@@ -243,7 +256,7 @@ async function promptForkSession(session: SessionInfo): Promise<boolean> {
 	}
 }
 
-async function getChangelogForDisplay(parsed: Args): Promise<string | undefined> {
+async function getChangelogForDisplay(parsed: Args): Promise<{ hasNew: boolean; version: string } | undefined> {
 	if (parsed.continue || parsed.resume) {
 		return undefined;
 	}
@@ -255,13 +268,13 @@ async function getChangelogForDisplay(parsed: Args): Promise<string | undefined>
 	if (!lastVersion) {
 		if (entries.length > 0) {
 			settings.set("lastChangelogVersion", VERSION);
-			return entries.map(e => e.content).join("\n\n");
+			return { hasNew: true, version: VERSION };
 		}
 	} else {
 		const newEntries = getNewEntries(entries, lastVersion);
 		if (newEntries.length > 0) {
 			settings.set("lastChangelogVersion", VERSION);
-			return newEntries.map(e => e.content).join("\n\n");
+			return { hasNew: true, version: VERSION };
 		}
 	}
 
@@ -877,7 +890,7 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 	} else if (isInteractive) {
 		const versionCheckPromise = checkForNewVersion(VERSION).catch(() => undefined);
 		logger.time("main:getChangelogForDisplay");
-		const changelogMarkdown = await getChangelogForDisplay(parsedArgs);
+		const changelogStatus = await getChangelogForDisplay(parsedArgs);
 
 		const scopedModelsForDisplay = sessionOptions.scopedModels ?? scopedModels;
 		if (scopedModelsForDisplay.length > 0) {
@@ -901,7 +914,7 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 		await runInteractiveMode(
 			session,
 			VERSION,
-			changelogMarkdown,
+			changelogStatus,
 			notifs,
 			versionCheckPromise,
 			parsedArgs.messages,

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -3,11 +3,23 @@ import { APP_NAME } from "@f5xc-salesdemos/pi-utils";
 import { theme } from "../../modes/theme/theme";
 import type { ModelStatus, WelcomeProfileStatus } from "./welcome-checks";
 
+export interface UpdateStatus {
+	available: boolean;
+	latestVersion?: string;
+}
+
+export interface ChangelogStatus {
+	hasNew: boolean;
+	version: string;
+}
+
 export class WelcomeComponent implements Component {
 	constructor(
 		private readonly version: string,
 		private modelStatus: ModelStatus,
 		private profileStatus?: WelcomeProfileStatus,
+		private updateStatus?: UpdateStatus,
+		private changelogStatus?: ChangelogStatus,
 	) {}
 	invalidate(): void {}
 	setModelStatus(status: ModelStatus): void {
@@ -15,6 +27,12 @@ export class WelcomeComponent implements Component {
 	}
 	setProfileStatus(status: WelcomeProfileStatus | undefined): void {
 		this.profileStatus = status;
+	}
+	setUpdateStatus(status: UpdateStatus | undefined): void {
+		this.updateStatus = status;
+	}
+	setChangelogStatus(status: ChangelogStatus | undefined): void {
+		this.changelogStatus = status;
 	}
 
 	render(termWidth: number): string[] {
@@ -111,24 +129,70 @@ export class WelcomeComponent implements Component {
 		if (this.profileStatus) {
 			lines.push(" F5 XC Profile", ...this.#renderProfileStatus());
 		}
+		if (this.#showUpdateSection()) {
+			lines.push(" Update Available", ...this.#renderUpdateStatus());
+		}
+		if (this.#showChangelogSection()) {
+			lines.push(" What's New", ...this.#renderChangelogStatus());
+		}
 		return Math.max(...lines.map(l => visibleWidth(l)));
 	}
 
 	#buildStatusLines(rightCol: number): string[] {
 		const lines: string[] = [];
 		const separatorWidth = Math.max(0, rightCol - 2);
+		const separator = ` ${theme.fg("muted", theme.boxRound.horizontal.repeat(separatorWidth))}`;
 		lines.push("");
 		lines.push(` ${theme.bold(theme.fg("contentAccent", "Model Provider"))}`);
 		lines.push(...this.#renderModelStatus());
 		lines.push("");
 		if (this.profileStatus) {
-			lines.push(` ${theme.fg("muted", theme.boxRound.horizontal.repeat(separatorWidth))}`);
+			lines.push(separator);
 			lines.push("");
 			lines.push(` ${theme.bold(theme.fg("contentAccent", "F5 XC Profile"))}`);
 			lines.push(...this.#renderProfileStatus());
 			lines.push("");
 		}
+		if (this.#showUpdateSection()) {
+			lines.push(separator);
+			lines.push("");
+			lines.push(` ${theme.bold(theme.fg("contentAccent", "Update Available"))}`);
+			lines.push(...this.#renderUpdateStatus());
+			lines.push("");
+		}
+		if (this.#showChangelogSection()) {
+			lines.push(separator);
+			lines.push("");
+			lines.push(` ${theme.bold(theme.fg("contentAccent", "What's New"))}`);
+			lines.push(...this.#renderChangelogStatus());
+			lines.push("");
+		}
 		return lines;
+	}
+
+	#showUpdateSection(): boolean {
+		return this.updateStatus?.available === true;
+	}
+
+	#showChangelogSection(): boolean {
+		return this.changelogStatus?.hasNew === true;
+	}
+
+	#renderUpdateStatus(): string[] {
+		const latest = this.updateStatus?.latestVersion;
+		const label = latest ? `v${latest}` : "new version";
+		return [
+			` ${theme.fg("warning", "\u2191")} ${theme.fg("muted", label)}`,
+			`   ${theme.fg("dim", "Run")} ${theme.fg("contentAccent", "xcsh update")}`,
+		];
+	}
+
+	#renderChangelogStatus(): string[] {
+		const v = this.changelogStatus?.version ?? this.version;
+		return [
+			` ${theme.fg("success", "\u2605")} ${theme.fg("muted", `v${v}`)}`,
+			`   ${theme.fg("dim", "Run")} ${theme.fg("contentAccent", "/changelog")}`,
+		];
 	}
 
 	#renderModelStatus(): string[] {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -49,7 +49,7 @@ import type { HookSelectorComponent } from "./components/hook-selector";
 import type { PythonExecutionComponent } from "./components/python-execution";
 import { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
-import { WelcomeComponent } from "./components/welcome";
+import { type ChangelogStatus, type UpdateStatus, WelcomeComponent } from "./components/welcome";
 import { runWelcomeChecks } from "./components/welcome-checks";
 import { BtwController } from "./controllers/btw-controller";
 import { CommandController } from "./controllers/command-controller";
@@ -161,7 +161,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	#pendingSlashCommands: SlashCommand[] = [];
 	#cleanupUnsubscribe?: () => void;
 	readonly #version: string;
-	readonly #changelogMarkdown: string | undefined;
+	readonly #changelogStatus: ChangelogStatus | undefined;
+	readonly #initialUpdateStatus: UpdateStatus | undefined;
 	#planModePreviousTools: string[] | undefined;
 	#planModePreviousModelState: { model: Model; thinkingLevel?: ThinkingLevel } | undefined;
 	#pendingModelSwitch: { model: Model; thinkingLevel?: ThinkingLevel } | undefined;
@@ -192,7 +193,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	constructor(
 		session: AgentSession,
 		version: string,
-		changelogMarkdown: string | undefined = undefined,
+		changelogStatus: ChangelogStatus | undefined = undefined,
+		initialUpdateStatus: UpdateStatus | undefined = undefined,
 		setToolUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void = () => {},
 		lspServers?: import("../tools").LspStartupServerInfo[],
 		mcpManager?: import("../mcp").MCPManager,
@@ -204,7 +206,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.keybindings = KeybindingsManager.inMemory();
 		this.agent = session.agent;
 		this.#version = version;
-		this.#changelogMarkdown = changelogMarkdown;
+		this.#changelogStatus = changelogStatus;
+		this.#initialUpdateStatus = initialUpdateStatus;
 		this.#toolUiContextSetter = setToolUIContext;
 		this.lspServers = lspServers;
 		this.mcpManager = mcpManager;
@@ -321,28 +324,19 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		if (!startupQuiet) {
-			// Add welcome header
-			this.#welcomeComponent = new WelcomeComponent(this.#version, welcomeResult.model, welcomeResult.profile);
+			// Welcome box owns all startup notifications (model, profile, update, changelog)
+			this.#welcomeComponent = new WelcomeComponent(
+				this.#version,
+				welcomeResult.model,
+				welcomeResult.profile,
+				this.#initialUpdateStatus,
+				this.#changelogStatus,
+			);
 
 			// Setup UI layout
 			this.ui.addChild(new Spacer(1));
 			this.ui.addChild(this.#welcomeComponent);
 			this.ui.addChild(new Spacer(1));
-
-			// Add changelog if provided
-			if (this.#changelogMarkdown) {
-				this.ui.addChild(new DynamicBorder());
-				if (settings.get("collapseChangelog")) {
-					const condensedText = `Updated to v${this.#version}. Use ${theme.bold("/changelog")} to view full changelog.`;
-					this.ui.addChild(new Text(condensedText, 1, 0));
-				} else {
-					this.ui.addChild(new Text(theme.bold(theme.fg("contentAccent", "What's New")), 1, 0));
-					this.ui.addChild(new Spacer(1));
-					this.ui.addChild(new Markdown(this.#changelogMarkdown.trim(), 1, 0, getMarkdownTheme()));
-					this.ui.addChild(new Spacer(1));
-				}
-				this.ui.addChild(new DynamicBorder());
-			}
 		}
 
 		this.ui.addChild(this.chatContainer);
@@ -1130,8 +1124,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.setWorkingMessage(message);
 	}
 
-	showNewVersionNotification(newVersion: string): void {
-		this.#uiHelpers.showNewVersionNotification(newVersion);
+	setUpdateStatus(status: UpdateStatus | undefined): void {
+		this.#welcomeComponent?.setUpdateStatus(status);
+		this.ui.requestRender();
 	}
 
 	clearEditor(): void {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -137,7 +137,6 @@ export interface InteractiveModeContext {
 	showStatus(message: string, options?: { dim?: boolean }): void;
 	showError(message: string): void;
 	showWarning(message: string): void;
-	showNewVersionNotification(newVersion: string): void;
 	clearEditor(): void;
 	updatePendingMessagesDisplay(): void;
 	queueCompactionMessage(text: string, mode: "steer" | "followUp"): void;

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -7,7 +7,6 @@ import { BashExecutionComponent } from "../../modes/components/bash-execution";
 import { BranchSummaryMessageComponent } from "../../modes/components/branch-summary-message";
 import { CompactionSummaryMessageComponent } from "../../modes/components/compaction-summary-message";
 import { CustomMessageComponent } from "../../modes/components/custom-message";
-import { DynamicBorder } from "../../modes/components/dynamic-border";
 import {
 	createSystemGutter,
 	createTextGutter,
@@ -453,23 +452,6 @@ export class UiHelpers {
 		}
 		this.ctx.chatContainer.addChild(new Spacer(1));
 		this.ctx.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
-		this.ctx.ui.requestRender();
-	}
-
-	showNewVersionNotification(newVersion: string): void {
-		this.ctx.chatContainer.addChild(new Spacer(1));
-		this.ctx.chatContainer.addChild(new DynamicBorder(text => theme.fg("warning", text)));
-		this.ctx.chatContainer.addChild(
-			new Text(
-				theme.bold(theme.fg("warning", "Update Available")) +
-					"\n" +
-					theme.fg("muted", `New version ${newVersion} is available. Run: `) +
-					theme.fg("contentAccent", "xcsh update"),
-				1,
-				0,
-			),
-		);
-		this.ctx.chatContainer.addChild(new DynamicBorder(text => theme.fg("warning", text)));
 		this.ctx.ui.requestRender();
 	}
 

--- a/packages/coding-agent/test/interactive-mode-lsp-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-lsp-startup.test.ts
@@ -48,7 +48,7 @@ describe("InteractiveMode welcome banner status checks", () => {
 			modelRegistry,
 		});
 		eventBus = new EventBus();
-		mode = new InteractiveMode(session, "test", undefined, () => {}, undefined, undefined, eventBus);
+		mode = new InteractiveMode(session, "test", undefined, undefined, () => {}, undefined, undefined, eventBus);
 	});
 
 	afterEach(async () => {

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -67,10 +67,6 @@ describe("fork settings schema defaults (PRs #48, #68, theme commits)", () => {
 		expect(SETTINGS_SCHEMA["inspect_image.enabled"].default).toBe(true);
 	});
 
-	it("changelog collapsed by default (PR #48)", () => {
-		expect(SETTINGS_SCHEMA.collapseChangelog.default).toBe(true);
-	});
-
 	// PR #68 — "powerline defaults, handoff save"
 	it("compaction handoff saves to disk by default (PR #68)", () => {
 		expect(SETTINGS_SCHEMA["compaction.handoffSaveToDisk"].default).toBe(true);

--- a/packages/coding-agent/test/welcome-component.test.ts
+++ b/packages/coding-agent/test/welcome-component.test.ts
@@ -1,5 +1,9 @@
 import { beforeAll, describe, expect, it } from "bun:test";
-import { WelcomeComponent } from "@f5xc-salesdemos/xcsh/modes/components/welcome";
+import {
+	type ChangelogStatus,
+	type UpdateStatus,
+	WelcomeComponent,
+} from "@f5xc-salesdemos/xcsh/modes/components/welcome";
 import type { ModelStatus, WelcomeProfileStatus } from "@f5xc-salesdemos/xcsh/modes/components/welcome-checks";
 import { initTheme } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
 
@@ -137,6 +141,96 @@ describe("WelcomeComponent", () => {
 			expect(width).toBeLessThanOrEqual(98);
 			// But should still render (not empty)
 			expect(width).toBeGreaterThan(0);
+		});
+	});
+
+	describe("update and changelog sections", () => {
+		const model: ModelStatus = { state: "connected", provider: "anthropic", latencyMs: 100 };
+		const profile: WelcomeProfileStatus = { state: "connected", name: "prod", latencyMs: 42 };
+
+		it("renders Update Available section when updateStatus is available", () => {
+			const update: UpdateStatus = { available: true, latestVersion: "17.5.0" };
+			const c = new WelcomeComponent("17.4.1", model, profile, update);
+			const out = renderPlain(c).join("\n");
+			expect(out).toContain("Update Available");
+			expect(out).toContain("17.5.0");
+			expect(out).toContain("xcsh update");
+		});
+
+		it("hides Update Available section when updateStatus is omitted", () => {
+			const c = new WelcomeComponent("17.4.1", model, profile);
+			expect(renderPlain(c).join("\n")).not.toContain("Update Available");
+		});
+
+		it("hides Update Available section when updateStatus.available is false", () => {
+			const update: UpdateStatus = { available: false };
+			const c = new WelcomeComponent("17.4.1", model, profile, update);
+			expect(renderPlain(c).join("\n")).not.toContain("Update Available");
+		});
+
+		it("renders What's New section when changelogStatus.hasNew is true", () => {
+			const changelog: ChangelogStatus = { hasNew: true, version: "17.4.1" };
+			const c = new WelcomeComponent("17.4.1", model, profile, undefined, changelog);
+			const out = renderPlain(c).join("\n");
+			expect(out).toContain("What's New");
+			expect(out).toContain("17.4.1");
+			expect(out).toContain("/changelog");
+		});
+
+		it("hides What's New section when changelogStatus is omitted", () => {
+			const c = new WelcomeComponent("17.4.1", model, profile);
+			expect(renderPlain(c).join("\n")).not.toContain("What's New");
+		});
+
+		it("hides What's New section when changelogStatus.hasNew is false", () => {
+			const changelog: ChangelogStatus = { hasNew: false, version: "17.4.1" };
+			const c = new WelcomeComponent("17.4.1", model, profile, undefined, changelog);
+			expect(renderPlain(c).join("\n")).not.toContain("What's New");
+		});
+
+		it("setUpdateStatus reflects in the next render", () => {
+			const c = new WelcomeComponent("17.4.1", model, profile);
+			expect(renderPlain(c).join("\n")).not.toContain("Update Available");
+			c.setUpdateStatus({ available: true, latestVersion: "17.5.0" });
+			const out = renderPlain(c).join("\n");
+			expect(out).toContain("Update Available");
+			expect(out).toContain("17.5.0");
+		});
+
+		it("setChangelogStatus reflects in the next render", () => {
+			const c = new WelcomeComponent("17.4.1", model, profile);
+			expect(renderPlain(c).join("\n")).not.toContain("What's New");
+			c.setChangelogStatus({ hasNew: true, version: "17.4.1" });
+			const out = renderPlain(c).join("\n");
+			expect(out).toContain("What's New");
+			expect(out).toContain("/changelog");
+		});
+
+		it("renders both update and changelog sections together", () => {
+			const update: UpdateStatus = { available: true, latestVersion: "17.5.0" };
+			const changelog: ChangelogStatus = { hasNew: true, version: "17.4.1" };
+			const c = new WelcomeComponent("17.4.1", model, profile, update, changelog);
+			const out = renderPlain(c).join("\n");
+			expect(out).toContain("Update Available");
+			expect(out).toContain("What's New");
+		});
+
+		it("Update Available hint is not truncated at 80 columns", () => {
+			const update: UpdateStatus = { available: true, latestVersion: "17.5.0" };
+			const c = new WelcomeComponent("17.4.1", model, profile, update);
+			const lines = renderPlain(c, 80);
+			const hintLine = lines.find(l => l.includes("xcsh update"));
+			expect(hintLine).toBeDefined();
+			expect(hintLine).not.toContain("\u2026");
+		});
+
+		it("What's New hint is not truncated at 80 columns", () => {
+			const changelog: ChangelogStatus = { hasNew: true, version: "17.4.1" };
+			const c = new WelcomeComponent("17.4.1", model, profile, undefined, changelog);
+			const lines = renderPlain(c, 80);
+			const hintLine = lines.find(l => l.includes("/changelog"));
+			expect(hintLine).toBeDefined();
+			expect(hintLine).not.toContain("\u2026");
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Welcome box now owns all startup notifications. Update Available and What's New appear as right-column status sections alongside Model Provider and F5 XC Profile, replacing the separate `DynamicBorder` changelog block and the async chat-container update notice.
- `WelcomeComponent` gains `UpdateStatus` / `ChangelogStatus` inputs plus `setUpdateStatus` / `setChangelogStatus` setters so the async npm version check can populate the box post-paint when it arrives after the 500 ms startup race.
- `collapseChangelog` setting is removed — full markdown is still available via `/changelog`.

Closes #114.

## Test plan

- [x] 11 new tests in `test/welcome-component.test.ts` cover render, setters, and 80-col truncation guards for both sections (`bun test test/welcome-component.test.ts` → 27 pass)
- [x] Full coding-agent suite: 3181 pass / 0 fail / 400 skip (`bun test` in `packages/coding-agent`)
- [x] `bun run check` (biome + tsgo) — 0 errors, 2 pre-existing warnings unrelated to this PR
- [ ] Manual smoke: `xcsh` startup shows Update Available + What's New inside the welcome box when applicable
- [ ] Manual smoke: `xcsh --quiet` still suppresses the welcome box
- [ ] Manual smoke: slow/offline network — box paints within ~500 ms without the update row; late arrival updates in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)