### PR TITLE
feat(plugins): normalize plugin display names — strip f5xc- prefix and -status suffix

### DIFF
--- a/packages/coding-agent/src/modes/components/plugins/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/plugins/state-manager.ts
@@ -3,10 +3,17 @@ import type { MarketplaceManager } from "../../../extensibility/plugins/marketpl
 import type { InstalledPluginSummary, MarketplacePluginEntry } from "../../../extensibility/plugins/marketplace/types";
 import type { DashboardPlugin, PluginDashboardState, PluginTab, PluginTabId } from "./types";
 
+export function normalizePluginDisplayName(name: string): string {
+	let result = name;
+	if (result.startsWith("f5xc-")) result = result.slice(5);
+	if (result.length > 0 && result.endsWith("-status")) result = result.slice(0, -7);
+	return result || name;
+}
+
 function npmToDashboard(npm: { name: string; version: string; enabled: boolean }): DashboardPlugin {
 	return {
 		id: `npm:${npm.name}`,
-		name: npm.name,
+		name: normalizePluginDisplayName(npm.name),
 		source: "npm",
 		version: npm.version,
 		installed: true,
@@ -24,7 +31,7 @@ function installedToDashboard(summary: InstalledPluginSummary, updateMap: Map<st
 
 	return {
 		id: summary.id,
-		name,
+		name: normalizePluginDisplayName(name),
 		marketplace,
 		source: "marketplace",
 		scope: summary.scope,
@@ -40,7 +47,7 @@ function installedToDashboard(summary: InstalledPluginSummary, updateMap: Map<st
 function catalogToDashboard(entry: MarketplacePluginEntry, marketplace: string): DashboardPlugin {
 	return {
 		id: `${entry.name}@${marketplace}`,
-		name: entry.name,
+		name: normalizePluginDisplayName(entry.name),
 		marketplace,
 		source: "marketplace",
 		version: entry.version,

--- a/packages/coding-agent/test/plugin-display-name.test.ts
+++ b/packages/coding-agent/test/plugin-display-name.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import { normalizePluginDisplayName } from "@f5xc-salesdemos/xcsh/modes/components/plugins/state-manager";
+
+describe("normalizePluginDisplayName", () => {
+	describe("f5xc- prefix stripping", () => {
+		it("strips f5xc- prefix", () => {
+			expect(normalizePluginDisplayName("f5xc-brand")).toBe("brand");
+		});
+
+		it("strips f5xc- prefix from multi-segment name", () => {
+			expect(normalizePluginDisplayName("f5xc-docs-pipeline")).toBe("docs-pipeline");
+		});
+
+		it("strips f5xc- prefix from multi-segment name with more parts", () => {
+			expect(normalizePluginDisplayName("f5xc-sales-engineer")).toBe("sales-engineer");
+		});
+
+		it("strips f5xc- prefix from name that also ends in -status", () => {
+			expect(normalizePluginDisplayName("f5xc-cloudstatus")).toBe("cloudstatus");
+		});
+	});
+
+	describe("-status suffix stripping", () => {
+		it("strips -status suffix", () => {
+			expect(normalizePluginDisplayName("aws-status")).toBe("aws");
+		});
+
+		it("strips -status suffix from gcloud", () => {
+			expect(normalizePluginDisplayName("gcloud-status")).toBe("gcloud");
+		});
+
+		it("strips -status suffix from azure", () => {
+			expect(normalizePluginDisplayName("azure-status")).toBe("azure");
+		});
+	});
+
+	describe("no transformation", () => {
+		it("leaves plain names unchanged", () => {
+			expect(normalizePluginDisplayName("bash-lsp")).toBe("bash-lsp");
+		});
+
+		it("leaves css-lsp unchanged", () => {
+			expect(normalizePluginDisplayName("css-lsp")).toBe("css-lsp");
+		});
+
+		it("leaves eslint-lsp unchanged", () => {
+			expect(normalizePluginDisplayName("eslint-lsp")).toBe("eslint-lsp");
+		});
+
+		it("does not strip -status when it is the entire name", () => {
+			expect(normalizePluginDisplayName("status")).toBe("status");
+		});
+
+		it("does not treat partial prefix match as f5xc-", () => {
+			expect(normalizePluginDisplayName("f5xc")).toBe("f5xc");
+		});
+	});
+
+	describe("edge cases", () => {
+		it("strips both prefix and suffix when both present: f5xc-foo-status → foo", () => {
+			expect(normalizePluginDisplayName("f5xc-foo-status")).toBe("foo");
+		});
+
+		it("handles f5xc- with single segment after stripping prefix", () => {
+			expect(normalizePluginDisplayName("f5xc-platform")).toBe("platform");
+		});
+
+		it("handles f5xc- prefix only (trailing dash removed)", () => {
+			expect(normalizePluginDisplayName("f5xc-meddpicc")).toBe("meddpicc");
+		});
+
+		it("handles f5xc-github-ops", () => {
+			expect(normalizePluginDisplayName("f5xc-github-ops")).toBe("github-ops");
+		});
+	});
+});


### PR DESCRIPTION
Closes #1113

## Summary
- Add `normalizePluginDisplayName()` utility that strips `f5xc-` prefix and `-status` suffix
- Normalize `name` field directly on `DashboardPlugin` — no backwards-compat `displayName` shim
- 16 unit tests covering all marketplace plugin names plus edge cases
- Search and sort use the normalized name

## Test plan
- [x] `bun test packages/coding-agent/test/plugin-display-name.test.ts` — 16/16 pass
- [x] `bun test packages/coding-agent/test/` — 4564 pass, 0 fail
- [x] `bun run ci:check:full` — zero type errors
- [x] Verified normalized output: `aws`, `azure`, `brand`, `gcloud`, `github-ops`, etc.