### PR TITLE
feat(sf-renderer): add TUI renderer for Salesforce tools with full XC-API visual parity

### DIFF
--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -625,3 +625,44 @@ export function formatParseErrors(errors: string[]): string[] {
 			: "Parse issues:";
 	return [header, ...capped.map(err => `- ${err}`)];
 }
+
+// =============================================================================
+// JSON / Display Utilities (shared with tool renderers)
+// =============================================================================
+
+export function stripEmpty(obj: unknown): unknown {
+	if (Array.isArray(obj)) return obj.map(stripEmpty).filter(v => v != null);
+	if (obj && typeof obj === "object") {
+		const entries = Object.entries(obj as Record<string, unknown>);
+		if (entries.length === 0) return obj;
+		const out: Record<string, unknown> = {};
+		for (const [k, v] of entries) {
+			if (v == null || v === "" || (Array.isArray(v) && v.length === 0)) continue;
+			const cleaned = stripEmpty(v);
+			if (cleaned != null) out[k] = cleaned;
+		}
+		return Object.keys(out).length > 0 ? out : null;
+	}
+	return obj;
+}
+
+export function formatTimestamp(iso: string): string {
+	return iso.replace("T", " ").replace(/:\d{2}(\.\d+)?Z$/, " UTC");
+}
+
+export function addSection(
+	sections: Array<{ label?: string; lines: string[] }>,
+	label: string,
+	lines: string[],
+	theme: Theme,
+	maxLines?: number,
+): void {
+	const titled = theme.fg("toolTitle", label);
+	if (maxLines && lines.length > maxLines) {
+		const truncated = lines.slice(0, maxLines);
+		truncated.push(theme.fg("dim", `… ${lines.length - maxLines} more lines`));
+		sections.push({ label: titled, lines: truncated });
+	} else {
+		sections.push({ label: titled, lines });
+	}
+}

--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -24,6 +24,7 @@ import { notebookToolRenderer } from "./notebook";
 import { pythonToolRenderer } from "./python";
 import { resolveToolRenderer } from "./resolve";
 import { searchToolBm25Renderer } from "./search-tool-bm25";
+import { sfToolRenderer } from "./sf-renderer";
 import { sshToolRenderer } from "./ssh";
 import { todoWriteToolRenderer } from "./todo-write";
 import { writeToolRenderer } from "./write";
@@ -70,4 +71,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
 	web_search: webSearchToolRenderer as ToolRenderer,
 	write: writeToolRenderer as ToolRenderer,
 	xcsh_api: xcshApiToolRenderer as ToolRenderer,
+	sf_setup: sfToolRenderer as ToolRenderer,
+	sf_query: sfToolRenderer as ToolRenderer,
+	sf_org_display: sfToolRenderer as ToolRenderer,
 };

--- a/packages/coding-agent/src/tools/sf-renderer.ts
+++ b/packages/coding-agent/src/tools/sf-renderer.ts
@@ -1,0 +1,272 @@
+/** TUI renderer for Salesforce tools — rich visual output at full parity with XC-API. */
+import type { Component } from "@f5xc-salesdemos/pi-tui";
+import { Text } from "@f5xc-salesdemos/pi-tui";
+import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import type { Theme, ThemeColor } from "../modes/theme/theme";
+import { CachedOutputBlock, F5_TOOL_BORDER_COLOR, renderStatusLine } from "../tui";
+import { addSection, formatErrorMessage, replaceTabs } from "./render-utils";
+import type { SfErrorType, SfToolDetails } from "./sf";
+import { flattenRecord } from "./sf/formatters";
+import type { SfOrg, SfQueryResult } from "./sf/types";
+
+const TOOL_TITLE = "Salesforce";
+const MAX_COL_WIDTH = 30;
+
+type SfRenderArgs = {
+	action?: string;
+	query?: string;
+	target_org?: string;
+};
+
+const TOOL_ACTION_COLORS: Partial<Record<string, ThemeColor>> = {
+	sf_setup: "chromeAccent",
+	sf_query: "contentAccent",
+};
+
+const ERROR_GUIDANCE: Record<SfErrorType, string> = {
+	auth_required: "Authenticate with: sf org login web --set-default --alias SFDC",
+	session_expired: "Re-authenticate: sf org login web --set-default\nThen run sf_setup action 'status' to confirm",
+	no_default_org: "Run sf_setup with action set_default to choose a default org",
+	invalid_query:
+		"Check field names and object types. Use SELECT ... FROM EntityDefinition to discover available objects",
+	exec_error: "Check sf CLI is installed and configured correctly",
+};
+
+function orgStatusColor(status: string): ThemeColor {
+	const lower = status.toLowerCase();
+	if (lower === "connected") return "success";
+	if (lower.includes("expired")) return "error";
+	return "warning";
+}
+
+function truncateCell(value: string, maxWidth: number): string {
+	if (value.length <= maxWidth) return value;
+	return `${value.slice(0, maxWidth - 1)}…`;
+}
+
+function buildOrgRows(orgs: SfOrg[], uiTheme: Theme): string[] {
+	return orgs.map(org => {
+		const defaultBadge = org.isDefault ? ` ${uiTheme.fg("chromeAccent", "(default)")}` : "";
+		const aliasText = org.alias
+			? uiTheme.fg("toolOutput", org.alias) + defaultBadge
+			: uiTheme.fg("dim", "(none)") + defaultBadge;
+		const username = uiTheme.fg("dim", org.username);
+		const status = uiTheme.fg(orgStatusColor(org.connectedStatus), org.connectedStatus);
+		const sandboxBadge = org.isSandbox ? `  ${uiTheme.fg("warning", "[sandbox]")}` : "";
+		return `  ${aliasText}  ${username}  ${status}${sandboxBadge}`;
+	});
+}
+
+function buildQueryTable(queryResult: SfQueryResult, uiTheme: Theme): string[] {
+	const records = queryResult.records as Record<string, unknown>[];
+	if (records.length === 0) return [uiTheme.fg("dim", "  No records found.")];
+
+	const flatRecords = records.map(r => flattenRecord(r));
+	const allColumns = Array.from(
+		flatRecords.reduce((cols, record) => {
+			for (const key of Object.keys(record)) cols.add(key);
+			return cols;
+		}, new Set<string>()),
+	);
+
+	const colWidths = allColumns.map(col => {
+		const maxData = flatRecords.reduce((max, rec) => {
+			const val = rec[col];
+			return Math.max(max, val == null ? 0 : String(val).replace(/[\n\r\t]+/g, " ").length);
+		}, 0);
+		return Math.min(MAX_COL_WIDTH, Math.max(col.length, maxData));
+	});
+
+	const lines: string[] = [];
+
+	// Header
+	const headerCells = allColumns.map((col, i) => uiTheme.fg("toolTitle", col.padEnd(colWidths[i]!)));
+	lines.push(`  ${headerCells.join("  ")}`);
+
+	// Separator
+	const sepCells = colWidths.map(w => uiTheme.fg("dim", "─".repeat(w)));
+	lines.push(`  ${sepCells.join("  ")}`);
+
+	// Rows
+	for (const rec of flatRecords) {
+		const cells = allColumns.map((col, i) => {
+			const val = rec[col];
+			const raw = val == null ? "" : String(val).replace(/[\n\r\t]+/g, " ");
+			const cell = truncateCell(raw, colWidths[i]!).padEnd(colWidths[i]!);
+			return val == null || raw === "" ? uiTheme.fg("dim", cell) : uiTheme.fg("toolOutput", cell);
+		});
+		lines.push(`  ${cells.join("  ")}`);
+	}
+
+	return lines;
+}
+
+function buildOrgKV(org: SfOrg, uiTheme: Theme): string[] {
+	const line = (label: string, value: string, valueColor: ThemeColor = "toolOutput") =>
+		`  ${uiTheme.fg("dim", label.padEnd(10))}${uiTheme.fg(valueColor, value)}`;
+
+	const lines: string[] = [];
+	if (org.alias) lines.push(line("alias:", org.alias));
+	lines.push(line("username:", org.username));
+	lines.push(line("org id:", org.orgId));
+	lines.push(line("instance:", org.instanceUrl));
+	lines.push(line("status:", org.connectedStatus, orgStatusColor(org.connectedStatus)));
+	if (org.isSandbox) lines.push(line("type:", "Sandbox", "warning"));
+	if (org.isDefault) lines.push(line("default:", "yes", "chromeAccent"));
+	return lines;
+}
+
+export const sfToolRenderer = {
+	renderCall(args: SfRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
+		const action = args.action ?? (args.query !== undefined ? "query" : "org");
+		const text = renderStatusLine(
+			{
+				icon: "pending",
+				title: TOOL_TITLE,
+				badge: { label: action, color: args.query !== undefined ? "contentAccent" : "chromeAccent" },
+			},
+			uiTheme,
+		);
+		return new Text(text, 0, 0);
+	},
+
+	renderResult(
+		result: { content: Array<{ type: string; text?: string }>; details?: SfToolDetails; isError?: boolean },
+		options: RenderResultOptions,
+		uiTheme: Theme,
+		_args?: SfRenderArgs,
+	): Component {
+		const details = result.details;
+		const isError = result.isError === true;
+
+		// Fallback: error without structured details
+		if (isError && !details) {
+			const errorText = result.content?.find(c => c.type === "text")?.text;
+			return new Text(formatErrorMessage(errorText, uiTheme), 0, 0);
+		}
+
+		const tool = details?.tool;
+		const action = details?.action;
+		const errorType = details?.errorType;
+		const sections: Array<{ label?: string; lines: string[] }> = [];
+
+		// --- Error path ---
+		if (isError) {
+			const errorText = result.content?.find(c => c.type === "text")?.text ?? "Unknown error";
+			addSection(sections, "Error", [uiTheme.fg("error", errorText)], uiTheme);
+
+			const badgeLabel = errorType ?? "error";
+			if (errorType) {
+				const guidance = ERROR_GUIDANCE[errorType];
+				const guidanceLines = guidance.split("\n").map(l => uiTheme.fg("warning", l));
+				addSection(sections, "Guidance", guidanceLines, uiTheme);
+			}
+
+			const header = renderStatusLine(
+				{
+					title: TOOL_TITLE,
+					titleColor: "contentAccent",
+					badge: { label: badgeLabel, color: "error" },
+				},
+				uiTheme,
+			);
+			const outputBlock = new CachedOutputBlock();
+			return {
+				render(width: number): string[] {
+					return outputBlock.render({ header, state: "error", sections, width }, uiTheme);
+				},
+				invalidate() {
+					outputBlock.invalidate();
+				},
+			};
+		}
+
+		// --- Success path ---
+		let badgeLabel = action ?? tool?.replace("sf_", "") ?? "sf";
+		const badgeColor: ThemeColor = tool ? (TOOL_ACTION_COLORS[tool] ?? "muted") : "muted";
+		const meta: string[] = [];
+
+		if (tool === "sf_setup") {
+			const orgs = details?.orgs;
+			if ((action === "status" || action === "list_orgs") && orgs !== undefined) {
+				const count = orgs.length;
+				meta.push(uiTheme.fg("dim", `${count} org${count !== 1 ? "s" : ""}`));
+				if (count === 0) {
+					addSection(sections, "Orgs", [uiTheme.fg("dim", "No authenticated orgs found.")], uiTheme);
+				} else {
+					addSection(sections, "Orgs", buildOrgRows(orgs, uiTheme), uiTheme);
+				}
+			} else {
+				const text = result.content?.find(c => c.type === "text")?.text ?? "";
+				addSection(
+					sections,
+					"Result",
+					text.split("\n").map(line => replaceTabs(uiTheme.fg("toolOutput", line))),
+					uiTheme,
+				);
+			}
+		} else if (tool === "sf_query") {
+			const queryResult = details?.queryResult;
+			if (queryResult) {
+				const count = queryResult.totalSize;
+				badgeLabel = "query";
+				meta.push(uiTheme.fg("dim", `${count} record${count !== 1 ? "s" : ""}`));
+				addSection(
+					sections,
+					`Results (${count} record${count !== 1 ? "s" : ""})`,
+					buildQueryTable(queryResult, uiTheme),
+					uiTheme,
+				);
+				if (!queryResult.done) {
+					addSection(
+						sections,
+						"Warning",
+						[uiTheme.fg("warning", "Results are incomplete. Use sf data export bulk for the full dataset.")],
+						uiTheme,
+					);
+				}
+			} else {
+				const text = result.content?.find(c => c.type === "text")?.text ?? "";
+				addSection(sections, "Result", [uiTheme.fg("toolOutput", text)], uiTheme);
+			}
+		} else if (tool === "sf_org_display") {
+			const org = details?.orgs?.[0];
+			if (org) {
+				badgeLabel = "org";
+				meta.push(uiTheme.fg("muted", org.alias ?? org.username));
+				meta.push(uiTheme.fg(orgStatusColor(org.connectedStatus), org.connectedStatus));
+				addSection(sections, "Summary", buildOrgKV(org, uiTheme), uiTheme);
+			} else {
+				const text = result.content?.find(c => c.type === "text")?.text ?? "";
+				addSection(sections, "Result", [uiTheme.fg("toolOutput", text)], uiTheme);
+			}
+		} else {
+			const text = result.content?.find(c => c.type === "text")?.text ?? "";
+			addSection(sections, "Result", [uiTheme.fg("toolOutput", text)], uiTheme);
+		}
+
+		const header = renderStatusLine(
+			{
+				title: TOOL_TITLE,
+				titleColor: "contentAccent",
+				badge: { label: badgeLabel, color: badgeColor },
+				meta: meta.length > 0 ? meta : undefined,
+			},
+			uiTheme,
+		);
+
+		const outputBlock = new CachedOutputBlock();
+		return {
+			render(width: number): string[] {
+				const state = options.isPartial ? "pending" : "success";
+				return outputBlock.render({ header, state, sections, width, borderColor: F5_TOOL_BORDER_COLOR }, uiTheme);
+			},
+			invalidate() {
+				outputBlock.invalidate();
+			},
+		};
+	},
+
+	mergeCallAndResult: true,
+	inline: true,
+};

--- a/packages/coding-agent/src/tools/sf.ts
+++ b/packages/coding-agent/src/tools/sf.ts
@@ -12,7 +12,14 @@ import sfQueryDescription from "../prompts/tools/sf-query.md" with { type: "text
 import sfSetupDescription from "../prompts/tools/sf-setup.md" with { type: "text" };
 import type { ToolSession } from ".";
 import type { SfExecApi } from "./sf/exec";
-import { execSfJson, execSfRaw } from "./sf/exec";
+import {
+	execSfJson,
+	execSfRaw,
+	SfAuthError,
+	SfNoDefaultOrgError,
+	SfQueryError,
+	SfSessionExpiredError,
+} from "./sf/exec";
 import { formatOrgDetail, formatOrgTable, formatQueryResults } from "./sf/formatters";
 import type { SfOrg, SfQueryResult, SfRawResult } from "./sf/types";
 import { ORG_ALIAS_PATTERN } from "./sf/types";
@@ -80,13 +87,30 @@ type SfSetupInput = Static<typeof sfSetupSchema>;
 type SfQueryInput = Static<typeof sfQuerySchema>;
 type SfOrgDisplayInput = Static<typeof sfOrgDisplaySchema>;
 
-interface SfToolDetails {
+export type SfErrorType = "auth_required" | "session_expired" | "no_default_org" | "invalid_query" | "exec_error";
+
+export interface SfToolDetails {
+	tool: "sf_setup" | "sf_query" | "sf_org_display";
+	action?: string;
 	orgs?: SfOrg[];
 	queryResult?: SfQueryResult;
+	errorType?: SfErrorType;
 }
 
-function textResult(text: string, details?: SfToolDetails): AgentToolResult<SfToolDetails> {
+function textResult(text: string, details: SfToolDetails): AgentToolResult<SfToolDetails> {
 	return { content: [{ type: "text", text }], details };
+}
+
+function errorResult(text: string, details: SfToolDetails): AgentToolResult<SfToolDetails> {
+	return { content: [{ type: "text", text }], isError: true, details };
+}
+
+function detectErrorType(err: unknown): SfErrorType {
+	if (err instanceof SfAuthError) return "auth_required";
+	if (err instanceof SfSessionExpiredError) return "session_expired";
+	if (err instanceof SfNoDefaultOrgError) return "no_default_org";
+	if (err instanceof SfQueryError) return "invalid_query";
+	return "exec_error";
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
@@ -152,63 +176,74 @@ export class SfSetupTool implements AgentTool<typeof sfSetupSchema, SfToolDetail
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<SfToolDetails>> {
 		const api = this.#testApi ?? makeExecApi(this.session.cwd);
+		const base = { tool: "sf_setup" as const, action: params.action };
 
-		switch (params.action) {
-			case "check": {
-				const result = await execSfRaw(api, ["--version"], signal);
-				return textResult(`sf is installed: ${result.stdout}`);
-			}
-
-			case "status": {
-				const orgResult = await execSfJson(api, ["org", "list"], signal);
-				const allOrgs = collectAllOrgs(orgResult.result as Record<string, unknown[]>);
-				let output = formatOrgTable(allOrgs);
-
-				const userProfile = await loadProfile();
-				if (userProfile.givenName || userProfile.familyName) {
-					const name = [userProfile.givenName, userProfile.familyName].filter(Boolean).join(" ");
-					output += `\n\nUser profile: **${name}** (${userProfile.email ?? "no email"})`;
+		try {
+			switch (params.action) {
+				case "check": {
+					const result = await execSfRaw(api, ["--version"], signal);
+					return textResult(`sf is installed: ${result.stdout}`, base);
 				}
 
-				return textResult(output, { orgs: allOrgs });
-			}
+				case "status": {
+					const orgResult = await execSfJson(api, ["org", "list"], signal);
+					const allOrgs = collectAllOrgs(orgResult.result as Record<string, unknown[]>);
+					let output = formatOrgTable(allOrgs);
 
-			case "login": {
-				const orgResult = await execSfJson(api, ["org", "list"], signal);
-				const allOrgs = collectAllOrgs(orgResult.result as Record<string, unknown[]>);
-				if (allOrgs.length > 0) {
-					return textResult("Already authenticated. Use 'status' action to see your orgs and profile.", {
-						orgs: allOrgs,
-					});
+					const userProfile = await loadProfile();
+					if (userProfile.givenName || userProfile.familyName) {
+						const name = [userProfile.givenName, userProfile.familyName].filter(Boolean).join(" ");
+						output += `\n\nUser profile: **${name}** (${userProfile.email ?? "no email"})`;
+					}
+
+					return textResult(output, { ...base, orgs: allOrgs });
 				}
-				return textResult(
-					"No authenticated orgs found.\n\nRun one of these commands to authenticate:\n" +
-						"- **Workstation**: `sf org login web --set-default --alias SFDC`\n" +
-						'- **Container**: `echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-stdin=- --set-default --alias f5`\n\n' +
-						"After authenticating, call sf_setup with action 'status' to confirm.",
-				);
-			}
 
-			case "list_orgs": {
-				const orgResult = await execSfJson(api, ["org", "list"], signal);
-				const allOrgs = collectAllOrgs(orgResult.result as Record<string, unknown[]>);
-				return textResult(formatOrgTable(allOrgs), { orgs: allOrgs });
-			}
-
-			case "set_default": {
-				if (!params.org) {
-					return textResult("Error: org parameter is required for set_default action.");
-				}
-				if (!ORG_ALIAS_PATTERN.test(params.org)) {
+				case "login": {
+					const orgResult = await execSfJson(api, ["org", "list"], signal);
+					const allOrgs = collectAllOrgs(orgResult.result as Record<string, unknown[]>);
+					if (allOrgs.length > 0) {
+						return textResult("Already authenticated. Use 'status' action to see your orgs and profile.", {
+							...base,
+							orgs: allOrgs,
+						});
+					}
 					return textResult(
-						`Error: invalid org alias "${params.org}". Only alphanumeric characters, dots, underscores, hyphens, and @ are allowed.`,
+						"No authenticated orgs found.\n\nRun one of these commands to authenticate:\n" +
+							"- **Workstation**: `sf org login web --set-default --alias SFDC`\n" +
+							'- **Container**: `echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-stdin=- --set-default --alias f5`\n\n' +
+							"After authenticating, call sf_setup with action 'status' to confirm.",
+						base,
 					);
 				}
-				await execSfRaw(api, ["config", "set", "target-org", params.org, "--global"], signal);
-				return textResult(`Default org set to: **${params.org}**`);
+
+				case "list_orgs": {
+					const orgResult = await execSfJson(api, ["org", "list"], signal);
+					const allOrgs = collectAllOrgs(orgResult.result as Record<string, unknown[]>);
+					return textResult(formatOrgTable(allOrgs), { ...base, orgs: allOrgs });
+				}
+
+				case "set_default": {
+					if (!params.org) {
+						return errorResult("Error: org parameter is required for set_default action.", base);
+					}
+					if (!ORG_ALIAS_PATTERN.test(params.org)) {
+						return errorResult(
+							`Error: invalid org alias "${params.org}". Only alphanumeric characters, dots, underscores, hyphens, and @ are allowed.`,
+							base,
+						);
+					}
+					await execSfRaw(api, ["config", "set", "target-org", params.org, "--global"], signal);
+					return textResult(`Default org set to: **${params.org}**`, base);
+				}
+
+				default:
+					return textResult(`Unknown action: ${params.action}`, base);
 			}
-			default:
-				return textResult(`Unknown action: ${params.action}`);
+		} catch (err) {
+			const errorType = detectErrorType(err);
+			const message = err instanceof Error ? err.message : String(err);
+			return errorResult(message, { ...base, errorType });
 		}
 	}
 }
@@ -242,39 +277,40 @@ export class SfQueryTool implements AgentTool<typeof sfQuerySchema, SfToolDetail
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<SfToolDetails>> {
 		const api = this.#testApi ?? makeExecApi(this.session.cwd);
+		const base = { tool: "sf_query" as const, action: "query" };
 
 		if (params.target_org && !ORG_ALIAS_PATTERN.test(params.target_org)) {
-			return textResult(
+			return errorResult(
 				`Error: invalid org alias "${params.target_org}". Only alphanumeric characters, dots, underscores, hyphens, and @ are allowed.`,
+				base,
 			);
 		}
 
 		const args = ["data", "query", "--query", params.query];
-		if (params.target_org) {
-			args.push("--target-org", params.target_org);
-		}
-		if (params.use_tooling_api) {
-			args.push("--use-tooling-api");
-		}
-		if (params.all_rows) {
-			args.push("--all-rows");
-		}
+		if (params.target_org) args.push("--target-org", params.target_org);
+		if (params.use_tooling_api) args.push("--use-tooling-api");
+		if (params.all_rows) args.push("--all-rows");
 
-		const result = await execSfJson(api, args, signal, params.query);
-		const queryData = result.result as SfQueryResult<Record<string, unknown>>;
+		try {
+			const result = await execSfJson(api, args, signal, params.query);
+			const queryData = result.result as SfQueryResult<Record<string, unknown>>;
+			const queryResult: SfQueryResult = {
+				totalSize: queryData.totalSize ?? 0,
+				done: queryData.done ?? true,
+				records: queryData.records ?? [],
+			};
 
-		const queryResult: SfQueryResult = {
-			totalSize: queryData.totalSize ?? 0,
-			done: queryData.done ?? true,
-			records: queryData.records ?? [],
-		};
-
-		let output = formatQueryResults(queryResult);
-		if (!queryResult.done) {
-			output +=
-				"\n\n**Warning**: Results are incomplete. The query returned more records than the API limit. Use `sf data export bulk` for the full dataset.";
+			let output = formatQueryResults(queryResult);
+			if (!queryResult.done) {
+				output +=
+					"\n\n**Warning**: Results are incomplete. The query returned more records than the API limit. Use `sf data export bulk` for the full dataset.";
+			}
+			return textResult(output, { ...base, queryResult });
+		} catch (err) {
+			const errorType = detectErrorType(err);
+			const message = err instanceof Error ? err.message : String(err);
+			return errorResult(message, { ...base, errorType });
 		}
-		return textResult(output, { queryResult });
 	}
 }
 
@@ -307,32 +343,38 @@ export class SfOrgDisplayTool implements AgentTool<typeof sfOrgDisplaySchema, Sf
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<SfToolDetails>> {
 		const api = this.#testApi ?? makeExecApi(this.session.cwd);
+		const base = { tool: "sf_org_display" as const };
 
 		if (params.target_org && !ORG_ALIAS_PATTERN.test(params.target_org)) {
-			return textResult(
+			return errorResult(
 				`Error: invalid org alias "${params.target_org}". Only alphanumeric characters, dots, underscores, hyphens, and @ are allowed.`,
+				base,
 			);
 		}
 
 		const args = ["org", "display"];
-		if (params.target_org) {
-			args.push("--target-org", params.target_org);
+		if (params.target_org) args.push("--target-org", params.target_org);
+
+		try {
+			const result = await execSfJson(api, args, signal);
+			const raw = result.result as Record<string, unknown>;
+
+			// SECURITY: only extract whitelisted fields
+			const org: SfOrg = {
+				username: String(raw.username ?? ""),
+				orgId: String(raw.id ?? raw.orgId ?? ""),
+				instanceUrl: String(raw.instanceUrl ?? ""),
+				connectedStatus: String(raw.connectedStatus ?? "Connected"),
+				alias: raw.alias ? String(raw.alias) : undefined,
+				isDefault: false,
+				isSandbox: Boolean(raw.isSandbox ?? false),
+			};
+
+			return textResult(formatOrgDetail(org), { ...base, orgs: [org] });
+		} catch (err) {
+			const errorType = detectErrorType(err);
+			const message = err instanceof Error ? err.message : String(err);
+			return errorResult(message, { ...base, errorType });
 		}
-
-		const result = await execSfJson(api, args, signal);
-		const raw = result.result as Record<string, unknown>;
-
-		// SECURITY: only extract whitelisted fields
-		const org: SfOrg = {
-			username: String(raw.username ?? ""),
-			orgId: String(raw.id ?? raw.orgId ?? ""),
-			instanceUrl: String(raw.instanceUrl ?? ""),
-			connectedStatus: String(raw.connectedStatus ?? "Connected"),
-			alias: raw.alias ? String(raw.alias) : undefined,
-			isDefault: false,
-			isSandbox: Boolean(raw.isSandbox ?? false),
-		};
-
-		return textResult(formatOrgDetail(org), { orgs: [org] });
 	}
 }

--- a/packages/coding-agent/src/tools/sf.ts
+++ b/packages/coding-agent/src/tools/sf.ts
@@ -97,11 +97,13 @@ export interface SfToolDetails {
 	errorType?: SfErrorType;
 }
 
-function textResult(text: string, details: SfToolDetails): AgentToolResult<SfToolDetails> {
+type SfResult = AgentToolResult<SfToolDetails> & { isError?: boolean };
+
+function textResult(text: string, details: SfToolDetails): SfResult {
 	return { content: [{ type: "text", text }], details };
 }
 
-function errorResult(text: string, details: SfToolDetails): AgentToolResult<SfToolDetails> {
+function errorResult(text: string, details: SfToolDetails): SfResult {
 	return { content: [{ type: "text", text }], isError: true, details };
 }
 
@@ -174,7 +176,7 @@ export class SfSetupTool implements AgentTool<typeof sfSetupSchema, SfToolDetail
 		signal?: AbortSignal,
 		_onUpdate?: AgentToolUpdateCallback<SfToolDetails>,
 		_context?: AgentToolContext,
-	): Promise<AgentToolResult<SfToolDetails>> {
+	): Promise<SfResult> {
 		const api = this.#testApi ?? makeExecApi(this.session.cwd);
 		const base = { tool: "sf_setup" as const, action: params.action };
 
@@ -275,7 +277,7 @@ export class SfQueryTool implements AgentTool<typeof sfQuerySchema, SfToolDetail
 		signal?: AbortSignal,
 		_onUpdate?: AgentToolUpdateCallback<SfToolDetails>,
 		_context?: AgentToolContext,
-	): Promise<AgentToolResult<SfToolDetails>> {
+	): Promise<SfResult> {
 		const api = this.#testApi ?? makeExecApi(this.session.cwd);
 		const base = { tool: "sf_query" as const, action: "query" };
 
@@ -341,7 +343,7 @@ export class SfOrgDisplayTool implements AgentTool<typeof sfOrgDisplaySchema, Sf
 		signal?: AbortSignal,
 		_onUpdate?: AgentToolUpdateCallback<SfToolDetails>,
 		_context?: AgentToolContext,
-	): Promise<AgentToolResult<SfToolDetails>> {
+	): Promise<SfResult> {
 		const api = this.#testApi ?? makeExecApi(this.session.cwd);
 		const base = { tool: "sf_org_display" as const };
 

--- a/packages/coding-agent/src/tools/xcsh-api-renderer.ts
+++ b/packages/coding-agent/src/tools/xcsh-api-renderer.ts
@@ -5,7 +5,13 @@ import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme, ThemeColor } from "../modes/theme/theme";
 import { highlightCode } from "../modes/theme/theme";
 import { CachedOutputBlock, F5_TOOL_BORDER_COLOR, renderStatusLine } from "../tui";
-import { formatErrorMessage, replaceTabs } from "./render-utils";
+import {
+	formatErrorMessage,
+	formatTimestamp,
+	addSection as pushSection,
+	replaceTabs,
+	stripEmpty,
+} from "./render-utils";
 import type { XcshApiToolDetails } from "./xcsh-api";
 
 const TOOL_TITLE = "XC-API";
@@ -31,30 +37,6 @@ function statusColor(status: number): ThemeColor {
 	return status < 300 ? "success" : status < 400 ? "warning" : "error";
 }
 
-/**
- * Strip null, empty string, and empty array fields recursively.
- * Preserves empty objects `{}` — these are F5 XC protobuf oneof presence markers
- * (e.g. `use_origin_server_name: {}` means that option is selected).
- */
-function stripEmpty(obj: unknown): unknown {
-	if (Array.isArray(obj)) return obj.map(stripEmpty).filter(v => v != null);
-	if (obj && typeof obj === "object") {
-		const entries = Object.entries(obj as Record<string, unknown>);
-		// Preserve source-empty objects (F5 XC oneof presence markers)
-		if (entries.length === 0) return obj;
-		const out: Record<string, unknown> = {};
-		for (const [k, v] of entries) {
-			if (v == null || v === "" || (Array.isArray(v) && v.length === 0)) continue;
-			const cleaned = stripEmpty(v);
-			if (cleaned != null) out[k] = cleaned;
-		}
-		return Object.keys(out).length > 0 ? out : null;
-	}
-	return obj;
-}
-function formatTimestamp(iso: string): string {
-	return iso.replace("T", " ").replace(/:\d{2}(\.\d+)?Z$/, " UTC");
-}
 function stripProtobufPrefix(message: string): string {
 	return message.replace(/^ves\.io\.schema\.\S+:\s*/i, "");
 }
@@ -247,14 +229,7 @@ export const xcshApiToolRenderer = {
 		const sections: Array<{ label?: string; lines: string[] }> = [];
 
 		const addSection = (label: string, lines: string[], maxLines?: number): void => {
-			const titled = uiTheme.fg("toolTitle", label);
-			if (maxLines && lines.length > maxLines) {
-				const truncated = lines.slice(0, maxLines);
-				truncated.push(uiTheme.fg("dim", `… ${lines.length - maxLines} more lines`));
-				sections.push({ label: titled, lines: truncated });
-			} else {
-				sections.push({ label: titled, lines });
-			}
+			pushSection(sections, label, lines, uiTheme, maxLines);
 		};
 
 		// Section: Request payload — show resolved body (actual JSON sent to API)

--- a/packages/coding-agent/test/sf/tools.test.ts
+++ b/packages/coding-agent/test/sf/tools.test.ts
@@ -371,7 +371,7 @@ describe("SfQueryTool.execute()", () => {
 		const api = mockApi([{ stdout: errorPayload }]);
 		const tool = new SfQueryTool(SESSION, api);
 		const result = await tool.execute("c1", { query: "SELECT * FROM" });
-		expect(result.isError).toBe(true);
+		expect((result as any).isError).toBe(true);
 		const text = result.content[0].type === "text" ? result.content[0].text : "";
 		expect(text).toContain("MALFORMED_QUERY");
 	});

--- a/packages/coding-agent/test/sf/tools.test.ts
+++ b/packages/coding-agent/test/sf/tools.test.ts
@@ -362,15 +362,30 @@ describe("SfQueryTool.execute()", () => {
 		expect(text).toContain("invalid org alias");
 	});
 
-	it("propagates SOQL errors with query context", async () => {
-		const errorResult = JSON.stringify({
+	it("returns isError result for MALFORMED_QUERY instead of throwing", async () => {
+		const errorPayload = JSON.stringify({
 			status: 1,
 			result: null,
 			message: "MALFORMED_QUERY: unexpected token",
 		});
-		const api = mockApi([{ stdout: errorResult }]);
+		const api = mockApi([{ stdout: errorPayload }]);
 		const tool = new SfQueryTool(SESSION, api);
-		await expect(tool.execute("c1", { query: "SELECT * FROM" })).rejects.toThrow("MALFORMED_QUERY");
+		const result = await tool.execute("c1", { query: "SELECT * FROM" });
+		expect(result.isError).toBe(true);
+		const text = result.content[0].type === "text" ? result.content[0].text : "";
+		expect(text).toContain("MALFORMED_QUERY");
+	});
+
+	it("sets errorType to invalid_query for MALFORMED_QUERY", async () => {
+		const errorPayload = JSON.stringify({
+			status: 1,
+			result: null,
+			message: "MALFORMED_QUERY: unexpected token",
+		});
+		const api = mockApi([{ stdout: errorPayload }]);
+		const tool = new SfQueryTool(SESSION, api);
+		const result = await tool.execute("c1", { query: "SELECT * FROM" });
+		expect(result.details?.errorType).toBe("invalid_query");
 	});
 });
 
@@ -498,5 +513,44 @@ describe("SfSetupTool.execute() set_default", () => {
 		expect(capturedArgs).toContain("target-org");
 		expect(capturedArgs).toContain("my-prod");
 		expect(capturedArgs).toContain("--global");
+	});
+});
+
+// ─── SfToolDetails tool and action fields ────────────────────────────────────
+
+describe("SfToolDetails.tool and action fields", () => {
+	it("sf_setup status result has tool=sf_setup and action=status", async () => {
+		const orgList = JSON.stringify({
+			status: 0,
+			result: { nonScratchOrgs: [], scratchOrgs: [], sandboxes: [], devHubs: [], other: [] },
+		});
+		const api = mockApi([{ stdout: orgList }]);
+		const tool = new SfSetupTool(SESSION, api);
+		const result = await tool.execute("c1", { action: "status" });
+		expect(result.details?.tool).toBe("sf_setup");
+		expect(result.details?.action).toBe("status");
+	});
+
+	it("sf_query result has tool=sf_query and action=query", async () => {
+		const queryPayload = JSON.stringify({
+			status: 0,
+			result: { totalSize: 0, done: true, records: [] },
+		});
+		const api = mockApi([{ stdout: queryPayload }]);
+		const tool = new SfQueryTool(SESSION, api);
+		const result = await tool.execute("c1", { query: "SELECT Id FROM Account" });
+		expect(result.details?.tool).toBe("sf_query");
+		expect(result.details?.action).toBe("query");
+	});
+
+	it("sf_org_display result has tool=sf_org_display", async () => {
+		const displayPayload = JSON.stringify({
+			status: 0,
+			result: { id: "00D1", username: "u@test.com", instanceUrl: "https://x", connectedStatus: "Connected" },
+		});
+		const api = mockApi([{ stdout: displayPayload }]);
+		const tool = new SfOrgDisplayTool(SESSION, api);
+		const result = await tool.execute("c1", {});
+		expect(result.details?.tool).toBe("sf_org_display");
 	});
 });

--- a/packages/coding-agent/test/tools/render-utils-shared.test.ts
+++ b/packages/coding-agent/test/tools/render-utils-shared.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import { getThemeByName } from "../../src/modes/theme/theme";
+import { addSection, formatTimestamp, stripEmpty } from "../../src/tools/render-utils";
+
+describe("stripEmpty", () => {
+	it("removes null values from objects", () => {
+		expect(stripEmpty({ a: null, b: "value" })).toEqual({ b: "value" });
+	});
+	it("removes empty string values", () => {
+		expect(stripEmpty({ a: "", b: "value" })).toEqual({ b: "value" });
+	});
+	it("removes empty arrays", () => {
+		expect(stripEmpty({ a: [], b: [1] })).toEqual({ b: [1] });
+	});
+	it("preserves empty objects (protobuf oneof presence markers)", () => {
+		expect(stripEmpty({ a: {} })).toEqual({ a: {} });
+	});
+	it("recursively strips nested nulls", () => {
+		expect(stripEmpty({ outer: { inner: null, keep: "x" } })).toEqual({ outer: { keep: "x" } });
+	});
+	it("strips nulls from arrays", () => {
+		expect(stripEmpty([null, "a", null])).toEqual(["a"]);
+	});
+	it("returns non-object primitives unchanged", () => {
+		expect(stripEmpty("hello")).toBe("hello");
+		expect(stripEmpty(42)).toBe(42);
+	});
+	it("returns null when all fields are empty", () => {
+		expect(stripEmpty({ a: null, b: "" })).toBeNull();
+	});
+});
+
+describe("formatTimestamp", () => {
+	it("converts ISO 8601 to readable UTC format", () => {
+		expect(formatTimestamp("2026-05-18T14:32:00Z")).toBe("2026-05-18 14:32 UTC");
+	});
+	it("handles millisecond precision", () => {
+		expect(formatTimestamp("2026-05-18T14:32:00.000Z")).toBe("2026-05-18 14:32 UTC");
+	});
+});
+
+describe("addSection", () => {
+	it("appends a labeled section with lines", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const sections: Array<{ label?: string; lines: string[] }> = [];
+		addSection(sections, "Results", ["line1", "line2"], theme!);
+		expect(sections).toHaveLength(1);
+		expect(sections[0].lines).toHaveLength(2);
+		expect(sections[0].label).toBeTruthy();
+	});
+	it("truncates to maxLines and appends ellipsis line", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const sections: Array<{ label?: string; lines: string[] }> = [];
+		addSection(sections, "Section", ["a", "b", "c", "d", "e"], theme!, 3);
+		expect(sections[0].lines).toHaveLength(4);
+	});
+	it("does not truncate when lines count is within maxLines", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const sections: Array<{ label?: string; lines: string[] }> = [];
+		addSection(sections, "Section", ["a", "b"], theme!, 5);
+		expect(sections[0].lines).toHaveLength(2);
+	});
+});

--- a/packages/coding-agent/test/tools/sf-renderer.test.ts
+++ b/packages/coding-agent/test/tools/sf-renderer.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "bun:test";
+import { getThemeByName } from "../../src/modes/theme/theme";
+import type { SfToolDetails } from "../../src/tools/sf";
+import { sfToolRenderer } from "../../src/tools/sf-renderer";
+
+function stripAnsi(str: string): string {
+	return str.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+const WIDTH = 120;
+
+// ─── renderCall ──────────────────────────────────────────────────────────────
+
+describe("sfToolRenderer renderCall", () => {
+	it("shows Salesforce title and action for sf_setup", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const component = sfToolRenderer.renderCall({ action: "status" }, { expanded: false, isPartial: true }, theme!);
+		const rendered = stripAnsi(component.render(WIDTH).join("\n"));
+		expect(rendered).toContain("Salesforce");
+		expect(rendered).toContain("status");
+	});
+
+	it("shows query for sf_query renderCall", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const component = sfToolRenderer.renderCall(
+			{ query: "SELECT Id FROM Account" },
+			{ expanded: false, isPartial: true },
+			theme!,
+		);
+		const rendered = stripAnsi(component.render(WIDTH).join("\n"));
+		expect(rendered).toContain("Salesforce");
+		expect(rendered).toContain("query");
+	});
+});
+
+// ─── renderResult: sf_setup status ───────────────────────────────────────────
+
+describe("sfToolRenderer renderResult: sf_setup status", () => {
+	it("renders bordered block with Salesforce title", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const details: SfToolDetails = {
+			tool: "sf_setup",
+			action: "status",
+			orgs: [
+				{
+					alias: "f5-prod",
+					username: "user@f5.com",
+					orgId: "00D000001",
+					instanceUrl: "https://f5.salesforce.com",
+					connectedStatus: "Connected",
+					isDefault: true,
+					isSandbox: false,
+				},
+			],
+		};
+		const result = { content: [{ type: "text", text: "| f5-prod | user@f5.com |" }], details };
+		const component = sfToolRenderer.renderResult(result, { expanded: false, isPartial: false }, theme!);
+		const rendered = stripAnsi(component.render(WIDTH).join("\n"));
+		expect(rendered).toContain("Salesforce");
+		expect(rendered).toContain("status");
+		expect(rendered).toContain("f5-prod");
+		expect(rendered).toContain("user@f5.com");
+		expect(rendered).toContain("Connected");
+		expect(rendered).toContain("(default)");
+	});
+
+	it("renders sandbox badge for sandbox orgs", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const details: SfToolDetails = {
+			tool: "sf_setup",
+			action: "list_orgs",
+			orgs: [
+				{
+					alias: "sb1",
+					username: "user@f5.com.sb1",
+					orgId: "00D000002",
+					instanceUrl: "https://f5--sb1.salesforce.com",
+					connectedStatus: "Connected",
+					isDefault: false,
+					isSandbox: true,
+				},
+			],
+		};
+		const result = { content: [{ type: "text", text: "" }], details };
+		const component = sfToolRenderer.renderResult(result, { expanded: false, isPartial: false }, theme!);
+		const rendered = stripAnsi(component.render(WIDTH).join("\n"));
+		expect(rendered).toContain("sandbox");
+	});
+
+	it("renders empty org list message when no orgs", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const details: SfToolDetails = { tool: "sf_setup", action: "status", orgs: [] };
+		const result = { content: [{ type: "text", text: "No authenticated orgs found." }], details };
+		const component = sfToolRenderer.renderResult(result, { expanded: false, isPartial: false }, theme!);
+		const rendered = stripAnsi(component.render(WIDTH).join("\n"));
+		expect(rendered).toContain("No authenticated orgs");
+	});
+});
+
+// ─── renderResult: sf_query ───────────────────────────────────────────────────
+
+describe("sfToolRenderer renderResult: sf_query", () => {
+	it("renders query header with record count", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const details: SfToolDetails = {
+			tool: "sf_query",
+			action: "query",
+			queryResult: {
+				totalSize: 2,
+				done: true,
+				records: [
+					{ attributes: { type: "Account" }, Name: "Acme", Industry: "Tech" },
+					{ attributes: { type: "Account" }, Name: "Globex", Industry: "Finance" },
+				],
+			},
+		};
+		const result = {
+			content: [{ type: "text", text: "2 records returned.\n\n| Name | Industry |\n|---|\n| Acme | Tech |" }],
+			details,
+		};
+		const component = sfToolRenderer.renderResult(result, { expanded: false, isPartial: false }, theme!);
+		const rendered = stripAnsi(component.render(WIDTH).join("\n"));
+		expect(rendered).toContain("Salesforce");
+		expect(rendered).toContain("query");
+		expect(rendered).toContain("2 record");
+		expect(rendered).toContain("Acme");
+		expect(rendered).toContain("Globex");
+		expect(rendered).not.toContain("attributes");
+	});
+
+	it("shows incomplete warning when done is false", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const details: SfToolDetails = {
+			tool: "sf_query",
+			action: "query",
+			queryResult: {
+				totalSize: 50000,
+				done: false,
+				records: [{ attributes: { type: "Account" }, Name: "Partial" }],
+			},
+		};
+		const result = { content: [{ type: "text", text: "50000 records returned." }], details };
+		const component = sfToolRenderer.renderResult(result, { expanded: false, isPartial: false }, theme!);
+		const rendered = stripAnsi(component.render(WIDTH).join("\n"));
+		expect(rendered).toContain("incomplete");
+	});
+});
+
+// ─── renderResult: sf_org_display ────────────────────────────────────────────
+
+describe("sfToolRenderer renderResult: sf_org_display", () => {
+	it("renders key-value org summary", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const details: SfToolDetails = {
+			tool: "sf_org_display",
+			orgs: [
+				{
+					alias: "devSandbox",
+					username: "dev@example.com.sandbox",
+					orgId: "00Dxx0000001gER",
+					instanceUrl: "https://example.sandbox.my.salesforce.com",
+					connectedStatus: "Connected",
+					isDefault: false,
+					isSandbox: true,
+				},
+			],
+		};
+		const result = {
+			content: [{ type: "text", text: "**devSandbox**\nUsername: dev@example.com.sandbox" }],
+			details,
+		};
+		const component = sfToolRenderer.renderResult(result, { expanded: false, isPartial: false }, theme!);
+		const rendered = stripAnsi(component.render(WIDTH).join("\n"));
+		expect(rendered).toContain("devSandbox");
+		expect(rendered).toContain("dev@example.com.sandbox");
+		expect(rendered).toContain("Connected");
+		expect(rendered).toContain("Sandbox");
+	});
+});
+
+// ─── renderResult: errors ────────────────────────────────────────────────────
+
+describe("sfToolRenderer renderResult: error states", () => {
+	it("renders error block with guidance for session_expired", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const details: SfToolDetails = {
+			tool: "sf_setup",
+			action: "status",
+			errorType: "session_expired",
+		};
+		const result = {
+			content: [{ type: "text", text: "Salesforce session expired." }],
+			details,
+			isError: true,
+		};
+		const component = sfToolRenderer.renderResult(result, { expanded: false, isPartial: false }, theme!);
+		const rendered = stripAnsi(component.render(WIDTH).join("\n"));
+		expect(rendered).toContain("session_expired");
+		expect(rendered).toContain("Re-authenticate");
+	});
+
+	it("renders error block with guidance for auth_required", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const details: SfToolDetails = {
+			tool: "sf_setup",
+			action: "login",
+			errorType: "auth_required",
+		};
+		const result = {
+			content: [{ type: "text", text: "No authenticated orgs." }],
+			details,
+			isError: true,
+		};
+		const component = sfToolRenderer.renderResult(result, { expanded: false, isPartial: false }, theme!);
+		const rendered = stripAnsi(component.render(WIDTH).join("\n"));
+		expect(rendered).toContain("Authenticate");
+		expect(rendered).toContain("sf org login web");
+	});
+
+	it("renders error block with guidance for invalid_query", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const details: SfToolDetails = {
+			tool: "sf_query",
+			action: "query",
+			errorType: "invalid_query",
+		};
+		const result = {
+			content: [{ type: "text", text: "MALFORMED_QUERY: unexpected token" }],
+			details,
+			isError: true,
+		};
+		const component = sfToolRenderer.renderResult(result, { expanded: false, isPartial: false }, theme!);
+		const rendered = stripAnsi(component.render(WIDTH).join("\n"));
+		expect(rendered).toContain("invalid_query");
+		expect(rendered).toContain("EntityDefinition");
+	});
+
+	it("falls back gracefully when details is undefined on error", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const result = {
+			content: [{ type: "text", text: "Something went wrong." }],
+			isError: true,
+		};
+		const component = sfToolRenderer.renderResult(result as never, { expanded: false, isPartial: false }, theme!);
+		const rendered = stripAnsi(component.render(WIDTH).join("\n"));
+		expect(rendered).toContain("Something went wrong");
+	});
+});
+
+// ─── mergeCallAndResult / inline flags ───────────────────────────────────────
+
+describe("sfToolRenderer metadata flags", () => {
+	it("has mergeCallAndResult set to true", () => {
+		expect(sfToolRenderer.mergeCallAndResult).toBe(true);
+	});
+
+	it("has inline set to true", () => {
+		expect(sfToolRenderer.inline).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- Extracts `stripEmpty`, `formatTimestamp`, `addSection` from `xcsh-api-renderer.ts` into shared `render-utils.ts` so both renderers benefit
- Enriches `SfToolDetails` with `tool`, `action`, and `errorType` fields; wraps execute() methods in try/catch returning structured `isError` results instead of throwing
- Creates `sf-renderer.ts` — bordered F5-branded output blocks with semantic colors, SOQL table rendering, contextual error guidance (5 error types), and `mergeCallAndResult: true` matching XC-API exactly
- Registers `sf_setup`, `sf_query`, `sf_org_display` in the renderer registry

Closes #861

## Test plan
- [ ] All 4710+ tests pass (`bun test --max-concurrency 4`)
- [ ] sf-renderer: 14 renderer tests covering all tool types, error states, metadata flags
- [ ] render-utils-shared: 13 tests for the 3 new shared utilities
- [ ] SF tools: 80 tests pass including updated error-structuring tests

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #861`