### PR TITLE
chore: verify shared Super-Linter Biome step under Biome latest

### DIFF
--- a/VERIFICATION_NOOP.md
+++ b/VERIFICATION_NOOP.md
@@ -1,0 +1,1 @@
+Verification no-op — confirms biome ci runs against xcsh's own biome.json under Biome latest. Delete or close PR after CI reports green.


### PR DESCRIPTION
## Summary

Disposable no-op PR that adds `VERIFICATION_NOOP.md` at the repo root to
trigger the shared Super-Linter workflow end-to-end. This confirms the
new Biome step in the shared workflow (f5xc-salesdemos/docs-control#385)
runs correctly against **xcsh's own** `biome.json` under Biome latest.

Closes #205

## Verification goals

1. Step order in the Actions log is: Checkout → Setup Biome → Run Biome → Run Super-Linter → Spectral OpenAPI lint.
2. `biome ci .` uses xcsh's own `biome.json` (60 lines) — not a fleet-synced one.
3. Super-Linter log no longer shows `BIOME_FORMAT` / `BIOME_LINT` sections.

## Expected outcomes

- If `biome ci` is green → close this PR, all good.
- If `biome ci` reports rule violations under Biome latest (CLI 2.4.12)
  → close this PR anyway; violations are data for xcsh maintainers to
  follow up on, not a blocker for the shared-workflow refactor.

## Test plan

- [ ] Super-Linter workflow runs to completion on this PR.
- [ ] CI log shows the new `biomejs/setup-biome` + `biome ci .` steps.
- [ ] `biome ci` is reading xcsh's own `biome.json` (verify via log output).
- [ ] PR will be **closed without merging** once CI results are captured.

## Do not merge

This PR is intentionally disposable. It adds a single file with no
functional change and will be closed once verification data is captured.

Refs f5xc-salesdemos/docs-control#385.
