### PR TITLE
feat(coding-agent): add registerServiceStatus to Extension API

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -28,6 +28,7 @@ import type {
 	LoadExtensionsResult,
 	MessageRenderer,
 	RegisteredCommand,
+	ServiceStatusContribution,
 	ToolDefinition,
 } from "./types";
 
@@ -176,6 +177,10 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 		this.extension.messageRenderers.set(customType, renderer as MessageRenderer);
 	}
 
+	registerServiceStatus(contribution: ServiceStatusContribution): void {
+		this.extension.serviceStatuses.set(contribution.name, contribution);
+	}
+
 	getFlag(name: string): boolean | string | undefined {
 		if (!this.extension.flags.has(name)) return undefined;
 		return this.runtime.flagValues.get(name);
@@ -257,6 +262,7 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 		commands: new Map(),
 		flags: new Map(),
 		shortcuts: new Map(),
+		serviceStatuses: new Map(),
 	};
 }
 

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -36,6 +36,7 @@ import type {
 	RegisteredTool,
 	ResourcesDiscoverEvent,
 	ResourcesDiscoverResult,
+	ServiceStatusContribution,
 	SessionBeforeBranchResult,
 	SessionBeforeCompactResult,
 	SessionBeforeSwitchResult,
@@ -249,6 +250,17 @@ export class ExtensionRunner {
 			}
 		}
 		return tools;
+	}
+
+	/** Get all registered service status contributions from all extensions. */
+	getAllRegisteredServiceStatuses(): ServiceStatusContribution[] {
+		const statuses: ServiceStatusContribution[] = [];
+		for (const ext of this.extensions) {
+			for (const contribution of ext.serviceStatuses.values()) {
+				statuses.push(contribution);
+			}
+		}
+		return statuses;
 	}
 
 	getFlags(): Map<string, ExtensionFlag> {

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -934,6 +934,19 @@ export interface RegisteredCommand {
 }
 
 // ============================================================================
+// Service Status Contributions
+// ============================================================================
+
+export interface ServiceStatusContribution {
+	name: string;
+	check: () => Promise<{ state: "connected" | "unauthenticated" | "unavailable"; hint?: string }>;
+	fix?: {
+		prompt: string;
+		command: string[];
+	};
+}
+
+// ============================================================================
 // Extension API
 // ============================================================================
 
@@ -1063,6 +1076,9 @@ export interface ExtensionAPI {
 
 	/** Register a custom renderer for CustomMessageEntry. */
 	registerMessageRenderer<T = unknown>(customType: string, renderer: MessageRenderer<T>): void;
+
+	/** Register a service status check for the welcome screen. */
+	registerServiceStatus(contribution: ServiceStatusContribution): void;
 
 	// =========================================================================
 	// Actions
@@ -1351,6 +1367,7 @@ export interface Extension {
 	commands: Map<string, RegisteredCommand>;
 	flags: Map<string, ExtensionFlag>;
 	shortcuts: Map<KeyId, ExtensionShortcut>;
+	serviceStatuses: Map<string, ServiceStatusContribution>;
 }
 
 /** Result of loading extensions. */

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -352,7 +352,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.ui.addChild(new Spacer(1));
 		}
 
-		const services =
+		const services: ServiceStatus[] =
 			!startupQuiet && welcomeResult.model.state === "connected"
 				? [
 						mapContextStatus(welcomeResult.context ?? { state: "no_context" }),
@@ -364,7 +364,20 @@ export class InteractiveMode implements InteractiveModeContext {
 					]
 				: [];
 
-		const fixableServices =
+		// Collect service statuses from plugins
+		if (this.session.extensionRunner) {
+			const pluginContributions = this.session.extensionRunner.getAllRegisteredServiceStatuses();
+			for (const contribution of pluginContributions) {
+				try {
+					const status = await contribution.check();
+					services.push({ name: contribution.name, ...status });
+				} catch {
+					services.push({ name: contribution.name, state: "unavailable", hint: "check failed" });
+				}
+			}
+		}
+
+		const fixableServices: FixableService[] =
 			!startupQuiet && welcomeResult.model.state === "connected"
 				? getFixableServices({
 						aws: awsStatus,
@@ -374,6 +387,32 @@ export class InteractiveMode implements InteractiveModeContext {
 						gitlab: gitlabStatus,
 					})
 				: [];
+
+		// Add fixable services from plugins
+		if (this.session.extensionRunner) {
+			const pluginContributions = this.session.extensionRunner.getAllRegisteredServiceStatuses();
+			for (const contribution of pluginContributions) {
+				if (contribution.fix) {
+					// Find the status we already checked above
+					const status = services.find(s => s.name === contribution.name);
+					if (status && status.state === "unauthenticated") {
+						fixableServices.push({
+							name: contribution.name,
+							prompt: contribution.fix.prompt,
+							command: contribution.fix.command,
+							recheck: async () => {
+								try {
+									const result = await contribution.check();
+									return { name: contribution.name, ...result };
+								} catch {
+									return { name: contribution.name, state: "unavailable" as const, hint: "recheck failed" };
+								}
+							},
+						});
+					}
+				}
+			}
+		}
 
 		if (!startupQuiet) {
 			this.#welcomeComponent = new WelcomeComponent(

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -649,6 +649,19 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 							]
 						: [];
 
+				// Collect service statuses from plugins
+				if (extensionRunner) {
+					const pluginContributions = extensionRunner.getAllRegisteredServiceStatuses();
+					for (const contribution of pluginContributions) {
+						try {
+							const status = await contribution.check();
+							services.push({ name: contribution.name, ...status });
+						} catch {
+							services.push({ name: contribution.name, state: "unavailable", hint: "check failed" });
+						}
+					}
+				}
+
 				return success(id, "get_integrations", {
 					version: VERSION,
 					model: welcomeResult.model,


### PR DESCRIPTION
## What

- Add `registerServiceStatus()` to the Extension API, following the same pattern as `registerTool()`, `registerCommand()`, etc.
- Plugins can now contribute service status entries to the welcome screen (connected/unauthenticated/unavailable)
- Plugin fixable services (auto-fix prompts for expired sessions) are merged into the welcome flow
- Completes the plugin extraction pattern -- extracted services (Salesforce, future AWS/Azure/GCP) can show their status on the welcome screen

## Why

The Salesforce plugin extraction removed the hardcoded welcome screen service check. This API lets plugins contribute status back to the welcome screen, completing the migration pattern.

## API

```typescript
pi.registerServiceStatus({
  name: 'Salesforce',
  check: async () => ({ state: 'connected' }),
  fix: { prompt: 'Not authenticated', command: ['sf', 'org', 'login', 'web'] },
});
```

Closes #1066

## Testing

- [x] 1269 tests pass (0 new failures)
- [x] Type check passes
- [x] `bun run check` passes
- [x] Pre-commit hooks pass
- [ ] Manual: install Salesforce plugin, verify status appears on welcome screen
- [x] Issue linked via `Closes #1066`