### PR TITLE
feat(theme): theme.forceSlot override for auto dark/light detection

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -263,6 +263,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"theme.forceSlot": {
+		type: "enum",
+		values: ["auto", "dark", "light"] as const,
+		default: "auto",
+		ui: {
+			tab: "appearance",
+			label: "Force Theme Slot",
+			description: "Override auto dark/light detection (useful inside tmux where OSC 11 is unreliable)",
+			submenu: true,
+		},
+	},
+
 	symbolPreset: {
 		type: "enum",
 		values: ["unicode", "nerd", "ascii"] as const,

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -26,7 +26,13 @@ import { YAML } from "bun";
 import { type Settings as SettingsCapabilityItem, settingsCapability } from "../capability/settings";
 import type { ModelRole } from "../config/model-registry";
 import { loadCapability } from "../discovery";
-import { isLightTheme, setAutoThemeMapping, setColorBlindMode, setSymbolPreset } from "../modes/theme/theme";
+import {
+	isLightTheme,
+	setAutoThemeMapping,
+	setColorBlindMode,
+	setForceSlot,
+	setSymbolPreset,
+} from "../modes/theme/theme";
 import { AgentStorage } from "../session/agent-storage";
 import { type EditMode, normalizeEditMode } from "../utils/edit-mode";
 import { withFileLock } from "./file-lock";
@@ -647,6 +653,11 @@ const SETTING_HOOKS: Partial<Record<SettingPath, SettingHook<any>>> = {
 	"theme.light": value => {
 		if (typeof value === "string") {
 			setAutoThemeMapping("light", value);
+		}
+	},
+	"theme.forceSlot": value => {
+		if (value === "auto" || value === "dark" || value === "light") {
+			setForceSlot(value);
 		}
 	},
 	symbolPreset: value => {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -704,6 +704,7 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 		settings.get("colorBlindMode"),
 		settings.get("theme.dark"),
 		settings.get("theme.light"),
+		settings.get("theme.forceSlot"),
 	);
 
 	let scopedModels: ScopedModel[] = [];

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -1894,9 +1894,33 @@ function detectTerminalBackground(): "dark" | "light" {
 	return "dark";
 }
 
+/**
+ * Theme-slot override mode. `"auto"` uses terminal-appearance detection to
+ * pick between the dark and light slots. `"dark"` / `"light"` skip detection
+ * and always load that slot — useful when running inside tmux where OSC 11
+ * queries and `COLORFGBG` don't reliably surface (see issue #228).
+ */
+export type ThemeForceSlot = "auto" | "dark" | "light";
+
+/**
+ * Pure slot-resolution helper. Exported so it can be unit-tested without a
+ * terminal. When `forceSlot` is `"dark"` or `"light"`, returns that slot's
+ * theme name unconditionally. Otherwise maps `detected` bg to the matching
+ * slot.
+ */
+export function resolveThemeSlot(
+	forceSlot: ThemeForceSlot,
+	detected: "dark" | "light",
+	darkTheme: string,
+	lightTheme: string,
+): string {
+	if (forceSlot === "dark") return darkTheme;
+	if (forceSlot === "light") return lightTheme;
+	return detected === "light" ? lightTheme : darkTheme;
+}
+
 function getDefaultTheme(): string {
-	const bg = detectTerminalBackground();
-	return bg === "light" ? autoLightTheme : autoDarkTheme;
+	return resolveThemeSlot(currentForceSlot, detectTerminalBackground(), autoDarkTheme, autoLightTheme);
 }
 
 // ============================================================================
@@ -1918,6 +1942,7 @@ var sigwinchHandler: (() => void) | undefined;
 var autoDetectedTheme: boolean = false;
 var autoDarkTheme: string = "xcsh-dark";
 var autoLightTheme: string = "xcsh-light";
+var currentForceSlot: ThemeForceSlot = "auto";
 var onThemeChangeCallback: (() => void) | undefined;
 var themeLoadRequestId: number = 0;
 
@@ -1934,10 +1959,12 @@ export async function initTheme(
 	colorBlindMode?: boolean,
 	darkTheme?: string,
 	lightTheme?: string,
+	forceSlot?: ThemeForceSlot,
 ): Promise<void> {
 	autoDetectedTheme = true;
 	autoDarkTheme = darkTheme ?? "xcsh-dark";
 	autoLightTheme = lightTheme ?? "xcsh-light";
+	currentForceSlot = forceSlot ?? "auto";
 	const name = getDefaultTheme();
 	currentThemeName = name;
 	currentSymbolPresetOverride = symbolPreset;
@@ -2030,6 +2057,19 @@ export function setAutoThemeMapping(mode: "dark" | "light", themeName: string): 
 	if (mode === "dark") autoDarkTheme = themeName;
 	else autoLightTheme = themeName;
 	reevaluateAutoTheme("setAutoThemeMapping");
+}
+
+/**
+ * Update the forced-slot override. Callers pass `"auto"` to restore the
+ * detection chain, or `"dark"` / `"light"` to skip detection entirely and
+ * always load that slot. Re-evaluates the active theme immediately.
+ *
+ * Primary use case: tmux sessions where OSC 11 and COLORFGBG don't surface
+ * a reliable bg signal (issue #228).
+ */
+export function setForceSlot(slot: ThemeForceSlot): void {
+	currentForceSlot = slot;
+	reevaluateAutoTheme("setForceSlot");
 }
 
 /**

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -30,6 +30,18 @@ describe("fork settings schema defaults (PRs #48, #68, theme commits)", () => {
 		expect(SETTINGS_SCHEMA["theme.light"].default).toBe("xcsh-light");
 	});
 
+	// issue #228 — theme.forceSlot (override auto dark/light detection)
+	it("theme.forceSlot defaults to 'auto' (backward-compatible; detection chain unchanged)", () => {
+		expect(SETTINGS_SCHEMA["theme.forceSlot"].default).toBe("auto");
+	});
+
+	it("theme.forceSlot accepts exactly auto | dark | light", () => {
+		const def = SETTINGS_SCHEMA["theme.forceSlot"];
+		expect(def.type).toBe("enum");
+		if (def.type !== "enum") throw new Error("unreachable");
+		expect([...def.values].sort()).toEqual(["auto", "dark", "light"]);
+	});
+
 	it("symbol preset defaults to nerd (not upstream unicode)", () => {
 		expect(SETTINGS_SCHEMA.symbolPreset.default).toBe("nerd");
 	});

--- a/packages/coding-agent/test/theme-force-slot.test.ts
+++ b/packages/coding-agent/test/theme-force-slot.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Issue #228 — theme.forceSlot setting overrides auto dark/light detection.
+ *
+ * Pure-function test for the slot-resolution helper. Unit-testable without
+ * a terminal so CI runs deterministically.
+ */
+import { describe, expect, it } from "bun:test";
+import { resolveThemeSlot } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
+
+describe("resolveThemeSlot — theme.forceSlot override (issue #228)", () => {
+	it("returns the dark theme when forceSlot=dark, regardless of detection", () => {
+		expect(resolveThemeSlot("dark", "light", "xcsh-dark", "xcsh-light")).toBe("xcsh-dark");
+		expect(resolveThemeSlot("dark", "dark", "xcsh-dark", "xcsh-light")).toBe("xcsh-dark");
+	});
+
+	it("returns the light theme when forceSlot=light, regardless of detection", () => {
+		expect(resolveThemeSlot("light", "dark", "xcsh-dark", "xcsh-light")).toBe("xcsh-light");
+		expect(resolveThemeSlot("light", "light", "xcsh-dark", "xcsh-light")).toBe("xcsh-light");
+	});
+
+	it("falls through to detection when forceSlot=auto (default)", () => {
+		expect(resolveThemeSlot("auto", "dark", "xcsh-dark", "xcsh-light")).toBe("xcsh-dark");
+		expect(resolveThemeSlot("auto", "light", "xcsh-dark", "xcsh-light")).toBe("xcsh-light");
+	});
+
+	it("respects custom slot theme names (not hardcoded to xcsh-*)", () => {
+		expect(resolveThemeSlot("dark", "light", "my-dark-theme", "my-light-theme")).toBe("my-dark-theme");
+		expect(resolveThemeSlot("light", "dark", "my-dark-theme", "my-light-theme")).toBe("my-light-theme");
+		expect(resolveThemeSlot("auto", "dark", "my-dark-theme", "my-light-theme")).toBe("my-dark-theme");
+	});
+});


### PR DESCRIPTION
Issue #228 — inside tmux, xcsh's auto-detection chain (OSC 11 → `COLORFGBG` → macOS appearance) silently fails: tmux doesn't pass the OSC 11 response through by default, doesn't set `COLORFGBG`, and blocks macOS appearance propagation to the child process. Users on a light-bg terminal silently get `xcsh-dark` loaded, with no warning.

This adds a first-class `theme.forceSlot` setting:

```
type:    "auto" | "dark" | "light"
default: "auto"   (backward-compatible; existing detection unchanged)
```

When set to `"dark"` or `"light"`, the detection chain is skipped entirely and that slot's theme is loaded unconditionally. Users inside tmux can set this via `/settings` or `config.yml`:

```yaml
theme:
  forceSlot: light
```

## Implementation

- New exported `ThemeForceSlot` type and pure helper `resolveThemeSlot`. `getDefaultTheme` now delegates to the helper so the override is applied in every theme-reload path (`initTheme`, `setTheme`, SIGWINCH, terminal-appearance change, etc.) without further plumbing.
- New `setForceSlot()` API paired with the settings hook, mirroring `setAutoThemeMapping` / `setSymbolPreset` / `setColorBlindMode`.
- `initTheme()` grows a 6th optional parameter; `main.ts` passes the current setting value through.
- Regression-guard pins the default and the enum value set so they can't silently drift.

Formalizes the workaround applied during PR #207 UAT (setting `theme.dark: xcsh-light` in `config.yml`) with a proper first-class setting and discoverable `/settings` entry.

Closes #228.

## Test plan

- [x] `bun --cwd=packages/coding-agent test theme-force-slot regression-guard` — 75/75 pass
  - 4 new `resolveThemeSlot` unit tests covering `auto` / `dark` / `light` + custom theme-name arguments
  - 2 new regression-guard pins (default value + enum value set)
  - 69 existing regression-guard tests still pass
- [x] `bun --cwd=packages/coding-agent test theme-auto-detection theme-gutter-fallback settings-theme-active-marker welcome-component` — 41/41 pass (no regressions in adjacent theme/settings/welcome code)
- [x] `bun --cwd=packages/coding-agent run check:types` — clean (tsgo --noEmit)
- [x] Biome lint clean on all 6 modified/new files
- [ ] CI: `check`, `test`, `native x2`, `install_methods` all green