### PR TITLE
chore: add autoresearch-seed.sh and autoresearch-teardown.sh to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,8 @@ autoresearch.checks.sh
 autoresearch-loop.sh
 autoresearch.ideas.md
 autoresearch-queries.txt
+autoresearch-seed.sh
+autoresearch-teardown.sh
 autoresearch.jsonl
 .autoresearch/
 


### PR DESCRIPTION
## What

Add `autoresearch-seed.sh` and `autoresearch-teardown.sh` to `.gitignore` under the existing "Autoresearch session artifacts" section.

## Why

These local autoresearch harness files match the pattern of the 8 already-gitignored autoresearch artifacts. They show as untracked, preventing a clean working tree for the autoresearch experiment loop.

Closes #974

## Testing

- [x] `pre-commit` hooks pass (governance, large file, secrets, spelling, editorconfig)
- [x] No code changes — `.gitignore` only
- [x] Issue linked via `Closes #974`