### PR TITLE
feat(xcsh-api): reduce CRUD tool-call count by 28% via stop signals and instruction hierarchy fixes

### DIFF
--- a/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
@@ -249,6 +249,12 @@ function renderCatalogDetail(cat: ApiCatalogCategory, index: ApiCatalogIndex, op
 			sections.push(`Required fields: ${op.minimumPayload.requiredFields.join(", ")}`);
 			sections.push("", "```json", JSON.stringify(op.minimumPayload.json, null, 2), "```");
 		}
+		// Universal reference format hint — shown even in compact mode
+		if (op.method.toUpperCase() === "POST" || op.method.toUpperCase() === "PUT") {
+			sections.push(
+				'Object references: `{"namespace": "$F5XC_NAMESPACE", "name": "<name>"}`. Pool arrays: `[{"pool": {"namespace": "$F5XC_NAMESPACE", "name": "<name>"}, "weight": 1, "priority": 1}]`.',
+			);
+		}
 
 		// Field Constraints (Tier 2) — skipped in compact mode, deduped when identical across operations
 		if (op.fieldMetadata && Object.keys(op.fieldMetadata).length > 0 && !options?.compact) {

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -263,6 +263,8 @@ Most tools resolve custom protocol URLs to internal resources (not web URLs):
   Do not issue a follow-up GET to verify — the response body is the verification.
   Only issue a GET if the user explicitly asks to read current state, or if the
   initial call returned a non-2xx status.
+  For xcsh_api mutations, the 200 response satisfies the "verify the effect" requirement — do not GET the resource again.
+  For CREATE, you **MUST NOT** GET referenced dependencies (origin pools, firewalls) to verify they exist — include them by name. For UPDATE, GET the target resource for its current spec, but you **MUST NOT** GET other referenced resources.
 
   **Namespace discovery** — when the user asks what resources exist in a namespace
   (e.g. "what's in my namespace", "list everything configured", "show all resources"),

--- a/packages/coding-agent/src/tools/xcsh-api.ts
+++ b/packages/coding-agent/src/tools/xcsh-api.ts
@@ -502,7 +502,7 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 		}
 
 		sections.push(
-			"\nInventory complete. Resource summary above contains all relationship data. No further API calls needed.",
+			"\nInventory complete. All listed resources exist and are valid references for mutations. No further API calls needed.",
 		);
 		const batchTotalItems = relevantData.reduce((sum, r) => sum + (r.itemCount ?? 0), 0);
 		const text = sections.join("\n");
@@ -546,7 +546,7 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 				return `Access denied${ctxHint}. The API token may lack the required role or permission for this operation. Check the token's role assignments in the F5 XC console.`;
 			case 404: {
 				const ns = process.env.F5XC_NAMESPACE ?? this.#contextEnv.get("F5XC_NAMESPACE") ?? "default";
-				return `Resource not found in namespace \`${ns}\`${ctxHint}. Use a GET list operation to verify existing resources.`;
+				return `Resource not found in namespace \`${ns}\`${ctxHint}. Verify the resource name, or use POST to create it.`;
 			}
 			case 409:
 				return `Resource already exists${ctxHint}. Use PUT to replace the existing resource, or DELETE it first before creating a new one.`;
@@ -700,6 +700,33 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 					detail.errorCodeLabel = codeLabel;
 				}
 				return this.#errorResult(`${statusLine}\n\n${bodyText}\n\n${errorCodePrefix}${guidance}`, detail);
+			}
+			// Mutation stop signals + cache invalidation: reduce post-mutation verification GETs
+			if (response.status >= 200 && response.status < 300 && params.method !== "GET") {
+				// Invalidate batch cache so subsequent namespace queries reflect the mutation
+				const nsMatch = resolvedPath.match(/\/api\/config\/namespaces\/([^/]+)\//);
+				if (nsMatch?.[1]) {
+					const nsCachePath = `${os.tmpdir()}/xcsh-batch-${nsMatch[1]}.json`;
+					await Bun.write(nsCachePath, JSON.stringify({ ts: 0 })).catch(() => {});
+				}
+				// Append stop signal to prevent unnecessary verification GETs
+				const verb = params.method === "DELETE" ? "Deleted" : params.method === "POST" ? "Created" : "Updated";
+				// POST returns the full resource; PUT/DELETE return {}.
+				// Only claim response contains the resource for POST to avoid misleading the model.
+				const resourceHint =
+					params.method === "POST"
+						? "The response above contains the complete resource. No verification GET is needed. Reference this resource by name in subsequent mutations immediately."
+						: "No verification GET is needed.";
+
+				return {
+					content: [
+						{
+							type: "text",
+							text: `${statusLine}\n\n${bodyText}\n\n${verb} ${resolvedPath} successfully. ${resourceHint}`,
+						},
+					],
+					details: detail,
+				};
 			}
 
 			return {


### PR DESCRIPTION
Closes #963

## Summary

Reduces xcsh_api tool calls for CRUD operations by **28.7%** (32.6 → 23.3 calls, p<0.001, n=65 cross-validated benchmark runs).

## Changes (39 lines, 3 files)

### `packages/coding-agent/src/tools/xcsh-api.ts` (+31, 2 changed)
- **Mutation stop signals**: POST/PUT/DELETE 2xx responses include stop signal with resolved resource path as proof. POST adds "Reference this resource by name in subsequent mutations immediately" for multi-step workflows.
- **Accurate PUT stop signal**: F5 XC PUT returns `{}` — stop signal no longer falsely claims "response contains the complete resource."
- **Cache invalidation**: After successful mutation, invalidates the namespace batch cache to prevent stale reads.
- **404 guidance fix**: Changed from "Use a GET list operation to verify" (which triggered auto-expand) to "Verify the resource name, or use POST to create it."

### `packages/coding-agent/src/prompts/system/system-prompt.md` (+2 lines)
- **Verify-the-effect override**: "For xcsh_api mutations, the 200 response satisfies the 'verify the effect' requirement" — resolves conflict where `<critical>` section's general verification instruction outranked the xcsh_api-specific stop signal.
- **Dependency trust**: "For CREATE, you **MUST NOT** GET referenced dependencies (origin pools, firewalls) to verify they exist" — prevents pre-mutation reference verification GETs.

### `packages/coding-agent/src/internal-urls/api-catalog-resolve.ts` (+6 lines)
- **Reference format in compact mode**: Adds universal object reference format hint after minimum payload for POST/PUT operations. Compact mode skips field constraints, leaving the model blind to the `{namespace, name}` reference format.

## Benchmark

16 CRUD queries (CREATE/UPDATE/DELETE/mixed workflows) against live F5 XC API:

| Measure | System v18.75.3 | This PR |
|---|---|---|
| Mean | 32.6 calls (n=10) | **23.3 calls** (n=55) |
| SD | 1.6 | 0.8 |
| Mode | 33 | **23** (64% of runs) |
| Completeness | 87.2% | 87.2% |

**28.7% reduction, p<0.001.** Theoretical minimum is 22 calls; achieved in 8% of runs.

## Research Process

Phase 3 of the xcsh-api batch discovery optimization series (Phase 1: namespace inventory 20→1 calls; Phase 2: relationship queries 171→162 calls). 16 directions explored across 13 sessions, 10 kept with statistical evidence, 6 dropped.

Key finding: **system prompt instruction hierarchy matters more than response text** — the same instruction placed in system-prompt.md works where xcsh-api.md fails, because it overrides competing general instructions at the same priority level.