### PR TITLE
fix(web-search): TDD coverage + validation for LiteLLM web_search API surface (#111)

### DIFF
--- a/packages/ai/src/utils/anthropic-auth.ts
+++ b/packages/ai/src/utils/anthropic-auth.ts
@@ -136,8 +136,10 @@ function readAnthropicAuthFromModelsYml(): AnthropicAuthConfig | null {
  * Strips known suffixes (`/` repeats, `/anthropic`, `/api/v1`, `/v1`) from a
  * LiteLLM base URL until no further suffix matches. Handles inputs like
  * `https://proxy/api/v1/anthropic` in any order.
+ *
+ * Exported for contract testing — see packages/ai/test/litellm-url-normalization.test.ts.
  */
-function normalizeLitellmBase(url: string): string {
+export function normalizeLitellmBase(url: string): string {
 	const suffixes = [/\/+$/, /\/anthropic$/, /\/api\/v\d+$/, /\/v\d+$/];
 	let prev: string;
 	let current = url;

--- a/packages/ai/test/anthropic-auth-models-yml.test.ts
+++ b/packages/ai/test/anthropic-auth-models-yml.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import { AuthCredentialStore } from "../src/auth-storage";
+import { findAnthropicAuth } from "../src/utils/anthropic-auth";
+
+const NEUTRALIZED_ENV: Record<string, string | undefined> = {
+	ANTHROPIC_API_KEY: undefined,
+	ANTHROPIC_BASE_URL: undefined,
+	ANTHROPIC_SEARCH_API_KEY: undefined,
+	ANTHROPIC_SEARCH_BASE_URL: undefined,
+	ANTHROPIC_OAUTH_TOKEN: undefined,
+	ANTHROPIC_FOUNDRY_API_KEY: undefined,
+	CLAUDE_CODE_USE_FOUNDRY: undefined,
+	LITELLM_BASE_URL: undefined,
+	LITELLM_API_KEY: undefined,
+};
+
+async function withEnv(overrides: Record<string, string | undefined>, fn: () => void | Promise<void>): Promise<void> {
+	const previous = new Map<string, string | undefined>();
+	for (const key of Object.keys(overrides)) {
+		previous.set(key, Bun.env[key]);
+	}
+	try {
+		for (const [key, value] of Object.entries(overrides)) {
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+		await fn();
+	} finally {
+		for (const [key, value] of previous.entries()) {
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+	}
+}
+
+function stubModelsYml(content: string | null): void {
+	const originalReadFileSync = fs.readFileSync.bind(fs);
+	vi.spyOn(fs, "readFileSync").mockImplementation(((...args: Parameters<typeof fs.readFileSync>) => {
+		if (typeof args[0] === "string" && args[0].endsWith("models.yml")) {
+			if (content === null) {
+				const err = Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" });
+				throw err;
+			}
+			return content;
+		}
+		return originalReadFileSync(...args);
+	}) as typeof fs.readFileSync);
+}
+
+beforeEach(() => {
+	vi.spyOn(AuthCredentialStore, "open").mockResolvedValue({
+		getApiKey: () => undefined,
+		listAuthCredentials: () => [],
+		replaceAuthCredentialsForProvider: () => {},
+		close: () => {},
+	} as unknown as AuthCredentialStore);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("findAnthropicAuth tier 6 — models.yml contract", () => {
+	it("resolves credentials when models.yml has a literal quoted apiKey", async () => {
+		stubModelsYml(
+			[
+				"providers:",
+				"  anthropic:",
+				'    baseUrl: "https://proxy.example.com/anthropic"',
+				'    apiKey: "sk-literal-test-123"',
+			].join("\n"),
+		);
+		await withEnv(NEUTRALIZED_ENV, async () => {
+			const auth = await findAnthropicAuth();
+			expect(auth).not.toBeNull();
+			expect(auth?.apiKey).toBe("sk-literal-test-123");
+			expect(auth?.baseUrl).toBe("https://proxy.example.com/anthropic");
+			expect(auth?.isOAuth).toBe(false);
+		});
+	});
+
+	it("resolves credentials via env-var reference when the referenced env var is set", async () => {
+		stubModelsYml(
+			[
+				"providers:",
+				"  anthropic:",
+				'    baseUrl: "https://proxy.example.com/anthropic"',
+				"    apiKey: LITELLM_API_KEY",
+			].join("\n"),
+		);
+		await withEnv({ ...NEUTRALIZED_ENV, LITELLM_API_KEY: "sk-env-resolved-456" }, async () => {
+			const auth = await findAnthropicAuth();
+			expect(auth).not.toBeNull();
+			expect(auth?.apiKey).toBe("sk-env-resolved-456");
+			expect(auth?.baseUrl).toBe("https://proxy.example.com/anthropic");
+		});
+	});
+
+	it("falls through to tier 7 when env-var referenced by apiKey is unset", async () => {
+		stubModelsYml(
+			[
+				"providers:",
+				"  anthropic:",
+				'    baseUrl: "https://proxy.example.com/anthropic"',
+				"    apiKey: UNDEFINED_ENV_VAR_XYZ",
+			].join("\n"),
+		);
+		await withEnv(
+			{
+				...NEUTRALIZED_ENV,
+				LITELLM_BASE_URL: "https://proxy.example.com",
+				LITELLM_API_KEY: "sk-tier7-fallback",
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth?.apiKey).toBe("sk-tier7-fallback");
+			},
+		);
+	});
+
+	it("skips shell-secret apiKey (tier 6 returns null)", async () => {
+		stubModelsYml(
+			[
+				"providers:",
+				"  anthropic:",
+				'    baseUrl: "https://proxy.example.com/anthropic"',
+				"    apiKey: !shellSecret get-key",
+			].join("\n"),
+		);
+		await withEnv(NEUTRALIZED_ENV, async () => {
+			const auth = await findAnthropicAuth();
+			expect(auth).toBeNull();
+		});
+	});
+
+	it("returns null when the anthropic provider block is absent", async () => {
+		stubModelsYml(
+			["providers:", "  openai:", '    baseUrl: "https://openai.example.com"', '    apiKey: "sk-openai"'].join("\n"),
+		);
+		await withEnv(NEUTRALIZED_ENV, async () => {
+			const auth = await findAnthropicAuth();
+			expect(auth).toBeNull();
+		});
+	});
+
+	it("returns null when models.yml does not exist and does not throw", async () => {
+		stubModelsYml(null);
+		await withEnv(NEUTRALIZED_ENV, async () => {
+			const auth = await findAnthropicAuth();
+			expect(auth).toBeNull();
+		});
+	});
+
+	it("returns null on malformed YAML without throwing", async () => {
+		stubModelsYml("::: not valid yaml {[broken");
+		await withEnv(NEUTRALIZED_ENV, async () => {
+			const auth = await findAnthropicAuth();
+			expect(auth).toBeNull();
+		});
+	});
+
+	it("returns null when anthropic block has baseUrl but no apiKey", async () => {
+		stubModelsYml(["providers:", "  anthropic:", '    baseUrl: "https://proxy.example.com/anthropic"'].join("\n"));
+		await withEnv(NEUTRALIZED_ENV, async () => {
+			const auth = await findAnthropicAuth();
+			expect(auth).toBeNull();
+		});
+	});
+
+	it("returns null when anthropic block has apiKey but no baseUrl", async () => {
+		stubModelsYml(["providers:", "  anthropic:", '    apiKey: "sk-test"'].join("\n"));
+		await withEnv(NEUTRALIZED_ENV, async () => {
+			const auth = await findAnthropicAuth();
+			expect(auth).toBeNull();
+		});
+	});
+
+	it("tier 6 wins over tier 7 when both are available", async () => {
+		stubModelsYml(
+			[
+				"providers:",
+				"  anthropic:",
+				'    baseUrl: "https://primary.example.com/anthropic"',
+				'    apiKey: "sk-models-yml-wins"',
+			].join("\n"),
+		);
+		await withEnv(
+			{
+				...NEUTRALIZED_ENV,
+				LITELLM_BASE_URL: "https://secondary.example.com",
+				LITELLM_API_KEY: "sk-tier7-loses",
+			},
+			async () => {
+				const auth = await findAnthropicAuth();
+				expect(auth?.apiKey).toBe("sk-models-yml-wins");
+				expect(auth?.baseUrl).toBe("https://primary.example.com/anthropic");
+			},
+		);
+	});
+
+	it("full-chain integration: only models.yml has credentials, no env, no DB", async () => {
+		stubModelsYml(
+			[
+				"providers:",
+				"  anthropic:",
+				'    baseUrl: "https://proxy.example.com/anthropic"',
+				'    apiKey: "sk-only-models-yml"',
+			].join("\n"),
+		);
+		await withEnv(NEUTRALIZED_ENV, async () => {
+			const auth = await findAnthropicAuth();
+			expect(auth).not.toBeNull();
+			expect(auth?.apiKey).toBe("sk-only-models-yml");
+			expect(auth?.baseUrl).toBe("https://proxy.example.com/anthropic");
+			expect(auth?.isOAuth).toBe(false);
+		});
+	});
+});

--- a/packages/ai/test/litellm-url-normalization.test.ts
+++ b/packages/ai/test/litellm-url-normalization.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeLitellmBase } from "../src/utils/anthropic-auth";
+
+type Case = { input: string; expected: string; description: string };
+
+const cases: Case[] = [
+	{ input: "https://proxy.example.com", expected: "https://proxy.example.com", description: "bare host" },
+	{ input: "https://proxy.example.com/", expected: "https://proxy.example.com", description: "trailing slash" },
+	{
+		input: "https://proxy.example.com///",
+		expected: "https://proxy.example.com",
+		description: "multiple trailing slashes",
+	},
+	{
+		input: "https://proxy.example.com/anthropic",
+		expected: "https://proxy.example.com",
+		description: "/anthropic suffix",
+	},
+	{
+		input: "https://proxy.example.com/anthropic/",
+		expected: "https://proxy.example.com",
+		description: "/anthropic/ with trailing slash",
+	},
+	{ input: "https://proxy.example.com/v1", expected: "https://proxy.example.com", description: "/v1 suffix" },
+	{
+		input: "https://proxy.example.com/api/v1",
+		expected: "https://proxy.example.com",
+		description: "/api/v1 suffix (Bug 3)",
+	},
+	{
+		input: "https://proxy.example.com/api/v1/",
+		expected: "https://proxy.example.com",
+		description: "/api/v1/ with trailing slash",
+	},
+	{
+		input: "https://proxy.example.com/api/v1/anthropic",
+		expected: "https://proxy.example.com",
+		description: "/api/v1/anthropic suffix",
+	},
+	{
+		input: "https://proxy.example.com/v1/anthropic",
+		expected: "https://proxy.example.com",
+		description: "/v1/anthropic suffix",
+	},
+	{
+		input: "https://proxy.example.com/v1/anthropic/v1",
+		expected: "https://proxy.example.com",
+		description: "/v1/anthropic/v1 mixed",
+	},
+	{
+		input: "https://proxy.example.com:8443/api/v1",
+		expected: "https://proxy.example.com:8443",
+		description: "port preserved",
+	},
+	{
+		input: "https://proxy.example.com/service-v1-legacy",
+		expected: "https://proxy.example.com/service-v1-legacy",
+		description: "partial-match in path segment NOT stripped",
+	},
+	{
+		input: "https://proxy.example.com//api/v1//anthropic",
+		expected: "https://proxy.example.com",
+		description: "double-slash misconfig collapses cleanly, does not yield empty host",
+	},
+	{ input: "", expected: "", description: "empty input returns empty string without throwing" },
+];
+
+describe("normalizeLitellmBase matrix", () => {
+	for (const { input, expected, description } of cases) {
+		it(`${description}: ${JSON.stringify(input)} → ${JSON.stringify(expected)}`, () => {
+			expect(normalizeLitellmBase(input)).toBe(expected);
+		});
+	}
+});
+
+describe("normalizeLitellmBase safety invariants", () => {
+	it("never returns an empty string for a non-empty input that has a host", () => {
+		expect(normalizeLitellmBase("https://proxy.example.com").length).toBeGreaterThan(0);
+		expect(normalizeLitellmBase("https://proxy.example.com//api/v1//anthropic").length).toBeGreaterThan(0);
+	});
+
+	it("is idempotent — applying twice yields the same result", () => {
+		for (const { input } of cases) {
+			const once = normalizeLitellmBase(input);
+			const twice = normalizeLitellmBase(once);
+			expect(twice).toBe(once);
+		}
+	});
+});

--- a/packages/coding-agent/src/web/search/errors.ts
+++ b/packages/coding-agent/src/web/search/errors.ts
@@ -1,0 +1,120 @@
+import { SearchProviderError } from "./types";
+
+export interface WebSearchError {
+	field?: string;
+	constraint?: string;
+	userMessage: string;
+	status?: number;
+	raw: unknown;
+}
+
+const FIELD_PATTERN = /tools\.\d+\.web_search_\d+\.([A-Za-z_][A-Za-z_0-9.]*?):\s*(.+?)(?:\n|$)/;
+
+const LITELLM_NOISE_PATTERNS: RegExp[] = [
+	/No fallback model group found for original model_group=[^\n]*/gi,
+	/Fallbacks=\[[^\]]*\][^\n]*/gi,
+	/Available Model Group Fallbacks=[^\n]*/gi,
+	/claude-haiku-[0-9a-z.-]+/gi,
+	/claude-[a-z0-9-]+-\d+/gi,
+	/model_group=[^\s,]+/gi,
+];
+
+function scrubLitellmNoise(text: string): string {
+	let cleaned = text;
+	for (const pattern of LITELLM_NOISE_PATTERNS) {
+		cleaned = cleaned.replace(pattern, "");
+	}
+	return cleaned
+		.replace(/\n{2,}/g, "\n")
+		.replace(/\s{2,}/g, " ")
+		.trim();
+}
+
+function fieldHint(field: string): string | undefined {
+	if (field === "user_location.country") {
+		return "user_location.country must be an ISO 3166-1 alpha-2 code (e.g. US, JP, GB)";
+	}
+	return undefined;
+}
+
+function extractRawMessage(input: unknown): string {
+	if (typeof input === "string") return input;
+	if (input instanceof SearchProviderError) return input.message;
+	if (input instanceof Error) return input.message;
+	if (input && typeof input === "object") {
+		const body = (input as { error?: { message?: unknown } }).error;
+		if (body && typeof body.message === "string") return body.message;
+	}
+	return "";
+}
+
+function tryParseJsonString(raw: string): unknown | undefined {
+	const trimmed = raw.trim();
+	if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return undefined;
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		return undefined;
+	}
+}
+
+function matchFieldPattern(text: string): RegExpMatchArray | null {
+	return text.match(FIELD_PATTERN);
+}
+
+export function parseWebSearchError(input: unknown): WebSearchError {
+	if (input instanceof SearchProviderError) {
+		if (input.status === 401 || input.status === 403) {
+			return {
+				status: input.status,
+				userMessage: `Web search authorization failed (${input.status}). Check API key or base URL.`,
+				raw: input,
+			};
+		}
+		if (input.status === 404) {
+			return {
+				status: input.status,
+				userMessage: "Web search returned 404 (model or endpoint not found).",
+				raw: input,
+			};
+		}
+	}
+
+	let bodyForFieldScan: unknown = input;
+	if (typeof input === "string") {
+		const parsed = tryParseJsonString(input);
+		if (parsed !== undefined) bodyForFieldScan = parsed;
+	}
+
+	const rawMessage = extractRawMessage(bodyForFieldScan);
+
+	if (rawMessage.length === 0) {
+		return {
+			userMessage: "web_search failed — no error detail available.",
+			raw: input,
+		};
+	}
+
+	const match = matchFieldPattern(rawMessage);
+	if (match) {
+		const field = match[1];
+		const constraint = match[2].trim();
+		const hint = fieldHint(field);
+		const userMessage = hint ? `web_search error: ${hint}.` : `web_search error: ${field} — ${constraint}.`;
+		return { field, constraint, userMessage, raw: input };
+	}
+
+	if (input instanceof Error && !(input instanceof SearchProviderError)) {
+		return {
+			userMessage: `web_search transport error: ${input.message}`,
+			raw: input,
+		};
+	}
+
+	const scrubbed = scrubLitellmNoise(rawMessage);
+	const userMessage =
+		scrubbed.length > 0
+			? `web_search failed — ${scrubbed}`
+			: "web_search failed — upstream error (details suppressed).";
+	return { userMessage, raw: input };
+}

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -30,19 +30,39 @@ import { SearchProviderError } from "./types";
 
 /** Web search tool parameters schema */
 export const webSearchSchema = Type.Object({
-	query: Type.String({ description: "Search query" }),
+	query: Type.String({ description: "Search query (non-empty, whitespace-only is rejected)" }),
 	recency: Type.Optional(
 		StringEnum(["day", "week", "month", "year"], {
-			description: "Recency filter (Brave, Perplexity)",
+			description: "Recency filter. Exhaustive enum — one of: day, week, month, year.",
 		}),
 	),
-	limit: Type.Optional(Type.Number({ description: "Max results to return" })),
-	max_tokens: Type.Optional(Type.Number({ description: "Maximum output tokens" })),
-	temperature: Type.Optional(Type.Number({ description: "Sampling temperature" })),
-	num_search_results: Type.Optional(Type.Number({ description: "Number of search results to retrieve" })),
-	allowed_domains: Type.Optional(Type.Array(Type.String(), { description: "Only return results from these domains" })),
-	blocked_domains: Type.Optional(Type.Array(Type.String(), { description: "Exclude results from these domains" })),
-	max_uses: Type.Optional(Type.Number({ description: "Maximum number of web searches per request" })),
+	limit: Type.Optional(
+		Type.Number({
+			description:
+				"Post-processing cap on the number of sources surfaced in the tool result. Positive integer. Controls output verbosity; see num_search_results for backend fetch count.",
+		}),
+	),
+	max_tokens: Type.Optional(Type.Number({ description: "Maximum output tokens. Positive integer." })),
+	temperature: Type.Optional(Type.Number({ description: "Sampling temperature between 0 and 2." })),
+	num_search_results: Type.Optional(
+		Type.Number({
+			description:
+				"Number of sources the backend should fetch. Positive integer. Controls provider fetch count; see limit for output-side trimming.",
+		}),
+	),
+	allowed_domains: Type.Optional(
+		Type.Array(Type.String(), {
+			description: "Only return results from these domains. Entries must be non-empty strings.",
+		}),
+	),
+	blocked_domains: Type.Optional(
+		Type.Array(Type.String(), {
+			description: "Exclude results from these domains. Entries must be non-empty strings.",
+		}),
+	),
+	max_uses: Type.Optional(
+		Type.Number({ description: "Maximum number of web searches per request. Positive integer." }),
+	),
 	user_location: Type.Optional(
 		Type.Object(
 			{

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -21,6 +21,7 @@ import webSearchSystemPrompt from "../../prompts/system/web-search.md" with { ty
 import webSearchDescription from "../../prompts/tools/web-search.md" with { type: "text" };
 import type { ToolSession } from "../../tools";
 import { formatAge } from "../../tools/render-utils";
+import { normalizeUserLocation, validateWebSearchParams, type WebSearchParams } from "./params";
 import { getSearchProvider, resolveProviderChain, type SearchProvider } from "./provider";
 import { renderSearchCall, renderSearchResult, type SearchRenderDetails } from "./render";
 import type { SearchProviderId, SearchResponse } from "./types";
@@ -47,7 +48,13 @@ export const webSearchSchema = Type.Object({
 				type: Type.Literal("approximate"),
 				city: Type.Optional(Type.String()),
 				region: Type.Optional(Type.String()),
-				country: Type.Optional(Type.String()),
+				country: Type.Optional(
+					Type.String({
+						minLength: 2,
+						maxLength: 2,
+						description: "ISO 3166-1 alpha-2 country code (e.g. US, JP, GB)",
+					}),
+				),
 				timezone: Type.Optional(Type.String()),
 			},
 			{ description: "Approximate user location for localized results" },
@@ -168,6 +175,19 @@ async function executeSearch(
 	_toolCallId: string,
 	params: SearchQueryParams,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; details: SearchRenderDetails }> {
+	const validation = validateWebSearchParams(params as WebSearchParams);
+	if (!validation.valid) {
+		const message = `web_search invalid parameter: ${validation.error}`;
+		return {
+			content: [{ type: "text" as const, text: `Error: ${message}` }],
+			details: { response: { provider: "none", sources: [] }, error: message },
+		};
+	}
+	const normalizedLocation = normalizeUserLocation(params.user_location);
+	const normalizedParams: SearchQueryParams = normalizedLocation
+		? { ...params, user_location: normalizedLocation }
+		: params;
+	params = normalizedParams;
 	const hasAnthropicOnlyParams =
 		params.allowed_domains?.length || params.blocked_domains?.length || params.max_uses || params.user_location;
 	const effectiveProvider =

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -21,6 +21,7 @@ import webSearchSystemPrompt from "../../prompts/system/web-search.md" with { ty
 import webSearchDescription from "../../prompts/tools/web-search.md" with { type: "text" };
 import type { ToolSession } from "../../tools";
 import { formatAge } from "../../tools/render-utils";
+import { parseWebSearchError } from "./errors";
 import { normalizeUserLocation, validateWebSearchParams, type WebSearchParams } from "./params";
 import { getSearchProvider, resolveProviderChain, type SearchProvider } from "./provider";
 import { renderSearchCall, renderSearchResult, type SearchRenderDetails } from "./render";
@@ -103,9 +104,9 @@ function formatProviderError(error: unknown, provider: SearchProvider): string {
 			}
 			return `${getSearchProvider(error.provider).label} authorization failed (${error.status}). Check API key or base URL.`;
 		}
-		return error.message;
+		return parseWebSearchError(error).userMessage;
 	}
-	if (error instanceof Error) return error.message;
+	if (error instanceof Error) return parseWebSearchError(error).userMessage;
 	return `Unknown error from ${provider.label}`;
 }
 

--- a/packages/coding-agent/src/web/search/params.ts
+++ b/packages/coding-agent/src/web/search/params.ts
@@ -1,0 +1,129 @@
+export type WebSearchRecency = "day" | "week" | "month" | "year";
+
+export interface WebSearchUserLocation {
+	type: "approximate";
+	city?: string;
+	region?: string;
+	country?: string;
+	timezone?: string;
+}
+
+export interface WebSearchParams {
+	query: string;
+	recency?: WebSearchRecency;
+	limit?: number;
+	max_tokens?: number;
+	temperature?: number;
+	num_search_results?: number;
+	max_uses?: number;
+	allowed_domains?: string[];
+	blocked_domains?: string[];
+	user_location?: WebSearchUserLocation;
+}
+
+export type ValidationResult = { valid: true } | { valid: false; error: string };
+
+const RECENCY_VALUES: readonly WebSearchRecency[] = ["day", "week", "month", "year"] as const;
+const ISO_ALPHA2 = /^[A-Za-z]{2}$/;
+
+function fail(error: string): ValidationResult {
+	return { valid: false, error };
+}
+
+function isPositiveInteger(value: number): boolean {
+	return Number.isInteger(value) && value > 0;
+}
+
+function validatePositiveInteger(name: string, value: number | undefined): ValidationResult | null {
+	if (value === undefined) return null;
+	if (!isPositiveInteger(value)) {
+		return fail(`${name} must be a positive integer (received ${value})`);
+	}
+	return null;
+}
+
+function validateDomainList(name: string, list: string[] | undefined): ValidationResult | null {
+	if (list === undefined) return null;
+	for (const entry of list) {
+		if (typeof entry !== "string" || entry.trim().length === 0) {
+			return fail(`${name} must not contain empty or whitespace-only entries`);
+		}
+	}
+	return null;
+}
+
+function validateUserLocation(loc: WebSearchUserLocation | undefined): ValidationResult | null {
+	if (loc === undefined) return null;
+	if (loc.type !== "approximate") {
+		return fail(`user_location.type must be "approximate" (received "${String(loc.type)}")`);
+	}
+	if (loc.country !== undefined) {
+		if (typeof loc.country !== "string" || !ISO_ALPHA2.test(loc.country)) {
+			return fail(
+				`user_location.country must be an ISO 3166-1 alpha-2 code (e.g. "US", "JP", "GB") (received "${String(loc.country)}")`,
+			);
+		}
+	}
+	if (loc.city !== undefined && (typeof loc.city !== "string" || loc.city.trim().length === 0)) {
+		return fail(`user_location.city must be a non-empty string`);
+	}
+	if (loc.region !== undefined && (typeof loc.region !== "string" || loc.region.trim().length === 0)) {
+		return fail(`user_location.region must be a non-empty string`);
+	}
+	if (loc.timezone !== undefined && (typeof loc.timezone !== "string" || loc.timezone.trim().length === 0)) {
+		return fail(`user_location.timezone must be a non-empty string`);
+	}
+	return null;
+}
+
+export function validateWebSearchParams(params: WebSearchParams): ValidationResult {
+	if (typeof params.query !== "string" || params.query.trim().length === 0) {
+		return fail("query must be a non-empty string");
+	}
+
+	if (params.recency !== undefined && !RECENCY_VALUES.includes(params.recency)) {
+		return fail(
+			`recency must be one of ${RECENCY_VALUES.map(v => `"${v}"`).join(", ")} (received "${String(params.recency)}")`,
+		);
+	}
+
+	const positiveIntegerFields: [string, number | undefined][] = [
+		["num_search_results", params.num_search_results],
+		["limit", params.limit],
+		["max_tokens", params.max_tokens],
+		["max_uses", params.max_uses],
+	];
+	for (const [name, value] of positiveIntegerFields) {
+		const result = validatePositiveInteger(name, value);
+		if (result) return result;
+	}
+
+	if (params.temperature !== undefined) {
+		if (typeof params.temperature !== "number" || params.temperature < 0 || params.temperature > 2) {
+			return fail(`temperature must be a number between 0 and 2 (received ${params.temperature})`);
+		}
+	}
+
+	for (const [name, list] of [
+		["allowed_domains", params.allowed_domains],
+		["blocked_domains", params.blocked_domains],
+	] as const) {
+		const result = validateDomainList(name, list);
+		if (result) return result;
+	}
+
+	const locResult = validateUserLocation(params.user_location);
+	if (locResult) return locResult;
+
+	return { valid: true };
+}
+
+export function normalizeUserLocation(loc: WebSearchUserLocation | undefined): WebSearchUserLocation | undefined {
+	if (loc === undefined) return undefined;
+	const next: WebSearchUserLocation = { type: loc.type };
+	if (loc.city !== undefined) next.city = loc.city;
+	if (loc.region !== undefined) next.region = loc.region;
+	if (loc.timezone !== undefined) next.timezone = loc.timezone;
+	if (loc.country !== undefined) next.country = loc.country.toUpperCase();
+	return next;
+}

--- a/packages/coding-agent/test/auto-config-websearch.test.ts
+++ b/packages/coding-agent/test/auto-config-websearch.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { YAML } from "bun";
+import { generateConfigYml } from "../src/config/auto-config";
+
+describe("generateConfigYml — web search provider contract", () => {
+	it("emits providers.webSearch: anthropic as a literal substring", () => {
+		const yml = generateConfigYml();
+		expect(yml).toContain("webSearch: anthropic");
+	});
+
+	it("parses back to an object with providers.webSearch === 'anthropic'", () => {
+		const yml = generateConfigYml();
+		const parsed = YAML.parse(yml) as { providers?: { webSearch?: string } };
+		expect(parsed.providers?.webSearch).toBe("anthropic");
+	});
+
+	it("places webSearch under the providers section (not top-level, not under web_search)", () => {
+		const yml = generateConfigYml();
+		const parsed = YAML.parse(yml) as Record<string, unknown>;
+		expect(parsed.webSearch).toBeUndefined();
+		expect(parsed.web_search).toBeUndefined();
+		expect((parsed.providers as { webSearch?: string } | undefined)?.webSearch).toBe("anthropic");
+	});
+
+	it("does not emit the dead key pattern `web_search:\\n  provider:`", () => {
+		const yml = generateConfigYml();
+		expect(yml).not.toMatch(/web_search\s*:\s*\n\s+provider\s*:/);
+	});
+
+	it("preserves the existing providers.image: openai guarantee", () => {
+		const yml = generateConfigYml();
+		const parsed = YAML.parse(yml) as { providers?: { image?: string } };
+		expect(parsed.providers?.image).toBe("openai");
+	});
+
+	it("keeps webSearch indented under providers (not at root)", () => {
+		const yml = generateConfigYml();
+		const lines = yml.split("\n");
+		const providersIdx = lines.findIndex(l => l.trim() === "providers:");
+		const webSearchIdx = lines.findIndex(l => l.trim().startsWith("webSearch:"));
+		expect(providersIdx).toBeGreaterThanOrEqual(0);
+		expect(webSearchIdx).toBeGreaterThan(providersIdx);
+		const wsLine = lines[webSearchIdx];
+		const indent = wsLine.length - wsLine.trimStart().length;
+		expect(indent).toBeGreaterThan(0);
+	});
+});

--- a/packages/coding-agent/test/tools/web-search-error-handling.test.ts
+++ b/packages/coding-agent/test/tools/web-search-error-handling.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "bun:test";
+import { parseWebSearchError } from "../../src/web/search/errors";
+import { SearchProviderError } from "../../src/web/search/types";
+
+describe("parseWebSearchError — Anthropic 400 field extraction", () => {
+	it("extracts user_location.country from invalid_request_error", () => {
+		const raw = {
+			error: {
+				type: "invalid_request_error",
+				message: "tools.0.web_search_20250305.user_location.country: String should have at most 2 characters",
+			},
+		};
+		const parsed = parseWebSearchError(raw);
+		expect(parsed.field).toBe("user_location.country");
+		expect(parsed.constraint).toContain("2 characters");
+		expect(parsed.userMessage).toContain("ISO 3166-1 alpha-2");
+		expect(parsed.userMessage.toLowerCase()).toContain("country");
+	});
+
+	it("extracts query field from a 400 on tools.0.web_search_20250305.query", () => {
+		const raw = {
+			error: {
+				type: "invalid_request_error",
+				message: "tools.0.web_search_20250305.query: String should not be empty",
+			},
+		};
+		const parsed = parseWebSearchError(raw);
+		expect(parsed.field).toBe("query");
+		expect(parsed.userMessage.toLowerCase()).toContain("query");
+	});
+
+	it("extracts a nested field without forcing the ISO alpha-2 hint", () => {
+		const raw = {
+			error: {
+				type: "invalid_request_error",
+				message: "tools.0.web_search_20250305.user_location.timezone: invalid timezone",
+			},
+		};
+		const parsed = parseWebSearchError(raw);
+		expect(parsed.field).toBe("user_location.timezone");
+		expect(parsed.userMessage).not.toContain("ISO 3166-1");
+	});
+});
+
+describe("parseWebSearchError — LiteLLM fallback chain scrubbing", () => {
+	it("strips `No fallback model group found for original model_group=...`", () => {
+		const raw = {
+			error: {
+				message:
+					"invalid_request_error\nNo fallback model group found for original model_group=claude-haiku-4-5-20251001. Fallbacks=[{'claude-haiku-4-5': ['claude-3-5-haiku-20241022']}]. Available Model Group Fallbacks=None",
+			},
+		};
+		const parsed = parseWebSearchError(raw);
+		expect(parsed.userMessage).not.toContain("fallback model group");
+		expect(parsed.userMessage.toLowerCase()).not.toContain("claude-haiku");
+		expect(parsed.userMessage).not.toContain("model_group");
+		expect(parsed.userMessage).not.toContain("Fallbacks=");
+	});
+
+	it("strips LiteLLM chain noise while keeping the underlying field error", () => {
+		const raw = {
+			error: {
+				message:
+					"tools.0.web_search_20250305.user_location.country: String should have at most 2 characters\nNo fallback model group found for original model_group=claude-haiku-4-5",
+			},
+		};
+		const parsed = parseWebSearchError(raw);
+		expect(parsed.field).toBe("user_location.country");
+		expect(parsed.userMessage).toContain("ISO 3166-1 alpha-2");
+		expect(parsed.userMessage).not.toContain("fallback");
+	});
+});
+
+describe("parseWebSearchError — generic + edge cases", () => {
+	it("returns a non-empty generic message for an unparseable body", () => {
+		const parsed = parseWebSearchError({ error: { message: "something broke" } });
+		expect(parsed.userMessage.length).toBeGreaterThan(0);
+		expect(parsed.field).toBeUndefined();
+	});
+
+	it("surfaces a transport-layer Error without a parsed field", () => {
+		const err = new Error("ECONNREFUSED 127.0.0.1:443");
+		const parsed = parseWebSearchError(err);
+		expect(parsed.userMessage).toContain("ECONNREFUSED");
+		expect(parsed.field).toBeUndefined();
+	});
+
+	it("accepts a JSON string body", () => {
+		const rawText = JSON.stringify({
+			error: {
+				type: "invalid_request_error",
+				message: "tools.0.web_search_20250305.query: must be non-empty",
+			},
+		});
+		const parsed = parseWebSearchError(rawText);
+		expect(parsed.field).toBe("query");
+	});
+
+	it("handles an empty body without throwing", () => {
+		const parsed = parseWebSearchError("");
+		expect(parsed.userMessage.length).toBeGreaterThan(0);
+		expect(parsed.field).toBeUndefined();
+	});
+});
+
+describe("parseWebSearchError — preserves existing auth branches", () => {
+	it("surfaces 401 with authorization context", () => {
+		const err = new SearchProviderError("anthropic", "Anthropic API error (401): unauthorized", 401);
+		const parsed = parseWebSearchError(err);
+		expect(parsed.status).toBe(401);
+		expect(parsed.userMessage.toLowerCase()).toContain("auth");
+	});
+
+	it("surfaces 403 with authorization context", () => {
+		const err = new SearchProviderError("anthropic", "Anthropic API error (403): forbidden", 403);
+		const parsed = parseWebSearchError(err);
+		expect(parsed.status).toBe(403);
+		expect(parsed.userMessage.toLowerCase()).toContain("auth");
+	});
+
+	it("keeps 404 language intact for model-not-found", () => {
+		const err = new SearchProviderError("anthropic", "Anthropic API error (404): model not found", 404);
+		const parsed = parseWebSearchError(err);
+		expect(parsed.status).toBe(404);
+		expect(parsed.userMessage.toLowerCase()).toContain("404");
+	});
+});

--- a/packages/coding-agent/test/tools/web-search-params.test.ts
+++ b/packages/coding-agent/test/tools/web-search-params.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeUserLocation, validateWebSearchParams, type WebSearchParams } from "../../src/web/search/params";
+
+function expectValid(params: WebSearchParams): void {
+	const result = validateWebSearchParams(params);
+	if (!result.valid) {
+		throw new Error(`Expected valid params, got error: ${result.error}`);
+	}
+	expect(result.valid).toBe(true);
+}
+
+function expectInvalid(params: WebSearchParams, errorSubstring: string): void {
+	const result = validateWebSearchParams(params);
+	expect(result.valid).toBe(false);
+	if (result.valid) return;
+	expect(result.error.toLowerCase()).toContain(errorSubstring.toLowerCase());
+}
+
+describe("validateWebSearchParams — query", () => {
+	it("accepts a non-empty query", () => {
+		expectValid({ query: "hello" });
+	});
+
+	it("accepts a single-character query", () => {
+		expectValid({ query: "h" });
+	});
+
+	it("rejects an empty query", () => {
+		expectInvalid({ query: "" }, "query");
+	});
+
+	it("rejects a whitespace-only query", () => {
+		expectInvalid({ query: "   \t\n" }, "query");
+	});
+});
+
+describe("validateWebSearchParams — recency", () => {
+	it.each(["day", "week", "month", "year"] as const)("accepts recency=%s", recency => {
+		expectValid({ query: "test", recency });
+	});
+
+	it("rejects an unknown recency value", () => {
+		expectInvalid({ query: "test", recency: "hour" as unknown as WebSearchParams["recency"] }, "recency");
+	});
+
+	it("rejects an empty recency string", () => {
+		expectInvalid({ query: "test", recency: "" as unknown as WebSearchParams["recency"] }, "recency");
+	});
+});
+
+describe("validateWebSearchParams — num_search_results", () => {
+	it("accepts positive integers", () => {
+		expectValid({ query: "test", num_search_results: 5 });
+	});
+
+	it("accepts large positive integers (no artificial cap)", () => {
+		expectValid({ query: "test", num_search_results: 1000 });
+	});
+
+	it("rejects zero", () => {
+		expectInvalid({ query: "test", num_search_results: 0 }, "num_search_results");
+	});
+
+	it("rejects negative values", () => {
+		expectInvalid({ query: "test", num_search_results: -1 }, "num_search_results");
+	});
+
+	it("rejects non-integer values", () => {
+		expectInvalid({ query: "test", num_search_results: 3.5 }, "num_search_results");
+	});
+});
+
+describe("validateWebSearchParams — limit", () => {
+	it("accepts positive integers", () => {
+		expectValid({ query: "test", limit: 3 });
+	});
+
+	it("rejects zero", () => {
+		expectInvalid({ query: "test", limit: 0 }, "limit");
+	});
+
+	it("rejects negative values", () => {
+		expectInvalid({ query: "test", limit: -5 }, "limit");
+	});
+
+	it("rejects non-integer values", () => {
+		expectInvalid({ query: "test", limit: 2.5 }, "limit");
+	});
+});
+
+describe("validateWebSearchParams — max_tokens", () => {
+	it("accepts positive integers", () => {
+		expectValid({ query: "test", max_tokens: 200 });
+	});
+
+	it("rejects zero", () => {
+		expectInvalid({ query: "test", max_tokens: 0 }, "max_tokens");
+	});
+
+	it("rejects negative values", () => {
+		expectInvalid({ query: "test", max_tokens: -10 }, "max_tokens");
+	});
+});
+
+describe("validateWebSearchParams — temperature", () => {
+	it.each([0, 0.5, 1, 1.5, 2])("accepts temperature=%s", temperature => {
+		expectValid({ query: "test", temperature });
+	});
+
+	it("rejects negative temperature", () => {
+		expectInvalid({ query: "test", temperature: -0.1 }, "temperature");
+	});
+
+	it("rejects temperature above 2", () => {
+		expectInvalid({ query: "test", temperature: 2.1 }, "temperature");
+	});
+});
+
+describe("validateWebSearchParams — max_uses", () => {
+	it("accepts positive integers", () => {
+		expectValid({ query: "test", max_uses: 3 });
+	});
+
+	it("rejects zero", () => {
+		expectInvalid({ query: "test", max_uses: 0 }, "max_uses");
+	});
+
+	it("rejects negative values", () => {
+		expectInvalid({ query: "test", max_uses: -2 }, "max_uses");
+	});
+});
+
+describe("validateWebSearchParams — allowed_domains / blocked_domains", () => {
+	it("accepts an empty allowed_domains array", () => {
+		expectValid({ query: "test", allowed_domains: [] });
+	});
+
+	it("accepts an array of non-empty domain strings", () => {
+		expectValid({ query: "test", allowed_domains: ["anthropic.com", "docs.anthropic.com"] });
+	});
+
+	it("rejects allowed_domains containing an empty string", () => {
+		expectInvalid({ query: "test", allowed_domains: ["anthropic.com", ""] }, "allowed_domains");
+	});
+
+	it("accepts an empty blocked_domains array", () => {
+		expectValid({ query: "test", blocked_domains: [] });
+	});
+
+	it("rejects blocked_domains containing whitespace-only string", () => {
+		expectInvalid({ query: "test", blocked_domains: ["  "] }, "blocked_domains");
+	});
+});
+
+describe("validateWebSearchParams — user_location.country", () => {
+	it("accepts an ISO 3166-1 alpha-2 uppercase code", () => {
+		expectValid({
+			query: "test",
+			user_location: { type: "approximate", country: "JP" },
+		});
+	});
+
+	it("accepts an ISO 3166-1 alpha-2 lowercase code (will be normalized)", () => {
+		expectValid({
+			query: "test",
+			user_location: { type: "approximate", country: "jp" },
+		});
+	});
+
+	it("rejects a full country name", () => {
+		expectInvalid({ query: "test", user_location: { type: "approximate", country: "Japan" } }, "ISO 3166-1 alpha-2");
+	});
+
+	it("rejects a single-character country code", () => {
+		expectInvalid({ query: "test", user_location: { type: "approximate", country: "J" } }, "ISO 3166-1 alpha-2");
+	});
+
+	it("rejects an empty country string", () => {
+		expectInvalid({ query: "test", user_location: { type: "approximate", country: "" } }, "ISO 3166-1 alpha-2");
+	});
+
+	it("accepts user_location without country (optional)", () => {
+		expectValid({
+			query: "test",
+			user_location: { type: "approximate", city: "Tokyo" },
+		});
+	});
+});
+
+describe("validateWebSearchParams — user_location fields", () => {
+	it("accepts a non-empty city", () => {
+		expectValid({
+			query: "test",
+			user_location: { type: "approximate", city: "Tokyo" },
+		});
+	});
+
+	it("rejects an empty city", () => {
+		expectInvalid({ query: "test", user_location: { type: "approximate", city: "" } }, "city");
+	});
+
+	it("accepts a non-empty region", () => {
+		expectValid({
+			query: "test",
+			user_location: { type: "approximate", region: "Tokyo" },
+		});
+	});
+
+	it("rejects an empty region", () => {
+		expectInvalid({ query: "test", user_location: { type: "approximate", region: "" } }, "region");
+	});
+
+	it("accepts an IANA-style timezone", () => {
+		expectValid({
+			query: "test",
+			user_location: { type: "approximate", timezone: "Asia/Tokyo" },
+		});
+	});
+
+	it("rejects an empty timezone", () => {
+		expectInvalid({ query: "test", user_location: { type: "approximate", timezone: "" } }, "timezone");
+	});
+
+	it("accepts user_location omitted entirely", () => {
+		expectValid({ query: "test" });
+	});
+
+	it("rejects user_location.type other than 'approximate'", () => {
+		expectInvalid(
+			{
+				query: "test",
+				user_location: {
+					type: "precise" as unknown as "approximate",
+					country: "JP",
+				},
+			},
+			"approximate",
+		);
+	});
+});
+
+describe("normalizeUserLocation", () => {
+	it("passes valid uppercase ISO codes unchanged", () => {
+		const loc = normalizeUserLocation({ type: "approximate", country: "US" });
+		expect(loc.country).toBe("US");
+	});
+
+	it("uppercases a lowercase ISO code", () => {
+		const loc = normalizeUserLocation({ type: "approximate", country: "jp" });
+		expect(loc.country).toBe("JP");
+	});
+
+	it("uppercases a mixed-case ISO code", () => {
+		const loc = normalizeUserLocation({ type: "approximate", country: "gB" });
+		expect(loc.country).toBe("GB");
+	});
+
+	it("preserves city / region / timezone verbatim during normalization", () => {
+		const loc = normalizeUserLocation({
+			type: "approximate",
+			city: "Tokyo",
+			region: "Kantō",
+			country: "jp",
+			timezone: "Asia/Tokyo",
+		});
+		expect(loc.city).toBe("Tokyo");
+		expect(loc.region).toBe("Kantō");
+		expect(loc.timezone).toBe("Asia/Tokyo");
+		expect(loc.country).toBe("JP");
+	});
+
+	it("returns undefined when input is undefined", () => {
+		expect(normalizeUserLocation(undefined)).toBeUndefined();
+	});
+
+	it("does not mutate its input", () => {
+		const input = { type: "approximate" as const, country: "jp" };
+		normalizeUserLocation(input);
+		expect(input.country).toBe("jp");
+	});
+});

--- a/packages/coding-agent/test/tools/web-search-params.test.ts
+++ b/packages/coding-agent/test/tools/web-search-params.test.ts
@@ -242,17 +242,17 @@ describe("validateWebSearchParams — user_location fields", () => {
 describe("normalizeUserLocation", () => {
 	it("passes valid uppercase ISO codes unchanged", () => {
 		const loc = normalizeUserLocation({ type: "approximate", country: "US" });
-		expect(loc.country).toBe("US");
+		expect(loc?.country).toBe("US");
 	});
 
 	it("uppercases a lowercase ISO code", () => {
 		const loc = normalizeUserLocation({ type: "approximate", country: "jp" });
-		expect(loc.country).toBe("JP");
+		expect(loc?.country).toBe("JP");
 	});
 
 	it("uppercases a mixed-case ISO code", () => {
 		const loc = normalizeUserLocation({ type: "approximate", country: "gB" });
-		expect(loc.country).toBe("GB");
+		expect(loc?.country).toBe("GB");
 	});
 
 	it("preserves city / region / timezone verbatim during normalization", () => {
@@ -263,10 +263,10 @@ describe("normalizeUserLocation", () => {
 			country: "jp",
 			timezone: "Asia/Tokyo",
 		});
-		expect(loc.city).toBe("Tokyo");
-		expect(loc.region).toBe("Kantō");
-		expect(loc.timezone).toBe("Asia/Tokyo");
-		expect(loc.country).toBe("JP");
+		expect(loc?.city).toBe("Tokyo");
+		expect(loc?.region).toBe("Kantō");
+		expect(loc?.timezone).toBe("Asia/Tokyo");
+		expect(loc?.country).toBe("JP");
 	});
 
 	it("returns undefined when input is undefined", () => {


### PR DESCRIPTION
## Summary

Reopens-comment remediation for #111. PR #112 fixed the three root-cause auth/config bugs (models.yml tier 6, `providers.webSearch` config key, LiteLLM URL normalization), but end-to-end validation surfaced a remaining defect (`user_location.country` accepts full country names → HTTP 400 with LiteLLM chain noise leaked) and the structural gap that every PR #112 bug mapped to a test file that did not exist before implementation.

This PR is the TDD-first response:

- 5 new test files written **before** the implementation they exercise
- 2 new source modules (`params.ts`, `errors.ts`) created only as the tests demanded them
- 1 schema tightening (`user_location.country` → `minLength: 2 / maxLength: 2`)
- 1 error-handling rewrite (delegates to a field-extracting parser that scrubs LiteLLM fallback-chain noise)
- 1 export (`normalizeLitellmBase`) so the URL matrix can test it directly
- Tool-schema description strings updated for `query`, `recency`, `limit` vs `num_search_results`, `max_tokens`, `max_uses`, `temperature`, and domain lists

### Commit stack (red → green pairing preserved for audit)

1. `test(web-search): red-phase parameter validation contract` — 57 cases across every documented `web_search` parameter
2. `feat(web-search): validate params before dispatch + ISO-alpha-2 country` — adds `params.ts`, wires `validateWebSearchParams` + `normalizeUserLocation` into `executeSearch`, tightens schema
3. `test(web-search): red-phase error parsing contract` — 12 cases covering Anthropic 400 field extraction, LiteLLM scrub, transport + unparseable + auth branches
4. `feat(web-search): structured error parser + LiteLLM noise scrub` — adds `errors.ts`, rewrites `formatProviderError`
5. `test(ai): lock down tier-6 models.yml auth contract` — 11 cases across literal / envVar / shellSecret / missing / malformed / partial blocks + full-chain integration (the Bug 1 condition)
6. `test(ai): LiteLLM URL normalization matrix + export` — 15 cases + idempotence + non-empty-host invariants
7. `test(coding-agent): auto-config providers.webSearch contract` — 6 cases asserting correct nesting, absence of the dead `web_search.provider` key, and preservation of `providers.image: openai`
8. `docs(web-search): document parameter constraints in tool schema` — surface the runtime contract to the LLM

### Coverage added

| New test file | Bug it prevents |
|---|---|
| `test/tools/web-search-params.test.ts` | T9 country-name defect; any future silent acceptance of invalid parameter values |
| `test/tools/web-search-error-handling.test.ts` | Raw 400 passthrough leaking LiteLLM fallback chain |
| `test/anthropic-auth-models-yml.test.ts` | Regression of PR #112 Bug 1 (no tier reading models.yml) |
| `test/litellm-url-normalization.test.ts` | Regression of PR #112 Bug 3 (`/api/v1` case), plus 13 other URL shapes |
| `test/auto-config-websearch.test.ts` | Regression of PR #112 Bug 2 (dead `web_search.provider` key) |

## Test plan

- [x] `bun --cwd=packages/coding-agent test test/tools/web-search-params.test.ts` — 57 pass
- [x] `bun --cwd=packages/coding-agent test test/tools/web-search-error-handling.test.ts` — 12 pass
- [x] `bun --cwd=packages/ai test test/anthropic-auth-models-yml.test.ts` — 11 pass
- [x] `bun --cwd=packages/ai test test/litellm-url-normalization.test.ts` — 17 pass
- [x] `bun --cwd=packages/coding-agent test test/auto-config-websearch.test.ts` — 6 pass
- [x] Regression: `bun --cwd=packages/ai test` — 566 pass, 0 fail
- [x] Regression: `bun --cwd=packages/coding-agent test test/tools/web-search-anthropic.test.ts test/tools/web-search-provider-chain.test.ts test/auto-config.test.ts test/auto-config-read.test.ts test/anthropic-auth-litellm.test.ts test/anthropic-auth-resilience.test.ts` — all green
- [ ] Manual smoke: replay reopen-comment T9 against live LiteLLM proxy with `country: "Japan"` (expect local rejection naming ISO-3166-1 alpha-2) then `country: "JP"` (expect success)

### Known pre-existing test noise (not caused by this PR)

Full `packages/coding-agent` run reports 3 intermittent timeout failures in `test/sdk-skills.test.ts` under the `createAgentSession skills option` describe block. In isolation all 5 tests pass (23.3s). Verified against `origin/main` in memory obs 80-81, 117, 119 — the flake is pre-existing and orthogonal to this work.

Closes #111 (pending live-proxy smoke test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)