### PR TITLE
fix(coding-agent,tui): guard against undefined experiment in log-experiment renderSummary

### DIFF
--- a/packages/coding-agent/src/autoresearch/tools/log-experiment.ts
+++ b/packages/coding-agent/src/autoresearch/tools/log-experiment.ts
@@ -372,7 +372,7 @@ export function createLogExperimentTool(
 		},
 		renderResult(result, _options, theme): Component {
 			const details = result.details;
-			if (!details) {
+			if (!isLogDetails(details)) {
 				return new Text(replaceTabs(result.content.find(part => part.type === "text")?.text ?? ""), 0, 0);
 			}
 			return {
@@ -770,8 +770,16 @@ function truncateAsiValue(value: ASIData[string]): string {
 	return text.length > 120 ? `${text.slice(0, 117)}...` : text;
 }
 
+function isLogDetails(value: unknown): value is LogDetails {
+	if (typeof value !== "object" || value === null) return false;
+	return "experiment" in value && "state" in value;
+}
+
 function renderSummary(details: LogDetails, theme: Theme, width?: number): string {
 	const { experiment, state } = details;
+	if (!experiment || !state) {
+		return theme.fg("dim", "(no experiment data)");
+	}
 	const color = experiment.status === "keep" ? "success" : experiment.status === "discard" ? "warning" : "error";
 	let summary = `${theme.fg(color, experiment.status.toUpperCase())} ${theme.fg("muted", truncateToWidth(replaceTabs(experiment.description ?? ""), Math.max(20, (width ?? 100) - 30)))}`;
 	summary += ` ${theme.fg("contentAccent", `${state.metricName}=${formatNum(experiment.metric, state.metricUnit)}`)}`;

--- a/packages/tui/src/components/box.ts
+++ b/packages/tui/src/components/box.ts
@@ -94,9 +94,13 @@ export class Box implements Component {
 		// Render all children
 		const childLines: string[] = [];
 		for (const child of this.children) {
-			const lines = child.render(contentWidth);
-			for (const line of lines) {
-				childLines.push(leftPad + line);
+			try {
+				const lines = child.render(contentWidth);
+				for (const line of lines) {
+					childLines.push(leftPad + line);
+				}
+			} catch {
+				// Swallow render errors from individual children to prevent process crash
 			}
 		}
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -200,7 +200,11 @@ export class Container implements Component {
 		width = Math.max(1, width);
 		const lines: string[] = [];
 		for (const child of this.children) {
-			lines.push(...child.render(width));
+			try {
+				lines.push(...child.render(width));
+			} catch {
+				// Swallow render errors from individual children to prevent process crash
+			}
 		}
 		return lines;
 	}


### PR DESCRIPTION
## What

Guard against undefined `experiment` property in `renderSummary()` and add
defensive rendering in TUI component render loops.

## Why

The xcsh binary crashes with `TypeError: undefined is not an object
(evaluating 'experiment.status')` when `renderSummary()` is called via a
lazy render closure with details that lack the expected `experiment`
property. This kills the entire process during normal TUI operation.

Closes #769

## Changes

- Add `isLogDetails()` type guard (matching the existing `isRunDetails()`
  pattern in `run-experiment.ts`) to validate details shape before rendering
- Use the guard in `renderResult()` to reject unexpected details shapes
- Add defense-in-depth early return in `renderSummary()` when `experiment`
  or `state` is missing
- Wrap TUI render loops (`Container.render` and `Box.render`) in try/catch
  so future tool renderer crashes degrade gracefully instead of killing the
  process

## Testing

- [ ] CI checks pass
- [x] Pre-commit hooks pass (governance, biome lint, spelling, secrets)
- [x] Issue linked via `Closes #769`