### PR TITLE
feat(coding-agent): always build with latest API specs, add repository dispatch receiver

### DIFF
--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -1,0 +1,90 @@
+---
+name: API Spec Update
+
+on:
+  repository_dispatch:
+    types: [enriched-specs-updated]
+
+jobs:
+  update-api-specs:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3"
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+
+      - run: bun install --frozen-lockfile
+
+      - name: Log dispatch payload
+        env:
+          PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
+          PAYLOAD_SOURCE: ${{ github.event.client_payload.trigger_source }}
+        run: |
+          echo "::notice::Received enriched-specs-updated dispatch"
+          echo "Upstream version: ${PAYLOAD_VERSION:-unknown}"
+          echo "Trigger source: ${PAYLOAD_SOURCE:-unknown}"
+
+      - name: Regenerate API spec index from latest release
+        working-directory: packages/coding-agent
+        run: bun run generate-api-spec-index
+
+      - name: Verify generated files exist
+        working-directory: packages/coding-agent
+        run: |
+          test -f src/internal-urls/api-spec-index.generated.ts
+          test -f src/internal-urls/api-catalog-index.generated.ts
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No changes detected — specs already up to date"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            SPEC_VERSION=$(grep 'API_SPEC_VERSION' packages/coding-agent/src/internal-urls/api-spec-index.generated.ts | grep -o '"[^"]*"' | tr -d '"')
+            echo "spec_version=${SPEC_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Specs updated to ${SPEC_VERSION}"
+          fi
+
+      - name: Configure git
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create PR with updated specs
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          SPEC_VERSION: ${{ steps.changes.outputs.spec_version }}
+        run: |
+          BRANCH="chore/api-specs-${SPEC_VERSION}"
+          git checkout -b "$BRANCH"
+          git add -f packages/coding-agent/src/internal-urls/api-spec-index.generated.ts
+          git add -f packages/coding-agent/src/internal-urls/api-catalog-index.generated.ts
+          git commit -m "chore(coding-agent): update embedded API specs to ${SPEC_VERSION}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(coding-agent): update embedded API specs to ${SPEC_VERSION}" \
+            --body "Automated update triggered by upstream api-specs-enriched release.
+
+          This PR updates the embedded API spec index and catalog to ${SPEC_VERSION}."
+          gh pr merge "$BRANCH" --squash --auto --delete-branch

--- a/packages/coding-agent/scripts/generate-api-spec-index.ts
+++ b/packages/coding-agent/scripts/generate-api-spec-index.ts
@@ -78,14 +78,27 @@ interface RawIndex {
 }
 
 const REPO = "f5xc-salesdemos/api-specs-enriched";
-const PINNED_TAG = "v2.1.63";
 const outputPath = path.resolve(import.meta.dir, "../src/internal-urls/api-spec-index.generated.ts");
 const catalogOutputPath = path.resolve(import.meta.dir, "../src/internal-urls/api-catalog-index.generated.ts");
+
+async function resolveLatestTag(): Promise<string> {
+	const response = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
+		headers: { Accept: "application/vnd.github+json" },
+	});
+	if (!response.ok) {
+		throw new Error(`Failed to fetch latest release from ${REPO}: ${response.status} ${response.statusText}`);
+	}
+	const data = (await response.json()) as { tag_name?: string };
+	if (!data.tag_name) {
+		throw new Error(`Latest release from ${REPO} has no tag_name`);
+	}
+	return data.tag_name;
+}
 
 async function downloadFromRelease(): Promise<string> {
 	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "api-specs-"));
 	downloadedTmpDir = tmpDir;
-	const tag = process.env.API_SPECS_TAG ?? PINNED_TAG;
+	const tag = process.env.API_SPECS_TAG ?? (await resolveLatestTag());
 	const zipName = `f5xc-api-specs-${tag}.zip`;
 	const downloadUrl = `https://github.com/${REPO}/releases/download/${tag}/${zipName}`;
 
@@ -139,8 +152,8 @@ async function downloadCatalog(specsDir: string): Promise<Record<string, unknown
 		return JSON.parse(fs.readFileSync(catalogPath, "utf-8"));
 	}
 
-	const tag = process.env.API_SPECS_TAG ?? PINNED_TAG;
-	const catalogUrl = `https://github.com/${REPO}/releases/download/${tag}/api-catalog.json`;
+	const catalogTag = process.env.API_SPECS_TAG ?? (await resolveLatestTag());
+	const catalogUrl = `https://github.com/${REPO}/releases/download/${catalogTag}/api-catalog.json`;
 	console.log(`Downloading API catalog from ${catalogUrl}...`);
 	try {
 		const response = await fetch(catalogUrl, { redirect: "follow" });


### PR DESCRIPTION
## Summary
- Removes pinned `PINNED_TAG` from the API spec generator — now resolves the latest release from `api-specs-enriched` dynamically via GitHub API at build time
- `API_SPECS_TAG` env var still available as explicit override when needed
- Adds `.github/workflows/api-spec-update.yml` — receives `enriched-specs-updated` repository dispatch from `api-specs-enriched`, regenerates embedded specs, and opens an auto-merge PR
- The dispatch infrastructure in `api-specs-enriched` is already configured and enabled for xcsh

## Test plan
- [ ] Generator resolves latest release (verified: picked up v2.1.65 automatically)
- [ ] 65 unit tests pass with dynamically resolved specs
- [ ] `API_SPECS_TAG=v2.1.63` override still works for pinning when needed
- [ ] Dispatch workflow syntax validates

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)