### PR TITLE
fix(coding-agent): align assistant content with user admonition bar at col 2

### DIFF
--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -82,7 +82,7 @@ export class AssistantMessageComponent extends Container {
 				);
 				continue;
 			}
-			this.#contentContainer.addChild(new Text(theme.fg("toolOutput", `[Image: ${image.mimeType}]`), 1, 0));
+			this.#contentContainer.addChild(new Text(theme.fg("toolOutput", `[Image: ${image.mimeType}]`), 0, 0));
 		}
 	}
 	#triggerMermaidPrerender(message: AssistantMessage): void {
@@ -137,7 +137,7 @@ export class AssistantMessageComponent extends Container {
 			if (content.type === "text" && content.text.trim()) {
 				// Assistant text messages with no background - trim the text
 				// Set paddingY=0 to avoid extra spacing before tool executions
-				this.#contentContainer.addChild(new Markdown(content.text.trim(), 1, 0, getMarkdownTheme()));
+				this.#contentContainer.addChild(new Markdown(content.text.trim(), 0, 0, getMarkdownTheme()));
 			} else if (content.type === "thinking" && content.thinking.trim()) {
 				// Add spacing only when another visible assistant content block follows.
 				// This avoids a superfluous blank line before separately-rendered tool execution blocks.
@@ -147,14 +147,14 @@ export class AssistantMessageComponent extends Container {
 
 				if (this.hideThinkingBlock) {
 					// Show static "Thinking..." label when hidden
-					this.#contentContainer.addChild(new Text(theme.italic(theme.fg("thinkingText", "Thinking...")), 1, 0));
+					this.#contentContainer.addChild(new Text(theme.italic(theme.fg("thinkingText", "Thinking...")), 0, 0));
 					if (hasVisibleContentAfter) {
 						this.#contentContainer.addChild(new Spacer(1));
 					}
 				} else {
 					// Thinking traces in thinkingText color, italic
 					this.#contentContainer.addChild(
-						new Markdown(content.thinking.trim(), 1, 0, getMarkdownTheme(), {
+						new Markdown(content.thinking.trim(), 0, 0, getMarkdownTheme(), {
 							color: (text: string) => theme.fg("thinkingText", text),
 							italic: true,
 						}),
@@ -181,11 +181,11 @@ export class AssistantMessageComponent extends Container {
 				} else {
 					this.#contentContainer.addChild(new Spacer(1));
 				}
-				this.#contentContainer.addChild(new Text(theme.fg("error", abortMessage), 1, 0));
+				this.#contentContainer.addChild(new Text(theme.fg("error", abortMessage), 0, 0));
 			} else if (message.stopReason === "error") {
 				const errorMsg = message.errorMessage || "Unknown error";
 				this.#contentContainer.addChild(new Spacer(1));
-				this.#contentContainer.addChild(new Text(theme.fg("error", `Error: ${errorMsg}`), 1, 0));
+				this.#contentContainer.addChild(new Text(theme.fg("error", `Error: ${errorMsg}`), 0, 0));
 			}
 		}
 
@@ -200,7 +200,7 @@ export class AssistantMessageComponent extends Container {
 				parts.push(`cache: ${formatNumber(usage.cacheRead)}`);
 			}
 			this.#contentContainer.addChild(new Spacer(1));
-			this.#contentContainer.addChild(new Text(theme.fg("dim", parts.join("  ")), 1, 0));
+			this.#contentContainer.addChild(new Text(theme.fg("dim", parts.join("  ")), 0, 0));
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -31,7 +31,7 @@ export class UserMessageComponent extends Container {
 			? (value: string) => theme.fg("dim", value)
 			: (value: string) => `\x1b[3m${theme.fg("userMessageText", value)}\x1b[23m`;
 		this.addChild(new Spacer(1));
-		this.addChild(new Markdown(text, 1, 0, getMarkdownTheme(), { color }));
+		this.addChild(new Markdown(text, 0, 0, getMarkdownTheme(), { color }));
 	}
 
 	override render(width: number): string[] {

--- a/packages/coding-agent/test/user-message.test.ts
+++ b/packages/coding-agent/test/user-message.test.ts
@@ -34,21 +34,22 @@ describe("UserMessageComponent", () => {
 		initTheme();
 	});
 
-	it("puts pi icon in gutter on first line and continuation bar in content area on every line", () => {
+	it("puts pi icon in gutter on first line and continuation bar in content area on every line, with exactly one space between bar and text", () => {
 		// After the gutter/content separation:
 		//   col 0-1 (gutter, unpainted): π on first content line, "  " on continuations
-		//   col 2+ (userMessageBg painted): ┃ + space + markdown content on every line
+		//   col 2+ (userMessageBg painted): ┃ + one space + markdown content on every line
+		// The single space between ┃ and text is critical — a double-space would
+		// indicate Markdown's paddingX is still contributing a stray leading col.
 		const c = new UserMessageComponent("hello world\nsecond line");
 		const lines = renderPlain(c);
 		expect(lines.length).toBeGreaterThan(1);
 		const pi = theme.icon.pi;
 		// Line 0 is the leading spacer. Content starts at line 1.
-		// First content line: π in gutter, ┃ in content — no leading spaces.
-		expect(lines[1].startsWith(`${pi} ${CONTINUATION_BAR} `)).toBe(true);
-		// Continuation lines: two spaces in gutter, ┃ in content.
-		for (let i = 2; i < lines.length; i++) {
-			expect(lines[i].startsWith(`  ${CONTINUATION_BAR} `)).toBe(true);
-		}
+		// Pin the full prefix including the first text char so a stray space
+		// between ┃ and text would break startsWith.
+		expect(lines[1].startsWith(`${pi} ${CONTINUATION_BAR} hello world`)).toBe(true);
+		// Continuation line: two gutter spaces, ┃, one space, text.
+		expect(lines[2].startsWith(`  ${CONTINUATION_BAR} second line`)).toBe(true);
 	});
 
 	it("leaves the 2-column gutter area unpainted (no bg) on every content line", () => {


### PR DESCRIPTION
## What

Assistant content (Thinking traces, reply text, tool info, error messages, image placeholders, token usage lines) was rendering one column right of the user-message ┃ accent bar. Additionally, the user-message text itself had two spaces between ┃ and the first character instead of one.

All 8 affected `Markdown`/`Text` construction sites — 7 inside `AssistantMessageComponent` and 1 inside `UserMessageComponent` — are switched from `paddingX=1` to `paddingX=0`. Assistant content now sits at col 2 (directly under the user's ┃), and the user-message text is exactly one space past ┃.

## Why

Follow-up to #183, which correctly moved π to the gutter at col 0 and ┃ to col 2 inside `userMessageBg`. During hands-on UAT a second alignment issue surfaced: the content children inside the gutter-indicator area were each introducing their own `paddingX=1`, which on the assistant side offset all content by one column (col 3 instead of col 2), and on the user side stacked on `contPrefix`'s trailing space to produce a double gap.

Closes #215

## Testing

- `bun test test/user-message.test.ts --max-concurrency 2` — 14 pass / 0 fail / 52 expect() calls
- `bun run check` (biome + tsgo --noEmit) — clean
- Full `packages/coding-agent` suite — user-message block 14/14 green; only pre-existing flaky failures in liteLLM config and ModelRegistry/skills discovery timeouts remain, unrelated to this change
- Hands-on UAT — user visually confirmed assistant content aligns at col 2 under ┃ and exactly one space between ┃ and user text

The existing user-message test was tightened to pin the one-space contract between ┃ and the message text by asserting the full prefix (including the first characters of the text content), catching any future regression that would reintroduce a double-space gap.

---

- [x] `bun run check` passes
- [x] `bun test` — no new failures vs baseline
- [ ] CHANGELOG updated (release automation handles this)
- [x] Issue linked via `Closes #215`