### PR TITLE
feat(coding-agent): /profile phase 3 — dynamic tab completion

### DIFF
--- a/packages/coding-agent/src/extensibility/slash-commands.ts
+++ b/packages/coding-agent/src/extensibility/slash-commands.ts
@@ -47,9 +47,12 @@ function buildArgumentCompletions(subcommands: SubcommandDef[]): (prefix: string
 				}));
 			return matches.length > 0 ? matches : null;
 		}
-		// Space present: delegate to the matched subcommand's provider.
+		// Space present: delegate to the matched subcommand's provider. Strip
+		// leading whitespace so extra spaces between the subcommand name and its
+		// argument (e.g. `activate  pr`) don't break providers that guard on
+		// `prefix.includes(" ")` as a past-argument signal.
 		const subName = argumentPrefix.slice(0, firstSpace).toLowerCase();
-		const subPrefix = argumentPrefix.slice(firstSpace + 1);
+		const subPrefix = argumentPrefix.slice(firstSpace + 1).replace(/^ +/, "");
 		const sub = subcommands.find(s => s.name === subName);
 		if (!sub?.getArgumentCompletions) return null;
 		const items = sub.getArgumentCompletions(subPrefix);

--- a/packages/coding-agent/src/extensibility/slash-commands.ts
+++ b/packages/coding-agent/src/extensibility/slash-commands.ts
@@ -28,23 +28,39 @@ export type { BuiltinSlashCommand, SubcommandDef } from "../slash-commands/built
 
 /**
  * Build getArgumentCompletions from declarative subcommand definitions.
- * Returns subcommand names filtered by prefix in the dropdown.
+ * Returns subcommand names filtered by prefix in the dropdown, or delegates
+ * to the matched subcommand's provider when a space is present.
  */
 function buildArgumentCompletions(subcommands: SubcommandDef[]): (prefix: string) => AutocompleteItem[] | null {
 	return (argumentPrefix: string) => {
-		if (argumentPrefix.includes(" ")) return null; // past the subcommand
-		const lower = argumentPrefix.toLowerCase();
-		const matches = subcommands
-			.filter(s => s.name.startsWith(lower))
-			.map(s => ({
-				value: `${s.name} `,
-				label: s.name,
-				description: s.description,
-				hint: s.usage,
-			}));
-		return matches.length > 0 ? matches : null;
+		const firstSpace = argumentPrefix.indexOf(" ");
+		if (firstSpace === -1) {
+			// No space yet — filter subcommands by prefix (original behaviour).
+			const lower = argumentPrefix.toLowerCase();
+			const matches = subcommands
+				.filter(s => s.name.toLowerCase().startsWith(lower))
+				.map(s => ({
+					value: `${s.name} `,
+					label: s.name,
+					description: s.description,
+					hint: s.usage,
+				}));
+			return matches.length > 0 ? matches : null;
+		}
+		// Space present: delegate to the matched subcommand's provider.
+		const subName = argumentPrefix.slice(0, firstSpace);
+		const subPrefix = argumentPrefix.slice(firstSpace + 1);
+		const sub = subcommands.find(s => s.name === subName);
+		if (!sub?.getArgumentCompletions) return null;
+		const items = sub.getArgumentCompletions(subPrefix);
+		if (!items || items.length === 0) return null;
+		// Prefix-rewrite values so applyCompletion replaces the full argumentText range.
+		return items.map(item => ({ ...item, value: `${subName} ${item.value}` }));
 	};
 }
+
+/** @internal Test-only named export. Do not import outside `test/`. */
+export const buildArgumentCompletionsForTest = buildArgumentCompletions;
 
 /**
  * Build getInlineHint from declarative subcommand definitions.

--- a/packages/coding-agent/src/extensibility/slash-commands.ts
+++ b/packages/coding-agent/src/extensibility/slash-commands.ts
@@ -48,7 +48,7 @@ function buildArgumentCompletions(subcommands: SubcommandDef[]): (prefix: string
 			return matches.length > 0 ? matches : null;
 		}
 		// Space present: delegate to the matched subcommand's provider.
-		const subName = argumentPrefix.slice(0, firstSpace);
+		const subName = argumentPrefix.slice(0, firstSpace).toLowerCase();
 		const subPrefix = argumentPrefix.slice(firstSpace + 1);
 		const sub = subcommands.find(s => s.name === subName);
 		if (!sub?.getArgumentCompletions) return null;

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -66,6 +66,7 @@ export class ProfileService {
 	#activeProfile: F5XCProfile | null = null;
 	#credentialSource: ProfileStatus["credentialSource"] = "none";
 	#authStatus: AuthStatus = "unknown";
+	#profilesCache: F5XCProfile[] = [];
 
 	private constructor(configDir: string) {
 		this.#configDir = configDir;
@@ -155,6 +156,9 @@ export class ProfileService {
 			return null;
 		}
 
+		// Seed profile cache first so completion has data even if no active profile is set.
+		await this.listProfiles();
+
 		let profileName = this.#readActiveProfileName();
 
 		// FR-104: auto-activate if exactly one profile exists
@@ -200,6 +204,11 @@ export class ProfileService {
 	}
 
 	async activate(name: string): Promise<F5XCProfile> {
+		if (this.#profilesCache.length === 0) {
+			// Self-heal: activate called before loadActive ever ran. Populate cache.
+			await this.listProfiles();
+		}
+
 		// Reject activation when env overrides are present — would create mismatched credentials
 		if (process.env[F5XC_API_URL]) {
 			throw new ProfileError(
@@ -234,7 +243,8 @@ export class ProfileService {
 				profiles.push(profile);
 			}
 		}
-		return profiles;
+		this.#profilesCache = [...profiles].sort((a, b) => a.name.localeCompare(b.name));
+		return this.#profilesCache;
 	}
 
 	async createProfile(profile: Omit<F5XCProfile, "metadata" | "version">): Promise<void> {
@@ -253,6 +263,7 @@ export class ProfileService {
 		const tmpPath = `${profilePath}.tmp`;
 		fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), { mode: 0o600 });
 		fs.renameSync(tmpPath, profilePath);
+		this.#profilesCache = [...this.#profilesCache, data].sort((a, b) => a.name.localeCompare(b.name));
 	}
 
 	async deleteProfile(name: string): Promise<void> {
@@ -262,6 +273,7 @@ export class ProfileService {
 			throw new ProfileError(`Profile '${name}' not found.`, name);
 		}
 		fs.unlinkSync(profilePath);
+		this.#profilesCache = this.#profilesCache.filter(p => p.name !== name);
 	}
 
 	/** Add or update environment variables on a profile. Keys matching secret
@@ -401,6 +413,29 @@ export class ProfileService {
 	/** Sync list of env var keys on the active profile, sorted. [] if no active profile. */
 	getActiveEnvKeys(): string[] {
 		return Object.keys(this.#activeProfile?.env ?? {}).sort();
+	}
+
+	/** Sync list of known profile names, sorted. [] before the first listProfiles()/loadActive(). */
+	listProfileNamesCached(): string[] {
+		return this.#profilesCache.map(p => p.name);
+	}
+
+	/**
+	 * Sync hint for a profile name. Used by the `/profile activate` completion
+	 * to display the tenant URL and a schema-incompatibility badge.
+	 * Returns null if the name is not in the cache.
+	 * `incompatible` is always set; `schemaVersion` is set only when incompatible.
+	 */
+	getProfileHint(name: string): { apiUrl?: string; incompatible: boolean; schemaVersion?: number } | null {
+		const profile = this.#profilesCache.find(p => p.name === name);
+		if (!profile) return null;
+		const version = profile.version;
+		const incompatible = version !== undefined && version > CURRENT_SCHEMA_VERSION;
+		return {
+			apiUrl: profile.apiUrl,
+			incompatible,
+			...(incompatible ? { schemaVersion: version } : {}),
+		};
 	}
 
 	maskToken(token: string): string {

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -68,6 +68,10 @@ export class ProfileService {
 	#authStatus: AuthStatus = "unknown";
 	#profilesCache: F5XCProfile[] = [];
 	#namespacesCache: string[] = [];
+	/** Incremented on every `activate()`. Fire-and-forget namespace body-parses snapshot
+	 * this at fetch time and discard the result if it has advanced — prevents a stale
+	 * in-flight response from overwriting the cache after the active profile changed. */
+	#activationEpoch = 0;
 
 	private constructor(configDir: string) {
 		this.#configDir = configDir;
@@ -232,6 +236,7 @@ export class ProfileService {
 		this.#applyToSettings(profile);
 		this.#credentialSource = hasEnvOverride() ? "mixed" : "profile";
 		this.#namespacesCache = [];
+		this.#activationEpoch += 1;
 		return profile;
 	}
 
@@ -375,20 +380,29 @@ export class ProfileService {
 			const latencyMs = Math.round(performance.now() - start);
 			if (response.ok) {
 				this.#authStatus = "connected";
-				// Only populate the namespace cache when validating the ACTIVE profile with
-				// its own credentials. Skipping explicit-credential calls prevents a
-				// `/profile show <other>` probe from overwriting the active profile's cached
-				// namespaces; skipping the no-active-profile case prevents env-backed sessions
-				// from offering completions to a command path that cannot succeed.
+				// Populate the namespace cache only when the call is validating the ACTIVE
+				// profile's credentials. Explicit creds are accepted when they match the
+				// active profile (this covers the `/profile activate` → `handleShow` flow,
+				// which always forwards the active profile's apiUrl/apiToken). Mismatching
+				// explicit creds (`/profile show <other>`) and no-active-profile env-backed
+				// sessions both skip population so completions never leak the wrong tenant.
+				const active = this.#activeProfile;
 				const isForActiveProfile =
-					options?.apiUrl === undefined && options?.apiToken === undefined && this.#activeProfile !== null;
+					active !== null &&
+					(options?.apiUrl === undefined || options.apiUrl === active.apiUrl) &&
+					(options?.apiToken === undefined || options.apiToken === active.apiToken);
 				if (isForActiveProfile) {
 					// Fire-and-forget: body parse runs in the background so the auth result
 					// returns on headers. Large namespace lists or slow proxies cannot stall
 					// /profile status, /profile show, or startup validation on this path.
+					// The captured epoch guards against stale writes: if `activate()` runs
+					// while the body is still parsing, the epoch advances and this callback
+					// discards its result.
+					const epochAtFetch = this.#activationEpoch;
 					response
 						.json()
 						.then(body => {
+							if (this.#activationEpoch !== epochAtFetch) return;
 							const items = (body as { items?: unknown })?.items;
 							if (Array.isArray(items)) {
 								const names = (items as unknown[])

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -161,7 +161,13 @@ export class ProfileService {
 			return null;
 		}
 
-		// Seed profile cache first so completion has data even if no active profile is set.
+		// Seed the profile cache so `/profile activate <tab>` has data at startup.
+		// listProfiles is declared async but its body uses fs.readdirSync /
+		// readFileSync — the cost is proportional to the number of profile files.
+		// For typical N ≤ 10 on local disk this is sub-millisecond; profiles are
+		// small JSON files. A future refactor to fs.promises + truly async I/O
+		// would let startup proceed in parallel with the reads, but the current
+		// sync form keeps createProfile/deleteProfile race-free with no coordination.
 		await this.listProfiles();
 
 		let profileName = this.#readActiveProfileName();

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -67,6 +67,7 @@ export class ProfileService {
 	#credentialSource: ProfileStatus["credentialSource"] = "none";
 	#authStatus: AuthStatus = "unknown";
 	#profilesCache: F5XCProfile[] = [];
+	#namespacesCache: string[] = [];
 
 	private constructor(configDir: string) {
 		this.#configDir = configDir;
@@ -230,6 +231,7 @@ export class ProfileService {
 		this.#activeProfile = profile;
 		this.#applyToSettings(profile);
 		this.#credentialSource = hasEnvOverride() ? "mixed" : "profile";
+		this.#namespacesCache = [];
 		return profile;
 	}
 
@@ -373,6 +375,19 @@ export class ProfileService {
 			const latencyMs = Math.round(performance.now() - start);
 			if (response.ok) {
 				this.#authStatus = "connected";
+				try {
+					const body = (await response.json()) as { items?: unknown };
+					if (Array.isArray(body.items)) {
+						const names = (body.items as unknown[])
+							.map(i =>
+								typeof i === "object" && i !== null && "name" in i ? (i as { name: unknown }).name : undefined,
+							)
+							.filter((n): n is string => typeof n === "string");
+						this.#namespacesCache = [...names].sort((a, b) => a.localeCompare(b));
+					}
+				} catch {
+					// Body not JSON or parse failed — leave cache untouched.
+				}
 				return { status: "connected", latencyMs };
 			}
 			if (response.status === 401 || response.status === 403) {
@@ -438,6 +453,11 @@ export class ProfileService {
 			incompatible,
 			...(incompatible ? { schemaVersion: version } : {}),
 		};
+	}
+
+	/** Sync namespace names from the most recent successful validateToken response, sorted. */
+	getCachedNamespaces(): string[] {
+		return [...this.#namespacesCache];
 	}
 
 	maskToken(token: string): string {

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -398,14 +398,14 @@ export class ProfileService {
 		};
 	}
 
-	maskToken(token: string): string {
-		if (token.length <= 4) return "****";
-		return `...${token.slice(-4)}`;
-	}
-
 	/** Sync list of env var keys on the active profile, sorted. [] if no active profile. */
 	getActiveEnvKeys(): string[] {
 		return Object.keys(this.#activeProfile?.env ?? {}).sort();
+	}
+
+	maskToken(token: string): string {
+		if (token.length <= 4) return "****";
+		return `...${token.slice(-4)}`;
 	}
 
 	// --- Private helpers ---

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -380,17 +380,18 @@ export class ProfileService {
 			const latencyMs = Math.round(performance.now() - start);
 			if (response.ok) {
 				this.#authStatus = "connected";
-				// Populate the namespace cache only when the call is validating the ACTIVE
-				// profile's credentials. Explicit creds are accepted when they match the
-				// active profile (this covers the `/profile activate` → `handleShow` flow,
-				// which always forwards the active profile's apiUrl/apiToken). Mismatching
-				// explicit creds (`/profile show <other>`) and no-active-profile env-backed
-				// sessions both skip population so completions never leak the wrong tenant.
+				// Populate the namespace cache only when the EFFECTIVE credentials (after
+				// env-override resolution) match the active profile's stored credentials.
+				// This covers the normal startup and `/profile activate → handleShow` paths
+				// while correctly rejecting:
+				//   - `/profile show <other>` — explicit creds for a different profile
+				//   - env-backed sessions — no active profile
+				//   - mixed-source calls — F5XC_API_TOKEN / F5XC_API_URL overrides an
+				//     active profile's creds, so the response reflects a different account
+				//     than the profile `/profile namespace` will mutate
 				const active = this.#activeProfile;
 				const isForActiveProfile =
-					active !== null &&
-					(options?.apiUrl === undefined || options.apiUrl === active.apiUrl) &&
-					(options?.apiToken === undefined || options.apiToken === active.apiToken);
+					active !== null && effectiveUrl === active.apiUrl && effectiveToken === active.apiToken;
 				if (isForActiveProfile) {
 					// Fire-and-forget: body parse runs in the background so the auth result
 					// returns on headers. Large namespace lists or slow proxies cannot stall

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -245,6 +245,14 @@ export class ProfileService {
 		const profiles: F5XCProfile[] = [];
 		for (const file of files) {
 			const name = file.replace(/\.json$/, "");
+			// Skip files whose basename doesn't satisfy the profile-name contract —
+			// they cannot be activated (#validateProfileName would reject), so
+			// surfacing them in /profile list or /profile activate <tab> just
+			// offers users a selection that the handler will immediately refuse.
+			if (!this.#isValidProfileName(name)) {
+				logger.warn("F5XC profile file has invalid name, skipping", { name });
+				continue;
+			}
 			const profile = this.#readProfile(name);
 			if (profile) {
 				profiles.push(profile);
@@ -515,8 +523,12 @@ export class ProfileService {
 		fs.renameSync(tmpPath, filePath);
 	}
 
+	#isValidProfileName(name: string): boolean {
+		return /^[a-zA-Z0-9_-]{1,64}$/.test(name);
+	}
+
 	#validateProfileName(name: string): void {
-		if (!/^[a-zA-Z0-9_-]{1,64}$/.test(name)) {
+		if (!this.#isValidProfileName(name)) {
 			throw new ProfileError(
 				`Invalid profile name: '${name}'. Names must be alphanumeric with dashes/underscores, max 64 chars.`,
 				name,

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -380,18 +380,28 @@ export class ProfileService {
 			const latencyMs = Math.round(performance.now() - start);
 			if (response.ok) {
 				this.#authStatus = "connected";
-				// Populate the namespace cache only when the EFFECTIVE credentials (after
-				// env-override resolution) match the active profile's stored credentials.
-				// This covers the normal startup and `/profile activate → handleShow` paths
-				// while correctly rejecting:
-				//   - `/profile show <other>` — explicit creds for a different profile
-				//   - env-backed sessions — no active profile
-				//   - mixed-source calls — F5XC_API_TOKEN / F5XC_API_URL overrides an
-				//     active profile's creds, so the response reflects a different account
-				//     than the profile `/profile namespace` will mutate
+				// Populate the namespace cache only when:
+				//   - the EFFECTIVE credentials (after env-override resolution) match the
+				//     active profile's stored credentials, AND
+				//   - the session is NOT mixed-source (no F5XC_API_TOKEN / F5XC_NAMESPACE
+				//     env override). In a mixed session, the activate → handleShow path
+				//     passes the profile's own token as options, so effective matches
+				//     active even though the user's actual operational credentials are
+				//     the env override. Suppressing the cache in that case prevents the
+				//     namespace dropdown from showing a list from the profile's account
+				//     when later API ops would run under the override's account.
+				//
+				// Cases handled correctly after these combined guards:
+				//   - startup and `/profile activate → handleShow` (no env override): populate
+				//   - `/profile show <other>` (mismatched explicit creds): skip via effective
+				//   - env-backed session (no active profile): skip via active !== null
+				//   - mixed-source / `F5XC_API_TOKEN` override: skip via !hasEnvOverride
 				const active = this.#activeProfile;
 				const isForActiveProfile =
-					active !== null && effectiveUrl === active.apiUrl && effectiveToken === active.apiToken;
+					!hasEnvOverride() &&
+					active !== null &&
+					effectiveUrl === active.apiUrl &&
+					effectiveToken === active.apiToken;
 				if (isForActiveProfile) {
 					// Fire-and-forget: body parse runs in the background so the auth result
 					// returns on headers. Large namespace lists or slow proxies cannot stall

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -403,6 +403,11 @@ export class ProfileService {
 		return `...${token.slice(-4)}`;
 	}
 
+	/** Sync list of env var keys on the active profile, sorted. [] if no active profile. */
+	getActiveEnvKeys(): string[] {
+		return Object.keys(this.#activeProfile?.env ?? {}).sort();
+	}
+
 	// --- Private helpers ---
 
 	#atomicWrite(filePath: string, content: string): void {

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -204,16 +204,16 @@ export class ProfileService {
 	}
 
 	async activate(name: string): Promise<F5XCProfile> {
-		if (this.#profilesCache.length === 0) {
-			// Self-heal: activate called before loadActive ever ran. Populate cache.
-			await this.listProfiles();
-		}
-
-		// Reject activation when env overrides are present — would create mismatched credentials
+		// Reject activation when env overrides are present — before any I/O
 		if (process.env[F5XC_API_URL]) {
 			throw new ProfileError(
 				"Cannot activate: F5XC_API_URL environment variable overrides profile. Run `unset F5XC_API_URL` first, or restart without it.",
 			);
+		}
+
+		// Self-heal: activate called before loadActive ever ran. Populate cache.
+		if (this.#profilesCache.length === 0) {
+			await this.listProfiles();
 		}
 
 		this.#validateProfileName(name);
@@ -244,7 +244,7 @@ export class ProfileService {
 			}
 		}
 		this.#profilesCache = [...profiles].sort((a, b) => a.name.localeCompare(b.name));
-		return this.#profilesCache;
+		return [...this.#profilesCache];
 	}
 
 	async createProfile(profile: Omit<F5XCProfile, "metadata" | "version">): Promise<void> {
@@ -304,6 +304,7 @@ export class ProfileService {
 		};
 		const profilePath = path.join(this.profilesDir, `${name}.json`);
 		this.#atomicWrite(profilePath, JSON.stringify(updated, null, 2));
+		this.#profilesCache = this.#profilesCache.map(p => (p.name === name ? updated : p));
 
 		if (this.#activeProfile?.name === name) {
 			this.#activeProfile = updated;
@@ -341,6 +342,7 @@ export class ProfileService {
 		};
 		const profilePath = path.join(this.profilesDir, `${name}.json`);
 		this.#atomicWrite(profilePath, JSON.stringify(updated, null, 2));
+		this.#profilesCache = this.#profilesCache.map(p => (p.name === name ? updated : p));
 
 		if (this.#activeProfile?.name === name) {
 			this.#activeProfile = updated;

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -375,18 +375,35 @@ export class ProfileService {
 			const latencyMs = Math.round(performance.now() - start);
 			if (response.ok) {
 				this.#authStatus = "connected";
-				try {
-					const body = (await response.json()) as { items?: unknown };
-					if (Array.isArray(body.items)) {
-						const names = (body.items as unknown[])
-							.map(i =>
-								typeof i === "object" && i !== null && "name" in i ? (i as { name: unknown }).name : undefined,
-							)
-							.filter((n): n is string => typeof n === "string");
-						this.#namespacesCache = [...names].sort((a, b) => a.localeCompare(b));
-					}
-				} catch {
-					// Body not JSON or parse failed — leave cache untouched.
+				// Only populate the namespace cache when validating the ACTIVE profile with
+				// its own credentials. Skipping explicit-credential calls prevents a
+				// `/profile show <other>` probe from overwriting the active profile's cached
+				// namespaces; skipping the no-active-profile case prevents env-backed sessions
+				// from offering completions to a command path that cannot succeed.
+				const isForActiveProfile =
+					options?.apiUrl === undefined && options?.apiToken === undefined && this.#activeProfile !== null;
+				if (isForActiveProfile) {
+					// Fire-and-forget: body parse runs in the background so the auth result
+					// returns on headers. Large namespace lists or slow proxies cannot stall
+					// /profile status, /profile show, or startup validation on this path.
+					response
+						.json()
+						.then(body => {
+							const items = (body as { items?: unknown })?.items;
+							if (Array.isArray(items)) {
+								const names = (items as unknown[])
+									.map(i =>
+										typeof i === "object" && i !== null && "name" in i
+											? (i as { name: unknown }).name
+											: undefined,
+									)
+									.filter((n): n is string => typeof n === "string");
+								this.#namespacesCache = [...names].sort((a, b) => a.localeCompare(b));
+							}
+						})
+						.catch(() => {
+							// Body not JSON or parse failed — leave cache untouched.
+						});
 				}
 				return { status: "connected", latencyMs };
 			}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -27,8 +27,13 @@ import { parseMarketplaceInstallArgs, parsePluginScopeArgs } from "./marketplace
 function tryGetProfileService(): ProfileService | null {
 	try {
 		return ProfileService.instance;
-	} catch {
-		return null;
+	} catch (err) {
+		// Expected only when the service hasn't been init()'d yet. Any other error
+		// is surfaced by rethrowing so the TUI's unhandled-rejection path logs it.
+		if (err instanceof Error && err.message.includes("not initialized")) {
+			return null;
+		}
+		throw err;
 	}
 }
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -21,7 +21,16 @@ import {
 	MarketplaceManager,
 } from "../extensibility/plugins/marketplace";
 import type { InteractiveModeContext } from "../modes/types";
+import { ProfileService } from "../services/f5xc-profile";
 import { parseMarketplaceInstallArgs, parsePluginScopeArgs } from "./marketplace-install-parser";
+
+function tryGetProfileService(): ProfileService | null {
+	try {
+		return ProfileService.instance;
+	} catch {
+		return null;
+	}
+}
 
 function refreshStatusLine(ctx: InteractiveModeContext): void {
 	ctx.statusLine.invalidate();
@@ -973,7 +982,34 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 		allowArgs: true,
 		subcommands: [
 			{ name: "list", description: "List all profiles" },
-			{ name: "activate", description: "Switch to a named profile", usage: "<name>" },
+			{
+				name: "activate",
+				description: "Switch to a named profile",
+				usage: "<name>",
+				getArgumentCompletions(prefix: string) {
+					if (prefix.includes(" ")) return null;
+					const svc = tryGetProfileService();
+					if (!svc) return null;
+					const lower = prefix.toLowerCase();
+					const items = svc
+						.listProfileNamesCached()
+						.filter(n => n.toLowerCase().startsWith(lower))
+						.map(n => {
+							const hint = svc.getProfileHint(n);
+							const parts: string[] = [];
+							if (hint?.apiUrl) parts.push(hint.apiUrl);
+							if (hint?.incompatible && hint.schemaVersion !== undefined) {
+								parts.push(`incompatible: v${hint.schemaVersion}`);
+							}
+							return {
+								value: n,
+								label: n,
+								description: parts.length > 0 ? parts.join(" · ") : undefined,
+							};
+						});
+					return items.length > 0 ? items : null;
+				},
+			},
 			{ name: "show", description: "Show profile details (masked)", usage: "[name]" },
 			{ name: "status", description: "Show current auth status" },
 			{ name: "create", description: "Create a new profile", usage: "<name> <url> <token> [namespace]" },

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1048,19 +1048,22 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 				usage: "KEY [KEY2 ...]",
 				getArgumentCompletions(prefix: string) {
 					const lastSpace = prefix.lastIndexOf(" ");
-					const head = lastSpace === -1 ? "" : prefix.slice(0, lastSpace + 1);
+					const headRaw = lastSpace === -1 ? "" : prefix.slice(0, lastSpace + 1);
 					const tail = lastSpace === -1 ? prefix : prefix.slice(lastSpace + 1);
 					const svc = tryGetProfileService();
 					if (!svc) return null;
-					const alreadyLower = new Set(
-						head
-							.trim()
-							.split(/\s+/)
-							.filter(Boolean)
-							.map(k => k.toLowerCase()),
-					);
-					const items = svc
-						.getActiveEnvKeys()
+					const knownKeys = svc.getActiveEnvKeys();
+					const canonicalByLower = new Map(knownKeys.map(k => [k.toLowerCase(), k]));
+					// Normalize already-typed tokens to their canonical case from the active
+					// profile's env map. unsetEnvVars does a case-sensitive `key in env`
+					// match, so a user who typed `/profile unset f5xc_email F<tab>` would
+					// otherwise end up with a command that silently skips f5xc_email even
+					// though the dropdown accepted it as "already selected".
+					const typedTokens = headRaw.trim().split(/\s+/).filter(Boolean);
+					const normalizedTokens = typedTokens.map(t => canonicalByLower.get(t.toLowerCase()) ?? t);
+					const head = normalizedTokens.length > 0 ? `${normalizedTokens.join(" ")} ` : "";
+					const alreadyLower = new Set(typedTokens.map(t => t.toLowerCase()));
+					const items = knownKeys
 						.filter(k => !alreadyLower.has(k.toLowerCase()))
 						.filter(k => k.toLowerCase().startsWith(tail.toLowerCase()))
 						.map(k => ({

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -35,7 +35,18 @@ export interface SubcommandDef {
 	description: string;
 	/** Usage hint shown as dim ghost text, e.g. "<name> [--scope project|user]". */
 	usage?: string;
-	/** Optional sync provider for dynamic completions of this subcommand's arguments. */
+	/**
+	 * Optional sync provider for dynamic completions of this subcommand's arguments.
+	 *
+	 * `argumentPrefix` is the text after the subcommand name and its trailing space.
+	 * For multi-token arguments (e.g. `/profile unset KEY1 KEY2`), the provider
+	 * receives the full tail (`"KEY1 KEY2"`) and must return items whose `value`
+	 * contains the complete replacement for that tail — including any already-typed
+	 * tokens the user should keep. The infrastructure prepends `<subcommand> ` to
+	 * each returned `value` before handing items to `applyCompletion`.
+	 *
+	 * Return `null` or `[]` to signal "no dropdown"; both are treated identically.
+	 */
 	getArgumentCompletions?: (argumentPrefix: string) => AutocompleteItem[] | null;
 }
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1027,6 +1027,11 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 					if (prefix.includes(" ")) return null;
 					const svc = tryGetProfileService();
 					if (!svc) return null;
+					// setNamespace() requires an active profile. Don't offer completions that
+					// would lead the user into a command path that cannot succeed (e.g. an
+					// env-backed session where cached namespaces came from startup validation
+					// but there is no active profile to apply them to).
+					if (!svc.getStatus().activeProfileName) return null;
 					const lower = prefix.toLowerCase();
 					const items = svc
 						.getCachedNamespaces()

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1054,26 +1054,31 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 					if (!svc) return null;
 					const knownKeys = svc.getActiveEnvKeys();
 					const knownExact = new Set(knownKeys);
-					// First-match-wins to preserve case-distinct keys (e.g. `Foo` + `FOO`
-					// in the same env record). Last-match-wins would rewrite one variant
-					// to the other during normalization.
-					const canonicalByLower = new Map<string, string>();
+					// Group known keys by their lowercased form so we can detect
+					// case-distinct collisions (e.g. both `Foo` and `FOO` present).
+					const variantsByLower = new Map<string, string[]>();
 					for (const k of knownKeys) {
 						const lower = k.toLowerCase();
-						if (!canonicalByLower.has(lower)) canonicalByLower.set(lower, k);
+						const existing = variantsByLower.get(lower);
+						if (existing) existing.push(k);
+						else variantsByLower.set(lower, [k]);
 					}
 					// Normalization priority:
 					//   1. Exact-case match → preserve user's token verbatim
-					//   2. Case-insensitive match → rewrite to canonical (first-seen)
-					//   3. Unknown → preserve as-typed so typos surface via handler
-					// Prior case-insensitive dedup exists so user typing `/profile unset
-					// f5xc_email F<tab>` still produces `F5XC_EMAIL F5XC_USERNAME` (the
-					// common case). But dedup now uses the post-normalization token, which
-					// is case-specific — so `Foo` vs `FOO` remain individually targetable.
+					//   2. Lowercase maps to exactly one canonical → rewrite (the common
+					//      "user typed lowercase, profile has uppercase" path)
+					//   3. Lowercase maps to multiple canonicals (ambiguous) → preserve
+					//      as-typed. Auto-picking one would silently target the wrong
+					//      variable. The handler will match nothing and report a no-op,
+					//      letting the user retype the exact case they meant.
+					//   4. No match → preserve as-typed so typos surface via handler.
 					const typedTokens = headRaw.trim().split(/\s+/).filter(Boolean);
-					const normalizedTokens = typedTokens.map(t =>
-						knownExact.has(t) ? t : (canonicalByLower.get(t.toLowerCase()) ?? t),
-					);
+					const normalizedTokens = typedTokens.map(t => {
+						if (knownExact.has(t)) return t;
+						const variants = variantsByLower.get(t.toLowerCase());
+						if (variants && variants.length === 1) return variants[0];
+						return t;
+					});
 					const head = normalizedTokens.length > 0 ? `${normalizedTokens.join(" ")} ` : "";
 					const alreadyExact = new Set(normalizedTokens);
 					const items = knownKeys

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1019,7 +1019,22 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 			{ name: "status", description: "Show current auth status" },
 			{ name: "create", description: "Create a new profile", usage: "<name> <url> <token> [namespace]" },
 			{ name: "delete", description: "Delete a profile", usage: "<name> --confirm" },
-			{ name: "namespace", description: "Switch namespace within active profile", usage: "<namespace>" },
+			{
+				name: "namespace",
+				description: "Switch namespace within active profile",
+				usage: "<namespace>",
+				getArgumentCompletions(prefix: string) {
+					if (prefix.includes(" ")) return null;
+					const svc = tryGetProfileService();
+					if (!svc) return null;
+					const lower = prefix.toLowerCase();
+					const items = svc
+						.getCachedNamespaces()
+						.filter(n => n.toLowerCase().startsWith(lower))
+						.map(n => ({ value: n, label: n }));
+					return items.length > 0 ? items : null;
+				},
+			},
 			{ name: "env", description: "Manage environment variables", usage: "set|unset|list [KEY=VALUE ...]" },
 			{ name: "set", description: "Set environment variable(s)", usage: "KEY=VALUE [KEY2=VALUE2 ...]" },
 			{

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1032,10 +1032,16 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 					const tail = lastSpace === -1 ? prefix : prefix.slice(lastSpace + 1);
 					const svc = tryGetProfileService();
 					if (!svc) return null;
-					const already = new Set(head.trim().split(/\s+/).filter(Boolean));
+					const alreadyLower = new Set(
+						head
+							.trim()
+							.split(/\s+/)
+							.filter(Boolean)
+							.map(k => k.toLowerCase()),
+					);
 					const items = svc
 						.getActiveEnvKeys()
-						.filter(k => !already.has(k))
+						.filter(k => !alreadyLower.has(k.toLowerCase()))
 						.filter(k => k.toLowerCase().startsWith(tail.toLowerCase()))
 						.map(k => ({
 							value: `${head}${k} `,

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1053,18 +1053,31 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 					const svc = tryGetProfileService();
 					if (!svc) return null;
 					const knownKeys = svc.getActiveEnvKeys();
-					const canonicalByLower = new Map(knownKeys.map(k => [k.toLowerCase(), k]));
-					// Normalize already-typed tokens to their canonical case from the active
-					// profile's env map. unsetEnvVars does a case-sensitive `key in env`
-					// match, so a user who typed `/profile unset f5xc_email F<tab>` would
-					// otherwise end up with a command that silently skips f5xc_email even
-					// though the dropdown accepted it as "already selected".
+					const knownExact = new Set(knownKeys);
+					// First-match-wins to preserve case-distinct keys (e.g. `Foo` + `FOO`
+					// in the same env record). Last-match-wins would rewrite one variant
+					// to the other during normalization.
+					const canonicalByLower = new Map<string, string>();
+					for (const k of knownKeys) {
+						const lower = k.toLowerCase();
+						if (!canonicalByLower.has(lower)) canonicalByLower.set(lower, k);
+					}
+					// Normalization priority:
+					//   1. Exact-case match → preserve user's token verbatim
+					//   2. Case-insensitive match → rewrite to canonical (first-seen)
+					//   3. Unknown → preserve as-typed so typos surface via handler
+					// Prior case-insensitive dedup exists so user typing `/profile unset
+					// f5xc_email F<tab>` still produces `F5XC_EMAIL F5XC_USERNAME` (the
+					// common case). But dedup now uses the post-normalization token, which
+					// is case-specific — so `Foo` vs `FOO` remain individually targetable.
 					const typedTokens = headRaw.trim().split(/\s+/).filter(Boolean);
-					const normalizedTokens = typedTokens.map(t => canonicalByLower.get(t.toLowerCase()) ?? t);
+					const normalizedTokens = typedTokens.map(t =>
+						knownExact.has(t) ? t : (canonicalByLower.get(t.toLowerCase()) ?? t),
+					);
 					const head = normalizedTokens.length > 0 ? `${normalizedTokens.join(" ")} ` : "";
-					const alreadyLower = new Set(typedTokens.map(t => t.toLowerCase()));
+					const alreadyExact = new Set(normalizedTokens);
 					const items = knownKeys
-						.filter(k => !alreadyLower.has(k.toLowerCase()))
+						.filter(k => !alreadyExact.has(k))
 						.filter(k => k.toLowerCase().startsWith(tail.toLowerCase()))
 						.map(k => ({
 							value: `${head}${k} `,

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -2,6 +2,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { getOAuthProviders } from "@f5xc-salesdemos/pi-ai";
+import type { AutocompleteItem } from "@f5xc-salesdemos/pi-tui";
 import { getConfigDirName } from "@f5xc-salesdemos/pi-utils";
 import { invalidate as invalidateFsCache } from "../capability/fs";
 import type { SettingPath, SettingValue } from "../config/settings";
@@ -34,6 +35,8 @@ export interface SubcommandDef {
 	description: string;
 	/** Usage hint shown as dim ghost text, e.g. "<name> [--scope project|user]". */
 	usage?: string;
+	/** Optional sync provider for dynamic completions of this subcommand's arguments. */
+	getArgumentCompletions?: (argumentPrefix: string) => AutocompleteItem[] | null;
 }
 
 /** Declarative builtin slash command definition used by autocomplete and help UI. */

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1022,7 +1022,29 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 			{ name: "namespace", description: "Switch namespace within active profile", usage: "<namespace>" },
 			{ name: "env", description: "Manage environment variables", usage: "set|unset|list [KEY=VALUE ...]" },
 			{ name: "set", description: "Set environment variable(s)", usage: "KEY=VALUE [KEY2=VALUE2 ...]" },
-			{ name: "unset", description: "Remove environment variable(s)", usage: "KEY [KEY2 ...]" },
+			{
+				name: "unset",
+				description: "Remove environment variable(s)",
+				usage: "KEY [KEY2 ...]",
+				getArgumentCompletions(prefix: string) {
+					const lastSpace = prefix.lastIndexOf(" ");
+					const head = lastSpace === -1 ? "" : prefix.slice(0, lastSpace + 1);
+					const tail = lastSpace === -1 ? prefix : prefix.slice(lastSpace + 1);
+					const svc = tryGetProfileService();
+					if (!svc) return null;
+					const already = new Set(head.trim().split(/\s+/).filter(Boolean));
+					const items = svc
+						.getActiveEnvKeys()
+						.filter(k => !already.has(k))
+						.filter(k => k.toLowerCase().startsWith(tail.toLowerCase()))
+						.map(k => ({
+							value: `${head}${k} `,
+							label: k,
+							description: "env var on active profile",
+						}));
+					return items.length > 0 ? items : null;
+				},
+			},
 		],
 		handle: async (command, runtime) => {
 			const { handleProfileCommand } = await import("../services/f5xc-profile-command");

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1260,6 +1260,27 @@ describe("ProfileService", () => {
 			}
 		});
 
+		it("env override alongside activate→handleShow's explicit-creds path does NOT populate cache", async () => {
+			// /profile activate calls activate() then handleShow() which passes the
+			// profile's own apiUrl/apiToken as explicit options. With F5XC_API_TOKEN
+			// also set, the effective comparison would pass (options override env in
+			// effectiveToken computation), but the session remains mixed-source — the
+			// namespace list returned for the profile's token doesn't match what the
+			// user's actual operational calls will see under the env override token.
+			// !hasEnvOverride() catches this case.
+			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "profile-account-ns" }] });
+			const service = await setupActiveProfile();
+			try {
+				process.env.F5XC_API_TOKEN = "env-override-token";
+				// Simulate handleShow's explicit-creds call for the active profile.
+				await service.validateToken({ apiUrl: TEST_PROFILE.apiUrl, apiToken: TEST_PROFILE.apiToken });
+				await waitForCachePopulate();
+				expect(service.getCachedNamespaces()).toEqual([]);
+			} finally {
+				delete process.env.F5XC_API_TOKEN;
+			}
+		});
+
 		it("stale in-flight namespace response is discarded when activate() intervenes", async () => {
 			writeProfile(f5xcProfilesDir, TEST_PROFILE);
 			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1153,7 +1153,7 @@ describe("ProfileService", () => {
 			expect(hint).not.toBeNull();
 			expect(hint!.apiUrl).toBe(TEST_PROFILE.apiUrl);
 			expect(hint!.incompatible).toBe(false);
-			expect(hint!.schemaVersion).toBeUndefined();
+			expect("schemaVersion" in hint!).toBe(false);
 		});
 
 		it("getProfileHint returns incompatible=true and schemaVersion for schema v2 profile", async () => {

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1089,10 +1089,7 @@ describe("ProfileService", () => {
 			const service = ProfileService.init(f5xcConfigDir);
 			await service.loadActive();
 			const keys = service.getActiveEnvKeys();
-			expect(keys).toEqual([...Object.keys(TEST_PROFILE_ENV.env!)].sort());
-			// Sanity: the fixture has at least F5XC_EMAIL and F5XC_USERNAME
-			expect(keys).toContain("F5XC_EMAIL");
-			expect(keys).toContain("F5XC_USERNAME");
+			expect(keys).toEqual(Object.keys(TEST_PROFILE_WITH_ENV.env).sort());
 		});
 	});
 });

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1220,13 +1220,60 @@ describe("ProfileService", () => {
 			expect(service.getCachedNamespaces()).toEqual(["default", "production", "shared"]);
 		});
 
-		it("validateToken with explicit apiUrl/apiToken does NOT populate cache (prevents /profile show <other> tenant leakage)", async () => {
+		it("validateToken with explicit creds for a NON-active profile does NOT populate cache (prevents /profile show <other> tenant leakage)", async () => {
 			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "staging-ns" }] });
 			const service = await setupActiveProfile();
 			// Simulate handleShow probing another profile's credentials — cache must
 			// remain scoped to the active profile.
 			await service.validateToken({ apiUrl: "https://other.console.ves.volterra.io", apiToken: "other-tok" });
 			await waitForCachePopulate();
+			expect(service.getCachedNamespaces()).toEqual([]);
+		});
+
+		it("validateToken with explicit creds MATCHING the active profile DOES populate cache (activate → handleShow flow)", async () => {
+			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }, { name: "ns2" }] });
+			const service = await setupActiveProfile();
+			// handleActivate calls activate() (clears cache) and then handleShow(), which
+			// always passes explicit creds. When those creds match the active profile,
+			// the cache must warm — otherwise /profile namespace <tab> would be empty
+			// immediately after activation until some other path fires validateToken().
+			await service.validateToken({ apiUrl: TEST_PROFILE.apiUrl, apiToken: TEST_PROFILE.apiToken });
+			await waitForCachePopulate();
+			expect(service.getCachedNamespaces()).toEqual(["ns1", "ns2"]);
+		});
+
+		it("stale in-flight namespace response is discarded when activate() intervenes", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+
+			// Build a fetch mock whose body resolution we hold until after activate() runs.
+			let releaseBody: (body: unknown) => void = () => {};
+			const bodyPromise = new Promise<unknown>(resolve => {
+				releaseBody = resolve;
+			});
+			globalThis.fetch = (() =>
+				Promise.resolve({
+					ok: true,
+					status: 200,
+					json: () => bodyPromise,
+				} as unknown as Response)) as unknown as typeof globalThis.fetch;
+
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			// validateToken returns on headers; the fire-and-forget body parse is now stalled.
+			await service.validateToken();
+
+			// Activate a different profile — clears the cache AND advances the epoch.
+			await service.activate(TEST_PROFILE_2.name);
+			expect(service.getCachedNamespaces()).toEqual([]);
+
+			// Release the stalled body with the first profile's namespaces. The .then()
+			// callback captured the prior epoch and must now discard the write.
+			releaseBody({ items: [{ name: "stale-from-prior-profile" }] });
+			await waitForCachePopulate();
+
 			expect(service.getCachedNamespaces()).toEqual([]);
 		});
 

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1165,6 +1165,32 @@ describe("ProfileService", () => {
 			expect(hint!.incompatible).toBe(true);
 			expect(hint!.schemaVersion).toBe(2);
 		});
+
+		it("listProfiles skips files whose basename fails the profile-name regex", async () => {
+			// A well-formed profile that will be listed.
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			// A stray file (copied/synced manually) whose basename has a space — can
+			// never be activated because #validateProfileName would reject it, so
+			// /profile list and /profile activate <tab> must also hide it.
+			fs.mkdirSync(f5xcProfilesDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(f5xcProfilesDir, "bad name.json"),
+				JSON.stringify({
+					apiUrl: TEST_PROFILE.apiUrl,
+					apiToken: TEST_PROFILE.apiToken,
+					defaultNamespace: "default",
+				}),
+				{ mode: 0o600 },
+			);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const names = service.listProfileNamesCached();
+			expect(names).toContain(TEST_PROFILE.name);
+			expect(names).not.toContain("bad name");
+			const listed = await service.listProfiles();
+			expect(listed.map(p => p.name)).not.toContain("bad name");
+		});
 	});
 
 	describe("namespace cache", () => {

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -8,12 +8,14 @@ import { type F5XCProfile, ProfileError, ProfileService } from "@f5xc-salesdemos
 import {
 	TEST_PROFILE as _TEST_PROFILE,
 	TEST_PROFILE_STAGING as _TEST_PROFILE_STAGING,
+	TEST_PROFILE_INCOMPATIBLE,
 	TEST_PROFILE_WITH_ENV,
 } from "./f5xc-test-fixtures";
 
 const TEST_PROFILE: F5XCProfile = { ..._TEST_PROFILE };
 const TEST_PROFILE_2: F5XCProfile = { ..._TEST_PROFILE_STAGING };
 const TEST_PROFILE_ENV: F5XCProfile = { ...TEST_PROFILE_WITH_ENV };
+const TEST_PROFILE_INCOMPAT: F5XCProfile = { ...TEST_PROFILE_INCOMPATIBLE };
 
 function writeProfile(profilesDir: string, profile: F5XCProfile): void {
 	fs.mkdirSync(profilesDir, { recursive: true });
@@ -1090,6 +1092,78 @@ describe("ProfileService", () => {
 			await service.loadActive();
 			const keys = service.getActiveEnvKeys();
 			expect(keys).toEqual(Object.keys(TEST_PROFILE_WITH_ENV.env).sort());
+		});
+	});
+
+	describe("profiles cache (listProfileNamesCached + getProfileHint)", () => {
+		it("listProfileNamesCached returns [] between init() and loadActive()", () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+			const service = ProfileService.init(f5xcConfigDir);
+			expect(service.listProfileNamesCached()).toEqual([]);
+		});
+
+		it("populates from loadActive() and returns sorted names", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE); // "production"
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_2); // "staging"
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			expect(service.listProfileNamesCached()).toEqual(["production", "staging"]);
+		});
+
+		it("refreshes cache when listProfiles() is called again after a direct filesystem change", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			expect(service.listProfileNamesCached()).toEqual(["production"]);
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_2); // simulate sibling-process add
+			await service.listProfiles(); // cache updates via this call
+			expect(service.listProfileNamesCached()).toEqual(["production", "staging"]);
+		});
+
+		it("createProfile updates cache in place", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			await service.createProfile(TEST_PROFILE_2);
+			expect(service.listProfileNamesCached()).toEqual(["production", "staging"]);
+		});
+
+		it("deleteProfile removes from cache", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			await service.deleteProfile("staging");
+			expect(service.listProfileNamesCached()).toEqual(["production"]);
+		});
+
+		it("getProfileHint returns null for unknown name", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			expect(service.getProfileHint("nope")).toBeNull();
+		});
+
+		it("getProfileHint returns apiUrl and incompatible=false for compatible profile", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			const hint = service.getProfileHint("production");
+			expect(hint).not.toBeNull();
+			expect(hint!.apiUrl).toBe(TEST_PROFILE.apiUrl);
+			expect(hint!.incompatible).toBe(false);
+			expect(hint!.schemaVersion).toBeUndefined();
+		});
+
+		it("getProfileHint returns incompatible=true and schemaVersion for schema v2 profile", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_INCOMPAT);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			const hint = service.getProfileHint(TEST_PROFILE_INCOMPAT.name);
+			expect(hint).not.toBeNull();
+			expect(hint!.incompatible).toBe(true);
+			expect(hint!.schemaVersion).toBe(2);
 		});
 	});
 });

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -8,12 +8,12 @@ import { type F5XCProfile, ProfileError, ProfileService } from "@f5xc-salesdemos
 import {
 	TEST_PROFILE as _TEST_PROFILE,
 	TEST_PROFILE_STAGING as _TEST_PROFILE_STAGING,
-	TEST_PROFILE_WITH_ENV as _TEST_PROFILE_WITH_ENV,
+	TEST_PROFILE_WITH_ENV,
 } from "./f5xc-test-fixtures";
 
 const TEST_PROFILE: F5XCProfile = { ..._TEST_PROFILE };
 const TEST_PROFILE_2: F5XCProfile = { ..._TEST_PROFILE_STAGING };
-const TEST_PROFILE_ENV: F5XCProfile = { ..._TEST_PROFILE_WITH_ENV };
+const TEST_PROFILE_ENV: F5XCProfile = { ...TEST_PROFILE_WITH_ENV };
 
 function writeProfile(profilesDir: string, profile: F5XCProfile): void {
 	fs.mkdirSync(profilesDir, { recursive: true });
@@ -1074,6 +1074,25 @@ describe("ProfileService", () => {
 			const result = await service.validateToken({});
 			expect(result.status).toBe("unknown");
 			expect(result.errorClass).toBeUndefined();
+		});
+	});
+
+	describe("getActiveEnvKeys", () => {
+		it("returns [] when no active profile", () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			expect(service.getActiveEnvKeys()).toEqual([]);
+		});
+
+		it("returns sorted keys from active profile's env record", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_ENV);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE_ENV.name);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			const keys = service.getActiveEnvKeys();
+			expect(keys).toEqual([...Object.keys(TEST_PROFILE_ENV.env!)].sort());
+			// Sanity: the fixture has at least F5XC_EMAIL and F5XC_USERNAME
+			expect(keys).toContain("F5XC_EMAIL");
+			expect(keys).toContain("F5XC_USERNAME");
 		});
 	});
 });

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1166,4 +1166,78 @@ describe("ProfileService", () => {
 			expect(hint!.schemaVersion).toBe(2);
 		});
 	});
+
+	describe("namespace cache", () => {
+		let savedFetch: typeof globalThis.fetch;
+		beforeEach(() => {
+			savedFetch = globalThis.fetch;
+		});
+		afterEach(() => {
+			globalThis.fetch = savedFetch;
+		});
+
+		function makeMockJsonResponse(status: number, body: unknown): typeof globalThis.fetch {
+			const fn = () =>
+				Promise.resolve(
+					new Response(JSON.stringify(body), {
+						status,
+						headers: { "Content-Type": "application/json" },
+					}),
+				);
+			return fn as unknown as typeof globalThis.fetch;
+		}
+		function makeMockTextResponse(status: number, body = "err"): typeof globalThis.fetch {
+			const fn = () => Promise.resolve(new Response(body, { status }));
+			return fn as unknown as typeof globalThis.fetch;
+		}
+
+		it("getCachedNamespaces returns [] before any validateToken call", () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			expect(service.getCachedNamespaces()).toEqual([]);
+		});
+
+		it("validateToken 2xx with JSON body populates namespace cache sorted by name", async () => {
+			globalThis.fetch = makeMockJsonResponse(200, {
+				items: [{ name: "production" }, { name: "default" }, { name: "shared" }],
+			});
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(service.getCachedNamespaces()).toEqual(["default", "production", "shared"]);
+		});
+
+		it("validateToken 5xx response leaves cache unchanged", async () => {
+			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }] });
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(service.getCachedNamespaces()).toEqual(["ns1"]);
+			globalThis.fetch = makeMockTextResponse(502);
+			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(service.getCachedNamespaces()).toEqual(["ns1"]); // unchanged
+		});
+
+		it("validateToken 2xx with malformed body (items is not an array) leaves cache unchanged", async () => {
+			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }] });
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(service.getCachedNamespaces()).toEqual(["ns1"]);
+
+			globalThis.fetch = makeMockJsonResponse(200, { items: "not-an-array" });
+			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(service.getCachedNamespaces()).toEqual(["ns1"]); // unchanged
+		});
+
+		it("activate(otherProfile) clears the namespace cache", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }, { name: "ns2" }] });
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(service.getCachedNamespaces()).toEqual(["ns1", "ns2"]);
+
+			await service.activate(TEST_PROFILE_2.name);
+			expect(service.getCachedNamespaces()).toEqual([]);
+		});
+	});
 });

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1191,49 +1191,89 @@ describe("ProfileService", () => {
 			return fn as unknown as typeof globalThis.fetch;
 		}
 
+		// validateToken's cache population is fire-and-forget (body parse runs off the
+		// hot path). Tests must yield to the microtask queue before asserting cache state.
+		function waitForCachePopulate(): Promise<void> {
+			return new Promise(resolve => setTimeout(resolve, 10));
+		}
+
+		async function setupActiveProfile(): Promise<ProfileService> {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			return service;
+		}
+
 		it("getCachedNamespaces returns [] before any validateToken call", () => {
 			const service = ProfileService.init(f5xcConfigDir);
 			expect(service.getCachedNamespaces()).toEqual([]);
 		});
 
-		it("validateToken 2xx with JSON body populates namespace cache sorted by name", async () => {
+		it("validateToken for active profile populates namespace cache sorted by name", async () => {
 			globalThis.fetch = makeMockJsonResponse(200, {
 				items: [{ name: "production" }, { name: "default" }, { name: "shared" }],
 			});
-			const service = ProfileService.init(f5xcConfigDir);
-			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			const service = await setupActiveProfile();
+			await service.validateToken();
+			await waitForCachePopulate();
 			expect(service.getCachedNamespaces()).toEqual(["default", "production", "shared"]);
+		});
+
+		it("validateToken with explicit apiUrl/apiToken does NOT populate cache (prevents /profile show <other> tenant leakage)", async () => {
+			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "staging-ns" }] });
+			const service = await setupActiveProfile();
+			// Simulate handleShow probing another profile's credentials — cache must
+			// remain scoped to the active profile.
+			await service.validateToken({ apiUrl: "https://other.console.ves.volterra.io", apiToken: "other-tok" });
+			await waitForCachePopulate();
+			expect(service.getCachedNamespaces()).toEqual([]);
+		});
+
+		it("validateToken in an env-backed session (no active profile) does NOT populate cache", async () => {
+			// No loadActive or activate — service has no active profile.
+			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }] });
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.validateToken();
+			await waitForCachePopulate();
+			expect(service.getCachedNamespaces()).toEqual([]);
 		});
 
 		it("validateToken 5xx response leaves cache unchanged", async () => {
 			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }] });
-			const service = ProfileService.init(f5xcConfigDir);
-			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			const service = await setupActiveProfile();
+			await service.validateToken();
+			await waitForCachePopulate();
 			expect(service.getCachedNamespaces()).toEqual(["ns1"]);
 			globalThis.fetch = makeMockTextResponse(502);
-			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			await service.validateToken();
+			await waitForCachePopulate();
 			expect(service.getCachedNamespaces()).toEqual(["ns1"]); // unchanged
 		});
 
 		it("validateToken 2xx with malformed body (items is not an array) leaves cache unchanged", async () => {
 			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }] });
-			const service = ProfileService.init(f5xcConfigDir);
-			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			const service = await setupActiveProfile();
+			await service.validateToken();
+			await waitForCachePopulate();
 			expect(service.getCachedNamespaces()).toEqual(["ns1"]);
 
 			globalThis.fetch = makeMockJsonResponse(200, { items: "not-an-array" });
-			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			await service.validateToken();
+			await waitForCachePopulate();
 			expect(service.getCachedNamespaces()).toEqual(["ns1"]); // unchanged
 		});
 
 		it("validateToken 2xx with non-JSON body leaves cache unchanged (proxy interception case)", async () => {
 			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }] });
-			const service = ProfileService.init(f5xcConfigDir);
-			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			const service = await setupActiveProfile();
+			await service.validateToken();
+			await waitForCachePopulate();
 			expect(service.getCachedNamespaces()).toEqual(["ns1"]);
 
 			globalThis.fetch = makeMockTextResponse(200);
-			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			await service.validateToken();
+			await waitForCachePopulate();
 			expect(service.getCachedNamespaces()).toEqual(["ns1"]); // unchanged — response.json() threw, catch swallowed
 		});
 
@@ -1244,7 +1284,8 @@ describe("ProfileService", () => {
 			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }, { name: "ns2" }] });
 			const service = ProfileService.init(f5xcConfigDir);
 			await service.loadActive();
-			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			await service.validateToken();
+			await waitForCachePopulate();
 			expect(service.getCachedNamespaces()).toEqual(["ns1", "ns2"]);
 
 			await service.activate(TEST_PROFILE_2.name);

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1242,6 +1242,24 @@ describe("ProfileService", () => {
 			expect(service.getCachedNamespaces()).toEqual(["ns1", "ns2"]);
 		});
 
+		it("env override (F5XC_API_TOKEN) alongside an active profile does NOT populate cache", async () => {
+			// Active profile is loaded normally, then F5XC_API_TOKEN is set to override
+			// the profile's token at validateToken time. The fetch hits the active
+			// tenant URL but with a different account's credentials, so the returned
+			// namespace list reflects a different account than /profile namespace
+			// would mutate. The cache must stay empty.
+			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "env-token-account-ns" }] });
+			const service = await setupActiveProfile();
+			try {
+				process.env.F5XC_API_TOKEN = "different-account-token";
+				await service.validateToken();
+				await waitForCachePopulate();
+				expect(service.getCachedNamespaces()).toEqual([]);
+			} finally {
+				delete process.env.F5XC_API_TOKEN;
+			}
+		});
+
 		it("stale in-flight namespace response is discarded when activate() intervenes", async () => {
 			writeProfile(f5xcProfilesDir, TEST_PROFILE);
 			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1226,6 +1226,17 @@ describe("ProfileService", () => {
 			expect(service.getCachedNamespaces()).toEqual(["ns1"]); // unchanged
 		});
 
+		it("validateToken 2xx with non-JSON body leaves cache unchanged (proxy interception case)", async () => {
+			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }] });
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(service.getCachedNamespaces()).toEqual(["ns1"]);
+
+			globalThis.fetch = makeMockTextResponse(200);
+			await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(service.getCachedNamespaces()).toEqual(["ns1"]); // unchanged — response.json() threw, catch swallowed
+		});
+
 		it("activate(otherProfile) clears the namespace cache", async () => {
 			writeProfile(f5xcProfilesDir, TEST_PROFILE);
 			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);

--- a/packages/coding-agent/test/f5xc-test-fixtures.ts
+++ b/packages/coding-agent/test/f5xc-test-fixtures.ts
@@ -65,3 +65,12 @@ export const TEST_PROFILE_WITH_METADATA = {
 		expiresAt: "2027-03-15T00:00:00.000Z",
 	},
 } as const;
+
+/** Profile with schema version 2 — intentionally incompatible with CURRENT_SCHEMA_VERSION (=1). */
+export const TEST_PROFILE_INCOMPATIBLE = {
+	name: "future-schema",
+	apiUrl: TEST_F5XC_URL,
+	apiToken: TEST_F5XC_TOKEN,
+	defaultNamespace: TEST_F5XC_NAMESPACE,
+	version: 2,
+} as const;

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Snowflake } from "@f5xc-salesdemos/pi-utils";
+import { _resetSettingsForTest, Settings } from "@f5xc-salesdemos/xcsh/config/settings";
+import { type F5XCProfile, ProfileService } from "@f5xc-salesdemos/xcsh/services/f5xc-profile";
+import { BUILTIN_SLASH_COMMAND_DEFS } from "@f5xc-salesdemos/xcsh/slash-commands/builtin-registry";
+import { TEST_PROFILE, TEST_PROFILE_INCOMPATIBLE, TEST_PROFILE_STAGING } from "./f5xc-test-fixtures";
+
+function writeProfile(profilesDir: string, profile: F5XCProfile): void {
+	fs.mkdirSync(profilesDir, { recursive: true });
+	fs.writeFileSync(path.join(profilesDir, `${profile.name}.json`), JSON.stringify(profile, null, 2), { mode: 0o600 });
+}
+
+function _writeActiveProfile(configDir: string, name: string): void {
+	fs.writeFileSync(path.join(configDir, "active_profile"), name, { mode: 0o644 });
+}
+
+function getProfileSubcommand(name: string) {
+	const profileCmd = BUILTIN_SLASH_COMMAND_DEFS.find(c => c.name === "profile");
+	if (!profileCmd?.subcommands) throw new Error("profile command not found in registry");
+	const sub = profileCmd.subcommands.find(s => s.name === name);
+	if (!sub) throw new Error(`subcommand '${name}' not found under /profile`);
+	return sub;
+}
+
+describe("/profile activate completion", () => {
+	let testDir: string;
+	let f5xcConfigDir: string;
+	let f5xcProfilesDir: string;
+	let projectDir: string;
+	let agentDir: string;
+
+	beforeEach(async () => {
+		_resetSettingsForTest();
+		ProfileService._resetForTest();
+		for (const key of Object.keys(process.env)) {
+			if (key.startsWith("F5XC_")) delete process.env[key];
+		}
+		delete process.env.XDG_CONFIG_HOME;
+
+		testDir = path.join(os.tmpdir(), "test-profile-completion", Snowflake.next());
+		f5xcConfigDir = path.join(testDir, "f5xc-config");
+		f5xcProfilesDir = path.join(f5xcConfigDir, "profiles");
+		projectDir = path.join(testDir, "project");
+		agentDir = path.join(testDir, "agent");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.mkdirSync(path.join(projectDir, ".xcsh"), { recursive: true });
+		fs.mkdirSync(agentDir, { recursive: true });
+		await Settings.init({ cwd: projectDir, agentDir, inMemory: true });
+	});
+
+	afterEach(() => {
+		fs.rmSync(testDir, { recursive: true, force: true });
+		ProfileService._resetForTest();
+		_resetSettingsForTest();
+	});
+
+	it("returns items for each cached profile with apiUrl in description", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		writeProfile(f5xcProfilesDir, TEST_PROFILE_STAGING);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const activate = getProfileSubcommand("activate");
+		const items = activate.getArgumentCompletions!("");
+		expect(items).not.toBeNull();
+		expect(items!.map(i => i.label)).toEqual(["production", "staging"]);
+		const prod = items!.find(i => i.label === "production");
+		expect(prod?.description).toContain(TEST_PROFILE.apiUrl);
+	});
+
+	it("filters case-insensitively by prefix", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		writeProfile(f5xcProfilesDir, TEST_PROFILE_STAGING);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const activate = getProfileSubcommand("activate");
+		const items = activate.getArgumentCompletions!("P");
+		expect(items?.map(i => i.label)).toEqual(["production"]);
+	});
+
+	it("incompatible profile gets 'incompatible: v2' in description", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE_INCOMPATIBLE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const activate = getProfileSubcommand("activate");
+		const items = activate.getArgumentCompletions!("");
+		expect(items?.[0]?.description).toContain("incompatible: v2");
+	});
+
+	it("returns null when no profile name matches", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const activate = getProfileSubcommand("activate");
+		expect(activate.getArgumentCompletions!("zz")).toBeNull();
+	});
+
+	it("returns null once the prefix contains a space (past-argument boundary)", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const activate = getProfileSubcommand("activate");
+		expect(activate.getArgumentCompletions!("production ")).toBeNull();
+	});
+
+	it("returns null when ProfileService is not initialized (no throw)", () => {
+		// Do NOT call ProfileService.init. tryGetProfileService will see .instance throw.
+		const activate = getProfileSubcommand("activate");
+		expect(() => activate.getArgumentCompletions!("")).not.toThrow();
+		expect(activate.getArgumentCompletions!("")).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -194,6 +194,16 @@ describe("/profile unset completion", () => {
 		expect(labels.length).toBe(Object.keys(TEST_PROFILE_WITH_ENV.env).length - 1);
 	});
 
+	it("mixed-case already-typed keys still excluded from the dropdown (case-insensitive dedup)", async () => {
+		await setupWithEnvProfile();
+		const unset = getProfileSubcommand("unset");
+		// User typed a key in lowercase before hitting tab — the dedup must still
+		// recognise it against the uppercase keys returned by getActiveEnvKeys().
+		const items = unset.getArgumentCompletions!("f5xc_email ");
+		const labels = items?.map(i => i.label) ?? [];
+		expect(labels).not.toContain("F5XC_EMAIL");
+	});
+
 	it("value for multi-key mode preserves head so infra prepending produces the correct full argument", async () => {
 		await setupWithEnvProfile();
 		const unset = getProfileSubcommand("unset");

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -312,4 +312,23 @@ describe("/profile namespace completion", () => {
 		const ns = getProfileSubcommand("namespace");
 		expect(ns.getArgumentCompletions!("ns1 ")).toBeNull();
 	});
+
+	it("returns null when prefix matches no cached namespace", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+		globalThis.fetch = mockNamespaceFetch(["ns1", "ns2"]);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		await service.validateToken({ apiUrl: TEST_PROFILE.apiUrl, apiToken: TEST_PROFILE.apiToken });
+
+		const ns = getProfileSubcommand("namespace");
+		expect(ns.getArgumentCompletions!("xyz")).toBeNull();
+	});
+
+	it("returns null when ProfileService is not initialized (no throw)", () => {
+		// Do NOT call ProfileService.init. tryGetProfileService will see .instance throw.
+		const ns = getProfileSubcommand("namespace");
+		expect(() => ns.getArgumentCompletions!("")).not.toThrow();
+		expect(ns.getArgumentCompletions!("")).toBeNull();
+	});
 });

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -220,6 +220,13 @@ describe("/profile unset completion", () => {
 		const allKeys = Object.keys(TEST_PROFILE_WITH_ENV.env).join(" ");
 		expect(unset.getArgumentCompletions!(`${allKeys} `)).toBeNull();
 	});
+
+	it("returns null when ProfileService is not initialized (no throw)", () => {
+		// Do NOT call ProfileService.init. tryGetProfileService sees .instance throw.
+		const unset = getProfileSubcommand("unset");
+		expect(() => unset.getArgumentCompletions!("")).not.toThrow();
+		expect(unset.getArgumentCompletions!("")).toBeNull();
+	});
 });
 
 describe("/profile namespace completion", () => {

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -276,6 +276,23 @@ describe("/profile namespace completion", () => {
 		return fn as unknown as typeof globalThis.fetch;
 	}
 
+	// validateToken's cache population is fire-and-forget; wait for the body-parse
+	// microtask chain to settle before asserting dropdown state.
+	function waitForCachePopulate(): Promise<void> {
+		return new Promise(resolve => setTimeout(resolve, 10));
+	}
+
+	async function setupWithActiveProfileAndCache(namespaces: string[]): Promise<ProfileService> {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+		globalThis.fetch = mockNamespaceFetch(namespaces);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		await service.validateToken(); // no explicit creds — active profile path populates cache
+		await waitForCachePopulate();
+		return service;
+	}
+
 	it("returns null when namespace cache is empty", () => {
 		ProfileService.init(f5xcConfigDir);
 		const ns = getProfileSubcommand("namespace");
@@ -283,51 +300,27 @@ describe("/profile namespace completion", () => {
 	});
 
 	it("returns cached namespace items with empty prefix", async () => {
-		writeProfile(f5xcProfilesDir, TEST_PROFILE);
-		writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
-		globalThis.fetch = mockNamespaceFetch(["ns1", "ns2", "production"]);
-		const service = ProfileService.init(f5xcConfigDir);
-		await service.loadActive();
-		await service.validateToken({ apiUrl: TEST_PROFILE.apiUrl, apiToken: TEST_PROFILE.apiToken });
-
+		await setupWithActiveProfileAndCache(["ns1", "ns2", "production"]);
 		const ns = getProfileSubcommand("namespace");
 		const items = ns.getArgumentCompletions!("");
 		expect(items?.map(i => i.label)).toEqual(["ns1", "ns2", "production"]);
 	});
 
 	it("filters case-insensitively by prefix", async () => {
-		writeProfile(f5xcProfilesDir, TEST_PROFILE);
-		writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
-		globalThis.fetch = mockNamespaceFetch(["ns1", "ns2", "production"]);
-		const service = ProfileService.init(f5xcConfigDir);
-		await service.loadActive();
-		await service.validateToken({ apiUrl: TEST_PROFILE.apiUrl, apiToken: TEST_PROFILE.apiToken });
-
+		await setupWithActiveProfileAndCache(["ns1", "ns2", "production"]);
 		const ns = getProfileSubcommand("namespace");
 		const items = ns.getArgumentCompletions!("Ns");
 		expect(items?.map(i => i.label)).toEqual(["ns1", "ns2"]);
 	});
 
 	it("returns null once prefix contains a space (past-argument boundary)", async () => {
-		writeProfile(f5xcProfilesDir, TEST_PROFILE);
-		writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
-		globalThis.fetch = mockNamespaceFetch(["ns1"]);
-		const service = ProfileService.init(f5xcConfigDir);
-		await service.loadActive();
-		await service.validateToken({ apiUrl: TEST_PROFILE.apiUrl, apiToken: TEST_PROFILE.apiToken });
-
+		await setupWithActiveProfileAndCache(["ns1"]);
 		const ns = getProfileSubcommand("namespace");
 		expect(ns.getArgumentCompletions!("ns1 ")).toBeNull();
 	});
 
 	it("returns null when prefix matches no cached namespace", async () => {
-		writeProfile(f5xcProfilesDir, TEST_PROFILE);
-		writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
-		globalThis.fetch = mockNamespaceFetch(["ns1", "ns2"]);
-		const service = ProfileService.init(f5xcConfigDir);
-		await service.loadActive();
-		await service.validateToken({ apiUrl: TEST_PROFILE.apiUrl, apiToken: TEST_PROFILE.apiToken });
-
+		await setupWithActiveProfileAndCache(["ns1", "ns2"]);
 		const ns = getProfileSubcommand("namespace");
 		expect(ns.getArgumentCompletions!("xyz")).toBeNull();
 	});
@@ -337,5 +330,19 @@ describe("/profile namespace completion", () => {
 		const ns = getProfileSubcommand("namespace");
 		expect(() => ns.getArgumentCompletions!("")).not.toThrow();
 		expect(ns.getArgumentCompletions!("")).toBeNull();
+	});
+
+	it("returns null in env-backed session (no active profile) even if validateToken ran at startup", async () => {
+		// Simulates the env-backed scenario Codex flagged: startup runs validateToken
+		// against env-provided credentials, but there is no active profile to apply
+		// namespaces to. The cache must stay empty (new guard in validateToken) AND
+		// the provider must reject completions (defense-in-depth guard in provider).
+		globalThis.fetch = mockNamespaceFetch(["ns-from-env"]);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.validateToken(); // no active profile
+		await waitForCachePopulate();
+		expect(service.getCachedNamespaces()).toEqual([]); // guard in validateToken
+		const ns = getProfileSubcommand("namespace");
+		expect(ns.getArgumentCompletions!("")).toBeNull(); // guard in provider
 	});
 });

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -252,6 +252,34 @@ describe("/profile unset completion", () => {
 		expect(() => unset.getArgumentCompletions!("")).not.toThrow();
 		expect(unset.getArgumentCompletions!("")).toBeNull();
 	});
+
+	it("preserves case-distinct env keys — exact-case typed token keeps the other variant targetable", async () => {
+		// Hypothetical profile with two keys that differ only by case. unsetEnvVars
+		// treats them as separate entries (`Foo in env` vs `FOO in env`). The
+		// completion must NOT: (a) rewrite the user's token to the wrong case, or
+		// (b) hide the other variant from the dropdown.
+		const caseDistinctProfile: F5XCProfile = {
+			name: "case-distinct",
+			apiUrl: TEST_PROFILE.apiUrl,
+			apiToken: TEST_PROFILE.apiToken,
+			defaultNamespace: TEST_PROFILE.defaultNamespace,
+			env: { Foo: "x", FOO: "y" },
+		};
+		writeProfile(f5xcProfilesDir, caseDistinctProfile);
+		writeActiveProfile(f5xcConfigDir, caseDistinctProfile.name);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const unset = getProfileSubcommand("unset");
+		// User typed exact-case Foo. Head must preserve it verbatim, FOO must
+		// remain available in the dropdown.
+		const items = unset.getArgumentCompletions!("Foo F");
+		const labels = items?.map(i => i.label) ?? [];
+		expect(labels).toContain("FOO");
+		expect(labels).not.toContain("Foo");
+		const pickFOO = items?.find(i => i.label === "FOO");
+		expect(pickFOO?.value).toBe("Foo FOO ");
+	});
 });
 
 describe("/profile namespace completion", () => {

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -6,14 +6,19 @@ import { Snowflake } from "@f5xc-salesdemos/pi-utils";
 import { _resetSettingsForTest, Settings } from "@f5xc-salesdemos/xcsh/config/settings";
 import { type F5XCProfile, ProfileService } from "@f5xc-salesdemos/xcsh/services/f5xc-profile";
 import { BUILTIN_SLASH_COMMAND_DEFS } from "@f5xc-salesdemos/xcsh/slash-commands/builtin-registry";
-import { TEST_PROFILE, TEST_PROFILE_INCOMPATIBLE, TEST_PROFILE_STAGING } from "./f5xc-test-fixtures";
+import {
+	TEST_PROFILE,
+	TEST_PROFILE_INCOMPATIBLE,
+	TEST_PROFILE_STAGING,
+	TEST_PROFILE_WITH_ENV,
+} from "./f5xc-test-fixtures";
 
 function writeProfile(profilesDir: string, profile: F5XCProfile): void {
 	fs.mkdirSync(profilesDir, { recursive: true });
 	fs.writeFileSync(path.join(profilesDir, `${profile.name}.json`), JSON.stringify(profile, null, 2), { mode: 0o600 });
 }
 
-function _writeActiveProfile(configDir: string, name: string): void {
+function writeActiveProfile(configDir: string, name: string): void {
 	fs.writeFileSync(path.join(configDir, "active_profile"), name, { mode: 0o644 });
 }
 
@@ -115,5 +120,94 @@ describe("/profile activate completion", () => {
 		const activate = getProfileSubcommand("activate");
 		expect(() => activate.getArgumentCompletions!("")).not.toThrow();
 		expect(activate.getArgumentCompletions!("")).toBeNull();
+	});
+});
+
+describe("/profile unset completion", () => {
+	let testDir: string;
+	let f5xcConfigDir: string;
+	let f5xcProfilesDir: string;
+	let projectDir: string;
+	let agentDir: string;
+
+	beforeEach(async () => {
+		_resetSettingsForTest();
+		ProfileService._resetForTest();
+		for (const key of Object.keys(process.env)) {
+			if (key.startsWith("F5XC_")) delete process.env[key];
+		}
+		delete process.env.XDG_CONFIG_HOME;
+
+		testDir = path.join(os.tmpdir(), "test-profile-completion-unset", Snowflake.next());
+		f5xcConfigDir = path.join(testDir, "f5xc-config");
+		f5xcProfilesDir = path.join(f5xcConfigDir, "profiles");
+		projectDir = path.join(testDir, "project");
+		agentDir = path.join(testDir, "agent");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.mkdirSync(path.join(projectDir, ".xcsh"), { recursive: true });
+		fs.mkdirSync(agentDir, { recursive: true });
+		await Settings.init({ cwd: projectDir, agentDir, inMemory: true });
+	});
+
+	afterEach(() => {
+		fs.rmSync(testDir, { recursive: true, force: true });
+		ProfileService._resetForTest();
+		_resetSettingsForTest();
+	});
+
+	async function setupWithEnvProfile() {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE_WITH_ENV);
+		writeActiveProfile(f5xcConfigDir, TEST_PROFILE_WITH_ENV.name);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		return service;
+	}
+
+	it("returns null when there is no active profile", () => {
+		ProfileService.init(f5xcConfigDir); // no loadActive()
+		const unset = getProfileSubcommand("unset");
+		expect(unset.getArgumentCompletions!("")).toBeNull();
+	});
+
+	it("returns all env keys sorted when prefix is empty", async () => {
+		await setupWithEnvProfile();
+		const unset = getProfileSubcommand("unset");
+		const items = unset.getArgumentCompletions!("");
+		expect(items).not.toBeNull();
+		const keys = [...Object.keys(TEST_PROFILE_WITH_ENV.env)].sort();
+		expect(items!.map(i => i.label)).toEqual(keys);
+	});
+
+	it("filters case-insensitively by prefix on the last word", async () => {
+		await setupWithEnvProfile();
+		const unset = getProfileSubcommand("unset");
+		const items = unset.getArgumentCompletions!("f5xc_em");
+		expect(items?.map(i => i.label)).toEqual(["F5XC_EMAIL"]);
+	});
+
+	it("excludes already-typed keys from the dropdown (multi-key flow)", async () => {
+		await setupWithEnvProfile();
+		const unset = getProfileSubcommand("unset");
+		const items = unset.getArgumentCompletions!("F5XC_EMAIL ");
+		const labels = items?.map(i => i.label) ?? [];
+		expect(labels).not.toContain("F5XC_EMAIL");
+		expect(labels.length).toBe(Object.keys(TEST_PROFILE_WITH_ENV.env).length - 1);
+	});
+
+	it("value for multi-key mode preserves head so infra prepending produces the correct full argument", async () => {
+		await setupWithEnvProfile();
+		const unset = getProfileSubcommand("unset");
+		const items = unset.getArgumentCompletions!("F5XC_EMAIL F");
+		const pick = items?.find(i => i.label === "F5XC_USERNAME");
+		expect(pick).toBeDefined();
+		// Provider-scoped value: "F5XC_EMAIL F5XC_USERNAME ". Infra layer prepends "unset ".
+		expect(pick!.value).toBe("F5XC_EMAIL F5XC_USERNAME ");
+	});
+
+	it("returns null when every known env key has been typed already", async () => {
+		await setupWithEnvProfile();
+		const unset = getProfileSubcommand("unset");
+		const allKeys = Object.keys(TEST_PROFILE_WITH_ENV.env).join(" ");
+		expect(unset.getArgumentCompletions!(`${allKeys} `)).toBeNull();
 	});
 });

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -221,3 +221,95 @@ describe("/profile unset completion", () => {
 		expect(unset.getArgumentCompletions!(`${allKeys} `)).toBeNull();
 	});
 });
+
+describe("/profile namespace completion", () => {
+	let testDir: string;
+	let f5xcConfigDir: string;
+	let f5xcProfilesDir: string;
+	let projectDir: string;
+	let agentDir: string;
+	let savedFetch: typeof globalThis.fetch;
+
+	beforeEach(async () => {
+		_resetSettingsForTest();
+		ProfileService._resetForTest();
+		for (const key of Object.keys(process.env)) {
+			if (key.startsWith("F5XC_")) delete process.env[key];
+		}
+		delete process.env.XDG_CONFIG_HOME;
+
+		testDir = path.join(os.tmpdir(), "test-profile-completion-ns", Snowflake.next());
+		f5xcConfigDir = path.join(testDir, "f5xc-config");
+		f5xcProfilesDir = path.join(f5xcConfigDir, "profiles");
+		projectDir = path.join(testDir, "project");
+		agentDir = path.join(testDir, "agent");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.mkdirSync(path.join(projectDir, ".xcsh"), { recursive: true });
+		fs.mkdirSync(agentDir, { recursive: true });
+		await Settings.init({ cwd: projectDir, agentDir, inMemory: true });
+		savedFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = savedFetch;
+		fs.rmSync(testDir, { recursive: true, force: true });
+		ProfileService._resetForTest();
+		_resetSettingsForTest();
+	});
+
+	function mockNamespaceFetch(names: string[]): typeof globalThis.fetch {
+		const body = JSON.stringify({ items: names.map(n => ({ name: n })) });
+		const fn = () =>
+			Promise.resolve(
+				new Response(body, {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+		return fn as unknown as typeof globalThis.fetch;
+	}
+
+	it("returns null when namespace cache is empty", () => {
+		ProfileService.init(f5xcConfigDir);
+		const ns = getProfileSubcommand("namespace");
+		expect(ns.getArgumentCompletions!("")).toBeNull();
+	});
+
+	it("returns cached namespace items with empty prefix", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+		globalThis.fetch = mockNamespaceFetch(["ns1", "ns2", "production"]);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		await service.validateToken({ apiUrl: TEST_PROFILE.apiUrl, apiToken: TEST_PROFILE.apiToken });
+
+		const ns = getProfileSubcommand("namespace");
+		const items = ns.getArgumentCompletions!("");
+		expect(items?.map(i => i.label)).toEqual(["ns1", "ns2", "production"]);
+	});
+
+	it("filters case-insensitively by prefix", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+		globalThis.fetch = mockNamespaceFetch(["ns1", "ns2", "production"]);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		await service.validateToken({ apiUrl: TEST_PROFILE.apiUrl, apiToken: TEST_PROFILE.apiToken });
+
+		const ns = getProfileSubcommand("namespace");
+		const items = ns.getArgumentCompletions!("Ns");
+		expect(items?.map(i => i.label)).toEqual(["ns1", "ns2"]);
+	});
+
+	it("returns null once prefix contains a space (past-argument boundary)", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+		globalThis.fetch = mockNamespaceFetch(["ns1"]);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		await service.validateToken({ apiUrl: TEST_PROFILE.apiUrl, apiToken: TEST_PROFILE.apiToken });
+
+		const ns = getProfileSubcommand("namespace");
+		expect(ns.getArgumentCompletions!("ns1 ")).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -253,6 +253,48 @@ describe("/profile unset completion", () => {
 		expect(unset.getArgumentCompletions!("")).toBeNull();
 	});
 
+	it("ambiguous lowercase token (maps to multiple case-distinct keys) is preserved as-typed", async () => {
+		// Profile has Foo AND FOO. User types lowercase `foo` — which variant
+		// did they mean? Neither is a safe auto-pick. Provider must leave the
+		// token as-typed so the handler's case-sensitive match fails cleanly
+		// instead of silently removing whichever one appeared first in the
+		// sorted key list.
+		const caseDistinctProfile: F5XCProfile = {
+			name: "ambig",
+			apiUrl: TEST_PROFILE.apiUrl,
+			apiToken: TEST_PROFILE.apiToken,
+			defaultNamespace: TEST_PROFILE.defaultNamespace,
+			env: { Foo: "x", FOO: "y" },
+		};
+		writeProfile(f5xcProfilesDir, caseDistinctProfile);
+		writeActiveProfile(f5xcConfigDir, caseDistinctProfile.name);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const unset = getProfileSubcommand("unset");
+		const items = unset.getArgumentCompletions!("foo B");
+		// No second key starts with B in this tiny fixture, so no dropdown —
+		// but the important check is that if it were to produce items, the
+		// head would carry lowercase `foo` verbatim. Force a match by seeding
+		// a Bar-like key:
+		const withBar: F5XCProfile = {
+			...caseDistinctProfile,
+			name: "ambig2",
+			env: { ...caseDistinctProfile.env, Bar: "z" },
+		};
+		writeProfile(f5xcProfilesDir, withBar);
+		await service.activate(withBar.name);
+
+		const items2 = unset.getArgumentCompletions!("foo B");
+		const pick = items2?.find(i => i.label === "Bar");
+		expect(pick).toBeDefined();
+		// Ambiguous `foo` preserved as-typed (not normalized to Foo or FOO).
+		expect(pick!.value).toBe("foo Bar ");
+		// Both Foo and FOO should also remain offered when the tail matches them
+		// (they're not deduped because `foo` didn't bind to a canonical).
+		expect(items).toBeNull(); // sanity: no B-prefixed key in first fixture
+	});
+
 	it("preserves case-distinct env keys — exact-case typed token keeps the other variant targetable", async () => {
 		// Hypothetical profile with two keys that differ only by case. unsetEnvVars
 		// treats them as separate entries (`Foo in env` vs `FOO in env`). The

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -214,6 +214,31 @@ describe("/profile unset completion", () => {
 		expect(pick!.value).toBe("F5XC_EMAIL F5XC_USERNAME ");
 	});
 
+	it("normalizes mixed-case already-typed tokens to canonical env-key case", async () => {
+		await setupWithEnvProfile();
+		const unset = getProfileSubcommand("unset");
+		// User typed F5XC_EMAIL in lowercase. unsetEnvVars matches case-sensitively
+		// (`key in env`), so a lowercase token would silently be skipped. The provider
+		// must rewrite the head to the canonical case before infra prepends.
+		const items = unset.getArgumentCompletions!("f5xc_email F");
+		const pick = items?.find(i => i.label === "F5XC_USERNAME");
+		expect(pick).toBeDefined();
+		expect(pick!.value).toBe("F5XC_EMAIL F5XC_USERNAME ");
+	});
+
+	it("unknown already-typed tokens are preserved as-typed (user mistyped, handler reports no-op)", async () => {
+		await setupWithEnvProfile();
+		const unset = getProfileSubcommand("unset");
+		// NOPE_KEY isn't in the active profile's env. The provider has nothing to
+		// normalize it to, so it leaves the token exactly as the user typed. The
+		// handler will report "No matching variables found" rather than silently
+		// replacing the typo with a real key.
+		const items = unset.getArgumentCompletions!("NOPE_KEY F");
+		const pick = items?.find(i => i.label === "F5XC_LB_NAME");
+		expect(pick).toBeDefined();
+		expect(pick!.value).toBe("NOPE_KEY F5XC_LB_NAME ");
+	});
+
 	it("returns null when every known env key has been typed already", async () => {
 		await setupWithEnvProfile();
 		const unset = getProfileSubcommand("unset");

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -126,4 +126,12 @@ describe("buildArgumentCompletions", () => {
 		// Provider returned values starting with "FOO BAR " (its head). Infra prepends "unset ".
 		expect(items!.map(i => i.value)).toEqual(["unset FOO BAR BAR ", "unset FOO BAR BAZ "]);
 	});
+
+	it("case-insensitive subcommand lookup when delegating (e.g. 'Activate ' → activate provider)", () => {
+		const fn = buildArgumentCompletionsForTest(SUBS);
+		const items = fn("Activate al");
+		expect(items?.map(i => i.label)).toEqual(["alpha"]);
+		// Prefix rewrite uses the lowercased canonical name, not the user's casing
+		expect(items?.[0]?.value).toBe("activate alpha");
+	});
 });

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "bun:test";
+import type { AutocompleteItem } from "@f5xc-salesdemos/pi-tui";
+import type { SubcommandDef } from "@f5xc-salesdemos/xcsh/extensibility/slash-commands";
+import { buildArgumentCompletionsForTest } from "@f5xc-salesdemos/xcsh/extensibility/slash-commands";
+
+// buildArgumentCompletions is module-private today. Task 1 exposes a test-only
+// named export `buildArgumentCompletionsForTest` that is identical to the internal
+// function. Production code continues to use the internal one via the BUILTIN_SLASH_COMMANDS
+// construction in slash-commands.ts.
+
+const NO_PROVIDER: SubcommandDef = { name: "list", description: "List items" };
+const WITH_PROVIDER: SubcommandDef = {
+	name: "activate",
+	description: "Activate an item",
+	usage: "<name>",
+	getArgumentCompletions: (prefix: string): AutocompleteItem[] | null => {
+		if (prefix.includes(" ")) return null;
+		const names = ["alpha", "beta", "gamma"];
+		const filtered = names.filter(n => n.startsWith(prefix.toLowerCase()));
+		return filtered.length > 0 ? filtered.map(n => ({ value: n, label: n })) : null;
+	},
+};
+const MULTI_WORD: SubcommandDef = {
+	name: "unset",
+	description: "Unset one or more keys",
+	usage: "KEY [KEY2 ...]",
+	getArgumentCompletions: (prefix: string): AutocompleteItem[] | null => {
+		const lastSpace = prefix.lastIndexOf(" ");
+		const head = lastSpace === -1 ? "" : prefix.slice(0, lastSpace + 1);
+		const tail = lastSpace === -1 ? prefix : prefix.slice(lastSpace + 1);
+		const keys = ["FOO", "BAR", "BAZ"];
+		const items = keys
+			.filter(k => k.toLowerCase().startsWith(tail.toLowerCase()))
+			.map(k => ({ value: `${head}${k} `, label: k }));
+		return items.length > 0 ? items : null;
+	},
+};
+
+const SUBS: SubcommandDef[] = [NO_PROVIDER, WITH_PROVIDER, MULTI_WORD];
+
+describe("buildArgumentCompletions", () => {
+	it("empty prefix returns all subcommands with `<name> ` values and hint = usage", () => {
+		const fn = buildArgumentCompletionsForTest(SUBS);
+		const items = fn("");
+		expect(items).not.toBeNull();
+		expect(items!.map(i => i.label)).toEqual(["list", "activate", "unset"]);
+		expect(items!.map(i => i.value)).toEqual(["list ", "activate ", "unset "]);
+		const activate = items!.find(i => i.label === "activate");
+		expect(activate?.hint).toBe("<name>");
+	});
+
+	it("partial prefix filters subcommand names case-insensitively", () => {
+		const fn = buildArgumentCompletionsForTest(SUBS);
+		const items = fn("ac");
+		expect(items?.map(i => i.label)).toEqual(["activate"]);
+	});
+
+	it("exact match without trailing space still filters subcommand list (no delegation)", () => {
+		const fn = buildArgumentCompletionsForTest(SUBS);
+		const items = fn("activate");
+		expect(items?.map(i => i.label)).toEqual(["activate"]);
+	});
+
+	it("trailing space delegates to matched subcommand's provider with empty prefix", () => {
+		const fn = buildArgumentCompletionsForTest(SUBS);
+		const items = fn("activate ");
+		expect(items).not.toBeNull();
+		expect(items!.map(i => i.label)).toEqual(["alpha", "beta", "gamma"]);
+	});
+
+	it("delegated values are prefix-rewritten with `<subcommand> `", () => {
+		const fn = buildArgumentCompletionsForTest(SUBS);
+		const items = fn("activate ");
+		expect(items!.every(i => i.value.startsWith("activate "))).toBe(true);
+		expect(items!.map(i => i.value)).toEqual(["activate alpha", "activate beta", "activate gamma"]);
+	});
+
+	it("tail forwarded to provider for filtering", () => {
+		const fn = buildArgumentCompletionsForTest(SUBS);
+		const items = fn("activate be");
+		expect(items?.map(i => i.label)).toEqual(["beta"]);
+		expect(items?.[0]?.value).toBe("activate beta");
+	});
+
+	it("unknown subcommand with trailing space returns null", () => {
+		const fn = buildArgumentCompletionsForTest(SUBS);
+		expect(fn("nope foo")).toBeNull();
+	});
+
+	it("known subcommand without provider returns null after trailing space", () => {
+		const fn = buildArgumentCompletionsForTest(SUBS);
+		expect(fn("list ")).toBeNull();
+		expect(fn("list foo")).toBeNull();
+	});
+
+	it("provider returning null propagates as null", () => {
+		const subs: SubcommandDef[] = [
+			{
+				name: "x",
+				description: "x",
+				getArgumentCompletions: () => null,
+			},
+		];
+		const fn = buildArgumentCompletionsForTest(subs);
+		expect(fn("x ")).toBeNull();
+		expect(fn("x any")).toBeNull();
+	});
+
+	it("provider returning [] treated as null", () => {
+		const subs: SubcommandDef[] = [
+			{
+				name: "x",
+				description: "x",
+				getArgumentCompletions: () => [],
+			},
+		];
+		const fn = buildArgumentCompletionsForTest(subs);
+		expect(fn("x ")).toBeNull();
+	});
+
+	it("multi-space tail passed to provider verbatim; value gets subcommand prefixed once", () => {
+		const fn = buildArgumentCompletionsForTest(SUBS);
+		const items = fn("unset FOO BAR B");
+		expect(items).not.toBeNull();
+		expect(items!.map(i => i.label)).toEqual(["BAR", "BAZ"]);
+		// Provider returned values starting with "FOO BAR " (its head). Infra prepends "unset ".
+		expect(items!.map(i => i.value)).toEqual(["unset FOO BAR BAR ", "unset FOO BAR BAZ "]);
+	});
+});

--- a/packages/coding-agent/test/slash-commands.test.ts
+++ b/packages/coding-agent/test/slash-commands.test.ts
@@ -134,4 +134,15 @@ describe("buildArgumentCompletions", () => {
 		// Prefix rewrite uses the lowercased canonical name, not the user's casing
 		expect(items?.[0]?.value).toBe("activate alpha");
 	});
+
+	it("extra whitespace between subcommand and argument is stripped before delegation", () => {
+		// User types `/profile activate  al` with a double space. The single-arg
+		// activate provider rejects any prefix containing a space (its past-arg
+		// guard), so without whitespace normalisation the dropdown would vanish
+		// as soon as the user accidentally hits space twice.
+		const fn = buildArgumentCompletionsForTest(SUBS);
+		const items = fn("activate  al");
+		expect(items?.map(i => i.label)).toEqual(["alpha"]);
+		expect(items?.[0]?.value).toBe("activate alpha");
+	});
 });


### PR DESCRIPTION
Closes #274 — Phase 3 of 7 for the `/profile` UX arc.

## What this delivers

Dynamic tab completion for three `/profile` subcommands:

- **`/profile activate <tab>`** — dropdown of profile names with tenant URL and an `(incompatible: vN)` badge for profiles with a newer schema version. Mirrors how `/profile list` surfaces incompatible profiles.
- **`/profile unset <tab>`** — dropdown of env-var keys on the active profile, with multi-key support (`/profile unset KEY1 KEY2 <tab>` filters already-typed keys and preserves the head). Case-insensitive matching with canonical-case substitution — user-typed `f5xc_email` becomes `F5XC_EMAIL` so the handler's case-sensitive `key in env` match works.
- **`/profile namespace <tab>`** — dropdown of namespaces cached from the last successful `validateToken` response against the active profile's credentials.

## Implementation shape

- **Infra** (`extensibility/slash-commands.ts`): `SubcommandDef.getArgumentCompletions?` optional sync callback. `buildArgumentCompletions` splits the prefix on the first space, lowercases the subcommand token, delegates to the matched subcommand's provider, trims leading whitespace, and prefix-rewrites returned item values with `` `<subName> ` `` so `applyCompletion` replaces the full argument-text range.
- **ProfileService getters** (`services/f5xc-profile.ts`): four sync getters — `listProfileNamesCached`, `getProfileHint`, `getCachedNamespaces`, `getActiveEnvKeys`. Two private caches: `#profilesCache` (seeded in `loadActive`, mutated in `createProfile`/`deleteProfile`/`setEnvVars`/`unsetEnvVars`/`activate`; invalid-name files filtered) and `#namespacesCache` (populated fire-and-forget by `validateToken`'s body parse, cleared on `activate` with an `#activationEpoch` counter that discards stale in-flight responses).
- **Cache population guard** is tight: `!hasEnvOverride()` AND `effectiveUrl === active.apiUrl` AND `effectiveToken === active.apiToken` AND `active !== null`. That combination lets the normal `activate → handleShow` path warm the cache while rejecting `/profile show <other>`, env-backed sessions, and mixed-source sessions.
- **Providers** (`slash-commands/builtin-registry.ts`): `tryGetProfileService()` helper with narrowed catch (only swallows the documented "not initialized" error). Unset provider uses first-match-wins for canonical-case normalization; ambiguous lowercase tokens that map to multiple case-distinct canonicals are preserved as-typed so the handler can report a clean no-match rather than silently targeting the wrong variable.

## Review history

This branch went through brainstorming → spec → plan → subagent-driven execution (7 tasks + final review) → 6 rounds of Codex review with fixes. Each Codex round landed a discrete fix commit with a regression test. One concern (P2 — startup reads all profile files synchronously) was pushed back with technical justification: the underlying `fs.readdirSync`/`readFileSync` calls mean "fire-and-forget" doesn't change wall-clock cost, and a proper fix requires converting to `fs.promises` plus coordination against concurrent create/delete writes — that is deferred as a follow-up refactor and flagged in a code comment at `f5xc-profile.ts:164-170`.

## Test coverage

| File | Kind | Cases |
|---|---|---|
| `test/slash-commands.test.ts` | NEW — infra contract | 13 |
| `test/f5xc-profile-service.test.ts` | extended — caches + lifecycle + JSON mock helper | +26 |
| `test/profile-completion.test.ts` | NEW — provider behaviour | 23 |
| `test/f5xc-test-fixtures.ts` | `TEST_PROFILE_INCOMPATIBLE` fixture added | — |

Total: 62 new/modified tests. All pass; `bun run check` clean.

## Manual verification (please run before approving)

`bun run dev` then, in the TUI editor:

1. `/profile activate <tab>` → dropdown shows profile names with tenant URL descriptions.
2. `/profile activate a<tab>` → filters case-insensitively.
3. Activate a profile; wait for validation to go `connected`; `/profile namespace <tab>` → shows namespaces.
4. `/profile namespace ns1<space><space>` (double space mid-argument) → completion still works (whitespace-robust).
5. `/profile unset FOO <tab>` → remaining env keys only (FOO filtered, dedup works).
6. `/profile unset foo <tab>` (lowercase) → dropdown shows remaining keys; selected value rewrites `foo` to canonical `FOO`.
7. `/profile unset FOO BAR BAZ<tab>` (all keys typed) → no dropdown.
8. Fresh shell with `F5XC_API_TOKEN=other-token` set; activate a profile; `/profile namespace <tab>` → empty (env-override suppresses cache).

If any of these misbehaves, it's probably a real bug — automated tests cover the provider contracts but don't exercise the pi-tui `applyCompletion` keystroke loop end-to-end.

## Related follow-ups (not this PR)

- Convert `listProfiles` internals to `fs.promises` to remove the O(n) sync cost at startup (P2 pushback from Codex round 6).
- If anyone files a bug about `/profile env unset <tab>` (two-word path), wire recursive `SubcommandDef.subcommands` — the infra supports it cleanly. Spec decision 1a explicitly scoped this out.

## Commits

21 commits on the branch, organised as `feat:` for each layer's primary work and `fix:` for each review-driven follow-up. Intentionally not squashing locally — the per-fix rationale in each commit message is load-bearing audit trail for the guard logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)