### PR TITLE
fix(context-env): fall back to process.env for path and payload variable resolution

### DIFF
--- a/packages/coding-agent/src/services/context-env.ts
+++ b/packages/coding-agent/src/services/context-env.ts
@@ -83,7 +83,7 @@ export function createContextEnv(settings: { get(key: string): unknown }, option
 				if (PAYLOAD_HIDDEN.has(envKey)) return match;
 				if (SECRET_ENV_PATTERNS.test(envKey)) return match;
 				if (sensitive.has(envKey)) return match;
-				return env[envKey] ?? match;
+				return env[envKey] ?? process.env[envKey] ?? match;
 			});
 
 			return resolved;
@@ -98,7 +98,7 @@ export function createContextEnv(settings: { get(key: string): unknown }, option
 				if (PAYLOAD_HIDDEN.has(key)) return match;
 				if (SECRET_ENV_PATTERNS.test(key)) return match;
 				if (sensitive.has(key)) return match;
-				const value = env[key];
+				const value = env[key] ?? process.env[key];
 				if (value === undefined) return match;
 				// JSON-escape the substituted value to prevent injection
 				return JSON.stringify(value).slice(1, -1);

--- a/packages/coding-agent/test/services/context-env.test.ts
+++ b/packages/coding-agent/test/services/context-env.test.ts
@@ -45,14 +45,27 @@ describe("createContextEnv", () => {
 
 		it("leaves unresolvable placeholders intact", () => {
 			const ctx = createContextEnv(makeSettings({}));
-			const result = ctx.resolvePath("/api/{namespace}/resources");
-			expect(result).toBe("/api/{namespace}/resources");
+			const result = ctx.resolvePath("/api/{nonexistent_placeholder}/resources");
+			expect(result).toBe("/api/{nonexistent_placeholder}/resources");
 		});
 
 		it("resolves multiple placeholders", () => {
 			const ctx = createContextEnv(makeSettings({ F5XC_NAMESPACE: "ns1" }));
 			const result = ctx.resolvePath("/api/{namespace}/vhs/{vh_name}", { vh_name: "example-vh" });
 			expect(result).toBe("/api/ns1/vhs/example-vh");
+		});
+
+		it("falls back to process.env when bash.environment is empty", () => {
+			const original = process.env.F5XC_NAMESPACE;
+			process.env.F5XC_NAMESPACE = "from-process-env";
+			try {
+				const ctx = createContextEnv(makeSettings({}));
+				const result = ctx.resolvePath("/api/{namespace}/resources");
+				expect(result).toBe("/api/from-process-env/resources");
+			} finally {
+				if (original) process.env.F5XC_NAMESPACE = original;
+				else delete process.env.F5XC_NAMESPACE;
+			}
 		});
 	});
 
@@ -71,8 +84,8 @@ describe("createContextEnv", () => {
 
 		it("leaves unresolvable $F5XC_* references unchanged", () => {
 			const ctx = createContextEnv(makeSettings({}));
-			const payload = '{"ns":"$F5XC_NAMESPACE"}';
-			expect(ctx.resolvePayloadVars(payload)).toBe('{"ns":"$F5XC_NAMESPACE"}');
+			const payload = '{"val":"$F5XC_NONEXISTENT_VAR"}';
+			expect(ctx.resolvePayloadVars(payload)).toBe('{"val":"$F5XC_NONEXISTENT_VAR"}');
 		});
 
 		it("returns unchanged payload when no $F5XC_ references", () => {


### PR DESCRIPTION
## What

Add `process.env` fallback to `resolvePath()` and `resolvePayloadVars()` in `context-env.ts` so that environment variables set via shell export, CI, or Docker are resolved correctly when they are not present in `bash.environment`.

## Why

`ContextService` intentionally skips writing inherited variables (like `F5XC_NAMESPACE`) to `bash.environment` since subprocesses inherit them from `process.env` directly. However, `context-env` only checked `bash.environment`, causing `{namespace}` placeholders to pass through as literal strings when the variable came from `process.env`.

Security guards (`PAYLOAD_HIDDEN`, `SECRET_ENV_PATTERNS`, `sensitiveKeys`) run before the fallback, so credentials cannot leak.

Closes #551

## Testing

- New test: `falls back to process.env when bash.environment is empty` confirms resolution via process.env
- Updated two existing tests to use truly non-existent placeholder names so they are not accidentally resolved from process.env
- All pre-commit hooks pass

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #551`