### PR TITLE
feat(api-spec): surface metadata.note from constraint enrichment in spec renderer

### DIFF
--- a/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
@@ -412,6 +412,8 @@ function formatFieldConstraints(prop: Record<string, unknown>): string {
 	if (c.maxItems != null) parts.push(`maxItems: ${c.maxItems}`);
 	if (c.format) parts.push(`format: ${c.format}`);
 	if (Array.isArray(c.enum)) parts.push(`enum: ${(c.enum as string[]).join(", ")}`);
+	const meta = c.metadata as Record<string, unknown> | undefined;
+	if (meta?.note) parts.push(`note: ${String(meta.note)}`);
 	return parts.join(", ");
 }
 

--- a/packages/coding-agent/test/internal-urls/api-spec-integration.test.ts
+++ b/packages/coding-agent/test/internal-urls/api-spec-integration.test.ts
@@ -97,6 +97,7 @@ describe("API spec integration — full traversal", () => {
 		expect(result.content).toContain("Mutually exclusive");
 		expect(result.content).toContain("health_check");
 		expect(result.content).toContain("max: 600");
+		expect(result.content).toContain("note: Accepts {0} union");
 	});
 });
 


### PR DESCRIPTION
## Summary
- Append `metadata.note` to rendered constraint string in `formatFieldConstraints()` when present in `x-f5xc-constraints`
- Add integration test assertion for note rendering on healthcheck `jitter_percent`

## Context
api-specs-enriched v2.1.68 stores non-obvious constraint qualifications in `x-f5xc-constraints.metadata.note` — e.g. jitter_percent's non-contiguous range (`{0} ∪ [10, 50]`), timeout's healthcheck-specific max (600 vs global 3600). These notes were correctly embedded in the spec data but never rendered by the spec resolver. Without the note, an AI agent would generate `jitter_percent: 5` and receive a 400 error.

## Test plan
- [x] `bun check:ts` clean (0 errors)
- [x] Live verification: jitter_percent row now shows `min: 0, max: 50, note: Accepts {0} union [10, 50] — simplified to [0, 50] for OpenAPI compat`
- [x] timeout row shows `min: 1, max: 600, note: API rejects timeout > 600 for healthchecks (global pattern says 3600)`
- [ ] Integration test: `expect(result.content).toContain("note: Accepts {0} union")`

## Files (2)
- `packages/coding-agent/src/internal-urls/api-spec-resolve.ts` (+2 lines)
- `packages/coding-agent/test/internal-urls/api-spec-integration.test.ts` (+1 line)

Closes #591