### PR TITLE
fix(bash): remove redundant inline spinner from collapsed streaming view

### DIFF
--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -778,8 +778,6 @@ export const bashToolRenderer = {
 							const lineCount = outputText.split("\n").filter(l => l.trim().length > 0).length;
 							const line = renderStatusLine(
 								{
-									icon: "running",
-									spinnerFrame: options.spinnerFrame,
 									title: "Bash",
 									description: summaryText,
 									meta: lineCount > 0 ? [`${lineCount} lines`] : undefined,


### PR DESCRIPTION
## Summary
- Remove `icon: "running"` and `spinnerFrame` from the collapsed streaming `renderStatusLine()` call
- The gutter ball already pulses to show activity -- the inline braille spinner was redundant
- Matches the pattern already established for the "pending" case in `formatStatusIcon()`

Closes #549

## Testing

- [x] 25 tests pass (bash-renderer.test.ts + bash-sixel-render.test.ts)
- [x] Biome clean
- [ ] CI pipeline passes

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [x] Issue linked via `Closes #549`