### PR TITLE
fix(coding-agent): strip provenance timestamps from field constraint dedup fingerprint

### DIFF
--- a/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
@@ -174,6 +174,13 @@ function formatRequiredFor(
 	return ops.length > 0 ? ops.join(", ") : "--";
 }
 
+function fieldMetadataFingerprint(metadata: Record<string, unknown>): string {
+	return JSON.stringify(metadata, (key, value) => {
+		if (key === "validatedAt" || key === "confidence" || key === "source") return undefined;
+		return value;
+	});
+}
+
 function formatDefault(defaultVal: unknown, serverDefault: boolean | undefined): string {
 	if (defaultVal == null && !serverDefault) return "--";
 	let val = "--";
@@ -235,7 +242,7 @@ function renderCatalogDetail(cat: ApiCatalogCategory, index: ApiCatalogIndex, op
 
 		// Field Constraints (Tier 2) — skipped in compact mode, deduped when identical across operations
 		if (op.fieldMetadata && Object.keys(op.fieldMetadata).length > 0 && !options?.compact) {
-			const currentFingerprint = JSON.stringify(op.fieldMetadata);
+			const currentFingerprint = fieldMetadataFingerprint(op.fieldMetadata as Record<string, unknown>);
 			if (fieldConstraintsRenderedForOp && currentFingerprint === fieldConstraintsFingerprint) {
 				sections.push("", "### Field Constraints");
 				sections.push(`Same as ${fieldConstraintsRenderedForOp} — see above.`, "");

--- a/packages/coding-agent/test/internal-urls/api-catalog-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/api-catalog-resolve.test.ts
@@ -253,12 +253,25 @@ describe("API Catalog Resolver", () => {
 		expect(result.content).toContain("### Curl Example");
 	});
 
-	it("deduplicates field constraints for POST/PUT with identical metadata", async () => {
-		const sharedMeta = {
+	it("deduplicates field constraints for POST/PUT with differing provenance timestamps", async () => {
+		const postMeta = {
 			"metadata.name": {
 				type: "string",
 				description: "Resource name",
-				constraints: { maxLength: 64 },
+				constraints: {
+					maxLength: 64,
+					metadata: { source: "discovery", confidence: 0.99, validatedAt: "2026-01-01T00:00:00.001Z" },
+				},
+			},
+		};
+		const putMeta = {
+			"metadata.name": {
+				type: "string",
+				description: "Resource name",
+				constraints: {
+					maxLength: 64,
+					metadata: { source: "discovery", confidence: 0.99, validatedAt: "2026-01-01T00:00:00.002Z" },
+				},
 			},
 		};
 		const cat = {
@@ -272,7 +285,7 @@ describe("API Catalog Resolver", () => {
 					path: "/api/test/{namespace}/resources",
 					dangerLevel: "medium",
 					parameters: [],
-					fieldMetadata: sharedMeta,
+					fieldMetadata: postMeta,
 				},
 				{
 					name: "replace_test",
@@ -281,7 +294,7 @@ describe("API Catalog Resolver", () => {
 					path: "/api/test/{namespace}/resources/{name}",
 					dangerLevel: "medium",
 					parameters: [],
-					fieldMetadata: sharedMeta,
+					fieldMetadata: putMeta,
 				},
 			],
 		};


### PR DESCRIPTION
## Summary

- Add `fieldMetadataFingerprint` JSON.stringify replacer that strips `validatedAt`, `confidence`, and `source` from constraint metadata
- The field constraint dedup from #476 never fired on real data because POST and PUT methods have differing `validatedAt` microsecond timestamps
- Updated tests to use separate POST/PUT objects with differing timestamps to exercise the real failure mode

Closes #478

## Test plan

- [ ] CI checks pass
- [ ] Unit tests verify dedup works with differing timestamps
- [ ] Existing field constraint tests continue to pass

---
Generated with [Claude Code](https://claude.ai/code)