### PR TITLE
fix(coding-agent): lazy-require terraform index and add generator script

### DIFF
--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -44,11 +44,16 @@ jobs:
         working-directory: packages/coding-agent
         run: bun run generate-api-spec-index
 
+      - name: Regenerate Terraform index from latest release
+        working-directory: packages/coding-agent
+        run: bun run generate-terraform-index
+
       - name: Verify generated files exist
         working-directory: packages/coding-agent
         run: |
           test -f src/internal-urls/api-spec-index.generated.ts
           test -f src/internal-urls/api-catalog-index.generated.ts
+          test -f src/internal-urls/terraform-index.generated.ts
 
       - name: Check for changes
         id: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick
-          sudo ln -s $(which fdfind) /usr/local/bin/fd
+          sudo ln -s "$(which fdfind)" /usr/local/bin/fd
           sudo ln -sf /usr/bin/convert /usr/local/bin/magick
       - run: bun install --frozen-lockfile
       - run: bun run build:native
@@ -378,7 +378,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick
-          sudo ln -s $(which fdfind) /usr/local/bin/fd
+          sudo ln -s "$(which fdfind)" /usr/local/bin/fd
           sudo ln -sf /usr/bin/convert /usr/local/bin/magick
       - run: bun install --frozen-lockfile
       - name: Install method smoke tests
@@ -657,33 +657,33 @@ jobs:
           APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: |
-          KEYCHAIN_PATH=$RUNNER_TEMP/signing.keychain-db
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
-          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> $GITHUB_ENV
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> "$GITHUB_ENV"
 
-          echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > $RUNNER_TEMP/certificate.p12
+          echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
 
-          openssl pkcs12 -info -in $RUNNER_TEMP/certificate.p12 -noout -passin pass:"$APPLE_CERTIFICATE_PASSWORD" || {
+          openssl pkcs12 -info -in "$RUNNER_TEMP/certificate.p12" -noout -passin pass:"$APPLE_CERTIFICATE_PASSWORD" || {
             echo "ERROR: Invalid p12 file or wrong password"
             exit 1
           }
 
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security default-keychain -s $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security default-keychain -s "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-          security import $RUNNER_TEMP/certificate.p12 \
-            -k $KEYCHAIN_PATH \
+          security import "$RUNNER_TEMP/certificate.p12" \
+            -k "$KEYCHAIN_PATH" \
             -P "$APPLE_CERTIFICATE_PASSWORD" \
             -T /usr/bin/codesign \
             -T /usr/bin/security
 
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
-          security find-identity -v -p codesigning $KEYCHAIN_PATH
-          rm $RUNNER_TEMP/certificate.p12
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+          rm "$RUNNER_TEMP/certificate.p12"
 
       - name: Sign macOS Binary
         env:
@@ -840,11 +840,9 @@ jobs:
       - name: List release binaries
         run: ls -la packages/coding-agent/binaries/
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
-          files: packages/coding-agent/binaries/*
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: gh release create "${{ github.ref_name }}" packages/coding-agent/binaries/* --generate-notes
 
   # Package Homebrew archives from signed binaries and update the tap
   update-homebrew:

--- a/.github/workflows/test-codesign.yml
+++ b/.github/workflows/test-codesign.yml
@@ -104,7 +104,7 @@ jobs:
             curl -sSfL "$URL" | tar -xJ
           fi
           echo "$PWD/zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}" >> "$GITHUB_PATH"
-          zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}/zig version
+          "zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_VERSION}/zig" version
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Build native addon from source

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -31,9 +31,9 @@
 		"xcsh": "src/cli.ts"
 	},
 	"scripts": {
-		"build": "bun run generate-build-info && bun run generate-api-spec-index && bun run generate-branding-index && test -f src/internal-urls/api-spec-index.generated.ts && bun --cwd=../stats scripts/generate-client-bundle.ts --generate && bun --cwd=../natives run embed:native && bun build --compile --define PI_COMPILED=true --external mupdf --root ../.. ./src/cli.ts --outfile dist/xcsh && bun --cwd=../natives run embed:native --reset && bun --cwd=../stats scripts/generate-client-bundle.ts --reset",
+		"build": "bun run generate-build-info && bun run generate-api-spec-index && bun run generate-branding-index && bun run generate-terraform-index && test -f src/internal-urls/api-spec-index.generated.ts && bun --cwd=../stats scripts/generate-client-bundle.ts --generate && bun --cwd=../natives run embed:native && bun build --compile --define PI_COMPILED=true --external mupdf --root ../.. ./src/cli.ts --outfile dist/xcsh && bun --cwd=../natives run embed:native --reset && bun --cwd=../stats scripts/generate-client-bundle.ts --reset",
 		"check": "biome check . && bun run format-prompts -- --check && bun run check:types",
-		"check:types": "bun run generate-build-info && bun run generate-api-spec-index && bun run generate-branding-index && tsgo -p tsconfig.json --noEmit",
+		"check:types": "bun run generate-build-info && bun run generate-api-spec-index && bun run generate-branding-index && bun run generate-terraform-index && tsgo -p tsconfig.json --noEmit",
 		"lint": "biome lint .",
 		"test": "bun run generate-build-info && bun run generate-api-spec-index && bun test --max-concurrency 4",
 		"fix": "biome check --write --unsafe . && bun run format-prompts && bun run generate-docs-index && bun run generate-api-spec-index && bun run generate-build-info",
@@ -43,7 +43,8 @@
 		"generate-api-spec-index": "bun scripts/generate-api-spec-index.ts",
 		"generate-branding-index": "bun scripts/generate-branding-index.ts",
 		"generate-build-info": "bun scripts/generate-build-info.ts",
-		"prepack": "bun scripts/generate-docs-index.ts && bun scripts/generate-api-spec-index.ts && bun scripts/generate-build-info.ts",
+		"generate-terraform-index": "bun scripts/generate-terraform-index.ts",
+		"prepack": "bun scripts/generate-docs-index.ts && bun scripts/generate-api-spec-index.ts && bun scripts/generate-build-info.ts && bun scripts/generate-terraform-index.ts",
 		"generate-template": "bun scripts/generate-template.ts"
 	},
 	"dependencies": {

--- a/packages/coding-agent/scripts/generate-terraform-index.ts
+++ b/packages/coding-agent/scripts/generate-terraform-index.ts
@@ -1,0 +1,56 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+const OUTPUT_FILE = path.join(import.meta.dir, "..", "src", "internal-urls", "terraform-index.generated.ts");
+
+const LOCAL_JSON_PATH = path.resolve(
+	import.meta.dir,
+	"..",
+	"..",
+	"..",
+	"..",
+	"terraform-provider-f5xc",
+	"docs",
+	"terraform-llms-index.json",
+);
+
+const GITHUB_RAW_URL =
+	"https://raw.githubusercontent.com/f5xc-salesdemos/terraform-provider-f5xc/main/docs/terraform-llms-index.json";
+
+async function loadTerraformIndex(): Promise<unknown> {
+	const localFile = Bun.file(LOCAL_JSON_PATH);
+	if (await localFile.exists()) {
+		console.log(`Reading from local checkout: ${LOCAL_JSON_PATH}`);
+		return localFile.json();
+	}
+
+	console.log(`Local not found, fetching from ${GITHUB_RAW_URL}`);
+	const headers: Record<string, string> = {};
+	const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+	if (token) {
+		headers.Authorization = `token ${token}`;
+	}
+
+	const response = await fetch(GITHUB_RAW_URL, { headers });
+	if (!response.ok) {
+		throw new Error(`Failed to fetch terraform-llms-index.json: ${response.status} ${response.statusText}`);
+	}
+	return response.json();
+}
+
+function generateTypeScript(data: unknown): string {
+	const lines = [
+		"// AUTO-GENERATED — do not edit. Run `bun generate-terraform-index` to regenerate.",
+		"",
+		'import type { TerraformIndex } from "./terraform-types";',
+		"",
+		`export const TERRAFORM_INDEX: TerraformIndex = ${JSON.stringify(data, null, "\t")} as const;`,
+		"",
+	];
+	return lines.join("\n");
+}
+
+const data = await loadTerraformIndex();
+const output = generateTypeScript(data);
+await fs.writeFile(OUTPUT_FILE, output, "utf-8");
+console.log(`Generated ${OUTPUT_FILE}`);

--- a/packages/coding-agent/src/internal-urls/terraform-index.generated.ts
+++ b/packages/coding-agent/src/internal-urls/terraform-index.generated.ts
@@ -1,3 +1,5 @@
+// AUTO-GENERATED — do not edit. Run `bun generate-terraform-index` to regenerate.
+
 import type { TerraformIndex } from "./terraform-types";
 
 export const TERRAFORM_INDEX: TerraformIndex = {

--- a/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
@@ -38,8 +38,8 @@ import { getRuntimeBuildInfo, type RuntimeBuildInfo, renderAboutDoc } from "./bu
 import { loadComputerProfile, renderComputerProfileMarkdown, seedComputerProfile } from "./computer-profile";
 import { EMBEDDED_DOC_FILENAMES, EMBEDDED_DOCS } from "./docs-index.generated";
 import { loadSalesforceContext, renderSalesforceContextMarkdown, seedSalesforceContext } from "./salesforce-context";
-import { TERRAFORM_INDEX } from "./terraform-index.generated";
 import { createTerraformResolver, type TerraformResolver } from "./terraform-resolve";
+import type { TerraformIndex } from "./terraform-types";
 import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
 import { loadProfile, renderProfileMarkdown, seedProfile } from "./user-profile";
 
@@ -62,6 +62,35 @@ const EMPTY_CATALOG_INDEX: ApiCatalogIndex = {
 	auth: { type: "", headerName: "", headerTemplate: "", tokenSource: "", baseUrlSource: "" },
 	defaults: {},
 };
+
+const EMPTY_TERRAFORM_INDEX: TerraformIndex = {
+	version: "unavailable",
+	provider: { source: "", registry: "", required_block: "", syntax_rules: [] },
+	categories: [],
+	resources: {},
+};
+
+let _terraformCache: { index: TerraformIndex } | null = null;
+
+function loadTerraformIndex(): TerraformIndex {
+	if (_terraformCache) return _terraformCache.index;
+	try {
+		const mod = require("./terraform-index.generated") as {
+			TERRAFORM_INDEX?: TerraformIndex;
+		};
+		const index = mod.TERRAFORM_INDEX ?? EMPTY_TERRAFORM_INDEX;
+		if (Object.keys(index.resources).length === 0) {
+			logger.warn("terraform index loaded but contains 0 resources");
+		}
+		_terraformCache = { index };
+	} catch (err) {
+		logger.warn("terraform index unavailable, terraform protocol disabled", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+		_terraformCache = { index: EMPTY_TERRAFORM_INDEX };
+	}
+	return _terraformCache.index;
+}
 
 let _apiSpecCache: {
 	index: ApiSpecIndex;
@@ -250,7 +279,7 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 
 	#getTerraformResolver(): TerraformResolver {
 		if (!this.#terraformResolver) {
-			this.#terraformResolver = createTerraformResolver(TERRAFORM_INDEX);
+			this.#terraformResolver = createTerraformResolver(loadTerraformIndex());
 		}
 		return this.#terraformResolver;
 	}
@@ -359,7 +388,8 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 		const userEntry = `- [${USER_ROUTE}](${SCHEME_PREFIX}${USER_ROUTE}) — human user profile`;
 		const computerEntry = `- [${COMPUTER_ROUTE}](${SCHEME_PREFIX}${COMPUTER_ROUTE}) — machine hardware and environment profile`;
 		const salesforceEntry = `- [${SALESFORCE_ROUTE}](${SCHEME_PREFIX}${SALESFORCE_ROUTE}) — Salesforce pipeline context and team discovery`;
-		const terraformEntry = `- [${TERRAFORM_HOST}/](${SCHEME_PREFIX}${TERRAFORM_HOST}/) — F5 XC Terraform provider (${Object.keys(TERRAFORM_INDEX.resources).length} resources, v${TERRAFORM_INDEX.version})`;
+		const tf = loadTerraformIndex();
+		const terraformEntry = `- [${TERRAFORM_HOST}/](${SCHEME_PREFIX}${TERRAFORM_HOST}/) — F5 XC Terraform provider (${Object.keys(tf.resources).length} resources, v${tf.version})`;
 		const listing = [
 			syntheticEntry,
 			apiSpecEntry,


### PR DESCRIPTION
## What

- Convert `TERRAFORM_INDEX` from static import to lazy `require()` with try/catch + `EMPTY_TERRAFORM_INDEX` fallback in `xcsh-protocol.ts`
- Add `scripts/generate-terraform-index.ts` (local file first, GitHub raw fallback) and wire into `build`, `check:types`, `prepack`, and the CI `api-spec-update` workflow
- Fix pre-existing shellcheck (SC2046, SC2086) and zizmor (superfluous-actions) findings in `ci.yml` and `test-codesign.yml`

## Why

The static `import` of the generated terraform index file meant a corrupted or missing generated file would crash all `xcsh://` protocol routes. The lazy require with fallback matches the resilient pattern already used by api-spec and api-catalog indexes.

The generator script and CI wiring ensure the terraform index stays current on every build and spec-update run.

The CI lint fixes resolve pre-existing findings that were blocking all workflow file commits through pre-commit hooks.

Closes #1024

## Testing

- [x] `pre-commit` passes (all hooks green: governance, YAML lint, Biome, actionlint, zizmor, secrets)
- [x] Issue linked via `Closes #1024`
- [ ] CI checks pass