### PR TITLE
feat(coding-agent): add enrichment rendering to xcsh catalog resolver

### DIFF
--- a/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
@@ -142,6 +142,39 @@ function renderCatalogSearch(
 	].join("\n");
 }
 
+function formatConstraints(constraints: Record<string, unknown> | undefined): string {
+	if (!constraints) return "--";
+	const parts: string[] = [];
+	if (constraints.pattern) parts.push(`pattern: \`${constraints.pattern}\``);
+	if (constraints.maxLength != null) parts.push(`maxLength: ${constraints.maxLength}`);
+	if (constraints.minLength != null) parts.push(`minLength: ${constraints.minLength}`);
+	if (constraints.minimum != null) parts.push(`min: ${constraints.minimum}`);
+	if (constraints.maximum != null) parts.push(`max: ${constraints.maximum}`);
+	if (constraints.minItems != null) parts.push(`minItems: ${constraints.minItems}`);
+	if (constraints.maxItems != null) parts.push(`maxItems: ${constraints.maxItems}`);
+	if (constraints.format) parts.push(`format: ${constraints.format}`);
+	if (Array.isArray(constraints.enum)) parts.push(`enum: ${constraints.enum.join(", ")}`);
+	return parts.length > 0 ? parts.join(", ") : "--";
+}
+
+function formatRequiredFor(
+	reqFor: { minimum_config?: boolean; create?: boolean; update?: boolean; read?: boolean } | undefined,
+): string {
+	if (!reqFor) return "--";
+	const ops: string[] = [];
+	if (reqFor.minimum_config) ops.push("minimum_config");
+	if (reqFor.create) ops.push("create");
+	if (reqFor.update) ops.push("update");
+	if (reqFor.read) ops.push("read");
+	return ops.length > 0 ? ops.join(", ") : "--";
+}
+
+function formatDefault(defaultVal: unknown, serverDefault: boolean | undefined): string {
+	if (defaultVal == null && !serverDefault) return "--";
+	const val = defaultVal != null ? String(defaultVal) : "--";
+	return serverDefault ? `${val} (server)` : val;
+}
+
 function renderCatalogDetail(cat: ApiCatalogCategory, index: ApiCatalogIndex): string {
 	const sections: string[] = [`# ${cat.displayName}`, "", `${cat.operations.length} operations.`];
 
@@ -159,7 +192,7 @@ function renderCatalogDetail(cat: ApiCatalogCategory, index: ApiCatalogIndex): s
 			}
 		}
 
-		if (op.bodySchema) {
+		if (!op.minimumPayload && op.bodySchema) {
 			const minConfig = (op.bodySchema as Record<string, unknown>)["x-f5xc-minimum-configuration"] as
 				| Record<string, unknown>
 				| undefined;
@@ -182,6 +215,47 @@ function renderCatalogDetail(cat: ApiCatalogCategory, index: ApiCatalogIndex): s
 			sections[sections.length - 1] = lastLine.replace(/ \\$/, "");
 		}
 		sections.push("```");
+
+		// Minimum Configuration (Tier 1)
+		if (op.minimumPayload) {
+			sections.push("", "### Minimum Configuration", "");
+			sections.push(`Required fields: ${op.minimumPayload.requiredFields.join(", ")}`);
+			sections.push("", "```json", JSON.stringify(op.minimumPayload.json, null, 2), "```");
+		}
+
+		// Field Constraints (Tier 2)
+		if (op.fieldMetadata && Object.keys(op.fieldMetadata).length > 0) {
+			sections.push("", "### Field Constraints", "");
+			sections.push("| Field | Type | Description | Constraint | Required For | Default |");
+			sections.push("|-------|------|-------------|-----------|--------------|---------|");
+			for (const [field, meta] of Object.entries(op.fieldMetadata)) {
+				const desc = meta.description ?? "";
+				const constraint = formatConstraints(meta.constraints);
+				const reqFor = formatRequiredFor(meta.required_for);
+				const def = formatDefault(meta.default, meta.serverDefault);
+				sections.push(`| ${field} | ${meta.type} | ${desc} | ${constraint} | ${reqFor} | ${def} |`);
+			}
+		}
+
+		// OneOf Recommendations
+		if (op.oneOfRecommendations && Object.keys(op.oneOfRecommendations).length > 0) {
+			sections.push("", "### OneOf Recommendations", "");
+			sections.push("| Path | Recommended Variant |");
+			sections.push("|------|-------------------|");
+			for (const [path, variant] of Object.entries(op.oneOfRecommendations)) {
+				sections.push(`| ${path} | ${variant} |`);
+			}
+		}
+
+		// Response Summary
+		if (op.responseSummary && op.responseSummary.length > 0) {
+			sections.push("", "### Response", "");
+			sections.push("| Field | Type | Description |");
+			sections.push("|-------|------|-------------|");
+			for (const f of op.responseSummary) {
+				sections.push(`| ${f.field} | ${f.type} | ${f.description} |`);
+			}
+		}
 	}
 
 	sections.push("");

--- a/packages/coding-agent/src/internal-urls/api-catalog-types.ts
+++ b/packages/coding-agent/src/internal-urls/api-catalog-types.ts
@@ -13,6 +13,34 @@ export interface ApiCatalogParameter {
 	readonly default?: string;
 }
 
+export interface ApiCatalogMinimumPayload {
+	readonly json: Record<string, unknown>;
+	readonly requiredFields: readonly string[];
+	readonly description: string;
+}
+
+export interface ApiCatalogFieldMeta {
+	readonly type: string;
+	readonly description?: string;
+	readonly required_for?: {
+		readonly minimum_config?: boolean;
+		readonly create?: boolean;
+		readonly update?: boolean;
+		readonly read?: boolean;
+	};
+	readonly serverDefault?: boolean;
+	readonly default?: unknown;
+	readonly recommendedValue?: unknown;
+	readonly constraints?: Record<string, unknown>;
+	readonly conflictsWith?: readonly string[];
+}
+
+export interface ApiCatalogResponseField {
+	readonly field: string;
+	readonly type: string;
+	readonly description: string;
+}
+
 export interface ApiCatalogOperation {
 	readonly name: string;
 	readonly description: string;
@@ -22,6 +50,10 @@ export interface ApiCatalogOperation {
 	readonly parameters: readonly ApiCatalogParameter[];
 	readonly bodySchema?: Record<string, unknown>;
 	readonly responseSchema?: Record<string, unknown>;
+	readonly minimumPayload?: ApiCatalogMinimumPayload;
+	readonly fieldMetadata?: Readonly<Record<string, ApiCatalogFieldMeta>>;
+	readonly oneOfRecommendations?: Readonly<Record<string, string>>;
+	readonly responseSummary?: readonly ApiCatalogResponseField[];
 }
 
 export interface ApiCatalogCategory {

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -197,7 +197,13 @@ Most tools resolve custom protocol URLs to internal resources (not web URLs):
   When the user needs to **make an API call** (create, read, update, delete):
 
   1. `xcsh://api-catalog/?search={term}` → find the operation
-  2. `xcsh://api-catalog/{category}` → get path, method, parameters, curl template
+  2. `xcsh://api-catalog/{category}` → get curl template, minimum payload,
+     field constraints, OneOf recommendations, and response summary
+
+  For POST/PUT operations, the catalog includes a ready-to-use JSON payload.
+  Customize the payload with user-specified values (name, namespace, etc.),
+  substitute path parameters (`{namespace}`, `{name}`) with actual values,
+  insert the payload as the `-d` body in the curl template, and execute.
 
   When the user needs to **understand a schema** (field types, nested objects, request body structure):
 

--- a/packages/coding-agent/test/internal-urls/api-catalog-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/api-catalog-resolve.test.ts
@@ -128,4 +128,128 @@ describe("API Catalog Resolver", () => {
 		expect(result.content).toContain("namespace");
 		expect(result.content).toContain("$F5XC_NAMESPACE");
 	});
+
+	it("renders minimum payload when present", async () => {
+		const cat = {
+			name: "test-resources",
+			displayName: "Test Resources",
+			operations: [
+				{
+					name: "create_test",
+					description: "Create a test",
+					method: "POST",
+					path: "/api/test/{namespace}/resources",
+					dangerLevel: "medium",
+					parameters: [],
+					minimumPayload: {
+						json: { metadata: { name: "example" }, spec: {} },
+						requiredFields: ["metadata", "spec"],
+						description: "Minimum config for test",
+					},
+				},
+			],
+		};
+		const blobs = { "test-resources": compressCategory(cat) };
+		const summaries = [{ name: "test-resources", displayName: "Test Resources", operationCount: 1 }];
+		const resolver = createApiCatalogResolver(testCatalogIndex, summaries, blobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/test-resources"));
+		expect(result.content).toContain("### Minimum Configuration");
+		expect(result.content).toContain('"name": "example"');
+		expect(result.content).toContain("Required fields: metadata, spec");
+	});
+
+	it("renders field constraints table when fieldMetadata present", async () => {
+		const cat = {
+			name: "test-resources",
+			displayName: "Test Resources",
+			operations: [
+				{
+					name: "create_test",
+					description: "Create",
+					method: "POST",
+					path: "/api/test",
+					dangerLevel: "medium",
+					parameters: [],
+					fieldMetadata: {
+						"metadata.name": {
+							type: "string",
+							description: "Resource name",
+							constraints: { pattern: "^[a-z0-9][-a-z0-9]*$", maxLength: 64 },
+							required_for: { minimum_config: true, create: true },
+						},
+					},
+				},
+			],
+		};
+		const blobs = { "test-resources": compressCategory(cat) };
+		const summaries = [{ name: "test-resources", displayName: "Test Resources", operationCount: 1 }];
+		const resolver = createApiCatalogResolver(testCatalogIndex, summaries, blobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/test-resources"));
+		expect(result.content).toContain("### Field Constraints");
+		expect(result.content).toContain("metadata.name");
+		expect(result.content).toContain("maxLength: 64");
+	});
+
+	it("renders oneOf recommendations table when present", async () => {
+		const cat = {
+			name: "test-resources",
+			displayName: "Test Resources",
+			operations: [
+				{
+					name: "create_test",
+					description: "Create",
+					method: "POST",
+					path: "/api/test",
+					dangerLevel: "medium",
+					parameters: [],
+					oneOfRecommendations: {
+						"spec.health_check": "http_health_check",
+						"spec.tls_choice": "no_tls",
+					},
+				},
+			],
+		};
+		const blobs = { "test-resources": compressCategory(cat) };
+		const summaries = [{ name: "test-resources", displayName: "Test Resources", operationCount: 1 }];
+		const resolver = createApiCatalogResolver(testCatalogIndex, summaries, blobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/test-resources"));
+		expect(result.content).toContain("### OneOf Recommendations");
+		expect(result.content).toContain("http_health_check");
+	});
+
+	it("renders response summary when present", async () => {
+		const cat = {
+			name: "test-resources",
+			displayName: "Test Resources",
+			operations: [
+				{
+					name: "create_test",
+					description: "Create",
+					method: "POST",
+					path: "/api/test",
+					dangerLevel: "medium",
+					parameters: [],
+					responseSummary: [
+						{ field: "metadata", type: "object", description: "Resource identity" },
+						{ field: "spec", type: "object", description: "Resource spec" },
+					],
+				},
+			],
+		};
+		const blobs = { "test-resources": compressCategory(cat) };
+		const summaries = [{ name: "test-resources", displayName: "Test Resources", operationCount: 1 }];
+		const resolver = createApiCatalogResolver(testCatalogIndex, summaries, blobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/test-resources"));
+		expect(result.content).toContain("### Response");
+		expect(result.content).toContain("Resource identity");
+	});
+
+	it("operations without enrichment render identically to before", async () => {
+		const resolver = createApiCatalogResolver(testCatalogIndex, testCategorySummaries, testCatalogBlobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/dns-zone"));
+		expect(result.content).not.toContain("### Minimum Configuration");
+		expect(result.content).not.toContain("### Field Constraints");
+		expect(result.content).not.toContain("### OneOf Recommendations");
+		expect(result.content).toContain("### Curl Example");
+	});
 });


### PR DESCRIPTION
## What

Add TypeScript types and rendering logic to display enrichment data from the upstream api-specs-enriched catalog compiler. POST/PUT operations now show `minimumPayload`, `fieldMetadata`, `oneOfRecommendations`, and `responseSummary`, eliminating the 40K-token spec fallback for CRUD operations.

## Why

The upstream api-specs-enriched catalog compiler now emits enrichment fields on POST/PUT operations. xcsh needs matching types and rendering to surface this data to the agent, significantly reducing token consumption for CRUD operations.

Closes #462

## Testing

- 5 new tests added to `api-catalog-resolve.test.ts` (12 total, all passing)
- Verified markdownlint passes on `system-prompt.md`
- Pre-commit hooks pass

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #N`