### PR TITLE
feat: dashboard tab parity and displayName/defaultEnabled support

### DIFF
--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -323,13 +323,15 @@ export class MarketplaceManager {
 		const now = new Date().toISOString();
 		// Carry over enabled flag from existing entry — a disabled plugin must stay disabled after upgrade
 		const wasDisabled = existing?.some(e => e.enabled === false);
+		// Honor defaultEnabled from catalog — new installs with defaultEnabled: false start disabled
+		const defaultDisabled = !existing && pluginEntry.defaultEnabled === false;
 		const installedEntry: InstalledPluginEntry = {
 			scope,
 			installPath: cachePath,
 			version,
 			installedAt: now,
 			lastUpdated: now,
-			...(wasDisabled ? { enabled: false } : {}),
+			...(wasDisabled || defaultDisabled ? { enabled: false } : {}),
 		};
 
 		const freshInstReg = await readInstalledPluginsRegistry(registryPath);

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/types.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/types.ts
@@ -76,6 +76,7 @@ export interface MarketplacePluginAuthor {
 
 export interface MarketplacePluginEntry {
 	name: string;
+	displayName?: string;
 	source: PluginSource;
 	description?: string;
 	version?: string;
@@ -87,6 +88,7 @@ export interface MarketplacePluginEntry {
 	category?: string;
 	tags?: string[];
 	strict?: boolean;
+	defaultEnabled?: boolean;
 	commands?: string | string[];
 	agents?: string | string[];
 	hooks?: string | Record<string, unknown>;

--- a/packages/coding-agent/src/modes/components/plugins/plugin-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/plugins/plugin-dashboard.ts
@@ -251,7 +251,7 @@ export class PluginDashboard extends Container {
 		if (!plugin) return;
 		const tabId = this.#activeTabId();
 
-		if (tabId === "available" && !plugin.installed) {
+		if (tabId === "discover" && !plugin.installed) {
 			await this.#installPlugin(plugin);
 		} else if (tabId === "updates" && plugin.hasUpdate) {
 			await this.#upgradePlugin(plugin);
@@ -320,7 +320,7 @@ export class PluginDashboard extends Container {
 	#getHelpText(): string {
 		const tabId = this.#activeTabId();
 		switch (tabId) {
-			case "available":
+			case "discover":
 				return " ↑/↓: navigate  Enter: install  Tab: next tab  Ctrl+R: reload  Esc: close";
 			case "updates":
 				return " ↑/↓: navigate  Enter: upgrade  Tab: next tab  Ctrl+R: reload  Esc: close";

--- a/packages/coding-agent/src/modes/components/plugins/plugin-inspector-pane.ts
+++ b/packages/coding-agent/src/modes/components/plugins/plugin-inspector-pane.ts
@@ -14,7 +14,7 @@ export class PluginInspectorPane implements Component {
 		const lines: string[] = [];
 		const p = this.plugin;
 
-		lines.push(theme.bold(theme.fg("contentAccent", replaceTabs(p.name))));
+		lines.push(theme.bold(theme.fg("contentAccent", replaceTabs(p.displayName || p.name))));
 		lines.push("");
 
 		lines.push(`${theme.fg("muted", "Source:")} ${p.source}`);

--- a/packages/coding-agent/src/modes/components/plugins/plugin-list-pane.ts
+++ b/packages/coding-agent/src/modes/components/plugins/plugin-list-pane.ts
@@ -22,7 +22,7 @@ export class PluginListPane implements Component {
 
 		if (this.plugins.length === 0) {
 			const msg =
-				this.activeTab === "available"
+				this.activeTab === "discover"
 					? "No plugins available. Add a marketplace first."
 					: this.activeTab === "updates"
 						? "All plugins are up to date."
@@ -71,7 +71,7 @@ export class PluginListPane implements Component {
 		}
 
 		parts.push(" ");
-		parts.push(plugin.name);
+		parts.push(plugin.displayName || plugin.name);
 
 		if (plugin.version) {
 			parts.push(theme.fg("dim", ` v${plugin.version}`));

--- a/packages/coding-agent/src/modes/components/plugins/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/plugins/state-manager.ts
@@ -48,6 +48,7 @@ function catalogToDashboard(entry: MarketplacePluginEntry, marketplace: string):
 	return {
 		id: `${entry.name}@${marketplace}`,
 		name: normalizePluginDisplayName(entry.name),
+		displayName: entry.displayName,
 		marketplace,
 		source: "marketplace",
 		version: entry.version,
@@ -96,6 +97,7 @@ export async function loadAllPlugins(mgr: MarketplaceManager, npmMgr: PluginMana
 			if (installedIds.has(pluginId)) {
 				const existing = plugins.find(p => p.id === pluginId);
 				if (existing) {
+					existing.displayName = existing.displayName || entry.displayName;
 					existing.description = existing.description || entry.description;
 					existing.category = existing.category || entry.category;
 					existing.tags = existing.tags || entry.tags;
@@ -124,12 +126,12 @@ export async function loadAllPlugins(mgr: MarketplaceManager, npmMgr: PluginMana
 export function buildTabs(plugins: DashboardPlugin[]): PluginTab[] {
 	const tabs: PluginTab[] = [];
 	const installedCount = plugins.filter(p => p.installed).length;
-	const availableCount = plugins.filter(p => !p.installed).length;
+	const discoverCount = plugins.filter(p => !p.installed).length;
 	const updatesCount = plugins.filter(p => p.hasUpdate).length;
 
 	tabs.push({ id: "installed", label: "Installed", count: installedCount });
-	if (availableCount > 0) {
-		tabs.push({ id: "available", label: "Available", count: availableCount });
+	if (discoverCount > 0) {
+		tabs.push({ id: "discover", label: "Discover", count: discoverCount });
 	}
 	if (updatesCount > 0) {
 		tabs.push({ id: "updates", label: "Updates", count: updatesCount });
@@ -141,7 +143,7 @@ export function filterByTab(plugins: DashboardPlugin[], tabId: PluginTabId): Das
 	switch (tabId) {
 		case "installed":
 			return plugins.filter(p => p.installed);
-		case "available":
+		case "discover":
 			return plugins.filter(p => !p.installed);
 		case "updates":
 			return plugins.filter(p => p.hasUpdate);
@@ -155,6 +157,7 @@ export function applySearch(plugins: DashboardPlugin[], query: string): Dashboar
 	const q = query.toLowerCase();
 	return plugins.filter(p => {
 		if (p.name.toLowerCase().includes(q)) return true;
+		if (p.displayName?.toLowerCase().includes(q)) return true;
 		if (p.description?.toLowerCase().includes(q)) return true;
 		if (p.marketplace?.toLowerCase().includes(q)) return true;
 		if (p.category?.toLowerCase().includes(q)) return true;

--- a/packages/coding-agent/src/modes/components/plugins/types.ts
+++ b/packages/coding-agent/src/modes/components/plugins/types.ts
@@ -1,6 +1,7 @@
 export interface DashboardPlugin {
 	id: string;
 	name: string;
+	displayName?: string;
 	marketplace?: string;
 	source: "npm" | "marketplace";
 	scope?: "user" | "project";
@@ -19,7 +20,7 @@ export interface DashboardPlugin {
 	updateVersion?: string;
 }
 
-export type PluginTabId = "installed" | "available" | "updates";
+export type PluginTabId = "installed" | "discover" | "updates";
 
 export interface PluginTab {
 	id: PluginTabId;


### PR DESCRIPTION
## Summary

- Rename "Available" tab → "Discover" matching Claude Code's official spec
- Add `displayName` field support: renders in list pane, inspector pane, and search
- Add `defaultEnabled` field support: plugins with `defaultEnabled: false` install as disabled

## Test plan

- [x] All 251 marketplace + slash command tests pass (0 failures)
- [x] Pre-commit hooks pass (biome format/lint)
- [ ] Dashboard shows "Discover" tab instead of "Available"
- [ ] Plugins with `displayName` in catalog show human-readable name
- [ ] Plugins with `defaultEnabled: false` install as disabled

Closes #1143

🤖 Generated with [Claude Code](https://claude.com/claude-code)