### PR TITLE
feat: add self-awareness manifest and SE-focused autoresearch framework

### DIFF
--- a/SELF_AWARENESS.md
+++ b/SELF_AWARENESS.md
@@ -1,0 +1,158 @@
+# xcsh Self-Awareness Manifest
+
+This document is xcsh's self-knowledge base. It defines what xcsh is, what it should become, and how to measure progress. It serves as the primary input for autoresearch self-evaluation sessions.
+
+## Mission
+
+xcsh is the technical coworker for F5 Distributed Cloud account teams. Primary operator: Sales Engineers and Solutions Architects. Purpose: accelerate deal velocity by making the SE more effective at every stage of the sales cycle.
+
+The tool is NOT a general-purpose coding assistant that happens to know about F5. It IS a specialized SE workstation that uses coding capability as one of many instruments in service of selling F5 Distributed Cloud.
+
+## Origin and Context
+
+Forked from pi-mono (a general-purpose coding assistant). The codebase retains significant generic coding infrastructure which is valuable as foundational capability. The specialization work is layered on top:
+
+- System prompt rewritten for SE persona (F5 XC expertise, MEDDPICC, demos, customer meetings)
+- F5 XC API integration (services/f5xc-*)
+- Salesforce pipeline integration (sf_query, sf_setup, xcsh://salesforce)
+- Product knowledge routing (llms.txt hierarchy)
+- Specialized agents (deal-analyst, status-operator, cli-operator, github-ops)
+- Internal documentation protocols (xcsh://about, xcsh://user, xcsh://computer, xcsh://salesforce)
+
+## Current Capability Inventory
+
+### Mature (functional, tested, integrated)
+| Capability | Implementation | Location |
+|---|---|---|
+| F5 XC API calls | REST client with auth, URL construction | `services/f5xc-api-client.ts`, `xcsh_api` tool |
+| F5 XC context awareness | Tenant/namespace detection, connection status | `services/f5xc-context.ts`, `services/f5xc-env.ts` |
+| Product knowledge routing | Tiered llms.txt cascade | System prompt `# Product knowledge` section |
+| Salesforce queries | SOQL execution, pipeline reporting | `sf_query` tool, `xcsh://salesforce` protocol |
+| Git operations | Branch management, commit workflow | `commit/` module, `github-ops` agent |
+| System prompt SE persona | Identity, epistemic integrity, stakes | `prompts/system/system-prompt.md` |
+| Code editing | AST-aware, LSP-integrated, multi-file | Full tool suite inherited from pi-mono |
+| Internal URL protocols | Self-docs, skills, rules, artifacts | `internal-urls/` module |
+
+### Developing (functional but shallow)
+| Capability | Current State | Gap |
+|---|---|---|
+| MEDDPICC qualification | Referenced in system prompt, deal-analyst agent exists | No structured qualification workflow, no eval criteria, no scoring rubric |
+| Demo management | System prompt references demos | No demo catalog, no environment provisioning, no demo script templates |
+| Customer meeting prep | Mentioned in mission statement | No structured pre-call planning workflow, no meeting template system |
+| Competitive positioning | Generic instruction to check product docs | No competitor database, no battlecard system, no objection handling library |
+| Presentation generation | Not implemented | No slide generation, no deck templates, no presentation workflows |
+
+### Missing (not yet started)
+| Capability | Value to SE | Complexity |
+|---|---|---|
+| Deal health dashboard | Real-time pipeline visibility with MEDDPICC scores | Medium |
+| Demo environment lifecycle | Provision, configure, tear down demo environments | High |
+| Call preparation briefs | Auto-generated pre-call intelligence packages | Medium |
+| Win/loss analysis | Pattern recognition across deal outcomes | Medium |
+| Technical validation plans | Structured POC/POV planning and tracking | Medium |
+| ROI/TCO calculators | Quantified business case generation | Low |
+| Competitive intelligence refresh | Automated tracking of competitor announcements | Medium |
+| Account planning | Territory strategy, white-space analysis | High |
+| Post-sale handoff | Structured knowledge transfer to PS/CSM | Low |
+
+## Evaluation Dimensions
+
+These are the axes along which xcsh should be measured. Each dimension has observable, testable criteria.
+
+### 1. Product Knowledge Accuracy
+**What to test**: Can xcsh correctly answer F5 XC product questions using the llms.txt hierarchy?
+**Metrics**:
+- Factual accuracy (verified against current docs)
+- Source citation quality (does it reference specific doc pages?)
+- Hallucination rate (claims not grounded in sources)
+- Coverage (can it handle questions across all F5 XC product areas?)
+**Benchmark approach**: Curated question set with known-correct answers, scored by accuracy.
+
+### 2. API Integration Reliability
+**What to test**: Do F5 XC API calls work correctly for common SE workflows?
+**Metrics**:
+- API call success rate
+- Correct endpoint selection (catalog lookup accuracy)
+- Payload construction accuracy
+- Error handling quality
+**Benchmark approach**: Scripted API call sequences against live tenant, scored by success/failure.
+
+### 3. Salesforce Data Quality
+**What to test**: Can xcsh pull accurate pipeline data and derive useful insights?
+**Metrics**:
+- Query accuracy (correct SOQL for the ask)
+- Data interpretation quality
+- Pipeline summary completeness
+- Forecast accuracy alignment
+**Benchmark approach**: Known pipeline state, compare xcsh analysis against ground truth.
+
+### 4. MEDDPICC Qualification
+**What to test**: Can xcsh effectively qualify a deal using MEDDPICC methodology?
+**Metrics**:
+- Element coverage (does it address all 8 elements?)
+- Gap identification accuracy
+- Coaching recommendation quality
+- Action item specificity
+**Benchmark approach**: Synthetic deal scenarios with known MEDDPICC gaps, scored by identification rate.
+
+### 5. Demo Reliability
+**What to test**: Can xcsh configure and validate demo environments?
+**Metrics**:
+- Configuration accuracy (do created objects work?)
+- Environment validation completeness
+- Troubleshooting effectiveness
+- Demo narrative quality
+**Benchmark approach**: End-to-end demo setup scenarios, scored by working-state verification.
+
+### 6. Customer Communication Quality
+**What to test**: Does xcsh produce appropriate customer-facing content?
+**Metrics**:
+- Technical accuracy
+- Audience-appropriate tone
+- Actionable recommendations
+- Professional formatting
+**Benchmark approach**: Scenario-based content generation, scored against rubric.
+
+### 7. Competitive Positioning
+**What to test**: Can xcsh accurately position F5 XC vs competitors?
+**Metrics**:
+- Claim accuracy (verified against current product state)
+- Differentiation clarity
+- Objection handling effectiveness
+- Win theme identification
+**Benchmark approach**: Competitive scenario prompts, scored against known differentiators.
+
+## Known Gaps and Priorities
+
+### Critical (blocks SE effectiveness)
+1. **No structured MEDDPICC workflow** — The deal-analyst agent exists but has no scoring rubric, no structured qualification process, no gap-to-action mapping.
+2. **No demo catalog** — SEs cannot list, select, or configure demos through xcsh. Demo management is entirely manual.
+3. **Product knowledge depends on external docs availability** — If llms.txt hierarchy is unreachable, xcsh loses product knowledge entirely.
+
+### Important (reduces SE efficiency)
+4. **No meeting preparation workflow** — Pre-call planning is manual. No account intelligence aggregation, no agenda templates, no technical discovery question banks.
+5. **No competitive battlecards** — Competitive positioning relies on live web search. No cached, verified competitive intelligence.
+6. **No presentation generation** — SEs create decks manually. No template system, no automated content population.
+
+### Desirable (enhances SE experience)
+7. **No self-evaluation loop** — xcsh cannot test its own capabilities automatically. This document is the first step toward enabling that.
+8. **No learning from interactions** — xcsh does not improve from past SE interactions. No feedback loop from deal outcomes.
+9. **No territory-level intelligence** — Pipeline analysis is per-query. No persistent territory view, trend analysis, or forecasting.
+
+## How This Document Is Used
+
+1. **Autoresearch self-evaluation**: When running `/autoresearch` with an SE evaluation goal, the program template (`autoresearch.program.md`) references this document to understand what to evaluate and how.
+2. **Capability gap identification**: New feature development should be prioritized against the gaps listed here.
+3. **Progress tracking**: As capabilities mature, update the inventory tables above.
+4. **Self-improvement loop**: xcsh reads this document to understand its own state, identify improvement opportunities, and generate specific enhancement proposals.
+
+## Update Protocol
+
+This document should be updated when:
+- A new SE capability is implemented
+- An existing capability matures from "developing" to "mature"
+- A new gap is identified from customer interactions
+- Evaluation criteria are refined based on real usage
+- The mission or priorities shift based on business needs
+
+Maintainer: The autoresearch self-evaluation loop itself should propose updates to this document as part of its findings.

--- a/autoresearch.program.md
+++ b/autoresearch.program.md
@@ -1,0 +1,140 @@
+# Autoresearch Program: xcsh SE Self-Evaluation
+
+This is the strategy overlay for autoresearch sessions in the xcsh repository. It redirects the experiment loop from generic code optimization toward evaluating and improving xcsh's sales engineering capabilities.
+
+## Context
+
+Read `SELF_AWARENESS.md` at the repo root before starting any evaluation session. It contains:
+- Mission definition (what xcsh is for)
+- Current capability inventory (what works, what's developing, what's missing)
+- Evaluation dimensions with specific metrics
+- Known gaps and priorities
+
+## Operating Mode: Self-Evaluation
+
+Unlike typical autoresearch sessions that optimize runtime performance of a code target, SE self-evaluation sessions analyze xcsh's own codebase, prompts, and configurations to identify and implement improvements toward its stated mission.
+
+The "benchmark" in this context is not a shell script measuring execution time. It is a structured evaluation of capability quality, measured through test scenarios that exercise specific SE workflows.
+
+## Evaluation Categories
+
+Each category maps to a dimension in `SELF_AWARENESS.md`. Pick one per autoresearch session.
+
+### Category 1: Prompt Effectiveness
+**Focus**: System prompt, agent definitions, tool descriptions
+**What to evaluate**:
+- Does the system prompt correctly frame xcsh as an SE tool (not a generic coding assistant)?
+- Are tool descriptions optimized for SE workflows?
+- Do agent definitions (deal-analyst, status-operator, etc.) have sufficient context?
+- Are there prompt patterns inherited from pi-mono that contradict the SE mission?
+**Where to look**: `packages/coding-agent/src/prompts/system/system-prompt.md`, agent frontmatter in discovery modules, tool description strings
+**Improvement types**: Rewrite prompt sections, add SE-specific examples, remove generic coding emphasis where inappropriate
+
+### Category 2: Product Knowledge Pipeline
+**Focus**: llms.txt routing, product documentation access
+**What to evaluate**:
+- Is the llms.txt cascade correctly specified in the system prompt?
+- Are all F5 XC product areas reachable through the cascade?
+- Is the routing discipline clear enough to prevent unnecessary web searches?
+- Are there product areas where the cascade has gaps?
+**Where to look**: System prompt `# Product knowledge` section, any hardcoded product references
+**Improvement types**: Update routing rules, add missing product area links, improve fallback behavior
+
+### Category 3: F5 XC API Integration
+**Focus**: API client, catalog, spec system
+**What to evaluate**:
+- Does the API catalog cover common SE operations (create LB, configure WAF, set up origin pools)?
+- Are the xcsh://api-catalog and xcsh://api-spec protocols correct?
+- Is error handling adequate for demo contexts (where errors need clear explanation)?
+- Are there common API workflows that should be templated?
+**Where to look**: `services/f5xc-api-client.ts`, `services/f5xc-context.ts`, `xcsh_api` tool implementation
+**Improvement types**: Add API workflow templates, improve error messages, extend catalog coverage
+
+### Category 4: Salesforce Integration
+**Focus**: Pipeline intelligence, deal analysis
+**What to evaluate**:
+- Are SOQL query templates correct and comprehensive?
+- Does the pipeline context (xcsh://salesforce) provide useful intelligence?
+- Can xcsh derive actionable insights from pipeline data?
+- Is the deal-analyst agent well-defined enough to produce quality output?
+**Where to look**: `sf_query` tool, `xcsh://salesforce` protocol, deal-analyst agent definition
+**Improvement types**: Add query templates, improve pipeline analysis prompts, enhance deal-analyst instructions
+
+### Category 5: SE Workflow Completeness
+**Focus**: End-to-end SE task coverage
+**What to evaluate**:
+- Can xcsh handle a complete pre-call preparation workflow?
+- Can xcsh create a technical validation plan?
+- Can xcsh generate a competitive positioning document?
+- Can xcsh run a MEDDPICC qualification session?
+**Where to look**: System prompt workflow references, agent definitions, skill files
+**Improvement types**: Add new skills, create workflow templates, define new agent types
+
+### Category 6: Self-Awareness and Introspection
+**Focus**: xcsh's ability to understand and improve itself
+**What to evaluate**:
+- Can xcsh accurately describe its own capabilities?
+- Can xcsh identify its own gaps?
+- Can xcsh propose specific improvements to its own codebase?
+- Is the xcsh://about protocol informative enough for self-evaluation?
+**Where to look**: `internal-urls/xcsh-protocol.ts`, `internal-urls/build-info-runtime.ts`, `SELF_AWARENESS.md`
+**Improvement types**: Extend self-documentation, add capability introspection, improve xcsh:// protocol
+
+## Session Strategy
+
+### Phase 1: Reconnaissance
+1. Read `SELF_AWARENESS.md` to understand current state
+2. Read the system prompt (`packages/coding-agent/src/prompts/system/system-prompt.md`) to understand the SE framing
+3. Identify the specific evaluation category for this session
+4. Read relevant source files for that category
+
+### Phase 2: Assessment
+1. Evaluate current state against the criteria in `SELF_AWARENESS.md`
+2. Identify specific, actionable gaps
+3. Prioritize by impact on SE effectiveness
+4. Document findings in `autoresearch.md`
+
+### Phase 3: Implementation
+1. Make targeted improvements to the highest-impact gaps
+2. Keep changes scoped to the evaluation category
+3. Test changes against the evaluation criteria
+4. Document what changed and why in the experiment log
+
+### Phase 4: Validation
+1. Verify improvements don't break existing functionality
+2. Run `bun check:ts` for type safety
+3. Verify prompt changes maintain coherence with the overall system prompt structure
+4. Update `SELF_AWARENESS.md` if capability status changed
+
+## Benchmark Approach for SE Evaluation
+
+Since SE capabilities are primarily prompt-driven and integration-driven rather than performance-driven, benchmarks should be structured as:
+
+### For prompt quality
+- Create test scenarios (synthetic SE tasks) in `autoresearch.sh`
+- Score responses against a rubric
+- Metric: accuracy/quality score (higher is better)
+
+### For integration quality
+- Test API call sequences against the live tenant
+- Score by success rate and correctness
+- Metric: success_rate (higher is better)
+
+### For workflow completeness
+- Trace through a complete SE workflow
+- Score by coverage of required steps
+- Metric: coverage_score (higher is better)
+
+## Heuristics Learned
+
+Update this section as autoresearch sessions produce durable lessons.
+
+- (No heuristics yet — this is the first iteration)
+
+## Anti-Patterns to Avoid
+
+1. **Do not optimize coding features at the expense of SE features** — The coding capability exists to serve the SE mission. Performance improvements to grep/LSP/etc. are not the goal of SE self-evaluation.
+2. **Do not add features without updating SELF_AWARENESS.md** — Every capability change should be reflected in the inventory.
+3. **Do not make prompt changes without understanding the full system prompt assembly** — The system prompt is composed from multiple sources. A local change can conflict with upstream sections.
+4. **Do not evaluate against hypothetical requirements** — Evaluate against what SEs actually need, as documented in the mission and capability inventory.
+5. **Do not conflate "works technically" with "helps the SE"** — An API call that succeeds but returns data the SE cannot use is not a capability improvement.

--- a/packages/coding-agent/src/autoresearch/helpers.ts
+++ b/packages/coding-agent/src/autoresearch/helpers.ts
@@ -21,6 +21,7 @@ export const AUTORESEARCH_COMMITTABLE_FILES = [
 	"autoresearch.sh",
 	"autoresearch.checks.sh",
 	"autoresearch.ideas.md",
+	"SELF_AWARENESS.md",
 ] as const;
 export const AUTORESEARCH_LOCAL_STATE_FILES = ["autoresearch.jsonl"] as const;
 export const AUTORESEARCH_LOCAL_STATE_DIRECTORIES = [".autoresearch"] as const;

--- a/packages/coding-agent/src/autoresearch/index.ts
+++ b/packages/coding-agent/src/autoresearch/index.ts
@@ -323,6 +323,7 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 		const checksPath = path.join(workDir, "autoresearch.checks.sh");
 		const ideasPath = path.join(workDir, "autoresearch.ideas.md");
 		const programPath = path.join(workDir, "autoresearch.program.md");
+		const selfAwarenessPath = path.join(workDir, "SELF_AWARENESS.md");
 		const pendingRun =
 			runtime.lastRunSummary ??
 			(await readPendingRunSummary(workDir, collectLoggedRunNumbers(runtime.state.results)));
@@ -362,6 +363,8 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 				ideas_path: ideasPath,
 				has_program: fs.existsSync(programPath),
 				program_path: programPath,
+				has_self_awareness: fs.existsSync(selfAwarenessPath),
+				self_awareness_path: selfAwarenessPath,
 				current_segment: runtime.state.currentSegment + 1,
 				current_segment_run_count: currentSegmentResults.length,
 				has_baseline_metric: baselineMetric !== null,

--- a/packages/coding-agent/src/autoresearch/prompt.md
+++ b/packages/coding-agent/src/autoresearch/prompt.md
@@ -27,6 +27,14 @@ You are running an autonomous experiment loop. Keep iterating until the user int
 
 Use it as a repo-local strategy overlay for this session. `autoresearch.md` remains the source of truth for benchmark, scope, and constraints.
 {{/if}}
+{{#if has_self_awareness}}
+
+### Self-Awareness Manifest
+
+`SELF_AWARENESS.md` exists at `{{self_awareness_path}}`.
+
+This document defines xcsh's mission, current capability inventory, evaluation dimensions, and known gaps. When the session goal involves self-evaluation, capability improvement, or SE workflow enhancement, read this document first — it is the ground truth for what xcsh is, what it should become, and how to measure progress.
+{{/if}}
 {{#if has_recent_results}}
 
 ### Current Segment Snapshot
@@ -218,6 +226,19 @@ Before the first benchmark:
 - Optionally add `autoresearch.checks.sh` if correctness or quality needs a hard gate.
 - Call `init_experiment` with arguments that match `autoresearch.md` exactly (benchmark command, metric, unit, direction, scope paths, off limits, constraints).
 - Run and log the baseline.
+{{#if has_self_awareness}}
+
+#### SE Self-Evaluation Sessions
+
+When the goal involves evaluating or improving xcsh's sales engineering capabilities (not runtime code performance):
+
+- Read `SELF_AWARENESS.md` first to understand the current capability inventory and evaluation dimensions
+- Read `autoresearch.program.md` for the SE-specific evaluation strategy
+- Design the benchmark script (`autoresearch.sh`) to test the specific SE capability dimension — product knowledge accuracy, API reliability, prompt effectiveness, or workflow completeness
+- Use quality/accuracy scores as the primary metric (direction: `higher`) rather than timing metrics
+- Focus `Files in Scope` on the prompts, agent definitions, tool descriptions, or service modules relevant to the SE capability being evaluated
+- Record capability status changes in `SELF_AWARENESS.md` when experiments yield durable improvements
+{{/if}}
 
 Until `init_experiment` succeeds, only autoresearch control files (`autoresearch.md`, `autoresearch.sh`, `autoresearch.program.md`, `autoresearch.ideas.md`, `autoresearch.checks.sh`) may be edited; after initialization, respect Files in Scope from the contract.
 


### PR DESCRIPTION
## Summary

Adds the foundational self-awareness and SE-focused autoresearch framework. This is the first step in adapting xcsh from a generic coding assistant toward a specialized SE workstation.

## Changes

**New files:**
- `SELF_AWARENESS.md` -- xcsh's self-knowledge base: mission, capability inventory (mature/developing/missing), 7 evaluation dimensions with metrics, known gaps prioritized by SE impact, update protocol
- `autoresearch.program.md` -- Strategy overlay that redirects the autoresearch experiment loop toward SE self-evaluation with 6 evaluation categories

**Modified files:**
- `packages/coding-agent/src/autoresearch/index.ts` -- Added `has_self_awareness`/`self_awareness_path` template variables to detect and reference `SELF_AWARENESS.md`
- `packages/coding-agent/src/autoresearch/prompt.md` -- Added Self-Awareness Manifest section and SE Self-Evaluation Sessions guidance
- `packages/coding-agent/src/autoresearch/helpers.ts` -- Added `SELF_AWARENESS.md` to committable files list

## How it works

When `/autoresearch` runs in this repo:
1. Engine detects `autoresearch.program.md` and injects it as the Local Playbook
2. Engine detects `SELF_AWARENESS.md` and injects the self-awareness reference
3. Prompt guides the agent to read these documents for SE-focused sessions
4. Existing experiment loop (init/run/log) drives iteration with SE quality metrics

No existing autoresearch functionality is altered. Generic code optimization sessions work identically in repos without `SELF_AWARENESS.md`.

## Validation

- `bun check:ts` passes clean
- All changes are additive (0 deletions from existing code)

closes #672, closes #673