### PR TITLE
feat(coding-agent): add previous context tracking to ContextService (#379)

### DIFF
--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -180,6 +180,7 @@ export class ContextService {
 	#apiClient: F5XCApiClient | null = null;
 	#revalidationTimer: NodeJS.Timeout | null = null;
 	#lastTokenHealth: TokenHealth = "ok";
+	#previousContextName: string | null = null;
 
 	private constructor(configDir: string) {
 		this.#configDir = configDir;
@@ -330,6 +331,7 @@ export class ContextService {
 			ContextService.#instance.#apiClient = null;
 			ContextService.#instance.#lastTokenHealth = "ok";
 			ContextService.#instance.stopRevalidation();
+			ContextService.#instance.#previousContextName = null;
 		}
 		ContextService.#instance = null;
 		// Clear listeners to prevent cross-test contamination. Each createAgentSession() call
@@ -338,6 +340,10 @@ export class ContextService {
 		ContextService.#onContextChangeListeners = [];
 		ContextService.#onAuthStatusChangeListeners = [];
 		ContextService.#onTokenHealthChangeListeners = [];
+	}
+
+	get previousContextName(): string | null {
+		return this.#previousContextName;
 	}
 
 	get contextsDir(): string {
@@ -439,6 +445,9 @@ export class ContextService {
 		// NFR-402: write active_context first — if it fails, don't update settings
 		this.#atomicWrite(this.activeContextPath, name);
 
+		if (this.#activeContext && this.#activeContext.name !== name) {
+			this.#previousContextName = this.#activeContext.name;
+		}
 		this.#activeContext = context;
 		this.#applyToSettings(context);
 		this.#credentialSource = hasEnvOverride() ? "mixed" : "context";
@@ -454,6 +463,13 @@ export class ContextService {
 		this.#refreshApiClient(context);
 
 		return context;
+	}
+
+	async activatePrevious(): Promise<F5XCContext> {
+		if (!this.#previousContextName) {
+			throw new ContextError("No previous context. Switch contexts first with /context activate <name>.");
+		}
+		return this.activate(this.#previousContextName);
 	}
 
 	async listContexts(): Promise<F5XCContext[]> {
@@ -506,6 +522,9 @@ export class ContextService {
 		}
 		fs.unlinkSync(contextPath);
 		this.#contextsCache = this.#contextsCache.filter(p => p.name !== name);
+		if (this.#previousContextName === name) {
+			this.#previousContextName = null;
+		}
 	}
 
 	/**
@@ -806,6 +825,9 @@ export class ContextService {
 		this.#contextsCache = this.#contextsCache
 			.map(p => (p.name === oldName ? { ...p, name: newName } : p))
 			.sort((a, b) => a.name.localeCompare(b.name));
+		if (this.#previousContextName === oldName) {
+			this.#previousContextName = newName;
+		}
 		if (wasActive && this.#activeContext) {
 			this.#activeContext = { ...this.#activeContext, name: newName };
 			for (const cb of ContextService.#onContextChangeListeners) {

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -1930,6 +1930,104 @@ describe("ContextService", () => {
 		});
 	});
 
+	describe("previousContextName", () => {
+		it("is null after fresh init", async () => {
+			const service = ContextService.init(f5xcConfigDir);
+			expect(service.previousContextName).toBeNull();
+		});
+
+		it("tracks the previous context on activate", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeContext(f5xcContextsDir, TEST_CONTEXT_2);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			await service.activate(TEST_CONTEXT_2.name);
+
+			expect(service.previousContextName).toBe(TEST_CONTEXT.name);
+		});
+
+		it("does not change previousContextName when re-activating the same context", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeContext(f5xcContextsDir, TEST_CONTEXT_2);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			await service.activate(TEST_CONTEXT_2.name);
+			expect(service.previousContextName).toBe(TEST_CONTEXT.name);
+
+			// Re-activate the same context — previous should NOT change
+			await service.activate(TEST_CONTEXT_2.name);
+			expect(service.previousContextName).toBe(TEST_CONTEXT.name);
+		});
+
+		it("activatePrevious switches to the previous context", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeContext(f5xcContextsDir, TEST_CONTEXT_2);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			await service.activate(TEST_CONTEXT_2.name);
+			const result = await service.activatePrevious();
+
+			expect(result.name).toBe(TEST_CONTEXT.name);
+			expect(service.getStatus().activeContextName).toBe(TEST_CONTEXT.name);
+		});
+
+		it("activatePrevious twice returns to the original context (ping-pong)", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeContext(f5xcContextsDir, TEST_CONTEXT_2);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			await service.activate(TEST_CONTEXT_2.name);
+			await service.activatePrevious();
+			await service.activatePrevious();
+
+			expect(service.getStatus().activeContextName).toBe(TEST_CONTEXT_2.name);
+			expect(service.previousContextName).toBe(TEST_CONTEXT.name);
+		});
+
+		it("activatePrevious throws when no previous exists", async () => {
+			const service = ContextService.init(f5xcConfigDir);
+			await expect(service.activatePrevious()).rejects.toThrow(/No previous context/);
+		});
+
+		it("deleteContext clears previousContextName when deleting the previous context", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeContext(f5xcContextsDir, TEST_CONTEXT_2);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			await service.activate(TEST_CONTEXT_2.name);
+			expect(service.previousContextName).toBe(TEST_CONTEXT.name);
+
+			await service.deleteContext(TEST_CONTEXT.name);
+			expect(service.previousContextName).toBeNull();
+		});
+
+		it("renameContext updates previousContextName when renaming the previous context", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeContext(f5xcContextsDir, TEST_CONTEXT_2);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT_2.name);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			// Switch from staging to production — previous becomes "staging"
+			await service.activate(TEST_CONTEXT.name);
+			expect(service.previousContextName).toBe(TEST_CONTEXT_2.name);
+
+			// Rename staging to staging-v2 — previous should update
+			await service.renameContext(TEST_CONTEXT_2.name, "staging-v2");
+			expect(service.previousContextName).toBe("staging-v2");
+		});
+	});
+
 	describe("importContexts", () => {
 		function makeBundle(contexts: F5XCContext[], tokensMasked = false): unknown {
 			return {


### PR DESCRIPTION
## What

- Add `#previousContextName` field to `ContextService`, tracked on `activate()` when switching to a different context
- Add `previousContextName` getter and `activatePrevious()` method for downstream #380 dispatch refactor
- Guard in `deleteContext()` (clears pointer) and `renameContext()` (updates pointer)
- Session-scoped, not persisted — matches `cd -` convention

## Why

Completes previous-context tracking for issue #379, unblocking the dispatch refactor #380.

Closes #379

## Testing

- 163/163 tests pass (8 new + 155 existing)
- `bun check` clean
- `previousContextName` getter and `activatePrevious()` accessible for #380

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [x] Issue linked via `Closes #N`