### PR TITLE
fix: refresh stale marketplace catalogs when plugin dashboard opens

### DIFF
--- a/packages/coding-agent/src/modes/components/plugins/plugin-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/plugins/plugin-dashboard.ts
@@ -114,6 +114,12 @@ export class PluginDashboard extends Container {
 		}
 
 		try {
+			await this.#mgr.refreshStaleMarketplaces();
+		} catch {
+			// Network failure is fine — display whatever is cached
+		}
+
+		try {
 			this.#state = await createInitialState(this.#mgr, this.#npmMgr);
 		} catch (error) {
 			this.#state = {


### PR DESCRIPTION
## Summary

- Add `refreshStaleMarketplaces()` call in `PluginDashboard.#init()` before loading state
- Ensures `/plugins` always shows current marketplace data, not stale cache
- Mirrors existing startup refresh pattern (`main.ts:745`)

## Test plan

- [x] All 233 marketplace tests pass (0 failures)
- [x] Pre-commit hooks pass (biome format/lint)
- [ ] Manual: clear cache, open `/plugins` — should fetch fresh catalog
- [ ] Manual: open `/plugins` again immediately — should not re-fetch (24h TTL)
- [ ] Manual: disconnect network, open `/plugins` — should show cached list gracefully

Closes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)