### PR TITLE
feat(coding-agent): /profile phase 5 — validate, rename, export, import

### DIFF
--- a/packages/coding-agent/src/services/f5xc-profile-command.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-command.ts
@@ -370,7 +370,11 @@ async function handleImport(ctx: CommandContext, service: ProfileService, args: 
 			lines.push(`Overwrote ${result.overwritten.length}: ${result.overwritten.join(", ")}`);
 		}
 		ctx.showStatus(lines.join("\n"));
-		ctx.statusLine?.invalidate();
+		// NOTE: do NOT call statusLine?.invalidate() — import does not change the
+		// active profile, so the status line's rendering is unchanged. Only
+		// handlers that can switch the active profile (activate, rename,
+		// namespace) should invalidate. Matches the no-op pattern in handleCreate
+		// and handleExport.
 	} catch (err) {
 		ctx.showError(err instanceof ProfileError ? err.message : String(err));
 	}

--- a/packages/coding-agent/src/services/f5xc-profile-command.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-command.ts
@@ -53,6 +53,8 @@ export async function handleProfileCommand(
 			return handleCreate(ctx, service, rest);
 		case "delete":
 			return handleDelete(ctx, service, rest);
+		case "rename":
+			return handleRename(ctx, service, rest);
 		case "namespace":
 			return handleNamespace(ctx, service, arg);
 		case "env":
@@ -260,6 +262,23 @@ async function handleCreate(ctx: CommandContext, service: ProfileService, args: 
 			defaultNamespace: namespace ?? "default",
 		});
 		ctx.showStatus(`Profile '${name}' created. Use /profile activate ${name} to switch to it.`);
+	} catch (err) {
+		ctx.showError(err instanceof ProfileError ? err.message : String(err));
+	}
+}
+
+async function handleRename(ctx: CommandContext, service: ProfileService, args: string[]): Promise<void> {
+	const [oldName, newName] = args;
+	if (!oldName || !newName) {
+		ctx.showError("Usage: /profile rename <old> <new>");
+		return;
+	}
+	try {
+		await service.renameProfile(oldName, newName);
+		ctx.showStatus(`Profile '${oldName}' renamed to '${newName}'.`);
+		ctx.statusLine?.invalidate();
+		ctx.updateEditorTopBorder?.();
+		ctx.ui?.requestRender();
 	} catch (err) {
 		ctx.showError(err instanceof ProfileError ? err.message : String(err));
 	}

--- a/packages/coding-agent/src/services/f5xc-profile-command.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-command.ts
@@ -43,6 +43,8 @@ export async function handleProfileCommand(
 			return handleList(ctx, service);
 		case "activate":
 			return handleActivate(ctx, service, arg);
+		case "validate":
+			return handleValidate(ctx, service, arg);
 		case "show":
 			return handleShow(ctx, service, arg);
 		case "status":
@@ -68,7 +70,7 @@ export async function handleProfileCommand(
 				return handleEnvSet(ctx, service, command.args);
 			}
 			ctx.showError(
-				`Unknown subcommand: ${sub}. Use /profile list|activate|show|status|create|delete|namespace|env|set|unset`,
+				`Unknown subcommand: ${sub}. Use /profile list|activate|validate|show|status|create|delete|namespace|env|set|unset`,
 			);
 	}
 }
@@ -189,6 +191,28 @@ async function handleShow(ctx: CommandContext, service: ProfileService, name?: s
 	}
 
 	ctx.showStatus(renderF5XCTable(profile.name, rows, { dividers }));
+}
+
+async function handleValidate(ctx: CommandContext, service: ProfileService, name: string): Promise<void> {
+	if (!name) {
+		ctx.showError(
+			"Missing profile name. Usage: /profile validate <name>. For the active profile, use /profile status.",
+		);
+		return;
+	}
+	try {
+		const result = await service.validateProfileByName(name);
+		const tenant = deriveTenantFromUrl(result.profile.apiUrl) ?? "";
+		const rows: TableRow[] = [
+			{ key: F5XC_TENANT, value: sanitize(tenant) },
+			{ key: F5XC_API_URL, value: sanitize(result.profile.apiUrl) },
+			{ key: F5XC_API_TOKEN, value: service.maskToken(result.profile.apiToken) },
+			{ key: "Status", value: formatAuthIndicator(result.status, result.latencyMs, result.errorClass) },
+		];
+		ctx.showStatus(renderF5XCTable(`${result.profile.name} (validation only)`, rows));
+	} catch (err) {
+		ctx.showError(err instanceof ProfileError ? err.message : String(err));
+	}
 }
 
 async function handleStatus(ctx: CommandContext, service: ProfileService): Promise<void> {

--- a/packages/coding-agent/src/services/f5xc-profile-command.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-command.ts
@@ -1,4 +1,6 @@
+import * as fs from "node:fs";
 import { SECRET_ENV_PATTERNS } from "../secrets/index";
+import { expandTilde } from "../tools/path-utils";
 import {
 	deriveTenantFromUrl,
 	F5XC_API_TOKEN,
@@ -57,6 +59,8 @@ export async function handleProfileCommand(
 			return handleRename(ctx, service, rest);
 		case "export":
 			return handleExport(ctx, service, rest);
+		case "import":
+			return handleImport(ctx, service, rest);
 		case "namespace":
 			return handleNamespace(ctx, service, arg);
 		case "env":
@@ -74,7 +78,7 @@ export async function handleProfileCommand(
 				return handleEnvSet(ctx, service, command.args);
 			}
 			ctx.showError(
-				`Unknown subcommand: ${sub}. Use /profile list|activate|validate|show|status|create|delete|rename|export|namespace|env|set|unset`,
+				`Unknown subcommand: ${sub}. Use /profile list|activate|validate|show|status|create|delete|rename|export|import|namespace|env|set|unset`,
 			);
 	}
 }
@@ -316,6 +320,57 @@ async function handleExport(ctx: CommandContext, service: ProfileService, args: 
 			includeToken,
 		});
 		ctx.showStatus(JSON.stringify(bundle, null, 2));
+	} catch (err) {
+		ctx.showError(err instanceof ProfileError ? err.message : String(err));
+	}
+}
+
+async function handleImport(ctx: CommandContext, service: ProfileService, args: string[]): Promise<void> {
+	const { positionals, flags } = splitArgs(args);
+	if (positionals.length === 0) {
+		ctx.showError("Usage: /profile import <path-or-json> [--overwrite]");
+		return;
+	}
+	// Rejoin positionals with spaces — inline JSON arriving as `{"foo": "bar"}`
+	// gets split on whitespace by the top-level parser. Rejoining restores it.
+	const source = positionals.join(" ").trim();
+	const overwrite = flags.has("--overwrite");
+
+	let parsed: unknown;
+	if (source.startsWith("{")) {
+		// Inline JSON
+		try {
+			parsed = JSON.parse(source);
+		} catch (err) {
+			ctx.showError(`Import source is not valid JSON: ${err instanceof Error ? err.message : String(err)}`);
+			return;
+		}
+	} else {
+		// File path — pass process.env.HOME so tests that mutate HOME are honoured
+		const filePath = expandTilde(source, process.env.HOME);
+		if (!fs.existsSync(filePath)) {
+			ctx.showError(`Import file not found: ${source}`);
+			return;
+		}
+		try {
+			const content = fs.readFileSync(filePath, "utf-8");
+			parsed = JSON.parse(content);
+		} catch (err) {
+			ctx.showError(`Import source is not valid JSON: ${err instanceof Error ? err.message : String(err)}`);
+			return;
+		}
+	}
+
+	try {
+		const result = await service.importProfiles(parsed, { overwrite });
+		const lines: string[] = [];
+		lines.push(`Imported ${result.imported.length} profile${result.imported.length === 1 ? "" : "s"}:`);
+		for (const name of result.imported) lines.push(`  + ${name}`);
+		if (result.overwritten.length > 0) {
+			lines.push(`Overwrote ${result.overwritten.length}: ${result.overwritten.join(", ")}`);
+		}
+		ctx.showStatus(lines.join("\n"));
+		ctx.statusLine?.invalidate();
 	} catch (err) {
 		ctx.showError(err instanceof ProfileError ? err.message : String(err));
 	}

--- a/packages/coding-agent/src/services/f5xc-profile-command.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-command.ts
@@ -59,8 +59,15 @@ export async function handleProfileCommand(
 			return handleRename(ctx, service, rest);
 		case "export":
 			return handleExport(ctx, service, rest);
-		case "import":
-			return handleImport(ctx, service, rest);
+		case "import": {
+			// Pass the raw args string (everything after the "import" subcommand)
+			// rather than the whitespace-tokenized `rest`. Inline JSON values can
+			// contain runs of whitespace inside string literals (tabs, multiple
+			// spaces) that `command.args.trim().split(/\s+/).join(" ")` would
+			// collapse — corrupting the bytes before JSON.parse.
+			const rawImportArgs = command.args.trim().replace(/^\S+\s*/, "");
+			return handleImport(ctx, service, rawImportArgs);
+		}
 		case "namespace":
 			return handleNamespace(ctx, service, arg);
 		case "env":
@@ -325,16 +332,32 @@ async function handleExport(ctx: CommandContext, service: ProfileService, args: 
 	}
 }
 
-async function handleImport(ctx: CommandContext, service: ProfileService, args: string[]): Promise<void> {
-	const { positionals, flags } = splitArgs(args);
-	if (positionals.length === 0) {
+async function handleImport(ctx: CommandContext, service: ProfileService, rawArgs: string): Promise<void> {
+	// Detect --overwrite at the leading or trailing edge of the raw args ONLY.
+	// Matching anywhere would falsely strip the literal "--overwrite" that could
+	// appear inside a JSON string value (e.g. `{"note":"--overwrite happened"}`).
+	// Leading/trailing is the natural CLI usage and leaves the source bytes
+	// intact for brace-balanced JSON parsing below.
+	let source = rawArgs.trim();
+	let overwrite = false;
+	if (source.startsWith("--overwrite")) {
+		const after = source.slice("--overwrite".length);
+		if (after === "" || /^\s/.test(after)) {
+			overwrite = true;
+			source = after.trimStart();
+		}
+	}
+	if (source.endsWith("--overwrite")) {
+		const before = source.slice(0, -"--overwrite".length);
+		if (before === "" || /\s$/.test(before)) {
+			overwrite = true;
+			source = before.trimEnd();
+		}
+	}
+	if (!source) {
 		ctx.showError("Usage: /profile import <path-or-json> [--overwrite]");
 		return;
 	}
-	// Rejoin positionals with spaces — inline JSON arriving as `{"foo": "bar"}`
-	// gets split on whitespace by the top-level parser. Rejoining restores it.
-	const source = positionals.join(" ").trim();
-	const overwrite = flags.has("--overwrite");
 
 	let parsed: unknown;
 	if (source.startsWith("{")) {

--- a/packages/coding-agent/src/services/f5xc-profile-command.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-command.ts
@@ -55,6 +55,8 @@ export async function handleProfileCommand(
 			return handleDelete(ctx, service, rest);
 		case "rename":
 			return handleRename(ctx, service, rest);
+		case "export":
+			return handleExport(ctx, service, rest);
 		case "namespace":
 			return handleNamespace(ctx, service, arg);
 		case "env":
@@ -72,7 +74,7 @@ export async function handleProfileCommand(
 				return handleEnvSet(ctx, service, command.args);
 			}
 			ctx.showError(
-				`Unknown subcommand: ${sub}. Use /profile list|activate|validate|show|status|create|delete|namespace|env|set|unset`,
+				`Unknown subcommand: ${sub}. Use /profile list|activate|validate|show|status|create|delete|rename|export|namespace|env|set|unset`,
 			);
 	}
 }
@@ -80,6 +82,23 @@ export async function handleProfileCommand(
 /** Strip control characters to prevent TUI corruption from malformed profile JSON */
 function sanitize(value: string): string {
 	return value.replace(/[\x00-\x1f\x7f]/g, "");
+}
+
+/**
+ * Split a positional+flag argument list into two groups:
+ *   - positionals: args that do not start with "--"
+ *   - flags: the set of args that do
+ * Unknown flags are preserved in the set — callers check `.has("--name")`
+ * and silently ignore anything they don't recognize.
+ */
+function splitArgs(args: string[]): { positionals: string[]; flags: Set<string> } {
+	const positionals: string[] = [];
+	const flags = new Set<string>();
+	for (const a of args) {
+		if (a.startsWith("--")) flags.add(a);
+		else positionals.push(a);
+	}
+	return { positionals, flags };
 }
 
 async function handleList(ctx: CommandContext, service: ProfileService): Promise<void> {
@@ -279,6 +298,24 @@ async function handleRename(ctx: CommandContext, service: ProfileService, args: 
 		ctx.statusLine?.invalidate();
 		ctx.updateEditorTopBorder?.();
 		ctx.ui?.requestRender();
+	} catch (err) {
+		ctx.showError(err instanceof ProfileError ? err.message : String(err));
+	}
+}
+
+async function handleExport(ctx: CommandContext, service: ProfileService, args: string[]): Promise<void> {
+	const { positionals, flags } = splitArgs(args);
+	if (positionals.length > 1) {
+		ctx.showError("Usage: /profile export [name] [--include-token]");
+		return;
+	}
+	const includeToken = flags.has("--include-token");
+	try {
+		const bundle = await service.exportProfiles({
+			names: positionals.length === 1 ? [positionals[0]] : undefined,
+			includeToken,
+		});
+		ctx.showStatus(JSON.stringify(bundle, null, 2));
 	} catch (err) {
 		ctx.showError(err instanceof ProfileError ? err.message : String(err));
 	}

--- a/packages/coding-agent/src/services/f5xc-profile-command.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-command.ts
@@ -96,17 +96,26 @@ function sanitize(value: string): string {
 }
 
 /**
- * Split a positional+flag argument list into two groups:
- *   - positionals: args that do not start with "--"
- *   - flags: the set of args that do
- * Unknown flags are preserved in the set — callers check `.has("--name")`
- * and silently ignore anything they don't recognize.
+ * Split a positional+flag argument list into two groups.
+ *
+ * Only tokens that exactly match one of `knownFlags` are treated as flags;
+ * everything else — including `--`-prefixed tokens that look flag-ish —
+ * goes to positionals. This matters because profile names allow leading
+ * dashes (the name regex is `/^[a-zA-Z0-9_-]{1,64}$/`), so a user with a
+ * profile named `--prod` needs `splitArgs(["--prod"], new Set(["--include-token"]))`
+ * to return `positionals=["--prod"], flags=new Set()` rather than silently
+ * eating the name as an unrecognized flag.
+ *
+ * Callers list the flags they actually understand. Unknown `--`-prefixed
+ * tokens that happen not to be valid profile names are left in positionals
+ * and surface downstream as "not found" errors rather than being silently
+ * absorbed.
  */
-function splitArgs(args: string[]): { positionals: string[]; flags: Set<string> } {
+function splitArgs(args: string[], knownFlags: Set<string>): { positionals: string[]; flags: Set<string> } {
 	const positionals: string[] = [];
 	const flags = new Set<string>();
 	for (const a of args) {
-		if (a.startsWith("--")) flags.add(a);
+		if (knownFlags.has(a)) flags.add(a);
 		else positionals.push(a);
 	}
 	return { positionals, flags };
@@ -314,8 +323,10 @@ async function handleRename(ctx: CommandContext, service: ProfileService, args: 
 	}
 }
 
+const EXPORT_KNOWN_FLAGS = new Set(["--include-token"]);
+
 async function handleExport(ctx: CommandContext, service: ProfileService, args: string[]): Promise<void> {
-	const { positionals, flags } = splitArgs(args);
+	const { positionals, flags } = splitArgs(args, EXPORT_KNOWN_FLAGS);
 	if (positionals.length > 1) {
 		ctx.showError("Usage: /profile export [name] [--include-token]");
 		return;

--- a/packages/coding-agent/src/services/f5xc-profile-command.ts
+++ b/packages/coding-agent/src/services/f5xc-profile-command.ts
@@ -404,11 +404,19 @@ async function handleImport(ctx: CommandContext, service: ProfileService, rawArg
 			lines.push(`Overwrote ${result.overwritten.length}: ${result.overwritten.join(", ")}`);
 		}
 		ctx.showStatus(lines.join("\n"));
-		// NOTE: do NOT call statusLine?.invalidate() — import does not change the
-		// active profile, so the status line's rendering is unchanged. Only
-		// handlers that can switch the active profile (activate, rename,
-		// namespace) should invalidate. Matches the no-op pattern in handleCreate
-		// and handleExport.
+		// Invalidate TUI chrome IF the active profile was overwritten. The
+		// service's importProfiles re-activates the active profile when an
+		// overwrite touches it, which means #activeProfile, bash.environment,
+		// and cached auth metadata all mutated. The status-line segment and
+		// editor top-border are handler-driven (not listener-driven), so
+		// without this the chrome advertises the old tenant until another
+		// command triggers a refresh. Match the pattern in handleRename.
+		const activeName = service.getStatus().activeProfileName;
+		if (activeName && result.overwritten.includes(activeName)) {
+			ctx.statusLine?.invalidate();
+			ctx.updateEditorTopBorder?.();
+			ctx.ui?.requestRender();
+		}
 	} catch (err) {
 		ctx.showError(err instanceof ProfileError ? err.message : String(err));
 	}

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -491,7 +491,26 @@ export class ProfileService {
 			throw new ProfileError(`Import bundle has ${badNames.length} invalid profile(s): ${badNames.join(", ")}.`);
 		}
 
-		// 4.5. Intra-bundle duplicate-name rejection. A bundle listing the
+		// 4.5. Per-profile schema-version compatibility. The envelope version
+		// (step 2) is the bundle format; `profile.version` is the per-profile
+		// schema version. Without this check a bundle produced by a newer xcsh
+		// (version: 2) would pass shape checks and reach the write loop,
+		// leaving unusable profiles on disk that activate/loadActive reject.
+		// In the overwrite-active path that would mean the active profile is
+		// silently bricked on the next startup. Reject upfront.
+		const incompatibleNames: string[] = [];
+		for (const p of normalized) {
+			if (p.version !== undefined && p.version > CURRENT_SCHEMA_VERSION) {
+				incompatibleNames.push(`${p.name} (v${p.version})`);
+			}
+		}
+		if (incompatibleNames.length > 0) {
+			throw new ProfileError(
+				`Import bundle has ${incompatibleNames.length} profile(s) with incompatible schema version (this xcsh supports v${CURRENT_SCHEMA_VERSION}): ${incompatibleNames.join(", ")}. Upgrade xcsh to import this bundle.`,
+			);
+		}
+
+		// 4.6. Intra-bundle duplicate-name rejection. A bundle listing the
 		// same name twice would silently clobber the first entry in the write
 		// loop and emit misleading duplicated names in `imported[]`. Reject
 		// before any write so the user can fix the malformed bundle.
@@ -590,7 +609,13 @@ export class ProfileService {
 
 		// Step 2: if renaming the active profile, update the pointer. On failure
 		// we must roll back the file rename so the user sees a consistent state.
-		const wasActive = this.#activeProfile?.name === oldName;
+		// Consult BOTH the hydrated in-memory state AND the on-disk pointer:
+		// loadActive() leaves #activeProfile null when F5XC_API_URL overrides
+		// the profile, but the on-disk active_profile file may still name the
+		// profile being renamed — and the next non-env session relies on that
+		// pointer to restore the user's active selection.
+		const onDiskActiveName = this.#readActiveProfileName();
+		const wasActive = this.#activeProfile?.name === oldName || onDiskActiveName === oldName;
 		if (wasActive) {
 			try {
 				this.#atomicWrite(this.activeProfilePath, newName);

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -359,14 +359,17 @@ export class ProfileService {
 	async renameProfile(oldName: string, newName: string): Promise<void> {
 		this.#validateProfileName(oldName);
 		this.#validateProfileName(newName);
-		if (oldName === newName) return;
 
 		const oldPath = path.join(this.profilesDir, `${oldName}.json`);
 		const newPath = path.join(this.profilesDir, `${newName}.json`);
 
+		// Existence check fires BEFORE the identity short-circuit so
+		// `renameProfile("ghost", "ghost")` returns the expected not-found error
+		// instead of a silent success that hides a typo.
 		if (!fs.existsSync(oldPath)) {
 			throw new ProfileError(`Profile '${oldName}' not found.`, oldName);
 		}
+		if (oldName === newName) return;
 		if (fs.existsSync(newPath)) {
 			throw new ProfileError(`Profile '${newName}' already exists.`, newName);
 		}
@@ -381,15 +384,11 @@ export class ProfileService {
 			try {
 				this.#atomicWrite(this.activeProfilePath, newName);
 			} catch (err) {
-				// Rollback
+				// Rollback. Inner try wraps ONLY the rename-back call so the
+				// rollback-succeeded / rollback-failed paths are clearly separated.
 				try {
 					fs.renameSync(newPath, oldPath);
-					throw new ProfileError(
-						`Failed to update active profile pointer: ${err instanceof Error ? err.message : String(err)}. Profile was not renamed.`,
-						oldName,
-					);
 				} catch (rollbackErr) {
-					if (rollbackErr instanceof ProfileError) throw rollbackErr;
 					logger.warn("F5XC profile rename rollback failed — manual recovery required", {
 						oldName,
 						newName,
@@ -401,6 +400,11 @@ export class ProfileService {
 						oldName,
 					);
 				}
+				// Rollback succeeded — throw the user-friendly error.
+				throw new ProfileError(
+					`Failed to update active profile pointer: ${err instanceof Error ? err.message : String(err)}. Profile was not renamed.`,
+					oldName,
+				);
 			}
 		}
 

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -677,7 +677,10 @@ export class ProfileService {
 			env,
 			sensitiveKeys,
 			version: typeof parsed.version === "number" ? parsed.version : undefined,
-			metadata: (parsed.metadata ?? undefined) as F5XCProfile["metadata"],
+			metadata:
+				parsed.metadata && typeof parsed.metadata === "object" && !Array.isArray(parsed.metadata)
+					? (parsed.metadata as F5XCProfile["metadata"])
+					: undefined,
 		};
 	}
 

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -423,7 +423,12 @@ export class ProfileService {
 	 *      rejects the whole import; no writes occur.
 	 *   5. Conflict detection against a fresh listProfiles() read — not the
 	 *      in-memory cache, which can miss concurrent-session edits.
-	 *   6. Atomic per-file write loop.
+	 *   6. Atomic per-file write loop. Each write is atomic individually via
+	 *      #atomicWrite, but the overall import is NOT transactional: if the
+	 *      Nth of M writes throws, the first N-1 profiles are kept and the
+	 *      remainder are not written. Multi-file rollback would require a
+	 *      two-phase commit we do not implement; validation steps 1–5 catch
+	 *      all foreseeable failures before any write begins.
 	 *   7. Cache refresh.
 	 */
 	async importProfiles(bundle: unknown, opts: { overwrite: boolean }): Promise<ImportResult> {

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -26,6 +26,12 @@ export interface ExportBundle {
 	profiles: F5XCProfile[];
 }
 
+export interface ImportResult {
+	imported: string[];
+	overwritten: string[];
+	skipped: string[];
+}
+
 export interface F5XCProfile {
 	name: string;
 	apiUrl: string;
@@ -405,6 +411,101 @@ export class ProfileService {
 			tokensMasked: !opts.includeToken,
 			profiles: cloned,
 		};
+	}
+
+	/**
+	 * Import profiles from a bundle. Validation order is load-bearing:
+	 *   1. Envelope schema (object with version/tokensMasked/profiles).
+	 *   2. Version match.
+	 *   3. tokensMasked: true is rejected — masked tokens would pass write but
+	 *      fail runtime auth with a misleading error.
+	 *   4. Per-profile field-shape via #validateProfileShape — any failure
+	 *      rejects the whole import; no writes occur.
+	 *   5. Conflict detection against a fresh listProfiles() read — not the
+	 *      in-memory cache, which can miss concurrent-session edits.
+	 *   6. Atomic per-file write loop.
+	 *   7. Cache refresh.
+	 */
+	async importProfiles(bundle: unknown, opts: { overwrite: boolean }): Promise<ImportResult> {
+		// 1. Envelope schema
+		if (!bundle || typeof bundle !== "object" || Array.isArray(bundle)) {
+			throw new ProfileError("Import bundle missing required fields: bundle must be an object.");
+		}
+		const b = bundle as Record<string, unknown>;
+		if (typeof b.version !== "number" || typeof b.tokensMasked !== "boolean" || !Array.isArray(b.profiles)) {
+			throw new ProfileError(
+				"Import bundle missing required fields: expected { version: number, tokensMasked: boolean, profiles: array }.",
+			);
+		}
+
+		// 2. Version
+		if (b.version !== CURRENT_EXPORT_VERSION) {
+			throw new ProfileError(
+				`Import bundle uses export version ${b.version}, but this version of xcsh only supports ${CURRENT_EXPORT_VERSION}.`,
+			);
+		}
+
+		// 3. Masked-token gate
+		if (b.tokensMasked === true) {
+			throw new ProfileError(
+				"Bundle contains masked tokens. Re-export with --include-token to produce an importable bundle.",
+			);
+		}
+
+		// 4. Per-profile field-shape
+		const rawProfiles = b.profiles as unknown[];
+		const normalized: F5XCProfile[] = [];
+		const badNames: string[] = [];
+		for (let i = 0; i < rawProfiles.length; i++) {
+			const raw = rawProfiles[i];
+			const rawObj = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+			const name = typeof rawObj.name === "string" ? rawObj.name : `<entry ${i}>`;
+			if (typeof rawObj.name !== "string" || !this.#isValidProfileName(rawObj.name)) {
+				badNames.push(`${name} (invalid name)`);
+				continue;
+			}
+			const shape = this.#validateProfileShape(raw, rawObj.name);
+			if (!shape) {
+				badNames.push(`${rawObj.name} (invalid shape)`);
+				continue;
+			}
+			normalized.push(shape);
+		}
+		if (badNames.length > 0) {
+			throw new ProfileError(`Import bundle has ${badNames.length} invalid profile(s): ${badNames.join(", ")}.`);
+		}
+
+		// 5. Conflict detection — fresh disk read, NOT listProfileNamesCached
+		const existing = await this.listProfiles();
+		const existingNames = new Set(existing.map(p => p.name));
+		const conflicts = normalized.filter(p => existingNames.has(p.name)).map(p => p.name);
+		if (conflicts.length > 0 && !opts.overwrite) {
+			throw new ProfileError(
+				`${conflicts.length} profile(s) conflict: ${conflicts.join(", ")}. Re-run with --overwrite to replace, or delete conflicts first.`,
+			);
+		}
+
+		// 6. Write loop — atomic per-file
+		fs.mkdirSync(this.profilesDir, { recursive: true, mode: 0o700 });
+		const imported: string[] = [];
+		const overwritten: string[] = [];
+		for (const profile of normalized) {
+			const filePath = path.join(this.profilesDir, `${profile.name}.json`);
+			const wasExisting = existingNames.has(profile.name);
+			const payload: F5XCProfile = {
+				...profile,
+				version: profile.version ?? CURRENT_SCHEMA_VERSION,
+				metadata: profile.metadata ?? { createdAt: new Date().toISOString() },
+			};
+			this.#atomicWrite(filePath, JSON.stringify(payload, null, 2));
+			imported.push(profile.name);
+			if (wasExisting) overwritten.push(profile.name);
+		}
+
+		// 7. Cache refresh
+		await this.listProfiles();
+
+		return { imported, overwritten, skipped: [] };
 	}
 
 	/**

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -397,9 +397,20 @@ export class ProfileService {
 		if (!opts.includeToken) {
 			for (const p of cloned) {
 				p.apiToken = this.maskToken(p.apiToken);
-				if (p.env && p.sensitiveKeys) {
-					for (const k of p.sensitiveKeys) {
-						if (p.env[k]) p.env[k] = this.maskToken(p.env[k]);
+				if (p.env) {
+					// Mask env values whose key is either in sensitiveKeys OR
+					// matches SECRET_ENV_PATTERNS. Mirrors the show() handler's
+					// masking contract: `setEnvVars` auto-populates sensitiveKeys
+					// from the pattern, but profiles edited directly on disk or
+					// imported from older formats may have secret-looking keys
+					// (e.g. F5XC_CONSOLE_PASSWORD, *_TOKEN, *_SECRET) without
+					// `sensitiveKeys` entries. Export must match show() to avoid
+					// leaking credentials that show() already masks.
+					const sensitive = new Set(p.sensitiveKeys ?? []);
+					for (const [k, v] of Object.entries(p.env)) {
+						if (sensitive.has(k) || SECRET_ENV_PATTERNS.test(k)) {
+							p.env[k] = this.maskToken(v);
+						}
 					}
 				}
 			}
@@ -480,6 +491,22 @@ export class ProfileService {
 			throw new ProfileError(`Import bundle has ${badNames.length} invalid profile(s): ${badNames.join(", ")}.`);
 		}
 
+		// 4.5. Intra-bundle duplicate-name rejection. A bundle listing the
+		// same name twice would silently clobber the first entry in the write
+		// loop and emit misleading duplicated names in `imported[]`. Reject
+		// before any write so the user can fix the malformed bundle.
+		const seen = new Set<string>();
+		const intraDuplicates = new Set<string>();
+		for (const p of normalized) {
+			if (seen.has(p.name)) intraDuplicates.add(p.name);
+			else seen.add(p.name);
+		}
+		if (intraDuplicates.size > 0) {
+			throw new ProfileError(
+				`Import bundle contains duplicate profile name(s): ${[...intraDuplicates].join(", ")}. Each name must appear at most once.`,
+			);
+		}
+
 		// 5. Conflict detection — fresh disk read, NOT listProfileNamesCached
 		const existing = await this.listProfiles();
 		const existingNames = new Set(existing.map(p => p.name));
@@ -509,6 +536,18 @@ export class ProfileService {
 
 		// 7. Cache refresh
 		await this.listProfiles();
+
+		// 8. Refresh active-profile state if its backing file was overwritten.
+		// importProfiles's write loop replaces the on-disk JSON, but #activeProfile,
+		// Settings.bash.environment (apiUrl/apiToken/namespace), and the cached
+		// auth metadata all hold a snapshot from the prior activate() call. Without
+		// this step, a successful `/profile import --overwrite` that touches the
+		// active profile leaves the session talking to the wrong tenant with the
+		// wrong token until the user restarts or re-activates manually.
+		const activeName = this.#activeProfile?.name;
+		if (activeName && overwritten.includes(activeName)) {
+			await this.activate(activeName);
+		}
 
 		return { imported, overwritten, skipped: [] };
 	}

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -14,6 +14,18 @@ import {
 
 export const CURRENT_SCHEMA_VERSION = 1;
 
+export const CURRENT_EXPORT_VERSION = 1;
+
+export interface ExportBundle {
+	/** Export format version — distinct from per-profile F5XCProfile.version (schema version). */
+	version: number;
+	exportedAt: string;
+	/** When true, importProfiles rejects this bundle. */
+	tokensMasked: boolean;
+	/** Same shape as on-disk profile JSON. Tokens masked iff tokensMasked=true. */
+	profiles: F5XCProfile[];
+}
+
 export interface F5XCProfile {
 	name: string;
 	apiUrl: string;
@@ -339,6 +351,60 @@ export class ProfileService {
 		}
 		fs.unlinkSync(profilePath);
 		this.#profilesCache = this.#profilesCache.filter(p => p.name !== name);
+	}
+
+	/**
+	 * Export one or more profiles as an ExportBundle. Profiles are deep-cloned
+	 * before any masking to guarantee the in-memory cache (#profilesCache and
+	 * #activeProfile, which may share references) is never mutated.
+	 *
+	 * When includeToken is false, apiToken and every env value whose key is in
+	 * sensitiveKeys is replaced with the masked form. The envelope's
+	 * tokensMasked flag reflects this so importProfiles can refuse masked
+	 * bundles.
+	 *
+	 * Throws ProfileError when a requested name does not exist on disk.
+	 */
+	async exportProfiles(opts: { names?: string[]; includeToken: boolean }): Promise<ExportBundle> {
+		const all = await this.listProfiles();
+		let selected: F5XCProfile[];
+		if (opts.names && opts.names.length > 0) {
+			const byName = new Map(all.map(p => [p.name, p]));
+			selected = [];
+			const missing: string[] = [];
+			for (const n of opts.names) {
+				const p = byName.get(n);
+				if (!p) missing.push(n);
+				else selected.push(p);
+			}
+			if (missing.length > 0) {
+				throw new ProfileError(`Profile(s) not found: ${missing.join(", ")}.`, missing[0]);
+			}
+		} else {
+			selected = all;
+		}
+
+		// Deep-clone BEFORE masking. maskToken is destructive; mutating cache
+		// entries would break subsequent activate/validate/show operations.
+		const cloned = selected.map(p => structuredClone(p));
+
+		if (!opts.includeToken) {
+			for (const p of cloned) {
+				p.apiToken = this.maskToken(p.apiToken);
+				if (p.env && p.sensitiveKeys) {
+					for (const k of p.sensitiveKeys) {
+						if (p.env[k]) p.env[k] = this.maskToken(p.env[k]);
+					}
+				}
+			}
+		}
+
+		return {
+			version: CURRENT_EXPORT_VERSION,
+			exportedAt: new Date().toISOString(),
+			tokensMasked: !opts.includeToken,
+			profiles: cloned,
+		};
 	}
 
 	/**

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -621,6 +621,66 @@ export class ProfileService {
 		}
 	}
 
+	/**
+	 * Field-shape check for a parsed profile object. Returns a normalized
+	 * F5XCProfile when obj passes the same rules #readProfile enforces on disk
+	 * reads, or null when a required field is missing/wrong-typed.
+	 *
+	 * Used by #readProfile (canonical name = filename) and by importProfiles
+	 * (canonical name = obj.name, which the caller must already have validated
+	 * via #isValidProfileName).
+	 *
+	 * Side effect: logger.warn on failure, matching #readProfile's original
+	 * behavior so existing log-assertion tests continue to pass.
+	 */
+	#validateProfileShape(obj: unknown, canonicalName: string): F5XCProfile | null {
+		if (!obj || typeof obj !== "object") {
+			logger.warn("F5XC profile is not an object", { name: canonicalName });
+			return null;
+		}
+		const parsed = obj as Record<string, unknown>;
+
+		if (
+			!parsed.apiUrl ||
+			typeof parsed.apiUrl !== "string" ||
+			!parsed.apiToken ||
+			typeof parsed.apiToken !== "string"
+		) {
+			logger.warn("F5XC profile missing or invalid required fields", { name: canonicalName });
+			return null;
+		}
+		if (parsed.defaultNamespace && typeof parsed.defaultNamespace !== "string") {
+			logger.warn("F5XC profile has non-string defaultNamespace", { name: canonicalName });
+			return null;
+		}
+
+		let env: Record<string, string> | undefined;
+		if (parsed.env && typeof parsed.env === "object" && !Array.isArray(parsed.env)) {
+			env = {};
+			for (const [k, v] of Object.entries(parsed.env)) {
+				if (typeof v === "string") env[k] = v;
+			}
+			if (Object.keys(env).length === 0) env = undefined;
+		}
+
+		let sensitiveKeys: string[] | undefined;
+		if (Array.isArray(parsed.sensitiveKeys) && env) {
+			const filtered = parsed.sensitiveKeys.filter((k: unknown): k is string => typeof k === "string" && k in env);
+			sensitiveKeys = filtered.length > 0 ? filtered : undefined;
+		}
+
+		return {
+			name: canonicalName,
+			apiUrl: parsed.apiUrl,
+			apiToken: parsed.apiToken,
+			defaultNamespace: typeof parsed.defaultNamespace === "string" ? parsed.defaultNamespace : "default",
+			env,
+			sensitiveKeys,
+			version: typeof parsed.version === "number" ? parsed.version : undefined,
+			metadata: (parsed.metadata ?? undefined) as F5XCProfile["metadata"],
+		};
+	}
+
 	#readProfile(name: string): F5XCProfile | null {
 		const filePath = path.join(this.profilesDir, `${name}.json`);
 		try {
@@ -630,51 +690,7 @@ export class ProfileService {
 			}
 			const content = fs.readFileSync(filePath, "utf-8");
 			const parsed = JSON.parse(content);
-
-			// Validate required fields exist and are strings
-			if (
-				!parsed.apiUrl ||
-				typeof parsed.apiUrl !== "string" ||
-				!parsed.apiToken ||
-				typeof parsed.apiToken !== "string"
-			) {
-				logger.warn("F5XC profile missing or invalid required fields", { name });
-				return null;
-			}
-			if (parsed.defaultNamespace && typeof parsed.defaultNamespace !== "string") {
-				logger.warn("F5XC profile has non-string defaultNamespace", { name });
-				return null;
-			}
-
-			// Read optional env map — accept only string values
-			let env: Record<string, string> | undefined;
-			if (parsed.env && typeof parsed.env === "object" && !Array.isArray(parsed.env)) {
-				env = {};
-				for (const [k, v] of Object.entries(parsed.env)) {
-					if (typeof v === "string") env[k] = v;
-				}
-				if (Object.keys(env).length === 0) env = undefined;
-			}
-
-			// Read optional sensitiveKeys — accept only string[] with keys present in env
-			let sensitiveKeys: string[] | undefined;
-			if (Array.isArray(parsed.sensitiveKeys) && env) {
-				const filtered = parsed.sensitiveKeys.filter(
-					(k: unknown): k is string => typeof k === "string" && k in env,
-				);
-				sensitiveKeys = filtered.length > 0 ? filtered : undefined;
-			}
-
-			return {
-				name, // Canonical identity is the filename, not parsed.name
-				apiUrl: parsed.apiUrl,
-				apiToken: parsed.apiToken,
-				defaultNamespace: parsed.defaultNamespace ?? "default",
-				env,
-				sensitiveKeys,
-				version: typeof parsed.version === "number" ? parsed.version : undefined,
-				metadata: parsed.metadata,
-			};
+			return this.#validateProfileShape(parsed, name);
 		} catch (err) {
 			logger.warn("F5XC profile read error", { name, error: String(err) });
 			return null;

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -341,6 +341,85 @@ export class ProfileService {
 		this.#profilesCache = this.#profilesCache.filter(p => p.name !== name);
 	}
 
+	/**
+	 * Rename a profile. File is renamed first (atomic rename(2)); if the profile
+	 * is active, active_profile is then updated to point at the new name. If the
+	 * pointer update fails, the file rename is rolled back.
+	 *
+	 * Throws ProfileError for invalid names, missing source, or a target name
+	 * that already exists. If the pointer-write rollback itself fails, logs a
+	 * warning and throws a ProfileError documenting the inconsistent filesystem
+	 * state for manual recovery.
+	 *
+	 * Fires onProfileChange listeners when the active profile is renamed.
+	 *
+	 * Note: does not rewrite the JSON body's "name" field. #readProfile treats
+	 * the filename as canonical identity, so the stale field is inert.
+	 */
+	async renameProfile(oldName: string, newName: string): Promise<void> {
+		this.#validateProfileName(oldName);
+		this.#validateProfileName(newName);
+		if (oldName === newName) return;
+
+		const oldPath = path.join(this.profilesDir, `${oldName}.json`);
+		const newPath = path.join(this.profilesDir, `${newName}.json`);
+
+		if (!fs.existsSync(oldPath)) {
+			throw new ProfileError(`Profile '${oldName}' not found.`, oldName);
+		}
+		if (fs.existsSync(newPath)) {
+			throw new ProfileError(`Profile '${newName}' already exists.`, newName);
+		}
+
+		// Step 1: rename file (atomic rename(2) on the same filesystem)
+		fs.renameSync(oldPath, newPath);
+
+		// Step 2: if renaming the active profile, update the pointer. On failure
+		// we must roll back the file rename so the user sees a consistent state.
+		const wasActive = this.#activeProfile?.name === oldName;
+		if (wasActive) {
+			try {
+				this.#atomicWrite(this.activeProfilePath, newName);
+			} catch (err) {
+				// Rollback
+				try {
+					fs.renameSync(newPath, oldPath);
+					throw new ProfileError(
+						`Failed to update active profile pointer: ${err instanceof Error ? err.message : String(err)}. Profile was not renamed.`,
+						oldName,
+					);
+				} catch (rollbackErr) {
+					if (rollbackErr instanceof ProfileError) throw rollbackErr;
+					logger.warn("F5XC profile rename rollback failed — manual recovery required", {
+						oldName,
+						newName,
+						originalError: String(err),
+						rollbackError: String(rollbackErr),
+					});
+					throw new ProfileError(
+						`Rename failed and rollback failed. Filesystem state: profiles/${newName}.json exists, active_profile still points at '${oldName}'. Manually rename profiles/${newName}.json back to profiles/${oldName}.json, or update active_profile to '${newName}'. Original error: ${err instanceof Error ? err.message : String(err)}. Rollback error: ${String(rollbackErr)}`,
+						oldName,
+					);
+				}
+			}
+		}
+
+		// Step 3: update cache + active-profile pointer in memory.
+		// Private-static listener access uses the same idiom as #applyToSettings
+		// (the loop `for (const cb of ProfileService.#onProfileChangeListeners)`
+		// already appears in that method) — direct `ProfileService.#name` access
+		// from inside the class body.
+		this.#profilesCache = this.#profilesCache
+			.map(p => (p.name === oldName ? { ...p, name: newName } : p))
+			.sort((a, b) => a.name.localeCompare(b.name));
+		if (wasActive && this.#activeProfile) {
+			this.#activeProfile = { ...this.#activeProfile, name: newName };
+			for (const cb of ProfileService.#onProfileChangeListeners) {
+				cb(this.#activeProfile);
+			}
+		}
+	}
+
 	/** Add or update environment variables on a profile. Keys matching secret
 	 *  naming patterns are automatically added to sensitiveKeys. */
 	async setEnvVars(name: string, vars: Record<string, string>): Promise<{ sensitive: string[] }> {

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -47,6 +47,13 @@ export interface ProfileStatus {
 	authCheckedAt?: number;
 }
 
+export interface ValidationResult {
+	profile: F5XCProfile;
+	status: AuthStatus;
+	latencyMs?: number;
+	errorClass?: "network" | "credential";
+}
+
 export class ProfileError extends Error {
 	constructor(
 		message: string,
@@ -509,6 +516,29 @@ export class ProfileService {
 			}
 			return { status: "offline", errorClass: "network" };
 		}
+	}
+
+	/**
+	 * Validate credentials for a named profile without switching the active one.
+	 * Uses validateToken's ad-hoc branch (explicit apiUrl + apiToken), so no
+	 * cached auth state, namespace cache, or active profile is mutated.
+	 *
+	 * Throws ProfileError when the name is invalid, the profile is missing, or
+	 * the profile's schema version is incompatible. Auth failure is not thrown:
+	 * it is returned as ValidationResult.status = "auth_error" / "offline".
+	 */
+	async validateProfileByName(name: string): Promise<ValidationResult> {
+		this.#validateProfileName(name);
+		const profile = this.#readProfile(name);
+		if (!profile) {
+			throw new ProfileError(`Profile '${name}' not found.`, name);
+		}
+		this.#assertCompatibleVersion(profile);
+		const { status, latencyMs, errorClass } = await this.validateToken({
+			apiUrl: profile.apiUrl,
+			apiToken: profile.apiToken,
+		});
+		return { profile, status, latencyMs, errorClass };
 	}
 
 	setNamespace(namespace: string): void {

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -47,6 +47,16 @@ export interface ProfileStatus {
 	authCheckedAt?: number;
 }
 
+/**
+ * Result of validating credentials for a named profile without activating it.
+ * Returned by `ProfileService.validateProfileByName()`. Callers get the full
+ * profile back rather than correlating by name so rendering code can use a
+ * single object (tenant, URL, masked token, status) without a second lookup.
+ *
+ * Auth failure is carried here as `status: "auth_error" | "offline"` with
+ * optional `errorClass` — not thrown. The method throws only for missing /
+ * invalid-name / incompatible-version cases.
+ */
 export interface ValidationResult {
 	profile: F5XCProfile;
 	status: AuthStatus;

--- a/packages/coding-agent/src/services/f5xc-profile.ts
+++ b/packages/coding-agent/src/services/f5xc-profile.ts
@@ -938,7 +938,16 @@ export class ProfileService {
 
 	#atomicWrite(filePath: string, content: string): void {
 		const tmpPath = `${filePath}.tmp`;
-		fs.writeFileSync(tmpPath, content);
+		// Force 0o600 on the tmp file so the atomic rename produces a
+		// destination with credential-file permissions. Without this, the
+		// tmp inherits process umask (typically 0644), fs.renameSync carries
+		// those permissions onto the destination, and any profile JSON
+		// updated through this helper (setEnvVars, unsetEnvVars, import
+		// overwrite) ends up world-readable even though createProfile
+		// explicitly writes at 0o600. active_profile pointer is also
+		// tightened — it names the profile but carries no credentials, so
+		// 0o600 is strictly no worse.
+		fs.writeFileSync(tmpPath, content, { mode: 0o600 });
 		fs.renameSync(tmpPath, filePath);
 	}
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1096,16 +1096,17 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 						}
 					}
 
-					// Offer --include-token unless already present
-					if (!hasIncludeToken) {
-						const lower = completingToken.toLowerCase();
-						if ("--include-token".startsWith(lower)) {
-							items.push({
-								value: "--include-token",
-								label: "--include-token",
-								description: "emit unmasked tokens",
-							});
-						}
+					// Offer --include-token unless already present. Match is
+					// case-sensitive because the handler's flag check uses
+					// exact-match `flags.has("--include-token")` — offering
+					// the suggestion for mis-cased prefixes (e.g. `--INCLUDE`)
+					// would produce a suggestion the handler then ignores.
+					if (!hasIncludeToken && "--include-token".startsWith(completingToken)) {
+						items.push({
+							value: "--include-token",
+							label: "--include-token",
+							description: "emit unmasked tokens",
+						});
 					}
 
 					return items.length > 0 ? items : null;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1048,6 +1048,22 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 			{ name: "create", description: "Create a new profile", usage: "<name> <url> <token> [namespace]" },
 			{ name: "delete", description: "Delete a profile", usage: "<name> --confirm" },
 			{
+				name: "rename",
+				description: "Rename a profile",
+				usage: "<old> <new>",
+				getArgumentCompletions(prefix: string) {
+					if (prefix.includes(" ")) return null;
+					const svc = tryGetProfileService();
+					if (!svc) return null;
+					const lower = prefix.toLowerCase();
+					const items = svc
+						.listProfileNamesCached()
+						.filter(n => n.toLowerCase().startsWith(lower))
+						.map(n => ({ value: n, label: n }));
+					return items.length > 0 ? items : null;
+				},
+			},
+			{
 				name: "namespace",
 				description: "Switch namespace within active profile",
 				usage: "<namespace>",

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1113,6 +1113,14 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 				},
 			},
 			{
+				name: "import",
+				description: "Import profiles from a file path or inline JSON",
+				usage: "<path-or-json> [--overwrite]",
+				// No dynamic completion — paths are hard to complete correctly,
+				// and faking it would only mislead. Users pre-expand paths in
+				// their shell.
+			},
+			{
 				name: "namespace",
 				description: "Switch namespace within active profile",
 				usage: "<namespace>",

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1064,6 +1064,54 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 				},
 			},
 			{
+				name: "export",
+				description: "Export a profile (or all profiles) as JSON",
+				usage: "[name] [--include-token]",
+				getArgumentCompletions(prefix: string) {
+					const svc = tryGetProfileService();
+					if (!svc) return null;
+					const tokens = prefix.split(/\s+/).filter(Boolean);
+					const hasIncludeToken = tokens.includes("--include-token");
+					const positionalsTyped = tokens.filter(t => !t.startsWith("--"));
+					// Last token is "in-progress" if the prefix does not end with space.
+					const trailingSpace = prefix.endsWith(" ") || prefix === "";
+					const typedPositionalCount = trailingSpace
+						? positionalsTyped.length
+						: Math.max(0, positionalsTyped.length - 1);
+					const completingToken = trailingSpace ? "" : (tokens[tokens.length - 1] ?? "");
+
+					const items: { value: string; label: string; description?: string }[] = [];
+
+					// Offer profile names only if no positional has been filled yet
+					if (typedPositionalCount === 0 && !completingToken.startsWith("--")) {
+						const lower = completingToken.toLowerCase();
+						for (const n of svc.listProfileNamesCached()) {
+							if (!n.toLowerCase().startsWith(lower)) continue;
+							const hint = svc.getProfileHint(n);
+							items.push({
+								value: n,
+								label: n,
+								description: hint?.apiUrl,
+							});
+						}
+					}
+
+					// Offer --include-token unless already present
+					if (!hasIncludeToken) {
+						const lower = completingToken.toLowerCase();
+						if ("--include-token".startsWith(lower)) {
+							items.push({
+								value: "--include-token",
+								label: "--include-token",
+								description: "emit unmasked tokens",
+							});
+						}
+					}
+
+					return items.length > 0 ? items : null;
+				},
+			},
+			{
 				name: "namespace",
 				description: "Switch namespace within active profile",
 				usage: "<namespace>",

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1090,8 +1090,18 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 
 					const items: { value: string; label: string; description?: string }[] = [];
 
-					// Offer profile names only if no positional has been filled yet
-					if (typedPositionalCount === 0 && !completingToken.startsWith("--")) {
+					// Offer profile names only if no positional has been filled yet.
+					// No startsWith("--") guard: profile names legitimately allow
+					// leading dashes (the regex is /^[a-zA-Z0-9_-]{1,64}$/), and
+					// the handler's splitArgs uses a known-flags allowlist that
+					// treats only --include-token as a flag. So a profile like
+					// `--prod` is valid; the completion filters by prefix and
+					// matches it naturally. When the user types `--in`, the
+					// flag-completion branch below matches `--include-token` by
+					// prefix; if there's ALSO a profile starting with `--in` it
+					// is offered here. Both lists are disjoint by filter so
+					// there's no double-offer of the same token.
+					if (typedPositionalCount === 0) {
 						const lower = completingToken.toLowerCase();
 						for (const n of svc.listProfileNamesCached()) {
 							if (!n.toLowerCase().startsWith(lower)) continue;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1079,6 +1079,14 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 						? positionalsTyped.length
 						: Math.max(0, positionalsTyped.length - 1);
 					const completingToken = trailingSpace ? "" : (tokens[tokens.length - 1] ?? "");
+					// `head` is every already-typed token EXCEPT the one being
+					// completed. getArgumentCompletions.value replaces the whole
+					// argument tail, so value must carry every token the user
+					// should keep — otherwise accepting a suggestion silently
+					// drops the other args. Contract: see SubcommandDef JSDoc
+					// above (line ~58).
+					const headTokens = trailingSpace ? tokens : tokens.slice(0, -1);
+					const head = headTokens.length > 0 ? `${headTokens.join(" ")} ` : "";
 
 					const items: { value: string; label: string; description?: string }[] = [];
 
@@ -1089,7 +1097,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 							if (!n.toLowerCase().startsWith(lower)) continue;
 							const hint = svc.getProfileHint(n);
 							items.push({
-								value: n,
+								value: `${head}${n}`,
 								label: n,
 								description: hint?.apiUrl,
 							});
@@ -1103,7 +1111,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 					// would produce a suggestion the handler then ignores.
 					if (!hasIncludeToken && "--include-token".startsWith(completingToken)) {
 						items.push({
-							value: "--include-token",
+							value: `${head}--include-token`,
 							label: "--include-token",
 							description: "emit unmasked tokens",
 						});

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1015,6 +1015,34 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 					return items.length > 0 ? items : null;
 				},
 			},
+			{
+				name: "validate",
+				description: "Validate credentials for a profile without activating",
+				usage: "<name>",
+				getArgumentCompletions(prefix: string) {
+					if (prefix.includes(" ")) return null;
+					const svc = tryGetProfileService();
+					if (!svc) return null;
+					const lower = prefix.toLowerCase();
+					const items = svc
+						.listProfileNamesCached()
+						.filter(n => n.toLowerCase().startsWith(lower))
+						.map(n => {
+							const hint = svc.getProfileHint(n);
+							const parts: string[] = [];
+							if (hint?.apiUrl) parts.push(hint.apiUrl);
+							if (hint?.incompatible && hint.schemaVersion !== undefined) {
+								parts.push(`incompatible: v${hint.schemaVersion}`);
+							}
+							return {
+								value: n,
+								label: n,
+								description: parts.length > 0 ? parts.join(" · ") : undefined,
+							};
+						});
+					return items.length > 0 ? items : null;
+				},
+			},
 			{ name: "show", description: "Show profile details (masked)", usage: "[name]" },
 			{ name: "status", description: "Show current auth status" },
 			{ name: "create", description: "Create a new profile", usage: "<name> <url> <token> [namespace]" },

--- a/packages/coding-agent/test/f5xc-profile-command.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-command.test.ts
@@ -797,4 +797,50 @@ describe("/profile slash command handler", () => {
 		expect(ctx.messages[0].type).toBe("error");
 		expect(ctx.messages[0].text).toMatch(/already exists/);
 	});
+
+	it("/profile export emits a masked bundle by default", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: "export", text: "/profile export" }, ctx);
+		expect(ctx.messages[0].type).toBe("status");
+		const parsed = JSON.parse(ctx.messages[0].text);
+		expect(parsed.version).toBe(1);
+		expect(parsed.tokensMasked).toBe(true);
+		expect(parsed.profiles[0].apiToken.startsWith("...")).toBe(true);
+	});
+
+	it("/profile export <name> filters to one profile", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: `export ${TEST_PROFILE.name}`, text: "" }, ctx);
+		const parsed = JSON.parse(ctx.messages[0].text);
+		expect(parsed.profiles.length).toBe(1);
+		expect(parsed.profiles[0].name).toBe(TEST_PROFILE.name);
+	});
+
+	it("/profile export --include-token emits unmasked tokens", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: "export --include-token", text: "" }, ctx);
+		const parsed = JSON.parse(ctx.messages[0].text);
+		expect(parsed.tokensMasked).toBe(false);
+		expect(parsed.profiles[0].apiToken).toBe(TEST_PROFILE.apiToken);
+	});
+
+	it("/profile export surfaces not-found errors", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: "export nonexistent", text: "" }, ctx);
+		expect(ctx.messages[0].type).toBe("error");
+		expect(ctx.messages[0].text).toMatch(/not found/);
+	});
 });

--- a/packages/coding-agent/test/f5xc-profile-command.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-command.test.ts
@@ -972,4 +972,46 @@ describe("/profile slash command handler", () => {
 		expect(ctx.messages[0].type).toBe("error");
 		expect(ctx.messages[0].text).toMatch(/not valid JSON|missing required fields/i);
 	});
+
+	it("/profile import preserves whitespace runs inside inline JSON string values", async () => {
+		// Regression: prior implementation tokenized args on /\s+/ and rejoined
+		// with single spaces, collapsing multi-space runs inside string values.
+		// A token/password like "foo   bar" would become "foo bar" before JSON.parse,
+		// importing a corrupted credential.
+		const weirdToken = "token\twith   embedded\t\twhitespace";
+		const profileWithWhitespace = {
+			...TEST_PROFILE,
+			apiToken: weirdToken,
+		};
+		const inline = JSON.stringify({
+			version: 1,
+			exportedAt: "",
+			tokensMasked: false,
+			profiles: [profileWithWhitespace],
+		});
+		ProfileService.init(f5xcConfigDir);
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: `import ${inline}`, text: "" }, ctx);
+		expect(ctx.messages[0].type).toBe("status");
+		// The imported profile on disk must have the original token bytes intact.
+		const onDiskPath = path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`);
+		const onDisk = JSON.parse(fs.readFileSync(onDiskPath, "utf-8"));
+		expect(onDisk.apiToken).toBe(weirdToken);
+	});
+
+	it("/profile import accepts --overwrite as a leading flag", async () => {
+		writeProfile(f5xcProfilesDir, { ...TEST_PROFILE, defaultNamespace: "original" });
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		const inline = JSON.stringify({
+			version: 1,
+			exportedAt: "",
+			tokensMasked: false,
+			profiles: [{ ...TEST_PROFILE, defaultNamespace: "new" }],
+		});
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: `import --overwrite ${inline}`, text: "" }, ctx);
+		expect(ctx.messages[0].type).toBe("status");
+		expect(ctx.messages[0].text).toMatch(/overwrote/i);
+	});
 });

--- a/packages/coding-agent/test/f5xc-profile-command.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-command.test.ts
@@ -843,4 +843,133 @@ describe("/profile slash command handler", () => {
 		expect(ctx.messages[0].type).toBe("error");
 		expect(ctx.messages[0].text).toMatch(/not found/);
 	});
+
+	it("/profile import with no arg shows usage error", async () => {
+		ProfileService.init(f5xcConfigDir);
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: "import", text: "/profile import" }, ctx);
+		expect(ctx.messages[0].type).toBe("error");
+		expect(ctx.messages[0].text).toContain("Usage: /profile import");
+	});
+
+	it("/profile import <path> imports from a file", async () => {
+		const bundlePath = path.join(testDir, "bundle.json");
+		fs.writeFileSync(
+			bundlePath,
+			JSON.stringify({
+				version: 1,
+				exportedAt: new Date().toISOString(),
+				tokensMasked: false,
+				profiles: [TEST_PROFILE],
+			}),
+		);
+		ProfileService.init(f5xcConfigDir);
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: `import ${bundlePath}`, text: "" }, ctx);
+		expect(ctx.messages[0].type).toBe("status");
+		expect(ctx.messages[0].text).toMatch(/imported/i);
+		expect(fs.existsSync(path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`))).toBe(true);
+	});
+
+	it("/profile import {inline JSON} parses inline", async () => {
+		const inline = JSON.stringify({
+			version: 1,
+			exportedAt: "",
+			tokensMasked: false,
+			profiles: [TEST_PROFILE],
+		});
+		ProfileService.init(f5xcConfigDir);
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: `import ${inline}`, text: "" }, ctx);
+		expect(ctx.messages[0].type).toBe("status");
+		expect(fs.existsSync(path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`))).toBe(true);
+	});
+
+	it("/profile import ~/file expands tilde", async () => {
+		const savedHome = process.env.HOME;
+		process.env.HOME = testDir;
+		try {
+			const bundlePath = path.join(testDir, "bundle.json");
+			fs.writeFileSync(
+				bundlePath,
+				JSON.stringify({
+					version: 1,
+					exportedAt: "",
+					tokensMasked: false,
+					profiles: [TEST_PROFILE],
+				}),
+			);
+			ProfileService.init(f5xcConfigDir);
+			const ctx = createMockCtx();
+			await handleProfileCommand({ name: "profile", args: "import ~/bundle.json", text: "" }, ctx);
+			expect(ctx.messages[0].type).toBe("status");
+		} finally {
+			if (savedHome === undefined) delete process.env.HOME;
+			else process.env.HOME = savedHome;
+		}
+	});
+
+	it("/profile import surfaces conflict error without --overwrite", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		const inline = JSON.stringify({
+			version: 1,
+			exportedAt: "",
+			tokensMasked: false,
+			profiles: [TEST_PROFILE],
+		});
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: `import ${inline}`, text: "" }, ctx);
+		expect(ctx.messages[0].type).toBe("error");
+		expect(ctx.messages[0].text).toMatch(/conflict/i);
+	});
+
+	it("/profile import --overwrite replaces conflicting profiles", async () => {
+		writeProfile(f5xcProfilesDir, { ...TEST_PROFILE, defaultNamespace: "old" });
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		const inline = JSON.stringify({
+			version: 1,
+			exportedAt: "",
+			tokensMasked: false,
+			profiles: [{ ...TEST_PROFILE, defaultNamespace: "new" }],
+		});
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: `import ${inline} --overwrite`, text: "" }, ctx);
+		expect(ctx.messages[0].type).toBe("status");
+		expect(ctx.messages[0].text).toMatch(/overwrote/i);
+	});
+
+	it("/profile import rejects masked bundle", async () => {
+		const inline = JSON.stringify({
+			version: 1,
+			exportedAt: "",
+			tokensMasked: true,
+			profiles: [{ ...TEST_PROFILE, apiToken: "...g7h8" }],
+		});
+		ProfileService.init(f5xcConfigDir);
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: `import ${inline}`, text: "" }, ctx);
+		expect(ctx.messages[0].type).toBe("error");
+		expect(ctx.messages[0].text).toMatch(/masked tokens/i);
+	});
+
+	it("/profile import reports unreadable path cleanly", async () => {
+		ProfileService.init(f5xcConfigDir);
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: "import /nonexistent/nope.json", text: "" }, ctx);
+		expect(ctx.messages[0].type).toBe("error");
+		expect(ctx.messages[0].text).toMatch(/not found|no such/i);
+	});
+
+	it("/profile import reports non-JSON file cleanly", async () => {
+		const bundlePath = path.join(testDir, "garbage.json");
+		fs.writeFileSync(bundlePath, "not actually json");
+		ProfileService.init(f5xcConfigDir);
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: `import ${bundlePath}`, text: "" }, ctx);
+		expect(ctx.messages[0].type).toBe("error");
+		expect(ctx.messages[0].text).toMatch(/not valid JSON|missing required fields/i);
+	});
 });

--- a/packages/coding-agent/test/f5xc-profile-command.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-command.test.ts
@@ -710,4 +710,50 @@ describe("/profile slash command handler", () => {
 			expect(plain).not.toContain("Last Rotated");
 		});
 	});
+
+	// --- /profile validate ---
+
+	it("/profile validate with no arg shows error pointing at /profile status", async () => {
+		ProfileService.init(f5xcConfigDir);
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: "validate", text: "/profile validate" }, ctx);
+		expect(ctx.messages[0].type).toBe("error");
+		expect(ctx.messages[0].text).toContain("Usage: /profile validate <name>");
+		expect(ctx.messages[0].text).toContain("/profile status");
+	});
+
+	it("/profile validate <name> renders a validation-only table for an existing profile", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const savedFetch = globalThis.fetch;
+		globalThis.fetch = (() =>
+			Promise.resolve(new Response("ok", { status: 200 }))) as unknown as typeof globalThis.fetch;
+		try {
+			ProfileService.init(f5xcConfigDir);
+			const ctx = createMockCtx();
+			await handleProfileCommand(
+				{ name: "profile", args: `validate ${TEST_PROFILE.name}`, text: `/profile validate ${TEST_PROFILE.name}` },
+				ctx,
+			);
+			expect(ctx.messages[0].type).toBe("status");
+			const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+			expect(plain).toContain(TEST_PROFILE.name);
+			expect(plain).toContain("validation only");
+			expect(plain).toContain("F5XC_API_URL");
+			expect(plain).toContain("F5XC_API_TOKEN");
+			expect(plain).toContain(`...${TEST_PROFILE.apiToken.slice(-4)}`);
+		} finally {
+			globalThis.fetch = savedFetch;
+		}
+	});
+
+	it("/profile validate <missing> surfaces ProfileError via showError", async () => {
+		ProfileService.init(f5xcConfigDir);
+		const ctx = createMockCtx();
+		await handleProfileCommand(
+			{ name: "profile", args: "validate nonexistent", text: "/profile validate nonexistent" },
+			ctx,
+		);
+		expect(ctx.messages[0].type).toBe("error");
+		expect(ctx.messages[0].text).toMatch(/not found/i);
+	});
 });

--- a/packages/coding-agent/test/f5xc-profile-command.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-command.test.ts
@@ -151,8 +151,10 @@ function writeActiveProfile(configDir: string, name: string): void {
 /** Minimal mock of InteractiveModeContext for slash command testing */
 function createMockCtx() {
 	const messages: { type: string; text: string }[] = [];
+	const calls = { invalidate: 0, updateEditorTopBorder: 0, requestRender: 0 };
 	return {
 		messages,
+		calls,
 		showStatus(msg: string) {
 			messages.push({ type: "status", text: msg });
 		},
@@ -163,9 +165,19 @@ function createMockCtx() {
 			messages.push({ type: "warning", text: msg });
 		},
 		editor: { setText(_text: string) {} },
-		statusLine: { invalidate() {} },
-		updateEditorTopBorder() {},
-		ui: { requestRender() {} },
+		statusLine: {
+			invalidate() {
+				calls.invalidate += 1;
+			},
+		},
+		updateEditorTopBorder() {
+			calls.updateEditorTopBorder += 1;
+		},
+		ui: {
+			requestRender() {
+				calls.requestRender += 1;
+			},
+		},
 	};
 }
 
@@ -973,6 +985,56 @@ describe("/profile slash command handler", () => {
 		await handleProfileCommand({ name: "profile", args: `import ${inline} --overwrite`, text: "" }, ctx);
 		expect(ctx.messages[0].type).toBe("status");
 		expect(ctx.messages[0].text).toMatch(/overwrote/i);
+	});
+
+	it("/profile import --overwrite refreshes TUI chrome when the active profile is touched", async () => {
+		// Regression: importProfiles re-activates the active profile when an
+		// overwrite touches it, mutating #activeProfile, bash.environment, and
+		// cached auth. Without invalidating statusLine + updateEditorTopBorder
+		// + ui.requestRender, the TUI's profile chrome advertises the old
+		// tenant until an unrelated command triggers a refresh.
+		writeProfile(f5xcProfilesDir, { ...TEST_PROFILE, defaultNamespace: "old" });
+		writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		const inline = JSON.stringify({
+			version: 1,
+			exportedAt: "",
+			tokensMasked: false,
+			profiles: [{ ...TEST_PROFILE, defaultNamespace: "new" }],
+		});
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: `import ${inline} --overwrite`, text: "" }, ctx);
+		expect(ctx.messages[0].type).toBe("status");
+		expect(ctx.calls.invalidate).toBeGreaterThanOrEqual(1);
+		expect(ctx.calls.updateEditorTopBorder).toBeGreaterThanOrEqual(1);
+		expect(ctx.calls.requestRender).toBeGreaterThanOrEqual(1);
+	});
+
+	it("/profile import --overwrite does NOT refresh TUI chrome when the active profile is untouched", async () => {
+		// Symmetric guard: importing a new name (or overwriting a non-active
+		// profile) must not invalidate the chrome — matches the handleCreate /
+		// handleExport no-op pattern.
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		// Overwrite the *staging* profile — active is production.
+		writeProfile(f5xcProfilesDir, { ...TEST_PROFILE_2, defaultNamespace: "original" });
+		const inline = JSON.stringify({
+			version: 1,
+			exportedAt: "",
+			tokensMasked: false,
+			profiles: [{ ...TEST_PROFILE_2, defaultNamespace: "replaced" }],
+		});
+		const ctx = createMockCtx();
+		// Reset the service's cache so the fresh listProfiles sees staging too
+		await service.listProfiles();
+		await handleProfileCommand({ name: "profile", args: `import ${inline} --overwrite`, text: "" }, ctx);
+		expect(ctx.messages[0].type).toBe("status");
+		expect(ctx.calls.invalidate).toBe(0);
+		expect(ctx.calls.updateEditorTopBorder).toBe(0);
+		expect(ctx.calls.requestRender).toBe(0);
 	});
 
 	it("/profile import rejects masked bundle", async () => {

--- a/packages/coding-agent/test/f5xc-profile-command.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-command.test.ts
@@ -756,4 +756,45 @@ describe("/profile slash command handler", () => {
 		expect(ctx.messages[0].type).toBe("error");
 		expect(ctx.messages[0].text).toMatch(/not found/i);
 	});
+
+	it("/profile rename with no args shows error", async () => {
+		ProfileService.init(f5xcConfigDir);
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: "rename", text: "/profile rename" }, ctx);
+		expect(ctx.messages[0].type).toBe("error");
+		expect(ctx.messages[0].text).toContain("Usage");
+	});
+
+	it("/profile rename <old> with only one arg shows error", async () => {
+		ProfileService.init(f5xcConfigDir);
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: "rename onlyone", text: "/profile rename onlyone" }, ctx);
+		expect(ctx.messages[0].type).toBe("error");
+		expect(ctx.messages[0].text).toContain("Usage");
+	});
+
+	it("/profile rename <old> <new> renames and reports success", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: `rename ${TEST_PROFILE.name} prod-new`, text: "" }, ctx);
+		expect(ctx.messages[0].type).toBe("status");
+		expect(ctx.messages[0].text).toContain(`'${TEST_PROFILE.name}'`);
+		expect(ctx.messages[0].text).toContain("'prod-new'");
+	});
+
+	it("/profile rename surfaces ProfileError when target exists", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		const ctx = createMockCtx();
+		await handleProfileCommand(
+			{ name: "profile", args: `rename ${TEST_PROFILE.name} ${TEST_PROFILE_2.name}`, text: "" },
+			ctx,
+		);
+		expect(ctx.messages[0].type).toBe("error");
+		expect(ctx.messages[0].text).toMatch(/already exists/);
+	});
 });

--- a/packages/coding-agent/test/f5xc-profile-command.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-command.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Snowflake } from "@f5xc-salesdemos/pi-utils";
 import { _resetSettingsForTest, Settings } from "@f5xc-salesdemos/xcsh/config/settings";
-import { CURRENT_SCHEMA_VERSION, ProfileService } from "@f5xc-salesdemos/xcsh/services/f5xc-profile";
+import { CURRENT_SCHEMA_VERSION, type F5XCProfile, ProfileService } from "@f5xc-salesdemos/xcsh/services/f5xc-profile";
 import { handleProfileCommand } from "@f5xc-salesdemos/xcsh/services/f5xc-profile-command";
 import {
 	formatAuthIndicator,
@@ -821,6 +821,40 @@ describe("/profile slash command handler", () => {
 		const parsed = JSON.parse(ctx.messages[0].text);
 		expect(parsed.profiles.length).toBe(1);
 		expect(parsed.profiles[0].name).toBe(TEST_PROFILE.name);
+	});
+
+	it("/profile export does not misparse a leading-dash profile name as a flag", async () => {
+		// Regression: profile names allow leading dashes (/^[a-zA-Z0-9_-]{1,64}$/).
+		// `/profile export --prod` used to send everything to flags, leaving
+		// zero positionals — which fell through to "export all profiles".
+		// Combined with --include-token it would dump every token unmasked.
+		// After the fix, splitArgs recognizes only the known --include-token
+		// flag; anything else stays in positionals.
+		const prefixedProfile: F5XCProfile = { ...TEST_PROFILE, name: "--prod" };
+		writeProfile(f5xcProfilesDir, prefixedProfile);
+		writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: "export --prod", text: "" }, ctx);
+		expect(ctx.messages[0].type).toBe("status");
+		const parsed = JSON.parse(ctx.messages[0].text);
+		expect(parsed.profiles.length).toBe(1);
+		expect(parsed.profiles[0].name).toBe("--prod");
+	});
+
+	it("/profile export --prod --include-token still honors the flag and filters to one profile", async () => {
+		const prefixedProfile: F5XCProfile = { ...TEST_PROFILE, name: "--prod" };
+		writeProfile(f5xcProfilesDir, prefixedProfile);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+		const ctx = createMockCtx();
+		await handleProfileCommand({ name: "profile", args: "export --prod --include-token", text: "" }, ctx);
+		const parsed = JSON.parse(ctx.messages[0].text);
+		expect(parsed.profiles.length).toBe(1);
+		expect(parsed.profiles[0].name).toBe("--prod");
+		expect(parsed.tokensMasked).toBe(false);
+		expect(parsed.profiles[0].apiToken).toBe(prefixedProfile.apiToken);
 	});
 
 	it("/profile export --include-token emits unmasked tokens", async () => {

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1846,4 +1846,96 @@ describe("ProfileService", () => {
 			expect(reactivated.apiToken).not.toContain("...");
 		});
 	});
+
+	describe("importProfiles", () => {
+		function makeBundle(profiles: F5XCProfile[], tokensMasked = false): unknown {
+			return {
+				version: 1,
+				exportedAt: new Date().toISOString(),
+				tokensMasked,
+				profiles,
+			};
+		}
+
+		it("imports a fresh bundle into an empty state", async () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			const bundle = makeBundle([{ ...TEST_PROFILE }, { ...TEST_PROFILE_2 }]);
+
+			const result = await service.importProfiles(bundle, { overwrite: false });
+			expect(result.imported.sort()).toEqual(["production", "staging"]);
+			expect(result.overwritten).toEqual([]);
+			expect(fs.existsSync(path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`))).toBe(true);
+			expect(fs.existsSync(path.join(f5xcProfilesDir, `${TEST_PROFILE_2.name}.json`))).toBe(true);
+		});
+
+		it("throws with all conflict names when overwrite: false", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.listProfiles();
+			const bundle = makeBundle([{ ...TEST_PROFILE }, { ...TEST_PROFILE_2 }]);
+
+			await expect(service.importProfiles(bundle, { overwrite: false })).rejects.toThrow(
+				/production.*staging|staging.*production/,
+			);
+		});
+
+		it("overwrites conflicting profiles when overwrite: true", async () => {
+			writeProfile(f5xcProfilesDir, { ...TEST_PROFILE, defaultNamespace: "original-ns" });
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.listProfiles();
+			const bundle = makeBundle([{ ...TEST_PROFILE, defaultNamespace: "imported-ns" }]);
+
+			const result = await service.importProfiles(bundle, { overwrite: true });
+			expect(result.imported).toEqual([TEST_PROFILE.name]);
+			expect(result.overwritten).toEqual([TEST_PROFILE.name]);
+			const onDisk = JSON.parse(fs.readFileSync(path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`), "utf-8"));
+			expect(onDisk.defaultNamespace).toBe("imported-ns");
+		});
+
+		it("rejects bundles with tokensMasked: true", async () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			const bundle = makeBundle([{ ...TEST_PROFILE, apiToken: "...g7h8" }], true);
+			await expect(service.importProfiles(bundle, { overwrite: false })).rejects.toThrow(/masked tokens/i);
+			expect(fs.existsSync(path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`))).toBe(false);
+		});
+
+		it("rejects envelope with missing required fields", async () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			await expect(service.importProfiles({ profiles: [TEST_PROFILE] }, { overwrite: false })).rejects.toThrow(
+				/missing required fields/i,
+			);
+			await expect(service.importProfiles({}, { overwrite: false })).rejects.toThrow(/missing required fields/i);
+			await expect(service.importProfiles(null, { overwrite: false })).rejects.toThrow(/missing required fields/i);
+		});
+
+		it("rejects envelope with wrong version", async () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			const bundle = { version: 999, exportedAt: "", tokensMasked: false, profiles: [TEST_PROFILE] };
+			await expect(service.importProfiles(bundle, { overwrite: false })).rejects.toThrow(/version/);
+		});
+
+		it("rejects per-profile field-shape failures without writing", async () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			const bundle = makeBundle([
+				{ ...TEST_PROFILE },
+				// Invalid: apiToken empty string
+				{ name: "bad", apiUrl: "https://x.com", apiToken: "", defaultNamespace: "default" } as F5XCProfile,
+			]);
+			await expect(service.importProfiles(bundle, { overwrite: false })).rejects.toThrow(/bad/);
+			expect(fs.existsSync(path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`))).toBe(false);
+		});
+
+		it("uses fresh listProfiles for conflict detection (not stale cache)", async () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.listProfiles(); // cache is empty
+
+			// Simulate an external actor creating a profile AFTER cache was populated
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+
+			const bundle = makeBundle([{ ...TEST_PROFILE }]);
+			// importProfiles must re-read the directory and find the conflict
+			await expect(service.importProfiles(bundle, { overwrite: false })).rejects.toThrow(/conflict/i);
+		});
+	});
 });

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -2089,6 +2089,38 @@ describe("ProfileService", () => {
 			expect(fs.existsSync(path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`))).toBe(false);
 		});
 
+		it("writes imported profile files with 0o600 permissions", async () => {
+			// Regression: profile JSON carries API tokens. #atomicWrite was
+			// creating tmp files under process umask (typically 0644), and
+			// fs.renameSync inherits source permissions — so imported files
+			// ended up world-readable even though createProfile forces 0o600.
+			// Check the mode of the resulting file matches the credential-file
+			// contract.
+			const service = ProfileService.init(f5xcConfigDir);
+			const bundle = makeBundle([{ ...TEST_PROFILE }]);
+			await service.importProfiles(bundle, { overwrite: false });
+
+			const onDiskPath = path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`);
+			const stat = fs.statSync(onDiskPath);
+			// Mask to permission bits; assert owner-only rw, no group/other access.
+			expect(stat.mode & 0o777).toBe(0o600);
+		});
+
+		it("preserves 0o600 permissions when overwriting an imported profile", async () => {
+			// Same invariant must hold on the overwrite path (the tmp file is
+			// created fresh, so this exercises the same code path — but it's
+			// the credential-exposure case Codex called out most directly).
+			writeProfile(f5xcProfilesDir, TEST_PROFILE); // createProfile-equivalent: 0o600
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.listProfiles();
+			const bundle = makeBundle([{ ...TEST_PROFILE, defaultNamespace: "replaced" }]);
+			await service.importProfiles(bundle, { overwrite: true });
+
+			const onDiskPath = path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`);
+			const stat = fs.statSync(onDiskPath);
+			expect(stat.mode & 0o777).toBe(0o600);
+		});
+
 		it("returns an empty result for a bundle with no profiles", async () => {
 			const service = ProfileService.init(f5xcConfigDir);
 			const bundle = makeBundle([]);

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1651,4 +1651,91 @@ describe("ProfileService", () => {
 			expect(status.authCheckedAt).toBeLessThanOrEqual(after);
 		});
 	});
+
+	describe("renameProfile", () => {
+		it("renames an inactive profile: file moves, cache updates", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			await service.renameProfile(TEST_PROFILE_2.name, "staging-renamed");
+
+			expect(fs.existsSync(path.join(f5xcProfilesDir, `${TEST_PROFILE_2.name}.json`))).toBe(false);
+			expect(fs.existsSync(path.join(f5xcProfilesDir, "staging-renamed.json"))).toBe(true);
+			const names = service.listProfileNamesCached();
+			expect(names).toContain("staging-renamed");
+			expect(names).not.toContain(TEST_PROFILE_2.name);
+			expect(service.getStatus().activeProfileName).toBe(TEST_PROFILE.name);
+		});
+
+		it("renames the active profile: file moves, pointer updates, onProfileChange fires", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const changes: F5XCProfile[] = [];
+			const listener = (p: F5XCProfile) => changes.push(p);
+			ProfileService.onProfileChange(listener);
+			try {
+				await service.renameProfile(TEST_PROFILE.name, "prod-renamed");
+			} finally {
+				ProfileService.offProfileChange(listener);
+			}
+
+			expect(fs.existsSync(path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`))).toBe(false);
+			expect(fs.existsSync(path.join(f5xcProfilesDir, "prod-renamed.json"))).toBe(true);
+			expect(fs.readFileSync(path.join(f5xcConfigDir, "active_profile"), "utf-8").trim()).toBe("prod-renamed");
+			expect(service.getStatus().activeProfileName).toBe("prod-renamed");
+			expect(changes.length).toBe(1);
+			expect(changes[0].name).toBe("prod-renamed");
+		});
+
+		it("throws ProfileError for invalid new name", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			await expect(service.renameProfile(TEST_PROFILE.name, "bad name!")).rejects.toThrow(ProfileError);
+		});
+
+		it("throws ProfileError when target name already exists", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+			await expect(service.renameProfile(TEST_PROFILE.name, TEST_PROFILE_2.name)).rejects.toThrow(/already exists/);
+		});
+
+		it("throws ProfileError when source profile does not exist", async () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			await expect(service.renameProfile("nonexistent", "whatever")).rejects.toThrow(/not found/);
+		});
+
+		it("rolls back when pointer write fails (EISDIR trick)", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+
+			// Pre-create active_profile.tmp as a DIRECTORY — #atomicWrite's
+			// writeFileSync(tmpPath, content) will throw EISDIR before the rename
+			// step, deterministically triggering the rollback path regardless of
+			// the executing UID.
+			const tmpPath = path.join(f5xcConfigDir, "active_profile.tmp");
+			fs.mkdirSync(tmpPath, { recursive: true });
+
+			try {
+				const service = ProfileService.init(f5xcConfigDir);
+				await service.loadActive();
+				await expect(service.renameProfile(TEST_PROFILE.name, "prod-renamed")).rejects.toThrow(
+					/Failed to update active profile pointer/,
+				);
+				expect(fs.existsSync(path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`))).toBe(true);
+				expect(fs.existsSync(path.join(f5xcProfilesDir, "prod-renamed.json"))).toBe(false);
+				expect(fs.readFileSync(path.join(f5xcConfigDir, "active_profile"), "utf-8").trim()).toBe(TEST_PROFILE.name);
+			} finally {
+				fs.rmSync(tmpPath, { recursive: true, force: true });
+			}
+		});
+	});
 });

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1079,6 +1079,82 @@ describe("ProfileService", () => {
 		});
 	});
 
+	describe("validateProfileByName", () => {
+		let savedFetch: typeof globalThis.fetch;
+
+		beforeEach(() => {
+			savedFetch = globalThis.fetch;
+		});
+
+		afterEach(() => {
+			globalThis.fetch = savedFetch;
+		});
+
+		function makeMockResponse(status: number): typeof globalThis.fetch {
+			const fn = () => Promise.resolve(new Response(status === 200 ? "ok" : "err", { status }));
+			return fn as unknown as typeof globalThis.fetch;
+		}
+
+		it("returns connected status for a valid profile", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			globalThis.fetch = makeMockResponse(200);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.listProfiles();
+
+			const result = await service.validateProfileByName(TEST_PROFILE.name);
+			expect(result.profile.name).toBe(TEST_PROFILE.name);
+			expect(result.status).toBe("connected");
+			expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+			expect(result.errorClass).toBeUndefined();
+		});
+
+		it("returns auth_error with credential errorClass on 401", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			globalThis.fetch = makeMockResponse(401);
+			const service = ProfileService.init(f5xcConfigDir);
+
+			const result = await service.validateProfileByName(TEST_PROFILE.name);
+			expect(result.status).toBe("auth_error");
+			expect(result.errorClass).toBe("credential");
+		});
+
+		it("throws ProfileError for invalid profile name", async () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			await expect(service.validateProfileByName("bad name!")).rejects.toThrow(ProfileError);
+		});
+
+		it("throws ProfileError for missing profile", async () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			await expect(service.validateProfileByName("nonexistent")).rejects.toThrow(/not found/);
+		});
+
+		it("throws ProfileError for incompatible schema version", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_INCOMPAT);
+			const service = ProfileService.init(f5xcConfigDir);
+			await expect(service.validateProfileByName(TEST_PROFILE_INCOMPAT.name)).rejects.toThrow(/schema version/);
+		});
+
+		it("does not mutate cached auth state when validating a non-active profile", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+			globalThis.fetch = makeMockResponse(200);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			await service.validateToken();
+			const before = service.getStatus();
+
+			globalThis.fetch = makeMockResponse(401);
+			await service.validateProfileByName(TEST_PROFILE_2.name);
+
+			const after = service.getStatus();
+			expect(after.authStatus).toBe(before.authStatus);
+			expect(after.authCheckedAt).toBe(before.authCheckedAt);
+			expect(after.authLatencyMs).toBe(before.authLatencyMs);
+		});
+	});
+
 	describe("getActiveEnvKeys", () => {
 		it("returns [] when no active profile", () => {
 			const service = ProfileService.init(f5xcConfigDir);

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1937,5 +1937,14 @@ describe("ProfileService", () => {
 			// importProfiles must re-read the directory and find the conflict
 			await expect(service.importProfiles(bundle, { overwrite: false })).rejects.toThrow(/conflict/i);
 		});
+
+		it("returns an empty result for a bundle with no profiles", async () => {
+			const service = ProfileService.init(f5xcConfigDir);
+			const bundle = makeBundle([]);
+			const result = await service.importProfiles(bundle, { overwrite: false });
+			expect(result.imported).toEqual([]);
+			expect(result.overwritten).toEqual([]);
+			expect(result.skipped).toEqual([]);
+		});
 	});
 });

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1820,6 +1820,43 @@ describe("ProfileService", () => {
 			expect(bundle.profiles[0].env?.F5XC_CONSOLE_PASSWORD).toBe("secret123");
 		});
 
+		it("masks secret-looking env keys even when sensitiveKeys is absent", async () => {
+			// Regression: `/profile show` masks env values whose key matches
+			// SECRET_ENV_PATTERNS (e.g. F5XC_CONSOLE_PASSWORD, SOMETHING_TOKEN).
+			// Export must match that contract — a profile edited directly on
+			// disk with a secret-looking key but no sensitiveKeys entry must
+			// still have its values masked on export.
+			const profileWithBareSecret: F5XCProfile = {
+				name: "raw-secret",
+				apiUrl: "https://raw.console.ves.volterra.io",
+				apiToken: "raw-token-plaintext-xxxx",
+				defaultNamespace: "default",
+				env: {
+					F5XC_CONSOLE_PASSWORD: "leaked-password",
+					F5XC_EXTRA_TOKEN: "leaked-token",
+					F5XC_EMAIL: "user@example.com",
+				},
+				// sensitiveKeys intentionally undefined
+			};
+			writeProfile(f5xcProfilesDir, profileWithBareSecret);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.listProfiles();
+
+			const bundle = await service.exportProfiles({
+				names: [profileWithBareSecret.name],
+				includeToken: false,
+			});
+			const env = bundle.profiles[0].env ?? {};
+			// Both secret-shaped keys must be masked
+			expect(env.F5XC_CONSOLE_PASSWORD?.startsWith("...")).toBe(true);
+			expect(env.F5XC_EXTRA_TOKEN?.startsWith("...")).toBe(true);
+			// Non-secret key passes through
+			expect(env.F5XC_EMAIL).toBe("user@example.com");
+			// Raw values never appear
+			expect(env.F5XC_CONSOLE_PASSWORD).not.toBe("leaked-password");
+			expect(env.F5XC_EXTRA_TOKEN).not.toBe("leaked-token");
+		});
+
 		it("throws ProfileError when a named profile does not exist", async () => {
 			writeProfile(f5xcProfilesDir, TEST_PROFILE);
 			const service = ProfileService.init(f5xcConfigDir);
@@ -1936,6 +1973,72 @@ describe("ProfileService", () => {
 			const bundle = makeBundle([{ ...TEST_PROFILE }]);
 			// importProfiles must re-read the directory and find the conflict
 			await expect(service.importProfiles(bundle, { overwrite: false })).rejects.toThrow(/conflict/i);
+		});
+
+		it("refreshes active profile state when an overwrite touches the active profile", async () => {
+			// Regression: overwriting the active profile must re-apply its new
+			// credentials to #activeProfile, Settings.bash.environment, and
+			// cached auth metadata. Otherwise the session keeps using the old
+			// token until restart or manual re-activation.
+			writeProfile(f5xcProfilesDir, { ...TEST_PROFILE, defaultNamespace: "old-ns" });
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const bundle = makeBundle([
+				{
+					...TEST_PROFILE,
+					apiUrl: "https://newtenant.console.ves.volterra.io",
+					apiToken: "new-token-value",
+					defaultNamespace: "new-ns",
+				},
+			]);
+			const result = await service.importProfiles(bundle, { overwrite: true });
+			expect(result.overwritten).toEqual([TEST_PROFILE.name]);
+
+			// The active profile's in-memory snapshot is refreshed — next
+			// status call reflects the new URL and namespace.
+			const status = service.getStatus();
+			expect(status.activeProfileUrl).toBe("https://newtenant.console.ves.volterra.io");
+			expect(status.activeProfileNamespace).toBe("new-ns");
+
+			// Settings.bash.environment is refreshed too (the env-vars the
+			// subprocess would inherit).
+			const bashEnv = Settings.instance.get("bash.environment") as Record<string, string>;
+			expect(bashEnv.F5XC_API_URL).toBe("https://newtenant.console.ves.volterra.io");
+			expect(bashEnv.F5XC_API_TOKEN).toBe("new-token-value");
+			expect(bashEnv.F5XC_NAMESPACE).toBe("new-ns");
+		});
+
+		it("does not re-activate when the overwrite does not touch the active profile", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeProfile(f5xcProfilesDir, { ...TEST_PROFILE_2, defaultNamespace: "staging-original" });
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const bundle = makeBundle([{ ...TEST_PROFILE_2, defaultNamespace: "staging-replaced" }]);
+			await service.importProfiles(bundle, { overwrite: true });
+
+			// Active profile unchanged
+			expect(service.getStatus().activeProfileName).toBe(TEST_PROFILE.name);
+			expect(service.getStatus().activeProfileUrl).toBe(TEST_PROFILE.apiUrl);
+		});
+
+		it("rejects a bundle with duplicate profile names inside it", async () => {
+			// Regression: two bundle entries with the same name would silently
+			// clobber the first in the write loop and emit misleading duplicated
+			// names in `imported[]`. Reject upfront before any write.
+			const service = ProfileService.init(f5xcConfigDir);
+			const bundle = makeBundle([
+				{ ...TEST_PROFILE, defaultNamespace: "first" },
+				{ ...TEST_PROFILE, defaultNamespace: "second" },
+			]);
+			await expect(service.importProfiles(bundle, { overwrite: false })).rejects.toThrow(/duplicate profile name/i);
+			// Nothing written: the original profile file from a prior test state
+			// is absent (no writeProfile call in this test), so the write loop
+			// never ran.
+			expect(fs.existsSync(path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`))).toBe(false);
 		});
 
 		it("returns an empty result for a bundle with no profiles", async () => {

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1719,6 +1719,34 @@ describe("ProfileService", () => {
 			await expect(service.renameProfile("nonexistent", "whatever")).rejects.toThrow(/not found/);
 		});
 
+		it("updates active_profile pointer when renaming under F5XC_API_URL override", async () => {
+			// Regression: with F5XC_API_URL set, loadActive() returns null and
+			// #activeProfile stays null even when active_profile on disk names
+			// a real profile. Renaming that profile must still update the
+			// on-disk active_profile pointer so the next non-env session can
+			// restore the user's previous active selection.
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+			// Simulate env-backed session
+			process.env.F5XC_API_URL = "https://override.console.ves.volterra.io";
+			try {
+				const service = ProfileService.init(f5xcConfigDir);
+				await service.loadActive();
+				// In-memory active is null under env override
+				expect(service.getStatus().activeProfileName).toBe(null);
+
+				await service.renameProfile(TEST_PROFILE.name, "prod-renamed");
+
+				// File moved
+				expect(fs.existsSync(path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`))).toBe(false);
+				expect(fs.existsSync(path.join(f5xcProfilesDir, "prod-renamed.json"))).toBe(true);
+				// Critically: on-disk pointer updated too
+				expect(fs.readFileSync(path.join(f5xcConfigDir, "active_profile"), "utf-8").trim()).toBe("prod-renamed");
+			} finally {
+				delete process.env.F5XC_API_URL;
+			}
+		});
+
 		it("throws ProfileError on identity rename of a missing profile", async () => {
 			// Regression: renaming a profile to itself must not short-circuit
 			// before the existence check, or a typo would silently succeed.
@@ -2023,6 +2051,26 @@ describe("ProfileService", () => {
 			// Active profile unchanged
 			expect(service.getStatus().activeProfileName).toBe(TEST_PROFILE.name);
 			expect(service.getStatus().activeProfileUrl).toBe(TEST_PROFILE.apiUrl);
+		});
+
+		it("rejects a bundle containing a profile with incompatible schema version", async () => {
+			// Regression: a bundle produced by a newer xcsh (per-profile version
+			// > CURRENT_SCHEMA_VERSION) used to pass shape checks and reach the
+			// write loop. The files would land on disk, then activate() would
+			// reject them as "schema version" incompatible — leaving the user
+			// with an unusable on-disk profile and potentially a stale
+			// active_profile pointer. Reject before any write.
+			const service = ProfileService.init(f5xcConfigDir);
+			const futureProfile: F5XCProfile = {
+				...TEST_PROFILE,
+				version: 999,
+			};
+			const bundle = makeBundle([futureProfile]);
+			await expect(service.importProfiles(bundle, { overwrite: false })).rejects.toThrow(
+				/incompatible schema version|schema version/i,
+			);
+			// No write happened — profiles dir is empty or non-existent.
+			expect(fs.existsSync(path.join(f5xcProfilesDir, `${TEST_PROFILE.name}.json`))).toBe(false);
 		});
 
 		it("rejects a bundle with duplicate profile names inside it", async () => {

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1691,6 +1691,12 @@ describe("ProfileService", () => {
 			expect(service.getStatus().activeProfileName).toBe("prod-renamed");
 			expect(changes.length).toBe(1);
 			expect(changes[0].name).toBe("prod-renamed");
+			// Regression guard: listener payload must carry every field of the
+			// renamed profile, not just the new name. A bug where the spread
+			// dropped fields would still pass the name check above.
+			expect(changes[0].apiUrl).toBe(TEST_PROFILE.apiUrl);
+			expect(changes[0].apiToken).toBe(TEST_PROFILE.apiToken);
+			expect(changes[0].defaultNamespace).toBe(TEST_PROFILE.defaultNamespace);
 		});
 
 		it("throws ProfileError for invalid new name", async () => {
@@ -1711,6 +1717,13 @@ describe("ProfileService", () => {
 		it("throws ProfileError when source profile does not exist", async () => {
 			const service = ProfileService.init(f5xcConfigDir);
 			await expect(service.renameProfile("nonexistent", "whatever")).rejects.toThrow(/not found/);
+		});
+
+		it("throws ProfileError on identity rename of a missing profile", async () => {
+			// Regression: renaming a profile to itself must not short-circuit
+			// before the existence check, or a typo would silently succeed.
+			const service = ProfileService.init(f5xcConfigDir);
+			await expect(service.renameProfile("ghost", "ghost")).rejects.toThrow(/not found/);
 		});
 
 		it("rolls back when pointer write fails (EISDIR trick)", async () => {

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1765,7 +1765,9 @@ describe("ProfileService", () => {
 			expect(bundle.profiles.length).toBe(1);
 			expect(bundle.profiles[0].name).toBe(TEST_PROFILE.name);
 			expect(bundle.profiles[0].apiToken.startsWith("...")).toBe(true);
-			expect(new Date(bundle.exportedAt).toString()).not.toBe("Invalid Date");
+			// ISO 8601 UTC format with `Z` suffix — pins the contract so a future
+			// refactor to e.g. toLocaleDateString() would fail this test.
+			expect(bundle.exportedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/);
 		});
 
 		it("exports all profiles when names is omitted", async () => {

--- a/packages/coding-agent/test/f5xc-profile-service.test.ts
+++ b/packages/coding-agent/test/f5xc-profile-service.test.ts
@@ -1751,4 +1751,97 @@ describe("ProfileService", () => {
 			}
 		});
 	});
+
+	describe("exportProfiles", () => {
+		it("exports a single named profile, masked by default", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.listProfiles();
+
+			const bundle = await service.exportProfiles({ names: [TEST_PROFILE.name], includeToken: false });
+			expect(bundle.version).toBe(1);
+			expect(bundle.tokensMasked).toBe(true);
+			expect(bundle.profiles.length).toBe(1);
+			expect(bundle.profiles[0].name).toBe(TEST_PROFILE.name);
+			expect(bundle.profiles[0].apiToken.startsWith("...")).toBe(true);
+			expect(new Date(bundle.exportedAt).toString()).not.toBe("Invalid Date");
+		});
+
+		it("exports all profiles when names is omitted", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_2);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.listProfiles();
+
+			const bundle = await service.exportProfiles({ includeToken: false });
+			expect(bundle.profiles.length).toBe(2);
+			expect(bundle.profiles.map(p => p.name).sort()).toEqual(["production", "staging"]);
+		});
+
+		it("preserves raw token when includeToken: true and sets tokensMasked: false", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.listProfiles();
+
+			const bundle = await service.exportProfiles({ includeToken: true });
+			expect(bundle.tokensMasked).toBe(false);
+			expect(bundle.profiles[0].apiToken).toBe(TEST_PROFILE.apiToken);
+		});
+
+		it("masks sensitiveKeys env values when includeToken: false", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_ENV);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.listProfiles();
+			// setEnvVars auto-detects F5XC_CONSOLE_PASSWORD as sensitive
+			await service.setEnvVars(TEST_PROFILE_ENV.name, { F5XC_CONSOLE_PASSWORD: "secret123" });
+
+			const bundle = await service.exportProfiles({
+				names: [TEST_PROFILE_ENV.name],
+				includeToken: false,
+			});
+			const password = bundle.profiles[0].env?.F5XC_CONSOLE_PASSWORD;
+			expect(password).toBeTruthy();
+			expect(password?.startsWith("...")).toBe(true);
+		});
+
+		it("preserves sensitiveKeys env values when includeToken: true", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE_ENV);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.listProfiles();
+			await service.setEnvVars(TEST_PROFILE_ENV.name, { F5XC_CONSOLE_PASSWORD: "secret123" });
+
+			const bundle = await service.exportProfiles({
+				names: [TEST_PROFILE_ENV.name],
+				includeToken: true,
+			});
+			expect(bundle.profiles[0].env?.F5XC_CONSOLE_PASSWORD).toBe("secret123");
+		});
+
+		it("throws ProfileError when a named profile does not exist", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.listProfiles();
+			await expect(service.exportProfiles({ names: ["nonexistent"], includeToken: false })).rejects.toThrow(
+				/not found/,
+			);
+		});
+
+		// Cache-safety regression test (CRITICAL): structuredClone before mask is
+		// the guard. Without it, maskToken() mutates the cached profile that is
+		// also referenced by #activeProfile, breaking subsequent activate/validate.
+		it("does not corrupt cached profile tokens after a masked export", async () => {
+			writeProfile(f5xcProfilesDir, TEST_PROFILE);
+			writeActiveProfile(f5xcConfigDir, TEST_PROFILE.name);
+			const service = ProfileService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			await service.exportProfiles({ includeToken: false });
+
+			// Re-activate — the raw token must still be intact
+			const reactivated = await service.activate(TEST_PROFILE.name);
+			expect(reactivated.apiToken).toBe(TEST_PROFILE.apiToken);
+			expect(reactivated.apiToken).not.toContain("...");
+		});
+	});
 });

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -656,6 +656,41 @@ describe("/profile export completion", () => {
 		expect(nameItem?.value).toBe("--include-token production");
 	});
 
+	it("offers leading-dash profile names as completions", async () => {
+		// Regression: profile names allow leading dashes (regex
+		// /^[a-zA-Z0-9_-]{1,64}$/), and splitArgs's known-flags allowlist
+		// means the handler correctly treats a name like `--prod` as a
+		// positional. The completion must not diverge from that contract
+		// by refusing to offer `--`-prefixed names.
+		const prefixedProfile = { ...TEST_PROFILE, name: "--prod" };
+		writeProfile(f5xcProfilesDir, prefixedProfile);
+		writeProfile(f5xcProfilesDir, TEST_PROFILE_STAGING);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const exportCmd = getProfileSubcommand("export");
+		// Typing `--p` should offer the leading-dash profile by prefix match.
+		const items = exportCmd.getArgumentCompletions!("--p");
+		expect(items).not.toBeNull();
+		const labels = items!.map(i => i.label);
+		expect(labels).toContain("--prod");
+	});
+
+	it("still offers --include-token when the flag prefix is ambiguous", async () => {
+		// With the leading-dash guard removed, typing `--in` could match both
+		// a hypothetical profile and the --include-token flag. Both branches
+		// filter by prefix independently — ensure the flag suggestion still
+		// appears when the typed prefix matches it.
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const exportCmd = getProfileSubcommand("export");
+		const items = exportCmd.getArgumentCompletions!("--in");
+		expect(items).not.toBeNull();
+		expect(items!.map(i => i.label)).toContain("--include-token");
+	});
+
 	it("returns null when --include-token is already present", async () => {
 		writeProfile(f5xcProfilesDir, TEST_PROFILE);
 		const service = ProfileService.init(f5xcConfigDir);

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -624,6 +624,38 @@ describe("/profile export completion", () => {
 		expect(items!.map(i => i.label)).toEqual(["--include-token"]);
 	});
 
+	it("preserves the positional in the --include-token completion value", async () => {
+		// Regression: getArgumentCompletions.value replaces the whole argument
+		// tail. If value is bare "--include-token", accepting the completion
+		// after "/profile export production " rewrites the line to
+		// "/profile export --include-token" — dropping "production" and turning
+		// a single-profile export into an all-profile export with unmasked
+		// tokens. Value must include the typed positional as a prefix, matching
+		// the contract in SubcommandDef.getArgumentCompletions.
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const exportCmd = getProfileSubcommand("export");
+		const items = exportCmd.getArgumentCompletions!("production ");
+		expect(items).not.toBeNull();
+		const flagItem = items!.find(i => i.label === "--include-token");
+		expect(flagItem?.value).toBe("production --include-token");
+	});
+
+	it("preserves prefix flag when typing the positional after --include-token", async () => {
+		// Mirror case: user typed "--include-token " first, then a partial name
+		// like "prod". Profile-name completions must preserve the flag.
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const exportCmd = getProfileSubcommand("export");
+		const items = exportCmd.getArgumentCompletions!("--include-token prod");
+		const nameItem = items?.find(i => i.label === "production");
+		expect(nameItem?.value).toBe("--include-token production");
+	});
+
 	it("returns null when --include-token is already present", async () => {
 		writeProfile(f5xcProfilesDir, TEST_PROFILE);
 		const service = ProfileService.init(f5xcConfigDir);

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -441,3 +441,74 @@ describe("/profile namespace completion", () => {
 		expect(ns.getArgumentCompletions!("")).toBeNull(); // guard in provider
 	});
 });
+
+describe("/profile validate completion", () => {
+	let testDir: string;
+	let f5xcConfigDir: string;
+	let f5xcProfilesDir: string;
+	let projectDir: string;
+	let agentDir: string;
+
+	beforeEach(async () => {
+		_resetSettingsForTest();
+		ProfileService._resetForTest();
+		for (const key of Object.keys(process.env)) {
+			if (key.startsWith("F5XC_")) delete process.env[key];
+		}
+		delete process.env.XDG_CONFIG_HOME;
+
+		testDir = path.join(os.tmpdir(), "test-profile-completion-validate", Snowflake.next());
+		f5xcConfigDir = path.join(testDir, "f5xc-config");
+		f5xcProfilesDir = path.join(f5xcConfigDir, "profiles");
+		projectDir = path.join(testDir, "project");
+		agentDir = path.join(testDir, "agent");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.mkdirSync(path.join(projectDir, ".xcsh"), { recursive: true });
+		fs.mkdirSync(agentDir, { recursive: true });
+		await Settings.init({ cwd: projectDir, agentDir, inMemory: true });
+	});
+
+	afterEach(() => {
+		fs.rmSync(testDir, { recursive: true, force: true });
+		ProfileService._resetForTest();
+		_resetSettingsForTest();
+	});
+
+	it("returns items for each cached profile with apiUrl in description", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		writeProfile(f5xcProfilesDir, TEST_PROFILE_STAGING);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const validate = getProfileSubcommand("validate");
+		const items = validate.getArgumentCompletions!("");
+		expect(items).not.toBeNull();
+		expect(items!.map(i => i.label)).toEqual(["production", "staging"]);
+	});
+
+	it("filters case-insensitively by prefix", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		writeProfile(f5xcProfilesDir, TEST_PROFILE_STAGING);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const validate = getProfileSubcommand("validate");
+		const items = validate.getArgumentCompletions!("P");
+		expect(items?.map(i => i.label)).toEqual(["production"]);
+	});
+
+	it("returns null once the prefix contains a space (single-arg boundary)", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const validate = getProfileSubcommand("validate");
+		expect(validate.getArgumentCompletions!("production ")).toBeNull();
+	});
+
+	it("returns null when ProfileService is not initialized", () => {
+		const validate = getProfileSubcommand("validate");
+		expect(() => validate.getArgumentCompletions!("")).not.toThrow();
+		expect(validate.getArgumentCompletions!("")).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -565,3 +565,71 @@ describe("/profile rename completion", () => {
 		expect(rename.getArgumentCompletions!("production ")).toBeNull();
 	});
 });
+
+describe("/profile export completion", () => {
+	let testDir: string;
+	let f5xcConfigDir: string;
+	let f5xcProfilesDir: string;
+	let projectDir: string;
+	let agentDir: string;
+
+	beforeEach(async () => {
+		_resetSettingsForTest();
+		ProfileService._resetForTest();
+		for (const key of Object.keys(process.env)) {
+			if (key.startsWith("F5XC_")) delete process.env[key];
+		}
+		delete process.env.XDG_CONFIG_HOME;
+
+		testDir = path.join(os.tmpdir(), "test-profile-completion-export", Snowflake.next());
+		f5xcConfigDir = path.join(testDir, "f5xc-config");
+		f5xcProfilesDir = path.join(f5xcConfigDir, "profiles");
+		projectDir = path.join(testDir, "project");
+		agentDir = path.join(testDir, "agent");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.mkdirSync(path.join(projectDir, ".xcsh"), { recursive: true });
+		fs.mkdirSync(agentDir, { recursive: true });
+		await Settings.init({ cwd: projectDir, agentDir, inMemory: true });
+	});
+
+	afterEach(() => {
+		fs.rmSync(testDir, { recursive: true, force: true });
+		ProfileService._resetForTest();
+		_resetSettingsForTest();
+	});
+
+	it("offers profile names plus --include-token on an empty prefix", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		writeProfile(f5xcProfilesDir, TEST_PROFILE_STAGING);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const exportCmd = getProfileSubcommand("export");
+		const items = exportCmd.getArgumentCompletions!("");
+		expect(items).not.toBeNull();
+		const labels = items!.map(i => i.label);
+		expect(labels).toContain("production");
+		expect(labels).toContain("staging");
+		expect(labels).toContain("--include-token");
+	});
+
+	it("offers only --include-token once a positional name is typed", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const exportCmd = getProfileSubcommand("export");
+		const items = exportCmd.getArgumentCompletions!("production ");
+		expect(items).not.toBeNull();
+		expect(items!.map(i => i.label)).toEqual(["--include-token"]);
+	});
+
+	it("returns null when --include-token is already present", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const exportCmd = getProfileSubcommand("export");
+		expect(exportCmd.getArgumentCompletions!("production --include-token ")).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/profile-completion.test.ts
+++ b/packages/coding-agent/test/profile-completion.test.ts
@@ -512,3 +512,56 @@ describe("/profile validate completion", () => {
 		expect(validate.getArgumentCompletions!("")).toBeNull();
 	});
 });
+
+describe("/profile rename completion", () => {
+	let testDir: string;
+	let f5xcConfigDir: string;
+	let f5xcProfilesDir: string;
+	let projectDir: string;
+	let agentDir: string;
+
+	beforeEach(async () => {
+		_resetSettingsForTest();
+		ProfileService._resetForTest();
+		for (const key of Object.keys(process.env)) {
+			if (key.startsWith("F5XC_")) delete process.env[key];
+		}
+		delete process.env.XDG_CONFIG_HOME;
+
+		testDir = path.join(os.tmpdir(), "test-profile-completion-rename", Snowflake.next());
+		f5xcConfigDir = path.join(testDir, "f5xc-config");
+		f5xcProfilesDir = path.join(f5xcConfigDir, "profiles");
+		projectDir = path.join(testDir, "project");
+		agentDir = path.join(testDir, "agent");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.mkdirSync(path.join(projectDir, ".xcsh"), { recursive: true });
+		fs.mkdirSync(agentDir, { recursive: true });
+		await Settings.init({ cwd: projectDir, agentDir, inMemory: true });
+	});
+
+	afterEach(() => {
+		fs.rmSync(testDir, { recursive: true, force: true });
+		ProfileService._resetForTest();
+		_resetSettingsForTest();
+	});
+
+	it("offers profile names on the first arg", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		writeProfile(f5xcProfilesDir, TEST_PROFILE_STAGING);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const rename = getProfileSubcommand("rename");
+		const items = rename.getArgumentCompletions!("");
+		expect(items!.map(i => i.label)).toEqual(["production", "staging"]);
+	});
+
+	it("returns null once the first arg is typed (second slot is user's choice)", async () => {
+		writeProfile(f5xcProfilesDir, TEST_PROFILE);
+		const service = ProfileService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const rename = getProfileSubcommand("rename");
+		expect(rename.getArgumentCompletions!("production ")).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

Phase 5/7 of the `/profile` rollout. Adds four new subcommands and one internal refactor:

- **`/profile validate <name>`** (section 5.1) — pre-flight auth check for a named profile without switching the active one. Uses `validateToken`'s ad-hoc branch so no cached auth state is mutated.
- **`/profile rename <old> <new>`** (section 5.3) — atomic file rename with pointer-update rollback. The rollback path is covered by an EISDIR-trigger test that is root-independent (pre-creating `active_profile.tmp` as a directory), unlike chmod-based failure injection that POSIX lets root bypass.
- **`/profile export [name] [--include-token]`** (section 5.2) — JSON bundle export. Masked by default (`apiToken` + `sensitiveKeys` env values); raw with `--include-token`. Deep-clone-before-mask is the load-bearing correctness invariant — the regression test verifies the cache is untouched after export.
- **`/profile import <path-or-json> [--overwrite]`** (section 5.2) — JSON bundle import. Seven-step validation fails closed before any write: envelope schema → version → masked-token gate → per-profile field-shape (reuses `#validateProfileShape` from the refactor) → fresh-disk conflict detection → atomic per-file writes → cache refresh.
- **Internal refactor** — extracted `#validateProfileShape` from `#readProfile` so disk-read and import paths share exact validation rules with zero drift.

**`/profile wizard`** (section 5.4) is deferred to a follow-up issue: #300. It is architecturally distinct — needs a new `ProfileCommandController` + `ProfileAddWizard` TUI Container component. The four subcommands in this PR are pure service-layer additions with zero TUI surface changes, so splitting the wizard out keeps the review surface small.

## What changed

- 3 source files modified: `f5xc-profile.ts`, `f5xc-profile-command.ts`, `slash-commands/builtin-registry.ts`
- 3 test files extended: `f5xc-profile-service.test.ts`, `f5xc-profile-command.test.ts`, `profile-completion.test.ts`
- 63 new tests across the three files. Full profile test surface: 237/237 pass.

## Test plan

- [ ] `bun run check:ts` clean
- [ ] `bun test packages/coding-agent/test/f5xc-profile-service.test.ts packages/coding-agent/test/f5xc-profile-command.test.ts packages/coding-agent/test/profile-completion.test.ts` → 237/237 pass
- [ ] `/profile validate <name>` with a real tenant — confirm auth indicator renders, cached status of active profile unchanged
- [ ] `/profile rename old-name new-name` on the active profile — confirm status line updates immediately
- [ ] `/profile export > /tmp/bundle.json` then `/profile import /tmp/bundle.json` on a fresh machine — round-trip works only when the source used `--include-token`; without it, import rejects with \"Bundle contains masked tokens.\"
- [ ] `/profile import ~/backup.json --overwrite` replaces conflicting profiles
- [ ] Tab completion: `/profile validate <TAB>`, `/profile rename <TAB>`, `/profile export <TAB>` all offer profile names; `/profile import <TAB>` offers nothing (paths are hard to complete correctly)

## Known non-regressions

Two pre-existing test failures appear in the full `bun run test:ts` sweep when run locally in the devcontainer:
- `test/auto-config.test.ts > tryAutoConfigLiteLLM > handles write permission errors gracefully`
- `test/auto-config.test.ts > validateModelsConfig > handles unreadable file`

Both rely on `chmod 0o444` to simulate denied filesystem permissions. POSIX lets root (the devcontainer's default UID) bypass mode bits, so the denial doesn't fire. These tests pass in CI (non-root UID) and are unrelated to this PR — they touch `src/setup-litellm.ts` which was last modified in an unrelated commit.

## Design notes

- `ImportResult.skipped` is always `[]` in this PR; the field is reserved for a future `--skip` flag (deferred as YAGNI since the fail-closed default + `--overwrite` covers the primary use case).
- The JSON body's `"name"` field is NOT rewritten on rename — `#readProfile` uses the filename as canonical identity, so the stale field is inert. Known cosmetic inconsistency; not worth a rewrite.

Closes #276

## Follow-up

- #300 — `/profile wizard` (section 5.4, deferred)