### PR TITLE
fix(tui): remove redundant double-negation in terminal capabilities

### DIFF
--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -146,7 +146,7 @@ export const TERMINAL_ID: TerminalId = (() => {
 		if (caseEq(TERM_PROGRAM, "alacritty")) return "alacritty";
 	}
 
-	if (!!TERM && TERM.toLowerCase().includes("ghostty")) return "ghostty";
+	if (TERM?.toLowerCase().includes("ghostty")) return "ghostty";
 
 	if (COLORTERM) {
 		if (caseEq(COLORTERM, "truecolor") || caseEq(COLORTERM, "24bit")) return "trueColor";


### PR DESCRIPTION
## What

Replace `!!TERM && TERM.toLowerCase().includes("ghostty")` with `TERM?.toLowerCase().includes("ghostty")` in `packages/tui/src/terminal-capabilities.ts`.

## Why

Clears biome lint diagnostics (noExtraBooleanCast + useOptionalChain). Optional chaining is semantically equivalent — returns `undefined` when `TERM` is nullish, which is falsy in the `if` guard. No behavior change.

Closes #389

## Testing

- [x] `biome check .` exits 0 with zero diagnostics on this file
- [x] No behavior change — optional chain is equivalent when TERM is undefined/null
- [x] Pre-commit hooks pass
- [x] Issue linked via `Closes #389`