### PR TITLE
feat(tui): two-key chord keybinding support

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -657,6 +657,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"keybindings.chordTimeout": {
+		type: "number",
+		default: 1000,
+		ui: {
+			tab: "interaction",
+			label: "Chord Timeout",
+			description: "Milliseconds to wait for the second key of a chord binding before abandoning it.",
+			submenu: true,
+		},
+	},
+
 	"startup.quiet": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -357,6 +357,17 @@ export class Settings {
 	}
 
 	/**
+	 * Get the chord-binding timeout (milliseconds) clamped to the supported range.
+	 * Values outside [200, 5000] are clamped so a malformed config cannot break the
+	 * chord dispatcher (e.g. 0 => never abandon, huge value => leaked state).
+	 */
+	getChordTimeoutMs(): number {
+		const raw = this.get("keybindings.chordTimeout");
+		const value = typeof raw === "number" && Number.isFinite(raw) ? raw : 1000;
+		return Math.min(5000, Math.max(200, Math.round(value)));
+	}
+
+	/**
 	 * Set a model role (helper for modelRoles record).
 	 */
 	setModelRole(role: ModelRole | string, modelId: string): void {

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -221,6 +221,15 @@ const OPTION_PROVIDERS: Partial<Record<SettingPath, OptionProvider>> = {
 		{ value: "15", label: "15 items" },
 		{ value: "20", label: "20 items" },
 	],
+	// Chord binding timeout (clamped to [200, 5000] ms at read time)
+	"keybindings.chordTimeout": [
+		{ value: "200", label: "200 ms", description: "Minimum — fastest abandon" },
+		{ value: "500", label: "500 ms", description: "Snappy" },
+		{ value: "1000", label: "1 second", description: "Default" },
+		{ value: "2000", label: "2 seconds", description: "Relaxed" },
+		{ value: "3000", label: "3 seconds" },
+		{ value: "5000", label: "5 seconds", description: "Maximum" },
+	],
 	// Ask timeout
 	"ask.timeout": [
 		{ value: "0", label: "Disabled" },

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -3,6 +3,7 @@ import type { AssistantMessage } from "@f5xc-salesdemos/pi-ai";
 import { type Component, truncateToWidth, visibleWidth } from "@f5xc-salesdemos/pi-tui";
 import { formatCount, getShellPwd } from "@f5xc-salesdemos/pi-utils";
 import { $ } from "bun";
+import { formatKeyHint } from "../../config/keybindings";
 import { settings } from "../../config/settings";
 import type { StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } from "../../config/settings-schema";
 import { theme } from "../../modes/theme/theme";
@@ -62,6 +63,10 @@ export class StatusLineComponent implements Component {
 	#sessionStartTime: number = Date.now();
 	#planModeStatus: { enabled: boolean; paused: boolean } | null = null;
 	#cwd: string = getShellPwd();
+	// Display text for a pending chord leader (e.g. "Ctrl+X-") or null when no
+	// chord is pending. Populated by the InputController's ChordDispatcher
+	// callbacks; rendered as a dim right-aligned segment in the top border.
+	#chordPending: string | null = null;
 
 	// Git status caching (1s TTL)
 	#cachedGitStatus: {
@@ -114,6 +119,33 @@ export class StatusLineComponent implements Component {
 
 	setPlanModeStatus(status: { enabled: boolean; paused: boolean } | undefined): void {
 		this.#planModeStatus = status ?? null;
+	}
+
+	/**
+	 * Called by the InputController's ChordDispatcher when a chord leader is
+	 * pressed. Displays e.g. "Ctrl+X-" in the top border so the user knows a
+	 * partial chord is active and the dispatcher is waiting for the 2nd key.
+	 */
+	setChordPending(leader: string): void {
+		// formatKeyHint's param type is KeyId (a template-literal union) but its
+		// implementation only needs a "+"-separated key string, which is exactly
+		// what the chord dispatcher hands us. Cast so callers can pass a plain
+		// string without having to thread KeyId through the controller API.
+		const next = `${formatKeyHint(leader as Parameters<typeof formatKeyHint>[0])}-`;
+		if (this.#chordPending === next) return;
+		this.#chordPending = next;
+		this.#onStatusChanged?.();
+	}
+
+	/**
+	 * Called when the chord is dispatched, abandoned, or times out. Clears the
+	 * pending indicator. No-op when no chord is pending (avoids spurious
+	 * re-renders).
+	 */
+	clearChordPending(): void {
+		if (this.#chordPending === null) return;
+		this.#chordPending = null;
+		this.#onStatusChanged?.();
 	}
 
 	setHookStatus(key: string, text: string | undefined): void {
@@ -481,6 +513,18 @@ export class StatusLineComponent implements Component {
 			const label = `${formatCount("job", runningBackgroundJobs)} running`;
 			rightParts.push({
 				content: theme.fg("statusLineSubagents", `${icon}${label}`),
+				bg: defaultBg,
+				fg: defaultFg,
+			});
+		}
+
+		// Chord-pending indicator: rightmost segment, dim style. Appended last
+		// so it visually sits at the far right of the top border (after any
+		// background-jobs indicator). Swallowed by truncation-from-right in the
+		// sizing loop below if the terminal is too narrow, which is acceptable.
+		if (this.#chordPending !== null) {
+			rightParts.push({
+				content: theme.fg("dim", this.#chordPending),
 				bg: defaultBg,
 				fg: defaultFg,
 			});

--- a/packages/coding-agent/src/modes/controllers/chord-routing.ts
+++ b/packages/coding-agent/src/modes/controllers/chord-routing.ts
@@ -1,0 +1,37 @@
+import type { ChordResult } from "@f5xc-salesdemos/pi-tui";
+
+/**
+ * Sinks invoked by routeChordResult. Exactly one of these fires per call
+ * (or neither, for pending / abandoned — which are intentionally swallowed
+ * so the user's partial chord never leaks into the editor buffer).
+ */
+export interface ChordRouteSinks {
+	action: (actionId: string) => void;
+	editor: (key: string) => void;
+}
+
+/**
+ * Pure routing: given a ChordResult, dispatch to the right sink.
+ *
+ * - `dispatched` → action sink (keybinding matched a complete chord)
+ * - `passthrough` → editor sink (key is not a chord leader or match)
+ * - `pending` / `abandoned` → swallowed (Emacs convention: an abandoned
+ *   leader does not emit the second key into the buffer)
+ *
+ * Extracted so tests can exercise routing logic without constructing a
+ * full InputController.
+ */
+export function routeChordResult(result: ChordResult, key: string, sinks: ChordRouteSinks): void {
+	switch (result.kind) {
+		case "dispatched":
+			sinks.action(result.action);
+			return;
+		case "passthrough":
+			sinks.editor(key);
+			return;
+		case "pending":
+		case "abandoned":
+			// Swallowed — Emacs convention for abandoned leaders.
+			return;
+	}
+}

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import { type AgentMessage, ThinkingLevel } from "@f5xc-salesdemos/pi-agent-core";
 import { sanitizeText } from "@f5xc-salesdemos/pi-natives";
-import type { AutocompleteProvider, SlashCommand } from "@f5xc-salesdemos/pi-tui";
+import { type AutocompleteProvider, ChordDispatcher, type SlashCommand } from "@f5xc-salesdemos/pi-tui";
 import { $env } from "@f5xc-salesdemos/pi-utils";
 import { settings } from "../../config/settings";
 import { createStreamingAssistantGutter } from "../../modes/components/gutter-block";
@@ -26,9 +26,63 @@ function isExpandable(obj: unknown): obj is Expandable {
 }
 
 export class InputController {
+	#dispatcher: ChordDispatcher | null = null;
+
 	constructor(private ctx: InteractiveModeContext) {}
 
+	/**
+	 * Rebuild the chord dispatcher from the current keybindings + settings.
+	 * Called from setupKeyHandlers so a subsequent keybindings reload / settings
+	 * change can re-init without leaking the previous pending-timer.
+	 *
+	 * The dispatcher callbacks drive the status-line chord-pending indicator.
+	 * Optional-chaining is deliberate: Task 11 adds setChordPending/clearChordPending
+	 * on StatusLineComponent, so this wiring stays safe before Task 11 lands.
+	 */
+	#initChordDispatcher(): void {
+		this.#dispatcher?.dispose();
+		this.#dispatcher = null;
+		// Feature-detect the context: partial mocks in tests may omit these methods.
+		// Production always satisfies both interfaces (see config/keybindings.ts,
+		// config/settings.ts), so the no-op branch here only protects test fakes.
+		const getBindings = this.ctx.keybindings?.getChordBindings?.bind(this.ctx.keybindings);
+		const getTimeout = this.ctx.settings?.getChordTimeoutMs?.bind(this.ctx.settings);
+		if (!getBindings || !getTimeout) return;
+		const bindings = getBindings();
+		const timeoutMs = getTimeout();
+		// Optional-chaining on methods that Task 11 adds to StatusLineComponent.
+		// Typed loosely so Task 10 can ship before Task 11 wires the methods.
+		const statusLine = this.ctx.statusLine as
+			| {
+					setChordPending?: (leader: string) => void;
+					clearChordPending?: () => void;
+			  }
+			| undefined;
+		this.#dispatcher = new ChordDispatcher(bindings, timeoutMs, {
+			onPending: leader => statusLine?.setChordPending?.(leader),
+			onCleared: () => statusLine?.clearChordPending?.(),
+		});
+	}
+
+	/**
+	 * Dispose of the chord dispatcher (clears any pending chord timer).
+	 * Exposed for tests and for the outer controller lifecycle.
+	 */
+	dispose(): void {
+		this.#dispatcher?.dispose();
+		this.#dispatcher = null;
+	}
+
+	/**
+	 * Exposed for tests: returns the current dispatcher instance (or null if
+	 * setupKeyHandlers has not been called yet).
+	 */
+	getChordDispatcher(): ChordDispatcher | null {
+		return this.#dispatcher;
+	}
+
 	setupKeyHandlers(): void {
+		this.#initChordDispatcher();
 		this.ctx.editor.setActionKeys("app.interrupt", this.ctx.keybindings.getKeys("app.interrupt"));
 		this.ctx.editor.shouldBypassAutocompleteOnEscape = () =>
 			Boolean(

--- a/packages/coding-agent/test/input-controller-chord.test.ts
+++ b/packages/coding-agent/test/input-controller-chord.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { routeChordResult } from "../src/modes/controllers/chord-routing";
+
+describe("routeChordResult", () => {
+	it("dispatched → calls action sink", () => {
+		const actions: string[] = [];
+		const editors: string[] = [];
+		routeChordResult({ kind: "dispatched", action: "app.exit" }, "ctrl+c", {
+			action: a => actions.push(a),
+			editor: k => editors.push(k),
+		});
+		expect(actions).toEqual(["app.exit"]);
+		expect(editors).toEqual([]);
+	});
+
+	it("passthrough → calls editor sink", () => {
+		const actions: string[] = [];
+		const editors: string[] = [];
+		routeChordResult({ kind: "passthrough" }, "a", {
+			action: a => actions.push(a),
+			editor: k => editors.push(k),
+		});
+		expect(actions).toEqual([]);
+		expect(editors).toEqual(["a"]);
+	});
+
+	it("pending → swallows (no action, no editor)", () => {
+		const actions: string[] = [];
+		const editors: string[] = [];
+		routeChordResult({ kind: "pending", leader: "ctrl+x" }, "ctrl+x", {
+			action: a => actions.push(a),
+			editor: k => editors.push(k),
+		});
+		expect(actions).toEqual([]);
+		expect(editors).toEqual([]);
+	});
+
+	it("abandoned → swallows (no action, no editor)", () => {
+		const actions: string[] = [];
+		const editors: string[] = [];
+		routeChordResult({ kind: "abandoned" }, "q", {
+			action: a => actions.push(a),
+			editor: k => editors.push(k),
+		});
+		expect(actions).toEqual([]);
+		expect(editors).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/settings-chordtimeout.test.ts
+++ b/packages/coding-agent/test/settings-chordtimeout.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getProjectAgentDir, Snowflake } from "@f5xc-salesdemos/pi-utils";
+import { _resetSettingsForTest, Settings } from "@f5xc-salesdemos/xcsh/config/settings";
+import { YAML } from "bun";
+
+describe("Settings — keybindings.chordTimeout", () => {
+	let testDir: string;
+	let agentDir: string;
+	let projectDir: string;
+
+	beforeEach(() => {
+		_resetSettingsForTest();
+
+		testDir = path.join(os.tmpdir(), "test-settings-chord-tmp", Snowflake.next());
+		agentDir = path.join(testDir, "agent");
+		projectDir = path.join(testDir, "project");
+
+		if (fs.existsSync(testDir)) {
+			fs.rmSync(testDir, { recursive: true });
+		}
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.mkdirSync(getProjectAgentDir(projectDir), { recursive: true });
+	});
+
+	afterEach(() => {
+		if (fs.existsSync(testDir)) {
+			fs.rmSync(testDir, { recursive: true });
+		}
+	});
+
+	it("returns the default of 1000 ms when unset", async () => {
+		const s = await Settings.init({ agentDir, cwd: projectDir });
+		expect(s.get("keybindings.chordTimeout")).toBe(1000);
+		expect(s.getChordTimeoutMs()).toBe(1000);
+	});
+
+	it("honors a user-provided value in range", async () => {
+		await Bun.write(
+			path.join(agentDir, "config.yml"),
+			YAML.stringify({ keybindings: { chordTimeout: 750 } }, null, 2),
+		);
+		const s = await Settings.init({ agentDir, cwd: projectDir });
+		expect(s.get("keybindings.chordTimeout")).toBe(750);
+		expect(s.getChordTimeoutMs()).toBe(750);
+	});
+
+	it("clamps a value below the minimum to 200 on read", async () => {
+		await Bun.write(
+			path.join(agentDir, "config.yml"),
+			YAML.stringify({ keybindings: { chordTimeout: 50 } }, null, 2),
+		);
+		const s = await Settings.init({ agentDir, cwd: projectDir });
+		expect(s.getChordTimeoutMs()).toBe(200);
+	});
+
+	it("clamps a value above the maximum to 5000 on read", async () => {
+		await Bun.write(
+			path.join(agentDir, "config.yml"),
+			YAML.stringify({ keybindings: { chordTimeout: 99_999 } }, null, 2),
+		);
+		const s = await Settings.init({ agentDir, cwd: projectDir });
+		expect(s.getChordTimeoutMs()).toBe(5000);
+	});
+
+	it("falls back to default on a malformed (non-number) value", async () => {
+		await Bun.write(
+			path.join(agentDir, "config.yml"),
+			YAML.stringify({ keybindings: { chordTimeout: "not-a-number" } }, null, 2),
+		);
+		const s = await Settings.init({ agentDir, cwd: projectDir });
+		// Non-number falls back to 1000 default, which is in range.
+		expect(s.getChordTimeoutMs()).toBe(1000);
+	});
+});

--- a/packages/coding-agent/test/status-line-chord-indicator.test.ts
+++ b/packages/coding-agent/test/status-line-chord-indicator.test.ts
@@ -1,0 +1,80 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import * as os from "node:os";
+import { _resetSettingsForTest, Settings } from "../src/config/settings";
+import { StatusLineComponent } from "../src/modes/components/status-line";
+import { initTheme } from "../src/modes/theme/theme";
+import type { AgentSession } from "../src/session/agent-session";
+
+beforeAll(async () => {
+	_resetSettingsForTest();
+	await Settings.init({ inMemory: true, cwd: os.tmpdir() });
+	await initTheme();
+});
+
+// Minimal AgentSession fake — StatusLineComponent only consumes the properties
+// accessed from #buildStatusLine (state, isStreaming, getAsyncJobSnapshot, ...).
+function makeSession(): AgentSession {
+	return {
+		state: { messages: [], model: undefined },
+		isFastModeEnabled: () => false,
+		isStreaming: false,
+		sessionManager: undefined,
+		modelRegistry: { isUsingOAuth: () => false },
+		settings: undefined,
+		getAsyncJobSnapshot: () => ({ running: [], queued: [] }),
+		extensionRunner: undefined,
+	} as unknown as AgentSession;
+}
+
+// Render width wide enough that the right-aligned chord-pending segment is
+// never truncated out by the sizing loop in #buildStatusLine.
+const WIDTH = 200;
+
+describe("StatusLineComponent — chord-pending indicator", () => {
+	it("does not render the indicator when no chord is pending", () => {
+		const component = new StatusLineComponent(makeSession());
+		const { content } = component.getTopBorder(WIDTH);
+		expect(content).not.toContain("Ctrl+X-");
+	});
+
+	it("renders 'Ctrl+X-' when chord leader 'ctrl+x' is pending", () => {
+		const component = new StatusLineComponent(makeSession());
+		component.setChordPending("ctrl+x");
+		const { content } = component.getTopBorder(WIDTH);
+		expect(content).toContain("Ctrl+X-");
+	});
+
+	it("clears the indicator when clearChordPending is called", () => {
+		const component = new StatusLineComponent(makeSession());
+		component.setChordPending("ctrl+x");
+		component.clearChordPending();
+		const { content } = component.getTopBorder(WIDTH);
+		expect(content).not.toContain("Ctrl+X-");
+	});
+
+	it("fires onStatusChanged exactly once per state transition", () => {
+		const component = new StatusLineComponent(makeSession());
+		let changes = 0;
+		component.onStatusChanged(() => {
+			changes += 1;
+		});
+
+		component.setChordPending("ctrl+x");
+		expect(changes).toBe(1);
+
+		// Idempotent: setting the same leader again should not re-fire.
+		component.setChordPending("ctrl+x");
+		expect(changes).toBe(1);
+
+		// Transitioning to a different leader fires again.
+		component.setChordPending("ctrl+c");
+		expect(changes).toBe(2);
+
+		component.clearChordPending();
+		expect(changes).toBe(3);
+
+		// Idempotent: clearing when already clear should not re-fire.
+		component.clearChordPending();
+		expect(changes).toBe(3);
+	});
+});

--- a/packages/tui/src/chord-dispatcher.ts
+++ b/packages/tui/src/chord-dispatcher.ts
@@ -1,0 +1,54 @@
+import type { ChordBinding } from "./chord-parser";
+import type { KeyId } from "./keys";
+
+export type ChordResult =
+	| { kind: "dispatched"; action: string }
+	| { kind: "pending"; leader: KeyId }
+	| { kind: "passthrough" }
+	| { kind: "abandoned" };
+
+export interface ChordDispatcherCallbacks {
+	onPending?: (leader: KeyId) => void;
+	onCleared?: () => void;
+}
+
+interface PendingState {
+	leader: KeyId;
+	timer: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Two-key chord state machine. Stateless across keystrokes except for one
+ * optional "pending leader" slot + its timeout timer. Consumers feed KeyIds
+ * via feedKey() and act on the returned ChordResult.
+ */
+export class ChordDispatcher {
+	readonly #bindings: ChordBinding[];
+	readonly #timeoutMs: number;
+	readonly #callbacks: ChordDispatcherCallbacks;
+	#pending: PendingState | null = null;
+
+	constructor(bindings: ChordBinding[], timeoutMs: number, callbacks: ChordDispatcherCallbacks = {}) {
+		this.#bindings = bindings;
+		this.#timeoutMs = timeoutMs;
+		this.#callbacks = callbacks;
+	}
+
+	feedKey(key: KeyId): ChordResult {
+		// Phase: single-stroke match only (pending/chord logic arrives in Task 5).
+		// #timeoutMs and #callbacks are used in Task 5.
+		for (const b of this.#bindings) {
+			if (b.sequence.length === 1 && b.sequence[0] === key) {
+				return { kind: "dispatched", action: b.action };
+			}
+		}
+		return { kind: "passthrough" };
+	}
+
+	dispose(): void {
+		if (this.#pending) {
+			clearTimeout(this.#pending.timer);
+			this.#pending = null;
+		}
+	}
+}

--- a/packages/tui/src/chord-dispatcher.ts
+++ b/packages/tui/src/chord-dispatcher.ts
@@ -35,14 +35,50 @@ export class ChordDispatcher {
 	}
 
 	feedKey(key: KeyId): ChordResult {
-		// Phase: single-stroke match only (pending/chord logic arrives in Task 5).
-		// #timeoutMs and #callbacks are used in Task 5.
+		// Phase 1: pending chord is active — interpret this key as the 2nd stroke.
+		if (this.#pending) {
+			const match = this.#bindings.find(
+				b => b.sequence.length === 2 && b.sequence[0] === this.#pending!.leader && b.sequence[1] === key,
+			);
+			this.#clearPending();
+			if (match) return { kind: "dispatched", action: match.action };
+			return { kind: "abandoned" };
+		}
+
+		// Phase 2: no pending chord.
+		// Single-stroke match wins first.
 		for (const b of this.#bindings) {
 			if (b.sequence.length === 1 && b.sequence[0] === key) {
 				return { kind: "dispatched", action: b.action };
 			}
 		}
+		// Chord leader?
+		const isLeader = this.#bindings.some(b => b.sequence.length === 2 && b.sequence[0] === key);
+		if (isLeader) {
+			this.#setPending(key);
+			return { kind: "pending", leader: key };
+		}
 		return { kind: "passthrough" };
+	}
+
+	#setPending(leader: KeyId): void {
+		const timer = setTimeout(() => this.#timeoutClear(), this.#timeoutMs);
+		this.#pending = { leader, timer };
+		this.#callbacks.onPending?.(leader);
+	}
+
+	#clearPending(): void {
+		if (!this.#pending) return;
+		clearTimeout(this.#pending.timer);
+		this.#pending = null;
+		this.#callbacks.onCleared?.();
+	}
+
+	#timeoutClear(): void {
+		// Timer fired; timer handle consumed by runtime.
+		if (!this.#pending) return;
+		this.#pending = null;
+		this.#callbacks.onCleared?.();
 	}
 
 	dispose(): void {

--- a/packages/tui/src/chord-parser.ts
+++ b/packages/tui/src/chord-parser.ts
@@ -37,3 +37,30 @@ export function parseBinding(input: string): ParseResult {
 	}
 	return { ok: true, sequence: tokens as KeyId[] };
 }
+
+export interface ChordBinding {
+	action: string;
+	sequence: KeyId[];
+}
+
+export type BindingsInput = Record<string, string | string[]>;
+
+export type ParseBindingsResult = { ok: true; bindings: ChordBinding[] } | { ok: false; error: BindingParseError };
+
+/**
+ * Parse a map of action → binding string(s) into a flat list of ChordBinding.
+ * Array values expand into multiple ChordBindings for the same action.
+ * Stops at the first parse error.
+ */
+export function parseBindings(input: BindingsInput): ParseBindingsResult {
+	const bindings: ChordBinding[] = [];
+	for (const [action, value] of Object.entries(input)) {
+		const list = Array.isArray(value) ? value : [value];
+		for (const str of list) {
+			const parsed = parseBinding(str);
+			if (!parsed.ok) return parsed;
+			bindings.push({ action, sequence: parsed.sequence });
+		}
+	}
+	return { ok: true, bindings };
+}

--- a/packages/tui/src/chord-parser.ts
+++ b/packages/tui/src/chord-parser.ts
@@ -1,0 +1,39 @@
+import type { KeyId } from "./keys";
+
+export interface ParsedBinding {
+	sequence: KeyId[];
+}
+
+export interface BindingParseError {
+	readonly message: string;
+	readonly input: string;
+}
+
+export type ParseResult = { ok: true; sequence: KeyId[] } | { ok: false; error: BindingParseError };
+
+/**
+ * Parse a binding string into a keystroke sequence.
+ *
+ * - Whitespace separates keystrokes in a chord.
+ * - One keystroke = single-stroke binding; two keystrokes = chord.
+ * - v1 rejects 3+ keystrokes.
+ * - Individual keystroke validation (known key names + modifier combos) is
+ *   deferred to KeyId at type check time and at runtime via parseKey on input.
+ */
+export function parseBinding(input: string): ParseResult {
+	const trimmed = input.trim();
+	if (trimmed.length === 0) {
+		return { ok: false, error: { message: "empty binding", input } };
+	}
+	const tokens = trimmed.split(/\s+/);
+	if (tokens.length > 2) {
+		return {
+			ok: false,
+			error: {
+				message: `chord bindings support at most 2 keystrokes (got ${tokens.length})`,
+				input,
+			},
+		};
+	}
+	return { ok: true, sequence: tokens as KeyId[] };
+}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -2,6 +2,23 @@
 
 // Autocomplete support
 export * from "./autocomplete";
+// Chord dispatcher
+export {
+	ChordDispatcher,
+	type ChordDispatcherCallbacks,
+	type ChordResult,
+} from "./chord-dispatcher";
+// Chord parser
+export {
+	type BindingParseError,
+	type BindingsInput,
+	type ChordBinding,
+	type ParseBindingsResult,
+	type ParsedBinding,
+	type ParseResult,
+	parseBinding,
+	parseBindings,
+} from "./chord-parser";
 // Components
 export * from "./components/box";
 export * from "./components/cancellable-loader";

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -47,13 +47,20 @@ export type Keybinding = keyof Keybindings;
 // Re-export KeyId from keys.ts
 export type { KeyId };
 
+/**
+ * Binding string accepted by the config layer. Single-stroke values are
+ * KeyId (strict template-literal union); chord-syntax values (e.g.
+ * "ctrl+x b") are plain strings validated at runtime by parseBinding.
+ */
+export type BindingString = KeyId | string;
+
 export interface KeybindingDefinition {
-	defaultKeys: KeyId | KeyId[];
+	defaultKeys: BindingString | BindingString[];
 	description?: string;
 }
 
 export type KeybindingDefinitions = Record<string, KeybindingDefinition>;
-export type KeybindingsConfig = Record<string, KeyId | KeyId[] | undefined>;
+export type KeybindingsConfig = Record<string, BindingString | BindingString[] | undefined>;
 
 export const TUI_KEYBINDINGS = {
 	"tui.editor.cursorUp": { defaultKeys: "up", description: "Move cursor up" },
@@ -165,9 +172,9 @@ const SHIFTED_SYMBOL_KEYS = new Set<string>([
 	"~",
 ]);
 
-const normalizeKeyId = (key: KeyId): KeyId => key.toLowerCase() as KeyId;
+const normalizeKeyId = (key: BindingString): KeyId => key.toLowerCase() as KeyId;
 
-function normalizeKeys(keys: KeyId | KeyId[] | undefined): KeyId[] {
+function normalizeKeys(keys: BindingString | BindingString[] | undefined): KeyId[] {
 	if (keys === undefined) return [];
 	const keyList = Array.isArray(keys) ? keys : [keys];
 	const seen = new Set<KeyId>();

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -1,3 +1,4 @@
+import { type ChordBinding, parseBinding } from "./chord-parser";
 import { type KeyId, matchesKey, parseKey } from "./keys";
 
 /**
@@ -262,6 +263,59 @@ export class KeybindingsManager {
 			resolved[id] = keys.length === 1 ? keys[0]! : [...keys];
 		}
 		return resolved;
+	}
+
+	/**
+	 * Return all bindings (standalone + chord) with their action names, with
+	 * user overrides already applied (same rules as getResolvedBindings).
+	 */
+	getChordBindings(): ChordBinding[] {
+		const result: ChordBinding[] = [];
+		for (const [action, keys] of this.#keysById) {
+			for (const key of keys) {
+				const parsed = parseBinding(key);
+				if (!parsed.ok) continue;
+				result.push({ action, sequence: parsed.sequence });
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Return conflicts where a key is used BOTH as a chord leader AND as a
+	 * standalone binding for some other action. Consumers (InputController)
+	 * should refuse to initialize the dispatcher if any are reported.
+	 */
+	getChordConflicts(): Array<{
+		key: KeyId;
+		standaloneActions: string[];
+		chordActions: string[];
+	}> {
+		const standaloneByKey = new Map<KeyId, Set<string>>();
+		const leaderByKey = new Map<KeyId, Set<string>>();
+		for (const binding of this.getChordBindings()) {
+			const [first, second] = binding.sequence;
+			if (second === undefined) {
+				const set = standaloneByKey.get(first!) ?? new Set<string>();
+				set.add(binding.action);
+				standaloneByKey.set(first!, set);
+			} else {
+				const set = leaderByKey.get(first!) ?? new Set<string>();
+				set.add(binding.action);
+				leaderByKey.set(first!, set);
+			}
+		}
+		const conflicts: Array<{ key: KeyId; standaloneActions: string[]; chordActions: string[] }> = [];
+		for (const [key, leaders] of leaderByKey) {
+			const standalones = standaloneByKey.get(key);
+			if (!standalones || standalones.size === 0) continue;
+			conflicts.push({
+				key,
+				standaloneActions: [...standalones].sort(),
+				chordActions: [...leaders].sort(),
+			});
+		}
+		return conflicts;
 	}
 }
 

--- a/packages/tui/test/chord-dispatcher.test.ts
+++ b/packages/tui/test/chord-dispatcher.test.ts
@@ -17,3 +17,27 @@ describe("ChordDispatcher — single-stroke dispatch", () => {
 		d.dispose();
 	});
 });
+
+describe("ChordDispatcher — pending + chord dispatch", () => {
+	it("sets pending on leader keystroke and dispatches on matching follow-up", () => {
+		const d = new ChordDispatcher([{ action: "app.sidebar.toggle", sequence: ["ctrl+x", "b"] }], 1000);
+		expect(d.feedKey("ctrl+x")).toEqual({ kind: "pending", leader: "ctrl+x" });
+		expect(d.feedKey("b")).toEqual({
+			kind: "dispatched",
+			action: "app.sidebar.toggle",
+		});
+		d.dispose();
+	});
+
+	it("invokes onPending callback on leader", () => {
+		let pendingLeader: string | null = null;
+		const d = new ChordDispatcher([{ action: "app.sidebar.toggle", sequence: ["ctrl+x", "b"] }], 1000, {
+			onPending: leader => {
+				pendingLeader = leader;
+			},
+		});
+		d.feedKey("ctrl+x");
+		expect(pendingLeader).toBe("ctrl+x");
+		d.dispose();
+	});
+});

--- a/packages/tui/test/chord-dispatcher.test.ts
+++ b/packages/tui/test/chord-dispatcher.test.ts
@@ -41,3 +41,73 @@ describe("ChordDispatcher — pending + chord dispatch", () => {
 		d.dispose();
 	});
 });
+
+describe("ChordDispatcher — abandoned path", () => {
+	it("returns abandoned when 2nd stroke does not match any chord", () => {
+		const d = new ChordDispatcher([{ action: "app.sidebar.toggle", sequence: ["ctrl+x", "b"] }], 1000);
+		d.feedKey("ctrl+x");
+		expect(d.feedKey("q")).toEqual({ kind: "abandoned" });
+		d.dispose();
+	});
+
+	it("fires onCleared when pending is abandoned by non-match", () => {
+		let cleared = 0;
+		const d = new ChordDispatcher([{ action: "app.sidebar.toggle", sequence: ["ctrl+x", "b"] }], 1000, {
+			onCleared: () => {
+				cleared += 1;
+			},
+		});
+		d.feedKey("ctrl+x");
+		d.feedKey("q");
+		expect(cleared).toBe(1);
+		d.dispose();
+	});
+
+	it("fresh keystroke after abandoned is evaluated from unset state", () => {
+		const d = new ChordDispatcher(
+			[
+				{ action: "app.sidebar.toggle", sequence: ["ctrl+x", "b"] },
+				{ action: "app.exit", sequence: ["ctrl+c"] },
+			],
+			1000,
+		);
+		d.feedKey("ctrl+x");
+		expect(d.feedKey("q")).toEqual({ kind: "abandoned" });
+		expect(d.feedKey("ctrl+c")).toEqual({
+			kind: "dispatched",
+			action: "app.exit",
+		});
+		d.dispose();
+	});
+});
+
+describe("ChordDispatcher — timeout", () => {
+	it("clears pending after timeoutMs and fires onCleared", async () => {
+		let cleared = 0;
+		const d = new ChordDispatcher([{ action: "app.sidebar.toggle", sequence: ["ctrl+x", "b"] }], 20, {
+			onCleared: () => {
+				cleared += 1;
+			},
+		});
+		d.feedKey("ctrl+x");
+		await new Promise(r => setTimeout(r, 50));
+		expect(cleared).toBe(1);
+		expect(d.feedKey("ctrl+x")).toEqual({ kind: "pending", leader: "ctrl+x" });
+		d.dispose();
+	});
+});
+
+describe("ChordDispatcher — dispose", () => {
+	it("clears pending, kills the timer, and does NOT invoke onCleared", async () => {
+		let cleared = 0;
+		const d = new ChordDispatcher([{ action: "app.sidebar.toggle", sequence: ["ctrl+x", "b"] }], 20, {
+			onCleared: () => {
+				cleared += 1;
+			},
+		});
+		d.feedKey("ctrl+x");
+		d.dispose();
+		await new Promise(r => setTimeout(r, 50));
+		expect(cleared).toBe(0);
+	});
+});

--- a/packages/tui/test/chord-dispatcher.test.ts
+++ b/packages/tui/test/chord-dispatcher.test.ts
@@ -30,14 +30,14 @@ describe("ChordDispatcher — pending + chord dispatch", () => {
 	});
 
 	it("invokes onPending callback on leader", () => {
-		let pendingLeader: string | null = null;
+		const pendingLeaders: string[] = [];
 		const d = new ChordDispatcher([{ action: "app.sidebar.toggle", sequence: ["ctrl+x", "b"] }], 1000, {
 			onPending: leader => {
-				pendingLeader = leader;
+				pendingLeaders.push(leader);
 			},
 		});
 		d.feedKey("ctrl+x");
-		expect(pendingLeader).toBe("ctrl+x");
+		expect(pendingLeaders).toEqual(["ctrl+x"]);
 		d.dispose();
 	});
 });

--- a/packages/tui/test/chord-dispatcher.test.ts
+++ b/packages/tui/test/chord-dispatcher.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { ChordDispatcher } from "@f5xc-salesdemos/pi-tui/chord-dispatcher";
+
+describe("ChordDispatcher — single-stroke dispatch", () => {
+	it("dispatches a single-stroke binding", () => {
+		const d = new ChordDispatcher([{ action: "app.exit", sequence: ["ctrl+c"] }], 1000);
+		expect(d.feedKey("ctrl+c")).toEqual({
+			kind: "dispatched",
+			action: "app.exit",
+		});
+		d.dispose();
+	});
+
+	it("returns passthrough when no binding matches", () => {
+		const d = new ChordDispatcher([{ action: "app.exit", sequence: ["ctrl+c"] }], 1000);
+		expect(d.feedKey("a")).toEqual({ kind: "passthrough" });
+		d.dispose();
+	});
+});

--- a/packages/tui/test/chord-exports.test.ts
+++ b/packages/tui/test/chord-exports.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "bun:test";
+import { ChordDispatcher, parseBinding } from "@f5xc-salesdemos/pi-tui";
+
+describe("pi-tui root exports", () => {
+	it("re-exports chord parser and dispatcher", () => {
+		expect(typeof parseBinding).toBe("function");
+		expect(typeof ChordDispatcher).toBe("function");
+	});
+});

--- a/packages/tui/test/chord-parser.test.ts
+++ b/packages/tui/test/chord-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { parseBinding } from "@f5xc-salesdemos/pi-tui/chord-parser";
+import { parseBinding, parseBindings } from "@f5xc-salesdemos/pi-tui/chord-parser";
 
 describe("parseBinding — single stroke", () => {
 	it("parses a plain single-stroke binding", () => {
@@ -41,5 +41,44 @@ describe("parseBinding — rejection", () => {
 	it("rejects empty input", () => {
 		expect(parseBinding("").ok).toBe(false);
 		expect(parseBinding("   ").ok).toBe(false);
+	});
+});
+
+describe("parseBindings — map action to parsed sequences", () => {
+	it("parses a map of action → binding string", () => {
+		const result = parseBindings({
+			"app.sidebar.toggle": "ctrl+x b",
+			"app.exit": "ctrl+c",
+		});
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.bindings).toEqual([
+				{ action: "app.sidebar.toggle", sequence: ["ctrl+x", "b"] },
+				{ action: "app.exit", sequence: ["ctrl+c"] },
+			]);
+		}
+	});
+
+	it("supports multiple sequences per action (array of binding strings)", () => {
+		const result = parseBindings({
+			"app.tools.expand": ["ctrl+o", "f4"],
+		});
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.bindings).toEqual([
+				{ action: "app.tools.expand", sequence: ["ctrl+o"] },
+				{ action: "app.tools.expand", sequence: ["f4"] },
+			]);
+		}
+	});
+
+	it("returns the first error encountered", () => {
+		const result = parseBindings({
+			"app.bad": "a b c",
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.input).toBe("a b c");
+		}
 	});
 });

--- a/packages/tui/test/chord-parser.test.ts
+++ b/packages/tui/test/chord-parser.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import { parseBinding } from "@f5xc-salesdemos/pi-tui/chord-parser";
+
+describe("parseBinding — single stroke", () => {
+	it("parses a plain single-stroke binding", () => {
+		const result = parseBinding("ctrl+b");
+		expect(result).toEqual({ ok: true, sequence: ["ctrl+b"] });
+	});
+
+	it("parses a bare key as single-stroke", () => {
+		expect(parseBinding("escape")).toEqual({ ok: true, sequence: ["escape"] });
+	});
+});

--- a/packages/tui/test/chord-parser.test.ts
+++ b/packages/tui/test/chord-parser.test.ts
@@ -11,3 +11,35 @@ describe("parseBinding — single stroke", () => {
 		expect(parseBinding("escape")).toEqual({ ok: true, sequence: ["escape"] });
 	});
 });
+
+describe("parseBinding — chord", () => {
+	it("parses a two-key chord", () => {
+		expect(parseBinding("ctrl+x b")).toEqual({
+			ok: true,
+			sequence: ["ctrl+x", "b"],
+		});
+	});
+
+	it("normalizes whitespace between tokens", () => {
+		expect(parseBinding("  ctrl+x    b  ")).toEqual({
+			ok: true,
+			sequence: ["ctrl+x", "b"],
+		});
+	});
+});
+
+describe("parseBinding — rejection", () => {
+	it("rejects 3+ keystrokes", () => {
+		const result = parseBinding("ctrl+x ctrl+f g");
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.message).toContain("at most 2");
+			expect(result.error.input).toBe("ctrl+x ctrl+f g");
+		}
+	});
+
+	it("rejects empty input", () => {
+		expect(parseBinding("").ok).toBe(false);
+		expect(parseBinding("   ").ok).toBe(false);
+	});
+});

--- a/packages/tui/test/keybindings-chord.test.ts
+++ b/packages/tui/test/keybindings-chord.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import type { KeyId } from "@f5xc-salesdemos/pi-tui/keybindings";
+import { KeybindingsManager } from "@f5xc-salesdemos/pi-tui/keybindings";
+
+const DEFINITIONS = {
+	"test.standalone": {
+		defaultKeys: "ctrl+a" as KeyId,
+		description: "Standalone test binding",
+	},
+	"test.chord": {
+		defaultKeys: "ctrl+x b" as KeyId,
+		description: "Chord test binding",
+	},
+	"test.multiple": {
+		defaultKeys: ["ctrl+p" as KeyId, "f4" as KeyId],
+		description: "Multiple alternative bindings",
+	},
+} as const;
+
+describe("KeybindingsManager.getChordBindings()", () => {
+	it("returns single-stroke bindings as sequence length 1", () => {
+		const m = new KeybindingsManager(DEFINITIONS);
+		const chords = m.getChordBindings();
+		expect(chords).toContainEqual({ action: "test.standalone", sequence: ["ctrl+a"] });
+	});
+
+	it("returns chord bindings as sequence length 2", () => {
+		const m = new KeybindingsManager(DEFINITIONS);
+		const chords = m.getChordBindings();
+		expect(chords).toContainEqual({ action: "test.chord", sequence: ["ctrl+x", "b"] });
+	});
+
+	it("flattens array-valued defaults into multiple ChordBindings", () => {
+		const m = new KeybindingsManager(DEFINITIONS);
+		const chords = m.getChordBindings();
+		const multiples = chords.filter(c => c.action === "test.multiple");
+		expect(multiples).toEqual([
+			{ action: "test.multiple", sequence: ["ctrl+p"] },
+			{ action: "test.multiple", sequence: ["f4"] },
+		]);
+	});
+
+	it("reflects user overrides (user-supplied chord replaces default)", () => {
+		const m = new KeybindingsManager(DEFINITIONS, {
+			"test.standalone": "ctrl+x s" as KeyId,
+		});
+		const chords = m.getChordBindings();
+		expect(chords).toContainEqual({ action: "test.standalone", sequence: ["ctrl+x", "s"] });
+		expect(chords).not.toContainEqual({ action: "test.standalone", sequence: ["ctrl+a"] });
+	});
+});
+
+describe("KeybindingsManager — chord leader conflict detection", () => {
+	it("reports a conflict when a key is both a chord leader and a standalone binding", () => {
+		const m = new KeybindingsManager({
+			"test.chord": { defaultKeys: "ctrl+x b" as KeyId },
+			"test.leader-collides": { defaultKeys: "ctrl+x" as KeyId },
+		});
+		const conflicts = m.getChordConflicts();
+		expect(conflicts).toHaveLength(1);
+		expect(conflicts[0]).toEqual({
+			key: "ctrl+x",
+			standaloneActions: ["test.leader-collides"],
+			chordActions: ["test.chord"],
+		});
+	});
+
+	it("no conflict when the same key is used only as a leader in multiple chords", () => {
+		const m = new KeybindingsManager({
+			"test.chord-a": { defaultKeys: "ctrl+x a" as KeyId },
+			"test.chord-b": { defaultKeys: "ctrl+x b" as KeyId },
+		});
+		expect(m.getChordConflicts()).toEqual([]);
+	});
+});

--- a/packages/tui/test/keybindings-chord.test.ts
+++ b/packages/tui/test/keybindings-chord.test.ts
@@ -1,18 +1,17 @@
 import { describe, expect, it } from "bun:test";
-import type { KeyId } from "@f5xc-salesdemos/pi-tui/keybindings";
 import { KeybindingsManager } from "@f5xc-salesdemos/pi-tui/keybindings";
 
 const DEFINITIONS = {
 	"test.standalone": {
-		defaultKeys: "ctrl+a" as KeyId,
+		defaultKeys: "ctrl+a",
 		description: "Standalone test binding",
 	},
 	"test.chord": {
-		defaultKeys: "ctrl+x b" as KeyId,
+		defaultKeys: "ctrl+x b",
 		description: "Chord test binding",
 	},
 	"test.multiple": {
-		defaultKeys: ["ctrl+p" as KeyId, "f4" as KeyId],
+		defaultKeys: ["ctrl+p", "f4"],
 		description: "Multiple alternative bindings",
 	},
 } as const;
@@ -42,7 +41,7 @@ describe("KeybindingsManager.getChordBindings()", () => {
 
 	it("reflects user overrides (user-supplied chord replaces default)", () => {
 		const m = new KeybindingsManager(DEFINITIONS, {
-			"test.standalone": "ctrl+x s" as KeyId,
+			"test.standalone": "ctrl+x s",
 		});
 		const chords = m.getChordBindings();
 		expect(chords).toContainEqual({ action: "test.standalone", sequence: ["ctrl+x", "s"] });
@@ -53,8 +52,8 @@ describe("KeybindingsManager.getChordBindings()", () => {
 describe("KeybindingsManager — chord leader conflict detection", () => {
 	it("reports a conflict when a key is both a chord leader and a standalone binding", () => {
 		const m = new KeybindingsManager({
-			"test.chord": { defaultKeys: "ctrl+x b" as KeyId },
-			"test.leader-collides": { defaultKeys: "ctrl+x" as KeyId },
+			"test.chord": { defaultKeys: "ctrl+x b" },
+			"test.leader-collides": { defaultKeys: "ctrl+x" },
 		});
 		const conflicts = m.getChordConflicts();
 		expect(conflicts).toHaveLength(1);
@@ -67,8 +66,8 @@ describe("KeybindingsManager — chord leader conflict detection", () => {
 
 	it("no conflict when the same key is used only as a leader in multiple chords", () => {
 		const m = new KeybindingsManager({
-			"test.chord-a": { defaultKeys: "ctrl+x a" as KeyId },
-			"test.chord-b": { defaultKeys: "ctrl+x b" as KeyId },
+			"test.chord-a": { defaultKeys: "ctrl+x a" },
+			"test.chord-b": { defaultKeys: "ctrl+x b" },
 		});
 		expect(m.getChordConflicts()).toEqual([]);
 	});

--- a/packages/tui/test/keybindings-chord.test.ts
+++ b/packages/tui/test/keybindings-chord.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { KeybindingsManager } from "@f5xc-salesdemos/pi-tui/keybindings";
+import { type KeybindingDefinitions, KeybindingsManager } from "@f5xc-salesdemos/pi-tui/keybindings";
 
-const DEFINITIONS = {
+const DEFINITIONS: KeybindingDefinitions = {
 	"test.standalone": {
 		defaultKeys: "ctrl+a",
 		description: "Standalone test binding",
@@ -14,7 +14,7 @@ const DEFINITIONS = {
 		defaultKeys: ["ctrl+p", "f4"],
 		description: "Multiple alternative bindings",
 	},
-} as const;
+};
 
 describe("KeybindingsManager.getChordBindings()", () => {
 	it("returns single-stroke bindings as sequence length 1", () => {


### PR DESCRIPTION
Closes #252

## Summary

Adds two-key chord keybinding support to pi-tui (e.g. `"ctrl+x b"` as a binding string) so subsequent PRs can bind Emacs-style chord shortcuts like `app.sidebar.toggle`. Zero user-visible behavior change in PR 0 — no chord bindings are registered in `coding-agent/KEYBINDINGS` yet; that's PR 2's job.

This is PR 0 of a 4-PR sequence that lands a togglable todo sidebar in the xcsh TUI. See the design spec (local-only, not committed) for the full architecture.

## What this PR adds

**pi-tui (`packages/tui`):**
- `chord-parser.ts` — `parseBinding(s)` / `parseBindings(map)` parse binding strings into `ChordBinding[]`; 2-key chord max in v1.
- `chord-dispatcher.ts` — `ChordDispatcher` state machine: `feedKey(key)` returns `dispatched | pending | passthrough | abandoned`. 1-second default timeout, `onPending`/`onCleared` callbacks for UI consumers, `dispose()` for teardown.
- `KeybindingsManager.getChordBindings()` — action-annotated chord bindings for the dispatcher.
- `KeybindingsManager.getChordConflicts()` — detects a key used as both a chord leader AND a standalone binding for different actions.
- `BindingString = KeyId | string` — widened type so chord-syntax strings pass the config schema.
- New exports from package root for downstream consumers.

**coding-agent (`packages/coding-agent`):**
- `keybindings.chordTimeout` setting (integer ms, default 1000, clamped 200–5000) with UI submenu + `settings.getChordTimeoutMs()` accessor.
- `routeChordResult` pure helper — routes `ChordResult` to action/editor sinks.
- `InputController` constructs a `ChordDispatcher` and exposes `dispose()` + `getChordDispatcher()`. Feature-detects chord methods on ctx for test compatibility.
- `StatusLineComponent.setChordPending(leader)` / `clearChordPending()` — renders a dim `Ctrl+X-` indicator in the status bar when a chord leader is pending.

## What this PR does NOT add

- **No actual chord binding** in coding-agent's `KEYBINDINGS` registry. `app.sidebar.toggle = "ctrl+x b"` arrives in PR 2.
- **No full wiring** of the dispatcher into pi-tui's editor key event loop. That integration lands in PR 2 when the first chord binding exists. For now the dispatcher is constructed but no keys flow through it — acceptable since no chord is bound.

## Tests

38 new tests (25 pi-tui + 13 coding-agent), all passing. Types clean in both packages. See:
- `packages/tui/test/chord-parser.test.ts` (9)
- `packages/tui/test/chord-dispatcher.test.ts` (9 — includes abandoned/timeout/dispose contract tests)
- `packages/tui/test/keybindings-chord.test.ts` (6)
- `packages/tui/test/chord-exports.test.ts` (1)
- `packages/coding-agent/test/settings-chordtimeout.test.ts` (5)
- `packages/coding-agent/test/input-controller-chord.test.ts` (4)
- `packages/coding-agent/test/status-line-chord-indicator.test.ts` (4)

## Test plan

- [ ] CI passes (biome, typecheck, tests)
- [ ] Full pi-tui suite green except the 8 pre-existing render-regression failures that exist on main
- [ ] Full coding-agent suite green except the 2 pre-existing failures (`tryAutoConfigLiteLLM permission test`, `validateModelsConfig unreadable file`)
- [ ] No new warnings from Biome

## Risk / rollback

Purely additive to pi-tui — `HorizontalSplit` and `TypedEventEmitter` arrive in PR 1, so PR 0 can be reverted cleanly if needed. No existing keybinding behavior changes.