### PR TITLE
fix(coding-agent): widen defaultThinkingLevel schema to include "off"

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Widened the `defaultThinkingLevel` schema enum to include `"off"`, which was already a supported runtime value via `resolveThinkingLevelForModel` but was not declared as a valid schema value. This closes a type-safety gap where programmatic callers (tests, config.yml edits) could set `"off"` without a `SettingValue` type narrowing it. The `/settings` UI dropdown is unchanged; the widening is schema-level only.
+
 ### Changed
 
 - Flipped eight user-facing factory defaults for new users:

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -437,7 +437,10 @@ export const SETTINGS_SCHEMA = {
 	// Reasoning and prompts
 	defaultThinkingLevel: {
 		type: "enum",
-		values: THINKING_EFFORTS,
+		// "off" is a valid runtime value (no reasoning) but not in THINKING_EFFORTS; widen the
+		// schema to match so programmatic callers and config.yml can set it without a type hole.
+		// The /settings UI dropdown intentionally still shows only the 5 efforts.
+		values: ["off", ...THINKING_EFFORTS] as const,
 		default: "xhigh",
 		ui: {
 			tab: "model",


### PR DESCRIPTION
## Summary

Widens the `defaultThinkingLevel` setting's schema enum in
`packages/coding-agent/src/config/settings-schema.ts` from the 5-value
`THINKING_EFFORTS` (`minimal | low | medium | high | xhigh`) to
`"off" | Effort`. This closes a type-safety gap where programmatic
callers (`Settings.isolated`, `config.yml` edits) could set `"off"`
(which is a valid runtime value) without a `SettingValue` type that
narrowed to it.

- `resolveThinkingLevelForModel` already preserves `Off`
  (`packages/coding-agent/src/thinking.ts:83-84`).
- `sdk-model-selection.test.ts:93` already relies on
  `defaultThinkingLevel: "off"` being accepted; it only compiled because
  `Settings.isolated` takes `Partial<Record<SettingPath, unknown>>` with
  no enum validation.
- The `/settings` UI dropdown is intentionally left narrow.
  `agent-session.ts:3685` already guards UI-driven persistence of `Off`.

Schema-only change. No UI change. No behavior change.

Closes #166

## Context

Follow-up identified during the codex review of #164 (the factory-
defaults flip). This widens the schema to match the existing runtime
behavior that flows through `resolveThinkingLevelForModel`.

## Verification

- Full `bun test`: 4388 pass / 15 fail / 855 skip — 15 failures are the
  exact pre-existing TUI/skills/config flakes already on main, zero new
  regressions. `sdk-model-selection.test.ts` passes.
- `bun run ci:check:full`: clean.
- `bunx markdownlint-cli2 packages/coding-agent/CHANGELOG.md`: 0 errors.
- codex:rescue review pass: no findings; confirmed `as const` inference
  widens `SettingValue` correctly and no production callers of
  `settings.get`/`settings.set` for this path have a mismatch.

## Notes for reviewer

- The existing `[Unreleased]` section at the top of the CHANGELOG
  contains content from #164 that was not moved to `[18.1.0]` by the
  auto-release workflow. That is pre-existing, unrelated cleanup, and
  is flagged for a separate chore.

## Test plan

- [ ] CI checks pass
- [ ] Confirm schema enum now accepts `"off"` and matches runtime