### PR TITLE
fix(smsv2): forward_proxy_policy must be in system namespace with allow_all only

### DIFF
--- a/autoresearch-smsv2-phrases.yaml
+++ b/autoresearch-smsv2-phrases.yaml
@@ -65,13 +65,13 @@ phrases:
     option_group: forward_proxy
     option_field: active_forward_proxy_policies
     site_name: ar-test-smsv2-4b
-    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-4b in namespace system using Azure not_managed provider with forward proxy policy ar-test-smsv2-fpp from namespace r-mordasiewicz"
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-4b in namespace system using Azure not_managed provider with forward proxy policy ar-test-smsv2-fpp from namespace system"
     prerequisites:
       - type: forward_proxy_policy
         name: ar-test-smsv2-fpp
         api_path: forward_proxy_policys
-        namespace: r-mordasiewicz
-        payload: '{"metadata":{"name":"ar-test-smsv2-fpp","namespace":"r-mordasiewicz"},"spec":{"drp_http_connect":{},"allow_all":{}}}'
+        namespace: system
+        payload: '{"metadata":{"name":"ar-test-smsv2-fpp","namespace":"system"},"spec":{"allow_all":{}}}'
 
   # ── Group 5: enterprise_proxy ─────────────────────────────────────────────
   - id: "5a"

--- a/autoresearch-smsv2-phrases.yaml
+++ b/autoresearch-smsv2-phrases.yaml
@@ -45,13 +45,13 @@ phrases:
     option_group: network_policy
     option_field: active_enhanced_firewall_policies
     site_name: ar-test-smsv2-3b
-    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-3b in namespace system using Azure not_managed provider with enhanced firewall policy ar-test-smsv2-efp from namespace r-mordasiewicz"
+    phrase: "Create a SecureMesh site v2 named ar-test-smsv2-3b in namespace system using Azure not_managed provider with enhanced firewall policy ar-test-smsv2-efp from namespace system"
     prerequisites:
       - type: enhanced_firewall_policy
         name: ar-test-smsv2-efp
         api_path: enhanced_firewall_policys
-        namespace: r-mordasiewicz
-        payload: '{"metadata":{"name":"ar-test-smsv2-efp","namespace":"r-mordasiewicz"},"spec":{}}'
+        namespace: system
+        payload: '{"metadata":{"name":"ar-test-smsv2-efp","namespace":"system"},"spec":{}}'
 
   # ── Group 4: forward_proxy ────────────────────────────────────────────────
   - id: "4a"

--- a/autoresearch-smsv2.sh
+++ b/autoresearch-smsv2.sh
@@ -56,8 +56,26 @@ cleanup() {
   for code in 1a 1b 2a 2b 3a 3b 4a 4b 5a 5b 6a 6b 7a 7b 8a 8b 9a 9b 10 11a 11b 12a 12b; do
     api_delete "/api/config/namespaces/system/securemesh_site_v2s/ar-test-smsv2-${code}" >/dev/null 2>&1 || true
   done
+  # enhanced_firewall_policys now created in system namespace (not user namespace)
+  for rtype in enhanced_firewall_policys; do
+    resources=$(curl -sf \
+      -H "Authorization: APIToken ${API_TOKEN}" \
+      "${API_URL}/api/config/namespaces/system/${rtype}" 2>/dev/null \
+      | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+items=d.get('items',d.get('objects',[]))
+for i in items:
+    name=i.get('name','') or i.get('metadata',{}).get('name','')
+    if name.startswith('ar-test-smsv2-'):
+        print(name)
+" 2>/dev/null || true)
+    for name in ${resources}; do
+      api_delete "/api/config/namespaces/system/${rtype}/${name}" >/dev/null 2>&1 || true
+    done
+  done
   # Prerequisite resources (user namespace)
-  for rtype in enhanced_firewall_policys forward_proxy_policys global_log_receivers; do
+  for rtype in forward_proxy_policys global_log_receivers; do
     resources=$(curl -sf \
       -H "Authorization: APIToken ${API_TOKEN}" \
       "${API_URL}/api/config/namespaces/${NAMESPACE}/${rtype}" 2>/dev/null \

--- a/autoresearch-smsv2.sh
+++ b/autoresearch-smsv2.sh
@@ -313,8 +313,17 @@ import json, sys, os, urllib.request
 site = sys.argv[1]; api = sys.argv[2]; tok = os.environ.get('F5XC_API_TOKEN','')
 d = json.load(sys.stdin)
 items = d.get('items', d.get('objects', []))
-# Scan only the last 20 — new registrations appear at the end of the list
-for item in items[-20:]:
+# Pre-filter: Azure registrations carry ves.io/provider=ves-io-AZURE label.
+# Only ~12 of 82 registrations are Azure, so this cuts scan work ~7x.
+# Fall back to items with no provider label so we never miss an untagged VM.
+candidates = []
+for item in items:
+    lbl = item.get('labels') or {}
+    provider = lbl.get('ves.io/provider', '')
+    if 'AZURE' in provider.upper() or not provider:
+        candidates.append(item)
+# Scan newest-first (end of list = most recently registered)
+for item in reversed(candidates):
     name = item.get('name','') or (item.get('metadata') or {}).get('name','')
     if not name: continue
     try:
@@ -557,11 +566,23 @@ run_t3() {
   cat > "${WORK_DIR}/find_reg2.py" << 'PYEOF'
 import json, sys, os, urllib.request
 site_a=sys.argv[1]; site_b=sys.argv[2]; api=sys.argv[3]; tok=os.environ.get('F5XC_API_TOKEN','')
+# Pass optional min_idx to skip already-scanned items
+min_idx = int(sys.argv[4]) if len(sys.argv) > 4 else 0
 d=json.load(sys.stdin)
 items=d.get('items',d.get('objects',[]))
-# Scan only the last 20 — new registrations appear at the end of the list
+# Pre-filter: Azure registrations have ves.io/provider=ves-io-AZURE label
+# Scan from min_idx (track position across polls to avoid re-scanning)
+candidates=[]
+for i, item in enumerate(items):
+    if i < min_idx: continue
+    lbl = item.get('labels') or {}
+    provider = lbl.get('ves.io/provider','')
+    # Include if Azure provider OR no provider info (fall back to full scan)
+    if 'AZURE' in provider.upper() or not provider:
+        candidates.append((i, item))
+# Scan candidates, newest first (end of list = most recent)
 result={}
-for item in items[-20:]:
+for idx, item in reversed(candidates):
     name=item.get('name','') or (item.get('metadata') or {}).get('name','')
     if not name or name in result.values(): continue
     try:

--- a/autoresearch-smsv2.sh
+++ b/autoresearch-smsv2.sh
@@ -74,8 +74,26 @@ for i in items:
       api_delete "/api/config/namespaces/system/${rtype}/${name}" >/dev/null 2>&1 || true
     done
   done
+  # forward_proxy_policys now created in system namespace (same as enhanced_firewall_policys)
+  for rtype in forward_proxy_policys; do
+    resources=$(curl -sf \
+      -H "Authorization: APIToken ${API_TOKEN}" \
+      "${API_URL}/api/config/namespaces/system/${rtype}" 2>/dev/null \
+      | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+items=d.get('items',d.get('objects',[]))
+for i in items:
+    name=i.get('name','') or i.get('metadata',{}).get('name','')
+    if name.startswith('ar-test-smsv2-'):
+        print(name)
+" 2>/dev/null || true)
+    for name in ${resources}; do
+      api_delete "/api/config/namespaces/system/${rtype}/${name}" >/dev/null 2>&1 || true
+    done
+  done
   # Prerequisite resources (user namespace)
-  for rtype in forward_proxy_policys global_log_receivers; do
+  for rtype in global_log_receivers; do
     resources=$(curl -sf \
       -H "Authorization: APIToken ${API_TOKEN}" \
       "${API_URL}/api/config/namespaces/${NAMESPACE}/${rtype}" 2>/dev/null \

--- a/packages/coding-agent/src/prompts/tools/xcsh-api.md
+++ b/packages/coding-agent/src/prompts/tools/xcsh-api.md
@@ -69,7 +69,7 @@ Each of the 12 oneOf groups has two or three mutually exclusive choices — pick
 |node_ha|`"disable_ha":{}` OR `"enable_ha":{}`||
 |blocked_services|`"block_all_services":{}` OR `"blocked_services":{"service_list":[{"service":"HTTP"}]}`||
 |network_policy|`"no_network_policy":{}` OR `"active_enhanced_firewall_policies":{"enhanced_firewall_policies":[{"name":"<n>","namespace":"system"}]}`|prereq: create `enhanced_firewall_policys` in **system** namespace with `spec:{}` — inner field is `enhanced_firewall_policies` (no "active_" prefix), policy **MUST** be in system namespace|
-|forward_proxy|`"no_forward_proxy":{}` OR `"active_forward_proxy_policies":{"active_forward_proxy_policies":[{"name":"<n>","namespace":"<ns>"}]}`|prereq: create `forward_proxy_policys` with `spec:{"drp_http_connect":{},"allow_all":{}}` — drp_http_connect **REQUIRED**|
+|forward_proxy|`"no_forward_proxy":{}` OR `"active_forward_proxy_policies":{"forward_proxy_policies":[{"name":"<n>","namespace":"system"}]}`|prereq: create `forward_proxy_policys` in **system** namespace with `spec:{"allow_all":{}}` — inner field is `forward_proxy_policies` (no "active_" prefix), policy **MUST** be in system namespace, do NOT add drp_http_connect in system namespace|
 |enterprise_proxy|`"f5_proxy":{}` OR `"custom_proxy":{"http_proxy":"http://proxy:8080","https_proxy":"http://proxy:8080"}`||
 |proxy_bypass|`"no_proxy_bypass":{}` OR `"custom_proxy_bypass":{"bypass_list":["10.0.0.0/8"]}`||
 |logs_receiver|`"logs_streaming_disabled":{}` OR `"log_receiver":{"name":"<n>","namespace":"<ns>"}`|prereq: create `global_log_receivers` with `spec:{"request_logs":{},"http_receiver":{"uri":"http://logs:8080","no_tls":{},"disable_authentication":{}}}`|

--- a/packages/coding-agent/src/prompts/tools/xcsh-api.md
+++ b/packages/coding-agent/src/prompts/tools/xcsh-api.md
@@ -68,7 +68,7 @@ Each of the 12 oneOf groups has two or three mutually exclusive choices — pick
 |---|---|---|
 |node_ha|`"disable_ha":{}` OR `"enable_ha":{}`||
 |blocked_services|`"block_all_services":{}` OR `"blocked_services":{"service_list":[{"service":"HTTP"}]}`||
-|network_policy|`"no_network_policy":{}` OR `"active_enhanced_firewall_policies":{"active_enhanced_firewall_policies":[{"name":"<n>","namespace":"<ns>"}]}`|prereq: create `enhanced_firewall_policys` with `spec:{}` first|
+|network_policy|`"no_network_policy":{}` OR `"active_enhanced_firewall_policies":{"enhanced_firewall_policies":[{"name":"<n>","namespace":"system"}]}`|prereq: create `enhanced_firewall_policys` in **system** namespace with `spec:{}` — inner field is `enhanced_firewall_policies` (no "active_" prefix), policy MUST be in system namespace|
 |forward_proxy|`"no_forward_proxy":{}` OR `"active_forward_proxy_policies":{"active_forward_proxy_policies":[{"name":"<n>","namespace":"<ns>"}]}`|prereq: create `forward_proxy_policys` with `spec:{"drp_http_connect":{},"allow_all":{}}` — drp_http_connect **REQUIRED**|
 |enterprise_proxy|`"f5_proxy":{}` OR `"custom_proxy":{"http_proxy":"http://proxy:8080","https_proxy":"http://proxy:8080"}`||
 |proxy_bypass|`"no_proxy_bypass":{}` OR `"custom_proxy_bypass":{"bypass_list":["10.0.0.0/8"]}`||

--- a/packages/coding-agent/src/prompts/tools/xcsh-api.md
+++ b/packages/coding-agent/src/prompts/tools/xcsh-api.md
@@ -68,7 +68,7 @@ Each of the 12 oneOf groups has two or three mutually exclusive choices — pick
 |---|---|---|
 |node_ha|`"disable_ha":{}` OR `"enable_ha":{}`||
 |blocked_services|`"block_all_services":{}` OR `"blocked_services":{"service_list":[{"service":"HTTP"}]}`||
-|network_policy|`"no_network_policy":{}` OR `"active_enhanced_firewall_policies":{"enhanced_firewall_policies":[{"name":"<n>","namespace":"system"}]}`|prereq: create `enhanced_firewall_policys` in **system** namespace with `spec:{}` — inner field is `enhanced_firewall_policies` (no "active_" prefix), policy MUST be in system namespace|
+|network_policy|`"no_network_policy":{}` OR `"active_enhanced_firewall_policies":{"enhanced_firewall_policies":[{"name":"<n>","namespace":"system"}]}`|prereq: create `enhanced_firewall_policys` in **system** namespace with `spec:{}` — inner field is `enhanced_firewall_policies` (no "active_" prefix), policy **MUST** be in system namespace|
 |forward_proxy|`"no_forward_proxy":{}` OR `"active_forward_proxy_policies":{"active_forward_proxy_policies":[{"name":"<n>","namespace":"<ns>"}]}`|prereq: create `forward_proxy_policys` with `spec:{"drp_http_connect":{},"allow_all":{}}` — drp_http_connect **REQUIRED**|
 |enterprise_proxy|`"f5_proxy":{}` OR `"custom_proxy":{"http_proxy":"http://proxy:8080","https_proxy":"http://proxy:8080"}`||
 |proxy_bypass|`"no_proxy_bypass":{}` OR `"custom_proxy_bypass":{"bypass_list":["10.0.0.0/8"]}`||


### PR DESCRIPTION
Closes #1246

## Summary

Discovered live that `forward_proxy_policy` for SMSv2 `active_forward_proxy_policies` has three requirements that differ from previous implementation:

- Policy must be in **system** namespace (same as `enhanced_firewall_policy`)
- Inner spec field is `forward_proxy_policies` (no `active_` prefix)
- Policy spec must be `{allow_all:{}}` only — `drp_http_connect` is **forbidden** in system namespace

## Changes

- **`autoresearch-smsv2-phrases.yaml`**: fix prerequisite namespace from `r-mordasiewicz` → `system`, remove `drp_http_connect` from prerequisite payload
- **`autoresearch-smsv2.sh`**: add cleanup trap block for `forward_proxy_policys` in system namespace; remove `forward_proxy_policys` from the user-namespace cleanup loop
- **`packages/coding-agent/src/prompts/tools/xcsh-api.md`**: correct inner field name (`forward_proxy_policies`, not `active_forward_proxy_policies`), add system namespace requirement, and update spec guidance to `allow_all` only

## Test plan

- [ ] Run `autoresearch-smsv2.sh` against a phrase from group `forward_proxy` (id `4a`) and confirm site creates successfully with the corrected policy namespace and spec
- [ ] Confirm cleanup trap deletes `forward_proxy_policys` from system namespace after test run
- [ ] Confirm `xcsh-api.md` renders correctly (`bun run format-prompts` passes with no changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)