### PR TITLE
refactor(coding-agent): complete xcsh naming cleanup, remove all Claude Code references

### DIFF
--- a/docs/extensions/marketplace.md
+++ b/docs/extensions/marketplace.md
@@ -13,17 +13,17 @@ The marketplace system lets you discover, install, and manage plugins from Git-h
 ## Quick start
 
 ```
-/marketplace add anthropics/claude-plugins-official
-/marketplace install wordpress.com@claude-plugins-official
+/marketplace add anthropics/f5xc-salesdemos-marketplace
+/marketplace install wordpress.com@f5xc-salesdemos-marketplace
 ```
 
 Or just type `/marketplace` with no arguments to open the interactive plugin browser.
 
 ## Concepts
 
-A **marketplace** is a Git repository (or local directory) containing a catalog file at `.claude-plugin/marketplace.json`. The catalog lists available plugins with their sources, descriptions, and metadata.
+A **marketplace** is a Git repository (or local directory) containing a catalog file at `.xcsh-plugin/marketplace.json`. The catalog lists available plugins with their sources, descriptions, and metadata.
 
-A **plugin** is a directory containing skills, commands, hooks, MCP servers, or LSP servers. Plugins are identified by `name@marketplace` (e.g. `code-review@claude-plugins-official`).
+A **plugin** is a directory containing skills, commands, hooks, MCP servers, or LSP servers. Plugins are identified by `name@marketplace` (e.g. `code-review@f5xc-salesdemos-marketplace`).
 
 **Scopes**: plugins can be installed at two scopes:
 
@@ -78,16 +78,16 @@ When you run `/marketplace add <source>`, the system classifies the source:
 
 | Source format | Type | Example |
 |---|---|---|
-| `owner/repo` | GitHub shorthand | `anthropics/claude-plugins-official` |
+| `owner/repo` | GitHub shorthand | `anthropics/f5xc-salesdemos-marketplace` |
 | `https://...*.json` | Direct catalog URL | `https://example.com/marketplace.json` |
 | `https://...*.git` or `git@...` | Git repository | `https://github.com/org/repo.git` |
 | `./path` or `~/path` or `/path` | Local directory | `./my-marketplace` |
 
-The system clones the repository (or reads the local directory), locates `.claude-plugin/marketplace.json`, validates it, and caches the catalog locally.
+The system clones the repository (or reads the local directory), locates `.xcsh-plugin/marketplace.json`, validates it, and caches the catalog locally.
 
 ## Catalog format (marketplace.json)
 
-A marketplace catalog lives at `.claude-plugin/marketplace.json` in the repository root:
+A marketplace catalog lives at `.xcsh-plugin/marketplace.json` in the repository root:
 
 ```json
 {

--- a/packages/coding-agent/examples/extensions/plan-mode.ts
+++ b/packages/coding-agent/examples/extensions/plan-mode.ts
@@ -1,7 +1,7 @@
 /**
  * Plan Mode Extension
  *
- * Provides a Claude Code-style "plan mode" for safe code exploration.
+ * Provides a xcsh-style "plan mode" for safe code exploration.
  * When enabled, the agent can only use read-only tools and cannot modify files.
  *
  * Features:

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -31,10 +31,10 @@ export interface LoadResult<T> {
  * A provider that can load items for a capability.
  */
 export interface Provider<T> {
-	/** Unique provider ID (e.g., "claude", "xcsh", "mcp-json", "agents-md") */
+	/** Unique provider ID (e.g., "xcsh", "mcp-json", "agents-md") */
 	id: string;
 
-	/** Human-readable name for UI display (e.g., "Claude Code", "OpenAI Codex") */
+	/** Human-readable name for UI display (e.g., "xcsh", "OpenAI Codex") */
 	displayName: string;
 
 	/** Short description for settings UI (e.g., "Load config from ~/.xcsh/ and .xcsh/") */

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -227,8 +227,8 @@ export const SETTINGS_SCHEMA = {
 	disabledProviders: {
 		type: "array",
 		default: [
-			"claude",
-			"claude-plugins",
+			"xcsh",
+			"xcsh-plugins",
 			"codex",
 			"agents",
 			"agents-md",
@@ -1639,32 +1639,32 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
-	"skills.enableClaudeUser": {
+	"skills.enableXcshUser": {
 		type: "boolean",
 		default: false,
 		ui: {
 			tab: "tasks",
-			label: "Claude User Skills",
-			description: "Load skills from ~/.xcsh/agent/skills/ (legacy Claude Code compatibility)",
+			label: "xcsh User Skills",
+			description: "Load skills from ~/.xcsh/agent/skills/",
 		},
 	},
 
-	"skills.enableClaudeProject": {
+	"skills.enableXcshProject": {
 		type: "boolean",
 		default: false,
 		ui: {
 			tab: "tasks",
-			label: "Claude Project Skills",
-			description: "Load skills from .xcsh/skills/ (legacy Claude Code compatibility)",
+			label: "xcsh Project Skills",
+			description: "Load skills from .xcsh/skills/",
 		},
 	},
 
-	"skills.enableClaudePlugins": {
+	"skills.enableXcshPlugins": {
 		type: "boolean",
 		default: false,
 		ui: {
 			tab: "tasks",
-			label: "Claude Marketplace Skills",
+			label: "xcsh Marketplace Skills",
 			description: "Load skills from marketplace plugins (~/.xcsh/plugins/cache/)",
 		},
 	},
@@ -1696,16 +1696,16 @@ export const SETTINGS_SCHEMA = {
 	"skills.includeSkills": { type: "array", default: [] as string[] },
 
 	// Commands
-	"commands.enableClaudeUser": {
+	"commands.enableXcshUser": {
 		type: "boolean",
 		default: true,
-		ui: { tab: "tasks", label: "Claude User Commands", description: "Load commands from ~/.xcsh/agent/commands/" },
+		ui: { tab: "tasks", label: "xcsh User Commands", description: "Load commands from ~/.xcsh/agent/commands/" },
 	},
 
-	"commands.enableClaudeProject": {
+	"commands.enableXcshProject": {
 		type: "boolean",
 		default: true,
-		ui: { tab: "tasks", label: "Claude Project Commands", description: "Load commands from .xcsh/commands/" },
+		ui: { tab: "tasks", label: "xcsh Project Commands", description: "Load commands from .xcsh/commands/" },
 	},
 
 	// ────────────────────────────────────────────────────────────────────────
@@ -2011,9 +2011,9 @@ export interface SkillsSettings {
 	enabled?: boolean;
 	enableSkillCommands?: boolean;
 	enableCodexUser?: boolean;
-	enableClaudeUser?: boolean;
-	enableClaudeProject?: boolean;
-	enableClaudePlugins?: boolean;
+	enableXcshUser?: boolean;
+	enableXcshProject?: boolean;
+	enableXcshPlugins?: boolean;
 	enablePiUser?: boolean;
 	enablePiProject?: boolean;
 	customDirectories?: string[];

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -1,5 +1,5 @@
 /**
- * Claude Code Marketplace Plugin Provider
+ * xcsh Marketplace Plugin Provider
  *
  * Loads configuration from ~/.xcsh/plugins/cache/ based on installed_plugins.json registry.
  * Priority: 70 (below claude.ts at 80, so user overrides in .xcsh/ take precedence)
@@ -15,17 +15,17 @@ import { type SlashCommand, slashCommandCapability } from "../capability/slash-c
 import { type CustomTool, toolCapability } from "../capability/tool";
 import type { LoadContext, LoadResult } from "../capability/types";
 import {
-	type ClaudePluginRoot,
 	createSourceMeta,
-	listClaudePluginRoots,
+	listXcshPluginRoots,
 	loadFilesFromDir,
 	scanSkillsFromDir,
+	type XcshPluginRoot,
 } from "./helpers";
 
 import { substitutePluginRoot } from "./substitute-plugin-root";
 
-const PROVIDER_ID = "claude-plugins";
-const DISPLAY_NAME = "Claude Code Marketplace";
+const PROVIDER_ID = "xcsh-plugins";
+const DISPLAY_NAME = "xcsh Marketplace";
 const PRIORITY = 70; // Below claude.ts (80) so user .xcsh/ overrides win
 
 // =============================================================================
@@ -36,7 +36,7 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 	const items: Skill[] = [];
 	const warnings: string[] = [];
 
-	const { roots, warnings: rootWarnings } = await listClaudePluginRoots(ctx.home, ctx.cwd);
+	const { roots, warnings: rootWarnings } = await listXcshPluginRoots(ctx.home, ctx.cwd);
 	warnings.push(...rootWarnings);
 
 	const results = await Promise.all(
@@ -70,7 +70,7 @@ async function loadSlashCommands(ctx: LoadContext): Promise<LoadResult<SlashComm
 	const items: SlashCommand[] = [];
 	const warnings: string[] = [];
 
-	const { roots, warnings: rootWarnings } = await listClaudePluginRoots(ctx.home, ctx.cwd);
+	const { roots, warnings: rootWarnings } = await listXcshPluginRoots(ctx.home, ctx.cwd);
 	warnings.push(...rootWarnings);
 
 	const results = await Promise.all(
@@ -108,12 +108,12 @@ async function loadHooks(ctx: LoadContext): Promise<LoadResult<Hook>> {
 	const items: Hook[] = [];
 	const warnings: string[] = [];
 
-	const { roots, warnings: rootWarnings } = await listClaudePluginRoots(ctx.home, ctx.cwd);
+	const { roots, warnings: rootWarnings } = await listXcshPluginRoots(ctx.home, ctx.cwd);
 	warnings.push(...rootWarnings);
 
 	const hookTypes = ["pre", "post"] as const;
 
-	const loadTasks: { root: ClaudePluginRoot; hookType: "pre" | "post" }[] = [];
+	const loadTasks: { root: XcshPluginRoot; hookType: "pre" | "post" }[] = [];
 	for (const root of roots) {
 		for (const hookType of hookTypes) {
 			loadTasks.push({ root, hookType });
@@ -155,7 +155,7 @@ async function loadTools(ctx: LoadContext): Promise<LoadResult<CustomTool>> {
 	const items: CustomTool[] = [];
 	const warnings: string[] = [];
 
-	const { roots, warnings: rootWarnings } = await listClaudePluginRoots(ctx.home, ctx.cwd);
+	const { roots, warnings: rootWarnings } = await listXcshPluginRoots(ctx.home, ctx.cwd);
 	warnings.push(...rootWarnings);
 
 	const results = await Promise.all(
@@ -192,7 +192,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 	const items: MCPServer[] = [];
 	const warnings: string[] = [];
 
-	const { roots, warnings: rootWarnings } = await listClaudePluginRoots(ctx.home, ctx.cwd);
+	const { roots, warnings: rootWarnings } = await listXcshPluginRoots(ctx.home, ctx.cwd);
 	warnings.push(...rootWarnings);
 
 	for (const root of roots) {
@@ -258,7 +258,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 registerProvider<Skill>(skillCapability.id, {
 	id: PROVIDER_ID,
 	displayName: DISPLAY_NAME,
-	description: "Load skills from Claude Code marketplace plugins (~/.xcsh/plugins/cache/)",
+	description: "Load skills from xcsh marketplace plugins (~/.xcsh/plugins/cache/)",
 	priority: PRIORITY,
 	load: loadSkills,
 });
@@ -266,7 +266,7 @@ registerProvider<Skill>(skillCapability.id, {
 registerProvider<SlashCommand>(slashCommandCapability.id, {
 	id: PROVIDER_ID,
 	displayName: DISPLAY_NAME,
-	description: "Load slash commands from Claude Code marketplace plugins",
+	description: "Load slash commands from xcsh marketplace plugins",
 	priority: PRIORITY,
 	load: loadSlashCommands,
 });
@@ -274,7 +274,7 @@ registerProvider<SlashCommand>(slashCommandCapability.id, {
 registerProvider<Hook>(hookCapability.id, {
 	id: PROVIDER_ID,
 	displayName: DISPLAY_NAME,
-	description: "Load hooks from Claude Code marketplace plugins",
+	description: "Load hooks from xcsh marketplace plugins",
 	priority: PRIORITY,
 	load: loadHooks,
 });
@@ -282,7 +282,7 @@ registerProvider<Hook>(hookCapability.id, {
 registerProvider<CustomTool>(toolCapability.id, {
 	id: PROVIDER_ID,
 	displayName: DISPLAY_NAME,
-	description: "Load custom tools from Claude Code marketplace plugins",
+	description: "Load custom tools from xcsh marketplace plugins",
 	priority: PRIORITY,
 	load: loadTools,
 });

--- a/packages/coding-agent/src/discovery/claude.ts
+++ b/packages/coding-agent/src/discovery/claude.ts
@@ -1,5 +1,5 @@
 /**
- * Claude Code Provider
+ * xcsh Provider
  *
  * Loads configuration from .xcsh directories.
  * Priority: 80 (tool-specific, below builtin but above shared standards)
@@ -28,8 +28,8 @@ import {
 	scanSkillsFromDir,
 } from "./helpers";
 
-const PROVIDER_ID = "claude";
-const DISPLAY_NAME = "Claude Code";
+const PROVIDER_ID = "xcsh";
+const DISPLAY_NAME = "xcsh";
 const PRIORITY = 80;
 const CONFIG_DIR = ".xcsh";
 

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -583,13 +583,13 @@ export function getExtensionNameFromPath(extensionPath: string): string {
 }
 
 // =============================================================================
-// Claude Code Plugin Cache Helpers
+// xcsh Plugin Cache Helpers
 // =============================================================================
 
 /**
- * Entry for an installed Claude Code plugin.
+ * Entry for an installed xcsh plugin.
  */
-export interface ClaudePluginEntry {
+export interface XcshPluginEntry {
 	scope: "user" | "project";
 	installPath: string;
 	version: string;
@@ -600,17 +600,17 @@ export interface ClaudePluginEntry {
 }
 
 /**
- * Claude Code installed_plugins.json registry format.
+ * xcsh installed_plugins.json registry format.
  */
-export interface ClaudePluginsRegistry {
+export interface XcshPluginsRegistry {
 	version: number;
-	plugins: Record<string, ClaudePluginEntry[]>;
+	plugins: Record<string, XcshPluginEntry[]>;
 }
 
 /**
  * Resolved plugin root for loading.
  */
-export interface ClaudePluginRoot {
+export interface XcshPluginRoot {
 	/** Plugin ID (e.g., "simpleclaude-core@simpleclaude") */
 	id: string;
 	/** Marketplace name */
@@ -626,10 +626,10 @@ export interface ClaudePluginRoot {
 }
 
 /**
- * Parse Claude Code installed_plugins.json content.
+ * Parse xcsh installed_plugins.json content.
  */
-export function parseClaudePluginsRegistry(content: string): ClaudePluginsRegistry | null {
-	const data = tryParseJson<ClaudePluginsRegistry>(content);
+export function parseXcshPluginsRegistry(content: string): XcshPluginsRegistry | null {
+	const data = tryParseJson<XcshPluginsRegistry>(content);
 	if (!data || typeof data !== "object") return null;
 	if (
 		typeof data.version !== "number" ||
@@ -711,7 +711,7 @@ export async function resolveOrDefaultProjectRegistryPath(cwd: string): Promise<
 	return path.join(cwd, getConfigDirName(), "plugins", "installed_plugins.json");
 }
 
-const pluginRootsCache = new Map<string, { roots: ClaudePluginRoot[]; warnings: string[] }>();
+const pluginRootsCache = new Map<string, { roots: XcshPluginRoot[]; warnings: string[] }>();
 
 /**
  * List all installed marketplace plugin roots from the plugin cache.
@@ -720,25 +720,25 @@ const pluginRootsCache = new Map<string, { roots: ClaudePluginRoot[]; warnings: 
  *
  * Results are cached per `home:resolvedProjectPath` key to avoid repeated parsing.
  */
-export async function listClaudePluginRoots(
+export async function listXcshPluginRoots(
 	home: string,
 	cwd?: string,
-): Promise<{ roots: ClaudePluginRoot[]; warnings: string[] }> {
+): Promise<{ roots: XcshPluginRoot[]; warnings: string[] }> {
 	const resolvedProjectPath = cwd ? await resolveActiveProjectRegistryPath(cwd) : null;
 	const cacheKey = `${home}:${resolvedProjectPath ?? ""}`;
 	const cached = pluginRootsCache.get(cacheKey);
 	if (cached) return cached;
 
-	const roots: ClaudePluginRoot[] = [];
+	const roots: XcshPluginRoot[] = [];
 	const warnings: string[] = [];
-	const projectRoots: ClaudePluginRoot[] = [];
+	const projectRoots: XcshPluginRoot[] = [];
 
 	// ── Installed plugins registry ───────────────────────────────────────────
 	// Path derived from `home` (not os.homedir()) so test isolation works when home is overridden.
 	const registryPath = path.join(home, getConfigDirName(), "plugins", "installed_plugins.json");
 	const content = await readFile(registryPath);
 	if (content) {
-		const registry = parseClaudePluginsRegistry(content);
+		const registry = parseXcshPluginsRegistry(content);
 		if (registry) {
 			for (const [pluginId, entries] of Object.entries(registry.plugins)) {
 				if (!Array.isArray(entries) || entries.length === 0) continue;
@@ -781,7 +781,7 @@ export async function listClaudePluginRoots(
 	if (resolvedProjectPath && resolvedProjectPath !== registryPath) {
 		const projectContent = await readFile(resolvedProjectPath);
 		if (projectContent) {
-			const projectRegistry = parseClaudePluginsRegistry(projectContent);
+			const projectRegistry = parseXcshPluginsRegistry(projectContent);
 			if (projectRegistry) {
 				for (const [pluginId, entries] of Object.entries(projectRegistry.plugins)) {
 					if (!Array.isArray(entries) || entries.length === 0) continue;
@@ -838,7 +838,7 @@ export async function listClaudePluginRoots(
 /**
  * Clear the plugin roots cache (useful for testing or when plugins change).
  */
-export function clearClaudePluginRootsCache(): void {
+export function clearXcshPluginRootsCache(): void {
 	pluginRootsCache.clear();
 	preloadedPluginRoots = [...injectedPluginDirRoots];
 	// Re-warm preloaded roots asynchronously so sync LSP config reads stay valid
@@ -851,8 +851,8 @@ export function clearClaudePluginRootsCache(): void {
 // Populated at startup by preloadPluginRoots(). Read synchronously by
 // getPreloadedPluginRoots(). Safe degradation: empty array if not warmed.
 
-let preloadedPluginRoots: ClaudePluginRoot[] = [];
-let injectedPluginDirRoots: ClaudePluginRoot[] = [];
+let preloadedPluginRoots: XcshPluginRoot[] = [];
+let injectedPluginDirRoots: XcshPluginRoot[] = [];
 let lastPreloadHome: string | undefined;
 
 /**
@@ -862,7 +862,7 @@ let lastPreloadHome: string | undefined;
  */
 export async function preloadPluginRoots(home: string, cwd?: string): Promise<void> {
 	lastPreloadHome = home;
-	const { roots } = await listClaudePluginRoots(home, cwd);
+	const { roots } = await listXcshPluginRoots(home, cwd);
 	preloadedPluginRoots = roots;
 }
 
@@ -870,7 +870,7 @@ export async function preloadPluginRoots(home: string, cwd?: string): Promise<vo
  * Get pre-loaded plugin roots synchronously.
  * Returns empty array if preloadPluginRoots() hasn't been called.
  */
-export function getPreloadedPluginRoots(): readonly ClaudePluginRoot[] {
+export function getPreloadedPluginRoots(): readonly XcshPluginRoot[] {
 	return preloadedPluginRoots;
 }
 
@@ -878,11 +878,11 @@ export function getPreloadedPluginRoots(): readonly ClaudePluginRoot[] {
 
 /**
  * Inject synthetic plugin roots from --plugin-dir paths.
- * These are prepended to the cache with highest precedence (before OMP/Claude entries).
- * Must be called before any listClaudePluginRoots() access.
+ * These are prepended to the cache with highest precedence (before OMP/xcsh entries).
+ * Must be called before any listXcshPluginRoots() access.
  */
 export async function injectPluginDirRoots(home: string, dirs: string[], cwd?: string): Promise<void> {
-	const injected: ClaudePluginRoot[] = [];
+	const injected: XcshPluginRoot[] = [];
 	for (const dir of dirs) {
 		const resolved = path.resolve(dir);
 		// Read plugin name from manifest
@@ -901,13 +901,13 @@ export async function injectPluginDirRoots(home: string, dirs: string[], cwd?: s
 		injected.push(buildPluginDirRoot(resolved, pluginName));
 	}
 
-	// Set injected roots BEFORE populating cache so listClaudePluginRoots merges them.
+	// Set injected roots BEFORE populating cache so listXcshPluginRoots merges them.
 	injectedPluginDirRoots = injected;
 	lastPreloadHome = home; // ensure cache-clear re-warm fires even when injectPluginDirRoots was the startup path
 	// Clear any stale cache entries (populated before injected roots were set).
 	pluginRootsCache.clear();
 	// Rebuild — cache miss triggers fresh load that includes both user+project registries
 	// and prepends injectedPluginDirRoots at highest precedence.
-	const { roots } = await listClaudePluginRoots(home, cwd);
+	const { roots } = await listXcshPluginRoots(home, cwd);
 	preloadedPluginRoots = roots;
 }

--- a/packages/coding-agent/src/discovery/plugin-dir-roots.ts
+++ b/packages/coding-agent/src/discovery/plugin-dir-roots.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 
-/** Synthetic plugin root for a --plugin-dir path. Shape-compatible with ClaudePluginRoot. */
+/** Synthetic plugin root for a --plugin-dir path. Shape-compatible with XcshPluginRoot. */
 export interface PluginDirRoot {
 	id: string;
 	marketplace: string;

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -3,7 +3,7 @@
  *
  * Constructor takes explicit paths for testability (same pattern as registry.ts).
  * The `clearPluginRootsCache` dependency is injected so callers can provide
- * the real `clearClaudePluginRootsCache` while tests supply a counter stub.
+ * the real `clearXcshPluginRootsCache` while tests supply a counter stub.
  */
 
 import * as fs from "node:fs/promises";
@@ -51,7 +51,7 @@ export interface MarketplaceManagerOptions {
 	projectInstalledRegistryPath?: string;
 	marketplacesCacheDir: string;
 	pluginsCacheDir: string;
-	/** Injected for testing; production callers pass clearClaudePluginRootsCache.
+	/** Injected for testing; production callers pass clearXcshPluginRootsCache.
 	 *  Receives any additional file paths that should also be invalidated from the fs cache.
 	 */
 	clearPluginRootsCache?: (extraPaths?: readonly string[]) => void;

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/types.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/types.ts
@@ -3,9 +3,9 @@
  *
  * Two registries:
  *   - MarketplacesRegistry: which marketplace catalogs the user has added (config)
- *   - InstalledPluginsRegistry: which plugins are installed (data, Claude Code-compatible)
+ *   - InstalledPluginsRegistry: which plugins are installed (data)
  *
- * The installed registry MUST pass `parseClaudePluginsRegistry()` validation —
+ * The installed registry MUST pass `parseXcshPluginsRegistry()` validation —
  * it uses `version: 2` (numeric) and `plugins: Record<string, ...[]>`.
  */
 
@@ -151,11 +151,11 @@ export interface MarketplaceRegistryEntry {
 }
 
 // ── Installed plugins registry ───────────────────────────────────────
-// MUST match ClaudePluginsRegistry shape for parseClaudePluginsRegistry()
+// MUST match XcshPluginsRegistry shape for parseXcshPluginsRegistry()
 // compatibility: `version: number`, `plugins: Record<string, entry[]>`.
 
 export interface InstalledPluginsRegistry {
-	/** MUST be 2 — parseClaudePluginsRegistry rejects non-numeric version. */
+	/** MUST be 2 — parseXcshPluginsRegistry rejects non-numeric version. */
 	version: 2;
 	plugins: Record<string, InstalledPluginEntry[]>;
 }
@@ -171,7 +171,7 @@ export interface InstalledPluginEntry {
 	lastUpdated: string;
 	/** For git-sourced plugins. */
 	gitCommitSha?: string;
-	/** OMP extension — not in Claude Code's type. CLI/UI concern only in v1. */
+	/** OMP extension — CLI/UI concern only in v1. */
 	enabled?: boolean;
 }
 

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -80,9 +80,9 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		cwd = getProjectDir(),
 		enabled = true,
 		enableCodexUser = true,
-		enableClaudeUser = true,
-		enableClaudeProject = true,
-		enableClaudePlugins = false,
+		enableXcshUser = true,
+		enableXcshProject = true,
+		enableXcshPlugins = false,
 		enablePiUser = true,
 		enablePiProject = true,
 		customDirectories = [],
@@ -97,16 +97,16 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 	}
 
 	const anyBuiltInSkillSourceEnabled =
-		enableCodexUser || enableClaudeUser || enableClaudeProject || enablePiUser || enablePiProject;
+		enableCodexUser || enableXcshUser || enableXcshProject || enablePiUser || enablePiProject;
 	// Helper to check if a source is enabled
 	function isSourceEnabled(source: SourceMeta): boolean {
 		const { provider, level } = source;
 		if (provider === "codex" && level === "user") return enableCodexUser;
-		if (provider === "claude" && level === "user") return enableClaudeUser;
-		if (provider === "claude" && level === "project") return enableClaudeProject;
+		if (provider === "xcsh" && level === "user") return enableXcshUser;
+		if (provider === "xcsh" && level === "project") return enableXcshProject;
 		if (provider === "native" && level === "user") return enablePiUser;
 		if (provider === "native" && level === "project") return enablePiProject;
-		if (provider === "claude-plugins") return enableClaudePlugins;
+		if (provider === "xcsh-plugins") return enableXcshPlugins;
 		return anyBuiltInSkillSourceEnabled;
 	}
 

--- a/packages/coding-agent/src/extensibility/slash-commands.ts
+++ b/packages/coding-agent/src/extensibility/slash-commands.ts
@@ -142,7 +142,7 @@ export interface FileSlashCommand {
 	name: string;
 	description: string;
 	content: string;
-	source: string; // e.g., "via Claude Code (User)"
+	source: string; // e.g., "via xcsh (User)"
 	/** Source metadata for display */
 	_source?: { providerName: string; level: "user" | "project" | "native" };
 }

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -33,7 +33,7 @@ import { resolveCliModel, resolveModelRoleValue, resolveModelScope, type ScopedM
 import { getDefault, type SettingPath, Settings, settings } from "./config/settings";
 import { initializeWithSettings } from "./discovery";
 import {
-	clearClaudePluginRootsCache,
+	clearXcshPluginRootsCache,
 	injectPluginDirRoots,
 	preloadPluginRoots,
 	resolveActiveProjectRegistryPath,
@@ -739,7 +739,7 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 						const h = os.homedir();
 						invalidateFsCache(path.join(h, getConfigDirName(), "plugins", "installed_plugins.json"));
 						for (const p of extraPaths ?? []) invalidateFsCache(p);
-						clearClaudePluginRootsCache();
+						clearXcshPluginRootsCache();
 					},
 				});
 				await mgr.refreshStaleMarketplaces();

--- a/packages/coding-agent/src/mcp/loader.ts
+++ b/packages/coding-agent/src/mcp/loader.ts
@@ -98,7 +98,7 @@ export async function discoverAndLoadMCPTools(cwd: string, options?: MCPToolsLoa
 			connection?._source?.providerName ?? source?.providerName ?? connection?._source?.provider ?? source?.provider;
 
 		// Format path with provider info if available
-		// Format: "mcp:serverName via providerName" (e.g., "mcp:agentx via Claude Code")
+		// Format: "mcp:serverName via providerName" (e.g., "mcp:agentx via xcsh")
 		const path = serverName && providerName ? `mcp:${serverName} via ${providerName}` : `mcp:${tool.name}`;
 
 		return {

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -68,9 +68,9 @@ export interface MCPToolDetails {
 	isError?: boolean;
 	/** Raw content from MCP response */
 	rawContent?: MCPContent[];
-	/** Provider ID (e.g., "claude", "mcp-json") */
+	/** Provider ID (e.g., "xcsh", "mcp-json") */
 	provider?: string;
-	/** Provider display name (e.g., "Claude Code", "MCP Config") */
+	/** Provider display name (e.g., "xcsh", "MCP Config") */
 	providerName?: string;
 }
 /**

--- a/packages/coding-agent/src/modes/components/gutter-block.ts
+++ b/packages/coding-agent/src/modes/components/gutter-block.ts
@@ -230,7 +230,7 @@ export class DisposableContainer extends Container {
  * Animated ● gutter for tool calls and slash-command executions.
  * Active: pulsing dot — alternates ● / blank in `muted` color to
  *   differentiate from the braille ✻ thinking spinner. Matches the
- *   Claude Code tool-initialization aesthetic.
+ *   xcsh tool-initialization aesthetic.
  * Done (unknown outcome): `dim` — neutral "completed" color when the call
  *   site does not have success/error information.
  * Done (success): `gutterSuccess` (falls back to `success` when the theme

--- a/packages/coding-agent/src/modes/components/plugins/plugin-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/plugins/plugin-dashboard.ts
@@ -13,7 +13,7 @@ import {
 } from "@f5xc-salesdemos/pi-tui";
 import { getConfigDirName } from "@f5xc-salesdemos/pi-utils";
 import { invalidate as invalidateFsCache } from "../../../capability/fs";
-import { clearClaudePluginRootsCache, resolveActiveProjectRegistryPath } from "../../../discovery/helpers";
+import { clearXcshPluginRootsCache, resolveActiveProjectRegistryPath } from "../../../discovery/helpers";
 import { PluginManager } from "../../../extensibility/plugins";
 import {
 	getInstalledPluginsRegistryPath,
@@ -30,7 +30,7 @@ import { PluginListPane } from "./plugin-list-pane";
 import { applySearch, buildTabs, createInitialState, filterByTab, loadAllPlugins } from "./state-manager";
 import type { DashboardPlugin, PluginDashboardState, PluginTabId } from "./types";
 
-const DEFAULT_MARKETPLACE = "anthropics/claude-plugins-official";
+const DEFAULT_MARKETPLACE = "f5xc-salesdemos/marketplace";
 
 class TwoColumnBody implements Component {
 	constructor(
@@ -98,7 +98,7 @@ export class PluginDashboard extends Container {
 				const home = os.homedir();
 				invalidateFsCache(path.join(home, getConfigDirName(), "plugins", "installed_plugins.json"));
 				for (const p of extraPaths ?? []) invalidateFsCache(p);
-				clearClaudePluginRootsCache();
+				clearXcshPluginRootsCache();
 			},
 		});
 
@@ -331,7 +331,7 @@ export class PluginDashboard extends Container {
 	#buildLayout(): void {
 		this.clear();
 		this.addChild(new DynamicBorder());
-		this.addChild(new Text(theme.bold(theme.fg("contentAccent", " Plugin Control Center")), 0, 0));
+		this.addChild(new Text(theme.bold(theme.fg("contentAccent", " xcsh Plugin Center")), 0, 0));
 		this.addChild(new Text(this.#renderTabBar(), 0, 0));
 		this.addChild(new Spacer(1));
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -13,7 +13,7 @@ import { Loader, Markdown, padding, Spacer, Text, visibleWidth } from "@f5xc-sal
 import { formatDuration, Snowflake, setProjectDir, setShellPwd } from "@f5xc-salesdemos/pi-utils";
 import { $ } from "bun";
 import { reset as resetCapabilities } from "../../capability";
-import { clearClaudePluginRootsCache } from "../../discovery/helpers";
+import { clearXcshPluginRootsCache } from "../../discovery/helpers";
 import { loadCustomShare } from "../../export/custom-share";
 import type { CompactOptions } from "../../extensibility/extensions/types";
 import { getGatewayStatus } from "../../ipy/gateway-coordinator";
@@ -677,7 +677,7 @@ export class CommandController {
 			await this.ctx.sessionManager.flush();
 			await this.ctx.sessionManager.moveTo(resolvedPath);
 			setProjectDir(resolvedPath);
-			clearClaudePluginRootsCache(); // re-warms preloadedPluginRoots with new project dir (async)
+			clearXcshPluginRootsCache(); // re-warms preloadedPluginRoots with new project dir (async)
 			resetCapabilities();
 			await this.ctx.refreshSlashCommandState(resolvedPath);
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -19,7 +19,7 @@ import { formatModelSelectorValue } from "../../config/model-resolver";
 import { settings } from "../../config/settings";
 import { DebugSelectorComponent } from "../../debug";
 import { disableProvider, enableProvider } from "../../discovery";
-import { clearClaudePluginRootsCache, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
+import { clearXcshPluginRootsCache, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
 	getInstalledPluginsRegistryPath,
 	getMarketplacesCacheDir,
@@ -482,7 +482,7 @@ export class SelectorController {
 				const home = os.homedir();
 				invalidateFsCache(path.join(home, getConfigDirName(), "plugins", "installed_plugins.json"));
 				for (const p of extraPaths ?? []) invalidateFsCache(p);
-				clearClaudePluginRootsCache();
+				clearXcshPluginRootsCache();
 			},
 		});
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -8,7 +8,7 @@ import { invalidate as invalidateFsCache } from "../capability/fs";
 import type { SettingPath, SettingValue } from "../config/settings";
 import { settings } from "../config/settings";
 import {
-	clearClaudePluginRootsCache,
+	clearXcshPluginRootsCache,
 	resolveActiveProjectRegistryPath,
 	resolveOrDefaultProjectRegistryPath,
 } from "../discovery/helpers.js";
@@ -905,7 +905,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 					const home = os.homedir();
 					invalidateFsCache(path.join(home, getConfigDirName(), "plugins", "installed_plugins.json"));
 					for (const p of extraPaths ?? []) invalidateFsCache(p);
-					clearClaudePluginRootsCache();
+					clearXcshPluginRootsCache();
 				},
 			});
 
@@ -946,7 +946,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 							const marketplaces = await mgr.listMarketplaces();
 							if (marketplaces.length === 0) {
 								runtime.ctx.showStatus(
-									"No marketplaces configured. Try:\n  /marketplace add anthropics/claude-plugins-official",
+									"No marketplaces configured. Try:\n  /marketplace add f5xc-salesdemos/marketplace",
 								);
 							} else {
 								runtime.ctx.showStatus("No plugins available in configured marketplaces");
@@ -1043,7 +1043,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 								"  /marketplace upgrade [name@marketplace]    Upgrade plugin(s)",
 								"",
 								"Quick start:",
-								"  /marketplace add anthropics/claude-plugins-official",
+								"  /marketplace add f5xc-salesdemos/marketplace",
 								"  /marketplace                               (opens interactive browser)",
 							].join("\n"),
 						);
@@ -1053,7 +1053,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 						const marketplaces = await mgr.listMarketplaces();
 						if (marketplaces.length === 0) {
 							runtime.ctx.showStatus(
-								"No marketplaces configured.\n\nGet started:\n  /marketplace add anthropics/claude-plugins-official\n\nThen browse plugins with /marketplace or /marketplace discover",
+								"No marketplaces configured.\n\nGet started:\n  /marketplace add f5xc-salesdemos/marketplace\n\nThen browse plugins with /marketplace or /marketplace discover",
 							);
 						} else {
 							const lines = marketplaces.map(m => `  ${m.name}  ${m.sourceUri}`);
@@ -1104,7 +1104,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 						const home = os.homedir();
 						invalidateFsCache(path.join(home, getConfigDirName(), "plugins", "installed_plugins.json"));
 						for (const p of extraPaths ?? []) invalidateFsCache(p);
-						clearClaudePluginRootsCache();
+						clearXcshPluginRootsCache();
 					},
 				});
 
@@ -1177,12 +1177,12 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 		description: "Reload all plugins (skills, commands, hooks, tools, agents, MCP)",
 		handle: async (_command, runtime) => {
 			// Invalidate the fs content cache for all registry files so
-			// listClaudePluginRoots re-reads from disk on next access.
+			// listXcshPluginRoots re-reads from disk on next access.
 			const home = os.homedir();
 			invalidateFsCache(path.join(home, getConfigDirName(), "plugins", "installed_plugins.json"));
 			const projectPath = await resolveActiveProjectRegistryPath(runtime.ctx.sessionManager.getCwd());
 			if (projectPath) invalidateFsCache(projectPath);
-			clearClaudePluginRootsCache();
+			clearXcshPluginRootsCache();
 			await runtime.ctx.refreshSlashCommandState();
 			runtime.ctx.showStatus("Plugins reloaded.");
 			runtime.ctx.editor.setText("");

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -16,7 +16,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { logger } from "@f5xc-salesdemos/pi-utils";
 import { findAllNearestProjectConfigDirs, getConfigDirs } from "../config";
-import { listClaudePluginRoots } from "../discovery/helpers";
+import { listXcshPluginRoots } from "../discovery/helpers";
 import { loadBundledAgents, parseAgent } from "./agents";
 import type { AgentDefinition, AgentSource } from "./types";
 
@@ -87,8 +87,8 @@ export async function discoverAgents(cwd: string, home: string = os.homedir()): 
 		if (user) orderedDirs.push({ dir: user.path, source: "user" });
 	}
 
-	// Load agents from Claude Code marketplace plugins
-	const { roots: pluginRoots } = await listClaudePluginRoots(home, resolvedCwd);
+	// Load agents from xcsh marketplace plugins
+	const { roots: pluginRoots } = await listXcshPluginRoots(home, resolvedCwd);
 	const sortedPluginRoots = [...pluginRoots].sort((a, b) => {
 		if (a.scope === b.scope) return 0;
 		return a.scope === "project" ? -1 : 1;

--- a/packages/coding-agent/src/tools/json-tree.ts
+++ b/packages/coding-agent/src/tools/json-tree.ts
@@ -47,7 +47,7 @@ export function formatScalar(value: unknown, maxLen: number): string {
 
 /**
  * Color a formatted scalar value based on its JS type using syntax highlighting colors.
- * Matches Claude Code / VS Code Dark+ JSON highlighting semantics.
+ * Matches xcsh / VS Code Dark+ JSON highlighting semantics.
  */
 function colorScalar(value: unknown, formatted: string, theme: Theme): string {
 	if (value === null || value === undefined) return theme.fg("syntaxKeyword", formatted);

--- a/packages/coding-agent/src/utils/shell-snapshot.ts
+++ b/packages/coding-agent/src/utils/shell-snapshot.ts
@@ -33,7 +33,7 @@ function getShellConfigFile(shell: string): string {
 /**
  * Generate the snapshot creation script.
  * This script sources the user's rc file and extracts functions, aliases, and options.
- * Matches Claude Code's snapshot generation logic.
+ * Matches xcsh snapshot generation logic.
  */
 function generateSnapshotScript(shell: string, snapshotPath: string, rcFile: string): string {
 	const hasRcFile = fs.existsSync(rcFile);

--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -85,7 +85,7 @@ function getModel(): string {
 /**
  * Builds system instruction blocks for the Anthropic API request.
  * @param auth - Authentication configuration
- * @param model - Model identifier (affects whether Claude Code instruction is included)
+ * @param model - Model identifier (affects whether xcsh instruction is included)
  * @param systemPrompt - Optional system prompt for guiding response style
  * @returns Array of system blocks for the API request
  */

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -4,13 +4,13 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { clearCache as clearFsCache } from "@f5xc-salesdemos/xcsh/capability/fs";
 import {
-	clearClaudePluginRootsCache,
-	listClaudePluginRoots,
-	parseClaudePluginsRegistry,
+	clearXcshPluginRootsCache,
+	listXcshPluginRoots,
+	parseXcshPluginsRegistry,
 } from "@f5xc-salesdemos/xcsh/discovery/helpers";
 import { discoverAgents } from "@f5xc-salesdemos/xcsh/task/discovery";
 
-describe("parseClaudePluginsRegistry", () => {
+describe("parseXcshPluginsRegistry", () => {
 	test("parses valid registry", () => {
 		const content = JSON.stringify({
 			version: 2,
@@ -27,48 +27,48 @@ describe("parseClaudePluginsRegistry", () => {
 			},
 		});
 
-		const result = parseClaudePluginsRegistry(content);
+		const result = parseXcshPluginsRegistry(content);
 		expect(result).not.toBeNull();
 		expect(result?.version).toBe(2);
 		expect(result?.plugins["my-plugin@marketplace"]).toHaveLength(1);
 	});
 
 	test("returns null for invalid JSON", () => {
-		expect(parseClaudePluginsRegistry("not json")).toBeNull();
+		expect(parseXcshPluginsRegistry("not json")).toBeNull();
 	});
 
 	test("returns null for missing version", () => {
 		const content = JSON.stringify({ plugins: {} });
-		expect(parseClaudePluginsRegistry(content)).toBeNull();
+		expect(parseXcshPluginsRegistry(content)).toBeNull();
 	});
 
 	test("returns null for missing plugins", () => {
 		const content = JSON.stringify({ version: 2 });
-		expect(parseClaudePluginsRegistry(content)).toBeNull();
+		expect(parseXcshPluginsRegistry(content)).toBeNull();
 	});
 
 	test("returns null for null plugins", () => {
 		const content = JSON.stringify({ version: 2, plugins: null });
-		expect(parseClaudePluginsRegistry(content)).toBeNull();
+		expect(parseXcshPluginsRegistry(content)).toBeNull();
 	});
 });
 
-describe("listClaudePluginRoots", () => {
+describe("listXcshPluginRoots", () => {
 	let tempDir: string;
 
 	beforeEach(async () => {
-		clearClaudePluginRootsCache();
+		clearXcshPluginRootsCache();
 		clearFsCache();
-		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-plugins-test-"));
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-plugins-test-"));
 	});
 
 	afterEach(async () => {
-		clearClaudePluginRootsCache();
+		clearXcshPluginRootsCache();
 		await fs.rm(tempDir, { recursive: true, force: true });
 	});
 
 	test("returns empty roots when no registry file exists", async () => {
-		const result = await listClaudePluginRoots(tempDir);
+		const result = await listXcshPluginRoots(tempDir);
 		expect(result.roots).toEqual([]);
 		expect(result.warnings).toEqual([]);
 	});
@@ -94,7 +94,7 @@ describe("listClaudePluginRoots", () => {
 
 		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
 
-		const result = await listClaudePluginRoots(tempDir);
+		const result = await listXcshPluginRoots(tempDir);
 		expect(result.roots).toHaveLength(1);
 		expect(result.roots[0]).toEqual({
 			id: "test-plugin@test-market",
@@ -127,7 +127,7 @@ describe("listClaudePluginRoots", () => {
 
 		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
 
-		const result = await listClaudePluginRoots(tempDir);
+		const result = await listXcshPluginRoots(tempDir);
 		expect(result.roots).toHaveLength(1);
 		expect(result.roots[0].scope).toBe("project");
 	});
@@ -160,7 +160,7 @@ describe("listClaudePluginRoots", () => {
 
 		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
 
-		const result = await listClaudePluginRoots(tempDir);
+		const result = await listXcshPluginRoots(tempDir);
 		// Should return both entries, not just the first one
 		expect(result.roots).toHaveLength(2);
 		expect(result.roots[0].version).toBe("2.0.0");
@@ -190,7 +190,7 @@ describe("listClaudePluginRoots", () => {
 
 		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
 
-		const result = await listClaudePluginRoots(tempDir);
+		const result = await listXcshPluginRoots(tempDir);
 		expect(result.roots).toHaveLength(0);
 		expect(result.warnings).toHaveLength(1);
 		expect(result.warnings[0]).toContain("Invalid plugin ID format");
@@ -216,7 +216,7 @@ describe("listClaudePluginRoots", () => {
 
 		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
 
-		const result = await listClaudePluginRoots(tempDir);
+		const result = await listXcshPluginRoots(tempDir);
 		expect(result.roots).toHaveLength(0);
 		expect(result.warnings).toHaveLength(1);
 		expect(result.warnings[0]).toContain("has no installPath");
@@ -250,7 +250,7 @@ describe("listClaudePluginRoots", () => {
 		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
 
 		// First call
-		const result1 = await listClaudePluginRoots(tempDir);
+		const result1 = await listXcshPluginRoots(tempDir);
 		expect(result1.roots).toHaveLength(1);
 
 		// Modify the file
@@ -266,13 +266,13 @@ describe("listClaudePluginRoots", () => {
 		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
 
 		// Second call should return cached result (still 1 plugin)
-		const result2 = await listClaudePluginRoots(tempDir);
+		const result2 = await listXcshPluginRoots(tempDir);
 		expect(result2.roots).toHaveLength(1);
 
 		// After clearing cache, should see new plugin
-		clearClaudePluginRootsCache();
+		clearXcshPluginRootsCache();
 		clearFsCache(); // Also clear fs cache so the file is re-read
-		const result3 = await listClaudePluginRoots(tempDir);
+		const result3 = await listXcshPluginRoots(tempDir);
 		expect(result3.roots).toHaveLength(2);
 	});
 
@@ -296,7 +296,7 @@ describe("listClaudePluginRoots", () => {
 
 		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
 
-		const result = await listClaudePluginRoots(tempDir);
+		const result = await listXcshPluginRoots(tempDir);
 		expect(result.roots).toHaveLength(1);
 		expect(result.roots[0].scope).toBe("user");
 	});
@@ -306,13 +306,13 @@ describe("discoverAgents plugin precedence", () => {
 	let tempDir: string;
 
 	beforeEach(async () => {
-		clearClaudePluginRootsCache();
+		clearXcshPluginRootsCache();
 		clearFsCache();
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-plugins-precedence-test-"));
 	});
 
 	afterEach(async () => {
-		clearClaudePluginRootsCache();
+		clearXcshPluginRootsCache();
 		await fs.rm(tempDir, { recursive: true, force: true });
 	});
 

--- a/packages/coding-agent/test/highlight-languages.test.ts
+++ b/packages/coding-agent/test/highlight-languages.test.ts
@@ -188,7 +188,7 @@ describe("JSON syntax highlighting", () => {
 
 	it("highlights object keys as variable (distinct from string values)", () => {
 		// Keys are colored as variable (light blue) to distinguish them from
-		// string values (terracotta), matching VS Code Dark+ / Claude Code behavior.
+		// string values (terracotta), matching VS Code Dark+ / xcsh behavior.
 		expectTokenColor('{"key": "value"}', "json", "key", COLORS.variable);
 	});
 
@@ -308,7 +308,7 @@ describe("HTML syntax highlighting", () => {
 	it("highlights attribute names as variable (light blue)", () => {
 		// Attribute names (entity.other.attribute-name.*) are colored as variable
 		// to distinguish them from tag names (keyword) and attribute values (string),
-		// matching VS Code Dark+ / Claude Code behavior.
+		// matching VS Code Dark+ / xcsh behavior.
 		expectTokenColor('<div class="main">', "html", "class", COLORS.variable);
 	});
 

--- a/packages/coding-agent/test/marketplace/discovery.test.ts
+++ b/packages/coding-agent/test/marketplace/discovery.test.ts
@@ -1,18 +1,18 @@
 /**
  * Discovery integration tests for OMP plugin registry reading.
  *
- * NOTE: listClaudePluginRoots() lives in discovery/helpers.ts which imports
+ * NOTE: listXcshPluginRoots() lives in discovery/helpers.ts which imports
  * @f5xc-salesdemos/pi-natives (native Rust addon via glob). We cannot call it here.
  *
- * Instead these tests validate the structural contract that listClaudePluginRoots
+ * Instead these tests validate the structural contract that listXcshPluginRoots
  * depends on:
  *   1. OMP registry lives at path.join(home, ".xcsh", "plugins", "installed_plugins.json")
  *      (matches getConfigDirName() == ".xcsh")
- *   2. The registry format passes the same validator that parseClaudePluginsRegistry uses
+ *   2. The registry format passes the same validator that parseXcshPluginsRegistry uses
  *   3. readInstalledPluginsRegistry / writeInstalledPluginsRegistry produce files that
  *      satisfy that validator
  *
- * End-to-end wiring (calling listClaudePluginRoots) is covered by wiring.test.ts,
+ * End-to-end wiring (calling listXcshPluginRoots) is covered by wiring.test.ts,
  * which runs in an environment where the native addon is available.
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
@@ -29,7 +29,7 @@ import {
 
 // ── Inline validator ───────────────────────────────────────────────────────────
 //
-// Mirrors parseClaudePluginsRegistry() in discovery/helpers.ts exactly.
+// Mirrors parseXcshPluginsRegistry() in discovery/helpers.ts exactly.
 // Kept here to avoid importing helpers.ts (which pulls in @f5xc-salesdemos/pi-natives).
 function validateClaudeRegistryFormat(content: string): Record<string, unknown> | null {
 	let data: Record<string, unknown>;
@@ -86,7 +86,7 @@ afterEach(() => {
 
 describe("OMP registry path contract", () => {
 	it("OMP registry lives at home/.xcsh/plugins/installed_plugins.json", () => {
-		// This is the path that listClaudePluginRoots reads.
+		// This is the path that listXcshPluginRoots reads.
 		// Any change to this path must be reflected in helpers.ts.
 		const expected = path.join(tmpHome, ".xcsh", "plugins", "installed_plugins.json");
 		expect(ompRegistryPath).toBe(expected);
@@ -130,7 +130,7 @@ describe("OMP registry format compatibility with Claude parser", () => {
 	});
 
 	it("file with missing version field fails validator (regression)", () => {
-		// Ensures validator correctly rejects what parseClaudePluginsRegistry rejects.
+		// Ensures validator correctly rejects what parseXcshPluginsRegistry rejects.
 		const badContent = JSON.stringify({ plugins: {} });
 		expect(validateClaudeRegistryFormat(badContent)).toBeNull();
 	});
@@ -200,7 +200,7 @@ describe("OMP registry round-trip", () => {
 	});
 
 	it("missing file returns empty registry (not an error)", async () => {
-		// listClaudePluginRoots treats absent file as empty, not a failure.
+		// listXcshPluginRoots treats absent file as empty, not a failure.
 		// readInstalledPluginsRegistry must match this behaviour.
 		const missingPath = path.join(tmpHome, "nonexistent", "installed_plugins.json");
 		const reg = await readInstalledPluginsRegistry(missingPath);
@@ -210,7 +210,7 @@ describe("OMP registry round-trip", () => {
 
 // ── Precedence contract (structural) ─────────────────────────────────────────
 //
-// listClaudePluginRoots must replace Claude entries with OMP entries when the same
+// listXcshPluginRoots must replace Claude entries with OMP entries when the same
 // plugin ID appears in both registries. We cannot call that function here, but we
 // can verify the data shapes that the replacement logic reads are correct.
 
@@ -221,7 +221,7 @@ describe("OMP precedence contract (registry structure)", () => {
 		const id = buildPluginId("shared-plugin", "common-mkt");
 		const xcshEntry = makeEntry("/xcsh/cached/path");
 
-		// OMP registry entry has installPath (required by listClaudePluginRoots)
+		// OMP registry entry has installPath (required by listXcshPluginRoots)
 		expect(xcshEntry.installPath).toBeTruthy();
 		expect(typeof xcshEntry.installPath).toBe("string");
 		// ID parses correctly with lastIndexOf("@")
@@ -236,7 +236,7 @@ describe("OMP precedence contract (registry structure)", () => {
 		const id = buildPluginId("dup-plugin", "mkt");
 		const sharedPath = "/tmp/shared-install-path";
 
-		// Simulate what listClaudePluginRoots would do:
+		// Simulate what listXcshPluginRoots would do:
 		const roots: Array<{ id: string; path: string }> = [{ id, path: sharedPath }];
 
 		// Second entry with same installPath should be deduplicated

--- a/packages/coding-agent/test/marketplace/project-scope.test.ts
+++ b/packages/coding-agent/test/marketplace/project-scope.test.ts
@@ -2,7 +2,7 @@
  * Tests for project-scope registry resolution contracts.
  *
  * resolveActiveProjectRegistryPath: walk-up, .git fallback, null return, canonical path.
- * listClaudePluginRoots: project entries shadow user entries for same plugin ID.
+ * listXcshPluginRoots: project entries shadow user entries for same plugin ID.
  *
  * Note: helpers.ts imports @f5xc-salesdemos/pi-natives (Rust addon via glob).
  * This file imports from helpers.ts directly — the native addon IS present in the
@@ -20,8 +20,8 @@ import {
 	writeInstalledPluginsRegistry,
 } from "@f5xc-salesdemos/xcsh/extensibility/plugins/marketplace";
 import {
-	clearClaudePluginRootsCache,
-	listClaudePluginRoots,
+	clearXcshPluginRootsCache,
+	listXcshPluginRoots,
 	resolveActiveProjectRegistryPath,
 } from "../../src/discovery/helpers";
 
@@ -132,14 +132,14 @@ describe("resolveActiveProjectRegistryPath", () => {
 	});
 });
 
-// ── listClaudePluginRoots: project shadows user ───────────────────────────────
+// ── listXcshPluginRoots: project shadows user ───────────────────────────────
 
-describe("listClaudePluginRoots — project shadows user", () => {
+describe("listXcshPluginRoots — project shadows user", () => {
 	let tmpHome: string;
 	let tmpProject: string;
-	/** Path where listClaudePluginRoots reads the user OMP registry. */
+	/** Path where listXcshPluginRoots reads the user OMP registry. */
 	let userRegPath: string;
-	/** Path where listClaudePluginRoots reads the project registry (resolved from tmpProject). */
+	/** Path where listXcshPluginRoots reads the project registry (resolved from tmpProject). */
 	let projectRegPath: string;
 
 	beforeEach(() => {
@@ -157,7 +157,7 @@ describe("listClaudePluginRoots — project shadows user", () => {
 
 	afterEach(() => {
 		// Cache is keyed by home:projectPath — must clear between tests.
-		clearClaudePluginRootsCache();
+		clearXcshPluginRootsCache();
 		fs.rmSync(tmpHome, { recursive: true, force: true });
 		fs.rmSync(tmpProject, { recursive: true, force: true });
 	});
@@ -175,7 +175,7 @@ describe("listClaudePluginRoots — project shadows user", () => {
 		projReg = addInstalledPlugin(projReg, pluginId, makeEntry("/project/install/shared-plugin", "project"));
 		await writeInstalledPluginsRegistry(projectRegPath, projReg);
 
-		const { roots } = await listClaudePluginRoots(tmpHome, tmpProject);
+		const { roots } = await listXcshPluginRoots(tmpHome, tmpProject);
 		const matching = roots.filter(r => r.id === pluginId);
 
 		// Exactly one entry survives — the user entry is suppressed.
@@ -196,7 +196,7 @@ describe("listClaudePluginRoots — project shadows user", () => {
 		projReg = addInstalledPlugin(projReg, projectPluginId, makeEntry("/project/install/project-only", "project"));
 		await writeInstalledPluginsRegistry(projectRegPath, projReg);
 
-		const { roots } = await listClaudePluginRoots(tmpHome, tmpProject);
+		const { roots } = await listXcshPluginRoots(tmpHome, tmpProject);
 		const ids = new Set(roots.map(r => r.id));
 
 		expect(ids.has(userPluginId)).toBe(true);

--- a/packages/coding-agent/test/marketplace/registry.test.ts
+++ b/packages/coding-agent/test/marketplace/registry.test.ts
@@ -24,10 +24,10 @@ import {
 	writeMarketplacesRegistry,
 } from "@f5xc-salesdemos/xcsh/extensibility/plugins/marketplace";
 
-// Inline the parseClaudePluginsRegistry validation logic to avoid pulling
+// Inline the parseXcshPluginsRegistry validation logic to avoid pulling
 // in discovery/helpers.ts which transitively imports @f5xc-salesdemos/pi-natives.
-// Matches the exact checks in helpers.ts parseClaudePluginsRegistry().
-function validateClaudeRegistryFormat(content: string): Record<string, unknown> | null {
+// Matches the exact checks in helpers.ts parseXcshPluginsRegistry().
+function validateXcshRegistryFormat(content: string): Record<string, unknown> | null {
 	let data: Record<string, unknown>;
 	try {
 		data = JSON.parse(content);
@@ -271,7 +271,7 @@ describe("registry file I/O", () => {
 		expect(read).toEqual(reg);
 	});
 
-	it("written installed registry passes Claude Code registry validation", async () => {
+	it("written installed registry passes xcsh registry validation", async () => {
 		const entry: InstalledPluginEntry = {
 			scope: "user",
 			installPath: path.join(tmpDir, "cache", "plugins", "mkt--plug--1.0.0"),
@@ -286,7 +286,7 @@ describe("registry file I/O", () => {
 		await writeInstalledPluginsRegistry(installedPath, reg);
 
 		const content = await Bun.file(installedPath).text();
-		const parsed = validateClaudeRegistryFormat(content);
+		const parsed = validateXcshRegistryFormat(content);
 		expect(parsed).not.toBeNull();
 		expect(parsed!.version).toBe(2);
 		const plugins = parsed!.plugins as Record<string, unknown>;

--- a/packages/coding-agent/test/sdk-skills.test.ts
+++ b/packages/coding-agent/test/sdk-skills.test.ts
@@ -14,8 +14,8 @@ function createIsolatedSkillsSettings(): Settings {
 	return Settings.isolated({
 		"skills.enabled": true,
 		"skills.enableCodexUser": false,
-		"skills.enableClaudeUser": false,
-		"skills.enableClaudeProject": false,
+		"skills.enableXcshUser": false,
+		"skills.enableXcshProject": false,
 		"skills.enablePiUser": false,
 		"skills.enablePiProject": true,
 	});

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -135,9 +135,9 @@ describe("skills", () => {
 		it("should load from customDirectories only when built-ins disabled", async () => {
 			const { skills } = await loadSkills({
 				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
-				enableClaudePlugins: false,
+				enableXcshUser: false,
+				enableXcshProject: false,
+				enableXcshPlugins: false,
 				enablePiUser: false,
 				enablePiProject: false,
 				customDirectories: [fixturesDir],
@@ -150,8 +150,8 @@ describe("skills", () => {
 		it("should return customDirectory skills sorted by name (case-insensitive)", async () => {
 			const { skills } = await loadSkills({
 				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
+				enableXcshUser: false,
+				enableXcshProject: false,
 				enablePiUser: false,
 				enablePiProject: false,
 				customDirectories: [fixturesDir],
@@ -181,7 +181,7 @@ describe("skills", () => {
 
 				const capability = getCapability<CapabilitySkill>(skillCapability.id);
 				expect(capability).toBeDefined();
-				const claudeProvider = capability?.providers.find(provider => provider.id === "claude");
+				const claudeProvider = capability?.providers.find(provider => provider.id === "xcsh");
 				expect(claudeProvider).toBeDefined();
 
 				const result = await claudeProvider!.load({ cwd: tempProjectDir, home: tempHomeDir, repoRoot: null });
@@ -195,8 +195,8 @@ describe("skills", () => {
 		it("should filter out ignoredSkills", async () => {
 			const { skills } = await loadSkills({
 				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
+				enableXcshUser: false,
+				enableXcshProject: false,
 				enablePiUser: false,
 				enablePiProject: false,
 				customDirectories: [fixturesDir],
@@ -208,8 +208,8 @@ describe("skills", () => {
 		it("should support glob patterns in ignoredSkills", async () => {
 			const { skills } = await loadSkills({
 				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
+				enableXcshUser: false,
+				enableXcshProject: false,
 				enablePiUser: false,
 				enablePiProject: false,
 				customDirectories: [fixturesDir],
@@ -237,8 +237,8 @@ enabled: false
 			try {
 				const { skills } = await loadSkills({
 					enableCodexUser: false,
-					enableClaudeUser: false,
-					enableClaudeProject: false,
+					enableXcshUser: false,
+					enableXcshProject: false,
 					enablePiUser: false,
 					enablePiProject: false,
 					customDirectories: [tempDir],
@@ -252,8 +252,8 @@ enabled: false
 		it("should have ignoredSkills take precedence over includeSkills", async () => {
 			const { skills } = await loadSkills({
 				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
+				enableXcshUser: false,
+				enableXcshProject: false,
 				enablePiUser: false,
 				enablePiProject: false,
 				customDirectories: [fixturesDir],
@@ -285,16 +285,16 @@ description: Skill loaded from a tilde-expanded custom directory.
 			try {
 				const { skills: withTilde } = await loadSkills({
 					enableCodexUser: false,
-					enableClaudeUser: false,
-					enableClaudeProject: false,
+					enableXcshUser: false,
+					enableXcshProject: false,
 					enablePiUser: false,
 					enablePiProject: false,
 					customDirectories: [tildeDir],
 				});
 				const { skills: withoutTilde } = await loadSkills({
 					enableCodexUser: false,
-					enableClaudeUser: false,
-					enableClaudeProject: false,
+					enableXcshUser: false,
+					enableXcshProject: false,
 					enablePiUser: false,
 					enablePiProject: false,
 					customDirectories: [tempHomeSkillsDir],
@@ -309,8 +309,8 @@ description: Skill loaded from a tilde-expanded custom directory.
 		it("should return empty when all sources disabled and no custom dirs", async () => {
 			const { skills } = await loadSkills({
 				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
+				enableXcshUser: false,
+				enableXcshProject: false,
 				enablePiUser: false,
 				enablePiProject: false,
 			});
@@ -321,8 +321,8 @@ description: Skill loaded from a tilde-expanded custom directory.
 			// Load all skills from fixtures
 			const { skills: allSkills } = await loadSkills({
 				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
+				enableXcshUser: false,
+				enableXcshProject: false,
 				enablePiUser: false,
 				enablePiProject: false,
 				customDirectories: [fixturesDir],
@@ -332,8 +332,8 @@ description: Skill loaded from a tilde-expanded custom directory.
 			// Filter to only include "valid-skill"
 			const { skills: filtered } = await loadSkills({
 				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
+				enableXcshUser: false,
+				enableXcshProject: false,
 				enablePiUser: false,
 				enablePiProject: false,
 				customDirectories: [fixturesDir],
@@ -346,8 +346,8 @@ description: Skill loaded from a tilde-expanded custom directory.
 		it("should support glob patterns in includeSkills", async () => {
 			const { skills } = await loadSkills({
 				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
+				enableXcshUser: false,
+				enableXcshProject: false,
 				enablePiUser: false,
 				enablePiProject: false,
 				customDirectories: [fixturesDir],
@@ -360,8 +360,8 @@ description: Skill loaded from a tilde-expanded custom directory.
 		it("should return all skills when includeSkills is empty", async () => {
 			const { skills: withEmpty } = await loadSkills({
 				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
+				enableXcshUser: false,
+				enableXcshProject: false,
 				enablePiUser: false,
 				enablePiProject: false,
 				customDirectories: [fixturesDir],
@@ -369,8 +369,8 @@ description: Skill loaded from a tilde-expanded custom directory.
 			});
 			const { skills: withoutOption } = await loadSkills({
 				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
+				enableXcshUser: false,
+				enableXcshProject: false,
 				enablePiUser: false,
 				enablePiProject: false,
 				customDirectories: [fixturesDir],
@@ -380,12 +380,12 @@ description: Skill loaded from a tilde-expanded custom directory.
 	});
 
 	describe("SkillsSettings type", () => {
-		it("should accept enableClaudePlugins option", async () => {
+		it("should accept enableXcshPlugins option", async () => {
 			const { skills } = await loadSkills({
 				enableCodexUser: false,
-				enableClaudeUser: false,
-				enableClaudeProject: false,
-				enableClaudePlugins: false,
+				enableXcshUser: false,
+				enableXcshProject: false,
+				enableXcshPlugins: false,
 				enablePiUser: false,
 				enablePiProject: false,
 				customDirectories: [fixturesDir],


### PR DESCRIPTION
Closes #1108

## Summary
- Replace all remaining "Claude Code" branding with "xcsh" across 31 files
- Rename provider IDs: `"claude"` → `"xcsh"`, `"claude-plugins"` → `"xcsh-plugins"`
- Rename types/functions: `ClaudePluginEntry/Registry/Root` → `XcshPlugin*`, `listClaudePluginRoots` → `listXcshPluginRoots`, etc.
- Rename settings keys: `enableClaudeUser/Project/Plugins` → `enableXcsh*`
- Bake in `f5xc-salesdemos/marketplace` as the default marketplace (no need for users to `/marketplace add`)
- Dashboard title: "Plugin Control Center" → "xcsh Plugin Center"
- Update all tests and documentation to match

## Test plan
- [ ] Run `bun run ci:check:full` — zero type errors
- [ ] Run `/plugins` — title shows "xcsh Plugin Center", default marketplace is f5xc-salesdemos/marketplace
- [ ] Verify settings UI labels show "xcsh" instead of "Claude"
- [ ] Run test suite — all renamed test references compile and pass