### PR TITLE
fix(coding-agent): move pi icon to gutter, keep heavy bar in content area

### DIFF
--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -7,16 +7,22 @@ const CONTINUATION_BAR = "┃";
 // render output is 3 terminal cells. Anything narrower than prefix+3 would
 // overflow the requested width — bail out instead.
 const MIN_MARKDOWN_WIDTH = 3;
-// Leading gutter reserved for sibling GutterBlock indicators (● etc.) so the
-// π / ┃ accent bar aligns with content text rather than sitting at column 0.
+// Two-column layout: the gutter (col 0..GUTTER_WIDTH-1) stays outside the
+// userMessageBg painted region and holds the π icon on the first content
+// line / two spaces on continuations — mirroring how GutterBlock renders
+// its ● indicator at col 0. The painted region starts at col GUTTER_WIDTH
+// and hosts the ┃ accent bar on every content line (including the first).
 const GUTTER_WIDTH = 2;
 const GUTTER_PAD = "  ";
 
 /**
- * Renders a user message as an F5-branded admonition block: pi icon on the
- * first content line, heavy vertical bar on continuations (both in `border`
- * color), `userMessageBg` painted across the full requested width, and a
- * leading blank spacer separating the prompt from the preceding block.
+ * Renders a user message as an F5-branded admonition block with a two-column
+ * layout: the π icon sits in the gutter at col 0 on the first content line
+ * (outside the painted region, matching the `●` indicator pattern used by
+ * `GutterBlock`); the ┃ heavy vertical bar renders at col GUTTER_WIDTH inside
+ * `userMessageBg` on every content line including the first. Both glyphs use
+ * the `border` fg. The bg is painted across the full requested width, and a
+ * leading blank spacer separates the prompt from the preceding block.
  */
 export class UserMessageComponent extends Container {
 	constructor(text: string, synthetic = false) {
@@ -29,13 +35,10 @@ export class UserMessageComponent extends Container {
 	}
 
 	override render(width: number): string[] {
-		const piPrefix = `${theme.icon.pi} `;
 		const contPrefix = `${CONTINUATION_BAR} `;
-		// Prefix width is theme-dependent — Unicode π is 1 col, Nerd Font
-		// glyph and ASCII "pi" are 2 cols. Measure both and reserve the
-		// larger so every content line leaves room for either shape.
-		const prefixWidth = Math.max(visibleWidth(piPrefix), visibleWidth(contPrefix));
-		const innerWidth = width - GUTTER_WIDTH - prefixWidth;
+		// π lives in the fixed-width gutter (see the content map below), so it
+		// does not factor into innerWidth. Only contPrefix eats content budget.
+		const innerWidth = width - GUTTER_WIDTH - visibleWidth(contPrefix);
 		if (innerWidth < MIN_MARKDOWN_WIDTH) {
 			return [];
 		}
@@ -52,12 +55,25 @@ export class UserMessageComponent extends Container {
 			return raw;
 		}
 
+		// First-line gutter: π icon padded to exactly GUTTER_WIDTH cells. The
+		// glyph width is theme-dependent (Unicode π = 1 col, Nerd Font PUA = 2
+		// cols, ASCII "pi" = 2 cols); right-pad with spaces so the gutter
+		// occupies a fixed slot and the ┃ bar at col GUTTER_WIDTH aligns across
+		// every content line.
+		const piIcon = theme.icon.pi;
+		const piPadSize = Math.max(0, GUTTER_WIDTH - visibleWidth(piIcon));
+		// Pad inside the theme.fg wrap so the border-fg escape, glyph, and
+		// pad space form one contiguous span (no intervening fg reset). This
+		// matches the shape the raw-escape assertion in test 6 looks for.
+		const piGutter = theme.fg("border", piIcon + " ".repeat(piPadSize));
+
 		const leading = raw.slice(0, firstContent);
 		const content = raw.slice(firstContent).map((line, i) => {
-			const prefix = theme.fg("border", i === 0 ? piPrefix : contPrefix);
+			const prefix = theme.fg("border", contPrefix);
 			const combined = prefix + line;
 			const pad = Math.max(0, width - GUTTER_WIDTH - visibleWidth(combined));
-			return GUTTER_PAD + theme.bg("userMessageBg", combined + padding(pad));
+			const gutter = i === 0 ? piGutter : GUTTER_PAD;
+			return gutter + theme.bg("userMessageBg", combined + padding(pad));
 		});
 
 		return [...leading, ...content];

--- a/packages/coding-agent/test/user-message.test.ts
+++ b/packages/coding-agent/test/user-message.test.ts
@@ -34,33 +34,42 @@ describe("UserMessageComponent", () => {
 		initTheme();
 	});
 
-	it("prefixes every content line with 2-space gutter pad + pi icon or continuation bar", () => {
-		// The π / ┃ sit inside the content area (column 2+), not at column 0
-		// where GutterBlock indicators (●) render. The leading 2 cols are
-		// plain spaces outside the message background.
+	it("puts pi icon in gutter on first line and continuation bar in content area on every line", () => {
+		// After the gutter/content separation:
+		//   col 0-1 (gutter, unpainted): π on first content line, "  " on continuations
+		//   col 2+ (userMessageBg painted): ┃ + space + markdown content on every line
 		const c = new UserMessageComponent("hello world\nsecond line");
 		const lines = renderPlain(c);
 		expect(lines.length).toBeGreaterThan(1);
 		const pi = theme.icon.pi;
 		// Line 0 is the leading spacer. Content starts at line 1.
-		expect(lines[1].startsWith(`  ${pi} `)).toBe(true);
+		// First content line: π in gutter, ┃ in content — no leading spaces.
+		expect(lines[1].startsWith(`${pi} ${CONTINUATION_BAR} `)).toBe(true);
+		// Continuation lines: two spaces in gutter, ┃ in content.
 		for (let i = 2; i < lines.length; i++) {
 			expect(lines[i].startsWith(`  ${CONTINUATION_BAR} `)).toBe(true);
 		}
 	});
 
-	it("leaves the 2-column gutter area unpainted (no bg) on content lines", () => {
-		const c = new UserMessageComponent("hello world");
+	it("leaves the 2-column gutter area unpainted (no bg) on every content line", () => {
+		// userMessageBg still starts at col >= 2 on every content line — the gutter
+		// stays outside the painted region. What lives IN the gutter differs by
+		// line: π on the first content line, two spaces on continuations.
+		const c = new UserMessageComponent("hello world\nsecond line");
 		const raw = c.render(120);
-		expect(raw.length).toBeGreaterThan(1);
+		expect(raw.length).toBeGreaterThan(2);
 		const bg = bgPrefix("userMessageBg");
-		// The bg must not appear in the first two columns — those cols are
-		// reserved for the gutter area that sibling components (GutterBlock)
-		// paint indicators into.
-		const bgIdx = raw[1].indexOf(bg);
-		expect(bgIdx).toBeGreaterThanOrEqual(2);
-		// Plain stripped line must start with two literal spaces.
-		expect(raw[1].replace(/\x1b\[[0-9;]*m/g, "").startsWith("  ")).toBe(true);
+		const pi = theme.icon.pi;
+		// First content line: bg starts after π + space, and the stripped line
+		// begins with the π glyph (not two spaces — π IS the gutter content).
+		const bgIdxFirst = raw[1].indexOf(bg);
+		expect(bgIdxFirst).toBeGreaterThanOrEqual(2);
+		expect(raw[1].replace(/\x1b\[[0-9;]*m/g, "").startsWith(`${pi} `)).toBe(true);
+		// Continuation line: bg starts after two literal spaces, and the stripped
+		// line begins with those two spaces.
+		const bgIdxCont = raw[2].indexOf(bg);
+		expect(bgIdxCont).toBeGreaterThanOrEqual(2);
+		expect(raw[2].replace(/\x1b\[[0-9;]*m/g, "").startsWith("  ")).toBe(true);
 	});
 
 	it("has a leading blank spacer line", () => {
@@ -91,17 +100,30 @@ describe("UserMessageComponent", () => {
 		}
 	});
 
-	it("uses pi icon on first content line and heavy bar on continuations, both in border color", () => {
+	it("renders border-coloured pi in the gutter on line 1 and border-coloured heavy bar in content on every line", () => {
+		// The π icon now lives in the gutter (outside userMessageBg) only on the
+		// first content line. The ┃ accent bar lives in the content area (inside
+		// userMessageBg) on every content line including the first. Both use
+		// border fg.
 		const c = new UserMessageComponent("line one\nline two");
 		const raw = c.render(120);
 		const borderFg = fgPrefix("border");
+		const bg = bgPrefix("userMessageBg");
 		const pi = theme.icon.pi;
 		expect(raw.length).toBeGreaterThan(2); // spacer + >=2 content lines
-		// First content line carries border-coloured pi.
-		expect(raw[1].includes(`${borderFg}${pi} `)).toBe(true);
-		// Subsequent content lines carry the heavy vertical bar in border colour.
+		// First content line: border-coloured π appears BEFORE the userMessageBg
+		// escape (i.e., it's in the gutter, outside the painted region). The
+		// border-coloured ┃ appears AFTER the bg escape (inside the painted region).
+		const line1PiIdx = raw[1].indexOf(`${borderFg}${pi} `);
+		const line1BgIdx = raw[1].indexOf(bg);
+		const line1BarIdx = raw[1].indexOf(`${borderFg}${CONTINUATION_BAR} `);
+		expect(line1PiIdx).toBeGreaterThanOrEqual(0);
+		expect(line1BgIdx).toBeGreaterThan(line1PiIdx);
+		expect(line1BarIdx).toBeGreaterThan(line1BgIdx);
+		// Continuation lines: border-coloured ┃ is present, π is not.
 		for (let i = 2; i < raw.length; i++) {
 			expect(raw[i].includes(`${borderFg}${CONTINUATION_BAR} `)).toBe(true);
+			expect(raw[i].includes(pi)).toBe(false);
 		}
 	});
 


### PR DESCRIPTION
## What

Separate the user-message indicator glyphs so they no longer overlap:
- `π` now renders in the gutter at col 0 (outside `userMessageBg`) on the
  first content line only, mirroring the `●` pattern used by `GutterBlock`.
- `┃` renders at col 2 (inside `userMessageBg`) on every content line,
  including the first.
- Continuation lines have two unpainted spaces in the gutter.
- Both glyphs stay in the `border` fg color.

The `π` gutter is padded to exactly `GUTTER_WIDTH` (2) visible cells so the
`┃` bar aligns vertically across first and continuation lines under all
three icon presets (Unicode π = 1 col, Nerd Font PUA glyph = 2 cols, ASCII
`pi` = 2 cols). Without the pad the first-line gutter swelled to 3 cols
under non-default themes and overflowed by 1 col.

## Why

Issue #183 was reopened because the `π` user-message icon was rendered
inside the `userMessageBg` region at col 2, stacked visually on the `┃`
accent bar (which also renders at col 2 on continuation lines). This change
separates the two concerns so the indicator and accent bar read as distinct
elements.

Closes #183

## Testing

- `bun test test/user-message.test.ts --max-concurrency 2` from
  `packages/coding-agent/`: **14 pass, 0 fail, 52 expect() calls**.
- `bun run check` from `packages/coding-agent/`: biome + `tsgo --noEmit`
  both green.
- `bun test --max-concurrency 2` full package suite: `user-message` describe
  block 14/14 green. Observed 5-8 unrelated flaky failures in liteLLM
  config, `ModelRegistry` runtime-provider registration (5000 ms timeouts),
  and `createAgentSession` skills tests — pre-existing flakes unrelated to
  this change that drift between runs.

Three existing tests in `user-message.test.ts` were updated to assert the
new layout contract. The other 11 tests in the file continue to pass
unchanged.

---

- [x] `bun run check` passes
- [x] `bun test` — no new failures vs baseline (user-message suite 14/14)
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #183`