### PR TITLE
fix(ci): write npm auth token to both project and user .npmrc, unset NPM_CONFIG_USERCONFIG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1047,7 +1047,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
+          TOKEN="${NODE_AUTH_TOKEN}"
+          echo "//registry.npmjs.org/:_authToken=${TOKEN}" > .npmrc
+          echo "//registry.npmjs.org/:_authToken=${TOKEN}" > "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          unset NPM_CONFIG_USERCONFIG
           bun run ci:release:publish
 
   # Verify npm install works end-to-end after publishing


### PR DESCRIPTION
## What

Write the resolved npm auth token to both the project-root `.npmrc` and the user-level `.npmrc` (at `NPM_CONFIG_USERCONFIG` or `$HOME/.npmrc`), then unset `NPM_CONFIG_USERCONFIG` so npm falls back to standard `.npmrc` discovery order.

## Why

npm publish still gets 404 despite writing `.npmrc` to the project root. The `NPM_CONFIG_USERCONFIG` env var set by `actions/setup-node` may be directing npm to read a different `.npmrc` that has stale or template auth, bypassing the project-level file entirely. Writing to both locations and unsetting the override ensures npm finds the correct token regardless of which config path it resolves.

Closes #958

## Testing

- [ ] CI checks pass (publish-npm job authenticates successfully)
- [x] Issue linked via `Closes #958`