### PR TITLE
feat(coding-agent): todo list indicators, active emphasis, and summary footer (#182)

### DIFF
--- a/packages/coding-agent/src/modes/components/todo-reminder.ts
+++ b/packages/coding-agent/src/modes/components/todo-reminder.ts
@@ -1,5 +1,6 @@
 import { Box, Container, Spacer, Text } from "@f5xc-salesdemos/pi-tui";
 import { theme } from "../../modes/theme/theme";
+import { renderTodoSummary } from "../../tools/todo-render";
 import type { TodoItem } from "../../tools/todo-write";
 
 /**
@@ -43,5 +44,11 @@ export class TodoReminderComponent extends Container {
 			})
 			.join("\n");
 		this.#box.addChild(new Text(theme.italic(todoList), 0, 0));
+
+		const summary = renderTodoSummary(this.todos, theme);
+		if (summary !== null) {
+			this.#box.addChild(new Spacer(1));
+			this.#box.addChild(new Text(summary, 0, 0));
+		}
 	}
 }

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -132,6 +132,11 @@ export type SymbolKey =
 	// Checkboxes
 	| "checkbox.checked"
 	| "checkbox.unchecked"
+	// Todo status
+	| "todo.active"
+	| "todo.pending"
+	| "todo.done"
+	| "todo.abandoned"
 	// Text Formatting
 	| "format.bullet"
 	| "format.dash"
@@ -291,6 +296,11 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	// Checkboxes
 	"checkbox.checked": "☑",
 	"checkbox.unchecked": "☐",
+	// Todo status
+	"todo.active": "■",
+	"todo.pending": "□",
+	"todo.done": "✓",
+	"todo.abandoned": "✗",
 	// Formatting
 	"format.bullet": "•",
 	"format.dash": "—",
@@ -536,6 +546,15 @@ const NERD_SYMBOLS: SymbolMap = {
 	"checkbox.checked": "\uf14a",
 	// pick:  | alt: 
 	"checkbox.unchecked": "\uf096",
+	// Todo status
+	// nf-fa-circle (filled)
+	"todo.active": "\uf111",
+	// nf-fa-circle-o (hollow)
+	"todo.pending": "\uf10c",
+	// nf-fa-check
+	"todo.done": "\uf00c",
+	// nf-fa-times
+	"todo.abandoned": "\uf00d",
 	// pick:  | alt:   •
 	"format.bullet": "\uf111",
 	// pick: – | alt: — ― -
@@ -700,6 +719,11 @@ const ASCII_SYMBOLS: SymbolMap = {
 	// Checkboxes
 	"checkbox.checked": "[x]",
 	"checkbox.unchecked": "[ ]",
+	// Todo status
+	"todo.active": "[>]",
+	"todo.pending": "[ ]",
+	"todo.done": "[x]",
+	"todo.abandoned": "[-]",
 	"format.bullet": "*",
 	"format.dash": "-",
 	"format.bracketLeft": "[",
@@ -1597,6 +1621,15 @@ export class Theme {
 		return {
 			checked: this.#symbols["checkbox.checked"],
 			unchecked: this.#symbols["checkbox.unchecked"],
+		};
+	}
+
+	get todo() {
+		return {
+			active: this.#symbols["todo.active"],
+			pending: this.#symbols["todo.pending"],
+			done: this.#symbols["todo.done"],
+			abandoned: this.#symbols["todo.abandoned"],
 		};
 	}
 

--- a/packages/coding-agent/src/tools/todo-render.ts
+++ b/packages/coding-agent/src/tools/todo-render.ts
@@ -1,0 +1,33 @@
+import chalk from "chalk";
+import type { Theme } from "../modes/theme/theme";
+import type { TodoItem } from "./todo-write";
+
+export function formatTodoLine(item: TodoItem, theme: Theme, prefix: string): string {
+	switch (item.status) {
+		case "completed":
+			return `${prefix}${theme.fg("chromeAccent", theme.todo.done)} ${theme.fg("dim", chalk.strikethrough(item.content))}`;
+		case "in_progress": {
+			const main = `${prefix}${theme.fg("warning", theme.todo.active)} ${theme.fg("warning", chalk.bold(item.content))}`;
+			if (!item.details) return main;
+			const detailLines = item.details.split("\n").map(l => theme.fg("dim", `${prefix}  ${l}`));
+			return [main, ...detailLines].join("\n");
+		}
+		case "abandoned":
+			return `${prefix}${theme.fg("error", theme.todo.abandoned)} ${theme.fg("error", chalk.strikethrough(item.content))}`;
+		default:
+			return `${prefix}${theme.fg("dim", theme.todo.pending)} ${theme.fg("dim", item.content)}`;
+	}
+}
+
+export function renderTodoSummary(tasks: TodoItem[], theme: Theme): string | null {
+	if (tasks.length <= 1) return null;
+	const active = tasks.filter(t => t.status === "in_progress").length;
+	const pending = tasks.filter(t => t.status === "pending").length;
+	const completed = tasks.filter(t => t.status === "completed").length;
+	const parts: string[] = [];
+	if (active > 0) parts.push(`${active} active`);
+	if (pending > 0) parts.push(`${pending} pending`);
+	if (completed > 0) parts.push(`${completed} completed`);
+	if (parts.length === 0) return null;
+	return theme.fg("dim", parts.join(", "));
+}

--- a/packages/coding-agent/src/tools/todo-write.ts
+++ b/packages/coding-agent/src/tools/todo-write.ts
@@ -9,7 +9,6 @@ import type { Component } from "@f5xc-salesdemos/pi-tui";
 import { Text } from "@f5xc-salesdemos/pi-tui";
 import { prompt } from "@f5xc-salesdemos/pi-utils";
 import { type Static, Type } from "@sinclair/typebox";
-import chalk from "chalk";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme } from "../modes/theme/theme";
 import todoWriteDescription from "../prompts/tools/todo-write.md" with { type: "text" };
@@ -17,6 +16,7 @@ import type { ToolSession } from "../sdk";
 import type { SessionEntry } from "../session/session-manager";
 import { renderStatusLine, renderTreeList } from "../tui";
 import { PREVIEW_LIMITS } from "./render-utils";
+import { formatTodoLine, renderTodoSummary } from "./todo-render";
 
 // =============================================================================
 // Types
@@ -389,24 +389,6 @@ interface TodoWriteRenderArgs {
 	ops?: Array<{ op: string }>;
 }
 
-function formatTodoLine(item: TodoItem, uiTheme: Theme, prefix: string): string {
-	const checkbox = uiTheme.checkbox;
-	switch (item.status) {
-		case "completed":
-			return `${prefix}${uiTheme.fg("chromeAccent", checkbox.checked)} ${uiTheme.fg("dim", chalk.strikethrough(item.content))}`;
-		case "in_progress": {
-			const main = uiTheme.fg("contentAccent", `${prefix}${checkbox.unchecked} ${item.content}`);
-			if (!item.details) return main;
-			const detailLines = item.details.split("\n").map(l => uiTheme.fg("dim", `${prefix}  ${l}`));
-			return [main, ...detailLines].join("\n");
-		}
-		case "abandoned":
-			return uiTheme.fg("error", `${prefix}${checkbox.unchecked} ${chalk.strikethrough(item.content)}`);
-		default:
-			return uiTheme.fg("dim", `${prefix}${checkbox.unchecked} ${item.content}`);
-	}
-}
-
 export const todoWriteToolRenderer = {
 	renderCall(args: TodoWriteRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
 		const count = args.ops?.length ?? 0;
@@ -451,6 +433,10 @@ export const todoWriteToolRenderer = {
 			);
 			for (const line of treeLines) lines.push(`${indent}${line}`);
 		}
+
+		const summary = renderTodoSummary(allTasks, uiTheme);
+		if (summary !== null) lines.push(`${indent}${summary}`);
+
 		return new Text(lines.join("\n"), 0, 0);
 	},
 	mergeCallAndResult: true,

--- a/packages/coding-agent/test/components/todo-reminder.test.ts
+++ b/packages/coding-agent/test/components/todo-reminder.test.ts
@@ -1,0 +1,36 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { sanitizeText } from "@f5xc-salesdemos/pi-natives";
+import { TodoReminderComponent } from "../../src/modes/components/todo-reminder";
+import { setTheme } from "../../src/modes/theme/theme";
+import type { TodoItem } from "../../src/tools/todo-write";
+
+beforeAll(async () => {
+	await setTheme("dark");
+});
+
+describe("TodoReminderComponent summary line", () => {
+	it("appends a count summary at the bottom when multiple todos remain", () => {
+		const todos: TodoItem[] = [
+			{ id: "task-1", status: "in_progress", content: "Active work" },
+			{ id: "task-2", status: "pending", content: "Next thing" },
+			{ id: "task-3", status: "pending", content: "Later thing" },
+		];
+		const component = new TodoReminderComponent(todos, 1, 3);
+		const rendered = sanitizeText(component.render(80).join("\n"));
+
+		const lines = rendered
+			.split("\n")
+			.map(l => l.trimEnd())
+			.filter(l => l.length > 0);
+		const last = lines[lines.length - 1];
+		expect(last.trim()).toBe("1 active, 2 pending");
+	});
+
+	it("omits the summary line for a single todo", () => {
+		const todos: TodoItem[] = [{ id: "task-1", status: "in_progress", content: "Only task" }];
+		const component = new TodoReminderComponent(todos, 1, 3);
+		const rendered = sanitizeText(component.render(80).join("\n"));
+
+		expect(rendered).not.toMatch(/\d+ (active|pending|completed)/);
+	});
+});

--- a/packages/coding-agent/test/tools/todo-render.test.ts
+++ b/packages/coding-agent/test/tools/todo-render.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "bun:test";
+import { sanitizeText } from "@f5xc-salesdemos/pi-natives";
+import chalk from "chalk";
+import { getThemeByName } from "../../src/modes/theme/theme";
+import { formatTodoLine, renderTodoSummary } from "../../src/tools/todo-render";
+import type { TodoItem } from "../../src/tools/todo-write";
+
+async function dark() {
+	const theme = await getThemeByName("dark");
+	if (!theme) throw new Error("dark theme not found");
+	return theme;
+}
+
+describe("formatTodoLine", () => {
+	it("renders completed with chromeAccent check + dim strikethrough content", async () => {
+		const theme = await dark();
+		const item: TodoItem = { id: "task-1", status: "completed", content: "Done thing" };
+		const line = formatTodoLine(item, theme, "");
+
+		expect(line).toContain(theme.fg("chromeAccent", theme.todo.done));
+		expect(line).toContain(theme.fg("dim", chalk.strikethrough("Done thing")));
+		expect(sanitizeText(line)).toBe(`${theme.todo.done} Done thing`);
+	});
+
+	it("renders in_progress with warning symbol and bold warning content", async () => {
+		const theme = await dark();
+		const item: TodoItem = { id: "task-1", status: "in_progress", content: "Active thing" };
+		const line = formatTodoLine(item, theme, "");
+
+		expect(line).toContain(theme.fg("warning", theme.todo.active));
+		expect(line).toContain(theme.fg("warning", chalk.bold("Active thing")));
+		expect(sanitizeText(line)).toBe(`${theme.todo.active} Active thing`);
+	});
+
+	it("renders in_progress details on subsequent dim lines with prefix", async () => {
+		const theme = await dark();
+		const item: TodoItem = {
+			id: "task-1",
+			status: "in_progress",
+			content: "Active thing",
+			details: "First detail\nSecond detail",
+		};
+		const line = formatTodoLine(item, theme, "  ");
+		const lines = line.split("\n");
+
+		expect(lines).toHaveLength(3);
+		expect(lines[0]).toContain(theme.fg("warning", chalk.bold("Active thing")));
+		expect(lines[1]).toBe(theme.fg("dim", "    First detail"));
+		expect(lines[2]).toBe(theme.fg("dim", "    Second detail"));
+	});
+
+	it("renders pending with dim symbol and dim content", async () => {
+		const theme = await dark();
+		const item: TodoItem = { id: "task-1", status: "pending", content: "Pending thing" };
+		const line = formatTodoLine(item, theme, "");
+
+		expect(line).toContain(theme.fg("dim", theme.todo.pending));
+		expect(line).toContain(theme.fg("dim", "Pending thing"));
+		expect(sanitizeText(line)).toBe(`${theme.todo.pending} Pending thing`);
+	});
+
+	it("renders abandoned with error symbol and error strikethrough content", async () => {
+		const theme = await dark();
+		const item: TodoItem = { id: "task-1", status: "abandoned", content: "Dropped thing" };
+		const line = formatTodoLine(item, theme, "");
+
+		expect(line).toContain(theme.fg("error", theme.todo.abandoned));
+		expect(line).toContain(theme.fg("error", chalk.strikethrough("Dropped thing")));
+		expect(sanitizeText(line)).toBe(`${theme.todo.abandoned} Dropped thing`);
+	});
+});
+
+describe("renderTodoSummary", () => {
+	const task = (status: TodoItem["status"], n: number): TodoItem => ({
+		id: `task-${n}`,
+		status,
+		content: `Task ${n}`,
+	});
+
+	it("returns null for an empty list", async () => {
+		const theme = await dark();
+		expect(renderTodoSummary([], theme)).toBeNull();
+	});
+
+	it("returns null for a single task", async () => {
+		const theme = await dark();
+		expect(renderTodoSummary([task("in_progress", 1)], theme)).toBeNull();
+	});
+
+	it("renders active + pending + completed counts in dim", async () => {
+		const theme = await dark();
+		const tasks: TodoItem[] = [
+			task("in_progress", 1),
+			...Array.from({ length: 12 }, (_, i) => task("pending", i + 2)),
+			...Array.from({ length: 2 }, (_, i) => task("completed", i + 14)),
+		];
+
+		const summary = renderTodoSummary(tasks, theme);
+		expect(summary).not.toBeNull();
+		expect(sanitizeText(summary!)).toBe("1 active, 12 pending, 2 completed");
+		expect(summary!).toBe(theme.fg("dim", "1 active, 12 pending, 2 completed"));
+	});
+
+	it("drops the 0-active segment when there is no active task", async () => {
+		const theme = await dark();
+		const tasks: TodoItem[] = [
+			...Array.from({ length: 12 }, (_, i) => task("pending", i + 1)),
+			...Array.from({ length: 2 }, (_, i) => task("completed", i + 13)),
+		];
+
+		const summary = renderTodoSummary(tasks, theme);
+		expect(sanitizeText(summary!)).toBe("12 pending, 2 completed");
+	});
+
+	it("renders only the completed count when all tasks are completed", async () => {
+		const theme = await dark();
+		const tasks = Array.from({ length: 5 }, (_, i) => task("completed", i + 1));
+
+		const summary = renderTodoSummary(tasks, theme);
+		expect(sanitizeText(summary!)).toBe("5 completed");
+	});
+});

--- a/packages/coding-agent/test/tools/todo-write.test.ts
+++ b/packages/coding-agent/test/tools/todo-write.test.ts
@@ -236,7 +236,7 @@ describe("todoWriteToolRenderer phase indentation", () => {
 		}
 	});
 
-	it("renders completed tasks with chromeAccent checkbox and dim strikethrough content", async () => {
+	it("renders completed tasks with chromeAccent todo.done + dim strikethrough content", async () => {
 		const theme = await getThemeByName("dark");
 		if (!theme) throw new Error("dark theme not found");
 
@@ -257,17 +257,78 @@ describe("todoWriteToolRenderer phase indentation", () => {
 		const component = todoWriteToolRenderer.renderResult(result, { expanded: true, isPartial: false }, theme);
 		const raw = component.render(120).join("\n");
 
-		// The completed-task styling is now two-tone: chromeAccent on the
-		// checkbox and dim on the strikethrough content.
-		const expectedCheckbox = theme.fg("chromeAccent", theme.checkbox.checked);
+		// The completed-task styling now uses the todo.done symbol in
+		// chromeAccent with a dim strikethrough on the content.
+		const expectedCheck = theme.fg("chromeAccent", theme.todo.done);
 		const expectedContent = theme.fg("dim", chalk.strikethrough("Preheat oven"));
-		expect(raw).toContain(expectedCheckbox);
+		expect(raw).toContain(expectedCheck);
 		expect(raw).toContain(expectedContent);
 
-		// The previous all-green styling must no longer appear for the
-		// completed task's content.
-		const oldAllSuccess = theme.fg("success", `${theme.checkbox.checked} ${chalk.strikethrough("Preheat oven")}`);
-		expect(raw).not.toContain(oldAllSuccess);
+		// The old checkbox symbol must no longer appear for completed tasks.
+		expect(raw).not.toContain(theme.fg("chromeAccent", theme.checkbox.checked));
+	});
+
+	it("appends a summary line with active/pending/completed counts for mixed lists", async () => {
+		const phases: TodoPhase[] = [
+			{
+				id: "phase-1",
+				name: "Work",
+				tasks: [
+					{ id: "task-1", status: "in_progress", content: "Active" },
+					{ id: "task-2", status: "pending", content: "Next" },
+					{ id: "task-3", status: "pending", content: "Later" },
+					{ id: "task-4", status: "completed", content: "Done" },
+				],
+			},
+		];
+
+		const lines = await renderDark(phases);
+		const nonEmpty = lines.filter(l => l.trim().length > 0);
+		const last = nonEmpty[nonEmpty.length - 1];
+		expect(last.trim()).toBe("1 active, 2 pending, 1 completed");
+	});
+
+	it("uses theme.todo.active for in_progress tasks and not the old checkbox", async () => {
+		const theme = await getThemeByName("dark");
+		if (!theme) throw new Error("dark theme not found");
+		const phases: TodoPhase[] = [
+			{
+				id: "phase-1",
+				name: "Work",
+				tasks: [
+					{ id: "task-1", status: "in_progress", content: "Active" },
+					{ id: "task-2", status: "pending", content: "Next" },
+				],
+			},
+		];
+		const result = {
+			content: [{ type: "text", text: "ignored" }],
+			details: { phases, storage: "memory" as const },
+		};
+		const raw = todoWriteToolRenderer
+			.renderResult(result, { expanded: true, isPartial: false }, theme)
+			.render(120)
+			.join("\n");
+
+		expect(raw).toContain(theme.fg("warning", theme.todo.active));
+		// The active task must not carry the old unchecked symbol.
+		expect(raw).not.toContain(theme.fg("contentAccent", `${theme.checkbox.unchecked} Active`));
+	});
+
+	it("omits the summary line for a single-task list", async () => {
+		const phases: TodoPhase[] = [
+			{
+				id: "phase-1",
+				name: "Solo",
+				tasks: [{ id: "task-1", status: "in_progress", content: "Only task" }],
+			},
+		];
+
+		const lines = await renderDark(phases);
+		const nonEmpty = lines.filter(l => l.trim().length > 0);
+		const last = nonEmpty[nonEmpty.length - 1];
+		expect(last).toContain("Only task");
+		expect(last.trim()).not.toMatch(/\d+ (active|pending|completed)/);
 	});
 
 	it("does not indent task lines when only one phase is present", async () => {


### PR DESCRIPTION
## Summary
- Adds `theme.todo.active/pending/done/abandoned` symbol keys with UNICODE/NERD/ASCII fallbacks
- Extracts shared render helpers into `packages/coding-agent/src/tools/todo-render.ts`
- Active tasks render with `■` in warning color + bold content; pending with `□` in dim; completed with `✓`; abandoned with `✗`
- Adds an "N active, N pending, N completed" summary line to both the tool result renderer and `TodoReminderComponent`

## Test plan
- [x] `bun test packages/coding-agent/test/tools/todo-render.test.ts` — 10/10
- [x] `bun test packages/coding-agent/test/tools/todo-write.test.ts` — all pass (existing + 3 new + 1 updated assertion)
- [x] `bun test packages/coding-agent/test/components/todo-reminder.test.ts` — 2/2
- [x] Full suite: only 2 pre-existing flaky file-permission tests, none in the touched paths
- [x] `bun check:ts` clean
- [ ] Manual smoke on xcsh-dark with a mixed-status todo list (leaving unchecked for human verification)

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)