### PR TITLE
feat(coding-agent): add getIntegrations convenience method to RPC client

### DIFF
--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -377,6 +377,18 @@ export class RpcClient {
 	}
 
 	/**
+	 * Get integration health status (F5 XC Context, GitLab, GitHub, Salesforce, Azure, AWS, Google Cloud).
+	 */
+	async getIntegrations(): Promise<{
+		version: string;
+		model: { state: "no_provider" | "connected" | "auth_error"; provider?: string; latencyMs?: number };
+		services: Array<{ name: string; state: "connected" | "unauthenticated" | "unavailable"; hint?: string }>;
+	}> {
+		const response = await this.#send({ type: "get_integrations" });
+		return this.#getData(response);
+	}
+
+	/**
 	 * Set thinking level.
 	 */
 	async setThinkingLevel(level: ThinkingLevel): Promise<void> {

--- a/packages/coding-agent/test/rpc.test.ts
+++ b/packages/coding-agent/test/rpc.test.ts
@@ -237,6 +237,16 @@ describe.skipIf(!e2eApiKey("ANTHROPIC_API_KEY"))("RPC mode", () => {
 		}
 	}, 30000);
 
+	test("should get integrations", async () => {
+		await client.start();
+		const result = await client.getIntegrations();
+
+		expect(result.version).toBeDefined();
+		expect(result.model).toBeDefined();
+		expect(result.model.state).toBeDefined();
+		expect(Array.isArray(result.services)).toBe(true);
+	}, 30000);
+
 	test("should get session stats", async () => {
 		await client.start();
 


### PR DESCRIPTION
## What

Add a `getIntegrations()` convenience method to the RPC client that wraps the existing `get_integrations` RPC command, providing a typed API for downstream consumers.

## Why

The RPC client had `getState()` and `getAvailableModels()` but was missing `getIntegrations()`. The vscode-f5xc-tools extension needs this to call the `get_integrations` RPC command through the typed client API.

Closes #980

## Testing

- Added E2E test following the existing test pattern (validates `version`, `model`, `model.state`, and `services` array are present in the response)
- Test uses the same `describe.skipIf(!e2eApiKey("ANTHROPIC_API_KEY"))` guard as other RPC tests

---

- [x] `bun run check` passes (pre-commit Biome lint passed)
- [x] `bun test` -- no new failures vs baseline
- [x] Issue linked via `Closes #980`