### PR TITLE
fix(ci): write .npmrc with resolved token for npm publish auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1046,7 +1046,9 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun run ci:release:publish
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
+          bun run ci:release:publish
 
   # Verify npm install works end-to-end after publishing
   verify-npm-install:


### PR DESCRIPTION
## What

Write the npm auth token as a literal value into `.npmrc` at the project root before running `bun run ci:release:publish` in the CI publish-npm job.

## Why

The `.npmrc` template created by `actions/setup-node` uses `${NODE_AUTH_TOKEN}` which is not resolved by npm when invoked via bun's script runner. This causes authentication failures during package publishing. Writing the token explicitly ensures auth works regardless of the shell environment. This is consistent with how v18.75.3 successfully published.

Closes #953

## Testing

- [ ] CI checks pass
- [ ] npm publish step authenticates successfully on next release

---

- [x] Issue linked via `Closes #953`