### PR TITLE
fix(coding-agent): resolve context display inconsistency in env-only mode

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -158,7 +158,7 @@ async function checkContextStatus(): Promise<WelcomeContextStatus> {
 			status.activeContextName ??
 			(status.credentialSource === "environment" && status.activeContextUrl
 				? (deriveTenantFromUrl(status.activeContextUrl) ?? "(environment)")
-				: null);
+				: undefined);
 		const result = await validateContextWithStartupRetry(opts => contextService.validateToken(opts));
 
 		switch (result.status) {

--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -2,6 +2,7 @@ import type { Model } from "@f5xc-salesdemos/pi-ai";
 import { validateApiKeyAgainstModelsEndpoint } from "@f5xc-salesdemos/pi-ai/utils/oauth/api-key-validation";
 import { logger } from "@f5xc-salesdemos/pi-utils";
 import { type AuthStatus, ContextService } from "../../services/f5xc-context";
+import { deriveTenantFromUrl } from "../../services/f5xc-env";
 import type { AuthStorage } from "../../session/auth-storage";
 
 // Startup validation budget. These are longer than validateToken's 3000ms default because
@@ -153,7 +154,11 @@ async function checkContextStatus(): Promise<WelcomeContextStatus> {
 			return { state: "no_context" };
 		}
 
-		const name = status.activeContextName ?? "default";
+		const name =
+			status.activeContextName ??
+			(status.credentialSource === "environment" && status.activeContextUrl
+				? (deriveTenantFromUrl(status.activeContextUrl) ?? "(environment)")
+				: null);
 		const result = await validateContextWithStartupRetry(opts => contextService.validateToken(opts));
 
 		switch (result.status) {

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -220,7 +220,7 @@ export class WelcomeComponent implements Component {
 	#renderContextStatus(): string[] {
 		if (!this.contextStatus) return [];
 		const { state, name, latencyMs } = this.contextStatus;
-		const n = name ?? "default";
+		const n = name ?? "(unknown)";
 		switch (state) {
 			case "connected":
 				return [

--- a/packages/coding-agent/src/services/f5xc-context-command.ts
+++ b/packages/coding-agent/src/services/f5xc-context-command.ts
@@ -125,6 +125,12 @@ function splitArgs(args: string[], knownFlags: Set<string>): { positionals: stri
 async function handleList(ctx: CommandContext, service: ContextService): Promise<void> {
 	const contexts = await service.listContexts();
 	if (contexts.length === 0) {
+		const status = service.getStatus();
+		if (status.credentialSource === "environment" && status.activeContextUrl) {
+			const label = deriveTenantFromUrl(status.activeContextUrl) ?? "(environment)";
+			ctx.showStatus(`  * ${sanitize(label).padEnd(20)} ${sanitize(status.activeContextUrl)}  (via env vars)`);
+			return;
+		}
 		ctx.showStatus("No F5 XC contexts found. Use /context create or ask me to help set one up.");
 		return;
 	}

--- a/packages/coding-agent/test/f5xc-context-command.test.ts
+++ b/packages/coding-agent/test/f5xc-context-command.test.ts
@@ -247,6 +247,20 @@ describe("/context slash command handler", () => {
 		expect(ctx.messages[0].text).toContain("No F5 XC contexts found");
 	});
 
+	it("/context list shows env-only entry when F5XC_API_URL is set", async () => {
+		process.env.F5XC_API_URL = "https://acme.console.ves.volterra.io";
+		process.env.F5XC_API_TOKEN = "FAKE-TOKEN";
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const ctx = createMockCtx();
+		await handleContextCommand({ name: "context", args: "list", text: "/context list" }, ctx);
+
+		expect(ctx.messages[0].type).toBe("status");
+		expect(ctx.messages[0].text).toContain("acme");
+		expect(ctx.messages[0].text).toContain("via env vars");
+	});
+
 	it("/context activate switches context", async () => {
 		writeContext(f5xcContextsDir, TEST_CONTEXT);
 		writeContext(f5xcContextsDir, TEST_CONTEXT_2);


### PR DESCRIPTION
## What

Fix the disagreement between `/context list` and the welcome screen when
F5XC credentials come from environment variables (`F5XC_API_URL`) rather
than persisted context files.

- `/context list` now includes the env-only entry with the tenant label
  derived from the URL
- Welcome screen derives the tenant name from `F5XC_API_URL` instead of
  hardcoding "default"

## Why

When `F5XC_API_URL` is set without any persisted contexts, the welcome
screen showed `default` as the tenant while `/context list` reported
"no contexts." Users had no way to verify which tenant was active.

Closes #371

## Testing

- New test in `f5xc-context-command.test.ts` covers the env-only path
- Existing tests unchanged and passing

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #371`