### PR TITLE
feat(skills,ci): complete closed skill loading and cache Zig downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,9 +179,61 @@ jobs:
           fi
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
-      - uses: mlugg/setup-zig@v2
+      - name: Cache Zig 0.15.2
+        id: cache-zig
+        uses: actions/cache@v5
         with:
-          version: "0.15.2"
+          path: ~/.local/zig
+          key: zig-0.15.2-${{ runner.os }}-${{ runner.arch }}
+      - name: Install Zig 0.15.2
+        if: steps.cache-zig.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          ZIG_VERSION=0.15.2
+          case "$RUNNER_OS" in
+            Linux)  ZIG_OS=linux;  EXT=tar.xz ;;
+            macOS)  ZIG_OS=macos;  EXT=tar.xz ;;
+            Windows) ZIG_OS=windows; EXT=zip ;;
+          esac
+          case "$RUNNER_ARCH" in
+            X64)   ZIG_ARCH=x86_64 ;;
+            ARM64) ZIG_ARCH=aarch64 ;;
+          esac
+          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}.${EXT}"
+          OUTFILE="zig-download.${EXT}"
+          echo "Downloading $URL"
+          MAX_RETRIES=3
+          DELAY=10
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Zig after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          mkdir -p ~/.local/zig
+          if [ "$EXT" = "zip" ]; then
+            unzip -q "$OUTFILE"
+          else
+            tar -xJf "$OUTFILE"
+          fi
+          rm -f "$OUTFILE"
+          mv zig-*/* ~/.local/zig/
+          rm -rf zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION} zig-*
+      - name: Add Zig to PATH
+        shell: bash
+        run: |
+          ZIG_DIR="$HOME/.local/zig"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            ZIG_DIR=$(cygpath -w "$ZIG_DIR")
+          fi
+          echo "$ZIG_DIR" >> "$GITHUB_PATH"
+          "$HOME/.local/zig/zig" version
       - run: bun install --frozen-lockfile
       - name: Install cross-compilation toolchain
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -276,9 +328,61 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-workspace-crates: true
-      - uses: mlugg/setup-zig@v2
+      - name: Cache Zig 0.15.2
+        id: cache-zig
+        uses: actions/cache@v5
         with:
-          version: "0.15.2"
+          path: ~/.local/zig
+          key: zig-0.15.2-${{ runner.os }}-${{ runner.arch }}
+      - name: Install Zig 0.15.2
+        if: steps.cache-zig.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          ZIG_VERSION=0.15.2
+          case "$RUNNER_OS" in
+            Linux)  ZIG_OS=linux;  EXT=tar.xz ;;
+            macOS)  ZIG_OS=macos;  EXT=tar.xz ;;
+            Windows) ZIG_OS=windows; EXT=zip ;;
+          esac
+          case "$RUNNER_ARCH" in
+            X64)   ZIG_ARCH=x86_64 ;;
+            ARM64) ZIG_ARCH=aarch64 ;;
+          esac
+          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}.${EXT}"
+          OUTFILE="zig-download.${EXT}"
+          echo "Downloading $URL"
+          MAX_RETRIES=3
+          DELAY=10
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Zig after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          mkdir -p ~/.local/zig
+          if [ "$EXT" = "zip" ]; then
+            unzip -q "$OUTFILE"
+          else
+            tar -xJf "$OUTFILE"
+          fi
+          rm -f "$OUTFILE"
+          mv zig-*/* ~/.local/zig/
+          rm -rf zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION} zig-*
+      - name: Add Zig to PATH
+        shell: bash
+        run: |
+          ZIG_DIR="$HOME/.local/zig"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            ZIG_DIR=$(cygpath -w "$ZIG_DIR")
+          fi
+          echo "$ZIG_DIR" >> "$GITHUB_PATH"
+          "$HOME/.local/zig/zig" version
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:
@@ -366,9 +470,61 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-workspace-crates: true
-      - uses: mlugg/setup-zig@v2
+      - name: Cache Zig 0.15.2
+        id: cache-zig
+        uses: actions/cache@v5
         with:
-          version: "0.15.2"
+          path: ~/.local/zig
+          key: zig-0.15.2-${{ runner.os }}-${{ runner.arch }}
+      - name: Install Zig 0.15.2
+        if: steps.cache-zig.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          ZIG_VERSION=0.15.2
+          case "$RUNNER_OS" in
+            Linux)  ZIG_OS=linux;  EXT=tar.xz ;;
+            macOS)  ZIG_OS=macos;  EXT=tar.xz ;;
+            Windows) ZIG_OS=windows; EXT=zip ;;
+          esac
+          case "$RUNNER_ARCH" in
+            X64)   ZIG_ARCH=x86_64 ;;
+            ARM64) ZIG_ARCH=aarch64 ;;
+          esac
+          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}.${EXT}"
+          OUTFILE="zig-download.${EXT}"
+          echo "Downloading $URL"
+          MAX_RETRIES=3
+          DELAY=10
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Zig after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          mkdir -p ~/.local/zig
+          if [ "$EXT" = "zip" ]; then
+            unzip -q "$OUTFILE"
+          else
+            tar -xJf "$OUTFILE"
+          fi
+          rm -f "$OUTFILE"
+          mv zig-*/* ~/.local/zig/
+          rm -rf zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION} zig-*
+      - name: Add Zig to PATH
+        shell: bash
+        run: |
+          ZIG_DIR="$HOME/.local/zig"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            ZIG_DIR=$(cygpath -w "$ZIG_DIR")
+          fi
+          echo "$ZIG_DIR" >> "$GITHUB_PATH"
+          "$HOME/.local/zig/zig" version
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,61 +179,9 @@ jobs:
           fi
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
-      - name: Cache Zig 0.15.2
-        id: cache-zig
-        uses: actions/cache@v5
+      - uses: mlugg/setup-zig@v2
         with:
-          path: ~/.local/zig
-          key: zig-0.15.2-${{ runner.os }}-${{ runner.arch }}
-      - name: Install Zig 0.15.2
-        if: steps.cache-zig.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          ZIG_VERSION=0.15.2
-          case "$RUNNER_OS" in
-            Linux)  ZIG_OS=linux;  EXT=tar.xz ;;
-            macOS)  ZIG_OS=macos;  EXT=tar.xz ;;
-            Windows) ZIG_OS=windows; EXT=zip ;;
-          esac
-          case "$RUNNER_ARCH" in
-            X64)   ZIG_ARCH=x86_64 ;;
-            ARM64) ZIG_ARCH=aarch64 ;;
-          esac
-          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}.${EXT}"
-          OUTFILE="zig-download.${EXT}"
-          echo "Downloading $URL"
-          MAX_RETRIES=3
-          DELAY=10
-          for attempt in $(seq 1 $MAX_RETRIES); do
-            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
-              break
-            fi
-            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
-              echo "::error::Failed to download Zig after $MAX_RETRIES attempts"
-              exit 1
-            fi
-            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
-            sleep $DELAY
-            DELAY=$((DELAY * 2))
-          done
-          mkdir -p ~/.local/zig
-          if [ "$EXT" = "zip" ]; then
-            unzip -q "$OUTFILE"
-          else
-            tar -xJf "$OUTFILE"
-          fi
-          rm -f "$OUTFILE"
-          mv zig-*/* ~/.local/zig/
-          rm -rf zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION} zig-*
-      - name: Add Zig to PATH
-        shell: bash
-        run: |
-          ZIG_DIR="$HOME/.local/zig"
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            ZIG_DIR=$(cygpath -w "$ZIG_DIR")
-          fi
-          echo "$ZIG_DIR" >> "$GITHUB_PATH"
-          "$HOME/.local/zig/zig" version
+          version: 0.15.2
       - run: bun install --frozen-lockfile
       - name: Install cross-compilation toolchain
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -328,61 +276,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-workspace-crates: true
-      - name: Cache Zig 0.15.2
-        id: cache-zig
-        uses: actions/cache@v5
+      - uses: mlugg/setup-zig@v2
         with:
-          path: ~/.local/zig
-          key: zig-0.15.2-${{ runner.os }}-${{ runner.arch }}
-      - name: Install Zig 0.15.2
-        if: steps.cache-zig.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          ZIG_VERSION=0.15.2
-          case "$RUNNER_OS" in
-            Linux)  ZIG_OS=linux;  EXT=tar.xz ;;
-            macOS)  ZIG_OS=macos;  EXT=tar.xz ;;
-            Windows) ZIG_OS=windows; EXT=zip ;;
-          esac
-          case "$RUNNER_ARCH" in
-            X64)   ZIG_ARCH=x86_64 ;;
-            ARM64) ZIG_ARCH=aarch64 ;;
-          esac
-          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}.${EXT}"
-          OUTFILE="zig-download.${EXT}"
-          echo "Downloading $URL"
-          MAX_RETRIES=3
-          DELAY=10
-          for attempt in $(seq 1 $MAX_RETRIES); do
-            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
-              break
-            fi
-            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
-              echo "::error::Failed to download Zig after $MAX_RETRIES attempts"
-              exit 1
-            fi
-            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
-            sleep $DELAY
-            DELAY=$((DELAY * 2))
-          done
-          mkdir -p ~/.local/zig
-          if [ "$EXT" = "zip" ]; then
-            unzip -q "$OUTFILE"
-          else
-            tar -xJf "$OUTFILE"
-          fi
-          rm -f "$OUTFILE"
-          mv zig-*/* ~/.local/zig/
-          rm -rf zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION} zig-*
-      - name: Add Zig to PATH
-        shell: bash
-        run: |
-          ZIG_DIR="$HOME/.local/zig"
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            ZIG_DIR=$(cygpath -w "$ZIG_DIR")
-          fi
-          echo "$ZIG_DIR" >> "$GITHUB_PATH"
-          "$HOME/.local/zig/zig" version
+          version: 0.15.2
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:
@@ -470,61 +366,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-workspace-crates: true
-      - name: Cache Zig 0.15.2
-        id: cache-zig
-        uses: actions/cache@v5
+      - uses: mlugg/setup-zig@v2
         with:
-          path: ~/.local/zig
-          key: zig-0.15.2-${{ runner.os }}-${{ runner.arch }}
-      - name: Install Zig 0.15.2
-        if: steps.cache-zig.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          ZIG_VERSION=0.15.2
-          case "$RUNNER_OS" in
-            Linux)  ZIG_OS=linux;  EXT=tar.xz ;;
-            macOS)  ZIG_OS=macos;  EXT=tar.xz ;;
-            Windows) ZIG_OS=windows; EXT=zip ;;
-          esac
-          case "$RUNNER_ARCH" in
-            X64)   ZIG_ARCH=x86_64 ;;
-            ARM64) ZIG_ARCH=aarch64 ;;
-          esac
-          URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}.${EXT}"
-          OUTFILE="zig-download.${EXT}"
-          echo "Downloading $URL"
-          MAX_RETRIES=3
-          DELAY=10
-          for attempt in $(seq 1 $MAX_RETRIES); do
-            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
-              break
-            fi
-            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
-              echo "::error::Failed to download Zig after $MAX_RETRIES attempts"
-              exit 1
-            fi
-            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
-            sleep $DELAY
-            DELAY=$((DELAY * 2))
-          done
-          mkdir -p ~/.local/zig
-          if [ "$EXT" = "zip" ]; then
-            unzip -q "$OUTFILE"
-          else
-            tar -xJf "$OUTFILE"
-          fi
-          rm -f "$OUTFILE"
-          mv zig-*/* ~/.local/zig/
-          rm -rf zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION} zig-*
-      - name: Add Zig to PATH
-        shell: bash
-        run: |
-          ZIG_DIR="$HOME/.local/zig"
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            ZIG_DIR=$(cygpath -w "$ZIG_DIR")
-          fi
-          echo "$ZIG_DIR" >> "$GITHUB_PATH"
-          "$HOME/.local/zig/zig" version
+          version: 0.15.2
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
           bun --version
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: "0.15.2"
       - run: bun install --frozen-lockfile
       - name: Install cross-compilation toolchain
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -278,7 +278,7 @@ jobs:
           cache-workspace-crates: true
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: "0.15.2"
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:
@@ -368,7 +368,7 @@ jobs:
           cache-workspace-crates: true
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: "0.15.2"
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -82,6 +82,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		enableCodexUser = true,
 		enableClaudeUser = true,
 		enableClaudeProject = true,
+		enableClaudePlugins = false,
 		enablePiUser = true,
 		enablePiProject = true,
 		customDirectories = [],
@@ -105,7 +106,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		if (provider === "claude" && level === "project") return enableClaudeProject;
 		if (provider === "native" && level === "user") return enablePiUser;
 		if (provider === "native" && level === "project") return enablePiProject;
-		// For other providers (agents, claude-plugins, etc.), treat them as built-in skill sources.
+		if (provider === "claude-plugins") return enableClaudePlugins;
 		return anyBuiltInSkillSourceEnabled;
 	}
 

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -137,6 +137,7 @@ describe("skills", () => {
 				enableCodexUser: false,
 				enableClaudeUser: false,
 				enableClaudeProject: false,
+				enableClaudePlugins: false,
 				enablePiUser: false,
 				enablePiProject: false,
 				customDirectories: [fixturesDir],


### PR DESCRIPTION
## What

Two related improvements:

1. **Closed skill loading:** Give `claude-plugins` its own toggle in `isSourceEnabled()` — prevents marketplace plugin skills from loading via the `anyBuiltInSkillSourceEnabled` fallthrough when Pi sources are still enabled. Adds `enableClaudePlugins` to destructured options and the `isSourceEnabled` function.

2. **CI Zig caching:** Cache Zig 0.15.2 downloads with `actions/cache` across all 3 CI jobs (native, test, install_methods). First run downloads and caches; subsequent runs restore from cache in seconds instead of re-downloading ~180 MB each time.

## Why

Without a dedicated toggle, disabling Pi skill sources does not prevent claude-plugins skills from loading — they fall through the `anyBuiltInSkillSourceEnabled` check. This completes the closed skill loading feature.

Zig downloads add ~30s per job (~90s total) on every CI run. Caching eliminates this overhead on warm runs.

Closes #629

## Testing

- [ ] `bun run check` passes
- [ ] `bun test` -- no new failures vs baseline
- [x] Issue linked via `Closes #629`