### PR TITLE
feat(coding-agent): update remaining source consumers for context rename (#310)

### DIFF
--- a/packages/coding-agent/src/internal-urls/build-info-runtime.ts
+++ b/packages/coding-agent/src/internal-urls/build-info-runtime.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { $ } from "bun";
-import type { ProfileStatus } from "../services/f5xc-profile";
+import type { ContextStatus } from "../services/f5xc-context";
 import { BUILD_INFO, type BuildInfo } from "./build-info.generated";
 
 export type BuildInfoSource = "compiled" | "live-git" | "embedded-fallback";
@@ -104,46 +104,46 @@ export function formatRelativeTime(epochMs: number, nowMs: number): string {
 	return `${days} day${days === 1 ? "" : "s"} ago`;
 }
 
-function renderAuthStatusLine(profile: ProfileStatus, nowMs: number): string {
-	const base = `**Auth Status:** ${profile.authStatus}`;
-	if (profile.authLatencyMs === undefined || profile.authCheckedAt === undefined) {
+function renderAuthStatusLine(context: ContextStatus, nowMs: number): string {
+	const base = `**Auth Status:** ${context.authStatus}`;
+	if (context.authLatencyMs === undefined || context.authCheckedAt === undefined) {
 		return base;
 	}
-	const checked = formatRelativeTime(profile.authCheckedAt, nowMs);
-	return `${base} (latency: ${profile.authLatencyMs}ms, checked: ${checked})`;
+	const checked = formatRelativeTime(context.authCheckedAt, nowMs);
+	return `${base} (latency: ${context.authLatencyMs}ms, checked: ${checked})`;
 }
 
-function renderPlatformContext(profile: ProfileStatus | null, nowMs: number): string {
-	// xcsh can be connected via a named profile OR via F5XC_API_URL / F5XC_API_TOKEN env vars.
-	// In the env-only case, activeProfileName is null but activeProfileTenant (derived from the
+function renderPlatformContext(context: ContextStatus | null, nowMs: number): string {
+	// xcsh can be connected via a named context OR via F5XC_API_URL / F5XC_API_TOKEN env vars.
+	// In the env-only case, activeContextName is null but activeContextTenant (derived from the
 	// env URL) and credentialSource ("environment") are still populated. Guard on tenant, not
 	// name, so env-backed deployments see the configured state instead of the unconfigured copy.
-	if (!profile?.isConfigured || !profile.activeProfileTenant) {
+	if (!context?.isConfigured || !context.activeContextTenant) {
 		return [
 			"## Current Platform Context",
 			"",
-			"No F5 XC profile active. Run `/profile create` or `/profile activate` to connect.",
+			"No F5 XC context active. Run `/context create` or `/context activate` to connect.",
 			"",
 		].join("\n");
 	}
 
-	const authLine = renderAuthStatusLine(profile, nowMs);
-	const credentialLine = `**Credential Source:** ${profile.credentialSource}${
-		profile.credentialSource === "profile" && profile.activeProfileName ? ` (name: ${profile.activeProfileName})` : ""
+	const authLine = renderAuthStatusLine(context, nowMs);
+	const credentialLine = `**Credential Source:** ${context.credentialSource}${
+		context.credentialSource === "context" && context.activeContextName ? ` (name: ${context.activeContextName})` : ""
 	}`;
 
 	return [
 		"## Current Platform Context",
 		"",
-		`- **Tenant:** ${profile.activeProfileTenant}`,
-		`- **Namespace:** ${profile.activeProfileNamespace ?? "default"}`,
+		`- **Tenant:** ${context.activeContextTenant}`,
+		`- **Namespace:** ${context.activeContextNamespace ?? "default"}`,
 		`- ${authLine}`,
 		`- ${credentialLine}`,
 		"",
 	].join("\n");
 }
 
-export function renderAboutDoc(info: RuntimeBuildInfo, profile: ProfileStatus | null): string {
+export function renderAboutDoc(info: RuntimeBuildInfo, context: ContextStatus | null): string {
 	return [
 		"# xcsh — identity and build fingerprint",
 		"",
@@ -163,7 +163,7 @@ export function renderAboutDoc(info: RuntimeBuildInfo, profile: ProfileStatus | 
 		`- PR that shipped this version: ${info.prNumber ? `#${info.prNumber}` : "unknown (resolve via gh if needed)"}`,
 		`- Provenance source: \`${info.source}\` (resolved at ${info.resolvedAt})`,
 		"",
-		renderPlatformContext(profile, Date.now()),
+		renderPlatformContext(context, Date.now()),
 		"## Source of truth",
 		"",
 		`- Repository: ${info.repoUrl}`,

--- a/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
@@ -10,7 +10,7 @@
  * - xcsh://about - Identity fingerprint (version, commit, branch, repo)
  */
 import * as path from "node:path";
-import type { ProfileStatus } from "../services/f5xc-profile";
+import type { ContextStatus } from "../services/f5xc-context";
 import { getRuntimeBuildInfo, type RuntimeBuildInfo, renderAboutDoc } from "./build-info-runtime";
 import { EMBEDDED_DOC_FILENAMES, EMBEDDED_DOCS } from "./docs-index.generated";
 import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
@@ -21,8 +21,8 @@ const ABOUT_ROUTE = "about";
 export interface InternalDocsProtocolOptions {
 	/** Override runtime build-info resolution. Primarily for tests. */
 	readonly resolveBuildInfo?: () => Promise<RuntimeBuildInfo>;
-	/** Sync getter returning the current profile status (or null if unconfigured / unavailable). */
-	readonly getProfileStatus?: () => ProfileStatus | null;
+	/** Sync getter returning the current context status (or null if unconfigured / unavailable). */
+	readonly getContextStatus?: () => ContextStatus | null;
 }
 
 /**
@@ -34,11 +34,11 @@ export interface InternalDocsProtocolOptions {
 export class InternalDocsProtocolHandler implements ProtocolHandler {
 	readonly scheme = "xcsh";
 	readonly #resolveBuildInfo: () => Promise<RuntimeBuildInfo>;
-	readonly #getProfileStatus: (() => ProfileStatus | null) | undefined;
+	readonly #getContextStatus: (() => ContextStatus | null) | undefined;
 
 	constructor(options: InternalDocsProtocolOptions = {}) {
 		this.#resolveBuildInfo = options.resolveBuildInfo ?? getRuntimeBuildInfo;
-		this.#getProfileStatus = options.getProfileStatus;
+		this.#getContextStatus = options.getContextStatus;
 	}
 
 	async resolve(url: InternalUrl): Promise<InternalResource> {
@@ -84,8 +84,8 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 
 		if (normalized === ABOUT_ROUTE || normalized === `${ABOUT_ROUTE}.md`) {
 			const info = await this.#resolveBuildInfo();
-			const profile = this.#getProfileStatus?.() ?? null;
-			const content = renderAboutDoc(info, profile);
+			const context = this.#getContextStatus?.() ?? null;
+			const content = renderAboutDoc(info, context);
 			return {
 				url: url.href,
 				content,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -638,14 +638,14 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 	const cwd = getProjectDir();
 	await logger.time("settings:init", Settings.init, { cwd });
 
-	// F5 XC profile loading — optional, never blocks startup.
+	// F5 XC context loading — optional, never blocks startup.
 	// NOTE: This runs in the CLI path only. SDK consumers using createAgentSession()
-	// directly must call ProfileService.init(configDir).loadActive() themselves.
+	// directly must call ContextService.init(configDir).loadActive() themselves.
 	try {
-		const { ProfileService } = await import("./services/f5xc-profile");
+		const { ContextService } = await import("./services/f5xc-context");
 		const { getF5XCConfigDir } = await import("@f5xc-salesdemos/pi-utils");
-		const profileService = ProfileService.init(getF5XCConfigDir());
-		await profileService.loadActive();
+		const contextService = ContextService.init(getF5XCConfigDir());
+		await contextService.loadActive();
 	} catch {
 		// F5 XC auth is optional — silently continue if anything fails
 	}

--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -1,27 +1,27 @@
 import type { Model } from "@f5xc-salesdemos/pi-ai";
 import { validateApiKeyAgainstModelsEndpoint } from "@f5xc-salesdemos/pi-ai/utils/oauth/api-key-validation";
 import { logger } from "@f5xc-salesdemos/pi-utils";
-import { type AuthStatus, ProfileService } from "../../services/f5xc-profile";
+import { type AuthStatus, ContextService } from "../../services/f5xc-context";
 import type { AuthStorage } from "../../session/auth-storage";
 
 // Startup validation budget. These are longer than validateToken's 3000ms default because
 // the welcome path runs during TLS/DNS cold-start — a single 3s shot races against warm-up
-// and falsely reports offline for profiles that reconnect cleanly moments later.
+// and falsely reports offline for contexts that reconnect cleanly moments later.
 const STARTUP_FIRST_TIMEOUT_MS = 4000;
 const STARTUP_RETRY_TIMEOUT_MS = 5000;
 const STARTUP_RETRY_DELAY_MS = 500;
 
-type ProfileValidator = (opts: {
+type ContextValidator = (opts: {
 	timeoutMs: number;
 }) => Promise<{ status: AuthStatus; latencyMs?: number; errorClass?: "network" | "credential" }>;
 
 /**
- * Runs the profile validator once with a startup-sized timeout; if the result is `offline`
+ * Runs the context validator once with a startup-sized timeout; if the result is `offline`
  * (the only transient class — auth_error/connected/unknown are definitive), waits briefly
  * to let DNS/TLS warm up, then tries once more with a longer timeout.
  */
-export async function validateProfileWithStartupRetry(
-	validate: ProfileValidator,
+export async function validateContextWithStartupRetry(
+	validate: ContextValidator,
 	options?: {
 		firstTimeoutMs?: number;
 		retryTimeoutMs?: number;
@@ -49,17 +49,17 @@ export interface ModelStatus {
 	latencyMs?: number;
 }
 
-export type ProfileCheckState = "no_profile" | "connected" | "auth_error" | "offline";
+export type ContextCheckState = "no_context" | "connected" | "auth_error" | "offline";
 
-export interface WelcomeProfileStatus {
-	state: ProfileCheckState;
+export interface WelcomeContextStatus {
+	state: ContextCheckState;
 	name?: string;
 	latencyMs?: number;
 }
 
 export interface WelcomeCheckResult {
 	model: ModelStatus;
-	profile?: WelcomeProfileStatus;
+	context?: WelcomeContextStatus;
 }
 
 /** Providers that don't store API keys (local inference servers) */
@@ -67,7 +67,7 @@ const KEYLESS_PROVIDERS = new Set(["ollama", "llama.cpp", "lm-studio", "llamafil
 
 /**
  * Run blocking startup checks for the welcome screen.
- * Model check always runs. Profile check only runs if model is connected.
+ * Model check always runs. Context check only runs if model is connected.
  */
 export async function runWelcomeChecks(
 	model: Model | undefined,
@@ -87,9 +87,9 @@ export async function runWelcomeChecks(
 		return { model: modelStatus };
 	}
 
-	// Step 3: Profile check (only if model is connected)
-	const profileStatus = await checkProfileStatus();
-	return { model: modelStatus, profile: profileStatus };
+	// Step 3: Context check (only if model is connected)
+	const contextStatus = await checkContextStatus();
+	return { model: modelStatus, context: contextStatus };
 }
 
 async function validateModelConnection(model: Model | undefined, authStorage: AuthStorage): Promise<ModelStatus> {
@@ -141,20 +141,20 @@ async function validateModelConnection(model: Model | undefined, authStorage: Au
 	}
 }
 
-async function checkProfileStatus(): Promise<WelcomeProfileStatus> {
+async function checkContextStatus(): Promise<WelcomeContextStatus> {
 	try {
-		const profileService = ProfileService.instance;
-		if (!profileService) {
-			return { state: "no_profile" };
+		const contextService = ContextService.instance;
+		if (!contextService) {
+			return { state: "no_context" };
 		}
 
-		const status = profileService.getStatus();
+		const status = contextService.getStatus();
 		if (!status.isConfigured) {
-			return { state: "no_profile" };
+			return { state: "no_context" };
 		}
 
-		const name = status.activeProfileName ?? "default";
-		const result = await validateProfileWithStartupRetry(opts => profileService.validateToken(opts));
+		const name = status.activeContextName ?? "default";
+		const result = await validateContextWithStartupRetry(opts => contextService.validateToken(opts));
 
 		switch (result.status) {
 			case "connected":
@@ -164,10 +164,10 @@ async function checkProfileStatus(): Promise<WelcomeProfileStatus> {
 			case "offline":
 				return { state: "offline", name };
 			default:
-				return { state: "no_profile" };
+				return { state: "no_context" };
 		}
 	} catch {
-		logger.warn("Welcome profile validation failed");
-		return { state: "no_profile" };
+		logger.warn("Welcome context validation failed");
+		return { state: "no_context" };
 	}
 }

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -1,8 +1,8 @@
 import { type Component, padding, truncateToWidth, visibleWidth } from "@f5xc-salesdemos/pi-tui";
 import { APP_NAME } from "@f5xc-salesdemos/pi-utils";
 import { theme } from "../../modes/theme/theme";
-import { formatStatusIcon } from "../../services/f5xc-profile-indicators";
-import type { ModelStatus, WelcomeProfileStatus } from "./welcome-checks";
+import { formatStatusIcon } from "../../services/f5xc-context-indicators";
+import type { ModelStatus, WelcomeContextStatus } from "./welcome-checks";
 
 export interface UpdateStatus {
 	available: boolean;
@@ -18,7 +18,7 @@ export class WelcomeComponent implements Component {
 	constructor(
 		private readonly version: string,
 		private modelStatus: ModelStatus,
-		private profileStatus?: WelcomeProfileStatus,
+		private contextStatus?: WelcomeContextStatus,
 		private updateStatus?: UpdateStatus,
 		private changelogStatus?: ChangelogStatus,
 	) {}
@@ -26,8 +26,8 @@ export class WelcomeComponent implements Component {
 	setModelStatus(status: ModelStatus): void {
 		this.modelStatus = status;
 	}
-	setProfileStatus(status: WelcomeProfileStatus | undefined): void {
-		this.profileStatus = status;
+	setContextStatus(status: WelcomeContextStatus | undefined): void {
+		this.contextStatus = status;
 	}
 	setUpdateStatus(status: UpdateStatus | undefined): void {
 		this.updateStatus = status;
@@ -127,8 +127,8 @@ export class WelcomeComponent implements Component {
 
 	#measureStatusWidth(): number {
 		const lines: string[] = [" Model Provider", ...this.#renderModelStatus()];
-		if (this.profileStatus) {
-			lines.push(" F5 XC Profile", ...this.#renderProfileStatus());
+		if (this.contextStatus) {
+			lines.push(" F5 XC Context", ...this.#renderContextStatus());
 		}
 		if (this.#showUpdateSection()) {
 			lines.push(" Update Available", ...this.#renderUpdateStatus());
@@ -147,11 +147,11 @@ export class WelcomeComponent implements Component {
 		lines.push(` ${theme.bold(theme.fg("contentAccent", "Model Provider"))}`);
 		lines.push(...this.#renderModelStatus());
 		lines.push("");
-		if (this.profileStatus) {
+		if (this.contextStatus) {
 			lines.push(separator);
 			lines.push("");
-			lines.push(` ${theme.bold(theme.fg("contentAccent", "F5 XC Profile"))}`);
-			lines.push(...this.#renderProfileStatus());
+			lines.push(` ${theme.bold(theme.fg("contentAccent", "F5 XC Context"))}`);
+			lines.push(...this.#renderContextStatus());
 			lines.push("");
 		}
 		if (this.#showUpdateSection()) {
@@ -217,9 +217,9 @@ export class WelcomeComponent implements Component {
 		}
 	}
 
-	#renderProfileStatus(): string[] {
-		if (!this.profileStatus) return [];
-		const { state, name, latencyMs } = this.profileStatus;
+	#renderContextStatus(): string[] {
+		if (!this.contextStatus) return [];
+		const { state, name, latencyMs } = this.contextStatus;
 		const n = name ?? "default";
 		switch (state) {
 			case "connected":
@@ -229,17 +229,17 @@ export class WelcomeComponent implements Component {
 			case "auth_error":
 				return [
 					` ${formatStatusIcon("error")} ${theme.fg("muted", n)} ${theme.fg("error", "\u2014 token invalid")}`,
-					`   ${theme.fg("dim", "Run /profile to update")}`,
+					`   ${theme.fg("dim", "Run /context to update")}`,
 				];
 			case "offline":
 				return [
 					` ${formatStatusIcon("warning")} ${theme.fg("muted", n)} ${theme.fg("warning", "\u2014 unreachable")}`,
-					`   ${theme.fg("dim", "Check network, /profile")}`,
+					`   ${theme.fg("dim", "Check network, /context")}`,
 				];
-			case "no_profile":
+			case "no_context":
 				return [
-					` ${formatStatusIcon("warning")} ${theme.fg("warning", "No profile configured")}`,
-					`   ${theme.fg("dim", "Run /profile create <name> <url> <token>")}`,
+					` ${formatStatusIcon("warning")} ${theme.fg("warning", "No context configured")}`,
+					`   ${theme.fg("dim", "Run /context create <name> <url> <token>")}`,
 				];
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -310,7 +310,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			getProjectDir(),
 		);
 
-		// Run blocking welcome screen status checks (model + profile)
+		// Run blocking welcome screen status checks (model + context)
 		const welcomeResult = await logger.time("InteractiveMode.init:welcomeChecks", () =>
 			runWelcomeChecks(this.session.model, this.session.modelRegistry.authStorage),
 		);
@@ -324,11 +324,11 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		if (!startupQuiet) {
-			// Welcome box owns all startup notifications (model, profile, update, changelog)
+			// Welcome box owns all startup notifications (model, context, update, changelog)
 			this.#welcomeComponent = new WelcomeComponent(
 				this.#version,
 				welcomeResult.model,
-				welcomeResult.profile,
+				welcomeResult.context,
 				this.#initialUpdateStatus,
 				this.#changelogStatus,
 			);

--- a/packages/coding-agent/src/services/f5xc-env.ts
+++ b/packages/coding-agent/src/services/f5xc-env.ts
@@ -11,11 +11,11 @@ export const F5XC_USERNAME = "F5XC_USERNAME" as const;
 export const F5XC_CONSOLE_PASSWORD = "F5XC_CONSOLE_PASSWORD" as const;
 
 /**
- * True iff an env var is overriding a profile-provided credential.
+ * True iff an env var is overriding a context-provided credential.
  * F5XC_API_URL alone is NOT an override — it is the signal that the user
- * wants to bypass profiles entirely (see ProfileService.loadActive FR-102).
+ * wants to bypass contexts entirely (see ContextService.loadActive FR-102).
  * The "override" concept only applies to token/namespace supplied alongside
- * a loaded profile.
+ * a loaded context.
  */
 export function hasEnvOverride(): boolean {
 	return !!process.env[F5XC_API_TOKEN] || !!process.env[F5XC_NAMESPACE];

--- a/packages/coding-agent/src/services/f5xc-table.ts
+++ b/packages/coding-agent/src/services/f5xc-table.ts
@@ -1,5 +1,5 @@
-import type { AuthStatus } from "./f5xc-profile";
-import { formatStatusIcon } from "./f5xc-profile-indicators";
+import type { AuthStatus } from "./f5xc-context";
+import { formatStatusIcon } from "./f5xc-context-indicators";
 
 // F5 Brand Red — same as welcome.ts line 203
 const F5_RED = "\x1b[38;5;160m";

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1833,7 +1833,7 @@ export class AgentSession {
 
 	/**
 	 * Register a cleanup callback to run during dispose(). Use for unregistering
-	 * external listeners (e.g., ProfileService.onProfileChange) that close over
+	 * external listeners (e.g., ContextService.onContextChange) that close over
 	 * this session's state and would otherwise leak after disposal.
 	 */
 	addDisposeHook(hook: () => void | Promise<void>): void {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -21,12 +21,12 @@ import {
 	MarketplaceManager,
 } from "../extensibility/plugins/marketplace";
 import type { InteractiveModeContext } from "../modes/types";
-import { ProfileService } from "../services/f5xc-profile";
+import { ContextService } from "../services/f5xc-context";
 import { parseMarketplaceInstallArgs, parsePluginScopeArgs } from "./marketplace-install-parser";
 
-function tryGetProfileService(): ProfileService | null {
+function tryGetContextService(): ContextService | null {
 	try {
-		return ProfileService.instance;
+		return ContextService.instance;
 	} catch (err) {
 		// Expected only when the service hasn't been init()'d yet. Any other error
 		// is surfaced by rethrowing so the TUI's unhandled-rejection path logs it.
@@ -53,7 +53,7 @@ export interface SubcommandDef {
 	 * Optional sync provider for dynamic completions of this subcommand's arguments.
 	 *
 	 * `argumentPrefix` is the text after the subcommand name and its trailing space.
-	 * For multi-token arguments (e.g. `/profile unset KEY1 KEY2`), the provider
+	 * For multi-token arguments (e.g. `/context unset KEY1 KEY2`), the provider
 	 * receives the full tail (`"KEY1 KEY2"`) and must return items whose `value`
 	 * contains the complete replacement for that tail — including any already-typed
 	 * tokens the user should keep. The infrastructure prepends `<subcommand> ` to
@@ -982,25 +982,25 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 		handle: shutdownHandler,
 	},
 	{
-		name: "profile",
-		description: "Manage F5 XC authentication profiles",
+		name: "context",
+		description: "Manage F5 XC authentication contexts",
 		allowArgs: true,
 		subcommands: [
-			{ name: "list", description: "List all profiles" },
+			{ name: "list", description: "List all contexts" },
 			{
 				name: "activate",
-				description: "Switch to a named profile",
+				description: "Switch to a named context",
 				usage: "<name>",
 				getArgumentCompletions(prefix: string) {
 					if (prefix.includes(" ")) return null;
-					const svc = tryGetProfileService();
+					const svc = tryGetContextService();
 					if (!svc) return null;
 					const lower = prefix.toLowerCase();
 					const items = svc
-						.listProfileNamesCached()
+						.listContextNamesCached()
 						.filter(n => n.toLowerCase().startsWith(lower))
 						.map(n => {
-							const hint = svc.getProfileHint(n);
+							const hint = svc.getContextHint(n);
 							const parts: string[] = [];
 							if (hint?.apiUrl) parts.push(hint.apiUrl);
 							if (hint?.incompatible && hint.schemaVersion !== undefined) {
@@ -1017,18 +1017,18 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 			},
 			{
 				name: "validate",
-				description: "Validate credentials for a profile without activating",
+				description: "Validate credentials for a context without activating",
 				usage: "<name>",
 				getArgumentCompletions(prefix: string) {
 					if (prefix.includes(" ")) return null;
-					const svc = tryGetProfileService();
+					const svc = tryGetContextService();
 					if (!svc) return null;
 					const lower = prefix.toLowerCase();
 					const items = svc
-						.listProfileNamesCached()
+						.listContextNamesCached()
 						.filter(n => n.toLowerCase().startsWith(lower))
 						.map(n => {
-							const hint = svc.getProfileHint(n);
+							const hint = svc.getContextHint(n);
 							const parts: string[] = [];
 							if (hint?.apiUrl) parts.push(hint.apiUrl);
 							if (hint?.incompatible && hint.schemaVersion !== undefined) {
@@ -1043,21 +1043,21 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 					return items.length > 0 ? items : null;
 				},
 			},
-			{ name: "show", description: "Show profile details (masked)", usage: "[name]" },
+			{ name: "show", description: "Show context details (masked)", usage: "[name]" },
 			{ name: "status", description: "Show current auth status" },
-			{ name: "create", description: "Create a new profile", usage: "<name> <url> <token> [namespace]" },
-			{ name: "delete", description: "Delete a profile", usage: "<name> --confirm" },
+			{ name: "create", description: "Create a new context", usage: "<name> <url> <token> [namespace]" },
+			{ name: "delete", description: "Delete a context", usage: "<name> --confirm" },
 			{
 				name: "rename",
-				description: "Rename a profile",
+				description: "Rename a context",
 				usage: "<old> <new>",
 				getArgumentCompletions(prefix: string) {
 					if (prefix.includes(" ")) return null;
-					const svc = tryGetProfileService();
+					const svc = tryGetContextService();
 					if (!svc) return null;
 					const lower = prefix.toLowerCase();
 					const items = svc
-						.listProfileNamesCached()
+						.listContextNamesCached()
 						.filter(n => n.toLowerCase().startsWith(lower))
 						.map(n => ({ value: n, label: n }));
 					return items.length > 0 ? items : null;
@@ -1065,10 +1065,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 			},
 			{
 				name: "export",
-				description: "Export a profile (or all profiles) as JSON",
+				description: "Export a context (or all contexts) as JSON",
 				usage: "[name] [--include-token]",
 				getArgumentCompletions(prefix: string) {
-					const svc = tryGetProfileService();
+					const svc = tryGetContextService();
 					if (!svc) return null;
 					const tokens = prefix.split(/\s+/).filter(Boolean);
 					const hasIncludeToken = tokens.includes("--include-token");
@@ -1090,22 +1090,22 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 
 					const items: { value: string; label: string; description?: string }[] = [];
 
-					// Offer profile names only if no positional has been filled yet.
-					// No startsWith("--") guard: profile names legitimately allow
+					// Offer context names only if no positional has been filled yet.
+					// No startsWith("--") guard: context names legitimately allow
 					// leading dashes (the regex is /^[a-zA-Z0-9_-]{1,64}$/), and
 					// the handler's splitArgs uses a known-flags allowlist that
-					// treats only --include-token as a flag. So a profile like
+					// treats only --include-token as a flag. So a context like
 					// `--prod` is valid; the completion filters by prefix and
 					// matches it naturally. When the user types `--in`, the
 					// flag-completion branch below matches `--include-token` by
-					// prefix; if there's ALSO a profile starting with `--in` it
+					// prefix; if there's ALSO a context starting with `--in` it
 					// is offered here. Both lists are disjoint by filter so
 					// there's no double-offer of the same token.
 					if (typedPositionalCount === 0) {
 						const lower = completingToken.toLowerCase();
-						for (const n of svc.listProfileNamesCached()) {
+						for (const n of svc.listContextNamesCached()) {
 							if (!n.toLowerCase().startsWith(lower)) continue;
-							const hint = svc.getProfileHint(n);
+							const hint = svc.getContextHint(n);
 							items.push({
 								value: `${head}${n}`,
 								label: n,
@@ -1132,7 +1132,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 			},
 			{
 				name: "import",
-				description: "Import profiles from a file path or inline JSON",
+				description: "Import contexts from a file path or inline JSON",
 				usage: "<path-or-json> [--overwrite]",
 				// No dynamic completion — paths are hard to complete correctly,
 				// and faking it would only mislead. Users pre-expand paths in
@@ -1140,17 +1140,17 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 			},
 			{
 				name: "namespace",
-				description: "Switch namespace within active profile",
+				description: "Switch namespace within active context",
 				usage: "<namespace>",
 				getArgumentCompletions(prefix: string) {
 					if (prefix.includes(" ")) return null;
-					const svc = tryGetProfileService();
+					const svc = tryGetContextService();
 					if (!svc) return null;
-					// setNamespace() requires an active profile. Don't offer completions that
+					// setNamespace() requires an active context. Don't offer completions that
 					// would lead the user into a command path that cannot succeed (e.g. an
 					// env-backed session where cached namespaces came from startup validation
-					// but there is no active profile to apply them to).
-					if (!svc.getStatus().activeProfileName) return null;
+					// but there is no active context to apply them to).
+					if (!svc.getStatus().activeContextName) return null;
 					const lower = prefix.toLowerCase();
 					const items = svc
 						.getCachedNamespaces()
@@ -1169,7 +1169,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 					const lastSpace = prefix.lastIndexOf(" ");
 					const headRaw = lastSpace === -1 ? "" : prefix.slice(0, lastSpace + 1);
 					const tail = lastSpace === -1 ? prefix : prefix.slice(lastSpace + 1);
-					const svc = tryGetProfileService();
+					const svc = tryGetContextService();
 					if (!svc) return null;
 					const knownKeys = svc.getActiveEnvKeys();
 					const knownExact = new Set(knownKeys);
@@ -1185,7 +1185,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 					// Normalization priority:
 					//   1. Exact-case match → preserve user's token verbatim
 					//   2. Lowercase maps to exactly one canonical → rewrite (the common
-					//      "user typed lowercase, profile has uppercase" path)
+					//      "user typed lowercase, context has uppercase" path)
 					//   3. Lowercase maps to multiple canonicals (ambiguous) → preserve
 					//      as-typed. Auto-picking one would silently target the wrong
 					//      variable. The handler will match nothing and report a no-op,
@@ -1206,15 +1206,15 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 						.map(k => ({
 							value: `${head}${k} `,
 							label: k,
-							description: "env var on active profile",
+							description: "env var on active context",
 						}));
 					return items.length > 0 ? items : null;
 				},
 			},
 		],
 		handle: async (command, runtime) => {
-			const { handleProfileCommand } = await import("../services/f5xc-profile-command");
-			await handleProfileCommand(command, runtime.ctx);
+			const { handleContextCommand } = await import("../services/f5xc-context-command");
+			await handleContextCommand(command, runtime.ctx);
 		},
 	},
 ];


### PR DESCRIPTION
## What

Updates all remaining source consumer files (10 files) to use the new Context* naming, import paths, and method names as part of the profile-to-context rename initiative.

## Why

Step 4 of the profile-to-context rename (#302). The /profile slash command is now /context, all subcommand descriptions reference "context(s)" instead of "profile(s)", and zero "profile" references remain across the updated files.

Closes #310

## Testing

- CI checks pass
- Pre-commit hooks (governance, biome lint, spelling, secrets detection) all pass
- 10 files changed with 122 insertions and 122 deletions (pure rename, no logic changes)

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #310`