### PR TITLE
fix(terraform-skill): narrow SKILL.md activation to explicit terraform requests only

### DIFF
--- a/.xcsh/skills/terraform-provider/SKILL.md
+++ b/.xcsh/skills/terraform-provider/SKILL.md
@@ -1,32 +1,44 @@
 ---
 name: terraform-provider
 description: |
-  Generate F5 XC Terraform code. Provider: f5xc-salesdemos/f5xc (NEVER volterraedge/volterra).
-  Every response MUST include a ```terraform code block. Output code first. Do not run terraform commands.
-  Provider block: terraform { required_providers { f5xc = { source = "f5xc-salesdemos/f5xc" } } }
-  Templates (adapt name/namespace/fields per request):
-  http_loadbalancer: resource "f5xc_http_loadbalancer" "example" { name="example" namespace="default" domains=["app.example.com"] advertise_on_public_default_vip {} http { port=80 } default_route_pools { pool { name="origin-pool-name" namespace="default" } weight=1 priority=1 } }
-  Pool ref: set pool.name to existing origin pool name in same namespace. HTTPS: replace http { port=80 } with https_auto_cert { http_redirect=true default_header {} tls_config { default_security {} } no_mtls {} }. WAF: add disable_waf {} or app_firewall { name="waf" namespace="ns" }. Import: terraform import f5xc_http_loadbalancer.example ns/name
-  origin_pool: resource "f5xc_origin_pool" "example" { name="example" namespace="default" port=8080 origin_servers { public_ip { ip="10.0.1.10" } } loadbalancer_algorithm="ROUND_ROBIN" endpoint_selection="LOCAL_PREFERRED" }
-  Healthcheck ref: add healthcheck { name="hc" namespace="ns" }. Import: terraform import f5xc_origin_pool.example ns/name
-  healthcheck: resource "f5xc_healthcheck" "example" { name="example" namespace="default" http_health_check { path="/healthz" } timeout=3 interval=10 unhealthy_threshold=3 healthy_threshold=3 }
-  TCP: replace http_health_check with tcp_health_check {}. Import: terraform import f5xc_healthcheck.example ns/name
-  app_firewall: resource "f5xc_app_firewall" "example" { name="example" namespace="default" blocking {} }
-  Import: terraform import f5xc_app_firewall.example ns/name
-  service_policy: resource "f5xc_service_policy" "example" { name="example" namespace="default" allow_all_requests {} any_server {} }
-  Deny all: replace allow_all_requests {} with deny_all_requests {}. Custom rules: use rule_list { rules { metadata { name="rule" } spec { action="ALLOW" any_client {} any_ip {} } } }. Import: terraform import f5xc_service_policy.example ns/name
-  certificate: resource "f5xc_certificate" "example" { name="example" namespace="default" certificate_url="string:///BASE64_CERT" private_key { blindfold_secret_info { location="string:///BASE64_KEY" } } }
-  Import: terraform import f5xc_certificate.example ns/name
-  rate_limiter_policy: resource "f5xc_rate_limiter_policy" "example" { name="example" namespace="default" any_server {} }
-  Import: terraform import f5xc_rate_limiter_policy.example ns/name
-  api_definition: resource "f5xc_api_definition" "example" { name="example" namespace="default" swagger_specs=["string:///BASE64_SPEC"] }
-  Import: terraform import f5xc_api_definition.example ns/name
-  namespace: resource "f5xc_namespace" "example" { name="staging" }
-  Labels: add labels = { env="prod" }. Import: terraform import f5xc_namespace.example name
-  Troubleshoot: "one of X must be set" = add empty block. "unsupported argument" = check template. Output corrected resource block.
-  Destroy: terraform destroy -target=f5xc_{type}.{label}
+  Generate F5 XC Terraform HCL code. Activate ONLY when the user explicitly asks for Terraform, HCL, .tf files, infrastructure-as-code, or terraform import/plan/apply/destroy. Do NOT activate for direct CRUD operations (create, read, update, delete a resource by name) — those use the xcsh_api tool, not Terraform.
+  Provider: f5xc-salesdemos/f5xc (NEVER volterraedge/volterra). Read skill://terraform-provider for templates.
 ---
 
 # F5 XC Terraform Provider
 
-Generate code directly from the templates in the description. Do not read additional URLs.
+Every response MUST include a ```terraform code block. Output code first. Do not run terraform commands.
+
+Provider block: terraform { required_providers { f5xc = { source = "f5xc-salesdemos/f5xc" } } }
+
+Templates (adapt name/namespace/fields per request):
+
+http_loadbalancer: resource "f5xc_http_loadbalancer" "example" { name="example" namespace="default" domains=["app.example.com"] advertise_on_public_default_vip {} http { port=80 } default_route_pools { pool { name="origin-pool-name" namespace="default" } weight=1 priority=1 } }
+Pool ref: set pool.name to existing origin pool name in same namespace. HTTPS: replace http { port=80 } with https_auto_cert { http_redirect=true default_header {} tls_config { default_security {} } no_mtls {} }. WAF: add disable_waf {} or app_firewall { name="waf" namespace="ns" }. Import: terraform import f5xc_http_loadbalancer.example ns/name
+
+origin_pool: resource "f5xc_origin_pool" "example" { name="example" namespace="default" port=8080 origin_servers { public_ip { ip="10.0.1.10" } } loadbalancer_algorithm="ROUND_ROBIN" endpoint_selection="LOCAL_PREFERRED" }
+Healthcheck ref: add healthcheck { name="hc" namespace="ns" }. Import: terraform import f5xc_origin_pool.example ns/name
+
+healthcheck: resource "f5xc_healthcheck" "example" { name="example" namespace="default" http_health_check { path="/healthz" } timeout=3 interval=10 unhealthy_threshold=3 healthy_threshold=3 }
+TCP: replace http_health_check with tcp_health_check {}. Import: terraform import f5xc_healthcheck.example ns/name
+
+app_firewall: resource "f5xc_app_firewall" "example" { name="example" namespace="default" blocking {} }
+Import: terraform import f5xc_app_firewall.example ns/name
+
+service_policy: resource "f5xc_service_policy" "example" { name="example" namespace="default" allow_all_requests {} any_server {} }
+Deny all: replace allow_all_requests {} with deny_all_requests {}. Custom rules: use rule_list { rules { metadata { name="rule" } spec { action="ALLOW" any_client {} any_ip {} } } }. Import: terraform import f5xc_service_policy.example ns/name
+
+certificate: resource "f5xc_certificate" "example" { name="example" namespace="default" certificate_url="string:///BASE64_CERT" private_key { blindfold_secret_info { location="string:///BASE64_KEY" } } }
+Import: terraform import f5xc_certificate.example ns/name
+
+rate_limiter_policy: resource "f5xc_rate_limiter_policy" "example" { name="example" namespace="default" any_server {} }
+Import: terraform import f5xc_rate_limiter_policy.example ns/name
+
+api_definition: resource "f5xc_api_definition" "example" { name="example" namespace="default" swagger_specs=["string:///BASE64_SPEC"] }
+Import: terraform import f5xc_api_definition.example ns/name
+
+namespace: resource "f5xc_namespace" "example" { name="staging" }
+Labels: add labels = { env="prod" }. Import: terraform import f5xc_namespace.example name
+
+Troubleshoot: "one of X must be set" = add empty block. "unsupported argument" = check template. Output corrected resource block.
+Destroy: terraform destroy -target=f5xc_{type}.{label}


### PR DESCRIPTION
## Summary
The terraform-provider skill was activating for direct CRUD phrases ('Create an HTTP load balancer routing to origin pool X'), causing xcsh to generate HCL instead of calling xcsh_api. This was the root cause of the 96.7% crud_score ceiling.

New SKILL.md description: activate ONLY when user explicitly asks for terraform/HCL/.tf files/infrastructure-as-code. Direct CRUD operations use xcsh_api.

Verified locally: phrase 22 now creates the LB via xcsh_api (HTTP 200).

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)