### PR TITLE
fix(tui): rebuild user-message Markdown child on invalidate

### DIFF
--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -25,13 +25,32 @@ const GUTTER_PAD = "  ";
  * leading blank spacer separates the prompt from the preceding block.
  */
 export class UserMessageComponent extends Container {
+	#text: string;
+	#synthetic: boolean;
+
 	constructor(text: string, synthetic = false) {
 		super();
-		const color = synthetic
+		this.#text = text;
+		this.#synthetic = synthetic;
+		this.#rebuild();
+	}
+
+	// Mirror AssistantMessageComponent: on invalidate, drop the Markdown child
+	// and rebuild it so getMarkdownTheme() is re-captured. Without this, a
+	// theme change leaves the Markdown child rendering with the original
+	// construction-time theme.
+	override invalidate(): void {
+		super.invalidate();
+		this.#rebuild();
+	}
+
+	#rebuild(): void {
+		this.children = [];
+		const color = this.#synthetic
 			? (value: string) => theme.fg("dim", value)
 			: (value: string) => `\x1b[3m${theme.fg("userMessageText", value)}\x1b[23m`;
 		this.addChild(new Spacer(1));
-		this.addChild(new Markdown(text, 0, 0, getMarkdownTheme(), { color }));
+		this.addChild(new Markdown(this.#text, 0, 0, getMarkdownTheme(), { color }));
 	}
 
 	override render(width: number): string[] {

--- a/packages/coding-agent/test/user-message-hotswap.test.ts
+++ b/packages/coding-agent/test/user-message-hotswap.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Issue #226 — UserMessageComponent captures getMarkdownTheme() at construction
+ * time and never rebuilds its Markdown child. When the global theme changes,
+ * the in-viewport rendering of user messages keeps the old theme's markdown
+ * styling (code blocks, quotes, headings, etc.) until the message scrolls out.
+ *
+ * Fix mirrors AssistantMessageComponent's override-invalidate + rebuild
+ * pattern. These tests pin that contract.
+ */
+import { describe, expect, it } from "bun:test";
+import { UserMessageComponent } from "@f5xc-salesdemos/xcsh/modes/components/user-message";
+import { initTheme } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
+
+function stripAnsi(s: string): string {
+	return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+describe("UserMessageComponent — invalidate replaces Markdown child (issue #226)", () => {
+	it("invalidate() swaps the Markdown child for a fresh instance (so new theme is captured)", async () => {
+		await initTheme();
+		const c = new UserMessageComponent("hello");
+		// Container children layout at construction:
+		//   [0] Spacer(1)
+		//   [1] Markdown(text, …, getMarkdownTheme())
+		expect(c.children.length).toBe(2);
+		const markdownBefore = c.children[1];
+
+		c.invalidate();
+
+		expect(c.children.length).toBe(2);
+		const markdownAfter = c.children[1];
+		expect(markdownAfter).not.toBe(markdownBefore);
+	});
+
+	it("preserves the text across rebuilds", async () => {
+		await initTheme();
+		const c = new UserMessageComponent("hello rebuild");
+		const before = stripAnsi(c.render(80).join("\n"));
+		expect(before).toContain("hello rebuild");
+
+		c.invalidate();
+
+		const after = stripAnsi(c.render(80).join("\n"));
+		expect(after).toContain("hello rebuild");
+	});
+
+	it("preserves the synthetic flag across rebuilds (dim-styled user message)", async () => {
+		await initTheme();
+		const plain = new UserMessageComponent("test", false);
+		const synthetic = new UserMessageComponent("test", true);
+
+		// Synthetic uses theme.fg("dim",...) instead of italic+userMessageText —
+		// after invalidate the flag must still be honored.
+		const syntheticBefore = synthetic.render(80).join("\n");
+		synthetic.invalidate();
+		const syntheticAfter = synthetic.render(80).join("\n");
+
+		plain.invalidate();
+		const plainAfter = plain.render(80).join("\n");
+
+		// Synthetic output should differ from plain output, both before and
+		// after invalidate, because the render-time color wrapping differs.
+		expect(syntheticBefore).not.toBe(plainAfter);
+		expect(syntheticAfter).not.toBe(plainAfter);
+	});
+});


### PR DESCRIPTION
Issue #226 — `UserMessageComponent` captured `getMarkdownTheme()` once at construction and never rebuilt its `Markdown` child. When the active theme changed (macOS dark/light flip, `/settings` slot swap), the in-viewport rendering of user messages kept the old theme's markdown styling until the message scrolled out.

`AssistantMessageComponent` already handles this by overriding `invalidate()` to re-run `updateContent()` which rebuilds its Markdown children. This applies the same pattern to user-message: text and synthetic flag become instance fields, and a `#rebuild()` helper is called from both the constructor and `override invalidate()`.

## Out of scope (intentionally left alone)

- Scrollback content already emitted to the terminal is frozen — no component-level fix can retroactively re-theme it.
- `todo-write` renders through `tool-execution`, which already overrides `invalidate` → `#updateDisplay`, rebuilding children with fresh theme. Any "Todo Write stayed dark" observation during PR #207 UAT is almost certainly attributable to the still-open F5 (tmux broke appearance detection → xcsh-dark was loaded on a light terminal).

Closes #226.

## Test plan

- [x] `bun --cwd=packages/coding-agent test user-message-hotswap.test.ts` — 3/3 pass
  - `invalidate()` replaces the `Markdown` child instance (so fresh `getMarkdownTheme()` is captured on next render)
  - text is preserved across rebuild
  - synthetic vs plain flag is honored after rebuild
- [x] `bun --cwd=packages/coding-agent test user-message` — 17/17 pass (3 new + 14 pre-existing, no regressions)
- [x] `bun --cwd=packages/coding-agent run check:types` — clean (tsgo --noEmit, no errors)
- [x] Biome lint clean on both touched files
- [ ] CI: `check`, `test`, `native x2`, `install_methods` all green