### PR TITLE
fix(auth): prevent literal env var names from leaking as API keys in resolveConfigValue

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 
 - Fixed gutter width propagation in the fallback tool renderer: `#formatToolExecution()` now receives the actual available width at render-time and uses it for line truncation instead of a hardcoded 80-column limit. On narrow terminals (<82 cols) this prevents content wider than the gutter-adjusted viewport; on wide terminals it allows longer output lines. ([#117](https://github.com/f5xc-salesdemos/xcsh/issues/117))
+- Fixed `resolveConfigValue` returning literal env var names (e.g. `"LITELLM_API_KEY"`) as API keys when the env var is unset, causing 401 errors on first launch. The resolver now rejects unresolved `ALL_CAPS_WITH_UNDERSCORES` patterns, matching the existing guard in `resolveYamlApiKeyConfig`. ([#241](https://github.com/f5xc-salesdemos/xcsh/issues/241))
 
 
 ### Changed

--- a/packages/coding-agent/src/config/resolve-config-value.ts
+++ b/packages/coding-agent/src/config/resolve-config-value.ts
@@ -6,6 +6,14 @@
 
 import { executeShell } from "@f5xc-salesdemos/pi-natives";
 
+/**
+ * Matches strings that look like environment variable names: ALL_CAPS_WITH_UNDERSCORES.
+ * Used to prevent sending literal env var names (e.g. "LITELLM_API_KEY") as Bearer
+ * tokens when the env var is unset. Same pattern as resolveYamlApiKeyConfig in
+ * model-registry.ts.
+ */
+const ENV_VAR_NAME_RE = /^[A-Z][A-Z0-9]*(?:_[A-Z][A-Z0-9]*)+$/;
+
 /** Cache for successful shell command results (persists for process lifetime). */
 const commandResultCache = new Map<string, string>();
 
@@ -15,14 +23,22 @@ const commandInFlight = new Map<string, Promise<string | undefined>>();
 /**
  * Resolve a config value (API key, header value, etc.) to an actual value.
  * - If starts with "!", executes the rest as a shell command and uses stdout (cached)
- * - Otherwise checks environment variable first, then treats as literal (not cached)
+ * - Otherwise checks environment variable first
+ * - If the env var is unset and the config string looks like an env var name
+ *   (ALL_CAPS_WITH_UNDERSCORES), returns undefined to prevent leaking literal
+ *   names as Bearer tokens (see issue #241)
+ * - Otherwise treats the config string as a literal value
  */
 export async function resolveConfigValue(config: string): Promise<string | undefined> {
 	if (config.startsWith("!")) {
 		return await executeCommand(config);
 	}
 	const envValue = process.env[config];
-	return envValue || config;
+	if (envValue) return envValue;
+	// Reject unresolved env var names to prevent sending literal names as API keys.
+	// Actual literal API keys (sk-ant-..., UUIDs, etc.) won't match this pattern.
+	if (ENV_VAR_NAME_RE.test(config)) return undefined;
+	return config;
 }
 
 async function executeCommand(commandConfig: string): Promise<string | undefined> {

--- a/packages/coding-agent/test/config/resolve-config-value.test.ts
+++ b/packages/coding-agent/test/config/resolve-config-value.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { clearConfigValueCache, resolveConfigValue, resolveHeaders } from "../../src/config/resolve-config-value";
+
+describe("resolveConfigValue", () => {
+	afterEach(() => {
+		clearConfigValueCache();
+		// Clean up any env vars we set during tests
+		delete process.env.__TEST_RESOLVE_VALUE;
+	});
+
+	it("returns env var value when the env var is set", async () => {
+		process.env.__TEST_RESOLVE_VALUE = "secret-key-123";
+		const result = await resolveConfigValue("__TEST_RESOLVE_VALUE");
+		expect(result).toBe("secret-key-123");
+	});
+
+	it("returns undefined for unresolved env var names instead of the literal name", async () => {
+		// This is the core regression guard for issue #241:
+		// LITELLM_API_KEY with no env var must NOT return "LITELLM_API_KEY" as a Bearer token.
+		delete process.env.LITELLM_API_KEY;
+		const result = await resolveConfigValue("LITELLM_API_KEY");
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined for other standard env var name patterns", async () => {
+		delete process.env.OPENAI_API_KEY;
+		delete process.env.GH_TOKEN;
+		delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+
+		expect(await resolveConfigValue("OPENAI_API_KEY")).toBeUndefined();
+		expect(await resolveConfigValue("GH_TOKEN")).toBeUndefined();
+		expect(await resolveConfigValue("CLAUDE_CODE_OAUTH_TOKEN")).toBeUndefined();
+	});
+
+	it("returns a literal value that does not look like an env var name", async () => {
+		// Actual API keys (lowercase, special chars, etc.) are treated as literals
+		expect(await resolveConfigValue("sk-ant-abc123def456")).toBe("sk-ant-abc123def456");
+		expect(await resolveConfigValue("my-custom-key")).toBe("my-custom-key");
+		expect(await resolveConfigValue("f5_proxy_key_v2")).toBe("f5_proxy_key_v2"); // lowercase
+	});
+
+	it("returns undefined for a shell command that fails", async () => {
+		const result = await resolveConfigValue("!false");
+		expect(result).toBeUndefined();
+	});
+
+	it("resolves a shell command and caches the result", async () => {
+		const result = await resolveConfigValue("!echo test-value");
+		expect(result).toBe("test-value");
+
+		// Second call should use cached value (same result)
+		const cached = await resolveConfigValue("!echo test-value");
+		expect(cached).toBe("test-value");
+	});
+});
+
+describe("resolveHeaders", () => {
+	afterEach(() => {
+		clearConfigValueCache();
+		delete process.env.__TEST_HEADER_VALUE;
+	});
+
+	it("returns undefined for undefined input", async () => {
+		expect(await resolveHeaders(undefined)).toBeUndefined();
+	});
+
+	it("resolves header values through resolveConfigValue", async () => {
+		process.env.__TEST_HEADER_VALUE = "Bearer my-token";
+		const result = await resolveHeaders({ Authorization: "__TEST_HEADER_VALUE" });
+		expect(result).toEqual({ Authorization: "Bearer my-token" });
+	});
+
+	it("omits headers with unresolved env var names", async () => {
+		delete process.env.UNSET_TOKEN;
+		const result = await resolveHeaders({
+			"x-custom": "literal-value",
+			Authorization: "UNSET_TOKEN",
+		});
+		// UNSET_TOKEN looks like an env var name, should be omitted
+		expect(result).toEqual({ "x-custom": "literal-value" });
+	});
+});


### PR DESCRIPTION
## Problem

When `models.yml` stores `apiKey: LITELLM_API_KEY` and the env var is unset, `resolveConfigValue` fell back to returning the literal string `"LITELLM_API_KEY"`. This was sent as a Bearer token to the LiteLLM proxy, causing 401 errors on first launch.

## Root cause

`resolveConfigValue` (line 25) had `return envValue || config` — when the env var is unset, it returns the config string itself (the env var name) as the resolved value:

```typescript
const envValue = process.env[config];
return envValue || config;  // "LITELLM_API_KEY" sent as Bearer token
```

The model registry already had a guard for this pattern in `resolveYamlApiKeyConfig` (`ENV_VAR_NAME_RE` rejects `ALL_CAPS_WITH_UNDERSCORES` patterns), but the `configValueResolver` used by `AuthStorage` — which the title-generator and model discovery call through — did not have the same protection.

## Fix

Add the same `ENV_VAR_NAME_RE` guard to `resolveConfigValue`:

```typescript
const envValue = process.env[config];
if (envValue) return envValue;
if (ENV_VAR_NAME_RE.test(config)) return undefined;  // reject "LITELLM_API_KEY"
return config;  // pass through actual literals ("sk-ant-...", UUIDs)
```

Actual API keys (lowercase, special chars, UUIDs) don't match the `ALL_CAPS_WITH_UNDERSCORES` pattern and are unaffected.

## Testing

Added 9 regression tests in `test/config/resolve-config-value.test.ts`:
- Env var resolution (set → returns value)
- Literal env var name rejection (`LITELLM_API_KEY`, `OPENAI_API_KEY`, `GH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`)
- Literal passthrough (actual API keys like `sk-ant-abc123`)
- Shell command execution and caching
- Header resolution with env var name filtering

TDD: all 3 env var leak tests failed before the fix, pass after.

Fixes #241