### PR TITLE
perf(coding-agent): reduce CRUD execution overhead with system prompt optimizations

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -196,12 +196,21 @@ Most tools resolve custom protocol URLs to internal resources (not web URLs):
 
   When the user needs to **make an API call** (create, read, update, delete):
 
-  1. `xcsh://api-catalog/?resource={resource_name}` → get endpoint path, method, minimum
-     payload JSON, required fields, and response summary
+  1. `xcsh://api-catalog/?resource={resource_name}&compact=true` → get endpoint path, method,
+     minimum payload JSON, OneOf recommendations, and response summary
   2. Call `xcsh_api` tool with `method`, `path`, `params` (all `{placeholder}` substitutions), and `payload`
+
+  When the resource type and required parameters are clear, your **first output
+  MUST be the catalog tool call** — do not preface with explanation or deliberation.
+  If required parameters (e.g., namespace) are ambiguous, ask first.
 
   The `xcsh_api` tool handles authentication, URL construction, and HTTP execution.
   Never construct curl commands for F5 XC API calls — use `xcsh_api` instead.
+
+  After `xcsh_api` returns a 200 or 201 response, report the result immediately.
+  Do not issue a follow-up GET to verify — the response body is the verification.
+  Only issue a GET if the user explicitly asks to read current state, or if the
+  initial call returned a non-2xx status.
 
   If the resource name is unknown, search first:
   `xcsh://api-catalog/?search={term}` → find the matching category, then read it.


### PR DESCRIPTION
## What

Three system prompt changes to reduce CRUD execution latency in the coding-agent:
1. Add `compact=true` to resource lookup (`34-76%` token reduction per catalog read)
2. Direct-action directive — first output MUST be tool call for unambiguous CRUD requests
3. Skip verification GET after `200/201` — response body is the verification

## Why

Issue #507 identified that LLM deliberation overhead and redundant tokens account for ~78% of CRUD execution time. These three prompt-level fixes address it with zero code changes.

Fix 4 (embed top-5 catalogs) was rejected — adds ~6,900 tokens to every turn, not cost-effective since API interaction is selectively enabled.

Closes #507

## Testing

- Prompt-only change — no runtime code modified
- Pre-commit hooks pass (governance, markdown lint, spelling, secrets detection, editorconfig)

---

- [x] `bun run check` passes (no code changes)
- [x] `bun test` — no new failures vs baseline (prompt-only change)
- [x] Issue linked via `Closes #507`