### PR TITLE
feat(settings): add todo.verbose setting to suppress todo output in transcript

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1199,6 +1199,16 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"todo.verbose": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			label: "Show Todo Tool Output",
+			description: "Display todo_write tool calls and reminders in the chat transcript",
+		},
+	},
+
 	// Search and AST tools
 	"find.enabled": {
 		type: "boolean",

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -338,6 +338,9 @@ export class EventController {
 					}
 
 					this.#resetReadGroup();
+					if (event.toolName === "todo_write" && !settings.get("todo.verbose")) {
+						break;
+					}
 					const tool = this.ctx.session.getToolByName(event.toolName);
 					const component = new ToolExecutionComponent(
 						event.toolName,
@@ -655,9 +658,11 @@ export class EventController {
 			}
 
 			case "todo_reminder": {
-				const component = new TodoReminderComponent(event.todos, event.attempt, event.maxAttempts);
-				this.ctx.chatContainer.addChild(createSystemGutter(this.ctx.ui, component));
-				this.ctx.ui.requestRender();
+				if (settings.get("todo.verbose")) {
+					const component = new TodoReminderComponent(event.todos, event.attempt, event.maxAttempts);
+					this.ctx.chatContainer.addChild(createSystemGutter(this.ctx.ui, component));
+					this.ctx.ui.requestRender();
+				}
 				break;
 			}
 

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -333,6 +333,9 @@ export class UiHelpers {
 
 					// Non-read tool call breaks the group.
 					finalizeReadGroup();
+					if (content.name === "todo_write" && !settings.get("todo.verbose")) {
+						continue;
+					}
 					const tool = this.ctx.session.getToolByName(content.name);
 					const renderArgs =
 						"partialJson" in content

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -93,6 +93,10 @@ describe("fork settings schema defaults (PRs #48, #68, theme commits)", () => {
 		expect(SETTINGS_SCHEMA["exa.enableSearch"].default).toBe(false);
 	});
 
+	it("todo.verbose defaults to false (quiet todo output for humans)", () => {
+		expect(SETTINGS_SCHEMA["todo.verbose"].default).toBe(false);
+	});
+
 	// statusLine.preset enum must include xcsh
 	it("xcsh is a valid statusLine.preset value", () => {
 		const presetDef = SETTINGS_SCHEMA["statusLine.preset"];


### PR DESCRIPTION
## What

Add a `todo.verbose` boolean setting (default: `false`) that controls whether todo/task management tool calls and reminders are rendered in the interactive chat transcript.

## Why

The todo system renders internal tool calls and reminder messages directly into the conversation UI, which is confusing and noisy for human users. This change suppresses that visual output while preserving 100% of the todo system's internal functionality. Users who want visibility can toggle the setting ON via `/settings > Tools > "Show Todo Tool Output"`.

Closes #948

## Testing

- Regression guard test updated to cover the new setting
- Setting schema validates correctly with default value
- Event controller and UI helpers gate output on setting value

---

- [x] `bun run check` passes (Biome lint + type-check via lint-staged)
- [x] Issue linked via `Closes #948`