### PR TITLE
refactor(coding-agent): remove watcherActive dead code from ProfileStatus (#273)

### DIFF
--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -38,7 +38,6 @@ export interface ProfileStatus {
 	credentialSource: "profile" | "environment" | "mixed" | "none";
 	authStatus: AuthStatus;
 	isConfigured: boolean;
-	watcherActive: boolean;
 }
 
 export class ProfileError extends Error {
@@ -375,7 +374,6 @@ export class ProfileService {
 			credentialSource: this.#credentialSource,
 			authStatus: this.#authStatus,
 			isConfigured: this.#credentialSource !== "none",
-			watcherActive: false,
 		};
 	}
 

--- a/packages/coding-agent/test/f5xc-profile-display.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-display.test.ts
@@ -11,7 +11,6 @@ function status(overrides: Partial<ProfileStatus> = {}): ProfileStatus {
 		credentialSource: "none",
 		authStatus: "unknown",
 		isConfigured: false,
-		watcherActive: false,
 		...overrides,
 	};
 }


### PR DESCRIPTION
## What

Remove the `watcherActive` dead-code field from `ProfileStatus` interface and
all sites that hardcode it to `false`.

## Why

Sub-task 2.2 of #273 — Phase 2 cleanup of partially-implemented features.
The field was hardcoded to `false` in 3 places with zero consumers. File
watching is a separate enhancement if ever needed and is not in scope here.

Closes #273

## Testing

- Pre-commit hooks pass (biome lint, governance, secrets, spelling)
- Changes are deletions only (3 lines removed) — no new behavior introduced

---

- [x] `bun run check` passes
- [x] `bun test` — no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #N`