### PR TITLE
feat(skills): add enableClaudePlugins to SkillsSettings interface

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1956,6 +1956,7 @@ export interface SkillsSettings {
 	enableCodexUser?: boolean;
 	enableClaudeUser?: boolean;
 	enableClaudeProject?: boolean;
+	enableClaudePlugins?: boolean;
 	enablePiUser?: boolean;
 	enablePiProject?: boolean;
 	customDirectories?: string[];

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -378,6 +378,21 @@ description: Skill loaded from a tilde-expanded custom directory.
 		});
 	});
 
+	describe("SkillsSettings type", () => {
+		it("should accept enableClaudePlugins option", async () => {
+			const { skills } = await loadSkills({
+				enableCodexUser: false,
+				enableClaudeUser: false,
+				enableClaudeProject: false,
+				enableClaudePlugins: false,
+				enablePiUser: false,
+				enablePiProject: false,
+				customDirectories: [fixturesDir],
+			});
+			expect(skills.length).toBeGreaterThan(0);
+		});
+	});
+
 	describe("collision handling", () => {
 		it("should detect name collisions and keep first skill", async () => {
 			// Load from first directory


### PR DESCRIPTION
## What

Add an `enableClaudePlugins?: boolean` property to the `SkillsSettings` interface.

## Why

Prepares the type system for a dedicated claude-plugins provider toggle. This is a prerequisite for wiring up a new skill discovery provider that loads plugins from the Claude plugins directory.

Closes #618

## Testing

- Added test verifying `loadSkills` accepts the new option
- Pre-commit hooks pass

---

- [x] `bun run check` passes
- [x] Issue linked via `Closes #618`