### PR TITLE
feat(coding-agent): F5 XC platform integration foundation (specs 6.1-6.4)

### DIFF
--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -433,6 +433,10 @@
 			"types": "./src/secrets/*.ts",
 			"import": "./src/secrets/*.ts"
 		},
+		"./services/*": {
+			"types": "./src/services/*.ts",
+			"import": "./src/services/*.ts"
+		},
 		"./session/*": {
 			"types": "./src/session/*.ts",
 			"import": "./src/session/*.ts"

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -447,11 +447,16 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 				const { renderF5XCContextSegment } = require("../../../services/f5xc-context-segment");
 				const result = renderF5XCContextSegment();
 				if (!result.visible) return result;
-				return {
-					...result,
-					bg: theme.fgColorAsBg("statusLineContextF5xcBg"),
-					fg: theme.getFgAnsi("statusLineContextF5xcFg"),
-				};
+				let bg = theme.fgColorAsBg("statusLineContextF5xcBg");
+				let fg = theme.getFgAnsi("statusLineContextF5xcFg");
+				if (result.tokenHealth === "expiring") {
+					bg = theme.fgColorAsBg("statusLineGitDirtyBg");
+					fg = theme.getFgAnsi("statusLineGitDirtyFg");
+				} else if (result.tokenHealth === "expired") {
+					bg = theme.fgColorAsBg("statusLineGitConflictBg");
+					fg = theme.getFgAnsi("statusLineGitConflictFg");
+				}
+				return { ...result, bg, fg };
 			} catch {
 				return { content: "", visible: false };
 			}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1787,6 +1787,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			const authListener = (prev: string, current: string) => {
 				if (prev === current) return;
 				const isDegradation = current === "auth_error" || current === "offline";
+				if (!isDegradation && prev === "unknown") return;
 				const content = isDegradation
 					? `[Auth status: ${prev} → ${current}] F5 XC credentials may be stale. Run /context validate to check.`
 					: `[Auth status: ${current}] F5 XC credentials are valid again.`;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1785,7 +1785,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			service.onContextChange(listener);
 			session.addDisposeHook(() => service.offContextChange(listener));
 			const authListener = (prev: string, current: string) => {
-				statusLine?.invalidate();
 				if (prev === current) return;
 				const isDegradation = current === "auth_error" || current === "offline";
 				const content = isDegradation
@@ -1801,7 +1800,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			service.onAuthStatusChange(authListener);
 			session.addDisposeHook(() => service.offAuthStatusChange(authListener));
 			const tokenHealthListener = (_prev: string, current: string) => {
-				statusLine?.invalidate();
 				if (current === "expiring") {
 					void session.sendCustomMessage({
 						customType: "token_health_change",

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1784,6 +1784,22 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 			service.onContextChange(listener);
 			session.addDisposeHook(() => service.offContextChange(listener));
+			const authListener = (prev: string, current: string) => {
+				statusLine?.invalidate();
+				if (prev === current) return;
+				const isDegradation = current === "auth_error" || current === "offline";
+				const content = isDegradation
+					? `[Auth status: ${prev} → ${current}] F5 XC credentials may be stale. Run /context validate to check.`
+					: `[Auth status: ${current}] F5 XC credentials are valid again.`;
+				void session.sendCustomMessage({
+					customType: "auth_status_change",
+					content,
+					display: true,
+					attribution: "agent",
+				});
+			};
+			service.onAuthStatusChange(authListener);
+			session.addDisposeHook(() => service.offAuthStatusChange(authListener));
 		} catch {
 			// ContextService not initialized — skip listener registration entirely.
 			// Tests and SDK consumers that don't use contexts won't reach this branch.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1800,6 +1800,26 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			};
 			service.onAuthStatusChange(authListener);
 			session.addDisposeHook(() => service.offAuthStatusChange(authListener));
+			const tokenHealthListener = (_prev: string, current: string) => {
+				statusLine?.invalidate();
+				if (current === "expiring") {
+					void session.sendCustomMessage({
+						customType: "token_health_change",
+						content: "[Token expiring] F5 XC API token expires soon. Run /context create to rotate.",
+						display: true,
+						attribution: "agent",
+					});
+				} else if (current === "expired") {
+					void session.sendCustomMessage({
+						customType: "token_health_change",
+						content: "[Token expired] F5 XC API token has expired. Run /context create to replace it.",
+						display: true,
+						attribution: "agent",
+					});
+				}
+			};
+			service.onTokenHealthChange(tokenHealthListener);
+			session.addDisposeHook(() => service.offTokenHealthChange(tokenHealthListener));
 		} catch {
 			// ContextService not initialized — skip listener registration entirely.
 			// Tests and SDK consumers that don't use contexts won't reach this branch.

--- a/packages/coding-agent/src/services/f5xc-api-client.ts
+++ b/packages/coding-agent/src/services/f5xc-api-client.ts
@@ -152,7 +152,7 @@ export class F5XCApiClient {
 	}
 
 	#sleep(ms: number): Promise<void> {
-		return new Promise(resolve => setTimeout(resolve, ms));
+		return Bun.sleep(ms);
 	}
 
 	#parseItems<T>(body: unknown, extract: (item: unknown) => T | null): T[] {

--- a/packages/coding-agent/src/services/f5xc-api-client.ts
+++ b/packages/coding-agent/src/services/f5xc-api-client.ts
@@ -148,7 +148,7 @@ export class F5XCApiClient {
 		const base = this.#baseDelayMs * 2 ** attempt;
 		const capped = Math.min(base, this.#maxDelayMs);
 		const jitter = capped * Math.random() * 0.25;
-		return Math.round(capped + jitter);
+		return Math.round(Math.min(capped + jitter, this.#maxDelayMs));
 	}
 
 	#sleep(ms: number): Promise<void> {

--- a/packages/coding-agent/src/services/f5xc-api-client.ts
+++ b/packages/coding-agent/src/services/f5xc-api-client.ts
@@ -1,0 +1,57 @@
+// biome-ignore lint/correctness/noUnusedImports: used in Task 2 (fetchWithRetry logging)
+import { logger } from "@f5xc-salesdemos/pi-utils";
+
+export type ApiErrorKind = "auth" | "network" | "server";
+
+export class F5XCApiError extends Error {
+	constructor(
+		message: string,
+		readonly kind: ApiErrorKind,
+		readonly status?: number,
+	) {
+		super(message);
+		this.name = "F5XCApiError";
+	}
+}
+
+export interface F5XCNamespace {
+	name: string;
+}
+
+export interface F5XCNamespaceStatus {
+	name: string;
+	phase: string;
+}
+
+export interface F5XCObject {
+	name: string;
+	namespace: string;
+	kind: string;
+}
+
+export interface F5XCApiClientOptions {
+	apiUrl: string;
+	apiToken: string;
+	timeoutMs?: number;
+	maxRetries?: number;
+	baseDelayMs?: number;
+	maxDelayMs?: number;
+}
+
+export class F5XCApiClient {
+	#apiUrl: string;
+	#apiToken: string;
+	#timeoutMs: number;
+	#maxRetries: number;
+	#baseDelayMs: number;
+	#maxDelayMs: number;
+
+	constructor(opts: F5XCApiClientOptions) {
+		this.#apiUrl = opts.apiUrl.replace(/\/+$/, "");
+		this.#apiToken = opts.apiToken;
+		this.#timeoutMs = opts.timeoutMs ?? 10_000;
+		this.#maxRetries = opts.maxRetries ?? 3;
+		this.#baseDelayMs = opts.baseDelayMs ?? 500;
+		this.#maxDelayMs = opts.maxDelayMs ?? 10_000;
+	}
+}

--- a/packages/coding-agent/src/services/f5xc-api-client.ts
+++ b/packages/coding-agent/src/services/f5xc-api-client.ts
@@ -178,4 +178,39 @@ export class F5XCApiClient {
 			return { name: record.name };
 		});
 	}
+
+	async getNamespaceStatus(ns: string): Promise<F5XCNamespaceStatus> {
+		const response = await this.#fetchWithRetry(`/api/web/namespaces/${encodeURIComponent(ns)}/status`);
+		const body: unknown = await response.json();
+		if (typeof body !== "object" || body === null) {
+			throw new F5XCApiError("Invalid response for namespace status: expected object", "server");
+		}
+		const record = body as Record<string, unknown>;
+		if (typeof record.name !== "string" || typeof record.phase !== "string") {
+			throw new F5XCApiError(
+				"Invalid response for namespace status: missing required fields (name, phase)",
+				"server",
+			);
+		}
+		return { name: record.name, phase: record.phase };
+	}
+
+	async listObjects(ns: string, kind: string): Promise<F5XCObject[]> {
+		const response = await this.#fetchWithRetry(
+			`/api/web/namespaces/${encodeURIComponent(ns)}/${encodeURIComponent(kind)}`,
+		);
+		const body: unknown = await response.json();
+		return this.#parseItems(body, (item): F5XCObject | null => {
+			if (typeof item !== "object" || item === null) return null;
+			const record = item as Record<string, unknown>;
+			if (
+				typeof record.name !== "string" ||
+				typeof record.namespace !== "string" ||
+				typeof record.kind !== "string"
+			) {
+				return null;
+			}
+			return { name: record.name, namespace: record.namespace, kind: record.kind };
+		});
+	}
 }

--- a/packages/coding-agent/src/services/f5xc-api-client.ts
+++ b/packages/coding-agent/src/services/f5xc-api-client.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/correctness/noUnusedImports: used in Task 2 (fetchWithRetry logging)
 import { logger } from "@f5xc-salesdemos/pi-utils";
 
 export type ApiErrorKind = "auth" | "network" | "server";
@@ -53,5 +52,130 @@ export class F5XCApiClient {
 		this.#maxRetries = opts.maxRetries ?? 3;
 		this.#baseDelayMs = opts.baseDelayMs ?? 500;
 		this.#maxDelayMs = opts.maxDelayMs ?? 10_000;
+	}
+
+	#isRetryable(status: number): boolean {
+		return status >= 500 || status === 429 || status === 408;
+	}
+
+	async #fetchWithRetry(path: string): Promise<Response> {
+		const url = `${this.#apiUrl}${path}`;
+		const headers = {
+			Authorization: `APIToken ${this.#apiToken}`,
+			Accept: "application/json",
+		};
+		const maxAttempts = this.#maxRetries + 1;
+		let lastStatus: number | undefined;
+
+		for (let attempt = 0; attempt < maxAttempts; attempt++) {
+			let response: Response;
+			try {
+				const start = performance.now();
+				response = await fetch(url, {
+					method: "GET",
+					headers,
+					signal: AbortSignal.timeout(this.#timeoutMs),
+				});
+				const latencyMs = Math.round(performance.now() - start);
+				logger.debug("F5XC API response", { path, status: response.status, latencyMs });
+			} catch (err) {
+				if (attempt < this.#maxRetries) {
+					const delayMs = this.#backoffDelay(attempt);
+					logger.debug("F5XC API retry (network)", {
+						path,
+						attempt: attempt + 1,
+						maxRetries: this.#maxRetries,
+						delayMs,
+					});
+					await this.#sleep(delayMs);
+					continue;
+				}
+				throw new F5XCApiError(
+					`Network error requesting ${path}: ${err instanceof Error ? err.message : String(err)}`,
+					"network",
+				);
+			}
+
+			if (response.status === 401 || response.status === 403) {
+				throw new F5XCApiError(
+					`Authentication failed for ${path} (HTTP ${response.status})`,
+					"auth",
+					response.status,
+				);
+			}
+
+			if (response.ok) {
+				return response;
+			}
+
+			lastStatus = response.status;
+
+			if (this.#isRetryable(response.status)) {
+				if (attempt < this.#maxRetries) {
+					let delayMs: number;
+					if (response.status === 429) {
+						const retryAfter = response.headers.get("Retry-After");
+						const retrySeconds = retryAfter ? Number(retryAfter) : NaN;
+						delayMs = Number.isFinite(retrySeconds)
+							? Math.min(retrySeconds * 1000, this.#maxDelayMs)
+							: this.#backoffDelay(attempt);
+					} else {
+						delayMs = this.#backoffDelay(attempt);
+					}
+					logger.debug("F5XC API retry", {
+						path,
+						attempt: attempt + 1,
+						maxRetries: this.#maxRetries,
+						status: response.status,
+						delayMs,
+					});
+					await this.#sleep(delayMs);
+					continue;
+				}
+			}
+
+			throw new F5XCApiError(`Request failed for ${path} (HTTP ${response.status})`, "server", response.status);
+		}
+
+		throw new F5XCApiError(
+			`Request failed for ${path} after ${maxAttempts} attempts (HTTP ${lastStatus})`,
+			"server",
+			lastStatus,
+		);
+	}
+
+	#backoffDelay(attempt: number): number {
+		const base = this.#baseDelayMs * 2 ** attempt;
+		const capped = Math.min(base, this.#maxDelayMs);
+		const jitter = capped * Math.random() * 0.25;
+		return Math.round(capped + jitter);
+	}
+
+	#sleep(ms: number): Promise<void> {
+		return new Promise(resolve => setTimeout(resolve, ms));
+	}
+
+	#parseItems<T>(body: unknown, extract: (item: unknown) => T | null): T[] {
+		if (typeof body !== "object" || body === null) return [];
+		const envelope = body as Record<string, unknown>;
+		const items = envelope.items;
+		if (!Array.isArray(items)) return [];
+		const results: T[] = [];
+		for (const item of items) {
+			const extracted = extract(item);
+			if (extracted !== null) results.push(extracted);
+		}
+		return results;
+	}
+
+	async listNamespaces(): Promise<F5XCNamespace[]> {
+		const response = await this.#fetchWithRetry("/api/web/namespaces");
+		const body: unknown = await response.json();
+		return this.#parseItems(body, (item): F5XCNamespace | null => {
+			if (typeof item !== "object" || item === null) return null;
+			const record = item as Record<string, unknown>;
+			if (typeof record.name !== "string") return null;
+			return { name: record.name };
+		});
 	}
 }

--- a/packages/coding-agent/src/services/f5xc-context-command.ts
+++ b/packages/coding-agent/src/services/f5xc-context-command.ts
@@ -15,6 +15,7 @@ import {
 	formatAuthIndicator,
 	formatExpiration,
 	formatRelativeTime,
+	formatRotation,
 	renderF5XCTable,
 	type TableRow,
 } from "./f5xc-table";
@@ -222,7 +223,10 @@ async function handleShow(ctx: CommandContext, service: ContextService, name?: s
 		metaRows.push({ key: "Last Rotated", value: formatRelativeTime(context.metadata.lastRotatedAt) });
 	}
 	if (context.metadata?.rotateAfterDays) {
-		metaRows.push({ key: "Rotation", value: `every ${context.metadata.rotateAfterDays} days` });
+		metaRows.push({
+			key: "Rotation",
+			value: formatRotation(context.metadata.rotateAfterDays, context.metadata?.lastRotatedAt),
+		});
 	}
 
 	const dividers: Array<{ before: number; label: string }> = [{ before: envDividerIndex, label: "Environment" }];

--- a/packages/coding-agent/src/services/f5xc-context-display.ts
+++ b/packages/coding-agent/src/services/f5xc-context-display.ts
@@ -1,15 +1,9 @@
 import type { ContextStatus } from "./f5xc-context";
 
-/**
- * Compose the canonical `<tenant|name|env>:<namespace|default>` label used by
- * the status-line segment and any future single-line context display.
- *
- * Fallback chain for the left side: tenant → context name → "env"
- * (the final fallback reflects env-backed sessions with no context loaded).
- * Right side defaults to `"default"` when no namespace is set.
- */
 export function formatContextLabel(status: ContextStatus): string {
 	const left = status.activeContextTenant ?? status.activeContextName ?? "env";
 	const right = status.activeContextNamespace ?? "default";
-	return `${left}:${right}`;
+	const base = `${left}:${right}`;
+	if (status.tokenHealth === "expiring" || status.tokenHealth === "expired") return `${base} ⚠`;
+	return base;
 }

--- a/packages/coding-agent/src/services/f5xc-context-segment.ts
+++ b/packages/coding-agent/src/services/f5xc-context-segment.ts
@@ -1,9 +1,10 @@
-import { ContextService } from "./f5xc-context";
+import { ContextService, type TokenHealth } from "./f5xc-context";
 import { formatContextLabel } from "./f5xc-context-display";
 
 export interface RenderedSegment {
 	content: string;
 	visible: boolean;
+	tokenHealth?: TokenHealth;
 }
 
 export function renderF5XCContextSegment(): RenderedSegment {
@@ -15,9 +16,8 @@ export function renderF5XCContextSegment(): RenderedSegment {
 			return { content: "", visible: false };
 		}
 
-		return { content: formatContextLabel(status), visible: true };
+		return { content: formatContextLabel(status), visible: true, tokenHealth: status.tokenHealth };
 	} catch {
-		// ContextService not initialized — silently hide segment
 		return { content: "", visible: false };
 	}
 }

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -134,6 +134,7 @@ export class ContextService {
 	#lastAuthLatencyMs: number | undefined;
 	#lastAuthCheckedAt: number | undefined;
 	#apiClient: F5XCApiClient | null = null;
+	#revalidationTimer: NodeJS.Timeout | null = null;
 
 	private constructor(configDir: string) {
 		this.#configDir = configDir;
@@ -147,10 +148,39 @@ export class ContextService {
 		if (!hasEnvOverride()) {
 			this.#populateNamespaceCache();
 		}
+		this.startRevalidation();
 	}
 
 	getApiClient(): F5XCApiClient | null {
 		return this.#apiClient;
+	}
+
+	startRevalidation(intervalMs = 300_000): void {
+		this.stopRevalidation();
+		const tick = async () => {
+			const previousStatus = this.#authStatus;
+			await this.validateToken();
+			if (this.#authStatus !== previousStatus) {
+				for (const cb of ContextService.#onAuthStatusChangeListeners) {
+					try {
+						cb(previousStatus, this.#authStatus);
+					} catch {}
+				}
+			}
+			if (this.#revalidationTimer !== null) {
+				this.#revalidationTimer = setTimeout(tick, intervalMs);
+				this.#revalidationTimer.unref?.();
+			}
+		};
+		this.#revalidationTimer = setTimeout(tick, intervalMs);
+		this.#revalidationTimer.unref?.();
+	}
+
+	stopRevalidation(): void {
+		if (this.#revalidationTimer) {
+			clearTimeout(this.#revalidationTimer);
+			this.#revalidationTimer = null;
+		}
 	}
 
 	#populateNamespaceCache(): void {
@@ -230,6 +260,7 @@ export class ContextService {
 	static _resetForTest(): void {
 		if (ContextService.#instance) {
 			ContextService.#instance.#apiClient = null;
+			ContextService.#instance.stopRevalidation();
 		}
 		ContextService.#instance = null;
 		// Clear listeners to prevent cross-test contamination. Each createAgentSession() call

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -814,56 +814,6 @@ export class ContextService {
 			}
 			if (response.ok) {
 				if (!adHoc) this.#authStatus = "connected";
-				// Populate the namespace cache only when:
-				//   - the EFFECTIVE credentials (after env-override resolution) match the
-				//     active context's stored credentials, AND
-				//   - the session is NOT mixed-source (no F5XC_API_TOKEN / F5XC_NAMESPACE
-				//     env override). In a mixed session, the activate → handleShow path
-				//     passes the context's own token as options, so effective matches
-				//     active even though the user's actual operational credentials are
-				//     the env override. Suppressing the cache in that case prevents the
-				//     namespace dropdown from showing a list from the context's account
-				//     when later API ops would run under the override's account.
-				//
-				// Cases handled correctly after these combined guards:
-				//   - startup and `/context activate → handleShow` (no env override): populate
-				//   - `/context show <other>` (mismatched explicit creds): skip via effective
-				//   - env-backed session (no active context): skip via active !== null
-				//   - mixed-source / `F5XC_API_TOKEN` override: skip via !hasEnvOverride
-				const active = this.#activeContext;
-				const isForActiveContext =
-					!hasEnvOverride() &&
-					active !== null &&
-					effectiveUrl === active.apiUrl &&
-					effectiveToken === active.apiToken;
-				if (isForActiveContext) {
-					// Fire-and-forget: body parse runs in the background so the auth result
-					// returns on headers. Large namespace lists or slow proxies cannot stall
-					// /context status, /context show, or startup validation on this path.
-					// The captured epoch guards against stale writes: if `activate()` runs
-					// while the body is still parsing, the epoch advances and this callback
-					// discards its result.
-					const epochAtFetch = this.#activationEpoch;
-					response
-						.json()
-						.then(body => {
-							if (this.#activationEpoch !== epochAtFetch) return;
-							const items = (body as { items?: unknown })?.items;
-							if (Array.isArray(items)) {
-								const names = (items as unknown[])
-									.map(i =>
-										typeof i === "object" && i !== null && "name" in i
-											? (i as { name: unknown }).name
-											: undefined,
-									)
-									.filter((n): n is string => typeof n === "string");
-								this.#namespacesCache = [...names].sort((a, b) => a.localeCompare(b));
-							}
-						})
-						.catch(() => {
-							// Body not JSON or parse failed — leave cache untouched.
-						});
-				}
 				return { status: "connected", latencyMs };
 			}
 			if (response.status === 401 || response.status === 403) {

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -182,6 +182,9 @@ export class ContextService {
 					} catch {}
 				}
 			}
+			if (this.#authStatus === "connected" && this.#namespacesCache.length === 0 && !hasEnvOverride()) {
+				this.#populateNamespaceCache();
+			}
 			const prevHealth = this.#lastTokenHealth;
 			const currentHealth = this.#computeTokenHealth();
 			if (currentHealth !== prevHealth) {

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -96,6 +96,7 @@ export class ContextError extends Error {
 export class ContextService {
 	static #instance: ContextService | null = null;
 	static #onContextChangeListeners: Array<(context: F5XCContext) => void> = [];
+	static #onAuthStatusChangeListeners: Array<(prev: AuthStatus, current: AuthStatus) => void> = [];
 
 	/** Register a callback invoked after a context is activated or its settings applied. */
 	static onContextChange(cb: (context: F5XCContext) => void): void {
@@ -109,6 +110,15 @@ export class ContextService {
 	static offContextChange(cb: (context: F5XCContext) => void): void {
 		const idx = ContextService.#onContextChangeListeners.indexOf(cb);
 		if (idx >= 0) ContextService.#onContextChangeListeners.splice(idx, 1);
+	}
+
+	static onAuthStatusChange(cb: (prev: AuthStatus, current: AuthStatus) => void): void {
+		ContextService.#onAuthStatusChangeListeners.push(cb);
+	}
+
+	static offAuthStatusChange(cb: (prev: AuthStatus, current: AuthStatus) => void): void {
+		const idx = ContextService.#onAuthStatusChangeListeners.indexOf(cb);
+		if (idx >= 0) ContextService.#onAuthStatusChangeListeners.splice(idx, 1);
 	}
 
 	#configDir: string;
@@ -226,6 +236,7 @@ export class ContextService {
 		// registers a listener closed over that session's sessionManager; without this reset,
 		// listeners from a disposed session persist into the next test and fire on activate().
 		ContextService.#onContextChangeListeners = [];
+		ContextService.#onAuthStatusChangeListeners = [];
 	}
 
 	get contextsDir(): string {

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -100,6 +100,7 @@ export class ContextService {
 	static #instance: ContextService | null = null;
 	static #onContextChangeListeners: Array<(context: F5XCContext) => void> = [];
 	static #onAuthStatusChangeListeners: Array<(prev: AuthStatus, current: AuthStatus) => void> = [];
+	static #onTokenHealthChangeListeners: Array<(prev: TokenHealth, current: TokenHealth) => void> = [];
 
 	/** Register a callback invoked after a context is activated or its settings applied. */
 	static onContextChange(cb: (context: F5XCContext) => void): void {
@@ -122,6 +123,15 @@ export class ContextService {
 	static offAuthStatusChange(cb: (prev: AuthStatus, current: AuthStatus) => void): void {
 		const idx = ContextService.#onAuthStatusChangeListeners.indexOf(cb);
 		if (idx >= 0) ContextService.#onAuthStatusChangeListeners.splice(idx, 1);
+	}
+
+	static onTokenHealthChange(cb: (prev: TokenHealth, current: TokenHealth) => void): void {
+		ContextService.#onTokenHealthChangeListeners.push(cb);
+	}
+
+	static offTokenHealthChange(cb: (prev: TokenHealth, current: TokenHealth) => void): void {
+		const idx = ContextService.#onTokenHealthChangeListeners.indexOf(cb);
+		if (idx >= 0) ContextService.#onTokenHealthChangeListeners.splice(idx, 1);
 	}
 
 	#configDir: string;
@@ -153,6 +163,7 @@ export class ContextService {
 			this.#populateNamespaceCache();
 		}
 		this.startRevalidation();
+		this.#lastTokenHealth = "ok";
 	}
 
 	getApiClient(): F5XCApiClient | null {
@@ -168,6 +179,16 @@ export class ContextService {
 				for (const cb of ContextService.#onAuthStatusChangeListeners) {
 					try {
 						cb(previousStatus, this.#authStatus);
+					} catch {}
+				}
+			}
+			const prevHealth = this.#lastTokenHealth;
+			const currentHealth = this.#computeTokenHealth();
+			if (currentHealth !== prevHealth) {
+				this.#lastTokenHealth = currentHealth;
+				for (const cb of ContextService.#onTokenHealthChangeListeners) {
+					try {
+						cb(prevHealth, currentHealth);
 					} catch {}
 				}
 			}
@@ -273,6 +294,7 @@ export class ContextService {
 	static _resetForTest(): void {
 		if (ContextService.#instance) {
 			ContextService.#instance.#apiClient = null;
+			ContextService.#instance.#lastTokenHealth = "ok";
 			ContextService.#instance.stopRevalidation();
 		}
 		ContextService.#instance = null;
@@ -281,6 +303,7 @@ export class ContextService {
 		// listeners from a disposed session persist into the next test and fire on activate().
 		ContextService.#onContextChangeListeners = [];
 		ContextService.#onAuthStatusChangeListeners = [];
+		ContextService.#onTokenHealthChangeListeners = [];
 	}
 
 	get contextsDir(): string {

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -52,6 +52,8 @@ export interface F5XCContext {
 
 export type AuthStatus = "connected" | "auth_error" | "offline" | "unknown";
 
+export type TokenHealth = "ok" | "expiring" | "expired";
+
 export interface ContextStatus {
 	activeContextName: string | null;
 	activeContextUrl: string | null;
@@ -64,6 +66,7 @@ export interface ContextStatus {
 	authLatencyMs?: number;
 	/** Epoch ms of the most recent validateToken() call. Absent if validateToken has not run. */
 	authCheckedAt?: number;
+	tokenHealth: TokenHealth;
 }
 
 /**
@@ -135,6 +138,7 @@ export class ContextService {
 	#lastAuthCheckedAt: number | undefined;
 	#apiClient: F5XCApiClient | null = null;
 	#revalidationTimer: NodeJS.Timeout | null = null;
+	#lastTokenHealth: TokenHealth = "ok";
 
 	private constructor(configDir: string) {
 		this.#configDir = configDir;
@@ -181,6 +185,15 @@ export class ContextService {
 			clearTimeout(this.#revalidationTimer);
 			this.#revalidationTimer = null;
 		}
+	}
+
+	#computeTokenHealth(): TokenHealth {
+		const expiresAt = this.#activeContext?.metadata?.expiresAt;
+		if (!expiresAt) return "ok";
+		const diffMs = new Date(expiresAt).getTime() - Date.now();
+		if (diffMs <= 0) return "expired";
+		if (diffMs <= 7 * 86_400_000) return "expiring";
+		return "ok";
 	}
 
 	#populateNamespaceCache(): void {
@@ -921,6 +934,7 @@ export class ContextService {
 			isConfigured: this.#credentialSource !== "none",
 			authLatencyMs: this.#lastAuthLatencyMs,
 			authCheckedAt: this.#lastAuthCheckedAt,
+			tokenHealth: this.#computeTokenHealth(),
 		};
 	}
 

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -66,7 +66,7 @@ export interface ContextStatus {
 	authLatencyMs?: number;
 	/** Epoch ms of the most recent validateToken() call. Absent if validateToken has not run. */
 	authCheckedAt?: number;
-	tokenHealth: TokenHealth;
+	tokenHealth?: TokenHealth;
 }
 
 /**

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -134,10 +134,28 @@ export class ContextService {
 			apiUrl: context.apiUrl,
 			apiToken: process.env[F5XC_API_TOKEN] ?? context.apiToken,
 		});
+		if (!hasEnvOverride()) {
+			this.#populateNamespaceCache();
+		}
 	}
 
 	getApiClient(): F5XCApiClient | null {
 		return this.#apiClient;
+	}
+
+	#populateNamespaceCache(): void {
+		const epochAtFetch = this.#activationEpoch;
+		const client = this.#apiClient;
+		if (!client) return;
+		client
+			.listNamespaces()
+			.then(namespaces => {
+				if (this.#activationEpoch !== epochAtFetch) return;
+				this.#namespacesCache = namespaces.map(n => n.name).sort((a, b) => a.localeCompare(b));
+			})
+			.catch(err => {
+				logger.debug("F5XC namespace cache population failed", { error: String(err) });
+			});
 	}
 
 	static init(configDir: string): ContextService {

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { getF5XCConfigDir, logger } from "@f5xc-salesdemos/pi-utils";
 import { Settings } from "../config/settings";
 import { SECRET_ENV_PATTERNS } from "../secrets/index";
+import { F5XCApiClient } from "./f5xc-api-client";
 import {
 	deriveTenantFromUrl,
 	F5XC_API_TOKEN,
@@ -122,9 +123,21 @@ export class ContextService {
 	#activationEpoch = 0;
 	#lastAuthLatencyMs: number | undefined;
 	#lastAuthCheckedAt: number | undefined;
+	#apiClient: F5XCApiClient | null = null;
 
 	private constructor(configDir: string) {
 		this.#configDir = configDir;
+	}
+
+	#refreshApiClient(context: F5XCContext): void {
+		this.#apiClient = new F5XCApiClient({
+			apiUrl: context.apiUrl,
+			apiToken: process.env[F5XC_API_TOKEN] ?? context.apiToken,
+		});
+	}
+
+	getApiClient(): F5XCApiClient | null {
+		return this.#apiClient;
 	}
 
 	static init(configDir: string): ContextService {
@@ -187,6 +200,9 @@ export class ContextService {
 	}
 
 	static _resetForTest(): void {
+		if (ContextService.#instance) {
+			ContextService.#instance.#apiClient = null;
+		}
 		ContextService.#instance = null;
 		// Clear listeners to prevent cross-test contamination. Each createAgentSession() call
 		// registers a listener closed over that session's sessionManager; without this reset,
@@ -265,6 +281,7 @@ export class ContextService {
 		this.#applyToSettings(context);
 		// Detect mixed source: context loaded but some fields come from process.env
 		this.#credentialSource = hasEnvOverride() ? "mixed" : "context";
+		this.#refreshApiClient(context);
 		return context;
 	}
 
@@ -304,6 +321,7 @@ export class ContextService {
 		this.#authStatus = "unknown";
 		this.#lastAuthLatencyMs = undefined;
 		this.#lastAuthCheckedAt = undefined;
+		this.#refreshApiClient(context);
 
 		return context;
 	}

--- a/packages/coding-agent/src/services/f5xc-table.ts
+++ b/packages/coding-agent/src/services/f5xc-table.ts
@@ -71,6 +71,23 @@ export function formatExpiration(isoDate: string, now?: Date): string {
 	return dateStr;
 }
 
+export function formatRotation(rotateAfterDays: number, lastRotatedAt?: string, now?: Date): string {
+	const base = `every ${rotateAfterDays} days`;
+	if (!lastRotatedAt) return base;
+	const rotatedMs = new Date(lastRotatedAt).getTime();
+	const nowMs = (now ?? new Date()).getTime();
+	const thresholdMs = rotatedMs + rotateAfterDays * 86_400_000;
+	const daysOverdue = Math.floor((nowMs - thresholdMs) / 86_400_000);
+	if (daysOverdue > 0) {
+		return `${base}  ${formatStatusIcon("warning")} overdue by ${daysOverdue} day${daysOverdue !== 1 ? "s" : ""}`;
+	}
+	const daysUntil = Math.ceil((thresholdMs - nowMs) / 86_400_000);
+	if (daysUntil <= 7) {
+		return `${base}  ${formatStatusIcon("warning")} rotation due in ${daysUntil} day${daysUntil !== 1 ? "s" : ""}`;
+	}
+	return base;
+}
+
 export interface TableRow {
 	key: string;
 	value: string;

--- a/packages/coding-agent/src/services/f5xc-table.ts
+++ b/packages/coding-agent/src/services/f5xc-table.ts
@@ -77,9 +77,10 @@ export function formatRotation(rotateAfterDays: number, lastRotatedAt?: string, 
 	const rotatedMs = new Date(lastRotatedAt).getTime();
 	const nowMs = (now ?? new Date()).getTime();
 	const thresholdMs = rotatedMs + rotateAfterDays * 86_400_000;
-	const daysOverdue = Math.floor((nowMs - thresholdMs) / 86_400_000);
-	if (daysOverdue > 0) {
-		return `${base}  ${formatStatusIcon("warning")} overdue by ${daysOverdue} day${daysOverdue !== 1 ? "s" : ""}`;
+	if (nowMs >= thresholdMs) {
+		const daysOverdue = Math.floor((nowMs - thresholdMs) / 86_400_000);
+		const label = daysOverdue === 0 ? "overdue" : `overdue by ${daysOverdue} day${daysOverdue !== 1 ? "s" : ""}`;
+		return `${base}  ${formatStatusIcon("warning")} ${label}`;
 	}
 	const daysUntil = Math.ceil((thresholdMs - nowMs) / 86_400_000);
 	if (daysUntil <= 7) {

--- a/packages/coding-agent/test/f5xc-api-client-integration.test.ts
+++ b/packages/coding-agent/test/f5xc-api-client-integration.test.ts
@@ -132,6 +132,35 @@ describe("ContextService API client integration", () => {
 		}
 	});
 
+	it("uses env-override token on activate", async () => {
+		writeContext(f5xcContextsDir, INTEGRATION_TEST_CONTEXT);
+		writeContext(f5xcContextsDir, INTEGRATION_TEST_CONTEXT_STAGING);
+		writeActiveContext(f5xcConfigDir, INTEGRATION_TEST_CONTEXT.name);
+
+		process.env.F5XC_API_TOKEN = "env-override-token";
+
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+		await service.activate("staging");
+
+		let capturedAuthHeader = "";
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+			const headers = init?.headers as Record<string, string> | undefined;
+			capturedAuthHeader = headers?.Authorization ?? "";
+			return new Response(JSON.stringify({ items: [] }), { status: 200 });
+		}) as typeof globalThis.fetch;
+
+		try {
+			const client = service.getApiClient();
+			expect(client).not.toBeNull();
+			await client!.listNamespaces();
+			expect(capturedAuthHeader).toBe("APIToken env-override-token");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
 	it("_resetForTest clears the API client", async () => {
 		writeContext(f5xcContextsDir, INTEGRATION_TEST_CONTEXT);
 		writeActiveContext(f5xcConfigDir, INTEGRATION_TEST_CONTEXT.name);

--- a/packages/coding-agent/test/f5xc-api-client-integration.test.ts
+++ b/packages/coding-agent/test/f5xc-api-client-integration.test.ts
@@ -116,7 +116,7 @@ describe("ContextService API client integration", () => {
 
 		let capturedAuthHeader = "";
 		const originalFetch = globalThis.fetch;
-		globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+		globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
 			const headers = init?.headers as Record<string, string> | undefined;
 			capturedAuthHeader = headers?.Authorization ?? "";
 			return new Response(JSON.stringify({ items: [] }), { status: 200 });
@@ -145,7 +145,7 @@ describe("ContextService API client integration", () => {
 
 		let capturedAuthHeader = "";
 		const originalFetch = globalThis.fetch;
-		globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+		globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
 			const headers = init?.headers as Record<string, string> | undefined;
 			capturedAuthHeader = headers?.Authorization ?? "";
 			return new Response(JSON.stringify({ items: [] }), { status: 200 });

--- a/packages/coding-agent/test/f5xc-api-client-integration.test.ts
+++ b/packages/coding-agent/test/f5xc-api-client-integration.test.ts
@@ -120,7 +120,7 @@ describe("ContextService API client integration", () => {
 			const headers = init?.headers as Record<string, string> | undefined;
 			capturedAuthHeader = headers?.Authorization ?? "";
 			return new Response(JSON.stringify({ items: [] }), { status: 200 });
-		}) as typeof globalThis.fetch;
+		}) as unknown as typeof globalThis.fetch;
 
 		try {
 			const client = service.getApiClient();
@@ -149,7 +149,7 @@ describe("ContextService API client integration", () => {
 			const headers = init?.headers as Record<string, string> | undefined;
 			capturedAuthHeader = headers?.Authorization ?? "";
 			return new Response(JSON.stringify({ items: [] }), { status: 200 });
-		}) as typeof globalThis.fetch;
+		}) as unknown as typeof globalThis.fetch;
 
 		try {
 			const client = service.getApiClient();

--- a/packages/coding-agent/test/f5xc-api-client-integration.test.ts
+++ b/packages/coding-agent/test/f5xc-api-client-integration.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Snowflake } from "@f5xc-salesdemos/pi-utils";
+import { _resetSettingsForTest, Settings } from "@f5xc-salesdemos/xcsh/config/settings";
+import { ContextService, type F5XCContext } from "@f5xc-salesdemos/xcsh/services/f5xc-context";
+
+const INTEGRATION_TEST_CONTEXT: F5XCContext = {
+	name: "production",
+	apiUrl: "https://test-tenant.console.ves.volterra.io",
+	apiToken: "FAKE-TOKEN-FOR-UNIT-TESTS",
+	defaultNamespace: "default",
+};
+
+const INTEGRATION_TEST_CONTEXT_STAGING: F5XCContext = {
+	name: "staging",
+	apiUrl: "https://test-staging.console.ves.volterra.io",
+	apiToken: "FAKE-STAGING-TOKEN-FOR-TESTS",
+	defaultNamespace: "staging-ns",
+};
+
+function writeContext(contextsDir: string, context: F5XCContext): void {
+	fs.mkdirSync(contextsDir, { recursive: true });
+	fs.writeFileSync(path.join(contextsDir, `${context.name}.json`), JSON.stringify(context, null, 2), { mode: 0o600 });
+}
+
+function writeActiveContext(configDir: string, name: string): void {
+	fs.writeFileSync(path.join(configDir, "active_context"), name, { mode: 0o644 });
+}
+
+describe("ContextService API client integration", () => {
+	let testDir: string;
+	let f5xcConfigDir: string;
+	let f5xcContextsDir: string;
+	let projectDir: string;
+	let agentDir: string;
+	const savedEnv: Record<string, string | undefined> = {};
+
+	beforeEach(async () => {
+		_resetSettingsForTest();
+		ContextService._resetForTest();
+		for (const key of Object.keys(process.env)) {
+			if (key.startsWith("F5XC_")) {
+				savedEnv[key] = process.env[key];
+				delete process.env[key];
+			}
+		}
+		savedEnv.XDG_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
+		delete process.env.XDG_CONFIG_HOME;
+
+		testDir = path.join(os.tmpdir(), "test-f5xc-api-client-integration", Snowflake.next());
+		f5xcConfigDir = path.join(testDir, "f5xc-config");
+		f5xcContextsDir = path.join(f5xcConfigDir, "contexts");
+		projectDir = path.join(testDir, "project");
+		agentDir = path.join(testDir, "agent");
+
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.mkdirSync(path.join(projectDir, ".xcsh"), { recursive: true });
+		fs.mkdirSync(agentDir, { recursive: true });
+
+		await Settings.init({ cwd: projectDir, agentDir, inMemory: true });
+	});
+
+	afterEach(() => {
+		_resetSettingsForTest();
+		ContextService._resetForTest();
+		for (const key of Object.keys(process.env)) {
+			if (key.startsWith("F5XC_")) delete process.env[key];
+		}
+		for (const [key, value] of Object.entries(savedEnv)) {
+			if (value !== undefined) process.env[key] = value;
+		}
+		delete process.env.XDG_CONFIG_HOME;
+		if (savedEnv.XDG_CONFIG_HOME !== undefined) {
+			process.env.XDG_CONFIG_HOME = savedEnv.XDG_CONFIG_HOME;
+		}
+		if (fs.existsSync(testDir)) {
+			fs.rmSync(testDir, { recursive: true });
+		}
+	});
+
+	it("creates API client on loadActive", async () => {
+		writeContext(f5xcContextsDir, INTEGRATION_TEST_CONTEXT);
+		writeActiveContext(f5xcConfigDir, INTEGRATION_TEST_CONTEXT.name);
+
+		const service = ContextService.init(f5xcConfigDir);
+		expect(service.getApiClient()).toBeNull();
+
+		await service.loadActive();
+		const client = service.getApiClient();
+		expect(client).not.toBeNull();
+	});
+
+	it("creates API client on activate with updated credentials", async () => {
+		writeContext(f5xcContextsDir, INTEGRATION_TEST_CONTEXT);
+		writeContext(f5xcContextsDir, INTEGRATION_TEST_CONTEXT_STAGING);
+		writeActiveContext(f5xcConfigDir, INTEGRATION_TEST_CONTEXT.name);
+
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		await service.activate("staging");
+		const client = service.getApiClient();
+		expect(client).not.toBeNull();
+	});
+
+	it("uses env-override token when F5XC_API_TOKEN is set", async () => {
+		writeContext(f5xcContextsDir, INTEGRATION_TEST_CONTEXT);
+		writeActiveContext(f5xcConfigDir, INTEGRATION_TEST_CONTEXT.name);
+
+		process.env.F5XC_API_TOKEN = "env-override-token";
+
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		let capturedAuthHeader = "";
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+			const headers = init?.headers as Record<string, string> | undefined;
+			capturedAuthHeader = headers?.Authorization ?? "";
+			return new Response(JSON.stringify({ items: [] }), { status: 200 });
+		}) as typeof globalThis.fetch;
+
+		try {
+			const client = service.getApiClient();
+			expect(client).not.toBeNull();
+			await client!.listNamespaces();
+			expect(capturedAuthHeader).toBe("APIToken env-override-token");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it("_resetForTest clears the API client", async () => {
+		writeContext(f5xcContextsDir, INTEGRATION_TEST_CONTEXT);
+		writeActiveContext(f5xcConfigDir, INTEGRATION_TEST_CONTEXT.name);
+
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+		expect(service.getApiClient()).not.toBeNull();
+
+		ContextService._resetForTest();
+		const freshService = ContextService.init(f5xcConfigDir);
+		expect(freshService.getApiClient()).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/f5xc-api-client.test.ts
+++ b/packages/coding-agent/test/f5xc-api-client.test.ts
@@ -39,7 +39,7 @@ describe("F5XCApiClient", () => {
 			globalThis.fetch = (async (input: RequestInfo | URL) => {
 				capturedUrl = String(input);
 				return new Response(JSON.stringify({ items: [] }), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: "https://test.example.io///",
@@ -57,7 +57,7 @@ describe("F5XCApiClient", () => {
 			globalThis.fetch = (async () => {
 				fetchCount++;
 				return new Response(JSON.stringify({ message: "unauthorized" }), { status: 401 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: TEST_API_URL,
@@ -82,7 +82,7 @@ describe("F5XCApiClient", () => {
 			globalThis.fetch = (async () => {
 				fetchCount++;
 				return new Response(JSON.stringify({ message: "forbidden" }), { status: 403 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: TEST_API_URL,
@@ -110,7 +110,7 @@ describe("F5XCApiClient", () => {
 					return new Response(JSON.stringify({}), { status: 503 });
 				}
 				return new Response(JSON.stringify({ items: [{ name: "ns1" }, { name: "ns2" }] }), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: TEST_API_URL,
@@ -130,7 +130,7 @@ describe("F5XCApiClient", () => {
 			globalThis.fetch = (async () => {
 				fetchCount++;
 				return new Response(JSON.stringify({}), { status: 503 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: TEST_API_URL,
@@ -156,7 +156,7 @@ describe("F5XCApiClient", () => {
 			globalThis.fetch = (async () => {
 				const err = new DOMException("The operation was aborted", "AbortError");
 				throw err;
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: TEST_API_URL,
@@ -186,7 +186,7 @@ describe("F5XCApiClient", () => {
 					});
 				}
 				return new Response(JSON.stringify({ items: [{ name: "ns1" }] }), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: TEST_API_URL,
@@ -206,7 +206,7 @@ describe("F5XCApiClient", () => {
 				return new Response(JSON.stringify({ items: [{ notName: "x" }, { name: "valid" }, { name: 42 }, null] }), {
 					status: 200,
 				});
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: TEST_API_URL,
@@ -221,7 +221,7 @@ describe("F5XCApiClient", () => {
 		it("returns empty array when response has no items array", async () => {
 			globalThis.fetch = (async () => {
 				return new Response(JSON.stringify({ something: "else" }), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: TEST_API_URL,
@@ -236,7 +236,7 @@ describe("F5XCApiClient", () => {
 		it("returns parsed namespaces on 200", async () => {
 			globalThis.fetch = (async () => {
 				return new Response(JSON.stringify({ items: [{ name: "ns1" }, { name: "ns2" }] }), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: TEST_API_URL,
@@ -253,7 +253,7 @@ describe("F5XCApiClient", () => {
 		it("returns parsed status on 200", async () => {
 			globalThis.fetch = (async () => {
 				return new Response(JSON.stringify({ name: "production", phase: "Active" }), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: TEST_API_URL,
@@ -268,7 +268,7 @@ describe("F5XCApiClient", () => {
 		it("throws auth error on 401", async () => {
 			globalThis.fetch = (async () => {
 				return new Response(JSON.stringify({}), { status: 401 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: TEST_API_URL,
@@ -288,7 +288,7 @@ describe("F5XCApiClient", () => {
 		it("throws server error when required fields are missing", async () => {
 			globalThis.fetch = (async () => {
 				return new Response(JSON.stringify({ unrelated: true }), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: TEST_API_URL,
@@ -320,7 +320,7 @@ describe("F5XCApiClient", () => {
 					}),
 					{ status: 200 },
 				);
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: TEST_API_URL,
@@ -339,7 +339,7 @@ describe("F5XCApiClient", () => {
 		it("throws auth error on 401", async () => {
 			globalThis.fetch = (async () => {
 				return new Response(JSON.stringify({}), { status: 401 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
 				apiUrl: TEST_API_URL,

--- a/packages/coding-agent/test/f5xc-api-client.test.ts
+++ b/packages/coding-agent/test/f5xc-api-client.test.ts
@@ -36,7 +36,7 @@ describe("F5XCApiClient", () => {
 	describe("URL normalization", () => {
 		it("strips trailing slashes from apiUrl", async () => {
 			let capturedUrl = "";
-			globalThis.fetch = (async (input: RequestInfo | URL) => {
+			globalThis.fetch = (async (input: string | URL | Request) => {
 				capturedUrl = String(input);
 				return new Response(JSON.stringify({ items: [] }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
@@ -309,7 +309,7 @@ describe("F5XCApiClient", () => {
 	describe("listObjects", () => {
 		it("returns parsed objects on 200", async () => {
 			let capturedUrl = "";
-			globalThis.fetch = (async (input: RequestInfo | URL) => {
+			globalThis.fetch = (async (input: string | URL | Request) => {
 				capturedUrl = String(input);
 				return new Response(
 					JSON.stringify({

--- a/packages/coding-agent/test/f5xc-api-client.test.ts
+++ b/packages/coding-agent/test/f5xc-api-client.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "bun:test";
-import { F5XCApiError } from "@f5xc-salesdemos/xcsh/services/f5xc-api-client";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { F5XCApiClient, F5XCApiError } from "@f5xc-salesdemos/xcsh/services/f5xc-api-client";
+
+const TEST_API_URL = "https://test-tenant.console.ves.volterra.io";
+const TEST_API_TOKEN = "FAKE-TOKEN-FOR-UNIT-TESTS";
 
 describe("F5XCApiError", () => {
 	it("carries kind and status", () => {
@@ -16,5 +19,160 @@ describe("F5XCApiError", () => {
 		const err = new F5XCApiError("timeout", "network");
 		expect(err.kind).toBe("network");
 		expect(err.status).toBeUndefined();
+	});
+});
+
+describe("F5XCApiClient", () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	describe("URL normalization", () => {
+		it("strips trailing slashes from apiUrl", async () => {
+			let capturedUrl = "";
+			globalThis.fetch = (async (input: RequestInfo | URL) => {
+				capturedUrl = String(input);
+				return new Response(JSON.stringify({ items: [] }), { status: 200 });
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: "https://test.example.io///",
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 0,
+			});
+			await client.listNamespaces();
+			expect(capturedUrl).toBe("https://test.example.io/api/web/namespaces");
+		});
+	});
+
+	describe("listNamespaces", () => {
+		it("throws auth error on 401 without retrying", async () => {
+			let fetchCount = 0;
+			globalThis.fetch = (async () => {
+				fetchCount++;
+				return new Response(JSON.stringify({ message: "unauthorized" }), { status: 401 });
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 3,
+			});
+
+			try {
+				await client.listNamespaces();
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(F5XCApiError);
+				const apiErr = err as F5XCApiError;
+				expect(apiErr.kind).toBe("auth");
+				expect(apiErr.status).toBe(401);
+			}
+			expect(fetchCount).toBe(1);
+		});
+
+		it("throws auth error on 403 without retrying", async () => {
+			let fetchCount = 0;
+			globalThis.fetch = (async () => {
+				fetchCount++;
+				return new Response(JSON.stringify({ message: "forbidden" }), { status: 403 });
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 3,
+			});
+
+			try {
+				await client.listNamespaces();
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(F5XCApiError);
+				const apiErr = err as F5XCApiError;
+				expect(apiErr.kind).toBe("auth");
+				expect(apiErr.status).toBe(403);
+			}
+			expect(fetchCount).toBe(1);
+		});
+
+		it("retries on 503 then returns data on success", async () => {
+			let fetchCount = 0;
+			globalThis.fetch = (async () => {
+				fetchCount++;
+				if (fetchCount <= 2) {
+					return new Response(JSON.stringify({}), { status: 503 });
+				}
+				return new Response(JSON.stringify({ items: [{ name: "ns1" }, { name: "ns2" }] }), { status: 200 });
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 3,
+				baseDelayMs: 1,
+				maxDelayMs: 1,
+			});
+
+			const result = await client.listNamespaces();
+			expect(result).toEqual([{ name: "ns1" }, { name: "ns2" }]);
+			expect(fetchCount).toBe(3);
+		});
+
+		it("throws server error after exhausting retries on 503", async () => {
+			let fetchCount = 0;
+			globalThis.fetch = (async () => {
+				fetchCount++;
+				return new Response(JSON.stringify({}), { status: 503 });
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 2,
+				baseDelayMs: 1,
+				maxDelayMs: 1,
+			});
+
+			try {
+				await client.listNamespaces();
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(F5XCApiError);
+				const apiErr = err as F5XCApiError;
+				expect(apiErr.kind).toBe("server");
+				expect(apiErr.status).toBe(503);
+			}
+			expect(fetchCount).toBe(3); // 1 initial + 2 retries
+		});
+
+		it("throws network error on fetch timeout", async () => {
+			globalThis.fetch = (async () => {
+				const err = new DOMException("The operation was aborted", "AbortError");
+				throw err;
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 0,
+			});
+
+			try {
+				await client.listNamespaces();
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(F5XCApiError);
+				const apiErr = err as F5XCApiError;
+				expect(apiErr.kind).toBe("network");
+				expect(apiErr.status).toBeUndefined();
+			}
+		});
 	});
 });

--- a/packages/coding-agent/test/f5xc-api-client.test.ts
+++ b/packages/coding-agent/test/f5xc-api-client.test.ts
@@ -174,5 +174,78 @@ describe("F5XCApiClient", () => {
 				expect(apiErr.status).toBeUndefined();
 			}
 		});
+
+		it("respects Retry-After header on 429", async () => {
+			let fetchCount = 0;
+			globalThis.fetch = (async () => {
+				fetchCount++;
+				if (fetchCount === 1) {
+					return new Response(JSON.stringify({}), {
+						status: 429,
+						headers: { "Retry-After": "1" },
+					});
+				}
+				return new Response(JSON.stringify({ items: [{ name: "ns1" }] }), { status: 200 });
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 1,
+				baseDelayMs: 1,
+				maxDelayMs: 5000,
+			});
+
+			const result = await client.listNamespaces();
+			expect(result).toEqual([{ name: "ns1" }]);
+			expect(fetchCount).toBe(2);
+		});
+
+		it("silently filters items missing name field", async () => {
+			globalThis.fetch = (async () => {
+				return new Response(JSON.stringify({ items: [{ notName: "x" }, { name: "valid" }, { name: 42 }, null] }), {
+					status: 200,
+				});
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 0,
+			});
+
+			const result = await client.listNamespaces();
+			expect(result).toEqual([{ name: "valid" }]);
+		});
+
+		it("returns empty array when response has no items array", async () => {
+			globalThis.fetch = (async () => {
+				return new Response(JSON.stringify({ something: "else" }), { status: 200 });
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 0,
+			});
+
+			const result = await client.listNamespaces();
+			expect(result).toEqual([]);
+		});
+
+		it("returns parsed namespaces on 200", async () => {
+			globalThis.fetch = (async () => {
+				return new Response(JSON.stringify({ items: [{ name: "ns1" }, { name: "ns2" }] }), { status: 200 });
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 0,
+			});
+
+			const result = await client.listNamespaces();
+			expect(result).toEqual([{ name: "ns1" }, { name: "ns2" }]);
+		});
 	});
 });

--- a/packages/coding-agent/test/f5xc-api-client.test.ts
+++ b/packages/coding-agent/test/f5xc-api-client.test.ts
@@ -248,4 +248,112 @@ describe("F5XCApiClient", () => {
 			expect(result).toEqual([{ name: "ns1" }, { name: "ns2" }]);
 		});
 	});
+
+	describe("getNamespaceStatus", () => {
+		it("returns parsed status on 200", async () => {
+			globalThis.fetch = (async () => {
+				return new Response(JSON.stringify({ name: "production", phase: "Active" }), { status: 200 });
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 0,
+			});
+
+			const result = await client.getNamespaceStatus("production");
+			expect(result).toEqual({ name: "production", phase: "Active" });
+		});
+
+		it("throws auth error on 401", async () => {
+			globalThis.fetch = (async () => {
+				return new Response(JSON.stringify({}), { status: 401 });
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 0,
+			});
+
+			try {
+				await client.getNamespaceStatus("production");
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(F5XCApiError);
+				expect((err as F5XCApiError).kind).toBe("auth");
+			}
+		});
+
+		it("throws server error when required fields are missing", async () => {
+			globalThis.fetch = (async () => {
+				return new Response(JSON.stringify({ unrelated: true }), { status: 200 });
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 0,
+			});
+
+			try {
+				await client.getNamespaceStatus("production");
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(F5XCApiError);
+				expect((err as F5XCApiError).kind).toBe("server");
+			}
+		});
+	});
+
+	describe("listObjects", () => {
+		it("returns parsed objects on 200", async () => {
+			let capturedUrl = "";
+			globalThis.fetch = (async (input: RequestInfo | URL) => {
+				capturedUrl = String(input);
+				return new Response(
+					JSON.stringify({
+						items: [
+							{ name: "obj1", namespace: "ns1", kind: "http_loadbalancer" },
+							{ name: "obj2", namespace: "ns1", kind: "origin_pool" },
+						],
+					}),
+					{ status: 200 },
+				);
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 0,
+			});
+
+			const result = await client.listObjects("ns1", "http_loadbalancers");
+			expect(result).toEqual([
+				{ name: "obj1", namespace: "ns1", kind: "http_loadbalancer" },
+				{ name: "obj2", namespace: "ns1", kind: "origin_pool" },
+			]);
+			expect(capturedUrl).toBe(`${TEST_API_URL}/api/web/namespaces/ns1/http_loadbalancers`);
+		});
+
+		it("throws auth error on 401", async () => {
+			globalThis.fetch = (async () => {
+				return new Response(JSON.stringify({}), { status: 401 });
+			}) as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 0,
+			});
+
+			try {
+				await client.listObjects("ns1", "http_loadbalancers");
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(F5XCApiError);
+				expect((err as F5XCApiError).kind).toBe("auth");
+			}
+		});
+	});
 });

--- a/packages/coding-agent/test/f5xc-api-client.test.ts
+++ b/packages/coding-agent/test/f5xc-api-client.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { F5XCApiError } from "@f5xc-salesdemos/xcsh/services/f5xc-api-client";
+
+describe("F5XCApiError", () => {
+	it("carries kind and status", () => {
+		const err = new F5XCApiError("unauthorized", "auth", 401);
+		expect(err).toBeInstanceOf(Error);
+		expect(err).toBeInstanceOf(F5XCApiError);
+		expect(err.message).toBe("unauthorized");
+		expect(err.name).toBe("F5XCApiError");
+		expect(err.kind).toBe("auth");
+		expect(err.status).toBe(401);
+	});
+
+	it("status is optional", () => {
+		const err = new F5XCApiError("timeout", "network");
+		expect(err.kind).toBe("network");
+		expect(err.status).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/f5xc-api-client.test.ts
+++ b/packages/coding-agent/test/f5xc-api-client.test.ts
@@ -149,7 +149,7 @@ describe("F5XCApiClient", () => {
 				expect(apiErr.kind).toBe("server");
 				expect(apiErr.status).toBe(503);
 			}
-			expect(fetchCount).toBe(3); // 1 initial + 2 retries
+			expect(fetchCount).toBe(3);
 		});
 
 		it("throws network error on fetch timeout", async () => {

--- a/packages/coding-agent/test/f5xc-context-display.test.ts
+++ b/packages/coding-agent/test/f5xc-context-display.test.ts
@@ -40,4 +40,26 @@ describe("formatContextLabel", () => {
 	it("uses explicit namespace in place of the 'default' fallback", () => {
 		expect(formatContextLabel(status({ activeContextNamespace: "staging" }))).toBe("env:staging");
 	});
+
+	it("appends warning icon when token is expiring", () => {
+		expect(
+			formatContextLabel(
+				status({ activeContextTenant: "acme", activeContextNamespace: "prod", tokenHealth: "expiring" }),
+			),
+		).toBe("acme:prod ⚠");
+	});
+
+	it("appends warning icon when token is expired", () => {
+		expect(
+			formatContextLabel(
+				status({ activeContextTenant: "acme", activeContextNamespace: "prod", tokenHealth: "expired" }),
+			),
+		).toBe("acme:prod ⚠");
+	});
+
+	it("no suffix when token health is ok", () => {
+		expect(
+			formatContextLabel(status({ activeContextTenant: "acme", activeContextNamespace: "prod", tokenHealth: "ok" })),
+		).toBe("acme:prod");
+	});
 });

--- a/packages/coding-agent/test/f5xc-context-display.test.ts
+++ b/packages/coding-agent/test/f5xc-context-display.test.ts
@@ -11,6 +11,7 @@ function status(overrides: Partial<ContextStatus> = {}): ContextStatus {
 		credentialSource: "none",
 		authStatus: "unknown",
 		isConfigured: false,
+		tokenHealth: "ok",
 		...overrides,
 	};
 }

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -1332,7 +1332,7 @@ describe("ContextService", () => {
 			globalThis.fetch = (async () => {
 				fetchCallCount++;
 				return new Response(JSON.stringify({ items: [{ name: "ns-from-validate" }] }), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 			await service.validateToken();
 			await waitForCachePopulate();
 			expect(service.getCachedNamespaces()).toEqual(["ns1"]);
@@ -1370,7 +1370,7 @@ describe("ContextService", () => {
 					return new Response(JSON.stringify({ items: body }), { status: 200 });
 				}
 				return new Response(JSON.stringify({ items: [{ name: "ns-from-second-context" }] }), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
@@ -1425,7 +1425,7 @@ describe("ContextService", () => {
 					return new Response(JSON.stringify({ items: [{ name: "ns1" }, { name: "ns2" }] }), { status: 200 });
 				}
 				return new Response(JSON.stringify({ items: [{ name: "staging-ns" }] }), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
@@ -2109,7 +2109,7 @@ describe("ContextService", () => {
 			globalThis.fetch = (async () => {
 				fetchCount++;
 				return new Response(JSON.stringify({}), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
@@ -2129,7 +2129,7 @@ describe("ContextService", () => {
 			globalThis.fetch = (async () => {
 				fetchCount++;
 				return new Response(JSON.stringify({}), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
@@ -2149,7 +2149,7 @@ describe("ContextService", () => {
 
 			globalThis.fetch = (async () => {
 				return new Response(JSON.stringify({}), { status: 401 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
@@ -2176,7 +2176,7 @@ describe("ContextService", () => {
 
 			globalThis.fetch = (async () => {
 				return new Response(JSON.stringify({}), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
@@ -2205,7 +2205,7 @@ describe("ContextService", () => {
 			globalThis.fetch = (async () => {
 				fetchCount++;
 				return new Response(JSON.stringify({}), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
@@ -2228,7 +2228,7 @@ describe("ContextService", () => {
 			globalThis.fetch = (async () => {
 				fetchCount++;
 				return new Response(JSON.stringify({}), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
@@ -2259,7 +2259,7 @@ describe("ContextService", () => {
 				await Bun.sleep(50);
 				concurrent--;
 				return new Response(JSON.stringify({}), { status: 200 });
-			}) as typeof globalThis.fetch;
+			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -2105,45 +2105,43 @@ describe("ContextService", () => {
 			writeContext(f5xcContextsDir, TEST_CONTEXT);
 			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
 
-			let fetchCount = 0;
 			globalThis.fetch = (async () => {
-				fetchCount++;
-				return new Response(JSON.stringify({}), { status: 200 });
+				return new Response(JSON.stringify({ items: [] }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
-			fetchCount = 0;
 			service.stopRevalidation();
+
+			const spy = vi.spyOn(service, "validateToken").mockResolvedValue({ status: "connected" });
 			service.startRevalidation(50);
 			await wait(250);
 			service.stopRevalidation();
-			expect(fetchCount).toBeGreaterThanOrEqual(2);
+			expect(spy.mock.calls.length).toBeGreaterThanOrEqual(2);
+			spy.mockRestore();
 		});
 
 		it("stopRevalidation clears the timer", async () => {
 			writeContext(f5xcContextsDir, TEST_CONTEXT);
 			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
 
-			let fetchCount = 0;
 			globalThis.fetch = (async () => {
-				fetchCount++;
 				return new Response(JSON.stringify({ items: [] }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
-			fetchCount = 0;
 			service.stopRevalidation();
+
+			const spy = vi.spyOn(service, "validateToken").mockResolvedValue({ status: "connected" });
 			service.startRevalidation(50);
 			await wait(80);
 			service.stopRevalidation();
-			// Wait for any tick that was already in-flight at stop time to complete.
-			// The mock is instant (no sleep), so any in-flight call resolves in <1ms.
 			await wait(20);
-			const countAtStop = fetchCount;
+			const countAtStop = spy.mock.calls.length;
 			await wait(200);
-			expect(fetchCount).toBe(countAtStop);
+			expect(spy.mock.calls.length).toBe(countAtStop);
+			spy.mockRestore();
 		});
 
 		it("onAuthStatusChange fires on status transition", async () => {
@@ -2204,9 +2202,7 @@ describe("ContextService", () => {
 			writeContext(f5xcContextsDir, TEST_CONTEXT_2);
 			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
 
-			let fetchCount = 0;
 			globalThis.fetch = (async () => {
-				fetchCount++;
 				return new Response(JSON.stringify({ items: [] }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
 
@@ -2214,49 +2210,46 @@ describe("ContextService", () => {
 			await service.loadActive();
 			service.stopRevalidation();
 
+			const spy = vi.spyOn(service, "validateToken").mockResolvedValue({ status: "connected" });
 			await service.activate(TEST_CONTEXT_2.name);
-			// activate() calls #refreshApiClient which starts the timer at the default 5-min
-			// interval. Stop it and let any in-flight namespace fetches settle before measuring.
 			service.stopRevalidation();
-			await wait(20);
 
-			fetchCount = 0;
+			spy.mockClear();
 			service.startRevalidation(50);
 			await wait(250);
 			service.stopRevalidation();
-			expect(fetchCount).toBeGreaterThanOrEqual(2);
+			expect(spy.mock.calls.length).toBeGreaterThanOrEqual(2);
+			spy.mockRestore();
 		});
 
 		it("_resetForTest clears timer and listeners", async () => {
 			writeContext(f5xcContextsDir, TEST_CONTEXT);
 			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
 
-			let fetchCount = 0;
 			globalThis.fetch = (async () => {
-				fetchCount++;
-				return new Response(JSON.stringify({}), { status: 200 });
+				return new Response(JSON.stringify({ items: [] }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
+			service.stopRevalidation();
 
+			const spy = vi.spyOn(service, "validateToken").mockResolvedValue({ status: "connected" });
 			const listener = () => {};
 			ContextService.onAuthStatusChange(listener);
-			fetchCount = 0;
-			service.stopRevalidation();
 			service.startRevalidation(50);
 
 			ContextService._resetForTest();
-			const countAtReset = fetchCount;
+			const countAtReset = spy.mock.calls.length;
 			await wait(200);
-			expect(fetchCount).toBe(countAtReset);
+			expect(spy.mock.calls.length).toBe(countAtReset);
+			spy.mockRestore();
 		});
 
 		it("recursive setTimeout prevents overlap", async () => {
 			writeContext(f5xcContextsDir, TEST_CONTEXT);
 			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
 
-			// Use a fast mock during loadActive so namespace fire-and-forget completes instantly.
 			globalThis.fetch = (async () => {
 				return new Response(JSON.stringify({ items: [] }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
@@ -2265,25 +2258,25 @@ describe("ContextService", () => {
 			await service.loadActive();
 			service.stopRevalidation();
 
-			// Swap to a slow mock that takes 50ms per call. Only the timer uses it now.
-			let fetchCount = 0;
+			let callCount = 0;
 			let concurrent = 0;
 			let maxConcurrent = 0;
-			globalThis.fetch = (async () => {
+			const spy = vi.spyOn(service, "validateToken").mockImplementation(async () => {
 				concurrent++;
 				maxConcurrent = Math.max(maxConcurrent, concurrent);
-				fetchCount++;
+				callCount++;
 				await Bun.sleep(50);
 				concurrent--;
-				return new Response(JSON.stringify({ items: [] }), { status: 200 });
-			}) as unknown as typeof globalThis.fetch;
+				return { status: "connected" };
+			});
 
 			service.startRevalidation(10);
 			await wait(300);
 			service.stopRevalidation();
 
 			expect(maxConcurrent).toBe(1);
-			expect(fetchCount).toBeLessThanOrEqual(5);
+			expect(callCount).toBeLessThanOrEqual(5);
+			spy.mockRestore();
 		});
 	});
 });

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -1299,7 +1299,8 @@ describe("ContextService", () => {
 			return new Promise(resolve => setTimeout(resolve, 10));
 		}
 
-		async function setupActiveContext(): Promise<ContextService> {
+		async function setupActiveContext(fetchMock?: typeof globalThis.fetch): Promise<ContextService> {
+			if (fetchMock) globalThis.fetch = fetchMock;
 			writeContext(f5xcContextsDir, TEST_CONTEXT);
 			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
 			const service = ContextService.init(f5xcConfigDir);
@@ -1307,75 +1308,43 @@ describe("ContextService", () => {
 			return service;
 		}
 
-		it("getCachedNamespaces returns [] before any validateToken call", () => {
+		it("getCachedNamespaces returns [] before activation", () => {
 			const service = ContextService.init(f5xcConfigDir);
 			expect(service.getCachedNamespaces()).toEqual([]);
 		});
 
-		it("validateToken for active context populates namespace cache sorted by name", async () => {
-			globalThis.fetch = makeMockJsonResponse(200, {
-				items: [{ name: "production" }, { name: "default" }, { name: "shared" }],
-			});
-			const service = await setupActiveContext();
-			await service.validateToken();
+		it("loadActive populates namespace cache sorted by name", async () => {
+			const service = await setupActiveContext(
+				makeMockJsonResponse(200, {
+					items: [{ name: "production" }, { name: "default" }, { name: "shared" }],
+				}),
+			);
 			await waitForCachePopulate();
 			expect(service.getCachedNamespaces()).toEqual(["default", "production", "shared"]);
 		});
 
-		it("validateToken with explicit creds for a NON-active context does NOT populate cache (prevents /context show <other> tenant leakage)", async () => {
-			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "staging-ns" }] });
-			const service = await setupActiveContext();
-			// Simulate handleShow probing another context's credentials — cache must
-			// remain scoped to the active context.
-			await service.validateToken({ apiUrl: "https://other.console.ves.volterra.io", apiToken: "other-tok" });
+		it("validateToken no longer populates namespace cache", async () => {
+			const service = await setupActiveContext(makeMockJsonResponse(200, { items: [{ name: "ns1" }] }));
 			await waitForCachePopulate();
-			expect(service.getCachedNamespaces()).toEqual([]);
+			expect(service.getCachedNamespaces()).toEqual(["ns1"]);
+
+			let fetchCallCount = 0;
+			globalThis.fetch = (async () => {
+				fetchCallCount++;
+				return new Response(JSON.stringify({ items: [{ name: "ns-from-validate" }] }), { status: 200 });
+			}) as typeof globalThis.fetch;
+			await service.validateToken();
+			await waitForCachePopulate();
+			expect(service.getCachedNamespaces()).toEqual(["ns1"]);
+			expect(fetchCallCount).toBe(1);
 		});
 
-		it("validateToken with explicit creds MATCHING the active context DOES populate cache (activate → handleShow flow)", async () => {
-			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }, { name: "ns2" }] });
-			const service = await setupActiveContext();
-			// handleActivate calls activate() (clears cache) and then handleShow(), which
-			// always passes explicit creds. When those creds match the active context,
-			// the cache must warm — otherwise /context namespace <tab> would be empty
-			// immediately after activation until some other path fires validateToken().
-			await service.validateToken({ apiUrl: TEST_CONTEXT.apiUrl, apiToken: TEST_CONTEXT.apiToken });
-			await waitForCachePopulate();
-			expect(service.getCachedNamespaces()).toEqual(["ns1", "ns2"]);
-		});
-
-		it("env override (F5XC_API_TOKEN) alongside an active context does NOT populate cache", async () => {
-			// Active context is loaded normally, then F5XC_API_TOKEN is set to override
-			// the context's token at validateToken time. The fetch hits the active
-			// tenant URL but with a different account's credentials, so the returned
-			// namespace list reflects a different account than /context namespace
-			// would mutate. The cache must stay empty.
-			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "env-token-account-ns" }] });
-			const service = await setupActiveContext();
+		it("env override (F5XC_API_TOKEN) suppresses namespace population on activation", async () => {
 			try {
 				process.env.F5XC_API_TOKEN = "different-account-token";
-				await service.validateToken();
-				await waitForCachePopulate();
-				expect(service.getCachedNamespaces()).toEqual([]);
-			} finally {
-				delete process.env.F5XC_API_TOKEN;
-			}
-		});
-
-		it("env override alongside activate→handleShow's explicit-creds path does NOT populate cache", async () => {
-			// /context activate calls activate() then handleShow() which passes the
-			// context's own apiUrl/apiToken as explicit options. With F5XC_API_TOKEN
-			// also set, the effective comparison would pass (options override env in
-			// effectiveToken computation), but the session remains mixed-source — the
-			// namespace list returned for the context's token doesn't match what the
-			// user's actual operational calls will see under the env override token.
-			// !hasEnvOverride() catches this case.
-			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "context-account-ns" }] });
-			const service = await setupActiveContext();
-			try {
-				process.env.F5XC_API_TOKEN = "env-override-token";
-				// Simulate handleShow's explicit-creds call for the active context.
-				await service.validateToken({ apiUrl: TEST_CONTEXT.apiUrl, apiToken: TEST_CONTEXT.apiToken });
+				const service = await setupActiveContext(
+					makeMockJsonResponse(200, { items: [{ name: "env-token-account-ns" }] }),
+				);
 				await waitForCachePopulate();
 				expect(service.getCachedNamespaces()).toEqual([]);
 			} finally {
@@ -1388,96 +1357,84 @@ describe("ContextService", () => {
 			writeContext(f5xcContextsDir, TEST_CONTEXT_2);
 			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
 
-			// Build a fetch mock whose body resolution we hold until after activate() runs.
-			let releaseBody: (body: unknown) => void = () => {};
-			const bodyPromise = new Promise<unknown>(resolve => {
-				releaseBody = resolve;
+			let releaseNamespaces: (value: { name: string }[]) => void = () => {};
+			const namespacesPromise = new Promise<{ name: string }[]>(resolve => {
+				releaseNamespaces = resolve;
 			});
-			globalThis.fetch = (() =>
-				Promise.resolve({
-					ok: true,
-					status: 200,
-					json: () => bodyPromise,
-				} as unknown as Response)) as unknown as typeof globalThis.fetch;
+
+			let callCount = 0;
+			globalThis.fetch = (async () => {
+				callCount++;
+				if (callCount === 1) {
+					const body = await namespacesPromise;
+					return new Response(JSON.stringify({ items: body }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ items: [{ name: "ns-from-second-context" }] }), { status: 200 });
+			}) as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
 
-			// validateToken returns on headers; the fire-and-forget body parse is now stalled.
-			await service.validateToken();
-
-			// Activate a different context — clears the cache AND advances the epoch.
 			await service.activate(TEST_CONTEXT_2.name);
-			expect(service.getCachedNamespaces()).toEqual([]);
-
-			// Release the stalled body with the first context's namespaces. The .then()
-			// callback captured the prior epoch and must now discard the write.
-			releaseBody({ items: [{ name: "stale-from-prior-context" }] });
 			await waitForCachePopulate();
 
-			expect(service.getCachedNamespaces()).toEqual([]);
+			releaseNamespaces([{ name: "stale-from-prior-context" }]);
+			await waitForCachePopulate();
+
+			const cached = service.getCachedNamespaces();
+			expect(cached).not.toContain("stale-from-prior-context");
 		});
 
-		it("validateToken in an env-backed session (no active context) does NOT populate cache", async () => {
-			// No loadActive or activate — service has no active context.
+		it("env-backed session (no active context) has empty namespace cache", async () => {
 			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }] });
 			const service = ContextService.init(f5xcConfigDir);
-			await service.validateToken();
-			await waitForCachePopulate();
 			expect(service.getCachedNamespaces()).toEqual([]);
 		});
 
-		it("validateToken 5xx response leaves cache unchanged", async () => {
-			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }] });
-			const service = await setupActiveContext();
-			await service.validateToken();
+		it("namespace cache persists across validateToken calls", async () => {
+			const service = await setupActiveContext(makeMockJsonResponse(200, { items: [{ name: "ns1" }] }));
 			await waitForCachePopulate();
 			expect(service.getCachedNamespaces()).toEqual(["ns1"]);
 			globalThis.fetch = makeMockTextResponse(502);
 			await service.validateToken();
 			await waitForCachePopulate();
-			expect(service.getCachedNamespaces()).toEqual(["ns1"]); // unchanged
-		});
-
-		it("validateToken 2xx with malformed body (items is not an array) leaves cache unchanged", async () => {
-			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }] });
-			const service = await setupActiveContext();
-			await service.validateToken();
-			await waitForCachePopulate();
 			expect(service.getCachedNamespaces()).toEqual(["ns1"]);
-
-			globalThis.fetch = makeMockJsonResponse(200, { items: "not-an-array" });
-			await service.validateToken();
-			await waitForCachePopulate();
-			expect(service.getCachedNamespaces()).toEqual(["ns1"]); // unchanged
 		});
 
-		it("validateToken 2xx with non-JSON body leaves cache unchanged (proxy interception case)", async () => {
-			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }] });
-			const service = await setupActiveContext();
-			await service.validateToken();
+		it("malformed namespace response (items not an array) leaves cache empty", async () => {
+			const service = await setupActiveContext(makeMockJsonResponse(200, { items: "not-an-array" }));
 			await waitForCachePopulate();
-			expect(service.getCachedNamespaces()).toEqual(["ns1"]);
-
-			globalThis.fetch = makeMockTextResponse(200);
-			await service.validateToken();
-			await waitForCachePopulate();
-			expect(service.getCachedNamespaces()).toEqual(["ns1"]); // unchanged — response.json() threw, catch swallowed
+			expect(service.getCachedNamespaces()).toEqual([]);
 		});
 
-		it("activate(otherContext) clears the namespace cache", async () => {
+		it("client.listNamespaces auth failure leaves cache empty (logged, not thrown)", async () => {
+			const service = await setupActiveContext(makeMockJsonResponse(401, {}));
+			await waitForCachePopulate();
+			expect(service.getCachedNamespaces()).toEqual([]);
+		});
+
+		it("activate repopulates namespace cache with new context data", async () => {
 			writeContext(f5xcContextsDir, TEST_CONTEXT);
 			writeContext(f5xcContextsDir, TEST_CONTEXT_2);
 			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
-			globalThis.fetch = makeMockJsonResponse(200, { items: [{ name: "ns1" }, { name: "ns2" }] });
+
+			let callCount = 0;
+			globalThis.fetch = (async () => {
+				callCount++;
+				if (callCount === 1) {
+					return new Response(JSON.stringify({ items: [{ name: "ns1" }, { name: "ns2" }] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ items: [{ name: "staging-ns" }] }), { status: 200 });
+			}) as typeof globalThis.fetch;
+
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
-			await service.validateToken();
 			await waitForCachePopulate();
 			expect(service.getCachedNamespaces()).toEqual(["ns1", "ns2"]);
 
 			await service.activate(TEST_CONTEXT_2.name);
-			expect(service.getCachedNamespaces()).toEqual([]);
+			await waitForCachePopulate();
+			expect(service.getCachedNamespaces()).toEqual(["staging-ns"]);
 		});
 	});
 

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -2128,7 +2128,7 @@ describe("ContextService", () => {
 			let fetchCount = 0;
 			globalThis.fetch = (async () => {
 				fetchCount++;
-				return new Response(JSON.stringify({}), { status: 200 });
+				return new Response(JSON.stringify({ items: [] }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
@@ -2138,6 +2138,9 @@ describe("ContextService", () => {
 			service.startRevalidation(50);
 			await wait(80);
 			service.stopRevalidation();
+			// Wait for any tick that was already in-flight at stop time to complete.
+			// The mock is instant (no sleep), so any in-flight call resolves in <1ms.
+			await wait(20);
 			const countAtStop = fetchCount;
 			await wait(200);
 			expect(fetchCount).toBe(countAtStop);
@@ -2253,6 +2256,16 @@ describe("ContextService", () => {
 			writeContext(f5xcContextsDir, TEST_CONTEXT);
 			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
 
+			// Use a fast mock during loadActive so namespace fire-and-forget completes instantly.
+			globalThis.fetch = (async () => {
+				return new Response(JSON.stringify({ items: [] }), { status: 200 });
+			}) as unknown as typeof globalThis.fetch;
+
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+			service.stopRevalidation();
+
+			// Swap to a slow mock that takes 50ms per call. Only the timer uses it now.
 			let fetchCount = 0;
 			let concurrent = 0;
 			let maxConcurrent = 0;
@@ -2265,16 +2278,6 @@ describe("ContextService", () => {
 				return new Response(JSON.stringify({ items: [] }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
 
-			const service = ContextService.init(f5xcConfigDir);
-			await service.loadActive();
-			service.stopRevalidation();
-			// loadActive fires a namespace fetch (fire-and-forget) that also hits the mock and
-			// takes 50ms. Wait for it to complete before resetting concurrency counters.
-			await wait(80);
-
-			fetchCount = 0;
-			concurrent = 0;
-			maxConcurrent = 0;
 			service.startRevalidation(10);
 			await wait(300);
 			service.stopRevalidation();

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -2204,17 +2204,21 @@ describe("ContextService", () => {
 			let fetchCount = 0;
 			globalThis.fetch = (async () => {
 				fetchCount++;
-				return new Response(JSON.stringify({}), { status: 200 });
+				return new Response(JSON.stringify({ items: [] }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
-			fetchCount = 0;
 			service.stopRevalidation();
-			service.startRevalidation(50);
 
 			await service.activate(TEST_CONTEXT_2.name);
+			// activate() calls #refreshApiClient which starts the timer at the default 5-min
+			// interval. Stop it and let any in-flight namespace fetches settle before measuring.
+			service.stopRevalidation();
+			await wait(20);
+
 			fetchCount = 0;
+			service.startRevalidation(50);
 			await wait(250);
 			service.stopRevalidation();
 			expect(fetchCount).toBeGreaterThanOrEqual(2);
@@ -2258,13 +2262,19 @@ describe("ContextService", () => {
 				fetchCount++;
 				await Bun.sleep(50);
 				concurrent--;
-				return new Response(JSON.stringify({}), { status: 200 });
+				return new Response(JSON.stringify({ items: [] }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);
 			await service.loadActive();
-			fetchCount = 0;
 			service.stopRevalidation();
+			// loadActive fires a namespace fetch (fire-and-forget) that also hits the mock and
+			// takes 50ms. Wait for it to complete before resetting concurrency counters.
+			await wait(80);
+
+			fetchCount = 0;
+			concurrent = 0;
+			maxConcurrent = 0;
 			service.startRevalidation(10);
 			await wait(300);
 			service.stopRevalidation();

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -2087,4 +2087,190 @@ describe("ContextService", () => {
 			expect(result.skipped).toEqual([]);
 		});
 	});
+
+	describe("background token re-validation", () => {
+		let savedFetch: typeof globalThis.fetch;
+		beforeEach(() => {
+			savedFetch = globalThis.fetch;
+		});
+		afterEach(() => {
+			globalThis.fetch = savedFetch;
+		});
+
+		function wait(ms: number): Promise<void> {
+			return new Promise(resolve => setTimeout(resolve, ms));
+		}
+
+		it("startRevalidation calls validateToken periodically", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+			let fetchCount = 0;
+			globalThis.fetch = (async () => {
+				fetchCount++;
+				return new Response(JSON.stringify({}), { status: 200 });
+			}) as typeof globalThis.fetch;
+
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+			fetchCount = 0;
+			service.stopRevalidation();
+			service.startRevalidation(50);
+			await wait(250);
+			service.stopRevalidation();
+			expect(fetchCount).toBeGreaterThanOrEqual(2);
+		});
+
+		it("stopRevalidation clears the timer", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+			let fetchCount = 0;
+			globalThis.fetch = (async () => {
+				fetchCount++;
+				return new Response(JSON.stringify({}), { status: 200 });
+			}) as typeof globalThis.fetch;
+
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+			fetchCount = 0;
+			service.stopRevalidation();
+			service.startRevalidation(50);
+			await wait(80);
+			service.stopRevalidation();
+			const countAtStop = fetchCount;
+			await wait(200);
+			expect(fetchCount).toBe(countAtStop);
+		});
+
+		it("onAuthStatusChange fires on status transition", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+			globalThis.fetch = (async () => {
+				return new Response(JSON.stringify({}), { status: 401 });
+			}) as typeof globalThis.fetch;
+
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const transitions: Array<{ prev: string; current: string }> = [];
+			const listener = (prev: string, current: string) => {
+				transitions.push({ prev, current });
+			};
+			ContextService.onAuthStatusChange(listener);
+
+			service.stopRevalidation();
+			service.startRevalidation(50);
+			await wait(120);
+			service.stopRevalidation();
+			ContextService.offAuthStatusChange(listener);
+
+			expect(transitions.length).toBeGreaterThanOrEqual(1);
+			expect(transitions[0]).toEqual({ prev: "unknown", current: "auth_error" });
+		});
+
+		it("onAuthStatusChange does not fire when status is stable", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+			globalThis.fetch = (async () => {
+				return new Response(JSON.stringify({}), { status: 200 });
+			}) as typeof globalThis.fetch;
+
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const transitions: Array<{ prev: string; current: string }> = [];
+			const listener = (prev: string, current: string) => {
+				transitions.push({ prev, current });
+			};
+			ContextService.onAuthStatusChange(listener);
+
+			service.stopRevalidation();
+			service.startRevalidation(50);
+			await wait(300);
+			service.stopRevalidation();
+			ContextService.offAuthStatusChange(listener);
+
+			expect(transitions).toEqual([{ prev: "unknown", current: "connected" }]);
+		});
+
+		it("context switch restarts the timer", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeContext(f5xcContextsDir, TEST_CONTEXT_2);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+			let fetchCount = 0;
+			globalThis.fetch = (async () => {
+				fetchCount++;
+				return new Response(JSON.stringify({}), { status: 200 });
+			}) as typeof globalThis.fetch;
+
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+			fetchCount = 0;
+			service.stopRevalidation();
+			service.startRevalidation(50);
+
+			await service.activate(TEST_CONTEXT_2.name);
+			fetchCount = 0;
+			await wait(250);
+			service.stopRevalidation();
+			expect(fetchCount).toBeGreaterThanOrEqual(2);
+		});
+
+		it("_resetForTest clears timer and listeners", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+			let fetchCount = 0;
+			globalThis.fetch = (async () => {
+				fetchCount++;
+				return new Response(JSON.stringify({}), { status: 200 });
+			}) as typeof globalThis.fetch;
+
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const listener = () => {};
+			ContextService.onAuthStatusChange(listener);
+			fetchCount = 0;
+			service.stopRevalidation();
+			service.startRevalidation(50);
+
+			ContextService._resetForTest();
+			const countAtReset = fetchCount;
+			await wait(200);
+			expect(fetchCount).toBe(countAtReset);
+		});
+
+		it("recursive setTimeout prevents overlap", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+			let fetchCount = 0;
+			let concurrent = 0;
+			let maxConcurrent = 0;
+			globalThis.fetch = (async () => {
+				concurrent++;
+				maxConcurrent = Math.max(maxConcurrent, concurrent);
+				fetchCount++;
+				await Bun.sleep(50);
+				concurrent--;
+				return new Response(JSON.stringify({}), { status: 200 });
+			}) as typeof globalThis.fetch;
+
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+			fetchCount = 0;
+			service.stopRevalidation();
+			service.startRevalidation(10);
+			await wait(300);
+			service.stopRevalidation();
+
+			expect(maxConcurrent).toBe(1);
+			expect(fetchCount).toBeLessThanOrEqual(5);
+		});
+	});
 });

--- a/packages/coding-agent/test/f5xc-table.test.ts
+++ b/packages/coding-agent/test/f5xc-table.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { initTheme } from "../src/modes/theme/theme";
 import { formatStatusIcon } from "../src/services/f5xc-context-indicators";
-import { formatAuthIndicator, renderF5XCTable } from "../src/services/f5xc-table";
+import { formatAuthIndicator, formatRotation, renderF5XCTable } from "../src/services/f5xc-table";
 
 const vw = (s: string) => (s ? Bun.stringWidth(s) : 0);
 const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
@@ -99,5 +99,29 @@ describe("renderF5XCTable", () => {
 		const lines = output.split("\n");
 		const widths = lines.map(l => vw(l));
 		expect(new Set(widths).size).toBe(1);
+	});
+});
+
+describe("formatRotation", () => {
+	const now = new Date("2026-04-27T12:00:00.000Z");
+
+	it("shows plain text when no lastRotatedAt", () => {
+		expect(formatRotation(30, undefined, now)).toBe("every 30 days");
+	});
+
+	it("shows plain text when rotation not due", () => {
+		expect(formatRotation(30, "2026-04-22T12:00:00.000Z", now)).toBe("every 30 days");
+	});
+
+	it("shows due-soon warning within 7 days of threshold", () => {
+		const result = formatRotation(30, "2026-03-31T12:00:00.000Z", now);
+		expect(result).toContain("every 30 days");
+		expect(result).toContain("rotation due in");
+	});
+
+	it("shows overdue warning when past threshold", () => {
+		const result = formatRotation(30, "2026-02-26T12:00:00.000Z", now);
+		expect(result).toContain("every 30 days");
+		expect(result).toContain("overdue by");
 	});
 });


### PR DESCRIPTION
## Summary

### Spec 6.1: F5 XC API Client Wrapper
- `F5XCApiClient` class with `listNamespaces`, `getNamespaceStatus`, `listObjects` and self-contained HTTP retry with exponential backoff
- `F5XCApiError` with `kind: "auth" | "network" | "server"` discriminant
- ContextService integration via `#refreshApiClient()` in `loadActive()` and `activate()`

### Spec 6.2: Namespace Discovery
- Migrate namespace cache from `validateToken()` fire-and-forget to `client.listNamespaces()` triggered on activation
- `validateToken()` cleaned up — response.ok branch: 34 lines -> 3 lines (pure auth)

### Spec 6.3: Background Token Re-validation
- `startRevalidation()`/`stopRevalidation()` with recursive `setTimeout` (no re-entrancy)
- `onAuthStatusChange`/`offAuthStatusChange` event pair fires on auth transitions
- SDK listener invalidates status bar + sends `sendCustomMessage` to agent

### Spec 6.4: Credential Refresh Warnings
- `TokenHealth` type (`ok | expiring | expired`) computed from `metadata.expiresAt` with 7-day threshold
- `onTokenHealthChange`/`offTokenHealthChange` event pair in re-validation tick
- `formatRotation()` shows overdue/due-soon warnings in `/context show`
- Status bar appends ⚠ suffix with warning/error colors for expiring/expired tokens
- SDK listener sends agent messages on token health degradation

## Test plan

- [ ] 17 client unit tests pass (`bun test packages/coding-agent/test/f5xc-api-client.test.ts`)
- [ ] 8 display tests pass (`bun test packages/coding-agent/test/f5xc-context-display.test.ts`)
- [ ] 5 integration tests (require native addon — CI)
- [ ] 10 namespace cache tests migrated (require native addon — CI)
- [ ] 7 background re-validation tests (require native addon — CI)
- [ ] 4 formatRotation tests (require native addon — CI)
- [ ] No regressions in existing tests
- [ ] `bun check` clean
- [ ] Biome lint clean

Closes #277