### PR TITLE
feat: document Salesforce plugin extraction in changelog

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Salesforce tools extracted to marketplace plugin: sf_setup, sf_query, sf_org_display, and sf_pipeline_report are now available as an installable plugin (`@f5xc-salesdemos/xcsh-salesforce`) via the Extension API instead of built-in tools. Install with `xcsh plugin install salesforce`. Context discovery, pipeline reporting, and container-adapted authentication are preserved with full feature parity. ([#1059](https://github.com/f5xc-salesdemos/xcsh/issues/1059))
+
 ## [18.75.0] - 2026-05-23
 
 ### Added


### PR DESCRIPTION
## What

Add changelog entry documenting the extraction of Salesforce tools to a marketplace plugin.

## Why

The `refactor:` commit (#1060) that extracted Salesforce tools to `@f5xc-salesdemos/xcsh-salesforce` did not trigger a release because `refactor:` is not a release-triggering prefix. This `feat:` commit documents the change in the changelog and triggers the auto-release pipeline to create a version bump PR.

## Summary

- Add changelog entry for Salesforce tools extraction to marketplace plugin
- Documents that sf_setup, sf_query, sf_org_display, sf_pipeline_report are now installable via `xcsh plugin install salesforce`
- This `feat:` commit triggers the auto-release pipeline to create a version bump PR

Closes #1061

## Testing

- [x] Pre-commit hooks pass (governance, markdown lint, spelling, secrets detection)
- [x] Issue linked via `Closes #1061`
- [x] Changelog entry follows existing format conventions
- [ ] CI checks pass