### PR TITLE
fix(ci): add exponential backoff retry to npm publish step

### DIFF
--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -58,19 +58,30 @@ async function publishPackage(pkg: PublishPackage): Promise<void> {
 		return;
 	}
 
-	console.log(`Publishing ${packageName}...`);
-	const result = await $`bun publish --access public`.cwd(path.join(repoRoot, pkg.dir)).quiet().nothrow();
-	const output = `${result.stdout.toString()}${result.stderr.toString()}`.trim();
-	if (result.exitCode === 0) {
+	const maxAttempts = 5;
+	let delay = 5_000;
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		console.log(`Publishing ${packageName}... (attempt ${attempt}/${maxAttempts})`);
+		const result = await $`bun publish --access public`.cwd(path.join(repoRoot, pkg.dir)).quiet().nothrow();
+		const output = `${result.stdout.toString()}${result.stderr.toString()}`.trim();
+		if (result.exitCode === 0) {
+			if (output) console.log(output);
+			return;
+		}
 		if (output) console.log(output);
-		return;
+		if (isAlreadyPublished(output)) {
+			console.log("Already published, skipping");
+			return;
+		}
+		if (attempt < maxAttempts) {
+			console.log(`Publish failed, retrying in ${delay / 1000}s...`);
+			await Bun.sleep(delay);
+			delay *= 2;
+			continue;
+		}
+		console.error(`Failed to publish ${packageName} after ${maxAttempts} attempts`);
+		process.exit(result.exitCode ?? 1);
 	}
-	if (output) console.log(output);
-	if (isAlreadyPublished(output)) {
-		console.log("Already published, skipping");
-		return;
-	}
-	process.exit(result.exitCode ?? 1);
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## What

Add retry logic with exponential backoff to the `publishPackage` function in `scripts/ci-release-publish.ts`.

## Why

The `publish-npm` job failed with a transient 404 from the npm registry during the v18.74.1 release. The `publishPackage` function had no retry logic — a single failed `bun publish` would immediately exit the workflow. This adds 5 attempts with exponential backoff (5s/10s/20s/40s/80s) to survive transient npm registry errors, matching the retry pattern already used for the codesign timestamp step.

Closes #915

## Testing

- [ ] CI checks pass
- [x] Issue linked via `Closes #915`
- [x] Pre-commit hooks pass (biome lint, spelling, secrets detection, large file check)