### PR TITLE
fix: use namespace import to prevent bundler shadow on registerProfileCollector

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -16,7 +16,7 @@ import { getExtensionNameFromPath } from "../../discovery/helpers";
 import type { ExecOptions } from "../../exec/exec";
 import { execCommand } from "../../exec/exec";
 import type { ProfileCollector } from "../../internal-urls/profile-collectors";
-import { registerProfileCollector as addProfileCollector } from "../../internal-urls/profile-collectors";
+import * as profileCollectors from "../../internal-urls/profile-collectors";
 import type { CustomMessage } from "../../session/messages";
 import { EventBus } from "../../utils/event-bus";
 import { getAllPluginExtensionPaths } from "../plugins/loader";
@@ -184,7 +184,7 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 	}
 
 	registerProfileCollector(collector: ProfileCollector): void {
-		addProfileCollector(collector);
+		profileCollectors.registerProfileCollector(collector);
 	}
 
 	getFlag(name: string): boolean | string | undefined {


### PR DESCRIPTION
Closes #1264

## Summary
- Import aliases (`as addProfileCollector`, `as registerProfileCollectorCore`) are resolved through to the original name by the bundler
- Switched to `import * as profileCollectors` with `profileCollectors.registerProfileCollector(collector)` — the property access cannot be collapsed

## Test plan
- [x] 321 tests pass
- [ ] Verify bundled binary uses property access pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)