### PR TITLE
fix(tui): use runtime terminal width for all tool renderer truncation

### DIFF
--- a/packages/coding-agent/src/autoresearch/tools/init-experiment.ts
+++ b/packages/coding-agent/src/autoresearch/tools/init-experiment.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { StringEnum } from "@f5xc-salesdemos/pi-ai";
-import { Text } from "@f5xc-salesdemos/pi-tui";
+import { type Component, Text } from "@f5xc-salesdemos/pi-tui";
 import { Type } from "@sinclair/typebox";
 import type { ToolDefinition } from "../../extensibility/extensions";
 import type { Theme } from "../../modes/theme/theme";
@@ -370,8 +370,13 @@ export function createInitExperimentTool(
 				details: { state: cloneExperimentState(state) },
 			};
 		},
-		renderCall(args, _options, theme): Text {
-			return new Text(renderInitCall(args.name, theme), 0, 0);
+		renderCall(args, _options, theme): Component {
+			return {
+				render(width: number): string[] {
+					return [renderInitCall(args.name, theme, width)];
+				},
+				invalidate() {},
+			};
 		},
 		renderResult(result): Text {
 			const text = replaceTabs(result.content.find(part => part.type === "text")?.text ?? "");
@@ -380,8 +385,8 @@ export function createInitExperimentTool(
 	};
 }
 
-function renderInitCall(name: string, theme: Theme): string {
-	return `${theme.fg("toolTitle", theme.bold("init_experiment"))} ${theme.fg("contentAccent", truncateToWidth(replaceTabs(name), 100))}`;
+function renderInitCall(name: string, theme: Theme, width?: number): string {
+	return `${theme.fg("toolTitle", theme.bold("init_experiment"))} ${theme.fg("contentAccent", truncateToWidth(replaceTabs(name), Math.max(20, (width ?? 100) - 20)))}`;
 }
 
 function collectLoggedRunNumbers(results: ExperimentState["results"]): Set<number> {

--- a/packages/coding-agent/src/autoresearch/tools/log-experiment.ts
+++ b/packages/coding-agent/src/autoresearch/tools/log-experiment.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { StringEnum } from "@f5xc-salesdemos/pi-ai";
-import { Text } from "@f5xc-salesdemos/pi-tui";
+import { type Component, Text } from "@f5xc-salesdemos/pi-tui";
 import { logger } from "@f5xc-salesdemos/pi-utils";
 import { Type } from "@sinclair/typebox";
 import type { ToolDefinition } from "../../extensibility/extensions";
@@ -358,22 +358,29 @@ export function createLogExperimentTool(
 				},
 			};
 		},
-		renderCall(args, _options, theme): Text {
+		renderCall(args, _options, theme): Component {
 			const color = args.status === "keep" ? "success" : args.status === "discard" ? "warning" : "error";
-			const description = truncateToWidth(replaceTabs(args.description), 100);
-			return new Text(
-				`${theme.fg("toolTitle", theme.bold("log_experiment"))} ${theme.fg(color, args.status)} ${theme.fg("muted", description)}`,
-				0,
-				0,
-			);
+			return {
+				render(width: number): string[] {
+					const description = truncateToWidth(replaceTabs(args.description), Math.max(20, width - 30));
+					return [
+						`${theme.fg("toolTitle", theme.bold("log_experiment"))} ${theme.fg(color, args.status)} ${theme.fg("muted", description)}`,
+					];
+				},
+				invalidate() {},
+			};
 		},
-		renderResult(result, _options, theme): Text {
+		renderResult(result, _options, theme): Component {
 			const details = result.details;
 			if (!details) {
 				return new Text(replaceTabs(result.content.find(part => part.type === "text")?.text ?? ""), 0, 0);
 			}
-			const summary = renderSummary(details, theme);
-			return new Text(summary, 0, 0);
+			return {
+				render(width: number): string[] {
+					return [renderSummary(details, theme, width)];
+				},
+				invalidate() {},
+			};
 		},
 	};
 }
@@ -763,10 +770,10 @@ function truncateAsiValue(value: ASIData[string]): string {
 	return text.length > 120 ? `${text.slice(0, 117)}...` : text;
 }
 
-function renderSummary(details: LogDetails, theme: Theme): string {
+function renderSummary(details: LogDetails, theme: Theme, width?: number): string {
 	const { experiment, state } = details;
 	const color = experiment.status === "keep" ? "success" : experiment.status === "discard" ? "warning" : "error";
-	let summary = `${theme.fg(color, experiment.status.toUpperCase())} ${theme.fg("muted", truncateToWidth(replaceTabs(experiment.description), 100))}`;
+	let summary = `${theme.fg(color, experiment.status.toUpperCase())} ${theme.fg("muted", truncateToWidth(replaceTabs(experiment.description), Math.max(20, (width ?? 100) - 30)))}`;
 	summary += ` ${theme.fg("contentAccent", `${state.metricName}=${formatNum(experiment.metric, state.metricUnit)}`)}`;
 	if (state.bestMetric !== null) {
 		summary += ` ${theme.fg("dim", `baseline ${formatNum(state.bestMetric, state.metricUnit)}`)}`;

--- a/packages/coding-agent/src/autoresearch/tools/run-experiment.ts
+++ b/packages/coding-agent/src/autoresearch/tools/run-experiment.ts
@@ -1,7 +1,7 @@
 import * as childProcess from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { Text } from "@f5xc-salesdemos/pi-tui";
+import { type Component, Text } from "@f5xc-salesdemos/pi-tui";
 import { formatBytes } from "@f5xc-salesdemos/pi-utils";
 import { Type } from "@sinclair/typebox";
 import type { ToolDefinition } from "../../extensibility/extensions";
@@ -380,13 +380,14 @@ export function createRunExperimentTool(
 				details: resultDetails,
 			};
 		},
-		renderCall(args, _options, theme): Text {
-			const commandPreview = truncateToWidth(replaceTabs(args.command), 100);
-			return new Text(
-				`${theme.fg("toolTitle", theme.bold("run_experiment"))} ${theme.fg("muted", commandPreview)}`,
-				0,
-				0,
-			);
+		renderCall(args, _options, theme): Component {
+			return {
+				render(width: number): string[] {
+					const commandPreview = truncateToWidth(replaceTabs(args.command), Math.max(20, width - 20));
+					return [`${theme.fg("toolTitle", theme.bold("run_experiment"))} ${theme.fg("muted", commandPreview)}`];
+				},
+				invalidate() {},
+			};
 		},
 		renderResult(result, options, theme): Text {
 			if (isProgressDetails(result.details)) {

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -3,7 +3,7 @@
  */
 import type { ToolCallContext } from "@f5xc-salesdemos/pi-agent-core";
 import type { Component } from "@f5xc-salesdemos/pi-tui";
-import { Text, visibleWidth, wrapTextWithAnsi } from "@f5xc-salesdemos/pi-tui";
+import { visibleWidth, wrapTextWithAnsi } from "@f5xc-salesdemos/pi-tui";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { FileDiagnosticsResult } from "../lsp";
 import { renderDiff as renderDiffColored } from "../modes/components/diff";
@@ -145,8 +145,6 @@ export interface EditRenderContext {
 
 const EDIT_STREAMING_PREVIEW_LINES = 12;
 const CALL_TEXT_PREVIEW_LINES = 6;
-const CALL_TEXT_PREVIEW_WIDTH = 80;
-const STREAMING_EDIT_PREVIEW_WIDTH = 120;
 const STREAMING_EDIT_PREVIEW_LIMIT = 4;
 const STREAMING_EDIT_PREVIEW_DST_LINE_LIMIT = 8;
 
@@ -207,11 +205,11 @@ function formatEditDescription(
 	};
 }
 
-function renderPlainTextPreview(text: string, uiTheme: Theme): string {
+function renderPlainTextPreview(text: string, uiTheme: Theme, width: number): string {
 	const previewLines = text.split("\n");
 	let preview = "\n\n";
 	for (const line of previewLines.slice(0, CALL_TEXT_PREVIEW_LINES)) {
-		preview += `${uiTheme.fg("toolOutput", truncateToWidth(replaceTabs(line), CALL_TEXT_PREVIEW_WIDTH))}\n`;
+		preview += `${uiTheme.fg("toolOutput", truncateToWidth(replaceTabs(line), width))}\n`;
 	}
 	if (previewLines.length > CALL_TEXT_PREVIEW_LINES) {
 		preview += uiTheme.fg("dim", `… ${previewLines.length - CALL_TEXT_PREVIEW_LINES} more lines`);
@@ -299,7 +297,11 @@ function formatChunkStreamingEdit(edit: Partial<ChunkToolEdit>): FormattedStream
 	return { srcLabel: `\u2022 edit ${target}`, dst: "" };
 }
 
-function formatStreamingHashlineEdits(edits: Partial<HashlineToolEdit | ChunkToolEdit>[], uiTheme: Theme): string {
+function formatStreamingHashlineEdits(
+	edits: Partial<HashlineToolEdit | ChunkToolEdit>[],
+	uiTheme: Theme,
+	width: number,
+): string {
 	let text = "\n\n";
 
 	// Detect whether these are chunk edits (target field) or hashline edits (loc field)
@@ -314,17 +316,17 @@ function formatStreamingHashlineEdits(edits: Partial<HashlineToolEdit | ChunkToo
 		shownEdits++;
 		if (shownEdits > STREAMING_EDIT_PREVIEW_LIMIT) break;
 		const formatted = formatEdit(edit as never);
-		text += uiTheme.fg("toolOutput", truncateToWidth(replaceTabs(formatted.srcLabel), STREAMING_EDIT_PREVIEW_WIDTH));
+		text += uiTheme.fg("toolOutput", truncateToWidth(replaceTabs(formatted.srcLabel), width));
 		text += "\n";
 		if (formatted.dst === "") {
-			text += uiTheme.fg("dim", truncateToWidth("  (delete)", STREAMING_EDIT_PREVIEW_WIDTH));
+			text += uiTheme.fg("dim", truncateToWidth("  (delete)", width));
 			text += "\n";
 			continue;
 		}
 		for (const dstLine of formatted.dst.split("\n")) {
 			shownDstLines++;
 			if (shownDstLines > STREAMING_EDIT_PREVIEW_DST_LINE_LIMIT) break;
-			text += uiTheme.fg("toolOutput", truncateToWidth(replaceTabs(`+ ${dstLine}`), STREAMING_EDIT_PREVIEW_WIDTH));
+			text += uiTheme.fg("toolOutput", truncateToWidth(replaceTabs(`+ ${dstLine}`), width));
 			text += "\n";
 		}
 		if (shownDstLines > STREAMING_EDIT_PREVIEW_DST_LINE_LIMIT) break;
@@ -347,7 +349,7 @@ function formatMetadataLine(lineCount: number | null, language: string | undefin
 	return uiTheme.fg("dim", `${icon}`);
 }
 
-function getCallPreview(args: EditRenderArgs, rawPath: string, uiTheme: Theme): string {
+function getCallPreview(args: EditRenderArgs, rawPath: string, uiTheme: Theme, width: number): string {
 	if (args.previewDiff) {
 		return formatStreamingDiff(args.previewDiff, rawPath, uiTheme, "preview");
 	}
@@ -358,14 +360,14 @@ function getCallPreview(args: EditRenderArgs, rawPath: string, uiTheme: Theme): 
 		// Only show hashline/chunk streaming edits — replace/patch use previewDiff above
 		const first = args.edits[0];
 		if (first && typeof first === "object" && ("loc" in first || isChunkStreamingEdit(first))) {
-			return formatStreamingHashlineEdits(args.edits, uiTheme);
+			return formatStreamingHashlineEdits(args.edits, uiTheme, width);
 		}
 	}
 	if (args.diff) {
-		return renderPlainTextPreview(args.diff, uiTheme);
+		return renderPlainTextPreview(args.diff, uiTheme, width);
 	}
 	if (args.newText || args.patch) {
-		return renderPlainTextPreview(args.newText ?? args.patch ?? "", uiTheme);
+		return renderPlainTextPreview(args.newText ?? args.patch ?? "", uiTheme, width);
 	}
 	return "";
 }
@@ -445,15 +447,20 @@ export const editToolRenderer = {
 		const { description } = formatEditDescription(rawPath, uiTheme, { rename });
 		const spinner =
 			options?.spinnerFrame !== undefined ? formatStatusIcon("running", uiTheme, options.spinnerFrame) : "";
-		let text = `${formatTitle(getOperationTitle(op), uiTheme)} ${spinner ? `${spinner} ` : ""}${description}`;
+		let header = `${formatTitle(getOperationTitle(op), uiTheme)} ${spinner ? `${spinner} ` : ""}${description}`;
 		// Show file count hint for multi-file edits
 		const fileCount = Array.isArray(args.edits) ? countEditFiles(args.edits as any[]) : 0;
 		if (fileCount > 1) {
-			text += uiTheme.fg("dim", ` (+${fileCount - 1} more)`);
+			header += uiTheme.fg("dim", ` (+${fileCount - 1} more)`);
 		}
-		text += getCallPreview(args, rawPath, uiTheme);
 
-		return new Text(text, 0, 0);
+		return {
+			render(width: number) {
+				const text = header + getCallPreview(args, rawPath, uiTheme, width);
+				return text.split("\n");
+			},
+			invalidate() {},
+		};
 	},
 
 	renderResult(

--- a/packages/coding-agent/src/exa/render.ts
+++ b/packages/coding-agent/src/exa/render.ts
@@ -15,17 +15,12 @@ import {
 	getDomain,
 	getPreviewLines,
 	PREVIEW_LIMITS,
-	TRUNCATE_LENGTHS,
 	truncateToWidth,
 } from "../tools/render-utils";
 import type { ExaRenderDetails } from "./types";
 
 const COLLAPSED_PREVIEW_LINES = PREVIEW_LIMITS.COLLAPSED_LINES;
-const COLLAPSED_PREVIEW_LINE_LEN = TRUNCATE_LENGTHS.LONG;
 const EXPANDED_TEXT_LINES = 5;
-const EXPANDED_TEXT_LINE_LEN = 90;
-const MAX_TITLE_LEN = TRUNCATE_LENGTHS.TITLE;
-const MAX_HIGHLIGHT_LEN = TRUNCATE_LENGTHS.CONTENT;
 
 function renderErrorMessage(message: string, theme: Theme): Text {
 	const clean = message.replace(/^Error:\s*/, "").trim();
@@ -42,7 +37,6 @@ export function renderExaResult(
 	options: RenderResultOptions,
 	uiTheme: Theme,
 ): Component {
-	const { expanded } = options;
 	const details = result.details;
 
 	if (details?.error) {
@@ -51,187 +45,188 @@ export function renderExaResult(
 	}
 
 	const response = details?.response;
-	if (!response) {
-		if (details?.raw) {
-			const rawText = typeof details.raw === "string" ? details.raw : JSON.stringify(details.raw, null, 2);
-			const rawLines = rawText.split("\n").filter(l => l.trim());
-			const maxLines = expanded ? rawLines.length : Math.min(rawLines.length, COLLAPSED_PREVIEW_LINES);
-			const displayLines = rawLines.slice(0, maxLines);
-			const remaining = rawLines.length - maxLines;
-			const expandHint = formatExpandHint(uiTheme, expanded, remaining > 0);
-
-			let text = `${uiTheme.fg("dim", "Raw response")}${expandHint}`;
-
-			for (let i = 0; i < displayLines.length; i++) {
-				const isLast = i === displayLines.length - 1 && remaining === 0;
-				const branch = isLast ? uiTheme.tree.last : uiTheme.tree.branch;
-				text += `\n ${uiTheme.fg("dim", branch)} ${uiTheme.fg(
-					"toolOutput",
-					truncateToWidth(displayLines[i], COLLAPSED_PREVIEW_LINE_LEN),
-				)}`;
-			}
-
-			if (remaining > 0) {
-				text += `\n ${uiTheme.fg("dim", uiTheme.tree.last)} ${uiTheme.fg(
-					"muted",
-					formatMoreItems(remaining, "line"),
-				)}`;
-			}
-
-			return new Text(text, 0, 0);
-		}
+	if (!response && !details?.raw) {
 		return renderEmptyMessage("No response data", uiTheme);
 	}
 
-	const results = response.results ?? [];
-	const resultCount = results.length;
-	const cost = response.costDollars?.total;
-	const time = response.searchTime;
+	return {
+		render(width: number): string[] {
+			const { expanded } = options;
+			const contentWidth = Math.max(20, width - 6);
 
-	const metaParts = [formatCount("result", resultCount)];
-	if (cost !== undefined) metaParts.push(`cost:$${cost.toFixed(4)}`);
-	if (time !== undefined) metaParts.push(`time:${time.toFixed(2)}s`);
-	const summaryText = metaParts.join(uiTheme.sep.dot);
+			if (!response) {
+				const rawText = typeof details?.raw === "string" ? details.raw : JSON.stringify(details?.raw, null, 2);
+				const rawLines = rawText.split("\n").filter(l => l.trim());
+				const maxLines = expanded ? rawLines.length : Math.min(rawLines.length, COLLAPSED_PREVIEW_LINES);
+				const displayLines = rawLines.slice(0, maxLines);
+				const remaining = rawLines.length - maxLines;
+				const expandHint = formatExpandHint(uiTheme, expanded, remaining > 0);
 
-	let hasMorePreview = false;
-	if (!expanded && resultCount > 0) {
-		const previewText = results[0].text ?? results[0].title ?? "";
-		const totalLines = previewText.split("\n").filter(l => l.trim()).length;
-		hasMorePreview = totalLines > COLLAPSED_PREVIEW_LINES || resultCount > 1;
-	}
-	const expandHint = formatExpandHint(uiTheme, expanded, hasMorePreview);
+				const lines: string[] = [`${uiTheme.fg("dim", "Raw response")}${expandHint}`];
 
-	let text = `${uiTheme.fg("dim", summaryText)}${expandHint}`;
+				for (let i = 0; i < displayLines.length; i++) {
+					const isLast = i === displayLines.length - 1 && remaining === 0;
+					const branch = isLast ? uiTheme.tree.last : uiTheme.tree.branch;
+					lines.push(
+						` ${uiTheme.fg("dim", branch)} ${uiTheme.fg("toolOutput", truncateToWidth(displayLines[i], contentWidth))}`,
+					);
+				}
 
-	if (!expanded) {
-		if (resultCount === 0) {
-			text += `\n ${uiTheme.fg("dim", uiTheme.tree.last)} ${uiTheme.fg("muted", "No results")}`;
-			return new Text(text, 0, 0);
-		}
+				if (remaining > 0) {
+					lines.push(
+						` ${uiTheme.fg("dim", uiTheme.tree.last)} ${uiTheme.fg("muted", formatMoreItems(remaining, "line"))}`,
+					);
+				}
 
-		const first = results[0];
-		const previewText = first.text ?? first.title ?? "";
-		const previewLines = previewText
-			? getPreviewLines(previewText, COLLAPSED_PREVIEW_LINES, COLLAPSED_PREVIEW_LINE_LEN)
-			: [];
-		const safePreviewLines = previewLines.length > 0 ? previewLines : ["No preview text"];
-		const totalLines = previewText.split("\n").filter(l => l.trim()).length;
-		const remainingLines = Math.max(0, totalLines - previewLines.length);
-		const extraItems: string[] = [];
-		if (remainingLines > 0) {
-			extraItems.push(formatMoreItems(remainingLines, "line"));
-		}
-		if (resultCount > 1) {
-			extraItems.push(formatMoreItems(resultCount - 1, "result"));
-		}
-
-		for (let i = 0; i < safePreviewLines.length; i++) {
-			const isLast = i === safePreviewLines.length - 1 && extraItems.length === 0;
-			const branch = isLast ? uiTheme.tree.last : uiTheme.tree.branch;
-			const line = safePreviewLines[i];
-			const color = line === "No preview text" ? "muted" : "toolOutput";
-			text += `\n ${uiTheme.fg("dim", branch)} ${uiTheme.fg(color, line)}`;
-		}
-
-		for (let i = 0; i < extraItems.length; i++) {
-			const isLast = i === extraItems.length - 1;
-			const branch = isLast ? uiTheme.tree.last : uiTheme.tree.branch;
-			text += `\n ${uiTheme.fg("dim", branch)} ${uiTheme.fg("muted", extraItems[i])}`;
-		}
-
-		return new Text(text, 0, 0);
-	}
-
-	if (resultCount === 0) {
-		text += `\n ${uiTheme.fg("dim", uiTheme.tree.last)} ${uiTheme.fg("muted", "No results")}`;
-		return new Text(text, 0, 0);
-	}
-
-	for (let i = 0; i < results.length; i++) {
-		const res = results[i];
-		const isLast = i === results.length - 1;
-		const branch = isLast ? uiTheme.tree.last : uiTheme.tree.branch;
-		const cont = isLast ? " " : uiTheme.tree.vertical;
-
-		const title = truncateToWidth(res.title ?? "Untitled", MAX_TITLE_LEN);
-		const domain = res.url ? getDomain(res.url) : "";
-		const domainPart = domain ? uiTheme.fg("dim", ` (${domain})`) : "";
-
-		text += `\n ${uiTheme.fg("dim", branch)} ${uiTheme.fg("contentAccent", title)}${domainPart}`;
-
-		if (res.url) {
-			text += `\n ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg(
-				"mdLinkUrl",
-				res.url,
-			)}`;
-		}
-
-		if (res.author) {
-			text += `\n ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg(
-				"muted",
-				`Author: ${res.author}`,
-			)}`;
-		}
-
-		if (res.publishedDate) {
-			text += `\n ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg(
-				"muted",
-				`Published: ${res.publishedDate}`,
-			)}`;
-		}
-
-		if (res.text) {
-			const textLines = res.text.split("\n").filter(l => l.trim());
-			const displayLines = textLines.slice(0, EXPANDED_TEXT_LINES);
-			for (const line of displayLines) {
-				text += `\n ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg(
-					"toolOutput",
-					truncateToWidth(line.trim(), EXPANDED_TEXT_LINE_LEN),
-				)}`;
+				return lines;
 			}
-			if (textLines.length > EXPANDED_TEXT_LINES) {
-				text += `\n ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg(
-					"muted",
-					formatMoreItems(textLines.length - EXPANDED_TEXT_LINES, "line"),
-				)}`;
-			}
-		}
 
-		if (res.highlights?.length) {
-			text += `\n ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg(
-				"contentAccent",
-				"Highlights",
-			)}`;
-			const maxHighlights = Math.min(res.highlights.length, 3);
-			for (let j = 0; j < maxHighlights; j++) {
-				const h = res.highlights[j];
-				text += `\n ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg(
-					"muted",
-					`${uiTheme.format.dash} ${truncateToWidth(h, MAX_HIGHLIGHT_LEN)}`,
-				)}`;
-			}
-			if (res.highlights.length > maxHighlights) {
-				text += `\n ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg(
-					"muted",
-					formatMoreItems(res.highlights.length - maxHighlights, "highlight"),
-				)}`;
-			}
-		}
-	}
+			const results = response.results ?? [];
+			const resultCount = results.length;
+			const cost = response.costDollars?.total;
+			const time = response.searchTime;
 
-	return new Text(text, 0, 0);
+			const metaParts = [formatCount("result", resultCount)];
+			if (cost !== undefined) metaParts.push(`cost:$${cost.toFixed(4)}`);
+			if (time !== undefined) metaParts.push(`time:${time.toFixed(2)}s`);
+			const summaryText = metaParts.join(uiTheme.sep.dot);
+
+			let hasMorePreview = false;
+			if (!expanded && resultCount > 0) {
+				const previewText = results[0].text ?? results[0].title ?? "";
+				const totalLines = previewText.split("\n").filter(l => l.trim()).length;
+				hasMorePreview = totalLines > COLLAPSED_PREVIEW_LINES || resultCount > 1;
+			}
+			const expandHint = formatExpandHint(uiTheme, expanded, hasMorePreview);
+
+			const lines: string[] = [`${uiTheme.fg("dim", summaryText)}${expandHint}`];
+
+			if (!expanded) {
+				if (resultCount === 0) {
+					lines.push(` ${uiTheme.fg("dim", uiTheme.tree.last)} ${uiTheme.fg("muted", "No results")}`);
+					return lines;
+				}
+
+				const first = results[0];
+				const previewText = first.text ?? first.title ?? "";
+				const previewLines = previewText ? getPreviewLines(previewText, COLLAPSED_PREVIEW_LINES, contentWidth) : [];
+				const safePreviewLines = previewLines.length > 0 ? previewLines : ["No preview text"];
+				const totalLines = previewText.split("\n").filter(l => l.trim()).length;
+				const remainingLines = Math.max(0, totalLines - previewLines.length);
+				const extraItems: string[] = [];
+				if (remainingLines > 0) {
+					extraItems.push(formatMoreItems(remainingLines, "line"));
+				}
+				if (resultCount > 1) {
+					extraItems.push(formatMoreItems(resultCount - 1, "result"));
+				}
+
+				for (let i = 0; i < safePreviewLines.length; i++) {
+					const isLast = i === safePreviewLines.length - 1 && extraItems.length === 0;
+					const branch = isLast ? uiTheme.tree.last : uiTheme.tree.branch;
+					const line = safePreviewLines[i];
+					const color = line === "No preview text" ? "muted" : "toolOutput";
+					lines.push(` ${uiTheme.fg("dim", branch)} ${uiTheme.fg(color, line)}`);
+				}
+
+				for (let i = 0; i < extraItems.length; i++) {
+					const isLast = i === extraItems.length - 1;
+					const branch = isLast ? uiTheme.tree.last : uiTheme.tree.branch;
+					lines.push(` ${uiTheme.fg("dim", branch)} ${uiTheme.fg("muted", extraItems[i])}`);
+				}
+
+				return lines;
+			}
+
+			if (resultCount === 0) {
+				lines.push(` ${uiTheme.fg("dim", uiTheme.tree.last)} ${uiTheme.fg("muted", "No results")}`);
+				return lines;
+			}
+
+			for (let i = 0; i < results.length; i++) {
+				const res = results[i];
+				const isLast = i === results.length - 1;
+				const branch = isLast ? uiTheme.tree.last : uiTheme.tree.branch;
+				const cont = isLast ? " " : uiTheme.tree.vertical;
+
+				const title = truncateToWidth(res.title ?? "Untitled", contentWidth);
+				const domain = res.url ? getDomain(res.url) : "";
+				const domainPart = domain ? uiTheme.fg("dim", ` (${domain})`) : "";
+
+				lines.push(` ${uiTheme.fg("dim", branch)} ${uiTheme.fg("contentAccent", title)}${domainPart}`);
+
+				if (res.url) {
+					lines.push(
+						` ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg("mdLinkUrl", res.url)}`,
+					);
+				}
+
+				if (res.author) {
+					lines.push(
+						` ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg("muted", `Author: ${res.author}`)}`,
+					);
+				}
+
+				if (res.publishedDate) {
+					lines.push(
+						` ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg("muted", `Published: ${res.publishedDate}`)}`,
+					);
+				}
+
+				if (res.text) {
+					const textLines = res.text.split("\n").filter(l => l.trim());
+					const displayLines = textLines.slice(0, EXPANDED_TEXT_LINES);
+					for (const line of displayLines) {
+						lines.push(
+							` ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg("toolOutput", truncateToWidth(line.trim(), contentWidth))}`,
+						);
+					}
+					if (textLines.length > EXPANDED_TEXT_LINES) {
+						lines.push(
+							` ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg("muted", formatMoreItems(textLines.length - EXPANDED_TEXT_LINES, "line"))}`,
+						);
+					}
+				}
+
+				if (res.highlights?.length) {
+					lines.push(
+						` ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg("contentAccent", "Highlights")}`,
+					);
+					const maxHighlights = Math.min(res.highlights.length, 3);
+					for (let j = 0; j < maxHighlights; j++) {
+						const h = res.highlights[j];
+						lines.push(
+							` ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg("muted", `${uiTheme.format.dash} ${truncateToWidth(h, contentWidth)}`)}`,
+						);
+					}
+					if (res.highlights.length > maxHighlights) {
+						lines.push(
+							` ${uiTheme.fg("dim", cont)} ${uiTheme.fg("dim", uiTheme.tree.hook)} ${uiTheme.fg("muted", formatMoreItems(res.highlights.length - maxHighlights, "highlight"))}`,
+						);
+					}
+				}
+			}
+
+			return lines;
+		},
+		invalidate() {},
+	};
 }
 
 /** Render Exa call (query/args preview) */
 export function renderExaCall(args: Record<string, unknown>, toolName: string, uiTheme: Theme): Component {
 	const toolLabel = toolName || "Exa Search";
-	const query = typeof args.query === "string" ? truncateToWidth(args.query, 80) : "?";
 	const numResults = typeof args.num_results === "number" ? args.num_results : undefined;
 
-	let text = `${uiTheme.fg("toolTitle", toolLabel)} ${uiTheme.fg("contentAccent", query)}`;
-	if (numResults !== undefined) {
-		text += ` ${uiTheme.fg("muted", `results:${numResults}`)}`;
-	}
-
-	return new Text(text, 0, 0);
+	return {
+		render(width: number): string[] {
+			const query = typeof args.query === "string" ? truncateToWidth(args.query, Math.max(20, width - 30)) : "?";
+			let text = `${uiTheme.fg("toolTitle", toolLabel)} ${uiTheme.fg("contentAccent", query)}`;
+			if (numResults !== undefined) {
+				text += ` ${uiTheme.fg("muted", `results:${numResults}`)}`;
+			}
+			return [truncateToWidth(text, width)];
+		},
+		invalidate() {},
+	};
 }

--- a/packages/coding-agent/src/lsp/render.ts
+++ b/packages/coding-agent/src/lsp/render.ts
@@ -21,7 +21,6 @@ import {
 	formatStatusIcon,
 	replaceTabs,
 	shortenPath,
-	TRUNCATE_LENGTHS,
 	truncateToWidth,
 } from "../tools/render-utils";
 import { renderStatusLine } from "../tui";
@@ -40,56 +39,60 @@ function sanitizeInlineText(value: string): string {
 	return replaceTabs(value).replaceAll(/\r?\n/g, " ");
 }
 
-export function renderCall(args: LspParams, _options: RenderResultOptions, theme: Theme): Text {
-	const actionLabel = (args.action ?? "request").replace(/_/g, " ");
-	const queryPreview = args.query ? truncateToWidth(args.query, TRUNCATE_LENGTHS.SHORT) : undefined;
-	const symbolPreview = args.symbol
-		? truncateToWidth(sanitizeInlineText(args.symbol), TRUNCATE_LENGTHS.SHORT)
-		: undefined;
+export function renderCall(args: LspParams, _options: RenderResultOptions, theme: Theme): Component {
+	return {
+		render(width: number): string[] {
+			const previewWidth = Math.max(15, Math.floor(width * 0.3));
+			const actionLabel = (args.action ?? "request").replace(/_/g, " ");
+			const queryPreview = args.query ? truncateToWidth(args.query, previewWidth) : undefined;
+			const symbolPreview = args.symbol ? truncateToWidth(sanitizeInlineText(args.symbol), previewWidth) : undefined;
 
-	let target: string | undefined;
-	let hasFileTarget = false;
+			let target: string | undefined;
+			let hasFileTarget = false;
 
-	if (args.file) {
-		target = shortenPath(args.file);
-		hasFileTarget = true;
-	}
+			if (args.file) {
+				target = shortenPath(args.file);
+				hasFileTarget = true;
+			}
 
-	if (hasFileTarget && args.line !== undefined) {
-		target += `:${args.line}`;
-		if (symbolPreview) {
-			target += ` (${symbolPreview})`;
-		}
-	} else if (!target && args.line !== undefined) {
-		target = `line ${args.line}`;
-		if (symbolPreview) {
-			target += ` (${symbolPreview})`;
-		}
-	}
+			if (hasFileTarget && args.line !== undefined) {
+				target += `:${args.line}`;
+				if (symbolPreview) {
+					target += ` (${symbolPreview})`;
+				}
+			} else if (!target && args.line !== undefined) {
+				target = `line ${args.line}`;
+				if (symbolPreview) {
+					target += ` (${symbolPreview})`;
+				}
+			}
 
-	const meta: string[] = [];
-	if (queryPreview && target) meta.push(`query:${queryPreview}`);
-	if (args.new_name) meta.push(`new:${args.new_name}`);
-	if (args.apply !== undefined) meta.push(`apply:${args.apply ? "true" : "false"}`);
+			const meta: string[] = [];
+			if (queryPreview && target) meta.push(`query:${queryPreview}`);
+			if (args.new_name) meta.push(`new:${args.new_name}`);
+			if (args.apply !== undefined) meta.push(`apply:${args.apply ? "true" : "false"}`);
 
-	const descriptionParts = [actionLabel];
-	if (target) {
-		descriptionParts.push(target);
-	} else if (queryPreview) {
-		descriptionParts.push(queryPreview);
-	}
+			const descriptionParts = [actionLabel];
+			if (target) {
+				descriptionParts.push(target);
+			} else if (queryPreview) {
+				descriptionParts.push(queryPreview);
+			}
 
-	const text = renderStatusLine(
-		{
-			icon: "pending",
-			title: "LSP",
-			description: descriptionParts.join(" "),
-			meta,
+			const text = renderStatusLine(
+				{
+					icon: "pending",
+					title: "LSP",
+					description: descriptionParts.join(" "),
+					meta,
+				},
+				theme,
+			);
+
+			return [truncateToWidth(text, width)];
 		},
-		theme,
-	);
-
-	return new Text(text, 0, 0);
+		invalidate() {},
+	};
 }
 
 // =============================================================================
@@ -157,22 +160,22 @@ export function renderResult(
 
 			if (codeBlockMatch) {
 				label = "Hover";
-				bodyLines = renderHover(codeBlockMatch, text, lines, expanded, theme);
+				bodyLines = renderHover(codeBlockMatch, text, lines, expanded, theme, width);
 			} else if (errorMatch || warningMatch || hasStatusError) {
 				label = "Diagnostics";
 				const errorCount = errorMatch ? Number.parseInt(errorMatch[1], 10) : 0;
 				const warnCount = warningMatch ? Number.parseInt(warningMatch[1], 10) : 0;
 				state = errorCount > 0 ? "error" : warnCount > 0 ? "warning" : "success";
-				bodyLines = renderDiagnostics(errorMatch, warningMatch, lines, expanded, theme);
+				bodyLines = renderDiagnostics(errorMatch, warningMatch, lines, expanded, theme, width);
 			} else if (refMatch) {
 				label = "References";
-				bodyLines = renderReferences(refMatch, lines, expanded, theme);
+				bodyLines = renderReferences(refMatch, lines, expanded, theme, width);
 			} else if (symbolsMatch) {
 				label = "Symbols";
-				bodyLines = renderSymbols(symbolsMatch, lines, expanded, theme);
+				bodyLines = renderSymbols(symbolsMatch, lines, expanded, theme, width);
 			} else {
 				label = "Response";
-				bodyLines = renderGeneric(text, lines, expanded, theme);
+				bodyLines = renderGeneric(text, lines, expanded, theme, width);
 			}
 
 			const actionLabel = (request?.action ?? result.details?.action ?? label.toLowerCase()).replace(/_/g, " ");
@@ -213,6 +216,7 @@ function renderHover(
 	_lines: string[],
 	expanded: boolean,
 	theme: Theme,
+	width: number,
 ): string[] {
 	const lang = codeBlockMatch[1] || "";
 	const code = codeBlockMatch[2].trim();
@@ -253,7 +257,7 @@ function renderHover(
 
 	let output = `${icon}${langLabel}${expandHint}`;
 	if (beforeCode) {
-		const preview = truncateToWidth(beforeCode, TRUNCATE_LENGTHS.TITLE);
+		const preview = truncateToWidth(beforeCode, width);
 		output += `\n ${theme.fg("dim", theme.tree.branch)} ${theme.fg("muted", preview)}`;
 	}
 	const h = theme.boxSharp.horizontal;
@@ -266,7 +270,7 @@ function renderHover(
 	}
 
 	if (afterCode) {
-		const docPreview = truncateToWidth(afterCode, TRUNCATE_LENGTHS.TITLE);
+		const docPreview = truncateToWidth(afterCode, width);
 		output += `\n ${theme.fg("dim", theme.tree.last)} ${theme.fg("muted", docPreview)}`;
 	} else {
 		output += `\n ${theme.fg("mdCodeBlockBorder", bottom)}`;
@@ -319,6 +323,7 @@ function renderDiagnostics(
 	lines: string[],
 	expanded: boolean,
 	theme: Theme,
+	width: number,
 ): string[] {
 	const errorCount = errorMatch ? Number.parseInt(errorMatch[1], 10) : 0;
 	const warnCount = warningMatch ? Number.parseInt(warningMatch[1], 10) : 0;
@@ -360,10 +365,7 @@ function renderDiagnostics(
 				`[${item.severity}]`,
 			)}`;
 			if (item.message) {
-				output += `\n ${theme.fg("dim", detailPrefix)}${theme.fg(
-					"muted",
-					truncateToWidth(item.message, TRUNCATE_LENGTHS.LINE),
-				)}`;
+				output += `\n ${theme.fg("dim", detailPrefix)}${theme.fg("muted", truncateToWidth(item.message, width))}`;
 			}
 		}
 		return output.split("\n");
@@ -386,9 +388,7 @@ function renderDiagnostics(
 		}
 		const severityColor = severityToColor(item.severity);
 		const location = formatDiagnosticLocation(item.file, item.line, item.col, theme);
-		const message = item.message
-			? ` ${theme.fg("muted", truncateToWidth(item.message, TRUNCATE_LENGTHS.CONTENT))}`
-			: "";
+		const message = item.message ? ` ${theme.fg("muted", truncateToWidth(item.message, width))}` : "";
 		output += `\n ${theme.fg("dim", branch)} ${theme.fg(severityColor, location)}${message}`;
 	}
 	if (remaining > 0) {
@@ -405,7 +405,13 @@ function renderDiagnostics(
 /**
  * Render references grouped by file.
  */
-function renderReferences(refMatch: RegExpMatchArray, lines: string[], expanded: boolean, theme: Theme): string[] {
+function renderReferences(
+	refMatch: RegExpMatchArray,
+	lines: string[],
+	expanded: boolean,
+	theme: Theme,
+	width: number,
+): string[] {
 	const refCount = Number.parseInt(refMatch[1], 10);
 	const icon =
 		refCount > 0 ? theme.styledSymbol("status.success", "success") : theme.styledSymbol("status.warning", "warning");
@@ -455,7 +461,7 @@ function renderReferences(refMatch: RegExpMatchArray, lines: string[], expanded:
 						const context = `at ${file}:${line}:${col}`;
 						output += `\n ${theme.fg("dim", fileCont)}${theme.fg("dim", locCont)}${theme.fg(
 							"muted",
-							truncateToWidth(context, TRUNCATE_LENGTHS.LINE),
+							truncateToWidth(context, width),
 						)}`;
 					}
 				}
@@ -492,7 +498,13 @@ function renderReferences(refMatch: RegExpMatchArray, lines: string[], expanded:
 /**
  * Render document symbols in a hierarchical tree.
  */
-function renderSymbols(symbolsMatch: RegExpMatchArray, lines: string[], expanded: boolean, theme: Theme): string[] {
+function renderSymbols(
+	symbolsMatch: RegExpMatchArray,
+	lines: string[],
+	expanded: boolean,
+	theme: Theme,
+	_width?: number,
+): string[] {
 	const fileName = symbolsMatch[1];
 	const icon = theme.styledSymbol("status.info", "contentAccent");
 
@@ -591,7 +603,7 @@ function renderSymbols(symbolsMatch: RegExpMatchArray, lines: string[], expanded
 /**
  * Generic fallback rendering for unknown result types.
  */
-function renderGeneric(text: string, lines: string[], expanded: boolean, theme: Theme): string[] {
+function renderGeneric(text: string, lines: string[], expanded: boolean, theme: Theme, width: number): string[] {
 	const hasError = text.includes("Error:") || text.includes(theme.status.error);
 	const hasSuccess = text.includes(theme.status.success) || text.includes("Applied");
 
@@ -614,17 +626,14 @@ function renderGeneric(text: string, lines: string[], expanded: boolean, theme: 
 
 	const firstLine = lines[0] || "No output";
 	const expandHint = formatExpandHint(theme, expanded, lines.length > 1);
-	let output = `${icon} ${theme.fg("dim", truncateToWidth(firstLine, TRUNCATE_LENGTHS.TITLE))}${expandHint}`;
+	let output = `${icon} ${theme.fg("dim", truncateToWidth(firstLine, width))}${expandHint}`;
 
 	if (lines.length > 1) {
 		const previewLines = lines.slice(1, 4);
 		for (let i = 0; i < previewLines.length; i++) {
 			const isLast = i === previewLines.length - 1 && lines.length <= 4;
 			const branch = isLast ? theme.tree.last : theme.tree.branch;
-			output += `\n ${theme.fg("dim", branch)} ${theme.fg(
-				"dim",
-				truncateToWidth(previewLines[i].trim(), TRUNCATE_LENGTHS.CONTENT),
-			)}`;
+			output += `\n ${theme.fg("dim", branch)} ${theme.fg("dim", truncateToWidth(previewLines[i].trim(), width))}`;
 		}
 		if (lines.length > 4) {
 			output += `\n ${theme.fg("dim", theme.tree.last)} ${theme.fg(

--- a/packages/coding-agent/src/mcp/render.ts
+++ b/packages/coding-agent/src/mcp/render.ts
@@ -5,7 +5,6 @@
  * showing args and output in JSON tree format similar to task tool.
  */
 import type { Component } from "@f5xc-salesdemos/pi-tui";
-import { Text } from "@f5xc-salesdemos/pi-tui";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme } from "../modes/theme/theme";
 import { highlightCode } from "../modes/theme/theme";
@@ -28,18 +27,22 @@ import type { MCPToolDetails } from "./tool-bridge";
  * Render MCP tool call.
  */
 export function renderMCPCall(args: Record<string, unknown>, theme: Theme, label: string): Component {
-	const lines: string[] = [];
-	lines.push(renderStatusLine({ icon: "pending", title: label }, theme));
+	return {
+		render(width: number): string[] {
+			const lines: string[] = [];
+			lines.push(truncateToWidth(renderStatusLine({ icon: "pending", title: label }, theme), width));
 
-	if (args && typeof args === "object" && Object.keys(args).length > 0) {
-		// Show args inline preview
-		const preview = formatArgsInline(args, 70);
-		if (preview) {
-			lines.push(` ${theme.fg("dim", theme.tree.last)} ${theme.fg("dim", preview)}`);
-		}
-	}
+			if (args && typeof args === "object" && Object.keys(args).length > 0) {
+				const preview = formatArgsInline(args, Math.max(20, width - 20));
+				if (preview) {
+					lines.push(` ${theme.fg("dim", theme.tree.last)} ${theme.fg("dim", preview)}`);
+				}
+			}
 
-	return new Text(lines.join("\n"), 0, 0);
+			return lines;
+		},
+		invalidate() {},
+	};
 }
 
 /**
@@ -51,102 +54,104 @@ export function renderMCPResult(
 	theme: Theme,
 	args?: Record<string, unknown>,
 ): Component {
-	const { expanded } = options;
-	const lines: string[] = [];
-
-	// Args section (when expanded)
-	if (expanded && args && typeof args === "object" && Object.keys(args).length > 0) {
-		lines.push(`${theme.fg("dim", "Args")}`);
-		const maxDepth = JSON_TREE_MAX_DEPTH_EXPANDED;
-		const maxLines = JSON_TREE_MAX_LINES_EXPANDED;
-		const tree = renderJsonTreeLines(
-			stripInternalArgs(args),
-			theme,
-			maxDepth,
-			maxLines,
-			JSON_TREE_SCALAR_LEN_EXPANDED,
-		);
-		for (const line of tree.lines) {
-			lines.push(line);
-		}
-		if (tree.truncated) {
-			lines.push(theme.fg("dim", "…"));
-		}
-		lines.push(""); // Blank line before output
-	}
-
-	// Output section
 	const textContent = result.content?.find(c => c.type === "text")?.text ?? "";
 	const trimmedOutput = textContent.trimEnd();
 
-	if (!trimmedOutput) {
-		lines.push(theme.fg("dim", "(no output)"));
-		return new Text(lines.join("\n"), 0, 0);
-	}
+	return {
+		render(width: number): string[] {
+			const { expanded } = options;
+			const lines: string[] = [];
 
-	// Try to parse as JSON for structured display
-	if (trimmedOutput.startsWith("{") || trimmedOutput.startsWith("[")) {
-		try {
-			const parsed = JSON.parse(trimmedOutput);
-			const maxDepth = expanded ? JSON_TREE_MAX_DEPTH_EXPANDED : JSON_TREE_MAX_DEPTH_COLLAPSED;
-			const maxLines = expanded ? JSON_TREE_MAX_LINES_EXPANDED : JSON_TREE_MAX_LINES_COLLAPSED;
-			const maxScalarLen = expanded ? JSON_TREE_SCALAR_LEN_EXPANDED : JSON_TREE_SCALAR_LEN_COLLAPSED;
-			const tree = renderJsonTreeLines(parsed, theme, maxDepth, maxLines, maxScalarLen);
-
-			if (tree.lines.length > 0) {
+			// Args section (when expanded)
+			if (expanded && args && typeof args === "object" && Object.keys(args).length > 0) {
+				lines.push(`${theme.fg("dim", "Args")}`);
+				const maxDepth = JSON_TREE_MAX_DEPTH_EXPANDED;
+				const maxLines = JSON_TREE_MAX_LINES_EXPANDED;
+				const tree = renderJsonTreeLines(
+					stripInternalArgs(args),
+					theme,
+					maxDepth,
+					maxLines,
+					JSON_TREE_SCALAR_LEN_EXPANDED,
+				);
 				for (const line of tree.lines) {
 					lines.push(line);
 				}
-				// Always show expand hint when collapsed (expanded view shows longer values and deeper nesting)
-				if (!expanded) {
-					lines.push(formatExpandHint(theme, expanded, true));
-				} else if (tree.truncated) {
+				if (tree.truncated) {
 					lines.push(theme.fg("dim", "…"));
 				}
-				return new Text(lines.join("\n"), 0, 0);
+				lines.push("");
 			}
-		} catch {
-			// Fall through to raw output
-		}
-	}
 
-	// Raw text output
-	const outputLines = trimmedOutput.split("\n");
-	const maxOutputLines = expanded ? 12 : 4;
-	const displayLines = outputLines.slice(0, maxOutputLines);
-
-	// Try to syntax-highlight structured output (e.g. JSON)
-	const firstNonEmpty = trimmedOutput.trim();
-	const isJson =
-		firstNonEmpty.length <= 32_768 &&
-		(firstNonEmpty[0] === "{" || firstNonEmpty[0] === "[") &&
-		(() => {
-			try {
-				JSON.parse(firstNonEmpty);
-				return true;
-			} catch {
-				return false;
+			// Output section
+			if (!trimmedOutput) {
+				lines.push(theme.fg("dim", "(no output)"));
+				return lines;
 			}
-		})();
 
-	if (isJson) {
-		const highlighted = highlightCode(displayLines.join("\n"), "json");
-		for (const line of highlighted) {
-			lines.push(truncateToWidth(line, 80));
-		}
-	} else {
-		for (const line of displayLines) {
-			lines.push(theme.fg("toolOutput", truncateToWidth(line, 80)));
-		}
-	}
+			// Try to parse as JSON for structured display
+			if (trimmedOutput.startsWith("{") || trimmedOutput.startsWith("[")) {
+				try {
+					const parsed = JSON.parse(trimmedOutput);
+					const maxDepth = expanded ? JSON_TREE_MAX_DEPTH_EXPANDED : JSON_TREE_MAX_DEPTH_COLLAPSED;
+					const maxLines = expanded ? JSON_TREE_MAX_LINES_EXPANDED : JSON_TREE_MAX_LINES_COLLAPSED;
+					const maxScalarLen = expanded ? JSON_TREE_SCALAR_LEN_EXPANDED : JSON_TREE_SCALAR_LEN_COLLAPSED;
+					const tree = renderJsonTreeLines(parsed, theme, maxDepth, maxLines, maxScalarLen);
 
-	if (outputLines.length > maxOutputLines) {
-		const remaining = outputLines.length - maxOutputLines;
-		lines.push(`${theme.fg("dim", `… ${remaining} more lines`)} ${formatExpandHint(theme, expanded, true)}`);
-	} else if (!expanded) {
-		// Show expand hint when collapsed even if all lines shown (lines may be truncated)
-		lines.push(formatExpandHint(theme, expanded, true));
-	}
+					if (tree.lines.length > 0) {
+						for (const line of tree.lines) {
+							lines.push(line);
+						}
+						if (!expanded) {
+							lines.push(formatExpandHint(theme, expanded, true));
+						} else if (tree.truncated) {
+							lines.push(theme.fg("dim", "…"));
+						}
+						return lines;
+					}
+				} catch {
+					// Fall through to raw output
+				}
+			}
 
-	return new Text(lines.join("\n"), 0, 0);
+			// Raw text output
+			const outputLines = trimmedOutput.split("\n");
+			const maxOutputLines = expanded ? 12 : 4;
+			const displayLines = outputLines.slice(0, maxOutputLines);
+
+			const firstNonEmpty = trimmedOutput.trim();
+			const isJson =
+				firstNonEmpty.length <= 32_768 &&
+				(firstNonEmpty[0] === "{" || firstNonEmpty[0] === "[") &&
+				(() => {
+					try {
+						JSON.parse(firstNonEmpty);
+						return true;
+					} catch {
+						return false;
+					}
+				})();
+
+			if (isJson) {
+				const highlighted = highlightCode(displayLines.join("\n"), "json");
+				for (const line of highlighted) {
+					lines.push(truncateToWidth(line, width));
+				}
+			} else {
+				for (const line of displayLines) {
+					lines.push(theme.fg("toolOutput", truncateToWidth(line, width)));
+				}
+			}
+
+			if (outputLines.length > maxOutputLines) {
+				const remaining = outputLines.length - maxOutputLines;
+				lines.push(`${theme.fg("dim", `… ${remaining} more lines`)} ${formatExpandHint(theme, expanded, true)}`);
+			} else if (!expanded) {
+				lines.push(formatExpandHint(theme, expanded, true));
+			}
+
+			return lines;
+		},
+		invalidate() {},
+	};
 }

--- a/packages/coding-agent/src/tools/calculator.ts
+++ b/packages/coding-agent/src/tools/calculator.ts
@@ -1,6 +1,5 @@
 import type { AgentTool, AgentToolResult } from "@f5xc-salesdemos/pi-agent-core";
 import type { Component } from "@f5xc-salesdemos/pi-tui";
-import { Text } from "@f5xc-salesdemos/pi-tui";
 import { prompt, untilAborted } from "@f5xc-salesdemos/pi-utils";
 import { type Static, Type } from "@sinclair/typebox";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
@@ -8,7 +7,7 @@ import type { Theme } from "../modes/theme/theme";
 import calculatorDescription from "../prompts/tools/calculator.md" with { type: "text" };
 import { Ellipsis, Hasher, type RenderCache, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
 import type { ToolSession } from ".";
-import { formatCount, formatEmptyMessage, formatErrorMessage, PREVIEW_LIMITS, TRUNCATE_LENGTHS } from "./render-utils";
+import { formatCount, formatEmptyMessage, formatErrorMessage, PREVIEW_LIMITS } from "./render-utils";
 
 // =============================================================================
 // Token Types
@@ -448,10 +447,17 @@ export const calculatorToolRenderer = {
 	renderCall(args: CalculatorRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
 		const count = args.calculations?.length ?? 0;
 		const firstExpression = args.calculations?.[0]?.expression;
-		const description = firstExpression ? truncateToWidth(firstExpression, TRUNCATE_LENGTHS.TITLE) : undefined;
 		const meta = count > 0 ? [formatCount("calc", count)] : [];
-		const text = renderStatusLine({ icon: "pending", title: "Calc", description, meta }, uiTheme);
-		return new Text(text, 0, 0);
+		return {
+			render(width: number): string[] {
+				const description = firstExpression
+					? truncateToWidth(firstExpression, Math.max(20, width - 20))
+					: undefined;
+				const text = renderStatusLine({ icon: "pending", title: "Calc", description, meta }, uiTheme);
+				return [truncateToWidth(text, width)];
+			},
+			invalidate() {},
+		};
 	},
 
 	/**
@@ -500,14 +506,6 @@ export const calculatorToolRenderer = {
 			};
 		}
 
-		const description = args?.calculations?.[0]?.expression
-			? truncateToWidth(args.calculations[0].expression, TRUNCATE_LENGTHS.TITLE)
-			: undefined;
-		const header = renderStatusLine(
-			{ title: "Calc", description, meta: [formatCount("result", outputs.length)] },
-			uiTheme,
-		);
-
 		let cached: RenderCache | undefined;
 
 		return {
@@ -515,6 +513,13 @@ export const calculatorToolRenderer = {
 				const { expanded } = options;
 				const key = new Hasher().bool(expanded).u32(width).digest();
 				if (cached?.key === key) return cached.lines;
+				const description = args?.calculations?.[0]?.expression
+					? truncateToWidth(args.calculations[0].expression, Math.max(20, width - 20))
+					: undefined;
+				const header = renderStatusLine(
+					{ title: "Calc", description, meta: [formatCount("result", outputs.length)] },
+					uiTheme,
+				);
 				const treeLines = renderTreeList(
 					{
 						items: outputs,

--- a/packages/coding-agent/src/tools/debug.ts
+++ b/packages/coding-agent/src/tools/debug.ts
@@ -6,7 +6,7 @@ import type {
 	RenderResultOptions,
 } from "@f5xc-salesdemos/pi-agent-core";
 import { StringEnum } from "@f5xc-salesdemos/pi-ai";
-import { type Component, Text } from "@f5xc-salesdemos/pi-tui";
+import type { Component } from "@f5xc-salesdemos/pi-tui";
 import { prompt } from "@f5xc-salesdemos/pi-utils";
 import { type Static, Type } from "@sinclair/typebox";
 import {
@@ -39,14 +39,7 @@ import { CachedOutputBlock } from "../tui/output-block";
 import type { ToolSession } from ".";
 import type { OutputMeta } from "./output-meta";
 import { resolveToCwd } from "./path-utils";
-import {
-	formatExpandHint,
-	formatStatusIcon,
-	PREVIEW_LIMITS,
-	replaceTabs,
-	TRUNCATE_LENGTHS,
-	truncateToWidth,
-} from "./render-utils";
+import { formatExpandHint, formatStatusIcon, PREVIEW_LIMITS, replaceTabs, truncateToWidth } from "./render-utils";
 import { ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
@@ -513,42 +506,48 @@ function resolveDisassemblyReference(memoryReference: string | undefined): strin
 	);
 }
 
-function summarizeDebugCall(args: DebugRenderArgs): string {
+function summarizeDebugCall(args: DebugRenderArgs, maxWidth: number): string {
 	const action = args.action ? args.action.replaceAll("_", " ") : "request";
 	if (args.program) {
-		return `${action} ${truncateToWidth(args.program, TRUNCATE_LENGTHS.TITLE)}`;
+		return `${action} ${truncateToWidth(args.program, maxWidth)}`;
 	}
 	if (args.file && args.line !== undefined) {
-		return `${action} ${truncateToWidth(`${args.file}:${args.line}`, TRUNCATE_LENGTHS.TITLE)}`;
+		return `${action} ${truncateToWidth(`${args.file}:${args.line}`, maxWidth)}`;
 	}
 	if (args.function) {
-		return `${action} ${truncateToWidth(args.function, TRUNCATE_LENGTHS.TITLE)}`;
+		return `${action} ${truncateToWidth(args.function, maxWidth)}`;
 	}
 	if (args.expression) {
-		return `${action} ${truncateToWidth(args.expression, TRUNCATE_LENGTHS.TITLE)}`;
+		return `${action} ${truncateToWidth(args.expression, maxWidth)}`;
 	}
 	if (args.command) {
-		return `${action} ${truncateToWidth(args.command, TRUNCATE_LENGTHS.TITLE)}`;
+		return `${action} ${truncateToWidth(args.command, maxWidth)}`;
 	}
 	if (args.memory_reference) {
-		return `${action} ${truncateToWidth(args.memory_reference, TRUNCATE_LENGTHS.TITLE)}`;
+		return `${action} ${truncateToWidth(args.memory_reference, maxWidth)}`;
 	}
 	if (args.instruction_reference) {
-		return `${action} ${truncateToWidth(args.instruction_reference, TRUNCATE_LENGTHS.TITLE)}`;
+		return `${action} ${truncateToWidth(args.instruction_reference, maxWidth)}`;
 	}
 	if (args.data_id) {
-		return `${action} ${truncateToWidth(args.data_id, TRUNCATE_LENGTHS.TITLE)}`;
+		return `${action} ${truncateToWidth(args.data_id, maxWidth)}`;
 	}
 	if (args.name) {
-		return `${action} ${truncateToWidth(args.name, TRUNCATE_LENGTHS.TITLE)}`;
+		return `${action} ${truncateToWidth(args.name, maxWidth)}`;
 	}
 	return action;
 }
 
 export const debugToolRenderer = {
 	renderCall(args: DebugRenderArgs, _options: RenderResultOptions, theme: Theme): Component {
-		const text = renderStatusLine({ icon: "pending", title: "Debug", description: summarizeDebugCall(args) }, theme);
-		return new Text(text, 0, 0);
+		return {
+			render(width: number): string[] {
+				const description = summarizeDebugCall(args, Math.max(20, width - 20));
+				const text = renderStatusLine({ icon: "pending", title: "Debug", description }, theme);
+				return [truncateToWidth(text, width)];
+			},
+			invalidate() {},
+		};
 	},
 
 	renderResult(
@@ -569,9 +568,7 @@ export const debugToolRenderer = {
 				const text = result.content.find(block => block.type === "text")?.text ?? "No output";
 				const rawLines = replaceTabs(text).split("\n");
 				const previewLimit = options.expanded ? PREVIEW_LIMITS.EXPANDED_LINES : PREVIEW_LIMITS.COLLAPSED_LINES;
-				const displayedLines = rawLines
-					.slice(0, previewLimit)
-					.map(line => truncateToWidth(line, TRUNCATE_LENGTHS.LINE));
+				const displayedLines = rawLines.slice(0, previewLimit).map(line => truncateToWidth(line, width));
 				const remaining = rawLines.length - displayedLines.length;
 				if (remaining > 0) {
 					displayedLines.push(

--- a/packages/coding-agent/src/tools/inspect-image-renderer.ts
+++ b/packages/coding-agent/src/tools/inspect-image-renderer.ts
@@ -1,5 +1,4 @@
 import type { Component } from "@f5xc-salesdemos/pi-tui";
-import { Text } from "@f5xc-salesdemos/pi-tui";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme } from "../modes/theme/theme";
 import { renderStatusLine } from "../tui";
@@ -22,22 +21,28 @@ interface InspectImageRendererResult {
 	isError?: boolean;
 }
 
-const INSPECT_QUESTION_PREVIEW_WIDTH = 100;
 const INSPECT_OUTPUT_COLLAPSED_LINES = 4;
 const INSPECT_OUTPUT_EXPANDED_LINES = 16;
-const INSPECT_OUTPUT_LINE_WIDTH = 120;
 
 export const inspectImageToolRenderer = {
 	renderCall(args: InspectImageRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
 		const rawPath = args.path ?? "";
 		const pathDisplay = rawPath ? shortenPath(rawPath) : "…";
-		const header = renderStatusLine({ icon: "pending", title: "Inspect Image", description: pathDisplay }, uiTheme);
 		const question = args.question?.trim();
-		if (!question) {
-			return new Text(header, 0, 0);
-		}
-		const questionLine = ` ${uiTheme.fg("dim", uiTheme.tree.last)} ${uiTheme.fg("dim", "Question:")} ${uiTheme.fg("contentAccent", truncateToWidth(replaceTabs(question), INSPECT_QUESTION_PREVIEW_WIDTH))}`;
-		return new Text(`${header}\n${questionLine}`, 0, 0);
+		return {
+			render(width: number): string[] {
+				const header = truncateToWidth(
+					renderStatusLine({ icon: "pending", title: "Inspect Image", description: pathDisplay }, uiTheme),
+					width,
+				);
+				if (!question) {
+					return [header];
+				}
+				const questionLine = ` ${uiTheme.fg("dim", uiTheme.tree.last)} ${uiTheme.fg("dim", "Question:")} ${uiTheme.fg("contentAccent", truncateToWidth(replaceTabs(question), Math.max(20, width - 25)))}`;
+				return [header, questionLine];
+			},
+			invalidate() {},
+		};
 	},
 
 	renderResult(
@@ -59,44 +64,49 @@ export const inspectImageToolRenderer = {
 			},
 			uiTheme,
 		);
-
-		const lines: string[] = [header];
 		const question = args?.question?.trim();
-		if (question) {
-			lines.push(
-				` ${uiTheme.fg("dim", uiTheme.tree.branch)} ${uiTheme.fg("dim", "Question:")} ${uiTheme.fg("contentAccent", truncateToWidth(replaceTabs(question), INSPECT_QUESTION_PREVIEW_WIDTH))}`,
-			);
-		}
-
 		const outputText = result.content.find(content => content.type === "text")?.text?.trimEnd() ?? "";
-		if (!outputText) {
-			lines.push(uiTheme.fg("dim", "(no output)"));
-			if (metaParts.length > 0) {
+
+		return {
+			render(width: number): string[] {
+				const lines: string[] = [header];
+				if (question) {
+					lines.push(
+						` ${uiTheme.fg("dim", uiTheme.tree.branch)} ${uiTheme.fg("dim", "Question:")} ${uiTheme.fg("contentAccent", truncateToWidth(replaceTabs(question), Math.max(20, width - 25)))}`,
+					);
+				}
+
+				if (!outputText) {
+					lines.push(uiTheme.fg("dim", "(no output)"));
+					if (metaParts.length > 0) {
+						lines.push("");
+						lines.push(uiTheme.fg("dim", metaParts.join(" · ")));
+					}
+					return lines;
+				}
+
 				lines.push("");
-				lines.push(uiTheme.fg("dim", metaParts.join(" · ")));
-			}
-			return new Text(lines.join("\n"), 0, 0);
-		}
+				const outputLines = replaceTabs(outputText).split("\n");
+				const maxLines = options.expanded ? INSPECT_OUTPUT_EXPANDED_LINES : INSPECT_OUTPUT_COLLAPSED_LINES;
+				for (const line of outputLines.slice(0, maxLines)) {
+					lines.push(uiTheme.fg("toolOutput", truncateToWidth(line, width)));
+				}
 
-		lines.push("");
-		const outputLines = replaceTabs(outputText).split("\n");
-		const maxLines = options.expanded ? INSPECT_OUTPUT_EXPANDED_LINES : INSPECT_OUTPUT_COLLAPSED_LINES;
-		for (const line of outputLines.slice(0, maxLines)) {
-			lines.push(uiTheme.fg("toolOutput", truncateToWidth(line, INSPECT_OUTPUT_LINE_WIDTH)));
-		}
+				if (outputLines.length > maxLines) {
+					const remaining = outputLines.length - maxLines;
+					const hint = formatExpandHint(uiTheme, options.expanded, true);
+					lines.push(`${uiTheme.fg("dim", `… ${remaining} more lines`)}${hint ? ` ${hint}` : ""}`);
+				}
 
-		if (outputLines.length > maxLines) {
-			const remaining = outputLines.length - maxLines;
-			const hint = formatExpandHint(uiTheme, options.expanded, true);
-			lines.push(`${uiTheme.fg("dim", `… ${remaining} more lines`)}${hint ? ` ${hint}` : ""}`);
-		}
+				if (metaParts.length > 0) {
+					lines.push("");
+					lines.push(uiTheme.fg("dim", metaParts.join(" · ")));
+				}
 
-		if (metaParts.length > 0) {
-			lines.push("");
-			lines.push(uiTheme.fg("dim", metaParts.join(" · ")));
-		}
-
-		return new Text(lines.join("\n"), 0, 0);
+				return lines;
+			},
+			invalidate() {},
+		};
 	},
 	mergeCallAndResult: true,
 };

--- a/packages/coding-agent/src/tools/python.ts
+++ b/packages/coding-agent/src/tools/python.ts
@@ -559,7 +559,7 @@ interface PythonRenderContext {
 }
 
 /** Format a status event as a single line for display. */
-function formatStatusEvent(event: PythonStatusEvent, theme: Theme): string {
+function formatStatusEvent(event: PythonStatusEvent, theme: Theme, width: number): string {
 	const { op, ...data } = event;
 
 	// Map operations to available theme icons
@@ -635,7 +635,8 @@ function formatStatusEvent(event: PythonStatusEvent, theme: Theme): string {
 		case "find":
 		case "glob":
 			parts.push(`${data.count} match${(data.count as number) !== 1 ? "es" : ""}`);
-			if (data.pattern) parts.push(`for "${truncateToWidth(String(data.pattern), 20)}"`);
+			if (data.pattern)
+				parts.push(`for "${truncateToWidth(String(data.pattern), Math.max(15, Math.floor(width * 0.15)))}"`);
 			break;
 		case "grep":
 			parts.push(`${data.count} match${(data.count as number) !== 1 ? "es" : ""}`);
@@ -643,16 +644,21 @@ function formatStatusEvent(event: PythonStatusEvent, theme: Theme): string {
 			break;
 		case "rgrep":
 			parts.push(`${data.count} match${(data.count as number) !== 1 ? "es" : ""}`);
-			if (data.pattern) parts.push(`for "${truncateToWidth(String(data.pattern), 20)}"`);
+			if (data.pattern)
+				parts.push(`for "${truncateToWidth(String(data.pattern), Math.max(15, Math.floor(width * 0.15)))}"`);
 			break;
 		case "ls":
 			parts.push(`${data.count} entr${(data.count as number) !== 1 ? "ies" : "y"}`);
 			break;
 		case "env":
 			if (data.action === "set") {
-				parts.push(`set ${data.key}=${truncateToWidth(String(data.value ?? ""), 30)}`);
+				parts.push(
+					`set ${data.key}=${truncateToWidth(String(data.value ?? ""), Math.max(15, Math.floor(width * 0.2)))}`,
+				);
 			} else if (data.action === "get") {
-				parts.push(`${data.key}=${truncateToWidth(String(data.value ?? ""), 30)}`);
+				parts.push(
+					`${data.key}=${truncateToWidth(String(data.value ?? ""), Math.max(15, Math.floor(width * 0.2)))}`,
+				);
 			} else {
 				parts.push(`${data.count} variable${(data.count as number) !== 1 ? "s" : ""}`);
 			}
@@ -744,12 +750,12 @@ function formatStatusEvent(event: PythonStatusEvent, theme: Theme): string {
 }
 
 /** Format status event with expanded detail lines. */
-function formatStatusEventExpanded(event: PythonStatusEvent, theme: Theme): string[] {
+function formatStatusEventExpanded(event: PythonStatusEvent, theme: Theme, width: number): string[] {
 	const lines: string[] = [];
 	const { op, ...data } = event;
 
 	// Main status line
-	lines.push(formatStatusEvent(event, theme));
+	lines.push(formatStatusEvent(event, theme, width));
 
 	// Add detail lines for operations with list data
 	const addItems = (items: unknown[], formatter: (item: unknown) => string, max = 5) => {
@@ -766,7 +772,7 @@ function formatStatusEventExpanded(event: PythonStatusEvent, theme: Theme): stri
 	const addPreview = (preview: string, maxLines = 3) => {
 		const previewLines = String(preview).split("\n").slice(0, maxLines);
 		for (const line of previewLines) {
-			lines.push(`   ${theme.fg("toolOutput", truncateToWidth(replaceTabs(line), 80))}`);
+			lines.push(`   ${theme.fg("toolOutput", truncateToWidth(replaceTabs(line), width))}`);
 		}
 		const totalLines = String(preview).split("\n").length;
 		if (totalLines > maxLines) {
@@ -786,7 +792,7 @@ function formatStatusEventExpanded(event: PythonStatusEvent, theme: Theme): stri
 			if (data.hits) {
 				addItems(data.hits as unknown[], h => {
 					const hit = h as { line: number; text: string };
-					return `${hit.line}: ${truncateToWidth(hit.text, 60)}`;
+					return `${hit.line}: ${truncateToWidth(hit.text, width)}`;
 				});
 			}
 			break;
@@ -794,7 +800,7 @@ function formatStatusEventExpanded(event: PythonStatusEvent, theme: Theme): stri
 			if (data.hits) {
 				addItems(data.hits as unknown[], h => {
 					const hit = h as { file: string; line: number; text: string };
-					return `${shortenPath(hit.file)}:${hit.line}: ${truncateToWidth(hit.text, 50)}`;
+					return `${shortenPath(hit.file)}:${hit.line}: ${truncateToWidth(hit.text, width)}`;
 				});
 			}
 			break;
@@ -813,7 +819,7 @@ function formatStatusEventExpanded(event: PythonStatusEvent, theme: Theme): stri
 			if (data.entries) {
 				addItems(data.entries as unknown[], e => {
 					const entry = e as { sha: string; subject: string };
-					return `${entry.sha} ${truncateToWidth(entry.subject, 50)}`;
+					return `${entry.sha} ${truncateToWidth(entry.subject, width)}`;
 				});
 			}
 			break;
@@ -840,7 +846,7 @@ function formatStatusEventExpanded(event: PythonStatusEvent, theme: Theme): stri
 }
 
 /** Render status events as tree lines. */
-function renderStatusEvents(events: PythonStatusEvent[], theme: Theme, expanded: boolean): string[] {
+function renderStatusEvents(events: PythonStatusEvent[], theme: Theme, expanded: boolean, width: number): string[] {
 	if (events.length === 0) return [];
 
 	const maxCollapsed = 3;
@@ -854,14 +860,14 @@ function renderStatusEvents(events: PythonStatusEvent[], theme: Theme, expanded:
 
 		if (expanded) {
 			// Show expanded details for each event
-			const eventLines = formatStatusEventExpanded(events[i], theme);
+			const eventLines = formatStatusEventExpanded(events[i], theme, width);
 			lines.push(`${theme.fg("dim", branch)} ${eventLines[0]}`);
 			const continueBranch = isLast ? "   " : `${theme.tree.vertical}  `;
 			for (let j = 1; j < eventLines.length; j++) {
 				lines.push(`${theme.fg("dim", continueBranch)}${eventLines[j]}`);
 			}
 		} else {
-			lines.push(`${theme.fg("dim", branch)} ${formatStatusEvent(events[i], theme)}`);
+			lines.push(`${theme.fg("dim", branch)} ${formatStatusEvent(events[i], theme, width)}`);
 		}
 	}
 
@@ -1021,7 +1027,7 @@ export const pythonToolRenderer = {
 					const lines: string[] = [];
 					for (let i = 0; i < cellResults.length; i++) {
 						const cell = cellResults[i];
-						const statusLines = renderStatusEvents(cell.statusEvents ?? [], uiTheme, expanded);
+						const statusLines = renderStatusEvents(cell.statusEvents ?? [], uiTheme, expanded, width);
 						const outputContent = formatCellOutputLines(cell, expanded, previewLines, uiTheme, width);
 						const outputLines = [...outputContent.lines];
 						if (!expanded && outputContent.hiddenCount > 0) {
@@ -1083,36 +1089,39 @@ export const pythonToolRenderer = {
 		const combinedOutput = [displayOutput, ...jsonLines].filter(Boolean).join("\n");
 
 		const statusEvents = details?.statusEvents ?? [];
-		const statusLines = renderStatusEvents(
-			statusEvents,
-			uiTheme,
-			options.renderContext?.expanded ?? options.expanded,
-		);
+		const expandedFlag = options.renderContext?.expanded ?? options.expanded;
 
-		if (!combinedOutput && statusLines.length === 0) {
+		if (!combinedOutput && statusEvents.length === 0) {
 			const lines = [timeoutLine, warningLine].filter(Boolean) as string[];
 			return new Text(lines.join("\n"), 0, 0);
 		}
 
-		if (!combinedOutput && statusLines.length > 0) {
-			const lines = [uiTheme.fg("dim", "Status"), ...statusLines, timeoutLine, warningLine].filter(
-				Boolean,
-			) as string[];
-			return new Text(lines.join("\n"), 0, 0);
+		if (!combinedOutput && statusEvents.length > 0) {
+			return {
+				render(width: number): string[] {
+					const statusLines = renderStatusEvents(statusEvents, uiTheme, expandedFlag, width);
+					return [uiTheme.fg("dim", "Status"), ...statusLines, timeoutLine, warningLine].filter(
+						Boolean,
+					) as string[];
+				},
+				invalidate() {},
+			};
 		}
 
-		if (options.renderContext?.expanded ?? options.expanded) {
-			const styledOutput = combinedOutput
-				.split("\n")
-				.map(line => uiTheme.fg("toolOutput", line))
-				.join("\n");
-			const lines = [
-				styledOutput,
-				...(statusLines.length > 0 ? [uiTheme.fg("dim", "Status"), ...statusLines] : []),
-				timeoutLine,
-				warningLine,
-			].filter(Boolean) as string[];
-			return new Text(lines.join("\n"), 0, 0);
+		if (expandedFlag) {
+			const styledOutputLines = combinedOutput.split("\n").map(line => uiTheme.fg("toolOutput", line));
+			return {
+				render(width: number): string[] {
+					const statusLines = renderStatusEvents(statusEvents, uiTheme, expandedFlag, width);
+					return [
+						...styledOutputLines,
+						...(statusLines.length > 0 ? [uiTheme.fg("dim", "Status"), ...statusLines] : []),
+						timeoutLine,
+						warningLine,
+					].filter(Boolean) as string[];
+				},
+				invalidate() {},
+			};
 		}
 
 		const styledOutput = combinedOutput
@@ -1147,6 +1156,7 @@ export const pythonToolRenderer = {
 					outputLines.push(truncateToWidth(skippedLine, width));
 				}
 				outputLines.push(...cachedLines);
+				const statusLines = renderStatusEvents(statusEvents, uiTheme, expandedFlag, width);
 				if (statusLines.length > 0) {
 					outputLines.push(truncateToWidth(uiTheme.fg("dim", "Status"), width));
 					for (const statusLine of statusLines) {

--- a/packages/coding-agent/src/tools/resolve.ts
+++ b/packages/coding-agent/src/tools/resolve.ts
@@ -5,7 +5,6 @@ import type {
 	AgentToolUpdateCallback,
 } from "@f5xc-salesdemos/pi-agent-core";
 import type { Component } from "@f5xc-salesdemos/pi-tui";
-import { Text } from "@f5xc-salesdemos/pi-tui";
 import { prompt, untilAborted } from "@f5xc-salesdemos/pi-utils";
 import { type Static, Type } from "@sinclair/typebox";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
@@ -30,10 +29,10 @@ export interface ResolveToolDetails {
 	label?: string;
 }
 
-function resolveReasonPreview(reason?: string): string | undefined {
+function resolveReasonPreview(reason?: string, maxWidth?: number): string | undefined {
 	const trimmed = reason?.trim();
 	if (!trimmed) return undefined;
-	return truncateToWidth(trimmed, 72, Ellipsis.Omit);
+	return truncateToWidth(trimmed, maxWidth ?? 72, Ellipsis.Omit);
 }
 
 /**
@@ -132,21 +131,26 @@ export class ResolveTool implements AgentTool<typeof resolveSchema, ResolveToolD
 
 export const resolveToolRenderer = {
 	renderCall(args: ResolveParams, _options: RenderResultOptions, uiTheme: Theme): Component {
-		const reason = resolveReasonPreview(args.reason);
-		const text = renderStatusLine(
-			{
-				icon: "pending",
-				title: "Resolve",
-				description: args.action,
-				badge: {
-					label: args.action === "apply" ? "proposed -> resolved" : "proposed -> rejected",
-					color: args.action === "apply" ? "success" : "warning",
-				},
-				meta: reason ? [uiTheme.fg("muted", reason)] : undefined,
+		return {
+			render(width: number): string[] {
+				const reason = resolveReasonPreview(args.reason, Math.max(20, width - 40));
+				const text = renderStatusLine(
+					{
+						icon: "pending",
+						title: "Resolve",
+						description: args.action,
+						badge: {
+							label: args.action === "apply" ? "proposed -> resolved" : "proposed -> rejected",
+							color: args.action === "apply" ? "success" : "warning",
+						},
+						meta: reason ? [uiTheme.fg("muted", reason)] : undefined,
+					},
+					uiTheme,
+				);
+				return [truncateToWidth(text, width)];
 			},
-			uiTheme,
-		);
-		return new Text(text, 0, 0);
+			invalidate() {},
+		};
 	},
 
 	renderResult(

--- a/packages/coding-agent/src/tools/search-tool-bm25.ts
+++ b/packages/coding-agent/src/tools/search-tool-bm25.ts
@@ -20,7 +20,7 @@ import type { Theme } from "../modes/theme/theme";
 import searchToolBm25Description from "../prompts/tools/search-tool-bm25.md" with { type: "text" };
 import { renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
 import type { ToolSession } from ".";
-import { formatCount, replaceTabs, TRUNCATE_LENGTHS } from "./render-utils";
+import { formatCount, replaceTabs } from "./render-utils";
 import { ToolError } from "./tool-errors";
 
 const DEFAULT_LIMIT = 8;
@@ -135,10 +135,15 @@ function renderMatchLines(match: SearchToolBm25Match, theme: Theme): string[] {
 
 function renderFallbackResult(text: string, theme: Theme): Component {
 	const header = renderStatusLine({ title: TOOL_DISCOVERY_TITLE }, theme);
-	const bodyLines = (text || "Tool discovery completed")
-		.split("\n")
-		.map(line => theme.fg("dim", truncateToWidth(replaceTabs(line), TRUNCATE_LENGTHS.LINE)));
-	return new Text([header, ...bodyLines].join("\n"), 0, 0);
+	return {
+		render(width: number): string[] {
+			const bodyLines = (text || "Tool discovery completed")
+				.split("\n")
+				.map(line => theme.fg("dim", truncateToWidth(replaceTabs(line), width)));
+			return [header, ...bodyLines];
+		},
+		invalidate() {},
+	};
 }
 
 export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema, SearchToolBm25Details> {

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -9,7 +9,6 @@ import type {
 	ToolCallContext,
 } from "@f5xc-salesdemos/pi-agent-core";
 import type { Component } from "@f5xc-salesdemos/pi-tui";
-import { Text } from "@f5xc-salesdemos/pi-tui";
 import { isEnoent, isRecord, prompt, untilAborted } from "@f5xc-salesdemos/pi-utils";
 import { type Static, Type } from "@sinclair/typebox";
 import { unzipSync, zipSync } from "fflate";
@@ -543,7 +542,7 @@ function normalizeDisplayText(text: string): string {
 	return text.replace(/\r/g, "");
 }
 
-function formatStreamingContent(content: string, uiTheme: Theme): string {
+function formatStreamingContent(content: string, uiTheme: Theme, maxWidth: number): string {
 	if (!content) return "";
 	const lines = normalizeDisplayText(content).split("\n");
 	const displayLines = lines.slice(-WRITE_STREAMING_PREVIEW_LINES);
@@ -554,13 +553,13 @@ function formatStreamingContent(content: string, uiTheme: Theme): string {
 		text += uiTheme.fg("dim", `… (${hidden} earlier lines)\n`);
 	}
 	for (const line of displayLines) {
-		text += `${uiTheme.fg("toolOutput", truncateToWidth(replaceTabs(line), 80))}\n`;
+		text += `${uiTheme.fg("toolOutput", truncateToWidth(replaceTabs(line), maxWidth))}\n`;
 	}
 	text += uiTheme.fg("dim", `… (streaming)`);
 	return text;
 }
 
-function renderContentPreview(content: string, expanded: boolean, uiTheme: Theme): string {
+function renderContentPreview(content: string, expanded: boolean, uiTheme: Theme, maxWidth: number): string {
 	if (!content) return "";
 	const lines = normalizeDisplayText(content).split("\n");
 	const maxLines = expanded ? lines.length : Math.min(lines.length, WRITE_PREVIEW_LINES);
@@ -569,7 +568,7 @@ function renderContentPreview(content: string, expanded: boolean, uiTheme: Theme
 
 	let text = "\n\n";
 	for (const line of displayLines) {
-		text += `${uiTheme.fg("toolOutput", truncateToWidth(replaceTabs(line), 80))}\n`;
+		text += `${uiTheme.fg("toolOutput", truncateToWidth(replaceTabs(line), maxWidth))}\n`;
 	}
 	if (!expanded && hidden > 0) {
 		const hint = formatExpandHint(uiTheme, expanded, hidden > 0);
@@ -589,16 +588,24 @@ export const writeToolRenderer = {
 		const spinner =
 			options?.spinnerFrame !== undefined ? formatStatusIcon("running", uiTheme, options.spinnerFrame) : "";
 
-		let text = `${formatTitle("Write", uiTheme)} ${spinner ? `${spinner} ` : ""}${langIcon} ${pathDisplay}`;
+		const header = `${formatTitle("Write", uiTheme)} ${spinner ? `${spinner} ` : ""}${langIcon} ${pathDisplay}`;
 
 		if (!args.content) {
-			return new Text(text, 0, 0);
+			return {
+				render(width: number) {
+					return [truncateToWidth(header, width, Ellipsis.Omit)];
+				},
+				invalidate() {},
+			};
 		}
 
-		// Show streaming preview of content (tail)
-		text += formatStreamingContent(args.content, uiTheme);
-
-		return new Text(text, 0, 0);
+		return {
+			render(width: number) {
+				const text = header + formatStreamingContent(args.content!, uiTheme, width);
+				return text.split("\n").map(l => truncateToWidth(l, width, Ellipsis.Omit));
+			},
+			invalidate() {},
+		};
 	},
 
 	renderResult(
@@ -636,7 +643,7 @@ export const writeToolRenderer = {
 
 				let text = header;
 				text += `\n${metadataLine}`;
-				text += renderContentPreview(fileContent, expanded, uiTheme);
+				text += renderContentPreview(fileContent, expanded, uiTheme, width);
 
 				if (diagnostics) {
 					const diagText = formatDiagnostics(diagnostics, expanded, uiTheme, fp =>

--- a/packages/coding-agent/src/web/search/render.ts
+++ b/packages/coding-agent/src/web/search/render.ts
@@ -17,7 +17,6 @@ import {
 	getDomain,
 	getPreviewLines,
 	PREVIEW_LIMITS,
-	TRUNCATE_LENGTHS,
 	truncateToWidth,
 } from "../../tools/render-utils";
 import { renderStatusLine, renderTreeList } from "../../tui";
@@ -35,39 +34,43 @@ function getVerboseSetting(): boolean {
 
 const MAX_COLLAPSED_ANSWER_LINES = PREVIEW_LIMITS.COLLAPSED_LINES;
 const MAX_EXPANDED_ANSWER_LINES = PREVIEW_LIMITS.EXPANDED_LINES;
-const MAX_ANSWER_LINE_LEN = TRUNCATE_LENGTHS.LINE;
 const MAX_SNIPPET_LINES = 2;
-const MAX_SNIPPET_LINE_LEN = TRUNCATE_LENGTHS.LINE;
 const MAX_COLLAPSED_ITEMS = PREVIEW_LIMITS.COLLAPSED_ITEMS;
 const MAX_QUERY_PREVIEW = 2;
-const MAX_QUERY_LEN = 90;
 const MAX_REQUEST_ID_LEN = 36;
 
 function renderFallbackText(contentText: string, expanded: boolean, theme: Theme): Component {
-	const lines = contentText.split("\n").filter(line => line.trim());
-	const maxLines = expanded ? lines.length : 6;
-	const displayLines = lines.slice(0, maxLines).map(line => truncateToWidth(line.trim(), 110));
-	const remaining = lines.length - displayLines.length;
+	return {
+		render(width: number): string[] {
+			const allLines = contentText.split("\n").filter(line => line.trim());
+			const maxLines = expanded ? allLines.length : 6;
+			const displayLines = allLines.slice(0, maxLines).map(line => truncateToWidth(line.trim(), width));
+			const remaining = allLines.length - displayLines.length;
 
-	const expandHint = formatExpandHint(theme, expanded, remaining > 0);
-	let text = `${theme.fg("dim", "Response")}${expandHint}`;
+			const expandHint = formatExpandHint(theme, expanded, remaining > 0);
+			const result: string[] = [`${theme.fg("dim", "Response")}${expandHint}`];
 
-	if (displayLines.length === 0) {
-		text += `\n ${theme.fg("dim", theme.tree.last)} ${theme.fg("muted", "No response data")}`;
-		return new Text(text, 0, 0);
-	}
+			if (displayLines.length === 0) {
+				result.push(` ${theme.fg("dim", theme.tree.last)} ${theme.fg("muted", "No response data")}`);
+				return result;
+			}
 
-	for (let i = 0; i < displayLines.length; i++) {
-		const isLast = i === displayLines.length - 1 && remaining === 0;
-		const branch = isLast ? theme.tree.last : theme.tree.branch;
-		text += `\n ${theme.fg("dim", branch)} ${theme.fg("dim", displayLines[i])}`;
-	}
+			for (let i = 0; i < displayLines.length; i++) {
+				const isLast = i === displayLines.length - 1 && remaining === 0;
+				const branch = isLast ? theme.tree.last : theme.tree.branch;
+				result.push(` ${theme.fg("dim", branch)} ${theme.fg("dim", displayLines[i])}`);
+			}
 
-	if (!expanded && remaining > 0) {
-		text += `\n ${theme.fg("dim", theme.tree.last)} ${theme.fg("muted", formatMoreItems(remaining, "line"))}`;
-	}
+			if (!expanded && remaining > 0) {
+				result.push(
+					` ${theme.fg("dim", theme.tree.last)} ${theme.fg("muted", formatMoreItems(remaining, "line"))}`,
+				);
+			}
 
-	return new Text(text, 0, 0);
+			return result;
+		},
+		invalidate() {},
+	};
 }
 
 export interface SearchRenderDetails {
@@ -113,14 +116,19 @@ export function renderSearchResult(
 					? `${Math.round(response.durationMs / 1000)}s`
 					: `${Math.round(response.durationMs)}ms`
 				: "";
-		const queryPreview = args?.query
-			? truncateToWidth(args.query, 80)
-			: searchQueries[0]
-				? truncateToWidth(searchQueries[0], 80)
-				: undefined;
-		const header = queryPreview ? `Web Search("${queryPreview}")` : "Web Search";
-		const summary = `  \u23BF  Did ${searches} search${plural}${dur ? ` in ${dur}` : ""}`;
-		return new Text(`${theme.fg("text", header)}\n${theme.fg("dim", summary)}`, 0, 0);
+		return {
+			render(width: number): string[] {
+				const queryPreview = args?.query
+					? truncateToWidth(args.query, Math.max(20, width - 15))
+					: searchQueries[0]
+						? truncateToWidth(searchQueries[0], Math.max(20, width - 15))
+						: undefined;
+				const header = queryPreview ? `Web Search("${queryPreview}")` : "Web Search";
+				const summary = `  \u23BF  Did ${searches} search${plural}${dur ? ` in ${dur}` : ""}`;
+				return [theme.fg("text", header), theme.fg("dim", summary)];
+			},
+			invalidate() {},
+		};
 	}
 
 	const sources = Array.isArray(response.sources) ? response.sources : [];
@@ -141,11 +149,6 @@ export function renderSearchResult(
 	const totalAnswerLines = answerLines.length;
 
 	const providerLabel = provider !== "none" ? getSearchProvider(provider).label : "None";
-	const queryPreview = args?.query
-		? truncateToWidth(args.query, 80)
-		: searchQueries[0]
-			? truncateToWidth(searchQueries[0], 80)
-			: undefined;
 	const header = renderStatusLine(
 		{
 			title: "Web Search",
@@ -179,13 +182,6 @@ export function renderSearchResult(
 			`${theme.fg("muted", "Request:")} ${theme.fg("text", truncateToWidth(response.requestId, MAX_REQUEST_ID_LEN))}`,
 		);
 	}
-	if (searchQueries.length > 0) {
-		const queriesPreview = searchQueries.slice(0, MAX_QUERY_PREVIEW);
-		const queryList = queriesPreview.map(q => truncateToWidth(q, MAX_QUERY_LEN));
-		const suffix = searchQueries.length > queriesPreview.length ? "…" : "";
-		metaLines.push(`${theme.fg("muted", "Queries:")} ${theme.fg("text", queryList.join("; "))}${suffix}`);
-	}
-
 	const outputBlock = new CachedOutputBlock();
 
 	return {
@@ -193,12 +189,27 @@ export function renderSearchResult(
 			// Read mutable state at render time
 			const { expanded } = options;
 
+			const queryPreview = args?.query
+				? truncateToWidth(args.query, Math.max(20, width - 20))
+				: searchQueries[0]
+					? truncateToWidth(searchQueries[0], Math.max(20, width - 20))
+					: undefined;
+
+			// Build metadata with width-aware query truncation
+			const allMetaLines = [...metaLines];
+			if (searchQueries.length > 0) {
+				const queriesPreview = searchQueries.slice(0, MAX_QUERY_PREVIEW);
+				const queryList = queriesPreview.map(q => truncateToWidth(q, Math.max(20, width - 20)));
+				const suffix = searchQueries.length > queriesPreview.length ? "…" : "";
+				allMetaLines.push(`${theme.fg("muted", "Queries:")} ${theme.fg("text", queryList.join("; "))}${suffix}`);
+			}
+
 			// Expanded-dependent computations
 			const answerLimit = expanded ? MAX_EXPANDED_ANSWER_LINES : MAX_COLLAPSED_ANSWER_LINES;
 			const answerPreview = contentText
 				? args?.allowLongAnswer
 					? answerLines.slice(0, args.maxAnswerLines ?? answerLines.length)
-					: getPreviewLines(contentText, answerLimit, MAX_ANSWER_LINE_LEN)
+					: getPreviewLines(contentText, answerLimit, width)
 				: [];
 			const remainingAnswer = totalAnswerLines - answerPreview.length;
 
@@ -215,7 +226,7 @@ export function renderSearchResult(
 								: typeof src.url === "string" && src.url.trim()
 									? src.url
 									: "Untitled";
-						const title = truncateToWidth(titleText, MAX_SNIPPET_LINE_LEN);
+						const title = truncateToWidth(titleText, width);
 						const url = typeof src.url === "string" ? src.url : "";
 						const domain = url ? getDomain(url) : "";
 						const age =
@@ -223,21 +234,23 @@ export function renderSearchResult(
 						const metaParts: string[] = [];
 						if (domain) metaParts.push(theme.fg("dim", `(${domain})`));
 						if (typeof src.author === "string" && src.author.trim())
-							metaParts.push(theme.fg("muted", truncateToWidth(src.author.trim(), 40)));
+							metaParts.push(
+								theme.fg("muted", truncateToWidth(src.author.trim(), Math.max(15, Math.floor(width * 0.25)))),
+							);
 						if (age) metaParts.push(theme.fg("muted", age));
 						const metaSep = theme.fg("dim", theme.sep.dot);
 						const metaSuffix = metaParts.length > 0 ? ` ${metaParts.join(metaSep)}` : "";
 						const srcLines: string[] = [
-							truncateToWidth(`${theme.fg("contentAccent", title)}${metaSuffix}`, MAX_SNIPPET_LINE_LEN),
+							truncateToWidth(`${theme.fg("contentAccent", title)}${metaSuffix}`, width),
 						];
 						const snippetText = typeof src.snippet === "string" ? src.snippet : "";
 						if (snippetText.trim()) {
-							const snippetLines = getPreviewLines(snippetText, MAX_SNIPPET_LINES, MAX_SNIPPET_LINE_LEN);
+							const snippetLines = getPreviewLines(snippetText, MAX_SNIPPET_LINES, width);
 							for (const snippetLine of snippetLines) {
 								srcLines.push(theme.fg("muted", `${theme.format.dash} ${snippetLine}`));
 							}
 						}
-						if (url) srcLines.push(theme.fg("mdLinkUrl", truncateToWidth(url, MAX_SNIPPET_LINE_LEN)));
+						if (url) srcLines.push(theme.fg("mdLinkUrl", truncateToWidth(url, width)));
 						return srcLines;
 					},
 				},
@@ -295,7 +308,7 @@ export function renderSearchResult(
 							label: theme.fg("toolTitle", "Sources"),
 							lines: sourceTree.length > 0 ? sourceTree : [theme.fg("muted", "No sources returned")],
 						},
-						{ label: theme.fg("toolTitle", "Metadata"), lines: metaLines },
+						{ label: theme.fg("toolTitle", "Metadata"), lines: allMetaLines },
 					],
 					width,
 				},
@@ -314,13 +327,18 @@ export function renderSearchCall(
 	_options: RenderResultOptions,
 	theme: Theme,
 ): Component {
-	const query = truncateToWidth(args.query ?? "", 80);
-	const verbose = getVerboseSetting();
-	if (!verbose) {
-		return new Text(`${theme.fg("text", `Web Search("${query}")`)}`, 0, 0);
-	}
-	const text = renderStatusLine({ icon: "pending", title: "Web Search", description: query }, theme);
-	return new Text(text, 0, 0);
+	return {
+		render(width: number): string[] {
+			const query = truncateToWidth(args.query ?? "", Math.max(20, width - 15));
+			const verbose = getVerboseSetting();
+			if (!verbose) {
+				return [theme.fg("text", `Web Search("${query}")`)];
+			}
+			const text = renderStatusLine({ icon: "pending", title: "Web Search", description: query }, theme);
+			return [truncateToWidth(text, width)];
+		},
+		invalidate() {},
+	};
 }
 
 export const webSearchToolRenderer = {


### PR DESCRIPTION
## What

Convert all tool renderers to use the runtime `width` parameter from `render(width: number)` instead of hardcoded truncation widths, matching the pattern already applied to the Bash tool.

## Why

All tool renderers except Bash used hardcoded truncation widths (80, 90, 100, 110 chars), causing inconsistent and clipped display on wide terminals. This unifies the truncation strategy across all 15 renderer files.

Also fixes:
- Tree-prefix overflow in Exa renderer
- Split-line regression in Python expanded output

Closes #576

## Testing

- All 15 modified files pass `biome check` (lint + format)
- Type-check passes via `tsc --noEmit`
- Pre-commit hooks pass on all staged files

---

- [x] `bun run check` passes
- [x] Issue linked via `Closes #576`