### PR TITLE
feat(coding-agent): add RESERVED_CONTEXT_NAMES constant and guard createContext (#378)

### DIFF
--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -17,6 +17,28 @@ export const CURRENT_SCHEMA_VERSION = 1;
 
 export const CURRENT_EXPORT_VERSION = 1;
 
+export const RESERVED_CONTEXT_NAMES = new Set([
+	"list",
+	"show",
+	"status",
+	"create",
+	"delete",
+	"rename",
+	"namespace",
+	"env",
+	"set",
+	"unset",
+	"add",
+	"remove",
+	"clear",
+	"activate",
+	"validate",
+	"export",
+	"import",
+	"wizard",
+	"help",
+]);
+
 export interface ExportBundle {
 	/** Export format version — distinct from per-context F5XCContext.version (schema version). */
 	version: number;
@@ -458,6 +480,7 @@ export class ContextService {
 
 	async createContext(context: Omit<F5XCContext, "metadata" | "version">): Promise<void> {
 		this.#validateContextName(context.name);
+		this.#assertNotReserved(context.name);
 		const contextPath = path.join(this.contextsDir, `${context.name}.json`);
 		if (fs.existsSync(contextPath)) {
 			throw new ContextError(`Context '${context.name}' already exists.`, context.name);
@@ -1045,6 +1068,15 @@ export class ContextService {
 		if (!this.#isValidContextName(name)) {
 			throw new ContextError(
 				`Invalid context name: '${name}'. Names must be alphanumeric with dashes/underscores, max 64 chars.`,
+				name,
+			);
+		}
+	}
+
+	#assertNotReserved(name: string): void {
+		if (RESERVED_CONTEXT_NAMES.has(name.toLowerCase())) {
+			throw new ContextError(
+				`Context name '${name}' conflicts with a /context subcommand. Choose a different name.`,
 				name,
 			);
 		}

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -566,6 +566,41 @@ describe("ContextService", () => {
 			expect(fs.existsSync(path.join(f5xcContextsDir, "atomic-test.json"))).toBe(true);
 			expect(fs.existsSync(path.join(f5xcContextsDir, "atomic-test.json.tmp"))).toBe(false);
 		});
+
+		it("rejects a reserved subcommand name", async () => {
+			const service = ContextService.init(f5xcConfigDir);
+			await expect(
+				service.createContext({
+					name: "list",
+					apiUrl: "https://t.console.ves.volterra.io",
+					apiToken: "tok",
+					defaultNamespace: "default",
+				}),
+			).rejects.toThrow(/conflicts with a \/context subcommand/);
+		});
+
+		it("rejects reserved names case-insensitively", async () => {
+			const service = ContextService.init(f5xcConfigDir);
+			await expect(
+				service.createContext({
+					name: "CREATE",
+					apiUrl: "https://t.console.ves.volterra.io",
+					apiToken: "tok",
+					defaultNamespace: "default",
+				}),
+			).rejects.toThrow(/conflicts with a \/context subcommand/);
+		});
+
+		it("allows a name that contains a reserved word as a substring", async () => {
+			const service = ContextService.init(f5xcConfigDir);
+			await service.createContext({
+				name: "my-list",
+				apiUrl: "https://t.console.ves.volterra.io",
+				apiToken: "tok",
+				defaultNamespace: "default",
+			});
+			expect(fs.existsSync(path.join(f5xcContextsDir, "my-list.json"))).toBe(true);
+		});
 	});
 
 	describe("deleteContext", () => {


### PR DESCRIPTION
## What

Add `RESERVED_CONTEXT_NAMES` Set (19 entries) and private `#assertNotReserved()` method to `ContextService`. Guard `createContext()` against reserved subcommand names to prevent name collisions with `/context` CLI subcommands.

## Why

Context names that match `/context` subcommands (e.g., `list`, `create`, `delete`) would shadow the subcommand, making it inaccessible. This guard rejects reserved names at creation time with a clear error message.

Closes #378

## Testing

- 3 TDD tests added:
  - Rejects exact reserved name (`list`)
  - Rejects reserved names case-insensitively (`CREATE`)
  - Allows names containing reserved words as substrings (`my-list`)

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #378`