### PR TITLE
feat: add SMSv2 option matrix benchmark

### DIFF
--- a/autoresearch-smsv2-phrases.yaml
+++ b/autoresearch-smsv2-phrases.yaml
@@ -1,0 +1,207 @@
+# SMSv2 Option Matrix — Natural Language Phrases for T1 Tests
+# Each phrase exercises one oneOf group in securemesh_site_v2
+# Benchmark: xcsh constructs payload → API accepts (HTTP 200) → PASS
+phrases:
+
+  # ── Group 1: node_ha ──────────────────────────────────────────────────────
+  - id: "1a"
+    option_group: node_ha
+    option_field: disable_ha
+    site_name: ar-test-smsv2-1a
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-1a in namespace system using Azure not_managed provider with HA disabled"
+    prerequisites: []
+
+  - id: "1b"
+    option_group: node_ha
+    option_field: enable_ha
+    site_name: ar-test-smsv2-1b
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-1b in namespace system using Azure not_managed provider with HA enabled for multi-node cluster"
+    prerequisites: []
+
+  # ── Group 2: blocked_services ─────────────────────────────────────────────
+  - id: "2a"
+    option_group: blocked_services
+    option_field: block_all_services
+    site_name: ar-test-smsv2-2a
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-2a in namespace system using Azure not_managed provider blocking all services"
+    prerequisites: []
+
+  - id: "2b"
+    option_group: blocked_services
+    option_field: blocked_services
+    site_name: ar-test-smsv2-2b
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-2b in namespace system using Azure not_managed provider with HTTP service in the blocked services list"
+    prerequisites: []
+
+  # ── Group 3: network_policy ───────────────────────────────────────────────
+  - id: "3a"
+    option_group: network_policy
+    option_field: no_network_policy
+    site_name: ar-test-smsv2-3a
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-3a in namespace system using Azure not_managed provider with no network policy"
+    prerequisites: []
+
+  - id: "3b"
+    option_group: network_policy
+    option_field: active_enhanced_firewall_policies
+    site_name: ar-test-smsv2-3b
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-3b in namespace system using Azure not_managed provider with enhanced firewall policy ar-test-smsv2-efp from namespace r-mordasiewicz"
+    prerequisites:
+      - type: enhanced_firewall_policy
+        name: ar-test-smsv2-efp
+        api_path: enhanced_firewall_policys
+        namespace: r-mordasiewicz
+        payload: '{"metadata":{"name":"ar-test-smsv2-efp","namespace":"r-mordasiewicz"},"spec":{}}'
+
+  # ── Group 4: forward_proxy ────────────────────────────────────────────────
+  - id: "4a"
+    option_group: forward_proxy
+    option_field: no_forward_proxy
+    site_name: ar-test-smsv2-4a
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-4a in namespace system using Azure not_managed provider with no forward proxy"
+    prerequisites: []
+
+  - id: "4b"
+    option_group: forward_proxy
+    option_field: active_forward_proxy_policies
+    site_name: ar-test-smsv2-4b
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-4b in namespace system using Azure not_managed provider with forward proxy policy ar-test-smsv2-fpp from namespace r-mordasiewicz"
+    prerequisites:
+      - type: forward_proxy_policy
+        name: ar-test-smsv2-fpp
+        api_path: forward_proxy_policys
+        namespace: r-mordasiewicz
+        payload: '{"metadata":{"name":"ar-test-smsv2-fpp","namespace":"r-mordasiewicz"},"spec":{"drp_http_connect":{},"allow_all":{}}}'
+
+  # ── Group 5: enterprise_proxy ─────────────────────────────────────────────
+  - id: "5a"
+    option_group: enterprise_proxy
+    option_field: f5_proxy
+    site_name: ar-test-smsv2-5a
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-5a in namespace system using Azure not_managed provider using F5 managed proxy"
+    prerequisites: []
+
+  - id: "5b"
+    option_group: enterprise_proxy
+    option_field: custom_proxy
+    site_name: ar-test-smsv2-5b
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-5b in namespace system using Azure not_managed provider with custom HTTP proxy at http://proxy.example.com:8080"
+    prerequisites: []
+
+  # ── Group 6: proxy_bypass ─────────────────────────────────────────────────
+  - id: "6a"
+    option_group: proxy_bypass
+    option_field: no_proxy_bypass
+    site_name: ar-test-smsv2-6a
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-6a in namespace system using Azure not_managed provider with no proxy bypass"
+    prerequisites: []
+
+  - id: "6b"
+    option_group: proxy_bypass
+    option_field: custom_proxy_bypass
+    site_name: ar-test-smsv2-6b
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-6b in namespace system using Azure not_managed provider with proxy bypass for 10.0.0.0/8 and 192.168.0.0/16"
+    prerequisites: []
+
+  # ── Group 7: logs_receiver ────────────────────────────────────────────────
+  - id: "7a"
+    option_group: logs_receiver
+    option_field: logs_streaming_disabled
+    site_name: ar-test-smsv2-7a
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-7a in namespace system using Azure not_managed provider with logs streaming disabled"
+    prerequisites: []
+
+  - id: "7b"
+    option_group: logs_receiver
+    option_field: log_receiver
+    site_name: ar-test-smsv2-7b
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-7b in namespace system using Azure not_managed provider sending logs to global log receiver ar-test-smsv2-glr in namespace r-mordasiewicz"
+    prerequisites:
+      - type: global_log_receiver
+        name: ar-test-smsv2-glr
+        api_path: global_log_receivers
+        namespace: r-mordasiewicz
+        payload: '{"metadata":{"name":"ar-test-smsv2-glr","namespace":"r-mordasiewicz"},"spec":{"request_logs":{},"http_receiver":{"uri":"http://logs.example.com:8080/logs","no_tls":{},"disable_authentication":{}}}}'
+
+  # ── Group 8: s2s_sli ──────────────────────────────────────────────────────
+  - id: "8a"
+    option_group: s2s_sli
+    option_field: no_s2s_connectivity_sli
+    site_name: ar-test-smsv2-8a
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-8a in namespace system using Azure not_managed provider with no site-to-site connectivity on SLI"
+    prerequisites: []
+
+  - id: "8b"
+    option_group: s2s_sli
+    option_field: dc_cluster_group_sli
+    site_name: ar-test-smsv2-8b
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-8b in namespace system using Azure not_managed provider with DC cluster group ar-test-smsv2-dcg from system namespace on SLI"
+    prerequisites:
+      - type: dc_cluster_group
+        name: ar-test-smsv2-dcg
+        api_path: dc_cluster_groups
+        namespace: system
+        payload: '{"metadata":{"name":"ar-test-smsv2-dcg","namespace":"system"},"spec":{}}'
+
+  # ── Group 9: s2s_slo ──────────────────────────────────────────────────────
+  - id: "9a"
+    option_group: s2s_slo
+    option_field: no_s2s_connectivity_slo
+    site_name: ar-test-smsv2-9a
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-9a in namespace system using Azure not_managed provider with no site-to-site connectivity on SLO"
+    prerequisites: []
+
+  - id: "9b"
+    option_group: s2s_slo
+    option_field: dc_cluster_group_slo
+    site_name: ar-test-smsv2-9b
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-9b in namespace system using Azure not_managed provider with DC cluster group ar-test-smsv2-dcg from system namespace on SLO"
+    prerequisites:
+      - type: dc_cluster_group
+        name: ar-test-smsv2-dcg
+        api_path: dc_cluster_groups
+        namespace: system
+        payload: '{"metadata":{"name":"ar-test-smsv2-dcg","namespace":"system"},"spec":{}}'
+
+  # ── Group 10: s2s_slo_mesh ────────────────────────────────────────────────
+  - id: "10"
+    option_group: s2s_slo_mesh
+    option_field: site_mesh_group_on_slo
+    site_name: ar-test-smsv2-10
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-10 in namespace system using Azure not_managed provider with site mesh group ar-test-smsv2-smg from system namespace on SLO"
+    prerequisites:
+      - type: site_mesh_group
+        name: ar-test-smsv2-smg
+        api_path: site_mesh_groups
+        namespace: system
+        payload: '{"metadata":{"name":"ar-test-smsv2-smg","namespace":"system"},"spec":{"type":"SITE_MESH_GROUP_TYPE_FULL_MESH","tunnel_type":"SITE_TO_SITE_TUNNEL_IPSEC","full_mesh":{"data_plane_mesh":{}},"bfd_disabled":{}}}'
+
+  # ── Group 11: url_categorization ──────────────────────────────────────────
+  - id: "11a"
+    option_group: url_categorization
+    option_field: disable_url_categorization
+    site_name: ar-test-smsv2-11a
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-11a in namespace system using Azure not_managed provider with URL categorization disabled"
+    prerequisites: []
+
+  - id: "11b"
+    option_group: url_categorization
+    option_field: enable_url_categorization
+    site_name: ar-test-smsv2-11b
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-11b in namespace system using Azure not_managed provider with URL categorization enabled"
+    prerequisites: []
+
+  # ── Group 12: management_network ──────────────────────────────────────────
+  - id: "12a"
+    option_group: management_network
+    option_field: disable_management_network
+    site_name: ar-test-smsv2-12a
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-12a in namespace system using Azure not_managed provider with management network disabled"
+    prerequisites: []
+
+  - id: "12b"
+    option_group: management_network
+    option_field: enable_management_network
+    site_name: ar-test-smsv2-12b
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-12b in namespace system using Azure not_managed provider with management network enabled"
+    prerequisites: []

--- a/autoresearch-smsv2.checks.sh
+++ b/autoresearch-smsv2.checks.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154
+set -euo pipefail
+
+# Cross-repo gate for SMSv2 autoresearch.
+# Reads benchmark output from stdin or RUN_DIR/benchmark.log.
+# exit 0 = no upstream issues (xcsh-only failures or no failures) → autoresearch loop continues
+# exit 1 = upstream fix needed → autoresearch stops with triage report
+
+if [ -n "${1:-}" ] && [ -d "$1" ]; then
+  RUN_DIR="$1"
+  if [ -f "${RUN_DIR}/benchmark.log" ]; then
+    OUTPUT=$(cat "${RUN_DIR}/benchmark.log")
+  elif [ -f "${RUN_DIR}/run.json" ]; then
+    OUTPUT=$(python3 -c "import json; d=json.load(open('${RUN_DIR}/run.json')); print(d.get('output',''))" 2>/dev/null || echo "")
+  else
+    OUTPUT=""
+  fi
+else
+  OUTPUT=$(cat)
+fi
+
+cross_repo=$(echo "${OUTPUT}" | grep "^ASI cross_repo_issues=" | sed 's/^ASI cross_repo_issues=//' || echo "{}")
+failures=$(echo "${OUTPUT}" | grep "^ASI failures=" | sed 's/^ASI failures=//' || echo "[]")
+
+if [ -z "${cross_repo}" ] || [ "${cross_repo}" = "{}" ]; then
+  echo "CHECKS: No ASI cross_repo_issues found — passing"
+  exit 0
+fi
+
+specs=$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); print(d.get('api-specs-enriched',0))" "${cross_repo}")
+xcsh_issues=$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); print(d.get('xcsh',0))" "${cross_repo}")
+
+payload_score=$(echo "${OUTPUT}" | grep "^METRIC smsv2_payload_score=" | sed 's/^METRIC smsv2_payload_score=//' | head -1 || echo "0")
+deployment_score=$(echo "${OUTPUT}" | grep "^METRIC smsv2_deployment_score=" | sed 's/^METRIC smsv2_deployment_score=//' | head -1 || echo "0")
+mesh_score=$(echo "${OUTPUT}" | grep "^METRIC smsv2_mesh_score=" | sed 's/^METRIC smsv2_mesh_score=//' | head -1 || echo "0")
+
+deploy_fail=0
+[ "${deployment_score}" = "0" ] && deploy_fail=1
+[ "${deployment_score}" = "skipped" ] && deploy_fail=0
+
+mesh_fail=0
+[ "${mesh_score}" = "0" ] && mesh_fail=1
+[ "${mesh_score}" = "skipped" ] && mesh_fail=0
+
+if [ "${specs}" -eq 0 ] && [ "${deploy_fail}" -eq 0 ] && [ "${mesh_fail}" -eq 0 ]; then
+  echo "CHECKS: All SMSv2 failures are xcsh-local — autoresearch can continue"
+  echo "  xcsh: ${xcsh_issues} issues"
+  exit 0
+fi
+
+echo ""
+echo "============================================"
+echo " SMSv2 AUTORESEARCH TRIAGE REPORT"
+echo "============================================"
+echo ""
+echo "Scores: payload=${payload_score}% deployment=${deployment_score} mesh=${mesh_score}"
+echo ""
+
+if [ "${specs}" -gt 0 ]; then
+  echo "--- api-specs-enriched fixes needed (${specs} issues) ---"
+  python3 -c "
+import json, sys
+failures = json.loads(sys.argv[1])
+for f in failures:
+    if f.get('fix_repo') == 'api-specs-enriched':
+        print(f'  [{f.get(\"error_type\",\"?\")}] {f.get(\"option_field\",\"?\")} (HTTP {f.get(\"http_code\",\"?\")})')
+        print(f'    Fix: api-specs-enriched/config/minimum_configs.yaml — check securemesh_site_v2 option_{f.get(\"option_field\",\"?\")} payload')
+" "${failures}"
+  echo ""
+fi
+
+if [ "${deploy_fail}" -eq 1 ]; then
+  echo "--- T2 CE Deployment FAILED ---"
+  echo "  The Azure CE did not reach ONLINE state within the timeout."
+  echo "  Actions: check cloud-init config, VPM logs, registration approval flow."
+  echo "  Reference: xcsh/autoresearch-smsv2.sh run_t2 function"
+  echo ""
+fi
+
+if [ "${mesh_fail}" -eq 1 ]; then
+  echo "--- T3 Mesh Connectivity FAILED ---"
+  echo "  One or both CEs did not reach ONLINE state within the timeout."
+  echo "  Actions: check site_mesh_group config, both CE registrations, Azure VNet routing."
+  echo "  Reference: xcsh/autoresearch-smsv2.sh run_t3 function"
+  echo ""
+fi
+
+echo "--- Next steps ---"
+[ "${specs}" -gt 0 ]    && echo "1. Fix api-specs-enriched gaps → make pipeline && merge"
+[ "${deploy_fail}" -eq 1 ] && echo "2. Fix T2 deployment issue → rerun autoresearch-smsv2.sh"
+[ "${mesh_fail}" -eq 1 ]   && echo "3. Fix T3 mesh issue → rerun autoresearch-smsv2.sh"
+echo "4. Restart autoresearch after all fixes"
+echo ""
+
+exit 1

--- a/autoresearch-smsv2.md
+++ b/autoresearch-smsv2.md
@@ -1,0 +1,34 @@
+## Benchmark
+
+- command: F5XC_API_URL=https://f5-amer-ent.console.ves.volterra.io F5XC_API_TOKEN=OULzp2FaqP1FTmgygm1dn5BDfYA= bash autoresearch-smsv2.sh
+- primary metric: smsv2_payload_score
+- metric unit: pct
+- direction: higher
+- secondary metrics:
+  - smsv2_deployment_score
+  - smsv2_mesh_score
+
+## Files in Scope
+
+- .xcsh/skills/
+- packages/coding-agent/src/prompts/tools/xcsh-api.md
+- packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
+
+## Off Limits
+
+- autoresearch-smsv2.sh
+- autoresearch-smsv2-phrases.yaml
+- autoresearch-smsv2.checks.sh
+- packages/coding-agent/src/autoresearch/
+
+## Constraints
+
+- do not modify the benchmark scripts
+- each option test must result in HTTP 200 from F5 XC API
+- all test resources are prefixed ar-test-smsv2-*
+- SMSv2 sites always created in system namespace
+- prerequisite objects (firewall policies, log receivers, cluster groups) created in r-mordasiewicz namespace
+- dc_cluster_group and site_mesh_group prerequisites created in system namespace
+- when T2 or T3 fail, stop and fix the deployment/mesh issue first
+- requires F5XC_API_URL and F5XC_API_TOKEN in environment
+- requires Azure CLI (az) authenticated for T2 and T3

--- a/autoresearch-smsv2.sh
+++ b/autoresearch-smsv2.sh
@@ -1,0 +1,786 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SMSv2 Option Matrix Benchmark
+# T1: Payload correctness (23 option tests — xcsh → F5 XC API 200)
+# T2: CE deployment (1 Azure CE → registration ONLINE)
+# T3: Mesh connectivity (2 Azure CEs + site_mesh_group → both ONLINE)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PHRASES_FILE="${PHRASES_FILE:-${SCRIPT_DIR}/autoresearch-smsv2-phrases.yaml}"
+WORK_DIR="/tmp/ar-smsv2-$$"
+API_URL="${F5XC_API_URL:-}"
+API_TOKEN="${F5XC_API_TOKEN:-}"
+NAMESPACE="r-mordasiewicz"
+AZURE_LOCATION="${AZURE_LOCATION:-canadaeast}"
+AZURE_RG_T2="ar-test-smsv2t2-rg"
+AZURE_RG_T3="ar-test-smsv2t3-rg"
+
+if [ -z "${API_URL}" ] || [ -z "${API_TOKEN}" ]; then
+  echo "ERROR: F5XC_API_URL and F5XC_API_TOKEN must be set" >&2
+  exit 1
+fi
+
+# ── API helpers ───────────────────────────────────────────────────────────────
+
+api_call() {
+  local method="$1" path="$2" data="${3:-}"
+  local code
+  for _ in 1 2 3; do
+    if [ -n "${data}" ]; then
+      code=$(curl -s -o /dev/null -w "%{http_code}" -X "${method}" \
+        -H "Authorization: APIToken ${API_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d "${data}" "${API_URL}${path}" 2>/dev/null || echo "000")
+    else
+      code=$(curl -s -o /dev/null -w "%{http_code}" -X "${method}" \
+        -H "Authorization: APIToken ${API_TOKEN}" \
+        "${API_URL}${path}" 2>/dev/null || echo "000")
+    fi
+    [ "${code}" != "000" ] && break
+    sleep 2
+  done
+  echo "${code}"
+}
+
+api_get()    { api_call GET    "$1"; }
+api_post()   { api_call POST   "$1" "$2"; }
+api_delete() { api_call DELETE "$1"; }
+
+# ── Cleanup trap ───────────────────────────────────────────────────────────────
+
+cleanup() {
+  echo ""
+  echo "Cleaning up test resources..."
+  # T1 SMSv2 sites (system namespace)
+  for code in 1a 1b 2a 2b 3a 3b 4a 4b 5a 5b 6a 6b 7a 7b 8a 8b 9a 9b 10 11a 11b 12a 12b; do
+    api_delete "/api/config/namespaces/system/securemesh_site_v2s/ar-test-smsv2-${code}" >/dev/null 2>&1 || true
+  done
+  # Prerequisite resources (user namespace)
+  for rtype in enhanced_firewall_policys forward_proxy_policys global_log_receivers; do
+    resources=$(curl -sf \
+      -H "Authorization: APIToken ${API_TOKEN}" \
+      "${API_URL}/api/config/namespaces/${NAMESPACE}/${rtype}" 2>/dev/null \
+      | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+items=d.get('items',d.get('objects',[]))
+for i in items:
+    name=i.get('name','') or i.get('metadata',{}).get('name','')
+    if name.startswith('ar-test-smsv2-'):
+        print(name)
+" 2>/dev/null || true)
+    for name in ${resources}; do
+      api_delete "/api/config/namespaces/${NAMESPACE}/${rtype}/${name}" >/dev/null 2>&1 || true
+    done
+  done
+  # Prerequisite resources (system namespace)
+  for rtype in dc_cluster_groups site_mesh_groups; do
+    resources=$(curl -sf \
+      -H "Authorization: APIToken ${API_TOKEN}" \
+      "${API_URL}/api/config/namespaces/system/${rtype}" 2>/dev/null \
+      | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+items=d.get('items',d.get('objects',[]))
+for i in items:
+    name=i.get('name','') or i.get('metadata',{}).get('name','')
+    if name.startswith('ar-test-smsv2-'):
+        print(name)
+" 2>/dev/null || true)
+    for name in ${resources}; do
+      api_delete "/api/config/namespaces/system/${rtype}/${name}" >/dev/null 2>&1 || true
+    done
+  done
+  # T2 and T3 Azure resource groups
+  if command -v az &>/dev/null; then
+    az group delete --name "${AZURE_RG_T2}" --yes --no-wait 2>/dev/null || true
+    az group delete --name "${AZURE_RG_T3}" --yes --no-wait 2>/dev/null || true
+  fi
+  # T2 and T3 F5 XC site objects
+  api_delete "/api/config/namespaces/system/securemesh_site_v2s/ar-test-smsv2-t2-site" >/dev/null 2>&1 || true
+  api_delete "/api/config/namespaces/system/securemesh_site_v2s/ar-test-smsv2-t3-site-a" >/dev/null 2>&1 || true
+  api_delete "/api/config/namespaces/system/securemesh_site_v2s/ar-test-smsv2-t3-site-b" >/dev/null 2>&1 || true
+  api_delete "/api/config/namespaces/system/site_mesh_groups/ar-test-smsv2-t3-smg" >/dev/null 2>&1 || true
+  rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+mkdir -p "${WORK_DIR}"
+
+# ── Prerequisite helpers ───────────────────────────────────────────────────────
+
+create_prerequisites() {
+  local phrase_idx="$1"
+  local phrases_file="$2"
+  python3 -c "
+import yaml, json, sys
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f)
+prereqs = data['phrases'][int(sys.argv[2])].get('prerequisites', [])
+json.dump(prereqs, sys.stdout)
+" "${phrases_file}" "${phrase_idx}" > "${WORK_DIR}/prereqs_${phrase_idx}.json"
+
+  python3 - "${WORK_DIR}/prereqs_${phrase_idx}.json" <<'PYEOF'
+import json, urllib.request, sys, os
+prereqs = json.load(open(sys.argv[1]))
+token = os.environ['F5XC_API_TOKEN']
+api_url = os.environ['F5XC_API_URL']
+for p in prereqs:
+    url = f'{api_url}/api/config/namespaces/{p["namespace"]}/{p["api_path"]}'
+    payload = json.loads(p['payload'])
+    req = urllib.request.Request(url, data=json.dumps(payload).encode(),
+        headers={'Authorization': f'APIToken {token}', 'Content-Type': 'application/json'}, method='POST')
+    try:
+        urllib.request.urlopen(req, timeout=15)
+        print(f'prereq created: {p["type"]} {p["name"]}')
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        if 'already exists' in body or e.code == 409:
+            print(f'prereq exists: {p["type"]} {p["name"]}')
+        else:
+            print(f'prereq FAIL {e.code}: {p["type"]} {p["name"]} - {body[:100]}', file=sys.stderr)
+PYEOF
+}
+
+delete_prerequisites() {
+  local phrase_idx="$1"
+  [ -f "${WORK_DIR}/prereqs_${phrase_idx}.json" ] || return 0
+  python3 - "${WORK_DIR}/prereqs_${phrase_idx}.json" <<'PYEOF'
+import json, urllib.request, sys, os
+prereqs = json.load(open(sys.argv[1]))
+token = os.environ['F5XC_API_TOKEN']
+api_url = os.environ['F5XC_API_URL']
+for p in prereqs:
+    url = f'{api_url}/api/config/namespaces/{p["namespace"]}/{p["api_path"]}/{p["name"]}'
+    req = urllib.request.Request(url, headers={'Authorization': f'APIToken {token}'}, method='DELETE')
+    try:
+        urllib.request.urlopen(req, timeout=10)
+    except Exception:
+        pass
+PYEOF
+}
+
+# ── T1: Payload correctness ────────────────────────────────────────────────────
+
+run_t1() {
+  echo "=== T1: Payload Correctness (23 option tests) ==="
+  echo ""
+
+  phrases_json="${WORK_DIR}/phrases.json"
+  python3 -c "
+import yaml, json
+with open('${PHRASES_FILE}') as f:
+    data = yaml.safe_load(f)
+json.dump(data['phrases'], open('${phrases_json}', 'w'))
+"
+  phrase_count=$(python3 -c "import json; print(len(json.load(open('${phrases_json}'))))")
+  echo "Loaded ${phrase_count} option phrases"
+  echo ""
+
+  t1_total=0
+  t1_pass=0
+  t1_failures_json="[]"
+  t1_xcsh_issues=0
+  t1_spec_issues=0
+
+  for idx in $(seq 0 $((phrase_count - 1))); do
+    python3 -c "
+import json
+phrases = json.load(open('${phrases_json}'))
+p = phrases[${idx}]
+json.dump({
+    'id': p['id'],
+    'option_group': p['option_group'],
+    'option_field': p['option_field'],
+    'site_name': p['site_name'],
+    'phrase': p['phrase'],
+}, open('${WORK_DIR}/p${idx}.json', 'w'))
+"
+    option_id=$(python3 -c "import json; print(json.load(open('${WORK_DIR}/p${idx}.json'))['id'])")
+    option_field=$(python3 -c "import json; print(json.load(open('${WORK_DIR}/p${idx}.json'))['option_field'])")
+    site_name=$(python3 -c "import json; print(json.load(open('${WORK_DIR}/p${idx}.json'))['site_name'])")
+    phrase=$(python3 -c "import json; print(json.load(open('${WORK_DIR}/p${idx}.json'))['phrase'])")
+
+    t1_total=$((t1_total + 1))
+    echo "[$((idx + 1))/${phrase_count}] ${option_id}/${option_field}: ${phrase:0:70}..."
+
+    # Create prerequisites before calling xcsh
+    create_prerequisites "${idx}" "${PHRASES_FILE}" 2>/dev/null || true
+
+    # Call xcsh
+    response=""
+    if command -v xcsh &>/dev/null; then
+      response=$(timeout 120 xcsh --print --no-session "${phrase}" 2>/dev/null || echo "")
+    else
+      echo "  SKIP: xcsh not in PATH"
+      t1_total=$((t1_total - 1))
+      delete_prerequisites "${idx}" 2>/dev/null || true
+      echo ""
+      continue
+    fi
+
+    # Verify site was created via direct API call
+    http_code=$(api_get "/api/config/namespaces/system/securemesh_site_v2s/${site_name}")
+
+    op_pass=0
+    error_type="UNKNOWN"
+    fix_repo="xcsh"
+
+    if [ "${http_code}" = "200" ]; then
+      op_pass=1
+      t1_pass=$((t1_pass + 1))
+    else
+      if echo "${response}" | grep -qiE "api call|POST|xcsh_api|securemesh|400|401|403|422|500"; then
+        error_type="API_REJECTED"
+        fix_repo="api-specs-enriched"
+        t1_spec_issues=$((t1_spec_issues + 1))
+      else
+        error_type="NO_API_CALL"
+        fix_repo="xcsh"
+        t1_xcsh_issues=$((t1_xcsh_issues + 1))
+      fi
+    fi
+
+    status="FAIL"
+    [ "${op_pass}" -eq 1 ] && status="PASS"
+    echo "  ${status}: option=${option_field} http=${http_code} fix=${fix_repo}"
+
+    if [ "${op_pass}" -eq 0 ]; then
+      phrase_escaped=$(python3 -c "import json,sys; print(json.dumps(sys.stdin.read().strip()))" <<< "${phrase}")
+      t1_failures_json=$(python3 -c "
+import json, sys
+failures = json.loads(sys.argv[1])
+failures.append({
+    'id': '${option_id}',
+    'option_field': '${option_field}',
+    'site_name': '${site_name}',
+    'phrase': json.loads(sys.argv[2]),
+    'error_type': '${error_type}',
+    'http_code': '${http_code}',
+    'fix_repo': '${fix_repo}',
+})
+print(json.dumps(failures))
+" "${t1_failures_json}" "${phrase_escaped}")
+    fi
+
+    # Clean up site and prerequisites after each test
+    api_delete "/api/config/namespaces/system/securemesh_site_v2s/${site_name}" >/dev/null 2>&1 || true
+    delete_prerequisites "${idx}" 2>/dev/null || true
+    echo ""
+  done
+
+  echo ""
+  echo "T1 complete: ${t1_pass}/${t1_total} passed"
+  echo ""
+
+  T1_TOTAL="${t1_total}"
+  T1_PASS="${t1_pass}"
+  T1_FAILURES="${t1_failures_json}"
+  T1_XCSH_ISSUES="${t1_xcsh_issues}"
+  T1_SPEC_ISSUES="${t1_spec_issues}"
+}
+
+run_t1
+
+# ── T2: CE Deployment ─────────────────────────────────────────────────────────
+
+run_t2() {
+  echo "=== T2: CE Deployment ==="
+  echo ""
+
+  if ! command -v az &>/dev/null; then
+    echo "SKIP T2: Azure CLI not available"
+    T2_SCORE="skipped"
+    return 0
+  fi
+  if ! az account show &>/dev/null 2>&1; then
+    echo "SKIP T2: Azure CLI not authenticated (run: az login)"
+    T2_SCORE="skipped"
+    return 0
+  fi
+
+  local site_name="ar-test-smsv2-t2-site"
+  local token_name="ar-test-smsv2-t2-token"
+  local vm_name="ar-test-smsv2-t2-ce"
+  local vnet_name="ar-test-smsv2-t2-vnet"
+
+  echo "Step 1: Create F5 XC registration token"
+  api_post "/api/register/namespaces/system/tokens" \
+    "{\"metadata\":{\"name\":\"${token_name}\",\"namespace\":\"system\"},\"spec\":{}}" >/dev/null 2>&1 || true
+  token_uid=$(curl -sf \
+    -H "Authorization: APIToken ${API_TOKEN}" \
+    "${API_URL}/api/register/namespaces/system/tokens/${token_name}" 2>/dev/null \
+    | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+uid=d.get('uid','') or d.get('spec',{}).get('uid','')
+print(uid)
+" 2>/dev/null || echo "")
+  if [ -z "${token_uid}" ]; then
+    echo "FAIL T2: could not retrieve token UID"
+    T2_SCORE=0
+    return 0
+  fi
+  echo "  Token UID: ${token_uid}"
+
+  echo "Step 2: Create SMSv2 site object"
+  site_payload="{\"metadata\":{\"name\":\"${site_name}\",\"namespace\":\"system\"},\"spec\":{\"azure\":{\"not_managed\":{\"node_list\":[]}},\"disable_ha\":{},\"block_all_services\":{},\"no_network_policy\":{},\"no_forward_proxy\":{},\"f5_proxy\":{},\"no_proxy_bypass\":{},\"logs_streaming_disabled\":{},\"no_s2s_connectivity_sli\":{},\"no_s2s_connectivity_slo\":{},\"disable_url_categorization\":{},\"disable_management_network\":{}}}"
+  site_code=$(api_post "/api/config/namespaces/system/securemesh_site_v2s" "${site_payload}")
+  if [ "${site_code}" != "200" ]; then
+    echo "FAIL T2: site create returned ${site_code}"
+    api_delete "/api/register/namespaces/system/tokens/${token_name}" >/dev/null 2>&1 || true
+    T2_SCORE=0
+    return 0
+  fi
+  echo "  Site created: ${site_name}"
+
+  echo "Step 3: Build cloud-init user-data"
+  cloud_init="${WORK_DIR}/t2-cloud-init.yaml"
+  cat > "${cloud_init}" << CLOUDINIT
+#cloud-config
+write_files:
+  - path: /etc/vpm/config.yaml
+    content: |
+      Vpm:
+        ClusterName: ${site_name}
+        ClusterType: ce
+        CertifiedHardware: generic-regular-nic-voltmesh
+        Token: ${token_uid}
+        Latitude: 43.7
+        Longitude: -79.4
+        MauricePrivateEndpoint: https://register-tls.ves.volterra.io
+        MauriceEndpoint: https://register.ves.volterra.io
+      Kubernetes:
+        EtcdUseTLS: True
+        Server: vip
+  - path: /etc/vpm/certified-hardware.yaml
+    content: |
+      active: generic-regular-nic-voltmesh
+      primaryOutsideNic: eth0
+      certifiedHardware:
+        generic-regular-nic-voltmesh:
+          outsideNic:
+            - eth0
+          Vpm:
+            PrivateNIC: eth0
+runcmd:
+  - mkdir -p /etc/systemd/network
+  - systemctl restart vpm
+CLOUDINIT
+
+  echo "Step 4: Provision Azure infrastructure"
+  az group create --name "${AZURE_RG_T2}" --location "${AZURE_LOCATION}" --output none
+
+  az network vnet create \
+    --resource-group "${AZURE_RG_T2}" \
+    --name "${vnet_name}" \
+    --address-prefix "10.200.0.0/16" \
+    --output none
+
+  az network vnet subnet create \
+    --resource-group "${AZURE_RG_T2}" \
+    --vnet-name "${vnet_name}" --name "outside" \
+    --address-prefix "10.200.1.0/24" --output none
+
+  az network vnet subnet create \
+    --resource-group "${AZURE_RG_T2}" \
+    --vnet-name "${vnet_name}" --name "inside" \
+    --address-prefix "10.200.2.0/24" --output none
+
+  az network nsg create \
+    --resource-group "${AZURE_RG_T2}" \
+    --name "ar-test-smsv2-t2-nsg" --output none
+
+  az network nsg rule create \
+    --resource-group "${AZURE_RG_T2}" \
+    --nsg-name "ar-test-smsv2-t2-nsg" \
+    --name "allow-all-inbound" --priority 100 \
+    --protocol "*" --source-address-prefixes "*" \
+    --destination-address-prefixes "*" \
+    --destination-port-ranges "*" \
+    --access Allow --direction Inbound --output none
+
+  az network nic create \
+    --resource-group "${AZURE_RG_T2}" --name "nic-outside" \
+    --vnet-name "${vnet_name}" --subnet "outside" \
+    --network-security-group "ar-test-smsv2-t2-nsg" \
+    --ip-forwarding true --output none
+
+  az network nic create \
+    --resource-group "${AZURE_RG_T2}" --name "nic-inside" \
+    --vnet-name "${vnet_name}" --subnet "inside" \
+    --ip-forwarding true --output none
+
+  IMAGE=$(az vm image list \
+    --publisher volterraedge --all \
+    --query "[?contains(offer,'voltmesh_node') || contains(offer,'entcloud')].urn | [-1]" \
+    -o tsv 2>/dev/null || echo "")
+  if [ -z "${IMAGE}" ]; then
+    echo "FAIL T2: could not find F5 XC CE image from publisher volterraedge"
+    T2_SCORE=0
+    return 0
+  fi
+  echo "  Using image: ${IMAGE}"
+  az vm image terms accept --urn "${IMAGE}" --output none 2>/dev/null || true
+
+  az vm create \
+    --resource-group "${AZURE_RG_T2}" \
+    --name "${vm_name}" \
+    --size "Standard_D4_v3" \
+    --image "${IMAGE}" \
+    --nics "nic-outside" "nic-inside" \
+    --admin-username azureuser \
+    --generate-ssh-keys \
+    --custom-data "${cloud_init}" \
+    --output none
+  echo "  VM deployed: ${vm_name}"
+
+  echo "Step 5: Poll for PENDING registration (up to 20 min)"
+  local reg_name=""
+  local deadline=$(($(date +%s) + 1200))
+  while [ "$(date +%s)" -lt "${deadline}" ]; do
+    reg_name=$(curl -sf \
+      -H "Authorization: APIToken ${API_TOKEN}" \
+      "${API_URL}/api/register/namespaces/system/registrations" 2>/dev/null \
+      | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for item in d.get('items',d.get('objects',[])):
+    meta=item.get('metadata',item)
+    spec=item.get('spec',{})
+    cluster=spec.get('cluster_name','') or spec.get('passport',{}).get('cluster_name','')
+    state=spec.get('state','')
+    if '${site_name}' in cluster and state == 'PENDING':
+        print(meta.get('name',''))
+        break
+" 2>/dev/null || echo "")
+    if [ -n "${reg_name}" ]; then
+      echo "  Registration PENDING: ${reg_name}"
+      break
+    fi
+    echo "  Waiting for registration... ($(( (deadline - $(date +%s)) / 60 ))m left)"
+    sleep 30
+  done
+
+  if [ -z "${reg_name}" ]; then
+    echo "FAIL T2: no PENDING registration appeared within 20 minutes"
+    T2_SCORE=0
+    return 0
+  fi
+
+  echo "Step 6: Approve registration"
+  passport=$(curl -sf \
+    -H "Authorization: APIToken ${API_TOKEN}" \
+    "${API_URL}/api/register/namespaces/system/registrations/${reg_name}" 2>/dev/null \
+    | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps(d.get('spec',{}).get('passport',{})))" \
+    2>/dev/null || echo "{}")
+  api_post "/api/register/namespaces/system/registrations/${reg_name}/approve" \
+    "{\"name\":\"${reg_name}\",\"namespace\":\"system\",\"passport\":${passport},\"state\":\"PENDING\"}" >/dev/null 2>&1 || true
+  sleep 3
+  api_post "/api/register/namespaces/system/registrations/${reg_name}/approve" \
+    "{\"name\":\"${reg_name}\",\"namespace\":\"system\",\"passport\":${passport},\"state\":\"APPROVED\"}" >/dev/null 2>&1 || true
+  echo "  Approval sent"
+
+  echo "Step 7: Poll for ONLINE state (up to 30 min)"
+  local online_deadline=$(($(date +%s) + 1800))
+  local reg_state=""
+  while [ "$(date +%s)" -lt "${online_deadline}" ]; do
+    reg_state=$(curl -sf \
+      -H "Authorization: APIToken ${API_TOKEN}" \
+      "${API_URL}/api/register/namespaces/system/registrations/${reg_name}" 2>/dev/null \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('spec',{}).get('state',''))" \
+      2>/dev/null || echo "")
+    echo "  State: ${reg_state} ($(( (online_deadline - $(date +%s)) / 60 ))m left)"
+    [ "${reg_state}" = "ONLINE" ] && break
+    sleep 60
+  done
+
+  if [ "${reg_state}" = "ONLINE" ]; then
+    echo "T2 PASS: CE registration ONLINE"
+    T2_SCORE=100
+  else
+    echo "T2 FAIL: state=${reg_state} (expected ONLINE)"
+    T2_SCORE=0
+  fi
+
+  # Cleanup T2
+  az group delete --name "${AZURE_RG_T2}" --yes --no-wait 2>/dev/null || true
+  api_delete "/api/config/namespaces/system/securemesh_site_v2s/${site_name}" >/dev/null 2>&1 || true
+  api_delete "/api/register/namespaces/system/tokens/${token_name}" >/dev/null 2>&1 || true
+}
+
+run_t2
+
+# ── T3: Mesh Connectivity ──────────────────────────────────────────────────────
+
+run_t3() {
+  echo "=== T3: Mesh Connectivity ==="
+  echo ""
+
+  if ! command -v az &>/dev/null || ! az account show &>/dev/null 2>&1; then
+    echo "SKIP T3: Azure CLI not available or not authenticated"
+    T3_SCORE="skipped"
+    return 0
+  fi
+
+  local smg_name="ar-test-smsv2-t3-smg"
+  local site_a="ar-test-smsv2-t3-site-a"
+  local site_b="ar-test-smsv2-t3-site-b"
+  local token_a="ar-test-smsv2-t3-token-a"
+  local token_b="ar-test-smsv2-t3-token-b"
+  local vnet_name="ar-test-smsv2-t3-vnet"
+
+  echo "Step 1: Create site_mesh_group"
+  smg_code=$(api_post "/api/config/namespaces/system/site_mesh_groups" \
+    "{\"metadata\":{\"name\":\"${smg_name}\",\"namespace\":\"system\"},\"spec\":{\"type\":\"SITE_MESH_GROUP_TYPE_FULL_MESH\",\"tunnel_type\":\"SITE_TO_SITE_TUNNEL_IPSEC\",\"full_mesh\":{\"data_plane_mesh\":{}},\"bfd_disabled\":{}}}")
+  if [ "${smg_code}" != "200" ]; then
+    echo "FAIL T3: site_mesh_group create returned ${smg_code}"
+    T3_SCORE=0
+    return 0
+  fi
+  echo "  site_mesh_group created: ${smg_name}"
+
+  echo "Step 2: Create registration tokens"
+  for tok_name in "${token_a}" "${token_b}"; do
+    api_post "/api/register/namespaces/system/tokens" \
+      "{\"metadata\":{\"name\":\"${tok_name}\",\"namespace\":\"system\"},\"spec\":{}}" >/dev/null 2>&1 || true
+  done
+  token_uid_a=$(curl -sf \
+    -H "Authorization: APIToken ${API_TOKEN}" \
+    "${API_URL}/api/register/namespaces/system/tokens/${token_a}" 2>/dev/null \
+    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('uid','') or d.get('spec',{}).get('uid',''))" 2>/dev/null || echo "")
+  token_uid_b=$(curl -sf \
+    -H "Authorization: APIToken ${API_TOKEN}" \
+    "${API_URL}/api/register/namespaces/system/tokens/${token_b}" 2>/dev/null \
+    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('uid','') or d.get('spec',{}).get('uid',''))" 2>/dev/null || echo "")
+
+  if [ -z "${token_uid_a}" ] || [ -z "${token_uid_b}" ]; then
+    echo "FAIL T3: could not retrieve token UIDs"
+    T3_SCORE=0
+    return 0
+  fi
+
+  echo "Step 3: Create SMSv2 site objects"
+  # Site A: no s2s on SLO (baseline CE)
+  api_post "/api/config/namespaces/system/securemesh_site_v2s" \
+    "{\"metadata\":{\"name\":\"${site_a}\",\"namespace\":\"system\"},\"spec\":{\"azure\":{\"not_managed\":{\"node_list\":[]}},\"disable_ha\":{},\"block_all_services\":{},\"no_network_policy\":{},\"no_forward_proxy\":{},\"f5_proxy\":{},\"no_proxy_bypass\":{},\"logs_streaming_disabled\":{},\"no_s2s_connectivity_sli\":{},\"no_s2s_connectivity_slo\":{},\"disable_url_categorization\":{},\"disable_management_network\":{}}}" >/dev/null 2>&1 || true
+  # Site B: joined to site_mesh_group on SLO
+  api_post "/api/config/namespaces/system/securemesh_site_v2s" \
+    "{\"metadata\":{\"name\":\"${site_b}\",\"namespace\":\"system\"},\"spec\":{\"azure\":{\"not_managed\":{\"node_list\":[]}},\"disable_ha\":{},\"block_all_services\":{},\"no_network_policy\":{},\"no_forward_proxy\":{},\"f5_proxy\":{},\"no_proxy_bypass\":{},\"logs_streaming_disabled\":{},\"no_s2s_connectivity_sli\":{},\"site_mesh_group_on_slo\":{\"name\":\"${smg_name}\",\"namespace\":\"system\"},\"disable_url_categorization\":{},\"disable_management_network\":{}}}" >/dev/null 2>&1 || true
+  echo "  Sites created: ${site_a}, ${site_b}"
+
+  echo "Step 4: Build cloud-init configs"
+  for suffix in a b; do
+    if [ "${suffix}" = "a" ]; then
+      cluster="${site_a}"
+      tok="${token_uid_a}"
+    else
+      cluster="${site_b}"
+      tok="${token_uid_b}"
+    fi
+    cat > "${WORK_DIR}/t3-cloud-init-${suffix}.yaml" << CLOUDINIT
+#cloud-config
+write_files:
+  - path: /etc/vpm/config.yaml
+    content: |
+      Vpm:
+        ClusterName: ${cluster}
+        ClusterType: ce
+        CertifiedHardware: generic-regular-nic-voltmesh
+        Token: ${tok}
+        Latitude: 43.7
+        Longitude: -79.4
+        MauricePrivateEndpoint: https://register-tls.ves.volterra.io
+        MauriceEndpoint: https://register.ves.volterra.io
+      Kubernetes:
+        EtcdUseTLS: True
+        Server: vip
+  - path: /etc/vpm/certified-hardware.yaml
+    content: |
+      active: generic-regular-nic-voltmesh
+      primaryOutsideNic: eth0
+      certifiedHardware:
+        generic-regular-nic-voltmesh:
+          outsideNic:
+            - eth0
+          Vpm:
+            PrivateNIC: eth0
+runcmd:
+  - mkdir -p /etc/systemd/network
+  - systemctl restart vpm
+CLOUDINIT
+  done
+
+  echo "Step 5: Provision Azure infrastructure (shared VNet, 4 subnets)"
+  az group create --name "${AZURE_RG_T3}" --location "${AZURE_LOCATION}" --output none
+
+  az network vnet create \
+    --resource-group "${AZURE_RG_T3}" \
+    --name "${vnet_name}" \
+    --address-prefix "10.201.0.0/16" --output none
+
+  for subnet_pair in "outside-a:10.201.1.0/24" "inside-a:10.201.2.0/24" "outside-b:10.201.3.0/24" "inside-b:10.201.4.0/24"; do
+    subnet_name="${subnet_pair%%:*}"
+    prefix="${subnet_pair##*:}"
+    az network vnet subnet create \
+      --resource-group "${AZURE_RG_T3}" \
+      --vnet-name "${vnet_name}" \
+      --name "${subnet_name}" \
+      --address-prefix "${prefix}" --output none
+  done
+
+  az network nsg create \
+    --resource-group "${AZURE_RG_T3}" \
+    --name "ar-test-smsv2-t3-nsg" --output none
+  az network nsg rule create \
+    --resource-group "${AZURE_RG_T3}" \
+    --nsg-name "ar-test-smsv2-t3-nsg" \
+    --name "allow-all-inbound" --priority 100 \
+    --protocol "*" --source-address-prefixes "*" \
+    --destination-address-prefixes "*" \
+    --destination-port-ranges "*" \
+    --access Allow --direction Inbound --output none
+
+  IMAGE=$(az vm image list \
+    --publisher volterraedge --all \
+    --query "[?contains(offer,'voltmesh_node') || contains(offer,'entcloud')].urn | [-1]" \
+    -o tsv 2>/dev/null || echo "")
+  if [ -z "${IMAGE}" ]; then
+    echo "FAIL T3: could not find CE image"
+    T3_SCORE=0
+    return 0
+  fi
+  az vm image terms accept --urn "${IMAGE}" --output none 2>/dev/null || true
+
+  for suffix in a b; do
+    az network nic create \
+      --resource-group "${AZURE_RG_T3}" \
+      --name "nic-outside-${suffix}" \
+      --vnet-name "${vnet_name}" --subnet "outside-${suffix}" \
+      --network-security-group "ar-test-smsv2-t3-nsg" \
+      --ip-forwarding true --output none
+    az network nic create \
+      --resource-group "${AZURE_RG_T3}" \
+      --name "nic-inside-${suffix}" \
+      --vnet-name "${vnet_name}" --subnet "inside-${suffix}" \
+      --ip-forwarding true --output none
+    az vm create \
+      --resource-group "${AZURE_RG_T3}" \
+      --name "ar-test-smsv2-t3-ce${suffix}" \
+      --size "Standard_D4_v3" --image "${IMAGE}" \
+      --nics "nic-outside-${suffix}" "nic-inside-${suffix}" \
+      --admin-username azureuser --generate-ssh-keys \
+      --custom-data "${WORK_DIR}/t3-cloud-init-${suffix}.yaml" \
+      --output none
+    echo "  VM ${suffix} deployed"
+  done
+
+  echo "Step 6: Poll for both PENDING registrations (up to 25 min)"
+  local deadline=$(($(date +%s) + 1500))
+  local reg_a="" reg_b=""
+  while [ "$(date +%s)" -lt "${deadline}" ]; do
+    all_regs=$(curl -sf \
+      -H "Authorization: APIToken ${API_TOKEN}" \
+      "${API_URL}/api/register/namespaces/system/registrations" 2>/dev/null \
+      | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+result={}
+for item in d.get('items',d.get('objects',[])):
+    meta=item.get('metadata',item)
+    spec=item.get('spec',{})
+    cluster=spec.get('cluster_name','') or spec.get('passport',{}).get('cluster_name','')
+    state=spec.get('state','')
+    name=meta.get('name','')
+    if '${site_a}' in cluster and state == 'PENDING':
+        result['a']=name
+    elif '${site_b}' in cluster and state == 'PENDING':
+        result['b']=name
+print(json.dumps(result))
+" 2>/dev/null || echo "{}")
+    reg_a=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('a',''))" "${all_regs}")
+    reg_b=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('b',''))" "${all_regs}")
+    echo "  Registrations: a=${reg_a:-waiting} b=${reg_b:-waiting} ($(( (deadline - $(date +%s)) / 60 ))m left)"
+    [ -n "${reg_a}" ] && [ -n "${reg_b}" ] && break
+    sleep 30
+  done
+
+  if [ -z "${reg_a}" ] || [ -z "${reg_b}" ]; then
+    echo "FAIL T3: registrations did not appear (a=${reg_a:-missing} b=${reg_b:-missing})"
+    T3_SCORE=0
+    return 0
+  fi
+
+  echo "Step 7: Approve both registrations"
+  for reg_name in "${reg_a}" "${reg_b}"; do
+    passport=$(curl -sf \
+      -H "Authorization: APIToken ${API_TOKEN}" \
+      "${API_URL}/api/register/namespaces/system/registrations/${reg_name}" 2>/dev/null \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps(d.get('spec',{}).get('passport',{})))" \
+      2>/dev/null || echo "{}")
+    api_post "/api/register/namespaces/system/registrations/${reg_name}/approve" \
+      "{\"name\":\"${reg_name}\",\"namespace\":\"system\",\"passport\":${passport},\"state\":\"PENDING\"}" >/dev/null 2>&1 || true
+    sleep 3
+    api_post "/api/register/namespaces/system/registrations/${reg_name}/approve" \
+      "{\"name\":\"${reg_name}\",\"namespace\":\"system\",\"passport\":${passport},\"state\":\"APPROVED\"}" >/dev/null 2>&1 || true
+    echo "  Approved: ${reg_name}"
+  done
+
+  echo "Step 8: Poll for both CEs ONLINE (up to 35 min)"
+  local online_deadline=$(($(date +%s) + 2100))
+  local state_a="" state_b=""
+  while [ "$(date +%s)" -lt "${online_deadline}" ]; do
+    state_a=$(curl -sf \
+      -H "Authorization: APIToken ${API_TOKEN}" \
+      "${API_URL}/api/register/namespaces/system/registrations/${reg_a}" 2>/dev/null \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('spec',{}).get('state',''))" 2>/dev/null || echo "")
+    state_b=$(curl -sf \
+      -H "Authorization: APIToken ${API_TOKEN}" \
+      "${API_URL}/api/register/namespaces/system/registrations/${reg_b}" 2>/dev/null \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('spec',{}).get('state',''))" 2>/dev/null || echo "")
+    echo "  States: a=${state_a} b=${state_b} ($(( (online_deadline - $(date +%s)) / 60 ))m left)"
+    [ "${state_a}" = "ONLINE" ] && [ "${state_b}" = "ONLINE" ] && break
+    sleep 60
+  done
+
+  if [ "${state_a}" = "ONLINE" ] && [ "${state_b}" = "ONLINE" ]; then
+    echo "T3 PASS: both CEs ONLINE — mesh plumbing verified"
+    T3_SCORE=100
+  else
+    echo "T3 FAIL: state_a=${state_a} state_b=${state_b} (both must be ONLINE)"
+    T3_SCORE=0
+  fi
+
+  # Cleanup T3
+  az group delete --name "${AZURE_RG_T3}" --yes --no-wait 2>/dev/null || true
+  for site in "${site_a}" "${site_b}"; do
+    api_delete "/api/config/namespaces/system/securemesh_site_v2s/${site}" >/dev/null 2>&1 || true
+  done
+  api_delete "/api/config/namespaces/system/site_mesh_groups/${smg_name}" >/dev/null 2>&1 || true
+  for tok_name in "${token_a}" "${token_b}"; do
+    api_delete "/api/register/namespaces/system/tokens/${tok_name}" >/dev/null 2>&1 || true
+  done
+}
+
+run_t3
+
+# ── Score emission ─────────────────────────────────────────────────────────────
+python3 - "${T2_SCORE}" "${T3_SCORE}" << PYEOF
+import sys
+t1_total = ${T1_TOTAL}
+t1_pass = ${T1_PASS}
+t2_score = sys.argv[1]
+t3_score = sys.argv[2]
+payload_score = round(t1_pass / max(1, t1_total) * 100, 1)
+print(f'METRIC smsv2_payload_score={payload_score}')
+print(f'METRIC smsv2_deployment_score={t2_score}')
+print(f'METRIC smsv2_mesh_score={t3_score}')
+print(f'METRIC smsv2_t1_tests={t1_total}')
+PYEOF
+
+cross_repo_json=$(python3 -c "
+import json
+print(json.dumps({'xcsh': ${T1_XCSH_ISSUES}, 'api-specs-enriched': ${T1_SPEC_ISSUES}, 'terraform-provider-f5xc': 0}))
+")
+echo "ASI failures=${T1_FAILURES}"
+echo "ASI cross_repo_issues=${cross_repo_json}"


### PR DESCRIPTION
## Summary

- Adds `autoresearch-smsv2.sh`: three-tier benchmark runner for `securemesh_site_v2` option matrix
- Adds `autoresearch-smsv2-phrases.yaml`: phrase library covering all 23 oneOf group options
- Adds `autoresearch-smsv2.md`: benchmark specification and scoring documentation
- Adds `autoresearch-smsv2.checks.sh`: exit-code hygiene (exit 0 = xcsh-local, exit 1 = upstream failure)

## Why

Adds three-tier autoresearch benchmark for the `securemesh_site_v2` option matrix:

- **T1** — exercises all 23 oneOf group options (xcsh → F5 XC API → 200 verify)
- **T2** — deploys a real Azure CE via proven cloud-init flow, verifies ONLINE registration
- **T3** — deploys two Azure CEs + `site_mesh_group_on_slo`, verifies both CEs ONLINE

Emits: `smsv2_payload_score`, `smsv2_deployment_score`, `smsv2_mesh_score`.

All prerequisite payloads verified live against SE tenant before implementation.

## Test plan

- [ ] Run `autoresearch-smsv2.sh` against SE tenant, confirm T1 payload score = 23/23
- [ ] Verify T2 deploys Azure CE and registers ONLINE within timeout
- [ ] Verify T3 mesh group forms between two CEs
- [ ] Confirm `autoresearch-smsv2.checks.sh` exits 0 for local xcsh errors, 1 for upstream failures

Closes #1210

🤖 Generated with [Claude Code](https://claude.com/claude-code)