### PR TITLE
chore: bump version to v18.36.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3556,9 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-swift"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef216011c3e3df4fa864736f347cb8d509b1066cf0c8549fb1fd81ac9832e59"
+checksum = "f3b98fb6bc8e6a6a10023f401aa6a1858115e849dfaf7de57dd8b8ea0f257bd9"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/bun.lock
+++ b/bun.lock
@@ -330,6 +330,16 @@
 
     "@f5xc-salesdemos/pi-natives": ["@f5xc-salesdemos/pi-natives@workspace:packages/natives"],
 
+    "@f5xc-salesdemos/pi-natives-darwin-arm64": ["@f5xc-salesdemos/pi-natives-darwin-arm64@18.36.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9mtmlPHIlBuhQJPmag5MQF6i6gmGYkh2ctiOqn5iWlhxUUUlNLObWN8caHMujEGdFLhVNgGkKE0nc0QpfYF2rg=="],
+
+    "@f5xc-salesdemos/pi-natives-darwin-x64": ["@f5xc-salesdemos/pi-natives-darwin-x64@18.36.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-7678DzDuXr64NC2VBxnok43JRgSJq8Z64aJgnyB1uLeh7RAym9+DAe50HcxgYr/jZM7tsPDaMnBNJqcpsDxboQ=="],
+
+    "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": ["@f5xc-salesdemos/pi-natives-linux-arm64-gnu@18.36.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-b3u8unnw0tt93DT84VKfVr3icraGI/nFLUthPdTd18AaBb6ajzasz02E+kPm0ceQM56uuMMNVRLu9fuRZ+BYhQ=="],
+
+    "@f5xc-salesdemos/pi-natives-linux-x64-gnu": ["@f5xc-salesdemos/pi-natives-linux-x64-gnu@18.36.1", "", { "os": "linux", "cpu": "x64" }, "sha512-GqJIlAOtjWaCwP2OTOv3nmvXxCAeq9JTRevqcnWDQzcoOXIP7+8tUlRXH4Zuc05zbfvJ2i4t4yIT2kngN56bvg=="],
+
+    "@f5xc-salesdemos/pi-natives-win32-x64-msvc": ["@f5xc-salesdemos/pi-natives-win32-x64-msvc@18.36.1", "", { "os": "win32", "cpu": "x64" }, "sha512-7qIuOTIhu1jvi3iiUlidOg9J47x9/1bULWwRv5ByNiLx5oreCzn1peyejg4BpSnYBaJt1Qc8LIlTzR5C18gxJA=="],
+
     "@f5xc-salesdemos/pi-tui": ["@f5xc-salesdemos/pi-tui@workspace:packages/tui"],
 
     "@f5xc-salesdemos/pi-utils": ["@f5xc-salesdemos/pi-utils@workspace:packages/utils"],
@@ -870,7 +880,7 @@
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
-    "fast-xml-builder": ["fast-xml-builder@1.1.6", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-exq7uOuwxoIsWZ7wKf9CV4Q0/yEAHxtktYDjCGsGrg+uKnNY/ly04Wkb2npZo5GEwz963yu+PRp+HLJf/qRrpQ=="],
+    "fast-xml-builder": ["fast-xml-builder@1.1.7", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.7.2", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w=="],
 


### PR DESCRIPTION
Automated release PR generated by `scripts/release.ts`.

Bumps every public package and the Cargo workspace to `v18.36.1` and updates CHANGELOGs for the releasable commits since the last tag.

Once this PR squash-merges to `main`, `.github/workflows/tag-on-version-bump.yml` pushes the `v18.36.1` git tag, which triggers the downstream release chain (build → sign → publish).

### Releasable commits (3)

- fix(gitlab-skill): remove deprecated --opened flag and fix Bun.spawn killed quirk (#524)
- fix(bash): fix command truncation and backslash continuations in collapsed view (#526)
- fix(xcsh_api): compact re-serialize JSON responses to eliminate server pretty-printing inflation (#522)

See `docs-control`'s onboarding note "Release automation: release PR pattern" for the governance rationale.