### PR TITLE
fix(coding-agent): gitignore build-info.generated.ts to stop false dirty flag

### DIFF
--- a/packages/coding-agent/.gitignore
+++ b/packages/coding-agent/.gitignore
@@ -1,1 +1,2 @@
 src/core/export-html/template.generated.ts
+src/internal-urls/build-info.generated.ts


### PR DESCRIPTION
## What

Add `src/internal-urls/build-info.generated.ts` to `packages/coding-agent/.gitignore` (one-line change).

## Why

`scripts/generate-build-info.ts` writes `build-info.generated.ts` into the source tree on every `bun install`, but the file was not gitignored. `resolveDirty()` uses `git status --porcelain`, which treats the freshly-written untracked file as dirty — so every run after the first one baked `dirty: true` into the compiled binary even on otherwise-clean workspaces, and `xcsh://about` surfaced an incorrect dirty flag.

The package-level `.gitignore` already follows this convention for `src/core/export-html/template.generated.ts`. Root `.gitignore` is governance-managed (in `.claude/governance.json` protected_files), so the package-local ignore is the correct place.

Closes #161

## Testing

Verified manually on a clean checkout: running `generate-build-info` twice in a row no longer flips `dirty` to `true`. `git status` stays clean after generation because the output file is now ignored.

---

- [x] Pre-commit lint gate passes
- [x] One-line scoped change (no code paths touched)
- [x] Issue linked via `Closes #161`