### PR TITLE
fix(coding-agent): inject xcsh repo identity into system prompt workstation section

### DIFF
--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -33,6 +33,23 @@ function getApiSpecMeta(): { domainCount: number; version: string } {
 	return _apiSpecMeta;
 }
 
+let _buildMeta: { version: string; repoSlug: string } | null = null;
+
+function getBuildMeta(): { version: string; repoSlug: string } {
+	if (_buildMeta) return _buildMeta;
+	try {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const mod = require("./internal-urls/build-info.generated");
+		_buildMeta = {
+			version: mod.BUILD_INFO?.version ?? "unknown",
+			repoSlug: mod.BUILD_INFO?.repoSlug ?? "unknown",
+		};
+	} catch {
+		_buildMeta = { version: "unknown", repoSlug: "unknown" };
+	}
+	return _buildMeta;
+}
+
 function apiSpecDomainCount(): number {
 	return getApiSpecMeta().domainCount;
 }
@@ -301,7 +318,9 @@ async function getCachedGpu(): Promise<string | undefined> {
 async function getEnvironmentInfo(): Promise<Array<{ label: string; value: string }>> {
 	const gpu = await getCachedGpu();
 	const cpus = os.cpus();
+	const build = getBuildMeta();
 	const entries: Array<{ label: string; value: string | undefined }> = [
+		{ label: "xcsh", value: `v${build.version} (${build.repoSlug})` },
 		{ label: "OS", value: `${os.platform()} ${os.release()}` },
 		{ label: "Distro", value: os.type() },
 		{ label: "Kernel", value: os.version() },

--- a/packages/coding-agent/test/system-prompt-api-spec.test.ts
+++ b/packages/coding-agent/test/system-prompt-api-spec.test.ts
@@ -6,6 +6,18 @@ beforeAll(() => {
 	registerCodingAgentPromptHelpers();
 });
 
+describe("system prompt xcsh identity", () => {
+	it("includes xcsh repo slug in workstation section", async () => {
+		const rendered = await buildSystemPrompt({ tools: new Map() });
+		expect(rendered).toContain("f5xc-salesdemos/xcsh");
+	});
+
+	it("includes xcsh version in workstation section", async () => {
+		const rendered = await buildSystemPrompt({ tools: new Map() });
+		expect(rendered).toMatch(/xcsh: v\d+\.\d+\.\d+/);
+	});
+});
+
 describe("system prompt API spec integration", () => {
 	it("includes xcsh://api-spec/ hint", async () => {
 		const rendered = await buildSystemPrompt({ tools: new Map() });


### PR DESCRIPTION
## What

Inject `BUILD_INFO.repoSlug` and version into the system prompt workstation section so the LLM has authoritative repository identity in every session.

## Why

When users ask xcsh to look up GitHub issues or PRs by number, the LLM has no repo identity in the system prompt and falls back to training data, guessing the wrong org (`f5devcentral/xcsh` instead of `f5xc-salesdemos/xcsh`). This causes failed API calls and confusing errors.

The fix adds a lazy `require()` loader that reads `BUILD_INFO.repoSlug` and version, rendering a line like `xcsh: v18.30.0 (f5xc-salesdemos/xcsh)` in the workstation section of every system prompt.

Closes #425

## Testing

- 6 tests pass including 2 new identity tests verifying the repo slug and version appear in system prompt output

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #425`