### PR TITLE
fix(context): reserved env key schema enforcement (#411)

### DIFF
--- a/packages/coding-agent/src/config/context-schema.json
+++ b/packages/coding-agent/src/config/context-schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/f5xc-salesdemos/xcsh/main/packages/coding-agent/src/config/context-schema.json",
+  "title": "F5 XC Context",
+  "description": "Schema for F5 XC context files stored in ~/.config/f5xc/contexts/<name>.json. Validated at load, create, and import time.",
+  "type": "object",
+  "required": ["apiUrl", "apiToken"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional schema reference for editor autocomplete and validation."
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_-]{1,64}$",
+      "not": {
+        "enum": [
+          "list", "show", "status", "create", "delete", "rename",
+          "namespace", "env", "set", "unset", "add", "remove",
+          "clear", "activate", "validate", "export", "import",
+          "wizard", "help"
+        ]
+      },
+      "description": "Context name. Derived from filename. Must not collide with /context subcommands."
+    },
+    "apiUrl": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://",
+      "description": "F5 XC console API URL (must be HTTPS)."
+    },
+    "apiToken": {
+      "type": "string",
+      "minLength": 1,
+      "description": "API token for authentication."
+    },
+    "defaultNamespace": {
+      "type": "string",
+      "minLength": 1,
+      "default": "default",
+      "description": "Default namespace for CRUD operations. Projected as F5XC_NAMESPACE in bash environment. Use /context namespace to change."
+    },
+    "env": {
+      "type": "object",
+      "description": "Additional environment variables injected into bash sessions. Reserved keys that have dedicated top-level fields are forbidden.",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "allOf": [
+          {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+            "description": "Keys must be valid environment variable names."
+          },
+          {
+            "not": {
+              "enum": ["F5XC_NAMESPACE", "F5XC_API_URL", "F5XC_API_TOKEN", "F5XC_TENANT"]
+            },
+            "description": "Reserved keys have dedicated top-level fields and must not appear in env."
+          }
+        ]
+      }
+    },
+    "sensitiveKeys": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true,
+      "description": "Env var names from env whose values should be masked in output. Values must reference keys present in env (enforced at runtime)."
+    },
+    "knowledgeSources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["url"],
+        "additionalProperties": false,
+        "properties": {
+          "url": { "type": "string", "format": "uri" },
+          "label": { "type": "string" },
+          "type": { "type": "string", "enum": ["llms-txt", "skill-dir", "docs-site"] }
+        }
+      }
+    },
+    "includeSkills": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true,
+      "description": "Skill names to force-include when this context is active. Must not overlap with excludeSkills (enforced at runtime)."
+    },
+    "excludeSkills": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true,
+      "description": "Skill names to exclude when this context is active. Must not overlap with includeSkills (enforced at runtime)."
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Schema version. Must be <= CURRENT_SCHEMA_VERSION (enforced at runtime since the ceiling is dynamic)."
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "createdAt": { "type": "string", "format": "date-time" },
+        "expiresAt": { "type": "string", "format": "date-time" },
+        "lastRotatedAt": { "type": "string", "format": "date-time" },
+        "rotateAfterDays": { "type": "integer", "minimum": 1 }
+      }
+    }
+  }
+}

--- a/packages/coding-agent/src/services/f5xc-context-command.ts
+++ b/packages/coding-agent/src/services/f5xc-context-command.ts
@@ -11,6 +11,7 @@ import {
 	F5XC_NAMESPACE,
 	F5XC_TENANT,
 	F5XC_USERNAME,
+	RESERVED_ENV_KEYS,
 } from "./f5xc-env";
 import {
 	formatAuthIndicator,
@@ -256,7 +257,7 @@ async function handleShow(ctx: CommandContext, service: ContextService, name?: s
 	rows.push({ key: F5XC_NAMESPACE, value: sanitize(context.defaultNamespace) });
 	if (context.env) {
 		for (const [key, value] of Object.entries(context.env)) {
-			if (authKeys.includes(key)) continue;
+			if (authKeys.includes(key) || RESERVED_ENV_KEYS.has(key)) continue;
 			rows.push({ key: sanitize(key), value: isSensitiveKey(key) ? service.maskToken(value) : sanitize(value) });
 		}
 	}

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -11,6 +11,8 @@ import {
 	F5XC_NAMESPACE,
 	F5XC_TENANT,
 	hasEnvOverride,
+	RESERVED_ENV_KEYS,
+	RESERVED_ENV_MESSAGES,
 } from "./f5xc-env";
 
 export const CURRENT_SCHEMA_VERSION = 1;
@@ -844,6 +846,12 @@ export class ContextService {
 		if (!context) throw new ContextError(`Context '${name}' not found.`, name);
 
 		this.#assertCompatibleVersion(context);
+
+		const reservedViolations = Object.keys(vars).filter(k => RESERVED_ENV_KEYS.has(k));
+		if (reservedViolations.length > 0) {
+			const messages = reservedViolations.map(k => RESERVED_ENV_MESSAGES[k]).join("\n");
+			throw new ContextError(messages, name);
+		}
 
 		const env = { ...(context.env ?? {}), ...vars };
 		const sensitiveSet = new Set(context.sensitiveKeys ?? []);

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -1218,7 +1218,7 @@ export class ContextService {
 							name: canonicalName,
 							key: k,
 							envValue: SECRET_ENV_PATTERNS.test(k) ? "[redacted]" : v,
-							topLevelValue: topLevelValue ?? "(derived)",
+							topLevelValue: SECRET_ENV_PATTERNS.test(k) ? "[redacted]" : (topLevelValue ?? "(derived)"),
 						});
 					}
 					continue;

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -510,8 +510,13 @@ export class ContextService {
 			version: CURRENT_SCHEMA_VERSION,
 			metadata: { createdAt: new Date().toISOString() },
 		};
+		const filePayload = {
+			$schema:
+				"https://raw.githubusercontent.com/f5xc-salesdemos/xcsh/main/packages/coding-agent/src/config/context-schema.json",
+			...data,
+		} as Record<string, unknown>;
 		const tmpPath = `${contextPath}.tmp`;
-		fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), { mode: 0o600 });
+		fs.writeFileSync(tmpPath, JSON.stringify(filePayload, null, 2), { mode: 0o600 });
 		fs.renameSync(tmpPath, contextPath);
 		this.#contextsCache = [...this.#contextsCache, data].sort((a, b) => a.name.localeCompare(b.name));
 	}

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -1217,7 +1217,7 @@ export class ContextService {
 						logger.warn("F5XC context env contains reserved key — stripping", {
 							name: canonicalName,
 							key: k,
-							envValue: v,
+							envValue: SECRET_ENV_PATTERNS.test(k) ? "[redacted]" : v,
 							topLevelValue: topLevelValue ?? "(derived)",
 						});
 					}
@@ -1326,7 +1326,7 @@ export class ContextService {
 		// Inject all additional env vars from context.env map
 		if (context.env) {
 			for (const [key, value] of Object.entries(context.env)) {
-				if (!process.env[key] && !(key in merged)) merged[key] = value;
+				if (!process.env[key] && !(RESERVED_ENV_KEYS.has(key) && key in merged)) merged[key] = value;
 			}
 		}
 

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -1189,7 +1189,36 @@ export class ContextService {
 		if (parsed.env && typeof parsed.env === "object" && !Array.isArray(parsed.env)) {
 			env = {};
 			for (const [k, v] of Object.entries(parsed.env)) {
-				if (typeof v === "string") env[k] = v;
+				if (typeof v !== "string") continue;
+				if (RESERVED_ENV_KEYS.has(k)) {
+					// Resolve the corresponding top-level field to detect value mismatches
+					let topLevelValue: string | undefined;
+					switch (k) {
+						case F5XC_NAMESPACE:
+							topLevelValue = typeof parsed.defaultNamespace === "string" ? parsed.defaultNamespace : undefined;
+							break;
+						case F5XC_API_URL:
+							topLevelValue = typeof parsed.apiUrl === "string" ? parsed.apiUrl : undefined;
+							break;
+						case F5XC_API_TOKEN:
+							topLevelValue = typeof parsed.apiToken === "string" ? parsed.apiToken : undefined;
+							break;
+						default:
+							topLevelValue = undefined;
+							break; // F5XC_TENANT: derived, no stored top-level field
+					}
+					// Warn on mismatch OR when there is no top-level field to compare (F5XC_TENANT)
+					if (topLevelValue === undefined || v !== topLevelValue) {
+						logger.warn("F5XC context env contains reserved key — stripping", {
+							name: canonicalName,
+							key: k,
+							envValue: v,
+							topLevelValue: topLevelValue ?? "(derived)",
+						});
+					}
+					continue;
+				}
+				env[k] = v;
 			}
 			if (Object.keys(env).length === 0) env = undefined;
 		}

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -1321,7 +1321,7 @@ export class ContextService {
 		// Inject all additional env vars from context.env map
 		if (context.env) {
 			for (const [key, value] of Object.entries(context.env)) {
-				if (!process.env[key]) merged[key] = value;
+				if (!process.env[key] && !(key in merged)) merged[key] = value;
 			}
 		}
 

--- a/packages/coding-agent/src/services/f5xc-env.ts
+++ b/packages/coding-agent/src/services/f5xc-env.ts
@@ -10,6 +10,20 @@ export const F5XC_TENANT = "F5XC_TENANT" as const;
 export const F5XC_USERNAME = "F5XC_USERNAME" as const;
 export const F5XC_CONSOLE_PASSWORD = "F5XC_CONSOLE_PASSWORD" as const;
 
+export const RESERVED_ENV_KEYS: ReadonlySet<string> = new Set([
+	F5XC_NAMESPACE,
+	F5XC_API_URL,
+	F5XC_API_TOKEN,
+	F5XC_TENANT,
+]);
+
+export const RESERVED_ENV_MESSAGES: Readonly<Record<string, string>> = {
+	[F5XC_NAMESPACE]: `${F5XC_NAMESPACE} is managed by defaultNamespace. Use /context namespace <value> to change it.`,
+	[F5XC_API_URL]: `${F5XC_API_URL} is managed by apiUrl. It cannot be overridden via env vars.`,
+	[F5XC_API_TOKEN]: `${F5XC_API_TOKEN} is managed by apiToken. It cannot be overridden via env vars.`,
+	[F5XC_TENANT]: `${F5XC_TENANT} is read-only (derived from apiUrl). It cannot be set directly.`,
+};
+
 /**
  * True iff an env var is overriding a context-provided credential.
  * F5XC_API_URL alone is NOT an override — it is the signal that the user

--- a/packages/coding-agent/test/f5xc-context-command.test.ts
+++ b/packages/coding-agent/test/f5xc-context-command.test.ts
@@ -1265,6 +1265,33 @@ describe("/context slash command handler", () => {
 		expect(plain).toContain("MY_VAR");
 	});
 
+	describe("/context show reserved key deduplication", () => {
+		it("does not display F5XC_NAMESPACE twice when it is present in context.env", async () => {
+			const corrupted: F5XCContext = {
+				name: "dedup-test",
+				apiUrl: "https://test.console.ves.volterra.io",
+				apiToken: "fake-token",
+				defaultNamespace: "my-namespace",
+				env: { F5XC_NAMESPACE: "my-namespace", SAFE_KEY: "safe-value" },
+			};
+			writeContext(f5xcContextsDir, corrupted);
+			writeActiveContext(f5xcConfigDir, "dedup-test");
+
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const ctx = createMockCtx();
+			await handleContextCommand({ name: "context", args: "show", text: "/context show" }, ctx);
+
+			const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
+			// F5XC_NAMESPACE should appear exactly once
+			const occurrences = (plain.match(/F5XC_NAMESPACE/g) ?? []).length;
+			expect(occurrences).toBe(1);
+			// SAFE_KEY should still appear
+			expect(plain).toContain("SAFE_KEY");
+		});
+	});
+
 	describe("/context set reserved key enforcement", () => {
 		it("/context set F5XC_NAMESPACE=x shows rejection message", async () => {
 			writeContext(f5xcContextsDir, TEST_CONTEXT);

--- a/packages/coding-agent/test/f5xc-context-command.test.ts
+++ b/packages/coding-agent/test/f5xc-context-command.test.ts
@@ -1264,4 +1264,44 @@ describe("/context slash command handler", () => {
 		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
 		expect(plain).toContain("MY_VAR");
 	});
+
+	describe("/context set reserved key enforcement", () => {
+		it("/context set F5XC_NAMESPACE=x shows rejection message", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const ctx = createMockCtx();
+			await handleContextCommand(
+				{ name: "context", args: "set F5XC_NAMESPACE=my-ns", text: "/context set F5XC_NAMESPACE=my-ns" },
+				ctx,
+			);
+			expect(ctx.messages[0].type).toBe("error");
+			expect(ctx.messages[0].text).toContain("F5XC_NAMESPACE");
+			expect(ctx.messages[0].text).toContain("/context namespace");
+		});
+
+		it("/context set with multiple reserved keys shows all violations in one error", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);
+
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const ctx = createMockCtx();
+			await handleContextCommand(
+				{
+					name: "context",
+					args: "set F5XC_NAMESPACE=x F5XC_API_URL=y",
+					text: "/context set F5XC_NAMESPACE=x F5XC_API_URL=y",
+				},
+				ctx,
+			);
+			expect(ctx.messages[0].type).toBe("error");
+			expect(ctx.messages[0].text).toContain("F5XC_NAMESPACE");
+			expect(ctx.messages[0].text).toContain("F5XC_API_URL");
+		});
+	});
 });

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -1022,6 +1022,82 @@ describe("ContextService", () => {
 		});
 	});
 
+	describe("setEnvVars() reserved key enforcement", () => {
+		it("throws ContextError for a single reserved key (F5XC_NAMESPACE)", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.listContexts();
+			await expect(service.setEnvVars(TEST_CONTEXT.name, { F5XC_NAMESPACE: "my-ns" })).rejects.toThrow(ContextError);
+		});
+
+		it("error message contains redirect for F5XC_NAMESPACE", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.listContexts();
+			await expect(service.setEnvVars(TEST_CONTEXT.name, { F5XC_NAMESPACE: "my-ns" })).rejects.toThrow(
+				/Use \/context namespace/,
+			);
+		});
+
+		it("throws ContextError for F5XC_API_URL", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.listContexts();
+			await expect(
+				service.setEnvVars(TEST_CONTEXT.name, { F5XC_API_URL: "https://other.example.com" }),
+			).rejects.toThrow(/managed by apiUrl/);
+		});
+
+		it("throws ContextError for F5XC_API_TOKEN", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.listContexts();
+			await expect(service.setEnvVars(TEST_CONTEXT.name, { F5XC_API_TOKEN: "new-token" })).rejects.toThrow(
+				/managed by apiToken/,
+			);
+		});
+
+		it("throws ContextError for F5XC_TENANT", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.listContexts();
+			await expect(service.setEnvVars(TEST_CONTEXT.name, { F5XC_TENANT: "my-tenant" })).rejects.toThrow(/read-only/);
+		});
+
+		it("collects all violations in a single error when multiple reserved keys passed", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.listContexts();
+			const err = await service
+				.setEnvVars(TEST_CONTEXT.name, { F5XC_NAMESPACE: "x", F5XC_API_URL: "y", OTHER_KEY: "z" })
+				.catch(e => e);
+			expect(err).toBeInstanceOf(ContextError);
+			expect(err.message).toContain("F5XC_NAMESPACE");
+			expect(err.message).toContain("F5XC_API_URL");
+		});
+
+		it("does not write to disk when reserved key violation is thrown", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.listContexts();
+			const before = fs.readFileSync(path.join(f5xcContextsDir, `${TEST_CONTEXT.name}.json`), "utf-8");
+			await service.setEnvVars(TEST_CONTEXT.name, { F5XC_NAMESPACE: "x", MY_KEY: "val" }).catch(() => {});
+			const after = fs.readFileSync(path.join(f5xcContextsDir, `${TEST_CONTEXT.name}.json`), "utf-8");
+			expect(after).toBe(before);
+		});
+
+		it("succeeds and writes when no reserved keys are present", async () => {
+			writeContext(f5xcContextsDir, TEST_CONTEXT);
+			const service = ContextService.init(f5xcConfigDir);
+			await service.listContexts();
+			await expect(service.setEnvVars(TEST_CONTEXT.name, { MY_CUSTOM_VAR: "val" })).resolves.toEqual({
+				sensitive: [],
+			});
+			const data = JSON.parse(fs.readFileSync(path.join(f5xcContextsDir, `${TEST_CONTEXT.name}.json`), "utf-8"));
+			expect(data.env.MY_CUSTOM_VAR).toBe("val");
+		});
+	});
+
 	describe("validateToken", () => {
 		let savedFetch: typeof globalThis.fetch;
 

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -601,6 +601,21 @@ describe("ContextService", () => {
 			});
 			expect(fs.existsSync(path.join(f5xcContextsDir, "my-list.json"))).toBe(true);
 		});
+
+		it("createContext() writes $schema pointer into the JSON file", async () => {
+			const service = ContextService.init(f5xcConfigDir);
+			await service.createContext({
+				name: "schema-test",
+				apiUrl: "https://t.console.ves.volterra.io",
+				apiToken: "tok",
+				defaultNamespace: "default",
+			});
+
+			const raw = JSON.parse(fs.readFileSync(path.join(f5xcContextsDir, "schema-test.json"), "utf-8"));
+			expect(raw.$schema).toBeDefined();
+			expect(typeof raw.$schema).toBe("string");
+			expect(raw.$schema).toContain("context-schema.json");
+		});
 	});
 
 	describe("deleteContext", () => {

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -783,6 +783,126 @@ describe("ContextService", () => {
 		});
 	});
 
+	describe("#validateContextShape() reserved key stripping", () => {
+		it("strips F5XC_NAMESPACE from env when loading a corrupted context file", async () => {
+			const corrupted = {
+				name: "corrupted",
+				apiUrl: "https://test.console.ves.volterra.io",
+				apiToken: "fake-token",
+				defaultNamespace: "my-namespace",
+				env: {
+					F5XC_NAMESPACE: "my-namespace",
+					SAFE_KEY: "safe-value",
+				},
+			};
+			fs.mkdirSync(f5xcContextsDir, { recursive: true });
+			fs.writeFileSync(path.join(f5xcContextsDir, "corrupted.json"), JSON.stringify(corrupted, null, 2), {
+				mode: 0o600,
+			});
+
+			const service = ContextService.init(f5xcConfigDir);
+			const contexts = await service.listContexts();
+			const loaded = contexts.find(c => c.name === "corrupted");
+			expect(loaded).toBeDefined();
+			expect(loaded?.env?.F5XC_NAMESPACE).toBeUndefined();
+			expect(loaded?.env?.SAFE_KEY).toBe("safe-value");
+		});
+
+		it("strips all four reserved keys from env", async () => {
+			const corrupted = {
+				name: "all-reserved",
+				apiUrl: "https://test.console.ves.volterra.io",
+				apiToken: "fake-token",
+				defaultNamespace: "my-namespace",
+				env: {
+					F5XC_NAMESPACE: "my-namespace",
+					F5XC_API_URL: "https://test.console.ves.volterra.io",
+					F5XC_API_TOKEN: "fake-token",
+					F5XC_TENANT: "test",
+					SAFE_KEY: "safe-value",
+				},
+			};
+			fs.mkdirSync(f5xcContextsDir, { recursive: true });
+			fs.writeFileSync(path.join(f5xcContextsDir, "all-reserved.json"), JSON.stringify(corrupted, null, 2), {
+				mode: 0o600,
+			});
+
+			const service = ContextService.init(f5xcConfigDir);
+			const contexts = await service.listContexts();
+			const loaded = contexts.find(c => c.name === "all-reserved");
+			expect(loaded?.env?.F5XC_NAMESPACE).toBeUndefined();
+			expect(loaded?.env?.F5XC_API_URL).toBeUndefined();
+			expect(loaded?.env?.F5XC_API_TOKEN).toBeUndefined();
+			expect(loaded?.env?.F5XC_TENANT).toBeUndefined();
+			expect(loaded?.env?.SAFE_KEY).toBe("safe-value");
+		});
+
+		it("emits logger.warn when env reserved key value differs from top-level field", async () => {
+			const { logger } = await import("@f5xc-salesdemos/pi-utils");
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+			try {
+				const corrupted = {
+					name: "mismatch",
+					apiUrl: "https://test.console.ves.volterra.io",
+					apiToken: "fake-token",
+					defaultNamespace: "correct-namespace",
+					env: {
+						F5XC_NAMESPACE: "different-namespace",
+					},
+				};
+				fs.mkdirSync(f5xcContextsDir, { recursive: true });
+				fs.writeFileSync(path.join(f5xcContextsDir, "mismatch.json"), JSON.stringify(corrupted, null, 2), {
+					mode: 0o600,
+				});
+
+				const service = ContextService.init(f5xcConfigDir);
+				await service.listContexts();
+
+				// logger.warn is called as logger.warn("message", { name, key, envValue, topLevelValue })
+				const reservedWarn = warnSpy.mock.calls.some(args => {
+					const ctx = args[1] as Record<string, unknown> | undefined;
+					return String(args[0]).includes("reserved key") && ctx?.key === "F5XC_NAMESPACE";
+				});
+				expect(reservedWarn).toBe(true);
+			} finally {
+				warnSpy.mockRestore();
+			}
+		});
+
+		it("does NOT emit logger.warn when env reserved key value matches top-level field", async () => {
+			const { logger } = await import("@f5xc-salesdemos/pi-utils");
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+			try {
+				const matching = {
+					name: "matching",
+					apiUrl: "https://test.console.ves.volterra.io",
+					apiToken: "fake-token",
+					defaultNamespace: "same-namespace",
+					env: {
+						F5XC_NAMESPACE: "same-namespace",
+						SAFE_KEY: "ok",
+					},
+				};
+				fs.mkdirSync(f5xcContextsDir, { recursive: true });
+				fs.writeFileSync(path.join(f5xcContextsDir, "matching.json"), JSON.stringify(matching, null, 2), {
+					mode: 0o600,
+				});
+
+				const service = ContextService.init(f5xcConfigDir);
+				await service.listContexts();
+
+				// No warn for F5XC_NAMESPACE when values are identical (silent strip)
+				const reservedWarn = warnSpy.mock.calls.some(args => {
+					const ctx = args[1] as Record<string, unknown> | undefined;
+					return String(args[0]).includes("reserved key") && ctx?.key === "F5XC_NAMESPACE";
+				});
+				expect(reservedWarn).toBe(false);
+			} finally {
+				warnSpy.mockRestore();
+			}
+		});
+	});
+
 	describe("maskToken", () => {
 		it("masks all but last 4 characters", () => {
 			const service = ContextService.init(f5xcConfigDir);

--- a/packages/coding-agent/test/f5xc-context-service.test.ts
+++ b/packages/coding-agent/test/f5xc-context-service.test.ts
@@ -768,6 +768,27 @@ describe("ContextService", () => {
 			expect(() => service.setNamespace("test")).toThrow(/No active context/);
 		});
 
+		it("bash.environment uses defaultNamespace, not env.F5XC_NAMESPACE, after loading corrupted context", async () => {
+			const corrupted = {
+				name: "ns-guard",
+				apiUrl: "https://test.console.ves.volterra.io",
+				apiToken: "fake-token",
+				defaultNamespace: "correct-ns",
+				env: { F5XC_NAMESPACE: "wrong-ns" },
+			};
+			fs.mkdirSync(f5xcContextsDir, { recursive: true });
+			fs.writeFileSync(path.join(f5xcContextsDir, "ns-guard.json"), JSON.stringify(corrupted, null, 2), {
+				mode: 0o600,
+			});
+			writeActiveContext(f5xcConfigDir, "ns-guard");
+
+			const service = ContextService.init(f5xcConfigDir);
+			await service.loadActive();
+
+			const bashEnv = Settings.instance.get("bash.environment") as Record<string, string>;
+			expect(bashEnv.F5XC_NAMESPACE).toBe("correct-ns");
+		});
+
 		it("contexts without env field work unchanged (backward compat)", async () => {
 			writeContext(f5xcContextsDir, TEST_CONTEXT);
 			writeActiveContext(f5xcConfigDir, TEST_CONTEXT.name);


### PR DESCRIPTION
## Summary

Closes #411.

Fixes four failure points that allowed reserved env keys (`F5XC_NAMESPACE`, `F5XC_API_URL`, `F5XC_API_TOKEN`, `F5XC_TENANT`) to appear in `context.env`, causing duplicate rows in `/context show` and silent correctness violations.

### Changes

- **`f5xc-env.ts`**: `RESERVED_ENV_KEYS` (ReadonlySet) and `RESERVED_ENV_MESSAGES` (per-key redirect messages) as single source of truth
- **`setEnvVars()`**: Collects all reserved-key violations before any mutation, throws a single `ContextError` with field-specific redirect messages
- **`#validateContextShape()`**: Strips reserved keys from `env` on load; warns via `logger.warn` when env value differs from top-level field (redacts secrets via `SECRET_ENV_PATTERNS`)
- **`applyToSettings()`**: Tightened guard to `!(RESERVED_ENV_KEYS.has(key) && key in merged)` so reserved-key projections can't be overwritten by `env`, without blocking ordinary env keys on context switch
- **`handleShow()`**: Skips reserved keys in env iteration (already rendered from top-level fields above the divider)
- **`context-schema.json`**: New draft-07 schema (editor-time only, no runtime validator) with `propertyNames.not.enum` for reserved key exclusion, `additionalProperties: false`, and full constraint audit from #411 comment thread
- **`createContext()`**: Writes `$schema` pointer into new context files for editor autocomplete

### Known limitations (tracked separately)

- `$schema` pointer is only written by `createContext()` — subsequent writes via `setEnvVars()`, `unsetEnvVars()`, and `importContexts()` do not preserve it (future follow-up)
- `createContext()` does not guard against reserved keys in the initial `env` map passed by callers (future follow-up)
- HTTPS validation gap in `#validateContextShape()` tracked in the follow-up issue filed alongside this PR

### Test plan

- [ ] `bun test packages/coding-agent` — all tests pass
- [ ] `/context set F5XC_NAMESPACE=x` shows rejection message with `/context namespace` redirect
- [ ] `/context set F5XC_NAMESPACE=x F5XC_API_URL=y` shows both violations in one error
- [ ] `/context show` with a corrupted context file (reserved key in env) shows `F5XC_NAMESPACE` exactly once
- [ ] Context file created via `/context create` contains `$schema` pointer referencing `context-schema.json`