### PR TITLE
fix(ci): switch from bun publish to npm publish for npm registry auth compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1047,7 +1047,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
           bun run ci:release:publish
 
   # Verify npm install works end-to-end after publishing

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -54,15 +54,17 @@ async function publishPackage(pkg: PublishPackage): Promise<void> {
 	}
 
 	if (isDryRun) {
-		console.log(`DRY RUN bun publish --access public (${pkg.dir})`);
+		console.log(`DRY RUN npm publish --access public (${pkg.dir})`);
 		return;
 	}
 
+	// Use npm publish instead of bun publish — bun publish has a known auth bug in CI
+	// https://github.com/oven-sh/bun/issues/24124
 	const maxAttempts = 5;
 	let delay = 5_000;
 	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 		console.log(`Publishing ${packageName}... (attempt ${attempt}/${maxAttempts})`);
-		const result = await $`bun publish --access public`.cwd(path.join(repoRoot, pkg.dir)).quiet().nothrow();
+		const result = await $`npm publish --access public`.cwd(path.join(repoRoot, pkg.dir)).quiet().nothrow();
 		const output = `${result.stdout.toString()}${result.stderr.toString()}`.trim();
 		if (result.exitCode === 0) {
 			if (output) console.log(output);


### PR DESCRIPTION
## What

- Replace `bun publish` with `npm publish` in `scripts/ci-release-publish.ts`
- Remove manual `.npmrc` creation from `.github/workflows/ci.yml` (npm handles this natively via `NODE_AUTH_TOKEN`)

## Why

`bun publish` has a known authentication bug in GitHub Actions CI — it fails with "missing authentication" even when a valid `.npmrc` and `NODE_AUTH_TOKEN` are configured. The confirmed workaround from the bun issue tracker (https://github.com/oven-sh/bun/issues/24124) is to use `npm publish` instead. `npm` natively supports `NODE_AUTH_TOKEN` from the `.npmrc` created by `actions/setup-node`, making the manual `.npmrc` write unnecessary.

Closes #937

## Testing

- [ ] CI checks pass
- [ ] npm publish step succeeds in the publish-npm workflow on next tag push
- [x] Issue linked via `Closes #937`