### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -11,6 +11,7 @@ skip-path:
   - docs/specifications
   - specs/discovered
   - specs/raw
+  - specs/original
   # Install-verification dockerfiles are test harnesses, not production
   # images — CKV_DOCKER_2 (HEALTHCHECK) and CKV_DOCKER_3 (non-root user)
   # are not meaningful for ephemeral CI validation containers.

--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -1,7 +1,18 @@
 {
   "source_repo": "f5xc-salesdemos/docs-control",
   "skip_files": {
-    "xcsh": ["biome.json", "LICENSE", "CONTRIBUTING.md", "ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"]
+    "xcsh": [
+      "biome.json",
+      "LICENSE",
+      "CONTRIBUTING.md",
+      "ruff.toml",
+      ".ruff.toml",
+      ".python-lint",
+      ".mypy.ini",
+      ".github/workflows/super-linter.yml"
+    ],
+    "api-specs": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
+    "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"]
   },
   "protected_files": [
     ".github/workflows/github-pages-deploy.yml",

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -9,6 +9,12 @@ on:
     paths:
       - '.github/config/**'
   workflow_dispatch:
+    inputs:
+      source_sha:
+        description: 'Commit SHA of the docs-control push that triggered this run. Forwarded to sync-managed-files for Pages staleness check.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -20,10 +26,14 @@ concurrency:
 jobs:
   enforce-settings:
     uses: f5xc-salesdemos/docs-control/.github/workflows/enforce-repo-settings.yml@main
+    with:
+      source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
 
   sync-files:
     uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main
+    with:
+      source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-sync-token: ${{ secrets.REPO_SYNC_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -172,4 +172,5 @@ out.jsonl
 out.html
 pi-*.html
 packages/coding-agent/src/internal-urls/docs-index.generated.ts
+packages/coding-agent/src/internal-urls/build-info.generated.ts
 packages/typescript-edit-benchmark/runs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,13 @@ Never run `git commit`, `git push`, `gh pr create` directly.
 ```
 Agent(
   subagent_type="f5xc-github-ops:github-ops",
+  mode="bypassPermissions",
   prompt="<type>: <desc>\n\nFiles:\n- <list>\n\nWhy: <reason>"
 )
 ```
+
+`mode="bypassPermissions"` is required — without it, plan mode can
+re-engage mid-workflow and strip the agent's Bash access, leaving
+it stuck after the first step.
 
 See `CONTRIBUTING.md` for project rules.

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,19 @@
+---
+# Governance-managed Trivy configuration.
+#
+# CVE suppressions live in .trivyignore (separate managed file).
+# This file configures filesystem-scan behavior — specifically,
+# directories that must never be walked.
+
+# Python tool caches create dangling symlinks during the same CI run
+# (mypy's missing_stubs/, ruff's, pytest's). Trivy's fs walker hits
+# those symlinks between mypy-populates and trivy-scans, producing a
+# FATAL "no such file or directory" and aborting the whole scan.
+# Skipping these directories is safe: they contain no production
+# artifacts — only scratch caches regenerated each run.
+#
+# See docs-control issue #377.
+skip-dirs:
+  - .mypy_cache
+  - .ruff_cache
+  - .pytest_cache


### PR DESCRIPTION
Closes #213

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .github/workflows/enforce-repo-settings.yml
- CLAUDE.md
- .gitignore
- .checkov.yaml
- trivy.yaml
- .claude/governance.json