### PR TITLE
feat(coding-agent): guard renameContext and importContexts against reserved names (#378)

### DIFF
--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -629,6 +629,10 @@ export class ContextService {
 				badNames.push(`${name} (invalid name)`);
 				continue;
 			}
+			if (RESERVED_CONTEXT_NAMES.has(rawObj.name.toLowerCase())) {
+				badNames.push(`${rawObj.name} (reserved subcommand name)`);
+				continue;
+			}
 			const shape = this.#validateContextShape(raw, rawObj.name);
 			if (!shape) {
 				badNames.push(`${rawObj.name} (invalid shape)`);
@@ -738,6 +742,7 @@ export class ContextService {
 	async renameContext(oldName: string, newName: string): Promise<void> {
 		this.#validateContextName(oldName);
 		this.#validateContextName(newName);
+		this.#assertNotReserved(newName);
 
 		const oldPath = path.join(this.contextsDir, `${oldName}.json`);
 		const newPath = path.join(this.contextsDir, `${newName}.json`);

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -1746,6 +1746,32 @@ describe("ContextService", () => {
 			await expect(service.renameContext("ghost", "ghost")).rejects.toThrow(/not found/);
 		});
 
+		it("rejects renaming TO a reserved subcommand name", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			await expect(service.renameContext(TEST_CONTEXT.name, "status")).rejects.toThrow(
+				/conflicts with a \/context subcommand/,
+			);
+			// Original file must still exist — rename was rejected before any I/O
+			expect(fs.existsSync(path.join(f5xcContextsDir, `${TEST_CONTEXT.name}.json`))).toBe(true);
+		});
+
+		it("allows renaming FROM a reserved name to a non-reserved name", async () => {
+			// Bypass createContext to simulate pre-guard data on disk
+			writeContext(f5xcContextsDir, { ...TEST_CONTEXT, name: "list" });
+			writeActiveContext(f5xcConfigDir, "list");
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			await service.renameContext("list", "my-list");
+
+			expect(fs.existsSync(path.join(f5xcContextsDir, "list.json"))).toBe(false);
+			expect(fs.existsSync(path.join(f5xcContextsDir, "my-list.json"))).toBe(true);
+		});
+
 		it("rolls back when pointer write fails (EISDIR trick)", async () => {
 			writeContext(f5xcContextsDir, TEST_CONTEXT);
 			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
@@ -2120,6 +2146,45 @@ describe("ContextService", () => {
 			expect(result.imported).toEqual([]);
 			expect(result.overwritten).toEqual([]);
 			expect(result.skipped).toEqual([]);
+		});
+
+		it("rejects a bundle containing a reserved subcommand name", async () => {
+			const service = ContextService.init(f5xcConfigDir);
+			const reserved: F5XCContext = {
+				name: "delete",
+				apiUrl: "https://t.console.ves.volterra.io",
+				apiToken: "tok",
+				defaultNamespace: "default",
+			};
+			const bundle = makeBundle([reserved]);
+
+			await expect(service.importContexts(bundle, { overwrite: false })).rejects.toThrow(/reserved subcommand name/);
+			// No file should have been written
+			expect(fs.existsSync(path.join(f5xcContextsDir, "delete.json"))).toBe(false);
+		});
+
+		it("rejects reserved names alongside other invalid entries in a single error", async () => {
+			const service = ContextService.init(f5xcConfigDir);
+			const bundle = {
+				version: 1,
+				exportedAt: new Date().toISOString(),
+				tokensMasked: false,
+				contexts: [
+					{ name: "import", apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok", defaultNamespace: "d" },
+					{
+						name: "bad name!",
+						apiUrl: "https://t.console.ves.volterra.io",
+						apiToken: "tok",
+						defaultNamespace: "d",
+					},
+				],
+			};
+
+			const err = await service.importContexts(bundle, { overwrite: false }).catch((e: Error) => e);
+			expect(err).toBeInstanceOf(ContextError);
+			expect((err as Error).message).toMatch(/2 invalid context/);
+			expect((err as Error).message).toMatch(/import \(reserved subcommand name\)/);
+			expect((err as Error).message).toMatch(/bad name! \(invalid name\)/);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Add `#assertNotReserved(newName)` guard to `renameContext()` — only the new name is checked, so renaming away from a pre-guard reserved name still works
- Add `RESERVED_CONTEXT_NAMES` check in the `importContexts()` validation loop using the `badNames` aggregation pattern
- 4 new tests covering both mutation paths

Completes the reserved-name guard implementation started in #383. All three mutation paths (`createContext`, `renameContext`, `importContexts`) now reject reserved subcommand names.

Closes #378

## Test plan
- [x] 155/155 tests pass (4 new + 151 existing)
- [x] `bun check` clean (types + lint + formatting)
- [x] `RESERVED_CONTEXT_NAMES` exported for downstream #380

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [x] Issue linked via `Closes #378`

🤖 Generated with [Claude Code](https://claude.com/claude-code)