### PR TITLE
fix: use collectorRegistry object to survive bundler inlining

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -16,7 +16,7 @@ import { getExtensionNameFromPath } from "../../discovery/helpers";
 import type { ExecOptions } from "../../exec/exec";
 import { execCommand } from "../../exec/exec";
 import type { ProfileCollector } from "../../internal-urls/profile-collectors";
-import * as profileCollectors from "../../internal-urls/profile-collectors";
+import { collectorRegistry } from "../../internal-urls/profile-collectors";
 import type { CustomMessage } from "../../session/messages";
 import { EventBus } from "../../utils/event-bus";
 import { getAllPluginExtensionPaths } from "../plugins/loader";
@@ -184,7 +184,7 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 	}
 
 	registerProfileCollector(collector: ProfileCollector): void {
-		profileCollectors.registerProfileCollector(collector);
+		collectorRegistry.register(collector);
 	}
 
 	getFlag(name: string): boolean | string | undefined {

--- a/packages/coding-agent/src/internal-urls/profile-collectors.ts
+++ b/packages/coding-agent/src/internal-urls/profile-collectors.ts
@@ -72,3 +72,8 @@ export function unregisterProfileCollector(id: string): boolean {
 	_collectors.splice(idx, 1);
 	return true;
 }
+
+export const collectorRegistry = {
+	register: registerProfileCollector,
+	unregister: unregisterProfileCollector,
+};


### PR DESCRIPTION
Closes #1269

## Summary
- Export `collectorRegistry = { register, unregister }` from profile-collectors
- Loader calls `collectorRegistry.register(collector)` — property access on a runtime object survives bundler inlining
- Previous attempts with import aliases and namespace imports both failed

## Test plan
- [x] 321 tests pass
- [ ] Verify binary shows `collectorRegistry.register(collector)` not self-call

🤖 Generated with [Claude Code](https://claude.com/claude-code)