### PR TITLE
fix(xcsh-api): error info loss, double-substitution guard, regex docs

### DIFF
--- a/packages/coding-agent/src/services/context-env.ts
+++ b/packages/coding-agent/src/services/context-env.ts
@@ -66,17 +66,29 @@ export function createContextEnv(settings: { get(key: string): unknown }, option
 		resolvePath(path: string, explicitParams?: Record<string, string>): string {
 			let resolved = path;
 
-			// Apply explicit params first
+			// Apply explicit params first — collect substituted ranges to prevent
+			// double-substitution (values containing {placeholder} syntax must not
+			// be re-resolved by the auto-resolve pass below).
+			const substituted = new Set<number>();
 			if (explicitParams) {
 				for (const [key, value] of Object.entries(explicitParams)) {
-					resolved = resolved.replaceAll(`{${key}}`, value);
+					const placeholder = `{${key}}`;
+					let idx = resolved.indexOf(placeholder);
+					while (idx !== -1) {
+						resolved = resolved.slice(0, idx) + value + resolved.slice(idx + placeholder.length);
+						// Mark all character positions within the substituted value
+						for (let i = idx; i < idx + value.length; i++) substituted.add(i);
+						idx = resolved.indexOf(placeholder, idx + value.length);
+					}
 				}
 			}
 
 			// Auto-resolve remaining {placeholder} values from bash.environment
 			const env = bashEnv();
 			const sensitive = allSensitiveKeys();
-			resolved = resolved.replace(/\{(\w+)\}/g, (match, key) => {
+			resolved = resolved.replace(/\{(\w+)\}/g, (match, key, offset: number) => {
+				// Skip placeholders that fall within a previously substituted range
+				if (substituted.has(offset)) return match;
 				// {namespace} maps directly to F5XC_NAMESPACE
 				const envKey = key === "namespace" ? F5XC_NAMESPACE : `F5XC_${key.toUpperCase()}`;
 				// Never auto-inject credential or sensitive values into URL paths
@@ -92,6 +104,9 @@ export function createContextEnv(settings: { get(key: string): unknown }, option
 		resolvePayloadVars(payloadJson: string): string {
 			const env = bashEnv();
 			const sensitive = allSensitiveKeys();
+			// Pattern matches $F5XC_* anywhere in the string (no word boundary).
+			// This is intentional: payload values like "$F5XC_NAMESPACE" are the
+			// primary use case and don't appear with preceding word chars in practice.
 			return payloadJson.replace(/\$F5XC_([A-Z0-9_]+)/g, (match, suffix) => {
 				const key = `F5XC_${suffix}`;
 				// Never expand credential keys into payloads

--- a/packages/coding-agent/src/tools/xcsh-api.ts
+++ b/packages/coding-agent/src/tools/xcsh-api.ts
@@ -105,7 +105,14 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 			const response = await fetch(url, init);
 			const raw = await response.text();
 			const contentType = response.headers.get("content-type") ?? "";
-			const bodyText = contentType.includes("application/json") ? JSON.stringify(JSON.parse(raw)) : raw;
+			let bodyText = raw;
+			if (contentType.includes("application/json")) {
+				try {
+					bodyText = JSON.stringify(JSON.parse(raw));
+				} catch {
+					// Server declared JSON but returned unparseable body — fall back to raw text
+				}
+			}
 			const statusLine = `${response.status} ${response.statusText}`;
 
 			return {
@@ -117,6 +124,7 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 			const message = err instanceof Error ? err.message : String(err);
 			return {
 				content: [{ type: "text", text: `Request failed: ${message}` }],
+				details: { status: 0, url, method: params.method, requestId },
 				isError: true,
 			};
 		}

--- a/packages/coding-agent/test/services/context-env.test.ts
+++ b/packages/coding-agent/test/services/context-env.test.ts
@@ -67,6 +67,13 @@ describe("createContextEnv", () => {
 				else delete process.env.F5XC_NAMESPACE;
 			}
 		});
+
+		it("does not re-resolve explicit param values containing {placeholder} syntax", () => {
+			const ctx = createContextEnv(makeSettings({ F5XC_OTHER: "leaked" }));
+			const result = ctx.resolvePath("/api/{namespace}/resource", { namespace: "{other}" });
+			// The value "{other}" should be inserted literally — NOT re-resolved to "leaked"
+			expect(result).toBe("/api/{other}/resource");
+		});
 	});
 
 	describe("resolvePayloadVars()", () => {

--- a/packages/coding-agent/test/xcsh-api-tool.test.ts
+++ b/packages/coding-agent/test/xcsh-api-tool.test.ts
@@ -330,4 +330,75 @@ describe("XcshApiTool", () => {
 			else delete process.env.F5XC_API_TOKEN;
 		}
 	});
+
+	it("returns raw text when server declares JSON but body is unparseable", async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (_input: any, _init?: any) => {
+			return new Response("not-valid-json", {
+				status: 200,
+				statusText: "OK",
+				headers: { "Content-Type": "application/json" },
+			});
+		}) as typeof fetch;
+		const originalUrl = process.env.F5XC_API_URL;
+		const originalToken = process.env.F5XC_API_TOKEN;
+		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
+		process.env.F5XC_API_TOKEN = "test-token";
+		try {
+			const tool = new XcshApiTool(mockSession());
+			const result = await tool.execute("call-json-fallback", {
+				method: "GET",
+				path: "/api/config/namespaces/default/healthchecks",
+			});
+			const text = result.content.find(c => c.type === "text")?.text ?? "";
+			// Should fall back to raw text, not throw into catch block
+			expect(text).toContain("200 OK");
+			expect(text).toContain("not-valid-json");
+			// Should NOT be an error — HTTP 200 with unparseable body is still a success
+			expect(result.isError).toBeUndefined();
+			// Details should be preserved (requestId, status)
+			const details = (result as any).details;
+			expect(details?.status).toBe(200);
+			expect(details?.requestId).toBeDefined();
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (originalUrl) process.env.F5XC_API_URL = originalUrl;
+			else delete process.env.F5XC_API_URL;
+			if (originalToken) process.env.F5XC_API_TOKEN = originalToken;
+			else delete process.env.F5XC_API_TOKEN;
+		}
+	});
+
+	it("includes requestId in network error details", async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (_input: any, _init?: any) => {
+			throw new TypeError("Failed to fetch");
+		}) as unknown as typeof fetch;
+		const originalUrl = process.env.F5XC_API_URL;
+		const originalToken = process.env.F5XC_API_TOKEN;
+		process.env.F5XC_API_URL = "https://test.console.ves.volterra.io";
+		process.env.F5XC_API_TOKEN = "test-token";
+		try {
+			const tool = new XcshApiTool(mockSession());
+			const result = await tool.execute("call-net-err", {
+				method: "GET",
+				path: "/api/config/namespaces/default/healthchecks",
+			});
+			expect(result.isError).toBe(true);
+			const text = result.content.find(c => c.type === "text")?.text ?? "";
+			expect(text).toContain("Failed to fetch");
+			// requestId should be present in details even on network error
+			const details = (result as any).details;
+			expect(details).toBeDefined();
+			expect(details?.requestId).toBeDefined();
+			expect(details?.status).toBe(0);
+			expect(details?.method).toBe("GET");
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (originalUrl) process.env.F5XC_API_URL = originalUrl;
+			else delete process.env.F5XC_API_URL;
+			if (originalToken) process.env.F5XC_API_TOKEN = originalToken;
+			else delete process.env.F5XC_API_TOKEN;
+		}
+	});
 });


### PR DESCRIPTION
## Summary

Fixes #554 — four findings from QA pass 2 comprehensive acceptance testing.

### Changes

| Finding | Severity | File | Fix |
|---|---|---|---|
| **F3**: Malformed JSON parse loses requestId + status | MEDIUM | `xcsh-api.ts` | Inner try/catch wraps JSON.parse; falls back to raw text |
| **F4**: Network errors lose requestId | LOW | `xcsh-api.ts` | Catch block now includes `details: { status: 0, url, method, requestId }` |
| **F1**: Double-substitution in resolvePath | MEDIUM | `context-env.ts` | Track substituted positions; auto-resolve skips them |
| **F2**: $F5XC_ regex mid-string match | LOW | `context-env.ts` | Documented as intentional with code comment |

### Tests added

- `returns raw text when server declares JSON but body is unparseable` — verifies F3 fix
- `includes requestId in network error details` — verifies F4 fix
- `does not re-resolve explicit param values containing {placeholder} syntax` — verifies F1 fix

### Verification

- `bun check:ts` clean (pre-existing glab warning unrelated)
- 40/40 tests pass, 66 assertions, 195ms
- Live CRUD verified: POST/GET/DELETE/verify-404 all succeed with {namespace} auto-resolution

### QA pass 2 context

119/120 tests passed across 7 categories (core unit, benchmark, auth determinism, path edge cases, payload edge cases, error handling, live CRUD). The single benchmark failure was POST latency variance (network), not a code regression.
