### PR TITLE
chore: bump version to v18.36.0

### DIFF
--- a/.xcsh/tools/glab/__tests__/config.test.ts
+++ b/.xcsh/tools/glab/__tests__/config.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import * as fs from "node:fs/promises"
+import * as os from "node:os"
+import * as path from "node:path"
+import { loadConfig, resolveProject, saveConfig } from "../lib/config"
+
+describe("loadConfig", () => {
+	let tmpDir: string
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "glab-test-"))
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("returns null when config file does not exist", async () => {
+		const result = await loadConfig(tmpDir)
+		expect(result).toBeNull()
+	})
+
+	it("reads and parses valid config JSON", async () => {
+		const config = {
+			project: "mygroup/myrepo",
+			hostname: "gitlab.com",
+			defaultState: "opened",
+			perPage: 30,
+		}
+		await fs.mkdir(path.join(tmpDir, ".xcsh"), { recursive: true })
+		await fs.writeFile(path.join(tmpDir, ".xcsh", "glab-config.json"), JSON.stringify(config), "utf8")
+		const result = await loadConfig(tmpDir)
+		expect(result?.project).toBe("mygroup/myrepo")
+		expect(result?.hostname).toBe("gitlab.com")
+	})
+
+	it("returns null for malformed JSON", async () => {
+		await fs.mkdir(path.join(tmpDir, ".xcsh"), { recursive: true })
+		await fs.writeFile(path.join(tmpDir, ".xcsh", "glab-config.json"), "not-json", "utf8")
+		const result = await loadConfig(tmpDir)
+		expect(result).toBeNull()
+	})
+})
+
+describe("saveConfig", () => {
+	let tmpDir: string
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "glab-test-"))
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("creates .xcsh directory and writes config", async () => {
+		await saveConfig(tmpDir, { project: "group/repo", hostname: "gitlab.com", defaultState: "opened", perPage: 30 })
+		const raw = await fs.readFile(path.join(tmpDir, ".xcsh", "glab-config.json"), "utf8")
+		const parsed = JSON.parse(raw)
+		expect(parsed.project).toBe("group/repo")
+	})
+
+	it("overwrites existing config", async () => {
+		await saveConfig(tmpDir, { project: "old/repo", hostname: "gitlab.com", defaultState: "opened", perPage: 30 })
+		await saveConfig(tmpDir, { project: "new/repo", hostname: "gitlab.com", defaultState: "opened", perPage: 30 })
+		const result = await loadConfig(tmpDir)
+		expect(result?.project).toBe("new/repo")
+	})
+})
+
+describe("resolveProject", () => {
+	let tmpDir: string
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "glab-test-"))
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("returns param project when provided directly", async () => {
+		const result = await resolveProject("override/project", tmpDir)
+		expect(result).toBe("override/project")
+	})
+
+	it("falls back to config file project", async () => {
+		await saveConfig(tmpDir, { project: "config/project", hostname: "gitlab.com", defaultState: "opened", perPage: 30 })
+		const result = await resolveProject(undefined, tmpDir)
+		expect(result).toBe("config/project")
+	})
+
+	it("returns null when no project anywhere", async () => {
+		const result = await resolveProject(undefined, tmpDir)
+		expect(result).toBeNull()
+	})
+})

--- a/.xcsh/tools/glab/__tests__/exec.test.ts
+++ b/.xcsh/tools/glab/__tests__/exec.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test"
+import type { CustomToolAPI, ExecResult } from "@f5xc-salesdemos/xcsh"
+import {
+	GlabAuthError,
+	GlabExecError,
+	GlabNotFoundError,
+	checkAuth,
+	checkInstalled,
+	execGlab,
+	execGlabJson,
+} from "../lib/exec"
+
+function makeMockPi(result: Partial<ExecResult>): Pick<CustomToolAPI, "exec" | "cwd"> {
+	return {
+		cwd: "/tmp/test",
+		exec: async (_cmd: string, _args: string[]) => ({
+			stdout: "",
+			stderr: "",
+			code: 0,
+			killed: false,
+			...result,
+		}),
+	}
+}
+
+describe("checkInstalled", () => {
+	it("returns true when which glab succeeds", async () => {
+		const pi = makeMockPi({ code: 0, stdout: "/usr/local/bin/glab\n" })
+		expect(await checkInstalled(pi as CustomToolAPI)).toBe(true)
+	})
+
+	it("returns false when which glab fails", async () => {
+		const pi = makeMockPi({ code: 1, stderr: "glab not found" })
+		expect(await checkInstalled(pi as CustomToolAPI)).toBe(false)
+	})
+})
+
+describe("checkAuth", () => {
+	it("returns true when auth status is ok", async () => {
+		const pi = makeMockPi({ code: 0, stdout: "Logged in to gitlab.com as mordasiewicz" })
+		expect(await checkAuth(pi as CustomToolAPI)).toBe(true)
+	})
+
+	it("returns false when not logged in", async () => {
+		const pi = makeMockPi({ code: 1, stderr: "not logged in" })
+		expect(await checkAuth(pi as CustomToolAPI)).toBe(false)
+	})
+})
+
+describe("execGlab", () => {
+	it("returns result on success", async () => {
+		const pi = makeMockPi({ code: 0, stdout: "ok" })
+		const result = await execGlab(pi as CustomToolAPI, ["issue", "list"])
+		expect(result.stdout).toBe("ok")
+	})
+
+	it("throws GlabAuthError on auth-related stderr", async () => {
+		const pi = makeMockPi({ code: 1, stderr: "authentication required: not logged in" })
+		await expect(execGlab(pi as CustomToolAPI, ["issue", "list"])).rejects.toBeInstanceOf(GlabAuthError)
+	})
+
+	it("throws GlabNotFoundError on 404 stderr", async () => {
+		const pi = makeMockPi({ code: 1, stderr: "GraphQL: 404 Not Found" })
+		await expect(execGlab(pi as CustomToolAPI, ["issue", "list"])).rejects.toBeInstanceOf(GlabNotFoundError)
+	})
+
+	it("throws GlabExecError on generic failure", async () => {
+		const pi = makeMockPi({ code: 1, stderr: "connection timeout" })
+		await expect(execGlab(pi as CustomToolAPI, ["issue", "list"])).rejects.toBeInstanceOf(GlabExecError)
+	})
+
+	it("throws on killed signal", async () => {
+		const pi = makeMockPi({ killed: true, code: 0, stdout: "" })
+		await expect(execGlab(pi as CustomToolAPI, ["issue", "list"])).rejects.toThrow("cancelled")
+	})
+})
+
+describe("execGlabJson", () => {
+	it("parses JSON stdout", async () => {
+		const data = [{ iid: 1, title: "Test Issue" }]
+		const pi = makeMockPi({ code: 0, stdout: JSON.stringify(data) })
+		const result = await execGlabJson(pi as CustomToolAPI, ["issue", "list"])
+		expect(result).toEqual(data)
+	})
+
+	it("throws on invalid JSON", async () => {
+		const pi = makeMockPi({ code: 0, stdout: "not-json" })
+		await expect(execGlabJson(pi as CustomToolAPI, ["issue", "list"])).rejects.toThrow()
+	})
+})

--- a/.xcsh/tools/glab/__tests__/formatters.test.ts
+++ b/.xcsh/tools/glab/__tests__/formatters.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "bun:test"
+import type { GlabIssue } from "../lib/types"
+import { formatIssueDetail, formatIssueTable } from "../lib/formatters"
+
+const makeIssue = (overrides: Partial<GlabIssue> = {}): GlabIssue => ({
+	id: 1001,
+	iid: 42,
+	title: "Login fails on mobile Safari",
+	description: "Steps to reproduce:\n1. Open Safari\n2. Click login",
+	state: "opened",
+	labels: ["xc::auth", "priority::high"],
+	assignees: [{ username: "alice", name: "Alice Smith" }],
+	author: { username: "bob", name: "Bob Jones" },
+	milestone: { title: "Sprint 23", iid: 5 },
+	created_at: "2024-12-01T10:00:00Z",
+	updated_at: "2024-12-15T14:30:00Z",
+	web_url: "https://gitlab.com/group/repo/-/issues/42",
+	references: { full: "group/repo#42" },
+	issue_type: "issue",
+	notes: [],
+	...overrides,
+})
+
+describe("formatIssueTable", () => {
+	it("renders a markdown table header", () => {
+		const result = formatIssueTable([makeIssue()])
+		expect(result).toContain("| IID |")
+		expect(result).toContain("Title")
+		expect(result).toContain("State")
+		expect(result).toContain("Labels")
+		expect(result).toContain("Assignee")
+		expect(result).toContain("Updated")
+	})
+
+	it("renders issue data in table row", () => {
+		const result = formatIssueTable([makeIssue()])
+		expect(result).toContain("42")
+		expect(result).toContain("Login fails on mobile Safari")
+		expect(result).toContain("opened")
+		expect(result).toContain("@alice")
+		expect(result).toContain("2024-12-15")
+	})
+
+	it("renders multiple issues as multiple rows", () => {
+		const issues = [makeIssue({ iid: 1 }), makeIssue({ iid: 2 }), makeIssue({ iid: 3 })]
+		const result = formatIssueTable(issues)
+		const rows = result.split("\n").filter(l => l.startsWith("|") && !l.includes("---") && !l.includes("IID"))
+		expect(rows).toHaveLength(3)
+	})
+
+	it("returns 'No issues found' message for empty array", () => {
+		const result = formatIssueTable([])
+		expect(result).toContain("No issues found")
+	})
+
+	it("handles issues with no assignees", () => {
+		const issue = makeIssue({ assignees: [] })
+		const result = formatIssueTable([issue])
+		expect(result).toContain("unassigned")
+	})
+})
+
+describe("formatIssueDetail", () => {
+	it("includes issue title as H1", () => {
+		const result = formatIssueDetail(makeIssue())
+		expect(result).toContain("# Issue #42: Login fails on mobile Safari")
+	})
+
+	it("includes state, author, labels", () => {
+		const result = formatIssueDetail(makeIssue())
+		expect(result).toContain("opened")
+		expect(result).toContain("@bob")
+		expect(result).toContain("xc::auth")
+		expect(result).toContain("priority::high")
+	})
+
+	it("includes description", () => {
+		const result = formatIssueDetail(makeIssue())
+		expect(result).toContain("Steps to reproduce")
+	})
+
+	it("shows 'No comments' when notes is empty", () => {
+		const result = formatIssueDetail(makeIssue({ notes: [] }))
+		expect(result).toContain("No comments")
+	})
+
+	it("renders comments when present", () => {
+		const issue = makeIssue({
+			notes: [
+				{
+					id: 1,
+					body: "Confirmed on iOS 17.2",
+					author: { username: "charlie", name: "Charlie" },
+					created_at: "2024-12-02T09:00:00Z",
+					updated_at: "2024-12-02T09:00:00Z",
+					system: false,
+				},
+			],
+		})
+		const result = formatIssueDetail(issue)
+		expect(result).toContain("@charlie")
+		expect(result).toContain("Confirmed on iOS 17.2")
+	})
+
+	it("skips system notes", () => {
+		const issue = makeIssue({
+			notes: [
+				{
+					id: 1,
+					body: "closed via MR !234",
+					author: { username: "gitlab-bot", name: "GitLab Bot" },
+					created_at: "2024-12-10T10:00:00Z",
+					updated_at: "2024-12-10T10:00:00Z",
+					system: true,
+				},
+			],
+		})
+		const result = formatIssueDetail(issue)
+		expect(result).not.toContain("@gitlab-bot")
+	})
+})

--- a/.xcsh/tools/glab/__tests__/graphql.test.ts
+++ b/.xcsh/tools/glab/__tests__/graphql.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test"
+import type { CustomToolAPI, ExecResult } from "@f5xc-salesdemos/xcsh"
+import type { GraphQLIssueNode } from "../lib/types"
+import { buildSearchQuery, executeGraphQL } from "../lib/graphql"
+
+describe("buildSearchQuery", () => {
+	it("builds a valid GraphQL query string", () => {
+		const query = buildSearchQuery()
+		expect(query).toContain("query SearchIssues")
+		expect(query).toContain("$projectPath")
+		expect(query).toContain("$search")
+		expect(query).toContain("$first")
+		expect(query).toContain("notes")
+		expect(query).toContain("assignees")
+	})
+})
+
+describe("executeGraphQL", () => {
+	function makePi(stdout: string, code = 0): Pick<CustomToolAPI, "exec" | "cwd"> {
+		return {
+			cwd: "/tmp",
+			exec: async () => ({ stdout, stderr: "", code, killed: false }) as ExecResult,
+		}
+	}
+
+	it("returns parsed nodes on success", async () => {
+		const mockNodes: GraphQLIssueNode[] = [
+			{
+				iid: "42",
+				title: "Test issue",
+				state: "opened",
+				labels: { nodes: [{ title: "bug" }] },
+				assignees: { nodes: [{ username: "alice" }] },
+				updatedAt: "2024-12-01T00:00:00Z",
+				notes: { nodes: [] },
+			},
+		]
+		const mockResponse = { data: { project: { issues: { nodes: mockNodes } } } }
+		const pi = makePi(JSON.stringify(mockResponse))
+		const result = await executeGraphQL(pi as CustomToolAPI, "group/project", "test query", 10)
+		expect(result).toHaveLength(1)
+		expect(result[0].title).toBe("Test issue")
+	})
+
+	it("returns empty array when project not found", async () => {
+		const mockResponse = { data: { project: null } }
+		const pi = makePi(JSON.stringify(mockResponse))
+		const result = await executeGraphQL(pi as CustomToolAPI, "group/project", "test", 10)
+		expect(result).toEqual([])
+	})
+
+	it("throws on GraphQL errors array", async () => {
+		const mockResponse = { errors: [{ message: "Field 'issues' doesn't exist" }] }
+		const pi = makePi(JSON.stringify(mockResponse))
+		await expect(executeGraphQL(pi as CustomToolAPI, "group/project", "test", 10)).rejects.toThrow(
+			"Field 'issues' doesn't exist",
+		)
+	})
+
+	it("throws on glab CLI failure", async () => {
+		const pi = makePi("", 1)
+		await expect(executeGraphQL(pi as CustomToolAPI, "group/project", "test", 10)).rejects.toThrow()
+	})
+})

--- a/.xcsh/tools/glab/__tests__/graphql.test.ts
+++ b/.xcsh/tools/glab/__tests__/graphql.test.ts
@@ -4,14 +4,21 @@ import type { GraphQLIssueNode } from "../lib/types"
 import { buildSearchQuery, executeGraphQL } from "../lib/graphql"
 
 describe("buildSearchQuery", () => {
-	it("builds a valid GraphQL query string", () => {
-		const query = buildSearchQuery()
+	it("builds a valid GraphQL query string without state", () => {
+		const query = buildSearchQuery(false)
 		expect(query).toContain("query SearchIssues")
 		expect(query).toContain("$projectPath")
 		expect(query).toContain("$search")
 		expect(query).toContain("$first")
 		expect(query).toContain("notes")
 		expect(query).toContain("assignees")
+		expect(query).not.toContain("$state")
+	})
+
+	it("includes state variable when requested", () => {
+		const query = buildSearchQuery(true)
+		expect(query).toContain("$state: IssuableState")
+		expect(query).toContain("state: $state")
 	})
 })
 

--- a/.xcsh/tools/glab/__tests__/tools.test.ts
+++ b/.xcsh/tools/glab/__tests__/tools.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "bun:test"
+import type { CustomToolAPI, ExecResult } from "@f5xc-salesdemos/xcsh"
+// Resolve typebox from bun's module store since it's not hoisted to root node_modules
+import { Type } from "../../../../node_modules/.bun/@sinclair+typebox@0.34.49/node_modules/@sinclair/typebox/build/esm/index.mjs"
+
+// Minimal StringEnum matching the pi-ai implementation
+function StringEnum<const T extends readonly string[]>(
+	values: T,
+	options?: { description?: string; default?: T[number] },
+) {
+	return Type.Unsafe({
+		type: "string",
+		enum: values as unknown as string[],
+		...(options?.description && { description: options.description }),
+		...(options?.default && { default: options.default }),
+	})
+}
+
+function makePi(execFn: (cmd: string, args: string[]) => ExecResult): CustomToolAPI {
+	const pi: Record<string, unknown> = {
+		cwd: "/tmp/test",
+		exec: async (cmd: string, args: string[]) => execFn(cmd, args),
+		hasUI: false,
+		logger: console,
+		typebox: { Type },
+		pi: { StringEnum },
+		pushPendingAction: () => {},
+		ui: {},
+	}
+	return pi as unknown as CustomToolAPI
+}
+
+function defaultExec(_cmd: string, _args: string[]): ExecResult {
+	return { stdout: "", stderr: "not stubbed", code: 1, killed: false }
+}
+
+describe("factory", () => {
+	it("exports 4 named tools", async () => {
+		const { default: factory } = await import("../index")
+		const pi = makePi(defaultExec)
+		const tools = await factory(pi)
+		const arr = Array.isArray(tools) ? tools : [tools]
+		expect(arr).toHaveLength(4)
+		const names = arr.map(t => t.name).sort()
+		expect(names).toEqual(["glab_issue_list", "glab_issue_view", "glab_search", "glab_setup"])
+	})
+})
+
+describe("glab_setup check action", () => {
+	it("returns installed message when glab found", async () => {
+		const { default: factory } = await import("../index")
+		const pi = makePi((cmd, args) => {
+			if (cmd === "which") return { stdout: "/usr/local/bin/glab\n", stderr: "", code: 0, killed: false }
+			if (cmd === "glab" && args[0] === "--version") return { stdout: "glab version 1.93.0\n", stderr: "", code: 0, killed: false }
+			return defaultExec(cmd, args)
+		})
+		const tools = await factory(pi)
+		const arr = Array.isArray(tools) ? tools : [tools]
+		const setup = arr.find(t => t.name === "glab_setup")!
+		const result = await setup.execute("id1", { action: "check" }, undefined, {} as any, undefined)
+		expect(result.content[0].type).toBe("text")
+		expect((result.content[0] as { type: "text"; text: string }).text).toContain("installed")
+	})
+
+	it("returns not installed when glab missing", async () => {
+		const { default: factory } = await import("../index")
+		const pi = makePi((cmd, _args) => {
+			if (cmd === "which") return { stdout: "", stderr: "not found", code: 1, killed: false }
+			return defaultExec(cmd, _args)
+		})
+		const tools = await factory(pi)
+		const arr = Array.isArray(tools) ? tools : [tools]
+		const setup = arr.find(t => t.name === "glab_setup")!
+		const result = await setup.execute("id1", { action: "check" }, undefined, {} as any, undefined)
+		const text = (result.content[0] as { type: "text"; text: string }).text
+		expect(text.toLowerCase()).toContain("not installed")
+	})
+})
+
+describe("glab_issue_list", () => {
+	it("returns no-project message when unconfigured", async () => {
+		const { default: factory } = await import("../index")
+		const pi = makePi(defaultExec)
+		pi.cwd = "/tmp/nonexistent-config-dir"
+		const tools = await factory(pi)
+		const arr = Array.isArray(tools) ? tools : [tools]
+		const listTool = arr.find(t => t.name === "glab_issue_list")!
+		const result = await listTool.execute("id1", {}, undefined, {} as any, undefined)
+		const text = (result.content[0] as { type: "text"; text: string }).text
+		expect(text.toLowerCase()).toContain("no gitlab project configured")
+	})
+
+	it("builds correct glab command with explicit project", async () => {
+		const { default: factory } = await import("../index")
+		const captured: string[][] = []
+		const pi = makePi((cmd, args) => {
+			if (cmd === "glab") {
+				captured.push(args)
+				if (args.includes("list") && args.includes("--output")) {
+					return { stdout: "[]", stderr: "", code: 0, killed: false }
+				}
+			}
+			return defaultExec(cmd, args)
+		})
+		const tools = await factory(pi)
+		const arr = Array.isArray(tools) ? tools : [tools]
+		const listTool = arr.find(t => t.name === "glab_issue_list")!
+		await listTool.execute("id1", { project: "group/repo" }, undefined, {} as any, undefined)
+		const issueCall = captured.find(a => a.includes("issue") && a.includes("list"))
+		expect(issueCall).toBeDefined()
+		expect(issueCall).toContain("--repo")
+		expect(issueCall).toContain("group/repo")
+		expect(issueCall).toContain("--output")
+		expect(issueCall).toContain("json")
+	})
+})
+
+describe("glab_search", () => {
+	it("calls REST search with correct params", async () => {
+		const { default: factory } = await import("../index")
+		const captured: string[][] = []
+		const pi = makePi((cmd, args) => {
+			if (cmd === "glab") {
+				captured.push(args)
+				// REST list returns empty
+				if (args.includes("list")) return { stdout: "[]", stderr: "", code: 0, killed: false }
+				// GraphQL returns empty
+				if (args.includes("graphql")) return { stdout: JSON.stringify({ data: { project: { issues: { nodes: [] } } } }), stderr: "", code: 0, killed: false }
+			}
+			return defaultExec(cmd, args)
+		})
+		const tools = await factory(pi)
+		const arr = Array.isArray(tools) ? tools : [tools]
+		const searchTool = arr.find(t => t.name === "glab_search")!
+		await searchTool.execute("id1", { query: "Tempus", project: "group/repo" }, undefined, {} as any, undefined)
+		const restCall = captured.find(a => a.includes("--search"))
+		expect(restCall).toBeDefined()
+		expect(restCall).toContain("Tempus")
+	})
+})

--- a/.xcsh/tools/glab/__tests__/tools.test.ts
+++ b/.xcsh/tools/glab/__tests__/tools.test.ts
@@ -113,6 +113,25 @@ describe("glab_issue_list", () => {
 		expect(issueCall).toContain("--output")
 		expect(issueCall).toContain("json")
 	})
+
+	it("maps state opened to --opened flag (not --state)", async () => {
+		const { default: factory } = await import("../index")
+		const captured: string[][] = []
+		const pi = makePi((cmd, args) => {
+			if (cmd === "glab") {
+				captured.push(args)
+				if (args.includes("list")) return { stdout: "[]", stderr: "", code: 0, killed: false }
+			}
+			return defaultExec(cmd, args)
+		})
+		const tools = await factory(pi)
+		const arr = Array.isArray(tools) ? tools : [tools]
+		const listTool = arr.find(t => t.name === "glab_issue_list")!
+		await listTool.execute("id1", { project: "group/repo", state: "opened" }, undefined, {} as any, undefined)
+		const issueCall = captured.find(a => a.includes("list"))!
+		expect(issueCall).toContain("--opened")
+		expect(issueCall).not.toContain("--state")
+	})
 })
 
 describe("glab_search", () => {

--- a/.xcsh/tools/glab/index.ts
+++ b/.xcsh/tools/glab/index.ts
@@ -306,7 +306,7 @@ const factory: CustomToolFactory = pi => {
 
 			let graphqlNodes: GraphQLIssueNode[] = []
 			try {
-				graphqlNodes = await executeGraphQL(pi, project, params.query, limit, signal)
+				graphqlNodes = await executeGraphQL(pi, project, params.query, limit, signal, params.state)
 			} catch {
 				// GraphQL unavailable — use REST results only
 			}

--- a/.xcsh/tools/glab/index.ts
+++ b/.xcsh/tools/glab/index.ts
@@ -1,0 +1,354 @@
+import type { CustomToolFactory } from "@f5xc-salesdemos/xcsh"
+import { GlabAuthError, checkAuth, checkInstalled, execGlabJson } from "./lib/exec"
+import { formatIssueDetail, formatIssueTable } from "./lib/formatters"
+import { executeGraphQL } from "./lib/graphql"
+import { loadConfig, resolveProject, saveConfig } from "./lib/config"
+import type { GlabIssue, GlabProject, GraphQLIssueNode } from "./lib/types"
+
+const factory: CustomToolFactory = pi => {
+	const { Type } = pi.typebox
+	const { StringEnum } = pi.pi
+
+	const SetupParams = Type.Object({
+		action: StringEnum(["check", "login", "select_project", "save_project", "status"] as const),
+		project: Type.Optional(Type.String({ description: "Project path to persist (used with save_project)" })),
+	})
+
+	const glabSetup = {
+		name: "glab_setup" as const,
+		label: "GitLab Setup",
+		description:
+			"GitLab onboarding wizard: check glab installation, authenticate, discover projects, and persist configuration. Run this first if the user has not set up GitLab yet.",
+		parameters: SetupParams,
+
+		async execute(
+			_toolCallId: string,
+			params: { action: string; project?: string },
+			_onUpdate: unknown,
+			_ctx: unknown,
+			signal?: AbortSignal,
+		) {
+			switch (params.action) {
+				case "check": {
+					const installed = await checkInstalled(pi)
+					if (!installed) {
+						return {
+							content: [
+								{
+									type: "text" as const,
+									text: "glab is not installed.\n\nInstall it with:\n- **macOS**: `brew install glab`\n- **Linux**: Download from https://gitlab.com/gitlab-org/cli/-/releases\n- **Windows**: `winget install gitlab.glab`\n\nAfter installing, call glab_setup with action \"login\" to authenticate.",
+								},
+							],
+						}
+					}
+					const verResult = await pi.exec("glab", ["--version"], { signal, cwd: pi.cwd })
+					return {
+						content: [{ type: "text" as const, text: `glab is installed: ${verResult.stdout.trim()}` }],
+					}
+				}
+
+				case "status": {
+					const authResult = await pi.exec("glab", ["auth", "status"], { signal, cwd: pi.cwd })
+					const config = await loadConfig(pi.cwd)
+					const projectInfo = config?.project
+						? `\nConfigured project: ${config.project}`
+						: "\nNo project configured. Run select_project to choose one."
+					const authStatus = authResult.code === 0 ? authResult.stdout : `Not authenticated: ${authResult.stderr}`
+					return {
+						content: [{ type: "text" as const, text: authStatus + projectInfo }],
+					}
+				}
+
+				case "login": {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: "Starting GitLab authentication...\n\nRunning: `glab auth login --hostname gitlab.com --git-protocol https --web`\n\nYour browser will open for you to authorize access. Return here after authorizing.",
+							},
+						],
+					}
+				}
+
+				case "select_project": {
+					const authenticated = await checkAuth(pi)
+					if (!authenticated) {
+						return {
+							content: [{ type: "text" as const, text: 'Not authenticated. Run glab_setup with action "login" first.' }],
+						}
+					}
+					const projects = await execGlabJson<GlabProject[]>(
+						pi,
+						["repo", "list", "--member", "--output", "json", "--per-page", "50"],
+						signal,
+					)
+					if (!projects.length) {
+						return {
+							content: [{ type: "text" as const, text: "No projects found for your account." }],
+						}
+					}
+					const list = projects
+						.map((p, i) => `${i + 1}. **${p.name_with_namespace}** — \`${p.path_with_namespace}\``)
+						.join("\n")
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Found ${projects.length} projects:\n\n${list}\n\nWhich project do you want to use for GitLab issue tracking? Reply with the number or full path.`,
+							},
+						],
+						details: { projects },
+					}
+				}
+
+				case "save_project": {
+					if (!params.project) {
+						return {
+							content: [
+								{ type: "text" as const, text: "Error: project parameter is required for save_project action." },
+							],
+						}
+					}
+					const existing = (await loadConfig(pi.cwd)) ?? {
+						project: "",
+						hostname: "gitlab.com",
+						defaultState: "opened" as const,
+						perPage: 30,
+					}
+					await saveConfig(pi.cwd, { ...existing, project: params.project })
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Configuration saved. Default project set to: **${params.project}**`,
+							},
+						],
+					}
+				}
+
+				default:
+					return { content: [{ type: "text" as const, text: `Unknown action: ${params.action}` }] }
+			}
+		},
+	}
+
+	const IssueListParams = Type.Object({
+		project: Type.Optional(
+			Type.String({ description: "GitLab project path (e.g. group/repo). Defaults to configured project." }),
+		),
+		state: Type.Optional(StringEnum(["opened", "closed", "all"] as const)),
+		labels: Type.Optional(
+			Type.Array(Type.String(), { description: "Filter by labels (e.g. ['bug', 'priority::high'])" }),
+		),
+		assignee: Type.Optional(Type.String({ description: "Filter by assignee username" })),
+		search: Type.Optional(Type.String({ description: "Search text in title and description" })),
+		milestone: Type.Optional(Type.String()),
+		sort: Type.Optional(StringEnum(["created_at", "updated_at", "priority", "due_date"] as const)),
+		order: Type.Optional(StringEnum(["asc", "desc"] as const)),
+		limit: Type.Optional(Type.Number({ default: 30, maximum: 100 })),
+	})
+
+	const glabIssueList = {
+		name: "glab_issue_list" as const,
+		label: "GitLab Issue List",
+		description:
+			"List GitLab issues with structured filters. Use for 'show open bugs', 'list issues assigned to X', 'show high priority issues'. Returns a summary table.",
+		parameters: IssueListParams,
+
+		async execute(
+			_toolCallId: string,
+			params: Record<string, unknown>,
+			_onUpdate: unknown,
+			_ctx: unknown,
+			signal?: AbortSignal,
+		) {
+			const project = await resolveProject(params.project as string | undefined, pi.cwd)
+			if (!project) {
+				return {
+					content: [
+						{ type: "text" as const, text: "No GitLab project configured. Run glab_setup to set one up." },
+					],
+				}
+			}
+
+			const args = ["issue", "list", "--output", "json", "--repo", project]
+			if (params.state) args.push("--state", params.state as string)
+			if (params.labels && Array.isArray(params.labels) && params.labels.length > 0)
+				args.push("--label", (params.labels as string[]).join(","))
+			if (params.assignee) args.push("--assignee", params.assignee as string)
+			if (params.search) args.push("--search", params.search as string)
+			if (params.milestone) args.push("--milestone", params.milestone as string)
+			if (params.sort) args.push("--sort", params.sort as string)
+			if (params.order) args.push("--order", params.order as string)
+			args.push("--per-page", String(Math.min(Number(params.limit ?? 30), 100)))
+
+			try {
+				const issues = await execGlabJson<GlabIssue[]>(pi, args, signal)
+				return {
+					content: [{ type: "text" as const, text: formatIssueTable(issues) }],
+					details: { items: issues, total: issues.length, project },
+				}
+			} catch (err) {
+				if (err instanceof GlabAuthError) {
+					return { content: [{ type: "text" as const, text: (err as Error).message }] }
+				}
+				throw err
+			}
+		},
+	}
+
+	const IssueViewParams = Type.Object({
+		issue: Type.Union([Type.Number(), Type.String()], { description: "Issue IID number or full URL" }),
+		project: Type.Optional(Type.String()),
+		comments: Type.Optional(Type.Boolean({ default: true })),
+	})
+
+	const glabIssueView = {
+		name: "glab_issue_view" as const,
+		label: "GitLab Issue View",
+		description:
+			"View a single GitLab issue with full details, description, and comments. Use when the user asks to 'show issue #N' or 'view details of issue X'.",
+		parameters: IssueViewParams,
+
+		async execute(
+			_toolCallId: string,
+			params: { issue: number | string; project?: string; comments?: boolean },
+			_onUpdate: unknown,
+			_ctx: unknown,
+			signal?: AbortSignal,
+		) {
+			const project = await resolveProject(params.project, pi.cwd)
+			if (!project) {
+				return {
+					content: [
+						{ type: "text" as const, text: "No GitLab project configured. Run glab_setup to set one up." },
+					],
+				}
+			}
+
+			const issueId = String(params.issue)
+			const args = ["issue", "view", issueId, "--output", "json", "--repo", project]
+			if (params.comments !== false) args.push("--comments")
+
+			try {
+				const issue = await execGlabJson<GlabIssue>(pi, args, signal)
+				return {
+					content: [{ type: "text" as const, text: formatIssueDetail(issue) }],
+					details: { issue, project },
+				}
+			} catch (err) {
+				if (err instanceof GlabAuthError) {
+					return { content: [{ type: "text" as const, text: (err as Error).message }] }
+				}
+				throw err
+			}
+		},
+	}
+
+	const SearchParams = Type.Object({
+		query: Type.String({
+			description: "Search text to find across issue titles, descriptions, labels, and comments",
+		}),
+		project: Type.Optional(Type.String()),
+		state: Type.Optional(StringEnum(["opened", "closed", "all"] as const)),
+		labels: Type.Optional(Type.Array(Type.String())),
+		limit: Type.Optional(Type.Number({ default: 20, maximum: 100 })),
+	})
+
+	const glabSearch = {
+		name: "glab_search" as const,
+		label: "GitLab Search",
+		description:
+			"Full-text search across GitLab issue titles, descriptions, labels, and comments. Use for queries like 'find issues about Tempus' or 'search for login timeout bugs'. Searches comments too.",
+		parameters: SearchParams,
+
+		async execute(
+			_toolCallId: string,
+			params: { query: string; project?: string; state?: string; labels?: string[]; limit?: number },
+			_onUpdate: unknown,
+			_ctx: unknown,
+			signal?: AbortSignal,
+		) {
+			const project = await resolveProject(params.project, pi.cwd)
+			if (!project) {
+				return {
+					content: [
+						{ type: "text" as const, text: "No GitLab project configured. Run glab_setup to set one up." },
+					],
+				}
+			}
+
+			const limit = Math.min(params.limit ?? 20, 100)
+			let issues: GlabIssue[] = []
+
+			const restArgs = [
+				"issue",
+				"list",
+				"--output",
+				"json",
+				"--repo",
+				project,
+				"--search",
+				params.query,
+				"--per-page",
+				String(limit),
+			]
+			if (params.state) restArgs.push("--state", params.state)
+			if (params.labels?.length) restArgs.push("--label", params.labels.join(","))
+
+			try {
+				issues = await execGlabJson<GlabIssue[]>(pi, restArgs, signal)
+			} catch (err) {
+				if (err instanceof GlabAuthError) {
+					return { content: [{ type: "text" as const, text: (err as Error).message }] }
+				}
+			}
+
+			let graphqlNodes: GraphQLIssueNode[] = []
+			try {
+				graphqlNodes = await executeGraphQL(pi, project, params.query, limit, signal)
+			} catch {
+				// GraphQL unavailable — use REST results only
+			}
+
+			if (graphqlNodes.length > 0) {
+				const seenIids = new Set(issues.map(i => i.iid))
+				for (const node of graphqlNodes) {
+					const iid = parseInt(node.iid, 10)
+					if (seenIids.has(iid)) continue
+					seenIids.add(iid)
+					const lowerQuery = params.query.toLowerCase()
+					const inTitle = node.title.toLowerCase().includes(lowerQuery)
+					const inComments = node.notes.nodes.some(n => n.body.toLowerCase().includes(lowerQuery))
+					if (inTitle || inComments) {
+						issues.push({
+							id: iid,
+							iid,
+							title: node.title,
+							description: "",
+							state: node.state === "OPEN" ? "opened" : "closed",
+							labels: node.labels.nodes.map(l => l.title),
+							assignees: node.assignees.nodes.map(a => ({ username: a.username, name: a.username })),
+							author: { username: "", name: "" },
+							milestone: null,
+							created_at: node.updatedAt,
+							updated_at: node.updatedAt,
+							web_url: `https://gitlab.com/${project}/-/issues/${iid}`,
+							references: { full: `${project}#${iid}` },
+							issue_type: "issue",
+						})
+					}
+				}
+			}
+
+			return {
+				content: [{ type: "text" as const, text: formatIssueTable(issues) }],
+				details: { items: issues, total: issues.length, project, query: params.query },
+			}
+		},
+	}
+
+	return [glabSetup, glabIssueList, glabIssueView, glabSearch]
+}
+
+export default factory

--- a/.xcsh/tools/glab/index.ts
+++ b/.xcsh/tools/glab/index.ts
@@ -172,14 +172,17 @@ const factory: CustomToolFactory = pi => {
 			}
 
 			const args = ["issue", "list", "--output", "json", "--repo", project]
-			if (params.state) args.push("--state", params.state as string)
+			const state = params.state as string | undefined
+			if (state === "opened") args.push("--opened")
+			else if (state === "closed") args.push("--closed")
+			else if (state === "all") args.push("--all")
 			if (params.labels && Array.isArray(params.labels) && params.labels.length > 0)
 				args.push("--label", (params.labels as string[]).join(","))
 			if (params.assignee) args.push("--assignee", params.assignee as string)
 			if (params.search) args.push("--search", params.search as string)
 			if (params.milestone) args.push("--milestone", params.milestone as string)
-			if (params.sort) args.push("--sort", params.sort as string)
-			if (params.order) args.push("--order", params.order as string)
+			if (params.sort) args.push("--order", params.sort as string)
+			if (params.order) args.push("--sort", params.order as string)
 			args.push("--per-page", String(Math.min(Number(params.limit ?? 30), 100)))
 
 			try {
@@ -293,7 +296,9 @@ const factory: CustomToolFactory = pi => {
 				"--per-page",
 				String(limit),
 			]
-			if (params.state) restArgs.push("--state", params.state)
+			if (params.state === "opened") restArgs.push("--opened")
+			else if (params.state === "closed") restArgs.push("--closed")
+			else if (params.state === "all") restArgs.push("--all")
 			if (params.labels?.length) restArgs.push("--label", params.labels.join(","))
 
 			try {

--- a/.xcsh/tools/glab/lib/config.ts
+++ b/.xcsh/tools/glab/lib/config.ts
@@ -1,0 +1,40 @@
+import * as fs from "node:fs/promises"
+import * as os from "node:os"
+import * as path from "node:path"
+import type { GlabConfig } from "./types"
+
+const CONFIG_FILENAME = "glab-config.json"
+const XCSH_DIR = ".xcsh"
+
+export async function loadConfig(cwd: string): Promise<GlabConfig | null> {
+	const projectConfig = path.join(cwd, XCSH_DIR, CONFIG_FILENAME)
+	try {
+		const raw = await fs.readFile(projectConfig, "utf8")
+		return JSON.parse(raw) as GlabConfig
+	} catch {
+		// try user-level fallback
+	}
+
+	const userConfig = path.join(os.homedir(), ".xcsh", "agent", CONFIG_FILENAME)
+	try {
+		const raw = await fs.readFile(userConfig, "utf8")
+		return JSON.parse(raw) as GlabConfig
+	} catch {
+		return null
+	}
+}
+
+export async function saveConfig(cwd: string, config: GlabConfig): Promise<void> {
+	const dir = path.join(cwd, XCSH_DIR)
+	await fs.mkdir(dir, { recursive: true })
+	await fs.writeFile(path.join(dir, CONFIG_FILENAME), JSON.stringify(config, null, 2), "utf8")
+}
+
+export async function resolveProject(
+	paramProject: string | undefined,
+	cwd: string,
+): Promise<string | null> {
+	if (paramProject) return paramProject
+	const config = await loadConfig(cwd)
+	return config?.project ?? null
+}

--- a/.xcsh/tools/glab/lib/exec.ts
+++ b/.xcsh/tools/glab/lib/exec.ts
@@ -1,0 +1,64 @@
+import type { CustomToolAPI, ExecResult } from "@f5xc-salesdemos/xcsh"
+
+export class GlabAuthError extends Error {
+	constructor(message: string) {
+		super(`GitLab auth error: ${message}. Run glab_setup with action "login".`)
+		this.name = "GlabAuthError"
+	}
+}
+
+export class GlabNotFoundError extends Error {
+	constructor(message: string) {
+		super(`GitLab resource not found (404/403): ${message}`)
+		this.name = "GlabNotFoundError"
+	}
+}
+
+export class GlabExecError extends Error {
+	constructor(
+		message: string,
+		public readonly code: number,
+	) {
+		super(`glab command failed (exit ${code}): ${message}`)
+		this.name = "GlabExecError"
+	}
+}
+
+export async function checkInstalled(pi: Pick<CustomToolAPI, "exec" | "cwd">): Promise<boolean> {
+	const result = await pi.exec("which", ["glab"], { cwd: pi.cwd })
+	return result.code === 0
+}
+
+export async function checkAuth(pi: Pick<CustomToolAPI, "exec" | "cwd">): Promise<boolean> {
+	const result = await pi.exec("glab", ["auth", "status"], { cwd: pi.cwd })
+	return result.code === 0
+}
+
+export async function execGlab(
+	pi: Pick<CustomToolAPI, "exec" | "cwd">,
+	args: string[],
+	signal?: AbortSignal,
+): Promise<ExecResult> {
+	const result = await pi.exec("glab", args, { signal, cwd: pi.cwd })
+	if (result.killed) throw new Error("Command was cancelled")
+	if (result.code !== 0) {
+		const stderr = result.stderr.toLowerCase()
+		if (stderr.includes("auth") || stderr.includes("not logged in") || stderr.includes("token")) {
+			throw new GlabAuthError(result.stderr)
+		}
+		if (stderr.includes("404") || stderr.includes("403") || stderr.includes("not found")) {
+			throw new GlabNotFoundError(result.stderr)
+		}
+		throw new GlabExecError(result.stderr, result.code)
+	}
+	return result
+}
+
+export async function execGlabJson<T = unknown>(
+	pi: Pick<CustomToolAPI, "exec" | "cwd">,
+	args: string[],
+	signal?: AbortSignal,
+): Promise<T> {
+	const result = await execGlab(pi, args, signal)
+	return JSON.parse(result.stdout) as T
+}

--- a/.xcsh/tools/glab/lib/formatters.ts
+++ b/.xcsh/tools/glab/lib/formatters.ts
@@ -1,0 +1,72 @@
+import type { GlabIssue } from "./types"
+
+function formatDate(iso: string): string {
+	return iso.slice(0, 10)
+}
+
+function truncateLabels(labels: string[], maxLen = 30): string {
+	if (!labels.length) return "(none)"
+	const joined = labels.join(", ")
+	if (joined.length <= maxLen) return joined
+	const truncated = labels.slice(0, 3).join(", ")
+	const remaining = labels.length - 3
+	return remaining > 0 ? `${truncated}, +${remaining}` : truncated
+}
+
+export function formatIssueTable(issues: GlabIssue[]): string {
+	if (issues.length === 0) {
+		return "No issues found matching the criteria."
+	}
+
+	const header = "| IID | Title | State | Labels | Assignee | Updated |"
+	const divider = "|-----|-------|-------|--------|----------|---------|"
+
+	const rows = issues.map(issue => {
+		const title = issue.title.length > 50 ? `${issue.title.slice(0, 47)}...` : issue.title
+		const labels = truncateLabels(issue.labels)
+		const assignee = issue.assignees.length > 0 ? `@${issue.assignees[0].username}` : "unassigned"
+		const updated = formatDate(issue.updated_at)
+		return `| ${issue.iid} | ${title} | ${issue.state} | ${labels} | ${assignee} | ${updated} |`
+	})
+
+	return [header, divider, ...rows].join("\n")
+}
+
+export function formatIssueDetail(issue: GlabIssue): string {
+	const lines: string[] = []
+
+	lines.push(`# Issue #${issue.iid}: ${issue.title}`)
+	lines.push("")
+	lines.push(
+		`State: ${issue.state} | Author: @${issue.author.username} | Created: ${formatDate(issue.created_at)} | Updated: ${formatDate(issue.updated_at)}`,
+	)
+
+	if (issue.labels.length > 0) {
+		lines.push(`Labels: ${issue.labels.join(", ")}`)
+	}
+
+	const assigneeStr = issue.assignees.length > 0 ? issue.assignees.map(a => `@${a.username}`).join(", ") : "unassigned"
+	lines.push(`Assignee: ${assigneeStr}${issue.milestone ? ` | Milestone: ${issue.milestone.title}` : ""}`)
+	lines.push("")
+	lines.push("---")
+	lines.push("")
+	lines.push(issue.description || "(no description)")
+
+	const humanNotes = (issue.notes ?? []).filter(n => !n.system)
+	lines.push("")
+	lines.push("---")
+	lines.push("")
+
+	if (humanNotes.length === 0) {
+		lines.push("No comments.")
+	} else {
+		lines.push(`## Comments (${humanNotes.length})`)
+		for (const note of humanNotes) {
+			lines.push("")
+			lines.push(`**@${note.author.username}** (${formatDate(note.created_at)}):`)
+			lines.push("> " + note.body.split("\n").join("\n> "))
+		}
+	}
+
+	return lines.join("\n")
+}

--- a/.xcsh/tools/glab/lib/graphql.ts
+++ b/.xcsh/tools/glab/lib/graphql.ts
@@ -1,0 +1,49 @@
+import type { CustomToolAPI } from "@f5xc-salesdemos/xcsh"
+import { execGlab } from "./exec"
+import type { GraphQLIssueNode, GraphQLSearchResponse } from "./types"
+
+export function buildSearchQuery(): string {
+	return `
+query SearchIssues($projectPath: ID!, $search: String!, $first: Int!) {
+  project(fullPath: $projectPath) {
+    issues(search: $search, first: $first) {
+      nodes {
+        iid
+        title
+        state
+        labels { nodes { title } }
+        assignees { nodes { username } }
+        updatedAt
+        notes(first: 20) {
+          nodes {
+            body
+            author { username }
+            createdAt
+          }
+        }
+      }
+    }
+  }
+}`.trim()
+}
+
+export async function executeGraphQL(
+	pi: Pick<CustomToolAPI, "exec" | "cwd">,
+	projectPath: string,
+	searchText: string,
+	limit: number,
+	signal?: AbortSignal,
+): Promise<GraphQLIssueNode[]> {
+	const query = buildSearchQuery()
+	const variables = JSON.stringify({ projectPath, search: searchText, first: limit })
+
+	const result = await execGlab(pi, ["api", "graphql", "-f", `query=${query}`, "-f", `variables=${variables}`], signal)
+
+	const response = JSON.parse(result.stdout) as GraphQLSearchResponse
+
+	if (response.errors && response.errors.length > 0) {
+		throw new Error(response.errors.map(e => e.message).join("; "))
+	}
+
+	return response.data?.project?.issues?.nodes ?? []
+}

--- a/.xcsh/tools/glab/lib/graphql.ts
+++ b/.xcsh/tools/glab/lib/graphql.ts
@@ -2,11 +2,13 @@ import type { CustomToolAPI } from "@f5xc-salesdemos/xcsh"
 import { execGlab } from "./exec"
 import type { GraphQLIssueNode, GraphQLSearchResponse } from "./types"
 
-export function buildSearchQuery(): string {
+export function buildSearchQuery(includeState: boolean): string {
+	const stateVar = includeState ? ", $state: IssuableState" : ""
+	const stateArg = includeState ? ", state: $state" : ""
 	return `
-query SearchIssues($projectPath: ID!, $search: String!, $first: Int!) {
+query SearchIssues($projectPath: ID!, $search: String!, $first: Int!${stateVar}) {
   project(fullPath: $projectPath) {
-    issues(search: $search, first: $first) {
+    issues(search: $search, first: $first${stateArg}) {
       nodes {
         iid
         title
@@ -33,9 +35,13 @@ export async function executeGraphQL(
 	searchText: string,
 	limit: number,
 	signal?: AbortSignal,
+	state?: string,
 ): Promise<GraphQLIssueNode[]> {
-	const query = buildSearchQuery()
-	const variables = JSON.stringify({ projectPath, search: searchText, first: limit })
+	const includeState = !!state && state !== "all"
+	const query = buildSearchQuery(includeState)
+	const vars: Record<string, unknown> = { projectPath, search: searchText, first: limit }
+	if (includeState) vars.state = state === "closed" ? "closed" : "opened"
+	const variables = JSON.stringify(vars)
 
 	const result = await execGlab(pi, ["api", "graphql", "-f", `query=${query}`, "-f", `variables=${variables}`], signal)
 

--- a/.xcsh/tools/glab/lib/types.ts
+++ b/.xcsh/tools/glab/lib/types.ts
@@ -1,0 +1,86 @@
+// .xcsh/tools/glab/lib/types.ts
+
+export interface GlabLabel {
+	name: string
+	color: string
+}
+
+export interface GlabUser {
+	username: string
+	name: string
+}
+
+export interface GlabMilestone {
+	title: string
+	iid: number
+}
+
+export interface GlabNote {
+	id: number
+	body: string
+	author: GlabUser
+	created_at: string
+	updated_at: string
+	system: boolean
+}
+
+export interface GlabIssue {
+	id: number
+	iid: number
+	title: string
+	description: string
+	state: "opened" | "closed"
+	labels: string[]
+	assignees: GlabUser[]
+	author: GlabUser
+	milestone: GlabMilestone | null
+	created_at: string
+	updated_at: string
+	web_url: string
+	references: { full: string }
+	issue_type: string
+	notes?: GlabNote[]
+}
+
+export interface GlabProject {
+	id: number
+	name: string
+	name_with_namespace: string
+	path_with_namespace: string
+	web_url: string
+	description: string | null
+}
+
+export interface GlabConfig {
+	project: string
+	hostname: string
+	defaultState: "opened" | "closed" | "all"
+	perPage: number
+}
+
+export interface GraphQLIssueNode {
+	iid: string
+	title: string
+	state: string
+	labels: { nodes: Array<{ title: string }> }
+	assignees: { nodes: Array<{ username: string }> }
+	updatedAt: string
+	notes: {
+		nodes: Array<{
+			body: string
+			author: { username: string }
+			createdAt: string
+		}>
+	}
+}
+
+export interface GraphQLSearchResponse {
+	data?: {
+		project?: {
+			issues?: {
+				nodes: GraphQLIssueNode[]
+			}
+		}
+	}
+	errors?: Array<{ message: string }>
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,7 +2136,7 @@ dependencies = [
 
 [[package]]
 name = "pi-natives"
-version = "18.35.3"
+version = "18.36.0"
 dependencies = [
  "arboard",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/brush-core-vendored", "crates/brush-builtins-vendored", "crat
 resolver = "3"
 
 [workspace.package]
-version = "18.35.3"
+version = "18.36.0"
 edition = "2024"
 license = "MIT"
 authors = ["Can Boluk"]

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "packages/agent": {
       "name": "@f5xc-salesdemos/pi-agent-core",
-      "version": "18.35.3",
+      "version": "18.36.0",
       "dependencies": {
         "@f5xc-salesdemos/pi-ai": "workspace:*",
         "@f5xc-salesdemos/pi-utils": "workspace:*",
@@ -27,7 +27,7 @@
     },
     "packages/ai": {
       "name": "@f5xc-salesdemos/pi-ai",
-      "version": "18.35.3",
+      "version": "18.36.0",
       "bin": {
         "pi-ai": "./src/cli.ts",
       },
@@ -51,7 +51,7 @@
     },
     "packages/coding-agent": {
       "name": "@f5xc-salesdemos/xcsh",
-      "version": "18.35.3",
+      "version": "18.36.0",
       "bin": {
         "xcsh": "src/cli.ts",
       },
@@ -83,22 +83,22 @@
     },
     "packages/natives": {
       "name": "@f5xc-salesdemos/pi-natives",
-      "version": "18.35.3",
+      "version": "18.36.0",
       "devDependencies": {
         "@napi-rs/cli": "3.6.0",
         "@types/bun": "^1.3",
       },
       "optionalDependencies": {
-        "@f5xc-salesdemos/pi-natives-darwin-arm64": "18.35.3",
-        "@f5xc-salesdemos/pi-natives-darwin-x64": "18.35.3",
-        "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.35.3",
-        "@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.35.3",
-        "@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.35.3",
+        "@f5xc-salesdemos/pi-natives-darwin-arm64": "18.36.0",
+        "@f5xc-salesdemos/pi-natives-darwin-x64": "18.36.0",
+        "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.36.0",
+        "@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.36.0",
+        "@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.36.0",
       },
     },
     "packages/stats": {
       "name": "@f5xc-salesdemos/xcsh-stats",
-      "version": "18.35.3",
+      "version": "18.36.0",
       "bin": {
         "xcsh-stats": "./src/index.ts",
       },
@@ -123,7 +123,7 @@
     },
     "packages/swarm-extension": {
       "name": "@f5xc-salesdemos/swarm-extension",
-      "version": "18.35.3",
+      "version": "18.36.0",
       "bin": {
         "xcsh-swarm": "src/cli.ts",
       },
@@ -139,7 +139,7 @@
     },
     "packages/tui": {
       "name": "@f5xc-salesdemos/pi-tui",
-      "version": "18.35.3",
+      "version": "18.36.0",
       "dependencies": {
         "@f5xc-salesdemos/pi-natives": "workspace:*",
         "@f5xc-salesdemos/pi-utils": "workspace:*",
@@ -178,7 +178,7 @@
     },
     "packages/utils": {
       "name": "@f5xc-salesdemos/pi-utils",
-      "version": "18.35.3",
+      "version": "18.36.0",
       "dependencies": {
         "beautiful-mermaid": "^1.1",
         "handlebars": "^4.7.9",
@@ -870,7 +870,7 @@
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
-    "fast-xml-builder": ["fast-xml-builder@1.1.5", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA=="],
+    "fast-xml-builder": ["fast-xml-builder@1.1.6", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-exq7uOuwxoIsWZ7wKf9CV4Q0/yEAHxtktYDjCGsGrg+uKnNY/ly04Wkb2npZo5GEwz963yu+PRp+HLJf/qRrpQ=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.7.2", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w=="],
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-agent-core",
-	"version": "18.35.3",
+	"version": "18.36.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-ai",
-	"version": "18.35.3",
+	"version": "18.36.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/xcsh",
-	"version": "18.35.3",
+	"version": "18.36.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-arm64/package.json
+++ b/packages/natives/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-darwin-arm64",
-	"version": "18.35.3",
+	"version": "18.36.0",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (macOS arm64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-x64/package.json
+++ b/packages/natives/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-darwin-x64",
-	"version": "18.35.3",
+	"version": "18.36.0",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (macOS x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-arm64-gnu/package.json
+++ b/packages/natives/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-linux-arm64-gnu",
-	"version": "18.35.3",
+	"version": "18.36.0",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Linux arm64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-x64-gnu/package.json
+++ b/packages/natives/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-linux-x64-gnu",
-	"version": "18.35.3",
+	"version": "18.36.0",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Linux x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/win32-x64-msvc/package.json
+++ b/packages/natives/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-win32-x64-msvc",
-	"version": "18.35.3",
+	"version": "18.36.0",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Windows x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives",
-	"version": "18.35.3",
+	"version": "18.36.0",
 	"description": "Native Rust bindings for grep, clipboard, image processing, syntax highlighting, PTY, and shell operations via N-API",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",
@@ -56,11 +56,11 @@
 		}
 	},
 	"optionalDependencies": {
-		"@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.35.3",
-		"@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.35.3",
-		"@f5xc-salesdemos/pi-natives-darwin-x64": "18.35.3",
-		"@f5xc-salesdemos/pi-natives-darwin-arm64": "18.35.3",
-		"@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.35.3"
+		"@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.36.0",
+		"@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.36.0",
+		"@f5xc-salesdemos/pi-natives-darwin-x64": "18.36.0",
+		"@f5xc-salesdemos/pi-natives-darwin-arm64": "18.36.0",
+		"@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.36.0"
 	},
 	"files": [
 		"native",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/xcsh-stats",
-	"version": "18.35.3",
+	"version": "18.36.0",
 	"description": "Local observability dashboard for pi AI usage statistics",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/swarm-extension/package.json
+++ b/packages/swarm-extension/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/swarm-extension",
-	"version": "18.35.3",
+	"version": "18.36.0",
 	"description": "Swarm orchestration extension for xcsh",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Derek Rynd",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-tui",
-	"version": "18.35.3",
+	"version": "18.36.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-utils",
-	"version": "18.35.3",
+	"version": "18.36.0",
 	"description": "Shared utilities for pi packages",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",


### PR DESCRIPTION
Automated release PR generated by `scripts/release.ts`.

Bumps every public package and the Cargo workspace to `v18.36.0` and updates CHANGELOGs for the releasable commits since the last tag.

Once this PR squash-merges to `main`, `.github/workflows/tag-on-version-bump.yml` pushes the `v18.36.0` git tag, which triggers the downstream release chain (build → sign → publish).

### Releasable commits (12)

- fix(gitlab-skill): use correct glab CLI flags for state and sort/order
- fix(gitlab-skill): pass state filter to GraphQL search query
- feat(gitlab-skill): main tools module with 4 glab tools
- feat(gitlab-skill): graphql module for full-text search including comments
- feat(gitlab-skill): formatters module for issue tables and detail views
- feat(gitlab-skill): exec module with error classification and glab CLI wrappers
- feat(gitlab-skill): config module with loadConfig/saveConfig/resolveProject
- feat(gitlab-skill): add glab TypeScript types and fix gitignore
- feat(gitlab-skill): add GitLab issue tracking via glab CLI (#514)
- perf(xcsh_api): TLS pre-warm, compact JSON, timeout, request ID (#512)
- perf(coding-agent): reduce CRUD execution overhead with system prompt optimizations (#509)
- fix(bash): remove redundant ok badge from collapsed view (#505)

See `docs-control`'s onboarding note "Release automation: release PR pattern" for the governance rationale.