### PR TITLE
fix(catalog): sanitize constraint column in field constraints table

### DIFF
--- a/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
@@ -237,7 +237,7 @@ function renderCatalogDetail(cat: ApiCatalogCategory, index: ApiCatalogIndex): s
 			sections.push("|-------|------|-------------|-----------|--------------|---------|");
 			for (const [field, meta] of Object.entries(op.fieldMetadata)) {
 				const desc = sanitizeTableCell(meta.description ?? "");
-				const constraint = formatConstraints(meta.constraints);
+				const constraint = sanitizeTableCell(formatConstraints(meta.constraints));
 				const reqFor = formatRequiredFor(meta.required_for);
 				const def = sanitizeTableCell(formatDefault(meta.default, meta.serverDefault));
 				sections.push(`| ${field} | ${meta.type} | ${desc} | ${constraint} | ${reqFor} | ${def} |`);


### PR DESCRIPTION
## What

Wrap `formatConstraints()` output in `sanitizeTableCell()` before insertion into the markdown field-constraints table in `renderCatalogDetail()`.

## Why

Enriched API spec patterns contain pipe characters (e.g. `^(https?|ftp)://...`) that act as markdown table column delimiters, producing malformed tables with extra columns for 69 affected fields. The `description` and `default` columns were already sanitized, but `constraint` was missed.

Follow-up to #467 / PR #468.

Closes #470

## Testing

- Verified the one-line change wraps the existing `formatConstraints()` call in `sanitizeTableCell()`, consistent with adjacent sanitization of `description` and `default` columns.
- Pre-commit hooks pass (biome lint, governance, secrets, spelling).

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [x] Issue linked via `Closes #470`