### PR TITLE
feat(welcome): add Azure CLI status to welcome screen

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -399,3 +399,30 @@ export function mapGitHubStatus(status: WelcomeGitHubStatus | undefined): Servic
 			return { name: "GitHub", state: "unauthenticated", hint: "run: gh auth login" };
 	}
 }
+
+export type AzureCheckState = "connected" | "auth_error";
+
+export interface WelcomeAzureStatus {
+	state: AzureCheckState;
+}
+
+export async function checkAzureStatus(): Promise<WelcomeAzureStatus | undefined> {
+	try {
+		if (!$which("az")) return undefined;
+		const result = await $`az account show --output json`.quiet().nothrow();
+		return { state: result.exitCode === 0 ? "connected" : "auth_error" };
+	} catch (err) {
+		logger.warn("Azure startup check failed", { error: String(err) });
+		return { state: "auth_error" };
+	}
+}
+
+export function mapAzureStatus(status: WelcomeAzureStatus | undefined): ServiceStatus {
+	if (!status) return { name: "Azure", state: "unavailable", hint: "not installed" };
+	switch (status.state) {
+		case "connected":
+			return { name: "Azure", state: "connected" };
+		case "auth_error":
+			return { name: "Azure", state: "unauthenticated", hint: "run: az login --use-device-code" };
+	}
+}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -51,9 +51,11 @@ import { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
 import { type UpdateStatus, WelcomeComponent } from "./components/welcome";
 import {
+	checkAzureStatus,
 	checkGitHubStatus,
 	checkGitLabStatus,
 	checkSalesforceStatus,
+	mapAzureStatus,
 	mapContextStatus,
 	mapGitHubStatus,
 	mapGitLabStatus,
@@ -316,14 +318,15 @@ export class InteractiveMode implements InteractiveModeContext {
 			getProjectDir(),
 		);
 
-		// Run blocking welcome screen status checks (model + context + gitlab + github + salesforce) in parallel
-		const [welcomeResult, gitlabStatus, salesforceStatus, githubStatus] = await Promise.all([
+		// Run blocking welcome screen status checks (model + context + gitlab + github + salesforce + azure) in parallel
+		const [welcomeResult, gitlabStatus, salesforceStatus, githubStatus, azureStatus] = await Promise.all([
 			logger.time("InteractiveMode.init:welcomeChecks", () =>
 				runWelcomeChecks(this.session.model, this.session.modelRegistry.authStorage),
 			),
 			checkGitLabStatus(getProjectDir()).catch(() => undefined),
 			checkSalesforceStatus(getProjectDir()).catch(() => undefined),
 			checkGitHubStatus().catch(() => undefined),
+			checkAzureStatus().catch(() => undefined),
 		]);
 
 		const startupQuiet = settings.get("startup.quiet");
@@ -344,6 +347,7 @@ export class InteractiveMode implements InteractiveModeContext {
 							mapGitLabStatus(gitlabStatus),
 							mapGitHubStatus(githubStatus),
 							mapSalesforceStatus(salesforceStatus),
+							mapAzureStatus(azureStatus),
 						]
 					: [];
 			this.#welcomeComponent = new WelcomeComponent(

--- a/packages/coding-agent/test/welcome-service-mappers.test.ts
+++ b/packages/coding-agent/test/welcome-service-mappers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+	mapAzureStatus,
 	mapContextStatus,
 	mapGitHubStatus,
 	mapGitLabStatus,
@@ -105,5 +106,24 @@ describe("mapGitHubStatus", () => {
 		const r = mapGitHubStatus({ state: "auth_error" });
 		expect(r.state).toBe("unauthenticated");
 		expect(r.hint).toContain("gh auth login");
+	});
+});
+
+describe("mapAzureStatus", () => {
+	it("undefined (not installed) → unavailable with 'not installed' hint", () => {
+		const r = mapAzureStatus(undefined);
+		expect(r.name).toBe("Azure");
+		expect(r.state).toBe("unavailable");
+		expect(r.hint).toBe("not installed");
+	});
+	it("connected → connected", () => {
+		const r = mapAzureStatus({ state: "connected" });
+		expect(r.state).toBe("connected");
+		expect(r.hint).toBeUndefined();
+	});
+	it("auth_error → unauthenticated with az login hint", () => {
+		const r = mapAzureStatus({ state: "auth_error" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("az login --use-device-code");
 	});
 });


### PR DESCRIPTION
## What

Add Azure CLI authentication status to the welcome screen service list.

## Why

Users need visibility into their Azure CLI authentication state alongside
existing service checks (GitHub, GitLab, Salesforce). This enables quick
detection of missing or expired Azure sessions.

Closes #616

## Testing

- Unit tests for Azure service mapper added in welcome-service-mappers.test.ts
- Follows established ServiceStatus/mapper pattern from GitHub CLI check (#612)

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #N`