### PR TITLE
feat: refine demo-components routing to use demo-resources catalog

### DIFF
--- a/.xcsh/skills/demo-components/SKILL.md
+++ b/.xcsh/skills/demo-components/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: demo-components
-description: Discover and deploy pre-configured demo infrastructure components (origin servers, traffic generators, CDN simulators) from the F5 XC component library. Invoke when users discuss building demos, need infrastructure, or ask about deploying demo environments.
+description: Discover and deploy pre-configured demo infrastructure components (origin servers, traffic generators, CDN simulators) from the demo-resources catalog. Invoke when users discuss building demos, need infrastructure, or ask about deploying demo environments.
 ---
 
 # Demo Infrastructure Components
 
 You are helping a sales engineer discover, select, and deploy pre-configured
-demo infrastructure from the F5 Distributed Cloud component library.
+demo infrastructure from the F5 Distributed Cloud component catalog.
 
 ## Progressive Discovery
 
@@ -15,39 +15,45 @@ intent requires more detail. Do not load all layers at once.
 
 ### Layer 1 — Discover the catalog
 
-Fetch the docs portal llms.txt to see available components:
+Fetch the demo-resources llms.txt to see available components:
 
-1. Use the fetch tool to retrieve `https://f5xc-salesdemos.github.io/docs/llms.txt`
-2. Parse the `## Lab Infrastructure` section — each entry is a deployable component
+1. Use the fetch tool to retrieve `https://f5xc-salesdemos.github.io/demo-resources/llms.txt`
+2. Parse the `## Sections` for component profile pages and `## Federated Sites`
+   for links to each component's full documentation
 3. Present the catalog to the user:
    - Component name and one-line description
-   - URL link to that component's llms.txt
+   - Link to more details
 4. Ask which component(s) the user needs, or recommend based on their demo type
 
 **Demo-to-component recommendations:**
-- **WAF demo** → origin-server (vulnerable apps as WAF targets) + traffic-generator (attack traffic)
-- **API security demo** → origin-server (VAmPI, DVGA, RESTaurant, crAPI) + traffic-generator (API fuzzing)
-- **Bot defense demo** → origin-server + traffic-generator (bot simulation suites)
-- **CDN demo** → origin-server (content to cache) + cdn-simulator (CDN edge behavior)
-- **Client-side defense demo** → origin-server (CSD Demo app) + traffic-generator
+
+- **WAF demo** — origin-server (vulnerable apps as WAF targets) + traffic-generator (attack traffic)
+- **API security demo** — origin-server (VAmPI, DVGA, RESTaurant, crAPI) + traffic-generator (API fuzzing)
+- **Bot defense demo** — origin-server + traffic-generator (bot simulation suites)
+- **CDN demo** — origin-server (content to cache) + cdn-simulator (CDN edge behavior)
+- **Client-side defense demo** — origin-server (CSD Demo app) + traffic-generator
 
 ### Layer 2 — Component profile
 
 When the user selects a specific component or asks for more detail:
 
-1. Fetch that component's llms.txt (URL from the catalog)
-2. Present: architecture summary, what it provides, integration points, pairs_with
-3. Note which other components pair with it and why
+1. Fetch the Component Catalog custom set for all profiles in one request:
+   `https://f5xc-salesdemos.github.io/demo-resources/_llms-txt/component-catalog.txt`
+2. Present the selected component's architecture, installed software, terraform
+   variables, and integration notes
+3. Note which other components pair with it
 
 ### Layer 3 — Deployment details
 
 When the user decides to deploy:
 
-1. Fetch the component's Deployment Guide custom set
-   - URL pattern: `https://f5xc-salesdemos.github.io/{component}/_llms-txt/deployment-guide.txt`
-2. Walk through prerequisites, required terraform variables, and deployment steps
-3. For each required terraform variable, ask the user to supply their value
-4. Guide the `terraform init` / `terraform plan` / `terraform apply` sequence
+1. Fetch the component's full documentation via its federated site link
+   (e.g., `https://f5xc-salesdemos.github.io/origin-server/llms.txt`)
+2. Fetch the deployment guide custom set:
+   `https://f5xc-salesdemos.github.io/{component}/_llms-txt/deployment-guide.txt`
+3. Walk through prerequisites, terraform variables, and deployment steps
+4. For each required terraform variable, ask the user for their value
+5. Guide the `terraform init` / `terraform plan` / `terraform apply` sequence
 
 ## Session Caching
 
@@ -57,6 +63,7 @@ you already fetched, reuse the cached content rather than re-fetching.
 ## Multi-Component Architectures
 
 When a demo requires multiple components:
+
 1. Present the full architecture showing how components connect to each other
    and to the F5 XC platform
 2. Note deployment order — typically: origin-server first, then traffic-generator
@@ -65,10 +72,10 @@ When a demo requires multiple components:
 
 ## Rules
 
-- Always fetch live from the docs portal — the component library updates as
-  repos are onboarded or decommissioned
-- Only present components that appear in the `## Lab Infrastructure` section
-  of the portal llms.txt — never fabricate component names or capabilities
-- If the `## Lab Infrastructure` section is absent, the portal may not yet have
-  categorized federation; fall back to the `## Federated Sites` section and
-  filter for entries whose descriptions mention "VM", "terraform", or "Azure"
+- Always fetch live from demo-resources — the catalog updates as new
+  components are onboarded or decommissioned
+- Only present components that appear in the demo-resources llms.txt —
+  never fabricate component names or capabilities
+- Components are use-case-agnostic building blocks; recommend them based
+  on what the user's demo needs, but describe them by what they ARE, not
+  by which demo they belong to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -532,13 +532,11 @@ The script handles: version bump, CHANGELOG finalization, commit, tag, publish, 
 
 ## Demo Infrastructure Components
 
-You have access to a library of deployable demo infrastructure components —
-pre-configured Azure VMs that can be deployed via Terraform to support live F5
-Distributed Cloud demos. Components include origin servers with vulnerable web
-applications, traffic generators with attack suites, CDN simulators, and more.
-The library grows over time as new components are added to the ecosystem.
+You have access to a catalog of deployable demo infrastructure components at
+the demo-resources documentation site. Components are pre-configured Azure VMs
+deployable via Terraform — origin servers, traffic generators, CDN simulators,
+and more. The catalog grows as new components are onboarded.
 
-When users discuss building demos, need infrastructure for testing, ask about
-deploying demo environments, or reference origin servers, traffic generators, or
-attack traffic, invoke the `demo-components` skill to discover available
-components and guide the architecture and deployment process.
+When users discuss building demos, need infrastructure for testing, or ask about
+deploying demo environments, invoke the `demo-components` skill to browse the
+catalog and guide component selection and deployment.

--- a/tests/skills/demo-components.test.ts
+++ b/tests/skills/demo-components.test.ts
@@ -1,41 +1,42 @@
 import { describe, expect, test } from 'bun:test';
 
-const CATEGORIZED_LLMS_TXT = `# F5 Distributed Cloud Sales Demos
+const DEMO_RESOURCES_LLMS_TXT = `# Demo Resources
 
-> Demo guides for F5 Distributed Cloud sales engineering.
+> Catalog of pre-configured Azure VM components for F5 Distributed
+> Cloud demo environments.
 
 ## Documentation Sets
 
-- [Abridged documentation](https://example.com/llms-small.txt): compact version
-- [Complete documentation](https://example.com/llms-full.txt): full docs
+- [Component Catalog](https://example.com/demo-resources/_llms-txt/component-catalog.txt): Architecture profiles for all deployable demo components
+- [Full Documentation](https://example.com/demo-resources/llms-full.txt): the full documentation for Demo Resources
 
-## Lab Infrastructure
-Deployable Azure VM components for demo environments. Terraform-based, deterministic, pre-configured.
+## Sections
+
+- [Overview](https://example.com/demo-resources/01-overview/): What demo resources are, how to select components
+- [Origin Server](https://example.com/demo-resources/origin-server/): Ubuntu 24.04 VM with nginx and 9 vulnerable apps
+- [Traffic Generator](https://example.com/demo-resources/traffic-generator/): Azure VM with 50+ security tools
+- [CDN Simulator](https://example.com/demo-resources/cdn-simulator/): NGINX-based CDN edge node simulator
+
+## Federated Sites
 
 - [Origin Server](https://example.com/origin-server/llms.txt): Ubuntu 24.04 origin server with vulnerable web applications
 - [Traffic Generator](https://example.com/traffic-generator/llms.txt): Azure VM with 50+ security tools and attack suites
 - [CDN Simulator](https://example.com/cdn-simulator/llms.txt): NGINX-based CDN edge node simulator
-
-## Product Features
-F5 XC product capability documentation and demo guides.
-
-- [WAF](https://example.com/waf/llms.txt): F5 XC web application firewall
-- [API Security](https://example.com/api-protection/llms.txt): F5 XC API security
 
 ## Notes
 
 - Content is auto-generated from official docs
 `;
 
-const FLAT_LLMS_TXT = `# F5 Distributed Cloud Sales Demos
+const PORTAL_LLMS_TXT = `# F5 Distributed Cloud Sales Demos
 
-## Federated Sites
+## Lab Infrastructure
+Deployable Azure VM components for demo environments.
 
+- [Demo Resources](https://example.com/demo-resources/llms.txt): Catalog of pre-configured Azure VM components
 - [Origin Server](https://example.com/origin-server/llms.txt): Ubuntu 24.04 origin server
-- [WAF](https://example.com/waf/llms.txt): F5 XC web application firewall
-`;
-
-const EMPTY_LAB_LLMS_TXT = `# F5 Distributed Cloud Sales Demos
+- [Traffic Generator](https://example.com/traffic-generator/llms.txt): Azure VM with 50+ security tools
+- [CDN Simulator](https://example.com/cdn-simulator/llms.txt): NGINX-based CDN edge node simulator
 
 ## Product Features
 
@@ -66,71 +67,66 @@ function parseSection(llmsTxt: string, sectionHeading: string): SiteEntry[] {
 	return entries;
 }
 
-function hasCategorizedFederation(llmsTxt: string): boolean {
-	return !llmsTxt.includes('\n## Federated Sites\n');
+function parseFederatedSites(llmsTxt: string): SiteEntry[] {
+	return parseSection(llmsTxt, 'Federated Sites');
 }
 
-function parseLabInfrastructure(llmsTxt: string): SiteEntry[] {
-	return parseSection(llmsTxt, 'Lab Infrastructure');
+function parseSections(llmsTxt: string): SiteEntry[] {
+	return parseSection(llmsTxt, 'Sections');
 }
 
-describe('parseLabInfrastructure', () => {
-	test('extracts all components from ## Lab Infrastructure', () => {
-		const components = parseLabInfrastructure(CATEGORIZED_LLMS_TXT);
-		expect(components).toHaveLength(3);
+describe('demo-resources llms.txt parsing', () => {
+	test('extracts federated sites from demo-resources', () => {
+		const sites = parseFederatedSites(DEMO_RESOURCES_LLMS_TXT);
+		expect(sites).toHaveLength(3);
+		expect(sites[0].label).toBe('Origin Server');
+		expect(sites[1].label).toBe('Traffic Generator');
+		expect(sites[2].label).toBe('CDN Simulator');
 	});
 
-	test('extracts correct labels', () => {
-		const components = parseLabInfrastructure(CATEGORIZED_LLMS_TXT);
-		expect(components[0].label).toBe('Origin Server');
-		expect(components[1].label).toBe('Traffic Generator');
-		expect(components[2].label).toBe('CDN Simulator');
+	test('extracts section entries from demo-resources', () => {
+		const sections = parseSections(DEMO_RESOURCES_LLMS_TXT);
+		expect(sections).toHaveLength(4);
+		expect(sections[0].label).toBe('Overview');
+		expect(sections[1].label).toBe('Origin Server');
 	});
 
-	test('extracts correct URLs', () => {
-		const components = parseLabInfrastructure(CATEGORIZED_LLMS_TXT);
-		expect(components[0].url).toBe('https://example.com/origin-server/llms.txt');
+	test('extracts federated site URLs for Layer 3 fetching', () => {
+		const sites = parseFederatedSites(DEMO_RESOURCES_LLMS_TXT);
+		expect(sites[0].url).toBe('https://example.com/origin-server/llms.txt');
+		expect(sites[1].url).toBe('https://example.com/traffic-generator/llms.txt');
 	});
 
-	test('extracts descriptions', () => {
-		const components = parseLabInfrastructure(CATEGORIZED_LLMS_TXT);
-		expect(components[0].description).toContain('vulnerable web applications');
-	});
-
-	test('returns empty when no Lab Infrastructure section', () => {
-		expect(parseLabInfrastructure(FLAT_LLMS_TXT)).toHaveLength(0);
-	});
-
-	test('returns empty when Lab Infrastructure section is absent', () => {
-		expect(parseLabInfrastructure(EMPTY_LAB_LLMS_TXT)).toHaveLength(0);
+	test('extracts descriptions from federated sites', () => {
+		const sites = parseFederatedSites(DEMO_RESOURCES_LLMS_TXT);
+		expect(sites[0].description).toContain('vulnerable web applications');
 	});
 });
 
-describe('parseSection', () => {
-	test('extracts Product Features section', () => {
-		const entries = parseSection(CATEGORIZED_LLMS_TXT, 'Product Features');
-		expect(entries).toHaveLength(2);
-		expect(entries[0].label).toBe('WAF');
-		expect(entries[1].label).toBe('API Security');
+describe('portal llms.txt with demo-resources entry', () => {
+	test('finds demo-resources in Lab Infrastructure', () => {
+		const entries = parseSection(PORTAL_LLMS_TXT, 'Lab Infrastructure');
+		expect(entries).toHaveLength(4);
+		expect(entries[0].label).toBe('Demo Resources');
 	});
 
+	test('demo-resources URL is correct', () => {
+		const entries = parseSection(PORTAL_LLMS_TXT, 'Lab Infrastructure');
+		const dr = entries.find((e) => e.label === 'Demo Resources');
+		expect(dr).toBeDefined();
+		expect(dr?.url).toBe('https://example.com/demo-resources/llms.txt');
+	});
+
+	test('Lab Infrastructure does not contain Product Features', () => {
+		const lab = parseSection(PORTAL_LLMS_TXT, 'Lab Infrastructure');
+		const prod = parseSection(PORTAL_LLMS_TXT, 'Product Features');
+		expect(lab.map((e) => e.label)).not.toContain('WAF');
+		expect(prod.map((e) => e.label)).not.toContain('Origin Server');
+	});
+});
+
+describe('parseSection edge cases', () => {
 	test('returns empty for nonexistent section', () => {
-		expect(parseSection(CATEGORIZED_LLMS_TXT, 'Nonexistent')).toHaveLength(0);
-	});
-
-	test('does not bleed into next section', () => {
-		const labEntries = parseSection(CATEGORIZED_LLMS_TXT, 'Lab Infrastructure');
-		const labels = labEntries.map((e) => e.label);
-		expect(labels).not.toContain('WAF');
-	});
-});
-
-describe('hasCategorizedFederation', () => {
-	test('returns true for categorized llms.txt', () => {
-		expect(hasCategorizedFederation(CATEGORIZED_LLMS_TXT)).toBe(true);
-	});
-
-	test('returns false for flat Federated Sites format', () => {
-		expect(hasCategorizedFederation(FLAT_LLMS_TXT)).toBe(false);
+		expect(parseSection(DEMO_RESOURCES_LLMS_TXT, 'Nonexistent')).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
## What

Refine the demo-components skill's progressive discovery routing to target the demo-resources catalog directly instead of parsing through the main 27-site portal.

## Why

The demo-resources catalog is the authoritative source for demo component information. Pointing the skill directly at it provides more precise routing with less noise, avoiding unnecessary parsing of the full portal site map.

Closes #417

## Testing

- [x] Pre-commit hooks pass (governance, markdown lint, biome, spelling, editorconfig, secrets)
- [x] Tests rewritten with demo-resources fixtures
- [ ] CI checks pass
- [x] Issue linked via `Closes #417`