### PR TITLE
fix(coding-agent): disable external discovery providers by default

### DIFF
--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -208,11 +208,13 @@ async function loadImpl<T>(
  * Filter providers based on options and disabled state.
  */
 function filterProviders<T>(capability: Capability<T>, options: LoadOptions): Provider<T>[] {
-	let providers = (capability.providers as Provider<T>[]).filter(p => !disabledProviders.has(p.id));
+	let providers = capability.providers as Provider<T>[];
 
 	if (options.providers) {
 		const allowed = new Set(options.providers);
 		providers = providers.filter(p => allowed.has(p.id));
+	} else {
+		providers = providers.filter(p => !disabledProviders.has(p.id));
 	}
 	if (options.excludeProviders) {
 		const excluded = new Set(options.excludeProviders);

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -224,7 +224,25 @@ export const SETTINGS_SCHEMA = {
 
 	enabledModels: { type: "array", default: EMPTY_STRING_ARRAY },
 
-	disabledProviders: { type: "array", default: EMPTY_STRING_ARRAY },
+	disabledProviders: {
+		type: "array",
+		default: [
+			"claude",
+			"claude-plugins",
+			"codex",
+			"agents",
+			"agents-md",
+			"gemini",
+			"opencode",
+			"cursor",
+			"windsurf",
+			"cline",
+			"github",
+			"vscode",
+			"mcp-json",
+			"ssh-json",
+		] as string[],
+	},
 
 	disabledExtensions: { type: "array", default: EMPTY_STRING_ARRAY },
 

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "@f5xc-salesdemos/xcsh/config/settings";
+import { setDisabledProviders } from "@f5xc-salesdemos/xcsh/discovery";
 import { createAgentSession } from "@f5xc-salesdemos/xcsh/sdk";
 import { SessionManager } from "@f5xc-salesdemos/xcsh/session/session-manager";
 import { buildSystemPrompt, loadProjectContextFiles, loadSystemPromptFiles } from "@f5xc-salesdemos/xcsh/system-prompt";
@@ -21,6 +22,7 @@ describe("SYSTEM.md prompt assembly", () => {
 		tempHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-system-home-"));
 		originalHome = process.env.HOME;
 		process.env.HOME = tempHomeDir;
+		setDisabledProviders([]);
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
## What

Disable 14 external discovery providers by default in the `disabledProviders` settings schema, leaving only the `native` provider enabled.

## Why

xcsh should only load plugins/config from its own `.xcsh/` directories, but external discovery providers (claude, claude-plugins, cursor, windsurf, gemini, codex, opencode, cline, github, vscode, agents, agents-md, mcp-json, ssh-json) were still enabled by default. This caused tools like Azure MCP to appear from `~/.claude/plugins/`, which is undesired behavior for xcsh deployments.

Closes #1093

## Testing

- [x] `bun run check` passes (pre-commit Biome lint passed)
- [x] Issue linked via `Closes #1093`
- [ ] CHANGELOG updated (if user-facing)