### PR TITLE
fix: subagent abort failures and tool_use/tool_result session corruption

### DIFF
--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -122,9 +122,6 @@ export function transformMessages<TApi extends Api>(
 		}
 		return msg;
 	});
-	const realToolResultIds = new Set(
-		transformed.filter((msg): msg is ToolResultMessage => msg.role === "toolResult").map(msg => msg.toolCallId),
-	);
 
 	// Second pass: insert synthetic empty tool results for orphaned tool calls
 	// and preserve aborted/errored tool results when they were already persisted.
@@ -138,7 +135,7 @@ export function transformMessages<TApi extends Api>(
 	const flushPendingToolCalls = (timestamp: number): void => {
 		if (pendingToolCalls.length === 0) return;
 		for (const tc of pendingToolCalls) {
-			if (!toolCallStatus.has(tc.id) && !realToolResultIds.has(tc.id)) {
+			if (!toolCallStatus.has(tc.id)) {
 				result.push({
 					role: "toolResult",
 					toolCallId: tc.id,
@@ -211,10 +208,16 @@ export function transformMessages<TApi extends Api>(
 			}
 
 			if (toolCallStatus.get(msg.toolCallId) === ToolCallStatus.Aborted) continue;
+			if (toolCallStatus.get(msg.toolCallId) === ToolCallStatus.Resolved) continue;
 			toolCallStatus.set(msg.toolCallId, ToolCallStatus.Resolved);
 			result.push(msg);
-		} else if (msg.role === "user" || msg.role === "developer") {
+		} else if (msg.role === "user") {
 			flushPendingToolCalls(messageTimestamp);
+			flushPendingAbortedToolCalls();
+			result.push(msg);
+		} else if (msg.role === "developer") {
+			// Developer messages are system-level guidance, not turn boundaries.
+			// Don't flush pending tool calls — tool_result may follow.
 			flushPendingAbortedToolCalls();
 			result.push(msg);
 		} else {

--- a/packages/ai/test/transform-messages.test.ts
+++ b/packages/ai/test/transform-messages.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "bun:test";
+import { transformMessages } from "../src/providers/transform-messages";
+import type { AssistantMessage, Message, Model, StopReason, ToolResultMessage } from "../src/types";
+
+function mockModel(): Model<"anthropic-messages"> {
+	return {
+		id: "test-model",
+		name: "Test",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0 },
+	} as Model<"anthropic-messages">;
+}
+
+function assistantWithToolCalls(
+	toolCalls: { id: string; name: string }[],
+	extra?: { text?: string; stopReason?: StopReason },
+): AssistantMessage {
+	const content: AssistantMessage["content"] = [];
+	if (extra?.text) content.push({ type: "text", text: extra.text });
+	for (const tc of toolCalls) {
+		content.push({ type: "toolCall", id: tc.id, name: tc.name, arguments: {} });
+	}
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "test",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: extra?.stopReason ?? "toolUse",
+		timestamp: Date.now(),
+	};
+}
+
+function toolResult(toolCallId: string, toolName: string, text = "done"): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName,
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+function userMessage(text: string): Message {
+	return { role: "user", content: [{ type: "text", text }], timestamp: Date.now() };
+}
+
+describe("transformMessages", () => {
+	const model = mockModel();
+
+	it("passes through correctly ordered tool_use/tool_result unchanged", () => {
+		const messages: Message[] = [
+			userMessage("go"),
+			assistantWithToolCalls([{ id: "tc1", name: "read" }]),
+			toolResult("tc1", "read"),
+		];
+		const result = transformMessages(messages, model);
+		expect(result).toHaveLength(3);
+		expect(result[0].role).toBe("user");
+		expect(result[1].role).toBe("assistant");
+		expect(result[2].role).toBe("toolResult");
+		expect((result[2] as ToolResultMessage).toolCallId).toBe("tc1");
+	});
+
+	it("injects synthetic tool_result between consecutive assistant messages even when real result exists later", () => {
+		const messages: Message[] = [
+			userMessage("go"),
+			assistantWithToolCalls([{ id: "tc1", name: "foo" }]),
+			// No tool_result for tc1 here — consecutive assistants
+			assistantWithToolCalls([{ id: "tc2", name: "bar" }], { text: "hello" }),
+			toolResult("tc2", "bar", "bar result"),
+			toolResult("tc1", "foo", "foo result"),
+		];
+		const result = transformMessages(messages, model);
+
+		// Expected ordering:
+		// user -> assistant[tc1] -> synthetic_toolResult[tc1] -> assistant[tc2] -> toolResult[tc2]
+		// The real toolResult[tc1] should be dropped (already resolved by synthetic)
+
+		// Find assistant messages
+		const assistantIndices = result.map((m, i) => (m.role === "assistant" ? i : -1)).filter(i => i >= 0);
+		expect(assistantIndices).toHaveLength(2);
+
+		// After first assistant, there must be a toolResult for tc1 (synthetic)
+		const afterFirstAssistant = result[assistantIndices[0] + 1];
+		expect(afterFirstAssistant.role).toBe("toolResult");
+		expect((afterFirstAssistant as ToolResultMessage).toolCallId).toBe("tc1");
+
+		// After second assistant, there must be a toolResult for tc2 (real)
+		const afterSecondAssistant = result[assistantIndices[1] + 1];
+		expect(afterSecondAssistant.role).toBe("toolResult");
+		expect((afterSecondAssistant as ToolResultMessage).toolCallId).toBe("tc2");
+
+		// The duplicate real toolResult for tc1 should be dropped
+		const tc1Results = result.filter(m => m.role === "toolResult" && (m as ToolResultMessage).toolCallId === "tc1");
+		expect(tc1Results).toHaveLength(1);
+	});
+
+	it("injects synthetic tool_result when tool_result is completely missing", () => {
+		const messages: Message[] = [
+			userMessage("go"),
+			assistantWithToolCalls([{ id: "tc1", name: "bash" }]),
+			// Process crashed — no tool_result at all
+			userMessage("next turn"),
+		];
+		const result = transformMessages(messages, model);
+
+		// Should have: user -> assistant[tc1] -> synthetic_toolResult[tc1] -> user
+		expect(result[1].role).toBe("assistant");
+		expect(result[2].role).toBe("toolResult");
+		const synthetic = result[2] as ToolResultMessage;
+		expect(synthetic.toolCallId).toBe("tc1");
+		expect(synthetic.isError).toBe(true);
+	});
+
+	it("handles multiple tool calls in one assistant with only some results missing", () => {
+		const messages: Message[] = [
+			userMessage("go"),
+			assistantWithToolCalls([
+				{ id: "tc1", name: "read" },
+				{ id: "tc2", name: "grep" },
+			]),
+			toolResult("tc1", "read"),
+			// tc2 result missing — next assistant arrives
+			assistantWithToolCalls([{ id: "tc3", name: "write" }], { text: "continuing" }),
+			toolResult("tc3", "write"),
+			toolResult("tc2", "grep", "late grep result"),
+		];
+		const result = transformMessages(messages, model);
+
+		// After first assistant: tc1 result (real), tc2 result (synthetic before second assistant)
+		// After second assistant: tc3 result (real)
+		// Late tc2 result: dropped (already resolved by synthetic)
+
+		const tc2Results = result.filter(m => m.role === "toolResult" && (m as ToolResultMessage).toolCallId === "tc2");
+		expect(tc2Results).toHaveLength(1);
+		// The synthetic should be an error result
+		expect((tc2Results[0] as ToolResultMessage).isError).toBe(true);
+	});
+
+	it("does not inject synthetic when tool_result immediately follows assistant", () => {
+		const messages: Message[] = [
+			userMessage("go"),
+			assistantWithToolCalls([
+				{ id: "tc1", name: "read" },
+				{ id: "tc2", name: "grep" },
+			]),
+			toolResult("tc1", "read"),
+			toolResult("tc2", "grep"),
+			userMessage("thanks"),
+		];
+		const result = transformMessages(messages, model);
+
+		// No synthetic results — all real results present
+		const toolResults = result.filter(m => m.role === "toolResult");
+		expect(toolResults).toHaveLength(2);
+		expect(toolResults.every(r => !(r as ToolResultMessage).isError)).toBe(true);
+	});
+});

--- a/packages/coding-agent/src/prompts/agents/explore.md
+++ b/packages/coding-agent/src/prompts/agents/explore.md
@@ -2,7 +2,7 @@
 name: explore
 description: Fast read-only codebase scout returning compressed context for handoff
 tools: read, grep, find, web_search
-model: pi/smol
+model: pi/task
 thinking-level: med
 output:
   properties:
@@ -10,6 +10,7 @@ output:
       metadata:
         description: Brief summary of findings and conclusions
       type: string
+  optionalProperties:
     files:
       metadata:
         description: Files examined with relevant code references

--- a/packages/coding-agent/src/prompts/system/subagent-submit-reminder.md
+++ b/packages/coding-agent/src/prompts/system/subagent-submit-reminder.md
@@ -1,11 +1,8 @@
 <system-reminder>
 You stopped without calling submit_result. This is reminder {{retryCount}} of {{maxRetries}}.
 
-You **MUST** call submit_result as your only action now. Choose one:
-- If task is complete: call submit_result with your result in `result.data`
-- If task failed: call submit_result with `result.error` describing what happened
+You **MUST** call submit_result now. No other tool calls, no text output.
 
-You **MUST NOT** give up if you can still complete the task through exploration (using available tools or repo context). If you submit an error, you **MUST** include what you tried and the exact blocker.
-
-You **MUST NOT** output text without a tool call. You **MUST** call submit_result to finish.
+- Task done: `submit_result` with `result.data` containing your findings
+- Task blocked: `submit_result` with `result.error` describing the blocker
 </system-reminder>

--- a/packages/coding-agent/src/prompts/system/subagent-submit-reminder.md
+++ b/packages/coding-agent/src/prompts/system/subagent-submit-reminder.md
@@ -2,7 +2,6 @@
 You stopped without calling submit_result. This is reminder {{retryCount}} of {{maxRetries}}.
 
 You **MUST** call submit_result now. No other tool calls, no text output.
-
 - Task done: `submit_result` with `result.data` containing your findings
 - Task blocked: `submit_result` with `result.error` describing the blocker
 </system-reminder>

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -12,9 +12,10 @@ import type {
 	MessageAttribution,
 	ProviderPayload,
 	TextContent,
+	ToolCall,
 	ToolResultMessage,
 } from "@f5xc-salesdemos/pi-ai";
-import { prompt } from "@f5xc-salesdemos/pi-utils";
+import { logger, prompt } from "@f5xc-salesdemos/pi-utils";
 import branchSummaryContextPrompt from "../prompts/compaction/branch-summary-context.md" with { type: "text" };
 import compactionSummaryContextPrompt from "../prompts/compaction/compaction-summary-context.md" with { type: "text" };
 import type { OutputMeta } from "../tools/output-meta";
@@ -261,6 +262,122 @@ export function createCustomMessage(
 }
 
 /**
+ * Repair tool_use / tool_result ordering in converted LLM messages.
+ *
+ * The Claude API requires every assistant message containing tool_use blocks
+ * to be immediately followed by the matching tool_result messages. Session
+ * corruption (injected messages, compaction boundaries, crash during tool
+ * execution) can break this invariant, producing a 400 error that bricks
+ * the session.
+ *
+ * This function:
+ * 1. Finds assistant messages with tool_use (toolCall) content
+ * 2. Collects the required tool_result IDs
+ * 3. If tool_results are elsewhere in the array, moves them to the correct position
+ * 4. If tool_results are missing entirely, injects synthetic error tool_results
+ * 5. Non-tool messages that got wedged between tool_use and tool_result are relocated
+ *    to just before the assistant message
+ */
+function repairToolResultOrdering(messages: Message[]): Message[] {
+	const result: Message[] = [];
+	let repaired = false;
+
+	// Index all toolResult messages by their toolCallId for O(1) lookup
+	const toolResultsByCallId = new Map<string, { message: Message; originalIndex: number }>();
+	for (let i = 0; i < messages.length; i++) {
+		const msg = messages[i];
+		if (msg.role === "toolResult") {
+			const trMsg = msg as ToolResultMessage;
+			toolResultsByCallId.set(trMsg.toolCallId, { message: msg, originalIndex: i });
+		}
+	}
+
+	// Track which toolResult messages have been placed by repair
+	const placedToolResultIndices = new Set<number>();
+
+	for (let i = 0; i < messages.length; i++) {
+		const msg = messages[i];
+
+		// Skip toolResult messages that were already placed by repair
+		if (msg.role === "toolResult" && placedToolResultIndices.has(i)) {
+			continue;
+		}
+
+		result.push(msg);
+
+		// Not an assistant message with tool calls — nothing to repair
+		if (msg.role !== "assistant") continue;
+		const assistantMsg = msg as AssistantMessage;
+		const toolCalls = assistantMsg.content.filter((c): c is ToolCall => c.type === "toolCall");
+		if (toolCalls.length === 0) continue;
+
+		// Collect required tool call IDs
+		const requiredIds = new Set(toolCalls.map(tc => tc.id));
+
+		// Check what immediately follows in the remaining messages
+		// Consume consecutive toolResult messages that match, and relocate any
+		// non-toolResult messages that got wedged between
+		const displaced: Message[] = [];
+		let j = i + 1;
+		while (j < messages.length && requiredIds.size > 0) {
+			const next = messages[j];
+			if (next.role === "toolResult") {
+				const trMsg = next as ToolResultMessage;
+				if (requiredIds.has(trMsg.toolCallId)) {
+					// This tool_result belongs here — place it
+					result.push(next);
+					placedToolResultIndices.add(j);
+					requiredIds.delete(trMsg.toolCallId);
+					if (displaced.length > 0) repaired = true;
+					j++;
+					continue;
+				}
+			}
+			// Non-matching message between tool_use and tool_result — displace it
+			displaced.push(next);
+			placedToolResultIndices.add(j); // Mark original index as consumed
+			j++;
+		}
+
+		// Advance main iterator past consumed messages
+		i = j - 1;
+
+		// Any remaining required IDs: find them later in the array or synthesize
+		for (const id of requiredIds) {
+			const found = toolResultsByCallId.get(id);
+			if (found && !placedToolResultIndices.has(found.originalIndex)) {
+				result.push(found.message);
+				placedToolResultIndices.add(found.originalIndex);
+				repaired = true;
+			} else {
+				// Missing tool_result entirely — inject synthetic error result
+				const toolCall = toolCalls.find(tc => tc.id === id);
+				result.push({
+					role: "toolResult",
+					toolCallId: id,
+					toolName: toolCall?.name ?? "unknown",
+					content: [{ type: "text", text: "Tool execution was interrupted (session recovery)." }],
+					isError: true,
+					timestamp: Date.now(),
+				} as ToolResultMessage);
+				repaired = true;
+			}
+		}
+
+		// Re-insert displaced messages after the tool_results
+		for (const d of displaced) {
+			result.push(d);
+		}
+	}
+
+	if (repaired) {
+		logger.warn("Repaired tool_use/tool_result ordering in conversation history");
+	}
+
+	return repaired ? result : messages;
+}
+
+/**
  * Transform AgentMessages (including custom types) to LLM-compatible Messages.
  *
  * This is used by:
@@ -269,7 +386,7 @@ export function createCustomMessage(
  * - Custom extensions and tools
  */
 export function convertToLlm(messages: AgentMessage[]): Message[] {
-	return messages
+	const converted = messages
 		.map((m): Message | undefined => {
 			switch (m.role) {
 				case "bashExecution":
@@ -370,4 +487,5 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 			}
 		})
 		.filter(m => m !== undefined);
+	return repairToolResultOrdering(converted);
 }

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -325,6 +325,29 @@ export function finalizeSubprocessOutput(args: FinalizeSubprocessOutputArgs): Fi
 				? `${SUBAGENT_WARNING_MISSING_SUBMIT_RESULT}\n\n${rawOutput}`
 				: SUBAGENT_WARNING_MISSING_SUBMIT_RESULT;
 		}
+
+		// Salvage output from aborted runs that produced content without calling submit_result
+		if (exitCode !== 0 && doneAborted && !signalAborted && rawOutput.trim().length > 0) {
+			if (hasOutputSchema) {
+				// Try schema-validated fallback: if the model produced valid JSON matching the schema,
+				// use it even though submit_result was never called
+				const abortFallback = resolveFallbackCompletion(rawOutput, outputSchema);
+				if (abortFallback) {
+					const completeData = normalizeCompleteData(abortFallback.data, reportFindings);
+					try {
+						rawOutput = JSON.stringify(completeData, null, 2) ?? "null";
+					} catch {
+						// Keep rawOutput as-is if serialization fails
+					}
+					exitCode = 0;
+					stderr = "";
+				}
+			} else {
+				// No schema required — raw text output is directly useful
+				exitCode = 0;
+				stderr = "";
+			}
+		}
 	}
 
 	return { rawOutput, exitCode, stderr, abortedViaSubmitResult, hasSubmitResult };
@@ -1250,7 +1273,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 	}
 
 	// Update final progress
-	const wasAborted = abortedViaSubmitResult || (!hasSubmitResult && (done.aborted || signal?.aborted || false));
+	// When salvage recovered the output (exitCode became 0), the result is not aborted.
+	const wasAborted = abortedViaSubmitResult || (!hasSubmitResult && exitCode !== 0 && (done.aborted || signal?.aborted || false));
 	const finalAbortReason = wasAborted
 		? abortedViaSubmitResult
 			? submitResultAbortReason

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1274,7 +1274,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 	// Update final progress
 	// When salvage recovered the output (exitCode became 0), the result is not aborted.
-	const wasAborted = abortedViaSubmitResult || (!hasSubmitResult && exitCode !== 0 && (done.aborted || signal?.aborted || false));
+	const wasAborted =
+		abortedViaSubmitResult || (!hasSubmitResult && exitCode !== 0 && (done.aborted || signal?.aborted || false));
 	const finalAbortReason = wasAborted
 		? abortedViaSubmitResult
 			? submitResultAbortReason

--- a/packages/coding-agent/src/utils/tool-choice.ts
+++ b/packages/coding-agent/src/utils/tool-choice.ts
@@ -24,5 +24,5 @@ export function buildNamedToolChoice(toolName: string, model?: Model<Api>): Tool
 		return "required";
 	}
 
-	return undefined;
+	return "required";
 }

--- a/packages/coding-agent/test/session/messages-repair.test.ts
+++ b/packages/coding-agent/test/session/messages-repair.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@f5xc-salesdemos/pi-agent-core";
+import type { AssistantMessage, ToolResultMessage } from "@f5xc-salesdemos/pi-ai";
+import { convertToLlm } from "../../src/session/messages";
+
+function userMessage(text: string): AgentMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp: Date.now() };
+}
+
+function assistantWithToolCalls(toolCalls: { id: string; name: string }[]): AgentMessage {
+	return {
+		role: "assistant",
+		content: toolCalls.map(tc => ({
+			type: "toolCall" as const,
+			id: tc.id,
+			name: tc.name,
+			arguments: {},
+		})),
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "test",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	} as AssistantMessage;
+}
+
+function toolResult(toolCallId: string, toolName: string, text = "done"): AgentMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName,
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: Date.now(),
+	} as ToolResultMessage;
+}
+
+function customMessage(text: string): AgentMessage {
+	return {
+		role: "custom" as AgentMessage["role"],
+		customType: "test-injection",
+		content: text,
+		display: false,
+		timestamp: Date.now(),
+	} as AgentMessage;
+}
+
+describe("convertToLlm tool_result ordering repair", () => {
+	it("passes through correctly ordered messages unchanged", () => {
+		const messages: AgentMessage[] = [
+			userMessage("do something"),
+			assistantWithToolCalls([{ id: "tc1", name: "read" }]),
+			toolResult("tc1", "read"),
+		];
+		const result = convertToLlm(messages);
+		expect(result).toHaveLength(3);
+		expect(result[0].role).toBe("user");
+		expect(result[1].role).toBe("assistant");
+		expect(result[2].role).toBe("toolResult");
+		expect((result[2] as ToolResultMessage).toolCallId).toBe("tc1");
+	});
+
+	it("repairs custom message wedged between tool_use and tool_result", () => {
+		const messages: AgentMessage[] = [
+			userMessage("do something"),
+			assistantWithToolCalls([{ id: "tc1", name: "read" }]),
+			customMessage("injected system reminder"),
+			toolResult("tc1", "read"),
+		];
+		const result = convertToLlm(messages);
+		expect(result).toHaveLength(4);
+		expect(result[0].role).toBe("user");
+		expect(result[1].role).toBe("assistant");
+		expect(result[2].role).toBe("toolResult");
+		expect((result[2] as ToolResultMessage).toolCallId).toBe("tc1");
+		expect(result[3].role).toBe("user");
+	});
+
+	it("injects synthetic tool_result when tool_result is missing entirely", () => {
+		const messages: AgentMessage[] = [
+			userMessage("do something"),
+			assistantWithToolCalls([{ id: "tc1", name: "bash" }]),
+			userMessage("next turn"),
+		];
+		const result = convertToLlm(messages);
+		expect(result).toHaveLength(4);
+		expect(result[1].role).toBe("assistant");
+		expect(result[2].role).toBe("toolResult");
+		const syntheticResult = result[2] as ToolResultMessage;
+		expect(syntheticResult.toolCallId).toBe("tc1");
+		expect(syntheticResult.toolName).toBe("bash");
+		expect(syntheticResult.isError).toBe(true);
+		expect(result[3].role).toBe("user");
+	});
+
+	it("repairs multiple tool calls with interleaved non-tool messages", () => {
+		const messages: AgentMessage[] = [
+			userMessage("multi-tool"),
+			assistantWithToolCalls([
+				{ id: "tc1", name: "read" },
+				{ id: "tc2", name: "grep" },
+			]),
+			customMessage("injected"),
+			toolResult("tc1", "read"),
+			toolResult("tc2", "grep"),
+		];
+		const result = convertToLlm(messages);
+		expect(result[1].role).toBe("assistant");
+		expect(result[2].role).toBe("toolResult");
+		expect(result[3].role).toBe("toolResult");
+		const ids = [result[2], result[3]].map(r => (r as ToolResultMessage).toolCallId).sort();
+		expect(ids).toEqual(["tc1", "tc2"]);
+	});
+
+	it("handles tool_result found later in the array (out of position)", () => {
+		const messages: AgentMessage[] = [
+			userMessage("start"),
+			assistantWithToolCalls([{ id: "tc1", name: "read" }]),
+			userMessage("user typed during execution"),
+			userMessage("another message"),
+			toolResult("tc1", "read"),
+		];
+		const result = convertToLlm(messages);
+		expect(result[1].role).toBe("assistant");
+		expect(result[2].role).toBe("toolResult");
+		expect((result[2] as ToolResultMessage).toolCallId).toBe("tc1");
+	});
+
+	it("preserves messages with no tool calls", () => {
+		const messages: AgentMessage[] = [
+			userMessage("hello"),
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "hi there" }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "test",
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: Date.now(),
+			} as AssistantMessage,
+			userMessage("thanks"),
+		];
+		const result = convertToLlm(messages);
+		expect(result).toHaveLength(3);
+		expect(result[0].role).toBe("user");
+		expect(result[1].role).toBe("assistant");
+		expect(result[2].role).toBe("user");
+	});
+});

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -355,4 +355,31 @@ describe("runSubprocess submit_result reminders", () => {
 		expect(result.abortReason).toBe("Cancelled before start");
 		expect(result.stderr).toBe("Cancelled before start");
 	});
+
+	it("salvages valid JSON output matching schema when submit_result is never called", async () => {
+		const session = createMockSession(({ promptIndex, emit, state }) => {
+			if (promptIndex === 1) {
+				// Model outputs valid JSON as text without calling submit_result
+				const assistant = createAssistantStopMessage('{"ok": true}');
+				state.messages.push(assistant);
+				emit({ type: "message_end", message: assistant });
+				return;
+			}
+			// Reminders: model produces no text output (e.g., forced tool calls that don't add text)
+			const assistant = createAssistantStopMessage("");
+			state.messages.push(assistant);
+			emit({ type: "message_end", message: assistant });
+		});
+
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "subagent-salvage-json",
+			outputSchema: { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] },
+		});
+		expect(result.exitCode).toBe(0);
+		expect(result.aborted).toBe(false);
+		expect(result.output).toContain('"ok": true');
+	});
 });

--- a/packages/coding-agent/test/task/executor-warnings.test.ts
+++ b/packages/coding-agent/test/task/executor-warnings.test.ts
@@ -133,4 +133,81 @@ describe("subagent warning injection", () => {
 		expect(result.rawOutput.includes("SYSTEM WARNING")).toBe(false);
 		expect(result.exitCode).toBe(0);
 	});
+	it("salvages text output from aborted run without output schema", () => {
+		const result = finalizeSubprocessOutput({
+			rawOutput: "exploration notes: found 5 files related to auth",
+			exitCode: 1,
+			stderr: "subagent terminated",
+			doneAborted: true,
+			signalAborted: false,
+			submitResultItems: undefined,
+			outputSchema: undefined,
+		});
+
+		expect(result.rawOutput).toBe("exploration notes: found 5 files related to auth");
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+	});
+
+	it("does not salvage aborted output when output schema is required", () => {
+		const result = finalizeSubprocessOutput({
+			rawOutput: "unstructured text",
+			exitCode: 1,
+			stderr: "subagent terminated",
+			doneAborted: true,
+			signalAborted: false,
+			submitResultItems: undefined,
+			outputSchema: { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] },
+		});
+
+		expect(result.rawOutput).toBe("unstructured text");
+		expect(result.exitCode).toBe(1);
+	});
+
+	it("does not salvage when signal aborted even without schema", () => {
+		const result = finalizeSubprocessOutput({
+			rawOutput: "partial notes",
+			exitCode: 1,
+			stderr: "cancelled",
+			doneAborted: true,
+			signalAborted: true,
+			submitResultItems: undefined,
+			outputSchema: undefined,
+		});
+
+		expect(result.rawOutput).toBe("partial notes");
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toBe("cancelled");
+	});
+
+	it("salvages aborted output when valid JSON matches output schema", () => {
+		const result = finalizeSubprocessOutput({
+			rawOutput: '{"ok": true}',
+			exitCode: 1,
+			stderr: "subagent terminated",
+			doneAborted: true,
+			signalAborted: false,
+			submitResultItems: undefined,
+			outputSchema: { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] },
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		expect(result.rawOutput).toContain('"ok": true');
+	});
+
+	it("does not salvage aborted output when JSON does not match schema", () => {
+		const result = finalizeSubprocessOutput({
+			rawOutput: '{"wrong": "field"}',
+			exitCode: 1,
+			stderr: "subagent terminated",
+			doneAborted: true,
+			signalAborted: false,
+			submitResultItems: undefined,
+			outputSchema: { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] },
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toBe("subagent terminated");
+	});
 });

--- a/packages/coding-agent/test/utils/tool-choice.test.ts
+++ b/packages/coding-agent/test/utils/tool-choice.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import type { Api, Model } from "@f5xc-salesdemos/pi-ai";
+import { buildNamedToolChoice } from "../../src/utils/tool-choice";
+
+function mockModel(api: Api): Model<Api> {
+	return { api, provider: "test", id: "test-model" } as Model<Api>;
+}
+
+describe("buildNamedToolChoice", () => {
+	it("returns undefined when model is undefined", () => {
+		expect(buildNamedToolChoice("submit_result")).toBeUndefined();
+	});
+
+	it("returns named tool choice for anthropic-messages", () => {
+		const result = buildNamedToolChoice("submit_result", mockModel("anthropic-messages"));
+		expect(result).toEqual({ type: "tool", name: "submit_result" });
+	});
+
+	it("returns named tool choice for bedrock-converse-stream", () => {
+		const result = buildNamedToolChoice("submit_result", mockModel("bedrock-converse-stream"));
+		expect(result).toEqual({ type: "tool", name: "submit_result" });
+	});
+
+	it("returns function tool choice for openai-responses", () => {
+		const result = buildNamedToolChoice("submit_result", mockModel("openai-responses"));
+		expect(result).toEqual({ type: "function", name: "submit_result" });
+	});
+
+	it("returns function tool choice for openai-codex-responses", () => {
+		const result = buildNamedToolChoice("submit_result", mockModel("openai-codex-responses"));
+		expect(result).toEqual({ type: "function", name: "submit_result" });
+	});
+
+	it("returns function tool choice for azure-openai-responses", () => {
+		const result = buildNamedToolChoice("submit_result", mockModel("azure-openai-responses"));
+		expect(result).toEqual({ type: "function", name: "submit_result" });
+	});
+
+	it("returns required for google-generative-ai", () => {
+		const result = buildNamedToolChoice("submit_result", mockModel("google-generative-ai"));
+		expect(result).toBe("required");
+	});
+
+	it("returns required for google-vertex", () => {
+		const result = buildNamedToolChoice("submit_result", mockModel("google-vertex"));
+		expect(result).toBe("required");
+	});
+
+	it("returns required as fallback for unknown API types", () => {
+		const result = buildNamedToolChoice("submit_result", mockModel("unknown-api" as Api));
+		expect(result).toBe("required");
+	});
+});


### PR DESCRIPTION
Closes #728

## Summary

Fixes three related agent reliability issues that cause subagent task failures and unrecoverable session crash loops.

### Problem 1: Subagent abort failures
Explore agents abort in <2s without calling `submit_result`, producing `exited without calling submit_result after 3 reminders` errors. Root causes: model too weak (`pi/smol`), reminders don't force tool calls, useful output discarded after abort.

### Problem 2: Session crash loop (tool_use/tool_result ordering)
A `tool_use` block without matching `tool_result` in the immediately following message corrupts the conversation history. Every subsequent API call replays the malformed history and fails with HTTP 400, bricking the session permanently. Model fallback also fails.

### Problem 3: transform-messages.ts flushPendingToolCalls bug
`flushPendingToolCalls()` skips synthetic `tool_result` injection when a real result exists anywhere later in the array, allowing consecutive assistant messages without intervening `tool_result` — violating the Claude API ordering constraint.

## Changes

### Commit 1: Subagent reliability (7 files, 14 tests)
- Explore agent model `pi/smol` -> `pi/task` (inherits parent session model)
- `buildNamedToolChoice` fallback `undefined` -> `"required"`
- Post-abort salvage: schema-validated JSON + schema-less text recovery
- `wasAborted` respects salvaged `exitCode`
- Explore output schema: `files`/`architecture` -> `optionalProperties`
- Simplified submit_result reminder prompt

### Commit 2: Session corruption defense (4 files, 11 tests)
- **Layer 1** (`convertToLlm`): `repairToolResultOrdering()` validates pairing, relocates wedged messages, injects synthetic results for missing `tool_result`s
- **Layer 2** (`transformMessages`): removed `realToolResultIds` look-ahead, added `Resolved` skip for duplicates

## Testing
25 new tests, 0 regressions. Zero type errors across both packages.