### PR TITLE
fix(tui): resolve theme $schema URL + mark active theme in /settings

### DIFF
--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -166,6 +166,30 @@ class SelectSubmenu extends Container {
 	}
 }
 
+/**
+ * Format the displayed value for a submenu-type setting row.
+ *
+ * Pure helper so the active-theme indicator and default-sentinel mappings can
+ * be unit-tested without rendering the TUI. Called from
+ * `#getSubmenuCurrentValue` with the current theme name injected by the caller.
+ */
+export function formatSubmenuCurrentValue(
+	path: SettingPath,
+	value: string,
+	currentThemeName: string | undefined,
+): string {
+	if (path === "compaction.thresholdPercent" && (value === "-1" || value === "")) {
+		return "default";
+	}
+	if (path === "compaction.thresholdTokens" && (value === "-1" || value === "")) {
+		return "default";
+	}
+	if ((path === "theme.dark" || path === "theme.light") && currentThemeName && value === currentThemeName) {
+		return `${value} (active)`;
+	}
+	return value;
+}
+
 function getSettingsTabs(): Tab[] {
 	return [
 		...SETTING_TABS.map(id => {
@@ -345,14 +369,7 @@ export class SettingsSelectorComponent extends Container {
 	}
 
 	#getSubmenuCurrentValue(path: SettingPath, value: unknown): string {
-		const rawValue = String(value ?? "");
-		if (path === "compaction.thresholdPercent" && (rawValue === "-1" || rawValue === "")) {
-			return "default";
-		}
-		if (path === "compaction.thresholdTokens" && (rawValue === "-1" || rawValue === "")) {
-			return "default";
-		}
-		return rawValue;
+		return formatSubmenuCurrentValue(path, String(value ?? ""), getCurrentThemeName());
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/theme/defaults/xcsh-dark.json
+++ b/packages/coding-agent/src/modes/theme/defaults/xcsh-dark.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/f5xc-salesdemos/xcsh/main/packages/coding-agent/theme-schema.json",
+	"$schema": "https://raw.githubusercontent.com/f5xc-salesdemos/xcsh/main/packages/coding-agent/src/modes/theme/theme-schema.json",
 	"name": "xcsh-dark",
 	"vars": {
 		"f5Red": "#ca260a",

--- a/packages/coding-agent/src/modes/theme/defaults/xcsh-light.json
+++ b/packages/coding-agent/src/modes/theme/defaults/xcsh-light.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/f5xc-salesdemos/xcsh/main/packages/coding-agent/theme-schema.json",
+	"$schema": "https://raw.githubusercontent.com/f5xc-salesdemos/xcsh/main/packages/coding-agent/src/modes/theme/theme-schema.json",
 	"name": "xcsh-light",
 	"vars": {
 		"f5Red": "#ca260a",

--- a/packages/coding-agent/test/settings-theme-active-marker.test.ts
+++ b/packages/coding-agent/test/settings-theme-active-marker.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Issue #221 — Dark/Light Theme rows in /settings must indicate which slot is
+ * the currently-loaded theme. The displayed value gains an "(active)" suffix
+ * on the matching row.
+ *
+ * The formatting is extracted to a pure helper `formatSubmenuCurrentValue` so
+ * it's testable without standing up the full TUI.
+ */
+import { describe, expect, it } from "bun:test";
+import { formatSubmenuCurrentValue } from "@f5xc-salesdemos/xcsh/modes/components/settings-selector";
+
+describe("formatSubmenuCurrentValue — active-theme indicator (issue #221)", () => {
+	it("appends '(active)' to theme.dark row value when it matches currentThemeName", () => {
+		expect(formatSubmenuCurrentValue("theme.dark", "xcsh-dark", "xcsh-dark")).toBe("xcsh-dark (active)");
+	});
+
+	it("appends '(active)' to theme.light row value when it matches currentThemeName", () => {
+		expect(formatSubmenuCurrentValue("theme.light", "xcsh-light", "xcsh-light")).toBe("xcsh-light (active)");
+	});
+
+	it("does not mark the dark slot active when xcsh-light is currently loaded", () => {
+		expect(formatSubmenuCurrentValue("theme.dark", "xcsh-dark", "xcsh-light")).toBe("xcsh-dark");
+	});
+
+	it("does not mark the light slot active when xcsh-dark is currently loaded", () => {
+		expect(formatSubmenuCurrentValue("theme.light", "xcsh-light", "xcsh-dark")).toBe("xcsh-light");
+	});
+
+	it("returns plain value when no currentThemeName is known (undefined)", () => {
+		expect(formatSubmenuCurrentValue("theme.dark", "xcsh-dark", undefined)).toBe("xcsh-dark");
+	});
+
+	it("preserves 'default' mapping for compaction.thresholdPercent -1 (existing behavior)", () => {
+		expect(formatSubmenuCurrentValue("compaction.thresholdPercent", "-1", "xcsh-dark")).toBe("default");
+		expect(formatSubmenuCurrentValue("compaction.thresholdPercent", "", "xcsh-dark")).toBe("default");
+	});
+
+	it("preserves 'default' mapping for compaction.thresholdTokens -1 (existing behavior)", () => {
+		expect(formatSubmenuCurrentValue("compaction.thresholdTokens", "-1", "xcsh-dark")).toBe("default");
+		expect(formatSubmenuCurrentValue("compaction.thresholdTokens", "", "xcsh-dark")).toBe("default");
+	});
+
+	it("returns plain value for unrelated submenu paths (no active marker)", () => {
+		expect(formatSubmenuCurrentValue("statusLine.preset", "xcsh", "xcsh-dark")).toBe("xcsh");
+	});
+
+	it("does not mark active when the selected row is a DIFFERENT theme than the current", () => {
+		// e.g., user has xcsh-light loaded but they highlight the dark slot which is xcsh-dark
+		expect(formatSubmenuCurrentValue("theme.dark", "xcsh-dark", "xcsh-light")).not.toContain("(active)");
+	});
+});

--- a/packages/coding-agent/test/theme-schema-url.test.ts
+++ b/packages/coding-agent/test/theme-schema-url.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Issue #220 — the `$schema` URL declared in xcsh-dark.json / xcsh-light.json
+ * must point to an in-repo file that actually exists, so editor/IDE schema
+ * validators can fetch it and project consumers have a working reference.
+ */
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dir, "../../..");
+const themeDir = path.join(repoRoot, "packages/coding-agent/src/modes/theme/defaults");
+
+async function repoPathFromSchemaUrl(themeFile: string): Promise<string> {
+	const raw = await fs.readFile(themeFile, "utf8");
+	const parsed = JSON.parse(raw);
+	const url = parsed.$schema;
+	expect(typeof url).toBe("string");
+	// Expected form: https://raw.githubusercontent.com/<owner>/<repo>/<branch>/<path>
+	const match = url.match(/^https:\/\/raw\.githubusercontent\.com\/[^/]+\/[^/]+\/[^/]+\/(.+)$/);
+	expect(match).not.toBeNull();
+	return match![1];
+}
+
+describe("theme JSON $schema URL resolves to an existing file (issue #220)", () => {
+	it("xcsh-dark.json $schema references a file that exists in the repo", async () => {
+		const repoRelative = await repoPathFromSchemaUrl(path.join(themeDir, "xcsh-dark.json"));
+		const abs = path.join(repoRoot, repoRelative);
+		const stat = await fs.stat(abs).catch(() => null);
+		expect(stat, `$schema points at "${repoRelative}" which does not exist in the repo`).not.toBeNull();
+	});
+
+	it("xcsh-light.json $schema references a file that exists in the repo", async () => {
+		const repoRelative = await repoPathFromSchemaUrl(path.join(themeDir, "xcsh-light.json"));
+		const abs = path.join(repoRoot, repoRelative);
+		const stat = await fs.stat(abs).catch(() => null);
+		expect(stat, `$schema points at "${repoRelative}" which does not exist in the repo`).not.toBeNull();
+	});
+});


### PR DESCRIPTION
Issues #220, #221 — first batch of PR #207 follow-ups, both scoped small and shippable together under the same theme/settings area.

## #220 ($schema URL 404)

The URL embedded in `xcsh-{dark,light}.json` was missing the `src/modes/theme/` path segment, so IDE JSON-schema validators 404'd on every theme-file save. Points the URL at the correct in-repo location.

## #221 (active-theme indicator)

`/settings` shows Dark Theme + Light Theme rows but nothing indicated which slot was currently loaded. Especially confusing inside tmux where appearance detection can be silently wrong (see the still-open F5 follow-up). The currently-active row now reads `xcsh-dark (active)` / `xcsh-light (active)`.

The display formatter is extracted as a pure exported helper (`formatSubmenuCurrentValue`) so the active-marker logic and the preserved `compaction.*` "default" sentinel mappings are unit-testable without spinning up the TUI.

Closes #220.
Closes #221.

## Test plan

- [x] `bun --cwd=packages/coding-agent test theme-schema-url.test.ts settings-theme-active-marker.test.ts` — 11/11 pass (17 expect() calls across 2 files)
  - `theme-schema-url.test.ts` — asserts `$schema` URL resolves to an in-repo file (F4 regression guard)
  - `settings-theme-active-marker.test.ts` — 9 assertions covering the active-theme marker + preserved legacy `default` mappings (F1)
- [x] `bun --cwd=packages/coding-agent run check:types` — clean (tsgo --noEmit, no errors)
- [x] Biome lint clean on all 3 modified + 2 new files
- [ ] CI: `check`, `test`, `native x2`, `install_methods` all green