### PR TITLE
chore: bump version to v19.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,7 +2136,7 @@ dependencies = [
 
 [[package]]
 name = "pi-natives"
-version = "18.92.0"
+version = "19.0.1"
 dependencies = [
  "arboard",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/brush-core-vendored", "crates/brush-builtins-vendored", "crat
 resolver = "3"
 
 [workspace.package]
-version = "18.92.0"
+version = "19.0.1"
 edition = "2024"
 license = "MIT"
 authors = ["Can Boluk"]

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/agent": {
       "name": "@f5xc-salesdemos/pi-agent-core",
-      "version": "18.92.0",
+      "version": "19.0.1",
       "dependencies": {
         "@f5xc-salesdemos/pi-ai": "workspace:*",
         "@f5xc-salesdemos/pi-utils": "workspace:*",
@@ -28,7 +28,7 @@
     },
     "packages/ai": {
       "name": "@f5xc-salesdemos/pi-ai",
-      "version": "18.92.0",
+      "version": "19.0.1",
       "bin": {
         "pi-ai": "./src/cli.ts",
       },
@@ -52,7 +52,7 @@
     },
     "packages/coding-agent": {
       "name": "@f5xc-salesdemos/xcsh",
-      "version": "18.92.0",
+      "version": "19.0.1",
       "bin": {
         "xcsh": "src/cli.ts",
       },
@@ -84,22 +84,22 @@
     },
     "packages/natives": {
       "name": "@f5xc-salesdemos/pi-natives",
-      "version": "18.92.0",
+      "version": "19.0.1",
       "devDependencies": {
         "@napi-rs/cli": "3.6.0",
         "@types/bun": "^1.3",
       },
       "optionalDependencies": {
-        "@f5xc-salesdemos/pi-natives-darwin-arm64": "18.92.0",
-        "@f5xc-salesdemos/pi-natives-darwin-x64": "18.92.0",
-        "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.92.0",
-        "@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.92.0",
-        "@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.92.0",
+        "@f5xc-salesdemos/pi-natives-darwin-arm64": "19.0.1",
+        "@f5xc-salesdemos/pi-natives-darwin-x64": "19.0.1",
+        "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "19.0.1",
+        "@f5xc-salesdemos/pi-natives-linux-x64-gnu": "19.0.1",
+        "@f5xc-salesdemos/pi-natives-win32-x64-msvc": "19.0.1",
       },
     },
     "packages/stats": {
       "name": "@f5xc-salesdemos/xcsh-stats",
-      "version": "18.92.0",
+      "version": "19.0.1",
       "bin": {
         "xcsh-stats": "./src/index.ts",
       },
@@ -124,7 +124,7 @@
     },
     "packages/swarm-extension": {
       "name": "@f5xc-salesdemos/swarm-extension",
-      "version": "18.92.0",
+      "version": "19.0.1",
       "bin": {
         "xcsh-swarm": "src/cli.ts",
       },
@@ -140,7 +140,7 @@
     },
     "packages/tui": {
       "name": "@f5xc-salesdemos/pi-tui",
-      "version": "18.92.0",
+      "version": "19.0.1",
       "dependencies": {
         "@f5xc-salesdemos/pi-natives": "workspace:*",
         "@f5xc-salesdemos/pi-utils": "workspace:*",
@@ -179,7 +179,7 @@
     },
     "packages/utils": {
       "name": "@f5xc-salesdemos/pi-utils",
-      "version": "18.92.0",
+      "version": "19.0.1",
       "dependencies": {
         "beautiful-mermaid": "^1.1",
         "handlebars": "^4.7.9",
@@ -703,7 +703,7 @@
 
     "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
-    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-agent-core",
-	"version": "18.92.0",
+	"version": "19.0.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-ai",
-	"version": "18.92.0",
+	"version": "19.0.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/xcsh",
-	"version": "18.92.0",
+	"version": "19.0.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/coding-agent/src/internal-urls/terraform-index.generated.ts
+++ b/packages/coding-agent/src/internal-urls/terraform-index.generated.ts
@@ -286,7 +286,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				"strict_schema_origin",
 			],
 			minimal_config:
-				'resource "f5xc_api_definition" "example" {\n  name      = "example-api-definition"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  swagger_specs = ["string:///base64-openapi-spec"]\n}',
+				'resource "f5xc_api_definition" "example" {\n  name      = "example-api-definition"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  swagger_specs = ["string:///base64-openapi-spec"]\n\n  non_validation_mode {}\n}',
 			dependencies: {
 				requires: ["namespace"],
 			},
@@ -1339,7 +1339,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		rate_limiter_policy: {
 			category: "security",
 			description: "Rate limiter policy create specification. configuration",
-			required: ["name", "namespace"],
+			required: ["name", "namespace", "burst_size", "committed_information_rate"],
 			server_defaults: ["rules"],
 			minimal_config:
 				'resource "f5xc_rate_limiter_policy" "example" {\n  name      = "example-rate-limiter-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  any_server {\n  }\n  server_name_matcher {\n  }\n  server_selector {\n  }\n}',

--- a/packages/natives/npm/darwin-arm64/package.json
+++ b/packages/natives/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-darwin-arm64",
-	"version": "18.92.0",
+	"version": "19.0.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (macOS arm64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-x64/package.json
+++ b/packages/natives/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-darwin-x64",
-	"version": "18.92.0",
+	"version": "19.0.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (macOS x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-arm64-gnu/package.json
+++ b/packages/natives/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-linux-arm64-gnu",
-	"version": "18.92.0",
+	"version": "19.0.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Linux arm64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-x64-gnu/package.json
+++ b/packages/natives/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-linux-x64-gnu",
-	"version": "18.92.0",
+	"version": "19.0.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Linux x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/win32-x64-msvc/package.json
+++ b/packages/natives/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-win32-x64-msvc",
-	"version": "18.92.0",
+	"version": "19.0.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Windows x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives",
-	"version": "18.92.0",
+	"version": "19.0.1",
 	"description": "Native Rust bindings for grep, clipboard, image processing, syntax highlighting, PTY, and shell operations via N-API",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",
@@ -56,11 +56,11 @@
 		}
 	},
 	"optionalDependencies": {
-		"@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.92.0",
-		"@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.92.0",
-		"@f5xc-salesdemos/pi-natives-darwin-x64": "18.92.0",
-		"@f5xc-salesdemos/pi-natives-darwin-arm64": "18.92.0",
-		"@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.92.0"
+		"@f5xc-salesdemos/pi-natives-linux-x64-gnu": "19.0.1",
+		"@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "19.0.1",
+		"@f5xc-salesdemos/pi-natives-darwin-x64": "19.0.1",
+		"@f5xc-salesdemos/pi-natives-darwin-arm64": "19.0.1",
+		"@f5xc-salesdemos/pi-natives-win32-x64-msvc": "19.0.1"
 	},
 	"files": [
 		"native",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/xcsh-stats",
-	"version": "18.92.0",
+	"version": "19.0.1",
 	"description": "Local observability dashboard for pi AI usage statistics",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/swarm-extension/package.json
+++ b/packages/swarm-extension/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/swarm-extension",
-	"version": "18.92.0",
+	"version": "19.0.1",
 	"description": "Swarm orchestration extension for xcsh",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Derek Rynd",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-tui",
-	"version": "18.92.0",
+	"version": "19.0.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-utils",
-	"version": "18.92.0",
+	"version": "19.0.1",
 	"description": "Shared utilities for pi packages",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",


### PR DESCRIPTION
Automated release PR generated by `scripts/release.ts`.

Bumps every public package and the Cargo workspace to `v19.0.1` and updates CHANGELOGs for the releasable commits since the last tag.

Once this PR squash-merges to `main`, `.github/workflows/tag-on-version-bump.yml` pushes the `v19.0.1` git tag, which triggers the downstream release chain (build → sign → publish).

_No commit list captured (manual invocation)._

See `docs-control`'s onboarding note "Release automation: release PR pattern" for the governance rationale.