### PR TITLE
chore: bump version to v18.31.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,7 +2136,7 @@ dependencies = [
 
 [[package]]
 name = "pi-natives"
-version = "18.31.0"
+version = "18.31.1"
 dependencies = [
  "arboard",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/brush-core-vendored", "crates/brush-builtins-vendored", "crat
 resolver = "3"
 
 [workspace.package]
-version = "18.31.0"
+version = "18.31.1"
 edition = "2024"
 license = "MIT"
 authors = ["Can Boluk"]

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "packages/agent": {
       "name": "@f5xc-salesdemos/pi-agent-core",
-      "version": "18.31.0",
+      "version": "18.31.1",
       "dependencies": {
         "@f5xc-salesdemos/pi-ai": "workspace:*",
         "@f5xc-salesdemos/pi-utils": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "packages/ai": {
       "name": "@f5xc-salesdemos/pi-ai",
-      "version": "18.31.0",
+      "version": "18.31.1",
       "bin": {
         "pi-ai": "./src/cli.ts",
       },
@@ -51,7 +51,7 @@
     },
     "packages/coding-agent": {
       "name": "@f5xc-salesdemos/xcsh",
-      "version": "18.31.0",
+      "version": "18.31.1",
       "bin": {
         "xcsh": "src/cli.ts",
       },
@@ -83,22 +83,22 @@
     },
     "packages/natives": {
       "name": "@f5xc-salesdemos/pi-natives",
-      "version": "18.31.0",
+      "version": "18.31.1",
       "devDependencies": {
         "@napi-rs/cli": "3.6.0",
         "@types/bun": "^1.3",
       },
       "optionalDependencies": {
-        "@f5xc-salesdemos/pi-natives-darwin-arm64": "18.31.0",
-        "@f5xc-salesdemos/pi-natives-darwin-x64": "18.31.0",
-        "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.31.0",
-        "@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.31.0",
-        "@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.31.0",
+        "@f5xc-salesdemos/pi-natives-darwin-arm64": "18.31.1",
+        "@f5xc-salesdemos/pi-natives-darwin-x64": "18.31.1",
+        "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.31.1",
+        "@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.31.1",
+        "@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.31.1",
       },
     },
     "packages/stats": {
       "name": "@f5xc-salesdemos/xcsh-stats",
-      "version": "18.31.0",
+      "version": "18.31.1",
       "bin": {
         "xcsh-stats": "./src/index.ts",
       },
@@ -123,7 +123,7 @@
     },
     "packages/swarm-extension": {
       "name": "@f5xc-salesdemos/swarm-extension",
-      "version": "18.31.0",
+      "version": "18.31.1",
       "bin": {
         "xcsh-swarm": "src/cli.ts",
       },
@@ -139,7 +139,7 @@
     },
     "packages/tui": {
       "name": "@f5xc-salesdemos/pi-tui",
-      "version": "18.31.0",
+      "version": "18.31.1",
       "dependencies": {
         "@f5xc-salesdemos/pi-natives": "workspace:*",
         "@f5xc-salesdemos/pi-utils": "workspace:*",
@@ -178,7 +178,7 @@
     },
     "packages/utils": {
       "name": "@f5xc-salesdemos/pi-utils",
-      "version": "18.31.0",
+      "version": "18.31.1",
       "dependencies": {
         "beautiful-mermaid": "^1.1",
         "handlebars": "^4.7.9",
@@ -1130,7 +1130,7 @@
 
     "rss-parser": ["rss-parser@3.13.0", "", { "dependencies": { "entities": "^2.0.3", "xml2js": "^0.5.0" } }, "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w=="],
 
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
@@ -1258,7 +1258,7 @@
 
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
-    "zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
+    "zod": ["zod@4.4.2", "", {}, "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
@@ -1280,6 +1280,8 @@
 
     "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "jwa/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
     "mammoth/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
@@ -1287,6 +1289,8 @@
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "rss-parser/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
+
+    "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -1305,8 +1309,6 @@
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "jszip/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "jszip/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-agent-core",
-	"version": "18.31.0",
+	"version": "18.31.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-ai",
-	"version": "18.31.0",
+	"version": "18.31.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/xcsh",
-	"version": "18.31.0",
+	"version": "18.31.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-arm64/package.json
+++ b/packages/natives/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-darwin-arm64",
-	"version": "18.31.0",
+	"version": "18.31.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (macOS arm64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-x64/package.json
+++ b/packages/natives/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-darwin-x64",
-	"version": "18.31.0",
+	"version": "18.31.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (macOS x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-arm64-gnu/package.json
+++ b/packages/natives/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-linux-arm64-gnu",
-	"version": "18.31.0",
+	"version": "18.31.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Linux arm64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-x64-gnu/package.json
+++ b/packages/natives/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-linux-x64-gnu",
-	"version": "18.31.0",
+	"version": "18.31.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Linux x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/win32-x64-msvc/package.json
+++ b/packages/natives/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-win32-x64-msvc",
-	"version": "18.31.0",
+	"version": "18.31.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Windows x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives",
-	"version": "18.31.0",
+	"version": "18.31.1",
 	"description": "Native Rust bindings for grep, clipboard, image processing, syntax highlighting, PTY, and shell operations via N-API",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",
@@ -56,11 +56,11 @@
 		}
 	},
 	"optionalDependencies": {
-		"@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.31.0",
-		"@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.31.0",
-		"@f5xc-salesdemos/pi-natives-darwin-x64": "18.31.0",
-		"@f5xc-salesdemos/pi-natives-darwin-arm64": "18.31.0",
-		"@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.31.0"
+		"@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.31.1",
+		"@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.31.1",
+		"@f5xc-salesdemos/pi-natives-darwin-x64": "18.31.1",
+		"@f5xc-salesdemos/pi-natives-darwin-arm64": "18.31.1",
+		"@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.31.1"
 	},
 	"files": [
 		"native",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/xcsh-stats",
-	"version": "18.31.0",
+	"version": "18.31.1",
 	"description": "Local observability dashboard for pi AI usage statistics",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/swarm-extension/package.json
+++ b/packages/swarm-extension/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/swarm-extension",
-	"version": "18.31.0",
+	"version": "18.31.1",
 	"description": "Swarm orchestration extension for xcsh",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Derek Rynd",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-tui",
-	"version": "18.31.0",
+	"version": "18.31.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-utils",
-	"version": "18.31.0",
+	"version": "18.31.1",
 	"description": "Shared utilities for pi packages",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",


### PR DESCRIPTION
Automated release PR generated by `scripts/release.ts`.

Bumps every public package and the Cargo workspace to `v18.31.1` and updates CHANGELOGs for the releasable commits since the last tag.

Once this PR squash-merges to `main`, `.github/workflows/tag-on-version-bump.yml` pushes the `v18.31.1` git tag, which triggers the downstream release chain (build → sign → publish).

### Releasable commits (1)

- fix(coding-agent): add build-time guard and observability for api-spec loading (#450)

See `docs-control`'s onboarding note "Release automation: release PR pattern" for the governance rationale.