### PR TITLE
perf(coding-agent): dedup field constraints + compact catalog mode

### DIFF
--- a/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
@@ -42,6 +42,7 @@ export function createApiCatalogResolver(
 			const category = pathname.replace(/^\//, "").replace(/\/$/, "");
 			const search = url.searchParams.get("search");
 			const resourceName = url.searchParams.get("resource");
+			const compact = url.searchParams.get("compact") === "true";
 
 			if (!category) {
 				if (resourceName && specIndex) {
@@ -52,7 +53,7 @@ export function createApiCatalogResolver(
 							if (categorySummaries.some(c => c.name === catName)) {
 								try {
 									const cat = decompress(catName);
-									return makeResource(url, renderCatalogDetail(cat, index));
+									return makeResource(url, renderCatalogDetail(cat, index, { compact }));
 								} catch {
 									break;
 								}
@@ -75,7 +76,7 @@ export function createApiCatalogResolver(
 
 			try {
 				const cat = decompress(category);
-				return makeResource(url, renderCatalogDetail(cat, index));
+				return makeResource(url, renderCatalogDetail(cat, index, { compact }));
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				return makeResource(url, `# Error loading ${category}\n\n${message}\n`);
@@ -182,8 +183,10 @@ function formatDefault(defaultVal: unknown, serverDefault: boolean | undefined):
 	return serverDefault ? `${val} (server)` : val;
 }
 
-function renderCatalogDetail(cat: ApiCatalogCategory, index: ApiCatalogIndex): string {
+function renderCatalogDetail(cat: ApiCatalogCategory, index: ApiCatalogIndex, options?: { compact?: boolean }): string {
 	const sections: string[] = [`# ${cat.displayName}`, "", `${cat.operations.length} operations.`];
+	let fieldConstraintsRenderedForOp: string | null = null;
+	let fieldConstraintsFingerprint: string | null = null;
 
 	for (const op of cat.operations) {
 		sections.push("", `## ${op.method.toUpperCase()} ${op.path}`, "");
@@ -230,17 +233,25 @@ function renderCatalogDetail(cat: ApiCatalogCategory, index: ApiCatalogIndex): s
 			sections.push("", "```json", JSON.stringify(op.minimumPayload.json, null, 2), "```");
 		}
 
-		// Field Constraints (Tier 2)
-		if (op.fieldMetadata && Object.keys(op.fieldMetadata).length > 0) {
-			sections.push("", "### Field Constraints", "");
-			sections.push("| Field | Type | Description | Constraint | Required For | Default |");
-			sections.push("|-------|------|-------------|-----------|--------------|---------|");
-			for (const [field, meta] of Object.entries(op.fieldMetadata)) {
-				const desc = sanitizeTableCell(meta.description ?? "");
-				const constraint = sanitizeTableCell(formatConstraints(meta.constraints));
-				const reqFor = formatRequiredFor(meta.required_for);
-				const def = sanitizeTableCell(formatDefault(meta.default, meta.serverDefault));
-				sections.push(`| ${field} | ${meta.type} | ${desc} | ${constraint} | ${reqFor} | ${def} |`);
+		// Field Constraints (Tier 2) — skipped in compact mode, deduped when identical across operations
+		if (op.fieldMetadata && Object.keys(op.fieldMetadata).length > 0 && !options?.compact) {
+			const currentFingerprint = JSON.stringify(op.fieldMetadata);
+			if (fieldConstraintsRenderedForOp && currentFingerprint === fieldConstraintsFingerprint) {
+				sections.push("", "### Field Constraints");
+				sections.push(`Same as ${fieldConstraintsRenderedForOp} — see above.`, "");
+			} else {
+				fieldConstraintsRenderedForOp = `${op.method.toUpperCase()} ${op.path}`;
+				fieldConstraintsFingerprint = currentFingerprint;
+				sections.push("", "### Field Constraints", "");
+				sections.push("| Field | Type | Description | Constraint | Required For | Default |");
+				sections.push("|-------|------|-------------|-----------|--------------|---------|");
+				for (const [field, meta] of Object.entries(op.fieldMetadata)) {
+					const desc = sanitizeTableCell(meta.description ?? "");
+					const constraint = sanitizeTableCell(formatConstraints(meta.constraints));
+					const reqFor = formatRequiredFor(meta.required_for);
+					const def = sanitizeTableCell(formatDefault(meta.default, meta.serverDefault));
+					sections.push(`| ${field} | ${meta.type} | ${desc} | ${constraint} | ${reqFor} | ${def} |`);
+				}
 			}
 		}
 

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -197,13 +197,17 @@ Most tools resolve custom protocol URLs to internal resources (not web URLs):
   When the user needs to **make an API call** (create, read, update, delete):
 
   1. `xcsh://api-catalog/?search={term}` → find the operation
-  2. `xcsh://api-catalog/{category}` → get curl template, minimum payload,
-     field constraints, OneOf recommendations, and response summary
+  2. `xcsh://api-catalog/{category}?compact=true` → get curl template, minimum payload,
+     OneOf recommendations, and response summary
 
   For POST/PUT operations, the catalog includes a ready-to-use JSON payload.
   Customize the payload with user-specified values (name, namespace, etc.),
   substitute path parameters (`{namespace}`, `{name}`) with actual values,
   insert the payload as the `-d` body in the curl template, and execute.
+
+  When the user needs **field-level validation rules** (constraints, patterns, enums):
+
+  1. `xcsh://api-catalog/{category}` → full catalog with field constraints table
 
   When the user needs to **understand a schema** (field types, nested objects, request body structure):
 
@@ -211,8 +215,8 @@ Most tools resolve custom protocol URLs to internal resources (not web URLs):
   If the domain is unknown, read `xcsh://api-spec/` first to identify it.
 
   **MUST NOT** read proactively.
-  Never start at `xcsh://api-spec/` for CRUD operations — it returns the full schema (~40K tokens)
-  when the catalog provides the same endpoint with curl template (~700 tokens).
+  Never start at `xcsh://api-spec/` for CRUD operations — the catalog provides
+  the same endpoint with curl template at a fraction of the token cost.
   Never guess API paths or request schemas.
   Also available: `xcsh://api-spec/workflows/` (step-by-step guides),
   `xcsh://api-spec/errors/{code}` (error resolution), `xcsh://api-spec/glossary/` (acronym reference).

--- a/packages/coding-agent/test/internal-urls/api-catalog-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/api-catalog-resolve.test.ts
@@ -252,4 +252,156 @@ describe("API Catalog Resolver", () => {
 		expect(result.content).not.toContain("### OneOf Recommendations");
 		expect(result.content).toContain("### Curl Example");
 	});
+
+	it("deduplicates field constraints for POST/PUT with identical metadata", async () => {
+		const sharedMeta = {
+			"metadata.name": {
+				type: "string",
+				description: "Resource name",
+				constraints: { maxLength: 64 },
+			},
+		};
+		const cat = {
+			name: "test-resources",
+			displayName: "Test Resources",
+			operations: [
+				{
+					name: "create_test",
+					description: "Create",
+					method: "POST",
+					path: "/api/test/{namespace}/resources",
+					dangerLevel: "medium",
+					parameters: [],
+					fieldMetadata: sharedMeta,
+				},
+				{
+					name: "replace_test",
+					description: "Replace",
+					method: "PUT",
+					path: "/api/test/{namespace}/resources/{name}",
+					dangerLevel: "medium",
+					parameters: [],
+					fieldMetadata: sharedMeta,
+				},
+			],
+		};
+		const blobs = { "test-resources": compressCategory(cat) };
+		const summaries = [{ name: "test-resources", displayName: "Test Resources", operationCount: 2 }];
+		const resolver = createApiCatalogResolver(testCatalogIndex, summaries, blobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/test-resources"));
+		const postIndex = result.content.indexOf("## POST");
+		const putIndex = result.content.indexOf("## PUT");
+		const postConstraints = result.content.indexOf("| metadata.name |");
+		const putBackRef = result.content.indexOf("Same as POST");
+		expect(postIndex).toBeGreaterThan(-1);
+		expect(putIndex).toBeGreaterThan(-1);
+		expect(postConstraints).toBeGreaterThan(postIndex);
+		expect(postConstraints).toBeLessThan(putIndex);
+		expect(putBackRef).toBeGreaterThan(putIndex);
+	});
+
+	it("renders both constraint tables when POST/PUT metadata differs", async () => {
+		const cat = {
+			name: "test-resources",
+			displayName: "Test Resources",
+			operations: [
+				{
+					name: "create_test",
+					description: "Create",
+					method: "POST",
+					path: "/api/test/{namespace}/resources",
+					dangerLevel: "medium",
+					parameters: [],
+					fieldMetadata: {
+						"metadata.name": { type: "string", constraints: { maxLength: 64 } },
+					},
+				},
+				{
+					name: "replace_test",
+					description: "Replace",
+					method: "PUT",
+					path: "/api/test/{namespace}/resources/{name}",
+					dangerLevel: "medium",
+					parameters: [],
+					fieldMetadata: {
+						"metadata.name": { type: "string", constraints: { maxLength: 64 } },
+						"spec.extra_field": { type: "string", constraints: { maxLength: 128 } },
+					},
+				},
+			],
+		};
+		const blobs = { "test-resources": compressCategory(cat) };
+		const summaries = [{ name: "test-resources", displayName: "Test Resources", operationCount: 2 }];
+		const resolver = createApiCatalogResolver(testCatalogIndex, summaries, blobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/test-resources"));
+		expect(result.content).not.toContain("Same as POST");
+		const constraintMatches = result.content.match(/### Field Constraints/g);
+		expect(constraintMatches?.length).toBe(2);
+	});
+
+	it("compact mode omits field constraints but keeps other sections", async () => {
+		const cat = {
+			name: "test-resources",
+			displayName: "Test Resources",
+			operations: [
+				{
+					name: "create_test",
+					description: "Create",
+					method: "POST",
+					path: "/api/test",
+					dangerLevel: "medium",
+					parameters: [],
+					minimumPayload: {
+						json: { metadata: { name: "example" } },
+						requiredFields: ["metadata"],
+						description: "Minimum config",
+					},
+					fieldMetadata: {
+						"metadata.name": {
+							type: "string",
+							constraints: { maxLength: 64 },
+						},
+					},
+					oneOfRecommendations: { "spec.tls_choice": "no_tls" },
+				},
+			],
+		};
+		const blobs = { "test-resources": compressCategory(cat) };
+		const summaries = [{ name: "test-resources", displayName: "Test Resources", operationCount: 1 }];
+		const resolver = createApiCatalogResolver(testCatalogIndex, summaries, blobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/test-resources?compact=true"));
+		expect(result.content).toContain("### Minimum Configuration");
+		expect(result.content).toContain("### Curl Example");
+		expect(result.content).toContain("### OneOf Recommendations");
+		expect(result.content).not.toContain("### Field Constraints");
+	});
+
+	it("non-compact mode still renders field constraints", async () => {
+		const cat = {
+			name: "test-resources",
+			displayName: "Test Resources",
+			operations: [
+				{
+					name: "create_test",
+					description: "Create",
+					method: "POST",
+					path: "/api/test",
+					dangerLevel: "medium",
+					parameters: [],
+					fieldMetadata: {
+						"metadata.name": {
+							type: "string",
+							constraints: { maxLength: 64 },
+						},
+					},
+				},
+			],
+		};
+		const blobs = { "test-resources": compressCategory(cat) };
+		const summaries = [{ name: "test-resources", displayName: "Test Resources", operationCount: 1 }];
+		const resolver = createApiCatalogResolver(testCatalogIndex, summaries, blobs);
+		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/test-resources"));
+		expect(result.content).toContain("### Field Constraints");
+		expect(result.content).toContain("metadata.name");
+	});
 });


### PR DESCRIPTION
## What

Reduce token consumption of API catalog lookups by eliminating duplicate field-constraint tables and adding a compact rendering mode.

## Why

The `http_loadbalancer` catalog burns 14,178 tokens per lookup -- 86.5% of which is duplicate field-constraint tables (POST and PUT render identical 93-row tables). Three targeted fixes reduce the dominant CRUD path to ~533 tokens (96% reduction):

1. **Dedup** -- `renderCatalogDetail` tracks a `JSON.stringify` fingerprint of `fieldMetadata`. When a subsequent operation has identical metadata, it renders "Same as POST ... -- see above." instead of repeating the table.

2. **Compact mode** -- `?compact=true` parameter skips field constraints entirely. Applied to both direct category lookups and `?resource=` lookups.

3. **System prompt** -- Step 2 now routes to `?compact=true` by default. Full catalog (without compact) is documented for field-validation use cases.

Closes #475

## Testing

- 16 tests total (was 12), 4 new tests covering:
  - Dedup: identical metadata across operations renders table once
  - Different-metadata: operations with distinct metadata each get their own table
  - Compact: `?compact=true` omits field constraints entirely
  - Non-compact: default behavior preserves full field constraints

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #475`