### PR TITLE
feat(skills): add skills.enableClaudePlugins setting to schema

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1628,6 +1628,16 @@ export const SETTINGS_SCHEMA = {
 
 	"skills.enableClaudeProject": { type: "boolean", default: true },
 
+	"skills.enableClaudePlugins": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tasks",
+			label: "Claude Marketplace Skills",
+			description: "Load skills from Claude Code marketplace plugins (~/.claude/plugins/cache/)",
+		},
+	},
+
 	"skills.enablePiUser": { type: "boolean", default: true },
 
 	"skills.enablePiProject": { type: "boolean", default: true },


### PR DESCRIPTION
## What

Add `skills.enableClaudePlugins` boolean setting to the settings schema. The setting defaults to `false` and appears on the tasks tab as "Claude Marketplace Skills".

## Why

Provides a dedicated toggle for loading skills from Claude Code marketplace plugins (`~/.claude/plugins/cache/`), giving users explicit control over this capability.

Closes #624

## Testing

- [x] `bun run check` passes (Biome lint + format via pre-commit)
- [x] Issue linked via `Closes #624`
- [ ] CHANGELOG updated (if user-facing)