### PR TITLE
feat: add xcsh://branding protocol handler and Terraform Provider Override

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@typescript/native-preview": "^7.0.0-dev.20260302.1",
         "lint-staged": "^16.3",
         "prettier": "^3.8",
+        "yaml": "2.9.0",
       },
     },
     "packages/agent": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
 		"@types/bun": "^1.3",
 		"@typescript/native-preview": "^7.0.0-dev.20260302.1",
 		"lint-staged": "^16.3",
-		"prettier": "^3.8"
+		"prettier": "^3.8",
+		"yaml": "2.9.0"
 	},
 	"lint-staged": {
 		"*.{js,ts,jsx,tsx,json,jsonc,css}": "biome check --write --no-errors-on-unmatched"

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -31,9 +31,9 @@
 		"xcsh": "src/cli.ts"
 	},
 	"scripts": {
-		"build": "bun run generate-build-info && bun run generate-api-spec-index && test -f src/internal-urls/api-spec-index.generated.ts && bun --cwd=../stats scripts/generate-client-bundle.ts --generate && bun --cwd=../natives run embed:native && bun build --compile --define PI_COMPILED=true --external mupdf --root ../.. ./src/cli.ts --outfile dist/xcsh && bun --cwd=../natives run embed:native --reset && bun --cwd=../stats scripts/generate-client-bundle.ts --reset",
+		"build": "bun run generate-build-info && bun run generate-api-spec-index && bun run generate-branding-index && test -f src/internal-urls/api-spec-index.generated.ts && bun --cwd=../stats scripts/generate-client-bundle.ts --generate && bun --cwd=../natives run embed:native && bun build --compile --define PI_COMPILED=true --external mupdf --root ../.. ./src/cli.ts --outfile dist/xcsh && bun --cwd=../natives run embed:native --reset && bun --cwd=../stats scripts/generate-client-bundle.ts --reset",
 		"check": "biome check . && bun run format-prompts -- --check && bun run check:types",
-		"check:types": "bun run generate-build-info && bun run generate-api-spec-index && tsgo -p tsconfig.json --noEmit",
+		"check:types": "bun run generate-build-info && bun run generate-api-spec-index && bun run generate-branding-index && tsgo -p tsconfig.json --noEmit",
 		"lint": "biome lint .",
 		"test": "bun run generate-build-info && bun run generate-api-spec-index && bun test --max-concurrency 4",
 		"fix": "biome check --write --unsafe . && bun run format-prompts && bun run generate-docs-index && bun run generate-api-spec-index && bun run generate-build-info",
@@ -41,6 +41,7 @@
 		"format-prompts": "bun scripts/format-prompts.ts",
 		"generate-docs-index": "bun scripts/generate-docs-index.ts",
 		"generate-api-spec-index": "bun scripts/generate-api-spec-index.ts",
+		"generate-branding-index": "bun scripts/generate-branding-index.ts",
 		"generate-build-info": "bun scripts/generate-build-info.ts",
 		"prepack": "bun scripts/generate-docs-index.ts && bun scripts/generate-api-spec-index.ts && bun scripts/generate-build-info.ts",
 		"generate-template": "bun scripts/generate-template.ts"

--- a/packages/coding-agent/scripts/generate-branding-index.ts
+++ b/packages/coding-agent/scripts/generate-branding-index.ts
@@ -1,0 +1,78 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import YAML from "yaml";
+
+const OUTPUT_FILE = path.join(import.meta.dir, "..", "src", "internal-urls", "branding-index.generated.ts");
+
+const LOCAL_BRANDING_PATH = path.resolve(
+	import.meta.dir,
+	"..",
+	"..",
+	"..",
+	"..",
+	"api-specs-enriched",
+	"config",
+	"branding.yaml",
+);
+
+const GITHUB_RAW_URL = "https://raw.githubusercontent.com/f5xc-salesdemos/api-specs-enriched/main/config/branding.yaml";
+
+interface BrandingCanonical {
+	long_form: string;
+	description?: string;
+	legacy_names: string[];
+	comparable_to: string[];
+}
+
+interface DeprecationEntry {
+	deprecated: Record<string, string>;
+	canonical: Record<string, string>;
+	required_providers_block?: string;
+}
+
+interface BrandingConfig {
+	version: string;
+	description: string;
+	canonical: Record<string, BrandingCanonical>;
+	deprecations: Record<string, DeprecationEntry>;
+	glossary: Record<string, Record<string, string>>;
+	domain_branding: Record<string, Record<string, string>>;
+}
+
+async function loadBrandingYaml(): Promise<BrandingConfig> {
+	const localFile = Bun.file(LOCAL_BRANDING_PATH);
+	if (await localFile.exists()) {
+		const content = await localFile.text();
+		return YAML.parse(content) as BrandingConfig;
+	}
+
+	const response = await fetch(GITHUB_RAW_URL);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch branding.yaml: ${response.status}`);
+	}
+	return YAML.parse(await response.text()) as BrandingConfig;
+}
+
+function generateTypeScript(config: BrandingConfig): string {
+	const lines: string[] = [
+		"// AUTO-GENERATED — do not edit. Run `bun generate-branding-index` to regenerate.",
+		"",
+		`export const BRANDING_VERSION = ${JSON.stringify(config.version)};`,
+		"",
+		`export const BRANDING_CANONICAL = ${JSON.stringify(config.canonical, null, 2)} as const;`,
+		"",
+		`export const BRANDING_DEPRECATIONS = ${JSON.stringify(config.deprecations, null, 2)} as const;`,
+		"",
+		`export const BRANDING_GLOSSARY = ${JSON.stringify(config.glossary, null, 2)} as const;`,
+		"",
+		`export const BRANDING_DOMAIN = ${JSON.stringify(config.domain_branding, null, 2)} as const;`,
+		"",
+	];
+
+	return lines.join("\n");
+}
+
+const config = await loadBrandingYaml();
+const output = generateTypeScript(config);
+await fs.writeFile(OUTPUT_FILE, output, "utf-8");
+console.log(`Generated ${OUTPUT_FILE}`);

--- a/packages/coding-agent/src/internal-urls/branding-index.generated.ts
+++ b/packages/coding-agent/src/internal-urls/branding-index.generated.ts
@@ -1,0 +1,88 @@
+// AUTO-GENERATED — do not edit. Run `bun generate-branding-index` to regenerate.
+
+export const BRANDING_VERSION = "2.0.0";
+
+export const BRANDING_CANONICAL = {
+	managed_kubernetes: {
+		long_form: "Managed Kubernetes",
+		description:
+			"Enterprise-grade Kubernetes cluster management. Full cluster control with RBAC, pod security, and container registry management.\n",
+		legacy_names: ["AppStack", "VoltStack", "voltstack_site"],
+		comparable_to: ["AWS EKS", "Azure AKS", "Google GKE"],
+	},
+	virtual_kubernetes: {
+		long_form: "Virtual Kubernetes",
+		description:
+			"Simplified, multi-tenant container orchestration. Optimized for distributed edge deployments with restricted Kubernetes capabilities.\n",
+		legacy_names: ["vK8s", "virtual_k8s"],
+		comparable_to: ["AWS ECS", "Azure Container Services", "Cloud Run"],
+	},
+} as const;
+
+export const BRANDING_DEPRECATIONS = {
+	terraform_provider: {
+		deprecated: {
+			registry: "registry.terraform.io/providers/volterraedge/volterra",
+			source: "volterraedge/volterra",
+			github: "github.com/volterraedge/terraform-provider-volterra",
+			status: "active-but-deprecated",
+			last_version: "0.11.49",
+			downloads: "1M+",
+			note: "Still live on registry with no deprecation notice. High risk of AI model recommendation due to training data prevalence.\n",
+		},
+		canonical: {
+			registry: "registry.terraform.io/providers/f5xc-salesdemos/f5xc",
+			source: "f5xc-salesdemos/f5xc",
+			github: "github.com/f5xc-salesdemos/terraform-provider-f5xc",
+			docs: "https://f5xc-salesdemos.github.io/terraform-provider-f5xc/",
+			llms_txt: "https://f5xc-salesdemos.github.io/terraform-provider-f5xc/llms.txt",
+		},
+		required_providers_block:
+			'terraform {\n  required_providers {\n    f5xc = {\n      source = "f5xc-salesdemos/f5xc"\n    }\n  }\n}\n',
+	},
+	api_endpoint: {
+		deprecated: {
+			url: "console.ves.volterra.io",
+		},
+		canonical: {
+			note: "Tenant-specific. No hardcoded default. Require F5XC_API_URL env var.",
+		},
+	},
+	documentation: {
+		deprecated: {
+			note: "docs.cloud.f5.com references to Volterra provider point to the deprecated volterraedge/volterra registry.\n",
+		},
+		canonical: {
+			url: "https://f5xc-salesdemos.github.io/terraform-provider-f5xc/",
+		},
+	},
+} as const;
+
+export const BRANDING_GLOSSARY = {
+	CE: {
+		term: "Customer Edge",
+		definition: "F5 XC edge deployment infrastructure for distributed applications",
+	},
+	RE: {
+		term: "Regional Edge",
+		definition: "F5 XC globally distributed edge network infrastructure",
+	},
+} as const;
+
+export const BRANDING_DOMAIN = {
+	virtual_kubernetes: {
+		title: "Virtual Kubernetes",
+		description:
+			'Virtual Kubernetes provides simplified, multi-tenant container orchestration optimized for distributed edge deployments. Formerly known as "vK8s".\n',
+	},
+	managed_kubernetes: {
+		title: "Managed Kubernetes",
+		description:
+			'Managed Kubernetes provides enterprise-grade cluster management with full RBAC, pod security, and container registry support. Formerly known as "AppStack".\n',
+	},
+	sites: {
+		title: "Customer Edge Sites",
+		description:
+			"Site deployment and management across cloud providers (AWS VPC, Azure VNET, GCP VPC), Managed Kubernetes deployments (formerly AppStack), and Secure Mesh deployments for networking-focused edge sites.\n",
+	},
+} as const;

--- a/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
@@ -42,6 +42,7 @@ const SCHEME_PREFIX = "xcsh://";
 const ABOUT_ROUTE = "about";
 const API_SPEC_HOST = "api-spec";
 const API_CATALOG_HOST = "api-catalog";
+const BRANDING_HOST = "branding";
 const USER_ROUTE = "user";
 const COMPUTER_ROUTE = "computer";
 const SALESFORCE_ROUTE = "salesforce";
@@ -138,6 +139,59 @@ function loadApiCatalog(): {
 	return _apiCatalogCache;
 }
 
+interface BrandingCanonicalEntry {
+	long_form: string;
+	description?: string;
+	legacy_names?: string[];
+	comparable_to?: string[];
+}
+
+interface BrandingDeprecationEntry {
+	deprecated: Record<string, string>;
+	canonical: Record<string, string>;
+	required_providers_block?: string;
+}
+
+let _brandingCache: {
+	version: string;
+	canonical: Record<string, BrandingCanonicalEntry>;
+	deprecations: Record<string, BrandingDeprecationEntry>;
+	glossary: Record<string, Record<string, string>>;
+	domain: Record<string, Record<string, string>>;
+} | null = null;
+
+function loadBranding(): {
+	version: string;
+	canonical: Record<string, BrandingCanonicalEntry>;
+	deprecations: Record<string, BrandingDeprecationEntry>;
+	glossary: Record<string, Record<string, string>>;
+	domain: Record<string, Record<string, string>>;
+} {
+	if (_brandingCache) return _brandingCache;
+	try {
+		const mod = require("./branding-index.generated") as {
+			BRANDING_VERSION?: string;
+			BRANDING_CANONICAL?: Record<string, BrandingCanonicalEntry>;
+			BRANDING_DEPRECATIONS?: Record<string, BrandingDeprecationEntry>;
+			BRANDING_GLOSSARY?: Record<string, Record<string, string>>;
+			BRANDING_DOMAIN?: Record<string, Record<string, string>>;
+		};
+		_brandingCache = {
+			version: mod.BRANDING_VERSION ?? "unknown",
+			canonical: (mod.BRANDING_CANONICAL ?? {}) as Record<string, BrandingCanonicalEntry>,
+			deprecations: (mod.BRANDING_DEPRECATIONS ?? {}) as Record<string, BrandingDeprecationEntry>,
+			glossary: mod.BRANDING_GLOSSARY ?? {},
+			domain: mod.BRANDING_DOMAIN ?? {},
+		};
+	} catch (err) {
+		logger.warn("branding index unavailable, branding protocol disabled", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+		_brandingCache = { version: "unavailable", canonical: {}, deprecations: {}, glossary: {}, domain: {} };
+	}
+	return _brandingCache;
+}
+
 export interface InternalDocsProtocolOptions {
 	readonly resolveBuildInfo?: () => Promise<RuntimeBuildInfo>;
 	readonly getContextStatus?: () => ContextStatus | null;
@@ -195,6 +249,10 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 
 		if (host === API_CATALOG_HOST) {
 			return this.#getApiCatalogResolver().resolve(url);
+		}
+
+		if (host === BRANDING_HOST) {
+			return this.#resolveBranding(url);
 		}
 
 		if (host === USER_ROUTE) {
@@ -274,9 +332,11 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 
 		const specs = loadApiSpecs();
 		const catalog = loadApiCatalog();
+		const branding = loadBranding();
 		const syntheticEntry = `- [${ABOUT_ROUTE}](${SCHEME_PREFIX}${ABOUT_ROUTE}) — identity and build fingerprint`;
 		const apiSpecEntry = `- [${API_SPEC_HOST}/](${SCHEME_PREFIX}${API_SPEC_HOST}/) — F5 XC API specifications (${specs.index.domains.length} domains, v${specs.version})`;
 		const apiCatalogEntry = `- [${API_CATALOG_HOST}/](${SCHEME_PREFIX}${API_CATALOG_HOST}/) — F5 XC API operation catalog (${catalog.summaries.length} categories, v${catalog.index.version})`;
+		const brandingEntry = `- [${BRANDING_HOST}](${SCHEME_PREFIX}${BRANDING_HOST}) — F5 XC branding and legacy name mapping (v${branding.version})`;
 		const userEntry = `- [${USER_ROUTE}](${SCHEME_PREFIX}${USER_ROUTE}) — human user profile`;
 		const computerEntry = `- [${COMPUTER_ROUTE}](${SCHEME_PREFIX}${COMPUTER_ROUTE}) — machine hardware and environment profile`;
 		const salesforceEntry = `- [${SALESFORCE_ROUTE}](${SCHEME_PREFIX}${SALESFORCE_ROUTE}) — Salesforce pipeline context and team discovery`;
@@ -284,12 +344,13 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 			syntheticEntry,
 			apiSpecEntry,
 			apiCatalogEntry,
+			brandingEntry,
 			userEntry,
 			computerEntry,
 			salesforceEntry,
 			...EMBEDDED_DOC_FILENAMES.map(f => `- [${f}](${SCHEME_PREFIX}${f})`),
 		].join("\n");
-		const totalCount = EMBEDDED_DOC_FILENAMES.length + 6;
+		const totalCount = EMBEDDED_DOC_FILENAMES.length + 7;
 		const content = `# Documentation\n\n${totalCount} files available:\n\n${listing}\n`;
 
 		return {
@@ -299,6 +360,156 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 			size: Buffer.byteLength(content, "utf-8"),
 			sourcePath: SCHEME_PREFIX,
 		};
+	}
+
+	#resolveBranding(url: InternalUrl): InternalResource {
+		const subpath = (url.rawPathname ?? url.pathname).replace(/^\/+/, "").replace(/\/+$/, "");
+
+		let content: string;
+
+		if (!subpath || subpath === "/") {
+			content = this.#brandingOverview();
+		} else if (subpath === "terraform") {
+			content = this.#brandingTerraform();
+		} else if (subpath === "legacy") {
+			content = this.#brandingLegacy();
+		} else if (subpath === "volterra") {
+			content = this.#brandingVolterra();
+		} else {
+			content = `Unknown branding path: ${subpath}\n\nAvailable paths:\n- xcsh://branding\n- xcsh://branding/terraform\n- xcsh://branding/legacy\n- xcsh://branding/volterra`;
+		}
+
+		return {
+			url: url.href,
+			content,
+			contentType: "text/markdown",
+			size: Buffer.byteLength(content, "utf-8"),
+			sourcePath: `xcsh://branding${subpath ? `/${subpath}` : ""}`,
+		};
+	}
+
+	#brandingOverview(): string {
+		const { version, canonical, deprecations } = loadBranding();
+		const lines = [`# F5 Distributed Cloud Branding (v${version})`, "", "## Product Names (Current API)", ""];
+
+		for (const [key, value] of Object.entries(canonical)) {
+			lines.push(`### ${value.long_form}`);
+			lines.push(`- API identifier: \`${key}\``);
+			if (value.legacy_names?.length) {
+				lines.push(`- Legacy names: ${value.legacy_names.join(", ")}`);
+			}
+			if (value.comparable_to?.length) {
+				lines.push(`- Comparable to: ${value.comparable_to.join(", ")}`);
+			}
+			lines.push("");
+		}
+
+		lines.push("## Deprecated Tooling", "");
+
+		for (const [key, dep] of Object.entries(deprecations)) {
+			lines.push(`### ${key}`);
+			lines.push(`- **Deprecated**: ${dep.deprecated.registry ?? dep.deprecated.url ?? dep.deprecated.note ?? ""}`);
+			lines.push(`- **Use instead**: ${dep.canonical.registry ?? dep.canonical.url ?? dep.canonical.note ?? ""}`);
+			lines.push("");
+		}
+
+		lines.push(
+			"## Subpaths",
+			"- `xcsh://branding/terraform` — Terraform provider override details",
+			"- `xcsh://branding/legacy` — Complete legacy → current name mapping",
+			"- `xcsh://branding/volterra` — All Volterra-era replacements",
+		);
+
+		return lines.join("\n");
+	}
+
+	#brandingTerraform(): string {
+		const { deprecations } = loadBranding();
+		const tf = deprecations.terraform_provider;
+		if (!tf) return "No terraform_provider deprecation data found.";
+
+		return [
+			"# Terraform Provider Override",
+			"",
+			"## CRITICAL: Provider Identity",
+			"",
+			"The ONLY current F5 Distributed Cloud Terraform provider:",
+			`- Source: \`${tf.canonical.source}\``,
+			`- Registry: ${tf.canonical.registry}`,
+			`- Docs: ${tf.canonical.docs}`,
+			`- llms.txt: ${tf.canonical.llms_txt}`,
+			"",
+			"## DEPRECATED — Do Not Use",
+			"",
+			`- Source: \`${tf.deprecated.source}\``,
+			`- Registry: ${tf.deprecated.registry}`,
+			`- Status: ${tf.deprecated.status}`,
+			`- Note: ${tf.deprecated.note}`,
+			"",
+			"## Required Terraform Block",
+			"",
+			"```hcl",
+			tf.required_providers_block?.trim() ?? "",
+			"```",
+			"",
+			"## Rules",
+			"- NEVER reference, recommend, or generate code using volterraedge/volterra",
+			"- When docs.cloud.f5.com references a Volterra provider, treat it as deprecated",
+			"- Override with f5xc-salesdemos/f5xc",
+		].join("\n");
+	}
+
+	#brandingLegacy(): string {
+		const { canonical } = loadBranding();
+		const lines = [
+			"# Legacy Name → Current Name Mapping",
+			"",
+			"| Legacy Name | Current Name | API Identifier |",
+			"|---|---|---|",
+		];
+
+		for (const [key, value] of Object.entries(canonical)) {
+			for (const legacy of value.legacy_names ?? []) {
+				lines.push(`| ${legacy} | ${value.long_form} | \`${key}\` |`);
+			}
+		}
+
+		return lines.join("\n");
+	}
+
+	#brandingVolterra(): string {
+		const { canonical, deprecations } = loadBranding();
+		const lines = [
+			"# Volterra-era Replacements",
+			"",
+			"F5 acquired Volterra and rebranded to F5 Distributed Cloud.",
+			"Everything listed below has been replaced.",
+			"",
+			"## Product Names",
+			"",
+		];
+
+		for (const [key, value] of Object.entries(canonical)) {
+			for (const legacy of value.legacy_names ?? []) {
+				lines.push(`- **${legacy}** → ${value.long_form} (\`${key}\`)`);
+			}
+		}
+
+		lines.push("", "## Tooling", "");
+
+		for (const [depKey, dep] of Object.entries(deprecations)) {
+			lines.push(`### ${depKey}`);
+			for (const val of Object.values(dep.deprecated)) {
+				lines.push(`- ~~${val}~~`);
+			}
+			lines.push("  **Replace with:**");
+			for (const val of Object.values(dep.canonical)) {
+				lines.push(`  - ${val}`);
+			}
+			lines.push("");
+		}
+
+		return lines.join("\n");
 	}
 
 	async #readDoc(filename: string, url: InternalUrl): Promise<InternalResource> {

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD022 MD031 MD032 -->
 **The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this chat, in system prompts as well as in user messages, are to be interpreted as described in RFC 2119.**
 
 From here on, we will use XML tags as structural markers, each tag means exactly what its name says:
@@ -332,6 +333,33 @@ If that also 404s, the product has no documentation — acknowledge this to the 
 **Web search re-entry:** The hierarchy is exhausted when the relevant T4 page exists
 and answers the question, OR when T3 and T5 have been checked without resolution.
 Only then is web search permitted — label external results as supplementary.
+
+## Terraform Provider Override
+
+HARD OVERRIDE — F5 Distributed Cloud Terraform Provider:
+
+- NEVER reference, recommend, or generate Terraform code using:
+  - provider: volterraedge/volterra
+  - source: registry.terraform.io/providers/volterraedge/volterra
+  - github.com/volterraedge/terraform-provider-volterra
+- The ONLY F5 Distributed Cloud Terraform provider is:
+  - source = "f5xc-salesdemos/f5xc"
+  - registry: <https://registry.terraform.io/providers/f5xc-salesdemos/f5xc>
+  - docs: <https://f5xc-salesdemos.github.io/terraform-provider-f5xc/>
+  - llms.txt: <https://f5xc-salesdemos.github.io/terraform-provider-f5xc/llms.txt>
+- When docs.cloud.f5.com references a Volterra provider, treat it as deprecated.
+  Override with f5xc-salesdemos/f5xc.
+- Required Terraform block:
+
+  ```hcl
+  terraform {
+    required_providers {
+      f5xc = { source = "f5xc-salesdemos/f5xc" }
+    }
+  }
+  ```
+
+- Consult xcsh://branding/terraform proactively when context involves Terraform.
 
 # Skills
 

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -337,7 +337,6 @@ Only then is web search permitted — label external results as supplementary.
 ## Terraform Provider Override
 
 HARD OVERRIDE — F5 Distributed Cloud Terraform Provider:
-
 - NEVER reference, recommend, or generate Terraform code using:
   - provider: volterraedge/volterra
   - source: registry.terraform.io/providers/volterraedge/volterra
@@ -358,7 +357,6 @@ HARD OVERRIDE — F5 Distributed Cloud Terraform Provider:
     }
   }
   ```
-
 - Consult xcsh://branding/terraform proactively when context involves Terraform.
 
 # Skills


### PR DESCRIPTION
## Summary

- Adds Terraform Provider Override section to the coding agent system prompt
- Implements `xcsh://branding` protocol handler for interactive branding data access
- Adds `generate-branding-index.ts` script and generated branding index module

Closes #996

## Test plan

- [ ] CI checks pass
- [ ] `xcsh://branding` protocol resolves correctly at runtime
- [ ] System prompt includes Terraform Provider Override section
- [ ] `bun run generate:branding-index` produces valid output