### PR TITLE
perf(xcsh_api): TLS pre-warm, compact JSON, timeout, request ID (#510)

### DIFF
--- a/packages/coding-agent/src/prompts/tools/xcsh-api.md
+++ b/packages/coding-agent/src/prompts/tools/xcsh-api.md
@@ -7,3 +7,5 @@ Pass all path `{placeholder}` values via `params`, e.g. `{ namespace: "default",
 Body is sent for all methods except GET when `payload` is provided — including DELETE operations that require a body.
 
 Use this tool after reading the API catalog to get the endpoint path and payload structure.
+
+API calls to the same F5 XC tenant reuse a single TLS connection — sequential calls are faster than parallel calls. Do not issue multiple xcsh_api calls in the same turn; issue them one at a time.

--- a/packages/coding-agent/src/tools/xcsh-api.ts
+++ b/packages/coding-agent/src/tools/xcsh-api.ts
@@ -25,6 +25,7 @@ export interface XcshApiToolDetails {
 	status: number;
 	url: string;
 	method: string;
+	requestId: string;
 }
 
 type XcshApiResult = AgentToolResult<XcshApiToolDetails> & { isError?: boolean };
@@ -35,21 +36,31 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 	readonly description: string;
 	readonly parameters = xcshApiSchema;
 
+	#apiBase: string;
+	#apiToken: string;
+
 	constructor(_session: ToolSession) {
 		this.description = prompt.render(xcshApiDescription);
+		this.#apiBase = (process.env.F5XC_API_URL ?? "").replace(/\/+$/, "");
+		this.#apiToken = process.env.F5XC_API_TOKEN ?? "";
+
+		if (this.#apiBase && this.#apiToken) {
+			fetch(`${this.#apiBase}/api/web/namespaces`, {
+				method: "HEAD",
+				headers: { Authorization: `APIToken ${this.#apiToken}` },
+			}).catch(() => {});
+		}
 	}
 
 	async execute(_toolCallId: string, params: XcshApiParams): Promise<XcshApiResult> {
-		const apiUrl = process.env.F5XC_API_URL;
-		if (!apiUrl) {
+		if (!this.#apiBase) {
 			return {
 				content: [{ type: "text", text: "Error: F5XC_API_URL environment variable is not set." }],
 				isError: true,
 			};
 		}
 
-		const apiToken = process.env.F5XC_API_TOKEN;
-		if (!apiToken) {
+		if (!this.#apiToken) {
 			return {
 				content: [{ type: "text", text: "Error: F5XC_API_TOKEN environment variable is not set." }],
 				isError: true,
@@ -63,13 +74,19 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 			}
 		}
 
-		const url = `${apiUrl.replace(/\/+$/, "")}${resolvedPath}`;
+		const url = `${this.#apiBase}${resolvedPath}`;
+		const requestId = crypto.randomUUID();
 		const headers: Record<string, string> = {
-			Authorization: `APIToken ${apiToken}`,
+			Authorization: `APIToken ${this.#apiToken}`,
 			Accept: "application/json",
+			"X-Request-ID": requestId,
 		};
 
-		const init: RequestInit = { method: params.method, headers };
+		const init: RequestInit = {
+			method: params.method,
+			headers,
+			signal: AbortSignal.timeout(30_000),
+		};
 
 		if (params.payload && params.method !== "GET") {
 			headers["Content-Type"] = "application/json";
@@ -78,21 +95,12 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 
 		try {
 			const response = await fetch(url, init);
-			const contentType = response.headers.get("content-type") ?? "";
-			let bodyText: string;
-
-			if (contentType.includes("application/json")) {
-				const json = await response.json();
-				bodyText = JSON.stringify(json, null, 2);
-			} else {
-				bodyText = await response.text();
-			}
-
+			const bodyText = await response.text();
 			const statusLine = `${response.status} ${response.statusText}`;
 
 			return {
 				content: [{ type: "text", text: `${statusLine}\n\n${bodyText}` }],
-				details: { status: response.status, url, method: params.method },
+				details: { status: response.status, url, method: params.method, requestId },
 				...(response.status >= 400 ? { isError: true } : {}),
 			};
 		} catch (err) {

--- a/packages/coding-agent/test/xcsh-api-tool.test.ts
+++ b/packages/coding-agent/test/xcsh-api-tool.test.ts
@@ -11,8 +11,10 @@ describe("XcshApiTool", () => {
 	});
 
 	it("rejects when F5XC_API_URL is missing", async () => {
-		const original = process.env.F5XC_API_URL;
+		const originalUrl = process.env.F5XC_API_URL;
+		const originalToken = process.env.F5XC_API_TOKEN;
 		delete process.env.F5XC_API_URL;
+		delete process.env.F5XC_API_TOKEN;
 		try {
 			const tool = new XcshApiTool(mockSession);
 			const result = await tool.execute("call-1", {
@@ -23,7 +25,10 @@ describe("XcshApiTool", () => {
 			const text = result.content.find(c => c.type === "text")?.text ?? "";
 			expect(text).toContain("F5XC_API_URL");
 		} finally {
-			if (original) process.env.F5XC_API_URL = original;
+			if (originalUrl) process.env.F5XC_API_URL = originalUrl;
+			else delete process.env.F5XC_API_URL;
+			if (originalToken) process.env.F5XC_API_TOKEN = originalToken;
+			else delete process.env.F5XC_API_TOKEN;
 		}
 	});
 
@@ -131,6 +136,95 @@ describe("XcshApiTool", () => {
 			});
 			expect(capturedBody).not.toBeNull();
 			expect(JSON.parse(capturedBody as unknown as string)).toEqual({ fail_if_referred: true });
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (originalUrl) process.env.F5XC_API_URL = originalUrl;
+			else delete process.env.F5XC_API_URL;
+			if (originalToken) process.env.F5XC_API_TOKEN = originalToken;
+			else delete process.env.F5XC_API_TOKEN;
+		}
+	});
+
+	it("returns compact JSON (not pretty-printed)", async () => {
+		const originalFetch = globalThis.fetch;
+		const compactJson = '{"metadata":{"name":"test"},"spec":{"timeout":30}}';
+		globalThis.fetch = (async (_input: any, _init?: any) => {
+			return new Response(compactJson, {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		}) as typeof fetch;
+		const originalUrl = process.env.F5XC_API_URL;
+		const originalToken = process.env.F5XC_API_TOKEN;
+		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
+		process.env.F5XC_API_TOKEN = "test-token";
+		try {
+			const tool = new XcshApiTool(mockSession);
+			const result = await tool.execute("call-6", {
+				method: "GET",
+				path: "/api/config/namespaces/default/healthchecks",
+			});
+			const text = result.content.find(c => c.type === "text")?.text ?? "";
+			expect(text).toContain(compactJson);
+			expect(text).not.toContain("  ");
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (originalUrl) process.env.F5XC_API_URL = originalUrl;
+			else delete process.env.F5XC_API_URL;
+			if (originalToken) process.env.F5XC_API_TOKEN = originalToken;
+			else delete process.env.F5XC_API_TOKEN;
+		}
+	});
+
+	it("includes X-Request-ID header and requestId in details", async () => {
+		let capturedHeaders: Record<string, string> = {};
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (_input: any, init?: any) => {
+			capturedHeaders = init?.headers ?? {};
+			return new Response("{}", { status: 200 });
+		}) as typeof fetch;
+		const originalUrl = process.env.F5XC_API_URL;
+		const originalToken = process.env.F5XC_API_TOKEN;
+		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
+		process.env.F5XC_API_TOKEN = "test-token";
+		try {
+			const tool = new XcshApiTool(mockSession);
+			const result = await tool.execute("call-7", {
+				method: "GET",
+				path: "/api/config/namespaces/default/healthchecks",
+			});
+			expect(capturedHeaders["X-Request-ID"]).toBeDefined();
+			expect(capturedHeaders["X-Request-ID"].length).toBeGreaterThan(0);
+			const details = (result as any).details;
+			expect(details?.requestId).toBe(capturedHeaders["X-Request-ID"]);
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (originalUrl) process.env.F5XC_API_URL = originalUrl;
+			else delete process.env.F5XC_API_URL;
+			if (originalToken) process.env.F5XC_API_TOKEN = originalToken;
+			else delete process.env.F5XC_API_TOKEN;
+		}
+	});
+
+	it("includes AbortSignal timeout on fetch", async () => {
+		let capturedSignal: AbortSignal | undefined;
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (_input: any, init?: any) => {
+			capturedSignal = init?.signal;
+			return new Response("{}", { status: 200 });
+		}) as typeof fetch;
+		const originalUrl = process.env.F5XC_API_URL;
+		const originalToken = process.env.F5XC_API_TOKEN;
+		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
+		process.env.F5XC_API_TOKEN = "test-token";
+		try {
+			const tool = new XcshApiTool(mockSession);
+			await tool.execute("call-8", {
+				method: "GET",
+				path: "/api/config/namespaces/default/healthchecks",
+			});
+			expect(capturedSignal).toBeDefined();
+			expect(capturedSignal).toBeInstanceOf(AbortSignal);
 		} finally {
 			globalThis.fetch = originalFetch;
 			if (originalUrl) process.env.F5XC_API_URL = originalUrl;


### PR DESCRIPTION
## What

Profile-guided optimizations for `xcsh_api` tool addressing all 8 performance gaps identified in #510.

### Changes

| Gap | Optimization | Impact |
|-----|-------------|--------|
| 1 | TLS pre-warm — background HEAD request at construction | Eliminates 551ms cold-start |
| 2 | Compact JSON — `response.text()` instead of `JSON.stringify(json, null, 2)` | -41% tokens |
| 3 | 30s timeout — `AbortSignal.timeout(30_000)` on fetch | Prevents hung requests |
| 4 | Direct text — no double JSON parse | Fewer allocations |
| 5 | Cached env/base — constructor caches `F5XC_API_URL` and `F5XC_API_TOKEN` | No repeated env lookups |
| 6 | Pre-trimmed base URL — trailing slash regex runs once at construction | One-time cost |
| 7 | X-Request-ID — `crypto.randomUUID()` header | Production debugging |
| 8 | Sequential docs — tool description notes sequential calls are faster | Agent guidance |

## Why

Issue #510 profiled `xcsh_api` and found TLS cold start (551ms) and pretty-print inflation (41% token waste) as the two real costs. This refactor eliminates both plus adds timeout and debugging headers.

Closes #511

## Testing

- 9 tests in `test/xcsh-api-tool.test.ts` (2 new for compact JSON + request ID + timeout)
- Pre-commit hooks pass (biome lint, governance, secrets detection, spelling)

---

- [x] `bun run check` passes (biome lint-staged)
- [x] Tests cover new behavior (compact JSON, request ID, timeout)
- [x] Issue linked via `Closes #511`