### PR TITLE
fix(coding-agent): strengthen llms.txt routing discipline

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -201,6 +201,26 @@ tier you need: a custom set (`/_llms-txt/{topic}.txt`), a single page (`/{slug}.
 or `llms-small.txt` / `llms-full.txt` when breadth is required. Content is live —
 never assume a cached snapshot is current.
 
+## Routing discipline
+
+You **MUST NOT** web-search for F5 XC product information before exhausting the
+llms.txt hierarchy. The hierarchy is the authoritative source; external results are
+supplementary, not primary.
+
+Follow the cascade sequentially — do not fetch multiple tiers in parallel:
+
+1. **Tier 1** — Read `docs/llms.txt`. Identify which product answers the question.
+2. **Tier 2** — Read that product's `llms.txt`. Read the `## Sections` list.
+3. **Tier 4** — Pick the most specific page from Sections. To fetch its content,
+   take the Sections URL, strip the trailing `/`, append `.md`.
+   Example: `https://…/ddos/bigip-configuration/` → fetch `https://…/ddos/bigip-configuration.md`
+4. **Tier 3** — Only if no single page covers the question, fetch a custom set
+   (`/_llms-txt/{topic}.txt`) for a topic-scoped bundle.
+5. **Tier 5/6** — Only if the question requires breadth across the entire product,
+   fetch `llms-small.txt` or `llms-full.txt`.
+
+Stop at the lowest tier that answers the question. Most questions resolve at Tier 4.
+
 # Skills
 
 Specialized knowledge packs loaded for this session. Relative paths in skill files resolve against the skill directory.

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -192,6 +192,10 @@ describe("system Handlebars prompt templates", () => {
 		expect(template).toContain("https://f5xc-salesdemos.github.io/docs/llms.txt");
 		expect(template).toContain("F5 Distributed Cloud product questions");
 		expect(template).toContain("live knowledge index");
+		expect(template).toContain("## Routing discipline");
+		expect(template).toContain("MUST NOT** web-search for F5 XC product information");
+		expect(template).toContain("strip the trailing `/`, append `.md`");
+		expect(template).toContain("Stop at the lowest tier that answers the question");
 	});
 
 	test("system-prompt carries epistemic-integrity clause against sycophantic reversal", async () => {


### PR DESCRIPTION
Refs #223

## Problem

UAT testing on 2026-04-22 showed the agent:
1. Correctly fetched T1 → T2 in the llms.txt cascade
2. **Also fired web search** before exhausting the hierarchy
3. **Fetched llms-full.txt (T6)** instead of the per-page `.md` endpoint listed in T2 Sections

The answer was correct but token cost was ~3x higher than necessary.

## Root cause

The system prompt's Product knowledge section said to 'start at' the llms.txt index but didn't:
- Prohibit web search for product questions
- Explain the per-page URL convention (`/slug/` → `/slug.md`)
- Specify sequential cascade order

## Fix

Add `## Routing discipline` block:
- `MUST NOT` web-search before exhausting the hierarchy
- Sequential cascade: T1 → T2 → T4 → T3 → T5/T6
- Explicit URL derivation: strip trailing `/`, append `.md`
- 'Stop at the lowest tier that answers the question'

## Test changes

4 new `toContain` assertions in `system-prompt-templates.test.ts`:
- `## Routing discipline` heading present
- Web search prohibition present
- URL convention documented
- Lowest-tier stop condition present