### PR TITLE
fix(ci): revert to bun publish with NPM_CONFIG_TOKEN for workspace:* resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1045,9 +1045,8 @@ jobs:
           find "$NPM_DIR" -name "*.node" -exec ls -lh {} \;
       - name: Publish to npm
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          bun run ci:release:publish
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bun run ci:release:publish
 
   # Verify npm install works end-to-end after publishing
   verify-npm-install:

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -58,13 +58,11 @@ async function publishPackage(pkg: PublishPackage): Promise<void> {
 		return;
 	}
 
-	// Use npm publish instead of bun publish — bun publish has a known auth bug in CI
-	// https://github.com/oven-sh/bun/issues/24124
 	const maxAttempts = 5;
 	let delay = 5_000;
 	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 		console.log(`Publishing ${packageName}... (attempt ${attempt}/${maxAttempts})`);
-		const result = await $`npm publish --access public`.cwd(path.join(repoRoot, pkg.dir)).quiet().nothrow();
+		const result = await $`bun publish --access public`.cwd(path.join(repoRoot, pkg.dir)).quiet().nothrow();
 		const output = `${result.stdout.toString()}${result.stderr.toString()}`.trim();
 		if (result.exitCode === 0) {
 			if (output) console.log(output);


### PR DESCRIPTION
## What

Revert the CI publish pipeline from `npm publish` + `NODE_AUTH_TOKEN` back to `bun publish` + `NPM_CONFIG_TOKEN`.

## Why

`npm publish` does not resolve `workspace:*` protocol references in `package.json` dependency fields. This causes the downstream `verify-npm-install` job to fail with `EUNSUPPORTEDPROTOCOL` when consumers install the published package.

The switch to `npm publish` was made in #938 to work around a suspected `bun publish` auth bug (404 on publish). The root cause was actually an expired `NPM_TOKEN` secret, not a `bun publish` defect. Now that the token is refreshed, `bun publish` with `NPM_CONFIG_TOKEN` works correctly.

### Changes
- `.github/workflows/ci.yml`: Change env var from `NODE_AUTH_TOKEN` to `NPM_CONFIG_TOKEN`
- `scripts/ci-release-publish.ts`: Change `npm publish` back to `bun publish`, remove outdated comment

Closes #945

## Testing

- [ ] CI checks pass
- [ ] Publish step uses `bun publish` with `NPM_CONFIG_TOKEN`
- [ ] `verify-npm-install` succeeds (no `EUNSUPPORTEDPROTOCOL` error)