### PR TITLE
revert: remove #308 utils changes accidentally included in #319

### DIFF
--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -438,7 +438,7 @@ export function getSSHConfigPath(scope: "user" | "project", cwd: string = getPro
 }
 
 // =============================================================================
-// F5 Distributed Cloud (F5 XC) context paths
+// F5 Distributed Cloud (F5 XC) profile paths
 // =============================================================================
 
 const F5XC_DIR_NAME = "f5xc";
@@ -449,17 +449,17 @@ export function getF5XCConfigDir(): string {
 	return path.join(xdgConfig, F5XC_DIR_NAME);
 }
 
-/** Get the F5 XC contexts directory (~/.config/f5xc/contexts). */
-export function getF5XCContextsDir(): string {
-	return path.join(getF5XCConfigDir(), "contexts");
+/** Get the F5 XC profiles directory (~/.config/f5xc/profiles). */
+export function getF5XCProfilesDir(): string {
+	return path.join(getF5XCConfigDir(), "profiles");
 }
 
-/** Get the path to the active context indicator file (~/.config/f5xc/active_context). */
-export function getF5XCActiveContextPath(): string {
-	return path.join(getF5XCConfigDir(), "active_context");
+/** Get the path to the active profile indicator file (~/.config/f5xc/active_profile). */
+export function getF5XCActiveProfilePath(): string {
+	return path.join(getF5XCConfigDir(), "active_profile");
 }
 
-/** Get the path to a specific context JSON file (~/.config/f5xc/contexts/<name>.json). */
-export function getF5XCContextPath(name: string): string {
-	return path.join(getF5XCContextsDir(), `${name}.json`);
+/** Get the path to a specific profile JSON file (~/.config/f5xc/profiles/<name>.json). */
+export function getF5XCProfilePath(name: string): string {
+	return path.join(getF5XCProfilesDir(), `${name}.json`);
 }

--- a/packages/utils/test/f5xc-dirs.test.ts
+++ b/packages/utils/test/f5xc-dirs.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getF5XCActiveContextPath, getF5XCConfigDir, getF5XCContextPath, getF5XCContextsDir } from "../src/dirs";
+import { getF5XCActiveProfilePath, getF5XCConfigDir, getF5XCProfilePath, getF5XCProfilesDir } from "../src/dirs";
 
 describe("F5XC XDG path helpers", () => {
 	const originalXdgConfig = process.env.XDG_CONFIG_HOME;
@@ -27,27 +27,27 @@ describe("F5XC XDG path helpers", () => {
 		});
 	});
 
-	describe("getF5XCContextsDir", () => {
-		it("returns config dir + /contexts", () => {
+	describe("getF5XCProfilesDir", () => {
+		it("returns config dir + /profiles", () => {
 			delete process.env.XDG_CONFIG_HOME;
-			const expected = path.join(os.homedir(), ".config", "f5xc", "contexts");
-			expect(getF5XCContextsDir()).toBe(expected);
+			const expected = path.join(os.homedir(), ".config", "f5xc", "profiles");
+			expect(getF5XCProfilesDir()).toBe(expected);
 		});
 	});
 
-	describe("getF5XCActiveContextPath", () => {
-		it("returns config dir + /active_context", () => {
+	describe("getF5XCActiveProfilePath", () => {
+		it("returns config dir + /active_profile", () => {
 			delete process.env.XDG_CONFIG_HOME;
-			const expected = path.join(os.homedir(), ".config", "f5xc", "active_context");
-			expect(getF5XCActiveContextPath()).toBe(expected);
+			const expected = path.join(os.homedir(), ".config", "f5xc", "active_profile");
+			expect(getF5XCActiveProfilePath()).toBe(expected);
 		});
 	});
 
-	describe("getF5XCContextPath", () => {
-		it("returns contexts dir + /<name>.json", () => {
+	describe("getF5XCProfilePath", () => {
+		it("returns profiles dir + /<name>.json", () => {
 			delete process.env.XDG_CONFIG_HOME;
-			const expected = path.join(os.homedir(), ".config", "f5xc", "contexts", "production.json");
-			expect(getF5XCContextPath("production")).toBe(expected);
+			const expected = path.join(os.homedir(), ".config", "f5xc", "profiles", "production.json");
+			expect(getF5XCProfilePath("production")).toBe(expected);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Reverts `packages/utils/src/dirs.ts` and `packages/utils/test/f5xc-dirs.test.ts` to their pre-merge state (before commit 845f1302b)
- The squash merge of PR #319 accidentally included utils/ changes from issue #308 that leaked in via dirty worktree state
- Only the `packages/coding-agent/src/services/` renames from #307 were intended in that PR

## Why

PR #319 was scoped to Step 1 (#307) — renaming core profile service files to context. The utils/ changes (renaming profile path helpers to context) belong to Step 2 (#308) and should land in their own PR after the service layer rename is complete. Including them prematurely caused #308 to be incorrectly closed.

Closes #321

## Test plan

- [ ] CI checks pass (note: `test`, `install_methods`, and `check` failures are pre-existing on main from the incomplete rename in PR #319 — see commit 845f1302b CI results)
- [ ] utils tests pass with the reverted profile naming
- [ ] No other packages are broken by this revert

## Pre-existing CI failures

The `test`, `install_methods`, and `check` jobs fail on main at commit 845f1302b because PR #319 renamed service files (`f5xc-profile*` -> `f5xc-context*`) but did not update the import paths in consumer files (`builtin-registry.ts`, `welcome.ts`, `welcome-checks.ts`, `segments.ts`). This revert does NOT introduce those failures — they are pre-existing.

---

- [x] Issue linked via `Closes #321`
- [x] Only specific files staged (no `git add -A`)