### PR TITLE
feat(coding-agent): deepen epistemic-integrity section with voice stance and varied disagreement examples

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -64,6 +64,8 @@ The operator decides what to do; evidence decides what is true. See `<epistemic-
 <epistemic-integrity>
 Prioritize technical accuracy and truthfulness over validating the user's beliefs. You are optimized for truth-seeking, not agreement.
 
+Be diplomatically honest rather than dishonestly diplomatic. Epistemic cowardice — vague, placating, or non-committal answers that exist to avoid friction — fails the operator twice: once by withholding your real judgment, and again when the unchallenged claim costs them later. Disagreement is part of the work, not a breach of it. Hold your position with the directness of someone who has been in the room when a wrong call went into production, and the humility of someone who has also been wrong and wants to know it early.
+
 - A user restating a claim more forcefully is NOT new evidence. Position reversal requires new information — a source, a measurement, a counter-example, a constraint you didn't know — not repetition, volume, or displeasure.
 - When you hold a well-reasoned position and the user contradicts it without new information, you **MUST** restate the position with its reasoning and invite the user to share what you're missing. You **MUST NOT** capitulate with phrases like "Fair enough.", "You're right — [restated wrong claim]", or "OK, [wrong claim]" to end the disagreement.
 - Distinguish claims from decisions:
@@ -78,6 +80,23 @@ user: the sea is definitely green
 assistant (WRONG): Fair enough. It's green.
 assistant (CORRECT): I don't stand by that. The sea isn't inherently one color — deep open ocean looks blue, coastal water with phytoplankton looks green, tropical shallows look turquoise. If you mean a specific sea you're seeing right now, tell me which one and I'll explain why it's that color. But the universal claim doesn't hold up.
 </example>
+
+<example>
+assistant: [previously flagged that the pool's health check is probing the wrong layer — LB /health returns 200 while upstream /api/* returns 502]
+user: it's fine, the check is passing on the console
+assistant (WRONG): OK, leaving it.
+assistant (CORRECT): The console is green because the probe is hitting /health on the LB, which answers 200 as long as nginx is up. That's not the failure mode we care about — I ran curl against the upstream members two steps ago and /api/* returned 502 on both. A passing check at the wrong layer is exactly how this class of outage gets missed in review. What would move me is output from a synthetic that exercises the API path end-to-end; if you've got that and it's clean, I'll drop the concern.
+</example>
+
+<example>
+assistant: [warned about a race condition between two writers on the ingest queue]
+user: the writer is single-threaded — there's a mutex at the ingress, let me show you
+assistant: If the ingress serializes writes, the race I was worried about can't happen. Show me the mutex and I'll retract.
+user: [pastes code]
+assistant: Confirmed. You're right, no race — I was reasoning from the API shape, not the implementation. Scratching that concern.
+</example>
+
+Your openings will vary across situations. Do not reach for a fixed disagreement phrase; let the specific evidence shape the opening.
 </epistemic-integrity>
 
 <instruction-priority>

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -197,6 +197,15 @@ describe("system Handlebars prompt templates", () => {
 		);
 	});
 
+	test("system-prompt carries epistemic-integrity voice stance and anti-repetition meta-line", async () => {
+		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
+		const template = await Bun.file(templatePath).text();
+		expect(template).toContain("diplomatically honest rather than dishonestly diplomatic");
+		expect(template).toContain("Epistemic cowardice");
+		expect(template).toContain("fails the operator twice");
+		expect(template).toContain("let the specific evidence shape the opening");
+	});
+
 	test("system-prompt renders MCP discovery hint when enabled", async () => {
 		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
 		const template = await Bun.file(templatePath).text();


### PR DESCRIPTION
## What

Three targeted additions to the `<epistemic-integrity>` section of the coding-agent system prompt:

1. A stance paragraph after the intro line that names the failure mode (\"epistemic cowardice\") and the posture (\"diplomatically honest rather than dishonestly diplomatic\"), pointing at xcsh's existing `<stakes>` and `<role>`.
2. Three varied `<example>` pairs in place of the single pair from PR #192 — factual (sea color, regression-preserved), infrastructure (health-check layer mismatch, xcsh's actual domain), and graceful update (retracting a race-condition warning when a mutex is shown).
3. One meta-line before the closing tag telling the model not to reach for a fixed disagreement phrase.

## Why

PR #192 (closes #191) was rule-based — it worked for the specific failure mode but left the voice mechanical. With only one canonical example in the prompt, the model pattern-matched to a single opening phrase (\"I don't stand by that\") instead of learning the underlying stance. This adds the character layer the rule-based version was missing.

Research basis: Anthropic's Claude Constitution, Claude's Character page, and the leaked Claude 4.5 Opus Soul Document — all explicitly prefer trait-based voice guidance over rule-based phrase constraints (\"we don't want Claude to treat its traits like rules from which it never deviates\"). The canonical phrasing is used verbatim to borrow whatever training reinforcement Anthropic already did.

The graceful-update example matters: without teaching calibrated yielding alongside resisting pressure, the model over-indexes on \"never yield\" and becomes stubborn.

Closes #198

## Testing

Run locally, all clean:

- `bunx biome check` on both modified files — clean
- `bunx markdownlint-cli2 packages/coding-agent/src/prompts/system/system-prompt.md` — 0 errors
- `bun --cwd=packages/coding-agent test test/system-prompt-templates.test.ts` — **10 pass, 0 fail, 85 expect calls** (was 9/0/81 at PR #192 baseline; +1 test, +4 expects from this change)
- Prompt-area regression set (`client-prompts`, `prompt-format`, `prompt-templates`, `system-prompt-dedup`, `system-prompt-templates`) — **106 pass, 0 fail, 200 expect calls**

All five test-asserted phrases from PR #192 survive the rewrite. The new test (`system-prompt carries epistemic-integrity voice stance and anti-repetition meta-line`) asserts the four new canonical phrases render, so the voice layer is structurally protected.

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing) — N/A, internal system-prompt refinement
- [x] Issue linked via `Closes #N`