### PR TITLE
fix(theme): WCAG AAA code block border contrast in both themes

### DIFF
--- a/packages/coding-agent/src/modes/theme/defaults/xcsh-dark.json
+++ b/packages/coding-agent/src/modes/theme/defaults/xcsh-dark.json
@@ -46,7 +46,7 @@
 		"mdLinkUrl": "#6b7280",
 		"mdCode": "#9CDCFE",
 		"mdCodeBlock": "#9CDCFE",
-		"mdCodeBlockBorder": "subtleGray",
+		"mdCodeBlockBorder": "#a0a8b4",
 		"mdQuote": "coolGray",
 		"mdQuoteBorder": "subtleGray",
 		"mdHr": "subtleGray",

--- a/packages/coding-agent/src/modes/theme/defaults/xcsh-light.json
+++ b/packages/coding-agent/src/modes/theme/defaults/xcsh-light.json
@@ -48,7 +48,7 @@
 		"mdLinkUrl": "f5DarkRed",
 		"mdCode": "successGreen",
 		"mdCodeBlock": "mediumGray",
-		"mdCodeBlockBorder": "lightGray",
+		"mdCodeBlockBorder": "#404850",
 		"mdQuote": "mediumGray",
 		"mdQuoteBorder": "lightGray",
 		"mdHr": "lightGray",


### PR DESCRIPTION
## Problem

Fenced code block borders (````) were nearly invisible in both themes. The `mdCodeBlockBorder` color had catastrophic contrast ratios against all rendering backgrounds:

| Theme | Old value | Old ratio (worst) | WCAG grade |
|---|---|---|---|
| xcsh-dark | `subtleGray` (#2a3038) | 1.33:1 | FAIL |
| xcsh-light | `lightGray` (#d0d0d0) | 1.36:1 | FAIL |

## Fix

Replaced with colors that exceed **WCAG AAA (7:1)** against all backgrounds code blocks render on (page background and tool output background).

### xcsh-dark: `subtleGray` → `#a0a8b4`

| Background | Hex | Contrast ratio |
|---|---|---|
| charcoal (page bg) | #151820 | **7.40:1** |
| deepCharcoal (tool output bg) | #0f1216 | **7.83:1** |

### xcsh-light: `lightGray` → `#404850`

| Background | Hex | Contrast ratio |
|---|---|---|
| warmWhite (page bg) | #faf8f5 | **8.76:1** |
| toolSuccessBg | #f0f8f0 | **8.58:1** |
| toolPendingBg | #f0f0f8 | **8.19:1** |

## Why not the issue's suggestion

The issue suggested using `dim` (#6b7280) for the dark theme. That only reaches 3.67:1 — fails even WCAG AA (4.5:1). The selected `#a0a8b4` is the first cool-toned gray in the palette that clears AAA.

## Scope

- 2 theme JSON files changed, 1 token each
- No code changes — `theme.fg("mdCodeBlockBorder", text)` picks up the new value automatically
- Code block text color (`mdCodeBlock`) unchanged

Fixes #158