### PR TITLE
fix(coding-agent): correct user-message rendering (remove right-arrow, italic, indent accent bar)

### DIFF
--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -1,17 +1,16 @@
 import { Container, Markdown, padding, Spacer, visibleWidth } from "@f5xc-salesdemos/pi-tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 
-// OSC 133 shell integration: marks prompt zones for terminal multiplexers
-const OSC133_ZONE_START = "\x1b]133;A\x07";
-const OSC133_ZONE_END = "\x1b]133;B\x07";
-const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
-
 // U+2503 BOX DRAWINGS HEAVY VERTICAL — continuation bar on wrapped lines.
 const CONTINUATION_BAR = "┃";
 // Markdown child uses paddingX=1 and clamps contentWidth>=1, so its minimum
 // render output is 3 terminal cells. Anything narrower than prefix+3 would
 // overflow the requested width — bail out instead.
 const MIN_MARKDOWN_WIDTH = 3;
+// Leading gutter reserved for sibling GutterBlock indicators (● etc.) so the
+// π / ┃ accent bar aligns with content text rather than sitting at column 0.
+const GUTTER_WIDTH = 2;
+const GUTTER_PAD = "  ";
 
 /**
  * Renders a user message as an F5-branded admonition block: pi icon on the
@@ -24,7 +23,7 @@ export class UserMessageComponent extends Container {
 		super();
 		const color = synthetic
 			? (value: string) => theme.fg("dim", value)
-			: (value: string) => theme.fg("userMessageText", value);
+			: (value: string) => `\x1b[3m${theme.fg("userMessageText", value)}\x1b[23m`;
 		this.addChild(new Spacer(1));
 		this.addChild(new Markdown(text, 1, 0, getMarkdownTheme(), { color }));
 	}
@@ -36,7 +35,7 @@ export class UserMessageComponent extends Container {
 		// glyph and ASCII "pi" are 2 cols. Measure both and reserve the
 		// larger so every content line leaves room for either shape.
 		const prefixWidth = Math.max(visibleWidth(piPrefix), visibleWidth(contPrefix));
-		const innerWidth = width - prefixWidth;
+		const innerWidth = width - GUTTER_WIDTH - prefixWidth;
 		if (innerWidth < MIN_MARKDOWN_WIDTH) {
 			return [];
 		}
@@ -57,12 +56,9 @@ export class UserMessageComponent extends Container {
 		const content = raw.slice(firstContent).map((line, i) => {
 			const prefix = theme.fg("border", i === 0 ? piPrefix : contPrefix);
 			const combined = prefix + line;
-			const pad = Math.max(0, width - visibleWidth(combined));
-			return theme.bg("userMessageBg", combined + padding(pad));
+			const pad = Math.max(0, width - GUTTER_WIDTH - visibleWidth(combined));
+			return GUTTER_PAD + theme.bg("userMessageBg", combined + padding(pad));
 		});
-
-		content[0] = OSC133_ZONE_START + content[0];
-		content[content.length - 1] = content[content.length - 1] + OSC133_ZONE_END + OSC133_ZONE_FINAL;
 
 		return [...leading, ...content];
 	}

--- a/packages/coding-agent/test/user-message.test.ts
+++ b/packages/coding-agent/test/user-message.test.ts
@@ -7,6 +7,8 @@ const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
 const CONTINUATION_BAR = "┃"; // U+2503 BOX DRAWINGS HEAVY VERTICAL
+const ITALIC_ON = "\x1b[3m";
+const ITALIC_OFF = "\x1b[23m";
 
 function stripAnsi(str: string): string {
 	return str.replace(/\x1b\][^\x07]*\x07/g, "").replace(/\x1b\[[0-9;]*m/g, "");
@@ -32,16 +34,33 @@ describe("UserMessageComponent", () => {
 		initTheme();
 	});
 
-	it("prefixes every content line with pi icon or continuation bar", () => {
+	it("prefixes every content line with 2-space gutter pad + pi icon or continuation bar", () => {
+		// The π / ┃ sit inside the content area (column 2+), not at column 0
+		// where GutterBlock indicators (●) render. The leading 2 cols are
+		// plain spaces outside the message background.
 		const c = new UserMessageComponent("hello world\nsecond line");
 		const lines = renderPlain(c);
 		expect(lines.length).toBeGreaterThan(1);
 		const pi = theme.icon.pi;
 		// Line 0 is the leading spacer. Content starts at line 1.
-		expect(lines[1].startsWith(`${pi} `)).toBe(true);
+		expect(lines[1].startsWith(`  ${pi} `)).toBe(true);
 		for (let i = 2; i < lines.length; i++) {
-			expect(lines[i].startsWith(`${CONTINUATION_BAR} `)).toBe(true);
+			expect(lines[i].startsWith(`  ${CONTINUATION_BAR} `)).toBe(true);
 		}
+	});
+
+	it("leaves the 2-column gutter area unpainted (no bg) on content lines", () => {
+		const c = new UserMessageComponent("hello world");
+		const raw = c.render(120);
+		expect(raw.length).toBeGreaterThan(1);
+		const bg = bgPrefix("userMessageBg");
+		// The bg must not appear in the first two columns — those cols are
+		// reserved for the gutter area that sibling components (GutterBlock)
+		// paint indicators into.
+		const bgIdx = raw[1].indexOf(bg);
+		expect(bgIdx).toBeGreaterThanOrEqual(2);
+		// Plain stripped line must start with two literal spaces.
+		expect(raw[1].replace(/\x1b\[[0-9;]*m/g, "").startsWith("  ")).toBe(true);
 	});
 
 	it("has a leading blank spacer line", () => {
@@ -86,16 +105,31 @@ describe("UserMessageComponent", () => {
 		}
 	});
 
-	it("preserves OSC 133 zone markers on first and last line", () => {
+	it("does not emit OSC 133 semantic prompt markers on any line", () => {
+		// OSC 133 markers belong on the live input editor, not historical
+		// transcript entries. iTerm2 renders a shell-integration triangle in
+		// the left margin for every zone, which is noise in the scrollback.
 		const c = new UserMessageComponent("line one\nline two");
 		const raw = c.render(120);
 		expect(raw.length).toBeGreaterThanOrEqual(2);
-		// Spacer does NOT carry markers.
-		expect(raw[0].includes(OSC133_ZONE_START)).toBe(false);
-		// First content line carries the start marker.
-		expect(raw[1].includes(OSC133_ZONE_START)).toBe(true);
-		// Last line ends with the end + final markers.
-		expect(raw[raw.length - 1].endsWith(OSC133_ZONE_END + OSC133_ZONE_FINAL)).toBe(true);
+		for (const line of raw) {
+			expect(line.includes(OSC133_ZONE_START)).toBe(false);
+			expect(line.includes(OSC133_ZONE_END)).toBe(false);
+			expect(line.includes(OSC133_ZONE_FINAL)).toBe(false);
+		}
+	});
+
+	it("renders non-synthetic user message text in italic", () => {
+		const c = new UserMessageComponent("italicize me");
+		const raw = c.render(120).join("\n");
+		expect(raw.includes(ITALIC_ON)).toBe(true);
+		expect(raw.includes(ITALIC_OFF)).toBe(true);
+	});
+
+	it("does not italicize synthetic messages", () => {
+		const c = new UserMessageComponent("synthetic entry", true);
+		const raw = c.render(120).join("\n");
+		expect(raw.includes(ITALIC_ON)).toBe(false);
 	});
 
 	it("uses dim fg for synthetic messages and not userMessageText", () => {
@@ -132,12 +166,14 @@ describe("UserMessageComponent", () => {
 		}
 	});
 
-	it("bails out with empty output when width cannot fit prefix + markdown minimum", () => {
-		// prefix (<=2 cols) + MIN_MARKDOWN_WIDTH (3) = minimum 5 cols. Any
-		// narrower and the contract of not-overflowing cannot be met —
-		// verify we return [] rather than emitting oversized lines.
+	it("bails out with empty output when width cannot fit gutter + prefix + markdown minimum", () => {
+		// gutter pad (2) + prefix (≤2 cols, theme-dependent: 1 for Unicode π,
+		// 2 for Nerd Font glyph or ASCII "pi") + MIN_MARKDOWN_WIDTH (3) =
+		// up to 7 cols. At widths below that upper bound the not-overflowing
+		// contract cannot be guaranteed — verify we return [] rather than
+		// emitting oversized lines.
 		const c = new UserMessageComponent("hi");
-		for (const w of [0, 1, 2, 3, 4]) {
+		for (const w of [0, 1, 2, 3, 4, 5, 6]) {
 			expect(c.render(w)).toEqual([]);
 		}
 	});


### PR DESCRIPTION
## What

Corrects three transcript rendering bugs reported in #183 against the
initial admonition restyle:

- **Remove OSC 133 emission from transcript messages.** Deletes the
  three OSC 133 constants (`OSC133_ZONE_START` / `OSC133_ZONE_END` /
  `OSC133_ZONE_FINAL`) and their injection at the render tail.
  iTerm2 was interpreting them as shell-integration semantic prompt
  markers and drawing a triangle in the left margin before every
  historical user message.
- **Italicize non-synthetic user message text.** Wraps the non-synthetic
  `userMessageText` color callback in ANSI italic escapes
  (`\x1b[3m` ... `\x1b[23m`) so user prompts are visually distinguished
  from assistant output. Synthetic messages stay unchanged.
- **Indent the red accent bar into the content area.** Adds
  `GUTTER_WIDTH = 2` / `GUTTER_PAD = "  "` constants, subtracts gutter
  width from both the inner-width budget and the padding math, and
  prepends `GUTTER_PAD` (plain, unpainted) to every content line. The
  π/┃ accent bar now renders at column 2+ instead of column 0, leaving
  column 0 for `GutterBlock` indicators (e.g. the outcome dot).

## Why

Reported in #183 against the initial restyle landed in #185. Three
visible regressions on the transcript:

1. iTerm2 triangle clutter before every history entry.
2. User prompts indistinguishable from assistant prose.
3. Accent bar colliding with the outcome dot in column 0.

**Scope note:** Deleting OSC 133 rather than re-homing it is a
deliberate scope reduction. Claude Code (the reference TUI coding
agent) ships with zero OSC 133 emission and no users miss it;
re-homing adds non-trivial risk to the existing visually-tuned
statusline; zero current user reports request those features.
Follow-up #195 will reintroduce emission from the live editor if
demand surfaces.

Closes #183. Part of this issue (OSC 133 re-home to the live TUI editor) is deferred to #195.

## Testing

- `bun test --cwd packages/coding-agent --filter user-message` — 14/14
  pass. Each assertion was watched fail first, then green (TDD).
  - OSC 133 test inverted to assert markers are **absent** on every line.
  - Added: italic-on test, italic-absent-for-synthetic test,
    unpainted-gutter test.
  - Updated: prefix-start and width-bail-out tests for the new geometry.
- `bun run check:ts` — clean (biome + tsgo).
- Codex review passed (one nit fixed: test comment was theme-specific).
- 6 pre-existing package-level failures unrelated to this change
  (auto-config permission tests + sdk-skills timeouts — reproduce
  identically on pre-change baseline).

---

- [x] `bun run check:ts` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #183`