### PR TITLE
fix(bash): remove redundant ok badge from collapsed view

### DIFF
--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -780,7 +780,6 @@ export const bashToolRenderer = {
 						{
 							title: "Bash",
 							description: summaryText,
-							badge: { label: "ok", color: "success" },
 						},
 						uiTheme,
 					);


### PR DESCRIPTION
## What

Remove the `badge: { label: "ok", color: "success" }` property from the collapsed Bash tool view renderer.

## Why

The gutter ball indicator already conveys success/failure status with its color (green/red). The `⟨ok⟩` badge is redundant visual noise, especially for non-technical users.

Closes #504

## Testing

- [x] `bun run check` passes (pre-commit Biome lint passed)
- [x] Issue linked via `Closes #504`
- [ ] CHANGELOG updated (if user-facing)