### PR TITLE
fix(xcsh_api): compact re-serialize JSON responses — eliminate server pretty-print inflation

### DIFF
--- a/packages/coding-agent/src/tools/xcsh-api.ts
+++ b/packages/coding-agent/src/tools/xcsh-api.ts
@@ -95,7 +95,9 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 
 		try {
 			const response = await fetch(url, init);
-			const bodyText = await response.text();
+			const raw = await response.text();
+			const contentType = response.headers.get("content-type") ?? "";
+			const bodyText = contentType.includes("application/json") ? JSON.stringify(JSON.parse(raw)) : raw;
 			const statusLine = `${response.status} ${response.statusText}`;
 
 			return {


### PR DESCRIPTION
## What

Compact re-serialize JSON API responses to eliminate whitespace token inflation.

```typescript
// Before (line 98)
const bodyText = await response.text();

// After
const raw = await response.text();
const contentType = response.headers.get("content-type") ?? "";
const bodyText = contentType.includes("application/json") ? JSON.stringify(JSON.parse(raw)) : raw;
```

## Why

The F5 XC API server returns 2-space-indented JSON on all endpoints. `resp.text()` (added in #512) passes this through unchanged — the token inflation that #510 identified as a 41% problem remains unfixed.

| Approach | Tokens | Notes |
|---|---|---|
| Old: `resp.json()` + `JSON.stringify(null,2)` | ~308 | xcsh re-pretty-printed |
| Previous: `resp.text()` | ~326 | server pretty-print passes through |
| **This fix**: `JSON.parse` + `JSON.stringify()` | ~219 | compact, no whitespace |

33% token reduction per JSON response. 0.01ms parse overhead (measured in #520).
Non-JSON responses (errors, plain text) pass through unchanged.

## Testing

- 9/9 existing tests pass
- Benchmark suite: **44/44 pass** (previously 43/44 — `Response not pretty-printed` assertion now passes)
- Verified against live API: response tokens 326 → 221

---

- [x] `bun run check` passes
- [x] All existing tests pass
- [x] Benchmark suite 44/44
- [x] Closes #520