### PR TITLE
feat(coding-agent): restyle user message as F5-branded admonition box (#183)

### DIFF
--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -1,4 +1,4 @@
-import { Container, Markdown } from "@f5xc-salesdemos/pi-tui";
+import { Container, Markdown, padding, Spacer, visibleWidth } from "@f5xc-salesdemos/pi-tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 
 // OSC 133 shell integration: marks prompt zones for terminal multiplexers
@@ -6,12 +6,18 @@ const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
 
-// U+258C LEFT HALF BLOCK — theme-coloured left bar, matches chrome accents.
-const BAR_PREFIX = "▌ ";
-const BAR_PREFIX_WIDTH = 2;
+// U+2503 BOX DRAWINGS HEAVY VERTICAL — continuation bar on wrapped lines.
+const CONTINUATION_BAR = "┃";
+// Markdown child uses paddingX=1 and clamps contentWidth>=1, so its minimum
+// render output is 3 terminal cells. Anything narrower than prefix+3 would
+// overflow the requested width — bail out instead.
+const MIN_MARKDOWN_WIDTH = 3;
 
 /**
- * Component that renders a user message
+ * Renders a user message as an F5-branded admonition block: pi icon on the
+ * first content line, heavy vertical bar on continuations (both in `border`
+ * color), `userMessageBg` painted across the full requested width, and a
+ * leading blank spacer separating the prompt from the preceding block.
  */
 export class UserMessageComponent extends Container {
 	constructor(text: string, synthetic = false) {
@@ -19,28 +25,45 @@ export class UserMessageComponent extends Container {
 		const color = synthetic
 			? (value: string) => theme.fg("dim", value)
 			: (value: string) => theme.fg("userMessageText", value);
-		this.addChild(
-			new Markdown(text, 1, 0, getMarkdownTheme(), {
-				color,
-			}),
-		);
+		this.addChild(new Spacer(1));
+		this.addChild(new Markdown(text, 1, 0, getMarkdownTheme(), { color }));
 	}
 
 	override render(width: number): string[] {
-		const innerWidth = width - BAR_PREFIX_WIDTH;
-		if (innerWidth <= 0) {
+		const piPrefix = `${theme.icon.pi} `;
+		const contPrefix = `${CONTINUATION_BAR} `;
+		// Prefix width is theme-dependent — Unicode π is 1 col, Nerd Font
+		// glyph and ASCII "pi" are 2 cols. Measure both and reserve the
+		// larger so every content line leaves room for either shape.
+		const prefixWidth = Math.max(visibleWidth(piPrefix), visibleWidth(contPrefix));
+		const innerWidth = width - prefixWidth;
+		if (innerWidth < MIN_MARKDOWN_WIDTH) {
 			return [];
 		}
-		const inner = super.render(innerWidth);
-		if (inner.length === 0) {
-			return inner;
+		const raw = super.render(innerWidth);
+		if (raw.length === 0) {
+			return raw;
 		}
 
-		const bar = theme.fg("border", BAR_PREFIX);
-		const lines = inner.map(line => bar + line);
+		let firstContent = 0;
+		while (firstContent < raw.length && raw[firstContent] === "") {
+			firstContent++;
+		}
+		if (firstContent === raw.length) {
+			return raw;
+		}
 
-		lines[0] = OSC133_ZONE_START + lines[0];
-		lines[lines.length - 1] = lines[lines.length - 1] + OSC133_ZONE_END + OSC133_ZONE_FINAL;
-		return lines;
+		const leading = raw.slice(0, firstContent);
+		const content = raw.slice(firstContent).map((line, i) => {
+			const prefix = theme.fg("border", i === 0 ? piPrefix : contPrefix);
+			const combined = prefix + line;
+			const pad = Math.max(0, width - visibleWidth(combined));
+			return theme.bg("userMessageBg", combined + padding(pad));
+		});
+
+		content[0] = OSC133_ZONE_START + content[0];
+		content[content.length - 1] = content[content.length - 1] + OSC133_ZONE_END + OSC133_ZONE_FINAL;
+
+		return [...leading, ...content];
 	}
 }

--- a/packages/coding-agent/test/user-message.test.ts
+++ b/packages/coding-agent/test/user-message.test.ts
@@ -1,13 +1,14 @@
 import { beforeAll, describe, expect, it } from "bun:test";
+import { visibleWidth } from "@f5xc-salesdemos/pi-tui";
 import { UserMessageComponent } from "@f5xc-salesdemos/xcsh/modes/components/user-message";
 import { initTheme, theme } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
+const CONTINUATION_BAR = "┃"; // U+2503 BOX DRAWINGS HEAVY VERTICAL
 
 function stripAnsi(str: string): string {
-	// Strip OSC sequences (ESC ] ... BEL) first, then CSI.
 	return str.replace(/\x1b\][^\x07]*\x07/g, "").replace(/\x1b\[[0-9;]*m/g, "");
 }
 
@@ -15,17 +16,13 @@ function renderPlain(component: UserMessageComponent, width = 120): string[] {
 	return component.render(width).map(stripAnsi);
 }
 
-// Extract the ANSI opening sequence produced by a theme helper, e.g. the
-// leading CSI escape returned from `theme.fg("border", "X")`. The helper
-// returns `${ansi}X\x1b[39m` (or `\x1b[49m` for bg), so we carve out the
-// prefix by slicing off the sentinel and reset.
 function fgPrefix(token: Parameters<typeof theme.fg>[0]): string {
-	const SENTINEL = "\u0001";
+	const SENTINEL = "";
 	const wrapped = theme.fg(token, SENTINEL);
 	return wrapped.slice(0, wrapped.indexOf(SENTINEL));
 }
 function bgPrefix(token: Parameters<typeof theme.bg>[0]): string {
-	const SENTINEL = "\u0001";
+	const SENTINEL = "";
 	const wrapped = theme.bg(token, SENTINEL);
 	return wrapped.slice(0, wrapped.indexOf(SENTINEL));
 }
@@ -35,60 +32,69 @@ describe("UserMessageComponent", () => {
 		initTheme();
 	});
 
-	it("prefixes every rendered line with '▌ '", () => {
-		const c = new UserMessageComponent("hello world");
+	it("prefixes every content line with pi icon or continuation bar", () => {
+		const c = new UserMessageComponent("hello world\nsecond line");
 		const lines = renderPlain(c);
-		expect(lines.length).toBeGreaterThan(0);
-		for (const line of lines) {
-			expect(line.startsWith("▌ ")).toBe(true);
+		expect(lines.length).toBeGreaterThan(1);
+		const pi = theme.icon.pi;
+		// Line 0 is the leading spacer. Content starts at line 1.
+		expect(lines[1].startsWith(`${pi} `)).toBe(true);
+		for (let i = 2; i < lines.length; i++) {
+			expect(lines[i].startsWith(`${CONTINUATION_BAR} `)).toBe(true);
 		}
 	});
 
-	it("has no leading or trailing blank line", () => {
+	it("has a leading blank spacer line", () => {
 		const c = new UserMessageComponent("hello world");
 		const lines = renderPlain(c);
-		expect(lines.length).toBeGreaterThan(0);
-		// After stripping "▌ " the remainder must have visible content
-		// on the first and last line — proves paddingY=0 and no Spacer.
-		const first = lines[0].replace(/^▌ /, "").trim();
-		const last = lines[lines.length - 1].replace(/^▌ /, "").trim();
-		expect(first.length).toBeGreaterThan(0);
-		expect(last.length).toBeGreaterThan(0);
+		expect(lines.length).toBeGreaterThan(1);
+		// Line 0 is the spacer (separator from preceding block) — empty.
+		expect(lines[0]).toBe("");
+		// Line 1 is the first content line — non-empty.
+		expect(lines[1].trim().length).toBeGreaterThan(0);
 	});
 
-	it("renders a single-line message on exactly one rendered line", () => {
-		// Proves the Spacer(1) is gone (previously forced 2+ lines for any input).
+	it("renders a single-line message as spacer + one content line", () => {
 		const c = new UserMessageComponent("hi");
-		expect(renderPlain(c)).toHaveLength(1);
+		expect(renderPlain(c)).toHaveLength(2);
 	});
 
-	it("does not paint userMessageBg anywhere", () => {
-		const c = new UserMessageComponent("hello world");
-		const raw = c.render(120).join("\n");
-		const forbidden = bgPrefix("userMessageBg");
-		expect(raw.includes(forbidden)).toBe(false);
-	});
-
-	it("colours the left bar with the theme's border token", () => {
-		const c = new UserMessageComponent("hello world");
+	it("paints userMessageBg on every content line", () => {
+		const c = new UserMessageComponent("hello world\nanother line");
 		const raw = c.render(120);
-		expect(raw.length).toBeGreaterThan(0);
+		expect(raw.length).toBeGreaterThan(1);
+		const bg = bgPrefix("userMessageBg");
+		// Spacer line (raw[0]) must NOT carry the bg.
+		expect(raw[0].includes(bg)).toBe(false);
+		// Every content line MUST carry the bg.
+		for (let i = 1; i < raw.length; i++) {
+			expect(raw[i].includes(bg)).toBe(true);
+		}
+	});
+
+	it("uses pi icon on first content line and heavy bar on continuations, both in border color", () => {
+		const c = new UserMessageComponent("line one\nline two");
+		const raw = c.render(120);
 		const borderFg = fgPrefix("border");
-		// Every line must open with the border fg sequence wrapping "▌ ".
-		// The first line also has the OSC133 start marker prepended —
-		// accept either ordering so the test locks behaviour without
-		// over-specifying marker placement vs. the bar.
-		for (const line of raw) {
-			expect(line.includes(`${borderFg}▌ `)).toBe(true);
+		const pi = theme.icon.pi;
+		expect(raw.length).toBeGreaterThan(2); // spacer + >=2 content lines
+		// First content line carries border-coloured pi.
+		expect(raw[1].includes(`${borderFg}${pi} `)).toBe(true);
+		// Subsequent content lines carry the heavy vertical bar in border colour.
+		for (let i = 2; i < raw.length; i++) {
+			expect(raw[i].includes(`${borderFg}${CONTINUATION_BAR} `)).toBe(true);
 		}
 	});
 
 	it("preserves OSC 133 zone markers on first and last line", () => {
 		const c = new UserMessageComponent("line one\nline two");
 		const raw = c.render(120);
-		expect(raw.length).toBeGreaterThanOrEqual(1);
-		// Markers must still surround the message as a whole.
-		expect(raw[0].includes(OSC133_ZONE_START)).toBe(true);
+		expect(raw.length).toBeGreaterThanOrEqual(2);
+		// Spacer does NOT carry markers.
+		expect(raw[0].includes(OSC133_ZONE_START)).toBe(false);
+		// First content line carries the start marker.
+		expect(raw[1].includes(OSC133_ZONE_START)).toBe(true);
+		// Last line ends with the end + final markers.
 		expect(raw[raw.length - 1].endsWith(OSC133_ZONE_END + OSC133_ZONE_FINAL)).toBe(true);
 	});
 
@@ -102,15 +108,44 @@ describe("UserMessageComponent", () => {
 		expect(rawReal.includes(fgPrefix("dim"))).toBe(false);
 	});
 
-	it("does not overflow the requested width", () => {
-		// Long single token at narrow width — every visible line must fit.
+	it("does not overflow the requested width in terminal columns", () => {
 		const longWord = "x".repeat(60);
 		const c = new UserMessageComponent(longWord);
 		const width = 40;
 		const lines = renderPlain(c, width);
 		expect(lines.length).toBeGreaterThan(0);
 		for (const line of lines) {
-			expect(line.length).toBeLessThanOrEqual(width);
+			// Compare terminal columns, not JS code-unit length — the
+			// contract is based on visibleWidth which counts wide glyphs
+			// (CJK, Nerd Font PUA) as 2 cells.
+			expect(visibleWidth(line)).toBeLessThanOrEqual(width);
 		}
+	});
+
+	it("background extends to the full requested width on every content line", () => {
+		const c = new UserMessageComponent("short");
+		const width = 80;
+		const lines = renderPlain(c, width);
+		expect(lines.length).toBeGreaterThan(1);
+		for (let i = 1; i < lines.length; i++) {
+			expect(visibleWidth(lines[i])).toBe(width);
+		}
+	});
+
+	it("bails out with empty output when width cannot fit prefix + markdown minimum", () => {
+		// prefix (<=2 cols) + MIN_MARKDOWN_WIDTH (3) = minimum 5 cols. Any
+		// narrower and the contract of not-overflowing cannot be met —
+		// verify we return [] rather than emitting oversized lines.
+		const c = new UserMessageComponent("hi");
+		for (const w of [0, 1, 2, 3, 4]) {
+			expect(c.render(w)).toEqual([]);
+		}
+	});
+
+	it("leading spacer line is completely unstyled (no bg, no fg)", () => {
+		const c = new UserMessageComponent("hello world");
+		const raw = c.render(120);
+		expect(raw.length).toBeGreaterThan(1);
+		expect(raw[0]).toBe("");
 	});
 });


### PR DESCRIPTION
## Summary

Closes #183.

Replaces the U+258C left half-block gutter with a theme-adaptive F5 pi icon
on the first content line and a U+2503 heavy vertical bar on continuations,
paints userMessageBg across the full rendered width, and adds a leading
Spacer(1) so the prompt no longer merges visually with the preceding block.

### Key changes

- `theme.icon.pi` (Unicode π / Nerd Font glyph / ASCII "pi") replaces the
  hardcoded left half-block; border color retained.
- `theme.bg("userMessageBg", ...)` applied to every content line after
  padding to the requested width; the leading spacer stays unstyled.
- OSC 133 zone markers moved to the first/last content lines (not the
  spacer) so shell-integration zones still surround the prompt text only.
- Prefix width derived via `visibleWidth(...)` to stay correct under the
  Nerd Font and ASCII symbol presets (where the glyph is 2 cells wide).
- Narrow-width guard: `innerWidth < 3` returns [] because the Markdown
  child's minimum render is 3 cells.

### Tests

Rewritten in place (10 existing + 1 new boundary test):

- Leading spacer, pi-on-first / bar-on-continuation, userMessageBg on
  every content line, OSC 133 on content (not spacer), background extends
  to full width, narrow-width bailout, unchanged behaviour for synthetic
  messages and overflow protection (now measured via visibleWidth).

### Why

Issue #183 asked for the human prompt to render as a proper admonition
block matching the visual weight of tool-output boxes. The
userMessageBg theme key and theme.icon.pi symbol preset already existed
across all 40+ themes — this wires them in.

## Test plan

- [x] `bun test packages/coding-agent/test/user-message.test.ts` — 11/11 pass
- [x] `bun check:ts` — exit 0 (Biome + tsgo clean)
- [x] Full `bun test packages/coding-agent/test/` — no new failures (7 pre-existing flaky failures in `tryAutoConfigLiteLLM`, `validateModelsConfig`, and `createAgentSession skills` are env/timeout-dependent, unrelated to this diff)
- [x] Codex rescue review completed — all P1/P2/P3 findings addressed
- [ ] CI checks pass on this PR