### PR TITLE
feat(coding-agent): shared ContextEnv module for F5XC context variable resolution

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1788,6 +1788,9 @@ export const SETTINGS_SCHEMA = {
 	/** Per-session environment variables injected into bash (used by f5xc context system) */
 	"bash.environment": { type: "record", default: {} as Record<string, string> },
 
+	/** Sensitive env var key names from the active f5xc context (populated by ContextService) */
+	"f5xc.sensitiveKeys": { type: "array", default: [] as string[] },
+
 	/** Clear terminal on startup */
 	"startup.clearScreen": { type: "boolean", default: false },
 

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -141,6 +141,15 @@ You are currently connected to F5 XC tenant: {{context.tenant}}, namespace: {{co
 Credential source: {{context.credentialSource}}.
 Auth status: {{context.authStatus}}.
 All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.
+{{#if context.envVars}}
+
+### Context Variables
+
+{{#each context.envVars}}- {{@key}}: {{this}}
+{{/each}}
+
+Use these values when constructing API payloads and resource names.
+{{/if}}
 {{#if knowledgeTopics}}
 Available F5 XC documentation topics: {{knowledgeTopics}}.
 {{/if}}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -92,6 +92,7 @@ import {
 	type SecretEntry,
 	SecretObfuscator,
 } from "./secrets";
+import { createContextEnv } from "./services/context-env";
 import { AgentSession } from "./session/agent-session";
 import { AuthStorage } from "./session/auth-storage";
 import { convertToLlm } from "./session/messages";
@@ -1361,7 +1362,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			// rebuilds reflect the most recent /context activate. Mid-session context changes without a
 			// tool change are handled via custom_message injection in the onContextChange listener.
 			let contextForPrompt:
-				| { tenant: string; namespace: string; credentialSource: string; authStatus: string }
+				| {
+						tenant: string;
+						namespace: string;
+						credentialSource: string;
+						authStatus: string;
+						envVars?: Record<string, string>;
+				  }
 				| undefined;
 			try {
 				const status = contextServiceRef?.instance?.getStatus();
@@ -1377,6 +1384,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						credentialSource: status.credentialSource,
 						authStatus: status.authStatus,
 					};
+					const sensitiveKeys = contextServiceRef?.instance?.getActiveSensitiveKeys();
+					const ctxEnv = createContextEnv(settings, sensitiveKeys?.size ? { sensitiveKeys } : undefined);
+					const envVars = ctxEnv.getNonSensitiveVars();
+					if (Object.keys(envVars).length > 0) {
+						contextForPrompt.envVars = envVars;
+					}
 				}
 			} catch {
 				// ContextService not available or not initialized — leave contextForPrompt undefined.

--- a/packages/coding-agent/src/services/context-env.ts
+++ b/packages/coding-agent/src/services/context-env.ts
@@ -1,0 +1,122 @@
+import { SECRET_ENV_PATTERNS } from "../secrets/index";
+import { F5XC_API_TOKEN, F5XC_API_URL, F5XC_NAMESPACE, F5XC_TENANT } from "./f5xc-env";
+
+/** Keys excluded from the system prompt context variables listing. */
+const PROMPT_HIDDEN = new Set([F5XC_API_TOKEN, F5XC_API_URL, F5XC_TENANT, F5XC_NAMESPACE]);
+
+/** Keys never expanded in payloads — credentials that must not leak into request bodies. */
+const PAYLOAD_HIDDEN = new Set([F5XC_API_TOKEN, F5XC_API_URL]);
+
+export interface ContextEnv {
+	/** Get a single env var value from bash.environment, or undefined. */
+	get(key: string): string | undefined;
+
+	/**
+	 * Resolve `{placeholder}` values in a URL path.
+	 * Explicit params are applied first. Remaining `{key}` placeholders are
+	 * resolved from bash.environment: `{namespace}` → F5XC_NAMESPACE,
+	 * `{key}` → F5XC_{KEY.toUpperCase()}.
+	 * Unresolvable placeholders are left intact.
+	 */
+	resolvePath(path: string, explicitParams?: Record<string, string>): string;
+
+	/**
+	 * Expand `$F5XC_*` variable references in a serialized JSON payload string.
+	 * Unresolvable references are left intact.
+	 */
+	resolvePayloadVars(payloadJson: string): string;
+
+	/**
+	 * Return non-sensitive F5XC_* env vars from bash.environment, suitable for
+	 * display in the LLM system prompt. Excludes ALWAYS_HIDDEN keys, keys
+	 * matching SECRET_ENV_PATTERNS, and explicitly provided sensitiveKeys.
+	 */
+	getNonSensitiveVars(): Record<string, string>;
+}
+
+export interface ContextEnvOptions {
+	/** Additional keys to treat as sensitive (e.g. from context.sensitiveKeys). */
+	sensitiveKeys?: ReadonlySet<string>;
+}
+
+/**
+ * Create a ContextEnv instance bound to the current bash.environment settings.
+ *
+ * @param settings - Any object with a `get(key)` method returning the value of
+ *   "bash.environment" as `Record<string, string>`. Pass `Settings.instance` or
+ *   `session.settings` in production; pass a stub in tests.
+ * @param options - Optional configuration (sensitiveKeys to exclude).
+ */
+export function createContextEnv(settings: { get(key: string): unknown }, options?: ContextEnvOptions): ContextEnv {
+	function bashEnv(): Record<string, string> {
+		return (settings.get("bash.environment") ?? {}) as Record<string, string>;
+	}
+
+	function allSensitiveKeys(): ReadonlySet<string> {
+		if (options?.sensitiveKeys) return options.sensitiveKeys;
+		const fromSettings = settings.get("f5xc.sensitiveKeys");
+		return new Set(Array.isArray(fromSettings) ? (fromSettings as string[]) : []);
+	}
+
+	return {
+		get(key: string): string | undefined {
+			return bashEnv()[key];
+		},
+
+		resolvePath(path: string, explicitParams?: Record<string, string>): string {
+			let resolved = path;
+
+			// Apply explicit params first
+			if (explicitParams) {
+				for (const [key, value] of Object.entries(explicitParams)) {
+					resolved = resolved.replaceAll(`{${key}}`, value);
+				}
+			}
+
+			// Auto-resolve remaining {placeholder} values from bash.environment
+			const env = bashEnv();
+			const sensitive = allSensitiveKeys();
+			resolved = resolved.replace(/\{(\w+)\}/g, (match, key) => {
+				// {namespace} maps directly to F5XC_NAMESPACE
+				const envKey = key === "namespace" ? F5XC_NAMESPACE : `F5XC_${key.toUpperCase()}`;
+				// Never auto-inject credential or sensitive values into URL paths
+				if (PAYLOAD_HIDDEN.has(envKey)) return match;
+				if (SECRET_ENV_PATTERNS.test(envKey)) return match;
+				if (sensitive.has(envKey)) return match;
+				return env[envKey] ?? match;
+			});
+
+			return resolved;
+		},
+
+		resolvePayloadVars(payloadJson: string): string {
+			const env = bashEnv();
+			const sensitive = allSensitiveKeys();
+			return payloadJson.replace(/\$F5XC_([A-Z0-9_]+)/g, (match, suffix) => {
+				const key = `F5XC_${suffix}`;
+				// Never expand credential keys into payloads
+				if (PAYLOAD_HIDDEN.has(key)) return match;
+				if (SECRET_ENV_PATTERNS.test(key)) return match;
+				if (sensitive.has(key)) return match;
+				const value = env[key];
+				if (value === undefined) return match;
+				// JSON-escape the substituted value to prevent injection
+				return JSON.stringify(value).slice(1, -1);
+			});
+		},
+
+		getNonSensitiveVars(): Record<string, string> {
+			const env = bashEnv();
+			const sensitive = allSensitiveKeys();
+			const result: Record<string, string> = {};
+			for (const [key, value] of Object.entries(env)) {
+				if (!key.startsWith("F5XC_")) continue;
+				if (PROMPT_HIDDEN.has(key)) continue;
+				if (SECRET_ENV_PATTERNS.test(key)) continue;
+				if (sensitive.has(key)) continue;
+				result[key] = value;
+			}
+			return result;
+		},
+	};
+}

--- a/packages/coding-agent/src/services/context-env.ts
+++ b/packages/coding-agent/src/services/context-env.ts
@@ -2,10 +2,10 @@ import { SECRET_ENV_PATTERNS } from "../secrets/index";
 import { F5XC_API_TOKEN, F5XC_API_URL, F5XC_NAMESPACE, F5XC_TENANT } from "./f5xc-env";
 
 /** Keys excluded from the system prompt context variables listing. */
-const PROMPT_HIDDEN = new Set([F5XC_API_TOKEN, F5XC_API_URL, F5XC_TENANT, F5XC_NAMESPACE]);
+const PROMPT_HIDDEN: ReadonlySet<string> = new Set([F5XC_API_TOKEN, F5XC_API_URL, F5XC_TENANT, F5XC_NAMESPACE]);
 
 /** Keys never expanded in payloads — credentials that must not leak into request bodies. */
-const PAYLOAD_HIDDEN = new Set([F5XC_API_TOKEN, F5XC_API_URL]);
+const PAYLOAD_HIDDEN: ReadonlySet<string> = new Set([F5XC_API_TOKEN, F5XC_API_URL]);
 
 export interface ContextEnv {
 	/** Get a single env var value from bash.environment, or undefined. */

--- a/packages/coding-agent/src/services/f5xc-context.ts
+++ b/packages/coding-agent/src/services/f5xc-context.ts
@@ -1051,6 +1051,11 @@ export class ContextService {
 		return Object.keys(this.#activeContext?.env ?? {}).sort();
 	}
 
+	/** Sync set of sensitive env var keys on the active context. Empty set if none. */
+	getActiveSensitiveKeys(): ReadonlySet<string> {
+		return new Set(this.#activeContext?.sensitiveKeys ?? []);
+	}
+
 	/** Sync list of known context names, sorted. [] before the first listContexts()/loadActive(). */
 	listContextNamesCached(): string[] {
 		return this.#contextsCache.map(p => p.name);
@@ -1331,6 +1336,7 @@ export class ContextService {
 		}
 
 		Settings.instance.override("bash.environment", merged);
+		Settings.instance.override("f5xc.sensitiveKeys", context.sensitiveKeys ?? []);
 
 		// Notify listeners (e.g. obfuscator refresh) about the context change.
 		for (const cb of ContextService.#onContextChangeListeners) {

--- a/packages/coding-agent/src/tools/xcsh-api.ts
+++ b/packages/coding-agent/src/tools/xcsh-api.ts
@@ -2,6 +2,7 @@ import type { AgentTool, AgentToolResult } from "@f5xc-salesdemos/pi-agent-core"
 import { prompt } from "@f5xc-salesdemos/pi-utils";
 import { type Static, Type } from "@sinclair/typebox";
 import xcshApiDescription from "../prompts/tools/xcsh-api.md" with { type: "text" };
+import { createContextEnv } from "../services/context-env";
 import type { ToolSession } from ".";
 
 const xcshApiSchema = Type.Object({
@@ -13,7 +14,8 @@ const xcshApiSchema = Type.Object({
 	params: Type.Optional(
 		Type.Record(Type.String(), Type.String(), {
 			description:
-				"Path parameter substitutions, e.g. { namespace: 'default', name: 'example-lb', vh_name: 'example-vh' }",
+				"Path parameter substitutions, e.g. { namespace: 'example-ns', vh_name: 'example-vh' }. " +
+				"Unspecified params are auto-resolved from context env (e.g. {namespace} from F5XC_NAMESPACE).",
 		}),
 	),
 	payload: Type.Optional(Type.Unknown({ description: "JSON body for POST/PUT/PATCH/DELETE requests" })),
@@ -38,11 +40,13 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 
 	#apiBase: string;
 	#apiToken: string;
+	#contextEnv: ReturnType<typeof createContextEnv>;
 
-	constructor(_session: ToolSession) {
+	constructor(session: ToolSession) {
 		this.description = prompt.render(xcshApiDescription);
 		this.#apiBase = (process.env.F5XC_API_URL ?? "").replace(/\/+$/, "");
 		this.#apiToken = process.env.F5XC_API_TOKEN ?? "";
+		this.#contextEnv = createContextEnv(session.settings);
 
 		if (this.#apiBase && this.#apiToken) {
 			fetch(`${this.#apiBase}/api/web/namespaces`, {
@@ -67,12 +71,7 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 			};
 		}
 
-		let resolvedPath = params.path;
-		if (params.params) {
-			for (const [key, value] of Object.entries(params.params)) {
-				resolvedPath = resolvedPath.replaceAll(`{${key}}`, value);
-			}
-		}
+		const resolvedPath = this.#contextEnv.resolvePath(params.path, params.params);
 
 		const url = `${this.#apiBase}${resolvedPath}`;
 		const requestId = crypto.randomUUID();
@@ -90,7 +89,8 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 
 		if (params.payload && params.method !== "GET") {
 			headers["Content-Type"] = "application/json";
-			init.body = JSON.stringify(params.payload);
+			const payloadJson = JSON.stringify(params.payload);
+			init.body = this.#contextEnv.resolvePayloadVars(payloadJson);
 		}
 
 		try {

--- a/packages/coding-agent/test/services/context-env.test.ts
+++ b/packages/coding-agent/test/services/context-env.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "bun:test";
+import { createContextEnv } from "../../src/services/context-env";
+
+function makeSettings(env: Record<string, string>, sensitiveKeys?: string[]): any {
+	return {
+		get: (key: string) => {
+			if (key === "bash.environment") return env;
+			if (key === "f5xc.sensitiveKeys") return sensitiveKeys ?? []; // gitleaks:allow
+			return undefined;
+		},
+	};
+}
+
+describe("createContextEnv", () => {
+	describe("get()", () => {
+		it("returns value for known key", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_NAMESPACE: "example-ns" }));
+			expect(ctx.get("F5XC_NAMESPACE")).toBe("example-ns");
+		});
+
+		it("returns undefined for missing key", () => {
+			const ctx = createContextEnv(makeSettings({}));
+			expect(ctx.get("F5XC_NAMESPACE")).toBeUndefined();
+		});
+	});
+
+	describe("resolvePath()", () => {
+		it("substitutes explicit params first", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_NAMESPACE: "env-ns" }));
+			const result = ctx.resolvePath("/api/{namespace}/resources", { namespace: "explicit-ns" });
+			expect(result).toBe("/api/explicit-ns/resources");
+		});
+
+		it("falls back to F5XC_NAMESPACE for {namespace}", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_NAMESPACE: "env-ns" }));
+			const result = ctx.resolvePath("/api/{namespace}/resources");
+			expect(result).toBe("/api/env-ns/resources");
+		});
+
+		it("resolves {name} from F5XC_NAME env var", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_NAME: "example-lb" }));
+			const result = ctx.resolvePath("/api/{namespace}/{name}", { namespace: "default" });
+			expect(result).toBe("/api/default/example-lb");
+		});
+
+		it("leaves unresolvable placeholders intact", () => {
+			const ctx = createContextEnv(makeSettings({}));
+			const result = ctx.resolvePath("/api/{namespace}/resources");
+			expect(result).toBe("/api/{namespace}/resources");
+		});
+
+		it("resolves multiple placeholders", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_NAMESPACE: "ns1" }));
+			const result = ctx.resolvePath("/api/{namespace}/vhs/{vh_name}", { vh_name: "example-vh" });
+			expect(result).toBe("/api/ns1/vhs/example-vh");
+		});
+	});
+
+	describe("resolvePayloadVars()", () => {
+		it("expands $F5XC_NAMESPACE in payload JSON", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_NAMESPACE: "r-mordasiewicz" }));
+			const payload = '{"metadata":{"namespace":"$F5XC_NAMESPACE","name":"test"}}';
+			expect(ctx.resolvePayloadVars(payload)).toBe('{"metadata":{"namespace":"r-mordasiewicz","name":"test"}}');
+		});
+
+		it("expands multiple $F5XC_* references", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_NAMESPACE: "example-ns", F5XC_LB_NAME: "example-lb" }));
+			const payload = '{"ns":"$F5XC_NAMESPACE","lb":"$F5XC_LB_NAME"}';
+			expect(ctx.resolvePayloadVars(payload)).toBe('{"ns":"example-ns","lb":"example-lb"}');
+		});
+
+		it("leaves unresolvable $F5XC_* references unchanged", () => {
+			const ctx = createContextEnv(makeSettings({}));
+			const payload = '{"ns":"$F5XC_NAMESPACE"}';
+			expect(ctx.resolvePayloadVars(payload)).toBe('{"ns":"$F5XC_NAMESPACE"}');
+		});
+
+		it("returns unchanged payload when no $F5XC_ references", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_NAMESPACE: "example-ns" }));
+			const payload = '{"name":"test"}';
+			expect(ctx.resolvePayloadVars(payload)).toBe('{"name":"test"}');
+		});
+
+		it("refuses to expand $F5XC_API_TOKEN in payload", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_API_TOKEN: "real-secret-token" }));
+			const payload = '{"token":"$F5XC_API_TOKEN"}';
+			expect(ctx.resolvePayloadVars(payload)).toBe('{"token":"$F5XC_API_TOKEN"}');
+		});
+
+		it("refuses to expand $F5XC_API_URL in payload", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_API_URL: "https://secret.com" }));
+			const payload = '{"url":"$F5XC_API_URL"}';
+			expect(ctx.resolvePayloadVars(payload)).toBe('{"url":"$F5XC_API_URL"}');
+		});
+
+		it("allows expanding $F5XC_NAMESPACE in payload (not a credential)", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_NAMESPACE: "example-ns" }));
+			const payload = '{"metadata":{"namespace":"$F5XC_NAMESPACE"}}';
+			expect(ctx.resolvePayloadVars(payload)).toBe('{"metadata":{"namespace":"example-ns"}}');
+		});
+
+		it("refuses to expand keys matching SECRET_ENV_PATTERNS", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_MY_SECRET_KEY: "shh" }));
+			const payload = '{"key":"$F5XC_MY_SECRET_KEY"}';
+			expect(ctx.resolvePayloadVars(payload)).toBe('{"key":"$F5XC_MY_SECRET_KEY"}');
+		});
+
+		it("refuses to expand explicit sensitiveKeys via options", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_USERNAME: "user" }), {
+				sensitiveKeys: new Set(["F5XC_USERNAME"]),
+			});
+			const payload = '{"user":"$F5XC_USERNAME"}';
+			expect(ctx.resolvePayloadVars(payload)).toBe('{"user":"$F5XC_USERNAME"}');
+		});
+
+		it("refuses to expand sensitiveKeys from f5xc.sensitiveKeys settings (no options)", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_USERNAME: "user" }, ["F5XC_USERNAME"]));
+			const payload = '{"user":"$F5XC_USERNAME"}';
+			expect(ctx.resolvePayloadVars(payload)).toBe('{"user":"$F5XC_USERNAME"}');
+		});
+
+		it("JSON-escapes substituted values containing special characters", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_DESC: 'value with "quotes" and \\backslash' }));
+			const payload = '{"desc":"$F5XC_DESC"}';
+			const result = ctx.resolvePayloadVars(payload);
+			expect(() => JSON.parse(result)).not.toThrow();
+			expect(JSON.parse(result).desc).toBe('value with "quotes" and \\backslash');
+		});
+	});
+
+	describe("getNonSensitiveVars()", () => {
+		it("excludes always-hidden keys", () => {
+			const ctx = createContextEnv(
+				makeSettings({
+					F5XC_API_TOKEN: "secret",
+					F5XC_API_URL: "https://example.com",
+					F5XC_TENANT: "example-tenant",
+					F5XC_NAMESPACE: "example-ns",
+					F5XC_LB_NAME: "example-lb",
+				}),
+			);
+			const vars = ctx.getNonSensitiveVars();
+			expect(vars).not.toHaveProperty("F5XC_API_TOKEN");
+			expect(vars).not.toHaveProperty("F5XC_API_URL");
+			expect(vars).not.toHaveProperty("F5XC_TENANT");
+			expect(vars).not.toHaveProperty("F5XC_NAMESPACE");
+			expect(vars).toHaveProperty("F5XC_LB_NAME", "example-lb");
+		});
+
+		it("excludes keys matching SECRET_ENV_PATTERNS", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_MY_SECRET_KEY: "shhhh", F5XC_LB_NAME: "example-lb" }));
+			const vars = ctx.getNonSensitiveVars();
+			expect(vars).not.toHaveProperty("F5XC_MY_SECRET_KEY");
+			expect(vars).toHaveProperty("F5XC_LB_NAME");
+		});
+
+		it("excludes explicit sensitiveKeys via options", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_USERNAME: "user@example.com" }), {
+				sensitiveKeys: new Set(["F5XC_USERNAME"]),
+			});
+			const vars = ctx.getNonSensitiveVars();
+			expect(vars).not.toHaveProperty("F5XC_USERNAME");
+		});
+
+		it("excludes sensitiveKeys from f5xc.sensitiveKeys settings", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_USERNAME: "user@example.com" }, ["F5XC_USERNAME"]));
+			const vars = ctx.getNonSensitiveVars();
+			expect(vars).not.toHaveProperty("F5XC_USERNAME");
+		});
+
+		it("returns empty object when no custom env vars", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_API_TOKEN: "tok", F5XC_API_URL: "https://example.com" }));
+			expect(ctx.getNonSensitiveVars()).toEqual({});
+		});
+
+		it("only returns F5XC_ prefixed keys", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_LB_NAME: "lb", HTTP_PROXY: "http://proxy" }));
+			const vars = ctx.getNonSensitiveVars();
+			expect(vars).toHaveProperty("F5XC_LB_NAME");
+			expect(vars).not.toHaveProperty("HTTP_PROXY");
+		});
+	});
+});

--- a/packages/coding-agent/test/xcsh-api-tool.test.ts
+++ b/packages/coding-agent/test/xcsh-api-tool.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { XcshApiTool } from "../src/tools/xcsh-api";
 
-describe("XcshApiTool", () => {
-	const mockSession = {} as any;
+function mockSession(bashEnv?: Record<string, string>): any {
+	return { settings: { get: (key: string) => (key === "bash.environment" ? (bashEnv ?? {}) : undefined) } };
+}
 
+describe("XcshApiTool", () => {
 	it("has correct name and label", () => {
-		const tool = new XcshApiTool(mockSession);
+		const tool = new XcshApiTool(mockSession());
 		expect(tool.name).toBe("xcsh_api");
 		expect(tool.label).toBe("API");
 	});
@@ -16,7 +18,7 @@ describe("XcshApiTool", () => {
 		delete process.env.F5XC_API_URL;
 		delete process.env.F5XC_API_TOKEN;
 		try {
-			const tool = new XcshApiTool(mockSession);
+			const tool = new XcshApiTool(mockSession());
 			const result = await tool.execute("call-1", {
 				method: "GET",
 				path: "/api/config/namespaces/default/http_loadbalancers",
@@ -38,7 +40,7 @@ describe("XcshApiTool", () => {
 		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
 		delete process.env.F5XC_API_TOKEN;
 		try {
-			const tool = new XcshApiTool(mockSession);
+			const tool = new XcshApiTool(mockSession());
 			const result = await tool.execute("call-2", {
 				method: "GET",
 				path: "/api/config/namespaces/default/http_loadbalancers",
@@ -66,7 +68,7 @@ describe("XcshApiTool", () => {
 		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
 		process.env.F5XC_API_TOKEN = "test-token";
 		try {
-			const tool = new XcshApiTool(mockSession);
+			const tool = new XcshApiTool(mockSession());
 			await tool.execute("call-3", {
 				method: "POST",
 				path: "/api/config/namespaces/{namespace}/http_loadbalancers",
@@ -97,7 +99,7 @@ describe("XcshApiTool", () => {
 		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
 		process.env.F5XC_API_TOKEN = "test-token";
 		try {
-			const tool = new XcshApiTool(mockSession);
+			const tool = new XcshApiTool(mockSession());
 			await tool.execute("call-4", {
 				method: "GET",
 				path: "/api/config/namespaces/{namespace}/virtual_hosts/{vh_name}/active_staged_signatures",
@@ -127,7 +129,7 @@ describe("XcshApiTool", () => {
 		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
 		process.env.F5XC_API_TOKEN = "test-token";
 		try {
-			const tool = new XcshApiTool(mockSession);
+			const tool = new XcshApiTool(mockSession());
 			await tool.execute("call-5", {
 				method: "DELETE",
 				path: "/api/config/namespaces/{namespace}/http_loadbalancers/{name}",
@@ -159,7 +161,7 @@ describe("XcshApiTool", () => {
 		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
 		process.env.F5XC_API_TOKEN = "test-token";
 		try {
-			const tool = new XcshApiTool(mockSession);
+			const tool = new XcshApiTool(mockSession());
 			const result = await tool.execute("call-6", {
 				method: "GET",
 				path: "/api/config/namespaces/default/healthchecks",
@@ -188,7 +190,7 @@ describe("XcshApiTool", () => {
 		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
 		process.env.F5XC_API_TOKEN = "test-token";
 		try {
-			const tool = new XcshApiTool(mockSession);
+			const tool = new XcshApiTool(mockSession());
 			const result = await tool.execute("call-7", {
 				method: "GET",
 				path: "/api/config/namespaces/default/healthchecks",
@@ -218,13 +220,70 @@ describe("XcshApiTool", () => {
 		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
 		process.env.F5XC_API_TOKEN = "test-token";
 		try {
-			const tool = new XcshApiTool(mockSession);
+			const tool = new XcshApiTool(mockSession());
 			await tool.execute("call-8", {
 				method: "GET",
 				path: "/api/config/namespaces/default/healthchecks",
 			});
 			expect(capturedSignal).toBeDefined();
 			expect(capturedSignal).toBeInstanceOf(AbortSignal);
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (originalUrl) process.env.F5XC_API_URL = originalUrl;
+			else delete process.env.F5XC_API_URL;
+			if (originalToken) process.env.F5XC_API_TOKEN = originalToken;
+			else delete process.env.F5XC_API_TOKEN;
+		}
+	});
+
+	it("auto-resolves {namespace} from bash.environment when not in params", async () => {
+		let capturedUrl = "";
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (input: any, _init?: any) => {
+			capturedUrl = typeof input === "string" ? input : input.url;
+			return new Response("{}", { status: 200 });
+		}) as typeof fetch;
+		const originalUrl = process.env.F5XC_API_URL;
+		const originalToken = process.env.F5XC_API_TOKEN;
+		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
+		process.env.F5XC_API_TOKEN = "test-token";
+		try {
+			const tool = new XcshApiTool(mockSession({ F5XC_NAMESPACE: "auto-ns" }));
+			await tool.execute("call-9", {
+				method: "GET",
+				path: "/api/config/namespaces/{namespace}/http_loadbalancers",
+			});
+			expect(capturedUrl).toContain("auto-ns");
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (originalUrl) process.env.F5XC_API_URL = originalUrl;
+			else delete process.env.F5XC_API_URL;
+			if (originalToken) process.env.F5XC_API_TOKEN = originalToken;
+			else delete process.env.F5XC_API_TOKEN;
+		}
+	});
+
+	it("expands $F5XC_NAMESPACE in payload", async () => {
+		let capturedBody: string | null = null;
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (_input: any, init?: any) => {
+			capturedBody = init?.body ?? null;
+			return new Response("{}", { status: 200 });
+		}) as typeof fetch;
+		const originalUrl = process.env.F5XC_API_URL;
+		const originalToken = process.env.F5XC_API_TOKEN;
+		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
+		process.env.F5XC_API_TOKEN = "test-token";
+		try {
+			const tool = new XcshApiTool(mockSession({ F5XC_NAMESPACE: "r-mordasiewicz" }));
+			await tool.execute("call-10", {
+				method: "POST",
+				path: "/api/config/namespaces/r-mordasiewicz/http_loadbalancers",
+				payload: { metadata: { namespace: "$F5XC_NAMESPACE" } },
+			});
+			expect(capturedBody).not.toBeNull();
+			const parsed = JSON.parse(capturedBody as unknown as string);
+			expect(parsed.metadata.namespace).toBe("r-mordasiewicz");
 		} finally {
 			globalThis.fetch = originalFetch;
 			if (originalUrl) process.env.F5XC_API_URL = originalUrl;


### PR DESCRIPTION
## What

Add a reusable `ContextEnv` service that centralises F5XC context variable resolution across tools:
- Auto-resolves `{namespace}` in API paths from `F5XC_NAMESPACE` env
- Expands `$F5XC_*` variables in request payloads
- Surfaces context env vars in the system prompt
- Security hardened: credential leak blocked via `sensitiveKeys`, JSON-escaped substitution prevents injection

## Why

Multiple tools duplicated F5XC context variable resolution logic. This shared module provides a single DRY implementation that is security-hardened and tested.

Closes #529

## Testing

- 183-line dedicated test suite (`context-env.test.ts`) covering get, resolvePath, expandPayload, toPromptBlock, and security scenarios
- Updated `xcsh-api-tool.test.ts` to verify integration
- All pre-commit hooks pass (governance, biome, gitleaks, markdown, spelling, editorconfig)

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #529`