### PR TITLE
fix(xcsh_api): resolve auth credentials from context profile via bash.environment

### DIFF
--- a/packages/coding-agent/src/tools/xcsh-api.ts
+++ b/packages/coding-agent/src/tools/xcsh-api.ts
@@ -44,9 +44,9 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 
 	constructor(session: ToolSession) {
 		this.description = prompt.render(xcshApiDescription);
-		this.#apiBase = (process.env.F5XC_API_URL ?? "").replace(/\/+$/, "");
-		this.#apiToken = process.env.F5XC_API_TOKEN ?? "";
 		this.#contextEnv = createContextEnv(session.settings);
+		this.#apiBase = (process.env.F5XC_API_URL ?? this.#contextEnv.get("F5XC_API_URL") ?? "").replace(/\/+$/, "");
+		this.#apiToken = process.env.F5XC_API_TOKEN ?? this.#contextEnv.get("F5XC_API_TOKEN") ?? "";
 
 		if (this.#apiBase && this.#apiToken) {
 			fetch(`${this.#apiBase}/api/web/namespaces`, {

--- a/packages/coding-agent/test/xcsh-api-tool.test.ts
+++ b/packages/coding-agent/test/xcsh-api-tool.test.ts
@@ -292,4 +292,42 @@ describe("XcshApiTool", () => {
 			else delete process.env.F5XC_API_TOKEN;
 		}
 	});
+
+	it("resolves credentials from bash.environment when process.env is empty", async () => {
+		let capturedUrl = "";
+		let capturedHeaders: Record<string, string> = {};
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (input: any, init?: any) => {
+			capturedUrl = typeof input === "string" ? input : input.url;
+			capturedHeaders = init?.headers ?? {};
+			return new Response("{}", { status: 200 });
+		}) as typeof fetch;
+		const originalUrl = process.env.F5XC_API_URL;
+		const originalToken = process.env.F5XC_API_TOKEN;
+		delete process.env.F5XC_API_URL;
+		delete process.env.F5XC_API_TOKEN;
+		try {
+			const tool = new XcshApiTool(
+				mockSession({
+					F5XC_API_URL: "https://context.console.ves.volterra.io",
+					F5XC_API_TOKEN: "context-token",
+					F5XC_NAMESPACE: "context-ns",
+				}),
+			);
+			await tool.execute("call-ctx", {
+				method: "GET",
+				path: "/api/config/namespaces/{namespace}/healthchecks",
+			});
+			expect(capturedUrl).toBe(
+				"https://context.console.ves.volterra.io/api/config/namespaces/context-ns/healthchecks",
+			);
+			expect(capturedHeaders.Authorization).toBe("APIToken context-token");
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (originalUrl) process.env.F5XC_API_URL = originalUrl;
+			else delete process.env.F5XC_API_URL;
+			if (originalToken) process.env.F5XC_API_TOKEN = originalToken;
+			else delete process.env.F5XC_API_TOKEN;
+		}
+	});
 });


### PR DESCRIPTION
## What

Fall back to `contextEnv.get()` when `process.env.F5XC_API_URL` / `F5XC_API_TOKEN` are empty, so credentials sourced from `/context` profiles (bash.environment settings) are resolved correctly.

## Why

The `xcsh_api` tool only read credentials from `process.env`. Context-based users (the majority) store credentials in bash.environment via `/context` profiles, causing the tool to error with "F5XC_API_URL environment variable is not set". The `ContextEnv` module from #529 already provided `get()` — this wires it into the constructor fallback chain.

Closes #528

## Testing

- New test: "resolves credentials from bash.environment when process.env is empty" — mocks a session with context-based credentials, verifies the tool resolves URL and token from `contextEnv.get()`.
- Existing tests continue to pass (process.env credentials still take priority).

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #528`