### PR TITLE
docs: add frontmatter descriptions and llms-config for llms.txt hierarchy

### DIFF
--- a/docs/configuration/blob-artifact-architecture.md
+++ b/docs/configuration/blob-artifact-architecture.md
@@ -1,5 +1,6 @@
 ---
 title: Blob and Artifact Storage Architecture
+description: Content-addressable blob store and artifact registry for session media, screenshots, and tool outputs.
 sidebar:
   order: 7
   label: Blob & artifact storage

--- a/docs/configuration/config-usage.md
+++ b/docs/configuration/config-usage.md
@@ -1,5 +1,6 @@
 ---
 title: Configuration Discovery and Resolution
+description: How xcsh discovers, resolves, and layers configuration from project, user, and enterprise roots.
 sidebar:
   order: 1
   label: Configuration

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -1,5 +1,6 @@
 ---
 title: Environment Variables
+description: Runtime environment variable reference for xcsh configuration and behavior control.
 sidebar:
   order: 2
   label: Environment variables

--- a/docs/configuration/fs-scan-cache-architecture.md
+++ b/docs/configuration/fs-scan-cache-architecture.md
@@ -1,5 +1,6 @@
 ---
 title: Filesystem Scan Cache Architecture
+description: Filesystem scan cache contract for fast file discovery with stale-while-revalidate semantics.
 sidebar:
   order: 8
   label: Filesystem scan cache

--- a/docs/configuration/hooks.md
+++ b/docs/configuration/hooks.md
@@ -1,5 +1,6 @@
 ---
 title: Hooks
+description: Hook system for pre/post event automation in the coding agent lifecycle.
 sidebar:
   order: 4
   label: Hooks

--- a/docs/configuration/porting-from-pi-mono.md
+++ b/docs/configuration/porting-from-pi-mono.md
@@ -1,5 +1,6 @@
 ---
 title: "Porting From pi-mono: A Practical Merge Guide"
+description: Practical guide for migrating code from the pi-mono monorepo into the xcsh codebase.
 sidebar:
   order: 9
   label: Porting from pi-mono

--- a/docs/configuration/rpc.md
+++ b/docs/configuration/rpc.md
@@ -1,5 +1,6 @@
 ---
 title: RPC Protocol Reference
+description: JSON-RPC protocol reference for inter-process communication between xcsh components.
 sidebar:
   order: 5
   label: RPC protocol

--- a/docs/configuration/sdk.md
+++ b/docs/configuration/sdk.md
@@ -1,5 +1,6 @@
 ---
 title: SDK
+description: SDK for building custom agents and integrations on top of the xcsh coding agent runtime.
 sidebar:
   order: 6
   label: SDK

--- a/docs/configuration/secrets.md
+++ b/docs/configuration/secrets.md
@@ -1,5 +1,6 @@
 ---
 title: Secret Obfuscation
+description: Secret obfuscation pipeline that redacts sensitive values from session logs and outputs.
 sidebar:
   order: 3
   label: Secrets

--- a/docs/extensions/extension-loading.md
+++ b/docs/extensions/extension-loading.md
@@ -1,5 +1,6 @@
 ---
 title: Extension Loading (TypeScript/JavaScript Modules)
+description: TypeScript and JavaScript module loading pipeline for extensions with resolution, validation, and caching.
 sidebar:
   order: 2
   label: Extension loading

--- a/docs/extensions/extensions.md
+++ b/docs/extensions/extensions.md
@@ -1,5 +1,6 @@
 ---
 title: Extensions
+description: Extension runtime overview covering types, runner lifecycle, registration, and discovery.
 sidebar:
   order: 1
   label: Overview

--- a/docs/extensions/gemini-manifest-extensions.md
+++ b/docs/extensions/gemini-manifest-extensions.md
@@ -1,5 +1,6 @@
 ---
 title: Gemini Manifest Extensions
+description: Gemini manifest extension format for cross-platform skill and agent compatibility.
 sidebar:
   order: 7
   label: Gemini manifest

--- a/docs/extensions/marketplace.md
+++ b/docs/extensions/marketplace.md
@@ -1,5 +1,6 @@
 ---
 title: Marketplace Plugin System
+description: Marketplace plugin system for discovering, installing, and managing curated plugin collections.
 sidebar:
   order: 4
   label: Marketplace

--- a/docs/extensions/plugin-manager-installer-plumbing.md
+++ b/docs/extensions/plugin-manager-installer-plumbing.md
@@ -1,5 +1,6 @@
 ---
 title: Plugin Manager and Installer Plumbing
+description: Plugin manager internals covering installation, validation, dependency resolution, and lifecycle management.
 sidebar:
   order: 5
   label: Plugin manager

--- a/docs/extensions/rulebook-matching-pipeline.md
+++ b/docs/extensions/rulebook-matching-pipeline.md
@@ -1,5 +1,6 @@
 ---
 title: Rulebook Matching Pipeline
+description: Rulebook matching pipeline for selecting and applying context-specific instruction sets to agent sessions.
 sidebar:
   order: 6
   label: Rulebook matching

--- a/docs/extensions/skills.md
+++ b/docs/extensions/skills.md
@@ -1,5 +1,6 @@
 ---
 title: Skills
+description: Skills system for registering, discovering, and invoking specialized capabilities in the coding agent.
 sidebar:
   order: 3
   label: Skills

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: xcsh Documentation
+description: AI-powered development CLI with TypeScript coding agent and Rust native layer for long-lived sessions, MCP support, and platform packaging.
 sidebar:
   order: 0
   label: Overview

--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -1,0 +1,46 @@
+{
+  "customSets": [
+    {
+      "label": "Configuration",
+      "description": "Config discovery, environment variables, hooks, secrets, and SDK reference",
+      "paths": ["configuration/**"]
+    },
+    {
+      "label": "Extensions",
+      "description": "Extension runtime, skills system, marketplace plugins, and rulebook matching",
+      "paths": ["extensions/**"]
+    },
+    {
+      "label": "MCP",
+      "description": "MCP server configuration, protocol transports, runtime lifecycle, and tool authoring",
+      "paths": ["mcp/**"]
+    },
+    {
+      "label": "Natives",
+      "description": "Rust N-API native addon architecture, binding contract, and subsystem internals",
+      "paths": ["natives/**"]
+    },
+    {
+      "label": "Providers",
+      "description": "Model configuration, provider streaming, and Python REPL runtime",
+      "paths": ["providers/**"]
+    },
+    {
+      "label": "Runtime Tools",
+      "description": "Bash, notebook, resolve tool runtimes, custom tools, and slash commands",
+      "paths": ["runtime-tools/**"]
+    },
+    {
+      "label": "Sessions",
+      "description": "Session storage, compaction, memory, handoff pipeline, and tree navigation",
+      "paths": ["sessions/**"]
+    },
+    {
+      "label": "TUI",
+      "description": "Terminal UI theming, tree command, extension integration, and runtime internals",
+      "paths": ["tui/**"]
+    }
+  ],
+  "promote": ["index*", "configuration/**", "sessions/**"],
+  "demote": ["natives/**"]
+}

--- a/docs/mcp/mcp-config.md
+++ b/docs/mcp/mcp-config.md
@@ -1,5 +1,6 @@
 ---
 title: MCP Configuration
+description: MCP server configuration, validation, and management for the coding agent runtime.
 sidebar:
   order: 1
   label: Configuration

--- a/docs/mcp/mcp-protocol-transports.md
+++ b/docs/mcp/mcp-protocol-transports.md
@@ -1,5 +1,6 @@
 ---
 title: MCP Protocol and Transport Internals
+description: MCP protocol implementation with stdio, SSE, and streamable HTTP transport layers.
 sidebar:
   order: 2
   label: Protocol & transports

--- a/docs/mcp/mcp-runtime-lifecycle.md
+++ b/docs/mcp/mcp-runtime-lifecycle.md
@@ -1,5 +1,6 @@
 ---
 title: MCP Runtime Lifecycle
+description: MCP server process lifecycle from initialization through tool registration, health monitoring, and shutdown.
 sidebar:
   order: 3
   label: Runtime lifecycle

--- a/docs/mcp/mcp-server-tool-authoring.md
+++ b/docs/mcp/mcp-server-tool-authoring.md
@@ -1,5 +1,6 @@
 ---
 title: MCP Server and Tool Authoring
+description: Guide to building custom MCP servers and registering tools for the coding agent.
 sidebar:
   order: 4
   label: Server & tool authoring

--- a/docs/natives/natives-addon-loader-runtime.md
+++ b/docs/natives/natives-addon-loader-runtime.md
@@ -1,5 +1,6 @@
 ---
 title: Natives Addon Loader Runtime
+description: N-API addon loader runtime with platform detection, fallback strategies, and module resolution.
 sidebar:
   order: 3
   label: Addon loader

--- a/docs/natives/natives-architecture.md
+++ b/docs/natives/natives-architecture.md
@@ -1,5 +1,6 @@
 ---
 title: Natives Architecture
+description: Rust N-API native addon architecture bridging TypeScript and platform-specific operations.
 sidebar:
   order: 1
   label: Architecture

--- a/docs/natives/natives-binding-contract.md
+++ b/docs/natives/natives-binding-contract.md
@@ -1,5 +1,6 @@
 ---
 title: Natives Binding Contract (TypeScript Side)
+description: TypeScript-side binding contract for calling into Rust native functions via N-API.
 sidebar:
   order: 2
   label: Binding contract

--- a/docs/natives/natives-build-release-debugging.md
+++ b/docs/natives/natives-build-release-debugging.md
@@ -1,5 +1,6 @@
 ---
 title: Natives Build, Release, and Debugging Runbook
+description: Build, release, and debugging runbook for the Rust native addon across platforms.
 sidebar:
   order: 8
   label: Build, release & debugging

--- a/docs/natives/natives-media-system-utils.md
+++ b/docs/natives/natives-media-system-utils.md
@@ -1,5 +1,6 @@
 ---
 title: Natives Media and System Utilities
+description: Native media processing utilities for screenshots, image handling, and system information.
 sidebar:
   order: 7
   label: Media & system utils

--- a/docs/natives/natives-rust-task-cancellation.md
+++ b/docs/natives/natives-rust-task-cancellation.md
@@ -1,5 +1,6 @@
 ---
 title: Native Rust Task Execution and Cancellation
+description: Rust async task execution model with cooperative cancellation and cleanup semantics.
 sidebar:
   order: 5
   label: Task cancellation

--- a/docs/natives/natives-shell-pty-process.md
+++ b/docs/natives/natives-shell-pty-process.md
@@ -1,5 +1,6 @@
 ---
 title: Natives Shell, PTY, Process, and Key Internals
+description: Shell execution, PTY management, process lifecycle, and key event handling in the native layer.
 sidebar:
   order: 4
   label: Shell, PTY & process

--- a/docs/natives/natives-text-search-pipeline.md
+++ b/docs/natives/natives-text-search-pipeline.md
@@ -1,5 +1,6 @@
 ---
 title: Natives Text and Search Pipeline
+description: Native text search pipeline with grep, glob, and ripgrep-based file content indexing.
 sidebar:
   order: 6
   label: Text & search pipeline

--- a/docs/natives/porting-to-natives.md
+++ b/docs/natives/porting-to-natives.md
@@ -1,5 +1,6 @@
 ---
 title: Porting to pi-natives (N-API) — Field Notes
+description: Field notes for migrating Node.js child_process and shell code to the Rust N-API native layer.
 sidebar:
   order: 9
   label: Porting to pi-natives

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -1,5 +1,6 @@
 ---
 title: Model and Provider Configuration
+description: Model registry and provider configuration via models.yml with routing, fallback, and pricing.
 sidebar:
   order: 1
   label: Models & providers

--- a/docs/providers/provider-streaming-internals.md
+++ b/docs/providers/provider-streaming-internals.md
@@ -1,5 +1,6 @@
 ---
 title: Provider Streaming Internals
+description: Provider streaming implementation with SSE parsing, token counting, and backpressure handling.
 sidebar:
   order: 2
   label: Streaming internals

--- a/docs/providers/python-repl.md
+++ b/docs/providers/python-repl.md
@@ -1,5 +1,6 @@
 ---
 title: Python Tool and IPython Runtime
+description: Python REPL tool runtime with IPython kernel management, execution, and output capture.
 sidebar:
   order: 3
   label: Python & IPython

--- a/docs/runtime-tools/bash-tool-runtime.md
+++ b/docs/runtime-tools/bash-tool-runtime.md
@@ -1,5 +1,6 @@
 ---
 title: Bash Tool Runtime
+description: Bash tool runtime with shell process management, sandboxing, timeout, and output streaming.
 sidebar:
   order: 1
   label: Bash tool

--- a/docs/runtime-tools/custom-tools.md
+++ b/docs/runtime-tools/custom-tools.md
@@ -1,5 +1,6 @@
 ---
 title: Custom Tools
+description: Custom tool registration, schema definition, and execution pipeline for extending the agent.
 sidebar:
   order: 4
   label: Custom tools

--- a/docs/runtime-tools/notebook-tool-runtime.md
+++ b/docs/runtime-tools/notebook-tool-runtime.md
@@ -1,5 +1,6 @@
 ---
 title: Notebook Tool Runtime Internals
+description: Jupyter notebook tool runtime with cell execution, kernel lifecycle, and output rendering.
 sidebar:
   order: 2
   label: Notebook tool

--- a/docs/runtime-tools/resolve-tool-runtime.md
+++ b/docs/runtime-tools/resolve-tool-runtime.md
@@ -1,5 +1,6 @@
 ---
 title: Resolve Tool Runtime Internals
+description: Resolve tool runtime for file path resolution, content fetching, and URL-based resource access.
 sidebar:
   order: 3
   label: Resolve tool

--- a/docs/runtime-tools/slash-command-internals.md
+++ b/docs/runtime-tools/slash-command-internals.md
@@ -1,5 +1,6 @@
 ---
 title: Slash Command Internals
+description: Slash command system internals with registration, argument parsing, and execution dispatch.
 sidebar:
   order: 5
   label: Slash commands

--- a/docs/runtime-tools/task-agent-discovery.md
+++ b/docs/runtime-tools/task-agent-discovery.md
@@ -1,5 +1,6 @@
 ---
 title: Task Agent Discovery and Selection
+description: Task agent discovery and selection logic for routing work to specialized subagent types.
 sidebar:
   order: 6
   label: Task agent discovery

--- a/docs/sessions/compaction.md
+++ b/docs/sessions/compaction.md
@@ -1,5 +1,6 @@
 ---
 title: Compaction and Branch Summaries
+description: Context window compaction and branch summary generation for long-lived sessions.
 sidebar:
   order: 5
   label: Compaction

--- a/docs/sessions/handoff-generation-pipeline.md
+++ b/docs/sessions/handoff-generation-pipeline.md
@@ -1,5 +1,6 @@
 ---
 title: Handoff Generation Pipeline
+description: Handoff generation pipeline for creating portable session summaries for team collaboration.
 sidebar:
   order: 8
   label: Handoff pipeline

--- a/docs/sessions/memory.md
+++ b/docs/sessions/memory.md
@@ -1,5 +1,6 @@
 ---
 title: Autonomous Memory
+description: Autonomous memory system for persisting user preferences, project context, and feedback across sessions.
 sidebar:
   order: 7
   label: Autonomous memory

--- a/docs/sessions/non-compaction-retry-policy.md
+++ b/docs/sessions/non-compaction-retry-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Non-Compaction Auto-Retry Policy
+description: Auto-retry policy for transient API failures outside the compaction path.
 sidebar:
   order: 6
   label: Retry policy

--- a/docs/sessions/session-operations-export-share-fork-resume.md
+++ b/docs/sessions/session-operations-export-share-fork-resume.md
@@ -1,5 +1,6 @@
 ---
 title: "Session Operations: Export, Dump, Share, Fork, Resume"
+description: Session operations for exporting, sharing, forking, and resuming conversations.
 sidebar:
   order: 3
   label: Operations

--- a/docs/sessions/session-switching-and-recent-listing.md
+++ b/docs/sessions/session-switching-and-recent-listing.md
@@ -1,5 +1,6 @@
 ---
 title: Session Switching and Recent Session Listing
+description: Session switching mechanics and recent session listing with search and filtering.
 sidebar:
   order: 4
   label: Switching & recent

--- a/docs/sessions/session-tree-plan.md
+++ b/docs/sessions/session-tree-plan.md
@@ -1,5 +1,6 @@
 ---
 title: Session Tree Architecture
+description: Session tree architecture with branching, navigation, and parent-child conversation relationships.
 sidebar:
   order: 2
   label: Tree architecture

--- a/docs/sessions/session.md
+++ b/docs/sessions/session.md
@@ -1,5 +1,6 @@
 ---
 title: Session Storage and Entry Model
+description: Append-only session storage model with entry types, persistence, and migration between formats.
 sidebar:
   order: 1
   label: Storage & entry model

--- a/docs/sessions/ttsr-injection-lifecycle.md
+++ b/docs/sessions/ttsr-injection-lifecycle.md
@@ -1,5 +1,6 @@
 ---
 title: TTSR Injection Lifecycle
+description: TTSR (tool-use, tool-result, system-reminder) injection lifecycle for context management.
 sidebar:
   order: 9
   label: TTSR injection

--- a/docs/tui/theme.md
+++ b/docs/tui/theme.md
@@ -1,5 +1,6 @@
 ---
 title: Theming Reference
+description: TUI theming reference with color tokens, font settings, and theme customization.
 sidebar:
   order: 3
   label: Theming

--- a/docs/tui/tree.md
+++ b/docs/tui/tree.md
@@ -1,5 +1,6 @@
 ---
 title: Tree Command Reference
+description: /tree command reference for visualizing session history and conversation branches.
 sidebar:
   order: 4
   label: /tree command

--- a/docs/tui/tui-runtime-internals.md
+++ b/docs/tui/tui-runtime-internals.md
@@ -1,5 +1,6 @@
 ---
 title: TUI Runtime Internals
+description: Terminal UI runtime internals covering rendering pipeline, input handling, and state management.
 sidebar:
   order: 2
   label: Runtime internals

--- a/docs/tui/tui.md
+++ b/docs/tui/tui.md
@@ -1,5 +1,6 @@
 ---
 title: TUI Integration for Extensions and Custom Tools
+description: TUI integration contract for extensions, custom tools, and custom renderers.
 sidebar:
   order: 1
   label: Extension integration


### PR DESCRIPTION
## What

Step 5 of the cascading llms.txt knowledge hierarchy — adds `description:` frontmatter to all 52 doc pages and creates `llms-config.json` with 8 custom sets (Configuration, Extensions, MCP, Natives, Providers, Runtime Tools, Sessions, TUI) so the starlight-llms-txt plugin generates tiered content output.

## Why

The llms.txt hierarchy requires page-level metadata to produce useful tiered output. Without `description:` frontmatter, the plugin cannot generate meaningful summaries. The 8 custom sets organize the doc sections into logical groups for consumption by LLM agents.

Closes #223

## Testing

- [x] Pre-commit hooks pass (governance, markdown lint, biome, spelling, editorconfig, secrets)
- [x] All 53 files staged and committed (52 modified docs + 1 new llms-config.json)
- [ ] CI checks pass
- [x] Issue linked via `Closes #223`