### PR TITLE
fix(bash): fix command truncation and backslash continuations in collapsed view

### DIFF
--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -773,9 +773,8 @@ export const bashToolRenderer = {
 				const hasAsyncDetails = details?.async != null;
 				const forceExpand = isError || hasAsyncDetails || hasSixelOutput;
 				if (!verbose && !expanded && !forceExpand) {
-					const rawCmd = args?.command;
-					const summaryText =
-						args?.description ?? (rawCmd && rawCmd.length > 60 ? `${rawCmd.slice(0, 60)}…` : rawCmd) ?? "…";
+					const rawCmd = args?.command?.replace(/\s*\\\n\s*/g, " ");
+					const summaryText = args?.description ?? rawCmd ?? "…";
 
 					if (options.isPartial) {
 						const lineCount = rawOutputLines.filter(l => l.trim().length > 0).length;

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -730,7 +730,12 @@ function getBashVerboseSetting(): boolean {
 
 export const bashToolRenderer = {
 	renderCall(args: BashRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
-		const summaryText = args.description ?? formatBashCommand(args);
+		let summaryText: string | undefined;
+		if (args.description) {
+			summaryText = args.description;
+		} else if (args.command) {
+			summaryText = formatBashCommand(args).replace(/\s*\\\r?\n\s*/g, " ");
+		}
 		const text = renderStatusLine({ icon: "pending", title: "Bash", description: summaryText }, uiTheme);
 		return new Text(text, 0, 0);
 	},
@@ -773,8 +778,8 @@ export const bashToolRenderer = {
 				const hasAsyncDetails = details?.async != null;
 				const forceExpand = isError || hasAsyncDetails || hasSixelOutput;
 				if (!verbose && !expanded && !forceExpand) {
-					const rawCmd = args?.command?.replace(/\s*\\\n\s*/g, " ");
-					const summaryText = args?.description ?? rawCmd ?? "…";
+					const rawCmd = args?.command?.replace(/\s*\\\r?\n\s*/g, " ");
+					const summaryText = args?.description ?? rawCmd ?? undefined;
 
 					if (options.isPartial) {
 						const lineCount = rawOutputLines.filter(l => l.trim().length > 0).length;

--- a/packages/coding-agent/test/tools/bash-renderer.test.ts
+++ b/packages/coding-agent/test/tools/bash-renderer.test.ts
@@ -111,7 +111,8 @@ describe("bash collapsed view (bash.verbose=false)", () => {
 		expect(rendered).not.toContain("Output");
 	});
 
-	it("falls back to truncated command when no description", () => {
+	it("falls back to command when no description, truncating at terminal width not 60 chars", () => {
+		// Command is 91 chars — previously would be cut at 60, now should show more on wide terminal
 		const longCommand =
 			"npm install --save-exact @some-very-long-scoped-package/with-a-really-long-name@1.2.3-beta.4";
 		const result = {
@@ -121,12 +122,29 @@ describe("bash collapsed view (bash.verbose=false)", () => {
 		const component = bashToolRenderer.renderResult(result as never, { expanded: false, isPartial: false }, theme!, {
 			command: longCommand,
 		});
-		const rendered = stripAnsi(component.render(120).join("\n"));
-		expect(rendered).toContain("…");
-		expect(rendered).toContain("npm install");
+		// Render at 200 cols — wide terminal should show full command without 60-char cutoff
+		const rendered = stripAnsi(component.render(200).join("\n"));
+		expect(rendered).toContain("with-a-really-long-name@1.2.3-beta.4");
 		expect(rendered).not.toContain("$ ");
 		expect(rendered).not.toContain("some verbose output");
 		expect(rendered).not.toContain("Output");
+	});
+
+	it("normalizes backslash line continuations in command fallback", () => {
+		const multiLineCommand = "gh pr create \\\n  --repo f5xc-salesdemos/xcsh \\\n  --base main";
+		const result = {
+			content: [{ type: "text", text: "ok\n" }],
+			isError: false,
+		};
+		const component = bashToolRenderer.renderResult(result as never, { expanded: false, isPartial: false }, theme!, {
+			command: multiLineCommand,
+		});
+		const rendered = stripAnsi(component.render(200).join("\n"));
+		// Should be a single line, no literal backslashes or newlines visible
+		expect(rendered).toContain("gh pr create");
+		expect(rendered).toContain("--repo f5xc-salesdemos/xcsh");
+		expect(rendered.split("\n").filter(l => l.includes("gh pr create")).length).toBe(1);
+		expect(rendered).not.toContain("\\");
 	});
 
 	it("auto-expands on error", () => {

--- a/packages/coding-agent/test/tools/bash-renderer.test.ts
+++ b/packages/coding-agent/test/tools/bash-renderer.test.ts
@@ -81,6 +81,15 @@ describe("bash description parameter", () => {
 		const rendered = stripAnsi(component.render(120).join("\n"));
 		expect(rendered).toContain("npm install");
 	});
+
+	it("renderCall shows just 'Bash' when neither description nor command available", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const component = bashToolRenderer.renderCall({}, { expanded: false, isPartial: false }, theme!);
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("Bash");
+		expect(rendered).not.toContain("$");
+		expect(rendered).not.toContain("…");
+	});
 });
 
 describe("bash collapsed view (bash.verbose=false)", () => {


### PR DESCRIPTION
## Summary
- Remove hardcoded 60-char truncation of command text in collapsed Bash view — now uses actual terminal width via `truncateToWidth(line, width)`
- Normalize backslash line continuations (`\\\n`) to spaces so multi-line shell commands display as clean single lines
- Updated tests: wide-terminal test verifies full command visible at 200 cols; new test verifies backslash normalization

Closes #525

## Test plan
- [x] 24 tests pass (bash-renderer + bash-sixel-render)
- [x] TypeScript compiles clean
- [x] Biome clean
- [ ] CI pipeline passes