### PR TITLE
fix(codespellrc): skip *.generated.ts from spell checking (#642)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored
+skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored,*.generated.ts
 ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine


### PR DESCRIPTION
## Summary
- Add `*.generated.ts` to the codespell skip pattern in `.codespellrc`
- Auto-generated TypeScript files contain upstream F5 XC API documentation typos that cannot be fixed downstream
- Canonical upstream fix tracked at f5xc-salesdemos/docs-control#438

## Test plan
- [x] codespell passes with `*.generated.ts` in skip list
- [x] No other files affected by this change

Closes #642