### PR TITLE
feat: recommended plugin UX — badge, install-all action, and help text

### DIFF
--- a/packages/coding-agent/src/modes/components/plugins/plugin-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/plugins/plugin-dashboard.ts
@@ -251,7 +251,7 @@ export class PluginDashboard extends Container {
 		if (!plugin) return;
 		const tabId = this.#activeTabId();
 
-		if (tabId === "discover" && !plugin.installed) {
+		if ((tabId === "discover" || tabId === "recommended") && !plugin.installed) {
 			await this.#installPlugin(plugin);
 		} else if (tabId === "updates" && plugin.hasUpdate) {
 			await this.#upgradePlugin(plugin);
@@ -289,6 +289,35 @@ export class PluginDashboard extends Container {
 		}
 	}
 
+	async #installAllRecommended(): Promise<void> {
+		const recommended = this.#state.allPlugins.filter(p => !p.installed && p.recommended && p.marketplace);
+		if (recommended.length === 0) {
+			this.#state.notice = "All recommended plugins are already installed";
+			this.#rebuildAndRender();
+			return;
+		}
+
+		this.#state.notice = `Installing ${recommended.length} recommended plugin(s)...`;
+		this.#rebuildAndRender();
+
+		let installed = 0;
+		let failed = 0;
+		for (const plugin of recommended) {
+			try {
+				await this.#mgr.installPlugin(plugin.name, plugin.marketplace!);
+				installed++;
+			} catch {
+				failed++;
+			}
+		}
+
+		this.#state.notice =
+			failed > 0
+				? `Installed ${installed}/${recommended.length} recommended plugin(s), ${failed} failed`
+				: `Installed ${installed} recommended plugin(s)`;
+		await this.#reloadData();
+	}
+
 	async #upgradePlugin(plugin: DashboardPlugin): Promise<void> {
 		this.#state.notice = `Upgrading ${plugin.name}...`;
 		this.#rebuildAndRender();
@@ -320,6 +349,8 @@ export class PluginDashboard extends Container {
 	#getHelpText(): string {
 		const tabId = this.#activeTabId();
 		switch (tabId) {
+			case "recommended":
+				return " ↑/↓: navigate  Enter: install  A: install all  Tab: next tab  Ctrl+R: reload  Esc: close";
 			case "discover":
 				return " ↑/↓: navigate  Enter: install  Tab: next tab  Ctrl+R: reload  Esc: close";
 			case "updates":
@@ -418,6 +449,11 @@ export class PluginDashboard extends Container {
 
 		if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
 			void this.#handleEnterAction();
+			return;
+		}
+
+		if (data.toLowerCase() === "a" && this.#activeTabId() === "recommended") {
+			void this.#installAllRecommended();
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/components/plugins/plugin-list-pane.ts
+++ b/packages/coding-agent/src/modes/components/plugins/plugin-list-pane.ts
@@ -24,9 +24,11 @@ export class PluginListPane implements Component {
 			const msg =
 				this.activeTab === "discover"
 					? "No plugins available. Add a marketplace first."
-					: this.activeTab === "updates"
-						? "All plugins are up to date."
-						: "No plugins installed.";
+					: this.activeTab === "recommended"
+						? "All recommended plugins are installed."
+						: this.activeTab === "updates"
+							? "All plugins are up to date."
+							: "No plugins installed.";
 			lines.push(theme.fg("muted", `  ${msg}`));
 			return lines;
 		}
@@ -66,6 +68,8 @@ export class PluginListPane implements Component {
 			} else {
 				parts.push(theme.fg("dim", theme.status.disabled));
 			}
+		} else if (plugin.recommended) {
+			parts.push(theme.fg("warning", "*"));
 		} else {
 			parts.push(theme.fg("dim", "·"));
 		}


### PR DESCRIPTION
## Summary

- `*` badge on uninstalled recommended plugins in the list pane
- `A` key installs all recommended plugins at once (Recommended tab only)
- `Enter` installs individual recommended plugins
- Tab-aware help text shows available actions
- "All recommended plugins are installed" empty state message

## Test plan

- [x] All 251 tests pass, type check clean
- [ ] Recommended tab shows `*` badge next to each recommended plugin
- [ ] Pressing `A` on Recommended tab batch-installs all recommended plugins
- [ ] Pressing `Enter` installs the selected recommended plugin
- [ ] Help bar shows "A: install all" on Recommended tab

Closes #1164

🤖 Generated with [Claude Code](https://claude.com/claude-code)