### PR TITLE
fix(ci): write npm auth token to NPM_CONFIG_USERCONFIG path instead of ~/.npmrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1047,7 +1047,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > "$HOME/.npmrc"
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
           bun run ci:release:publish
 
   # Verify npm install works end-to-end after publishing


### PR DESCRIPTION
## What

Write the npm auth token to `${NPM_CONFIG_USERCONFIG}` (with fallback to `$HOME/.npmrc`) instead of hardcoding `~/.npmrc` in the CI publish step.

## Why

`actions/setup-node` sets `NPM_CONFIG_USERCONFIG=/home/runner/work/_temp/.npmrc`, which overrides `~/.npmrc`. When `bun publish` runs, it reads the `NPM_CONFIG_USERCONFIG` path -- which contains an unresolvable `${NODE_AUTH_TOKEN}` template literal from setup-node -- instead of the `~/.npmrc` we wrote the real token to. This causes npm authentication failures during publish.

Closes #929

## Testing

- [ ] CI checks pass
- [x] Verified the change targets the correct line in the publish-npm job
- [x] Fallback to `$HOME/.npmrc` preserves behavior when `NPM_CONFIG_USERCONFIG` is unset
- [x] Issue linked via `Closes #929`