### PR TITLE
feat(coding-agent): use checkbox emoji for welcome + /profile status indicators

### DIFF
--- a/packages/coding-agent/src/services/f5xc-profile-indicators.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-indicators.ts
@@ -1,16 +1,17 @@
-import { theme } from "../modes/theme/theme";
-
 export type StatusCategory = "connected" | "error" | "warning" | "unknown";
 
+// Checkbox emoji indicators shared by the welcome screen and the /profile table.
+// Target terminal: iTerm2 + Nerd Fonts, where emoji presentation and width (2 cells)
+// are consistent. Emoji carry their own coloring — no theme.fg wrapping needed.
 export function formatStatusIcon(status: StatusCategory): string {
 	switch (status) {
 		case "connected":
-			return theme.fg("success", "●");
+			return "✅";
 		case "error":
-			return theme.fg("error", "○");
+			return "❌";
 		case "warning":
-			return theme.fg("warning", "⚠");
+			return "⚠️";
 		case "unknown":
-			return theme.fg("dim", "○");
+			return "❓";
 	}
 }

--- a/packages/coding-agent/test/f5xc-profile-indicators.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-indicators.test.ts
@@ -6,48 +6,41 @@ function stripAnsi(s: string): string {
 	return s.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
+// The coding-agent surfaces (welcome screen + /profile table) unify on checkbox-style
+// emoji for at-a-glance status. We target iTerm2 + Nerd Fonts where emoji presentation
+// and width are consistent. Each icon is 2 terminal cells wide (emoji-presentation).
 describe("formatStatusIcon", () => {
 	beforeAll(() => {
 		initTheme();
 	});
 
-	it("returns a filled circle for 'connected'", () => {
-		expect(stripAnsi(formatStatusIcon("connected"))).toBe("●");
+	it("returns ✅ for 'connected'", () => {
+		expect(stripAnsi(formatStatusIcon("connected"))).toBe("✅");
 	});
 
-	it("returns an empty circle for 'error'", () => {
-		expect(stripAnsi(formatStatusIcon("error"))).toBe("○");
+	it("returns ❌ for 'error'", () => {
+		expect(stripAnsi(formatStatusIcon("error"))).toBe("❌");
 	});
 
-	it("returns a warning triangle for 'warning'", () => {
-		expect(stripAnsi(formatStatusIcon("warning"))).toBe("⚠");
+	it("returns ⚠️ for 'warning' (with VS16 emoji-presentation selector)", () => {
+		expect(stripAnsi(formatStatusIcon("warning"))).toBe("⚠️");
 	});
 
-	it("returns an empty circle for 'unknown'", () => {
-		expect(stripAnsi(formatStatusIcon("unknown"))).toBe("○");
+	it("returns ❓ for 'unknown'", () => {
+		expect(stripAnsi(formatStatusIcon("unknown"))).toBe("❓");
 	});
 
-	it("wraps the glyph in ANSI color escapes (success for connected)", () => {
-		const out = formatStatusIcon("connected");
-		expect(out).not.toBe(stripAnsi(out));
-		expect(out).toContain("\x1b[");
+	it("every category produces a distinct glyph", () => {
+		const categories: StatusCategory[] = ["connected", "error", "warning", "unknown"];
+		const glyphs = new Set(categories.map(c => stripAnsi(formatStatusIcon(c))));
+		expect(glyphs.size).toBe(4);
 	});
 
-	it("applies distinct colors for distinct categories", () => {
-		const connectedColored = formatStatusIcon("connected");
-		const errorColored = formatStatusIcon("error");
-		const warningColored = formatStatusIcon("warning");
-		const unknownColored = formatStatusIcon("unknown");
-		// All four categories must produce visually distinct ANSI output.
-		const set = new Set([connectedColored, errorColored, warningColored, unknownColored]);
-		expect(set.size).toBe(4);
-	});
-
-	it("produces exactly 1 cell of visible width per icon (column alignment)", () => {
+	it("produces exactly 2 cells of visible width per icon (emoji presentation)", () => {
 		const categories: StatusCategory[] = ["connected", "error", "warning", "unknown"];
 		for (const cat of categories) {
 			const plain = stripAnsi(formatStatusIcon(cat));
-			expect(Bun.stringWidth(plain)).toBe(1);
+			expect(Bun.stringWidth(plain)).toBe(2);
 		}
 	});
 });

--- a/packages/coding-agent/test/f5xc-table.test.ts
+++ b/packages/coding-agent/test/f5xc-table.test.ts
@@ -6,33 +6,33 @@ import { formatAuthIndicator, renderF5XCTable } from "../src/services/f5xc-table
 const vw = (s: string) => (s ? Bun.stringWidth(s) : 0);
 const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
 
-describe("formatAuthIndicator (unified with welcome indicators)", () => {
+describe("formatAuthIndicator (unified emoji indicators)", () => {
 	beforeAll(() => {
 		initTheme();
 	});
 
-	it("connected uses the shared connected glyph", () => {
+	it("connected uses the shared ✅ glyph", () => {
 		const out = formatAuthIndicator("connected", 42);
-		expect(stripAnsi(out)).toContain("●");
+		expect(stripAnsi(out)).toContain("✅");
 		expect(stripAnsi(out)).toContain("Connected");
 		expect(stripAnsi(out)).toContain("(42ms)");
 	});
 
-	it("auth_error uses the shared error glyph (empty circle)", () => {
+	it("auth_error uses the shared ❌ glyph", () => {
 		const out = formatAuthIndicator("auth_error");
-		expect(stripAnsi(out)).toContain("○");
+		expect(stripAnsi(out)).toContain("❌");
 		expect(stripAnsi(out)).toContain("Auth Error");
 	});
 
-	it("offline uses the shared warning glyph (triangle, not error)", () => {
+	it("offline uses the shared ⚠️ glyph", () => {
 		const out = formatAuthIndicator("offline");
-		expect(stripAnsi(out)).toContain("⚠");
+		expect(stripAnsi(out)).toContain("⚠️");
 		expect(stripAnsi(out)).toContain("Offline");
 	});
 
-	it("unknown uses the shared unknown glyph", () => {
+	it("unknown uses the shared ❓ glyph", () => {
 		const out = formatAuthIndicator("unknown");
-		expect(stripAnsi(out)).toContain("○");
+		expect(stripAnsi(out)).toContain("❓");
 	});
 
 	it("connected glyph matches formatStatusIcon('connected')", () => {

--- a/packages/coding-agent/test/welcome-component.test.ts
+++ b/packages/coding-agent/test/welcome-component.test.ts
@@ -25,10 +25,9 @@ describe("WelcomeComponent", () => {
 		expect(out).toContain("Model Provider");
 		expect(out).toContain("litellm");
 		expect(out).toContain("connected (142ms)");
-		// Must use the unified filled-circle glyph, not ✓ or emoji
-		expect(out).toContain("●");
-		expect(out).not.toContain("✓");
-		expect(out).not.toContain("✅");
+		// Unified emoji indicator (iTerm2 + Nerd Fonts)
+		expect(out).toContain("✅");
+		expect(out).not.toContain("●");
 	});
 
 	it("renders no_provider", () => {
@@ -36,10 +35,8 @@ describe("WelcomeComponent", () => {
 		const out = renderPlain(c).join("\n");
 		expect(out).toContain("No model provider configured");
 		expect(out).toContain("/login");
-		// Error states use empty-circle glyph, not ✗ or emoji
-		expect(out).toContain("○");
-		expect(out).not.toContain("✗");
-		expect(out).not.toContain("❌");
+		expect(out).toContain("❌");
+		expect(out).not.toContain("○");
 	});
 
 	it("renders auth_error", () => {
@@ -47,8 +44,7 @@ describe("WelcomeComponent", () => {
 		const out = renderPlain(c).join("\n");
 		expect(out).toContain("connection failed");
 		expect(out).toContain("/login");
-		expect(out).toContain("○");
-		expect(out).not.toContain("✗");
+		expect(out).toContain("❌");
 	});
 
 	it("hides profile when undefined", () => {
@@ -63,8 +59,7 @@ describe("WelcomeComponent", () => {
 		const out = renderPlain(c).join("\n");
 		expect(out).toContain("F5 XC Profile");
 		expect(out).toContain("production");
-		// Connected profile uses the same filled-circle glyph as the profile table
-		expect(out).toContain("●");
+		expect(out).toContain("✅");
 	});
 
 	it("shows profile auth_error with update hint", () => {
@@ -73,28 +68,24 @@ describe("WelcomeComponent", () => {
 		const out = renderPlain(c).join("\n");
 		expect(out).toContain("token invalid");
 		expect(out).toContain("Run /profile to update");
-		expect(out).toContain("○");
-		expect(out).not.toContain("✗");
+		expect(out).toContain("❌");
 	});
 
-	it("shows profile offline with network hint (warning triangle)", () => {
+	it("shows profile offline with network hint", () => {
 		const ms: ModelStatus = { state: "connected", provider: "litellm", latencyMs: 100 };
 		const c = new WelcomeComponent("15.15.0", ms, { state: "offline", name: "prod" });
 		const out = renderPlain(c).join("\n");
 		expect(out).toContain("unreachable");
 		expect(out).toContain("Check network, /profile");
-		// Offline is transient, uses warning glyph
-		expect(out).toContain("⚠");
-		expect(out).not.toContain("⚠️"); // must be VS-less 1-cell form
+		expect(out).toContain("⚠️");
 	});
 
-	it("shows no_profile hint (warning, not informational)", () => {
+	it("shows no_profile hint", () => {
 		const ms: ModelStatus = { state: "connected", provider: "litellm", latencyMs: 100 };
 		const c = new WelcomeComponent("15.15.0", ms, { state: "no_profile" });
 		const out = renderPlain(c).join("\n");
 		expect(out).toContain("No profile configured");
-		// no_profile is actionable (nudge the user to configure) — warning glyph
-		expect(out).toContain("⚠");
+		expect(out).toContain("⚠️");
 	});
 
 	it("renders version header", () => {

--- a/packages/coding-agent/test/welcome-status-icons.test.ts
+++ b/packages/coding-agent/test/welcome-status-icons.test.ts
@@ -10,68 +10,61 @@ function renderPlain(component: WelcomeComponent, width = 120): string {
 	return component.render(width).map(stripAnsi).join("\n");
 }
 
-// Unified circle indicators (see #224): welcome and the /profile table both use the
-// same 1-cell theme-colored glyph set via formatStatusIcon(). Emoji (✅/❌/⚠️) are
-// rejected because they occupy 2 terminal cells and break column alignment.
-describe("WelcomeComponent unified status icons (#224)", () => {
+// Welcome and /profile table unify on checkbox emoji (✅/❌/⚠️/❓) via formatStatusIcon.
+// Target terminal: iTerm2 + Nerd Fonts, where emoji presentation and width are consistent.
+describe("WelcomeComponent unified emoji status icons", () => {
 	beforeAll(async () => {
 		await initTheme();
 	});
 
-	it("connected provider renders ● (filled circle, not emoji or ✓/✔)", () => {
-		const c = new WelcomeComponent("18.5.2", { state: "connected", provider: "anthropic", latencyMs: 42 });
+	it("connected provider renders ✅", () => {
+		const c = new WelcomeComponent("18.7.0", { state: "connected", provider: "anthropic", latencyMs: 42 });
 		const out = renderPlain(c);
-		expect(out).toContain("●");
-		expect(out).not.toContain("✅");
-		expect(out).not.toMatch(/[✓✔]\s+anthropic/);
+		expect(out).toContain("✅");
+		expect(out).not.toContain("●");
 	});
 
-	it("auth_error provider renders ○ (empty circle, not emoji or ✗/✘)", () => {
-		const c = new WelcomeComponent("18.5.2", { state: "auth_error", provider: "anthropic" });
+	it("auth_error provider renders ❌", () => {
+		const c = new WelcomeComponent("18.7.0", { state: "auth_error", provider: "anthropic" });
 		const out = renderPlain(c);
-		expect(out).toContain("○");
-		expect(out).not.toContain("❌");
-		expect(out).not.toMatch(/[✗✘]\s+anthropic/);
+		expect(out).toContain("❌");
+		expect(out).not.toMatch(/[○●]\s+anthropic/);
 	});
 
-	it("no_provider renders ○ (empty circle)", () => {
-		const c = new WelcomeComponent("18.5.2", { state: "no_provider" });
+	it("no_provider renders ❌", () => {
+		const c = new WelcomeComponent("18.7.0", { state: "no_provider" });
 		const out = renderPlain(c);
-		expect(out).toContain("○");
-		expect(out).not.toContain("❌");
+		expect(out).toContain("❌");
 	});
 
-	it("profile connected renders ● (matches /profile table)", () => {
+	it("profile connected renders ✅ (matches /profile table)", () => {
 		const ms: ModelStatus = { state: "connected", provider: "anthropic", latencyMs: 10 };
 		const ps: WelcomeProfileStatus = { state: "connected", name: "prod", latencyMs: 10 };
-		const c = new WelcomeComponent("18.5.2", ms, ps);
+		const c = new WelcomeComponent("18.7.0", ms, ps);
 		const out = renderPlain(c);
-		expect(out).toContain("●");
-		expect(out).not.toContain("✅");
+		expect(out).toContain("✅");
+		expect(out).not.toContain("●");
 	});
 
-	it("profile auth_error renders ○", () => {
+	it("profile auth_error renders ❌", () => {
 		const ms: ModelStatus = { state: "connected", provider: "anthropic", latencyMs: 10 };
-		const c = new WelcomeComponent("18.5.2", ms, { state: "auth_error", name: "prod" });
+		const c = new WelcomeComponent("18.7.0", ms, { state: "auth_error", name: "prod" });
 		const out = renderPlain(c);
-		expect(out).toContain("○");
-		expect(out).not.toContain("❌");
+		expect(out).toContain("❌");
 	});
 
-	it("profile offline renders ⚠ (text-presentation triangle, not ⚠️ emoji)", () => {
+	it("profile offline renders ⚠️ (emoji presentation, VS16 included)", () => {
 		const ms: ModelStatus = { state: "connected", provider: "anthropic", latencyMs: 10 };
-		const c = new WelcomeComponent("18.5.2", ms, { state: "offline", name: "prod" });
+		const c = new WelcomeComponent("18.7.0", ms, { state: "offline", name: "prod" });
 		const out = renderPlain(c);
-		expect(out).toContain("⚠");
-		// Must not include the VS16 emoji presentation selector (makes it 2-cell on most terminals)
-		expect(out).not.toContain("⚠️");
+		expect(out).toContain("⚠️");
 	});
 
-	it("profile no_profile renders ⚠ (warning-level nudge to configure)", () => {
+	it("profile no_profile renders ⚠️ (actionable nudge to configure)", () => {
 		const ms: ModelStatus = { state: "connected", provider: "anthropic", latencyMs: 10 };
-		const c = new WelcomeComponent("18.5.2", ms, { state: "no_profile" });
+		const c = new WelcomeComponent("18.7.0", ms, { state: "no_profile" });
 		const out = renderPlain(c);
-		expect(out).toContain("⚠");
+		expect(out).toContain("⚠️");
 		expect(out).toContain("No profile configured");
 	});
 });
@@ -82,7 +75,7 @@ describe("WelcomeComponent F5 logo halo", () => {
 	});
 
 	it("applies explicit dark-red bg to ▒ halo cells so the shadow doesn't wash out on light terminals", () => {
-		const c = new WelcomeComponent("18.5.2", { state: "connected", provider: "anthropic", latencyMs: 10 });
+		const c = new WelcomeComponent("18.7.0", { state: "connected", provider: "anthropic", latencyMs: 10 });
 		// Render keeps ANSI escapes
 		const raw = c.render(120).join("\n");
 		// The shadow bg is emitted as ANSI 256 color 88 (dark red) whenever a ▒ halo cell is painted.


### PR DESCRIPTION
## Summary

Switch the shared `formatStatusIcon` helper (in `packages/coding-agent/src/services/f5xc-profile-indicators.ts`, introduced by #233) to return checkbox-style emoji instead of text circles. Both the welcome screen and the `/profile` table already delegate to `formatStatusIcon`, so the new glyphs propagate automatically to welcome rows and to `/profile show` / `/profile status` output — no call-site changes required.

## Mapping

| Status     | Before | After |
| ---------- | ------ | ----- |
| connected  | `●`    | `✅`  |
| error      | `○`    | `❌`  |
| warning    | `⚠`    | `⚠️` (with VS16 emoji presentation) |
| unknown    | `○`    | `❓`  |

The `theme.fg` wrapping was also dropped, since emoji carry their own color.

## Why

User feedback on #233: they run **iTerm2 + Nerd Fonts** and want checkbox-style emoji for the at-a-glance feel across both surfaces. #233 chose text circles for terminal-width portability; this reverses that visual decision while keeping #233's structural fix — the shared `formatStatusIcon` module and the startup-retry helper both stay intact.

## Terminal width

Both surfaces compute column widths via `Bun.stringWidth`, which treats these emoji as 2 cells. Column alignment is preserved. Verified visually in welcome (`✅ litellm — connected (142ms)` / `⚠️ f5-amer-ent — unreachable`) and in `formatAuthIndicator` (`✅ Connected (55ms)`, `❌ Auth Error`, `⚠️ Offline`, `❓ Unknown`).

## Testing

- `bun run check` — biome + tsgo both exit 0
- Touched-area tests (52 tests across 4 files): all pass
- Full `bun test`: 4689 pass / 855 skip / 10 fail. The 10 failures reproduce on the clean v18.7.0 baseline — pre-existing flakes in `test/auto-config.test.ts`, `packages/tui/test/overlay-scroll.test.ts`, and `packages/tui/test/render-regressions.test.ts`. None touch modified code.
- Visual smoke test confirmed emoji render and column alignment holds in both surfaces.

Closes #237

---

- [x] `bun run check` passes
- [x] `bun test` — no new failures vs baseline
- [ ] CHANGELOG updated (release automation will handle)
- [x] Issue linked via `Closes #N`