### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored,*.generated.ts
-ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine,dentify,opps
+ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine,dentify,opps,pecified,atmost,atleast

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,20 @@ docs/api-reference/
 .etag
 .github_release
 
+# Autoresearch session artifacts
+autoresearch.sh
+autoresearch.md
+autoresearch.program.md
+autoresearch.checks.sh
+autoresearch-loop.sh
+autoresearch.ideas.md
+autoresearch-queries.txt
+autoresearch.jsonl
+.autoresearch/
+
+# Session-resume files
+handoff.md
+
 # Union from xcsh fork (promoted 2026-04-19)
 .npm/
 packages/*/dist/
@@ -176,11 +190,3 @@ pi-*.html
 packages/coding-agent/src/internal-urls/docs-index.generated.ts
 packages/coding-agent/src/internal-urls/build-info.generated.ts
 packages/typescript-edit-benchmark/runs/
-.autoresearch/
-autoresearch.jsonl
-autoresearch.md
-autoresearch.sh
-autoresearch.checks.sh
-autoresearch-queries.txt
-autoresearch-seed.sh
-autoresearch-teardown.sh


### PR DESCRIPTION
Closes #940

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .gitignore
- .codespellrc