### PR TITLE
fix(ci): use NODE_AUTH_TOKEN for npm publish authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1045,7 +1045,7 @@ jobs:
           find "$NPM_DIR" -name "*.node" -exec ls -lh {} \;
       - name: Publish to npm
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bun run ci:release:publish
 
   # Verify npm install works end-to-end after publishing


### PR DESCRIPTION
## What

Change the npm publish environment variable from `NPM_CONFIG_TOKEN` to `NODE_AUTH_TOKEN` in the `publish-npm` CI job.

## Why

`actions/setup-node@v6` creates an `.npmrc` that references `${NODE_AUTH_TOKEN}`, but the publish step was setting `NPM_CONFIG_TOKEN` instead. The `.npmrc` token variable resolved to an invalid placeholder, causing npm to mask the authentication failure as a 404 for the scoped package.

Closes #918

## Testing

- [ ] CI checks pass
- [ ] `publish-npm` job succeeds on next tag-triggered release
- [x] Issue linked via `Closes #918`