### PR TITLE
fix: correct token UID extraction to use system_metadata.uid

### DIFF
--- a/autoresearch-smsv2.sh
+++ b/autoresearch-smsv2.sh
@@ -313,7 +313,7 @@ run_t2() {
     | python3 -c "
 import json,sys
 d=json.load(sys.stdin)
-uid=d.get('uid','') or d.get('spec',{}).get('uid','')
+uid=d.get('system_metadata',{}).get('uid','') or d.get('uid','') or d.get('spec',{}).get('uid','')
 print(uid)
 " 2>/dev/null || echo "")
   if [ -z "${token_uid}" ]; then
@@ -548,11 +548,11 @@ run_t3() {
   token_uid_a=$(curl -sf \
     -H "Authorization: APIToken ${API_TOKEN}" \
     "${API_URL}/api/register/namespaces/system/tokens/${token_a}" 2>/dev/null \
-    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('uid','') or d.get('spec',{}).get('uid',''))" 2>/dev/null || echo "")
+    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('system_metadata',{}).get('uid','') or d.get('uid','') or d.get('spec',{}).get('uid',''))" 2>/dev/null || echo "")
   token_uid_b=$(curl -sf \
     -H "Authorization: APIToken ${API_TOKEN}" \
     "${API_URL}/api/register/namespaces/system/tokens/${token_b}" 2>/dev/null \
-    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('uid','') or d.get('spec',{}).get('uid',''))" 2>/dev/null || echo "")
+    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('system_metadata',{}).get('uid','') or d.get('uid','') or d.get('spec',{}).get('uid',''))" 2>/dev/null || echo "")
 
   if [ -z "${token_uid_a}" ] || [ -z "${token_uid_b}" ]; then
     echo "FAIL T3: could not retrieve token UIDs"


### PR DESCRIPTION
## What

Fix token UID extraction in T2 and T3 functions of `autoresearch-smsv2.sh` to check `system_metadata.uid` first.

## Why

The F5 XC registration token API returns the UID under `system_metadata.uid`, not at the top-level `uid` or `spec.uid`. T2 and T3 were failing with "could not retrieve token UID" because the python3 inline extractors only checked `d.get('uid','')` and `d.get('spec',{}).get('uid','')`. All three extraction points now check `system_metadata.uid` first, with fallback to `uid` and `spec.uid` for forward-compatibility.

## Testing

Manually verified the extraction logic against the actual API response shape. The fix is a targeted 3-line change across the three UID extraction points in T2 and T3.

---

- [x] Change is limited to the bugfix (no scope creep)
- [x] All three UID extraction points updated consistently

Closes #1213