### PR TITLE
fix(cli): --no-tools and --no-mcp now disable MCP tools

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -33,6 +33,7 @@ export interface Args {
 	models?: string[];
 	tools?: string[];
 	noTools?: boolean;
+	noMcp?: boolean;
 	noLsp?: boolean;
 	noPty?: boolean;
 	hooks?: string[];
@@ -114,6 +115,8 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 			result.noLsp = true;
 		} else if (arg === "--no-pty") {
 			result.noPty = true;
+		} else if (arg === "--no-mcp") {
+			result.noMcp = true;
 		} else if (arg === "--tools" && i + 1 < args.length) {
 			const toolNames = args[++i]
 				.split(",")

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -76,6 +76,9 @@ export default class Index extends Command {
 		"no-tools": Flags.boolean({
 			description: "Disable all built-in tools",
 		}),
+		"no-mcp": Flags.boolean({
+			description: "Disable MCP server discovery and tools",
+		}),
 		"no-lsp": Flags.boolean({
 			description: "Disable LSP tools, formatting, and diagnostics",
 		}),

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -554,6 +554,10 @@ async function buildSessionOptions(
 		options.toolNames = parsed.tools;
 	}
 
+	if (parsed.noTools || parsed.noMcp) {
+		options.enableMCP = false;
+	}
+
 	if (parsed.noLsp) {
 		options.enableLsp = false;
 	}

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -219,6 +219,24 @@ describe("parseArgs", () => {
 		});
 	});
 
+	describe("--no-mcp flag", () => {
+		test("parses --no-mcp flag", () => {
+			const result = parseArgs(["--no-mcp"]);
+			expect(result.noMcp).toBe(true);
+		});
+
+		test("--no-mcp does not set noTools", () => {
+			const result = parseArgs(["--no-mcp"]);
+			expect(result.noTools).toBeUndefined();
+		});
+
+		test("--no-mcp combines with --no-tools", () => {
+			const result = parseArgs(["--no-tools", "--no-mcp"]);
+			expect(result.noTools).toBe(true);
+			expect(result.noMcp).toBe(true);
+		});
+	});
+
 	describe("--no-lsp flag", () => {
 		test("parses --no-lsp flag", () => {
 			const result = parseArgs(["--no-lsp"]);


### PR DESCRIPTION
## Summary

- `--no-tools` now also sets `enableMCP = false`, which skips MCP server discovery entirely
- Added `--no-mcp` flag for explicitly disabling MCP without disabling built-in tools
- The `enableMCP` SDK option already existed and worked correctly — it just was never exposed from the CLI

Previously, `--no-tools` only disabled built-in tools, but MCP tools (e.g. `mcp_chrome_devtools_*`) were still sent in the API request, causing 400 errors from the proxy.

Closes #607

## Test plan

- [x] Unit tests added for `--no-mcp` flag parsing
- [ ] CI checks pass
- [ ] Manual verification: `xcsh -p --no-tools` no longer includes MCP tools in API request