### PR TITLE
feat(coding-agent): add custom knowledge source registration to F5XC contexts

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1404,6 +1404,20 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				// KnowledgeService not available — leave undefined.
 			}
 
+			let contextSkillDirs: string[] | undefined;
+			let contextIncludeSkills: string[] | undefined;
+			let contextExcludeSkills: string[] | undefined;
+			try {
+				if (contextServiceRef?.instance) {
+					const skillConfig = contextServiceRef.instance.getActiveContextSkillConfig();
+					if (skillConfig.skillDirs.length > 0) contextSkillDirs = skillConfig.skillDirs;
+					if (skillConfig.includeSkills.length > 0) contextIncludeSkills = skillConfig.includeSkills;
+					if (skillConfig.excludeSkills.length > 0) contextExcludeSkills = skillConfig.excludeSkills;
+				}
+			} catch {
+				// ContextService not available — leave undefined.
+			}
+
 			// Build combined append prompt: memory instructions + MCP server instructions
 			const serverInstructions = mcpManager?.getServerInstructions();
 			let appendPrompt: string | undefined = memoryInstructions ?? undefined;
@@ -1441,6 +1455,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				secretsEnabled,
 				context: contextForPrompt,
 				knowledgeTopics,
+				contextSkillDirs,
+				contextIncludeSkills,
+				contextExcludeSkills,
 			});
 
 			if (options.systemPrompt === undefined) {
@@ -1466,6 +1483,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					secretsEnabled,
 					context: contextForPrompt,
 					knowledgeTopics,
+					contextSkillDirs,
+					contextIncludeSkills,
+					contextExcludeSkills,
 				});
 			}
 			return options.systemPrompt(defaultPrompt);

--- a/packages/coding-agent/src/services/f5xc-context-command.ts
+++ b/packages/coding-agent/src/services/f5xc-context-command.ts
@@ -229,6 +229,19 @@ async function handleShow(ctx: CommandContext, service: ContextService, name?: s
 		});
 	}
 
+	if (context.knowledgeSources && context.knowledgeSources.length > 0) {
+		for (const src of context.knowledgeSources) {
+			const label = src.label ?? src.type ?? "source";
+			metaRows.push({ key: `Knowledge (${label})`, value: sanitize(src.url) });
+		}
+	}
+	if (context.includeSkills && context.includeSkills.length > 0) {
+		metaRows.push({ key: "Include Skills", value: sanitize(context.includeSkills.join(", ")) });
+	}
+	if (context.excludeSkills && context.excludeSkills.length > 0) {
+		metaRows.push({ key: "Exclude Skills", value: sanitize(context.excludeSkills.join(", ")) });
+	}
+
 	const dividers: Array<{ before: number; label: string }> = [{ before: envDividerIndex, label: "Environment" }];
 	if (metaRows.length > 0) {
 		dividers.push({ before: rows.length, label: "Metadata" });

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -33,6 +33,12 @@ export interface ImportResult {
 	skipped: string[];
 }
 
+export interface KnowledgeSource {
+	url: string;
+	label?: string;
+	type?: "llms-txt" | "skill-dir" | "docs-site";
+}
+
 export interface F5XCContext {
 	name: string;
 	apiUrl: string;
@@ -41,6 +47,9 @@ export interface F5XCContext {
 	env?: Record<string, string>;
 	/** Env var names from `env` whose values should be masked in output (e.g. ["F5XC_USERNAME"]). */
 	sensitiveKeys?: string[];
+	knowledgeSources?: KnowledgeSource[];
+	includeSkills?: string[];
+	excludeSkills?: string[];
 	version?: number;
 	metadata?: {
 		createdAt?: string;
@@ -997,6 +1006,15 @@ export class ContextService {
 		return [...this.#namespacesCache];
 	}
 
+	getActiveContextSkillConfig(): { skillDirs: string[]; includeSkills: string[]; excludeSkills: string[] } {
+		const ctx = this.#activeContext;
+		return {
+			skillDirs: ctx?.knowledgeSources?.filter(s => s.type === "skill-dir").map(s => s.url) ?? [],
+			includeSkills: ctx?.includeSkills ?? [],
+			excludeSkills: ctx?.excludeSkills ?? [],
+		};
+	}
+
 	maskToken(token: string): string {
 		if (token.length <= 4) return "****";
 		return `...${token.slice(-4)}`;
@@ -1105,6 +1123,31 @@ export class ContextService {
 			sensitiveKeys = filtered.length > 0 ? filtered : undefined;
 		}
 
+		let knowledgeSources: KnowledgeSource[] | undefined;
+		if (Array.isArray(parsed.knowledgeSources)) {
+			const validTypes = new Set(["llms-txt", "skill-dir", "docs-site"]);
+			const filtered = (parsed.knowledgeSources as unknown[]).filter((s): s is KnowledgeSource => {
+				if (!s || typeof s !== "object") return false;
+				const entry = s as Record<string, unknown>;
+				if (typeof entry.url !== "string") return false;
+				if ("type" in entry && !validTypes.has(entry.type as string)) return false;
+				return true;
+			});
+			knowledgeSources = filtered.length > 0 ? filtered : undefined;
+		}
+
+		let includeSkills: string[] | undefined;
+		if (Array.isArray(parsed.includeSkills)) {
+			const filtered = (parsed.includeSkills as unknown[]).filter((s): s is string => typeof s === "string");
+			includeSkills = filtered.length > 0 ? filtered : undefined;
+		}
+
+		let excludeSkills: string[] | undefined;
+		if (Array.isArray(parsed.excludeSkills)) {
+			const filtered = (parsed.excludeSkills as unknown[]).filter((s): s is string => typeof s === "string");
+			excludeSkills = filtered.length > 0 ? filtered : undefined;
+		}
+
 		return {
 			name: canonicalName,
 			apiUrl: parsed.apiUrl,
@@ -1112,6 +1155,9 @@ export class ContextService {
 			defaultNamespace: typeof parsed.defaultNamespace === "string" ? parsed.defaultNamespace : "default",
 			env,
 			sensitiveKeys,
+			knowledgeSources,
+			includeSkills,
+			excludeSkills,
 			version: typeof parsed.version === "number" ? parsed.version : undefined,
 			metadata:
 				parsed.metadata && typeof parsed.metadata === "object" && !Array.isArray(parsed.metadata)

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -486,6 +486,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 			...skillsSettings,
 			customDirectories: [...(skillsSettings?.customDirectories ?? []), ...(options.contextSkillDirs ?? [])],
 			includeSkills: [...(skillsSettings?.includeSkills ?? []), ...(options.contextIncludeSkills ?? [])],
+			// F5XCContext uses "excludeSkills"; SkillsSettings uses "ignoredSkills" — same semantics, different name.
 			ignoredSkills: [...(skillsSettings?.ignoredSkills ?? []), ...(options.contextExcludeSkills ?? [])],
 		};
 		const skillsPromise: Promise<Skill[]> =

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -442,6 +442,9 @@ export interface BuildSystemPromptOptions {
 		authStatus: string;
 	};
 	knowledgeTopics?: string;
+	contextSkillDirs?: string[];
+	contextIncludeSkills?: string[];
+	contextExcludeSkills?: string[];
 }
 
 /** Build the system prompt with tools, guidelines, and context */
@@ -479,11 +482,17 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 			? Promise.resolve(providedContextFiles)
 			: logger.time("loadProjectContextFiles", loadProjectContextFiles, { cwd: resolvedCwd });
 		const agentsMdSearchPromise = logger.time("buildAgentsMdSearch", buildAgentsMdSearch, resolvedCwd);
+		const mergedSkillsSettings = {
+			...skillsSettings,
+			customDirectories: [...(skillsSettings?.customDirectories ?? []), ...(options.contextSkillDirs ?? [])],
+			includeSkills: [...(skillsSettings?.includeSkills ?? []), ...(options.contextIncludeSkills ?? [])],
+			ignoredSkills: [...(skillsSettings?.ignoredSkills ?? []), ...(options.contextExcludeSkills ?? [])],
+		};
 		const skillsPromise: Promise<Skill[]> =
 			providedSkills !== undefined
 				? Promise.resolve(providedSkills)
-				: skillsSettings?.enabled !== false
-					? loadSkills({ ...skillsSettings, cwd: resolvedCwd }).then(result => result.skills)
+				: mergedSkillsSettings?.enabled !== false
+					? loadSkills({ ...mergedSkillsSettings, cwd: resolvedCwd }).then(result => result.skills)
 					: Promise.resolve([]);
 
 		return Promise.all([

--- a/packages/coding-agent/test/f5xc-context-knowledge.test.ts
+++ b/packages/coding-agent/test/f5xc-context-knowledge.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Snowflake } from "@f5xc-salesdemos/pi-utils";
+import { _resetSettingsForTest, Settings } from "@f5xc-salesdemos/xcsh/config/settings";
+import { ContextService, type F5XCContext } from "@f5xc-salesdemos/xcsh/services/f5xc-context";
+import {
+	TEST_CONTEXT as _TEST_CONTEXT,
+	TEST_CONTEXT_WITH_KNOWLEDGE as _TEST_CONTEXT_WITH_KNOWLEDGE,
+} from "./f5xc-test-fixtures";
+
+const TEST_CONTEXT: F5XCContext = { ..._TEST_CONTEXT };
+const TEST_CONTEXT_WITH_KNOWLEDGE: F5XCContext = { ..._TEST_CONTEXT_WITH_KNOWLEDGE };
+
+function writeContext(contextsDir: string, context: F5XCContext): void {
+	fs.mkdirSync(contextsDir, { recursive: true });
+	fs.writeFileSync(path.join(contextsDir, `${context.name}.json`), JSON.stringify(context, null, 2), { mode: 0o600 });
+}
+
+function writeActiveContext(configDir: string, name: string): void {
+	fs.writeFileSync(path.join(configDir, "active_context"), name, { mode: 0o644 });
+}
+
+describe("ContextService knowledge sources", () => {
+	let testDir: string;
+	let f5xcConfigDir: string;
+	let f5xcContextsDir: string;
+	let projectDir: string;
+	let agentDir: string;
+
+	const savedEnv: Record<string, string | undefined> = {};
+
+	beforeEach(async () => {
+		_resetSettingsForTest();
+		ContextService._resetForTest();
+		testDir = path.join(os.tmpdir(), `xcsh-test-knowledge-${Snowflake.generate()}`);
+		f5xcConfigDir = path.join(testDir, "f5xc");
+		f5xcContextsDir = path.join(f5xcConfigDir, "contexts");
+		projectDir = path.join(testDir, "project");
+		agentDir = path.join(testDir, "agent");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.mkdirSync(f5xcConfigDir, { recursive: true });
+
+		savedEnv.F5XC_API_URL = process.env.F5XC_API_URL;
+		savedEnv.F5XC_API_TOKEN = process.env.F5XC_API_TOKEN;
+		savedEnv.F5XC_NAMESPACE = process.env.F5XC_NAMESPACE;
+		delete process.env.F5XC_API_URL;
+		delete process.env.F5XC_API_TOKEN;
+		delete process.env.F5XC_NAMESPACE;
+
+		await Settings.init({ cwd: projectDir, agentDir, inMemory: true });
+	});
+
+	afterEach(() => {
+		ContextService._resetForTest();
+		_resetSettingsForTest();
+		for (const [key, value] of Object.entries(savedEnv)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		fs.rmSync(testDir, { recursive: true, force: true });
+	});
+
+	it("round-trips knowledgeSources through create and read", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT_WITH_KNOWLEDGE);
+		const service = ContextService.init(f5xcConfigDir);
+		const contexts = await service.listContexts();
+		const ctx = contexts.find(c => c.name === "with-knowledge");
+		expect(ctx).toBeDefined();
+		expect(ctx?.knowledgeSources).toHaveLength(2);
+		expect(ctx?.knowledgeSources?.[0].type).toBe("skill-dir");
+		expect(ctx?.knowledgeSources?.[1].url).toBe("https://example.com/llms.txt");
+		expect(ctx?.includeSkills).toEqual(["f5xc-*"]);
+		expect(ctx?.excludeSkills).toEqual(["deprecated-*"]);
+	});
+
+	it("export/import round-trip preserves new fields", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT_WITH_KNOWLEDGE);
+		const service = ContextService.init(f5xcConfigDir);
+		const bundle = await service.exportContexts({ includeToken: true });
+
+		const importDir = path.join(testDir, "import");
+		const importConfigDir = path.join(importDir, "f5xc");
+		fs.mkdirSync(path.join(importConfigDir, "contexts"), { recursive: true });
+		ContextService._resetForTest();
+		_resetSettingsForTest();
+		await Settings.init({ cwd: projectDir, agentDir, inMemory: true });
+		const importService = ContextService.init(importConfigDir);
+		await importService.importContexts(bundle, { overwrite: false });
+
+		const contexts = await importService.listContexts();
+		const ctx = contexts.find(c => c.name === "with-knowledge");
+		expect(ctx?.knowledgeSources).toHaveLength(2);
+		expect(ctx?.includeSkills).toEqual(["f5xc-*"]);
+		expect(ctx?.excludeSkills).toEqual(["deprecated-*"]);
+	});
+
+	it("getActiveContextSkillConfig returns skill-dir URLs only", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT_WITH_KNOWLEDGE);
+		writeActiveContext(f5xcConfigDir, "with-knowledge");
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const config = service.getActiveContextSkillConfig();
+		expect(config.skillDirs).toEqual(["/home/test/skills"]);
+		expect(config.includeSkills).toEqual(["f5xc-*"]);
+		expect(config.excludeSkills).toEqual(["deprecated-*"]);
+	});
+
+	it("getActiveContextSkillConfig returns empty for plain context", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT);
+		writeActiveContext(f5xcConfigDir, "production");
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const config = service.getActiveContextSkillConfig();
+		expect(config.skillDirs).toEqual([]);
+		expect(config.includeSkills).toEqual([]);
+		expect(config.excludeSkills).toEqual([]);
+	});
+
+	it("validates and preserves well-formed knowledgeSources", async () => {
+		const context: F5XCContext = {
+			...TEST_CONTEXT,
+			name: "valid-sources",
+			knowledgeSources: [
+				{ url: "https://example.com/llms.txt", type: "llms-txt" },
+				{ url: "/path/to/skills", type: "skill-dir", label: "My Skills" },
+				{ url: "https://docs.example.com", type: "docs-site" },
+			],
+		};
+		writeContext(f5xcContextsDir, context);
+		const service = ContextService.init(f5xcConfigDir);
+		const contexts = await service.listContexts();
+		const ctx = contexts.find(c => c.name === "valid-sources");
+		expect(ctx?.knowledgeSources).toHaveLength(3);
+	});
+
+	it("drops malformed knowledgeSources entries", async () => {
+		const rawContext = {
+			...TEST_CONTEXT,
+			name: "bad-sources",
+			knowledgeSources: [
+				{ url: "https://valid.com/llms.txt", type: "llms-txt" },
+				{ noUrl: true },
+				{ url: 123 },
+				{ url: "https://bad-type.com", type: "invalid-type" },
+				"not-an-object",
+			],
+		};
+		writeContext(f5xcContextsDir, rawContext as unknown as F5XCContext);
+		const service = ContextService.init(f5xcConfigDir);
+		const contexts = await service.listContexts();
+		const ctx = contexts.find(c => c.name === "bad-sources");
+		expect(ctx?.knowledgeSources).toHaveLength(1);
+		expect(ctx?.knowledgeSources?.[0].url).toBe("https://valid.com/llms.txt");
+	});
+
+	it("loads contexts without knowledgeSources unchanged (backward compat)", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT);
+		const service = ContextService.init(f5xcConfigDir);
+		const contexts = await service.listContexts();
+		const ctx = contexts.find(c => c.name === "production");
+		expect(ctx).toBeDefined();
+		expect(ctx?.knowledgeSources).toBeUndefined();
+		expect(ctx?.includeSkills).toBeUndefined();
+		expect(ctx?.excludeSkills).toBeUndefined();
+		expect(ctx?.apiUrl).toBe(TEST_CONTEXT.apiUrl);
+	});
+});

--- a/packages/coding-agent/test/f5xc-context-knowledge.test.ts
+++ b/packages/coding-agent/test/f5xc-context-knowledge.test.ts
@@ -11,7 +11,7 @@ import {
 } from "./f5xc-test-fixtures";
 
 const TEST_CONTEXT: F5XCContext = { ..._TEST_CONTEXT };
-const TEST_CONTEXT_WITH_KNOWLEDGE: F5XCContext = structuredClone(_TEST_CONTEXT_WITH_KNOWLEDGE) as F5XCContext;
+const TEST_CONTEXT_WITH_KNOWLEDGE = structuredClone(_TEST_CONTEXT_WITH_KNOWLEDGE) as unknown as F5XCContext;
 
 function writeContext(contextsDir: string, context: F5XCContext): void {
 	fs.mkdirSync(contextsDir, { recursive: true });

--- a/packages/coding-agent/test/f5xc-context-knowledge.test.ts
+++ b/packages/coding-agent/test/f5xc-context-knowledge.test.ts
@@ -11,7 +11,7 @@ import {
 } from "./f5xc-test-fixtures";
 
 const TEST_CONTEXT: F5XCContext = { ..._TEST_CONTEXT };
-const TEST_CONTEXT_WITH_KNOWLEDGE: F5XCContext = { ..._TEST_CONTEXT_WITH_KNOWLEDGE };
+const TEST_CONTEXT_WITH_KNOWLEDGE: F5XCContext = structuredClone(_TEST_CONTEXT_WITH_KNOWLEDGE) as F5XCContext;
 
 function writeContext(contextsDir: string, context: F5XCContext): void {
 	fs.mkdirSync(contextsDir, { recursive: true });
@@ -34,7 +34,7 @@ describe("ContextService knowledge sources", () => {
 	beforeEach(async () => {
 		_resetSettingsForTest();
 		ContextService._resetForTest();
-		testDir = path.join(os.tmpdir(), `xcsh-test-knowledge-${Snowflake.generate()}`);
+		testDir = path.join(os.tmpdir(), `xcsh-test-knowledge-${Snowflake.next()}`);
 		f5xcConfigDir = path.join(testDir, "f5xc");
 		f5xcContextsDir = path.join(f5xcConfigDir, "contexts");
 		projectDir = path.join(testDir, "project");

--- a/packages/coding-agent/test/f5xc-test-fixtures.ts
+++ b/packages/coding-agent/test/f5xc-test-fixtures.ts
@@ -74,3 +74,17 @@ export const TEST_CONTEXT_INCOMPATIBLE = {
 	defaultNamespace: TEST_F5XC_NAMESPACE,
 	version: 2,
 } as const;
+
+/** Context with knowledge sources and skill filters for #356 tests */
+export const TEST_CONTEXT_WITH_KNOWLEDGE = {
+	name: "with-knowledge",
+	apiUrl: TEST_F5XC_URL,
+	apiToken: TEST_F5XC_TOKEN,
+	defaultNamespace: TEST_F5XC_NAMESPACE,
+	knowledgeSources: [
+		{ url: "/home/test/skills", type: "skill-dir" as const, label: "Custom Skills" },
+		{ url: "https://example.com/llms.txt", type: "llms-txt" as const },
+	],
+	includeSkills: ["f5xc-*"],
+	excludeSkills: ["deprecated-*"],
+} as const;


### PR DESCRIPTION
## What

Add custom knowledge source registration to F5XC context definitions. Contexts can now declare `knowledgeSources` (skill-dir, llms-txt, docs-site), `includeSkills`, and `excludeSkills` fields.

## Why

Custom knowledge source registration allows F5XC contexts to declare skill directories, documentation endpoints, and per-context skill include/exclude patterns. Skill-dir entries are injected into skill discovery at composition time, and context switching automatically re-filters via `refreshBaseSystemPrompt`. Part of #278 knowledge ecosystem integration.

Closes #356

## Testing

- New test file `f5xc-context-knowledge.test.ts` covers knowledge source registration, skill filtering, and context switching behavior
- Pre-commit hooks pass (biome lint, spelling, secrets detection, large file check)

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #356`