### PR TITLE
fix(tui): propagate gutter width to fallback tool renderer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 
-## [18.18.0] - 2026-04-25
+
+### Fixed
+
+- Fixed gutter width propagation in the fallback tool renderer: `#formatToolExecution()` now receives the actual available width at render-time and uses it for line truncation instead of a hardcoded 80-column limit. On narrow terminals (<82 cols) this prevents content wider than the gutter-adjusted viewport; on wide terminals it allows longer output lines. ([#117](https://github.com/f5xc-salesdemos/xcsh/issues/117))
+
 
 ### Changed
 

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -110,6 +110,8 @@ export class ToolExecutionComponent extends Container {
 	#spinnerInterval?: NodeJS.Timeout;
 	// Track if args are still being streamed (for edit/write spinner)
 	#argsComplete = false;
+	// True when this component uses #contentText (fallback path, no custom renderer)
+	#usesFallbackText = false;
 	#renderState: {
 		spinnerFrame?: number;
 		expanded: boolean;
@@ -149,6 +151,7 @@ export class ToolExecutionComponent extends Container {
 		if (hasCustomRenderer || hasRenderer) {
 			this.addChild(this.#contentBox);
 		} else {
+			this.#usesFallbackText = true;
 			this.addChild(this.#contentText);
 		}
 
@@ -359,6 +362,15 @@ export class ToolExecutionComponent extends Container {
 		this.#updateDisplay();
 	}
 
+	override render(width: number): string[] {
+		// For fallback tools (no custom renderer), regenerate text with the
+		// correct width at render-time instead of using the hardcoded default.
+		if (this.#usesFallbackText) {
+			this.#contentText.setText(this.#formatToolExecution(width));
+		}
+		return super.render(width);
+	}
+
 	#updateDisplay(): void {
 		// Set background based on state
 		const bgFn = this.#isPartial
@@ -563,9 +575,9 @@ export class ToolExecutionComponent extends Container {
 				}
 			}
 		} else {
-			// Other built-in tools: use Text directly with caching
+			// Other built-in tools: bg is set eagerly; text content is generated
+			// lazily in render(width) so truncation respects the actual available width.
 			this.#contentText.setCustomBgFn(bgFn);
-			this.#contentText.setText(this.#formatToolExecution());
 		}
 
 		// Handle images (same for both custom and built-in)
@@ -682,16 +694,17 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	/**
-	 * Format a generic tool execution (fallback for tools without custom renderers)
+	 * Format a generic tool execution (fallback for tools without custom renderers).
+	 * @param width Available content width (from GutterBlock), used for truncation.
 	 */
-	#formatToolExecution(): string {
+	#formatToolExecution(width = 80): string {
 		const lines: string[] = [];
 		const icon = this.#isPartial ? "pending" : undefined;
 		lines.push(renderStatusLine({ icon, title: this.#toolLabel }, theme));
 
 		const argsObject = this.#args && typeof this.#args === "object" ? (this.#args as Record<string, unknown>) : null;
 		if (!this.#expanded && argsObject && Object.keys(argsObject).length > 0) {
-			const preview = formatArgsInline(argsObject, 70);
+			const preview = formatArgsInline(argsObject, Math.max(20, width - 10));
 			if (preview) {
 				lines.push(` ${theme.fg("dim", theme.tree.last)} ${theme.fg("dim", preview)}`);
 			}
@@ -753,7 +766,7 @@ export class ToolExecutionComponent extends Container {
 		const displayLines = outputLines.slice(0, maxOutputLines);
 
 		for (const line of displayLines) {
-			lines.push(theme.fg("toolOutput", truncateToWidth(replaceTabs(line), 80)));
+			lines.push(theme.fg("toolOutput", truncateToWidth(replaceTabs(line), width)));
 		}
 
 		if (outputLines.length > maxOutputLines) {


### PR DESCRIPTION
## Problem

The fallback renderer for tools without custom renderers (`#formatToolExecution`) was pre-formatting output with `truncateToWidth(line, 80)` — a hardcoded limit evaluated at update-time, before the render width is known.

On 80-col terminals the gutter subtracts 2 cols, leaving 78 available. The 80-col truncation produced lines 2 chars wider than the available space. On wider terminals the hardcoded cap wasted usable columns. The inline args preview had the same problem with a hardcoded limit of 70.

## Root cause

`#formatToolExecution()` was called from `#updateDisplay()` which runs eagerly on every state change (args update, result update, expand/collapse). At that point, the render width is not yet known — it only arrives when the TUI calls `component.render(width)` later.

## Fix

- Add `#usesFallbackText` flag (set when no custom renderer exists and `#contentText` is the active child)
- Override `render(width)` to call `#contentText.setText(#formatToolExecution(width))` just before `super.render(width)`, so truncation runs with the actual gutter-adjusted width
- Remove the premature `setText` call from `#updateDisplay()` for the fallback path — bg is still set eagerly; text content waits for render-time width
- `#formatToolExecution(width)` replaces hardcoded `80` on line truncation and hardcoded `70` on inline args preview with the actual available width

## Scope

This fixes the fallback path only. Tools with custom renderers (bash, python, edit, grep, etc.) have their own `render(width)` methods that already receive the correct width from the Container tree. Adding `width` to `RenderResultOptions` for the benefit of pre-formatting decisions in those renderers is a separate, larger effort.

## Testing

- All 80 gutter-block and boxed-gutter-integration tests pass
- Full `bun check:ts` passes

Fixes #117