### PR TITLE
fix(tui): add missing spacer on tool_execution_start fallback (refs #253)

### DIFF
--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -353,6 +353,7 @@ export class EventController {
 					);
 					component.setExpanded(this.ctx.toolOutputExpanded);
 					const gutter = createToolGutter(this.ctx.ui, component);
+					this.ctx.chatContainer.addChild(new Spacer(1));
 					this.ctx.chatContainer.addChild(gutter);
 					this.ctx.pendingTools.set(event.toolCallId, component);
 					this.#pendingGutters.set(event.toolCallId, gutter);


### PR DESCRIPTION
## Summary

Follow-up to #258. Adds the one missing `new Spacer(1)` insertion in
`event-controller.ts` at the non-Read branch of the
`tool_execution_start` handler (was line 356 on main, now ~line 357).

This path is used by the Cursor exec bridge
(`packages/coding-agent/src/cursor.ts` emits `tool_execution_start`
directly at lines 61, 106, 245). Without this fix, Cursor-bridge
sessions with a non-Read tool rendered flush against the prior
message live, but `renderSessionContext()` inserted a Spacer on
rebuild — producing a visible reflow on session reload/resume.

The fix mirrors the sibling one-liner already present at
`event-controller.ts:244` for the `message_update` path.

Closes #267.

## Test plan

- [x] `bun run check` passes across all packages
- [x] Existing #253 regression test still passes: 3/3 scenarios in `ui-helpers-rebuild-spacing.test.ts`
- [x] Full `bun run test`: 3668 pass, 2 fail, 400 skip. The 2 failures are pre-existing in `auto-config.test.ts` baseline noise (same two that existed on main before #258 merged and remain unchanged)
- [ ] Manual TUI visual check in a Cursor-bridge session — confirm a non-Read tool block has one blank line before it, matching the reload-time layout
