### PR TITLE
feat(coding-agent): add interactive TUI Plugin Control Center dashboard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,7 @@
         "@google/genai": "^1.43",
         "@sinclair/typebox": "^0.34",
         "@smithy/node-http-handler": "^4.4",
-        "ajv": "~8.18.0",
+        "ajv": "^8.20",
         "ajv-formats": "^3.0",
         "openai": "^6.25",
         "partial-json": "^0.1",
@@ -67,7 +67,7 @@
         "@mozilla/readability": "^0.6",
         "@sinclair/typebox": "^0.34",
         "@xterm/headless": "^6.0",
-        "ajv": "^8.18",
+        "ajv": "^8.20",
         "chalk": "^5.6",
         "diff": "^8.0",
         "fflate": "0.8.2",
@@ -193,7 +193,7 @@
     },
   },
   "overrides": {
-    "ajv": "~8.18.0",
+    "ajv": "^8.20",
     "date-fns": "~4.1.0",
   },
   "packages": {
@@ -312,6 +312,16 @@
     "@f5xc-salesdemos/pi-ai": ["@f5xc-salesdemos/pi-ai@workspace:packages/ai"],
 
     "@f5xc-salesdemos/pi-natives": ["@f5xc-salesdemos/pi-natives@workspace:packages/natives"],
+
+    "@f5xc-salesdemos/pi-natives-darwin-arm64": ["@f5xc-salesdemos/pi-natives-darwin-arm64@18.91.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mEHIWKwBsTlwGxWchapXviSzLpO64vnEZzsYSANF3lelePzqANap80i/N1aBMpimCWndAZRtNSwsfnvF5KBIPQ=="],
+
+    "@f5xc-salesdemos/pi-natives-darwin-x64": ["@f5xc-salesdemos/pi-natives-darwin-x64@18.91.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-439iVPcbSeHK1TryKN+kyu5Ka4VlxySsfBk56+N8fLnZqVi6fxR11nU19HTojdvyrd0yt+r+SNd1ePhkAQHd9Q=="],
+
+    "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": ["@f5xc-salesdemos/pi-natives-linux-arm64-gnu@18.91.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-HeRnXR0YQPnC1gVEsw1Ge5S9up1WBmwE+odxQbIkroDezllpwIqJn+53/lwK7upuTuXkWuE+vzFAkllStlbjYg=="],
+
+    "@f5xc-salesdemos/pi-natives-linux-x64-gnu": ["@f5xc-salesdemos/pi-natives-linux-x64-gnu@18.91.4", "", { "os": "linux", "cpu": "x64" }, "sha512-sHnb1NNkfRUuFxg4Gvbj/5ak0FB7Sx0foVF/qNFbCQy1UjkluAgr3tmohNxpsKWu33Ir605uZxhnzXhozM9+rg=="],
+
+    "@f5xc-salesdemos/pi-natives-win32-x64-msvc": ["@f5xc-salesdemos/pi-natives-win32-x64-msvc@18.91.4", "", { "os": "win32", "cpu": "x64" }, "sha512-Q1FP8Lkd8EFVT0iEJ056GRcBtfVAhoyxUbPy+zLXsgWULOQkDXlOJHNXDCP/J71rcZA75U2tPwP9waayk1fBWw=="],
 
     "@f5xc-salesdemos/pi-tui": ["@f5xc-salesdemos/pi-tui@workspace:packages/tui"],
 
@@ -601,7 +611,7 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"*.{js,ts,jsx,tsx,json,jsonc,css}": "biome check --write --no-errors-on-unmatched"
 	},
 	"overrides": {
-		"ajv": "~8.18.0",
+		"ajv": "^8.20",
 		"date-fns": "~4.1.0"
 	}
 }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -48,7 +48,7 @@
 		"@f5xc-salesdemos/pi-utils": "workspace:*",
 		"@sinclair/typebox": "^0.34",
 		"@smithy/node-http-handler": "^4.4",
-		"ajv": "~8.18.0",
+		"ajv": "^8.20",
 		"ajv-formats": "^3.0",
 		"openai": "^6.25",
 		"partial-json": "^0.1",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -58,7 +58,7 @@
 		"@f5xc-salesdemos/pi-utils": "workspace:*",
 		"@sinclair/typebox": "^0.34",
 		"@xterm/headless": "^6.0",
-		"ajv": "^8.18",
+		"ajv": "^8.20",
 		"chalk": "^5.6",
 		"diff": "^8.0",
 		"fflate": "0.8.2",

--- a/packages/coding-agent/scripts/generate-branding-index.ts
+++ b/packages/coding-agent/scripts/generate-branding-index.ts
@@ -61,7 +61,9 @@ function generateTypeScript(config: BrandingConfig): string {
 		"",
 		`export const BRANDING_CANONICAL = ${JSON.stringify(config.canonical, null, 2)} as const;`,
 		"",
-		`export const BRANDING_DEPRECATIONS = ${JSON.stringify(config.deprecations, null, 2)} as const;`,
+		config.deprecations
+			? `export const BRANDING_DEPRECATIONS = ${JSON.stringify(config.deprecations, null, 2)} as const;`
+			: "export const BRANDING_DEPRECATIONS = null;",
 		"",
 		`export const BRANDING_GLOSSARY = ${JSON.stringify(config.glossary, null, 2)} as const;`,
 		"",

--- a/packages/coding-agent/src/internal-urls/branding-index.generated.ts
+++ b/packages/coding-agent/src/internal-urls/branding-index.generated.ts
@@ -35,7 +35,7 @@ export const BRANDING_CANONICAL = {
 	},
 } as const;
 
-export const BRANDING_DEPRECATIONS = undefined as const;
+export const BRANDING_DEPRECATIONS = null;
 
 export const BRANDING_GLOSSARY = {
 	XCKS: {

--- a/packages/coding-agent/src/modes/components/plugins/index.ts
+++ b/packages/coding-agent/src/modes/components/plugins/index.ts
@@ -1,0 +1,5 @@
+export * from "./plugin-dashboard";
+export * from "./plugin-inspector-pane";
+export * from "./plugin-list-pane";
+export * from "./state-manager";
+export * from "./types";

--- a/packages/coding-agent/src/modes/components/plugins/plugin-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/plugins/plugin-dashboard.ts
@@ -1,0 +1,449 @@
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	type Component,
+	Container,
+	matchesKey,
+	padding,
+	replaceTabs,
+	Spacer,
+	Text,
+	truncateToWidth,
+	visibleWidth,
+} from "@f5xc-salesdemos/pi-tui";
+import { getConfigDirName } from "@f5xc-salesdemos/pi-utils";
+import { invalidate as invalidateFsCache } from "../../../capability/fs";
+import { clearClaudePluginRootsCache, resolveActiveProjectRegistryPath } from "../../../discovery/helpers";
+import { PluginManager } from "../../../extensibility/plugins";
+import {
+	getInstalledPluginsRegistryPath,
+	getMarketplacesCacheDir,
+	getMarketplacesRegistryPath,
+	getPluginsCacheDir,
+	MarketplaceManager,
+} from "../../../extensibility/plugins/marketplace";
+import { theme } from "../../theme/theme";
+import { matchesAppInterrupt } from "../../utils/keybinding-matchers";
+import { DynamicBorder } from "../dynamic-border";
+import { PluginInspectorPane } from "./plugin-inspector-pane";
+import { PluginListPane } from "./plugin-list-pane";
+import { applySearch, buildTabs, createInitialState, filterByTab, loadAllPlugins } from "./state-manager";
+import type { DashboardPlugin, PluginDashboardState, PluginTabId } from "./types";
+
+const DEFAULT_MARKETPLACE = "anthropics/claude-plugins-official";
+
+class TwoColumnBody implements Component {
+	constructor(
+		private readonly leftPane: PluginListPane,
+		private readonly rightPane: PluginInspectorPane,
+		private readonly maxHeight: number,
+	) {}
+
+	render(width: number): string[] {
+		const leftWidth = Math.floor(width * 0.5);
+		const rightWidth = width - leftWidth - 3;
+		const leftLines = this.leftPane.render(leftWidth);
+		const rightLines = this.rightPane.render(rightWidth);
+		const lineCount = Math.min(this.maxHeight, Math.max(leftLines.length, rightLines.length));
+		const out: string[] = [];
+		const separator = theme.fg("dim", ` ${theme.boxSharp.vertical} `);
+
+		for (let i = 0; i < lineCount; i++) {
+			const left = truncateToWidth(leftLines[i] ?? "", leftWidth);
+			const leftPadded = left + padding(Math.max(0, leftWidth - visibleWidth(left)));
+			const right = truncateToWidth(rightLines[i] ?? "", rightWidth);
+			out.push(leftPadded + separator + right);
+		}
+
+		return out;
+	}
+
+	invalidate(): void {
+		this.leftPane.invalidate?.();
+		this.rightPane.invalidate?.();
+	}
+}
+
+export class PluginDashboard extends Container {
+	#state!: PluginDashboardState;
+	#mgr!: MarketplaceManager;
+	#npmMgr!: PluginManager;
+
+	onClose?: () => void;
+	onRequestRender?: () => void;
+
+	private constructor(
+		private readonly cwd: string,
+		private readonly terminalHeight: number,
+	) {
+		super();
+	}
+
+	static async create(cwd: string, terminalHeight?: number): Promise<PluginDashboard> {
+		const dashboard = new PluginDashboard(cwd, terminalHeight ?? process.stdout.rows ?? 24);
+		await dashboard.#init();
+		return dashboard;
+	}
+
+	async #init(): Promise<void> {
+		const projectRegistryPath = (await resolveActiveProjectRegistryPath(this.cwd)) ?? undefined;
+
+		this.#mgr = new MarketplaceManager({
+			marketplacesRegistryPath: getMarketplacesRegistryPath(),
+			installedRegistryPath: getInstalledPluginsRegistryPath(),
+			projectInstalledRegistryPath: projectRegistryPath,
+			marketplacesCacheDir: getMarketplacesCacheDir(),
+			pluginsCacheDir: getPluginsCacheDir(),
+			clearPluginRootsCache: (extraPaths?: readonly string[]) => {
+				const home = os.homedir();
+				invalidateFsCache(path.join(home, getConfigDirName(), "plugins", "installed_plugins.json"));
+				for (const p of extraPaths ?? []) invalidateFsCache(p);
+				clearClaudePluginRootsCache();
+			},
+		});
+
+		this.#npmMgr = new PluginManager();
+
+		try {
+			const marketplaces = await this.#mgr.listMarketplaces();
+			if (marketplaces.length === 0) {
+				await this.#mgr.addMarketplace(DEFAULT_MARKETPLACE);
+			}
+		} catch {
+			// Network failure on first run is fine — continue with whatever is available
+		}
+
+		try {
+			this.#state = await createInitialState(this.#mgr, this.#npmMgr);
+		} catch (error) {
+			this.#state = {
+				tabs: [{ id: "installed", label: "Installed", count: 0 }],
+				activeTabIndex: 0,
+				allPlugins: [],
+				tabFiltered: [],
+				searchFiltered: [],
+				searchQuery: "",
+				selectedIndex: 0,
+				scrollOffset: 0,
+				notice: null,
+				loading: false,
+				loadError: error instanceof Error ? error.message : String(error),
+			};
+		}
+
+		this.#buildLayout();
+	}
+
+	#selectedPlugin(): DashboardPlugin | null {
+		return this.#state.searchFiltered[this.#state.selectedIndex] ?? null;
+	}
+
+	#activeTabId(): PluginTabId {
+		return this.#state.tabs[this.#state.activeTabIndex]?.id ?? "installed";
+	}
+
+	#getMaxVisibleItems(): number {
+		return Math.max(5, this.terminalHeight - 14);
+	}
+
+	#applyFilters(): void {
+		this.#state.tabFiltered = filterByTab(this.#state.allPlugins, this.#activeTabId());
+		this.#state.searchFiltered = applySearch(this.#state.tabFiltered, this.#state.searchQuery);
+		this.#clampSelection();
+	}
+
+	#clampSelection(): void {
+		const len = this.#state.searchFiltered.length;
+		if (len === 0) {
+			this.#state.selectedIndex = 0;
+			this.#state.scrollOffset = 0;
+			return;
+		}
+
+		this.#state.selectedIndex = Math.min(this.#state.selectedIndex, len - 1);
+		this.#state.selectedIndex = Math.max(0, this.#state.selectedIndex);
+
+		const maxVisible = this.#getMaxVisibleItems();
+		if (this.#state.selectedIndex < this.#state.scrollOffset) {
+			this.#state.scrollOffset = this.#state.selectedIndex;
+		} else if (this.#state.selectedIndex >= this.#state.scrollOffset + maxVisible) {
+			this.#state.scrollOffset = this.#state.selectedIndex - maxVisible + 1;
+		}
+	}
+
+	#switchTab(direction: 1 | -1): void {
+		if (this.#state.tabs.length === 0) return;
+		this.#state.activeTabIndex =
+			(this.#state.activeTabIndex + direction + this.#state.tabs.length) % this.#state.tabs.length;
+		this.#state.selectedIndex = 0;
+		this.#state.scrollOffset = 0;
+		this.#applyFilters();
+		this.#buildLayout();
+	}
+
+	#moveSelection(delta: -1 | 1): void {
+		if (this.#state.searchFiltered.length === 0) return;
+		this.#state.selectedIndex = Math.max(
+			0,
+			Math.min(this.#state.searchFiltered.length - 1, this.#state.selectedIndex + delta),
+		);
+		this.#clampSelection();
+		this.#buildLayout();
+	}
+
+	async #reloadData(): Promise<void> {
+		this.#state.loading = true;
+		this.#state.loadError = null;
+		this.#buildLayout();
+
+		try {
+			const selectedId = this.#selectedPlugin()?.id;
+			const allPlugins = await loadAllPlugins(this.#mgr, this.#npmMgr);
+			const tabs = buildTabs(allPlugins);
+			const prevTabId = this.#activeTabId();
+			const nextTabIndex = Math.max(
+				0,
+				tabs.findIndex(t => t.id === prevTabId),
+			);
+
+			this.#state.allPlugins = allPlugins;
+			this.#state.tabs = tabs;
+			this.#state.activeTabIndex = nextTabIndex;
+			this.#applyFilters();
+
+			if (selectedId) {
+				const idx = this.#state.searchFiltered.findIndex(p => p.id === selectedId);
+				if (idx >= 0) this.#state.selectedIndex = idx;
+			}
+			this.#clampSelection();
+		} catch (error) {
+			this.#state.loadError = error instanceof Error ? error.message : String(error);
+		} finally {
+			this.#state.loading = false;
+			this.#rebuildAndRender();
+		}
+	}
+
+	async #toggleEnabled(): Promise<void> {
+		const plugin = this.#selectedPlugin();
+		if (!plugin?.installed) return;
+
+		try {
+			if (plugin.source === "marketplace") {
+				await this.#mgr.setPluginEnabled(plugin.id, !plugin.enabled, plugin.scope);
+			}
+			plugin.enabled = !plugin.enabled;
+			this.#state.notice = `${plugin.enabled ? "Enabled" : "Disabled"} ${plugin.name}`;
+		} catch (error) {
+			this.#state.notice = `Toggle failed: ${error instanceof Error ? error.message : String(error)}`;
+		}
+		this.#rebuildAndRender();
+	}
+
+	async #handleEnterAction(): Promise<void> {
+		const plugin = this.#selectedPlugin();
+		if (!plugin) return;
+		const tabId = this.#activeTabId();
+
+		if (tabId === "available" && !plugin.installed) {
+			await this.#installPlugin(plugin);
+		} else if (tabId === "updates" && plugin.hasUpdate) {
+			await this.#upgradePlugin(plugin);
+		} else if (tabId === "installed" && plugin.installed && plugin.source === "marketplace") {
+			await this.#uninstallPlugin(plugin);
+		}
+	}
+
+	async #installPlugin(plugin: DashboardPlugin): Promise<void> {
+		if (!plugin.marketplace) return;
+		this.#state.notice = `Installing ${plugin.name}...`;
+		this.#rebuildAndRender();
+
+		try {
+			await this.#mgr.installPlugin(plugin.name, plugin.marketplace);
+			this.#state.notice = `Installed ${plugin.name}`;
+			await this.#reloadData();
+		} catch (error) {
+			this.#state.notice = `Install failed: ${error instanceof Error ? error.message : String(error)}`;
+			this.#rebuildAndRender();
+		}
+	}
+
+	async #uninstallPlugin(plugin: DashboardPlugin): Promise<void> {
+		this.#state.notice = `Uninstalling ${plugin.name}...`;
+		this.#rebuildAndRender();
+
+		try {
+			await this.#mgr.uninstallPlugin(plugin.id, plugin.scope);
+			this.#state.notice = `Uninstalled ${plugin.name}`;
+			await this.#reloadData();
+		} catch (error) {
+			this.#state.notice = `Uninstall failed: ${error instanceof Error ? error.message : String(error)}`;
+			this.#rebuildAndRender();
+		}
+	}
+
+	async #upgradePlugin(plugin: DashboardPlugin): Promise<void> {
+		this.#state.notice = `Upgrading ${plugin.name}...`;
+		this.#rebuildAndRender();
+
+		try {
+			await this.#mgr.upgradePlugin(plugin.id, plugin.scope);
+			this.#state.notice = `Upgraded ${plugin.name}`;
+			await this.#reloadData();
+		} catch (error) {
+			this.#state.notice = `Upgrade failed: ${error instanceof Error ? error.message : String(error)}`;
+			this.#rebuildAndRender();
+		}
+	}
+
+	#renderTabBar(): string {
+		const parts: string[] = [" "];
+		for (let i = 0; i < this.#state.tabs.length; i++) {
+			const tab = this.#state.tabs[i];
+			const label = `${tab.label} (${tab.count})`;
+			if (i === this.#state.activeTabIndex) {
+				parts.push(theme.bg("selectedBg", ` ${label} `));
+			} else {
+				parts.push(theme.fg("muted", ` ${label} `));
+			}
+		}
+		return parts.join("");
+	}
+
+	#getHelpText(): string {
+		const tabId = this.#activeTabId();
+		switch (tabId) {
+			case "available":
+				return " ↑/↓: navigate  Enter: install  Tab: next tab  Ctrl+R: reload  Esc: close";
+			case "updates":
+				return " ↑/↓: navigate  Enter: upgrade  Tab: next tab  Ctrl+R: reload  Esc: close";
+			default:
+				return " ↑/↓: navigate  Space: toggle  Enter: uninstall  U: upgrade  Tab: next tab  Ctrl+R: reload  Esc: close";
+		}
+	}
+
+	#rebuildAndRender(): void {
+		this.#buildLayout();
+		this.onRequestRender?.();
+	}
+
+	#buildLayout(): void {
+		this.clear();
+		this.addChild(new DynamicBorder());
+		this.addChild(new Text(theme.bold(theme.fg("contentAccent", " Plugin Control Center")), 0, 0));
+		this.addChild(new Text(this.#renderTabBar(), 0, 0));
+		this.addChild(new Spacer(1));
+
+		if (this.#state.notice) {
+			this.addChild(new Text(theme.fg("success", replaceTabs(this.#state.notice)), 0, 0));
+			this.addChild(new Spacer(1));
+		}
+
+		if (this.#state.loading) {
+			this.addChild(new Text(theme.fg("muted", "Loading plugins..."), 0, 0));
+			this.addChild(new Spacer(1));
+		} else if (this.#state.loadError) {
+			this.addChild(
+				new Text(theme.fg("error", `Failed to load plugins: ${replaceTabs(this.#state.loadError)}`), 0, 0),
+			);
+			this.addChild(new Spacer(1));
+		} else {
+			const selected = this.#selectedPlugin();
+			const listPane = new PluginListPane(
+				this.#state.searchFiltered,
+				this.#state.selectedIndex,
+				this.#state.scrollOffset,
+				this.#state.searchQuery,
+				this.#getMaxVisibleItems(),
+				this.#activeTabId(),
+			);
+			const inspector = new PluginInspectorPane(selected);
+			const bodyHeight = Math.max(5, this.terminalHeight - 8);
+			this.addChild(new TwoColumnBody(listPane, inspector, bodyHeight));
+			this.addChild(new Spacer(1));
+			this.addChild(new Text(theme.fg("dim", this.#getHelpText()), 0, 0));
+		}
+
+		this.addChild(new DynamicBorder());
+	}
+
+	handleInput(data: string): void {
+		if (matchesKey(data, "ctrl+c")) {
+			this.onClose?.();
+			return;
+		}
+
+		if (matchesAppInterrupt(data)) {
+			if (this.#state.searchQuery) {
+				this.#state.searchQuery = "";
+				this.#applyFilters();
+				this.#buildLayout();
+			} else {
+				this.onClose?.();
+			}
+			return;
+		}
+
+		if (matchesKey(data, "tab")) {
+			this.#switchTab(1);
+			return;
+		}
+
+		if (matchesKey(data, "shift+tab")) {
+			this.#switchTab(-1);
+			return;
+		}
+
+		if (matchesKey(data, "up") || data === "k") {
+			this.#moveSelection(-1);
+			return;
+		}
+
+		if (matchesKey(data, "down") || data === "j") {
+			this.#moveSelection(1);
+			return;
+		}
+
+		if (matchesKey(data, "space")) {
+			void this.#toggleEnabled();
+			return;
+		}
+
+		if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
+			void this.#handleEnterAction();
+			return;
+		}
+
+		if (data.toLowerCase() === "u") {
+			const plugin = this.#selectedPlugin();
+			if (plugin?.hasUpdate) {
+				void this.#upgradePlugin(plugin);
+			}
+			return;
+		}
+
+		if (matchesKey(data, "ctrl+r")) {
+			void this.#reloadData();
+			return;
+		}
+
+		if (matchesKey(data, "backspace") || matchesKey(data, "delete") || data === "\x7f") {
+			if (this.#state.searchQuery.length > 0) {
+				this.#state.searchQuery = this.#state.searchQuery.slice(0, -1);
+				this.#state.notice = null;
+				this.#applyFilters();
+				this.#buildLayout();
+			}
+			return;
+		}
+
+		if (data.length === 1 && data >= " " && data <= "~" && data !== "j" && data !== "k" && data !== "u") {
+			this.#state.searchQuery += data;
+			this.#state.notice = null;
+			this.#applyFilters();
+			this.#buildLayout();
+			return;
+		}
+	}
+}

--- a/packages/coding-agent/src/modes/components/plugins/plugin-inspector-pane.ts
+++ b/packages/coding-agent/src/modes/components/plugins/plugin-inspector-pane.ts
@@ -1,0 +1,84 @@
+import type { Component } from "@f5xc-salesdemos/pi-tui";
+import { replaceTabs, truncateToWidth, wrapTextWithAnsi } from "@f5xc-salesdemos/pi-tui";
+import { theme } from "../../theme/theme";
+import type { DashboardPlugin } from "./types";
+
+export class PluginInspectorPane implements Component {
+	constructor(private readonly plugin: DashboardPlugin | null) {}
+
+	render(width: number): string[] {
+		if (!this.plugin) {
+			return [theme.fg("muted", "Select a plugin"), theme.fg("dim", "to view details")];
+		}
+
+		const lines: string[] = [];
+		const p = this.plugin;
+
+		lines.push(theme.bold(theme.fg("contentAccent", replaceTabs(p.name))));
+		lines.push("");
+
+		lines.push(`${theme.fg("muted", "Source:")} ${p.source}`);
+
+		if (p.marketplace) {
+			lines.push(`${theme.fg("muted", "Marketplace:")} ${replaceTabs(p.marketplace)}`);
+		}
+
+		if (p.installed) {
+			const statusIcon = p.enabled
+				? theme.fg("success", `${theme.status.enabled} Enabled`)
+				: theme.fg("dim", `${theme.status.disabled} Disabled`);
+			lines.push(`${theme.fg("muted", "Status:")} ${statusIcon}`);
+		} else {
+			lines.push(`${theme.fg("muted", "Status:")} ${theme.fg("dim", "Not installed")}`);
+		}
+
+		if (p.scope) {
+			lines.push(`${theme.fg("muted", "Scope:")} ${p.scope}`);
+		}
+
+		if (p.version) {
+			lines.push(`${theme.fg("muted", "Version:")} ${p.version}`);
+		}
+
+		if (p.hasUpdate && p.updateVersion) {
+			lines.push(`${theme.fg("muted", "Update:")} ${theme.fg("warning", `v${p.updateVersion} available`)}`);
+		}
+
+		if (p.shadowedBy) {
+			lines.push(`${theme.fg("muted", "Shadowed:")} ${theme.fg("warning", `by ${p.shadowedBy} scope`)}`);
+		}
+
+		if (p.description) {
+			lines.push("");
+			lines.push(theme.fg("muted", "Description:"));
+			for (const wrapped of wrapTextWithAnsi(replaceTabs(p.description), Math.max(10, width - 2))) {
+				lines.push(truncateToWidth(`  ${wrapped}`, width));
+			}
+		}
+
+		if (p.author) {
+			lines.push("");
+			lines.push(`${theme.fg("muted", "Author:")} ${replaceTabs(p.author)}`);
+		}
+
+		if (p.license) {
+			lines.push(`${theme.fg("muted", "License:")} ${replaceTabs(p.license)}`);
+		}
+
+		if (p.homepage) {
+			lines.push(`${theme.fg("muted", "Homepage:")} ${replaceTabs(p.homepage)}`);
+		}
+
+		if (p.category) {
+			lines.push(`${theme.fg("muted", "Category:")} ${replaceTabs(p.category)}`);
+		}
+
+		if (p.tags && p.tags.length > 0) {
+			lines.push(`${theme.fg("muted", "Tags:")} ${p.tags.map(t => replaceTabs(t)).join(", ")}`);
+		}
+
+		return lines;
+	}
+
+	invalidate(): void {}
+}

--- a/packages/coding-agent/src/modes/components/plugins/plugin-list-pane.ts
+++ b/packages/coding-agent/src/modes/components/plugins/plugin-list-pane.ts
@@ -1,0 +1,104 @@
+import type { Component } from "@f5xc-salesdemos/pi-tui";
+import { truncateToWidth } from "@f5xc-salesdemos/pi-tui";
+import { theme } from "../../theme/theme";
+import type { DashboardPlugin, PluginTabId } from "./types";
+
+export class PluginListPane implements Component {
+	constructor(
+		private readonly plugins: DashboardPlugin[],
+		private readonly selectedIndex: number,
+		private readonly scrollOffset: number,
+		private readonly searchQuery: string,
+		private readonly maxVisible: number,
+		private readonly activeTab: PluginTabId,
+	) {}
+
+	render(width: number): string[] {
+		const lines: string[] = [];
+		const searchPrefix = theme.fg("muted", "Search: ");
+		const searchText = this.searchQuery || theme.fg("dim", "type to filter");
+		lines.push(`${searchPrefix}${searchText}`);
+		lines.push("");
+
+		if (this.plugins.length === 0) {
+			const msg =
+				this.activeTab === "available"
+					? "No plugins available. Add a marketplace first."
+					: this.activeTab === "updates"
+						? "All plugins are up to date."
+						: "No plugins installed.";
+			lines.push(theme.fg("muted", `  ${msg}`));
+			return lines;
+		}
+
+		const start = this.scrollOffset;
+		const end = Math.min(start + this.maxVisible, this.plugins.length);
+
+		for (let i = start; i < end; i++) {
+			const plugin = this.plugins[i];
+			const selected = i === this.selectedIndex;
+			let line = this.#formatPluginLine(plugin);
+
+			if (selected) {
+				line = theme.bg("selectedBg", theme.bold(theme.fg("chromeAccent", line)));
+			} else if (!plugin.enabled && plugin.installed) {
+				line = theme.fg("dim", line);
+			}
+
+			lines.push(truncateToWidth(line, width));
+		}
+
+		if (this.plugins.length > this.maxVisible) {
+			lines.push(theme.fg("muted", `  (${this.selectedIndex + 1}/${this.plugins.length})`));
+		}
+
+		return lines;
+	}
+
+	#formatPluginLine(plugin: DashboardPlugin): string {
+		const parts: string[] = [" "];
+
+		if (plugin.installed) {
+			if (plugin.hasUpdate) {
+				parts.push(theme.fg("warning", "▲"));
+			} else if (plugin.enabled) {
+				parts.push(theme.fg("success", theme.status.enabled));
+			} else {
+				parts.push(theme.fg("dim", theme.status.disabled));
+			}
+		} else {
+			parts.push(theme.fg("dim", "·"));
+		}
+
+		parts.push(" ");
+		parts.push(plugin.name);
+
+		if (plugin.version) {
+			parts.push(theme.fg("dim", ` v${plugin.version}`));
+		}
+
+		if (plugin.hasUpdate && plugin.updateVersion) {
+			parts.push(theme.fg("warning", ` → v${plugin.updateVersion}`));
+		}
+
+		if (plugin.scope) {
+			parts.push(theme.fg("muted", ` [${plugin.scope}]`));
+		}
+
+		if (plugin.shadowedBy) {
+			parts.push(theme.fg("dim", " [shadowed]"));
+		}
+
+		if (plugin.installed && !plugin.enabled) {
+			parts.push(theme.fg("dim", " (disabled)"));
+		}
+
+		if (plugin.source === "npm") {
+			parts.push(theme.fg("dim", " (npm)"));
+		}
+
+		return parts.join("");
+	}
+
+	invalidate(): void {}
+}

--- a/packages/coding-agent/src/modes/components/plugins/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/plugins/state-manager.ts
@@ -1,0 +1,211 @@
+import type { PluginManager } from "../../../extensibility/plugins/manager";
+import type { MarketplaceManager } from "../../../extensibility/plugins/marketplace";
+import type { InstalledPluginSummary, MarketplacePluginEntry } from "../../../extensibility/plugins/marketplace/types";
+import type { DashboardPlugin, PluginDashboardState, PluginTab, PluginTabId } from "./types";
+
+function npmToDashboard(npm: { name: string; version: string; enabled: boolean }): DashboardPlugin {
+	return {
+		id: `npm:${npm.name}`,
+		name: npm.name,
+		source: "npm",
+		version: npm.version,
+		installed: true,
+		enabled: npm.enabled !== false,
+		hasUpdate: false,
+	};
+}
+
+function installedToDashboard(summary: InstalledPluginSummary, updateMap: Map<string, string>): DashboardPlugin {
+	const entry = summary.entries[0];
+	const atIdx = summary.id.lastIndexOf("@");
+	const name = atIdx > 0 ? summary.id.slice(0, atIdx) : summary.id;
+	const marketplace = atIdx > 0 ? summary.id.slice(atIdx + 1) : undefined;
+	const updateVersion = updateMap.get(`${summary.id}:${summary.scope}`);
+
+	return {
+		id: summary.id,
+		name,
+		marketplace,
+		source: "marketplace",
+		scope: summary.scope,
+		version: entry?.version,
+		installed: true,
+		enabled: entry?.enabled !== false,
+		shadowedBy: summary.shadowedBy,
+		hasUpdate: !!updateVersion,
+		updateVersion,
+	};
+}
+
+function catalogToDashboard(entry: MarketplacePluginEntry, marketplace: string): DashboardPlugin {
+	return {
+		id: `${entry.name}@${marketplace}`,
+		name: entry.name,
+		marketplace,
+		source: "marketplace",
+		version: entry.version,
+		catalogVersion: entry.version,
+		description: entry.description,
+		category: entry.category,
+		tags: entry.tags,
+		author: entry.author?.name,
+		homepage: entry.homepage,
+		license: entry.license,
+		installed: false,
+		enabled: false,
+		hasUpdate: false,
+	};
+}
+
+export async function loadAllPlugins(mgr: MarketplaceManager, npmMgr: PluginManager): Promise<DashboardPlugin[]> {
+	const [npmPlugins, installedSummaries, updates] = await Promise.all([
+		npmMgr.list().catch(() => []),
+		mgr.listInstalledPlugins().catch(() => []),
+		mgr.checkForUpdates().catch(() => []),
+	]);
+
+	const updateMap = new Map<string, string>();
+	for (const u of updates) {
+		updateMap.set(`${u.pluginId}:${u.scope}`, u.to);
+	}
+
+	const plugins: DashboardPlugin[] = [];
+
+	for (const p of npmPlugins) {
+		plugins.push(npmToDashboard(p));
+	}
+
+	const installedIds = new Set<string>();
+	for (const s of installedSummaries) {
+		installedIds.add(s.id);
+		plugins.push(installedToDashboard(s, updateMap));
+	}
+
+	const marketplaces = await mgr.listMarketplaces().catch(() => []);
+	for (const mkt of marketplaces) {
+		const available = await mgr.listAvailablePlugins(mkt.name).catch(() => []);
+		for (const entry of available) {
+			const pluginId = `${entry.name}@${mkt.name}`;
+			if (installedIds.has(pluginId)) {
+				const existing = plugins.find(p => p.id === pluginId);
+				if (existing) {
+					existing.description = existing.description || entry.description;
+					existing.category = existing.category || entry.category;
+					existing.tags = existing.tags || entry.tags;
+					existing.author = existing.author || entry.author?.name;
+					existing.homepage = existing.homepage || entry.homepage;
+					existing.license = existing.license || entry.license;
+					existing.catalogVersion = entry.version;
+				}
+				continue;
+			}
+			plugins.push(catalogToDashboard(entry, mkt.name));
+		}
+	}
+
+	plugins.sort((a, b) => {
+		if (a.installed !== b.installed) return a.installed ? -1 : 1;
+		if (a.installed && b.installed) {
+			if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
+		}
+		return a.name.localeCompare(b.name);
+	});
+
+	return plugins;
+}
+
+export function buildTabs(plugins: DashboardPlugin[]): PluginTab[] {
+	const tabs: PluginTab[] = [];
+	const installedCount = plugins.filter(p => p.installed).length;
+	const availableCount = plugins.filter(p => !p.installed).length;
+	const updatesCount = plugins.filter(p => p.hasUpdate).length;
+
+	tabs.push({ id: "installed", label: "Installed", count: installedCount });
+	if (availableCount > 0) {
+		tabs.push({ id: "available", label: "Available", count: availableCount });
+	}
+	if (updatesCount > 0) {
+		tabs.push({ id: "updates", label: "Updates", count: updatesCount });
+	}
+	return tabs;
+}
+
+export function filterByTab(plugins: DashboardPlugin[], tabId: PluginTabId): DashboardPlugin[] {
+	switch (tabId) {
+		case "installed":
+			return plugins.filter(p => p.installed);
+		case "available":
+			return plugins.filter(p => !p.installed);
+		case "updates":
+			return plugins.filter(p => p.hasUpdate);
+		default:
+			return plugins;
+	}
+}
+
+export function applySearch(plugins: DashboardPlugin[], query: string): DashboardPlugin[] {
+	if (!query) return plugins;
+	const q = query.toLowerCase();
+	return plugins.filter(p => {
+		if (p.name.toLowerCase().includes(q)) return true;
+		if (p.description?.toLowerCase().includes(q)) return true;
+		if (p.marketplace?.toLowerCase().includes(q)) return true;
+		if (p.category?.toLowerCase().includes(q)) return true;
+		if (p.tags?.some(t => t.toLowerCase().includes(q))) return true;
+		if (p.author?.toLowerCase().includes(q)) return true;
+		return false;
+	});
+}
+
+export async function createInitialState(
+	mgr: MarketplaceManager,
+	npmMgr: PluginManager,
+): Promise<PluginDashboardState> {
+	const allPlugins = await loadAllPlugins(mgr, npmMgr);
+	const tabs = buildTabs(allPlugins);
+	const activeTab = tabs[0] ?? { id: "installed" as const, label: "Installed", count: 0 };
+	const tabFiltered = filterByTab(allPlugins, activeTab.id);
+
+	return {
+		tabs,
+		activeTabIndex: 0,
+		allPlugins,
+		tabFiltered,
+		searchFiltered: tabFiltered,
+		searchQuery: "",
+		selectedIndex: 0,
+		scrollOffset: 0,
+		notice: null,
+		loading: false,
+		loadError: null,
+	};
+}
+
+export async function refreshState(
+	state: PluginDashboardState,
+	mgr: MarketplaceManager,
+	npmMgr: PluginManager,
+): Promise<PluginDashboardState> {
+	const allPlugins = await loadAllPlugins(mgr, npmMgr);
+	const tabs = buildTabs(allPlugins);
+	const prevTabId = state.tabs[state.activeTabIndex]?.id ?? "installed";
+	const nextTabIndex = Math.max(
+		0,
+		tabs.findIndex(t => t.id === prevTabId),
+	);
+	const activeTab = tabs[nextTabIndex] ?? tabs[0];
+	const tabFiltered = filterByTab(allPlugins, activeTab?.id ?? "installed");
+	const searchFiltered = applySearch(tabFiltered, state.searchQuery);
+
+	return {
+		...state,
+		tabs,
+		activeTabIndex: nextTabIndex,
+		allPlugins,
+		tabFiltered,
+		searchFiltered,
+		notice: state.notice,
+		loading: false,
+		loadError: null,
+	};
+}

--- a/packages/coding-agent/src/modes/components/plugins/types.ts
+++ b/packages/coding-agent/src/modes/components/plugins/types.ts
@@ -1,0 +1,42 @@
+export interface DashboardPlugin {
+	id: string;
+	name: string;
+	marketplace?: string;
+	source: "npm" | "marketplace";
+	scope?: "user" | "project";
+	version?: string;
+	catalogVersion?: string;
+	description?: string;
+	category?: string;
+	tags?: string[];
+	author?: string;
+	homepage?: string;
+	license?: string;
+	installed: boolean;
+	enabled: boolean;
+	shadowedBy?: "project";
+	hasUpdate: boolean;
+	updateVersion?: string;
+}
+
+export type PluginTabId = "installed" | "available" | "updates";
+
+export interface PluginTab {
+	id: PluginTabId;
+	label: string;
+	count: number;
+}
+
+export interface PluginDashboardState {
+	tabs: PluginTab[];
+	activeTabIndex: number;
+	allPlugins: DashboardPlugin[];
+	tabFiltered: DashboardPlugin[];
+	searchFiltered: DashboardPlugin[];
+	searchQuery: string;
+	selectedIndex: number;
+	scrollOffset: number;
+	notice: string | null;
+	loading: boolean;
+	loadError: string | null;
+}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -49,6 +49,7 @@ import { HistorySearchComponent } from "../components/history-search";
 import { ModelSelectorComponent } from "../components/model-selector";
 import { OAuthSelectorComponent } from "../components/oauth-selector";
 import { PluginSelectorComponent } from "../components/plugin-selector";
+import { PluginDashboard } from "../components/plugins";
 import { SessionObserverOverlayComponent } from "../components/session-observer-overlay";
 import { SessionSelectorComponent } from "../components/session-selector";
 import { SettingsSelectorComponent } from "../components/settings-selector";
@@ -208,6 +209,20 @@ export class SelectorController {
 			activeModelPattern,
 			defaultModelPattern,
 		});
+		this.showSelector(done => {
+			dashboard.onClose = () => {
+				done();
+				this.ctx.ui.requestRender();
+			};
+			dashboard.onRequestRender = () => {
+				this.ctx.ui.requestRender();
+			};
+			return { component: dashboard, focus: dashboard };
+		});
+	}
+
+	async showPluginDashboard(): Promise<void> {
+		const dashboard = await PluginDashboard.create(getProjectDir(), this.ctx.ui.terminal.rows);
 		this.showSelector(done => {
 			dashboard.onClose = () => {
 				done();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1515,6 +1515,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		void this.#selectorController.showPluginSelector(mode);
 	}
 
+	showPluginDashboard(): void {
+		void this.#selectorController.showPluginDashboard();
+	}
+
 	showUserMessageSelector(): void {
 		this.#selectorController.showUserMessageSelector();
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -202,6 +202,7 @@ export interface InteractiveModeContext {
 	showAgentsDashboard(): void;
 	showModelSelector(options?: { temporaryOnly?: boolean }): void;
 	showPluginSelector(mode?: "install" | "uninstall"): void;
+	showPluginDashboard(): void;
 	showUserMessageSelector(): void;
 	showTreeSelector(): void;
 	showSessionSelector(): void;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1082,8 +1082,14 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 		handle: async (command, runtime) => {
 			runtime.ctx.editor.setText("");
 			const args = command.args.trim().split(/\s+/);
-			const sub = args[0] || "list";
+			const sub = args[0] || "";
 			const rest = args.slice(1).join(" ").trim();
+
+			// No args or bare "list" with no further args → open interactive dashboard
+			if (!sub || (sub === "list" && !rest)) {
+				runtime.ctx.showPluginDashboard();
+				return;
+			}
 
 			try {
 				const mgr = new MarketplaceManager({
@@ -1118,7 +1124,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 						runtime.ctx.showStatus(`${isEnable ? "Enabled" : "Disabled"} ${parsed.pluginId}`);
 						break;
 					}
-					default: {
+					case "list": {
 						const lines: string[] = [];
 
 						const npm = new PluginManager();
@@ -1148,6 +1154,16 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 						} else {
 							runtime.ctx.showStatus(lines.join("\n"));
 						}
+						break;
+					}
+					default: {
+						runtime.ctx.showStatus(
+							"Usage: /plugins [list|enable|disable]\n\n" +
+								"  /plugins              Open plugin dashboard\n" +
+								"  /plugins list <query> List plugins matching query\n" +
+								"  /plugins enable <id>  Enable a plugin\n" +
+								"  /plugins disable <id> Disable a plugin",
+						);
 						break;
 					}
 				}


### PR DESCRIPTION
Closes #1102

## Summary
- Replace plain-text `/plugins` output with a full tabbed 2-column dashboard following the ExtensionDashboard/AgentDashboard pattern
- Features Installed/Available/Updates tabs, keyboard navigation, search filtering, and auto-registration of the default marketplace on first run
- Fix pre-existing type errors: update ajv from ~8.18 to ^8.20 across all packages to resolve type mismatch with ajv-formats, and fix branding-index generator to emit bare `null` instead of invalid `undefined as const`

## Test plan
- [ ] Run `/plugins` — verify the TUI dashboard renders with Installed/Available/Updates tabs
- [ ] Test keyboard navigation (Tab/arrow keys/Enter) between tabs and plugin list
- [ ] Test search filtering within plugin list
- [ ] Run `bun run ci:check:full` — verify zero type errors
- [ ] Run `biome check .` — verify no new lint errors