### PR TITLE
feat(coding-agent): document cloud connector plugin extraction and registerServiceStatus API in changelog

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Plugin-based welcome screen service status via `registerServiceStatus()` Extension API: plugins can now contribute service status entries and auto-fix prompts to the xcsh welcome screen. ([#1066](https://github.com/f5xc-salesdemos/xcsh/issues/1066))
+
+### Changed
+
+- All cloud connector integrations extracted to marketplace plugins: GitHub (9 tools), GitLab (4 tools), Azure, AWS, Google Cloud welcome checks are now installable via `xcsh plugin install`. Only F5 XC Context remains as a built-in service. ([#1069](https://github.com/f5xc-salesdemos/xcsh/issues/1069), [#1071](https://github.com/f5xc-salesdemos/xcsh/issues/1071))
+
 ## [18.88.0] - 2026-05-31
 
 ### Changed


### PR DESCRIPTION
## Summary

- Add changelog entries for registerServiceStatus Extension API and cloud connector extractions
- Documents: GitHub (9 tools), GitLab (4 tools), Azure, AWS, GCloud moved to plugins
- This feat: commit triggers auto-release for v18.90.0

## Why

The refactor: commits that extracted cloud connectors did not trigger releases. This documents the changes and triggers the version bump.

Closes #1073

## Testing

- [x] Pre-commit hooks pass (governance, markdown lint, spelling, secrets, editorconfig)
- [x] No code changes -- changelog only
- [x] Issue linked via `Closes #1073`

---

Generated with Claude Code