### PR TITLE
fix(coding-agent): /profile phase 4 post-merge corrections (Codex)

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -739,88 +739,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	// getProfileStatus getter below). Null when ProfileService isn't available (SDK consumers, tests).
 	let profileServiceRef: typeof import("./services/f5xc-profile").ProfileService | null = null;
 
-	// Register profile-change listener to refresh obfuscator and notify the LLM when /profile activate runs.
-	// The callback is captured as a named const so the `addDisposeHook` call below can unregister it;
-	// otherwise listeners accumulate across createAgentSession calls (SDK/ACP multi-session flows) and
-	// fire on disposed sessions.
-	let profileChangeListener: ((profile: import("./services/f5xc-profile").F5XCProfile) => void) | null = null;
+	// Capture ProfileService reference for sync consumers (rebuildSystemPrompt profile resolution,
+	// InternalDocsProtocolHandler getProfileStatus). The profile-change listener itself is
+	// registered later, atomically with its addDisposeHook cleanup, AFTER session construction
+	// succeeds — registering it here would leak on createAgentSession failures.
 	try {
 		const { ProfileService } = await import("./services/f5xc-profile");
 		profileServiceRef = ProfileService;
-
-		// Track the profile name the LLM was last told about. Seed with the session-start name
-		// so re-activating the same profile, or firing the listener for settings-only events
-		// (/profile env set|unset, /profile namespace), does NOT produce a spurious "Profile
-		// switched" directive. The listener is shared across all #applyToSettings call paths in
-		// ProfileService — activate, setNamespace, setEnvVars, unsetEnvVars, loadActive — and only
-		// an actual profile switch should notify the LLM.
-		let lastEmittedProfileName: string | undefined =
-			ProfileService.instance?.getStatus()?.activeProfileName ?? undefined;
-
-		profileChangeListener = profile => {
-			const newValues: string[] = [profile.apiToken];
-			if (profile.sensitiveKeys && profile.env) {
-				for (const key of profile.sensitiveKeys) {
-					const v = profile.env[key];
-					if (v) newValues.push(v);
-				}
-			}
-			const bashEnv = (settings.get("bash.environment") ?? {}) as Record<string, string>;
-			for (const [name, value] of Object.entries(bashEnv)) {
-				if (value && SECRET_ENV_PATTERNS.test(name)) newValues.push(value);
-			}
-			if (obfuscator) {
-				obfuscator.addPlainSecrets(newValues);
-			} else {
-				// Obfuscator was undefined at session start (no secrets detected).
-				// Create one now so late profile activations are still masked.
-				const entries: SecretEntry[] = newValues
-					.filter(v => v.length > 0)
-					.map(v => ({ type: "plain" as const, content: v, mode: "obfuscate" as const }));
-				if (entries.length > 0) {
-					obfuscator = new SecretObfuscator(entries);
-				}
-			}
-
-			// After obfuscator update, notify the LLM of the profile switch — but ONLY when the
-			// active profile name actually changed. Scenario 4 regression test: when session
-			// starts with no profile and the user activates mid-session, lastEmittedProfileName
-			// is undefined and currentName is truthy, so the guard correctly emits.
-			// Read ProfileService.getStatus() (not derived from the callback arg) to stay consistent
-			// with session-start emission, which honors the F5XC_NAMESPACE env override.
-			try {
-				const currentStatus = profileServiceRef?.instance?.getStatus();
-				const currentName = currentStatus?.activeProfileName ?? undefined;
-				if (currentName && currentStatus?.activeProfileTenant && currentName !== lastEmittedProfileName) {
-					const namespace = currentStatus.activeProfileNamespace ?? "default";
-
-					// Append the profile_change entry for replay/resume state reconstruction.
-					sessionManager.appendProfileChange(currentName, currentStatus.activeProfileTenant, namespace);
-
-					// Push a custom_message into BOTH agent.state.messages AND the session log so
-					// the LLM sees the directive on its next turn. Using sessionManager.append*
-					// alone would persist to the log but leave agent.state stale until compaction
-					// or session reload — the LLM's active context wouldn't see the switch.
-					// sendCustomMessage handles streaming vs non-streaming correctly (queues
-					// via steer/followUp/nextTurn when a turn is in flight).
-					void session.sendCustomMessage({
-						customType: "profile_change_notice",
-						content:
-							`[Profile switched to ${currentName}] Tenant: ${currentStatus.activeProfileTenant}, ` +
-							`namespace: ${namespace}. Target this tenant and namespace ` +
-							`for subsequent F5 XC operations.`,
-						display: true,
-						attribution: "agent",
-					});
-					lastEmittedProfileName = currentName;
-				}
-			} catch {
-				// ProfileService.instance throws if not initialized; skip.
-			}
-		};
-		ProfileService.onProfileChange(profileChangeListener);
 	} catch {
-		// ProfileService not available — skip
+		// ProfileService not available (SDK consumers, tests). Skip.
 	}
 
 	// Check if session has existing data to restore
@@ -1757,14 +1684,109 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		});
 		hasSession = true;
 
-		// Unregister the profile-change listener when the session is disposed. Without this, each
-		// createAgentSession() call leaks a listener that closes over this session's sessionManager
-		// and `session`, so a /profile activate fire in a later session would also mutate disposed
-		// sessions' state (bogus profile_change entries, custom_message injection on a dead agent).
-		if (profileChangeListener && profileServiceRef) {
-			const listener = profileChangeListener;
+		// Register the profile-change listener now that the session exists. Registering here
+		// (atomically with addDisposeHook below) means a failed createAgentSession leaves no
+		// leaked listener, and the listener closes over a fully-constructed session.
+		//
+		// The listener fires on every #applyToSettings call in ProfileService (activate,
+		// setNamespace, setEnvVars, unsetEnvVars, loadActive). It serves two roles:
+		//   1. Refresh the secret obfuscator when profile env/token changes.
+		//   2. Notify the LLM when profile context the prompt block mirrors (name OR namespace)
+		//      changes — settings-only events (env var mutations) do not emit the notice.
+		//
+		// Wrapped in try so that tests and SDK consumers that never initialize ProfileService
+		// don't trip on .instance throwing. In those paths we skip listener registration
+		// entirely — there's no profile to track.
+		try {
+			if (!profileServiceRef) throw new Error("no ProfileService");
 			const service = profileServiceRef;
+
+			// Track both name and namespace — they both appear in the system-prompt anchor block
+			// and both affect F5 XC operation targeting, so either changing is an LLM-visible event.
+			// Seed from current state so re-activating the same profile, or firing for env-only
+			// mutations, does not produce a spurious "Profile switched" directive.
+			const seedStatus = service.instance.getStatus();
+			let lastEmittedContext: { name: string; namespace: string } | undefined =
+				seedStatus.activeProfileName && seedStatus.activeProfileTenant
+					? {
+							name: seedStatus.activeProfileName,
+							namespace: seedStatus.activeProfileNamespace ?? "default",
+						}
+					: undefined;
+
+			const listener: (profile: import("./services/f5xc-profile").F5XCProfile) => void = profile => {
+				// Role 1: obfuscator refresh on credential change.
+				const newValues: string[] = [profile.apiToken];
+				if (profile.sensitiveKeys && profile.env) {
+					for (const key of profile.sensitiveKeys) {
+						const v = profile.env[key];
+						if (v) newValues.push(v);
+					}
+				}
+				const bashEnv = (settings.get("bash.environment") ?? {}) as Record<string, string>;
+				for (const [name, value] of Object.entries(bashEnv)) {
+					if (value && SECRET_ENV_PATTERNS.test(name)) newValues.push(value);
+				}
+				if (obfuscator) {
+					obfuscator.addPlainSecrets(newValues);
+				} else {
+					// Obfuscator was undefined at session start (no secrets detected).
+					// Create one now so late profile activations are still masked.
+					const entries: SecretEntry[] = newValues
+						.filter(v => v.length > 0)
+						.map(v => ({ type: "plain" as const, content: v, mode: "obfuscate" as const }));
+					if (entries.length > 0) {
+						obfuscator = new SecretObfuscator(entries);
+					}
+				}
+
+				// Role 2: notify the LLM when name OR namespace changes. Read
+				// ProfileService.getStatus() (not the callback arg) to honor the F5XC_NAMESPACE
+				// env override consistently with session-start emission.
+				try {
+					const currentStatus = service.instance?.getStatus();
+					const currentName = currentStatus?.activeProfileName ?? undefined;
+					const currentTenant = currentStatus?.activeProfileTenant ?? undefined;
+					if (!currentName || !currentTenant) return;
+					const currentNamespace = currentStatus.activeProfileNamespace ?? "default";
+
+					const changed =
+						!lastEmittedContext ||
+						currentName !== lastEmittedContext.name ||
+						currentNamespace !== lastEmittedContext.namespace;
+					if (!changed) return;
+
+					// Append the profile_change entry for replay/resume state reconstruction.
+					sessionManager.appendProfileChange(currentName, currentTenant, currentNamespace);
+
+					// Push a custom_message into BOTH agent.state.messages AND the session log so
+					// the LLM sees the directive on its next turn. sendCustomMessage handles
+					// streaming vs non-streaming correctly (queues via steer/followUp/nextTurn
+					// when a turn is in flight).
+					const nameChanged = !lastEmittedContext || currentName !== lastEmittedContext.name;
+					const prefix = nameChanged
+						? `[Profile switched to ${currentName}]`
+						: `[F5 XC namespace changed to ${currentNamespace}]`;
+					void session.sendCustomMessage({
+						customType: "profile_change_notice",
+						content:
+							`${prefix} Tenant: ${currentTenant}, ` +
+							`namespace: ${currentNamespace}. Target this tenant and namespace ` +
+							`for subsequent F5 XC operations.`,
+						display: true,
+						attribution: "agent",
+					});
+					lastEmittedContext = { name: currentName, namespace: currentNamespace };
+				} catch {
+					// ProfileService.instance throws if not initialized; skip.
+				}
+			};
+
+			service.onProfileChange(listener);
 			session.addDisposeHook(() => service.offProfileChange(listener));
+		} catch {
+			// ProfileService not initialized — skip listener registration entirely.
+			// Tests and SDK consumers that don't use profiles won't reach this branch.
 		}
 
 		if (model?.api === "openai-codex-responses") {

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -375,11 +375,20 @@ export class ProfileService {
 		const effectiveToken = options?.apiToken ?? process.env[F5XC_API_TOKEN] ?? this.#activeProfile?.apiToken;
 		if (!effectiveUrl || !effectiveToken) return { status: "unknown" };
 
-		// Ad-hoc mode: caller is validating credentials other than the active profile's
-		// effective creds (e.g., `/profile show <other>` passes explicit apiUrl/apiToken).
-		// In that case, do NOT touch the cached auth state — getStatus() would otherwise
-		// report the active profile's identity with ad-hoc creds' latency/status.
-		const adHoc = options?.apiUrl !== undefined || options?.apiToken !== undefined;
+		// Ad-hoc mode: caller is validating credentials that DIFFER from the active/effective
+		// ones — e.g., `/profile show <other>` passes a non-active profile's apiUrl/apiToken.
+		// In that case, do NOT touch the cached auth state — getStatus() would otherwise report
+		// the active profile's identity with some other profile's latency/status.
+		//
+		// `/profile show` on the ACTIVE profile (and `/profile show` with no name, which resolves
+		// to the active name) also passes explicit creds via handleShow, but those creds match
+		// the active/effective ones, so we DO want to refresh the cache — a user running
+		// /profile show on the active profile is explicitly requesting a fresh validation.
+		const activeUrl = process.env[F5XC_API_URL] ?? this.#activeProfile?.apiUrl;
+		const activeToken = process.env[F5XC_API_TOKEN] ?? this.#activeProfile?.apiToken;
+		const adHoc =
+			(options?.apiUrl !== undefined && options.apiUrl !== activeUrl) ||
+			(options?.apiToken !== undefined && options.apiToken !== activeToken);
 
 		const url = `${effectiveUrl}/api/web/namespaces`;
 		const timeout = options?.timeoutMs ?? 3000;

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -374,6 +374,13 @@ export class ProfileService {
 		const effectiveUrl = options?.apiUrl ?? process.env[F5XC_API_URL] ?? this.#activeProfile?.apiUrl;
 		const effectiveToken = options?.apiToken ?? process.env[F5XC_API_TOKEN] ?? this.#activeProfile?.apiToken;
 		if (!effectiveUrl || !effectiveToken) return { status: "unknown" };
+
+		// Ad-hoc mode: caller is validating credentials other than the active profile's
+		// effective creds (e.g., `/profile show <other>` passes explicit apiUrl/apiToken).
+		// In that case, do NOT touch the cached auth state — getStatus() would otherwise
+		// report the active profile's identity with ad-hoc creds' latency/status.
+		const adHoc = options?.apiUrl !== undefined || options?.apiToken !== undefined;
+
 		const url = `${effectiveUrl}/api/web/namespaces`;
 		const timeout = options?.timeoutMs ?? 3000;
 		const checkedAt = Date.now();
@@ -385,23 +392,27 @@ export class ProfileService {
 				signal: AbortSignal.timeout(timeout),
 			});
 			const latencyMs = Math.round(performance.now() - start);
-			this.#lastAuthLatencyMs = latencyMs;
-			this.#lastAuthCheckedAt = checkedAt;
+			if (!adHoc) {
+				this.#lastAuthLatencyMs = latencyMs;
+				this.#lastAuthCheckedAt = checkedAt;
+			}
 			if (response.ok) {
-				this.#authStatus = "connected";
+				if (!adHoc) this.#authStatus = "connected";
 				return { status: "connected", latencyMs };
 			}
 			if (response.status === 401 || response.status === 403) {
-				this.#authStatus = "auth_error";
+				if (!adHoc) this.#authStatus = "auth_error";
 				return { status: "auth_error", latencyMs, errorClass: "credential" };
 			}
 			// 5xx, 429, etc. — server reachable but unhealthy; treat as offline so startup retry fires
-			this.#authStatus = "offline";
+			if (!adHoc) this.#authStatus = "offline";
 			return { status: "offline", latencyMs, errorClass: "network" };
 		} catch {
-			this.#lastAuthLatencyMs = Date.now() - checkedAt;
-			this.#lastAuthCheckedAt = checkedAt;
-			this.#authStatus = "offline";
+			if (!adHoc) {
+				this.#lastAuthLatencyMs = Date.now() - checkedAt;
+				this.#lastAuthCheckedAt = checkedAt;
+				this.#authStatus = "offline";
+			}
 			return { status: "offline", errorClass: "network" };
 		}
 	}

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1214,5 +1214,37 @@ describe("ProfileService", () => {
 			expect(after.authLatencyMs).toBe(cachedLatency);
 			expect(after.authCheckedAt).toBe(cachedCheckedAt);
 		});
+
+		it("updates the cache when called with explicit creds that match the active profile", async () => {
+			// Regression test: /profile show (with no name, or with the active profile's name)
+			// passes explicit apiUrl/apiToken to validateToken via handleShow — but those creds
+			// still match the active/effective ones. A naive ad-hoc check that triggers on
+			// `options.apiUrl !== undefined` would incorrectly skip the cache refresh, leaving
+			// getStatus() consumers stuck on stale auth state after the user explicitly asked
+			// for a fresh validation. The refined check compares supplied creds against the
+			// active/effective ones and only treats a mismatch as ad-hoc.
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+
+			globalThis.fetch = makeMockResponse(200);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const before = Date.now();
+			// Call validateToken with explicit creds that match the active profile — this is
+			// exactly what handleShow(ctx, service) does for a `/profile show` on the active profile.
+			await service.validateToken({
+				apiUrl: TEST_PROFILE.apiUrl,
+				apiToken: TEST_PROFILE.apiToken,
+			});
+			const after = Date.now();
+
+			const status = service.getStatus();
+			expect(status.authStatus).toBe("connected");
+			expect(typeof status.authLatencyMs).toBe("number");
+			expect(typeof status.authCheckedAt).toBe("number");
+			expect(status.authCheckedAt).toBeGreaterThanOrEqual(before);
+			expect(status.authCheckedAt).toBeLessThanOrEqual(after);
+		});
 	});
 });

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1098,12 +1098,24 @@ describe("ProfileService", () => {
 			return fn as unknown as typeof globalThis.fetch;
 		}
 
+		// Helper: set up a service with TEST_PROFILE as the active profile, ready for
+		// active-mode validateToken() calls that populate cache. Ad-hoc mode (validateToken with
+		// explicit apiUrl/apiToken args) deliberately does NOT touch cache — see the dedicated
+		// ad-hoc test below.
+		async function activeProfileService(): Promise<ProfileService> {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			return service;
+		}
+
 		it("populates authLatencyMs and authCheckedAt on a successful validation", async () => {
 			globalThis.fetch = makeMockResponse(200);
-			const service = ProfileService.init(f5xcConfigDir);
+			const service = await activeProfileService();
 
 			const before = Date.now();
-			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			await service.validateToken();
 			const after = Date.now();
 
 			const status = service.getStatus();
@@ -1116,10 +1128,10 @@ describe("ProfileService", () => {
 
 		it("populates both fields even on a failed validation", async () => {
 			globalThis.fetch = makeNetworkError();
-			const service = ProfileService.init(f5xcConfigDir);
+			const service = await activeProfileService();
 
 			const before = Date.now();
-			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" }).catch(() => {});
+			await service.validateToken().catch(() => {});
 			const after = Date.now();
 
 			const status = service.getStatus();
@@ -1132,9 +1144,9 @@ describe("ProfileService", () => {
 
 		it("stores authCheckedAt as epoch number, not ISO string", async () => {
 			globalThis.fetch = makeMockResponse(200);
-			const service = ProfileService.init(f5xcConfigDir);
+			const service = await activeProfileService();
 
-			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			await service.validateToken();
 
 			const status = service.getStatus();
 			expect(typeof status.authCheckedAt).toBe("number");
@@ -1150,7 +1162,7 @@ describe("ProfileService", () => {
 			globalThis.fetch = makeMockResponse(200);
 			const service = ProfileService.init(f5xcConfigDir);
 			await service.loadActive();
-			await service.validateToken({ apiUrl: TEST_PROFILE.apiUrl, apiToken: TEST_PROFILE.apiToken });
+			await service.validateToken();
 
 			const before = service.getStatus();
 			expect(before.authStatus).toBe("connected");
@@ -1165,6 +1177,42 @@ describe("ProfileService", () => {
 			expect(after.authStatus).toBe("unknown");
 			expect(after.authLatencyMs).toBeUndefined();
 			expect(after.authCheckedAt).toBeUndefined();
+		});
+
+		it("does not overwrite the active profile's cached auth state when called in ad-hoc mode", async () => {
+			// Regression test for cross-profile cache clobber: /profile show <other> calls
+			// validateToken with explicit apiUrl/apiToken to check a profile that is NOT active.
+			// The cached fields (#lastAuthLatencyMs, #lastAuthCheckedAt, #authStatus) are reported
+			// by getStatus() as the ACTIVE profile's auth state, so ad-hoc validation must not
+			// clobber them.
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+
+			globalThis.fetch = makeMockResponse(200);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			await service.validateToken(); // populate cache for active profile
+			const before = service.getStatus();
+			expect(before.authStatus).toBe("connected");
+			expect(typeof before.authLatencyMs).toBe("number");
+			const cachedLatency = before.authLatencyMs;
+			const cachedCheckedAt = before.authCheckedAt;
+
+			// Ad-hoc validate a DIFFERENT profile by passing explicit apiUrl/apiToken.
+			// The result path is 401 — which would set authStatus to "auth_error" if not guarded.
+			globalThis.fetch = makeMockResponse(401);
+			const adHocResult = await service.validateToken({
+				apiUrl: TEST_PROFILE_2.apiUrl,
+				apiToken: TEST_PROFILE_2.apiToken,
+			});
+			expect(adHocResult.status).toBe("auth_error");
+
+			// Active profile's cached state must be unchanged.
+			const after = service.getStatus();
+			expect(after.authStatus).toBe("connected");
+			expect(after.authLatencyMs).toBe(cachedLatency);
+			expect(after.authCheckedAt).toBe(cachedCheckedAt);
 		});
 	});
 });

--- a/packages/coding-agent/test/sdk-profile-integration.test.ts
+++ b/packages/coding-agent/test/sdk-profile-integration.test.ts
@@ -380,4 +380,60 @@ describe("createAgentSession profile tracking", () => {
 		// sessionAManager should be untouched since its listener was unregistered on dispose.
 		expect(sessionAManager.getEntries()).toHaveLength(sessionAEntryCountAtDispose);
 	});
+
+	it("scenario 8: mid-session /profile namespace emits profile_change + custom_message", async () => {
+		// Regression test for the name-only guard bug. /profile namespace staging fires the
+		// listener but keeps the same profile name; previous guard (name-only) skipped emission,
+		// leaving the LLM anchored on the old namespace. New guard (name-or-namespace) emits.
+		await ProfileService.instance.createProfile({
+			name: "prod",
+			apiUrl: "https://acme-corp.console.ves.volterra.io/api",
+			apiToken: "tok",
+			defaultNamespace: "production",
+		});
+		await ProfileService.instance.activate("prod");
+
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			settings,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		try {
+			const entriesBefore = session.sessionManager.getEntries().length;
+
+			ProfileService.instance.setNamespace("staging");
+			await Promise.resolve();
+
+			const added = session.sessionManager.getEntries().slice(entriesBefore);
+			const profileChanges = added.filter(e => e.type === "profile_change");
+			const customMessages = added.filter(
+				e => e.type === "custom_message" && (e as { customType?: string }).customType === "profile_change_notice",
+			);
+
+			expect(profileChanges).toHaveLength(1);
+			expect(profileChanges[0]).toMatchObject({
+				type: "profile_change",
+				profileName: "prod",
+				tenant: "acme-corp",
+				namespace: "staging",
+			});
+			expect(customMessages).toHaveLength(1);
+			const content = (customMessages[0] as { content: string }).content;
+			// Content should mention the namespace change. Exact wording is "[F5 XC namespace
+			// changed to staging]" (not "[Profile switched to prod]" — the name didn't change).
+			expect(content).toContain("namespace changed to staging");
+			expect(content).toContain("Tenant: acme-corp");
+			expect(content).toContain("namespace: staging");
+		} finally {
+			await session.dispose();
+		}
+	});
 });


### PR DESCRIPTION
Three post-merge bugs in PR #290 caught by Codex review. All are regressions introduced by #290 itself. See #292 for full reproducer detail on each.

## Summary

- **P1** — Listener guard now tracks `{name, namespace}` tuple instead of just name. `/profile namespace staging` mid-session now emits both a `profile_change` entry and a `custom_message` directive, so the LLM sees the namespace change on its next turn. Previously the guard missed this event entirely, leaving the LLM anchored on the session-start namespace forever.
- **P2** — `ProfileService.validateToken()` skips cache writes (`authLatencyMs`, `authCheckedAt`, `authStatus`) when called in ad-hoc mode (explicit `apiUrl`/`apiToken`). Previously `/profile show staging` while `prod` was active clobbered `prod`'s cached auth state with `staging`'s latency — subsequent `xcsh://about` / status-line reads reported a confusing mix.
- **P3** — Profile-change listener registration moved to atomic pair with `addDisposeHook()` immediately after `session = new AgentSession(...)`. Wrapped in try/catch so tests and SDK consumers that never initialize ProfileService skip cleanly. Previously, any throw during the ~900 lines of session setup between listener registration and dispose-hook registration would leak the listener onto the static `ProfileService.#onProfileChangeListeners` array, closing over a partially-constructed session.

## Test plan
- [x] `bun check` clean across all workspaces.
- [x] `test/f5xc-profile-service.test.ts` — new test verifies ad-hoc validateToken does not clobber active profile's cache; existing tests updated to use active-profile mode.
- [x] `test/sdk-profile-integration.test.ts` — new scenario 8 verifies `/profile namespace` mid-session emits notice with correct "namespace changed" wording.
- [x] Full regression sweep: 3805 pass, only documented baseline flakes failing (tryAutoConfigLiteLLM, validateModelsConfig, sdk-skills timeouts).

Closes #292.