### PR TITLE
fix(coding-agent): colorize TUI gutter dots by outcome

### DIFF
--- a/packages/coding-agent/src/modes/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/components/bash-execution.ts
@@ -7,6 +7,7 @@ import { Container, ImageProtocol, Loader, Spacer, TERMINAL, Text, type TUI } fr
 import { getSymbolTheme, highlightCode, theme } from "../../modes/theme/theme";
 import { formatTruncationMetaNotice, type TruncationMeta } from "../../tools/output-meta";
 import { getSixelLineMask, isSixelPassthroughEnabled, sanitizeWithOptionalSixelPassthrough } from "../../utils/sixel";
+import { sanitizeErrorMessage } from "../utils/sanitize-error-message";
 import { DynamicBorder } from "./dynamic-border";
 import { truncateToVisualLines } from "./visual-truncate";
 
@@ -43,8 +44,14 @@ const CHUNK_THROTTLE_MS = 50;
 
 export class BashExecutionComponent extends Container {
 	#outputLines: string[] = [];
-	#status: "running" | "complete" | "cancelled" | "error" = "running";
+	// Failure-mode taxonomy:
+	//   "complete"  — zero exit
+	//   "error"     — non-zero exit (shell reported failure)
+	//   "cancelled" — user cancelled (e.g. pressed Esc)
+	//   "errored"   — uncaught exception (executor threw; no exit code)
+	#status: "running" | "complete" | "cancelled" | "error" | "errored" = "running";
 	#exitCode: number | undefined = undefined;
+	#errorMessage: string | undefined = undefined;
 	#loader: Loader;
 	#truncation?: TruncationMeta;
 	#expanded = false;
@@ -134,6 +141,29 @@ export class BashExecutionComponent extends Container {
 		}
 
 		this.#displayDirty = true;
+	}
+
+	/**
+	 * Gutter-outcome for this execution once a terminal status has been set.
+	 * "error" for cancelled, non-zero exit, or an uncaught executor exception;
+	 * "success" for clean zero exit; undefined while still running.
+	 */
+	get outcome(): "success" | "error" | undefined {
+		if (this.#status === "running") return undefined;
+		return this.#status === "complete" ? "success" : "error";
+	}
+
+	/**
+	 * Terminal state for an uncaught executor exception — distinct from a
+	 * non-zero shell exit (which uses `setComplete`). Footer renders
+	 * `(error: <message>)`. Idempotent after the first terminal call.
+	 */
+	setError(err: Error | string): void {
+		if (this.#status !== "running") return;
+		this.#status = "errored";
+		this.#errorMessage = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
+		this.#loader.stop();
+		this.#updateDisplay();
 	}
 
 	setComplete(
@@ -227,6 +257,12 @@ export class BashExecutionComponent extends Container {
 				statusParts.push(theme.fg("warning", "(cancelled)"));
 			} else if (this.#status === "error") {
 				statusParts.push(theme.fg("error", `(exit ${this.#exitCode})`));
+			} else if (this.#status === "errored") {
+				// `\u00a0` (NBSP) keeps the wrapper joined to the message so
+				// the Text component does not wrap at "(error:_<msg>)" in
+				// narrow terminals. Falls back to "unknown" if setError was
+				// never called with a message.
+				statusParts.push(theme.fg("error", `(error:\u00a0${this.#errorMessage ?? "unknown"})`));
 			}
 
 			if (this.#truncation) {

--- a/packages/coding-agent/src/modes/components/gutter-block.ts
+++ b/packages/coding-agent/src/modes/components/gutter-block.ts
@@ -16,13 +16,21 @@ export interface GutterConfig {
 	symbol: string;
 	/** Color function for active state (used for static active indicator) */
 	activeColorFn: (s: string) => string;
-	/** Color function for done state */
+	/**
+	 * Neutral done-state color. Used when `setDone()` is called without an
+	 * outcome, or when the specific outcome color function is not configured.
+	 */
 	doneColorFn: (s: string) => string;
+	/** Optional color function used for `setDone("success")`. */
+	doneSuccessColorFn?: (s: string) => string;
+	/** Optional color function used for `setDone("error")`. */
+	doneErrorColorFn?: (s: string) => string;
 	/** Whether to show spinner animation when active */
 	animated: boolean;
 }
 
 type GutterState = "active" | "done";
+type GutterOutcome = "success" | "error";
 
 /**
  * GutterBlock wraps a child component and prepends a 2-character left gutter
@@ -33,6 +41,7 @@ export class GutterBlock<T extends Component> implements Component {
 	#child: T;
 	#config: GutterConfig;
 	#state: GutterState;
+	#outcome?: GutterOutcome;
 	#ui: TUI;
 
 	// Spinner state
@@ -60,8 +69,9 @@ export class GutterBlock<T extends Component> implements Component {
 		return this.#state;
 	}
 
-	setDone(): void {
+	setDone(outcome?: GutterOutcome): void {
 		if (this.#state === "done") return;
+		this.#outcome = outcome;
 		this.#state = "done";
 		this.#stopSpinner();
 		this.#ui.requestRender();
@@ -125,7 +135,8 @@ export class GutterBlock<T extends Component> implements Component {
 
 	#buildGutterPrefix(): string {
 		if (this.#state === "done") {
-			return `${this.#config.doneColorFn(this.#config.symbol)} `;
+			const colorFn = this.#doneColorFnForOutcome();
+			return `${colorFn(this.#config.symbol)} `;
 		}
 
 		if (this.#config.animated) {
@@ -134,6 +145,16 @@ export class GutterBlock<T extends Component> implements Component {
 		}
 
 		return `${this.#config.activeColorFn(this.#config.symbol)} `;
+	}
+
+	#doneColorFnForOutcome(): (s: string) => string {
+		if (this.#outcome === "error" && this.#config.doneErrorColorFn) {
+			return this.#config.doneErrorColorFn;
+		}
+		if (this.#outcome === "success" && this.#config.doneSuccessColorFn) {
+			return this.#config.doneSuccessColorFn;
+		}
+		return this.#config.doneColorFn;
 	}
 
 	#startSpinner(): void {
@@ -183,12 +204,22 @@ export class DisposableContainer extends Container {
 // Factory functions
 // ============================================================================
 
-/** Animated ● gutter for active tool calls — spinner in spinnerAccent, done in dim */
+/**
+ * Animated ● gutter for tool calls and slash-command executions.
+ * Active: spinner in `spinnerAccent`.
+ * Done (unknown outcome): `dim` — neutral "completed" color when the call
+ *   site does not have success/error information.
+ * Done (success): `gutterSuccess` (falls back to `success` when the theme
+ *   does not define the dedicated token).
+ * Done (error): `gutterError` (falls back to `error`).
+ */
 export function createToolGutter<T extends Component>(ui: TUI, child: T): GutterBlock<T> {
 	return new GutterBlock(ui, child, {
 		symbol: "●",
 		activeColorFn: (s: string) => theme.fg("spinnerAccent", s),
 		doneColorFn: (s: string) => theme.fg("dim", s),
+		doneSuccessColorFn: (s: string) => theme.fg("gutterSuccess", s),
+		doneErrorColorFn: (s: string) => theme.fg("gutterError", s),
 		animated: true,
 	});
 }

--- a/packages/coding-agent/src/modes/components/python-execution.ts
+++ b/packages/coding-agent/src/modes/components/python-execution.ts
@@ -7,6 +7,7 @@ import { sanitizeText } from "@f5xc-salesdemos/pi-natives";
 import { Container, Loader, Spacer, Text, type TUI } from "@f5xc-salesdemos/pi-tui";
 import { getSymbolTheme, highlightCode, theme } from "../../modes/theme/theme";
 import { formatTruncationMetaNotice, type TruncationMeta } from "../../tools/output-meta";
+import { sanitizeErrorMessage } from "../utils/sanitize-error-message";
 import { DynamicBorder } from "./dynamic-border";
 import { truncateToVisualLines } from "./visual-truncate";
 
@@ -36,8 +37,14 @@ function highlightIfStructured(lines: string[]): string[] | undefined {
 
 export class PythonExecutionComponent extends Container {
 	#outputLines: string[] = [];
-	#status: "running" | "complete" | "cancelled" | "error" = "running";
+	// Failure-mode taxonomy:
+	//   "complete"  — zero exit
+	//   "error"     — non-zero exit (interpreter reported failure)
+	//   "cancelled" — user cancelled
+	//   "errored"   — uncaught exception (executor threw; no exit code)
+	#status: "running" | "complete" | "cancelled" | "error" | "errored" = "running";
 	#exitCode: number | undefined = undefined;
+	#errorMessage: string | undefined = undefined;
 	#loader: Loader;
 	#truncation?: TruncationMeta;
 	#expanded = false;
@@ -104,6 +111,29 @@ export class PythonExecutionComponent extends Container {
 			this.#outputLines.push(...newLines);
 		}
 
+		this.#updateDisplay();
+	}
+
+	/**
+	 * Gutter-outcome for this execution once a terminal status has been set.
+	 * "error" for cancelled, non-zero exit, or an uncaught executor exception;
+	 * "success" for clean zero exit; undefined while still running.
+	 */
+	get outcome(): "success" | "error" | undefined {
+		if (this.#status === "running") return undefined;
+		return this.#status === "complete" ? "success" : "error";
+	}
+
+	/**
+	 * Terminal state for an uncaught executor exception — distinct from a
+	 * non-zero interpreter exit (which uses `setComplete`). Footer renders
+	 * `(error: <message>)`. Idempotent after the first terminal call.
+	 */
+	setError(err: Error | string): void {
+		if (this.#status !== "running") return;
+		this.#status = "errored";
+		this.#errorMessage = sanitizeErrorMessage(err instanceof Error ? err.message : String(err));
+		this.#loader.stop();
 		this.#updateDisplay();
 	}
 
@@ -174,6 +204,11 @@ export class PythonExecutionComponent extends Container {
 				statusParts.push(theme.fg("warning", "(cancelled)"));
 			} else if (this.#status === "error") {
 				statusParts.push(theme.fg("error", `(exit ${this.#exitCode})`));
+			} else if (this.#status === "errored") {
+				// `\u00a0` (NBSP) keeps the wrapper joined to the message so
+				// the Text component does not wrap at "(error:_<msg>)" in
+				// narrow terminals.
+				statusParts.push(theme.fg("error", `(error:\u00a0${this.#errorMessage ?? "unknown"})`));
 			}
 
 			if (this.#truncation) {

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -725,6 +725,7 @@ export class CommandController {
 		}
 		this.ctx.ui.requestRender();
 
+		let failed = false;
 		try {
 			const result = await this.ctx.session.executeBash(
 				command,
@@ -750,14 +751,16 @@ export class CommandController {
 					truncation: meta?.truncation,
 				});
 			}
+			failed = result.cancelled || (typeof result.exitCode === "number" && result.exitCode !== 0);
 		} catch (error) {
+			failed = true;
 			if (this.ctx.bashComponent) {
-				this.ctx.bashComponent.setComplete(undefined, false);
+				this.ctx.bashComponent.setError(error instanceof Error ? error : String(error));
 			}
 			this.ctx.showError(`Bash command failed: ${error instanceof Error ? error.message : "Unknown error"}`);
 		}
 
-		bashGutter?.setDone();
+		bashGutter?.setDone(failed ? "error" : "success");
 		this.ctx.bashComponent = undefined;
 		this.ctx.ui.requestRender();
 	}
@@ -776,6 +779,7 @@ export class CommandController {
 		}
 		this.ctx.ui.requestRender();
 
+		let failed = false;
 		try {
 			const result = await this.ctx.session.executePython(
 				code,
@@ -794,14 +798,16 @@ export class CommandController {
 					truncation: meta?.truncation,
 				});
 			}
+			failed = result.cancelled || (typeof result.exitCode === "number" && result.exitCode !== 0);
 		} catch (error) {
+			failed = true;
 			if (this.ctx.pythonComponent) {
-				this.ctx.pythonComponent.setComplete(undefined, false);
+				this.ctx.pythonComponent.setError(error instanceof Error ? error : String(error));
 			}
 			this.ctx.showError(`Python execution failed: ${error instanceof Error ? error.message : "Unknown error"}`);
 		}
 
-		pythonGutter?.setDone();
+		pythonGutter?.setDone(failed ? "error" : "success");
 		this.ctx.pythonComponent = undefined;
 		this.ctx.ui.requestRender();
 	}

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -15,6 +15,7 @@ import { ToolExecutionComponent } from "../../modes/components/tool-execution";
 import { TtsrNotificationComponent } from "../../modes/components/ttsr-notification";
 import { getSymbolTheme, theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext, TodoPhase } from "../../modes/types";
+import { ReadGroupOutcomeAggregator } from "../../modes/utils/read-group-outcome-aggregator";
 import type { AgentSessionEvent } from "../../session/agent-session";
 import { calculatePromptTokens } from "../../session/compaction/compaction";
 import type { ExitPlanModeDetails } from "../../tools";
@@ -31,6 +32,7 @@ export class EventController {
 	#lastAssistantComponent: AssistantMessageComponent | undefined = undefined;
 	#idleCompactionTimer?: NodeJS.Timeout;
 	#pendingGutters = new Map<string, GutterBlock<any>>();
+	#readGroupAggregator = new ReadGroupOutcomeAggregator();
 	// streamingAssistantGutter is stored on ctx for cross-controller access (e.g. thinking toggle)
 	constructor(private ctx: InteractiveModeContext) {}
 
@@ -63,15 +65,20 @@ export class EventController {
 		return this.#lastReadGroup;
 	}
 
-	/** Remove a read tool's gutter entry; setDone() if no other reads share the same group gutter */
-	#cleanupReadGutter(toolCallId: string): void {
+	/**
+	 * Remove a read tool's gutter entry. Records the caller-supplied outcome
+	 * into the group aggregator; finalizes the gutter (calling `setDone` with
+	 * the aggregated worst outcome) only when no other reads still share the
+	 * same group gutter. The spinner stays active during the group lifetime.
+	 */
+	#cleanupReadGutter(toolCallId: string, outcome: "success" | "error"): void {
 		const gutter = this.#pendingGutters.get(toolCallId);
 		this.#pendingGutters.delete(toolCallId);
-		if (gutter) {
-			const stillActive = Array.from(this.#pendingGutters.values()).some(g => g === gutter);
-			if (!stillActive) {
-				gutter.setDone();
-			}
+		if (!gutter) return;
+		this.#readGroupAggregator.record(gutter, outcome);
+		const stillActive = Array.from(this.#pendingGutters.values()).some(g => g === gutter);
+		if (!stillActive) {
+			this.#readGroupAggregator.finalize(gutter);
 		}
 	}
 
@@ -366,7 +373,7 @@ export class EventController {
 						event.toolCallId,
 					);
 					if (isFinalAsyncState) {
-						this.#pendingGutters.get(event.toolCallId)?.setDone();
+						this.#pendingGutters.get(event.toolCallId)?.setDone(asyncState === "failed" ? "error" : "success");
 						this.#pendingGutters.delete(event.toolCallId);
 						this.ctx.pendingTools.delete(event.toolCallId);
 						this.#backgroundToolCallIds.delete(event.toolCallId);
@@ -388,7 +395,7 @@ export class EventController {
 						if (asyncState === "running") {
 							this.#backgroundToolCallIds.add(event.toolCallId);
 						} else {
-							this.#cleanupReadGutter(event.toolCallId);
+							this.#cleanupReadGutter(event.toolCallId, event.isError ? "error" : "success");
 							this.#backgroundToolCallIds.delete(event.toolCallId);
 							this.#clearReadToolCall(event.toolCallId);
 						}
@@ -414,7 +421,7 @@ export class EventController {
 						if (isBackgroundRunning) {
 							this.#backgroundToolCallIds.add(event.toolCallId);
 						} else {
-							this.#cleanupReadGutter(event.toolCallId);
+							this.#cleanupReadGutter(event.toolCallId, event.isError ? "error" : "success");
 							this.ctx.pendingTools.delete(event.toolCallId);
 							this.#backgroundToolCallIds.delete(event.toolCallId);
 							this.#clearReadToolCall(event.toolCallId);
@@ -434,7 +441,7 @@ export class EventController {
 						if (isBackgroundRunning) {
 							this.#backgroundToolCallIds.add(event.toolCallId);
 						} else {
-							this.#pendingGutters.get(event.toolCallId)?.setDone();
+							this.#pendingGutters.get(event.toolCallId)?.setDone(event.isError ? "error" : "success");
 							this.#pendingGutters.delete(event.toolCallId);
 							this.ctx.pendingTools.delete(event.toolCallId);
 							this.#backgroundToolCallIds.delete(event.toolCallId);
@@ -479,11 +486,33 @@ export class EventController {
 					this.ctx.streamingMessage = undefined;
 				}
 				await this.ctx.flushPendingModelSwitch();
-				for (const toolCallId of Array.from(this.ctx.pendingTools.keys())) {
-					if (!this.#backgroundToolCallIds.has(toolCallId)) {
-						this.#pendingGutters.get(toolCallId)?.setDone();
+				// Orphan pending tools at agent_end mean the turn aborted or
+				// errored before those tools completed. Mark the gutter as
+				// error so the live UI matches what a transcript rebuild
+				// renders for the same condition.
+				//
+				// We deliberately do NOT call `updateResult` here: a tool
+				// may have streamed partial output via
+				// `tool_execution_update` before aborting, and replacing
+				// that content with a synthetic "did not complete" string
+				// would discard the most diagnostic output in the exact
+				// failure case the user cares about. The error gutter
+				// color carries the outcome; the body keeps whatever
+				// streamed content it had.
+				{
+					const orphanGutters = new Set<GutterBlock<any>>();
+					for (const toolCallId of Array.from(this.ctx.pendingTools.keys())) {
+						if (this.#backgroundToolCallIds.has(toolCallId)) continue;
+						const gutter = this.#pendingGutters.get(toolCallId);
+						if (gutter) {
+							this.#readGroupAggregator.record(gutter, "error");
+							orphanGutters.add(gutter);
+						}
 						this.#pendingGutters.delete(toolCallId);
 						this.ctx.pendingTools.delete(toolCallId);
+					}
+					for (const gutter of orphanGutters) {
+						this.#readGroupAggregator.finalize(gutter);
 					}
 				}
 				this.#backgroundToolCallIds = new Set(

--- a/packages/coding-agent/src/modes/theme/dark.json
+++ b/packages/coding-agent/src/modes/theme/dark.json
@@ -28,6 +28,8 @@
 		"warning": "yellow",
 		"muted": "gray",
 		"dim": "dimGray",
+		"gutterSuccess": "cyan",
+		"gutterError": "red",
 		"text": "",
 		"thinkingText": "gray",
 		"selectedBg": "selectedBg",

--- a/packages/coding-agent/src/modes/theme/light.json
+++ b/packages/coding-agent/src/modes/theme/light.json
@@ -4,6 +4,7 @@
 	"vars": {
 		"teal": "#5a8080",
 		"blue": "#547da7",
+		"cyan": "#0077a0",
 		"green": "#588458",
 		"red": "#aa5555",
 		"yellow": "#9a7326",
@@ -27,6 +28,8 @@
 		"warning": "yellow",
 		"muted": "mediumGray",
 		"dim": "dimGray",
+		"gutterSuccess": "cyan",
+		"gutterError": "red",
 		"text": "",
 		"thinkingText": "mediumGray",
 		"selectedBg": "selectedBg",

--- a/packages/coding-agent/src/modes/theme/theme-schema.json
+++ b/packages/coding-agent/src/modes/theme/theme-schema.json
@@ -128,6 +128,14 @@
 					"$ref": "#/$defs/colorValue",
 					"description": "Error states"
 				},
+				"gutterSuccess": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Optional: done-state tool/command gutter dot color for successful outcomes. Falls back to `success` when omitted."
+				},
+				"gutterError": {
+					"$ref": "#/$defs/colorValue",
+					"description": "Optional: done-state tool/command gutter dot color for failed outcomes. Falls back to `error` when omitted."
+				},
 				"warning": {
 					"$ref": "#/$defs/colorValue",
 					"description": "Warning states"

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -818,6 +818,8 @@ const ThemeJsonSchema = Type.Object({
 		warning: ColorValueSchema,
 		muted: ColorValueSchema,
 		dim: ColorValueSchema,
+		gutterSuccess: Type.Optional(ColorValueSchema),
+		gutterError: Type.Optional(ColorValueSchema),
 		text: ColorValueSchema,
 		thinkingText: ColorValueSchema,
 		// Backgrounds & Content Text (11 colors)
@@ -937,6 +939,8 @@ export type ThemeColor =
 	| "warning"
 	| "muted"
 	| "dim"
+	| "gutterSuccess"
+	| "gutterError"
 	| "text"
 	| "thinkingText"
 	| "userMessageText"
@@ -1026,6 +1030,8 @@ const THEME_COLOR_RECORD = {
 	warning: true,
 	muted: true,
 	dim: true,
+	gutterSuccess: true,
+	gutterError: true,
 	text: true,
 	thinkingText: true,
 	userMessageText: true,
@@ -1314,6 +1320,9 @@ export class Theme {
 		// Fallback: chromeAccent and contentAccent inherit from accent when not defined
 		this.#fgColors.chromeAccent ??= this.#fgColors.accent;
 		this.#fgColors.spinnerAccent ??= this.#fgColors.accent;
+		// Gutter outcome colors inherit from success/error unless a theme overrides them
+		this.#fgColors.gutterSuccess ??= this.#fgColors.success;
+		this.#fgColors.gutterError ??= this.#fgColors.error;
 		// Powerline segment bg/fg fallbacks
 		this.#fgColors.statusLineOsIconBg ??= this.#fgColors.muted;
 		this.#fgColors.statusLineOsIconFg ??= this.#fgColors.text;

--- a/packages/coding-agent/src/modes/utils/read-group-outcome-aggregator.ts
+++ b/packages/coding-agent/src/modes/utils/read-group-outcome-aggregator.ts
@@ -1,0 +1,55 @@
+import type { Component } from "@f5xc-salesdemos/pi-tui";
+import type { GutterBlock } from "../components/gutter-block";
+
+type Outcome = "success" | "error";
+
+/**
+ * Aggregates per-read outcomes across a shared read-group gutter so the
+ * final rendered dot reflects the worst-case outcome of the group.
+ *
+ * Called by two paths:
+ *   • live event-controller — reads arrive one at a time during streaming;
+ *     the gutter's spinner must stay active until the last read in the
+ *     group completes, so finalize is called only when `stillActive` is
+ *     false.
+ *   • replay ui-helpers — transcript rebuild walks completed tool results
+ *     in order; finalize is called at each group boundary.
+ *
+ * Semantics:
+ *   • `record` merges an incoming outcome into the running worst-case for
+ *     the gutter. "error" beats "success" regardless of ordering.
+ *   • `finalize` flushes the aggregated outcome to `gutter.setDone()`,
+ *     clears the entry, and returns. Calling `finalize` on a gutter that
+ *     was never `record`ed calls `setDone()` with no argument so the
+ *     gutter renders in its neutral done state.
+ *   • `peek` is read-only — useful for assertions and instrumentation.
+ */
+// Gutter generic parameter is not relevant to aggregation; constrain to
+// `Component` (the superclass required by GutterBlock) so callers with
+// concrete child types still flow in cleanly.
+type AnyGutter = GutterBlock<Component>;
+
+export class ReadGroupOutcomeAggregator {
+	#outcomes = new WeakMap<AnyGutter, Outcome>();
+
+	record(gutter: AnyGutter, outcome: Outcome): void {
+		const current = this.#outcomes.get(gutter);
+		// "error" is strictly worse than "success" — once any read in the
+		// group fails, the whole group is marked failed.
+		if (current === "error") return;
+		this.#outcomes.set(gutter, outcome);
+	}
+
+	peek(gutter: AnyGutter): Outcome | undefined {
+		return this.#outcomes.get(gutter);
+	}
+
+	finalize(gutter: AnyGutter): void {
+		const outcome = this.#outcomes.get(gutter);
+		this.#outcomes.delete(gutter);
+		gutter.setDone(outcome);
+	}
+}
+
+// Re-export for callers that need the generic gutter type alias.
+export type { AnyGutter as ReadGroupGutter, Outcome as ReadGroupOutcome };

--- a/packages/coding-agent/src/modes/utils/sanitize-error-message.ts
+++ b/packages/coding-agent/src/modes/utils/sanitize-error-message.ts
@@ -1,0 +1,60 @@
+import { Ellipsis, truncateToWidth } from "@f5xc-salesdemos/pi-tui";
+
+/**
+ * Single-line-safe sanitizer for error messages rendered inside TUI status
+ * footers (e.g. `(error: <message>)`). Protects the layout from payloads that
+ * contain ANSI escape sequences, embedded newlines, tabs, other control
+ * characters, wide glyphs (CJK / emoji), or are simply too long to fit on
+ * one terminal row.
+ *
+ * Contract (applied in order):
+ *   1. Full ANSI escape sequences (CSI like `\x1b[31m`, OSC like
+ *      `\x1b]8;;...\x1b\\`, and single-byte ESC introducers) are removed
+ *      WHOLE — not just the lone ESC byte — so no `[31mboom[0m` garbage
+ *      survives.
+ *   2. Embedded newlines and tabs are collapsed to a single space.
+ *   3. Any remaining ASCII control characters (\x00–\x1F and \x7F) are
+ *      stripped.
+ *   4. Runs of whitespace are collapsed to a single space; leading/trailing
+ *      whitespace is trimmed.
+ *   5. Output is truncated to {@link MAX_ERROR_MESSAGE_WIDTH} **terminal
+ *      cells** (not UTF-16 code units) via `truncateToWidth` from pi-tui;
+ *      wide glyphs therefore count as 2 cells each. Truncation is marked
+ *      with a single horizontal ellipsis (`…`). The limit is chosen so
+ *      that `(error: <msg>)` (9-cell wrapper) fits on a single row of an
+ *      80-column terminal.
+ */
+
+// Sanitized-message budget for the `(error: <msg>)` footer.
+//
+// The footer is rendered inside GutterBlock (2-cell prefix) + the bash/
+// python execution box (which reserves a 1-cell Text indent on each side
+// plus a further gap on the right before wrapping occurs in practice).
+// Arithmetic gives ~68 cells on an 80-column terminal, but empirical
+// rendering with `createToolGutter(new BashExecutionComponent(...)).render(80)`
+// still wraps the trailing `)` onto the next row at that ceiling.
+// Pin the budget well inside the algebraic limit so the guarantee holds
+// under the real layered layout.
+//
+// Net budget for the message: 60 cells → full footer ≤ ~73 cells →
+// safe on any terminal ≥ 80 columns even after the gutter + box overhead.
+export const MAX_ERROR_MESSAGE_WIDTH = 60;
+
+// Matches CSI (Control Sequence Introducer) / SGR sequences: \x1b[ … final byte.
+const ANSI_CSI_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+// Matches OSC (Operating System Command) sequences: \x1b] … terminator (BEL or ESC\).
+const ANSI_OSC_RE = /\x1b\][\s\S]*?(?:\x07|\x1b\\)/g;
+// Fallback for any stray single-byte ESC sequences (e.g. "\x1bM" reverse index).
+const ANSI_ESC_RE = /\x1b[@-_]?/g;
+
+export function sanitizeErrorMessage(raw: string): string {
+	const withoutAnsi = raw.replace(ANSI_OSC_RE, "").replace(ANSI_CSI_RE, "").replace(ANSI_ESC_RE, "");
+	// Collapse whitespace-like control chars (tab, newline, CR, form feed)
+	// to a single space, then strip every remaining control character.
+	const flattened = withoutAnsi.replace(/[\t\n\r\f\v]+/g, " ").replace(/[\x00-\x1F\x7F]/g, "");
+	const collapsed = flattened.replace(/\s+/g, " ").trim();
+	// truncateToWidth measures in terminal cells (wide glyphs count as 2)
+	// and appends an ellipsis when it clips. Returns the input unchanged if
+	// already within budget.
+	return truncateToWidth(collapsed, MAX_ERROR_MESSAGE_WIDTH, Ellipsis.Unicode);
+}

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -20,6 +20,7 @@ import { ToolExecutionComponent } from "../../modes/components/tool-execution";
 import { UserMessageComponent } from "../../modes/components/user-message";
 import { theme } from "../../modes/theme/theme";
 import type { CompactionQueuedMessage, InteractiveModeContext } from "../../modes/types";
+import { ReadGroupOutcomeAggregator } from "../../modes/utils/read-group-outcome-aggregator";
 import { type CustomMessage, SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "../../session/messages";
 import type { SessionContext } from "../../session/session-manager";
 import { formatBytes, formatDuration } from "../../tools/render-utils";
@@ -86,7 +87,7 @@ export class UiHelpers {
 					truncation: message.meta?.truncation,
 				});
 				const gutter = createToolGutter(this.ctx.ui, component);
-				gutter.setDone();
+				gutter.setDone(component.outcome);
 				this.ctx.chatContainer.addChild(gutter);
 				break;
 			}
@@ -99,7 +100,7 @@ export class UiHelpers {
 					truncation: message.meta?.truncation,
 				});
 				const gutter = createToolGutter(this.ctx.ui, component);
-				gutter.setDone();
+				gutter.setDone(component.outcome);
 				this.ctx.chatContainer.addChild(gutter);
 				break;
 			}
@@ -227,6 +228,30 @@ export class UiHelpers {
 		}
 
 		let readGroup: ReadToolGroupComponent | null = null;
+		// Parallel to `readGroup`: the wrapping gutter for the current read
+		// group. Held so the aggregator can finalize the correct gutter at
+		// each group boundary.
+		let readGroupGutter: ReturnType<typeof createToolGutter> | null = null;
+		// IDs of reads added to the current group but not yet matched to a
+		// toolResult. Any still-pending read at group boundary counts as an
+		// "error" outcome for the group, matching the live
+		// `agent_end`-time error coloring of orphaned tools.
+		let unmatchedReadsInGroup = new Set<string>();
+		const readGroupAggregator = new ReadGroupOutcomeAggregator();
+		const finalizeReadGroup = (): void => {
+			if (readGroupGutter) {
+				// Any read in this group that never received a toolResult
+				// is an orphan → record error so the group aggregates to
+				// "error" instead of silently ending on the last success.
+				for (const _id of unmatchedReadsInGroup) {
+					readGroupAggregator.record(readGroupGutter, "error");
+				}
+				readGroupAggregator.finalize(readGroupGutter);
+			}
+			readGroup = null;
+			readGroupGutter = null;
+			unmatchedReadsInGroup = new Set<string>();
+		};
 		const readToolCallArgs = new Map<string, Record<string, unknown>>();
 		const readToolCallAssistantComponents = new Map<string, AssistantMessageComponent>();
 		const toolGutters = new Map<string, ReturnType<typeof createToolGutter>>();
@@ -246,7 +271,9 @@ export class UiHelpers {
 				if (assistantComponent) {
 					assistantComponent.setUsageInfo(message.usage);
 				}
-				readGroup = null;
+				// New assistant message — finalize the previous group so its
+				// gutter resolves with the worst outcome seen so far.
+				finalizeReadGroup();
 				const hasErrorStop = message.stopReason === "aborted" || message.stopReason === "error";
 				const errorMessage = hasErrorStop
 					? message.stopReason === "aborted"
@@ -270,10 +297,15 @@ export class UiHelpers {
 							if (!readGroup) {
 								readGroup = new ReadToolGroupComponent();
 								readGroup.setExpanded(this.ctx.toolOutputExpanded);
-								const readGutter = createToolGutter(this.ctx.ui, readGroup);
-								readGutter.setDone();
-								this.ctx.chatContainer.addChild(readGutter);
+								readGroupGutter = createToolGutter(this.ctx.ui, readGroup);
+								this.ctx.chatContainer.addChild(readGroupGutter);
 							}
+							if (readGroupGutter) {
+								readGroupAggregator.record(readGroupGutter, "error");
+							}
+							// error-stop path injects an immediate error
+							// result, so the read is NOT unmatched.
+							unmatchedReadsInGroup.delete(content.id);
 							readGroup.updateArgs(content.arguments, content.id);
 							readGroup.updateResult(
 								{ content: [{ type: "text", text: errorMessage }], isError: true },
@@ -289,11 +321,17 @@ export class UiHelpers {
 							if (assistantComponent) {
 								readToolCallAssistantComponents.set(content.id, assistantComponent);
 							}
+							// Track this read as part of the current group.
+							// A matching toolResult will remove it; anything
+							// left at group boundary is an unmatched orphan
+							// and counts as an error for the aggregator.
+							unmatchedReadsInGroup.add(content.id);
 						}
 						continue;
 					}
 
-					readGroup = null;
+					// Non-read tool call breaks the group.
+					finalizeReadGroup();
 					const tool = this.ctx.session.getToolByName(content.name);
 					const renderArgs =
 						"partialJson" in content
@@ -322,7 +360,7 @@ export class UiHelpers {
 							false,
 							content.id,
 						);
-						toolGutter.setDone();
+						toolGutter.setDone("error");
 					} else {
 						// Tool result hasn't arrived yet — keep gutter active until completion
 						this.ctx.pendingTools.set(content.id, component);
@@ -339,19 +377,28 @@ export class UiHelpers {
 						assistantComponent.setToolResultImages(message.toolCallId, images);
 						const hasText = message.content.some(c => c.type === "text");
 						if (!hasText) {
+							// Image-only reads are still successful reads —
+							// record them into the current group aggregate
+							// and remove from unmatched tracking so the
+							// group does not wrongly aggregate to "error"
+							// on a subsequent boundary.
+							if (readGroupGutter) {
+								readGroupAggregator.record(readGroupGutter, message.isError ? "error" : "success");
+							}
+							unmatchedReadsInGroup.delete(message.toolCallId);
 							readToolCallArgs.delete(message.toolCallId);
 							readToolCallAssistantComponents.delete(message.toolCallId);
 							continue;
 						}
 					}
+					const readOutcome: "success" | "error" = message.isError ? "error" : "success";
 					let component = this.ctx.pendingTools.get(message.toolCallId);
 					if (!component) {
 						if (!readGroup) {
 							readGroup = new ReadToolGroupComponent();
 							readGroup.setExpanded(this.ctx.toolOutputExpanded);
-							const readGutter = createToolGutter(this.ctx.ui, readGroup);
-							readGutter.setDone();
-							this.ctx.chatContainer.addChild(readGutter);
+							readGroupGutter = createToolGutter(this.ctx.ui, readGroup);
+							this.ctx.chatContainer.addChild(readGroupGutter);
 						}
 						const args = readToolCallArgs.get(message.toolCallId);
 						if (args) {
@@ -360,21 +407,49 @@ export class UiHelpers {
 						component = readGroup;
 						this.ctx.pendingTools.set(message.toolCallId, readGroup);
 					}
+					if (readGroupGutter) {
+						readGroupAggregator.record(readGroupGutter, readOutcome);
+					}
+					// This read now has a matching result — it is no longer
+					// an unmatched orphan for the group's aggregation.
+					unmatchedReadsInGroup.delete(message.toolCallId);
 					component.updateResult(message, false, message.toolCallId);
 					this.ctx.pendingTools.delete(message.toolCallId);
-					toolGutters.get(message.toolCallId)?.setDone();
+					toolGutters.get(message.toolCallId)?.setDone(readOutcome);
 					toolGutters.delete(message.toolCallId);
 					readToolCallArgs.delete(message.toolCallId);
 					readToolCallAssistantComponents.delete(message.toolCallId);
 					continue;
 				}
 
-				// Match tool results to pending tool components
+				// Match tool results to pending tool components.
+				//
+				// Persisted async-running results (details.async.state ===
+				// "running") describe jobs that were active when the
+				// session was saved — the persisted outcome is neither
+				// success nor failure, just "incomplete". Finalize the
+				// gutter with the neutral (dim) done color so rebuilt
+				// transcripts don't misreport them as successful. True
+				// resumption of such a job across sessions would require
+				// handing the gutter to the live EventController's
+				// private #pendingGutters map — out of scope for this
+				// rebuild.
 				const component = this.ctx.pendingTools.get(message.toolCallId);
 				if (component) {
+					const asyncState = (message.details as { async?: { state?: string } } | undefined)?.async?.state;
+					const isAsyncRunning = asyncState === "running";
 					component.updateResult(message, false, message.toolCallId);
 					this.ctx.pendingTools.delete(message.toolCallId);
-					toolGutters.get(message.toolCallId)?.setDone();
+					const gutter = toolGutters.get(message.toolCallId);
+					if (gutter) {
+						if (isAsyncRunning) {
+							// Neutral "completed state" color — not
+							// success and not error.
+							gutter.setDone();
+						} else {
+							gutter.setDone(message.isError ? "error" : "success");
+						}
+					}
 					toolGutters.delete(message.toolCallId);
 				}
 			} else {
@@ -388,10 +463,25 @@ export class UiHelpers {
 			this.ctx.addMessageToChat(message, options);
 		}
 
-		this.ctx.pendingTools.clear();
-		// Mark any remaining tool gutters as done (tools without results in history)
-		for (const gutter of toolGutters.values()) {
-			gutter.setDone();
+		// Finalize any still-open read group at the tail of the transcript.
+		// This also records "error" for any reads in the final group that
+		// never received a toolResult, so incomplete groups aggregate to
+		// error rather than silently closing on the last success.
+		finalizeReadGroup();
+		// Tool gutters without a matching result mean the session was
+		// persisted with an unfinished tool — an aborted/errored turn.
+		// Inject an error body so the component renders as failed (it has
+		// no prior streamed content during a rebuild), and mark the
+		// gutter error.
+		for (const [toolCallId, gutter] of toolGutters.entries()) {
+			const component = this.ctx.pendingTools.get(toolCallId);
+			component?.updateResult(
+				{ content: [{ type: "text", text: "Tool call did not complete" }], isError: true },
+				false,
+				toolCallId,
+			);
+			this.ctx.pendingTools.delete(toolCallId);
+			gutter.setDone("error");
 		}
 		toolGutters.clear();
 		this.ctx.ui.requestRender();
@@ -603,14 +693,14 @@ export class UiHelpers {
 		for (const component of this.ctx.pendingBashComponents) {
 			this.ctx.pendingMessagesContainer.removeChild(component);
 			const gutter = createToolGutter(this.ctx.ui, component);
-			gutter.setDone();
+			gutter.setDone(component.outcome);
 			this.ctx.chatContainer.addChild(gutter);
 		}
 		this.ctx.pendingBashComponents = [];
 		for (const component of this.ctx.pendingPythonComponents) {
 			this.ctx.pendingMessagesContainer.removeChild(component);
 			const gutter = createToolGutter(this.ctx.ui, component);
-			gutter.setDone();
+			gutter.setDone(component.outcome);
 			this.ctx.chatContainer.addChild(gutter);
 		}
 		this.ctx.pendingPythonComponents = [];

--- a/packages/coding-agent/test/bash-execution-outcome.test.ts
+++ b/packages/coding-agent/test/bash-execution-outcome.test.ts
@@ -1,0 +1,163 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { TUI } from "@f5xc-salesdemos/pi-tui";
+import { BashExecutionComponent } from "../src/modes/components/bash-execution";
+import { initTheme } from "../src/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+const ui = { requestRender: () => {} } as unknown as TUI;
+
+// Strip ANSI escape sequences so status assertions read cleanly.
+// NBSP → regular space so test matchers like `.toContain("(error: msg)")`
+// don't need to care about the wrap-prevention character choice.
+function stripAnsi(s: string): string {
+	return s.replace(/\x1b\[[0-9;]*m/g, "").replace(/\u00a0/g, " ");
+}
+
+function renderedFooter(c: BashExecutionComponent): string {
+	return stripAnsi(c.render(80).join("\n"));
+}
+
+describe("BashExecutionComponent — outcome + status footer", () => {
+	it("running: outcome is undefined, no status footer", () => {
+		const c = new BashExecutionComponent("echo hi", ui, false);
+		expect(c.outcome).toBeUndefined();
+		const footer = renderedFooter(c);
+		expect(footer).not.toContain("(exit");
+		expect(footer).not.toContain("(error:");
+		expect(footer).not.toContain("(cancelled)");
+	});
+
+	it("clean zero exit: outcome 'success', no (exit N) footer", () => {
+		const c = new BashExecutionComponent("echo ok", ui, false);
+		c.setComplete(0, false);
+		expect(c.outcome).toBe("success");
+		const footer = renderedFooter(c);
+		expect(footer).not.toContain("(exit");
+		expect(footer).not.toContain("(error:");
+	});
+
+	it("non-zero exit: outcome 'error', footer shows (exit N)", () => {
+		const c = new BashExecutionComponent("false", ui, false);
+		c.setComplete(1, false);
+		expect(c.outcome).toBe("error");
+		expect(renderedFooter(c)).toContain("(exit 1)");
+	});
+
+	it("cancelled: outcome 'error', footer shows (cancelled)", () => {
+		const c = new BashExecutionComponent("sleep 10", ui, false);
+		c.setComplete(undefined, true);
+		expect(c.outcome).toBe("error");
+		expect(renderedFooter(c)).toContain("(cancelled)");
+	});
+
+	it("setError(Error): outcome 'error', footer shows (error: <message>)", () => {
+		const c = new BashExecutionComponent("thing", ui, false);
+		c.setError(new Error("shell crashed"));
+		expect(c.outcome).toBe("error");
+		const footer = renderedFooter(c);
+		expect(footer).toContain("(error: shell crashed)");
+		// Should NOT fall back to (exit undefined) or (cancelled)
+		expect(footer).not.toContain("(exit");
+		expect(footer).not.toContain("(cancelled)");
+	});
+
+	it("setError(string): outcome 'error', footer shows the string message", () => {
+		const c = new BashExecutionComponent("thing", ui, false);
+		c.setError("spawn ENOENT");
+		expect(c.outcome).toBe("error");
+		expect(renderedFooter(c)).toContain("(error: spawn ENOENT)");
+	});
+
+	it("setError stops the loader and is a no-op if called twice", () => {
+		const c = new BashExecutionComponent("thing", ui, false);
+		c.setError(new Error("first"));
+		expect(c.outcome).toBe("error");
+		// Second call must not regress state or throw.
+		c.setError(new Error("second"));
+		expect(c.outcome).toBe("error");
+	});
+
+	it("setError: multi-line exception message is collapsed to a single line", () => {
+		const c = new BashExecutionComponent("thing", ui, false);
+		c.setError(new Error("line one\nline two\nline three"));
+		const footer = renderedFooter(c);
+		// All three parts should appear on the SAME footer line — no embedded
+		// newlines that could break TUI layout.
+		const errorLine = footer.split("\n").find(l => l.includes("(error:"));
+		expect(errorLine).toBeDefined();
+		expect(errorLine).toContain("line one");
+		expect(errorLine).toContain("line two");
+		expect(errorLine).toContain("line three");
+	});
+
+	it("setError: tab and control characters are stripped", () => {
+		const c = new BashExecutionComponent("thing", ui, false);
+		c.setError(new Error("bad\tword\x07here"));
+		const footer = renderedFooter(c);
+		expect(footer).toContain("(error:");
+		// Raw control chars (tab, BEL) must not survive into the footer.
+		expect(footer).not.toContain("\t");
+		expect(footer).not.toContain("\x07");
+	});
+
+	it("setError: overly long message is truncated with an ellipsis (rendered wide)", () => {
+		const c = new BashExecutionComponent("thing", ui, false);
+		const longMsg = "x".repeat(500);
+		c.setError(new Error(longMsg));
+		// Render at a wide terminal so the sanitizer's ellipsis is visible
+		// — visual-truncate at narrow widths clips the line before the
+		// trailing `…` the sanitizer appends. Layout safety at narrow
+		// widths is tested below.
+		const wide = stripAnsi(c.render(400).join("\n"));
+		const errorLine = wide.split("\n").find(l => l.includes("(error:"));
+		expect(errorLine).toBeDefined();
+		// Strip the terminal-width padding before measuring the payload length.
+		expect(errorLine!.trimEnd().length).toBeLessThan(250);
+		expect(errorLine).toContain("…");
+	});
+
+	it("setError: narrow render width keeps the entire footer on a single row", () => {
+		const c = new BashExecutionComponent("thing", ui, false);
+		c.setError(new Error("x".repeat(500)));
+		const narrowLines = c.render(80).map(stripAnsi);
+		// The row containing `(error:` must also contain the closing `)` —
+		// if the footer wrapped across multiple terminal rows, the opening
+		// `(error:` would be on one row and the closing `)` on another.
+		const errorRow = narrowLines.find(l => l.includes("(error:"));
+		expect(errorRow).toBeDefined();
+		expect(errorRow).toMatch(/\(error:.*\)/);
+	});
+
+	it("setError: gutter-wrapped layout also keeps the footer on a single row", async () => {
+		// Real UI path: BashExecutionComponent is wrapped in a tool gutter
+		// before being added to the chat container. That gutter consumes 2
+		// cells on every row, tightening the footer budget beyond the
+		// component's own math. Verify that the sanitizer budget is tight
+		// enough that `(error: ...)` fits even under the gutter overhead.
+		const { createToolGutter } = await import("../src/modes/components/gutter-block");
+		const c = new BashExecutionComponent("thing", ui, false);
+		c.setError(new Error("x".repeat(500)));
+		const wrapped = createToolGutter(ui, c);
+		wrapped.setDone("error");
+		const rows = wrapped.render(80).map(stripAnsi);
+		const errorRow = rows.find(l => l.includes("(error:"));
+		expect(errorRow).toBeDefined();
+		expect(errorRow).toMatch(/\(error:.*\)/);
+	});
+
+	it("setError: ANSI-colored exception text is rendered without escape-code garbage", () => {
+		const c = new BashExecutionComponent("thing", ui, false);
+		c.setError(new Error("\x1b[31mboom\x1b[0m"));
+		const footer = renderedFooter(c);
+		const errorRow = footer.split("\n").find(l => l.includes("(error:"));
+		expect(errorRow).toBeDefined();
+		// The CSI payload (`[31m`, `[0m`) must be fully stripped — not just
+		// the ESC byte — or the footer will render `[31mboom[0m` garbage.
+		expect(errorRow).toContain("boom");
+		expect(errorRow).not.toContain("[31m");
+		expect(errorRow).not.toContain("[0m");
+	});
+});

--- a/packages/coding-agent/test/gutter-block.test.ts
+++ b/packages/coding-agent/test/gutter-block.test.ts
@@ -312,6 +312,89 @@ describe("GutterBlock", () => {
 			expect(gutter.state).toBe("done");
 		});
 
+		it('setDone("error") uses doneErrorColorFn when provided', () => {
+			const ui = mockTUI();
+			const gutter = new GutterBlock(ui, stubComponent(["x"]), {
+				symbol: "●",
+				activeColorFn: s => `[active:${s}]`,
+				doneColorFn: s => `[done-ok:${s}]`,
+				doneErrorColorFn: s => `[done-err:${s}]`,
+				animated: false,
+			});
+
+			gutter.setDone("error");
+
+			expect(gutter.state).toBe("done");
+			const lines = gutter.render(80);
+			expect(lines[0]).toContain("[done-err:●]");
+		});
+
+		it('setDone("success") uses doneSuccessColorFn when provided', () => {
+			const ui = mockTUI();
+			const gutter = new GutterBlock(ui, stubComponent(["x"]), {
+				symbol: "●",
+				activeColorFn: s => `[active:${s}]`,
+				doneColorFn: s => `[done-neutral:${s}]`,
+				doneSuccessColorFn: s => `[done-ok:${s}]`,
+				doneErrorColorFn: s => `[done-err:${s}]`,
+				animated: false,
+			});
+
+			gutter.setDone("success");
+
+			const lines = gutter.render(80);
+			expect(lines[0]).toContain("[done-ok:●]");
+		});
+
+		it("setDone() with no argument uses the neutral doneColorFn", () => {
+			const ui = mockTUI();
+			const gutter = new GutterBlock(ui, stubComponent(["x"]), {
+				symbol: "●",
+				activeColorFn: s => `[active:${s}]`,
+				doneColorFn: s => `[done-neutral:${s}]`,
+				doneSuccessColorFn: s => `[done-ok:${s}]`,
+				doneErrorColorFn: s => `[done-err:${s}]`,
+				animated: false,
+			});
+
+			gutter.setDone();
+
+			const lines = gutter.render(80);
+			expect(lines[0]).toContain("[done-neutral:●]");
+		});
+
+		it('setDone("success") falls back to doneColorFn when doneSuccessColorFn is absent', () => {
+			const ui = mockTUI();
+			const gutter = new GutterBlock(ui, stubComponent(["x"]), {
+				symbol: "●",
+				activeColorFn: s => `[active:${s}]`,
+				doneColorFn: s => `[done-only:${s}]`,
+				// no doneSuccessColorFn — keeps text / streaming-assistant gutters inert
+				animated: false,
+			});
+
+			gutter.setDone("success");
+
+			const lines = gutter.render(80);
+			expect(lines[0]).toContain("[done-only:●]");
+		});
+
+		it('setDone("error") falls back to doneColorFn when doneErrorColorFn is absent', () => {
+			const ui = mockTUI();
+			const gutter = new GutterBlock(ui, stubComponent(["x"]), {
+				symbol: "●",
+				activeColorFn: s => `[active:${s}]`,
+				doneColorFn: s => `[done-only:${s}]`,
+				// no doneErrorColorFn — keeps text / streaming-assistant gutters inert
+				animated: false,
+			});
+
+			gutter.setDone("error");
+
+			const lines = gutter.render(80);
+			expect(lines[0]).toContain("[done-only:●]");
+		});
+
 		it("setDone() is a no-op if already done", () => {
 			const ui = mockTUI();
 			const gutter = new GutterBlock(
@@ -666,6 +749,62 @@ describe("factory functions", () => {
 
 		const lines = gutter.render(80);
 		expect(stripAnsi(lines[0])).toContain("●");
+	});
+
+	it("createToolGutter renders three distinct ANSI sequences for neutral / success / error", () => {
+		const neutralGutter = createToolGutter(mockTUI(), stubComponent(["x"]));
+		const okGutter = createToolGutter(mockTUI(), stubComponent(["x"]));
+		const errGutter = createToolGutter(mockTUI(), stubComponent(["x"]));
+
+		neutralGutter.setDone();
+		okGutter.setDone("success");
+		errGutter.setDone("error");
+
+		const neutralLine = neutralGutter.render(80)[0];
+		const okLine = okGutter.render(80)[0];
+		const errLine = errGutter.render(80)[0];
+		// All three still carry the ● glyph
+		expect(stripAnsi(neutralLine)).toContain("●");
+		expect(stripAnsi(okLine)).toContain("●");
+		expect(stripAnsi(errLine)).toContain("●");
+		// And all three produce distinct raw (ANSI-bearing) prefixes:
+		// neutral = dim, success = gutterSuccess (cyan), error = gutterError (red).
+		expect(neutralLine).not.toEqual(okLine);
+		expect(neutralLine).not.toEqual(errLine);
+		expect(okLine).not.toEqual(errLine);
+	});
+
+	it("createToolGutter success prefix carries the gutterSuccess ANSI bytes", async () => {
+		const { getThemeByName, setThemeInstance } = await import("../src/modes/theme/theme");
+		const dark = await getThemeByName("dark");
+		expect(dark).toBeDefined();
+		setThemeInstance(dark!);
+
+		const gutter = createToolGutter(mockTUI(), stubComponent(["x"]));
+		gutter.setDone("success");
+		const line = gutter.render(80)[0];
+		// The prefix must use the gutterSuccess token's resolved ANSI — no
+		// matter the terminal color mode (truecolor vs 256color). We assert
+		// substring-presence of whatever `theme.fg("gutterSuccess", "●")`
+		// renders, so the test doesn't fossilize a specific color mode.
+		const expectedGutterSuccessBytes = dark!.fg("gutterSuccess", "●");
+		expect(line).toContain(expectedGutterSuccessBytes);
+		// Negative: must NOT contain the gutterError bytes
+		const gutterErrorBytes = dark!.fg("gutterError", "●");
+		expect(line).not.toContain(gutterErrorBytes);
+	});
+
+	it("createToolGutter error prefix carries the gutterError ANSI bytes", async () => {
+		const { getThemeByName, setThemeInstance } = await import("../src/modes/theme/theme");
+		const dark = await getThemeByName("dark");
+		expect(dark).toBeDefined();
+		setThemeInstance(dark!);
+
+		const gutter = createToolGutter(mockTUI(), stubComponent(["x"]));
+		gutter.setDone("error");
+		const line = gutter.render(80)[0];
+		const expectedGutterErrorBytes = dark!.fg("gutterError", "●");
+		expect(line).toContain(expectedGutterErrorBytes);
 	});
 
 	it("createSystemGutter uses ※ symbol", () => {

--- a/packages/coding-agent/test/python-execution-outcome.test.ts
+++ b/packages/coding-agent/test/python-execution-outcome.test.ts
@@ -1,0 +1,138 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { TUI } from "@f5xc-salesdemos/pi-tui";
+import { PythonExecutionComponent } from "../src/modes/components/python-execution";
+import { initTheme } from "../src/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+const ui = { requestRender: () => {} } as unknown as TUI;
+
+// Strip ANSI and normalize NBSP to regular space — tests shouldn't care
+// about the wrap-prevention character choice.
+function stripAnsi(s: string): string {
+	return s.replace(/\x1b\[[0-9;]*m/g, "").replace(/\u00a0/g, " ");
+}
+
+function renderedFooter(c: PythonExecutionComponent): string {
+	return stripAnsi(c.render(80).join("\n"));
+}
+
+describe("PythonExecutionComponent — outcome + status footer", () => {
+	it("running: outcome is undefined, no status footer", () => {
+		const c = new PythonExecutionComponent("print('x')", ui, false);
+		expect(c.outcome).toBeUndefined();
+		const footer = renderedFooter(c);
+		expect(footer).not.toContain("(exit");
+		expect(footer).not.toContain("(error:");
+		expect(footer).not.toContain("(cancelled)");
+	});
+
+	it("clean zero exit: outcome 'success', no (exit N) footer", () => {
+		const c = new PythonExecutionComponent("1+1", ui, false);
+		c.setComplete(0, false);
+		expect(c.outcome).toBe("success");
+		expect(renderedFooter(c)).not.toContain("(exit");
+	});
+
+	it("non-zero exit: outcome 'error', footer shows (exit N)", () => {
+		const c = new PythonExecutionComponent("raise SystemExit(2)", ui, false);
+		c.setComplete(2, false);
+		expect(c.outcome).toBe("error");
+		expect(renderedFooter(c)).toContain("(exit 2)");
+	});
+
+	it("cancelled: outcome 'error', footer shows (cancelled)", () => {
+		const c = new PythonExecutionComponent("import time; time.sleep(10)", ui, false);
+		c.setComplete(undefined, true);
+		expect(c.outcome).toBe("error");
+		expect(renderedFooter(c)).toContain("(cancelled)");
+	});
+
+	it("setError(Error): outcome 'error', footer shows (error: <message>)", () => {
+		const c = new PythonExecutionComponent("print", ui, false);
+		c.setError(new Error("interpreter not found"));
+		expect(c.outcome).toBe("error");
+		const footer = renderedFooter(c);
+		expect(footer).toContain("(error: interpreter not found)");
+		expect(footer).not.toContain("(exit");
+		expect(footer).not.toContain("(cancelled)");
+	});
+
+	it("setError(string): outcome 'error', footer shows the string message", () => {
+		const c = new PythonExecutionComponent("print", ui, false);
+		c.setError("spawn ENOENT");
+		expect(c.outcome).toBe("error");
+		expect(renderedFooter(c)).toContain("(error: spawn ENOENT)");
+	});
+
+	it("setError is idempotent on a terminal component", () => {
+		const c = new PythonExecutionComponent("print", ui, false);
+		c.setError(new Error("first"));
+		c.setError(new Error("second"));
+		expect(c.outcome).toBe("error");
+	});
+
+	it("setError: multi-line exception message is collapsed to a single line", () => {
+		const c = new PythonExecutionComponent("print", ui, false);
+		c.setError(new Error("line one\nline two"));
+		const footer = renderedFooter(c);
+		const errorLine = footer.split("\n").find(l => l.includes("(error:"));
+		expect(errorLine).toBeDefined();
+		expect(errorLine).toContain("line one");
+		expect(errorLine).toContain("line two");
+	});
+
+	it("setError: tab and control characters are stripped", () => {
+		const c = new PythonExecutionComponent("print", ui, false);
+		c.setError(new Error("bad\tword\x07here"));
+		const footer = renderedFooter(c);
+		expect(footer).toContain("(error:");
+		expect(footer).not.toContain("\t");
+		expect(footer).not.toContain("\x07");
+	});
+
+	it("setError: overly long message is truncated with an ellipsis (rendered wide)", () => {
+		const c = new PythonExecutionComponent("print", ui, false);
+		c.setError(new Error("x".repeat(500)));
+		const wide = stripAnsi(c.render(400).join("\n"));
+		const errorLine = wide.split("\n").find(l => l.includes("(error:"));
+		expect(errorLine).toBeDefined();
+		// Strip the terminal-width padding before measuring the payload length.
+		expect(errorLine!.trimEnd().length).toBeLessThan(250);
+		expect(errorLine).toContain("…");
+	});
+
+	it("setError: narrow render width keeps the entire footer on a single row", () => {
+		const c = new PythonExecutionComponent("print", ui, false);
+		c.setError(new Error("x".repeat(500)));
+		const narrowLines = c.render(80).map(stripAnsi);
+		const errorRow = narrowLines.find(l => l.includes("(error:"));
+		expect(errorRow).toBeDefined();
+		expect(errorRow).toMatch(/\(error:.*\)/);
+	});
+
+	it("setError: gutter-wrapped layout also keeps the footer on a single row", async () => {
+		const { createToolGutter } = await import("../src/modes/components/gutter-block");
+		const c = new PythonExecutionComponent("print", ui, false);
+		c.setError(new Error("x".repeat(500)));
+		const wrapped = createToolGutter(ui, c);
+		wrapped.setDone("error");
+		const rows = wrapped.render(80).map(stripAnsi);
+		const errorRow = rows.find(l => l.includes("(error:"));
+		expect(errorRow).toBeDefined();
+		expect(errorRow).toMatch(/\(error:.*\)/);
+	});
+
+	it("setError: ANSI-colored exception text is rendered without escape-code garbage", () => {
+		const c = new PythonExecutionComponent("print", ui, false);
+		c.setError(new Error("\x1b[31mboom\x1b[0m"));
+		const footer = renderedFooter(c);
+		const errorRow = footer.split("\n").find(l => l.includes("(error:"));
+		expect(errorRow).toBeDefined();
+		expect(errorRow).toContain("boom");
+		expect(errorRow).not.toContain("[31m");
+		expect(errorRow).not.toContain("[0m");
+	});
+});

--- a/packages/coding-agent/test/read-group-outcome-aggregator.test.ts
+++ b/packages/coding-agent/test/read-group-outcome-aggregator.test.ts
@@ -1,0 +1,224 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import type { Component, TUI } from "@f5xc-salesdemos/pi-tui";
+import { createToolGutter, type GutterBlock } from "../src/modes/components/gutter-block";
+import { initTheme } from "../src/modes/theme/theme";
+import { ReadGroupOutcomeAggregator } from "../src/modes/utils/read-group-outcome-aggregator";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+const mockTUI = (): TUI => ({ requestRender: vi.fn() }) as unknown as TUI;
+const stub = (lines: string[]): Component => ({
+	render: () => [...lines],
+	invalidate: vi.fn(),
+});
+
+// Build a tool gutter that records which outcome `setDone` was ultimately
+// called with — the aggregator's only observable effect on a gutter.
+function makeTrackedGutter(): { gutter: GutterBlock<Component>; calls: Array<"success" | "error" | undefined> } {
+	const calls: Array<"success" | "error" | undefined> = [];
+	const gutter = createToolGutter(mockTUI(), stub(["x"]));
+	const originalSetDone = gutter.setDone.bind(gutter);
+	gutter.setDone = (outcome?: "success" | "error") => {
+		calls.push(outcome);
+		originalSetDone(outcome);
+	};
+	return { gutter, calls };
+}
+
+describe("ReadGroupOutcomeAggregator", () => {
+	it('finalize with only success records calls setDone("success")', () => {
+		const agg = new ReadGroupOutcomeAggregator();
+		const { gutter, calls } = makeTrackedGutter();
+
+		agg.record(gutter, "success");
+		agg.finalize(gutter);
+
+		expect(calls).toEqual(["success"]);
+	});
+
+	it('finalize with only error records calls setDone("error")', () => {
+		const agg = new ReadGroupOutcomeAggregator();
+		const { gutter, calls } = makeTrackedGutter();
+
+		agg.record(gutter, "error");
+		agg.finalize(gutter);
+
+		expect(calls).toEqual(["error"]);
+	});
+
+	it("error wins after success (success→error ordering)", () => {
+		const agg = new ReadGroupOutcomeAggregator();
+		const { gutter, calls } = makeTrackedGutter();
+
+		agg.record(gutter, "success");
+		agg.record(gutter, "error");
+		agg.finalize(gutter);
+
+		expect(calls).toEqual(["error"]);
+	});
+
+	it("error wins after success (error→success ordering)", () => {
+		const agg = new ReadGroupOutcomeAggregator();
+		const { gutter, calls } = makeTrackedGutter();
+
+		agg.record(gutter, "error");
+		agg.record(gutter, "success");
+		agg.finalize(gutter);
+
+		expect(calls).toEqual(["error"]);
+	});
+
+	it("finalize without any record calls setDone() with undefined outcome", () => {
+		const agg = new ReadGroupOutcomeAggregator();
+		const { gutter, calls } = makeTrackedGutter();
+
+		agg.finalize(gutter);
+
+		expect(calls).toEqual([undefined]);
+	});
+
+	it("peek reveals the running worst-case outcome without finalizing", () => {
+		const agg = new ReadGroupOutcomeAggregator();
+		const { gutter, calls } = makeTrackedGutter();
+
+		expect(agg.peek(gutter)).toBeUndefined();
+		agg.record(gutter, "success");
+		expect(agg.peek(gutter)).toBe("success");
+		agg.record(gutter, "error");
+		expect(agg.peek(gutter)).toBe("error");
+		// peek is read-only: still no setDone
+		expect(calls).toEqual([]);
+	});
+
+	it("tracks multiple gutters independently", () => {
+		const agg = new ReadGroupOutcomeAggregator();
+		const a = makeTrackedGutter();
+		const b = makeTrackedGutter();
+
+		agg.record(a.gutter, "success");
+		agg.record(b.gutter, "error");
+		agg.finalize(a.gutter);
+		agg.finalize(b.gutter);
+
+		expect(a.calls).toEqual(["success"]);
+		expect(b.calls).toEqual(["error"]);
+	});
+
+	it("finalize clears the tracked outcome so a gutter can be reused", () => {
+		const agg = new ReadGroupOutcomeAggregator();
+		const { gutter, calls } = makeTrackedGutter();
+
+		agg.record(gutter, "error");
+		agg.finalize(gutter);
+		// After finalize, the record is gone — peek returns undefined again.
+		expect(agg.peek(gutter)).toBeUndefined();
+		// Finalizing the same gutter a second time uses the fresh (empty) state.
+		agg.finalize(gutter);
+		// Second finalize adds another bare setDone() call (idempotent at the gutter level).
+		expect(calls).toEqual(["error", undefined]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Integration scenarios — rehearse the exact control flow of both call sites.
+// ---------------------------------------------------------------------------
+
+describe("ReadGroupOutcomeAggregator — call-site scenarios", () => {
+	/**
+	 * Mirrors `EventController.#cleanupReadGutter`. The live path keeps the
+	 * group gutter's spinner active while any read in the group is still
+	 * pending, then finalizes with the worst outcome once the last read
+	 * completes.
+	 */
+	function simulateLiveCleanup(
+		agg: ReadGroupOutcomeAggregator,
+		gutter: GutterBlock<Component>,
+		pendingGutters: Map<string, GutterBlock<Component>>,
+		toolCallId: string,
+		outcome: "success" | "error",
+	): void {
+		pendingGutters.delete(toolCallId);
+		agg.record(gutter, outcome);
+		const stillActive = Array.from(pendingGutters.values()).some(g => g === gutter);
+		if (!stillActive) {
+			agg.finalize(gutter);
+		}
+	}
+
+	it("live: two reads sharing one group — first success, second error → final error", () => {
+		const agg = new ReadGroupOutcomeAggregator();
+		const { gutter, calls } = makeTrackedGutter();
+		const pending = new Map<string, GutterBlock<Component>>([
+			["r1", gutter],
+			["r2", gutter],
+		]);
+
+		// First read completes successfully; r2 still pending → no finalize
+		simulateLiveCleanup(agg, gutter, pending, "r1", "success");
+		expect(calls).toEqual([]);
+
+		// Second read fails → finalize
+		simulateLiveCleanup(agg, gutter, pending, "r2", "error");
+		expect(calls).toEqual(["error"]);
+	});
+
+	it("live: two reads sharing one group — first error, second success → final error", () => {
+		const agg = new ReadGroupOutcomeAggregator();
+		const { gutter, calls } = makeTrackedGutter();
+		const pending = new Map<string, GutterBlock<Component>>([
+			["r1", gutter],
+			["r2", gutter],
+		]);
+
+		simulateLiveCleanup(agg, gutter, pending, "r1", "error");
+		expect(calls).toEqual([]);
+		simulateLiveCleanup(agg, gutter, pending, "r2", "success");
+		expect(calls).toEqual(["error"]);
+	});
+
+	it("live: two independent groups — one fails, one succeeds — finalize independently", () => {
+		const agg = new ReadGroupOutcomeAggregator();
+		const groupA = makeTrackedGutter();
+		const groupB = makeTrackedGutter();
+		const pending = new Map<string, GutterBlock<Component>>([
+			["a1", groupA.gutter],
+			["b1", groupB.gutter],
+		]);
+
+		simulateLiveCleanup(agg, groupA.gutter, pending, "a1", "error");
+		simulateLiveCleanup(agg, groupB.gutter, pending, "b1", "success");
+		expect(groupA.calls).toEqual(["error"]);
+		expect(groupB.calls).toEqual(["success"]);
+	});
+
+	/**
+	 * Mirrors `UiHelpers.loadConversation` replay flow. Each read result is
+	 * recorded into the aggregator, and the group is finalized at group
+	 * boundaries (non-read tool call, new assistant message, end of loop).
+	 */
+	it("replay: sequential reads across two groups separated by a boundary", () => {
+		const agg = new ReadGroupOutcomeAggregator();
+		const groupA = makeTrackedGutter();
+		const groupB = makeTrackedGutter();
+
+		// Group A — mixed outcomes
+		agg.record(groupA.gutter, "success");
+		agg.record(groupA.gutter, "error");
+		agg.record(groupA.gutter, "success");
+
+		// Boundary: non-read tool call arrives, finalize group A
+		agg.finalize(groupA.gutter);
+
+		// Group B — all success
+		agg.record(groupB.gutter, "success");
+		agg.record(groupB.gutter, "success");
+
+		// End of loop: finalize group B
+		agg.finalize(groupB.gutter);
+
+		expect(groupA.calls).toEqual(["error"]);
+		expect(groupB.calls).toEqual(["success"]);
+	});
+});

--- a/packages/coding-agent/test/sanitize-error-message.test.ts
+++ b/packages/coding-agent/test/sanitize-error-message.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import { MAX_ERROR_MESSAGE_WIDTH, sanitizeErrorMessage } from "../src/modes/utils/sanitize-error-message";
+
+describe("sanitizeErrorMessage", () => {
+	it("passes plain single-line messages through unchanged", () => {
+		expect(sanitizeErrorMessage("command not found")).toBe("command not found");
+	});
+
+	it("collapses embedded newlines to a single space", () => {
+		expect(sanitizeErrorMessage("line one\nline two\nline three")).toBe("line one line two line three");
+	});
+
+	it("collapses tabs and CR to a single space", () => {
+		expect(sanitizeErrorMessage("a\tb\r\nc")).toBe("a b c");
+	});
+
+	it("strips ASCII control characters except already-handled whitespace", () => {
+		// BEL, ESC, NUL, DEL must not survive
+		expect(sanitizeErrorMessage("bad\x07\x1b\x00\x7fword")).toBe("badword");
+	});
+
+	it("collapses runs of whitespace to a single space and trims", () => {
+		expect(sanitizeErrorMessage("   a     b   ")).toBe("a b");
+	});
+
+	it("truncates long messages at MAX_ERROR_MESSAGE_WIDTH with an ellipsis", () => {
+		const input = "x".repeat(MAX_ERROR_MESSAGE_WIDTH + 100);
+		const out = sanitizeErrorMessage(input);
+		expect(out.length).toBe(MAX_ERROR_MESSAGE_WIDTH);
+		expect(out.endsWith("…")).toBe(true);
+		expect(out.slice(0, MAX_ERROR_MESSAGE_WIDTH - 1)).toBe("x".repeat(MAX_ERROR_MESSAGE_WIDTH - 1));
+	});
+
+	it("handles empty and whitespace-only input", () => {
+		expect(sanitizeErrorMessage("")).toBe("");
+		expect(sanitizeErrorMessage("   \n\t  ")).toBe("");
+	});
+
+	it("preserves non-ASCII printable characters (unicode symbols, accents)", () => {
+		expect(sanitizeErrorMessage("café — ü ★")).toBe("café — ü ★");
+	});
+
+	it("strips full ANSI CSI escape sequences (colored error output)", () => {
+		// A subprocess returning `\x1b[31mboom\x1b[0m` must not leave
+		// `[31mboom[0m` garbage in the footer.
+		expect(sanitizeErrorMessage("\x1b[31mboom\x1b[0m")).toBe("boom");
+	});
+
+	it("strips ANSI SGR sequences with multiple parameters", () => {
+		expect(sanitizeErrorMessage("prefix \x1b[1;31;40merror\x1b[0m suffix")).toBe("prefix error suffix");
+	});
+
+	it("strips OSC escape sequences (terminal titles, hyperlinks)", () => {
+		// OSC 8 (hyperlink) and OSC terminators must be removed.
+		expect(sanitizeErrorMessage("pre \x1b]8;;http://x.y\x1b\\label\x1b]8;;\x1b\\ post")).toBe("pre label post");
+	});
+
+	it("truncation width stays well inside an 80-column terminal with the footer wrapper", () => {
+		// `(error: <msg>)` adds 9 chars of wrapper. A typical terminal is 80
+		// columns. Guarantee the sanitized message plus wrapper stays under
+		// 80 so the footer renders on a single line.
+		expect(MAX_ERROR_MESSAGE_WIDTH + 9).toBeLessThanOrEqual(80);
+	});
+
+	it("truncation measures in terminal cells, not UTF-16 code units (CJK)", async () => {
+		// CJK glyphs render as 2 cells but are 1 UTF-16 code unit each. If we
+		// truncated by .length we would emit up to MAX_ERROR_MESSAGE_WIDTH
+		// glyphs = 2*MAX cells, overflowing the 80-col target. The sanitizer
+		// must use display-width truncation.
+		const { visibleWidth } = await import("@f5xc-salesdemos/pi-tui");
+		const cjk = "漢".repeat(100); // 100 code units, 200 cells
+		const out = sanitizeErrorMessage(cjk);
+		expect(visibleWidth(out)).toBeLessThanOrEqual(MAX_ERROR_MESSAGE_WIDTH);
+	});
+
+	it("truncation preserves narrow ASCII up to the budget", async () => {
+		const { visibleWidth } = await import("@f5xc-salesdemos/pi-tui");
+		const out = sanitizeErrorMessage("x".repeat(MAX_ERROR_MESSAGE_WIDTH + 50));
+		expect(visibleWidth(out)).toBeLessThanOrEqual(MAX_ERROR_MESSAGE_WIDTH);
+		expect(out.endsWith("…")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/theme-gutter-fallback.test.ts
+++ b/packages/coding-agent/test/theme-gutter-fallback.test.ts
@@ -1,0 +1,47 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { getThemeByName, initTheme } from "../src/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+describe("theme: gutterSuccess / gutterError fallback", () => {
+	it("dark.json defines gutterSuccess explicitly — distinct from success", async () => {
+		const dark = await getThemeByName("dark");
+		expect(dark).toBeDefined();
+		// dark.json sets gutterSuccess="cyan" and success="green" — different ANSI
+		expect(dark!.fg("gutterSuccess", "●")).not.toBe(dark!.fg("success", "●"));
+	});
+
+	it("dark.json defines gutterError explicitly — distinct from error only if theme author wants it", async () => {
+		const dark = await getThemeByName("dark");
+		expect(dark).toBeDefined();
+		// dark.json sets gutterError="red" AND error="red" — same bytes; the fallback contract
+		// says gutterError is OPTIONALLY independent. Here they happen to match intentionally.
+		const dark_error = dark!.fg("error", "●");
+		const dark_gutterError = dark!.fg("gutterError", "●");
+		expect(dark_gutterError).toBe(dark_error);
+	});
+
+	it("a theme without gutter tokens falls back to success/error", async () => {
+		// `titanium` is one of ~90 built-in default themes that does NOT define
+		// gutterSuccess or gutterError in its JSON. The Theme constructor's
+		// nullish-coalesce fallback should make theme.fg(\"gutterSuccess\", ...)
+		// produce the same bytes as theme.fg(\"success\", ...).
+		const titanium = await getThemeByName("titanium");
+		expect(titanium).toBeDefined();
+		expect(titanium!.fg("gutterSuccess", "●")).toBe(titanium!.fg("success", "●"));
+		expect(titanium!.fg("gutterError", "●")).toBe(titanium!.fg("error", "●"));
+	});
+
+	it("fallback does not throw for gutterSuccess/gutterError on any built-in theme", async () => {
+		// Spot-check several defaults. If any theme lacked the fallback, fg()
+		// would throw "Unknown theme color" — this test pins the safety net.
+		for (const name of ["dark", "light", "titanium", "graphite", "marble", "xcsh-dark"]) {
+			const theme = await getThemeByName(name);
+			expect(theme, `missing theme: ${name}`).toBeDefined();
+			expect(() => theme!.fg("gutterSuccess", "●")).not.toThrow();
+			expect(() => theme!.fg("gutterError", "●")).not.toThrow();
+		}
+	});
+});


### PR DESCRIPTION
## What

Gutter dots next to TUI tool-call and slash-command blocks now reflect
the tool's outcome instead of always fading to dim grey:

- `setDone()` — neutral dim (unknown / mid-stream orphan)
- `setDone("success")` — cyan, via new `gutterSuccess` theme token
  (falls back to `success`)
- `setDone("error")` — red, via new `gutterError` theme token
  (falls back to `error`)

Touches the shared `GutterBlock` primitive, bash/python execution
components, the live event controller, the slash-command controller,
the conversation-replay path in `ui-helpers.loadConversation`, the
theme schema + dark/light JSON, and the new
`ReadGroupOutcomeAggregator` + `sanitizeErrorMessage` utilities.

## Why

Closes #173 — the previous behavior dropped all outcome information
at terminal render time, so a failed bash/python tool call looked
identical to a successful one once completed. The three-tier outcome
model restores the success/error distinction in the gutter while
keeping a neutral color for mid-stream/orphaned states.

Backwards compatibility: `gutterSuccess` / `gutterError` are optional
theme tokens and nullish-coalesce to `success` / `error` in the Theme
constructor, so all ~100 built-in themes continue to load without
updates. `dark.json` and `light.json` set them explicitly to cyan.

## Testing

Verification run in the worktree:

- `bun run check:ts` — clean
- `bun --cwd=packages/coding-agent test` — 3407 pass, 2 pre-existing
  flakes (permission + 5s async-skills timeouts, unrelated to this
  change)
- +65 net new passing tests across 5 new test files covering:
  gutter-block colorization, bash + python "errored" status,
  read-group outcome aggregation, error-message sanitization,
  and theme `gutterSuccess`/`gutterError` fallback behavior

Closes #173

---

- [x] `bun run check` passes
- [x] `bun test` — no new failures vs baseline
- [ ] CHANGELOG updated (not user-facing: internal TUI visual fix)
- [x] Issue linked via `Closes #173`