### PR TITLE
feat(coding-agent): flip eight user-facing factory defaults

### DIFF
--- a/docs/configuration/rpc.md
+++ b/docs/configuration/rpc.md
@@ -294,11 +294,11 @@ If omitted during streaming, prompt fails.
 
 ### Queue defaults
 
-From `packages/agent/src/agent.ts` defaults:
+From the coding-agent settings schema (`packages/coding-agent/src/config/settings-schema.ts`):
 
 - `steeringMode`: `"one-at-a-time"`
 - `followUpMode`: `"one-at-a-time"`
-- `interruptMode`: `"immediate"`
+- `interruptMode`: `"wait"`
 
 ### Mode semantics
 

--- a/docs/configuration/secrets.md
+++ b/docs/configuration/secrets.md
@@ -11,11 +11,11 @@ Prevents sensitive values (API keys, tokens, passwords) from being sent to LLM p
 
 ## Enabling
 
-Disabled by default. Toggle via `/settings` UI or directly in `config.yml`:
+Enabled by default. Toggle via `/settings` UI or directly in `config.yml`:
 
 ```yaml
 secrets:
-  enabled: true
+  enabled: false
 ```
 
 ## How it works

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Flipped eight user-facing factory defaults for new users:
+  - `defaultThinkingLevel`: `"high"` → `"xhigh"`
+  - `hideThinkingBlock`: `false` → `true`
+  - `interruptMode`: `"immediate"` → `"wait"`
+  - `todo.eager`: `false` → `true`
+  - `grep.contextBefore`: `0` → `3`
+  - `grep.contextAfter`: `0` → `3`
+  - `task.eager`: `false` → `true`
+  - `secrets.enabled`: `false` → `true`
+  - Existing users keep any value they have already saved in `config.yml`; no force-migration runs.
+
 ## [15.0.0] - 2026-04-10
 
 ### Fixed
@@ -9,6 +22,7 @@
 - Fixed cached Ollama discovery rows so upgraded installs switch to the OpenAI Responses transport instead of staying on the old completions transport
 
 ## [14.0.2] - 2026-04-09
+
 ### Added
 
 - Added `/force` slash command to force the next agent turn to use a specific tool
@@ -1562,7 +1576,7 @@
 ### Fixed
 
 - Restored inline rendering for `read` tool image results in assistant transcript components, including streaming and rebuilt session history paths.
-- Fixed shell-escaped read paths (for example, pasted `\ `-escaped screenshot filenames) by resolving unescaped fallback candidates before macOS filename normalization variants.
+- Fixed shell-escaped read paths (for example, pasted backslash-escaped screenshot filenames) by resolving unescaped fallback candidates before macOS filename normalization variants.
 
 ## [13.3.8] - 2026-02-28
 
@@ -4458,7 +4472,7 @@
 - Enhanced Python kernel availability checking with faster validation
 - Optimized Python environment warming to avoid blocking during tool initialization
 - Reorganized settings interface into behavior, tools, display, voice, status, lsp, and exa tabs
-- Migrated environment variables from PI* to OMP* prefix with automatic migration
+- Migrated environment variables from `PI_*` to `OMP_*` prefix with automatic migration
 - Updated model selector to use TabBar component for provider navigation
 - Changed role badges to inverted style with colored backgrounds
 - Added support for /models command alias in addition to /model

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -438,7 +438,7 @@ export const SETTINGS_SCHEMA = {
 	defaultThinkingLevel: {
 		type: "enum",
 		values: THINKING_EFFORTS,
-		default: "high",
+		default: "xhigh",
 		ui: {
 			tab: "model",
 			label: "Thinking Level",
@@ -449,7 +449,7 @@ export const SETTINGS_SCHEMA = {
 
 	hideThinkingBlock: {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: { tab: "model", label: "Hide Thinking Blocks", description: "Hide thinking blocks in assistant responses" },
 	},
 
@@ -600,7 +600,7 @@ export const SETTINGS_SCHEMA = {
 	interruptMode: {
 		type: "enum",
 		values: ["immediate", "wait"] as const,
-		default: "immediate",
+		default: "wait",
 		ui: {
 			tab: "interaction",
 			label: "Interrupt Mode",
@@ -1165,7 +1165,7 @@ export const SETTINGS_SCHEMA = {
 
 	"todo.eager": {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: {
 			tab: "tools",
 			label: "Create Todos Automatically",
@@ -1188,7 +1188,7 @@ export const SETTINGS_SCHEMA = {
 
 	"grep.contextBefore": {
 		type: "number",
-		default: 0,
+		default: 3,
 		ui: {
 			tab: "tools",
 			label: "Grep Context Before",
@@ -1199,7 +1199,7 @@ export const SETTINGS_SCHEMA = {
 
 	"grep.contextAfter": {
 		type: "number",
-		default: 0,
+		default: 3,
 		ui: {
 			tab: "tools",
 			label: "Grep Context After",
@@ -1503,7 +1503,7 @@ export const SETTINGS_SCHEMA = {
 
 	"task.eager": {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: {
 			tab: "tasks",
 			label: "Prefer Task Delegation",
@@ -1599,7 +1599,7 @@ export const SETTINGS_SCHEMA = {
 	// Secret handling
 	"secrets.enabled": {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: { tab: "providers", label: "Hide Secrets", description: "Obfuscate secrets before sending to AI providers" },
 	},
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1568,7 +1568,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			transformContext,
 			steeringMode: settings.get("steeringMode") ?? "one-at-a-time",
 			followUpMode: settings.get("followUpMode") ?? "one-at-a-time",
-			interruptMode: settings.get("interruptMode") ?? "immediate",
+			interruptMode: settings.get("interruptMode") ?? "wait",
 			thinkingBudgets: settings.getGroup("thinkingBudgets"),
 			temperature: settings.get("temperature") >= 0 ? settings.get("temperature") : undefined,
 			topP: settings.get("topP") >= 0 ? settings.get("topP") : undefined,

--- a/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
@@ -645,7 +645,7 @@ describe("AgentSession MCP discovery", () => {
 			sessionManager,
 			settings: Settings.isolated({
 				"mcp.discoveryMode": true,
-				defaultThinkingLevel: "high",
+				defaultThinkingLevel: "xhigh",
 				serviceTier: "priority",
 			}),
 			modelRegistry: {} as never,

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -174,7 +174,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			sessionManager: firstManager,
 			settings: Settings.isolated({
 				"mcp.discoveryMode": true,
-				defaultThinkingLevel: "high",
+				defaultThinkingLevel: "xhigh",
 				serviceTier: "priority",
 			}),
 			model: createReasoningModel(),
@@ -210,7 +210,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			sessionManager: resumedManager,
 			settings: Settings.isolated({
 				"mcp.discoveryMode": true,
-				defaultThinkingLevel: "high",
+				defaultThinkingLevel: "xhigh",
 				serviceTier: "none",
 			}),
 			model: createReasoningModel(),
@@ -263,7 +263,7 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			settings: Settings.isolated({
 				"mcp.discoveryMode": true,
 				"mcp.discoveryDefaultServers": ["github"],
-				defaultThinkingLevel: "high",
+				defaultThinkingLevel: "xhigh",
 				serviceTier: "priority",
 			}),
 			model: createReasoningModel(),

--- a/packages/coding-agent/test/tools/grep-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/grep-internal-urls.test.ts
@@ -35,7 +35,7 @@ describe("GrepTool internal URL resolution", () => {
 			hasUI: false,
 			getSessionFile: () => null,
 			getSessionSpawns: () => "*",
-			settings: Settings.isolated(),
+			settings: Settings.isolated({ "grep.contextBefore": 0, "grep.contextAfter": 0 }),
 			...overrides,
 		};
 	}


### PR DESCRIPTION
## What

Update factory defaults in `packages/coding-agent/src/config/settings-schema.ts` so net-new users land on a more opinionated baseline.

| Setting | Old | New |
| --- | --- | --- |
| `defaultThinkingLevel` | `"high"` | `"xhigh"` |
| `hideThinkingBlock` | `false` | `true` |
| `interruptMode` | `"immediate"` | `"wait"` |
| `todo.eager` | `false` | `true` |
| `grep.contextBefore` | `0` | `3` |
| `grep.contextAfter` | `0` | `3` |
| `task.eager` | `false` | `true` |
| `secrets.enabled` | `false` | `true` |

Aligned follow-ups:

- `sdk.ts` `interruptMode` fallback matches the new schema default.
- `docs/configuration/rpc.md` queue-defaults docs updated.
- `docs/configuration/secrets.md` "Disabled by default" prose updated.
- Four `"high"`-pinned thinking-level fixtures in MCP discovery tests bumped to `"xhigh"` to match the new default. The mock models clamp thinking at Medium/High (`thinking.ts:86`), so this does not route through new code paths.
- `grep-internal-urls` test helper pinned to `contextBefore/After=0` to preserve its "regex returns only matching lines" assertion.
- `CHANGELOG.md` `[Unreleased]` Changed entry added.

## Why

New users currently hit a stack of conservative defaults that most operators re-flip within minutes: thinking level too low, raw thinking text visible, immediate interrupt mode that breaks streaming, eager-todo/task disabled, no grep context, and secrets detection off. This PR makes the factory defaults match the common opinionated baseline so a fresh install is useful out-of-the-box.

**Scope is net-new-users only.** Existing users keep any value they already saved in `config.yml`. No migration code, no feature flag, no telemetry.

Closes #163

## Testing

- Red baseline: 15 pre-existing test failures captured before the change (TUI scrollback, skills discovery, config edge cases — all unrelated).
- Post-change full `bun test`: 14-15 failures, identical set to baseline, zero new regressions.
- `bun run ci:check:full`: clean.
- Runtime smoke (temporary test, since removed): `Settings.isolated()` returns the 8 new defaults on a fresh init; explicitly-pinned user values survive.
- Two `codex:rescue` review passes completed; blocker (secrets.md drift) and nits (rpc.md attribution, CHANGELOG entry, AGENTS.md drift) all resolved.

---

- [x] `bun run check` passes
- [x] `bun test` — no new failures vs baseline
- [x] CHANGELOG updated (user-facing)
- [x] Issue linked via `Closes #163`

## Notes for reviewer

- **Scope is new-users-only.** Existing users keep saved values; no force-migration runs.
- **Pre-existing bug flagged:** `packages/coding-agent/test/sdk-model-selection.test.ts:93` sets `defaultThinkingLevel: "off"`, which is not in `THINKING_EFFORTS`. Unrelated to this change; not addressed here.
- **Generated files** (`build-info.generated.ts`, `docs-index.generated.ts`) are gitignored/untracked and regenerated by CI.
- **Unrelated housekeeping bundled for lint-gate passage:** this PR also includes three mechanical markdown lint fixes to `packages/coding-agent/CHANGELOG.md` that were necessary to get past the repo's `markdownlint-cli2` pre-commit hook. All three are fixes to pre-existing content in release-history entries and do not change rendered meaning:
  - `14.0.2` entry: inserted a blank line between the `## [14.0.2] - 2026-04-09` heading and the following `### Added` subheading (MD022).
  - `13.3.8` Fixed entry: replaced the inline code span `` `\ ` `` (which had a trailing space inside the backticks) with the prose phrase "backslash-escaped" (MD038).
  - `13.3.7` Added entry: changed `PI* to OMP* prefix` to `` `PI_*` to `OMP_*` prefix `` so the asterisks are inside a code span rather than looking like unclosed emphasis (MD037).