### PR TITLE
fix(ci): write npm auth token directly to .npmrc for bun publish compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1046,7 +1046,9 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun run ci:release:publish
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > "$HOME/.npmrc"
+          bun run ci:release:publish
 
   # Verify npm install works end-to-end after publishing
   verify-npm-install:


### PR DESCRIPTION
## What

Write the npm auth token as a literal value into `~/.npmrc` at runtime instead of relying on the `${NODE_AUTH_TOKEN}` template variable in `.npmrc`.

## Why

`bun publish` does not resolve `${NODE_AUTH_TOKEN}` template variables from the `.npmrc` file created by `actions/setup-node`. This causes authentication failures during the CI publish step. The publish step now writes `//registry.npmjs.org/:_authToken=<TOKEN>` from the shell-resolved `NODE_AUTH_TOKEN` env var before running `bun run ci:release:publish`.

Closes #926

## Testing

- [ ] CI checks pass
- [x] Verified the change only affects the publish-npm job's publish step
- [x] No other workflow steps are modified
- [x] Issue linked via `Closes #926`