### PR TITLE
fix(ci): pass GITHUB_TOKEN to check job for API spec generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
       - run: bun install --frozen-lockfile
       - name: Type check workspace
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run ci:check:full
 
   native:


### PR DESCRIPTION
## What

Add `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` environment variable to the `check` job's type check step in the CI workflow.

## Why

The `check` job runs `generate-api-spec-index` as part of `ci:check:full`, which downloads API specs from the GitHub API. Without a token, this hits the unauthenticated rate limit (60 req/hr) and fails with HTTP 403. This was observed in run 25359939792. The fix matches the pattern already used in other jobs (native, release).

Closes #585

## Testing

- [ ] CI checks pass (this PR itself exercises the fix)
- [x] Issue linked via `Closes #585`