### PR TITLE
feat: api-specs autoresearch benchmark (curl_validity + spec_accuracy)

### DIFF
--- a/autoresearch-api-specs.checks.sh
+++ b/autoresearch-api-specs.checks.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154
+set -euo pipefail
+
+# Cross-repo gate for api-specs autoresearch.
+# Reads ASI gaps from stdin or ${RUN_DIR}/benchmark.log.
+# For each new gap: creates a GitHub issue in api-specs-enriched (deduplicates).
+# For curl_example_fails gaps: opens a draft PR stub.
+# exit 0 = no gaps → autoresearch loop continues
+# exit 1 = gaps exist → autoresearch stops
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_SPECS_DIR="${SCRIPT_DIR}/../api-specs-enriched"
+
+# ── Read input ────────────────────────────────────────────────────────────────
+if [ -n "${1:-}" ] && [ -d "$1" ]; then
+  RUN_DIR="$1"
+  if [ -f "${RUN_DIR}/benchmark.log" ]; then
+    OUTPUT=$(cat "${RUN_DIR}/benchmark.log")
+  elif [ -f "${RUN_DIR}/run.json" ]; then
+    OUTPUT=$(python3 -c "import json; d=json.load(open('${RUN_DIR}/run.json')); print(d.get('output',''))" 2>/dev/null || echo "")
+  else
+    OUTPUT=""
+  fi
+else
+  OUTPUT=$(cat)
+fi
+
+# ── Parse gaps ────────────────────────────────────────────────────────────────
+gaps=$(echo "${OUTPUT}" | grep "^ASI gaps=" | sed 's/^ASI gaps=//' || echo "[]")
+if [ -z "${gaps}" ] || [ "${gaps}" = "[]" ]; then
+  echo "CHECKS: No gaps found — api-specs-enriched is accurate"
+  exit 0
+fi
+
+gap_count=$(python3 -c "import json,sys; print(len(json.loads(sys.argv[1])))" "${gaps}")
+echo ""
+echo "============================================"
+echo " API-SPECS AUTORESEARCH TRIAGE REPORT"
+echo "============================================"
+echo ""
+echo "Gaps found: ${gap_count}"
+echo ""
+
+# ── GitHub org detection ──────────────────────────────────────────────────────
+GITHUB_ORG=""
+if command -v gh &>/dev/null; then
+  GITHUB_ORG=$(cd "${API_SPECS_DIR}" && gh repo view --json owner --jq '.owner.login' 2>/dev/null || echo "")
+fi
+
+if [ -z "${GITHUB_ORG}" ]; then
+  echo "WARNING: gh not authenticated or api-specs-enriched has no remote — skipping issue creation"
+  echo ""
+  echo "Gaps (no issues created):"
+  python3 -c "
+import json, sys
+for g in json.loads(sys.argv[1]):
+    print(f'  [{g[\"gap_type\"]}] {g[\"resource\"]}: {g[\"description\"]}')
+    print(f'    Fix: {g[\"fix_file\"]}')
+" "${gaps}"
+  echo ""
+  exit 1
+fi
+
+REPO="${GITHUB_ORG}/api-specs-enriched"
+
+# ── Issue dedup + creation ────────────────────────────────────────────────────
+created=0
+skipped=0
+
+while IFS='|' read -r idx gap_type resource fix_file description; do
+  search_title="[autoresearch] ${gap_type}: ${resource}"
+
+  existing=$(gh issue list \
+    --repo "${REPO}" \
+    --search "${search_title}" \
+    --state open \
+    --json number,title \
+    --jq 'length' 2>/dev/null || echo "0")
+
+  if [ "${existing}" -gt 0 ]; then
+    echo "  SKIP (exists): [${gap_type}] ${resource}"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  # Determine label
+  label="autoresearch,bug"
+  [ "${gap_type}" = "missing_constraint" ] && label="autoresearch,enhancement"
+
+  # Build issue body
+  probed=$(python3 -c "
+import json, sys
+gaps = json.loads(sys.argv[1])
+idx = int(sys.argv[2])
+print(gaps[idx].get('probed', ''))
+" "${gaps}" "${idx}")
+
+  expected=$(python3 -c "
+import json, sys
+gaps = json.loads(sys.argv[1])
+idx = int(sys.argv[2])
+print(gaps[idx].get('expected', ''))
+" "${gaps}" "${idx}")
+
+  body="**Gap type:** \`${gap_type}\`
+**Resource:** \`${resource}\`
+**Fix file:** \`${fix_file}\`
+
+**Description:**
+${description}
+
+**Probed value:** ${probed}
+**Expected value:** ${expected}
+
+---
+*Created automatically by autoresearch-api-specs benchmark*
+*Run: \`F5XC_API_URL=... bash xcsh/autoresearch-api-specs.sh\`*"
+
+  url=$(gh issue create \
+    --repo "${REPO}" \
+    --title "${search_title} — ${description:0:60}" \
+    --body "${body}" \
+    --label "${label}" \
+    2>/dev/null || echo "")
+
+  if [ -n "${url}" ]; then
+    echo "  CREATED: [${gap_type}] ${resource}"
+    echo "    ${url}"
+    created=$((created + 1))
+
+    # Draft PR stub for curl_example_fails only
+    if [ "${gap_type}" = "curl_example_fails" ]; then
+      ts=$(date +%s)
+      branch="fix/autoresearch-curl-${resource}-${ts}"
+      (cd "${API_SPECS_DIR}" && \
+        git checkout -b "${branch}" 2>/dev/null && \
+        echo "# autoresearch gap: ${description}" >> "config/minimum_configs.yaml" && \
+        git add config/minimum_configs.yaml && \
+        git commit -m "fix(minimum_configs): autoresearch gap in ${resource} curl example
+
+Refs: ${url}" && \
+        git push origin "${branch}" && \
+        gh pr create \
+          --repo "${REPO}" \
+          --title "fix(minimum_configs): autoresearch gap in ${resource} curl example" \
+          --body "Stub PR for: ${url}
+
+Autoresearch detected a failing curl example for \`${resource}\`.
+Please replace the stub comment with the corrected minimum config." \
+          --draft \
+          --base main \
+          2>/dev/null || true)
+    fi
+  else
+    echo "  WARN: failed to create issue for [${gap_type}] ${resource}"
+  fi
+done < <(python3 -c "
+import json, sys
+for i, g in enumerate(json.loads(sys.argv[1])):
+    print(f'{i}|{g[\"gap_type\"]}|{g[\"resource\"]}|{g[\"fix_file\"]}|{g[\"description\"]}')
+" "${gaps}")
+
+echo ""
+echo "--- Summary ---"
+echo "  Issues created: ${created}"
+echo "  Issues skipped (already exist): ${skipped}"
+echo ""
+echo "--- Next steps ---"
+echo "1. Fix api-specs-enriched config files per issues above"
+echo "2. Run: cd api-specs-enriched && make pipeline && merge"
+echo "3. Restart autoresearch"
+echo ""
+
+exit 1

--- a/autoresearch-api-specs.sh
+++ b/autoresearch-api-specs.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# API-Specs Enriched Autoresearch Benchmark
+# Measures accuracy of api-specs-enriched config files against live F5 XC API.
+# Emits two scores:
+#   curl_validity_score  — % resources whose minimum_configs.yaml curl examples pass CRUD
+#   spec_accuracy_score  — % constraint checks that match constraint_patterns.yaml / discovered_defaults.yaml
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_SPECS_DIR="${SCRIPT_DIR}/../api-specs-enriched"
+WORK_DIR="/tmp/ar-api-specs-$$"
+NAMESPACE="${F5XC_NAMESPACE:-r-mordasiewicz}"
+DRY_RUN="${DRY_RUN:-false}"
+
+if [ -z "${F5XC_API_URL:-}" ] || [ -z "${F5XC_API_TOKEN:-}" ]; then
+  echo "ERROR: F5XC_API_URL and F5XC_API_TOKEN must be set" >&2
+  exit 1
+fi
+
+if [ ! -f "${API_SPECS_DIR}/config/minimum_configs.yaml" ]; then
+  echo "ERROR: api-specs-enriched not found at ${API_SPECS_DIR}" >&2
+  exit 1
+fi
+
+cleanup() { rm -rf "${WORK_DIR}"; }
+trap cleanup EXIT
+mkdir -p "${WORK_DIR}"
+
+# Discover curl-test resources: all top-level keys under resources: in minimum_configs.yaml
+curl_resources=$(python3 -c "
+import yaml
+with open('${API_SPECS_DIR}/config/minimum_configs.yaml') as f:
+    data = yaml.safe_load(f)
+print(' '.join(data.get('resources', {}).keys()))
+")
+
+# Discover constraint-probe resources: RESOURCE_ENDPOINTS from constraint_prober.py
+probe_resources=$(python3 -c "
+import sys
+sys.path.insert(0, '${API_SPECS_DIR}')
+from scripts.discovery.constraint_prober import RESOURCE_ENDPOINTS
+print(' '.join(RESOURCE_ENDPOINTS.keys()))
+" 2>/dev/null || echo "healthcheck origin_pool http_loadbalancer tcp_loadbalancer app_firewall service_policy")
+
+echo "API-Specs Enriched Autoresearch Benchmark"
+echo "Curl resources ($(echo "${curl_resources}" | wc -w | tr -d ' ')): ${curl_resources}"
+echo "Probe resources ($(echo "${probe_resources}" | wc -w | tr -d ' ')): ${probe_resources}"
+echo ""
+
+# ── curl_validity_score ─────────────────────────────────────────────────────
+echo "Running curl validity tests..."
+
+# Ensure rich is available (required by validate_curl_examples.py)
+python3 -c "import rich" 2>/dev/null || \
+  pip install -q rich --break-system-packages >/dev/null 2>&1 || true
+
+curl_total=0
+curl_pass=0
+gaps_json="[]"
+
+for resource in ${curl_resources}; do
+  curl_total=$((curl_total + 1))
+  output_base="${WORK_DIR}/${resource}_curl"
+
+  dry_flag=""
+  [ "${DRY_RUN}" = "true" ] && dry_flag="--dry-run"
+
+  (cd "${API_SPECS_DIR}" && \
+    F5XC_API_URL="${F5XC_API_URL}" \
+    F5XC_API_TOKEN="${F5XC_API_TOKEN}" \
+    python3 scripts/validate_curl_examples.py \
+      --resource "${resource}" \
+      --namespace "${NAMESPACE}" \
+      --output "${output_base}" \
+      ${dry_flag} \
+      2>/dev/null || true)
+
+  report_file="${output_base}.json"
+  resource_pass=0
+  resource_skip=0
+  fail_desc="no_report"
+
+  if [ -f "${report_file}" ]; then
+    result=$(python3 -c "
+import json, sys
+report = json.load(open(sys.argv[1]))
+resource = sys.argv[2]
+for r in report.get('results', []):
+    if r.get('full_success'):
+        print('PASS')
+    else:
+        ops = r.get('operations', {})
+        for op_name, op in ops.items():
+            if not op.get('success', True):
+                code = op.get('status_code', 0)
+                err = (op.get('error') or '')[:80]
+                print(f'FAIL:{op_name}:{code}:{err}')
+                break
+        else:
+            print('FAIL:unknown:0:')
+    break
+else:
+    print('SKIP')
+" "${report_file}" "${resource}" 2>/dev/null || echo "SKIP")
+
+    if [ "${result}" = "PASS" ]; then
+      resource_pass=1
+      echo "  PASS: ${resource}"
+    elif [ "${result}" = "SKIP" ]; then
+      echo "  SKIP: ${resource} (not in report)"
+      curl_total=$((curl_total - 1))
+      resource_skip=1
+    else
+      fail_desc="${result}"
+      echo "  FAIL: ${resource} (${result})"
+    fi
+  else
+    echo "  FAIL: ${resource} (validate_curl_examples.py produced no report)"
+  fi
+
+  curl_pass=$((curl_pass + resource_pass))
+
+  if [ "${resource_pass}" -eq 0 ] && [ "${resource_skip}" -eq 0 ]; then
+    desc_json=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "${fail_desc}")
+    gaps_json=$(python3 -c "
+import json, sys
+gaps = json.loads(sys.argv[1])
+gaps.append({
+    'resource': '${resource}',
+    'gap_type': 'curl_example_fails',
+    'fix_file': 'config/minimum_configs.yaml',
+    'description': json.loads(sys.argv[2]),
+    'fix_repo': 'api-specs-enriched',
+    'probed': 'failed',
+    'expected': 'success',
+})
+print(json.dumps(gaps))
+" "${gaps_json}" "${desc_json}")
+  fi
+done
+echo ""
+
+# ── spec_accuracy_score ──────────────────────────────────────────────────────
+echo "Running spec accuracy probes..."
+
+# Ensure httpx is available (required by constraint_prober.py)
+python3 -c "import httpx" 2>/dev/null || \
+  pip install -q httpx --break-system-packages >/dev/null 2>&1 || true
+
+spec_total=0
+spec_pass=0
+
+for resource in ${probe_resources}; do
+  prober_output="${WORK_DIR}/${resource}_probe.json"
+
+  dry_flag=""
+  [ "${DRY_RUN}" = "true" ] && dry_flag="--dry-run"
+
+  (cd "${API_SPECS_DIR}" && \
+    F5XC_API_URL="${F5XC_API_URL}" \
+    F5XC_API_TOKEN="${F5XC_API_TOKEN}" \
+    F5XC_NAMESPACE="${NAMESPACE}" \
+    python3 -W ignore -m scripts.discovery.constraint_prober \
+      --resource "${resource}" \
+      --output "${prober_output}" \
+      --rate 3.0 \
+      ${dry_flag} 2>&1 | grep -v "^INFO:httpx" || true)
+
+  [ -f "${prober_output}" ] || \
+    echo '{"fields":[],"server_default_fields":{}}' > "${prober_output}"
+
+  result=$(python3 -c "
+import json, yaml, re, sys
+
+resource = sys.argv[1]
+prober_path = sys.argv[2]
+api_specs_dir = sys.argv[3]
+
+probed = json.load(open(prober_path))
+fields = probed.get('fields', [])
+server_defaults = probed.get('server_default_fields', {})
+
+with open(f'{api_specs_dir}/config/constraint_patterns.yaml') as f:
+    patterns_data = yaml.safe_load(f)
+string_patterns = patterns_data.get('string_patterns', [])
+
+with open(f'{api_specs_dir}/config/discovered_defaults.yaml') as f:
+    defaults_data = yaml.safe_load(f)
+resource_defaults = defaults_data.get('resources', {}).get(resource, {}).get('defaults', {})
+
+checks_total = 0
+checks_pass = 0
+gaps = []
+
+def find_pattern(field_path, pattern_list):
+    leaf = field_path.split('.')[-1]
+    for p in pattern_list:
+        if re.search(p.get('pattern', ''), leaf, re.IGNORECASE):
+            return p
+    return None
+
+def within_tolerance(a, b, tol=0.10):
+    if b == 0:
+        return a == 0
+    return abs(float(a) - float(b)) / max(abs(float(b)), 1) <= tol
+
+# Check string constraints from prober
+for field in fields:
+    if field.get('probe_strategy') != 'string_length':
+        continue
+    actual = field.get('actual', {})
+    field_path = field.get('field_path', '')
+    probed_max = actual.get('maxLength')
+    if probed_max is None:
+        continue
+
+    checks_total += 1
+    pat = find_pattern(field_path, string_patterns)
+
+    if pat and 'constraints' in pat:
+        encoded_max = pat['constraints'].get('maxLength')
+        if encoded_max is not None:
+            if within_tolerance(probed_max, encoded_max):
+                checks_pass += 1
+            else:
+                gaps.append({
+                    'resource': resource,
+                    'gap_type': 'constraint_value_wrong',
+                    'fix_file': 'config/constraint_patterns.yaml',
+                    'description': f'{field_path}: maxLength probed={probed_max} encoded={encoded_max}',
+                    'fix_repo': 'api-specs-enriched',
+                    'probed': str(probed_max),
+                    'expected': str(encoded_max),
+                })
+        else:
+            checks_pass += 1
+    else:
+        gaps.append({
+            'resource': resource,
+            'gap_type': 'missing_constraint',
+            'fix_file': 'config/constraint_patterns.yaml',
+            'description': f'{field_path}: probed maxLength={probed_max} but no matching pattern entry',
+            'fix_repo': 'api-specs-enriched',
+            'probed': f'maxLength={probed_max}',
+            'expected': 'pattern entry in constraint_patterns.yaml',
+        })
+
+# Check server defaults
+config_default_keys = set(resource_defaults.keys())
+for key in server_defaults.keys():
+    checks_total += 1
+    if key in config_default_keys:
+        checks_pass += 1
+    else:
+        gaps.append({
+            'resource': resource,
+            'gap_type': 'server_default_wrong',
+            'fix_file': 'config/discovered_defaults.yaml',
+            'description': f'{resource}: server applies {key!r} by default but absent from discovered_defaults.yaml',
+            'fix_repo': 'api-specs-enriched',
+            'probed': key,
+            'expected': 'present in discovered_defaults.yaml',
+        })
+
+print(json.dumps({'checks_total': checks_total, 'checks_pass': checks_pass, 'gaps': gaps}))
+" "${resource}" "${prober_output}" "${API_SPECS_DIR}" 2>/dev/null || \
+    echo '{"checks_total":0,"checks_pass":0,"gaps":[]}')
+
+  r_total=$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['checks_total'])" "${result}")
+  r_pass=$(python3 -c "import json,sys; print(json.loads(sys.argv[1])['checks_pass'])" "${result}")
+  r_gaps=$(python3 -c "import json,sys; print(json.dumps(json.loads(sys.argv[1])['gaps']))" "${result}")
+
+  spec_total=$((spec_total + r_total))
+  spec_pass=$((spec_pass + r_pass))
+
+  echo "  ${resource}: ${r_pass}/${r_total} checks pass"
+
+  gaps_json=$(python3 -c "
+import json, sys
+print(json.dumps(json.loads(sys.argv[1]) + json.loads(sys.argv[2])))
+" "${gaps_json}" "${r_gaps}" 2>/dev/null || echo "${gaps_json}")
+done
+echo ""
+
+
+# ── Score emission ────────────────────────────────────────────────────────────
+probe_count=$(echo "${probe_resources}" | wc -w | tr -d ' ')
+
+python3 -c "
+curl_total = ${curl_total}
+curl_pass = ${curl_pass}
+spec_total = ${spec_total}
+spec_pass = ${spec_pass}
+probe_count = ${probe_count}
+curl_validity_score = round(curl_pass / max(1, curl_total) * 100, 1)
+spec_accuracy_score = round(spec_pass / max(1, spec_total) * 100, 1)
+print(f'METRIC curl_validity_score={curl_validity_score}')
+print(f'METRIC spec_accuracy_score={spec_accuracy_score}')
+print(f'METRIC curl_resources_tested={curl_total}')
+print(f'METRIC spec_resources_tested={probe_count}')
+"
+
+spec_issues=$(python3 -c "
+import json, sys
+gaps = json.loads(sys.argv[1])
+print(sum(1 for g in gaps if g.get('fix_repo') == 'api-specs-enriched'))
+" "${gaps_json}")
+
+echo "ASI gaps=${gaps_json}"
+echo "ASI cross_repo_issues={\"api-specs-enriched\": ${spec_issues}, \"xcsh\": 0, \"terraform-provider-f5xc\": 0}"


### PR DESCRIPTION
## Summary

Add two-phase autoresearch benchmark targeting api-specs-enriched config accuracy.

- `autoresearch-api-specs.sh` — measures `curl_validity_score` (curl examples from `minimum_configs.yaml` against live API) and `spec_accuracy_score` (constraint patterns vs live API prober values)
- `autoresearch-api-specs.checks.sh` — creates GitHub issues in `api-specs-enriched` for every gap found, with dedup via `gh issue list`, exits 1 to stop the autoresearch loop

## Test plan
- [x] Dry-run passes without API calls
- [x] Live run against staging API emits all 4 METRIC lines
- [x] Checks script exits 0 on empty gaps, exits 1 on gaps
- [x] bun test: 5733 pass, 0 fail

Closes #1136