### PR TITLE
fix: rename import alias to avoid bundler shadow on registerProfileCollector

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -16,7 +16,7 @@ import { getExtensionNameFromPath } from "../../discovery/helpers";
 import type { ExecOptions } from "../../exec/exec";
 import { execCommand } from "../../exec/exec";
 import type { ProfileCollector } from "../../internal-urls/profile-collectors";
-import { registerProfileCollector as registerProfileCollectorCore } from "../../internal-urls/profile-collectors";
+import { registerProfileCollector as addProfileCollector } from "../../internal-urls/profile-collectors";
 import type { CustomMessage } from "../../session/messages";
 import { EventBus } from "../../utils/event-bus";
 import { getAllPluginExtensionPaths } from "../plugins/loader";
@@ -184,7 +184,7 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 	}
 
 	registerProfileCollector(collector: ProfileCollector): void {
-		registerProfileCollectorCore(collector);
+		addProfileCollector(collector);
 	}
 
 	getFlag(name: string): boolean | string | undefined {


### PR DESCRIPTION
Closes #1260

## Summary
- Bundler inlined `registerProfileCollectorCore` back to `registerProfileCollector`, causing infinite recursion in `ConcreteExtensionAPI.registerProfileCollector()`
- Renamed import alias to `addProfileCollector` which the bundler cannot shadow

## Root cause
This is why the Salesforce collector never registered at runtime — the `typeof pi.registerProfileCollector === 'function'` check passed but the actual call stack-overflowed silently.

## Test plan
- [x] 321 existing tests pass
- [ ] Install new version, verify `strings` on binary shows `addProfileCollector(collector)` not self-call
- [ ] Start interactive session, verify manager updates from Salesforce

🤖 Generated with [Claude Code](https://claude.com/claude-code)