### PR TITLE
fix(coding-agent): extension test filter to exclude installed plugins from test counts

### DIFF
--- a/packages/coding-agent/test/utils/filter-user-extensions.ts
+++ b/packages/coding-agent/test/utils/filter-user-extensions.ts
@@ -1,12 +1,11 @@
-import * as path from "node:path";
-import { getAgentDir } from "@f5xc-salesdemos/pi-utils";
+import { getConfigRootDir } from "@f5xc-salesdemos/pi-utils";
 
 export function filterUserExtensions<T extends { path: string }>(extensions: T[]): T[] {
-	const userExtensionsDir = path.join(getAgentDir(), "extensions");
-	return extensions.filter(ext => !ext.path.startsWith(userExtensionsDir));
+	const configRoot = getConfigRootDir();
+	return extensions.filter(ext => !ext.path.startsWith(configRoot));
 }
 
 export function filterUserExtensionErrors<T extends { path: string }>(errors: T[]): T[] {
-	const userExtensionsDir = path.join(getAgentDir(), "extensions");
-	return errors.filter(err => !err.path.startsWith(userExtensionsDir));
+	const configRoot = getConfigRootDir();
+	return errors.filter(err => !err.path.startsWith(configRoot));
 }


### PR DESCRIPTION
## What

Fix `filterUserExtensions` test utility to filter all user-global extension paths, not just agent extensions.

## Why

15 pre-existing test failures in extension-runner and extension-discovery tests. The root cause: `filterUserExtensions` only filtered `~/.xcsh/agent/extensions/` but not `~/.xcsh/plugins/node_modules/` — installed marketplace plugins (salesforce, github, gitlab, etc.) inflated tool/command/extension counts.

These tests were broken by installing marketplace plugins — they were never designed for a system with installed extensions. The filter fix makes tests isolated from the user's plugin state.

Closes #1088

## Summary
- Fix 15 pre-existing test failures in extension-runner and extension-discovery tests
- Root cause: `filterUserExtensions` test utility only filtered `~/.xcsh/agent/extensions/` but not `~/.xcsh/plugins/node_modules/` — installed plugins (salesforce, github, gitlab, etc.) inflated tool/command/extension counts
- Fix: filter by config root dir (`~/.xcsh/`) instead of just the agent extensions subdirectory
- Now excludes all user-global extensions regardless of origin path

## Testing

- [x] 4548 tests pass, 0 failures (previously 15 failures)
- [x] All 45 extension runner + discovery tests pass
- [x] `bun run check` passes
- [x] Issue linked via `Closes #1088`

---

- [x] `bun run check` passes
- [x] `bun test` -- no new failures vs baseline
- [ ] CHANGELOG updated (if user-facing)
- [x] Issue linked via `Closes #N`