### PR TITLE
fix(welcome): uniform status format across all sections

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -211,13 +211,11 @@ export class WelcomeComponent implements Component {
 	}
 
 	#renderModelStatus(): string[] {
-		const { state, provider, latencyMs } = this.modelStatus;
+		const { state, provider } = this.modelStatus;
 		const p = provider ?? "unknown";
 		switch (state) {
 			case "connected":
-				return [
-					` ${formatStatusIcon("connected")} ${theme.fg("muted", p)} ${theme.fg("dim", `\u2014 connected (${latencyMs ?? "?"}ms)`)}`,
-				];
+				return [` ${formatStatusIcon("connected")} ${theme.fg("muted", p)} ${theme.fg("dim", "\u2014 connected")}`];
 			case "auth_error":
 				return [
 					` ${formatStatusIcon("error")} ${theme.fg("muted", p)} ${theme.fg("error", "\u2014 connection failed")}`,
@@ -233,13 +231,11 @@ export class WelcomeComponent implements Component {
 
 	#renderContextStatus(): string[] {
 		if (!this.contextStatus) return [];
-		const { state, name, latencyMs } = this.contextStatus;
+		const { state, name } = this.contextStatus;
 		const n = name ?? "(unknown)";
 		switch (state) {
 			case "connected":
-				return [
-					` ${formatStatusIcon("connected")} ${theme.fg("muted", n)} ${theme.fg("dim", `\u2014 connected (${latencyMs ?? "?"}ms)`)}`,
-				];
+				return [` ${formatStatusIcon("connected")} ${theme.fg("muted", n)} ${theme.fg("dim", "\u2014 connected")}`];
 			case "auth_error":
 				return [
 					` ${formatStatusIcon("error")} ${theme.fg("muted", n)} ${theme.fg("error", "\u2014 token invalid")}`,
@@ -266,11 +262,11 @@ export class WelcomeComponent implements Component {
 
 	#renderGitLabStatus(): string[] {
 		if (!this.gitlabStatus) return [];
-		const { state, project, user } = this.gitlabStatus;
+		const { state, project } = this.gitlabStatus;
 		switch (state) {
 			case "connected":
 				return [
-					` ${formatStatusIcon("connected")} ${theme.fg("muted", project ?? "configured")}${user ? ` ${theme.fg("dim", `(${user})`)}` : ""} ${theme.fg("dim", "\u2014 ready")}`,
+					` ${formatStatusIcon("connected")} ${theme.fg("muted", project ?? "configured")} ${theme.fg("dim", "\u2014 connected")}`,
 				];
 			case "auth_error":
 				return [

--- a/packages/coding-agent/test/welcome-component.test.ts
+++ b/packages/coding-agent/test/welcome-component.test.ts
@@ -28,7 +28,7 @@ describe("WelcomeComponent", () => {
 		const out = renderPlain(c).join("\n");
 		expect(out).toContain("Model Provider");
 		expect(out).toContain("litellm");
-		expect(out).toContain("connected (142ms)");
+		expect(out).toContain("connected");
 		// Unified emoji indicator (iTerm2 + Nerd Fonts)
 		expect(out).toContain("✅");
 		expect(out).not.toContain("●");
@@ -113,7 +113,7 @@ describe("WelcomeComponent", () => {
 		it("box is no wider than the content requires", () => {
 			const c = new WelcomeComponent("15.15.0", connected);
 			const width = boxWidth(c);
-			// Widest right-column line is ~33 chars ("✓ anthropic — connected (100ms)")
+			// Widest right-column line is ~25 chars ("\u2705 anthropic \u2014 connected")
 			// Left column is 48-50, plus 3 borders = box should be well under 100
 			expect(width).toBeLessThan(100);
 		});
@@ -264,7 +264,7 @@ describe("WelcomeComponent", () => {
 			const out = renderPlain(c).join("\n");
 			expect(out).toContain("GitLab");
 			expect(out).toContain("mygroup/myproject");
-			expect(out).toContain("ready");
+			expect(out).toContain("connected");
 			expect(out).toContain("\u2705");
 		});
 


### PR DESCRIPTION
## Summary

Standardize the three welcome screen status sections to a uniform format. Closes #555.

**Before:**
| Section | Output |
|---|---|
| Model Provider | `✅ anthropic — connected (123ms)` |
| F5 XC Context | `✅ f5-amer-ent — connected (598ms)` |
| GitLab | `✅ f5/volterra/support/zendesk (mordasiewicz) — ready` |

**After:**
| Section | Output |
|---|---|
| Model Provider | `✅ anthropic — connected` |
| F5 XC Context | `✅ f5-amer-ent — connected` |
| GitLab | `✅ f5/volterra/support/zendesk — connected` |

## Changes

- **`welcome.ts`** — Remove `latencyMs` display from Model Provider and F5 XC Context connected states; remove username and change "ready" to "connected" in GitLab connected state
- **`welcome-component.test.ts`** — Update assertions to match simplified format

## Verification

- 61 tests pass, 0 fail across all 3 test files
- `bun check:ts` clean
- No changes to data model or check functions — only rendering