### PR TITLE
refactor(coding-agent): DRY /profile — extract f5xc-env, formatProfileLabel, ProfileService.getOrInit

### DIFF
--- a/packages/coding-agent/src/services/f5xc-env.ts
+++ b/packages/coding-agent/src/services/f5xc-env.ts
@@ -1,0 +1,53 @@
+/**
+ * F5 XC environment variable names. Typed `as const` so bracket access like
+ * `process.env[F5XC_API_URL]` type-checks correctly. Single source of truth —
+ * every consumer imports these instead of repeating the string literal.
+ */
+export const F5XC_API_URL = "F5XC_API_URL" as const;
+export const F5XC_API_TOKEN = "F5XC_API_TOKEN" as const;
+export const F5XC_NAMESPACE = "F5XC_NAMESPACE" as const;
+export const F5XC_TENANT = "F5XC_TENANT" as const;
+export const F5XC_USERNAME = "F5XC_USERNAME" as const;
+export const F5XC_CONSOLE_PASSWORD = "F5XC_CONSOLE_PASSWORD" as const;
+
+/**
+ * True iff an env var is overriding a profile-provided credential.
+ * F5XC_API_URL alone is NOT an override — it is the signal that the user
+ * wants to bypass profiles entirely (see ProfileService.loadActive FR-102).
+ * The "override" concept only applies to token/namespace supplied alongside
+ * a loaded profile.
+ */
+export function hasEnvOverride(): boolean {
+	return !!process.env[F5XC_API_TOKEN] || !!process.env[F5XC_NAMESPACE];
+}
+
+/**
+ * RFC 1123 DNS label: 1–63 chars, alphanumeric edges, hyphens allowed only
+ * in the interior. Case-insensitive; matched URL hostname is lowercased.
+ */
+const DNS_LABEL_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
+
+/**
+ * Derive the tenant name (first DNS label) from an API URL.
+ *
+ * Returns null when:
+ *   - the URL fails to parse
+ *   - the hostname is dotless (e.g. `localhost`)
+ *   - the first label does not match the RFC 1123 DNS label rule
+ *
+ * Known edge case: IP-address URLs like `https://192.168.1.1` return `"192"`
+ * because a numeric label is technically a valid DNS label. This is
+ * out-of-spec for F5 XC tenant URLs and the misconfiguration surfaces
+ * visibly in the UI.
+ */
+export function deriveTenantFromUrl(url: string): string | null {
+	let hostname: string;
+	try {
+		hostname = new URL(url).hostname;
+	} catch {
+		return null;
+	}
+	if (!hostname.includes(".")) return null;
+	const label = hostname.split(".")[0].toLowerCase();
+	return DNS_LABEL_RE.test(label) ? label : null;
+}

--- a/packages/coding-agent/src/services/f5xc-profile-command.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-command.ts
@@ -1,5 +1,3 @@
-import * as os from "node:os";
-import * as path from "node:path";
 import { SECRET_ENV_PATTERNS } from "../secrets/index";
 import {
 	deriveTenantFromUrl,
@@ -22,25 +20,13 @@ interface CommandContext {
 	ui?: { requestRender(): void };
 }
 
-async function getOrInitService(): Promise<ProfileService> {
-	try {
-		return ProfileService.instance;
-	} catch {
-		// Lazy init for SDK/embedder paths where main.ts startup didn't run
-		const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
-		const service = ProfileService.init(path.join(xdgConfig, "f5xc"));
-		await service.loadActive();
-		return service;
-	}
-}
-
 export async function handleProfileCommand(
 	command: { name: string; args: string; text: string },
 	ctx: CommandContext,
 ): Promise<void> {
 	const [sub, ...rest] = command.args.trim().split(/\s+/);
 	const arg = rest.join(" ");
-	const service = await getOrInitService();
+	const service = await ProfileService.getOrInit();
 
 	ctx.editor.setText("");
 

--- a/packages/coding-agent/src/services/f5xc-profile-command.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-command.ts
@@ -1,6 +1,15 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import { SECRET_ENV_PATTERNS } from "../secrets/index";
+import {
+	deriveTenantFromUrl,
+	F5XC_API_TOKEN,
+	F5XC_API_URL,
+	F5XC_CONSOLE_PASSWORD,
+	F5XC_NAMESPACE,
+	F5XC_TENANT,
+	F5XC_USERNAME,
+} from "./f5xc-env";
 import { ProfileError, ProfileService } from "./f5xc-profile";
 import { formatAuthIndicator, renderF5XCTable, type TableRow } from "./f5xc-table";
 
@@ -126,25 +135,20 @@ async function handleShow(ctx: CommandContext, service: ProfileService, name?: s
 	}
 
 	// Derive tenant from URL
-	let tenant = "";
-	try {
-		tenant = new URL(profile.apiUrl).hostname.split(".")[0];
-	} catch {
-		/* skip */
-	}
+	const tenant = deriveTenantFromUrl(profile.apiUrl) ?? "";
 
 	// Validate the shown profile's token (not necessarily the active one)
 	const auth = await service.validateToken({ timeoutMs: 3000, apiUrl: profile.apiUrl, apiToken: profile.apiToken });
 
 	// Build table rows — auth section first
 	const rows: TableRow[] = [
-		{ key: "F5XC_TENANT", value: sanitize(tenant) },
-		{ key: "F5XC_API_URL", value: sanitize(profile.apiUrl) },
-		{ key: "F5XC_API_TOKEN", value: service.maskToken(profile.apiToken) },
+		{ key: F5XC_TENANT, value: sanitize(tenant) },
+		{ key: F5XC_API_URL, value: sanitize(profile.apiUrl) },
+		{ key: F5XC_API_TOKEN, value: service.maskToken(profile.apiToken) },
 	];
 
 	// Auth-related env vars
-	const authKeys = ["F5XC_USERNAME", "F5XC_CONSOLE_PASSWORD"];
+	const authKeys: string[] = [F5XC_USERNAME, F5XC_CONSOLE_PASSWORD];
 	for (const key of authKeys) {
 		const value = profile.env?.[key];
 		if (value) {
@@ -159,7 +163,7 @@ async function handleShow(ctx: CommandContext, service: ProfileService, name?: s
 	const envDividerIndex = rows.length;
 
 	// Environment section: namespace + remaining env vars
-	rows.push({ key: "F5XC_NAMESPACE", value: sanitize(profile.defaultNamespace) });
+	rows.push({ key: F5XC_NAMESPACE, value: sanitize(profile.defaultNamespace) });
 	if (profile.env) {
 		for (const [key, value] of Object.entries(profile.env)) {
 			if (authKeys.includes(key)) continue;

--- a/packages/coding-agent/src/services/f5xc-profile-display.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-display.ts
@@ -1,0 +1,15 @@
+import type { ProfileStatus } from "./f5xc-profile";
+
+/**
+ * Compose the canonical `<tenant|name|env>:<namespace|default>` label used by
+ * the status-line segment and any future single-line profile display.
+ *
+ * Fallback chain for the left side: tenant → profile name → "env"
+ * (the final fallback reflects env-backed sessions with no profile loaded).
+ * Right side defaults to `"default"` when no namespace is set.
+ */
+export function formatProfileLabel(status: ProfileStatus): string {
+	const left = status.activeProfileTenant ?? status.activeProfileName ?? "env";
+	const right = status.activeProfileNamespace ?? "default";
+	return `${left}:${right}`;
+}

--- a/packages/coding-agent/src/services/f5xc-profile-segment.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-segment.ts
@@ -1,4 +1,5 @@
 import { ProfileService } from "./f5xc-profile";
+import { formatProfileLabel } from "./f5xc-profile-display";
 
 export interface RenderedSegment {
 	content: string;
@@ -14,9 +15,7 @@ export function renderF5XCProfileSegment(): RenderedSegment {
 			return { content: "", visible: false };
 		}
 
-		// For env-backed sessions (no profile name), show tenant:namespace from env vars
-		const label = status.activeProfileTenant ?? status.activeProfileName ?? "env";
-		return { content: `${label}:${status.activeProfileNamespace ?? "default"}`, visible: true };
+		return { content: formatProfileLabel(status), visible: true };
 	} catch {
 		// ProfileService not initialized — silently hide segment
 		return { content: "", visible: false };

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -79,7 +79,7 @@ export class ProfileService {
 	 * configDir (or `getF5XCConfigDir()` if omitted) and run loadActive()
 	 * before returning.
 	 *
-	 * Initialization contract:
+	 * Primary patterns used in-tree:
 	 *   - main.ts: CLI startup calls `ProfileService.init(dir).loadActive()`
 	 *     eagerly — deterministic, synchronous path for the CLI.
 	 *   - SDK/embedder paths and slash-command handlers call
@@ -87,9 +87,14 @@ export class ProfileService {
 	 *   - Synchronous render paths (e.g. status-line segments) call `.instance`
 	 *     inside try/catch and silently hide if uninitialized — they MUST NOT
 	 *     trigger bootstrapping as a side effect of rendering.
+	 *   - welcome-checks.ts reads `.instance` directly after startup has already
+	 *     populated the singleton via init().
 	 *
 	 * No race exists: `init()` is synchronous, so a concurrent caller always
 	 * observes the populated singleton before re-entering the null branch.
+	 *
+	 * @param configDir — seed directory when bootstrapping; ignored when an
+	 *   instance already exists.
 	 */
 	static async getOrInit(configDir?: string): Promise<ProfileService> {
 		if (ProfileService.#instance) return ProfileService.#instance;

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { logger } from "@f5xc-salesdemos/pi-utils";
+import { getF5XCConfigDir, logger } from "@f5xc-salesdemos/pi-utils";
 import { Settings } from "../config/settings";
 import { SECRET_ENV_PATTERNS } from "../secrets/index";
 import {
@@ -72,6 +72,31 @@ export class ProfileService {
 	static init(configDir: string): ProfileService {
 		ProfileService.#instance = new ProfileService(configDir);
 		return ProfileService.#instance;
+	}
+
+	/**
+	 * Return the existing instance, or bootstrap one using the provided
+	 * configDir (or `getF5XCConfigDir()` if omitted) and run loadActive()
+	 * before returning.
+	 *
+	 * Initialization contract:
+	 *   - main.ts: CLI startup calls `ProfileService.init(dir).loadActive()`
+	 *     eagerly — deterministic, synchronous path for the CLI.
+	 *   - SDK/embedder paths and slash-command handlers call
+	 *     `ProfileService.getOrInit()` — returns existing or bootstraps.
+	 *   - Synchronous render paths (e.g. status-line segments) call `.instance`
+	 *     inside try/catch and silently hide if uninitialized — they MUST NOT
+	 *     trigger bootstrapping as a side effect of rendering.
+	 *
+	 * No race exists: `init()` is synchronous, so a concurrent caller always
+	 * observes the populated singleton before re-entering the null branch.
+	 */
+	static async getOrInit(configDir?: string): Promise<ProfileService> {
+		if (ProfileService.#instance) return ProfileService.#instance;
+		const dir = configDir ?? getF5XCConfigDir();
+		const service = ProfileService.init(dir);
+		await service.loadActive();
+		return service;
 	}
 
 	/**

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -3,6 +3,14 @@ import * as path from "node:path";
 import { logger } from "@f5xc-salesdemos/pi-utils";
 import { Settings } from "../config/settings";
 import { SECRET_ENV_PATTERNS } from "../secrets/index";
+import {
+	deriveTenantFromUrl,
+	F5XC_API_TOKEN,
+	F5XC_API_URL,
+	F5XC_NAMESPACE,
+	F5XC_TENANT,
+	hasEnvOverride,
+} from "./f5xc-env";
 
 export interface F5XCProfile {
 	name: string;
@@ -105,7 +113,7 @@ export class ProfileService {
 	async loadActive(): Promise<F5XCProfile | null> {
 		// FR-102: F5XC_API_URL is the signal to skip profile loading entirely.
 		// Subprocesses inherit process.env, so they already see the env vars directly.
-		if (process.env.F5XC_API_URL) {
+		if (process.env[F5XC_API_URL]) {
 			this.#credentialSource = "environment";
 			return null;
 		}
@@ -144,14 +152,13 @@ export class ProfileService {
 		this.#activeProfile = profile;
 		this.#applyToSettings(profile);
 		// Detect mixed source: profile loaded but some fields come from process.env
-		const hasEnvOverride = !!process.env.F5XC_API_TOKEN || !!process.env.F5XC_NAMESPACE;
-		this.#credentialSource = hasEnvOverride ? "mixed" : "profile";
+		this.#credentialSource = hasEnvOverride() ? "mixed" : "profile";
 		return profile;
 	}
 
 	async activate(name: string): Promise<F5XCProfile> {
 		// Reject activation when env overrides are present — would create mismatched credentials
-		if (process.env.F5XC_API_URL) {
+		if (process.env[F5XC_API_URL]) {
 			throw new ProfileError(
 				"Cannot activate a profile while F5XC_API_URL is set in the environment. " +
 					"Unset F5XC_API_URL first, or restart xcsh without it.",
@@ -169,8 +176,7 @@ export class ProfileService {
 
 		this.#activeProfile = profile;
 		this.#applyToSettings(profile);
-		const hasEnvOverride = !!process.env.F5XC_API_TOKEN || !!process.env.F5XC_NAMESPACE;
-		this.#credentialSource = hasEnvOverride ? "mixed" : "profile";
+		this.#credentialSource = hasEnvOverride() ? "mixed" : "profile";
 		return profile;
 	}
 
@@ -289,8 +295,8 @@ export class ProfileService {
 	}): Promise<{ status: AuthStatus; latencyMs?: number }> {
 		// Use explicit credentials if provided (for non-active profiles or env-backed sessions),
 		// otherwise fall back to effective credentials (env override > active profile)
-		const effectiveUrl = options?.apiUrl ?? process.env.F5XC_API_URL ?? this.#activeProfile?.apiUrl;
-		const effectiveToken = options?.apiToken ?? process.env.F5XC_API_TOKEN ?? this.#activeProfile?.apiToken;
+		const effectiveUrl = options?.apiUrl ?? process.env[F5XC_API_URL] ?? this.#activeProfile?.apiUrl;
+		const effectiveToken = options?.apiToken ?? process.env[F5XC_API_TOKEN] ?? this.#activeProfile?.apiToken;
 		if (!effectiveUrl || !effectiveToken) return { status: "unknown" };
 		const url = `${effectiveUrl}/api/web/namespaces`;
 		const timeout = options?.timeoutMs ?? 3000;
@@ -325,25 +331,17 @@ export class ProfileService {
 		this.#activeProfile = { ...this.#activeProfile, defaultNamespace: namespace };
 		// Re-apply settings with the new namespace
 		this.#applyToSettings(this.#activeProfile);
-		const hasEnvOverride = !!process.env.F5XC_API_TOKEN || !!process.env.F5XC_NAMESPACE;
-		this.#credentialSource = hasEnvOverride ? "mixed" : "profile";
+		this.#credentialSource = hasEnvOverride() ? "mixed" : "profile";
 	}
 
 	getStatus(): ProfileStatus {
-		const url = process.env.F5XC_API_URL ?? this.#activeProfile?.apiUrl ?? null;
-		let tenant: string | null = null;
-		if (url) {
-			try {
-				tenant = new URL(url).hostname.split(".")[0];
-			} catch {
-				/* invalid URL */
-			}
-		}
+		const url = process.env[F5XC_API_URL] ?? this.#activeProfile?.apiUrl ?? null;
+		const tenant = url ? deriveTenantFromUrl(url) : null;
 		return {
 			activeProfileName: this.#activeProfile?.name ?? null,
 			activeProfileUrl: url,
 			activeProfileTenant: tenant,
-			activeProfileNamespace: process.env.F5XC_NAMESPACE ?? this.#activeProfile?.defaultNamespace ?? null,
+			activeProfileNamespace: process.env[F5XC_NAMESPACE] ?? this.#activeProfile?.defaultNamespace ?? null,
 			credentialSource: this.#credentialSource,
 			authStatus: this.#authStatus,
 			isConfigured: this.#credentialSource !== "none",
@@ -468,17 +466,14 @@ export class ProfileService {
 		for (const [key, value] of Object.entries(existing)) {
 			if (!key.startsWith("F5XC_")) merged[key] = value;
 		}
-		if (!process.env.F5XC_API_URL) merged.F5XC_API_URL = profile.apiUrl;
-		if (!process.env.F5XC_API_TOKEN) merged.F5XC_API_TOKEN = profile.apiToken;
-		if (!process.env.F5XC_NAMESPACE) merged.F5XC_NAMESPACE = profile.defaultNamespace;
+		if (!process.env[F5XC_API_URL]) merged[F5XC_API_URL] = profile.apiUrl;
+		if (!process.env[F5XC_API_TOKEN]) merged[F5XC_API_TOKEN] = profile.apiToken;
+		if (!process.env[F5XC_NAMESPACE]) merged[F5XC_NAMESPACE] = profile.defaultNamespace;
 
 		// Auto-derive F5XC_TENANT from first hostname label of apiUrl
-		if (!process.env.F5XC_TENANT) {
-			try {
-				merged.F5XC_TENANT = new URL(profile.apiUrl).hostname.split(".")[0];
-			} catch {
-				/* invalid URL — skip */
-			}
+		if (!process.env[F5XC_TENANT]) {
+			const tenant = deriveTenantFromUrl(profile.apiUrl);
+			if (tenant) merged[F5XC_TENANT] = tenant;
 		}
 
 		// Inject all additional env vars from profile.env map

--- a/packages/coding-agent/test/f5xc-env.test.ts
+++ b/packages/coding-agent/test/f5xc-env.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	deriveTenantFromUrl,
+	F5XC_API_TOKEN,
+	F5XC_API_URL,
+	F5XC_NAMESPACE,
+	hasEnvOverride,
+} from "@f5xc-salesdemos/xcsh/services/f5xc-env";
+
+describe("f5xc-env", () => {
+	const savedEnv: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		for (const key of Object.keys(process.env)) {
+			if (key.startsWith("F5XC_")) {
+				savedEnv[key] = process.env[key];
+				delete process.env[key];
+			}
+		}
+	});
+
+	afterEach(() => {
+		for (const key of Object.keys(process.env)) {
+			if (key.startsWith("F5XC_")) delete process.env[key];
+		}
+		for (const [key, value] of Object.entries(savedEnv)) {
+			if (value !== undefined) process.env[key] = value;
+		}
+	});
+
+	describe("hasEnvOverride", () => {
+		it("returns false when no F5XC env vars are set", () => {
+			expect(hasEnvOverride()).toBe(false);
+		});
+
+		it("returns true when F5XC_API_TOKEN is set", () => {
+			process.env[F5XC_API_TOKEN] = "tok";
+			expect(hasEnvOverride()).toBe(true);
+		});
+
+		it("returns true when F5XC_NAMESPACE is set", () => {
+			process.env[F5XC_NAMESPACE] = "ns";
+			expect(hasEnvOverride()).toBe(true);
+		});
+
+		it("returns true when both F5XC_API_TOKEN and F5XC_NAMESPACE are set", () => {
+			process.env[F5XC_API_TOKEN] = "tok";
+			process.env[F5XC_NAMESPACE] = "ns";
+			expect(hasEnvOverride()).toBe(true);
+		});
+
+		it("returns false when only F5XC_API_URL is set (URL alone is not an override)", () => {
+			process.env[F5XC_API_URL] = "https://acme.console.ves.volterra.io";
+			expect(hasEnvOverride()).toBe(false);
+		});
+	});
+
+	describe("deriveTenantFromUrl", () => {
+		it("returns the first hostname label for a normal F5 XC URL", () => {
+			expect(deriveTenantFromUrl("https://acme.console.ves.volterra.io")).toBe("acme");
+		});
+
+		it("lowercases mixed-case labels", () => {
+			expect(deriveTenantFromUrl("https://Acme-01.console.example.com")).toBe("acme-01");
+		});
+
+		it("returns a 63-character label as-is", () => {
+			const label = "a".repeat(63);
+			expect(deriveTenantFromUrl(`https://${label}.example.com`)).toBe(label);
+		});
+
+		it("returns null for a 64-character label (exceeds DNS label limit)", () => {
+			const label = "a".repeat(64);
+			expect(deriveTenantFromUrl(`https://${label}.example.com`)).toBeNull();
+		});
+
+		it("returns null for labels containing underscores", () => {
+			expect(deriveTenantFromUrl("https://acme_01.example.com")).toBeNull();
+		});
+
+		it("returns null for labels with a leading hyphen", () => {
+			expect(deriveTenantFromUrl("https://-acme.example.com")).toBeNull();
+		});
+
+		it("returns null for labels with a trailing hyphen", () => {
+			expect(deriveTenantFromUrl("https://acme-.example.com")).toBeNull();
+		});
+
+		it("returns null for dotless hostnames (including localhost)", () => {
+			expect(deriveTenantFromUrl("https://localhost")).toBeNull();
+		});
+
+		it("returns null for completely invalid URLs", () => {
+			expect(deriveTenantFromUrl("not a url")).toBeNull();
+		});
+
+		it("returns '192' for an IP-address URL (documented edge case: numeric DNS labels are valid)", () => {
+			expect(deriveTenantFromUrl("https://192.168.1.1")).toBe("192");
+		});
+	});
+});

--- a/packages/coding-agent/test/f5xc-profile-display.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-display.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import type { ProfileStatus } from "@f5xc-salesdemos/xcsh/services/f5xc-profile";
+import { formatProfileLabel } from "@f5xc-salesdemos/xcsh/services/f5xc-profile-display";
+
+function status(overrides: Partial<ProfileStatus> = {}): ProfileStatus {
+	return {
+		activeProfileName: null,
+		activeProfileUrl: null,
+		activeProfileTenant: null,
+		activeProfileNamespace: null,
+		credentialSource: "none",
+		authStatus: "unknown",
+		isConfigured: false,
+		watcherActive: false,
+		...overrides,
+	};
+}
+
+describe("formatProfileLabel", () => {
+	it("uses tenant and namespace when both are present", () => {
+		expect(formatProfileLabel(status({ activeProfileTenant: "acme", activeProfileNamespace: "prod" }))).toBe(
+			"acme:prod",
+		);
+	});
+
+	it("falls back to profile name when tenant is null", () => {
+		expect(formatProfileLabel(status({ activeProfileName: "my-profile" }))).toBe("my-profile:default");
+	});
+
+	it("falls back to 'env' when both tenant and name are null", () => {
+		expect(formatProfileLabel(status())).toBe("env:default");
+	});
+
+	it("prefers tenant over name when both are present", () => {
+		expect(formatProfileLabel(status({ activeProfileTenant: "acme", activeProfileName: "my-profile" }))).toBe(
+			"acme:default",
+		);
+	});
+
+	it("uses explicit namespace in place of the 'default' fallback", () => {
+		expect(formatProfileLabel(status({ activeProfileNamespace: "staging" }))).toBe("env:staging");
+	});
+});

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -43,6 +43,8 @@ describe("ProfileService", () => {
 				delete process.env[key];
 			}
 		}
+		savedEnv.XDG_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
+		delete process.env.XDG_CONFIG_HOME;
 
 		testDir = path.join(os.tmpdir(), "test-f5xc-profile", Snowflake.next());
 		f5xcConfigDir = path.join(testDir, "f5xc-config");
@@ -66,6 +68,10 @@ describe("ProfileService", () => {
 		}
 		for (const [key, value] of Object.entries(savedEnv)) {
 			if (value !== undefined) process.env[key] = value;
+		}
+		delete process.env.XDG_CONFIG_HOME;
+		if (savedEnv.XDG_CONFIG_HOME !== undefined) {
+			process.env.XDG_CONFIG_HOME = savedEnv.XDG_CONFIG_HOME;
 		}
 		if (fs.existsSync(testDir)) {
 			fs.rmSync(testDir, { recursive: true });
@@ -719,6 +725,37 @@ describe("ProfileService", () => {
 		it("masks short tokens completely", () => {
 			const service = ProfileService.init(f5xcConfigDir);
 			expect(service.maskToken("abc")).toBe("****");
+		});
+	});
+
+	describe("getOrInit", () => {
+		it("returns the existing instance when already initialized", async () => {
+			const first = ProfileService.init(f5xcConfigDir);
+			const second = await ProfileService.getOrInit(f5xcConfigDir);
+			expect(second).toBe(first);
+		});
+
+		it("bootstraps with the provided configDir when no instance exists", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+
+			const service = await ProfileService.getOrInit(f5xcConfigDir);
+			expect(service.profilesDir).toBe(f5xcProfilesDir);
+			expect(service.getStatus().activeProfileName).toBe(TEST_PROFILE.name);
+		});
+
+		it("falls back to getF5XCConfigDir() when configDir is omitted", async () => {
+			process.env.XDG_CONFIG_HOME = testDir;
+			const service = await ProfileService.getOrInit();
+			expect(service.profilesDir.startsWith(testDir)).toBe(true);
+		});
+
+		it("is idempotent under concurrent callers", async () => {
+			const [a, b] = await Promise.all([
+				ProfileService.getOrInit(f5xcConfigDir),
+				ProfileService.getOrInit(f5xcConfigDir),
+			]);
+			expect(a).toBe(b);
 		});
 	});
 });

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -270,6 +270,11 @@ describe("F5 XC profile auto-loading at CLI startup (PR #69)", () => {
 		const src = await fs.readFile(path.join(import.meta.dir, "../src/main.ts"), "utf8");
 		expect(src).toContain("getF5XCConfigDir");
 	});
+
+	it("f5xc-profile-command.ts does NOT reimplement XDG_CONFIG_HOME derivation", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../src/services/f5xc-profile-command.ts"), "utf8");
+		expect(src).not.toContain("XDG_CONFIG_HOME");
+	});
 });
 
 // ─── ProfileService Obfuscator Integration ────────────────────────────────


### PR DESCRIPTION
## Summary

- Extract `f5xc-env.ts` leaf module with typed `as const` env-var name constants, `hasEnvOverride()`, and `deriveTenantFromUrl()` — replaces ~20 scattered `process.env.F5XC_*` string literals and 3 duplicated inline helpers
- Extract `f5xc-profile-display.ts` with `formatProfileLabel()` — consolidates `tenant:namespace` label composition duplicated across segment and command surfaces
- Add `ProfileService.getOrInit()` static method — eliminates the local `getOrInitService()` helper in `f5xc-profile-command.ts` and gives SDK/embedder callers a canonical lazy-init entry point

## Test Plan
- [ ] `bun test packages/coding-agent/test/f5xc-env.test.ts` — 15 tests (hasEnvOverride, deriveTenantFromUrl)
- [ ] `bun test packages/coding-agent/test/f5xc-profile-display.test.ts` — 5 tests (formatProfileLabel)
- [ ] `bun test packages/coding-agent/test/f5xc-profile-service.test.ts` — includes 4 new getOrInit tests
- [ ] `bun test packages/coding-agent/test/regression-guard.test.ts` — asserts XDG_CONFIG_HOME removed from profile-command

Closes #272