### PR TITLE
feat: plugin profile reconciliation with field-ownership model

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -19,6 +19,8 @@ import type { CustomMessage } from "../../session/messages";
 import { EventBus } from "../../utils/event-bus";
 import { getAllPluginExtensionPaths } from "../plugins/loader";
 import { resolvePath } from "../utils";
+import type { ProfileCollector } from "../../internal-urls/profile-collectors";
+import { registerProfileCollector as registerProfileCollectorCore } from "../../internal-urls/profile-collectors";
 import type {
 	Extension,
 	ExtensionAPI,
@@ -179,6 +181,10 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 
 	registerServiceStatus(contribution: ServiceStatusContribution): void {
 		this.extension.serviceStatuses.set(contribution.name, contribution);
+	}
+
+	registerProfileCollector(collector: ProfileCollector): void {
+		registerProfileCollectorCore(collector);
 	}
 
 	getFlag(name: string): boolean | string | undefined {

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -15,12 +15,12 @@ import { loadCapability } from "../../discovery";
 import { getExtensionNameFromPath } from "../../discovery/helpers";
 import type { ExecOptions } from "../../exec/exec";
 import { execCommand } from "../../exec/exec";
+import type { ProfileCollector } from "../../internal-urls/profile-collectors";
+import { registerProfileCollector as registerProfileCollectorCore } from "../../internal-urls/profile-collectors";
 import type { CustomMessage } from "../../session/messages";
 import { EventBus } from "../../utils/event-bus";
 import { getAllPluginExtensionPaths } from "../plugins/loader";
 import { resolvePath } from "../utils";
-import type { ProfileCollector } from "../../internal-urls/profile-collectors";
-import { registerProfileCollector as registerProfileCollectorCore } from "../../internal-urls/profile-collectors";
 import type {
 	Extension,
 	ExtensionAPI,

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -58,6 +58,7 @@ import type {
 	WriteToolInput,
 } from "../../tools";
 import type { TodoItem } from "../../tools/todo-write";
+import type { ProfileCollector } from "../../internal-urls/profile-collectors";
 import type { EventBus } from "../../utils/event-bus";
 import type { SlashCommandInfo } from "../slash-commands";
 
@@ -1080,6 +1081,9 @@ export interface ExtensionAPI {
 
 	/** Register a service status check for the welcome screen. */
 	registerServiceStatus(contribution: ServiceStatusContribution): void;
+
+	/** Register a profile collector that pushes discovered person-data to the user profile. */
+	registerProfileCollector(collector: ProfileCollector): void;
 
 	// =========================================================================
 	// Actions

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -35,6 +35,7 @@ import type { ModelRegistry } from "../../config/model-registry";
 import type { EditToolDetails } from "../../edit";
 import type { BashResult } from "../../exec/bash-executor";
 import type { ExecOptions, ExecResult } from "../../exec/exec";
+import type { ProfileCollector } from "../../internal-urls/profile-collectors";
 import type { PythonResult } from "../../ipy/executor";
 import type { Theme } from "../../modes/theme/theme";
 import type { CompactionPreparation, CompactionResult } from "../../session/compaction";
@@ -58,7 +59,6 @@ import type {
 	WriteToolInput,
 } from "../../tools";
 import type { TodoItem } from "../../tools/todo-write";
-import type { ProfileCollector } from "../../internal-urls/profile-collectors";
 import type { EventBus } from "../../utils/event-bus";
 import type { SlashCommandInfo } from "../slash-commands";
 

--- a/packages/coding-agent/src/internal-urls/profile-collectors.ts
+++ b/packages/coding-agent/src/internal-urls/profile-collectors.ts
@@ -52,4 +52,14 @@ const systemCollector: ProfileCollector = {
 // Registry
 // ---------------------------------------------------------------------------
 
-export const PROFILE_COLLECTORS: readonly ProfileCollector[] = [systemCollector];
+const _collectors: ProfileCollector[] = [systemCollector];
+
+export const PROFILE_COLLECTORS: readonly ProfileCollector[] = _collectors;
+
+export function registerProfileCollector(collector: ProfileCollector): void {
+	if (_collectors.some(c => c.id === collector.id)) {
+		logger.warn(`Profile collector '${collector.id}' already registered, skipping`);
+		return;
+	}
+	_collectors.push(collector);
+}

--- a/packages/coding-agent/src/internal-urls/user-profile.ts
+++ b/packages/coding-agent/src/internal-urls/user-profile.ts
@@ -145,6 +145,7 @@ export async function seedProfile(): Promise<UserProfile> {
 }
 
 const META_FIELDS = new Set(["sources", "observations", "updatedAt", "_fieldOwnership"]);
+const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
 export function reconcileProfile(
 	target: UserProfile,
@@ -155,6 +156,7 @@ export function reconcileProfile(
 
 	for (const [key, value] of Object.entries(source)) {
 		if (value === undefined || value === null) continue;
+		if (FORBIDDEN_KEYS.has(key)) continue;
 		const k = key as keyof UserProfile;
 		if (META_FIELDS.has(k)) continue;
 
@@ -164,9 +166,9 @@ export function reconcileProfile(
 		if (currentOwner && currentOwner !== sourceId) continue;
 		if (!currentOwner && target[k] !== undefined && target[k] !== null) continue;
 
-		(target as Record<string, unknown>)[k] = value;
+		Object.defineProperty(target, k, { value, writable: true, enumerable: true, configurable: true });
 		if (!currentOwner) {
-			ownership[k] = sourceId;
+			Object.defineProperty(ownership, k, { value: sourceId, writable: true, enumerable: true, configurable: true });
 		}
 	}
 

--- a/packages/coding-agent/src/internal-urls/user-profile.ts
+++ b/packages/coding-agent/src/internal-urls/user-profile.ts
@@ -147,11 +147,7 @@ export async function seedProfile(): Promise<UserProfile> {
 const META_FIELDS = new Set(["sources", "observations", "updatedAt", "_fieldOwnership"]);
 const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
-export function reconcileProfile(
-	target: UserProfile,
-	source: Partial<UserProfile>,
-	sourceId: string,
-): void {
+export function reconcileProfile(target: UserProfile, source: Partial<UserProfile>, sourceId: string): void {
 	const ownership = target._fieldOwnership ?? {};
 
 	for (const [key, value] of Object.entries(source)) {

--- a/packages/coding-agent/src/internal-urls/user-profile.ts
+++ b/packages/coding-agent/src/internal-urls/user-profile.ts
@@ -67,6 +67,8 @@ export interface UserProfile {
 	observations?: UserProfileObservation[];
 	sources?: { github?: string; system?: string; conversation?: string };
 	updatedAt?: string;
+	/** Tracks which collector ID authoritatively owns each top-level field. */
+	_fieldOwnership?: Record<string, string>;
 }
 
 const PROFILE_PATH = path.join(os.homedir(), ".xcsh", "user-profile.json");
@@ -133,6 +135,59 @@ export async function seedProfile(): Promise<UserProfile> {
 			mergeProfile(profile, partial);
 			(profile.sources as Record<string, string>)[collector.id] = new Date().toISOString();
 			logger.debug(`Profile collector '${collector.id}' completed`);
+		} catch (err: unknown) {
+			logger.debug(`Profile collector '${collector.id}' failed`, { error: err });
+		}
+	}
+
+	await saveProfile(profile);
+	return profile;
+}
+
+const META_FIELDS = new Set(["sources", "observations", "updatedAt", "_fieldOwnership"]);
+
+export function reconcileProfile(
+	target: UserProfile,
+	source: Partial<UserProfile>,
+	sourceId: string,
+): void {
+	const ownership = target._fieldOwnership ?? {};
+
+	for (const [key, value] of Object.entries(source)) {
+		if (value === undefined || value === null) continue;
+		const k = key as keyof UserProfile;
+		if (META_FIELDS.has(k)) continue;
+
+		const currentOwner = ownership[k];
+
+		if (currentOwner === "user") continue;
+		if (currentOwner && currentOwner !== sourceId) continue;
+		if (!currentOwner && target[k] !== undefined && target[k] !== null) continue;
+
+		(target as Record<string, unknown>)[k] = value;
+		if (!currentOwner) {
+			ownership[k] = sourceId;
+		}
+	}
+
+	target._fieldOwnership = ownership;
+}
+
+export async function reconcileFromCollectors(): Promise<UserProfile> {
+	const profile = await loadProfile();
+	if (!profile.sources) profile.sources = {};
+
+	for (const collector of PROFILE_COLLECTORS) {
+		try {
+			const isAvailable = await collector.available();
+			if (!isAvailable) {
+				logger.debug(`Profile collector '${collector.id}' not available, skipping`);
+				continue;
+			}
+			const partial = await collector.collect();
+			reconcileProfile(profile, partial, collector.id);
+			(profile.sources as Record<string, string>)[collector.id] = new Date().toISOString();
+			logger.debug(`Profile collector '${collector.id}' reconciled`);
 		} catch (err: unknown) {
 			logger.debug(`Profile collector '${collector.id}' failed`, { error: err });
 		}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -29,7 +29,7 @@ import type { CompactOptions } from "../extensibility/extensions/types";
 import { BUILTIN_SLASH_COMMANDS, loadSlashCommands } from "../extensibility/slash-commands";
 import { resolveLocalUrlToPath } from "../internal-urls";
 import { seedComputerProfile } from "../internal-urls/computer-profile";
-import { seedProfile } from "../internal-urls/user-profile";
+import { reconcileFromCollectors } from "../internal-urls/user-profile";
 import { renameApprovedPlanFile } from "../plan-mode/approved-plan";
 import planModeApprovedPrompt from "../prompts/system/plan-mode-approved.md" with { type: "text" };
 import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
@@ -321,7 +321,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		);
 
 		// Refresh user profile in background — fire and forget
-		seedProfile().catch(err => logger.warn("Background profile refresh failed", { error: String(err) }));
+		reconcileFromCollectors().catch(err => logger.warn("Background profile refresh failed", { error: String(err) }));
 		// Refresh computer profile in background — fire and forget
 		seedComputerProfile().catch(err =>
 			logger.warn("Background computer profile refresh failed", { error: String(err) }),


### PR DESCRIPTION
Closes #1223

## Summary
- Adds `registerProfileCollector()` to the Extension API so plugins can push discovered person-data back to `user-profile.json`
- Introduces `reconcileProfile()` with a `_fieldOwnership` map — source-of-truth collectors can overwrite their owned fields while user-authored fields stay protected
- Replaces `seedProfile()` at session startup with `reconcileFromCollectors()` so plugin-contributed collectors run alongside the built-in system collector

## Test plan
- [ ] Unit test `reconcileProfile()` for all 5 ownership scenarios (empty fill, owner overwrite, user-protected, cross-source skip, implicit user-authored)
- [ ] Unit test `registerProfileCollector()` for registration and duplicate rejection
- [ ] Integration test: mock a collector, run `reconcileFromCollectors()`, verify profile updated with `_fieldOwnership` entries
- [ ] Manual: start session with Salesforce plugin installed, verify `~/.xcsh/user-profile.json` gets updated manager field

🤖 Generated with [Claude Code](https://claude.com/claude-code)