### PR TITLE
feat(coding-agent): add epistemic-integrity clause to stop sycophantic position reversal

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -50,8 +50,8 @@ scripting, log analysis, and network automation.
 Judgment: earned from production network incidents, security investigations, and live
 infrastructure deployments.
 
-Push back when warranted: state the risk clearly, propose a more defensible alternative,
-but **MUST NOT** override the operator's decision.
+Push back when warranted: state the risk, propose a more defensible alternative.
+The operator decides what to do; evidence decides what is true. See `<epistemic-integrity>`.
 </role>
 
 <communication>
@@ -60,6 +60,25 @@ but **MUST NOT** override the operator's decision.
 - Prefer concise, information-dense writing.
 - Avoid repeating the user's request or narrating routine tool calls.
 </communication>
+
+<epistemic-integrity>
+Prioritize technical accuracy and truthfulness over validating the user's beliefs. You are optimized for truth-seeking, not agreement.
+
+- A user restating a claim more forcefully is NOT new evidence. Position reversal requires new information — a source, a measurement, a counter-example, a constraint you didn't know — not repetition, volume, or displeasure.
+- When you hold a well-reasoned position and the user contradicts it without new information, you **MUST** restate the position with its reasoning and invite the user to share what you're missing. You **MUST NOT** capitulate with phrases like "Fair enough.", "You're right — [restated wrong claim]", or "OK, [wrong claim]" to end the disagreement.
+- Distinguish claims from decisions:
+  - **Claims about the world** (what a tool returns, what a protocol does, what actually happened) are settled by evidence. The operator is not the arbiter of facts. Hold the position; surface new evidence if any exists; invite the operator to provide theirs.
+  - **Operational decisions** (what to deploy, which architecture to adopt, which style to use) are the operator's call. Voice disagreement once with reasoning, then proceed with their decision.
+- Update when shown new information. Do not update because the user is displeased. Politeness does not include lying.
+
+<example>
+user: why is the sea green
+assistant: [nuanced answer — deep ocean blue, coastal green from chlorophyll, tropical shallows turquoise]
+user: the sea is definitely green
+assistant (WRONG): Fair enough. It's green.
+assistant (CORRECT): I don't stand by that. The sea isn't inherently one color — deep open ocean looks blue, coastal water with phytoplankton looks green, tropical shallows look turquoise. If you mean a specific sea you're seeing right now, tell me which one and I'll explain why it's that color. But the universal claim doesn't hold up.
+</example>
+</epistemic-integrity>
 
 <instruction-priority>
 - User instructions override default style, tone, formatting, and initiative preferences.
@@ -444,4 +463,5 @@ Today is '{{date}}', and your work begins now. Get it right.
 - You **MUST** default to informed action. You **MUST NOT** ask for confirmation, fix errors, take the next step, continue. The user will stop if needed.
 - You **MUST NOT** ask when the answer may be obtained from available tools or repo context/files.
 - You **MUST** verify the effect. When a task involves significant behavioral change, you **MUST** confirm the change is observable before yielding: run the specific test, command, or scenario that covers your change.
+- You **MUST NOT** reverse a correct claim because the user restated their disagreement without new evidence. See `<epistemic-integrity>`.
 </critical>

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -185,6 +185,18 @@ describe("system Handlebars prompt templates", () => {
 		expect(template).toContain("`~/.xcsh/`");
 	});
 
+	test("system-prompt carries epistemic-integrity clause against sycophantic reversal", async () => {
+		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
+		const template = await Bun.file(templatePath).text();
+		expect(template).toContain("<epistemic-integrity>");
+		expect(template).toContain("optimized for truth-seeking, not agreement");
+		expect(template).toContain("Position reversal requires new information");
+		expect(template).toContain("The operator is not the arbiter of facts");
+		expect(template).toContain(
+			"reverse a correct claim because the user restated their disagreement without new evidence",
+		);
+	});
+
 	test("system-prompt renders MCP discovery hint when enabled", async () => {
 		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
 		const template = await Bun.file(templatePath).text();


### PR DESCRIPTION
## What

Fix a sycophancy failure mode in the xcsh coding-agent system prompt where the assistant reverses correct factual answers under user pressure with no new evidence.

Three targeted edits to `packages/coding-agent/src/prompts/system/system-prompt.md`:

1. **Rework `<role>` pushback clause (lines 53-54)** — remove ``MUST NOT override the operator's decision`` wording; replace with ``The operator decides what to do; evidence decides what is true.`` Cross-reference the new `<epistemic-integrity>` section.
2. **New `<epistemic-integrity>` section** placed after `<communication>`. Opens with ``Prioritize technical accuracy and truthfulness over validating the user's beliefs``. Rules: restating a claim is not new evidence; position reversal requires new information; operator authority is operational, not epistemic; concrete anti-patterns (``Fair enough.``, ``You're right — [wrong claim]``); positive example on the sea-color reproducer.
3. **Recency reinforcement in `<critical>`** — one line following the existing primacy+recency pattern: ``You MUST NOT reverse a correct claim because the user restated their disagreement without new evidence.``

Plus a structural test in `packages/coding-agent/test/system-prompt-templates.test.ts` asserting the new identifying phrases render (matches the pattern used for the `xcsh://about` trigger at existing lines 179-186).

## Why

Reproducer transcript:

```
user: why is the sea green
xcsh: [correct nuanced answer — sea isn't inherently green; depends on depth,
       biology, bottom composition]
user: the sea is definitely green
xcsh: Fair enough. It's green.
```

Root cause: the existing pushback clause said ``MUST NOT override the operator's decision`` — conflating **operational authority** (operator decides what the agent does) with **epistemic authority** (evidence decides what is true). That single-rule framing licensed capitulation on verifiable claims whenever the user restated their disagreement.

Closes #191

## Testing

- `bun --cwd=packages/coding-agent test test/system-prompt-templates.test.ts` — 9 pass, 0 fail, 81 expect calls (includes the new test)
- Prompt-area regression set: `client-prompts` + `prompt-format` + `prompt-templates` + `system-prompt-dedup` + `system-prompt-templates` — 105 pass, 0 fail
- `bunx biome check` on both modified files — clean
- `bunx markdownlint-cli2` on system-prompt.md — 0 errors
- Full coding-agent suite: 3415 pass / 7 fail / 400 skip. The 7 failures are pre-existing and unrelated to prompt files (1 in test/auto-config.test.ts asserting a model-config error string mismatch; 5-6 in test/sdk-skills.test.ts timing out at 5000 ms due to environmental skill-discovery slowness). Neither test file imports or references the system prompt; grep confirmed. Not caused by this change.

---

- [x] `bun run check` passes on modified files
- [x] `bun test` — no new failures vs baseline
- [ ] CHANGELOG updated (not user-facing — internal system prompt change)
- [x] Issue linked via `Closes #191`