### PR TITLE
fix(coding-agent): strengthen xcsh://about routing to prevent unnecessary GitHub tool calls

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -189,6 +189,8 @@ Most tools resolve custom protocol URLs to internal resources (not web URLs):
 - `mcp://<resource-uri>` — MCP resource from a connected server; matched against exact resource URIs first, then RFC 6570 URI templates advertised by connected servers
 - `xcsh://..` — Internal xcsh documentation. **MUST NOT** read unless the user asks about xcsh itself.
   - `xcsh://about` — Identity, version, build fingerprint, architecture, self-improvement. **MUST** read for any question about xcsh before exploring `~/.xcsh/`.
+    This document contains the authoritative repository URL, issues URL, and source location.
+    For identity questions (source code, repo, version, who built this) — answer from `xcsh://about` alone. Do not call external GitHub tools.
 - `xcsh://api-spec/` — F5 XC API specifications.
   **MUST NOT** read proactively. When the user needs to interact with the F5 XC API:
   1. Read `xcsh://api-spec/` to identify the correct domain


### PR DESCRIPTION
## What

Adds explicit guidance in the system prompt's `xcsh://about` entry that marks it as the complete and authoritative source for identity questions, preventing redundant external GitHub tool calls.

## Why

When asked "where is your source code?", xcsh correctly reads `xcsh://about` (which contains the authoritative repo URL) but then also calls the `gh repo view` tool. This fails when not running inside a git checkout. The LLM needs stronger routing hints to stop after reading `xcsh://about` for identity queries.

Closes #437

## Testing

- Verified the system prompt change is syntactically valid Markdown
- Pre-commit hooks pass (governance, markdown lint, spelling, secrets)
- Manual verification: the two added lines are correctly nested under the `xcsh://about` bullet point

---

- [x] `bun run check` passes (markdown lint + spelling)
- [x] No new test failures vs baseline (prompt-only change, no code logic affected)
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #437`