### PR TITLE
feat: unify /context subcommand output under branded F5-red table chrome

### DIFF
--- a/packages/coding-agent/src/modes/controllers/context-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/context-command-controller.ts
@@ -1,3 +1,4 @@
+import { renderContextMessage } from "../../services/f5xc-table";
 import { ContextAddWizard } from "../components/context-add-wizard";
 import type { InteractiveModeContext } from "../types";
 
@@ -31,10 +32,11 @@ export class ContextCommandController {
 					const { ContextService } = await import("../../services/f5xc-context");
 					const service = await ContextService.getOrInit();
 					await service.createContext(context);
-					this.#ctx.showStatus(`Context '${context.name}' created.`);
 					if (shouldActivate) {
 						await service.activate(context.name);
-						this.#ctx.showStatus(`Context '${context.name}' activated.`);
+						this.#ctx.showStatus(renderContextMessage(context.name, "Created and activated."), { dim: false });
+					} else {
+						this.#ctx.showStatus(renderContextMessage(context.name, "Created."), { dim: false });
 					}
 					this.#ctx.statusLine?.invalidate();
 					this.#ctx.updateEditorTopBorder?.();

--- a/packages/coding-agent/src/services/f5xc-context-command.ts
+++ b/packages/coding-agent/src/services/f5xc-context-command.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import { SECRET_ENV_PATTERNS } from "../secrets/index";
 import { expandTilde } from "../tools/path-utils";
 import { ContextError, ContextService, CURRENT_SCHEMA_VERSION } from "./f5xc-context";
+import { formatStatusIcon } from "./f5xc-context-indicators";
 import {
 	deriveTenantFromUrl,
 	F5XC_API_TOKEN,
@@ -16,12 +17,13 @@ import {
 	formatExpiration,
 	formatRelativeTime,
 	formatRotation,
+	renderContextMessage,
 	renderF5XCTable,
 	type TableRow,
 } from "./f5xc-table";
 
 interface CommandContext {
-	showStatus(msg: string): void;
+	showStatus(msg: string, options?: { dim?: boolean }): void;
 	showError(msg: string): void;
 	editor: { setText(text: string): void };
 	statusLine?: { invalidate(): void };
@@ -130,20 +132,30 @@ async function handleList(ctx: CommandContext, service: ContextService): Promise
 		const status = service.getStatus();
 		if (status.credentialSource === "environment" && status.activeContextUrl) {
 			const label = deriveTenantFromUrl(status.activeContextUrl) ?? "(environment)";
-			ctx.showStatus(`  * ${sanitize(label).padEnd(20)} ${sanitize(status.activeContextUrl)}  (via env vars)`);
+			ctx.showStatus(
+				renderContextMessage(
+					"contexts",
+					`  * ${sanitize(label)}  ${sanitize(status.activeContextUrl)}  (via env vars)`,
+				),
+				{ dim: false },
+			);
 			return;
 		}
-		ctx.showStatus("No F5 XC contexts found. Use /context create or ask me to help set one up.");
+		ctx.showStatus(
+			renderContextMessage("contexts", "No F5 XC contexts found. Use /context create or ask me to help set one up."),
+			{ dim: false },
+		);
 		return;
 	}
 	const status = service.getStatus();
-	const lines = contexts.map(p => {
-		const marker = p.name === status.activeContextName ? "*" : " ";
+	const rows: TableRow[] = contexts.map(p => {
+		const isActive = p.name === status.activeContextName;
+		const marker = isActive ? `${formatStatusIcon("connected")} ` : "  ";
 		const versionSuffix =
 			p.version !== undefined && p.version > CURRENT_SCHEMA_VERSION ? ` (v${p.version} — upgrade required)` : "";
-		return `  ${marker} ${sanitize(p.name).padEnd(20)} ${sanitize(p.apiUrl)}${versionSuffix}`;
+		return { key: `${marker}${sanitize(p.name)}`, value: `${sanitize(p.apiUrl)}${versionSuffix}` };
 	});
-	ctx.showStatus(lines.join("\n"));
+	ctx.showStatus(renderF5XCTable("contexts", rows), { dim: false });
 }
 
 async function handleActivate(ctx: CommandContext, service: ContextService, name: string): Promise<void> {
@@ -286,7 +298,7 @@ async function handleShow(ctx: CommandContext, service: ContextService, name?: s
 		rows.push(...metaRows);
 	}
 
-	ctx.showStatus(renderF5XCTable(context.name, rows, { dividers }));
+	ctx.showStatus(renderF5XCTable(context.name, rows, { dividers }), { dim: false });
 }
 
 async function handleValidate(ctx: CommandContext, service: ContextService, name: string): Promise<void> {
@@ -305,7 +317,7 @@ async function handleValidate(ctx: CommandContext, service: ContextService, name
 			{ key: F5XC_API_TOKEN, value: service.maskToken(result.context.apiToken) },
 			{ key: "Status", value: formatAuthIndicator(result.status, result.latencyMs, result.errorClass) },
 		];
-		ctx.showStatus(renderF5XCTable(`${result.context.name} (validation only)`, rows));
+		ctx.showStatus(renderF5XCTable(`${result.context.name} (validation only)`, rows), { dim: false });
 	} catch (err) {
 		ctx.showError(err instanceof ContextError ? err.message : String(err));
 	}
@@ -314,7 +326,10 @@ async function handleValidate(ctx: CommandContext, service: ContextService, name
 async function handleStatus(ctx: CommandContext, service: ContextService): Promise<void> {
 	const status = service.getStatus();
 	if (!status.isConfigured) {
-		ctx.showStatus("F5 XC: not configured. Use /context create or ask me to help set one up.");
+		ctx.showStatus(
+			renderContextMessage("status", "Not configured. Use /context create or ask me to help set one up."),
+			{ dim: false },
+		);
 		return;
 	}
 	const auth = await service.validateToken({ timeoutMs: 3000 });
@@ -325,7 +340,7 @@ async function handleStatus(ctx: CommandContext, service: ContextService): Promi
 		{ key: "Namespace", value: status.activeContextNamespace ?? "(not set)" },
 		{ key: "Status", value: formatAuthIndicator(auth.status, auth.latencyMs, auth.errorClass) },
 	];
-	ctx.showStatus(renderF5XCTable(status.activeContextName ?? "status", rows));
+	ctx.showStatus(renderF5XCTable(status.activeContextName ?? "status", rows), { dim: false });
 }
 
 async function handleCreate(ctx: CommandContext, service: ContextService, args: string[]): Promise<void> {
@@ -355,7 +370,9 @@ async function handleCreate(ctx: CommandContext, service: ContextService, args: 
 			apiToken: token,
 			defaultNamespace: namespace ?? "default",
 		});
-		ctx.showStatus(`Context '${name}' created. Use /context activate ${name} to switch to it.`);
+		ctx.showStatus(renderContextMessage(name, `Created. Use /context activate ${name} to switch to it.`), {
+			dim: false,
+		});
 	} catch (err) {
 		ctx.showError(err instanceof ContextError ? err.message : String(err));
 	}
@@ -369,7 +386,7 @@ async function handleRename(ctx: CommandContext, service: ContextService, args: 
 	}
 	try {
 		await service.renameContext(oldName, newName);
-		ctx.showStatus(`Context '${oldName}' renamed to '${newName}'.`);
+		ctx.showStatus(renderContextMessage(newName, `Renamed from '${oldName}'.`), { dim: false });
 		ctx.statusLine?.invalidate();
 		ctx.updateEditorTopBorder?.();
 		ctx.ui?.requestRender();
@@ -452,13 +469,13 @@ async function handleImport(ctx: CommandContext, service: ContextService, rawArg
 
 	try {
 		const result = await service.importContexts(parsed, { overwrite });
-		const lines: string[] = [];
-		lines.push(`Imported ${result.imported.length} context${result.imported.length === 1 ? "" : "s"}:`);
-		for (const name of result.imported) lines.push(`  + ${name}`);
+		const bodyLines: string[] = [];
+		bodyLines.push(`Imported ${result.imported.length} context${result.imported.length === 1 ? "" : "s"}:`);
+		for (const name of result.imported) bodyLines.push(`  + ${name}`);
 		if (result.overwritten.length > 0) {
-			lines.push(`Overwrote ${result.overwritten.length}: ${result.overwritten.join(", ")}`);
+			bodyLines.push(`Overwrote ${result.overwritten.length}: ${result.overwritten.join(", ")}`);
 		}
-		ctx.showStatus(lines.join("\n"));
+		ctx.showStatus(renderContextMessage("import", bodyLines.join("\n")), { dim: false });
 		// Invalidate TUI chrome IF the active context was overwritten. The
 		// service's importContexts re-activates the active context when an
 		// overwrite touches it, which means #activeContext, bash.environment,
@@ -491,13 +508,17 @@ async function handleDelete(ctx: CommandContext, service: ContextService, args: 
 	}
 	if (!confirmed) {
 		ctx.showStatus(
-			`This will permanently delete context '${name}' from ~/.config/f5xc/contexts/.\nRun /context delete ${name} --confirm to proceed.`,
+			renderContextMessage(
+				name,
+				`This will permanently delete context '${name}' from ~/.config/f5xc/contexts/.\nRun /context delete ${name} --confirm to proceed.`,
+			),
+			{ dim: false },
 		);
 		return;
 	}
 	try {
 		await service.deleteContext(name);
-		ctx.showStatus(`Context '${name}' deleted.`);
+		ctx.showStatus(renderContextMessage(name, "Deleted."), { dim: false });
 	} catch (err) {
 		ctx.showError(err instanceof ContextError ? err.message : String(err));
 	}
@@ -512,7 +533,7 @@ async function handleNamespace(ctx: CommandContext, service: ContextService, nam
 	}
 	try {
 		service.setNamespace(namespace);
-		ctx.showStatus(`Namespace switched to: ${namespace}`);
+		ctx.showStatus(renderContextMessage("namespace", `Namespace → ${namespace}`), { dim: false });
 		ctx.statusLine?.invalidate();
 		ctx.updateEditorTopBorder?.();
 		ctx.ui?.requestRender();
@@ -597,7 +618,7 @@ async function handleEnvList(ctx: CommandContext, service: ContextService): Prom
 	const contexts = await service.listContexts();
 	const context = contexts.find(p => p.name === contextName);
 	if (!context?.env || Object.keys(context.env).length === 0) {
-		ctx.showStatus(`Context '${contextName}' has no custom environment variables.`);
+		ctx.showStatus(renderContextMessage(`${contextName} env`, "No custom environment variables."), { dim: false });
 		return;
 	}
 	const rows: TableRow[] = [];
@@ -605,7 +626,7 @@ async function handleEnvList(ctx: CommandContext, service: ContextService): Prom
 		const sensitive = isSensitiveKey(key) || (context.sensitiveKeys ?? []).includes(key);
 		rows.push({ key: sanitize(key), value: sensitive ? service.maskToken(value) : sanitize(value) });
 	}
-	ctx.showStatus(renderF5XCTable(`${contextName} env`, rows));
+	ctx.showStatus(renderF5XCTable(`${contextName} env`, rows), { dim: false });
 }
 
 async function handleEnvSet(ctx: CommandContext, service: ContextService, args: string): Promise<void> {
@@ -623,15 +644,14 @@ async function handleEnvSet(ctx: CommandContext, service: ContextService, args: 
 	}
 	try {
 		const result = await service.setEnvVars(contextName, vars);
-		const lines: string[] = [];
+		const bodyLines: string[] = [];
+		bodyLines.push(`Set ${keys.length} variable${keys.length > 1 ? "s" : ""} on '${contextName}':`);
 		for (const key of keys) {
 			const lock = result.sensitive.includes(key) ? " (auto-sensitive)" : "";
 			const displayValue = isSensitiveKey(key) ? "***" : vars[key];
-			lines.push(`  ${key}=${displayValue}${lock}`);
+			bodyLines.push(`  ${key}=${displayValue}${lock}`);
 		}
-		ctx.showStatus(
-			`Set ${keys.length} variable${keys.length > 1 ? "s" : ""} on '${contextName}':\n${lines.join("\n")}`,
-		);
+		ctx.showStatus(renderContextMessage(contextName, bodyLines.join("\n")), { dim: false });
 		ctx.statusLine?.invalidate();
 	} catch (err) {
 		ctx.showError(err instanceof ContextError ? err.message : String(err));
@@ -653,11 +673,15 @@ async function handleEnvUnset(ctx: CommandContext, service: ContextService, args
 	try {
 		const result = await service.unsetEnvVars(contextName, keys);
 		if (result.removed.length === 0) {
-			ctx.showStatus(`No matching variables found on '${contextName}'.`);
+			ctx.showStatus(renderContextMessage(contextName, "No matching variables found."), { dim: false });
 			return;
 		}
 		ctx.showStatus(
-			`Removed ${result.removed.length} variable${result.removed.length > 1 ? "s" : ""} from '${contextName}':\n${result.removed.map(k => `  ${k}`).join("\n")}`,
+			renderContextMessage(
+				contextName,
+				`Removed ${result.removed.length} variable${result.removed.length > 1 ? "s" : ""} from '${contextName}':\n${result.removed.map(k => `  ${k}`).join("\n")}`,
+			),
+			{ dim: false },
 		);
 		ctx.statusLine?.invalidate();
 	} catch (err) {

--- a/packages/coding-agent/src/services/f5xc-table.ts
+++ b/packages/coding-agent/src/services/f5xc-table.ts
@@ -141,3 +141,24 @@ export function renderF5XCTable(title: string, rows: TableRow[], options?: Table
 
 	return lines.join("\n");
 }
+
+export function renderContextMessage(title: string, body: string): string {
+	const bodyLines = body.split("\n");
+	const maxLine = Math.max(...bodyLines.map(l => visibleWidth(l)), 0);
+	const innerWidth = Math.max(maxLine + 2, visibleWidth(title) + 3, 40);
+
+	const lines: string[] = [];
+
+	const titleText = ` ${title} `;
+	const titlePad = innerWidth - visibleWidth(titleText) - 1;
+	lines.push(`${r(BOX.tl + BOX.h)}${BOLD}${titleText}${RESET}${r(BOX.h.repeat(Math.max(0, titlePad)) + BOX.tr)}`);
+
+	for (const bodyLine of bodyLines) {
+		const pad = innerWidth - visibleWidth(bodyLine) - 2;
+		lines.push(`${r(BOX.v)} ${bodyLine}${" ".repeat(Math.max(0, pad))} ${r(BOX.v)}`);
+	}
+
+	lines.push(r(BOX.bl + BOX.h.repeat(innerWidth) + BOX.br));
+
+	return lines.join("\n");
+}

--- a/packages/coding-agent/test/f5xc-context-command.test.ts
+++ b/packages/coding-agent/test/f5xc-context-command.test.ts
@@ -155,7 +155,7 @@ function createMockCtx() {
 	return {
 		messages,
 		calls,
-		showStatus(msg: string) {
+		showStatus(msg: string, _options?: { dim?: boolean }) {
 			messages.push({ type: "status", text: msg });
 		},
 		showError(msg: string) {
@@ -233,8 +233,11 @@ describe("/context slash command handler", () => {
 
 		expect(ctx.messages.length).toBe(1);
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toContain("* production");
-		expect(ctx.messages[0].text).toContain("  staging");
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("contexts");
+		expect(plain).toContain("✅");
+		expect(plain).toContain("production");
+		expect(plain).toContain("staging");
 	});
 
 	it("/context list shows helpful message when no contexts", async () => {
@@ -244,7 +247,9 @@ describe("/context slash command handler", () => {
 		await handleContextCommand({ name: "context", args: "list", text: "/context list" }, ctx);
 
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toContain("No F5 XC contexts found");
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("contexts");
+		expect(plain).toContain("No F5 XC contexts found");
 	});
 
 	it("/context list shows env-only entry when F5XC_API_URL is set", async () => {
@@ -257,8 +262,10 @@ describe("/context slash command handler", () => {
 		await handleContextCommand({ name: "context", args: "list", text: "/context list" }, ctx);
 
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toContain("acme");
-		expect(ctx.messages[0].text).toContain("via env vars");
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("contexts");
+		expect(plain).toContain("acme");
+		expect(plain).toContain("via env vars");
 	});
 
 	it("/context activate switches context", async () => {
@@ -340,7 +347,9 @@ describe("/context slash command handler", () => {
 		);
 
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toContain("Context 'myprof' created");
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("myprof");
+		expect(plain).toContain("Created");
 		// Context file should exist on disk
 		expect(fs.existsSync(path.join(f5xcContextsDir, "myprof.json"))).toBe(true);
 	});
@@ -469,7 +478,9 @@ describe("/context slash command handler", () => {
 		);
 
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toContain("deleted");
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("staging");
+		expect(plain).toContain("Deleted");
 		expect(fs.existsSync(path.join(f5xcContextsDir, "staging.json"))).toBe(false);
 	});
 
@@ -485,8 +496,9 @@ describe("/context slash command handler", () => {
 		await handleContextCommand({ name: "context", args: "delete staging", text: "/context delete staging" }, ctx);
 
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toContain("--confirm");
-		// File should still exist
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("staging");
+		expect(plain).toContain("--confirm");
 		expect(fs.existsSync(path.join(f5xcContextsDir, "staging.json"))).toBe(true);
 	});
 
@@ -545,7 +557,9 @@ describe("/context slash command handler", () => {
 		await handleContextCommand({ name: "context", args: "", text: "/context" }, ctx);
 
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toContain("* production");
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("contexts");
+		expect(plain).toContain("production");
 	});
 
 	// --- /context namespace ---
@@ -564,9 +578,9 @@ describe("/context slash command handler", () => {
 		);
 
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toContain("Namespace switched to: other-ns");
-
-		// Verify it actually changed
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("namespace");
+		expect(plain).toContain("other-ns");
 		expect(service.getStatus().activeContextNamespace).toBe("other-ns");
 	});
 
@@ -615,8 +629,10 @@ describe("/context slash command handler", () => {
 		await handleContextCommand({ name: "context", args: "list", text: "/context list" }, ctx);
 
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toContain("future");
-		expect(ctx.messages[0].text).toContain("upgrade required");
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("contexts");
+		expect(plain).toContain("future");
+		expect(plain).toContain("upgrade required");
 	});
 
 	describe("error message actionability", () => {
@@ -807,8 +823,9 @@ describe("/context slash command handler", () => {
 		const ctx = createMockCtx();
 		await handleContextCommand({ name: "context", args: `rename ${TEST_CONTEXT.name} prod-new`, text: "" }, ctx);
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toContain(`'${TEST_CONTEXT.name}'`);
-		expect(ctx.messages[0].text).toContain("'prod-new'");
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("prod-new");
+		expect(plain).toContain("Renamed");
 	});
 
 	it("/context rename surfaces ContextError when target exists", async () => {
@@ -928,7 +945,9 @@ describe("/context slash command handler", () => {
 		const ctx = createMockCtx();
 		await handleContextCommand({ name: "context", args: `import ${bundlePath}`, text: "" }, ctx);
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toMatch(/imported/i);
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("import");
+		expect(plain).toMatch(/imported/i);
 		expect(fs.existsSync(path.join(f5xcContextsDir, `${TEST_CONTEXT.name}.json`))).toBe(true);
 	});
 
@@ -999,7 +1018,8 @@ describe("/context slash command handler", () => {
 		const ctx = createMockCtx();
 		await handleContextCommand({ name: "context", args: `import ${inline} --overwrite`, text: "" }, ctx);
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toMatch(/overwrote/i);
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toMatch(/overwrote/i);
 	});
 
 	it("/context import --overwrite refreshes TUI chrome when the active context is touched", async () => {
@@ -1123,7 +1143,8 @@ describe("/context slash command handler", () => {
 		const ctx = createMockCtx();
 		await handleContextCommand({ name: "context", args: `import --overwrite ${inline}`, text: "" }, ctx);
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toMatch(/overwrote/i);
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toMatch(/overwrote/i);
 	});
 
 	it("/context <name> directly switches to a named context", async () => {
@@ -1206,7 +1227,9 @@ describe("/context slash command handler", () => {
 
 		expect(ctx.messages.length).toBe(1);
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toContain("production");
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("contexts");
+		expect(plain).toContain("production");
 	});
 
 	it("/context (bare) still lists contexts (regression)", async () => {
@@ -1221,7 +1244,9 @@ describe("/context slash command handler", () => {
 
 		expect(ctx.messages.length).toBe(1);
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toContain("production");
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("contexts");
+		expect(plain).toContain("production");
 	});
 
 	it("/context KEY=VALUE still sets env vars (regression)", async () => {
@@ -1236,6 +1261,7 @@ describe("/context slash command handler", () => {
 
 		expect(ctx.messages.length).toBe(1);
 		expect(ctx.messages[0].type).toBe("status");
-		expect(ctx.messages[0].text).toContain("MY_VAR");
+		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(plain).toContain("MY_VAR");
 	});
 });

--- a/packages/coding-agent/test/f5xc-security.test.ts
+++ b/packages/coding-agent/test/f5xc-security.test.ts
@@ -336,11 +336,12 @@ describe("F5XC security: TUI sanitization", () => {
 		await handleContextCommand({ name: "context", args: "list", text: "/context list" }, ctx);
 
 		const output = ctx.messages[0].text;
-		// \r\n stripped — "INJECTED" text remains inline but can't spoof a new line
-		const lines = output.split("\n");
-		// Should be a single line (no injected newlines breaking the output)
-		expect(lines.length).toBe(1);
-		expect(output).toContain("https://evil.io");
+		const plain = output.replace(/\x1b\[[0-9;]*m/g, "");
+		// \r\n stripped — "INJECTED" text remains inline but can't spoof a separate line
+		expect(plain).toContain("https://evil.ioINJECTED");
+		// The URL and injected text stay on the same line within the frame
+		const contentLines = plain.split("\n").filter(l => l.includes("evil.io"));
+		expect(contentLines.length).toBe(1);
 	});
 });
 

--- a/packages/coding-agent/test/f5xc-table.test.ts
+++ b/packages/coding-agent/test/f5xc-table.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { initTheme } from "../src/modes/theme/theme";
 import { formatStatusIcon } from "../src/services/f5xc-context-indicators";
-import { formatAuthIndicator, formatRotation, renderF5XCTable } from "../src/services/f5xc-table";
+import { formatAuthIndicator, formatRotation, renderContextMessage, renderF5XCTable } from "../src/services/f5xc-table";
 
 const vw = (s: string) => (s ? Bun.stringWidth(s) : 0);
 const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
@@ -130,5 +130,64 @@ describe("formatRotation", () => {
 		const result = formatRotation(30, "2026-02-26T12:00:00.000Z", now);
 		expect(result).toContain("every 30 days");
 		expect(result).toContain("overdue by");
+	});
+});
+
+describe("renderContextMessage", () => {
+	it("all lines have equal visible width", () => {
+		const output = renderContextMessage("test-title", "Hello world\nSecond line");
+		const lines = output.split("\n");
+		const widths = lines.map(l => vw(l));
+		expect(new Set(widths).size).toBe(1);
+	});
+
+	it("respects minimum inner width of 40", () => {
+		const output = renderContextMessage("x", "y");
+		const firstLine = output.split("\n")[0];
+		expect(vw(firstLine)).toBeGreaterThanOrEqual(42);
+	});
+
+	it("handles ANSI-colored body text without misalignment", () => {
+		const colored = "\x1b[32mSuccess\x1b[0m — context created";
+		const output = renderContextMessage("title", colored);
+		const lines = output.split("\n");
+		const widths = lines.map(l => vw(l));
+		expect(new Set(widths).size).toBe(1);
+	});
+
+	it("renders title in top border", () => {
+		const output = renderContextMessage("my-context", "Created.");
+		const plain = stripAnsi(output);
+		expect(plain).toContain("my-context");
+	});
+
+	it("renders body content inside frame", () => {
+		const output = renderContextMessage("title", "Line one\nLine two");
+		const plain = stripAnsi(output);
+		expect(plain).toContain("Line one");
+		expect(plain).toContain("Line two");
+	});
+
+	it("handles multi-line body with varying line lengths", () => {
+		const output = renderContextMessage("title", "Short\nThis is a much longer line of text");
+		const lines = output.split("\n");
+		const widths = lines.map(l => vw(l));
+		expect(new Set(widths).size).toBe(1);
+	});
+
+	it("handles single-line body", () => {
+		const output = renderContextMessage("ctx", "Deleted.");
+		const lines = output.split("\n");
+		expect(lines.length).toBe(3);
+		const widths = lines.map(l => vw(l));
+		expect(new Set(widths).size).toBe(1);
+	});
+
+	it("handles title wider than body without misalignment", () => {
+		const longName = "a".repeat(64);
+		const output = renderContextMessage(longName, "OK");
+		const lines = output.split("\n");
+		const widths = lines.map(l => vw(l));
+		expect(new Set(widths).size).toBe(1);
 	});
 });


### PR DESCRIPTION
## Summary

- Add `renderContextMessage(title, body)` helper in `f5xc-table.ts` for freeform text inside the branded F5-red table frame
- Migrate 15 bare `ctx.showStatus` calls across all `/context` subcommands to render inside the branded frame with `dim:false`
- Collapse wizard callbacks to a single framed output; export stays raw JSON, errors stay unframed
- Update context-command-controller to pass through frame rendering
- Add and update tests for the new table helper and context command output

Closes #408

## Test plan

- [ ] CI checks pass
- [ ] `bun test` passes for `f5xc-table.test.ts` and `f5xc-context-command.test.ts`
- [ ] `/context` subcommands render output inside F5-red branded table frame
- [ ] `/context export` still emits raw JSON (no frame)
- [ ] Error output remains unframed