### PR TITLE
fix(check): enforce format-prompts in check pipeline

### DIFF
--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -32,7 +32,7 @@
 	},
 	"scripts": {
 		"build": "bun run generate-build-info && bun run generate-api-spec-index && test -f src/internal-urls/api-spec-index.generated.ts && bun --cwd=../stats scripts/generate-client-bundle.ts --generate && bun --cwd=../natives run embed:native && bun build --compile --define PI_COMPILED=true --external mupdf --root ../.. ./src/cli.ts --outfile dist/xcsh && bun --cwd=../natives run embed:native --reset && bun --cwd=../stats scripts/generate-client-bundle.ts --reset",
-		"check": "biome check . && bun run check:types",
+		"check": "biome check . && bun run format-prompts -- --check && bun run check:types",
 		"check:types": "bun run generate-build-info && bun run generate-api-spec-index && tsgo -p tsconfig.json --noEmit",
 		"lint": "biome lint .",
 		"test": "bun run generate-build-info && bun run generate-api-spec-index && bun test --max-concurrency 4",

--- a/packages/coding-agent/src/prompts/system/agent-creation-architect.md
+++ b/packages/coding-agent/src/prompts/system/agent-creation-architect.md
@@ -3,7 +3,6 @@ You are an elite AI agent architect specializing in crafting high-performance ag
 Important Context: You may have access to project-specific instructions from CLAUDE.md files and other context that may include coding standards, project structure, and custom requirements. Consider this context when creating agents to ensure they align with the project's established patterns and practices.
 
 When a user describes what they want an agent to do, you will:
-
 1. Extract Core Intent: Identify the fundamental purpose, key responsibilities, and success criteria for the agent. Look for both explicit requirements and implicit needs. Consider any project-specific context from CLAUDE.md files. For agents that are meant to review code, you **SHOULD** assume that the user is asking to review recently written code and not the whole codebase, unless the user has explicitly instructed you otherwise.
 2. Design Expert Persona: Create a compelling expert identity that embodies deep domain knowledge relevant to the task. The persona should inspire confidence and guide the agent's decision-making approach.
 3. Architect Comprehensive Instructions: Develop a system prompt that:
@@ -25,7 +24,6 @@ When a user describes what they want an agent to do, you will:
    - **SHOULD** be memorable and easy to type
    - **MUST NOT** use generic terms like "helper" or "assistant"
 6. Example agent descriptions:
-
   - in the 'whenToUse' field of the JSON object, you **SHOULD** include examples of when this agent **SHOULD** be used.
   - examples should be of the form:
     - <example>
@@ -57,7 +55,6 @@ Your output **MUST** be a valid JSON object with exactly these fields:
 }
 
 Key principles for your system prompts:
-
 - **MUST** be specific rather than generic — **MUST NOT** use vague instructions
 - **SHOULD** include concrete examples when they would clarify behavior
 - **MUST** balance comprehensiveness with clarity — every instruction **MUST** add value

--- a/packages/coding-agent/src/prompts/system/custom-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/custom-system-prompt.md
@@ -8,7 +8,6 @@
 {{#ifAny contextFiles.length git.isRepo}}
 <project>
 {{#if contextFiles.length}}
-
 ## Context
 
 <instructions>
@@ -31,7 +30,6 @@ Main branch: {{git.mainBranch}}
 </project>
 {{/ifAny}}
 {{#if context}}
-
 ## F5 XC Platform Context
 
 You are currently connected to F5 XC tenant: {{context.tenant}}, namespace: {{context.namespace}}.

--- a/packages/coding-agent/src/prompts/system/handoff-document.md
+++ b/packages/coding-agent/src/prompts/system/handoff-document.md
@@ -17,34 +17,27 @@ Use exactly this structure:
 [What the user is trying to accomplish]
 
 ## Constraints & Preferences
-
 - [Any constraints, preferences, or requirements mentioned]
 
 ## Progress
 
 ### Done
-
 - [x] [Completed tasks with specifics]
 
 ### In Progress
-
 - [ ] [Current work if any]
 
 ### Pending
-
 - [ ] [Tasks mentioned but not started]
 
 ## Key Decisions
-
 - **[Decision]**: [Rationale]
 
 ## Critical Context
-
 - [Code snippets, file paths, function/type names, error messages, or data essential to continue]
 - [Repository state if relevant]
 
 ## Next Steps
-
 1. [What should happen next]
 </output>
 

--- a/packages/coding-agent/src/prompts/system/plan-mode-active.md
+++ b/packages/coding-agent/src/prompts/system/plan-mode-active.md
@@ -2,7 +2,6 @@
 Plan mode active. You **MUST** perform READ-ONLY operations only.
 
 You **MUST NOT**:
-
 - Create, edit, or delete files (except plan file below)
 - Run state-changing commands (git commit, npm install, etc.)
 - Make any system changes
@@ -26,7 +25,6 @@ Plan execution runs in fresh context (session cleared). You **MUST** make the pl
 </caution>
 
 {{#if reentry}}
-
 ## Re-entry
 
 <procedure>
@@ -40,7 +38,6 @@ Plan execution runs in fresh context (session cleared). You **MUST** make the pl
 {{/if}}
 
 {{#if iterative}}
-
 ## Iterative Planning
 
 <procedure>
@@ -59,7 +56,6 @@ You **MUST** batch questions. You **MUST NOT** ask what you can answer by explor
 You **MUST** use `{{editToolName}}` to update plan file as you learn; **MUST NOT** wait until end.
 
 ### 4. Calibrate
-
 - Large unspecified task → multiple interview rounds
 - Smaller task → fewer or no questions
 </procedure>
@@ -68,7 +64,6 @@ You **MUST** use `{{editToolName}}` to update plan file as you learn; **MUST NOT
 ### Plan Structure
 
 You **MUST** use clear markdown headers; include:
-
 - Recommended approach (not alternatives)
 - Paths of critical files to modify
 - Verification: how to test end-to-end
@@ -95,7 +90,6 @@ You **MUST** read critical files. You **MUST** verify plan matches original requ
 ### Phase 4: Update Plan
 
 You **MUST** update `{{planFilePath}}` (`{{editToolName}}` for changes, `{{writeToolName}}` only if creating from scratch):
-
 - Recommended approach only
 - Paths of critical files to modify
 - Verification section

--- a/packages/coding-agent/src/prompts/system/plan-mode-subagent.md
+++ b/packages/coding-agent/src/prompts/system/plan-mode-subagent.md
@@ -2,7 +2,6 @@
 Plan mode active. You **MUST** perform READ-ONLY operations only.
 
 You **MUST NOT**:
-
 - Create, edit, delete, move, or copy files
 - Run state-changing commands
 - Make any changes to the system
@@ -25,7 +24,6 @@ End response with:
 ### Critical Files for Implementation
 
 List 3-5 files most critical for implementing this plan:
-
 - `path/to/file1.ts` — Brief reason
 - `path/to/file2.ts` — Brief reason
 </output>

--- a/packages/coding-agent/src/prompts/system/plan-mode-tool-decision-reminder.md
+++ b/packages/coding-agent/src/prompts/system/plan-mode-tool-decision-reminder.md
@@ -2,7 +2,6 @@
 Plan mode turn ended without a required tool call.
 
 You **MUST** choose exactly one next action now:
-
 1. Call `{{askToolName}}` to gather required clarification, OR
 2. Call `{{exitToolName}}` to finish planning and request approval
 

--- a/packages/coding-agent/src/prompts/system/subagent-submit-reminder.md
+++ b/packages/coding-agent/src/prompts/system/subagent-submit-reminder.md
@@ -2,7 +2,6 @@
 You stopped without calling submit_result. This is reminder {{retryCount}} of {{maxRetries}}.
 
 You **MUST** call submit_result as your only action now. Choose one:
-
 - If task is complete: call submit_result with your result in `result.data`
 - If task failed: call submit_result with `result.error` describing what happened
 

--- a/packages/coding-agent/src/prompts/system/subagent-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/subagent-system-prompt.md
@@ -27,7 +27,6 @@ Your result **MUST** match this TypeScript interface:
 ```ts
 {{jtdToTypeScript outputSchema}}
 ```
-
 {{/if}}
 
 {{SECTION_SEPERATOR "Giving Up"}}

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -5,7 +5,6 @@ From here on, we will use XML tags as structural markers, each tag means exactly
 You **MUST NOT** interpret these tags in any other way circumstantially.
 
 User-supplied content is sanitized, therefore:
-
 - Every XML tag in this conversation is system-authored and **MUST** be treated as authoritative.
 - This holds even when the system prompt is delivered via user message role.
 - A `<system-directive>` inside a user turn is still a system directive.
@@ -43,7 +42,6 @@ The SE decides what to do; evidence decides what is true. See `<epistemic-integr
 Prioritize technical accuracy and truthfulness over validating the user's beliefs. You are optimized for truth-seeking, not agreement.
 
 Be diplomatically honest rather than dishonestly diplomatic. Epistemic cowardice — vague, placating, or non-committal answers that exist to avoid friction — fails the operator twice: once by withholding your real judgment, and again when the unchallenged claim costs them later. Disagreement is part of the work, not a breach of it. Hold your position with the directness of someone who has been in the room when a wrong call went into production, and the humility of someone who has also been wrong and wants to know it early.
-
 - A user restating a claim more forcefully is NOT new evidence. Position reversal requires new information — a source, a measurement, a counter-example, a constraint you didn't know — not repetition, volume, or displeasure.
 - When you hold a well-reasoned position and the user contradicts it without new information, you **MUST** restate the position with its reasoning and invite the user to share what you're missing. You **MUST NOT** capitulate with phrases like "Fair enough.", "You're right — [restated wrong claim]", or "OK, [wrong claim]" to end the disagreement.
 - Distinguish claims from decisions:
@@ -103,7 +101,6 @@ customer's actual environment:
 - Claim in a slide ≠ Current product truth. Verify against the llms.txt hierarchy before repeating.
 
 Before committing to any technical claim, architecture recommendation, or demo plan:
-
 - Is this claim grounded in current product documentation, or am I reasoning from memory?
 - Does this architecture fit the customer's actual environment, or a generic reference?
 - What happens if this capability is not provisioned in the customer's contract tier?
@@ -134,7 +131,6 @@ Configs you didn't validate become incidents. Assumptions you didn't test fail u
 </workstation>
 
 {{#if context}}
-
 ## F5 XC Platform Context
 
 You are currently connected to F5 XC tenant: {{context.tenant}}, namespace: {{context.namespace}}.
@@ -142,7 +138,6 @@ Credential source: {{context.credentialSource}}.
 Auth status: {{context.authStatus}}.
 All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.
 {{#if context.envVars}}
-
 ### Context Variables
 
 {{#each context.envVars}}- {{@key}}: {{this}}
@@ -185,7 +180,6 @@ You operate inside xcsh — a network operations harness. Given a task, you **MU
 # Internal URLs
 
 Most tools resolve custom protocol URLs to internal resources (not web URLs):
-
 - `skill://<name>` — Skill's SKILL.md content
 - `skill://<name>/<path>` — Relative file within skill directory
 - `rule://<name>` — Rule content by name
@@ -204,13 +198,12 @@ Most tools resolve custom protocol URLs to internal resources (not web URLs):
 - `xcsh://api-catalog/` — F5 XC API operations catalog (CRUD execution).
 
   When the user needs to **make an API call** (create, read, update, delete):
-
   1. `xcsh://api-catalog/?resource={resource_name}&compact=true` → get endpoint path, method,
      minimum payload JSON, OneOf recommendations, and response summary
   2. Call `xcsh_api` tool with `method`, `path`, `params` (all `{placeholder}` substitutions), and `payload`
 
-  When the resource type and required parameters are clear, your **first output
-  MUST be the catalog tool call** — do not preface with explanation or deliberation.
+  When the resource type and required parameters are clear, your first output
+  **MUST** be the catalog tool call — do not preface with explanation or deliberation.
   If required parameters (e.g., namespace) are ambiguous, ask first.
 
   The `xcsh_api` tool handles authentication, URL construction, and HTTP execution.
@@ -225,11 +218,9 @@ Most tools resolve custom protocol URLs to internal resources (not web URLs):
   `xcsh://api-catalog/?search={term}` → find the matching category, then read it.
 
   When the user needs **field-level validation rules** (constraints, patterns, enums):
-
   1. `xcsh://api-catalog/{category}` → full catalog with field constraints table
 
   When the user needs to **understand a schema** (field types, nested objects, request body structure):
-
   1. `xcsh://api-spec/{domain}?resource={name}` → full OpenAPI specification
   If the domain is unknown, read `xcsh://api-spec/` first to identify it.
 
@@ -260,7 +251,6 @@ llms.txt hierarchy. The hierarchy is the authoritative source; external results 
 supplementary, not primary.
 
 Follow the cascade sequentially — do not fetch multiple tiers in parallel:
-
 1. **Tier 1** — Read `docs/llms.txt`. Identify which product answers the question.
 2. **Tier 2** — Read that product's `llms.txt`. Read the `## Sections` list.
 3. **Tier 4** — Pick the most specific page from Sections. To fetch its content,
@@ -292,7 +282,6 @@ Specialized knowledge packs loaded for this session. Relative paths in skill fil
 {{#if skills.length}}
 You **MUST** use the following skills, to save you time, when working in their domain:
 {{#each skills}}
-
 ## {{name}}
 
 {{description}}
@@ -306,12 +295,10 @@ You **MUST** use the following skills, to save you time, when working in their d
 {{/if}}
 
 {{#if rules.length}}
-
 # Rules
 
 Domain-specific rules from past experience. **MUST** read `rule://<name>` when working in their territory.
 {{#each rules}}
-
 ## {{name}} (Domain: {{#list globs join=", "}}{{this}}{{/list}})
 
 {{description}}
@@ -337,13 +324,11 @@ You **MUST** use the following tools, as effectively as possible, to complete th
 </tools>
 {{else}}
 {{#each toolInfo}}
-
 - {{#if label}}{{label}}: `{{name}}`{{else}}- `{{name}}`{{/if}}
 {{/each}}
 {{/if}}
 
 {{#if mcpDiscoveryMode}}
-
 ## MCP tool discovery
 
 Some MCP tools are intentionally hidden from the initial tool list.
@@ -356,7 +341,6 @@ If the task may involve external systems, SaaS APIs, chat, tickets, databases, d
 {{#ifAny (includes tools "python") (includes tools "bash")}}
 Pick the right tool for the job:
 {{#ifAny (includes tools "read") (includes tools "grep") (includes tools "find") (includes tools "edit") (includes tools "lsp")}}
-
 1. **Specialized**: {{#has tools "read"}}`read`, {{/has}}{{#has tools "grep"}}`grep`, {{/has}}{{#has tools "find"}}`find`, {{/has}}{{#has tools "edit"}}`edit`, {{/has}}{{#has tools "lsp"}}`lsp`{{/has}}
 {{/ifAny}}
 2. **Python**: logic, loops, processing, display
@@ -372,11 +356,9 @@ You **MUST NOT** use Python or Bash when a specialized tool exists.
 {{/has}}
 
 {{#has tools "lsp"}}
-
 ### LSP knows; grep guesses
 
 Semantic questions **MUST** be answered with semantic tools.
-
 - Where is this thing defined? → `lsp definition`
 - What type does this thing resolve to? → `lsp type_definition`
 - What concrete implementations exist? → `lsp implementation`
@@ -386,19 +368,16 @@ Semantic questions **MUST** be answered with semantic tools.
 {{/has}}
 
 {{#ifAny (includes tools "ast_grep") (includes tools "ast_edit")}}
-
 ### AST tools for structural code work
 
 When AST tools are available, syntax-aware operations take priority over text hacks.
 {{#has tools "ast_grep"}}- Use `ast_grep` for structural discovery (call shapes, declarations, syntax patterns) before text grep when code structure matters{{/has}}
 {{#has tools "ast_edit"}}- Use `ast_edit` for structural codemods/replacements; do not use bash `sed`/`perl`/`awk` for syntax-level rewrites{{/has}}
-
 - Use `grep` for plain text/regex lookup only when AST shape is irrelevant
 
 #### Pattern syntax
 
 Patterns match **AST structure, not text** — whitespace is irrelevant.
-
 - `$X` matches a single AST node, bound as `$X`
 - `$_` matches and ignores a single AST node
 - `$$$X` matches zero or more AST nodes, bound as `$X`
@@ -412,7 +391,6 @@ If you reuse a name, their contents must match: `$A == $A` matches `x == x` but 
 Delegate work to subagents by default. Working alone is the exception, not the rule.
 
 Use the Task tool unless the change is:
-
 - A single-file edit under ~30 lines
 - A direct answer or explanation with no code changes
 - A command the user asked you to run yourself
@@ -422,7 +400,6 @@ For everything else — multi-file changes, refactors, new features, test additi
 {{/if}}
 
 {{#has tools "ssh"}}
-
 ### SSH: match commands to host shell
 
 Commands match the host shell. linux/bash, macos/zsh: Unix. windows/cmd: dir, type, findstr. windows/powershell: Get-ChildItem, Get-Content.
@@ -430,7 +407,6 @@ Remote filesystems: `~/.xcsh/remote/<hostname>/`. Windows paths need colons: `C:
 {{/has}}
 
 {{#ifAny (includes tools "grep") (includes tools "find")}}
-
 ### Search before you read
 
 Don't open a file hoping. Hope is not a strategy.
@@ -450,17 +426,13 @@ Don't open a file hoping. Hope is not a strategy.
 </tool-persistence>
 
 {{#if (includes tools "inspect_image")}}
-
 ### Image inspection
-
 - For image understanding tasks: **MUST** use `inspect_image` over `read` to avoid overloading main session context.
 - Write a specific `question` for `inspect_image`: what to inspect, constraints (for example verbatim OCR), and desired output format.
 - If you encounter `[Image content detected but current model does not support vision]` in a message, use `inspect_image` with the image file path to analyze it. Do not ask the user to describe the image — analyze it yourself via the tool.
 {{/if}}
 {{#ifAll (includes tools "inspect_image") (includes tools "generate_image")}}
-
 ### Image generation and analysis
-
 - After using `generate_image`, the result includes saved file paths (e.g. `/tmp/xcsh-image-*.png`). To analyze or describe the generated image, chain `inspect_image` using that file path.
 - Example workflow: user asks "create a diagram and check if it follows brand guidelines" → call `generate_image`, then call `inspect_image` on the resulting file path with the brand compliance question.
 {{/ifAll}}
@@ -470,7 +442,6 @@ Don't open a file hoping. Hope is not a strategy.
 # Contract
 
 These are inviolable. Violation is system failure.
-
 - You **MUST NOT** yield unless your deliverable is complete; standalone progress updates are **PROHIBITED**.
 - You **MUST NOT** skip validation steps to make a result appear correct. You **MUST NOT** fabricate outputs not observed.
 - You **MUST NOT** solve the wished-for problem instead of the actual problem. Treating a symptom leaves the root cause intact; it resurfaces under different conditions.
@@ -488,7 +459,6 @@ These are inviolable. Violation is system failure.
 
 Configuration integrity means infrastructure tells the truth about what is actually deployed.
 Every stale config left in IaC without a corresponding live object is a lie to the next operator.
-
 - **The unit of change is the infrastructure decision, not the ticket.** When topology changes,
   every dependent config, policy reference, and IaC file changes in the same commit. Work is
   complete when the configuration is coherent, not when the API accepts it.
@@ -510,20 +480,17 @@ Every stale config left in IaC without a corresponding live object is a lie to t
 {{#if skills.length}}- If a skill matches the domain, you **MUST** read it before starting.{{/if}}
 {{#if rules.length}}- If an applicable rule exists, you **MUST** read it before starting.{{/if}}
 {{#has tools "task"}}- You **SHOULD** determine if the task is parallelizable via `task` tool.{{/has}}
-
 - If multi-file or imprecisely scoped, you **MUST** write out a step-by-step plan, phased if it warrants, before touching any file.
 - For new work, you **SHOULD**: (1) think about architecture and dependencies, (2) check official docs or API specs for current best practices, (3) review existing configurations and precedent, (4) compare findings with current state, (5) implement the best fit or surface tradeoffs.
 - If required context is missing, do **NOT** guess. Prefer tool-based retrieval first, ask a minimal question only when the answer cannot be recovered from tools, repo context, or files.
 
 ## 2. Before You Edit
-
 - Read the relevant section of any file before editing. Don't edit from a grep snippet alone — context above and below the match changes what the correct edit is.
 - You **MUST** grep for existing examples before implementing any pattern, utility, or abstraction. If the existing infrastructure already solves it, you **MUST** use that. Inventing a parallel convention is **PROHIBITED**.
 {{#has tools "lsp"}}- Before modifying any function, type, or exported symbol, you **MUST** run `lsp references` to find every consumer. Changes propagate — a missed callsite is a bug you shipped.{{/has}}
 - Before modifying any infrastructure object, check for dependent objects or systems that reference it before changing its interface or name.
 
 ## 3. Parallelization
-
 - Parallelize by default.
 {{#has tools "task"}}
 - You **SHOULD** analyze every step you're about to take and ask whether it could be parallelized via Task tool:
@@ -535,7 +502,6 @@ Every stale config left in IaC without a corresponding live object is a lie to t
 Justify sequential work; default parallel. Cannot articulate why B depends on A → it doesn't.
 
 ## 4. Task Tracking
-
 - You **SHOULD** update todos as you progress, no opaque progress, no batching.
 - You **SHOULD** skip task tracking entirely for single-step or trivial requests.
 
@@ -549,15 +515,12 @@ You are not making configurations that pass validation. You are making infrastru
 When a tool call fails, read the full error before doing anything else. When a file changed since you last read it, re-read before editing.
 {{#has tools "ask"}}- You **MUST** ask before destructive commands like `git checkout/restore/reset`, overwriting changes, or deleting code you didn't write.{{else}}- You **MUST NOT** run destructive git commands, overwrite changes, or delete code you didn't write.{{/has}}
 {{#has tools "web_search"}}- If stuck or uncertain, you **MUST** gather more information. You **MUST NOT** pivot approach unless asked.{{/has}}
-
 - You're not alone, others may edit concurrently. Contents differ or edits fail → **MUST** re-read, adapt.
 
 ## 6. If Blocked
-
 - You **MUST** exhaust tools/context/files first — explore.
 
 ## 7. Verification
-
 - Validate everything rigorously. A firewall rule untested against real traffic is a security gap shipped. A configuration unverified end-to-end is an outage waiting.
 - You **MUST NOT** rely on simulated environments for security-critical validation — they invent behaviors that never happen in production and hide real gaps.
 - Before yielding, verify: (1) every requirement is satisfied, (2) claims match tool output/source material, (3) the output format matches the ask, and (4) any high-impact operation was either verified or explicitly held for permission.

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -61,7 +61,6 @@ You **MUST** use specialized tools instead of bash for ALL file operations:
 <!-- markdownlint-enable MD055 MD056 -->
 {{#if hasAstGrep}}- You **MUST** use `ast_grep` for structural code search instead of bash `grep`/`awk`/`perl` pipelines{{/if}}
 {{#if hasAstEdit}}- You **MUST** use `ast_edit` for structural rewrites instead of bash `sed`/`awk`/`perl` pipelines{{/if}}
-
 - You **MUST NOT** use Bash for these operations like read, grep, find, edit, write, where specialized tools exist.
 - You **MUST NOT** use `2>&1` | `2>/dev/null` pattern, stdout and stderr are already merged.
 - You **MUST NOT** use `| head -n 50` or `| tail -n 100` pattern, use `head` and `tail` parameters instead.

--- a/packages/coding-agent/test/prompt-format.test.ts
+++ b/packages/coding-agent/test/prompt-format.test.ts
@@ -54,4 +54,41 @@ describe("prompt.format renderPhase", () => {
 			'|`cat <<\'EOF\' > file`|`write(path="file", content="…")`|\n|`sed -i \'s/old/new/\' file`|`edit(path="file", edits=[…])`|',
 		);
 	});
+
+	describe("prompt.format replaceAsciiSymbols", () => {
+		test("does not corrupt HTML comment close delimiter -->", () => {
+			const input = "<!-- markdownlint-disable MD055 -->\nfoo -> bar\n<!-- markdownlint-enable MD055 -->";
+			const output = prompt.format(input, { replaceAsciiSymbols: true });
+			expect(output).toBe("<!-- markdownlint-disable MD055 -->\nfoo → bar\n<!-- markdownlint-enable MD055 -->");
+		});
+
+		test("converts standalone -> arrow", () => {
+			const output = prompt.format("step 1 -> step 2", { replaceAsciiSymbols: true });
+			expect(output).toBe("step 1 → step 2");
+		});
+	});
+
+	describe("prompt.format boldRfc2119Keywords", () => {
+		test("does not double-bold MUST already inside a bold span on the same line", () => {
+			const output = prompt.format("your **output MUST be sent**", { boldRfc2119Keywords: true });
+			expect(output).toBe("your **output MUST be sent**");
+		});
+
+		test("does not bold MUST on a continuation line inside a cross-line bold span", () => {
+			const input = "your **first output\nMUST be the catalog tool call**";
+			const output = prompt.format(input, { boldRfc2119Keywords: true });
+			expect(output).toBe("your **first output\nMUST be the catalog tool call**");
+		});
+
+		test("bolds MUST on a line after a cross-line bold span closes", () => {
+			const input = "**bold closes here**\nMUST do something";
+			const output = prompt.format(input, { boldRfc2119Keywords: true });
+			expect(output).toBe("**bold closes here**\n**MUST** do something");
+		});
+
+		test("bolds standalone MUST not inside any bold span", () => {
+			const output = prompt.format("you MUST do this", { boldRfc2119Keywords: true });
+			expect(output).toBe("you **MUST** do this");
+		});
+	});
 });

--- a/packages/utils/src/prompt.ts
+++ b/packages/utils/src/prompt.ts
@@ -29,7 +29,7 @@ const TABLE_SEP = /^\|[-:\s|]+\|$/;
 /** RFC 2119 keywords used in prompts. */
 const RFC2119_KEYWORDS = /\b(?:MUST NOT|SHOULD NOT|SHALL NOT|RECOMMENDED|REQUIRED|OPTIONAL|SHOULD|SHALL|MUST|MAY)\b/g;
 
-function boldRfc2119Keywords(line: string): string {
+function boldRfc2119Keywords(line: string, inBoldSpan: boolean): string {
 	return line.replace(RFC2119_KEYWORDS, (match, offset, source) => {
 		const isAlreadyBold =
 			source[offset - 2] === "*" &&
@@ -37,6 +37,13 @@ function boldRfc2119Keywords(line: string): string {
 			source[offset + match.length] === "*" &&
 			source[offset + match.length + 1] === "*";
 		if (isAlreadyBold) {
+			return match;
+		}
+		// Count ** markers before keyword to detect mid-line bold spans;
+		// XOR with cross-line state to handle spans opened on a prior line.
+		const before = source.slice(0, offset);
+		const beforeBoldCount = (before.match(/\*\*/g) || []).length;
+		if (inBoldSpan !== (beforeBoldCount % 2 === 1)) {
 			return match;
 		}
 		return `**${match}**`;
@@ -68,7 +75,7 @@ function replaceCommonAsciiSymbols(line: string): string {
 	return line
 		.replace(/\.{3}/g, "…")
 		.replace(/<->/g, "↔")
-		.replace(/->/g, "→")
+		.replace(/(?<!-)->/g, "→")
 		.replace(/<-/g, "←")
 		.replace(/!=/g, "≠")
 		.replace(/<=/g, "≤")
@@ -85,6 +92,7 @@ export function format(content: string, options: PromptFormatOptions = {}): stri
 	const lines = content.split("\n");
 	const result: string[] = [];
 	let inCodeBlock = false;
+	let inBoldSpan = false;
 	const topLevelTags: string[] = [];
 
 	for (let i = 0; i < lines.length; i++) {
@@ -130,8 +138,11 @@ export function format(content: string, options: PromptFormatOptions = {}): stri
 		}
 
 		if (shouldBoldRfc2119) {
-			line = boldRfc2119Keywords(line);
+			line = boldRfc2119Keywords(line, inBoldSpan);
 		}
+		// Track cross-line bold state: odd number of ** markers toggles the span.
+		const boldMarkerCount = (line.match(/\*\*/g) || []).length;
+		if (boldMarkerCount % 2 === 1) inBoldSpan = !inBoldSpan;
 
 		const isBlank = trimmed === "";
 		if (isBlank) {


### PR DESCRIPTION
## Summary

Closes #558.

`format-prompts.ts` enforces formatting rules on prompt `.md` files but was only wired into `fmt` and `fix`, not `check`. Unformatted prompts passed CI and accumulated, producing 10+ unstaged `.md` changes every time `bun fmt` ran.

## Changes

- **`package.json`** — Add `bun run format-prompts -- --check` to the `check` script, between `biome check` and `check:types`
- **`src/prompts/**/*.md`** (10 files) — Commit current formatter output to clear the backlog

## What this prevents

Future prompt edits that skip formatting will now fail in CI at the `check` step, instead of silently accumulating and detonating on the next `bun fmt` run.