### PR TITLE
feat(welcome): add AWS and Google Cloud CLI status to welcome screen

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -426,3 +426,58 @@ export function mapAzureStatus(status: WelcomeAzureStatus | undefined): ServiceS
 			return { name: "Azure", state: "unauthenticated", hint: "run: az login --use-device-code" };
 	}
 }
+
+export type AwsCheckState = "connected" | "auth_error";
+
+export interface WelcomeAwsStatus {
+	state: AwsCheckState;
+}
+
+export async function checkAwsStatus(): Promise<WelcomeAwsStatus | undefined> {
+	try {
+		if (!$which("aws")) return undefined;
+		const result = await $`aws sts get-caller-identity --output json`.quiet().nothrow();
+		return { state: result.exitCode === 0 ? "connected" : "auth_error" };
+	} catch (err) {
+		logger.warn("AWS startup check failed", { error: String(err) });
+		return { state: "auth_error" };
+	}
+}
+
+export function mapAwsStatus(status: WelcomeAwsStatus | undefined): ServiceStatus {
+	if (!status) return { name: "AWS", state: "unavailable", hint: "not installed" };
+	switch (status.state) {
+		case "connected":
+			return { name: "AWS", state: "connected" };
+		case "auth_error":
+			return { name: "AWS", state: "unauthenticated", hint: "run: aws configure" };
+	}
+}
+
+export type GcloudCheckState = "connected" | "auth_error";
+
+export interface WelcomeGcloudStatus {
+	state: GcloudCheckState;
+}
+
+export async function checkGcloudStatus(): Promise<WelcomeGcloudStatus | undefined> {
+	try {
+		if (!$which("gcloud")) return undefined;
+		const result = await $`gcloud auth list --format=value(account)`.quiet().nothrow();
+		const hasAccount = result.text().trim().length > 0;
+		return { state: hasAccount ? "connected" : "auth_error" };
+	} catch (err) {
+		logger.warn("Google Cloud startup check failed", { error: String(err) });
+		return { state: "auth_error" };
+	}
+}
+
+export function mapGcloudStatus(status: WelcomeGcloudStatus | undefined): ServiceStatus {
+	if (!status) return { name: "Google Cloud", state: "unavailable", hint: "not installed" };
+	switch (status.state) {
+		case "connected":
+			return { name: "Google Cloud", state: "connected" };
+		case "auth_error":
+			return { name: "Google Cloud", state: "unauthenticated", hint: "run: gcloud auth login" };
+	}
+}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -51,12 +51,16 @@ import { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
 import { type UpdateStatus, WelcomeComponent } from "./components/welcome";
 import {
+	checkAwsStatus,
 	checkAzureStatus,
+	checkGcloudStatus,
 	checkGitHubStatus,
 	checkGitLabStatus,
 	checkSalesforceStatus,
+	mapAwsStatus,
 	mapAzureStatus,
 	mapContextStatus,
+	mapGcloudStatus,
 	mapGitHubStatus,
 	mapGitLabStatus,
 	mapSalesforceStatus,
@@ -318,16 +322,19 @@ export class InteractiveMode implements InteractiveModeContext {
 			getProjectDir(),
 		);
 
-		// Run blocking welcome screen status checks (model + context + gitlab + github + salesforce + azure) in parallel
-		const [welcomeResult, gitlabStatus, salesforceStatus, githubStatus, azureStatus] = await Promise.all([
-			logger.time("InteractiveMode.init:welcomeChecks", () =>
-				runWelcomeChecks(this.session.model, this.session.modelRegistry.authStorage),
-			),
-			checkGitLabStatus(getProjectDir()).catch(() => undefined),
-			checkSalesforceStatus(getProjectDir()).catch(() => undefined),
-			checkGitHubStatus().catch(() => undefined),
-			checkAzureStatus().catch(() => undefined),
-		]);
+		// Run blocking welcome screen status checks in parallel
+		const [welcomeResult, gitlabStatus, salesforceStatus, githubStatus, azureStatus, awsStatus, gcloudStatus] =
+			await Promise.all([
+				logger.time("InteractiveMode.init:welcomeChecks", () =>
+					runWelcomeChecks(this.session.model, this.session.modelRegistry.authStorage),
+				),
+				checkGitLabStatus(getProjectDir()).catch(() => undefined),
+				checkSalesforceStatus(getProjectDir()).catch(() => undefined),
+				checkGitHubStatus().catch(() => undefined),
+				checkAzureStatus().catch(() => undefined),
+				checkAwsStatus().catch(() => undefined),
+				checkGcloudStatus().catch(() => undefined),
+			]);
 
 		const startupQuiet = settings.get("startup.quiet");
 		this.#welcomeComponent = undefined;
@@ -348,6 +355,8 @@ export class InteractiveMode implements InteractiveModeContext {
 							mapGitHubStatus(githubStatus),
 							mapSalesforceStatus(salesforceStatus),
 							mapAzureStatus(azureStatus),
+							mapAwsStatus(awsStatus),
+							mapGcloudStatus(gcloudStatus),
 						]
 					: [];
 			this.#welcomeComponent = new WelcomeComponent(

--- a/packages/coding-agent/test/welcome-service-mappers.test.ts
+++ b/packages/coding-agent/test/welcome-service-mappers.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import {
+	mapAwsStatus,
 	mapAzureStatus,
 	mapContextStatus,
+	mapGcloudStatus,
 	mapGitHubStatus,
 	mapGitLabStatus,
 	mapSalesforceStatus,
@@ -125,5 +127,43 @@ describe("mapAzureStatus", () => {
 		const r = mapAzureStatus({ state: "auth_error" });
 		expect(r.state).toBe("unauthenticated");
 		expect(r.hint).toContain("az login --use-device-code");
+	});
+});
+
+describe("mapAwsStatus", () => {
+	it("undefined (not installed) → unavailable with 'not installed' hint", () => {
+		const r = mapAwsStatus(undefined);
+		expect(r.name).toBe("AWS");
+		expect(r.state).toBe("unavailable");
+		expect(r.hint).toBe("not installed");
+	});
+	it("connected → connected", () => {
+		const r = mapAwsStatus({ state: "connected" });
+		expect(r.state).toBe("connected");
+		expect(r.hint).toBeUndefined();
+	});
+	it("auth_error → unauthenticated with aws configure hint", () => {
+		const r = mapAwsStatus({ state: "auth_error" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("aws configure");
+	});
+});
+
+describe("mapGcloudStatus", () => {
+	it("undefined (not installed) → unavailable with 'not installed' hint", () => {
+		const r = mapGcloudStatus(undefined);
+		expect(r.name).toBe("Google Cloud");
+		expect(r.state).toBe("unavailable");
+		expect(r.hint).toBe("not installed");
+	});
+	it("connected → connected", () => {
+		const r = mapGcloudStatus({ state: "connected" });
+		expect(r.state).toBe("connected");
+		expect(r.hint).toBeUndefined();
+	});
+	it("auth_error → unauthenticated with gcloud auth login hint", () => {
+		const r = mapGcloudStatus({ state: "auth_error" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("gcloud auth login");
 	});
 });


### PR DESCRIPTION
## What

Add AWS CLI and Google Cloud CLI authentication status checks to the welcome screen service list.

## Why

Expands the welcome screen to show authentication status for additional cloud providers (AWS and Google Cloud), helping users see at a glance which cloud CLI tools are configured. This complements the existing checks for GitLab, Salesforce, GitHub, and Azure.

Closes #622

## Implementation

**AWS CLI:**
- Command: `aws sts get-caller-identity --output json`
- Detection: exit code 0 = authenticated, non-zero = not authenticated
- Auth hint: `aws configure`

**Google Cloud CLI:**
- Command: `gcloud auth list --format=value(account)`
- Detection: gcloud exit codes are unreliable (always 0), so uses output detection — empty string means no active account
- Auth hint: `gcloud auth login`

Both services follow the established ServiceStatus/mapper pattern.

## Testing

- Unit tests added for both mappers in `welcome-service-mappers.test.ts`
- Tests cover success, failure, and edge cases

---

- [x] `bun run check` passes
- [x] Pre-commit hooks pass
- [x] Issue linked via `Closes #622`