### PR TITLE
fix: correct xcsh casing in prose, docs, and install-script branding

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,11 @@
 ---
-title: XCSh Documentation
+title: xcsh Documentation
 sidebar:
   order: 0
   label: Overview
 ---
 
-XCSh is an AI-powered development CLI with a TypeScript coding agent and a
+xcsh is an AI-powered development CLI with a TypeScript coding agent and a
 Rust native layer (`pi-natives`). It extends the open-source
 [`badlogic/pi-mono`](https://github.com/badlogic/pi-mono) line with a
 hardened runtime, long-lived sessions with tree navigation and compaction,

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -439,7 +439,7 @@ const OPTION_PROVIDERS: Partial<Record<SettingPath, OptionProvider>> = {
 		{ value: "full", label: "Full", description: "All segments including time" },
 		{ value: "nerd", label: "Nerd", description: "Maximum info with Nerd Font icons" },
 		{ value: "ascii", label: "ASCII", description: "No special characters" },
-		{ value: "xcsh", label: "XCSH", description: "Powerline with OS icon, path, git, plan mode" },
+		{ value: "xcsh", label: "xcsh", description: "Powerline with OS icon, path, git, plan mode" },
 		{ value: "custom", label: "Custom", description: "User-defined segments" },
 	],
 	// Status line separator

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -103,7 +103,7 @@ describe("fork settings schema defaults (PRs #48, #68, theme commits)", () => {
 	});
 });
 
-// ─── XCsh Status Line Preset ──────────────────────────────────────────────
+// ─── xcsh Status Line Preset ──────────────────────────────────────────────
 
 describe("xcsh status line preset (PRs #76, #81)", () => {
 	it("xcsh preset exists in presets registry", () => {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,4 +1,4 @@
-# XCSH Coding Agent Installer for Windows
+# xcsh Coding Agent Installer for Windows
 # Usage: irm https://raw.githubusercontent.com/f5xc-salesdemos/xcsh/main/scripts/install.ps1 | iex
 #
 # Or with options:
@@ -148,7 +148,7 @@ function Configure-BashShell {
         } else {
             Write-Host ""
             Write-Host "⚠ No bash shell found!" -ForegroundColor Yellow
-            Write-Host "  XCSH requires a bash shell on Windows. Options:" -ForegroundColor Yellow
+            Write-Host "  xcsh requires a bash shell on Windows. Options:" -ForegroundColor Yellow
             Write-Host "    1. Install Git for Windows: https://git-scm.com/download/win" -ForegroundColor Yellow
             Write-Host "    2. Use WSL, Cygwin, or MSYS2" -ForegroundColor Yellow
             Write-Host ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-# XCSH Coding Agent Installer
+# xcsh Coding Agent Installer
 # Usage: curl -fsSL https://raw.githubusercontent.com/f5xc-salesdemos/xcsh/main/scripts/install.sh | sh
 #
 # Options:


### PR DESCRIPTION
## What

Lowercase all non-identifier occurrences of the project name across
prose, documentation, and install-script user-facing branding.

Changes (7 edits across 5 files):

- \`docs/index.md\` — frontmatter title + first-paragraph prose
  (\`XCSh\` → \`xcsh\`, 2 changes)
- \`packages/coding-agent/test/regression-guard.test.ts\` — line 106
  comment (\`XCsh\` → \`xcsh\`)
- \`scripts/install.sh\` — line 4 comment (\`XCSH\` → \`xcsh\`)
- \`scripts/install.ps1\` — line 1 comment + line 151 user-facing
  \`Write-Host\` string (\`XCSH\` → \`xcsh\`, 2 changes)
- \`packages/coding-agent/src/modes/components/settings-defs.ts\` —
  line 442 dropdown label (\`XCSH\` → \`xcsh\`)

## Why

A previous refactoring introduced mixed-case \`XCSh\`/\`XCsh\` and
all-caps \`XCSH\` branding in prose. Project convention is that the
name is always written as lowercase \`xcsh\`.

Identifier-shaped uses (\`XCSH_*\` env vars, \`__XCSH_*__\` bash
sentinels, Ruby class \`Xcsh < Formula\` in
\`scripts/ci-release-homebrew.ts\`, Python \`__xcsh_*\` identifiers)
were intentionally left alone — they are not prose and changing
them would break code or external conventions.

Closes #294

## Testing

- [x] Pre-commit lint gate (governance, markdown, shell, biome,
  spelling, editorconfig, secrets) — all passed locally
- [ ] CI checks pass
- [ ] Visual verification of docs site title after merge (if Pages
  triggers)

## Note

\`README.md:1\` has a related \`# XCSh\` → \`# xcsh\` fix that belongs
in this change, but README.md is a docs-control-managed file
(blocked by \`.claude/governance.json\` hook). A separate upstream
issue in \`f5xc-salesdemos/docs-control\` is being filed in parallel.