### PR TITLE
feat(coding-agent): /profile phase 2 — complete partially-implemented features

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -11,7 +11,9 @@ const STARTUP_FIRST_TIMEOUT_MS = 4000;
 const STARTUP_RETRY_TIMEOUT_MS = 5000;
 const STARTUP_RETRY_DELAY_MS = 500;
 
-type ProfileValidator = (opts: { timeoutMs: number }) => Promise<{ status: AuthStatus; latencyMs?: number }>;
+type ProfileValidator = (opts: {
+	timeoutMs: number;
+}) => Promise<{ status: AuthStatus; latencyMs?: number; errorClass?: "network" | "credential" }>;
 
 /**
  * Runs the profile validator once with a startup-sized timeout; if the result is `offline`

--- a/packages/coding-agent/src/services/f5xc-profile-command.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-command.ts
@@ -96,7 +96,7 @@ async function handleList(ctx: CommandContext, service: ProfileService): Promise
 
 async function handleActivate(ctx: CommandContext, service: ProfileService, name: string): Promise<void> {
 	if (!name) {
-		ctx.showError("Usage: /profile activate <name>");
+		ctx.showError("Usage: /profile activate <name>. Run `/profile list` to see available profiles.");
 		return;
 	}
 	try {
@@ -118,13 +118,15 @@ function isSensitiveKey(key: string): boolean {
 async function handleShow(ctx: CommandContext, service: ProfileService, name?: string): Promise<void> {
 	const targetName = name || service.getStatus().activeProfileName;
 	if (!targetName) {
-		ctx.showError("No active profile. Use /profile activate <name> first.");
+		ctx.showError(
+			"No active profile. Run `/profile create <name>` to create one, or `/profile activate <name>` if profiles exist.",
+		);
 		return;
 	}
 	const profiles = await service.listProfiles();
 	const profile = profiles.find(p => p.name === targetName);
 	if (!profile) {
-		ctx.showError(`Profile '${targetName}' not found.`);
+		ctx.showError(`Profile '${targetName}' not found. Run \`/profile list\` to see available profiles.`);
 		return;
 	}
 
@@ -248,7 +250,7 @@ async function handleDelete(ctx: CommandContext, service: ProfileService, args: 
 	}
 	const status = service.getStatus();
 	if (name === status.activeProfileName) {
-		ctx.showError("Cannot delete the active profile. Activate a different profile first.");
+		ctx.showError("Cannot delete the active profile. Run `/profile activate <other>` to switch first.");
 		return;
 	}
 	if (!confirmed) {

--- a/packages/coding-agent/src/services/f5xc-profile-command.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-command.ts
@@ -9,7 +9,13 @@ import {
 	F5XC_USERNAME,
 } from "./f5xc-env";
 import { CURRENT_SCHEMA_VERSION, ProfileError, ProfileService } from "./f5xc-profile";
-import { formatAuthIndicator, renderF5XCTable, type TableRow } from "./f5xc-table";
+import {
+	formatAuthIndicator,
+	formatExpiration,
+	formatRelativeTime,
+	renderF5XCTable,
+	type TableRow,
+} from "./f5xc-table";
 
 interface CommandContext {
 	showStatus(msg: string): void;
@@ -159,7 +165,28 @@ async function handleShow(ctx: CommandContext, service: ProfileService, name?: s
 		}
 	}
 
-	ctx.showStatus(renderF5XCTable(profile.name, rows, { dividerBefore: envDividerIndex }));
+	// Metadata section (only rendered when at least one field is present)
+	const metaRows: TableRow[] = [];
+	if (profile.metadata?.createdAt) {
+		metaRows.push({ key: "Created", value: formatRelativeTime(profile.metadata.createdAt) });
+	}
+	if (profile.metadata?.expiresAt) {
+		metaRows.push({ key: "Expires", value: formatExpiration(profile.metadata.expiresAt) });
+	}
+	if (profile.metadata?.lastRotatedAt) {
+		metaRows.push({ key: "Last Rotated", value: formatRelativeTime(profile.metadata.lastRotatedAt) });
+	}
+	if (profile.metadata?.rotateAfterDays) {
+		metaRows.push({ key: "Rotation", value: `every ${profile.metadata.rotateAfterDays} days` });
+	}
+
+	const dividers: Array<{ before: number; label: string }> = [{ before: envDividerIndex, label: "Environment" }];
+	if (metaRows.length > 0) {
+		dividers.push({ before: rows.length, label: "Metadata" });
+		rows.push(...metaRows);
+	}
+
+	ctx.showStatus(renderF5XCTable(profile.name, rows, { dividers }));
 }
 
 async function handleStatus(ctx: CommandContext, service: ProfileService): Promise<void> {

--- a/packages/coding-agent/src/services/f5xc-profile-command.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-command.ts
@@ -8,7 +8,7 @@ import {
 	F5XC_TENANT,
 	F5XC_USERNAME,
 } from "./f5xc-env";
-import { ProfileError, ProfileService } from "./f5xc-profile";
+import { CURRENT_SCHEMA_VERSION, ProfileError, ProfileService } from "./f5xc-profile";
 import { formatAuthIndicator, renderF5XCTable, type TableRow } from "./f5xc-table";
 
 interface CommandContext {
@@ -81,7 +81,9 @@ async function handleList(ctx: CommandContext, service: ProfileService): Promise
 	const status = service.getStatus();
 	const lines = profiles.map(p => {
 		const marker = p.name === status.activeProfileName ? "*" : " ";
-		return `  ${marker} ${sanitize(p.name).padEnd(20)} ${sanitize(p.apiUrl)}`;
+		const versionSuffix =
+			p.version !== undefined && p.version > CURRENT_SCHEMA_VERSION ? ` (v${p.version} — upgrade required)` : "";
+		return `  ${marker} ${sanitize(p.name).padEnd(20)} ${sanitize(p.apiUrl)}${versionSuffix}`;
 	});
 	ctx.showStatus(lines.join("\n"));
 }

--- a/packages/coding-agent/src/services/f5xc-profile-command.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-command.ts
@@ -145,7 +145,7 @@ async function handleShow(ctx: CommandContext, service: ProfileService, name?: s
 	}
 
 	// Auth status indicator
-	rows.push({ key: "Status", value: formatAuthIndicator(auth.status, auth.latencyMs) });
+	rows.push({ key: "Status", value: formatAuthIndicator(auth.status, auth.latencyMs, auth.errorClass) });
 
 	// Track where environment section starts
 	const envDividerIndex = rows.length;
@@ -174,7 +174,7 @@ async function handleStatus(ctx: CommandContext, service: ProfileService): Promi
 		{ key: "Source", value: status.credentialSource },
 		{ key: "API URL", value: status.activeProfileUrl ?? "(not set)" },
 		{ key: "Namespace", value: status.activeProfileNamespace ?? "(not set)" },
-		{ key: "Status", value: formatAuthIndicator(auth.status, auth.latencyMs) },
+		{ key: "Status", value: formatAuthIndicator(auth.status, auth.latencyMs, auth.errorClass) },
 	];
 	ctx.showStatus(renderF5XCTable(status.activeProfileName ?? "status", rows));
 }

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -342,7 +342,7 @@ export class ProfileService {
 		timeoutMs?: number;
 		apiUrl?: string;
 		apiToken?: string;
-	}): Promise<{ status: AuthStatus; latencyMs?: number }> {
+	}): Promise<{ status: AuthStatus; latencyMs?: number; errorClass?: "network" | "credential" }> {
 		// Use explicit credentials if provided (for non-active profiles or env-backed sessions),
 		// otherwise fall back to effective credentials (env override > active profile)
 		const effectiveUrl = options?.apiUrl ?? process.env[F5XC_API_URL] ?? this.#activeProfile?.apiUrl;
@@ -364,13 +364,14 @@ export class ProfileService {
 			}
 			if (response.status === 401 || response.status === 403) {
 				this.#authStatus = "auth_error";
-				return { status: "auth_error", latencyMs };
+				return { status: "auth_error", latencyMs, errorClass: "credential" };
 			}
-			this.#authStatus = "connected";
-			return { status: "connected", latencyMs };
+			// 5xx, 429, etc. — server reachable but unhealthy; treat as offline so startup retry fires
+			this.#authStatus = "offline";
+			return { status: "offline", latencyMs, errorClass: "network" };
 		} catch {
 			this.#authStatus = "offline";
-			return { status: "offline" };
+			return { status: "offline", errorClass: "network" };
 		}
 	}
 

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -12,6 +12,8 @@ import {
 	hasEnvOverride,
 } from "./f5xc-env";
 
+export const CURRENT_SCHEMA_VERSION = 1;
+
 export interface F5XCProfile {
 	name: string;
 	apiUrl: string;
@@ -20,6 +22,7 @@ export interface F5XCProfile {
 	env?: Record<string, string>;
 	/** Env var names from `env` whose values should be masked in output (e.g. ["F5XC_USERNAME"]). */
 	sensitiveKeys?: string[];
+	version?: number;
 	metadata?: {
 		createdAt?: string;
 		expiresAt?: string;
@@ -172,6 +175,17 @@ export class ProfileService {
 			return null;
 		}
 
+		// Gate: incompatible schema version — log warning and return null (don't crash startup)
+		try {
+			this.#assertCompatibleVersion(profile);
+		} catch (err) {
+			logger.warn("F5XC: profile uses incompatible schema version, skipping", {
+				name: profileName,
+				error: String(err),
+			});
+			return null;
+		}
+
 		// Only persist active_profile after the profile validates
 		if (autoActivated) {
 			this.#atomicWrite(this.activeProfilePath, profileName);
@@ -200,6 +214,8 @@ export class ProfileService {
 			throw new ProfileError(`Profile '${name}' not found.`, name);
 		}
 
+		this.#assertCompatibleVersion(profile);
+
 		// NFR-402: write active_profile first — if it fails, don't update settings
 		this.#atomicWrite(this.activeProfilePath, name);
 
@@ -222,7 +238,7 @@ export class ProfileService {
 		return profiles;
 	}
 
-	async createProfile(profile: Omit<F5XCProfile, "metadata">): Promise<void> {
+	async createProfile(profile: Omit<F5XCProfile, "metadata" | "version">): Promise<void> {
 		this.#validateProfileName(profile.name);
 		const profilePath = path.join(this.profilesDir, `${profile.name}.json`);
 		if (fs.existsSync(profilePath)) {
@@ -232,6 +248,7 @@ export class ProfileService {
 		fs.mkdirSync(this.#configDir, { recursive: true, mode: 0o700 });
 		const data: F5XCProfile = {
 			...profile,
+			version: CURRENT_SCHEMA_VERSION,
 			metadata: { createdAt: new Date().toISOString() },
 		};
 		const tmpPath = `${profilePath}.tmp`;
@@ -254,6 +271,8 @@ export class ProfileService {
 		this.#validateProfileName(name);
 		const profile = this.#readProfile(name);
 		if (!profile) throw new ProfileError(`Profile '${name}' not found.`, name);
+
+		this.#assertCompatibleVersion(profile);
 
 		const env = { ...(profile.env ?? {}), ...vars };
 		const sensitiveSet = new Set(profile.sensitiveKeys ?? []);
@@ -287,6 +306,8 @@ export class ProfileService {
 		this.#validateProfileName(name);
 		const profile = this.#readProfile(name);
 		if (!profile) throw new ProfileError(`Profile '${name}' not found.`, name);
+
+		this.#assertCompatibleVersion(profile);
 
 		const env = { ...(profile.env ?? {}) };
 		const removed: string[] = [];
@@ -399,6 +420,15 @@ export class ProfileService {
 		}
 	}
 
+	#assertCompatibleVersion(profile: F5XCProfile): void {
+		if (profile.version !== undefined && profile.version > CURRENT_SCHEMA_VERSION) {
+			throw new ProfileError(
+				`Profile '${profile.name}' uses schema version ${profile.version}, but this version of xcsh only supports version ${CURRENT_SCHEMA_VERSION}. Upgrade xcsh to use this profile, or run \`/profile create\` to create a new one.`,
+				profile.name,
+			);
+		}
+	}
+
 	#readActiveProfileName(): string | null {
 		try {
 			if (!fs.existsSync(this.activeProfilePath)) return null;
@@ -466,6 +496,7 @@ export class ProfileService {
 				defaultNamespace: parsed.defaultNamespace ?? "default",
 				env,
 				sensitiveKeys,
+				version: typeof parsed.version === "number" ? parsed.version : undefined,
 				metadata: parsed.metadata,
 			};
 		} catch (err) {

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -203,15 +203,14 @@ export class ProfileService {
 		// Reject activation when env overrides are present — would create mismatched credentials
 		if (process.env[F5XC_API_URL]) {
 			throw new ProfileError(
-				"Cannot activate a profile while F5XC_API_URL is set in the environment. " +
-					"Unset F5XC_API_URL first, or restart xcsh without it.",
+				"Cannot activate: F5XC_API_URL environment variable overrides profile. Run `unset F5XC_API_URL` first, or restart without it.",
 			);
 		}
 
 		this.#validateProfileName(name);
 		const profile = this.#readProfile(name);
 		if (!profile) {
-			throw new ProfileError(`Profile '${name}' not found.`, name);
+			throw new ProfileError(`Profile '${name}' not found. Run \`/profile list\` to see available profiles.`, name);
 		}
 
 		this.#assertCompatibleVersion(profile);
@@ -377,7 +376,7 @@ export class ProfileService {
 
 	setNamespace(namespace: string): void {
 		if (!this.#activeProfile) {
-			throw new ProfileError("No active profile. Activate a profile first.");
+			throw new ProfileError("No active profile. Run `/profile activate <name>` to select one.");
 		}
 		this.#activeProfile = { ...this.#activeProfile, defaultNamespace: namespace };
 		// Re-apply settings with the new namespace

--- a/packages/coding-agent/src/services/f5xc-table.ts
+++ b/packages/coding-agent/src/services/f5xc-table.ts
@@ -38,13 +38,46 @@ export function formatAuthIndicator(
 	}
 }
 
+export function formatRelativeTime(isoDate: string, now?: Date): string {
+	const nowMs = (now ?? new Date()).getTime();
+	const thenMs = new Date(isoDate).getTime();
+	const diffMs = nowMs - thenMs;
+	const absDiffMs = Math.abs(diffMs);
+	const minutes = Math.floor(absDiffMs / 60_000);
+	const hours = Math.floor(minutes / 60);
+	const days = Math.floor(hours / 24);
+	const months = Math.floor(days / 30);
+
+	if (months > 0) return `${months} month${months > 1 ? "s" : ""} ago`;
+	if (days > 0) return `${days} day${days > 1 ? "s" : ""} ago`;
+	if (hours > 0) return `${hours} hour${hours > 1 ? "s" : ""} ago`;
+	if (minutes > 0) return `${minutes} minute${minutes > 1 ? "s" : ""} ago`;
+	return "just now";
+}
+
+export function formatExpiration(isoDate: string, now?: Date): string {
+	const nowMs = (now ?? new Date()).getTime();
+	const expiresMs = new Date(isoDate).getTime();
+	const dateStr = isoDate.split("T")[0];
+	const diffDays = Math.ceil((expiresMs - nowMs) / 86_400_000);
+
+	if (diffDays < 0) {
+		const ago = Math.abs(diffDays);
+		return `${dateStr}  ${formatStatusIcon("warning")} expired ${ago} day${ago > 1 ? "s" : ""} ago`;
+	}
+	if (diffDays <= 7) {
+		return `${dateStr}  ${formatStatusIcon("warning")} expires in ${diffDays} day${diffDays !== 1 ? "s" : ""}`;
+	}
+	return dateStr;
+}
+
 export interface TableRow {
 	key: string;
 	value: string;
 }
 
 export interface TableOptions {
-	dividerBefore?: number; // insert ├──┤ divider before this row index
+	dividers?: Array<{ before: number; label: string }>;
 }
 
 // Measures the visible terminal column width of a string.
@@ -68,9 +101,10 @@ export function renderF5XCTable(title: string, rows: TableRow[], options?: Table
 
 	// Rows
 	for (let i = 0; i < rows.length; i++) {
-		// Optional divider
-		if (options?.dividerBefore === i) {
-			const divLabel = " Environment ";
+		// Optional labeled dividers
+		const divider = options?.dividers?.find(d => d.before === i);
+		if (divider) {
+			const divLabel = ` ${divider.label} `;
 			const divPad = innerWidth - visibleWidth(divLabel) - 1;
 			lines.push(`${r(BOX.lt + BOX.h)}${BOLD}${divLabel}${RESET}${r(BOX.h.repeat(Math.max(0, divPad)) + BOX.rt)}`);
 		}

--- a/packages/coding-agent/src/services/f5xc-table.ts
+++ b/packages/coding-agent/src/services/f5xc-table.ts
@@ -20,15 +20,19 @@ const BOX = {
 
 const r = (s: string) => `${F5_RED}${s}${RESET}`;
 
-export function formatAuthIndicator(status: AuthStatus, latencyMs?: number): string {
+export function formatAuthIndicator(
+	status: AuthStatus,
+	latencyMs?: number,
+	errorClass?: "network" | "credential",
+): string {
 	const ms = latencyMs !== undefined ? ` (${latencyMs}ms)` : "";
 	switch (status) {
 		case "connected":
 			return `${formatStatusIcon("connected")} Connected${ms}`;
 		case "auth_error":
-			return `${formatStatusIcon("error")} Auth Error${ms}`;
+			return `${formatStatusIcon("error")} Auth Error — check token${ms}`;
 		case "offline":
-			return `${formatStatusIcon("warning")} Offline`;
+			return `${formatStatusIcon("warning")} Offline — ${errorClass === "credential" ? "auth issue" : "network issue"}${ms}`;
 		default:
 			return `${formatStatusIcon("unknown")} Unknown`;
 	}

--- a/packages/coding-agent/test/f5xc-profile-command.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-command.test.ts
@@ -6,7 +6,31 @@ import { Snowflake } from "@f5xc-salesdemos/pi-utils";
 import { _resetSettingsForTest, Settings } from "@f5xc-salesdemos/xcsh/config/settings";
 import { CURRENT_SCHEMA_VERSION, ProfileService } from "@f5xc-salesdemos/xcsh/services/f5xc-profile";
 import { handleProfileCommand } from "@f5xc-salesdemos/xcsh/services/f5xc-profile-command";
+import { formatAuthIndicator } from "@f5xc-salesdemos/xcsh/services/f5xc-table";
 import { TEST_PROFILE, TEST_PROFILE_STAGING as TEST_PROFILE_2 } from "./f5xc-test-fixtures";
+
+describe("formatAuthIndicator", () => {
+	it("includes latencyMs for offline results", () => {
+		const result = formatAuthIndicator("offline", 342, "network");
+		expect(result).toContain("342ms");
+	});
+
+	it("shows credential-specific text for auth_error", () => {
+		const result = formatAuthIndicator("auth_error", 100, "credential");
+		expect(result).toContain("check token");
+	});
+
+	it("shows network-specific text for offline", () => {
+		const result = formatAuthIndicator("offline", undefined, "network");
+		expect(result).toContain("network");
+	});
+
+	it("shows connected without errorClass", () => {
+		const result = formatAuthIndicator("connected", 50);
+		expect(result).toContain("Connected");
+		expect(result).toContain("50ms");
+	});
+});
 
 function writeProfile(
 	profilesDir: string,

--- a/packages/coding-agent/test/f5xc-profile-command.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-command.test.ts
@@ -6,7 +6,12 @@ import { Snowflake } from "@f5xc-salesdemos/pi-utils";
 import { _resetSettingsForTest, Settings } from "@f5xc-salesdemos/xcsh/config/settings";
 import { CURRENT_SCHEMA_VERSION, ProfileService } from "@f5xc-salesdemos/xcsh/services/f5xc-profile";
 import { handleProfileCommand } from "@f5xc-salesdemos/xcsh/services/f5xc-profile-command";
-import { formatAuthIndicator } from "@f5xc-salesdemos/xcsh/services/f5xc-table";
+import {
+	formatAuthIndicator,
+	formatExpiration,
+	formatRelativeTime,
+	renderF5XCTable,
+} from "@f5xc-salesdemos/xcsh/services/f5xc-table";
 import { TEST_PROFILE, TEST_PROFILE_STAGING as TEST_PROFILE_2 } from "./f5xc-test-fixtures";
 
 describe("formatAuthIndicator", () => {
@@ -29,6 +34,105 @@ describe("formatAuthIndicator", () => {
 		const result = formatAuthIndicator("connected", 50);
 		expect(result).toContain("Connected");
 		expect(result).toContain("50ms");
+	});
+});
+
+describe("formatRelativeTime", () => {
+	const now = new Date("2026-04-23T12:00:00Z");
+
+	it("returns 'just now' for less than 1 minute ago", () => {
+		const recent = new Date(now.getTime() - 30_000).toISOString();
+		expect(formatRelativeTime(recent, now)).toBe("just now");
+	});
+
+	it("returns '15 minutes ago'", () => {
+		const t = new Date(now.getTime() - 15 * 60_000).toISOString();
+		expect(formatRelativeTime(t, now)).toBe("15 minutes ago");
+	});
+
+	it("returns '3 hours ago'", () => {
+		const t = new Date(now.getTime() - 3 * 3_600_000).toISOString();
+		expect(formatRelativeTime(t, now)).toBe("3 hours ago");
+	});
+
+	it("returns '3 days ago'", () => {
+		const t = new Date(now.getTime() - 3 * 86_400_000).toISOString();
+		expect(formatRelativeTime(t, now)).toBe("3 days ago");
+	});
+
+	it("returns '3 months ago'", () => {
+		const t = new Date(now.getTime() - 90 * 86_400_000).toISOString();
+		expect(formatRelativeTime(t, now)).toBe("3 months ago");
+	});
+
+	it("uses singular '1 day ago'", () => {
+		const t = new Date(now.getTime() - 1 * 86_400_000).toISOString();
+		expect(formatRelativeTime(t, now)).toBe("1 day ago");
+	});
+});
+
+describe("formatExpiration", () => {
+	const now = new Date("2026-04-23T12:00:00Z");
+
+	it("returns bare date string when more than 7 days away", () => {
+		const future = "2026-05-10T00:00:00.000Z";
+		const result = formatExpiration(future, now);
+		expect(result).toBe("2026-05-10");
+		expect(result).not.toContain("⚠");
+		expect(result).not.toContain("expires");
+	});
+
+	it("shows warning when within 7 days", () => {
+		const soon = "2026-04-28T00:00:00.000Z";
+		const result = formatExpiration(soon, now);
+		expect(result).toContain("expires in");
+	});
+
+	it("shows warning for today (0 days)", () => {
+		const today = "2026-04-23T23:59:00.000Z";
+		const result = formatExpiration(today, now);
+		expect(result).toContain("expires in");
+	});
+
+	it("shows 'expired' warning for past dates", () => {
+		const past = "2026-04-01T00:00:00.000Z";
+		const result = formatExpiration(past, now);
+		expect(result).toContain("expired");
+	});
+
+	it("uses singular '1 day' in warning", () => {
+		// 20 hours after now — ceil((20h) / 24h) = 1 day
+		const tomorrow = "2026-04-24T08:00:00.000Z";
+		const result = formatExpiration(tomorrow, now);
+		expect(result).toContain("1 day");
+		expect(result).not.toMatch(/1 days/);
+	});
+});
+
+describe("renderF5XCTable", () => {
+	it("renders multiple labeled dividers", () => {
+		const rows = [
+			{ key: "A", value: "1" },
+			{ key: "B", value: "2" },
+			{ key: "C", value: "3" },
+			{ key: "D", value: "4" },
+		];
+		const result = renderF5XCTable("test", rows, {
+			dividers: [
+				{ before: 2, label: "Section Two" },
+				{ before: 3, label: "Section Three" },
+			],
+		});
+		const plain = result.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("Section Two");
+		expect(plain).toContain("Section Three");
+	});
+
+	it("renders with no dividers (backwards compatible)", () => {
+		const rows = [{ key: "A", value: "1" }];
+		const result = renderF5XCTable("test", rows);
+		expect(result).toContain("A");
+		expect(result).not.toContain("Environment");
 	});
 });
 
@@ -486,5 +590,78 @@ describe("/profile slash command handler", () => {
 		expect(ctx.messages[0].type).toBe("status");
 		expect(ctx.messages[0].text).toContain("future");
 		expect(ctx.messages[0].text).toContain("upgrade required");
+	});
+
+	// --- /profile show metadata display ---
+
+	describe("/profile show metadata display", () => {
+		it("shows metadata section when profile has metadata", async () => {
+			const metaProfile = {
+				name: "meta-test",
+				apiUrl: TEST_PROFILE.apiUrl,
+				apiToken: TEST_PROFILE.apiToken,
+				defaultNamespace: TEST_PROFILE.defaultNamespace,
+				metadata: {
+					createdAt: "2026-01-01T00:00:00.000Z",
+					expiresAt: "2027-06-01T00:00:00.000Z",
+					lastRotatedAt: "2026-03-01T00:00:00.000Z",
+					rotateAfterDays: 90,
+				},
+			};
+			writeProfile(f5xcProfilesDir, metaProfile);
+			writeActiveProfile(f5xcConfigDir, "meta-test");
+
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const ctx = createMockCtx();
+			await handleProfileCommand({ name: "profile", args: "show", text: "/profile show" }, ctx);
+
+			const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+			expect(plain).toContain("Metadata");
+			expect(plain).toContain("Created");
+			expect(plain).toContain("Expires");
+			expect(plain).toContain("Last Rotated");
+			expect(plain).toContain("every 90 days");
+		});
+
+		it("does not show metadata section when profile has no metadata", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const ctx = createMockCtx();
+			await handleProfileCommand({ name: "profile", args: "show", text: "/profile show" }, ctx);
+
+			const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+			expect(plain).not.toContain("Metadata");
+			expect(plain).not.toContain("Created");
+		});
+
+		it("shows only createdAt when that is the only metadata field", async () => {
+			const minMetaProfile = {
+				name: "min-meta",
+				apiUrl: TEST_PROFILE.apiUrl,
+				apiToken: TEST_PROFILE.apiToken,
+				defaultNamespace: TEST_PROFILE.defaultNamespace,
+				metadata: { createdAt: "2026-01-01T00:00:00.000Z" },
+			};
+			writeProfile(f5xcProfilesDir, minMetaProfile);
+			writeActiveProfile(f5xcConfigDir, "min-meta");
+
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const ctx = createMockCtx();
+			await handleProfileCommand({ name: "profile", args: "show", text: "/profile show" }, ctx);
+
+			const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+			expect(plain).toContain("Metadata");
+			expect(plain).toContain("Created");
+			expect(plain).not.toContain("Expires");
+			expect(plain).not.toContain("Last Rotated");
+		});
 	});
 });

--- a/packages/coding-agent/test/f5xc-profile-command.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-command.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Snowflake } from "@f5xc-salesdemos/pi-utils";
 import { _resetSettingsForTest, Settings } from "@f5xc-salesdemos/xcsh/config/settings";
-import { ProfileService } from "@f5xc-salesdemos/xcsh/services/f5xc-profile";
+import { CURRENT_SCHEMA_VERSION, ProfileService } from "@f5xc-salesdemos/xcsh/services/f5xc-profile";
 import { handleProfileCommand } from "@f5xc-salesdemos/xcsh/services/f5xc-profile-command";
 import { TEST_PROFILE, TEST_PROFILE_STAGING as TEST_PROFILE_2 } from "./f5xc-test-fixtures";
 
@@ -434,5 +434,33 @@ describe("/profile slash command handler", () => {
 
 		expect(ctx.messages[0].type).toBe("error");
 		expect(ctx.messages[0].text).toContain("Unknown subcommand");
+	});
+
+	it("/profile list shows version warning suffix for incompatible profiles", async () => {
+		fs.mkdirSync(f5xcProfilesDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(f5xcProfilesDir, "future.json"),
+			JSON.stringify(
+				{
+					name: "future",
+					apiUrl: "https://example.console.ves.volterra.io",
+					apiToken: "tok",
+					defaultNamespace: "default",
+					version: CURRENT_SCHEMA_VERSION + 1,
+				},
+				null,
+				2,
+			),
+			{ mode: 0o600 },
+		);
+
+		ProfileService.init(f5xcConfigDir);
+
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: "list", text: "/profile list" }, ctx);
+
+		expect(ctx.messages[0].type).toBe("status");
+		expect(ctx.messages[0].text).toContain("future");
+		expect(ctx.messages[0].text).toContain("upgrade required");
 	});
 });

--- a/packages/coding-agent/test/f5xc-profile-command.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-command.test.ts
@@ -592,6 +592,52 @@ describe("/profile slash command handler", () => {
 		expect(ctx.messages[0].text).toContain("upgrade required");
 	});
 
+	describe("error message actionability", () => {
+		it("/profile activate with no name shows usage with /profile list hint", async () => {
+			ProfileService.init(f5xcConfigDir);
+			const ctx = createMockCtx();
+			await handleProfileCommand({ name: "profile", args: "activate", text: "/profile activate" }, ctx);
+			expect(ctx.messages[0].type).toBe("error");
+			expect(ctx.messages[0].text).toContain("/profile list");
+		});
+
+		it("/profile show with no active profile shows create/activate hint", async () => {
+			ProfileService.init(f5xcConfigDir);
+			const ctx = createMockCtx();
+			await handleProfileCommand({ name: "profile", args: "show", text: "/profile show" }, ctx);
+			expect(ctx.messages[0].type).toBe("error");
+			expect(ctx.messages[0].text).toContain("/profile create");
+			expect(ctx.messages[0].text).toContain("/profile activate");
+		});
+
+		it("/profile show with unknown profile name shows /profile list hint", async () => {
+			ProfileService.init(f5xcConfigDir);
+			const ctx = createMockCtx();
+			await handleProfileCommand({ name: "profile", args: "show ghost", text: "/profile show ghost" }, ctx);
+			expect(ctx.messages[0].type).toBe("error");
+			expect(ctx.messages[0].text).toContain("ghost");
+			expect(ctx.messages[0].text).toContain("/profile list");
+		});
+
+		it("/profile delete active profile shows activate-other hint", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			const ctx = createMockCtx();
+			await handleProfileCommand(
+				{
+					name: "profile",
+					args: `delete ${TEST_PROFILE.name} --confirm`,
+					text: "/profile delete production --confirm",
+				},
+				ctx,
+			);
+			expect(ctx.messages[0].type).toBe("error");
+			expect(ctx.messages[0].text).toContain("/profile activate");
+		});
+	});
+
 	// --- /profile show metadata display ---
 
 	describe("/profile show metadata display", () => {

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -367,6 +367,36 @@ describe("ProfileService", () => {
 			const service = ProfileService.init(f5xcConfigDir);
 			await expect(service.activate("")).rejects.toThrow(/Invalid profile name/);
 		});
+
+		it("rejects activation when F5XC_API_URL set — error cites unset command", async () => {
+			process.env.F5XC_API_URL = "https://env.console.ves.volterra.io";
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			const service = ProfileService.init(f5xcConfigDir);
+			const err = await service.activate(TEST_PROFILE.name).catch(e => e);
+			expect(err.message).toContain("unset F5XC_API_URL");
+			expect(err.message).not.toContain("/profile env");
+		});
+
+		it("profile not found error cites /profile list", async () => {
+			fs.mkdirSync(f5xcProfilesDir, { recursive: true });
+			const service = ProfileService.init(f5xcConfigDir);
+			const err = await service.activate("ghost").catch(e => e);
+			expect(err.message).toContain("ghost");
+			expect(err.message).toContain("/profile list");
+		});
+	});
+
+	describe("setNamespace", () => {
+		it("setNamespace error cites /profile activate", () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			let err: Error | null = null;
+			try {
+				service.setNamespace("ns");
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toContain("/profile activate");
+		});
 	});
 
 	describe("getStatus", () => {

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -758,4 +758,200 @@ describe("ProfileService", () => {
 			expect(a).toBe(b);
 		});
 	});
+
+	describe("schema version", () => {
+		it("createProfile writes version: 1 to disk", async () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.createProfile({
+				name: "versioned",
+				apiUrl: "https://example.console.ves.volterra.io",
+				apiToken: "tok",
+				defaultNamespace: "default",
+			});
+			const raw = JSON.parse(fs.readFileSync(path.join(f5xcProfilesDir, "versioned.json"), "utf-8"));
+			expect(raw.version).toBe(1);
+		});
+
+		it("reading a legacy profile (no version field) succeeds", async () => {
+			fs.mkdirSync(f5xcProfilesDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(f5xcProfilesDir, "legacy.json"),
+				JSON.stringify(
+					{
+						name: "legacy",
+						apiUrl: "https://example.console.ves.volterra.io",
+						apiToken: "tok",
+						defaultNamespace: "default",
+					},
+					null,
+					2,
+				),
+				{ mode: 0o600 },
+			);
+			writeActiveProfile(f5xcConfigDir, "legacy");
+			const service = ProfileService.init(f5xcConfigDir);
+			const result = await service.loadActive();
+			expect(result).not.toBeNull();
+			expect((result as F5XCProfile).version).toBeUndefined();
+		});
+
+		it("reading a v1 profile succeeds", async () => {
+			fs.mkdirSync(f5xcProfilesDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(f5xcProfilesDir, "v1.json"),
+				JSON.stringify(
+					{
+						name: "v1",
+						apiUrl: "https://example.console.ves.volterra.io",
+						apiToken: "tok",
+						defaultNamespace: "default",
+						version: 1,
+					},
+					null,
+					2,
+				),
+				{ mode: 0o600 },
+			);
+			writeActiveProfile(f5xcConfigDir, "v1");
+			const service = ProfileService.init(f5xcConfigDir);
+			const result = await service.loadActive();
+			expect(result).not.toBeNull();
+			expect((result as F5XCProfile).version).toBe(1);
+		});
+
+		it("activate() rejects a v2 profile with actionable error", async () => {
+			fs.mkdirSync(f5xcProfilesDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(f5xcProfilesDir, "future.json"),
+				JSON.stringify(
+					{
+						name: "future",
+						apiUrl: "https://example.console.ves.volterra.io",
+						apiToken: "tok",
+						defaultNamespace: "default",
+						version: 2,
+					},
+					null,
+					2,
+				),
+				{ mode: 0o600 },
+			);
+			const service = ProfileService.init(f5xcConfigDir);
+			await expect(service.activate("future")).rejects.toThrow(/schema version 2/);
+			await expect(service.activate("future")).rejects.toThrow(/upgrade xcsh/i);
+		});
+
+		it("loadActive() returns null for a v2 profile — does not crash startup", async () => {
+			fs.mkdirSync(f5xcProfilesDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(f5xcProfilesDir, "future.json"),
+				JSON.stringify(
+					{
+						name: "future",
+						apiUrl: "https://example.console.ves.volterra.io",
+						apiToken: "tok",
+						defaultNamespace: "default",
+						version: 2,
+					},
+					null,
+					2,
+				),
+				{ mode: 0o600 },
+			);
+			writeActiveProfile(f5xcConfigDir, "future");
+			const service = ProfileService.init(f5xcConfigDir);
+			const result = await service.loadActive();
+			expect(result).toBeNull();
+		});
+
+		it("loadActive() does NOT persist auto-activate for an incompatible profile", async () => {
+			fs.mkdirSync(f5xcProfilesDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(f5xcProfilesDir, "future.json"),
+				JSON.stringify(
+					{
+						name: "future",
+						apiUrl: "https://example.console.ves.volterra.io",
+						apiToken: "tok",
+						defaultNamespace: "default",
+						version: 2,
+					},
+					null,
+					2,
+				),
+				{ mode: 0o600 },
+			);
+			// No active_profile file — triggers auto-activate path
+			const service = ProfileService.init(f5xcConfigDir);
+			const result = await service.loadActive();
+			expect(result).toBeNull();
+			expect(fs.existsSync(path.join(f5xcConfigDir, "active_profile"))).toBe(false);
+		});
+
+		it("setEnvVars() rejects a v2 profile before write-back", async () => {
+			fs.mkdirSync(f5xcProfilesDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(f5xcProfilesDir, "future.json"),
+				JSON.stringify(
+					{
+						name: "future",
+						apiUrl: "https://example.console.ves.volterra.io",
+						apiToken: "tok",
+						defaultNamespace: "default",
+						version: 2,
+					},
+					null,
+					2,
+				),
+				{ mode: 0o600 },
+			);
+			const service = ProfileService.init(f5xcConfigDir);
+			await expect(service.setEnvVars("future", { MY_KEY: "val" })).rejects.toThrow(/schema version 2/);
+		});
+
+		it("unsetEnvVars() rejects a v2 profile before write-back", async () => {
+			fs.mkdirSync(f5xcProfilesDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(f5xcProfilesDir, "future.json"),
+				JSON.stringify(
+					{
+						name: "future",
+						apiUrl: "https://example.console.ves.volterra.io",
+						apiToken: "tok",
+						defaultNamespace: "default",
+						version: 2,
+						env: { MY_KEY: "val" },
+					},
+					null,
+					2,
+				),
+				{ mode: 0o600 },
+			);
+			const service = ProfileService.init(f5xcConfigDir);
+			await expect(service.unsetEnvVars("future", ["MY_KEY"])).rejects.toThrow(/schema version 2/);
+		});
+
+		it("listProfiles() includes incompatible profiles (no gate)", async () => {
+			fs.mkdirSync(f5xcProfilesDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(f5xcProfilesDir, "future.json"),
+				JSON.stringify(
+					{
+						name: "future",
+						apiUrl: "https://example.console.ves.volterra.io",
+						apiToken: "tok",
+						defaultNamespace: "default",
+						version: 2,
+					},
+					null,
+					2,
+				),
+				{ mode: 0o600 },
+			);
+			const service = ProfileService.init(f5xcConfigDir);
+			const profiles = await service.listProfiles();
+			expect(profiles.length).toBe(1);
+			expect(profiles[0].version).toBe(2);
+		});
+	});
 });

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -954,4 +954,96 @@ describe("ProfileService", () => {
 			expect(profiles[0].version).toBe(2);
 		});
 	});
+
+	describe("validateToken", () => {
+		let savedFetch: typeof globalThis.fetch;
+
+		beforeEach(() => {
+			savedFetch = globalThis.fetch;
+		});
+
+		afterEach(() => {
+			globalThis.fetch = savedFetch;
+		});
+
+		function makeMockResponse(status: number): typeof globalThis.fetch {
+			const fn = () => Promise.resolve(new Response(status === 200 ? "ok" : "err", { status }));
+			return fn as unknown as typeof globalThis.fetch;
+		}
+
+		function makeNetworkError(): typeof globalThis.fetch {
+			const fn = () => Promise.reject(new Error("network failure"));
+			return fn as unknown as typeof globalThis.fetch;
+		}
+
+		it("200 response returns connected with latencyMs, no errorClass", async () => {
+			globalThis.fetch = makeMockResponse(200);
+			const service = ProfileService.init(f5xcConfigDir);
+			const result = await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(result.status).toBe("connected");
+			expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+			expect(result.errorClass).toBeUndefined();
+		});
+
+		it("401 response returns auth_error with errorClass: credential", async () => {
+			globalThis.fetch = makeMockResponse(401);
+			const service = ProfileService.init(f5xcConfigDir);
+			const result = await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(result.status).toBe("auth_error");
+			expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+			expect(result.errorClass).toBe("credential");
+		});
+
+		it("403 response returns auth_error with errorClass: credential", async () => {
+			globalThis.fetch = makeMockResponse(403);
+			const service = ProfileService.init(f5xcConfigDir);
+			const result = await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(result.status).toBe("auth_error");
+			expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+			expect(result.errorClass).toBe("credential");
+		});
+
+		it("500 response returns offline with errorClass: network and latencyMs (was 'connected')", async () => {
+			globalThis.fetch = makeMockResponse(500);
+			const service = ProfileService.init(f5xcConfigDir);
+			const result = await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(result.status).toBe("offline");
+			expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+			expect(result.errorClass).toBe("network");
+		});
+
+		it("502 response returns offline with errorClass: network (was 'connected')", async () => {
+			globalThis.fetch = makeMockResponse(502);
+			const service = ProfileService.init(f5xcConfigDir);
+			const result = await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(result.status).toBe("offline");
+			expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+			expect(result.errorClass).toBe("network");
+		});
+
+		it("429 response returns offline with errorClass: network", async () => {
+			globalThis.fetch = makeMockResponse(429);
+			const service = ProfileService.init(f5xcConfigDir);
+			const result = await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(result.status).toBe("offline");
+			expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+			expect(result.errorClass).toBe("network");
+		});
+
+		it("network error returns offline with errorClass: network, no latencyMs", async () => {
+			globalThis.fetch = makeNetworkError();
+			const service = ProfileService.init(f5xcConfigDir);
+			const result = await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(result.status).toBe("offline");
+			expect(result.latencyMs).toBeUndefined();
+			expect(result.errorClass).toBe("network");
+		});
+
+		it("missing credentials returns unknown with no errorClass", async () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			const result = await service.validateToken({});
+			expect(result.status).toBe("unknown");
+			expect(result.errorClass).toBeUndefined();
+		});
+	});
 });

--- a/packages/coding-agent/test/f5xc-table.test.ts
+++ b/packages/coding-agent/test/f5xc-table.test.ts
@@ -84,7 +84,7 @@ describe("renderF5XCTable", () => {
 			{ key: "F5XC_NAMESPACE", value: "default" },
 			{ key: "F5XC_CUSTOM_VAR", value: "some-value" },
 		];
-		const output = renderF5XCTable("myorg", rows, { dividerBefore: 2 });
+		const output = renderF5XCTable("myorg", rows, { dividers: [{ before: 2, label: "Environment" }] });
 		const lines = output.split("\n");
 		const widths = lines.map(l => vw(l));
 		expect(new Set(widths).size).toBe(1);


### PR DESCRIPTION
## Summary

Completes five partially-implemented `/profile` features (phase 2 of 7):

- **Schema version gate** — profiles written by future xcsh versions carry `version: N`. Activation and write-back paths reject incompatible versions to prevent silent data loss. `/profile list` shows a version warning suffix.
- **Fix 5xx misclassification** — `validateToken` previously returned `"connected"` for 5xx responses, showing a green checkmark and bypassing startup retry. Now returns `"offline"` with `errorClass: "network"`. 401/403 carry `errorClass: "credential"`.
- **Metadata display** — `/profile show` displays a Metadata section (createdAt, expiresAt with expiry warning, lastRotatedAt, rotateAfterDays). Table renderer generalized from single hardcoded divider to named dividers array.
- **Actionable error messages** — all 7 error paths now include what command to run next.
- **Dead code removal** — `watcherActive` field removed (merged separately in #285).

## Test plan

- [x] 145 profile tests pass (45 new), 0 fail
- [x] TypeScript clean
- [x] 4 commits in dependency order (2.4 → 2.3 → 2.1 → 2.5)

Closes #273

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>