### PR TITLE
feat(gitlab): add welcome screen GitLab status with auto-discovery

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -1,9 +1,11 @@
 import type { Model } from "@f5xc-salesdemos/pi-ai";
 import { validateApiKeyAgainstModelsEndpoint } from "@f5xc-salesdemos/pi-ai/utils/oauth/api-key-validation";
-import { logger } from "@f5xc-salesdemos/pi-utils";
+import { $which, logger } from "@f5xc-salesdemos/pi-utils";
+import { $ } from "bun";
 import { type AuthStatus, ContextService } from "../../services/f5xc-context";
 import { deriveTenantFromUrl } from "../../services/f5xc-env";
 import type { AuthStorage } from "../../session/auth-storage";
+import { ensureGlabConfig, parseAuthStatus } from "../../tools/glab/config";
 
 // Startup validation budget. These are longer than validateToken's 3000ms default because
 // the welcome path runs during TLS/DNS cold-start — a single 3s shot races against warm-up
@@ -57,6 +59,14 @@ export interface WelcomeContextStatus {
 	name?: string;
 	latencyMs?: number;
 	errorClass?: "network" | "credential" | "url_not_found";
+}
+
+export type GitLabCheckState = "not_installed" | "connected" | "auth_error" | "not_configured" | "project_inaccessible";
+
+export interface WelcomeGitLabStatus {
+	state: GitLabCheckState;
+	project?: string;
+	user?: string;
 }
 
 export interface WelcomeCheckResult {
@@ -175,5 +185,50 @@ async function checkContextStatus(): Promise<WelcomeContextStatus> {
 	} catch {
 		logger.warn("Welcome context validation failed");
 		return { state: "no_context" };
+	}
+}
+
+/** Idempotent startup check: glab installed -> authenticated -> config ensured -> project verified. */
+export async function checkGitLabStatus(cwd: string): Promise<WelcomeGitLabStatus | undefined> {
+	try {
+		if (!$which("glab")) return undefined;
+
+		// Step 1: Check authentication, parse hostname + user
+		const authResult = await $`glab auth status`.quiet().nothrow();
+		if (authResult.exitCode !== 0) return { state: "auth_error" };
+		const { hostname, user } = parseAuthStatus(authResult.stderr.toString());
+
+		// Step 2: Suppress glab update nag that pollutes stderr (idempotent)
+		await $`glab config set check_update false`.quiet().nothrow();
+
+		// Step 3: Try to detect project from git remote in cwd
+		let detectedProject: string | undefined;
+		const repoResult = await $`glab repo view --output json`.cwd(cwd).quiet().nothrow();
+		if (repoResult.exitCode === 0) {
+			try {
+				const repo = JSON.parse(repoResult.text());
+				if (repo.path_with_namespace) detectedProject = repo.path_with_namespace;
+			} catch {
+				// JSON parse failed — ignore
+			}
+		}
+
+		// Step 4: Ensure config (merges existing + detected + defaults)
+		const config = await ensureGlabConfig(cwd, { hostname, project: detectedProject });
+
+		// Step 5: If we have a project, verify access
+		if (config.project) {
+			const encoded = encodeURIComponent(config.project);
+			const accessResult = await $`glab api projects/${encoded}`.quiet().nothrow();
+			if (accessResult.exitCode === 0) {
+				return { state: "connected", project: config.project, user };
+			}
+			return { state: "project_inaccessible", project: config.project, user };
+		}
+
+		return { state: "not_configured", user };
+	} catch (err) {
+		logger.warn("GitLab startup check failed", { error: String(err) });
+		return { state: "not_configured" };
 	}
 }

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -2,7 +2,7 @@ import { type Component, padding, truncateToWidth, visibleWidth } from "@f5xc-sa
 import { APP_NAME } from "@f5xc-salesdemos/pi-utils";
 import { theme } from "../../modes/theme/theme";
 import { formatStatusIcon } from "../../services/f5xc-context-indicators";
-import type { ModelStatus, WelcomeContextStatus } from "./welcome-checks";
+import type { ModelStatus, WelcomeContextStatus, WelcomeGitLabStatus } from "./welcome-checks";
 
 export interface UpdateStatus {
 	available: boolean;
@@ -21,6 +21,7 @@ export class WelcomeComponent implements Component {
 		private contextStatus?: WelcomeContextStatus,
 		private updateStatus?: UpdateStatus,
 		private changelogStatus?: ChangelogStatus,
+		private gitlabStatus?: WelcomeGitLabStatus,
 	) {}
 	invalidate(): void {}
 	setModelStatus(status: ModelStatus): void {
@@ -34,6 +35,9 @@ export class WelcomeComponent implements Component {
 	}
 	setChangelogStatus(status: ChangelogStatus | undefined): void {
 		this.changelogStatus = status;
+	}
+	setGitLabStatus(status: WelcomeGitLabStatus | undefined): void {
+		this.gitlabStatus = status;
 	}
 
 	render(termWidth: number): string[] {
@@ -130,6 +134,9 @@ export class WelcomeComponent implements Component {
 		if (this.contextStatus) {
 			lines.push(" F5 XC Context", ...this.#renderContextStatus());
 		}
+		if (this.gitlabStatus) {
+			lines.push(" GitLab", ...this.#renderGitLabStatus());
+		}
 		if (this.#showUpdateSection()) {
 			lines.push(" Update Available", ...this.#renderUpdateStatus());
 		}
@@ -152,6 +159,13 @@ export class WelcomeComponent implements Component {
 			lines.push("");
 			lines.push(` ${theme.bold(theme.fg("contentAccent", "F5 XC Context"))}`);
 			lines.push(...this.#renderContextStatus());
+			lines.push("");
+		}
+		if (this.gitlabStatus) {
+			lines.push(separator);
+			lines.push("");
+			lines.push(` ${theme.bold(theme.fg("contentAccent", "GitLab"))}`);
+			lines.push(...this.#renderGitLabStatus());
 			lines.push("");
 		}
 		if (this.#showUpdateSection()) {
@@ -247,6 +261,34 @@ export class WelcomeComponent implements Component {
 					` ${formatStatusIcon("warning")} ${theme.fg("warning", "No context configured")}`,
 					`   ${theme.fg("dim", "Run /context create <name> <url> <token>")}`,
 				];
+		}
+	}
+
+	#renderGitLabStatus(): string[] {
+		if (!this.gitlabStatus) return [];
+		const { state, project, user } = this.gitlabStatus;
+		switch (state) {
+			case "connected":
+				return [
+					` ${formatStatusIcon("connected")} ${theme.fg("muted", project ?? "configured")}${user ? ` ${theme.fg("dim", `(${user})`)}` : ""} ${theme.fg("dim", "\u2014 ready")}`,
+				];
+			case "auth_error":
+				return [
+					` ${formatStatusIcon("error")} ${theme.fg("error", "Not authenticated")}`,
+					`   ${theme.fg("dim", "Run")} ${theme.fg("contentAccent", "glab auth login")}`,
+				];
+			case "not_configured":
+				return [
+					` ${formatStatusIcon("warning")} ${theme.fg("warning", "No project configured")}`,
+					`   ${theme.fg("dim", "Run glab_setup action save_project project GROUP/REPO")}`,
+				];
+			case "project_inaccessible":
+				return [
+					` ${formatStatusIcon("warning")} ${theme.fg("muted", project ?? "unknown")} ${theme.fg("warning", "\u2014 access denied")}`,
+					`   ${theme.fg("dim", "Check permissions or run glab_setup with action save_project")}`,
+				];
+			case "not_installed":
+				return [` ${formatStatusIcon("warning")} ${theme.fg("warning", "glab CLI not installed")}`];
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -35,7 +35,6 @@ import { HistoryStorage } from "../session/history-storage";
 import type { SessionContext, SessionManager } from "../session/session-manager";
 import { STTController, type SttState } from "../stt";
 import type { ExitPlanModeDetails } from "../tools";
-import { glabStartupWarning } from "../tools/glab/config";
 import type { EventBus } from "../utils/event-bus";
 import { getEditorCommand, openInEditor } from "../utils/external-editor";
 import { popTerminalTitle, pushTerminalTitle, setSessionTerminalTitle } from "../utils/title-generator";
@@ -51,7 +50,7 @@ import type { PythonExecutionComponent } from "./components/python-execution";
 import { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
 import { type ChangelogStatus, type UpdateStatus, WelcomeComponent } from "./components/welcome";
-import { runWelcomeChecks } from "./components/welcome-checks";
+import { checkGitLabStatus, runWelcomeChecks } from "./components/welcome-checks";
 import { BtwController } from "./controllers/btw-controller";
 import { CommandController } from "./controllers/command-controller";
 import { EventController } from "./controllers/event-controller";
@@ -311,19 +310,18 @@ export class InteractiveMode implements InteractiveModeContext {
 			getProjectDir(),
 		);
 
-		// Run blocking welcome screen status checks (model + context) and glab setup check in parallel
-		const [welcomeResult, glabWarning] = await Promise.all([
+		// Run blocking welcome screen status checks (model + context + gitlab) in parallel
+		const [welcomeResult, gitlabStatus] = await Promise.all([
 			logger.time("InteractiveMode.init:welcomeChecks", () =>
 				runWelcomeChecks(this.session.model, this.session.modelRegistry.authStorage),
 			),
-			glabStartupWarning(getProjectDir()).catch(() => null),
+			checkGitLabStatus(getProjectDir()).catch(() => undefined),
 		]);
 
 		const startupQuiet = settings.get("startup.quiet");
 		this.#welcomeComponent = undefined;
 
 		const allWarnings = [...this.session.configWarnings];
-		if (glabWarning) allWarnings.push(glabWarning);
 		for (const warning of allWarnings) {
 			this.ui.addChild(new Text(theme.fg("warning", `Warning: ${warning}`), 1, 0));
 			this.ui.addChild(new Spacer(1));
@@ -337,6 +335,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				welcomeResult.context,
 				this.#initialUpdateStatus,
 				this.#changelogStatus,
+				gitlabStatus,
 			);
 
 			// Setup UI layout

--- a/packages/coding-agent/src/tools/glab/config.ts
+++ b/packages/coding-agent/src/tools/glab/config.ts
@@ -61,14 +61,46 @@ export async function resolveProject(
 	return null;
 }
 
-/** Idempotent startup check: returns a warning string if glab is installed but not configured, null otherwise. */
-export async function glabStartupWarning(cwd: string): Promise<string | null> {
-	// Fast path: if glab is not installed, nothing to warn about
-	const { $which } = await import("@f5xc-salesdemos/pi-utils");
-	if (!$which("glab")) return null;
-	// Check if config already exists at project or user level
-	const config = await loadConfig(cwd);
-	if (config?.project) return null;
-	// glab is installed but no project configured — emit a one-time warning
-	return "GitLab (glab) is installed but no project is configured. Run: glab_setup with action save_project and project GROUP/REPO";
+const CONFIG_DEFAULTS = {
+	hostname: "gitlab.com",
+	defaultState: "opened" as const,
+	perPage: 100,
+};
+
+/**
+ * Parse glab auth status output to extract hostname and username.
+ * Expected format: "Logged in to gitlab.com as username (...)"
+ */
+export function parseAuthStatus(output: string): { hostname?: string; user?: string } {
+	const match = output.match(/Logged in to ([\w.-]+) as (\S+)/);
+	if (match) return { hostname: match[1], user: match[2] };
+	const firstLine = output.split("\n").find(l => l.trim() && !l.startsWith(" "));
+	return { hostname: firstLine?.trim() };
+}
+
+/**
+ * Ensures xcsh glab config exists with sensible defaults.
+ * Merges existing config with detected values (hostname from auth, project from git remote).
+ * Only writes to disk if the config is new or values were updated.
+ */
+export async function ensureGlabConfig(
+	cwd: string,
+	detected?: { hostname?: string; project?: string },
+): Promise<GlabConfig> {
+	const existing = await loadConfig(cwd);
+	const config: GlabConfig = {
+		hostname: existing?.hostname ?? detected?.hostname ?? CONFIG_DEFAULTS.hostname,
+		defaultState: existing?.defaultState ?? CONFIG_DEFAULTS.defaultState,
+		perPage: existing?.perPage ?? CONFIG_DEFAULTS.perPage,
+	};
+	const project = existing?.project ?? detected?.project;
+	if (project) config.project = project;
+
+	const changed =
+		!existing ||
+		existing.hostname !== config.hostname ||
+		existing.project !== config.project ||
+		existing.defaultState !== config.defaultState;
+	if (changed) await saveConfig(cwd, config);
+	return config;
 }

--- a/packages/coding-agent/src/tools/glab/types.ts
+++ b/packages/coding-agent/src/tools/glab/types.ts
@@ -52,7 +52,7 @@ export interface GlabProject {
 }
 
 export interface GlabConfig {
-	project: string;
+	project?: string;
 	hostname: string;
 	defaultState: "opened" | "closed" | "all";
 	perPage: number;

--- a/packages/coding-agent/test/glab/config.test.ts
+++ b/packages/coding-agent/test/glab/config.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { loadConfig, resolveProject, saveConfig } from "../../src/tools/glab/config";
+import { ensureGlabConfig, loadConfig, parseAuthStatus, resolveProject, saveConfig } from "../../src/tools/glab/config";
 
 describe("loadConfig", () => {
 	let tmpDir: string;
@@ -121,5 +121,103 @@ describe("resolveProject", () => {
 	it("returns null when no project anywhere", async () => {
 		const result = await resolveProject(undefined, tmpDir);
 		expect(result).toBeNull();
+	});
+});
+
+describe("ensureGlabConfig", () => {
+	let tmpDir: string;
+	let originalHome: string | undefined;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "glab-test-"));
+		originalHome = process.env.HOME;
+		process.env.HOME = tmpDir;
+	});
+
+	afterEach(async () => {
+		process.env.HOME = originalHome;
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("returns existing config when project is already set", async () => {
+		const existing = {
+			project: "custom/project",
+			hostname: "gitlab.example.com",
+			defaultState: "closed" as const,
+			perPage: 50,
+		};
+		await saveConfig(tmpDir, existing);
+		const result = await ensureGlabConfig(tmpDir);
+		expect(result.project).toBe("custom/project");
+		expect(result.hostname).toBe("gitlab.example.com");
+	});
+
+	it("creates config with defaults when none exists", async () => {
+		const result = await ensureGlabConfig(tmpDir);
+		expect(result.hostname).toBe("gitlab.com");
+		expect(result.defaultState).toBe("opened");
+		expect(result.perPage).toBe(100);
+		expect(result.project).toBeUndefined();
+	});
+
+	it("merges detected hostname into new config", async () => {
+		const result = await ensureGlabConfig(tmpDir, { hostname: "gitlab.example.com" });
+		expect(result.hostname).toBe("gitlab.example.com");
+		expect(result.project).toBeUndefined();
+	});
+
+	it("merges detected project into new config", async () => {
+		const result = await ensureGlabConfig(tmpDir, { project: "detected/project" });
+		expect(result.project).toBe("detected/project");
+	});
+
+	it("preserves existing project over detected value", async () => {
+		await saveConfig(tmpDir, {
+			project: "existing/project",
+			hostname: "gitlab.com",
+			defaultState: "opened",
+			perPage: 100,
+		});
+		const result = await ensureGlabConfig(tmpDir, { project: "detected/project" });
+		expect(result.project).toBe("existing/project");
+	});
+
+	it("persists newly created config to disk", async () => {
+		await ensureGlabConfig(tmpDir, { project: "new/project" });
+		const loaded = await loadConfig(tmpDir);
+		expect(loaded).not.toBeNull();
+		expect(loaded!.project).toBe("new/project");
+	});
+
+	it("is idempotent — second call returns same config", async () => {
+		const first = await ensureGlabConfig(tmpDir, { hostname: "gitlab.example.com" });
+		const second = await ensureGlabConfig(tmpDir);
+		expect(first.hostname).toBe(second.hostname);
+	});
+});
+
+describe("parseAuthStatus", () => {
+	it("extracts hostname and user from standard output", () => {
+		const output = [
+			"gitlab.com",
+			"  ✓ Logged in to gitlab.com as jdoe (/path/to/config.yml)",
+			"  ✓ Git operations for gitlab.com configured to use https protocol.",
+		].join("\n");
+		const { hostname, user } = parseAuthStatus(output);
+		expect(hostname).toBe("gitlab.com");
+		expect(user).toBe("jdoe");
+	});
+
+	it("handles self-hosted hostname", () => {
+		const output = "gitlab.example.com\n  ✓ Logged in to gitlab.example.com as admin (/config.yml)";
+		const { hostname, user } = parseAuthStatus(output);
+		expect(hostname).toBe("gitlab.example.com");
+		expect(user).toBe("admin");
+	});
+
+	it("falls back to first line when no Logged in pattern", () => {
+		const output = "gitlab.example.com\n  some other output";
+		const { hostname } = parseAuthStatus(output);
+		expect(hostname).toBe("gitlab.example.com");
 	});
 });

--- a/packages/coding-agent/test/welcome-component.test.ts
+++ b/packages/coding-agent/test/welcome-component.test.ts
@@ -4,7 +4,11 @@ import {
 	type UpdateStatus,
 	WelcomeComponent,
 } from "@f5xc-salesdemos/xcsh/modes/components/welcome";
-import type { ModelStatus, WelcomeContextStatus } from "@f5xc-salesdemos/xcsh/modes/components/welcome-checks";
+import type {
+	ModelStatus,
+	WelcomeContextStatus,
+	WelcomeGitLabStatus,
+} from "@f5xc-salesdemos/xcsh/modes/components/welcome-checks";
 import { initTheme } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
 
 function stripAnsi(str: string): string {
@@ -240,6 +244,74 @@ describe("WelcomeComponent", () => {
 			const c = new WelcomeComponent("17.4.1", model, context, undefined, changelog);
 			const lines = renderPlain(c, 80);
 			const hintLine = lines.find(l => l.includes("/changelog"));
+			expect(hintLine).toBeDefined();
+			expect(hintLine).not.toContain("\u2026");
+		});
+	});
+
+	describe("gitlab section", () => {
+		const model: ModelStatus = { state: "connected", provider: "anthropic", latencyMs: 100 };
+		const context: WelcomeContextStatus = { state: "connected", name: "prod", latencyMs: 42 };
+
+		it("hides gitlab when status is undefined", () => {
+			const c = new WelcomeComponent("17.4.1", model, context);
+			expect(renderPlain(c).join("\n")).not.toContain("GitLab");
+		});
+
+		it("renders connected state with project name", () => {
+			const gitlab: WelcomeGitLabStatus = { state: "connected", project: "mygroup/myproject" };
+			const c = new WelcomeComponent("17.4.1", model, context, undefined, undefined, gitlab);
+			const out = renderPlain(c).join("\n");
+			expect(out).toContain("GitLab");
+			expect(out).toContain("mygroup/myproject");
+			expect(out).toContain("ready");
+			expect(out).toContain("\u2705");
+		});
+
+		it("renders auth_error with login hint", () => {
+			const gitlab: WelcomeGitLabStatus = { state: "auth_error" };
+			const c = new WelcomeComponent("17.4.1", model, context, undefined, undefined, gitlab);
+			const out = renderPlain(c).join("\n");
+			expect(out).toContain("GitLab");
+			expect(out).toContain("Not authenticated");
+			expect(out).toContain("glab auth login");
+			expect(out).toContain("\u274C");
+		});
+
+		it("renders not_configured with setup hint", () => {
+			const gitlab: WelcomeGitLabStatus = { state: "not_configured" };
+			const c = new WelcomeComponent("17.4.1", model, context, undefined, undefined, gitlab);
+			const out = renderPlain(c).join("\n");
+			expect(out).toContain("GitLab");
+			expect(out).toContain("No project configured");
+			expect(out).toContain("glab_setup");
+			expect(out).toContain("\u26A0");
+		});
+
+		it("renders project_inaccessible with access hint", () => {
+			const gitlab: WelcomeGitLabStatus = { state: "project_inaccessible", project: "restricted/repo" };
+			const c = new WelcomeComponent("17.4.1", model, context, undefined, undefined, gitlab);
+			const out = renderPlain(c).join("\n");
+			expect(out).toContain("GitLab");
+			expect(out).toContain("restricted/repo");
+			expect(out).toContain("access denied");
+			expect(out).toContain("\u26A0");
+		});
+
+		it("setGitLabStatus reflects in next render", () => {
+			const c = new WelcomeComponent("17.4.1", model, context);
+			expect(renderPlain(c).join("\n")).not.toContain("GitLab");
+			c.setGitLabStatus({ state: "connected", project: "group/repo" });
+			const out = renderPlain(c).join("\n");
+			expect(out).toContain("GitLab");
+			expect(out).toContain("group/repo");
+		});
+
+		it("gitlab hint is not truncated at 80 columns", () => {
+			const gitlab: WelcomeGitLabStatus = { state: "auth_error" };
+			const c = new WelcomeComponent("17.4.1", model, context, undefined, undefined, gitlab);
+			const lines = renderPlain(c, 80);
+			const hintLine = lines.find(l => l.includes("glab auth login"));
 			expect(hintLine).toBeDefined();
 			expect(hintLine).not.toContain("\u2026");
 		});


### PR DESCRIPTION
## Summary

Closes #547

Adds a GitLab section to the welcome screen that idempotently checks glab CLI installation, authentication, and project configuration at startup. Replaces the old text-based warning with a structured status section inside the welcome box.

## Discovery Flow

```
checkGitLabStatus(cwd)
│
├── $which("glab") → not found? → section hidden
│
├── glab auth status → failed? → ❌ "Not authenticated"
│   └── parse hostname + username from stderr
│
├── glab config set check_update false (suppress nag)
│
├── glab repo view --output json → auto-detect project from git remote
│
├── ensureGlabConfig(cwd, {hostname, project}) → merge + save
│
└── config.project exists?
    ├── yes → glab api projects/<encoded> → accessible?
    │         ├── ✅ "connected" (project + user shown)
    │         └── ⚠️ "access denied" (project shown, permissions hint)
    └── no  → ⚠️ "No project configured" (generic setup hint)
```

## Changes

| File | Change |
|------|--------|
| `src/tools/glab/types.ts` | `project` optional in `GlabConfig` |
| `src/tools/glab/config.ts` | `parseAuthStatus()`, `ensureGlabConfig(cwd, detected?)`, removed dead `glabStartupWarning` |
| `src/modes/components/welcome-checks.ts` | `checkGitLabStatus()` with full 5-step discovery chain, new states + user field |
| `src/modes/components/welcome.ts` | GitLab section rendering (5 states) |
| `src/modes/interactive-mode.ts` | Wire gitlab check into welcome screen, remove old text warning |
| `test/glab/config.test.ts` | 10 new tests (ensureGlabConfig merging + parseAuthStatus parsing) |
| `test/welcome-component.test.ts` | 7 GitLab rendering tests (all 5 states + setter + truncation) |

## Key Design Decisions

- **No hardcoded project paths** — project is discovered from git remote or set by user via `glab_setup`. No org-specific PII in source code.
- **Hostname parsed from auth output** — supports self-hosted GitLab instances without hardcoding.
- **Project access verified at startup** — `glab api projects/<path>` catches permission issues before query time.
- **Config survives upgrades** — stored in `~/.xcsh/agent/glab-config.json`, independent of xcsh version.
- **Existing config always wins** — detected values from git remote only fill gaps, never overwrite user settings.

## Testing

```
105 pass, 0 fail, 196 assertions across 8 files
bun check exits 0 (TS lint + types + Rust fmt/clippy)
```