### PR TITLE
fix(coding-agent): pass GITHUB_TOKEN to GitHub API calls in spec generation

### DIFF
--- a/packages/coding-agent/scripts/generate-api-spec-index.ts
+++ b/packages/coding-agent/scripts/generate-api-spec-index.ts
@@ -80,9 +80,16 @@ const REPO = "f5xc-salesdemos/api-specs-enriched";
 const outputPath = path.resolve(import.meta.dir, "../src/internal-urls/api-spec-index.generated.ts");
 const catalogOutputPath = path.resolve(import.meta.dir, "../src/internal-urls/api-catalog-index.generated.ts");
 
+function githubHeaders(): Record<string, string> {
+	const headers: Record<string, string> = { Accept: "application/vnd.github+json" };
+	const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+	if (token) headers.Authorization = `Bearer ${token}`;
+	return headers;
+}
+
 async function resolveLatestTag(): Promise<string> {
 	const response = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
-		headers: { Accept: "application/vnd.github+json" },
+		headers: githubHeaders(),
 	});
 	if (!response.ok) {
 		throw new Error(`Failed to fetch latest release from ${REPO}: ${response.status} ${response.statusText}`);


### PR DESCRIPTION
## Summary

- Add `githubHeaders()` helper that includes Bearer token from `GITHUB_TOKEN` or `GH_TOKEN` when available
- Apply authenticated headers to the `resolveLatestTag()` fetch call to `api.github.com`
- Prevents HTTP 403 rate limit errors during `build-sign-macos` CI job

Closes #489

## Test plan

- [ ] CI checks pass
- [ ] Release workflow no longer hits 403 rate limit when fetching latest api-specs-enriched release tag