### PR TITLE
fix(statusline): use actual rendered widths for gap fill calculation

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -695,9 +695,9 @@ export class StatusLineComponent implements Component {
 			return leftGroup + (leftGroup && rightGroup ? " " : "") + rightGroup;
 		}
 
-		leftWidth = groupWidth(left);
-		rightWidth = groupWidth(right);
-		const gapWidth = Math.max(0, topFillWidth - leftWidth - rightWidth);
+		const actualLeftWidth = visibleWidth(leftGroup);
+		const actualRightWidth = visibleWidth(rightGroup);
+		const gapWidth = Math.max(0, topFillWidth - actualLeftWidth - actualRightWidth);
 		if (gapWidth === 0) {
 			return leftGroup + rightGroup;
 		}


### PR DESCRIPTION
## What

Replace `groupWidth()` estimates with `visibleWidth()` of actual rendered ANSI output when calculating the gap fill between left and right status line segment groups.

## Why

Powerline separator characters and ANSI escape boundaries caused `groupWidth()` to undercount, making the gap fill too wide and pushing the right-side `context_f5xc` segment past the terminal edge where the editor clipped it to "...".

Closes #921

## Testing

- [x] `bun run check` -- pre-commit hooks pass (biome check, spelling, secrets detection)
- [x] Change is minimal and isolated to gap width calculation
- [ ] Visual verification that right-side segments render within terminal bounds
- [x] Issue linked via `Closes #921`