### PR TITLE
fix(coding-agent): detect redirect and non-JSON responses in validateToken

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -14,7 +14,7 @@ const STARTUP_RETRY_DELAY_MS = 500;
 
 type ContextValidator = (opts: {
 	timeoutMs: number;
-}) => Promise<{ status: AuthStatus; latencyMs?: number; errorClass?: "network" | "credential" }>;
+}) => Promise<{ status: AuthStatus; latencyMs?: number; errorClass?: "network" | "credential" | "url_not_found" }>;
 
 /**
  * Runs the context validator once with a startup-sized timeout; if the result is `offline`
@@ -28,7 +28,7 @@ export async function validateContextWithStartupRetry(
 		retryTimeoutMs?: number;
 		retryDelayMs?: number;
 	},
-): Promise<{ status: AuthStatus; latencyMs?: number }> {
+): Promise<{ status: AuthStatus; latencyMs?: number; errorClass?: "network" | "credential" | "url_not_found" }> {
 	const firstTimeoutMs = options?.firstTimeoutMs ?? STARTUP_FIRST_TIMEOUT_MS;
 	const retryTimeoutMs = options?.retryTimeoutMs ?? STARTUP_RETRY_TIMEOUT_MS;
 	const retryDelayMs = options?.retryDelayMs ?? STARTUP_RETRY_DELAY_MS;
@@ -56,6 +56,7 @@ export interface WelcomeContextStatus {
 	state: ContextCheckState;
 	name?: string;
 	latencyMs?: number;
+	errorClass?: "network" | "credential" | "url_not_found";
 }
 
 export interface WelcomeCheckResult {
@@ -167,7 +168,7 @@ async function checkContextStatus(): Promise<WelcomeContextStatus> {
 			case "auth_error":
 				return { state: "auth_error", name };
 			case "offline":
-				return { state: "offline", name };
+				return { state: "offline", name, errorClass: result.errorClass };
 			default:
 				return { state: "no_context" };
 		}

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -232,6 +232,12 @@ export class WelcomeComponent implements Component {
 					`   ${theme.fg("dim", "Run /context to update")}`,
 				];
 			case "offline":
+				if (this.contextStatus?.errorClass === "url_not_found") {
+					return [
+						` ${formatStatusIcon("error")} ${theme.fg("muted", n)} ${theme.fg("error", "\u2014 tenant not found")}`,
+						`   ${theme.fg("dim", "Recreate with /context create or check with /context show")}`,
+					];
+				}
 				return [
 					` ${formatStatusIcon("warning")} ${theme.fg("muted", n)} ${theme.fg("warning", "\u2014 unreachable")}`,
 					`   ${theme.fg("dim", "Check network, /context")}`,

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -114,7 +114,7 @@ export interface ValidationResult {
 	context: F5XCContext;
 	status: AuthStatus;
 	latencyMs?: number;
-	errorClass?: "network" | "credential";
+	errorClass?: "network" | "credential" | "url_not_found";
 }
 
 export class ContextError extends Error {
@@ -915,7 +915,7 @@ export class ContextService {
 		timeoutMs?: number;
 		apiUrl?: string;
 		apiToken?: string;
-	}): Promise<{ status: AuthStatus; latencyMs?: number; errorClass?: "network" | "credential" }> {
+	}): Promise<{ status: AuthStatus; latencyMs?: number; errorClass?: "network" | "credential" | "url_not_found" }> {
 		// Use explicit credentials if provided (for non-active contexts or env-backed sessions),
 		// otherwise fall back to effective credentials (env override > active context)
 		const effectiveUrl = options?.apiUrl ?? process.env[F5XC_API_URL] ?? this.#activeContext?.apiUrl;
@@ -946,13 +946,23 @@ export class ContextService {
 				method: "GET",
 				headers: { Authorization: `APIToken ${effectiveToken}`, Accept: "application/json" },
 				signal: AbortSignal.timeout(timeout),
+				redirect: "manual",
 			});
 			const latencyMs = Math.round(performance.now() - start);
 			if (!adHoc) {
 				this.#lastAuthLatencyMs = latencyMs;
 				this.#lastAuthCheckedAt = checkedAt;
 			}
+			if (response.type === "opaqueredirect" || (response.status >= 300 && response.status < 400)) {
+				if (!adHoc) this.#authStatus = "offline";
+				return { status: "offline", latencyMs, errorClass: "url_not_found" };
+			}
 			if (response.ok) {
+				const contentType = response.headers.get("content-type") ?? "";
+				if (!contentType.includes("application/json")) {
+					if (!adHoc) this.#authStatus = "offline";
+					return { status: "offline", latencyMs, errorClass: "url_not_found" };
+				}
 				if (!adHoc) this.#authStatus = "connected";
 				return { status: "connected", latencyMs };
 			}

--- a/packages/coding-agent/src/services/f5xc-table.ts
+++ b/packages/coding-agent/src/services/f5xc-table.ts
@@ -23,7 +23,7 @@ const r = (s: string) => `${F5_RED}${s}${RESET}`;
 export function formatAuthIndicator(
 	status: AuthStatus,
 	latencyMs?: number,
-	errorClass?: "network" | "credential",
+	errorClass?: "network" | "credential" | "url_not_found",
 ): string {
 	const ms = latencyMs !== undefined ? ` (${latencyMs}ms)` : "";
 	switch (status) {
@@ -32,6 +32,9 @@ export function formatAuthIndicator(
 		case "auth_error":
 			return `${formatStatusIcon("error")} Auth Error — check token${ms}`;
 		case "offline":
+			if (errorClass === "url_not_found") {
+				return `${formatStatusIcon("error")} Offline — tenant URL not found${ms}`;
+			}
 			return `${formatStatusIcon("warning")} Offline — ${errorClass === "credential" ? "auth issue" : "network issue"}${ms}`;
 		default:
 			return `${formatStatusIcon("unknown")} Unknown`;

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -1033,13 +1033,26 @@ describe("ContextService", () => {
 			globalThis.fetch = savedFetch;
 		});
 
-		function makeMockResponse(status: number): typeof globalThis.fetch {
-			const fn = () => Promise.resolve(new Response(status === 200 ? "ok" : "err", { status }));
+		function makeMockResponse(status: number, headers?: Record<string, string>): typeof globalThis.fetch {
+			const effectiveHeaders = headers ?? (status === 200 ? { "content-type": "application/json" } : {});
+			const fn = () =>
+				Promise.resolve(new Response(status === 200 ? "{}" : "err", { status, headers: effectiveHeaders }));
 			return fn as unknown as typeof globalThis.fetch;
 		}
 
 		function makeNetworkError(): typeof globalThis.fetch {
 			const fn = () => Promise.reject(new Error("network failure"));
+			return fn as unknown as typeof globalThis.fetch;
+		}
+
+		function makeRedirectResponse(): typeof globalThis.fetch {
+			const fn = () =>
+				Promise.resolve({
+					type: "opaqueredirect" as ResponseType,
+					status: 0,
+					ok: false,
+					headers: new Headers(),
+				} as unknown as Response);
 			return fn as unknown as typeof globalThis.fetch;
 		}
 
@@ -1112,6 +1125,33 @@ describe("ContextService", () => {
 			expect(result.status).toBe("unknown");
 			expect(result.errorClass).toBeUndefined();
 		});
+
+		it("redirect response returns offline with errorClass: url_not_found", async () => {
+			globalThis.fetch = makeRedirectResponse();
+			const service = ContextService.init(f5xcConfigDir);
+			const result = await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(result.status).toBe("offline");
+			expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+			expect(result.errorClass).toBe("url_not_found");
+		});
+
+		it("200 with non-JSON content-type returns offline with errorClass: url_not_found", async () => {
+			globalThis.fetch = makeMockResponse(200, { "content-type": "text/html" });
+			const service = ContextService.init(f5xcConfigDir);
+			const result = await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(result.status).toBe("offline");
+			expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+			expect(result.errorClass).toBe("url_not_found");
+		});
+
+		it("200 with application/json charset variant returns connected", async () => {
+			globalThis.fetch = makeMockResponse(200, { "content-type": "application/json; charset=utf-8" });
+			const service = ContextService.init(f5xcConfigDir);
+			const result = await service.validateToken({ apiUrl: "https://t.console.ves.volterra.io", apiToken: "tok" });
+			expect(result.status).toBe("connected");
+			expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+			expect(result.errorClass).toBeUndefined();
+		});
 	});
 
 	describe("validateContextByName", () => {
@@ -1126,7 +1166,8 @@ describe("ContextService", () => {
 		});
 
 		function makeMockResponse(status: number): typeof globalThis.fetch {
-			const fn = () => Promise.resolve(new Response(status === 200 ? "ok" : "err", { status }));
+			const headers = status === 200 ? { "content-type": "application/json" } : {};
+			const fn = () => Promise.resolve(new Response(status === 200 ? "{}" : "err", { status, headers }));
 			return fn as unknown as typeof globalThis.fetch;
 		}
 
@@ -1485,7 +1526,8 @@ describe("ContextService", () => {
 		});
 
 		function makeMockResponse(status: number): typeof globalThis.fetch {
-			const fn = () => Promise.resolve(new Response(status === 200 ? "ok" : "err", { status }));
+			const headers = status === 200 ? { "content-type": "application/json" } : {};
+			const fn = () => Promise.resolve(new Response(status === 200 ? "{}" : "err", { status, headers }));
 			return fn as unknown as typeof globalThis.fetch;
 		}
 
@@ -2374,7 +2416,7 @@ describe("ContextService", () => {
 			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
 
 			globalThis.fetch = (async () => {
-				return new Response(JSON.stringify({}), { status: 200 });
+				return new Response(JSON.stringify({}), { status: 200, headers: { "content-type": "application/json" } });
 			}) as unknown as typeof globalThis.fetch;
 
 			const service = ContextService.init(f5xcConfigDir);

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -1048,7 +1048,7 @@ describe("ContextService", () => {
 		function makeRedirectResponse(): typeof globalThis.fetch {
 			const fn = () =>
 				Promise.resolve({
-					type: "opaqueredirect" as ResponseType,
+					type: "opaqueredirect" as Response["type"],
 					status: 0,
 					ok: false,
 					headers: new Headers(),

--- a/packages/coding-agent/test/f5xc-table.test.ts
+++ b/packages/coding-agent/test/f5xc-table.test.ts
@@ -42,6 +42,13 @@ describe("formatAuthIndicator (unified emoji indicators)", () => {
 	it("offline glyph matches formatStatusIcon('warning')", () => {
 		expect(formatAuthIndicator("offline").startsWith(formatStatusIcon("warning"))).toBe(true);
 	});
+
+	it("offline with url_not_found uses error glyph and shows tenant message", () => {
+		const out = formatAuthIndicator("offline", 42, "url_not_found");
+		expect(stripAnsi(out)).toContain("❌");
+		expect(stripAnsi(out)).toContain("tenant URL not found");
+		expect(stripAnsi(out)).toContain("(42ms)");
+	});
 });
 
 describe("renderF5XCTable", () => {

--- a/packages/coding-agent/test/welcome-checks.test.ts
+++ b/packages/coding-agent/test/welcome-checks.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import type { Model } from "@f5xc-salesdemos/pi-ai";
-import { runWelcomeChecks } from "@f5xc-salesdemos/xcsh/modes/components/welcome-checks";
+import {
+	runWelcomeChecks,
+	validateContextWithStartupRetry,
+} from "@f5xc-salesdemos/xcsh/modes/components/welcome-checks";
 
 function mockAuth(opts: { hasAuth?: boolean; peekApiKey?: string | undefined }) {
 	return { hasAuth: () => opts.hasAuth ?? false, peekApiKey: async () => opts.peekApiKey } as any;
@@ -47,5 +50,22 @@ describe("runWelcomeChecks", () => {
 	it("never includes context when model fails", async () => {
 		const r = await runWelcomeChecks(mockModel(), mockAuth({ hasAuth: false }));
 		expect(r.context).toBeUndefined();
+	});
+});
+
+describe("validateContextWithStartupRetry", () => {
+	it("propagates errorClass from validator result", async () => {
+		const validator = async () => ({
+			status: "offline" as const,
+			latencyMs: 42,
+			errorClass: "url_not_found" as const,
+		});
+		const result = await validateContextWithStartupRetry(validator, {
+			firstTimeoutMs: 100,
+			retryTimeoutMs: 100,
+			retryDelayMs: 0,
+		});
+		expect(result.status).toBe("offline");
+		expect(result.errorClass).toBe("url_not_found");
 	});
 });


### PR DESCRIPTION
## What

- Add `redirect:"manual"` to `validateToken()` fetch call to expose HTTP 302 redirects instead of silently following them to the login page
- Add a content-type guard that detects non-JSON 200 responses (e.g., HTML login pages)
- Propagate a new `url_not_found` errorClass through `welcome-checks.ts`, `welcome.ts`, and `f5xc-table.ts` so users see "tenant not found" instead of a false "connected" status

## Why

When a tenant URL is wrong or the tenant does not exist, F5 XC returns a 302 redirect to the login page. Because `fetch()` defaults to `redirect:"follow"`, `validateToken()` silently follows the redirect, receives a 200 OK with HTML content, and reports the tenant as "connected" — a false positive that confuses users.

Closes #403

## Testing

- Unit tests added for redirect detection (`f5xc-context-service.test.ts`)
- Unit tests added for `url_not_found` errorClass rendering (`f5xc-table.test.ts`, `welcome-checks.test.ts`)
- All existing tests continue to pass

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [x] Issue linked via `Closes #403`