### PR TITLE
fix(tui): statusline cwd stale after init and /move command

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -62,7 +62,7 @@ export class StatusLineComponent implements Component {
 	#subagentCount: number = 0;
 	#sessionStartTime: number = Date.now();
 	#planModeStatus: { enabled: boolean; paused: boolean } | null = null;
-	#cwd: string = getShellPwd();
+	#cwd: string;
 	// Display text for a pending chord leader (e.g. "Ctrl+X-") or null when no
 	// chord is pending. Populated by the InputController's ChordDispatcher
 	// callbacks; rendered as a dim right-aligned segment in the top border.
@@ -91,6 +91,7 @@ export class StatusLineComponent implements Component {
 	#lastTokensPerSecondTimestamp: number | null = null;
 
 	constructor(private readonly session: AgentSession) {
+		this.#cwd = session.sessionManager?.getCwd() ?? getShellPwd();
 		this.#settings = {
 			preset: settings.get("statusLine.preset"),
 			leftSegments: settings.get("statusLine.leftSegments"),

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -681,7 +681,8 @@ export class CommandController {
 			resetCapabilities();
 			await this.ctx.refreshSlashCommandState(resolvedPath);
 
-			this.ctx.statusLine.invalidate();
+			setShellPwd(resolvedPath);
+			this.ctx.statusLine.setCwd(resolvedPath);
 			this.ctx.updateEditorTopBorder();
 
 			this.ctx.chatContainer.addChild(new Spacer(1));

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -472,10 +472,12 @@ describe("Provider registration: env var fallback must not send literal name (PR
 // ─── Statusline CWD Tracking (#118, #120) ─────────────────────────────────
 
 describe("statusline tracks assistant cwd, not global shellPwd (PR #120 regression, #118)", () => {
-	it("status-line.ts owns a #cwd field instead of reading getShellPwd() in #buildSegmentContext", async () => {
+	it("status-line.ts owns a #cwd field initialized from session.cwd, not a stale global", async () => {
 		const src = await fs.readFile(path.join(import.meta.dir, "../src/modes/components/status-line.ts"), "utf8");
-		// The component must track cwd internally, not read the global
-		expect(src).toContain("#cwd: string = getShellPwd()");
+		// The component must declare #cwd as a typed field (not inline-initialized from a global)
+		expect(src).toContain("#cwd: string;");
+		// Constructor must initialize #cwd from the session's authoritative cwd
+		expect(src).toContain("session.sessionManager?.getCwd() ?? getShellPwd()");
 		// #buildSegmentContext must use the instance field, not the global
 		expect(src).toContain("cwd: this.#cwd");
 	});
@@ -498,6 +500,17 @@ describe("statusline tracks assistant cwd, not global shellPwd (PR #120 regressi
 			"utf8",
 		);
 		expect(src).toContain("this.ctx.statusLine.setCwd(result.newCwd)");
+	});
+
+	it("command-controller.ts /move handler syncs shellPwd and statusLine cwd", async () => {
+		const src = await fs.readFile(
+			path.join(import.meta.dir, "../src/modes/controllers/command-controller.ts"),
+			"utf8",
+		);
+		// /move must sync the global shellPwd so getShellPwd() stays current
+		expect(src).toContain("setShellPwd(resolvedPath)");
+		// /move must update the statusline's #cwd directly
+		expect(src).toContain("this.ctx.statusLine.setCwd(resolvedPath)");
 	});
 
 	it("status-line.ts git queries resolve against this.#cwd, not getShellPwd()", async () => {

--- a/packages/coding-agent/test/status-line-cwd-watch.test.ts
+++ b/packages/coding-agent/test/status-line-cwd-watch.test.ts
@@ -128,3 +128,54 @@ describe("StatusLineComponent.watchCwd", () => {
 		}
 	});
 });
+
+describe("StatusLineComponent cwd initialization", () => {
+	it("initializes #cwd from session.sessionManager.getCwd() when available", () => {
+		const originalShellPwd = getShellPwd();
+		const shellDir = path.join(os.tmpdir(), `xcsh-init-shell-${process.pid}`);
+		const sessionDir = path.join(os.tmpdir(), `xcsh-init-session-${process.pid}`);
+		fs.mkdirSync(shellDir, { recursive: true });
+		fs.mkdirSync(sessionDir, { recursive: true });
+
+		try {
+			// shellPwd points to one directory, session.cwd to another
+			setShellPwd(shellDir);
+			const session = {
+				...makeSession(),
+				sessionManager: { getCwd: () => sessionDir },
+			} as unknown as AgentSession;
+
+			const component = new StatusLineComponent(session);
+			const rendered = component.getTopBorder(200).content;
+			const stripped = rendered.replace(/\u001b\[[0-9;]*m/g, "");
+
+			// Statusline must show the session cwd, not the stale shellPwd
+			expect(stripped).toContain(path.basename(sessionDir));
+			expect(stripped).not.toContain(path.basename(shellDir));
+
+			component.dispose();
+		} finally {
+			setShellPwd(originalShellPwd);
+		}
+	});
+
+	it("falls back to getShellPwd() when sessionManager is undefined", () => {
+		const originalShellPwd = getShellPwd();
+		const shellDir = path.join(os.tmpdir(), `xcsh-init-fallback-${process.pid}`);
+		fs.mkdirSync(shellDir, { recursive: true });
+
+		try {
+			setShellPwd(shellDir);
+			// session with no sessionManager — the existing makeSession() pattern
+			const component = new StatusLineComponent(makeSession());
+			const rendered = component.getTopBorder(200).content;
+			const stripped = rendered.replace(/\u001b\[[0-9;]*m/g, "");
+
+			expect(stripped).toContain(path.basename(shellDir));
+
+			component.dispose();
+		} finally {
+			setShellPwd(originalShellPwd);
+		}
+	});
+});

--- a/packages/coding-agent/test/status-line-cwd-watch.test.ts
+++ b/packages/coding-agent/test/status-line-cwd-watch.test.ts
@@ -142,7 +142,10 @@ describe("StatusLineComponent cwd initialization", () => {
 			setShellPwd(shellDir);
 			const session = {
 				...makeSession(),
-				sessionManager: { getCwd: () => sessionDir },
+				sessionManager: {
+					getCwd: () => sessionDir,
+					getUsageStatistics: () => ({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }),
+				},
 			} as unknown as AgentSession;
 
 			const component = new StatusLineComponent(session);


### PR DESCRIPTION
## Problem

The statusline showed a stale working directory in two scenarios (issue #118, reopened):

1. **Startup** — `StatusLineComponent.#cwd` was field-initialized from `getShellPwd()`, a module-level variable set once at `process.cwd()` import time. When `--cwd` flag, session resume, or `maybeAutoChdir` set a different session cwd, `shellPwd` was never updated — the statusline started with the wrong directory.

2. **`/move` command** — Called `setProjectDir()` and `statusLine.invalidate()`, but `invalidate()` only clears git caches. It never updates `#cwd`, and never calls `setShellPwd()`. The statusline remained stale until the next bash tool execution.

## Root Cause

Three cwd state variables (`projectDir`, `shellPwd`, `session.cwd`) diverged at startup and during `/move`. The statusline read the wrong one at init, and `/move` didn't sync the ones it should have.

## Fix

### 1. StatusLine constructor reads session.cwd

```diff
-#cwd: string = getShellPwd();
+#cwd: string;

 constructor(private readonly session: AgentSession) {
+    this.#cwd = session.sessionManager?.getCwd() ?? getShellPwd();
```

Falls back to `getShellPwd()` when `sessionManager` is unavailable (e.g., test doubles).

### 2. `/move` handler syncs all state

```diff
+setShellPwd(resolvedPath);
+this.ctx.statusLine.setCwd(resolvedPath);
-this.ctx.statusLine.invalidate();
```

`setCwd()` internally calls `#invalidateGitCaches()` + `#setupGitWatcher()`, so no functionality is lost from removing `invalidate()`.

## Tests

| File | Test | Verifies |
|---|---|---|
| `status-line-cwd-watch.test.ts` | "initializes #cwd from session.sessionManager.getCwd()" | Session cwd takes priority over stale shellPwd at construction |
| `status-line-cwd-watch.test.ts` | "falls back to getShellPwd() when sessionManager is undefined" | Graceful degradation |
| `regression-guard.test.ts` | Updated init guard + new /move sync guard | Source-level assertion that both `setShellPwd` and `setCwd` are called |

All 73 regression-guard tests pass. Runtime cwd-watch tests require native addon build (CI covers this).

Fixes #118