### PR TITLE
feat(coding-agent): auto-validate credentials on context switch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Auto-validate credentials on context switch: SDK context change listener now fires a background `validateToken()` after emitting the switch notification, sending a follow-up `context_validation_result` custom message so the LLM knows whether the new context's credentials are valid
+
 ## [18.64.2] - 2026-05-16
 
 ### Fixed
@@ -20,11 +24,13 @@
 ### Changed
 
 - Regenerated API spec index from catalog v2.1.82: http_loadbalancer CRUD verification corrections (6 new server defaults, corrected minimum configs, cross-field dependencies, default_pool inline pool discovery, 5 composable routing approaches) and tcp_loadbalancer minimum config corrections (listen_port, origin_pools_weights, do_not_advertise format, 9 server defaults, forced hash_policy default) ([#753](https://github.com/f5xc-salesdemos/xcsh/issues/753), [#757](https://github.com/f5xc-salesdemos/xcsh/issues/757))
+
 ## [18.53.0] - 2026-05-09
 
 ### Changed
 
 - Autoresearch subsystem code quality: -513 lines (18.8% reduction), ~13% faster type checking. Un-exported internal symbols, relocated types, consolidated duplicate patterns, replaced manual deep copies with `structuredClone`, replaced `while(exec)` with `matchAll`, compressed control flow, extracted shared interfaces ([#734](https://github.com/f5xc-salesdemos/xcsh/pull/734))
+
 ## [18.53.0] - 2026-05-09
 
 ### Fixed
@@ -79,12 +85,10 @@
 
 ## [18.18.4] - 2026-04-26
 
-
 ### Fixed
 
 - Fixed gutter width propagation in the fallback tool renderer: `#formatToolExecution()` now receives the actual available width at render-time and uses it for line truncation instead of a hardcoded 80-column limit. On narrow terminals (<82 cols) this prevents content wider than the gutter-adjusted viewport; on wide terminals it allows longer output lines. ([#117](https://github.com/f5xc-salesdemos/xcsh/issues/117))
 - Fixed `resolveConfigValue` returning literal env var names (e.g. `"LITELLM_API_KEY"`) as API keys when the env var is unset, causing 401 errors on first launch. The resolver now rejects unresolved `ALL_CAPS_WITH_UNDERSCORES` patterns, matching the existing guard in `resolveYamlApiKeyConfig`. ([#241](https://github.com/f5xc-salesdemos/xcsh/issues/241))
-
 
 ### Changed
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1906,6 +1906,30 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					});
 					lastEmittedContext = { name: currentName, namespace: currentNamespace };
 					void session.refreshBaseSystemPrompt();
+					// Role 3: background-validate credentials after context switch so the
+					// LLM knows whether the new context is usable. Fire-and-forget — do
+					// not block the context change notification.
+					void (async () => {
+						try {
+							const { status: authStatus, latencyMs } = await service.instance.validateToken({
+								timeoutMs: 5000,
+							});
+							const qualifier =
+								authStatus === "connected"
+									? `connected${latencyMs ? ` (${latencyMs}ms)` : ""}`
+									: authStatus === "auth_error"
+										? "credential error -- token may be invalid or expired"
+										: "unreachable -- network error or tenant offline";
+							void session.sendCustomMessage({
+								customType: "context_validation_result",
+								content: `[Auth status: ${authStatus}] Credentials for ${currentTenant}: ${qualifier}.`,
+								display: true,
+								attribution: "agent",
+							});
+						} catch {
+							// Validation failed (e.g., no credentials configured) -- skip silently.
+						}
+					})();
 				} catch {
 					// ContextService.instance throws if not initialized; skip.
 				}


### PR DESCRIPTION
Fixes #924

## Problem
When switching F5 XC contexts, the SDK injects a [Context switched to X] notification into the LLM conversation but does not validate whether credentials are actually valid. The TUI user sees auth status via handleShow(), but the LLM is blind to credential validity.

## Solution
In the SDK context change listener (sdk.ts), after emitting the context_change_notice:
- Fire a background (non-blocking) validateToken() with 5s timeout
- Send a follow-up context_validation_result custom message with auth status (connected/auth_error/offline)

Context switch notification remains immediate; auth validation arrives 1-3s later.

## Changes
- packages/coding-agent/src/sdk.ts +24 lines
- packages/coding-agent/CHANGELOG.md — new entry + fixed pre-existing markdownlint errors

## Testing
- bun check:ts passes
- All 286 context tests pass (278 command/service + 8 SDK integration)
- markdownlint clean (0 errors, was 8)