### PR TITLE
fix(autoresearch): fix LB skill template and api_get double-write bug

### DIFF
--- a/.xcsh/skills/terraform-provider/SKILL.md
+++ b/.xcsh/skills/terraform-provider/SKILL.md
@@ -5,8 +5,8 @@ description: |
   Every response MUST include a ```terraform code block. Output code first. Do not run terraform commands.
   Provider block: terraform { required_providers { f5xc = { source = "f5xc-salesdemos/f5xc" } } }
   Templates (adapt name/namespace/fields per request):
-  http_loadbalancer: resource "f5xc_http_loadbalancer" "example" { name="example" namespace="default" domains=["app.example.com"] advertise_on_public_default_vip {} no_challenge {} round_robin {} https_auto_cert { http_redirect=true default_header {} tls_config { default_security {} } no_mtls {} } }
-  WAF: add app_firewall { name="waf" namespace="ns" }. Import: terraform import f5xc_http_loadbalancer.example ns/name
+  http_loadbalancer: resource "f5xc_http_loadbalancer" "example" { name="example" namespace="default" domains=["app.example.com"] advertise_on_public_default_vip {} http { port=80 } default_route_pools { pool { name="origin-pool-name" namespace="default" } weight=1 priority=1 } }
+  Pool ref: set pool.name to existing origin pool name in same namespace. HTTPS: replace http { port=80 } with https_auto_cert { http_redirect=true default_header {} tls_config { default_security {} } no_mtls {} }. WAF: add disable_waf {} or app_firewall { name="waf" namespace="ns" }. Import: terraform import f5xc_http_loadbalancer.example ns/name
   origin_pool: resource "f5xc_origin_pool" "example" { name="example" namespace="default" port=8080 origin_servers { public_ip { ip="10.0.1.10" } } loadbalancer_algorithm="ROUND_ROBIN" endpoint_selection="LOCAL_PREFERRED" }
   Healthcheck ref: add healthcheck { name="hc" namespace="ns" }. Import: terraform import f5xc_origin_pool.example ns/name
   healthcheck: resource "f5xc_healthcheck" "example" { name="example" namespace="default" http_health_check { path="/healthz" } timeout=3 interval=10 unhealthy_threshold=3 healthy_threshold=3 }

--- a/autoresearch-crud.sh
+++ b/autoresearch-crud.sh
@@ -76,10 +76,10 @@ failures_json="[]"
 
 api_get() {
   local path="$1"
-  # Use -s without -f: -f exits non-zero on 4xx which appends "000" to the status code
+  # -w writes "000" on network failure; || true prevents double-write from || echo "000"
   curl -s -o /dev/null -w "%{http_code}" \
     -H "Authorization: APIToken ${API_TOKEN}" \
-    "${API_URL}${path}" 2>/dev/null || echo "000"
+    "${API_URL}${path}" 2>/dev/null || true
 }
 
 for idx in $(seq 0 $((phrase_count - 1))); do


### PR DESCRIPTION
## Summary

- **SKILL.md**: http_loadbalancer template was using `https_auto_cert` (breaks on test domains) with no `default_route_pools` (LB has nowhere to route). Fixed to `http{port=80}` + `default_route_pools` based on the acceptance-test-verified `with-origin-pool.tf` example.
- **autoresearch-crud.sh**: `api_get` used `|| echo "000"` which doubled the "000" curl writes on network failure (curl `-w "%{http_code}"` writes "000" + exits non-zero → echo adds "000" = "000000"). Fixed to `|| true`.

## Verification

Run 2 against staging API (nferreira.staging.volterra.us, ns r-mordasiewicz):
- Phrases 22-25 (http_loadbalancer CRUD): **all PASS** (was all FAIL before)
- api_get now returns clean 3-digit codes

## Test plan

- [ ] CI passes
- [ ] Run `autoresearch-crud.sh` against staging: phrases 22-25 pass (http_loadbalancer create/read/update/delete)
- [ ] Confirm api_get returns "000" (not "000000") on network failure

Closes #1122