### PR TITLE
fix(xcsh-api): add explicit DELETE guidance for delete/destroy phrases

### DIFF
--- a/packages/coding-agent/src/internal-urls/terraform-index.generated.ts
+++ b/packages/coding-agent/src/internal-urls/terraform-index.generated.ts
@@ -133,13 +133,6 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			resources: ["certificate", "certificate_chain", "crl", "trusted_ca_list"],
 		},
 		{
-			name: "Applications",
-			slug: "applications",
-			description: "Application settings, types, discovery, and filtering",
-			resource_count: 4,
-			resources: ["app_setting", "app_type", "discovery", "filter_set"],
-		},
-		{
 			name: "Monitoring",
 			slug: "monitoring",
 			description: "Log receivers, alert policies, APM, and global logging configuration",
@@ -147,11 +140,11 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			resources: ["alert_receiver", "apm", "global_log_receiver", "log_receiver"],
 		},
 		{
-			name: "DNS",
-			slug: "dns",
-			description: "DNS domains, zones, compliance checks, and DNS proxy configuration",
-			resource_count: 3,
-			resources: ["dns_compliance_checks", "dns_domain", "dns_proxy"],
+			name: "Applications",
+			slug: "applications",
+			description: "Application settings, types, discovery, and filtering",
+			resource_count: 4,
+			resources: ["app_setting", "app_type", "discovery", "filter_set"],
 		},
 		{
 			name: "Authentication",
@@ -175,18 +168,18 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			resources: ["bigip_http_proxy", "data_group", "irule"],
 		},
 		{
+			name: "DNS",
+			slug: "dns",
+			description: "DNS domains, zones, compliance checks, and DNS proxy configuration",
+			resource_count: 3,
+			resources: ["dns_compliance_checks", "dns_domain", "dns_proxy"],
+		},
+		{
 			name: "Uncategorized",
 			slug: "uncategorized",
 			description: "Resources pending categorization",
 			resource_count: 2,
 			resources: ["application_profiles", "authorization_server"],
-		},
-		{
-			name: "Cloud Resources",
-			slug: "cloud-resources",
-			description: "Cloud elastic IPs, address allocators, and geo-location resources",
-			resource_count: 2,
-			resources: ["address_allocator", "cloud_elastic_ip"],
 		},
 		{
 			name: "Organization",
@@ -196,11 +189,11 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			resources: ["namespace", "tenant_configuration"],
 		},
 		{
-			name: "Service Mesh",
-			slug: "service-mesh",
-			description: "Service mesh policies and traffic management",
-			resource_count: 1,
-			resources: ["policer"],
+			name: "Cloud Resources",
+			slug: "cloud-resources",
+			description: "Cloud elastic IPs, address allocators, and geo-location resources",
+			resource_count: 2,
+			resources: ["address_allocator", "cloud_elastic_ip"],
 		},
 		{
 			name: "Integrations",
@@ -215,6 +208,13 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Cloud subscription management and metering",
 			resource_count: 1,
 			resources: ["cminstance"],
+		},
+		{
+			name: "Service Mesh",
+			slug: "service-mesh",
+			description: "Service mesh policies and traffic management",
+			resource_count: 1,
+			resources: ["policer"],
 		},
 	],
 	resources: {
@@ -1411,7 +1411,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			required: ["name", "namespace"],
 			oneof_groups: [
 				{
-					fields: ["allow_list", "deny_list", "rule_list"],
+					fields: ["allow_all_requests", "allow_list", "deny_all_requests", "deny_list", "rule_list"],
 				},
 				{
 					fields: ["any_server", "server_name", "server_name_matcher", "server_selector"],
@@ -1419,7 +1419,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			],
 			server_defaults: ["port_matcher", "any_server"],
 			minimal_config:
-				'resource "f5xc_service_policy" "example" {\n  name      = "example-service-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  // One of the arguments from this list "allow_list deny_list rule_list" must be set\n\n  rule_list {\n    rules {\n      metadata {\n        name = "allow-api"\n      }\n      spec {\n        action = "ALLOW"\n        any_client {}\n        any_ip {}\n        path {\n          prefix_values = ["/api/"]\n        }\n      }\n    }\n  }\n\n  // One of the arguments from this list "any_server server_name server_name_matcher server_selector" must be set\n\n  any_server {}\n}',
+				'resource "f5xc_service_policy" "example" {\n  name      = "example-service-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  // One of the arguments from this list "allow_all_requests allow_list deny_all_requests deny_list rule_list" must be set\n\n  rule_list {\n    rules {\n      metadata {\n        name = "allow-api"\n      }\n      spec {\n        action = "ALLOW"\n        any_client {}\n        any_ip {}\n        path {\n          prefix_values = ["/api/"]\n        }\n      }\n    }\n  }\n\n  // One of the arguments from this list "any_server server_name server_name_matcher server_selector" must be set\n\n  any_server {}\n}',
 			dependencies: {
 				requires: ["namespace"],
 			},

--- a/packages/coding-agent/src/prompts/tools/xcsh-api.md
+++ b/packages/coding-agent/src/prompts/tools/xcsh-api.md
@@ -23,6 +23,8 @@ API calls to the same F5 XC tenant reuse a single TLS connection — sequential 
 **Relationship queries**: When the batch response says "Inventory complete" and includes a `Resource relationships:` section, the specs and relationships are already fully fetched. Answer directly from that data. Do NOT make additional GET calls to read individual resources you already have from the batch.
 **Tenant-wide queries**: When asked about resources across ALL namespaces (e.g. "show all LBs in the entire tenant"), use `paths: ["*"]` with `params: {namespace: "*"}` to batch every namespace in ONE call. Do NOT list namespaces first — the wildcard handles discovery automatically.
 
+**Deleting resources** — when asked to delete, remove, or destroy an F5 XC resource, you **MUST** call `xcsh_api` with `method: "DELETE"` and `path` set to the resource's API endpoint including the resource name, e.g. `DELETE /api/config/namespaces/{namespace}/http_loadbalancers/{name}`. Pass `namespace` and `name` via `params`. No `payload` is needed for standard deletes. Do NOT respond with explanatory text instead of making the DELETE call — execute the deletion directly.
+
 **HTTP load balancer with origin pool** — when asked to create an LB routing to a named pool, use this exact payload structure (POST to `http_loadbalancers`):
 
 ```json


### PR DESCRIPTION
xcsh was not calling xcsh_api DELETE. Added explicit guidance. Verified: http_lb delete 404 ✓, malicious_user_mitigation 200 ✓. Closes #1199