### PR TITLE
feat(coding-agent): API spec v2.1.63 full integration — xcsh://api-catalog/, workflows, errors, glossary

### DIFF
--- a/packages/coding-agent/scripts/generate-api-spec-index.ts
+++ b/packages/coding-agent/scripts/generate-api-spec-index.ts
@@ -11,10 +11,6 @@ interface SpecPathOperation {
 	[key: string]: unknown;
 }
 
-/**
- * Finds the operationId schema components (e.g., 'dns_zone', 'views.forward_proxy_policy')
- * that correspond to a given resource name by matching path segments.
- */
 function findResourceSchemaComponents(
 	resourceName: string,
 	paths: Record<string, Record<string, SpecPathOperation>>,
@@ -38,11 +34,29 @@ function findResourceSchemaComponents(
 	return [...found];
 }
 
+interface IndexEntryResource {
+	name: string;
+	description: string;
+	description_short?: string;
+	tier?: string;
+	icon?: string;
+	supports_logs?: boolean;
+	supports_metrics?: boolean;
+	dependencies?: { required: string[]; optional: string[] };
+	relationship_hints?: string[];
+	schema_components?: string[];
+	api_paths?: string[];
+}
+
 interface IndexEntry {
 	domain: string;
 	title: string;
 	description: string;
 	"x-f5xc-description-short": string;
+	"x-f5xc-description-medium"?: string;
+	"x-f5xc-icon"?: string;
+	"x-f5xc-is-preview"?: boolean;
+	"x-f5xc-requires-tier"?: string;
 	file: string;
 	path_count: number;
 	schema_count: number;
@@ -50,18 +64,23 @@ interface IndexEntry {
 	"x-f5xc-category": string;
 	"x-f5xc-use-cases"?: string[];
 	"x-f5xc-related-domains"?: string[];
-	"x-f5xc-primary-resources"?: Array<{ name: string; description: string }>;
+	"x-f5xc-primary-resources"?: IndexEntryResource[];
 }
 
 interface RawIndex {
 	version: string;
 	timestamp: string;
 	specifications: IndexEntry[];
+	"x-f5xc-critical-resources"?: string[];
+	"x-f5xc-guided-workflows"?: Record<string, unknown>;
+	"x-f5xc-error-resolution"?: Record<string, unknown>;
+	"x-f5xc-acronyms"?: Record<string, unknown>;
 }
 
 const REPO = "f5xc-salesdemos/api-specs-enriched";
-const PINNED_TAG = "v2.1.62";
+const PINNED_TAG = "v2.1.63";
 const outputPath = path.resolve(import.meta.dir, "../src/internal-urls/api-spec-index.generated.ts");
+const catalogOutputPath = path.resolve(import.meta.dir, "../src/internal-urls/api-catalog-index.generated.ts");
 
 async function downloadFromRelease(): Promise<string> {
 	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "api-specs-"));
@@ -114,6 +133,34 @@ async function findSpecsDir(): Promise<string> {
 	return downloadFromRelease();
 }
 
+async function downloadCatalog(specsDir: string): Promise<Record<string, unknown> | null> {
+	const catalogPath = path.join(specsDir, "api-catalog.json");
+	if (fs.existsSync(catalogPath)) {
+		return JSON.parse(fs.readFileSync(catalogPath, "utf-8"));
+	}
+
+	const tag = process.env.API_SPECS_TAG ?? PINNED_TAG;
+	const catalogUrl = `https://github.com/${REPO}/releases/download/${tag}/api-catalog.json`;
+	console.log(`Downloading API catalog from ${catalogUrl}...`);
+	try {
+		const response = await fetch(catalogUrl, { redirect: "follow" });
+		if (!response.ok) {
+			console.warn(`api-catalog.json not found (${response.status}), skipping catalog generation`);
+			return null;
+		}
+		const text = await response.text();
+		return JSON.parse(text);
+	} catch (err) {
+		console.warn(`Failed to download api-catalog.json: ${err instanceof Error ? err.message : err}`);
+		return null;
+	}
+}
+
+function serializeEnrichment(key: string, value: unknown): string | undefined {
+	if (!value) return undefined;
+	return `\t${key}: ${JSON.stringify(value)},`;
+}
+
 let downloadedTmpDir: string | null = null;
 
 const specsDir = await findSpecsDir();
@@ -149,9 +196,22 @@ for (const entry of rawIndex.specifications) {
 	const b64 = compressed.toString("base64");
 
 	const resources = (entry["x-f5xc-primary-resources"] ?? []).map(r => {
-		const schemaComponents = findResourceSchemaComponents(r.name, specJson.paths ?? {});
-		const scStr = schemaComponents.length > 0 ? `, schemaComponents: ${JSON.stringify(schemaComponents)}` : "";
-		return `\t\t\t{ name: ${JSON.stringify(r.name)}, description: ${JSON.stringify(r.description)}${scStr} },`;
+		const upstreamSc = r.schema_components ?? [];
+		const schemaComponents =
+			upstreamSc.length > 0 ? upstreamSc : findResourceSchemaComponents(r.name, specJson.paths ?? {});
+		const fields: string[] = [`name: ${JSON.stringify(r.name)}`, `description: ${JSON.stringify(r.description)}`];
+		if (schemaComponents.length > 0) fields.push(`schemaComponents: ${JSON.stringify(schemaComponents)}`);
+		if (r.api_paths?.length) fields.push(`apiPaths: ${JSON.stringify(r.api_paths)}`);
+		if (r.tier) fields.push(`tier: ${JSON.stringify(r.tier)}`);
+		if (r.icon) fields.push(`icon: ${JSON.stringify(r.icon)}`);
+		if (r.description_short) fields.push(`descriptionShort: ${JSON.stringify(r.description_short)}`);
+		if (r.supports_logs != null) fields.push(`supportsLogs: ${r.supports_logs}`);
+		if (r.supports_metrics != null) fields.push(`supportsMetrics: ${r.supports_metrics}`);
+		if (r.dependencies && (r.dependencies.required.length > 0 || r.dependencies.optional.length > 0)) {
+			fields.push(`dependencies: ${JSON.stringify(r.dependencies)}`);
+		}
+		if (r.relationship_hints?.length) fields.push(`relationshipHints: ${JSON.stringify(r.relationship_hints)}`);
+		return `\t\t\t{ ${fields.join(", ")} },`;
 	});
 
 	const useCases = entry["x-f5xc-use-cases"];
@@ -173,6 +233,14 @@ for (const entry of rawIndex.specifications) {
 			`\t\t\t],`,
 			useCases ? `\t\t\tuseCases: ${JSON.stringify(useCases)},` : undefined,
 			relatedDomains?.length ? `\t\t\trelatedDomains: ${JSON.stringify(relatedDomains)},` : undefined,
+			entry["x-f5xc-icon"] ? `\t\t\ticon: ${JSON.stringify(entry["x-f5xc-icon"])},` : undefined,
+			entry["x-f5xc-description-medium"]
+				? `\t\t\tdescriptionMedium: ${JSON.stringify(entry["x-f5xc-description-medium"])},`
+				: undefined,
+			entry["x-f5xc-is-preview"] ? `\t\t\tisPreview: true,` : undefined,
+			entry["x-f5xc-requires-tier"]
+				? `\t\t\trequiresTier: ${JSON.stringify(entry["x-f5xc-requires-tier"])},`
+				: undefined,
 			"\t\t},",
 		]
 			.filter(Boolean)
@@ -182,6 +250,11 @@ for (const entry of rawIndex.specifications) {
 	blobEntries.push(`\t${JSON.stringify(entry.domain)}: ${JSON.stringify(b64)},`);
 	processedCount++;
 }
+
+const criticalResources = rawIndex["x-f5xc-critical-resources"];
+const guidedWorkflows = rawIndex["x-f5xc-guided-workflows"];
+const errorResolution = rawIndex["x-f5xc-error-resolution"];
+const acronyms = rawIndex["x-f5xc-acronyms"];
 
 const output = [
 	"// Auto-generated by scripts/generate-api-spec-index.ts - DO NOT EDIT",
@@ -196,13 +269,19 @@ const output = [
 	`\tdomains: [`,
 	...domainEntries,
 	`\t],`,
+	serializeEnrichment("criticalResources", criticalResources),
+	serializeEnrichment("guidedWorkflows", guidedWorkflows),
+	serializeEnrichment("errorResolution", errorResolution),
+	serializeEnrichment("acronyms", acronyms),
 	`};`,
 	"",
 	`export const API_SPEC_BLOBS: Readonly<Record<string, string>> = {`,
 	...blobEntries,
 	`};`,
 	"",
-].join("\n");
+]
+	.filter(l => l !== undefined)
+	.join("\n");
 
 await Bun.write(outputPath, output);
 
@@ -210,6 +289,53 @@ const outputSize = (Buffer.byteLength(output) / 1024 / 1024).toFixed(1);
 console.log(
 	`Generated ${path.relative(process.cwd(), outputPath)} (${processedCount} domains, ${skippedCount} skipped, ${outputSize} MB)`,
 );
+
+// Generate API catalog index
+const catalog = await downloadCatalog(specsDir);
+if (catalog) {
+	const categories = (catalog.categories ?? []) as Array<{ name: string; displayName: string; operations: unknown[] }>;
+	const catalogBlobEntries: string[] = [];
+	const catalogIndexEntries: string[] = [];
+
+	for (const cat of categories) {
+		const catJson = JSON.stringify(cat);
+		const catCompressed = gzipSync(Buffer.from(catJson));
+		catalogBlobEntries.push(`\t${JSON.stringify(cat.name)}: ${JSON.stringify(catCompressed.toString("base64"))},`);
+		catalogIndexEntries.push(
+			`\t\t{ name: ${JSON.stringify(cat.name)}, displayName: ${JSON.stringify(cat.displayName)}, operationCount: ${cat.operations?.length ?? 0} },`,
+		);
+	}
+
+	const catalogOutput = [
+		"// Auto-generated by scripts/generate-api-spec-index.ts - DO NOT EDIT",
+		"",
+		`import type { ApiCatalogCategorySummary, ApiCatalogIndex } from "./api-catalog-types";`,
+		"",
+		`export const API_CATALOG_INDEX: ApiCatalogIndex = {`,
+		`\tversion: ${JSON.stringify(catalog.version ?? "unknown")},`,
+		`\tdisplayName: ${JSON.stringify(catalog.displayName ?? "F5 Distributed Cloud")},`,
+		`\tservice: ${JSON.stringify(catalog.service ?? "f5xc")},`,
+		`\tcategoryCount: ${categories.length},`,
+		`\tauth: ${JSON.stringify(catalog.auth ?? {})},`,
+		`\tdefaults: ${JSON.stringify(catalog.defaults ?? {})},`,
+		`};`,
+		"",
+		`export const API_CATALOG_CATEGORY_SUMMARIES: ReadonlyArray<ApiCatalogCategorySummary> = [`,
+		...catalogIndexEntries,
+		`];`,
+		"",
+		`export const API_CATALOG_BLOBS: Readonly<Record<string, string>> = {`,
+		...catalogBlobEntries,
+		`};`,
+		"",
+	].join("\n");
+
+	await Bun.write(catalogOutputPath, catalogOutput);
+	const catalogSize = (Buffer.byteLength(catalogOutput) / 1024 / 1024).toFixed(1);
+	console.log(
+		`Generated ${path.relative(process.cwd(), catalogOutputPath)} (${categories.length} categories, ${catalogSize} MB)`,
+	);
+}
 
 if (downloadedTmpDir) {
 	fs.rmSync(downloadedTmpDir, { recursive: true, force: true });

--- a/packages/coding-agent/src/internal-urls/.gitignore
+++ b/packages/coding-agent/src/internal-urls/.gitignore
@@ -1,1 +1,2 @@
+api-catalog-index.generated.ts
 api-spec-index.generated.ts

--- a/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
@@ -145,7 +145,8 @@ function renderCatalogDetail(cat: ApiCatalogCategory, index: ApiCatalogIndex): s
 		}
 
 		sections.push("", "### Curl Example", "", "```bash");
-		const authHeader = `${index.auth.headerName}: ${index.auth.headerTemplate.replace("$TOKEN", `$${index.auth.tokenSource}`)}`;
+		const tokenVar = `$${index.auth.tokenSource}`;
+		const authHeader = `${index.auth.headerName}: ${index.auth.headerTemplate.replace("$TOKEN", tokenVar).replace("{token}", tokenVar)}`;
 		sections.push(`curl -X ${op.method.toUpperCase()} "$${index.auth.baseUrlSource}${op.path}" \\`);
 		sections.push(`  -H "${authHeader}" \\`);
 		if (op.method.toUpperCase() !== "GET" && op.method.toUpperCase() !== "DELETE") {

--- a/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
@@ -1,0 +1,176 @@
+import { gunzipSync } from "node:zlib";
+import { LRUCache } from "lru-cache";
+import type { ApiCatalogCategory, ApiCatalogCategorySummary, ApiCatalogIndex } from "./api-catalog-types";
+import type { InternalResource, InternalUrl } from "./types";
+
+const LRU_CAPACITY = 5;
+
+export interface ApiCatalogResolver {
+	resolve(url: InternalUrl): Promise<InternalResource>;
+}
+
+export function createApiCatalogResolver(
+	index: ApiCatalogIndex,
+	categorySummaries: readonly ApiCatalogCategorySummary[],
+	blobs: Record<string, string>,
+): ApiCatalogResolver {
+	const cache = new LRUCache<string, ApiCatalogCategory>({ max: LRU_CAPACITY });
+
+	function decompress(category: string): ApiCatalogCategory {
+		const cached = cache.get(category);
+		if (cached) return cached;
+
+		const blob = blobs[category];
+		if (!blob) throw new Error(`No catalog blob for category: ${category}`);
+
+		const buffer = Buffer.from(blob, "base64");
+		const decompressed = gunzipSync(buffer);
+		const cat = JSON.parse(decompressed.toString("utf-8")) as ApiCatalogCategory;
+		cache.set(category, cat);
+		return cat;
+	}
+
+	return {
+		async resolve(url: InternalUrl): Promise<InternalResource> {
+			const pathname = url.rawPathname ?? url.pathname;
+			const category = pathname.replace(/^\//, "").replace(/\/$/, "");
+			const search = url.searchParams.get("search");
+
+			if (!category) {
+				const content = search
+					? renderCatalogSearch(index, categorySummaries, search)
+					: renderCatalogIndex(index, categorySummaries);
+				return makeResource(url, content);
+			}
+
+			const summary = categorySummaries.find(c => c.name === category);
+			if (!summary) {
+				return makeResource(url, renderUnknownCategory(category, categorySummaries));
+			}
+
+			try {
+				const cat = decompress(category);
+				return makeResource(url, renderCatalogDetail(cat, index));
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return makeResource(url, `# Error loading ${category}\n\n${message}\n`);
+			}
+		},
+	};
+}
+
+function makeResource(url: InternalUrl, content: string): InternalResource {
+	return {
+		url: url.href,
+		content,
+		contentType: "text/markdown",
+		size: Buffer.byteLength(content, "utf-8"),
+		sourcePath: `xcsh://${url.rawHost}${url.rawPathname ?? "/"}`,
+	};
+}
+
+function renderCatalogIndex(index: ApiCatalogIndex, summaries: readonly ApiCatalogCategorySummary[]): string {
+	const rows = summaries.map(c => `| ${c.name} | ${c.displayName} | ${c.operationCount} |`);
+
+	return [
+		`# F5 XC API Catalog (v${index.version})`,
+		"",
+		`${summaries.length} categories. Read \`xcsh://api-catalog/{category}\` for operation details.`,
+		"",
+		"| Category | Display Name | Operations |",
+		"|----------|--------------|------------|",
+		...rows,
+		"",
+	].join("\n");
+}
+
+function renderCatalogSearch(
+	_index: ApiCatalogIndex,
+	summaries: readonly ApiCatalogCategorySummary[],
+	term: string,
+): string {
+	const lower = term.toLowerCase();
+	const matches = summaries.filter(
+		c => c.name.toLowerCase().includes(lower) || c.displayName.toLowerCase().includes(lower),
+	);
+
+	if (matches.length === 0) {
+		return [
+			`# No categories matching "${term}"`,
+			"",
+			`Use \`xcsh://api-catalog/\` to see all ${summaries.length} categories.`,
+			"",
+		].join("\n");
+	}
+
+	const rows = matches.map(c => `| ${c.name} | ${c.displayName} | ${c.operationCount} |`);
+
+	return [
+		`# API Catalog — search: "${term}"`,
+		"",
+		`${matches.length} matching categories.`,
+		"",
+		"| Category | Display Name | Operations |",
+		"|----------|--------------|------------|",
+		...rows,
+		"",
+	].join("\n");
+}
+
+function renderCatalogDetail(cat: ApiCatalogCategory, index: ApiCatalogIndex): string {
+	const sections: string[] = [`# ${cat.displayName}`, "", `${cat.operations.length} operations.`];
+
+	for (const op of cat.operations) {
+		sections.push("", `## ${op.method.toUpperCase()} ${op.path}`, "");
+		sections.push(op.description);
+		sections.push(`Danger level: ${op.dangerLevel}`);
+
+		if (op.parameters.length > 0) {
+			sections.push("", "### Parameters", "");
+			sections.push("| Name | In | Required | Type | Default |");
+			sections.push("|------|-----|----------|------|---------|");
+			for (const p of op.parameters) {
+				sections.push(`| ${p.name} | ${p.in} | ${p.required ? "yes" : "no"} | ${p.type} | ${p.default ?? ""} |`);
+			}
+		}
+
+		if (op.bodySchema) {
+			const minConfig = (op.bodySchema as Record<string, unknown>)["x-f5xc-minimum-configuration"] as
+				| Record<string, unknown>
+				| undefined;
+			if (minConfig?.required_fields) {
+				sections.push("", "### Minimum Configuration");
+				sections.push(`Required fields: ${(minConfig.required_fields as string[]).join(", ")}`);
+			}
+		}
+
+		sections.push("", "### Curl Example", "", "```bash");
+		const authHeader = `${index.auth.headerName}: ${index.auth.headerTemplate.replace("$TOKEN", `$${index.auth.tokenSource}`)}`;
+		sections.push(`curl -X ${op.method.toUpperCase()} "$${index.auth.baseUrlSource}${op.path}" \\`);
+		sections.push(`  -H "${authHeader}" \\`);
+		if (op.method.toUpperCase() !== "GET" && op.method.toUpperCase() !== "DELETE") {
+			sections.push('  -H "Content-Type: application/json" \\');
+			sections.push("  -d @payload.json");
+		} else {
+			const lastLine = sections[sections.length - 1];
+			sections[sections.length - 1] = lastLine.replace(/ \\$/, "");
+		}
+		sections.push("```");
+	}
+
+	sections.push("");
+	return sections.join("\n");
+}
+
+function renderUnknownCategory(requested: string, summaries: readonly ApiCatalogCategorySummary[]): string {
+	const suggestions = summaries
+		.filter(c => c.name.includes(requested) || requested.includes(c.name.slice(0, 4)))
+		.slice(0, 5);
+
+	const sections = [`# Category not found: ${requested}`, ""];
+	if (suggestions.length > 0) {
+		sections.push("Did you mean:", ...suggestions.map(c => `- \`${c.name}\` — ${c.displayName}`), "");
+	}
+	sections.push("Use `xcsh://api-catalog/` to see all categories.", "");
+	return sections.join("\n");
+}

--- a/packages/coding-agent/src/internal-urls/api-catalog-types.ts
+++ b/packages/coding-agent/src/internal-urls/api-catalog-types.ts
@@ -1,0 +1,54 @@
+/**
+ * Types for the embedded API catalog index.
+ *
+ * The catalog provides pre-built curl templates and operation metadata
+ * generated at build time from api-catalog.json in the api-specs-enriched repository.
+ */
+
+export interface ApiCatalogParameter {
+	readonly name: string;
+	readonly in: string;
+	readonly required: boolean;
+	readonly type: string;
+	readonly default?: string;
+}
+
+export interface ApiCatalogOperation {
+	readonly name: string;
+	readonly description: string;
+	readonly method: string;
+	readonly path: string;
+	readonly dangerLevel: string;
+	readonly parameters: readonly ApiCatalogParameter[];
+	readonly bodySchema?: Record<string, unknown>;
+	readonly responseSchema?: Record<string, unknown>;
+}
+
+export interface ApiCatalogCategory {
+	readonly name: string;
+	readonly displayName: string;
+	readonly operations: readonly ApiCatalogOperation[];
+}
+
+export interface ApiCatalogAuth {
+	readonly type: string;
+	readonly headerName: string;
+	readonly headerTemplate: string;
+	readonly tokenSource: string;
+	readonly baseUrlSource: string;
+}
+
+export interface ApiCatalogIndex {
+	readonly version: string;
+	readonly displayName: string;
+	readonly service: string;
+	readonly categoryCount: number;
+	readonly auth: ApiCatalogAuth;
+	readonly defaults: Record<string, { readonly source: string }>;
+}
+
+export interface ApiCatalogCategorySummary {
+	readonly name: string;
+	readonly displayName: string;
+	readonly operationCount: number;
+}

--- a/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
@@ -6,8 +6,6 @@ import type { InternalResource, InternalUrl } from "./types";
 const LRU_CAPACITY = 5;
 const SCHEMA_RENDER_MAX_DEPTH = 3;
 
-// Module-level cache for groupPathsBySchema results, keyed by spec identity.
-// Different resolver instances create distinct OpenAPISpec objects so there is no cross-resolver leakage.
 const groupsCache = new WeakMap<OpenAPISpec, Map<string, Record<string, Record<string, OpenAPIPathOperation>>>>();
 
 function getCachedGroups(spec: OpenAPISpec): Map<string, Record<string, Record<string, OpenAPIPathOperation>>> {
@@ -55,6 +53,21 @@ export function createApiSpecResolver(index: ApiSpecIndex, blobs: Record<string,
 				return makeResource(url, renderDomainIndex(index));
 			}
 
+			// Reserved sub-paths — checked before domain lookup
+			if (domain === "workflows" || domain.startsWith("workflows/")) {
+				const workflowId = domain.replace(/^workflows\/?/, "");
+				return makeResource(url, workflowId ? renderWorkflowDetail(workflowId, index) : renderWorkflowIndex(index));
+			}
+
+			if (domain === "errors" || domain.startsWith("errors/")) {
+				const errorKey = domain.replace(/^errors\/?/, "");
+				return makeResource(url, errorKey ? renderErrorDetail(errorKey, index) : renderErrorIndex(index));
+			}
+
+			if (domain === "glossary" || domain.startsWith("glossary/")) {
+				return makeResource(url, renderGlossary(index));
+			}
+
 			const entry = index.domains.find(d => d.domain === domain);
 			if (!entry) {
 				return makeResource(url, renderUnknownDomain(domain, index));
@@ -99,24 +112,67 @@ function makeResource(url: InternalUrl, content: string): InternalResource {
 }
 
 function renderDomainIndex(index: ApiSpecIndex): string {
-	const rows = index.domains.map(
-		d => `| ${d.domain} | ${d.category} | ${d.resources.length} | ${d.pathCount} | ${d.descriptionShort} |`,
-	);
+	const criticalSet = new Set(index.criticalResources ?? []);
+	const rows = index.domains.map(d => {
+		const icon = d.icon ?? "";
+		const tier = d.requiresTier ?? "";
+		const hasCritical = d.resources.some(r => criticalSet.has(r.name));
+		const desc = hasCritical ? `${d.descriptionShort} *` : d.descriptionShort;
+		return `| ${icon} | ${d.domain} | ${d.category} | ${d.resources.length} | ${d.pathCount} | ${tier} | ${desc} |`;
+	});
 
-	return [
+	const lines = [
 		`# F5 XC API Specifications (v${index.version})`,
 		"",
 		`${index.domains.length} domains. Read \`xcsh://api-spec/{domain}\` for resource details.`,
 		"",
-		"| Domain | Category | Resources | Paths | Description |",
-		"|--------|----------|-----------|-------|-------------|",
+		"| Icon | Domain | Category | Resources | Paths | Tier | Description |",
+		"|------|--------|----------|-----------|-------|------|-------------|",
 		...rows,
 		"",
-	].join("\n");
+	];
+
+	if (criticalSet.size > 0) {
+		lines.push("\\* = contains critical resources", "");
+	}
+
+	return lines.join("\n");
 }
 
 function renderDomainDetail(domain: string, entry: ApiSpecDomainEntry, spec: OpenAPISpec): string {
-	const resourceRows = entry.resources.map(r => `| ${r.name} | ${r.description} |`);
+	const sections: string[] = [
+		`# ${entry.title} — F5 XC API`,
+		"",
+		`Category: ${entry.category} | Paths: ${entry.pathCount} | Complexity: ${entry.complexity}`,
+	];
+
+	if (entry.isPreview || entry.requiresTier === "Advanced") {
+		const tags: string[] = [];
+		if (entry.isPreview) tags.push("Preview API");
+		if (entry.requiresTier === "Advanced") tags.push("Requires Advanced tier");
+		sections.push("", `> ${tags.join(" | ")}`);
+	}
+
+	if (entry.descriptionMedium) {
+		sections.push("", entry.descriptionMedium);
+	}
+
+	sections.push("", "## Resources", "");
+	sections.push("| Resource | Description | Tier | Observability | Requires |");
+	sections.push("|----------|-------------|------|---------------|----------|");
+	for (const r of entry.resources) {
+		const tier = r.tier ?? "";
+		const obs: string[] = [];
+		if (r.supportsLogs) obs.push("logs");
+		if (r.supportsMetrics) obs.push("metrics");
+		const requires = r.dependencies?.required.join(", ") ?? "";
+		sections.push(`| ${r.name} | ${r.description} | ${tier} | ${obs.join(", ")} | ${requires} |`);
+	}
+
+	const hints = entry.resources.flatMap(r => r.relationshipHints ?? []);
+	if (hints.length > 0) {
+		sections.push("", "## Relationships", ...hints.map(h => `- ${h}`));
+	}
 
 	const operationRows: string[] = [];
 	for (const [pathKey, methods] of Object.entries(spec.paths)) {
@@ -127,23 +183,10 @@ function renderDomainDetail(domain: string, entry: ApiSpecDomainEntry, spec: Ope
 		}
 	}
 
-	const sections = [
-		`# ${entry.title} — F5 XC API`,
-		"",
-		`Category: ${entry.category} | Paths: ${entry.pathCount} | Complexity: ${entry.complexity}`,
-		"",
-		"## Resources",
-		"",
-		"| Resource | Description |",
-		"|----------|-------------|",
-		...resourceRows,
-		"",
-		"## Operations",
-		"",
-		"| Method | Path | Summary |",
-		"|--------|------|---------|",
-		...operationRows,
-	];
+	sections.push("", "## Operations", "");
+	sections.push("| Method | Path | Summary |");
+	sections.push("|--------|------|---------|");
+	sections.push(...operationRows);
 
 	if (entry.useCases?.length) {
 		sections.push("", "## Use Cases", ...entry.useCases.map(u => `- ${u}`));
@@ -190,7 +233,20 @@ function filterPathsByResource(
 	resource: string,
 	entry?: ApiSpecDomainEntry,
 ): Record<string, Record<string, OpenAPIPathOperation>> {
-	// Index-guided lookup: use pre-computed schemaComponents from the enriched index
+	// Primary: use pre-computed api_paths from enriched index
+	if (entry) {
+		const indexedResource = entry.resources.find(r => r.name === resource);
+		if (indexedResource?.apiPaths?.length) {
+			const result: Record<string, Record<string, OpenAPIPathOperation>> = {};
+			for (const ap of indexedResource.apiPaths) {
+				const methods = spec.paths[ap];
+				if (methods) result[ap] = methods;
+			}
+			if (Object.keys(result).length > 0) return result;
+		}
+	}
+
+	// Fallback 1: index-guided schemaComponents lookup
 	if (entry) {
 		const indexedResource = entry.resources.find(r => r.name === resource);
 		if (indexedResource?.schemaComponents?.length) {
@@ -199,9 +255,9 @@ function filterPathsByResource(
 			for (const comp of indexedResource.schemaComponents) {
 				const paths = groups.get(comp);
 				if (paths) {
-					for (const [pathKey, methods] of Object.entries(paths)) {
+					for (const [pathKey, pathMethods] of Object.entries(paths)) {
 						if (!result[pathKey]) result[pathKey] = {};
-						Object.assign(result[pathKey], methods);
+						Object.assign(result[pathKey], pathMethods);
 					}
 				}
 			}
@@ -209,6 +265,7 @@ function filterPathsByResource(
 		}
 	}
 
+	// Fallback 2: operationId-based heuristic matching
 	const groups = getCachedGroups(spec);
 
 	const exactKey = resource.replace(/-/g, "_");
@@ -226,11 +283,11 @@ function filterPathsByResource(
 			schema === exactKey ||
 			schema.endsWith(`.${exactKey}`)
 		) {
-			for (const [path, methods] of Object.entries(paths)) {
+			for (const [p, methods] of Object.entries(paths)) {
 				if (!partial.has("merged")) partial.set("merged", {});
 				const merged = partial.get("merged")!;
-				if (!merged[path]) merged[path] = {};
-				Object.assign(merged[path], methods);
+				if (!merged[p]) merged[p] = {};
+				Object.assign(merged[p], methods);
 			}
 		}
 	}
@@ -377,6 +434,148 @@ function renderSchemaAsTable(schema: Record<string, unknown>, spec: OpenAPISpec,
 
 	rows.push("");
 	return rows.join("\n");
+}
+
+function renderWorkflowIndex(index: ApiSpecIndex): string {
+	const workflows = index.guidedWorkflows?.workflows ?? [];
+	if (workflows.length === 0) {
+		return "# Guided Workflows\n\nNo workflows available.\n";
+	}
+
+	const rows = workflows.map(w => `| ${w.id} | ${w.name} | ${w.domain} | ${w.complexity} | ${w.steps.length} |`);
+
+	return [
+		"# Guided API Workflows",
+		"",
+		`${workflows.length} step-by-step workflows. Read \`xcsh://api-spec/workflows/{id}\` for details.`,
+		"",
+		"| ID | Name | Domain | Complexity | Steps |",
+		"|----|------|--------|------------|-------|",
+		...rows,
+		"",
+	].join("\n");
+}
+
+function renderWorkflowDetail(id: string, index: ApiSpecIndex): string {
+	const workflow = index.guidedWorkflows?.workflows.find(w => w.id === id);
+	if (!workflow) {
+		const available = index.guidedWorkflows?.workflows.map(w => `- \`${w.id}\` — ${w.name}`) ?? [];
+		return [`# Workflow not found: ${id}`, "", "Available workflows:", ...available, ""].join("\n");
+	}
+
+	const sections: string[] = [
+		`# ${workflow.name}`,
+		"",
+		`Complexity: ${workflow.complexity} | Domain: ${workflow.domain} | Steps: ${workflow.steps.length}`,
+	];
+
+	if (workflow.prerequisites.length > 0) {
+		sections.push("", "**Prerequisites:**", ...workflow.prerequisites.map(p => `- ${p}`));
+	}
+
+	for (const step of workflow.steps) {
+		sections.push("", `## Step ${step.order}: ${step.name}`, "");
+		sections.push(step.description);
+		if (step.resource) sections.push(`Resource: \`${step.resource}\``);
+		if (step.required_fields?.length) sections.push(`Required fields: ${step.required_fields.join(", ")}`);
+		if (step.depends_on?.length) sections.push(`Depends on: step ${step.depends_on.join(", step ")}`);
+		if (step.tips?.length) sections.push("", "**Tips:**", ...step.tips.map(t => `- ${t}`));
+		if (step.verification?.length) sections.push("", "**Verify:**", ...step.verification.map(v => `- ${v}`));
+	}
+
+	sections.push("");
+	return sections.join("\n");
+}
+
+function renderErrorIndex(index: ApiSpecIndex): string {
+	const er = index.errorResolution;
+	if (!er) {
+		return "# Error Resolution\n\nNo error resolution data available.\n";
+	}
+
+	const httpRows = Object.entries(er.http_errors).map(([code, e]) => `| HTTP | ${code} | ${e.name} |`);
+	const resourceRows = Object.keys(er.resource_errors).map(r => `| Resource | ${r} | ${r} errors |`);
+
+	return [
+		"# API Error Resolution",
+		"",
+		"Read `xcsh://api-spec/errors/{code}` for HTTP errors or `xcsh://api-spec/errors/{resource}` for resource-specific errors.",
+		"",
+		"| Type | Code/Resource | Name |",
+		"|------|---------------|------|",
+		...httpRows,
+		...resourceRows,
+		"",
+	].join("\n");
+}
+
+function renderErrorDetail(key: string, index: ApiSpecIndex): string {
+	const er = index.errorResolution;
+	if (!er) return `# Error: ${key}\n\nNo error resolution data available.\n`;
+
+	const httpError = er.http_errors[key];
+	if (httpError) {
+		const sections: string[] = [
+			`# HTTP ${httpError.code} — ${httpError.name}`,
+			"",
+			httpError.description,
+			"",
+			"## Common Causes",
+			...httpError.common_causes.map(c => `- ${c}`),
+			"",
+			"## Diagnostic Steps",
+		];
+		for (const ds of httpError.diagnostic_steps) {
+			sections.push(`${ds.step}. **${ds.action}** — ${ds.description}`);
+			if (ds.command) sections.push(`   \`${ds.command}\``);
+		}
+		sections.push("", "## Prevention", ...httpError.prevention.map(p => `- ${p}`));
+		if (httpError.related_errors?.length) {
+			sections.push("", `Related errors: ${httpError.related_errors.join(", ")}`);
+		}
+		sections.push("");
+		return sections.join("\n");
+	}
+
+	const resourceErrors = er.resource_errors[key];
+	if (resourceErrors) {
+		const rows = resourceErrors.map(e => `| ${e.error_code} | ${e.pattern} | ${e.resolution} |`);
+		return [
+			`# ${key} — Common Errors`,
+			"",
+			"| Error Code | Pattern | Resolution |",
+			"|------------|---------|------------|",
+			...rows,
+			"",
+		].join("\n");
+	}
+
+	return [
+		`# Error not found: ${key}`,
+		"",
+		"Use `xcsh://api-spec/errors/` to see available error codes and resources.",
+		"",
+	].join("\n");
+}
+
+function renderGlossary(index: ApiSpecIndex): string {
+	const ac = index.acronyms;
+	if (!ac) return "# API Glossary\n\nNo glossary data available.\n";
+
+	const sections = ["# API Glossary", ""];
+	for (const cat of ac.categories) {
+		const items = ac.acronyms.filter(a => a.category === cat);
+		if (items.length === 0) continue;
+		sections.push(`## ${cat}`, "");
+		sections.push("| Acronym | Expansion |");
+		sections.push("|---------|-----------|");
+		for (const a of items) {
+			sections.push(`| ${a.acronym} | ${a.expansion} |`);
+		}
+		sections.push("");
+	}
+
+	return sections.join("\n");
 }
 
 function renderUnknownDomain(requested: string, index: ApiSpecIndex): string {

--- a/packages/coding-agent/src/internal-urls/api-spec-types.ts
+++ b/packages/coding-agent/src/internal-urls/api-spec-types.ts
@@ -9,6 +9,17 @@ export interface ApiSpecDomainResource {
 	readonly name: string;
 	readonly description: string;
 	readonly schemaComponents?: readonly string[];
+	readonly apiPaths?: readonly string[];
+	readonly tier?: string;
+	readonly icon?: string;
+	readonly descriptionShort?: string;
+	readonly supportsLogs?: boolean;
+	readonly supportsMetrics?: boolean;
+	readonly dependencies?: {
+		readonly required: readonly string[];
+		readonly optional: readonly string[];
+	};
+	readonly relationshipHints?: readonly string[];
 }
 
 export interface ApiSpecDomainEntry {
@@ -23,12 +34,89 @@ export interface ApiSpecDomainEntry {
 	readonly resources: readonly ApiSpecDomainResource[];
 	readonly useCases?: readonly string[];
 	readonly relatedDomains?: readonly string[];
+	readonly icon?: string;
+	readonly descriptionMedium?: string;
+	readonly isPreview?: boolean;
+	readonly requiresTier?: string;
+}
+
+export interface ApiSpecGuidedWorkflows {
+	readonly version: string;
+	readonly domains: readonly string[];
+	readonly workflows: readonly ApiSpecGuidedWorkflow[];
+}
+
+export interface ApiSpecGuidedWorkflow {
+	readonly id: string;
+	readonly name: string;
+	readonly description: string;
+	readonly complexity: string;
+	readonly estimated_steps: number;
+	readonly prerequisites: readonly string[];
+	readonly steps: readonly ApiSpecGuidedWorkflowStep[];
+	readonly domain: string;
+}
+
+export interface ApiSpecGuidedWorkflowStep {
+	readonly order: number;
+	readonly action: string;
+	readonly name: string;
+	readonly description: string;
+	readonly resource?: string;
+	readonly required_fields?: readonly string[];
+	readonly tips?: readonly string[];
+	readonly optional?: boolean;
+	readonly depends_on?: readonly number[];
+	readonly verification?: readonly string[];
+}
+
+export interface ApiSpecHttpError {
+	readonly code: number;
+	readonly name: string;
+	readonly description: string;
+	readonly common_causes: readonly string[];
+	readonly diagnostic_steps: readonly {
+		readonly step: number;
+		readonly action: string;
+		readonly description: string;
+		readonly command?: string;
+	}[];
+	readonly prevention: readonly string[];
+	readonly related_errors?: readonly number[];
+}
+
+export interface ApiSpecResourceErrorEntry {
+	readonly error_code: number;
+	readonly pattern: string;
+	readonly resolution: string;
+}
+
+export interface ApiSpecErrorResolution {
+	readonly version: string;
+	readonly httpErrors: Record<string, ApiSpecHttpError>;
+	readonly resourceErrors: Record<string, readonly ApiSpecResourceErrorEntry[]>;
+}
+
+export interface ApiSpecAcronym {
+	readonly acronym: string;
+	readonly expansion: string;
+	readonly category: string;
+}
+
+export interface ApiSpecAcronyms {
+	readonly version: string;
+	readonly categories: readonly string[];
+	readonly acronyms: readonly ApiSpecAcronym[];
 }
 
 export interface ApiSpecIndex {
 	readonly version: string;
 	readonly timestamp: string;
 	readonly domains: readonly ApiSpecDomainEntry[];
+	readonly criticalResources?: readonly string[];
+	readonly guidedWorkflows?: ApiSpecGuidedWorkflows;
+	readonly errorResolution?: ApiSpecErrorResolution;
+	readonly acronyms?: ApiSpecAcronyms;
 }
 
 export interface OpenAPIPathOperation {

--- a/packages/coding-agent/src/internal-urls/api-spec-types.ts
+++ b/packages/coding-agent/src/internal-urls/api-spec-types.ts
@@ -42,6 +42,7 @@ export interface ApiSpecDomainEntry {
 
 export interface ApiSpecGuidedWorkflows {
 	readonly version: string;
+	readonly total_workflows: number;
 	readonly domains: readonly string[];
 	readonly workflows: readonly ApiSpecGuidedWorkflow[];
 }

--- a/packages/coding-agent/src/internal-urls/api-spec-types.ts
+++ b/packages/coding-agent/src/internal-urls/api-spec-types.ts
@@ -93,8 +93,8 @@ export interface ApiSpecResourceErrorEntry {
 
 export interface ApiSpecErrorResolution {
 	readonly version: string;
-	readonly httpErrors: Record<string, ApiSpecHttpError>;
-	readonly resourceErrors: Record<string, readonly ApiSpecResourceErrorEntry[]>;
+	readonly http_errors: Record<string, ApiSpecHttpError>;
+	readonly resource_errors: Record<string, readonly ApiSpecResourceErrorEntry[]>;
 }
 
 export interface ApiSpecAcronym {

--- a/packages/coding-agent/src/internal-urls/index.ts
+++ b/packages/coding-agent/src/internal-urls/index.ts
@@ -21,6 +21,7 @@
  */
 
 export * from "./agent-protocol";
+export * from "./api-catalog-resolve";
 export * from "./api-catalog-types";
 export * from "./api-spec-resolve";
 export * from "./api-spec-types";

--- a/packages/coding-agent/src/internal-urls/index.ts
+++ b/packages/coding-agent/src/internal-urls/index.ts
@@ -21,6 +21,7 @@
  */
 
 export * from "./agent-protocol";
+export * from "./api-catalog-types";
 export * from "./api-spec-resolve";
 export * from "./api-spec-types";
 export * from "./artifact-protocol";

--- a/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
@@ -11,9 +11,16 @@
  * - xcsh://api-spec/ - API specification index
  * - xcsh://api-spec/{domain} - Domain detail
  * - xcsh://api-spec/{domain}?resource={name} - Resource spec
+ * - xcsh://api-spec/workflows/ - Guided API workflows
+ * - xcsh://api-spec/errors/ - Error resolution
+ * - xcsh://api-spec/glossary/ - Acronym glossary
+ * - xcsh://api-catalog/ - API operation catalog
+ * - xcsh://api-catalog/{category} - Category operations with curl templates
  */
 import * as path from "node:path";
 import type { ContextStatus } from "../services/f5xc-context";
+import { type ApiCatalogResolver, createApiCatalogResolver } from "./api-catalog-resolve";
+import type { ApiCatalogCategorySummary, ApiCatalogIndex } from "./api-catalog-types";
 import { type ApiSpecResolver, createApiSpecResolver } from "./api-spec-resolve";
 import type { ApiSpecIndex } from "./api-spec-types";
 import { getRuntimeBuildInfo, type RuntimeBuildInfo, renderAboutDoc } from "./build-info-runtime";
@@ -23,17 +30,20 @@ import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
 const SCHEME_PREFIX = "xcsh://";
 const ABOUT_ROUTE = "about";
 const API_SPEC_HOST = "api-spec";
+const API_CATALOG_HOST = "api-catalog";
 
 const EMPTY_INDEX: ApiSpecIndex = { version: "unknown", timestamp: "", domains: [] };
+const EMPTY_CATALOG_INDEX: ApiCatalogIndex = {
+	version: "unknown",
+	displayName: "F5 Distributed Cloud",
+	service: "f5xc",
+	categoryCount: 0,
+	auth: { type: "", headerName: "", headerTemplate: "", tokenSource: "", baseUrlSource: "" },
+	defaults: {},
+};
 
 let _apiSpecCache: { index: ApiSpecIndex; blobs: Record<string, string>; version: string } | null = null;
 
-/**
- * Lazily loads the generated API spec index. Uses require() instead of
- * top-level import because the generated file may not exist in all
- * contexts (tarball install, type-check without build). The try-catch
- * falls back to an empty index so the handler degrades gracefully.
- */
 function loadApiSpecs(): { index: ApiSpecIndex; blobs: Record<string, string>; version: string } {
 	if (_apiSpecCache) return _apiSpecCache;
 	try {
@@ -50,31 +60,51 @@ function loadApiSpecs(): { index: ApiSpecIndex; blobs: Record<string, string>; v
 	return _apiSpecCache;
 }
 
-export interface InternalDocsProtocolOptions {
-	/** Override runtime build-info resolution. Primarily for tests. */
-	readonly resolveBuildInfo?: () => Promise<RuntimeBuildInfo>;
-	/** Sync getter returning the current context status (or null if unconfigured / unavailable). */
-	readonly getContextStatus?: () => ContextStatus | null;
-	/** Override the API spec resolver. Primarily for tests. */
-	readonly apiSpecResolver?: ApiSpecResolver;
+let _apiCatalogCache: {
+	index: ApiCatalogIndex;
+	summaries: readonly ApiCatalogCategorySummary[];
+	blobs: Record<string, string>;
+} | null = null;
+
+function loadApiCatalog(): {
+	index: ApiCatalogIndex;
+	summaries: readonly ApiCatalogCategorySummary[];
+	blobs: Record<string, string>;
+} {
+	if (_apiCatalogCache) return _apiCatalogCache;
+	try {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const mod = require("./api-catalog-index.generated");
+		_apiCatalogCache = {
+			index: mod.API_CATALOG_INDEX ?? EMPTY_CATALOG_INDEX,
+			summaries: mod.API_CATALOG_CATEGORY_SUMMARIES ?? [],
+			blobs: mod.API_CATALOG_BLOBS ?? {},
+		};
+	} catch {
+		_apiCatalogCache = { index: EMPTY_CATALOG_INDEX, summaries: [], blobs: {} };
+	}
+	return _apiCatalogCache;
 }
 
-/**
- * Handler for the xcsh:// internal documentation protocol.
- *
- * Resolves documentation file names to their content, lists available docs,
- * and serves the runtime identity doc at xcsh://about.
- */
+export interface InternalDocsProtocolOptions {
+	readonly resolveBuildInfo?: () => Promise<RuntimeBuildInfo>;
+	readonly getContextStatus?: () => ContextStatus | null;
+	readonly apiSpecResolver?: ApiSpecResolver;
+	readonly apiCatalogResolver?: ApiCatalogResolver;
+}
+
 export class InternalDocsProtocolHandler implements ProtocolHandler {
 	readonly scheme = "xcsh";
 	readonly #resolveBuildInfo: () => Promise<RuntimeBuildInfo>;
 	readonly #getContextStatus: (() => ContextStatus | null) | undefined;
 	#apiSpecResolver: ApiSpecResolver | null;
+	#apiCatalogResolver: ApiCatalogResolver | null;
 
 	constructor(options: InternalDocsProtocolOptions = {}) {
 		this.#resolveBuildInfo = options.resolveBuildInfo ?? getRuntimeBuildInfo;
 		this.#getContextStatus = options.getContextStatus;
 		this.#apiSpecResolver = options.apiSpecResolver ?? null;
+		this.#apiCatalogResolver = options.apiCatalogResolver ?? null;
 	}
 
 	#getApiSpecResolver(): ApiSpecResolver {
@@ -85,11 +115,23 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 		return this.#apiSpecResolver;
 	}
 
+	#getApiCatalogResolver(): ApiCatalogResolver {
+		if (!this.#apiCatalogResolver) {
+			const catalog = loadApiCatalog();
+			this.#apiCatalogResolver = createApiCatalogResolver(catalog.index, catalog.summaries, catalog.blobs);
+		}
+		return this.#apiCatalogResolver;
+	}
+
 	async resolve(url: InternalUrl): Promise<InternalResource> {
 		const host = url.rawHost || url.hostname;
 
 		if (host === API_SPEC_HOST) {
 			return this.#getApiSpecResolver().resolve(url);
+		}
+
+		if (host === API_CATALOG_HOST) {
+			return this.#getApiCatalogResolver().resolve(url);
 		}
 
 		const pathname = url.rawPathname ?? url.pathname;
@@ -108,14 +150,17 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 		}
 
 		const specs = loadApiSpecs();
+		const catalog = loadApiCatalog();
 		const syntheticEntry = `- [${ABOUT_ROUTE}](${SCHEME_PREFIX}${ABOUT_ROUTE}) — identity and build fingerprint`;
 		const apiSpecEntry = `- [${API_SPEC_HOST}/](${SCHEME_PREFIX}${API_SPEC_HOST}/) — F5 XC API specifications (${specs.index.domains.length} domains, v${specs.version})`;
+		const apiCatalogEntry = `- [${API_CATALOG_HOST}/](${SCHEME_PREFIX}${API_CATALOG_HOST}/) — F5 XC API operation catalog (${catalog.summaries.length} categories, v${catalog.index.version})`;
 		const listing = [
 			syntheticEntry,
 			apiSpecEntry,
+			apiCatalogEntry,
 			...EMBEDDED_DOC_FILENAMES.map(f => `- [${f}](${SCHEME_PREFIX}${f})`),
 		].join("\n");
-		const totalCount = EMBEDDED_DOC_FILENAMES.length + 2;
+		const totalCount = EMBEDDED_DOC_FILENAMES.length + 3;
 		const content = `# Documentation\n\n${totalCount} files available:\n\n${listing}\n`;
 
 		return {

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -197,6 +197,14 @@ Most tools resolve custom protocol URLs to internal resources (not web URLs):
   2. Read `xcsh://api-spec/{domain}` to find the resource and operations
   3. Read `xcsh://api-spec/{domain}?resource={name}` for full endpoint specification
   Never guess API paths or request schemas.
+  Also available: `xcsh://api-spec/workflows/` (step-by-step guides),
+  `xcsh://api-spec/errors/{code}` (error resolution),
+  `xcsh://api-spec/glossary/` (acronym reference).
+
+- `xcsh://api-catalog/` — Pre-built API operation catalog with curl templates.
+  **MUST NOT** read proactively. When building API requests:
+  1. Read `xcsh://api-catalog/?search={term}` to find the right operation
+  2. Read `xcsh://api-catalog/{category}` for full operation details and curl template
 
 In `bash`, URIs auto-resolve to filesystem paths (e.g., `python skill://my-skill/scripts/init.py`).
 

--- a/packages/coding-agent/test/internal-urls/api-catalog-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/api-catalog-resolve.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import * as zlib from "node:zlib";
+import { createApiCatalogResolver } from "../../src/internal-urls/api-catalog-resolve";
+import type { ApiCatalogIndex } from "../../src/internal-urls/api-catalog-types";
+import type { InternalUrl } from "../../src/internal-urls/types";
+
+const testCatalogIndex: ApiCatalogIndex = {
+	version: "2.1.63",
+	displayName: "F5 Distributed Cloud",
+	service: "f5xc",
+	categoryCount: 2,
+	auth: {
+		type: "apiToken",
+		headerName: "Authorization",
+		headerTemplate: "APIToken $TOKEN",
+		tokenSource: "F5XC_API_TOKEN",
+		baseUrlSource: "F5XC_API_URL",
+	},
+	defaults: { namespace: { source: "F5XC_NAMESPACE" } },
+};
+
+const testCategorySummaries = [
+	{ name: "dns-zone", displayName: "DNS Zone", operationCount: 2 },
+	{ name: "http-loadbalancer", displayName: "HTTP Load Balancer", operationCount: 1 },
+];
+
+function compressCategory(cat: Record<string, unknown>): string {
+	return zlib.gzipSync(Buffer.from(JSON.stringify(cat))).toString("base64");
+}
+
+const testCatalogBlobs: Record<string, string> = {
+	"dns-zone": compressCategory({
+		name: "dns-zone",
+		displayName: "DNS Zone",
+		operations: [
+			{
+				name: "create_dns_zone",
+				description: "Create a DNS zone",
+				method: "POST",
+				path: "/api/config/dns/namespaces/{namespace}/dns_zones",
+				dangerLevel: "medium",
+				parameters: [{ name: "namespace", in: "path", required: true, type: "string", default: "$F5XC_NAMESPACE" }],
+				bodySchema: { type: "object", properties: { name: { type: "string" } } },
+			},
+			{
+				name: "list_dns_zones",
+				description: "List DNS zones",
+				method: "GET",
+				path: "/api/config/dns/namespaces/{namespace}/dns_zones",
+				dangerLevel: "low",
+				parameters: [{ name: "namespace", in: "path", required: true, type: "string", default: "$F5XC_NAMESPACE" }],
+			},
+		],
+	}),
+	"http-loadbalancer": compressCategory({
+		name: "http-loadbalancer",
+		displayName: "HTTP Load Balancer",
+		operations: [
+			{
+				name: "create_http_lb",
+				description: "Create HTTP load balancer",
+				method: "POST",
+				path: "/api/config/namespaces/{namespace}/http_loadbalancers",
+				dangerLevel: "high",
+				parameters: [{ name: "namespace", in: "path", required: true, type: "string" }],
+			},
+		],
+	}),
+};
+
+function parseUrl(urlStr: string): InternalUrl {
+	const url = new URL(urlStr) as InternalUrl;
+	const match = urlStr.match(/^xcsh:\/\/([^/?#]+)(\/[^?#]*)?/);
+	url.rawHost = match?.[1] ?? "";
+	url.rawPathname = match?.[2] ?? "/";
+	return url;
+}
+
+describe("API Catalog Resolver", () => {
+	it("renders catalog index with all categories", async () => {
+		const resolver = createApiCatalogResolver(testCatalogIndex, testCategorySummaries, testCatalogBlobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/"));
+		expect(result.contentType).toBe("text/markdown");
+		expect(result.content).toContain("dns-zone");
+		expect(result.content).toContain("DNS Zone");
+		expect(result.content).toContain("http-loadbalancer");
+	});
+
+	it("filters categories by search term", async () => {
+		const resolver = createApiCatalogResolver(testCatalogIndex, testCategorySummaries, testCatalogBlobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/?search=dns"));
+		expect(result.content).toContain("dns-zone");
+		expect(result.content).not.toContain("http-loadbalancer");
+	});
+
+	it("search is case-insensitive", async () => {
+		const resolver = createApiCatalogResolver(testCatalogIndex, testCategorySummaries, testCatalogBlobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/?search=DNS"));
+		expect(result.content).toContain("dns-zone");
+	});
+
+	it("renders category detail with operations", async () => {
+		const resolver = createApiCatalogResolver(testCatalogIndex, testCategorySummaries, testCatalogBlobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/dns-zone"));
+		expect(result.content).toContain("POST");
+		expect(result.content).toContain("/api/config/dns/namespaces/{namespace}/dns_zones");
+		expect(result.content).toContain("Create a DNS zone");
+		expect(result.content).toContain("medium");
+	});
+
+	it("renders curl template for operations", async () => {
+		const resolver = createApiCatalogResolver(testCatalogIndex, testCategorySummaries, testCatalogBlobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/dns-zone"));
+		expect(result.content).toContain("curl");
+		expect(result.content).toContain("$F5XC_API_URL");
+		expect(result.content).toContain("$F5XC_API_TOKEN");
+	});
+
+	it("returns helpful error for unknown category", async () => {
+		const resolver = createApiCatalogResolver(testCatalogIndex, testCategorySummaries, testCatalogBlobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/nonexistent"));
+		expect(result.content).toContain("not found");
+	});
+
+	it("renders parameters in category detail", async () => {
+		const resolver = createApiCatalogResolver(testCatalogIndex, testCategorySummaries, testCatalogBlobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/dns-zone"));
+		expect(result.content).toContain("namespace");
+		expect(result.content).toContain("$F5XC_NAMESPACE");
+	});
+});

--- a/packages/coding-agent/test/internal-urls/api-spec-integration.test.ts
+++ b/packages/coding-agent/test/internal-urls/api-spec-integration.test.ts
@@ -37,6 +37,12 @@ describe("API spec integration — full traversal", () => {
 		expect(result.content).toContain("network_security");
 	});
 
+	it("Level 1: domain index includes icon and tier columns", async () => {
+		const result = await createRouter().resolve("xcsh://api-spec/");
+		expect(result.content).toContain("Icon");
+		expect(result.content).toContain("Tier");
+	});
+
 	it("Level 2: domain detail shows resources and operations for a known domain", async () => {
 		const result = await createRouter().resolve("xcsh://api-spec/dns");
 		expect(result.contentType).toBe("text/markdown");
@@ -65,5 +71,36 @@ describe("API spec integration — full traversal", () => {
 			expect(result.contentType).toBe("text/markdown");
 			expect(result.content.length).toBeGreaterThan(0);
 		}
+	});
+
+	it("workflows index renders", async () => {
+		const result = await createRouter().resolve("xcsh://api-spec/workflows/");
+		expect(result.contentType).toBe("text/markdown");
+		expect(result.content).toContain("Guided");
+	});
+
+	it("errors index renders", async () => {
+		const result = await createRouter().resolve("xcsh://api-spec/errors/");
+		expect(result.contentType).toBe("text/markdown");
+		expect(result.content).toContain("401");
+	});
+
+	it("glossary renders acronym table", async () => {
+		const result = await createRouter().resolve("xcsh://api-spec/glossary/");
+		expect(result.contentType).toBe("text/markdown");
+		expect(result.content).toContain("Acronym");
+	});
+});
+
+describe("API catalog integration — full traversal", () => {
+	it("catalog index lists categories", async () => {
+		const result = await createRouter().resolve("xcsh://api-catalog/");
+		expect(result.contentType).toBe("text/markdown");
+		expect(result.content).toContain("Category");
+	});
+
+	it("catalog search filters categories", async () => {
+		const result = await createRouter().resolve("xcsh://api-catalog/?search=dns");
+		expect(result.contentType).toBe("text/markdown");
 	});
 });

--- a/packages/coding-agent/test/internal-urls/api-spec-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/api-spec-resolve.test.ts
@@ -103,6 +103,7 @@ function compressSpec(spec: OpenAPISpec): string {
 const testIndex: ApiSpecIndex = {
 	version: "1.0.0",
 	timestamp: "2026-04-30T00:00:00Z",
+	criticalResources: ["dns_zone", "http_loadbalancer"],
 	domains: [
 		{
 			domain: "dns",
@@ -113,8 +114,23 @@ const testIndex: ApiSpecIndex = {
 			pathCount: 5,
 			schemaCount: 3,
 			complexity: "standard",
+			icon: "🌐",
+			requiresTier: "Standard",
 			resources: [
-				{ name: "dns_zone", description: "Primary DNS zone management" },
+				{
+					name: "dns_zone",
+					description: "Primary DNS zone management",
+					schemaComponents: ["dns_zone"],
+					apiPaths: [
+						"/api/config/dns/namespaces/{ns}/dns_zones",
+						"/api/config/dns/namespaces/{ns}/dns_zones/{name}",
+					],
+					tier: "Standard",
+					supportsLogs: true,
+					supportsMetrics: true,
+					dependencies: { required: [], optional: ["dns_load_balancer"] },
+					relationshipHints: ["dns_load_balancer: Geographic or weighted DNS routing"],
+				},
 				{ name: "dns_record", description: "Individual DNS records" },
 			],
 			useCases: ["Manage DNS zones", "Configure records"],
@@ -132,6 +148,62 @@ const testIndex: ApiSpecIndex = {
 			resources: [{ name: "cdn_distribution", description: "CDN distributions" }],
 		},
 	],
+	guidedWorkflows: {
+		version: "1.0.0",
+		domains: ["cdn"],
+		workflows: [
+			{
+				id: "enable_cdn",
+				name: "Enable CDN Distribution",
+				description: "Configure CDN",
+				complexity: "medium",
+				estimated_steps: 3,
+				prerequisites: ["Existing origin server"],
+				domain: "cdn",
+				steps: [
+					{
+						order: 1,
+						action: "create_origin",
+						name: "Define Origin",
+						description: "Configure origin",
+						resource: "cdn_origin",
+						required_fields: ["name"],
+					},
+					{
+						order: 2,
+						action: "create_dist",
+						name: "Create Distribution",
+						description: "Create CDN dist",
+						depends_on: [1],
+					},
+				],
+			},
+		],
+	},
+	errorResolution: {
+		version: "1.0.0",
+		http_errors: {
+			"401": {
+				code: 401,
+				name: "Unauthorized",
+				description: "Authentication credentials missing or invalid",
+				common_causes: ["Missing Authorization header", "Expired token"],
+				diagnostic_steps: [{ step: 1, action: "Check header", description: "Verify Authorization header" }],
+				prevention: ["Rotate tokens regularly"],
+			},
+		},
+		resource_errors: {
+			dns_zone: [{ error_code: 409, pattern: "zone exists", resolution: "Use existing zone or delete first" }],
+		},
+	},
+	acronyms: {
+		version: "1.0.0",
+		categories: ["Networking"],
+		acronyms: [
+			{ acronym: "DNS", expansion: "Domain Name System", category: "Networking" },
+			{ acronym: "CDN", expansion: "Content Delivery Network", category: "Networking" },
+		],
+	},
 };
 
 const testBlobs: Record<string, string> = {
@@ -181,6 +253,27 @@ describe("API Spec Resolver", () => {
 			expect(result.content).toContain("Category");
 			expect(result.content).toContain("Description");
 		});
+
+		it("contains icon column", async () => {
+			const resolver = createApiSpecResolver(testIndex, testBlobs);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/"));
+			expect(result.content).toContain("Icon");
+			expect(result.content).toContain("🌐");
+		});
+
+		it("contains tier column", async () => {
+			const resolver = createApiSpecResolver(testIndex, testBlobs);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/"));
+			expect(result.content).toContain("Tier");
+			expect(result.content).toContain("Standard");
+		});
+
+		it("marks domains with critical resources", async () => {
+			const resolver = createApiSpecResolver(testIndex, testBlobs);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/"));
+			expect(result.content).toContain("DNS management *");
+			expect(result.content).toContain("critical resources");
+		});
 	});
 
 	describe("Level 2 — Domain Detail", () => {
@@ -223,6 +316,36 @@ describe("API Spec Resolver", () => {
 			const result = await resolver.resolve(parseUrl("xcsh://api-spec/dns"));
 			expect(result.content).toContain("xcsh://api-spec/dns?resource=");
 		});
+
+		it("shows tier/preview banner for advanced domains", async () => {
+			const advancedIndex: ApiSpecIndex = {
+				...testIndex,
+				domains: [{ ...testIndex.domains[0], requiresTier: "Advanced", isPreview: true }, testIndex.domains[1]],
+			};
+			const resolver = createApiSpecResolver(advancedIndex, testBlobs);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/dns"));
+			expect(result.content).toContain("Advanced");
+			expect(result.content).toContain("Preview");
+		});
+
+		it("shows dependency information", async () => {
+			const resolver = createApiSpecResolver(testIndex, testBlobs);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/dns"));
+			expect(result.content).toContain("dns_load_balancer");
+		});
+
+		it("shows relationship hints", async () => {
+			const resolver = createApiSpecResolver(testIndex, testBlobs);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/dns"));
+			expect(result.content).toContain("Geographic or weighted DNS routing");
+		});
+
+		it("shows observability flags", async () => {
+			const resolver = createApiSpecResolver(testIndex, testBlobs);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/dns"));
+			expect(result.content).toContain("logs");
+			expect(result.content).toContain("metrics");
+		});
 	});
 
 	describe("Level 3 — Resource filter", () => {
@@ -254,6 +377,51 @@ describe("API Spec Resolver", () => {
 			const result = await resolver.resolve(parseUrl("xcsh://api-spec/dns?resource=nonexistent"));
 			expect(result.content).toContain("Resource not found");
 			expect(result.content).toContain("dns_zone");
+		});
+
+		it("prefers apiPaths over schemaComponents when both are present", async () => {
+			const specWithExtra = makeSpec({
+				paths: {
+					"/api/config/dns/namespaces/{ns}/dns_zones": {
+						post: { summary: "Create DNS zone", operationId: "ves.io.schema.dns_zone.API.Create" },
+					},
+					"/api/config/dns/namespaces/{ns}/dns_zones/{name}": {
+						get: { summary: "Get DNS zone", operationId: "ves.io.schema.dns_zone.API.Get" },
+					},
+					"/api/extra/dns_zone_stats": {
+						get: {
+							summary: "Stats (should be excluded)",
+							operationId: "ves.io.schema.dns_zone.CustomAPI.Stats",
+						},
+					},
+				},
+			});
+			const indexWithApiPaths: ApiSpecIndex = {
+				...testIndex,
+				domains: [
+					{
+						...testIndex.domains[0],
+						resources: [
+							{
+								name: "dns_zone",
+								description: "DNS zone",
+								schemaComponents: ["dns_zone"],
+								apiPaths: [
+									"/api/config/dns/namespaces/{ns}/dns_zones",
+									"/api/config/dns/namespaces/{ns}/dns_zones/{name}",
+								],
+							},
+						],
+					},
+					testIndex.domains[1],
+				],
+			};
+			const blobs = { dns: compressSpec(specWithExtra), cdn: testBlobs.cdn };
+			const resolver = createApiSpecResolver(indexWithApiPaths, blobs);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/dns?resource=dns_zone"));
+			expect(result.content).toContain("Create DNS zone");
+			expect(result.content).toContain("Get DNS zone");
+			expect(result.content).not.toContain("Stats (should be excluded)");
 		});
 	});
 
@@ -310,14 +478,40 @@ describe("API Spec Resolver", () => {
 					},
 				},
 			});
+			const indexNoApiPaths: ApiSpecIndex = {
+				...testIndex,
+				domains: [
+					{
+						...testIndex.domains[0],
+						resources: [
+							{ name: "dns_zone", description: "DNS zone" },
+							{ name: "dns_record", description: "DNS records" },
+						],
+					},
+					testIndex.domains[1],
+				],
+			};
 			const blobs = { dns: compressSpec(specWithCustomApi) };
-			const resolver = createApiSpecResolver(testIndex, blobs);
+			const resolver = createApiSpecResolver(indexNoApiPaths, blobs);
 			const result = await resolver.resolve(parseUrl("xcsh://api-spec/dns?resource=dns_zone"));
 			expect(result.content).toContain("Verify DNS zone");
 			expect(result.content).toContain("List DNS zones");
 		});
 
 		it("matches dotted schema components", async () => {
+			const indexNoApiPaths: ApiSpecIndex = {
+				...testIndex,
+				domains: [
+					{
+						...testIndex.domains[0],
+						resources: [
+							{ name: "dns_zone", description: "DNS zone" },
+							{ name: "dns_record", description: "DNS records" },
+						],
+					},
+					testIndex.domains[1],
+				],
+			};
 			const specWithDottedSchema = makeSpec({
 				paths: {
 					"/api/config/network/namespaces/{ns}/forward_proxy_policies": {
@@ -329,7 +523,7 @@ describe("API Spec Resolver", () => {
 				},
 			});
 			const blobs = { dns: compressSpec(specWithDottedSchema) };
-			const resolver = createApiSpecResolver(testIndex, blobs);
+			const resolver = createApiSpecResolver(indexNoApiPaths, blobs);
 			const result = await resolver.resolve(parseUrl("xcsh://api-spec/dns?resource=views.forward_proxy_policy"));
 			expect(result.content).toContain("List forward proxy policies");
 		});
@@ -360,6 +554,64 @@ describe("API Spec Resolver", () => {
 			expect(result.contentType).toBe("text/markdown");
 			expect(result.content).toContain("metadata");
 			expect(result.content).toContain("spec");
+		});
+	});
+
+	describe("Reserved sub-paths", () => {
+		it("renders workflow index", async () => {
+			const resolver = createApiSpecResolver(testIndex, testBlobs);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/workflows/"));
+			expect(result.content).toContain("enable_cdn");
+			expect(result.content).toContain("Enable CDN Distribution");
+			expect(result.content).toContain("medium");
+		});
+
+		it("renders workflow detail", async () => {
+			const resolver = createApiSpecResolver(testIndex, testBlobs);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/workflows/enable_cdn"));
+			expect(result.content).toContain("Define Origin");
+			expect(result.content).toContain("cdn_origin");
+			expect(result.content).toContain("Existing origin server");
+		});
+
+		it("renders error index", async () => {
+			const resolver = createApiSpecResolver(testIndex, testBlobs);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/errors/"));
+			expect(result.content).toContain("401");
+			expect(result.content).toContain("Unauthorized");
+			expect(result.content).toContain("dns_zone");
+		});
+
+		it("renders HTTP error detail", async () => {
+			const resolver = createApiSpecResolver(testIndex, testBlobs);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/errors/401"));
+			expect(result.content).toContain("Missing Authorization header");
+			expect(result.content).toContain("Rotate tokens regularly");
+		});
+
+		it("renders resource error detail", async () => {
+			const resolver = createApiSpecResolver(testIndex, testBlobs);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/errors/dns_zone"));
+			expect(result.content).toContain("zone exists");
+			expect(result.content).toContain("Use existing zone or delete first");
+		});
+
+		it("renders glossary", async () => {
+			const resolver = createApiSpecResolver(testIndex, testBlobs);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/glossary/"));
+			expect(result.content).toContain("DNS");
+			expect(result.content).toContain("Domain Name System");
+			expect(result.content).toContain("Networking");
+		});
+
+		it("does not confuse reserved sub-paths with domain names", async () => {
+			const resolver = createApiSpecResolver(testIndex, testBlobs);
+			const wf = await resolver.resolve(parseUrl("xcsh://api-spec/workflows/"));
+			expect(wf.content).not.toContain("Domain not found");
+			const err = await resolver.resolve(parseUrl("xcsh://api-spec/errors/"));
+			expect(err.content).not.toContain("Domain not found");
+			const gl = await resolver.resolve(parseUrl("xcsh://api-spec/glossary/"));
+			expect(gl.content).not.toContain("Domain not found");
 		});
 	});
 });

--- a/packages/coding-agent/test/internal-urls/api-spec-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/api-spec-resolve.test.ts
@@ -150,6 +150,7 @@ const testIndex: ApiSpecIndex = {
 	],
 	guidedWorkflows: {
 		version: "1.0.0",
+		total_workflows: 1,
 		domains: ["cdn"],
 		workflows: [
 			{

--- a/packages/coding-agent/test/system-prompt-api-spec.test.ts
+++ b/packages/coding-agent/test/system-prompt-api-spec.test.ts
@@ -26,10 +26,8 @@ describe("system prompt API spec integration", () => {
 
 	it("renders api-spec hint without dynamic metadata", async () => {
 		const rendered = await buildSystemPrompt({ tools: new Map() });
-		// Old Handlebars variables must not leak into rendered prompt
 		expect(rendered).not.toContain("{{apiSpecDomainCount}}");
 		expect(rendered).not.toContain("{{apiSpecVersion}}");
-		// Static compressed hint must be present
 		expect(rendered).toContain("F5 XC API specifications");
 	});
 
@@ -37,5 +35,33 @@ describe("system prompt API spec integration", () => {
 		const rendered = await buildSystemPrompt({ tools: new Map() });
 		expect(rendered).toContain("**MUST NOT** read proactively");
 		expect(rendered).toContain("Never guess API paths or request schemas");
+	});
+
+	it("includes xcsh://api-catalog/ hint", async () => {
+		const rendered = await buildSystemPrompt({ tools: new Map() });
+		expect(rendered).toContain("xcsh://api-catalog/");
+	});
+
+	it("includes workflow hint", async () => {
+		const rendered = await buildSystemPrompt({ tools: new Map() });
+		expect(rendered).toContain("xcsh://api-spec/workflows/");
+	});
+
+	it("includes error resolution hint", async () => {
+		const rendered = await buildSystemPrompt({ tools: new Map() });
+		expect(rendered).toContain("xcsh://api-spec/errors/");
+	});
+
+	it("includes glossary hint", async () => {
+		const rendered = await buildSystemPrompt({ tools: new Map() });
+		expect(rendered).toContain("xcsh://api-spec/glossary/");
+	});
+
+	it("contains MUST NOT read proactively for api-catalog", async () => {
+		const rendered = await buildSystemPrompt({ tools: new Map() });
+		const catalogIdx = rendered.indexOf("xcsh://api-catalog/");
+		expect(catalogIdx).toBeGreaterThan(-1);
+		const afterCatalog = rendered.slice(catalogIdx);
+		expect(afterCatalog).toContain("MUST NOT");
 	});
 });


### PR DESCRIPTION
## Summary
- Bumps `api-specs-enriched` to v2.1.63 and consumes all new enrichments: per-resource `api_paths` + `schema_components`, tier/preview/dependency annotations, 7 guided workflows, HTTP + resource error resolution, and acronym glossary
- Adds `xcsh://api-catalog/` host: 867-category pre-built operation catalog with curl templates
- Extends `xcsh://api-spec/` with `workflows/`, `errors/`, and `glossary/` sub-paths
- Updates system prompt hints to surface all new URL paths to the agent

## Test plan
- [ ] 65 unit tests across api-spec-resolve, api-catalog-resolve, integration, and system-prompt suites — all green
- [ ] Type check passes (`tsgo --noEmit`) with generated v2.1.63 index
- [ ] Biome lint and all pre-commit hooks pass

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)