### PR TITLE
fix(status-line): track assistant cwd from event, not global shellPwd (#118)

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -61,6 +61,7 @@ export class StatusLineComponent implements Component {
 	#subagentCount: number = 0;
 	#sessionStartTime: number = Date.now();
 	#planModeStatus: { enabled: boolean; paused: boolean } | null = null;
+	#cwd: string = getShellPwd();
 
 	// Git status caching (1s TTL)
 	#cachedGitStatus: {
@@ -134,7 +135,8 @@ export class StatusLineComponent implements Component {
 
 	watchCwd(eventBus: EventBus): void {
 		this.#cwdUnsubscribe?.();
-		this.#cwdUnsubscribe = eventBus.on("cwd:changed", () => {
+		this.#cwdUnsubscribe = eventBus.on("cwd:changed", newCwd => {
+			if (typeof newCwd === "string") this.#cwd = newCwd;
 			this.#invalidateGitCaches();
 			this.#setupGitWatcher();
 			this.#onStatusChanged?.();
@@ -147,7 +149,7 @@ export class StatusLineComponent implements Component {
 			this.#gitWatcher = null;
 		}
 
-		const gitHeadPath = git.repo.resolveSync(getShellPwd())?.headPath ?? null;
+		const gitHeadPath = git.repo.resolveSync(this.#cwd)?.headPath ?? null;
 		if (!gitHeadPath) return;
 
 		try {
@@ -177,13 +179,20 @@ export class StatusLineComponent implements Component {
 		this.#invalidateGitCaches();
 	}
 
+	/** Update the displayed working directory (e.g. after a user !cd command). */
+	setCwd(cwd: string): void {
+		this.#cwd = cwd;
+		this.#invalidateGitCaches();
+		this.#setupGitWatcher();
+	}
+
 	#invalidateGitCaches(): void {
 		this.#cachedBranch = undefined;
 		this.#cachedBranchRepoId = undefined;
 		this.#cachedPrContext = undefined;
 	}
 	#getCurrentBranch(): string | null {
-		const head = git.head.resolveSync(getShellPwd());
+		const head = git.head.resolveSync(this.#cwd);
 		const gitHeadPath = head?.headPath ?? null;
 		if (this.#cachedBranch !== undefined && this.#cachedBranchRepoId === gitHeadPath) {
 			return this.#cachedBranch;
@@ -204,7 +213,7 @@ export class StatusLineComponent implements Component {
 		if (this.#defaultBranch === undefined) {
 			this.#defaultBranch = "main";
 			(async () => {
-				const resolved = await git.branch.default(getShellPwd());
+				const resolved = await git.branch.default(this.#cwd);
 				if (resolved) {
 					this.#defaultBranch = resolved;
 					if (this.#onBranchChange) {
@@ -235,7 +244,7 @@ export class StatusLineComponent implements Component {
 		(async () => {
 			try {
 				// Prefer gitstatusd daemon (10x faster than git CLI)
-				const gsResult = await queryGitStatus(getShellPwd());
+				const gsResult = await queryGitStatus(this.#cwd);
 				if (gsResult) {
 					this.#cachedGitStatus = {
 						staged: gsResult.staged,
@@ -249,7 +258,7 @@ export class StatusLineComponent implements Component {
 					};
 				} else {
 					// Fallback to git CLI
-					const summary = await git.status.summary(getShellPwd());
+					const summary = await git.status.summary(this.#cwd);
 					this.#cachedGitStatus = summary
 						? { ...summary, conflicted: 0, ahead: 0, behind: 0, stashes: 0, action: "" }
 						: null;
@@ -299,7 +308,7 @@ export class StatusLineComponent implements Component {
 			};
 			try {
 				// Requires `gh repo set-default` to be configured; fails gracefully if not
-				const result = await $`gh pr view --json number,url`.cwd(getShellPwd()).quiet().nothrow();
+				const result = await $`gh pr view --json number,url`.cwd(this.#cwd).quiet().nothrow();
 				if (result.exitCode !== 0) {
 					setCachedPr(null);
 					return;
@@ -383,7 +392,7 @@ export class StatusLineComponent implements Component {
 		return {
 			session: this.session,
 			width,
-			cwd: getShellPwd(),
+			cwd: this.#cwd,
 			options: this.#resolveSettings().segmentOptions ?? {},
 			planMode: this.#planModeStatus,
 			usageStats,

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -739,7 +739,7 @@ export class CommandController {
 			// Update CWD if the shell changed directory (e.g. via cd)
 			if (result.newCwd && result.newCwd !== this.ctx.sessionManager.getCwd()) {
 				setShellPwd(result.newCwd);
-				this.ctx.statusLine.invalidate();
+				this.ctx.statusLine.setCwd(result.newCwd);
 				this.ctx.ui.requestRender();
 			}
 

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -393,3 +393,46 @@ describe("Provider registration: env var fallback must not send literal name (PR
 		expect(probeSection).toContain("apiKeyLiteral");
 	});
 });
+
+// ─── Statusline CWD Tracking (#118, #120) ─────────────────────────────────
+
+describe("statusline tracks assistant cwd, not global shellPwd (PR #120 regression, #118)", () => {
+	it("status-line.ts owns a #cwd field instead of reading getShellPwd() in #buildSegmentContext", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/modes/components/status-line.ts"), "utf8");
+		// The component must track cwd internally, not read the global
+		expect(src).toContain("#cwd: string = getShellPwd()");
+		// #buildSegmentContext must use the instance field, not the global
+		expect(src).toContain("cwd: this.#cwd");
+	});
+
+	it("status-line.ts exposes setCwd for callers without an event bus", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/modes/components/status-line.ts"), "utf8");
+		expect(src).toContain("setCwd(cwd: string): void");
+	});
+
+	it("watchCwd captures the cwd:changed event payload into #cwd", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/modes/components/status-line.ts"), "utf8");
+		// The handler must read the event value and store it
+		expect(src).toContain('eventBus.on("cwd:changed", newCwd =>');
+		expect(src).toContain("this.#cwd = newCwd");
+	});
+
+	it("command-controller.ts uses setCwd instead of invalidate for cwd changes", async () => {
+		const src = await fs.readFile(
+			path.join(import.meta.dir, "../src/modes/controllers/command-controller.ts"),
+			"utf8",
+		);
+		expect(src).toContain("this.ctx.statusLine.setCwd(result.newCwd)");
+	});
+
+	it("status-line.ts git queries resolve against this.#cwd, not getShellPwd()", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/modes/components/status-line.ts"), "utf8");
+		// All git call sites must use the instance cwd, not the global
+		expect(src).toContain("git.repo.resolveSync(this.#cwd)");
+		expect(src).toContain("git.head.resolveSync(this.#cwd)");
+		expect(src).toContain("git.branch.default(this.#cwd)");
+		expect(src).toContain("queryGitStatus(this.#cwd)");
+		expect(src).toContain("git.status.summary(this.#cwd)");
+		expect(src).toContain(".cwd(this.#cwd)");
+	});
+});

--- a/packages/coding-agent/test/status-line-cwd-watch.test.ts
+++ b/packages/coding-agent/test/status-line-cwd-watch.test.ts
@@ -60,14 +60,16 @@ describe("StatusLineComponent.watchCwd", () => {
 		expect(changed).toBe(0);
 	});
 
-	it("renders the new shellPwd in the top border after cwd:changed", () => {
-		// Regression for #118: setShellPwd + cwd:changed must propagate through
-		// #buildSegmentContext so the next getTopBorder() reflects the new cwd.
+	it("renders the cwd from the cwd:changed event payload, not getShellPwd()", () => {
+		// Regression for #118: the statusline must track the cwd carried by the
+		// cwd:changed event (the assistant's working directory), not the global
+		// shellPwd. The event payload and shellPwd can diverge when a user !cd
+		// command updates shellPwd but the assistant's cwd stays unchanged.
 		//
 		// Use persistent, pid-scoped directories rather than mkdtempSync with
 		// cleanup. getTopBorder() kicks off fire-and-forget async IIFEs inside
 		// the component (#getGitStatus, #isDefaultBranch) that spawn `git` with
-		// cwd=getShellPwd(); if the dir is rm'd before those subprocesses run,
+		// the tracked cwd; if the dir is rm'd before those subprocesses run,
 		// posix_spawn fails with ENOENT and the rejection surfaces in whatever
 		// test happens to run next. Persistent dirs let those queries spawn
 		// cleanly, return "not a repository," and be handled by the existing
@@ -84,8 +86,35 @@ describe("StatusLineComponent.watchCwd", () => {
 			const bus = new EventBus();
 			component.watchCwd(bus);
 
-			setShellPwd(dirB);
+			// Only emit the event -- do NOT call setShellPwd(dirB).
+			// This proves the statusline reads the event payload, not the global.
 			bus.emit("cwd:changed", dirB);
+
+			const rendered = component.getTopBorder(200).content;
+			const stripped = rendered.replace(/\u001b\[[0-9;]*m/g, "");
+
+			expect(stripped).toContain(path.basename(dirB));
+			expect(stripped).not.toContain(path.basename(dirA));
+
+			component.dispose();
+		} finally {
+			setShellPwd(originalShellPwd);
+		}
+	});
+
+	it("setCwd updates the displayed directory without an event bus", () => {
+		const originalShellPwd = getShellPwd();
+		const dirA = path.join(os.tmpdir(), `xcsh-cwd-setcwd-a-${process.pid}`);
+		const dirB = path.join(os.tmpdir(), `xcsh-cwd-setcwd-b-${process.pid}`);
+		fs.mkdirSync(dirA, { recursive: true });
+		fs.mkdirSync(dirB, { recursive: true });
+
+		try {
+			setShellPwd(dirA);
+			const component = new StatusLineComponent(makeSession());
+
+			// setCwd should update the displayed path without eventBus.
+			component.setCwd(dirB);
 
 			const rendered = component.getTopBorder(200).content;
 			const stripped = rendered.replace(/\u001b\[[0-9;]*m/g, "");


### PR DESCRIPTION
Fixes #118.

## Problem

PR #120 changed the statusline path segment to read `getShellPwd()` instead of `getProjectDir()`. This fixed the original stale-cwd bug, but introduced a regression: the statusline now follows the **persistent shell's pwd** rather than the **AI assistant's effective working directory**. These diverge when:

- A user `!cd` command (via command-controller) updates `shellPwd` but not `toolSession.cwd`
- A subagent bash command updates the global `shellPwd` without reflecting the main agent's intent

## Fix

`StatusLineComponent` now maintains its own `#cwd` field:

1. **Seeded** from `getShellPwd()` at construction (same initial value as before)
2. **Updated** from the `cwd:changed` event payload -- the bash tool already emits the assistant's new cwd as the event data
3. **All git queries** (branch, status, PR lookup, `.git/HEAD` watcher) resolve against `this.#cwd` instead of calling `getShellPwd()` globally

Additionally, the command-controller now calls `statusLine.setCwd(result.newCwd)` instead of `statusLine.invalidate()`, so user `!cd` commands also propagate correctly.

## TDD

Followed Red-Green cycle:

1. **Red** (`796d6dc`): 5 regression guards in `regression-guard.test.ts` + updated unit tests in `status-line-cwd-watch.test.ts` -- all fail against unfixed code
2. **Green** (`b8171b3`): implementation that makes all tests pass

## Files (4)

- `packages/coding-agent/test/regression-guard.test.ts` -- 5 structural regression guards asserting `#cwd` field, `setCwd()` method, event payload capture, `this.#cwd` in git queries, and command-controller wiring
- `packages/coding-agent/test/status-line-cwd-watch.test.ts` -- updated regression test proves event payload (not `setShellPwd()`) drives display; new `setCwd` test
- `packages/coding-agent/src/modes/components/status-line.ts` -- add `#cwd` field, `setCwd()` method, replace all `getShellPwd()` references
- `packages/coding-agent/src/modes/controllers/command-controller.ts` -- use `setCwd()` instead of `invalidate()`

## Test plan

- `bun check:ts` -- clean (pre-existing warnings only)
- `bun test test/regression-guard.test.ts` -- 61/61 pass (5 new)
- CI -- all jobs green