### PR TITLE
feat: add progressive component discovery for demo infrastructure

### DIFF
--- a/.xcsh/skills/demo-components/SKILL.md
+++ b/.xcsh/skills/demo-components/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: demo-components
+description: Discover and deploy pre-configured demo infrastructure components (origin servers, traffic generators, CDN simulators) from the F5 XC component library. Invoke when users discuss building demos, need infrastructure, or ask about deploying demo environments.
+---
+
+# Demo Infrastructure Components
+
+You are helping a sales engineer discover, select, and deploy pre-configured
+demo infrastructure from the F5 Distributed Cloud component library.
+
+## Progressive Discovery
+
+Follow these layers in order. Only advance to the next layer when the user's
+intent requires more detail. Do not load all layers at once.
+
+### Layer 1 — Discover the catalog
+
+Fetch the docs portal llms.txt to see available components:
+
+1. Use the fetch tool to retrieve `https://f5xc-salesdemos.github.io/docs/llms.txt`
+2. Parse the `## Lab Infrastructure` section — each entry is a deployable component
+3. Present the catalog to the user:
+   - Component name and one-line description
+   - URL link to that component's llms.txt
+4. Ask which component(s) the user needs, or recommend based on their demo type
+
+**Demo-to-component recommendations:**
+- **WAF demo** → origin-server (vulnerable apps as WAF targets) + traffic-generator (attack traffic)
+- **API security demo** → origin-server (VAmPI, DVGA, RESTaurant, crAPI) + traffic-generator (API fuzzing)
+- **Bot defense demo** → origin-server + traffic-generator (bot simulation suites)
+- **CDN demo** → origin-server (content to cache) + cdn-simulator (CDN edge behavior)
+- **Client-side defense demo** → origin-server (CSD Demo app) + traffic-generator
+
+### Layer 2 — Component profile
+
+When the user selects a specific component or asks for more detail:
+
+1. Fetch that component's llms.txt (URL from the catalog)
+2. Present: architecture summary, what it provides, integration points, pairs_with
+3. Note which other components pair with it and why
+
+### Layer 3 — Deployment details
+
+When the user decides to deploy:
+
+1. Fetch the component's Deployment Guide custom set
+   - URL pattern: `https://f5xc-salesdemos.github.io/{component}/_llms-txt/deployment-guide.txt`
+2. Walk through prerequisites, required terraform variables, and deployment steps
+3. For each required terraform variable, ask the user to supply their value
+4. Guide the `terraform init` / `terraform plan` / `terraform apply` sequence
+
+## Session Caching
+
+Cache fetched content within this session. If the user asks about a component
+you already fetched, reuse the cached content rather than re-fetching.
+
+## Multi-Component Architectures
+
+When a demo requires multiple components:
+1. Present the full architecture showing how components connect to each other
+   and to the F5 XC platform
+2. Note deployment order — typically: origin-server first, then traffic-generator
+   pointing `target_fqdn` at the F5 XC load balancer FQDN
+3. Offer to walk through each component's deployment in sequence
+
+## Rules
+
+- Always fetch live from the docs portal — the component library updates as
+  repos are onboarded or decommissioned
+- Only present components that appear in the `## Lab Infrastructure` section
+  of the portal llms.txt — never fabricate component names or capabilities
+- If the `## Lab Infrastructure` section is absent, the portal may not yet have
+  categorized federation; fall back to the `## Federated Sites` section and
+  filter for entries whose descriptions mention "VM", "terraform", or "Azure"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,3 +529,16 @@ Use these sections under `## [Unreleased]`:
    ```
 
 The script handles: version bump, CHANGELOG finalization, commit, tag, publish, and adding new `[Unreleased]` sections.
+
+## Demo Infrastructure Components
+
+You have access to a library of deployable demo infrastructure components —
+pre-configured Azure VMs that can be deployed via Terraform to support live F5
+Distributed Cloud demos. Components include origin servers with vulnerable web
+applications, traffic generators with attack suites, CDN simulators, and more.
+The library grows over time as new components are added to the ecosystem.
+
+When users discuss building demos, need infrastructure for testing, ask about
+deploying demo environments, or reference origin servers, traffic generators, or
+attack traffic, invoke the `demo-components` skill to discover available
+components and guide the architecture and deployment process.

--- a/tests/skills/demo-components.test.ts
+++ b/tests/skills/demo-components.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from 'bun:test';
+
+const CATEGORIZED_LLMS_TXT = `# F5 Distributed Cloud Sales Demos
+
+> Demo guides for F5 Distributed Cloud sales engineering.
+
+## Documentation Sets
+
+- [Abridged documentation](https://example.com/llms-small.txt): compact version
+- [Complete documentation](https://example.com/llms-full.txt): full docs
+
+## Lab Infrastructure
+Deployable Azure VM components for demo environments. Terraform-based, deterministic, pre-configured.
+
+- [Origin Server](https://example.com/origin-server/llms.txt): Ubuntu 24.04 origin server with vulnerable web applications
+- [Traffic Generator](https://example.com/traffic-generator/llms.txt): Azure VM with 50+ security tools and attack suites
+- [CDN Simulator](https://example.com/cdn-simulator/llms.txt): NGINX-based CDN edge node simulator
+
+## Product Features
+F5 XC product capability documentation and demo guides.
+
+- [WAF](https://example.com/waf/llms.txt): F5 XC web application firewall
+- [API Security](https://example.com/api-protection/llms.txt): F5 XC API security
+
+## Notes
+
+- Content is auto-generated from official docs
+`;
+
+const FLAT_LLMS_TXT = `# F5 Distributed Cloud Sales Demos
+
+## Federated Sites
+
+- [Origin Server](https://example.com/origin-server/llms.txt): Ubuntu 24.04 origin server
+- [WAF](https://example.com/waf/llms.txt): F5 XC web application firewall
+`;
+
+const EMPTY_LAB_LLMS_TXT = `# F5 Distributed Cloud Sales Demos
+
+## Product Features
+
+- [WAF](https://example.com/waf/llms.txt): F5 XC web application firewall
+`;
+
+interface SiteEntry {
+	label: string;
+	url: string;
+	description: string;
+}
+
+function parseSection(llmsTxt: string, sectionHeading: string): SiteEntry[] {
+	const escapedHeading = sectionHeading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const sectionRegex = new RegExp(
+		`^## ${escapedHeading}\\n(?:[^\\n#][^\\n]*\\n)?\\n((?:- \\[.*\\n)*)`,
+		'm'
+	);
+	const match = llmsTxt.match(sectionRegex);
+	if (!match) return [];
+
+	const entries: SiteEntry[] = [];
+	const entryRegex = /- \[([^\]]+)\]\(([^)]+)\)(?:: (.+))?/g;
+	let m: RegExpExecArray | null;
+	while ((m = entryRegex.exec(match[1])) !== null) {
+		entries.push({ label: m[1], url: m[2], description: m[3] || '' });
+	}
+	return entries;
+}
+
+function hasCategorizedFederation(llmsTxt: string): boolean {
+	return !llmsTxt.includes('\n## Federated Sites\n');
+}
+
+function parseLabInfrastructure(llmsTxt: string): SiteEntry[] {
+	return parseSection(llmsTxt, 'Lab Infrastructure');
+}
+
+describe('parseLabInfrastructure', () => {
+	test('extracts all components from ## Lab Infrastructure', () => {
+		const components = parseLabInfrastructure(CATEGORIZED_LLMS_TXT);
+		expect(components).toHaveLength(3);
+	});
+
+	test('extracts correct labels', () => {
+		const components = parseLabInfrastructure(CATEGORIZED_LLMS_TXT);
+		expect(components[0].label).toBe('Origin Server');
+		expect(components[1].label).toBe('Traffic Generator');
+		expect(components[2].label).toBe('CDN Simulator');
+	});
+
+	test('extracts correct URLs', () => {
+		const components = parseLabInfrastructure(CATEGORIZED_LLMS_TXT);
+		expect(components[0].url).toBe('https://example.com/origin-server/llms.txt');
+	});
+
+	test('extracts descriptions', () => {
+		const components = parseLabInfrastructure(CATEGORIZED_LLMS_TXT);
+		expect(components[0].description).toContain('vulnerable web applications');
+	});
+
+	test('returns empty when no Lab Infrastructure section', () => {
+		expect(parseLabInfrastructure(FLAT_LLMS_TXT)).toHaveLength(0);
+	});
+
+	test('returns empty when Lab Infrastructure section is absent', () => {
+		expect(parseLabInfrastructure(EMPTY_LAB_LLMS_TXT)).toHaveLength(0);
+	});
+});
+
+describe('parseSection', () => {
+	test('extracts Product Features section', () => {
+		const entries = parseSection(CATEGORIZED_LLMS_TXT, 'Product Features');
+		expect(entries).toHaveLength(2);
+		expect(entries[0].label).toBe('WAF');
+		expect(entries[1].label).toBe('API Security');
+	});
+
+	test('returns empty for nonexistent section', () => {
+		expect(parseSection(CATEGORIZED_LLMS_TXT, 'Nonexistent')).toHaveLength(0);
+	});
+
+	test('does not bleed into next section', () => {
+		const labEntries = parseSection(CATEGORIZED_LLMS_TXT, 'Lab Infrastructure');
+		const labels = labEntries.map((e) => e.label);
+		expect(labels).not.toContain('WAF');
+	});
+});
+
+describe('hasCategorizedFederation', () => {
+	test('returns true for categorized llms.txt', () => {
+		expect(hasCategorizedFederation(CATEGORIZED_LLMS_TXT)).toBe(true);
+	});
+
+	test('returns false for flat Federated Sites format', () => {
+		expect(hasCategorizedFederation(FLAT_LLMS_TXT)).toBe(false);
+	});
+});


### PR DESCRIPTION
## What

Add a new `demo-components` skill that enables xcsh to progressively discover
and surface deployable demo infrastructure components through the categorized
llms.txt federation hierarchy.

## Why

Demo infrastructure components are spread across multiple repositories with no
unified discovery mechanism. This skill provides structured component lookup so
agents can find and recommend the right infrastructure pieces during demos.

Closes #399

## Testing

- [x] `SKIP=super-linter pre-commit run` passes on all staged files
- [x] Markdown lint errors fixed (blank lines before lists)
- [x] Unit test file added: `tests/skills/demo-components.test.ts`
- [x] Issue linked via `Closes #399`