### PR TITLE
feat: recommended plugins with guided setup and prerequisite detection

### DIFF
--- a/packages/coding-agent/src/extensibility/plugins/marketplace/prerequisites.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/prerequisites.ts
@@ -1,0 +1,50 @@
+import type { MarketplacePluginEntry } from "./types";
+
+const cache = new Map<string, boolean>();
+
+export async function checkPrerequisite(detectCmd: string): Promise<boolean> {
+	const cached = cache.get(detectCmd);
+	if (cached !== undefined) return cached;
+
+	try {
+		const [cmd, ...args] = detectCmd.split(/\s+/);
+		const proc = Bun.spawn([cmd!, ...args], {
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		const exitCode = await proc.exited;
+		const available = exitCode === 0;
+		cache.set(detectCmd, available);
+		return available;
+	} catch {
+		cache.set(detectCmd, false);
+		return false;
+	}
+}
+
+export async function checkAllPrerequisites(
+	plugins: MarketplacePluginEntry[],
+): Promise<Map<string, { available: boolean; missing: string[] }>> {
+	const results = new Map<string, { available: boolean; missing: string[] }>();
+
+	for (const plugin of plugins) {
+		if (!plugin.prerequisites || plugin.prerequisites.length === 0) {
+			results.set(plugin.name, { available: true, missing: [] });
+			continue;
+		}
+
+		const missing: string[] = [];
+		for (const prereq of plugin.prerequisites) {
+			const ok = await checkPrerequisite(prereq.detectCmd);
+			if (!ok) missing.push(prereq.tool);
+		}
+
+		results.set(plugin.name, { available: missing.length === 0, missing });
+	}
+
+	return results;
+}
+
+export function clearPrerequisiteCache(): void {
+	cache.clear();
+}

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/types.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/types.ts
@@ -89,6 +89,8 @@ export interface MarketplacePluginEntry {
 	tags?: string[];
 	strict?: boolean;
 	defaultEnabled?: boolean;
+	recommended?: boolean;
+	prerequisites?: Array<{ tool: string; installCmd: string; detectCmd: string }>;
 	commands?: string | string[];
 	agents?: string | string[];
 	hooks?: string | Record<string, unknown>;

--- a/packages/coding-agent/src/modes/components/plugins/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/plugins/state-manager.ts
@@ -62,6 +62,8 @@ function catalogToDashboard(entry: MarketplacePluginEntry, marketplace: string):
 		installed: false,
 		enabled: false,
 		hasUpdate: false,
+		recommended: entry.recommended,
+		prerequisites: entry.prerequisites,
 	};
 }
 
@@ -98,6 +100,8 @@ export async function loadAllPlugins(mgr: MarketplaceManager, npmMgr: PluginMana
 				const existing = plugins.find(p => p.id === pluginId);
 				if (existing) {
 					existing.displayName = existing.displayName || entry.displayName;
+					existing.recommended = existing.recommended || entry.recommended;
+					existing.prerequisites = existing.prerequisites || entry.prerequisites;
 					existing.description = existing.description || entry.description;
 					existing.category = existing.category || entry.category;
 					existing.tags = existing.tags || entry.tags;
@@ -126,10 +130,14 @@ export async function loadAllPlugins(mgr: MarketplaceManager, npmMgr: PluginMana
 export function buildTabs(plugins: DashboardPlugin[]): PluginTab[] {
 	const tabs: PluginTab[] = [];
 	const installedCount = plugins.filter(p => p.installed).length;
+	const recommendedCount = plugins.filter(p => !p.installed && p.recommended).length;
 	const discoverCount = plugins.filter(p => !p.installed).length;
 	const updatesCount = plugins.filter(p => p.hasUpdate).length;
 
 	tabs.push({ id: "installed", label: "Installed", count: installedCount });
+	if (recommendedCount > 0) {
+		tabs.push({ id: "recommended", label: "Recommended", count: recommendedCount });
+	}
 	if (discoverCount > 0) {
 		tabs.push({ id: "discover", label: "Discover", count: discoverCount });
 	}
@@ -143,6 +151,8 @@ export function filterByTab(plugins: DashboardPlugin[], tabId: PluginTabId): Das
 	switch (tabId) {
 		case "installed":
 			return plugins.filter(p => p.installed);
+		case "recommended":
+			return plugins.filter(p => !p.installed && p.recommended);
 		case "discover":
 			return plugins.filter(p => !p.installed);
 		case "updates":

--- a/packages/coding-agent/src/modes/components/plugins/types.ts
+++ b/packages/coding-agent/src/modes/components/plugins/types.ts
@@ -18,9 +18,11 @@ export interface DashboardPlugin {
 	shadowedBy?: "project";
 	hasUpdate: boolean;
 	updateVersion?: string;
+	recommended?: boolean;
+	prerequisites?: Array<{ tool: string; installCmd: string; detectCmd: string }>;
 }
 
-export type PluginTabId = "installed" | "discover" | "updates";
+export type PluginTabId = "installed" | "recommended" | "discover" | "updates";
 
 export interface PluginTab {
 	id: PluginTabId;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -875,6 +875,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 			{ name: "discover", description: "Browse available plugins", usage: "[marketplace]" },
 			{ name: "list", description: "List all installed plugins" },
 			{ name: "validate", description: "Validate marketplace or plugin manifest", usage: "[path]" },
+			{ name: "setup", description: "Guided setup for recommended plugins" },
 			{ name: "help", description: "Show usage guide" },
 		],
 		allowArgs: true,
@@ -969,7 +970,6 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 								}
 								break;
 							}
-							case "list":
 							default: {
 								const marketplaces = await mgr.listMarketplaces();
 								if (marketplaces.length === 0) {
@@ -1162,6 +1162,80 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 						}
 						break;
 					}
+					// ── Setup (guided recommended plugin install) ──
+					case "setup": {
+						const { checkPrerequisite } = await import("../extensibility/plugins/marketplace/prerequisites");
+						const allPlugins = await mgr.listAvailablePlugins();
+						const recommended = allPlugins.filter(p => p.recommended);
+						if (recommended.length === 0) {
+							runtime.ctx.showStatus("No recommended plugins found in configured marketplaces");
+							break;
+						}
+
+						const installed = await mgr.listInstalledPlugins();
+						const installedIds = new Set(installed.map(p => p.id));
+						const toInstall = recommended.filter(
+							p => !Array.from(installedIds).some(id => id.startsWith(`${p.name}@`)),
+						);
+
+						if (toInstall.length === 0) {
+							runtime.ctx.showStatus("All recommended plugins are already installed");
+							break;
+						}
+
+						const lines: string[] = ["Recommended plugins setup:\n"];
+						let installedCount = 0;
+						let skippedCount = 0;
+						const skippedReasons: string[] = [];
+
+						for (const plugin of toInstall) {
+							if (plugin.prerequisites && plugin.prerequisites.length > 0) {
+								const missing: string[] = [];
+								for (const prereq of plugin.prerequisites) {
+									const ok = await checkPrerequisite(prereq.detectCmd);
+									if (!ok) missing.push(`${prereq.tool} (${prereq.installCmd})`);
+								}
+								if (missing.length > 0) {
+									lines.push(`  ⊘ ${plugin.displayName || plugin.name} — missing: ${missing.join(", ")}`);
+									skippedCount++;
+									skippedReasons.push(...missing);
+									continue;
+								}
+							}
+
+							const marketplaces = await mgr.listMarketplaces();
+							let installed = false;
+							for (const mkt of marketplaces) {
+								const available = await mgr.listAvailablePlugins(mkt.name);
+								if (available.some(a => a.name === plugin.name)) {
+									try {
+										await mgr.installPlugin(plugin.name, mkt.name);
+										lines.push(`  + ${plugin.displayName || plugin.name} — installed`);
+										installedCount++;
+										installed = true;
+									} catch (err) {
+										lines.push(
+											`  ! ${plugin.displayName || plugin.name} — ${err instanceof Error ? err.message : String(err)}`,
+										);
+										skippedCount++;
+									}
+									break;
+								}
+							}
+							if (!installed && skippedCount === 0) {
+								lines.push(`  ? ${plugin.displayName || plugin.name} — not found in any marketplace`);
+								skippedCount++;
+							}
+						}
+
+						lines.push("");
+						lines.push(`Installed ${installedCount}/${toInstall.length} recommended plugin(s)`);
+						if (skippedCount > 0) {
+							lines.push(`${skippedCount} skipped — install missing tools and run /plugin setup again`);
+						}
+						runtime.ctx.showStatus(lines.join("\n"));
+						break;
+					}
 					// ── Help ──
 					case "help": {
 						runtime.ctx.showStatus(
@@ -1180,6 +1254,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 								"  /plugin upgrade [name@marketplace]         Upgrade plugin(s)",
 								"  /plugin list                               List installed plugins",
 								"  /plugin validate [path]                    Validate marketplace or plugin",
+								"  /plugin setup                              Guided setup for recommended plugins",
 								"",
 								"Quick start:",
 								"  /plugin marketplace add f5xc-salesdemos/marketplace",


### PR DESCRIPTION
## Summary

- Add `recommended` and `prerequisites` fields to `MarketplacePluginEntry`
- Add "Recommended" tab to plugin dashboard (shown when uninstalled recommended plugins exist)
- Add `/plugin setup` guided onboarding command with prerequisite detection
- New `prerequisites.ts` utility for session-cached CLI tool detection

## Test plan

- [x] All 251 marketplace + slash command tests pass
- [x] TypeScript type check clean
- [x] Pre-commit hooks pass
- [ ] Dashboard shows "Recommended" tab when marketplace has recommended plugins
- [ ] `/plugin setup` checks prerequisites and batch-installs recommended plugins
- [ ] Missing prerequisites show `brew install` guidance

Closes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)