### PR TITLE
fix: welcome banner cloud provider hints are incomplete and misleading

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -364,8 +364,16 @@ export function mapContextStatus(status: WelcomeContextStatus): ServiceStatus {
 		case "no_context":
 			return { name: "F5 XC Context", state: "unauthenticated", hint: "run: /context create" };
 		case "auth_error":
-		case "offline":
 			return { name: "F5 XC Context", state: "unauthenticated", hint: "run: /context" };
+		case "offline":
+			switch (status.errorClass) {
+				case "network":
+					return { name: "F5 XC Context", state: "unauthenticated", hint: "network unreachable" };
+				case "url_not_found":
+					return { name: "F5 XC Context", state: "unauthenticated", hint: "tenant URL not found" };
+				default:
+					return { name: "F5 XC Context", state: "unauthenticated", hint: "run: /context" };
+			}
 	}
 }
 
@@ -376,6 +384,8 @@ export function mapGitLabStatus(status: WelcomeGitLabStatus | undefined): Servic
 			return { name: "GitLab", state: "connected" };
 		case "not_installed":
 			return { name: "GitLab", state: "unavailable", hint: "not installed" };
+		case "project_inaccessible":
+			return { name: "GitLab", state: "unauthenticated", hint: "check project access" };
 		default:
 			return { name: "GitLab", state: "unauthenticated", hint: "run: glab auth login" };
 	}
@@ -386,6 +396,10 @@ export function mapSalesforceStatus(status: WelcomeSalesforceStatus | undefined)
 	switch (status.state) {
 		case "connected":
 			return { name: "Salesforce", state: "connected" };
+		case "session_expired":
+			return { name: "Salesforce", state: "unauthenticated", hint: "session expired, run: sf org login web" };
+		case "not_configured":
+			return { name: "Salesforce", state: "unauthenticated", hint: "run: sf org login web --set-default" };
 		default:
 			return { name: "Salesforce", state: "unauthenticated", hint: "run: sf org login web" };
 	}
@@ -428,17 +442,52 @@ export function mapAzureStatus(status: WelcomeAzureStatus | undefined): ServiceS
 	}
 }
 
-export type AwsCheckState = "connected" | "auth_error";
+export type AwsCheckState =
+	| "connected"
+	| "sso_expired"
+	| "not_configured"
+	| "profile_not_found"
+	| "network_error"
+	| "auth_error";
 
 export interface WelcomeAwsStatus {
 	state: AwsCheckState;
+}
+
+/** Classify AWS CLI stderr into a specific failure state. Exported for testing. */
+export function classifyAwsError(stderr: string): AwsCheckState {
+	const s = stderr.toLowerCase();
+	// SSO session/token expiry
+	if (
+		s.includes("sso session") ||
+		s.includes("sso token") ||
+		s.includes("expiredtokenexception") ||
+		s.includes("expiredtoken")
+	) {
+		return "sso_expired";
+	}
+	// No credentials configured at all
+	if (s.includes("unable to locate credentials")) {
+		return "not_configured";
+	}
+	// AWS_PROFILE points to a non-existent profile
+	if (s.includes("config profile") && s.includes("could not be found")) {
+		return "profile_not_found";
+	}
+	// Network/connectivity errors
+	if (s.includes("could not connect") || s.includes("connection error") || s.includes("endpoint url")) {
+		return "network_error";
+	}
+	return "auth_error";
 }
 
 export async function checkAwsStatus(): Promise<WelcomeAwsStatus | undefined> {
 	try {
 		if (!$which("aws")) return undefined;
 		const result = await $`aws sts get-caller-identity --output json`.quiet().nothrow();
-		return { state: result.exitCode === 0 ? "connected" : "auth_error" };
+		if (result.exitCode === 0) return { state: "connected" };
+		const stderr = result.stderr.toString();
+		return { state: classifyAwsError(stderr) };
 	} catch (err) {
 		logger.warn("AWS startup check failed", { error: String(err) });
 		return { state: "auth_error" };
@@ -450,23 +499,43 @@ export function mapAwsStatus(status: WelcomeAwsStatus | undefined): ServiceStatu
 	switch (status.state) {
 		case "connected":
 			return { name: "AWS", state: "connected" };
+		case "sso_expired":
+			return { name: "AWS", state: "unauthenticated", hint: "SSO session expired, run: aws sso login" };
+		case "not_configured":
+			return { name: "AWS", state: "unauthenticated", hint: "run: aws configure" };
+		case "profile_not_found":
+			return { name: "AWS", state: "unauthenticated", hint: "check AWS_PROFILE env var" };
+		case "network_error":
+			return { name: "AWS", state: "unauthenticated", hint: "network unreachable" };
 		case "auth_error":
 			return { name: "AWS", state: "unauthenticated", hint: "run: aws configure" };
 	}
 }
 
-export type GcloudCheckState = "connected" | "auth_error";
+export type GcloudCheckState = "connected" | "token_expired" | "auth_error";
 
 export interface WelcomeGcloudStatus {
 	state: GcloudCheckState;
 }
 
+/** Classify gcloud stderr into a specific failure state. Exported for testing. */
+export function classifyGcloudError(stderr: string): GcloudCheckState {
+	const s = stderr.toLowerCase();
+	if (s.includes("valid credentials") || s.includes("refreshing your current auth tokens")) {
+		return "token_expired";
+	}
+	return "auth_error";
+}
+
 export async function checkGcloudStatus(): Promise<WelcomeGcloudStatus | undefined> {
 	try {
 		if (!$which("gcloud")) return undefined;
-		const result = await $`gcloud auth list --format=value(account)`.quiet().nothrow();
-		const hasAccount = result.text().trim().length > 0;
-		return { state: hasAccount ? "connected" : "auth_error" };
+		const result = await $`gcloud auth print-access-token --quiet`.quiet().nothrow();
+		if (result.exitCode === 0 && result.text().trim().length > 0) {
+			return { state: "connected" };
+		}
+		const stderr = result.stderr.toString();
+		return { state: classifyGcloudError(stderr) };
 	} catch (err) {
 		logger.warn("Google Cloud startup check failed", { error: String(err) });
 		return { state: "auth_error" };
@@ -478,6 +547,8 @@ export function mapGcloudStatus(status: WelcomeGcloudStatus | undefined): Servic
 	switch (status.state) {
 		case "connected":
 			return { name: "Google Cloud", state: "connected" };
+		case "token_expired":
+			return { name: "Google Cloud", state: "unauthenticated", hint: "token expired, run: gcloud auth login" };
 		case "auth_error":
 			return { name: "Google Cloud", state: "unauthenticated", hint: "run: gcloud auth login" };
 	}

--- a/packages/coding-agent/test/welcome-service-mappers.test.ts
+++ b/packages/coding-agent/test/welcome-service-mappers.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
+	classifyAwsError,
+	classifyGcloudError,
 	mapAwsStatus,
 	mapAzureStatus,
 	mapContextStatus,
@@ -27,7 +29,17 @@ describe("mapContextStatus", () => {
 		expect(r.state).toBe("unauthenticated");
 		expect(r.hint).toContain("/context");
 	});
-	it("offline → unauthenticated with /context hint", () => {
+	it("offline with network errorClass → hint mentions connectivity", () => {
+		const r = mapContextStatus({ state: "offline", name: "prod", errorClass: "network" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("network");
+	});
+	it("offline with url_not_found errorClass → hint mentions URL", () => {
+		const r = mapContextStatus({ state: "offline", name: "prod", errorClass: "url_not_found" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("URL");
+	});
+	it("offline without errorClass → generic /context hint", () => {
 		const r = mapContextStatus({ state: "offline", name: "prod" });
 		expect(r.state).toBe("unauthenticated");
 		expect(r.hint).toContain("/context");
@@ -56,10 +68,11 @@ describe("mapGitLabStatus", () => {
 		expect(r.state).toBe("unauthenticated");
 		expect(r.hint).toContain("glab auth login");
 	});
-	it("project_inaccessible → unauthenticated with glab hint", () => {
+	it("project_inaccessible → unauthenticated with project access hint", () => {
 		const r = mapGitLabStatus({ state: "project_inaccessible", project: "g/r" });
 		expect(r.state).toBe("unauthenticated");
-		expect(r.hint).toContain("glab auth login");
+		expect(r.hint).not.toContain("glab auth login");
+		expect(r.hint).toContain("project");
 	});
 });
 
@@ -80,9 +93,10 @@ describe("mapSalesforceStatus", () => {
 		expect(r.state).toBe("unauthenticated");
 		expect(r.hint).toContain("sf org login web");
 	});
-	it("session_expired → unauthenticated with sf hint", () => {
+	it("session_expired → unauthenticated with 'session expired' wording", () => {
 		const r = mapSalesforceStatus({ state: "session_expired", orgAlias: "SFDC" });
 		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("session expired");
 		expect(r.hint).toContain("sf org login web");
 	});
 	it("not_configured → unauthenticated with sf hint", () => {
@@ -142,10 +156,30 @@ describe("mapAwsStatus", () => {
 		expect(r.state).toBe("connected");
 		expect(r.hint).toBeUndefined();
 	});
-	it("auth_error → unauthenticated with aws configure hint", () => {
+	it("sso_expired → unauthenticated with 'aws sso login' hint", () => {
+		const r = mapAwsStatus({ state: "sso_expired" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("aws sso login");
+	});
+	it("not_configured → unauthenticated with 'aws configure' hint", () => {
+		const r = mapAwsStatus({ state: "not_configured" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("aws configure");
+	});
+	it("profile_not_found → unauthenticated with profile hint", () => {
+		const r = mapAwsStatus({ state: "profile_not_found" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("AWS_PROFILE");
+	});
+	it("auth_error (generic fallback) → unauthenticated with 'aws configure' hint", () => {
 		const r = mapAwsStatus({ state: "auth_error" });
 		expect(r.state).toBe("unauthenticated");
 		expect(r.hint).toContain("aws configure");
+	});
+	it("network_error → unauthenticated with connectivity hint", () => {
+		const r = mapAwsStatus({ state: "network_error" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("network");
 	});
 });
 
@@ -165,5 +199,68 @@ describe("mapGcloudStatus", () => {
 		const r = mapGcloudStatus({ state: "auth_error" });
 		expect(r.state).toBe("unauthenticated");
 		expect(r.hint).toContain("gcloud auth login");
+	});
+	it("token_expired → unauthenticated with 'gcloud auth login' hint and expiry wording", () => {
+		const r = mapGcloudStatus({ state: "token_expired" });
+		expect(r.state).toBe("unauthenticated");
+		expect(r.hint).toContain("expired");
+		expect(r.hint).toContain("gcloud auth login");
+	});
+});
+
+describe("classifyAwsError", () => {
+	it("detects SSO token expiry", () => {
+		expect(classifyAwsError("The SSO session associated with this profile has expired")).toBe("sso_expired");
+	});
+	it("detects SSO token missing", () => {
+		expect(classifyAwsError("Error loading SSO Token: Token for Users-280469140135 does not exist")).toBe(
+			"sso_expired",
+		);
+	});
+	it("detects ExpiredTokenException", () => {
+		expect(
+			classifyAwsError("An error occurred (ExpiredTokenException) when calling the GetCallerIdentity operation"),
+		).toBe("sso_expired");
+	});
+	it("detects ExpiredToken", () => {
+		expect(classifyAwsError("An error occurred (ExpiredToken) when calling the GetCallerIdentity operation")).toBe(
+			"sso_expired",
+		);
+	});
+	it("detects no credentials", () => {
+		expect(classifyAwsError("Unable to locate credentials")).toBe("not_configured");
+	});
+	it("detects profile not found", () => {
+		expect(classifyAwsError("The config profile (Users-280469140135) could not be found")).toBe("profile_not_found");
+	});
+	it("detects InvalidClientTokenId", () => {
+		expect(
+			classifyAwsError("An error occurred (InvalidClientTokenId) when calling the GetCallerIdentity operation"),
+		).toBe("auth_error");
+	});
+	it("detects network/connection errors", () => {
+		expect(classifyAwsError("Could not connect to the endpoint URL")).toBe("network_error");
+	});
+	it("returns auth_error for unknown errors", () => {
+		expect(classifyAwsError("something completely unexpected")).toBe("auth_error");
+	});
+});
+
+describe("classifyGcloudError", () => {
+	it("detects expired credentials", () => {
+		expect(classifyGcloudError("does not have any valid credentials")).toBe("token_expired");
+	});
+	it("detects token refresh failure", () => {
+		expect(
+			classifyGcloudError(
+				"ERROR: (gcloud.auth.print-access-token) There was a problem refreshing your current auth tokens",
+			),
+		).toBe("token_expired");
+	});
+	it("returns auth_error for no account", () => {
+		expect(classifyGcloudError("You do not currently have an active account selected")).toBe("auth_error");
+	});
+	it("returns auth_error for unknown errors", () => {
+		expect(classifyGcloudError("something unknown")).toBe("auth_error");
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the welcome banner cloud provider auth checks to give users the correct remediation hints instead of generic/wrong suggestions.

**Closes #825**

## Changes

### AWS (critical fix)
- Parse stderr from `aws sts get-caller-identity` to classify failures into 6 states: `connected`, `sso_expired`, `not_configured`, `profile_not_found`, `network_error`, `auth_error`
- SSO token expiry now correctly suggests `aws sso login` instead of `aws configure`
- Bad `AWS_PROFILE` now suggests checking the env var
- Network errors identified as connectivity issues, not auth problems

### Google Cloud (false positive fix)
- Replaced `gcloud auth list` (only checks if accounts exist in credential store) with `gcloud auth print-access-token --quiet` (actually validates and refreshes tokens)
- Added `token_expired` state with explicit hint

### F5 XC Context
- `offline` state now surfaces `errorClass` (`network` / `url_not_found`) in hints instead of generic `/context` suggestion

### GitLab
- `project_inaccessible` now gets "check project access" hint instead of suggesting re-login (user is already authenticated)

### Salesforce
- `session_expired` now includes explicit "session expired" wording so user knows config is fine
- `not_configured` now hints `sf org login web --set-default`

## Validation

- 46 tests pass (up from 26 baseline)
- `classifyAwsError` and `classifyGcloudError` tested against real CLI error output patterns
- Verified stderr capture works through Bun shell (`.quiet().nothrow()`)
- `bun check:ts`: 0 errors
- Tested against real AWS SSO config, Azure, GCloud environments