### PR TITLE
feat(coding-agent): refactor /context dispatch — direct switch, dash-previous, mixed completions (#380)

### DIFF
--- a/packages/coding-agent/src/extensibility/slash-commands.ts
+++ b/packages/coding-agent/src/extensibility/slash-commands.ts
@@ -122,7 +122,7 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<
 	if (cmd.subcommands) {
 		return {
 			...cmd,
-			getArgumentCompletions: buildArgumentCompletions(cmd.subcommands),
+			getArgumentCompletions: cmd.getArgumentCompletions ?? buildArgumentCompletions(cmd.subcommands),
 			getInlineHint: buildSubcommandInlineHint(cmd.subcommands),
 		};
 	}

--- a/packages/coding-agent/src/services/f5xc-context-command.ts
+++ b/packages/coding-agent/src/services/f5xc-context-command.ts
@@ -80,14 +80,16 @@ export async function handleContextCommand(
 		case "remove":
 		case "clear":
 			return handleEnvUnset(ctx, service, arg);
-		default:
-			// Natural language fallback: detect KEY=VALUE patterns
+		default: {
+			ENV_SET_PATTERN.lastIndex = 0;
 			if (ENV_SET_PATTERN.test(command.args)) {
 				return handleEnvSet(ctx, service, command.args);
 			}
-			ctx.showError(
-				`Unknown subcommand: ${sub}. Use /context list|activate|validate|show|status|create|delete|rename|export|import|namespace|env|set|unset`,
-			);
+			if (sub === "-") {
+				return handleActivatePrevious(ctx, service);
+			}
+			return handleDirectSwitch(ctx, service, sub!);
+		}
 	}
 }
 
@@ -155,6 +157,36 @@ async function handleActivate(ctx: CommandContext, service: ContextService, name
 		ctx.updateEditorTopBorder?.();
 		ctx.ui?.requestRender();
 		// Show the same red table as /context show
+		return handleShow(ctx, service);
+	} catch (err) {
+		ctx.showError(err instanceof ContextError ? err.message : String(err));
+	}
+}
+
+async function handleDirectSwitch(ctx: CommandContext, service: ContextService, name: string): Promise<void> {
+	try {
+		await service.activate(name);
+		ctx.statusLine?.invalidate();
+		ctx.updateEditorTopBorder?.();
+		ctx.ui?.requestRender();
+		return handleShow(ctx, service);
+	} catch (err) {
+		if (err instanceof ContextError && err.message.includes("not found")) {
+			ctx.showError(
+				`Context '${name}' not found. Run /context list to see available contexts, or /context create ${name} <url> <token> to create one.`,
+			);
+			return;
+		}
+		ctx.showError(err instanceof ContextError ? err.message : String(err));
+	}
+}
+
+async function handleActivatePrevious(ctx: CommandContext, service: ContextService): Promise<void> {
+	try {
+		await service.activatePrevious();
+		ctx.statusLine?.invalidate();
+		ctx.updateEditorTopBorder?.();
+		ctx.ui?.requestRender();
 		return handleShow(ctx, service);
 	} catch (err) {
 		ctx.showError(err instanceof ContextError ? err.message : String(err));
@@ -498,6 +530,7 @@ const ENV_SET_PATTERN = /([A-Za-z_][A-Za-z0-9_]*)=(\S+)/g;
 
 function parseEnvPairs(text: string): Record<string, string> {
 	const vars: Record<string, string> = {};
+	ENV_SET_PATTERN.lastIndex = 0;
 	for (const match of text.matchAll(ENV_SET_PATTERN)) {
 		vars[match[1]] = match[2];
 	}

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -72,6 +72,7 @@ export interface BuiltinSlashCommand {
 	subcommands?: SubcommandDef[];
 	/** Static inline hint when command takes a simple argument (no subcommands). */
 	inlineHint?: string;
+	getArgumentCompletions?: (argumentPrefix: string) => AutocompleteItem[] | null;
 }
 
 interface ParsedBuiltinSlashCommand {
@@ -128,6 +129,235 @@ const shutdownHandler = (_command: ParsedBuiltinSlashCommand, runtime: BuiltinSl
 	runtime.ctx.editor.setText("");
 	void runtime.ctx.shutdown();
 };
+
+const CONTEXT_SUBCOMMANDS: SubcommandDef[] = [
+	{ name: "list", description: "List all contexts" },
+	{
+		name: "activate",
+		description: "Switch to a named context",
+		usage: "<name>",
+		getArgumentCompletions(prefix: string) {
+			if (prefix.includes(" ")) return null;
+			const svc = tryGetContextService();
+			if (!svc) return null;
+			const lower = prefix.toLowerCase();
+			const items = svc
+				.listContextNamesCached()
+				.filter(n => n.toLowerCase().startsWith(lower))
+				.map(n => {
+					const hint = svc.getContextHint(n);
+					const parts: string[] = [];
+					if (hint?.apiUrl) parts.push(hint.apiUrl);
+					if (hint?.incompatible && hint.schemaVersion !== undefined) {
+						parts.push(`incompatible: v${hint.schemaVersion}`);
+					}
+					return {
+						value: n,
+						label: n,
+						description: parts.length > 0 ? parts.join(" · ") : undefined,
+					};
+				});
+			return items.length > 0 ? items : null;
+		},
+	},
+	{
+		name: "validate",
+		description: "Validate credentials for a context without activating",
+		usage: "<name>",
+		getArgumentCompletions(prefix: string) {
+			if (prefix.includes(" ")) return null;
+			const svc = tryGetContextService();
+			if (!svc) return null;
+			const lower = prefix.toLowerCase();
+			const items = svc
+				.listContextNamesCached()
+				.filter(n => n.toLowerCase().startsWith(lower))
+				.map(n => {
+					const hint = svc.getContextHint(n);
+					const parts: string[] = [];
+					if (hint?.apiUrl) parts.push(hint.apiUrl);
+					if (hint?.incompatible && hint.schemaVersion !== undefined) {
+						parts.push(`incompatible: v${hint.schemaVersion}`);
+					}
+					return {
+						value: n,
+						label: n,
+						description: parts.length > 0 ? parts.join(" · ") : undefined,
+					};
+				});
+			return items.length > 0 ? items : null;
+		},
+	},
+	{ name: "show", description: "Show context details (masked)", usage: "[name]" },
+	{ name: "status", description: "Show current auth status" },
+	{ name: "create", description: "Create a new context", usage: "<name> <url> <token> [namespace]" },
+	{ name: "delete", description: "Delete a context", usage: "<name> --confirm" },
+	{
+		name: "rename",
+		description: "Rename a context",
+		usage: "<old> <new>",
+		getArgumentCompletions(prefix: string) {
+			if (prefix.includes(" ")) return null;
+			const svc = tryGetContextService();
+			if (!svc) return null;
+			const lower = prefix.toLowerCase();
+			const items = svc
+				.listContextNamesCached()
+				.filter(n => n.toLowerCase().startsWith(lower))
+				.map(n => ({ value: n, label: n }));
+			return items.length > 0 ? items : null;
+		},
+	},
+	{
+		name: "export",
+		description: "Export a context (or all contexts) as JSON",
+		usage: "[name] [--include-token]",
+		getArgumentCompletions(prefix: string) {
+			const svc = tryGetContextService();
+			if (!svc) return null;
+			const tokens = prefix.split(/\s+/).filter(Boolean);
+			const hasIncludeToken = tokens.includes("--include-token");
+			const positionalsTyped = tokens.filter(t => !t.startsWith("--"));
+			// Last token is "in-progress" if the prefix does not end with space.
+			const trailingSpace = prefix.endsWith(" ") || prefix === "";
+			const typedPositionalCount = trailingSpace
+				? positionalsTyped.length
+				: Math.max(0, positionalsTyped.length - 1);
+			const completingToken = trailingSpace ? "" : (tokens[tokens.length - 1] ?? "");
+			// `head` is every already-typed token EXCEPT the one being
+			// completed. getArgumentCompletions.value replaces the whole
+			// argument tail, so value must carry every token the user
+			// should keep — otherwise accepting a suggestion silently
+			// drops the other args. Contract: see SubcommandDef JSDoc
+			// above (line ~58).
+			const headTokens = trailingSpace ? tokens : tokens.slice(0, -1);
+			const head = headTokens.length > 0 ? `${headTokens.join(" ")} ` : "";
+
+			const items: { value: string; label: string; description?: string }[] = [];
+
+			// Offer context names only if no positional has been filled yet.
+			// No startsWith("--") guard: context names legitimately allow
+			// leading dashes (the regex is /^[a-zA-Z0-9_-]{1,64}$/), and
+			// the handler's splitArgs uses a known-flags allowlist that
+			// treats only --include-token as a flag. So a context like
+			// `--prod` is valid; the completion filters by prefix and
+			// matches it naturally. When the user types `--in`, the
+			// flag-completion branch below matches `--include-token` by
+			// prefix; if there's ALSO a context starting with `--in` it
+			// is offered here. Both lists are disjoint by filter so
+			// there's no double-offer of the same token.
+			if (typedPositionalCount === 0) {
+				const lower = completingToken.toLowerCase();
+				for (const n of svc.listContextNamesCached()) {
+					if (!n.toLowerCase().startsWith(lower)) continue;
+					const hint = svc.getContextHint(n);
+					items.push({
+						value: `${head}${n}`,
+						label: n,
+						description: hint?.apiUrl,
+					});
+				}
+			}
+
+			// Offer --include-token unless already present. Match is
+			// case-sensitive because the handler's flag check uses
+			// exact-match `flags.has("--include-token")` — offering
+			// the suggestion for mis-cased prefixes (e.g. `--INCLUDE`)
+			// would produce a suggestion the handler then ignores.
+			if (!hasIncludeToken && "--include-token".startsWith(completingToken)) {
+				items.push({
+					value: `${head}--include-token`,
+					label: "--include-token",
+					description: "emit unmasked tokens",
+				});
+			}
+
+			return items.length > 0 ? items : null;
+		},
+	},
+	{
+		name: "import",
+		description: "Import contexts from a file path or inline JSON",
+		usage: "<path-or-json> [--overwrite]",
+		// No dynamic completion — paths are hard to complete correctly,
+		// and faking it would only mislead. Users pre-expand paths in
+		// their shell.
+	},
+	{
+		name: "namespace",
+		description: "Switch namespace within active context",
+		usage: "<namespace>",
+		getArgumentCompletions(prefix: string) {
+			if (prefix.includes(" ")) return null;
+			const svc = tryGetContextService();
+			if (!svc) return null;
+			// setNamespace() requires an active context. Don't offer completions that
+			// would lead the user into a command path that cannot succeed (e.g. an
+			// env-backed session where cached namespaces came from startup validation
+			// but there is no active context to apply them to).
+			if (!svc.getStatus().activeContextName) return null;
+			const lower = prefix.toLowerCase();
+			const items = svc
+				.getCachedNamespaces()
+				.filter(n => n.toLowerCase().startsWith(lower))
+				.map(n => ({ value: n, label: n }));
+			return items.length > 0 ? items : null;
+		},
+	},
+	{ name: "env", description: "Manage environment variables", usage: "set|unset|list [KEY=VALUE ...]" },
+	{ name: "set", description: "Set environment variable(s)", usage: "KEY=VALUE [KEY2=VALUE2 ...]" },
+	{
+		name: "unset",
+		description: "Remove environment variable(s)",
+		usage: "KEY [KEY2 ...]",
+		getArgumentCompletions(prefix: string) {
+			const lastSpace = prefix.lastIndexOf(" ");
+			const headRaw = lastSpace === -1 ? "" : prefix.slice(0, lastSpace + 1);
+			const tail = lastSpace === -1 ? prefix : prefix.slice(lastSpace + 1);
+			const svc = tryGetContextService();
+			if (!svc) return null;
+			const knownKeys = svc.getActiveEnvKeys();
+			const knownExact = new Set(knownKeys);
+			// Group known keys by their lowercased form so we can detect
+			// case-distinct collisions (e.g. both `Foo` and `FOO` present).
+			const variantsByLower = new Map<string, string[]>();
+			for (const k of knownKeys) {
+				const lower = k.toLowerCase();
+				const existing = variantsByLower.get(lower);
+				if (existing) existing.push(k);
+				else variantsByLower.set(lower, [k]);
+			}
+			// Normalization priority:
+			//   1. Exact-case match → preserve user's token verbatim
+			//   2. Lowercase maps to exactly one canonical → rewrite (the common
+			//      "user typed lowercase, context has uppercase" path)
+			//   3. Lowercase maps to multiple canonicals (ambiguous) → preserve
+			//      as-typed. Auto-picking one would silently target the wrong
+			//      variable. The handler will match nothing and report a no-op,
+			//      letting the user retype the exact case they meant.
+			//   4. No match → preserve as-typed so typos surface via handler.
+			const typedTokens = headRaw.trim().split(/\s+/).filter(Boolean);
+			const normalizedTokens = typedTokens.map(t => {
+				if (knownExact.has(t)) return t;
+				const variants = variantsByLower.get(t.toLowerCase());
+				if (variants && variants.length === 1) return variants[0];
+				return t;
+			});
+			const head = normalizedTokens.length > 0 ? `${normalizedTokens.join(" ")} ` : "";
+			const alreadyExact = new Set(normalizedTokens);
+			const items = knownKeys
+				.filter(k => !alreadyExact.has(k))
+				.filter(k => k.toLowerCase().startsWith(tail.toLowerCase()))
+				.map(k => ({
+					value: `${head}${k} `,
+					label: k,
+					description: "env var on active context",
+				}));
+			return items.length > 0 ? items : null;
+		},
+	},
+	{ name: "wizard", description: "Guided interactive context setup" },
+];
 
 const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 	{
@@ -985,234 +1215,50 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 		name: "context",
 		description: "Manage F5 XC authentication contexts",
 		allowArgs: true,
-		subcommands: [
-			{ name: "list", description: "List all contexts" },
-			{
-				name: "activate",
-				description: "Switch to a named context",
-				usage: "<name>",
-				getArgumentCompletions(prefix: string) {
-					if (prefix.includes(" ")) return null;
-					const svc = tryGetContextService();
-					if (!svc) return null;
-					const lower = prefix.toLowerCase();
-					const items = svc
-						.listContextNamesCached()
-						.filter(n => n.toLowerCase().startsWith(lower))
-						.map(n => {
-							const hint = svc.getContextHint(n);
-							const parts: string[] = [];
-							if (hint?.apiUrl) parts.push(hint.apiUrl);
-							if (hint?.incompatible && hint.schemaVersion !== undefined) {
-								parts.push(`incompatible: v${hint.schemaVersion}`);
-							}
-							return {
-								value: n,
-								label: n,
-								description: parts.length > 0 ? parts.join(" · ") : undefined,
-							};
-						});
-					return items.length > 0 ? items : null;
-				},
-			},
-			{
-				name: "validate",
-				description: "Validate credentials for a context without activating",
-				usage: "<name>",
-				getArgumentCompletions(prefix: string) {
-					if (prefix.includes(" ")) return null;
-					const svc = tryGetContextService();
-					if (!svc) return null;
-					const lower = prefix.toLowerCase();
-					const items = svc
-						.listContextNamesCached()
-						.filter(n => n.toLowerCase().startsWith(lower))
-						.map(n => {
-							const hint = svc.getContextHint(n);
-							const parts: string[] = [];
-							if (hint?.apiUrl) parts.push(hint.apiUrl);
-							if (hint?.incompatible && hint.schemaVersion !== undefined) {
-								parts.push(`incompatible: v${hint.schemaVersion}`);
-							}
-							return {
-								value: n,
-								label: n,
-								description: parts.length > 0 ? parts.join(" · ") : undefined,
-							};
-						});
-					return items.length > 0 ? items : null;
-				},
-			},
-			{ name: "show", description: "Show context details (masked)", usage: "[name]" },
-			{ name: "status", description: "Show current auth status" },
-			{ name: "create", description: "Create a new context", usage: "<name> <url> <token> [namespace]" },
-			{ name: "delete", description: "Delete a context", usage: "<name> --confirm" },
-			{
-				name: "rename",
-				description: "Rename a context",
-				usage: "<old> <new>",
-				getArgumentCompletions(prefix: string) {
-					if (prefix.includes(" ")) return null;
-					const svc = tryGetContextService();
-					if (!svc) return null;
-					const lower = prefix.toLowerCase();
-					const items = svc
-						.listContextNamesCached()
-						.filter(n => n.toLowerCase().startsWith(lower))
-						.map(n => ({ value: n, label: n }));
-					return items.length > 0 ? items : null;
-				},
-			},
-			{
-				name: "export",
-				description: "Export a context (or all contexts) as JSON",
-				usage: "[name] [--include-token]",
-				getArgumentCompletions(prefix: string) {
-					const svc = tryGetContextService();
-					if (!svc) return null;
-					const tokens = prefix.split(/\s+/).filter(Boolean);
-					const hasIncludeToken = tokens.includes("--include-token");
-					const positionalsTyped = tokens.filter(t => !t.startsWith("--"));
-					// Last token is "in-progress" if the prefix does not end with space.
-					const trailingSpace = prefix.endsWith(" ") || prefix === "";
-					const typedPositionalCount = trailingSpace
-						? positionalsTyped.length
-						: Math.max(0, positionalsTyped.length - 1);
-					const completingToken = trailingSpace ? "" : (tokens[tokens.length - 1] ?? "");
-					// `head` is every already-typed token EXCEPT the one being
-					// completed. getArgumentCompletions.value replaces the whole
-					// argument tail, so value must carry every token the user
-					// should keep — otherwise accepting a suggestion silently
-					// drops the other args. Contract: see SubcommandDef JSDoc
-					// above (line ~58).
-					const headTokens = trailingSpace ? tokens : tokens.slice(0, -1);
-					const head = headTokens.length > 0 ? `${headTokens.join(" ")} ` : "";
-
-					const items: { value: string; label: string; description?: string }[] = [];
-
-					// Offer context names only if no positional has been filled yet.
-					// No startsWith("--") guard: context names legitimately allow
-					// leading dashes (the regex is /^[a-zA-Z0-9_-]{1,64}$/), and
-					// the handler's splitArgs uses a known-flags allowlist that
-					// treats only --include-token as a flag. So a context like
-					// `--prod` is valid; the completion filters by prefix and
-					// matches it naturally. When the user types `--in`, the
-					// flag-completion branch below matches `--include-token` by
-					// prefix; if there's ALSO a context starting with `--in` it
-					// is offered here. Both lists are disjoint by filter so
-					// there's no double-offer of the same token.
-					if (typedPositionalCount === 0) {
-						const lower = completingToken.toLowerCase();
-						for (const n of svc.listContextNamesCached()) {
-							if (!n.toLowerCase().startsWith(lower)) continue;
-							const hint = svc.getContextHint(n);
-							items.push({
-								value: `${head}${n}`,
-								label: n,
-								description: hint?.apiUrl,
-							});
-						}
-					}
-
-					// Offer --include-token unless already present. Match is
-					// case-sensitive because the handler's flag check uses
-					// exact-match `flags.has("--include-token")` — offering
-					// the suggestion for mis-cased prefixes (e.g. `--INCLUDE`)
-					// would produce a suggestion the handler then ignores.
-					if (!hasIncludeToken && "--include-token".startsWith(completingToken)) {
-						items.push({
-							value: `${head}--include-token`,
-							label: "--include-token",
-							description: "emit unmasked tokens",
-						});
-					}
-
-					return items.length > 0 ? items : null;
-				},
-			},
-			{
-				name: "import",
-				description: "Import contexts from a file path or inline JSON",
-				usage: "<path-or-json> [--overwrite]",
-				// No dynamic completion — paths are hard to complete correctly,
-				// and faking it would only mislead. Users pre-expand paths in
-				// their shell.
-			},
-			{
-				name: "namespace",
-				description: "Switch namespace within active context",
-				usage: "<namespace>",
-				getArgumentCompletions(prefix: string) {
-					if (prefix.includes(" ")) return null;
-					const svc = tryGetContextService();
-					if (!svc) return null;
-					// setNamespace() requires an active context. Don't offer completions that
-					// would lead the user into a command path that cannot succeed (e.g. an
-					// env-backed session where cached namespaces came from startup validation
-					// but there is no active context to apply them to).
-					if (!svc.getStatus().activeContextName) return null;
-					const lower = prefix.toLowerCase();
-					const items = svc
-						.getCachedNamespaces()
-						.filter(n => n.toLowerCase().startsWith(lower))
-						.map(n => ({ value: n, label: n }));
-					return items.length > 0 ? items : null;
-				},
-			},
-			{ name: "env", description: "Manage environment variables", usage: "set|unset|list [KEY=VALUE ...]" },
-			{ name: "set", description: "Set environment variable(s)", usage: "KEY=VALUE [KEY2=VALUE2 ...]" },
-			{
-				name: "unset",
-				description: "Remove environment variable(s)",
-				usage: "KEY [KEY2 ...]",
-				getArgumentCompletions(prefix: string) {
-					const lastSpace = prefix.lastIndexOf(" ");
-					const headRaw = lastSpace === -1 ? "" : prefix.slice(0, lastSpace + 1);
-					const tail = lastSpace === -1 ? prefix : prefix.slice(lastSpace + 1);
-					const svc = tryGetContextService();
-					if (!svc) return null;
-					const knownKeys = svc.getActiveEnvKeys();
-					const knownExact = new Set(knownKeys);
-					// Group known keys by their lowercased form so we can detect
-					// case-distinct collisions (e.g. both `Foo` and `FOO` present).
-					const variantsByLower = new Map<string, string[]>();
-					for (const k of knownKeys) {
-						const lower = k.toLowerCase();
-						const existing = variantsByLower.get(lower);
-						if (existing) existing.push(k);
-						else variantsByLower.set(lower, [k]);
-					}
-					// Normalization priority:
-					//   1. Exact-case match → preserve user's token verbatim
-					//   2. Lowercase maps to exactly one canonical → rewrite (the common
-					//      "user typed lowercase, context has uppercase" path)
-					//   3. Lowercase maps to multiple canonicals (ambiguous) → preserve
-					//      as-typed. Auto-picking one would silently target the wrong
-					//      variable. The handler will match nothing and report a no-op,
-					//      letting the user retype the exact case they meant.
-					//   4. No match → preserve as-typed so typos surface via handler.
-					const typedTokens = headRaw.trim().split(/\s+/).filter(Boolean);
-					const normalizedTokens = typedTokens.map(t => {
-						if (knownExact.has(t)) return t;
-						const variants = variantsByLower.get(t.toLowerCase());
-						if (variants && variants.length === 1) return variants[0];
-						return t;
+		getArgumentCompletions(argumentPrefix: string) {
+			const firstSpace = argumentPrefix.indexOf(" ");
+			if (firstSpace !== -1) {
+				const subName = argumentPrefix.slice(0, firstSpace).toLowerCase();
+				const subPrefix = argumentPrefix.slice(firstSpace + 1).replace(/^ +/, "");
+				const sub = CONTEXT_SUBCOMMANDS.find(s => s.name === subName);
+				if (!sub?.getArgumentCompletions) return null;
+				const items = sub.getArgumentCompletions(subPrefix);
+				if (!items || items.length === 0) return null;
+				return items.map(item => ({ ...item, value: `${subName} ${item.value}` }));
+			}
+			const lower = argumentPrefix.toLowerCase();
+			const items: { value: string; label: string; description?: string; hint?: string }[] = [];
+			const svc = tryGetContextService();
+			if (svc) {
+				for (const n of svc.listContextNamesCached()) {
+					if (!n.toLowerCase().startsWith(lower)) continue;
+					const hint = svc.getContextHint(n);
+					items.push({
+						value: `${n} `,
+						label: n,
+						description: hint?.apiUrl,
 					});
-					const head = normalizedTokens.length > 0 ? `${normalizedTokens.join(" ")} ` : "";
-					const alreadyExact = new Set(normalizedTokens);
-					const items = knownKeys
-						.filter(k => !alreadyExact.has(k))
-						.filter(k => k.toLowerCase().startsWith(tail.toLowerCase()))
-						.map(k => ({
-							value: `${head}${k} `,
-							label: k,
-							description: "env var on active context",
-						}));
-					return items.length > 0 ? items : null;
-				},
-			},
-			{ name: "wizard", description: "Guided interactive context setup" },
-		],
+				}
+				if (svc.previousContextName && "-".startsWith(lower)) {
+					items.push({
+						value: "- ",
+						label: "-",
+						description: `Switch to ${svc.previousContextName}`,
+					});
+				}
+			}
+			for (const sub of CONTEXT_SUBCOMMANDS) {
+				if (!sub.name.toLowerCase().startsWith(lower)) continue;
+				items.push({
+					value: `${sub.name} `,
+					label: sub.name,
+					description: sub.description,
+					hint: sub.usage,
+				});
+			}
+			return items.length > 0 ? items : null;
+		},
+		subcommands: CONTEXT_SUBCOMMANDS,
 		handle: async (command, runtime) => {
 			runtime.ctx.editor.addToHistory(command.text);
 			runtime.ctx.editor.setText("");
@@ -1238,6 +1284,7 @@ export const BUILTIN_SLASH_COMMAND_DEFS: ReadonlyArray<BuiltinSlashCommand> = BU
 		description: command.description,
 		subcommands: command.subcommands,
 		inlineHint: command.inlineHint,
+		getArgumentCompletions: command.getArgumentCompletions,
 	}),
 );
 

--- a/packages/coding-agent/test/context-completion.test.ts
+++ b/packages/coding-agent/test/context-completion.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Snowflake } from "@f5xc-salesdemos/pi-utils";
 import { _resetSettingsForTest, Settings } from "@f5xc-salesdemos/xcsh/config/settings";
+import { BUILTIN_SLASH_COMMANDS } from "@f5xc-salesdemos/xcsh/extensibility/slash-commands";
 import { ContextService, type F5XCContext } from "@f5xc-salesdemos/xcsh/services/f5xc-context";
 import { BUILTIN_SLASH_COMMAND_DEFS } from "@f5xc-salesdemos/xcsh/slash-commands/builtin-registry";
 import {
@@ -28,6 +29,12 @@ function getContextSubcommand(name: string) {
 	const sub = contextCmd.subcommands.find(s => s.name === name);
 	if (!sub) throw new Error(`subcommand '${name}' not found under /context`);
 	return sub;
+}
+
+function getContextTopLevelCompletions(prefix: string) {
+	const contextCmd = BUILTIN_SLASH_COMMANDS.find(c => c.name === "context");
+	if (!contextCmd?.getArgumentCompletions) throw new Error("context command has no getArgumentCompletions");
+	return contextCmd.getArgumentCompletions(prefix);
 }
 
 describe("/context activate completion", () => {
@@ -698,5 +705,104 @@ describe("/context export completion", () => {
 
 		const exportCmd = getContextSubcommand("export");
 		expect(exportCmd.getArgumentCompletions!("production --include-token ")).toBeNull();
+	});
+});
+
+describe("/context mixed completions", () => {
+	let testDir: string;
+	let f5xcConfigDir: string;
+	let f5xcContextsDir: string;
+	let projectDir: string;
+	let agentDir: string;
+
+	beforeEach(async () => {
+		_resetSettingsForTest();
+		ContextService._resetForTest();
+		for (const key of Object.keys(process.env)) {
+			if (key.startsWith("F5XC_")) delete process.env[key];
+		}
+		delete process.env.XDG_CONFIG_HOME;
+
+		testDir = path.join(os.tmpdir(), "test-context-mixed-completion", Snowflake.next());
+		f5xcConfigDir = path.join(testDir, "f5xc-config");
+		f5xcContextsDir = path.join(f5xcConfigDir, "contexts");
+		projectDir = path.join(testDir, "project");
+		agentDir = path.join(testDir, "agent");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.mkdirSync(path.join(projectDir, ".xcsh"), { recursive: true });
+		fs.mkdirSync(agentDir, { recursive: true });
+		await Settings.init({ cwd: projectDir, agentDir, inMemory: true });
+	});
+
+	afterEach(() => {
+		fs.rmSync(testDir, { recursive: true, force: true });
+		ContextService._resetForTest();
+		_resetSettingsForTest();
+	});
+
+	it("shows context names first, then dash-previous, then subcommands", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT);
+		writeContext(f5xcContextsDir, TEST_CONTEXT_STAGING);
+		writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+		await service.activate(TEST_CONTEXT_STAGING.name);
+
+		const items = getContextTopLevelCompletions("");
+		expect(items).not.toBeNull();
+		const labels = items!.map(i => i.label);
+		const prodIdx = labels.indexOf("production");
+		const stagingIdx = labels.indexOf("staging");
+		const dashIdx = labels.indexOf("-");
+		const listIdx = labels.indexOf("list");
+		expect(prodIdx).toBeGreaterThanOrEqual(0);
+		expect(stagingIdx).toBeGreaterThanOrEqual(0);
+		expect(dashIdx).toBeGreaterThan(stagingIdx);
+		expect(listIdx).toBeGreaterThan(dashIdx);
+	});
+
+	it("omits dash-previous when no previous context exists", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT);
+		writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const items = getContextTopLevelCompletions("");
+		expect(items).not.toBeNull();
+		const labels = items!.map(i => i.label);
+		expect(labels).not.toContain("-");
+		expect(labels).toContain("production");
+		expect(labels).toContain("list");
+	});
+
+	it("filters by prefix across both context names and subcommands", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT);
+		writeContext(f5xcContextsDir, TEST_CONTEXT_STAGING);
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const items = getContextTopLevelCompletions("s");
+		expect(items).not.toBeNull();
+		const labels = items!.map(i => i.label);
+		expect(labels).toContain("staging");
+		expect(labels).toContain("show");
+		expect(labels).toContain("status");
+		expect(labels).toContain("set");
+		expect(labels).not.toContain("production");
+		expect(labels).not.toContain("list");
+	});
+
+	it("delegates to subcommand completion when space is present", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT);
+		writeContext(f5xcContextsDir, TEST_CONTEXT_STAGING);
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const items = getContextTopLevelCompletions("activate ");
+		expect(items).not.toBeNull();
+		const labels = items!.map(i => i.label);
+		expect(labels).toContain("production");
+		expect(labels).toContain("staging");
+		expect(labels).not.toContain("list");
 	});
 });

--- a/packages/coding-agent/test/f5xc-context-command.test.ts
+++ b/packages/coding-agent/test/f5xc-context-command.test.ts
@@ -580,14 +580,15 @@ describe("/context slash command handler", () => {
 		expect(ctx.messages[0].text).toContain("Usage");
 	});
 
-	it("/context unknown shows error with valid subcommands", async () => {
+	it("/context unknown shows not-found error with create suggestion (dispatch refactor)", async () => {
 		ContextService.init(f5xcConfigDir);
 
 		const ctx = createMockCtx();
 		await handleContextCommand({ name: "context", args: "banana", text: "/context banana" }, ctx);
 
 		expect(ctx.messages[0].type).toBe("error");
-		expect(ctx.messages[0].text).toContain("Unknown subcommand");
+		expect(ctx.messages[0].text).toContain("not found");
+		expect(ctx.messages[0].text).toContain("/context create banana");
 	});
 
 	it("/context list shows version warning suffix for incompatible contexts", async () => {
@@ -1123,5 +1124,118 @@ describe("/context slash command handler", () => {
 		await handleContextCommand({ name: "context", args: `import --overwrite ${inline}`, text: "" }, ctx);
 		expect(ctx.messages[0].type).toBe("status");
 		expect(ctx.messages[0].text).toMatch(/overwrote/i);
+	});
+
+	it("/context <name> directly switches to a named context", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT);
+		writeContext(f5xcContextsDir, TEST_CONTEXT_2);
+		writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const ctx = createMockCtx();
+		await handleContextCommand(
+			{ name: "context", args: TEST_CONTEXT_2.name, text: `/context ${TEST_CONTEXT_2.name}` },
+			ctx,
+		);
+
+		expect(ctx.messages.length).toBeGreaterThanOrEqual(1);
+		expect(ctx.messages[0].type).toBe("status");
+		expect(ctx.calls.invalidate).toBeGreaterThan(0);
+	});
+
+	it("/context <nonexistent> shows error with create suggestion", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT);
+		writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const ctx = createMockCtx();
+		await handleContextCommand({ name: "context", args: "nonexistent", text: "/context nonexistent" }, ctx);
+
+		expect(ctx.messages.length).toBe(1);
+		expect(ctx.messages[0].type).toBe("error");
+		expect(ctx.messages[0].text).toContain("not found");
+		expect(ctx.messages[0].text).toContain("/context create nonexistent");
+	});
+
+	it("/context - switches to previous context", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT);
+		writeContext(f5xcContextsDir, TEST_CONTEXT_2);
+		writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+		await service.activate(TEST_CONTEXT_2.name);
+
+		const ctx = createMockCtx();
+		await handleContextCommand({ name: "context", args: "-", text: "/context -" }, ctx);
+
+		expect(ctx.messages.length).toBeGreaterThanOrEqual(1);
+		expect(ctx.messages[0].type).toBe("status");
+		expect(service.getStatus().activeContextName).toBe(TEST_CONTEXT.name);
+		expect(ctx.calls.invalidate).toBeGreaterThan(0);
+	});
+
+	it("/context - with no previous shows error", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT);
+		writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const ctx = createMockCtx();
+		await handleContextCommand({ name: "context", args: "-", text: "/context -" }, ctx);
+
+		expect(ctx.messages.length).toBe(1);
+		expect(ctx.messages[0].type).toBe("error");
+		expect(ctx.messages[0].text).toContain("No previous context");
+	});
+
+	it("/context list still works after dispatch refactor (regression)", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT);
+		writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const ctx = createMockCtx();
+		await handleContextCommand({ name: "context", args: "list", text: "/context list" }, ctx);
+
+		expect(ctx.messages.length).toBe(1);
+		expect(ctx.messages[0].type).toBe("status");
+		expect(ctx.messages[0].text).toContain("production");
+	});
+
+	it("/context (bare) still lists contexts (regression)", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT);
+		writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const ctx = createMockCtx();
+		await handleContextCommand({ name: "context", args: "", text: "/context" }, ctx);
+
+		expect(ctx.messages.length).toBe(1);
+		expect(ctx.messages[0].type).toBe("status");
+		expect(ctx.messages[0].text).toContain("production");
+	});
+
+	it("/context KEY=VALUE still sets env vars (regression)", async () => {
+		writeContext(f5xcContextsDir, TEST_CONTEXT);
+		writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+		const service = ContextService.init(f5xcConfigDir);
+		await service.loadActive();
+
+		const ctx = createMockCtx();
+		await handleContextCommand({ name: "context", args: "MY_VAR=hello", text: "/context MY_VAR=hello" }, ctx);
+
+		expect(ctx.messages.length).toBe(1);
+		expect(ctx.messages[0].type).toBe("status");
+		expect(ctx.messages[0].text).toContain("MY_VAR");
 	});
 });


### PR DESCRIPTION
## What

Refactor `/context` command dispatch to follow kubectx conventions:
- `/context <name>` directly switches context (no "activate" verb needed)
- `/context -` switches to previous context (cd `-` convention)
- Tab completions mix context names + `-` + subcommands (names first)
- Fix `ENV_SET_PATTERN.lastIndex` statefulness bug in default branch and `parseEnvPairs`
- Narrow `handleDirectSwitch` error rewriting to only "not found" errors (other ContextErrors pass through)

## Why

Completes the kubectl-informed `/context` UX redesign (#303). All three sub-issues now merged: #378 (reserved name guard), #379 (previous context tracking), #380 (dispatch refactor).

Closes #380

## Testing

- 287/287 tests pass across 3 suites (11 new: 7 dispatch + 4 completion)
- `bun check` clean
- Codex review — addressed Finding 2 (narrowed ContextError rewrite)
- Regression guards: `/context list`, bare `/context`, `/context KEY=VALUE` all preserved

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [x] Issue linked via `Closes #380`