### PR TITLE
fix(tui): enforce error border color universally, overriding tool-specific border

### DIFF
--- a/packages/coding-agent/src/tui/output-block.ts
+++ b/packages/coding-agent/src/tui/output-block.ts
@@ -39,12 +39,14 @@ export function renderOutputBlock(options: OutputBlockOptions, theme: Theme): st
 	const v = theme.boxSharp.vertical;
 	const cap = h.repeat(3);
 	const lineWidth = Math.max(0, width);
-	// Border colors: running/pending use accent, everything else uses dim (gray).
-	// Error state uses dim — the red toolErrorBg background is the error signal; no red border on generic tools.
-	// borderColorOverride (from options) takes precedence for F5-branded tools (e.g. XC-API); use F5_TOOL_BORDER_COLOR.
+	// Border colors: error→error (red), warning→warning, running/pending→spinnerAccent, success→dim.
+	// borderColorOverride (from options) takes precedence for non-error states on F5-branded tools (e.g. XC-API);
+	// override is always cleared on error so all tools show a consistent error border; use F5_TOOL_BORDER_COLOR.
 	const resolvedBorderColor: ThemeColor =
-		borderColorOverride ??
-		(state === "warning" ? "warning" : state === "running" || state === "pending" ? "spinnerAccent" : "dim");
+		state === "error"
+			? "error"
+			: (borderColorOverride ??
+				(state === "warning" ? "warning" : state === "running" || state === "pending" ? "spinnerAccent" : "dim"));
 	const border = (text: string) => theme.fg(resolvedBorderColor, text);
 	const bgFn = (() => {
 		if (!state || !applyBg) return undefined;


### PR DESCRIPTION
## What

Move the error state check before `borderColorOverride` in the `resolvedBorderColor` resolution chain.

## Why

Currently, tools with a custom `borderColorOverride` (such as F5-branded tools using `F5_TOOL_BORDER_COLOR`) retain their branded border color even when in an error state. This creates inconsistent error signaling across the TUI.

After this change, all tools — including F5-branded tools — display the standard error border color (`alertRed` via `ThemeColor.error`) when in an error state. The red background tint (`toolErrorBg`) plus red border together provide consistent error signaling. F5 branding only applies in non-error states.

Closes #858

## Testing

- Visual inspection: F5-branded tool in error state now shows red border instead of branded color
- Non-error states retain expected border colors (branded, warning, running/pending, success)

---

- [x] `bun run check` passes (pre-commit hooks passed)
- [x] Issue linked via `Closes #858`