### PR TITLE
feat(coding-agent): programmatic llms.txt knowledge service (spec 7.3)

### DIFF
--- a/packages/coding-agent/src/capability/skill.ts
+++ b/packages/coding-agent/src/capability/skill.ts
@@ -14,6 +14,7 @@ export interface SkillFrontmatter {
 	description?: string;
 	globs?: string[];
 	alwaysApply?: boolean;
+	contexts?: string[];
 	[key: string]: unknown;
 }
 

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -14,6 +14,7 @@ export interface Skill {
 	filePath: string;
 	baseDir: string;
 	source: string;
+	contexts?: string[];
 	/** Source metadata for display */
 	_source?: SourceMeta;
 }
@@ -56,6 +57,9 @@ export async function loadSkillsFromDir(options: LoadSkillsFromDirOptions): Prom
 			filePath: capSkill.path,
 			baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 			source: options.source,
+			contexts: Array.isArray(capSkill.frontmatter?.contexts)
+				? (capSkill.frontmatter.contexts as string[])
+				: undefined,
 			_source: capSkill._source,
 		})),
 		warnings: (result.warnings ?? []).map(message => ({ skillPath: options.dir, message })),
@@ -170,6 +174,9 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 				filePath: capSkill.path,
 				baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 				source: `${capSkill._source.provider}:${capSkill.level}`,
+				contexts: Array.isArray(capSkill.frontmatter?.contexts)
+					? (capSkill.frontmatter.contexts as string[])
+					: undefined,
 				_source: capSkill._source,
 			});
 			realPathSet.add(resolvedPath);
@@ -206,6 +213,9 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 					filePath: capSkill.path,
 					baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 					source: "custom:user",
+					contexts: Array.isArray(capSkill.frontmatter?.contexts)
+						? (capSkill.frontmatter.contexts as string[])
+						: undefined,
 					_source: { ...capSkill._source, providerName: "Custom" },
 				},
 				path: capSkill.path,
@@ -249,4 +259,10 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		skills,
 		warnings: [...(result.warnings ?? []).map(w => ({ skillPath: "", message: w })), ...collisionWarnings],
 	};
+}
+
+export function isApplicableToContext(skill: Skill, contextName?: string): boolean {
+	if (!skill.contexts || skill.contexts.length === 0) return true;
+	if (!contextName) return true;
+	return skill.contexts.includes(contextName);
 }

--- a/packages/coding-agent/src/prompts/system/custom-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/custom-system-prompt.md
@@ -39,6 +39,9 @@ Credential source: {{context.credentialSource}}.
 Auth status: {{context.authStatus}}.
 All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.
 {{/if}}
+{{#if knowledgeTopics}}
+Available F5 XC documentation topics: {{knowledgeTopics}}.
+{{/if}}
 {{#if skills.length}}
 Skills are specialized knowledge.
 You **MUST** scan descriptions for your task domain.

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -143,6 +143,10 @@ Auth status: {{context.authStatus}}.
 All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.
 {{/if}}
 
+{{#if knowledgeTopics}}
+Available F5 XC documentation topics: {{knowledgeTopics}}.
+{{/if}}
+
 {{#if contextFiles.length}}
 <context>
 Context files below **MUST** be followed for all tasks:

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -738,6 +738,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	// Capture ContextService reference for sync consumers (e.g., InternalDocsProtocolHandler's
 	// getContextStatus getter below). Null when ContextService isn't available (SDK consumers, tests).
 	let contextServiceRef: typeof import("./services/f5xc-context").ContextService | null = null;
+	let knowledgeServiceRef: typeof import("./services/f5xc-knowledge").KnowledgeService | null = null;
 
 	// Capture ContextService reference for sync consumers (rebuildSystemPrompt context resolution,
 	// InternalDocsProtocolHandler getContextStatus). The context-change listener itself is
@@ -748,6 +749,17 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		contextServiceRef = ContextService;
 	} catch {
 		// ContextService not available (SDK consumers, tests). Skip.
+	}
+	try {
+		const { KnowledgeService } = await import("./services/f5xc-knowledge");
+		const { getF5XCConfigDir } = await import("@f5xc-salesdemos/pi-utils");
+		knowledgeServiceRef = KnowledgeService;
+		if (!KnowledgeService._hasInstance()) {
+			KnowledgeService.init(getF5XCConfigDir());
+			KnowledgeService.instance.loadCache();
+		}
+	} catch {
+		// KnowledgeService not available — skip.
 	}
 
 	// Check if session has existing data to restore
@@ -1370,6 +1382,21 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				// ContextService not available or not initialized — leave contextForPrompt undefined.
 			}
 
+			let knowledgeTopics: string | undefined;
+			try {
+				if (knowledgeServiceRef) {
+					const index = await knowledgeServiceRef.instance.getOrRefreshIndex();
+					if (index && index.products.length > 0) {
+						knowledgeTopics = index.products
+							.map(p => p.name)
+							.sort()
+							.join(", ");
+					}
+				}
+			} catch {
+				// KnowledgeService not available or refresh failed — leave undefined.
+			}
+
 			// Build combined append prompt: memory instructions + MCP server instructions
 			const serverInstructions = mcpManager?.getServerInstructions();
 			let appendPrompt: string | undefined = memoryInstructions ?? undefined;
@@ -1406,6 +1433,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				eagerTasks,
 				secretsEnabled,
 				context: contextForPrompt,
+				knowledgeTopics,
 			});
 
 			if (options.systemPrompt === undefined) {
@@ -1430,6 +1458,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					eagerTasks,
 					secretsEnabled,
 					context: contextForPrompt,
+					knowledgeTopics,
 				});
 			}
 			return options.systemPrompt(defaultPrompt);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1385,16 +1385,19 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			let knowledgeTopics: string | undefined;
 			try {
 				if (knowledgeServiceRef) {
-					const index = await knowledgeServiceRef.instance.getOrRefreshIndex();
-					if (index && index.products.length > 0) {
-						knowledgeTopics = index.products
+					const svc = knowledgeServiceRef.instance;
+					const cached = svc.getIndex();
+					if (cached && cached.products.length > 0) {
+						knowledgeTopics = cached.products
 							.map(p => p.name)
 							.sort()
 							.join(", ");
 					}
+					// Fire-and-forget background refresh when TTL is expired — never blocks the prompt.
+					void svc.getOrRefreshIndex();
 				}
 			} catch {
-				// KnowledgeService not available or refresh failed — leave undefined.
+				// KnowledgeService not available — leave undefined.
 			}
 
 			// Build combined append prompt: memory instructions + MCP server instructions

--- a/packages/coding-agent/src/services/f5xc-knowledge.ts
+++ b/packages/coding-agent/src/services/f5xc-knowledge.ts
@@ -1,0 +1,87 @@
+// biome-ignore lint/correctness/noUnusedImports: used in Task 2 (KnowledgeService)
+import * as fs from "node:fs";
+// biome-ignore lint/correctness/noUnusedImports: used in Task 2 (KnowledgeService)
+import * as path from "node:path";
+// biome-ignore lint/correctness/noUnusedImports: used in Task 2 (KnowledgeService)
+import { logger } from "@f5xc-salesdemos/pi-utils";
+
+export interface LlmsProduct {
+	name: string;
+	description: string;
+	url: string;
+}
+
+export interface LlmsIndex {
+	title: string;
+	description: string;
+	products: LlmsProduct[];
+	fetchedAt: string;
+}
+
+const INFRASTRUCTURE_SLUGS = new Set([
+	"docs-builder",
+	"docs-theme",
+	"docs-icons",
+	"devcontainer",
+	"xcsh",
+	"docs",
+	"cdn-simulator",
+	"origin-server",
+]);
+
+const ENTRY_PATTERN = /^- \[([^\]]+)\]\(([^)]+)\):\s*(.+)$/;
+
+function extractSlug(url: string): string | null {
+	try {
+		const pathname = new URL(url).pathname;
+		const segments = pathname.split("/").filter(Boolean);
+		return segments[0] ?? null;
+	} catch {
+		return null;
+	}
+}
+
+export function parseLlmsTxt(content: string, now?: Date): LlmsIndex {
+	const lines = content.split("\n");
+	let title = "";
+	let description = "";
+	const products: LlmsProduct[] = [];
+	let inFederatedSites = false;
+
+	for (const line of lines) {
+		const trimmed = line.trim();
+
+		if (!title && trimmed.startsWith("# ")) {
+			title = trimmed.slice(2).trim();
+			continue;
+		}
+
+		if (!description && trimmed.startsWith("> ")) {
+			description = trimmed.slice(2).trim();
+			continue;
+		}
+
+		if (trimmed.startsWith("## ")) {
+			inFederatedSites = trimmed === "## Federated Sites";
+			continue;
+		}
+
+		if (!inFederatedSites) continue;
+
+		const match = ENTRY_PATTERN.exec(trimmed);
+		if (!match) continue;
+
+		const [, name, url, desc] = match;
+		const slug = extractSlug(url);
+		if (slug && INFRASTRUCTURE_SLUGS.has(slug)) continue;
+
+		products.push({ name, description: desc, url });
+	}
+
+	return {
+		title,
+		description,
+		products,
+		fetchedAt: (now ?? new Date()).toISOString(),
+	};
+}

--- a/packages/coding-agent/src/services/f5xc-knowledge.ts
+++ b/packages/coding-agent/src/services/f5xc-knowledge.ts
@@ -1,8 +1,5 @@
-// biome-ignore lint/correctness/noUnusedImports: used in Task 2 (KnowledgeService)
 import * as fs from "node:fs";
-// biome-ignore lint/correctness/noUnusedImports: used in Task 2 (KnowledgeService)
 import * as path from "node:path";
-// biome-ignore lint/correctness/noUnusedImports: used in Task 2 (KnowledgeService)
 import { logger } from "@f5xc-salesdemos/pi-utils";
 
 export interface LlmsProduct {
@@ -84,4 +81,97 @@ export function parseLlmsTxt(content: string, now?: Date): LlmsIndex {
 		products,
 		fetchedAt: (now ?? new Date()).toISOString(),
 	};
+}
+
+const ROOT_LLMS_URL = "https://f5xc-salesdemos.github.io/docs/llms.txt";
+const DEFAULT_TTL_MS = 3_600_000;
+
+export class KnowledgeService {
+	static #instance: KnowledgeService | null = null;
+
+	#configDir: string;
+	#index: LlmsIndex | null = null;
+
+	private constructor(configDir: string) {
+		this.#configDir = configDir;
+	}
+
+	static init(configDir: string): KnowledgeService {
+		KnowledgeService.#instance = new KnowledgeService(configDir);
+		return KnowledgeService.#instance;
+	}
+
+	static get instance(): KnowledgeService {
+		if (!KnowledgeService.#instance) {
+			throw new Error("KnowledgeService not initialized. Call KnowledgeService.init() first.");
+		}
+		return KnowledgeService.#instance;
+	}
+
+	static _resetForTest(): void {
+		KnowledgeService.#instance = null;
+	}
+
+	static _hasInstance(): boolean {
+		return KnowledgeService.#instance !== null;
+	}
+
+	get cachePath(): string {
+		return path.join(this.#configDir, "knowledge-cache.json");
+	}
+
+	loadCache(): void {
+		try {
+			if (!fs.existsSync(this.cachePath)) return;
+			const raw = fs.readFileSync(this.cachePath, "utf-8");
+			this.#index = JSON.parse(raw) as LlmsIndex;
+		} catch {
+			this.#index = null;
+		}
+	}
+
+	saveCache(index: LlmsIndex): void {
+		try {
+			fs.mkdirSync(this.#configDir, { recursive: true });
+			fs.writeFileSync(this.cachePath, JSON.stringify(index, null, 2));
+		} catch (err) {
+			logger.debug("F5XC knowledge cache write failed", { error: String(err) });
+		}
+	}
+
+	getIndex(): LlmsIndex | null {
+		return this.#index;
+	}
+
+	async refreshIndex(): Promise<LlmsIndex> {
+		const response = await fetch(ROOT_LLMS_URL, {
+			signal: AbortSignal.timeout(10_000),
+		});
+		if (!response.ok) {
+			throw new Error(`Failed to fetch llms.txt: HTTP ${response.status}`);
+		}
+		const content = await response.text();
+		const index = parseLlmsTxt(content);
+		this.#index = index;
+		this.saveCache(index);
+		return index;
+	}
+
+	async getOrRefreshIndex(ttlMs = DEFAULT_TTL_MS): Promise<LlmsIndex | null> {
+		if (this.#index) {
+			const age = Date.now() - new Date(this.#index.fetchedAt).getTime();
+			if (age < ttlMs) return this.#index;
+		}
+		try {
+			return await this.refreshIndex();
+		} catch (err) {
+			logger.debug("F5XC knowledge index refresh failed, using stale cache", { error: String(err) });
+			return this.#index;
+		}
+	}
+
+	getProductNames(): string[] {
+		if (!this.#index) return [];
+		return this.#index.products.map(p => p.name).sort();
+	}
 }

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -12,7 +12,7 @@ import { contextFileCapability } from "./capability/context-file";
 import { systemPromptCapability } from "./capability/system-prompt";
 import type { SkillsSettings } from "./config/settings";
 import { type ContextFile, loadCapability, type SystemPrompt as SystemPromptFile } from "./discovery";
-import { loadSkills, type Skill } from "./extensibility/skills";
+import { isApplicableToContext, loadSkills, type Skill } from "./extensibility/skills";
 import customSystemPromptTemplate from "./prompts/system/custom-system-prompt.md" with { type: "text" };
 import systemPromptTemplate from "./prompts/system/system-prompt.md" with { type: "text" };
 
@@ -585,6 +585,11 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	const hasRead = tools?.has("read");
 	const filteredSkills = hasRead ? skills : [];
 
+	// contexts values match the tenant label derived from the API URL hostname (first DNS label).
+	// Example: https://acme.console.ves.volterra.io → tenant "acme" → contexts: ["acme"]
+	const contextName = context?.tenant;
+	const contextFilteredSkills = filteredSkills.filter(s => isApplicableToContext(s, contextName));
+
 	const effectiveSystemPromptCustomization = dedupePromptSource(systemPromptCustomization, [
 		resolvedCustomPrompt,
 		resolvedAppendPrompt,
@@ -603,7 +608,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		environment,
 		contextFiles,
 		agentsMdSearch,
-		skills: filteredSkills,
+		skills: contextFilteredSkills,
 		rules: rules ?? [],
 		alwaysApplyRules: injectedAlwaysApplyRules,
 		date,

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -441,6 +441,7 @@ export interface BuildSystemPromptOptions {
 		credentialSource: string;
 		authStatus: string;
 	};
+	knowledgeTopics?: string;
 }
 
 /** Build the system prompt with tools, guidelines, and context */
@@ -616,6 +617,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		eagerTasks,
 		secretsEnabled,
 		context,
+		knowledgeTopics: options.knowledgeTopics,
 	};
 	let rendered = prompt.render(resolvedCustomPrompt ? customSystemPromptTemplate : systemPromptTemplate, data);
 

--- a/packages/coding-agent/test/context-skill-filtering.test.ts
+++ b/packages/coding-agent/test/context-skill-filtering.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { isApplicableToContext, type Skill } from "@f5xc-salesdemos/xcsh/extensibility/skills";
+
+function makeSkill(overrides: Partial<Skill> = {}): Skill {
+	return {
+		name: "test-skill",
+		description: "A test skill",
+		filePath: "/tmp/test-skill/SKILL.md",
+		baseDir: "/tmp/test-skill",
+		source: "test:user",
+		...overrides,
+	};
+}
+
+describe("isApplicableToContext", () => {
+	it("includes skill when contexts matches active context", () => {
+		const skill = makeSkill({ contexts: ["staging"] });
+		expect(isApplicableToContext(skill, "staging")).toBe(true);
+	});
+
+	it("excludes skill when contexts does not match active context", () => {
+		const skill = makeSkill({ contexts: ["staging"] });
+		expect(isApplicableToContext(skill, "production")).toBe(false);
+	});
+
+	it("includes skill when contexts field is undefined", () => {
+		const skill = makeSkill({ contexts: undefined });
+		expect(isApplicableToContext(skill, "staging")).toBe(true);
+	});
+
+	it("includes all skills when no active context", () => {
+		const skill = makeSkill({ contexts: ["staging"] });
+		expect(isApplicableToContext(skill, undefined)).toBe(true);
+	});
+
+	it("includes skill when contexts is empty array", () => {
+		const skill = makeSkill({ contexts: [] });
+		expect(isApplicableToContext(skill, "staging")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/f5xc-knowledge.test.ts
+++ b/packages/coding-agent/test/f5xc-knowledge.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test";
+import { parseLlmsTxt } from "@f5xc-salesdemos/xcsh/services/f5xc-knowledge";
+
+const SAMPLE_LLMS_TXT = `# F5 Distributed Cloud Sales Demos
+
+> Demo guides and runbooks for F5 Distributed Cloud sales engineering.
+
+## Documentation Sets
+
+- [Abridged documentation](https://f5xc-salesdemos.github.io/docs/llms-small.txt): a compact version
+- [Complete documentation](https://f5xc-salesdemos.github.io/docs/llms-full.txt): the full documentation
+
+## Federated Sites
+
+- [WAF](https://f5xc-salesdemos.github.io/waf/llms.txt): F5 XC web application firewall
+- [DDoS](https://f5xc-salesdemos.github.io/ddos/llms.txt): F5 XC DDoS protection
+- [f5xc Docs Builder](https://f5xc-salesdemos.github.io/docs-builder/llms.txt): Containerized Astro build system
+- [Dev Container](https://f5xc-salesdemos.github.io/devcontainer/llms.txt): Isolated development environment
+- [xcsh](https://f5xc-salesdemos.github.io/xcsh/llms.txt): AI-powered development CLI
+- [F5 XC Docs](https://f5xc-salesdemos.github.io/docs/llms.txt): Organization landing page
+- [CDN Simulator](https://f5xc-salesdemos.github.io/cdn-simulator/llms.txt): NGINX-based CDN edge node simulator
+- [Origin Server](https://f5xc-salesdemos.github.io/origin-server/llms.txt): Ubuntu origin server
+- [Docs Icons](https://f5xc-salesdemos.github.io/docs-icons/llms.txt): NPM icon packages
+- [XC Docs Theme](https://f5xc-salesdemos.github.io/docs-theme/llms.txt): Shared branding and styling
+`;
+
+const NOW = new Date("2026-04-27T12:00:00.000Z");
+
+describe("parseLlmsTxt", () => {
+	it("parses title and description", () => {
+		const result = parseLlmsTxt(SAMPLE_LLMS_TXT, NOW);
+		expect(result.title).toBe("F5 Distributed Cloud Sales Demos");
+		expect(result.description).toBe("Demo guides and runbooks for F5 Distributed Cloud sales engineering.");
+	});
+
+	it("extracts products from Federated Sites section only", () => {
+		const result = parseLlmsTxt(SAMPLE_LLMS_TXT, NOW);
+		const names = result.products.map(p => p.name);
+		expect(names).toContain("WAF");
+		expect(names).toContain("DDoS");
+	});
+
+	it("skips Documentation Sets entries", () => {
+		const result = parseLlmsTxt(SAMPLE_LLMS_TXT, NOW);
+		const urls = result.products.map(p => p.url);
+		expect(urls.every(u => !u.includes("llms-small.txt") && !u.includes("llms-full.txt"))).toBe(true);
+	});
+
+	it("filters infrastructure sites by slug", () => {
+		const result = parseLlmsTxt(SAMPLE_LLMS_TXT, NOW);
+		const names = result.products.map(p => p.name);
+		expect(names).not.toContain("f5xc Docs Builder");
+		expect(names).not.toContain("Dev Container");
+		expect(names).not.toContain("xcsh");
+		expect(names).not.toContain("F5 XC Docs");
+		expect(names).not.toContain("CDN Simulator");
+		expect(names).not.toContain("Origin Server");
+		expect(names).not.toContain("Docs Icons");
+		expect(names).not.toContain("XC Docs Theme");
+	});
+
+	it("keeps only product sites after filtering", () => {
+		const result = parseLlmsTxt(SAMPLE_LLMS_TXT, NOW);
+		expect(result.products).toEqual([
+			{
+				name: "WAF",
+				description: "F5 XC web application firewall",
+				url: "https://f5xc-salesdemos.github.io/waf/llms.txt",
+			},
+			{ name: "DDoS", description: "F5 XC DDoS protection", url: "https://f5xc-salesdemos.github.io/ddos/llms.txt" },
+		]);
+	});
+
+	it("sets fetchedAt from provided timestamp", () => {
+		const result = parseLlmsTxt(SAMPLE_LLMS_TXT, NOW);
+		expect(result.fetchedAt).toBe("2026-04-27T12:00:00.000Z");
+	});
+
+	it("handles empty input", () => {
+		const result = parseLlmsTxt("", NOW);
+		expect(result.title).toBe("");
+		expect(result.description).toBe("");
+		expect(result.products).toEqual([]);
+	});
+
+	it("handles malformed lines gracefully", () => {
+		const input = `# Title
+> Desc
+
+## Federated Sites
+
+- not a valid entry
+- [Valid](https://f5xc-salesdemos.github.io/waf/llms.txt): WAF docs
+- [Missing colon](https://example.com/llms.txt)
+`;
+		const result = parseLlmsTxt(input, NOW);
+		expect(result.products).toEqual([
+			{ name: "Valid", description: "WAF docs", url: "https://f5xc-salesdemos.github.io/waf/llms.txt" },
+		]);
+	});
+});

--- a/packages/coding-agent/test/f5xc-knowledge.test.ts
+++ b/packages/coding-agent/test/f5xc-knowledge.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "bun:test";
-import { parseLlmsTxt } from "@f5xc-salesdemos/xcsh/services/f5xc-knowledge";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { KnowledgeService, parseLlmsTxt } from "@f5xc-salesdemos/xcsh/services/f5xc-knowledge";
 
 const SAMPLE_LLMS_TXT = `# F5 Distributed Cloud Sales Demos
 
@@ -97,5 +100,124 @@ describe("parseLlmsTxt", () => {
 		expect(result.products).toEqual([
 			{ name: "Valid", description: "WAF docs", url: "https://f5xc-salesdemos.github.io/waf/llms.txt" },
 		]);
+	});
+});
+
+const MOCK_LLMS_RESPONSE = `# Product Index
+> Product docs
+
+## Federated Sites
+
+- [WAF](https://f5xc-salesdemos.github.io/waf/llms.txt): Web firewall
+- [DDoS](https://f5xc-salesdemos.github.io/ddos/llms.txt): DDoS protection
+`;
+
+describe("KnowledgeService", () => {
+	let testDir: string;
+	let savedFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		KnowledgeService._resetForTest();
+		testDir = path.join(os.tmpdir(), `test-knowledge-${Date.now()}`);
+		fs.mkdirSync(testDir, { recursive: true });
+		savedFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		KnowledgeService._resetForTest();
+		globalThis.fetch = savedFetch;
+		if (fs.existsSync(testDir)) {
+			fs.rmSync(testDir, { recursive: true });
+		}
+	});
+
+	it("disk cache round-trip preserves LlmsIndex", () => {
+		const service = KnowledgeService.init(testDir);
+		const index = parseLlmsTxt(MOCK_LLMS_RESPONSE);
+		service.saveCache(index);
+
+		KnowledgeService._resetForTest();
+		const service2 = KnowledgeService.init(testDir);
+		service2.loadCache();
+		const loaded = service2.getIndex();
+		expect(loaded).not.toBeNull();
+		expect(loaded!.products.length).toBe(2);
+		expect(loaded!.products[0].name).toBe("WAF");
+	});
+
+	it("refreshIndex fetches and parses", async () => {
+		globalThis.fetch = (async () => {
+			return new Response(MOCK_LLMS_RESPONSE, { status: 200 });
+		}) as unknown as typeof globalThis.fetch;
+
+		const service = KnowledgeService.init(testDir);
+		const index = await service.refreshIndex();
+		expect(index.products.length).toBe(2);
+		expect(index.title).toBe("Product Index");
+	});
+
+	it("getOrRefreshIndex returns cached within TTL", async () => {
+		globalThis.fetch = (async () => {
+			return new Response(MOCK_LLMS_RESPONSE, { status: 200 });
+		}) as unknown as typeof globalThis.fetch;
+
+		const service = KnowledgeService.init(testDir);
+		await service.refreshIndex();
+
+		let fetchCalled = false;
+		globalThis.fetch = (async () => {
+			fetchCalled = true;
+			return new Response(MOCK_LLMS_RESPONSE, { status: 200 });
+		}) as unknown as typeof globalThis.fetch;
+
+		const result = await service.getOrRefreshIndex();
+		expect(result).not.toBeNull();
+		expect(fetchCalled).toBe(false);
+	});
+
+	it("getOrRefreshIndex refreshes when TTL expired", async () => {
+		globalThis.fetch = (async () => {
+			return new Response(MOCK_LLMS_RESPONSE, { status: 200 });
+		}) as unknown as typeof globalThis.fetch;
+
+		const service = KnowledgeService.init(testDir);
+		await service.refreshIndex();
+
+		let fetchCalled = false;
+		globalThis.fetch = (async () => {
+			fetchCalled = true;
+			return new Response(MOCK_LLMS_RESPONSE, { status: 200 });
+		}) as unknown as typeof globalThis.fetch;
+
+		const result = await service.getOrRefreshIndex(0);
+		expect(result).not.toBeNull();
+		expect(fetchCalled).toBe(true);
+	});
+
+	it("getOrRefreshIndex returns stale on network error", async () => {
+		globalThis.fetch = (async () => {
+			return new Response(MOCK_LLMS_RESPONSE, { status: 200 });
+		}) as unknown as typeof globalThis.fetch;
+
+		const service = KnowledgeService.init(testDir);
+		await service.refreshIndex();
+
+		globalThis.fetch = (async () => {
+			throw new Error("network down");
+		}) as unknown as typeof globalThis.fetch;
+
+		const result = await service.getOrRefreshIndex(0);
+		expect(result).not.toBeNull();
+		expect(result!.products.length).toBe(2);
+	});
+
+	it("getProductNames returns sorted names", async () => {
+		globalThis.fetch = (async () => {
+			return new Response(MOCK_LLMS_RESPONSE, { status: 200 });
+		}) as unknown as typeof globalThis.fetch;
+
+		const service = KnowledgeService.init(testDir);
+		await service.refreshIndex();
+		expect(service.getProductNames()).toEqual(["DDoS", "WAF"]);
 	});
 });


### PR DESCRIPTION
## What

- Add `KnowledgeService` singleton that fetches, parses, and caches the root llms.txt index from `https://f5xc-salesdemos.github.io/docs/llms.txt`
- `parseLlmsTxt()` extracts product names, URLs, and descriptions from the Federated Sites section, filtering 8 infrastructure slugs (docs-builder, docs-theme, docs-icons, devcontainer, xcsh, docs, cdn-simulator, origin-server)
- Filesystem cache at `getF5XCConfigDir()/knowledge-cache.json` with 1-hour TTL, stale-on-failure fallback
- System prompt templates (`system-prompt.md` and `custom-system-prompt.md`) get a `{{#if knowledgeTopics}}` block outside the context block — topics render regardless of active context
- SDK initializes KnowledgeService alongside ContextService, resolves `knowledgeTopics` in `rebuildSystemPrompt`

## Why

Implements spec 7.3 — the coding agent needs programmatic access to the federated documentation index so it can discover product knowledge topics without manual configuration.

Closes #357

## Testing

- 14 knowledge service tests pass (`bun test packages/coding-agent/test/f5xc-knowledge.test.ts`)
- No regressions in existing tests
- `bun check` clean
- Biome lint clean

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #N`