### PR TITLE
fix(ci): write npm auth token to $HOME/.npmrc for npm publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1047,10 +1047,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          TOKEN="${NODE_AUTH_TOKEN}"
-          echo "//registry.npmjs.org/:_authToken=${TOKEN}" > .npmrc
-          echo "//registry.npmjs.org/:_authToken=${TOKEN}" > "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
-          unset NPM_CONFIG_USERCONFIG
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > "$HOME/.npmrc"
           bun run ci:release:publish
 
   # Verify npm install works end-to-end after publishing


### PR DESCRIPTION
## What

Simplify npm auth token setup in the CI publish step to write directly to `$HOME/.npmrc`.

## Why

npm only checks `.npmrc` in the package directory (not walked up) and `~/.npmrc` for auth tokens. The previous approach wrote to both a local `.npmrc` and `$NPM_CONFIG_USERCONFIG` (a temp path), then unset the env var — leaving `~/.npmrc` potentially empty. Writing directly to `$HOME/.npmrc` is the canonical approach that npm always reads as user config.

Closes #964

## Testing

- [ ] CI checks pass
- [x] Issue linked via `Closes #964`

---

**Change:** 4 lines removed, 1 line added in `.github/workflows/ci.yml`