### PR TITLE
chore: add autoresearch seed and teardown scripts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,5 @@ autoresearch.md
 autoresearch.sh
 autoresearch.checks.sh
 autoresearch-queries.txt
+autoresearch-seed.sh
+autoresearch-teardown.sh


### PR DESCRIPTION
## What

Add `autoresearch-seed.sh` and `autoresearch-teardown.sh` to the existing autoresearch section in `.gitignore`.

## Why

Phase 2 of the autoresearch experiment adds seed and teardown scripts for creating and removing test resources across multiple namespaces. These are local-only experiment infrastructure files and should not be tracked in version control, consistent with the other autoresearch files already listed in `.gitignore`.

Closes #813

## Testing

- [x] Pre-commit hooks pass
- [x] No code changes — `.gitignore` only
- [x] Issue linked via `Closes #813`