### PR TITLE
fix(ci): add retry with exponential backoff to Zig download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,14 +89,28 @@ jobs:
             ARM64) ZIG_ARCH=aarch64 ;;
           esac
           URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}.${EXT}"
+          OUTFILE="zig-download.${EXT}"
           echo "Downloading $URL"
+          MAX_RETRIES=3
+          DELAY=10
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Zig after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
           if [ "$EXT" = "zip" ]; then
-            curl -sSfL "$URL" -o zig.zip
-            unzip -q zig.zip
-            rm zig.zip
+            unzip -q "$OUTFILE"
           else
-            curl -sSfL "$URL" | tar -xJ
+            tar -xJf "$OUTFILE"
           fi
+          rm -f "$OUTFILE"
           ZIG_DIR="$PWD/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}"
           # Convert to Windows path if on Windows (Git Bash uses /d/... style)
           if [ "$RUNNER_OS" = "Windows" ]; then
@@ -161,14 +175,28 @@ jobs:
             ARM64) ZIG_ARCH=aarch64 ;;
           esac
           URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}.${EXT}"
+          OUTFILE="zig-download.${EXT}"
           echo "Downloading $URL"
+          MAX_RETRIES=3
+          DELAY=10
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Zig after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
           if [ "$EXT" = "zip" ]; then
-            curl -sSfL "$URL" -o zig.zip
-            unzip -q zig.zip
-            rm zig.zip
+            unzip -q "$OUTFILE"
           else
-            curl -sSfL "$URL" | tar -xJ
+            tar -xJf "$OUTFILE"
           fi
+          rm -f "$OUTFILE"
           ZIG_DIR="$PWD/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}"
           # Convert to Windows path if on Windows (Git Bash uses /d/... style)
           if [ "$RUNNER_OS" = "Windows" ]; then
@@ -226,14 +254,28 @@ jobs:
             ARM64) ZIG_ARCH=aarch64 ;;
           esac
           URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}.${EXT}"
+          OUTFILE="zig-download.${EXT}"
           echo "Downloading $URL"
+          MAX_RETRIES=3
+          DELAY=10
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Zig after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
           if [ "$EXT" = "zip" ]; then
-            curl -sSfL "$URL" -o zig.zip
-            unzip -q zig.zip
-            rm zig.zip
+            unzip -q "$OUTFILE"
           else
-            curl -sSfL "$URL" | tar -xJ
+            tar -xJf "$OUTFILE"
           fi
+          rm -f "$OUTFILE"
           ZIG_DIR="$PWD/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}"
           # Convert to Windows path if on Windows (Git Bash uses /d/... style)
           if [ "$RUNNER_OS" = "Windows" ]; then


### PR DESCRIPTION
## Problem

The Zig toolchain download in CI uses raw `curl` against `ziglang.org` with no retry logic. Transient DNS resolution failures (`curl: (6) Could not resolve host: ziglang.org`) on GitHub Actions runners kill the entire native build matrix and block releases.

This caused the v18.19.1 release pipeline failure: [run #25007295518](https://github.com/f5xc-salesdemos/xcsh/actions/runs/25007295518) — the `macos-15-intel` runner couldn't resolve `ziglang.org`, failing the native build, which skipped all downstream release jobs.

## Fix

Wrap the curl download in a retry loop with exponential backoff:
- **3 attempts** with **10s → 20s → 40s** backoff between retries
- **15s connect timeout** and **120s max-time** per attempt (catches hung connections)
- Download to a **file** instead of piping to tar — pipes can't be retried
- Clean error annotation (`::error::`) on final failure

Applied to all 3 identical Zig install blocks:
- `native` job (8-matrix build)
- `test` job
- `install_methods` job

## Why curl --retry isn't enough

`curl --retry` only retries on **HTTP-level** transient errors (5xx, timeouts). DNS resolution failures (exit code 6) are **not retried** by curl's built-in retry. A shell-level loop is required.

Fixes #359