### PR TITLE
refactor(coding-agent): clean stale migration comment in namespace filtering

### DIFF
--- a/packages/coding-agent/src/tools/xcsh-api.ts
+++ b/packages/coding-agent/src/tools/xcsh-api.ts
@@ -6,9 +6,7 @@ import xcshApiDescription from "../prompts/tools/xcsh-api.md" with { type: "text
 import { type ContextEnv, createContextEnv } from "../services/context-env";
 import type { ToolSession } from ".";
 
-// ── Spec-driven namespace filtering ────────────────────────────────
-// Replaces hardcoded startsWith("ves-io")/startsWith("system")/startsWith("shared")
-// with data-driven classification aligned to x-f5xc-namespace-profile extension.
+// Namespace filtering driven by x-f5xc-namespace-profile from enriched API specs.
 
 type NamespaceType = "system" | "shared" | "default" | "custom";
 


### PR DESCRIPTION
## Summary
- Replace 3-line migration comment (referencing old hardcoded startsWith filters) with concise single-line comment referencing the x-f5xc-namespace-profile extension

Closes #984

## Test plan
- [ ] `bun test packages/coding-agent/test/xcsh-api-tool.test.ts` passes (15 tests)
- [ ] CI checks pass