### PR TITLE
fix(welcome): guard service list on model success and remove dead changelog code

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -56,7 +56,6 @@ import type { AgentSession } from "./session/agent-session";
 import { resolveResumableSession, type SessionInfo, SessionManager } from "./session/session-manager";
 import { resolvePromptInput } from "./system-prompt";
 import type { LspStartupServerInfo } from "./tools";
-import { getChangelogPath, getNewEntries, parseChangelog } from "./utils/changelog";
 import type { EventBus } from "./utils/event-bus";
 
 async function checkForNewVersion(currentVersion: string): Promise<string | undefined> {
@@ -252,31 +251,6 @@ async function promptForkSession(session: SessionInfo): Promise<boolean> {
 	} finally {
 		rl.close();
 	}
-}
-
-async function getChangelogForDisplay(parsed: Args): Promise<{ hasNew: boolean; version: string } | undefined> {
-	if (parsed.continue || parsed.resume) {
-		return undefined;
-	}
-
-	const lastVersion = settings.get("lastChangelogVersion");
-	const changelogPath = getChangelogPath();
-	const entries = await parseChangelog(changelogPath);
-
-	if (!lastVersion) {
-		if (entries.length > 0) {
-			settings.set("lastChangelogVersion", VERSION);
-			return { hasNew: true, version: VERSION };
-		}
-	} else {
-		const newEntries = getNewEntries(entries, lastVersion);
-		if (newEntries.length > 0) {
-			settings.set("lastChangelogVersion", VERSION);
-			return { hasNew: true, version: VERSION };
-		}
-	}
-
-	return undefined;
 }
 
 async function createSessionManager(parsed: Args, cwd: string): Promise<SessionManager | undefined> {
@@ -888,8 +862,6 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 		await runAcpMode(session, createAcpSession);
 	} else if (isInteractive) {
 		const versionCheckPromise = checkForNewVersion(VERSION).catch(() => undefined);
-		logger.time("main:getChangelogForDisplay");
-		await getChangelogForDisplay(parsedArgs);
 
 		const scopedModelsForDisplay = sessionOptions.scopedModels ?? scopedModels;
 		if (scopedModelsForDisplay.length > 0) {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -334,11 +334,14 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		if (!startupQuiet) {
 			// Welcome box owns all startup notifications (model, services, update)
-			const services = [
-				mapContextStatus(welcomeResult.context ?? { state: "no_context" }),
-				mapGitLabStatus(gitlabStatus),
-				mapSalesforceStatus(salesforceStatus),
-			];
+			const services =
+				welcomeResult.model.state === "connected"
+					? [
+							mapContextStatus(welcomeResult.context ?? { state: "no_context" }),
+							mapGitLabStatus(gitlabStatus),
+							mapSalesforceStatus(salesforceStatus),
+						]
+					: [];
 			this.#welcomeComponent = new WelcomeComponent(
 				this.#version,
 				welcomeResult.model,


### PR DESCRIPTION
## What

Two P1 fixes in the welcome screen flow:
1. Guard service list construction behind `model.state === "connected"` check
2. Remove dead `getChangelogForDisplay()` function and its imports from `main.ts`

## Why

- Services array was built regardless of model connection state, producing misleading `/context create` hints when the model auth failed
- `getChangelogForDisplay()` was dead code since the changelog is no longer displayed on the welcome screen, but its side effect of advancing `lastChangelogVersion` could still fire

Closes #608

## Testing

- [x] `bun run check` passes (Biome lint + type-check via pre-commit)
- [x] Pre-commit hooks pass
- [x] Issue linked via `Closes #608`