### PR TITLE
style(theme): unify inline code color with code block in xcsh-dark and dark (#157)

### DIFF
--- a/packages/coding-agent/src/modes/theme/dark.json
+++ b/packages/coding-agent/src/modes/theme/dark.json
@@ -44,7 +44,7 @@
 		"mdHeading": "#febc38",
 		"mdLink": "#0088fa",
 		"mdLinkUrl": "dimGray",
-		"mdCode": "#e5c1ff",
+		"mdCode": "#9CDCFE",
 		"mdCodeBlock": "#9CDCFE",
 		"mdCodeBlockBorder": "darkGray",
 		"mdQuote": "gray",

--- a/packages/coding-agent/src/modes/theme/defaults/xcsh-dark.json
+++ b/packages/coding-agent/src/modes/theme/defaults/xcsh-dark.json
@@ -42,7 +42,7 @@
 		"mdHeading": "#febc38",
 		"mdLink": "#0088fa",
 		"mdLinkUrl": "#6b7280",
-		"mdCode": "#e5c1ff",
+		"mdCode": "#9CDCFE",
 		"mdCodeBlock": "#9CDCFE",
 		"mdCodeBlockBorder": "subtleGray",
 		"mdQuote": "coolGray",


### PR DESCRIPTION
## Summary
- Changes `mdCode` in `xcsh-dark.json` and `dark.json` from `#e5c1ff` (purple) to `#9CDCFE` (blue), matching existing `mdCodeBlock`.
- Eliminates the purple/lavender clash against the blue/cyan chrome in the two affected dark themes.
- `thinkingXhigh: "#e5c1ff"` in `dark.json` is a different token and is intentionally left unchanged per the issue scope.

## Test plan
- [x] Both JSON files parse cleanly.
- [x] `bun --cwd=packages/coding-agent run check:types` passes.
- [x] `bun --cwd=packages/coding-agent test` — 3 pre-existing failures unrelated to theme (models.yml loader, sdk-skills timeout).
- [ ] Visual confirmation: inline backtick code in xcsh-dark / dark renders the same light blue as fenced code blocks. (Not run in this session — requires interactive TUI.)

Closes #157