### PR TITLE
fix(ci): write .npmrc to project root for bun publish auth discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1047,7 +1047,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
           bun run ci:release:publish
 
   # Verify npm install works end-to-end after publishing


### PR DESCRIPTION
## What

Write the npm auth token `.npmrc` to the project root instead of `${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}` in the CI publish step.

## Why

`bun publish` does not respect the `NPM_CONFIG_USERCONFIG` environment variable set by `actions/setup-node`. It walks up from the package directory looking for `.npmrc` in parent directories. Writing the auth token to the project root `.npmrc` (the repo working directory) ensures bun finds it when publishing from any package subdirectory.

Closes #934

## Testing

- [ ] CI checks pass
- [ ] Next publish workflow successfully authenticates to npm registry
- [x] Issue linked via `Closes #934`