### PR TITLE
fix: pass GH_TOKEN to build binary steps in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -664,6 +664,7 @@ jobs:
       - name: Build Linux and Windows binaries
         env:
           XCSH_BUILD_BRANCH: main # compiled binaries have no .git at runtime; pin branch at build time
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: bun scripts/ci-release-build-binaries.ts --platform linux,win32
       - name: Stage native addons for release
         run: cp packages/natives/native/*.node packages/coding-agent/binaries/
@@ -761,6 +762,7 @@ jobs:
       - name: Build macOS binary
         env:
           XCSH_BUILD_BRANCH: main # compiled binaries have no .git at runtime; pin branch at build time
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: bun scripts/ci-release-build-binaries.ts --platform darwin --arch ${{ matrix.arch }}
       - name: Stage macOS native addons for release
         run: cp packages/natives/native/*.node packages/coding-agent/binaries/


### PR DESCRIPTION
## Summary

- Add `GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}` to Linux/Windows build step env
- Add `GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}` to macOS build step env

## Why

The `generate-api-spec-index.ts` script (called during build) makes GitHub API calls to resolve the latest `api-specs-enriched` release. Without `GH_TOKEN`, these calls are unauthenticated and hit rate limits (HTTP 403). Both v18.34.1 and v18.34.2 releases failed on `build-sign-macos` due to this.

The script already checks for `GH_TOKEN` (added in PR #490), but the CI workflow was not passing the token to the build steps.

Closes #496

## Test plan

- [ ] CI checks pass
- [ ] Verify build steps have access to GitHub API during release