### PR TITLE
fix: resolve pre-existing lint warning and add changelog for release

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Welcome banner cloud provider hints: AWS SSO token expiry now correctly suggests `aws sso login` instead of `aws configure`; Google Cloud check replaced `gcloud auth list` (false positives on expired tokens) with `gcloud auth print-access-token`; F5 XC Context surfaces `errorClass` (network/URL) in hints; GitLab `project_inaccessible` gets its own hint; Salesforce differentiates `session_expired` and `not_configured` hints ([#825](https://github.com/f5xc-salesdemos/xcsh/issues/825))
+
 ## [18.64.0] - 2026-05-13
 
 ### Added

--- a/packages/coding-agent/test/xcsh-api-tool.test.ts
+++ b/packages/coding-agent/test/xcsh-api-tool.test.ts
@@ -294,10 +294,10 @@ describe("XcshApiTool", () => {
 	});
 
 	it("includes resolvedPayload in details for POST with payload", async () => {
-		let capturedBody: string | null = null;
+		let _capturedBody: string | null = null;
 		const originalFetch = globalThis.fetch;
 		globalThis.fetch = (async (_input: any, init?: any) => {
-			capturedBody = init?.body ?? null;
+			_capturedBody = init?.body ?? null;
 			return new Response(JSON.stringify({ metadata: { name: "test" } }), { status: 200 });
 		}) as typeof fetch;
 		const originalUrl = process.env.F5XC_API_URL;


### PR DESCRIPTION
## Summary

Closes #829

- Fix pre-existing `noUnusedVariables` warning in `xcsh-api-tool.test.ts` (unused `capturedBody` variable prefixed with `_`)
- Add changelog entry under `[Unreleased]` for #825 welcome banner provider hints fix to trigger version bump on release

## Validation

- `bun check:ts`: 0 errors, 0 fixable warnings (2 remaining are generated file size warnings)
- `bun test xcsh-api-tool.test.ts`: 15/15 pass