### PR TITLE
feat(welcome): add GitHub CLI status to welcome screen

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -331,6 +331,23 @@ export async function checkSalesforceStatus(_cwd: string): Promise<WelcomeSalesf
 	}
 }
 
+export type GitHubCheckState = "connected" | "auth_error";
+
+export interface WelcomeGitHubStatus {
+	state: GitHubCheckState;
+}
+
+export async function checkGitHubStatus(): Promise<WelcomeGitHubStatus | undefined> {
+	try {
+		if (!$which("gh")) return undefined;
+		const result = await $`gh auth status`.quiet().nothrow();
+		return { state: result.exitCode === 0 ? "connected" : "auth_error" };
+	} catch (err) {
+		logger.warn("GitHub startup check failed", { error: String(err) });
+		return { state: "auth_error" };
+	}
+}
+
 export type ServiceState = "connected" | "unauthenticated" | "unavailable";
 
 export interface ServiceStatus {
@@ -370,5 +387,15 @@ export function mapSalesforceStatus(status: WelcomeSalesforceStatus | undefined)
 			return { name: "Salesforce", state: "connected" };
 		default:
 			return { name: "Salesforce", state: "unauthenticated", hint: "run: sf org login web" };
+	}
+}
+
+export function mapGitHubStatus(status: WelcomeGitHubStatus | undefined): ServiceStatus {
+	if (!status) return { name: "GitHub", state: "unavailable", hint: "not installed" };
+	switch (status.state) {
+		case "connected":
+			return { name: "GitHub", state: "connected" };
+		case "auth_error":
+			return { name: "GitHub", state: "unauthenticated", hint: "run: gh auth login" };
 	}
 }

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -51,9 +51,11 @@ import { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
 import { type UpdateStatus, WelcomeComponent } from "./components/welcome";
 import {
+	checkGitHubStatus,
 	checkGitLabStatus,
 	checkSalesforceStatus,
 	mapContextStatus,
+	mapGitHubStatus,
 	mapGitLabStatus,
 	mapSalesforceStatus,
 	runWelcomeChecks,
@@ -314,13 +316,14 @@ export class InteractiveMode implements InteractiveModeContext {
 			getProjectDir(),
 		);
 
-		// Run blocking welcome screen status checks (model + context + gitlab + salesforce) in parallel
-		const [welcomeResult, gitlabStatus, salesforceStatus] = await Promise.all([
+		// Run blocking welcome screen status checks (model + context + gitlab + github + salesforce) in parallel
+		const [welcomeResult, gitlabStatus, salesforceStatus, githubStatus] = await Promise.all([
 			logger.time("InteractiveMode.init:welcomeChecks", () =>
 				runWelcomeChecks(this.session.model, this.session.modelRegistry.authStorage),
 			),
 			checkGitLabStatus(getProjectDir()).catch(() => undefined),
 			checkSalesforceStatus(getProjectDir()).catch(() => undefined),
+			checkGitHubStatus().catch(() => undefined),
 		]);
 
 		const startupQuiet = settings.get("startup.quiet");
@@ -339,6 +342,7 @@ export class InteractiveMode implements InteractiveModeContext {
 					? [
 							mapContextStatus(welcomeResult.context ?? { state: "no_context" }),
 							mapGitLabStatus(gitlabStatus),
+							mapGitHubStatus(githubStatus),
 							mapSalesforceStatus(salesforceStatus),
 						]
 					: [];

--- a/packages/coding-agent/test/welcome-service-mappers.test.ts
+++ b/packages/coding-agent/test/welcome-service-mappers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	mapContextStatus,
+	mapGitHubStatus,
 	mapGitLabStatus,
 	mapSalesforceStatus,
 } from "@f5xc-salesdemos/xcsh/modes/components/welcome-checks";
@@ -85,5 +86,24 @@ describe("mapSalesforceStatus", () => {
 		const r = mapSalesforceStatus({ state: "not_configured" });
 		expect(r.state).toBe("unauthenticated");
 		expect(r.hint).toContain("sf org login web");
+	});
+});
+
+describe("mapGitHubStatus", () => {
+	it("undefined (not installed) → unavailable with 'not installed' hint", () => {
+		const r = mapGitHubStatus(undefined);
+		expect(r.name).toBe("GitHub");
+		expect(r.state).toBe("unavailable");
+		expect(r.hint).toBe("not installed");
+	});
+	it("connected → connected", () => {
+		const r = mapGitHubStatus({ state: "connected" });
+		expect(r.state).toBe("connected");
+		expect(r.hint).toBeUndefined();
+	});
+	it("auth_error → unauthenticated with gh auth login hint", () => {
+		const r = mapGitHubStatus({ state: "auth_error" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("gh auth login");
 	});
 });


### PR DESCRIPTION
## What

Add `gh` CLI authentication check to the welcome screen service status list, alongside the existing GitLab and Salesforce checks.

## Why

The welcome screen displays integration statuses to help users see at a glance which services are configured. GitHub CLI was missing from this list despite being a prerequisite tool. Adding it provides a consistent overview and actionable remediation guidance when `gh` is not authenticated or not installed.

Closes #611

## Testing

- [x] Unit tests added for GitHub mapper (authenticated, not authenticated, not installed cases)
- [x] `bun run check` passes
- [x] Pre-commit hooks pass
- [x] Issue linked via `Closes #611`