### PR TITLE
fix(autoresearch): use allow_all_requests in service_policy skill template

### DIFF
--- a/.xcsh/skills/terraform-provider/SKILL.md
+++ b/.xcsh/skills/terraform-provider/SKILL.md
@@ -13,8 +13,8 @@ description: |
   TCP: replace http_health_check with tcp_health_check {}. Import: terraform import f5xc_healthcheck.example ns/name
   app_firewall: resource "f5xc_app_firewall" "example" { name="example" namespace="default" blocking {} }
   Import: terraform import f5xc_app_firewall.example ns/name
-  service_policy: resource "f5xc_service_policy" "example" { name="example" namespace="default" rule_list { rules { metadata { name="allow-internal" } spec { action="ALLOW" any_client {} any_ip {} } } } any_server {} }
-  Import: terraform import f5xc_service_policy.example ns/name
+  service_policy: resource "f5xc_service_policy" "example" { name="example" namespace="default" allow_all_requests {} any_server {} }
+  Deny all: replace allow_all_requests {} with deny_all_requests {}. Custom rules: use rule_list { rules { metadata { name="rule" } spec { action="ALLOW" any_client {} any_ip {} } } }. Import: terraform import f5xc_service_policy.example ns/name
   certificate: resource "f5xc_certificate" "example" { name="example" namespace="default" certificate_url="string:///BASE64_CERT" private_key { blindfold_secret_info { location="string:///BASE64_KEY" } } }
   Import: terraform import f5xc_certificate.example ns/name
   rate_limiter_policy: resource "f5xc_rate_limiter_policy" "example" { name="example" namespace="default" any_server {} }


### PR DESCRIPTION
## Summary

Updates the terraform-provider SKILL.md service_policy template from the verbose `rule_list` pattern to the simpler `allow_all_requests {}`.

**Before:**
```hcl
rule_list { rules { metadata { name="allow-internal" } spec { action="ALLOW" any_client {} any_ip {} } } } any_server {}
```

**After:**
```hcl
allow_all_requests {} any_server {}
```

## Why

- `allow_all_requests {}` is a valid terraform attribute (confirmed in provider acceptance tests)
- xcsh's f5xc-platform plugin already uses this concept for direct API calls — aligning the terraform template with it reduces LLM decision variance
- The old template's `name="allow-internal"` label confused the LLM when the phrase says "allows all traffic"
- Custom rules and deny-all patterns are documented in the follow-up note line

## Companion PR

terraform-provider-f5xc #725 — fixes the index generator so the JSON index also includes `allow_all_requests`/`deny_all_requests` in the service_policy oneOf group.

## Test plan

- [ ] CI passes
- [ ] CRUD benchmark service_policy phrases (9-12) pass consistently

Closes #1125