### PR TITLE
feat(coding-agent): /profile [4/7] profile-identity integration

### DIFF
--- a/packages/coding-agent/src/internal-urls/build-info-runtime.ts
+++ b/packages/coding-agent/src/internal-urls/build-info-runtime.ts
@@ -114,7 +114,11 @@ function renderAuthStatusLine(profile: ProfileStatus, nowMs: number): string {
 }
 
 function renderPlatformContext(profile: ProfileStatus | null, nowMs: number): string {
-	if (!profile?.isConfigured || !profile.activeProfileName || !profile.activeProfileTenant) {
+	// xcsh can be connected via a named profile OR via F5XC_API_URL / F5XC_API_TOKEN env vars.
+	// In the env-only case, activeProfileName is null but activeProfileTenant (derived from the
+	// env URL) and credentialSource ("environment") are still populated. Guard on tenant, not
+	// name, so env-backed deployments see the configured state instead of the unconfigured copy.
+	if (!profile?.isConfigured || !profile.activeProfileTenant) {
 		return [
 			"## Current Platform Context",
 			"",
@@ -125,7 +129,7 @@ function renderPlatformContext(profile: ProfileStatus | null, nowMs: number): st
 
 	const authLine = renderAuthStatusLine(profile, nowMs);
 	const credentialLine = `**Credential Source:** ${profile.credentialSource}${
-		profile.credentialSource === "profile" ? ` (name: ${profile.activeProfileName})` : ""
+		profile.credentialSource === "profile" && profile.activeProfileName ? ` (name: ${profile.activeProfileName})` : ""
 	}`;
 
 	return [

--- a/packages/coding-agent/src/internal-urls/build-info-runtime.ts
+++ b/packages/coding-agent/src/internal-urls/build-info-runtime.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { $ } from "bun";
+import type { ProfileStatus } from "../services/f5xc-profile";
 import { BUILD_INFO, type BuildInfo } from "./build-info.generated";
 
 export type BuildInfoSource = "compiled" | "live-git" | "embedded-fallback";
@@ -82,7 +83,63 @@ export async function resolveRuntimeBuildInfo(
 	};
 }
 
-export function renderAboutDoc(info: RuntimeBuildInfo): string {
+/**
+ * Format an epoch-ms timestamp relative to `now` as a human-readable string.
+ * Buckets: sub-60s -> "just now"; 1-59 min -> "N min ago";
+ * 1-23 h -> "N hour(s) ago"; 24 h+ -> "N day(s) ago".
+ * Exported for testability; consumed only by renderAboutDoc.
+ */
+export function formatRelativeTime(epochMs: number, nowMs: number): string {
+	const deltaMs = Math.max(0, nowMs - epochMs);
+	if (deltaMs < 60_000) return "just now";
+	if (deltaMs < 60 * 60_000) {
+		const mins = Math.floor(deltaMs / 60_000);
+		return `${mins} min ago`;
+	}
+	if (deltaMs < 24 * 60 * 60_000) {
+		const hours = Math.floor(deltaMs / (60 * 60_000));
+		return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+	}
+	const days = Math.floor(deltaMs / (24 * 60 * 60_000));
+	return `${days} day${days === 1 ? "" : "s"} ago`;
+}
+
+function renderAuthStatusLine(profile: ProfileStatus, nowMs: number): string {
+	const base = `**Auth Status:** ${profile.authStatus}`;
+	if (profile.authLatencyMs === undefined || profile.authCheckedAt === undefined) {
+		return base;
+	}
+	const checked = formatRelativeTime(profile.authCheckedAt, nowMs);
+	return `${base} (latency: ${profile.authLatencyMs}ms, checked: ${checked})`;
+}
+
+function renderPlatformContext(profile: ProfileStatus | null, nowMs: number): string {
+	if (!profile?.isConfigured || !profile.activeProfileName || !profile.activeProfileTenant) {
+		return [
+			"## Current Platform Context",
+			"",
+			"No F5 XC profile active. Run `/profile create` or `/profile activate` to connect.",
+			"",
+		].join("\n");
+	}
+
+	const authLine = renderAuthStatusLine(profile, nowMs);
+	const credentialLine = `**Credential Source:** ${profile.credentialSource}${
+		profile.credentialSource === "profile" ? ` (name: ${profile.activeProfileName})` : ""
+	}`;
+
+	return [
+		"## Current Platform Context",
+		"",
+		`- **Tenant:** ${profile.activeProfileTenant}`,
+		`- **Namespace:** ${profile.activeProfileNamespace ?? "default"}`,
+		`- ${authLine}`,
+		`- ${credentialLine}`,
+		"",
+	].join("\n");
+}
+
+export function renderAboutDoc(info: RuntimeBuildInfo, profile: ProfileStatus | null): string {
 	return [
 		"# xcsh — identity and build fingerprint",
 		"",
@@ -102,6 +159,7 @@ export function renderAboutDoc(info: RuntimeBuildInfo): string {
 		`- PR that shipped this version: ${info.prNumber ? `#${info.prNumber}` : "unknown (resolve via gh if needed)"}`,
 		`- Provenance source: \`${info.source}\` (resolved at ${info.resolvedAt})`,
 		"",
+		renderPlatformContext(profile, Date.now()),
 		"## Source of truth",
 		"",
 		`- Repository: ${info.repoUrl}`,

--- a/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
@@ -10,6 +10,7 @@
  * - xcsh://about - Identity fingerprint (version, commit, branch, repo)
  */
 import * as path from "node:path";
+import type { ProfileStatus } from "../services/f5xc-profile";
 import { getRuntimeBuildInfo, type RuntimeBuildInfo, renderAboutDoc } from "./build-info-runtime";
 import { EMBEDDED_DOC_FILENAMES, EMBEDDED_DOCS } from "./docs-index.generated";
 import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
@@ -20,6 +21,8 @@ const ABOUT_ROUTE = "about";
 export interface InternalDocsProtocolOptions {
 	/** Override runtime build-info resolution. Primarily for tests. */
 	readonly resolveBuildInfo?: () => Promise<RuntimeBuildInfo>;
+	/** Sync getter returning the current profile status (or null if unconfigured / unavailable). */
+	readonly getProfileStatus?: () => ProfileStatus | null;
 }
 
 /**
@@ -31,9 +34,11 @@ export interface InternalDocsProtocolOptions {
 export class InternalDocsProtocolHandler implements ProtocolHandler {
 	readonly scheme = "xcsh";
 	readonly #resolveBuildInfo: () => Promise<RuntimeBuildInfo>;
+	readonly #getProfileStatus: (() => ProfileStatus | null) | undefined;
 
 	constructor(options: InternalDocsProtocolOptions = {}) {
 		this.#resolveBuildInfo = options.resolveBuildInfo ?? getRuntimeBuildInfo;
+		this.#getProfileStatus = options.getProfileStatus;
 	}
 
 	async resolve(url: InternalUrl): Promise<InternalResource> {
@@ -79,7 +84,8 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 
 		if (normalized === ABOUT_ROUTE || normalized === `${ABOUT_ROUTE}.md`) {
 			const info = await this.#resolveBuildInfo();
-			const content = renderAboutDoc(info);
+			const profile = this.#getProfileStatus?.() ?? null;
+			const content = renderAboutDoc(info, profile);
 			return {
 				url: url.href,
 				content,

--- a/packages/coding-agent/src/prompts/system/custom-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/custom-system-prompt.md
@@ -30,6 +30,14 @@ Main branch: {{git.mainBranch}}
 {{/if}}
 </project>
 {{/ifAny}}
+{{#if profile}}
+## F5 XC Platform Context
+
+You are currently connected to F5 XC tenant: {{profile.tenant}}, namespace: {{profile.namespace}}.
+Credential source: {{profile.credentialSource}}.
+Auth status: {{profile.authStatus}}.
+All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.
+{{/if}}
 {{#if skills.length}}
 Skills are specialized knowledge.
 You **MUST** scan descriptions for your task domain.

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -133,6 +133,15 @@ Configs you didn't validate become incidents. Assumptions you didn't test fail u
 {{#list environment prefix="- " join="\n"}}{{label}}: {{value}}{{/list}}
 </workstation>
 
+{{#if profile}}
+## F5 XC Platform Context
+
+You are currently connected to F5 XC tenant: {{profile.tenant}}, namespace: {{profile.namespace}}.
+Credential source: {{profile.credentialSource}}.
+Auth status: {{profile.authStatus}}.
+All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.
+{{/if}}
+
 {{#if contextFiles.length}}
 <context>
 Context files below **MUST** be followed for all tasks:

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -735,9 +735,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	}
 	const secretsEnabled = obfuscator?.hasSecrets() === true;
 
+	// Capture ProfileService reference for sync consumers (e.g., InternalDocsProtocolHandler's
+	// getProfileStatus getter below). Null when ProfileService isn't available (SDK consumers, tests).
+	let profileServiceRef: typeof import("./services/f5xc-profile").ProfileService | null = null;
+
 	// Register profile-change listener to refresh obfuscator when /profile activate runs.
 	try {
 		const { ProfileService } = await import("./services/f5xc-profile");
+		profileServiceRef = ProfileService;
 		ProfileService.onProfileChange(profile => {
 			const newValues: string[] = [profile.apiToken];
 			if (profile.sensitiveKeys && profile.env) {
@@ -1056,7 +1061,18 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				getRules: () => [...rulebookRules, ...alwaysApplyRules],
 			}),
 		);
-		internalRouter.register(new InternalDocsProtocolHandler());
+		internalRouter.register(
+			new InternalDocsProtocolHandler({
+				getProfileStatus: () => {
+					try {
+						return profileServiceRef?.instance?.getStatus() ?? null;
+					} catch {
+						// ProfileService.instance throws if not initialized; ignore.
+						return null;
+					}
+				},
+			}),
+		);
 		internalRouter.register(new JobsProtocolHandler({ getAsyncJobManager: () => asyncJobManager }));
 		internalRouter.register(new McpProtocolHandler({ getMcpManager: () => mcpManager }));
 		toolSession.internalRouter = internalRouter;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -743,6 +743,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	try {
 		const { ProfileService } = await import("./services/f5xc-profile");
 		profileServiceRef = ProfileService;
+
+		// Track the profile name the LLM was last told about. Seed with the session-start name
+		// (set by the createAgentSession profile_change emission below) so re-activating the same
+		// profile, or firing the listener for settings-only events (/profile env set|unset, /profile
+		// namespace), does NOT produce a spurious "Profile switched" directive. The listener is
+		// shared across all #applyToSettings call paths in ProfileService — activate, setNamespace,
+		// setEnvVars, unsetEnvVars, loadActive — and only profile activation should notify the LLM.
+		let lastEmittedProfileName: string | undefined =
+			ProfileService.instance?.getStatus()?.activeProfileName ?? undefined;
+
 		ProfileService.onProfileChange(profile => {
 			const newValues: string[] = [profile.apiToken];
 			if (profile.sensitiveKeys && profile.env) {
@@ -766,6 +776,33 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				if (entries.length > 0) {
 					obfuscator = new SecretObfuscator(entries);
 				}
+			}
+
+			// After obfuscator update, emit profile_change + custom_message entries only when the
+			// ACTIVE PROFILE NAME actually changed. Settings-only events (env vars, namespace edit)
+			// also fire this listener but do not constitute a profile switch from the LLM's
+			// perspective. Scenario 4 regression test: when session starts with no profile and
+			// the user activates mid-session, lastEmittedProfileName is undefined and currentName
+			// is truthy, so the guard correctly emits.
+			// Read ProfileService.getStatus() (not derived from the callback arg) to stay consistent
+			// with session-start emission, which honors the F5XC_NAMESPACE env override.
+			try {
+				const currentStatus = profileServiceRef?.instance?.getStatus();
+				const currentName = currentStatus?.activeProfileName ?? undefined;
+				if (currentName && currentStatus?.activeProfileTenant && currentName !== lastEmittedProfileName) {
+					const namespace = currentStatus.activeProfileNamespace ?? "default";
+					sessionManager.appendProfileChange(currentName, currentStatus.activeProfileTenant, namespace);
+					sessionManager.appendCustomMessageEntry(
+						"profile_change_notice",
+						`[Profile switched to ${currentName}] Tenant: ${currentStatus.activeProfileTenant}, ` +
+							`namespace: ${namespace}. Target this tenant and namespace ` +
+							`for subsequent F5 XC operations.`,
+						true,
+					);
+					lastEmittedProfileName = currentName;
+				}
+			} catch {
+				// ProfileService.instance throws if not initialized; skip.
 			}
 		});
 	} catch {
@@ -1367,6 +1404,26 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			});
 			const memoryInstructions = await buildMemoryToolDeveloperInstructions(agentDir, settings);
 
+			// Resolve F5 XC profile context for the prompt. Read fresh each rebuild so tool-triggered
+			// rebuilds reflect the most recent /profile activate. Mid-session profile changes without a
+			// tool change are handled via custom_message injection in the onProfileChange listener.
+			let profileForPrompt:
+				| { tenant: string; namespace: string; credentialSource: string; authStatus: string }
+				| undefined;
+			try {
+				const status = profileServiceRef?.instance?.getStatus();
+				if (status?.isConfigured && status.activeProfileName && status.activeProfileTenant) {
+					profileForPrompt = {
+						tenant: status.activeProfileTenant,
+						namespace: status.activeProfileNamespace ?? "default",
+						credentialSource: status.credentialSource,
+						authStatus: status.authStatus,
+					};
+				}
+			} catch {
+				// ProfileService not available or not initialized — leave profileForPrompt undefined.
+			}
+
 			// Build combined append prompt: memory instructions + MCP server instructions
 			const serverInstructions = mcpManager?.getServerInstructions();
 			let appendPrompt: string | undefined = memoryInstructions ?? undefined;
@@ -1402,6 +1459,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				mcpDiscoveryServerSummaries: discoverableMCPSummary.servers.map(formatDiscoverableMCPToolServerSummary),
 				eagerTasks,
 				secretsEnabled,
+				profile: profileForPrompt,
 			});
 
 			if (options.systemPrompt === undefined) {
@@ -1425,6 +1483,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					mcpDiscoveryServerSummaries: discoverableMCPSummary.servers.map(formatDiscoverableMCPToolServerSummary),
 					eagerTasks,
 					secretsEnabled,
+					profile: profileForPrompt,
 				});
 			}
 			return options.systemPrompt(defaultPrompt);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1616,6 +1616,20 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				sessionManager.appendModelChange(`${model.provider}/${model.id}`);
 			}
 			sessionManager.appendThinkingLevelChange(thinkingLevel);
+			// Save active profile (if any) so resumed sessions know their platform context.
+			try {
+				const { ProfileService } = await import("./services/f5xc-profile");
+				const status = ProfileService.instance?.getStatus();
+				if (status?.isConfigured && status.activeProfileName && status.activeProfileTenant) {
+					sessionManager.appendProfileChange(
+						status.activeProfileName,
+						status.activeProfileTenant,
+						status.activeProfileNamespace ?? "default",
+					);
+				}
+			} catch {
+				// ProfileService not available (SDK consumers, tests). Skip.
+			}
 		}
 
 		session = new AgentSession({

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -739,21 +739,25 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	// getProfileStatus getter below). Null when ProfileService isn't available (SDK consumers, tests).
 	let profileServiceRef: typeof import("./services/f5xc-profile").ProfileService | null = null;
 
-	// Register profile-change listener to refresh obfuscator when /profile activate runs.
+	// Register profile-change listener to refresh obfuscator and notify the LLM when /profile activate runs.
+	// The callback is captured as a named const so the `addDisposeHook` call below can unregister it;
+	// otherwise listeners accumulate across createAgentSession calls (SDK/ACP multi-session flows) and
+	// fire on disposed sessions.
+	let profileChangeListener: ((profile: import("./services/f5xc-profile").F5XCProfile) => void) | null = null;
 	try {
 		const { ProfileService } = await import("./services/f5xc-profile");
 		profileServiceRef = ProfileService;
 
 		// Track the profile name the LLM was last told about. Seed with the session-start name
-		// (set by the createAgentSession profile_change emission below) so re-activating the same
-		// profile, or firing the listener for settings-only events (/profile env set|unset, /profile
-		// namespace), does NOT produce a spurious "Profile switched" directive. The listener is
-		// shared across all #applyToSettings call paths in ProfileService — activate, setNamespace,
-		// setEnvVars, unsetEnvVars, loadActive — and only profile activation should notify the LLM.
+		// so re-activating the same profile, or firing the listener for settings-only events
+		// (/profile env set|unset, /profile namespace), does NOT produce a spurious "Profile
+		// switched" directive. The listener is shared across all #applyToSettings call paths in
+		// ProfileService — activate, setNamespace, setEnvVars, unsetEnvVars, loadActive — and only
+		// an actual profile switch should notify the LLM.
 		let lastEmittedProfileName: string | undefined =
 			ProfileService.instance?.getStatus()?.activeProfileName ?? undefined;
 
-		ProfileService.onProfileChange(profile => {
+		profileChangeListener = profile => {
 			const newValues: string[] = [profile.apiToken];
 			if (profile.sensitiveKeys && profile.env) {
 				for (const key of profile.sensitiveKeys) {
@@ -778,12 +782,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				}
 			}
 
-			// After obfuscator update, emit profile_change + custom_message entries only when the
-			// ACTIVE PROFILE NAME actually changed. Settings-only events (env vars, namespace edit)
-			// also fire this listener but do not constitute a profile switch from the LLM's
-			// perspective. Scenario 4 regression test: when session starts with no profile and
-			// the user activates mid-session, lastEmittedProfileName is undefined and currentName
-			// is truthy, so the guard correctly emits.
+			// After obfuscator update, notify the LLM of the profile switch — but ONLY when the
+			// active profile name actually changed. Scenario 4 regression test: when session
+			// starts with no profile and the user activates mid-session, lastEmittedProfileName
+			// is undefined and currentName is truthy, so the guard correctly emits.
 			// Read ProfileService.getStatus() (not derived from the callback arg) to stay consistent
 			// with session-start emission, which honors the F5XC_NAMESPACE env override.
 			try {
@@ -791,20 +793,32 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				const currentName = currentStatus?.activeProfileName ?? undefined;
 				if (currentName && currentStatus?.activeProfileTenant && currentName !== lastEmittedProfileName) {
 					const namespace = currentStatus.activeProfileNamespace ?? "default";
+
+					// Append the profile_change entry for replay/resume state reconstruction.
 					sessionManager.appendProfileChange(currentName, currentStatus.activeProfileTenant, namespace);
-					sessionManager.appendCustomMessageEntry(
-						"profile_change_notice",
-						`[Profile switched to ${currentName}] Tenant: ${currentStatus.activeProfileTenant}, ` +
+
+					// Push a custom_message into BOTH agent.state.messages AND the session log so
+					// the LLM sees the directive on its next turn. Using sessionManager.append*
+					// alone would persist to the log but leave agent.state stale until compaction
+					// or session reload — the LLM's active context wouldn't see the switch.
+					// sendCustomMessage handles streaming vs non-streaming correctly (queues
+					// via steer/followUp/nextTurn when a turn is in flight).
+					void session.sendCustomMessage({
+						customType: "profile_change_notice",
+						content:
+							`[Profile switched to ${currentName}] Tenant: ${currentStatus.activeProfileTenant}, ` +
 							`namespace: ${namespace}. Target this tenant and namespace ` +
 							`for subsequent F5 XC operations.`,
-						true,
-					);
+						display: true,
+						attribution: "agent",
+					});
 					lastEmittedProfileName = currentName;
 				}
 			} catch {
 				// ProfileService.instance throws if not initialized; skip.
 			}
-		});
+		};
+		ProfileService.onProfileChange(profileChangeListener);
 	} catch {
 		// ProfileService not available — skip
 	}
@@ -1412,7 +1426,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				| undefined;
 			try {
 				const status = profileServiceRef?.instance?.getStatus();
-				if (status?.isConfigured && status.activeProfileName && status.activeProfileTenant) {
+				// The LLM needs to anchor on tenant + namespace regardless of whether credentials
+				// come from a named profile or from F5XC_API_URL/F5XC_API_TOKEN env vars. For the
+				// env-only path, activeProfileName is null but activeProfileTenant (derived from
+				// F5XC_API_URL) is still set and credentialSource is "environment". Guard on
+				// tenant, not name, so env-backed deployments also get the prompt anchor.
+				if (status?.isConfigured && status.activeProfileTenant) {
 					profileForPrompt = {
 						tenant: status.activeProfileTenant,
 						namespace: status.activeProfileNamespace ?? "default",
@@ -1737,6 +1756,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			asyncJobManager,
 		});
 		hasSession = true;
+
+		// Unregister the profile-change listener when the session is disposed. Without this, each
+		// createAgentSession() call leaks a listener that closes over this session's sessionManager
+		// and `session`, so a /profile activate fire in a later session would also mutate disposed
+		// sessions' state (bogus profile_change entries, custom_message injection on a dead agent).
+		if (profileChangeListener && profileServiceRef) {
+			const listener = profileChangeListener;
+			const service = profileServiceRef;
+			session.addDisposeHook(() => service.offProfileChange(listener));
+		}
 
 		if (model?.api === "openai-codex-responses") {
 			const codexModel = model;

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -138,6 +138,10 @@ export class ProfileService {
 
 	static _resetForTest(): void {
 		ProfileService.#instance = null;
+		// Clear listeners to prevent cross-test contamination. Each createAgentSession() call
+		// registers a listener closed over that session's sessionManager; without this reset,
+		// listeners from a disposed session persist into the next test and fire on activate().
+		ProfileService.#onProfileChangeListeners = [];
 	}
 
 	get profilesDir(): string {

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -66,6 +66,15 @@ export class ProfileService {
 		ProfileService.#onProfileChangeListeners.push(cb);
 	}
 
+	/**
+	 * Remove a previously-registered profile-change callback. No-op if the callback isn't registered.
+	 * Call on session disposal to prevent leaked listeners from mutating dead session state.
+	 */
+	static offProfileChange(cb: (profile: F5XCProfile) => void): void {
+		const idx = ProfileService.#onProfileChangeListeners.indexOf(cb);
+		if (idx >= 0) ProfileService.#onProfileChangeListeners.splice(idx, 1);
+	}
+
 	#configDir: string;
 	#activeProfile: F5XCProfile | null = null;
 	#credentialSource: ProfileStatus["credentialSource"] = "none";

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -41,6 +41,10 @@ export interface ProfileStatus {
 	credentialSource: "profile" | "environment" | "mixed" | "none";
 	authStatus: AuthStatus;
 	isConfigured: boolean;
+	/** Milliseconds measured by the most recent validateToken() call. Absent if validateToken has not run. */
+	authLatencyMs?: number;
+	/** Epoch ms of the most recent validateToken() call. Absent if validateToken has not run. */
+	authCheckedAt?: number;
 }
 
 export class ProfileError extends Error {
@@ -66,6 +70,8 @@ export class ProfileService {
 	#activeProfile: F5XCProfile | null = null;
 	#credentialSource: ProfileStatus["credentialSource"] = "none";
 	#authStatus: AuthStatus = "unknown";
+	#lastAuthLatencyMs: number | undefined;
+	#lastAuthCheckedAt: number | undefined;
 
 	private constructor(configDir: string) {
 		this.#configDir = configDir;
@@ -221,6 +227,14 @@ export class ProfileService {
 		this.#activeProfile = profile;
 		this.#applyToSettings(profile);
 		this.#credentialSource = hasEnvOverride() ? "mixed" : "profile";
+
+		// Invalidate auth-freshness cache on profile switch — the previous profile's latency
+		// and "checked N min ago" timestamp are stale now that a different tenant is active.
+		// Subsequent validateToken() (e.g., from /profile status) repopulates these fields.
+		this.#authStatus = "unknown";
+		this.#lastAuthLatencyMs = undefined;
+		this.#lastAuthCheckedAt = undefined;
+
 		return profile;
 	}
 
@@ -349,6 +363,7 @@ export class ProfileService {
 		if (!effectiveUrl || !effectiveToken) return { status: "unknown" };
 		const url = `${effectiveUrl}/api/web/namespaces`;
 		const timeout = options?.timeoutMs ?? 3000;
+		const checkedAt = Date.now();
 		try {
 			const start = performance.now();
 			const response = await fetch(url, {
@@ -357,6 +372,8 @@ export class ProfileService {
 				signal: AbortSignal.timeout(timeout),
 			});
 			const latencyMs = Math.round(performance.now() - start);
+			this.#lastAuthLatencyMs = latencyMs;
+			this.#lastAuthCheckedAt = checkedAt;
 			if (response.ok) {
 				this.#authStatus = "connected";
 				return { status: "connected", latencyMs };
@@ -369,6 +386,8 @@ export class ProfileService {
 			this.#authStatus = "offline";
 			return { status: "offline", latencyMs, errorClass: "network" };
 		} catch {
+			this.#lastAuthLatencyMs = Date.now() - checkedAt;
+			this.#lastAuthCheckedAt = checkedAt;
 			this.#authStatus = "offline";
 			return { status: "offline", errorClass: "network" };
 		}
@@ -395,6 +414,8 @@ export class ProfileService {
 			credentialSource: this.#credentialSource,
 			authStatus: this.#authStatus,
 			isConfigured: this.#credentialSource !== "none",
+			authLatencyMs: this.#lastAuthLatencyMs,
+			authCheckedAt: this.#lastAuthCheckedAt,
 		};
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -428,6 +428,10 @@ export class AgentSession {
 	#unsubscribeAgent?: () => void;
 	#eventListeners: AgentSessionEventListener[] = [];
 
+	// Callers (e.g., SDK-level code that registers external listeners) register cleanups here so
+	// dispose() unregisters them. Prevents leaked listeners from mutating dead session state.
+	#disposeHooks: Array<() => void | Promise<void>> = [];
+
 	/** Tracks pending steering messages for UI display. Removed when delivered. */
 	#steeringMessages: string[] = [];
 	/** Tracks pending follow-up messages for UI display. Removed when delivered. */
@@ -1828,6 +1832,15 @@ export class AgentSession {
 	}
 
 	/**
+	 * Register a cleanup callback to run during dispose(). Use for unregistering
+	 * external listeners (e.g., ProfileService.onProfileChange) that close over
+	 * this session's state and would otherwise leak after disposal.
+	 */
+	addDisposeHook(hook: () => void | Promise<void>): void {
+		this.#disposeHooks.push(hook);
+	}
+
+	/**
 	 * Remove all listeners, flush pending writes, and disconnect from agent.
 	 * Call this when completely done with the session.
 	 */
@@ -1859,6 +1872,16 @@ export class AgentSession {
 		this.#closeAllProviderSessions("dispose");
 		this.#disconnectFromAgent();
 		this.#eventListeners = [];
+
+		// Run caller-registered cleanups last so they observe a fully-torn-down session.
+		for (const hook of this.#disposeHooks) {
+			try {
+				await hook();
+			} catch (error) {
+				logger.warn("AgentSession dispose hook threw", { error: String(error) });
+			}
+		}
+		this.#disposeHooks = [];
 	}
 
 	#closeAllProviderSessions(reason: string): void {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -93,6 +93,16 @@ export interface ModelChangeEntry extends SessionEntryBase {
 	role?: string;
 }
 
+export interface ProfileChangeEntry extends SessionEntryBase {
+	type: "profile_change";
+	/** Profile name from ProfileStatus.activeProfileName. */
+	profileName: string;
+	/** Tenant derived from the active profile's apiUrl. */
+	tenant: string;
+	/** Effective namespace (F5XC_NAMESPACE env override applied, falls back to profile.defaultNamespace). */
+	namespace: string;
+}
+
 export interface ServiceTierChangeEntry extends SessionEntryBase {
 	type: "service_tier_change";
 	serviceTier: ServiceTier | null;
@@ -208,6 +218,7 @@ export type SessionEntry =
 	| SessionMessageEntry
 	| ThinkingLevelChangeEntry
 	| ModelChangeEntry
+	| ProfileChangeEntry
 	| ServiceTierChangeEntry
 	| CompactionEntry
 	| BranchSummaryEntry
@@ -236,6 +247,10 @@ export interface SessionContext {
 	serviceTier?: ServiceTier;
 	/** Model roles: { default: "provider/modelId", small: "provider/modelId", ... } */
 	models: Record<string, string>;
+	/** Active profile name from the last profile_change entry, or undefined if none. */
+	activeProfileName?: string;
+	/** Active profile tenant from the last profile_change entry, or undefined if none. */
+	activeProfileTenant?: string;
 	/** Names of TTSR rules that have been injected this session */
 	injectedTtsrRules: string[];
 	/** MCP tool names selected through discovery for this session branch. */
@@ -552,6 +567,8 @@ export function buildSessionContext(
 	let thinkingLevel: string | undefined = "off";
 	let serviceTier: ServiceTier | undefined;
 	const models: Record<string, string> = {};
+	let activeProfileName: string | undefined;
+	let activeProfileTenant: string | undefined;
 	let compaction: CompactionEntry | null = null;
 	const injectedTtsrRulesSet = new Set<string>();
 	let selectedMCPToolNames: string[] = [];
@@ -568,6 +585,9 @@ export function buildSessionContext(
 				const role = entry.role ?? "default";
 				models[role] = entry.model;
 			}
+		} else if (entry.type === "profile_change") {
+			activeProfileName = entry.profileName;
+			activeProfileTenant = entry.tenant;
 		} else if (entry.type === "service_tier_change") {
 			serviceTier = entry.serviceTier ?? undefined;
 		} else if (entry.type === "message" && entry.message.role === "assistant") {
@@ -677,6 +697,8 @@ export function buildSessionContext(
 		thinkingLevel,
 		serviceTier,
 		models,
+		activeProfileName,
+		activeProfileTenant,
 		injectedTtsrRules,
 		selectedMCPToolNames,
 		hasPersistedMCPToolSelection,
@@ -2153,6 +2175,26 @@ export class SessionManager {
 			timestamp: new Date().toISOString(),
 			model,
 			role,
+		};
+		this.#appendEntry(entry);
+		return entry.id;
+	}
+
+	/**
+	 * Append a profile change as child of current leaf, then advance leaf. Returns entry id.
+	 * @param profileName Profile name from ProfileStatus.activeProfileName
+	 * @param tenant Tenant derived from the active profile's apiUrl
+	 * @param namespace Effective namespace (F5XC_NAMESPACE env override applied, falls back to profile.defaultNamespace)
+	 */
+	appendProfileChange(profileName: string, tenant: string, namespace: string): string {
+		const entry: ProfileChangeEntry = {
+			type: "profile_change",
+			id: generateId(this.#byId),
+			parentId: this.#leafId,
+			timestamp: new Date().toISOString(),
+			profileName,
+			tenant,
+			namespace,
 		};
 		this.#appendEntry(entry);
 		return entry.id;

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -434,6 +434,13 @@ export interface BuildSystemPromptOptions {
 	alwaysApplyRules?: AlwaysApplyRule[];
 	/** Whether secret obfuscation is active. When true, explains the redaction format in the prompt. */
 	secretsEnabled?: boolean;
+	/** Active F5 XC profile context for the `{{#if profile}}` template block. Omit when no profile is active. */
+	profile?: {
+		tenant: string;
+		namespace: string;
+		credentialSource: string;
+		authStatus: string;
+	};
 }
 
 /** Build the system prompt with tools, guidelines, and context */
@@ -459,6 +466,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		mcpDiscoveryServerSummaries = [],
 		eagerTasks = false,
 		secretsEnabled = false,
+		profile,
 	} = options;
 	const resolvedCwd = cwd ?? getProjectDir();
 
@@ -607,6 +615,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		mcpDiscoveryServerSummaries,
 		eagerTasks,
 		secretsEnabled,
+		profile,
 	};
 	let rendered = prompt.render(resolvedCustomPrompt ? customSystemPromptTemplate : systemPromptTemplate, data);
 

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1076,4 +1076,95 @@ describe("ProfileService", () => {
 			expect(result.errorClass).toBeUndefined();
 		});
 	});
+
+	describe("ProfileService.validateToken auth freshness cache", () => {
+		let savedFetch: typeof globalThis.fetch;
+
+		beforeEach(() => {
+			savedFetch = globalThis.fetch;
+		});
+
+		afterEach(() => {
+			globalThis.fetch = savedFetch;
+		});
+
+		function makeMockResponse(status: number): typeof globalThis.fetch {
+			const fn = () => Promise.resolve(new Response(status === 200 ? "ok" : "err", { status }));
+			return fn as unknown as typeof globalThis.fetch;
+		}
+
+		function makeNetworkError(): typeof globalThis.fetch {
+			const fn = () => Promise.reject(new Error("network failure"));
+			return fn as unknown as typeof globalThis.fetch;
+		}
+
+		it("populates authLatencyMs and authCheckedAt on a successful validation", async () => {
+			globalThis.fetch = makeMockResponse(200);
+			const service = ProfileService.init(f5xcConfigDir);
+
+			const before = Date.now();
+			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			const after = Date.now();
+
+			const status = service.getStatus();
+			expect(typeof status.authLatencyMs).toBe("number");
+			expect(status.authLatencyMs).toBeGreaterThanOrEqual(0);
+			expect(typeof status.authCheckedAt).toBe("number");
+			expect(status.authCheckedAt).toBeGreaterThanOrEqual(before);
+			expect(status.authCheckedAt).toBeLessThanOrEqual(after);
+		});
+
+		it("populates both fields even on a failed validation", async () => {
+			globalThis.fetch = makeNetworkError();
+			const service = ProfileService.init(f5xcConfigDir);
+
+			const before = Date.now();
+			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" }).catch(() => {});
+			const after = Date.now();
+
+			const status = service.getStatus();
+			expect(typeof status.authLatencyMs).toBe("number");
+			expect(status.authLatencyMs).toBeGreaterThanOrEqual(0);
+			expect(typeof status.authCheckedAt).toBe("number");
+			expect(status.authCheckedAt).toBeGreaterThanOrEqual(before);
+			expect(status.authCheckedAt).toBeLessThanOrEqual(after);
+		});
+
+		it("stores authCheckedAt as epoch number, not ISO string", async () => {
+			globalThis.fetch = makeMockResponse(200);
+			const service = ProfileService.init(f5xcConfigDir);
+
+			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+
+			const status = service.getStatus();
+			expect(typeof status.authCheckedAt).toBe("number");
+			expect(Number.isInteger(status.authCheckedAt)).toBe(true);
+		});
+
+		it("invalidates the auth-freshness cache on profile switch", async () => {
+			// Arrange: two profiles, activate the first, run a successful validateToken to populate the cache.
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+
+			globalThis.fetch = makeMockResponse(200);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			await service.validateToken({ apiUrl: TEST_PROFILE.apiUrl, apiToken: TEST_PROFILE.apiToken });
+
+			const before = service.getStatus();
+			expect(before.authStatus).toBe("connected");
+			expect(typeof before.authLatencyMs).toBe("number");
+			expect(typeof before.authCheckedAt).toBe("number");
+
+			// Act: switch to the second profile. Do not re-validate.
+			await service.activate(TEST_PROFILE_2.name);
+
+			// Assert: cache fields cleared; auth status resets to unknown until the next validateToken.
+			const after = service.getStatus();
+			expect(after.authStatus).toBe("unknown");
+			expect(after.authLatencyMs).toBeUndefined();
+			expect(after.authCheckedAt).toBeUndefined();
+		});
+	});
 });

--- a/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
+++ b/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import type { BuildInfo } from "../../src/internal-urls/build-info.generated";
 import {
+	formatRelativeTime,
+	type RuntimeBuildInfo,
 	type RuntimeBuildInfoDeps,
 	renderAboutDoc,
 	resolveRuntimeBuildInfo,
 } from "../../src/internal-urls/build-info-runtime";
+import type { ProfileStatus } from "../../src/services/f5xc-profile";
 
 const embedded: BuildInfo = {
 	version: "17.4.2",
@@ -177,7 +180,7 @@ describe("renderAboutDoc", () => {
 			source: "live-git" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info);
+		const md = renderAboutDoc(info, null);
 		expect(md).toContain(embedded.version);
 		expect(md).toContain(embedded.shortCommit);
 		expect(md).toContain(embedded.branch);
@@ -192,7 +195,7 @@ describe("renderAboutDoc", () => {
 			source: "compiled" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info);
+		const md = renderAboutDoc(info, null);
 		expect(md).toContain("compiled");
 	});
 
@@ -202,7 +205,7 @@ describe("renderAboutDoc", () => {
 			source: "embedded-fallback" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info);
+		const md = renderAboutDoc(info, null);
 		expect(md).toContain("embedded-fallback");
 	});
 
@@ -212,7 +215,7 @@ describe("renderAboutDoc", () => {
 			source: "live-git" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info).toLowerCase();
+		const md = renderAboutDoc(info, null).toLowerCase();
 		expect(md).toMatch(/gh pr list|git log/);
 	});
 
@@ -222,7 +225,7 @@ describe("renderAboutDoc", () => {
 			source: "live-git" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info);
+		const md = renderAboutDoc(info, null);
 		expect(md).toContain("## Product knowledge");
 		expect(md).toContain("https://f5xc-salesdemos.github.io/docs/llms.txt");
 		expect(md).toContain("federated");
@@ -234,7 +237,7 @@ describe("renderAboutDoc", () => {
 			source: "live-git" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info);
+		const md = renderAboutDoc(info, null);
 		expect(md).toContain("## Lineage");
 		expect(md).toContain("badlogic/pi-mono");
 		expect(md).toContain("## Architecture");
@@ -247,5 +250,129 @@ describe("renderAboutDoc", () => {
 		expect(md).toContain("## Capabilities");
 		expect(md).toContain("MCP server/client");
 		expect(md).toContain("F5 XC federated product docs");
+	});
+});
+
+function fakeBuildInfo(): RuntimeBuildInfo {
+	return {
+		version: "18.14.0",
+		commit: "abc1234deadbeef",
+		shortCommit: "abc1234",
+		branch: "main",
+		tag: "",
+		commitDate: "2026-04-23T00:00:00Z",
+		buildDate: "2026-04-23T00:00:00Z",
+		dirty: false,
+		prNumber: "",
+		repoUrl: "https://github.com/f5xc-salesdemos/xcsh",
+		repoSlug: "f5xc-salesdemos/xcsh",
+		commitUrl: "https://github.com/f5xc-salesdemos/xcsh/commit/abc1234deadbeef",
+		releaseUrl: "https://github.com/f5xc-salesdemos/xcsh/releases/tag/v18.14.0",
+		source: "live-git",
+		resolvedAt: "2026-04-23T00:00:00Z",
+	};
+}
+
+describe("formatRelativeTime", () => {
+	it("renders 'just now' for sub-60-second deltas", () => {
+		const now = 1_700_000_000_000;
+		expect(formatRelativeTime(now - 0, now)).toBe("just now");
+		expect(formatRelativeTime(now - 30_000, now)).toBe("just now");
+		expect(formatRelativeTime(now - 59_999, now)).toBe("just now");
+	});
+
+	it("renders 'N min ago' for 1–59 minutes", () => {
+		const now = 1_700_000_000_000;
+		expect(formatRelativeTime(now - 60_000, now)).toBe("1 min ago");
+		expect(formatRelativeTime(now - 3 * 60_000, now)).toBe("3 min ago");
+		expect(formatRelativeTime(now - 59 * 60_000, now)).toBe("59 min ago");
+	});
+
+	it("renders 'N hours ago' for 1–23 hours", () => {
+		const now = 1_700_000_000_000;
+		expect(formatRelativeTime(now - 60 * 60_000, now)).toBe("1 hour ago");
+		expect(formatRelativeTime(now - 2 * 60 * 60_000, now)).toBe("2 hours ago");
+		expect(formatRelativeTime(now - 23 * 60 * 60_000, now)).toBe("23 hours ago");
+	});
+
+	it("renders 'N days ago' for deltas of 24 hours or more", () => {
+		const now = 1_700_000_000_000;
+		expect(formatRelativeTime(now - 24 * 60 * 60_000, now)).toBe("1 day ago");
+		expect(formatRelativeTime(now - 3 * 24 * 60 * 60_000, now)).toBe("3 days ago");
+	});
+});
+
+describe("renderAboutDoc platform context section", () => {
+	it("renders the unconfigured message when profile is null", () => {
+		const doc = renderAboutDoc(fakeBuildInfo(), null);
+		expect(doc).toContain("## Current Platform Context");
+		expect(doc).toContain("No F5 XC profile active");
+		expect(doc).toContain("/profile create");
+		expect(doc).toContain("/profile activate");
+	});
+
+	it("renders tenant/namespace/status/source when a profile is active with fresh latency", () => {
+		const now = Date.now();
+		const profile: ProfileStatus = {
+			activeProfileName: "prod",
+			activeProfileUrl: "https://acme-corp.console.ves.volterra.io/api",
+			activeProfileTenant: "acme-corp",
+			activeProfileNamespace: "production",
+			credentialSource: "profile",
+			authStatus: "connected",
+			isConfigured: true,
+			authLatencyMs: 142,
+			authCheckedAt: now - 3 * 60_000, // 3 min ago
+		};
+		const doc = renderAboutDoc(fakeBuildInfo(), profile);
+		expect(doc).toContain("**Tenant:** acme-corp");
+		expect(doc).toContain("**Namespace:** production");
+		expect(doc).toContain("**Auth Status:** connected (latency: 142ms, checked: 3 min ago)");
+		expect(doc).toContain("**Credential Source:** profile (name: prod)");
+	});
+
+	it("renders auth status without latency suffix when authCheckedAt is absent", () => {
+		const profile: ProfileStatus = {
+			activeProfileName: "prod",
+			activeProfileUrl: "https://acme-corp.console.ves.volterra.io/api",
+			activeProfileTenant: "acme-corp",
+			activeProfileNamespace: "production",
+			credentialSource: "profile",
+			authStatus: "unknown",
+			isConfigured: true,
+		};
+		const doc = renderAboutDoc(fakeBuildInfo(), profile);
+		expect(doc).toContain("**Auth Status:** unknown");
+		expect(doc).not.toContain("latency:");
+		expect(doc).not.toContain("checked:");
+	});
+
+	it("falls back to unconfigured message when profile.isConfigured is false", () => {
+		const profile: ProfileStatus = {
+			activeProfileName: null,
+			activeProfileUrl: null,
+			activeProfileTenant: null,
+			activeProfileNamespace: null,
+			credentialSource: "none",
+			authStatus: "unknown",
+			isConfigured: false,
+		};
+		const doc = renderAboutDoc(fakeBuildInfo(), profile);
+		expect(doc).toContain("No F5 XC profile active");
+	});
+
+	it("omits '(name: ...)' suffix when credential source is not 'profile'", () => {
+		const profile: ProfileStatus = {
+			activeProfileName: "prod",
+			activeProfileUrl: "https://acme-corp.console.ves.volterra.io/api",
+			activeProfileTenant: "acme-corp",
+			activeProfileNamespace: "production",
+			credentialSource: "environment",
+			authStatus: "connected",
+			isConfigured: true,
+		};
+		const doc = renderAboutDoc(fakeBuildInfo(), profile);
+		expect(doc).toContain("**Credential Source:** environment");
+		expect(doc).not.toContain("environment (name:");
 	});
 });

--- a/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
+++ b/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
@@ -375,4 +375,29 @@ describe("renderAboutDoc platform context section", () => {
 		expect(doc).toContain("**Credential Source:** environment");
 		expect(doc).not.toContain("environment (name:");
 	});
+
+	it("renders platform context for env-backed sessions with no activeProfileName", () => {
+		// Regression test: xcsh launched with F5XC_API_URL / F5XC_API_TOKEN has isConfigured=true,
+		// credentialSource='environment', a derived tenant, and activeProfileName=null. Previously
+		// the guard rejected this case and printed "No F5 XC profile active"; now it should render
+		// the configured section so users see the tenant/namespace they're actually connected to.
+		const profile: ProfileStatus = {
+			activeProfileName: null,
+			activeProfileUrl: "https://acme-corp.console.ves.volterra.io/api",
+			activeProfileTenant: "acme-corp",
+			activeProfileNamespace: "production",
+			credentialSource: "environment",
+			authStatus: "connected",
+			isConfigured: true,
+		};
+		const doc = renderAboutDoc(fakeBuildInfo(), profile);
+		expect(doc).toContain("- **Tenant:** acme-corp");
+		expect(doc).toContain("- **Namespace:** production");
+		expect(doc).toContain("**Auth Status:** connected");
+		expect(doc).toContain("**Credential Source:** environment");
+		// No `(name: ...)` suffix for env-only, since there's no profile name to show.
+		expect(doc).not.toContain("environment (name:");
+		// Must NOT fall through to the unconfigured message.
+		expect(doc).not.toContain("No F5 XC profile active");
+	});
 });

--- a/packages/coding-agent/test/sdk-profile-integration.test.ts
+++ b/packages/coding-agent/test/sdk-profile-integration.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Snowflake } from "@f5xc-salesdemos/pi-utils";
+import { _resetSettingsForTest, Settings } from "@f5xc-salesdemos/xcsh/config/settings";
+import { createAgentSession } from "@f5xc-salesdemos/xcsh/sdk";
+import { ProfileService } from "@f5xc-salesdemos/xcsh/services/f5xc-profile";
+
+describe("createAgentSession profile tracking", () => {
+	const tempDirs: string[] = [];
+	let configDir: string;
+	let cwd: string;
+	let agentDir: string;
+	let settings: Settings;
+
+	const savedEnv: Record<string, string | undefined> = {};
+
+	beforeEach(async () => {
+		_resetSettingsForTest();
+		ProfileService._resetForTest();
+
+		// Save and clear F5XC_* env vars (prevent container env leakage from affecting
+		// ProfileService.activate or profile status derivation).
+		for (const key of Object.keys(process.env)) {
+			if (key.startsWith("F5XC_")) {
+				savedEnv[key] = process.env[key];
+				delete process.env[key];
+			}
+		}
+
+		const testDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-sdk-profile-${Snowflake.next()}-`));
+		tempDirs.push(testDir);
+		configDir = path.join(testDir, "f5xc-config");
+		cwd = path.join(testDir, "project");
+		agentDir = path.join(testDir, "agent");
+		fs.mkdirSync(configDir, { recursive: true });
+		fs.mkdirSync(cwd, { recursive: true });
+		fs.mkdirSync(agentDir, { recursive: true });
+
+		// Settings.init populates the global singleton used by ProfileService.activate.
+		settings = await Settings.init({ cwd, agentDir, inMemory: true });
+
+		ProfileService.init(configDir);
+	});
+
+	afterEach(() => {
+		ProfileService._resetForTest();
+		_resetSettingsForTest();
+		// Restore F5XC_* env vars
+		for (const key of Object.keys(process.env)) {
+			if (key.startsWith("F5XC_")) delete process.env[key];
+		}
+		for (const [key, value] of Object.entries(savedEnv)) {
+			if (value !== undefined) process.env[key] = value;
+			delete savedEnv[key];
+		}
+		for (const dir of tempDirs.splice(0)) {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("scenario 1: emits profile_change only at session start when a profile is active", async () => {
+		await ProfileService.instance.createProfile({
+			name: "prod",
+			apiUrl: "https://acme-corp.console.ves.volterra.io/api",
+			apiToken: "tok",
+			defaultNamespace: "production",
+		});
+		await ProfileService.instance.activate("prod");
+
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			settings,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		try {
+			const entries = session.sessionManager.getEntries();
+			const profileChanges = entries.filter(e => e.type === "profile_change");
+			const customMessages = entries.filter(e => e.type === "custom_message");
+
+			expect(profileChanges).toHaveLength(1);
+			expect(profileChanges[0]).toMatchObject({
+				type: "profile_change",
+				profileName: "prod",
+				tenant: "acme-corp",
+				namespace: "production",
+			});
+			expect(customMessages).toHaveLength(0);
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("scenario 3: emits no profile entries at session start when no profile is active", async () => {
+		// ProfileService initialized in beforeEach but no activate() call.
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			settings,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		try {
+			const entries = session.sessionManager.getEntries();
+			expect(entries.filter(e => e.type === "profile_change")).toHaveLength(0);
+			expect(entries.filter(e => e.type === "custom_message")).toHaveLength(0);
+		} finally {
+			await session.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/sdk-profile-integration.test.ts
+++ b/packages/coding-agent/test/sdk-profile-integration.test.ts
@@ -278,4 +278,106 @@ describe("createAgentSession profile tracking", () => {
 			await session.dispose();
 		}
 	});
+
+	it("scenario 6: mid-session activate pushes the notice into agent.state.messages (LLM sees it)", async () => {
+		// Regression test: writing only to the session log leaves agent.state.messages stale until
+		// compaction or session reload, so the LLM doesn't see the profile switch on its next turn.
+		// sendCustomMessage must route the notice through agent.appendMessage so it enters the
+		// LLM's active context immediately.
+		await ProfileService.instance.createProfile({
+			name: "prod",
+			apiUrl: "https://acme-corp.console.ves.volterra.io/api",
+			apiToken: "tok",
+			defaultNamespace: "production",
+		});
+		await ProfileService.instance.createProfile({
+			name: "staging",
+			apiUrl: "https://beta-llc.console.ves.volterra.io/api",
+			apiToken: "tok2",
+			defaultNamespace: "staging",
+		});
+		await ProfileService.instance.activate("prod");
+
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			settings,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		try {
+			const messagesBefore = session.state.messages.length;
+
+			await ProfileService.instance.activate("staging");
+
+			// Give the fire-and-forget sendCustomMessage promise a microtask to run.
+			await Promise.resolve();
+
+			const messagesAfter = session.state.messages;
+			const added = messagesAfter.slice(messagesBefore);
+			const customMessages = added.filter(
+				m =>
+					(m as { role?: string; customType?: string }).role === "custom" &&
+					(m as { customType?: string }).customType === "profile_change_notice",
+			);
+
+			expect(customMessages).toHaveLength(1);
+			const customMessageText = (customMessages[0] as { content: string | unknown[] }).content;
+			const text = typeof customMessageText === "string" ? customMessageText : JSON.stringify(customMessageText);
+			expect(text).toContain("[Profile switched to staging]");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("scenario 7: disposing a session unregisters its profile-change listener", async () => {
+		// Regression test for the listener-leak bug. Each createAgentSession registered a listener
+		// that closed over that session's sessionManager; disposing the session didn't remove it,
+		// so a later /profile activate in ANY session would mutate disposed sessions' logs.
+		// addDisposeHook + ProfileService.offProfileChange should prevent this.
+		await ProfileService.instance.createProfile({
+			name: "prod",
+			apiUrl: "https://acme-corp.console.ves.volterra.io/api",
+			apiToken: "tok",
+			defaultNamespace: "production",
+		});
+		await ProfileService.instance.createProfile({
+			name: "staging",
+			apiUrl: "https://beta-llc.console.ves.volterra.io/api",
+			apiToken: "tok2",
+			defaultNamespace: "staging",
+		});
+		await ProfileService.instance.activate("prod");
+
+		// Create and immediately dispose session A — capture sessionManager ref for later inspection.
+		const { session: sessionA } = await createAgentSession({
+			cwd,
+			agentDir,
+			settings,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+		const sessionAManager = sessionA.sessionManager;
+		const sessionAEntryCountAtDispose = sessionAManager.getEntries().length;
+		await sessionA.dispose();
+
+		// Activate another profile. If the listener still leaked, it would fire and append entries
+		// to sessionAManager's in-memory #fileEntries.
+		await ProfileService.instance.activate("staging");
+		await Promise.resolve();
+
+		// sessionAManager should be untouched since its listener was unregistered on dispose.
+		expect(sessionAManager.getEntries()).toHaveLength(sessionAEntryCountAtDispose);
+	});
 });

--- a/packages/coding-agent/test/sdk-profile-integration.test.ts
+++ b/packages/coding-agent/test/sdk-profile-integration.test.ts
@@ -123,4 +123,159 @@ describe("createAgentSession profile tracking", () => {
 			await session.dispose();
 		}
 	});
+
+	it("scenario 2: session starts with profile A; mid-session activate emits both profile_change and custom_message", async () => {
+		await ProfileService.instance.createProfile({
+			name: "prod",
+			apiUrl: "https://acme-corp.console.ves.volterra.io/api",
+			apiToken: "tok",
+			defaultNamespace: "production",
+		});
+		await ProfileService.instance.createProfile({
+			name: "staging",
+			apiUrl: "https://beta-llc.console.ves.volterra.io/api",
+			apiToken: "tok2",
+			defaultNamespace: "staging",
+		});
+		await ProfileService.instance.activate("prod");
+
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			settings,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		try {
+			const entriesBefore = session.sessionManager.getEntries().length;
+
+			await ProfileService.instance.activate("staging");
+
+			const entriesAfter = session.sessionManager.getEntries();
+			const added = entriesAfter.slice(entriesBefore);
+			const profileChanges = added.filter(e => e.type === "profile_change");
+			const customMessages = added.filter(
+				e => e.type === "custom_message" && (e as { customType?: string }).customType === "profile_change_notice",
+			);
+
+			expect(profileChanges).toHaveLength(1);
+			expect(profileChanges[0]).toMatchObject({
+				type: "profile_change",
+				profileName: "staging",
+				tenant: "beta-llc",
+				namespace: "staging",
+			});
+			expect(customMessages).toHaveLength(1);
+			const content = (customMessages[0] as { content: string }).content;
+			expect(content).toContain("[Profile switched to staging]");
+			expect(content).toContain("Tenant: beta-llc");
+			expect(content).toContain("namespace: staging");
+			expect((customMessages[0] as { display: boolean }).display).toBe(true);
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("scenario 4: session starts with NO profile; mid-session activate emits both profile_change and custom_message", async () => {
+		await ProfileService.instance.createProfile({
+			name: "prod",
+			apiUrl: "https://acme-corp.console.ves.volterra.io/api",
+			apiToken: "tok",
+			defaultNamespace: "production",
+		});
+		// No activate() yet — session launches with no active profile.
+
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			settings,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		try {
+			const entriesBefore = session.sessionManager.getEntries().length;
+
+			await ProfileService.instance.activate("prod");
+
+			const entriesAfter = session.sessionManager.getEntries();
+			const added = entriesAfter.slice(entriesBefore);
+			const profileChanges = added.filter(e => e.type === "profile_change");
+			const customMessages = added.filter(
+				e => e.type === "custom_message" && (e as { customType?: string }).customType === "profile_change_notice",
+			);
+
+			// Regression test for the guard-bug flagged during brainstorming.
+			// The session started without a profile → the system prompt has no profile block.
+			// Mid-session activate MUST emit both a profile_change (for replay) and a custom_message
+			// (so the LLM gains profile context it never had at startup).
+			expect(profileChanges).toHaveLength(1);
+			expect(profileChanges[0]).toMatchObject({
+				type: "profile_change",
+				profileName: "prod",
+				tenant: "acme-corp",
+				namespace: "production",
+			});
+			expect(customMessages).toHaveLength(1);
+			expect((customMessages[0] as { content: string }).content).toContain("[Profile switched to prod]");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("scenario 5: re-activating the currently-active profile does not emit a spurious custom_message", async () => {
+		// Regression test for listener-fires-on-non-switch noise. ProfileService fires the
+		// onProfileChange listener on every #applyToSettings call, including setNamespace,
+		// setEnvVars, unsetEnvVars, and re-activation of the same profile. Only actual profile
+		// switches (name changes) should produce an LLM-visible custom_message.
+		await ProfileService.instance.createProfile({
+			name: "prod",
+			apiUrl: "https://acme-corp.console.ves.volterra.io/api",
+			apiToken: "tok",
+			defaultNamespace: "production",
+		});
+		await ProfileService.instance.activate("prod");
+
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			settings,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		try {
+			const entriesBefore = session.sessionManager.getEntries().length;
+
+			// Re-activate the same profile. Listener fires, but name hasn't changed.
+			await ProfileService.instance.activate("prod");
+
+			const added = session.sessionManager.getEntries().slice(entriesBefore);
+			const profileChanges = added.filter(e => e.type === "profile_change");
+			const customMessages = added.filter(
+				e => e.type === "custom_message" && (e as { customType?: string }).customType === "profile_change_notice",
+			);
+
+			expect(profileChanges).toHaveLength(0);
+			expect(customMessages).toHaveLength(0);
+		} finally {
+			await session.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -5,6 +5,7 @@ import {
 	type CompactionEntry,
 	type ModelChangeEntry,
 	type SessionEntry,
+	SessionManager,
 	type SessionMessageEntry,
 	type ThinkingLevelChangeEntry,
 } from "@f5xc-salesdemos/xcsh/session/session-manager";
@@ -337,6 +338,39 @@ describe("buildSessionContext", () => {
 			const ctx = buildSessionContext(entries, "2");
 			// Should only get the orphan since parent chain is broken
 			expect(ctx.messages).toHaveLength(1);
+		});
+	});
+
+	describe("profile_change replay", () => {
+		it("derives activeProfileName and activeProfileTenant from the only profile_change entry", () => {
+			const session = SessionManager.inMemory();
+			session.appendProfileChange("prod", "acme-corp", "production");
+
+			const ctx = session.buildSessionContext();
+
+			expect(ctx.activeProfileName).toBe("prod");
+			expect(ctx.activeProfileTenant).toBe("acme-corp");
+		});
+
+		it("uses the most recent profile_change when multiple are present", () => {
+			const session = SessionManager.inMemory();
+			session.appendProfileChange("prod", "acme-corp", "production");
+			session.appendProfileChange("staging", "beta-llc", "staging");
+
+			const ctx = session.buildSessionContext();
+
+			expect(ctx.activeProfileName).toBe("staging");
+			expect(ctx.activeProfileTenant).toBe("beta-llc");
+		});
+
+		it("leaves both fields undefined when no profile_change entries exist", () => {
+			const session = SessionManager.inMemory();
+			session.appendMessage({ role: "user", content: "hi", timestamp: 1 });
+
+			const ctx = session.buildSessionContext();
+
+			expect(ctx.activeProfileName).toBeUndefined();
+			expect(ctx.activeProfileTenant).toBeUndefined();
 		});
 	});
 });

--- a/packages/coding-agent/test/session-manager/profile-change.test.ts
+++ b/packages/coding-agent/test/session-manager/profile-change.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { SessionManager } from "@f5xc-salesdemos/xcsh/session/session-manager";
+
+describe("SessionManager.appendProfileChange", () => {
+	it("writes a profile_change entry with the given fields", () => {
+		const session = SessionManager.inMemory();
+
+		const id = session.appendProfileChange("prod", "acme-corp", "production");
+
+		const entries = session.getEntries();
+		const entry = entries.find(e => e.type === "profile_change");
+		expect(entry).toBeDefined();
+		expect(entry).toMatchObject({
+			type: "profile_change",
+			profileName: "prod",
+			tenant: "acme-corp",
+			namespace: "production",
+			id,
+		});
+		expect(typeof (entry as { timestamp: string }).timestamp).toBe("string");
+	});
+
+	it("returns a non-empty entry id", () => {
+		const session = SessionManager.inMemory();
+		const id = session.appendProfileChange("prod", "acme-corp", "default");
+		expect(id.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -338,6 +338,64 @@ describe("system Handlebars prompt templates", () => {
 		expect(template).toContain("misconfigurations → outages");
 	});
 
+	test("custom-system-prompt renders the F5 XC profile block when profile is present", async () => {
+		const templatePath = path.join(systemPromptsDir, "custom-system-prompt.md");
+		const template = await Bun.file(templatePath).text();
+		const rendered = prompt.render(template, {
+			...baseRenderContext,
+			profile: {
+				tenant: "acme-corp",
+				namespace: "production",
+				credentialSource: "profile",
+				authStatus: "connected",
+			},
+		});
+		expect(rendered).toContain("## F5 XC Platform Context");
+		expect(rendered).toContain("You are currently connected to F5 XC tenant: acme-corp, namespace: production.");
+		expect(rendered).toContain("Credential source: profile.");
+		expect(rendered).toContain("Auth status: connected.");
+		expect(rendered).toContain(
+			"All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.",
+		);
+	});
+
+	test("custom-system-prompt omits the F5 XC profile block when profile is absent", async () => {
+		const templatePath = path.join(systemPromptsDir, "custom-system-prompt.md");
+		const template = await Bun.file(templatePath).text();
+		const rendered = prompt.render(template, { ...baseRenderContext, profile: undefined });
+		expect(rendered).not.toContain("## F5 XC Platform Context");
+		expect(rendered).not.toContain("All F5 XC operations should target");
+	});
+
+	test("system-prompt renders the F5 XC profile block when profile is present", async () => {
+		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
+		const template = await Bun.file(templatePath).text();
+		const rendered = prompt.render(template, {
+			...baseRenderContext,
+			profile: {
+				tenant: "acme-corp",
+				namespace: "production",
+				credentialSource: "profile",
+				authStatus: "connected",
+			},
+		});
+		expect(rendered).toContain("## F5 XC Platform Context");
+		expect(rendered).toContain("You are currently connected to F5 XC tenant: acme-corp, namespace: production.");
+		expect(rendered).toContain("Credential source: profile.");
+		expect(rendered).toContain("Auth status: connected.");
+		expect(rendered).toContain(
+			"All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.",
+		);
+	});
+
+	test("system-prompt omits the F5 XC profile block when profile is absent", async () => {
+		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
+		const template = await Bun.file(templatePath).text();
+		const rendered = prompt.render(template, { ...baseRenderContext, profile: undefined });
+		expect(rendered).not.toContain("## F5 XC Platform Context");
+		expect(rendered).not.toContain("All F5 XC operations should target");
+	});
+
 	test("epistemic-integrity swaps sea-color example for SE-domain bot-defense example (P5)", async () => {
 		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
 		const template = await Bun.file(templatePath).text();

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -396,6 +396,33 @@ describe("system Handlebars prompt templates", () => {
 		expect(rendered).not.toContain("All F5 XC operations should target");
 	});
 
+	test("profile block renders for env-backed sessions (credentialSource='environment', no profile name)", async () => {
+		// Regression test for the overlooked env-only path. xcsh launched with F5XC_API_URL /
+		// F5XC_API_TOKEN has isConfigured=true and a real tenant but activeProfileName=null.
+		// The Handlebars context doesn't carry activeProfileName directly — only tenant/namespace/
+		// credentialSource/authStatus — so rendering the template with credentialSource:"environment"
+		// should still produce the anchor block. Verified for both templates.
+		for (const fileName of ["system-prompt.md", "custom-system-prompt.md"]) {
+			const templatePath = path.join(systemPromptsDir, fileName);
+			const template = await Bun.file(templatePath).text();
+			const rendered = prompt.render(template, {
+				...baseRenderContext,
+				profile: {
+					tenant: "acme-corp",
+					namespace: "production",
+					credentialSource: "environment",
+					authStatus: "connected",
+				},
+			});
+			expect(rendered).toContain("## F5 XC Platform Context");
+			expect(rendered).toContain("You are currently connected to F5 XC tenant: acme-corp, namespace: production.");
+			expect(rendered).toContain("Credential source: environment.");
+			expect(rendered).toContain(
+				"All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.",
+			);
+		}
+	});
+
 	test("epistemic-integrity swaps sea-color example for SE-domain bot-defense example (P5)", async () => {
 		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
 		const template = await Bun.file(templatePath).text();


### PR DESCRIPTION
## Summary

- Adds `profile_change` session entries + `SessionContext` derivation (phase 4.3) so the active profile at session launch and all mid-session switches are recorded in the session log and surfaced via `SessionContext.activeProfileName` / `activeProfileTenant`.
- Extends `xcsh://about` with a "Current Platform Context" section showing tenant, namespace, auth status (with cached latency + checked-at), and credential source (phase 4.1). Cached on `ProfileStatus` so `renderAboutDoc` stays sync and pure — no network I/O on every about-doc read. `activate()` now invalidates the auth-freshness cache so a profile switch doesn't carry stale latency from the previous tenant.
- Adds a conditional `F5 XC Platform Context` block to the system prompt (phase 4.2) — in both `system-prompt.md` and `custom-system-prompt.md` so the LLM receives the anchor on every code path. Plus a transcript `custom_message` on mid-session `/profile activate` so the LLM sees profile switches without rebuilding the (cached) system prompt. The listener gates emission on actual profile-name changes to avoid spurious notifications on `setNamespace` / `setEnvVars` / `unsetEnvVars` and re-activation of the same profile.
- Defers phase 4.4 (profile-aware skill filtering) to a dedicated ticket per the design doc rationale — it's exploratory by design and mixing with three concrete code changes would inflate review scope.

## Test plan

- [x] `bun check` clean across all workspaces
- [x] `test/f5xc-profile-service.test.ts` — `authLatencyMs` / `authCheckedAt` populated on success and failure paths; cache invalidated on `activate()`
- [x] `test/internal-urls/build-info-runtime.test.ts` — `renderAboutDoc` platform-context section (null profile, profile with fresh latency, profile with absent `authCheckedAt`, `isConfigured:false`, non-profile credential source); `formatRelativeTime` bucket boundaries
- [x] `test/system-prompt-templates.test.ts` — `{{#if profile}}` block renders when profile present, absent otherwise, in **both** `system-prompt.md` and `custom-system-prompt.md`
- [x] `test/session-manager/profile-change.test.ts` — `appendProfileChange` writes a well-formed entry
- [x] `test/session-manager/build-context.test.ts` — `buildSessionContext` replay picks last `profile_change` for `activeProfileName` / `activeProfileTenant`
- [x] `test/sdk-profile-integration.test.ts` — 5 scenarios:
  - 1: session-start with profile emits `profile_change` only
  - 2: mid-session switch emits both `profile_change` and `custom_message`
  - 3: session-start without profile emits nothing
  - 4: session-start without profile + mid-session activate emits both (guard-bug regression test)
  - 5: re-activating the currently-active profile does NOT emit a spurious `custom_message`
- [x] No regressions on baseline flakes (`tryAutoConfigLiteLLM`, `validateModelsConfig` are pre-existing)

Closes #275.