### PR TITLE
feat(gitlab-skill): add idempotent startup check with welcome warning

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -35,6 +35,7 @@ import { HistoryStorage } from "../session/history-storage";
 import type { SessionContext, SessionManager } from "../session/session-manager";
 import { STTController, type SttState } from "../stt";
 import type { ExitPlanModeDetails } from "../tools";
+import { glabStartupWarning } from "../tools/glab/config";
 import type { EventBus } from "../utils/event-bus";
 import { getEditorCommand, openInEditor } from "../utils/external-editor";
 import { popTerminalTitle, pushTerminalTitle, setSessionTerminalTitle } from "../utils/title-generator";
@@ -310,15 +311,20 @@ export class InteractiveMode implements InteractiveModeContext {
 			getProjectDir(),
 		);
 
-		// Run blocking welcome screen status checks (model + context)
-		const welcomeResult = await logger.time("InteractiveMode.init:welcomeChecks", () =>
-			runWelcomeChecks(this.session.model, this.session.modelRegistry.authStorage),
-		);
+		// Run blocking welcome screen status checks (model + context) and glab setup check in parallel
+		const [welcomeResult, glabWarning] = await Promise.all([
+			logger.time("InteractiveMode.init:welcomeChecks", () =>
+				runWelcomeChecks(this.session.model, this.session.modelRegistry.authStorage),
+			),
+			glabStartupWarning(getProjectDir()).catch(() => null),
+		]);
 
 		const startupQuiet = settings.get("startup.quiet");
 		this.#welcomeComponent = undefined;
 
-		for (const warning of this.session.configWarnings) {
+		const allWarnings = [...this.session.configWarnings];
+		if (glabWarning) allWarnings.push(glabWarning);
+		for (const warning of allWarnings) {
 			this.ui.addChild(new Text(theme.fg("warning", `Warning: ${warning}`), 1, 0));
 			this.ui.addChild(new Spacer(1));
 		}

--- a/packages/coding-agent/src/tools/glab/config.ts
+++ b/packages/coding-agent/src/tools/glab/config.ts
@@ -60,3 +60,15 @@ export async function resolveProject(
 	}
 	return null;
 }
+
+/** Idempotent startup check: returns a warning string if glab is installed but not configured, null otherwise. */
+export async function glabStartupWarning(cwd: string): Promise<string | null> {
+	// Fast path: if glab is not installed, nothing to warn about
+	const { $which } = await import("@f5xc-salesdemos/pi-utils");
+	if (!$which("glab")) return null;
+	// Check if config already exists at project or user level
+	const config = await loadConfig(cwd);
+	if (config?.project) return null;
+	// glab is installed but no project configured — emit a one-time warning
+	return "GitLab (glab) is installed but no project is configured. Run: glab_setup with action save_project and project GROUP/REPO";
+}


### PR DESCRIPTION
Closes #539

## Summary

Adds glabStartupWarning() to the welcome screen initialization.

- Non-blocking: runs in parallel with model/context checks
- Idempotent: only checks file existence, no API calls
- Fails silently: .catch(() => null) ensures glab never blocks startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)