### PR TITLE
fix(coding-agent): increase inline image viewport height fraction from 60% to 80%

### DIFF
--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -25,7 +25,7 @@ export function resolveImageOptions(): { maxWidthCells: number; maxHeightCells?:
 	const maxWidthCells = settings.get("tui.maxInlineImageColumns");
 	const rowSetting = Math.max(0, settings.get("tui.maxInlineImageRows"));
 	const viewportRows = process.stdout.rows;
-	const viewportFraction = viewportRows ? Math.floor(viewportRows * 0.6) : 0;
+	const viewportFraction = viewportRows ? Math.floor(viewportRows * 0.8) : 0;
 	let maxHeightCells: number | undefined;
 	if (rowSetting === 0) {
 		// No explicit cap — use viewport fraction as safety bound


### PR DESCRIPTION
## What

Increase the inline image viewport height fraction from 60% to 80% in `resolveImageOptions()`.

## Why

Images were capped at 60% of the terminal viewport height, leaving significant unused visual real estate. Increasing to 80% gives inline images more space while still reserving room for command prompts and other UI elements.

Closes #1049

## Testing

- [ ] `bun run check` passes
- [ ] `bun test` -- no new failures vs baseline
- [x] Issue linked via `Closes #1049`