### PR TITLE
fix: restore MEDDPICC bold-first-letter style with codespell ignore

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored,*.generated.ts
-ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine
+ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine,dentify

--- a/packages/coding-agent/src/prompts/tools/sf-query.md
+++ b/packages/coding-agent/src/prompts/tools/sf-query.md
@@ -106,7 +106,7 @@ For each deal, assess these 8 MEDDPICC elements from available SFDC data:
 **D**ecision Criteria: Are evaluation criteria documented? Check Opportunity.NextStep, Description.
 **D**ecision Process: Is the buying process mapped? Check stage progression timeline, paper process.
 **P**aper Process: Are procurement steps known? Check Opportunity.Description for legal/procurement notes.
-**Identify** Pain: Is the business pain articulated? Check Opportunity.Description, discovery notes.
+**I**dentify Pain: Is the business pain articulated? Check Opportunity.Description, discovery notes.
 **C**hampion: Is there an internal advocate? Check Contact roles for 'Champion' or active engagement.
 **C**ompetition: Are competitors identified? Check Opportunity.CompetitorName or description.
 Score each element: Green (validated), Yellow (partially known), Red (unknown/missing).


### PR DESCRIPTION
## Summary

- Add "dentify" to `.codespellrc` ignore-words-list so codespell does not flag the bold-first-letter pattern `**I**dentify`
- Restore `**I**dentify Pain` formatting in `sf-query.md` to match the other MEDDPICC elements (`**M**etrics`, `**E**conomic Buyer`, etc.)
- Aligns with upstream docs-control `.codespellrc` fix (docs-control#446/PR#447)

Closes #889

## Test plan

- [ ] CI checks pass (pre-commit spelling check, markdown lint)
- [ ] Verify `**I**dentify` renders with bold "I" in markdown preview
- [ ] Confirm codespell no longer flags "dentify" as misspelling