### PR TITLE
fix(coding-agent): align todo-write task lines and restyle completed items

### DIFF
--- a/packages/coding-agent/src/tools/todo-write.ts
+++ b/packages/coding-agent/src/tools/todo-write.ts
@@ -393,7 +393,7 @@ function formatTodoLine(item: TodoItem, uiTheme: Theme, prefix: string): string 
 	const checkbox = uiTheme.checkbox;
 	switch (item.status) {
 		case "completed":
-			return uiTheme.fg("success", `${prefix}${checkbox.checked} ${chalk.strikethrough(item.content)}`);
+			return `${prefix}${uiTheme.fg("chromeAccent", checkbox.checked)} ${uiTheme.fg("dim", chalk.strikethrough(item.content))}`;
 		case "in_progress": {
 			const main = uiTheme.fg("contentAccent", `${prefix}${checkbox.unchecked} ${item.content}`);
 			if (!item.details) return main;
@@ -434,9 +434,10 @@ export const todoWriteToolRenderer = {
 
 		const { expanded } = options;
 		const lines: string[] = [header];
+		const indent = phases.length > 1 ? "  " : "";
 		for (const phase of phases) {
 			if (phases.length > 1) {
-				lines.push(uiTheme.fg("contentAccent", `  ${uiTheme.tree.hook} ${phase.name}`));
+				lines.push(uiTheme.fg("contentAccent", `${indent}${uiTheme.tree.hook} ${phase.name}`));
 			}
 			const treeLines = renderTreeList(
 				{
@@ -448,7 +449,7 @@ export const todoWriteToolRenderer = {
 				},
 				uiTheme,
 			);
-			lines.push(...treeLines);
+			for (const line of treeLines) lines.push(`${indent}${line}`);
 		}
 		return new Text(lines.join("\n"), 0, 0);
 	},

--- a/packages/coding-agent/test/tools/todo-write.test.ts
+++ b/packages/coding-agent/test/tools/todo-write.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "bun:test";
+import { sanitizeText } from "@f5xc-salesdemos/pi-natives";
 import { Settings } from "@f5xc-salesdemos/xcsh/config/settings";
 import type { ToolSession } from "@f5xc-salesdemos/xcsh/tools";
 import { type TodoPhase, TodoWriteTool } from "@f5xc-salesdemos/xcsh/tools";
+import chalk from "chalk";
+import { getThemeByName } from "../../src/modes/theme/theme";
+import { todoWriteToolRenderer } from "../../src/tools/todo-write";
 
 function createSession(initialPhases: TodoPhase[] = []): ToolSession {
 	let phases = initialPhases;
@@ -183,5 +187,112 @@ describe("TodoWriteTool details field", () => {
 		if (!summary || summary.type !== "text") throw new Error("Expected text summary");
 		// Task is auto-promoted to in_progress, so details should appear in summary
 		expect(summary.text).toContain("Edit src/parser.ts");
+	});
+});
+
+describe("todoWriteToolRenderer phase indentation", () => {
+	async function renderDark(phases: TodoPhase[]): Promise<string[]> {
+		const theme = await getThemeByName("dark");
+		if (!theme) throw new Error("dark theme not found");
+		const result = {
+			content: [{ type: "text", text: "ignored" }],
+			details: { phases, storage: "memory" as const },
+		};
+		const component = todoWriteToolRenderer.renderResult(result, { expanded: true, isPartial: false }, theme);
+		return sanitizeText(component.render(120).join("\n")).split("\n");
+	}
+
+	it("indents task lines under phase headers when multiple phases exist", async () => {
+		const phases: TodoPhase[] = [
+			{
+				id: "phase-1",
+				name: "Preparation",
+				tasks: [
+					{ id: "task-1", status: "in_progress", content: "Preheat oven to 350F" },
+					{ id: "task-2", status: "pending", content: "Grease and flour two pans" },
+				],
+			},
+			{
+				id: "phase-2",
+				name: "Baking",
+				tasks: [{ id: "task-3", status: "pending", content: "Bake for 30 minutes" }],
+			},
+		];
+
+		const lines = await renderDark(phases);
+		const body = lines.slice(1); // drop the overall status header line
+
+		// Phase headers keep their 2-space indent.
+		const phaseHeaders = body.filter(l => l.includes("Preparation") || l.includes("Baking"));
+		expect(phaseHeaders.length).toBe(2);
+		for (const line of phaseHeaders) expect(line.startsWith("  ")).toBe(true);
+
+		// Every task line must carry the same 2-space indent so tree branches
+		// nest visually under the phase name.
+		for (const content of ["Preheat oven to 350F", "Grease and flour two pans", "Bake for 30 minutes"]) {
+			const line = body.find(l => l.includes(content));
+			expect(line).toBeDefined();
+			expect(line!.startsWith("  ")).toBe(true);
+		}
+	});
+
+	it("renders completed tasks with chromeAccent checkbox and dim strikethrough content", async () => {
+		const theme = await getThemeByName("dark");
+		if (!theme) throw new Error("dark theme not found");
+
+		const phases: TodoPhase[] = [
+			{
+				id: "phase-1",
+				name: "Baking",
+				tasks: [
+					{ id: "task-1", status: "completed", content: "Preheat oven" },
+					{ id: "task-2", status: "in_progress", content: "Bake cake" },
+				],
+			},
+		];
+		const result = {
+			content: [{ type: "text", text: "ignored" }],
+			details: { phases, storage: "memory" as const },
+		};
+		const component = todoWriteToolRenderer.renderResult(result, { expanded: true, isPartial: false }, theme);
+		const raw = component.render(120).join("\n");
+
+		// The completed-task styling is now two-tone: chromeAccent on the
+		// checkbox and dim on the strikethrough content.
+		const expectedCheckbox = theme.fg("chromeAccent", theme.checkbox.checked);
+		const expectedContent = theme.fg("dim", chalk.strikethrough("Preheat oven"));
+		expect(raw).toContain(expectedCheckbox);
+		expect(raw).toContain(expectedContent);
+
+		// The previous all-green styling must no longer appear for the
+		// completed task's content.
+		const oldAllSuccess = theme.fg("success", `${theme.checkbox.checked} ${chalk.strikethrough("Preheat oven")}`);
+		expect(raw).not.toContain(oldAllSuccess);
+	});
+
+	it("does not indent task lines when only one phase is present", async () => {
+		const phases: TodoPhase[] = [
+			{
+				id: "phase-1",
+				name: "Solo",
+				tasks: [
+					{ id: "task-1", status: "in_progress", content: "Only task" },
+					{ id: "task-2", status: "pending", content: "Second task" },
+				],
+			},
+		];
+
+		const lines = await renderDark(phases);
+		const body = lines.slice(1);
+
+		// No phase header rendered when phases.length === 1.
+		expect(body.some(l => l.includes("Solo"))).toBe(false);
+
+		// Task lines must not carry the multi-phase 2-space indent.
+		for (const content of ["Only task", "Second task"]) {
+			const line = body.find(l => l.includes(content));
+			expect(line).toBeDefined();
+			expect(line!.startsWith("  ")).toBe(false);
+		}
 	});
 });


### PR DESCRIPTION
## What

Two targeted UX fixes in `packages/coding-agent/src/tools/todo-write.ts` so the todo-write tool renders a cleaner tree and a more readable state hierarchy.

1. **Multi-phase indentation** — when `todoWriteToolRenderer.renderResult` renders more than one phase, every tree line (task, continuation, "N more" summary) now carries the same 2-space indent as the phase header, so branches nest visually under the phase name. Single-phase layouts remain unchanged.
2. **Completed-task styling** — `formatTodoLine` no longer wraps the whole completed line in `success` green. The checkbox is now rendered in `chromeAccent` and the strikethrough content in `dim`, so completed items recede visually and no longer compete with the active `in_progress` task.

## Why

Fixes #154. In multi-phase layouts, task lines rendered flush-left under phase headers, making it ambiguous which tasks belonged to which phase. Simultaneously, completed tasks were styled in bright `success` green — drawing the eye away from the single active `in_progress` task, which is the one the user actually needs to track.

Closes #154

## Testing

New tests added to `packages/coding-agent/test/tools/todo-write.test.ts`:

- indents task lines under phase headers when multiple phases exist
- does not indent task lines when only one phase is present (regression guard)
- renders completed tasks with `chromeAccent` checkbox and `dim` strikethrough content

Verification run locally:

- `bun test --max-concurrency 2 packages/coding-agent/test/tools/todo-write.test.ts` — 10 pass, 0 fail
- `bun run check:ts` — 0 errors across workspace
- `bun test --max-concurrency 2 --cwd packages/coding-agent` — 6 pre-existing failures in `auto-config.test.ts` and `sdk-skills.test.ts` that also fail on baseline (unrelated to this change; verified by stashing and re-running)

---

- [x] `bun run check` passes (ts)
- [x] `bun test` — no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #154`