### PR TITLE
test: UAT coverage for user profile system

### DIFF
--- a/packages/coding-agent/src/internal-urls/user-profile.ts
+++ b/packages/coding-agent/src/internal-urls/user-profile.ts
@@ -68,7 +68,7 @@ export async function saveProfile(profile: UserProfile): Promise<void> {
 	await Bun.write(PROFILE_PATH, JSON.stringify(profile, null, 2));
 }
 
-function mergeProfile(target: UserProfile, source: Partial<UserProfile>): void {
+export function mergeProfile(target: UserProfile, source: Partial<UserProfile>): void {
 	for (const [key, value] of Object.entries(source)) {
 		if (value === undefined || value === null) continue;
 		const k = key as keyof UserProfile;

--- a/packages/coding-agent/test/internal-urls/seed-profile.test.ts
+++ b/packages/coding-agent/test/internal-urls/seed-profile.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { PROFILE_COLLECTORS } from "../../src/internal-urls/profile-collectors";
+import type { UserProfile } from "../../src/internal-urls/user-profile";
+import { seedProfile } from "../../src/internal-urls/user-profile";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface MockIOResult {
+	lastWritten: () => UserProfile;
+	writeCallCount: () => number;
+}
+
+function mockIO(initial: object = {}): MockIOResult {
+	let captured = "";
+	let writes = 0;
+
+	vi.spyOn(Bun, "file").mockReturnValue({
+		json: () => Promise.resolve(initial),
+	} as unknown as ReturnType<typeof Bun.file>);
+
+	vi.spyOn(Bun, "write").mockImplementation((async (_dest: unknown, data: unknown) => {
+		captured = String(data);
+		writes++;
+		return captured.length;
+	}) as typeof Bun.write);
+
+	return {
+		lastWritten: () => JSON.parse(captured) as UserProfile,
+		writeCallCount: () => writes,
+	};
+}
+
+function collector(id: string) {
+	const c = PROFILE_COLLECTORS.find(p => p.id === id);
+	if (!c) throw new Error(`unknown collector: ${id}`);
+	return c;
+}
+
+// ---------------------------------------------------------------------------
+// seedProfile
+// ---------------------------------------------------------------------------
+
+describe("seedProfile", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("skips unavailable collectors and omits their source timestamp", async () => {
+		const io = mockIO();
+
+		vi.spyOn(collector("salesforce"), "available").mockResolvedValue(false);
+
+		vi.spyOn(collector("github"), "available").mockResolvedValue(true);
+		vi.spyOn(collector("github"), "collect").mockResolvedValue({ givenName: "Robin" });
+
+		vi.spyOn(collector("system"), "available").mockResolvedValue(true);
+		vi.spyOn(collector("system"), "collect").mockResolvedValue({ knowsLanguage: ["en-US"] });
+
+		await seedProfile();
+
+		const written = io.lastWritten();
+		expect(written.sources?.salesforce).toBeUndefined();
+		expect(written.sources?.github).toBeString();
+		expect(written.sources?.system).toBeString();
+	});
+
+	it("isolates a throwing collector — others still run and profile saves", async () => {
+		const io = mockIO();
+
+		vi.spyOn(collector("salesforce"), "available").mockResolvedValue(true);
+		vi.spyOn(collector("salesforce"), "collect").mockRejectedValue(new Error("sf exploded"));
+
+		vi.spyOn(collector("github"), "available").mockResolvedValue(true);
+		vi.spyOn(collector("github"), "collect").mockResolvedValue({ givenName: "Robin" });
+
+		vi.spyOn(collector("system"), "available").mockResolvedValue(false);
+
+		await seedProfile();
+
+		const written = io.lastWritten();
+		expect(written.sources?.salesforce).toBeUndefined();
+		expect(written.sources?.github).toBeString();
+		expect(written.givenName).toBe("Robin");
+	});
+
+	it("records source timestamps within the call window", async () => {
+		mockIO();
+
+		vi.spyOn(collector("salesforce"), "available").mockResolvedValue(true);
+		vi.spyOn(collector("salesforce"), "collect").mockResolvedValue({});
+
+		vi.spyOn(collector("github"), "available").mockResolvedValue(true);
+		vi.spyOn(collector("github"), "collect").mockResolvedValue({});
+
+		vi.spyOn(collector("system"), "available").mockResolvedValue(true);
+		vi.spyOn(collector("system"), "collect").mockResolvedValue({});
+
+		const before = Date.now();
+		const result = await seedProfile();
+		const after = Date.now();
+
+		for (const id of ["salesforce", "github", "system"] as const) {
+			const ts = new Date(result.sources![id]!).getTime();
+			expect(ts).toBeGreaterThanOrEqual(before);
+			expect(ts).toBeLessThanOrEqual(after);
+		}
+	});
+
+	it("saves profile to disk exactly once", async () => {
+		const io = mockIO();
+
+		vi.spyOn(collector("salesforce"), "available").mockResolvedValue(false);
+		vi.spyOn(collector("github"), "available").mockResolvedValue(false);
+		vi.spyOn(collector("system"), "available").mockResolvedValue(false);
+
+		await seedProfile();
+
+		expect(io.writeCallCount()).toBe(1);
+	});
+
+	it("does not overwrite existing profile fields with collector data", async () => {
+		const io = mockIO({ givenName: "Robin", email: "r@f5.com" });
+
+		vi.spyOn(collector("salesforce"), "available").mockResolvedValue(true);
+		vi.spyOn(collector("salesforce"), "collect").mockResolvedValue({
+			email: "other@f5.com",
+			telephone: "+1-555-1234",
+		});
+
+		vi.spyOn(collector("github"), "available").mockResolvedValue(false);
+		vi.spyOn(collector("system"), "available").mockResolvedValue(false);
+
+		await seedProfile();
+
+		const written = io.lastWritten();
+		expect(written.email).toBe("r@f5.com");
+		expect(written.telephone).toBe("+1-555-1234");
+	});
+});

--- a/packages/coding-agent/test/internal-urls/user-profile-merge.test.ts
+++ b/packages/coding-agent/test/internal-urls/user-profile-merge.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "bun:test";
+import { mergeProfile, type UserProfile } from "../../src/internal-urls/user-profile";
+
+describe("mergeProfile", () => {
+	describe("scalar fields", () => {
+		it("sets givenName when target is empty", () => {
+			const target: UserProfile = {};
+			mergeProfile(target, { givenName: "Ada" });
+			expect(target.givenName).toBe("Ada");
+		});
+
+		it("does not overwrite existing givenName", () => {
+			const target: UserProfile = { givenName: "Ada" };
+			mergeProfile(target, { givenName: "Grace" });
+			expect(target.givenName).toBe("Ada");
+		});
+
+		it("skips null source values", () => {
+			const target: UserProfile = {};
+			mergeProfile(target, { givenName: null as unknown as string });
+			expect(target.givenName).toBeUndefined();
+		});
+
+		it("skips undefined source values", () => {
+			const target: UserProfile = {};
+			mergeProfile(target, { givenName: undefined });
+			expect(target.givenName).toBeUndefined();
+		});
+	});
+
+	describe("sameAs array", () => {
+		it("initializes when target has none", () => {
+			const target: UserProfile = {};
+			mergeProfile(target, { sameAs: ["https://github.com/ada"] });
+			expect(target.sameAs).toEqual(["https://github.com/ada"]);
+		});
+
+		it("appends new URLs to existing array", () => {
+			const target: UserProfile = { sameAs: ["https://github.com/ada"] };
+			mergeProfile(target, { sameAs: ["https://twitter.com/ada"] });
+			expect(target.sameAs).toContain("https://github.com/ada");
+			expect(target.sameAs).toContain("https://twitter.com/ada");
+			expect(target.sameAs).toHaveLength(2);
+		});
+
+		it("deduplicates URLs already present", () => {
+			const url = "https://github.com/ada";
+			const target: UserProfile = { sameAs: [url] };
+			mergeProfile(target, { sameAs: [url, url] });
+			expect(target.sameAs?.filter(u => u === url)).toHaveLength(1);
+			expect(target.sameAs).toHaveLength(1);
+		});
+	});
+
+	describe("knowsLanguage", () => {
+		it("sets when target has none", () => {
+			const target: UserProfile = {};
+			mergeProfile(target, { knowsLanguage: ["en", "fr"] });
+			expect(target.knowsLanguage).toEqual(["en", "fr"]);
+		});
+
+		it("does not overwrite existing array", () => {
+			const target: UserProfile = { knowsLanguage: ["en"] };
+			mergeProfile(target, { knowsLanguage: ["fr", "de"] });
+			expect(target.knowsLanguage).toEqual(["en"]);
+		});
+	});
+
+	describe("object fields (first-writer-wins)", () => {
+		it("sets address when target has none", () => {
+			const target: UserProfile = {};
+			mergeProfile(target, { address: { addressLocality: "Seattle", addressRegion: "WA" } });
+			expect(target.address?.addressLocality).toBe("Seattle");
+		});
+
+		it("does not overwrite existing address", () => {
+			const target: UserProfile = { address: { addressLocality: "Portland" } };
+			mergeProfile(target, { address: { addressLocality: "Seattle" } });
+			expect(target.address?.addressLocality).toBe("Portland");
+		});
+
+		it("sets worksFor when target has none", () => {
+			const target: UserProfile = {};
+			mergeProfile(target, { worksFor: { name: "F5", url: "https://f5.com" } });
+			expect(target.worksFor?.name).toBe("F5");
+		});
+
+		it("does not overwrite existing worksFor", () => {
+			const target: UserProfile = { worksFor: { name: "Acme" } };
+			mergeProfile(target, { worksFor: { name: "F5" } });
+			expect(target.worksFor?.name).toBe("Acme");
+		});
+
+		it("sets birthPlace when target has none", () => {
+			const target: UserProfile = {};
+			mergeProfile(target, { birthPlace: { addressLocality: "London", addressRegion: "England" } });
+			expect(target.birthPlace?.addressLocality).toBe("London");
+			expect(target.birthPlace?.addressRegion).toBe("England");
+		});
+	});
+
+	describe("protected keys", () => {
+		it("sources is never copied from source", () => {
+			const target: UserProfile = {};
+			mergeProfile(target, { sources: { github: "2024-01-01T00:00:00.000Z" } });
+			expect(target.sources).toBeUndefined();
+		});
+
+		it("observations is never copied from source", () => {
+			const target: UserProfile = {};
+			mergeProfile(target, { observations: [{ key: "foo", value: "bar" }] });
+			expect(target.observations).toBeUndefined();
+		});
+
+		it("updatedAt is never copied from source", () => {
+			const target: UserProfile = {};
+			mergeProfile(target, { updatedAt: "2024-01-01T00:00:00.000Z" });
+			expect(target.updatedAt).toBeUndefined();
+		});
+	});
+});

--- a/packages/coding-agent/test/internal-urls/user-profile.test.ts
+++ b/packages/coding-agent/test/internal-urls/user-profile.test.ts
@@ -211,3 +211,50 @@ describe("renderProfileMarkdown", () => {
 		expect(md).toContain("*Last updated:");
 	});
 });
+
+describe("renderProfileMarkdown — demographics", () => {
+	it("renders birthDate under Demographics", () => {
+		const profile: UserProfile = { givenName: "Robin", birthDate: "1971-02-12" };
+		const md = renderProfileMarkdown(profile);
+		expect(md).toContain("## Demographics");
+		expect(md).toContain("**Birth Date:** 1971-02-12");
+	});
+
+	it("renders birthPlace under Demographics", () => {
+		const profile: UserProfile = {
+			givenName: "Robin",
+			birthPlace: { addressLocality: "Regina", addressRegion: "Saskatchewan", addressCountry: "Canada" },
+		};
+		const md = renderProfileMarkdown(profile);
+		expect(md).toContain("## Demographics");
+		expect(md).toContain("**Birth Place:** Regina, Saskatchewan, Canada");
+	});
+
+	it("includes additionalName (middle name) in full name", () => {
+		const profile: UserProfile = {
+			givenName: "Robin",
+			additionalName: "Jean",
+			familyName: "Mordasiewicz",
+			email: "r@f5.com",
+		};
+		const md = renderProfileMarkdown(profile);
+		expect(md).toContain("Robin Jean Mordasiewicz");
+	});
+
+	it("renders worksFor without URL as plain text", () => {
+		const profile: UserProfile = { givenName: "Test", worksFor: { name: "F5" } };
+		const md = renderProfileMarkdown(profile);
+		expect(md).toContain("**Organization:** F5");
+		expect(md).not.toContain("[F5]");
+	});
+
+	it("renders manager name without parentheses when email absent", () => {
+		const profile: UserProfile = {
+			givenName: "Test",
+			manager: { givenName: "Paul", familyName: "Slosberg" },
+		};
+		const md = renderProfileMarkdown(profile);
+		expect(md).toContain("**Manager:** Paul Slosberg");
+		expect(md).not.toContain("Paul Slosberg (");
+	});
+});

--- a/packages/coding-agent/test/internal-urls/xcsh-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/xcsh-protocol.test.ts
@@ -226,4 +226,9 @@ describe("xcsh://user", () => {
 		const hasSeedHint = resource.content.includes("seed=true");
 		expect(hasProfile || hasSeedHint).toBe(true);
 	});
+
+	it("sourcePath is xcsh://user regardless of seed query param", async () => {
+		const resource = await createRouter().resolve("xcsh://user?seed=true");
+		expect(resource.sourcePath).toBe("xcsh://user");
+	}, 30_000);
 });


### PR DESCRIPTION
Closes #594

## What

28 new contract-level tests for the user profile system shipped in #589.

## Why

The previous suite had 41 tests across 3 files covering interface shape and I/O plumbing. No test would have caught a regression in the core behaviors: merge semantics, collector orchestration, or Demographics rendering.

## Changes

### Source
- `user-profile.ts`: export `mergeProfile` (was module-private)

### Tests (net +28 tests, 41 → 69)

| File | +Tests | Contracts |
|---|---|---|
| `user-profile-merge.test.ts` (new) | +17 | `mergeProfile`: scalar first-writer-wins, sameAs dedup/union, knowsLanguage first-writer-wins, object fields first-writer-wins, protected keys never copied |
| `seed-profile.test.ts` (new) | +5 | `seedProfile`: unavailable collector skipped, throwing collector isolated, per-collector timestamps, single disk write, existing fields not overwritten |
| `user-profile.test.ts` | +5 | `renderProfileMarkdown`: birthDate, birthPlace, additionalName, worksFor plain text, manager without email |
| `xcsh-protocol.test.ts` | +1 | `xcsh://user?seed=true` sourcePath is `xcsh://user` |

## Verification

```
bun test test/internal-urls/user-profile-merge.test.ts \
         test/internal-urls/user-profile.test.ts \
         test/internal-urls/seed-profile.test.ts \
         test/internal-urls/profile-collectors.test.ts \
         test/internal-urls/xcsh-protocol.test.ts
# 69 pass, 0 fail
```