### PR TITLE
fix(tui): gracefully truncate oversized lines instead of crashing

### DIFF
--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -457,7 +457,7 @@ export const editToolRenderer = {
 		return {
 			render(width: number) {
 				const text = header + getCallPreview(args, rawPath, uiTheme, width);
-				return text.split("\n");
+				return width > 0 ? text.split("\n").flatMap(line => wrapEditRendererLine(line, width)) : text.split("\n");
 			},
 			invalidate() {},
 		};

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -3,7 +3,7 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { $flag, getCrashLogPath, getDebugLogPath } from "@f5xc-salesdemos/pi-utils";
+import { $flag, getDebugLogPath } from "@f5xc-salesdemos/pi-utils";
 import { isKeyRelease, matchesKey } from "./keys";
 import type { Terminal } from "./terminal";
 import { ImageProtocol, setCellDimensions, setTerminalImageProtocol, TERMINAL } from "./terminal-capabilities";
@@ -996,6 +996,14 @@ export class TUI extends Container {
 		// Render all components to get new lines
 		let newLines = this.render(width);
 
+		// Clamp any oversized lines before dirty-checking so the truncated form
+		// matches what we store in #previousLines, preventing perpetual repaints.
+		for (let i = 0; i < newLines.length; i++) {
+			if (!TERMINAL.isImageLine(newLines[i]) && visibleWidth(newLines[i]) > width) {
+				newLines[i] = sliceByColumn(newLines[i], 0, width, true);
+			}
+		}
+
 		// Composite overlays into the rendered lines (before differential compare)
 		if (this.overlayStack.length > 0) {
 			newLines = this.#compositeOverlays(newLines, width, height);
@@ -1195,36 +1203,7 @@ export class TUI extends Container {
 			if (i > firstChanged) buffer += "\r\n";
 			buffer += "\x1b[2K"; // Clear current line
 			const line = newLines[i];
-			const isImage = TERMINAL.isImageLine(line);
-			if (!isImage && visibleWidth(line) > width) {
-				// Log all lines to crash file for debugging
-				const crashLogPath = getCrashLogPath();
-				const crashData = [
-					`Crash at ${new Date().toISOString()}`,
-					`Terminal width: ${width}`,
-					`Line ${i} visible width: ${visibleWidth(line)}`,
-					"",
-					"=== All rendered lines ===",
-					...newLines.map((l, idx) => `[${idx}] (w=${visibleWidth(l)}) ${l}`),
-					"",
-				].join("\n");
-				fs.mkdirSync(path.dirname(crashLogPath), { recursive: true });
-				fs.writeFileSync(crashLogPath, crashData);
-
-				// Clean up terminal state before throwing
-				this.stop();
-
-				const errorMsg = [
-					`Rendered line ${i} exceeds terminal width (${visibleWidth(line)} > ${width}).`,
-					"",
-					"This is likely caused by a custom TUI component not truncating its output.",
-					"Use visibleWidth() to measure and truncateToWidth() to truncate lines.",
-					"",
-					`Debug log written to: ${crashLogPath}`,
-				].join("\n");
-				throw new Error(errorMsg);
-			}
-			buffer += isImage ? line : line + SEGMENT_RESET;
+			buffer += TERMINAL.isImageLine(line) ? line : line + SEGMENT_RESET;
 		}
 
 		// Track where cursor ended up after rendering


### PR DESCRIPTION
## What

Prevent a hard crash when the edit tool streams lines wider than the terminal.

Two-layer fix:
1. **Edit renderer** `renderCall` now wraps lines through `wrapEditRendererLine`, matching the pattern already used by `renderResult`.
2. **TUI `#doRender`** normalizes oversized lines immediately after `render()` returns — before dirty-checking and before writing to the terminal — so clipped lines match `#previousLines` and don't cause perpetual repaints.

## Why

PR #578 widened tool renderers to use runtime terminal width but the edit `renderCall` path had no line wrapping, and the TUI had a crash assertion instead of graceful truncation. Users hit a crash when the edit tool streamed long content lines (e.g. a 270-char prompt line into a 186-col terminal).

Closes #583

## Testing

- Verified Biome lint and format pass (`bun run check`)
- Pre-commit hooks pass on both changed files

---

- [x] `bun run check` passes
- [x] Issue linked via `Closes #583`