### PR TITLE
fix(coding-agent): address Codex review findings for knowledge and skill filtering

### DIFF
--- a/packages/coding-agent/src/prompts/system/custom-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/custom-system-prompt.md
@@ -38,9 +38,9 @@ You are currently connected to F5 XC tenant: {{context.tenant}}, namespace: {{co
 Credential source: {{context.credentialSource}}.
 Auth status: {{context.authStatus}}.
 All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.
-{{/if}}
 {{#if knowledgeTopics}}
 Available F5 XC documentation topics: {{knowledgeTopics}}.
+{{/if}}
 {{/if}}
 {{#if skills.length}}
 Skills are specialized knowledge.

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -141,10 +141,9 @@ You are currently connected to F5 XC tenant: {{context.tenant}}, namespace: {{co
 Credential source: {{context.credentialSource}}.
 Auth status: {{context.authStatus}}.
 All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.
-{{/if}}
-
 {{#if knowledgeTopics}}
 Available F5 XC documentation topics: {{knowledgeTopics}}.
+{{/if}}
 {{/if}}
 
 {{#if contextFiles.length}}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1386,15 +1386,19 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			try {
 				if (knowledgeServiceRef) {
 					const svc = knowledgeServiceRef.instance;
-					const cached = svc.getIndex();
+					let cached = svc.getIndex();
+					if (!cached) {
+						await svc.getOrRefreshIndex();
+						cached = svc.getIndex();
+					} else {
+						void svc.getOrRefreshIndex();
+					}
 					if (cached && cached.products.length > 0) {
 						knowledgeTopics = cached.products
 							.map(p => p.name)
 							.sort()
 							.join(", ");
 					}
-					// Fire-and-forget background refresh when TTL is expired — never blocks the prompt.
-					void svc.getOrRefreshIndex();
 				}
 			} catch {
 				// KnowledgeService not available — leave undefined.
@@ -1809,6 +1813,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						attribution: "agent",
 					});
 					lastEmittedContext = { name: currentName, namespace: currentNamespace };
+					void session.refreshBaseSystemPrompt();
 				} catch {
 					// ContextService.instance throws if not initialized; skip.
 				}


### PR DESCRIPTION
## What

- Await `getOrRefreshIndex()` on first run when the knowledge cache is empty so the initial system prompt includes knowledge topics
- Add `refreshBaseSystemPrompt()` to the `onContextChange` listener so tenant-scoped skills re-filter after `/context activate`
- Move the `knowledgeTopics` template block inside the `{{#if context}}` guard to prevent F5 XC topic hints from leaking into non-F5XC sessions

## Why

Three P2 findings from Codex review of the knowledge service and skill filtering code. Without these fixes: (1) the first session after cache expiry silently omits knowledge topics from the prompt, (2) switching tenants via `/context activate` leaves stale skill filters in the system prompt, and (3) F5 XC documentation topic hints appear in sessions that have no active F5 XC context.

Refs #278

## Testing

- [ ] `bun run check` passes
- [ ] `bun test` -- no new failures vs baseline
- [x] Issue linked via `Refs #278`