### PR TITLE
feat(tui): pi-tui foundation (HorizontalSplit, TypedEventEmitter, ANSI-width invariants)

### DIFF
--- a/packages/tui/src/events.ts
+++ b/packages/tui/src/events.ts
@@ -1,0 +1,32 @@
+/**
+ * Typed publish-subscribe emitter.
+ *
+ * - Keys of `T` are event names; values are payload shapes.
+ * - `on()` returns an unsubscribe closure — the ONLY unsubscribe path.
+ *   No public `off()` method; this avoids divergence between two
+ *   unsubscribe mechanisms and keeps bookkeeping on the emitter.
+ * - `emit()` with zero subscribers is a documented no-op (it does not
+ *   throw and invokes no callback).
+ */
+export class TypedEventEmitter<T extends Record<string, unknown>> {
+	readonly #handlers = new Map<keyof T, Set<(payload: unknown) => void>>();
+
+	on<K extends keyof T>(event: K, handler: (payload: T[K]) => void): () => void {
+		let set = this.#handlers.get(event);
+		if (!set) {
+			set = new Set();
+			this.#handlers.set(event, set);
+		}
+		const wrapped = (p: unknown) => handler(p as T[K]);
+		set.add(wrapped);
+		return () => {
+			set?.delete(wrapped);
+		};
+	}
+
+	emit<K extends keyof T>(event: K, payload: T[K]): void {
+		const set = this.#handlers.get(event);
+		if (!set) return;
+		for (const handler of set) handler(payload);
+	}
+}

--- a/packages/tui/src/horizontal-split.ts
+++ b/packages/tui/src/horizontal-split.ts
@@ -60,16 +60,27 @@ export class HorizontalSplit implements Component {
 	 * flex children split the remainder proportionally. Collapsed children
 	 * receive 0. Separator columns (widths.separatorCount) are accounted for.
 	 *
-	 * Task 3 handles fixed-only. Flex / collapse / fallback arrive in later tasks.
+	 * Task 5 adds binary collapse: when a flex child's minWidth is unmet, the
+	 * lowest-priority active child is dropped to zero and allocation is retried.
+	 * Task 6 adds the final fallback when nothing can be dropped.
 	 */
 	#allocate(totalWidth: number): number[] {
+		return this.#allocateWithActive(
+			totalWidth,
+			this.#children.map((_, i) => i),
+		);
+	}
+
+	#allocateWithActive(totalWidth: number, activeIndices: number[]): number[] {
 		const n = this.#children.length;
-		const separatorCost = Math.max(0, n - 1);
 		const widths = new Array<number>(n).fill(0);
+		if (activeIndices.length === 0) return widths;
+
+		const separatorCost = Math.max(0, activeIndices.length - 1);
 		let remaining = totalWidth - separatorCost;
 
-		// Fixed pass
-		for (let i = 0; i < n; i++) {
+		// Fixed pass for active children only
+		for (const i of activeIndices) {
 			const child = this.#children[i]!;
 			if (child.width.kind === "fixed") {
 				widths[i] = Math.min(child.width.value, Math.max(0, remaining));
@@ -77,14 +88,11 @@ export class HorizontalSplit implements Component {
 			}
 		}
 
-		// Flex pass: proportional distribution
-		const flexIndices: number[] = [];
+		// Flex pass
+		const flexIndices = activeIndices.filter(i => this.#children[i]!.width.kind === "flex");
 		let totalFlex = 0;
-		for (let i = 0; i < n; i++) {
-			if (this.#children[i]!.width.kind === "flex") {
-				flexIndices.push(i);
-				totalFlex += (this.#children[i]!.width as { value: number }).value;
-			}
+		for (const i of flexIndices) {
+			totalFlex += (this.#children[i]!.width as { value: number }).value;
 		}
 		if (flexIndices.length > 0 && totalFlex > 0) {
 			let distributed = 0;
@@ -94,23 +102,35 @@ export class HorizontalSplit implements Component {
 				widths[i] = Math.floor((remaining * flex) / totalFlex);
 				distributed += widths[i]!;
 			}
-			// Last flex child absorbs the rounding remainder so sum matches exactly.
 			const last = flexIndices[flexIndices.length - 1]!;
 			widths[last] = Math.max(0, remaining - distributed);
+		} else if (flexIndices.length > 0) {
+			// All flex values sum to 0 — distribute evenly or give to first.
+			// Spec doesn't hit this normally; give all remaining to first flex child.
+			widths[flexIndices[0]!] = Math.max(0, remaining);
 		}
 
-		// Validate minWidth on flex children. Binary collapse (Task 5) will handle violations.
+		// minWidth validation — if violations, drop lowest-priority violator and retry.
+		const violators: number[] = [];
 		for (const i of flexIndices) {
 			const spec = this.#children[i]!.width as { kind: "flex"; value: number; minWidth?: number };
 			if (spec.minWidth !== undefined && widths[i]! < spec.minWidth) {
-				throw new Error(
-					`HorizontalSplit: flex child ${i} below minWidth ` +
-						`(got ${widths[i]}, min ${spec.minWidth}). Binary collapse lands in Task 5.`,
-				);
+				violators.push(i);
 			}
 		}
+		if (violators.length === 0) return widths;
 
-		return widths;
+		// Find lowest-priority active child.
+		const activeByPriority = [...activeIndices].sort(
+			(a, b) => this.#children[a]!.priority - this.#children[b]!.priority,
+		);
+		const drop = activeByPriority[0]!;
+		const nextActive = activeIndices.filter(i => i !== drop);
+		if (nextActive.length === 0) {
+			// Nothing left to drop — fall through with current widths; Task 6 adds the fallback.
+			return widths;
+		}
+		return this.#allocateWithActive(totalWidth, nextActive);
 	}
 
 	#compose(widths: number[]): string[] {

--- a/packages/tui/src/horizontal-split.ts
+++ b/packages/tui/src/horizontal-split.ts
@@ -65,10 +65,10 @@ export class HorizontalSplit implements Component {
 	#allocate(totalWidth: number): number[] {
 		const n = this.#children.length;
 		const separatorCost = Math.max(0, n - 1);
-		let remaining = totalWidth - separatorCost;
 		const widths = new Array<number>(n).fill(0);
+		let remaining = totalWidth - separatorCost;
 
-		// Fixed pass (Task 3 scope).
+		// Fixed pass
 		for (let i = 0; i < n; i++) {
 			const child = this.#children[i]!;
 			if (child.width.kind === "fixed") {
@@ -76,7 +76,40 @@ export class HorizontalSplit implements Component {
 				remaining -= widths[i]!;
 			}
 		}
-		// Flex / collapse / fallback land in Tasks 4–6.
+
+		// Flex pass: proportional distribution
+		const flexIndices: number[] = [];
+		let totalFlex = 0;
+		for (let i = 0; i < n; i++) {
+			if (this.#children[i]!.width.kind === "flex") {
+				flexIndices.push(i);
+				totalFlex += (this.#children[i]!.width as { value: number }).value;
+			}
+		}
+		if (flexIndices.length > 0 && totalFlex > 0) {
+			let distributed = 0;
+			for (let k = 0; k < flexIndices.length - 1; k++) {
+				const i = flexIndices[k]!;
+				const flex = (this.#children[i]!.width as { value: number }).value;
+				widths[i] = Math.floor((remaining * flex) / totalFlex);
+				distributed += widths[i]!;
+			}
+			// Last flex child absorbs the rounding remainder so sum matches exactly.
+			const last = flexIndices[flexIndices.length - 1]!;
+			widths[last] = Math.max(0, remaining - distributed);
+		}
+
+		// Validate minWidth on flex children. Binary collapse (Task 5) will handle violations.
+		for (const i of flexIndices) {
+			const spec = this.#children[i]!.width as { kind: "flex"; value: number; minWidth?: number };
+			if (spec.minWidth !== undefined && widths[i]! < spec.minWidth) {
+				throw new Error(
+					`HorizontalSplit: flex child ${i} below minWidth ` +
+						`(got ${widths[i]}, min ${spec.minWidth}). Binary collapse lands in Task 5.`,
+				);
+			}
+		}
+
 		return widths;
 	}
 

--- a/packages/tui/src/horizontal-split.ts
+++ b/packages/tui/src/horizontal-split.ts
@@ -170,6 +170,14 @@ function padOrSliceToWidth(line: string, width: number): string {
 	if (width <= 0) return "";
 	const visible = visibleWidth(line);
 	if (visible === width) return line;
-	if (visible > width) return sliceByColumn(line, 0, width);
+	if (visible > width) {
+		// strict=true: exclude any wide char that would extend past the right edge.
+		// The resulting slice has visibleWidth <= width; pad the remainder with
+		// unstyled spaces so the next child still starts at its own col 0.
+		const sliced = sliceByColumn(line, 0, width, true);
+		const slicedWidth = visibleWidth(sliced);
+		if (slicedWidth < width) return sliced + padding(width - slicedWidth);
+		return sliced;
+	}
 	return line + padding(width - visible);
 }

--- a/packages/tui/src/horizontal-split.ts
+++ b/packages/tui/src/horizontal-split.ts
@@ -1,0 +1,115 @@
+import type { Component } from "./tui";
+import { padding, sliceByColumn, visibleWidth } from "./utils";
+
+const RESET_SGR = "\x1b[0m";
+
+/** Width configuration for a single HorizontalSplit child. */
+export type SplitChildWidth = { kind: "fixed"; value: number } | { kind: "flex"; value: number; minWidth?: number };
+
+/** One child placed in a HorizontalSplit, with width + priority metadata. */
+export interface SplitChild {
+	component: Component;
+	width: SplitChildWidth;
+	/** Lower priority collapses first when the terminal is too narrow to satisfy all flex minimums. */
+	priority: number;
+}
+
+/**
+ * Side-by-side layout primitive.
+ *
+ * Implements `Component` directly (not a Container subclass) because each
+ * child carries width/priority metadata that doesn't fit the plain
+ * `Component[]` model of `Container`. API surface matches spec §6.1:
+ * `render(width)` returns the composed rows.
+ *
+ * Width allocation (spec §6.1):
+ * 1. Subtract separator cost (N-1 columns for N children).
+ * 2. Allocate fixed-width children first.
+ * 3. Distribute remaining columns across flex children proportionally
+ *    by `flex.value`.
+ * 4. If any flex child falls below its `minWidth`: drop the lowest-priority
+ *    child (binary collapse — not fractional shrink) and retry.
+ * 5. If all minimums still unsatisfiable: expand the highest-priority flex
+ *    child to consume everything; no separators rendered.
+ *
+ * Line composition (spec §6.1):
+ * - row count = max(child.render(w).length)
+ * - each row: per-child slice-or-pad to its allocated width, joined by
+ *   the separator character, terminated with `\x1b[0m`.
+ */
+export class HorizontalSplit implements Component {
+	readonly #children: SplitChild[];
+	readonly #separator: string;
+
+	constructor(children: SplitChild[], separator: string = " ") {
+		this.#children = children;
+		this.#separator = separator;
+	}
+
+	invalidate(): void {
+		for (const c of this.#children) c.component.invalidate?.();
+	}
+
+	render(totalWidth: number): string[] {
+		const widths = this.#allocate(Math.max(1, totalWidth));
+		return this.#compose(widths);
+	}
+
+	/**
+	 * Allocate per-child widths. Fixed children get their configured value;
+	 * flex children split the remainder proportionally. Collapsed children
+	 * receive 0. Separator columns (widths.separatorCount) are accounted for.
+	 *
+	 * Task 3 handles fixed-only. Flex / collapse / fallback arrive in later tasks.
+	 */
+	#allocate(totalWidth: number): number[] {
+		const n = this.#children.length;
+		const separatorCost = Math.max(0, n - 1);
+		let remaining = totalWidth - separatorCost;
+		const widths = new Array<number>(n).fill(0);
+
+		// Fixed pass (Task 3 scope).
+		for (let i = 0; i < n; i++) {
+			const child = this.#children[i]!;
+			if (child.width.kind === "fixed") {
+				widths[i] = Math.min(child.width.value, Math.max(0, remaining));
+				remaining -= widths[i]!;
+			}
+		}
+		// Flex / collapse / fallback land in Tasks 4–6.
+		return widths;
+	}
+
+	#compose(widths: number[]): string[] {
+		const visibleIdx = widths.map((w, i) => (w > 0 ? i : -1)).filter(i => i >= 0);
+		if (visibleIdx.length === 0) return [];
+
+		const perChildLines = visibleIdx.map(i => this.#children[i]!.component.render(widths[i]!));
+		const rowCount = perChildLines.reduce((m, l) => Math.max(m, l.length), 0);
+
+		const rows: string[] = [];
+		for (let r = 0; r < rowCount; r++) {
+			const parts: string[] = [];
+			for (let v = 0; v < visibleIdx.length; v++) {
+				const childWidth = widths[visibleIdx[v]!]!;
+				const raw = perChildLines[v]![r] ?? "";
+				parts.push(padOrSliceToWidth(raw, childWidth));
+			}
+			rows.push(parts.join(this.#separator) + RESET_SGR);
+		}
+		return rows;
+	}
+}
+
+/**
+ * Pad `line` to exactly `width` visible columns, slicing if longer.
+ * Uses the existing ANSI-aware helpers from `utils.ts` so SGR state is
+ * preserved (and any open SGR is closed) at the slice boundary.
+ */
+function padOrSliceToWidth(line: string, width: number): string {
+	if (width <= 0) return "";
+	const visible = visibleWidth(line);
+	if (visible === width) return line;
+	if (visible > width) return sliceByColumn(line, 0, width);
+	return line + padding(width - visible);
+}

--- a/packages/tui/src/horizontal-split.ts
+++ b/packages/tui/src/horizontal-split.ts
@@ -127,8 +127,15 @@ export class HorizontalSplit implements Component {
 		const drop = activeByPriority[0]!;
 		const nextActive = activeIndices.filter(i => i !== drop);
 		if (nextActive.length === 0) {
-			// Nothing left to drop — fall through with current widths; Task 6 adds the fallback.
-			return widths;
+			// Terminal fallback: expand the highest-priority child of the ORIGINAL
+			// child set to consume everything. No separators (only one active child).
+			const byPriority = [...this.#children.keys()].sort(
+				(a, b) => this.#children[b]!.priority - this.#children[a]!.priority,
+			);
+			const winner = byPriority[0]!;
+			const fallback = new Array<number>(n).fill(0);
+			fallback[winner] = Math.max(1, totalWidth);
+			return fallback;
 		}
 		return this.#allocateWithActive(totalWidth, nextActive);
 	}

--- a/packages/tui/src/horizontal-split.ts
+++ b/packages/tui/src/horizontal-split.ts
@@ -155,7 +155,10 @@ export class HorizontalSplit implements Component {
 				const raw = perChildLines[v]![r] ?? "";
 				parts.push(padOrSliceToWidth(raw, childWidth));
 			}
-			rows.push(parts.join(this.#separator) + RESET_SGR);
+			// Insert RESET_SGR between cells so unclosed SGR in one cell does
+			// not bleed through the separator into the next cell. Row end still
+			// gets RESET_SGR.
+			rows.push(parts.join(RESET_SGR + this.#separator) + RESET_SGR);
 		}
 		return rows;
 	}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -35,8 +35,16 @@ export * from "./components/text";
 export * from "./components/truncated-text";
 // Editor component interface (for custom editors)
 export type * from "./editor-component";
+// Events
+export { TypedEventEmitter } from "./events";
 // Fuzzy matching
 export * from "./fuzzy";
+// Horizontal split layout primitive
+export {
+	HorizontalSplit,
+	type SplitChild,
+	type SplitChildWidth,
+} from "./horizontal-split";
 // Keybindings
 export * from "./keybindings";
 // Kitty keyboard protocol helpers

--- a/packages/tui/test/ansi-width-invariants.test.ts
+++ b/packages/tui/test/ansi-width-invariants.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "bun:test";
+import { padding, sliceByColumn, truncateToWidth, visibleWidth } from "@f5xc-salesdemos/pi-tui";
+
+// Spec §6.3 names bound to existing utils.ts implementations.
+const visualWidth = visibleWidth;
+const sliceByColumns = (s: string, columns: number) => sliceByColumn(s, 0, columns);
+const padToColumns = (s: string, columns: number) => {
+	const w = visibleWidth(s);
+	if (w >= columns) return s;
+	return s + padding(columns - w);
+};
+
+describe("visualWidth (spec §6.3) — counts visible columns", () => {
+	it("counts ASCII printable characters as 1 column each", () => {
+		expect(visualWidth("hello")).toBe(5);
+	});
+
+	it("counts wide (CJK) characters as 2 columns", () => {
+		// "日本" = 2 CJK graphemes, each 2 cols wide
+		expect(visualWidth("日本")).toBe(4);
+	});
+
+	it("ignores SGR (ANSI color) escape sequences", () => {
+		// red "abc" via SGR 31 / reset via 0
+		const red = "\x1b[31mabc\x1b[0m";
+		expect(visualWidth(red)).toBe(3);
+	});
+
+	it("counts emoji as their terminal-visible width", () => {
+		// Common emoji render as 2 columns. Bun.stringWidth handles this.
+		expect(visualWidth("🙂")).toBe(2);
+	});
+
+	it("counts the empty string as 0", () => {
+		expect(visualWidth("")).toBe(0);
+	});
+});
+
+describe("sliceByColumns (spec §6.3) — ANSI-aware slice", () => {
+	it("slices plain ASCII at a column boundary", () => {
+		expect(sliceByColumns("abcdef", 3)).toBe("abc");
+	});
+
+	it("preserves SGR state inside the slice", () => {
+		// Ask for 3 cols of red "abcdef": output must contain the SGR
+		// opener so the slice renders in red, and must close any open SGR
+		// at the boundary so callers can safely concatenate.
+		const red = "\x1b[31mabcdef\x1b[0m";
+		const out = sliceByColumns(red, 3);
+		expect(out).toContain("\x1b[31m"); // opening SGR retained
+		expect(visualWidth(out)).toBe(3);
+	});
+
+	it("does not include content past the requested column count", () => {
+		// Cumulative visible width of `out` is exactly 3 cells; no 'd' leaks.
+		const out = sliceByColumns("abcdef", 3);
+		// The returned text's visible content is "abc". Appending "Z" and
+		// re-measuring proves no hidden-visible char snuck in.
+		expect(visualWidth(`${out}Z`)).toBe(4);
+	});
+
+	it("returns empty text for a zero-column request", () => {
+		expect(sliceByColumns("abc", 0)).toBe("");
+	});
+});
+
+describe("padToColumns (spec §6.3) — append unstyled spaces", () => {
+	it("appends spaces to reach the requested column count", () => {
+		const out = padToColumns("ab", 5);
+		expect(out).toBe("ab   ");
+		expect(visualWidth(out)).toBe(5);
+	});
+
+	it("returns the input unchanged when already at the requested width", () => {
+		expect(padToColumns("abcde", 5)).toBe("abcde");
+	});
+
+	it("returns the input unchanged when wider than requested (no truncation)", () => {
+		// padToColumns only pads; truncation is a different operation.
+		expect(padToColumns("abcdef", 3)).toBe("abcdef");
+	});
+
+	it("pads correctly after SGR-styled input without extending the style", () => {
+		const input = "\x1b[32mab\x1b[0m";
+		const out = padToColumns(input, 5);
+		// The appended spaces come AFTER the reset — they are unstyled.
+		// visibleWidth is 5 because the styled "ab" is 2 cols + 3 pad spaces.
+		expect(visualWidth(out)).toBe(5);
+		// Sanity: the trailing characters of `out` are exactly three spaces.
+		expect(out.endsWith("   ")).toBe(true);
+	});
+});
+
+describe("truncateToWidth with pad=true (used by HorizontalSplit in Task 7)", () => {
+	it("truncates and pads to exactly the requested width", () => {
+		expect(visualWidth(truncateToWidth("abcdefghij", 5, null, true))).toBe(5);
+	});
+
+	it("pads a short input to the requested width", () => {
+		const out = truncateToWidth("ab", 5, null, true);
+		expect(visualWidth(out)).toBe(5);
+	});
+});

--- a/packages/tui/test/events.test.ts
+++ b/packages/tui/test/events.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import { TypedEventEmitter } from "@f5xc-salesdemos/pi-tui/events";
+
+type Events = {
+	todoPhasesChanged: { count: number };
+	reminderFired: { id: string };
+};
+
+describe("TypedEventEmitter — on / emit", () => {
+	it("fires the handler with the typed payload on emit", () => {
+		const bus = new TypedEventEmitter<Events>();
+		const received: Array<{ count: number }> = [];
+		bus.on("todoPhasesChanged", p => received.push(p));
+		bus.emit("todoPhasesChanged", { count: 3 });
+		expect(received).toEqual([{ count: 3 }]);
+	});
+
+	it("delivers independent event types without crosstalk", () => {
+		const bus = new TypedEventEmitter<Events>();
+		const todos: Array<{ count: number }> = [];
+		const reminders: Array<{ id: string }> = [];
+		bus.on("todoPhasesChanged", p => todos.push(p));
+		bus.on("reminderFired", p => reminders.push(p));
+		bus.emit("todoPhasesChanged", { count: 1 });
+		bus.emit("reminderFired", { id: "r1" });
+		expect(todos).toEqual([{ count: 1 }]);
+		expect(reminders).toEqual([{ id: "r1" }]);
+	});
+});
+
+describe("TypedEventEmitter — unsubscribe", () => {
+	it("returns a closure from on() that removes the handler", () => {
+		const bus = new TypedEventEmitter<Events>();
+		const received: Array<{ count: number }> = [];
+		const unsubscribe = bus.on("todoPhasesChanged", p => received.push(p));
+		bus.emit("todoPhasesChanged", { count: 1 });
+		unsubscribe();
+		bus.emit("todoPhasesChanged", { count: 2 });
+		expect(received).toEqual([{ count: 1 }]);
+	});
+
+	it("unsubscribing one handler does not affect peers on the same event", () => {
+		const bus = new TypedEventEmitter<Events>();
+		const a: Array<{ count: number }> = [];
+		const b: Array<{ count: number }> = [];
+		const unsubA = bus.on("todoPhasesChanged", p => a.push(p));
+		bus.on("todoPhasesChanged", p => b.push(p));
+		bus.emit("todoPhasesChanged", { count: 1 });
+		unsubA();
+		bus.emit("todoPhasesChanged", { count: 2 });
+		expect(a).toEqual([{ count: 1 }]);
+		expect(b).toEqual([{ count: 1 }, { count: 2 }]);
+	});
+
+	it("calling the unsubscribe closure twice is safe (no throw)", () => {
+		const bus = new TypedEventEmitter<Events>();
+		const unsubscribe = bus.on("todoPhasesChanged", () => {});
+		unsubscribe();
+		expect(() => unsubscribe()).not.toThrow();
+	});
+});
+
+describe("TypedEventEmitter — multiple subscribers", () => {
+	it("fires all subscribers in insertion order on emit", () => {
+		const bus = new TypedEventEmitter<Events>();
+		const order: string[] = [];
+		bus.on("todoPhasesChanged", () => order.push("a"));
+		bus.on("todoPhasesChanged", () => order.push("b"));
+		bus.on("todoPhasesChanged", () => order.push("c"));
+		bus.emit("todoPhasesChanged", { count: 0 });
+		expect(order).toEqual(["a", "b", "c"]);
+	});
+});
+
+describe("TypedEventEmitter — zero subscribers (documented no-op)", () => {
+	it("emitting an event with no subscribers is a no-op (no throw)", () => {
+		const bus = new TypedEventEmitter<Events>();
+		expect(() => bus.emit("todoPhasesChanged", { count: 1 })).not.toThrow();
+	});
+
+	it("internal handler map stays absent for events that were never subscribed", () => {
+		const bus = new TypedEventEmitter<Events>();
+		const unsub = bus.on("todoPhasesChanged", () => {});
+		unsub();
+		expect(() => bus.emit("todoPhasesChanged", { count: 2 })).not.toThrow();
+	});
+});

--- a/packages/tui/test/horizontal-split.test.ts
+++ b/packages/tui/test/horizontal-split.test.ts
@@ -201,3 +201,28 @@ describe("HorizontalSplit — line composition", () => {
 		expect(split.render(5)).toEqual([]);
 	});
 });
+
+describe("HorizontalSplit — unconditional SGR reset", () => {
+	it("appends \\x1b[0m to every composed row regardless of child content", () => {
+		const a = new StubComponent(["plain"]);
+		const b = new StubComponent(["plain"]);
+		const split = new HorizontalSplit([fixedChild(a, 5), fixedChild(b, 5)], " ");
+		for (const row of split.render(11)) {
+			expect(row.endsWith("\x1b[0m")).toBe(true);
+		}
+	});
+
+	it("closes unclosed SGR state from a child rather than bleeding into next row", () => {
+		// Child A emits row 0 with unclosed \x1b[31m (red). The reset at row
+		// end must make it impossible for the NEXT row to inherit redness.
+		const a = new StubComponent(["\x1b[31mRED", "plain"]);
+		const b = new StubComponent(["B1", "B2"]);
+		const split = new HorizontalSplit([fixedChild(a, 5), fixedChild(b, 3)], " ");
+		const rows = split.render(9);
+		// Row 0 must end with reset.
+		expect(rows[0]!.endsWith("\x1b[0m")).toBe(true);
+		// Row 1 must not start with any inherited SGR state — it begins with
+		// the literal child A row-1 content ("plain" fits exactly in 5 cols).
+		expect(rows[1]!.startsWith("plain")).toBe(true);
+	});
+});

--- a/packages/tui/test/horizontal-split.test.ts
+++ b/packages/tui/test/horizontal-split.test.ts
@@ -226,3 +226,31 @@ describe("HorizontalSplit — unconditional SGR reset", () => {
 		expect(rows[1]!.startsWith("plain")).toBe(true);
 	});
 });
+
+describe("HorizontalSplit — wide-character boundary rule", () => {
+	it("replaces a wide char straddling the rightmost column with a space", () => {
+		// Child A has width 3 and content "a日" — "a" = 1 col, "日" = 2 cols,
+		// total = 3. It fits exactly. Now shrink to width 2: "日" would start
+		// at col 1 and straddle columns 1-2, leaving "a" at col 0. The slice
+		// must yield "a " (2 cols) — wide char dropped, replaced by space.
+		const a = new StubComponent(["a日"]);
+		const b = new StubComponent(["X"]);
+		const split = new HorizontalSplit([fixedChild(a, 2), fixedChild(b, 1)], "|");
+		const rows = split.render(4);
+		// Row 0: "a |X\x1b[0m" — a's right column is a space replacing the
+		// would-be-straddling wide char.
+		expect(rows[0]).toBe("a |X\x1b[0m");
+	});
+
+	it("adjacent child starts at its own column 0 regardless of wide-char drop", () => {
+		// Child A loses one column to a wide-char drop. Child B still begins
+		// rendering from column 0 of its own allocation.
+		const a = new StubComponent(["日"]); // only a wide char, allocate 1 col
+		const b = new StubComponent(["ZZZ"]);
+		const split = new HorizontalSplit([fixedChild(a, 1), fixedChild(b, 3)], " ");
+		const rows = split.render(5);
+		// A's 1-col allocation cannot fit the 2-col "日" — result is " " (a
+		// single space replacing the wide char). B is unaffected.
+		expect(rows[0]).toBe("  ZZZ\x1b[0m");
+	});
+});

--- a/packages/tui/test/horizontal-split.test.ts
+++ b/packages/tui/test/horizontal-split.test.ts
@@ -170,3 +170,34 @@ describe("HorizontalSplit — unsatisfiable-minimums fallback", () => {
 		expect(rows[0]).not.toContain("|");
 	});
 });
+
+describe("HorizontalSplit — line composition", () => {
+	it("renders each child within its allocated column width", () => {
+		const a = new StubComponent(["AA"]); // 2 cols
+		const b = new StubComponent(["BBBB"]); // 4 cols
+		const split = new HorizontalSplit([fixedChild(a, 4), fixedChild(b, 4)], " ");
+		// total = 9, separator = 1, both children get 4.
+		// child a's "AA" pads to 4 cols → "AA  "; child b's "BBBB" stays.
+		const rows = split.render(9);
+		expect(rows).toEqual(["AA   BBBB\x1b[0m"]);
+	});
+
+	it("matches the taller child's row count by padding shorter child with blank lines", () => {
+		const a = new StubComponent(["A1", "A2", "A3"]);
+		const b = new StubComponent(["B1"]);
+		const split = new HorizontalSplit([fixedChild(a, 2), fixedChild(b, 2)], " ");
+		const rows = split.render(5);
+		expect(rows).toHaveLength(3);
+		expect(rows[0]).toBe("A1 B1\x1b[0m");
+		// Subsequent rows: b is empty → padded to 2 cols of unstyled space.
+		expect(rows[1]).toBe("A2   \x1b[0m");
+		expect(rows[2]).toBe("A3   \x1b[0m");
+	});
+
+	it("returns an empty row array when all children have 0 rendered rows", () => {
+		const a = new StubComponent([]);
+		const b = new StubComponent([]);
+		const split = new HorizontalSplit([fixedChild(a, 2), fixedChild(b, 2)], " ");
+		expect(split.render(5)).toEqual([]);
+	});
+});

--- a/packages/tui/test/horizontal-split.test.ts
+++ b/packages/tui/test/horizontal-split.test.ts
@@ -45,3 +45,54 @@ describe("HorizontalSplit — fixed-width allocation", () => {
 		expect(rows[0]).toBe("AAA BBB\x1b[0m");
 	});
 });
+
+const flexChild = (c: Component, value: number, opts: { minWidth?: number; priority?: number } = {}): SplitChild => ({
+	component: c,
+	width: { kind: "flex", value, minWidth: opts.minWidth },
+	priority: opts.priority ?? 100,
+});
+
+describe("HorizontalSplit — flex allocation", () => {
+	it("splits remaining columns proportionally between flex children", () => {
+		const a = new StubComponent(["A"]);
+		const b = new StubComponent(["B"]);
+		const split = new HorizontalSplit([flexChild(a, 2), flexChild(b, 1)], " ");
+		// total = 31, separator = 1, remaining = 30, flex 2:1 → 20:10
+		split.render(31);
+		expect(a.lastWidth).toBe(20);
+		expect(b.lastWidth).toBe(10);
+	});
+
+	it("mixes fixed and flex: fixed first, remainder to flex", () => {
+		const left = new StubComponent(["L"]);
+		const right = new StubComponent(["R"]);
+		const split = new HorizontalSplit([fixedChild(left, 10), flexChild(right, 1)], " ");
+		// total = 50, separator = 1, fixed = 10, flex gets remaining 39
+		split.render(50);
+		expect(left.lastWidth).toBe(10);
+		expect(right.lastWidth).toBe(39);
+	});
+
+	it("splits remainder across three flex children proportionally", () => {
+		const a = new StubComponent([]);
+		const b = new StubComponent([]);
+		const c = new StubComponent([]);
+		// flex 1:1:2, total width 22, separators = 2, remaining = 20 → 5:5:10
+		const split = new HorizontalSplit([flexChild(a, 1), flexChild(b, 1), flexChild(c, 2)], " ");
+		split.render(22);
+		expect(a.lastWidth).toBe(5);
+		expect(b.lastWidth).toBe(5);
+		expect(c.lastWidth).toBe(10);
+	});
+
+	it("distributes leftover columns from rounding to the largest-share child", () => {
+		const a = new StubComponent([]);
+		const b = new StubComponent([]);
+		// flex 1:1, remaining = 5 → ideal 2.5:2.5, integer 2:3 (remainder to
+		// the last or the largest — either is acceptable, but the sum must
+		// equal the remaining columns).
+		const split = new HorizontalSplit([flexChild(a, 1), flexChild(b, 1)], " ");
+		split.render(6); // separator = 1, remaining = 5
+		expect((a.lastWidth ?? 0) + (b.lastWidth ?? 0)).toBe(5);
+	});
+});

--- a/packages/tui/test/horizontal-split.test.ts
+++ b/packages/tui/test/horizontal-split.test.ts
@@ -254,3 +254,52 @@ describe("HorizontalSplit — wide-character boundary rule", () => {
 		expect(rows[0]).toBe("  ZZZ\x1b[0m");
 	});
 });
+
+describe("HorizontalSplit — collapsed-state output", () => {
+	it("contains no separator character when a child is collapsed", () => {
+		const main = new StubComponent(["MAIN"]);
+		const side = new StubComponent(["SIDE"]);
+		const split = new HorizontalSplit(
+			[
+				flexChild(main, 1, { minWidth: 5, priority: 10 }),
+				flexChild(side, 1, { minWidth: 50, priority: 1 }), // will be collapsed
+			],
+			"|",
+		);
+		const rows = split.render(25);
+		for (const row of rows) expect(row).not.toContain("|");
+	});
+
+	it("contains no right-column content when side is collapsed", () => {
+		const main = new StubComponent(["MAIN"]);
+		const side = new StubComponent(["SECRET"]);
+		const split = new HorizontalSplit(
+			[flexChild(main, 1, { minWidth: 5, priority: 10 }), flexChild(side, 1, { minWidth: 50, priority: 1 })],
+			" ",
+		);
+		const rows = split.render(25);
+		for (const row of rows) expect(row).not.toContain("SECRET");
+	});
+
+	it("contains no trailing ANSI SGR state leaking past the row reset", () => {
+		// The main column uses its own SGR. The composer must still end
+		// each row with \x1b[0m and nothing after it.
+		const main = new StubComponent(["\x1b[31mBOLD-RED"]);
+		const side = new StubComponent(["x"]);
+		const split = new HorizontalSplit(
+			[
+				flexChild(main, 1, { minWidth: 5, priority: 10 }),
+				flexChild(side, 1, { minWidth: 50, priority: 1 }), // collapsed
+			],
+			" ",
+		);
+		const rows = split.render(20);
+		// Each row ends exactly at the reset; nothing follows.
+		for (const row of rows) {
+			expect(row.endsWith("\x1b[0m")).toBe(true);
+			// No duplicate resets or dangling CSI sequences after the row reset.
+			const afterReset = row.slice(row.lastIndexOf("\x1b[0m") + "\x1b[0m".length);
+			expect(afterReset).toBe("");
+		}
+	});
+});

--- a/packages/tui/test/horizontal-split.test.ts
+++ b/packages/tui/test/horizontal-split.test.ts
@@ -96,3 +96,58 @@ describe("HorizontalSplit — flex allocation", () => {
 		expect((a.lastWidth ?? 0) + (b.lastWidth ?? 0)).toBe(5);
 	});
 });
+
+describe("HorizontalSplit — binary collapse", () => {
+	it("drops the lowest-priority flex child when its minWidth is unmet", () => {
+		const main = new StubComponent(["MAIN"]);
+		const side = new StubComponent(["SIDE"]);
+		const split = new HorizontalSplit(
+			[
+				flexChild(main, 1, { minWidth: 10, priority: 10 }),
+				flexChild(side, 0, { minWidth: 20, priority: 1 }), // lower priority
+			],
+			" ",
+		);
+		// width = 25, separator = 1, remaining = 24. Proportional on flex 1:0
+		// gives main=24 and side=0, side has minWidth 20 → unmet → drop side.
+		// After drop: no separator, main fills 25.
+		split.render(25);
+		expect(main.lastWidth).toBe(25);
+		expect(side.lastWidth).toBeNull(); // not rendered
+	});
+
+	it("suppresses the separator when a child is collapsed", () => {
+		const main = new StubComponent(["MAIN"]);
+		const side = new StubComponent(["SIDE"]);
+		const split = new HorizontalSplit(
+			[flexChild(main, 1, { minWidth: 10, priority: 10 }), flexChild(side, 0, { minWidth: 20, priority: 1 })],
+			"|",
+		);
+		const rows = split.render(25);
+		// With side dropped, output must contain no separator '|'
+		expect(rows[0]).not.toContain("|");
+	});
+
+	it("drops in ascending priority order when multiple minimums are unmet", () => {
+		const a = new StubComponent([]);
+		const b = new StubComponent([]);
+		const c = new StubComponent([]);
+		// Each child wants 20 cols. Budget = 30 (minus 2 separators = 28).
+		// After proportional 1:1:1 allocation each gets ~9. All three violate.
+		// Drop c first (priority 1), retry with 29 cols between two children:
+		// 14:15, a still violates min 20. Drop b (priority 2), retry: a alone
+		// gets 30 (full width since no separators remain) — satisfies min.
+		const split = new HorizontalSplit(
+			[
+				flexChild(a, 1, { minWidth: 20, priority: 100 }),
+				flexChild(b, 1, { minWidth: 20, priority: 2 }),
+				flexChild(c, 1, { minWidth: 20, priority: 1 }),
+			],
+			" ",
+		);
+		split.render(30);
+		expect(a.lastWidth).toBe(30);
+		expect(b.lastWidth).toBeNull();
+		expect(c.lastWidth).toBeNull();
+	});
+});

--- a/packages/tui/test/horizontal-split.test.ts
+++ b/packages/tui/test/horizontal-split.test.ts
@@ -151,3 +151,22 @@ describe("HorizontalSplit — binary collapse", () => {
 		expect(c.lastWidth).toBeNull();
 	});
 });
+
+describe("HorizontalSplit — unsatisfiable-minimums fallback", () => {
+	it("expands the highest-priority flex child to full width when no minimum can be met", () => {
+		const a = new StubComponent(["A"]);
+		const b = new StubComponent(["B"]);
+		const split = new HorizontalSplit(
+			[flexChild(a, 1, { minWidth: 50, priority: 100 }), flexChild(b, 1, { minWidth: 50, priority: 1 })],
+			"|",
+		);
+		// total = 20, even after dropping b, a's minWidth 50 is still unmet.
+		// Fallback: expand highest-priority child (a) to consume everything,
+		// no separators rendered.
+		split.render(20);
+		expect(a.lastWidth).toBe(20);
+		expect(b.lastWidth).toBeNull();
+		const rows = split.render(20);
+		expect(rows[0]).not.toContain("|");
+	});
+});

--- a/packages/tui/test/horizontal-split.test.ts
+++ b/packages/tui/test/horizontal-split.test.ts
@@ -34,7 +34,7 @@ describe("HorizontalSplit — fixed-width allocation", () => {
 		const b = new StubComponent(["BBBBB"]);
 		const split = new HorizontalSplit([fixedChild(a, 3), fixedChild(b, 5)], "|");
 		const rows = split.render(9);
-		expect(rows).toEqual(["AAA|BBBBB\x1b[0m"]);
+		expect(rows).toEqual(["AAA\x1b[0m|BBBBB\x1b[0m"]);
 	});
 
 	it("defaults the separator to a single space when omitted", () => {
@@ -42,7 +42,7 @@ describe("HorizontalSplit — fixed-width allocation", () => {
 		const b = new StubComponent(["BBB"]);
 		const split = new HorizontalSplit([fixedChild(a, 3), fixedChild(b, 3)]);
 		const rows = split.render(7);
-		expect(rows[0]).toBe("AAA BBB\x1b[0m");
+		expect(rows[0]).toBe("AAA\x1b[0m BBB\x1b[0m");
 	});
 });
 
@@ -179,7 +179,7 @@ describe("HorizontalSplit — line composition", () => {
 		// total = 9, separator = 1, both children get 4.
 		// child a's "AA" pads to 4 cols → "AA  "; child b's "BBBB" stays.
 		const rows = split.render(9);
-		expect(rows).toEqual(["AA   BBBB\x1b[0m"]);
+		expect(rows).toEqual(["AA  \x1b[0m BBBB\x1b[0m"]);
 	});
 
 	it("matches the taller child's row count by padding shorter child with blank lines", () => {
@@ -188,10 +188,10 @@ describe("HorizontalSplit — line composition", () => {
 		const split = new HorizontalSplit([fixedChild(a, 2), fixedChild(b, 2)], " ");
 		const rows = split.render(5);
 		expect(rows).toHaveLength(3);
-		expect(rows[0]).toBe("A1 B1\x1b[0m");
+		expect(rows[0]).toBe("A1\x1b[0m B1\x1b[0m");
 		// Subsequent rows: b is empty → padded to 2 cols of unstyled space.
-		expect(rows[1]).toBe("A2   \x1b[0m");
-		expect(rows[2]).toBe("A3   \x1b[0m");
+		expect(rows[1]).toBe("A2\x1b[0m   \x1b[0m");
+		expect(rows[2]).toBe("A3\x1b[0m   \x1b[0m");
 	});
 
 	it("returns an empty row array when all children have 0 rendered rows", () => {
@@ -239,7 +239,7 @@ describe("HorizontalSplit — wide-character boundary rule", () => {
 		const rows = split.render(4);
 		// Row 0: "a |X\x1b[0m" — a's right column is a space replacing the
 		// would-be-straddling wide char.
-		expect(rows[0]).toBe("a |X\x1b[0m");
+		expect(rows[0]).toBe("a \x1b[0m|X\x1b[0m");
 	});
 
 	it("adjacent child starts at its own column 0 regardless of wide-char drop", () => {
@@ -251,7 +251,7 @@ describe("HorizontalSplit — wide-character boundary rule", () => {
 		const rows = split.render(5);
 		// A's 1-col allocation cannot fit the 2-col "日" — result is " " (a
 		// single space replacing the wide char). B is unaffected.
-		expect(rows[0]).toBe("  ZZZ\x1b[0m");
+		expect(rows[0]).toBe(" \x1b[0m ZZZ\x1b[0m");
 	});
 });
 
@@ -301,5 +301,20 @@ describe("HorizontalSplit — collapsed-state output", () => {
 			const afterReset = row.slice(row.lastIndexOf("\x1b[0m") + "\x1b[0m".length);
 			expect(afterReset).toBe("");
 		}
+	});
+});
+
+describe("HorizontalSplit — ANSI-safe slicing between adjacent children", () => {
+	it("does not leak child A's SGR state into child B's column", () => {
+		// Child A: red "AAA" (no reset at end). Child B: green "BBB".
+		const a = new StubComponent(["\x1b[31mAAA"]);
+		const b = new StubComponent(["\x1b[32mBBB"]);
+		const split = new HorizontalSplit([fixedChild(a, 3), fixedChild(b, 3)], " ");
+		const rows = split.render(7);
+		expect(rows[0]).toContain("\x1b[32mBBB");
+		const aStart = rows[0]!.indexOf("\x1b[31mAAA");
+		const bStart = rows[0]!.indexOf("\x1b[32mBBB");
+		const between = rows[0]!.slice(aStart, bStart);
+		expect(between).toContain("\x1b[0m");
 	});
 });

--- a/packages/tui/test/horizontal-split.test.ts
+++ b/packages/tui/test/horizontal-split.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import type { Component } from "@f5xc-salesdemos/pi-tui";
+import { HorizontalSplit, type SplitChild } from "@f5xc-salesdemos/pi-tui/horizontal-split";
+
+/** Component stub that records the width it was asked to render at and emits a fixed string. */
+class StubComponent implements Component {
+	lastWidth: number | null = null;
+	constructor(public readonly lines: string[]) {}
+	render(width: number): string[] {
+		this.lastWidth = width;
+		return this.lines;
+	}
+	invalidate(): void {}
+}
+
+const fixedChild = (c: Component, value: number, priority = 100): SplitChild => ({
+	component: c,
+	width: { kind: "fixed", value },
+	priority,
+});
+
+describe("HorizontalSplit — fixed-width allocation", () => {
+	it("passes each fixed child its configured width on render", () => {
+		const a = new StubComponent(["AAA"]);
+		const b = new StubComponent(["BBBBB"]);
+		const split = new HorizontalSplit([fixedChild(a, 3), fixedChild(b, 5)], " ");
+		split.render(9);
+		expect(a.lastWidth).toBe(3);
+		expect(b.lastWidth).toBe(5);
+	});
+
+	it("joins children with the configured single-character separator", () => {
+		const a = new StubComponent(["AAA"]);
+		const b = new StubComponent(["BBBBB"]);
+		const split = new HorizontalSplit([fixedChild(a, 3), fixedChild(b, 5)], "|");
+		const rows = split.render(9);
+		expect(rows).toEqual(["AAA|BBBBB\x1b[0m"]);
+	});
+
+	it("defaults the separator to a single space when omitted", () => {
+		const a = new StubComponent(["AAA"]);
+		const b = new StubComponent(["BBB"]);
+		const split = new HorizontalSplit([fixedChild(a, 3), fixedChild(b, 3)]);
+		const rows = split.render(7);
+		expect(rows[0]).toBe("AAA BBB\x1b[0m");
+	});
+});

--- a/packages/tui/test/pi-tui-pr1-exports.test.ts
+++ b/packages/tui/test/pi-tui-pr1-exports.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import { HorizontalSplit, TypedEventEmitter } from "@f5xc-salesdemos/pi-tui";
+
+describe("pi-tui root exports — PR 1 additions", () => {
+	it("re-exports TypedEventEmitter from the package root", () => {
+		expect(typeof TypedEventEmitter).toBe("function");
+	});
+
+	it("re-exports HorizontalSplit from the package root", () => {
+		expect(typeof HorizontalSplit).toBe("function");
+	});
+});


### PR DESCRIPTION
## Summary

PR 1 of 4 in the todo-sidebar rollout. Adds three additive pi-tui primitives that PR 2 will consume. No consumer changes in this PR — additive API only.

### Scope
- **TypedEventEmitter<T>** (`packages/tui/src/events.ts`) — typed pub-sub with `on()` returning unsubscribe closure (no `off()` method), zero-subscriber `emit()` no-op.
- **HorizontalSplit** (`packages/tui/src/horizontal-split.ts`) — side-by-side layout primitive with fixed + flex width allocation, binary-collapse priority-based narrowing, unsatisfiable-minimums fallback (expand highest-priority winner), wide-char boundary rule, ANSI-safe cell composition with inter-cell SGR reset and unconditional row-end reset.
- **ANSI/width invariant tests** (`packages/tui/test/ansi-width-invariants.test.ts`) — locks existing `visibleWidth` / `sliceByColumn` / `truncateToWidth` / `padding` in `utils.ts` to spec §6.3 contracts (SGR preservation, wide-char counting, empty-string, unstyled padding). No source changes to utils.ts.

### Spec deviations (narrower than spec, preserves contract)
1. `HorizontalSplit` implements `Component` directly rather than extending `Container` — per-child width/priority metadata doesn't fit `Container.children: Component[]`.
2. No new `packages/tui/src/ansi-width.ts` — spec §6.3 explicitly allows reusing existing utilities; invariant tests lock behavior without forking logic.

### Test counts
- `events.test.ts` — 8 tests (TypedEventEmitter contract)
- `horizontal-split.test.ts` — 22 tests (allocation + composition + SGR + wide-char + collapse + fallback)
- `ansi-width-invariants.test.ts` — 15 tests (spec §6.3)
- `pi-tui-pr1-exports.test.ts` — 2 tests (root re-exports smoke)
- Total: 47 new tests, all passing.

### Out of scope
- SidebarComponent, TodosSection, RemindersSection — PR 2.
- Ctrl+X B binding for sidebar toggle — PR 2 (uses PR #251's chord support).
- HTML export coherence — PR 3.

## Test plan
- [x] `bun test packages/tui/test/` passes (modulo 8 known baseline failures in `render-regressions.test.ts` and `overlay-scroll.test.ts` that predate this PR)
- [x] `bun run --cwd=packages/tui check:types` clean
- [x] `bun run --cwd=packages/coding-agent check:types` clean (no regression)
- [x] `bunx @biomejs/biome check packages/tui/src packages/tui/test` clean
- [x] Monorepo pi-tui consumer audit: `typescript-edit-benchmark` uses only `padding` (unchanged); `coding-agent` uses existing exports only. No existing consumer affected.

Closes #260