### PR TITLE
fix(coding-agent): remove hardcoded cap on inline image display dimensions

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -404,16 +404,16 @@ export const SETTINGS_SCHEMA = {
 
 	"tui.maxInlineImageColumns": {
 		type: "number",
-		default: 100,
+		default: 0,
 		description:
-			"Maximum width in terminal columns for inline images (default 100). Set to 0 for unlimited (bounded only by terminal width).",
+			"Maximum width in terminal columns for inline images. Set to 0 for unlimited (bounded only by terminal width).",
 	},
 
 	"tui.maxInlineImageRows": {
 		type: "number",
-		default: 20,
+		default: 0,
 		description:
-			"Maximum height in terminal rows for inline images (default 20). Set to 0 to use only the viewport-based limit (60% of terminal height).",
+			"Maximum height in terminal rows for inline images. Set to 0 to use only the viewport-based limit (60% of terminal height).",
 	},
 	// Display rendering
 	"display.tabWidth": {


### PR DESCRIPTION
## What

Changed `tui.maxInlineImageColumns` default from 100 to 0 and `tui.maxInlineImageRows` default from 20 to 0 in `settings-schema.ts`. A value of 0 means unlimited — images scale to actual terminal width and 60% viewport height.

## Why

Images displayed via `display_image` and `inspect_image` rendered too small. A 1568x977 image in a 180-column terminal only used 64 columns (36% of terminal width) because the hardcoded default of 100 capped image width regardless of terminal size.

Closes #1046

## Testing

- [x] `bun run check` passes (Biome lint via pre-commit)
- [x] Issue linked via `Closes #1046`
- [ ] CHANGELOG updated (if user-facing)