### PR TITLE
fix(tui): hide completed thinking label from transcript

### DIFF
--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -146,10 +146,13 @@ export class AssistantMessageComponent extends Container {
 					.some(c => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()));
 
 				if (this.hideThinkingBlock) {
-					// Show static "Thinking..." label when hidden
-					this.#contentContainer.addChild(new Text(theme.italic(theme.fg("thinkingText", "Thinking...")), 0, 0));
-					if (hasVisibleContentAfter) {
-						this.#contentContainer.addChild(new Spacer(1));
+					if (!message.stopReason) {
+						this.#contentContainer.addChild(
+							new Text(theme.italic(theme.fg("thinkingText", "Thinking...")), 0, 0),
+						);
+						if (hasVisibleContentAfter) {
+							this.#contentContainer.addChild(new Spacer(1));
+						}
 					}
 				} else {
 					// Thinking traces in thinkingText color, italic


### PR DESCRIPTION
## What

Hide the greyed-out "Thinking..." label from completed thinking blocks in the transcript when `hideThinkingBlock` is true (the default).

## Why

Completed thinking blocks showed a persistent "Thinking..." label in the transcript, creating visual clutter. Now the label only appears during active streaming (when `message.stopReason` is undefined) and is hidden once the message is done.

Closes #971

## Testing

- Biome lint and pre-commit hooks pass
- Visual: thinking label appears during streaming, disappears from transcript after message completes

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #N`