### PR TITLE
fix(tui): align gutter indicator with boxed tool output titles (#153)

### DIFF
--- a/packages/coding-agent/src/modes/components/custom-message.ts
+++ b/packages/coding-agent/src/modes/components/custom-message.ts
@@ -23,7 +23,7 @@ export class CustomMessageComponent extends Container {
 		this.addChild(new Spacer(1));
 
 		// Create box with custom background (used for default rendering)
-		this.#box = new Box(1, 1, t => theme.bg("customMessageBg", t));
+		this.#box = new Box(1, 0, t => theme.bg("customMessageBg", t));
 
 		this.#rebuild();
 	}

--- a/packages/coding-agent/src/modes/components/gutter-block.ts
+++ b/packages/coding-agent/src/modes/components/gutter-block.ts
@@ -5,6 +5,12 @@ const GUTTER_WIDTH = 2; // 1 char indicator + 1 char space
 const SPINNER_INTERVAL_MS = 80;
 const GUTTER_PAD = "  "; // 2 spaces for continuation lines
 
+// Matches CSI SGR escape sequences (\x1b[...m) used for colors and styles.
+// Needed because Box/Text padding lines look like "\x1b[48;5;236m   \x1b[0m" —
+// visually empty but not whitespace, so String.trim() alone leaves the escape
+// codes behind and the line falsely reads as content.
+const ANSI_SGR_RE = /\x1b\[[0-9;]*m/g;
+
 export interface GutterConfig {
 	/** Indicator symbol shown when done (e.g. "●", "✻", "※") */
 	symbol: string;
@@ -94,11 +100,12 @@ export class GutterBlock<T extends Component> implements Component {
 			return [];
 		}
 
-		// Find the first non-empty line — most wrapped components start with a Spacer(1)
-		// that produces blank lines. Place the indicator on the first content line, not the spacer.
+		// Find the first visually non-empty line. Leading lines may be plain "" (a
+		// Spacer) or ANSI-background-padded "empty" lines from Box/Text paddingY>=1.
+		// Strip SGR escapes before trim() so the padded lines register as empty.
 		let firstContentIdx = 0;
 		for (let i = 0; i < childLines.length; i++) {
-			if (childLines[i].trim() !== "") {
+			if (childLines[i].replace(ANSI_SGR_RE, "").trim() !== "") {
 				firstContentIdx = i;
 				break;
 			}

--- a/packages/coding-agent/src/modes/components/hook-message.ts
+++ b/packages/coding-agent/src/modes/components/hook-message.ts
@@ -23,7 +23,7 @@ export class HookMessageComponent extends Container {
 		this.addChild(new Spacer(1));
 
 		// Create box with purple background (used for default rendering)
-		this.#box = new Box(1, 1, t => theme.bg("customMessageBg", t));
+		this.#box = new Box(1, 0, t => theme.bg("customMessageBg", t));
 
 		this.#rebuild();
 	}

--- a/packages/coding-agent/src/modes/components/skill-message.ts
+++ b/packages/coding-agent/src/modes/components/skill-message.ts
@@ -13,7 +13,7 @@ export class SkillMessageComponent extends Container {
 		super();
 		this.addChild(new Spacer(1));
 
-		this.#box = new Box(1, 1, t => theme.bg("customMessageBg", t));
+		this.#box = new Box(1, 0, t => theme.bg("customMessageBg", t));
 		this.#rebuild();
 	}
 

--- a/packages/coding-agent/src/modes/components/todo-reminder.ts
+++ b/packages/coding-agent/src/modes/components/todo-reminder.ts
@@ -18,7 +18,7 @@ export class TodoReminderComponent extends Container {
 
 		this.addChild(new Spacer(1));
 
-		this.#box = new Box(1, 1, t => theme.inverse(theme.fg("warning", t)));
+		this.#box = new Box(1, 0, t => theme.inverse(theme.fg("warning", t)));
 		this.addChild(this.#box);
 
 		this.#rebuild();

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -143,8 +143,8 @@ export class ToolExecutionComponent extends Container {
 		this.addChild(new Spacer(1));
 
 		// Always create both - contentBox for custom tools/bash/tools with renderers, contentText for other built-ins
-		this.#contentBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
-		this.#contentText = new Text("", 1, 1, (text: string) => theme.bg("toolPendingBg", text));
+		this.#contentBox = new Box(1, 0, (text: string) => theme.bg("toolPendingBg", text));
+		this.#contentText = new Text("", 1, 0, (text: string) => theme.bg("toolPendingBg", text));
 
 		// Use Box for custom tools or built-in tools that have renderers
 		const hasRenderer = toolName in toolRenderers;
@@ -471,7 +471,7 @@ export class ToolExecutionComponent extends Container {
 					const fileBgFn = fileResult.isError
 						? (text: string) => theme.bg("toolErrorBg", text)
 						: (text: string) => theme.bg("toolSuccessBg", text);
-					const fileBox = new Box(1, 1, fileBgFn);
+					const fileBox = new Box(1, 0, fileBgFn);
 					try {
 						const resultComponent = renderer.renderResult(
 							{ content: [], details: fileResult, isError: fileResult.isError },
@@ -497,7 +497,7 @@ export class ToolExecutionComponent extends Container {
 					const pendingSpacer = new Spacer(1);
 					this.#multiFileBoxes.push(pendingSpacer);
 					this.addChild(pendingSpacer);
-					const pendingBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
+					const pendingBox = new Box(1, 0, (text: string) => theme.bg("toolPendingBg", text));
 					const pendingText = renderStatusLine(
 						{
 							icon: "pending",

--- a/packages/coding-agent/src/modes/components/ttsr-notification.ts
+++ b/packages/coding-agent/src/modes/components/ttsr-notification.ts
@@ -16,7 +16,7 @@ export class TtsrNotificationComponent extends Container {
 		this.addChild(new Spacer(1));
 
 		// Use inverse warning color for yellow background effect
-		this.#box = new Box(1, 1, t => theme.inverse(theme.fg("warning", t)));
+		this.#box = new Box(1, 0, t => theme.inverse(theme.fg("warning", t)));
 		this.addChild(this.#box);
 
 		this.#rebuild();

--- a/packages/coding-agent/test/boxed-gutter-integration.test.ts
+++ b/packages/coding-agent/test/boxed-gutter-integration.test.ts
@@ -1,0 +1,68 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { Box, Text, type TUI } from "@f5xc-salesdemos/pi-tui";
+import { GutterBlock } from "../src/modes/components/gutter-block";
+import { initTheme } from "../src/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+function mockTUI(): TUI {
+	return { requestRender: vi.fn() } as unknown as TUI;
+}
+
+function stripAnsi(str: string): string {
+	return str.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+// End-to-end reproduction of xcsh#153: a real Box(paddingY=1) wrapping a real
+// Text emits ANSI-background-colored empty lines as padding. The GutterBlock
+// must still place its indicator on the line containing the actual content —
+// not on the invisible padding line above it.
+describe("GutterBlock + Box(paddingY=1) integration (xcsh#153)", () => {
+	it("places the ● indicator on the content line, not on the Box's top padding line", () => {
+		const ui = mockTUI();
+		const bgFn = (s: string) => `\x1b[48;5;236m${s}\x1b[0m`;
+		const box = new Box(1, 1, bgFn);
+		box.addChild(new Text("Title", 1, 0));
+
+		const gutter = new GutterBlock(ui, box, {
+			symbol: "●",
+			activeColorFn: s => s,
+			doneColorFn: s => s,
+			animated: false,
+		});
+
+		const lines = gutter.render(40);
+		// Box emits: [top-pad, content, bottom-pad] — 3 lines minimum.
+		expect(lines.length).toBeGreaterThanOrEqual(3);
+
+		// Locate the line that actually contains the visible "Title" text.
+		const titleIdx = lines.findIndex(line => stripAnsi(line).includes("Title"));
+		expect(titleIdx).toBeGreaterThan(-1);
+
+		// The indicator must be on that line, not above it.
+		expect(lines[titleIdx]).toStartWith("● ");
+
+		// Any line before the title is a padding line — it must carry the
+		// continuation pad, never the indicator.
+		for (let i = 0; i < titleIdx; i++) {
+			expect(lines[i]).not.toStartWith("● ");
+			expect(lines[i]).toStartWith("  ");
+		}
+	});
+
+	// The 9 boxed tool-output call sites in modes/components/ were flipped to
+	// paddingY=0 so no background-colored blank rows render above or below the
+	// content. This test locks the invariant: Box(_, 0, bgFn) with a single Text
+	// child renders exactly one content line — no leading/trailing padding.
+	it("Box(paddingY=0) wrapping Text renders exactly one content line, no padding rows", () => {
+		const bgFn = (s: string) => `\x1b[48;5;236m${s}\x1b[0m`;
+		const box = new Box(1, 0, bgFn);
+		box.addChild(new Text("Content", 1, 0));
+
+		const lines = box.render(40);
+		expect(lines).toHaveLength(1);
+		expect(stripAnsi(lines[0])).toContain("Content");
+	});
+});

--- a/packages/coding-agent/test/gutter-block.test.ts
+++ b/packages/coding-agent/test/gutter-block.test.ts
@@ -159,6 +159,82 @@ describe("GutterBlock", () => {
 		});
 	});
 
+	// Regression for xcsh#153: Box/Text with paddingY>=1 emit ANSI-background-colored
+	// empty lines (e.g. "\x1b[48;5;236m          \x1b[0m") as top/bottom padding.
+	// The old `.trim() !== ""` check treated these as content because trim() strips
+	// whitespace but not ANSI escapes — so the gutter indicator landed on the padding
+	// line instead of the first visible line of content. visibleWidth() handles this
+	// correctly because it measures displayable width, ignoring ANSI sequences.
+	describe("render — ANSI-padded empty line handling (xcsh#153)", () => {
+		// A realistic approximation of what `applyBackgroundToLine("", width, bgFn)`
+		// produces: ANSI bg open + spaces + ANSI reset. Visually empty, but truthy
+		// after String.trim() because trim() leaves the escape codes behind.
+		const ansiPaddedEmpty = (width: number) => `\x1b[48;5;236m${" ".repeat(width)}\x1b[0m`;
+
+		it("skips ANSI-padded empty top line and places indicator on the first content line", () => {
+			const ui = mockTUI();
+			const child = stubComponent([ansiPaddedEmpty(10), "Todo Write", ansiPaddedEmpty(10)]);
+			const gutter = new GutterBlock(ui, child, {
+				symbol: "●",
+				activeColorFn: s => s,
+				doneColorFn: s => s,
+				animated: false,
+			});
+
+			const lines = gutter.render(80);
+			expect(lines).toHaveLength(3);
+			// Top padding line gets continuation pad (2 spaces), NOT the indicator
+			expect(lines[0]).toStartWith("  ");
+			expect(lines[0]).not.toStartWith("● ");
+			// Title line gets the indicator
+			expect(lines[1]).toStartWith("● ");
+			expect(stripAnsi(lines[1])).toContain("Todo Write");
+			// Bottom padding line gets continuation pad
+			expect(lines[2]).toStartWith("  ");
+			expect(lines[2]).not.toStartWith("● ");
+		});
+
+		it("handles both plain and ANSI-padded empty leading lines interleaved", () => {
+			const ui = mockTUI();
+			const child = stubComponent(["", ansiPaddedEmpty(6), "title"]);
+			const gutter = new GutterBlock(ui, child, {
+				symbol: "●",
+				activeColorFn: s => s,
+				doneColorFn: s => s,
+				animated: false,
+			});
+
+			const lines = gutter.render(80);
+			expect(lines).toHaveLength(3);
+			// Both leading empty lines (plain and ANSI-padded) get continuation pad
+			expect(lines[0]).toBe("  ");
+			expect(lines[1]).toStartWith("  ");
+			expect(lines[1]).not.toStartWith("● ");
+			// Third line — the real content — gets the indicator
+			expect(lines[2]).toStartWith("● ");
+			expect(stripAnsi(lines[2])).toContain("title");
+		});
+
+		it("falls back to index 0 when every line is ANSI-padded empty (preserves existing contract)", () => {
+			const ui = mockTUI();
+			const child = stubComponent([ansiPaddedEmpty(4), ansiPaddedEmpty(4), ansiPaddedEmpty(4)]);
+			const gutter = new GutterBlock(ui, child, {
+				symbol: "●",
+				activeColorFn: s => s,
+				doneColorFn: s => s,
+				animated: false,
+			});
+
+			const lines = gutter.render(80);
+			expect(lines).toHaveLength(3);
+			// When no content line exists, firstContentIdx stays at 0 — matches the
+			// fallback behavior the existing plain-"" test relies on implicitly.
+			expect(lines[0]).toStartWith("● ");
+			expect(lines[1]).toStartWith("  ");
+			expect(lines[2]).toStartWith("  ");
+		});
+	});
+
 	describe("state transitions", () => {
 		it("starts in active state by default", () => {
 			const ui = mockTUI();


### PR DESCRIPTION
## What

Fix gutter indicator (`●`) misalignment with boxed tool output titles. The indicator landed on an ANSI-background-padded empty row instead of the title row.

## Why

`GutterBlock` placed its indicator on the first line where `trim() !== ""`, intending to skip leading `Spacer` lines. However, `Box`/`Text` with `paddingY>=1` emit background-colored "empty" lines (e.g. `"\x1b[48;5;236m   \x1b[0m"`) that are visually blank but not whitespace — so `trim()` alone classified them as content and the indicator landed one line above the title.

Closes #153

## How — two-layer fix

1. **`gutter-block.ts`** — strip SGR escapes before `trim()` when detecting the first non-empty line. Defense in depth: any future caller that reintroduces `paddingY>=1` still aligns correctly.
2. **9 call sites in `modes/components/`** — set `paddingY=0` on `Box`/`Text` for `tool-execution` (×4), `custom-message`, `hook-message`, `skill-message`, `todo-reminder`, `ttsr-notification`. Matches the existing precedent at `assistant-message.ts:140` and eliminates the background-colored padding rows that flanked the title.

`Box`/`Text` constructor defaults are unchanged — auditing every caller is out of scope for this bug fix.

## Testing

- Extended `gutter-block.test.ts` with 3 new ANSI-padded empty-line cases.
- Added `boxed-gutter-integration.test.ts` covering the end-to-end `Box`+`GutterBlock` render path and the `paddingY=0` invariant.
- 38/38 green across both suites.
- `bun run check` — clean (Biome + tsgo across 10 workspaces).
- `bun run test:ts` — 3332 pass; 2 pre-existing failures in `auto-config.test.ts` (chmod/permission tests) that are unrelated to this change.
- `bun run ci:test:smoke` — clean.

---

- [x] `bun run check` passes
- [x] `bun test` — no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #N`