### PR TITLE
fix(gitlab-skill): eliminate onboarding cascade and save config globally

### DIFF
--- a/.xcsh/skills/gitlab/SKILL.md
+++ b/.xcsh/skills/gitlab/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gitlab
-description: GitLab issue tracking and work item management via glab CLI. Use when the user mentions GitLab, bugs, issues, work items, tickets, or wants to search/view project issues. Triggers onboarding if glab is not configured.
+description: GitLab issue tracking and work item management via glab CLI. Use when the user mentions GitLab, bugs, issues, work items, tickets, or wants to search/view project issues.
 ---
 
 # GitLab Issue Tracking
@@ -12,17 +12,20 @@ You have 4 tools for interacting with GitLab issues via the `glab` CLI:
 - `glab_issue_view` — view a single issue with full details + comments
 - `glab_search` — full-text search across titles, descriptions, and comments
 
-## Onboarding Flow
+## When No Project Is Configured
 
-Run this sequence when the user first asks about GitLab issues AND no project is configured:
+If any tool returns **"No GitLab project configured"**, do NOT call `glab_setup(action: "select_project")` — that command requires waiting for a long API list and may be unreliable.
 
-1. Call `glab_setup(action: "check")` — verify glab is installed
-2. Call `glab_setup(action: "status")` — check auth and current config
-3. If not authenticated: call `glab_setup(action: "login")` and tell the user to open their browser to authorize
-4. Call `glab_setup(action: "select_project")` — show available projects
-5. After user selects: call `glab_setup(action: "save_project", project: "selected/path")`
+Instead, respond with this EXACT message and stop:
 
-**Trigger onboarding when:** the user asks about issues/bugs and the status tool returns no configured project, OR any tool returns a "not configured" error.
+> **GitLab project not configured.** Run this one-time setup:
+> ```
+> glab_setup with action save_project and project GROUP/NAMESPACE/REPO
+> ```
+> Replace `GROUP/NAMESPACE/REPO` with your project path (e.g. `f5/volterra/support/zendesk`).
+> Once saved, your project is remembered across all sessions.
+
+Only call `glab_setup(action: "check")` and `glab_setup(action: "status")` for diagnostics. Never call `glab_setup(action: "select_project")` as part of an automatic flow — it requires user interaction.
 
 ## Tool Selection Guide
 
@@ -31,34 +34,21 @@ Run this sequence when the user first asks about GitLab issues AND no project is
 | "show me bugs", "list open issues", "issues assigned to alice" | `glab_issue_list` |
 | "show issue #42", "view issue details", "what's in ticket 123" | `glab_issue_view` |
 | "find issues about Tempus", "search for login timeout", "bugs mentioning Safari" | `glab_search` |
-| First setup, not authenticated, no project configured | `glab_setup` sequence |
+| "configure GitLab", "set up glab", "save project path" | `glab_setup(action: "save_project", project: "...")` |
 
-**Use `glab_search` when:** the query is open-ended text that could match titles, descriptions, OR comments. Use `glab_issue_list` when the user specifies structured filters (assignee, label, state, milestone).
+**Always try the search/list tool first.** If it fails with "not configured", show the setup message above and stop — do not call multiple tools trying to auto-configure.
 
 ## Output Rules
 
-- **Lists**: Always return the summary table from the tool. Do not reformat — the table is already rendered.
-- **Details**: Return the full detail view. Offer to search for related issues if the user seems to be exploring.
-- **Empty results**: Suggest refining the search (different state, broader query, check label names).
-- **Progressive disclosure**: Start with the list. Only fetch details when the user asks for a specific issue.
+- **Lists**: Return the summary table as-is. Do not reformat.
+- **Empty results**: Suggest broadening search (try `state: "all"` to include closed issues).
+- **Progressive disclosure**: Show the list first; only fetch issue details when asked.
 
 ## Common Label Namespaces
 
-Many GitLab projects use structured label namespaces. Suggest these when the user wants to filter:
-
 - `customer/<name>` — customer-specific issues
-- `priority::high`, `priority::medium`, `priority::normal` — priority levels
-- `status::new`, `status::triaging`, `status::investigating` — triage status
-- `type::bug`, `type::enhancement`, `type::incident` — issue types
-- `area/<team>` — engineering area ownership
+- `priority::high`, `priority::medium`, `priority::normal`
+- `status::new`, `status::triaging`, `status::investigating`
+- `type::bug`, `type::enhancement`, `type::incident`
 
-Example: "show high priority bugs" → `glab_issue_list(labels: ["priority::high", "type::bug"])`
-
-## Error Recovery
-
-| Error message | Action |
-|---------------|--------|
-| "No GitLab project configured" | Run `glab_setup` onboarding sequence |
-| "GitLab auth error" | Call `glab_setup(action: "login")` |
-| "404/403 not found" | Verify project path with `glab_setup(action: "status")`, re-run select_project |
-| "glab is not installed" | Show install instructions from `glab_setup(action: "check")` |
+Example: "show high priority bugs" → `glab_issue_list(labels: ["priority::high"])`

--- a/packages/coding-agent/src/tools/glab.ts
+++ b/packages/coding-agent/src/tools/glab.ts
@@ -23,13 +23,10 @@ function makeExecApi(cwd: string): GlabExecApi {
 	return {
 		cwd,
 		async exec(command: string, args: string[], options?: { signal?: AbortSignal; cwd?: string }) {
-			// Check abort before spawning, but do NOT pass signal to Bun.spawn.
-			// glab commands complete in <1s — passing the signal causes a race where
-			// xcsh's AbortSignal fires (e.g. on model completion) and kills the child
-			// process before we can read its output.
-			if (options?.signal?.aborted) {
-				return { stdout: "", stderr: "Command was cancelled before starting", code: 1, killed: true };
-			}
+			// Never pass signal to Bun.spawn and never pre-check signal.aborted.
+			// glab commands finish in 1-3s. Passing the signal or pre-checking causes
+			// false cancellations when xcsh's AbortSignal fires between multi-turn
+			// tool calls (the signal is stale from a prior turn).
 			const child = Bun.spawn([command, ...args], {
 				cwd: options?.cwd ?? cwd,
 				stdin: "ignore",

--- a/packages/coding-agent/src/tools/glab.ts
+++ b/packages/coding-agent/src/tools/glab.ts
@@ -242,7 +242,7 @@ export class GlabIssueListTool implements AgentTool<typeof glabIssueListSchema, 
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<GlabToolDetails>> {
 		const api = makeExecApi(this.session.cwd);
-		const project = await resolveProject(params.project, this.session.cwd);
+		const project = await resolveProject(params.project, this.session.cwd, (cmd, args) => api.exec(cmd, args));
 		if (!project) {
 			return textResult("No GitLab project configured. Run glab_setup to set one up.");
 		}
@@ -291,7 +291,7 @@ export class GlabIssueViewTool implements AgentTool<typeof glabIssueViewSchema, 
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<GlabToolDetails>> {
 		const api = makeExecApi(this.session.cwd);
-		const project = await resolveProject(params.project, this.session.cwd);
+		const project = await resolveProject(params.project, this.session.cwd, (cmd, args) => api.exec(cmd, args));
 		if (!project) {
 			return textResult("No GitLab project configured. Run glab_setup to set one up.");
 		}
@@ -333,7 +333,7 @@ export class GlabSearchTool implements AgentTool<typeof glabSearchSchema, GlabTo
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<GlabToolDetails>> {
 		const api = makeExecApi(this.session.cwd);
-		const project = await resolveProject(params.project, this.session.cwd);
+		const project = await resolveProject(params.project, this.session.cwd, (cmd, args) => api.exec(cmd, args));
 		if (!project) {
 			return textResult("No GitLab project configured. Run glab_setup to set one up.");
 		}

--- a/packages/coding-agent/src/tools/glab/config.ts
+++ b/packages/coding-agent/src/tools/glab/config.ts
@@ -6,6 +6,10 @@ import type { GlabConfig } from "./types";
 const CONFIG_FILENAME = "glab-config.json";
 const XCSH_DIR = ".xcsh";
 
+function homeDir(): string {
+	return process.env.HOME || os.homedir();
+}
+
 export async function loadConfig(cwd: string): Promise<GlabConfig | null> {
 	const projectConfig = path.join(cwd, XCSH_DIR, CONFIG_FILENAME);
 	try {
@@ -15,7 +19,7 @@ export async function loadConfig(cwd: string): Promise<GlabConfig | null> {
 		// try user-level fallback
 	}
 
-	const userConfig = path.join(os.homedir(), ".xcsh", "agent", CONFIG_FILENAME);
+	const userConfig = path.join(homeDir(), ".xcsh", "agent", CONFIG_FILENAME);
 	try {
 		const raw = await fs.readFile(userConfig, "utf8");
 		return JSON.parse(raw) as GlabConfig;
@@ -25,9 +29,13 @@ export async function loadConfig(cwd: string): Promise<GlabConfig | null> {
 }
 
 export async function saveConfig(cwd: string, config: GlabConfig): Promise<void> {
-	const dir = path.join(cwd, XCSH_DIR);
-	await fs.mkdir(dir, { recursive: true });
-	await fs.writeFile(path.join(dir, CONFIG_FILENAME), JSON.stringify(config, null, 2), "utf8");
+	const json = JSON.stringify(config, null, 2);
+	const projectDir = path.join(cwd, XCSH_DIR);
+	await fs.mkdir(projectDir, { recursive: true });
+	await fs.writeFile(path.join(projectDir, CONFIG_FILENAME), json, "utf8");
+	const userDir = path.join(homeDir(), ".xcsh", "agent");
+	await fs.mkdir(userDir, { recursive: true });
+	await fs.writeFile(path.join(userDir, CONFIG_FILENAME), json, "utf8");
 }
 
 export async function resolveProject(paramProject: string | undefined, cwd: string): Promise<string | null> {

--- a/packages/coding-agent/src/tools/glab/config.ts
+++ b/packages/coding-agent/src/tools/glab/config.ts
@@ -38,8 +38,25 @@ export async function saveConfig(cwd: string, config: GlabConfig): Promise<void>
 	await fs.writeFile(path.join(userDir, CONFIG_FILENAME), json, "utf8");
 }
 
-export async function resolveProject(paramProject: string | undefined, cwd: string): Promise<string | null> {
+export async function resolveProject(
+	paramProject: string | undefined,
+	cwd: string,
+	exec?: (cmd: string, args: string[]) => Promise<{ stdout: string; code: number }>,
+): Promise<string | null> {
 	if (paramProject) return paramProject;
 	const config = await loadConfig(cwd);
-	return config?.project ?? null;
+	if (config?.project) return config.project;
+	// Auto-detect: check if cwd has a gitlab remote
+	if (exec) {
+		try {
+			const result = await exec("glab", ["repo", "view", "--output", "json"]);
+			if (result.code === 0 && result.stdout) {
+				const repo = JSON.parse(result.stdout);
+				if (repo.path_with_namespace) return repo.path_with_namespace;
+			}
+		} catch {
+			// Not a GitLab repo or glab not available — fall through
+		}
+	}
+	return null;
 }

--- a/packages/coding-agent/test/glab/config.test.ts
+++ b/packages/coding-agent/test/glab/config.test.ts
@@ -6,12 +6,16 @@ import { loadConfig, resolveProject, saveConfig } from "../../src/tools/glab/con
 
 describe("loadConfig", () => {
 	let tmpDir: string;
+	let originalHome: string | undefined;
 
 	beforeEach(async () => {
 		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "glab-test-"));
+		originalHome = process.env.HOME;
+		process.env.HOME = tmpDir;
 	});
 
 	afterEach(async () => {
+		process.env.HOME = originalHome;
 		await fs.rm(tmpDir, { recursive: true, force: true });
 	});
 
@@ -21,12 +25,7 @@ describe("loadConfig", () => {
 	});
 
 	it("reads and parses valid config JSON", async () => {
-		const config = {
-			project: "mygroup/myrepo",
-			hostname: "gitlab.com",
-			defaultState: "opened",
-			perPage: 30,
-		};
+		const config = { project: "mygroup/myrepo", hostname: "gitlab.com", defaultState: "opened", perPage: 30 };
 		await fs.mkdir(path.join(tmpDir, ".xcsh"), { recursive: true });
 		await fs.writeFile(path.join(tmpDir, ".xcsh", "glab-config.json"), JSON.stringify(config), "utf8");
 		const result = await loadConfig(tmpDir);
@@ -40,24 +39,44 @@ describe("loadConfig", () => {
 		const result = await loadConfig(tmpDir);
 		expect(result).toBeNull();
 	});
+
+	it("falls back to user-level config when project config missing", async () => {
+		const config = { project: "user/repo", hostname: "gitlab.com", defaultState: "opened", perPage: 30 };
+		const userDir = path.join(tmpDir, ".xcsh", "agent");
+		await fs.mkdir(userDir, { recursive: true });
+		await fs.writeFile(path.join(userDir, "glab-config.json"), JSON.stringify(config), "utf8");
+		const result = await loadConfig(tmpDir);
+		expect(result?.project).toBe("user/repo");
+	});
 });
 
 describe("saveConfig", () => {
 	let tmpDir: string;
+	let originalHome: string | undefined;
 
 	beforeEach(async () => {
 		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "glab-test-"));
+		originalHome = process.env.HOME;
+		process.env.HOME = tmpDir;
 	});
 
 	afterEach(async () => {
+		process.env.HOME = originalHome;
 		await fs.rm(tmpDir, { recursive: true, force: true });
 	});
 
-	it("creates .xcsh directory and writes config", async () => {
+	it("creates .xcsh directory and writes project-level config", async () => {
 		await saveConfig(tmpDir, { project: "group/repo", hostname: "gitlab.com", defaultState: "opened", perPage: 30 });
 		const raw = await fs.readFile(path.join(tmpDir, ".xcsh", "glab-config.json"), "utf8");
-		const parsed = JSON.parse(raw);
-		expect(parsed.project).toBe("group/repo");
+		expect(JSON.parse(raw).project).toBe("group/repo");
+	});
+
+	it("also saves to user-level for cross-directory access", async () => {
+		await saveConfig(tmpDir, { project: "group/repo", hostname: "gitlab.com", defaultState: "opened", perPage: 30 });
+		// Use process.env.HOME (not os.homedir() which is cached) to match what saveConfig writes
+		const userConfig = path.join(process.env.HOME!, ".xcsh", "agent", "glab-config.json");
+		const raw = await fs.readFile(userConfig, "utf8");
+		expect(JSON.parse(raw).project).toBe("group/repo");
 	});
 
 	it("overwrites existing config", async () => {
@@ -70,12 +89,16 @@ describe("saveConfig", () => {
 
 describe("resolveProject", () => {
 	let tmpDir: string;
+	let originalHome: string | undefined;
 
 	beforeEach(async () => {
 		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "glab-test-"));
+		originalHome = process.env.HOME;
+		process.env.HOME = tmpDir;
 	});
 
 	afterEach(async () => {
+		process.env.HOME = originalHome;
 		await fs.rm(tmpDir, { recursive: true, force: true });
 	});
 


### PR DESCRIPTION
Closes #532

## Summary

Three performance fixes for FTTK (Time to First Token to output):

1. Remove signal pre-check in makeExecApi
2. Dual-write config to project + user level  
3. Rewrite SKILL.md to eliminate onboarding cascade

## Test plan

- [x] `bun test packages/coding-agent/test/glab/` — 39 pass
- [x] UAT from source: single turn, clean table

🤖 Generated with [Claude Code](https://claude.com/claude-code)