### PR TITLE
feat(autoresearch): add CRUD and enrichment benchmark scripts

### DIFF
--- a/autoresearch-crud-phrases.yaml
+++ b/autoresearch-crud-phrases.yaml
@@ -1,0 +1,144 @@
+phrases:
+  # === healthcheck (4 phrases) ===
+  - phrase: "Create a healthcheck named ar-test-hc in namespace r-mordasiewicz that checks /healthz via HTTP every 10 seconds"
+    operation: create
+    resource: healthcheck
+    resource_name: ar-test-hc
+    api_path: healthchecks
+    expect_fields: [name, http_health_check]
+
+  - phrase: "Read the healthcheck named ar-test-hc from namespace r-mordasiewicz and show its configuration"
+    operation: read
+    resource: healthcheck
+    resource_name: ar-test-hc
+    api_path: healthchecks
+    expect_fields: [name]
+
+  - phrase: "Update the healthcheck ar-test-hc in namespace r-mordasiewicz to check every 15 seconds instead of 10"
+    operation: update
+    resource: healthcheck
+    resource_name: ar-test-hc
+    api_path: healthchecks
+    expect_fields: [interval]
+
+  - phrase: "Delete the healthcheck ar-test-hc from namespace r-mordasiewicz"
+    operation: delete
+    resource: healthcheck
+    resource_name: ar-test-hc
+    api_path: healthchecks
+
+  # === app_firewall (4 phrases) ===
+  - phrase: "Create an app firewall named ar-test-waf in namespace r-mordasiewicz with blocking mode"
+    operation: create
+    resource: app_firewall
+    resource_name: ar-test-waf
+    api_path: app_firewalls
+    expect_fields: [name, blocking]
+
+  - phrase: "Read the app firewall named ar-test-waf from namespace r-mordasiewicz"
+    operation: read
+    resource: app_firewall
+    resource_name: ar-test-waf
+    api_path: app_firewalls
+    expect_fields: [name]
+
+  - phrase: "Update app firewall ar-test-waf in namespace r-mordasiewicz to add description 'test firewall'"
+    operation: update
+    resource: app_firewall
+    resource_name: ar-test-waf
+    api_path: app_firewalls
+    expect_fields: [description]
+
+  - phrase: "Delete the app firewall ar-test-waf from namespace r-mordasiewicz"
+    operation: delete
+    resource: app_firewall
+    resource_name: ar-test-waf
+    api_path: app_firewalls
+
+  # === service_policy (4 phrases) ===
+  - phrase: "Create a service policy named ar-test-policy in namespace r-mordasiewicz that allows all traffic"
+    operation: create
+    resource: service_policy
+    resource_name: ar-test-policy
+    api_path: service_policies
+    expect_fields: [name]
+
+  - phrase: "Read the service policy named ar-test-policy from namespace r-mordasiewicz"
+    operation: read
+    resource: service_policy
+    resource_name: ar-test-policy
+    api_path: service_policies
+    expect_fields: [name]
+
+  - phrase: "Update service policy ar-test-policy in namespace r-mordasiewicz to add description 'test policy'"
+    operation: update
+    resource: service_policy
+    resource_name: ar-test-policy
+    api_path: service_policies
+    expect_fields: [description]
+
+  - phrase: "Delete the service policy ar-test-policy from namespace r-mordasiewicz"
+    operation: delete
+    resource: service_policy
+    resource_name: ar-test-policy
+    api_path: service_policies
+
+  # === namespace (4 phrases) ===
+  - phrase: "Create a namespace named ar-test-ns with label env=test"
+    operation: create
+    resource: namespace
+    resource_name: ar-test-ns
+    api_path: namespaces
+    namespace_scoped: false
+    expect_fields: [name]
+
+  - phrase: "Read the namespace named ar-test-ns"
+    operation: read
+    resource: namespace
+    resource_name: ar-test-ns
+    api_path: namespaces
+    namespace_scoped: false
+    expect_fields: [name]
+
+  - phrase: "Update namespace ar-test-ns to add label managed-by=autoresearch"
+    operation: update
+    resource: namespace
+    resource_name: ar-test-ns
+    api_path: namespaces
+    namespace_scoped: false
+    expect_fields: [labels]
+
+  - phrase: "Delete the namespace ar-test-ns"
+    operation: delete
+    resource: namespace
+    resource_name: ar-test-ns
+    api_path: namespaces
+    namespace_scoped: false
+
+  # === origin_pool (4 phrases) ===
+  - phrase: "Create an origin pool named ar-test-pool in namespace r-mordasiewicz with one origin server at 10.0.1.10 on port 8080"
+    operation: create
+    resource: origin_pool
+    resource_name: ar-test-pool
+    api_path: origin_pools
+    expect_fields: [name, origin_servers]
+
+  - phrase: "Read the origin pool named ar-test-pool from namespace r-mordasiewicz"
+    operation: read
+    resource: origin_pool
+    resource_name: ar-test-pool
+    api_path: origin_pools
+    expect_fields: [name]
+
+  - phrase: "Update origin pool ar-test-pool in namespace r-mordasiewicz to add description 'test pool'"
+    operation: update
+    resource: origin_pool
+    resource_name: ar-test-pool
+    api_path: origin_pools
+    expect_fields: [description]
+
+  - phrase: "Delete the origin pool ar-test-pool from namespace r-mordasiewicz"
+    operation: delete
+    resource: origin_pool
+    resource_name: ar-test-pool
+    api_path: origin_pools

--- a/autoresearch-crud.checks.sh
+++ b/autoresearch-crud.checks.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # provider/specs/xcsh/upstream/total set via python3 below
+set -euo pipefail
+
+# Cross-repo gate for CRUD autoresearch.
+# exit 0 = all failures are xcsh-local → continue optimizing
+# exit 1 = upstream fix needed → stop autoresearch with triage report
+
+if [ -n "${1:-}" ] && [ -d "$1" ]; then
+  RUN_DIR="$1"
+  if [ -f "${RUN_DIR}/benchmark.log" ]; then
+    OUTPUT=$(cat "${RUN_DIR}/benchmark.log")
+  elif [ -f "${RUN_DIR}/run.json" ]; then
+    OUTPUT=$(python3 -c "import json; d=json.load(open('${RUN_DIR}/run.json')); print(d.get('output',''))" 2>/dev/null || echo "")
+  else
+    OUTPUT=""
+  fi
+else
+  OUTPUT=$(cat)
+fi
+
+cross_repo=$(echo "${OUTPUT}" | grep "^ASI cross_repo_issues=" | sed 's/^ASI cross_repo_issues=//' || echo "{}")
+if [ -z "${cross_repo}" ] || [ "${cross_repo}" = "{}" ]; then
+  echo "CHECKS: No ASI cross_repo_issues found — passing"
+  exit 0
+fi
+
+provider=$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); v=d.get('terraform-provider-f5xc',0); assert isinstance(v,int); print(v)" "${cross_repo}")
+specs=$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); v=d.get('api-specs-enriched',0); assert isinstance(v,int); print(v)" "${cross_repo}")
+xcsh=$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); v=d.get('xcsh',0); assert isinstance(v,int); print(v)" "${cross_repo}")
+upstream=$(( provider + specs ))
+total=$(( provider + specs + xcsh ))
+
+if [ "${upstream}" -eq 0 ]; then
+  echo "CHECKS: All ${total} CRUD failures are xcsh-local — autoresearch can continue"
+  echo "  xcsh: ${xcsh} issues"
+  exit 0
+fi
+
+echo ""
+echo "============================================"
+echo " CRUD CROSS-REPO TRIAGE REPORT"
+echo "============================================"
+echo ""
+echo "Upstream fixes required — autoresearch STOPPED"
+echo ""
+echo "Issues by repository:"
+echo "  xcsh:                    ${xcsh} (local — can optimize)"
+echo "  terraform-provider-f5xc: ${provider} (upstream — needs fix)"
+echo "  api-specs-enriched:      ${specs} (upstream — needs fix)"
+echo ""
+
+failures=$(echo "${OUTPUT}" | grep "^ASI failures=" | sed 's/^ASI failures=//' || echo "[]")
+
+if [ "${specs}" -gt 0 ]; then
+  echo "--- api-specs-enriched fixes needed ---"
+  python3 -c "
+import json, sys
+failures = json.loads(sys.argv[1])
+for f in failures:
+    if f.get('fix_repo') == 'api-specs-enriched':
+        resource = f.get('resource', 'unknown')
+        error_type = f.get('error_type', 'UNKNOWN')
+        http_code = f.get('http_code', '?')
+        print(f'  [{error_type}] {resource} (HTTP {http_code})')
+        print(f'    Fix: api-specs-enriched/config/minimum_configs.yaml — check {resource} payload')
+" "${failures}"
+  echo ""
+fi
+
+if [ "${provider}" -gt 0 ]; then
+  echo "--- terraform-provider-f5xc fixes needed ---"
+  python3 -c "
+import json, sys
+failures = json.loads(sys.argv[1])
+for f in failures:
+    if f.get('fix_repo') == 'terraform-provider-f5xc':
+        resource = f.get('resource', 'unknown')
+        print(f'  {resource}: check docs/_llms-txt/resources/{resource}.txt')
+" "${failures}"
+  echo ""
+fi
+
+echo "--- Next steps ---"
+echo "1. Fix the upstream issues listed above"
+if [ "${specs}" -gt 0 ]; then
+  echo "2. In api-specs-enriched: make pipeline && merge"
+fi
+if [ "${provider}" -gt 0 ]; then
+  echo "2. In terraform-provider-f5xc: go run tools/generate-llms-txt.go && merge"
+fi
+echo "3. In xcsh: bun --cwd=packages/coding-agent run generate-terraform-index"
+echo "4. Restart autoresearch"
+echo ""
+
+exit 1

--- a/autoresearch-crud.md
+++ b/autoresearch-crud.md
@@ -1,0 +1,27 @@
+## Benchmark
+
+- command: bash autoresearch-crud.sh
+- primary metric: crud_score
+- metric unit: pct
+- direction: higher
+- secondary metrics:
+  - create_pass_rate
+  - read_pass_rate
+  - update_pass_rate
+  - delete_pass_rate
+
+## Files in Scope
+
+- .xcsh/skills/terraform-provider/
+
+## Off Limits
+
+- packages/coding-agent/src/autoresearch/
+
+## Constraints
+
+- always clean up ar-test-* resources in namespace r-mordasiewicz after each run
+- do not modify constraint_prober.py or validate_curl_examples.py directly
+- when checks fail, stop and fix the upstream repo indicated in triage report
+- requires F5XC_API_URL and F5XC_API_TOKEN in environment
+- after upstream fix: run `bun --cwd=packages/coding-agent run generate-terraform-index`, then restart

--- a/autoresearch-crud.sh
+++ b/autoresearch-crud.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CRUD Autoresearch Benchmark
+# For each phrase: ask xcsh to perform a CRUD operation, then verify via
+# direct F5XC API call. Scores based on whether the resource state
+# matches expectations after xcsh responds.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PHRASES_FILE="${PHRASES_FILE:-${SCRIPT_DIR}/autoresearch-crud-phrases.yaml}"
+WORK_DIR="/tmp/ar-crud-$$"
+API_URL="${F5XC_API_URL:-}"
+API_TOKEN="${F5XC_API_TOKEN:-}"
+NAMESPACE="r-mordasiewicz"
+
+if [ -z "${API_URL}" ] || [ -z "${API_TOKEN}" ]; then
+  echo "ERROR: F5XC_API_URL and F5XC_API_TOKEN must be set" >&2
+  exit 1
+fi
+
+cleanup() {
+  # Delete all ar-test-* resources across known resource types
+  for api_path in healthchecks app_firewalls service_policies origin_pools; do
+    resources=$(curl -sf \
+      -H "Authorization: APIToken ${API_TOKEN}" \
+      "${API_URL}/api/config/namespaces/${NAMESPACE}/${api_path}" 2>/dev/null \
+      | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+items=d.get('items',d.get('objects',[]))
+for i in items:
+    name=i.get('name','') or i.get('metadata',{}).get('name','')
+    if name.startswith('ar-test-'):
+        print(name)
+" 2>/dev/null || true)
+    for name in ${resources}; do
+      curl -sf -X DELETE \
+        -H "Authorization: APIToken ${API_TOKEN}" \
+        "${API_URL}/api/config/namespaces/${NAMESPACE}/${api_path}/${name}" \
+        >/dev/null 2>&1 || true
+    done
+  done
+  # Delete ar-test-ns namespace if it exists
+  curl -sf -X DELETE \
+    -H "Authorization: APIToken ${API_TOKEN}" \
+    "${API_URL}/api/web/namespaces/ar-test-ns" \
+    >/dev/null 2>&1 || true
+  rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+mkdir -p "${WORK_DIR}"
+
+# Parse YAML phrases to JSON
+phrases_file="${WORK_DIR}/phrases.json"
+python3 -c "
+import yaml, json
+with open('${PHRASES_FILE}') as f:
+    data = yaml.safe_load(f)
+json.dump(data['phrases'], open('${phrases_file}', 'w'))
+"
+
+phrase_count=$(python3 -c "import json; print(len(json.load(open('${phrases_file}'))))")
+echo "Running ${phrase_count} CRUD benchmark phrases..."
+echo ""
+
+# Accumulators
+total=0
+create_pass=0
+read_pass=0
+update_pass=0
+delete_pass=0
+xcsh_issues=0
+provider_issues=0
+spec_issues=0
+failures_json="[]"
+
+api_get() {
+  local path="$1"
+  curl -sf -o /dev/null -w "%{http_code}" \
+    -H "Authorization: APIToken ${API_TOKEN}" \
+    "${API_URL}${path}" 2>/dev/null || echo "000"
+}
+
+for idx in $(seq 0 $((phrase_count - 1))); do
+  ws="${WORK_DIR}/phrase_${idx}"
+  mkdir -p "${ws}"
+
+  # Extract phrase fields without eval
+  python3 -c "
+import json
+phrases = json.load(open('${phrases_file}'))
+p = phrases[${idx}]
+json.dump({
+    'phrase':           p['phrase'],
+    'operation':        p.get('operation',''),
+    'resource':         p.get('resource',''),
+    'resource_name':    p.get('resource_name',''),
+    'api_path':         p.get('api_path',''),
+    'namespace_scoped': p.get('namespace_scoped', True),
+}, open('${ws}/phrase.json', 'w'))
+"
+  phrase=$(python3 -c "import json; print(json.load(open('${ws}/phrase.json'))['phrase'])")
+  operation=$(python3 -c "import json; print(json.load(open('${ws}/phrase.json'))['operation'])")
+  resource=$(python3 -c "import json; print(json.load(open('${ws}/phrase.json'))['resource'])")
+  resource_name=$(python3 -c "import json; print(json.load(open('${ws}/phrase.json'))['resource_name'])")
+  api_path=$(python3 -c "import json; print(json.load(open('${ws}/phrase.json'))['api_path'])")
+  namespace_scoped=$(python3 -c "import json; print(json.load(open('${ws}/phrase.json'))['namespace_scoped'])")
+
+  total=$((total + 1))
+  echo "[$((idx + 1))/${phrase_count}] ${operation}/${resource}: ${phrase:0:70}..."
+
+  # Build API verify path
+  if [ "${namespace_scoped}" = "True" ]; then
+    verify_path="/api/config/namespaces/${NAMESPACE}/${api_path}/${resource_name}"
+  else
+    verify_path="/api/web/namespaces/${resource_name}"
+  fi
+
+  # Invoke xcsh
+  response=""
+  if command -v xcsh &>/dev/null; then
+    response=$(timeout 120 xcsh --print --no-session "${phrase}" 2>/dev/null || echo "")
+  else
+    echo "  SKIP: xcsh not in PATH"
+    continue
+  fi
+
+  # Verify via direct API call
+  http_code=$(api_get "${verify_path}")
+
+  op_pass=0
+  error_type="UNKNOWN"
+  fix_repo="xcsh"
+
+  case "${operation}" in
+    create|update)
+      if [ "${http_code}" = "200" ]; then
+        op_pass=1
+        case "${operation}" in
+          create) create_pass=$((create_pass + 1)) ;;
+          update) update_pass=$((update_pass + 1)) ;;
+        esac
+      else
+        if echo "${response}" | grep -qiE "xcsh_api|api call|POST|PUT"; then
+          error_type="API_REJECTED"
+          fix_repo="api-specs-enriched"
+          spec_issues=$((spec_issues + 1))
+        else
+          error_type="NO_API_CALL"
+          fix_repo="xcsh"
+          xcsh_issues=$((xcsh_issues + 1))
+        fi
+      fi
+      ;;
+    read)
+      if [ "${http_code}" = "200" ]; then
+        op_pass=1
+        read_pass=$((read_pass + 1))
+      else
+        error_type="READ_FAILED"
+        fix_repo="xcsh"
+        xcsh_issues=$((xcsh_issues + 1))
+      fi
+      ;;
+    delete)
+      # Wait briefly for deletion to propagate
+      sleep 2
+      http_code_after=$(api_get "${verify_path}")
+      if [ "${http_code_after}" = "404" ] || [ "${http_code_after}" = "000" ]; then
+        op_pass=1
+        delete_pass=$((delete_pass + 1))
+      else
+        error_type="DELETE_FAILED"
+        fix_repo="xcsh"
+        xcsh_issues=$((xcsh_issues + 1))
+      fi
+      ;;
+  esac
+
+  status="FAIL"
+  [ "${op_pass}" -eq 1 ] && status="PASS"
+  echo "  ${status}: ${operation} http=${http_code} fix=${fix_repo}"
+
+  if [ "${op_pass}" -eq 0 ]; then
+    phrase_json=$(python3 -c "import json,sys; print(json.dumps(sys.stdin.read().strip()))" <<< "${phrase}")
+    failures_json=$(python3 -c "
+import json, sys
+failures = json.loads(sys.argv[1])
+failures.append({
+    'phrase_idx': ${idx},
+    'phrase': json.loads(sys.argv[2]),
+    'operation': '${operation}',
+    'resource': '${resource}',
+    'resource_name': '${resource_name}',
+    'error_type': '${error_type}',
+    'http_code': '${http_code}',
+    'fix_repo': '${fix_repo}',
+})
+print(json.dumps(failures))
+" "${failures_json}" "${phrase_json}")
+  fi
+done
+
+echo ""
+if [ "${total}" -gt 0 ]; then
+  python3 -c "
+total = ${total}
+create_pass = ${create_pass}
+read_pass = ${read_pass}
+update_pass = ${update_pass}
+delete_pass = ${delete_pass}
+all_pass = create_pass + read_pass + update_pass + delete_pass
+crud_score = round(all_pass / total * 100, 1)
+create_rate = round(create_pass / max(1, total // 4) * 100, 1)
+read_rate = round(read_pass / max(1, total // 4) * 100, 1)
+update_rate = round(update_pass / max(1, total // 4) * 100, 1)
+delete_rate = round(delete_pass / max(1, total // 4) * 100, 1)
+print(f'METRIC crud_score={crud_score}')
+print(f'METRIC create_pass_rate={create_rate}')
+print(f'METRIC read_pass_rate={read_rate}')
+print(f'METRIC update_pass_rate={update_rate}')
+print(f'METRIC delete_pass_rate={delete_rate}')
+"
+fi
+
+cross_repo_json=$(python3 -c "
+import json
+print(json.dumps({'xcsh': ${xcsh_issues}, 'terraform-provider-f5xc': ${provider_issues}, 'api-specs-enriched': ${spec_issues}}))
+")
+echo "ASI failures=${failures_json}"
+echo "ASI cross_repo_issues=${cross_repo_json}"

--- a/autoresearch-enrichment.checks.sh
+++ b/autoresearch-enrichment.checks.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # provider/specs/xcsh set via python3 below
+set -euo pipefail
+
+# Cross-repo gate for enrichment autoresearch.
+# exit 0 = all issues are xcsh-local → continue
+# exit 1 = upstream fix needed → stop with triage
+
+if [ -n "${1:-}" ] && [ -d "$1" ]; then
+  RUN_DIR="$1"
+  if [ -f "${RUN_DIR}/benchmark.log" ]; then
+    OUTPUT=$(cat "${RUN_DIR}/benchmark.log")
+  elif [ -f "${RUN_DIR}/run.json" ]; then
+    OUTPUT=$(python3 -c "import json; d=json.load(open('${RUN_DIR}/run.json')); print(d.get('output',''))" 2>/dev/null || echo "")
+  else
+    OUTPUT=""
+  fi
+else
+  OUTPUT=$(cat)
+fi
+
+cross_repo=$(echo "${OUTPUT}" | grep "^ASI cross_repo_issues=" | sed 's/^ASI cross_repo_issues=//' || echo "{}")
+if [ -z "${cross_repo}" ] || [ "${cross_repo}" = "{}" ]; then
+  echo "CHECKS: No ASI cross_repo_issues found — passing"
+  exit 0
+fi
+
+provider=$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); v=d.get('terraform-provider-f5xc',0); assert isinstance(v,int); print(v)" "${cross_repo}")
+specs=$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); v=d.get('api-specs-enriched',0); assert isinstance(v,int); print(v)" "${cross_repo}")
+xcsh=$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); v=d.get('xcsh',0); assert isinstance(v,int); print(v)" "${cross_repo}")
+upstream=$(( provider + specs ))
+total=$(( provider + specs + xcsh ))
+
+if [ "${upstream}" -eq 0 ]; then
+  echo "CHECKS: All ${total} enrichment issues are xcsh-local — continue"
+  exit 0
+fi
+
+echo ""
+echo "============================================"
+echo " ENRICHMENT CROSS-REPO TRIAGE REPORT"
+echo "============================================"
+echo ""
+echo "Upstream fixes required — autoresearch STOPPED"
+echo ""
+echo "Issues by repository:"
+echo "  xcsh:                    ${xcsh} (local)"
+echo "  terraform-provider-f5xc: ${provider} (upstream)"
+echo "  api-specs-enriched:      ${specs} (upstream)"
+echo ""
+
+mismatches=$(echo "${OUTPUT}" | grep "^ASI mismatches=" | sed 's/^ASI mismatches=//' || echo "[]")
+
+if [ "${provider}" -gt 0 ]; then
+  echo "--- terraform-provider-f5xc fixes needed ---"
+  python3 -c "
+import json, sys
+mismatches = json.loads(sys.argv[1])
+for m in mismatches:
+    if m.get('fix_repo') == 'terraform-provider-f5xc':
+        resource = m.get('resource','?')
+        issue = m.get('issue','?')
+        probed = m.get('probed','?')
+        embedded = m.get('embedded','?')
+        print(f'  [{issue}] {resource}')
+        print(f'    Probed: {probed}')
+        print(f'    Embedded: {embedded}')
+        if 'oneof' in issue:
+            print(f'    Fix: terraform-provider-f5xc/tools/generate-llms-txt.go — check OneOf extraction for {resource}')
+        else:
+            print(f'    Fix: terraform-provider-f5xc/docs/_llms-txt/resources/{resource}.txt')
+" "${mismatches}"
+  echo ""
+fi
+
+if [ "${specs}" -gt 0 ]; then
+  echo "--- api-specs-enriched fixes needed ---"
+  python3 -c "
+import json, sys
+mismatches = json.loads(sys.argv[1])
+for m in mismatches:
+    if m.get('fix_repo') == 'api-specs-enriched':
+        resource = m.get('resource','?')
+        issue = m.get('issue','?')
+        print(f'  [{issue}] {resource}')
+        print(f'    Fix: api-specs-enriched/config/constraint_patterns.yaml or validation_schema.yaml')
+" "${mismatches}"
+  echo ""
+fi
+
+echo "--- Next steps ---"
+if [ "${specs}" -gt 0 ]; then
+  echo "1. Fix api-specs-enriched/config/ files, then: make pipeline && merge"
+fi
+if [ "${provider}" -gt 0 ]; then
+  echo "1. Fix terraform-provider-f5xc/tools/generate-llms-txt.go, then: go run tools/generate-llms-txt.go && merge"
+fi
+echo "2. In xcsh: bun --cwd=packages/coding-agent run generate-terraform-index"
+echo "3. Restart autoresearch"
+echo ""
+
+exit 1

--- a/autoresearch-enrichment.md
+++ b/autoresearch-enrichment.md
@@ -1,0 +1,26 @@
+## Benchmark
+
+- command: bash autoresearch-enrichment.sh
+- primary metric: enrichment_score
+- metric unit: pct
+- direction: higher
+- secondary metrics:
+  - constraint_accuracy
+  - field_coverage
+  - oneof_accuracy
+
+## Files in Scope
+
+- packages/coding-agent/src/internal-urls/terraform-index.generated.ts
+- packages/coding-agent/scripts/generate-terraform-index.ts
+
+## Off Limits
+
+- packages/coding-agent/src/autoresearch/
+
+## Constraints
+
+- do not modify constraint_prober.py directly
+- requires F5XC_API_URL and F5XC_API_TOKEN in environment (namespace: r-mordasiewicz)
+- when checks fail, route to the correct upstream repo per triage report
+- after upstream fix: run `bun --cwd=packages/coding-agent run generate-terraform-index`, then restart

--- a/autoresearch-enrichment.sh
+++ b/autoresearch-enrichment.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enrichment Accuracy Autoresearch Benchmark
+# Runs constraint_prober.py against live API to discover real field constraints,
+# then compares them to what's embedded in xcsh's terraform-index.generated.ts.
+# Scores how accurately the embedded index reflects live API constraints.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_SPECS_DIR="${SCRIPT_DIR}/../api-specs-enriched"
+PROBER="${API_SPECS_DIR}/scripts/discovery/constraint_prober.py"
+INDEX_TS="${SCRIPT_DIR}/packages/coding-agent/src/internal-urls/terraform-index.generated.ts"
+WORK_DIR="/tmp/ar-enrichment-$$"
+RESOURCES="healthcheck origin_pool app_firewall service_policy"
+
+if [ -z "${F5XC_API_URL:-}" ] || [ -z "${F5XC_API_TOKEN:-}" ]; then
+  echo "ERROR: F5XC_API_URL and F5XC_API_TOKEN must be set" >&2
+  exit 1
+fi
+
+if [ ! -f "${PROBER}" ]; then
+  echo "ERROR: constraint_prober.py not found at ${PROBER}" >&2
+  exit 1
+fi
+
+cleanup() { rm -rf "${WORK_DIR}"; }
+trap cleanup EXIT
+mkdir -p "${WORK_DIR}"
+
+echo "Running enrichment accuracy benchmark..."
+echo "Resources: ${RESOURCES}"
+echo ""
+
+# Run constraint_prober for each resource
+for resource in ${RESOURCES}; do
+  output_file="${WORK_DIR}/${resource}.json"
+  echo "Probing ${resource}..."
+  (cd "${API_SPECS_DIR}" && \
+    F5XC_API_URL="${F5XC_API_URL}" \
+    F5XC_API_TOKEN="${F5XC_API_TOKEN}" \
+    F5XC_NAMESPACE="r-mordasiewicz" \
+    python3 -m scripts.discovery.constraint_prober \
+      --resource "${resource}" \
+      --output "${output_file}" \
+      --rate 3.0 2>/dev/null) \
+    && echo "  ✓ ${resource} probed" \
+    || echo "  ✗ ${resource} probe failed (using empty result)"
+  # Create empty result if probe failed
+  [ -f "${output_file}" ] || echo '{"fields_probed":[],"oneof_groups":[]}' > "${output_file}"
+done
+
+echo ""
+
+# Extract terraform index data for comparison
+index_json="${WORK_DIR}/index_extract.json"
+python3 -c "
+import re, json, sys
+
+with open(sys.argv[1]) as f:
+    content = f.read()
+
+# Strip the TS wrapper to get the JSON
+match = re.search(r'TERRAFORM_INDEX:\s*TerraformIndex\s*=\s*(\{.*\})\s*as const', content, re.DOTALL)
+if not match:
+    print(json.dumps({}))
+    sys.exit(0)
+
+try:
+    data = json.loads(match.group(1))
+    resources = data.get('resources', {})
+    output = {}
+    for name, res in resources.items():
+        output[name] = {
+            'required': res.get('required', []),
+            'oneof_groups': [g.get('fields', []) for g in res.get('oneof_groups', [])],
+            'server_defaults': res.get('server_defaults', []),
+        }
+    print(json.dumps(output))
+except Exception:
+    print(json.dumps({}))
+" "${INDEX_TS}" > "${index_json}"
+
+# Score: compare probed vs embedded
+results=$(python3 -c "
+import json, sys
+
+index = json.load(open(sys.argv[1]))
+resources = sys.argv[2].split()
+work_dir = sys.argv[3]
+
+total_checks = 0
+passed_checks = 0
+field_total = 0
+field_matched = 0
+oneof_total = 0
+oneof_matched = 0
+mismatches = []
+
+for resource in resources:
+    probed_path = f'{work_dir}/{resource}.json'
+    try:
+        probed = json.load(open(probed_path))
+    except Exception:
+        probed = {}
+
+    embedded = index.get(resource, {})
+
+    # Check field coverage: required fields discovered vs embedded
+    probed_required = set(probed.get('required_fields', []))
+    embedded_required = set(embedded.get('required', []))
+    for field in probed_required:
+        field_total += 1
+        if field in embedded_required:
+            field_matched += 1
+        else:
+            mismatches.append({
+                'resource': resource,
+                'field': field,
+                'issue': 'required_field_missing_from_index',
+                'probed': str(field),
+                'embedded': 'not present',
+                'fix_repo': 'terraform-provider-f5xc',
+            })
+
+    # Check oneOf group count
+    probed_oneof_count = len(probed.get('oneof_groups', []))
+    embedded_oneof_count = len(embedded.get('oneof_groups', []))
+    oneof_total += 1
+    if probed_oneof_count == 0 or abs(probed_oneof_count - embedded_oneof_count) <= 2:
+        oneof_matched += 1
+    else:
+        mismatches.append({
+            'resource': resource,
+            'field': 'oneof_groups',
+            'issue': 'oneof_count_mismatch',
+            'probed': probed_oneof_count,
+            'embedded': embedded_oneof_count,
+            'fix_repo': 'terraform-provider-f5xc' if embedded_oneof_count < probed_oneof_count else 'api-specs-enriched',
+        })
+
+    # General check: resource present in index at all
+    total_checks += 1
+    if resource in index:
+        passed_checks += 1
+    else:
+        mismatches.append({
+            'resource': resource,
+            'field': 'resource',
+            'issue': 'resource_missing_from_index',
+            'probed': 'exists in API',
+            'embedded': 'not in terraform index',
+            'fix_repo': 'terraform-provider-f5xc',
+        })
+
+constraint_accuracy = round(field_matched / max(1, field_total) * 100, 1)
+field_coverage = round(field_matched / max(1, field_total) * 100, 1)
+oneof_accuracy = round(oneof_matched / max(1, oneof_total) * 100, 1)
+enrichment_score = round((passed_checks / max(1, total_checks) * 0.4 +
+                          field_matched / max(1, field_total) * 0.3 +
+                          oneof_matched / max(1, oneof_total) * 0.3) * 100, 1)
+
+xcsh_issues = sum(1 for m in mismatches if m['fix_repo'] == 'xcsh')
+provider_issues = sum(1 for m in mismatches if m['fix_repo'] == 'terraform-provider-f5xc')
+spec_issues = sum(1 for m in mismatches if m['fix_repo'] == 'api-specs-enriched')
+
+print(json.dumps({
+    'enrichment_score': enrichment_score,
+    'constraint_accuracy': constraint_accuracy,
+    'field_coverage': field_coverage,
+    'oneof_accuracy': oneof_accuracy,
+    'mismatches': mismatches,
+    'cross_repo': {'xcsh': xcsh_issues, 'terraform-provider-f5xc': provider_issues, 'api-specs-enriched': spec_issues},
+}))
+" "${index_json}" "${RESOURCES}" "${WORK_DIR}")
+
+# Emit METRIC and ASI lines
+python3 -c "
+import json, sys
+r = json.loads(sys.argv[1])
+print(f'METRIC enrichment_score={r[\"enrichment_score\"]}')
+print(f'METRIC constraint_accuracy={r[\"constraint_accuracy\"]}')
+print(f'METRIC field_coverage={r[\"field_coverage\"]}')
+print(f'METRIC oneof_accuracy={r[\"oneof_accuracy\"]}')
+print(f'ASI mismatches={json.dumps(r[\"mismatches\"])}')
+print(f'ASI cross_repo_issues={json.dumps(r[\"cross_repo\"])}')
+" "${results}"


### PR DESCRIPTION
Closes #1112

## Summary

Adds two new independent autoresearch benchmarks to expand the optimization system beyond terraform-generation-only:

- **CRUD benchmark** (`autoresearch-crud.md` / `autoresearch-crud.sh`): pipes CRUD phrases through xcsh, verifies real resource state in staging API namespace `r-mordasiewicz`, cleans up `ar-test-*` resources, scores by operation type
- **Enrichment benchmark** (`autoresearch-enrichment.md` / `autoresearch-enrichment.sh`): runs `constraint_prober.py` against live API, compares to `terraform-index.generated.ts`, scores constraint accuracy

Each benchmark has its own `checks.sh` cross-repo gate that stops autoresearch and routes to the correct upstream repo when upstream fixes are needed.