### PR TITLE
feat(bash): add collapsed view for Bash tool output

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1438,6 +1438,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"bash.verbose": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			label: "Bash Verbose",
+			description:
+				"Show standard command output panel. When disabled, shows a compact single-line summary with status indicator.",
+		},
+	},
+
 	// MCP
 	"mcp.enableProjectConfig": {
 		type: "boolean",

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -8,8 +8,8 @@ Executes bash command in shell session for terminal operations like git, bun, ca
 - PTY mode is opt-in: set `pty: true` only when command expects a real terminal (for example `sudo`, `ssh` where you need input from the user); default is `false`
 - You **MUST** use `;` only when later commands should run regardless of earlier failures
 - `skill://` URIs are auto-resolved to filesystem paths before execution
-	- `python skill://my-skill/scripts/init.py` runs the script from the skill directory
-	- `skill://<name>/<relative-path>` resolves within the skill's base directory
+  - `python skill://my-skill/scripts/init.py` runs the script from the skill directory
+  - `skill://<name>/<relative-path>` resolves within the skill's base directory
 - Internal URLs are also auto-resolved to filesystem paths before execution.
 {{#if asyncEnabled}}
 - Use `async: true` for long-running commands when you don't need immediate output; the call returns a background job ID and the result is delivered automatically as a follow-up.
@@ -46,17 +46,22 @@ You **MUST** use specialized tools instead of bash for ALL file operations:
 |---|---|
 |`cat file`, `head -n N file`|`read(path="file", limit=N)`|
 |`cat -n file \|sed -n '50,150p'`|`read(path="file", offset=50, limit=100)`|
+<!-- markdownlint-disable MD055 MD056 -->
 {{#if hasGrep}}|`grep -A 20 'pat' file`|`grep(pattern="pat", path="file", post=20)`|
 |`grep -rn 'pat' dir/`|`grep(pattern="pat", path="dir/")`|
 |`rg 'pattern' dir/`|`grep(pattern="pattern", path="dir/")`|{{/if}}
 {{#if hasFind}}|`find dir -name '*.ts'`|`find(pattern="dir/**/*.ts")`|{{/if}}
+<!-- markdownlint-enable MD055 MD056 -->
 |`ls dir/`|`read(path="dir/")`|
 |`cat <<'EOF' > file`|`write(path="file", content="…")`|
 |`sed -i 's/old/new/' file`|`edit(path="file", edits=[…])`|
 
+<!-- markdownlint-disable MD055 MD056 -->
 {{#if hasAstEdit}}|`sed -i 's/oldFn(/newFn(/' src/*.ts`|`ast_edit({ops:[{pat:"oldFn($$$A)", out:"newFn($$$A)"}], path:"src/"})`|{{/if}}
+<!-- markdownlint-enable MD055 MD056 -->
 {{#if hasAstGrep}}- You **MUST** use `ast_grep` for structural code search instead of bash `grep`/`awk`/`perl` pipelines{{/if}}
 {{#if hasAstEdit}}- You **MUST** use `ast_edit` for structural rewrites instead of bash `sed`/`awk`/`perl` pipelines{{/if}}
+
 - You **MUST NOT** use Bash for these operations like read, grep, find, edit, write, where specialized tools exist.
 - You **MUST NOT** use `2>&1` | `2>/dev/null` pattern, stdout and stderr are already merged.
 - You **MUST NOT** use `| head -n 50` or `| tail -n 100` pattern, use `head` and `tail` parameters instead.

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -2,6 +2,7 @@ Executes bash command in shell session for terminal operations like git, bun, ca
 
 <instruction>
 - You **MUST** use `cwd` parameter to set working directory instead of `cd dir && …`
+- Always provide a `description` parameter: a short, human-readable summary of what the command does (e.g. "Install dependencies", "Run test suite"). This is displayed in compact mode and during execution.
 - Prefer `env: { NAME: "…" }` for multiline, quote-heavy, or untrusted values instead of inlining them into shell syntax; reference them from the command as `$NAME`
 - Quote variable expansions like `"$NAME"` to preserve exact content and avoid shell parsing bugs
 - PTY mode is opt-in: set `pty: true` only when command expects a real terminal (for example `sudo`, `ssh` where you need input from the user); default is `false`

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -9,6 +9,7 @@ import type { Component } from "@f5xc-salesdemos/pi-tui";
 import { ImageProtocol, TERMINAL, Text } from "@f5xc-salesdemos/pi-tui";
 import { $env, getProjectDir, isEnoent, prompt, setShellPwd } from "@f5xc-salesdemos/pi-utils";
 import { Type } from "@sinclair/typebox";
+import { Settings } from "../config/settings";
 import { type BashResult, executeBash } from "../exec/bash-executor";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
@@ -26,7 +27,7 @@ import { applyHeadTail } from "./bash-normalize";
 import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-skill-urls";
 import { formatStyledTruncationWarning, type OutputMeta } from "./output-meta";
 import { resolveToCwd } from "./path-utils";
-import { formatToolWorkingDirectory, replaceTabs } from "./render-utils";
+import { formatToolWorkingDirectory, replaceTabs, truncateToWidth } from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
@@ -41,6 +42,12 @@ const DEFAULT_AUTO_BACKGROUND_THRESHOLD_MS = 60_000;
 
 const bashSchemaBase = Type.Object({
 	command: Type.String({ description: "Command to execute" }),
+	description: Type.Optional(
+		Type.String({
+			description:
+				"Human-readable description of what this command does (e.g. 'Install dependencies', 'Run test suite')",
+		}),
+	),
 	env: Type.Optional(
 		Type.Record(Type.String({ pattern: BASH_ENV_NAME_PATTERN.source }), Type.String(), {
 			description:
@@ -71,6 +78,7 @@ type BashToolSchema = typeof bashSchemaBase | typeof bashSchemaWithAsync;
 
 export interface BashToolInput {
 	command: string;
+	description?: string;
 	env?: Record<string, string>;
 	timeout?: number;
 	cwd?: string;
@@ -680,6 +688,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 
 interface BashRenderArgs {
 	command?: string;
+	description?: string;
 	env?: Record<string, string>;
 	timeout?: number;
 	cwd?: string;
@@ -711,10 +720,18 @@ function formatBashCommand(args: BashRenderArgs): string {
 	return displayWorkdir ? `${prompt} cd ${displayWorkdir} && ${renderedCommand}` : `${prompt} ${renderedCommand}`;
 }
 
+function getBashVerboseSetting(): boolean {
+	try {
+		return Settings.instance.get("bash.verbose");
+	} catch {
+		return false;
+	}
+}
+
 export const bashToolRenderer = {
 	renderCall(args: BashRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
-		const cmdText = formatBashCommand(args);
-		const text = renderStatusLine({ icon: "pending", title: "Bash", description: cmdText }, uiTheme);
+		const summaryText = args.description ?? formatBashCommand(args);
+		const text = renderStatusLine({ icon: "pending", title: "Bash", description: summaryText }, uiTheme);
 		return new Text(text, 0, 0);
 	},
 
@@ -746,6 +763,30 @@ export const bashToolRenderer = {
 				const displayOutput = output.trimEnd();
 				const showingFullOutput = expanded && renderContext?.isFullOutput === true;
 
+				const rawOutputLines = displayOutput.split("\n");
+				const sixelLineMask =
+					TERMINAL.imageProtocol === ImageProtocol.Sixel ? getSixelLineMask(rawOutputLines) : undefined;
+				const hasSixelOutput = sixelLineMask?.some(Boolean) ?? false;
+
+				// Collapsed mode: single status line when bash.verbose=false
+				const verbose = getBashVerboseSetting();
+				const hasAsyncDetails = details?.async != null;
+				const forceExpand = isError || hasAsyncDetails || hasSixelOutput;
+				if (!verbose && !expanded && !forceExpand && !options.isPartial) {
+					const rawCmd = args?.command;
+					const summaryText =
+						args?.description ?? (rawCmd && rawCmd.length > 60 ? `${rawCmd.slice(0, 60)}…` : rawCmd) ?? "…";
+					const line = renderStatusLine(
+						{
+							title: "Bash",
+							description: summaryText,
+							badge: { label: "ok", color: "success" },
+						},
+						uiTheme,
+					);
+					return [truncateToWidth(line, width)];
+				}
+
 				// Build truncation warning
 				const timeoutSeconds = details?.timeoutSeconds ?? renderContext?.timeout;
 				const timeoutLine =
@@ -762,10 +803,6 @@ export const bashToolRenderer = {
 
 				const outputLines: string[] = [];
 				const hasOutput = displayOutput.trim().length > 0;
-				const rawOutputLines = displayOutput.split("\n");
-				const sixelLineMask =
-					TERMINAL.imageProtocol === ImageProtocol.Sixel ? getSixelLineMask(rawOutputLines) : undefined;
-				const hasSixelOutput = sixelLineMask?.some(Boolean) ?? false;
 				if (hasOutput) {
 					if (hasSixelOutput) {
 						outputLines.push(

--- a/packages/coding-agent/test/tools/bash-renderer.test.ts
+++ b/packages/coding-agent/test/tools/bash-renderer.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { sanitizeText } from "@f5xc-salesdemos/pi-natives";
+import { ImageProtocol, TERMINAL } from "@f5xc-salesdemos/pi-tui";
 import { bashToolRenderer } from "@f5xc-salesdemos/xcsh/tools/bash";
+import { _resetSettingsForTest, Settings } from "../../src/config/settings";
+import { SETTINGS_SCHEMA } from "../../src/config/settings-schema";
 import { getThemeByName } from "../../src/modes/theme/theme";
+
+function stripAnsi(str: string): string {
+	return str.replace(/\x1b\[[0-9;]*m/g, "");
+}
 
 describe("bash renderResult has no terminal status glyph", () => {
 	it("success renderResult contains no ✓/✗/⚠ after ANSI strip", async () => {
@@ -28,5 +35,208 @@ describe("bash renderResult has no terminal status glyph", () => {
 		});
 		const rendered = sanitizeText(component.render(200).join("\n"));
 		expect(rendered).not.toMatch(/[✓✔✗✘⚠ⓘ]/);
+	});
+});
+
+describe("bash.verbose setting", () => {
+	it("defaults to false in schema", () => {
+		const schema = SETTINGS_SCHEMA["bash.verbose"];
+		expect(schema).toBeDefined();
+		expect(schema.type).toBe("boolean");
+		expect(schema.default).toBe(false);
+	});
+});
+
+describe("bash description parameter", () => {
+	it("renderCall accepts description in args without error", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const component = bashToolRenderer.renderCall(
+			{ command: "npm install", description: "Install dependencies" },
+			{ expanded: false, isPartial: false },
+			theme!,
+		);
+		const lines = component.render(120);
+		expect(lines.length).toBeGreaterThan(0);
+	});
+
+	it("renderCall shows description instead of command when provided", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const component = bashToolRenderer.renderCall(
+			{ command: "npm install --save-exact foo@1.2.3", description: "Install dependencies" },
+			{ expanded: false, isPartial: false },
+			theme!,
+		);
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("Install dependencies");
+		expect(rendered).not.toContain("npm install");
+	});
+
+	it("renderCall falls back to command when no description", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const component = bashToolRenderer.renderCall(
+			{ command: "npm install" },
+			{ expanded: false, isPartial: false },
+			theme!,
+		);
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("npm install");
+	});
+});
+
+describe("bash collapsed view (bash.verbose=false)", () => {
+	let theme: Awaited<ReturnType<typeof getThemeByName>>;
+
+	beforeAll(async () => {
+		_resetSettingsForTest();
+		await Settings.init({ inMemory: true, overrides: { "bash.verbose": false } });
+		theme = await getThemeByName("xcsh-dark");
+	});
+
+	afterAll(() => {
+		_resetSettingsForTest();
+	});
+
+	it("renders single status line with description on success", () => {
+		const result = {
+			content: [{ type: "text", text: "added 150 packages\n" }],
+			isError: false,
+		};
+		const component = bashToolRenderer.renderResult(result as never, { expanded: false, isPartial: false }, theme!, {
+			command: "npm install",
+			description: "Install dependencies",
+		});
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("Install dependencies");
+		expect(rendered).not.toContain("added 150 packages");
+		expect(rendered).not.toContain("Output");
+	});
+
+	it("falls back to truncated command when no description", () => {
+		const longCommand =
+			"npm install --save-exact @some-very-long-scoped-package/with-a-really-long-name@1.2.3-beta.4";
+		const result = {
+			content: [{ type: "text", text: "some verbose output\n" }],
+			isError: false,
+		};
+		const component = bashToolRenderer.renderResult(result as never, { expanded: false, isPartial: false }, theme!, {
+			command: longCommand,
+		});
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("…");
+		expect(rendered).toContain("npm install");
+		expect(rendered).not.toContain("$ ");
+		expect(rendered).not.toContain("some verbose output");
+		expect(rendered).not.toContain("Output");
+	});
+
+	it("auto-expands on error", () => {
+		const result = {
+			content: [{ type: "text", text: "permission denied\n" }],
+			isError: true,
+		};
+		const component = bashToolRenderer.renderResult(result as never, { expanded: false, isPartial: false }, theme!, {
+			command: "rm -rf /",
+			description: "Delete everything",
+		});
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("permission denied");
+		expect(rendered).toContain("Output");
+	});
+
+	it("auto-expands when SIXEL image output is present", () => {
+		const sixelData = "\x1bPq#0;2;0;0;0#0\x1b\\";
+		const result = {
+			content: [{ type: "text", text: sixelData }],
+			isError: false,
+		};
+		const origProtocol = TERMINAL.imageProtocol;
+		(TERMINAL as { imageProtocol: ImageProtocol | null }).imageProtocol = ImageProtocol.Sixel;
+		const component = bashToolRenderer.renderResult(result as never, { expanded: false, isPartial: false }, theme!, {
+			command: "render-image",
+			description: "Render image",
+		});
+		const lines = component.render(120);
+		(TERMINAL as { imageProtocol: ImageProtocol | null }).imageProtocol = origProtocol;
+		const rendered = stripAnsi(lines.join("\n"));
+		expect(rendered).toContain("Output");
+	});
+
+	it("auto-expands when async details present", () => {
+		const result = {
+			content: [{ type: "text", text: "Background job bg_123 started\n" }],
+			details: { async: { state: "running" as const, jobId: "bg_123", type: "bash" as const } },
+			isError: false,
+		};
+		const component = bashToolRenderer.renderResult(result as never, { expanded: false, isPartial: false }, theme!, {
+			command: "long-task",
+			description: "Run long task",
+		});
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("Background job bg_123");
+		expect(rendered).toContain("Output");
+	});
+
+	it("expands when ctrl+o override is active", () => {
+		const result = {
+			content: [{ type: "text", text: "detailed output here\n" }],
+			isError: false,
+		};
+		const component = bashToolRenderer.renderResult(result as never, { expanded: true, isPartial: false }, theme!, {
+			command: "echo test",
+			description: "Run test",
+		});
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("detailed output here");
+	});
+});
+
+describe("bash verbose mode (bash.verbose=true)", () => {
+	let theme: Awaited<ReturnType<typeof getThemeByName>>;
+
+	beforeAll(async () => {
+		_resetSettingsForTest();
+		await Settings.init({ inMemory: true, overrides: { "bash.verbose": true } });
+		theme = await getThemeByName("xcsh-dark");
+	});
+
+	afterAll(() => {
+		_resetSettingsForTest();
+	});
+
+	it("renders full output panel when verbose is true", () => {
+		const result = {
+			content: [{ type: "text", text: "added 150 packages\n" }],
+			isError: false,
+		};
+		const component = bashToolRenderer.renderResult(result as never, { expanded: false, isPartial: false }, theme!, {
+			command: "npm install",
+			description: "Install dependencies",
+		});
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("added 150 packages");
+		expect(rendered).toContain("Output");
+	});
+});
+
+describe("bash collapsed view — Settings not initialized", () => {
+	let theme: Awaited<ReturnType<typeof getThemeByName>>;
+
+	beforeAll(async () => {
+		_resetSettingsForTest();
+		theme = await getThemeByName("xcsh-dark");
+	});
+
+	it("defaults to collapsed when Settings is not initialized (no crash)", () => {
+		const result = {
+			content: [{ type: "text", text: "output text\n" }],
+			isError: false,
+		};
+		const component = bashToolRenderer.renderResult(result as never, { expanded: false, isPartial: false }, theme!, {
+			command: "echo test",
+			description: "Run test",
+		});
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("Run test");
+		expect(rendered).not.toContain("output text");
 	});
 });

--- a/packages/coding-agent/test/tools/bash-sixel-render.test.ts
+++ b/packages/coding-agent/test/tools/bash-sixel-render.test.ts
@@ -75,7 +75,7 @@ describe("bashToolRenderer", () => {
 		const uiTheme = theme!;
 		const component = bashToolRenderer.renderResult(
 			{ content: [{ type: "text", text: "" }], details: { timeoutSeconds: 120 }, isError: false },
-			{ expanded: false, isPartial: false, renderContext: { timeout: 1200 } },
+			{ expanded: true, isPartial: false, renderContext: { timeout: 1200 } },
 			uiTheme,
 			{ command: "python3 scripts/vim-edit-benchmark.py", timeout: 1200 },
 		);


### PR DESCRIPTION
## What

- Add `bash.verbose` boolean setting (default `false`) toggled via `/settings` — when disabled, Bash tool renders a compact single-line status instead of the full output panel
- Add `description` parameter to Bash tool schema so the AI provides a human-readable summary per command (e.g. "Install dependencies")
- Update `renderCall()` to show description during pending state and `renderResult()` to show collapsed view on success
- Auto-expand on errors, async/background results, and SIXEL image output
- Width-safe collapsed line via `truncateToWidth()` to prevent TUI crashes on narrow terminals

## Why

Power users running many Bash commands in a session want a compact view that reduces terminal noise while preserving the ability to inspect output on demand. This mirrors the collapsed view pattern already used by other tools in the TUI.

Closes #494

## Testing

- [x] 14 unit tests covering collapsed/verbose modes, edge cases (error, SIXEL, async, Ctrl+O override), Settings fallback
- [x] TypeScript compiles clean (`tsc --noEmit` passes)
- [ ] CI pipeline passes

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #494`