### PR TITLE
fix(coding-agent): add routing edge cases — 404 fallback, multi-product, web search re-entry

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -214,12 +214,24 @@ Follow the cascade sequentially — do not fetch multiple tiers in parallel:
 3. **Tier 4** — Pick the most specific page from Sections. To fetch its content,
    take the Sections URL, strip the trailing `/`, append `.md`.
    Example: `https://…/ddos/bigip-configuration/` → fetch `https://…/ddos/bigip-configuration.md`
+   If 404, try appending `/index.md` instead. Nested paths follow the same rule at the leaf.
 4. **Tier 3** — Only if no single page covers the question, fetch a custom set
    (`/_llms-txt/{topic}.txt`) for a topic-scoped bundle.
 5. **Tier 5/6** — Only if the question requires breadth across the entire product,
    fetch `llms-small.txt` or `llms-full.txt`.
 
 Stop at the lowest tier that answers the question. Most questions resolve at Tier 4.
+
+**Multi-product questions:** Read T1, identify all relevant products, then fetch each
+product's T2 sequentially. Once you have the right pages identified, fetch T4 endpoints
+in parallel.
+
+**Fallback:** If a product's `llms.txt` returns 404, try `llms-small.txt` directly.
+If that also 404s, the product has no documentation — acknowledge this to the user.
+
+**Web search re-entry:** The hierarchy is exhausted when the relevant T4 page exists
+and answers the question, OR when T3 and T5 have been checked without resolution.
+Only then is web search permitted — label external results as supplementary.
 
 # Skills
 

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -196,6 +196,9 @@ describe("system Handlebars prompt templates", () => {
 		expect(template).toContain("MUST NOT** web-search for F5 XC product information");
 		expect(template).toContain("strip the trailing `/`, append `.md`");
 		expect(template).toContain("Stop at the lowest tier that answers the question");
+		expect(template).toContain("Multi-product questions");
+		expect(template).toContain("If 404, try appending `/index.md`");
+		expect(template).toContain("Web search re-entry");
 	});
 
 	test("system-prompt carries epistemic-integrity clause against sycophantic reversal", async () => {


### PR DESCRIPTION
Refs #223

## Context

Cascade audit found 3 high-priority gaps in the `## Routing discipline` section:

1. **Multi-product questions** (e.g., "compare WAF and bot defense") — no guidance on how to handle composite queries across products
2. **404 fallback** — no recovery path when `.md` or `llms.txt` endpoints return 404
3. **Web search re-entry** — "exhausted" was undefined; agent had no criteria for when external search becomes appropriate

## Changes

- Add 404 fallback to Tier 4 step: try `/index.md` if `.md` returns 404
- Add `**Multi-product questions:**` block — sequential T2, parallel T4
- Add `**Fallback:**` block — `llms.txt` 404 → try `llms-small.txt`
- Add `**Web search re-entry:**` — precise definition of exhaustion + supplementary labeling
- 3 new test assertions