### PR TITLE
feat(tui): add TUI renderers for all unstyled custom tools

### DIFF
--- a/packages/coding-agent/src/tools/action-renderer.ts
+++ b/packages/coding-agent/src/tools/action-renderer.ts
@@ -1,0 +1,198 @@
+/** TUI renderer for lightweight action tools — checkpoint, rewind, cancel_job, poll. */
+import type { Component } from "@f5xc-salesdemos/pi-tui";
+import { Text } from "@f5xc-salesdemos/pi-tui";
+import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import type { Theme, ThemeColor } from "../modes/theme/theme";
+import { CachedOutputBlock, F5_TOOL_BORDER_COLOR, renderStatusLine } from "../tui";
+import type { CancelJobToolDetails } from "./cancel-job";
+import type { CheckpointToolDetails, RewindToolDetails } from "./checkpoint";
+import type { PollToolDetails } from "./poll-tool";
+import { addSection, formatErrorMessage, replaceTabs } from "./render-utils";
+
+type ActionDetails = CheckpointToolDetails | RewindToolDetails | CancelJobToolDetails | PollToolDetails;
+
+type ActionRenderArgs = {
+	goal?: string;
+	report?: string;
+	job_id?: string;
+	jobs?: string[];
+};
+
+const CANCEL_STATUS_COLORS: Record<string, ThemeColor> = {
+	cancelled: "success",
+	not_found: "warning",
+	already_completed: "dim",
+};
+
+const POLL_STATUS_COLORS: Record<string, ThemeColor> = {
+	completed: "success",
+	failed: "error",
+	running: "chromeAccent",
+	cancelled: "warning",
+};
+
+function formatDuration(ms: number): string {
+	if (ms < 1_000) return `${ms}ms`;
+	const seconds = Math.floor(ms / 1_000);
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	const remainingSeconds = seconds % 60;
+	return `${minutes}m${remainingSeconds}s`;
+}
+
+function isCheckpointDetails(d: ActionDetails): d is CheckpointToolDetails {
+	return "goal" in d && "startedAt" in d;
+}
+
+function isRewindDetails(d: ActionDetails): d is RewindToolDetails {
+	return "report" in d && "rewound" in d;
+}
+
+function isCancelJobDetails(d: ActionDetails): d is CancelJobToolDetails {
+	return "status" in d && "jobId" in d;
+}
+
+function isPollDetails(d: ActionDetails): d is PollToolDetails {
+	return "jobs" in d && Array.isArray((d as PollToolDetails).jobs);
+}
+
+function buildPollJobTable(details: PollToolDetails, uiTheme: Theme): string[] {
+	const jobs = details.jobs;
+	if (jobs.length === 0) return [uiTheme.fg("dim", "  No jobs.")];
+
+	return jobs.map(job => {
+		const statusColor = POLL_STATUS_COLORS[job.status] ?? "muted";
+		const status = uiTheme.fg(statusColor, job.status.padEnd(10));
+		const id = uiTheme.fg("toolOutput", job.id);
+		const typeBadge = uiTheme.fg("dim", `[${job.type}]`);
+		const label = uiTheme.fg("muted", job.label.length > 50 ? `${job.label.slice(0, 47)}…` : job.label);
+		const duration = uiTheme.fg("dim", formatDuration(job.durationMs));
+		return `  ${status}  ${id} ${typeBadge}  ${label}  ${duration}`;
+	});
+}
+
+export const actionRenderer = {
+	renderCall(args: ActionRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
+		let title: string;
+		let description: string | undefined;
+
+		if (args.goal !== undefined) {
+			title = "Checkpoint";
+			description = uiTheme.fg("muted", args.goal.length > 60 ? `${args.goal.slice(0, 57)}…` : args.goal);
+		} else if (args.report !== undefined) {
+			title = "Rewind";
+		} else if (args.job_id !== undefined) {
+			title = "Cancel Job";
+			description = uiTheme.fg("muted", args.job_id);
+		} else if (args.jobs !== undefined) {
+			title = "Poll";
+			description =
+				args.jobs.length > 0
+					? uiTheme.fg("muted", `${args.jobs.length} job${args.jobs.length !== 1 ? "s" : ""}`)
+					: undefined;
+		} else {
+			title = "Poll";
+		}
+
+		const text = renderStatusLine({ icon: "pending", title, description }, uiTheme);
+		return new Text(text, 0, 0);
+	},
+
+	renderResult(
+		result: { content: Array<{ type: string; text?: string }>; details?: ActionDetails; isError?: boolean },
+		options: RenderResultOptions,
+		uiTheme: Theme,
+		_args?: ActionRenderArgs,
+	): Component {
+		const details = result.details;
+		const isError = result.isError === true;
+
+		if (isError || !details) {
+			const errorText = result.content?.find(c => c.type === "text")?.text;
+			return new Text(formatErrorMessage(errorText, uiTheme), 0, 0);
+		}
+
+		const sections: Array<{ label?: string; lines: string[] }> = [];
+		const meta: string[] = [];
+		let title: string;
+		let badgeLabel: string;
+		let badgeColor: ThemeColor;
+
+		if (isCheckpointDetails(details)) {
+			title = "Checkpoint";
+			badgeLabel = "created";
+			badgeColor = "chromeAccent";
+			addSection(sections, "Goal", [uiTheme.fg("toolOutput", `  ${details.goal}`)], uiTheme);
+		} else if (isRewindDetails(details)) {
+			title = "Rewind";
+			badgeLabel = details.rewound ? "rewound" : "no-op";
+			badgeColor = details.rewound ? "warning" : "dim";
+			addSection(
+				sections,
+				"Report",
+				details.report.split("\n").map(line => replaceTabs(uiTheme.fg("toolOutput", `  ${line}`))),
+				uiTheme,
+			);
+		} else if (isCancelJobDetails(details)) {
+			title = "Cancel Job";
+			badgeLabel = details.status;
+			badgeColor = CANCEL_STATUS_COLORS[details.status] ?? "muted";
+			meta.push(uiTheme.fg("dim", details.jobId));
+			const text = result.content?.find(c => c.type === "text")?.text ?? "";
+			addSection(sections, "Result", [uiTheme.fg("toolOutput", `  ${text}`)], uiTheme);
+		} else if (isPollDetails(details)) {
+			title = "Poll";
+			const completed = details.jobs.filter(j => j.status !== "running");
+			const running = details.jobs.filter(j => j.status === "running");
+			badgeLabel = `${details.jobs.length} job${details.jobs.length !== 1 ? "s" : ""}`;
+			badgeColor = running.length > 0 ? "chromeAccent" : "success";
+			if (completed.length > 0) meta.push(uiTheme.fg("success", `${completed.length} done`));
+			if (running.length > 0) meta.push(uiTheme.fg("chromeAccent", `${running.length} running`));
+			addSection(sections, "Jobs", buildPollJobTable(details, uiTheme), uiTheme);
+			for (const job of completed) {
+				if (job.resultText) {
+					const outputLines = job.resultText.split("\n").map(line => replaceTabs(uiTheme.fg("toolOutput", line)));
+					addSection(sections, `Output: ${job.id}`, outputLines, uiTheme, 30);
+				}
+				if (job.errorText) {
+					addSection(sections, `Error: ${job.id}`, [uiTheme.fg("error", job.errorText)], uiTheme);
+				}
+			}
+		} else {
+			title = "Action";
+			badgeLabel = "done";
+			badgeColor = "muted";
+			const text = result.content?.find(c => c.type === "text")?.text ?? "";
+			addSection(
+				sections,
+				"Result",
+				text.split("\n").map(line => replaceTabs(uiTheme.fg("toolOutput", line))),
+				uiTheme,
+			);
+		}
+
+		const header = renderStatusLine(
+			{
+				title,
+				titleColor: "muted",
+				badge: { label: badgeLabel, color: badgeColor },
+				meta: meta.length > 0 ? meta : undefined,
+			},
+			uiTheme,
+		);
+
+		const outputBlock = new CachedOutputBlock();
+		return {
+			render(width: number): string[] {
+				const state = options.isPartial ? "pending" : "success";
+				return outputBlock.render({ header, state, sections, width, borderColor: F5_TOOL_BORDER_COLOR }, uiTheme);
+			},
+			invalidate() {
+				outputBlock.invalidate();
+			},
+		};
+	},
+
+	mergeCallAndResult: true,
+	inline: true,
+};

--- a/packages/coding-agent/src/tools/browser-renderer.ts
+++ b/packages/coding-agent/src/tools/browser-renderer.ts
@@ -1,0 +1,129 @@
+/** TUI renderer for the browser (puppeteer) tool — lightweight action-aware display. */
+import type { Component } from "@f5xc-salesdemos/pi-tui";
+import { Text } from "@f5xc-salesdemos/pi-tui";
+import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import type { Theme, ThemeColor } from "../modes/theme/theme";
+import { CachedOutputBlock, F5_TOOL_BORDER_COLOR, renderStatusLine } from "../tui";
+import type { BrowserToolDetails } from "./browser";
+import { addSection, formatErrorMessage, replaceTabs, shortenPath } from "./render-utils";
+
+const TOOL_TITLE = "Browser";
+const MAX_CONTENT_LINES = 30;
+
+type BrowserRenderArgs = {
+	action?: string;
+	url?: string;
+	selector?: string;
+	text?: string;
+};
+
+const ACTION_COLORS: Partial<Record<string, ThemeColor>> = {
+	open: "muted",
+	goto: "muted",
+	close: "dim",
+	click: "chromeAccent",
+	click_id: "chromeAccent",
+	type: "chromeAccent",
+	type_id: "chromeAccent",
+	fill: "chromeAccent",
+	fill_id: "chromeAccent",
+	press: "chromeAccent",
+	scroll: "muted",
+	drag: "chromeAccent",
+	wait_for_selector: "dim",
+	evaluate: "contentAccent",
+	get_text: "contentAccent",
+	get_html: "contentAccent",
+	get_attribute: "contentAccent",
+	extract_readable: "contentAccent",
+	screenshot: "warning",
+	observe: "accent",
+};
+
+export const browserRenderer = {
+	renderCall(args: BrowserRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
+		const action = args.action ?? "browse";
+		const description = args.url
+			? uiTheme.fg("muted", args.url)
+			: args.selector
+				? uiTheme.fg("dim", args.selector)
+				: undefined;
+		const badgeColor = ACTION_COLORS[action] ?? "muted";
+		const text = renderStatusLine(
+			{ icon: "pending", title: TOOL_TITLE, badge: { label: action, color: badgeColor }, description },
+			uiTheme,
+		);
+		return new Text(text, 0, 0);
+	},
+
+	renderResult(
+		result: { content: Array<{ type: string; text?: string }>; details?: BrowserToolDetails; isError?: boolean },
+		options: RenderResultOptions,
+		uiTheme: Theme,
+		args?: BrowserRenderArgs,
+	): Component {
+		const details = result.details;
+		const isError = result.isError === true;
+
+		if (isError && !details) {
+			const errorText = result.content?.find(c => c.type === "text")?.text;
+			return new Text(formatErrorMessage(errorText, uiTheme), 0, 0);
+		}
+
+		const action = details?.action ?? args?.action ?? "browse";
+		const badgeColor = ACTION_COLORS[action] ?? "muted";
+		const sections: Array<{ label?: string; lines: string[] }> = [];
+		const meta: string[] = [];
+
+		if (isError) {
+			const errorText = result.content?.find(c => c.type === "text")?.text ?? "Unknown error";
+			addSection(sections, "Error", [uiTheme.fg("error", errorText)], uiTheme);
+		} else {
+			if (details?.url)
+				meta.push(uiTheme.fg("dim", details.url.length > 50 ? `${details.url.slice(0, 47)}…` : details.url));
+
+			if (details?.screenshotPath) {
+				addSection(
+					sections,
+					"Screenshot",
+					[uiTheme.fg("toolOutput", `  ${shortenPath(details.screenshotPath)}`)],
+					uiTheme,
+				);
+			}
+
+			if (details?.viewport) {
+				meta.push(uiTheme.fg("dim", `${details.viewport.width}×${details.viewport.height}`));
+			}
+
+			const textContent = result.content?.find(c => c.type === "text")?.text;
+			if (textContent) {
+				const contentLines = textContent.split("\n").map(line => replaceTabs(uiTheme.fg("toolOutput", line)));
+				addSection(sections, "Result", contentLines, uiTheme, MAX_CONTENT_LINES);
+			}
+		}
+
+		const header = renderStatusLine(
+			{
+				title: TOOL_TITLE,
+				titleColor: "contentAccent",
+				badge: { label: action, color: isError ? "error" : badgeColor },
+				meta: meta.length > 0 ? meta : undefined,
+			},
+			uiTheme,
+		);
+
+		const outputBlock = new CachedOutputBlock();
+		return {
+			render(width: number): string[] {
+				const state = options.isPartial ? "pending" : isError ? "error" : "success";
+				return outputBlock.render({ header, state, sections, width, borderColor: F5_TOOL_BORDER_COLOR }, uiTheme);
+			},
+			invalidate() {
+				outputBlock.invalidate();
+			},
+		};
+	},
+
+	mergeCallAndResult: true,
+	inline: true,
+};

--- a/packages/coding-agent/src/tools/gh-tools-renderer.ts
+++ b/packages/coding-agent/src/tools/gh-tools-renderer.ts
@@ -1,0 +1,284 @@
+/** TUI renderer for GitHub tools — rich visual output for issue/PR/repo/search/diff/checkout/push. */
+import type { Component } from "@f5xc-salesdemos/pi-tui";
+import { Text } from "@f5xc-salesdemos/pi-tui";
+import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import type { Theme, ThemeColor } from "../modes/theme/theme";
+import { CachedOutputBlock, F5_TOOL_BORDER_COLOR, renderStatusLine } from "../tui";
+import type { GhToolDetails } from "./gh";
+import { addSection, formatErrorMessage, replaceTabs } from "./render-utils";
+
+const TOOL_TITLE = "GitHub";
+const MAX_BODY_LINES = 30;
+const MAX_DIFF_LINES = 80;
+const MAX_SECTION_LINES = 40;
+
+type GhRenderArgs = {
+	repo?: string;
+	branch?: string;
+	issue?: string;
+	pr?: string;
+	query?: string;
+	nameOnly?: boolean;
+};
+
+function ghStateColor(state: string | undefined): ThemeColor {
+	if (!state) return "dim";
+	const upper = state.toUpperCase();
+	if (upper === "OPEN" || upper === "OPENED") return "success";
+	if (upper === "CLOSED") return "dim";
+	if (upper === "MERGED") return "chromeAccent";
+	return "muted";
+}
+
+/** Extract key-value pairs from lines like "Key: Value". */
+function extractKV(lines: string[]): Array<{ key: string; value: string }> {
+	const pairs: Array<{ key: string; value: string }> = [];
+	for (const line of lines) {
+		const match = line.match(/^(\s*\S[^:]*?):\s+(.+)$/);
+		if (match) {
+			pairs.push({ key: match[1]!.trim(), value: match[2]!.trim() });
+		}
+	}
+	return pairs;
+}
+
+/** Split markdown text into sections by ## headings. */
+function splitSections(text: string): Array<{ heading: string; body: string }> {
+	const result: Array<{ heading: string; body: string }> = [];
+	const parts = text.split(/^## /m);
+	for (const part of parts) {
+		if (!part.trim()) continue;
+		const newlineIdx = part.indexOf("\n");
+		if (newlineIdx < 0) {
+			result.push({ heading: part.trim(), body: "" });
+		} else {
+			result.push({ heading: part.slice(0, newlineIdx).trim(), body: part.slice(newlineIdx + 1).trim() });
+		}
+	}
+	return result;
+}
+
+/** Build themed KV section from extracted pairs. */
+function buildKVSection(pairs: Array<{ key: string; value: string }>, uiTheme: Theme): string[] {
+	const maxKeyLen = Math.max(...pairs.map(p => p.key.length), 8);
+	return pairs.map(p => {
+		const stateKeys = new Set(["State", "Draft", "Review decision", "Merge state", "Visibility"]);
+		const valueColor: ThemeColor = stateKeys.has(p.key) ? ghStateColor(p.value) : "toolOutput";
+		return `  ${uiTheme.fg("dim", p.key.padEnd(maxKeyLen + 2))}${uiTheme.fg(valueColor, p.value)}`;
+	});
+}
+
+/** Color diff lines using theme diff tokens. */
+function colorDiffLines(lines: string[], uiTheme: Theme): string[] {
+	return lines.map(line => {
+		if (line.startsWith("+") && !line.startsWith("+++")) return uiTheme.fg("toolDiffAdded", replaceTabs(line));
+		if (line.startsWith("-") && !line.startsWith("---")) return uiTheme.fg("toolDiffRemoved", replaceTabs(line));
+		if (line.startsWith("@@")) return uiTheme.fg("chromeAccent", replaceTabs(line));
+		if (line.startsWith("diff ") || line.startsWith("index ")) return uiTheme.fg("dim", replaceTabs(line));
+		return uiTheme.fg("muted", replaceTabs(line));
+	});
+}
+
+function renderMarkdownSections(
+	text: string,
+	uiTheme: Theme,
+	sections: Array<{ label?: string; lines: string[] }>,
+): void {
+	// Extract the H1 title line and preamble KV
+	const lines = text.split("\n");
+	let titleLine: string | undefined;
+	const preambleLines: string[] = [];
+	let bodyStart = 0;
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i]!;
+		if (line.startsWith("# ") && !titleLine) {
+			titleLine = line.slice(2).trim();
+			continue;
+		}
+		if (line.startsWith("## ")) {
+			bodyStart = i;
+			break;
+		}
+		if (line.trim()) preambleLines.push(line);
+		bodyStart = i + 1;
+	}
+
+	// Build themed KV from preamble, and preserve non-KV prose lines
+	const kvPairs = extractKV(preambleLines);
+	const nonKVLines = preambleLines.filter(line => !line.match(/^(\s*\S[^:]*?):\s+(.+)$/));
+	if (kvPairs.length > 0) {
+		addSection(sections, "Summary", buildKVSection(kvPairs, uiTheme), uiTheme);
+	}
+	if (nonKVLines.length > 0) {
+		const proseLines = nonKVLines.map(line => replaceTabs(uiTheme.fg("toolOutput", line)));
+		addSection(sections, "Details", proseLines, uiTheme, MAX_BODY_LINES);
+	}
+
+	// Process ## sections
+	const remainingText = lines.slice(bodyStart).join("\n");
+	const mdSections = splitSections(remainingText);
+	for (const section of mdSections) {
+		const sectionLines = section.body
+			.split("\n")
+			.filter(l => l.trim())
+			.map(line => replaceTabs(uiTheme.fg("toolOutput", line)));
+		if (sectionLines.length > 0) {
+			const maxLines = section.heading.toLowerCase().includes("comment") ? MAX_SECTION_LINES : MAX_BODY_LINES;
+			addSection(sections, section.heading, sectionLines, uiTheme, maxLines);
+		}
+	}
+}
+
+export const ghToolsRenderer = {
+	renderCall(args: GhRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
+		let description: string | undefined;
+		if (args.issue) {
+			description = uiTheme.fg("muted", `issue ${args.issue}`);
+		} else if (args.pr) {
+			description = uiTheme.fg("muted", `PR ${args.pr}`);
+		} else if (args.query) {
+			description = uiTheme.fg("muted", `search: ${args.query}`);
+		} else if (args.repo) {
+			description = uiTheme.fg("muted", args.repo);
+		}
+		const text = renderStatusLine({ icon: "pending", title: TOOL_TITLE, description }, uiTheme);
+		return new Text(text, 0, 0);
+	},
+
+	renderResult(
+		result: { content: Array<{ type: string; text?: string }>; details?: GhToolDetails; isError?: boolean },
+		options: RenderResultOptions,
+		uiTheme: Theme,
+		args?: GhRenderArgs,
+	): Component {
+		const details = result.details;
+		const isError = result.isError === true;
+
+		if (isError && !details) {
+			const errorText = result.content?.find(c => c.type === "text")?.text;
+			return new Text(formatErrorMessage(errorText, uiTheme), 0, 0);
+		}
+
+		const tool = details?.tool;
+		const sections: Array<{ label?: string; lines: string[] }> = [];
+		const meta: string[] = [];
+		let description: string | undefined;
+		let badgeLabel: string | undefined;
+		let badgeColor: ThemeColor = "muted";
+		const textContent = result.content?.find(c => c.type === "text")?.text ?? "";
+
+		if (isError) {
+			addSection(sections, "Error", [uiTheme.fg("error", textContent || "Unknown error")], uiTheme);
+			const header = renderStatusLine(
+				{ title: TOOL_TITLE, titleColor: "contentAccent", badge: { label: "error", color: "error" } },
+				uiTheme,
+			);
+			const outputBlock = new CachedOutputBlock();
+			return {
+				render(width: number): string[] {
+					return outputBlock.render({ header, state: "error", sections, width }, uiTheme);
+				},
+				invalidate() {
+					outputBlock.invalidate();
+				},
+			};
+		}
+
+		if (tool === "gh_pr_diff") {
+			description = args?.pr ? `PR ${args.pr} diff` : "diff";
+			if (args?.nameOnly) {
+				badgeLabel = "files";
+				badgeColor = "contentAccent";
+			}
+			const diffLines = textContent.split("\n");
+			const themed = args?.nameOnly
+				? diffLines.map(line => uiTheme.fg("toolOutput", `  ${replaceTabs(line)}`))
+				: colorDiffLines(diffLines, uiTheme);
+			addSection(sections, args?.nameOnly ? "Files" : "Diff", themed, uiTheme, MAX_DIFF_LINES);
+		} else if (tool === "gh_pr_checkout") {
+			// Extract title from first markdown header
+			const titleMatch = textContent.match(/^# (.+)/m);
+			description = titleMatch ? titleMatch[1] : "checkout";
+			if (details?.branch) meta.push(uiTheme.fg("dim", details.branch));
+			if (details?.worktreePath) meta.push(uiTheme.fg("dim", details.worktreePath));
+			renderMarkdownSections(textContent, uiTheme, sections);
+		} else if (tool === "gh_pr_push") {
+			description = "push";
+			if (details?.branch) meta.push(uiTheme.fg("dim", details.branch));
+			if (details?.remote) meta.push(uiTheme.fg("dim", `→ ${details.remote}:${details.remoteBranch ?? ""}`));
+			renderMarkdownSections(textContent, uiTheme, sections);
+		} else if (tool === "gh_search_issues" || tool === "gh_search_prs") {
+			const kind = tool === "gh_search_issues" ? "issues" : "PRs";
+			description = `search ${kind}: ${args?.query ?? ""}`;
+			// Count results from markdown list items
+			const resultCount = (textContent.match(/^- #\d+/gm) ?? []).length;
+			meta.push(uiTheme.fg("dim", `${resultCount} result${resultCount !== 1 ? "s" : ""}`));
+			renderMarkdownSections(textContent, uiTheme, sections);
+		} else if (tool === "gh_repo_view") {
+			const titleMatch = textContent.match(/^# (.+)/m);
+			description = titleMatch ? titleMatch[1] : (details?.repo ?? args?.repo ?? "repo");
+			renderMarkdownSections(textContent, uiTheme, sections);
+		} else if (tool === "gh_issue_view") {
+			const titleMatch = textContent.match(/^# Issue #(\d+): (.+)/m);
+			if (titleMatch) {
+				description = `#${titleMatch[1]}: ${titleMatch[2]}`;
+			} else {
+				description = args?.issue ? `issue ${args.issue}` : "issue";
+			}
+			// Extract state from KV
+			const stateMatch = textContent.match(/^State:\s+(.+)/m);
+			if (stateMatch) meta.push(uiTheme.fg(ghStateColor(stateMatch[1]), stateMatch[1]!));
+			renderMarkdownSections(textContent, uiTheme, sections);
+		} else if (tool === "gh_pr_view") {
+			const titleMatch = textContent.match(/^# Pull Request #(\d+): (.+)/m);
+			if (titleMatch) {
+				description = `#${titleMatch[1]}: ${titleMatch[2]}`;
+			} else {
+				description = args?.pr ? `PR ${args.pr}` : "PR";
+			}
+			const stateMatch = textContent.match(/^State:\s+(.+)/m);
+			if (stateMatch) meta.push(uiTheme.fg(ghStateColor(stateMatch[1]), stateMatch[1]!));
+			const draftMatch = textContent.match(/^Draft:\s+(.+)/m);
+			if (draftMatch?.[1] === "true") meta.push(uiTheme.fg("warning", "DRAFT"));
+			renderMarkdownSections(textContent, uiTheme, sections);
+		} else {
+			// Fallback for unknown tool
+			renderMarkdownSections(textContent, uiTheme, sections);
+		}
+
+		const header = description
+			? renderStatusLine(
+					{
+						title: TOOL_TITLE,
+						titleColor: "contentAccent",
+						description,
+						meta: meta.length > 0 ? meta : undefined,
+					},
+					uiTheme,
+				)
+			: renderStatusLine(
+					{
+						title: TOOL_TITLE,
+						titleColor: "contentAccent",
+						badge: badgeLabel ? { label: badgeLabel, color: badgeColor } : undefined,
+						meta: meta.length > 0 ? meta : undefined,
+					},
+					uiTheme,
+				);
+
+		const outputBlock = new CachedOutputBlock();
+		return {
+			render(width: number): string[] {
+				const state = options.isPartial ? "pending" : "success";
+				return outputBlock.render({ header, state, sections, width, borderColor: F5_TOOL_BORDER_COLOR }, uiTheme);
+			},
+			invalidate() {
+				outputBlock.invalidate();
+			},
+		};
+	},
+
+	mergeCallAndResult: true,
+	inline: true,
+};

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -259,6 +259,7 @@ type GhSearchPrsInput = Static<typeof ghSearchPrsSchema>;
 type GhRunWatchInput = Static<typeof ghRunWatchSchema>;
 
 export interface GhToolDetails {
+	tool?: string;
 	meta?: OutputMeta;
 	artifactId?: string;
 	repo?: string;
@@ -1939,7 +1940,10 @@ export class GhRepoViewTool implements AgentTool<typeof ghRepoViewSchema, GhTool
 			const data = await git.github.json<GhRepoViewData>(this.session.cwd, args, signal, {
 				repoProvided: Boolean(repo),
 			});
-			return buildTextResult(formatRepoView(data, { repo, branch }), data.url);
+			return buildTextResult(formatRepoView(data, { repo, branch }), data.url, {
+				tool: "gh_repo_view",
+				repo: repo ?? data.nameWithOwner,
+			});
 		});
 	}
 }
@@ -1976,7 +1980,9 @@ export class GhIssueViewTool implements AgentTool<typeof ghIssueViewSchema, GhTo
 			const data = await git.github.json<GhIssueViewData>(this.session.cwd, args, signal, {
 				repoProvided: Boolean(repo),
 			});
-			return buildTextResult(formatIssueView(data, { issue, repo, comments: includeComments }), data.url);
+			return buildTextResult(formatIssueView(data, { issue, repo, comments: includeComments }), data.url, {
+				tool: "gh_issue_view",
+			});
 		});
 	}
 }
@@ -2020,7 +2026,9 @@ export class GhPrViewTool implements AgentTool<typeof ghPrViewSchema, GhToolDeta
 			if (includeComments && resolvedRepo && typeof data.number === "number") {
 				data.reviewComments = await fetchPrReviewComments(this.session.cwd, resolvedRepo, data.number, signal);
 			}
-			return buildTextResult(formatPrView(data, { pr, repo, comments: includeComments }), data.url);
+			return buildTextResult(formatPrView(data, { pr, repo, comments: includeComments }), data.url, {
+				tool: "gh_pr_view",
+			});
 		});
 	}
 }
@@ -2069,7 +2077,7 @@ export class GhPrDiffTool implements AgentTool<typeof ghPrDiffSchema, GhToolDeta
 			});
 			const title = params.nameOnly ? "# Pull Request Files" : "# Pull Request Diff";
 			const body = output.length > 0 ? output : params.nameOnly ? "No changed files." : "No diff output.";
-			return buildTextResult(`${title}\n\n${body}`);
+			return buildTextResult(`${title}\n\n${body}`, undefined, { tool: "gh_pr_diff" });
 		});
 	}
 }
@@ -2194,6 +2202,7 @@ export class GhPrCheckoutTool implements AgentTool<typeof ghPrCheckoutSchema, Gh
 				}),
 				data.url,
 				{
+					tool: "gh_pr_checkout",
 					repo: repo ?? data.headRepository?.nameWithOwner,
 					branch: localBranch,
 					worktreePath: resolvedWorktreePath,
@@ -2257,6 +2266,7 @@ export class GhPrPushTool implements AgentTool<typeof ghPrPushSchema, GhToolDeta
 				}),
 				target.prUrl,
 				{
+					tool: "gh_pr_push",
 					branch: localBranch,
 					remote: target.remoteName,
 					remoteBranch: target.remoteBranch,
@@ -2296,7 +2306,9 @@ export class GhSearchIssuesTool implements AgentTool<typeof ghSearchIssuesSchema
 			const items = await git.github.json<GhSearchResult[]>(this.session.cwd, args, signal, {
 				repoProvided: Boolean(repo),
 			});
-			return buildTextResult(formatSearchResults("issues", query, repo, items));
+			return buildTextResult(formatSearchResults("issues", query, repo, items), undefined, {
+				tool: "gh_search_issues",
+			});
 		});
 	}
 }
@@ -2331,7 +2343,9 @@ export class GhSearchPrsTool implements AgentTool<typeof ghSearchPrsSchema, GhTo
 			const items = await git.github.json<GhSearchResult[]>(this.session.cwd, args, signal, {
 				repoProvided: Boolean(repo),
 			});
-			return buildTextResult(formatSearchResults("pull requests", query, repo, items));
+			return buildTextResult(formatSearchResults("pull requests", query, repo, items), undefined, {
+				tool: "gh_search_prs",
+			});
 		});
 	}
 }

--- a/packages/coding-agent/src/tools/glab-renderer.ts
+++ b/packages/coding-agent/src/tools/glab-renderer.ts
@@ -1,0 +1,244 @@
+/** TUI renderer for GitLab tools — rich visual output at full parity with XC-API. */
+import type { Component } from "@f5xc-salesdemos/pi-tui";
+import { Text } from "@f5xc-salesdemos/pi-tui";
+import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import type { Theme, ThemeColor } from "../modes/theme/theme";
+import { CachedOutputBlock, F5_TOOL_BORDER_COLOR, renderStatusLine } from "../tui";
+import type { GlabToolDetails } from "./glab";
+import type { GlabIssue } from "./glab/types";
+import { addSection, formatErrorMessage, replaceTabs } from "./render-utils";
+
+const TOOL_TITLE = "GitLab";
+const MAX_TITLE_WIDTH = 50;
+const MAX_DESCRIPTION_LINES = 20;
+const MAX_COMMENT_LINES = 40;
+
+type GlabRenderArgs = {
+	action?: string;
+	project?: string;
+	issue?: number;
+	query?: string;
+	state?: string;
+	labels?: string[];
+	limit?: number;
+	search?: string;
+};
+
+function issueStateColor(state: string): ThemeColor {
+	return state === "opened" ? "success" : "dim";
+}
+
+function formatDate(iso: string): string {
+	return iso.slice(0, 10);
+}
+
+function truncateTitle(title: string): string {
+	if (title.length <= MAX_TITLE_WIDTH) return title;
+	return `${title.slice(0, MAX_TITLE_WIDTH - 1)}…`;
+}
+
+function truncateLabels(labels: string[], maxLen = 30): string {
+	if (!labels.length) return "";
+	const joined = labels.join(", ");
+	if (joined.length <= maxLen) return joined;
+	const truncated = labels.slice(0, 3).join(", ");
+	const remaining = labels.length - 3;
+	return remaining > 0 ? `${truncated}, +${remaining}` : truncated;
+}
+
+function buildIssueTable(issues: GlabIssue[], uiTheme: Theme): string[] {
+	if (issues.length === 0) return [uiTheme.fg("dim", "  No issues found.")];
+
+	return issues.map(issue => {
+		const iid = uiTheme.fg("toolOutput", `#${issue.iid}`);
+		const title = uiTheme.fg("toolOutput", truncateTitle(issue.title));
+		const state = uiTheme.fg(issueStateColor(issue.state), issue.state);
+		const labels = issue.labels.length > 0 ? uiTheme.fg("muted", truncateLabels(issue.labels)) : "";
+		const assignee =
+			issue.assignees.length > 0
+				? uiTheme.fg("dim", `@${issue.assignees[0]!.username}`)
+				: uiTheme.fg("dim", "unassigned");
+		const updated = uiTheme.fg("dim", formatDate(issue.updated_at));
+
+		const parts = [`  ${iid}  ${title}  ${state}`];
+		if (labels) parts.push(labels);
+		parts.push(assignee, updated);
+		return parts.join("  ");
+	});
+}
+
+function buildIssueDetail(issue: GlabIssue, uiTheme: Theme): Array<{ label?: string; lines: string[] }> {
+	const sections: Array<{ label?: string; lines: string[] }> = [];
+	const kv = (label: string, value: string, valueColor: ThemeColor = "toolOutput") =>
+		`  ${uiTheme.fg("dim", label.padEnd(12))}${uiTheme.fg(valueColor, value)}`;
+
+	const summaryLines: string[] = [];
+	summaryLines.push(kv("state:", issue.state, issueStateColor(issue.state)));
+	summaryLines.push(kv("author:", `@${issue.author.username}`));
+	summaryLines.push(kv("created:", formatDate(issue.created_at)));
+	summaryLines.push(kv("updated:", formatDate(issue.updated_at)));
+	if (issue.labels.length > 0) summaryLines.push(kv("labels:", issue.labels.join(", ")));
+	const assigneeStr =
+		issue.assignees.length > 0 ? issue.assignees.map(a => `@${a.username}`).join(", ") : "unassigned";
+	summaryLines.push(kv("assignee:", assigneeStr));
+	if (issue.milestone) summaryLines.push(kv("milestone:", issue.milestone.title));
+	addSection(sections, "Summary", summaryLines, uiTheme);
+
+	if (issue.description) {
+		const descLines = issue.description.split("\n").map(line => replaceTabs(uiTheme.fg("toolOutput", line)));
+		addSection(sections, "Description", descLines, uiTheme, MAX_DESCRIPTION_LINES);
+	}
+
+	const humanNotes = (issue.notes ?? []).filter(n => !n.system);
+	if (humanNotes.length > 0) {
+		const commentLines: string[] = [];
+		for (const note of humanNotes) {
+			commentLines.push(
+				`  ${uiTheme.fg("chromeAccent", `@${note.author.username}`)} ${uiTheme.fg("dim", formatDate(note.created_at))}`,
+			);
+			for (const line of note.body.split("\n")) {
+				commentLines.push(`    ${uiTheme.fg("toolOutput", replaceTabs(line))}`);
+			}
+			commentLines.push("");
+		}
+		addSection(sections, `Comments (${humanNotes.length})`, commentLines, uiTheme, MAX_COMMENT_LINES);
+	}
+
+	return sections;
+}
+
+export const glabRenderer = {
+	renderCall(args: GlabRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
+		let description: string;
+		if (args.query) {
+			description = uiTheme.fg("muted", `search: ${args.query}`);
+		} else if (args.issue !== undefined) {
+			description = uiTheme.fg("muted", `#${args.issue}`);
+		} else if (args.action) {
+			description = uiTheme.fg("muted", args.action);
+		} else if (args.search) {
+			description = uiTheme.fg("muted", `issues: ${args.search}`);
+		} else {
+			description = uiTheme.fg("muted", "issues");
+		}
+		const text = renderStatusLine({ icon: "pending", title: TOOL_TITLE, description }, uiTheme);
+		return new Text(text, 0, 0);
+	},
+
+	renderResult(
+		result: { content: Array<{ type: string; text?: string }>; details?: GlabToolDetails; isError?: boolean },
+		options: RenderResultOptions,
+		uiTheme: Theme,
+		args?: GlabRenderArgs,
+	): Component {
+		const details = result.details;
+		const isError = result.isError === true;
+
+		if (isError && !details) {
+			const errorText = result.content?.find(c => c.type === "text")?.text;
+			return new Text(formatErrorMessage(errorText, uiTheme), 0, 0);
+		}
+
+		const tool = details?.tool;
+		const sections: Array<{ label?: string; lines: string[] }> = [];
+		const meta: string[] = [];
+		let description: string | undefined;
+		let badgeLabel: string | undefined;
+		let badgeColor: ThemeColor = "muted";
+
+		if (isError) {
+			const errorText = result.content?.find(c => c.type === "text")?.text ?? "Unknown error";
+			addSection(sections, "Error", [uiTheme.fg("error", errorText)], uiTheme);
+			const header = renderStatusLine(
+				{ title: TOOL_TITLE, titleColor: "accent", badge: { label: "error", color: "error" } },
+				uiTheme,
+			);
+			const outputBlock = new CachedOutputBlock();
+			return {
+				render(width: number): string[] {
+					return outputBlock.render({ header, state: "error", sections, width }, uiTheme);
+				},
+				invalidate() {
+					outputBlock.invalidate();
+				},
+			};
+		}
+
+		if (tool === "glab_search" || tool === "glab_issue_list") {
+			const items = details?.items ?? [];
+			const count = details?.total ?? items.length;
+			description = details?.query ? `search: ${details.query}` : "issues";
+			meta.push(uiTheme.fg("dim", `${count} issue${count !== 1 ? "s" : ""}`));
+			if (details?.project) meta.push(uiTheme.fg("muted", details.project));
+			addSection(sections, "Results", buildIssueTable(items, uiTheme), uiTheme);
+		} else if (tool === "glab_issue_view") {
+			const issue = details?.issue;
+			if (issue) {
+				description = `#${issue.iid}: ${truncateTitle(issue.title)}`;
+				meta.push(uiTheme.fg(issueStateColor(issue.state), issue.state));
+				if (details?.project) meta.push(uiTheme.fg("muted", details.project));
+				sections.push(...buildIssueDetail(issue, uiTheme));
+			} else {
+				const text = result.content?.find(c => c.type === "text")?.text ?? "";
+				addSection(
+					sections,
+					"Result",
+					text.split("\n").map(line => replaceTabs(uiTheme.fg("toolOutput", line))),
+					uiTheme,
+				);
+			}
+		} else if (tool === "glab_setup") {
+			badgeLabel = args?.action ?? "setup";
+			badgeColor = "chromeAccent";
+			const text = result.content?.find(c => c.type === "text")?.text ?? "";
+			addSection(
+				sections,
+				"Result",
+				text.split("\n").map(line => replaceTabs(uiTheme.fg("toolOutput", line))),
+				uiTheme,
+			);
+		} else {
+			const text = result.content?.find(c => c.type === "text")?.text ?? "";
+			addSection(
+				sections,
+				"Result",
+				text.split("\n").map(line => replaceTabs(uiTheme.fg("toolOutput", line))),
+				uiTheme,
+			);
+		}
+
+		const header = description
+			? renderStatusLine(
+					{
+						title: TOOL_TITLE,
+						titleColor: "accent",
+						description,
+						meta: meta.length > 0 ? meta : undefined,
+					},
+					uiTheme,
+				)
+			: renderStatusLine(
+					{
+						title: TOOL_TITLE,
+						titleColor: "accent",
+						badge: badgeLabel ? { label: badgeLabel, color: badgeColor } : undefined,
+						meta: meta.length > 0 ? meta : undefined,
+					},
+					uiTheme,
+				);
+
+		const outputBlock = new CachedOutputBlock();
+		return {
+			render(width: number): string[] {
+				const state = options.isPartial ? "pending" : "success";
+				return outputBlock.render({ header, state, sections, width, borderColor: F5_TOOL_BORDER_COLOR }, uiTheme);
+			},
+			invalidate() {
+				outputBlock.invalidate();
+			},
+		};
+	},
+
+	mergeCallAndResult: true,
+	inline: true,
+};

--- a/packages/coding-agent/src/tools/glab.ts
+++ b/packages/coding-agent/src/tools/glab.ts
@@ -113,7 +113,8 @@ type GlabIssueListInput = Static<typeof glabIssueListSchema>;
 type GlabIssueViewInput = Static<typeof glabIssueViewSchema>;
 type GlabSearchInput = Static<typeof glabSearchSchema>;
 
-interface GlabToolDetails {
+export interface GlabToolDetails {
+	tool?: "glab_setup" | "glab_issue_list" | "glab_issue_view" | "glab_search";
 	items?: GlabIssue[];
 	issue?: GlabIssue;
 	projects?: GlabProject[];
@@ -195,7 +196,7 @@ export class GlabSetupTool implements AgentTool<typeof glabSetupSchema, GlabTool
 					.join("\n");
 				return textResult(
 					`Found ${projects.length} projects:\n\n${list}\n\nWhich project do you want to use for GitLab issue tracking? Reply with the number or full path.`,
-					{ projects },
+					{ tool: "glab_setup", projects },
 				);
 			}
 
@@ -260,7 +261,12 @@ export class GlabIssueListTool implements AgentTool<typeof glabIssueListSchema, 
 
 		try {
 			const issues = await execGlabJson<GlabIssue[]>(api, args, signal);
-			return textResult(formatIssueTable(issues), { items: issues, total: issues.length, project });
+			return textResult(formatIssueTable(issues), {
+				tool: "glab_issue_list",
+				items: issues,
+				total: issues.length,
+				project,
+			});
 		} catch (err) {
 			if (err instanceof GlabAuthError) return textResult((err as Error).message);
 			throw err;
@@ -302,7 +308,7 @@ export class GlabIssueViewTool implements AgentTool<typeof glabIssueViewSchema, 
 
 		try {
 			const issue = await execGlabJson<GlabIssue>(api, args, signal);
-			return textResult(formatIssueDetail(issue), { issue, project });
+			return textResult(formatIssueDetail(issue), { tool: "glab_issue_view", issue, project });
 		} catch (err) {
 			if (err instanceof GlabAuthError) return textResult((err as Error).message);
 			throw err;
@@ -401,6 +407,7 @@ export class GlabSearchTool implements AgentTool<typeof glabSearchSchema, GlabTo
 		}
 
 		return textResult(formatIssueTable(issues), {
+			tool: "glab_search",
 			items: issues,
 			total: issues.length,
 			project,

--- a/packages/coding-agent/src/tools/mermaid-renderer.ts
+++ b/packages/coding-agent/src/tools/mermaid-renderer.ts
@@ -1,0 +1,82 @@
+/** TUI renderer for the render_mermaid tool — bordered ASCII diagram output. */
+import type { Component } from "@f5xc-salesdemos/pi-tui";
+import { Text } from "@f5xc-salesdemos/pi-tui";
+import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import type { Theme } from "../modes/theme/theme";
+import { CachedOutputBlock, F5_TOOL_BORDER_COLOR, renderStatusLine } from "../tui";
+import type { RenderMermaidToolDetails } from "./render-mermaid";
+import { addSection, formatErrorMessage, replaceTabs } from "./render-utils";
+
+const TOOL_TITLE = "Mermaid";
+const MAX_DIAGRAM_LINES = 40;
+
+type MermaidRenderArgs = {
+	mermaid?: string;
+};
+
+export const mermaidRenderer = {
+	renderCall(_args: MermaidRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
+		const text = renderStatusLine(
+			{ icon: "pending", title: TOOL_TITLE, description: uiTheme.fg("muted", "rendering diagram") },
+			uiTheme,
+		);
+		return new Text(text, 0, 0);
+	},
+
+	renderResult(
+		result: {
+			content: Array<{ type: string; text?: string }>;
+			details?: RenderMermaidToolDetails;
+			isError?: boolean;
+		},
+		options: RenderResultOptions,
+		uiTheme: Theme,
+		_args?: MermaidRenderArgs,
+	): Component {
+		const isError = result.isError === true;
+
+		if (isError) {
+			const errorText = result.content?.find(c => c.type === "text")?.text;
+			return new Text(formatErrorMessage(errorText, uiTheme), 0, 0);
+		}
+
+		const sections: Array<{ label?: string; lines: string[] }> = [];
+		const meta: string[] = [];
+		const rawText = result.content?.find(c => c.type === "text")?.text ?? "";
+
+		// Strip artifact reference from display
+		const artifactIdx = rawText.indexOf("\n\nSaved artifact:");
+		const diagramText = artifactIdx >= 0 ? rawText.slice(0, artifactIdx) : rawText;
+
+		const diagramLines = diagramText.split("\n").map(line => replaceTabs(uiTheme.fg("toolOutput", line)));
+		addSection(sections, "Diagram", diagramLines, uiTheme, MAX_DIAGRAM_LINES);
+
+		if (result.details?.artifactId) {
+			meta.push(uiTheme.fg("dim", `artifact:${result.details.artifactId.slice(0, 8)}`));
+		}
+
+		const header = renderStatusLine(
+			{
+				title: TOOL_TITLE,
+				titleColor: "dim",
+				description: uiTheme.fg("muted", "diagram"),
+				meta: meta.length > 0 ? meta : undefined,
+			},
+			uiTheme,
+		);
+
+		const outputBlock = new CachedOutputBlock();
+		return {
+			render(width: number): string[] {
+				const state = options.isPartial ? "pending" : "success";
+				return outputBlock.render({ header, state, sections, width, borderColor: F5_TOOL_BORDER_COLOR }, uiTheme);
+			},
+			invalidate() {
+				outputBlock.invalidate();
+			},
+		};
+	},
+
+	mergeCallAndResult: true,
+	inline: true,
+};

--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -10,16 +10,21 @@ import { lspToolRenderer } from "../lsp/render";
 import type { Theme } from "../modes/theme/theme";
 import { taskToolRenderer } from "../task/render";
 import { webSearchToolRenderer } from "../web/search/render";
+import { actionRenderer } from "./action-renderer";
 import { askToolRenderer } from "./ask";
 import { astEditToolRenderer } from "./ast-edit";
 import { astGrepToolRenderer } from "./ast-grep";
 import { bashToolRenderer } from "./bash";
+import { browserRenderer } from "./browser-renderer";
 import { calculatorToolRenderer } from "./calculator";
 import { debugToolRenderer } from "./debug";
 import { findToolRenderer } from "./find";
 import { ghRunWatchToolRenderer } from "./gh-renderer";
+import { ghToolsRenderer } from "./gh-tools-renderer";
+import { glabRenderer } from "./glab-renderer";
 import { grepToolRenderer } from "./grep";
 import { inspectImageToolRenderer } from "./inspect-image-renderer";
+import { mermaidRenderer } from "./mermaid-renderer";
 import { notebookToolRenderer } from "./notebook";
 import { pythonToolRenderer } from "./python";
 import { resolveToolRenderer } from "./resolve";
@@ -68,6 +73,24 @@ export const toolRenderers: Record<string, ToolRenderer> = {
 	task: taskToolRenderer as ToolRenderer,
 	todo_write: todoWriteToolRenderer as ToolRenderer,
 	gh_run_watch: ghRunWatchToolRenderer as ToolRenderer,
+	gh_repo_view: ghToolsRenderer as ToolRenderer,
+	gh_issue_view: ghToolsRenderer as ToolRenderer,
+	gh_pr_view: ghToolsRenderer as ToolRenderer,
+	gh_pr_diff: ghToolsRenderer as ToolRenderer,
+	gh_pr_checkout: ghToolsRenderer as ToolRenderer,
+	gh_pr_push: ghToolsRenderer as ToolRenderer,
+	gh_search_issues: ghToolsRenderer as ToolRenderer,
+	gh_search_prs: ghToolsRenderer as ToolRenderer,
+	glab_setup: glabRenderer as ToolRenderer,
+	glab_issue_list: glabRenderer as ToolRenderer,
+	glab_issue_view: glabRenderer as ToolRenderer,
+	glab_search: glabRenderer as ToolRenderer,
+	checkpoint: actionRenderer as ToolRenderer,
+	rewind: actionRenderer as ToolRenderer,
+	cancel_job: actionRenderer as ToolRenderer,
+	poll: actionRenderer as ToolRenderer,
+	puppeteer: browserRenderer as ToolRenderer,
+	render_mermaid: mermaidRenderer as ToolRenderer,
 	web_search: webSearchToolRenderer as ToolRenderer,
 	write: writeToolRenderer as ToolRenderer,
 	xcsh_api: xcshApiToolRenderer as ToolRenderer,


### PR DESCRIPTION
## What

Add polished TUI renderers for all custom tools that currently lack styled output, covering 18 new tool renderer registrations across 5 new renderer modules.

**New renderer files:**
- `glab-renderer.ts` -- GitLab tools (glab_search, glab_issue_list, glab_issue_view, glab_setup)
- `gh-tools-renderer.ts` -- GitHub tools (gh_repo_view, gh_issue_view, gh_pr_view, gh_pr_diff, gh_pr_checkout, gh_pr_push, gh_search_issues, gh_search_prs)
- `action-renderer.ts` -- Action tools (checkpoint, rewind, cancel_job, poll)
- `browser-renderer.ts` -- Browser tool (puppeteer)
- `mermaid-renderer.ts` -- Mermaid tool (render_mermaid)

**Modified files:**
- `renderers.ts` -- Register 18 new tool entries
- `gh.ts` -- Add tool discriminator to GhToolDetails
- `glab.ts` -- Export GlabToolDetails with tool discriminator

## Why

All custom tools now have consistent, polished TUI rendering matching the XC-API and Salesforce visual standards -- F5 red borders, themed status lines, semantic color coding, and structured sections.

Closes #1006

## Testing

- [x] `bun run check` -- Biome lint and type-check pass
- [x] Pre-commit hooks pass (governance, lint, secrets, spelling)
- [x] Issue linked via `Closes #1006`
- [ ] CI checks pass