### PR TITLE
refactor(coding-agent): remove dead welcome screen stub code

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -1,7 +1,6 @@
 import type { Model } from "@f5xc-salesdemos/pi-ai";
 import { validateApiKeyAgainstModelsEndpoint } from "@f5xc-salesdemos/pi-ai/utils/oauth/api-key-validation";
 import { logger } from "@f5xc-salesdemos/pi-utils";
-import { loadProfile } from "../../internal-urls/user-profile";
 import { type AuthStatus, ContextService } from "../../services/f5xc-context";
 import { deriveTenantFromUrl } from "../../services/f5xc-env";
 import type { AuthStorage } from "../../session/auth-storage";
@@ -207,54 +206,9 @@ export function mapContextStatus(status: WelcomeContextStatus): ServiceStatus {
 	}
 }
 
-export type ProfileCheckState = "current" | "stale" | "missing";
-
-export interface WelcomeProfileStatus {
-	state: ProfileCheckState;
-	name?: string;
-	updatedAt?: string;
-	staleDays?: number;
-}
-
-const PROFILE_STALE_HOURS = 24;
-
-/** Check user profile freshness. Returns undefined only on unexpected error. */
-export async function checkProfileStatus(): Promise<WelcomeProfileStatus | undefined> {
-	try {
-		const profile = await loadProfile();
-		if (!profile.givenName && !profile.familyName) {
-			return { state: "missing" };
-		}
-		const name = [profile.givenName, profile.familyName].filter(Boolean).join(" ");
-		const updatedAt = profile.updatedAt;
-
-		if (!updatedAt) {
-			return { state: "stale", name };
-		}
-
-		const ageHours = (Date.now() - new Date(updatedAt).getTime()) / (1000 * 60 * 60);
-		if (ageHours > PROFILE_STALE_HOURS) {
-			return {
-				state: "stale",
-				name,
-				updatedAt,
-				staleDays: Math.floor(ageHours / 24),
-			};
-		}
-
-		return { state: "current", name, updatedAt };
-	} catch {
-		return { state: "missing" };
-	}
-}
-
 export interface FixableService {
 	name: string;
 	prompt: string;
 	command: string[];
 	recheck: () => Promise<ServiceStatus>;
-}
-
-export function getFixableServices(): FixableService[] {
-	return [];
 }

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -54,7 +54,6 @@ import type { ToolExecutionHandle } from "./components/tool-execution";
 import { type UpdateStatus, WelcomeComponent } from "./components/welcome";
 import {
 	type FixableService,
-	getFixableServices,
 	mapContextStatus,
 	runWelcomeChecks,
 	type ServiceStatus,
@@ -353,8 +352,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			}
 		}
 
-		const fixableServices: FixableService[] =
-			!startupQuiet && welcomeResult.model.state === "connected" ? getFixableServices() : [];
+		const fixableServices: FixableService[] = [];
 
 		// Add fixable services from plugins
 		if (this.session.extensionRunner) {

--- a/packages/coding-agent/test/profile-hint-and-checks.test.ts
+++ b/packages/coding-agent/test/profile-hint-and-checks.test.ts
@@ -1,8 +1,7 @@
-import { afterEach, beforeAll, describe, expect, it, test, vi } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import * as path from "node:path";
 import { prompt } from "@f5xc-salesdemos/pi-utils";
 import { registerCodingAgentPromptHelpers } from "../src/config/prompt-templates";
-import { checkProfileStatus } from "../src/modes/components/welcome-checks";
 
 // ---------- system-prompt profile hint ----------
 
@@ -91,85 +90,5 @@ describe("system-prompt userProfile hint", () => {
 		expect(rendered).toContain("PII");
 		expect(rendered).toContain("SHOULD NOT");
 		expect(rendered).toContain("routine work");
-	});
-});
-
-// ---------- checkProfileStatus ----------
-
-function mockProfile(data: object): void {
-	vi.spyOn(Bun, "file").mockReturnValue({
-		json: () => Promise.resolve(data),
-	} as unknown as ReturnType<typeof Bun.file>);
-}
-
-function mockProfileMissing(): void {
-	vi.spyOn(Bun, "file").mockReturnValue({
-		json: () => Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" })),
-	} as unknown as ReturnType<typeof Bun.file>);
-}
-
-describe("checkProfileStatus", () => {
-	afterEach(() => vi.restoreAllMocks());
-
-	it("returns current when profile is fresh (updatedAt within 24h)", async () => {
-		const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(); // 1h ago
-		mockProfile({ givenName: "Ada", familyName: "Lovelace", updatedAt: recentTs });
-
-		const result = await checkProfileStatus();
-		expect(result?.state).toBe("current");
-		expect(result?.name).toBe("Ada Lovelace");
-		expect(result?.updatedAt).toBe(recentTs);
-	});
-
-	it("returns stale when updatedAt is older than 24h", async () => {
-		const oldTs = new Date(Date.now() - 50 * 60 * 60 * 1000).toISOString(); // 50h ago
-		mockProfile({ givenName: "Ada", familyName: "Lovelace", updatedAt: oldTs });
-
-		const result = await checkProfileStatus();
-		expect(result?.state).toBe("stale");
-		expect(result?.name).toBe("Ada Lovelace");
-		expect(result?.staleDays).toBe(2);
-	});
-
-	it("returns stale when updatedAt is absent", async () => {
-		mockProfile({ givenName: "Ada", familyName: "Lovelace" });
-
-		const result = await checkProfileStatus();
-		expect(result?.state).toBe("stale");
-		expect(result?.name).toBe("Ada Lovelace");
-		expect(result?.staleDays).toBeUndefined();
-	});
-
-	it("returns missing when profile file does not exist", async () => {
-		mockProfileMissing();
-
-		const result = await checkProfileStatus();
-		expect(result?.state).toBe("missing");
-	});
-
-	it("returns missing when profile has no name fields", async () => {
-		const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
-		mockProfile({ jobTitle: "Engineer", updatedAt: recentTs });
-
-		const result = await checkProfileStatus();
-		expect(result?.state).toBe("missing");
-	});
-
-	it("builds name from givenName only when familyName is absent", async () => {
-		const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
-		mockProfile({ givenName: "Ada", updatedAt: recentTs });
-
-		const result = await checkProfileStatus();
-		expect(result?.state).toBe("current");
-		expect(result?.name).toBe("Ada");
-	});
-
-	it("builds name from familyName only when givenName is absent", async () => {
-		const recentTs = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
-		mockProfile({ familyName: "Lovelace", updatedAt: recentTs });
-
-		const result = await checkProfileStatus();
-		expect(result?.state).toBe("current");
-		expect(result?.name).toBe("Lovelace");
 	});
 });

--- a/packages/coding-agent/test/welcome-auto-fix.test.ts
+++ b/packages/coding-agent/test/welcome-auto-fix.test.ts
@@ -1,8 +1,0 @@
-import { describe, expect, it } from "bun:test";
-import { getFixableServices } from "@f5xc-salesdemos/xcsh/modes/components/welcome-checks";
-
-describe("getFixableServices", () => {
-	it("returns empty array (all cloud services extracted to plugins)", () => {
-		expect(getFixableServices()).toEqual([]);
-	});
-});


### PR DESCRIPTION
## Summary
Clean break — remove all backward-compatibility stubs and unused code from the welcome screen system:

- Remove `getFixableServices()` empty stub (returned `[]` since all cloud services moved to plugins)
- Remove unused `checkProfileStatus()`, `ProfileCheckState`, `WelcomeProfileStatus` (defined but never called)
- Remove `loadProfile` import that was only used by removed profile check
- Simplify `interactive-mode.ts` fixable services initialization to `[]` (plugins populate via Extension API)
- Delete `welcome-auto-fix.test.ts` (only tested the removed stub)
- Remove `checkProfileStatus` tests from `profile-hint-and-checks.test.ts`

What remains is clean: F5 XC Context (the one built-in service), `FixableService` interface (used by plugin contributions), and `ServiceStatus` types (used by `registerServiceStatus` API).

Closes #1076

## Test plan
- [x] 1218 tests pass (0 new failures)
- [x] Zero grep matches for removed identifiers
- [x] `bun run check` passes
- [x] Pre-commit hooks pass

Why: No backward compatibility needed — this is pre-release code. Dead stubs and unused definitions removed for clean codebase.