### PR TITLE
fix(ci): add retry with exponential backoff to Bun setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,60 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: oven-sh/setup-bun@v2
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@v2
+        id: setup-bun
+        continue-on-error: true
         with:
           bun-version: "1.3"
+      - name: Retry Bun setup on failure
+        if: steps.setup-bun.outcome == 'failure'
+        shell: bash
+        run: |
+          BUN_VERSION=$(curl -sSf "https://api.github.com/repos/oven-sh/bun/releases" \
+            -H "Accept: application/vnd.github+json" \
+            | grep -o '"tag_name": "bun-v1\.3\.[0-9]*"' \
+            | head -1 \
+            | grep -o '1\.3\.[0-9]*') || true
+          if [ -z "$BUN_VERSION" ]; then
+            echo "::warning::Could not resolve latest 1.3.x, falling back to 1.3.13"
+            BUN_VERSION=1.3.13
+          fi
+          echo "Resolved Bun version: $BUN_VERSION"
+          case "$RUNNER_OS" in
+            Linux)  PLATFORM="linux-x64" ;;
+            macOS)
+              case "$RUNNER_ARCH" in
+                ARM64) PLATFORM="darwin-aarch64" ;;
+                *)     PLATFORM="darwin-x64" ;;
+              esac ;;
+            Windows) PLATFORM="windows-x64" ;;
+          esac
+          URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${PLATFORM}.zip"
+          OUTFILE="bun-download.zip"
+          echo "::warning::setup-bun action failed, retrying manual download from $URL"
+          MAX_RETRIES=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Bun after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          unzip -q "$OUTFILE"
+          rm -f "$OUTFILE"
+          BUN_DIR="$PWD/bun-${PLATFORM}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            BUN_DIR=$(cygpath -w "$BUN_DIR")
+          fi
+          echo "$BUN_DIR" >> "$GITHUB_PATH"
+          bun --version
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:
@@ -72,9 +123,60 @@ jobs:
         with:
           key: ${{ matrix.target }}${{ matrix.variants }}
           cache-workspace-crates: true
-      - uses: oven-sh/setup-bun@v2
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@v2
+        id: setup-bun
+        continue-on-error: true
         with:
           bun-version: "1.3"
+      - name: Retry Bun setup on failure
+        if: steps.setup-bun.outcome == 'failure'
+        shell: bash
+        run: |
+          BUN_VERSION=$(curl -sSf "https://api.github.com/repos/oven-sh/bun/releases" \
+            -H "Accept: application/vnd.github+json" \
+            | grep -o '"tag_name": "bun-v1\.3\.[0-9]*"' \
+            | head -1 \
+            | grep -o '1\.3\.[0-9]*') || true
+          if [ -z "$BUN_VERSION" ]; then
+            echo "::warning::Could not resolve latest 1.3.x, falling back to 1.3.13"
+            BUN_VERSION=1.3.13
+          fi
+          echo "Resolved Bun version: $BUN_VERSION"
+          case "$RUNNER_OS" in
+            Linux)  PLATFORM="linux-x64" ;;
+            macOS)
+              case "$RUNNER_ARCH" in
+                ARM64) PLATFORM="darwin-aarch64" ;;
+                *)     PLATFORM="darwin-x64" ;;
+              esac ;;
+            Windows) PLATFORM="windows-x64" ;;
+          esac
+          URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${PLATFORM}.zip"
+          OUTFILE="bun-download.zip"
+          echo "::warning::setup-bun action failed, retrying manual download from $URL"
+          MAX_RETRIES=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Bun after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          unzip -q "$OUTFILE"
+          rm -f "$OUTFILE"
+          BUN_DIR="$PWD/bun-${PLATFORM}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            BUN_DIR=$(cygpath -w "$BUN_DIR")
+          fi
+          echo "$BUN_DIR" >> "$GITHUB_PATH"
+          bun --version
       - name: Install Zig 0.15.2
         shell: bash
         run: |
@@ -152,9 +254,60 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
-      - uses: oven-sh/setup-bun@v2
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@v2
+        id: setup-bun
+        continue-on-error: true
         with:
           bun-version: "1.3"
+      - name: Retry Bun setup on failure
+        if: steps.setup-bun.outcome == 'failure'
+        shell: bash
+        run: |
+          BUN_VERSION=$(curl -sSf "https://api.github.com/repos/oven-sh/bun/releases" \
+            -H "Accept: application/vnd.github+json" \
+            | grep -o '"tag_name": "bun-v1\.3\.[0-9]*"' \
+            | head -1 \
+            | grep -o '1\.3\.[0-9]*') || true
+          if [ -z "$BUN_VERSION" ]; then
+            echo "::warning::Could not resolve latest 1.3.x, falling back to 1.3.13"
+            BUN_VERSION=1.3.13
+          fi
+          echo "Resolved Bun version: $BUN_VERSION"
+          case "$RUNNER_OS" in
+            Linux)  PLATFORM="linux-x64" ;;
+            macOS)
+              case "$RUNNER_ARCH" in
+                ARM64) PLATFORM="darwin-aarch64" ;;
+                *)     PLATFORM="darwin-x64" ;;
+              esac ;;
+            Windows) PLATFORM="windows-x64" ;;
+          esac
+          URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${PLATFORM}.zip"
+          OUTFILE="bun-download.zip"
+          echo "::warning::setup-bun action failed, retrying manual download from $URL"
+          MAX_RETRIES=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Bun after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          unzip -q "$OUTFILE"
+          rm -f "$OUTFILE"
+          BUN_DIR="$PWD/bun-${PLATFORM}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            BUN_DIR=$(cygpath -w "$BUN_DIR")
+          fi
+          echo "$BUN_DIR" >> "$GITHUB_PATH"
+          bun --version
       - uses: dtolnay/rust-toolchain@nightly # TODO: unpin once nightly codegen regression is fixed
         with:
           toolchain: nightly-2026-03-27
@@ -231,9 +384,60 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: true
-      - uses: oven-sh/setup-bun@v2
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@v2
+        id: setup-bun
+        continue-on-error: true
         with:
           bun-version: "1.3"
+      - name: Retry Bun setup on failure
+        if: steps.setup-bun.outcome == 'failure'
+        shell: bash
+        run: |
+          BUN_VERSION=$(curl -sSf "https://api.github.com/repos/oven-sh/bun/releases" \
+            -H "Accept: application/vnd.github+json" \
+            | grep -o '"tag_name": "bun-v1\.3\.[0-9]*"' \
+            | head -1 \
+            | grep -o '1\.3\.[0-9]*') || true
+          if [ -z "$BUN_VERSION" ]; then
+            echo "::warning::Could not resolve latest 1.3.x, falling back to 1.3.13"
+            BUN_VERSION=1.3.13
+          fi
+          echo "Resolved Bun version: $BUN_VERSION"
+          case "$RUNNER_OS" in
+            Linux)  PLATFORM="linux-x64" ;;
+            macOS)
+              case "$RUNNER_ARCH" in
+                ARM64) PLATFORM="darwin-aarch64" ;;
+                *)     PLATFORM="darwin-x64" ;;
+              esac ;;
+            Windows) PLATFORM="windows-x64" ;;
+          esac
+          URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${PLATFORM}.zip"
+          OUTFILE="bun-download.zip"
+          echo "::warning::setup-bun action failed, retrying manual download from $URL"
+          MAX_RETRIES=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Bun after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          unzip -q "$OUTFILE"
+          rm -f "$OUTFILE"
+          BUN_DIR="$PWD/bun-${PLATFORM}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            BUN_DIR=$(cygpath -w "$BUN_DIR")
+          fi
+          echo "$BUN_DIR" >> "$GITHUB_PATH"
+          bun --version
       - uses: dtolnay/rust-toolchain@nightly # TODO: unpin once nightly codegen regression is fixed
         with:
           toolchain: nightly-2026-03-27
@@ -310,9 +514,60 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
-      - uses: oven-sh/setup-bun@v2
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@v2
+        id: setup-bun
+        continue-on-error: true
         with:
           bun-version: "1.3"
+      - name: Retry Bun setup on failure
+        if: steps.setup-bun.outcome == 'failure'
+        shell: bash
+        run: |
+          BUN_VERSION=$(curl -sSf "https://api.github.com/repos/oven-sh/bun/releases" \
+            -H "Accept: application/vnd.github+json" \
+            | grep -o '"tag_name": "bun-v1\.3\.[0-9]*"' \
+            | head -1 \
+            | grep -o '1\.3\.[0-9]*') || true
+          if [ -z "$BUN_VERSION" ]; then
+            echo "::warning::Could not resolve latest 1.3.x, falling back to 1.3.13"
+            BUN_VERSION=1.3.13
+          fi
+          echo "Resolved Bun version: $BUN_VERSION"
+          case "$RUNNER_OS" in
+            Linux)  PLATFORM="linux-x64" ;;
+            macOS)
+              case "$RUNNER_ARCH" in
+                ARM64) PLATFORM="darwin-aarch64" ;;
+                *)     PLATFORM="darwin-x64" ;;
+              esac ;;
+            Windows) PLATFORM="windows-x64" ;;
+          esac
+          URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${PLATFORM}.zip"
+          OUTFILE="bun-download.zip"
+          echo "::warning::setup-bun action failed, retrying manual download from $URL"
+          MAX_RETRIES=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Bun after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          unzip -q "$OUTFILE"
+          rm -f "$OUTFILE"
+          BUN_DIR="$PWD/bun-${PLATFORM}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            BUN_DIR=$(cygpath -w "$BUN_DIR")
+          fi
+          echo "$BUN_DIR" >> "$GITHUB_PATH"
+          bun --version
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:
@@ -338,9 +593,60 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           lfs: true
-      - uses: oven-sh/setup-bun@v2
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@v2
+        id: setup-bun
+        continue-on-error: true
         with:
           bun-version: "1.3"
+      - name: Retry Bun setup on failure
+        if: steps.setup-bun.outcome == 'failure'
+        shell: bash
+        run: |
+          BUN_VERSION=$(curl -sSf "https://api.github.com/repos/oven-sh/bun/releases" \
+            -H "Accept: application/vnd.github+json" \
+            | grep -o '"tag_name": "bun-v1\.3\.[0-9]*"' \
+            | head -1 \
+            | grep -o '1\.3\.[0-9]*') || true
+          if [ -z "$BUN_VERSION" ]; then
+            echo "::warning::Could not resolve latest 1.3.x, falling back to 1.3.13"
+            BUN_VERSION=1.3.13
+          fi
+          echo "Resolved Bun version: $BUN_VERSION"
+          case "$RUNNER_OS" in
+            Linux)  PLATFORM="linux-x64" ;;
+            macOS)
+              case "$RUNNER_ARCH" in
+                ARM64) PLATFORM="darwin-aarch64" ;;
+                *)     PLATFORM="darwin-x64" ;;
+              esac ;;
+            Windows) PLATFORM="windows-x64" ;;
+          esac
+          URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${PLATFORM}.zip"
+          OUTFILE="bun-download.zip"
+          echo "::warning::setup-bun action failed, retrying manual download from $URL"
+          MAX_RETRIES=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Bun after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          unzip -q "$OUTFILE"
+          rm -f "$OUTFILE"
+          BUN_DIR="$PWD/bun-${PLATFORM}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            BUN_DIR=$(cygpath -w "$BUN_DIR")
+          fi
+          echo "$BUN_DIR" >> "$GITHUB_PATH"
+          bun --version
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:
@@ -386,9 +692,60 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           lfs: true
-      - uses: oven-sh/setup-bun@v2
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@v2
+        id: setup-bun
+        continue-on-error: true
         with:
           bun-version: "1.3"
+      - name: Retry Bun setup on failure
+        if: steps.setup-bun.outcome == 'failure'
+        shell: bash
+        run: |
+          BUN_VERSION=$(curl -sSf "https://api.github.com/repos/oven-sh/bun/releases" \
+            -H "Accept: application/vnd.github+json" \
+            | grep -o '"tag_name": "bun-v1\.3\.[0-9]*"' \
+            | head -1 \
+            | grep -o '1\.3\.[0-9]*') || true
+          if [ -z "$BUN_VERSION" ]; then
+            echo "::warning::Could not resolve latest 1.3.x, falling back to 1.3.13"
+            BUN_VERSION=1.3.13
+          fi
+          echo "Resolved Bun version: $BUN_VERSION"
+          case "$RUNNER_OS" in
+            Linux)  PLATFORM="linux-x64" ;;
+            macOS)
+              case "$RUNNER_ARCH" in
+                ARM64) PLATFORM="darwin-aarch64" ;;
+                *)     PLATFORM="darwin-x64" ;;
+              esac ;;
+            Windows) PLATFORM="windows-x64" ;;
+          esac
+          URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${PLATFORM}.zip"
+          OUTFILE="bun-download.zip"
+          echo "::warning::setup-bun action failed, retrying manual download from $URL"
+          MAX_RETRIES=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Bun after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          unzip -q "$OUTFILE"
+          rm -f "$OUTFILE"
+          BUN_DIR="$PWD/bun-${PLATFORM}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            BUN_DIR=$(cygpath -w "$BUN_DIR")
+          fi
+          echo "$BUN_DIR" >> "$GITHUB_PATH"
+          bun --version
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:
@@ -595,9 +952,60 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
-      - uses: oven-sh/setup-bun@v2
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@v2
+        id: setup-bun
+        continue-on-error: true
         with:
           bun-version: "1.3"
+      - name: Retry Bun setup on failure
+        if: steps.setup-bun.outcome == 'failure'
+        shell: bash
+        run: |
+          BUN_VERSION=$(curl -sSf "https://api.github.com/repos/oven-sh/bun/releases" \
+            -H "Accept: application/vnd.github+json" \
+            | grep -o '"tag_name": "bun-v1\.3\.[0-9]*"' \
+            | head -1 \
+            | grep -o '1\.3\.[0-9]*') || true
+          if [ -z "$BUN_VERSION" ]; then
+            echo "::warning::Could not resolve latest 1.3.x, falling back to 1.3.13"
+            BUN_VERSION=1.3.13
+          fi
+          echo "Resolved Bun version: $BUN_VERSION"
+          case "$RUNNER_OS" in
+            Linux)  PLATFORM="linux-x64" ;;
+            macOS)
+              case "$RUNNER_ARCH" in
+                ARM64) PLATFORM="darwin-aarch64" ;;
+                *)     PLATFORM="darwin-x64" ;;
+              esac ;;
+            Windows) PLATFORM="windows-x64" ;;
+          esac
+          URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${PLATFORM}.zip"
+          OUTFILE="bun-download.zip"
+          echo "::warning::setup-bun action failed, retrying manual download from $URL"
+          MAX_RETRIES=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Bun after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          unzip -q "$OUTFILE"
+          rm -f "$OUTFILE"
+          BUN_DIR="$PWD/bun-${PLATFORM}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            BUN_DIR=$(cygpath -w "$BUN_DIR")
+          fi
+          echo "$BUN_DIR" >> "$GITHUB_PATH"
+          bun --version
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:
@@ -647,9 +1055,60 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           lfs: true
-      - uses: oven-sh/setup-bun@v2
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@v2
+        id: setup-bun
+        continue-on-error: true
         with:
           bun-version: "1.3"
+      - name: Retry Bun setup on failure
+        if: steps.setup-bun.outcome == 'failure'
+        shell: bash
+        run: |
+          BUN_VERSION=$(curl -sSf "https://api.github.com/repos/oven-sh/bun/releases" \
+            -H "Accept: application/vnd.github+json" \
+            | grep -o '"tag_name": "bun-v1\.3\.[0-9]*"' \
+            | head -1 \
+            | grep -o '1\.3\.[0-9]*') || true
+          if [ -z "$BUN_VERSION" ]; then
+            echo "::warning::Could not resolve latest 1.3.x, falling back to 1.3.13"
+            BUN_VERSION=1.3.13
+          fi
+          echo "Resolved Bun version: $BUN_VERSION"
+          case "$RUNNER_OS" in
+            Linux)  PLATFORM="linux-x64" ;;
+            macOS)
+              case "$RUNNER_ARCH" in
+                ARM64) PLATFORM="darwin-aarch64" ;;
+                *)     PLATFORM="darwin-x64" ;;
+              esac ;;
+            Windows) PLATFORM="windows-x64" ;;
+          esac
+          URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${PLATFORM}.zip"
+          OUTFILE="bun-download.zip"
+          echo "::warning::setup-bun action failed, retrying manual download from $URL"
+          MAX_RETRIES=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Bun after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          unzip -q "$OUTFILE"
+          rm -f "$OUTFILE"
+          BUN_DIR="$PWD/bun-${PLATFORM}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            BUN_DIR=$(cygpath -w "$BUN_DIR")
+          fi
+          echo "$BUN_DIR" >> "$GITHUB_PATH"
+          bun --version
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
@@ -695,9 +1154,60 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
-      - uses: oven-sh/setup-bun@v2
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@v2
+        id: setup-bun
+        continue-on-error: true
         with:
           bun-version: "1.3"
+      - name: Retry Bun setup on failure
+        if: steps.setup-bun.outcome == 'failure'
+        shell: bash
+        run: |
+          BUN_VERSION=$(curl -sSf "https://api.github.com/repos/oven-sh/bun/releases" \
+            -H "Accept: application/vnd.github+json" \
+            | grep -o '"tag_name": "bun-v1\.3\.[0-9]*"' \
+            | head -1 \
+            | grep -o '1\.3\.[0-9]*') || true
+          if [ -z "$BUN_VERSION" ]; then
+            echo "::warning::Could not resolve latest 1.3.x, falling back to 1.3.13"
+            BUN_VERSION=1.3.13
+          fi
+          echo "Resolved Bun version: $BUN_VERSION"
+          case "$RUNNER_OS" in
+            Linux)  PLATFORM="linux-x64" ;;
+            macOS)
+              case "$RUNNER_ARCH" in
+                ARM64) PLATFORM="darwin-aarch64" ;;
+                *)     PLATFORM="darwin-x64" ;;
+              esac ;;
+            Windows) PLATFORM="windows-x64" ;;
+          esac
+          URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${PLATFORM}.zip"
+          OUTFILE="bun-download.zip"
+          echo "::warning::setup-bun action failed, retrying manual download from $URL"
+          MAX_RETRIES=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Bun after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          unzip -q "$OUTFILE"
+          rm -f "$OUTFILE"
+          BUN_DIR="$PWD/bun-${PLATFORM}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            BUN_DIR=$(cygpath -w "$BUN_DIR")
+          fi
+          echo "$BUN_DIR" >> "$GITHUB_PATH"
+          bun --version
       - name: Install xcsh via npm and verify native addon loads
         env:
           EXPECTED_VERSION: ${{ github.ref_name }}

--- a/.github/workflows/test-codesign.yml
+++ b/.github/workflows/test-codesign.yml
@@ -21,9 +21,60 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: true
-      - uses: oven-sh/setup-bun@v2
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@v2
+        id: setup-bun
+        continue-on-error: true
         with:
           bun-version: "1.3"
+      - name: Retry Bun setup on failure
+        if: steps.setup-bun.outcome == 'failure'
+        shell: bash
+        run: |
+          BUN_VERSION=$(curl -sSf "https://api.github.com/repos/oven-sh/bun/releases" \
+            -H "Accept: application/vnd.github+json" \
+            | grep -o '"tag_name": "bun-v1\.3\.[0-9]*"' \
+            | head -1 \
+            | grep -o '1\.3\.[0-9]*') || true
+          if [ -z "$BUN_VERSION" ]; then
+            echo "::warning::Could not resolve latest 1.3.x, falling back to 1.3.13"
+            BUN_VERSION=1.3.13
+          fi
+          echo "Resolved Bun version: $BUN_VERSION"
+          case "$RUNNER_OS" in
+            Linux)  PLATFORM="linux-x64" ;;
+            macOS)
+              case "$RUNNER_ARCH" in
+                ARM64) PLATFORM="darwin-aarch64" ;;
+                *)     PLATFORM="darwin-x64" ;;
+              esac ;;
+            Windows) PLATFORM="windows-x64" ;;
+          esac
+          URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${PLATFORM}.zip"
+          OUTFILE="bun-download.zip"
+          echo "::warning::setup-bun action failed, retrying manual download from $URL"
+          MAX_RETRIES=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Bun after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          unzip -q "$OUTFILE"
+          rm -f "$OUTFILE"
+          BUN_DIR="$PWD/bun-${PLATFORM}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            BUN_DIR=$(cygpath -w "$BUN_DIR")
+          fi
+          echo "$BUN_DIR" >> "$GITHUB_PATH"
+          bun --version
       - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly-2026-03-27


### PR DESCRIPTION
## What

Wrap all 11 `oven-sh/setup-bun@v2` invocations across `ci.yml` and `test-codesign.yml` with `continue-on-error: true` plus a fallback retry step that resolves and downloads Bun manually when the official action fails.

## Why

Transient CDN 502 errors from the Bun setup action cause entire CI runs to fail, particularly affecting Windows native release builds. Seen in https://github.com/f5xc-salesdemos/xcsh/actions/runs/25094035484/job/73526487601

Closes #392

## Summary

- Wrap all 11 `oven-sh/setup-bun@v2` invocations with `continue-on-error: true` + fallback retry step
- Fallback resolves latest bun 1.3.x from GitHub API, downloads with 3 retries and exponential backoff (15s -> 30s -> 60s)
- Handles all CI platforms: Linux x64, macOS x64/arm64, Windows x64 (with cygpath conversion)
- Zero overhead on happy path — retry step is skipped when setup-bun succeeds
- Follows the established Zig download retry pattern from #358

## Testing

- [x] YAML validated (python3 yaml.safe_load)
- [x] Happy path: setup-bun succeeds -> retry step skipped (no overhead)
- [x] Failure path: setup-bun fails -> resolves version -> downloads with retry + backoff
- [x] CI will validate on this PR across all platforms

---

- [x] Issue linked via `Closes #392`