### PR TITLE
feat(statusline): add priority-based truncation with progressive abbreviation

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -20,7 +20,7 @@ import {
 	type PrCacheContext,
 } from "./status-line/git-utils";
 import { getPreset } from "./status-line/presets";
-import { renderSegment, type SegmentContext } from "./status-line/segments";
+import { renderSegment, SEGMENTS, type SegmentContext } from "./status-line/segments";
 import { getSeparator } from "./status-line/separators";
 import { calculateTokensPerSecond } from "./status-line/token-rate";
 
@@ -490,8 +490,9 @@ export class StatusLineComponent implements Component {
 
 		// Collect visible segments (preserving bg/fg metadata)
 		type SegPart = { content: string; bg: string; fg: string };
-		const collectParts = (segIds: readonly string[]): SegPart[] => {
+		const collectParts = (segIds: readonly string[]): { parts: SegPart[]; ids: string[] } => {
 			const parts: SegPart[] = [];
+			const ids: string[] = [];
 			for (const segId of segIds) {
 				const rendered = renderSegment(segId as any, ctx);
 				if (rendered.visible && rendered.content) {
@@ -500,13 +501,14 @@ export class StatusLineComponent implements Component {
 						bg: rendered.bg || defaultBg,
 						fg: rendered.fg || defaultFg,
 					});
+					ids.push(segId);
 				}
 			}
-			return parts;
+			return { parts, ids };
 		};
 
-		const leftParts = collectParts(effectiveSettings.leftSegments);
-		const rightParts = collectParts(effectiveSettings.rightSegments);
+		const { parts: leftParts, ids: leftIds } = collectParts(effectiveSettings.leftSegments);
+		const { parts: rightParts, ids: rightIds } = collectParts(effectiveSettings.rightSegments);
 
 		const runningBackgroundJobs = this.session.getAsyncJobSnapshot()?.running.length ?? 0;
 		if (runningBackgroundJobs > 0) {
@@ -534,6 +536,8 @@ export class StatusLineComponent implements Component {
 		const topFillWidth = Math.max(0, width);
 		const left = [...leftParts];
 		const right = [...rightParts];
+		const leftSegIds = [...leftIds];
+		const rightSegIds = [...rightIds];
 
 		const sepWidth = visibleWidth(separatorDef.left);
 		const capWidth = separatorDef.endCaps ? visibleWidth(separatorDef.endCaps.right) : 0;
@@ -541,23 +545,74 @@ export class StatusLineComponent implements Component {
 		const groupWidth = (parts: SegPart[]): number => {
 			if (parts.length === 0) return 0;
 			const partsWidth = parts.reduce((sum, p) => sum + visibleWidth(p.content), 0);
-			// Each segment gets 1 char padding on each side, separators between segments
 			const sepTotal = Math.max(0, parts.length - 1) * sepWidth;
 			return partsWidth + parts.length * 2 + sepTotal + capWidth;
 		};
 
 		let leftWidth = groupWidth(left);
 		let rightWidth = groupWidth(right);
-		const totalWidth = () => leftWidth + rightWidth + (left.length > 0 && right.length > 0 ? 1 : 0);
+		const totalWidth = () => leftWidth + rightWidth;
 
-		if (topFillWidth > 0) {
-			while (totalWidth() > topFillWidth && right.length > 0) {
-				right.pop();
-				rightWidth = groupWidth(right);
-			}
-			while (totalWidth() > topFillWidth && left.length > 0) {
-				left.pop();
-				leftWidth = groupWidth(left);
+		if (topFillWidth > 0 && totalWidth() > topFillWidth) {
+			const preset = getPreset(effectiveSettings.preset ?? "default");
+			const dropOrder = preset.dropOrder;
+
+			if (dropOrder) {
+				type SegRef = { group: "left" | "right"; part: SegPart; segId: string };
+				const segRefs: SegRef[] = [
+					...left.map((part, i) => ({ group: "left" as const, part, segId: leftSegIds[i] })),
+					...right.map((part, i) => ({ group: "right" as const, part, segId: rightSegIds[i] })),
+				];
+
+				const inOrder: SegRef[] = [];
+				const notInOrder: SegRef[] = [];
+				for (const ref of segRefs) {
+					const orderIdx = dropOrder.indexOf(ref.segId as any);
+					if (orderIdx === -1) notInOrder.push(ref);
+					else inOrder.push(ref);
+				}
+				inOrder.sort((a, b) => dropOrder.indexOf(a.segId as any) - dropOrder.indexOf(b.segId as any));
+				const dropQueue = [...notInOrder, ...inOrder];
+
+				for (const ref of dropQueue) {
+					if (totalWidth() <= topFillWidth) break;
+
+					const segDef = SEGMENTS[ref.segId as StatusLineSegmentId];
+					const group = ref.group === "left" ? left : right;
+
+					const currentIdx = group.indexOf(ref.part);
+					if (currentIdx === -1) continue;
+
+					if (segDef?.truncate) {
+						const currentContentWidth = visibleWidth(ref.part.content);
+						const deficit = totalWidth() - topFillWidth;
+						const targetWidth = Math.max(1, currentContentWidth - deficit);
+						const truncated = segDef.truncate(targetWidth, ctx);
+						if (truncated?.visible && truncated.content) {
+							group[currentIdx] = {
+								content: truncated.content,
+								bg: truncated.bg || ref.part.bg,
+								fg: truncated.fg || ref.part.fg,
+							};
+							if (ref.group === "left") leftWidth = groupWidth(left);
+							else rightWidth = groupWidth(right);
+							continue;
+						}
+					}
+
+					group.splice(currentIdx, 1);
+					if (ref.group === "left") leftWidth = groupWidth(left);
+					else rightWidth = groupWidth(right);
+				}
+			} else {
+				while (totalWidth() > topFillWidth && right.length > 0) {
+					right.pop();
+					rightWidth = groupWidth(right);
+				}
+				while (totalWidth() > topFillWidth && left.length > 0) {
+					left.pop();
+					leftWidth = groupWidth(left);
+				}
 			}
 		}
 
@@ -636,13 +691,16 @@ export class StatusLineComponent implements Component {
 		const rightGroup = renderGroup(right, "right");
 		if (!leftGroup && !rightGroup) return "";
 
-		if (topFillWidth === 0 || left.length === 0 || right.length === 0) {
+		if (topFillWidth === 0 || (left.length === 0 && right.length === 0)) {
 			return leftGroup + (leftGroup && rightGroup ? " " : "") + rightGroup;
 		}
 
 		leftWidth = groupWidth(left);
 		rightWidth = groupWidth(right);
-		const gapWidth = Math.max(1, topFillWidth - leftWidth - rightWidth);
+		const gapWidth = Math.max(0, topFillWidth - leftWidth - rightWidth);
+		if (gapWidth === 0) {
+			return leftGroup + rightGroup;
+		}
 		const gapFill = theme.fg("border", theme.boxRound.horizontal.repeat(gapWidth));
 		return leftGroup + gapFill + rightGroup;
 	}

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -10,6 +10,18 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 			path: { abbreviate: true, maxLength: 40, stripWorkPrefix: true },
 			git: { showBranch: true, showStaged: true, showUnstaged: true, showUntracked: true },
 		},
+		dropOrder: [
+			"pr",
+			"token_total",
+			"cost",
+			"git",
+			"path",
+			"context_pct",
+			"plan_mode",
+			"model",
+			"pi",
+			"context_f5xc",
+		],
 	},
 
 	minimal: {
@@ -20,6 +32,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 			path: { abbreviate: true, maxLength: 30 },
 			git: { showBranch: true, showStaged: false, showUnstaged: false, showUntracked: false },
 		},
+		dropOrder: ["git", "plan_mode", "context_pct", "path", "context_f5xc"],
 	},
 
 	compact: {
@@ -30,6 +43,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 			model: { showThinkingLevel: false },
 			git: { showBranch: true, showStaged: true, showUnstaged: true, showUntracked: false },
 		},
+		dropOrder: ["pr", "cost", "git", "context_pct", "plan_mode", "model", "context_f5xc"],
 	},
 
 	full: {
@@ -52,6 +66,25 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 			git: { showBranch: true, showStaged: true, showUnstaged: true, showUntracked: true },
 			time: { format: "24h", showSeconds: false },
 		},
+		dropOrder: [
+			"time",
+			"time_spent",
+			"cache_read",
+			"token_rate",
+			"token_out",
+			"token_in",
+			"subagents",
+			"pr",
+			"git",
+			"path",
+			"cost",
+			"context_pct",
+			"plan_mode",
+			"hostname",
+			"model",
+			"pi",
+			"context_f5xc",
+		],
 	},
 
 	nerd: {
@@ -77,6 +110,28 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 			git: { showBranch: true, showStaged: true, showUnstaged: true, showUntracked: true },
 			time: { format: "24h", showSeconds: true },
 		},
+		dropOrder: [
+			"context_total",
+			"cache_write",
+			"session",
+			"time",
+			"time_spent",
+			"cache_read",
+			"token_rate",
+			"token_out",
+			"token_in",
+			"subagents",
+			"pr",
+			"git",
+			"path",
+			"cost",
+			"context_pct",
+			"plan_mode",
+			"hostname",
+			"model",
+			"pi",
+			"context_f5xc",
+		],
 	},
 
 	ascii: {
@@ -89,6 +144,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 			path: { abbreviate: true, maxLength: 40 },
 			git: { showBranch: true, showStaged: true, showUnstaged: true, showUntracked: true },
 		},
+		dropOrder: ["pr", "token_total", "cost", "git", "path", "context_pct", "model", "context_f5xc"],
 	},
 
 	xcsh: {
@@ -101,6 +157,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 			git: { showBranch: true, showStaged: true, showUnstaged: true, showUntracked: true },
 			context_pct: { compact: true },
 		},
+		dropOrder: ["plan_mode", "git", "path", "context_pct", "context_f5xc"],
 	},
 
 	custom: {

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -461,6 +461,25 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 				return { content: "", visible: false };
 			}
 		},
+		truncate(maxWidth: number, _ctx: SegmentContext): RenderedSegment | null {
+			try {
+				const { truncateF5XCContextSegment } = require("../../../services/f5xc-context-segment");
+				const result = truncateF5XCContextSegment(maxWidth);
+				if (!result) return null;
+				let bg = theme.fgColorAsBg("statusLineContextF5xcBg");
+				let fg = theme.getFgAnsi("statusLineContextF5xcFg");
+				if (result.tokenHealth === "expiring") {
+					bg = theme.fgColorAsBg("statusLineGitDirtyBg");
+					fg = theme.getFgAnsi("statusLineGitDirtyFg");
+				} else if (result.tokenHealth === "expired") {
+					bg = theme.fgColorAsBg("statusLineGitConflictBg");
+					fg = theme.getFgAnsi("statusLineGitConflictFg");
+				}
+				return { ...result, bg, fg };
+			} catch {
+				return null;
+			}
+		},
 	},
 };
 

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -66,6 +66,7 @@ export interface RenderedSegment {
 export interface StatusLineSegment {
 	id: StatusLineSegmentId;
 	render(ctx: SegmentContext): RenderedSegment;
+	truncate?(maxWidth: number, ctx: SegmentContext): RenderedSegment | null;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -91,4 +92,5 @@ export interface PresetDef {
 	rightSegments: StatusLineSegmentId[];
 	separator: StatusLineSeparatorStyle;
 	segmentOptions?: StatusLineSegmentOptions;
+	dropOrder?: StatusLineSegmentId[];
 }

--- a/packages/coding-agent/src/services/f5xc-context-display.ts
+++ b/packages/coding-agent/src/services/f5xc-context-display.ts
@@ -7,3 +7,43 @@ export function formatContextLabel(status: ContextStatus): string {
 	if (status.tokenHealth === "expiring" || status.tokenHealth === "expired") return `${base} ⚠`;
 	return base;
 }
+
+export function truncateContextLabel(status: ContextStatus, maxWidth: number): string | null {
+	if (!status.isConfigured) return null;
+
+	const left = status.activeContextTenant ?? status.activeContextName ?? "env";
+	const right = status.activeContextNamespace ?? "default";
+	const hasWarning = status.tokenHealth === "expiring" || status.tokenHealth === "expired";
+	const warningSuffix = hasWarning ? " ⚠" : "";
+	const warningLen = warningSuffix.length;
+	const available = maxWidth - warningLen;
+
+	if (available < 4) return null;
+
+	const full = `${left}:${right}`;
+	if (full.length <= available) return `${full}${warningSuffix}`;
+
+	// Tier 1: Truncate right side, keep full left
+	if (available >= left.length + 3) {
+		const rightMax = available - left.length - 1 - 1;
+		return `${left}:${right.slice(0, rightMax)}…${warningSuffix}`;
+	}
+
+	// Tier 2: Abbreviate both sides
+	if (available >= 6) {
+		const contentBudget = available - 2;
+		const leftBudget = Math.max(2, Math.ceil(contentBudget / 2));
+		const rightBudget = contentBudget - leftBudget;
+		const abbrLeft = left.slice(0, leftBudget);
+		const abbrRight = rightBudget > 0 ? right.slice(0, rightBudget) : "";
+		return `${abbrLeft}:${abbrRight}…${warningSuffix}`;
+	}
+
+	// Tier 3: Tenant abbreviation only
+	if (available >= 4) {
+		const leftBudget = available - 2;
+		return `${left.slice(0, leftBudget)}:…${warningSuffix}`;
+	}
+
+	return null;
+}

--- a/packages/coding-agent/src/services/f5xc-context-segment.ts
+++ b/packages/coding-agent/src/services/f5xc-context-segment.ts
@@ -1,5 +1,5 @@
 import { ContextService, type TokenHealth } from "./f5xc-context";
-import { formatContextLabel } from "./f5xc-context-display";
+import { formatContextLabel, truncateContextLabel } from "./f5xc-context-display";
 
 export interface RenderedSegment {
 	content: string;
@@ -19,5 +19,21 @@ export function renderF5XCContextSegment(): RenderedSegment {
 		return { content: formatContextLabel(status), visible: true, tokenHealth: status.tokenHealth };
 	} catch {
 		return { content: "", visible: false };
+	}
+}
+
+export function truncateF5XCContextSegment(maxWidth: number): RenderedSegment | null {
+	try {
+		const service = ContextService.instance;
+		const status = service.getStatus();
+
+		if (!status.isConfigured) return null;
+
+		const truncated = truncateContextLabel(status, maxWidth);
+		if (truncated === null) return null;
+
+		return { content: truncated, visible: true, tokenHealth: status.tokenHealth };
+	} catch {
+		return null;
 	}
 }

--- a/packages/coding-agent/test/status-line-truncation.test.ts
+++ b/packages/coding-agent/test/status-line-truncation.test.ts
@@ -1,0 +1,116 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { initTheme } from "../src/modes/theme/theme";
+import type { ContextStatus } from "../src/services/f5xc-context";
+import { truncateContextLabel } from "../src/services/f5xc-context-display";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+describe("status-line types", () => {
+	it("PresetDef accepts dropOrder field", async () => {
+		const { STATUS_LINE_PRESETS } = await import("../src/modes/components/status-line/presets");
+		const xcsh = STATUS_LINE_PRESETS.xcsh;
+		expect(xcsh.dropOrder).toBeDefined();
+		expect(Array.isArray(xcsh.dropOrder)).toBe(true);
+	});
+
+	it("StatusLineSegment accepts truncate method", async () => {
+		const { SEGMENTS } = await import("../src/modes/components/status-line/segments");
+		const f5xcSegment = SEGMENTS.context_f5xc;
+		expect(typeof f5xcSegment.truncate).toBe("function");
+	});
+});
+
+function makeStatus(overrides: Partial<ContextStatus> = {}): ContextStatus {
+	return {
+		activeContextName: "test-context",
+		activeContextUrl: "https://example.console.ves.volterra.io/api",
+		activeContextTenant: "nferreira",
+		activeContextNamespace: "r-mordasiewicz",
+		credentialSource: "context",
+		authStatus: "valid",
+		isConfigured: true,
+		tokenHealth: "ok",
+		...overrides,
+	} as ContextStatus;
+}
+
+describe("truncateContextLabel", () => {
+	it("returns full label when maxWidth is large enough", () => {
+		const result = truncateContextLabel(makeStatus(), 30);
+		expect(result).toBe("nferreira:r-mordasiewicz");
+	});
+
+	it("truncates namespace with ellipsis when width is 15-24", () => {
+		const result = truncateContextLabel(makeStatus(), 18);
+		expect(result).not.toBeNull();
+		expect(result!.length).toBeLessThanOrEqual(18);
+		expect(result!).toMatch(/^nferreira:.*…$/);
+	});
+
+	it("abbreviates both sides when width is 8-14", () => {
+		const result = truncateContextLabel(makeStatus(), 10);
+		expect(result).not.toBeNull();
+		expect(result!.length).toBeLessThanOrEqual(10);
+		expect(result!).toContain(":");
+	});
+
+	it("shows tenant abbreviation only when width is 4-7", () => {
+		const result = truncateContextLabel(makeStatus(), 5);
+		expect(result).not.toBeNull();
+		expect(result!.length).toBeLessThanOrEqual(5);
+		expect(result!).toMatch(/^.+:…$/);
+	});
+
+	it("returns null when width is less than 4", () => {
+		const result = truncateContextLabel(makeStatus(), 3);
+		expect(result).toBeNull();
+	});
+
+	it("preserves warning indicator and subtracts its width", () => {
+		const status = makeStatus({ tokenHealth: "expiring" });
+		const result = truncateContextLabel(status, 15);
+		expect(result).not.toBeNull();
+		expect(result!).toContain("⚠");
+		expect(result!.length).toBeLessThanOrEqual(15);
+	});
+
+	it("returns null for unconfigured status", () => {
+		const status = makeStatus({ isConfigured: false });
+		const result = truncateContextLabel(status, 30);
+		expect(result).toBeNull();
+	});
+});
+
+describe("preset dropOrder", () => {
+	it("all non-custom presets define dropOrder", async () => {
+		const { STATUS_LINE_PRESETS } = await import("../src/modes/components/status-line/presets");
+		for (const [name, preset] of Object.entries(STATUS_LINE_PRESETS)) {
+			if (name === "custom") {
+				expect(preset.dropOrder).toBeUndefined();
+				continue;
+			}
+			expect(preset.dropOrder).toBeDefined();
+			expect(Array.isArray(preset.dropOrder)).toBe(true);
+			expect(preset.dropOrder!.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("xcsh dropOrder has context_f5xc as highest priority (last element)", async () => {
+		const { STATUS_LINE_PRESETS } = await import("../src/modes/components/status-line/presets");
+		const xcsh = STATUS_LINE_PRESETS.xcsh;
+		expect(xcsh.dropOrder![xcsh.dropOrder!.length - 1]).toBe("context_f5xc");
+	});
+
+	it("dropOrder entries are a subset of leftSegments + rightSegments", async () => {
+		const { STATUS_LINE_PRESETS } = await import("../src/modes/components/status-line/presets");
+		for (const [name, preset] of Object.entries(STATUS_LINE_PRESETS)) {
+			if (name === "custom" || !preset.dropOrder) continue;
+			const allSegments = new Set([...preset.leftSegments, ...preset.rightSegments]);
+			for (const id of preset.dropOrder) {
+				expect(allSegments.has(id)).toBe(true);
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Add priority-based truncation system for status line segments that shrinks gap fill to 0 before dropping any segment
- Segments are dropped in configurable dropOrder (lowest priority first), with context_f5xc progressively abbreviating through 4 tiers before removal
- Custom preset falls back to original right-to-left behavior for backward compatibility

Closes #909

## Test plan

- [ ] CI checks pass
- [ ] `bun test` passes status-line-truncation tests
- [ ] Verify narrow terminal (VS Code) no longer truncates F5XC namespace context indicator
- [ ] Verify custom preset backward compatibility