### PR TITLE
fix(crud): add skip_crud_test support; skip namespace phrases on SE tenant

### DIFF
--- a/autoresearch-crud-phrases.yaml
+++ b/autoresearch-crud-phrases.yaml
@@ -84,12 +84,15 @@ phrases:
     api_path: service_policys
 
   # === namespace (4 phrases) ===
+  # skip_crud_test: true — account permission restriction on SE tenant (f5-amer-ent)
+  # namespace creation requires elevated permissions not available on this tenant
   - phrase: "Create a namespace named ar-test-ns with label env=test"
     operation: create
     resource: namespace
     resource_name: ar-test-ns
     api_path: namespaces
     namespace_scoped: false
+    skip_crud_test: true
     expect_fields: [name]
 
   - phrase: "Read the namespace named ar-test-ns"
@@ -98,6 +101,7 @@ phrases:
     resource_name: ar-test-ns
     api_path: namespaces
     namespace_scoped: false
+    skip_crud_test: true
     expect_fields: [name]
 
   - phrase: "Update namespace ar-test-ns to add label managed-by=autoresearch"
@@ -106,6 +110,7 @@ phrases:
     resource_name: ar-test-ns
     api_path: namespaces
     namespace_scoped: false
+    skip_crud_test: true
     expect_fields: [labels]
 
   - phrase: "Delete the namespace ar-test-ns"
@@ -114,6 +119,7 @@ phrases:
     resource_name: ar-test-ns
     api_path: namespaces
     namespace_scoped: false
+    skip_crud_test: true
 
   # === origin_pool (4 phrases) ===
   - phrase: "Create an origin pool named ar-test-pool in namespace r-mordasiewicz with one origin server at 10.0.1.10 on port 8080"

--- a/autoresearch-crud.sh
+++ b/autoresearch-crud.sh
@@ -131,6 +131,7 @@ json.dump({
     'api_path':         p.get('api_path',''),
     'namespace_scoped': p.get('namespace_scoped', True),
     'api_namespace':    p.get('api_namespace', ''),
+    'skip_crud_test':   p.get('skip_crud_test', False),
 }, open('${ws}/phrase.json', 'w'))
 "
   phrase=$(python3 -c "import json; print(json.load(open('${ws}/phrase.json'))['phrase'])")
@@ -141,6 +142,13 @@ json.dump({
   namespace_scoped=$(python3 -c "import json; print(json.load(open('${ws}/phrase.json'))['namespace_scoped'])")
   # api_namespace overrides NAMESPACE for verify_path (used for system-namespace resources)
   phrase_ns=$(python3 -c "import json; v=json.load(open('${ws}/phrase.json'))['api_namespace']; print(v if v else '${NAMESPACE}')")
+  skip_crud=$(python3 -c "import json; print(json.load(open('${ws}/phrase.json'))['skip_crud_test'])")
+
+  # Skip phrases flagged skip_crud_test (e.g. namespace — account permission restriction)
+  if [ "${skip_crud}" = "True" ]; then
+    echo "[$((idx + 1))/${phrase_count}] SKIP: ${operation}/${resource} (skip_crud_test=true)"
+    continue
+  fi
 
   total=$((total + 1))
   echo "[$((idx + 1))/${phrase_count}] ${operation}/${resource}: ${phrase:0:70}..."

--- a/autoresearch-crud.sh
+++ b/autoresearch-crud.sh
@@ -140,7 +140,7 @@ json.dump({
   api_path=$(python3 -c "import json; print(json.load(open('${ws}/phrase.json'))['api_path'])")
   namespace_scoped=$(python3 -c "import json; print(json.load(open('${ws}/phrase.json'))['namespace_scoped'])")
   # api_namespace overrides NAMESPACE for verify_path (used for system-namespace resources)
-  phrase_ns=$(python3 -c "import json; v=json.load(open('${ws}/phrase.json'))['api_namespace']; print(v if v else '${NAMESPACE}'")
+  phrase_ns=$(python3 -c "import json; v=json.load(open('${ws}/phrase.json'))['api_namespace']; print(v if v else '${NAMESPACE}')")
 
   total=$((total + 1))
   echo "[$((idx + 1))/${phrase_count}] ${operation}/${resource}: ${phrase:0:70}..."


### PR DESCRIPTION
## Summary
- autoresearch-crud.sh: skip_crud_test field support — phrases marked skip_crud_test: true are skipped (not counted as failures)
- autoresearch-crud-phrases.yaml: namespace CRUD phrases marked skip_crud_test: true — the SE tenant account (f5-amer-ent) does not have permission to create namespaces

95 total phrases, 91 active (4 namespace skipped). Eliminates false failures from permanent account restrictions.

Closes #1195

🤖 Generated with [Claude Code](https://claude.com/claude-code)