### PR TITLE
fix(tui): remove duplicate spacer in tool call entries

### DIFF
--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -139,9 +139,6 @@ export class ToolExecutionComponent extends Container {
 		this.#ui = ui;
 		this.#cwd = cwd;
 		this.#args = cloneToolArgs(args);
-
-		this.addChild(new Spacer(1));
-
 		// Always create both - contentBox for custom tools/bash/tools with renderers, contentText for other built-ins
 		this.#contentBox = new Box(1, 0, (text: string) => theme.bg("toolPendingBg", text));
 		this.#contentText = new Text("", 1, 0, (text: string) => theme.bg("toolPendingBg", text));


### PR DESCRIPTION
## Problem

Tool call entries in the TUI transcript rendered with two blank lines of separation instead of one. Every other entry type (assistant text, thinking blocks) used single-spacing, making tool entries visually inconsistent.

## Root Cause

Two independent `Spacer(1)` components stacked for every tool call entry:
1. **External** — added by `event-controller.ts` / `ui-helpers.ts` before the gutter
2. **Internal** — added by `ToolExecutionComponent` constructor as its first child

Both rendered as a blank line, producing double-spacing.

## Fix

Removed the internal `Spacer(1)` from the `ToolExecutionComponent` constructor. The external spacer (present in all four insertion paths) provides the single blank line of separation.

Intra-entry spacers (multi-file edit results, pending file indicators, image attachments) are unaffected — those are separate code paths within the component.

Fixes #318