### PR TITLE
fix(tui): use dim border for error state on all tool calls

### DIFF
--- a/packages/coding-agent/src/tools/xcsh-api-renderer.ts
+++ b/packages/coding-agent/src/tools/xcsh-api-renderer.ts
@@ -4,7 +4,7 @@ import { Text } from "@f5xc-salesdemos/pi-tui";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme, ThemeColor } from "../modes/theme/theme";
 import { highlightCode } from "../modes/theme/theme";
-import { CachedOutputBlock, renderStatusLine } from "../tui";
+import { CachedOutputBlock, F5_TOOL_BORDER_COLOR, renderStatusLine } from "../tui";
 import { formatErrorMessage, replaceTabs } from "./render-utils";
 import type { XcshApiToolDetails } from "./xcsh-api";
 
@@ -209,7 +209,7 @@ export const xcshApiToolRenderer = {
 				render(width: number): string[] {
 					const state = options.isPartial ? "pending" : "success";
 					return batchBlock.render(
-						{ header: batchHeader, state, sections: batchSections, width, borderColor: "border" },
+						{ header: batchHeader, state, sections: batchSections, width, borderColor: F5_TOOL_BORDER_COLOR },
 						uiTheme,
 					);
 				},
@@ -383,7 +383,10 @@ export const xcshApiToolRenderer = {
 		return {
 			render(width: number): string[] {
 				const state = options.isPartial ? "pending" : isError ? "error" : "success";
-				return outputBlock.render({ header, state, sections, width, borderColor: "border" }, uiTheme);
+				return outputBlock.render(
+					{ header, state, sections, width, borderColor: isError ? undefined : F5_TOOL_BORDER_COLOR },
+					uiTheme,
+				);
 			},
 			invalidate() {
 				outputBlock.invalidate();

--- a/packages/coding-agent/src/tui/output-block.ts
+++ b/packages/coding-agent/src/tui/output-block.ts
@@ -8,6 +8,12 @@ import type { State } from "./types";
 import type { RenderCache } from "./utils";
 import { getStateBgColor, Hasher, padToWidth, truncateToWidth } from "./utils";
 
+/**
+ * Border color override for F5-branded tool renderers.
+ * Pass as `borderColor` in OutputBlockOptions to apply F5 red framing regardless of tool state.
+ */
+export const F5_TOOL_BORDER_COLOR: ThemeColor = "border";
+
 export interface OutputBlockOptions {
 	header?: string;
 	headerMeta?: string;
@@ -33,17 +39,12 @@ export function renderOutputBlock(options: OutputBlockOptions, theme: Theme): st
 	const v = theme.boxSharp.vertical;
 	const cap = h.repeat(3);
 	const lineWidth = Math.max(0, width);
-	// Border colors: running/pending use accent, success uses dim (gray), error/warning keep their colors.
-	// borderColorOverride (from options) takes precedence for branded core tools (e.g. XC-API).
+	// Border colors: running/pending use accent, everything else uses dim (gray).
+	// Error state uses dim — the red toolErrorBg background is the error signal; no red border on generic tools.
+	// borderColorOverride (from options) takes precedence for F5-branded tools (e.g. XC-API); use F5_TOOL_BORDER_COLOR.
 	const resolvedBorderColor: ThemeColor =
 		borderColorOverride ??
-		(state === "error"
-			? "error"
-			: state === "warning"
-				? "warning"
-				: state === "running" || state === "pending"
-					? "spinnerAccent"
-					: "dim");
+		(state === "warning" ? "warning" : state === "running" || state === "pending" ? "spinnerAccent" : "dim");
 	const border = (text: string) => theme.fg(resolvedBorderColor, text);
 	const bgFn = (() => {
 		if (!state || !applyBg) return undefined;


### PR DESCRIPTION
## Summary

- Use dim border for error state on all tool calls
- Reserve F5 red frame (borderColorOverride) for non-error states on branded tools only
- Provides quieter visual signal that doesn't clash with F5 brand colour

Closes #855

## Test plan

- [ ] CI checks pass
- [ ] Verify tool call error states show dim border
- [ ] Verify F5-branded tools (XC-API) show red frame on non-error states only