### PR TITLE
fix(tui): reserve F5 red border for brand chrome, use dim border on errors

### DIFF
--- a/packages/coding-agent/src/tui/output-block.ts
+++ b/packages/coding-agent/src/tui/output-block.ts
@@ -21,7 +21,7 @@ export interface OutputBlockOptions {
 	sections?: Array<{ label?: string; lines: string[] }>;
 	width: number;
 	applyBg?: boolean;
-	/** Override the state-derived border color. Use sparingly — only for branded core tools. */
+	/** Override the state-derived border color. Always takes precedence, including on error. Use for branded core tools. */
 	borderColor?: ThemeColor;
 }
 
@@ -39,14 +39,11 @@ export function renderOutputBlock(options: OutputBlockOptions, theme: Theme): st
 	const v = theme.boxSharp.vertical;
 	const cap = h.repeat(3);
 	const lineWidth = Math.max(0, width);
-	// Border colors: error→error (red), warning→warning, running/pending→spinnerAccent, success→dim.
-	// borderColorOverride (from options) takes precedence for non-error states on F5-branded tools (e.g. XC-API);
-	// override is always cleared on error so all tools show a consistent error border; use F5_TOOL_BORDER_COLOR.
+	// borderColorOverride (F5 brand chrome) always takes precedence;
+	// built-in tools without an override use dim borders regardless of error state.
 	const resolvedBorderColor: ThemeColor =
-		state === "error"
-			? "error"
-			: (borderColorOverride ??
-				(state === "warning" ? "warning" : state === "running" || state === "pending" ? "spinnerAccent" : "dim"));
+		borderColorOverride ??
+		(state === "warning" ? "warning" : state === "running" || state === "pending" ? "spinnerAccent" : "dim");
 	const border = (text: string) => theme.fg(resolvedBorderColor, text);
 	const bgFn = (() => {
 		if (!state || !applyBg) return undefined;


### PR DESCRIPTION
Closes #1227

## Summary
- Reserves the F5 red thin frame border exclusively for xcsh custom tool brand chrome
- Built-in tools (bash, read, write, python, etc.) now use a neutral `dim` border on error — same as success state
- Error indication for all tools relies on the existing `toolErrorBg` background tint, red error text, and status icons
- `borderColorOverride` (used by custom tools via `F5_TOOL_BORDER_COLOR`) now always takes precedence, including on error state

## Test plan
- [ ] Run xcsh, execute a failing bash command (`false` or `ls /nonexistent`) — confirm dim border with reddish background tint
- [ ] Trigger a custom xcsh tool error — confirm F5 red border persists with reddish background tint
- [ ] Verify success state appearance is unchanged for both built-in and custom tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)