### PR TITLE
fix(settings): suppress todo_write in streaming render path

### DIFF
--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -240,6 +240,9 @@ export class EventController {
 								? { ...content.arguments, __partialJson: content.partialJson }
 								: content.arguments;
 						if (!this.ctx.pendingTools.has(content.id)) {
+							if (content.name === "todo_write" && !settings.get("todo.verbose")) {
+								continue;
+							}
 							this.#resetReadGroup();
 							this.ctx.chatContainer.addChild(new Spacer(1));
 							const tool = this.ctx.session.getToolByName(content.name);


### PR DESCRIPTION
## What

Add `todo.verbose` guard to the streaming render path in `EventController` so that `todo_write` tool calls are suppressed when the setting is disabled.

## Why

The `todo.verbose` setting only guarded the `tool_execution_start` event handler but missed the `message_update` streaming path (line ~242) where `ToolExecutionComponents` are created during assistant message streaming. The streaming path creates the component before `tool_execution_start` fires, so the existing guard was never reached. This caused `todo_write` UI elements to appear even when `todo.verbose` was set to `false`.

Closes #968

## Testing

- Verified that the `todo.verbose` check is applied consistently in the streaming render path
- Pre-commit hooks pass (Biome lint, governance checks, secrets detection, spelling)

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #N`