### PR TITLE
fix(coding-agent): use F5 brand red for profile_f5xc segment in xcsh themes

### DIFF
--- a/packages/coding-agent/src/modes/theme/defaults/xcsh-dark.json
+++ b/packages/coding-agent/src/modes/theme/defaults/xcsh-dark.json
@@ -105,7 +105,7 @@
 		"statusLineContextPctWarningBg": 22,
 		"statusLineContextPctPurpleBg": 94,
 		"statusLineContextPctErrorBg": 88,
-		"statusLineProfileF5xcBg": 52,
+		"statusLineProfileF5xcBg": "f5Red",
 		"statusLineProfileF5xcFg": 231,
 		"pythonMode": "#f0c040",
 		"syntaxControl": "#569CD6"

--- a/packages/coding-agent/src/modes/theme/defaults/xcsh-light.json
+++ b/packages/coding-agent/src/modes/theme/defaults/xcsh-light.json
@@ -107,7 +107,7 @@
 		"statusLineContextPctWarningBg": 22,
 		"statusLineContextPctPurpleBg": 94,
 		"statusLineContextPctErrorBg": 88,
-		"statusLineProfileF5xcBg": 52,
+		"statusLineProfileF5xcBg": "f5Red",
 		"statusLineProfileF5xcFg": 231,
 		"pythonMode": "warningAmber",
 		"syntaxControl": "f5Red"

--- a/packages/coding-agent/test/theme-profile-f5xc-brand.test.ts
+++ b/packages/coding-agent/test/theme-profile-f5xc-brand.test.ts
@@ -1,0 +1,16 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { getThemeByName, initTheme } from "../src/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+describe("theme: profile_f5xc segment uses F5 brand red in xcsh themes", () => {
+	for (const name of ["xcsh-light", "xcsh-dark"]) {
+		it(`${name} statusLineProfileF5xcBg resolves to the same ANSI as accent`, async () => {
+			const theme = await getThemeByName(name);
+			expect(theme).toBeDefined();
+			expect(theme!.fg("statusLineProfileF5xcBg", "●")).toBe(theme!.fg("accent", "●"));
+		});
+	}
+});


### PR DESCRIPTION
## Summary
- Both xcsh-branded themes now render the `profile_f5xc` status-line segment in F5 brand red (`#ca260a`), matching every other accent.
- Adds a regression test asserting `statusLineProfileF5xcBg` resolves to the same ANSI bytes as `accent` in both xcsh-light and xcsh-dark.

## Root cause
- Both `xcsh-light.json` and `xcsh-dark.json` set `statusLineProfileF5xcBg: 52` — ANSI 256-color index 52 renders as `#5f0000` (dark maroon), not F5 brand red.
- Fix: replace the integer with the `f5Red` var reference so it resolves to `#ca260a`, consistent with the `accent` token.

## Test plan
- [x] `bun --cwd=packages/coding-agent test test/theme-profile-f5xc-brand.test.ts` — 2 pass
- [x] `bun --cwd=packages/coding-agent test test/theme-gutter-fallback.test.ts test/theme-auto-detection.test.ts` — 7 pass
- [x] biome check of touched files — clean
- [ ] CI green

Closes #229