### PR TITLE
fix(tui): render blank line before tool-call groups (fixes #253)

### DIFF
--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -1,6 +1,6 @@
 import { INTENT_FIELD } from "@f5xc-salesdemos/pi-agent-core";
 import type { AssistantMessage, ImageContent } from "@f5xc-salesdemos/pi-ai";
-import { Loader, TERMINAL, Text } from "@f5xc-salesdemos/pi-tui";
+import { Loader, Spacer, TERMINAL } from "@f5xc-salesdemos/pi-tui";
 import { settings } from "../../config/settings";
 import { AssistantMessageComponent } from "../../modes/components/assistant-message";
 import {
@@ -50,7 +50,7 @@ export class EventController {
 
 	#getReadGroup(toolCallId?: string): ReadToolGroupComponent {
 		if (!this.#lastReadGroup) {
-			this.ctx.chatContainer.addChild(new Text("", 0, 0));
+			this.ctx.chatContainer.addChild(new Spacer(1));
 			const group = new ReadToolGroupComponent();
 			group.setExpanded(this.ctx.toolOutputExpanded);
 			const gutter = createToolGutter(this.ctx.ui, group);
@@ -241,7 +241,7 @@ export class EventController {
 								: content.arguments;
 						if (!this.ctx.pendingTools.has(content.id)) {
 							this.#resetReadGroup();
-							this.ctx.chatContainer.addChild(new Text("", 0, 0));
+							this.ctx.chatContainer.addChild(new Spacer(1));
 							const tool = this.ctx.session.getToolByName(content.name);
 							const component = new ToolExecutionComponent(
 								content.name,

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -298,6 +298,7 @@ export class UiHelpers {
 								readGroup = new ReadToolGroupComponent();
 								readGroup.setExpanded(this.ctx.toolOutputExpanded);
 								readGroupGutter = createToolGutter(this.ctx.ui, readGroup);
+								this.ctx.chatContainer.addChild(new Spacer(1));
 								this.ctx.chatContainer.addChild(readGroupGutter);
 							}
 							if (readGroupGutter) {
@@ -352,6 +353,7 @@ export class UiHelpers {
 					);
 					component.setExpanded(this.ctx.toolOutputExpanded);
 					const toolGutter = createToolGutter(this.ctx.ui, component);
+					this.ctx.chatContainer.addChild(new Spacer(1));
 					this.ctx.chatContainer.addChild(toolGutter);
 
 					if (hasErrorStop && errorMessage) {
@@ -398,6 +400,7 @@ export class UiHelpers {
 							readGroup = new ReadToolGroupComponent();
 							readGroup.setExpanded(this.ctx.toolOutputExpanded);
 							readGroupGutter = createToolGutter(this.ctx.ui, readGroup);
+							this.ctx.chatContainer.addChild(new Spacer(1));
 							this.ctx.chatContainer.addChild(readGroupGutter);
 						}
 						const args = readToolCallArgs.get(message.toolCallId);

--- a/packages/coding-agent/test/modes/utils/ui-helpers-rebuild-spacing.test.ts
+++ b/packages/coding-agent/test/modes/utils/ui-helpers-rebuild-spacing.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from "bun:test";
+import type { AgentMessage } from "@f5xc-salesdemos/pi-agent-core";
+import { Container, Spacer } from "@f5xc-salesdemos/pi-tui";
+import { _resetSettingsForTest, Settings } from "@f5xc-salesdemos/xcsh/config/settings";
+import { initTheme } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
+import type { InteractiveModeContext } from "@f5xc-salesdemos/xcsh/modes/types";
+import { UiHelpers } from "@f5xc-salesdemos/xcsh/modes/utils/ui-helpers";
+import type { SessionContext } from "@f5xc-salesdemos/xcsh/session/session-manager";
+
+function baseCtx(): InteractiveModeContext {
+	return {
+		chatContainer: new Container(),
+		pendingTools: new Map(),
+		ui: { requestRender: vi.fn() },
+		sessionManager: { getCwd: () => "/tmp" },
+		session: { getToolByName: () => undefined },
+		statusLine: { invalidate: vi.fn() },
+		updateEditorBorderColor: vi.fn(),
+		addMessageToChat: vi.fn(),
+		toolOutputExpanded: false,
+		getUserMessageText: () => "",
+		optimisticUserMessageSignature: undefined,
+	} as unknown as InteractiveModeContext;
+}
+
+function emptySessionContext(messages: AgentMessage[]): SessionContext {
+	return {
+		messages,
+		models: {},
+		injectedTtsrRules: [],
+		selectedMCPToolNames: [],
+		hasPersistedMCPToolSelection: false,
+		mode: "none",
+	} as SessionContext;
+}
+
+describe("UiHelpers.renderSessionContext spacing", () => {
+	beforeAll(async () => {
+		initTheme();
+		await Settings.init({ inMemory: true, cwd: "/tmp" });
+	});
+
+	afterAll(() => {
+		_resetSettingsForTest();
+	});
+
+	test("inserts Spacer(1) before a non-Read tool gutter", () => {
+		const ctx = baseCtx();
+		const helpers = new UiHelpers(ctx);
+
+		const messages: AgentMessage[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "toolCall",
+						id: "call-bash-1",
+						name: "bash",
+						arguments: { command: "echo hi" },
+					},
+				],
+				usage: undefined,
+				stopReason: null,
+			} as unknown as AgentMessage,
+		];
+
+		helpers.renderSessionContext(emptySessionContext(messages));
+
+		const children = ctx.chatContainer.children;
+		expect(children.length).toBe(2);
+		expect(children[0]).toBeInstanceOf(Spacer);
+		expect(children[1]).not.toBeInstanceOf(Spacer);
+	});
+
+	test("inserts Spacer(1) before a fresh Read-group gutter and NOT between consecutive Reads", () => {
+		const ctx = baseCtx();
+		const helpers = new UiHelpers(ctx);
+
+		const messages: AgentMessage[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "toolCall",
+						id: "read-1",
+						name: "read",
+						arguments: { path: "/tmp/a.txt" },
+					},
+					{
+						type: "toolCall",
+						id: "read-2",
+						name: "read",
+						arguments: { path: "/tmp/b.txt" },
+					},
+				],
+				usage: undefined,
+				stopReason: undefined,
+			} as unknown as AgentMessage,
+			{
+				role: "toolResult",
+				toolName: "read",
+				toolCallId: "read-1",
+				content: [{ type: "text", text: "file contents" }],
+				isError: false,
+			} as unknown as AgentMessage,
+			{
+				role: "toolResult",
+				toolName: "read",
+				toolCallId: "read-2",
+				content: [{ type: "text", text: "file contents 2" }],
+				isError: false,
+			} as unknown as AgentMessage,
+		];
+
+		helpers.renderSessionContext(emptySessionContext(messages));
+
+		const children = ctx.chatContainer.children;
+		const spacers = children.filter(c => c instanceof Spacer);
+		expect(spacers.length).toBe(1);
+	});
+
+	test("inserts Spacer(1) before a Read-group gutter on an error-stopped assistant message", () => {
+		const ctx = baseCtx();
+		const helpers = new UiHelpers(ctx);
+
+		const messages: AgentMessage[] = [
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "toolCall",
+						id: "read-err",
+						name: "read",
+						arguments: { path: "/tmp/a.txt" },
+					},
+				],
+				usage: undefined,
+				stopReason: "error",
+				errorMessage: "boom",
+			} as unknown as AgentMessage,
+		];
+
+		helpers.renderSessionContext(emptySessionContext(messages));
+
+		const children = ctx.chatContainer.children;
+		const spacers = children.filter(c => c instanceof Spacer);
+		expect(spacers.length).toBeGreaterThanOrEqual(1);
+	});
+});


### PR DESCRIPTION
## Summary

- Replaces silent-no-op `new Text("", 0, 0)` spacers with `new Spacer(1)` at two live-streaming sites in `event-controller.ts`.
- Adds the missing `new Spacer(1)` child at three rebuild-path sites in `ui-helpers.ts` (assistant-path error-stop Read group, non-Read tool, toolResult Read group).
- Drops the now-unused `Text` import from `event-controller.ts`.
- Adds a regression test on `renderSessionContext` covering non-Read tool, grouped-Reads, and error-stopped Read.

Root cause: `Text.render()` in `packages/tui/src/components/text.ts:56-62` early-returns `[]` for empty text. `Spacer(1).render()` correctly returns `[""]`. Four other non-spacer `new Text("", …)` call sites in the codebase construct-then-fill via `setText`, so the fix belongs at the call sites, not in `Text.render()`.

Closes #253.

## Test plan

- [x] `bun run check` passes across all packages
- [x] New regression test passes: 3/3 scenarios in `ui-helpers-rebuild-spacing.test.ts`
- [x] Full `bun run test`: 3637 pass, 2 fail, 400 skip. The 2 failures are pre-existing in `auto-config.test.ts` (baseline noise, unrelated)
- [ ] Manual TUI visual check after merge — confirm blank line separates pi-gutter user message from Read block; consecutive Reads stay condensed