### PR TITLE
feat: document welcome screen cleanup in changelog

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Welcome screen fully plugin-driven: removed all hardcoded cloud service stubs (`getFixableServices` empty stub, `checkProfileStatus` dead code). Only F5 XC Context remains as a built-in service. All cloud connector status checks now come exclusively from the Extension API `registerServiceStatus()`. ([#1076](https://github.com/f5xc-salesdemos/xcsh/issues/1076))
+
 ## [18.90.0] - 2026-06-01
 
 ### Added


### PR DESCRIPTION
## Summary

- Add changelog entry for welcome screen dead code removal
- Triggers v18.91.0 release

## Why

The `refactor:` commit from PR #1077 did not trigger auto-release because `refactor:` is not a release-triggering conventional commit type. This `feat:` documents the change in the changelog and triggers the version bump.

Closes #1081

## Test plan

- [x] Pre-commit hooks pass
- [x] CHANGELOG.md entry follows existing format
- [ ] CI checks pass
- [ ] Auto-release workflow creates `release/v18.91.0` branch after merge