### PR TITLE
fix(ci): skip Puppeteer browser download in macOS build-sign job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -752,7 +752,10 @@ jobs:
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('**/bun.lock') }}
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
       - name: Download macOS native addons
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## What

Add `PUPPETEER_SKIP_DOWNLOAD=true` env var to the `bun install` step in the `build-sign-macos` CI job.

## Why

The build-sign-macos job failed because Puppeteer's postinstall script tried to download `chrome-headless-shell` from `storage.googleapis.com`, which was unreachable due to a transient DNS failure on the GitHub Actions macOS runner. The build-sign job only builds and signs the CLI binary — it never launches a browser, so the Puppeteer browser download is unnecessary.

Closes #574

## Testing

- [x] Change is a single env var addition — no functional code affected
- [x] `bun install` will skip browser download when `PUPPETEER_SKIP_DOWNLOAD=true` is set
- [ ] CI checks pass
- [x] Issue linked via `Closes #574`