### PR TITLE
fix(coding-agent): export registerCodingAgentPromptHelpers() for tests

### DIFF
--- a/packages/coding-agent/src/config/prompt-templates.ts
+++ b/packages/coding-agent/src/config/prompt-templates.ts
@@ -23,14 +23,6 @@ export interface PromptTemplate {
 	source: string; // e.g., "(user)", "(project)", "(project:frontend)"
 }
 
-prompt.registerHelper("jtdToTypeScript", (schema: unknown): string => {
-	try {
-		return jtdToTypeScript(schema);
-	} catch {
-		return "unknown";
-	}
-});
-
 /**
  * Renders a section separator:
  *
@@ -42,8 +34,6 @@ export function sectionSeparator(name: string): string {
 	return `\n\n═══════════${name}═══════════\n`;
 }
 
-prompt.registerHelper("SECTION_SEPERATOR", (name: unknown): string => sectionSeparator(String(name)));
-
 function formatHashlineRef(lineNum: unknown, content: unknown): { num: number; text: string; ref: string } {
 	const num = typeof lineNum === "number" ? lineNum : Number.parseInt(String(lineNum), 10);
 	const raw = typeof content === "string" ? content : String(content ?? "");
@@ -53,51 +43,77 @@ function formatHashlineRef(lineNum: unknown, content: unknown): { num: number; t
 }
 
 /**
- * {{href lineNum "content"}} — compute a real hashline ref for prompt examples.
- * Returns `"lineNum#hash"` using the actual hash algorithm.
+ * Registers all coding-agent-specific Handlebars helpers on the shared prompt engine.
+ *
+ * Called at module load for production (bottom of this file). Tests that render
+ * prompt templates directly via `prompt.render(...)` without going through
+ * `buildSystemPrompt()` MUST call this in `beforeAll` — see Issue #175.
+ *
+ * Handlebars `registerHelper` is idempotent (overwrites), so calling this more
+ * than once is safe.
  */
-prompt.registerHelper("href", (lineNum: unknown, content: unknown): string => {
-	const { ref } = formatHashlineRef(lineNum, content);
-	return JSON.stringify(ref);
-});
+export function registerCodingAgentPromptHelpers(): void {
+	prompt.registerHelper("jtdToTypeScript", (schema: unknown): string => {
+		try {
+			return jtdToTypeScript(schema);
+		} catch {
+			return "unknown";
+		}
+	});
 
-/**
- * {{hline lineNum "content"}} — format a full read-style line with prefix.
- * Returns `"lineNum#hash:content"`.
- */
-prompt.registerHelper("hline", (lineNum: unknown, content: unknown): string => {
-	const { ref, text } = formatHashlineRef(lineNum, content);
-	return `${ref}:${text}`;
-});
+	prompt.registerHelper("SECTION_SEPERATOR", (name: unknown): string => sectionSeparator(String(name)));
 
-/**
- * {{anchor name checksum}} — render a branch anchor tag using the current anchor style.
- * Style is resolved from the template context (`anchorStyle`) or defaults to "full".
- */
-prompt.registerHelper("anchor", function (this: prompt.TemplateContext, name: string, checksum: string): string {
-	const style = (this.anchorStyle as ChunkAnchorStyle) ?? "full";
-	return formatAnchor(name, checksum, style);
-});
+	/**
+	 * {{href lineNum "content"}} — compute a real hashline ref for prompt examples.
+	 * Returns `"lineNum#hash"` using the actual hash algorithm.
+	 */
+	prompt.registerHelper("href", (lineNum: unknown, content: unknown): string => {
+		const { ref } = formatHashlineRef(lineNum, content);
+		return JSON.stringify(ref);
+	});
 
-/**
- * {{sel "parent_Name.child_Name"}} — render a chunk path for `sel` fields in examples.
- * In `full` style the path is returned as-is (`class_Server.fn_start`).
- * In `kind` style each segment is trimmed to its kind prefix (`class.fn`).
- * In `bare` style the path is omitted (the model uses only `crc` to identify chunks).
- */
-prompt.registerHelper("sel", function (this: prompt.TemplateContext, chunkPath: string): string {
-	const style = (this.anchorStyle as ChunkAnchorStyle) ?? "full";
-	if (style === "full") return chunkPath;
-	if (style === "bare") return "";
-	// kind: trim each segment to its kind prefix (before the first `_`)
-	return chunkPath
-		.split(".")
-		.map(seg => {
-			const idx = seg.indexOf("_");
-			return idx === -1 ? seg : seg.slice(0, idx);
-		})
-		.join(".");
-});
+	/**
+	 * {{hline lineNum "content"}} — format a full read-style line with prefix.
+	 * Returns `"lineNum#hash:content"`.
+	 */
+	prompt.registerHelper("hline", (lineNum: unknown, content: unknown): string => {
+		const { ref, text } = formatHashlineRef(lineNum, content);
+		return `${ref}:${text}`;
+	});
+
+	/**
+	 * {{anchor name checksum}} — render a branch anchor tag using the current anchor style.
+	 * Style is resolved from the template context (`anchorStyle`) or defaults to "full".
+	 */
+	prompt.registerHelper("anchor", function (this: prompt.TemplateContext, name: string, checksum: string): string {
+		const style = (this.anchorStyle as ChunkAnchorStyle) ?? "full";
+		return formatAnchor(name, checksum, style);
+	});
+
+	/**
+	 * {{sel "parent_Name.child_Name"}} — render a chunk path for `sel` fields in examples.
+	 * In `full` style the path is returned as-is (`class_Server.fn_start`).
+	 * In `kind` style each segment is trimmed to its kind prefix (`class.fn`).
+	 * In `bare` style the path is omitted (the model uses only `crc` to identify chunks).
+	 */
+	prompt.registerHelper("sel", function (this: prompt.TemplateContext, chunkPath: string): string {
+		const style = (this.anchorStyle as ChunkAnchorStyle) ?? "full";
+		if (style === "full") return chunkPath;
+		if (style === "bare") return "";
+		// kind: trim each segment to its kind prefix (before the first `_`)
+		return chunkPath
+			.split(".")
+			.map(seg => {
+				const idx = seg.indexOf("_");
+				return idx === -1 ? seg : seg.slice(0, idx);
+			})
+			.join(".");
+	});
+}
+
+// Preserve original module-load behavior so existing importers continue to work
+// unchanged. See `registerCodingAgentPromptHelpers` docblock.
+registerCodingAgentPromptHelpers();
 
 const INLINE_ARG_SHELL_PATTERN = /\$(?:ARGUMENTS|@(?:\[\d+(?::\d*)?\])?|\d+)/;
 const INLINE_ARG_TEMPLATE_PATTERN = /\{\{[\s\S]*?(?:\b(?:arguments|ARGUMENTS|args)\b|\barg\s+[^}]+)[\s\S]*?\}\}/;

--- a/packages/coding-agent/test/config/prompt-templates-helpers.test.ts
+++ b/packages/coding-agent/test/config/prompt-templates-helpers.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { prompt } from "@f5xc-salesdemos/pi-utils";
+import { registerCodingAgentPromptHelpers } from "../../src/config/prompt-templates";
+
+describe("registerCodingAgentPromptHelpers", () => {
+	it("is exported as a callable function", () => {
+		expect(typeof registerCodingAgentPromptHelpers).toBe("function");
+	});
+
+	it("registers all six coding-agent Handlebars helpers", () => {
+		registerCodingAgentPromptHelpers();
+		// Behavioral check: rendering a template that uses each helper must not throw
+		// `Missing helper`. We assert each helper produces some output (shape is verified
+		// in dedicated tests below); failure here means the helper was not registered.
+		expect(() => prompt.render('{{SECTION_SEPERATOR "X"}}', {})).not.toThrow();
+		expect(() => prompt.render("{{jtdToTypeScript schema}}", { schema: { type: "string" } })).not.toThrow();
+		expect(() => prompt.render('{{href 1 "x"}}', {})).not.toThrow();
+		expect(() => prompt.render('{{hline 1 "x"}}', {})).not.toThrow();
+		expect(() => prompt.render('{{anchor "n" "c"}}', {})).not.toThrow();
+		expect(() => prompt.render('{{sel "a.b"}}', {})).not.toThrow();
+	});
+
+	it("SECTION_SEPERATOR helper renders the expected separator shape", () => {
+		registerCodingAgentPromptHelpers();
+		const rendered = prompt.render('{{SECTION_SEPERATOR "Workspace"}}', {});
+		expect(rendered).toContain("Workspace");
+		expect(rendered).toContain("═");
+	});
+
+	it("is idempotent — calling twice does not throw or leak state", () => {
+		expect(() => {
+			registerCodingAgentPromptHelpers();
+			registerCodingAgentPromptHelpers();
+		}).not.toThrow();
+		const rendered = prompt.render('{{SECTION_SEPERATOR "Identity"}}', {});
+		expect(rendered).toContain("Identity");
+	});
+
+	it("href helper produces a hashline-style reference", () => {
+		registerCodingAgentPromptHelpers();
+		const rendered = prompt.render('{{href 42 "hello"}}', {});
+		// Shape: JSON-quoted "lineNum#hash" where hash is whatever computeLineHash returns.
+		expect(rendered).toMatch(/^"42#[A-Za-z0-9]+"$/);
+	});
+
+	it("hline helper produces a read-style formatted line", () => {
+		registerCodingAgentPromptHelpers();
+		const rendered = prompt.render('{{hline 10 "const x = 1;"}}', {});
+		// Shape: lineNum#hash:content
+		expect(rendered).toMatch(/^10#[A-Za-z0-9]+:const x = 1;$/);
+	});
+});

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { prompt } from "@f5xc-salesdemos/pi-utils";
 import { buildSystemPrompt } from "@f5xc-salesdemos/xcsh/system-prompt";
 import Handlebars from "handlebars";
+import { registerCodingAgentPromptHelpers } from "../src/config/prompt-templates";
 
 const baseGitContext = {
 	isRepo: true,
@@ -87,6 +88,17 @@ async function withTempDir(run: (dir: string) => Promise<void>): Promise<void> {
 }
 
 describe("system Handlebars prompt templates", () => {
+	beforeAll(() => {
+		registerCodingAgentPromptHelpers();
+	});
+
+	test("custom-system-prompt renders without depending on coding-agent helpers", async () => {
+		const templatePath = path.join(systemPromptsDir, "custom-system-prompt.md");
+		const template = await Bun.file(templatePath).text();
+		const rendered = prompt.render(template, { ...baseRenderContext });
+		expect(rendered.length).toBeGreaterThan(0);
+	});
+
 	test("parses and compiles every system template", async () => {
 		const templates = await loadSystemPromptTemplates();
 		expect(templates.size).toBeGreaterThan(0);


### PR DESCRIPTION
## What

Wrap the 6 Handlebars helpers in `packages/coding-agent/src/config/prompt-templates.ts` (`jtdToTypeScript`, `SECTION_SEPERATOR`, `href`, `hline`, `anchor`, `sel`) in a new exported `registerCodingAgentPromptHelpers()` function. Helper bodies preserved byte-identical. A module-bottom side-effect call keeps production wiring (`sdk.ts` -> `index.ts` -> `prompt-templates.ts`) unchanged.

Tests that call `prompt.render()` directly now invoke `registerCodingAgentPromptHelpers()` from a `beforeAll()` hook so they pick up the helpers without depending on unrelated import side effects.

Changes:

- `packages/coding-agent/src/config/prompt-templates.ts` — extract registration into exported function, retain module-bottom call.
- `packages/coding-agent/test/config/prompt-templates-helpers.test.ts` (new) — 6 unit tests covering export, registration (behavioural via `prompt.render`), `SECTION_SEPERATOR` output, idempotency, and `href` / `hline` output.
- `packages/coding-agent/test/system-prompt-templates.test.ts` — import the new function, register in `beforeAll()`, add one custom-system-prompt regression-guard test.

## Why

Issue #175: two tests in `system-prompt-templates.test.ts` failed on `main` with `Missing helper: "SECTION_SEPERATOR"`. Root cause — helper was registered as a module-load side effect in `prompt-templates.ts`, but tests calling `prompt.render(template, ...)` bypassed any import path that loaded that module.

Option A from the issue (explicit registration function) was chosen. Tests now opt in via `beforeAll`; production keeps the side-effect registration and observes no behaviour change.

Closes #175

## Testing

Local verification (all green):

- `bun test test/config/prompt-templates-helpers.test.ts` -> 6 pass / 0 fail (new)
- `bun test test/system-prompt-templates.test.ts` -> 8 pass / 0 fail (was 5 pass / 2 fail — both `SECTION_SEPERATOR` failures resolved; 1 new regression-guard test passing)
- `bun test test/system-prompt-dedup.test.ts` -> 5 pass / 0 fail
- `bun test test/internal-urls/xcsh-protocol.test.ts` -> 17 pass / 0 fail
- `bun test test/plan-mode/plan-mode-approved-prompt.test.ts` -> 1 pass / 0 fail
- `bun run check:types` -> clean
- Biome on 3 modified files -> clean (one quote-style nit auto-fixed)

Full `packages/coding-agent/test` scope: 3347 pass / 400 skip / 7 fail. The 7 failures are pre-existing repo-wide infrastructure debt (filesystem/permission timeouts) in `auto-config.test.ts`, `sdk-skills.test.ts`, and `setup-litellm.test.ts` — none of those files import `prompt-templates.ts`; verified unrelated to this branch.

---

- [x] `bun run check` passes
- [x] `bun test` — no new failures vs baseline (2 previously failing tests now pass)
- [ ] CHANGELOG updated (if user-facing) — not user-facing; test/internal plumbing only
- [x] Issue linked via `Closes #175`