### PR TITLE
fix(xcsh_api): resolve credentials at execute time to support mid-session context switches

### DIFF
--- a/packages/coding-agent/src/tools/xcsh-api.ts
+++ b/packages/coding-agent/src/tools/xcsh-api.ts
@@ -38,33 +38,41 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 	readonly description: string;
 	readonly parameters = xcshApiSchema;
 
-	#apiBase: string;
-	#apiToken: string;
 	#contextEnv: ReturnType<typeof createContextEnv>;
 
 	constructor(session: ToolSession) {
 		this.description = prompt.render(xcshApiDescription);
 		this.#contextEnv = createContextEnv(session.settings);
-		this.#apiBase = (process.env.F5XC_API_URL ?? this.#contextEnv.get("F5XC_API_URL") ?? "").replace(/\/+$/, "");
-		this.#apiToken = process.env.F5XC_API_TOKEN ?? this.#contextEnv.get("F5XC_API_TOKEN") ?? "";
 
-		if (this.#apiBase && this.#apiToken) {
-			fetch(`${this.#apiBase}/api/web/namespaces`, {
+		const apiBase = this.#resolveApiBase();
+		const apiToken = this.#resolveApiToken();
+		if (apiBase && apiToken) {
+			fetch(`${apiBase}/api/web/namespaces`, {
 				method: "HEAD",
-				headers: { Authorization: `APIToken ${this.#apiToken}` },
+				headers: { Authorization: `APIToken ${apiToken}` },
 			}).catch(() => {});
 		}
 	}
 
+	#resolveApiBase(): string {
+		return (process.env.F5XC_API_URL ?? this.#contextEnv.get("F5XC_API_URL") ?? "").replace(/\/+$/, "");
+	}
+
+	#resolveApiToken(): string {
+		return process.env.F5XC_API_TOKEN ?? this.#contextEnv.get("F5XC_API_TOKEN") ?? "";
+	}
+
 	async execute(_toolCallId: string, params: XcshApiParams): Promise<XcshApiResult> {
-		if (!this.#apiBase) {
+		const apiBase = this.#resolveApiBase();
+		if (!apiBase) {
 			return {
 				content: [{ type: "text", text: "Error: F5XC_API_URL environment variable is not set." }],
 				isError: true,
 			};
 		}
 
-		if (!this.#apiToken) {
+		const apiToken = this.#resolveApiToken();
+		if (!apiToken) {
 			return {
 				content: [{ type: "text", text: "Error: F5XC_API_TOKEN environment variable is not set." }],
 				isError: true,
@@ -73,10 +81,10 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 
 		const resolvedPath = this.#contextEnv.resolvePath(params.path, params.params);
 
-		const url = `${this.#apiBase}${resolvedPath}`;
+		const url = `${apiBase}${resolvedPath}`;
 		const requestId = crypto.randomUUID();
 		const headers: Record<string, string> = {
-			Authorization: `APIToken ${this.#apiToken}`,
+			Authorization: `APIToken ${apiToken}`,
 			Accept: "application/json",
 			"X-Request-ID": requestId,
 		};


### PR DESCRIPTION
## What

Replace cached `#apiBase` and `#apiToken` fields in `xcsh-api.ts` with `#resolveApiBase()` and `#resolveApiToken()` private methods that read live from `process.env` with `bash.environment` fallback on each `execute()` call.

## Why

Codex P1 finding: credentials were snapshotted at construction time, so mid-session `/context activate` left `xcsh_api` using stale or wrong-tenant credentials. The TLS pre-warm still works -- it reads credentials once at construction for the initial HEAD request, then `execute()` reads fresh credentials on each call.

Closes #544

## Testing

- Biome lint passes
- Pre-commit hooks pass (governance, large file check, secrets detection, spelling, editorconfig)
- TLS pre-warm path unchanged (reads credentials at construction for HEAD request only)
- Execute path now resolves credentials on each call via private resolver methods

---

- [x] `bun run check` passes (Biome lint via pre-commit)
- [x] Issue linked via `Closes #544`