### PR TITLE
fix(bash): fix streaming flicker in collapsed view

### DIFF
--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -772,10 +772,26 @@ export const bashToolRenderer = {
 				const verbose = getBashVerboseSetting();
 				const hasAsyncDetails = details?.async != null;
 				const forceExpand = isError || hasAsyncDetails || hasSixelOutput;
-				if (!verbose && !expanded && !forceExpand && !options.isPartial) {
+				if (!verbose && !expanded && !forceExpand) {
 					const rawCmd = args?.command;
 					const summaryText =
 						args?.description ?? (rawCmd && rawCmd.length > 60 ? `${rawCmd.slice(0, 60)}…` : rawCmd) ?? "…";
+
+					if (options.isPartial) {
+						const lineCount = rawOutputLines.filter(l => l.trim().length > 0).length;
+						const line = renderStatusLine(
+							{
+								icon: "running",
+								spinnerFrame: options.spinnerFrame,
+								title: "Bash",
+								description: summaryText,
+								meta: lineCount > 0 ? [`${lineCount} lines`] : undefined,
+							},
+							uiTheme,
+						);
+						return [truncateToWidth(line, width)];
+					}
+
 					const line = renderStatusLine(
 						{
 							title: "Bash",

--- a/packages/coding-agent/test/tools/bash-renderer.test.ts
+++ b/packages/coding-agent/test/tools/bash-renderer.test.ts
@@ -188,6 +188,76 @@ describe("bash collapsed view (bash.verbose=false)", () => {
 		const rendered = stripAnsi(component.render(120).join("\n"));
 		expect(rendered).toContain("detailed output here");
 	});
+
+	it("streaming: shows description and suppresses raw output", () => {
+		const result = {
+			content: [{ type: "text", text: "line 1\nline 2\nline 3\nline 4\nline 5\n" }],
+			isError: false,
+		};
+		const component = bashToolRenderer.renderResult(
+			result as never,
+			{ expanded: false, isPartial: true, spinnerFrame: 0 },
+			theme!,
+			{ command: "npm install", description: "Install dependencies" },
+		);
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("Install dependencies");
+		expect(rendered).not.toContain("line 1");
+		expect(rendered).not.toContain("Output");
+	});
+
+	it("streaming: shows live line count", () => {
+		const result = {
+			content: [{ type: "text", text: "first\nsecond\nthird\n" }],
+			isError: false,
+		};
+		const component = bashToolRenderer.renderResult(
+			result as never,
+			{ expanded: false, isPartial: true, spinnerFrame: 0 },
+			theme!,
+			{ command: "make build", description: "Build project" },
+		);
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("lines");
+	});
+
+	it("streaming: omits line count when output is empty", () => {
+		const result = {
+			content: [{ type: "text", text: "" }],
+			isError: false,
+		};
+		const component = bashToolRenderer.renderResult(
+			result as never,
+			{ expanded: false, isPartial: true, spinnerFrame: 0 },
+			theme!,
+			{ command: "sleep 5", description: "Wait for process" },
+		);
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("Wait for process");
+		expect(rendered).not.toContain("lines");
+	});
+
+	it("streaming: does not suppress output when verbose is true", async () => {
+		_resetSettingsForTest();
+		await Settings.init({ inMemory: true, overrides: { "bash.verbose": true } });
+		try {
+			const result = {
+				content: [{ type: "text", text: "visible output\n" }],
+				isError: false,
+			};
+			const component = bashToolRenderer.renderResult(
+				result as never,
+				{ expanded: false, isPartial: true, spinnerFrame: 0 },
+				theme!,
+				{ command: "echo test", description: "Run test" },
+			);
+			const rendered = stripAnsi(component.render(120).join("\n"));
+			expect(rendered).toContain("visible output");
+		} finally {
+			_resetSettingsForTest();
+			await Settings.init({ inMemory: true, overrides: { "bash.verbose": false } });
+		}
+	});
 });
 
 describe("bash verbose mode (bash.verbose=true)", () => {


### PR DESCRIPTION
## What

Fix streaming flicker in collapsed Bash tool view — output no longer briefly flashes during command execution.

## Why

The collapsed early-return guard had `!options.isPartial`, so it only activated for completed results. During streaming, the guard did not apply, causing raw output to flash briefly before the final collapsed state rendered.

Closes #516

## Changes

- Collapsed mode now covers both streaming and completed states
- Streaming state shows animated spinner + description + live non-empty line count (e.g. `◐ Bash: Install dependencies  47 lines`)
- Completed state shows description only (gutter handles status icon)
- Force-expand conditions (error, async, SIXEL) still bypass collapsed mode during streaming
- Added try/finally for Settings cleanup in verbose-mode streaming test

## Testing

- [x] 4 new streaming tests: description shown, line count shown, empty output omits count, verbose mode unaffected
- [x] All 23 bash-renderer tests pass
- [x] All 5 bash-sixel-render tests pass
- [x] TypeScript compiles clean
- [x] Biome and markdownlint clean

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #N`