### PR TITLE
feat(welcome): add ServiceStatus type and service mapper functions

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -330,3 +330,45 @@ export async function checkSalesforceStatus(_cwd: string): Promise<WelcomeSalesf
 		return { state: "auth_error" };
 	}
 }
+
+export type ServiceState = "connected" | "unauthenticated" | "unavailable";
+
+export interface ServiceStatus {
+	name: string;
+	state: ServiceState;
+	hint?: string;
+}
+
+export function mapContextStatus(status: WelcomeContextStatus): ServiceStatus {
+	switch (status.state) {
+		case "connected":
+			return { name: "F5 XC Context", state: "connected" };
+		case "no_context":
+			return { name: "F5 XC Context", state: "unauthenticated", hint: "run: /context create" };
+		case "auth_error":
+		case "offline":
+			return { name: "F5 XC Context", state: "unauthenticated", hint: "run: /context" };
+	}
+}
+
+export function mapGitLabStatus(status: WelcomeGitLabStatus | undefined): ServiceStatus {
+	if (!status) return { name: "GitLab", state: "unavailable", hint: "not installed" };
+	switch (status.state) {
+		case "connected":
+			return { name: "GitLab", state: "connected" };
+		case "not_installed":
+			return { name: "GitLab", state: "unavailable", hint: "not installed" };
+		default:
+			return { name: "GitLab", state: "unauthenticated", hint: "run: glab auth login" };
+	}
+}
+
+export function mapSalesforceStatus(status: WelcomeSalesforceStatus | undefined): ServiceStatus {
+	if (!status) return { name: "Salesforce", state: "unavailable", hint: "not installed" };
+	switch (status.state) {
+		case "connected":
+			return { name: "Salesforce", state: "connected" };
+		default:
+			return { name: "Salesforce", state: "unauthenticated", hint: "run: sf org login web" };
+	}
+}

--- a/packages/coding-agent/test/welcome-service-mappers.test.ts
+++ b/packages/coding-agent/test/welcome-service-mappers.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+import {
+	mapContextStatus,
+	mapGitLabStatus,
+	mapSalesforceStatus,
+} from "@f5xc-salesdemos/xcsh/modes/components/welcome-checks";
+
+describe("mapContextStatus", () => {
+	it("no_context → unauthenticated with /context create hint", () => {
+		const r = mapContextStatus({ state: "no_context" });
+		expect(r.name).toBe("F5 XC Context");
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("/context create");
+	});
+	it("connected → connected", () => {
+		const r = mapContextStatus({ state: "connected", name: "prod", latencyMs: 10 });
+		expect(r.state).toBe("connected");
+		expect(r.name).toBe("F5 XC Context");
+		expect(r.hint).toBeUndefined();
+	});
+	it("auth_error → unauthenticated with /context hint", () => {
+		const r = mapContextStatus({ state: "auth_error", name: "prod" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("/context");
+	});
+	it("offline → unauthenticated with /context hint", () => {
+		const r = mapContextStatus({ state: "offline", name: "prod" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("/context");
+	});
+});
+
+describe("mapGitLabStatus", () => {
+	it("undefined (not installed) → unavailable with 'not installed' hint", () => {
+		const r = mapGitLabStatus(undefined);
+		expect(r.name).toBe("GitLab");
+		expect(r.state).toBe("unavailable");
+		expect(r.hint).toBe("not installed");
+	});
+	it("connected → connected", () => {
+		const r = mapGitLabStatus({ state: "connected", project: "group/repo" });
+		expect(r.state).toBe("connected");
+		expect(r.hint).toBeUndefined();
+	});
+	it("auth_error → unauthenticated with glab hint", () => {
+		const r = mapGitLabStatus({ state: "auth_error" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("glab auth login");
+	});
+	it("not_configured → unauthenticated with glab hint", () => {
+		const r = mapGitLabStatus({ state: "not_configured" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("glab auth login");
+	});
+	it("project_inaccessible → unauthenticated with glab hint", () => {
+		const r = mapGitLabStatus({ state: "project_inaccessible", project: "g/r" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("glab auth login");
+	});
+});
+
+describe("mapSalesforceStatus", () => {
+	it("undefined (not installed) → unavailable with 'not installed' hint", () => {
+		const r = mapSalesforceStatus(undefined);
+		expect(r.name).toBe("Salesforce");
+		expect(r.state).toBe("unavailable");
+		expect(r.hint).toBe("not installed");
+	});
+	it("connected → connected", () => {
+		const r = mapSalesforceStatus({ state: "connected", orgAlias: "SFDC" });
+		expect(r.state).toBe("connected");
+		expect(r.hint).toBeUndefined();
+	});
+	it("auth_error → unauthenticated with sf hint", () => {
+		const r = mapSalesforceStatus({ state: "auth_error" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("sf org login web");
+	});
+	it("session_expired → unauthenticated with sf hint", () => {
+		const r = mapSalesforceStatus({ state: "session_expired", orgAlias: "SFDC" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("sf org login web");
+	});
+	it("not_configured → unauthenticated with sf hint", () => {
+		const r = mapSalesforceStatus({ state: "not_configured" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("sf org login web");
+	});
+});


### PR DESCRIPTION
## What

Add `ServiceStatus` type and three mapper functions (`mapToolStatus`, `mapModelStatus`, `mapMcpStatus`) to the welcome-checks module for the compact status redesign.

## Why

The welcome screen compact status redesign needs a unified type and mappers to translate heterogeneous check results into a consistent `ServiceStatus` representation. This lays the groundwork for the compact status renderer.

Closes #601

## Testing

- Full unit test coverage for all mapper functions and edge cases in `welcome-service-mappers.test.ts`
- Pre-commit hooks (Biome lint, spelling, secrets, large file check) all pass

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #601`