### PR TITLE
chore: bump version to v18.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "pi-natives"
-version = "18.21.1"
+version = "18.22.0"
 dependencies = [
  "arboard",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/brush-core-vendored", "crates/brush-builtins-vendored", "crat
 resolver = "3"
 
 [workspace.package]
-version = "18.21.1"
+version = "18.22.0"
 edition = "2024"
 license = "MIT"
 authors = ["Can Boluk"]

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "packages/agent": {
       "name": "@f5xc-salesdemos/pi-agent-core",
-      "version": "18.21.1",
+      "version": "18.22.0",
       "dependencies": {
         "@f5xc-salesdemos/pi-ai": "workspace:*",
         "@f5xc-salesdemos/pi-utils": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "packages/ai": {
       "name": "@f5xc-salesdemos/pi-ai",
-      "version": "18.21.1",
+      "version": "18.22.0",
       "bin": {
         "pi-ai": "./src/cli.ts",
       },
@@ -51,7 +51,7 @@
     },
     "packages/coding-agent": {
       "name": "@f5xc-salesdemos/xcsh",
-      "version": "18.21.1",
+      "version": "18.22.0",
       "bin": {
         "xcsh": "src/cli.ts",
       },
@@ -83,22 +83,22 @@
     },
     "packages/natives": {
       "name": "@f5xc-salesdemos/pi-natives",
-      "version": "18.21.1",
+      "version": "18.22.0",
       "devDependencies": {
         "@napi-rs/cli": "3.6.0",
         "@types/bun": "^1.3",
       },
       "optionalDependencies": {
-        "@f5xc-salesdemos/pi-natives-darwin-arm64": "18.21.1",
-        "@f5xc-salesdemos/pi-natives-darwin-x64": "18.21.1",
-        "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.21.1",
-        "@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.21.1",
-        "@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.21.1",
+        "@f5xc-salesdemos/pi-natives-darwin-arm64": "18.22.0",
+        "@f5xc-salesdemos/pi-natives-darwin-x64": "18.22.0",
+        "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.22.0",
+        "@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.22.0",
+        "@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.22.0",
       },
     },
     "packages/stats": {
       "name": "@f5xc-salesdemos/xcsh-stats",
-      "version": "18.21.1",
+      "version": "18.22.0",
       "bin": {
         "xcsh-stats": "./src/index.ts",
       },
@@ -123,7 +123,7 @@
     },
     "packages/swarm-extension": {
       "name": "@f5xc-salesdemos/swarm-extension",
-      "version": "18.21.1",
+      "version": "18.22.0",
       "bin": {
         "xcsh-swarm": "src/cli.ts",
       },
@@ -139,7 +139,7 @@
     },
     "packages/tui": {
       "name": "@f5xc-salesdemos/pi-tui",
-      "version": "18.21.1",
+      "version": "18.22.0",
       "dependencies": {
         "@f5xc-salesdemos/pi-natives": "workspace:*",
         "@f5xc-salesdemos/pi-utils": "workspace:*",
@@ -178,7 +178,7 @@
     },
     "packages/utils": {
       "name": "@f5xc-salesdemos/pi-utils",
-      "version": "18.21.1",
+      "version": "18.22.0",
       "dependencies": {
         "beautiful-mermaid": "^1.1",
         "handlebars": "^4.7.9",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-agent-core",
-	"version": "18.21.1",
+	"version": "18.22.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-ai",
-	"version": "18.21.1",
+	"version": "18.22.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/xcsh",
-	"version": "18.21.1",
+	"version": "18.22.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-arm64/package.json
+++ b/packages/natives/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-darwin-arm64",
-	"version": "18.21.1",
+	"version": "18.22.0",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (macOS arm64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-x64/package.json
+++ b/packages/natives/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-darwin-x64",
-	"version": "18.21.1",
+	"version": "18.22.0",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (macOS x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-arm64-gnu/package.json
+++ b/packages/natives/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-linux-arm64-gnu",
-	"version": "18.21.1",
+	"version": "18.22.0",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Linux arm64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-x64-gnu/package.json
+++ b/packages/natives/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-linux-x64-gnu",
-	"version": "18.21.1",
+	"version": "18.22.0",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Linux x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/win32-x64-msvc/package.json
+++ b/packages/natives/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-win32-x64-msvc",
-	"version": "18.21.1",
+	"version": "18.22.0",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Windows x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives",
-	"version": "18.21.1",
+	"version": "18.22.0",
 	"description": "Native Rust bindings for grep, clipboard, image processing, syntax highlighting, PTY, and shell operations via N-API",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",
@@ -56,11 +56,11 @@
 		}
 	},
 	"optionalDependencies": {
-		"@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.21.1",
-		"@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.21.1",
-		"@f5xc-salesdemos/pi-natives-darwin-x64": "18.21.1",
-		"@f5xc-salesdemos/pi-natives-darwin-arm64": "18.21.1",
-		"@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.21.1"
+		"@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.22.0",
+		"@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.22.0",
+		"@f5xc-salesdemos/pi-natives-darwin-x64": "18.22.0",
+		"@f5xc-salesdemos/pi-natives-darwin-arm64": "18.22.0",
+		"@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.22.0"
 	},
 	"files": [
 		"native",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/xcsh-stats",
-	"version": "18.21.1",
+	"version": "18.22.0",
 	"description": "Local observability dashboard for pi AI usage statistics",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/swarm-extension/package.json
+++ b/packages/swarm-extension/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/swarm-extension",
-	"version": "18.21.1",
+	"version": "18.22.0",
 	"description": "Swarm orchestration extension for xcsh",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Derek Rynd",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-tui",
-	"version": "18.21.1",
+	"version": "18.22.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-utils",
-	"version": "18.21.1",
+	"version": "18.22.0",
 	"description": "Shared utilities for pi packages",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",


### PR DESCRIPTION
Automated release PR generated by `scripts/release.ts`.

Bumps every public package and the Cargo workspace to `v18.22.0` and updates CHANGELOGs for the releasable commits since the last tag.

Once this PR squash-merges to `main`, `.github/workflows/tag-on-version-bump.yml` pushes the `v18.22.0` git tag, which triggers the downstream release chain (build → sign → publish).

### Releasable commits (1)

- feat(coding-agent): /context wizard interactive setup (#300) (#374)

See `docs-control`'s onboarding note "Release automation: release PR pattern" for the governance rationale.