### PR TITLE
fix: correct deployment guide URL in demo-components skill

### DIFF
--- a/.xcsh/skills/demo-components/SKILL.md
+++ b/.xcsh/skills/demo-components/SKILL.md
@@ -49,7 +49,7 @@ When the user decides to deploy:
 
 1. Fetch the deployment guide custom set directly — do NOT fetch the component's
    llms.txt first (it is just a table of contents pointing here):
-   `https://f5xc-salesdemos.github.io/{component}/_llms-txt/deployment-guide.txt`
+   `https://f5xc-salesdemos.github.io/{component}/_llms-txt/deployment.txt`
 2. Walk through prerequisites, terraform variables, and deployment steps
 3. For each required terraform variable, ask the user for their value.
    All components share these standard variables:


### PR DESCRIPTION
## What

Fix the Layer 3 deployment URL template in the demo-components skill from `deployment-guide.txt` to `deployment.txt`.

## Why

The starlight-llms-txt plugin generates the file as `deployment.txt` (derived from the "Deployment" custom set label), not `deployment-guide.txt`. All three component URLs (origin-server, cdn-simulator, traffic-generator) returned 404 for the old filename and 200 for the correct one. This was blocking xcsh from fetching deployment instructions during the AI-assisted deployment flow.

Closes #498

## Testing

- [x] Verified `deployment.txt` returns 200 for all three components
- [x] Verified `deployment-guide.txt` returns 404 for all three components
- [x] Pre-commit hooks pass
- [x] Issue linked via `Closes #498`