### PR TITLE
feat(coding-agent): restyle human message with theme-border left bar

### DIFF
--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -1,4 +1,4 @@
-import { Container, Markdown, Spacer } from "@f5xc-salesdemos/pi-tui";
+import { Container, Markdown } from "@f5xc-salesdemos/pi-tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 
 // OSC 133 shell integration: marks prompt zones for terminal multiplexers
@@ -6,30 +6,38 @@ const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
 
+// U+258C LEFT HALF BLOCK — theme-coloured left bar, matches chrome accents.
+const BAR_PREFIX = "▌ ";
+const BAR_PREFIX_WIDTH = 2;
+
 /**
  * Component that renders a user message
  */
 export class UserMessageComponent extends Container {
 	constructor(text: string, synthetic = false) {
 		super();
-		const bgColor = (value: string) => theme.bg("userMessageBg", value);
 		const color = synthetic
 			? (value: string) => theme.fg("dim", value)
 			: (value: string) => theme.fg("userMessageText", value);
-		this.addChild(new Spacer(1));
 		this.addChild(
-			new Markdown(text, 1, 1, getMarkdownTheme(), {
-				bgColor,
+			new Markdown(text, 1, 0, getMarkdownTheme(), {
 				color,
 			}),
 		);
 	}
 
 	override render(width: number): string[] {
-		const lines = super.render(width);
-		if (lines.length === 0) {
-			return lines;
+		const innerWidth = width - BAR_PREFIX_WIDTH;
+		if (innerWidth <= 0) {
+			return [];
 		}
+		const inner = super.render(innerWidth);
+		if (inner.length === 0) {
+			return inner;
+		}
+
+		const bar = theme.fg("border", BAR_PREFIX);
+		const lines = inner.map(line => bar + line);
 
 		lines[0] = OSC133_ZONE_START + lines[0];
 		lines[lines.length - 1] = lines[lines.length - 1] + OSC133_ZONE_END + OSC133_ZONE_FINAL;

--- a/packages/coding-agent/test/user-message.test.ts
+++ b/packages/coding-agent/test/user-message.test.ts
@@ -1,0 +1,116 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { UserMessageComponent } from "@f5xc-salesdemos/xcsh/modes/components/user-message";
+import { initTheme, theme } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
+
+const OSC133_ZONE_START = "\x1b]133;A\x07";
+const OSC133_ZONE_END = "\x1b]133;B\x07";
+const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
+
+function stripAnsi(str: string): string {
+	// Strip OSC sequences (ESC ] ... BEL) first, then CSI.
+	return str.replace(/\x1b\][^\x07]*\x07/g, "").replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function renderPlain(component: UserMessageComponent, width = 120): string[] {
+	return component.render(width).map(stripAnsi);
+}
+
+// Extract the ANSI opening sequence produced by a theme helper, e.g. the
+// leading CSI escape returned from `theme.fg("border", "X")`. The helper
+// returns `${ansi}X\x1b[39m` (or `\x1b[49m` for bg), so we carve out the
+// prefix by slicing off the sentinel and reset.
+function fgPrefix(token: Parameters<typeof theme.fg>[0]): string {
+	const SENTINEL = "\u0001";
+	const wrapped = theme.fg(token, SENTINEL);
+	return wrapped.slice(0, wrapped.indexOf(SENTINEL));
+}
+function bgPrefix(token: Parameters<typeof theme.bg>[0]): string {
+	const SENTINEL = "\u0001";
+	const wrapped = theme.bg(token, SENTINEL);
+	return wrapped.slice(0, wrapped.indexOf(SENTINEL));
+}
+
+describe("UserMessageComponent", () => {
+	beforeAll(() => {
+		initTheme();
+	});
+
+	it("prefixes every rendered line with '▌ '", () => {
+		const c = new UserMessageComponent("hello world");
+		const lines = renderPlain(c);
+		expect(lines.length).toBeGreaterThan(0);
+		for (const line of lines) {
+			expect(line.startsWith("▌ ")).toBe(true);
+		}
+	});
+
+	it("has no leading or trailing blank line", () => {
+		const c = new UserMessageComponent("hello world");
+		const lines = renderPlain(c);
+		expect(lines.length).toBeGreaterThan(0);
+		// After stripping "▌ " the remainder must have visible content
+		// on the first and last line — proves paddingY=0 and no Spacer.
+		const first = lines[0].replace(/^▌ /, "").trim();
+		const last = lines[lines.length - 1].replace(/^▌ /, "").trim();
+		expect(first.length).toBeGreaterThan(0);
+		expect(last.length).toBeGreaterThan(0);
+	});
+
+	it("renders a single-line message on exactly one rendered line", () => {
+		// Proves the Spacer(1) is gone (previously forced 2+ lines for any input).
+		const c = new UserMessageComponent("hi");
+		expect(renderPlain(c)).toHaveLength(1);
+	});
+
+	it("does not paint userMessageBg anywhere", () => {
+		const c = new UserMessageComponent("hello world");
+		const raw = c.render(120).join("\n");
+		const forbidden = bgPrefix("userMessageBg");
+		expect(raw.includes(forbidden)).toBe(false);
+	});
+
+	it("colours the left bar with the theme's border token", () => {
+		const c = new UserMessageComponent("hello world");
+		const raw = c.render(120);
+		expect(raw.length).toBeGreaterThan(0);
+		const borderFg = fgPrefix("border");
+		// Every line must open with the border fg sequence wrapping "▌ ".
+		// The first line also has the OSC133 start marker prepended —
+		// accept either ordering so the test locks behaviour without
+		// over-specifying marker placement vs. the bar.
+		for (const line of raw) {
+			expect(line.includes(`${borderFg}▌ `)).toBe(true);
+		}
+	});
+
+	it("preserves OSC 133 zone markers on first and last line", () => {
+		const c = new UserMessageComponent("line one\nline two");
+		const raw = c.render(120);
+		expect(raw.length).toBeGreaterThanOrEqual(1);
+		// Markers must still surround the message as a whole.
+		expect(raw[0].includes(OSC133_ZONE_START)).toBe(true);
+		expect(raw[raw.length - 1].endsWith(OSC133_ZONE_END + OSC133_ZONE_FINAL)).toBe(true);
+	});
+
+	it("uses dim fg for synthetic messages and not userMessageText", () => {
+		const synthetic = new UserMessageComponent("synthetic entry", true);
+		const raw = synthetic.render(120).join("\n");
+		expect(raw.includes(fgPrefix("dim"))).toBe(true);
+
+		const real = new UserMessageComponent("real entry", false);
+		const rawReal = real.render(120).join("\n");
+		expect(rawReal.includes(fgPrefix("dim"))).toBe(false);
+	});
+
+	it("does not overflow the requested width", () => {
+		// Long single token at narrow width — every visible line must fit.
+		const longWord = "x".repeat(60);
+		const c = new UserMessageComponent(longWord);
+		const width = 40;
+		const lines = renderPlain(c, width);
+		expect(lines.length).toBeGreaterThan(0);
+		for (const line of lines) {
+			expect(line.length).toBeLessThanOrEqual(width);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

**Problem.** After submit, a human message in the dialogue rendered as a full-width `deepCharcoal` box with blank vertical padding above and below the text, visually isolated from the rest of the chrome. Issue #115 asks for enhanced theme styling that integrates with the existing border/accent palette.

**Solution.** Drop the background box and vertical padding. Prefix every rendered line with a single `▌ ` (U+258C LEFT HALF BLOCK) coloured via `theme.fg("border", …)` so the bar tracks the active theme — F5-red (`#CA260A`) in `xcsh-dark`, `lightGray` in `xcsh-light` — matching the existing border/accent/statusline chrome.

**Implementation notes:**

- Child Markdown is rendered at `width - 2` so the 2-column bar prefix cannot overflow the terminal (same approach `GutterBlock` uses for assistant `●` messages).
- OSC 133 zone markers are preserved on first/last rendered line.
- Synthetic messages still use the `dim` fg; real user messages use `userMessageText`.

Closes #115

## Test plan

- [x] `bun --cwd=packages/coding-agent test test/user-message.test.ts` — 8 pass, 0 fail
- [x] `bun --cwd=packages/coding-agent run check:types` — clean, exit 0
- [x] `bun --cwd=packages/coding-agent test` — 3330 pass, 7 fail. The 7 failures are pre-existing in `test/auto-config.test.ts` and `test/sdk-skills.test.ts`, reproduce with this PR's changes stashed, and are **not** caused by this change.
- [x] Visual check with `xcsh-dark` active — bar renders as `\x1b[38;2;202;38;10m` = `#CA260A` (F5 red).
- [ ] CI checks pass on this PR.