### PR TITLE
feat: add cross-repo failure triage to terraform autoresearch benchmark

### DIFF
--- a/autoresearch-terraform.sh
+++ b/autoresearch-terraform.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 # Terraform Autoresearch Benchmark
 # Reads phrases from terraform-phrases.yaml, pipes each through xcsh,
 # extracts terraform code, runs terraform validate/plan, and scores.
+# Emits METRIC lines for the autoresearch framework and ASI lines for
+# cross-repo failure triage.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PHRASES_FILE="${SCRIPT_DIR}/terraform-phrases.yaml"
@@ -15,6 +17,52 @@ PROVIDER_BLOCK='terraform {
     }
   }
 }'
+
+# Error pattern → fix repo mapping (matches design spec failure triage table)
+# Returns: "terraform-provider-f5xc" | "api-specs-enriched" | "xcsh"
+classify_error() {
+  local error_text="$1"
+  local tf_code="$2"
+
+  if [ -z "${tf_code}" ]; then
+    echo "xcsh"
+    return
+  fi
+
+  if echo "${error_text}" | grep -qiE "unsupported argument|An argument named"; then
+    echo "terraform-provider-f5xc"
+  elif echo "${error_text}" | grep -qiP "one of .+ must be set|Required argument"; then
+    echo "terraform-provider-f5xc"
+  elif echo "${error_text}" | grep -qiE "404|not found|namespace.*not.*exist"; then
+    echo "api-specs-enriched"
+  elif echo "${error_text}" | grep -qiE "Invalid value for|invalid configuration"; then
+    echo "api-specs-enriched"
+  else
+    echo "xcsh"
+  fi
+}
+
+classify_error_type() {
+  local error_text="$1"
+  local tf_code="$2"
+
+  if [ -z "${tf_code}" ]; then
+    echo "NO_TERRAFORM_OUTPUT"
+    return
+  fi
+
+  if echo "${error_text}" | grep -qiE "unsupported argument|An argument named"; then
+    echo "UNSUPPORTED_ARGUMENT"
+  elif echo "${error_text}" | grep -qiP "one of .+ must be set|Required argument"; then
+    echo "MISSING_ONEOF"
+  elif echo "${error_text}" | grep -qiE "404|not found|namespace.*not.*exist"; then
+    echo "NAMESPACE_NOT_FOUND"
+  elif echo "${error_text}" | grep -qiE "Invalid value for|invalid configuration"; then
+    echo "INVALID_MINIMAL_CONFIG"
+  else
+    echo "OTHER"
+  fi
+}
 
 cleanup() {
   rm -rf "${WORK_DIR}"
@@ -42,6 +90,12 @@ plan_pass=0
 keyword_total=0
 turn_total=0
 composite_total=0
+# Failure records (JSON array built up incrementally)
+failures_json="[]"
+# Per-repo issue counts
+xcsh_issues=0
+provider_issues=0
+spec_issues=0
 
 for idx in $(seq 0 $((phrase_count - 1))); do
   ws="${WORK_DIR}/phrase_${idx}"
@@ -89,7 +143,7 @@ blocks = re.findall(r'\`\`\`(?:terraform|hcl)\n(.*?)\`\`\`', content, re.DOTALL)
 print('\n'.join(blocks))
 " 2>/dev/null || echo "")
 
-  # Score: keyword match (0.0, 0.5, or 1.0)
+  # Score: keyword match (0, 50, or 100)
   keyword_score=0
   if [ -n "${expect_resource}" ]; then
     if echo "${tf_code}" | grep -qi "${expect_resource}" 2>/dev/null; then
@@ -100,24 +154,37 @@ print('\n'.join(blocks))
   fi
   keyword_total=$((keyword_total + keyword_score))
 
-  # Score: terraform validate
+  # Score: terraform validate (capture output for failure classification)
   v_score=0
   p_score=0
+  v_error=""
+  p_error=""
+
   if [ -n "${tf_code}" ]; then
     printf '%s\n\n%s\n' "${PROVIDER_BLOCK}" "${tf_code}" > "${ws}/main.tf"
 
-    if terraform -chdir="${ws}" init -backend=false -input=false -no-color >/dev/null 2>&1; then
-      if terraform -chdir="${ws}" validate -no-color >/dev/null 2>&1; then
-        v_score=1
+    if terraform -chdir="${ws}" init -backend=false -input=false -no-color >"${ws}/init.out" 2>&1; then
+      # Capture validate output for error classification
+      v_output=$(terraform -chdir="${ws}" validate -no-color 2>&1) && v_score=1 || v_score=0
+      echo "${v_output}" > "${ws}/validate.out"
+      if [ "${v_score}" -eq 1 ]; then
         validate_pass=$((validate_pass + 1))
+      else
+        v_error="${v_output}"
       fi
 
+      # terraform plan (only if API token available)
       if [ -n "${F5XC_API_TOKEN:-}" ] && [ -n "${F5XC_API_URL:-}" ]; then
-        if terraform -chdir="${ws}" plan -no-color -input=false >/dev/null 2>&1; then
-          p_score=1
+        p_output=$(terraform -chdir="${ws}" plan -no-color -input=false 2>&1) && p_score=1 || p_score=0
+        echo "${p_output}" > "${ws}/plan.out"
+        if [ "${p_score}" -eq 1 ]; then
           plan_pass=$((plan_pass + 1))
+        else
+          p_error="${p_output}"
         fi
       fi
+    else
+      v_error=$(cat "${ws}/init.out")
     fi
   fi
 
@@ -125,18 +192,53 @@ print('\n'.join(blocks))
 
   # Compute phrase score (integer math: multiply by 1000 for 3 decimal precision)
   # 0.4*validate + 0.3*keyword + 0.2*plan + 0.1*(1/turns)
-  # keyword is 0/50/100, normalize to 0/0.5/1.0
   phrase_score_x1000=$(( (400 * v_score) + (3 * keyword_score) + (200 * p_score) + (100 / turns) ))
   composite_total=$((composite_total + phrase_score_x1000))
 
-  # Status: per contract, phrase must produce valid terraform to pass
-  kw_display=$(python3 -c "print(${keyword_score}/100)")
-  ps_display=$(python3 -c "print(round(${phrase_score_x1000}/1000, 3))")
+  # Classify failure and build ASI failure record
   status="FAIL"
   if [ "${v_score}" -eq 1 ]; then
     status="PASS"
+  else
+    combined_error="${v_error}${p_error}"
+    fix_repo=$(classify_error "${combined_error}" "${tf_code}")
+    error_type=$(classify_error_type "${combined_error}" "${tf_code}")
+
+    # Increment per-repo issue counter
+    case "${fix_repo}" in
+      "terraform-provider-f5xc") provider_issues=$((provider_issues + 1)) ;;
+      "api-specs-enriched") spec_issues=$((spec_issues + 1)) ;;
+      *) xcsh_issues=$((xcsh_issues + 1)) ;;
+    esac
+
+    # Append to failures JSON array
+    # Truncate error to 200 chars for JSON safety
+    error_short=$(python3 -c "import json,sys; s=sys.stdin.read().strip()[:200]; print(json.dumps(s))" <<< "${combined_error}")
+    phrase_json=$(python3 -c "import json,sys; print(json.dumps(sys.stdin.read().strip()))" <<< "${phrase}")
+    failures_json=$(python3 -c "
+import json, sys
+failures = json.loads(sys.argv[1])
+failures.append({
+    'phrase_idx': ${idx},
+    'phrase': json.loads(sys.argv[4]),
+    'operation': '${operation}',
+    'expect_resource': '${expect_resource}',
+    'error_type': '${error_type}',
+    'error_signal': json.loads(sys.argv[2]),
+    'fix_repo': '${fix_repo}',
+})
+print(json.dumps(failures))
+" "${failures_json}" "${error_short}" "" "${phrase_json}")
   fi
-  echo "  ${status}: validate=${v_score} keyword=${kw_display} plan=${p_score} turns=${turns} score=${ps_display}"
+
+  kw_display=$(python3 -c "print(${keyword_score}/100)")
+  ps_display=$(python3 -c "print(round(${phrase_score_x1000}/1000, 3))")
+  if [ "${v_score}" -eq 0 ]; then
+    fix_repo_display=$(classify_error "${v_error}${p_error}" "${tf_code}")
+    echo "  ${status}: validate=${v_score} keyword=${kw_display} plan=${p_score} turns=${turns} score=${ps_display} fix=${fix_repo_display}"
+  else
+    echo "  ${status}: validate=${v_score} keyword=${kw_display} plan=${p_score} turns=${turns} score=${ps_display}"
+  fi
 done
 
 echo ""
@@ -168,3 +270,15 @@ else
   echo "METRIC avg_turns=0"
   echo "METRIC plan_pass_rate=0"
 fi
+
+# Emit ASI: structured failure records for cross-repo triage
+cross_repo_json=$(python3 -c "
+import json
+print(json.dumps({
+    'xcsh': ${xcsh_issues},
+    'terraform-provider-f5xc': ${provider_issues},
+    'api-specs-enriched': ${spec_issues},
+}))
+")
+echo "ASI failures=${failures_json}"
+echo "ASI cross_repo_issues=${cross_repo_json}"

--- a/autoresearch.checks.sh
+++ b/autoresearch.checks.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # provider/specs/xcsh/total/upstream are set via eval
+set -euo pipefail
+
+# Cross-repo failure classifier for terraform autoresearch.
+#
+# Called by the autoresearch framework after autoresearch-terraform.sh passes.
+# Reads the benchmark output, parses ASI failure records, and decides:
+#   exit 0 = all failures are xcsh-local → autoresearch continues optimizing
+#   exit 1 = upstream fix needed → autoresearch stops with triage report
+#
+# The autoresearch framework passes the run directory as an argument or
+# pipes the benchmark output to stdin. The ASI data is in the benchmark
+# stdout, which the framework captures in the run's output file.
+
+# Read the benchmark output — framework passes run dir as $1, output is in run.json
+if [ -n "${1:-}" ] && [ -d "$1" ]; then
+  RUN_DIR="$1"
+  if [ -f "${RUN_DIR}/benchmark.log" ]; then
+    OUTPUT=$(cat "${RUN_DIR}/benchmark.log")
+  elif [ -f "${RUN_DIR}/run.json" ]; then
+    OUTPUT=$(python3 -c "import json; d=json.load(open('${RUN_DIR}/run.json')); print(d.get('output',''))" 2>/dev/null || echo "")
+  else
+    OUTPUT=""
+  fi
+else
+  OUTPUT=$(cat)
+fi
+
+# Extract ASI cross_repo_issues line
+cross_repo=$(echo "${OUTPUT}" | grep "^ASI cross_repo_issues=" | sed 's/^ASI cross_repo_issues=//' || echo "{}")
+if [ -z "${cross_repo}" ] || [ "${cross_repo}" = "{}" ]; then
+  echo "CHECKS: No ASI cross_repo_issues found in output — passing (no failures to triage)"
+  exit 0
+fi
+
+# Parse the per-repo issue counts
+upstream_issues=$(python3 -c "
+import json, sys
+data = json.loads(sys.argv[1])
+provider = data.get('terraform-provider-f5xc', 0)
+specs = data.get('api-specs-enriched', 0)
+xcsh = data.get('xcsh', 0)
+total = provider + specs + xcsh
+print(f'provider={provider}')
+print(f'specs={specs}')
+print(f'xcsh={xcsh}')
+print(f'total={total}')
+print(f'upstream={provider + specs}')
+" "${cross_repo}")
+
+eval "${upstream_issues}"
+
+if [ "${upstream:-0}" -eq 0 ]; then
+  echo "CHECKS: All ${total} failures are xcsh-local — autoresearch can continue optimizing"
+  echo "  xcsh: ${xcsh} issues"
+  exit 0
+fi
+
+# Upstream issues found — print triage report and stop autoresearch
+echo ""
+echo "============================================"
+echo " CROSS-REPO TRIAGE REPORT"
+echo "============================================"
+echo ""
+echo "Upstream fixes required — autoresearch STOPPED"
+echo ""
+echo "Issues by repository:"
+echo "  xcsh:                      ${xcsh} (local — can optimize)"
+echo "  terraform-provider-f5xc:   ${provider} (upstream — needs fix)"
+echo "  api-specs-enriched:        ${specs} (upstream — needs fix)"
+echo ""
+
+# Extract and display the failure details
+failures=$(echo "${OUTPUT}" | grep "^ASI failures=" | sed 's/^ASI failures=//' || echo "[]")
+
+if [ "${provider:-0}" -gt 0 ]; then
+  echo "--- terraform-provider-f5xc fixes needed ---"
+  python3 -c "
+import json, sys
+failures = json.loads(sys.argv[1])
+for f in failures:
+    if f.get('fix_repo') == 'terraform-provider-f5xc':
+        error_type = f.get('error_type', 'UNKNOWN')
+        resource = f.get('expect_resource', 'unknown')
+        signal = f.get('error_signal', '')[:120]
+        print(f'  [{error_type}] {resource}')
+        if error_type == 'UNSUPPORTED_ARGUMENT':
+            name = resource.replace('f5xc_', '')
+            print(f'    Fix: docs/_llms-txt/resources/{name}.txt — check Required/OneOf field names')
+        elif error_type == 'MISSING_ONEOF':
+            name = resource.replace('f5xc_', '')
+            print(f'    Fix: docs/_llms-txt/resources/{name}.txt — add missing OneOf group')
+        if signal:
+            print(f'    Signal: {signal}')
+" "${failures}"
+  echo ""
+fi
+
+if [ "${specs:-0}" -gt 0 ]; then
+  echo "--- api-specs-enriched fixes needed ---"
+  python3 -c "
+import json, sys
+failures = json.loads(sys.argv[1])
+for f in failures:
+    if f.get('fix_repo') == 'api-specs-enriched':
+        error_type = f.get('error_type', 'UNKNOWN')
+        resource = f.get('expect_resource', 'unknown')
+        signal = f.get('error_signal', '')[:120]
+        print(f'  [{error_type}] {resource}')
+        if error_type == 'NAMESPACE_NOT_FOUND':
+            print(f'    Fix: config/namespace_profile.yaml — check namespace constraint')
+        elif error_type == 'INVALID_MINIMAL_CONFIG':
+            print(f'    Fix: config/minimum_configs.yaml — update minimal config for resource')
+        if signal:
+            print(f'    Signal: {signal}')
+" "${failures}"
+  echo ""
+fi
+
+echo "--- Next steps ---"
+echo "1. Fix the upstream issues listed above"
+echo "2. Merge upstream changes and wait for CI to regenerate"
+if [ "${provider:-0}" -gt 0 ]; then
+  echo "3. In terraform-provider-f5xc: go run tools/generate-llms-txt.go && merge"
+fi
+if [ "${specs:-0}" -gt 0 ]; then
+  echo "3. In api-specs-enriched: make pipeline && merge (dispatches to terraform-provider)"
+fi
+echo "4. In xcsh: bun --cwd=packages/coding-agent run generate-terraform-index"
+echo "5. Restart autoresearch"
+echo ""
+
+exit 1

--- a/autoresearch.md
+++ b/autoresearch.md
@@ -26,3 +26,5 @@
 - do not reduce the number of test phrases
 - each phrase must produce valid terraform or be counted as a failure
 - preserve existing xcsh:// protocol routes
+- when autoresearch.checks.sh fails with cross-repo issues, stop and address the upstream dependency before continuing
+- after upstream fix: run `bun --cwd=packages/coding-agent run generate-terraform-index` to refresh the embedded index, then restart autoresearch


### PR DESCRIPTION
## What

Add cross-repo failure classification to the terraform autoresearch benchmark so the optimization loop can detect when a failure belongs to an upstream repo and stop cleanly with a structured triage report.

## Why

Without cross-repo triage, autoresearch loops endlessly on terraform failures that require fixes in upstream repos (terraform-provider-f5xc or api-specs-enriched). This change enables the loop to classify errors by owning repo and stop when upstream work is needed, then restart after fixes are applied.

## Changes

- **autoresearch-terraform.sh** — captures terraform validate/plan stderr, classifies errors by repo using triage patterns, emits ASI failures and cross_repo_issues JSON
- **autoresearch.checks.sh** (new) — cross-repo failure classifier that reads ASI output, counts issues by repo, exits 0 if all xcsh-local, exits 1 with structured triage report if upstream fix needed
- **autoresearch.md** — added cross-repo stop/restart constraints to contract

## Error Classification

| Error Class | Owning Repo | Description |
|-------------|-------------|-------------|
| UNSUPPORTED_ARGUMENT | terraform-provider-f5xc | L2 doc field names |
| MISSING_ONEOF | terraform-provider-f5xc | L2 OneOf section |
| NAMESPACE_NOT_FOUND | api-specs-enriched | Namespace profile |
| INVALID_MINIMAL_CONFIG | api-specs-enriched | minimum_configs.yaml |
| NO_TERRAFORM_OUTPUT, OTHER | xcsh | Skill routing, progressive discovery |

Closes #1032

## Testing

- [ ] CI checks pass
- [ ] autoresearch-terraform.sh correctly classifies known error patterns into the right repo categories
- [ ] autoresearch.checks.sh exits 0 when all failures are xcsh-local
- [ ] autoresearch.checks.sh exits 1 with structured triage report when upstream failures are detected