### PR TITLE
feat(autoresearch): add http_loadbalancer to CRUD and enrichment benchmarks

### DIFF
--- a/autoresearch-crud-phrases.yaml
+++ b/autoresearch-crud-phrases.yaml
@@ -142,3 +142,40 @@ phrases:
     resource: origin_pool
     resource_name: ar-test-pool
     api_path: origin_pools
+
+  # === http_loadbalancer (5 phrases: setup pool + CRUD) ===
+  # Phrase 21: create a dedicated origin pool for the LB (setup step, counted as create)
+  - phrase: "Create an origin pool named ar-test-lb-pool in namespace r-mordasiewicz with one origin server at 10.0.1.20 on port 80"
+    operation: create
+    resource: origin_pool
+    resource_name: ar-test-lb-pool
+    api_path: origin_pools
+    expect_fields: [name, origin_servers]
+
+  # Phrase 22: create LB referencing the pool (tests dependency chaining)
+  - phrase: "Create an HTTP load balancer named ar-test-lb in namespace r-mordasiewicz on domain ar-test.example.com routing to origin pool ar-test-lb-pool"
+    operation: create
+    resource: http_loadbalancer
+    resource_name: ar-test-lb
+    api_path: http_loadbalancers
+    expect_fields: [name, domains]
+
+  - phrase: "Read the HTTP load balancer named ar-test-lb from namespace r-mordasiewicz"
+    operation: read
+    resource: http_loadbalancer
+    resource_name: ar-test-lb
+    api_path: http_loadbalancers
+    expect_fields: [name]
+
+  - phrase: "Update the HTTP load balancer ar-test-lb in namespace r-mordasiewicz to add description 'test lb'"
+    operation: update
+    resource: http_loadbalancer
+    resource_name: ar-test-lb
+    api_path: http_loadbalancers
+    expect_fields: [description]
+
+  - phrase: "Delete the HTTP load balancer ar-test-lb from namespace r-mordasiewicz"
+    operation: delete
+    resource: http_loadbalancer
+    resource_name: ar-test-lb
+    api_path: http_loadbalancers

--- a/autoresearch-crud.sh
+++ b/autoresearch-crud.sh
@@ -20,7 +20,7 @@ fi
 
 cleanup() {
   # Delete all ar-test-* resources across known resource types
-  for api_path in healthchecks app_firewalls service_policys origin_pools; do
+  for api_path in healthchecks app_firewalls service_policys origin_pools http_loadbalancers; do
     resources=$(curl -sf \
       -H "Authorization: APIToken ${API_TOKEN}" \
       "${API_URL}/api/config/namespaces/${NAMESPACE}/${api_path}" 2>/dev/null \

--- a/autoresearch-enrichment.sh
+++ b/autoresearch-enrichment.sh
@@ -11,7 +11,7 @@ API_SPECS_DIR="${SCRIPT_DIR}/../api-specs-enriched"
 PROBER="${API_SPECS_DIR}/scripts/discovery/constraint_prober.py"
 INDEX_TS="${SCRIPT_DIR}/packages/coding-agent/src/internal-urls/terraform-index.generated.ts"
 WORK_DIR="/tmp/ar-enrichment-$$"
-RESOURCES="healthcheck origin_pool app_firewall service_policy"
+RESOURCES="healthcheck origin_pool app_firewall service_policy http_loadbalancer"
 
 if [ -z "${F5XC_API_URL:-}" ] || [ -z "${F5XC_API_TOKEN:-}" ]; then
   echo "ERROR: F5XC_API_URL and F5XC_API_TOKEN must be set" >&2


### PR DESCRIPTION
Closes #1119

## Summary

Expands the autoresearch benchmark suite to include `http_loadbalancer` — the most complex F5XC resource and the primary one users deploy.

**autoresearch-crud-phrases.yaml** — 5 new phrases (20→25 total):
- Phrase 21: create prerequisite origin pool `ar-test-lb-pool` (setup)
- Phrase 22: create `http_loadbalancer` ar-test-lb on `ar-test.example.com` routing to `ar-test-lb-pool` (dependency chaining test)
- Phrases 23-25: read / update / delete the LB

**autoresearch-crud.sh** — add `http_loadbalancers` to cleanup loop

**autoresearch-enrichment.sh** — add `http_loadbalancer` to RESOURCES (4→5 resources)

## Baseline benchmark results (staging, namespace r-mordasiewicz)

| Metric | Before | After |
|--------|--------|-------|
| crud_score | 100.0% | **88.0%** |
| enrichment_score | 100.0% | **100.0%** |
| create_pass_rate | 100% | 100% |
| read_pass_rate | 100% | 83.3% |
| update_pass_rate | 100% | 83.3% |
| delete_pass_rate | 100% | 100% |

**LB failures (all `fix_repo=xcsh`, `error_type=NO_API_CALL`):**
- Phrase 22: create http_loadbalancer — xcsh does not produce a successful LB create
- Phrases 23-24: read/update cascade-fail since create failed
- Phrase 25 (delete): PASS — resource absent = 404 = deleted

The enrichment benchmark remains 100% — the terraform index already correctly documents all 20 LB OneOf groups and required fields (`name`, `namespace`, `domains`).

## What autoresearch will optimize

xcsh's http_loadbalancer skill needs to generate terraform that:
1. Sets `domains` correctly
2. Wires the LB to the existing origin pool by name
3. Satisfies one of the 20 OneOf groups (e.g. `advertise_on_public_default_vip`, `http`, routing rules)

crud_score 88% → 100% is the autoresearch target.

## Test plan
- [ ] `bash autoresearch-crud.sh` — baseline crud_score=88.0%
- [ ] `bash autoresearch-enrichment.sh` — enrichment_score=100.0%

🤖 Generated with [Claude Code](https://claude.com/claude-code)