### PR TITLE
fix(bash): eliminate transient verbose flash in collapsed view

### DIFF
--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -761,6 +761,45 @@ export const bashToolRenderer = {
 				// REACTIVE: read mutable options at render time
 				const { renderContext } = options;
 				const expanded = renderContext?.expanded ?? options.expanded;
+
+				// Collapsed mode check first — before heavy computation.
+				// This ensures the collapsed line is always returned when bash.verbose=false,
+				// preventing any transient verbose output flash.
+				const verbose = getBashVerboseSetting();
+				if (!verbose && !expanded) {
+					const hasAsyncDetails = details?.async != null;
+					const outputText = renderContext?.output ?? result.content?.find(c => c.type === "text")?.text ?? "";
+					const hasSixel = TERMINAL.imageProtocol === ImageProtocol.Sixel && outputText.includes("\x1bP");
+					if (!isError && !hasAsyncDetails && !hasSixel) {
+						const rawCmd = args?.command?.replace(/\s*\\\r?\n\s*/g, " ");
+						const summaryText = args?.description ?? rawCmd ?? undefined;
+
+						if (options.isPartial) {
+							const lineCount = outputText.split("\n").filter(l => l.trim().length > 0).length;
+							const line = renderStatusLine(
+								{
+									icon: "running",
+									spinnerFrame: options.spinnerFrame,
+									title: "Bash",
+									description: summaryText,
+									meta: lineCount > 0 ? [`${lineCount} lines`] : undefined,
+								},
+								uiTheme,
+							);
+							return [truncateToWidth(line, width)];
+						}
+
+						const line = renderStatusLine(
+							{
+								title: "Bash",
+								description: summaryText,
+							},
+							uiTheme,
+						);
+						return [truncateToWidth(line, width)];
+					}
+				}
+
 				const previewLines = renderContext?.previewLines ?? BASH_DEFAULT_PREVIEW_LINES;
 
 				// Get output from context (preferred) or fall back to result content
@@ -772,39 +811,6 @@ export const bashToolRenderer = {
 				const sixelLineMask =
 					TERMINAL.imageProtocol === ImageProtocol.Sixel ? getSixelLineMask(rawOutputLines) : undefined;
 				const hasSixelOutput = sixelLineMask?.some(Boolean) ?? false;
-
-				// Collapsed mode: single status line when bash.verbose=false
-				const verbose = getBashVerboseSetting();
-				const hasAsyncDetails = details?.async != null;
-				const forceExpand = isError || hasAsyncDetails || hasSixelOutput;
-				if (!verbose && !expanded && !forceExpand) {
-					const rawCmd = args?.command?.replace(/\s*\\\r?\n\s*/g, " ");
-					const summaryText = args?.description ?? rawCmd ?? undefined;
-
-					if (options.isPartial) {
-						const lineCount = rawOutputLines.filter(l => l.trim().length > 0).length;
-						const line = renderStatusLine(
-							{
-								icon: "running",
-								spinnerFrame: options.spinnerFrame,
-								title: "Bash",
-								description: summaryText,
-								meta: lineCount > 0 ? [`${lineCount} lines`] : undefined,
-							},
-							uiTheme,
-						);
-						return [truncateToWidth(line, width)];
-					}
-
-					const line = renderStatusLine(
-						{
-							title: "Bash",
-							description: summaryText,
-						},
-						uiTheme,
-					);
-					return [truncateToWidth(line, width)];
-				}
 
 				// Build truncation warning
 				const timeoutSeconds = details?.timeoutSeconds ?? renderContext?.timeout;


### PR DESCRIPTION
## What

Move collapsed mode check to the top of the render callback, before any heavy computation that could introduce render frames where the verbose path executes.

## Why

The collapsed Bash view could briefly flash verbose output before settling into the collapsed line. The collapsed early-return was positioned after several computations (output parsing, SIXEL detection, line splitting) that could introduce render frames where the verbose path executed.

Closes #537

## Summary

- Move collapsed mode check to the top of the render callback, before any heavy computation
- Ensures the collapsed single-line is always returned immediately when `bash.verbose=false`
- SIXEL detection in collapsed path uses lightweight `outputText.includes("\x1bP")` instead of the full `getSixelLineMask()` computation
- Force-expand conditions (error, async, SIXEL) still bypass collapsed mode
- Remove hardcoded 60-char truncation — uses terminal width via `truncateToWidth`
- Normalize backslash line continuations in both `renderCall()` and `renderResult()`
- Fix `renderCall()` showing `$ …` when no args available — now shows just `Bash`

## Testing

- 25 tests pass (bash-renderer.test.ts + bash-sixel-render.test.ts)
- Tests cover: collapsed success, streaming, error auto-expand, SIXEL auto-expand, async auto-expand, Ctrl+O override, verbose mode, Settings fallback, wide terminal truncation, backslash normalization, empty args
- Biome clean

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [x] Issue linked via `Closes #537`