### PR TITLE
fix: correct remaining deployment-guide.txt references in demo-components skill

### DIFF
--- a/.xcsh/skills/demo-components/SKILL.md
+++ b/.xcsh/skills/demo-components/SKILL.md
@@ -97,7 +97,7 @@ When a demo requires multiple components:
   this skill is the single entry point; the portal duplicates component
   listings and causes redundant fetches
 - Do NOT fetch individual component llms.txt files (e.g., origin-server/llms.txt)
-  as an intermediate step — go directly to the deployment-guide custom set
+  as an intermediate step — go directly to the deployment custom set
   when the user wants to deploy
 - Follow the layer sequence strictly: demo-resources/llms.txt → component-catalog.txt
-  → deployment-guide.txt. Maximum 3 fetches for a full discovery-to-deploy flow
+  → deployment.txt. Maximum 3 fetches for a full discovery-to-deploy flow


### PR DESCRIPTION
## What

Fix two remaining references to "deployment-guide" in the Rules section of
`.xcsh/skills/demo-components/SKILL.md` that were missed by PR #499.

## Why

PR #499 corrected the Layer 3 URL on line 52 from `deployment-guide.txt` to
`deployment.txt`, but two additional references in the Rules section (lines 100
and 103) still used the old "deployment-guide" name. These must match the actual
generated filename `deployment.txt`.

Closes #501

## Testing

- [x] Verified all three references to the deployment filename in SKILL.md now
      consistently use "deployment.txt" / "deployment"
- [x] `pre-commit` hooks pass (markdown lint, spelling, secrets, large files)
- [x] Issue linked via `Closes #501`