### PR TITLE
fix: pass github.ref_name through env variable in release step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -842,7 +842,8 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: gh release create "${{ github.ref_name }}" packages/coding-agent/binaries/* --generate-notes
+          REF_NAME: ${{ github.ref_name }}
+        run: gh release create "$REF_NAME" packages/coding-agent/binaries/* --generate-notes
 
   # Package Homebrew archives from signed binaries and update the tap
   update-homebrew:


### PR DESCRIPTION
## What

Move `${{ github.ref_name }}` from direct shell interpolation to an `env` variable in the `Create GitHub Release` step of `.github/workflows/ci.yml`.

## Why

Security review flagged that `${{ github.ref_name }}` interpolated directly into a `run:` shell command is injectable if a tag name contains shell metacharacters. Passing it through an env variable (`REF_NAME: ${{ github.ref_name }}` then `"$REF_NAME"`) makes the shell treat it as data, not code.

Closes #1027

## Testing

- [x] `pre-commit` passes (YAML lint, GitHub Actions lint, GitHub Actions security, infrastructure security scan)
- [x] Single-line change — no runtime behavior difference for well-formed tag names
- [ ] CI checks pass
- [x] Issue linked via `Closes #1027`