### PR TITLE
feat(coding-agent): rename UI, theme, schema, and prompt refs from profile to context (#311)

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -76,7 +76,7 @@ export type StatusLineSegmentId =
 	| "cache_read"
 	| "cache_write"
 	| "session_name"
-	| "profile_f5xc"
+	| "context_f5xc"
 	| "os_icon";
 
 interface UiMetadata {

--- a/packages/coding-agent/src/modes/components/status-line-segment-editor.ts
+++ b/packages/coding-agent/src/modes/components/status-line-segment-editor.ts
@@ -38,7 +38,7 @@ const SEGMENT_INFO: Record<StatusLineSegmentId, { label: string; short: string }
 	cache_read: { label: "Cache ↓", short: "cache read" },
 	cache_write: { label: "Cache ↑", short: "cache write" },
 	session_name: { label: "Session Name", short: "session name" },
-	profile_f5xc: { label: "F5 XC Profile", short: "F5 XC tenant" },
+	context_f5xc: { label: "F5 XC Context", short: "F5 XC tenant" },
 };
 
 type Column = "left" | "right" | "disabled";

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -3,7 +3,7 @@ import type { PresetDef, StatusLinePreset } from "./types";
 export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	default: {
 		leftSegments: ["pi", "model", "plan_mode", "path", "git", "pr", "context_pct", "token_total", "cost"],
-		rightSegments: ["profile_f5xc"],
+		rightSegments: ["context_f5xc"],
 		separator: "powerline",
 		segmentOptions: {
 			model: { showThinkingLevel: true },
@@ -14,7 +14,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	minimal: {
 		leftSegments: ["path", "git"],
-		rightSegments: ["plan_mode", "context_pct", "profile_f5xc"],
+		rightSegments: ["plan_mode", "context_pct", "context_f5xc"],
 		separator: "slash",
 		segmentOptions: {
 			path: { abbreviate: true, maxLength: 30 },
@@ -24,7 +24,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	compact: {
 		leftSegments: ["model", "plan_mode", "git", "pr"],
-		rightSegments: ["cost", "context_pct", "profile_f5xc"],
+		rightSegments: ["cost", "context_pct", "context_f5xc"],
 		separator: "powerline",
 		segmentOptions: {
 			model: { showThinkingLevel: false },
@@ -43,7 +43,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 			"context_pct",
 			"time_spent",
 			"time",
-			"profile_f5xc",
+			"context_f5xc",
 		],
 		separator: "powerline",
 		segmentOptions: {
@@ -68,7 +68,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 			"context_total",
 			"time_spent",
 			"time",
-			"profile_f5xc",
+			"context_f5xc",
 		],
 		separator: "powerline",
 		segmentOptions: {
@@ -82,7 +82,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	ascii: {
 		// No Nerd Font dependencies
 		leftSegments: ["model", "plan_mode", "path", "git", "pr"],
-		rightSegments: ["token_total", "cost", "context_pct", "profile_f5xc"],
+		rightSegments: ["token_total", "cost", "context_pct", "context_f5xc"],
 		separator: "ascii",
 		segmentOptions: {
 			model: { showThinkingLevel: true },
@@ -93,7 +93,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	xcsh: {
 		leftSegments: ["context_pct", "path", "git"],
-		rightSegments: ["plan_mode", "profile_f5xc"],
+		rightSegments: ["plan_mode", "context_f5xc"],
 		separator: "powerline",
 		segmentOptions: {
 			model: { showThinkingLevel: true },
@@ -106,7 +106,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	custom: {
 		// User-defined - these are just defaults that get overridden
 		leftSegments: ["model", "plan_mode", "path", "git", "pr"],
-		rightSegments: ["token_total", "cost", "context_pct", "profile_f5xc"],
+		rightSegments: ["token_total", "cost", "context_pct", "context_f5xc"],
 		separator: "powerline",
 		segmentOptions: {},
 	},

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -440,17 +440,17 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 			return { content: `${ansi}${sanitizeStatusText(name)}\x1b[39m`, visible: true };
 		},
 	},
-	profile_f5xc: {
-		id: "profile_f5xc",
+	context_f5xc: {
+		id: "context_f5xc",
 		render() {
 			try {
-				const { renderF5XCProfileSegment } = require("../../../services/f5xc-profile-segment");
-				const result = renderF5XCProfileSegment();
+				const { renderF5XCContextSegment } = require("../../../services/f5xc-context-segment");
+				const result = renderF5XCContextSegment();
 				if (!result.visible) return result;
 				return {
 					...result,
-					bg: theme.fgColorAsBg("statusLineProfileF5xcBg"),
-					fg: theme.getFgAnsi("statusLineProfileF5xcFg"),
+					bg: theme.fgColorAsBg("statusLineContextF5xcBg"),
+					fg: theme.getFgAnsi("statusLineContextF5xcFg"),
 				};
 			} catch {
 				return { content: "", visible: false };

--- a/packages/coding-agent/src/modes/theme/defaults/xcsh-dark.json
+++ b/packages/coding-agent/src/modes/theme/defaults/xcsh-dark.json
@@ -100,8 +100,8 @@
 		"statusLineGitConflictFg": 7,
 		"statusLinePlanModeBg": 236,
 		"statusLinePlanModeFg": 117,
-		"statusLineProfileF5xcBg": "f5Red",
-		"statusLineProfileF5xcFg": 231,
+		"statusLineContextF5xcBg": "f5Red",
+		"statusLineContextF5xcFg": 231,
 		"pythonMode": "#f0c040",
 		"syntaxControl": "#569CD6"
 	},

--- a/packages/coding-agent/src/modes/theme/defaults/xcsh-light.json
+++ b/packages/coding-agent/src/modes/theme/defaults/xcsh-light.json
@@ -102,8 +102,8 @@
 		"statusLineGitConflictFg": 255,
 		"statusLinePlanModeBg": 223,
 		"statusLinePlanModeFg": 238,
-		"statusLineProfileF5xcBg": "f5Red",
-		"statusLineProfileF5xcFg": 231,
+		"statusLineContextF5xcBg": "f5Red",
+		"statusLineContextF5xcFg": 231,
 		"pythonMode": "warningAmber",
 		"syntaxControl": "f5Red"
 	},

--- a/packages/coding-agent/src/modes/theme/theme-schema.json
+++ b/packages/coding-agent/src/modes/theme/theme-schema.json
@@ -123,8 +123,8 @@
 				"statusLineGitConflictFg",
 				"statusLinePlanModeBg",
 				"statusLinePlanModeFg",
-				"statusLineProfileF5xcBg",
-				"statusLineProfileF5xcFg"
+				"statusLineContextF5xcBg",
+				"statusLineContextF5xcFg"
 			],
 			"properties": {
 				"accent": {
@@ -483,13 +483,13 @@
 					"$ref": "#/$defs/colorValue",
 					"description": "256-color palette index for the powerline plan-mode segment foreground. See issue #242 for the two-domain color model."
 				},
-				"statusLineProfileF5xcBg": {
+				"statusLineContextF5xcBg": {
 					"$ref": "#/$defs/colorValue",
-					"description": "256-color palette index OR color reference for the powerline F5 XC profile segment background. Stays F5 brand red across light and dark themes. See issue #242 for the two-domain color model."
+					"description": "256-color palette index OR color reference for the powerline F5 XC context segment background. Stays F5 brand red across light and dark themes. See issue #242 for the two-domain color model."
 				},
-				"statusLineProfileF5xcFg": {
+				"statusLineContextF5xcFg": {
 					"$ref": "#/$defs/colorValue",
-					"description": "256-color palette index for the powerline F5 XC profile segment foreground. See issue #242 for the two-domain color model."
+					"description": "256-color palette index for the powerline F5 XC context segment foreground. See issue #242 for the two-domain color model."
 				}
 			},
 			"additionalProperties": false

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -927,8 +927,8 @@ const ThemeJsonSchema = Type.Object({
 			statusLineGitConflictFg: ColorValueSchema,
 			statusLinePlanModeBg: ColorValueSchema,
 			statusLinePlanModeFg: ColorValueSchema,
-			statusLineProfileF5xcBg: ColorValueSchema,
-			statusLineProfileF5xcFg: ColorValueSchema,
+			statusLineContextF5xcBg: ColorValueSchema,
+			statusLineContextF5xcFg: ColorValueSchema,
 		},
 		{ additionalProperties: false },
 	),
@@ -1030,8 +1030,8 @@ export type ThemeColor =
 	| "statusLineGitConflictFg"
 	| "statusLinePlanModeBg"
 	| "statusLinePlanModeFg"
-	| "statusLineProfileF5xcBg"
-	| "statusLineProfileF5xcFg";
+	| "statusLineContextF5xcBg"
+	| "statusLineContextF5xcFg";
 
 /** Set of all valid ThemeColor string values for runtime validation */
 const THEME_COLOR_RECORD = {
@@ -1117,8 +1117,8 @@ const THEME_COLOR_RECORD = {
 	statusLineGitConflictFg: true,
 	statusLinePlanModeBg: true,
 	statusLinePlanModeFg: true,
-	statusLineProfileF5xcBg: true,
-	statusLineProfileF5xcFg: true,
+	statusLineContextF5xcBg: true,
+	statusLineContextF5xcFg: true,
 } satisfies Record<ThemeColor, true>;
 
 const VALID_THEME_COLORS: ReadonlySet<string> = new Set(Object.keys(THEME_COLOR_RECORD));

--- a/packages/coding-agent/src/prompts/system/custom-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/custom-system-prompt.md
@@ -30,12 +30,13 @@ Main branch: {{git.mainBranch}}
 {{/if}}
 </project>
 {{/ifAny}}
-{{#if profile}}
+{{#if context}}
+
 ## F5 XC Platform Context
 
-You are currently connected to F5 XC tenant: {{profile.tenant}}, namespace: {{profile.namespace}}.
-Credential source: {{profile.credentialSource}}.
-Auth status: {{profile.authStatus}}.
+You are currently connected to F5 XC tenant: {{context.tenant}}, namespace: {{context.namespace}}.
+Credential source: {{context.credentialSource}}.
+Auth status: {{context.authStatus}}.
 All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.
 {{/if}}
 {{#if skills.length}}

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -133,12 +133,13 @@ Configs you didn't validate become incidents. Assumptions you didn't test fail u
 {{#list environment prefix="- " join="\n"}}{{label}}: {{value}}{{/list}}
 </workstation>
 
-{{#if profile}}
+{{#if context}}
+
 ## F5 XC Platform Context
 
-You are currently connected to F5 XC tenant: {{profile.tenant}}, namespace: {{profile.namespace}}.
-Credential source: {{profile.credentialSource}}.
-Auth status: {{profile.authStatus}}.
+You are currently connected to F5 XC tenant: {{context.tenant}}, namespace: {{context.namespace}}.
+Credential source: {{context.credentialSource}}.
+Auth status: {{context.authStatus}}.
 All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.
 {{/if}}
 

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -434,8 +434,8 @@ export interface BuildSystemPromptOptions {
 	alwaysApplyRules?: AlwaysApplyRule[];
 	/** Whether secret obfuscation is active. When true, explains the redaction format in the prompt. */
 	secretsEnabled?: boolean;
-	/** Active F5 XC profile context for the `{{#if profile}}` template block. Omit when no profile is active. */
-	profile?: {
+	/** Active F5 XC context for the `{{#if context}}` template block. Omit when no context is active. */
+	context?: {
 		tenant: string;
 		namespace: string;
 		credentialSource: string;
@@ -466,7 +466,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		mcpDiscoveryServerSummaries = [],
 		eagerTasks = false,
 		secretsEnabled = false,
-		profile,
+		context,
 	} = options;
 	const resolvedCwd = cwd ?? getProjectDir();
 
@@ -615,7 +615,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		mcpDiscoveryServerSummaries,
 		eagerTasks,
 		secretsEnabled,
-		profile,
+		context,
 	};
 	let rendered = prompt.render(resolvedCustomPrompt ? customSystemPromptTemplate : systemPromptTemplate, data);
 


### PR DESCRIPTION
## What

Rename all remaining `profile` references to `context` across UI components,
theme definitions, JSON schemas, settings schema, and system prompts.

**Files changed (11):**
- Status-line presets, segments, and segment editor
- Theme engine and dark/light default theme JSON files
- Theme JSON schema
- Settings schema
- System prompt builder and both system prompt markdown templates

## Why

Step 5 of the profile-to-context rename initiative (#302). This batch covers
the UI layer, theme system, configuration schema, and prompt templates --
completing the rename across all non-test source files.

Closes #311

## Testing

- [x] Pre-commit hooks pass (markdownlint, biome, spelling, editorconfig, secrets)
- [x] No new files added, no files deleted -- renames within existing content only
- [ ] CI checks pass

---

- [x] Issue linked via `Closes #311`