### PR TITLE
feat(welcome): show recommended plugin status on welcome screen

### DIFF
--- a/packages/coding-agent/src/modes/components/plugins/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/plugins/state-manager.ts
@@ -3,12 +3,9 @@ import type { MarketplaceManager } from "../../../extensibility/plugins/marketpl
 import type { InstalledPluginSummary, MarketplacePluginEntry } from "../../../extensibility/plugins/marketplace/types";
 import type { DashboardPlugin, PluginDashboardState, PluginTab, PluginTabId } from "./types";
 
-export function normalizePluginDisplayName(name: string): string {
-	let result = name;
-	if (result.startsWith("f5xc-")) result = result.slice(5);
-	if (result.length > 0 && result.endsWith("-status")) result = result.slice(0, -7);
-	return result || name;
-}
+export { normalizePluginDisplayName } from "./utils";
+
+import { normalizePluginDisplayName } from "./utils";
 
 function npmToDashboard(npm: { name: string; version: string; enabled: boolean }): DashboardPlugin {
 	return {

--- a/packages/coding-agent/src/modes/components/plugins/utils.ts
+++ b/packages/coding-agent/src/modes/components/plugins/utils.ts
@@ -1,0 +1,6 @@
+export function normalizePluginDisplayName(name: string): string {
+	let result = name;
+	if (result.startsWith("f5xc-")) result = result.slice(5);
+	if (result.length > 0 && result.endsWith("-status")) result = result.slice(0, -7);
+	return result || name;
+}

--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -1,9 +1,17 @@
 import type { Model } from "@f5xc-salesdemos/pi-ai";
 import { validateApiKeyAgainstModelsEndpoint } from "@f5xc-salesdemos/pi-ai/utils/oauth/api-key-validation";
 import { logger } from "@f5xc-salesdemos/pi-utils";
+import { MarketplaceManager } from "../../extensibility/plugins/marketplace";
+import {
+	getInstalledPluginsRegistryPath,
+	getMarketplacesCacheDir,
+	getMarketplacesRegistryPath,
+	getPluginsCacheDir,
+} from "../../extensibility/plugins/marketplace/registry";
 import { type AuthStatus, ContextService } from "../../services/f5xc-context";
 import { deriveTenantFromUrl } from "../../services/f5xc-env";
 import type { AuthStorage } from "../../session/auth-storage";
+import { normalizePluginDisplayName } from "./plugins/utils";
 
 // Startup validation budget. These are longer than validateToken's 3000ms default because
 // the welcome path runs during TLS/DNS cold-start — a single 3s shot races against warm-up
@@ -213,4 +221,46 @@ export interface FixableService {
 	prompt: string;
 	command: string[];
 	recheck: () => Promise<ServiceStatus>;
+}
+
+export interface RecommendedPluginStatus {
+	name: string;
+	installed: boolean;
+}
+
+export async function checkRecommendedPlugins(): Promise<RecommendedPluginStatus[]> {
+	try {
+		const mgr = new MarketplaceManager({
+			marketplacesRegistryPath: getMarketplacesRegistryPath(),
+			installedRegistryPath: getInstalledPluginsRegistryPath(),
+			marketplacesCacheDir: getMarketplacesCacheDir(),
+			pluginsCacheDir: getPluginsCacheDir(),
+			clearPluginRootsCache: () => {},
+		});
+
+		const [marketplaces, installedSummaries] = await Promise.all([
+			mgr.listMarketplaces(),
+			mgr.listInstalledPlugins(),
+		]);
+
+		const installedIds = new Set(installedSummaries.map(s => s.id));
+		const results: RecommendedPluginStatus[] = [];
+
+		for (const mkt of marketplaces) {
+			const available = await mgr.listAvailablePlugins(mkt.name).catch(() => []);
+			for (const entry of available) {
+				if (!entry.recommended) continue;
+				const pluginId = `${entry.name}@${mkt.name}`;
+				results.push({
+					name: normalizePluginDisplayName(entry.name),
+					installed: installedIds.has(pluginId),
+				});
+			}
+		}
+
+		return results.sort((a, b) => a.name.localeCompare(b.name));
+	} catch (err) {
+		logger.debug("checkRecommendedPlugins failed", { error: String(err) });
+		return [];
+	}
 }

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -2,7 +2,7 @@ import { type Component, padding, truncateToWidth, visibleWidth } from "@f5xc-sa
 import { APP_NAME } from "@f5xc-salesdemos/pi-utils";
 import { theme } from "../../modes/theme/theme";
 import { formatStatusIcon } from "../../services/f5xc-context-indicators";
-import type { ModelStatus, ServiceStatus } from "./welcome-checks";
+import type { ModelStatus, RecommendedPluginStatus, ServiceStatus } from "./welcome-checks";
 
 export interface UpdateStatus {
 	available: boolean;
@@ -15,6 +15,7 @@ export class WelcomeComponent implements Component {
 		private modelStatus: ModelStatus,
 		private services: ServiceStatus[] = [],
 		private updateStatus?: UpdateStatus,
+		private recommendedPlugins: RecommendedPluginStatus[] = [],
 	) {}
 	invalidate(): void {}
 	setModelStatus(status: ModelStatus): void {
@@ -25,6 +26,9 @@ export class WelcomeComponent implements Component {
 	}
 	setUpdateStatus(status: UpdateStatus | undefined): void {
 		this.updateStatus = status;
+	}
+	setRecommendedPlugins(plugins: RecommendedPluginStatus[]): void {
+		this.recommendedPlugins = plugins;
 	}
 
 	render(termWidth: number): string[] {
@@ -136,6 +140,12 @@ export class WelcomeComponent implements Component {
 				lines.push(this.#renderServiceLine(svc));
 			}
 		}
+		if (this.recommendedPlugins.length > 0) {
+			lines.push(" Recommended Plugins");
+			for (const p of this.recommendedPlugins) {
+				lines.push(this.#renderRecommendedLine(p));
+			}
+		}
 		if (this.#showUpdateSection()) {
 			lines.push(this.#renderUpdateLine());
 		}
@@ -163,7 +173,11 @@ export class WelcomeComponent implements Component {
 		lines.push("");
 		const coreServices = this.services.filter(s => !s._isPlugin);
 		const pluginServices = this.services.filter(s => s._isPlugin);
-		const hasContent = coreServices.length > 0 || pluginServices.length > 0 || this.#showUpdateSection();
+		const hasContent =
+			coreServices.length > 0 ||
+			pluginServices.length > 0 ||
+			this.recommendedPlugins.length > 0 ||
+			this.#showUpdateSection();
 		if (hasContent) {
 			lines.push(separator);
 			for (const svc of coreServices) {
@@ -179,12 +193,31 @@ export class WelcomeComponent implements Component {
 					}
 				}
 			}
+			if (this.recommendedPlugins.length > 0) {
+				lines.push("");
+				lines.push(` ${theme.fg("dim", "Recommended Plugins")}`);
+				for (const p of this.recommendedPlugins) {
+					lines.push(this.#renderRecommendedLine(p));
+				}
+				const missing = this.recommendedPlugins.filter(p => !p.installed);
+				if (missing.length > 0) {
+					lines.push(`   ${theme.fg("dim", "run: /plugin setup")}`);
+				}
+			}
+
 			if (this.#showUpdateSection()) {
 				lines.push(this.#renderUpdateLine());
 			}
 		}
 		lines.push("");
 		return lines;
+	}
+
+	#renderRecommendedLine(plugin: RecommendedPluginStatus): string {
+		if (plugin.installed) {
+			return ` ${formatStatusIcon("connected")} ${theme.fg("muted", plugin.name)}`;
+		}
+		return ` ${theme.fg("dim", "·")} ${theme.fg("dim", plugin.name)}`;
 	}
 
 	#showUpdateSection(): boolean {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -53,6 +53,7 @@ import { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
 import { type UpdateStatus, WelcomeComponent } from "./components/welcome";
 import {
+	checkRecommendedPlugins,
 	type FixableService,
 	mapContextStatus,
 	runWelcomeChecks,
@@ -386,12 +387,15 @@ export class InteractiveMode implements InteractiveModeContext {
 			}
 		}
 
+		const recommendedPlugins = !startupQuiet ? await checkRecommendedPlugins().catch(() => []) : [];
+
 		if (!startupQuiet) {
 			this.#welcomeComponent = new WelcomeComponent(
 				this.#version,
 				welcomeResult.model,
 				services,
 				this.#initialUpdateStatus,
+				recommendedPlugins,
 			);
 
 			// Setup UI layout

--- a/packages/coding-agent/test/welcome-recommended-plugins.test.ts
+++ b/packages/coding-agent/test/welcome-recommended-plugins.test.ts
@@ -1,0 +1,75 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { WelcomeComponent } from "@f5xc-salesdemos/xcsh/modes/components/welcome";
+import type { RecommendedPluginStatus } from "@f5xc-salesdemos/xcsh/modes/components/welcome-checks";
+import { initTheme } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+const MODEL_CONNECTED = { state: "connected" as const, provider: "anthropic" };
+
+describe("WelcomeComponent recommended plugins", () => {
+	it("renders recommended plugins section when plugins are provided", () => {
+		const plugins: RecommendedPluginStatus[] = [
+			{ name: "github-ops", installed: true },
+			{ name: "platform", installed: false },
+			{ name: "brand", installed: true },
+		];
+
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, plugins);
+		const lines = component.render(120);
+		const raw = lines.join("\n");
+
+		expect(raw).toContain("Recommended Plugins");
+		expect(raw).toContain("github-ops");
+		expect(raw).toContain("platform");
+		expect(raw).toContain("brand");
+	});
+
+	it("shows /plugin setup hint when some plugins are missing", () => {
+		const plugins: RecommendedPluginStatus[] = [
+			{ name: "github-ops", installed: true },
+			{ name: "platform", installed: false },
+		];
+
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, plugins);
+		const lines = component.render(120);
+		const raw = lines.join("\n");
+
+		expect(raw).toContain("/plugin setup");
+	});
+
+	it("does not show /plugin setup hint when all plugins are installed", () => {
+		const plugins: RecommendedPluginStatus[] = [
+			{ name: "github-ops", installed: true },
+			{ name: "platform", installed: true },
+		];
+
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, plugins);
+		const lines = component.render(120);
+		const raw = lines.join("\n");
+
+		expect(raw).toContain("Recommended Plugins");
+		expect(raw).not.toContain("/plugin setup");
+	});
+
+	it("does not render recommended section when list is empty", () => {
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, []);
+		const lines = component.render(120);
+		const raw = lines.join("\n");
+
+		expect(raw).not.toContain("Recommended Plugins");
+	});
+
+	it("setRecommendedPlugins updates the rendered output", () => {
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED);
+		let lines = component.render(120);
+		expect(lines.join("\n")).not.toContain("Recommended Plugins");
+
+		component.setRecommendedPlugins([{ name: "firecrawl", installed: false }]);
+		lines = component.render(120);
+		expect(lines.join("\n")).toContain("Recommended Plugins");
+		expect(lines.join("\n")).toContain("firecrawl");
+	});
+});


### PR DESCRIPTION
Closes #1181

## Summary
- Add "Recommended Plugins" section to the startup splash screen
- Each recommended plugin shows installed (✓) or missing (·) status
- Displays "run: /plugin setup" hint when any recommended plugins are missing
- Extract `normalizePluginDisplayName` to shared `plugins/utils.ts` for reuse

## Test plan
- [x] `bun run ci:check:full` — zero type errors
- [x] `bun test` — 4617 pass, 0 fail (5 new welcome screen tests)
- [ ] Launch xcsh — welcome screen shows "Recommended Plugins" section
- [ ] Install all recommended via `/plugin setup`, relaunch — all show as installed, hint disappears