### PR TITLE
fix(settings): suppress persistent todo panel when todo.verbose is off

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -629,6 +629,9 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	#renderTodoList(): void {
 		this.todoContainer.clear();
+		if (!settings.get("todo.verbose")) {
+			return;
+		}
 		const phases = this.todoPhases.filter(phase => phase.tasks.length > 0);
 		if (phases.length === 0) {
 			return;


### PR DESCRIPTION
## What

Add a `todo.verbose` guard to `#renderTodoList()` in `interactive-mode.ts` so the persistent todo panel is hidden when the setting is `false`.

## Why

The `todo.verbose` setting (v18.77.0) suppressed `todo_write` tool calls and reminders in the chat transcript, but missed the persistent todo panel rendered by `#renderTodoList()`. The panel continued displaying at the bottom of the screen even when the setting was off. This adds the missing early-return check for consistency.

Closes #961

## Testing

- When `todo.verbose` is `false`, the todo panel no longer renders
- When `todo.verbose` is `true` (default), behaviour is unchanged

---

- [x] `bun run check` passes (pre-commit Biome lint passed)
- [x] Issue linked via `Closes #961`