### PR TITLE
fix(coding-agent): address codex P1/P2 findings for xcsh_api tool

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -198,7 +198,7 @@ Most tools resolve custom protocol URLs to internal resources (not web URLs):
 
   1. `xcsh://api-catalog/?resource={resource_name}` → get endpoint path, method, minimum
      payload JSON, required fields, and response summary
-  2. Call `xcsh_api` tool with `method`, `path`, `namespace`, `name`, and `payload`
+  2. Call `xcsh_api` tool with `method`, `path`, `params` (all `{placeholder}` substitutions), and `payload`
 
   The `xcsh_api` tool handles authentication, URL construction, and HTTP execution.
   Never construct curl commands for F5 XC API calls — use `xcsh_api` instead.

--- a/packages/coding-agent/src/prompts/tools/xcsh-api.md
+++ b/packages/coding-agent/src/prompts/tools/xcsh-api.md
@@ -3,4 +3,7 @@ Execute an F5 Distributed Cloud API call directly.
 Handles authentication, URL construction, and HTTP execution.
 Requires `F5XC_API_URL` and `F5XC_API_TOKEN` environment variables.
 
+Pass all path `{placeholder}` values via `params`, e.g. `{ namespace: "default", name: "example-lb", vh_name: "example-vh" }`.
+Body is sent for all methods except GET when `payload` is provided — including DELETE operations that require a body.
+
 Use this tool after reading the API catalog to get the endpoint path and payload structure.

--- a/packages/coding-agent/src/tools/xcsh-api.ts
+++ b/packages/coding-agent/src/tools/xcsh-api.ts
@@ -5,13 +5,18 @@ import xcshApiDescription from "../prompts/tools/xcsh-api.md" with { type: "text
 import type { ToolSession } from ".";
 
 const xcshApiSchema = Type.Object({
-	method: Type.Union([Type.Literal("GET"), Type.Literal("POST"), Type.Literal("PUT"), Type.Literal("DELETE")], {
-		description: "HTTP method",
-	}),
+	method: Type.Union(
+		[Type.Literal("GET"), Type.Literal("POST"), Type.Literal("PUT"), Type.Literal("PATCH"), Type.Literal("DELETE")],
+		{ description: "HTTP method" },
+	),
 	path: Type.String({ description: "API path, e.g. /api/config/namespaces/{namespace}/http_loadbalancers" }),
-	namespace: Type.Optional(Type.String({ description: "Substituted into {namespace} in path" })),
-	name: Type.Optional(Type.String({ description: "Substituted into {name} in path" })),
-	payload: Type.Optional(Type.Unknown({ description: "JSON body for POST/PUT requests" })),
+	params: Type.Optional(
+		Type.Record(Type.String(), Type.String(), {
+			description:
+				"Path parameter substitutions, e.g. { namespace: 'default', name: 'example-lb', vh_name: 'example-vh' }",
+		}),
+	),
+	payload: Type.Optional(Type.Unknown({ description: "JSON body for POST/PUT/PATCH/DELETE requests" })),
 });
 
 type XcshApiParams = Static<typeof xcshApiSchema>;
@@ -52,11 +57,10 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 		}
 
 		let resolvedPath = params.path;
-		if (params.namespace) {
-			resolvedPath = resolvedPath.replaceAll("{namespace}", params.namespace);
-		}
-		if (params.name) {
-			resolvedPath = resolvedPath.replaceAll("{name}", params.name);
+		if (params.params) {
+			for (const [key, value] of Object.entries(params.params)) {
+				resolvedPath = resolvedPath.replaceAll(`{${key}}`, value);
+			}
 		}
 
 		const url = `${apiUrl.replace(/\/+$/, "")}${resolvedPath}`;
@@ -67,7 +71,7 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 
 		const init: RequestInit = { method: params.method, headers };
 
-		if (params.payload && (params.method === "POST" || params.method === "PUT")) {
+		if (params.payload && params.method !== "GET") {
 			headers["Content-Type"] = "application/json";
 			init.body = JSON.stringify(params.payload);
 		}

--- a/packages/coding-agent/test/xcsh-api-tool.test.ts
+++ b/packages/coding-agent/test/xcsh-api-tool.test.ts
@@ -49,7 +49,7 @@ describe("XcshApiTool", () => {
 		}
 	});
 
-	it("substitutes {namespace} and {name} in path", async () => {
+	it("substitutes all path params via params map", async () => {
 		let capturedUrl = "";
 		const originalFetch = globalThis.fetch;
 		globalThis.fetch = (async (input: any, _init?: any) => {
@@ -65,13 +65,72 @@ describe("XcshApiTool", () => {
 			await tool.execute("call-3", {
 				method: "POST",
 				path: "/api/config/namespaces/{namespace}/http_loadbalancers",
-				namespace: "my-ns",
-				name: "my-lb",
-				payload: { metadata: { name: "my-lb" } },
+				params: { namespace: "example-ns" },
+				payload: { metadata: { name: "example-lb" } },
 			});
 			expect(capturedUrl).toBe(
-				"https://test.console.ves.volterra.io/api/config/namespaces/my-ns/http_loadbalancers",
+				"https://test.console.ves.volterra.io/api/config/namespaces/example-ns/http_loadbalancers",
 			);
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (originalUrl) process.env.F5XC_API_URL = originalUrl;
+			else delete process.env.F5XC_API_URL;
+			if (originalToken) process.env.F5XC_API_TOKEN = originalToken;
+			else delete process.env.F5XC_API_TOKEN;
+		}
+	});
+
+	it("substitutes extra path params like vh_name", async () => {
+		let capturedUrl = "";
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (input: any, _init?: any) => {
+			capturedUrl = typeof input === "string" ? input : input.url;
+			return new Response("{}", { status: 200 });
+		}) as typeof fetch;
+		const originalUrl = process.env.F5XC_API_URL;
+		const originalToken = process.env.F5XC_API_TOKEN;
+		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
+		process.env.F5XC_API_TOKEN = "test-token";
+		try {
+			const tool = new XcshApiTool(mockSession);
+			await tool.execute("call-4", {
+				method: "GET",
+				path: "/api/config/namespaces/{namespace}/virtual_hosts/{vh_name}/active_staged_signatures",
+				params: { namespace: "default", vh_name: "example-vh" },
+			});
+			expect(capturedUrl).toBe(
+				"https://test.console.ves.volterra.io/api/config/namespaces/default/virtual_hosts/example-vh/active_staged_signatures",
+			);
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (originalUrl) process.env.F5XC_API_URL = originalUrl;
+			else delete process.env.F5XC_API_URL;
+			if (originalToken) process.env.F5XC_API_TOKEN = originalToken;
+			else delete process.env.F5XC_API_TOKEN;
+		}
+	});
+
+	it("sends body for DELETE when payload is provided", async () => {
+		let capturedBody: string | null = null;
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (_input: any, init?: any) => {
+			capturedBody = init?.body ?? null;
+			return new Response("{}", { status: 200 });
+		}) as typeof fetch;
+		const originalUrl = process.env.F5XC_API_URL;
+		const originalToken = process.env.F5XC_API_TOKEN;
+		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
+		process.env.F5XC_API_TOKEN = "test-token";
+		try {
+			const tool = new XcshApiTool(mockSession);
+			await tool.execute("call-5", {
+				method: "DELETE",
+				path: "/api/config/namespaces/{namespace}/http_loadbalancers/{name}",
+				params: { namespace: "default", name: "example-lb" },
+				payload: { fail_if_referred: true },
+			});
+			expect(capturedBody).not.toBeNull();
+			expect(JSON.parse(capturedBody as string)).toEqual({ fail_if_referred: true });
 		} finally {
 			globalThis.fetch = originalFetch;
 			if (originalUrl) process.env.F5XC_API_URL = originalUrl;

--- a/packages/coding-agent/test/xcsh-api-tool.test.ts
+++ b/packages/coding-agent/test/xcsh-api-tool.test.ts
@@ -130,7 +130,7 @@ describe("XcshApiTool", () => {
 				payload: { fail_if_referred: true },
 			});
 			expect(capturedBody).not.toBeNull();
-			expect(JSON.parse(capturedBody as string)).toEqual({ fail_if_referred: true });
+			expect(JSON.parse(capturedBody as unknown as string)).toEqual({ fail_if_referred: true });
 		} finally {
 			globalThis.fetch = originalFetch;
 			if (originalUrl) process.env.F5XC_API_URL = originalUrl;


### PR DESCRIPTION
## What

Address Codex review P1/P2 findings for the `xcsh_api` tool implementation:
- Add DELETE request body support
- Replace hardcoded params with generic params map
- Add PATCH method support
- Apply `example-` naming convention in API documentation

## Why

Codex automated review identified priority findings that needed correction for correctness and consistency with API conventions.

Closes #486

## Testing

- Unit tests updated in `xcsh-api-tool.test.ts` covering new functionality
- Pre-commit hooks pass (Biome lint, markdown lint, spelling, secrets detection)

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #486`