### PR TITLE
fix(gitlab-skill): remove deprecated --opened flag and fix Bun.spawn killed quirk

### DIFF
--- a/packages/coding-agent/src/tools/glab.ts
+++ b/packages/coding-agent/src/tools/glab.ts
@@ -23,12 +23,18 @@ function makeExecApi(cwd: string): GlabExecApi {
 	return {
 		cwd,
 		async exec(command: string, args: string[], options?: { signal?: AbortSignal; cwd?: string }) {
+			// Check abort before spawning, but do NOT pass signal to Bun.spawn.
+			// glab commands complete in <1s — passing the signal causes a race where
+			// xcsh's AbortSignal fires (e.g. on model completion) and kills the child
+			// process before we can read its output.
+			if (options?.signal?.aborted) {
+				return { stdout: "", stderr: "Command was cancelled before starting", code: 1, killed: true };
+			}
 			const child = Bun.spawn([command, ...args], {
 				cwd: options?.cwd ?? cwd,
 				stdin: "ignore",
 				stdout: "pipe",
 				stderr: "pipe",
-				signal: options?.signal,
 			});
 			if (!child.stdout || !child.stderr) {
 				return { stdout: "", stderr: "Failed to capture output", code: 1, killed: false };

--- a/packages/coding-agent/src/tools/glab.ts
+++ b/packages/coding-agent/src/tools/glab.ts
@@ -245,8 +245,7 @@ export class GlabIssueListTool implements AgentTool<typeof glabIssueListSchema, 
 		}
 
 		const args = ["issue", "list", "--output", "json", "--repo", project];
-		if (params.state === "opened") args.push("--opened");
-		else if (params.state === "closed") args.push("--closed");
+		if (params.state === "closed") args.push("--closed");
 		else if (params.state === "all") args.push("--all");
 		if (params.labels?.length) args.push("--label", params.labels.join(","));
 		if (params.assignee) args.push("--assignee", params.assignee);
@@ -351,8 +350,7 @@ export class GlabSearchTool implements AgentTool<typeof glabSearchSchema, GlabTo
 			"--per-page",
 			String(limit),
 		];
-		if (params.state === "opened") restArgs.push("--opened");
-		else if (params.state === "closed") restArgs.push("--closed");
+		if (params.state === "closed") restArgs.push("--closed");
 		else if (params.state === "all") restArgs.push("--all");
 		if (params.labels?.length) restArgs.push("--label", params.labels.join(","));
 

--- a/packages/coding-agent/src/tools/glab/exec.ts
+++ b/packages/coding-agent/src/tools/glab/exec.ts
@@ -46,7 +46,9 @@ export async function checkAuth(pi: GlabExecApi): Promise<boolean> {
 
 export async function execGlab(pi: GlabExecApi, args: string[], signal?: AbortSignal): Promise<GlabExecResult> {
 	const result = await pi.exec("glab", args, { signal, cwd: pi.cwd });
-	if (result.killed) throw new Error("Command was cancelled");
+	// Bun.spawn sets killed=true even on successful exits — only treat as
+	// cancelled when killed AND no stdout was captured (actual signal kill).
+	if (result.killed && !result.stdout && result.code !== 0) throw new Error("Command was cancelled");
 	if (result.code !== 0) {
 		const stderr = result.stderr.toLowerCase();
 		if (stderr.includes("auth") || stderr.includes("not logged in") || stderr.includes("token")) {

--- a/packages/coding-agent/test/glab/exec.test.ts
+++ b/packages/coding-agent/test/glab/exec.test.ts
@@ -69,9 +69,15 @@ describe("execGlab", () => {
 		await expect(execGlab(pi, ["issue", "list"])).rejects.toBeInstanceOf(GlabExecError);
 	});
 
-	it("throws on killed signal", async () => {
-		const pi = makeMockPi({ killed: true, code: 0, stdout: "" });
+	it("throws on killed signal with no output", async () => {
+		const pi = makeMockPi({ killed: true, code: 1, stdout: "" });
 		await expect(execGlab(pi, ["issue", "list"])).rejects.toThrow("cancelled");
+	});
+
+	it("succeeds when killed=true but stdout present (Bun quirk)", async () => {
+		const pi = makeMockPi({ killed: true, code: 0, stdout: '[{"iid":1}]' });
+		const result = await execGlab(pi, ["issue", "list"]);
+		expect(result.stdout).toBe('[{"iid":1}]');
 	});
 });
 


### PR DESCRIPTION
Closes #523

## Summary

Two fixes for glab tool reliability:

1. **Remove deprecated `--opened` flag** — glab 1.93+ deprecates it (open is default). Removes stderr deprecation noise.
2. **Fix `Bun.spawn` killed=true on successful exit** — Bun reports `killed=true` even when a process exits normally with code 0 and stdout captured. The old check `if (result.killed) throw` incorrectly treated every glab call as cancelled. Now only throws when killed AND no stdout AND non-zero exit.

## Test plan

- [x] `bun test packages/coding-agent/test/glab/` — 37 pass (added test for killed+stdout case)
- [x] UAT from source: `glab_issue_list`, `glab_search`, `glab_issue_view` all return data

🤖 Generated with [Claude Code](https://claude.com/claude-code)