### PR TITLE
fix(welcome): remove redundant status text from connected states

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -229,7 +229,7 @@ export class WelcomeComponent implements Component {
 		const p = provider ?? "unknown";
 		switch (state) {
 			case "connected":
-				return [` ${formatStatusIcon("connected")} ${theme.fg("muted", p)} ${theme.fg("dim", "\u2014 connected")}`];
+				return [` ${formatStatusIcon("connected")} ${theme.fg("muted", p)}`];
 			case "auth_error":
 				return [
 					` ${formatStatusIcon("error")} ${theme.fg("muted", p)} ${theme.fg("error", "\u2014 connection failed")}`,
@@ -249,7 +249,7 @@ export class WelcomeComponent implements Component {
 		const n = name ?? "(unknown)";
 		switch (state) {
 			case "connected":
-				return [` ${formatStatusIcon("connected")} ${theme.fg("muted", n)} ${theme.fg("dim", "\u2014 connected")}`];
+				return [` ${formatStatusIcon("connected")} ${theme.fg("muted", n)}`];
 			case "auth_error":
 				return [
 					` ${formatStatusIcon("error")} ${theme.fg("muted", n)} ${theme.fg("error", "\u2014 token invalid")}`,
@@ -279,9 +279,7 @@ export class WelcomeComponent implements Component {
 		const { state, project } = this.gitlabStatus;
 		switch (state) {
 			case "connected":
-				return [
-					` ${formatStatusIcon("connected")} ${theme.fg("muted", project ?? "configured")} ${theme.fg("dim", "\u2014 connected")}`,
-				];
+				return [` ${formatStatusIcon("connected")} ${theme.fg("muted", project ?? "configured")}`];
 			case "auth_error":
 				return [
 					` ${formatStatusIcon("error")} ${theme.fg("error", "Not authenticated")}`,
@@ -308,7 +306,7 @@ export class WelcomeComponent implements Component {
 		switch (state) {
 			case "connected":
 				return [
-					` ${formatStatusIcon("connected")} ${theme.fg("muted", orgAlias ?? "org")}${username ? ` ${theme.fg("dim", `(${username})`)}` : ""} ${theme.fg("dim", "— ready")}`,
+					` ${formatStatusIcon("connected")} ${theme.fg("muted", orgAlias ?? "org")}${username ? ` ${theme.fg("dim", `(${username})`)}` : ""}`,
 				];
 			case "not_configured":
 				return [

--- a/packages/coding-agent/test/welcome-component.test.ts
+++ b/packages/coding-agent/test/welcome-component.test.ts
@@ -28,7 +28,6 @@ describe("WelcomeComponent", () => {
 		const out = renderPlain(c).join("\n");
 		expect(out).toContain("Model Provider");
 		expect(out).toContain("litellm");
-		expect(out).toContain("connected");
 		// Unified emoji indicator (iTerm2 + Nerd Fonts)
 		expect(out).toContain("✅");
 		expect(out).not.toContain("●");
@@ -264,7 +263,6 @@ describe("WelcomeComponent", () => {
 			const out = renderPlain(c).join("\n");
 			expect(out).toContain("GitLab");
 			expect(out).toContain("mygroup/myproject");
-			expect(out).toContain("connected");
 			expect(out).toContain("\u2705");
 		});
 


### PR DESCRIPTION
## Summary

- Remove redundant status text from connected states in the welcome component

Closes #567

## Test plan

- [ ] CI checks pass
- [ ] Welcome component renders correctly without redundant status text in connected states