### PR TITLE
fix: update nightly toolchain and inline collector registration

### DIFF
--- a/crates/brush-builtins-vendored/src/alias.rs
+++ b/crates/brush-builtins-vendored/src/alias.rs
@@ -6,48 +6,44 @@ use brush_core::{ExecutionResult, builtins};
 /// Manage aliases within the shell.
 #[derive(Parser)]
 pub(crate) struct AliasCommand {
-    /// Print all defined aliases in a reusable format.
-    #[arg(short = 'p')]
-    print: bool,
+	/// Print all defined aliases in a reusable format.
+	#[arg(short = 'p')]
+	print: bool,
 
-    /// List of aliases to display or update.
-    #[arg(name = "name[=value]")]
-    aliases: Vec<String>,
+	/// List of aliases to display or update.
+	#[arg(name = "name[=value]")]
+	aliases: Vec<String>,
 }
 
 impl builtins::Command for AliasCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        let mut exit_code = ExecutionResult::success();
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		let mut exit_code = ExecutionResult::success();
 
-        if self.print || self.aliases.is_empty() {
-            for (name, value) in &context.shell.aliases {
-                writeln!(context.stdout(), "alias {name}='{value}'")?;
-            }
-        } else {
-            for alias in &self.aliases {
-                if let Some((name, unexpanded_value)) = alias.split_once('=') {
-                    context
-                        .shell
-                        .aliases
-                        .insert(name.to_owned(), unexpanded_value.to_owned());
-                } else if let Some(value) = context.shell.aliases.get(alias) {
-                    writeln!(context.stdout(), "alias {alias}='{value}'")?;
-                } else {
-                    writeln!(
-                        context.stderr(),
-                        "{}: {alias}: not found",
-                        context.command_name
-                    )?;
-                    exit_code = ExecutionResult::general_error();
-                }
-            }
-        }
+		if self.print || self.aliases.is_empty() {
+			for (name, value) in &context.shell.aliases {
+				writeln!(context.stdout(), "alias {name}='{value}'")?;
+			}
+		} else {
+			for alias in &self.aliases {
+				if let Some((name, unexpanded_value)) = alias.split_once('=') {
+					context
+						.shell
+						.aliases
+						.insert(name.to_owned(), unexpanded_value.to_owned());
+				} else if let Some(value) = context.shell.aliases.get(alias) {
+					writeln!(context.stdout(), "alias {alias}='{value}'")?;
+				} else {
+					writeln!(context.stderr(), "{}: {alias}: not found", context.command_name)?;
+					exit_code = ExecutionResult::general_error();
+				}
+			}
+		}
 
-        Ok(exit_code)
-    }
+		Ok(exit_code)
+	}
 }

--- a/crates/brush-builtins-vendored/src/bg.rs
+++ b/crates/brush-builtins-vendored/src/bg.rs
@@ -6,42 +6,37 @@ use brush_core::{ExecutionResult, builtins};
 /// Moves a job to run in the background.
 #[derive(Parser)]
 pub(crate) struct BgCommand {
-    /// List of job specs to move to background.
-    job_specs: Vec<String>,
+	/// List of job specs to move to background.
+	job_specs: Vec<String>,
 }
 
 impl builtins::Command for BgCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        let mut exit_code = ExecutionResult::success();
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		let mut exit_code = ExecutionResult::success();
 
-        if !self.job_specs.is_empty() {
-            for job_spec in &self.job_specs {
-                if let Some(job) = context.shell.jobs.resolve_job_spec(job_spec) {
-                    job.move_to_background()?;
-                } else {
-                    writeln!(
-                        context.stderr(),
-                        "{}: {}: no such job",
-                        context.command_name,
-                        job_spec
-                    )?;
-                    exit_code = ExecutionResult::general_error();
-                }
-            }
-        } else {
-            if let Some(job) = context.shell.jobs.current_job_mut() {
-                job.move_to_background()?;
-            } else {
-                writeln!(context.stderr(), "{}: no current job", context.command_name)?;
-                exit_code = ExecutionResult::general_error();
-            }
-        }
+		if !self.job_specs.is_empty() {
+			for job_spec in &self.job_specs {
+				if let Some(job) = context.shell.jobs.resolve_job_spec(job_spec) {
+					job.move_to_background()?;
+				} else {
+					writeln!(context.stderr(), "{}: {}: no such job", context.command_name, job_spec)?;
+					exit_code = ExecutionResult::general_error();
+				}
+			}
+		} else {
+			if let Some(job) = context.shell.jobs.current_job_mut() {
+				job.move_to_background()?;
+			} else {
+				writeln!(context.stderr(), "{}: no current job", context.command_name)?;
+				exit_code = ExecutionResult::general_error();
+			}
+		}
 
-        Ok(exit_code)
-    }
+		Ok(exit_code)
+	}
 }

--- a/crates/brush-builtins-vendored/src/bind.rs
+++ b/crates/brush-builtins-vendored/src/bind.rs
@@ -4,390 +4,379 @@ use strum::IntoEnumIterator;
 use tokio::sync::Mutex;
 
 use brush_core::{
-    ExecutionExitCode, ExecutionResult, builtins, error, interfaces, sys, trace_categories,
+	ExecutionExitCode, ExecutionResult, builtins, error, interfaces, sys, trace_categories,
 };
 
 /// Identifier for a keymap
 #[derive(Clone, ValueEnum)]
 enum BindKeyMap {
-    #[clap(name = "emacs-standard", alias = "emacs")]
-    EmacsStandard,
-    #[clap(name = "emacs-meta")]
-    EmacsMeta,
-    #[clap(name = "emacs-ctlx")]
-    EmacsCtlx,
-    #[clap(name = "vi-command", aliases = &["vi", "vi-move"])]
-    ViCommand,
-    #[clap(name = "vi-insert")]
-    ViInsert,
+	#[clap(name = "emacs-standard", alias = "emacs")]
+	EmacsStandard,
+	#[clap(name = "emacs-meta")]
+	EmacsMeta,
+	#[clap(name = "emacs-ctlx")]
+	EmacsCtlx,
+	#[clap(name = "vi-command", aliases = &["vi", "vi-move"])]
+	ViCommand,
+	#[clap(name = "vi-insert")]
+	ViInsert,
 }
 
 impl BindKeyMap {
-    const fn is_vi(&self) -> bool {
-        matches!(self, Self::ViCommand | Self::ViInsert)
-    }
+	const fn is_vi(&self) -> bool {
+		matches!(self, Self::ViCommand | Self::ViInsert)
+	}
 
-    #[expect(dead_code)]
-    const fn is_emacs(&self) -> bool {
-        matches!(
-            self,
-            Self::EmacsStandard | Self::EmacsMeta | Self::EmacsCtlx
-        )
-    }
+	#[expect(dead_code)]
+	const fn is_emacs(&self) -> bool {
+		matches!(self, Self::EmacsStandard | Self::EmacsMeta | Self::EmacsCtlx)
+	}
 }
 
 /// Inspect and modify key bindings and other input configuration.
 #[derive(Parser)]
 pub(crate) struct BindCommand {
-    /// Name of key map to use.
-    #[arg(short = 'm')]
-    keymap: Option<BindKeyMap>,
-    /// List functions.
-    #[arg(short = 'l')]
-    list_funcs: bool,
-    /// List functions and bindings.
-    #[arg(short = 'P')]
-    list_funcs_and_bindings: bool,
-    /// List functions and bindings in a format suitable for use as input.
-    #[arg(short = 'p')]
-    list_funcs_and_bindings_reusable: bool,
-    /// List key sequences that invoke macros.
-    #[arg(short = 'S')]
-    list_key_seqs_that_invoke_macros: bool,
-    /// List key sequences that invoke macros in a format suitable for use as input.
-    #[arg(short = 's')]
-    list_key_seqs_that_invoke_macros_reusable: bool,
-    /// List variables.
-    #[arg(short = 'V')]
-    list_vars: bool,
-    /// List variables in a format suitable for use as input.
-    #[arg(short = 'v')]
-    list_vars_reusable: bool,
-    /// Find the keys bound to the given named function.
-    #[arg(short = 'q', value_name = "FUNC_NAME")]
-    query_func_bindings: Option<String>,
-    /// Remove all bindings for the given named function.
-    #[arg(short = 'u', value_name = "FUNC_NAME")]
-    remove_func_bindings: Option<String>,
-    /// Remove the binding for the given key sequence.
-    #[arg(short = 'r', value_name = "KEY_SEQ")]
-    remove_key_seq_binding: Option<String>,
-    /// Import bindings from the given file.
-    #[arg(short = 'f', value_name = "PATH")]
-    bindings_file: Option<String>,
-    /// Bind key sequence to command.
-    #[arg(short = 'x', value_name = "BINDING")]
-    key_seq_bindings: Vec<String>,
-    /// List key sequence bindings.
-    #[arg(short = 'X')]
-    list_key_seq_bindings: bool,
-    /// Key sequence binding to readline function or command.
-    key_sequence: Option<String>,
+	/// Name of key map to use.
+	#[arg(short = 'm')]
+	keymap: Option<BindKeyMap>,
+	/// List functions.
+	#[arg(short = 'l')]
+	list_funcs: bool,
+	/// List functions and bindings.
+	#[arg(short = 'P')]
+	list_funcs_and_bindings: bool,
+	/// List functions and bindings in a format suitable for use as input.
+	#[arg(short = 'p')]
+	list_funcs_and_bindings_reusable: bool,
+	/// List key sequences that invoke macros.
+	#[arg(short = 'S')]
+	list_key_seqs_that_invoke_macros: bool,
+	/// List key sequences that invoke macros in a format suitable for use as input.
+	#[arg(short = 's')]
+	list_key_seqs_that_invoke_macros_reusable: bool,
+	/// List variables.
+	#[arg(short = 'V')]
+	list_vars: bool,
+	/// List variables in a format suitable for use as input.
+	#[arg(short = 'v')]
+	list_vars_reusable: bool,
+	/// Find the keys bound to the given named function.
+	#[arg(short = 'q', value_name = "FUNC_NAME")]
+	query_func_bindings: Option<String>,
+	/// Remove all bindings for the given named function.
+	#[arg(short = 'u', value_name = "FUNC_NAME")]
+	remove_func_bindings: Option<String>,
+	/// Remove the binding for the given key sequence.
+	#[arg(short = 'r', value_name = "KEY_SEQ")]
+	remove_key_seq_binding: Option<String>,
+	/// Import bindings from the given file.
+	#[arg(short = 'f', value_name = "PATH")]
+	bindings_file: Option<String>,
+	/// Bind key sequence to command.
+	#[arg(short = 'x', value_name = "BINDING")]
+	key_seq_bindings: Vec<String>,
+	/// List key sequence bindings.
+	#[arg(short = 'X')]
+	list_key_seq_bindings: bool,
+	/// Key sequence binding to readline function or command.
+	key_sequence: Option<String>,
 }
 
 const BIND_FEATURE_ISSUE_ID: u32 = 380;
 
 impl builtins::Command for BindCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        if let Some(key_bindings) = context.shell.key_bindings() {
-            Ok(self.execute_impl(key_bindings, &context).await?)
-        } else {
-            writeln!(
-                context.stderr(),
-                "bind: key bindings not supported in this config"
-            )?;
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		if let Some(key_bindings) = context.shell.key_bindings() {
+			Ok(self.execute_impl(key_bindings, &context).await?)
+		} else {
+			writeln!(context.stderr(), "bind: key bindings not supported in this config")?;
 
-            Ok(ExecutionExitCode::Unimplemented.into())
-        }
-    }
+			Ok(ExecutionExitCode::Unimplemented.into())
+		}
+	}
 }
 
 impl BindCommand {
-    async fn execute_impl(
-        &self,
-        bindings: &Arc<Mutex<dyn interfaces::KeyBindings>>,
-        context: &brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, brush_core::Error> {
-        let mut bindings = bindings.lock().await;
+	async fn execute_impl(
+		&self,
+		bindings: &Arc<Mutex<dyn interfaces::KeyBindings>>,
+		context: &brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, brush_core::Error> {
+		let mut bindings = bindings.lock().await;
 
-        if self.list_funcs {
-            for func in interfaces::InputFunction::iter() {
-                writeln!(context.stdout(), "{func}")?;
-            }
-        }
+		if self.list_funcs {
+			for func in interfaces::InputFunction::iter() {
+				writeln!(context.stdout(), "{func}")?;
+			}
+		}
 
-        if self.list_funcs_and_bindings {
-            for (seq, action) in &bindings.get_current() {
-                writeln!(context.stdout(), "{action} can be found on {seq}")?;
-            }
+		if self.list_funcs_and_bindings {
+			for (seq, action) in &bindings.get_current() {
+				writeln!(context.stdout(), "{action} can be found on {seq}")?;
+			}
 
-            return error::unimp_with_issue("bind -P", BIND_FEATURE_ISSUE_ID);
-        }
+			return error::unimp_with_issue("bind -P", BIND_FEATURE_ISSUE_ID);
+		}
 
-        if self.list_funcs_and_bindings_reusable {
-            return error::unimp_with_issue("bind -p", BIND_FEATURE_ISSUE_ID);
-        }
+		if self.list_funcs_and_bindings_reusable {
+			return error::unimp_with_issue("bind -p", BIND_FEATURE_ISSUE_ID);
+		}
 
-        if self.list_key_seqs_that_invoke_macros {
-            return error::unimp_with_issue("bind -S", BIND_FEATURE_ISSUE_ID);
-        }
+		if self.list_key_seqs_that_invoke_macros {
+			return error::unimp_with_issue("bind -S", BIND_FEATURE_ISSUE_ID);
+		}
 
-        if self.list_key_seqs_that_invoke_macros_reusable {
-            return error::unimp_with_issue("bind -s", BIND_FEATURE_ISSUE_ID);
-        }
+		if self.list_key_seqs_that_invoke_macros_reusable {
+			return error::unimp_with_issue("bind -s", BIND_FEATURE_ISSUE_ID);
+		}
 
-        if self.list_vars {
-            return error::unimp_with_issue("bind -V", BIND_FEATURE_ISSUE_ID);
-        }
+		if self.list_vars {
+			return error::unimp_with_issue("bind -V", BIND_FEATURE_ISSUE_ID);
+		}
 
-        if self.list_vars_reusable {
-            // For now we'll just display a few items and show defaults.
-            writeln!(context.stdout(), "set mark-directories on")?;
-            writeln!(context.stdout(), "set mark-symlinked-directories off")?;
-        }
+		if self.list_vars_reusable {
+			// For now we'll just display a few items and show defaults.
+			writeln!(context.stdout(), "set mark-directories on")?;
+			writeln!(context.stdout(), "set mark-symlinked-directories off")?;
+		}
 
-        if self.query_func_bindings.is_some() {
-            return error::unimp_with_issue("bind -q", BIND_FEATURE_ISSUE_ID);
-        }
+		if self.query_func_bindings.is_some() {
+			return error::unimp_with_issue("bind -q", BIND_FEATURE_ISSUE_ID);
+		}
 
-        if self.remove_func_bindings.is_some() {
-            return error::unimp_with_issue("bind -u", BIND_FEATURE_ISSUE_ID);
-        }
+		if self.remove_func_bindings.is_some() {
+			return error::unimp_with_issue("bind -u", BIND_FEATURE_ISSUE_ID);
+		}
 
-        if self.remove_key_seq_binding.is_some() {
-            return error::unimp_with_issue("bind -r", BIND_FEATURE_ISSUE_ID);
-        }
+		if self.remove_key_seq_binding.is_some() {
+			return error::unimp_with_issue("bind -r", BIND_FEATURE_ISSUE_ID);
+		}
 
-        if self.bindings_file.is_some() {
-            return error::unimp_with_issue("bind -f", BIND_FEATURE_ISSUE_ID);
-        }
+		if self.bindings_file.is_some() {
+			return error::unimp_with_issue("bind -f", BIND_FEATURE_ISSUE_ID);
+		}
 
-        if self.list_key_seq_bindings {
-            return error::unimp_with_issue("bind -X", BIND_FEATURE_ISSUE_ID);
-        }
+		if self.list_key_seq_bindings {
+			return error::unimp_with_issue("bind -X", BIND_FEATURE_ISSUE_ID);
+		}
 
-        if !self.key_seq_bindings.is_empty() {
-            if self.keymap.as_ref().is_some_and(|k| k.is_vi()) {
-                // NOTE(vi): Quietly ignore since we don't support vi mode.
-                return Ok(ExecutionResult::success());
-            }
+		if !self.key_seq_bindings.is_empty() {
+			if self.keymap.as_ref().is_some_and(|k| k.is_vi()) {
+				// NOTE(vi): Quietly ignore since we don't support vi mode.
+				return Ok(ExecutionResult::success());
+			}
 
-            for key_seq_and_command in &self.key_seq_bindings {
-                let (key_seq, command) = parse_key_sequence_and_shell_command(key_seq_and_command)?;
-                bind_key_sequence_to_shell_cmd(&mut *bindings, key_seq, command)?;
-            }
-        }
+			for key_seq_and_command in &self.key_seq_bindings {
+				let (key_seq, command) = parse_key_sequence_and_shell_command(key_seq_and_command)?;
+				bind_key_sequence_to_shell_cmd(&mut *bindings, key_seq, command)?;
+			}
+		}
 
-        if let Some(key_sequence) = &self.key_sequence {
-            if self.keymap.as_ref().is_some_and(|k| k.is_vi()) {
-                // NOTE(vi): Quietly ignore since we don't support vi mode.
-                return Ok(ExecutionResult::success());
-            }
+		if let Some(key_sequence) = &self.key_sequence {
+			if self.keymap.as_ref().is_some_and(|k| k.is_vi()) {
+				// NOTE(vi): Quietly ignore since we don't support vi mode.
+				return Ok(ExecutionResult::success());
+			}
 
-            let (key_seq, target) = parse_key_sequence_and_readline_target(key_sequence.as_str())?;
-            bind_key_sequence_to_readline_target(&mut *bindings, key_seq, target)?;
-        }
+			let (key_seq, target) = parse_key_sequence_and_readline_target(key_sequence.as_str())?;
+			bind_key_sequence_to_readline_target(&mut *bindings, key_seq, target)?;
+		}
 
-        drop(bindings);
+		drop(bindings);
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }
 
 fn parse_key_sequence_and_shell_command(
-    input: &str,
+	input: &str,
 ) -> Result<(interfaces::KeySequence, String), brush_core::Error> {
-    tracing::debug!(target: trace_categories::INPUT,
-        "parsing key binding entry: '{input}'"
-    );
+	tracing::debug!(target: trace_categories::INPUT,
+		 "parsing key binding entry: '{input}'"
+	);
 
-    // First trim any whitespace.
-    let input = input.trim();
+	// First trim any whitespace.
+	let input = input.trim();
 
-    // This should be something of the form:
-    //     "KEY-SEQUENCE": SHELL-COMMAND
-    let binding = brush_parser::readline_binding::parse_key_sequence_shell_cmd_binding(input)?;
-    let strokes = key_sequence_to_abstract_strokes(&binding.seq)?;
+	// This should be something of the form:
+	//     "KEY-SEQUENCE": SHELL-COMMAND
+	let binding = brush_parser::readline_binding::parse_key_sequence_shell_cmd_binding(input)?;
+	let strokes = key_sequence_to_abstract_strokes(&binding.seq)?;
 
-    Ok((interfaces::KeySequence { strokes }, binding.shell_cmd))
+	Ok((interfaces::KeySequence { strokes }, binding.shell_cmd))
 }
 
 #[derive(Debug)]
 #[allow(dead_code, reason = "not all variants implemented yet")]
 enum BindableReadlineTarget {
-    Function(brush_core::interfaces::InputFunction),
-    Command(String),
+	Function(brush_core::interfaces::InputFunction),
+	Command(String),
 }
 
 fn parse_key_sequence_and_readline_target(
-    input: &str,
+	input: &str,
 ) -> Result<(interfaces::KeySequence, BindableReadlineTarget), brush_core::Error> {
-    tracing::debug!(target: trace_categories::INPUT,
-        "parsing key binding entry: '{input}'"
-    );
+	tracing::debug!(target: trace_categories::INPUT,
+		 "parsing key binding entry: '{input}'"
+	);
 
-    // First trim any whitespace.
-    let input = input.trim();
+	// First trim any whitespace.
+	let input = input.trim();
 
-    // This should be of one of these forms:
-    //     "KEY-SEQUENCE":function-name
-    //     "KEY-SEQUENCE":readline-command
-    let binding = brush_parser::readline_binding::parse_key_sequence_readline_binding(input)?;
-    let strokes = key_sequence_to_abstract_strokes(&binding.seq)?;
+	// This should be of one of these forms:
+	//     "KEY-SEQUENCE":function-name
+	//     "KEY-SEQUENCE":readline-command
+	let binding = brush_parser::readline_binding::parse_key_sequence_readline_binding(input)?;
+	let strokes = key_sequence_to_abstract_strokes(&binding.seq)?;
 
-    match binding.target {
-        brush_parser::readline_binding::ReadlineTarget::Function(func_name) => {
-            let func = parse_readline_function(func_name.as_str())?;
-            Ok((
-                interfaces::KeySequence { strokes },
-                BindableReadlineTarget::Function(func),
-            ))
-        }
-        brush_parser::readline_binding::ReadlineTarget::Command(cmd) => Ok((
-            interfaces::KeySequence { strokes },
-            BindableReadlineTarget::Command(cmd),
-        )),
-    }
+	match binding.target {
+		brush_parser::readline_binding::ReadlineTarget::Function(func_name) => {
+			let func = parse_readline_function(func_name.as_str())?;
+			Ok((interfaces::KeySequence { strokes }, BindableReadlineTarget::Function(func)))
+		},
+		brush_parser::readline_binding::ReadlineTarget::Command(cmd) => {
+			Ok((interfaces::KeySequence { strokes }, BindableReadlineTarget::Command(cmd)))
+		},
+	}
 }
 
 fn bind_key_sequence_to_shell_cmd(
-    bindings: &mut dyn interfaces::KeyBindings,
-    key_sequence: interfaces::KeySequence,
-    command: String,
+	bindings: &mut dyn interfaces::KeyBindings,
+	key_sequence: interfaces::KeySequence,
+	command: String,
 ) -> Result<(), brush_core::Error> {
-    tracing::debug!(target: trace_categories::INPUT,
-        "binding key sequence: '{key_sequence}' => command '{command}'"
-    );
+	tracing::debug!(target: trace_categories::INPUT,
+		 "binding key sequence: '{key_sequence}' => command '{command}'"
+	);
 
-    bindings.bind(key_sequence, interfaces::KeyAction::ShellCommand(command))?;
+	bindings.bind(key_sequence, interfaces::KeyAction::ShellCommand(command))?;
 
-    Ok(())
+	Ok(())
 }
 
 fn bind_key_sequence_to_readline_target(
-    bindings: &mut dyn interfaces::KeyBindings,
-    key_sequence: interfaces::KeySequence,
-    target: BindableReadlineTarget,
+	bindings: &mut dyn interfaces::KeyBindings,
+	key_sequence: interfaces::KeySequence,
+	target: BindableReadlineTarget,
 ) -> Result<(), brush_core::Error> {
-    match target {
-        BindableReadlineTarget::Function(func) => {
-            tracing::debug!(target: trace_categories::INPUT,
-                "binding key sequence: '{key_sequence}' => readline function '{func}'"
-            );
+	match target {
+		BindableReadlineTarget::Function(func) => {
+			tracing::debug!(target: trace_categories::INPUT,
+				 "binding key sequence: '{key_sequence}' => readline function '{func}'"
+			);
 
-            if matches!(func, interfaces::InputFunction::ViEditingMode) {
-                // NOTE(vi): We don't support vi mode; silently ignore.
-                return Ok(());
-            }
+			if matches!(func, interfaces::InputFunction::ViEditingMode) {
+				// NOTE(vi): We don't support vi mode; silently ignore.
+				return Ok(());
+			}
 
-            bindings.bind(key_sequence, interfaces::KeyAction::DoInputFunction(func))?;
-            Ok(())
-        }
-        BindableReadlineTarget::Command(cmd_macro) => {
-            tracing::debug!(target: trace_categories::INPUT,
-                "binding key sequence: '{key_sequence}' => readline macro '{cmd_macro}'"
-            );
+			bindings.bind(key_sequence, interfaces::KeyAction::DoInputFunction(func))?;
+			Ok(())
+		},
+		BindableReadlineTarget::Command(cmd_macro) => {
+			tracing::debug!(target: trace_categories::INPUT,
+				 "binding key sequence: '{key_sequence}' => readline macro '{cmd_macro}'"
+			);
 
-            error::unimp("binding key sequence to readline macro")
-        }
-    }
+			error::unimp("binding key sequence to readline macro")
+		},
+	}
 }
 
 fn key_sequence_to_abstract_strokes(
-    seq: &brush_parser::readline_binding::KeySequence,
+	seq: &brush_parser::readline_binding::KeySequence,
 ) -> Result<Vec<interfaces::KeyStroke>, brush_core::Error> {
-    let phys_strokes = brush_parser::readline_binding::key_sequence_to_strokes(seq)?;
+	let phys_strokes = brush_parser::readline_binding::key_sequence_to_strokes(seq)?;
 
-    // Lift from key codes to abstract keys.
-    let mut abstract_strokes = vec![];
-    for mut phys_stroke in phys_strokes {
-        let mut key = sys::input::try_get_key_from_key_code(phys_stroke.key_code.as_slice());
+	// Lift from key codes to abstract keys.
+	let mut abstract_strokes = vec![];
+	for mut phys_stroke in phys_strokes {
+		let mut key = sys::input::try_get_key_from_key_code(phys_stroke.key_code.as_slice());
 
-        // If we couldn't interpret it directly but we see it starts with the escape character,
-        // try to see if we can parse it as an Alt+<key> sequence.
-        if key.is_none() && phys_stroke.key_code.len() > 1 && phys_stroke.key_code[0] == b'\x1b' {
-            key = sys::input::try_get_key_from_key_code(&phys_stroke.key_code[1..]);
-            if key.is_some() {
-                phys_stroke.meta = true;
-            }
-        }
+		// If we couldn't interpret it directly but we see it starts with the escape character,
+		// try to see if we can parse it as an Alt+<key> sequence.
+		if key.is_none() && phys_stroke.key_code.len() > 1 && phys_stroke.key_code[0] == b'\x1b' {
+			key = sys::input::try_get_key_from_key_code(&phys_stroke.key_code[1..]);
+			if key.is_some() {
+				phys_stroke.meta = true;
+			}
+		}
 
-        let Some(key) = key else {
-            return Err(error::ErrorKind::UnhandledKeyCode(phys_stroke.key_code).into());
-        };
+		let Some(key) = key else {
+			return Err(error::ErrorKind::UnhandledKeyCode(phys_stroke.key_code).into());
+		};
 
-        abstract_strokes.push(interfaces::KeyStroke {
-            alt: phys_stroke.meta,
-            control: phys_stroke.control,
-            shift: false,
-            key,
-        });
-    }
+		abstract_strokes.push(interfaces::KeyStroke {
+			alt: phys_stroke.meta,
+			control: phys_stroke.control,
+			shift: false,
+			key,
+		});
+	}
 
-    Ok(abstract_strokes)
+	Ok(abstract_strokes)
 }
 
 fn parse_readline_function(
-    func_name: &str,
+	func_name: &str,
 ) -> Result<interfaces::InputFunction, brush_core::Error> {
-    interfaces::InputFunction::from_str(func_name).map_err(|_err| {
-        brush_core::ErrorKind::UnknownKeyBindingFunction(func_name.to_owned()).into()
-    })
+	interfaces::InputFunction::from_str(func_name)
+		.map_err(|_err| brush_core::ErrorKind::UnknownKeyBindingFunction(func_name.to_owned()).into())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use pretty_assertions::{assert_eq, assert_matches};
+	use super::*;
+	use pretty_assertions::{assert_eq, assert_matches};
 
-    #[test]
-    fn parse_example_key_sequence_and_readline_func() {
-        let (key_seq, target) =
-            parse_key_sequence_and_readline_target(r#""\C-a":beginning-of-line"#).unwrap();
+	#[test]
+	fn parse_example_key_sequence_and_readline_func() {
+		let (key_seq, target) =
+			parse_key_sequence_and_readline_target(r#""\C-a":beginning-of-line"#).unwrap();
 
-        assert_eq!(
-            key_seq,
-            interfaces::KeySequence {
-                strokes: vec![interfaces::KeyStroke {
-                    alt: false,
-                    control: true,
-                    shift: false,
-                    key: interfaces::Key::Character('a'),
-                }],
-            }
-        );
+		assert_eq!(
+			key_seq,
+			interfaces::KeySequence {
+				strokes: vec![interfaces::KeyStroke {
+					alt: false,
+					control: true,
+					shift: false,
+					key: interfaces::Key::Character('a'),
+				}],
+			}
+		);
 
-        assert_matches!(
-            target,
-            BindableReadlineTarget::Function(interfaces::InputFunction::BeginningOfLine)
-        );
-    }
+		assert_matches!(
+			target,
+			BindableReadlineTarget::Function(interfaces::InputFunction::BeginningOfLine)
+		);
+	}
 
-    #[test]
-    fn parse_escape_char_key_binding() {
-        let (key_seq, target) =
-            parse_key_sequence_and_readline_target(r#""\er":transpose-chars"#).unwrap();
+	#[test]
+	fn parse_escape_char_key_binding() {
+		let (key_seq, target) =
+			parse_key_sequence_and_readline_target(r#""\er":transpose-chars"#).unwrap();
 
-        assert_eq!(
-            key_seq,
-            interfaces::KeySequence {
-                strokes: vec![interfaces::KeyStroke {
-                    alt: true,
-                    control: false,
-                    shift: false,
-                    key: interfaces::Key::Character('r'),
-                }],
-            }
-        );
+		assert_eq!(
+			key_seq,
+			interfaces::KeySequence {
+				strokes: vec![interfaces::KeyStroke {
+					alt: true,
+					control: false,
+					shift: false,
+					key: interfaces::Key::Character('r'),
+				}],
+			}
+		);
 
-        assert_matches!(
-            target,
-            BindableReadlineTarget::Function(interfaces::InputFunction::TransposeChars)
-        );
-    }
+		assert_matches!(
+			target,
+			BindableReadlineTarget::Function(interfaces::InputFunction::TransposeChars)
+		);
+	}
 }

--- a/crates/brush-builtins-vendored/src/break_.rs
+++ b/crates/brush-builtins-vendored/src/break_.rs
@@ -5,30 +5,30 @@ use brush_core::{ExecutionControlFlow, ExecutionExitCode, ExecutionResult, built
 /// Breaks out of a control-flow loop.
 #[derive(Parser)]
 pub(crate) struct BreakCommand {
-    /// If specified, indicates which nested loop to break out of.
-    #[clap(default_value_t = 1)]
-    which_loop: i8,
+	/// If specified, indicates which nested loop to break out of.
+	#[clap(default_value_t = 1)]
+	which_loop: i8,
 }
 
 impl builtins::Command for BreakCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        _context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        // If specified, which_loop needs to be positive.
-        if self.which_loop <= 0 {
-            return Ok(ExecutionExitCode::InvalidUsage.into());
-        }
+	async fn execute(
+		&self,
+		_context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		// If specified, which_loop needs to be positive.
+		if self.which_loop <= 0 {
+			return Ok(ExecutionExitCode::InvalidUsage.into());
+		}
 
-        let mut result = ExecutionResult::success();
+		let mut result = ExecutionResult::success();
 
-        result.next_control_flow = ExecutionControlFlow::BreakLoop {
-            #[expect(clippy::cast_sign_loss)]
-            levels: (self.which_loop - 1) as usize,
-        };
+		result.next_control_flow = ExecutionControlFlow::BreakLoop {
+			#[expect(clippy::cast_sign_loss)]
+			levels: (self.which_loop - 1) as usize,
+		};
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 }

--- a/crates/brush-builtins-vendored/src/brushinfo.rs
+++ b/crates/brush-builtins-vendored/src/brushinfo.rs
@@ -7,131 +7,131 @@ use brush_core::{ExecutionResult, builtins, sys};
 /// Change the current working directory.
 #[derive(Parser)]
 pub(crate) struct BrushInfoCommand {
-    #[clap(subcommand)]
-    command_group: CommandGroup,
+	#[clap(subcommand)]
+	command_group: CommandGroup,
 }
 
 #[derive(Subcommand)]
 enum CommandGroup {
-    #[clap(subcommand)]
-    Process(ProcessCommand),
-    #[clap(subcommand)]
-    Complete(CompleteCommand),
+	#[clap(subcommand)]
+	Process(ProcessCommand),
+	#[clap(subcommand)]
+	Complete(CompleteCommand),
 }
 
 /// Commands for configuring tracing events.
 #[expect(clippy::enum_variant_names)]
 #[derive(Subcommand)]
 enum ProcessCommand {
-    /// Display process ID.
-    #[clap(name = "pid")]
-    ShowProcessId,
-    /// Display process group ID.
-    #[clap(name = "pgid")]
-    ShowProcessGroupId,
-    /// Display foreground process ID.
-    #[clap(name = "fgpid")]
-    ShowForegroundProcessId,
-    /// Display parent process ID.
-    #[clap(name = "ppid")]
-    ShowParentProcessId,
+	/// Display process ID.
+	#[clap(name = "pid")]
+	ShowProcessId,
+	/// Display process group ID.
+	#[clap(name = "pgid")]
+	ShowProcessGroupId,
+	/// Display foreground process ID.
+	#[clap(name = "fgpid")]
+	ShowForegroundProcessId,
+	/// Display parent process ID.
+	#[clap(name = "ppid")]
+	ShowParentProcessId,
 }
 
 /// Commands for generating completions.
 #[derive(Subcommand)]
 enum CompleteCommand {
-    /// Generate completions for an input line.
-    #[clap(name = "line")]
-    Line {
-        /// The 0-indexed cursor position for generation.
-        #[arg(long = "cursor", short = 'c')]
-        cursor_index: Option<usize>,
+	/// Generate completions for an input line.
+	#[clap(name = "line")]
+	Line {
+		/// The 0-indexed cursor position for generation.
+		#[arg(long = "cursor", short = 'c')]
+		cursor_index: Option<usize>,
 
-        /// The input line to generate completions for.
-        line: String,
-    },
+		/// The input line to generate completions for.
+		line: String,
+	},
 }
 
 impl builtins::Command for BrushInfoCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        mut context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        self.command_group.execute(&mut context).await
-    }
+	async fn execute(
+		&self,
+		mut context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		self.command_group.execute(&mut context).await
+	}
 }
 
 impl CommandGroup {
-    async fn execute(
-        &self,
-        context: &mut brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, brush_core::Error> {
-        match self {
-            Self::Process(process) => process.execute(context),
-            Self::Complete(complete) => complete.execute(context).await,
-        }
-    }
+	async fn execute(
+		&self,
+		context: &mut brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, brush_core::Error> {
+		match self {
+			Self::Process(process) => process.execute(context),
+			Self::Complete(complete) => complete.execute(context).await,
+		}
+	}
 }
 
 impl ProcessCommand {
-    fn execute(
-        &self,
-        context: &brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, brush_core::Error> {
-        match self {
-            Self::ShowProcessId => {
-                writeln!(context.stdout(), "{}", std::process::id())?;
-                Ok(ExecutionResult::success())
-            }
-            Self::ShowProcessGroupId => {
-                if let Some(pgid) = sys::terminal::get_process_group_id() {
-                    writeln!(context.stdout(), "{pgid}")?;
-                    Ok(ExecutionResult::success())
-                } else {
-                    writeln!(context.stderr(), "failed to get process group ID")?;
-                    Ok(ExecutionResult::general_error())
-                }
-            }
-            Self::ShowForegroundProcessId => {
-                if let Some(pid) = sys::terminal::get_foreground_pid() {
-                    writeln!(context.stdout(), "{pid}")?;
-                    Ok(ExecutionResult::success())
-                } else {
-                    writeln!(context.stderr(), "failed to get foreground process ID")?;
-                    Ok(ExecutionResult::general_error())
-                }
-            }
-            Self::ShowParentProcessId => {
-                if let Some(pid) = sys::terminal::get_parent_process_id() {
-                    writeln!(context.stdout(), "{pid}")?;
-                    Ok(ExecutionResult::success())
-                } else {
-                    writeln!(context.stderr(), "failed to get parent process ID")?;
-                    Ok(ExecutionResult::general_error())
-                }
-            }
-        }
-    }
+	fn execute(
+		&self,
+		context: &brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, brush_core::Error> {
+		match self {
+			Self::ShowProcessId => {
+				writeln!(context.stdout(), "{}", std::process::id())?;
+				Ok(ExecutionResult::success())
+			},
+			Self::ShowProcessGroupId => {
+				if let Some(pgid) = sys::terminal::get_process_group_id() {
+					writeln!(context.stdout(), "{pgid}")?;
+					Ok(ExecutionResult::success())
+				} else {
+					writeln!(context.stderr(), "failed to get process group ID")?;
+					Ok(ExecutionResult::general_error())
+				}
+			},
+			Self::ShowForegroundProcessId => {
+				if let Some(pid) = sys::terminal::get_foreground_pid() {
+					writeln!(context.stdout(), "{pid}")?;
+					Ok(ExecutionResult::success())
+				} else {
+					writeln!(context.stderr(), "failed to get foreground process ID")?;
+					Ok(ExecutionResult::general_error())
+				}
+			},
+			Self::ShowParentProcessId => {
+				if let Some(pid) = sys::terminal::get_parent_process_id() {
+					writeln!(context.stdout(), "{pid}")?;
+					Ok(ExecutionResult::success())
+				} else {
+					writeln!(context.stderr(), "failed to get parent process ID")?;
+					Ok(ExecutionResult::general_error())
+				}
+			},
+		}
+	}
 }
 
 impl CompleteCommand {
-    async fn execute(
-        &self,
-        context: &mut brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, brush_core::Error> {
-        match self {
-            Self::Line { cursor_index, line } => {
-                let completions = context
-                    .shell
-                    .complete(line, cursor_index.unwrap_or(line.len()))
-                    .await?;
-                for candidate in completions.candidates {
-                    writeln!(context.stdout(), "{candidate}")?;
-                }
-                Ok(ExecutionResult::success())
-            }
-        }
-    }
+	async fn execute(
+		&self,
+		context: &mut brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, brush_core::Error> {
+		match self {
+			Self::Line { cursor_index, line } => {
+				let completions = context
+					.shell
+					.complete(line, cursor_index.unwrap_or(line.len()))
+					.await?;
+				for candidate in completions.candidates {
+					writeln!(context.stdout(), "{candidate}")?;
+				}
+				Ok(ExecutionResult::success())
+			},
+		}
+	}
 }

--- a/crates/brush-builtins-vendored/src/builder.rs
+++ b/crates/brush-builtins-vendored/src/builder.rs
@@ -2,17 +2,17 @@ use crate::BuiltinSet;
 
 /// Extension trait that simplifies adding default builtins to a shell builder.
 pub trait ShellBuilderExt {
-    /// Add default builtins to the shell being built.
-    ///
-    /// # Arguments
-    ///
-    /// * `set` - The well-known set of built-ins to add.
-    #[must_use]
-    fn default_builtins(self, set: BuiltinSet) -> Self;
+	/// Add default builtins to the shell being built.
+	///
+	/// # Arguments
+	///
+	/// * `set` - The well-known set of built-ins to add.
+	#[must_use]
+	fn default_builtins(self, set: BuiltinSet) -> Self;
 }
 
 impl<S: brush_core::ShellBuilderState> ShellBuilderExt for brush_core::ShellBuilder<S> {
-    fn default_builtins(self, set: BuiltinSet) -> Self {
-        self.builtins(crate::default_builtins(set))
-    }
+	fn default_builtins(self, set: BuiltinSet) -> Self {
+		self.builtins(crate::default_builtins(set))
+	}
 }

--- a/crates/brush-builtins-vendored/src/builtin_.rs
+++ b/crates/brush-builtins-vendored/src/builtin_.rs
@@ -5,39 +5,39 @@ use brush_core::{ExecutionResult, builtins};
 /// Directly invokes a built-in, without going through typical search order.
 #[derive(Default, Parser)]
 pub(crate) struct BuiltinCommand {
-    #[clap(skip)]
-    args: Vec<brush_core::CommandArg>,
+	#[clap(skip)]
+	args: Vec<brush_core::CommandArg>,
 }
 
 impl builtins::DeclarationCommand for BuiltinCommand {
-    fn set_declarations(&mut self, args: Vec<brush_core::CommandArg>) {
-        self.args = args;
-    }
+	fn set_declarations(&mut self, args: Vec<brush_core::CommandArg>) {
+		self.args = args;
+	}
 }
 
 impl builtins::Command for BuiltinCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        mut context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        if self.args.is_empty() {
-            return Ok(ExecutionResult::success());
-        }
+	async fn execute(
+		&self,
+		mut context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		if self.args.is_empty() {
+			return Ok(ExecutionResult::success());
+		}
 
-        let args: Vec<_> = self.args.iter().skip(1).cloned().collect();
-        if args.is_empty() {
-            return Ok(ExecutionResult::success());
-        }
+		let args: Vec<_> = self.args.iter().skip(1).cloned().collect();
+		if args.is_empty() {
+			return Ok(ExecutionResult::success());
+		}
 
-        let builtin_name = args[0].to_string();
+		let builtin_name = args[0].to_string();
 
-        if let Some(builtin) = context.shell.builtins().get(&builtin_name) {
-            context.command_name = builtin_name;
-            (builtin.execute_func)(context, args).await
-        } else {
-            Err(brush_core::ErrorKind::BuiltinNotFound(builtin_name).into())
-        }
-    }
+		if let Some(builtin) = context.shell.builtins().get(&builtin_name) {
+			context.command_name = builtin_name;
+			(builtin.execute_func)(context, args).await
+		} else {
+			Err(brush_core::ErrorKind::BuiltinNotFound(builtin_name).into())
+		}
+	}
 }

--- a/crates/brush-builtins-vendored/src/cd.rs
+++ b/crates/brush-builtins-vendored/src/cd.rs
@@ -8,90 +8,90 @@ use brush_core::{ExecutionResult, builtins, error};
 /// Change the current shell working directory.
 #[derive(Parser)]
 pub(crate) struct CdCommand {
-    /// Force following symlinks.
-    #[arg(short = 'L', overrides_with = "use_physical_dir")]
-    force_follow_symlinks: bool,
+	/// Force following symlinks.
+	#[arg(short = 'L', overrides_with = "use_physical_dir")]
+	force_follow_symlinks: bool,
 
-    /// Use physical dir structure without following symlinks.
-    #[arg(short = 'P', overrides_with = "force_follow_symlinks")]
-    use_physical_dir: bool,
+	/// Use physical dir structure without following symlinks.
+	#[arg(short = 'P', overrides_with = "force_follow_symlinks")]
+	use_physical_dir: bool,
 
-    /// Exit with non zero exit status if current working directory resolution fails.
-    #[arg(short = 'e')]
-    exit_on_failed_cwd_resolution: bool,
+	/// Exit with non zero exit status if current working directory resolution fails.
+	#[arg(short = 'e')]
+	exit_on_failed_cwd_resolution: bool,
 
-    /// Show file with extended attributes as a dir with extended
-    /// attributes.
-    #[arg(short = '@')]
-    file_with_xattr_as_dir: bool,
+	/// Show file with extended attributes as a dir with extended
+	/// attributes.
+	#[arg(short = '@')]
+	file_with_xattr_as_dir: bool,
 
-    /// By default it is the value of the HOME shell variable. If `TARGET_DIR` is "-", it is
-    /// converted to $OLDPWD.
-    target_dir: Option<PathBuf>,
+	/// By default it is the value of the HOME shell variable. If `TARGET_DIR` is "-", it is
+	/// converted to $OLDPWD.
+	target_dir: Option<PathBuf>,
 }
 
 impl builtins::Command for CdCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, Self::Error> {
-        // TODO: implement 'cd -@'
-        if self.file_with_xattr_as_dir {
-            return error::unimp("cd -@");
-        }
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, Self::Error> {
+		// TODO: implement 'cd -@'
+		if self.file_with_xattr_as_dir {
+			return error::unimp("cd -@");
+		}
 
-        let mut should_print = false;
-        let mut target_dir = if let Some(target_dir) = &self.target_dir {
-            // `cd -', equivalent to `cd $OLDPWD'
-            if target_dir.as_os_str() == "-" {
-                should_print = true;
-                if let Some(oldpwd) = context.shell.env_str("OLDPWD") {
-                    PathBuf::from(oldpwd.to_string())
-                } else {
-                    writeln!(context.stderr(), "OLDPWD not set")?;
-                    return Ok(ExecutionResult::general_error());
-                }
-            } else {
-                // TODO: remove clone, and use temporary lifetime extension after rust 1.75
-                target_dir.clone()
-            }
-        // `cd' without arguments is equivalent to `cd $HOME'
-        } else {
-            if let Some(home_var) = context.shell.env_str("HOME") {
-                PathBuf::from(home_var.to_string())
-            } else {
-                writeln!(context.stderr(), "HOME not set")?;
-                return Ok(ExecutionResult::general_error());
-            }
-        };
+		let mut should_print = false;
+		let mut target_dir = if let Some(target_dir) = &self.target_dir {
+			// `cd -', equivalent to `cd $OLDPWD'
+			if target_dir.as_os_str() == "-" {
+				should_print = true;
+				if let Some(oldpwd) = context.shell.env_str("OLDPWD") {
+					PathBuf::from(oldpwd.to_string())
+				} else {
+					writeln!(context.stderr(), "OLDPWD not set")?;
+					return Ok(ExecutionResult::general_error());
+				}
+			} else {
+				// TODO: remove clone, and use temporary lifetime extension after rust 1.75
+				target_dir.clone()
+			}
+		// `cd' without arguments is equivalent to `cd $HOME'
+		} else {
+			if let Some(home_var) = context.shell.env_str("HOME") {
+				PathBuf::from(home_var.to_string())
+			} else {
+				writeln!(context.stderr(), "HOME not set")?;
+				return Ok(ExecutionResult::general_error());
+			}
+		};
 
-        if self.use_physical_dir
-            || context
-                .shell
-                .options
-                .do_not_resolve_symlinks_when_changing_dir
-        {
-            // -e is only relevant in physical mode.
-            if self.exit_on_failed_cwd_resolution {
-                return error::unimp("cd -e");
-            }
+		if self.use_physical_dir
+			|| context
+				.shell
+				.options
+				.do_not_resolve_symlinks_when_changing_dir
+		{
+			// -e is only relevant in physical mode.
+			if self.exit_on_failed_cwd_resolution {
+				return error::unimp("cd -e");
+			}
 
-            target_dir = context.shell.absolute_path(target_dir).canonicalize()?;
-        }
+			target_dir = context.shell.absolute_path(target_dir).canonicalize()?;
+		}
 
-        context.shell.set_working_dir(&target_dir)?;
+		context.shell.set_working_dir(&target_dir)?;
 
-        // Bash compatibility
-        // https://www.gnu.org/software/bash/manual/bash.html#index-cd
-        // If a non-empty directory name from CDPATH is used, or if '-' is the first argument, and
-        // the directory change is successful, the absolute pathname of the new working
-        // directory is written to the standard output.
-        if should_print {
-            writeln!(context.stdout(), "{}", target_dir.display())?;
-        }
+		// Bash compatibility
+		// https://www.gnu.org/software/bash/manual/bash.html#index-cd
+		// If a non-empty directory name from CDPATH is used, or if '-' is the first argument, and
+		// the directory change is successful, the absolute pathname of the new working
+		// directory is written to the standard output.
+		if should_print {
+			writeln!(context.stdout(), "{}", target_dir.display())?;
+		}
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }

--- a/crates/brush-builtins-vendored/src/colon.rs
+++ b/crates/brush-builtins-vendored/src/colon.rs
@@ -4,24 +4,22 @@ use brush_core::{ExecutionResult, builtins, error};
 pub(crate) struct ColonCommand {}
 
 impl builtins::SimpleCommand for ColonCommand {
-    fn get_content(
-        _name: &str,
-        content_type: builtins::ContentType,
-    ) -> Result<String, brush_core::Error> {
-        match content_type {
-            builtins::ContentType::DetailedHelp => {
-                Ok("Null command; always returns success.".into())
-            }
-            builtins::ContentType::ShortUsage => Ok(":: :".into()),
-            builtins::ContentType::ShortDescription => Ok(": - Null command".into()),
-            builtins::ContentType::ManPage => error::unimp("man page not yet implemented"),
-        }
-    }
+	fn get_content(
+		_name: &str,
+		content_type: builtins::ContentType,
+	) -> Result<String, brush_core::Error> {
+		match content_type {
+			builtins::ContentType::DetailedHelp => Ok("Null command; always returns success.".into()),
+			builtins::ContentType::ShortUsage => Ok(":: :".into()),
+			builtins::ContentType::ShortDescription => Ok(": - Null command".into()),
+			builtins::ContentType::ManPage => error::unimp("man page not yet implemented"),
+		}
+	}
 
-    fn execute<I: Iterator<Item = S>, S: AsRef<str>>(
-        _context: brush_core::ExecutionContext<'_>,
-        _args: I,
-    ) -> Result<ExecutionResult, brush_core::Error> {
-        Ok(ExecutionResult::success())
-    }
+	fn execute<I: Iterator<Item = S>, S: AsRef<str>>(
+		_context: brush_core::ExecutionContext<'_>,
+		_args: I,
+	) -> Result<ExecutionResult, brush_core::Error> {
+		Ok(ExecutionResult::success())
+	}
 }

--- a/crates/brush-builtins-vendored/src/command.rs
+++ b/crates/brush-builtins-vendored/src/command.rs
@@ -2,165 +2,162 @@ use clap::Parser;
 use std::{fmt::Display, io::Write, path::Path};
 
 use brush_core::{
-    ExecutionResult, ExecutionSpawnResult, builtins, commands, pathsearch,
-    sys::{self, fs::PathExt},
+	ExecutionResult, ExecutionSpawnResult, builtins, commands, pathsearch,
+	sys::{self, fs::PathExt},
 };
 
 /// Directly invokes an external command, without going through typical search order.
 #[derive(Parser)]
 pub(crate) struct CommandCommand {
-    /// Use default PATH value.
-    #[arg(short = 'p')]
-    use_default_path: bool,
+	/// Use default PATH value.
+	#[arg(short = 'p')]
+	use_default_path: bool,
 
-    /// Display a short description of the command.
-    #[arg(short = 'v')]
-    print_description: bool,
+	/// Display a short description of the command.
+	#[arg(short = 'v')]
+	print_description: bool,
 
-    /// Display a more verbose description of the command.
-    #[arg(short = 'V')]
-    print_verbose_description: bool,
+	/// Display a more verbose description of the command.
+	#[arg(short = 'V')]
+	print_verbose_description: bool,
 
-    /// Command and arguments.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    command_and_args: Vec<String>,
+	/// Command and arguments.
+	#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+	command_and_args: Vec<String>,
 }
 
 impl CommandCommand {
-    fn command(&self) -> Option<&String> {
-        self.command_and_args.first()
-    }
+	fn command(&self) -> Option<&String> {
+		self.command_and_args.first()
+	}
 }
 
 impl builtins::Command for CommandCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, Self::Error> {
-        // Silently exit if no command was provided.
-        if let Some(command_name) = self.command() {
-            if self.print_description || self.print_verbose_description {
-                if let Some(found_cmd) = Self::try_find_command(
-                    context.shell,
-                    command_name.as_str(),
-                    self.use_default_path,
-                ) {
-                    if self.print_description {
-                        writeln!(context.stdout(), "{found_cmd}")?;
-                    } else {
-                        match found_cmd {
-                            FoundCommand::Builtin(_name) => {
-                                writeln!(context.stdout(), "{command_name} is a shell builtin")?;
-                            }
-                            FoundCommand::External(path) => {
-                                writeln!(context.stdout(), "{command_name} is {path}")?;
-                            }
-                        }
-                    }
-                    Ok(ExecutionResult::success())
-                } else {
-                    if self.print_verbose_description {
-                        writeln!(context.stderr(), "command: {command_name}: not found")?;
-                    }
-                    Ok(ExecutionResult::general_error())
-                }
-            } else {
-                self.execute_command(context, command_name, self.use_default_path)
-                    .await
-            }
-        } else {
-            Ok(ExecutionResult::success())
-        }
-    }
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, Self::Error> {
+		// Silently exit if no command was provided.
+		if let Some(command_name) = self.command() {
+			if self.print_description || self.print_verbose_description {
+				if let Some(found_cmd) =
+					Self::try_find_command(context.shell, command_name.as_str(), self.use_default_path)
+				{
+					if self.print_description {
+						writeln!(context.stdout(), "{found_cmd}")?;
+					} else {
+						match found_cmd {
+							FoundCommand::Builtin(_name) => {
+								writeln!(context.stdout(), "{command_name} is a shell builtin")?;
+							},
+							FoundCommand::External(path) => {
+								writeln!(context.stdout(), "{command_name} is {path}")?;
+							},
+						}
+					}
+					Ok(ExecutionResult::success())
+				} else {
+					if self.print_verbose_description {
+						writeln!(context.stderr(), "command: {command_name}: not found")?;
+					}
+					Ok(ExecutionResult::general_error())
+				}
+			} else {
+				self
+					.execute_command(context, command_name, self.use_default_path)
+					.await
+			}
+		} else {
+			Ok(ExecutionResult::success())
+		}
+	}
 }
 
 enum FoundCommand {
-    Builtin(String),
-    External(String),
+	Builtin(String),
+	External(String),
 }
 
 impl Display for FoundCommand {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Builtin(name) => write!(f, "{name}"),
-            Self::External(path) => write!(f, "{path}"),
-        }
-    }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::Builtin(name) => write!(f, "{name}"),
+			Self::External(path) => write!(f, "{path}"),
+		}
+	}
 }
 
 impl CommandCommand {
-    fn try_find_command(
-        shell: &mut brush_core::Shell,
-        command_name: &str,
-        use_default_path: bool,
-    ) -> Option<FoundCommand> {
-        // Look in path.
-        if command_name.contains(std::path::MAIN_SEPARATOR) {
-            let candidate_path = shell.absolute_path(Path::new(command_name));
-            if candidate_path.executable() {
-                Some(FoundCommand::External(
-                    candidate_path.to_string_lossy().to_string(),
-                ))
-            } else {
-                None
-            }
-        } else {
-            if let Some(builtin_cmd) = shell.builtins().get(command_name) {
-                if !builtin_cmd.disabled {
-                    return Some(FoundCommand::Builtin(command_name.to_owned()));
-                }
-            }
+	fn try_find_command(
+		shell: &mut brush_core::Shell,
+		command_name: &str,
+		use_default_path: bool,
+	) -> Option<FoundCommand> {
+		// Look in path.
+		if command_name.contains(std::path::MAIN_SEPARATOR) {
+			let candidate_path = shell.absolute_path(Path::new(command_name));
+			if candidate_path.executable() {
+				Some(FoundCommand::External(candidate_path.to_string_lossy().to_string()))
+			} else {
+				None
+			}
+		} else {
+			if let Some(builtin_cmd) = shell.builtins().get(command_name) {
+				if !builtin_cmd.disabled {
+					return Some(FoundCommand::Builtin(command_name.to_owned()));
+				}
+			}
 
-            if use_default_path {
-                let dirs = sys::fs::get_default_standard_utils_paths();
+			if use_default_path {
+				let dirs = sys::fs::get_default_standard_utils_paths();
 
-                pathsearch::search_for_executable(dirs.iter().map(String::as_str), command_name)
-                    .next()
-                    .map(|path| FoundCommand::External(path.to_string_lossy().to_string()))
-            } else {
-                shell
-                    .find_first_executable_in_path_using_cache(command_name)
-                    .map(|path| FoundCommand::External(path.to_string_lossy().to_string()))
-            }
-        }
-    }
+				pathsearch::search_for_executable(dirs.iter().map(String::as_str), command_name)
+					.next()
+					.map(|path| FoundCommand::External(path.to_string_lossy().to_string()))
+			} else {
+				shell
+					.find_first_executable_in_path_using_cache(command_name)
+					.map(|path| FoundCommand::External(path.to_string_lossy().to_string()))
+			}
+		}
+	}
 
-    async fn execute_command(
-        &self,
-        mut context: brush_core::ExecutionContext<'_>,
-        command_name: &str,
-        use_default_path: bool,
-    ) -> Result<ExecutionResult, brush_core::Error> {
-        command_name.clone_into(&mut context.command_name);
-        let command_and_args = self.command_and_args.iter().map(|arg| arg.into()).collect();
+	async fn execute_command(
+		&self,
+		mut context: brush_core::ExecutionContext<'_>,
+		command_name: &str,
+		use_default_path: bool,
+	) -> Result<ExecutionResult, brush_core::Error> {
+		command_name.clone_into(&mut context.command_name);
+		let command_and_args = self.command_and_args.iter().map(|arg| arg.into()).collect();
 
-        let path_dirs = if use_default_path {
-            Some(sys::fs::get_default_standard_utils_paths())
-        } else {
-            None
-        };
+		let path_dirs = if use_default_path {
+			Some(sys::fs::get_default_standard_utils_paths())
+		} else {
+			None
+		};
 
-        // We do not have an existing process group to place this into.
-        let mut pgid = None;
-        let cancel_token = context.cancel_token();
+		// We do not have an existing process group to place this into.
+		let mut pgid = None;
+		let cancel_token = context.cancel_token();
 
-        match commands::execute(
-            context,
-            &mut pgid,
-            command_and_args,
-            false, /* use functions? */
-            path_dirs,
-        )
-        .await?
-        {
-            ExecutionSpawnResult::StartedProcess(mut child) => {
-                // TODO: jobs: review this logic
-                let wait_result = child.wait(cancel_token).await?;
-                Ok(ExecutionResult::from(wait_result))
-            }
-            ExecutionSpawnResult::Completed(result) => Ok(result),
-        }
-    }
+		match commands::execute(
+			context,
+			&mut pgid,
+			command_and_args,
+			false, /* use functions? */
+			path_dirs,
+		)
+		.await?
+		{
+			ExecutionSpawnResult::StartedProcess(mut child) => {
+				// TODO: jobs: review this logic
+				let wait_result = child.wait(cancel_token).await?;
+				Ok(ExecutionResult::from(wait_result))
+			},
+			ExecutionSpawnResult::Completed(result) => Ok(result),
+		}
+	}
 }

--- a/crates/brush-builtins-vendored/src/complete.rs
+++ b/crates/brush-builtins-vendored/src/complete.rs
@@ -484,15 +484,15 @@ impl builtins::Command for CompGenCommand {
 
 		let completion_context = completion::Context {
 			token_to_complete: unquoted_token.as_str(),
-			preceding_token:   None,
-			command_name:      None,
-			token_index:       0,
-			tokens:            &[&brush_parser::Token::Word(
+			preceding_token: None,
+			command_name: None,
+			token_index: 0,
+			tokens: &[&brush_parser::Token::Word(
 				token_to_complete.to_owned(),
 				brush_parser::TokenLocation::default(),
 			)],
-			input_line:        token_to_complete,
-			cursor_index:      token_to_complete.len(),
+			input_line: token_to_complete,
+			cursor_index: token_to_complete.len(),
 		};
 
 		let result = spec
@@ -537,7 +537,7 @@ pub(crate) struct CompOptCommand {
 
 	/// Enable the specified option for selected completion scenarios.
 	#[arg(short = 'o', value_name = "OPT")]
-	enabled_options:  Vec<CompleteOption>,
+	enabled_options: Vec<CompleteOption>,
 	#[arg(long = concat!("+o"), hide = true)]
 	disabled_options: Vec<CompleteOption>,
 

--- a/crates/brush-builtins-vendored/src/continue_.rs
+++ b/crates/brush-builtins-vendored/src/continue_.rs
@@ -5,30 +5,30 @@ use brush_core::{ExecutionControlFlow, ExecutionExitCode, ExecutionResult, built
 /// Continue to the next iteration of a control-flow loop.
 #[derive(Parser)]
 pub(crate) struct ContinueCommand {
-    /// If specified, indicates which nested loop to continue to the next iteration of.
-    #[clap(default_value_t = 1)]
-    which_loop: i8,
+	/// If specified, indicates which nested loop to continue to the next iteration of.
+	#[clap(default_value_t = 1)]
+	which_loop: i8,
 }
 
 impl builtins::Command for ContinueCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        _context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        // If specified, which_loop needs to be positive.
-        if self.which_loop <= 0 {
-            return Ok(ExecutionExitCode::InvalidUsage.into());
-        }
+	async fn execute(
+		&self,
+		_context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		// If specified, which_loop needs to be positive.
+		if self.which_loop <= 0 {
+			return Ok(ExecutionExitCode::InvalidUsage.into());
+		}
 
-        let mut result = ExecutionResult::success();
+		let mut result = ExecutionResult::success();
 
-        result.next_control_flow = ExecutionControlFlow::ContinueLoop {
-            #[expect(clippy::cast_sign_loss)]
-            levels: (self.which_loop - 1) as usize,
-        };
+		result.next_control_flow = ExecutionControlFlow::ContinueLoop {
+			#[expect(clippy::cast_sign_loss)]
+			levels: (self.which_loop - 1) as usize,
+		};
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 }

--- a/crates/brush-builtins-vendored/src/declare.rs
+++ b/crates/brush-builtins-vendored/src/declare.rs
@@ -3,47 +3,39 @@ use itertools::Itertools;
 use std::{io::Write, sync::LazyLock};
 
 use brush_core::{
-    ErrorKind, ExecutionResult, builtins,
-    env::{self, EnvironmentLookup, EnvironmentScope},
-    error,
-    variables::{
-        self, ArrayLiteral, ShellValue, ShellValueLiteral, ShellValueUnsetType, ShellVariable,
-        ShellVariableUpdateTransform,
-    },
+	ErrorKind, ExecutionResult, builtins,
+	env::{self, EnvironmentLookup, EnvironmentScope},
+	error,
+	variables::{
+		self, ArrayLiteral, ShellValue, ShellValueLiteral, ShellValueUnsetType, ShellVariable,
+		ShellVariableUpdateTransform,
+	},
 };
 
+crate::minus_or_plus_flag_arg!(MakeIndexedArrayFlag, 'a', "Make the variable an indexed array.");
 crate::minus_or_plus_flag_arg!(
-    MakeIndexedArrayFlag,
-    'a',
-    "Make the variable an indexed array."
+	MakeAssociativeArrayFlag,
+	'A',
+	"Make the variable an associative array."
 );
 crate::minus_or_plus_flag_arg!(
-    MakeAssociativeArrayFlag,
-    'A',
-    "Make the variable an associative array."
-);
-crate::minus_or_plus_flag_arg!(
-    CapitalizeValueOnAssignmentFlag,
-    'c',
-    "Enable capitalize-on-assignment for the variable."
+	CapitalizeValueOnAssignmentFlag,
+	'c',
+	"Enable capitalize-on-assignment for the variable."
 );
 crate::minus_or_plus_flag_arg!(MakeIntegerFlag, 'i', "Mark the variable as integer-typed");
 crate::minus_or_plus_flag_arg!(
-    LowercaseValueOnAssignmentFlag,
-    'l',
-    "Enable lowercase-on-assignment for the variable."
+	LowercaseValueOnAssignmentFlag,
+	'l',
+	"Enable lowercase-on-assignment for the variable."
 );
-crate::minus_or_plus_flag_arg!(
-    MakeNameRefFlag,
-    'n',
-    "Mark the variable as a name reference"
-);
+crate::minus_or_plus_flag_arg!(MakeNameRefFlag, 'n', "Mark the variable as a name reference");
 crate::minus_or_plus_flag_arg!(MakeReadonlyFlag, 'r', "Mark the variable as read-only.");
 crate::minus_or_plus_flag_arg!(MakeTracedFlag, 't', "Enable tracing for the variable.");
 crate::minus_or_plus_flag_arg!(
-    UppercaseValueOnAssignmentFlag,
-    'u',
-    "Enable uppercase-on-assignment for the variable."
+	UppercaseValueOnAssignmentFlag,
+	'u',
+	"Enable uppercase-on-assignment for the variable."
 );
 crate::minus_or_plus_flag_arg!(MakeExportedFlag, 'x', "Mark the variable for export.");
 
@@ -51,582 +43,555 @@ crate::minus_or_plus_flag_arg!(MakeExportedFlag, 'x', "Mark the variable for exp
 #[derive(Parser)]
 #[clap(override_usage = "declare [OPTIONS] [DECLARATIONS]...")]
 pub(crate) struct DeclareCommand {
-    /// Constrain to function names or definitions.
-    #[arg(short = 'f')]
-    function_names_or_defs_only: bool,
+	/// Constrain to function names or definitions.
+	#[arg(short = 'f')]
+	function_names_or_defs_only: bool,
 
-    /// Constrain to function names only.
-    #[arg(short = 'F')]
-    function_names_only: bool,
+	/// Constrain to function names only.
+	#[arg(short = 'F')]
+	function_names_only: bool,
 
-    /// Create global variable, if applicable.
-    #[arg(short = 'g')]
-    create_global: bool,
+	/// Create global variable, if applicable.
+	#[arg(short = 'g')]
+	create_global: bool,
 
-    /// When creating a local variable that shadows another variable of the same name,
-    /// then initialize it with the contents and attributes of the variable being shadowed.
-    #[arg(short = 'I')]
-    locals_inherit_from_prev_scope: bool,
+	/// When creating a local variable that shadows another variable of the same name,
+	/// then initialize it with the contents and attributes of the variable being shadowed.
+	#[arg(short = 'I')]
+	locals_inherit_from_prev_scope: bool,
 
-    /// Display each item's attributes and values.
-    #[arg(short = 'p')]
-    print: bool,
+	/// Display each item's attributes and values.
+	#[arg(short = 'p')]
+	print: bool,
 
-    //
-    // Attribute options
-    #[clap(flatten)] // -a
-    make_indexed_array: MakeIndexedArrayFlag,
-    #[clap(flatten)] // -A
-    make_associative_array: MakeAssociativeArrayFlag,
-    #[clap(flatten)] // -c
-    capitalize_value_on_assignment: CapitalizeValueOnAssignmentFlag,
-    #[clap(flatten)] // -i
-    make_integer: MakeIntegerFlag,
-    #[clap(flatten)] // -l
-    lowercase_value_on_assignment: LowercaseValueOnAssignmentFlag,
-    #[clap(flatten)] // -n
-    make_nameref: MakeNameRefFlag,
-    #[clap(flatten)] // -r
-    make_readonly: MakeReadonlyFlag,
-    #[clap(flatten)] // -t
-    make_traced: MakeTracedFlag,
-    #[clap(flatten)] // -u
-    uppercase_value_on_assignment: UppercaseValueOnAssignmentFlag,
-    #[clap(flatten)] // -x
-    make_exported: MakeExportedFlag,
+	//
+	// Attribute options
+	#[clap(flatten)] // -a
+	make_indexed_array: MakeIndexedArrayFlag,
+	#[clap(flatten)] // -A
+	make_associative_array: MakeAssociativeArrayFlag,
+	#[clap(flatten)] // -c
+	capitalize_value_on_assignment: CapitalizeValueOnAssignmentFlag,
+	#[clap(flatten)] // -i
+	make_integer: MakeIntegerFlag,
+	#[clap(flatten)] // -l
+	lowercase_value_on_assignment: LowercaseValueOnAssignmentFlag,
+	#[clap(flatten)] // -n
+	make_nameref: MakeNameRefFlag,
+	#[clap(flatten)] // -r
+	make_readonly: MakeReadonlyFlag,
+	#[clap(flatten)] // -t
+	make_traced: MakeTracedFlag,
+	#[clap(flatten)] // -u
+	uppercase_value_on_assignment: UppercaseValueOnAssignmentFlag,
+	#[clap(flatten)] // -x
+	make_exported: MakeExportedFlag,
 
-    //
-    // Declarations
-    //
-    // N.B. These are skipped by clap, but filled in by the BuiltinDeclarationCommand trait.
-    #[clap(skip)]
-    declarations: Vec<brush_core::CommandArg>,
+	//
+	// Declarations
+	//
+	// N.B. These are skipped by clap, but filled in by the BuiltinDeclarationCommand trait.
+	#[clap(skip)]
+	declarations: Vec<brush_core::CommandArg>,
 }
 
 #[derive(Clone, Copy)]
 enum DeclareVerb {
-    Declare,
-    Local,
-    Readonly,
+	Declare,
+	Local,
+	Readonly,
 }
 
 impl builtins::DeclarationCommand for DeclareCommand {
-    fn set_declarations(&mut self, declarations: Vec<brush_core::CommandArg>) {
-        self.declarations = declarations;
-    }
+	fn set_declarations(&mut self, declarations: Vec<brush_core::CommandArg>) {
+		self.declarations = declarations;
+	}
 }
 
 impl builtins::Command for DeclareCommand {
-    fn takes_plus_options() -> bool {
-        true
-    }
+	fn takes_plus_options() -> bool {
+		true
+	}
 
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        mut context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        let verb = match context.command_name.as_str() {
-            "local" => DeclareVerb::Local,
-            "readonly" => DeclareVerb::Readonly,
-            _ => DeclareVerb::Declare,
-        };
+	async fn execute(
+		&self,
+		mut context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		let verb = match context.command_name.as_str() {
+			"local" => DeclareVerb::Local,
+			"readonly" => DeclareVerb::Readonly,
+			_ => DeclareVerb::Declare,
+		};
 
-        if matches!(verb, DeclareVerb::Local) && !context.shell.in_function() {
-            writeln!(context.stderr(), "can only be used in a function")?;
-            return Ok(ExecutionResult::general_error());
-        }
+		if matches!(verb, DeclareVerb::Local) && !context.shell.in_function() {
+			writeln!(context.stderr(), "can only be used in a function")?;
+			return Ok(ExecutionResult::general_error());
+		}
 
-        if self.locals_inherit_from_prev_scope {
-            return error::unimp("declare -I");
-        }
+		if self.locals_inherit_from_prev_scope {
+			return error::unimp("declare -I");
+		}
 
-        let mut result = ExecutionResult::success();
-        if !self.declarations.is_empty() {
-            for declaration in &self.declarations {
-                if self.print && !matches!(verb, DeclareVerb::Readonly) {
-                    if !self.try_display_declaration(&context, declaration, verb)? {
-                        result = ExecutionResult::general_error();
-                    }
-                } else {
-                    if !self.process_declaration(&mut context, declaration, verb)? {
-                        result = ExecutionResult::general_error();
-                    }
-                }
-            }
-        } else {
-            // Display matching declarations from the variable environment.
-            if !self.function_names_only && !self.function_names_or_defs_only {
-                self.display_matching_env_declarations(&context, verb)?;
-            }
+		let mut result = ExecutionResult::success();
+		if !self.declarations.is_empty() {
+			for declaration in &self.declarations {
+				if self.print && !matches!(verb, DeclareVerb::Readonly) {
+					if !self.try_display_declaration(&context, declaration, verb)? {
+						result = ExecutionResult::general_error();
+					}
+				} else {
+					if !self.process_declaration(&mut context, declaration, verb)? {
+						result = ExecutionResult::general_error();
+					}
+				}
+			}
+		} else {
+			// Display matching declarations from the variable environment.
+			if !self.function_names_only && !self.function_names_or_defs_only {
+				self.display_matching_env_declarations(&context, verb)?;
+			}
 
-            // Do the same for functions.
-            if !matches!(verb, DeclareVerb::Local | DeclareVerb::Readonly)
-                && (!self.print || self.function_names_only || self.function_names_or_defs_only)
-            {
-                self.display_matching_functions(&context)?;
-            }
-        }
+			// Do the same for functions.
+			if !matches!(verb, DeclareVerb::Local | DeclareVerb::Readonly)
+				&& (!self.print || self.function_names_only || self.function_names_or_defs_only)
+			{
+				self.display_matching_functions(&context)?;
+			}
+		}
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 }
 
 impl DeclareCommand {
-    fn try_display_declaration(
-        &self,
-        context: &brush_core::ExecutionContext<'_>,
-        declaration: &brush_core::CommandArg,
-        verb: DeclareVerb,
-    ) -> Result<bool, brush_core::Error> {
-        let name = match declaration {
-            brush_core::CommandArg::String(s) => s,
-            brush_core::CommandArg::Assignment(_) => {
-                writeln!(context.stderr(), "declare: {declaration}: not found")?;
-                return Ok(false);
-            }
-        };
+	fn try_display_declaration(
+		&self,
+		context: &brush_core::ExecutionContext<'_>,
+		declaration: &brush_core::CommandArg,
+		verb: DeclareVerb,
+	) -> Result<bool, brush_core::Error> {
+		let name = match declaration {
+			brush_core::CommandArg::String(s) => s,
+			brush_core::CommandArg::Assignment(_) => {
+				writeln!(context.stderr(), "declare: {declaration}: not found")?;
+				return Ok(false);
+			},
+		};
 
-        let lookup = if matches!(verb, DeclareVerb::Local) {
-            EnvironmentLookup::OnlyInCurrentLocal
-        } else {
-            EnvironmentLookup::Anywhere
-        };
+		let lookup = if matches!(verb, DeclareVerb::Local) {
+			EnvironmentLookup::OnlyInCurrentLocal
+		} else {
+			EnvironmentLookup::Anywhere
+		};
 
-        if self.function_names_only || self.function_names_or_defs_only {
-            if let Some(func_registration) = context.shell.funcs().get(name) {
-                if self.function_names_only {
-                    if self.print {
-                        writeln!(context.stdout(), "declare -f {name}")?;
-                    } else {
-                        writeln!(context.stdout(), "{name}")?;
-                    }
-                } else {
-                    writeln!(context.stdout(), "{}", func_registration.definition())?;
-                }
-                Ok(true)
-            } else {
-                // For some reason, bash does not print an error message in this case.
-                Ok(false)
-            }
-        } else if let Some(variable) = context.shell.env.get_using_policy(name, lookup) {
-            let mut cs = variable.attribute_flags(context.shell);
-            if cs.is_empty() {
-                cs.push('-');
-            }
+		if self.function_names_only || self.function_names_or_defs_only {
+			if let Some(func_registration) = context.shell.funcs().get(name) {
+				if self.function_names_only {
+					if self.print {
+						writeln!(context.stdout(), "declare -f {name}")?;
+					} else {
+						writeln!(context.stdout(), "{name}")?;
+					}
+				} else {
+					writeln!(context.stdout(), "{}", func_registration.definition())?;
+				}
+				Ok(true)
+			} else {
+				// For some reason, bash does not print an error message in this case.
+				Ok(false)
+			}
+		} else if let Some(variable) = context.shell.env.get_using_policy(name, lookup) {
+			let mut cs = variable.attribute_flags(context.shell);
+			if cs.is_empty() {
+				cs.push('-');
+			}
 
-            let resolved_value = variable.resolve_value(context.shell);
-            let separator_str = if matches!(resolved_value, ShellValue::Unset(_)) {
-                ""
-            } else {
-                "="
-            };
+			let resolved_value = variable.resolve_value(context.shell);
+			let separator_str = if matches!(resolved_value, ShellValue::Unset(_)) {
+				""
+			} else {
+				"="
+			};
 
-            writeln!(
-                context.stdout(),
-                "declare -{cs} {name}{separator_str}{}",
-                resolved_value.format(variables::FormatStyle::DeclarePrint, context.shell)?
-            )?;
+			writeln!(
+				context.stdout(),
+				"declare -{cs} {name}{separator_str}{}",
+				resolved_value.format(variables::FormatStyle::DeclarePrint, context.shell)?
+			)?;
 
-            Ok(true)
-        } else {
-            writeln!(context.stderr(), "declare: {name}: not found")?;
-            Ok(false)
-        }
-    }
+			Ok(true)
+		} else {
+			writeln!(context.stderr(), "declare: {name}: not found")?;
+			Ok(false)
+		}
+	}
 
-    fn process_declaration(
-        &self,
-        context: &mut brush_core::ExecutionContext<'_>,
-        declaration: &brush_core::CommandArg,
-        verb: DeclareVerb,
-    ) -> Result<bool, brush_core::Error> {
-        let create_var_local = matches!(verb, DeclareVerb::Local)
-            || (context.shell.in_function() && !self.create_global);
+	fn process_declaration(
+		&self,
+		context: &mut brush_core::ExecutionContext<'_>,
+		declaration: &brush_core::CommandArg,
+		verb: DeclareVerb,
+	) -> Result<bool, brush_core::Error> {
+		let create_var_local =
+			matches!(verb, DeclareVerb::Local) || (context.shell.in_function() && !self.create_global);
 
-        if self.function_names_or_defs_only || self.function_names_only {
-            return self.try_display_declaration(context, declaration, verb);
-        }
+		if self.function_names_or_defs_only || self.function_names_only {
+			return self.try_display_declaration(context, declaration, verb);
+		}
 
-        // Extract the variable name and the initial value being assigned (if any).
-        let (name, assigned_index, initial_value, name_is_array) =
-            Self::declaration_to_name_and_value(declaration)?;
+		// Extract the variable name and the initial value being assigned (if any).
+		let (name, assigned_index, initial_value, name_is_array) =
+			Self::declaration_to_name_and_value(declaration)?;
 
-        // Special-case: `local -`
-        if name == "-" && matches!(verb, DeclareVerb::Local) {
-            // TODO: `local -` allows shadowing the current `set` options (i.e., $-), with
-            // subsequent updates getting discarded when the current local scope is popped.
-            tracing::warn!("not yet implemented: local -");
-            return Ok(true);
-        }
+		// Special-case: `local -`
+		if name == "-" && matches!(verb, DeclareVerb::Local) {
+			// TODO: `local -` allows shadowing the current `set` options (i.e., $-), with
+			// subsequent updates getting discarded when the current local scope is popped.
+			tracing::warn!("not yet implemented: local -");
+			return Ok(true);
+		}
 
-        // Make sure it's a valid name.
-        if !env::valid_variable_name(name.as_str()) {
-            writeln!(
-                context.stderr(),
-                "{}: {name}: not a valid variable name",
-                context.command_name
-            )?;
-            return Ok(false);
-        }
+		// Make sure it's a valid name.
+		if !env::valid_variable_name(name.as_str()) {
+			writeln!(context.stderr(), "{}: {name}: not a valid variable name", context.command_name)?;
+			return Ok(false);
+		}
 
-        // Figure out where we should look.
-        let lookup = if create_var_local {
-            EnvironmentLookup::OnlyInCurrentLocal
-        } else {
-            EnvironmentLookup::Anywhere
-        };
+		// Figure out where we should look.
+		let lookup = if create_var_local {
+			EnvironmentLookup::OnlyInCurrentLocal
+		} else {
+			EnvironmentLookup::Anywhere
+		};
 
-        // Look up the variable.
-        if let Some(var) = context
-            .shell
-            .env
-            .get_mut_using_policy(name.as_str(), lookup)
-        {
-            if self.make_associative_array.is_some() {
-                var.convert_to_associative_array()?;
-            }
-            if self.make_indexed_array.is_some() {
-                var.convert_to_indexed_array()?;
-            }
+		// Look up the variable.
+		if let Some(var) = context
+			.shell
+			.env
+			.get_mut_using_policy(name.as_str(), lookup)
+		{
+			if self.make_associative_array.is_some() {
+				var.convert_to_associative_array()?;
+			}
+			if self.make_indexed_array.is_some() {
+				var.convert_to_indexed_array()?;
+			}
 
-            self.apply_attributes_before_update(var)?;
+			self.apply_attributes_before_update(var)?;
 
-            if let Some(initial_value) = initial_value {
-                // We append if the declaration included an explicit index.
-                var.assign(initial_value, assigned_index.is_some())?;
-            }
+			if let Some(initial_value) = initial_value {
+				// We append if the declaration included an explicit index.
+				var.assign(initial_value, assigned_index.is_some())?;
+			}
 
-            self.apply_attributes_after_update(var, verb)?;
-        } else {
-            let unset_type = if self.make_indexed_array.is_some() {
-                ShellValueUnsetType::IndexedArray
-            } else if self.make_associative_array.is_some() {
-                ShellValueUnsetType::AssociativeArray
-            } else if name_is_array {
-                ShellValueUnsetType::IndexedArray
-            } else {
-                ShellValueUnsetType::Untyped
-            };
+			self.apply_attributes_after_update(var, verb)?;
+		} else {
+			let unset_type = if self.make_indexed_array.is_some() {
+				ShellValueUnsetType::IndexedArray
+			} else if self.make_associative_array.is_some() {
+				ShellValueUnsetType::AssociativeArray
+			} else if name_is_array {
+				ShellValueUnsetType::IndexedArray
+			} else {
+				ShellValueUnsetType::Untyped
+			};
 
-            let mut var = ShellVariable::new(ShellValue::Unset(unset_type));
+			let mut var = ShellVariable::new(ShellValue::Unset(unset_type));
 
-            self.apply_attributes_before_update(&mut var)?;
+			self.apply_attributes_before_update(&mut var)?;
 
-            if let Some(initial_value) = initial_value {
-                var.assign(initial_value, false)?;
-            }
+			if let Some(initial_value) = initial_value {
+				var.assign(initial_value, false)?;
+			}
 
-            if context.shell.options.export_variables_on_modification && !var.value().is_array() {
-                var.export();
-            }
+			if context.shell.options.export_variables_on_modification && !var.value().is_array() {
+				var.export();
+			}
 
-            self.apply_attributes_after_update(&mut var, verb)?;
+			self.apply_attributes_after_update(&mut var, verb)?;
 
-            let scope = if create_var_local {
-                EnvironmentScope::Local
-            } else {
-                EnvironmentScope::Global
-            };
+			let scope = if create_var_local {
+				EnvironmentScope::Local
+			} else {
+				EnvironmentScope::Global
+			};
 
-            context.shell.env.add(name, var, scope)?;
-        }
+			context.shell.env.add(name, var, scope)?;
+		}
 
-        Ok(true)
-    }
+		Ok(true)
+	}
 
-    #[allow(clippy::unwrap_in_result)]
-    fn declaration_to_name_and_value(
-        declaration: &brush_core::CommandArg,
-    ) -> Result<(String, Option<String>, Option<ShellValueLiteral>, bool), brush_core::Error> {
-        let name;
-        let assigned_index;
-        let initial_value;
-        let name_is_array;
+	#[allow(clippy::unwrap_in_result)]
+	fn declaration_to_name_and_value(
+		declaration: &brush_core::CommandArg,
+	) -> Result<(String, Option<String>, Option<ShellValueLiteral>, bool), brush_core::Error> {
+		let name;
+		let assigned_index;
+		let initial_value;
+		let name_is_array;
 
-        match declaration {
-            brush_core::CommandArg::String(s) => {
-                // We need to handle the case of someone invoking `declare array[index]`.
-                // In such case, we ignore the index and treat it as a declaration of
-                // the array.
-                static ARRAY_AND_INDEX_RE: LazyLock<fancy_regex::Regex> =
-                    LazyLock::new(|| fancy_regex::Regex::new(r"^(.*?)\[(.*?)\]$").unwrap());
-                if let Some(captures) = ARRAY_AND_INDEX_RE.captures(s)? {
-                    name = captures.get(1).unwrap().as_str().to_owned();
-                    assigned_index = Some(captures.get(2).unwrap().as_str().to_owned());
-                    name_is_array = true;
-                } else {
-                    name = s.clone();
-                    assigned_index = None;
-                    name_is_array = false;
-                }
-                initial_value = None;
-            }
-            brush_core::CommandArg::Assignment(assignment) => {
-                match &assignment.name {
-                    brush_parser::ast::AssignmentName::VariableName(var_name) => {
-                        name = var_name.to_owned();
-                        assigned_index = None;
-                    }
-                    brush_parser::ast::AssignmentName::ArrayElementName(var_name, index) => {
-                        if matches!(
-                            assignment.value,
-                            brush_parser::ast::AssignmentValue::Array(_)
-                        ) {
-                            return Err(ErrorKind::AssigningListToArrayMember.into());
-                        }
+		match declaration {
+			brush_core::CommandArg::String(s) => {
+				// We need to handle the case of someone invoking `declare array[index]`.
+				// In such case, we ignore the index and treat it as a declaration of
+				// the array.
+				static ARRAY_AND_INDEX_RE: LazyLock<fancy_regex::Regex> =
+					LazyLock::new(|| fancy_regex::Regex::new(r"^(.*?)\[(.*?)\]$").unwrap());
+				if let Some(captures) = ARRAY_AND_INDEX_RE.captures(s)? {
+					name = captures.get(1).unwrap().as_str().to_owned();
+					assigned_index = Some(captures.get(2).unwrap().as_str().to_owned());
+					name_is_array = true;
+				} else {
+					name = s.clone();
+					assigned_index = None;
+					name_is_array = false;
+				}
+				initial_value = None;
+			},
+			brush_core::CommandArg::Assignment(assignment) => {
+				match &assignment.name {
+					brush_parser::ast::AssignmentName::VariableName(var_name) => {
+						name = var_name.to_owned();
+						assigned_index = None;
+					},
+					brush_parser::ast::AssignmentName::ArrayElementName(var_name, index) => {
+						if matches!(assignment.value, brush_parser::ast::AssignmentValue::Array(_)) {
+							return Err(ErrorKind::AssigningListToArrayMember.into());
+						}
 
-                        name = var_name.to_owned();
-                        assigned_index = Some(index.to_owned());
-                    }
-                }
+						name = var_name.to_owned();
+						assigned_index = Some(index.to_owned());
+					},
+				}
 
-                match &assignment.value {
-                    brush_parser::ast::AssignmentValue::Scalar(s) => {
-                        if let Some(index) = &assigned_index {
-                            initial_value = Some(ShellValueLiteral::Array(ArrayLiteral(vec![(
-                                Some(index.to_owned()),
-                                s.value.clone(),
-                            )])));
-                            name_is_array = true;
-                        } else {
-                            initial_value = Some(ShellValueLiteral::Scalar(s.value.clone()));
-                            name_is_array = false;
-                        }
-                    }
-                    brush_parser::ast::AssignmentValue::Array(a) => {
-                        initial_value = Some(ShellValueLiteral::Array(ArrayLiteral(
-                            a.iter()
-                                .map(|(i, v)| {
-                                    (i.as_ref().map(|w| w.value.clone()), v.value.clone())
-                                })
-                                .collect(),
-                        )));
-                        name_is_array = true;
-                    }
-                }
-            }
-        }
+				match &assignment.value {
+					brush_parser::ast::AssignmentValue::Scalar(s) => {
+						if let Some(index) = &assigned_index {
+							initial_value = Some(ShellValueLiteral::Array(ArrayLiteral(vec![(
+								Some(index.to_owned()),
+								s.value.clone(),
+							)])));
+							name_is_array = true;
+						} else {
+							initial_value = Some(ShellValueLiteral::Scalar(s.value.clone()));
+							name_is_array = false;
+						}
+					},
+					brush_parser::ast::AssignmentValue::Array(a) => {
+						initial_value = Some(ShellValueLiteral::Array(ArrayLiteral(
+							a.iter()
+								.map(|(i, v)| (i.as_ref().map(|w| w.value.clone()), v.value.clone()))
+								.collect(),
+						)));
+						name_is_array = true;
+					},
+				}
+			},
+		}
 
-        Ok((name, assigned_index, initial_value, name_is_array))
-    }
+		Ok((name, assigned_index, initial_value, name_is_array))
+	}
 
-    fn display_matching_env_declarations(
-        &self,
-        context: &brush_core::ExecutionContext<'_>,
-        verb: DeclareVerb,
-    ) -> Result<(), brush_core::Error> {
-        //
-        // Dump all declarations. Use attribute flags to filter which variables are dumped.
-        //
+	fn display_matching_env_declarations(
+		&self,
+		context: &brush_core::ExecutionContext<'_>,
+		verb: DeclareVerb,
+	) -> Result<(), brush_core::Error> {
+		//
+		// Dump all declarations. Use attribute flags to filter which variables are dumped.
+		//
 
-        // We start by excluding all variables that are not enumerable.
-        #[expect(clippy::type_complexity)]
-        let mut filters: Vec<Box<dyn Fn((&String, &ShellVariable)) -> bool>> =
-            vec![Box::new(|(_, v)| v.is_enumerable())];
+		// We start by excluding all variables that are not enumerable.
+		#[expect(clippy::type_complexity)]
+		let mut filters: Vec<Box<dyn Fn((&String, &ShellVariable)) -> bool>> =
+			vec![Box::new(|(_, v)| v.is_enumerable())];
 
-        // Add filters depending on verb.
-        if matches!(verb, DeclareVerb::Readonly) {
-            filters.push(Box::new(|(_, v)| v.is_readonly()));
-        }
+		// Add filters depending on verb.
+		if matches!(verb, DeclareVerb::Readonly) {
+			filters.push(Box::new(|(_, v)| v.is_readonly()));
+		}
 
-        // Add filters depending on attribute flags.
-        if let Some(value) = self.make_indexed_array.to_bool() {
-            filters.push(Box::new(move |(_, v)| {
-                matches!(v.value(), ShellValue::IndexedArray(_)) == value
-            }));
-        }
-        if let Some(value) = self.make_associative_array.to_bool() {
-            filters.push(Box::new(move |(_, v)| {
-                matches!(v.value(), ShellValue::AssociativeArray(_)) == value
-            }));
-        }
-        if let Some(value) = self.make_integer.to_bool() {
-            filters.push(Box::new(move |(_, v)| v.is_treated_as_integer() == value));
-        }
-        if let Some(value) = self.capitalize_value_on_assignment.to_bool() {
-            filters.push(Box::new(move |(_, v)| {
-                matches!(
-                    v.get_update_transform(),
-                    ShellVariableUpdateTransform::Capitalize
-                ) == value
-            }));
-        }
-        if let Some(value) = self.lowercase_value_on_assignment.to_bool() {
-            filters.push(Box::new(move |(_, v)| {
-                matches!(
-                    v.get_update_transform(),
-                    ShellVariableUpdateTransform::Lowercase
-                ) == value
-            }));
-        }
-        if let Some(value) = self.make_nameref.to_bool() {
-            filters.push(Box::new(move |(_, v)| v.is_treated_as_nameref() == value));
-        }
-        if let Some(value) = self.make_readonly.to_bool() {
-            filters.push(Box::new(move |(_, v)| v.is_readonly() == value));
-        }
-        if let Some(value) = self.make_readonly.to_bool() {
-            filters.push(Box::new(move |(_, v)| v.is_trace_enabled() == value));
-        }
-        if let Some(value) = self.uppercase_value_on_assignment.to_bool() {
-            filters.push(Box::new(move |(_, v)| {
-                matches!(
-                    v.get_update_transform(),
-                    ShellVariableUpdateTransform::Uppercase
-                ) == value
-            }));
-        }
-        if let Some(value) = self.make_exported.to_bool() {
-            filters.push(Box::new(move |(_, v)| v.is_exported() == value));
-        }
+		// Add filters depending on attribute flags.
+		if let Some(value) = self.make_indexed_array.to_bool() {
+			filters.push(Box::new(move |(_, v)| {
+				matches!(v.value(), ShellValue::IndexedArray(_)) == value
+			}));
+		}
+		if let Some(value) = self.make_associative_array.to_bool() {
+			filters.push(Box::new(move |(_, v)| {
+				matches!(v.value(), ShellValue::AssociativeArray(_)) == value
+			}));
+		}
+		if let Some(value) = self.make_integer.to_bool() {
+			filters.push(Box::new(move |(_, v)| v.is_treated_as_integer() == value));
+		}
+		if let Some(value) = self.capitalize_value_on_assignment.to_bool() {
+			filters.push(Box::new(move |(_, v)| {
+				matches!(v.get_update_transform(), ShellVariableUpdateTransform::Capitalize) == value
+			}));
+		}
+		if let Some(value) = self.lowercase_value_on_assignment.to_bool() {
+			filters.push(Box::new(move |(_, v)| {
+				matches!(v.get_update_transform(), ShellVariableUpdateTransform::Lowercase) == value
+			}));
+		}
+		if let Some(value) = self.make_nameref.to_bool() {
+			filters.push(Box::new(move |(_, v)| v.is_treated_as_nameref() == value));
+		}
+		if let Some(value) = self.make_readonly.to_bool() {
+			filters.push(Box::new(move |(_, v)| v.is_readonly() == value));
+		}
+		if let Some(value) = self.make_readonly.to_bool() {
+			filters.push(Box::new(move |(_, v)| v.is_trace_enabled() == value));
+		}
+		if let Some(value) = self.uppercase_value_on_assignment.to_bool() {
+			filters.push(Box::new(move |(_, v)| {
+				matches!(v.get_update_transform(), ShellVariableUpdateTransform::Uppercase) == value
+			}));
+		}
+		if let Some(value) = self.make_exported.to_bool() {
+			filters.push(Box::new(move |(_, v)| v.is_exported() == value));
+		}
 
-        let iter_policy = if matches!(verb, DeclareVerb::Local) {
-            EnvironmentLookup::OnlyInCurrentLocal
-        } else {
-            EnvironmentLookup::Anywhere
-        };
+		let iter_policy = if matches!(verb, DeclareVerb::Local) {
+			EnvironmentLookup::OnlyInCurrentLocal
+		} else {
+			EnvironmentLookup::Anywhere
+		};
 
-        // Iterate through an ordered list of all matching declarations tracked in the
-        // environment.
-        for (name, variable) in context
-            .shell
-            .env
-            .iter_using_policy(iter_policy)
-            .filter(|pair| filters.iter().all(|f| f(*pair)))
-            .sorted_by_key(|v| v.0)
-        {
-            if self.print {
-                let mut cs = variable.attribute_flags(context.shell);
-                if cs.is_empty() {
-                    cs.push('-');
-                }
+		// Iterate through an ordered list of all matching declarations tracked in the
+		// environment.
+		for (name, variable) in context
+			.shell
+			.env
+			.iter_using_policy(iter_policy)
+			.filter(|pair| filters.iter().all(|f| f(*pair)))
+			.sorted_by_key(|v| v.0)
+		{
+			if self.print {
+				let mut cs = variable.attribute_flags(context.shell);
+				if cs.is_empty() {
+					cs.push('-');
+				}
 
-                let separator_str = if matches!(variable.value(), ShellValue::Unset(_)) {
-                    ""
-                } else {
-                    "="
-                };
+				let separator_str = if matches!(variable.value(), ShellValue::Unset(_)) {
+					""
+				} else {
+					"="
+				};
 
-                writeln!(
-                    context.stdout(),
-                    "declare -{cs} {name}{separator_str}{}",
-                    variable
-                        .value()
-                        .format(variables::FormatStyle::DeclarePrint, context.shell)?
-                )?;
-            } else {
-                writeln!(
-                    context.stdout(),
-                    "{name}={}",
-                    variable
-                        .value()
-                        .format(variables::FormatStyle::Basic, context.shell)?
-                )?;
-            }
-        }
+				writeln!(
+					context.stdout(),
+					"declare -{cs} {name}{separator_str}{}",
+					variable
+						.value()
+						.format(variables::FormatStyle::DeclarePrint, context.shell)?
+				)?;
+			} else {
+				writeln!(
+					context.stdout(),
+					"{name}={}",
+					variable
+						.value()
+						.format(variables::FormatStyle::Basic, context.shell)?
+				)?;
+			}
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    fn display_matching_functions(
-        &self,
-        context: &brush_core::ExecutionContext<'_>,
-    ) -> Result<(), brush_core::Error> {
-        for (name, registration) in context.shell.funcs().iter().sorted_by_key(|v| v.0) {
-            if self.function_names_only {
-                writeln!(context.stdout(), "declare -f {name}")?;
-            } else {
-                writeln!(context.stdout(), "{}", registration.definition())?;
-            }
-        }
+	fn display_matching_functions(
+		&self,
+		context: &brush_core::ExecutionContext<'_>,
+	) -> Result<(), brush_core::Error> {
+		for (name, registration) in context.shell.funcs().iter().sorted_by_key(|v| v.0) {
+			if self.function_names_only {
+				writeln!(context.stdout(), "declare -f {name}")?;
+			} else {
+				writeln!(context.stdout(), "{}", registration.definition())?;
+			}
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    #[expect(clippy::unnecessary_wraps)]
-    const fn apply_attributes_before_update(
-        &self,
-        var: &mut ShellVariable,
-    ) -> Result<(), brush_core::Error> {
-        if let Some(value) = self.make_integer.to_bool() {
-            if value {
-                var.treat_as_integer();
-            } else {
-                var.unset_treat_as_integer();
-            }
-        }
-        if let Some(value) = self.capitalize_value_on_assignment.to_bool() {
-            if value {
-                var.set_update_transform(ShellVariableUpdateTransform::Capitalize);
-            } else if matches!(
-                var.get_update_transform(),
-                ShellVariableUpdateTransform::Capitalize
-            ) {
-                var.set_update_transform(ShellVariableUpdateTransform::None);
-            }
-        }
-        if let Some(value) = self.lowercase_value_on_assignment.to_bool() {
-            if value {
-                var.set_update_transform(ShellVariableUpdateTransform::Lowercase);
-            } else if matches!(
-                var.get_update_transform(),
-                ShellVariableUpdateTransform::Lowercase
-            ) {
-                var.set_update_transform(ShellVariableUpdateTransform::None);
-            }
-        }
-        if let Some(value) = self.make_nameref.to_bool() {
-            if value {
-                var.treat_as_nameref();
-            } else {
-                var.unset_treat_as_nameref();
-            }
-        }
-        if let Some(value) = self.make_traced.to_bool() {
-            if value {
-                var.enable_trace();
-            } else {
-                var.disable_trace();
-            }
-        }
-        if let Some(value) = self.uppercase_value_on_assignment.to_bool() {
-            if value {
-                var.set_update_transform(ShellVariableUpdateTransform::Uppercase);
-            } else if matches!(
-                var.get_update_transform(),
-                ShellVariableUpdateTransform::Uppercase
-            ) {
-                var.set_update_transform(ShellVariableUpdateTransform::None);
-            }
-        }
-        if let Some(value) = self.make_exported.to_bool() {
-            if value {
-                var.export();
-            } else {
-                var.unexport();
-            }
-        }
+	#[expect(clippy::unnecessary_wraps)]
+	const fn apply_attributes_before_update(
+		&self,
+		var: &mut ShellVariable,
+	) -> Result<(), brush_core::Error> {
+		if let Some(value) = self.make_integer.to_bool() {
+			if value {
+				var.treat_as_integer();
+			} else {
+				var.unset_treat_as_integer();
+			}
+		}
+		if let Some(value) = self.capitalize_value_on_assignment.to_bool() {
+			if value {
+				var.set_update_transform(ShellVariableUpdateTransform::Capitalize);
+			} else if matches!(var.get_update_transform(), ShellVariableUpdateTransform::Capitalize) {
+				var.set_update_transform(ShellVariableUpdateTransform::None);
+			}
+		}
+		if let Some(value) = self.lowercase_value_on_assignment.to_bool() {
+			if value {
+				var.set_update_transform(ShellVariableUpdateTransform::Lowercase);
+			} else if matches!(var.get_update_transform(), ShellVariableUpdateTransform::Lowercase) {
+				var.set_update_transform(ShellVariableUpdateTransform::None);
+			}
+		}
+		if let Some(value) = self.make_nameref.to_bool() {
+			if value {
+				var.treat_as_nameref();
+			} else {
+				var.unset_treat_as_nameref();
+			}
+		}
+		if let Some(value) = self.make_traced.to_bool() {
+			if value {
+				var.enable_trace();
+			} else {
+				var.disable_trace();
+			}
+		}
+		if let Some(value) = self.uppercase_value_on_assignment.to_bool() {
+			if value {
+				var.set_update_transform(ShellVariableUpdateTransform::Uppercase);
+			} else if matches!(var.get_update_transform(), ShellVariableUpdateTransform::Uppercase) {
+				var.set_update_transform(ShellVariableUpdateTransform::None);
+			}
+		}
+		if let Some(value) = self.make_exported.to_bool() {
+			if value {
+				var.export();
+			} else {
+				var.unexport();
+			}
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    fn apply_attributes_after_update(
-        &self,
-        var: &mut ShellVariable,
-        verb: DeclareVerb,
-    ) -> Result<(), brush_core::Error> {
-        if matches!(verb, DeclareVerb::Readonly) {
-            var.set_readonly();
-        } else if let Some(value) = self.make_readonly.to_bool() {
-            if value {
-                var.set_readonly();
-            } else {
-                var.unset_readonly()?;
-            }
-        }
+	fn apply_attributes_after_update(
+		&self,
+		var: &mut ShellVariable,
+		verb: DeclareVerb,
+	) -> Result<(), brush_core::Error> {
+		if matches!(verb, DeclareVerb::Readonly) {
+			var.set_readonly();
+		} else if let Some(value) = self.make_readonly.to_bool() {
+			if value {
+				var.set_readonly();
+			} else {
+				var.unset_readonly()?;
+			}
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 }

--- a/crates/brush-builtins-vendored/src/dirs.rs
+++ b/crates/brush-builtins-vendored/src/dirs.rs
@@ -5,22 +5,22 @@ use brush_core::{ExecutionResult, builtins};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum DirError {
-    /// Directory stack is empty.
-    #[error("directory stack is empty")]
-    DirStackEmpty,
+	/// Directory stack is empty.
+	#[error("directory stack is empty")]
+	DirStackEmpty,
 
-    /// A shell error occurred.
-    #[error(transparent)]
-    ShellError(#[from] brush_core::Error),
+	/// A shell error occurred.
+	#[error(transparent)]
+	ShellError(#[from] brush_core::Error),
 }
 
 impl From<&DirError> for brush_core::ExecutionExitCode {
-    fn from(value: &DirError) -> Self {
-        match value {
-            DirError::DirStackEmpty => Self::GeneralError,
-            DirError::ShellError(e) => e.into(),
-        }
-    }
+	fn from(value: &DirError) -> Self {
+		match value {
+			DirError::DirStackEmpty => Self::GeneralError,
+			DirError::ShellError(e) => e.into(),
+		}
+	}
 }
 
 impl brush_core::BuiltinError for DirError {}
@@ -28,74 +28,74 @@ impl brush_core::BuiltinError for DirError {}
 /// Manage the current directory stack.
 #[derive(Default, Parser)]
 pub(crate) struct DirsCommand {
-    /// Clear the directory stack.
-    #[arg(short = 'c')]
-    clear: bool,
+	/// Clear the directory stack.
+	#[arg(short = 'c')]
+	clear: bool,
 
-    /// Don't tilde-shorten paths.
-    #[arg(short = 'l')]
-    tilde_long: bool,
+	/// Don't tilde-shorten paths.
+	#[arg(short = 'l')]
+	tilde_long: bool,
 
-    /// Print one directory per line instead of all on one line.
-    #[arg(short = 'p')]
-    print_one_per_line: bool,
+	/// Print one directory per line instead of all on one line.
+	#[arg(short = 'p')]
+	print_one_per_line: bool,
 
-    /// Print one directory per line with its index.
-    #[arg(short = 'v')]
-    print_one_per_line_with_index: bool,
-    //
-    // TODO: implement +N and -N
+	/// Print one directory per line with its index.
+	#[arg(short = 'v')]
+	print_one_per_line_with_index: bool,
+	//
+	// TODO: implement +N and -N
 }
 
 impl builtins::Command for DirsCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        if self.clear {
-            context.shell.directory_stack.clear();
-        } else {
-            let dirs = vec![context.shell.working_dir()]
-                .into_iter()
-                .chain(
-                    context
-                        .shell
-                        .directory_stack
-                        .iter()
-                        .rev()
-                        .map(|p| p.as_path()),
-                )
-                .collect::<Vec<_>>();
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		if self.clear {
+			context.shell.directory_stack.clear();
+		} else {
+			let dirs = vec![context.shell.working_dir()]
+				.into_iter()
+				.chain(
+					context
+						.shell
+						.directory_stack
+						.iter()
+						.rev()
+						.map(|p| p.as_path()),
+				)
+				.collect::<Vec<_>>();
 
-            let one_per_line = self.print_one_per_line || self.print_one_per_line_with_index;
+			let one_per_line = self.print_one_per_line || self.print_one_per_line_with_index;
 
-            for (i, dir) in dirs.iter().enumerate() {
-                if !one_per_line && i > 0 {
-                    write!(context.stdout(), " ")?;
-                }
+			for (i, dir) in dirs.iter().enumerate() {
+				if !one_per_line && i > 0 {
+					write!(context.stdout(), " ")?;
+				}
 
-                if self.print_one_per_line_with_index {
-                    write!(context.stdout(), "{i:2}  ")?;
-                }
+				if self.print_one_per_line_with_index {
+					write!(context.stdout(), "{i:2}  ")?;
+				}
 
-                let mut dir_str = dir.to_string_lossy().to_string();
+				let mut dir_str = dir.to_string_lossy().to_string();
 
-                if !self.tilde_long {
-                    dir_str = context.shell.tilde_shorten(dir_str);
-                }
+				if !self.tilde_long {
+					dir_str = context.shell.tilde_shorten(dir_str);
+				}
 
-                write!(context.stdout(), "{dir_str}")?;
+				write!(context.stdout(), "{dir_str}")?;
 
-                if one_per_line || i == dirs.len() - 1 {
-                    writeln!(context.stdout())?;
-                }
-            }
+				if one_per_line || i == dirs.len() - 1 {
+					writeln!(context.stdout())?;
+				}
+			}
 
-            return Ok(ExecutionResult::success());
-        }
+			return Ok(ExecutionResult::success());
+		}
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }

--- a/crates/brush-builtins-vendored/src/dot.rs
+++ b/crates/brush-builtins-vendored/src/dot.rs
@@ -6,29 +6,25 @@ use clap::Parser;
 /// Evaluate the provided script in the current shell environment.
 #[derive(Parser)]
 pub(crate) struct DotCommand {
-    /// Path to the script to evaluate.
-    script_path: String,
+	/// Path to the script to evaluate.
+	script_path: String,
 
-    /// Any arguments to be passed as positional parameters to the script.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    script_args: Vec<String>,
+	/// Any arguments to be passed as positional parameters to the script.
+	#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+	script_args: Vec<String>,
 }
 
 impl builtins::Command for DotCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        // TODO: Handle trap inheritance.
-        context
-            .shell
-            .source_script(
-                Path::new(&self.script_path),
-                self.script_args.iter(),
-                &context.params,
-            )
-            .await
-    }
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		// TODO: Handle trap inheritance.
+		context
+			.shell
+			.source_script(Path::new(&self.script_path), self.script_args.iter(), &context.params)
+			.await
+	}
 }

--- a/crates/brush-builtins-vendored/src/echo.rs
+++ b/crates/brush-builtins-vendored/src/echo.rs
@@ -7,75 +7,75 @@ use brush_core::{ExecutionResult, builtins, escape};
 #[derive(Parser)]
 #[clap(disable_help_flag = true, disable_version_flag = true)]
 pub(crate) struct EchoCommand {
-    /// Suppress the trailing newline from the output.
-    #[arg(short = 'n')]
-    no_trailing_newline: bool,
+	/// Suppress the trailing newline from the output.
+	#[arg(short = 'n')]
+	no_trailing_newline: bool,
 
-    /// Interpret backslash escapes in the provided text.
-    #[arg(short = 'e')]
-    interpret_backslash_escapes: bool,
+	/// Interpret backslash escapes in the provided text.
+	#[arg(short = 'e')]
+	interpret_backslash_escapes: bool,
 
-    /// Do not interpret backslash escapes in the provided text.
-    #[arg(short = 'E')]
-    no_interpret_backslash_escapes: bool,
+	/// Do not interpret backslash escapes in the provided text.
+	#[arg(short = 'E')]
+	no_interpret_backslash_escapes: bool,
 
-    /// Tokens to echo to standard output.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    args: Vec<String>,
+	/// Tokens to echo to standard output.
+	#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+	args: Vec<String>,
 }
 
 impl builtins::Command for EchoCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    /// Override the default [`builtins::Command::new`] function to handle clap's limitation related
-    /// to `--`. See [`builtins::parse_known`] for more information
-    /// TODO: we can safely remove this after the issue is resolved
-    fn new<I>(args: I) -> Result<Self, clap::Error>
-    where
-        I: IntoIterator<Item = String>,
-    {
-        let (mut this, rest_args) = brush_core::builtins::try_parse_known::<Self>(args)?;
-        if let Some(args) = rest_args {
-            this.args.extend(args);
-        }
-        Ok(this)
-    }
+	/// Override the default [`builtins::Command::new`] function to handle clap's limitation related
+	/// to `--`. See [`builtins::parse_known`] for more information
+	/// TODO: we can safely remove this after the issue is resolved
+	fn new<I>(args: I) -> Result<Self, clap::Error>
+	where
+		I: IntoIterator<Item = String>,
+	{
+		let (mut this, rest_args) = brush_core::builtins::try_parse_known::<Self>(args)?;
+		if let Some(args) = rest_args {
+			this.args.extend(args);
+		}
+		Ok(this)
+	}
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        let mut trailing_newline = !self.no_trailing_newline;
-        let mut s;
-        if self.interpret_backslash_escapes {
-            s = String::new();
-            for (i, arg) in self.args.iter().enumerate() {
-                if i > 0 {
-                    s.push(' ');
-                }
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		let mut trailing_newline = !self.no_trailing_newline;
+		let mut s;
+		if self.interpret_backslash_escapes {
+			s = String::new();
+			for (i, arg) in self.args.iter().enumerate() {
+				if i > 0 {
+					s.push(' ');
+				}
 
-                let (expanded_arg, keep_going) = escape::expand_backslash_escapes(
-                    arg.as_str(),
-                    escape::EscapeExpansionMode::EchoBuiltin,
-                )?;
-                s.push_str(&String::from_utf8_lossy(expanded_arg.as_slice()));
+				let (expanded_arg, keep_going) = escape::expand_backslash_escapes(
+					arg.as_str(),
+					escape::EscapeExpansionMode::EchoBuiltin,
+				)?;
+				s.push_str(&String::from_utf8_lossy(expanded_arg.as_slice()));
 
-                if !keep_going {
-                    trailing_newline = false;
-                    break;
-                }
-            }
-        } else {
-            s = self.args.join(" ");
-        }
+				if !keep_going {
+					trailing_newline = false;
+					break;
+				}
+			}
+		} else {
+			s = self.args.join(" ");
+		}
 
-        if trailing_newline {
-            s.push('\n');
-        }
+		if trailing_newline {
+			s.push('\n');
+		}
 
-        write!(context.stdout(), "{s}")?;
-        context.stdout().flush()?;
+		write!(context.stdout(), "{s}")?;
+		context.stdout().flush()?;
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }

--- a/crates/brush-builtins-vendored/src/enable.rs
+++ b/crates/brush-builtins-vendored/src/enable.rs
@@ -9,88 +9,88 @@ use brush_core::error;
 /// Enable, disable, or display built-in commands.
 #[derive(Parser)]
 pub(crate) struct EnableCommand {
-    /// Print a list of built-in commands.
-    #[arg(short = 'a')]
-    print_list: bool,
+	/// Print a list of built-in commands.
+	#[arg(short = 'a')]
+	print_list: bool,
 
-    /// Disables the specified built-in commands.
-    #[arg(short = 'n')]
-    disable: bool,
+	/// Disables the specified built-in commands.
+	#[arg(short = 'n')]
+	disable: bool,
 
-    /// Print a list of built-in commands with reusable output.
-    #[arg(short = 'p')]
-    print_reusably: bool,
+	/// Print a list of built-in commands with reusable output.
+	#[arg(short = 'p')]
+	print_reusably: bool,
 
-    /// Only operate on special built-in commands.
-    #[arg(short = 's')]
-    special_only: bool,
+	/// Only operate on special built-in commands.
+	#[arg(short = 's')]
+	special_only: bool,
 
-    /// Path to a shared object from which built-in commands will be loaded.
-    #[arg(short = 'f', value_name = "PATH")]
-    shared_object_path: Option<String>,
+	/// Path to a shared object from which built-in commands will be loaded.
+	#[arg(short = 'f', value_name = "PATH")]
+	shared_object_path: Option<String>,
 
-    /// Remove the built-in commands loaded from the indicated object path.
-    #[arg(short = 'd')]
-    remove_loaded_builtin: bool,
+	/// Remove the built-in commands loaded from the indicated object path.
+	#[arg(short = 'd')]
+	remove_loaded_builtin: bool,
 
-    /// Names of built-in commands to operate on.
-    names: Vec<String>,
+	/// Names of built-in commands to operate on.
+	names: Vec<String>,
 }
 
 impl builtins::Command for EnableCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, Self::Error> {
-        let mut result = ExecutionResult::success();
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, Self::Error> {
+		let mut result = ExecutionResult::success();
 
-        if self.shared_object_path.is_some() {
-            return error::unimp("enable -f");
-        }
-        if self.remove_loaded_builtin {
-            return error::unimp("enable -d");
-        }
+		if self.shared_object_path.is_some() {
+			return error::unimp("enable -f");
+		}
+		if self.remove_loaded_builtin {
+			return error::unimp("enable -d");
+		}
 
-        if !self.names.is_empty() {
-            for name in &self.names {
-                if let Some(builtin) = context.shell.builtin_mut(name) {
-                    builtin.disabled = self.disable;
-                } else {
-                    writeln!(context.stderr(), "{name}: not a shell builtin")?;
-                    result = ExecutionResult::general_error();
-                }
-            }
-        } else {
-            let builtins: Vec<_> = context
-                .shell
-                .builtins()
-                .iter()
-                .sorted_by_key(|(name, _reg)| *name)
-                .collect();
+		if !self.names.is_empty() {
+			for name in &self.names {
+				if let Some(builtin) = context.shell.builtin_mut(name) {
+					builtin.disabled = self.disable;
+				} else {
+					writeln!(context.stderr(), "{name}: not a shell builtin")?;
+					result = ExecutionResult::general_error();
+				}
+			}
+		} else {
+			let builtins: Vec<_> = context
+				.shell
+				.builtins()
+				.iter()
+				.sorted_by_key(|(name, _reg)| *name)
+				.collect();
 
-            for (builtin_name, builtin) in builtins {
-                if self.disable {
-                    if !builtin.disabled {
-                        continue;
-                    }
-                } else if self.print_list {
-                    if builtin.disabled {
-                        continue;
-                    }
-                }
+			for (builtin_name, builtin) in builtins {
+				if self.disable {
+					if !builtin.disabled {
+						continue;
+					}
+				} else if self.print_list {
+					if builtin.disabled {
+						continue;
+					}
+				}
 
-                if self.special_only && !builtin.special_builtin {
-                    continue;
-                }
+				if self.special_only && !builtin.special_builtin {
+					continue;
+				}
 
-                let prefix = if builtin.disabled { "-n " } else { "" };
+				let prefix = if builtin.disabled { "-n " } else { "" };
 
-                writeln!(context.stdout(), "enable {prefix}{builtin_name}")?;
-            }
-        }
+				writeln!(context.stdout(), "enable {prefix}{builtin_name}")?;
+			}
+		}
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 }

--- a/crates/brush-builtins-vendored/src/eval.rs
+++ b/crates/brush-builtins-vendored/src/eval.rs
@@ -4,33 +4,33 @@ use clap::Parser;
 /// Evaluate the given string as script.
 #[derive(Parser)]
 pub(crate) struct EvalCommand {
-    /// The script to evaluate.
-    #[clap(allow_hyphen_values = true)]
-    args: Vec<String>,
+	/// The script to evaluate.
+	#[clap(allow_hyphen_values = true)]
+	args: Vec<String>,
 }
 
 impl builtins::Command for EvalCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        if !self.args.is_empty() {
-            let args_concatenated = self.args.join(" ");
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		if !self.args.is_empty() {
+			let args_concatenated = self.args.join(" ");
 
-            tracing::debug!("Applying eval to: {:?}", args_concatenated);
+			tracing::debug!("Applying eval to: {:?}", args_concatenated);
 
-            // Return the direct result of running the string; we intentionally
-            // pass through the result and honor its requested control flow. eval
-            // executes in the current environment, so all control flow (return,
-            // exit, break, continue) should propagate.
-            context
-                .shell
-                .run_string(args_concatenated, &context.params)
-                .await
-        } else {
-            Ok(ExecutionResult::success())
-        }
-    }
+			// Return the direct result of running the string; we intentionally
+			// pass through the result and honor its requested control flow. eval
+			// executes in the current environment, so all control flow (return,
+			// exit, break, continue) should propagate.
+			context
+				.shell
+				.run_string(args_concatenated, &context.params)
+				.await
+		} else {
+			Ok(ExecutionResult::success())
+		}
+	}
 }

--- a/crates/brush-builtins-vendored/src/exec.rs
+++ b/crates/brush-builtins-vendored/src/exec.rs
@@ -6,61 +6,61 @@ use brush_core::{ErrorKind, ExecutionExitCode, ExecutionResult, builtins, comman
 /// Exec the provided command.
 #[derive(Parser)]
 pub(crate) struct ExecCommand {
-    /// Pass given name as zeroth argument to command.
-    #[arg(short = 'a', value_name = "NAME")]
-    name_for_argv0: Option<String>,
+	/// Pass given name as zeroth argument to command.
+	#[arg(short = 'a', value_name = "NAME")]
+	name_for_argv0: Option<String>,
 
-    /// Exec command with an empty environment.
-    #[arg(short = 'c')]
-    empty_environment: bool,
+	/// Exec command with an empty environment.
+	#[arg(short = 'c')]
+	empty_environment: bool,
 
-    /// Exec command as a login shell.
-    #[arg(short = 'l')]
-    exec_as_login: bool,
+	/// Exec command as a login shell.
+	#[arg(short = 'l')]
+	exec_as_login: bool,
 
-    /// Command and args.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    args: Vec<String>,
+	/// Command and args.
+	#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+	args: Vec<String>,
 }
 
 impl builtins::Command for ExecCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, Self::Error> {
-        if self.args.is_empty() {
-            // When no arguments are present, then there's nothing for us to execute -- but we need
-            // to ensure that any redirections setup for this builtin get applied to the calling
-            // shell instance.
-            #[allow(clippy::needless_collect)]
-            let fds: Vec<_> = context.iter_fds().collect();
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, Self::Error> {
+		if self.args.is_empty() {
+			// When no arguments are present, then there's nothing for us to execute -- but we need
+			// to ensure that any redirections setup for this builtin get applied to the calling
+			// shell instance.
+			#[allow(clippy::needless_collect)]
+			let fds: Vec<_> = context.iter_fds().collect();
 
-            context.shell.replace_open_files(fds.into_iter());
-            return Ok(ExecutionResult::success());
-        }
+			context.shell.replace_open_files(fds.into_iter());
+			return Ok(ExecutionResult::success());
+		}
 
-        let mut argv0 = Cow::Borrowed(self.name_for_argv0.as_ref().unwrap_or(&self.args[0]));
+		let mut argv0 = Cow::Borrowed(self.name_for_argv0.as_ref().unwrap_or(&self.args[0]));
 
-        if self.exec_as_login {
-            argv0 = Cow::Owned(std::format!("-{argv0}"));
-        }
+		if self.exec_as_login {
+			argv0 = Cow::Owned(std::format!("-{argv0}"));
+		}
 
-        let mut cmd = commands::compose_std_command(
-            &context,
-            &self.args[0],
-            argv0.as_str(),
-            &self.args[1..],
-            self.empty_environment,
-        )?;
+		let mut cmd = commands::compose_std_command(
+			&context,
+			&self.args[0],
+			argv0.as_str(),
+			&self.args[1..],
+			self.empty_environment,
+		)?;
 
-        let exec_error = cmd.exec();
+		let exec_error = cmd.exec();
 
-        if exec_error.kind() == std::io::ErrorKind::NotFound {
-            Ok(ExecutionExitCode::NotFound.into())
-        } else {
-            Err(ErrorKind::from(exec_error).into())
-        }
-    }
+		if exec_error.kind() == std::io::ErrorKind::NotFound {
+			Ok(ExecutionExitCode::NotFound.into())
+		} else {
+			Err(ErrorKind::from(exec_error).into())
+		}
+	}
 }

--- a/crates/brush-builtins-vendored/src/exit.rs
+++ b/crates/brush-builtins-vendored/src/exit.rs
@@ -5,27 +5,27 @@ use brush_core::{ExecutionControlFlow, ExecutionResult, builtins};
 /// Exit the shell.
 #[derive(Parser)]
 pub(crate) struct ExitCommand {
-    /// The exit code to return.
-    code: Option<i32>,
+	/// The exit code to return.
+	code: Option<i32>,
 }
 
 impl builtins::Command for ExitCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        #[expect(clippy::cast_sign_loss)]
-        let code_8bit = if let Some(code_32bit) = &self.code {
-            (code_32bit & 0xFF) as u8
-        } else {
-            context.shell.last_result()
-        };
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		#[expect(clippy::cast_sign_loss)]
+		let code_8bit = if let Some(code_32bit) = &self.code {
+			(code_32bit & 0xFF) as u8
+		} else {
+			context.shell.last_result()
+		};
 
-        let mut result = ExecutionResult::new(code_8bit);
-        result.next_control_flow = ExecutionControlFlow::ExitShell;
+		let mut result = ExecutionResult::new(code_8bit);
+		result.next_control_flow = ExecutionControlFlow::ExitShell;
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 }

--- a/crates/brush-builtins-vendored/src/export.rs
+++ b/crates/brush-builtins-vendored/src/export.rs
@@ -3,155 +3,155 @@ use itertools::Itertools;
 use std::io::Write;
 
 use brush_core::{
-    ExecutionExitCode, ExecutionResult, builtins,
-    env::{EnvironmentLookup, EnvironmentScope},
-    variables,
+	ExecutionExitCode, ExecutionResult, builtins,
+	env::{EnvironmentLookup, EnvironmentScope},
+	variables,
 };
 
 /// Add or update exported shell variables.
 #[derive(Parser)]
 pub(crate) struct ExportCommand {
-    /// Names are treated as function names.
-    #[arg(short = 'f')]
-    names_are_functions: bool,
+	/// Names are treated as function names.
+	#[arg(short = 'f')]
+	names_are_functions: bool,
 
-    /// Un-export the names.
-    #[arg(short = 'n')]
-    unexport: bool,
+	/// Un-export the names.
+	#[arg(short = 'n')]
+	unexport: bool,
 
-    /// Display all exported names.
-    #[arg(short = 'p')]
-    display_exported_names: bool,
+	/// Display all exported names.
+	#[arg(short = 'p')]
+	display_exported_names: bool,
 
-    //
-    // Declarations
-    //
-    // N.B. These are skipped by clap, but filled in by the BuiltinDeclarationCommand trait.
-    #[clap(skip)]
-    declarations: Vec<brush_core::CommandArg>,
+	//
+	// Declarations
+	//
+	// N.B. These are skipped by clap, but filled in by the BuiltinDeclarationCommand trait.
+	#[clap(skip)]
+	declarations: Vec<brush_core::CommandArg>,
 }
 
 impl builtins::DeclarationCommand for ExportCommand {
-    fn set_declarations(&mut self, declarations: Vec<brush_core::CommandArg>) {
-        self.declarations = declarations;
-    }
+	fn set_declarations(&mut self, declarations: Vec<brush_core::CommandArg>) {
+		self.declarations = declarations;
+	}
 }
 
 impl builtins::Command for ExportCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        mut context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        if self.declarations.is_empty() {
-            display_all_exported_vars(&context)?;
-            return Ok(ExecutionResult::success());
-        }
+	async fn execute(
+		&self,
+		mut context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		if self.declarations.is_empty() {
+			display_all_exported_vars(&context)?;
+			return Ok(ExecutionResult::success());
+		}
 
-        let mut result = ExecutionResult::success();
-        for decl in &self.declarations {
-            let current_result = self.process_decl(&mut context, decl)?;
-            if !current_result.is_success() {
-                result = current_result;
-            }
-        }
+		let mut result = ExecutionResult::success();
+		for decl in &self.declarations {
+			let current_result = self.process_decl(&mut context, decl)?;
+			if !current_result.is_success() {
+				result = current_result;
+			}
+		}
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 }
 
 impl ExportCommand {
-    fn process_decl(
-        &self,
-        context: &mut brush_core::ExecutionContext<'_>,
-        decl: &brush_core::CommandArg,
-    ) -> Result<ExecutionResult, brush_core::Error> {
-        match decl {
-            brush_core::CommandArg::String(s) => {
-                // See if this is supposed to be a function name.
-                if self.names_are_functions {
-                    // Try to find the function already present; if we find it, then mark it
-                    // exported.
-                    if let Some(func) = context.shell.func_mut(s) {
-                        if self.unexport {
-                            func.unexport();
-                        } else {
-                            func.export();
-                        }
-                    } else {
-                        writeln!(context.stderr(), "{s}: not a function")?;
-                        return Ok(ExecutionExitCode::InvalidUsage.into());
-                    }
-                }
-                // Try to find the variable already present; if we find it, then mark it
-                // exported.
-                else if let Some((_, variable)) = context.shell.env.get_mut(s) {
-                    if self.unexport {
-                        variable.unexport();
-                    } else {
-                        variable.export();
-                    }
-                }
-            }
-            brush_core::CommandArg::Assignment(assignment) => {
-                let name = match &assignment.name {
-                    brush_parser::ast::AssignmentName::VariableName(name) => name,
-                    brush_parser::ast::AssignmentName::ArrayElementName(_, _) => {
-                        writeln!(context.stderr(), "not a valid variable name")?;
-                        return Ok(ExecutionExitCode::InvalidUsage.into());
-                    }
-                };
+	fn process_decl(
+		&self,
+		context: &mut brush_core::ExecutionContext<'_>,
+		decl: &brush_core::CommandArg,
+	) -> Result<ExecutionResult, brush_core::Error> {
+		match decl {
+			brush_core::CommandArg::String(s) => {
+				// See if this is supposed to be a function name.
+				if self.names_are_functions {
+					// Try to find the function already present; if we find it, then mark it
+					// exported.
+					if let Some(func) = context.shell.func_mut(s) {
+						if self.unexport {
+							func.unexport();
+						} else {
+							func.export();
+						}
+					} else {
+						writeln!(context.stderr(), "{s}: not a function")?;
+						return Ok(ExecutionExitCode::InvalidUsage.into());
+					}
+				}
+				// Try to find the variable already present; if we find it, then mark it
+				// exported.
+				else if let Some((_, variable)) = context.shell.env.get_mut(s) {
+					if self.unexport {
+						variable.unexport();
+					} else {
+						variable.export();
+					}
+				}
+			},
+			brush_core::CommandArg::Assignment(assignment) => {
+				let name = match &assignment.name {
+					brush_parser::ast::AssignmentName::VariableName(name) => name,
+					brush_parser::ast::AssignmentName::ArrayElementName(_, _) => {
+						writeln!(context.stderr(), "not a valid variable name")?;
+						return Ok(ExecutionExitCode::InvalidUsage.into());
+					},
+				};
 
-                let value = match &assignment.value {
-                    brush_parser::ast::AssignmentValue::Scalar(s) => {
-                        variables::ShellValueLiteral::Scalar(s.flatten())
-                    }
-                    brush_parser::ast::AssignmentValue::Array(a) => {
-                        variables::ShellValueLiteral::Array(variables::ArrayLiteral(
-                            a.iter()
-                                .map(|(k, v)| (k.as_ref().map(|k| k.flatten()), v.flatten()))
-                                .collect(),
-                        ))
-                    }
-                };
+				let value = match &assignment.value {
+					brush_parser::ast::AssignmentValue::Scalar(s) => {
+						variables::ShellValueLiteral::Scalar(s.flatten())
+					},
+					brush_parser::ast::AssignmentValue::Array(a) => {
+						variables::ShellValueLiteral::Array(variables::ArrayLiteral(
+							a.iter()
+								.map(|(k, v)| (k.as_ref().map(|k| k.flatten()), v.flatten()))
+								.collect(),
+						))
+					},
+				};
 
-                // Update the variable with the provided value and then mark it exported.
-                context.shell.env.update_or_add(
-                    name,
-                    value,
-                    |var| {
-                        if self.unexport {
-                            var.unexport();
-                        } else {
-                            var.export();
-                        }
-                        Ok(())
-                    },
-                    EnvironmentLookup::Anywhere,
-                    EnvironmentScope::Global,
-                )?;
-            }
-        }
+				// Update the variable with the provided value and then mark it exported.
+				context.shell.env.update_or_add(
+					name,
+					value,
+					|var| {
+						if self.unexport {
+							var.unexport();
+						} else {
+							var.export();
+						}
+						Ok(())
+					},
+					EnvironmentLookup::Anywhere,
+					EnvironmentScope::Global,
+				)?;
+			},
+		}
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }
 
 fn display_all_exported_vars(
-    context: &brush_core::ExecutionContext<'_>,
+	context: &brush_core::ExecutionContext<'_>,
 ) -> Result<(), brush_core::Error> {
-    // Enumerate variables, sorted by key.
-    for (name, variable) in context.shell.env.iter().sorted_by_key(|v| v.0) {
-        if variable.is_exported() {
-            let value = variable.value().try_get_cow_str(context.shell);
-            if let Some(value) = value {
-                writeln!(context.stdout(), "declare -x {name}=\"{value}\"")?;
-            } else {
-                writeln!(context.stdout(), "declare -x {name}")?;
-            }
-        }
-    }
+	// Enumerate variables, sorted by key.
+	for (name, variable) in context.shell.env.iter().sorted_by_key(|v| v.0) {
+		if variable.is_exported() {
+			let value = variable.value().try_get_cow_str(context.shell);
+			if let Some(value) = value {
+				writeln!(context.stdout(), "declare -x {name}=\"{value}\"")?;
+			} else {
+				writeln!(context.stdout(), "declare -x {name}")?;
+			}
+		}
+	}
 
-    Ok(())
+	Ok(())
 }

--- a/crates/brush-builtins-vendored/src/false_.rs
+++ b/crates/brush-builtins-vendored/src/false_.rs
@@ -7,12 +7,12 @@ use brush_core::{ExecutionResult, builtins};
 pub(crate) struct FalseCommand {}
 
 impl builtins::Command for FalseCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        _context: brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, Self::Error> {
-        Ok(ExecutionResult::general_error())
-    }
+	async fn execute(
+		&self,
+		_context: brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, Self::Error> {
+		Ok(ExecutionResult::general_error())
+	}
 }

--- a/crates/brush-builtins-vendored/src/fc.rs
+++ b/crates/brush-builtins-vendored/src/fc.rs
@@ -5,295 +5,286 @@ use std::io::Write;
 /// Process command history list.
 #[derive(Parser)]
 pub(crate) struct FcCommand {
-    /// List commands instead of editing them.
-    #[arg(short = 'l')]
-    list: bool,
+	/// List commands instead of editing them.
+	#[arg(short = 'l')]
+	list: bool,
 
-    /// Suppress line numbers when listing.
-    #[arg(short = 'n', requires = "list")]
-    no_line_numbers: bool,
+	/// Suppress line numbers when listing.
+	#[arg(short = 'n', requires = "list")]
+	no_line_numbers: bool,
 
-    /// Reverse the order of commands.
-    #[arg(short = 'r')]
-    reverse: bool,
+	/// Reverse the order of commands.
+	#[arg(short = 'r')]
+	reverse: bool,
 
-    /// Re-execute command after substitution (old=new format).
-    #[arg(short = 's')]
-    substitute: bool,
+	/// Re-execute command after substitution (old=new format).
+	#[arg(short = 's')]
+	substitute: bool,
 
-    /// Editor to use (only relevant when not listing or substituting).
-    #[arg(short = 'e', value_name = "ENAME")]
-    editor: Option<String>,
+	/// Editor to use (only relevant when not listing or substituting).
+	#[arg(short = 'e', value_name = "ENAME")]
+	editor: Option<String>,
 
-    /// First command in range (number or string prefix).
-    #[arg(value_name = "FIRST", allow_hyphen_values = true)]
-    first: Option<String>,
+	/// First command in range (number or string prefix).
+	#[arg(value_name = "FIRST", allow_hyphen_values = true)]
+	first: Option<String>,
 
-    /// Last command in range (number or string prefix).
-    #[arg(value_name = "LAST", allow_hyphen_values = true)]
-    last: Option<String>,
+	/// Last command in range (number or string prefix).
+	#[arg(value_name = "LAST", allow_hyphen_values = true)]
+	last: Option<String>,
 }
 
 impl builtins::Command for FcCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, Self::Error> {
-        if self.substitute {
-            return self.do_execute(context).await;
-        }
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, Self::Error> {
+		if self.substitute {
+			return self.do_execute(context).await;
+		}
 
-        if self.list {
-            return self.do_list(&context);
-        }
+		if self.list {
+			return self.do_list(&context);
+		}
 
-        error::unimp("fc editor mode is not yet implemented")
-    }
+		error::unimp("fc editor mode is not yet implemented")
+	}
 }
 
 impl FcCommand {
-    fn do_list(
-        &self,
-        context: &brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, brush_core::Error> {
-        let history = context
-            .shell
-            .history()
-            .ok_or_else(|| brush_core::Error::from(brush_core::ErrorKind::HistoryNotEnabled))?;
+	fn do_list(
+		&self,
+		context: &brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, brush_core::Error> {
+		let history = context
+			.shell
+			.history()
+			.ok_or_else(|| brush_core::Error::from(brush_core::ErrorKind::HistoryNotEnabled))?;
 
-        let (first_idx, last_idx, reverse) = self.resolve_range(history)?;
+		let (first_idx, last_idx, reverse) = self.resolve_range(history)?;
 
-        // Determine the order of iteration
-        let indices: Vec<usize> = if reverse {
-            (first_idx..=last_idx).rev().collect()
-        } else {
-            (first_idx..=last_idx).collect()
-        };
+		// Determine the order of iteration
+		let indices: Vec<usize> = if reverse {
+			(first_idx..=last_idx).rev().collect()
+		} else {
+			(first_idx..=last_idx).collect()
+		};
 
-        for idx in indices {
-            if let Some(item) = history.get(idx) {
-                if self.no_line_numbers {
-                    // With -n, bash still outputs a tab before the command
-                    writeln!(context.stdout(), "\t {}", item.command_line)?;
-                } else {
-                    // Match bash's fc format: number, tab, command
-                    writeln!(context.stdout(), "{}\t {}", idx + 1, item.command_line)?;
-                }
-            }
-        }
+		for idx in indices {
+			if let Some(item) = history.get(idx) {
+				if self.no_line_numbers {
+					// With -n, bash still outputs a tab before the command
+					writeln!(context.stdout(), "\t {}", item.command_line)?;
+				} else {
+					// Match bash's fc format: number, tab, command
+					writeln!(context.stdout(), "{}\t {}", idx + 1, item.command_line)?;
+				}
+			}
+		}
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 
-    async fn do_execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, brush_core::Error> {
-        let history = context
-            .shell
-            .history()
-            .ok_or_else(|| brush_core::Error::from(brush_core::ErrorKind::HistoryNotEnabled))?;
+	async fn do_execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, brush_core::Error> {
+		let history = context
+			.shell
+			.history()
+			.ok_or_else(|| brush_core::Error::from(brush_core::ErrorKind::HistoryNotEnabled))?;
 
-        // Parse the first argument for pattern=replacement
-        let (pattern, replacement) = self
-            .first
-            .as_ref()
-            .and_then(|s| s.split_once('='))
-            .map_or((None, None), |(p, r)| (Some(p), Some(r)));
+		// Parse the first argument for pattern=replacement
+		let (pattern, replacement) = self
+			.first
+			.as_ref()
+			.and_then(|s| s.split_once('='))
+			.map_or((None, None), |(p, r)| (Some(p), Some(r)));
 
-        // Determine which command to re-execute
-        let cmd_spec = if pattern.is_some() {
-            // If we have a pattern, the command spec is in 'last' if present
-            self.last.as_deref()
-        } else {
-            // Otherwise, it's in 'first'
-            self.first.as_deref()
-        };
+		// Determine which command to re-execute
+		let cmd_spec = if pattern.is_some() {
+			// If we have a pattern, the command spec is in 'last' if present
+			self.last.as_deref()
+		} else {
+			// Otherwise, it's in 'first'
+			self.first.as_deref()
+		};
 
-        // Find the command
-        let cmd_line = if let Some(spec) = cmd_spec {
-            Self::find_command_by_specifier(history, spec)?
-        } else {
-            // No spec means use the previous command (excluding the fc command itself)
-            let effective_count = effective_history_count(history);
-            history
-                .get(effective_count.saturating_sub(1))
-                .map(|item| item.command_line.clone())
-                .ok_or_else(|| brush_core::Error::from(error::ErrorKind::HistoryItemNotFound))?
-        };
+		// Find the command
+		let cmd_line = if let Some(spec) = cmd_spec {
+			Self::find_command_by_specifier(history, spec)?
+		} else {
+			// No spec means use the previous command (excluding the fc command itself)
+			let effective_count = effective_history_count(history);
+			history
+				.get(effective_count.saturating_sub(1))
+				.map(|item| item.command_line.clone())
+				.ok_or_else(|| brush_core::Error::from(error::ErrorKind::HistoryItemNotFound))?
+		};
 
-        // Apply substitution if present
-        let final_cmd = if let (Some(pat), Some(rep)) = (pattern, replacement) {
-            cmd_line.replace(pat, rep)
-        } else {
-            cmd_line
-        };
+		// Apply substitution if present
+		let final_cmd = if let (Some(pat), Some(rep)) = (pattern, replacement) {
+			cmd_line.replace(pat, rep)
+		} else {
+			cmd_line
+		};
 
-        // Echo the command to stderr.
-        writeln!(context.stderr(), "{final_cmd}")?;
+		// Echo the command to stderr.
+		writeln!(context.stderr(), "{final_cmd}")?;
 
-        // Remove the fc command from history before executing the substituted command
-        // This matches bash behavior where the fc command is replaced by the executed command
-        let history_mut = context
-            .shell
-            .history_mut()
-            .ok_or_else(|| brush_core::Error::from(brush_core::ErrorKind::HistoryNotEnabled))?;
-        history_mut.remove_nth_item(history_mut.count().saturating_sub(1));
+		// Remove the fc command from history before executing the substituted command
+		// This matches bash behavior where the fc command is replaced by the executed command
+		let history_mut = context
+			.shell
+			.history_mut()
+			.ok_or_else(|| brush_core::Error::from(brush_core::ErrorKind::HistoryNotEnabled))?;
+		history_mut.remove_nth_item(history_mut.count().saturating_sub(1));
 
-        // Execute the command
-        let result = context
-            .shell
-            .run_string(final_cmd.clone(), &context.params)
-            .await?;
+		// Execute the command
+		let result = context
+			.shell
+			.run_string(final_cmd.clone(), &context.params)
+			.await?;
 
-        // Add the executed command to history.
-        context.shell.add_to_history(&final_cmd)?;
+		// Add the executed command to history.
+		context.shell.add_to_history(&final_cmd)?;
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 
-    fn resolve_range(
-        &self,
-        history: &history::History,
-    ) -> Result<(usize, usize, bool), brush_core::Error> {
-        let effective_count = effective_history_count(history);
-        let max_idx = effective_count.saturating_sub(1);
+	fn resolve_range(
+		&self,
+		history: &history::History,
+	) -> Result<(usize, usize, bool), brush_core::Error> {
+		let effective_count = effective_history_count(history);
+		let max_idx = effective_count.saturating_sub(1);
 
-        // Resolve first index
-        let first_idx = self
-            .first
-            .as_ref()
-            .map(|s| Self::resolve_position(history, s))
-            .transpose()?
-            .unwrap_or_else(|| {
-                if self.list {
-                    effective_count.saturating_sub(16) // Default for listing: -16
-                } else {
-                    max_idx // Default for editing: previous command
-                }
-            });
+		// Resolve first index
+		let first_idx = self
+			.first
+			.as_ref()
+			.map(|s| Self::resolve_position(history, s))
+			.transpose()?
+			.unwrap_or_else(|| {
+				if self.list {
+					effective_count.saturating_sub(16) // Default for listing: -16
+				} else {
+					max_idx // Default for editing: previous command
+				}
+			});
 
-        // Resolve last index (default depends on mode and first_idx)
-        let default_last = if self.list { max_idx } else { first_idx };
-        let last_idx = self
-            .last
-            .as_ref()
-            .map(|s| Self::resolve_position(history, s))
-            .transpose()?
-            .unwrap_or(default_last);
+		// Resolve last index (default depends on mode and first_idx)
+		let default_last = if self.list { max_idx } else { first_idx };
+		let last_idx = self
+			.last
+			.as_ref()
+			.map(|s| Self::resolve_position(history, s))
+			.transpose()?
+			.unwrap_or(default_last);
 
-        // If first > last, swap them and indicate reversal
-        let (first_idx, last_idx, force_reverse) = if first_idx > last_idx {
-            (last_idx, first_idx, true)
-        } else {
-            (first_idx, last_idx, false)
-        };
+		// If first > last, swap them and indicate reversal
+		let (first_idx, last_idx, force_reverse) = if first_idx > last_idx {
+			(last_idx, first_idx, true)
+		} else {
+			(first_idx, last_idx, false)
+		};
 
-        // Clamp both indices to valid range
-        Ok((
-            first_idx.min(max_idx),
-            last_idx.min(max_idx),
-            force_reverse || self.reverse,
-        ))
-    }
+		// Clamp both indices to valid range
+		Ok((first_idx.min(max_idx), last_idx.min(max_idx), force_reverse || self.reverse))
+	}
 
-    /// Resolves a position specifier (number or string prefix) to a history index.
-    /// NOTE: The returned index may still be out of range if the history is empty.
-    ///
-    /// # Arguments
-    ///
-    /// * `history` - The history to resolve against.
-    /// * `spec` - The position specifier (number or string prefix).
-    fn resolve_position(
-        history: &history::History,
-        spec: &str,
-    ) -> Result<usize, brush_core::Error> {
-        // Try to parse it as a number. If it's not parseable, then we need to assume
-        // it's a string prefix we need to search for.
-        let Ok(num) = spec.parse::<i64>() else {
-            // Not a number, treat as string prefix
-            return Self::find_command_by_prefix(history, spec);
-        };
+	/// Resolves a position specifier (number or string prefix) to a history index.
+	/// NOTE: The returned index may still be out of range if the history is empty.
+	///
+	/// # Arguments
+	///
+	/// * `history` - The history to resolve against.
+	/// * `spec` - The position specifier (number or string prefix).
+	fn resolve_position(history: &history::History, spec: &str) -> Result<usize, brush_core::Error> {
+		// Try to parse it as a number. If it's not parseable, then we need to assume
+		// it's a string prefix we need to search for.
+		let Ok(num) = spec.parse::<i64>() else {
+			// Not a number, treat as string prefix
+			return Self::find_command_by_prefix(history, spec);
+		};
 
-        let effective_count = effective_history_count(history);
+		let effective_count = effective_history_count(history);
 
-        #[expect(clippy::cast_sign_loss)]
-        #[expect(clippy::cast_possible_truncation)]
-        let result = match num.cmp(&0) {
-            std::cmp::Ordering::Equal => {
-                // 0 means -1 for listing (relative to effective count)
-                effective_count.saturating_sub(1)
-            }
-            std::cmp::Ordering::Greater => {
-                // Positive: 1-based index
-                let idx = (num - 1) as usize;
-                if idx < effective_count {
-                    idx
-                } else {
-                    // Out of range - use 0 (first item)
-                    0
-                }
-            }
-            std::cmp::Ordering::Less => {
-                // Negative: offset from end (relative to effective count)
-                let offset = (-num) as usize;
-                effective_count.saturating_sub(offset)
-            }
-        };
+		#[expect(clippy::cast_sign_loss)]
+		#[expect(clippy::cast_possible_truncation)]
+		let result = match num.cmp(&0) {
+			std::cmp::Ordering::Equal => {
+				// 0 means -1 for listing (relative to effective count)
+				effective_count.saturating_sub(1)
+			},
+			std::cmp::Ordering::Greater => {
+				// Positive: 1-based index
+				let idx = (num - 1) as usize;
+				if idx < effective_count {
+					idx
+				} else {
+					// Out of range - use 0 (first item)
+					0
+				}
+			},
+			std::cmp::Ordering::Less => {
+				// Negative: offset from end (relative to effective count)
+				let offset = (-num) as usize;
+				effective_count.saturating_sub(offset)
+			},
+		};
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 
-    /// Finds the command matching the given specifier (number or string prefix). Returns
-    /// the command line. Returns an error if no such command can be found in the history.
-    ///
-    /// # Arguments
-    ///
-    /// * `history` - The history to search.
-    /// * `spec` - The position spec
-    fn find_command_by_specifier(
-        history: &history::History,
-        spec: &str,
-    ) -> Result<String, brush_core::Error> {
-        let idx = Self::resolve_position(history, spec)?;
-        history
-            .get(idx)
-            .map(|item| item.command_line.clone())
-            .ok_or_else(|| brush_core::Error::from(error::ErrorKind::HistoryItemNotFound))
-    }
+	/// Finds the command matching the given specifier (number or string prefix). Returns
+	/// the command line. Returns an error if no such command can be found in the history.
+	///
+	/// # Arguments
+	///
+	/// * `history` - The history to search.
+	/// * `spec` - The position spec
+	fn find_command_by_specifier(
+		history: &history::History,
+		spec: &str,
+	) -> Result<String, brush_core::Error> {
+		let idx = Self::resolve_position(history, spec)?;
+		history
+			.get(idx)
+			.map(|item| item.command_line.clone())
+			.ok_or_else(|| brush_core::Error::from(error::ErrorKind::HistoryItemNotFound))
+	}
 
-    /// Finds the most recent command starting with the given prefix. Returns
-    /// the index of the command in the history. Returns an error if no such
-    /// command can be found in the history.
-    ///
-    /// # Arguments
-    ///
-    /// * `history` - The history to search.
-    /// * `prefix` - The command prefix to search for.
-    fn find_command_by_prefix(
-        history: &history::History,
-        prefix: &str,
-    ) -> Result<usize, brush_core::Error> {
-        // Search backwards for a command starting with the prefix (excluding fc command itself)
-        let effective_count = effective_history_count(history);
+	/// Finds the most recent command starting with the given prefix. Returns
+	/// the index of the command in the history. Returns an error if no such
+	/// command can be found in the history.
+	///
+	/// # Arguments
+	///
+	/// * `history` - The history to search.
+	/// * `prefix` - The command prefix to search for.
+	fn find_command_by_prefix(
+		history: &history::History,
+		prefix: &str,
+	) -> Result<usize, brush_core::Error> {
+		// Search backwards for a command starting with the prefix (excluding fc command itself)
+		let effective_count = effective_history_count(history);
 
-        for idx in (0..effective_count).rev() {
-            if let Some(item) = history.get(idx) {
-                if item.command_line.starts_with(prefix) {
-                    return Ok(idx);
-                }
-            }
-        }
+		for idx in (0..effective_count).rev() {
+			if let Some(item) = history.get(idx) {
+				if item.command_line.starts_with(prefix) {
+					return Ok(idx);
+				}
+			}
+		}
 
-        Err(brush_core::Error::from(
-            error::ErrorKind::HistoryItemNotFound,
-        ))
-    }
+		Err(brush_core::Error::from(error::ErrorKind::HistoryItemNotFound))
+	}
 }
 
 /// Returns the effective history count (excluding the fc command itself).
 fn effective_history_count(history: &history::History) -> usize {
-    history.count().saturating_sub(1)
+	history.count().saturating_sub(1)
 }

--- a/crates/brush-builtins-vendored/src/fg.rs
+++ b/crates/brush-builtins-vendored/src/fg.rs
@@ -6,65 +6,61 @@ use brush_core::{ExecutionResult, builtins, jobs, sys};
 /// Move a specified job to the foreground.
 #[derive(Parser)]
 pub(crate) struct FgCommand {
-    /// Job spec for the job to move to the foreground; if not specified, the current job is moved.
-    job_spec: Option<String>,
+	/// Job spec for the job to move to the foreground; if not specified, the current job is moved.
+	job_spec: Option<String>,
 }
 
 impl builtins::Command for FgCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        let mut stderr = context.stdout();
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		let mut stderr = context.stdout();
 
-        if let Some(job_spec) = &self.job_spec {
-            if let Some(job) = context.shell.jobs.resolve_job_spec(job_spec) {
-                job.move_to_foreground()?;
-                writeln!(stderr, "{}", job.command_line)?;
+		if let Some(job_spec) = &self.job_spec {
+			if let Some(job) = context.shell.jobs.resolve_job_spec(job_spec) {
+				job.move_to_foreground()?;
+				writeln!(stderr, "{}", job.command_line)?;
 
-                let result = job.wait().await?;
-                if context.shell.options.interactive {
-                    sys::terminal::move_self_to_foreground()?;
-                }
+				let result = job.wait().await?;
+				if context.shell.options.interactive {
+					sys::terminal::move_self_to_foreground()?;
+				}
 
-                if matches!(job.state, jobs::JobState::Stopped) {
-                    // N.B. We use the '\r' to overwrite any ^Z output.
-                    let formatted = job.to_string();
-                    writeln!(context.stderr(), "\r{formatted}")?;
-                }
+				if matches!(job.state, jobs::JobState::Stopped) {
+					// N.B. We use the '\r' to overwrite any ^Z output.
+					let formatted = job.to_string();
+					writeln!(context.stderr(), "\r{formatted}")?;
+				}
 
-                Ok(result)
-            } else {
-                writeln!(
-                    stderr,
-                    "{}: {}: no such job",
-                    job_spec, context.command_name
-                )?;
-                Ok(ExecutionResult::general_error())
-            }
-        } else {
-            if let Some(job) = context.shell.jobs.current_job_mut() {
-                job.move_to_foreground()?;
-                writeln!(stderr, "{}", job.command_line)?;
+				Ok(result)
+			} else {
+				writeln!(stderr, "{}: {}: no such job", job_spec, context.command_name)?;
+				Ok(ExecutionResult::general_error())
+			}
+		} else {
+			if let Some(job) = context.shell.jobs.current_job_mut() {
+				job.move_to_foreground()?;
+				writeln!(stderr, "{}", job.command_line)?;
 
-                let result = job.wait().await?;
-                if context.shell.options.interactive {
-                    sys::terminal::move_self_to_foreground()?;
-                }
+				let result = job.wait().await?;
+				if context.shell.options.interactive {
+					sys::terminal::move_self_to_foreground()?;
+				}
 
-                if matches!(job.state, jobs::JobState::Stopped) {
-                    // N.B. We use the '\r' to overwrite any ^Z output.
-                    let formatted = job.to_string();
-                    writeln!(context.stderr(), "\r{formatted}")?;
-                }
+				if matches!(job.state, jobs::JobState::Stopped) {
+					// N.B. We use the '\r' to overwrite any ^Z output.
+					let formatted = job.to_string();
+					writeln!(context.stderr(), "\r{formatted}")?;
+				}
 
-                Ok(result)
-            } else {
-                writeln!(stderr, "{}: no current job", context.command_name)?;
-                Ok(ExecutionResult::general_error())
-            }
-        }
-    }
+				Ok(result)
+			} else {
+				writeln!(stderr, "{}: no current job", context.command_name)?;
+				Ok(ExecutionResult::general_error())
+			}
+		}
+	}
 }

--- a/crates/brush-builtins-vendored/src/hash.rs
+++ b/crates/brush-builtins-vendored/src/hash.rs
@@ -5,97 +5,89 @@ use brush_core::{ExecutionResult, builtins};
 
 #[derive(Parser)]
 pub(crate) struct HashCommand {
-    /// Remove entries associated with the given names.
-    #[arg(short = 'd')]
-    remove: bool,
+	/// Remove entries associated with the given names.
+	#[arg(short = 'd')]
+	remove: bool,
 
-    /// Display paths in a format usable for input.
-    #[arg(short = 'l')]
-    display_as_usable_input: bool,
+	/// Display paths in a format usable for input.
+	#[arg(short = 'l')]
+	display_as_usable_input: bool,
 
-    /// The path to associate with the names.
-    #[arg(short = 'p', value_name = "PATH")]
-    path_to_use: Option<PathBuf>,
+	/// The path to associate with the names.
+	#[arg(short = 'p', value_name = "PATH")]
+	path_to_use: Option<PathBuf>,
 
-    /// Remove all entries.
-    #[arg(short = 'r')]
-    remove_all: bool,
+	/// Remove all entries.
+	#[arg(short = 'r')]
+	remove_all: bool,
 
-    /// Display the paths associated with the names.
-    #[arg(short = 't')]
-    display_paths: bool,
+	/// Display the paths associated with the names.
+	#[arg(short = 't')]
+	display_paths: bool,
 
-    /// Names to process.
-    names: Vec<String>,
+	/// Names to process.
+	names: Vec<String>,
 }
 
 impl builtins::Command for HashCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        let mut result = ExecutionResult::success();
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		let mut result = ExecutionResult::success();
 
-        if self.remove_all {
-            context.shell.program_location_cache.reset();
-        } else if self.remove {
-            for name in &self.names {
-                if !context.shell.program_location_cache.unset(name) {
-                    writeln!(context.stderr(), "{name}: not found")?;
-                    result = ExecutionResult::general_error();
-                }
-            }
-        } else if self.display_paths {
-            for name in &self.names {
-                if let Some(path) = context.shell.program_location_cache.get(name) {
-                    if self.display_as_usable_input {
-                        writeln!(
-                            context.stdout(),
-                            "builtin hash -p {} {name}",
-                            path.to_string_lossy()
-                        )?;
-                    } else {
-                        let mut prefix = String::new();
+		if self.remove_all {
+			context.shell.program_location_cache.reset();
+		} else if self.remove {
+			for name in &self.names {
+				if !context.shell.program_location_cache.unset(name) {
+					writeln!(context.stderr(), "{name}: not found")?;
+					result = ExecutionResult::general_error();
+				}
+			}
+		} else if self.display_paths {
+			for name in &self.names {
+				if let Some(path) = context.shell.program_location_cache.get(name) {
+					if self.display_as_usable_input {
+						writeln!(context.stdout(), "builtin hash -p {} {name}", path.to_string_lossy())?;
+					} else {
+						let mut prefix = String::new();
 
-                        if self.names.len() > 1 {
-                            prefix.push_str(name.as_str());
-                            prefix.push('\t');
-                        }
+						if self.names.len() > 1 {
+							prefix.push_str(name.as_str());
+							prefix.push('\t');
+						}
 
-                        writeln!(
-                            context.stdout(),
-                            "{prefix}{}",
-                            path.to_string_lossy().as_ref()
-                        )?;
-                    }
-                } else {
-                    writeln!(context.stderr(), "{name}: not found")?;
-                    result = ExecutionResult::general_error();
-                }
-            }
-        } else if let Some(path) = &self.path_to_use {
-            for name in &self.names {
-                context.shell.program_location_cache.set(name, path.clone());
-            }
-        } else {
-            for name in &self.names {
-                // Remove from the cache if already hashed.
-                let _ = context.shell.program_location_cache.unset(name);
+						writeln!(context.stdout(), "{prefix}{}", path.to_string_lossy().as_ref())?;
+					}
+				} else {
+					writeln!(context.stderr(), "{name}: not found")?;
+					result = ExecutionResult::general_error();
+				}
+			}
+		} else if let Some(path) = &self.path_to_use {
+			for name in &self.names {
+				context.shell.program_location_cache.set(name, path.clone());
+			}
+		} else {
+			for name in &self.names {
+				// Remove from the cache if already hashed.
+				let _ = context.shell.program_location_cache.unset(name);
 
-                // Hash the path.
-                if context
-                    .shell
-                    .find_first_executable_in_path_using_cache(name)
-                    .is_none()
-                {
-                    writeln!(context.stderr(), "{name}: not found")?;
-                    result = ExecutionResult::general_error();
-                }
-            }
-        }
+				// Hash the path.
+				if context
+					.shell
+					.find_first_executable_in_path_using_cache(name)
+					.is_none()
+				{
+					writeln!(context.stderr(), "{name}: not found")?;
+					result = ExecutionResult::general_error();
+				}
+			}
+		}
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 }

--- a/crates/brush-builtins-vendored/src/help.rs
+++ b/crates/brush-builtins-vendored/src/help.rs
@@ -6,133 +6,126 @@ use std::io::Write;
 /// Display command help.
 #[derive(Parser)]
 pub(crate) struct HelpCommand {
-    /// Display a short description for the commands.
-    #[arg(short = 'd')]
-    short_description: bool,
+	/// Display a short description for the commands.
+	#[arg(short = 'd')]
+	short_description: bool,
 
-    /// Display a man-style page of documentation for the commands.
-    #[arg(short = 'm')]
-    man_page_style: bool,
+	/// Display a man-style page of documentation for the commands.
+	#[arg(short = 'm')]
+	man_page_style: bool,
 
-    /// Display a short usage summary for the commands.
-    #[arg(short = 's')]
-    short_usage: bool,
+	/// Display a short usage summary for the commands.
+	#[arg(short = 's')]
+	short_usage: bool,
 
-    /// Patterns of topics to display help for.
-    topic_patterns: Vec<String>,
+	/// Patterns of topics to display help for.
+	topic_patterns: Vec<String>,
 }
 
 impl builtins::Command for HelpCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        if self.topic_patterns.is_empty() {
-            Self::display_general_help(&context)?;
-        } else {
-            for topic_pattern in &self.topic_patterns {
-                self.display_help_for_topic_pattern(&context, topic_pattern)?;
-            }
-        }
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		if self.topic_patterns.is_empty() {
+			Self::display_general_help(&context)?;
+		} else {
+			for topic_pattern in &self.topic_patterns {
+				self.display_help_for_topic_pattern(&context, topic_pattern)?;
+			}
+		}
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }
 
 impl HelpCommand {
-    fn display_general_help(
-        context: &brush_core::ExecutionContext<'_>,
-    ) -> Result<(), brush_core::Error> {
-        const COLUMN_COUNT: usize = 3;
+	fn display_general_help(
+		context: &brush_core::ExecutionContext<'_>,
+	) -> Result<(), brush_core::Error> {
+		const COLUMN_COUNT: usize = 3;
 
-        if let Some(display_str) = context.shell.product_display_str() {
-            writeln!(context.stdout(), "{display_str}\n")?;
-        }
+		if let Some(display_str) = context.shell.product_display_str() {
+			writeln!(context.stdout(), "{display_str}\n")?;
+		}
 
-        writeln!(
-            context.stdout(),
-            "The following commands are implemented as shell built-ins:"
-        )?;
+		writeln!(context.stdout(), "The following commands are implemented as shell built-ins:")?;
 
-        let builtins = get_builtins_sorted_by_name(context);
-        let items_per_column = builtins.len().div_ceil(COLUMN_COUNT);
+		let builtins = get_builtins_sorted_by_name(context);
+		let items_per_column = builtins.len().div_ceil(COLUMN_COUNT);
 
-        for i in 0..items_per_column {
-            for j in 0..COLUMN_COUNT {
-                if let Some((name, builtin)) = builtins.get(i + j * items_per_column) {
-                    let prefix = if builtin.disabled { "*" } else { " " };
-                    write!(context.stdout(), "  {prefix}{name:<20}")?; // adjust 20 to the desired
-                    // column width
-                }
-            }
-            writeln!(context.stdout())?;
-        }
+		for i in 0..items_per_column {
+			for j in 0..COLUMN_COUNT {
+				if let Some((name, builtin)) = builtins.get(i + j * items_per_column) {
+					let prefix = if builtin.disabled { "*" } else { " " };
+					write!(context.stdout(), "  {prefix}{name:<20}")?; // adjust 20 to the desired
+					// column width
+				}
+			}
+			writeln!(context.stdout())?;
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    fn display_help_for_topic_pattern(
-        &self,
-        context: &brush_core::ExecutionContext<'_>,
-        topic_pattern: &str,
-    ) -> Result<(), brush_core::Error> {
-        let pattern = brush_core::patterns::Pattern::from(topic_pattern)
-            .set_extended_globbing(context.shell.options.extended_globbing)
-            .set_case_insensitive(context.shell.options.case_insensitive_pathname_expansion);
+	fn display_help_for_topic_pattern(
+		&self,
+		context: &brush_core::ExecutionContext<'_>,
+		topic_pattern: &str,
+	) -> Result<(), brush_core::Error> {
+		let pattern = brush_core::patterns::Pattern::from(topic_pattern)
+			.set_extended_globbing(context.shell.options.extended_globbing)
+			.set_case_insensitive(context.shell.options.case_insensitive_pathname_expansion);
 
-        let mut found_count = 0;
-        for (builtin_name, builtin_registration) in get_builtins_sorted_by_name(context) {
-            if pattern.exactly_matches(builtin_name.as_str())? {
-                self.display_help_for_builtin(
-                    context,
-                    builtin_name.as_str(),
-                    builtin_registration,
-                )?;
-                found_count += 1;
-            }
-        }
+		let mut found_count = 0;
+		for (builtin_name, builtin_registration) in get_builtins_sorted_by_name(context) {
+			if pattern.exactly_matches(builtin_name.as_str())? {
+				self.display_help_for_builtin(context, builtin_name.as_str(), builtin_registration)?;
+				found_count += 1;
+			}
+		}
 
-        if found_count == 0 {
-            writeln!(context.stderr(), "No help topics match '{topic_pattern}'")?;
-        }
+		if found_count == 0 {
+			writeln!(context.stderr(), "No help topics match '{topic_pattern}'")?;
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    fn display_help_for_builtin(
-        &self,
-        context: &brush_core::ExecutionContext<'_>,
-        name: &str,
-        registration: &builtins::Registration,
-    ) -> Result<(), brush_core::Error> {
-        let content_type = if self.short_description {
-            builtins::ContentType::ShortDescription
-        } else if self.man_page_style {
-            builtins::ContentType::ManPage
-        } else if self.short_usage {
-            builtins::ContentType::ShortUsage
-        } else {
-            builtins::ContentType::DetailedHelp
-        };
+	fn display_help_for_builtin(
+		&self,
+		context: &brush_core::ExecutionContext<'_>,
+		name: &str,
+		registration: &builtins::Registration,
+	) -> Result<(), brush_core::Error> {
+		let content_type = if self.short_description {
+			builtins::ContentType::ShortDescription
+		} else if self.man_page_style {
+			builtins::ContentType::ManPage
+		} else if self.short_usage {
+			builtins::ContentType::ShortUsage
+		} else {
+			builtins::ContentType::DetailedHelp
+		};
 
-        let content = (registration.content_func)(name, content_type)?;
+		let content = (registration.content_func)(name, content_type)?;
 
-        write!(context.stdout(), "{content}")?;
-        context.stdout().flush()?;
+		write!(context.stdout(), "{content}")?;
+		context.stdout().flush()?;
 
-        Ok(())
-    }
+		Ok(())
+	}
 }
 
 fn get_builtins_sorted_by_name<'a>(
-    context: &'a brush_core::ExecutionContext<'_>,
+	context: &'a brush_core::ExecutionContext<'_>,
 ) -> Vec<(&'a String, &'a builtins::Registration)> {
-    context
-        .shell
-        .builtins()
-        .iter()
-        .sorted_by_key(|(name, _)| *name)
-        .collect()
+	context
+		.shell
+		.builtins()
+		.iter()
+		.sorted_by_key(|(name, _)| *name)
+		.collect()
 }

--- a/crates/brush-builtins-vendored/src/history.rs
+++ b/crates/brush-builtins-vendored/src/history.rs
@@ -7,240 +7,233 @@ use std::{io::Write, path::PathBuf};
 #[derive(Parser)]
 #[expect(clippy::option_option)]
 pub(crate) struct HistoryCommand {
-    /// Clears all history.
-    #[arg(short = 'c')]
-    clear_history: bool,
+	/// Clears all history.
+	#[arg(short = 'c')]
+	clear_history: bool,
 
-    /// Deletes the history entry at the given offset. Positive offsets are relative to the
-    /// beginning of the history, while negative offsets are relative to the end of the history.
-    #[arg(short = 'd', value_name = "OFFSET")]
-    delete_offset: Option<i64>,
+	/// Deletes the history entry at the given offset. Positive offsets are relative to the
+	/// beginning of the history, while negative offsets are relative to the end of the history.
+	#[arg(short = 'd', value_name = "OFFSET")]
+	delete_offset: Option<i64>,
 
-    /// Appends the history from the current session to the history file.
-    #[arg(short = 'a', group = "anrw", num_args = 0..=1, value_name = "HIST_FILE")]
-    append_session_to_file: Option<Option<String>>,
+	/// Appends the history from the current session to the history file.
+	#[arg(short = 'a', group = "anrw", num_args = 0..=1, value_name = "HIST_FILE")]
+	append_session_to_file: Option<Option<String>>,
 
-    /// Appends any remaining history from the history file to the current session.
-    #[arg(short = 'n', group = "anrw", num_args = 0..=1, value_name = "HIST_FILE")]
-    append_rest_of_file_to_session: Option<Option<String>>,
+	/// Appends any remaining history from the history file to the current session.
+	#[arg(short = 'n', group = "anrw", num_args = 0..=1, value_name = "HIST_FILE")]
+	append_rest_of_file_to_session: Option<Option<String>>,
 
-    /// Appends the history from the history file to the current session.
-    #[arg(short = 'r', group = "anrw", num_args = 0..=1, value_name = "HIST_FILE")]
-    append_file_to_session: Option<Option<String>>,
+	/// Appends the history from the history file to the current session.
+	#[arg(short = 'r', group = "anrw", num_args = 0..=1, value_name = "HIST_FILE")]
+	append_file_to_session: Option<Option<String>>,
 
-    /// Replaces the history file with the current session history.
-    #[arg(short = 'w', group = "anrw", num_args = 0..=1, value_name = "HIST_FILE")]
-    write_session_to_file: Option<Option<String>>,
+	/// Replaces the history file with the current session history.
+	#[arg(short = 'w', group = "anrw", num_args = 0..=1, value_name = "HIST_FILE")]
+	write_session_to_file: Option<Option<String>>,
 
-    /// History-expands positional arguments and displays them.
-    #[arg(short = 'p', num_args = 0.., value_name = "ARG")]
-    expand_args: Option<Vec<String>>,
+	/// History-expands positional arguments and displays them.
+	#[arg(short = 'p', num_args = 0.., value_name = "ARG")]
+	expand_args: Option<Vec<String>>,
 
-    /// Appends positional arguments as an entry in the current session.
-    #[arg(short = 's', num_args = 0.., value_name = "ARG")]
-    append_args_to_session: Option<Vec<String>>,
+	/// Appends positional arguments as an entry in the current session.
+	#[arg(short = 's', num_args = 0.., value_name = "ARG")]
+	append_args_to_session: Option<Vec<String>>,
 
-    /// Arguments.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    args: Vec<String>,
+	/// Arguments.
+	#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+	args: Vec<String>,
 }
 
 struct HistoryConfig {
-    default_history_file_path: Option<PathBuf>,
-    time_format: Option<String>,
+	default_history_file_path: Option<PathBuf>,
+	time_format: Option<String>,
 }
 
 impl builtins::Command for HistoryCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, Self::Error> {
-        // Retrieve the shell's history config while we still can.
-        let config = HistoryConfig {
-            default_history_file_path: context.shell.history_file_path(),
-            time_format: context.shell.history_time_format(),
-        };
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, Self::Error> {
+		// Retrieve the shell's history config while we still can.
+		let config = HistoryConfig {
+			default_history_file_path: context.shell.history_file_path(),
+			time_format: context.shell.history_time_format(),
+		};
 
-        let stdout = context.stdout();
-        let stderr = context.stderr();
+		let stdout = context.stdout();
+		let stderr = context.stderr();
 
-        if let Some(history) = context.shell.history_mut() {
-            self.execute_with_history(history, config, stdout, stderr)
-        } else {
-            Err(brush_core::ErrorKind::HistoryNotEnabled.into())
-        }
-    }
+		if let Some(history) = context.shell.history_mut() {
+			self.execute_with_history(history, config, stdout, stderr)
+		} else {
+			Err(brush_core::ErrorKind::HistoryNotEnabled.into())
+		}
+	}
 }
 
 impl HistoryCommand {
-    #[expect(clippy::cast_possible_wrap)]
-    #[expect(clippy::cast_possible_truncation)]
-    #[expect(clippy::cast_sign_loss)]
-    fn execute_with_history(
-        &self,
-        history: &mut history::History,
-        config: HistoryConfig,
-        stdout: impl Write,
-        mut stderr: impl Write,
-    ) -> Result<ExecutionResult, brush_core::Error> {
-        if self.clear_history {
-            history.clear()?;
-        }
+	#[expect(clippy::cast_possible_wrap)]
+	#[expect(clippy::cast_possible_truncation)]
+	#[expect(clippy::cast_sign_loss)]
+	fn execute_with_history(
+		&self,
+		history: &mut history::History,
+		config: HistoryConfig,
+		stdout: impl Write,
+		mut stderr: impl Write,
+	) -> Result<ExecutionResult, brush_core::Error> {
+		if self.clear_history {
+			history.clear()?;
+		}
 
-        if let Some(offset) = self.delete_offset {
-            if offset == 0 {
-                writeln!(stderr, "cannot delete history item at offset 0")?;
-                return Ok(ExecutionExitCode::InvalidUsage.into());
-            }
+		if let Some(offset) = self.delete_offset {
+			if offset == 0 {
+				writeln!(stderr, "cannot delete history item at offset 0")?;
+				return Ok(ExecutionExitCode::InvalidUsage.into());
+			}
 
-            if offset > 0 {
-                // Convert to 0-based index.
-                let index = (offset - 1) as usize;
-                if !history.remove_nth_item(index) {
-                    writeln!(stderr, "index past end of history")?;
-                    return Ok(ExecutionExitCode::InvalidUsage.into());
-                }
-            } else {
-                let count = history.count() as i64;
-                let index = count + offset;
-                if index < 0 {
-                    writeln!(stderr, "index before beginning of history")?;
-                    return Ok(ExecutionExitCode::InvalidUsage.into());
-                }
+			if offset > 0 {
+				// Convert to 0-based index.
+				let index = (offset - 1) as usize;
+				if !history.remove_nth_item(index) {
+					writeln!(stderr, "index past end of history")?;
+					return Ok(ExecutionExitCode::InvalidUsage.into());
+				}
+			} else {
+				let count = history.count() as i64;
+				let index = count + offset;
+				if index < 0 {
+					writeln!(stderr, "index before beginning of history")?;
+					return Ok(ExecutionExitCode::InvalidUsage.into());
+				}
 
-                let _ = history.remove_nth_item(index as usize);
-            }
+				let _ = history.remove_nth_item(index as usize);
+			}
 
-            return Ok(ExecutionResult::success());
-        }
+			return Ok(ExecutionResult::success());
+		}
 
-        if let Some(append_option) = &self.append_session_to_file {
-            if let Some(file_path) = get_effective_history_file_path(
-                config.default_history_file_path,
-                append_option.as_ref(),
-            ) {
-                history.flush(
-                    file_path,
-                    true,                         /*append?*/
-                    true,                         /*unsaved items only*/
-                    config.time_format.is_some(), /*write timestamps?*/
-                )?;
-            }
+		if let Some(append_option) = &self.append_session_to_file {
+			if let Some(file_path) = get_effective_history_file_path(
+				config.default_history_file_path,
+				append_option.as_ref(),
+			) {
+				history.flush(
+					file_path,
+					true,                         /*append?*/
+					true,                         /*unsaved items only*/
+					config.time_format.is_some(), /*write timestamps?*/
+				)?;
+			}
 
-            return Ok(ExecutionResult::success());
-        }
+			return Ok(ExecutionResult::success());
+		}
 
-        if self.append_rest_of_file_to_session.is_some() {
-            return error::unimp("history -n is not yet implemented");
-        }
+		if self.append_rest_of_file_to_session.is_some() {
+			return error::unimp("history -n is not yet implemented");
+		}
 
-        if self.append_file_to_session.is_some() {
-            return error::unimp("history -r is not yet implemented");
-        }
+		if self.append_file_to_session.is_some() {
+			return error::unimp("history -r is not yet implemented");
+		}
 
-        if let Some(write_option) = &self.write_session_to_file {
-            if let Some(file_path) = get_effective_history_file_path(
-                config.default_history_file_path,
-                write_option.as_ref(),
-            ) {
-                history.flush(
-                    file_path,
-                    false,                        /*append?*/
-                    false,                        /*unsaved items only?*/
-                    config.time_format.is_some(), /*write timestamps?*/
-                )?;
-            }
+		if let Some(write_option) = &self.write_session_to_file {
+			if let Some(file_path) =
+				get_effective_history_file_path(config.default_history_file_path, write_option.as_ref())
+			{
+				history.flush(
+					file_path,
+					false,                        /*append?*/
+					false,                        /*unsaved items only?*/
+					config.time_format.is_some(), /*write timestamps?*/
+				)?;
+			}
 
-            return Ok(ExecutionResult::success());
-        }
+			return Ok(ExecutionResult::success());
+		}
 
-        if self.expand_args.is_some() {
-            return error::unimp("history -p is not yet implemented");
-        }
+		if self.expand_args.is_some() {
+			return error::unimp("history -p is not yet implemented");
+		}
 
-        if let Some(args) = &self.append_args_to_session {
-            history.add(history::Item::new(args.join(" ")))?;
-            return Ok(ExecutionResult::success());
-        }
+		if let Some(args) = &self.append_args_to_session {
+			history.add(history::Item::new(args.join(" ")))?;
+			return Ok(ExecutionResult::success());
+		}
 
-        let max_entries: Option<usize> = if let Some(arg) = self.args.first() {
-            Some(arg.parse()?)
-        } else {
-            None
-        };
+		let max_entries: Option<usize> = if let Some(arg) = self.args.first() {
+			Some(arg.parse()?)
+		} else {
+			None
+		};
 
-        display_history(history, &config, max_entries, stdout, stderr)?;
+		display_history(history, &config, max_entries, stdout, stderr)?;
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }
 
 fn display_history(
-    history: &history::History,
-    config: &HistoryConfig,
-    max_entries: Option<usize>,
-    mut stdout: impl Write,
-    _stderr: impl Write,
+	history: &history::History,
+	config: &HistoryConfig,
+	max_entries: Option<usize>,
+	mut stdout: impl Write,
+	_stderr: impl Write,
 ) -> Result<(), brush_core::Error> {
-    let item_count = history.count();
-    let skip_count = item_count - max_entries.unwrap_or(item_count);
+	let item_count = history.count();
+	let skip_count = item_count - max_entries.unwrap_or(item_count);
 
-    for (i, item) in history.iter().skip(skip_count).enumerate() {
-        let mut formatted_timestamp = String::new();
+	for (i, item) in history.iter().skip(skip_count).enumerate() {
+		let mut formatted_timestamp = String::new();
 
-        if let Some(timestamp) = item.timestamp {
-            let local_timestamp = timestamp.with_timezone(&chrono::Local);
-            if let Some(time_format) = &config.time_format {
-                let fmt_items = chrono::format::StrftimeItems::new(time_format);
-                formatted_timestamp = local_timestamp.format_with_items(fmt_items).to_string();
-            }
-        }
+		if let Some(timestamp) = item.timestamp {
+			let local_timestamp = timestamp.with_timezone(&chrono::Local);
+			if let Some(time_format) = &config.time_format {
+				let fmt_items = chrono::format::StrftimeItems::new(time_format);
+				formatted_timestamp = local_timestamp.format_with_items(fmt_items).to_string();
+			}
+		}
 
-        // Output format is something like:
-        //     1  echo hello world
-        std::writeln!(
-            stdout,
-            "{:>5}  {formatted_timestamp}{}",
-            skip_count + i + 1,
-            item.command_line
-        )?;
-    }
+		// Output format is something like:
+		//     1  echo hello world
+		std::writeln!(
+			stdout,
+			"{:>5}  {formatted_timestamp}{}",
+			skip_count + i + 1,
+			item.command_line
+		)?;
+	}
 
-    Ok(())
+	Ok(())
 }
 
 fn get_effective_history_file_path(
-    default_history_file_path: Option<PathBuf>,
-    option: Option<&String>,
+	default_history_file_path: Option<PathBuf>,
+	option: Option<&String>,
 ) -> Option<PathBuf> {
-    option.map_or_else(
-        || default_history_file_path,
-        |file_path| Some(PathBuf::from(file_path)),
-    )
+	option.map_or_else(|| default_history_file_path, |file_path| Some(PathBuf::from(file_path)))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use anyhow::Result;
-    use pretty_assertions::{assert_eq, assert_matches};
+	use super::*;
+	use anyhow::Result;
+	use pretty_assertions::{assert_eq, assert_matches};
 
-    #[test]
-    fn test_parse_dash_a() -> Result<()> {
-        let cmd = HistoryCommand::try_parse_from(["history", "5"])?;
-        assert_matches!(cmd.append_session_to_file, None);
+	#[test]
+	fn test_parse_dash_a() -> Result<()> {
+		let cmd = HistoryCommand::try_parse_from(["history", "5"])?;
+		assert_matches!(cmd.append_session_to_file, None);
 
-        let cmd = HistoryCommand::try_parse_from(["history", "-a"])?;
-        assert_matches!(cmd.append_session_to_file, Some(None));
+		let cmd = HistoryCommand::try_parse_from(["history", "-a"])?;
+		assert_matches!(cmd.append_session_to_file, Some(None));
 
-        let cmd = HistoryCommand::try_parse_from(["history", "-a", "token"])?;
-        assert_eq!(
-            cmd.append_session_to_file,
-            Some(Some(String::from("token")))
-        );
+		let cmd = HistoryCommand::try_parse_from(["history", "-a", "token"])?;
+		assert_eq!(cmd.append_session_to_file, Some(Some(String::from("token"))));
 
-        Ok(())
-    }
+		Ok(())
+	}
 }

--- a/crates/brush-builtins-vendored/src/jobs.rs
+++ b/crates/brush-builtins-vendored/src/jobs.rs
@@ -6,78 +6,78 @@ use brush_core::{ExecutionResult, builtins, error, jobs};
 /// Manage jobs.
 #[derive(Parser)]
 pub(crate) struct JobsCommand {
-    /// Also show process IDs.
-    #[arg(short = 'l')]
-    also_show_pids: bool,
+	/// Also show process IDs.
+	#[arg(short = 'l')]
+	also_show_pids: bool,
 
-    /// List only jobs that have changed status since the last notification.
-    #[arg(short = 'n')]
-    list_changed_only: bool,
+	/// List only jobs that have changed status since the last notification.
+	#[arg(short = 'n')]
+	list_changed_only: bool,
 
-    /// Show only process IDs.
-    #[arg(short = 'p')]
-    show_pids_only: bool,
+	/// Show only process IDs.
+	#[arg(short = 'p')]
+	show_pids_only: bool,
 
-    /// Show only running jobs.
-    #[arg(short = 'r')]
-    running_jobs_only: bool,
+	/// Show only running jobs.
+	#[arg(short = 'r')]
+	running_jobs_only: bool,
 
-    /// Show only stopped jobs.
-    #[arg(short = 's')]
-    stopped_jobs_only: bool,
+	/// Show only stopped jobs.
+	#[arg(short = 's')]
+	stopped_jobs_only: bool,
 
-    /// Job specs to list.
-    // TODO: Add -x option
-    job_specs: Vec<String>,
+	/// Job specs to list.
+	// TODO: Add -x option
+	job_specs: Vec<String>,
 }
 
 impl builtins::Command for JobsCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        if self.also_show_pids {
-            return error::unimp("jobs -l");
-        }
-        if self.list_changed_only {
-            return error::unimp("jobs -n");
-        }
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		if self.also_show_pids {
+			return error::unimp("jobs -l");
+		}
+		if self.list_changed_only {
+			return error::unimp("jobs -n");
+		}
 
-        if self.job_specs.is_empty() {
-            for job in &context.shell.jobs.jobs {
-                self.display_job(&context, job)?;
-            }
-        } else {
-            return error::unimp("jobs with job specs");
-        }
+		if self.job_specs.is_empty() {
+			for job in &context.shell.jobs.jobs {
+				self.display_job(&context, job)?;
+			}
+		} else {
+			return error::unimp("jobs with job specs");
+		}
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }
 
 impl JobsCommand {
-    fn display_job(
-        &self,
-        context: &brush_core::ExecutionContext<'_>,
-        job: &jobs::Job,
-    ) -> Result<(), brush_core::Error> {
-        if self.running_jobs_only && !matches!(job.state, jobs::JobState::Running) {
-            return Ok(());
-        }
-        if self.stopped_jobs_only && !matches!(job.state, jobs::JobState::Stopped) {
-            return Ok(());
-        }
+	fn display_job(
+		&self,
+		context: &brush_core::ExecutionContext<'_>,
+		job: &jobs::Job,
+	) -> Result<(), brush_core::Error> {
+		if self.running_jobs_only && !matches!(job.state, jobs::JobState::Running) {
+			return Ok(());
+		}
+		if self.stopped_jobs_only && !matches!(job.state, jobs::JobState::Stopped) {
+			return Ok(());
+		}
 
-        if self.show_pids_only {
-            if let Some(pid) = job.representative_pid() {
-                writeln!(context.stdout(), "{pid}")?;
-            }
-        } else {
-            writeln!(context.stdout(), "{job}")?;
-        }
+		if self.show_pids_only {
+			if let Some(pid) = job.representative_pid() {
+				writeln!(context.stdout(), "{pid}")?;
+			}
+		} else {
+			writeln!(context.stdout(), "{job}")?;
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 }

--- a/crates/brush-builtins-vendored/src/kill.rs
+++ b/crates/brush-builtins-vendored/src/kill.rs
@@ -7,173 +7,168 @@ use brush_core::{ExecutionExitCode, ExecutionResult, builtins, sys};
 /// Signal a job or process.
 #[derive(Parser)]
 pub(crate) struct KillCommand {
-    /// Name of the signal to send.
-    #[arg(short = 's', value_name = "SIG_NAME")]
-    signal_name: Option<String>,
+	/// Name of the signal to send.
+	#[arg(short = 's', value_name = "SIG_NAME")]
+	signal_name: Option<String>,
 
-    /// Number of the signal to send.
-    #[arg(short = 'n', value_name = "SIG_NUM")]
-    signal_number: Option<usize>,
+	/// Number of the signal to send.
+	#[arg(short = 'n', value_name = "SIG_NUM")]
+	signal_number: Option<usize>,
 
-    //
-    // TODO: implement -sigspec syntax
-    /// List known signal names.
-    #[arg(short = 'l', short_alias = 'L')]
-    list_signals: bool,
+	//
+	// TODO: implement -sigspec syntax
+	/// List known signal names.
+	#[arg(short = 'l', short_alias = 'L')]
+	list_signals: bool,
 
-    // Interpretation of these depends on whether -l is present.
-    #[arg(allow_hyphen_values = true)]
-    args: Vec<String>,
+	// Interpretation of these depends on whether -l is present.
+	#[arg(allow_hyphen_values = true)]
+	args: Vec<String>,
 }
 
 impl builtins::Command for KillCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        // Default signal is SIGKILL.
-        let mut trap_signal = TrapSignal::Signal(nix::sys::signal::Signal::SIGKILL);
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		// Default signal is SIGKILL.
+		let mut trap_signal = TrapSignal::Signal(nix::sys::signal::Signal::SIGKILL);
 
-        // Try parsing the signal name (if specified).
-        if let Some(signal_name) = &self.signal_name {
-            if let Ok(parsed_trap_signal) = TrapSignal::try_from(signal_name.as_str()) {
-                trap_signal = parsed_trap_signal;
-            } else {
-                writeln!(
-                    context.stderr(),
-                    "{}: invalid signal name: {}",
-                    context.command_name,
-                    signal_name
-                )?;
-                return Ok(ExecutionExitCode::InvalidUsage.into());
-            }
-        }
+		// Try parsing the signal name (if specified).
+		if let Some(signal_name) = &self.signal_name {
+			if let Ok(parsed_trap_signal) = TrapSignal::try_from(signal_name.as_str()) {
+				trap_signal = parsed_trap_signal;
+			} else {
+				writeln!(
+					context.stderr(),
+					"{}: invalid signal name: {}",
+					context.command_name,
+					signal_name
+				)?;
+				return Ok(ExecutionExitCode::InvalidUsage.into());
+			}
+		}
 
-        // Try parsing the signal number (if specified).
-        if let Some(signal_number) = &self.signal_number {
-            #[expect(clippy::cast_possible_truncation)]
-            #[expect(clippy::cast_possible_wrap)]
-            if let Ok(parsed_trap_signal) = TrapSignal::try_from(*signal_number as i32) {
-                trap_signal = parsed_trap_signal;
-            } else {
-                writeln!(
-                    context.stderr(),
-                    "{}: invalid signal number: {}",
-                    context.command_name,
-                    signal_number
-                )?;
-                return Ok(ExecutionExitCode::InvalidUsage.into());
-            }
-        }
+		// Try parsing the signal number (if specified).
+		if let Some(signal_number) = &self.signal_number {
+			#[expect(clippy::cast_possible_truncation)]
+			#[expect(clippy::cast_possible_wrap)]
+			if let Ok(parsed_trap_signal) = TrapSignal::try_from(*signal_number as i32) {
+				trap_signal = parsed_trap_signal;
+			} else {
+				writeln!(
+					context.stderr(),
+					"{}: invalid signal number: {}",
+					context.command_name,
+					signal_number
+				)?;
+				return Ok(ExecutionExitCode::InvalidUsage.into());
+			}
+		}
 
-        // Look through the remaining args for a pid/job spec or a -sigspec style option.
-        let mut pid_or_job_spec = None;
-        for arg in &self.args {
-            // See if this is -sigspec syntax.
-            if let Some(possible_sigspec) = arg.strip_prefix("-") {
-                // See if this is -sigspec syntax.
-                if let Ok(parsed_trap_signal) = TrapSignal::try_from(possible_sigspec) {
-                    trap_signal = parsed_trap_signal;
-                } else {
-                    writeln!(
-                        context.stderr(),
-                        "{}: invalid signal name",
-                        context.command_name
-                    )?;
-                    return Ok(ExecutionExitCode::InvalidUsage.into());
-                }
-            } else if pid_or_job_spec.is_none() {
-                pid_or_job_spec = Some(arg);
-            } else {
-                writeln!(
-                    context.stderr(),
-                    "{}: too many jobs or processes specified",
-                    context.command_name
-                )?;
-                return Ok(ExecutionExitCode::InvalidUsage.into());
-            }
-        }
+		// Look through the remaining args for a pid/job spec or a -sigspec style option.
+		let mut pid_or_job_spec = None;
+		for arg in &self.args {
+			// See if this is -sigspec syntax.
+			if let Some(possible_sigspec) = arg.strip_prefix("-") {
+				// See if this is -sigspec syntax.
+				if let Ok(parsed_trap_signal) = TrapSignal::try_from(possible_sigspec) {
+					trap_signal = parsed_trap_signal;
+				} else {
+					writeln!(context.stderr(), "{}: invalid signal name", context.command_name)?;
+					return Ok(ExecutionExitCode::InvalidUsage.into());
+				}
+			} else if pid_or_job_spec.is_none() {
+				pid_or_job_spec = Some(arg);
+			} else {
+				writeln!(
+					context.stderr(),
+					"{}: too many jobs or processes specified",
+					context.command_name
+				)?;
+				return Ok(ExecutionExitCode::InvalidUsage.into());
+			}
+		}
 
-        if self.list_signals {
-            return print_signals(&context, self.args.as_ref());
-        } else {
-            if pid_or_job_spec.is_none() {
-                writeln!(context.stderr(), "{}: invalid usage", context.command_name)?;
-                return Ok(ExecutionExitCode::InvalidUsage.into());
-            }
+		if self.list_signals {
+			return print_signals(&context, self.args.as_ref());
+		} else {
+			if pid_or_job_spec.is_none() {
+				writeln!(context.stderr(), "{}: invalid usage", context.command_name)?;
+				return Ok(ExecutionExitCode::InvalidUsage.into());
+			}
 
-            let pid_or_job_spec = pid_or_job_spec.unwrap();
-            if pid_or_job_spec.starts_with('%') {
-                // It's a job spec.
-                if let Some(job) = context.shell.jobs.resolve_job_spec(pid_or_job_spec) {
-                    job.kill(trap_signal)?;
-                } else {
-                    writeln!(
-                        context.stderr(),
-                        "{}: {}: no such job",
-                        context.command_name,
-                        pid_or_job_spec
-                    )?;
-                    return Ok(ExecutionResult::general_error());
-                }
-            } else {
-                let pid = pid_or_job_spec.parse::<i32>()?;
+			let pid_or_job_spec = pid_or_job_spec.unwrap();
+			if pid_or_job_spec.starts_with('%') {
+				// It's a job spec.
+				if let Some(job) = context.shell.jobs.resolve_job_spec(pid_or_job_spec) {
+					job.kill(trap_signal)?;
+				} else {
+					writeln!(
+						context.stderr(),
+						"{}: {}: no such job",
+						context.command_name,
+						pid_or_job_spec
+					)?;
+					return Ok(ExecutionResult::general_error());
+				}
+			} else {
+				let pid = pid_or_job_spec.parse::<i32>()?;
 
-                // It's a pid.
-                sys::signal::kill_process(pid, trap_signal)?;
-            }
-        }
-        Ok(ExecutionResult::success())
-    }
+				// It's a pid.
+				sys::signal::kill_process(pid, trap_signal)?;
+			}
+		}
+		Ok(ExecutionResult::success())
+	}
 }
 
 fn print_signals(
-    context: &brush_core::ExecutionContext<'_>,
-    signals: &[String],
+	context: &brush_core::ExecutionContext<'_>,
+	signals: &[String],
 ) -> Result<ExecutionResult, brush_core::Error> {
-    let mut exit_code = ExecutionResult::success();
-    if !signals.is_empty() {
-        for s in signals {
-            // If the user gives us a code, we print the name; if they give a name, we print its
-            // code.
-            enum PrintSignal {
-                Name(&'static str),
-                Num(i32),
-            }
+	let mut exit_code = ExecutionResult::success();
+	if !signals.is_empty() {
+		for s in signals {
+			// If the user gives us a code, we print the name; if they give a name, we print its
+			// code.
+			enum PrintSignal {
+				Name(&'static str),
+				Num(i32),
+			}
 
-            let signal = if let Ok(n) = s.parse::<i32>() {
-                // bash compatibility. `SIGHUP` -> `HUP`
-                TrapSignal::try_from(n).map(|s| {
-                    PrintSignal::Name(s.as_str().strip_prefix("SIG").unwrap_or(s.as_str()))
-                })
-            } else {
-                TrapSignal::try_from(s.as_str()).map(|sig| {
-                    i32::try_from(sig).map_or(PrintSignal::Name(sig.as_str()), PrintSignal::Num)
-                })
-            };
+			let signal = if let Ok(n) = s.parse::<i32>() {
+				// bash compatibility. `SIGHUP` -> `HUP`
+				TrapSignal::try_from(n)
+					.map(|s| PrintSignal::Name(s.as_str().strip_prefix("SIG").unwrap_or(s.as_str())))
+			} else {
+				TrapSignal::try_from(s.as_str()).map(|sig| {
+					i32::try_from(sig).map_or(PrintSignal::Name(sig.as_str()), PrintSignal::Num)
+				})
+			};
 
-            match signal {
-                Ok(PrintSignal::Num(n)) => {
-                    writeln!(context.stdout(), "{n}")?;
-                }
-                Ok(PrintSignal::Name(s)) => {
-                    writeln!(context.stdout(), "{s}")?;
-                }
-                Err(e) => {
-                    writeln!(context.stderr(), "{e}")?;
-                    exit_code = ExecutionResult::general_error();
-                }
-            }
-        }
-    } else {
-        return brush_core::traps::format_signals(
-            context.stdout(),
-            TrapSignal::iterator().filter(|s| !matches!(s, TrapSignal::Exit)),
-        )
-        .map(|()| ExecutionResult::success());
-    }
+			match signal {
+				Ok(PrintSignal::Num(n)) => {
+					writeln!(context.stdout(), "{n}")?;
+				},
+				Ok(PrintSignal::Name(s)) => {
+					writeln!(context.stdout(), "{s}")?;
+				},
+				Err(e) => {
+					writeln!(context.stderr(), "{e}")?;
+					exit_code = ExecutionResult::general_error();
+				},
+			}
+		}
+	} else {
+		return brush_core::traps::format_signals(
+			context.stdout(),
+			TrapSignal::iterator().filter(|s| !matches!(s, TrapSignal::Exit)),
+		)
+		.map(|()| ExecutionResult::success());
+	}
 
-    Ok(exit_code)
+	Ok(exit_code)
 }

--- a/crates/brush-builtins-vendored/src/let_.rs
+++ b/crates/brush-builtins-vendored/src/let_.rs
@@ -6,36 +6,36 @@ use brush_core::{ExecutionExitCode, ExecutionResult, arithmetic::Evaluatable, bu
 /// Evaluate arithmetic expressions.
 #[derive(Parser)]
 pub(crate) struct LetCommand {
-    /// Arithmetic expressions to evaluate.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    exprs: Vec<String>,
+	/// Arithmetic expressions to evaluate.
+	#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+	exprs: Vec<String>,
 }
 
 impl builtins::Command for LetCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        let mut result = ExecutionExitCode::InvalidUsage.into();
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		let mut result = ExecutionExitCode::InvalidUsage.into();
 
-        if self.exprs.is_empty() {
-            writeln!(context.stderr(), "missing expression")?;
-            return Ok(result);
-        }
+		if self.exprs.is_empty() {
+			writeln!(context.stderr(), "missing expression")?;
+			return Ok(result);
+		}
 
-        for expr in &self.exprs {
-            let parsed = brush_parser::arithmetic::parse(expr.as_str())?;
-            let evaluated = parsed.eval(context.shell)?;
+		for expr in &self.exprs {
+			let parsed = brush_parser::arithmetic::parse(expr.as_str())?;
+			let evaluated = parsed.eval(context.shell)?;
 
-            if evaluated == 0 {
-                result = ExecutionResult::general_error();
-            } else {
-                result = ExecutionResult::success();
-            }
-        }
+			if evaluated == 0 {
+				result = ExecutionResult::general_error();
+			} else {
+				result = ExecutionResult::success();
+			}
+		}
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 }

--- a/crates/brush-builtins-vendored/src/lib.rs
+++ b/crates/brush-builtins-vendored/src/lib.rs
@@ -18,11 +18,7 @@ mod cd;
 mod colon;
 #[cfg(feature = "builtin.command")]
 mod command;
-#[cfg(any(
-    feature = "builtin.complete",
-    feature = "builtin.compgen",
-    feature = "builtin.compopt"
-))]
+#[cfg(any(feature = "builtin.complete", feature = "builtin.compgen", feature = "builtin.compopt"))]
 mod complete;
 #[cfg(feature = "builtin.continue")]
 mod continue_;

--- a/crates/brush-builtins-vendored/src/mapfile.rs
+++ b/crates/brush-builtins-vendored/src/mapfile.rs
@@ -7,149 +7,149 @@ use brush_core::{ErrorKind, ExecutionResult, builtins, env, error, variables};
 /// Inspect and modify key bindings and other input configuration.
 #[derive(Parser)]
 pub(crate) struct MapFileCommand {
-    /// Delimiter to use (defaults to newline).
-    #[arg(short = 'd', default_value = "\n")]
-    delimiter: String,
+	/// Delimiter to use (defaults to newline).
+	#[arg(short = 'd', default_value = "\n")]
+	delimiter: String,
 
-    /// Maximum number of entries to read (0 means no limit).
-    #[arg(short = 'n', default_value_t = 0)]
-    max_count: i64,
+	/// Maximum number of entries to read (0 means no limit).
+	#[arg(short = 'n', default_value_t = 0)]
+	max_count: i64,
 
-    /// Index into array at which to start assignment.
-    #[arg(short = 'O', default_value_t = 0)]
-    origin: i64,
+	/// Index into array at which to start assignment.
+	#[arg(short = 'O', default_value_t = 0)]
+	origin: i64,
 
-    /// Number of initial entries to skip.
-    #[arg(short = 's', default_value_t = 0, value_parser = clap::value_parser!(i64).range(0..))]
-    skip_count: i64,
+	/// Number of initial entries to skip.
+	#[arg(short = 's', default_value_t = 0, value_parser = clap::value_parser!(i64).range(0..))]
+	skip_count: i64,
 
-    /// Whether or not to remove the delimiter from each read line.
-    #[arg(short = 't')]
-    remove_delimiter: bool,
+	/// Whether or not to remove the delimiter from each read line.
+	#[arg(short = 't')]
+	remove_delimiter: bool,
 
-    /// File descriptor to read from (defaults to stdin).
-    #[arg(short = 'u', default_value_t = 0)]
-    fd: brush_core::ShellFd,
+	/// File descriptor to read from (defaults to stdin).
+	#[arg(short = 'u', default_value_t = 0)]
+	fd: brush_core::ShellFd,
 
-    /// Name of function to call for each group of lines.
-    #[arg(short = 'C')]
-    callback: Option<String>,
+	/// Name of function to call for each group of lines.
+	#[arg(short = 'C')]
+	callback: Option<String>,
 
-    /// Number of lines to pass the callback for each group.
-    #[arg(short = 'c', default_value_t = 5000, value_parser = clap::value_parser!(i64).range(1..))]
-    callback_group_size: i64,
+	/// Number of lines to pass the callback for each group.
+	#[arg(short = 'c', default_value_t = 5000, value_parser = clap::value_parser!(i64).range(1..))]
+	callback_group_size: i64,
 
-    /// Name of array to read into.
-    #[arg(default_value = "MAPFILE")]
-    array_var_name: String,
+	/// Name of array to read into.
+	#[arg(default_value = "MAPFILE")]
+	array_var_name: String,
 }
 
 impl builtins::Command for MapFileCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        if self.origin != 0 {
-            // This will require merging into a potentially already-existing array.
-            return error::unimp("mapfile -O is not yet implemented");
-        }
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		if self.origin != 0 {
+			// This will require merging into a potentially already-existing array.
+			return error::unimp("mapfile -O is not yet implemented");
+		}
 
-        if self.callback_group_size != 5000 || self.callback.is_some() {
-            return error::unimp("mapfile -C/-c is not yet implemented");
-        }
+		if self.callback_group_size != 5000 || self.callback.is_some() {
+			return error::unimp("mapfile -C/-c is not yet implemented");
+		}
 
-        let input_file = context
-            .try_fd(self.fd)
-            .ok_or_else(|| ErrorKind::BadFileDescriptor(self.fd))?;
+		let input_file = context
+			.try_fd(self.fd)
+			.ok_or_else(|| ErrorKind::BadFileDescriptor(self.fd))?;
 
-        // Read!
-        let results = self.read_entries(input_file)?;
+		// Read!
+		let results = self.read_entries(input_file)?;
 
-        // Assign!
-        context.shell.env.update_or_add(
-            &self.array_var_name,
-            variables::ShellValueLiteral::Array(results),
-            |_| Ok(()),
-            env::EnvironmentLookup::Anywhere,
-            env::EnvironmentScope::Global,
-        )?;
+		// Assign!
+		context.shell.env.update_or_add(
+			&self.array_var_name,
+			variables::ShellValueLiteral::Array(results),
+			|_| Ok(()),
+			env::EnvironmentLookup::Anywhere,
+			env::EnvironmentScope::Global,
+		)?;
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }
 
 impl MapFileCommand {
-    fn read_entries(
-        &self,
-        mut input_file: brush_core::openfiles::OpenFile,
-    ) -> Result<variables::ArrayLiteral, brush_core::Error> {
-        let _term_mode = setup_terminal_settings(&input_file)?;
+	fn read_entries(
+		&self,
+		mut input_file: brush_core::openfiles::OpenFile,
+	) -> Result<variables::ArrayLiteral, brush_core::Error> {
+		let _term_mode = setup_terminal_settings(&input_file)?;
 
-        let mut entries = vec![];
-        let mut read_count = 0;
-        let max_count = self.max_count.try_into()?;
-        let delimiter = self.delimiter.chars().next().unwrap_or('\n') as u8;
+		let mut entries = vec![];
+		let mut read_count = 0;
+		let max_count = self.max_count.try_into()?;
+		let delimiter = self.delimiter.chars().next().unwrap_or('\n') as u8;
 
-        let mut buf = [0u8; 1];
+		let mut buf = [0u8; 1];
 
-        while max_count == 0 || entries.len() < max_count {
-            let mut line = vec![];
-            let mut saw_delimiter = false;
+		while max_count == 0 || entries.len() < max_count {
+			let mut line = vec![];
+			let mut saw_delimiter = false;
 
-            loop {
-                match input_file.read(&mut buf) {
-                    Ok(0) => break,                                         // End of input
-                    Ok(1) if buf[0] == b'\x03' => break,                    // Ctrl+C
-                    Ok(1) if buf[0] == b'\x04' && line.is_empty() => break, // Ctrl+D
-                    Ok(1) => {
-                        let byte = buf[0];
-                        line.push(byte);
-                        if byte == delimiter {
-                            saw_delimiter = true;
-                            break;
-                        }
-                    }
-                    Ok(_) => unreachable!("input can only be 0, 1, or error"),
-                    Err(e) => return Err(e.into()),
-                }
-            }
+			loop {
+				match input_file.read(&mut buf) {
+					Ok(0) => break,                                         // End of input
+					Ok(1) if buf[0] == b'\x03' => break,                    // Ctrl+C
+					Ok(1) if buf[0] == b'\x04' && line.is_empty() => break, // Ctrl+D
+					Ok(1) => {
+						let byte = buf[0];
+						line.push(byte);
+						if byte == delimiter {
+							saw_delimiter = true;
+							break;
+						}
+					},
+					Ok(_) => unreachable!("input can only be 0, 1, or error"),
+					Err(e) => return Err(e.into()),
+				}
+			}
 
-            if line.is_empty() && !saw_delimiter {
-                break;
-            }
+			if line.is_empty() && !saw_delimiter {
+				break;
+			}
 
-            if read_count < self.skip_count {
-                read_count += 1;
-                continue;
-            }
+			if read_count < self.skip_count {
+				read_count += 1;
+				continue;
+			}
 
-            if self.remove_delimiter && line.ends_with(&[delimiter]) {
-                line.pop();
-            }
+			if self.remove_delimiter && line.ends_with(&[delimiter]) {
+				line.pop();
+			}
 
-            let line_str = String::from_utf8_lossy(&line).to_string();
+			let line_str = String::from_utf8_lossy(&line).to_string();
 
-            entries.push((None, line_str));
-        }
+			entries.push((None, line_str));
+		}
 
-        Ok(variables::ArrayLiteral(entries))
-    }
+		Ok(variables::ArrayLiteral(entries))
+	}
 }
 
 fn setup_terminal_settings(
-    file: &brush_core::openfiles::OpenFile,
+	file: &brush_core::openfiles::OpenFile,
 ) -> Result<Option<brush_core::terminal::AutoModeGuard>, brush_core::Error> {
-    let mode = brush_core::terminal::AutoModeGuard::new(file.to_owned()).ok();
-    if let Some(mode) = &mode {
-        let config = brush_core::terminal::Settings::builder()
-            .line_input(false)
-            .interrupt_signals(false)
-            .build();
+	let mode = brush_core::terminal::AutoModeGuard::new(file.to_owned()).ok();
+	if let Some(mode) = &mode {
+		let config = brush_core::terminal::Settings::builder()
+			.line_input(false)
+			.interrupt_signals(false)
+			.build();
 
-        mode.apply_settings(&config)?;
-    }
+		mode.apply_settings(&config)?;
+	}
 
-    Ok(mode)
+	Ok(mode)
 }

--- a/crates/brush-builtins-vendored/src/popd.rs
+++ b/crates/brush-builtins-vendored/src/popd.rs
@@ -5,32 +5,32 @@ use brush_core::{ExecutionResult, builtins};
 /// Pop a path from the current directory stack.
 #[derive(Parser)]
 pub(crate) struct PopdCommand {
-    /// Pop the path without changing the current working directory.
-    #[clap(short = 'n')]
-    no_directory_change: bool,
-    //
-    // TODO: implement +N and -N
+	/// Pop the path without changing the current working directory.
+	#[clap(short = 'n')]
+	no_directory_change: bool,
+	//
+	// TODO: implement +N and -N
 }
 
 impl builtins::Command for PopdCommand {
-    type Error = crate::dirs::DirError;
+	type Error = crate::dirs::DirError;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        if let Some(popped) = context.shell.directory_stack.pop() {
-            if !self.no_directory_change {
-                context.shell.set_working_dir(&popped)?;
-            }
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		if let Some(popped) = context.shell.directory_stack.pop() {
+			if !self.no_directory_change {
+				context.shell.set_working_dir(&popped)?;
+			}
 
-            // Display dirs.
-            let dirs_cmd = crate::dirs::DirsCommand::default();
-            dirs_cmd.execute(context).await?;
+			// Display dirs.
+			let dirs_cmd = crate::dirs::DirsCommand::default();
+			dirs_cmd.execute(context).await?;
 
-            Ok(ExecutionResult::success())
-        } else {
-            Err(crate::dirs::DirError::DirStackEmpty)
-        }
-    }
+			Ok(ExecutionResult::success())
+		} else {
+			Err(crate::dirs::DirError::DirStackEmpty)
+		}
+	}
 }

--- a/crates/brush-builtins-vendored/src/printf.rs
+++ b/crates/brush-builtins-vendored/src/printf.rs
@@ -8,177 +8,177 @@ use brush_core::{Error, ErrorKind, ExecutionResult, builtins, escape, expansion}
 #[derive(Parser)]
 #[clap(disable_help_flag = true, disable_version_flag = true)]
 pub(crate) struct PrintfCommand {
-    /// If specified, the output of the command is assigned to this variable.
-    #[arg(short = 'v')]
-    output_variable: Option<String>,
+	/// If specified, the output of the command is assigned to this variable.
+	#[arg(short = 'v')]
+	output_variable: Option<String>,
 
-    /// Format string + arguments to the format string.
-    #[arg(trailing_var_arg = true, required = true, allow_hyphen_values = true)]
-    format_and_args: Vec<String>,
+	/// Format string + arguments to the format string.
+	#[arg(trailing_var_arg = true, required = true, allow_hyphen_values = true)]
+	format_and_args: Vec<String>,
 }
 
 impl builtins::Command for PrintfCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, Self::Error> {
-        if let Some(variable_name) = &self.output_variable {
-            // Format to a u8 vector.
-            let mut result: Vec<u8> = vec![];
-            format(self.format_and_args.as_slice(), &mut result)?;
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, Self::Error> {
+		if let Some(variable_name) = &self.output_variable {
+			// Format to a u8 vector.
+			let mut result: Vec<u8> = vec![];
+			format(self.format_and_args.as_slice(), &mut result)?;
 
-            // Convert to a string.
-            let result_str = String::from_utf8(result).map_err(|_| {
-                brush_core::ErrorKind::PrintfInvalidUsage("invalid UTF-8 output".into())
-            })?;
+			// Convert to a string.
+			let result_str = String::from_utf8(result).map_err(|_| {
+				brush_core::ErrorKind::PrintfInvalidUsage("invalid UTF-8 output".into())
+			})?;
 
-            // Assign to the selected variable.
-            expansion::assign_to_named_parameter(
-                context.shell,
-                &context.params,
-                variable_name,
-                result_str,
-            )
-            .await?;
-        } else {
-            format(self.format_and_args.as_slice(), context.stdout())?;
-            context.stdout().flush()?;
-        }
+			// Assign to the selected variable.
+			expansion::assign_to_named_parameter(
+				context.shell,
+				&context.params,
+				variable_name,
+				result_str,
+			)
+			.await?;
+		} else {
+			format(self.format_and_args.as_slice(), context.stdout())?;
+			context.stdout().flush()?;
+		}
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }
 
 fn format(format_and_args: &[String], writer: impl Write) -> Result<(), brush_core::Error> {
-    match format_and_args {
-        // Special-case invocation of printf with %q-based format string from bash-completion.
-        // It has hard-coded expectation of backslash-style escaping instead of quoting.
-        [fmt, arg] if fmt == "%q" => format_special_case_for_percent_q(None, arg, writer),
-        [fmt, arg] if fmt == "~%q" => format_special_case_for_percent_q(Some("~"), arg, writer),
-        // Handle format string with arguments using uucore
-        [fmt, args @ ..] => format_via_uucore(fmt, args.iter(), writer),
-        // Handle case with no format string (we shouldn't be able to get here since clap will
-        // fail parsing when the format string is missing)
-        [] => Err(ErrorKind::PrintfInvalidUsage("missing operand".into()).into()),
-    }
+	match format_and_args {
+		// Special-case invocation of printf with %q-based format string from bash-completion.
+		// It has hard-coded expectation of backslash-style escaping instead of quoting.
+		[fmt, arg] if fmt == "%q" => format_special_case_for_percent_q(None, arg, writer),
+		[fmt, arg] if fmt == "~%q" => format_special_case_for_percent_q(Some("~"), arg, writer),
+		// Handle format string with arguments using uucore
+		[fmt, args @ ..] => format_via_uucore(fmt, args.iter(), writer),
+		// Handle case with no format string (we shouldn't be able to get here since clap will
+		// fail parsing when the format string is missing)
+		[] => Err(ErrorKind::PrintfInvalidUsage("missing operand".into()).into()),
+	}
 }
 
 fn format_special_case_for_percent_q(
-    prefix: Option<&str>,
-    arg: &str,
-    mut writer: impl Write,
+	prefix: Option<&str>,
+	arg: &str,
+	mut writer: impl Write,
 ) -> Result<(), brush_core::Error> {
-    let mut result = escape::quote_if_needed(arg, escape::QuoteMode::BackslashEscape).to_string();
+	let mut result = escape::quote_if_needed(arg, escape::QuoteMode::BackslashEscape).to_string();
 
-    if let Some(prefix) = prefix {
-        result.insert_str(0, prefix);
-    }
+	if let Some(prefix) = prefix {
+		result.insert_str(0, prefix);
+	}
 
-    write!(writer, "{result}")?;
+	write!(writer, "{result}")?;
 
-    Ok(())
+	Ok(())
 }
 
 fn format_via_uucore(
-    format_string: &str,
-    args: impl Iterator<Item = impl AsRef<str>>,
-    mut writer: impl Write,
+	format_string: &str,
+	args: impl Iterator<Item = impl AsRef<str>>,
+	mut writer: impl Write,
 ) -> Result<(), brush_core::Error> {
-    // Convert string arguments to FormatArgument::Unparsed
-    let format_args: Vec<_> = args
-        .map(|s| format::FormatArgument::Unparsed(s.as_ref().to_string().into()))
-        .collect();
+	// Convert string arguments to FormatArgument::Unparsed
+	let format_args: Vec<_> = args
+		.map(|s| format::FormatArgument::Unparsed(s.as_ref().to_string().into()))
+		.collect();
 
-    // Parse format string once.
-    let format_items = parse_format_string(format_string)?;
+	// Parse format string once.
+	let format_items = parse_format_string(format_string)?;
 
-    // Wrap the format arguments.
-    let mut format_args_wrapper = format::FormatArguments::new(&format_args);
+	// Wrap the format arguments.
+	let mut format_args_wrapper = format::FormatArguments::new(&format_args);
 
-    // Keep going until we've exhausted all format arguments. Also make sure to run at least once
-    // even if there's no format arguments.
-    while format_args.is_empty() || !format_args_wrapper.is_exhausted() {
-        // Process all format items, in order. We'll bail when we're told to stop.
-        for item in &format_items {
-            let control_flow = item
-                .write(&mut writer, &mut format_args_wrapper)
-                .map_err(|e| {
-                    Error::from(ErrorKind::PrintfInvalidUsage(std::format!(
-                        "printf formatting error: {e}"
-                    )))
-                })?;
+	// Keep going until we've exhausted all format arguments. Also make sure to run at least once
+	// even if there's no format arguments.
+	while format_args.is_empty() || !format_args_wrapper.is_exhausted() {
+		// Process all format items, in order. We'll bail when we're told to stop.
+		for item in &format_items {
+			let control_flow = item
+				.write(&mut writer, &mut format_args_wrapper)
+				.map_err(|e| {
+					Error::from(ErrorKind::PrintfInvalidUsage(std::format!(
+						"printf formatting error: {e}"
+					)))
+				})?;
 
-            if control_flow == ControlFlow::Break(()) {
-                break;
-            }
-        }
+			if control_flow == ControlFlow::Break(()) {
+				break;
+			}
+		}
 
-        // Start next batch if not exhausted
-        if !format_args_wrapper.is_exhausted() {
-            format_args_wrapper.start_next_batch();
-        }
+		// Start next batch if not exhausted
+		if !format_args_wrapper.is_exhausted() {
+			format_args_wrapper.start_next_batch();
+		}
 
-        if format_args.is_empty() {
-            break;
-        }
-    }
+		if format_args.is_empty() {
+			break;
+		}
+	}
 
-    Ok(())
+	Ok(())
 }
 
 fn parse_format_string(
-    format_string: &str,
+	format_string: &str,
 ) -> Result<Vec<format::FormatItem<format::EscapedChar>>, brush_core::Error> {
-    let format_items: Result<Vec<_>, _> =
-        format::parse_spec_and_escape(format_string.as_bytes()).collect();
+	let format_items: Result<Vec<_>, _> =
+		format::parse_spec_and_escape(format_string.as_bytes()).collect();
 
-    // Observe any errors we encountered along the way.
-    let format_items = format_items
-        .map_err(|e| ErrorKind::PrintfInvalidUsage(format!("printf parsing error: {e}")))?;
+	// Observe any errors we encountered along the way.
+	let format_items = format_items
+		.map_err(|e| ErrorKind::PrintfInvalidUsage(format!("printf parsing error: {e}")))?;
 
-    Ok(format_items)
+	Ok(format_items)
 }
 
 #[cfg(test)]
 #[expect(clippy::panic_in_result_fn)]
 mod tests {
-    use super::*;
-    use anyhow::Result;
+	use super::*;
+	use anyhow::Result;
 
-    fn sprintf_via_uucore(
-        format_string: &str,
-        args: impl Iterator<Item = impl AsRef<str>>,
-    ) -> Result<String> {
-        let mut result = vec![];
-        format_via_uucore(format_string, args, &mut result)?;
+	fn sprintf_via_uucore(
+		format_string: &str,
+		args: impl Iterator<Item = impl AsRef<str>>,
+	) -> Result<String> {
+		let mut result = vec![];
+		format_via_uucore(format_string, args, &mut result)?;
 
-        Ok(String::from_utf8(result)?)
-    }
+		Ok(String::from_utf8(result)?)
+	}
 
-    #[test]
-    fn test_basic_sprintf() -> Result<()> {
-        assert_eq!(sprintf_via_uucore("%s", std::iter::once(&"xyz"))?, "xyz");
-        assert_eq!(sprintf_via_uucore(r"%d\n", std::iter::once(&"1"))?, "1\n");
+	#[test]
+	fn test_basic_sprintf() -> Result<()> {
+		assert_eq!(sprintf_via_uucore("%s", std::iter::once(&"xyz"))?, "xyz");
+		assert_eq!(sprintf_via_uucore(r"%d\n", std::iter::once(&"1"))?, "1\n");
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    #[test]
-    fn test_sprintf_without_args() -> Result<()> {
-        let empty: [&str; 0] = [];
+	#[test]
+	fn test_sprintf_without_args() -> Result<()> {
+		let empty: [&str; 0] = [];
 
-        assert_eq!(sprintf_via_uucore("xyz", empty.iter())?, "xyz");
-        assert_eq!(sprintf_via_uucore("%s|", empty.iter())?, "|");
+		assert_eq!(sprintf_via_uucore("xyz", empty.iter())?, "xyz");
+		assert_eq!(sprintf_via_uucore("%s|", empty.iter())?, "|");
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    #[test]
-    fn test_sprintf_with_cycles() -> Result<()> {
-        assert_eq!(sprintf_via_uucore("%s|", ["x", "y"].iter())?, "x|y|");
+	#[test]
+	fn test_sprintf_with_cycles() -> Result<()> {
+		assert_eq!(sprintf_via_uucore("%s|", ["x", "y"].iter())?, "x|y|");
 
-        Ok(())
-    }
+		Ok(())
+	}
 }

--- a/crates/brush-builtins-vendored/src/pushd.rs
+++ b/crates/brush-builtins-vendored/src/pushd.rs
@@ -5,41 +5,41 @@ use brush_core::{ExecutionResult, builtins};
 /// Push a path onto the current directory stack.
 #[derive(Parser)]
 pub(crate) struct PushdCommand {
-    /// Push the path without changing the current working directory.
-    #[clap(short = 'n')]
-    no_directory_change: bool,
+	/// Push the path without changing the current working directory.
+	#[clap(short = 'n')]
+	no_directory_change: bool,
 
-    /// Directory to push on the directory stack.
-    dir: String,
-    //
-    // TODO: implement +N and -N
+	/// Directory to push on the directory stack.
+	dir: String,
+	//
+	// TODO: implement +N and -N
 }
 
 impl builtins::Command for PushdCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        if self.no_directory_change {
-            context
-                .shell
-                .directory_stack
-                .push(std::path::PathBuf::from(&self.dir));
-        } else {
-            let prev_working_dir = context.shell.working_dir().to_path_buf();
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		if self.no_directory_change {
+			context
+				.shell
+				.directory_stack
+				.push(std::path::PathBuf::from(&self.dir));
+		} else {
+			let prev_working_dir = context.shell.working_dir().to_path_buf();
 
-            let dir = std::path::Path::new(&self.dir);
-            context.shell.set_working_dir(dir)?;
+			let dir = std::path::Path::new(&self.dir);
+			context.shell.set_working_dir(dir)?;
 
-            context.shell.directory_stack.push(prev_working_dir);
-        }
+			context.shell.directory_stack.push(prev_working_dir);
+		}
 
-        // Display dirs.
-        let dirs_cmd = crate::dirs::DirsCommand::default();
-        dirs_cmd.execute(context).await?;
+		// Display dirs.
+		let dirs_cmd = crate::dirs::DirsCommand::default();
+		dirs_cmd.execute(context).await?;
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }

--- a/crates/brush-builtins-vendored/src/pwd.rs
+++ b/crates/brush-builtins-vendored/src/pwd.rs
@@ -5,36 +5,36 @@ use std::{borrow::Cow, io::Write, path::Path};
 /// Display the current working directory.
 #[derive(Parser)]
 pub(crate) struct PwdCommand {
-    /// Print the physical directory without any symlinks.
-    #[arg(short = 'P', overrides_with = "allow_symlinks")]
-    physical: bool,
+	/// Print the physical directory without any symlinks.
+	#[arg(short = 'P', overrides_with = "allow_symlinks")]
+	physical: bool,
 
-    /// Print $PWD if it names the current working directory.
-    #[arg(short = 'L', overrides_with = "physical")]
-    allow_symlinks: bool,
+	/// Print $PWD if it names the current working directory.
+	#[arg(short = 'L', overrides_with = "physical")]
+	allow_symlinks: bool,
 }
 
 impl builtins::Command for PwdCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        let mut cwd: Cow<'_, Path> = context.shell.working_dir().into();
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		let mut cwd: Cow<'_, Path> = context.shell.working_dir().into();
 
-        let should_canonicalize = self.physical
-            || context
-                .shell
-                .options
-                .do_not_resolve_symlinks_when_changing_dir;
+		let should_canonicalize = self.physical
+			|| context
+				.shell
+				.options
+				.do_not_resolve_symlinks_when_changing_dir;
 
-        if should_canonicalize {
-            cwd = cwd.canonicalize()?.into();
-        }
+		if should_canonicalize {
+			cwd = cwd.canonicalize()?.into();
+		}
 
-        writeln!(context.stdout(), "{}", cwd.to_string_lossy())?;
+		writeln!(context.stdout(), "{}", cwd.to_string_lossy())?;
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }

--- a/crates/brush-builtins-vendored/src/return_.rs
+++ b/crates/brush-builtins-vendored/src/return_.rs
@@ -6,35 +6,32 @@ use brush_core::{ExecutionControlFlow, ExecutionExitCode, ExecutionResult, built
 /// Return from the current function.
 #[derive(Parser)]
 pub(crate) struct ReturnCommand {
-    /// The exit code to return.
-    code: Option<i32>,
+	/// The exit code to return.
+	code: Option<i32>,
 }
 
 impl builtins::Command for ReturnCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        #[expect(clippy::cast_sign_loss)]
-        let code_8bit = if let Some(code_32bit) = &self.code {
-            (code_32bit & 0xFF) as u8
-        } else {
-            context.shell.last_result()
-        };
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		#[expect(clippy::cast_sign_loss)]
+		let code_8bit = if let Some(code_32bit) = &self.code {
+			(code_32bit & 0xFF) as u8
+		} else {
+			context.shell.last_result()
+		};
 
-        if context.shell.in_function() || context.shell.in_sourced_script() {
-            let mut result = ExecutionResult::new(code_8bit);
-            result.next_control_flow = ExecutionControlFlow::ReturnFromFunctionOrScript;
+		if context.shell.in_function() || context.shell.in_sourced_script() {
+			let mut result = ExecutionResult::new(code_8bit);
+			result.next_control_flow = ExecutionControlFlow::ReturnFromFunctionOrScript;
 
-            Ok(result)
-        } else {
-            writeln!(
-                context.stderr(),
-                "return: can only be used in a function or sourced script"
-            )?;
-            Ok(ExecutionExitCode::InvalidUsage.into())
-        }
-    }
+			Ok(result)
+		} else {
+			writeln!(context.stderr(), "return: can only be used in a function or sourced script")?;
+			Ok(ExecutionExitCode::InvalidUsage.into())
+		}
+	}
 }

--- a/crates/brush-builtins-vendored/src/set.rs
+++ b/crates/brush-builtins-vendored/src/set.rs
@@ -7,428 +7,413 @@ use itertools::Itertools;
 use brush_core::{ExecutionExitCode, ExecutionResult, builtins, variables};
 
 crate::minus_or_plus_flag_arg!(
-    ExportVariablesOnModification,
-    'a',
-    "Export variables on modification"
+	ExportVariablesOnModification,
+	'a',
+	"Export variables on modification"
 );
 crate::minus_or_plus_flag_arg!(
-    NotifyJobTerminationImmediately,
-    'b',
-    "Notify job termination immediately"
+	NotifyJobTerminationImmediately,
+	'b',
+	"Notify job termination immediately"
 );
-crate::minus_or_plus_flag_arg!(
-    ExitOnNonzeroCommandExit,
-    'e',
-    "Exit on nonzero command exit"
-);
+crate::minus_or_plus_flag_arg!(ExitOnNonzeroCommandExit, 'e', "Exit on nonzero command exit");
 crate::minus_or_plus_flag_arg!(DisableFilenameGlobbing, 'f', "Disable filename globbing");
 crate::minus_or_plus_flag_arg!(RememberCommandLocations, 'h', "Remember command locations");
 crate::minus_or_plus_flag_arg!(
-    PlaceAllAssignmentArgsInCommandEnv,
-    'k',
-    "Place all assignment args in command environment"
+	PlaceAllAssignmentArgsInCommandEnv,
+	'k',
+	"Place all assignment args in command environment"
 );
 crate::minus_or_plus_flag_arg!(EnableJobControl, 'm', "Enable job control");
 crate::minus_or_plus_flag_arg!(DoNotExecuteCommands, 'n', "Do not execute commands");
 crate::minus_or_plus_flag_arg!(RealEffectiveUidMismatch, 'p', "Real effective UID mismatch");
 crate::minus_or_plus_flag_arg!(ExitAfterOneCommand, 't', "Exit after one command");
-crate::minus_or_plus_flag_arg!(
-    TreatUnsetVariablesAsError,
-    'u',
-    "Treat unset variables as error"
-);
+crate::minus_or_plus_flag_arg!(TreatUnsetVariablesAsError, 'u', "Treat unset variables as error");
 crate::minus_or_plus_flag_arg!(PrintShellInputLines, 'v', "Print shell input lines");
-crate::minus_or_plus_flag_arg!(
-    PrintCommandsAndArguments,
-    'x',
-    "Print commands and arguments"
-);
+crate::minus_or_plus_flag_arg!(PrintCommandsAndArguments, 'x', "Print commands and arguments");
 crate::minus_or_plus_flag_arg!(PerformBraceExpansion, 'B', "Perform brace expansion");
 crate::minus_or_plus_flag_arg!(
-    DisallowOverwritingRegularFilesViaOutputRedirection,
-    'C',
-    "Disallow overwriting regular files via output redirection"
+	DisallowOverwritingRegularFilesViaOutputRedirection,
+	'C',
+	"Disallow overwriting regular files via output redirection"
 );
 crate::minus_or_plus_flag_arg!(
-    ShellFunctionsInheritErrTrap,
-    'E',
-    "Shell functions inherit ERR trap"
+	ShellFunctionsInheritErrTrap,
+	'E',
+	"Shell functions inherit ERR trap"
 );
 crate::minus_or_plus_flag_arg!(
-    EnableBangStyleHistorySubstitution,
-    'H',
-    "Enable bang style history substitution"
+	EnableBangStyleHistorySubstitution,
+	'H',
+	"Enable bang style history substitution"
 );
 crate::minus_or_plus_flag_arg!(
-    DoNotResolveSymlinksWhenChangingDir,
-    'P',
-    "Do not resolve symlinks when changing dir"
+	DoNotResolveSymlinksWhenChangingDir,
+	'P',
+	"Do not resolve symlinks when changing dir"
 );
 crate::minus_or_plus_flag_arg!(
-    ShellFunctionsInheritDebugAndReturnTraps,
-    'T',
-    "Shell functions inherit DEBUG and RETURN traps"
+	ShellFunctionsInheritDebugAndReturnTraps,
+	'T',
+	"Shell functions inherit DEBUG and RETURN traps"
 );
 
 #[derive(clap::Parser)]
 pub(crate) struct SetOption {
-    #[arg(short = 'o', name = "setopt_enable", num_args=0..=1, value_name = "OPT")]
-    enable: Option<Vec<String>>,
-    #[arg(long = concat!("+o"), name = "setopt_disable", hide = true, num_args=0..=1)]
-    disable: Option<Vec<String>>,
+	#[arg(short = 'o', name = "setopt_enable", num_args=0..=1, value_name = "OPT")]
+	enable: Option<Vec<String>>,
+	#[arg(long = concat!("+o"), name = "setopt_disable", hide = true, num_args=0..=1)]
+	disable: Option<Vec<String>>,
 }
 
 /// Manage set-based shell options.
 #[derive(Parser)]
 #[clap(disable_help_flag = true)]
 pub(crate) struct SetCommand {
-    /// Display help for this command.
-    #[clap(long, action = clap::ArgAction::HelpLong)]
-    help: Option<bool>,
+	/// Display help for this command.
+	#[clap(long, action = clap::ArgAction::HelpLong)]
+	help: Option<bool>,
 
-    #[clap(flatten)]
-    export_variables_on_modification: ExportVariablesOnModification,
-    #[clap(flatten)]
-    notify_job_termination_immediately: NotifyJobTerminationImmediately,
-    #[clap(flatten)]
-    exit_on_nonzero_command_exit: ExitOnNonzeroCommandExit,
-    #[clap(flatten)]
-    disable_filename_globbing: DisableFilenameGlobbing,
-    #[clap(flatten)]
-    remember_command_locations: RememberCommandLocations,
-    #[clap(flatten)]
-    place_all_assignment_args_in_command_env: PlaceAllAssignmentArgsInCommandEnv,
-    #[clap(flatten)]
-    enable_job_control: EnableJobControl,
-    #[clap(flatten)]
-    do_not_execute_commands: DoNotExecuteCommands,
-    #[clap(flatten)]
-    real_effective_uid_mismatch: RealEffectiveUidMismatch,
-    #[clap(flatten)]
-    exit_after_one_command: ExitAfterOneCommand,
-    #[clap(flatten)]
-    treat_unset_variables_as_error: TreatUnsetVariablesAsError,
-    #[clap(flatten)]
-    print_shell_input_lines: PrintShellInputLines,
-    #[clap(flatten)]
-    print_commands_and_arguments: PrintCommandsAndArguments,
-    #[clap(flatten)]
-    perform_brace_expansion: PerformBraceExpansion,
-    #[clap(flatten)]
-    disallow_overwriting_regular_files_via_output_redirection:
-        DisallowOverwritingRegularFilesViaOutputRedirection,
-    #[clap(flatten)]
-    shell_functions_inherit_err_trap: ShellFunctionsInheritErrTrap,
-    #[clap(flatten)]
-    enable_bang_style_history_substitution: EnableBangStyleHistorySubstitution,
-    #[clap(flatten)]
-    do_not_resolve_symlinks_when_changing_dir: DoNotResolveSymlinksWhenChangingDir,
-    #[clap(flatten)]
-    shell_functions_inherit_debug_and_return_traps: ShellFunctionsInheritDebugAndReturnTraps,
+	#[clap(flatten)]
+	export_variables_on_modification: ExportVariablesOnModification,
+	#[clap(flatten)]
+	notify_job_termination_immediately: NotifyJobTerminationImmediately,
+	#[clap(flatten)]
+	exit_on_nonzero_command_exit: ExitOnNonzeroCommandExit,
+	#[clap(flatten)]
+	disable_filename_globbing: DisableFilenameGlobbing,
+	#[clap(flatten)]
+	remember_command_locations: RememberCommandLocations,
+	#[clap(flatten)]
+	place_all_assignment_args_in_command_env: PlaceAllAssignmentArgsInCommandEnv,
+	#[clap(flatten)]
+	enable_job_control: EnableJobControl,
+	#[clap(flatten)]
+	do_not_execute_commands: DoNotExecuteCommands,
+	#[clap(flatten)]
+	real_effective_uid_mismatch: RealEffectiveUidMismatch,
+	#[clap(flatten)]
+	exit_after_one_command: ExitAfterOneCommand,
+	#[clap(flatten)]
+	treat_unset_variables_as_error: TreatUnsetVariablesAsError,
+	#[clap(flatten)]
+	print_shell_input_lines: PrintShellInputLines,
+	#[clap(flatten)]
+	print_commands_and_arguments: PrintCommandsAndArguments,
+	#[clap(flatten)]
+	perform_brace_expansion: PerformBraceExpansion,
+	#[clap(flatten)]
+	disallow_overwriting_regular_files_via_output_redirection:
+		DisallowOverwritingRegularFilesViaOutputRedirection,
+	#[clap(flatten)]
+	shell_functions_inherit_err_trap: ShellFunctionsInheritErrTrap,
+	#[clap(flatten)]
+	enable_bang_style_history_substitution: EnableBangStyleHistorySubstitution,
+	#[clap(flatten)]
+	do_not_resolve_symlinks_when_changing_dir: DoNotResolveSymlinksWhenChangingDir,
+	#[clap(flatten)]
+	shell_functions_inherit_debug_and_return_traps: ShellFunctionsInheritDebugAndReturnTraps,
 
-    #[clap(flatten)]
-    set_option: SetOption,
+	#[clap(flatten)]
+	set_option: SetOption,
 
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    positional_args: Vec<String>,
+	#[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+	positional_args: Vec<String>,
 }
 
 impl builtins::Command for SetCommand {
-    fn takes_plus_options() -> bool {
-        true
-    }
+	fn takes_plus_options() -> bool {
+		true
+	}
 
-    /// Override the default [`builtins::Command::new`] function to handle clap's limitation related
-    /// to `--`. See [`builtins::parse_known`] for more information
-    /// TODO: we can safely remove this after the issue is resolved
-    fn new<I>(args: I) -> Result<Self, clap::Error>
-    where
-        I: IntoIterator<Item = String>,
-    {
-        //
-        // TODO: This is getting pretty messy; we need to see how to avoid this -- handling from
-        // leaking into too many commands' custom parsing.
-        //
+	/// Override the default [`builtins::Command::new`] function to handle clap's limitation related
+	/// to `--`. See [`builtins::parse_known`] for more information
+	/// TODO: we can safely remove this after the issue is resolved
+	fn new<I>(args: I) -> Result<Self, clap::Error>
+	where
+		I: IntoIterator<Item = String>,
+	{
+		//
+		// TODO: This is getting pretty messy; we need to see how to avoid this -- handling from
+		// leaking into too many commands' custom parsing.
+		//
 
-        // Apply the same workaround from the default implementation of Command::new to handle '+'
-        // args.
-        let mut updated_args = vec![];
-        let mut now_parsing_positional_args = false;
-        let mut next_arg_is_option_value = false;
-        for (i, arg) in args.into_iter().enumerate() {
-            if now_parsing_positional_args || next_arg_is_option_value {
-                updated_args.push(arg);
+		// Apply the same workaround from the default implementation of Command::new to handle '+'
+		// args.
+		let mut updated_args = vec![];
+		let mut now_parsing_positional_args = false;
+		let mut next_arg_is_option_value = false;
+		for (i, arg) in args.into_iter().enumerate() {
+			if now_parsing_positional_args || next_arg_is_option_value {
+				updated_args.push(arg);
 
-                next_arg_is_option_value = false;
-                continue;
-            }
+				next_arg_is_option_value = false;
+				continue;
+			}
 
-            if arg == "-" || arg == "--" || (i > 0 && !arg.starts_with(['-', '+'])) {
-                now_parsing_positional_args = true;
-            }
+			if arg == "-" || arg == "--" || (i > 0 && !arg.starts_with(['-', '+'])) {
+				now_parsing_positional_args = true;
+			}
 
-            if let Some(plus_options) = arg.strip_prefix("+") {
-                next_arg_is_option_value = plus_options.ends_with('o');
-                for c in plus_options.chars() {
-                    updated_args.push(format!("--+{c}"));
-                }
-            } else {
-                next_arg_is_option_value = arg.starts_with('-') && arg.ends_with('o');
-                updated_args.push(arg);
-            }
-        }
+			if let Some(plus_options) = arg.strip_prefix("+") {
+				next_arg_is_option_value = plus_options.ends_with('o');
+				for c in plus_options.chars() {
+					updated_args.push(format!("--+{c}"));
+				}
+			} else {
+				next_arg_is_option_value = arg.starts_with('-') && arg.ends_with('o');
+				updated_args.push(arg);
+			}
+		}
 
-        let (mut this, rest_args) = brush_core::builtins::try_parse_known::<Self>(updated_args)?;
-        if let Some(args) = rest_args {
-            this.positional_args.extend(args);
-        }
-        Ok(this)
-    }
+		let (mut this, rest_args) = brush_core::builtins::try_parse_known::<Self>(updated_args)?;
+		if let Some(args) = rest_args {
+			this.positional_args.extend(args);
+		}
+		Ok(this)
+	}
 
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    
-    #[allow(clippy::useless_let_if_seq)]
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, Self::Error> {
-        let mut result = ExecutionResult::success();
+	#[allow(clippy::useless_let_if_seq)]
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, Self::Error> {
+		let mut result = ExecutionResult::success();
 
-        let mut saw_option = false;
+		let mut saw_option = false;
 
-        if let Some(value) = self.print_commands_and_arguments.to_bool() {
-            context.shell.options.print_commands_and_arguments = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.print_commands_and_arguments.to_bool() {
+			context.shell.options.print_commands_and_arguments = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.export_variables_on_modification.to_bool() {
-            context.shell.options.export_variables_on_modification = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.export_variables_on_modification.to_bool() {
+			context.shell.options.export_variables_on_modification = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.notify_job_termination_immediately.to_bool() {
-            context.shell.options.notify_job_termination_immediately = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.notify_job_termination_immediately.to_bool() {
+			context.shell.options.notify_job_termination_immediately = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.exit_on_nonzero_command_exit.to_bool() {
-            context.shell.options.exit_on_nonzero_command_exit = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.exit_on_nonzero_command_exit.to_bool() {
+			context.shell.options.exit_on_nonzero_command_exit = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.disable_filename_globbing.to_bool() {
-            context.shell.options.disable_filename_globbing = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.disable_filename_globbing.to_bool() {
+			context.shell.options.disable_filename_globbing = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.remember_command_locations.to_bool() {
-            context.shell.options.remember_command_locations = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.remember_command_locations.to_bool() {
+			context.shell.options.remember_command_locations = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.place_all_assignment_args_in_command_env.to_bool() {
-            context
-                .shell
-                .options
-                .place_all_assignment_args_in_command_env = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.place_all_assignment_args_in_command_env.to_bool() {
+			context
+				.shell
+				.options
+				.place_all_assignment_args_in_command_env = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.enable_job_control.to_bool() {
-            context.shell.options.enable_job_control = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.enable_job_control.to_bool() {
+			context.shell.options.enable_job_control = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.do_not_execute_commands.to_bool() {
-            context.shell.options.do_not_execute_commands = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.do_not_execute_commands.to_bool() {
+			context.shell.options.do_not_execute_commands = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.real_effective_uid_mismatch.to_bool() {
-            context.shell.options.real_effective_uid_mismatch = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.real_effective_uid_mismatch.to_bool() {
+			context.shell.options.real_effective_uid_mismatch = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.exit_after_one_command.to_bool() {
-            context.shell.options.exit_after_one_command = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.exit_after_one_command.to_bool() {
+			context.shell.options.exit_after_one_command = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.treat_unset_variables_as_error.to_bool() {
-            context.shell.options.treat_unset_variables_as_error = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.treat_unset_variables_as_error.to_bool() {
+			context.shell.options.treat_unset_variables_as_error = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.print_shell_input_lines.to_bool() {
-            context.shell.options.print_shell_input_lines = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.print_shell_input_lines.to_bool() {
+			context.shell.options.print_shell_input_lines = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.print_commands_and_arguments.to_bool() {
-            context.shell.options.print_commands_and_arguments = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.print_commands_and_arguments.to_bool() {
+			context.shell.options.print_commands_and_arguments = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.perform_brace_expansion.to_bool() {
-            context.shell.options.perform_brace_expansion = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.perform_brace_expansion.to_bool() {
+			context.shell.options.perform_brace_expansion = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self
-            .disallow_overwriting_regular_files_via_output_redirection
-            .to_bool()
-        {
-            context
-                .shell
-                .options
-                .disallow_overwriting_regular_files_via_output_redirection = value;
-            saw_option = true;
-        }
+		if let Some(value) = self
+			.disallow_overwriting_regular_files_via_output_redirection
+			.to_bool()
+		{
+			context
+				.shell
+				.options
+				.disallow_overwriting_regular_files_via_output_redirection = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.shell_functions_inherit_err_trap.to_bool() {
-            context.shell.options.shell_functions_inherit_err_trap = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.shell_functions_inherit_err_trap.to_bool() {
+			context.shell.options.shell_functions_inherit_err_trap = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.enable_bang_style_history_substitution.to_bool() {
-            context.shell.options.enable_bang_style_history_substitution = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.enable_bang_style_history_substitution.to_bool() {
+			context.shell.options.enable_bang_style_history_substitution = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self.do_not_resolve_symlinks_when_changing_dir.to_bool() {
-            context
-                .shell
-                .options
-                .do_not_resolve_symlinks_when_changing_dir = value;
-            saw_option = true;
-        }
+		if let Some(value) = self.do_not_resolve_symlinks_when_changing_dir.to_bool() {
+			context
+				.shell
+				.options
+				.do_not_resolve_symlinks_when_changing_dir = value;
+			saw_option = true;
+		}
 
-        if let Some(value) = self
-            .shell_functions_inherit_debug_and_return_traps
-            .to_bool()
-        {
-            context
-                .shell
-                .options
-                .shell_functions_inherit_debug_and_return_traps = value;
-            saw_option = true;
-        }
+		if let Some(value) = self
+			.shell_functions_inherit_debug_and_return_traps
+			.to_bool()
+		{
+			context
+				.shell
+				.options
+				.shell_functions_inherit_debug_and_return_traps = value;
+			saw_option = true;
+		}
 
-        let mut named_options: HashMap<String, bool> = HashMap::new();
-        if let Some(option_names) = &self.set_option.disable {
-            saw_option = true;
-            if option_names.is_empty() {
-                for option in brush_core::namedoptions::options(
-                    brush_core::namedoptions::ShellOptionKind::SetO,
-                )
-                .iter()
-                .sorted_by_key(|option| option.name)
-                {
-                    let option_value = option.definition.get(&context.shell.options);
-                    let option_value_str = if option_value { "-o" } else { "+o" };
-                    writeln!(context.stdout(), "set {option_value_str} {}", option.name)?;
-                }
-            } else {
-                for option_name in option_names {
-                    named_options.insert(option_name.to_owned(), false);
-                }
-            }
-        }
-        if let Some(option_names) = &self.set_option.enable {
-            saw_option = true;
-            if option_names.is_empty() {
-                for option in brush_core::namedoptions::options(
-                    brush_core::namedoptions::ShellOptionKind::SetO,
-                )
-                .iter()
-                .sorted_by_key(|option| option.name)
-                {
-                    let option_value = option.definition.get(&context.shell.options);
-                    let option_value_str = if option_value { "on" } else { "off" };
-                    writeln!(context.stdout(), "{:15}\t{option_value_str}", option.name)?;
-                }
-            } else {
-                for option_name in option_names {
-                    named_options.insert(option_name.to_owned(), true);
-                }
-            }
-        }
+		let mut named_options: HashMap<String, bool> = HashMap::new();
+		if let Some(option_names) = &self.set_option.disable {
+			saw_option = true;
+			if option_names.is_empty() {
+				for option in
+					brush_core::namedoptions::options(brush_core::namedoptions::ShellOptionKind::SetO)
+						.iter()
+						.sorted_by_key(|option| option.name)
+				{
+					let option_value = option.definition.get(&context.shell.options);
+					let option_value_str = if option_value { "-o" } else { "+o" };
+					writeln!(context.stdout(), "set {option_value_str} {}", option.name)?;
+				}
+			} else {
+				for option_name in option_names {
+					named_options.insert(option_name.to_owned(), false);
+				}
+			}
+		}
+		if let Some(option_names) = &self.set_option.enable {
+			saw_option = true;
+			if option_names.is_empty() {
+				for option in
+					brush_core::namedoptions::options(brush_core::namedoptions::ShellOptionKind::SetO)
+						.iter()
+						.sorted_by_key(|option| option.name)
+				{
+					let option_value = option.definition.get(&context.shell.options);
+					let option_value_str = if option_value { "on" } else { "off" };
+					writeln!(context.stdout(), "{:15}\t{option_value_str}", option.name)?;
+				}
+			} else {
+				for option_name in option_names {
+					named_options.insert(option_name.to_owned(), true);
+				}
+			}
+		}
 
-        for (option_name, value) in named_options {
-            if let Some(option_def) =
-                brush_core::namedoptions::options(brush_core::namedoptions::ShellOptionKind::SetO)
-                    .get(option_name.as_str())
-            {
-                option_def.set(&mut context.shell.options, value);
-            } else {
-                result = ExecutionExitCode::InvalidUsage.into();
-            }
-        }
+		for (option_name, value) in named_options {
+			if let Some(option_def) =
+				brush_core::namedoptions::options(brush_core::namedoptions::ShellOptionKind::SetO)
+					.get(option_name.as_str())
+			{
+				option_def.set(&mut context.shell.options, value);
+			} else {
+				result = ExecutionExitCode::InvalidUsage.into();
+			}
+		}
 
-        let skip = match self.positional_args.first() {
-            Some(x) if x == "-" => {
-                if self.positional_args.len() > 1 {
-                    context.shell.positional_parameters.clear();
-                }
-                1
-            }
-            Some(x) if x == "--" => {
-                context.shell.positional_parameters.clear();
-                1
-            }
-            Some(_) => {
-                context.shell.positional_parameters.clear();
-                0
-            }
-            None => 0,
-        };
+		let skip = match self.positional_args.first() {
+			Some(x) if x == "-" => {
+				if self.positional_args.len() > 1 {
+					context.shell.positional_parameters.clear();
+				}
+				1
+			},
+			Some(x) if x == "--" => {
+				context.shell.positional_parameters.clear();
+				1
+			},
+			Some(_) => {
+				context.shell.positional_parameters.clear();
+				0
+			},
+			None => 0,
+		};
 
-        for arg in self.positional_args.iter().skip(skip) {
-            context.shell.positional_parameters.push(arg.to_owned());
-        }
+		for arg in self.positional_args.iter().skip(skip) {
+			context.shell.positional_parameters.push(arg.to_owned());
+		}
 
-        saw_option = saw_option || !self.positional_args.is_empty();
+		saw_option = saw_option || !self.positional_args.is_empty();
 
-        // If we *still* haven't seen any options, then we need to display all variables and
-        // functions.
-        if !saw_option {
-            display_all(&context)?;
-        }
+		// If we *still* haven't seen any options, then we need to display all variables and
+		// functions.
+		if !saw_option {
+			display_all(&context)?;
+		}
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 }
 
 fn display_all(context: &brush_core::ExecutionContext<'_>) -> Result<(), brush_core::Error> {
-    // Display variables.
-    for (name, var) in context.shell.env.iter().sorted_by_key(|v| v.0) {
-        if !var.is_enumerable() {
-            continue;
-        }
+	// Display variables.
+	for (name, var) in context.shell.env.iter().sorted_by_key(|v| v.0) {
+		if !var.is_enumerable() {
+			continue;
+		}
 
-        // TODO: For now, skip all dynamic variables. The current behavior
-        // of bash is not quite clear. We've empirically found that some
-        // special variables don't get displayed until they're observed
-        // at least once.
-        if matches!(var.value(), variables::ShellValue::Dynamic { .. }) {
-            continue;
-        }
+		// TODO: For now, skip all dynamic variables. The current behavior
+		// of bash is not quite clear. We've empirically found that some
+		// special variables don't get displayed until they're observed
+		// at least once.
+		if matches!(var.value(), variables::ShellValue::Dynamic { .. }) {
+			continue;
+		}
 
-        writeln!(
-            context.stdout(),
-            "{name}={}",
-            var.value()
-                .format(variables::FormatStyle::Basic, context.shell)?,
-        )?;
-    }
+		writeln!(
+			context.stdout(),
+			"{name}={}",
+			var.value()
+				.format(variables::FormatStyle::Basic, context.shell)?,
+		)?;
+	}
 
-    // Display functions... unless we're in posix compliance mode.
-    if !context.shell.options.posix_mode {
-        for (_name, registration) in context.shell.funcs().iter().sorted_by_key(|v| v.0) {
-            writeln!(context.stdout(), "{}", registration.definition())?;
-        }
-    }
+	// Display functions... unless we're in posix compliance mode.
+	if !context.shell.options.posix_mode {
+		for (_name, registration) in context.shell.funcs().iter().sorted_by_key(|v| v.0) {
+			writeln!(context.stdout(), "{}", registration.definition())?;
+		}
+	}
 
-    Ok(())
+	Ok(())
 }

--- a/crates/brush-builtins-vendored/src/shift.rs
+++ b/crates/brush-builtins-vendored/src/shift.rs
@@ -5,32 +5,32 @@ use brush_core::{ExecutionExitCode, ExecutionResult, builtins};
 /// Shift positional arguments.
 #[derive(Parser)]
 pub(crate) struct ShiftCommand {
-    /// Number of positions to shift the arguments by (defaults to 1).
-    n: Option<i32>,
+	/// Number of positions to shift the arguments by (defaults to 1).
+	n: Option<i32>,
 }
 
 impl builtins::Command for ShiftCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        let n = self.n.unwrap_or(1);
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		let n = self.n.unwrap_or(1);
 
-        if n < 0 {
-            return Ok(ExecutionExitCode::InvalidUsage.into());
-        }
+		if n < 0 {
+			return Ok(ExecutionExitCode::InvalidUsage.into());
+		}
 
-        #[expect(clippy::cast_sign_loss)]
-        let n = n as usize;
+		#[expect(clippy::cast_sign_loss)]
+		let n = n as usize;
 
-        if n > context.shell.positional_parameters.len() {
-            return Ok(ExecutionExitCode::InvalidUsage.into());
-        }
+		if n > context.shell.positional_parameters.len() {
+			return Ok(ExecutionExitCode::InvalidUsage.into());
+		}
 
-        context.shell.positional_parameters.drain(0..n);
+		context.shell.positional_parameters.drain(0..n);
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }

--- a/crates/brush-builtins-vendored/src/suspend.rs
+++ b/crates/brush-builtins-vendored/src/suspend.rs
@@ -6,29 +6,29 @@ use brush_core::{ExecutionExitCode, ExecutionResult, builtins};
 /// Suspend the shell.
 #[derive(Parser)]
 pub(crate) struct SuspendCommand {
-    /// Force suspend login shells.
-    #[arg(short = 'f')]
-    force: bool,
+	/// Force suspend login shells.
+	#[arg(short = 'f')]
+	force: bool,
 }
 
 impl builtins::Command for SuspendCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, Self::Error> {
-        if context.shell.options.login_shell && !self.force {
-            writeln!(context.stderr(), "login shell cannot be suspended")?;
-            return Ok(ExecutionExitCode::InvalidUsage.into());
-        }
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, Self::Error> {
+		if context.shell.options.login_shell && !self.force {
+			writeln!(context.stderr(), "login shell cannot be suspended")?;
+			return Ok(ExecutionExitCode::InvalidUsage.into());
+		}
 
-        #[expect(clippy::cast_possible_wrap)]
-        brush_core::sys::signal::kill_process(
-            std::process::id() as i32,
-            brush_core::traps::TrapSignal::Signal(nix::sys::signal::SIGSTOP),
-        )?;
+		#[expect(clippy::cast_possible_wrap)]
+		brush_core::sys::signal::kill_process(
+			std::process::id() as i32,
+			brush_core::traps::TrapSignal::Signal(nix::sys::signal::SIGSTOP),
+		)?;
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }

--- a/crates/brush-builtins-vendored/src/test.rs
+++ b/crates/brush-builtins-vendored/src/test.rs
@@ -2,52 +2,52 @@ use clap::Parser;
 use std::io::Write;
 
 use brush_core::{
-    ErrorKind, ExecutionExitCode, ExecutionParameters, ExecutionResult, Shell, builtins, tests,
+	ErrorKind, ExecutionExitCode, ExecutionParameters, ExecutionResult, Shell, builtins, tests,
 };
 
 /// Evaluate test expression.
 #[derive(Parser)]
 #[clap(disable_help_flag = true, disable_version_flag = true)]
 pub(crate) struct TestCommand {
-    #[clap(allow_hyphen_values = true)]
-    args: Vec<String>,
+	#[clap(allow_hyphen_values = true)]
+	args: Vec<String>,
 }
 
 impl builtins::Command for TestCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        let mut args = self.args.as_slice();
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		let mut args = self.args.as_slice();
 
-        if context.command_name == "[" {
-            match args.last() {
-                Some(s) if s == "]" => (),
-                None | Some(_) => {
-                    writeln!(context.stderr(), "[: missing ']'")?;
-                    return Ok(ExecutionExitCode::InvalidUsage.into());
-                }
-            }
+		if context.command_name == "[" {
+			match args.last() {
+				Some(s) if s == "]" => (),
+				None | Some(_) => {
+					writeln!(context.stderr(), "[: missing ']'")?;
+					return Ok(ExecutionExitCode::InvalidUsage.into());
+				},
+			}
 
-            args = &args[0..args.len() - 1];
-        }
+			args = &args[0..args.len() - 1];
+		}
 
-        if execute_test(context.shell, &context.params, args)? {
-            Ok(ExecutionResult::success())
-        } else {
-            Ok(ExecutionResult::general_error())
-        }
-    }
+		if execute_test(context.shell, &context.params, args)? {
+			Ok(ExecutionResult::success())
+		} else {
+			Ok(ExecutionResult::general_error())
+		}
+	}
 }
 
 fn execute_test(
-    shell: &mut Shell,
-    params: &ExecutionParameters,
-    args: &[String],
+	shell: &mut Shell,
+	params: &ExecutionParameters,
+	args: &[String],
 ) -> Result<bool, brush_core::Error> {
-    let test_command =
-        brush_parser::test_command::parse(args).map_err(ErrorKind::TestCommandParseError)?;
-    tests::eval_expr(&test_command, shell, params)
+	let test_command =
+		brush_parser::test_command::parse(args).map_err(ErrorKind::TestCommandParseError)?;
+	tests::eval_expr(&test_command, shell, params)
 }

--- a/crates/brush-builtins-vendored/src/times.rs
+++ b/crates/brush-builtins-vendored/src/times.rs
@@ -8,29 +8,29 @@ use brush_core::{ExecutionResult, builtins, timing};
 pub(crate) struct TimesCommand {}
 
 impl builtins::Command for TimesCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, Self::Error> {
-        let (self_user, self_system) = brush_core::sys::resource::get_self_user_and_system_time()?;
-        writeln!(
-            context.stdout(),
-            "{} {}",
-            timing::format_duration_non_posixly(&self_user),
-            timing::format_duration_non_posixly(&self_system),
-        )?;
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, Self::Error> {
+		let (self_user, self_system) = brush_core::sys::resource::get_self_user_and_system_time()?;
+		writeln!(
+			context.stdout(),
+			"{} {}",
+			timing::format_duration_non_posixly(&self_user),
+			timing::format_duration_non_posixly(&self_system),
+		)?;
 
-        let (children_user, children_system) =
-            brush_core::sys::resource::get_children_user_and_system_time()?;
-        writeln!(
-            context.stdout(),
-            "{} {}",
-            timing::format_duration_non_posixly(&children_user),
-            timing::format_duration_non_posixly(&children_system),
-        )?;
+		let (children_user, children_system) =
+			brush_core::sys::resource::get_children_user_and_system_time()?;
+		writeln!(
+			context.stdout(),
+			"{} {}",
+			timing::format_duration_non_posixly(&children_user),
+			timing::format_duration_non_posixly(&children_system),
+		)?;
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }

--- a/crates/brush-builtins-vendored/src/trap.rs
+++ b/crates/brush-builtins-vendored/src/trap.rs
@@ -7,96 +7,96 @@ use brush_core::{ExecutionResult, builtins};
 /// Manage signal traps.
 #[derive(Parser)]
 pub(crate) struct TrapCommand {
-    /// List all signal names.
-    #[arg(short = 'l')]
-    list_signals: bool,
+	/// List all signal names.
+	#[arg(short = 'l')]
+	list_signals: bool,
 
-    /// Print registered trap commands.
-    #[arg(short = 'p')]
-    print_trap_commands: bool,
+	/// Print registered trap commands.
+	#[arg(short = 'p')]
+	print_trap_commands: bool,
 
-    args: Vec<String>,
+	args: Vec<String>,
 }
 
 impl builtins::Command for TrapCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        mut context: brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, Self::Error> {
-        if self.list_signals {
-            brush_core::traps::format_signals(context.stdout(), TrapSignal::iterator())
-                .map(|()| ExecutionResult::success())
-        } else if self.print_trap_commands || self.args.is_empty() {
-            if !self.args.is_empty() {
-                for signal_type in &self.args {
-                    Self::display_handlers_for(&context, signal_type.parse()?)?;
-                }
-            } else {
-                Self::display_all_handlers(&context)?;
-            }
-            Ok(ExecutionResult::success())
-        } else if self.args.len() == 1 {
-            // When only a single argument is given, it is assumed to be a signal name
-            // and an indication to remove the handlers for that signal.
-            let signal = self.args[0].as_str();
-            Self::remove_all_handlers(&mut context, signal.parse()?);
-            Ok(ExecutionResult::success())
-        } else if self.args[0] == "-" {
-            // Alternatively, "-" as the first argument indicates that the next
-            // argument is a signal name and we need to remove the handlers for that signal.
-            let signal = self.args[1].as_str();
-            Self::remove_all_handlers(&mut context, signal.parse()?);
-            Ok(ExecutionResult::success())
-        } else {
-            let handler = &self.args[0];
+	async fn execute(
+		&self,
+		mut context: brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, Self::Error> {
+		if self.list_signals {
+			brush_core::traps::format_signals(context.stdout(), TrapSignal::iterator())
+				.map(|()| ExecutionResult::success())
+		} else if self.print_trap_commands || self.args.is_empty() {
+			if !self.args.is_empty() {
+				for signal_type in &self.args {
+					Self::display_handlers_for(&context, signal_type.parse()?)?;
+				}
+			} else {
+				Self::display_all_handlers(&context)?;
+			}
+			Ok(ExecutionResult::success())
+		} else if self.args.len() == 1 {
+			// When only a single argument is given, it is assumed to be a signal name
+			// and an indication to remove the handlers for that signal.
+			let signal = self.args[0].as_str();
+			Self::remove_all_handlers(&mut context, signal.parse()?);
+			Ok(ExecutionResult::success())
+		} else if self.args[0] == "-" {
+			// Alternatively, "-" as the first argument indicates that the next
+			// argument is a signal name and we need to remove the handlers for that signal.
+			let signal = self.args[1].as_str();
+			Self::remove_all_handlers(&mut context, signal.parse()?);
+			Ok(ExecutionResult::success())
+		} else {
+			let handler = &self.args[0];
 
-            let mut signal_types = vec![];
-            for signal in &self.args[1..] {
-                signal_types.push(signal.parse()?);
-            }
+			let mut signal_types = vec![];
+			for signal in &self.args[1..] {
+				signal_types.push(signal.parse()?);
+			}
 
-            Self::register_handler(&mut context, signal_types, handler.as_str());
-            Ok(ExecutionResult::success())
-        }
-    }
+			Self::register_handler(&mut context, signal_types, handler.as_str());
+			Ok(ExecutionResult::success())
+		}
+	}
 }
 
 impl TrapCommand {
-    fn display_all_handlers(
-        context: &brush_core::ExecutionContext<'_>,
-    ) -> Result<(), brush_core::Error> {
-        for (signal, _) in context.shell.traps.iter_handlers() {
-            Self::display_handlers_for(context, signal)?;
-        }
-        Ok(())
-    }
+	fn display_all_handlers(
+		context: &brush_core::ExecutionContext<'_>,
+	) -> Result<(), brush_core::Error> {
+		for (signal, _) in context.shell.traps.iter_handlers() {
+			Self::display_handlers_for(context, signal)?;
+		}
+		Ok(())
+	}
 
-    fn display_handlers_for(
-        context: &brush_core::ExecutionContext<'_>,
-        signal_type: TrapSignal,
-    ) -> Result<(), brush_core::Error> {
-        if let Some(handler) = context.shell.traps.get_handler(signal_type) {
-            writeln!(context.stdout(), "trap -- '{handler}' {signal_type}")?;
-        }
-        Ok(())
-    }
+	fn display_handlers_for(
+		context: &brush_core::ExecutionContext<'_>,
+		signal_type: TrapSignal,
+	) -> Result<(), brush_core::Error> {
+		if let Some(handler) = context.shell.traps.get_handler(signal_type) {
+			writeln!(context.stdout(), "trap -- '{handler}' {signal_type}")?;
+		}
+		Ok(())
+	}
 
-    fn remove_all_handlers(context: &mut brush_core::ExecutionContext<'_>, signal: TrapSignal) {
-        context.shell.traps.remove_handlers(signal);
-    }
+	fn remove_all_handlers(context: &mut brush_core::ExecutionContext<'_>, signal: TrapSignal) {
+		context.shell.traps.remove_handlers(signal);
+	}
 
-    fn register_handler(
-        context: &mut brush_core::ExecutionContext<'_>,
-        signals: Vec<TrapSignal>,
-        handler: &str,
-    ) {
-        for signal in signals {
-            context
-                .shell
-                .traps
-                .register_handler(signal, handler.to_owned());
-        }
-    }
+	fn register_handler(
+		context: &mut brush_core::ExecutionContext<'_>,
+		signals: Vec<TrapSignal>,
+		handler: &str,
+	) {
+		for signal in signals {
+			context
+				.shell
+				.traps
+				.register_handler(signal, handler.to_owned());
+		}
+	}
 }

--- a/crates/brush-builtins-vendored/src/true_.rs
+++ b/crates/brush-builtins-vendored/src/true_.rs
@@ -7,12 +7,12 @@ use brush_core::{ExecutionResult, builtins};
 pub(crate) struct TrueCommand {}
 
 impl builtins::Command for TrueCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        _context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        Ok(ExecutionResult::success())
-    }
+	async fn execute(
+		&self,
+		_context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		Ok(ExecutionResult::success())
+	}
 }

--- a/crates/brush-builtins-vendored/src/type_.rs
+++ b/crates/brush-builtins-vendored/src/type_.rs
@@ -10,208 +10,202 @@ use brush_core::{ExecutionResult, Shell, builtins};
 /// Inspect the type of a named shell item.
 #[derive(Parser)]
 pub(crate) struct TypeCommand {
-    /// Display all locations of the specified name, not just the first.
-    #[arg(short = 'a')]
-    all_locations: bool,
+	/// Display all locations of the specified name, not just the first.
+	#[arg(short = 'a')]
+	all_locations: bool,
 
-    /// Don't consider functions when resolving the name.
-    #[arg(short = 'f')]
-    suppress_func_lookup: bool,
+	/// Don't consider functions when resolving the name.
+	#[arg(short = 'f')]
+	suppress_func_lookup: bool,
 
-    /// Force searching by file path, even if the name is an alias, built-in
-    /// command, or shell function.
-    #[arg(short = 'P')]
-    force_path_search: bool,
+	/// Force searching by file path, even if the name is an alias, built-in
+	/// command, or shell function.
+	#[arg(short = 'P')]
+	force_path_search: bool,
 
-    /// Show file path only.
-    #[arg(short = 'p')]
-    show_path_only: bool,
+	/// Show file path only.
+	#[arg(short = 'p')]
+	show_path_only: bool,
 
-    /// Only display the type of the specified name.
-    #[arg(short = 't')]
-    type_only: bool,
+	/// Only display the type of the specified name.
+	#[arg(short = 't')]
+	type_only: bool,
 
-    /// Names to search for.
-    names: Vec<String>,
+	/// Names to search for.
+	names: Vec<String>,
 }
 
 enum ResolvedType<'a> {
-    Alias(String),
-    Keyword,
-    Function(&'a ast::FunctionDefinition),
-    Builtin,
-    File { path: PathBuf, hashed: bool },
+	Alias(String),
+	Keyword,
+	Function(&'a ast::FunctionDefinition),
+	Builtin,
+	File { path: PathBuf, hashed: bool },
 }
 
 impl builtins::Command for TypeCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        let mut result = ExecutionResult::success();
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		let mut result = ExecutionResult::success();
 
-        for name in &self.names {
-            let resolved_types = self.resolve_types(context.shell, name);
+		for name in &self.names {
+			let resolved_types = self.resolve_types(context.shell, name);
 
-            if resolved_types.is_empty() {
-                if !self.type_only && !self.force_path_search && !self.show_path_only {
-                    writeln!(context.stderr(), "type: {name} not found")?;
-                }
+			if resolved_types.is_empty() {
+				if !self.type_only && !self.force_path_search && !self.show_path_only {
+					writeln!(context.stderr(), "type: {name} not found")?;
+				}
 
-                result = ExecutionResult::general_error();
-                continue;
-            }
+				result = ExecutionResult::general_error();
+				continue;
+			}
 
-            for resolved_type in resolved_types {
-                if self.show_path_only && !matches!(resolved_type, ResolvedType::File { .. }) {
-                    // Do nothing.
-                } else if self.type_only {
-                    match resolved_type {
-                        ResolvedType::Alias(_) => {
-                            writeln!(context.stdout(), "alias")?;
-                        }
-                        ResolvedType::Keyword => {
-                            writeln!(context.stdout(), "keyword")?;
-                        }
-                        ResolvedType::Function(_) => {
-                            writeln!(context.stdout(), "function")?;
-                        }
-                        ResolvedType::Builtin => {
-                            writeln!(context.stdout(), "builtin")?;
-                        }
-                        ResolvedType::File { path, .. } => {
-                            if self.show_path_only || self.force_path_search {
-                                writeln!(context.stdout(), "{}", path.to_string_lossy())?;
-                            } else {
-                                writeln!(context.stdout(), "file")?;
-                            }
-                        }
-                    }
-                } else {
-                    match resolved_type {
-                        ResolvedType::Alias(target) => {
-                            writeln!(context.stdout(), "{name} is aliased to '{target}'")?;
-                        }
-                        ResolvedType::Keyword => {
-                            writeln!(context.stdout(), "{name} is a shell keyword")?;
-                        }
-                        ResolvedType::Function(def) => {
-                            writeln!(context.stdout(), "{name} is a function")?;
-                            writeln!(context.stdout(), "{def}")?;
-                        }
-                        ResolvedType::Builtin => {
-                            writeln!(context.stdout(), "{name} is a shell builtin")?;
-                        }
-                        ResolvedType::File { path, hashed } => {
-                            if hashed && self.all_locations && !self.force_path_search {
-                                // Do nothing. When we're displaying all locations, then
-                                // we don't show hashed paths.
-                            } else if self.show_path_only || self.force_path_search {
-                                writeln!(context.stdout(), "{}", path.to_string_lossy())?;
-                            } else if hashed {
-                                writeln!(
-                                    context.stdout(),
-                                    "{name} is hashed ({path})",
-                                    name = name,
-                                    path = path.to_string_lossy()
-                                )?;
-                            } else {
-                                writeln!(
-                                    context.stdout(),
-                                    "{name} is {path}",
-                                    name = name,
-                                    path = path.to_string_lossy()
-                                )?;
-                            }
-                        }
-                    }
-                }
+			for resolved_type in resolved_types {
+				if self.show_path_only && !matches!(resolved_type, ResolvedType::File { .. }) {
+					// Do nothing.
+				} else if self.type_only {
+					match resolved_type {
+						ResolvedType::Alias(_) => {
+							writeln!(context.stdout(), "alias")?;
+						},
+						ResolvedType::Keyword => {
+							writeln!(context.stdout(), "keyword")?;
+						},
+						ResolvedType::Function(_) => {
+							writeln!(context.stdout(), "function")?;
+						},
+						ResolvedType::Builtin => {
+							writeln!(context.stdout(), "builtin")?;
+						},
+						ResolvedType::File { path, .. } => {
+							if self.show_path_only || self.force_path_search {
+								writeln!(context.stdout(), "{}", path.to_string_lossy())?;
+							} else {
+								writeln!(context.stdout(), "file")?;
+							}
+						},
+					}
+				} else {
+					match resolved_type {
+						ResolvedType::Alias(target) => {
+							writeln!(context.stdout(), "{name} is aliased to '{target}'")?;
+						},
+						ResolvedType::Keyword => {
+							writeln!(context.stdout(), "{name} is a shell keyword")?;
+						},
+						ResolvedType::Function(def) => {
+							writeln!(context.stdout(), "{name} is a function")?;
+							writeln!(context.stdout(), "{def}")?;
+						},
+						ResolvedType::Builtin => {
+							writeln!(context.stdout(), "{name} is a shell builtin")?;
+						},
+						ResolvedType::File { path, hashed } => {
+							if hashed && self.all_locations && !self.force_path_search {
+								// Do nothing. When we're displaying all locations, then
+								// we don't show hashed paths.
+							} else if self.show_path_only || self.force_path_search {
+								writeln!(context.stdout(), "{}", path.to_string_lossy())?;
+							} else if hashed {
+								writeln!(
+									context.stdout(),
+									"{name} is hashed ({path})",
+									name = name,
+									path = path.to_string_lossy()
+								)?;
+							} else {
+								writeln!(
+									context.stdout(),
+									"{name} is {path}",
+									name = name,
+									path = path.to_string_lossy()
+								)?;
+							}
+						},
+					}
+				}
 
-                // If we only want the first, then break after the first.
-                if !self.all_locations {
-                    break;
-                }
-            }
-        }
+				// If we only want the first, then break after the first.
+				if !self.all_locations {
+					break;
+				}
+			}
+		}
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 }
 
 impl TypeCommand {
-    fn resolve_types<'a>(&self, shell: &'a Shell, name: &str) -> Vec<ResolvedType<'a>> {
-        let mut types = vec![];
+	fn resolve_types<'a>(&self, shell: &'a Shell, name: &str) -> Vec<ResolvedType<'a>> {
+		let mut types = vec![];
 
-        if !self.force_path_search {
-            // Check for aliases.
-            if let Some(a) = shell.aliases.get(name) {
-                types.push(ResolvedType::Alias(a.clone()));
-                if !self.all_locations {
-                    return types;
-                }
-            }
+		if !self.force_path_search {
+			// Check for aliases.
+			if let Some(a) = shell.aliases.get(name) {
+				types.push(ResolvedType::Alias(a.clone()));
+				if !self.all_locations {
+					return types;
+				}
+			}
 
-            // Check for keywords.
-            if shell.is_keyword(name) {
-                types.push(ResolvedType::Keyword);
-                if !self.all_locations {
-                    return types;
-                }
-            }
+			// Check for keywords.
+			if shell.is_keyword(name) {
+				types.push(ResolvedType::Keyword);
+				if !self.all_locations {
+					return types;
+				}
+			}
 
-            // Check for functions.
-            if !self.suppress_func_lookup {
-                if let Some(registration) = shell.funcs().get(name) {
-                    types.push(ResolvedType::Function(registration.definition()));
-                    if !self.all_locations {
-                        return types;
-                    }
-                }
-            }
+			// Check for functions.
+			if !self.suppress_func_lookup {
+				if let Some(registration) = shell.funcs().get(name) {
+					types.push(ResolvedType::Function(registration.definition()));
+					if !self.all_locations {
+						return types;
+					}
+				}
+			}
 
-            // Check for builtins.
-            if shell.builtins().get(name).is_some_and(|b| !b.disabled) {
-                types.push(ResolvedType::Builtin);
-                if !self.all_locations {
-                    return types;
-                }
-            }
-        }
+			// Check for builtins.
+			if shell.builtins().get(name).is_some_and(|b| !b.disabled) {
+				types.push(ResolvedType::Builtin);
+				if !self.all_locations {
+					return types;
+				}
+			}
+		}
 
-        // Look in path.
-        if name.contains(std::path::MAIN_SEPARATOR) {
-            if shell.absolute_path(Path::new(name)).executable() {
-                types.push(ResolvedType::File {
-                    path: PathBuf::from(name),
-                    hashed: false,
-                });
+		// Look in path.
+		if name.contains(std::path::MAIN_SEPARATOR) {
+			if shell.absolute_path(Path::new(name)).executable() {
+				types.push(ResolvedType::File { path: PathBuf::from(name), hashed: false });
 
-                if !self.all_locations {
-                    return types;
-                }
-            }
-        } else {
-            if let Some(path) = shell.program_location_cache.get(name) {
-                types.push(ResolvedType::File { path, hashed: true });
-                if !self.all_locations {
-                    return types;
-                }
-            }
+				if !self.all_locations {
+					return types;
+				}
+			}
+		} else {
+			if let Some(path) = shell.program_location_cache.get(name) {
+				types.push(ResolvedType::File { path, hashed: true });
+				if !self.all_locations {
+					return types;
+				}
+			}
 
-            for item in shell.find_executables_in_path(name) {
-                types.push(ResolvedType::File {
-                    path: item,
-                    hashed: false,
-                });
+			for item in shell.find_executables_in_path(name) {
+				types.push(ResolvedType::File { path: item, hashed: false });
 
-                if !self.all_locations {
-                    return types;
-                }
-            }
-        }
+				if !self.all_locations {
+					return types;
+				}
+			}
+		}
 
-        types
-    }
+		types
+	}
 }

--- a/crates/brush-builtins-vendored/src/ulimit.rs
+++ b/crates/brush-builtins-vendored/src/ulimit.rs
@@ -1,349 +1,341 @@
 use clap::{
-    Parser,
-    builder::{IntoResettable, StyledStr},
+	Parser,
+	builder::{IntoResettable, StyledStr},
 };
 use std::{
-    io::{self, ErrorKind, Write},
-    str::FromStr,
+	io::{self, ErrorKind, Write},
+	str::FromStr,
 };
 
 use brush_core::{ExecutionResult, builtins};
 
 #[derive(Clone, Copy)]
 enum Unit {
-    Block,
-    Bytes,
-    HalfKBytes,
-    KBytes,
-    Micros,
-    Number,
-    Seconds,
+	Block,
+	Bytes,
+	HalfKBytes,
+	KBytes,
+	Micros,
+	Number,
+	Seconds,
 }
 
 impl Unit {
-    const fn scale(self) -> u64 {
-        match self {
-            Self::Block | Self::HalfKBytes => 512,
-            Self::KBytes => 1024,
-            _ => 1,
-        }
-    }
+	const fn scale(self) -> u64 {
+		match self {
+			Self::Block | Self::HalfKBytes => 512,
+			Self::KBytes => 1024,
+			_ => 1,
+		}
+	}
 }
 
 #[derive(Clone, Copy)]
 enum Virtual {
-    Pipe,
-    VMem,
+	Pipe,
+	VMem,
 }
 
 impl Virtual {
-    fn get(self) -> std::io::Result<(u64, u64)> {
-        match self {
-            Self::Pipe => {
-                let lim = nix::unistd::PathconfVar::PIPE_BUF as u64 * 512;
-                Ok((lim, lim))
-            }
-            Self::VMem => rlimit::Resource::AS
-                .get()
-                .or_else(|_| rlimit::Resource::VMEM.get()),
-        }
-    }
-    fn set(self, soft: u64, hard: u64) -> std::io::Result<()> {
-        match self {
-            Self::Pipe => Err(std::io::Error::from(ErrorKind::Unsupported)),
-            Self::VMem => rlimit::Resource::AS
-                .set(soft, hard)
-                .or_else(|_| rlimit::Resource::VMEM.set(soft, hard)),
-        }
-    }
-    const fn is_supported(self) -> bool {
-        match self {
-            Self::Pipe => true,
-            Self::VMem => {
-                rlimit::Resource::AS.is_supported() || rlimit::Resource::VMEM.is_supported()
-            }
-        }
-    }
+	fn get(self) -> std::io::Result<(u64, u64)> {
+		match self {
+			Self::Pipe => {
+				let lim = nix::unistd::PathconfVar::PIPE_BUF as u64 * 512;
+				Ok((lim, lim))
+			},
+			Self::VMem => rlimit::Resource::AS
+				.get()
+				.or_else(|_| rlimit::Resource::VMEM.get()),
+		}
+	}
+	fn set(self, soft: u64, hard: u64) -> std::io::Result<()> {
+		match self {
+			Self::Pipe => Err(std::io::Error::from(ErrorKind::Unsupported)),
+			Self::VMem => rlimit::Resource::AS
+				.set(soft, hard)
+				.or_else(|_| rlimit::Resource::VMEM.set(soft, hard)),
+		}
+	}
+	const fn is_supported(self) -> bool {
+		match self {
+			Self::Pipe => true,
+			Self::VMem => rlimit::Resource::AS.is_supported() || rlimit::Resource::VMEM.is_supported(),
+		}
+	}
 }
 
 #[derive(Clone, Copy)]
 enum Resource {
-    Phy(rlimit::Resource),
-    Virt(Virtual),
+	Phy(rlimit::Resource),
+	Virt(Virtual),
 }
 
 impl Resource {
-    fn get(self) -> std::io::Result<(u64, u64)> {
-        match self {
-            Self::Phy(res) => res.get(),
-            Self::Virt(res) => res.get(),
-        }
-    }
-    fn set(self, soft: u64, hard: u64) -> std::io::Result<()> {
-        match self {
-            Self::Phy(res) => res.set(soft, hard),
-            Self::Virt(res) => res.set(soft, hard),
-        }
-    }
-    const fn is_supported(self) -> bool {
-        match self {
-            Self::Phy(res) => res.is_supported(),
-            Self::Virt(res) => res.is_supported(),
-        }
-    }
+	fn get(self) -> std::io::Result<(u64, u64)> {
+		match self {
+			Self::Phy(res) => res.get(),
+			Self::Virt(res) => res.get(),
+		}
+	}
+	fn set(self, soft: u64, hard: u64) -> std::io::Result<()> {
+		match self {
+			Self::Phy(res) => res.set(soft, hard),
+			Self::Virt(res) => res.set(soft, hard),
+		}
+	}
+	const fn is_supported(self) -> bool {
+		match self {
+			Self::Phy(res) => res.is_supported(),
+			Self::Virt(res) => res.is_supported(),
+		}
+	}
 }
 
 #[derive(Clone, Copy)]
 struct ResourceDescription {
-    resource: Resource,
-    help: &'static str,
-    description: &'static str,
-    short: char,
-    unit: Unit,
+	resource: Resource,
+	help: &'static str,
+	description: &'static str,
+	short: char,
+	unit: Unit,
 }
 
 impl ResourceDescription {
-    const SBSIZE: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::SBSIZE),
-        help: "the socket buffer size",
-        description: "socket buffer size",
-        short: 'b',
-        unit: Unit::Bytes,
-    };
-    const CORE: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::CORE),
-        help: "the maximum size of core files created",
-        description: "core file size",
-        short: 'c',
-        unit: Unit::Block,
-    };
-    const DATA: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::DATA),
-        help: "the maximum size of a process's data segment",
-        description: "data seg size",
-        short: 'd',
-        unit: Unit::KBytes,
-    };
-    const NICE: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::NICE),
-        help: "the maximum scheduling priority (`nice`)",
-        description: "scheduling priority",
-        short: 'e',
-        unit: Unit::Number,
-    };
-    const FSIZE: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::FSIZE),
-        help: "the maximum size of files written by the shell and its children",
-        description: "file size",
-        short: 'f',
-        unit: Unit::Block,
-    };
-    const SIGPENDING: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::SIGPENDING),
-        help: "the maximum number of pending signals",
-        description: "pending signals",
-        short: 'i',
-        unit: Unit::Number,
-    };
-    const MEMLOCK: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::MEMLOCK),
-        help: "the maximum size a process may lock into memory",
-        description: "max locked memory",
-        short: 'l',
-        unit: Unit::KBytes,
-    };
-    const KQUEUES: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::KQUEUES),
-        help: "the maximum number of kqueues allocated for this process",
-        description: "max kqueues",
-        short: 'k',
-        unit: Unit::Number,
-    };
-    const RSS: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::RSS),
-        help: "the maximum resident set size",
-        description: "max memory size",
-        short: 'm',
-        unit: Unit::KBytes,
-    };
-    const LOCKS: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::LOCKS),
-        help: "the maximum number of file locks",
-        description: "file locks",
-        short: 'x',
-        unit: Unit::Number,
-    };
-    const NOFILE: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::NOFILE),
-        help: "the maximum number of open file descriptors",
-        description: "open files",
-        short: 'n',
-        unit: Unit::Number,
-    };
-    const MSGQUEUE: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::MSGQUEUE),
-        help: "the maximum number of bytes in POSIX message queues",
-        description: "POSIX message queues",
-        short: 'q',
-        unit: Unit::Bytes,
-    };
-    const PIPE: Self = Self {
-        resource: Resource::Virt(Virtual::Pipe),
-        help: "the pipe buffer size",
-        description: "pipe size",
-        short: 'p',
-        unit: Unit::HalfKBytes,
-    };
-    const RTPRIO: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::RTPRIO),
-        help: "the maximum real-time scheduling priority",
-        description: "real-time priority",
-        short: 'r',
-        unit: Unit::Number,
-    };
-    const RTTIME: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::RTTIME),
-        help: "the maximum real-time scheduling priority",
-        description: "real-time non-blocking time",
-        short: 'R',
-        unit: Unit::Micros,
-    };
-    const STACK: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::STACK),
-        help: "the maximum stack size",
-        description: "stack size",
-        short: 's',
-        unit: Unit::KBytes,
-    };
-    const CPU: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::CPU),
-        help: "the maximum amount of cpu time in seconds",
-        description: "cpu time",
-        short: 't',
-        unit: Unit::Seconds,
-    };
-    const NPROC: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::NPROC),
-        help: "the maximum number of user processes",
-        description: "max user processes",
-        short: 'u',
-        unit: Unit::Number,
-    };
-    const VMEM: Self = Self {
-        resource: Resource::Virt(Virtual::VMem),
-        help: "the size of virtual memory",
-        description: "virtual memory",
-        short: 'v',
-        unit: Unit::KBytes,
-    };
-    const THREADS: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::THREADS),
-        help: "the maximum number of threads",
-        description: "number of threads",
-        short: 'T',
-        unit: Unit::Number,
-    };
-    const NPTS: Self = Self {
-        resource: Resource::Phy(rlimit::Resource::NPTS),
-        help: "the maximum number of pseudoterminals",
-        description: "number of pseudoterminals",
-        short: 'P',
-        unit: Unit::Number,
-    };
+	const SBSIZE: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::SBSIZE),
+		help: "the socket buffer size",
+		description: "socket buffer size",
+		short: 'b',
+		unit: Unit::Bytes,
+	};
+	const CORE: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::CORE),
+		help: "the maximum size of core files created",
+		description: "core file size",
+		short: 'c',
+		unit: Unit::Block,
+	};
+	const DATA: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::DATA),
+		help: "the maximum size of a process's data segment",
+		description: "data seg size",
+		short: 'd',
+		unit: Unit::KBytes,
+	};
+	const NICE: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::NICE),
+		help: "the maximum scheduling priority (`nice`)",
+		description: "scheduling priority",
+		short: 'e',
+		unit: Unit::Number,
+	};
+	const FSIZE: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::FSIZE),
+		help: "the maximum size of files written by the shell and its children",
+		description: "file size",
+		short: 'f',
+		unit: Unit::Block,
+	};
+	const SIGPENDING: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::SIGPENDING),
+		help: "the maximum number of pending signals",
+		description: "pending signals",
+		short: 'i',
+		unit: Unit::Number,
+	};
+	const MEMLOCK: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::MEMLOCK),
+		help: "the maximum size a process may lock into memory",
+		description: "max locked memory",
+		short: 'l',
+		unit: Unit::KBytes,
+	};
+	const KQUEUES: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::KQUEUES),
+		help: "the maximum number of kqueues allocated for this process",
+		description: "max kqueues",
+		short: 'k',
+		unit: Unit::Number,
+	};
+	const RSS: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::RSS),
+		help: "the maximum resident set size",
+		description: "max memory size",
+		short: 'm',
+		unit: Unit::KBytes,
+	};
+	const LOCKS: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::LOCKS),
+		help: "the maximum number of file locks",
+		description: "file locks",
+		short: 'x',
+		unit: Unit::Number,
+	};
+	const NOFILE: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::NOFILE),
+		help: "the maximum number of open file descriptors",
+		description: "open files",
+		short: 'n',
+		unit: Unit::Number,
+	};
+	const MSGQUEUE: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::MSGQUEUE),
+		help: "the maximum number of bytes in POSIX message queues",
+		description: "POSIX message queues",
+		short: 'q',
+		unit: Unit::Bytes,
+	};
+	const PIPE: Self = Self {
+		resource: Resource::Virt(Virtual::Pipe),
+		help: "the pipe buffer size",
+		description: "pipe size",
+		short: 'p',
+		unit: Unit::HalfKBytes,
+	};
+	const RTPRIO: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::RTPRIO),
+		help: "the maximum real-time scheduling priority",
+		description: "real-time priority",
+		short: 'r',
+		unit: Unit::Number,
+	};
+	const RTTIME: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::RTTIME),
+		help: "the maximum real-time scheduling priority",
+		description: "real-time non-blocking time",
+		short: 'R',
+		unit: Unit::Micros,
+	};
+	const STACK: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::STACK),
+		help: "the maximum stack size",
+		description: "stack size",
+		short: 's',
+		unit: Unit::KBytes,
+	};
+	const CPU: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::CPU),
+		help: "the maximum amount of cpu time in seconds",
+		description: "cpu time",
+		short: 't',
+		unit: Unit::Seconds,
+	};
+	const NPROC: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::NPROC),
+		help: "the maximum number of user processes",
+		description: "max user processes",
+		short: 'u',
+		unit: Unit::Number,
+	};
+	const VMEM: Self = Self {
+		resource: Resource::Virt(Virtual::VMem),
+		help: "the size of virtual memory",
+		description: "virtual memory",
+		short: 'v',
+		unit: Unit::KBytes,
+	};
+	const THREADS: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::THREADS),
+		help: "the maximum number of threads",
+		description: "number of threads",
+		short: 'T',
+		unit: Unit::Number,
+	};
+	const NPTS: Self = Self {
+		resource: Resource::Phy(rlimit::Resource::NPTS),
+		help: "the maximum number of pseudoterminals",
+		description: "number of pseudoterminals",
+		short: 'P',
+		unit: Unit::Number,
+	};
 
-    fn get(&self, hard: bool) -> std::io::Result<String> {
-        let (soft_limit, hard_limit) = self.resource.get()?;
-        let val = if hard { hard_limit } else { soft_limit };
+	fn get(&self, hard: bool) -> std::io::Result<String> {
+		let (soft_limit, hard_limit) = self.resource.get()?;
+		let val = if hard { hard_limit } else { soft_limit };
 
-        if val == rlimit::INFINITY {
-            Ok("unlimited".into())
-        } else {
-            Ok(format!("{}", val / self.unit.scale()))
-        }
-    }
+		if val == rlimit::INFINITY {
+			Ok("unlimited".into())
+		} else {
+			Ok(format!("{}", val / self.unit.scale()))
+		}
+	}
 
-    fn set(&self, set_hard: bool, value: LimitValue) -> std::io::Result<()> {
-        let (soft, hard) = self.resource.get()?;
-        let value = match value {
-            LimitValue::Soft => soft,
-            LimitValue::Hard => hard,
-            LimitValue::Unlimited => rlimit::INFINITY,
-            LimitValue::Value(v) => v * self.unit.scale(),
-            LimitValue::Unset => return Ok(()),
-        };
+	fn set(&self, set_hard: bool, value: LimitValue) -> std::io::Result<()> {
+		let (soft, hard) = self.resource.get()?;
+		let value = match value {
+			LimitValue::Soft => soft,
+			LimitValue::Hard => hard,
+			LimitValue::Unlimited => rlimit::INFINITY,
+			LimitValue::Value(v) => v * self.unit.scale(),
+			LimitValue::Unset => return Ok(()),
+		};
 
-        if set_hard {
-            self.resource.set(soft, value)
-        } else {
-            self.resource.set(value, hard)
-        }
-    }
+		if set_hard {
+			self.resource.set(soft, value)
+		} else {
+			self.resource.set(value, hard)
+		}
+	}
 
-    /// Print either soft or hard limit
-    fn print(&self, context: &brush_core::ExecutionContext<'_>, hard: bool) -> io::Result<()> {
-        if !self.resource.is_supported() {
-            return Ok(());
-        }
-        let unit = match self.unit {
-            Unit::Block => format!("(block, -{})", self.short),
-            Unit::Bytes => format!("(bytes, -{})", self.short),
-            Unit::HalfKBytes => format!("(512 bytes, -{})", self.short),
-            Unit::KBytes => format!("(kbytes, -{})", self.short),
-            Unit::Micros => format!("(microseconds, -{})", self.short),
-            Unit::Number => format!("(-{})", self.short),
-            Unit::Seconds => format!("(seconds, -{})", self.short),
-        };
-        let resource = self.get(hard).unwrap_or_else(|e| format!("{e}"));
-        writeln!(
-            context.stdout(),
-            "{:<26}{:>16} {}",
-            self.description,
-            unit,
-            resource
-        )
-    }
+	/// Print either soft or hard limit
+	fn print(&self, context: &brush_core::ExecutionContext<'_>, hard: bool) -> io::Result<()> {
+		if !self.resource.is_supported() {
+			return Ok(());
+		}
+		let unit = match self.unit {
+			Unit::Block => format!("(block, -{})", self.short),
+			Unit::Bytes => format!("(bytes, -{})", self.short),
+			Unit::HalfKBytes => format!("(512 bytes, -{})", self.short),
+			Unit::KBytes => format!("(kbytes, -{})", self.short),
+			Unit::Micros => format!("(microseconds, -{})", self.short),
+			Unit::Number => format!("(-{})", self.short),
+			Unit::Seconds => format!("(seconds, -{})", self.short),
+		};
+		let resource = self.get(hard).unwrap_or_else(|e| format!("{e}"));
+		writeln!(context.stdout(), "{:<26}{:>16} {}", self.description, unit, resource)
+	}
 
-    /// Provide the matching help String
-    fn help(&self) -> String {
-        format!(
-            "{} {}",
-            self.help,
-            if self.resource.is_supported() {
-                "(supported)"
-            } else {
-                "(unsupported)"
-            }
-        )
-    }
+	/// Provide the matching help String
+	fn help(&self) -> String {
+		format!(
+			"{} {}",
+			self.help,
+			if self.resource.is_supported() {
+				"(supported)"
+			} else {
+				"(unsupported)"
+			}
+		)
+	}
 }
 
 impl IntoResettable<StyledStr> for ResourceDescription {
-    fn into_resettable(self) -> clap::builder::Resettable<StyledStr> {
-        clap::builder::Resettable::Value(self.help().into())
-    }
+	fn into_resettable(self) -> clap::builder::Resettable<StyledStr> {
+		clap::builder::Resettable::Value(self.help().into())
+	}
 }
 
 #[derive(Debug, Clone, Copy)]
 enum LimitValue {
-    Unset,
-    Unlimited,
-    Soft,
-    Hard,
-    Value(u64),
+	Unset,
+	Unlimited,
+	Soft,
+	Hard,
+	Value(u64),
 }
 
 impl FromStr for LimitValue {
-    type Err = <u64 as FromStr>::Err;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let v = match s {
-            "" => Self::Unset,
-            "unlimited" => Self::Unlimited,
-            "soft" => Self::Soft,
-            "hard" => Self::Hard,
-            _ => Self::Value(s.parse()?),
-        };
-        Ok(v)
-    }
+	type Err = <u64 as FromStr>::Err;
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		let v = match s {
+			"" => Self::Unset,
+			"unlimited" => Self::Unlimited,
+			"soft" => Self::Soft,
+			"hard" => Self::Hard,
+			_ => Self::Value(s.parse()?),
+		};
+		Ok(v)
+	}
 }
 
 /// Modify shell resource limits.
@@ -352,149 +344,149 @@ impl FromStr for LimitValue {
 /// it creates, on systems that allow such control.
 #[derive(Parser, Debug)]
 pub(crate) struct ULimitCommand {
-    /// use the `soft` resource limit
-    #[arg(short = 'S')]
-    soft: bool,
-    /// use the `hard` resource limit
-    #[arg(short = 'H')]
-    hard: bool,
-    /// all current limits are reported
-    #[arg(short = 'a')]
-    all: bool,
-    /// the maximum socket buffer size
-    #[arg(short = 'b', default_missing_value = "", num_args(0..=1), help = ResourceDescription::SBSIZE)]
-    sbsize: Option<LimitValue>,
-    /// the maximum size of core files created
-    #[arg(short = 'c', default_missing_value = "", num_args(0..=1), help = ResourceDescription::CORE)]
-    core: Option<LimitValue>,
-    /// the maximum size of a process's data segment
-    #[arg(short = 'd', default_missing_value = "", num_args(0..=1), help = ResourceDescription::DATA)]
-    data: Option<LimitValue>,
-    /// the maximum scheduling priority (`nice`)
-    #[arg(short = 'e', default_missing_value = "", num_args(0..=1), help = ResourceDescription::NICE)]
-    nice: Option<LimitValue>,
-    /// the maximum size of files written by the shell and its children
-    #[arg(short = 'f', default_missing_value = "", num_args(0..=1), help = ResourceDescription::FSIZE)]
-    file_size: Option<LimitValue>,
-    /// the maximum number of pending signals
-    #[arg(short = 'i', default_missing_value = "", num_args(0..=1), help = ResourceDescription::SIGPENDING)]
-    sigpending: Option<LimitValue>,
-    /// the maximum size a process may lock into memory
-    #[arg(short = 'l', default_missing_value = "", num_args(0..=1), help = ResourceDescription::MEMLOCK)]
-    memlock: Option<LimitValue>,
-    /// the maximum number of kqueues allocated for this process
-    #[arg(short = 'k', default_missing_value = "", num_args(0..=1), help = ResourceDescription::KQUEUES)]
-    kqueues: Option<LimitValue>,
-    /// the maximum resident set size
-    #[arg(short = 'm', default_missing_value = "", num_args(0..=1), help = ResourceDescription::RSS)]
-    rss: Option<LimitValue>,
-    /// the maximum number of open file descriptors
-    #[arg(short = 'n', default_missing_value = "", num_args(0..=1), help = ResourceDescription::NOFILE)]
-    file_open: Option<LimitValue>,
-    /// the pipe buffer size
-    #[arg(short = 'p', default_missing_value = "", num_args(0..=1), help = ResourceDescription::PIPE)]
-    pipe: Option<LimitValue>,
-    /// the maximum number of bytes in POSIX message queues
-    #[arg(short = 'q', default_missing_value = "", num_args(0..=1), help = ResourceDescription::MSGQUEUE)]
-    msgqueue: Option<LimitValue>,
-    /// the maximum real-time scheduling priority
-    #[arg(short = 'r', default_missing_value = "", num_args(0..=1), help = ResourceDescription::RTPRIO)]
-    rtprio: Option<LimitValue>,
-    /// the maximum stack size
-    #[arg(short = 's', default_missing_value = "", num_args(0..=1), help = ResourceDescription::STACK)]
-    stack: Option<LimitValue>,
-    /// the maximum amount of cpu time in seconds
-    #[arg(short = 't', default_missing_value = "", num_args(0..=1), help = ResourceDescription::CPU)]
-    cpu: Option<LimitValue>,
-    /// the size of virtual memory
-    #[arg(short = 'u', default_missing_value = "", num_args(0..=1), help = ResourceDescription::NPROC)]
-    nproc: Option<LimitValue>,
-    /// the size of virtual memory
-    #[arg(short = 'v', default_missing_value = "", num_args(0..=1), help = ResourceDescription::VMEM)]
-    vmem: Option<LimitValue>,
-    /// the maximum number of file locks
-    #[arg(short = 'x', default_missing_value = "", num_args(0..=1), help = ResourceDescription::LOCKS)]
-    file_lock: Option<LimitValue>,
-    /// the maximum number of pseudoterminals
-    #[arg(short = 'P', default_missing_value = "", num_args(0..=1), help = ResourceDescription::NPTS)]
-    npts: Option<LimitValue>,
-    /// real-time non-blocking time
-    #[arg(short = 'R', default_missing_value = "", num_args(0..=1), help = ResourceDescription::RTTIME)]
-    rttime: Option<LimitValue>,
-    /// the maximum number of threads
-    #[arg(short = 'T', default_missing_value = "", num_args(0..=1), help = ResourceDescription::THREADS)]
-    threads: Option<LimitValue>,
+	/// use the `soft` resource limit
+	#[arg(short = 'S')]
+	soft: bool,
+	/// use the `hard` resource limit
+	#[arg(short = 'H')]
+	hard: bool,
+	/// all current limits are reported
+	#[arg(short = 'a')]
+	all: bool,
+	/// the maximum socket buffer size
+	#[arg(short = 'b', default_missing_value = "", num_args(0..=1), help = ResourceDescription::SBSIZE)]
+	sbsize: Option<LimitValue>,
+	/// the maximum size of core files created
+	#[arg(short = 'c', default_missing_value = "", num_args(0..=1), help = ResourceDescription::CORE)]
+	core: Option<LimitValue>,
+	/// the maximum size of a process's data segment
+	#[arg(short = 'd', default_missing_value = "", num_args(0..=1), help = ResourceDescription::DATA)]
+	data: Option<LimitValue>,
+	/// the maximum scheduling priority (`nice`)
+	#[arg(short = 'e', default_missing_value = "", num_args(0..=1), help = ResourceDescription::NICE)]
+	nice: Option<LimitValue>,
+	/// the maximum size of files written by the shell and its children
+	#[arg(short = 'f', default_missing_value = "", num_args(0..=1), help = ResourceDescription::FSIZE)]
+	file_size: Option<LimitValue>,
+	/// the maximum number of pending signals
+	#[arg(short = 'i', default_missing_value = "", num_args(0..=1), help = ResourceDescription::SIGPENDING)]
+	sigpending: Option<LimitValue>,
+	/// the maximum size a process may lock into memory
+	#[arg(short = 'l', default_missing_value = "", num_args(0..=1), help = ResourceDescription::MEMLOCK)]
+	memlock: Option<LimitValue>,
+	/// the maximum number of kqueues allocated for this process
+	#[arg(short = 'k', default_missing_value = "", num_args(0..=1), help = ResourceDescription::KQUEUES)]
+	kqueues: Option<LimitValue>,
+	/// the maximum resident set size
+	#[arg(short = 'm', default_missing_value = "", num_args(0..=1), help = ResourceDescription::RSS)]
+	rss: Option<LimitValue>,
+	/// the maximum number of open file descriptors
+	#[arg(short = 'n', default_missing_value = "", num_args(0..=1), help = ResourceDescription::NOFILE)]
+	file_open: Option<LimitValue>,
+	/// the pipe buffer size
+	#[arg(short = 'p', default_missing_value = "", num_args(0..=1), help = ResourceDescription::PIPE)]
+	pipe: Option<LimitValue>,
+	/// the maximum number of bytes in POSIX message queues
+	#[arg(short = 'q', default_missing_value = "", num_args(0..=1), help = ResourceDescription::MSGQUEUE)]
+	msgqueue: Option<LimitValue>,
+	/// the maximum real-time scheduling priority
+	#[arg(short = 'r', default_missing_value = "", num_args(0..=1), help = ResourceDescription::RTPRIO)]
+	rtprio: Option<LimitValue>,
+	/// the maximum stack size
+	#[arg(short = 's', default_missing_value = "", num_args(0..=1), help = ResourceDescription::STACK)]
+	stack: Option<LimitValue>,
+	/// the maximum amount of cpu time in seconds
+	#[arg(short = 't', default_missing_value = "", num_args(0..=1), help = ResourceDescription::CPU)]
+	cpu: Option<LimitValue>,
+	/// the size of virtual memory
+	#[arg(short = 'u', default_missing_value = "", num_args(0..=1), help = ResourceDescription::NPROC)]
+	nproc: Option<LimitValue>,
+	/// the size of virtual memory
+	#[arg(short = 'v', default_missing_value = "", num_args(0..=1), help = ResourceDescription::VMEM)]
+	vmem: Option<LimitValue>,
+	/// the maximum number of file locks
+	#[arg(short = 'x', default_missing_value = "", num_args(0..=1), help = ResourceDescription::LOCKS)]
+	file_lock: Option<LimitValue>,
+	/// the maximum number of pseudoterminals
+	#[arg(short = 'P', default_missing_value = "", num_args(0..=1), help = ResourceDescription::NPTS)]
+	npts: Option<LimitValue>,
+	/// real-time non-blocking time
+	#[arg(short = 'R', default_missing_value = "", num_args(0..=1), help = ResourceDescription::RTTIME)]
+	rttime: Option<LimitValue>,
+	/// the maximum number of threads
+	#[arg(short = 'T', default_missing_value = "", num_args(0..=1), help = ResourceDescription::THREADS)]
+	threads: Option<LimitValue>,
 
-    /// argument for the implicit limit (`-f`)
-    limit: Option<LimitValue>,
+	/// argument for the implicit limit (`-f`)
+	limit: Option<LimitValue>,
 }
 
 impl builtins::Command for ULimitCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        let exit_code = ExecutionResult::success();
-        let mut resources_to_set = Vec::new();
-        let mut resources_to_get = Vec::new();
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		let exit_code = ExecutionResult::success();
+		let mut resources_to_set = Vec::new();
+		let mut resources_to_get = Vec::new();
 
-        let mut set_or_get = |val, descr| {
-            match val {
-                Some(LimitValue::Unset) => resources_to_get.push(descr),
-                Some(v) => resources_to_set.push((descr, v)),
-                None => {}
-            }
-            if self.all {
-                resources_to_get.push(descr);
-            }
-        };
+		let mut set_or_get = |val, descr| {
+			match val {
+				Some(LimitValue::Unset) => resources_to_get.push(descr),
+				Some(v) => resources_to_set.push((descr, v)),
+				None => {},
+			}
+			if self.all {
+				resources_to_get.push(descr);
+			}
+		};
 
-        set_or_get(self.sbsize, ResourceDescription::SBSIZE);
-        set_or_get(self.core, ResourceDescription::CORE);
-        set_or_get(self.data, ResourceDescription::DATA);
-        set_or_get(self.file_size, ResourceDescription::FSIZE);
-        set_or_get(self.sigpending, ResourceDescription::SIGPENDING);
-        set_or_get(self.kqueues, ResourceDescription::KQUEUES);
-        set_or_get(self.memlock, ResourceDescription::MEMLOCK);
-        set_or_get(self.rss, ResourceDescription::RSS);
-        set_or_get(self.file_lock, ResourceDescription::LOCKS);
-        set_or_get(self.file_open, ResourceDescription::NOFILE);
-        set_or_get(self.pipe, ResourceDescription::PIPE);
-        set_or_get(self.npts, ResourceDescription::NPTS);
-        set_or_get(self.nice, ResourceDescription::NICE);
-        set_or_get(self.msgqueue, ResourceDescription::MSGQUEUE);
-        set_or_get(self.rtprio, ResourceDescription::RTPRIO);
-        set_or_get(self.rttime, ResourceDescription::RTTIME);
-        set_or_get(self.stack, ResourceDescription::STACK);
-        set_or_get(self.threads, ResourceDescription::THREADS);
-        set_or_get(self.cpu, ResourceDescription::CPU);
-        set_or_get(self.nproc, ResourceDescription::NPROC);
-        set_or_get(self.vmem, ResourceDescription::VMEM);
+		set_or_get(self.sbsize, ResourceDescription::SBSIZE);
+		set_or_get(self.core, ResourceDescription::CORE);
+		set_or_get(self.data, ResourceDescription::DATA);
+		set_or_get(self.file_size, ResourceDescription::FSIZE);
+		set_or_get(self.sigpending, ResourceDescription::SIGPENDING);
+		set_or_get(self.kqueues, ResourceDescription::KQUEUES);
+		set_or_get(self.memlock, ResourceDescription::MEMLOCK);
+		set_or_get(self.rss, ResourceDescription::RSS);
+		set_or_get(self.file_lock, ResourceDescription::LOCKS);
+		set_or_get(self.file_open, ResourceDescription::NOFILE);
+		set_or_get(self.pipe, ResourceDescription::PIPE);
+		set_or_get(self.npts, ResourceDescription::NPTS);
+		set_or_get(self.nice, ResourceDescription::NICE);
+		set_or_get(self.msgqueue, ResourceDescription::MSGQUEUE);
+		set_or_get(self.rtprio, ResourceDescription::RTPRIO);
+		set_or_get(self.rttime, ResourceDescription::RTTIME);
+		set_or_get(self.stack, ResourceDescription::STACK);
+		set_or_get(self.threads, ResourceDescription::THREADS);
+		set_or_get(self.cpu, ResourceDescription::CPU);
+		set_or_get(self.nproc, ResourceDescription::NPROC);
+		set_or_get(self.vmem, ResourceDescription::VMEM);
 
-        if resources_to_set.is_empty() {
-            if resources_to_get.is_empty() {
-                if let Some(fsize) = self.limit {
-                    resources_to_set.push((ResourceDescription::FSIZE, fsize));
-                } else {
-                    resources_to_get.push(ResourceDescription::FSIZE);
-                }
-            }
-        }
+		if resources_to_set.is_empty() {
+			if resources_to_get.is_empty() {
+				if let Some(fsize) = self.limit {
+					resources_to_set.push((ResourceDescription::FSIZE, fsize));
+				} else {
+					resources_to_get.push(ResourceDescription::FSIZE);
+				}
+			}
+		}
 
-        for (resource, value) in resources_to_set {
-            resource.set(self.hard, value)?;
-        }
+		for (resource, value) in resources_to_set {
+			resource.set(self.hard, value)?;
+		}
 
-        if resources_to_get.len() == 1 {
-            writeln!(context.stdout(), "{}", resources_to_get[0].get(self.hard)?)?;
-        } else {
-            for resource in resources_to_get {
-                resource.print(&context, self.hard)?;
-            }
-        }
+		if resources_to_get.len() == 1 {
+			writeln!(context.stdout(), "{}", resources_to_get[0].get(self.hard)?)?;
+		} else {
+			for resource in resources_to_get {
+				resource.print(&context, self.hard)?;
+			}
+		}
 
-        Ok(exit_code)
-    }
+		Ok(exit_code)
+	}
 }

--- a/crates/brush-builtins-vendored/src/umask.rs
+++ b/crates/brush-builtins-vendored/src/umask.rs
@@ -8,90 +8,90 @@ use std::io::Write;
 /// Manage the process umask.
 #[derive(Parser)]
 pub(crate) struct UmaskCommand {
-    /// If MODE is omitted, output in a form that may be reused as input.
-    #[arg(short = 'p')]
-    print_roundtrippable: bool,
+	/// If MODE is omitted, output in a form that may be reused as input.
+	#[arg(short = 'p')]
+	print_roundtrippable: bool,
 
-    /// Makes the output symbolic; otherwise an octal number is given.
-    #[arg(short = 'S')]
-    symbolic_output: bool,
+	/// Makes the output symbolic; otherwise an octal number is given.
+	#[arg(short = 'S')]
+	symbolic_output: bool,
 
-    /// Mode mask.
-    mode: Option<String>,
+	/// Mode mask.
+	mode: Option<String>,
 }
 
 impl builtins::Command for UmaskCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        if let Some(mode) = &self.mode {
-            if mode.starts_with(|c: char| c.is_digit(8)) {
-                let parsed = nix::sys::stat::mode_t::from_str_radix(mode.as_str(), 8)?;
-                set_umask(parsed)?;
-            } else {
-                return brush_core::error::unimp("umask setting mode from symbolic value");
-            }
-        } else {
-            let umask = get_umask()?;
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		if let Some(mode) = &self.mode {
+			if mode.starts_with(|c: char| c.is_digit(8)) {
+				let parsed = nix::sys::stat::mode_t::from_str_radix(mode.as_str(), 8)?;
+				set_umask(parsed)?;
+			} else {
+				return brush_core::error::unimp("umask setting mode from symbolic value");
+			}
+		} else {
+			let umask = get_umask()?;
 
-            let formatted = if self.symbolic_output {
-                let u = symbolic_mask_from_bits((!umask & 0o700) >> 6);
-                let g = symbolic_mask_from_bits((!umask & 0o070) >> 3);
-                let o = symbolic_mask_from_bits(!umask & 0o007);
-                std::format!("u={u},g={g},o={o}")
-            } else {
-                std::format!("{umask:04o}")
-            };
+			let formatted = if self.symbolic_output {
+				let u = symbolic_mask_from_bits((!umask & 0o700) >> 6);
+				let g = symbolic_mask_from_bits((!umask & 0o070) >> 3);
+				let o = symbolic_mask_from_bits(!umask & 0o007);
+				std::format!("u={u},g={g},o={o}")
+			} else {
+				std::format!("{umask:04o}")
+			};
 
-            if self.print_roundtrippable {
-                writeln!(context.stdout(), "umask {formatted}")?;
-            } else {
-                writeln!(context.stdout(), "{formatted}")?;
-            }
-        }
+			if self.print_roundtrippable {
+				writeln!(context.stdout(), "umask {formatted}")?;
+			} else {
+				writeln!(context.stdout(), "{formatted}")?;
+			}
+		}
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }
 
 cfg_if! {
-    if #[cfg(target_os = "linux")] {
-        fn get_umask() -> Result<u32, brush_core::Error> {
-            let umask = procfs::process::Process::myself().ok().and_then(|me| me.status().ok()).and_then(|status| status.umask);
-            umask.ok_or_else(|| brush_core::ErrorKind::InvalidUmask.into())
-        }
-    } else {
-        #[expect(clippy::unnecessary_wraps)]
-        fn get_umask() -> Result<u32, brush_core::Error> {
-            let u = nix::sys::stat::umask(Mode::empty());
-            nix::sys::stat::umask(u);
-            Ok(u32::from(u.bits()))
-        }
-    }
+	 if #[cfg(target_os = "linux")] {
+		  fn get_umask() -> Result<u32, brush_core::Error> {
+				let umask = procfs::process::Process::myself().ok().and_then(|me| me.status().ok()).and_then(|status| status.umask);
+				umask.ok_or_else(|| brush_core::ErrorKind::InvalidUmask.into())
+		  }
+	 } else {
+		  #[expect(clippy::unnecessary_wraps)]
+		  fn get_umask() -> Result<u32, brush_core::Error> {
+				let u = nix::sys::stat::umask(Mode::empty());
+				nix::sys::stat::umask(u);
+				Ok(u32::from(u.bits()))
+		  }
+	 }
 }
 
 fn set_umask(value: nix::sys::stat::mode_t) -> Result<(), brush_core::Error> {
-    // value of mode_t can be platform dependent
-    let mode = nix::sys::stat::Mode::from_bits(value).ok_or_else(|| ErrorKind::InvalidUmask)?;
-    nix::sys::stat::umask(mode);
-    Ok(())
+	// value of mode_t can be platform dependent
+	let mode = nix::sys::stat::Mode::from_bits(value).ok_or_else(|| ErrorKind::InvalidUmask)?;
+	nix::sys::stat::umask(mode);
+	Ok(())
 }
 
 fn symbolic_mask_from_bits(bits: u32) -> String {
-    let mut result = String::new();
+	let mut result = String::new();
 
-    if (bits & 0b100) != 0 {
-        result.push('r');
-    }
-    if (bits & 0b010) != 0 {
-        result.push('w');
-    }
-    if (bits & 0b001) != 0 {
-        result.push('x');
-    }
+	if (bits & 0b100) != 0 {
+		result.push('r');
+	}
+	if (bits & 0b010) != 0 {
+		result.push('w');
+	}
+	if (bits & 0b001) != 0 {
+		result.push('x');
+	}
 
-    result
+	result
 }

--- a/crates/brush-builtins-vendored/src/unalias.rs
+++ b/crates/brush-builtins-vendored/src/unalias.rs
@@ -6,39 +6,34 @@ use brush_core::{ExecutionResult, builtins};
 /// Unset a shell alias.
 #[derive(Parser)]
 pub(crate) struct UnaliasCommand {
-    /// Remove all aliases.
-    #[arg(short = 'a')]
-    remove_all: bool,
+	/// Remove all aliases.
+	#[arg(short = 'a')]
+	remove_all: bool,
 
-    /// Names of aliases to operate on.
-    aliases: Vec<String>,
+	/// Names of aliases to operate on.
+	aliases: Vec<String>,
 }
 
 impl builtins::Command for UnaliasCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        let mut exit_code = ExecutionResult::success();
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		let mut exit_code = ExecutionResult::success();
 
-        if self.remove_all {
-            context.shell.aliases.clear();
-        } else {
-            for alias in &self.aliases {
-                if context.shell.aliases.remove(alias).is_none() {
-                    writeln!(
-                        context.stderr(),
-                        "{}: {}: not found",
-                        context.command_name,
-                        alias
-                    )?;
-                    exit_code = ExecutionResult::general_error();
-                }
-            }
-        }
+		if self.remove_all {
+			context.shell.aliases.clear();
+		} else {
+			for alias in &self.aliases {
+				if context.shell.aliases.remove(alias).is_none() {
+					writeln!(context.stderr(), "{}: {}: not found", context.command_name, alias)?;
+					exit_code = ExecutionResult::general_error();
+				}
+			}
+		}
 
-        Ok(exit_code)
-    }
+		Ok(exit_code)
+	}
 }

--- a/crates/brush-builtins-vendored/src/unimp.rs
+++ b/crates/brush-builtins-vendored/src/unimp.rs
@@ -5,31 +5,31 @@ use clap::Parser;
 /// (UNIMPLEMENTED COMMAND)
 #[derive(Parser)]
 pub(crate) struct UnimplementedCommand {
-    #[clap(allow_hyphen_values = true)]
-    args: Vec<String>,
+	#[clap(allow_hyphen_values = true)]
+	args: Vec<String>,
 
-    #[clap(skip)]
-    declarations: Vec<brush_core::CommandArg>,
+	#[clap(skip)]
+	declarations: Vec<brush_core::CommandArg>,
 }
 
 impl builtins::Command for UnimplementedCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        tracing::warn!(target: trace_categories::UNIMPLEMENTED,
-            "unimplemented built-in: {} {}",
-            context.command_name,
-            self.args.join(" ")
-        );
-        Ok(ExecutionExitCode::Unimplemented.into())
-    }
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		tracing::warn!(target: trace_categories::UNIMPLEMENTED,
+			 "unimplemented built-in: {} {}",
+			 context.command_name,
+			 self.args.join(" ")
+		);
+		Ok(ExecutionExitCode::Unimplemented.into())
+	}
 }
 
 impl builtins::DeclarationCommand for UnimplementedCommand {
-    fn set_declarations(&mut self, declarations: Vec<brush_core::CommandArg>) {
-        self.declarations = declarations;
-    }
+	fn set_declarations(&mut self, declarations: Vec<brush_core::CommandArg>) {
+		self.declarations = declarations;
+	}
 }

--- a/crates/brush-builtins-vendored/src/unset.rs
+++ b/crates/brush-builtins-vendored/src/unset.rs
@@ -7,116 +7,114 @@ use brush_core::{ExecutionResult, Shell, ShellValue, builtins, variables::ShellV
 /// Unset a variable.
 #[derive(Parser)]
 pub(crate) struct UnsetCommand {
-    #[clap(flatten)]
-    name_interpretation: UnsetNameInterpretation,
+	#[clap(flatten)]
+	name_interpretation: UnsetNameInterpretation,
 
-    /// Names of variables to unset.
-    names: Vec<String>,
+	/// Names of variables to unset.
+	names: Vec<String>,
 }
 
 #[derive(Parser)]
 #[clap(group = clap::ArgGroup::new("name-interpretation").multiple(false).required(false))]
 pub(crate) struct UnsetNameInterpretation {
-    /// Treat each name as a shell function.
-    #[arg(short = 'f', group = "name-interpretation")]
-    shell_functions: bool,
+	/// Treat each name as a shell function.
+	#[arg(short = 'f', group = "name-interpretation")]
+	shell_functions: bool,
 
-    /// Treat each name as a shell variable.
-    #[arg(short = 'v', group = "name-interpretation")]
-    shell_variables: bool,
+	/// Treat each name as a shell variable.
+	#[arg(short = 'v', group = "name-interpretation")]
+	shell_variables: bool,
 
-    /// Treat each name as a name reference.
-    #[arg(short = 'n', group = "name-interpretation")]
-    name_references: bool,
+	/// Treat each name as a name reference.
+	#[arg(short = 'n', group = "name-interpretation")]
+	name_references: bool,
 }
 
 impl UnsetNameInterpretation {
-    pub const fn unspecified(&self) -> bool {
-        !self.shell_functions && !self.shell_variables && !self.name_references
-    }
+	pub const fn unspecified(&self) -> bool {
+		!self.shell_functions && !self.shell_variables && !self.name_references
+	}
 }
 
 impl builtins::Command for UnsetCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<brush_core::ExecutionResult, Self::Error> {
-        //
-        // TODO: implement nameref
-        //
-        if self.name_interpretation.name_references {
-            return brush_core::error::unimp("unset: name references are not yet implemented");
-        }
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<brush_core::ExecutionResult, Self::Error> {
+		//
+		// TODO: implement nameref
+		//
+		if self.name_interpretation.name_references {
+			return brush_core::error::unimp("unset: name references are not yet implemented");
+		}
 
-        let unspecified = self.name_interpretation.unspecified();
+		let unspecified = self.name_interpretation.unspecified();
 
-        #[expect(clippy::needless_continue)]
-        for name in &self.names {
-            if unspecified || self.name_interpretation.shell_variables {
-                let parameter =
-                    brush_parser::word::parse_parameter(name, &context.shell.parser_options())?;
+		#[expect(clippy::needless_continue)]
+		for name in &self.names {
+			if unspecified || self.name_interpretation.shell_variables {
+				let parameter =
+					brush_parser::word::parse_parameter(name, &context.shell.parser_options())?;
 
-                let result = match parameter {
-                    brush_parser::word::Parameter::Positional(_) => continue,
-                    brush_parser::word::Parameter::Special(_) => continue,
-                    brush_parser::word::Parameter::Named(name) => {
-                        context.shell.env.unset(name.as_str())?.is_some()
-                    }
-                    brush_parser::word::Parameter::NamedWithIndex { name, index } => {
-                        unset_array_index(context.shell, name.as_str(), index.as_str())?
-                    }
-                    brush_parser::word::Parameter::NamedWithAllIndices {
-                        name: _,
-                        concatenate: _,
-                    } => continue,
-                };
+				let result = match parameter {
+					brush_parser::word::Parameter::Positional(_) => continue,
+					brush_parser::word::Parameter::Special(_) => continue,
+					brush_parser::word::Parameter::Named(name) => {
+						context.shell.env.unset(name.as_str())?.is_some()
+					},
+					brush_parser::word::Parameter::NamedWithIndex { name, index } => {
+						unset_array_index(context.shell, name.as_str(), index.as_str())?
+					},
+					brush_parser::word::Parameter::NamedWithAllIndices { name: _, concatenate: _ } => {
+						continue;
+					},
+				};
 
-                if result {
-                    continue;
-                }
-            }
+				if result {
+					continue;
+				}
+			}
 
-            // TODO: Deal with readonly functions
-            if unspecified || self.name_interpretation.shell_functions {
-                if context.shell.undefine_func(name) {
-                    continue;
-                }
-            }
-        }
+			// TODO: Deal with readonly functions
+			if unspecified || self.name_interpretation.shell_functions {
+				if context.shell.undefine_func(name) {
+					continue;
+				}
+			}
+		}
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }
 
 fn unset_array_index(
-    shell: &mut Shell,
-    name: &str,
-    index: &str,
+	shell: &mut Shell,
+	name: &str,
+	index: &str,
 ) -> Result<bool, brush_core::Error> {
-    // First check to see if it's an associative array.
-    let is_assoc_array = if let Some((_, var)) = shell.env.get(name) {
-        matches!(
-            var.value(),
-            ShellValue::AssociativeArray(_)
-                | ShellValue::Unset(ShellValueUnsetType::AssociativeArray)
-        )
-    } else {
-        false
-    };
+	// First check to see if it's an associative array.
+	let is_assoc_array = if let Some((_, var)) = shell.env.get(name) {
+		matches!(
+			var.value(),
+			ShellValue::AssociativeArray(_) | ShellValue::Unset(ShellValueUnsetType::AssociativeArray)
+		)
+	} else {
+		false
+	};
 
-    // Compute which index we should actually use. For indexed arrays, we need to evaluate
-    // the index string as an arithmetic expression first.
-    let index_to_use: Cow<'_, str> = if is_assoc_array {
-        index.into()
-    } else {
-        // First evaluate the index expression.
-        let index_as_expr = brush_parser::arithmetic::parse(index)?;
-        let evaluated_index = shell.eval_arithmetic(&index_as_expr)?;
-        evaluated_index.to_string().into()
-    };
+	// Compute which index we should actually use. For indexed arrays, we need to evaluate
+	// the index string as an arithmetic expression first.
+	let index_to_use: Cow<'_, str> = if is_assoc_array {
+		index.into()
+	} else {
+		// First evaluate the index expression.
+		let index_as_expr = brush_parser::arithmetic::parse(index)?;
+		let evaluated_index = shell.eval_arithmetic(&index_as_expr)?;
+		evaluated_index.to_string().into()
+	};
 
-    // Now we can try to unset, and return the result.
-    shell.env.unset_index(name, index_to_use.as_ref())
+	// Now we can try to unset, and return the result.
+	shell.env.unset_index(name, index_to_use.as_ref())
 }

--- a/crates/brush-builtins-vendored/src/wait.rs
+++ b/crates/brush-builtins-vendored/src/wait.rs
@@ -6,51 +6,51 @@ use brush_core::{ExecutionResult, builtins, error};
 /// Wait for jobs to terminate.
 #[derive(Parser)]
 pub(crate) struct WaitCommand {
-    /// Wait for specified job to terminate (instead of change status).
-    #[arg(short = 'f')]
-    wait_for_terminate: bool,
+	/// Wait for specified job to terminate (instead of change status).
+	#[arg(short = 'f')]
+	wait_for_terminate: bool,
 
-    /// Wait for a single job to change status; if jobs are specified, waits for
-    /// the first to change status, and otherwise waits for the next change.
-    #[arg(short = 'n')]
-    wait_for_first_or_next: bool,
+	/// Wait for a single job to change status; if jobs are specified, waits for
+	/// the first to change status, and otherwise waits for the next change.
+	#[arg(short = 'n')]
+	wait_for_first_or_next: bool,
 
-    /// Name of variable to receive the job ID of the job whose status is indicated.
-    #[arg(short = 'p', value_name = "VAR_NAME")]
-    variable_to_receive_id: Option<String>,
+	/// Name of variable to receive the job ID of the job whose status is indicated.
+	#[arg(short = 'p', value_name = "VAR_NAME")]
+	variable_to_receive_id: Option<String>,
 
-    /// Specs of jobs to wait for.
-    job_specs: Vec<String>,
+	/// Specs of jobs to wait for.
+	job_specs: Vec<String>,
 }
 
 impl builtins::Command for WaitCommand {
-    type Error = brush_core::Error;
+	type Error = brush_core::Error;
 
-    async fn execute(
-        &self,
-        context: brush_core::ExecutionContext<'_>,
-    ) -> Result<ExecutionResult, Self::Error> {
-        if self.wait_for_terminate {
-            return error::unimp("wait -f");
-        }
-        if self.wait_for_first_or_next {
-            return error::unimp("wait -n");
-        }
-        if self.variable_to_receive_id.is_some() {
-            return error::unimp("wait -p");
-        }
-        if !self.job_specs.is_empty() {
-            return error::unimp("wait with job specs");
-        }
+	async fn execute(
+		&self,
+		context: brush_core::ExecutionContext<'_>,
+	) -> Result<ExecutionResult, Self::Error> {
+		if self.wait_for_terminate {
+			return error::unimp("wait -f");
+		}
+		if self.wait_for_first_or_next {
+			return error::unimp("wait -n");
+		}
+		if self.variable_to_receive_id.is_some() {
+			return error::unimp("wait -p");
+		}
+		if !self.job_specs.is_empty() {
+			return error::unimp("wait with job specs");
+		}
 
-        let jobs = context.shell.jobs.wait_all().await?;
+		let jobs = context.shell.jobs.wait_all().await?;
 
-        if context.shell.options.enable_job_control {
-            for job in jobs {
-                writeln!(context.stdout(), "{job}")?;
-            }
-        }
+		if context.shell.options.enable_job_control {
+			for job in jobs {
+				writeln!(context.stdout(), "{job}")?;
+			}
+		}
 
-        Ok(ExecutionResult::success())
-    }
+		Ok(ExecutionResult::success())
+	}
 }

--- a/crates/brush-core-vendored/src/arithmetic.rs
+++ b/crates/brush-core-vendored/src/arithmetic.rs
@@ -8,64 +8,64 @@ use brush_parser::ast;
 /// Represents an error that occurs during evaluation of an arithmetic expression.
 #[derive(Debug, thiserror::Error)]
 pub enum EvalError {
-    /// Division by zero.
-    #[error("division by zero")]
-    DivideByZero,
+	/// Division by zero.
+	#[error("division by zero")]
+	DivideByZero,
 
-    /// Negative exponent.
-    #[error("exponent less than 0")]
-    NegativeExponent,
+	/// Negative exponent.
+	#[error("exponent less than 0")]
+	NegativeExponent,
 
-    /// Failed to tokenize an arithmetic expression.
-    #[error("failed to tokenize expression")]
-    FailedToTokenizeExpression,
+	/// Failed to tokenize an arithmetic expression.
+	#[error("failed to tokenize expression")]
+	FailedToTokenizeExpression,
 
-    /// Failed to expand an arithmetic expression.
-    #[error("failed to expand expression: '{0}'")]
-    FailedToExpandExpression(String),
+	/// Failed to expand an arithmetic expression.
+	#[error("failed to expand expression: '{0}'")]
+	FailedToExpandExpression(String),
 
-    /// Failed to access an element of an array.
-    #[error("failed to access array")]
-    FailedToAccessArray,
+	/// Failed to access an element of an array.
+	#[error("failed to access array")]
+	FailedToAccessArray,
 
-    /// Failed to update the shell environment in an assignment operator.
-    #[error("failed to update environment")]
-    FailedToUpdateEnvironment,
+	/// Failed to update the shell environment in an assignment operator.
+	#[error("failed to update environment")]
+	FailedToUpdateEnvironment,
 
-    /// Failed to parse an arithmetic expression.
-    #[error("failed to parse expression: '{0}'")]
-    ParseError(String),
+	/// Failed to parse an arithmetic expression.
+	#[error("failed to parse expression: '{0}'")]
+	ParseError(String),
 
-    /// Failed to trace an arithmetic expression.
-    #[error("failed tracing expression")]
-    TraceError,
+	/// Failed to trace an arithmetic expression.
+	#[error("failed tracing expression")]
+	TraceError,
 }
 
 /// Trait implemented by arithmetic expressions that can be evaluated.
 pub(crate) trait ExpandAndEvaluate {
-    /// Evaluate the given expression, returning the resulting numeric value.
-    ///
-    /// # Arguments
-    ///
-    /// * `shell` - The shell to use for evaluation.
-    /// * `trace_if_needed` - Whether to trace the evaluation.
-    async fn eval(
-        &self,
-        shell: &mut Shell,
-        params: &ExecutionParameters,
-        trace_if_needed: bool,
-    ) -> Result<i64, EvalError>;
+	/// Evaluate the given expression, returning the resulting numeric value.
+	///
+	/// # Arguments
+	///
+	/// * `shell` - The shell to use for evaluation.
+	/// * `trace_if_needed` - Whether to trace the evaluation.
+	async fn eval(
+		&self,
+		shell: &mut Shell,
+		params: &ExecutionParameters,
+		trace_if_needed: bool,
+	) -> Result<i64, EvalError>;
 }
 
 impl ExpandAndEvaluate for ast::UnexpandedArithmeticExpr {
-    async fn eval(
-        &self,
-        shell: &mut Shell,
-        params: &ExecutionParameters,
-        trace_if_needed: bool,
-    ) -> Result<i64, EvalError> {
-        expand_and_eval(shell, params, self.value.as_str(), trace_if_needed).await
-    }
+	async fn eval(
+		&self,
+		shell: &mut Shell,
+		params: &ExecutionParameters,
+		trace_if_needed: bool,
+	) -> Result<i64, EvalError> {
+		expand_and_eval(shell, params, self.value.as_str(), trace_if_needed).await
+	}
 }
 
 /// Evaluate the given arithmetic expression, returning the resulting numeric value.
@@ -76,276 +76,273 @@ impl ExpandAndEvaluate for ast::UnexpandedArithmeticExpr {
 /// * `expr` - The unexpanded arithmetic expression to evaluate.
 /// * `trace_if_needed` - Whether to trace the evaluation.
 pub(crate) async fn expand_and_eval(
-    shell: &mut Shell,
-    params: &ExecutionParameters,
-    expr: &str,
-    trace_if_needed: bool,
+	shell: &mut Shell,
+	params: &ExecutionParameters,
+	expr: &str,
+	trace_if_needed: bool,
 ) -> Result<i64, EvalError> {
-    // Per documentation, first shell-expand it.
-    let expanded_self = expansion::basic_expand_str_without_tilde(shell, params, expr)
-        .await
-        .map_err(|_e| EvalError::FailedToExpandExpression(expr.to_owned()))?;
+	// Per documentation, first shell-expand it.
+	let expanded_self = expansion::basic_expand_str_without_tilde(shell, params, expr)
+		.await
+		.map_err(|_e| EvalError::FailedToExpandExpression(expr.to_owned()))?;
 
-    // Now parse.
-    let expr = brush_parser::arithmetic::parse(&expanded_self)
-        .map_err(|_e| EvalError::ParseError(expanded_self))?;
+	// Now parse.
+	let expr = brush_parser::arithmetic::parse(&expanded_self)
+		.map_err(|_e| EvalError::ParseError(expanded_self))?;
 
-    // Trace if applicable.
-    if trace_if_needed && shell.options.print_commands_and_arguments {
-        shell
-            .trace_command(params, std::format!("(( {expr} ))"))
-            .await
-            .map_err(|_err| EvalError::TraceError)?;
-    }
+	// Trace if applicable.
+	if trace_if_needed && shell.options.print_commands_and_arguments {
+		shell
+			.trace_command(params, std::format!("(( {expr} ))"))
+			.await
+			.map_err(|_err| EvalError::TraceError)?;
+	}
 
-    // Now evaluate.
-    expr.eval(shell)
+	// Now evaluate.
+	expr.eval(shell)
 }
 
 /// Trait implemented by evaluatable arithmetic expressions.
 pub trait Evaluatable {
-    /// Evaluate the given arithmetic expression, returning the resulting numeric value.
-    ///
-    /// # Arguments
-    ///
-    /// * `shell` - The shell to use for evaluation.
-    fn eval(&self, shell: &mut Shell) -> Result<i64, EvalError>;
+	/// Evaluate the given arithmetic expression, returning the resulting numeric value.
+	///
+	/// # Arguments
+	///
+	/// * `shell` - The shell to use for evaluation.
+	fn eval(&self, shell: &mut Shell) -> Result<i64, EvalError>;
 }
 
 impl Evaluatable for ast::ArithmeticExpr {
-    fn eval(&self, shell: &mut Shell) -> Result<i64, EvalError> {
-        let value = match self {
-            Self::Literal(l) => *l,
-            Self::Reference(lvalue) => deref_lvalue(shell, lvalue)?,
-            Self::UnaryOp(op, operand) => apply_unary_op(shell, *op, operand)?,
-            Self::BinaryOp(op, left, right) => apply_binary_op(shell, *op, left, right)?,
-            Self::Conditional(condition, then_expr, else_expr) => {
-                let conditional_eval = condition.eval(shell)?;
+	fn eval(&self, shell: &mut Shell) -> Result<i64, EvalError> {
+		let value = match self {
+			Self::Literal(l) => *l,
+			Self::Reference(lvalue) => deref_lvalue(shell, lvalue)?,
+			Self::UnaryOp(op, operand) => apply_unary_op(shell, *op, operand)?,
+			Self::BinaryOp(op, left, right) => apply_binary_op(shell, *op, left, right)?,
+			Self::Conditional(condition, then_expr, else_expr) => {
+				let conditional_eval = condition.eval(shell)?;
 
-                // Ensure we only evaluate the branch indicated by the condition.
-                if conditional_eval != 0 {
-                    then_expr.eval(shell)?
-                } else {
-                    else_expr.eval(shell)?
-                }
-            }
-            Self::Assignment(lvalue, expr) => {
-                let expr_eval = expr.eval(shell)?;
-                assign(shell, lvalue, expr_eval)?
-            }
-            Self::UnaryAssignment(op, lvalue) => apply_unary_assignment_op(shell, lvalue, *op)?,
-            Self::BinaryAssignment(op, lvalue, operand) => {
-                let value = apply_binary_op(shell, *op, &Self::Reference(lvalue.clone()), operand)?;
-                assign(shell, lvalue, value)?
-            }
-        };
+				// Ensure we only evaluate the branch indicated by the condition.
+				if conditional_eval != 0 {
+					then_expr.eval(shell)?
+				} else {
+					else_expr.eval(shell)?
+				}
+			},
+			Self::Assignment(lvalue, expr) => {
+				let expr_eval = expr.eval(shell)?;
+				assign(shell, lvalue, expr_eval)?
+			},
+			Self::UnaryAssignment(op, lvalue) => apply_unary_assignment_op(shell, lvalue, *op)?,
+			Self::BinaryAssignment(op, lvalue, operand) => {
+				let value = apply_binary_op(shell, *op, &Self::Reference(lvalue.clone()), operand)?;
+				assign(shell, lvalue, value)?
+			},
+		};
 
-        Ok(value)
-    }
+		Ok(value)
+	}
 }
 
 fn deref_lvalue(shell: &mut Shell, lvalue: &ast::ArithmeticTarget) -> Result<i64, EvalError> {
-    let value_str: Cow<'_, str> = match lvalue {
-        ast::ArithmeticTarget::Variable(name) => shell.env_str(name).unwrap_or(Cow::Borrowed("")),
-        ast::ArithmeticTarget::ArrayElement(name, index_expr) => {
-            let index_str = index_expr.eval(shell)?.to_string();
+	let value_str: Cow<'_, str> = match lvalue {
+		ast::ArithmeticTarget::Variable(name) => shell.env_str(name).unwrap_or(Cow::Borrowed("")),
+		ast::ArithmeticTarget::ArrayElement(name, index_expr) => {
+			let index_str = index_expr.eval(shell)?.to_string();
 
-            shell
-                .env
-                .get(name)
-                .map_or_else(
-                    || Ok(None),
-                    |(_, v)| v.value().get_at(index_str.as_str(), shell),
-                )
-                .map_err(|_err| EvalError::FailedToAccessArray)?
-                .unwrap_or(Cow::Borrowed(""))
-        }
-    };
+			shell
+				.env
+				.get(name)
+				.map_or_else(|| Ok(None), |(_, v)| v.value().get_at(index_str.as_str(), shell))
+				.map_err(|_err| EvalError::FailedToAccessArray)?
+				.unwrap_or(Cow::Borrowed(""))
+		},
+	};
 
-    let parsed_value = brush_parser::arithmetic::parse(value_str.as_ref())
-        .map_err(|_err| EvalError::ParseError(value_str.to_string()))?;
+	let parsed_value = brush_parser::arithmetic::parse(value_str.as_ref())
+		.map_err(|_err| EvalError::ParseError(value_str.to_string()))?;
 
-    parsed_value.eval(shell)
+	parsed_value.eval(shell)
 }
 
 fn apply_unary_op(
-    shell: &mut Shell,
-    op: ast::UnaryOperator,
-    operand: &ast::ArithmeticExpr,
+	shell: &mut Shell,
+	op: ast::UnaryOperator,
+	operand: &ast::ArithmeticExpr,
 ) -> Result<i64, EvalError> {
-    let operand_eval = operand.eval(shell)?;
+	let operand_eval = operand.eval(shell)?;
 
-    match op {
-        ast::UnaryOperator::UnaryPlus => Ok(operand_eval),
-        ast::UnaryOperator::UnaryMinus => Ok(-operand_eval),
-        ast::UnaryOperator::BitwiseNot => Ok(!operand_eval),
-        ast::UnaryOperator::LogicalNot => Ok(bool_to_i64(operand_eval == 0)),
-    }
+	match op {
+		ast::UnaryOperator::UnaryPlus => Ok(operand_eval),
+		ast::UnaryOperator::UnaryMinus => Ok(-operand_eval),
+		ast::UnaryOperator::BitwiseNot => Ok(!operand_eval),
+		ast::UnaryOperator::LogicalNot => Ok(bool_to_i64(operand_eval == 0)),
+	}
 }
 
 fn apply_binary_op(
-    shell: &mut Shell,
-    op: ast::BinaryOperator,
-    left: &ast::ArithmeticExpr,
-    right: &ast::ArithmeticExpr,
+	shell: &mut Shell,
+	op: ast::BinaryOperator,
+	left: &ast::ArithmeticExpr,
+	right: &ast::ArithmeticExpr,
 ) -> Result<i64, EvalError> {
-    // First, special-case short-circuiting operators. For those, we need
-    // to ensure we don't eagerly evaluate both operands. After we
-    // get these out of the way, we can easily just evaluate operands
-    // for the other operators.
-    match op {
-        ast::BinaryOperator::LogicalAnd => {
-            let left = left.eval(shell)?;
-            if left == 0 {
-                return Ok(bool_to_i64(false));
-            }
+	// First, special-case short-circuiting operators. For those, we need
+	// to ensure we don't eagerly evaluate both operands. After we
+	// get these out of the way, we can easily just evaluate operands
+	// for the other operators.
+	match op {
+		ast::BinaryOperator::LogicalAnd => {
+			let left = left.eval(shell)?;
+			if left == 0 {
+				return Ok(bool_to_i64(false));
+			}
 
-            let right = right.eval(shell)?;
-            return Ok(bool_to_i64(right != 0));
-        }
-        ast::BinaryOperator::LogicalOr => {
-            let left = left.eval(shell)?;
-            if left != 0 {
-                return Ok(bool_to_i64(true));
-            }
+			let right = right.eval(shell)?;
+			return Ok(bool_to_i64(right != 0));
+		},
+		ast::BinaryOperator::LogicalOr => {
+			let left = left.eval(shell)?;
+			if left != 0 {
+				return Ok(bool_to_i64(true));
+			}
 
-            let right = right.eval(shell)?;
-            return Ok(bool_to_i64(right != 0));
-        }
-        _ => (),
-    }
+			let right = right.eval(shell)?;
+			return Ok(bool_to_i64(right != 0));
+		},
+		_ => (),
+	}
 
-    // The remaining operators unconditionally operate both operands.
-    let left = left.eval(shell)?;
-    let right = right.eval(shell)?;
+	// The remaining operators unconditionally operate both operands.
+	let left = left.eval(shell)?;
+	let right = right.eval(shell)?;
 
-    #[expect(clippy::cast_possible_truncation)]
-    #[expect(clippy::cast_sign_loss)]
-    match op {
-        ast::BinaryOperator::Power => {
-            if right >= 0 {
-                Ok(wrapping_pow_u64(left, right as u64))
-            } else {
-                Err(EvalError::NegativeExponent)
-            }
-        }
-        ast::BinaryOperator::Multiply => Ok(left.wrapping_mul(right)),
-        ast::BinaryOperator::Divide => {
-            if right == 0 {
-                Err(EvalError::DivideByZero)
-            } else {
-                Ok(left.wrapping_div(right))
-            }
-        }
-        ast::BinaryOperator::Modulo => {
-            if right == 0 {
-                Err(EvalError::DivideByZero)
-            } else {
-                Ok(left % right)
-            }
-        }
-        ast::BinaryOperator::Comma => Ok(right),
-        ast::BinaryOperator::Add => Ok(left.wrapping_add(right)),
-        ast::BinaryOperator::Subtract => Ok(left.wrapping_sub(right)),
-        ast::BinaryOperator::ShiftLeft => Ok(left.wrapping_shl(right as u32)),
-        ast::BinaryOperator::ShiftRight => Ok(left.wrapping_shr(right as u32)),
-        ast::BinaryOperator::LessThan => Ok(bool_to_i64(left < right)),
-        ast::BinaryOperator::LessThanOrEqualTo => Ok(bool_to_i64(left <= right)),
-        ast::BinaryOperator::GreaterThan => Ok(bool_to_i64(left > right)),
-        ast::BinaryOperator::GreaterThanOrEqualTo => Ok(bool_to_i64(left >= right)),
-        ast::BinaryOperator::Equals => Ok(bool_to_i64(left == right)),
-        ast::BinaryOperator::NotEquals => Ok(bool_to_i64(left != right)),
-        ast::BinaryOperator::BitwiseAnd => Ok(left & right),
-        ast::BinaryOperator::BitwiseXor => Ok(left ^ right),
-        ast::BinaryOperator::BitwiseOr => Ok(left | right),
-        ast::BinaryOperator::LogicalAnd => unreachable!("LogicalAnd covered above"),
-        ast::BinaryOperator::LogicalOr => unreachable!("LogicalOr covered above"),
-    }
+	#[expect(clippy::cast_possible_truncation)]
+	#[expect(clippy::cast_sign_loss)]
+	match op {
+		ast::BinaryOperator::Power => {
+			if right >= 0 {
+				Ok(wrapping_pow_u64(left, right as u64))
+			} else {
+				Err(EvalError::NegativeExponent)
+			}
+		},
+		ast::BinaryOperator::Multiply => Ok(left.wrapping_mul(right)),
+		ast::BinaryOperator::Divide => {
+			if right == 0 {
+				Err(EvalError::DivideByZero)
+			} else {
+				Ok(left.wrapping_div(right))
+			}
+		},
+		ast::BinaryOperator::Modulo => {
+			if right == 0 {
+				Err(EvalError::DivideByZero)
+			} else {
+				Ok(left % right)
+			}
+		},
+		ast::BinaryOperator::Comma => Ok(right),
+		ast::BinaryOperator::Add => Ok(left.wrapping_add(right)),
+		ast::BinaryOperator::Subtract => Ok(left.wrapping_sub(right)),
+		ast::BinaryOperator::ShiftLeft => Ok(left.wrapping_shl(right as u32)),
+		ast::BinaryOperator::ShiftRight => Ok(left.wrapping_shr(right as u32)),
+		ast::BinaryOperator::LessThan => Ok(bool_to_i64(left < right)),
+		ast::BinaryOperator::LessThanOrEqualTo => Ok(bool_to_i64(left <= right)),
+		ast::BinaryOperator::GreaterThan => Ok(bool_to_i64(left > right)),
+		ast::BinaryOperator::GreaterThanOrEqualTo => Ok(bool_to_i64(left >= right)),
+		ast::BinaryOperator::Equals => Ok(bool_to_i64(left == right)),
+		ast::BinaryOperator::NotEquals => Ok(bool_to_i64(left != right)),
+		ast::BinaryOperator::BitwiseAnd => Ok(left & right),
+		ast::BinaryOperator::BitwiseXor => Ok(left ^ right),
+		ast::BinaryOperator::BitwiseOr => Ok(left | right),
+		ast::BinaryOperator::LogicalAnd => unreachable!("LogicalAnd covered above"),
+		ast::BinaryOperator::LogicalOr => unreachable!("LogicalOr covered above"),
+	}
 }
 
 fn apply_unary_assignment_op(
-    shell: &mut Shell,
-    lvalue: &ast::ArithmeticTarget,
-    op: ast::UnaryAssignmentOperator,
+	shell: &mut Shell,
+	lvalue: &ast::ArithmeticTarget,
+	op: ast::UnaryAssignmentOperator,
 ) -> Result<i64, EvalError> {
-    let value = deref_lvalue(shell, lvalue)?;
+	let value = deref_lvalue(shell, lvalue)?;
 
-    match op {
-        ast::UnaryAssignmentOperator::PrefixIncrement => {
-            let new_value = value + 1;
-            assign(shell, lvalue, new_value)?;
-            Ok(new_value)
-        }
-        ast::UnaryAssignmentOperator::PrefixDecrement => {
-            let new_value = value - 1;
-            assign(shell, lvalue, new_value)?;
-            Ok(new_value)
-        }
-        ast::UnaryAssignmentOperator::PostfixIncrement => {
-            let new_value = value + 1;
-            assign(shell, lvalue, new_value)?;
-            Ok(value)
-        }
-        ast::UnaryAssignmentOperator::PostfixDecrement => {
-            let new_value = value - 1;
-            assign(shell, lvalue, new_value)?;
-            Ok(value)
-        }
-    }
+	match op {
+		ast::UnaryAssignmentOperator::PrefixIncrement => {
+			let new_value = value + 1;
+			assign(shell, lvalue, new_value)?;
+			Ok(new_value)
+		},
+		ast::UnaryAssignmentOperator::PrefixDecrement => {
+			let new_value = value - 1;
+			assign(shell, lvalue, new_value)?;
+			Ok(new_value)
+		},
+		ast::UnaryAssignmentOperator::PostfixIncrement => {
+			let new_value = value + 1;
+			assign(shell, lvalue, new_value)?;
+			Ok(value)
+		},
+		ast::UnaryAssignmentOperator::PostfixDecrement => {
+			let new_value = value - 1;
+			assign(shell, lvalue, new_value)?;
+			Ok(value)
+		},
+	}
 }
 
 fn assign(shell: &mut Shell, lvalue: &ast::ArithmeticTarget, value: i64) -> Result<i64, EvalError> {
-    match lvalue {
-        ast::ArithmeticTarget::Variable(name) => {
-            shell
-                .env
-                .update_or_add(
-                    name.as_str(),
-                    variables::ShellValueLiteral::Scalar(value.to_string()),
-                    |_| Ok(()),
-                    env::EnvironmentLookup::Anywhere,
-                    env::EnvironmentScope::Global,
-                )
-                .map_err(|_err| EvalError::FailedToUpdateEnvironment)?;
-        }
-        ast::ArithmeticTarget::ArrayElement(name, index_expr) => {
-            let index_str = index_expr.eval(shell)?.to_string();
+	match lvalue {
+		ast::ArithmeticTarget::Variable(name) => {
+			shell
+				.env
+				.update_or_add(
+					name.as_str(),
+					variables::ShellValueLiteral::Scalar(value.to_string()),
+					|_| Ok(()),
+					env::EnvironmentLookup::Anywhere,
+					env::EnvironmentScope::Global,
+				)
+				.map_err(|_err| EvalError::FailedToUpdateEnvironment)?;
+		},
+		ast::ArithmeticTarget::ArrayElement(name, index_expr) => {
+			let index_str = index_expr.eval(shell)?.to_string();
 
-            shell
-                .env
-                .update_or_add_array_element(
-                    name.as_str(),
-                    index_str,
-                    value.to_string(),
-                    |_| Ok(()),
-                    env::EnvironmentLookup::Anywhere,
-                    env::EnvironmentScope::Global,
-                )
-                .map_err(|_err| EvalError::FailedToUpdateEnvironment)?;
-        }
-    }
+			shell
+				.env
+				.update_or_add_array_element(
+					name.as_str(),
+					index_str,
+					value.to_string(),
+					|_| Ok(()),
+					env::EnvironmentLookup::Anywhere,
+					env::EnvironmentScope::Global,
+				)
+				.map_err(|_err| EvalError::FailedToUpdateEnvironment)?;
+		},
+	}
 
-    Ok(value)
+	Ok(value)
 }
 
 const fn bool_to_i64(value: bool) -> i64 {
-    if value { 1 } else { 0 }
+	if value { 1 } else { 0 }
 }
 
 // N.B. We implement our own version of wrapping_pow that takes a 64-bit exponent.
 // This seems to be the best way to guarantee that we handle overflow cases
 // with exponents correctly.
 const fn wrapping_pow_u64(mut base: i64, mut exponent: u64) -> i64 {
-    let mut result: i64 = 1;
+	let mut result: i64 = 1;
 
-    while exponent > 0 {
-        if exponent % 2 == 1 {
-            result = result.wrapping_mul(base);
-        }
+	while exponent > 0 {
+		if exponent % 2 == 1 {
+			result = result.wrapping_mul(base);
+		}
 
-        base = base.wrapping_mul(base);
-        exponent /= 2;
-    }
+		base = base.wrapping_mul(base);
+		exponent /= 2;
+	}
 
-    result
+	result
 }

--- a/crates/brush-core-vendored/src/braceexpansion.rs
+++ b/crates/brush-core-vendored/src/braceexpansion.rs
@@ -2,79 +2,71 @@ use brush_parser::word;
 use itertools::Itertools;
 
 pub(crate) fn generate_and_combine_brace_expansions(
-    pieces: Vec<brush_parser::word::BraceExpressionOrText>,
+	pieces: Vec<brush_parser::word::BraceExpressionOrText>,
 ) -> impl IntoIterator<Item = String> {
-    let expansions: Vec<Vec<String>> = pieces
-        .into_iter()
-        .map(|piece| expand_brace_expr_or_text(piece).collect())
-        .collect();
+	let expansions: Vec<Vec<String>> = pieces
+		.into_iter()
+		.map(|piece| expand_brace_expr_or_text(piece).collect())
+		.collect();
 
-    expansions
-        .into_iter()
-        .multi_cartesian_product()
-        .map(|v| v.join(""))
+	expansions
+		.into_iter()
+		.multi_cartesian_product()
+		.map(|v| v.join(""))
 }
 
 fn expand_brace_expr_or_text(
-    beot: word::BraceExpressionOrText,
+	beot: word::BraceExpressionOrText,
 ) -> Box<dyn Iterator<Item = String>> {
-    match beot {
-        word::BraceExpressionOrText::Expr(members) => {
-            // Chain all member iterators together
-            Box::new(members.into_iter().flat_map(expand_brace_expr_member))
-        }
-        word::BraceExpressionOrText::Text(text) => Box::new(std::iter::once(text)),
-    }
+	match beot {
+		word::BraceExpressionOrText::Expr(members) => {
+			// Chain all member iterators together
+			Box::new(members.into_iter().flat_map(expand_brace_expr_member))
+		},
+		word::BraceExpressionOrText::Text(text) => Box::new(std::iter::once(text)),
+	}
 }
 
 #[expect(clippy::cast_possible_truncation)]
 fn expand_brace_expr_member(bem: word::BraceExpressionMember) -> Box<dyn Iterator<Item = String>> {
-    match bem {
-        word::BraceExpressionMember::NumberSequence {
-            start,
-            end,
-            increment,
-        } => {
-            let increment = increment.unsigned_abs() as usize;
+	match bem {
+		word::BraceExpressionMember::NumberSequence { start, end, increment } => {
+			let increment = increment.unsigned_abs() as usize;
 
-            if start <= end {
-                Box::new((start..=end).step_by(increment).map(|n| n.to_string()))
-            } else {
-                Box::new(
-                    (end..=start)
-                        .step_by(increment)
-                        .map(|n| n.to_string())
-                        .collect::<Vec<_>>()
-                        .into_iter()
-                        .rev(),
-                )
-            }
-        }
+			if start <= end {
+				Box::new((start..=end).step_by(increment).map(|n| n.to_string()))
+			} else {
+				Box::new(
+					(end..=start)
+						.step_by(increment)
+						.map(|n| n.to_string())
+						.collect::<Vec<_>>()
+						.into_iter()
+						.rev(),
+				)
+			}
+		},
 
-        word::BraceExpressionMember::CharSequence {
-            start,
-            end,
-            increment,
-        } => {
-            let increment = increment.unsigned_abs() as usize;
+		word::BraceExpressionMember::CharSequence { start, end, increment } => {
+			let increment = increment.unsigned_abs() as usize;
 
-            if start <= end {
-                Box::new((start..=end).step_by(increment).map(|c| c.to_string()))
-            } else {
-                Box::new(
-                    (end..=start)
-                        .step_by(increment)
-                        .map(|c| c.to_string())
-                        .collect::<Vec<_>>()
-                        .into_iter()
-                        .rev(),
-                )
-            }
-        }
+			if start <= end {
+				Box::new((start..=end).step_by(increment).map(|c| c.to_string()))
+			} else {
+				Box::new(
+					(end..=start)
+						.step_by(increment)
+						.map(|c| c.to_string())
+						.collect::<Vec<_>>()
+						.into_iter()
+						.rev(),
+				)
+			}
+		},
 
-        word::BraceExpressionMember::Child(elements) => {
-            // Chain all element iterators together
-            Box::new(generate_and_combine_brace_expansions(elements).into_iter())
-        }
-    }
+		word::BraceExpressionMember::Child(elements) => {
+			// Chain all element iterators together
+			Box::new(generate_and_combine_brace_expansions(elements).into_iter())
+		},
+	}
 }

--- a/crates/brush-core-vendored/src/builtins.rs
+++ b/crates/brush-core-vendored/src/builtins.rs
@@ -13,8 +13,8 @@ use crate::{BuiltinError, CommandArg, commands, error, results};
 /// * The context in which the command is being executed.
 /// * The arguments to the command.
 pub type CommandExecuteFunc = fn(
-    commands::ExecutionContext<'_>,
-    Vec<commands::CommandArg>,
+	commands::ExecutionContext<'_>,
+	Vec<commands::CommandArg>,
 ) -> BoxFuture<'_, Result<results::ExecutionResult, error::Error>>;
 
 /// Type of a function to retrieve help content for a built-in command.
@@ -27,236 +27,233 @@ pub type CommandContentFunc = fn(&str, ContentType) -> Result<String, error::Err
 
 /// Trait implemented by built-in shell commands.
 pub trait Command: clap::Parser {
-    /// The error type returned by the command.
-    type Error: BuiltinError + 'static;
+	/// The error type returned by the command.
+	type Error: BuiltinError + 'static;
 
-    /// Instantiates the built-in command with the given arguments.
-    ///
-    /// # Arguments
-    ///
-    /// * `args` - The arguments to the command.
-    fn new<I>(args: I) -> Result<Self, clap::Error>
-    where
-        I: IntoIterator<Item = String>,
-    {
-        if !Self::takes_plus_options() {
-            Self::try_parse_from(args)
-        } else {
-            // N.B. clap doesn't support named options like '+x'. To work around this, we
-            // establish a pattern of renaming them.
-            let mut updated_args = vec![];
-            for arg in args {
-                if let Some(plus_options) = arg.strip_prefix("+") {
-                    for c in plus_options.chars() {
-                        updated_args.push(format!("--+{c}"));
-                    }
-                } else {
-                    updated_args.push(arg);
-                }
-            }
+	/// Instantiates the built-in command with the given arguments.
+	///
+	/// # Arguments
+	///
+	/// * `args` - The arguments to the command.
+	fn new<I>(args: I) -> Result<Self, clap::Error>
+	where
+		I: IntoIterator<Item = String>,
+	{
+		if !Self::takes_plus_options() {
+			Self::try_parse_from(args)
+		} else {
+			// N.B. clap doesn't support named options like '+x'. To work around this, we
+			// establish a pattern of renaming them.
+			let mut updated_args = vec![];
+			for arg in args {
+				if let Some(plus_options) = arg.strip_prefix("+") {
+					for c in plus_options.chars() {
+						updated_args.push(format!("--+{c}"));
+					}
+				} else {
+					updated_args.push(arg);
+				}
+			}
 
-            Self::try_parse_from(updated_args)
-        }
-    }
+			Self::try_parse_from(updated_args)
+		}
+	}
 
-    /// Returns whether or not the command takes options with a leading '+' or '-' character.
-    fn takes_plus_options() -> bool {
-        false
-    }
+	/// Returns whether or not the command takes options with a leading '+' or '-' character.
+	fn takes_plus_options() -> bool {
+		false
+	}
 
-    /// Executes the built-in command in the provided context.
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - The context in which the command is being executed.
-    // NOTE: we use desugared async here because we need a Send marker
-    fn execute(
-        &self,
-        context: commands::ExecutionContext<'_>,
-    ) -> impl std::future::Future<Output = Result<results::ExecutionResult, Self::Error>>
-    + std::marker::Send;
+	/// Executes the built-in command in the provided context.
+	///
+	/// # Arguments
+	///
+	/// * `context` - The context in which the command is being executed.
+	// NOTE: we use desugared async here because we need a Send marker
+	fn execute(
+		&self,
+		context: commands::ExecutionContext<'_>,
+	) -> impl std::future::Future<Output = Result<results::ExecutionResult, Self::Error>>
+	+ std::marker::Send;
 
-    /// Returns the textual help content associated with the command.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the command.
-    /// * `content_type` - The type of content to retrieve.
-    fn get_content(name: &str, content_type: ContentType) -> Result<String, error::Error> {
-        let mut clap_command = Self::command()
-            .styles(brush_help_styles())
-            .next_line_help(false);
-        clap_command.set_bin_name(name);
+	/// Returns the textual help content associated with the command.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the command.
+	/// * `content_type` - The type of content to retrieve.
+	fn get_content(name: &str, content_type: ContentType) -> Result<String, error::Error> {
+		let mut clap_command = Self::command()
+			.styles(brush_help_styles())
+			.next_line_help(false);
+		clap_command.set_bin_name(name);
 
-        let s = match content_type {
-            ContentType::DetailedHelp => clap_command.render_help().ansi().to_string(),
-            ContentType::ShortUsage => get_builtin_short_usage(name, &clap_command),
-            ContentType::ShortDescription => get_builtin_short_description(name, &clap_command),
-            ContentType::ManPage => get_builtin_man_page(name, &clap_command)?,
-        };
+		let s = match content_type {
+			ContentType::DetailedHelp => clap_command.render_help().ansi().to_string(),
+			ContentType::ShortUsage => get_builtin_short_usage(name, &clap_command),
+			ContentType::ShortDescription => get_builtin_short_description(name, &clap_command),
+			ContentType::ManPage => get_builtin_man_page(name, &clap_command)?,
+		};
 
-        Ok(s)
-    }
+		Ok(s)
+	}
 }
 
 /// Trait implemented by built-in shell commands that take specially handled declarations
 /// as arguments.
 pub trait DeclarationCommand: Command {
-    /// Stores the declarations within the command instance.
-    ///
-    /// # Arguments
-    ///
-    /// * `declarations` - The declarations to store.
-    fn set_declarations(&mut self, declarations: Vec<commands::CommandArg>);
+	/// Stores the declarations within the command instance.
+	///
+	/// # Arguments
+	///
+	/// * `declarations` - The declarations to store.
+	fn set_declarations(&mut self, declarations: Vec<commands::CommandArg>);
 }
 
 /// Type of help content, typically associated with a built-in command.
 pub enum ContentType {
-    /// Detailed help content for the command.
-    DetailedHelp,
-    /// Short usage information for the command.
-    ShortUsage,
-    /// Short description for the command.
-    ShortDescription,
-    /// man-style help page.
-    ManPage,
+	/// Detailed help content for the command.
+	DetailedHelp,
+	/// Short usage information for the command.
+	ShortUsage,
+	/// Short description for the command.
+	ShortDescription,
+	/// man-style help page.
+	ManPage,
 }
 
 /// Encapsulates a registration for a built-in command.
 #[derive(Clone)]
 pub struct Registration {
-    /// Function to execute the builtin.
-    pub execute_func: CommandExecuteFunc,
+	/// Function to execute the builtin.
+	pub execute_func: CommandExecuteFunc,
 
-    /// Function to retrieve the builtin's content/help text.
-    pub content_func: CommandContentFunc,
+	/// Function to retrieve the builtin's content/help text.
+	pub content_func: CommandContentFunc,
 
-    /// Has this registration been disabled?
-    pub disabled: bool,
+	/// Has this registration been disabled?
+	pub disabled: bool,
 
-    /// Is the builtin classified as "special" by specification?
-    pub special_builtin: bool,
+	/// Is the builtin classified as "special" by specification?
+	pub special_builtin: bool,
 
-    /// Is this builtin one that takes specially handled declarations?
-    pub declaration_builtin: bool,
+	/// Is this builtin one that takes specially handled declarations?
+	pub declaration_builtin: bool,
 }
 
 impl Registration {
-    /// Updates the given registration to mark it for a special builtin.
-    #[must_use]
-    pub const fn special(self) -> Self {
-        Self {
-            special_builtin: true,
-            ..self
-        }
-    }
+	/// Updates the given registration to mark it for a special builtin.
+	#[must_use]
+	pub const fn special(self) -> Self {
+		Self { special_builtin: true, ..self }
+	}
 }
 
 fn get_builtin_man_page(_name: &str, _command: &clap::Command) -> Result<String, error::Error> {
-    error::unimp("man page rendering is not yet implemented")
+	error::unimp("man page rendering is not yet implemented")
 }
 
 fn get_builtin_short_description(name: &str, command: &clap::Command) -> String {
-    let about = command
-        .get_about()
-        .map_or_else(String::new, |s| s.to_string());
+	let about = command
+		.get_about()
+		.map_or_else(String::new, |s| s.to_string());
 
-    std::format!("{name} - {about}\n")
+	std::format!("{name} - {about}\n")
 }
 
 fn get_builtin_short_usage(name: &str, command: &clap::Command) -> String {
-    let mut usage = String::new();
+	let mut usage = String::new();
 
-    let mut needs_space = false;
+	let mut needs_space = false;
 
-    let mut optional_short_opts = vec![];
-    let mut required_short_opts = vec![];
-    for opt in command.get_opts() {
-        if opt.is_hide_set() {
-            continue;
-        }
+	let mut optional_short_opts = vec![];
+	let mut required_short_opts = vec![];
+	for opt in command.get_opts() {
+		if opt.is_hide_set() {
+			continue;
+		}
 
-        if let Some(c) = opt.get_short() {
-            if !opt.is_required_set() {
-                optional_short_opts.push(c);
-            } else {
-                required_short_opts.push(c);
-            }
-        }
-    }
+		if let Some(c) = opt.get_short() {
+			if !opt.is_required_set() {
+				optional_short_opts.push(c);
+			} else {
+				required_short_opts.push(c);
+			}
+		}
+	}
 
-    if !optional_short_opts.is_empty() {
-        if needs_space {
-            usage.push(' ');
-        }
+	if !optional_short_opts.is_empty() {
+		if needs_space {
+			usage.push(' ');
+		}
 
-        usage.push('[');
-        usage.push('-');
-        for c in optional_short_opts {
-            usage.push(c);
-        }
+		usage.push('[');
+		usage.push('-');
+		for c in optional_short_opts {
+			usage.push(c);
+		}
 
-        usage.push(']');
-        needs_space = true;
-    }
+		usage.push(']');
+		needs_space = true;
+	}
 
-    if !required_short_opts.is_empty() {
-        if needs_space {
-            usage.push(' ');
-        }
+	if !required_short_opts.is_empty() {
+		if needs_space {
+			usage.push(' ');
+		}
 
-        usage.push('-');
-        for c in required_short_opts {
-            usage.push(c);
-        }
+		usage.push('-');
+		for c in required_short_opts {
+			usage.push(c);
+		}
 
-        needs_space = true;
-    }
+		needs_space = true;
+	}
 
-    for pos in command.get_positionals() {
-        if pos.is_hide_set() {
-            continue;
-        }
+	for pos in command.get_positionals() {
+		if pos.is_hide_set() {
+			continue;
+		}
 
-        if !pos.is_required_set() {
-            if needs_space {
-                usage.push(' ');
-            }
+		if !pos.is_required_set() {
+			if needs_space {
+				usage.push(' ');
+			}
 
-            usage.push('[');
-            needs_space = false;
-        }
+			usage.push('[');
+			needs_space = false;
+		}
 
-        if let Some(names) = pos.get_value_names() {
-            for name in names {
-                if needs_space {
-                    usage.push(' ');
-                }
+		if let Some(names) = pos.get_value_names() {
+			for name in names {
+				if needs_space {
+					usage.push(' ');
+				}
 
-                usage.push_str(name);
-                needs_space = true;
-            }
-        }
+				usage.push_str(name);
+				needs_space = true;
+			}
+		}
 
-        if !pos.is_required_set() {
-            usage.push(']');
-            needs_space = true;
-        }
-    }
+		if !pos.is_required_set() {
+			usage.push(']');
+			needs_space = true;
+		}
+	}
 
-    std::format!("{name}: {name} {usage}\n")
+	std::format!("{name}: {name} {usage}\n")
 }
 
 fn brush_help_styles() -> clap::builder::Styles {
-    styling::Styles::styled()
-        .header(
-            styling::AnsiColor::Yellow.on_default()
-                | styling::Effects::BOLD
-                | styling::Effects::UNDERLINE,
-        )
-        .usage(styling::AnsiColor::Green.on_default() | styling::Effects::BOLD)
-        .literal(styling::AnsiColor::Magenta.on_default() | styling::Effects::BOLD)
-        .placeholder(styling::AnsiColor::Cyan.on_default())
+	styling::Styles::styled()
+		.header(
+			styling::AnsiColor::Yellow.on_default()
+				| styling::Effects::BOLD
+				| styling::Effects::UNDERLINE,
+		)
+		.usage(styling::AnsiColor::Green.on_default() | styling::Effects::BOLD)
+		.literal(styling::AnsiColor::Magenta.on_default() | styling::Effects::BOLD)
+		.placeholder(styling::AnsiColor::Cyan.on_default())
 }
 
 /// This function and the [`try_parse_known`] exists to deal with
@@ -288,96 +285,96 @@ fn brush_help_styles() -> clap::builder::Styles {
 ///    }
 /// ```
 pub fn parse_known<T: clap::Parser, S>(
-    args: impl IntoIterator<Item = S>,
+	args: impl IntoIterator<Item = S>,
 ) -> (T, Option<impl Iterator<Item = S>>)
 where
-    S: Into<std::ffi::OsString> + Clone + PartialEq<&'static str>,
+	S: Into<std::ffi::OsString> + Clone + PartialEq<&'static str>,
 {
-    let mut args = args.into_iter();
-    // the best way to save `--` is to get it out with a side effect while `clap` iterates over the
-    // args this way we can be 100% sure that we have '--' and the remaining args
-    // and we will iterate only once
-    let mut hyphen = None;
-    let args_before_hyphen = args.by_ref().take_while(|a| {
-        let is_hyphen = *a == "--";
-        if is_hyphen {
-            hyphen = Some(a.clone());
-        }
-        !is_hyphen
-    });
-    let parsed_args = T::parse_from(args_before_hyphen);
-    let raw_args = hyphen.map(|hyphen| std::iter::once(hyphen).chain(args));
-    (parsed_args, raw_args)
+	let mut args = args.into_iter();
+	// the best way to save `--` is to get it out with a side effect while `clap` iterates over the
+	// args this way we can be 100% sure that we have '--' and the remaining args
+	// and we will iterate only once
+	let mut hyphen = None;
+	let args_before_hyphen = args.by_ref().take_while(|a| {
+		let is_hyphen = *a == "--";
+		if is_hyphen {
+			hyphen = Some(a.clone());
+		}
+		!is_hyphen
+	});
+	let parsed_args = T::parse_from(args_before_hyphen);
+	let raw_args = hyphen.map(|hyphen| std::iter::once(hyphen).chain(args));
+	(parsed_args, raw_args)
 }
 
 /// Similar to [`parse_known`] but with [`clap::Parser::try_parse_from`]
 /// This function is used to parse arguments in builtins such as
 /// `crate::echo::EchoCommand`
 pub fn try_parse_known<T: clap::Parser>(
-    args: impl IntoIterator<Item = String>,
+	args: impl IntoIterator<Item = String>,
 ) -> Result<(T, Option<impl Iterator<Item = String>>), clap::Error> {
-    let mut args = args.into_iter();
-    let mut hyphen = None;
-    let args_before_hyphen = args.by_ref().take_while(|a| {
-        let is_hyphen = a == "--";
-        if is_hyphen {
-            hyphen = Some(a.clone());
-        }
-        !is_hyphen
-    });
-    let parsed_args = T::try_parse_from(args_before_hyphen)?;
+	let mut args = args.into_iter();
+	let mut hyphen = None;
+	let args_before_hyphen = args.by_ref().take_while(|a| {
+		let is_hyphen = a == "--";
+		if is_hyphen {
+			hyphen = Some(a.clone());
+		}
+		!is_hyphen
+	});
+	let parsed_args = T::try_parse_from(args_before_hyphen)?;
 
-    let raw_args = hyphen.map(|hyphen| std::iter::once(hyphen).chain(args));
-    Ok((parsed_args, raw_args))
+	let raw_args = hyphen.map(|hyphen| std::iter::once(hyphen).chain(args));
+	Ok((parsed_args, raw_args))
 }
 
 /// A simple command that can be registered as a built-in.
 pub trait SimpleCommand {
-    /// Returns the content of the built-in command.
-    fn get_content(name: &str, content_type: ContentType) -> Result<String, error::Error>;
+	/// Returns the content of the built-in command.
+	fn get_content(name: &str, content_type: ContentType) -> Result<String, error::Error>;
 
-    /// Executes the built-in command.
-    fn execute<I: Iterator<Item = S>, S: AsRef<str>>(
-        context: commands::ExecutionContext<'_>,
-        args: I,
-    ) -> Result<results::ExecutionResult, error::Error>;
+	/// Executes the built-in command.
+	fn execute<I: Iterator<Item = S>, S: AsRef<str>>(
+		context: commands::ExecutionContext<'_>,
+		args: I,
+	) -> Result<results::ExecutionResult, error::Error>;
 }
 
 /// Returns a built-in command registration, given an implementation of the
 /// `SimpleCommand` trait.
 pub fn simple_builtin<B: SimpleCommand + Send + Sync>() -> Registration {
-    Registration {
-        execute_func: exec_simple_builtin::<B>,
-        content_func: B::get_content,
-        disabled: false,
-        special_builtin: false,
-        declaration_builtin: false,
-    }
+	Registration {
+		execute_func: exec_simple_builtin::<B>,
+		content_func: B::get_content,
+		disabled: false,
+		special_builtin: false,
+		declaration_builtin: false,
+	}
 }
 
 /// Returns a built-in command registration, given an implementation of the
 /// `Command` trait.
 pub fn builtin<B: Command + Send + Sync>() -> Registration {
-    Registration {
-        execute_func: exec_builtin::<B>,
-        content_func: get_builtin_content::<B>,
-        disabled: false,
-        special_builtin: false,
-        declaration_builtin: false,
-    }
+	Registration {
+		execute_func: exec_builtin::<B>,
+		content_func: get_builtin_content::<B>,
+		disabled: false,
+		special_builtin: false,
+		declaration_builtin: false,
+	}
 }
 
 /// Returns a built-in command registration, given an implementation of the
 /// `DeclarationCommand` trait. Used for select commands that can take parsed
 /// declarations as arguments.
 pub fn decl_builtin<B: DeclarationCommand + Send + Sync>() -> Registration {
-    Registration {
-        execute_func: exec_declaration_builtin::<B>,
-        content_func: get_builtin_content::<B>,
-        disabled: false,
-        special_builtin: false,
-        declaration_builtin: true,
-    }
+	Registration {
+		execute_func: exec_declaration_builtin::<B>,
+		content_func: get_builtin_content::<B>,
+		disabled: false,
+		special_builtin: false,
+		declaration_builtin: true,
+	}
 }
 
 #[allow(clippy::too_long_first_doc_paragraph)]
@@ -388,135 +385,135 @@ pub fn decl_builtin<B: DeclarationCommand + Send + Sync>() -> Registration {
 /// via `set_declarations`. This is primarily only expected to be used with
 /// select builtin commands that wrap other builtins (e.g., "builtin").
 pub fn raw_arg_builtin<B: DeclarationCommand + Default + Send + Sync>() -> Registration {
-    Registration {
-        execute_func: exec_raw_arg_builtin::<B>,
-        content_func: get_builtin_content::<B>,
-        disabled: false,
-        special_builtin: false,
-        declaration_builtin: true,
-    }
+	Registration {
+		execute_func: exec_raw_arg_builtin::<B>,
+		content_func: get_builtin_content::<B>,
+		disabled: false,
+		special_builtin: false,
+		declaration_builtin: true,
+	}
 }
 
 fn get_builtin_content<T: Command + Send + Sync>(
-    name: &str,
-    content_type: ContentType,
+	name: &str,
+	content_type: ContentType,
 ) -> Result<String, error::Error> {
-    T::get_content(name, content_type)
+	T::get_content(name, content_type)
 }
 
 fn exec_simple_builtin<T: SimpleCommand + Send + Sync>(
-    context: commands::ExecutionContext<'_>,
-    args: Vec<CommandArg>,
+	context: commands::ExecutionContext<'_>,
+	args: Vec<CommandArg>,
 ) -> BoxFuture<'_, Result<results::ExecutionResult, error::Error>> {
-    Box::pin(async move { exec_simple_builtin_impl::<T>(context, args).await })
+	Box::pin(async move { exec_simple_builtin_impl::<T>(context, args).await })
 }
 
 #[expect(clippy::unused_async)]
 async fn exec_simple_builtin_impl<T: SimpleCommand + Send + Sync>(
-    context: commands::ExecutionContext<'_>,
-    args: Vec<CommandArg>,
+	context: commands::ExecutionContext<'_>,
+	args: Vec<CommandArg>,
 ) -> Result<results::ExecutionResult, error::Error> {
-    let plain_args = args.into_iter().map(|arg| match arg {
-        CommandArg::String(s) => s,
-        CommandArg::Assignment(a) => a.to_string(),
-    });
+	let plain_args = args.into_iter().map(|arg| match arg {
+		CommandArg::String(s) => s,
+		CommandArg::Assignment(a) => a.to_string(),
+	});
 
-    T::execute(context, plain_args)
+	T::execute(context, plain_args)
 }
 
 fn exec_builtin<T: Command + Send + Sync>(
-    context: commands::ExecutionContext<'_>,
-    args: Vec<CommandArg>,
+	context: commands::ExecutionContext<'_>,
+	args: Vec<CommandArg>,
 ) -> BoxFuture<'_, Result<results::ExecutionResult, error::Error>> {
-    Box::pin(async move { exec_builtin_impl::<T>(context, args).await })
+	Box::pin(async move { exec_builtin_impl::<T>(context, args).await })
 }
 
 async fn exec_builtin_impl<T: Command + Send + Sync>(
-    context: commands::ExecutionContext<'_>,
-    args: Vec<CommandArg>,
+	context: commands::ExecutionContext<'_>,
+	args: Vec<CommandArg>,
 ) -> Result<results::ExecutionResult, error::Error> {
-    let plain_args = args.into_iter().map(|arg| match arg {
-        CommandArg::String(s) => s,
-        CommandArg::Assignment(a) => a.to_string(),
-    });
+	let plain_args = args.into_iter().map(|arg| match arg {
+		CommandArg::String(s) => s,
+		CommandArg::Assignment(a) => a.to_string(),
+	});
 
-    let result = T::new(plain_args);
-    let command = match result {
-        Ok(command) => command,
-        Err(e) => {
-            writeln!(context.stderr(), "{e}")?;
-            return Ok(results::ExecutionExitCode::InvalidUsage.into());
-        }
-    };
+	let result = T::new(plain_args);
+	let command = match result {
+		Ok(command) => command,
+		Err(e) => {
+			writeln!(context.stderr(), "{e}")?;
+			return Ok(results::ExecutionExitCode::InvalidUsage.into());
+		},
+	};
 
-    call_builtin(command, context).await
+	call_builtin(command, context).await
 }
 
 fn exec_declaration_builtin<T: DeclarationCommand + Send + Sync>(
-    context: commands::ExecutionContext<'_>,
-    args: Vec<CommandArg>,
+	context: commands::ExecutionContext<'_>,
+	args: Vec<CommandArg>,
 ) -> BoxFuture<'_, Result<results::ExecutionResult, error::Error>> {
-    Box::pin(async move { exec_declaration_builtin_impl::<T>(context, args).await })
+	Box::pin(async move { exec_declaration_builtin_impl::<T>(context, args).await })
 }
 
 async fn exec_declaration_builtin_impl<T: DeclarationCommand + Send + Sync>(
-    context: commands::ExecutionContext<'_>,
-    args: Vec<CommandArg>,
+	context: commands::ExecutionContext<'_>,
+	args: Vec<CommandArg>,
 ) -> Result<results::ExecutionResult, error::Error> {
-    let mut options = vec![];
-    let mut declarations = vec![];
+	let mut options = vec![];
+	let mut declarations = vec![];
 
-    for (i, arg) in args.into_iter().enumerate() {
-        match arg {
-            CommandArg::String(s)
-                if i == 0 || (s.len() > 1 && (s.starts_with('-') || s.starts_with('+'))) =>
-            {
-                options.push(s);
-            }
-            _ => declarations.push(arg),
-        }
-    }
+	for (i, arg) in args.into_iter().enumerate() {
+		match arg {
+			CommandArg::String(s)
+				if i == 0 || (s.len() > 1 && (s.starts_with('-') || s.starts_with('+'))) =>
+			{
+				options.push(s);
+			},
+			_ => declarations.push(arg),
+		}
+	}
 
-    let result = T::new(options);
-    let mut command = match result {
-        Ok(command) => command,
-        Err(e) => {
-            writeln!(context.stderr(), "{e}")?;
-            return Ok(results::ExecutionExitCode::InvalidUsage.into());
-        }
-    };
+	let result = T::new(options);
+	let mut command = match result {
+		Ok(command) => command,
+		Err(e) => {
+			writeln!(context.stderr(), "{e}")?;
+			return Ok(results::ExecutionExitCode::InvalidUsage.into());
+		},
+	};
 
-    command.set_declarations(declarations);
+	command.set_declarations(declarations);
 
-    call_builtin(command, context).await
+	call_builtin(command, context).await
 }
 
 fn exec_raw_arg_builtin<T: DeclarationCommand + Default + Send + Sync>(
-    context: commands::ExecutionContext<'_>,
-    args: Vec<CommandArg>,
+	context: commands::ExecutionContext<'_>,
+	args: Vec<CommandArg>,
 ) -> BoxFuture<'_, Result<results::ExecutionResult, error::Error>> {
-    Box::pin(async move { exec_raw_arg_builtin_impl::<T>(context, args).await })
+	Box::pin(async move { exec_raw_arg_builtin_impl::<T>(context, args).await })
 }
 
 async fn exec_raw_arg_builtin_impl<T: DeclarationCommand + Default + Send + Sync>(
-    context: commands::ExecutionContext<'_>,
-    args: Vec<CommandArg>,
+	context: commands::ExecutionContext<'_>,
+	args: Vec<CommandArg>,
 ) -> Result<results::ExecutionResult, error::Error> {
-    let mut command = T::default();
-    command.set_declarations(args);
+	let mut command = T::default();
+	command.set_declarations(args);
 
-    call_builtin(command, context).await
+	call_builtin(command, context).await
 }
 
 async fn call_builtin(
-    command: impl Command,
-    context: commands::ExecutionContext<'_>,
+	command: impl Command,
+	context: commands::ExecutionContext<'_>,
 ) -> Result<results::ExecutionResult, error::Error> {
-    let builtin_name = context.command_name.clone();
-    let result = command
-        .execute(context)
-        .await
-        .map_err(|e| error::ErrorKind::BuiltinError(Box::new(e), builtin_name))?;
+	let builtin_name = context.command_name.clone();
+	let result = command
+		.execute(context)
+		.await
+		.map_err(|e| error::ErrorKind::BuiltinError(Box::new(e), builtin_name))?;
 
-    Ok(result)
+	Ok(result)
 }

--- a/crates/brush-core-vendored/src/commands.rs
+++ b/crates/brush-core-vendored/src/commands.rs
@@ -27,11 +27,11 @@ pub enum CommandWaitResult {
 /// Represents the context for executing a command.
 pub struct ExecutionContext<'a> {
 	/// The shell in which the command is being executed.
-	pub shell:        &'a mut Shell,
+	pub shell: &'a mut Shell,
 	/// The name of the command being executed.    
 	pub command_name: String,
 	/// The parameters for the execution.
-	pub params:       ExecutionParameters,
+	pub params: ExecutionParameters,
 }
 
 impl ExecutionContext<'_> {

--- a/crates/brush-core-vendored/src/completion.rs
+++ b/crates/brush-core-vendored/src/completion.rs
@@ -130,9 +130,9 @@ pub struct Config {
 
 	/// Optionally, a completion spec to be used as a default, when earlier
 	/// matches yield no candidates.
-	pub default:      Option<Spec>,
+	pub default: Option<Spec>,
 	/// Optionally, a completion spec to be used when the command line is empty.
-	pub empty_line:   Option<Spec>,
+	pub empty_line: Option<Spec>,
 	/// Optionally, a completion spec to be used for the initial word of a
 	/// command line.
 	pub initial_word: Option<Spec>,
@@ -151,19 +151,19 @@ pub struct GenerationOptions {
 	pub bash_default: bool,
 	/// Use default readline-style filename completion if no completions are
 	/// generated.
-	pub default:      bool,
+	pub default: bool,
 	/// Treat completions as directory names.
-	pub dir_names:    bool,
+	pub dir_names: bool,
 	/// Treat completions as filenames.
-	pub file_names:   bool,
+	pub file_names: bool,
 	/// Do not add usual quoting for completions.
-	pub no_quote:     bool,
+	pub no_quote: bool,
 	/// Do not sort completions.
-	pub no_sort:      bool,
+	pub no_sort: bool,
 	/// Do not append typical space to a completion at the end of the input line.
-	pub no_space:     bool,
+	pub no_space: bool,
 	/// Also complete with directory names.
-	pub plus_dirs:    bool,
+	pub plus_dirs: bool,
 }
 
 /// Encapsulates a command completion specification; provides policy for how to
@@ -178,21 +178,21 @@ pub struct Spec {
 	//
 	// Generators
 	/// Actions to take to generate completions.
-	pub actions:       Vec<CompleteAction>,
+	pub actions: Vec<CompleteAction>,
 	/// Optionally, a glob pattern whose expansion will be used as completions.
-	pub glob_pattern:  Option<String>,
+	pub glob_pattern: Option<String>,
 	/// Optionally, a list of words to use as completions.
-	pub word_list:     Option<String>,
+	pub word_list: Option<String>,
 	/// Optionally, the name of a shell function to invoke to generate
 	/// completions.
 	pub function_name: Option<String>,
 	/// Optionally, the name of a command to execute to generate completions.
-	pub command:       Option<String>,
+	pub command: Option<String>,
 
 	//
 	// Filters
 	/// Optionally, a pattern to filter completions.
-	pub filter_pattern:          Option<String>,
+	pub filter_pattern: Option<String>,
 	/// If true, completion candidates matching `filter_pattern` are removed;
 	/// otherwise, those not matching it are removed.
 	pub filter_pattern_excludes: bool,
@@ -214,7 +214,7 @@ pub struct Context<'a> {
 	pub token_to_complete: &'a str,
 
 	/// If available, the name of the command being invoked.
-	pub command_name:    Option<&'a str>,
+	pub command_name: Option<&'a str>,
 	/// If there was one, the token preceding the one being completed.
 	pub preceding_token: Option<&'a str>,
 
@@ -222,11 +222,11 @@ pub struct Context<'a> {
 	pub token_index: usize,
 
 	/// The input line.
-	pub input_line:   &'a str,
+	pub input_line: &'a str,
 	/// The 0-based index of the cursor in the input line.
 	pub cursor_index: usize,
 	/// The tokens in the input line.
-	pub tokens:       &'a [&'a brush_parser::Token],
+	pub tokens: &'a [&'a brush_parser::Token],
 }
 
 impl Spec {
@@ -340,8 +340,8 @@ impl Spec {
 		};
 
 		let processing_options = ProcessingOptions {
-			treat_as_filenames:               options.file_names,
-			no_autoquote_filenames:           options.no_quote,
+			treat_as_filenames: options.file_names,
+			no_autoquote_filenames: options.no_quote,
 			no_trailing_space_at_end_of_line: options.no_space,
 		};
 
@@ -728,11 +728,11 @@ pub struct Completions {
 	/// The number of elements in the input line that should be removed before
 	/// insertion. Represented as a byte count; must capture an exact character
 	/// boundary.
-	pub delete_count:    usize,
+	pub delete_count: usize,
 	/// The ordered set of completions.
-	pub candidates:      IndexSet<String>,
+	pub candidates: IndexSet<String>,
 	/// Options for processing the candidates.
-	pub options:         ProcessingOptions,
+	pub options: ProcessingOptions,
 }
 
 /// Options governing how command completion candidates are processed after
@@ -740,9 +740,9 @@ pub struct Completions {
 #[derive(Debug)]
 pub struct ProcessingOptions {
 	/// Treat completions as file names.
-	pub treat_as_filenames:               bool,
+	pub treat_as_filenames: bool,
 	/// Don't auto-quote completions that are file names.
-	pub no_autoquote_filenames:           bool,
+	pub no_autoquote_filenames: bool,
 	/// Don't append a trailing space to completions at the end of the input
 	/// line.
 	pub no_trailing_space_at_end_of_line: bool,
@@ -751,8 +751,8 @@ pub struct ProcessingOptions {
 impl Default for ProcessingOptions {
 	fn default() -> Self {
 		Self {
-			treat_as_filenames:               true,
-			no_autoquote_filenames:           false,
+			treat_as_filenames: true,
+			no_autoquote_filenames: false,
 			no_trailing_space_at_end_of_line: false,
 		}
 	}
@@ -967,12 +967,12 @@ impl Config {
 
 			let completion_context = Context {
 				token_to_complete: completion_prefix,
-				preceding_token:   preceding_token.map(|t| t.to_str()),
-				command_name:      adjusted_tokens.first().map(|token| token.to_str()),
-				input_line:        input,
-				token_index:       completion_token_index,
-				tokens:            adjusted_tokens.as_slice(),
-				cursor_index:      position,
+				preceding_token: preceding_token.map(|t| t.to_str()),
+				command_name: adjusted_tokens.first().map(|token| token.to_str()),
+				input_line: input,
+				token_index: completion_token_index,
+				tokens: adjusted_tokens.as_slice(),
+				cursor_index: position,
 			};
 
 			result = self
@@ -1182,10 +1182,13 @@ fn simple_tokenize_by_delimiters(input: &str, delimiters: &[char]) -> Vec<brush_
 
 		let piece = piece.strip_suffix(delimiters).unwrap_or(piece);
 		let end = start + piece.len();
-		tokens.push(brush_parser::Token::Word(piece.to_string(), brush_parser::TokenLocation {
-			start: brush_parser::SourcePosition { index: start, line: 1, column: start + 1 }.into(),
-			end:   brush_parser::SourcePosition { index: end, line: 1, column: end + 1 }.into(),
-		}));
+		tokens.push(brush_parser::Token::Word(
+			piece.to_string(),
+			brush_parser::TokenLocation {
+				start: brush_parser::SourcePosition { index: start, line: 1, column: start + 1 }.into(),
+				end: brush_parser::SourcePosition { index: end, line: 1, column: end + 1 }.into(),
+			},
+		));
 
 		start = next_start;
 	}

--- a/crates/brush-core-vendored/src/env.rs
+++ b/crates/brush-core-vendored/src/env.rs
@@ -11,601 +11,599 @@ use crate::variables::{self, ShellValue, ShellValueUnsetType, ShellVariable};
 /// Represents the policy for looking up variables in a shell environment.
 #[derive(Clone, Copy)]
 pub enum EnvironmentLookup {
-    /// Look anywhere.
-    Anywhere,
-    /// Look only in the global scope.
-    OnlyInGlobal,
-    /// Look only in the current local scope.    
-    OnlyInCurrentLocal,
-    /// Look only in local scopes.
-    OnlyInLocal,
+	/// Look anywhere.
+	Anywhere,
+	/// Look only in the global scope.
+	OnlyInGlobal,
+	/// Look only in the current local scope.    
+	OnlyInCurrentLocal,
+	/// Look only in local scopes.
+	OnlyInLocal,
 }
 
 /// Represents a shell environment scope.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EnvironmentScope {
-    /// Scope local to a function instance
-    Local,
-    /// Globals
-    Global,
-    /// Transient overrides for a command invocation
-    Command,
+	/// Scope local to a function instance
+	Local,
+	/// Globals
+	Global,
+	/// Transient overrides for a command invocation
+	Command,
 }
 
 /// Represents the shell variable environment, composed of a stack of scopes.
 #[derive(Clone, Debug)]
 pub struct ShellEnvironment {
-    /// Stack of scopes, with the top of the stack being the current scope.
-    scopes: Vec<(EnvironmentScope, ShellVariableMap)>,
-    /// Whether or not to auto-export variables on creation or modification.
-    export_variables_on_modification: bool,
-    /// Count of total entries (may include duplicates with shadowed variables).
-    entry_count: usize,
+	/// Stack of scopes, with the top of the stack being the current scope.
+	scopes: Vec<(EnvironmentScope, ShellVariableMap)>,
+	/// Whether or not to auto-export variables on creation or modification.
+	export_variables_on_modification: bool,
+	/// Count of total entries (may include duplicates with shadowed variables).
+	entry_count: usize,
 }
 
 impl Default for ShellEnvironment {
-    fn default() -> Self {
-        Self::new()
-    }
+	fn default() -> Self {
+		Self::new()
+	}
 }
 
 impl ShellEnvironment {
-    /// Returns a new shell environment.
-    pub fn new() -> Self {
-        Self {
-            scopes: vec![(EnvironmentScope::Global, ShellVariableMap::default())],
-            export_variables_on_modification: false,
-            entry_count: 0,
-        }
-    }
+	/// Returns a new shell environment.
+	pub fn new() -> Self {
+		Self {
+			scopes: vec![(EnvironmentScope::Global, ShellVariableMap::default())],
+			export_variables_on_modification: false,
+			entry_count: 0,
+		}
+	}
 
-    /// Pushes a new scope of the given type onto the environment's scope stack.
-    ///
-    /// # Arguments
-    ///
-    /// * `scope_type` - The type of scope to push.
-    pub fn push_scope(&mut self, scope_type: EnvironmentScope) {
-        self.scopes.push((scope_type, ShellVariableMap::default()));
-    }
+	/// Pushes a new scope of the given type onto the environment's scope stack.
+	///
+	/// # Arguments
+	///
+	/// * `scope_type` - The type of scope to push.
+	pub fn push_scope(&mut self, scope_type: EnvironmentScope) {
+		self.scopes.push((scope_type, ShellVariableMap::default()));
+	}
 
-    /// Pops the top-most scope off the environment's scope stack.
-    ///
-    /// # Arguments
-    ///
-    /// * `expected_scope_type` - The type of scope that is expected to be atop the stack.
-    pub fn pop_scope(&mut self, expected_scope_type: EnvironmentScope) -> Result<(), error::Error> {
-        // TODO: Should we panic instead on failure? It's effectively a broken invariant.
-        match self.scopes.pop() {
-            Some((actual_scope_type, _)) if actual_scope_type == expected_scope_type => Ok(()),
-            _ => Err(error::ErrorKind::MissingScope.into()),
-        }
-    }
+	/// Pops the top-most scope off the environment's scope stack.
+	///
+	/// # Arguments
+	///
+	/// * `expected_scope_type` - The type of scope that is expected to be atop the stack.
+	pub fn pop_scope(&mut self, expected_scope_type: EnvironmentScope) -> Result<(), error::Error> {
+		// TODO: Should we panic instead on failure? It's effectively a broken invariant.
+		match self.scopes.pop() {
+			Some((actual_scope_type, _)) if actual_scope_type == expected_scope_type => Ok(()),
+			_ => Err(error::ErrorKind::MissingScope.into()),
+		}
+	}
 
-    //
-    // Iterators/Getters
-    //
+	//
+	// Iterators/Getters
+	//
 
-    /// Returns an iterator over all exported variables defined in the variable.
-    pub fn iter_exported(&self) -> impl Iterator<Item = (&String, &ShellVariable)> {
-        // We won't actually need to store all entries, but we expect it should be
-        // within the same order.
-        let mut visible_vars: HashMap<&String, &ShellVariable> =
-            HashMap::with_capacity(self.entry_count);
+	/// Returns an iterator over all exported variables defined in the variable.
+	pub fn iter_exported(&self) -> impl Iterator<Item = (&String, &ShellVariable)> {
+		// We won't actually need to store all entries, but we expect it should be
+		// within the same order.
+		let mut visible_vars: HashMap<&String, &ShellVariable> =
+			HashMap::with_capacity(self.entry_count);
 
-        for (_, var_map) in self.scopes.iter().rev() {
-            for (name, var) in var_map.iter().filter(|(_, v)| v.is_exported()) {
-                // Only insert the variable if it hasn't been seen yet.
-                if let hash_map::Entry::Vacant(entry) = visible_vars.entry(name) {
-                    entry.insert(var);
-                }
-            }
-        }
+		for (_, var_map) in self.scopes.iter().rev() {
+			for (name, var) in var_map.iter().filter(|(_, v)| v.is_exported()) {
+				// Only insert the variable if it hasn't been seen yet.
+				if let hash_map::Entry::Vacant(entry) = visible_vars.entry(name) {
+					entry.insert(var);
+				}
+			}
+		}
 
-        visible_vars.into_iter()
-    }
+		visible_vars.into_iter()
+	}
 
-    /// Returns an iterator over all the variables defined in the environment.
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &ShellVariable)> {
-        self.iter_using_policy(EnvironmentLookup::Anywhere)
-    }
+	/// Returns an iterator over all the variables defined in the environment.
+	pub fn iter(&self) -> impl Iterator<Item = (&String, &ShellVariable)> {
+		self.iter_using_policy(EnvironmentLookup::Anywhere)
+	}
 
-    /// Returns an iterator over all the variables defined in the environment,
-    /// using the given lookup policy.
-    ///
-    /// # Arguments
-    ///
-    /// * `lookup_policy` - The policy to use when looking up variables.
-    pub fn iter_using_policy(
-        &self,
-        lookup_policy: EnvironmentLookup,
-    ) -> impl Iterator<Item = (&String, &ShellVariable)> {
-        // We won't actually need to store all entries, but we expect it should be
-        // within the same order.
-        let mut visible_vars: HashMap<&String, &ShellVariable> =
-            HashMap::with_capacity(self.entry_count);
+	/// Returns an iterator over all the variables defined in the environment,
+	/// using the given lookup policy.
+	///
+	/// # Arguments
+	///
+	/// * `lookup_policy` - The policy to use when looking up variables.
+	pub fn iter_using_policy(
+		&self,
+		lookup_policy: EnvironmentLookup,
+	) -> impl Iterator<Item = (&String, &ShellVariable)> {
+		// We won't actually need to store all entries, but we expect it should be
+		// within the same order.
+		let mut visible_vars: HashMap<&String, &ShellVariable> =
+			HashMap::with_capacity(self.entry_count);
 
-        let mut local_count = 0;
-        for (scope_type, var_map) in self.scopes.iter().rev() {
-            if matches!(scope_type, EnvironmentScope::Local) {
-                local_count += 1;
-            }
+		let mut local_count = 0;
+		for (scope_type, var_map) in self.scopes.iter().rev() {
+			if matches!(scope_type, EnvironmentScope::Local) {
+				local_count += 1;
+			}
 
-            match lookup_policy {
-                EnvironmentLookup::Anywhere => (),
-                EnvironmentLookup::OnlyInGlobal => {
-                    if !matches!(scope_type, EnvironmentScope::Global) {
-                        continue;
-                    }
-                }
-                EnvironmentLookup::OnlyInCurrentLocal => {
-                    if !(matches!(scope_type, EnvironmentScope::Local) && local_count == 1) {
-                        continue;
-                    }
-                }
-                EnvironmentLookup::OnlyInLocal => {
-                    if !matches!(scope_type, EnvironmentScope::Local) {
-                        continue;
-                    }
-                }
-            }
+			match lookup_policy {
+				EnvironmentLookup::Anywhere => (),
+				EnvironmentLookup::OnlyInGlobal => {
+					if !matches!(scope_type, EnvironmentScope::Global) {
+						continue;
+					}
+				},
+				EnvironmentLookup::OnlyInCurrentLocal => {
+					if !(matches!(scope_type, EnvironmentScope::Local) && local_count == 1) {
+						continue;
+					}
+				},
+				EnvironmentLookup::OnlyInLocal => {
+					if !matches!(scope_type, EnvironmentScope::Local) {
+						continue;
+					}
+				},
+			}
 
-            for (name, var) in var_map.iter() {
-                // Only insert the variable if it hasn't been seen yet.
-                if let hash_map::Entry::Vacant(entry) = visible_vars.entry(name) {
-                    entry.insert(var);
-                }
-            }
+			for (name, var) in var_map.iter() {
+				// Only insert the variable if it hasn't been seen yet.
+				if let hash_map::Entry::Vacant(entry) = visible_vars.entry(name) {
+					entry.insert(var);
+				}
+			}
 
-            if matches!(scope_type, EnvironmentScope::Local)
-                && matches!(lookup_policy, EnvironmentLookup::OnlyInCurrentLocal)
-            {
-                break;
-            }
-        }
+			if matches!(scope_type, EnvironmentScope::Local)
+				&& matches!(lookup_policy, EnvironmentLookup::OnlyInCurrentLocal)
+			{
+				break;
+			}
+		}
 
-        visible_vars.into_iter()
-    }
+		visible_vars.into_iter()
+	}
 
-    /// Tries to retrieve an immutable reference to the variable with the given name
-    /// in the environment.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to retrieve.
-    pub fn get<S: AsRef<str>>(&self, name: S) -> Option<(EnvironmentScope, &ShellVariable)> {
-        // Look through scopes, from the top of the stack on down.
-        for (scope_type, map) in self.scopes.iter().rev() {
-            if let Some(var) = map.get(name.as_ref()) {
-                return Some((*scope_type, var));
-            }
-        }
+	/// Tries to retrieve an immutable reference to the variable with the given name
+	/// in the environment.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to retrieve.
+	pub fn get<S: AsRef<str>>(&self, name: S) -> Option<(EnvironmentScope, &ShellVariable)> {
+		// Look through scopes, from the top of the stack on down.
+		for (scope_type, map) in self.scopes.iter().rev() {
+			if let Some(var) = map.get(name.as_ref()) {
+				return Some((*scope_type, var));
+			}
+		}
 
-        None
-    }
+		None
+	}
 
-    /// Tries to retrieve a mutable reference to the variable with the given name
-    /// in the environment.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to retrieve.
-    pub fn get_mut<S: AsRef<str>>(
-        &mut self,
-        name: S,
-    ) -> Option<(EnvironmentScope, &mut ShellVariable)> {
-        // Look through scopes, from the top of the stack on down.
-        for (scope_type, map) in self.scopes.iter_mut().rev() {
-            if let Some(var) = map.get_mut(name.as_ref()) {
-                return Some((*scope_type, var));
-            }
-        }
+	/// Tries to retrieve a mutable reference to the variable with the given name
+	/// in the environment.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to retrieve.
+	pub fn get_mut<S: AsRef<str>>(
+		&mut self,
+		name: S,
+	) -> Option<(EnvironmentScope, &mut ShellVariable)> {
+		// Look through scopes, from the top of the stack on down.
+		for (scope_type, map) in self.scopes.iter_mut().rev() {
+			if let Some(var) = map.get_mut(name.as_ref()) {
+				return Some((*scope_type, var));
+			}
+		}
 
-        None
-    }
+		None
+	}
 
-    /// Tries to retrieve the string value of the variable with the given name in the
-    /// environment.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to retrieve.
-    /// * `shell` - The shell owning the environment.
-    pub fn get_str<S: AsRef<str>>(&self, name: S, shell: &shell::Shell) -> Option<Cow<'_, str>> {
-        self.get(name.as_ref())
-            .map(|(_, v)| v.value().to_cow_str(shell))
-    }
+	/// Tries to retrieve the string value of the variable with the given name in the
+	/// environment.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to retrieve.
+	/// * `shell` - The shell owning the environment.
+	pub fn get_str<S: AsRef<str>>(&self, name: S, shell: &shell::Shell) -> Option<Cow<'_, str>> {
+		self
+			.get(name.as_ref())
+			.map(|(_, v)| v.value().to_cow_str(shell))
+	}
 
-    /// Checks if a variable of the given name is set in the environment.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to check.
-    pub fn is_set<S: AsRef<str>>(&self, name: S) -> bool {
-        if let Some((_, var)) = self.get(name) {
-            !matches!(var.value(), ShellValue::Unset(_))
-        } else {
-            false
-        }
-    }
+	/// Checks if a variable of the given name is set in the environment.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to check.
+	pub fn is_set<S: AsRef<str>>(&self, name: S) -> bool {
+		if let Some((_, var)) = self.get(name) {
+			!matches!(var.value(), ShellValue::Unset(_))
+		} else {
+			false
+		}
+	}
 
-    //
-    // Setters
-    //
+	//
+	// Setters
+	//
 
-    /// Tries to unset the variable with the given name in the environment, returning
-    /// whether or not such a variable existed.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to unset.
-    pub fn unset(&mut self, name: &str) -> Result<Option<ShellVariable>, error::Error> {
-        let mut local_count = 0;
-        for (scope_type, map) in self.scopes.iter_mut().rev() {
-            if matches!(scope_type, EnvironmentScope::Local) {
-                local_count += 1;
-            }
+	/// Tries to unset the variable with the given name in the environment, returning
+	/// whether or not such a variable existed.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to unset.
+	pub fn unset(&mut self, name: &str) -> Result<Option<ShellVariable>, error::Error> {
+		let mut local_count = 0;
+		for (scope_type, map) in self.scopes.iter_mut().rev() {
+			if matches!(scope_type, EnvironmentScope::Local) {
+				local_count += 1;
+			}
 
-            let unset_result = Self::try_unset_in_map(map, name)?;
+			let unset_result = Self::try_unset_in_map(map, name)?;
 
-            if unset_result.is_some() {
-                // If we end up finding a local in the top-most local frame, then we replace
-                // it with a placeholder.
-                if matches!(scope_type, EnvironmentScope::Local) && local_count == 1 {
-                    map.set(
-                        name,
-                        ShellVariable::new(ShellValue::Unset(ShellValueUnsetType::Untyped)),
-                    );
-                } else if self.entry_count > 0 {
-                    // Entry count should never be 0 here, but we're being defensive.
-                    self.entry_count -= 1;
-                }
+			if unset_result.is_some() {
+				// If we end up finding a local in the top-most local frame, then we replace
+				// it with a placeholder.
+				if matches!(scope_type, EnvironmentScope::Local) && local_count == 1 {
+					map.set(name, ShellVariable::new(ShellValue::Unset(ShellValueUnsetType::Untyped)));
+				} else if self.entry_count > 0 {
+					// Entry count should never be 0 here, but we're being defensive.
+					self.entry_count -= 1;
+				}
 
-                return Ok(unset_result);
-            }
-        }
+				return Ok(unset_result);
+			}
+		}
 
-        Ok(None)
-    }
+		Ok(None)
+	}
 
-    /// Tries to unset an array element from the environment, using the given name and
-    /// element index for lookup. Returns whether or not an element was unset.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the array variable to unset an element from.
-    /// * `index` - The index of the element to unset.
-    pub fn unset_index(&mut self, name: &str, index: &str) -> Result<bool, error::Error> {
-        if let Some((_, var)) = self.get_mut(name) {
-            var.unset_index(index)
-        } else {
-            Ok(false)
-        }
-    }
+	/// Tries to unset an array element from the environment, using the given name and
+	/// element index for lookup. Returns whether or not an element was unset.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the array variable to unset an element from.
+	/// * `index` - The index of the element to unset.
+	pub fn unset_index(&mut self, name: &str, index: &str) -> Result<bool, error::Error> {
+		if let Some((_, var)) = self.get_mut(name) {
+			var.unset_index(index)
+		} else {
+			Ok(false)
+		}
+	}
 
-    fn try_unset_in_map(
-        map: &mut ShellVariableMap,
-        name: &str,
-    ) -> Result<Option<ShellVariable>, error::Error> {
-        match map.get(name).map(|v| v.is_readonly()) {
-            Some(true) => Err(error::ErrorKind::ReadonlyVariable.into()),
-            Some(false) => Ok(map.unset(name)),
-            None => Ok(None),
-        }
-    }
+	fn try_unset_in_map(
+		map: &mut ShellVariableMap,
+		name: &str,
+	) -> Result<Option<ShellVariable>, error::Error> {
+		match map.get(name).map(|v| v.is_readonly()) {
+			Some(true) => Err(error::ErrorKind::ReadonlyVariable.into()),
+			Some(false) => Ok(map.unset(name)),
+			None => Ok(None),
+		}
+	}
 
-    /// Tries to retrieve an immutable reference to a variable from the environment,
-    /// using the given name and lookup policy.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to retrieve.
-    /// * `lookup_policy` - The policy to use when looking up the variable.
-    pub fn get_using_policy<N: AsRef<str>>(
-        &self,
-        name: N,
-        lookup_policy: EnvironmentLookup,
-    ) -> Option<&ShellVariable> {
-        let mut local_count = 0;
-        for (scope_type, var_map) in self.scopes.iter().rev() {
-            if matches!(scope_type, EnvironmentScope::Local) {
-                local_count += 1;
-            }
+	/// Tries to retrieve an immutable reference to a variable from the environment,
+	/// using the given name and lookup policy.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to retrieve.
+	/// * `lookup_policy` - The policy to use when looking up the variable.
+	pub fn get_using_policy<N: AsRef<str>>(
+		&self,
+		name: N,
+		lookup_policy: EnvironmentLookup,
+	) -> Option<&ShellVariable> {
+		let mut local_count = 0;
+		for (scope_type, var_map) in self.scopes.iter().rev() {
+			if matches!(scope_type, EnvironmentScope::Local) {
+				local_count += 1;
+			}
 
-            match lookup_policy {
-                EnvironmentLookup::Anywhere => (),
-                EnvironmentLookup::OnlyInGlobal => {
-                    if !matches!(scope_type, EnvironmentScope::Global) {
-                        continue;
-                    }
-                }
-                EnvironmentLookup::OnlyInCurrentLocal => {
-                    if !(matches!(scope_type, EnvironmentScope::Local) && local_count == 1) {
-                        continue;
-                    }
-                }
-                EnvironmentLookup::OnlyInLocal => {
-                    if !matches!(scope_type, EnvironmentScope::Local) {
-                        continue;
-                    }
-                }
-            }
+			match lookup_policy {
+				EnvironmentLookup::Anywhere => (),
+				EnvironmentLookup::OnlyInGlobal => {
+					if !matches!(scope_type, EnvironmentScope::Global) {
+						continue;
+					}
+				},
+				EnvironmentLookup::OnlyInCurrentLocal => {
+					if !(matches!(scope_type, EnvironmentScope::Local) && local_count == 1) {
+						continue;
+					}
+				},
+				EnvironmentLookup::OnlyInLocal => {
+					if !matches!(scope_type, EnvironmentScope::Local) {
+						continue;
+					}
+				},
+			}
 
-            if let Some(var) = var_map.get(name.as_ref()) {
-                return Some(var);
-            }
+			if let Some(var) = var_map.get(name.as_ref()) {
+				return Some(var);
+			}
 
-            if matches!(scope_type, EnvironmentScope::Local)
-                && matches!(lookup_policy, EnvironmentLookup::OnlyInCurrentLocal)
-            {
-                break;
-            }
-        }
+			if matches!(scope_type, EnvironmentScope::Local)
+				&& matches!(lookup_policy, EnvironmentLookup::OnlyInCurrentLocal)
+			{
+				break;
+			}
+		}
 
-        None
-    }
+		None
+	}
 
-    /// Tries to retrieve a mutable reference to a variable from the environment,
-    /// using the given name and lookup policy.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to retrieve.
-    /// * `lookup_policy` - The policy to use when looking up the variable.
-    pub fn get_mut_using_policy<N: AsRef<str>>(
-        &mut self,
-        name: N,
-        lookup_policy: EnvironmentLookup,
-    ) -> Option<&mut ShellVariable> {
-        let mut local_count = 0;
-        for (scope_type, var_map) in self.scopes.iter_mut().rev() {
-            if matches!(scope_type, EnvironmentScope::Local) {
-                local_count += 1;
-            }
+	/// Tries to retrieve a mutable reference to a variable from the environment,
+	/// using the given name and lookup policy.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to retrieve.
+	/// * `lookup_policy` - The policy to use when looking up the variable.
+	pub fn get_mut_using_policy<N: AsRef<str>>(
+		&mut self,
+		name: N,
+		lookup_policy: EnvironmentLookup,
+	) -> Option<&mut ShellVariable> {
+		let mut local_count = 0;
+		for (scope_type, var_map) in self.scopes.iter_mut().rev() {
+			if matches!(scope_type, EnvironmentScope::Local) {
+				local_count += 1;
+			}
 
-            match lookup_policy {
-                EnvironmentLookup::Anywhere => (),
-                EnvironmentLookup::OnlyInGlobal => {
-                    if !matches!(scope_type, EnvironmentScope::Global) {
-                        continue;
-                    }
-                }
-                EnvironmentLookup::OnlyInCurrentLocal => {
-                    if !(matches!(scope_type, EnvironmentScope::Local) && local_count == 1) {
-                        continue;
-                    }
-                }
-                EnvironmentLookup::OnlyInLocal => {
-                    if !matches!(scope_type, EnvironmentScope::Local) {
-                        continue;
-                    }
-                }
-            }
+			match lookup_policy {
+				EnvironmentLookup::Anywhere => (),
+				EnvironmentLookup::OnlyInGlobal => {
+					if !matches!(scope_type, EnvironmentScope::Global) {
+						continue;
+					}
+				},
+				EnvironmentLookup::OnlyInCurrentLocal => {
+					if !(matches!(scope_type, EnvironmentScope::Local) && local_count == 1) {
+						continue;
+					}
+				},
+				EnvironmentLookup::OnlyInLocal => {
+					if !matches!(scope_type, EnvironmentScope::Local) {
+						continue;
+					}
+				},
+			}
 
-            if let Some(var) = var_map.get_mut(name.as_ref()) {
-                return Some(var);
-            }
+			if let Some(var) = var_map.get_mut(name.as_ref()) {
+				return Some(var);
+			}
 
-            if matches!(scope_type, EnvironmentScope::Local)
-                && matches!(lookup_policy, EnvironmentLookup::OnlyInCurrentLocal)
-            {
-                break;
-            }
-        }
+			if matches!(scope_type, EnvironmentScope::Local)
+				&& matches!(lookup_policy, EnvironmentLookup::OnlyInCurrentLocal)
+			{
+				break;
+			}
+		}
 
-        None
-    }
+		None
+	}
 
-    /// Update a variable in the environment, or add it if it doesn't already exist.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to update or add.
-    /// * `value` - The value to assign to the variable.
-    /// * `updater` - A function to call to update the variable after assigning the value.
-    /// * `lookup_policy` - The policy to use when looking up the variable.
-    /// * `scope_if_creating` - The scope to create the variable in if it doesn't already exist.
-    pub fn update_or_add<N: Into<String>>(
-        &mut self,
-        name: N,
-        value: variables::ShellValueLiteral,
-        updater: impl Fn(&mut ShellVariable) -> Result<(), error::Error>,
-        lookup_policy: EnvironmentLookup,
-        scope_if_creating: EnvironmentScope,
-    ) -> Result<(), error::Error> {
-        let name = name.into();
+	/// Update a variable in the environment, or add it if it doesn't already exist.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to update or add.
+	/// * `value` - The value to assign to the variable.
+	/// * `updater` - A function to call to update the variable after assigning the value.
+	/// * `lookup_policy` - The policy to use when looking up the variable.
+	/// * `scope_if_creating` - The scope to create the variable in if it doesn't already exist.
+	pub fn update_or_add<N: Into<String>>(
+		&mut self,
+		name: N,
+		value: variables::ShellValueLiteral,
+		updater: impl Fn(&mut ShellVariable) -> Result<(), error::Error>,
+		lookup_policy: EnvironmentLookup,
+		scope_if_creating: EnvironmentScope,
+	) -> Result<(), error::Error> {
+		let name = name.into();
 
-        let auto_export = self.export_variables_on_modification;
-        if let Some(var) = self.get_mut_using_policy(&name, lookup_policy) {
-            var.assign(value, false)?;
-            if auto_export {
-                var.export();
-            }
-            updater(var)
-        } else {
-            let mut var = ShellVariable::new(ShellValue::Unset(ShellValueUnsetType::Untyped));
-            var.assign(value, false)?;
-            if auto_export {
-                var.export();
-            }
-            updater(&mut var)?;
+		let auto_export = self.export_variables_on_modification;
+		if let Some(var) = self.get_mut_using_policy(&name, lookup_policy) {
+			var.assign(value, false)?;
+			if auto_export {
+				var.export();
+			}
+			updater(var)
+		} else {
+			let mut var = ShellVariable::new(ShellValue::Unset(ShellValueUnsetType::Untyped));
+			var.assign(value, false)?;
+			if auto_export {
+				var.export();
+			}
+			updater(&mut var)?;
 
-            self.add(name, var, scope_if_creating)
-        }
-    }
+			self.add(name, var, scope_if_creating)
+		}
+	}
 
-    /// Update an array element in the environment, or add it if it doesn't already exist.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to update or add.
-    /// * `index` - The index of the element to update or add.
-    /// * `value` - The value to assign to the variable.
-    /// * `updater` - A function to call to update the variable after assigning the value.
-    /// * `lookup_policy` - The policy to use when looking up the variable.
-    /// * `scope_if_creating` - The scope to create the variable in if it doesn't already exist.
-    pub fn update_or_add_array_element<N: Into<String>>(
-        &mut self,
-        name: N,
-        index: String,
-        value: String,
-        updater: impl Fn(&mut ShellVariable) -> Result<(), error::Error>,
-        lookup_policy: EnvironmentLookup,
-        scope_if_creating: EnvironmentScope,
-    ) -> Result<(), error::Error> {
-        let name = name.into();
+	/// Update an array element in the environment, or add it if it doesn't already exist.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to update or add.
+	/// * `index` - The index of the element to update or add.
+	/// * `value` - The value to assign to the variable.
+	/// * `updater` - A function to call to update the variable after assigning the value.
+	/// * `lookup_policy` - The policy to use when looking up the variable.
+	/// * `scope_if_creating` - The scope to create the variable in if it doesn't already exist.
+	pub fn update_or_add_array_element<N: Into<String>>(
+		&mut self,
+		name: N,
+		index: String,
+		value: String,
+		updater: impl Fn(&mut ShellVariable) -> Result<(), error::Error>,
+		lookup_policy: EnvironmentLookup,
+		scope_if_creating: EnvironmentScope,
+	) -> Result<(), error::Error> {
+		let name = name.into();
 
-        if let Some(var) = self.get_mut_using_policy(&name, lookup_policy) {
-            var.assign_at_index(index, value, false)?;
-            updater(var)
-        } else {
-            let mut var = ShellVariable::new(ShellValue::Unset(ShellValueUnsetType::Untyped));
-            var.assign(
-                variables::ShellValueLiteral::Array(variables::ArrayLiteral(vec![(
-                    Some(index),
-                    value,
-                )])),
-                false,
-            )?;
-            updater(&mut var)?;
+		if let Some(var) = self.get_mut_using_policy(&name, lookup_policy) {
+			var.assign_at_index(index, value, false)?;
+			updater(var)
+		} else {
+			let mut var = ShellVariable::new(ShellValue::Unset(ShellValueUnsetType::Untyped));
+			var.assign(
+				variables::ShellValueLiteral::Array(variables::ArrayLiteral(vec![(
+					Some(index),
+					value,
+				)])),
+				false,
+			)?;
+			updater(&mut var)?;
 
-            self.add(name, var, scope_if_creating)
-        }
-    }
+			self.add(name, var, scope_if_creating)
+		}
+	}
 
-    /// Adds a variable to the environment.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to add.
-    /// * `var` - The variable to add.
-    /// * `target_scope` - The scope to add the variable to.
-    pub fn add<N: Into<String>>(
-        &mut self,
-        name: N,
-        mut var: ShellVariable,
-        target_scope: EnvironmentScope,
-    ) -> Result<(), error::Error> {
-        if self.export_variables_on_modification {
-            var.export();
-        }
+	/// Adds a variable to the environment.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to add.
+	/// * `var` - The variable to add.
+	/// * `target_scope` - The scope to add the variable to.
+	pub fn add<N: Into<String>>(
+		&mut self,
+		name: N,
+		mut var: ShellVariable,
+		target_scope: EnvironmentScope,
+	) -> Result<(), error::Error> {
+		if self.export_variables_on_modification {
+			var.export();
+		}
 
-        for (scope_type, map) in self.scopes.iter_mut().rev() {
-            if *scope_type == target_scope {
-                let prev_var = map.set(name, var);
-                if prev_var.is_none() {
-                    self.entry_count += 1;
-                }
+		for (scope_type, map) in self.scopes.iter_mut().rev() {
+			if *scope_type == target_scope {
+				let prev_var = map.set(name, var);
+				if prev_var.is_none() {
+					self.entry_count += 1;
+				}
 
-                return Ok(());
-            }
-        }
+				return Ok(());
+			}
+		}
 
-        Err(error::ErrorKind::MissingScope.into())
-    }
+		Err(error::ErrorKind::MissingScope.into())
+	}
 
-    /// Sets a global variable in the environment.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to set.
-    /// * `var` - The variable to set.
-    pub fn set_global<N: Into<String>>(
-        &mut self,
-        name: N,
-        var: ShellVariable,
-    ) -> Result<(), error::Error> {
-        self.add(name, var, EnvironmentScope::Global)
-    }
+	/// Sets a global variable in the environment.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to set.
+	/// * `var` - The variable to set.
+	pub fn set_global<N: Into<String>>(
+		&mut self,
+		name: N,
+		var: ShellVariable,
+	) -> Result<(), error::Error> {
+		self.add(name, var, EnvironmentScope::Global)
+	}
 }
 
 /// Represents a map from names to shell variables.
 #[derive(Clone, Debug, Default)]
 pub struct ShellVariableMap {
-    variables: HashMap<String, ShellVariable>,
+	variables: HashMap<String, ShellVariable>,
 }
 
 impl ShellVariableMap {
-    //
-    // Iterators/Getters
-    //
+	//
+	// Iterators/Getters
+	//
 
-    /// Returns an iterator over all the variables in the map.
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &ShellVariable)> {
-        self.variables.iter()
-    }
+	/// Returns an iterator over all the variables in the map.
+	pub fn iter(&self) -> impl Iterator<Item = (&String, &ShellVariable)> {
+		self.variables.iter()
+	}
 
-    /// Tries to retrieve an immutable reference to the variable with the given name.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to retrieve.
-    pub fn get(&self, name: &str) -> Option<&ShellVariable> {
-        self.variables.get(name)
-    }
+	/// Tries to retrieve an immutable reference to the variable with the given name.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to retrieve.
+	pub fn get(&self, name: &str) -> Option<&ShellVariable> {
+		self.variables.get(name)
+	}
 
-    /// Tries to retrieve a mutable reference to the variable with the given name.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to retrieve.
-    pub fn get_mut(&mut self, name: &str) -> Option<&mut ShellVariable> {
-        self.variables.get_mut(name)
-    }
+	/// Tries to retrieve a mutable reference to the variable with the given name.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to retrieve.
+	pub fn get_mut(&mut self, name: &str) -> Option<&mut ShellVariable> {
+		self.variables.get_mut(name)
+	}
 
-    //
-    // Setters
-    //
+	//
+	// Setters
+	//
 
-    /// Tries to unset the variable with the given name, returning the removed
-    /// variable or None if it was not already set.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to unset.
-    pub fn unset(&mut self, name: &str) -> Option<ShellVariable> {
-        self.variables.remove(name)
-    }
+	/// Tries to unset the variable with the given name, returning the removed
+	/// variable or None if it was not already set.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to unset.
+	pub fn unset(&mut self, name: &str) -> Option<ShellVariable> {
+		self.variables.remove(name)
+	}
 
-    /// Sets a variable in the map.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to set.
-    /// * `var` - The variable to set.
-    pub fn set<N: Into<String>>(&mut self, name: N, var: ShellVariable) -> Option<ShellVariable> {
-        self.variables.insert(name.into(), var)
-    }
+	/// Sets a variable in the map.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to set.
+	/// * `var` - The variable to set.
+	pub fn set<N: Into<String>>(&mut self, name: N, var: ShellVariable) -> Option<ShellVariable> {
+		self.variables.insert(name.into(), var)
+	}
 }
 
 /// Checks if the given name is a valid variable name.
 pub fn valid_variable_name(s: &str) -> bool {
-    let mut cs = s.chars();
-    match cs.next() {
-        Some(c) if c.is_ascii_alphabetic() || c == '_' => {
-            cs.all(|c| c.is_ascii_alphanumeric() || c == '_')
-        }
-        Some(_) | None => false,
-    }
+	let mut cs = s.chars();
+	match cs.next() {
+		Some(c) if c.is_ascii_alphabetic() || c == '_' => {
+			cs.all(|c| c.is_ascii_alphanumeric() || c == '_')
+		},
+		Some(_) | None => false,
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_valid_variable_name() {
-        assert!(!valid_variable_name(""));
-        assert!(!valid_variable_name("1"));
-        assert!(!valid_variable_name(" a"));
-        assert!(!valid_variable_name(" "));
+	#[test]
+	fn test_valid_variable_name() {
+		assert!(!valid_variable_name(""));
+		assert!(!valid_variable_name("1"));
+		assert!(!valid_variable_name(" a"));
+		assert!(!valid_variable_name(" "));
 
-        assert!(valid_variable_name("_"));
-        assert!(valid_variable_name("_a"));
-        assert!(valid_variable_name("_1"));
-        assert!(valid_variable_name("_a1"));
-        assert!(valid_variable_name("a"));
-        assert!(valid_variable_name("A"));
-        assert!(valid_variable_name("a1"));
-        assert!(valid_variable_name("A1"));
-    }
+		assert!(valid_variable_name("_"));
+		assert!(valid_variable_name("_a"));
+		assert!(valid_variable_name("_1"));
+		assert!(valid_variable_name("_a1"));
+		assert!(valid_variable_name("a"));
+		assert!(valid_variable_name("A"));
+		assert!(valid_variable_name("a1"));
+		assert!(valid_variable_name("A1"));
+	}
 }

--- a/crates/brush-core-vendored/src/error.rs
+++ b/crates/brush-core-vendored/src/error.rs
@@ -9,249 +9,249 @@ use crate::{Shell, ShellFd, results, sys};
 #[derive(thiserror::Error, Debug)]
 #[error(transparent)]
 pub struct Error {
-    /// The kind of error.
-    kind: ErrorKind,
+	/// The kind of error.
+	kind: ErrorKind,
 }
 
 /// Monolithic error type for the shell
 #[derive(thiserror::Error, Debug)]
 pub enum ErrorKind {
-    /// A tilde expression was used without a valid HOME variable
-    #[error("cannot expand tilde expression with HOME not set")]
-    TildeWithoutValidHome,
+	/// A tilde expression was used without a valid HOME variable
+	#[error("cannot expand tilde expression with HOME not set")]
+	TildeWithoutValidHome,
 
-    /// An attempt was made to assign a list to an array member
-    #[error("cannot assign list to array member")]
-    AssigningListToArrayMember,
+	/// An attempt was made to assign a list to an array member
+	#[error("cannot assign list to array member")]
+	AssigningListToArrayMember,
 
-    /// An attempt was made to convert an associative array to an indexed array.
-    #[error("cannot convert associative array to indexed array")]
-    ConvertingAssociativeArrayToIndexedArray,
+	/// An attempt was made to convert an associative array to an indexed array.
+	#[error("cannot convert associative array to indexed array")]
+	ConvertingAssociativeArrayToIndexedArray,
 
-    /// An attempt was made to convert an indexed array to an associative array.
-    #[error("cannot convert indexed array to associative array")]
-    ConvertingIndexedArrayToAssociativeArray,
+	/// An attempt was made to convert an indexed array to an associative array.
+	#[error("cannot convert indexed array to associative array")]
+	ConvertingIndexedArrayToAssociativeArray,
 
-    /// An error occurred while sourcing the indicated script file.
-    #[error("failed to source file: {0}")]
-    FailedSourcingFile(PathBuf, #[source] std::io::Error),
+	/// An error occurred while sourcing the indicated script file.
+	#[error("failed to source file: {0}")]
+	FailedSourcingFile(PathBuf, #[source] std::io::Error),
 
-    /// The shell failed to send a signal to a process.
-    #[error("failed to send signal to process")]
-    FailedToSendSignal,
+	/// The shell failed to send a signal to a process.
+	#[error("failed to send signal to process")]
+	FailedToSendSignal,
 
-    /// An attempt was made to assign a value to a special parameter.
-    #[error("cannot assign in this way")]
-    CannotAssignToSpecialParameter,
+	/// An attempt was made to assign a value to a special parameter.
+	#[error("cannot assign in this way")]
+	CannotAssignToSpecialParameter,
 
-    /// Checked expansion error.
-    #[error("expansion error: {0}")]
-    CheckedExpansionError(String),
+	/// Checked expansion error.
+	#[error("expansion error: {0}")]
+	CheckedExpansionError(String),
 
-    /// A reference was made to an unknown shell function.
-    #[error("function not found: {0}")]
-    FunctionNotFound(String),
+	/// A reference was made to an unknown shell function.
+	#[error("function not found: {0}")]
+	FunctionNotFound(String),
 
-    /// Command was not found.
-    #[error("command not found: {0}")]
-    CommandNotFound(String),
+	/// Command was not found.
+	#[error("command not found: {0}")]
+	CommandNotFound(String),
 
-    /// Not a builtin.
-    #[error("not a shell builtin: {0}")]
-    BuiltinNotFound(String),
+	/// Not a builtin.
+	#[error("not a shell builtin: {0}")]
+	BuiltinNotFound(String),
 
-    /// The working directory does not exist.
-    #[error("working directory does not exist: {0}")]
-    WorkingDirMissing(PathBuf),
+	/// The working directory does not exist.
+	#[error("working directory does not exist: {0}")]
+	WorkingDirMissing(PathBuf),
 
-    /// Failed to execute command.
-    #[error("failed to execute command '{0}': {1}")]
-    FailedToExecuteCommand(String, #[source] std::io::Error),
+	/// Failed to execute command.
+	#[error("failed to execute command '{0}': {1}")]
+	FailedToExecuteCommand(String, #[source] std::io::Error),
 
-    /// History item was not found.
-    #[error("history item not found")]
-    HistoryItemNotFound,
+	/// History item was not found.
+	#[error("history item not found")]
+	HistoryItemNotFound,
 
-    /// The requested functionality has not yet been implemented in this shell.
-    #[error("not yet implemented: {0}")]
-    Unimplemented(&'static str),
+	/// The requested functionality has not yet been implemented in this shell.
+	#[error("not yet implemented: {0}")]
+	Unimplemented(&'static str),
 
-    /// The requested functionality has not yet been implemented in this shell; it is tracked in a
-    /// GitHub issue.
-    #[error("not yet implemented: {0}; see https://github.com/reubeno/brush/issues/{1}")]
-    UnimplementedAndTracked(&'static str, u32),
+	/// The requested functionality has not yet been implemented in this shell; it is tracked in a
+	/// GitHub issue.
+	#[error("not yet implemented: {0}; see https://github.com/reubeno/brush/issues/{1}")]
+	UnimplementedAndTracked(&'static str, u32),
 
-    /// An expected environment scope could not be found.
-    #[error("missing scope")]
-    MissingScope,
+	/// An expected environment scope could not be found.
+	#[error("missing scope")]
+	MissingScope,
 
-    /// The given path is not a directory.
-    #[error("not a directory: {0}")]
-    NotADirectory(PathBuf),
+	/// The given path is not a directory.
+	#[error("not a directory: {0}")]
+	NotADirectory(PathBuf),
 
-    /// The given path is a directory.
-    #[error("path is a directory")]
-    IsADirectory,
+	/// The given path is a directory.
+	#[error("path is a directory")]
+	IsADirectory,
 
-    /// The given variable is not an array.
-    #[error("variable is not an array")]
-    NotArray,
+	/// The given variable is not an array.
+	#[error("variable is not an array")]
+	NotArray,
 
-    /// The current user could not be determined.
-    #[error("no current user")]
-    NoCurrentUser,
+	/// The current user could not be determined.
+	#[error("no current user")]
+	NoCurrentUser,
 
-    /// The requested input or output redirection is invalid.
-    #[error("invalid redirection")]
-    InvalidRedirection,
+	/// The requested input or output redirection is invalid.
+	#[error("invalid redirection")]
+	InvalidRedirection,
 
-    /// An error occurred while redirecting input or output with the given file.
-    #[error("failed to redirect to {0}: {1}")]
-    RedirectionFailure(String, String),
+	/// An error occurred while redirecting input or output with the given file.
+	#[error("failed to redirect to {0}: {1}")]
+	RedirectionFailure(String, String),
 
-    /// An error occurred evaluating an arithmetic expression.
-    #[error("arithmetic evaluation error: {0}")]
-    EvalError(#[from] crate::arithmetic::EvalError),
+	/// An error occurred evaluating an arithmetic expression.
+	#[error("arithmetic evaluation error: {0}")]
+	EvalError(#[from] crate::arithmetic::EvalError),
 
-    /// The given string could not be parsed as an integer.
-    #[error("failed to parse integer")]
-    IntParseError(#[from] std::num::ParseIntError),
+	/// The given string could not be parsed as an integer.
+	#[error("failed to parse integer")]
+	IntParseError(#[from] std::num::ParseIntError),
 
-    /// The given string could not be parsed as an integer.
-    #[error("failed to parse integer")]
-    TryIntParseError(#[from] std::num::TryFromIntError),
+	/// The given string could not be parsed as an integer.
+	#[error("failed to parse integer")]
+	TryIntParseError(#[from] std::num::TryFromIntError),
 
-    /// A byte sequence could not be decoded as a valid UTF-8 string.
-    #[error("failed to decode utf-8")]
-    FromUtf8Error(#[from] std::string::FromUtf8Error),
+	/// A byte sequence could not be decoded as a valid UTF-8 string.
+	#[error("failed to decode utf-8")]
+	FromUtf8Error(#[from] std::string::FromUtf8Error),
 
-    /// A byte sequence could not be decoded as a valid UTF-8 string.
-    #[error("failed to decode utf-8")]
-    Utf8Error(#[from] std::str::Utf8Error),
+	/// A byte sequence could not be decoded as a valid UTF-8 string.
+	#[error("failed to decode utf-8")]
+	Utf8Error(#[from] std::str::Utf8Error),
 
-    /// An attempt was made to modify a readonly variable.
-    #[error("cannot mutate readonly variable")]
-    ReadonlyVariable,
+	/// An attempt was made to modify a readonly variable.
+	#[error("cannot mutate readonly variable")]
+	ReadonlyVariable,
 
-    /// The indicated pattern is invalid.
-    #[error("invalid pattern: '{0}'")]
-    InvalidPattern(String),
+	/// The indicated pattern is invalid.
+	#[error("invalid pattern: '{0}'")]
+	InvalidPattern(String),
 
-    /// A regular expression error occurred
-    #[error("regex error: {0}")]
-    RegexError(#[from] fancy_regex::Error),
+	/// A regular expression error occurred
+	#[error("regex error: {0}")]
+	RegexError(#[from] fancy_regex::Error),
 
-    /// An invalid regular expression was provided.
-    #[error("invalid regex: {0}; expression: '{1}'")]
-    InvalidRegexError(fancy_regex::Error, String),
+	/// An invalid regular expression was provided.
+	#[error("invalid regex: {0}; expression: '{1}'")]
+	InvalidRegexError(fancy_regex::Error, String),
 
-    /// An I/O error occurred.
-    #[error("i/o error: {0}")]
-    IoError(#[from] std::io::Error),
+	/// An I/O error occurred.
+	#[error("i/o error: {0}")]
+	IoError(#[from] std::io::Error),
 
-    /// Invalid substitution syntax.
-    #[error("bad substitution: {0}")]
-    BadSubstitution(String),
+	/// Invalid substitution syntax.
+	#[error("bad substitution: {0}")]
+	BadSubstitution(String),
 
-    /// An error occurred while creating a child process.
-    #[error("failed to create child process")]
-    ChildCreationFailure,
+	/// An error occurred while creating a child process.
+	#[error("failed to create child process")]
+	ChildCreationFailure,
 
-    /// An error occurred while formatting a string.
-    #[error(transparent)]
-    FormattingError(#[from] std::fmt::Error),
+	/// An error occurred while formatting a string.
+	#[error(transparent)]
+	FormattingError(#[from] std::fmt::Error),
 
-    /// An error occurred while parsing.
-    #[error("{1}: {0}")]
-    ParseError(brush_parser::ParseError, brush_parser::SourceInfo),
+	/// An error occurred while parsing.
+	#[error("{1}: {0}")]
+	ParseError(brush_parser::ParseError, brush_parser::SourceInfo),
 
-    /// An error occurred while parsing a function body.
-    #[error("{0}: {1}")]
-    FunctionParseError(String, brush_parser::ParseError),
+	/// An error occurred while parsing a function body.
+	#[error("{0}: {1}")]
+	FunctionParseError(String, brush_parser::ParseError),
 
-    /// An error occurred while parsing a word.
-    #[error(transparent)]
-    WordParseError(#[from] brush_parser::WordParseError),
+	/// An error occurred while parsing a word.
+	#[error(transparent)]
+	WordParseError(#[from] brush_parser::WordParseError),
 
-    /// Unable to parse a test command.
-    #[error(transparent)]
-    TestCommandParseError(#[from] brush_parser::TestCommandParseError),
+	/// Unable to parse a test command.
+	#[error(transparent)]
+	TestCommandParseError(#[from] brush_parser::TestCommandParseError),
 
-    /// Unable to parse a key binding specification.
-    #[error(transparent)]
-    BindingParseError(#[from] brush_parser::BindingParseError),
+	/// Unable to parse a key binding specification.
+	#[error(transparent)]
+	BindingParseError(#[from] brush_parser::BindingParseError),
 
-    /// A threading error occurred.
-    #[error("threading error")]
-    ThreadingError(#[from] tokio::task::JoinError),
+	/// A threading error occurred.
+	#[error("threading error")]
+	ThreadingError(#[from] tokio::task::JoinError),
 
-    /// An invalid signal was referenced.
-    #[error("{0}: invalid signal specification")]
-    InvalidSignal(String),
+	/// An invalid signal was referenced.
+	#[error("{0}: invalid signal specification")]
+	InvalidSignal(String),
 
-    /// A platform error occurred.
-    #[error("platform error: {0}")]
-    PlatformError(#[from] sys::PlatformError),
+	/// A platform error occurred.
+	#[error("platform error: {0}")]
+	PlatformError(#[from] sys::PlatformError),
 
-    /// An invalid umask was provided.
-    #[error("invalid umask value")]
-    InvalidUmask,
+	/// An invalid umask was provided.
+	#[error("invalid umask value")]
+	InvalidUmask,
 
-    /// The given open file cannot be read from.
-    #[error("cannot read from {0}")]
-    OpenFileNotReadable(&'static str),
+	/// The given open file cannot be read from.
+	#[error("cannot read from {0}")]
+	OpenFileNotReadable(&'static str),
 
-    /// The given open file cannot be written to.
-    #[error("cannot write to {0}")]
-    OpenFileNotWritable(&'static str),
+	/// The given open file cannot be written to.
+	#[error("cannot write to {0}")]
+	OpenFileNotWritable(&'static str),
 
-    /// Bad file descriptor.
-    #[error("bad file descriptor: {0}")]
-    BadFileDescriptor(ShellFd),
+	/// Bad file descriptor.
+	#[error("bad file descriptor: {0}")]
+	BadFileDescriptor(ShellFd),
 
-    /// Printf failure
-    #[error("printf failure: {0}")]
-    PrintfFailure(i32),
+	/// Printf failure
+	#[error("printf failure: {0}")]
+	PrintfFailure(i32),
 
-    /// Printf invalid usage
-    #[error("printf: {0}")]
-    PrintfInvalidUsage(String),
+	/// Printf invalid usage
+	#[error("printf: {0}")]
+	PrintfInvalidUsage(String),
 
-    /// Interrupted
-    #[error("interrupted")]
-    Interrupted,
+	/// Interrupted
+	#[error("interrupted")]
+	Interrupted,
 
-    /// Maximum function call depth was exceeded.
-    #[error("maximum function call depth exceeded")]
-    MaxFunctionCallDepthExceeded,
+	/// Maximum function call depth was exceeded.
+	#[error("maximum function call depth exceeded")]
+	MaxFunctionCallDepthExceeded,
 
-    /// System time error.
-    #[error("system time error: {0}")]
-    TimeError(#[from] std::time::SystemTimeError),
+	/// System time error.
+	#[error("system time error: {0}")]
+	TimeError(#[from] std::time::SystemTimeError),
 
-    /// Array index out of range.
-    #[error("array index out of range: {0}")]
-    ArrayIndexOutOfRange(i64),
+	/// Array index out of range.
+	#[error("array index out of range: {0}")]
+	ArrayIndexOutOfRange(i64),
 
-    /// Unhandled key code.
-    #[error("unhandled key code: {0:?}")]
-    UnhandledKeyCode(Vec<u8>),
+	/// Unhandled key code.
+	#[error("unhandled key code: {0:?}")]
+	UnhandledKeyCode(Vec<u8>),
 
-    /// An error occurred in a built-in command.
-    #[error("{1}: {0}")]
-    BuiltinError(Box<dyn BuiltinError>, String),
+	/// An error occurred in a built-in command.
+	#[error("{1}: {0}")]
+	BuiltinError(Box<dyn BuiltinError>, String),
 
-    /// Operation not supported on this platform.
-    #[error("operation not supported on this platform: {0}")]
-    NotSupportedOnThisPlatform(&'static str),
+	/// Operation not supported on this platform.
+	#[error("operation not supported on this platform: {0}")]
+	NotSupportedOnThisPlatform(&'static str),
 
-    /// Command history is not enabled in this shell.
-    #[error("command history is not enabled in this shell")]
-    HistoryNotEnabled,
+	/// Command history is not enabled in this shell.
+	#[error("command history is not enabled in this shell")]
+	HistoryNotEnabled,
 
-    /// Unknown key binding function.
-    #[error("unknown key binding function: {0}")]
-    UnknownKeyBindingFunction(String),
+	/// Unknown key binding function.
+	#[error("unknown key binding function: {0}")]
+	UnknownKeyBindingFunction(String),
 }
 
 impl BuiltinError for Error {}
@@ -261,77 +261,75 @@ pub trait BuiltinError: std::error::Error + ConvertibleToExitCode + Send + Sync 
 
 /// Helper trait for converting values to exit codes.
 pub trait ConvertibleToExitCode {
-    /// Converts to an exit code.
-    fn as_exit_code(&self) -> results::ExecutionExitCode;
+	/// Converts to an exit code.
+	fn as_exit_code(&self) -> results::ExecutionExitCode;
 }
 
 impl<T> ConvertibleToExitCode for T
 where
-    results::ExecutionExitCode: for<'a> From<&'a T>,
+	results::ExecutionExitCode: for<'a> From<&'a T>,
 {
-    fn as_exit_code(&self) -> results::ExecutionExitCode {
-        self.into()
-    }
+	fn as_exit_code(&self) -> results::ExecutionExitCode {
+		self.into()
+	}
 }
 
 impl From<&ErrorKind> for results::ExecutionExitCode {
-    fn from(value: &ErrorKind) -> Self {
-        match value {
-            ErrorKind::CommandNotFound(..) => Self::NotFound,
-            ErrorKind::Unimplemented(..) | ErrorKind::UnimplementedAndTracked(..) => {
-                Self::Unimplemented
-            }
-            ErrorKind::ParseError(..) => Self::InvalidUsage,
-            ErrorKind::FunctionParseError(..) => Self::InvalidUsage,
-            ErrorKind::FailedToExecuteCommand(..) => Self::CannotExecute,
-            ErrorKind::BuiltinError(inner, ..) => inner.as_exit_code(),
-            _ => Self::GeneralError,
-        }
-    }
+	fn from(value: &ErrorKind) -> Self {
+		match value {
+			ErrorKind::CommandNotFound(..) => Self::NotFound,
+			ErrorKind::Unimplemented(..) | ErrorKind::UnimplementedAndTracked(..) => {
+				Self::Unimplemented
+			},
+			ErrorKind::ParseError(..) => Self::InvalidUsage,
+			ErrorKind::FunctionParseError(..) => Self::InvalidUsage,
+			ErrorKind::FailedToExecuteCommand(..) => Self::CannotExecute,
+			ErrorKind::BuiltinError(inner, ..) => inner.as_exit_code(),
+			_ => Self::GeneralError,
+		}
+	}
 }
 
 impl From<&Error> for results::ExecutionExitCode {
-    fn from(error: &Error) -> Self {
-        Self::from(&error.kind)
-    }
+	fn from(error: &Error) -> Self {
+		Self::from(&error.kind)
+	}
 }
 
 impl<T> From<T> for Error
 where
-    ErrorKind: From<T>,
+	ErrorKind: From<T>,
 {
-    fn from(convertible_to_kind: T) -> Self {
-        Self {
-            kind: convertible_to_kind.into(),
-        }
-    }
+	fn from(convertible_to_kind: T) -> Self {
+		Self { kind: convertible_to_kind.into() }
+	}
 }
 
 /// Trait implementable by consumers of this crate to customize formatting errors into
 /// displayable text.
 pub trait ErrorFormatter: Send {
-    /// Format the given error for display within the context of the provided shell.
-    ///
-    /// # Arguments
-    ///
-    /// * `error` - The error to format.
-    /// * `shell` - The shell in which the error occurred.
-    fn format_error(&self, error: &Error, shell: &Shell) -> String;
+	/// Format the given error for display within the context of the provided shell.
+	///
+	/// # Arguments
+	///
+	/// * `error` - The error to format.
+	/// * `shell` - The shell in which the error occurred.
+	fn format_error(&self, error: &Error, shell: &Shell) -> String;
 }
 
 /// Default implementation of the [`ErrorFormatter`] trait.
 pub(crate) struct DefaultErrorFormatter {}
 
 impl DefaultErrorFormatter {
-    pub const fn new() -> Self {
-        Self {}
-    }
+	pub const fn new() -> Self {
+		Self {}
+	}
 }
 
 impl ErrorFormatter for DefaultErrorFormatter {
-    fn format_error(&self, err: &Error, _shell: &Shell) -> String {
-        std::format!("error: {err:#}\n")
-    }
+	fn format_error(&self, err: &Error, _shell: &Shell) -> String {
+		std::format!("error: {err:#}\n")
+	}
 }
 
 /// Convenience function for returning an error for unimplemented functionality.
@@ -340,7 +338,7 @@ impl ErrorFormatter for DefaultErrorFormatter {
 ///
 /// * `msg` - The message to include in the error
 pub fn unimp<T>(msg: &'static str) -> Result<T, Error> {
-    Err(ErrorKind::Unimplemented(msg).into())
+	Err(ErrorKind::Unimplemented(msg).into())
 }
 
 /// Convenience function for returning an error for *tracked*, unimplemented functionality.
@@ -351,5 +349,5 @@ pub fn unimp<T>(msg: &'static str) -> Result<T, Error> {
 /// * `project_issue_id` - The GitHub issue ID where the implementation is tracked.
 #[allow(unused)]
 pub fn unimp_with_issue<T>(msg: &'static str, project_issue_id: u32) -> Result<T, Error> {
-    Err(ErrorKind::UnimplementedAndTracked(msg, project_issue_id).into())
+	Err(ErrorKind::UnimplementedAndTracked(msg, project_issue_id).into())
 }

--- a/crates/brush-core-vendored/src/escape.rs
+++ b/crates/brush-core-vendored/src/escape.rs
@@ -9,10 +9,10 @@ use crate::error;
 /// Escape expansion mode.
 #[derive(Clone, Copy)]
 pub enum EscapeExpansionMode {
-    /// echo builtin mode.
-    EchoBuiltin,
-    /// ANSI-C quotes.
-    AnsiCQuotes,
+	/// echo builtin mode.
+	EchoBuiltin,
+	/// ANSI-C quotes.
+	AnsiCQuotes,
 }
 
 /// Expands backslash escapes in the provided string.
@@ -23,209 +23,209 @@ pub enum EscapeExpansionMode {
 /// * `mode` - The mode to use for expansion.
 
 pub fn expand_backslash_escapes(
-    s: &str,
-    mode: EscapeExpansionMode,
+	s: &str,
+	mode: EscapeExpansionMode,
 ) -> Result<(Vec<u8>, bool), error::Error> {
-    let mut result: Vec<u8> = vec![];
-    let mut it = s.chars();
-    while let Some(c) = it.next() {
-        if c != '\\' {
-            // Not a backslash, add and move on.
-            result.append(c.to_string().into_bytes().as_mut());
-            continue;
-        }
+	let mut result: Vec<u8> = vec![];
+	let mut it = s.chars();
+	while let Some(c) = it.next() {
+		if c != '\\' {
+			// Not a backslash, add and move on.
+			result.append(c.to_string().into_bytes().as_mut());
+			continue;
+		}
 
-        match it.next() {
-            Some('a') => result.push(b'\x07'),
-            Some('b') => result.push(b'\x08'),
-            Some('c') => {
-                match mode {
-                    EscapeExpansionMode::EchoBuiltin => {
-                        // Stop all additional output!
-                        return Ok((result, false));
-                    }
-                    EscapeExpansionMode::AnsiCQuotes => {
-                        if let Some(_next_next) = it.next() {
-                            return error::unimp("control character in ANSI C quotes");
-                        } else {
-                            result.push(b'\\');
-                            result.push(b'c');
-                        }
-                    }
-                }
-            }
-            Some('e' | 'E') => result.push(b'\x1b'),
-            Some('f') => result.push(b'\x0c'),
-            Some('n') => result.push(b'\n'),
-            Some('r') => result.push(b'\r'),
-            Some('t') => result.push(b'\t'),
-            Some('v') => result.push(b'\x0b'),
-            Some('\\') => result.push(b'\\'),
-            Some('\'') if matches!(mode, EscapeExpansionMode::AnsiCQuotes) => result.push(b'\''),
-            Some('\"') if matches!(mode, EscapeExpansionMode::AnsiCQuotes) => result.push(b'\"'),
-            Some('?') if matches!(mode, EscapeExpansionMode::AnsiCQuotes) => result.push(b'?'),
-            Some('0') => {
-                // Consume 0-3 valid octal chars
-                let mut taken_so_far = 0;
-                let mut octal_chars: String = it
-                    .take_while_ref(|c| {
-                        if taken_so_far < 3 && matches!(*c, '0'..='7') {
-                            taken_so_far += 1;
-                            true
-                        } else {
-                            false
-                        }
-                    })
-                    .collect();
+		match it.next() {
+			Some('a') => result.push(b'\x07'),
+			Some('b') => result.push(b'\x08'),
+			Some('c') => {
+				match mode {
+					EscapeExpansionMode::EchoBuiltin => {
+						// Stop all additional output!
+						return Ok((result, false));
+					},
+					EscapeExpansionMode::AnsiCQuotes => {
+						if let Some(_next_next) = it.next() {
+							return error::unimp("control character in ANSI C quotes");
+						} else {
+							result.push(b'\\');
+							result.push(b'c');
+						}
+					},
+				}
+			},
+			Some('e' | 'E') => result.push(b'\x1b'),
+			Some('f') => result.push(b'\x0c'),
+			Some('n') => result.push(b'\n'),
+			Some('r') => result.push(b'\r'),
+			Some('t') => result.push(b'\t'),
+			Some('v') => result.push(b'\x0b'),
+			Some('\\') => result.push(b'\\'),
+			Some('\'') if matches!(mode, EscapeExpansionMode::AnsiCQuotes) => result.push(b'\''),
+			Some('\"') if matches!(mode, EscapeExpansionMode::AnsiCQuotes) => result.push(b'\"'),
+			Some('?') if matches!(mode, EscapeExpansionMode::AnsiCQuotes) => result.push(b'?'),
+			Some('0') => {
+				// Consume 0-3 valid octal chars
+				let mut taken_so_far = 0;
+				let mut octal_chars: String = it
+					.take_while_ref(|c| {
+						if taken_so_far < 3 && matches!(*c, '0'..='7') {
+							taken_so_far += 1;
+							true
+						} else {
+							false
+						}
+					})
+					.collect();
 
-                if octal_chars.is_empty() {
-                    octal_chars.push('0');
-                }
+				if octal_chars.is_empty() {
+					octal_chars.push('0');
+				}
 
-                let value = u8::from_str_radix(octal_chars.as_str(), 8)?;
-                result.push(value);
-            }
-            Some('x') => {
-                // Consume 1-2 valid hex chars
-                let mut taken_so_far = 0;
-                let hex_chars: String = it
-                    .take_while_ref(|c| {
-                        if taken_so_far < 2 && c.is_ascii_hexdigit() {
-                            taken_so_far += 1;
-                            true
-                        } else {
-                            false
-                        }
-                    })
-                    .collect();
+				let value = u8::from_str_radix(octal_chars.as_str(), 8)?;
+				result.push(value);
+			},
+			Some('x') => {
+				// Consume 1-2 valid hex chars
+				let mut taken_so_far = 0;
+				let hex_chars: String = it
+					.take_while_ref(|c| {
+						if taken_so_far < 2 && c.is_ascii_hexdigit() {
+							taken_so_far += 1;
+							true
+						} else {
+							false
+						}
+					})
+					.collect();
 
-                if hex_chars.is_empty() {
-                    result.push(b'\\');
-                    result.append(c.to_string().into_bytes().as_mut());
-                } else {
-                    let value = u8::from_str_radix(hex_chars.as_str(), 16)?;
-                    result.push(value);
-                }
-            }
-            Some('u') => {
-                // Consume 1-4 hex digits
-                let mut taken_so_far = 0;
-                let hex_chars: String = it
-                    .take_while_ref(|c| {
-                        if taken_so_far < 4 && c.is_ascii_hexdigit() {
-                            taken_so_far += 1;
-                            true
-                        } else {
-                            false
-                        }
-                    })
-                    .collect();
+				if hex_chars.is_empty() {
+					result.push(b'\\');
+					result.append(c.to_string().into_bytes().as_mut());
+				} else {
+					let value = u8::from_str_radix(hex_chars.as_str(), 16)?;
+					result.push(value);
+				}
+			},
+			Some('u') => {
+				// Consume 1-4 hex digits
+				let mut taken_so_far = 0;
+				let hex_chars: String = it
+					.take_while_ref(|c| {
+						if taken_so_far < 4 && c.is_ascii_hexdigit() {
+							taken_so_far += 1;
+							true
+						} else {
+							false
+						}
+					})
+					.collect();
 
-                if hex_chars.is_empty() {
-                    result.push(b'\\');
-                    result.append(c.to_string().into_bytes().as_mut());
-                } else {
-                    let value = u16::from_str_radix(hex_chars.as_str(), 16)?;
+				if hex_chars.is_empty() {
+					result.push(b'\\');
+					result.append(c.to_string().into_bytes().as_mut());
+				} else {
+					let value = u16::from_str_radix(hex_chars.as_str(), 16)?;
 
-                    if let Some(decoded) = char::from_u32(u32::from(value)) {
-                        result.append(decoded.to_string().into_bytes().as_mut());
-                    } else {
-                        result.push(b'\\');
-                        result.append(c.to_string().into_bytes().as_mut());
-                    }
-                }
-            }
-            Some('U') => {
-                // Consume 1-8 hex digits
-                let mut taken_so_far = 0;
-                let hex_chars: String = it
-                    .take_while_ref(|c| {
-                        if taken_so_far < 8 && c.is_ascii_hexdigit() {
-                            taken_so_far += 1;
-                            true
-                        } else {
-                            false
-                        }
-                    })
-                    .collect();
+					if let Some(decoded) = char::from_u32(u32::from(value)) {
+						result.append(decoded.to_string().into_bytes().as_mut());
+					} else {
+						result.push(b'\\');
+						result.append(c.to_string().into_bytes().as_mut());
+					}
+				}
+			},
+			Some('U') => {
+				// Consume 1-8 hex digits
+				let mut taken_so_far = 0;
+				let hex_chars: String = it
+					.take_while_ref(|c| {
+						if taken_so_far < 8 && c.is_ascii_hexdigit() {
+							taken_so_far += 1;
+							true
+						} else {
+							false
+						}
+					})
+					.collect();
 
-                if hex_chars.is_empty() {
-                    result.push(b'\\');
-                    result.append(c.to_string().into_bytes().as_mut());
-                } else {
-                    let value = u32::from_str_radix(hex_chars.as_str(), 16)?;
+				if hex_chars.is_empty() {
+					result.push(b'\\');
+					result.append(c.to_string().into_bytes().as_mut());
+				} else {
+					let value = u32::from_str_radix(hex_chars.as_str(), 16)?;
 
-                    if let Some(decoded) = char::from_u32(value) {
-                        result.append(decoded.to_string().into_bytes().as_mut());
-                    } else {
-                        result.push(b'\\');
-                        result.append(c.to_string().into_bytes().as_mut());
-                    }
-                }
-            }
-            Some(c) => {
-                // Not a valid escape sequence.
-                result.push(b'\\');
-                result.append(c.to_string().into_bytes().as_mut());
-            }
-            None => {
-                // Trailing backslash.
-                result.push(b'\\');
-            }
-        }
-    }
+					if let Some(decoded) = char::from_u32(value) {
+						result.append(decoded.to_string().into_bytes().as_mut());
+					} else {
+						result.push(b'\\');
+						result.append(c.to_string().into_bytes().as_mut());
+					}
+				}
+			},
+			Some(c) => {
+				// Not a valid escape sequence.
+				result.push(b'\\');
+				result.append(c.to_string().into_bytes().as_mut());
+			},
+			None => {
+				// Trailing backslash.
+				result.push(b'\\');
+			},
+		}
+	}
 
-    Ok((result, true))
+	Ok((result, true))
 }
 
 /// Quoting mode to use for escaping.
 #[derive(Clone, Copy, Default)]
 pub enum QuoteMode {
-    /// Single-quote.
-    #[default]
-    SingleQuote,
-    /// Double-quote.
-    DoubleQuote,
-    /// Backslash-escape.
-    BackslashEscape,
+	/// Single-quote.
+	#[default]
+	SingleQuote,
+	/// Double-quote.
+	DoubleQuote,
+	/// Backslash-escape.
+	BackslashEscape,
 }
 
 /// Options influencing how to escape/quote an input string.
 #[derive(Default)]
 pub(crate) struct QuoteOptions {
-    /// Whether or not to *always* escape or quote the input; if false, then escaping/quoting
-    /// will only be applied if the input contains characters that *require* it.
-    pub always_quote: bool,
-    /// Preferred mode for quoting/escaping. Quoting may be "upgraded" to a more expressive
-    /// format if the input is not expressible otherwise.
-    pub preferred_mode: QuoteMode,
-    /// Whether or not to *avoid* using ANSI C quoting just for the benefit of newline characters.
-    /// Default is for newline characters to require upgrading the string's quoting to
-    /// ANSI C quoting.
-    pub avoid_ansi_c_quoting_newline: bool,
+	/// Whether or not to *always* escape or quote the input; if false, then escaping/quoting
+	/// will only be applied if the input contains characters that *require* it.
+	pub always_quote: bool,
+	/// Preferred mode for quoting/escaping. Quoting may be "upgraded" to a more expressive
+	/// format if the input is not expressible otherwise.
+	pub preferred_mode: QuoteMode,
+	/// Whether or not to *avoid* using ANSI C quoting just for the benefit of newline characters.
+	/// Default is for newline characters to require upgrading the string's quoting to
+	/// ANSI C quoting.
+	pub avoid_ansi_c_quoting_newline: bool,
 }
 
 pub(crate) fn quote<'a>(s: &'a str, options: &QuoteOptions) -> Cow<'a, str> {
-    let use_ansi_c_quotes = s.contains(|c| {
-        needs_ansi_c_quoting(c) && (!options.avoid_ansi_c_quoting_newline || c != '\n')
-    });
+	let use_ansi_c_quotes = s.contains(|c| {
+		needs_ansi_c_quoting(c) && (!options.avoid_ansi_c_quoting_newline || c != '\n')
+	});
 
-    if use_ansi_c_quotes {
-        return ansi_c_quote(s).into();
-    }
+	if use_ansi_c_quotes {
+		return ansi_c_quote(s).into();
+	}
 
-    let use_default_quotes =
-        !use_ansi_c_quotes && (options.always_quote || s.is_empty() || s.contains(needs_escaping));
+	let use_default_quotes =
+		!use_ansi_c_quotes && (options.always_quote || s.is_empty() || s.contains(needs_escaping));
 
-    if !use_default_quotes {
-        return s.into();
-    }
+	if !use_default_quotes {
+		return s.into();
+	}
 
-    match options.preferred_mode {
-        QuoteMode::BackslashEscape => backslash_escape(s).into(),
-        QuoteMode::SingleQuote => single_quote(s).into(),
-        QuoteMode::DoubleQuote => double_quote(s).into(),
-    }
+	match options.preferred_mode {
+		QuoteMode::BackslashEscape => backslash_escape(s).into(),
+		QuoteMode::SingleQuote => single_quote(s).into(),
+		QuoteMode::DoubleQuote => double_quote(s).into(),
+	}
 }
 
 /// Escape the given string, forcing quoting.
@@ -235,13 +235,9 @@ pub(crate) fn quote<'a>(s: &'a str, options: &QuoteOptions) -> Cow<'a, str> {
 /// * `s` - The string to escape.
 /// * `mode` - The quoting mode to use.
 pub fn force_quote(s: &str, mode: QuoteMode) -> String {
-    let options = QuoteOptions {
-        always_quote: true,
-        preferred_mode: mode,
-        ..Default::default()
-    };
+	let options = QuoteOptions { always_quote: true, preferred_mode: mode, ..Default::default() };
 
-    quote(s, &options).to_string()
+	quote(s, &options).to_string()
 }
 
 /// Applies the given quoting mode to the provided string, only changing it if required.
@@ -251,199 +247,185 @@ pub fn force_quote(s: &str, mode: QuoteMode) -> String {
 /// * `s` - The string to escape.
 /// * `mode` - The quoting mode to use.
 pub fn quote_if_needed(s: &str, mode: QuoteMode) -> Cow<'_, str> {
-    let options = QuoteOptions {
-        always_quote: false,
-        preferred_mode: mode,
-        ..Default::default()
-    };
+	let options = QuoteOptions { always_quote: false, preferred_mode: mode, ..Default::default() };
 
-    quote(s, &options)
+	quote(s, &options)
 }
 
 fn backslash_escape(s: &str) -> String {
-    let mut output = String::new();
+	let mut output = String::new();
 
-    // TODO: Handle other interesting sequences.
-    for c in s.chars() {
-        match c {
-            c if needs_escaping(c) => {
-                output.push('\\');
-                output.push(c);
-            }
-            c => output.push(c),
-        }
-    }
+	// TODO: Handle other interesting sequences.
+	for c in s.chars() {
+		match c {
+			c if needs_escaping(c) => {
+				output.push('\\');
+				output.push(c);
+			},
+			c => output.push(c),
+		}
+	}
 
-    output
+	output
 }
 
 fn single_quote(s: &str) -> String {
-    // Special-case the empty string.
-    if s.is_empty() {
-        return "''".into();
-    }
+	// Special-case the empty string.
+	if s.is_empty() {
+		return "''".into();
+	}
 
-    let mut result = String::new();
+	let mut result = String::new();
 
-    // Go through the string; put everything in single quotes except for
-    // the single quote character itself. It will get escaped outside
-    // all quoting.
-    let mut first = true;
-    for part in s.split('\'') {
-        if !first {
-            result.push('\\');
-            result.push('\'');
-        } else {
-            first = false;
-        }
+	// Go through the string; put everything in single quotes except for
+	// the single quote character itself. It will get escaped outside
+	// all quoting.
+	let mut first = true;
+	for part in s.split('\'') {
+		if !first {
+			result.push('\\');
+			result.push('\'');
+		} else {
+			first = false;
+		}
 
-        if !part.is_empty() {
-            result.push('\'');
-            result.push_str(part);
-            result.push('\'');
-        }
-    }
+		if !part.is_empty() {
+			result.push('\'');
+			result.push_str(part);
+			result.push('\'');
+		}
+	}
 
-    result
+	result
 }
 
 fn double_quote(s: &str) -> String {
-    let mut result = String::new();
+	let mut result = String::new();
 
-    result.push('"');
+	result.push('"');
 
-    for c in s.chars() {
-        if matches!(c, '$' | '`' | '"' | '\\') {
-            result.push('\\');
-        }
+	for c in s.chars() {
+		if matches!(c, '$' | '`' | '"' | '\\') {
+			result.push('\\');
+		}
 
-        result.push(c);
-    }
+		result.push(c);
+	}
 
-    result.push('"');
+	result.push('"');
 
-    result
+	result
 }
 
 fn ansi_c_quote(s: &str) -> String {
-    let mut result = String::new();
+	let mut result = String::new();
 
-    result.push_str("$'");
+	result.push_str("$'");
 
-    for c in s.chars() {
-        match c {
-            '\x07' => result.push_str("\\a"),
-            '\x08' => result.push_str("\\b"),
-            '\x1b' => result.push_str("\\E"),
-            '\x0c' => result.push_str("\\f"),
-            '\n' => result.push_str("\\n"),
-            '\r' => result.push_str("\\r"),
-            '\t' => result.push_str("\\t"),
-            '\x0b' => result.push_str("\\v"),
-            '\\' => result.push_str("\\\\"),
-            '\'' => result.push_str("\\'"),
-            c if needs_ansi_c_quoting(c) => {
-                result.push_str(std::format!("\\{:03o}", c as u8).as_str());
-            }
-            _ => result.push(c),
-        }
-    }
+	for c in s.chars() {
+		match c {
+			'\x07' => result.push_str("\\a"),
+			'\x08' => result.push_str("\\b"),
+			'\x1b' => result.push_str("\\E"),
+			'\x0c' => result.push_str("\\f"),
+			'\n' => result.push_str("\\n"),
+			'\r' => result.push_str("\\r"),
+			'\t' => result.push_str("\\t"),
+			'\x0b' => result.push_str("\\v"),
+			'\\' => result.push_str("\\\\"),
+			'\'' => result.push_str("\\'"),
+			c if needs_ansi_c_quoting(c) => {
+				result.push_str(std::format!("\\{:03o}", c as u8).as_str());
+			},
+			_ => result.push(c),
+		}
+	}
 
-    result.push('\'');
+	result.push('\'');
 
-    result
+	result
 }
 
 // Returns whether or not the given character needs to be escaped (or quoted) if outside
 // quotes.
 const fn needs_escaping(c: char) -> bool {
-    matches!(
-        c,
-        '(' | ')'
-            | '['
-            | ']'
-            | '{'
-            | '}'
-            | '$'
-            | '*'
-            | '?'
-            | '|'
-            | '&'
-            | ';'
-            | '<'
-            | '>'
-            | '`'
-            | '\\'
-            | '"'
-            | '!'
-            | '^'
-            | ','
-            | ' '
-            | '\''
-    )
+	matches!(
+		c,
+		'(' | ')'
+			| '[' | ']'
+			| '{' | '}'
+			| '$' | '*'
+			| '?' | '|'
+			| '&' | ';'
+			| '<' | '>'
+			| '`' | '\\'
+			| '"' | '!'
+			| '^' | ','
+			| ' ' | '\''
+	)
 }
 
 const fn needs_ansi_c_quoting(c: char) -> bool {
-    c.is_ascii_control()
+	c.is_ascii_control()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_backslash_escape() {
-        assert_eq!(quote_if_needed("a", QuoteMode::BackslashEscape), "a");
-        assert_eq!(quote_if_needed("a b", QuoteMode::BackslashEscape), r"a\ b");
-        assert_eq!(quote_if_needed("", QuoteMode::BackslashEscape), "");
-    }
+	#[test]
+	fn test_backslash_escape() {
+		assert_eq!(quote_if_needed("a", QuoteMode::BackslashEscape), "a");
+		assert_eq!(quote_if_needed("a b", QuoteMode::BackslashEscape), r"a\ b");
+		assert_eq!(quote_if_needed("", QuoteMode::BackslashEscape), "");
+	}
 
-    #[test]
-    fn test_single_quote_escape() {
-        assert_eq!(quote_if_needed("a", QuoteMode::SingleQuote), "a");
-        assert_eq!(quote_if_needed("a b", QuoteMode::SingleQuote), "'a b'");
-        assert_eq!(quote_if_needed("", QuoteMode::SingleQuote), "''");
-        assert_eq!(quote_if_needed("'", QuoteMode::SingleQuote), "\\'");
-    }
+	#[test]
+	fn test_single_quote_escape() {
+		assert_eq!(quote_if_needed("a", QuoteMode::SingleQuote), "a");
+		assert_eq!(quote_if_needed("a b", QuoteMode::SingleQuote), "'a b'");
+		assert_eq!(quote_if_needed("", QuoteMode::SingleQuote), "''");
+		assert_eq!(quote_if_needed("'", QuoteMode::SingleQuote), "\\'");
+	}
 
-    fn assert_echo_expands_to(unexpanded: &str, expected: &str) {
-        assert_eq!(
-            String::from_utf8(
-                expand_backslash_escapes(unexpanded, EscapeExpansionMode::EchoBuiltin)
-                    .unwrap()
-                    .0
-            )
-            .unwrap(),
-            expected
-        );
-    }
+	fn assert_echo_expands_to(unexpanded: &str, expected: &str) {
+		assert_eq!(
+			String::from_utf8(
+				expand_backslash_escapes(unexpanded, EscapeExpansionMode::EchoBuiltin)
+					.unwrap()
+					.0
+			)
+			.unwrap(),
+			expected
+		);
+	}
 
-    #[test]
-    fn test_echo_expansion() {
-        assert_echo_expands_to("a", "a");
-        assert_echo_expands_to(r"\M", "\\M");
-        assert_echo_expands_to(r"a\nb", "a\nb");
-        assert_echo_expands_to(r"\a", "\x07");
-        assert_echo_expands_to(r"\b", "\x08");
-        assert_echo_expands_to(r"\e", "\x1b");
-        assert_echo_expands_to(r"\f", "\x0c");
-        assert_echo_expands_to(r"\n", "\n");
-        assert_echo_expands_to(r"\r", "\r");
-        assert_echo_expands_to(r"\t", "\t");
-        assert_echo_expands_to(r"\v", "\x0b");
-        assert_echo_expands_to(r"\\", "\\");
-        assert_echo_expands_to(r"\'", "\\'");
-        assert_echo_expands_to(r#"\""#, r#"\""#);
-        assert_echo_expands_to(r"\?", "\\?");
-        assert_echo_expands_to(r"\0", "\0");
-        assert_echo_expands_to(r"\00", "\0");
-        assert_echo_expands_to(r"\000", "\0");
-        assert_echo_expands_to(r"\081", "\081");
-        assert_echo_expands_to(r"\0101", "A");
-        assert_echo_expands_to(r"abc\", "abc\\");
-        assert_echo_expands_to(r"\x41", "A");
-        assert_echo_expands_to(r"\xf0\x9f\x90\x8d", "🐍");
-        assert_echo_expands_to(r"\u2620", "☠");
-        assert_echo_expands_to(r"\U0001f602", "😂");
-    }
+	#[test]
+	fn test_echo_expansion() {
+		assert_echo_expands_to("a", "a");
+		assert_echo_expands_to(r"\M", "\\M");
+		assert_echo_expands_to(r"a\nb", "a\nb");
+		assert_echo_expands_to(r"\a", "\x07");
+		assert_echo_expands_to(r"\b", "\x08");
+		assert_echo_expands_to(r"\e", "\x1b");
+		assert_echo_expands_to(r"\f", "\x0c");
+		assert_echo_expands_to(r"\n", "\n");
+		assert_echo_expands_to(r"\r", "\r");
+		assert_echo_expands_to(r"\t", "\t");
+		assert_echo_expands_to(r"\v", "\x0b");
+		assert_echo_expands_to(r"\\", "\\");
+		assert_echo_expands_to(r"\'", "\\'");
+		assert_echo_expands_to(r#"\""#, r#"\""#);
+		assert_echo_expands_to(r"\?", "\\?");
+		assert_echo_expands_to(r"\0", "\0");
+		assert_echo_expands_to(r"\00", "\0");
+		assert_echo_expands_to(r"\000", "\0");
+		assert_echo_expands_to(r"\081", "\081");
+		assert_echo_expands_to(r"\0101", "A");
+		assert_echo_expands_to(r"abc\", "abc\\");
+		assert_echo_expands_to(r"\x41", "A");
+		assert_echo_expands_to(r"\xf0\x9f\x90\x8d", "🐍");
+		assert_echo_expands_to(r"\u2620", "☠");
+		assert_echo_expands_to(r"\U0001f602", "😂");
+	}
 }

--- a/crates/brush-core-vendored/src/expansion.rs
+++ b/crates/brush-core-vendored/src/expansion.rs
@@ -19,10 +19,10 @@ use crate::{
 
 #[derive(Debug)]
 struct Expansion {
-	fields:      Vec<WordField>,
+	fields: Vec<WordField>,
 	concatenate: bool,
-	from_array:  bool,
-	undefined:   bool,
+	from_array: bool,
+	undefined: bool,
 }
 
 impl Default for Expansion {
@@ -68,10 +68,10 @@ impl Expansion {
 
 	fn undefined() -> Self {
 		Self {
-			fields:      vec![WordField::from(String::new())],
+			fields: vec![WordField::from(String::new())],
 			concatenate: true,
-			undefined:   true,
-			from_array:  false,
+			undefined: true,
+			from_array: false,
 		}
 	}
 
@@ -1085,10 +1085,10 @@ impl<'a> WordExpander<'a> {
 				}
 
 				Ok(Expansion {
-					fields:      transformed_fields,
+					fields: transformed_fields,
 					concatenate: expanded_parameter.concatenate,
-					from_array:  expanded_parameter.from_array,
-					undefined:   expanded_parameter.undefined,
+					from_array: expanded_parameter.from_array,
+					undefined: expanded_parameter.undefined,
 				})
 			},
 			brush_parser::word::ParameterExpr::UppercaseFirstChar { parameter, indirect, pattern } => {
@@ -1382,20 +1382,20 @@ impl<'a> WordExpander<'a> {
 					let values = var.value().element_values(self.shell);
 
 					Ok(Expansion {
-						fields:      values
+						fields: values
 							.into_iter()
 							.map(|value| WordField(vec![ExpansionPiece::Splittable(value)]))
 							.collect(),
 						concatenate: *concatenate,
-						from_array:  true,
-						undefined:   false,
+						from_array: true,
+						undefined: false,
 					})
 				} else {
 					Ok(Expansion {
-						fields:      vec![],
+						fields: vec![],
 						concatenate: *concatenate,
-						from_array:  true,
-						undefined:   false,
+						from_array: true,
+						undefined: false,
 					})
 				}
 			},
@@ -1427,13 +1427,13 @@ impl<'a> WordExpander<'a> {
 				let positional_params = self.shell.positional_parameters.iter();
 
 				Expansion {
-					fields:      positional_params
+					fields: positional_params
 						.into_iter()
 						.map(|param| WordField(vec![ExpansionPiece::Splittable(param.to_owned())]))
 						.collect(),
 					concatenate: *concatenate,
-					from_array:  true,
-					undefined:   false,
+					from_array: true,
+					undefined: false,
 				}
 			},
 			brush_parser::word::SpecialParameter::PositionalParameterCount => {
@@ -1686,10 +1686,10 @@ where
 	}
 
 	Ok(Expansion {
-		fields:      transformed_fields,
+		fields: transformed_fields,
 		concatenate: expansion.concatenate,
-		from_array:  expansion.from_array,
-		undefined:   expansion.undefined,
+		from_array: expansion.from_array,
+		undefined: expansion.undefined,
 	})
 }
 
@@ -1778,10 +1778,13 @@ mod tests {
 
 		let fields = expander.split_fields(expansion);
 
-		assert_eq!(fields, vec![
-			WordField(vec![ExpansionPiece::Unsplittable(String::from("A"))]),
-			WordField(vec![ExpansionPiece::Unsplittable(String::new())])
-		]);
+		assert_eq!(
+			fields,
+			vec![
+				WordField(vec![ExpansionPiece::Unsplittable(String::from("A"))]),
+				WordField(vec![ExpansionPiece::Unsplittable(String::new())])
+			]
+		);
 
 		Ok(())
 	}

--- a/crates/brush-core-vendored/src/extendedtests.rs
+++ b/crates/brush-core-vendored/src/extendedtests.rs
@@ -2,608 +2,588 @@ use brush_parser::ast;
 use std::path::Path;
 
 use crate::{
-    ExecutionParameters, Shell, ShellFd, arithmetic, env, error, escape, expansion, namedoptions,
-    patterns,
-    sys::{
-        fs::{MetadataExt, PathExt},
-        users,
-    },
-    variables::{self, ArrayLiteral},
+	ExecutionParameters, Shell, ShellFd, arithmetic, env, error, escape, expansion, namedoptions,
+	patterns,
+	sys::{
+		fs::{MetadataExt, PathExt},
+		users,
+	},
+	variables::{self, ArrayLiteral},
 };
 
 #[async_recursion::async_recursion]
 pub(crate) async fn eval_extended_test_expr(
-    expr: &ast::ExtendedTestExpr,
-    shell: &mut Shell,
-    params: &ExecutionParameters,
+	expr: &ast::ExtendedTestExpr,
+	shell: &mut Shell,
+	params: &ExecutionParameters,
 ) -> Result<bool, error::Error> {
-    match expr {
-        ast::ExtendedTestExpr::UnaryTest(op, operand) => {
-            apply_unary_predicate(op, operand, shell, params).await
-        }
-        ast::ExtendedTestExpr::BinaryTest(op, left, right) => {
-            apply_binary_predicate(op, left, right, shell, params).await
-        }
-        ast::ExtendedTestExpr::And(left, right) => {
-            let result = eval_extended_test_expr(left, shell, params).await?
-                && eval_extended_test_expr(right, shell, params).await?;
-            Ok(result)
-        }
-        ast::ExtendedTestExpr::Or(left, right) => {
-            let result = eval_extended_test_expr(left, shell, params).await?
-                || eval_extended_test_expr(right, shell, params).await?;
-            Ok(result)
-        }
-        ast::ExtendedTestExpr::Not(expr) => {
-            let result = !eval_extended_test_expr(expr, shell, params).await?;
-            Ok(result)
-        }
-        ast::ExtendedTestExpr::Parenthesized(expr) => {
-            eval_extended_test_expr(expr, shell, params).await
-        }
-    }
+	match expr {
+		ast::ExtendedTestExpr::UnaryTest(op, operand) => {
+			apply_unary_predicate(op, operand, shell, params).await
+		},
+		ast::ExtendedTestExpr::BinaryTest(op, left, right) => {
+			apply_binary_predicate(op, left, right, shell, params).await
+		},
+		ast::ExtendedTestExpr::And(left, right) => {
+			let result = eval_extended_test_expr(left, shell, params).await?
+				&& eval_extended_test_expr(right, shell, params).await?;
+			Ok(result)
+		},
+		ast::ExtendedTestExpr::Or(left, right) => {
+			let result = eval_extended_test_expr(left, shell, params).await?
+				|| eval_extended_test_expr(right, shell, params).await?;
+			Ok(result)
+		},
+		ast::ExtendedTestExpr::Not(expr) => {
+			let result = !eval_extended_test_expr(expr, shell, params).await?;
+			Ok(result)
+		},
+		ast::ExtendedTestExpr::Parenthesized(expr) => {
+			eval_extended_test_expr(expr, shell, params).await
+		},
+	}
 }
 
 async fn apply_unary_predicate(
-    op: &ast::UnaryPredicate,
-    operand: &ast::Word,
-    shell: &mut Shell,
-    params: &ExecutionParameters,
+	op: &ast::UnaryPredicate,
+	operand: &ast::Word,
+	shell: &mut Shell,
+	params: &ExecutionParameters,
 ) -> Result<bool, error::Error> {
-    let expanded_operand = expansion::basic_expand_word(shell, params, operand).await?;
+	let expanded_operand = expansion::basic_expand_word(shell, params, operand).await?;
 
-    if shell.options.print_commands_and_arguments {
-        shell
-            .trace_command(
-                params,
-                std::format!(
-                    "[[ {op} {} ]]",
-                    escape::quote_if_needed(&expanded_operand, escape::QuoteMode::SingleQuote)
-                ),
-            )
-            .await?;
-    }
+	if shell.options.print_commands_and_arguments {
+		shell
+			.trace_command(
+				params,
+				std::format!(
+					"[[ {op} {} ]]",
+					escape::quote_if_needed(&expanded_operand, escape::QuoteMode::SingleQuote)
+				),
+			)
+			.await?;
+	}
 
-    apply_unary_predicate_to_str(op, expanded_operand.as_str(), shell, params)
+	apply_unary_predicate_to_str(op, expanded_operand.as_str(), shell, params)
 }
-
 
 pub(crate) fn apply_unary_predicate_to_str(
-    op: &ast::UnaryPredicate,
-    operand: &str,
-    shell: &Shell,
-    params: &ExecutionParameters,
+	op: &ast::UnaryPredicate,
+	operand: &str,
+	shell: &Shell,
+	params: &ExecutionParameters,
 ) -> Result<bool, error::Error> {
-    match op {
-        ast::UnaryPredicate::StringHasNonZeroLength => Ok(!operand.is_empty()),
-        ast::UnaryPredicate::StringHasZeroLength => Ok(operand.is_empty()),
-        ast::UnaryPredicate::FileExists => {
-            let path = shell.absolute_path(Path::new(operand));
-            Ok(path.exists())
-        }
-        ast::UnaryPredicate::FileExistsAndIsBlockSpecialFile => {
-            let path = shell.absolute_path(Path::new(operand));
-            Ok(path.exists_and_is_block_device())
-        }
-        ast::UnaryPredicate::FileExistsAndIsCharSpecialFile => {
-            let path = shell.absolute_path(Path::new(operand));
-            Ok(path.exists_and_is_char_device())
-        }
-        ast::UnaryPredicate::FileExistsAndIsDir => {
-            let path = shell.absolute_path(Path::new(operand));
-            Ok(path.is_dir())
-        }
-        ast::UnaryPredicate::FileExistsAndIsRegularFile => {
-            let path = shell.absolute_path(Path::new(operand));
-            Ok(path.is_file())
-        }
-        ast::UnaryPredicate::FileExistsAndIsSetgid => {
-            let path = shell.absolute_path(Path::new(operand));
-            Ok(path.exists_and_is_setgid())
-        }
-        ast::UnaryPredicate::FileExistsAndIsSymlink => {
-            let path = shell.absolute_path(Path::new(operand));
-            Ok(path.is_symlink())
-        }
-        ast::UnaryPredicate::FileExistsAndHasStickyBit => {
-            let path = shell.absolute_path(Path::new(operand));
-            Ok(path.exists_and_is_sticky_bit())
-        }
-        ast::UnaryPredicate::FileExistsAndIsFifo => {
-            let path = shell.absolute_path(Path::new(operand));
-            Ok(path.exists_and_is_fifo())
-        }
-        ast::UnaryPredicate::FileExistsAndIsReadable => {
-            let path = shell.absolute_path(Path::new(operand));
-            Ok(path.readable())
-        }
-        ast::UnaryPredicate::FileExistsAndIsNotZeroLength => {
-            let path = shell.absolute_path(Path::new(operand));
-            if let Ok(metadata) = path.metadata() {
-                Ok(metadata.len() > 0)
-            } else {
-                Ok(false)
-            }
-        }
-        ast::UnaryPredicate::FdIsOpenTerminal => {
-            if let Ok(fd) = operand.parse::<ShellFd>() {
-                if let Some(open_file) = params.try_fd(shell, fd) {
-                    Ok(open_file.is_term())
-                } else {
-                    Ok(false)
-                }
-            } else {
-                Ok(false)
-            }
-        }
-        ast::UnaryPredicate::FileExistsAndIsSetuid => {
-            let path = shell.absolute_path(Path::new(operand));
-            Ok(path.exists_and_is_setuid())
-        }
-        ast::UnaryPredicate::FileExistsAndIsWritable => {
-            let path = shell.absolute_path(Path::new(operand));
-            Ok(path.writable())
-        }
-        ast::UnaryPredicate::FileExistsAndIsExecutable => {
-            let path = shell.absolute_path(Path::new(operand));
-            Ok(path.executable())
-        }
-        ast::UnaryPredicate::FileExistsAndOwnedByEffectiveGroupId => {
-            let path = shell.absolute_path(Path::new(operand));
-            if !path.exists() {
-                return Ok(false);
-            }
+	match op {
+		ast::UnaryPredicate::StringHasNonZeroLength => Ok(!operand.is_empty()),
+		ast::UnaryPredicate::StringHasZeroLength => Ok(operand.is_empty()),
+		ast::UnaryPredicate::FileExists => {
+			let path = shell.absolute_path(Path::new(operand));
+			Ok(path.exists())
+		},
+		ast::UnaryPredicate::FileExistsAndIsBlockSpecialFile => {
+			let path = shell.absolute_path(Path::new(operand));
+			Ok(path.exists_and_is_block_device())
+		},
+		ast::UnaryPredicate::FileExistsAndIsCharSpecialFile => {
+			let path = shell.absolute_path(Path::new(operand));
+			Ok(path.exists_and_is_char_device())
+		},
+		ast::UnaryPredicate::FileExistsAndIsDir => {
+			let path = shell.absolute_path(Path::new(operand));
+			Ok(path.is_dir())
+		},
+		ast::UnaryPredicate::FileExistsAndIsRegularFile => {
+			let path = shell.absolute_path(Path::new(operand));
+			Ok(path.is_file())
+		},
+		ast::UnaryPredicate::FileExistsAndIsSetgid => {
+			let path = shell.absolute_path(Path::new(operand));
+			Ok(path.exists_and_is_setgid())
+		},
+		ast::UnaryPredicate::FileExistsAndIsSymlink => {
+			let path = shell.absolute_path(Path::new(operand));
+			Ok(path.is_symlink())
+		},
+		ast::UnaryPredicate::FileExistsAndHasStickyBit => {
+			let path = shell.absolute_path(Path::new(operand));
+			Ok(path.exists_and_is_sticky_bit())
+		},
+		ast::UnaryPredicate::FileExistsAndIsFifo => {
+			let path = shell.absolute_path(Path::new(operand));
+			Ok(path.exists_and_is_fifo())
+		},
+		ast::UnaryPredicate::FileExistsAndIsReadable => {
+			let path = shell.absolute_path(Path::new(operand));
+			Ok(path.readable())
+		},
+		ast::UnaryPredicate::FileExistsAndIsNotZeroLength => {
+			let path = shell.absolute_path(Path::new(operand));
+			if let Ok(metadata) = path.metadata() {
+				Ok(metadata.len() > 0)
+			} else {
+				Ok(false)
+			}
+		},
+		ast::UnaryPredicate::FdIsOpenTerminal => {
+			if let Ok(fd) = operand.parse::<ShellFd>() {
+				if let Some(open_file) = params.try_fd(shell, fd) {
+					Ok(open_file.is_term())
+				} else {
+					Ok(false)
+				}
+			} else {
+				Ok(false)
+			}
+		},
+		ast::UnaryPredicate::FileExistsAndIsSetuid => {
+			let path = shell.absolute_path(Path::new(operand));
+			Ok(path.exists_and_is_setuid())
+		},
+		ast::UnaryPredicate::FileExistsAndIsWritable => {
+			let path = shell.absolute_path(Path::new(operand));
+			Ok(path.writable())
+		},
+		ast::UnaryPredicate::FileExistsAndIsExecutable => {
+			let path = shell.absolute_path(Path::new(operand));
+			Ok(path.executable())
+		},
+		ast::UnaryPredicate::FileExistsAndOwnedByEffectiveGroupId => {
+			let path = shell.absolute_path(Path::new(operand));
+			if !path.exists() {
+				return Ok(false);
+			}
 
-            let md = path.metadata()?;
-            Ok(md.gid() == users::get_effective_gid()?)
-        }
-        ast::UnaryPredicate::FileExistsAndModifiedSinceLastRead => {
-            error::unimp("unary extended test predicate: FileExistsAndModifiedSinceLastRead")
-        }
-        ast::UnaryPredicate::FileExistsAndOwnedByEffectiveUserId => {
-            let path = shell.absolute_path(Path::new(operand));
-            if !path.exists() {
-                return Ok(false);
-            }
+			let md = path.metadata()?;
+			Ok(md.gid() == users::get_effective_gid()?)
+		},
+		ast::UnaryPredicate::FileExistsAndModifiedSinceLastRead => {
+			error::unimp("unary extended test predicate: FileExistsAndModifiedSinceLastRead")
+		},
+		ast::UnaryPredicate::FileExistsAndOwnedByEffectiveUserId => {
+			let path = shell.absolute_path(Path::new(operand));
+			if !path.exists() {
+				return Ok(false);
+			}
 
-            let md = path.metadata()?;
-            Ok(md.uid() == users::get_effective_uid()?)
-        }
-        ast::UnaryPredicate::FileExistsAndIsSocket => {
-            let path = shell.absolute_path(Path::new(operand));
-            Ok(path.exists_and_is_socket())
-        }
-        ast::UnaryPredicate::ShellOptionEnabled => {
-            let shopt_name = operand;
-            if let Some(option) =
-                namedoptions::options(namedoptions::ShellOptionKind::SetO).get(shopt_name)
-            {
-                Ok(option.get(&shell.options))
-            } else {
-                Ok(false)
-            }
-        }
-        ast::UnaryPredicate::ShellVariableIsSetAndAssigned => Ok(shell.env.is_set(operand)),
-        ast::UnaryPredicate::ShellVariableIsSetAndNameRef => match shell.env.get(operand) {
-            Some((_, reffed)) => Ok(reffed.value().is_set() && reffed.is_treated_as_nameref()),
-            None => Ok(false),
-        },
-    }
+			let md = path.metadata()?;
+			Ok(md.uid() == users::get_effective_uid()?)
+		},
+		ast::UnaryPredicate::FileExistsAndIsSocket => {
+			let path = shell.absolute_path(Path::new(operand));
+			Ok(path.exists_and_is_socket())
+		},
+		ast::UnaryPredicate::ShellOptionEnabled => {
+			let shopt_name = operand;
+			if let Some(option) =
+				namedoptions::options(namedoptions::ShellOptionKind::SetO).get(shopt_name)
+			{
+				Ok(option.get(&shell.options))
+			} else {
+				Ok(false)
+			}
+		},
+		ast::UnaryPredicate::ShellVariableIsSetAndAssigned => Ok(shell.env.is_set(operand)),
+		ast::UnaryPredicate::ShellVariableIsSetAndNameRef => match shell.env.get(operand) {
+			Some((_, reffed)) => Ok(reffed.value().is_set() && reffed.is_treated_as_nameref()),
+			None => Ok(false),
+		},
+	}
 }
 
-
 async fn apply_binary_predicate(
-    op: &ast::BinaryPredicate,
-    left: &ast::Word,
-    right: &ast::Word,
-    shell: &mut Shell,
-    params: &ExecutionParameters,
+	op: &ast::BinaryPredicate,
+	left: &ast::Word,
+	right: &ast::Word,
+	shell: &mut Shell,
+	params: &ExecutionParameters,
 ) -> Result<bool, error::Error> {
-    match op {
-        ast::BinaryPredicate::StringMatchesRegex => {
-            let s = expansion::basic_expand_word(shell, params, left).await?;
-            let regex = expansion::basic_expand_regex(shell, params, right)
-                .await?
-                .set_multiline(true);
+	match op {
+		ast::BinaryPredicate::StringMatchesRegex => {
+			let s = expansion::basic_expand_word(shell, params, left).await?;
+			let regex = expansion::basic_expand_regex(shell, params, right)
+				.await?
+				.set_multiline(true);
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {s} {op} {right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {s} {op} {right} ]]"))
+					.await?;
+			}
 
-            let (matches, captures) = match regex.matches(s.as_str()) {
-                Ok(Some(captures)) => (true, captures),
-                Ok(None) => (false, vec![]),
-                // If we can't compile the regex, don't abort the whole operation but make sure to
-                // report it.
-                // TODO: Docs indicate we should yield 2 on an invalid regex (not 1).
-                Err(e) => {
-                    tracing::warn!("error using regex: {}", e);
-                    (false, vec![])
-                }
-            };
+			let (matches, captures) = match regex.matches(s.as_str()) {
+				Ok(Some(captures)) => (true, captures),
+				Ok(None) => (false, vec![]),
+				// If we can't compile the regex, don't abort the whole operation but make sure to
+				// report it.
+				// TODO: Docs indicate we should yield 2 on an invalid regex (not 1).
+				Err(e) => {
+					tracing::warn!("error using regex: {}", e);
+					(false, vec![])
+				},
+			};
 
-            let captures_value = variables::ShellValueLiteral::Array(ArrayLiteral(
-                captures
-                    .into_iter()
-                    .map(|c| (None, c.unwrap_or_default()))
-                    .collect(),
-            ));
+			let captures_value = variables::ShellValueLiteral::Array(ArrayLiteral(
+				captures
+					.into_iter()
+					.map(|c| (None, c.unwrap_or_default()))
+					.collect(),
+			));
 
-            shell.env.update_or_add(
-                "BASH_REMATCH",
-                captures_value,
-                |_| Ok(()),
-                env::EnvironmentLookup::Anywhere,
-                env::EnvironmentScope::Global,
-            )?;
+			shell.env.update_or_add(
+				"BASH_REMATCH",
+				captures_value,
+				|_| Ok(()),
+				env::EnvironmentLookup::Anywhere,
+				env::EnvironmentScope::Global,
+			)?;
 
-            Ok(matches)
-        }
-        ast::BinaryPredicate::StringExactlyMatchesString => {
-            let left = expansion::basic_expand_word(shell, params, left).await?;
-            let right = expansion::basic_expand_word(shell, params, right).await?;
+			Ok(matches)
+		},
+		ast::BinaryPredicate::StringExactlyMatchesString => {
+			let left = expansion::basic_expand_word(shell, params, left).await?;
+			let right = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
+					.await?;
+			}
 
-            Ok(left == right)
-        }
-        ast::BinaryPredicate::StringDoesNotExactlyMatchString => {
-            let left = expansion::basic_expand_word(shell, params, left).await?;
-            let right = expansion::basic_expand_word(shell, params, right).await?;
+			Ok(left == right)
+		},
+		ast::BinaryPredicate::StringDoesNotExactlyMatchString => {
+			let left = expansion::basic_expand_word(shell, params, left).await?;
+			let right = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
+					.await?;
+			}
 
-            Ok(left != right)
-        }
-        ast::BinaryPredicate::StringContainsSubstring => {
-            let s = expansion::basic_expand_word(shell, params, left).await?;
-            let substring = expansion::basic_expand_word(shell, params, right).await?;
+			Ok(left != right)
+		},
+		ast::BinaryPredicate::StringContainsSubstring => {
+			let s = expansion::basic_expand_word(shell, params, left).await?;
+			let substring = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {s} {op} {substring} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {s} {op} {substring} ]]"))
+					.await?;
+			}
 
-            Ok(s.contains(substring.as_str()))
-        }
-        ast::BinaryPredicate::FilesReferToSameDeviceAndInodeNumbers => {
-            let left = expansion::basic_expand_word(shell, params, left).await?;
-            let right = expansion::basic_expand_word(shell, params, right).await?;
+			Ok(s.contains(substring.as_str()))
+		},
+		ast::BinaryPredicate::FilesReferToSameDeviceAndInodeNumbers => {
+			let left = expansion::basic_expand_word(shell, params, left).await?;
+			let right = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
+					.await?;
+			}
 
-            files_refer_to_same_device_and_inode_numbers(shell, left, right)
-        }
-        ast::BinaryPredicate::LeftFileIsNewerOrExistsWhenRightDoesNot => {
-            let left = expansion::basic_expand_word(shell, params, left).await?;
-            let right = expansion::basic_expand_word(shell, params, right).await?;
+			files_refer_to_same_device_and_inode_numbers(shell, left, right)
+		},
+		ast::BinaryPredicate::LeftFileIsNewerOrExistsWhenRightDoesNot => {
+			let left = expansion::basic_expand_word(shell, params, left).await?;
+			let right = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
+					.await?;
+			}
 
-            left_file_is_newer_or_exists_when_right_does_not(shell, left, right)
-        }
-        ast::BinaryPredicate::LeftFileIsOlderOrDoesNotExistWhenRightDoes => {
-            let left = expansion::basic_expand_word(shell, params, left).await?;
-            let right = expansion::basic_expand_word(shell, params, right).await?;
+			left_file_is_newer_or_exists_when_right_does_not(shell, left, right)
+		},
+		ast::BinaryPredicate::LeftFileIsOlderOrDoesNotExistWhenRightDoes => {
+			let left = expansion::basic_expand_word(shell, params, left).await?;
+			let right = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
+					.await?;
+			}
 
-            left_file_is_older_or_does_not_exist_when_right_does(shell, left, right)
-        }
-        ast::BinaryPredicate::LeftSortsBeforeRight => {
-            let left = expansion::basic_expand_word(shell, params, left).await?;
-            let right = expansion::basic_expand_word(shell, params, right).await?;
+			left_file_is_older_or_does_not_exist_when_right_does(shell, left, right)
+		},
+		ast::BinaryPredicate::LeftSortsBeforeRight => {
+			let left = expansion::basic_expand_word(shell, params, left).await?;
+			let right = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
+					.await?;
+			}
 
-            // TODO: According to docs, should be lexicographical order of the current locale.
-            Ok(left < right)
-        }
-        ast::BinaryPredicate::LeftSortsAfterRight => {
-            let left = expansion::basic_expand_word(shell, params, left).await?;
-            let right = expansion::basic_expand_word(shell, params, right).await?;
+			// TODO: According to docs, should be lexicographical order of the current locale.
+			Ok(left < right)
+		},
+		ast::BinaryPredicate::LeftSortsAfterRight => {
+			let left = expansion::basic_expand_word(shell, params, left).await?;
+			let right = expansion::basic_expand_word(shell, params, right).await?;
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
+					.await?;
+			}
 
-            // TODO: According to docs, should be lexicographical order of the current locale.
-            Ok(left > right)
-        }
-        ast::BinaryPredicate::ArithmeticEqualTo => {
-            let left =
-                arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
-            let right =
-                arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
+			// TODO: According to docs, should be lexicographical order of the current locale.
+			Ok(left > right)
+		},
+		ast::BinaryPredicate::ArithmeticEqualTo => {
+			let left = arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
+			let right =
+				arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
+					.await?;
+			}
 
-            Ok(left == right)
-        }
-        ast::BinaryPredicate::ArithmeticNotEqualTo => {
-            let left =
-                arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
-            let right =
-                arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
+			Ok(left == right)
+		},
+		ast::BinaryPredicate::ArithmeticNotEqualTo => {
+			let left = arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
+			let right =
+				arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
+					.await?;
+			}
 
-            Ok(left != right)
-        }
-        ast::BinaryPredicate::ArithmeticLessThan => {
-            let left =
-                arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
-            let right =
-                arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
+			Ok(left != right)
+		},
+		ast::BinaryPredicate::ArithmeticLessThan => {
+			let left = arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
+			let right =
+				arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
+					.await?;
+			}
 
-            Ok(left < right)
-        }
-        ast::BinaryPredicate::ArithmeticLessThanOrEqualTo => {
-            let left =
-                arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
-            let right =
-                arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
+			Ok(left < right)
+		},
+		ast::BinaryPredicate::ArithmeticLessThanOrEqualTo => {
+			let left = arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
+			let right =
+				arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
+					.await?;
+			}
 
-            Ok(left <= right)
-        }
-        ast::BinaryPredicate::ArithmeticGreaterThan => {
-            let left =
-                arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
-            let right =
-                arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
+			Ok(left <= right)
+		},
+		ast::BinaryPredicate::ArithmeticGreaterThan => {
+			let left = arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
+			let right =
+				arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
+					.await?;
+			}
 
-            Ok(left > right)
-        }
-        ast::BinaryPredicate::ArithmeticGreaterThanOrEqualTo => {
-            let left =
-                arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
-            let right =
-                arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
+			Ok(left > right)
+		},
+		ast::BinaryPredicate::ArithmeticGreaterThanOrEqualTo => {
+			let left = arithmetic::expand_and_eval(shell, params, left.value.as_str(), false).await?;
+			let right =
+				arithmetic::expand_and_eval(shell, params, right.value.as_str(), false).await?;
 
-            if shell.options.print_commands_and_arguments {
-                shell
-                    .trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				shell
+					.trace_command(params, std::format!("[[ {left} {op} {right} ]]"))
+					.await?;
+			}
 
-            Ok(left >= right)
-        }
-        // N.B. The "=", "==", and "!=" operators don't compare 2 strings; they check
-        // for whether the lefthand operand (a string) is matched by the righthand
-        // operand (treated as a shell pattern).
-        // TODO: implement case-insensitive matching if relevant via shopt options (nocasematch).
-        ast::BinaryPredicate::StringExactlyMatchesPattern => {
-            let s = expansion::basic_expand_word(shell, params, left).await?;
-            let pattern = expansion::basic_expand_pattern(shell, params, right)
-                .await?
-                .set_extended_globbing(shell.options.extended_globbing)
-                .set_case_insensitive(shell.options.case_insensitive_conditionals);
+			Ok(left >= right)
+		},
+		// N.B. The "=", "==", and "!=" operators don't compare 2 strings; they check
+		// for whether the lefthand operand (a string) is matched by the righthand
+		// operand (treated as a shell pattern).
+		// TODO: implement case-insensitive matching if relevant via shopt options (nocasematch).
+		ast::BinaryPredicate::StringExactlyMatchesPattern => {
+			let s = expansion::basic_expand_word(shell, params, left).await?;
+			let pattern = expansion::basic_expand_pattern(shell, params, right)
+				.await?
+				.set_extended_globbing(shell.options.extended_globbing)
+				.set_case_insensitive(shell.options.case_insensitive_conditionals);
 
-            if shell.options.print_commands_and_arguments {
-                let expanded_right = expansion::basic_expand_word(shell, params, right).await?;
-                let escaped_right = escape::quote_if_needed(
-                    expanded_right.as_str(),
-                    escape::QuoteMode::BackslashEscape,
-                );
-                shell
-                    .trace_command(params, std::format!("[[ {s} {op} {escaped_right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				let expanded_right = expansion::basic_expand_word(shell, params, right).await?;
+				let escaped_right =
+					escape::quote_if_needed(expanded_right.as_str(), escape::QuoteMode::BackslashEscape);
+				shell
+					.trace_command(params, std::format!("[[ {s} {op} {escaped_right} ]]"))
+					.await?;
+			}
 
-            pattern.exactly_matches(s.as_str())
-        }
-        ast::BinaryPredicate::StringDoesNotExactlyMatchPattern => {
-            let s = expansion::basic_expand_word(shell, params, left).await?;
-            let pattern = expansion::basic_expand_pattern(shell, params, right)
-                .await?
-                .set_extended_globbing(shell.options.extended_globbing)
-                .set_case_insensitive(shell.options.case_insensitive_conditionals);
+			pattern.exactly_matches(s.as_str())
+		},
+		ast::BinaryPredicate::StringDoesNotExactlyMatchPattern => {
+			let s = expansion::basic_expand_word(shell, params, left).await?;
+			let pattern = expansion::basic_expand_pattern(shell, params, right)
+				.await?
+				.set_extended_globbing(shell.options.extended_globbing)
+				.set_case_insensitive(shell.options.case_insensitive_conditionals);
 
-            if shell.options.print_commands_and_arguments {
-                let expanded_right = expansion::basic_expand_word(shell, params, right).await?;
-                let escaped_right = escape::quote_if_needed(
-                    expanded_right.as_str(),
-                    escape::QuoteMode::BackslashEscape,
-                );
-                shell
-                    .trace_command(params, std::format!("[[ {s} {op} {escaped_right} ]]"))
-                    .await?;
-            }
+			if shell.options.print_commands_and_arguments {
+				let expanded_right = expansion::basic_expand_word(shell, params, right).await?;
+				let escaped_right =
+					escape::quote_if_needed(expanded_right.as_str(), escape::QuoteMode::BackslashEscape);
+				shell
+					.trace_command(params, std::format!("[[ {s} {op} {escaped_right} ]]"))
+					.await?;
+			}
 
-            let eq = pattern.exactly_matches(s.as_str())?;
-            Ok(!eq)
-        }
-    }
+			let eq = pattern.exactly_matches(s.as_str())?;
+			Ok(!eq)
+		},
+	}
 }
 
 pub(crate) fn apply_binary_predicate_to_strs(
-    op: &ast::BinaryPredicate,
-    left: &str,
-    right: &str,
-    shell: &Shell,
+	op: &ast::BinaryPredicate,
+	left: &str,
+	right: &str,
+	shell: &Shell,
 ) -> Result<bool, error::Error> {
-    match op {
-        ast::BinaryPredicate::FilesReferToSameDeviceAndInodeNumbers => {
-            files_refer_to_same_device_and_inode_numbers(shell, left, right)
-        }
-        ast::BinaryPredicate::LeftFileIsNewerOrExistsWhenRightDoesNot => {
-            left_file_is_newer_or_exists_when_right_does_not(shell, left, right)
-        }
-        ast::BinaryPredicate::LeftFileIsOlderOrDoesNotExistWhenRightDoes => {
-            left_file_is_older_or_does_not_exist_when_right_does(shell, left, right)
-        }
-        ast::BinaryPredicate::LeftSortsBeforeRight => {
-            // TODO: According to docs, should be lexicographical order of the current locale.
-            Ok(left < right)
-        }
-        ast::BinaryPredicate::LeftSortsAfterRight => {
-            // TODO: According to docs, should be lexicographical order of the current locale.
-            Ok(left > right)
-        }
-        ast::BinaryPredicate::ArithmeticEqualTo => Ok(apply_test_binary_arithmetic_predicate(
-            left,
-            right,
-            |left, right| left == right,
-        )),
-        ast::BinaryPredicate::ArithmeticNotEqualTo => Ok(apply_test_binary_arithmetic_predicate(
-            left,
-            right,
-            |left, right| left != right,
-        )),
-        ast::BinaryPredicate::ArithmeticLessThan => Ok(apply_test_binary_arithmetic_predicate(
-            left,
-            right,
-            |left, right| left < right,
-        )),
-        ast::BinaryPredicate::ArithmeticLessThanOrEqualTo => Ok(
-            apply_test_binary_arithmetic_predicate(left, right, |left, right| left <= right),
-        ),
-        ast::BinaryPredicate::ArithmeticGreaterThan => Ok(apply_test_binary_arithmetic_predicate(
-            left,
-            right,
-            |left, right| left > right,
-        )),
-        ast::BinaryPredicate::ArithmeticGreaterThanOrEqualTo => Ok(
-            apply_test_binary_arithmetic_predicate(left, right, |left, right| left >= right),
-        ),
-        ast::BinaryPredicate::StringExactlyMatchesPattern => {
-            let pattern = patterns::Pattern::from(right)
-                .set_extended_globbing(shell.options.extended_globbing)
-                .set_case_insensitive(shell.options.case_insensitive_conditionals);
+	match op {
+		ast::BinaryPredicate::FilesReferToSameDeviceAndInodeNumbers => {
+			files_refer_to_same_device_and_inode_numbers(shell, left, right)
+		},
+		ast::BinaryPredicate::LeftFileIsNewerOrExistsWhenRightDoesNot => {
+			left_file_is_newer_or_exists_when_right_does_not(shell, left, right)
+		},
+		ast::BinaryPredicate::LeftFileIsOlderOrDoesNotExistWhenRightDoes => {
+			left_file_is_older_or_does_not_exist_when_right_does(shell, left, right)
+		},
+		ast::BinaryPredicate::LeftSortsBeforeRight => {
+			// TODO: According to docs, should be lexicographical order of the current locale.
+			Ok(left < right)
+		},
+		ast::BinaryPredicate::LeftSortsAfterRight => {
+			// TODO: According to docs, should be lexicographical order of the current locale.
+			Ok(left > right)
+		},
+		ast::BinaryPredicate::ArithmeticEqualTo => {
+			Ok(apply_test_binary_arithmetic_predicate(left, right, |left, right| left == right))
+		},
+		ast::BinaryPredicate::ArithmeticNotEqualTo => {
+			Ok(apply_test_binary_arithmetic_predicate(left, right, |left, right| left != right))
+		},
+		ast::BinaryPredicate::ArithmeticLessThan => {
+			Ok(apply_test_binary_arithmetic_predicate(left, right, |left, right| left < right))
+		},
+		ast::BinaryPredicate::ArithmeticLessThanOrEqualTo => {
+			Ok(apply_test_binary_arithmetic_predicate(left, right, |left, right| left <= right))
+		},
+		ast::BinaryPredicate::ArithmeticGreaterThan => {
+			Ok(apply_test_binary_arithmetic_predicate(left, right, |left, right| left > right))
+		},
+		ast::BinaryPredicate::ArithmeticGreaterThanOrEqualTo => {
+			Ok(apply_test_binary_arithmetic_predicate(left, right, |left, right| left >= right))
+		},
+		ast::BinaryPredicate::StringExactlyMatchesPattern => {
+			let pattern = patterns::Pattern::from(right)
+				.set_extended_globbing(shell.options.extended_globbing)
+				.set_case_insensitive(shell.options.case_insensitive_conditionals);
 
-            pattern.exactly_matches(left)
-        }
-        ast::BinaryPredicate::StringDoesNotExactlyMatchPattern => {
-            let pattern = patterns::Pattern::from(right)
-                .set_extended_globbing(shell.options.extended_globbing)
-                .set_case_insensitive(shell.options.case_insensitive_conditionals);
+			pattern.exactly_matches(left)
+		},
+		ast::BinaryPredicate::StringDoesNotExactlyMatchPattern => {
+			let pattern = patterns::Pattern::from(right)
+				.set_extended_globbing(shell.options.extended_globbing)
+				.set_case_insensitive(shell.options.case_insensitive_conditionals);
 
-            let eq = pattern.exactly_matches(left)?;
-            Ok(!eq)
-        }
-        ast::BinaryPredicate::StringExactlyMatchesString => Ok(left == right),
-        ast::BinaryPredicate::StringDoesNotExactlyMatchString => Ok(left != right),
-        _ => error::unimp("unsupported test binary predicate"),
-    }
+			let eq = pattern.exactly_matches(left)?;
+			Ok(!eq)
+		},
+		ast::BinaryPredicate::StringExactlyMatchesString => Ok(left == right),
+		ast::BinaryPredicate::StringDoesNotExactlyMatchString => Ok(left != right),
+		_ => error::unimp("unsupported test binary predicate"),
+	}
 }
 
 fn apply_test_binary_arithmetic_predicate(
-    left: &str,
-    right: &str,
-    op: fn(i64, i64) -> bool,
+	left: &str,
+	right: &str,
+	op: fn(i64, i64) -> bool,
 ) -> bool {
-    let left: Result<i64, _> = left.parse();
-    let right: Result<i64, _> = right.parse();
+	let left: Result<i64, _> = left.parse();
+	let right: Result<i64, _> = right.parse();
 
-    if let (Ok(left), Ok(right)) = (left, right) {
-        op(left, right)
-    } else {
-        false
-    }
+	if let (Ok(left), Ok(right)) = (left, right) {
+		op(left, right)
+	} else {
+		false
+	}
 }
 
 fn left_file_is_older_or_does_not_exist_when_right_does(
-    shell: &Shell,
-    left: impl AsRef<str>,
-    right: impl AsRef<str>,
+	shell: &Shell,
+	left: impl AsRef<str>,
+	right: impl AsRef<str>,
 ) -> Result<bool, error::Error> {
-    let (l_path, r_path) = (
-        shell.absolute_path(Path::new(left.as_ref())),
-        shell.absolute_path(Path::new(right.as_ref())),
-    );
+	let (l_path, r_path) = (
+		shell.absolute_path(Path::new(left.as_ref())),
+		shell.absolute_path(Path::new(right.as_ref())),
+	);
 
-    match (l_path.metadata(), r_path.metadata()) {
-        (Ok(m1), Ok(m2)) => Ok(m1.modified()? < m2.modified()?),
-        (Err(_), Ok(_)) => Ok(true),
-        _ => Ok(false),
-    }
+	match (l_path.metadata(), r_path.metadata()) {
+		(Ok(m1), Ok(m2)) => Ok(m1.modified()? < m2.modified()?),
+		(Err(_), Ok(_)) => Ok(true),
+		_ => Ok(false),
+	}
 }
 
 fn left_file_is_newer_or_exists_when_right_does_not(
-    shell: &Shell,
-    left: impl AsRef<str>,
-    right: impl AsRef<str>,
+	shell: &Shell,
+	left: impl AsRef<str>,
+	right: impl AsRef<str>,
 ) -> Result<bool, error::Error> {
-    let (l_path, r_path) = (
-        shell.absolute_path(Path::new(left.as_ref())),
-        shell.absolute_path(Path::new(right.as_ref())),
-    );
+	let (l_path, r_path) = (
+		shell.absolute_path(Path::new(left.as_ref())),
+		shell.absolute_path(Path::new(right.as_ref())),
+	);
 
-    match (l_path.metadata(), r_path.metadata()) {
-        (Ok(m1), Ok(m2)) => Ok(m1.modified()? > m2.modified()?),
-        (Ok(_), Err(_)) => Ok(true),
-        _ => Ok(false),
-    }
+	match (l_path.metadata(), r_path.metadata()) {
+		(Ok(m1), Ok(m2)) => Ok(m1.modified()? > m2.modified()?),
+		(Ok(_), Err(_)) => Ok(true),
+		_ => Ok(false),
+	}
 }
 
 fn files_refer_to_same_device_and_inode_numbers(
-    shell: &Shell,
-    left: impl AsRef<str>,
-    right: impl AsRef<str>,
+	shell: &Shell,
+	left: impl AsRef<str>,
+	right: impl AsRef<str>,
 ) -> Result<bool, error::Error> {
-    let (l_path, r_path) = (
-        shell.absolute_path(Path::new(left.as_ref())),
-        shell.absolute_path(Path::new(right.as_ref())),
-    );
+	let (l_path, r_path) = (
+		shell.absolute_path(Path::new(left.as_ref())),
+		shell.absolute_path(Path::new(right.as_ref())),
+	);
 
-    if !l_path.readable() || !r_path.readable() {
-        return Ok(false);
-    }
+	if !l_path.readable() || !r_path.readable() {
+		return Ok(false);
+	}
 
-    Ok(l_path.get_device_and_inode()? == r_path.get_device_and_inode()?)
+	Ok(l_path.get_device_and_inode()? == r_path.get_device_and_inode()?)
 }

--- a/crates/brush-core-vendored/src/functions.rs
+++ b/crates/brush-core-vendored/src/functions.rs
@@ -1,8 +1,8 @@
 //! Structures for managing function registrations and calls.
 
 use std::{
-    collections::{HashMap, VecDeque},
-    sync::Arc,
+	collections::{HashMap, VecDeque},
+	sync::Arc,
 };
 
 use brush_parser::ast;
@@ -10,168 +10,165 @@ use brush_parser::ast;
 /// An environment for defined, named functions.
 #[derive(Clone, Default)]
 pub struct FunctionEnv {
-    functions: HashMap<String, Registration>,
+	functions: HashMap<String, Registration>,
 }
 
 impl FunctionEnv {
-    /// Tries to retrieve the registration for a function by name.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the function to retrieve.
-    pub fn get(&self, name: &str) -> Option<&Registration> {
-        self.functions.get(name)
-    }
+	/// Tries to retrieve the registration for a function by name.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the function to retrieve.
+	pub fn get(&self, name: &str) -> Option<&Registration> {
+		self.functions.get(name)
+	}
 
-    /// Tries to retrieve a mutable reference to the registration for a
-    /// function by name.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the function to retrieve.
-    pub fn get_mut(&mut self, name: &str) -> Option<&mut Registration> {
-        self.functions.get_mut(name)
-    }
+	/// Tries to retrieve a mutable reference to the registration for a
+	/// function by name.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the function to retrieve.
+	pub fn get_mut(&mut self, name: &str) -> Option<&mut Registration> {
+		self.functions.get_mut(name)
+	}
 
-    /// Unregisters a function from the environment.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the function to remove.
-    pub fn remove(&mut self, name: &str) -> Option<Registration> {
-        self.functions.remove(name)
-    }
+	/// Unregisters a function from the environment.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the function to remove.
+	pub fn remove(&mut self, name: &str) -> Option<Registration> {
+		self.functions.remove(name)
+	}
 
-    /// Updates a function registration in this environment.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the function to update.
-    /// * `registration` - The new registration for the function.
-    pub fn update(&mut self, name: String, registration: Registration) {
-        self.functions.insert(name, registration);
-    }
+	/// Updates a function registration in this environment.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the function to update.
+	/// * `registration` - The new registration for the function.
+	pub fn update(&mut self, name: String, registration: Registration) {
+		self.functions.insert(name, registration);
+	}
 
-    /// Clear all functions in this environment.
-    pub fn clear(&mut self) {
-        self.functions.clear();
-    }
+	/// Clear all functions in this environment.
+	pub fn clear(&mut self) {
+		self.functions.clear();
+	}
 
-    /// Returns an iterator over the functions registered in this environment.
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &Registration)> {
-        self.functions.iter()
-    }
+	/// Returns an iterator over the functions registered in this environment.
+	pub fn iter(&self) -> impl Iterator<Item = (&String, &Registration)> {
+		self.functions.iter()
+	}
 }
 
 /// Encapsulates a registration for a defined function.
 #[derive(Clone)]
 pub struct Registration {
-    /// The definition of the function.
-    pub(crate) definition: Arc<brush_parser::ast::FunctionDefinition>,
-    /// Whether or not this function definition should be exported to children.
-    exported: bool,
+	/// The definition of the function.
+	pub(crate) definition: Arc<brush_parser::ast::FunctionDefinition>,
+	/// Whether or not this function definition should be exported to children.
+	exported: bool,
 }
 
 impl From<brush_parser::ast::FunctionDefinition> for Registration {
-    fn from(definition: brush_parser::ast::FunctionDefinition) -> Self {
-        Self {
-            definition: Arc::new(definition),
-            exported: false,
-        }
-    }
+	fn from(definition: brush_parser::ast::FunctionDefinition) -> Self {
+		Self { definition: Arc::new(definition), exported: false }
+	}
 }
 
 impl Registration {
-    /// Returns a reference to the function definition.
-    pub fn definition(&self) -> &brush_parser::ast::FunctionDefinition {
-        &self.definition
-    }
+	/// Returns a reference to the function definition.
+	pub fn definition(&self) -> &brush_parser::ast::FunctionDefinition {
+		&self.definition
+	}
 
-    /// Marks the function for export.
-    pub const fn export(&mut self) {
-        self.exported = true;
-    }
+	/// Marks the function for export.
+	pub const fn export(&mut self) {
+		self.exported = true;
+	}
 
-    /// Unmarks the function for export.
-    pub const fn unexport(&mut self) {
-        self.exported = false;
-    }
+	/// Unmarks the function for export.
+	pub const fn unexport(&mut self) {
+		self.exported = false;
+	}
 
-    /// Returns whether this function is exported.
-    pub const fn is_exported(&self) -> bool {
-        self.exported
-    }
+	/// Returns whether this function is exported.
+	pub const fn is_exported(&self) -> bool {
+		self.exported
+	}
 }
 
 /// Represents an active shell function call.
 #[derive(Clone, Debug)]
 pub struct FunctionCall {
-    /// The name of the function invoked.
-    pub function_name: String,
-    /// The definition of the invoked function.
-    pub function_definition: Arc<brush_parser::ast::FunctionDefinition>,
+	/// The name of the function invoked.
+	pub function_name: String,
+	/// The definition of the invoked function.
+	pub function_definition: Arc<brush_parser::ast::FunctionDefinition>,
 }
 
 /// Encapsulates a function call stack.
 #[derive(Clone, Debug, Default)]
 pub struct CallStack {
-    frames: VecDeque<FunctionCall>,
+	frames: VecDeque<FunctionCall>,
 }
 
 impl std::fmt::Display for CallStack {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.is_empty() {
-            return Ok(());
-        }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		if self.is_empty() {
+			return Ok(());
+		}
 
-        writeln!(f, "Function call stack (most recent first):")?;
+		writeln!(f, "Function call stack (most recent first):")?;
 
-        for (index, frame) in self.iter().enumerate() {
-            writeln!(f, "  #{}| {}", index, frame.function_name)?;
-        }
+		for (index, frame) in self.iter().enumerate() {
+			writeln!(f, "  #{}| {}", index, frame.function_name)?;
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 }
 
 impl CallStack {
-    /// Creates a new empty function call stack.
-    pub fn new() -> Self {
-        Self::default()
-    }
+	/// Creates a new empty function call stack.
+	pub fn new() -> Self {
+		Self::default()
+	}
 
-    /// Removes the top from from the stack. If the stack is empty, does nothing and
-    /// returns `None`; otherwise, returns the removed call frame.
-    pub fn pop(&mut self) -> Option<FunctionCall> {
-        self.frames.pop_front()
-    }
+	/// Removes the top from from the stack. If the stack is empty, does nothing and
+	/// returns `None`; otherwise, returns the removed call frame.
+	pub fn pop(&mut self) -> Option<FunctionCall> {
+		self.frames.pop_front()
+	}
 
-    /// Pushes a new frame onto the stack.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the function being called.
-    /// * `function_def` - The definition of the function being called.
-    pub fn push(&mut self, name: impl Into<String>, function_def: &Arc<ast::FunctionDefinition>) {
-        self.frames.push_front(FunctionCall {
-            function_name: name.into(),
-            function_definition: function_def.clone(),
-        });
-    }
+	/// Pushes a new frame onto the stack.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the function being called.
+	/// * `function_def` - The definition of the function being called.
+	pub fn push(&mut self, name: impl Into<String>, function_def: &Arc<ast::FunctionDefinition>) {
+		self.frames.push_front(FunctionCall {
+			function_name: name.into(),
+			function_definition: function_def.clone(),
+		});
+	}
 
-    /// Returns the current depth of the function call stack.
-    pub fn depth(&self) -> usize {
-        self.frames.len()
-    }
+	/// Returns the current depth of the function call stack.
+	pub fn depth(&self) -> usize {
+		self.frames.len()
+	}
 
-    /// Returns whether or not the function call stack is empty.
-    pub fn is_empty(&self) -> bool {
-        self.frames.is_empty()
-    }
+	/// Returns whether or not the function call stack is empty.
+	pub fn is_empty(&self) -> bool {
+		self.frames.is_empty()
+	}
 
-    /// Returns an iterator over the function call frames, starting from the most
-    /// recent.
-    pub fn iter(&self) -> impl Iterator<Item = &FunctionCall> {
-        self.frames.iter()
-    }
+	/// Returns an iterator over the function call frames, starting from the most
+	/// recent.
+	pub fn iter(&self) -> impl Iterator<Item = &FunctionCall> {
+		self.frames.iter()
+	}
 }

--- a/crates/brush-core-vendored/src/history.rs
+++ b/crates/brush-core-vendored/src/history.rs
@@ -2,8 +2,8 @@
 
 use chrono::Utc;
 use std::{
-    io::{BufRead, Read, Write},
-    path::Path,
+	io::{BufRead, Read, Write},
+	path::Path,
 };
 
 use crate::error;
@@ -15,476 +15,470 @@ type ItemId = i64;
 // TODO: support maximum item count
 #[derive(Clone, Default)]
 pub struct History {
-    items: rpds::VectorSync<ItemId>,
-    id_map: rpds::HashTrieMapSync<ItemId, Item>,
-    next_id: ItemId,
+	items: rpds::VectorSync<ItemId>,
+	id_map: rpds::HashTrieMapSync<ItemId, Item>,
+	next_id: ItemId,
 }
 
 impl History {
-    /// Constructs a new `History` instance, with its contents initialized from the given readable
-    /// stream. If errors are encountered reading lines from the stream, unreadable lines will
-    /// be skipped but the call will still return successfully, with a warning logged. An error
-    /// result will be returned only if an internal error occurs updating the history.
-    ///
-    /// # Arguments
-    ///
-    /// * `reader` - The readable stream to import history from.
-    pub fn import(reader: impl Read) -> Result<Self, error::Error> {
-        let mut history = Self::default();
+	/// Constructs a new `History` instance, with its contents initialized from the given readable
+	/// stream. If errors are encountered reading lines from the stream, unreadable lines will
+	/// be skipped but the call will still return successfully, with a warning logged. An error
+	/// result will be returned only if an internal error occurs updating the history.
+	///
+	/// # Arguments
+	///
+	/// * `reader` - The readable stream to import history from.
+	pub fn import(reader: impl Read) -> Result<Self, error::Error> {
+		let mut history = Self::default();
 
-        let buf_reader = std::io::BufReader::new(reader);
+		let buf_reader = std::io::BufReader::new(reader);
 
-        let mut next_timestamp = None;
-        for line_result in buf_reader.lines() {
-            // If we couldn't decode the line (perhaps it wasn't valid UTF8?), skip it and make
-            // a best-effort attempt to proceed on. We'll later warn the user.
-            let line = match line_result {
-                Ok(line) => line,
-                Err(err) => {
-                    tracing::warn!("unreadable history line; {err}");
-                    continue;
-                }
-            };
+		let mut next_timestamp = None;
+		for line_result in buf_reader.lines() {
+			// If we couldn't decode the line (perhaps it wasn't valid UTF8?), skip it and make
+			// a best-effort attempt to proceed on. We'll later warn the user.
+			let line = match line_result {
+				Ok(line) => line,
+				Err(err) => {
+					tracing::warn!("unreadable history line; {err}");
+					continue;
+				},
+			};
 
-            // Look for timestamp comments; ignore other comment lines.
-            if let Some(comment) = line.strip_prefix("#") {
-                if let Ok(seconds_since_epoch) = comment.trim().parse() {
-                    next_timestamp =
-                        chrono::DateTime::<Utc>::from_timestamp(seconds_since_epoch, 0);
-                } else {
-                    next_timestamp = None;
-                }
+			// Look for timestamp comments; ignore other comment lines.
+			if let Some(comment) = line.strip_prefix("#") {
+				if let Ok(seconds_since_epoch) = comment.trim().parse() {
+					next_timestamp = chrono::DateTime::<Utc>::from_timestamp(seconds_since_epoch, 0);
+				} else {
+					next_timestamp = None;
+				}
 
-                continue;
-            }
+				continue;
+			}
 
-            let item = Item {
-                id: history.next_id,
-                command_line: line,
-                timestamp: next_timestamp.take(),
-                dirty: false,
-            };
+			let item = Item {
+				id: history.next_id,
+				command_line: line,
+				timestamp: next_timestamp.take(),
+				dirty: false,
+			};
 
-            history.add(item)?;
-        }
+			history.add(item)?;
+		}
 
-        Ok(history)
-    }
+		Ok(history)
+	}
 
-    /// Tries to retrieve a history item by its unique identifier. Returns `None` if no item is
-    /// found.
-    ///
-    /// # Arguments
-    ///
-    /// * `id` - The unique identifier of the history item to retrieve.
-    pub fn get_by_id(&self, id: ItemId) -> Result<Option<&Item>, error::Error> {
-        Ok(self.id_map.get(&id))
-    }
+	/// Tries to retrieve a history item by its unique identifier. Returns `None` if no item is
+	/// found.
+	///
+	/// # Arguments
+	///
+	/// * `id` - The unique identifier of the history item to retrieve.
+	pub fn get_by_id(&self, id: ItemId) -> Result<Option<&Item>, error::Error> {
+		Ok(self.id_map.get(&id))
+	}
 
-    /// Replaces the history item with the given ID with a new item. Returns an error if the item
-    /// cannot be updated.
-    ///
-    /// # Arguments
-    ///
-    /// * `id` - The unique identifier of the history item to update.
-    /// * `item` - The new history item to replace the old one.
-    pub fn update_by_id(&mut self, id: ItemId, item: Item) -> Result<(), error::Error> {
-        let existing_item = self
-            .id_map
-            .get_mut(&id)
-            .ok_or(error::ErrorKind::HistoryItemNotFound)?;
-        *existing_item = item;
-        Ok(())
-    }
+	/// Replaces the history item with the given ID with a new item. Returns an error if the item
+	/// cannot be updated.
+	///
+	/// # Arguments
+	///
+	/// * `id` - The unique identifier of the history item to update.
+	/// * `item` - The new history item to replace the old one.
+	pub fn update_by_id(&mut self, id: ItemId, item: Item) -> Result<(), error::Error> {
+		let existing_item = self
+			.id_map
+			.get_mut(&id)
+			.ok_or(error::ErrorKind::HistoryItemNotFound)?;
+		*existing_item = item;
+		Ok(())
+	}
 
-    /// Removes the nth item from the history. Returns the removed item, or `None` if no such item
-    /// exists (i.e., because it was out of range).
-    pub fn remove_nth_item(&mut self, n: usize) -> bool {
-        if let Some(id) = self.items.get(n).copied() {
-            self.items = self
-                .items
-                .into_iter()
-                .enumerate()
-                .filter_map(|(i, id)| if i != n { Some(id) } else { None })
-                .copied()
-                .collect();
+	/// Removes the nth item from the history. Returns the removed item, or `None` if no such item
+	/// exists (i.e., because it was out of range).
+	pub fn remove_nth_item(&mut self, n: usize) -> bool {
+		if let Some(id) = self.items.get(n).copied() {
+			self.items = self
+				.items
+				.into_iter()
+				.enumerate()
+				.filter_map(|(i, id)| if i != n { Some(id) } else { None })
+				.copied()
+				.collect();
 
-            self.id_map.remove_mut(&id);
+			self.id_map.remove_mut(&id);
 
-            true
-        } else {
-            false
-        }
-    }
+			true
+		} else {
+			false
+		}
+	}
 
-    /// Adds a new history item. Returns the unique identifier of the newly added item.
-    ///
-    /// # Arguments
-    ///
-    /// * `item` - The history item to add.
-    pub fn add(&mut self, mut item: Item) -> Result<ItemId, error::Error> {
-        let id = self.next_id;
+	/// Adds a new history item. Returns the unique identifier of the newly added item.
+	///
+	/// # Arguments
+	///
+	/// * `item` - The history item to add.
+	pub fn add(&mut self, mut item: Item) -> Result<ItemId, error::Error> {
+		let id = self.next_id;
 
-        item.id = id;
-        self.next_id += 1;
+		item.id = id;
+		self.next_id += 1;
 
-        self.items.push_back_mut(item.id);
-        self.id_map.insert_mut(item.id, item);
+		self.items.push_back_mut(item.id);
+		self.id_map.insert_mut(item.id, item);
 
-        Ok(id)
-    }
+		Ok(id)
+	}
 
-    /// Deletes a history item by its unique identifier. Returns an error if the item cannot be
-    /// deleted.
-    ///
-    /// # Arguments
-    ///
-    /// * `id` - The unique identifier of the history item to delete.
-    pub fn delete_item_by_id(&mut self, id: ItemId) -> Result<(), error::Error> {
-        self.id_map.remove_mut(&id);
-        self.items = self
-            .items
-            .into_iter()
-            .filter(|&item_id| *item_id != id)
-            .copied()
-            .collect();
+	/// Deletes a history item by its unique identifier. Returns an error if the item cannot be
+	/// deleted.
+	///
+	/// # Arguments
+	///
+	/// * `id` - The unique identifier of the history item to delete.
+	pub fn delete_item_by_id(&mut self, id: ItemId) -> Result<(), error::Error> {
+		self.id_map.remove_mut(&id);
+		self.items = self
+			.items
+			.into_iter()
+			.filter(|&item_id| *item_id != id)
+			.copied()
+			.collect();
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    /// Clears all history items.
-    pub fn clear(&mut self) -> Result<(), error::Error> {
-        self.id_map = rpds::HashTrieMapSync::new_sync();
-        self.items = rpds::VectorSync::new_sync();
-        Ok(())
-    }
+	/// Clears all history items.
+	pub fn clear(&mut self) -> Result<(), error::Error> {
+		self.id_map = rpds::HashTrieMapSync::new_sync();
+		self.items = rpds::VectorSync::new_sync();
+		Ok(())
+	}
 
-    /// Flushes the history to backing storage (if relevant).
-    ///
-    /// # Arguments
-    ///
-    /// * `history_file_path` - The path to the history file.
-    /// * `append` - Whether to append to the file or overwrite it.
-    /// * `unsaved_items_only` - Whether to only write unsaved items; if true, any items will be marked as "saved" once saved.
-    /// * `write_timestamps` - Whether to write timestamps for each command line.
-    pub fn flush(
-        &mut self,
-        history_file_path: impl AsRef<Path>,
-        append: bool,
-        unsaved_items_only: bool,
-        write_timestamps: bool,
-    ) -> Result<(), error::Error> {
-        // Open the file
-        let mut file_options = std::fs::File::options();
+	/// Flushes the history to backing storage (if relevant).
+	///
+	/// # Arguments
+	///
+	/// * `history_file_path` - The path to the history file.
+	/// * `append` - Whether to append to the file or overwrite it.
+	/// * `unsaved_items_only` - Whether to only write unsaved items; if true, any items will be marked as "saved" once saved.
+	/// * `write_timestamps` - Whether to write timestamps for each command line.
+	pub fn flush(
+		&mut self,
+		history_file_path: impl AsRef<Path>,
+		append: bool,
+		unsaved_items_only: bool,
+		write_timestamps: bool,
+	) -> Result<(), error::Error> {
+		// Open the file
+		let mut file_options = std::fs::File::options();
 
-        if append {
-            file_options.append(true);
-        } else {
-            file_options.write(true).truncate(true);
-        }
+		if append {
+			file_options.append(true);
+		} else {
+			file_options.write(true).truncate(true);
+		}
 
-        let mut file = file_options.create(true).open(history_file_path.as_ref())?;
+		let mut file = file_options.create(true).open(history_file_path.as_ref())?;
 
-        for item_id in &self.items {
-            if let Some(item) = self.id_map.get_mut(item_id) {
-                if unsaved_items_only && !item.dirty {
-                    continue;
-                }
+		for item_id in &self.items {
+			if let Some(item) = self.id_map.get_mut(item_id) {
+				if unsaved_items_only && !item.dirty {
+					continue;
+				}
 
-                if write_timestamps {
-                    if let Some(timestamp) = item.timestamp {
-                        writeln!(file, "#{}", timestamp.timestamp())?;
-                    }
-                }
+				if write_timestamps {
+					if let Some(timestamp) = item.timestamp {
+						writeln!(file, "#{}", timestamp.timestamp())?;
+					}
+				}
 
-                writeln!(file, "{}", item.command_line)?;
+				writeln!(file, "{}", item.command_line)?;
 
-                if unsaved_items_only {
-                    item.dirty = false;
-                }
-            }
-        }
+				if unsaved_items_only {
+					item.dirty = false;
+				}
+			}
+		}
 
-        file.flush()?;
+		file.flush()?;
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    /// Searches through history using the given query.
-    ///
-    /// # Arguments
-    ///
-    /// * `query` - The query to use.
-    pub fn search(&self, query: Query) -> Result<impl Iterator<Item = &self::Item>, error::Error> {
-        Ok(Search::new(self, query))
-    }
+	/// Searches through history using the given query.
+	///
+	/// # Arguments
+	///
+	/// * `query` - The query to use.
+	pub fn search(&self, query: Query) -> Result<impl Iterator<Item = &self::Item>, error::Error> {
+		Ok(Search::new(self, query))
+	}
 
-    /// Returns an iterator over the history items.
-    pub fn iter(&self) -> impl Iterator<Item = &self::Item> {
-        Search::all(self)
-    }
+	/// Returns an iterator over the history items.
+	pub fn iter(&self) -> impl Iterator<Item = &self::Item> {
+		Search::all(self)
+	}
 
-    /// Retrieves the nth history item, if it exists. Returns `None` if no such item exists.
-    /// Indexing is zero-based, with an index of 0 referencing the oldest item in the history.
-    ///
-    /// # Arguments
-    ///
-    /// * `index` - The index of the history item to retrieve.
-    pub fn get(&self, index: usize) -> Option<&Item> {
-        if let Some(id) = self.items.get(index) {
-            self.id_map.get(id)
-        } else {
-            None
-        }
-    }
+	/// Retrieves the nth history item, if it exists. Returns `None` if no such item exists.
+	/// Indexing is zero-based, with an index of 0 referencing the oldest item in the history.
+	///
+	/// # Arguments
+	///
+	/// * `index` - The index of the history item to retrieve.
+	pub fn get(&self, index: usize) -> Option<&Item> {
+		if let Some(id) = self.items.get(index) {
+			self.id_map.get(id)
+		} else {
+			None
+		}
+	}
 
-    /// Returns the number of items in the history.
-    pub fn count(&self) -> usize {
-        self.items.len()
-    }
+	/// Returns the number of items in the history.
+	pub fn count(&self) -> usize {
+		self.items.len()
+	}
 }
 
 /// Represents an item in the history.
 #[derive(Clone, Default)]
 pub struct Item {
-    /// The unique identifier of the history item.
-    pub id: ItemId,
-    /// The actual command line.
-    pub command_line: String,
-    /// The timestamp when the command was started.
-    pub timestamp: Option<chrono::DateTime<Utc>>,
-    /// Whether or not the item is dirty, i.e., has not yet been written to backing storage.
-    pub dirty: bool,
+	/// The unique identifier of the history item.
+	pub id: ItemId,
+	/// The actual command line.
+	pub command_line: String,
+	/// The timestamp when the command was started.
+	pub timestamp: Option<chrono::DateTime<Utc>>,
+	/// Whether or not the item is dirty, i.e., has not yet been written to backing storage.
+	pub dirty: bool,
 }
 
 impl Item {
-    /// Constructs a new `Item` with the given command line.
-    ///
-    /// # Arguments
-    ///
-    /// * `command_line` - The command line of the item.
-    pub fn new(command_line: impl Into<String>) -> Self {
-        Self {
-            id: 0, // NOTE: ID will be assigned when added to the history.
-            command_line: command_line.into(),
-            timestamp: Some(chrono::Utc::now()),
-            dirty: true,
-        }
-    }
+	/// Constructs a new `Item` with the given command line.
+	///
+	/// # Arguments
+	///
+	/// * `command_line` - The command line of the item.
+	pub fn new(command_line: impl Into<String>) -> Self {
+		Self {
+			id: 0, // NOTE: ID will be assigned when added to the history.
+			command_line: command_line.into(),
+			timestamp: Some(chrono::Utc::now()),
+			dirty: true,
+		}
+	}
 }
 
 /// Encapsulates query parameters for searching through history.
 #[derive(Default)]
 pub struct Query {
-    /// Whether to search forward or backward
-    pub direction: Direction,
-    /// Optionally, clamp results to items with a timestamp strictly after this.
-    pub not_at_or_before_time: Option<chrono::DateTime<Utc>>,
-    /// Optionally, clamp results to items with a timestamp strictly before this.
-    pub not_at_or_after_time: Option<chrono::DateTime<Utc>>,
-    /// Optionally, clamp results to items with an ID equal strictly after this.
-    pub not_at_or_before_id: Option<ItemId>,
-    /// Optionally, clamp results to items with an ID equal strictly before this.
-    pub not_at_or_after_id: Option<ItemId>,
-    /// Optionally, maximum number of items to retrieve
-    pub max_items: Option<i64>,
-    /// Optionally, a string-based filter on command line.
-    pub command_line_filter: Option<CommandLineFilter>,
+	/// Whether to search forward or backward
+	pub direction: Direction,
+	/// Optionally, clamp results to items with a timestamp strictly after this.
+	pub not_at_or_before_time: Option<chrono::DateTime<Utc>>,
+	/// Optionally, clamp results to items with a timestamp strictly before this.
+	pub not_at_or_after_time: Option<chrono::DateTime<Utc>>,
+	/// Optionally, clamp results to items with an ID equal strictly after this.
+	pub not_at_or_before_id: Option<ItemId>,
+	/// Optionally, clamp results to items with an ID equal strictly before this.
+	pub not_at_or_after_id: Option<ItemId>,
+	/// Optionally, maximum number of items to retrieve
+	pub max_items: Option<i64>,
+	/// Optionally, a string-based filter on command line.
+	pub command_line_filter: Option<CommandLineFilter>,
 }
 
 impl Query {
-    /// Checks if the query includes the given item.
-    ///
-    /// # Arguments
-    ///
-    /// * `item` - The item to check.
-    pub fn includes(&self, item: &Item) -> bool {
-        // Filter based on not_at_or_before_time.
-        if let Some(not_at_or_before_time) = &self.not_at_or_before_time {
-            if item
-                .timestamp
-                .is_some_and(|ts| ts <= *not_at_or_before_time)
-            {
-                return false;
-            }
-        }
+	/// Checks if the query includes the given item.
+	///
+	/// # Arguments
+	///
+	/// * `item` - The item to check.
+	pub fn includes(&self, item: &Item) -> bool {
+		// Filter based on not_at_or_before_time.
+		if let Some(not_at_or_before_time) = &self.not_at_or_before_time {
+			if item
+				.timestamp
+				.is_some_and(|ts| ts <= *not_at_or_before_time)
+			{
+				return false;
+			}
+		}
 
-        // Filter based on not_at_or_after_time
-        if let Some(not_at_or_after_time) = &self.not_at_or_after_time {
-            if item.timestamp.is_some_and(|ts| ts >= *not_at_or_after_time) {
-                return false;
-            }
-        }
+		// Filter based on not_at_or_after_time
+		if let Some(not_at_or_after_time) = &self.not_at_or_after_time {
+			if item.timestamp.is_some_and(|ts| ts >= *not_at_or_after_time) {
+				return false;
+			}
+		}
 
-        // Filter based on not_at_or_before_id
-        if self
-            .not_at_or_before_id
-            .is_some_and(|query_id| item.id <= query_id)
-        {
-            return false;
-        }
+		// Filter based on not_at_or_before_id
+		if self
+			.not_at_or_before_id
+			.is_some_and(|query_id| item.id <= query_id)
+		{
+			return false;
+		}
 
-        // Filter based on not_at_or_after_id
-        if self
-            .not_at_or_after_id
-            .is_some_and(|query_id| item.id >= query_id)
-        {
-            return false;
-        }
+		// Filter based on not_at_or_after_id
+		if self
+			.not_at_or_after_id
+			.is_some_and(|query_id| item.id >= query_id)
+		{
+			return false;
+		}
 
-        // Filter based on command_line_filter
-        if let Some(command_line_filter) = &self.command_line_filter {
-            match command_line_filter {
-                CommandLineFilter::Prefix(prefix) => {
-                    if !item.command_line.starts_with(prefix) {
-                        return false;
-                    }
-                }
-                CommandLineFilter::Suffix(suffix) => {
-                    if !item.command_line.ends_with(suffix) {
-                        return false;
-                    }
-                }
-                CommandLineFilter::Contains(contains) => {
-                    if !item.command_line.contains(contains) {
-                        return false;
-                    }
-                }
-                CommandLineFilter::Exact(exact) => {
-                    if item.command_line != *exact {
-                        return false;
-                    }
-                }
-            }
-        }
+		// Filter based on command_line_filter
+		if let Some(command_line_filter) = &self.command_line_filter {
+			match command_line_filter {
+				CommandLineFilter::Prefix(prefix) => {
+					if !item.command_line.starts_with(prefix) {
+						return false;
+					}
+				},
+				CommandLineFilter::Suffix(suffix) => {
+					if !item.command_line.ends_with(suffix) {
+						return false;
+					}
+				},
+				CommandLineFilter::Contains(contains) => {
+					if !item.command_line.contains(contains) {
+						return false;
+					}
+				},
+				CommandLineFilter::Exact(exact) => {
+					if item.command_line != *exact {
+						return false;
+					}
+				},
+			}
+		}
 
-        true
-    }
+		true
+	}
 }
 
 /// Represents the direction of a search operation.
 #[derive(Default)]
 pub enum Direction {
-    /// Search forward from the oldest part of history.
-    #[default]
-    Forward,
-    /// Search backward from the youngest part of history.
-    Backward,
+	/// Search forward from the oldest part of history.
+	#[default]
+	Forward,
+	/// Search backward from the youngest part of history.
+	Backward,
 }
 
 /// Filter criteria for command lines.
 pub enum CommandLineFilter {
-    /// The command line must start with this string.
-    Prefix(String),
-    /// The command line must end with this string.
-    Suffix(String),
-    /// The command line must contain this string.
-    Contains(String),
-    /// The command line must match this string exactly.
-    Exact(String),
+	/// The command line must start with this string.
+	Prefix(String),
+	/// The command line must end with this string.
+	Suffix(String),
+	/// The command line must contain this string.
+	Contains(String),
+	/// The command line must match this string exactly.
+	Exact(String),
 }
 
 /// Represents a search operation.
 pub struct Search<'a> {
-    /// The history to search through.
-    history: &'a History,
-    /// The query to apply.
-    query: Query,
-    /// The next index in `items`.
-    next_index: Option<usize>,
-    /// Count of items returned so far.
-    count: usize,
+	/// The history to search through.
+	history: &'a History,
+	/// The query to apply.
+	query: Query,
+	/// The next index in `items`.
+	next_index: Option<usize>,
+	/// Count of items returned so far.
+	count: usize,
 }
 
 impl<'a> Search<'a> {
-    /// Constructs a new search against the provided history, querying *all* items.
-    ///
-    /// # Arguments
-    ///
-    /// * `history` - The history to search through.
-    pub fn all(history: &'a History) -> Self {
-        Self::new(history, Query::default())
-    }
+	/// Constructs a new search against the provided history, querying *all* items.
+	///
+	/// # Arguments
+	///
+	/// * `history` - The history to search through.
+	pub fn all(history: &'a History) -> Self {
+		Self::new(history, Query::default())
+	}
 
-    /// Constructs a new search against the provided history, using the given query.
-    ///
-    /// # Arguments
-    ///
-    /// * `history` - The history to search through.
-    /// * `query` - The query to use.
-    pub fn new(history: &'a History, query: Query) -> Self {
-        let next_index = match query.direction {
-            Direction::Forward => Some(0),
-            Direction::Backward => {
-                if history.items.is_empty() {
-                    None
-                } else {
-                    Some(history.items.len() - 1)
-                }
-            }
-        };
+	/// Constructs a new search against the provided history, using the given query.
+	///
+	/// # Arguments
+	///
+	/// * `history` - The history to search through.
+	/// * `query` - The query to use.
+	pub fn new(history: &'a History, query: Query) -> Self {
+		let next_index = match query.direction {
+			Direction::Forward => Some(0),
+			Direction::Backward => {
+				if history.items.is_empty() {
+					None
+				} else {
+					Some(history.items.len() - 1)
+				}
+			},
+		};
 
-        Self {
-            history,
-            query,
-            next_index,
-            count: 0,
-        }
-    }
+		Self { history, query, next_index, count: 0 }
+	}
 
-    const fn increment_next_index(&mut self) {
-        if let Some(index) = self.next_index {
-            self.next_index = match self.query.direction {
-                Direction::Forward => Some(index + 1),
-                Direction::Backward => {
-                    if index == 0 {
-                        None
-                    } else {
-                        Some(index - 1)
-                    }
-                }
-            }
-        }
-    }
+	const fn increment_next_index(&mut self) {
+		if let Some(index) = self.next_index {
+			self.next_index = match self.query.direction {
+				Direction::Forward => Some(index + 1),
+				Direction::Backward => {
+					if index == 0 {
+						None
+					} else {
+						Some(index - 1)
+					}
+				},
+			}
+		}
+	}
 }
 
 impl<'a> Iterator for Search<'a> {
-    type Item = &'a Item;
+	type Item = &'a Item;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if let Some(index) = self.next_index {
-                // Make sure we haven't hit the end of the history.
-                if index >= self.history.items.len() {
-                    return None;
-                }
+	fn next(&mut self) -> Option<Self::Item> {
+		loop {
+			if let Some(index) = self.next_index {
+				// Make sure we haven't hit the end of the history.
+				if index >= self.history.items.len() {
+					return None;
+				}
 
-                let id = self.history.items[index];
-                self.increment_next_index();
+				let id = self.history.items[index];
+				self.increment_next_index();
 
-                if let Some(item) = self.history.id_map.get(&id) {
-                    // Filter based on max_items. Once we hit the limit,
-                    // we stop searching.
-                    #[expect(clippy::cast_possible_truncation)]
-                    #[expect(clippy::cast_sign_loss)]
-                    if self
-                        .query
-                        .max_items
-                        .is_some_and(|max_items| self.count >= max_items as usize)
-                    {
-                        return None;
-                    }
+				if let Some(item) = self.history.id_map.get(&id) {
+					// Filter based on max_items. Once we hit the limit,
+					// we stop searching.
+					#[expect(clippy::cast_possible_truncation)]
+					#[expect(clippy::cast_sign_loss)]
+					if self
+						.query
+						.max_items
+						.is_some_and(|max_items| self.count >= max_items as usize)
+					{
+						return None;
+					}
 
-                    // Check other filters. If they don't match, then we
-                    // skip but keep searching.
-                    if self.query.includes(item) {
-                        self.count += 1;
-                        return Some(item);
-                    }
-                }
-            } else {
-                return None;
-            }
-        }
-    }
+					// Check other filters. If they don't match, then we
+					// skip but keep searching.
+					if self.query.includes(item) {
+						self.count += 1;
+						return Some(item);
+					}
+				}
+			} else {
+				return None;
+			}
+		}
+	}
 }

--- a/crates/brush-core-vendored/src/interfaces/keybindings.rs
+++ b/crates/brush-core-vendored/src/interfaces/keybindings.rs
@@ -1,24 +1,24 @@
 use std::{
-    collections::HashMap,
-    fmt::{self, Display, Formatter},
+	collections::HashMap,
+	fmt::{self, Display, Formatter},
 };
 
 /// Represents an action that can be taken in response to a key sequence.
 #[derive(Debug)]
 pub enum KeyAction {
-    /// Execute a shell command.
-    ShellCommand(String),
-    /// Execute an input "function".
-    DoInputFunction(InputFunction),
+	/// Execute a shell command.
+	ShellCommand(String),
+	/// Execute an input "function".
+	DoInputFunction(InputFunction),
 }
 
 impl Display for KeyAction {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::ShellCommand(command) => write!(f, "shell command: {command}"),
-            Self::DoInputFunction(function) => function.fmt(f),
-        }
-    }
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::ShellCommand(command) => write!(f, "shell command: {command}"),
+			Self::DoInputFunction(function) => function.fmt(f),
+		}
+	}
 }
 
 /// Defines all input functions.
@@ -26,312 +26,305 @@ impl Display for KeyAction {
 #[strum(serialize_all = "kebab-case")]
 #[expect(missing_docs)]
 pub enum InputFunction {
-    Abort,
-    AcceptLine,
-    AliasExpandLine,
-    ArrowKeyPrefix,
-    BackwardByte,
-    BackwardChar,
-    BackwardDeleteChar,
-    BackwardKillLine,
-    BackwardKillWord,
-    BackwardWord,
-    BeginningOfHistory,
-    BeginningOfLine,
-    BracketedPasteBegin,
-    CallLastKbdMacro,
-    CapitalizeWord,
-    CharacterSearch,
-    CharacterSearchBackward,
-    ClearDisplay,
-    ClearScreen,
-    Complete,
-    CompleteCommand,
-    CompleteFilename,
-    CompleteHostname,
-    CompleteIntoBraces,
-    CompleteUsername,
-    CompleteVariable,
-    CopyBackwardWord,
-    CopyForwardWord,
-    CopyRegionAsKill,
-    DabbrevExpand,
-    DeleteChar,
-    DeleteCharOrList,
-    DeleteHorizontalSpace,
-    DigitArgument,
-    DisplayShellVersion,
-    DoLowercaseVersion,
-    DowncaseWord,
-    DumpFunctions,
-    DumpMacros,
-    DumpVariables,
-    DynamicCompleteHistory,
-    EditAndExecuteCommand,
-    EmacsEditingMode,
-    EndKbdMacro,
-    EndOfHistory,
-    EndOfLine,
-    ExchangePointAndMark,
-    ForwardBackwardDeleteChar,
-    ForwardByte,
-    ForwardChar,
-    ForwardSearchHistory,
-    ForwardWord,
-    GlobCompleteWord,
-    GlobExpandWord,
-    GlobListExpansions,
-    HistoryAndAliasExpandLine,
-    HistoryExpandLine,
-    HistorySearchBackward,
-    HistorySearchForward,
-    HistorySubstringSearchBackward,
-    HistorySubstringSearchForward,
-    InsertComment,
-    InsertCompletions,
-    InsertLastArgument,
-    KillLine,
-    KillRegion,
-    KillWholeLine,
-    KillWord,
-    MagicSpace,
-    MenuComplete,
-    MenuCompleteBackward,
-    NextHistory,
-    NextScreenLine,
-    NonIncrementalForwardSearchHistory,
-    NonIncrementalForwardSearchHistoryAgain,
-    NonIncrementalReverseSearchHistory,
-    NonIncrementalReverseSearchHistoryAgain,
-    OldMenuComplete,
-    OperateAndGetNext,
-    OverwriteMode,
-    PossibleCommandCompletions,
-    PossibleCompletions,
-    PossibleFilenameCompletions,
-    PossibleHostnameCompletions,
-    PossibleUsernameCompletions,
-    PossibleVariableCompletions,
-    PreviousHistory,
-    PreviousScreenLine,
-    PrintLastKbdMacro,
-    QuotedInsert,
-    ReReadInitFile,
-    RedrawCurrentLine,
-    ReverseSearchHistory,
-    RevertLine,
-    SelfInsert,
-    SetMark,
-    ShellBackwardKillWord,
-    ShellBackwardWord,
-    ShellExpandLine,
-    ShellForwardWord,
-    ShellKillWord,
-    ShellTransposeWords,
-    SkipCsiSequence,
-    StartKbdMacro,
-    TabInsert,
-    TildeExpand,
-    TransposeChars,
-    TransposeWords,
-    TtyStatus,
-    Undo,
-    UniversalArgument,
-    UnixFilenameRubout,
-    UnixLineDiscard,
-    UnixWordRubout,
-    UpcaseWord,
-    ViAppendEol,
-    ViAppendMode,
-    ViArgDigit,
-    ViBWord,
-    ViBackToIndent,
-    ViBackwardBigword,
-    ViBackwardWord,
-    ViBword,
-    ViChangeCase,
-    ViChangeChar,
-    ViChangeTo,
-    ViCharSearch,
-    ViColumn,
-    ViComplete,
-    ViDelete,
-    ViDeleteTo,
-    ViEWord,
-    ViEditingMode,
-    ViEndBigword,
-    ViEndWord,
-    ViEofMaybe,
-    ViEword,
-    ViFWord,
-    ViFetchHistory,
-    ViFirstPrint,
-    ViForwardBigword,
-    ViForwardWord,
-    ViFword,
-    ViGotoMark,
-    ViInsertBeg,
-    ViInsertionMode,
-    ViMatch,
-    ViMovementMode,
-    ViNextWord,
-    ViOverstrike,
-    ViOverstrikeDelete,
-    ViPrevWord,
-    ViPut,
-    ViRedo,
-    ViReplace,
-    ViRubout,
-    ViSearch,
-    ViSearchAgain,
-    ViSetMark,
-    ViSubst,
-    ViTildeExpand,
-    ViUnixWordRubout,
-    ViYankArg,
-    ViYankPop,
-    ViYankTo,
-    Yank,
-    YankLastArg,
-    YankNthArg,
-    YankPop,
+	Abort,
+	AcceptLine,
+	AliasExpandLine,
+	ArrowKeyPrefix,
+	BackwardByte,
+	BackwardChar,
+	BackwardDeleteChar,
+	BackwardKillLine,
+	BackwardKillWord,
+	BackwardWord,
+	BeginningOfHistory,
+	BeginningOfLine,
+	BracketedPasteBegin,
+	CallLastKbdMacro,
+	CapitalizeWord,
+	CharacterSearch,
+	CharacterSearchBackward,
+	ClearDisplay,
+	ClearScreen,
+	Complete,
+	CompleteCommand,
+	CompleteFilename,
+	CompleteHostname,
+	CompleteIntoBraces,
+	CompleteUsername,
+	CompleteVariable,
+	CopyBackwardWord,
+	CopyForwardWord,
+	CopyRegionAsKill,
+	DabbrevExpand,
+	DeleteChar,
+	DeleteCharOrList,
+	DeleteHorizontalSpace,
+	DigitArgument,
+	DisplayShellVersion,
+	DoLowercaseVersion,
+	DowncaseWord,
+	DumpFunctions,
+	DumpMacros,
+	DumpVariables,
+	DynamicCompleteHistory,
+	EditAndExecuteCommand,
+	EmacsEditingMode,
+	EndKbdMacro,
+	EndOfHistory,
+	EndOfLine,
+	ExchangePointAndMark,
+	ForwardBackwardDeleteChar,
+	ForwardByte,
+	ForwardChar,
+	ForwardSearchHistory,
+	ForwardWord,
+	GlobCompleteWord,
+	GlobExpandWord,
+	GlobListExpansions,
+	HistoryAndAliasExpandLine,
+	HistoryExpandLine,
+	HistorySearchBackward,
+	HistorySearchForward,
+	HistorySubstringSearchBackward,
+	HistorySubstringSearchForward,
+	InsertComment,
+	InsertCompletions,
+	InsertLastArgument,
+	KillLine,
+	KillRegion,
+	KillWholeLine,
+	KillWord,
+	MagicSpace,
+	MenuComplete,
+	MenuCompleteBackward,
+	NextHistory,
+	NextScreenLine,
+	NonIncrementalForwardSearchHistory,
+	NonIncrementalForwardSearchHistoryAgain,
+	NonIncrementalReverseSearchHistory,
+	NonIncrementalReverseSearchHistoryAgain,
+	OldMenuComplete,
+	OperateAndGetNext,
+	OverwriteMode,
+	PossibleCommandCompletions,
+	PossibleCompletions,
+	PossibleFilenameCompletions,
+	PossibleHostnameCompletions,
+	PossibleUsernameCompletions,
+	PossibleVariableCompletions,
+	PreviousHistory,
+	PreviousScreenLine,
+	PrintLastKbdMacro,
+	QuotedInsert,
+	ReReadInitFile,
+	RedrawCurrentLine,
+	ReverseSearchHistory,
+	RevertLine,
+	SelfInsert,
+	SetMark,
+	ShellBackwardKillWord,
+	ShellBackwardWord,
+	ShellExpandLine,
+	ShellForwardWord,
+	ShellKillWord,
+	ShellTransposeWords,
+	SkipCsiSequence,
+	StartKbdMacro,
+	TabInsert,
+	TildeExpand,
+	TransposeChars,
+	TransposeWords,
+	TtyStatus,
+	Undo,
+	UniversalArgument,
+	UnixFilenameRubout,
+	UnixLineDiscard,
+	UnixWordRubout,
+	UpcaseWord,
+	ViAppendEol,
+	ViAppendMode,
+	ViArgDigit,
+	ViBWord,
+	ViBackToIndent,
+	ViBackwardBigword,
+	ViBackwardWord,
+	ViBword,
+	ViChangeCase,
+	ViChangeChar,
+	ViChangeTo,
+	ViCharSearch,
+	ViColumn,
+	ViComplete,
+	ViDelete,
+	ViDeleteTo,
+	ViEWord,
+	ViEditingMode,
+	ViEndBigword,
+	ViEndWord,
+	ViEofMaybe,
+	ViEword,
+	ViFWord,
+	ViFetchHistory,
+	ViFirstPrint,
+	ViForwardBigword,
+	ViForwardWord,
+	ViFword,
+	ViGotoMark,
+	ViInsertBeg,
+	ViInsertionMode,
+	ViMatch,
+	ViMovementMode,
+	ViNextWord,
+	ViOverstrike,
+	ViOverstrikeDelete,
+	ViPrevWord,
+	ViPut,
+	ViRedo,
+	ViReplace,
+	ViRubout,
+	ViSearch,
+	ViSearchAgain,
+	ViSetMark,
+	ViSubst,
+	ViTildeExpand,
+	ViUnixWordRubout,
+	ViYankArg,
+	ViYankPop,
+	ViYankTo,
+	Yank,
+	YankLastArg,
+	YankNthArg,
+	YankPop,
 }
 
 /// Represents a sequence of keys.
 #[derive(Debug, Eq, Hash, PartialEq)]
 pub struct KeySequence {
-    /// The strokes in the sequence.
-    pub strokes: Vec<KeyStroke>,
+	/// The strokes in the sequence.
+	pub strokes: Vec<KeyStroke>,
 }
 
 impl Display for KeySequence {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        for stroke in &self.strokes {
-            stroke.fmt(f)?;
-        }
-        Ok(())
-    }
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		for stroke in &self.strokes {
+			stroke.fmt(f)?;
+		}
+		Ok(())
+	}
 }
 
 impl From<KeyStroke> for KeySequence {
-    /// Creates a new key sequence with a single stroke.
-    fn from(value: KeyStroke) -> Self {
-        Self {
-            strokes: vec![value],
-        }
-    }
+	/// Creates a new key sequence with a single stroke.
+	fn from(value: KeyStroke) -> Self {
+		Self { strokes: vec![value] }
+	}
 }
 
 #[derive(Debug, Eq, Hash, PartialEq)]
 /// Represents a single key press.
 pub struct KeyStroke {
-    /// Alt key was pressed.
-    pub alt: bool,
-    /// Control key was pressed.
-    pub control: bool,
-    /// Shift key was pressed.
-    pub shift: bool,
-    /// Primary key pressed.
-    pub key: Key,
+	/// Alt key was pressed.
+	pub alt: bool,
+	/// Control key was pressed.
+	pub control: bool,
+	/// Shift key was pressed.
+	pub shift: bool,
+	/// Primary key pressed.
+	pub key: Key,
 }
 
 impl Display for KeyStroke {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        if self.alt {
-            write!(f, "\\e")?;
-        }
-        if self.control {
-            write!(f, "\\C-")?;
-        }
-        if self.shift {
-            // TODO: Figure out what to do here or if the key encodes the shift in it.
-        }
-        self.key.fmt(f)
-    }
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		if self.alt {
+			write!(f, "\\e")?;
+		}
+		if self.control {
+			write!(f, "\\C-")?;
+		}
+		if self.shift {
+			// TODO: Figure out what to do here or if the key encodes the shift in it.
+		}
+		self.key.fmt(f)
+	}
 }
 
 impl From<Key> for KeyStroke {
-    /// Creates a new key stroke with a single key.
-    fn from(value: Key) -> Self {
-        Self {
-            alt: false,
-            control: false,
-            shift: false,
-            key: value,
-        }
-    }
+	/// Creates a new key stroke with a single key.
+	fn from(value: Key) -> Self {
+		Self { alt: false, control: false, shift: false, key: value }
+	}
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 /// Represents a single key.
 pub enum Key {
-    /// A simple character key.
-    Character(char),
-    /// Backspace key.
-    Backspace,
-    /// Enter key.
-    Enter,
-    /// Left arrow key.
-    Left,
-    /// Right arrow key.
-    Right,
-    /// Up arrow key.
-    Up,
-    /// Down arrow key.
-    Down,
-    /// Home key.
-    Home,
-    /// End key.
-    End,
-    /// Page up key.
-    PageUp,
-    /// Page down key.
-    PageDown,
-    /// Tab key.
-    Tab,
-    /// Shift + Tab key.
-    BackTab,
-    /// Delete key.
-    Delete,
-    /// Insert key.
-    Insert,
-    /// F key.
-    F(u8),
-    /// Escape key.
-    Escape,
+	/// A simple character key.
+	Character(char),
+	/// Backspace key.
+	Backspace,
+	/// Enter key.
+	Enter,
+	/// Left arrow key.
+	Left,
+	/// Right arrow key.
+	Right,
+	/// Up arrow key.
+	Up,
+	/// Down arrow key.
+	Down,
+	/// Home key.
+	Home,
+	/// End key.
+	End,
+	/// Page up key.
+	PageUp,
+	/// Page down key.
+	PageDown,
+	/// Tab key.
+	Tab,
+	/// Shift + Tab key.
+	BackTab,
+	/// Delete key.
+	Delete,
+	/// Insert key.
+	Insert,
+	/// F key.
+	F(u8),
+	/// Escape key.
+	Escape,
 }
 
 impl Display for Key {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Character(c @ ('\\' | '\"' | '\'')) => write!(f, "\\{c}")?,
-            Self::Character(c) => write!(f, "{c}")?,
-            Self::Backspace => write!(f, "Backspace")?,
-            Self::Enter => write!(f, "Enter")?,
-            Self::Left => write!(f, "Left")?,
-            Self::Right => write!(f, "Right")?,
-            Self::Up => write!(f, "Up")?,
-            Self::Down => write!(f, "Down")?,
-            Self::Home => write!(f, "Home")?,
-            Self::End => write!(f, "End")?,
-            Self::PageUp => write!(f, "PageUp")?,
-            Self::PageDown => write!(f, "PageDown")?,
-            Self::Tab => write!(f, "Tab")?,
-            Self::BackTab => write!(f, "BackTab")?,
-            Self::Delete => write!(f, "Delete")?,
-            Self::Insert => write!(f, "Insert")?,
-            Self::F(n) => write!(f, "F{n}")?,
-            Self::Escape => write!(f, "Esc")?,
-        }
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::Character(c @ ('\\' | '\"' | '\'')) => write!(f, "\\{c}")?,
+			Self::Character(c) => write!(f, "{c}")?,
+			Self::Backspace => write!(f, "Backspace")?,
+			Self::Enter => write!(f, "Enter")?,
+			Self::Left => write!(f, "Left")?,
+			Self::Right => write!(f, "Right")?,
+			Self::Up => write!(f, "Up")?,
+			Self::Down => write!(f, "Down")?,
+			Self::Home => write!(f, "Home")?,
+			Self::End => write!(f, "End")?,
+			Self::PageUp => write!(f, "PageUp")?,
+			Self::PageDown => write!(f, "PageDown")?,
+			Self::Tab => write!(f, "Tab")?,
+			Self::BackTab => write!(f, "BackTab")?,
+			Self::Delete => write!(f, "Delete")?,
+			Self::Insert => write!(f, "Insert")?,
+			Self::F(n) => write!(f, "F{n}")?,
+			Self::Escape => write!(f, "Esc")?,
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 }
 
 /// Encapsulates the shell's interaction with key bindings for input.
 pub trait KeyBindings: Send {
-    /// Retrieves current bindings.
-    fn get_current(&self) -> HashMap<KeySequence, KeyAction>;
-    /// Updates a binding.
-    fn bind(&mut self, seq: KeySequence, action: KeyAction) -> Result<(), std::io::Error>;
+	/// Retrieves current bindings.
+	fn get_current(&self) -> HashMap<KeySequence, KeyAction>;
+	/// Updates a binding.
+	fn bind(&mut self, seq: KeySequence, action: KeyAction) -> Result<(), std::io::Error>;
 }

--- a/crates/brush-core-vendored/src/interp.rs
+++ b/crates/brush-core-vendored/src/interp.rs
@@ -56,8 +56,8 @@ struct PipelineExecutionContext<'a> {
 	shell: &'a mut Shell,
 
 	current_pipeline_index: usize,
-	pipeline_len:           usize,
-	output_pipes:           &'a mut Vec<std::io::PipeReader>,
+	pipeline_len: usize,
+	output_pipes: &'a mut Vec<std::io::PipeReader>,
 
 	process_group_id: Option<i32>,
 }
@@ -66,11 +66,11 @@ struct PipelineExecutionContext<'a> {
 #[derive(Clone, Default)]
 pub struct ExecutionParameters {
 	/// The open files tracked by the current context.
-	open_files:               openfiles::OpenFiles,
+	open_files: openfiles::OpenFiles,
 	/// Policy for how to manage spawned external processes.
 	pub process_group_policy: ProcessGroupPolicy,
 	/// Optional cancellation token shared with callers.
-	cancel_token:             Option<CancellationToken>,
+	cancel_token: Option<CancellationToken>,
 }
 
 impl ExecutionParameters {
@@ -337,7 +337,11 @@ async fn should_try_spawn_pipeline_as_job(
 	if shell.aliases.contains_key(command_name) {
 		return Ok(false);
 	}
-	if shell.builtins().get(command_name.as_str()).is_some_and(|registration| !registration.disabled) {
+	if shell
+		.builtins()
+		.get(command_name.as_str())
+		.is_some_and(|registration| !registration.disabled)
+	{
 		return Ok(false);
 	}
 	if shell.funcs().get(command_name.as_str()).is_some() {
@@ -346,7 +350,6 @@ async fn should_try_spawn_pipeline_as_job(
 
 	Ok(true)
 }
-
 
 async fn try_spawn_pipeline_as_job(
 	pipeline: &ast::Pipeline,

--- a/crates/brush-core-vendored/src/jobs.rs
+++ b/crates/brush-core-vendored/src/jobs.rs
@@ -18,433 +18,437 @@ pub(crate) type JobResult = (Job, Result<ExecutionResult, error::Error>);
 /// Manages the jobs that are currently managed by the shell.
 #[derive(Default)]
 pub struct JobManager {
-    /// The jobs that are currently managed by the shell.
-    pub jobs: Vec<Job>,
+	/// The jobs that are currently managed by the shell.
+	pub jobs: Vec<Job>,
 }
 
 /// Represents a task that is part of a job.
 pub enum JobTask {
-    /// An external process.
-    External(processes::ChildProcess),
-    /// An internal asynchronous task.
-    Internal(JobJoinHandle),
+	/// An external process.
+	External(processes::ChildProcess),
+	/// An internal asynchronous task.
+	Internal(JobJoinHandle),
 }
 
 /// Represents the result of waiting on a job task.
 pub enum JobTaskWaitResult {
-    /// The task has completed.
-    Completed(ExecutionResult),
-    /// The task was stopped.
-    Stopped,
+	/// The task has completed.
+	Completed(ExecutionResult),
+	/// The task was stopped.
+	Stopped,
 }
 
 impl JobTask {
-    /// Waits for the task to complete. Returns the result of the wait.
-    pub async fn wait(&mut self) -> Result<JobTaskWaitResult, error::Error> {
-        match self {
-            Self::External(process) => {
-                // Background jobs don't receive cancellation tokens
-                let wait_result = process.wait(None).await?;
-                match wait_result {
-                    processes::ProcessWaitResult::Completed(output) => {
-                        Ok(JobTaskWaitResult::Completed(output.into()))
-                    }
-                    processes::ProcessWaitResult::Stopped => Ok(JobTaskWaitResult::Stopped),
-                    processes::ProcessWaitResult::Cancelled => {
-                        // Should never happen since we pass None, but handle gracefully
-                        Ok(JobTaskWaitResult::Completed(ExecutionResult::new(130)))
-                    }
-                }
-            }
-            Self::Internal(handle) => Ok(JobTaskWaitResult::Completed(handle.await??)),
-        }
-    }
+	/// Waits for the task to complete. Returns the result of the wait.
+	pub async fn wait(&mut self) -> Result<JobTaskWaitResult, error::Error> {
+		match self {
+			Self::External(process) => {
+				// Background jobs don't receive cancellation tokens
+				let wait_result = process.wait(None).await?;
+				match wait_result {
+					processes::ProcessWaitResult::Completed(output) => {
+						Ok(JobTaskWaitResult::Completed(output.into()))
+					},
+					processes::ProcessWaitResult::Stopped => Ok(JobTaskWaitResult::Stopped),
+					processes::ProcessWaitResult::Cancelled => {
+						// Should never happen since we pass None, but handle gracefully
+						Ok(JobTaskWaitResult::Completed(ExecutionResult::new(130)))
+					},
+				}
+			},
+			Self::Internal(handle) => Ok(JobTaskWaitResult::Completed(handle.await??)),
+		}
+	}
 
-    #[allow(clippy::unwrap_in_result)]
-    fn poll(&mut self) -> Option<Result<ExecutionResult, error::Error>> {
-        match self {
-            Self::External(process) => {
-                let check_result = process.poll();
-                check_result.map(|polled_result| polled_result.map(|output| output.into()))
-            }
-            Self::Internal(handle) => {
-                let checkable_handle = handle;
-                checkable_handle.now_or_never().map(|r| r.unwrap())
-            }
-        }
-    }
+	#[allow(clippy::unwrap_in_result)]
+	fn poll(&mut self) -> Option<Result<ExecutionResult, error::Error>> {
+		match self {
+			Self::External(process) => {
+				let check_result = process.poll();
+				check_result.map(|polled_result| polled_result.map(|output| output.into()))
+			},
+			Self::Internal(handle) => {
+				let checkable_handle = handle;
+				checkable_handle.now_or_never().map(|r| r.unwrap())
+			},
+		}
+	}
 }
 
 impl JobManager {
-    /// Returns a new job manager.
-    pub fn new() -> Self {
-        Self::default()
-    }
+	/// Returns a new job manager.
+	pub fn new() -> Self {
+		Self::default()
+	}
 
-    /// Adds a job to the job manager and marks it as the current job;
-    /// returns an immutable reference to the job.
-    ///
-    /// # Arguments
-    ///
-    /// * `job` - The job to add.
-    pub fn add_as_current(&mut self, mut job: Job) -> &Job {
-        for j in &mut self.jobs {
-            if matches!(j.annotation, JobAnnotation::Current) {
-                j.annotation = JobAnnotation::Previous;
-                break;
-            }
-        }
+	/// Adds a job to the job manager and marks it as the current job;
+	/// returns an immutable reference to the job.
+	///
+	/// # Arguments
+	///
+	/// * `job` - The job to add.
+	pub fn add_as_current(&mut self, mut job: Job) -> &Job {
+		for j in &mut self.jobs {
+			if matches!(j.annotation, JobAnnotation::Current) {
+				j.annotation = JobAnnotation::Previous;
+				break;
+			}
+		}
 
-        let id = self.jobs.len() + 1;
-        job.id = id;
-        job.annotation = JobAnnotation::Current;
-        self.jobs.push(job);
-        self.jobs.last().unwrap()
-    }
+		let id = self.jobs.len() + 1;
+		job.id = id;
+		job.annotation = JobAnnotation::Current;
+		self.jobs.push(job);
+		self.jobs.last().unwrap()
+	}
 
-    /// Returns the current job, if there is one.
-    pub fn current_job(&self) -> Option<&Job> {
-        self.jobs
-            .iter()
-            .find(|j| matches!(j.annotation, JobAnnotation::Current))
-    }
+	/// Returns the current job, if there is one.
+	pub fn current_job(&self) -> Option<&Job> {
+		self
+			.jobs
+			.iter()
+			.find(|j| matches!(j.annotation, JobAnnotation::Current))
+	}
 
-    /// Returns a mutable reference to the current job, if there is one.
-    pub fn current_job_mut(&mut self) -> Option<&mut Job> {
-        self.jobs
-            .iter_mut()
-            .find(|j| matches!(j.annotation, JobAnnotation::Current))
-    }
+	/// Returns a mutable reference to the current job, if there is one.
+	pub fn current_job_mut(&mut self) -> Option<&mut Job> {
+		self
+			.jobs
+			.iter_mut()
+			.find(|j| matches!(j.annotation, JobAnnotation::Current))
+	}
 
-    /// Returns the previous job, if there is one.
-    pub fn prev_job(&self) -> Option<&Job> {
-        self.jobs
-            .iter()
-            .find(|j| matches!(j.annotation, JobAnnotation::Previous))
-    }
+	/// Returns the previous job, if there is one.
+	pub fn prev_job(&self) -> Option<&Job> {
+		self
+			.jobs
+			.iter()
+			.find(|j| matches!(j.annotation, JobAnnotation::Previous))
+	}
 
-    /// Returns a mutable reference to the previous job, if there is one.
-    pub fn prev_job_mut(&mut self) -> Option<&mut Job> {
-        self.jobs
-            .iter_mut()
-            .find(|j| matches!(j.annotation, JobAnnotation::Previous))
-    }
+	/// Returns a mutable reference to the previous job, if there is one.
+	pub fn prev_job_mut(&mut self) -> Option<&mut Job> {
+		self
+			.jobs
+			.iter_mut()
+			.find(|j| matches!(j.annotation, JobAnnotation::Previous))
+	}
 
-    /// Tries to resolve the given job specification to a job.
-    ///
-    /// # Arguments
-    ///
-    /// * `job_spec` - The job specification to resolve.
-    pub fn resolve_job_spec(&mut self, job_spec: &str) -> Option<&mut Job> {
-        let remainder = job_spec.strip_prefix('%')?;
+	/// Tries to resolve the given job specification to a job.
+	///
+	/// # Arguments
+	///
+	/// * `job_spec` - The job specification to resolve.
+	pub fn resolve_job_spec(&mut self, job_spec: &str) -> Option<&mut Job> {
+		let remainder = job_spec.strip_prefix('%')?;
 
-        match remainder {
-            "%" | "+" => self.current_job_mut(),
-            "-" => self.prev_job_mut(),
-            s if s.chars().all(char::is_numeric) => {
-                let id = s.parse::<usize>().ok()?;
-                self.jobs.iter_mut().find(|j| j.id == id)
-            }
-            _ => {
-                tracing::warn!(target: trace_categories::UNIMPLEMENTED, "unimplemented: job spec naming command: '{job_spec}'");
-                None
-            }
-        }
-    }
+		match remainder {
+			"%" | "+" => self.current_job_mut(),
+			"-" => self.prev_job_mut(),
+			s if s.chars().all(char::is_numeric) => {
+				let id = s.parse::<usize>().ok()?;
+				self.jobs.iter_mut().find(|j| j.id == id)
+			},
+			_ => {
+				tracing::warn!(target: trace_categories::UNIMPLEMENTED, "unimplemented: job spec naming command: '{job_spec}'");
+				None
+			},
+		}
+	}
 
-    /// Waits for all managed jobs to complete.
-    pub async fn wait_all(&mut self) -> Result<Vec<Job>, error::Error> {
-        for job in &mut self.jobs {
-            job.wait().await?;
-        }
+	/// Waits for all managed jobs to complete.
+	pub async fn wait_all(&mut self) -> Result<Vec<Job>, error::Error> {
+		for job in &mut self.jobs {
+			job.wait().await?;
+		}
 
-        Ok(self.sweep_completed_jobs())
-    }
+		Ok(self.sweep_completed_jobs())
+	}
 
-    /// Polls all managed jobs for completion.
-    pub fn poll(&mut self) -> Result<Vec<JobResult>, error::Error> {
-        let mut results = vec![];
+	/// Polls all managed jobs for completion.
+	pub fn poll(&mut self) -> Result<Vec<JobResult>, error::Error> {
+		let mut results = vec![];
 
-        let mut i = 0;
-        while i != self.jobs.len() {
-            if let Some(result) = self.jobs[i].poll_done()? {
-                let job = self.jobs.remove(i);
-                results.push((job, result));
-            } else if matches!(self.jobs[i].state, JobState::Done) {
-                // TODO: This is a workaround to remove jobs that are done but for which we don't
-                // know what happened.
-                results.push((self.jobs.remove(i), Ok(ExecutionResult::success())));
-            } else {
-                i += 1;
-            }
-        }
+		let mut i = 0;
+		while i != self.jobs.len() {
+			if let Some(result) = self.jobs[i].poll_done()? {
+				let job = self.jobs.remove(i);
+				results.push((job, result));
+			} else if matches!(self.jobs[i].state, JobState::Done) {
+				// TODO: This is a workaround to remove jobs that are done but for which we don't
+				// know what happened.
+				results.push((self.jobs.remove(i), Ok(ExecutionResult::success())));
+			} else {
+				i += 1;
+			}
+		}
 
-        Ok(results)
-    }
+		Ok(results)
+	}
 
-    fn sweep_completed_jobs(&mut self) -> Vec<Job> {
-        let mut completed_jobs = vec![];
+	fn sweep_completed_jobs(&mut self) -> Vec<Job> {
+		let mut completed_jobs = vec![];
 
-        let mut i = 0;
-        while i != self.jobs.len() {
-            if self.jobs[i].tasks.is_empty() {
-                completed_jobs.push(self.jobs.remove(i));
-            } else {
-                i += 1;
-            }
-        }
+		let mut i = 0;
+		while i != self.jobs.len() {
+			if self.jobs[i].tasks.is_empty() {
+				completed_jobs.push(self.jobs.remove(i));
+			} else {
+				i += 1;
+			}
+		}
 
-        completed_jobs
-    }
+		completed_jobs
+	}
 }
 
 /// Represents the current execution state of a job.
 #[derive(Clone)]
 pub enum JobState {
-    /// Unknown state.
-    Unknown,
-    /// The job is running.
-    Running,
-    /// The job is stopped.
-    Stopped,
-    /// The job has completed.
-    Done,
+	/// Unknown state.
+	Unknown,
+	/// The job is running.
+	Running,
+	/// The job is stopped.
+	Stopped,
+	/// The job has completed.
+	Done,
 }
 
 impl Display for JobState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Unknown => write!(f, "Unknown"),
-            Self::Running => write!(f, "Running"),
-            Self::Stopped => write!(f, "Stopped"),
-            Self::Done => write!(f, "Done"),
-        }
-    }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::Unknown => write!(f, "Unknown"),
+			Self::Running => write!(f, "Running"),
+			Self::Stopped => write!(f, "Stopped"),
+			Self::Done => write!(f, "Done"),
+		}
+	}
 }
 
 /// Represents an annotation for a job.
 #[derive(Clone)]
 pub enum JobAnnotation {
-    /// No annotation.
-    None,
-    /// The job is the current job.
-    Current,
-    /// The job is the previous job.
-    Previous,
+	/// No annotation.
+	None,
+	/// The job is the current job.
+	Current,
+	/// The job is the previous job.
+	Previous,
 }
 
 impl Display for JobAnnotation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::None => write!(f, ""),
-            Self::Current => write!(f, "+"),
-            Self::Previous => write!(f, "-"),
-        }
-    }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::None => write!(f, ""),
+			Self::Current => write!(f, "+"),
+			Self::Previous => write!(f, "-"),
+		}
+	}
 }
 
 /// Encapsulates a set of processes managed by the shell as a single unit.
 pub struct Job {
-    /// The tasks that make up the job.
-    tasks: VecDeque<JobTask>,
+	/// The tasks that make up the job.
+	tasks: VecDeque<JobTask>,
 
-    /// If available, the process group ID of the job's processes.
-    pgid: Option<sys::process::ProcessId>,
+	/// If available, the process group ID of the job's processes.
+	pgid: Option<sys::process::ProcessId>,
 
-    /// The annotation of the job (e.g., current, previous).
-    annotation: JobAnnotation,
+	/// The annotation of the job (e.g., current, previous).
+	annotation: JobAnnotation,
 
-    /// The shell-internal ID of the job.
-    pub id: usize,
+	/// The shell-internal ID of the job.
+	pub id: usize,
 
-    /// The command line of the job.
-    pub command_line: String,
+	/// The command line of the job.
+	pub command_line: String,
 
-    /// The current operational state of the job.
-    pub state: JobState,
+	/// The current operational state of the job.
+	pub state: JobState,
 }
 
 impl Display for Job {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "[{}]{:3}{}\t{}",
-            self.id,
-            self.annotation.to_string(),
-            self.state,
-            self.command_line
-        )
-    }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(
+			f,
+			"[{}]{:3}{}\t{}",
+			self.id,
+			self.annotation.to_string(),
+			self.state,
+			self.command_line
+		)
+	}
 }
 
 impl Job {
-    /// Returns a new job object.
-    ///
-    /// # Arguments
-    ///
-    /// * `children` - The job's known child processes.
-    /// * `command_line` - The command line of the job.
-    /// * `state` - The current operational state of the job.
-    pub(crate) fn new<I>(tasks: I, command_line: String, state: JobState) -> Self
-    where
-        I: IntoIterator<Item = JobTask>,
-    {
-        Self {
-            id: 0,
-            tasks: tasks.into_iter().collect(),
-            pgid: None,
-            annotation: JobAnnotation::None,
-            command_line,
-            state,
-        }
-    }
+	/// Returns a new job object.
+	///
+	/// # Arguments
+	///
+	/// * `children` - The job's known child processes.
+	/// * `command_line` - The command line of the job.
+	/// * `state` - The current operational state of the job.
+	pub(crate) fn new<I>(tasks: I, command_line: String, state: JobState) -> Self
+	where
+		I: IntoIterator<Item = JobTask>,
+	{
+		Self {
+			id: 0,
+			tasks: tasks.into_iter().collect(),
+			pgid: None,
+			annotation: JobAnnotation::None,
+			command_line,
+			state,
+		}
+	}
 
-    /// Returns a pid-style string for the job.
-    pub fn to_pid_style_string(&self) -> String {
-        let display_pid = self
-            .representative_pid()
-            .map_or_else(|| String::from("<pid unknown>"), |pid| pid.to_string());
-        std::format!("[{}]{}\t{}", self.id, self.annotation, display_pid)
-    }
+	/// Returns a pid-style string for the job.
+	pub fn to_pid_style_string(&self) -> String {
+		let display_pid = self
+			.representative_pid()
+			.map_or_else(|| String::from("<pid unknown>"), |pid| pid.to_string());
+		std::format!("[{}]{}\t{}", self.id, self.annotation, display_pid)
+	}
 
-    /// Returns the annotation of the job.
-    pub fn annotation(&self) -> JobAnnotation {
-        self.annotation.clone()
-    }
+	/// Returns the annotation of the job.
+	pub fn annotation(&self) -> JobAnnotation {
+		self.annotation.clone()
+	}
 
-    /// Returns the command name of the job.
-    pub fn command_name(&self) -> &str {
-        self.command_line
-            .split_ascii_whitespace()
-            .next()
-            .unwrap_or_default()
-    }
+	/// Returns the command name of the job.
+	pub fn command_name(&self) -> &str {
+		self
+			.command_line
+			.split_ascii_whitespace()
+			.next()
+			.unwrap_or_default()
+	}
 
-    /// Returns whether the job is the current job.
-    pub const fn is_current(&self) -> bool {
-        matches!(self.annotation, JobAnnotation::Current)
-    }
+	/// Returns whether the job is the current job.
+	pub const fn is_current(&self) -> bool {
+		matches!(self.annotation, JobAnnotation::Current)
+	}
 
-    /// Returns whether the job is the previous job.
-    pub const fn is_prev(&self) -> bool {
-        matches!(self.annotation, JobAnnotation::Previous)
-    }
+	/// Returns whether the job is the previous job.
+	pub const fn is_prev(&self) -> bool {
+		matches!(self.annotation, JobAnnotation::Previous)
+	}
 
-    /// Polls whether the job has completed.
-    pub fn poll_done(
-        &mut self,
-    ) -> Result<Option<Result<ExecutionResult, error::Error>>, error::Error> {
-        let mut result: Option<Result<ExecutionResult, error::Error>> = None;
+	/// Polls whether the job has completed.
+	pub fn poll_done(
+		&mut self,
+	) -> Result<Option<Result<ExecutionResult, error::Error>>, error::Error> {
+		let mut result: Option<Result<ExecutionResult, error::Error>> = None;
 
-        tracing::debug!(target: trace_categories::JOBS, "Polling job {} for completion...", self.id);
+		tracing::debug!(target: trace_categories::JOBS, "Polling job {} for completion...", self.id);
 
-        while !self.tasks.is_empty() {
-            let task = &mut self.tasks[0];
-            match task.poll() {
-                Some(r) => {
-                    self.tasks.remove(0);
-                    result = Some(r);
-                }
-                None => {
-                    return Ok(None);
-                }
-            }
-        }
+		while !self.tasks.is_empty() {
+			let task = &mut self.tasks[0];
+			match task.poll() {
+				Some(r) => {
+					self.tasks.remove(0);
+					result = Some(r);
+				},
+				None => {
+					return Ok(None);
+				},
+			}
+		}
 
-        tracing::debug!(target: trace_categories::JOBS, "Job {} has completed.", self.id);
+		tracing::debug!(target: trace_categories::JOBS, "Job {} has completed.", self.id);
 
-        self.state = JobState::Done;
+		self.state = JobState::Done;
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 
-    /// Waits for the job to complete.
-    pub async fn wait(&mut self) -> Result<ExecutionResult, error::Error> {
-        let mut result = ExecutionResult::success();
+	/// Waits for the job to complete.
+	pub async fn wait(&mut self) -> Result<ExecutionResult, error::Error> {
+		let mut result = ExecutionResult::success();
 
-        while let Some(task) = self.tasks.back_mut() {
-            match task.wait().await? {
-                JobTaskWaitResult::Completed(execution_result) => {
-                    result = execution_result;
-                    self.tasks.pop_back();
-                }
-                JobTaskWaitResult::Stopped => {
-                    self.state = JobState::Stopped;
-                    return Ok(ExecutionResult::stopped());
-                }
-            }
-        }
+		while let Some(task) = self.tasks.back_mut() {
+			match task.wait().await? {
+				JobTaskWaitResult::Completed(execution_result) => {
+					result = execution_result;
+					self.tasks.pop_back();
+				},
+				JobTaskWaitResult::Stopped => {
+					self.state = JobState::Stopped;
+					return Ok(ExecutionResult::stopped());
+				},
+			}
+		}
 
-        self.state = JobState::Done;
+		self.state = JobState::Done;
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 
-    /// Moves the job to execute in the background.
-    pub fn move_to_background(&mut self) -> Result<(), error::Error> {
-        if matches!(self.state, JobState::Stopped) {
-            if let Some(pgid) = self.process_group_id() {
-                sys::signal::continue_process(pgid)?;
-                self.state = JobState::Running;
-                Ok(())
-            } else {
-                Err(error::ErrorKind::FailedToSendSignal.into())
-            }
-        } else {
-            error::unimp("move job to background")
-        }
-    }
+	/// Moves the job to execute in the background.
+	pub fn move_to_background(&mut self) -> Result<(), error::Error> {
+		if matches!(self.state, JobState::Stopped) {
+			if let Some(pgid) = self.process_group_id() {
+				sys::signal::continue_process(pgid)?;
+				self.state = JobState::Running;
+				Ok(())
+			} else {
+				Err(error::ErrorKind::FailedToSendSignal.into())
+			}
+		} else {
+			error::unimp("move job to background")
+		}
+	}
 
-    /// Moves the job to execute in the foreground.
-    pub fn move_to_foreground(&mut self) -> Result<(), error::Error> {
-        if matches!(self.state, JobState::Stopped) {
-            if let Some(pgid) = self.process_group_id() {
-                sys::signal::continue_process(pgid)?;
-                self.state = JobState::Running;
-            } else {
-                return Err(error::ErrorKind::FailedToSendSignal.into());
-            }
-        }
+	/// Moves the job to execute in the foreground.
+	pub fn move_to_foreground(&mut self) -> Result<(), error::Error> {
+		if matches!(self.state, JobState::Stopped) {
+			if let Some(pgid) = self.process_group_id() {
+				sys::signal::continue_process(pgid)?;
+				self.state = JobState::Running;
+			} else {
+				return Err(error::ErrorKind::FailedToSendSignal.into());
+			}
+		}
 
-        if let Some(pgid) = self.process_group_id() {
-            sys::terminal::move_to_foreground(pgid)?;
-        }
+		if let Some(pgid) = self.process_group_id() {
+			sys::terminal::move_to_foreground(pgid)?;
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    /// Kills the job.
-    ///
-    /// # Arguments
-    ///
-    /// * `signal` - The signal to send to the job.
-    pub fn kill(&self, signal: traps::TrapSignal) -> Result<(), error::Error> {
-        if let Some(pid) = self.process_group_id() {
-            sys::signal::kill_process(pid, signal)
-        } else {
-            Err(error::ErrorKind::FailedToSendSignal.into())
-        }
-    }
+	/// Kills the job.
+	///
+	/// # Arguments
+	///
+	/// * `signal` - The signal to send to the job.
+	pub fn kill(&self, signal: traps::TrapSignal) -> Result<(), error::Error> {
+		if let Some(pid) = self.process_group_id() {
+			sys::signal::kill_process(pid, signal)
+		} else {
+			Err(error::ErrorKind::FailedToSendSignal.into())
+		}
+	}
 
-    /// Tries to retrieve a "representative" pid for the job.
-    pub fn representative_pid(&self) -> Option<sys::process::ProcessId> {
-        for task in &self.tasks {
-            match task {
-                JobTask::External(p) => {
-                    if let Some(pid) = p.pid() {
-                        return Some(pid);
-                    }
-                }
-                JobTask::Internal(_) => (),
-            }
-        }
-        None
-    }
+	/// Tries to retrieve a "representative" pid for the job.
+	pub fn representative_pid(&self) -> Option<sys::process::ProcessId> {
+		for task in &self.tasks {
+			match task {
+				JobTask::External(p) => {
+					if let Some(pid) = p.pid() {
+						return Some(pid);
+					}
+				},
+				JobTask::Internal(_) => (),
+			}
+		}
+		None
+	}
 
-    /// Tries to retrieve the process group ID (PGID) of the job.
-    pub fn process_group_id(&self) -> Option<sys::process::ProcessId> {
-        // TODO: Don't assume that the first PID is the PGID.
-        self.pgid.or_else(|| self.representative_pid())
-    }
-
+	/// Tries to retrieve the process group ID (PGID) of the job.
+	pub fn process_group_id(&self) -> Option<sys::process::ProcessId> {
+		// TODO: Don't assume that the first PID is the PGID.
+		self.pgid.or_else(|| self.representative_pid())
+	}
 }

--- a/crates/brush-core-vendored/src/keywords.rs
+++ b/crates/brush-core-vendored/src/keywords.rs
@@ -2,36 +2,36 @@ use std::collections::HashSet;
 use std::sync::LazyLock;
 
 fn get_keywords(sh_mode_only: bool) -> HashSet<String> {
-    let mut keywords = HashSet::new();
-    keywords.insert(String::from("!"));
-    keywords.insert(String::from("{"));
-    keywords.insert(String::from("}"));
-    keywords.insert(String::from("case"));
-    keywords.insert(String::from("do"));
-    keywords.insert(String::from("done"));
-    keywords.insert(String::from("elif"));
-    keywords.insert(String::from("else"));
-    keywords.insert(String::from("esac"));
-    keywords.insert(String::from("fi"));
-    keywords.insert(String::from("for"));
-    keywords.insert(String::from("if"));
-    keywords.insert(String::from("in"));
-    keywords.insert(String::from("then"));
-    keywords.insert(String::from("until"));
-    keywords.insert(String::from("while"));
+	let mut keywords = HashSet::new();
+	keywords.insert(String::from("!"));
+	keywords.insert(String::from("{"));
+	keywords.insert(String::from("}"));
+	keywords.insert(String::from("case"));
+	keywords.insert(String::from("do"));
+	keywords.insert(String::from("done"));
+	keywords.insert(String::from("elif"));
+	keywords.insert(String::from("else"));
+	keywords.insert(String::from("esac"));
+	keywords.insert(String::from("fi"));
+	keywords.insert(String::from("for"));
+	keywords.insert(String::from("if"));
+	keywords.insert(String::from("in"));
+	keywords.insert(String::from("then"));
+	keywords.insert(String::from("until"));
+	keywords.insert(String::from("while"));
 
-    if !sh_mode_only {
-        keywords.insert(String::from("[["));
-        keywords.insert(String::from("]]"));
-        keywords.insert(String::from("coproc"));
-        keywords.insert(String::from("function"));
-        keywords.insert(String::from("select"));
-        keywords.insert(String::from("time"));
-    }
+	if !sh_mode_only {
+		keywords.insert(String::from("[["));
+		keywords.insert(String::from("]]"));
+		keywords.insert(String::from("coproc"));
+		keywords.insert(String::from("function"));
+		keywords.insert(String::from("select"));
+		keywords.insert(String::from("time"));
+	}
 
-    keywords
+	keywords
 }
 
 pub(crate) static SH_MODE_KEYWORDS: LazyLock<HashSet<String>> =
-    LazyLock::new(|| get_keywords(true));
+	LazyLock::new(|| get_keywords(true));
 pub(crate) static KEYWORDS: LazyLock<HashSet<String>> = LazyLock::new(|| get_keywords(false));

--- a/crates/brush-core-vendored/src/namedoptions.rs
+++ b/crates/brush-core-vendored/src/namedoptions.rs
@@ -10,65 +10,65 @@ type OptionSetter = fn(shell: &mut RuntimeOptions, value: bool) -> ();
 
 /// Defines an option.
 pub struct ShellOptionDef {
-    /// Getter function that retrieves the current value of the option.
-    getter: OptionGetter,
-    /// Setter function that may be used to set the current value of the option.
-    setter: OptionSetter,
+	/// Getter function that retrieves the current value of the option.
+	getter: OptionGetter,
+	/// Setter function that may be used to set the current value of the option.
+	setter: OptionSetter,
 }
 
 impl ShellOptionDef {
-    /// Constructs a new option definition.
-    ///
-    /// # Arguments
-    ///
-    /// * `getter` - A function that retrieves the current value of the option.
-    /// * `setter` - A function that sets the current value of the option.
-    fn new(getter: OptionGetter, setter: OptionSetter) -> Self {
-        Self { getter, setter }
-    }
+	/// Constructs a new option definition.
+	///
+	/// # Arguments
+	///
+	/// * `getter` - A function that retrieves the current value of the option.
+	/// * `setter` - A function that sets the current value of the option.
+	fn new(getter: OptionGetter, setter: OptionSetter) -> Self {
+		Self { getter, setter }
+	}
 
-    /// Retrieves the current value of this option from the given runtime options.
-    ///
-    /// # Arguments
-    ///
-    /// * `options` - The runtime options to retrieve the value from.
-    pub fn get(&self, options: &RuntimeOptions) -> bool {
-        (self.getter)(options)
-    }
+	/// Retrieves the current value of this option from the given runtime options.
+	///
+	/// # Arguments
+	///
+	/// * `options` - The runtime options to retrieve the value from.
+	pub fn get(&self, options: &RuntimeOptions) -> bool {
+		(self.getter)(options)
+	}
 
-    /// Sets the value of this option in the given runtime options.
-    ///
-    /// # Arguments
-    ///
-    /// * `options` - The runtime options to modify.
-    /// * `value` - The new value to set for the option.
-    pub fn set(&self, options: &mut RuntimeOptions, value: bool) {
-        (self.setter)(options, value);
-    }
+	/// Sets the value of this option in the given runtime options.
+	///
+	/// # Arguments
+	///
+	/// * `options` - The runtime options to modify.
+	/// * `value` - The new value to set for the option.
+	pub fn set(&self, options: &mut RuntimeOptions, value: bool) {
+		(self.setter)(options, value);
+	}
 }
 
 /// Describes a shell option.
 pub struct ShellOption {
-    /// The name of the option.
-    pub name: &'static str,
-    /// The definition of the option.
-    pub definition: &'static ShellOptionDef,
+	/// The name of the option.
+	pub name: &'static str,
+	/// The definition of the option.
+	pub definition: &'static ShellOptionDef,
 }
 
 /// Describes a set of shell options.
 pub struct ShellOptionSet {
-    inner: &'static HashMap<&'static str, ShellOptionDef>,
+	inner: &'static HashMap<&'static str, ShellOptionDef>,
 }
 
 /// Kind of shell option.
 #[derive(Clone, Copy)]
 pub enum ShellOptionKind {
-    /// `set` option.
-    Set,
-    /// `set -o` option.
-    SetO,
-    /// `shopt` option.
-    Shopt,
+	/// `set` option.
+	Set,
+	/// `set -o` option.
+	SetO,
+	/// `shopt` option.
+	Shopt,
 }
 
 /// Returns the options for the given shell option kind.
@@ -77,753 +77,718 @@ pub enum ShellOptionKind {
 ///
 /// * `kind` - The kind of shell options to retrieve.
 pub fn options(kind: ShellOptionKind) -> ShellOptionSet {
-    match kind {
-        ShellOptionKind::Set => ShellOptionSet {
-            inner: &SET_OPTIONS,
-        },
-        ShellOptionKind::SetO => ShellOptionSet {
-            inner: &SET_O_OPTIONS,
-        },
-        ShellOptionKind::Shopt => ShellOptionSet {
-            inner: &SHOPT_OPTIONS,
-        },
-    }
+	match kind {
+		ShellOptionKind::Set => ShellOptionSet { inner: &SET_OPTIONS },
+		ShellOptionKind::SetO => ShellOptionSet { inner: &SET_O_OPTIONS },
+		ShellOptionKind::Shopt => ShellOptionSet { inner: &SHOPT_OPTIONS },
+	}
 }
 
 impl ShellOptionSet {
-    /// Returns an iterator over the options defined in this set.
-    pub fn iter(&self) -> impl Iterator<Item = ShellOption> {
-        self.inner
-            .iter()
-            .map(|(&name, definition)| ShellOption { name, definition })
-    }
+	/// Returns an iterator over the options defined in this set.
+	pub fn iter(&self) -> impl Iterator<Item = ShellOption> {
+		self
+			.inner
+			.iter()
+			.map(|(&name, definition)| ShellOption { name, definition })
+	}
 
-    /// Returns the option with the given name, if it exists.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the option to retrieve.
-    pub fn get(&self, name: &str) -> Option<&'static ShellOptionDef> {
-        self.inner.get(name)
-    }
+	/// Returns the option with the given name, if it exists.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the option to retrieve.
+	pub fn get(&self, name: &str) -> Option<&'static ShellOptionDef> {
+		self.inner.get(name)
+	}
 }
 
 static SET_OPTIONS: LazyLock<HashMap<&'static str, ShellOptionDef>> = LazyLock::new(|| {
-    HashMap::from([
-        (
-            "a",
-            ShellOptionDef::new(
-                |options| options.export_variables_on_modification,
-                |options, value| options.export_variables_on_modification = value,
-            ),
-        ),
-        (
-            "b",
-            ShellOptionDef::new(
-                |options| options.notify_job_termination_immediately,
-                |options, value| options.notify_job_termination_immediately = value,
-            ),
-        ),
-        (
-            "e",
-            ShellOptionDef::new(
-                |options| options.exit_on_nonzero_command_exit,
-                |options, value| options.exit_on_nonzero_command_exit = value,
-            ),
-        ),
-        (
-            "f",
-            ShellOptionDef::new(
-                |options| options.disable_filename_globbing,
-                |options, value| options.disable_filename_globbing = value,
-            ),
-        ),
-        (
-            "h",
-            ShellOptionDef::new(
-                |options| options.remember_command_locations,
-                |options, value| options.remember_command_locations = value,
-            ),
-        ),
-        (
-            "i",
-            ShellOptionDef::new(
-                |options| options.interactive,
-                |options, value| options.interactive = value,
-            ),
-        ),
-        (
-            "k",
-            ShellOptionDef::new(
-                |options| options.place_all_assignment_args_in_command_env,
-                |options, value| options.place_all_assignment_args_in_command_env = value,
-            ),
-        ),
-        (
-            "m",
-            ShellOptionDef::new(
-                |options| options.enable_job_control,
-                |options, value| options.enable_job_control = value,
-            ),
-        ),
-        (
-            "n",
-            ShellOptionDef::new(
-                |options| options.do_not_execute_commands,
-                |options, value| options.do_not_execute_commands = value,
-            ),
-        ),
-        (
-            "p",
-            ShellOptionDef::new(
-                |options| options.real_effective_uid_mismatch,
-                |options, value| options.real_effective_uid_mismatch = value,
-            ),
-        ),
-        (
-            "t",
-            ShellOptionDef::new(
-                |options| options.exit_after_one_command,
-                |options, value| options.exit_after_one_command = value,
-            ),
-        ),
-        (
-            "u",
-            ShellOptionDef::new(
-                |options| options.treat_unset_variables_as_error,
-                |options, value| options.treat_unset_variables_as_error = value,
-            ),
-        ),
-        (
-            "v",
-            ShellOptionDef::new(
-                |options| options.print_shell_input_lines,
-                |options, value| options.print_shell_input_lines = value,
-            ),
-        ),
-        (
-            "x",
-            ShellOptionDef::new(
-                |options| options.print_commands_and_arguments,
-                |options, value| options.print_commands_and_arguments = value,
-            ),
-        ),
-        (
-            "B",
-            ShellOptionDef::new(
-                |options| options.perform_brace_expansion,
-                |options, value| options.perform_brace_expansion = value,
-            ),
-        ),
-        (
-            "C",
-            ShellOptionDef::new(
-                |options| options.disallow_overwriting_regular_files_via_output_redirection,
-                |options, value| {
-                    options.disallow_overwriting_regular_files_via_output_redirection = value;
-                },
-            ),
-        ),
-        (
-            "E",
-            ShellOptionDef::new(
-                |options| options.shell_functions_inherit_err_trap,
-                |options, value| options.shell_functions_inherit_err_trap = value,
-            ),
-        ),
-        (
-            "H",
-            ShellOptionDef::new(
-                |options| options.enable_bang_style_history_substitution,
-                |options, value| options.enable_bang_style_history_substitution = value,
-            ),
-        ),
-        (
-            "P",
-            ShellOptionDef::new(
-                |options| options.do_not_resolve_symlinks_when_changing_dir,
-                |options, value| options.do_not_resolve_symlinks_when_changing_dir = value,
-            ),
-        ),
-        (
-            "T",
-            ShellOptionDef::new(
-                |options| options.shell_functions_inherit_debug_and_return_traps,
-                |options, value| options.shell_functions_inherit_debug_and_return_traps = value,
-            ),
-        ),
-        (
-            "s",
-            ShellOptionDef::new(
-                |options| options.read_commands_from_stdin,
-                |options, value| options.read_commands_from_stdin = value,
-            ),
-        ),
-    ])
+	HashMap::from([
+		(
+			"a",
+			ShellOptionDef::new(
+				|options| options.export_variables_on_modification,
+				|options, value| options.export_variables_on_modification = value,
+			),
+		),
+		(
+			"b",
+			ShellOptionDef::new(
+				|options| options.notify_job_termination_immediately,
+				|options, value| options.notify_job_termination_immediately = value,
+			),
+		),
+		(
+			"e",
+			ShellOptionDef::new(
+				|options| options.exit_on_nonzero_command_exit,
+				|options, value| options.exit_on_nonzero_command_exit = value,
+			),
+		),
+		(
+			"f",
+			ShellOptionDef::new(
+				|options| options.disable_filename_globbing,
+				|options, value| options.disable_filename_globbing = value,
+			),
+		),
+		(
+			"h",
+			ShellOptionDef::new(
+				|options| options.remember_command_locations,
+				|options, value| options.remember_command_locations = value,
+			),
+		),
+		(
+			"i",
+			ShellOptionDef::new(
+				|options| options.interactive,
+				|options, value| options.interactive = value,
+			),
+		),
+		(
+			"k",
+			ShellOptionDef::new(
+				|options| options.place_all_assignment_args_in_command_env,
+				|options, value| options.place_all_assignment_args_in_command_env = value,
+			),
+		),
+		(
+			"m",
+			ShellOptionDef::new(
+				|options| options.enable_job_control,
+				|options, value| options.enable_job_control = value,
+			),
+		),
+		(
+			"n",
+			ShellOptionDef::new(
+				|options| options.do_not_execute_commands,
+				|options, value| options.do_not_execute_commands = value,
+			),
+		),
+		(
+			"p",
+			ShellOptionDef::new(
+				|options| options.real_effective_uid_mismatch,
+				|options, value| options.real_effective_uid_mismatch = value,
+			),
+		),
+		(
+			"t",
+			ShellOptionDef::new(
+				|options| options.exit_after_one_command,
+				|options, value| options.exit_after_one_command = value,
+			),
+		),
+		(
+			"u",
+			ShellOptionDef::new(
+				|options| options.treat_unset_variables_as_error,
+				|options, value| options.treat_unset_variables_as_error = value,
+			),
+		),
+		(
+			"v",
+			ShellOptionDef::new(
+				|options| options.print_shell_input_lines,
+				|options, value| options.print_shell_input_lines = value,
+			),
+		),
+		(
+			"x",
+			ShellOptionDef::new(
+				|options| options.print_commands_and_arguments,
+				|options, value| options.print_commands_and_arguments = value,
+			),
+		),
+		(
+			"B",
+			ShellOptionDef::new(
+				|options| options.perform_brace_expansion,
+				|options, value| options.perform_brace_expansion = value,
+			),
+		),
+		(
+			"C",
+			ShellOptionDef::new(
+				|options| options.disallow_overwriting_regular_files_via_output_redirection,
+				|options, value| {
+					options.disallow_overwriting_regular_files_via_output_redirection = value;
+				},
+			),
+		),
+		(
+			"E",
+			ShellOptionDef::new(
+				|options| options.shell_functions_inherit_err_trap,
+				|options, value| options.shell_functions_inherit_err_trap = value,
+			),
+		),
+		(
+			"H",
+			ShellOptionDef::new(
+				|options| options.enable_bang_style_history_substitution,
+				|options, value| options.enable_bang_style_history_substitution = value,
+			),
+		),
+		(
+			"P",
+			ShellOptionDef::new(
+				|options| options.do_not_resolve_symlinks_when_changing_dir,
+				|options, value| options.do_not_resolve_symlinks_when_changing_dir = value,
+			),
+		),
+		(
+			"T",
+			ShellOptionDef::new(
+				|options| options.shell_functions_inherit_debug_and_return_traps,
+				|options, value| options.shell_functions_inherit_debug_and_return_traps = value,
+			),
+		),
+		(
+			"s",
+			ShellOptionDef::new(
+				|options| options.read_commands_from_stdin,
+				|options, value| options.read_commands_from_stdin = value,
+			),
+		),
+	])
 });
 
 static SET_O_OPTIONS: LazyLock<HashMap<&'static str, ShellOptionDef>> = LazyLock::new(|| {
-    HashMap::from([
-        (
-            "allexport",
-            ShellOptionDef::new(
-                |options| options.export_variables_on_modification,
-                |options, value| options.export_variables_on_modification = value,
-            ),
-        ),
-        (
-            "braceexpand",
-            ShellOptionDef::new(
-                |options| options.perform_brace_expansion,
-                |options, value| options.perform_brace_expansion = value,
-            ),
-        ),
-        (
-            "emacs",
-            ShellOptionDef::new(
-                |options| options.emacs_mode,
-                |options, value| options.emacs_mode = value,
-            ),
-        ),
-        (
-            "errexit",
-            ShellOptionDef::new(
-                |options| options.exit_on_nonzero_command_exit,
-                |options, value| options.exit_on_nonzero_command_exit = value,
-            ),
-        ),
-        (
-            "errtrace",
-            ShellOptionDef::new(
-                |options| options.shell_functions_inherit_err_trap,
-                |options, value| options.shell_functions_inherit_err_trap = value,
-            ),
-        ),
-        (
-            "functrace",
-            ShellOptionDef::new(
-                |options| options.shell_functions_inherit_debug_and_return_traps,
-                |options, value| options.shell_functions_inherit_debug_and_return_traps = value,
-            ),
-        ),
-        (
-            "hashall",
-            ShellOptionDef::new(
-                |options| options.remember_command_locations,
-                |options, value| options.remember_command_locations = value,
-            ),
-        ),
-        (
-            "histexpand",
-            ShellOptionDef::new(
-                |options| options.enable_bang_style_history_substitution,
-                |options, value| options.enable_bang_style_history_substitution = value,
-            ),
-        ),
-        (
-            "history",
-            ShellOptionDef::new(
-                |options| options.enable_command_history,
-                |options, value| options.enable_command_history = value,
-            ),
-        ),
-        (
-            "ignoreeof",
-            ShellOptionDef::new(
-                |options| options.ignore_eof,
-                |options, value| options.ignore_eof = value,
-            ),
-        ),
-        (
-            "interactive-comments",
-            ShellOptionDef::new(
-                |options| options.interactive_comments,
-                |options, value| options.interactive_comments = value,
-            ),
-        ),
-        (
-            "keyword",
-            ShellOptionDef::new(
-                |options| options.place_all_assignment_args_in_command_env,
-                |options, value| options.place_all_assignment_args_in_command_env = value,
-            ),
-        ),
-        (
-            "monitor",
-            ShellOptionDef::new(
-                |options| options.enable_job_control,
-                |options, value| options.enable_job_control = value,
-            ),
-        ),
-        (
-            "noclobber",
-            ShellOptionDef::new(
-                |options| options.disallow_overwriting_regular_files_via_output_redirection,
-                |options, value| {
-                    options.disallow_overwriting_regular_files_via_output_redirection = value;
-                },
-            ),
-        ),
-        (
-            "noexec",
-            ShellOptionDef::new(
-                |options| options.do_not_execute_commands,
-                |options, value| options.do_not_execute_commands = value,
-            ),
-        ),
-        (
-            "noglob",
-            ShellOptionDef::new(
-                |options| options.disable_filename_globbing,
-                |options, value| options.disable_filename_globbing = value,
-            ),
-        ),
-        ("nolog", ShellOptionDef::new(|_| false, |_, _| ())),
-        (
-            "notify",
-            ShellOptionDef::new(
-                |options| options.notify_job_termination_immediately,
-                |options, value| options.notify_job_termination_immediately = value,
-            ),
-        ),
-        (
-            "nounset",
-            ShellOptionDef::new(
-                |options| options.treat_unset_variables_as_error,
-                |options, value| options.treat_unset_variables_as_error = value,
-            ),
-        ),
-        (
-            "onecmd",
-            ShellOptionDef::new(
-                |options| options.exit_after_one_command,
-                |options, value| options.exit_after_one_command = value,
-            ),
-        ),
-        (
-            "physical",
-            ShellOptionDef::new(
-                |options| options.do_not_resolve_symlinks_when_changing_dir,
-                |options, value| options.do_not_resolve_symlinks_when_changing_dir = value,
-            ),
-        ),
-        (
-            "pipefail",
-            ShellOptionDef::new(
-                |options| options.return_first_failure_from_pipeline,
-                |options, value| options.return_first_failure_from_pipeline = value,
-            ),
-        ),
-        (
-            "posix",
-            ShellOptionDef::new(
-                |options| options.posix_mode,
-                |options, value| options.posix_mode = value,
-            ),
-        ),
-        (
-            "privileged",
-            ShellOptionDef::new(
-                |options| options.real_effective_uid_mismatch,
-                |options, value| options.real_effective_uid_mismatch = value,
-            ),
-        ),
-        (
-            "verbose",
-            ShellOptionDef::new(
-                |options| options.print_shell_input_lines,
-                |options, value| options.print_shell_input_lines = value,
-            ),
-        ),
-        (
-            "vi",
-            ShellOptionDef::new(
-                |options| options.vi_mode,
-                |options, value| options.vi_mode = value,
-            ),
-        ),
-        (
-            "xtrace",
-            ShellOptionDef::new(
-                |options| options.print_commands_and_arguments,
-                |options, value| options.print_commands_and_arguments = value,
-            ),
-        ),
-    ])
+	HashMap::from([
+		(
+			"allexport",
+			ShellOptionDef::new(
+				|options| options.export_variables_on_modification,
+				|options, value| options.export_variables_on_modification = value,
+			),
+		),
+		(
+			"braceexpand",
+			ShellOptionDef::new(
+				|options| options.perform_brace_expansion,
+				|options, value| options.perform_brace_expansion = value,
+			),
+		),
+		(
+			"emacs",
+			ShellOptionDef::new(
+				|options| options.emacs_mode,
+				|options, value| options.emacs_mode = value,
+			),
+		),
+		(
+			"errexit",
+			ShellOptionDef::new(
+				|options| options.exit_on_nonzero_command_exit,
+				|options, value| options.exit_on_nonzero_command_exit = value,
+			),
+		),
+		(
+			"errtrace",
+			ShellOptionDef::new(
+				|options| options.shell_functions_inherit_err_trap,
+				|options, value| options.shell_functions_inherit_err_trap = value,
+			),
+		),
+		(
+			"functrace",
+			ShellOptionDef::new(
+				|options| options.shell_functions_inherit_debug_and_return_traps,
+				|options, value| options.shell_functions_inherit_debug_and_return_traps = value,
+			),
+		),
+		(
+			"hashall",
+			ShellOptionDef::new(
+				|options| options.remember_command_locations,
+				|options, value| options.remember_command_locations = value,
+			),
+		),
+		(
+			"histexpand",
+			ShellOptionDef::new(
+				|options| options.enable_bang_style_history_substitution,
+				|options, value| options.enable_bang_style_history_substitution = value,
+			),
+		),
+		(
+			"history",
+			ShellOptionDef::new(
+				|options| options.enable_command_history,
+				|options, value| options.enable_command_history = value,
+			),
+		),
+		(
+			"ignoreeof",
+			ShellOptionDef::new(
+				|options| options.ignore_eof,
+				|options, value| options.ignore_eof = value,
+			),
+		),
+		(
+			"interactive-comments",
+			ShellOptionDef::new(
+				|options| options.interactive_comments,
+				|options, value| options.interactive_comments = value,
+			),
+		),
+		(
+			"keyword",
+			ShellOptionDef::new(
+				|options| options.place_all_assignment_args_in_command_env,
+				|options, value| options.place_all_assignment_args_in_command_env = value,
+			),
+		),
+		(
+			"monitor",
+			ShellOptionDef::new(
+				|options| options.enable_job_control,
+				|options, value| options.enable_job_control = value,
+			),
+		),
+		(
+			"noclobber",
+			ShellOptionDef::new(
+				|options| options.disallow_overwriting_regular_files_via_output_redirection,
+				|options, value| {
+					options.disallow_overwriting_regular_files_via_output_redirection = value;
+				},
+			),
+		),
+		(
+			"noexec",
+			ShellOptionDef::new(
+				|options| options.do_not_execute_commands,
+				|options, value| options.do_not_execute_commands = value,
+			),
+		),
+		(
+			"noglob",
+			ShellOptionDef::new(
+				|options| options.disable_filename_globbing,
+				|options, value| options.disable_filename_globbing = value,
+			),
+		),
+		("nolog", ShellOptionDef::new(|_| false, |_, _| ())),
+		(
+			"notify",
+			ShellOptionDef::new(
+				|options| options.notify_job_termination_immediately,
+				|options, value| options.notify_job_termination_immediately = value,
+			),
+		),
+		(
+			"nounset",
+			ShellOptionDef::new(
+				|options| options.treat_unset_variables_as_error,
+				|options, value| options.treat_unset_variables_as_error = value,
+			),
+		),
+		(
+			"onecmd",
+			ShellOptionDef::new(
+				|options| options.exit_after_one_command,
+				|options, value| options.exit_after_one_command = value,
+			),
+		),
+		(
+			"physical",
+			ShellOptionDef::new(
+				|options| options.do_not_resolve_symlinks_when_changing_dir,
+				|options, value| options.do_not_resolve_symlinks_when_changing_dir = value,
+			),
+		),
+		(
+			"pipefail",
+			ShellOptionDef::new(
+				|options| options.return_first_failure_from_pipeline,
+				|options, value| options.return_first_failure_from_pipeline = value,
+			),
+		),
+		(
+			"posix",
+			ShellOptionDef::new(
+				|options| options.posix_mode,
+				|options, value| options.posix_mode = value,
+			),
+		),
+		(
+			"privileged",
+			ShellOptionDef::new(
+				|options| options.real_effective_uid_mismatch,
+				|options, value| options.real_effective_uid_mismatch = value,
+			),
+		),
+		(
+			"verbose",
+			ShellOptionDef::new(
+				|options| options.print_shell_input_lines,
+				|options, value| options.print_shell_input_lines = value,
+			),
+		),
+		(
+			"vi",
+			ShellOptionDef::new(|options| options.vi_mode, |options, value| options.vi_mode = value),
+		),
+		(
+			"xtrace",
+			ShellOptionDef::new(
+				|options| options.print_commands_and_arguments,
+				|options, value| options.print_commands_and_arguments = value,
+			),
+		),
+	])
 });
 
 static SHOPT_OPTIONS: LazyLock<HashMap<&'static str, ShellOptionDef>> = LazyLock::new(|| {
-    HashMap::from([
-        (
-            "autocd",
-            ShellOptionDef::new(
-                |options| options.auto_cd,
-                |options, value| options.auto_cd = value,
-            ),
-        ),
-        (
-            "assoc_expand_once",
-            ShellOptionDef::new(
-                |options| options.assoc_expand_once,
-                |options, value| options.assoc_expand_once = value,
-            ),
-        ),
-        (
-            "cdable_vars",
-            ShellOptionDef::new(
-                |options| options.cdable_vars,
-                |options, value| options.cdable_vars = value,
-            ),
-        ),
-        (
-            "cdspell",
-            ShellOptionDef::new(
-                |options| options.cd_autocorrect_spelling,
-                |options, value| options.cd_autocorrect_spelling = value,
-            ),
-        ),
-        (
-            "checkhash",
-            ShellOptionDef::new(
-                |options| options.check_hashtable_before_command_exec,
-                |options, value| options.check_hashtable_before_command_exec = value,
-            ),
-        ),
-        (
-            "checkjobs",
-            ShellOptionDef::new(
-                |options| options.check_jobs_before_exit,
-                |options, value| options.check_jobs_before_exit = value,
-            ),
-        ),
-        (
-            "checkwinsize",
-            ShellOptionDef::new(
-                |options| options.check_window_size_after_external_commands,
-                |options, value| options.check_window_size_after_external_commands = value,
-            ),
-        ),
-        (
-            "cmdhist",
-            ShellOptionDef::new(
-                |options| options.save_multiline_cmds_in_history,
-                |options, value| options.save_multiline_cmds_in_history = value,
-            ),
-        ),
-        (
-            "compat31",
-            ShellOptionDef::new(
-                |options| options.compat31,
-                |options, value| options.compat31 = value,
-            ),
-        ),
-        (
-            "compat32",
-            ShellOptionDef::new(
-                |options| options.compat32,
-                |options, value| options.compat32 = value,
-            ),
-        ),
-        (
-            "compat40",
-            ShellOptionDef::new(
-                |options| options.compat40,
-                |options, value| options.compat40 = value,
-            ),
-        ),
-        (
-            "compat41",
-            ShellOptionDef::new(
-                |options| options.compat41,
-                |options, value| options.compat41 = value,
-            ),
-        ),
-        (
-            "compat42",
-            ShellOptionDef::new(
-                |options| options.compat42,
-                |options, value| options.compat42 = value,
-            ),
-        ),
-        (
-            "compat43",
-            ShellOptionDef::new(
-                |options| options.compat43,
-                |options, value| options.compat43 = value,
-            ),
-        ),
-        (
-            "compat44",
-            ShellOptionDef::new(
-                |options| options.compat44,
-                |options, value| options.compat44 = value,
-            ),
-        ),
-        (
-            "complete_fullquote",
-            ShellOptionDef::new(
-                |options| options.quote_all_metachars_in_completion,
-                |options, value| options.quote_all_metachars_in_completion = value,
-            ),
-        ),
-        (
-            "direxpand",
-            ShellOptionDef::new(
-                |options| options.expand_dir_names_on_completion,
-                |options, value| options.expand_dir_names_on_completion = value,
-            ),
-        ),
-        (
-            "dirspell",
-            ShellOptionDef::new(
-                |options| options.autocorrect_dir_spelling_on_completion,
-                |options, value| options.autocorrect_dir_spelling_on_completion = value,
-            ),
-        ),
-        (
-            "dotglob",
-            ShellOptionDef::new(
-                |options| options.glob_matches_dotfiles,
-                |options, value| options.glob_matches_dotfiles = value,
-            ),
-        ),
-        (
-            "execfail",
-            ShellOptionDef::new(
-                |options| options.exit_on_exec_fail,
-                |options, value| options.exit_on_exec_fail = value,
-            ),
-        ),
-        (
-            "expand_aliases",
-            ShellOptionDef::new(
-                |options| options.expand_aliases,
-                |options, value| options.expand_aliases = value,
-            ),
-        ),
-        (
-            "extdebug",
-            ShellOptionDef::new(
-                |options| options.enable_debugger,
-                |options, value| options.enable_debugger = value,
-            ),
-        ),
-        (
-            "extglob",
-            ShellOptionDef::new(
-                |options| options.extended_globbing,
-                |options, value| options.extended_globbing = value,
-            ),
-        ),
-        (
-            "extquote",
-            ShellOptionDef::new(
-                |options| options.extquote,
-                |options, value| options.extquote = value,
-            ),
-        ),
-        (
-            "failglob",
-            ShellOptionDef::new(
-                |options| options.fail_expansion_on_globs_without_match,
-                |options, value| options.fail_expansion_on_globs_without_match = value,
-            ),
-        ),
-        (
-            "force_fignore",
-            ShellOptionDef::new(
-                |options| options.force_fignore,
-                |options, value| options.force_fignore = value,
-            ),
-        ),
-        (
-            "globasciiranges",
-            ShellOptionDef::new(
-                |options| options.glob_ranges_use_c_locale,
-                |options, value| options.glob_ranges_use_c_locale = value,
-            ),
-        ),
-        (
-            "globstar",
-            ShellOptionDef::new(
-                |options| options.enable_star_star_glob,
-                |options, value| options.enable_star_star_glob = value,
-            ),
-        ),
-        (
-            "gnu_errfmt",
-            ShellOptionDef::new(
-                |options| options.errors_in_gnu_format,
-                |options, value| options.errors_in_gnu_format = value,
-            ),
-        ),
-        (
-            "histappend",
-            ShellOptionDef::new(
-                |options| options.append_to_history_file,
-                |options, value| options.append_to_history_file = value,
-            ),
-        ),
-        (
-            "histreedit",
-            ShellOptionDef::new(
-                |options| options.allow_reedit_failed_history_subst,
-                |options, value| options.allow_reedit_failed_history_subst = value,
-            ),
-        ),
-        (
-            "histverify",
-            ShellOptionDef::new(
-                |options| options.allow_modifying_history_substitution,
-                |options, value| options.allow_modifying_history_substitution = value,
-            ),
-        ),
-        (
-            "hostcomplete",
-            ShellOptionDef::new(
-                |options| options.enable_hostname_completion,
-                |options, value| options.enable_hostname_completion = value,
-            ),
-        ),
-        (
-            "huponexit",
-            ShellOptionDef::new(
-                |options| options.send_sighup_to_all_jobs_on_exit,
-                |options, value| options.send_sighup_to_all_jobs_on_exit = value,
-            ),
-        ),
-        (
-            "inherit_errexit",
-            ShellOptionDef::new(
-                |options| options.command_subst_inherits_errexit,
-                |options, value| options.command_subst_inherits_errexit = value,
-            ),
-        ),
-        (
-            "interactive_comments",
-            ShellOptionDef::new(
-                |options| options.interactive_comments,
-                |options, value| options.interactive_comments = value,
-            ),
-        ),
-        (
-            "lastpipe",
-            ShellOptionDef::new(
-                |options| options.run_last_pipeline_cmd_in_current_shell,
-                |options, value| options.run_last_pipeline_cmd_in_current_shell = value,
-            ),
-        ),
-        (
-            "lithist",
-            ShellOptionDef::new(
-                |options| options.embed_newlines_in_multiline_cmds_in_history,
-                |options, value| options.embed_newlines_in_multiline_cmds_in_history = value,
-            ),
-        ),
-        (
-            "localvar_inherit",
-            ShellOptionDef::new(
-                |options| options.local_vars_inherit_value_and_attrs,
-                |options, value| options.local_vars_inherit_value_and_attrs = value,
-            ),
-        ),
-        (
-            "localvar_unset",
-            ShellOptionDef::new(
-                |options| options.localvar_unset,
-                |options, value| options.localvar_unset = value,
-            ),
-        ),
-        (
-            "login_shell",
-            ShellOptionDef::new(
-                |options| options.login_shell,
-                |options, value| options.login_shell = value,
-            ),
-        ),
-        (
-            "mailwarn",
-            ShellOptionDef::new(
-                |options| options.mail_warn,
-                |options, value| options.mail_warn = value,
-            ),
-        ),
-        (
-            "no_empty_cmd_completion",
-            ShellOptionDef::new(
-                |options| options.no_empty_cmd_completion,
-                |options, value| options.no_empty_cmd_completion = value,
-            ),
-        ),
-        (
-            "nocaseglob",
-            ShellOptionDef::new(
-                |options| options.case_insensitive_pathname_expansion,
-                |options, value| options.case_insensitive_pathname_expansion = value,
-            ),
-        ),
-        (
-            "nocasematch",
-            ShellOptionDef::new(
-                |options| options.case_insensitive_conditionals,
-                |options, value| options.case_insensitive_conditionals = value,
-            ),
-        ),
-        (
-            "nullglob",
-            ShellOptionDef::new(
-                |options| options.expand_non_matching_patterns_to_null,
-                |options, value| options.expand_non_matching_patterns_to_null = value,
-            ),
-        ),
-        (
-            "progcomp",
-            ShellOptionDef::new(
-                |options| options.programmable_completion,
-                |options, value| options.programmable_completion = value,
-            ),
-        ),
-        (
-            "progcomp_alias",
-            ShellOptionDef::new(
-                |options| options.programmable_completion_alias,
-                |options, value| options.programmable_completion_alias = value,
-            ),
-        ),
-        (
-            "promptvars",
-            ShellOptionDef::new(
-                |options| options.expand_prompt_strings,
-                |options, value| options.expand_prompt_strings = value,
-            ),
-        ),
-        (
-            "restricted_shell",
-            ShellOptionDef::new(
-                |options| options.restricted_shell,
-                |options, value| options.restricted_shell = value,
-            ),
-        ),
-        (
-            "shift_verbose",
-            ShellOptionDef::new(
-                |options| options.shift_verbose,
-                |options, value| options.shift_verbose = value,
-            ),
-        ),
-        (
-            "sourcepath",
-            ShellOptionDef::new(
-                |options| options.source_builtin_searches_path,
-                |options, value| options.source_builtin_searches_path = value,
-            ),
-        ),
-        (
-            "xpg_echo",
-            ShellOptionDef::new(
-                |options| options.echo_builtin_expands_escape_sequences,
-                |options, value| options.echo_builtin_expands_escape_sequences = value,
-            ),
-        ),
-    ])
+	HashMap::from([
+		(
+			"autocd",
+			ShellOptionDef::new(|options| options.auto_cd, |options, value| options.auto_cd = value),
+		),
+		(
+			"assoc_expand_once",
+			ShellOptionDef::new(
+				|options| options.assoc_expand_once,
+				|options, value| options.assoc_expand_once = value,
+			),
+		),
+		(
+			"cdable_vars",
+			ShellOptionDef::new(
+				|options| options.cdable_vars,
+				|options, value| options.cdable_vars = value,
+			),
+		),
+		(
+			"cdspell",
+			ShellOptionDef::new(
+				|options| options.cd_autocorrect_spelling,
+				|options, value| options.cd_autocorrect_spelling = value,
+			),
+		),
+		(
+			"checkhash",
+			ShellOptionDef::new(
+				|options| options.check_hashtable_before_command_exec,
+				|options, value| options.check_hashtable_before_command_exec = value,
+			),
+		),
+		(
+			"checkjobs",
+			ShellOptionDef::new(
+				|options| options.check_jobs_before_exit,
+				|options, value| options.check_jobs_before_exit = value,
+			),
+		),
+		(
+			"checkwinsize",
+			ShellOptionDef::new(
+				|options| options.check_window_size_after_external_commands,
+				|options, value| options.check_window_size_after_external_commands = value,
+			),
+		),
+		(
+			"cmdhist",
+			ShellOptionDef::new(
+				|options| options.save_multiline_cmds_in_history,
+				|options, value| options.save_multiline_cmds_in_history = value,
+			),
+		),
+		(
+			"compat31",
+			ShellOptionDef::new(|options| options.compat31, |options, value| options.compat31 = value),
+		),
+		(
+			"compat32",
+			ShellOptionDef::new(|options| options.compat32, |options, value| options.compat32 = value),
+		),
+		(
+			"compat40",
+			ShellOptionDef::new(|options| options.compat40, |options, value| options.compat40 = value),
+		),
+		(
+			"compat41",
+			ShellOptionDef::new(|options| options.compat41, |options, value| options.compat41 = value),
+		),
+		(
+			"compat42",
+			ShellOptionDef::new(|options| options.compat42, |options, value| options.compat42 = value),
+		),
+		(
+			"compat43",
+			ShellOptionDef::new(|options| options.compat43, |options, value| options.compat43 = value),
+		),
+		(
+			"compat44",
+			ShellOptionDef::new(|options| options.compat44, |options, value| options.compat44 = value),
+		),
+		(
+			"complete_fullquote",
+			ShellOptionDef::new(
+				|options| options.quote_all_metachars_in_completion,
+				|options, value| options.quote_all_metachars_in_completion = value,
+			),
+		),
+		(
+			"direxpand",
+			ShellOptionDef::new(
+				|options| options.expand_dir_names_on_completion,
+				|options, value| options.expand_dir_names_on_completion = value,
+			),
+		),
+		(
+			"dirspell",
+			ShellOptionDef::new(
+				|options| options.autocorrect_dir_spelling_on_completion,
+				|options, value| options.autocorrect_dir_spelling_on_completion = value,
+			),
+		),
+		(
+			"dotglob",
+			ShellOptionDef::new(
+				|options| options.glob_matches_dotfiles,
+				|options, value| options.glob_matches_dotfiles = value,
+			),
+		),
+		(
+			"execfail",
+			ShellOptionDef::new(
+				|options| options.exit_on_exec_fail,
+				|options, value| options.exit_on_exec_fail = value,
+			),
+		),
+		(
+			"expand_aliases",
+			ShellOptionDef::new(
+				|options| options.expand_aliases,
+				|options, value| options.expand_aliases = value,
+			),
+		),
+		(
+			"extdebug",
+			ShellOptionDef::new(
+				|options| options.enable_debugger,
+				|options, value| options.enable_debugger = value,
+			),
+		),
+		(
+			"extglob",
+			ShellOptionDef::new(
+				|options| options.extended_globbing,
+				|options, value| options.extended_globbing = value,
+			),
+		),
+		(
+			"extquote",
+			ShellOptionDef::new(|options| options.extquote, |options, value| options.extquote = value),
+		),
+		(
+			"failglob",
+			ShellOptionDef::new(
+				|options| options.fail_expansion_on_globs_without_match,
+				|options, value| options.fail_expansion_on_globs_without_match = value,
+			),
+		),
+		(
+			"force_fignore",
+			ShellOptionDef::new(
+				|options| options.force_fignore,
+				|options, value| options.force_fignore = value,
+			),
+		),
+		(
+			"globasciiranges",
+			ShellOptionDef::new(
+				|options| options.glob_ranges_use_c_locale,
+				|options, value| options.glob_ranges_use_c_locale = value,
+			),
+		),
+		(
+			"globstar",
+			ShellOptionDef::new(
+				|options| options.enable_star_star_glob,
+				|options, value| options.enable_star_star_glob = value,
+			),
+		),
+		(
+			"gnu_errfmt",
+			ShellOptionDef::new(
+				|options| options.errors_in_gnu_format,
+				|options, value| options.errors_in_gnu_format = value,
+			),
+		),
+		(
+			"histappend",
+			ShellOptionDef::new(
+				|options| options.append_to_history_file,
+				|options, value| options.append_to_history_file = value,
+			),
+		),
+		(
+			"histreedit",
+			ShellOptionDef::new(
+				|options| options.allow_reedit_failed_history_subst,
+				|options, value| options.allow_reedit_failed_history_subst = value,
+			),
+		),
+		(
+			"histverify",
+			ShellOptionDef::new(
+				|options| options.allow_modifying_history_substitution,
+				|options, value| options.allow_modifying_history_substitution = value,
+			),
+		),
+		(
+			"hostcomplete",
+			ShellOptionDef::new(
+				|options| options.enable_hostname_completion,
+				|options, value| options.enable_hostname_completion = value,
+			),
+		),
+		(
+			"huponexit",
+			ShellOptionDef::new(
+				|options| options.send_sighup_to_all_jobs_on_exit,
+				|options, value| options.send_sighup_to_all_jobs_on_exit = value,
+			),
+		),
+		(
+			"inherit_errexit",
+			ShellOptionDef::new(
+				|options| options.command_subst_inherits_errexit,
+				|options, value| options.command_subst_inherits_errexit = value,
+			),
+		),
+		(
+			"interactive_comments",
+			ShellOptionDef::new(
+				|options| options.interactive_comments,
+				|options, value| options.interactive_comments = value,
+			),
+		),
+		(
+			"lastpipe",
+			ShellOptionDef::new(
+				|options| options.run_last_pipeline_cmd_in_current_shell,
+				|options, value| options.run_last_pipeline_cmd_in_current_shell = value,
+			),
+		),
+		(
+			"lithist",
+			ShellOptionDef::new(
+				|options| options.embed_newlines_in_multiline_cmds_in_history,
+				|options, value| options.embed_newlines_in_multiline_cmds_in_history = value,
+			),
+		),
+		(
+			"localvar_inherit",
+			ShellOptionDef::new(
+				|options| options.local_vars_inherit_value_and_attrs,
+				|options, value| options.local_vars_inherit_value_and_attrs = value,
+			),
+		),
+		(
+			"localvar_unset",
+			ShellOptionDef::new(
+				|options| options.localvar_unset,
+				|options, value| options.localvar_unset = value,
+			),
+		),
+		(
+			"login_shell",
+			ShellOptionDef::new(
+				|options| options.login_shell,
+				|options, value| options.login_shell = value,
+			),
+		),
+		(
+			"mailwarn",
+			ShellOptionDef::new(
+				|options| options.mail_warn,
+				|options, value| options.mail_warn = value,
+			),
+		),
+		(
+			"no_empty_cmd_completion",
+			ShellOptionDef::new(
+				|options| options.no_empty_cmd_completion,
+				|options, value| options.no_empty_cmd_completion = value,
+			),
+		),
+		(
+			"nocaseglob",
+			ShellOptionDef::new(
+				|options| options.case_insensitive_pathname_expansion,
+				|options, value| options.case_insensitive_pathname_expansion = value,
+			),
+		),
+		(
+			"nocasematch",
+			ShellOptionDef::new(
+				|options| options.case_insensitive_conditionals,
+				|options, value| options.case_insensitive_conditionals = value,
+			),
+		),
+		(
+			"nullglob",
+			ShellOptionDef::new(
+				|options| options.expand_non_matching_patterns_to_null,
+				|options, value| options.expand_non_matching_patterns_to_null = value,
+			),
+		),
+		(
+			"progcomp",
+			ShellOptionDef::new(
+				|options| options.programmable_completion,
+				|options, value| options.programmable_completion = value,
+			),
+		),
+		(
+			"progcomp_alias",
+			ShellOptionDef::new(
+				|options| options.programmable_completion_alias,
+				|options, value| options.programmable_completion_alias = value,
+			),
+		),
+		(
+			"promptvars",
+			ShellOptionDef::new(
+				|options| options.expand_prompt_strings,
+				|options, value| options.expand_prompt_strings = value,
+			),
+		),
+		(
+			"restricted_shell",
+			ShellOptionDef::new(
+				|options| options.restricted_shell,
+				|options, value| options.restricted_shell = value,
+			),
+		),
+		(
+			"shift_verbose",
+			ShellOptionDef::new(
+				|options| options.shift_verbose,
+				|options, value| options.shift_verbose = value,
+			),
+		),
+		(
+			"sourcepath",
+			ShellOptionDef::new(
+				|options| options.source_builtin_searches_path,
+				|options, value| options.source_builtin_searches_path = value,
+			),
+		),
+		(
+			"xpg_echo",
+			ShellOptionDef::new(
+				|options| options.echo_builtin_expands_escape_sequences,
+				|options, value| options.echo_builtin_expands_escape_sequences = value,
+			),
+		),
+	])
 });

--- a/crates/brush-core-vendored/src/options.rs
+++ b/crates/brush-core-vendored/src/options.rs
@@ -8,318 +8,318 @@ use crate::{CreateOptions, namedoptions};
 #[derive(Clone, Default)]
 #[expect(clippy::module_name_repetitions)]
 pub struct RuntimeOptions {
-    //
-    // Single-character options.
-    /// -a
-    pub export_variables_on_modification: bool,
-    /// -b
-    pub notify_job_termination_immediately: bool,
-    /// -e
-    pub exit_on_nonzero_command_exit: bool,
-    /// -f
-    pub disable_filename_globbing: bool,
-    /// -h
-    pub remember_command_locations: bool,
-    /// -k
-    pub place_all_assignment_args_in_command_env: bool,
-    /// -m
-    pub enable_job_control: bool,
-    /// -n
-    pub do_not_execute_commands: bool,
-    /// -p
-    pub real_effective_uid_mismatch: bool,
-    /// -t
-    pub exit_after_one_command: bool,
-    /// -u
-    pub treat_unset_variables_as_error: bool,
-    /// -v
-    pub print_shell_input_lines: bool,
-    /// -x
-    pub print_commands_and_arguments: bool,
-    /// -B
-    pub perform_brace_expansion: bool,
-    /// -C
-    pub disallow_overwriting_regular_files_via_output_redirection: bool,
-    /// -E
-    pub shell_functions_inherit_err_trap: bool,
-    /// -H
-    pub enable_bang_style_history_substitution: bool,
-    /// -P
-    pub do_not_resolve_symlinks_when_changing_dir: bool,
-    /// -T
-    pub shell_functions_inherit_debug_and_return_traps: bool,
+	//
+	// Single-character options.
+	/// -a
+	pub export_variables_on_modification: bool,
+	/// -b
+	pub notify_job_termination_immediately: bool,
+	/// -e
+	pub exit_on_nonzero_command_exit: bool,
+	/// -f
+	pub disable_filename_globbing: bool,
+	/// -h
+	pub remember_command_locations: bool,
+	/// -k
+	pub place_all_assignment_args_in_command_env: bool,
+	/// -m
+	pub enable_job_control: bool,
+	/// -n
+	pub do_not_execute_commands: bool,
+	/// -p
+	pub real_effective_uid_mismatch: bool,
+	/// -t
+	pub exit_after_one_command: bool,
+	/// -u
+	pub treat_unset_variables_as_error: bool,
+	/// -v
+	pub print_shell_input_lines: bool,
+	/// -x
+	pub print_commands_and_arguments: bool,
+	/// -B
+	pub perform_brace_expansion: bool,
+	/// -C
+	pub disallow_overwriting_regular_files_via_output_redirection: bool,
+	/// -E
+	pub shell_functions_inherit_err_trap: bool,
+	/// -H
+	pub enable_bang_style_history_substitution: bool,
+	/// -P
+	pub do_not_resolve_symlinks_when_changing_dir: bool,
+	/// -T
+	pub shell_functions_inherit_debug_and_return_traps: bool,
 
-    //
-    // Options set through -o.
-    /// 'emacs'
-    pub emacs_mode: bool,
-    /// 'history'
-    pub enable_command_history: bool,
-    /// 'ignoreeof'
-    pub ignore_eof: bool,
-    /// 'pipefail'
-    pub return_first_failure_from_pipeline: bool,
-    /// 'posix'
-    pub posix_mode: bool,
-    /// 'vi'
-    pub vi_mode: bool,
+	//
+	// Options set through -o.
+	/// 'emacs'
+	pub emacs_mode: bool,
+	/// 'history'
+	pub enable_command_history: bool,
+	/// 'ignoreeof'
+	pub ignore_eof: bool,
+	/// 'pipefail'
+	pub return_first_failure_from_pipeline: bool,
+	/// 'posix'
+	pub posix_mode: bool,
+	/// 'vi'
+	pub vi_mode: bool,
 
-    //
-    // Options set through shopt.
-    /// `assoc_expand_once`
-    pub assoc_expand_once: bool,
-    /// 'autocd'
-    pub auto_cd: bool,
-    /// `cdable_vars`
-    pub cdable_vars: bool,
-    /// 'cdspell'
-    pub cd_autocorrect_spelling: bool,
-    /// 'checkhash'
-    pub check_hashtable_before_command_exec: bool,
-    /// 'checkjobs'
-    pub check_jobs_before_exit: bool,
-    /// 'checkwinsize'
-    pub check_window_size_after_external_commands: bool,
-    /// 'cmdhist'
-    pub save_multiline_cmds_in_history: bool,
-    /// 'compat31'
-    pub compat31: bool,
-    /// 'compat32'
-    pub compat32: bool,
-    /// 'compat40'
-    pub compat40: bool,
-    /// 'compat41'
-    pub compat41: bool,
-    /// 'compat42'
-    pub compat42: bool,
-    /// 'compat43'
-    pub compat43: bool,
-    /// 'compat44'
-    pub compat44: bool,
-    /// `complete_fullquote`
-    pub quote_all_metachars_in_completion: bool,
-    /// 'direxpand'
-    pub expand_dir_names_on_completion: bool,
-    /// 'dirspell'
-    pub autocorrect_dir_spelling_on_completion: bool,
-    /// 'dotglob'
-    pub glob_matches_dotfiles: bool,
-    /// 'execfail'
-    pub exit_on_exec_fail: bool,
-    /// `expand_aliases`
-    pub expand_aliases: bool,
-    /// 'extdebug'
-    pub enable_debugger: bool,
-    /// 'extglob'
-    pub extended_globbing: bool,
-    /// 'extquote'
-    pub extquote: bool,
-    /// 'failglob'
-    pub fail_expansion_on_globs_without_match: bool,
-    /// `force_fignore`
-    pub force_fignore: bool,
-    /// 'globasciiranges'
-    pub glob_ranges_use_c_locale: bool,
-    /// 'globstar'
-    pub enable_star_star_glob: bool,
-    /// `gnu_errfmt`
-    pub errors_in_gnu_format: bool,
-    /// 'histappend'
-    pub append_to_history_file: bool,
-    /// 'histreedit'
-    pub allow_reedit_failed_history_subst: bool,
-    /// 'histverify'
-    pub allow_modifying_history_substitution: bool,
-    /// 'hostcomplete'
-    pub enable_hostname_completion: bool,
-    /// 'huponexit'
-    pub send_sighup_to_all_jobs_on_exit: bool,
-    /// `inherit_errexit`
-    pub command_subst_inherits_errexit: bool,
-    /// `interactive_comments`
-    pub interactive_comments: bool,
-    /// 'lastpipe'
-    pub run_last_pipeline_cmd_in_current_shell: bool,
-    /// 'lithist'
-    pub embed_newlines_in_multiline_cmds_in_history: bool,
-    /// `localvar_inherit`
-    pub local_vars_inherit_value_and_attrs: bool,
-    /// `localvar_unset`
-    pub localvar_unset: bool,
-    /// `login_shell`
-    pub login_shell: bool,
-    /// 'mailwarn'
-    pub mail_warn: bool,
-    /// `no_empty_cmd_completion`
-    pub no_empty_cmd_completion: bool,
-    /// 'nocaseglob'
-    pub case_insensitive_pathname_expansion: bool,
-    /// 'nocasematch'
-    pub case_insensitive_conditionals: bool,
-    /// 'nullglob'
-    pub expand_non_matching_patterns_to_null: bool,
-    /// 'progcomp'
-    pub programmable_completion: bool,
-    /// `progcomp_alias`
-    pub programmable_completion_alias: bool,
-    /// 'promptvars'
-    pub expand_prompt_strings: bool,
-    /// `restricted_shell`
-    pub restricted_shell: bool,
-    /// `shift_verbose`
-    pub shift_verbose: bool,
-    /// `sourcepath`
-    pub source_builtin_searches_path: bool,
-    /// `xpg_echo`
-    pub echo_builtin_expands_escape_sequences: bool,
+	//
+	// Options set through shopt.
+	/// `assoc_expand_once`
+	pub assoc_expand_once: bool,
+	/// 'autocd'
+	pub auto_cd: bool,
+	/// `cdable_vars`
+	pub cdable_vars: bool,
+	/// 'cdspell'
+	pub cd_autocorrect_spelling: bool,
+	/// 'checkhash'
+	pub check_hashtable_before_command_exec: bool,
+	/// 'checkjobs'
+	pub check_jobs_before_exit: bool,
+	/// 'checkwinsize'
+	pub check_window_size_after_external_commands: bool,
+	/// 'cmdhist'
+	pub save_multiline_cmds_in_history: bool,
+	/// 'compat31'
+	pub compat31: bool,
+	/// 'compat32'
+	pub compat32: bool,
+	/// 'compat40'
+	pub compat40: bool,
+	/// 'compat41'
+	pub compat41: bool,
+	/// 'compat42'
+	pub compat42: bool,
+	/// 'compat43'
+	pub compat43: bool,
+	/// 'compat44'
+	pub compat44: bool,
+	/// `complete_fullquote`
+	pub quote_all_metachars_in_completion: bool,
+	/// 'direxpand'
+	pub expand_dir_names_on_completion: bool,
+	/// 'dirspell'
+	pub autocorrect_dir_spelling_on_completion: bool,
+	/// 'dotglob'
+	pub glob_matches_dotfiles: bool,
+	/// 'execfail'
+	pub exit_on_exec_fail: bool,
+	/// `expand_aliases`
+	pub expand_aliases: bool,
+	/// 'extdebug'
+	pub enable_debugger: bool,
+	/// 'extglob'
+	pub extended_globbing: bool,
+	/// 'extquote'
+	pub extquote: bool,
+	/// 'failglob'
+	pub fail_expansion_on_globs_without_match: bool,
+	/// `force_fignore`
+	pub force_fignore: bool,
+	/// 'globasciiranges'
+	pub glob_ranges_use_c_locale: bool,
+	/// 'globstar'
+	pub enable_star_star_glob: bool,
+	/// `gnu_errfmt`
+	pub errors_in_gnu_format: bool,
+	/// 'histappend'
+	pub append_to_history_file: bool,
+	/// 'histreedit'
+	pub allow_reedit_failed_history_subst: bool,
+	/// 'histverify'
+	pub allow_modifying_history_substitution: bool,
+	/// 'hostcomplete'
+	pub enable_hostname_completion: bool,
+	/// 'huponexit'
+	pub send_sighup_to_all_jobs_on_exit: bool,
+	/// `inherit_errexit`
+	pub command_subst_inherits_errexit: bool,
+	/// `interactive_comments`
+	pub interactive_comments: bool,
+	/// 'lastpipe'
+	pub run_last_pipeline_cmd_in_current_shell: bool,
+	/// 'lithist'
+	pub embed_newlines_in_multiline_cmds_in_history: bool,
+	/// `localvar_inherit`
+	pub local_vars_inherit_value_and_attrs: bool,
+	/// `localvar_unset`
+	pub localvar_unset: bool,
+	/// `login_shell`
+	pub login_shell: bool,
+	/// 'mailwarn'
+	pub mail_warn: bool,
+	/// `no_empty_cmd_completion`
+	pub no_empty_cmd_completion: bool,
+	/// 'nocaseglob'
+	pub case_insensitive_pathname_expansion: bool,
+	/// 'nocasematch'
+	pub case_insensitive_conditionals: bool,
+	/// 'nullglob'
+	pub expand_non_matching_patterns_to_null: bool,
+	/// 'progcomp'
+	pub programmable_completion: bool,
+	/// `progcomp_alias`
+	pub programmable_completion_alias: bool,
+	/// 'promptvars'
+	pub expand_prompt_strings: bool,
+	/// `restricted_shell`
+	pub restricted_shell: bool,
+	/// `shift_verbose`
+	pub shift_verbose: bool,
+	/// `sourcepath`
+	pub source_builtin_searches_path: bool,
+	/// `xpg_echo`
+	pub echo_builtin_expands_escape_sequences: bool,
 
-    //
-    // Options set by the shell.
-    /// Whether or not the shell is interactive.
-    pub interactive: bool,
-    /// Whether or not the shell is reading commands from standard input.
-    pub read_commands_from_stdin: bool,
-    /// Whether or not the shell is in maximal `sh` compatibility mode.    
-    pub sh_mode: bool,
-    /// Maximum function call depth.
-    pub max_function_call_depth: Option<usize>,
+	//
+	// Options set by the shell.
+	/// Whether or not the shell is interactive.
+	pub interactive: bool,
+	/// Whether or not the shell is reading commands from standard input.
+	pub read_commands_from_stdin: bool,
+	/// Whether or not the shell is in maximal `sh` compatibility mode.    
+	pub sh_mode: bool,
+	/// Maximum function call depth.
+	pub max_function_call_depth: Option<usize>,
 }
 
 impl RuntimeOptions {
-    /// Creates a default set of runtime options based on the given creation options.
-    ///
-    /// # Arguments
-    ///
-    /// * `create_options` - The options used to create the shell.
-    pub fn defaults_from(create_options: &CreateOptions) -> Self {
-        // There's a set of options enabled by default for all shells.
-        let mut options = Self {
-            interactive: create_options.interactive,
-            disallow_overwriting_regular_files_via_output_redirection: create_options
-                .disallow_overwriting_regular_files_via_output_redirection,
-            do_not_execute_commands: create_options.do_not_execute_commands,
-            enable_command_history: create_options.interactive,
-            enable_job_control: create_options.interactive,
-            exit_after_one_command: create_options.exit_after_one_command,
-            read_commands_from_stdin: create_options.read_commands_from_stdin,
-            sh_mode: create_options.sh_mode,
-            posix_mode: create_options.posix,
-            print_commands_and_arguments: create_options.print_commands_and_arguments,
-            print_shell_input_lines: create_options.verbose,
-            remember_command_locations: true,
-            check_window_size_after_external_commands: true,
-            save_multiline_cmds_in_history: true,
-            extquote: true,
-            force_fignore: true,
-            enable_hostname_completion: true,
-            interactive_comments: true,
-            expand_prompt_strings: true,
-            source_builtin_searches_path: true,
-            perform_brace_expansion: true,
-            quote_all_metachars_in_completion: true,
-            programmable_completion: true,
-            glob_ranges_use_c_locale: true,
-            max_function_call_depth: create_options.max_function_call_depth,
-            ..Self::default()
-        };
+	/// Creates a default set of runtime options based on the given creation options.
+	///
+	/// # Arguments
+	///
+	/// * `create_options` - The options used to create the shell.
+	pub fn defaults_from(create_options: &CreateOptions) -> Self {
+		// There's a set of options enabled by default for all shells.
+		let mut options = Self {
+			interactive: create_options.interactive,
+			disallow_overwriting_regular_files_via_output_redirection: create_options
+				.disallow_overwriting_regular_files_via_output_redirection,
+			do_not_execute_commands: create_options.do_not_execute_commands,
+			enable_command_history: create_options.interactive,
+			enable_job_control: create_options.interactive,
+			exit_after_one_command: create_options.exit_after_one_command,
+			read_commands_from_stdin: create_options.read_commands_from_stdin,
+			sh_mode: create_options.sh_mode,
+			posix_mode: create_options.posix,
+			print_commands_and_arguments: create_options.print_commands_and_arguments,
+			print_shell_input_lines: create_options.verbose,
+			remember_command_locations: true,
+			check_window_size_after_external_commands: true,
+			save_multiline_cmds_in_history: true,
+			extquote: true,
+			force_fignore: true,
+			enable_hostname_completion: true,
+			interactive_comments: true,
+			expand_prompt_strings: true,
+			source_builtin_searches_path: true,
+			perform_brace_expansion: true,
+			quote_all_metachars_in_completion: true,
+			programmable_completion: true,
+			glob_ranges_use_c_locale: true,
+			max_function_call_depth: create_options.max_function_call_depth,
+			..Self::default()
+		};
 
-        // Additional options are enabled by default for interactive shells.
-        if create_options.interactive {
-            options.enable_bang_style_history_substitution = true;
-            options.emacs_mode = !create_options.no_editing;
-            options.expand_aliases = true;
-        }
+		// Additional options are enabled by default for interactive shells.
+		if create_options.interactive {
+			options.enable_bang_style_history_substitution = true;
+			options.emacs_mode = !create_options.no_editing;
+			options.expand_aliases = true;
+		}
 
-        // Update any options.
-        for enabled_option in &create_options.enabled_options {
-            if let Some(option) = namedoptions::options(namedoptions::ShellOptionKind::SetO)
-                .get(enabled_option.as_str())
-            {
-                option.set(&mut options, true);
-            }
-        }
-        for disabled_option in &create_options.disabled_options {
-            if let Some(option) = namedoptions::options(namedoptions::ShellOptionKind::SetO)
-                .get(disabled_option.as_str())
-            {
-                option.set(&mut options, false);
-            }
-        }
+		// Update any options.
+		for enabled_option in &create_options.enabled_options {
+			if let Some(option) =
+				namedoptions::options(namedoptions::ShellOptionKind::SetO).get(enabled_option.as_str())
+			{
+				option.set(&mut options, true);
+			}
+		}
+		for disabled_option in &create_options.disabled_options {
+			if let Some(option) =
+				namedoptions::options(namedoptions::ShellOptionKind::SetO).get(disabled_option.as_str())
+			{
+				option.set(&mut options, false);
+			}
+		}
 
-        // Update any shopt options.
-        for enabled_option in &create_options.enabled_shopt_options {
-            if let Some(shopt_option) = namedoptions::options(namedoptions::ShellOptionKind::Shopt)
-                .get(enabled_option.as_str())
-            {
-                shopt_option.set(&mut options, true);
-            }
-        }
-        for disabled_option in &create_options.disabled_shopt_options {
-            if let Some(shopt_option) = namedoptions::options(namedoptions::ShellOptionKind::Shopt)
-                .get(disabled_option.as_str())
-            {
-                shopt_option.set(&mut options, false);
-            }
-        }
+		// Update any shopt options.
+		for enabled_option in &create_options.enabled_shopt_options {
+			if let Some(shopt_option) =
+				namedoptions::options(namedoptions::ShellOptionKind::Shopt).get(enabled_option.as_str())
+			{
+				shopt_option.set(&mut options, true);
+			}
+		}
+		for disabled_option in &create_options.disabled_shopt_options {
+			if let Some(shopt_option) = namedoptions::options(namedoptions::ShellOptionKind::Shopt)
+				.get(disabled_option.as_str())
+			{
+				shopt_option.set(&mut options, false);
+			}
+		}
 
-        options
-    }
+		options
+	}
 
-    /// Returns a string representing the current `set`-style option flags set in the shell.
-    pub fn option_flags(&self) -> String {
-        let mut cs = vec![];
+	/// Returns a string representing the current `set`-style option flags set in the shell.
+	pub fn option_flags(&self) -> String {
+		let mut cs = vec![];
 
-        for o in namedoptions::options(namedoptions::ShellOptionKind::Set).iter() {
-            if o.definition.get(self) {
-                cs.push(o.name.chars().next().unwrap());
-            }
-        }
+		for o in namedoptions::options(namedoptions::ShellOptionKind::Set).iter() {
+			if o.definition.get(self) {
+				cs.push(o.name.chars().next().unwrap());
+			}
+		}
 
-        // Sort the flags in a way that matches what bash does.
-        cs.sort_by(|a, b| {
-            if a == b {
-                std::cmp::Ordering::Equal
-            } else if *a == 's' {
-                std::cmp::Ordering::Greater
-            } else if *b == 's' {
-                std::cmp::Ordering::Less
-            } else if a.is_ascii_lowercase() && b.is_ascii_uppercase() {
-                std::cmp::Ordering::Less
-            } else if a.is_ascii_uppercase() && b.is_ascii_lowercase() {
-                std::cmp::Ordering::Greater
-            } else {
-                a.cmp(b)
-            }
-        });
+		// Sort the flags in a way that matches what bash does.
+		cs.sort_by(|a, b| {
+			if a == b {
+				std::cmp::Ordering::Equal
+			} else if *a == 's' {
+				std::cmp::Ordering::Greater
+			} else if *b == 's' {
+				std::cmp::Ordering::Less
+			} else if a.is_ascii_lowercase() && b.is_ascii_uppercase() {
+				std::cmp::Ordering::Less
+			} else if a.is_ascii_uppercase() && b.is_ascii_lowercase() {
+				std::cmp::Ordering::Greater
+			} else {
+				a.cmp(b)
+			}
+		});
 
-        cs.into_iter().collect()
-    }
+		cs.into_iter().collect()
+	}
 
-    /// Returns a colon-separated list of sorted 'set -o' options enabled.
-    pub fn seto_optstr(&self) -> String {
-        let mut cs = vec![];
+	/// Returns a colon-separated list of sorted 'set -o' options enabled.
+	pub fn seto_optstr(&self) -> String {
+		let mut cs = vec![];
 
-        for option in namedoptions::options(namedoptions::ShellOptionKind::SetO).iter() {
-            if option.definition.get(self) {
-                cs.push(option.name);
-            }
-        }
+		for option in namedoptions::options(namedoptions::ShellOptionKind::SetO).iter() {
+			if option.definition.get(self) {
+				cs.push(option.name);
+			}
+		}
 
-        cs.sort_unstable();
-        cs.into_iter().join(":")
-    }
+		cs.sort_unstable();
+		cs.into_iter().join(":")
+	}
 
-    /// Returns a colon-separated list of sorted 'shopt' options enabled.
-    pub fn shopt_optstr(&self) -> String {
-        let mut cs = vec![];
+	/// Returns a colon-separated list of sorted 'shopt' options enabled.
+	pub fn shopt_optstr(&self) -> String {
+		let mut cs = vec![];
 
-        for option in namedoptions::options(namedoptions::ShellOptionKind::Shopt).iter() {
-            if option.definition.get(self) {
-                cs.push(option.name);
-            }
-        }
+		for option in namedoptions::options(namedoptions::ShellOptionKind::Shopt).iter() {
+			if option.definition.get(self) {
+				cs.push(option.name);
+			}
+		}
 
-        cs.sort_unstable();
-        cs.into_iter().join(":")
-    }
+		cs.sort_unstable();
+		cs.into_iter().join(":")
+	}
 }

--- a/crates/brush-core-vendored/src/pathcache.rs
+++ b/crates/brush-core-vendored/src/pathcache.rs
@@ -6,53 +6,53 @@ use std::path::PathBuf;
 /// A cache of paths associated with names.
 #[derive(Clone, Default)]
 pub struct PathCache {
-    /// The cache itself.
-    cache: std::collections::HashMap<String, PathBuf>,
+	/// The cache itself.
+	cache: std::collections::HashMap<String, PathBuf>,
 }
 
 impl PathCache {
-    /// Clears all elements from the cache.
-    pub fn reset(&mut self) {
-        self.cache.clear();
-    }
+	/// Clears all elements from the cache.
+	pub fn reset(&mut self) {
+		self.cache.clear();
+	}
 
-    /// Returns the path associated with the given name.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name to lookup.
-    pub fn get<S: AsRef<str>>(&self, name: S) -> Option<PathBuf> {
-        self.cache.get(name.as_ref()).cloned()
-    }
+	/// Returns the path associated with the given name.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name to lookup.
+	pub fn get<S: AsRef<str>>(&self, name: S) -> Option<PathBuf> {
+		self.cache.get(name.as_ref()).cloned()
+	}
 
-    /// Sets the path associated with the given name.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name to set.
-    /// * `path` - The path to associate with the name.
-    pub fn set<S: AsRef<str>>(&mut self, name: S, path: PathBuf) {
-        self.cache.insert(name.as_ref().to_string(), path);
-    }
+	/// Sets the path associated with the given name.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name to set.
+	/// * `path` - The path to associate with the name.
+	pub fn set<S: AsRef<str>>(&mut self, name: S, path: PathBuf) {
+		self.cache.insert(name.as_ref().to_string(), path);
+	}
 
-    /// Projects the cache into a shell value.
-    pub fn to_value(&self) -> Result<variables::ShellValue, error::Error> {
-        let pairs = self
-            .cache
-            .iter()
-            .map(|(k, v)| (Some(k.to_owned()), v.to_string_lossy().to_string()))
-            .collect::<Vec<_>>();
+	/// Projects the cache into a shell value.
+	pub fn to_value(&self) -> Result<variables::ShellValue, error::Error> {
+		let pairs = self
+			.cache
+			.iter()
+			.map(|(k, v)| (Some(k.to_owned()), v.to_string_lossy().to_string()))
+			.collect::<Vec<_>>();
 
-        variables::ShellValue::associative_array_from_literals(variables::ArrayLiteral(pairs))
-    }
+		variables::ShellValue::associative_array_from_literals(variables::ArrayLiteral(pairs))
+	}
 
-    /// Removes the path associated with the given name, if there is one.
-    /// Returns whether or not an entry was removed.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name to remove.
-    pub fn unset<S: AsRef<str>>(&mut self, name: S) -> bool {
-        self.cache.remove(name.as_ref()).is_some()
-    }
+	/// Removes the path associated with the given name, if there is one.
+	/// Returns whether or not an entry was removed.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name to remove.
+	pub fn unset<S: AsRef<str>>(&mut self, name: S) -> bool {
+		self.cache.remove(name.as_ref()).is_some()
+	}
 }

--- a/crates/brush-core-vendored/src/pathsearch.rs
+++ b/crates/brush-core-vendored/src/pathsearch.rs
@@ -2,112 +2,111 @@
 
 use std::{collections::VecDeque, path::PathBuf};
 
-
 use crate::sys::fs::PathExt;
 
 /// Encapsulates the result of a path search.
 pub struct ExecutablePathSearch<PI>
 where
-    PI: AsRef<str>,
+	PI: AsRef<str>,
 {
-    paths: VecDeque<PI>,
-    filenames: Vec<String>,
+	paths: VecDeque<PI>,
+	filenames: Vec<String>,
 }
 
 #[cfg(windows)]
 fn candidate_filenames(filename: &str) -> Vec<String> {
-    if std::path::Path::new(filename).extension().is_some() {
-        return vec![filename.to_string()];
-    }
+	if std::path::Path::new(filename).extension().is_some() {
+		return vec![filename.to_string()];
+	}
 
-    let mut candidates = Vec::new();
-    candidates.push(filename.to_string());
-    for ext in crate::sys::fs::executable_extensions() {
-        candidates.push(format!("{filename}{ext}"));
-    }
-    candidates
+	let mut candidates = Vec::new();
+	candidates.push(filename.to_string());
+	for ext in crate::sys::fs::executable_extensions() {
+		candidates.push(format!("{filename}{ext}"));
+	}
+	candidates
 }
 
 #[cfg(not(windows))]
 fn candidate_filenames(filename: &str) -> Vec<String> {
-    vec![filename.to_string()]
+	vec![filename.to_string()]
 }
 
 impl<PI> Iterator for ExecutablePathSearch<PI>
 where
-    PI: AsRef<str>,
+	PI: AsRef<str>,
 {
-    type Item = PathBuf;
+	type Item = PathBuf;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        while let Some(path) = self.paths.pop_front() {
-            let base_path = PathBuf::from(path.as_ref());
-            for filename in &self.filenames {
-                let path = base_path.join(filename);
-                if path.is_file() && path.as_path().executable() {
-                    return Some(path);
-                }
-            }
-        }
+	fn next(&mut self) -> Option<Self::Item> {
+		while let Some(path) = self.paths.pop_front() {
+			let base_path = PathBuf::from(path.as_ref());
+			for filename in &self.filenames {
+				let path = base_path.join(filename);
+				if path.is_file() && path.as_path().executable() {
+					return Some(path);
+				}
+			}
+		}
 
-        None
-    }
+		None
+	}
 }
 
 pub(crate) struct ExecutablePathPrefixSearch<PI>
 where
-    PI: AsRef<str>,
+	PI: AsRef<str>,
 {
-    paths: VecDeque<PI>,
-    queued_items: VecDeque<PathBuf>,
-    filename_prefix: String,
-    case_insensitive: bool,
+	paths: VecDeque<PI>,
+	queued_items: VecDeque<PathBuf>,
+	filename_prefix: String,
+	case_insensitive: bool,
 }
 
 impl<PI> Iterator for ExecutablePathPrefixSearch<PI>
 where
-    PI: AsRef<str>,
+	PI: AsRef<str>,
 {
-    type Item = PathBuf;
+	type Item = PathBuf;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        // If we already found some items and queued them, then yield one now.
-        if let Some(item) = self.queued_items.pop_front() {
-            return Some(item);
-        }
+	fn next(&mut self) -> Option<Self::Item> {
+		// If we already found some items and queued them, then yield one now.
+		if let Some(item) = self.queued_items.pop_front() {
+			return Some(item);
+		}
 
-        while let Some(path) = self.paths.pop_front() {
-            let path = PathBuf::from(path.as_ref());
+		while let Some(path) = self.paths.pop_front() {
+			let path = PathBuf::from(path.as_ref());
 
-            if let Ok(readdir) = path.read_dir() {
-                for entry in readdir.flatten() {
-                    if let Ok(mut filename) = entry.file_name().into_string() {
-                        if self.case_insensitive {
-                            filename = filename.to_ascii_lowercase();
-                        }
+			if let Ok(readdir) = path.read_dir() {
+				for entry in readdir.flatten() {
+					if let Ok(mut filename) = entry.file_name().into_string() {
+						if self.case_insensitive {
+							filename = filename.to_ascii_lowercase();
+						}
 
-                        if !filename.starts_with(&self.filename_prefix) {
-                            continue;
-                        }
-                    }
+						if !filename.starts_with(&self.filename_prefix) {
+							continue;
+						}
+					}
 
-                    let entry_path = entry.path();
+					let entry_path = entry.path();
 
-                    if let Ok(file_type) = entry.file_type() {
-                        if file_type.is_file() && entry_path.executable() {
-                            self.queued_items.push_back(entry_path);
-                        }
-                    }
-                }
-            }
+					if let Ok(file_type) = entry.file_type() {
+						if file_type.is_file() && entry_path.executable() {
+							self.queued_items.push_back(entry_path);
+						}
+					}
+				}
+			}
 
-            if let Some(item) = self.queued_items.pop_front() {
-                return Some(item);
-            }
-        }
+			if let Some(item) = self.queued_items.pop_front() {
+				return Some(item);
+			}
+		}
 
-        None
-    }
+		None
+	}
 }
 
 /// Search for the given executable name in the provided paths.
@@ -118,36 +117,33 @@ where
 /// * `filename` - The name of the executable file to search for.
 pub fn search_for_executable<P, PI, N>(paths: P, filename: N) -> ExecutablePathSearch<PI>
 where
-    P: Iterator<Item = PI>,
-    PI: AsRef<str>,
-    N: AsRef<str>,
+	P: Iterator<Item = PI>,
+	PI: AsRef<str>,
+	N: AsRef<str>,
 {
-    let filenames = candidate_filenames(filename.as_ref());
-    ExecutablePathSearch {
-        paths: paths.collect(),
-        filenames,
-    }
+	let filenames = candidate_filenames(filename.as_ref());
+	ExecutablePathSearch { paths: paths.collect(), filenames }
 }
 
 pub(crate) fn search_for_executable_with_prefix<P, PI>(
-    paths: P,
-    filename_prefix: &str,
-    case_insensitive: bool,
+	paths: P,
+	filename_prefix: &str,
+	case_insensitive: bool,
 ) -> ExecutablePathPrefixSearch<PI>
 where
-    P: Iterator<Item = PI>,
-    PI: AsRef<str>,
+	P: Iterator<Item = PI>,
+	PI: AsRef<str>,
 {
-    let stored_prefix = if case_insensitive {
-        filename_prefix.to_ascii_lowercase()
-    } else {
-        filename_prefix.into()
-    };
+	let stored_prefix = if case_insensitive {
+		filename_prefix.to_ascii_lowercase()
+	} else {
+		filename_prefix.into()
+	};
 
-    ExecutablePathPrefixSearch {
-        paths: paths.collect(),
-        queued_items: VecDeque::new(),
-        filename_prefix: stored_prefix,
-        case_insensitive,
-    }
+	ExecutablePathPrefixSearch {
+		paths: paths.collect(),
+		queued_items: VecDeque::new(),
+		filename_prefix: stored_prefix,
+		case_insensitive,
+	}
 }

--- a/crates/brush-core-vendored/src/patterns.rs
+++ b/crates/brush-core-vendored/src/patterns.rs
@@ -2,26 +2,26 @@
 
 use crate::{error, regex, trace_categories};
 use std::{
-    collections::VecDeque,
-    path::{Path, PathBuf},
+	collections::VecDeque,
+	path::{Path, PathBuf},
 };
 
 /// Represents a piece of a shell pattern.
 #[derive(Clone, Debug)]
 pub(crate) enum PatternPiece {
-    /// A pattern that should be interpreted as a shell pattern.
-    Pattern(String),
-    /// A literal string that should be matched exactly.
-    Literal(String),
+	/// A pattern that should be interpreted as a shell pattern.
+	Pattern(String),
+	/// A literal string that should be matched exactly.
+	Literal(String),
 }
 
 impl PatternPiece {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Pattern(s) => s,
-            Self::Literal(s) => s,
-        }
-    }
+	pub fn as_str(&self) -> &str {
+		match self {
+			Self::Pattern(s) => s,
+			Self::Literal(s) => s,
+		}
+	}
 }
 
 type PatternWord = Vec<PatternPiece>;
@@ -29,370 +29,355 @@ type PatternWord = Vec<PatternPiece>;
 /// Options for filename expansion.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct FilenameExpansionOptions {
-    pub require_dot_in_pattern_to_match_dot_files: bool,
+	pub require_dot_in_pattern_to_match_dot_files: bool,
 }
 
 /// Encapsulates a shell pattern.
 #[derive(Clone, Debug)]
 pub struct Pattern {
-    pieces: PatternWord,
-    enable_extended_globbing: bool,
-    multiline: bool,
-    case_insensitive: bool,
+	pieces: PatternWord,
+	enable_extended_globbing: bool,
+	multiline: bool,
+	case_insensitive: bool,
 }
 
 impl Default for Pattern {
-    fn default() -> Self {
-        Self {
-            pieces: vec![],
-            enable_extended_globbing: false,
-            multiline: true,
-            case_insensitive: false,
-        }
-    }
+	fn default() -> Self {
+		Self {
+			pieces: vec![],
+			enable_extended_globbing: false,
+			multiline: true,
+			case_insensitive: false,
+		}
+	}
 }
 
 impl From<PatternWord> for Pattern {
-    fn from(pieces: PatternWord) -> Self {
-        Self {
-            pieces,
-            ..Default::default()
-        }
-    }
+	fn from(pieces: PatternWord) -> Self {
+		Self { pieces, ..Default::default() }
+	}
 }
 
 impl From<&PatternWord> for Pattern {
-    fn from(value: &PatternWord) -> Self {
-        Self {
-            pieces: value.clone(),
-            ..Default::default()
-        }
-    }
+	fn from(value: &PatternWord) -> Self {
+		Self { pieces: value.clone(), ..Default::default() }
+	}
 }
 
 impl From<&str> for Pattern {
-    fn from(value: &str) -> Self {
-        Self {
-            pieces: vec![PatternPiece::Pattern(value.to_owned())],
-            ..Default::default()
-        }
-    }
+	fn from(value: &str) -> Self {
+		Self { pieces: vec![PatternPiece::Pattern(value.to_owned())], ..Default::default() }
+	}
 }
 
 impl From<String> for Pattern {
-    fn from(value: String) -> Self {
-        Self {
-            pieces: vec![PatternPiece::Pattern(value)],
-            ..Default::default()
-        }
-    }
+	fn from(value: String) -> Self {
+		Self { pieces: vec![PatternPiece::Pattern(value)], ..Default::default() }
+	}
 }
 
 impl Pattern {
-    /// Enables (or disables) extended globbing support for this pattern.
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - Whether or not to enable extended globbing (extglob).
-    #[must_use]
-    pub const fn set_extended_globbing(mut self, value: bool) -> Self {
-        self.enable_extended_globbing = value;
-        self
-    }
+	/// Enables (or disables) extended globbing support for this pattern.
+	///
+	/// # Arguments
+	///
+	/// * `value` - Whether or not to enable extended globbing (extglob).
+	#[must_use]
+	pub const fn set_extended_globbing(mut self, value: bool) -> Self {
+		self.enable_extended_globbing = value;
+		self
+	}
 
-    /// Enables (or disables) multiline support for this pattern.
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - Whether or not to enable multiline matching.
-    #[must_use]
-    pub const fn set_multiline(mut self, value: bool) -> Self {
-        self.multiline = value;
-        self
-    }
+	/// Enables (or disables) multiline support for this pattern.
+	///
+	/// # Arguments
+	///
+	/// * `value` - Whether or not to enable multiline matching.
+	#[must_use]
+	pub const fn set_multiline(mut self, value: bool) -> Self {
+		self.multiline = value;
+		self
+	}
 
-    /// Enables (or disables) case-insensitive matching for this pattern.
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - Whether or not to enable case-insensitive matching.
-    #[must_use]
-    pub const fn set_case_insensitive(mut self, value: bool) -> Self {
-        self.case_insensitive = value;
-        self
-    }
+	/// Enables (or disables) case-insensitive matching for this pattern.
+	///
+	/// # Arguments
+	///
+	/// * `value` - Whether or not to enable case-insensitive matching.
+	#[must_use]
+	pub const fn set_case_insensitive(mut self, value: bool) -> Self {
+		self.case_insensitive = value;
+		self
+	}
 
-    /// Returns whether or not the pattern is empty.
-    pub fn is_empty(&self) -> bool {
-        self.pieces.iter().all(|p| p.as_str().is_empty())
-    }
+	/// Returns whether or not the pattern is empty.
+	pub fn is_empty(&self) -> bool {
+		self.pieces.iter().all(|p| p.as_str().is_empty())
+	}
 
-    /// Placeholder function that always returns true.
-    pub(crate) const fn accept_all_expand_filter(_path: &Path) -> bool {
-        true
-    }
+	/// Placeholder function that always returns true.
+	pub(crate) const fn accept_all_expand_filter(_path: &Path) -> bool {
+		true
+	}
 
-    /// Expands the pattern into a list of matching file paths.
-    ///
-    /// # Arguments
-    ///
-    /// * `working_dir` - The current working directory, used for relative paths.
-    /// * `path_filter` - Optionally provides a function that filters paths after expansion.
-    
-    #[allow(clippy::unwrap_in_result)]
-    pub(crate) fn expand<PF>(
-        &self,
-        working_dir: &Path,
-        path_filter: Option<&PF>,
-        options: &FilenameExpansionOptions,
-    ) -> Result<Vec<String>, error::Error>
-    where
-        PF: Fn(&Path) -> bool,
-    {
-        // If the pattern is completely empty, then short-circuit the function; there's
-        // no reason to proceed onward when we know there's no expansions.
-        if self.is_empty() {
-            return Ok(vec![]);
+	/// Expands the pattern into a list of matching file paths.
+	///
+	/// # Arguments
+	///
+	/// * `working_dir` - The current working directory, used for relative paths.
+	/// * `path_filter` - Optionally provides a function that filters paths after expansion.
 
-        // Similarly, if we're *confident* the pattern doesn't require expansion, then we
-        // know there's a single expansion (before filtering).
-        } else if !self.pieces.iter().any(|piece| {
-            matches!(piece, PatternPiece::Pattern(_)) && requires_expansion(piece.as_str())
-        }) {
-            let concatenated: String = self.pieces.iter().map(|piece| piece.as_str()).collect();
+	#[allow(clippy::unwrap_in_result)]
+	pub(crate) fn expand<PF>(
+		&self,
+		working_dir: &Path,
+		path_filter: Option<&PF>,
+		options: &FilenameExpansionOptions,
+	) -> Result<Vec<String>, error::Error>
+	where
+		PF: Fn(&Path) -> bool,
+	{
+		// If the pattern is completely empty, then short-circuit the function; there's
+		// no reason to proceed onward when we know there's no expansions.
+		if self.is_empty() {
+			return Ok(vec![]);
 
-            if let Some(filter) = path_filter {
-                if !filter(Path::new(&concatenated)) {
-                    return Ok(vec![]);
-                }
-            }
+		// Similarly, if we're *confident* the pattern doesn't require expansion, then we
+		// know there's a single expansion (before filtering).
+		} else if !self.pieces.iter().any(|piece| {
+			matches!(piece, PatternPiece::Pattern(_)) && requires_expansion(piece.as_str())
+		}) {
+			let concatenated: String = self.pieces.iter().map(|piece| piece.as_str()).collect();
 
-            return Ok(vec![concatenated]);
-        }
+			if let Some(filter) = path_filter {
+				if !filter(Path::new(&concatenated)) {
+					return Ok(vec![]);
+				}
+			}
 
-        tracing::debug!(target: trace_categories::PATTERN, "expanding pattern: {self:?}");
+			return Ok(vec![concatenated]);
+		}
 
-        let mut components: Vec<PatternWord> = vec![];
-        for piece in &self.pieces {
-            let mut split_result = piece
-                .as_str()
-                .split(std::path::MAIN_SEPARATOR)
-                .map(|s| match piece {
-                    PatternPiece::Pattern(_) => PatternPiece::Pattern(s.to_owned()),
-                    PatternPiece::Literal(_) => PatternPiece::Literal(s.to_owned()),
-                })
-                .collect::<VecDeque<_>>();
+		tracing::debug!(target: trace_categories::PATTERN, "expanding pattern: {self:?}");
 
-            if let Some(first_piece) = split_result.pop_front() {
-                if let Some(last_component) = components.last_mut() {
-                    last_component.push(first_piece);
-                } else {
-                    components.push(vec![first_piece]);
-                }
-            }
+		let mut components: Vec<PatternWord> = vec![];
+		for piece in &self.pieces {
+			let mut split_result = piece
+				.as_str()
+				.split(std::path::MAIN_SEPARATOR)
+				.map(|s| match piece {
+					PatternPiece::Pattern(_) => PatternPiece::Pattern(s.to_owned()),
+					PatternPiece::Literal(_) => PatternPiece::Literal(s.to_owned()),
+				})
+				.collect::<VecDeque<_>>();
 
-            while let Some(piece) = split_result.pop_front() {
-                components.push(vec![piece]);
-            }
-        }
+			if let Some(first_piece) = split_result.pop_front() {
+				if let Some(last_component) = components.last_mut() {
+					last_component.push(first_piece);
+				} else {
+					components.push(vec![first_piece]);
+				}
+			}
 
-        // Check if the path appears to be absolute.
-        let is_absolute = if let Some(first_component) = components.first() {
-            first_component
-                .iter()
-                .all(|piece| piece.as_str().is_empty())
-        } else {
-            false
-        };
+			while let Some(piece) = split_result.pop_front() {
+				components.push(vec![piece]);
+			}
+		}
 
-        let prefix_to_remove;
-        let mut paths_so_far = if is_absolute {
-            prefix_to_remove = None;
-            // TODO: Figure out appropriate thing to do on non-Unix platforms.
-            vec![PathBuf::from(std::path::MAIN_SEPARATOR_STR)]
-        } else {
-            let mut working_dir_str = working_dir.to_string_lossy().to_string();
+		// Check if the path appears to be absolute.
+		let is_absolute = if let Some(first_component) = components.first() {
+			first_component
+				.iter()
+				.all(|piece| piece.as_str().is_empty())
+		} else {
+			false
+		};
 
-            if !working_dir_str.ends_with(std::path::MAIN_SEPARATOR) {
-                working_dir_str.push(std::path::MAIN_SEPARATOR);
-            }
+		let prefix_to_remove;
+		let mut paths_so_far = if is_absolute {
+			prefix_to_remove = None;
+			// TODO: Figure out appropriate thing to do on non-Unix platforms.
+			vec![PathBuf::from(std::path::MAIN_SEPARATOR_STR)]
+		} else {
+			let mut working_dir_str = working_dir.to_string_lossy().to_string();
 
-            prefix_to_remove = Some(working_dir_str);
-            vec![working_dir.to_path_buf()]
-        };
+			if !working_dir_str.ends_with(std::path::MAIN_SEPARATOR) {
+				working_dir_str.push(std::path::MAIN_SEPARATOR);
+			}
 
-        for component in components {
-            if !component.iter().any(|piece| {
-                matches!(piece, PatternPiece::Pattern(_)) && requires_expansion(piece.as_str())
-            }) {
-                for p in &mut paths_so_far {
-                    let flattened = component
-                        .iter()
-                        .map(|piece| piece.as_str())
-                        .collect::<String>();
-                    p.push(flattened);
-                }
-                continue;
-            }
+			prefix_to_remove = Some(working_dir_str);
+			vec![working_dir.to_path_buf()]
+		};
 
-            let current_paths = std::mem::take(&mut paths_so_far);
-            for current_path in current_paths {
-                let subpattern = Self::from(&component)
-                    .set_extended_globbing(self.enable_extended_globbing)
-                    .set_case_insensitive(self.case_insensitive);
+		for component in components {
+			if !component.iter().any(|piece| {
+				matches!(piece, PatternPiece::Pattern(_)) && requires_expansion(piece.as_str())
+			}) {
+				for p in &mut paths_so_far {
+					let flattened = component
+						.iter()
+						.map(|piece| piece.as_str())
+						.collect::<String>();
+					p.push(flattened);
+				}
+				continue;
+			}
 
-                let subpattern_starts_with_dot = subpattern
-                    .pieces
-                    .first()
-                    .is_some_and(|piece| piece.as_str().starts_with('.'));
+			let current_paths = std::mem::take(&mut paths_so_far);
+			for current_path in current_paths {
+				let subpattern = Self::from(&component)
+					.set_extended_globbing(self.enable_extended_globbing)
+					.set_case_insensitive(self.case_insensitive);
 
-                let allow_dot_files = !options.require_dot_in_pattern_to_match_dot_files
-                    || subpattern_starts_with_dot;
+				let subpattern_starts_with_dot = subpattern
+					.pieces
+					.first()
+					.is_some_and(|piece| piece.as_str().starts_with('.'));
 
-                let matches_dotfile_policy = |dir_entry: &std::fs::DirEntry| {
-                    !dir_entry.file_name().to_string_lossy().starts_with('.') || allow_dot_files
-                };
+				let allow_dot_files =
+					!options.require_dot_in_pattern_to_match_dot_files || subpattern_starts_with_dot;
 
-                let regex = subpattern.to_regex(true, true)?;
-                let matches_regex = |dir_entry: &std::fs::DirEntry| {
-                    regex
-                        .is_match(dir_entry.file_name().to_string_lossy().as_ref())
-                        .unwrap_or(false)
-                };
+				let matches_dotfile_policy = |dir_entry: &std::fs::DirEntry| {
+					!dir_entry.file_name().to_string_lossy().starts_with('.') || allow_dot_files
+				};
 
-                let mut matching_paths_in_dir: Vec<_> = current_path
-                    .read_dir()
-                    .map_or_else(|_| vec![], |dir| dir.into_iter().collect())
-                    .into_iter()
-                    .filter_map(|result| result.ok())
-                    .filter(matches_regex)
-                    .filter(matches_dotfile_policy)
-                    .map(|entry| entry.path())
-                    .collect();
+				let regex = subpattern.to_regex(true, true)?;
+				let matches_regex = |dir_entry: &std::fs::DirEntry| {
+					regex
+						.is_match(dir_entry.file_name().to_string_lossy().as_ref())
+						.unwrap_or(false)
+				};
 
-                matching_paths_in_dir.sort();
+				let mut matching_paths_in_dir: Vec<_> = current_path
+					.read_dir()
+					.map_or_else(|_| vec![], |dir| dir.into_iter().collect())
+					.into_iter()
+					.filter_map(|result| result.ok())
+					.filter(matches_regex)
+					.filter(matches_dotfile_policy)
+					.map(|entry| entry.path())
+					.collect();
 
-                paths_so_far.append(&mut matching_paths_in_dir);
-            }
-        }
+				matching_paths_in_dir.sort();
 
-        let results: Vec<_> = paths_so_far
-            .into_iter()
-            .filter_map(|path| {
-                if let Some(filter) = path_filter {
-                    if !filter(path.as_path()) {
-                        return None;
-                    }
-                }
+				paths_so_far.append(&mut matching_paths_in_dir);
+			}
+		}
 
-                let path_str = path.to_string_lossy();
-                let mut path_ref = path_str.as_ref();
+		let results: Vec<_> = paths_so_far
+			.into_iter()
+			.filter_map(|path| {
+				if let Some(filter) = path_filter {
+					if !filter(path.as_path()) {
+						return None;
+					}
+				}
 
-                if let Some(prefix_to_remove) = &prefix_to_remove {
-                    path_ref = path_ref.strip_prefix(prefix_to_remove).unwrap();
-                }
+				let path_str = path.to_string_lossy();
+				let mut path_ref = path_str.as_ref();
 
-                Some(path_ref.to_string())
-            })
-            .collect();
+				if let Some(prefix_to_remove) = &prefix_to_remove {
+					path_ref = path_ref.strip_prefix(prefix_to_remove).unwrap();
+				}
 
-        tracing::debug!(target: trace_categories::PATTERN, "  => results: {results:?}");
+				Some(path_ref.to_string())
+			})
+			.collect();
 
-        Ok(results)
-    }
+		tracing::debug!(target: trace_categories::PATTERN, "  => results: {results:?}");
 
-    /// Converts the pattern to a regular expression string.
-    ///
-    /// # Arguments
-    ///
-    /// * `strict_prefix_match` - Whether or not the pattern should strictly match the beginning of
-    ///   the string.
-    /// * `strict_suffix_match` - Whether or not the pattern should strictly match the end of the
-    ///   string.
-    pub(crate) fn to_regex_str(
-        &self,
-        strict_prefix_match: bool,
-        strict_suffix_match: bool,
-    ) -> Result<String, error::Error> {
-        let mut regex_str = String::new();
+		Ok(results)
+	}
 
-        if strict_prefix_match {
-            regex_str.push('^');
-        }
+	/// Converts the pattern to a regular expression string.
+	///
+	/// # Arguments
+	///
+	/// * `strict_prefix_match` - Whether or not the pattern should strictly match the beginning of
+	///   the string.
+	/// * `strict_suffix_match` - Whether or not the pattern should strictly match the end of the
+	///   string.
+	pub(crate) fn to_regex_str(
+		&self,
+		strict_prefix_match: bool,
+		strict_suffix_match: bool,
+	) -> Result<String, error::Error> {
+		let mut regex_str = String::new();
 
-        let mut current_pattern = String::new();
-        for piece in &self.pieces {
-            match piece {
-                PatternPiece::Pattern(s) => {
-                    current_pattern.push_str(s);
-                }
-                PatternPiece::Literal(s) => {
-                    for c in s.chars() {
-                        current_pattern.push('\\');
-                        current_pattern.push(c);
-                    }
-                }
-            }
-        }
+		if strict_prefix_match {
+			regex_str.push('^');
+		}
 
-        let regex_piece =
-            pattern_to_regex_str(current_pattern.as_str(), self.enable_extended_globbing)?;
-        regex_str.push_str(regex_piece.as_str());
+		let mut current_pattern = String::new();
+		for piece in &self.pieces {
+			match piece {
+				PatternPiece::Pattern(s) => {
+					current_pattern.push_str(s);
+				},
+				PatternPiece::Literal(s) => {
+					for c in s.chars() {
+						current_pattern.push('\\');
+						current_pattern.push(c);
+					}
+				},
+			}
+		}
 
-        if strict_suffix_match {
-            regex_str.push('$');
-        }
+		let regex_piece =
+			pattern_to_regex_str(current_pattern.as_str(), self.enable_extended_globbing)?;
+		regex_str.push_str(regex_piece.as_str());
 
-        Ok(regex_str)
-    }
+		if strict_suffix_match {
+			regex_str.push('$');
+		}
 
-    /// Converts the pattern to a regular expression.
-    ///
-    /// # Arguments
-    ///
-    /// * `strict_prefix_match` - Whether or not the pattern should strictly match the beginning of
-    ///   the string.
-    /// * `strict_suffix_match` - Whether or not the pattern should strictly match the end of the
-    ///   string.
-    pub(crate) fn to_regex(
-        &self,
-        strict_prefix_match: bool,
-        strict_suffix_match: bool,
-    ) -> Result<fancy_regex::Regex, error::Error> {
-        let regex_str = self.to_regex_str(strict_prefix_match, strict_suffix_match)?;
+		Ok(regex_str)
+	}
 
-        tracing::debug!(target: trace_categories::PATTERN, "pattern: '{self:?}' => regex: '{regex_str}'");
+	/// Converts the pattern to a regular expression.
+	///
+	/// # Arguments
+	///
+	/// * `strict_prefix_match` - Whether or not the pattern should strictly match the beginning of
+	///   the string.
+	/// * `strict_suffix_match` - Whether or not the pattern should strictly match the end of the
+	///   string.
+	pub(crate) fn to_regex(
+		&self,
+		strict_prefix_match: bool,
+		strict_suffix_match: bool,
+	) -> Result<fancy_regex::Regex, error::Error> {
+		let regex_str = self.to_regex_str(strict_prefix_match, strict_suffix_match)?;
 
-        let re = regex::compile_regex(regex_str, self.case_insensitive, self.multiline)?;
-        Ok(re)
-    }
+		tracing::debug!(target: trace_categories::PATTERN, "pattern: '{self:?}' => regex: '{regex_str}'");
 
-    /// Checks if the pattern exactly matches the given string. An error result
-    /// is returned if the pattern is found to be invalid or malformed
-    /// during processing.
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - The string to check for a match.
-    pub fn exactly_matches(&self, value: &str) -> Result<bool, error::Error> {
-        let re = self.to_regex(true, true)?;
-        Ok(re.is_match(value)?)
-    }
+		let re = regex::compile_regex(regex_str, self.case_insensitive, self.multiline)?;
+		Ok(re)
+	}
+
+	/// Checks if the pattern exactly matches the given string. An error result
+	/// is returned if the pattern is found to be invalid or malformed
+	/// during processing.
+	///
+	/// # Arguments
+	///
+	/// * `value` - The string to check for a match.
+	pub fn exactly_matches(&self, value: &str) -> Result<bool, error::Error> {
+		let re = self.to_regex(true, true)?;
+		Ok(re.is_match(value)?)
+	}
 }
 
 fn requires_expansion(s: &str) -> bool {
-    // TODO: Make this more accurate.
-    s.contains(['*', '?', '[', ']', '(', ')'])
+	// TODO: Make this more accurate.
+	s.contains(['*', '?', '[', ']', '(', ')'])
 }
 
 fn pattern_to_regex_str(
-    pattern: &str,
-    enable_extended_globbing: bool,
+	pattern: &str,
+	enable_extended_globbing: bool,
 ) -> Result<String, error::Error> {
-    Ok(brush_parser::pattern::pattern_to_regex_str(
-        pattern,
-        enable_extended_globbing,
-    )?)
+	Ok(brush_parser::pattern::pattern_to_regex_str(pattern, enable_extended_globbing)?)
 }
 
 /// Removes the largest matching prefix from a string that matches the given pattern.
@@ -403,27 +388,24 @@ fn pattern_to_regex_str(
 /// * `pattern` - The pattern to match.
 #[expect(clippy::ref_option)]
 pub(crate) fn remove_largest_matching_prefix<'a>(
-    s: &'a str,
-    pattern: &Option<Pattern>,
+	s: &'a str,
+	pattern: &Option<Pattern>,
 ) -> Result<&'a str, error::Error> {
-    if let Some(pattern) = pattern {
-        let indices = s.char_indices().rev();
-        let mut last_idx = s.len();
+	if let Some(pattern) = pattern {
+		let indices = s.char_indices().rev();
+		let mut last_idx = s.len();
 
-        #[allow(
-            clippy::string_slice,
-            reason = "because we get the indices from char_indices()"
-        )]
-        for (idx, _) in indices {
-            let prefix = &s[0..last_idx];
-            if pattern.exactly_matches(prefix)? {
-                return Ok(&s[last_idx..]);
-            }
+		#[allow(clippy::string_slice, reason = "because we get the indices from char_indices()")]
+		for (idx, _) in indices {
+			let prefix = &s[0..last_idx];
+			if pattern.exactly_matches(prefix)? {
+				return Ok(&s[last_idx..]);
+			}
 
-            last_idx = idx;
-        }
-    }
-    Ok(s)
+			last_idx = idx;
+		}
+	}
+	Ok(s)
 }
 
 /// Removes the smallest matching prefix from a string that matches the given pattern.
@@ -434,25 +416,22 @@ pub(crate) fn remove_largest_matching_prefix<'a>(
 /// * `pattern` - The pattern to match.
 #[expect(clippy::ref_option)]
 pub(crate) fn remove_smallest_matching_prefix<'a>(
-    s: &'a str,
-    pattern: &Option<Pattern>,
+	s: &'a str,
+	pattern: &Option<Pattern>,
 ) -> Result<&'a str, error::Error> {
-    if let Some(pattern) = pattern {
-        let mut indices = s.char_indices();
+	if let Some(pattern) = pattern {
+		let mut indices = s.char_indices();
 
-        #[allow(
-            clippy::string_slice,
-            reason = "because we get the indices from char_indices()"
-        )]
-        while indices.next().is_some() {
-            let next_index = indices.offset();
-            let prefix = &s[0..next_index];
-            if pattern.exactly_matches(prefix)? {
-                return Ok(&s[next_index..]);
-            }
-        }
-    }
-    Ok(s)
+		#[allow(clippy::string_slice, reason = "because we get the indices from char_indices()")]
+		while indices.next().is_some() {
+			let next_index = indices.offset();
+			let prefix = &s[0..next_index];
+			if pattern.exactly_matches(prefix)? {
+				return Ok(&s[next_index..]);
+			}
+		}
+	}
+	Ok(s)
 }
 
 /// Removes the largest matching suffix from a string that matches the given pattern.
@@ -463,22 +442,19 @@ pub(crate) fn remove_smallest_matching_prefix<'a>(
 /// * `pattern` - The pattern to match.
 #[expect(clippy::ref_option)]
 pub(crate) fn remove_largest_matching_suffix<'a>(
-    s: &'a str,
-    pattern: &Option<Pattern>,
+	s: &'a str,
+	pattern: &Option<Pattern>,
 ) -> Result<&'a str, error::Error> {
-    if let Some(pattern) = pattern {
-        #[allow(
-            clippy::string_slice,
-            reason = "because we get the indices from char_indices()"
-        )]
-        for (idx, _) in s.char_indices() {
-            let suffix = &s[idx..];
-            if pattern.exactly_matches(suffix)? {
-                return Ok(&s[..idx]);
-            }
-        }
-    }
-    Ok(s)
+	if let Some(pattern) = pattern {
+		#[allow(clippy::string_slice, reason = "because we get the indices from char_indices()")]
+		for (idx, _) in s.char_indices() {
+			let suffix = &s[idx..];
+			if pattern.exactly_matches(suffix)? {
+				return Ok(&s[..idx]);
+			}
+		}
+	}
+	Ok(s)
 }
 
 /// Removes the smallest matching suffix from a string that matches the given pattern.
@@ -489,387 +465,309 @@ pub(crate) fn remove_largest_matching_suffix<'a>(
 /// * `pattern` - The pattern to match.
 #[expect(clippy::ref_option)]
 pub(crate) fn remove_smallest_matching_suffix<'a>(
-    s: &'a str,
-    pattern: &Option<Pattern>,
+	s: &'a str,
+	pattern: &Option<Pattern>,
 ) -> Result<&'a str, error::Error> {
-    if let Some(pattern) = pattern {
-        #[allow(
-            clippy::string_slice,
-            reason = "because we get the indices from char_indices()"
-        )]
-        for (idx, _) in s.char_indices().rev() {
-            let suffix = &s[idx..];
-            if pattern.exactly_matches(suffix)? {
-                return Ok(&s[..idx]);
-            }
-        }
-    }
-    Ok(s)
+	if let Some(pattern) = pattern {
+		#[allow(clippy::string_slice, reason = "because we get the indices from char_indices()")]
+		for (idx, _) in s.char_indices().rev() {
+			let suffix = &s[idx..];
+			if pattern.exactly_matches(suffix)? {
+				return Ok(&s[..idx]);
+			}
+		}
+	}
+	Ok(s)
 }
 
 #[cfg(test)]
 #[expect(clippy::panic_in_result_fn)]
 mod tests {
-    use super::*;
-    use anyhow::Result;
+	use super::*;
+	use anyhow::Result;
 
-    fn pattern_to_exact_regex_str<P>(pattern: P) -> Result<String, error::Error>
-    where
-        P: Into<Pattern>,
-    {
-        let pattern: Pattern = pattern
-            .into()
-            .set_extended_globbing(true)
-            .set_multiline(false);
+	fn pattern_to_exact_regex_str<P>(pattern: P) -> Result<String, error::Error>
+	where
+		P: Into<Pattern>,
+	{
+		let pattern: Pattern = pattern
+			.into()
+			.set_extended_globbing(true)
+			.set_multiline(false);
 
-        pattern.to_regex_str(true, true)
-    }
+		pattern.to_regex_str(true, true)
+	}
 
-    #[test]
-    fn test_pattern_translation() -> Result<()> {
-        assert_eq!(pattern_to_exact_regex_str("a")?.as_str(), "^a$");
-        assert_eq!(pattern_to_exact_regex_str("a*")?.as_str(), "^a.*$");
-        assert_eq!(pattern_to_exact_regex_str("a?")?.as_str(), "^a.$");
-        assert_eq!(pattern_to_exact_regex_str("a@(b|c)")?.as_str(), "^a(b|c)$");
-        assert_eq!(pattern_to_exact_regex_str("a?(b|c)")?.as_str(), "^a(b|c)?$");
-        assert_eq!(
-            pattern_to_exact_regex_str("a*(ab|ac)")?.as_str(),
-            "^a(ab|ac)*$"
-        );
-        assert_eq!(
-            pattern_to_exact_regex_str("a+(ab|ac)")?.as_str(),
-            "^a(ab|ac)+$"
-        );
-        assert_eq!(pattern_to_exact_regex_str("[ab]")?.as_str(), "^[ab]$");
-        assert_eq!(pattern_to_exact_regex_str("[ab]*")?.as_str(), "^[ab].*$");
-        assert_eq!(
-            pattern_to_exact_regex_str("[<{().[]*")?.as_str(),
-            r"^[<{().\[].*$"
-        );
-        assert_eq!(pattern_to_exact_regex_str("[a-d]")?.as_str(), "^[a-d]$");
-        assert_eq!(pattern_to_exact_regex_str(r"\*")?.as_str(), r"^\*$");
+	#[test]
+	fn test_pattern_translation() -> Result<()> {
+		assert_eq!(pattern_to_exact_regex_str("a")?.as_str(), "^a$");
+		assert_eq!(pattern_to_exact_regex_str("a*")?.as_str(), "^a.*$");
+		assert_eq!(pattern_to_exact_regex_str("a?")?.as_str(), "^a.$");
+		assert_eq!(pattern_to_exact_regex_str("a@(b|c)")?.as_str(), "^a(b|c)$");
+		assert_eq!(pattern_to_exact_regex_str("a?(b|c)")?.as_str(), "^a(b|c)?$");
+		assert_eq!(pattern_to_exact_regex_str("a*(ab|ac)")?.as_str(), "^a(ab|ac)*$");
+		assert_eq!(pattern_to_exact_regex_str("a+(ab|ac)")?.as_str(), "^a(ab|ac)+$");
+		assert_eq!(pattern_to_exact_regex_str("[ab]")?.as_str(), "^[ab]$");
+		assert_eq!(pattern_to_exact_regex_str("[ab]*")?.as_str(), "^[ab].*$");
+		assert_eq!(pattern_to_exact_regex_str("[<{().[]*")?.as_str(), r"^[<{().\[].*$");
+		assert_eq!(pattern_to_exact_regex_str("[a-d]")?.as_str(), "^[a-d]$");
+		assert_eq!(pattern_to_exact_regex_str(r"\*")?.as_str(), r"^\*$");
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    #[test]
-    fn test_pattern_word_translation() -> Result<()> {
-        assert_eq!(
-            pattern_to_exact_regex_str(vec![PatternPiece::Pattern("a*".to_owned())])?.as_str(),
-            "^a.*$"
-        );
-        assert_eq!(
-            pattern_to_exact_regex_str(vec![
-                PatternPiece::Pattern("a*".to_owned()),
-                PatternPiece::Literal("b".to_owned()),
-            ])?
-            .as_str(),
-            "^a.*b$"
-        );
-        assert_eq!(
-            pattern_to_exact_regex_str(vec![
-                PatternPiece::Literal("a*".to_owned()),
-                PatternPiece::Pattern("b".to_owned()),
-            ])?
-            .as_str(),
-            r"^a\*b$"
-        );
+	#[test]
+	fn test_pattern_word_translation() -> Result<()> {
+		assert_eq!(
+			pattern_to_exact_regex_str(vec![PatternPiece::Pattern("a*".to_owned())])?.as_str(),
+			"^a.*$"
+		);
+		assert_eq!(
+			pattern_to_exact_regex_str(vec![
+				PatternPiece::Pattern("a*".to_owned()),
+				PatternPiece::Literal("b".to_owned()),
+			])?
+			.as_str(),
+			"^a.*b$"
+		);
+		assert_eq!(
+			pattern_to_exact_regex_str(vec![
+				PatternPiece::Literal("a*".to_owned()),
+				PatternPiece::Pattern("b".to_owned()),
+			])?
+			.as_str(),
+			r"^a\*b$"
+		);
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    #[test]
-    fn test_remove_largest_matching_prefix() -> Result<()> {
-        assert_eq!(
-            remove_largest_matching_prefix("ooof", &Some(Pattern::from("")))?,
-            "ooof"
-        );
-        assert_eq!(
-            remove_largest_matching_prefix("ooof", &Some(Pattern::from("x")))?,
-            "ooof"
-        );
-        assert_eq!(
-            remove_largest_matching_prefix("ooof", &Some(Pattern::from("o")))?,
-            "oof"
-        );
-        assert_eq!(
-            remove_largest_matching_prefix("ooof", &Some(Pattern::from("o*o")))?,
-            "f"
-        );
-        assert_eq!(
-            remove_largest_matching_prefix("ooof", &Some(Pattern::from("o*")))?,
-            ""
-        );
-        assert_eq!(
-            remove_largest_matching_prefix("🚀🚀🚀rocket", &Some(Pattern::from("🚀")))?,
-            "🚀🚀rocket"
-        );
-        Ok(())
-    }
+	#[test]
+	fn test_remove_largest_matching_prefix() -> Result<()> {
+		assert_eq!(remove_largest_matching_prefix("ooof", &Some(Pattern::from("")))?, "ooof");
+		assert_eq!(remove_largest_matching_prefix("ooof", &Some(Pattern::from("x")))?, "ooof");
+		assert_eq!(remove_largest_matching_prefix("ooof", &Some(Pattern::from("o")))?, "oof");
+		assert_eq!(remove_largest_matching_prefix("ooof", &Some(Pattern::from("o*o")))?, "f");
+		assert_eq!(remove_largest_matching_prefix("ooof", &Some(Pattern::from("o*")))?, "");
+		assert_eq!(
+			remove_largest_matching_prefix("🚀🚀🚀rocket", &Some(Pattern::from("🚀")))?,
+			"🚀🚀rocket"
+		);
+		Ok(())
+	}
 
-    #[test]
-    fn test_remove_smallest_matching_prefix() -> Result<()> {
-        assert_eq!(
-            remove_smallest_matching_prefix("ooof", &Some(Pattern::from("")))?,
-            "ooof"
-        );
-        assert_eq!(
-            remove_smallest_matching_prefix("ooof", &Some(Pattern::from("x")))?,
-            "ooof"
-        );
-        assert_eq!(
-            remove_smallest_matching_prefix("ooof", &Some(Pattern::from("o")))?,
-            "oof"
-        );
-        assert_eq!(
-            remove_smallest_matching_prefix("ooof", &Some(Pattern::from("o*o")))?,
-            "of"
-        );
-        assert_eq!(
-            remove_smallest_matching_prefix("ooof", &Some(Pattern::from("o*")))?,
-            "oof"
-        );
-        assert_eq!(
-            remove_smallest_matching_prefix("ooof", &Some(Pattern::from("ooof")))?,
-            ""
-        );
-        assert_eq!(
-            remove_smallest_matching_prefix("🚀🚀🚀rocket", &Some(Pattern::from("🚀")))?,
-            "🚀🚀rocket"
-        );
-        Ok(())
-    }
+	#[test]
+	fn test_remove_smallest_matching_prefix() -> Result<()> {
+		assert_eq!(remove_smallest_matching_prefix("ooof", &Some(Pattern::from("")))?, "ooof");
+		assert_eq!(remove_smallest_matching_prefix("ooof", &Some(Pattern::from("x")))?, "ooof");
+		assert_eq!(remove_smallest_matching_prefix("ooof", &Some(Pattern::from("o")))?, "oof");
+		assert_eq!(remove_smallest_matching_prefix("ooof", &Some(Pattern::from("o*o")))?, "of");
+		assert_eq!(remove_smallest_matching_prefix("ooof", &Some(Pattern::from("o*")))?, "oof");
+		assert_eq!(remove_smallest_matching_prefix("ooof", &Some(Pattern::from("ooof")))?, "");
+		assert_eq!(
+			remove_smallest_matching_prefix("🚀🚀🚀rocket", &Some(Pattern::from("🚀")))?,
+			"🚀🚀rocket"
+		);
+		Ok(())
+	}
 
-    #[test]
-    fn test_remove_largest_matching_suffix() -> Result<()> {
-        assert_eq!(
-            remove_largest_matching_suffix("foo", &Some(Pattern::from("")))?,
-            "foo"
-        );
-        assert_eq!(
-            remove_largest_matching_suffix("foo", &Some(Pattern::from("x")))?,
-            "foo"
-        );
-        assert_eq!(
-            remove_largest_matching_suffix("foo", &Some(Pattern::from("o")))?,
-            "fo"
-        );
-        assert_eq!(
-            remove_largest_matching_suffix("foo", &Some(Pattern::from("o*")))?,
-            "f"
-        );
-        assert_eq!(
-            remove_largest_matching_suffix("foo", &Some(Pattern::from("foo")))?,
-            ""
-        );
-        assert_eq!(
-            remove_largest_matching_suffix("rocket🚀🚀🚀", &Some(Pattern::from("🚀")))?,
-            "rocket🚀🚀"
-        );
-        Ok(())
-    }
+	#[test]
+	fn test_remove_largest_matching_suffix() -> Result<()> {
+		assert_eq!(remove_largest_matching_suffix("foo", &Some(Pattern::from("")))?, "foo");
+		assert_eq!(remove_largest_matching_suffix("foo", &Some(Pattern::from("x")))?, "foo");
+		assert_eq!(remove_largest_matching_suffix("foo", &Some(Pattern::from("o")))?, "fo");
+		assert_eq!(remove_largest_matching_suffix("foo", &Some(Pattern::from("o*")))?, "f");
+		assert_eq!(remove_largest_matching_suffix("foo", &Some(Pattern::from("foo")))?, "");
+		assert_eq!(
+			remove_largest_matching_suffix("rocket🚀🚀🚀", &Some(Pattern::from("🚀")))?,
+			"rocket🚀🚀"
+		);
+		Ok(())
+	}
 
-    #[test]
-    fn test_remove_smallest_matching_suffix() -> Result<()> {
-        assert_eq!(
-            remove_smallest_matching_suffix("fooo", &Some(Pattern::from("")))?,
-            "fooo"
-        );
-        assert_eq!(
-            remove_smallest_matching_suffix("fooo", &Some(Pattern::from("x")))?,
-            "fooo"
-        );
-        assert_eq!(
-            remove_smallest_matching_suffix("fooo", &Some(Pattern::from("o")))?,
-            "foo"
-        );
-        assert_eq!(
-            remove_smallest_matching_suffix("fooo", &Some(Pattern::from("o*o")))?,
-            "fo"
-        );
-        assert_eq!(
-            remove_smallest_matching_suffix("fooo", &Some(Pattern::from("o*")))?,
-            "foo"
-        );
-        assert_eq!(
-            remove_smallest_matching_suffix("fooo", &Some(Pattern::from("fooo")))?,
-            ""
-        );
-        assert_eq!(
-            remove_smallest_matching_suffix("rocket🚀🚀🚀", &Some(Pattern::from("🚀")))?,
-            "rocket🚀🚀"
-        );
-        Ok(())
-    }
+	#[test]
+	fn test_remove_smallest_matching_suffix() -> Result<()> {
+		assert_eq!(remove_smallest_matching_suffix("fooo", &Some(Pattern::from("")))?, "fooo");
+		assert_eq!(remove_smallest_matching_suffix("fooo", &Some(Pattern::from("x")))?, "fooo");
+		assert_eq!(remove_smallest_matching_suffix("fooo", &Some(Pattern::from("o")))?, "foo");
+		assert_eq!(remove_smallest_matching_suffix("fooo", &Some(Pattern::from("o*o")))?, "fo");
+		assert_eq!(remove_smallest_matching_suffix("fooo", &Some(Pattern::from("o*")))?, "foo");
+		assert_eq!(remove_smallest_matching_suffix("fooo", &Some(Pattern::from("fooo")))?, "");
+		assert_eq!(
+			remove_smallest_matching_suffix("rocket🚀🚀🚀", &Some(Pattern::from("🚀")))?,
+			"rocket🚀🚀"
+		);
+		Ok(())
+	}
 
-    #[test]
-    #[expect(clippy::cognitive_complexity)]
-    fn test_matching() -> Result<()> {
-        assert!(Pattern::from("abc").exactly_matches("abc")?);
+	#[test]
+	#[expect(clippy::cognitive_complexity)]
+	fn test_matching() -> Result<()> {
+		assert!(Pattern::from("abc").exactly_matches("abc")?);
 
-        assert!(!Pattern::from("abc").exactly_matches("ABC")?);
-        assert!(!Pattern::from("abc").exactly_matches("xabcx")?);
-        assert!(!Pattern::from("abc").exactly_matches("")?);
-        assert!(!Pattern::from("abc").exactly_matches("abcd")?);
-        assert!(!Pattern::from("abc").exactly_matches("def")?);
+		assert!(!Pattern::from("abc").exactly_matches("ABC")?);
+		assert!(!Pattern::from("abc").exactly_matches("xabcx")?);
+		assert!(!Pattern::from("abc").exactly_matches("")?);
+		assert!(!Pattern::from("abc").exactly_matches("abcd")?);
+		assert!(!Pattern::from("abc").exactly_matches("def")?);
 
-        assert!(Pattern::from("*").exactly_matches("")?);
-        assert!(Pattern::from("*").exactly_matches("abc")?);
-        assert!(Pattern::from("*").exactly_matches(" ")?);
+		assert!(Pattern::from("*").exactly_matches("")?);
+		assert!(Pattern::from("*").exactly_matches("abc")?);
+		assert!(Pattern::from("*").exactly_matches(" ")?);
 
-        assert!(Pattern::from("a*").exactly_matches("a")?);
-        assert!(Pattern::from("a*").exactly_matches("ab")?);
-        assert!(Pattern::from("a*").exactly_matches("a ")?);
+		assert!(Pattern::from("a*").exactly_matches("a")?);
+		assert!(Pattern::from("a*").exactly_matches("ab")?);
+		assert!(Pattern::from("a*").exactly_matches("a ")?);
 
-        assert!(!Pattern::from("a*").exactly_matches("A")?);
-        assert!(!Pattern::from("a*").exactly_matches("")?);
-        assert!(!Pattern::from("a*").exactly_matches("bc")?);
-        assert!(!Pattern::from("a*").exactly_matches("xax")?);
-        assert!(!Pattern::from("a*").exactly_matches(" a")?);
+		assert!(!Pattern::from("a*").exactly_matches("A")?);
+		assert!(!Pattern::from("a*").exactly_matches("")?);
+		assert!(!Pattern::from("a*").exactly_matches("bc")?);
+		assert!(!Pattern::from("a*").exactly_matches("xax")?);
+		assert!(!Pattern::from("a*").exactly_matches(" a")?);
 
-        assert!(Pattern::from("*a").exactly_matches("a")?);
-        assert!(Pattern::from("*a").exactly_matches("ba")?);
-        assert!(Pattern::from("*a").exactly_matches("aa")?);
-        assert!(Pattern::from("*a").exactly_matches(" a")?);
+		assert!(Pattern::from("*a").exactly_matches("a")?);
+		assert!(Pattern::from("*a").exactly_matches("ba")?);
+		assert!(Pattern::from("*a").exactly_matches("aa")?);
+		assert!(Pattern::from("*a").exactly_matches(" a")?);
 
-        assert!(!Pattern::from("*a").exactly_matches("BA")?);
-        assert!(!Pattern::from("*a").exactly_matches("")?);
-        assert!(!Pattern::from("*a").exactly_matches("ab")?);
-        assert!(!Pattern::from("*a").exactly_matches("xax")?);
+		assert!(!Pattern::from("*a").exactly_matches("BA")?);
+		assert!(!Pattern::from("*a").exactly_matches("")?);
+		assert!(!Pattern::from("*a").exactly_matches("ab")?);
+		assert!(!Pattern::from("*a").exactly_matches("xax")?);
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    fn make_extglob(s: &str) -> Pattern {
-        let pattern = Pattern::from(s).set_extended_globbing(true);
-        let regex_str = pattern.to_regex_str(true, true).unwrap();
-        eprintln!("pattern: '{s}' => regex: '{regex_str}'");
+	fn make_extglob(s: &str) -> Pattern {
+		let pattern = Pattern::from(s).set_extended_globbing(true);
+		let regex_str = pattern.to_regex_str(true, true).unwrap();
+		eprintln!("pattern: '{s}' => regex: '{regex_str}'");
 
-        pattern
-    }
+		pattern
+	}
 
-    #[test]
-    fn test_extglob_or_matching() -> Result<()> {
-        assert!(make_extglob("@(a|b)").exactly_matches("a")?);
-        assert!(make_extglob("@(a|b)").exactly_matches("b")?);
+	#[test]
+	fn test_extglob_or_matching() -> Result<()> {
+		assert!(make_extglob("@(a|b)").exactly_matches("a")?);
+		assert!(make_extglob("@(a|b)").exactly_matches("b")?);
 
-        assert!(!make_extglob("@(a|b)").exactly_matches("")?);
-        assert!(!make_extglob("@(a|b)").exactly_matches("c")?);
-        assert!(!make_extglob("@(a|b)").exactly_matches("ab")?);
+		assert!(!make_extglob("@(a|b)").exactly_matches("")?);
+		assert!(!make_extglob("@(a|b)").exactly_matches("c")?);
+		assert!(!make_extglob("@(a|b)").exactly_matches("ab")?);
 
-        assert!(!make_extglob("@(a|b)").exactly_matches("")?);
-        assert!(make_extglob("@(a*b|b)").exactly_matches("ab")?);
-        assert!(make_extglob("@(a*b|b)").exactly_matches("axb")?);
-        assert!(make_extglob("@(a*b|b)").exactly_matches("b")?);
+		assert!(!make_extglob("@(a|b)").exactly_matches("")?);
+		assert!(make_extglob("@(a*b|b)").exactly_matches("ab")?);
+		assert!(make_extglob("@(a*b|b)").exactly_matches("axb")?);
+		assert!(make_extglob("@(a*b|b)").exactly_matches("b")?);
 
-        assert!(!make_extglob("@(a*b|b)").exactly_matches("a")?);
+		assert!(!make_extglob("@(a*b|b)").exactly_matches("a")?);
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    #[test]
-    fn test_extglob_not_matching() -> Result<()> {
-        // Basic cases.
-        assert!(make_extglob("!(a)").exactly_matches("")?);
-        assert!(make_extglob("!(a)").exactly_matches(" ")?);
-        assert!(make_extglob("!(a)").exactly_matches("x")?);
-        assert!(make_extglob("!(a)").exactly_matches(" a ")?);
-        assert!(make_extglob("!(a)").exactly_matches("a ")?);
-        assert!(make_extglob("!(a)").exactly_matches("aa")?);
-        assert!(!make_extglob("!(a)").exactly_matches("a")?);
+	#[test]
+	fn test_extglob_not_matching() -> Result<()> {
+		// Basic cases.
+		assert!(make_extglob("!(a)").exactly_matches("")?);
+		assert!(make_extglob("!(a)").exactly_matches(" ")?);
+		assert!(make_extglob("!(a)").exactly_matches("x")?);
+		assert!(make_extglob("!(a)").exactly_matches(" a ")?);
+		assert!(make_extglob("!(a)").exactly_matches("a ")?);
+		assert!(make_extglob("!(a)").exactly_matches("aa")?);
+		assert!(!make_extglob("!(a)").exactly_matches("a")?);
 
-        assert!(make_extglob("a!(a)a").exactly_matches("aa")?);
-        assert!(make_extglob("a!(a)a").exactly_matches("aaaa")?);
-        assert!(make_extglob("a!(a)a").exactly_matches("aba")?);
-        assert!(!make_extglob("a!(a)a").exactly_matches("a")?);
-        assert!(!make_extglob("a!(a)a").exactly_matches("aaa")?);
-        assert!(!make_extglob("a!(a)a").exactly_matches("baaa")?);
+		assert!(make_extglob("a!(a)a").exactly_matches("aa")?);
+		assert!(make_extglob("a!(a)a").exactly_matches("aaaa")?);
+		assert!(make_extglob("a!(a)a").exactly_matches("aba")?);
+		assert!(!make_extglob("a!(a)a").exactly_matches("a")?);
+		assert!(!make_extglob("a!(a)a").exactly_matches("aaa")?);
+		assert!(!make_extglob("a!(a)a").exactly_matches("baaa")?);
 
-        // Alternates.
-        assert!(make_extglob("!(a|b)").exactly_matches("c")?);
-        assert!(make_extglob("!(a|b)").exactly_matches("ab")?);
-        assert!(make_extglob("!(a|b)").exactly_matches("aa")?);
-        assert!(make_extglob("!(a|b)").exactly_matches("bb")?);
-        assert!(!make_extglob("!(a|b)").exactly_matches("a")?);
-        assert!(!make_extglob("!(a|b)").exactly_matches("b")?);
+		// Alternates.
+		assert!(make_extglob("!(a|b)").exactly_matches("c")?);
+		assert!(make_extglob("!(a|b)").exactly_matches("ab")?);
+		assert!(make_extglob("!(a|b)").exactly_matches("aa")?);
+		assert!(make_extglob("!(a|b)").exactly_matches("bb")?);
+		assert!(!make_extglob("!(a|b)").exactly_matches("a")?);
+		assert!(!make_extglob("!(a|b)").exactly_matches("b")?);
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    #[test]
-    fn test_extglob_advanced_not_matching() -> Result<()> {
-        assert!(make_extglob("!(a*)").exactly_matches("b")?);
-        assert!(make_extglob("!(a*)").exactly_matches("")?);
-        assert!(!make_extglob("!(a*)").exactly_matches("a")?);
-        assert!(!make_extglob("!(a*)").exactly_matches("abc")?);
-        assert!(!make_extglob("!(a*)").exactly_matches("aabc")?);
+	#[test]
+	fn test_extglob_advanced_not_matching() -> Result<()> {
+		assert!(make_extglob("!(a*)").exactly_matches("b")?);
+		assert!(make_extglob("!(a*)").exactly_matches("")?);
+		assert!(!make_extglob("!(a*)").exactly_matches("a")?);
+		assert!(!make_extglob("!(a*)").exactly_matches("abc")?);
+		assert!(!make_extglob("!(a*)").exactly_matches("aabc")?);
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    #[test]
-    fn test_extglob_not_degenerate_matching() -> Result<()> {
-        // Degenerate case.
-        assert!(make_extglob("!()").exactly_matches("a")?);
-        assert!(!make_extglob("!()").exactly_matches("")?);
+	#[test]
+	fn test_extglob_not_degenerate_matching() -> Result<()> {
+		// Degenerate case.
+		assert!(make_extglob("!()").exactly_matches("a")?);
+		assert!(!make_extglob("!()").exactly_matches("")?);
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    #[test]
-    fn test_extglob_zero_or_more_matching() -> Result<()> {
-        assert!(make_extglob("x*(a)x").exactly_matches("xx")?);
-        assert!(make_extglob("x*(a)x").exactly_matches("xax")?);
-        assert!(make_extglob("x*(a)x").exactly_matches("xaax")?);
+	#[test]
+	fn test_extglob_zero_or_more_matching() -> Result<()> {
+		assert!(make_extglob("x*(a)x").exactly_matches("xx")?);
+		assert!(make_extglob("x*(a)x").exactly_matches("xax")?);
+		assert!(make_extglob("x*(a)x").exactly_matches("xaax")?);
 
-        assert!(!make_extglob("x*(a)x").exactly_matches("x")?);
-        assert!(!make_extglob("x*(a)x").exactly_matches("xa")?);
-        assert!(!make_extglob("x*(a)x").exactly_matches("xxx")?);
+		assert!(!make_extglob("x*(a)x").exactly_matches("x")?);
+		assert!(!make_extglob("x*(a)x").exactly_matches("xa")?);
+		assert!(!make_extglob("x*(a)x").exactly_matches("xxx")?);
 
-        assert!(make_extglob("*(a|b)").exactly_matches("")?);
-        assert!(make_extglob("*(a|b)").exactly_matches("a")?);
-        assert!(make_extglob("*(a|b)").exactly_matches("b")?);
-        assert!(make_extglob("*(a|b)").exactly_matches("aba")?);
-        assert!(make_extglob("*(a|b)").exactly_matches("aaa")?);
+		assert!(make_extglob("*(a|b)").exactly_matches("")?);
+		assert!(make_extglob("*(a|b)").exactly_matches("a")?);
+		assert!(make_extglob("*(a|b)").exactly_matches("b")?);
+		assert!(make_extglob("*(a|b)").exactly_matches("aba")?);
+		assert!(make_extglob("*(a|b)").exactly_matches("aaa")?);
 
-        assert!(!make_extglob("*(a|b)").exactly_matches("c")?);
-        assert!(!make_extglob("*(a|b)").exactly_matches("ca")?);
+		assert!(!make_extglob("*(a|b)").exactly_matches("c")?);
+		assert!(!make_extglob("*(a|b)").exactly_matches("ca")?);
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    #[test]
-    fn test_extglob_one_or_more_matching() -> Result<()> {
-        fn make_extglob(s: &str) -> Pattern {
-            Pattern::from(s).set_extended_globbing(true)
-        }
+	#[test]
+	fn test_extglob_one_or_more_matching() -> Result<()> {
+		fn make_extglob(s: &str) -> Pattern {
+			Pattern::from(s).set_extended_globbing(true)
+		}
 
-        assert!(make_extglob("x+(a)x").exactly_matches("xax")?);
-        assert!(make_extglob("x+(a)x").exactly_matches("xaax")?);
+		assert!(make_extglob("x+(a)x").exactly_matches("xax")?);
+		assert!(make_extglob("x+(a)x").exactly_matches("xaax")?);
 
-        assert!(!make_extglob("x+(a)x").exactly_matches("xx")?);
-        assert!(!make_extglob("x+(a)x").exactly_matches("x")?);
-        assert!(!make_extglob("x+(a)x").exactly_matches("xa")?);
-        assert!(!make_extglob("x+(a)x").exactly_matches("xxx")?);
+		assert!(!make_extglob("x+(a)x").exactly_matches("xx")?);
+		assert!(!make_extglob("x+(a)x").exactly_matches("x")?);
+		assert!(!make_extglob("x+(a)x").exactly_matches("xa")?);
+		assert!(!make_extglob("x+(a)x").exactly_matches("xxx")?);
 
-        assert!(make_extglob("+(a|b)").exactly_matches("a")?);
-        assert!(make_extglob("+(a|b)").exactly_matches("b")?);
-        assert!(make_extglob("+(a|b)").exactly_matches("aba")?);
-        assert!(make_extglob("+(a|b)").exactly_matches("aaa")?);
+		assert!(make_extglob("+(a|b)").exactly_matches("a")?);
+		assert!(make_extglob("+(a|b)").exactly_matches("b")?);
+		assert!(make_extglob("+(a|b)").exactly_matches("aba")?);
+		assert!(make_extglob("+(a|b)").exactly_matches("aaa")?);
 
-        assert!(!make_extglob("+(a|b)").exactly_matches("")?);
-        assert!(!make_extglob("+(a|b)").exactly_matches("c")?);
-        assert!(!make_extglob("+(a|b)").exactly_matches("ca")?);
+		assert!(!make_extglob("+(a|b)").exactly_matches("")?);
+		assert!(!make_extglob("+(a|b)").exactly_matches("c")?);
+		assert!(!make_extglob("+(a|b)").exactly_matches("ca")?);
 
-        assert!(make_extglob("+(x+(ab)y)").exactly_matches("xaby")?);
-        assert!(make_extglob("+(x+(ab)y)").exactly_matches("xababy")?);
-        assert!(make_extglob("+(x+(ab)y)").exactly_matches("xabababy")?);
-        assert!(make_extglob("+(x+(ab)y)").exactly_matches("xabababyxabababyxabababy")?);
+		assert!(make_extglob("+(x+(ab)y)").exactly_matches("xaby")?);
+		assert!(make_extglob("+(x+(ab)y)").exactly_matches("xababy")?);
+		assert!(make_extglob("+(x+(ab)y)").exactly_matches("xabababy")?);
+		assert!(make_extglob("+(x+(ab)y)").exactly_matches("xabababyxabababyxabababy")?);
 
-        assert!(!make_extglob("+(x+(ab)y)").exactly_matches("xy")?);
-        assert!(!make_extglob("+(x+(ab)y)").exactly_matches("xay")?);
-        assert!(!make_extglob("+(x+(ab)y)").exactly_matches("xyxy")?);
+		assert!(!make_extglob("+(x+(ab)y)").exactly_matches("xy")?);
+		assert!(!make_extglob("+(x+(ab)y)").exactly_matches("xay")?);
+		assert!(!make_extglob("+(x+(ab)y)").exactly_matches("xyxy")?);
 
-        Ok(())
-    }
+		Ok(())
+	}
 }

--- a/crates/brush-core-vendored/src/processes.rs
+++ b/crates/brush-core-vendored/src/processes.rs
@@ -6,132 +6,132 @@ use crate::{error, sys};
 
 /// Tracks a child process being awaited.
 pub struct ChildProcess {
-    /// If available, the process ID of the child.
-    pid: Option<sys::process::ProcessId>,
-    /// Child process handle kept alive for cancellation/termination.
-    child: sys::process::Child,
-    /// Tracks whether this process has already been reaped.
-    reaped: bool,
+	/// If available, the process ID of the child.
+	pid: Option<sys::process::ProcessId>,
+	/// Child process handle kept alive for cancellation/termination.
+	child: sys::process::Child,
+	/// Tracks whether this process has already been reaped.
+	reaped: bool,
 }
 
 impl ChildProcess {
-    /// Wraps a child process and its future.
-    pub fn new(pid: Option<sys::process::ProcessId>, child: sys::process::Child) -> Self {
-        Self { pid, child, reaped: false }
-    }
+	/// Wraps a child process and its future.
+	pub fn new(pid: Option<sys::process::ProcessId>, child: sys::process::Child) -> Self {
+		Self { pid, child, reaped: false }
+	}
 
-    /// Returns the process's ID.
-    pub const fn pid(&self) -> Option<sys::process::ProcessId> {
-        self.pid
-    }
+	/// Returns the process's ID.
+	pub const fn pid(&self) -> Option<sys::process::ProcessId> {
+		self.pid
+	}
 
-    /// Waits for the process to exit.
-    ///
-    /// If a cancellation token is provided and triggered, the process will be killed.
-    pub async fn wait(
-        &mut self,
-        cancel_token: Option<CancellationToken>,
-    ) -> Result<ProcessWaitResult, error::Error> {
-        #[allow(unused_mut, reason = "only mutated on some platforms")]
-        let mut sigtstp = sys::signal::tstp_signal_listener()?;
-        #[allow(unused_mut, reason = "only mutated on some platforms")]
-        let mut sigchld = sys::signal::chld_signal_listener()?;
+	/// Waits for the process to exit.
+	///
+	/// If a cancellation token is provided and triggered, the process will be killed.
+	pub async fn wait(
+		&mut self,
+		cancel_token: Option<CancellationToken>,
+	) -> Result<ProcessWaitResult, error::Error> {
+		#[allow(unused_mut, reason = "only mutated on some platforms")]
+		let mut sigtstp = sys::signal::tstp_signal_listener()?;
+		#[allow(unused_mut, reason = "only mutated on some platforms")]
+		let mut sigchld = sys::signal::chld_signal_listener()?;
 
-        let cancelled = async {
-            match &cancel_token {
-                Some(token) => token.cancelled().await,
-                None => std::future::pending().await,
-            }
-        };
-        tokio::pin!(cancelled);
+		let cancelled = async {
+			match &cancel_token {
+				Some(token) => token.cancelled().await,
+				None => std::future::pending().await,
+			}
+		};
+		tokio::pin!(cancelled);
 
-        #[allow(clippy::ignored_unit_patterns)]
-        loop {
-            let status = {
-                let wait_future = self.child.wait();
-                tokio::pin!(wait_future);
-                tokio::select! {
-                    status = &mut wait_future => Some(status),
-                    _ = &mut cancelled => None,
-                    _ = sigtstp.recv() => return Ok(ProcessWaitResult::Stopped),
-                    _ = sigchld.recv() => {
-                        if sys::signal::poll_for_stopped_children()? {
-                            return Ok(ProcessWaitResult::Stopped);
-                        }
-                        continue;
-                    },
-                    _ = sys::signal::await_ctrl_c() => {
-                        // SIGINT got thrown. Handle it and continue looping. The child should
-                        // have received it as well, and either handled it or ended up getting
-                        // terminated (in which case we'll see the child exit).
-                        continue;
-                    },
-                }
-            };
+		#[allow(clippy::ignored_unit_patterns)]
+		loop {
+			let status = {
+				let wait_future = self.child.wait();
+				tokio::pin!(wait_future);
+				tokio::select! {
+					 status = &mut wait_future => Some(status),
+					 _ = &mut cancelled => None,
+					 _ = sigtstp.recv() => return Ok(ProcessWaitResult::Stopped),
+					 _ = sigchld.recv() => {
+						  if sys::signal::poll_for_stopped_children()? {
+								return Ok(ProcessWaitResult::Stopped);
+						  }
+						  continue;
+					 },
+					 _ = sys::signal::await_ctrl_c() => {
+						  // SIGINT got thrown. Handle it and continue looping. The child should
+						  // have received it as well, and either handled it or ended up getting
+						  // terminated (in which case we'll see the child exit).
+						  continue;
+					 },
+				}
+			};
 
-            return match status {
-                Some(status) => {
-                    let status = status?;
-                    self.reaped = true;
-                    Ok(ProcessWaitResult::Completed(output_from_status(status)))
-                }
-                None => {
-                    if self.child.kill().await.is_ok() {
-                        self.reaped = true;
-                    } else if let Ok(Some(_)) = self.child.try_wait() {
-                        self.reaped = true;
-                    }
-                    Ok(ProcessWaitResult::Cancelled)
-                }
-            };
-        }
-    }
+			return match status {
+				Some(status) => {
+					let status = status?;
+					self.reaped = true;
+					Ok(ProcessWaitResult::Completed(output_from_status(status)))
+				},
+				None => {
+					if self.child.kill().await.is_ok() {
+						self.reaped = true;
+					} else if let Ok(Some(_)) = self.child.try_wait() {
+						self.reaped = true;
+					}
+					Ok(ProcessWaitResult::Cancelled)
+				},
+			};
+		}
+	}
 
-    /// Sends a kill signal and attempts a synchronous reap if still running.
-    fn kill(&mut self) {
-        if self.reaped {
-            return;
-        }
+	/// Sends a kill signal and attempts a synchronous reap if still running.
+	fn kill(&mut self) {
+		if self.reaped {
+			return;
+		}
 
-        if let Ok(Some(_)) = self.child.try_wait() {
-            self.reaped = true;
-            return;
-        }
-        let _ = self.child.start_kill();
-        if let Ok(Some(_)) = self.child.try_wait() {
-            self.reaped = true;
-    }
-    }
+		if let Ok(Some(_)) = self.child.try_wait() {
+			self.reaped = true;
+			return;
+		}
+		let _ = self.child.start_kill();
+		if let Ok(Some(_)) = self.child.try_wait() {
+			self.reaped = true;
+		}
+	}
 
-    pub(crate) fn poll(&mut self) -> Option<Result<std::process::Output, error::Error>> {
-        match self.child.try_wait() {
-            Ok(Some(status)) => {
-                self.reaped = true;
-                Some(Ok(output_from_status(status)))
-            }
-            Ok(None) => None,
-            Err(err) => Some(Err(err.into())),
-        }
-    }
+	pub(crate) fn poll(&mut self) -> Option<Result<std::process::Output, error::Error>> {
+		match self.child.try_wait() {
+			Ok(Some(status)) => {
+				self.reaped = true;
+				Some(Ok(output_from_status(status)))
+			},
+			Ok(None) => None,
+			Err(err) => Some(Err(err.into())),
+		}
+	}
 }
 
 impl Drop for ChildProcess {
-    fn drop(&mut self) {
-        // Ensure we don't leak zombie processes.
-        self.kill();
-    }
+	fn drop(&mut self) {
+		// Ensure we don't leak zombie processes.
+		self.kill();
+	}
 }
 
 fn output_from_status(status: std::process::ExitStatus) -> std::process::Output {
-    std::process::Output { status, stdout: Vec::new(), stderr: Vec::new() }
+	std::process::Output { status, stdout: Vec::new(), stderr: Vec::new() }
 }
 
 /// Represents the result of waiting for an executing process.
 pub enum ProcessWaitResult {
-    /// The process completed.
-    Completed(std::process::Output),
-    /// The process stopped and has not yet completed.
-    Stopped,
-    /// The process was killed due to cancellation.
-    Cancelled,
+	/// The process completed.
+	Completed(std::process::Output),
+	/// The process stopped and has not yet completed.
+	Stopped,
+	/// The process was killed due to cancellation.
+	Cancelled,
 }

--- a/crates/brush-core-vendored/src/prompt.rs
+++ b/crates/brush-core-vendored/src/prompt.rs
@@ -1,7 +1,7 @@
 use crate::{
-    ExecutionParameters, error, expansion,
-    shell::Shell,
-    sys::{self, users},
+	ExecutionParameters, error, expansion,
+	shell::Shell,
+	sys::{self, users},
 };
 use std::path::Path;
 
@@ -10,241 +10,227 @@ const VERSION_MINOR: &str = env!("CARGO_PKG_VERSION_MINOR");
 const VERSION_PATCH: &str = env!("CARGO_PKG_VERSION_PATCH");
 
 pub(crate) async fn expand_prompt(
-    shell: &mut Shell,
-    params: &ExecutionParameters,
-    spec: String,
+	shell: &mut Shell,
+	params: &ExecutionParameters,
+	spec: String,
 ) -> Result<String, error::Error> {
-    // Parse the prompt spec into its pieces.
-    let prompt_pieces = parse_prompt(spec)?;
+	// Parse the prompt spec into its pieces.
+	let prompt_pieces = parse_prompt(spec)?;
 
-    // Now, render each piece.
-    let mut formatted_prompt = String::new();
-    for piece in prompt_pieces {
-        let needs_escaping = matches!(
-            piece,
-            brush_parser::prompt::PromptPiece::EscapedSequence(_)
-                | brush_parser::prompt::PromptPiece::DollarOrPound
-        );
+	// Now, render each piece.
+	let mut formatted_prompt = String::new();
+	for piece in prompt_pieces {
+		let needs_escaping = matches!(
+			piece,
+			brush_parser::prompt::PromptPiece::EscapedSequence(_)
+				| brush_parser::prompt::PromptPiece::DollarOrPound
+		);
 
-        let formatted_piece = format_prompt_piece(shell, piece)?;
+		let formatted_piece = format_prompt_piece(shell, piece)?;
 
-        if shell.options.expand_prompt_strings && needs_escaping {
-            formatted_prompt.push('\\');
-        }
+		if shell.options.expand_prompt_strings && needs_escaping {
+			formatted_prompt.push('\\');
+		}
 
-        formatted_prompt.push_str(&formatted_piece);
-    }
+		formatted_prompt.push_str(&formatted_piece);
+	}
 
-    if shell.options.expand_prompt_strings {
-        // Now expand any remaining escape sequences.
-        formatted_prompt = expansion::basic_expand_str(shell, params, &formatted_prompt).await?;
-    }
+	if shell.options.expand_prompt_strings {
+		// Now expand any remaining escape sequences.
+		formatted_prompt = expansion::basic_expand_str(shell, params, &formatted_prompt).await?;
+	}
 
-    Ok(formatted_prompt)
+	Ok(formatted_prompt)
 }
 
 #[cached::proc_macro::cached(size = 64, result = true)]
 fn parse_prompt(
-    spec: String,
+	spec: String,
 ) -> Result<Vec<brush_parser::prompt::PromptPiece>, brush_parser::WordParseError> {
-    brush_parser::prompt::parse(spec.as_str())
+	brush_parser::prompt::parse(spec.as_str())
 }
 
 fn format_prompt_piece(
-    shell: &Shell,
-    piece: brush_parser::prompt::PromptPiece,
+	shell: &Shell,
+	piece: brush_parser::prompt::PromptPiece,
 ) -> Result<String, error::Error> {
-    let formatted = match piece {
-        brush_parser::prompt::PromptPiece::EscapedSequence(s) => s,
-        brush_parser::prompt::PromptPiece::Literal(l) => l,
-        brush_parser::prompt::PromptPiece::AsciiCharacter(c) => {
-            char::from_u32(c).map_or_else(String::new, |c| c.to_string())
-        }
-        brush_parser::prompt::PromptPiece::Backslash => "\\".to_owned(),
-        brush_parser::prompt::PromptPiece::BellCharacter => "\x07".to_owned(),
-        brush_parser::prompt::PromptPiece::CarriageReturn => "\r".to_owned(),
-        brush_parser::prompt::PromptPiece::CurrentCommandNumber => {
-            return error::unimp("prompt: current command number");
-        }
-        brush_parser::prompt::PromptPiece::CurrentHistoryNumber => {
-            return error::unimp("prompt: current history number");
-        }
-        brush_parser::prompt::PromptPiece::CurrentUser => users::get_current_username()?,
-        brush_parser::prompt::PromptPiece::CurrentWorkingDirectory {
-            tilde_replaced,
-            basename,
-        } => format_current_working_directory(shell, tilde_replaced, basename),
-        brush_parser::prompt::PromptPiece::Date(format) => {
-            format_date(&chrono::Local::now(), &format)
-        }
-        brush_parser::prompt::PromptPiece::DollarOrPound => {
-            if users::is_root() {
-                "#".to_owned()
-            } else {
-                "$".to_owned()
-            }
-        }
-        brush_parser::prompt::PromptPiece::EndNonPrintingSequence => String::new(),
-        brush_parser::prompt::PromptPiece::EscapeCharacter => "\x1b".to_owned(),
-        brush_parser::prompt::PromptPiece::Hostname {
-            only_up_to_first_dot,
-        } => {
-            let hn = sys::network::get_hostname()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string();
-            if only_up_to_first_dot {
-                if let Some((first, _)) = hn.split_once('.') {
-                    return Ok(first.to_owned());
-                }
-            }
-            hn
-        }
-        brush_parser::prompt::PromptPiece::Newline => "\n".to_owned(),
-        brush_parser::prompt::PromptPiece::NumberOfManagedJobs => shell.jobs.jobs.len().to_string(),
-        brush_parser::prompt::PromptPiece::ShellBaseName => {
-            if let Some(shell_name) = &shell.shell_name {
-                Path::new(shell_name)
-                    .file_name()
-                    .map(|name| name.to_string_lossy().to_string())
-                    .unwrap_or_default()
-            } else {
-                String::new()
-            }
-        }
-        brush_parser::prompt::PromptPiece::ShellRelease => {
-            std::format!("{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_PATCH}")
-        }
-        brush_parser::prompt::PromptPiece::ShellVersion => {
-            std::format!("{VERSION_MAJOR}.{VERSION_MINOR}")
-        }
-        brush_parser::prompt::PromptPiece::StartNonPrintingSequence => String::new(),
-        brush_parser::prompt::PromptPiece::TerminalDeviceBaseName => {
-            return error::unimp("prompt: terminal device base name");
-        }
-        brush_parser::prompt::PromptPiece::Time(time_fmt) => {
-            format_time(&chrono::Local::now(), &time_fmt)
-        }
-    };
+	let formatted = match piece {
+		brush_parser::prompt::PromptPiece::EscapedSequence(s) => s,
+		brush_parser::prompt::PromptPiece::Literal(l) => l,
+		brush_parser::prompt::PromptPiece::AsciiCharacter(c) => {
+			char::from_u32(c).map_or_else(String::new, |c| c.to_string())
+		},
+		brush_parser::prompt::PromptPiece::Backslash => "\\".to_owned(),
+		brush_parser::prompt::PromptPiece::BellCharacter => "\x07".to_owned(),
+		brush_parser::prompt::PromptPiece::CarriageReturn => "\r".to_owned(),
+		brush_parser::prompt::PromptPiece::CurrentCommandNumber => {
+			return error::unimp("prompt: current command number");
+		},
+		brush_parser::prompt::PromptPiece::CurrentHistoryNumber => {
+			return error::unimp("prompt: current history number");
+		},
+		brush_parser::prompt::PromptPiece::CurrentUser => users::get_current_username()?,
+		brush_parser::prompt::PromptPiece::CurrentWorkingDirectory { tilde_replaced, basename } => {
+			format_current_working_directory(shell, tilde_replaced, basename)
+		},
+		brush_parser::prompt::PromptPiece::Date(format) => {
+			format_date(&chrono::Local::now(), &format)
+		},
+		brush_parser::prompt::PromptPiece::DollarOrPound => {
+			if users::is_root() {
+				"#".to_owned()
+			} else {
+				"$".to_owned()
+			}
+		},
+		brush_parser::prompt::PromptPiece::EndNonPrintingSequence => String::new(),
+		brush_parser::prompt::PromptPiece::EscapeCharacter => "\x1b".to_owned(),
+		brush_parser::prompt::PromptPiece::Hostname { only_up_to_first_dot } => {
+			let hn = sys::network::get_hostname()
+				.unwrap_or_default()
+				.to_string_lossy()
+				.to_string();
+			if only_up_to_first_dot {
+				if let Some((first, _)) = hn.split_once('.') {
+					return Ok(first.to_owned());
+				}
+			}
+			hn
+		},
+		brush_parser::prompt::PromptPiece::Newline => "\n".to_owned(),
+		brush_parser::prompt::PromptPiece::NumberOfManagedJobs => shell.jobs.jobs.len().to_string(),
+		brush_parser::prompt::PromptPiece::ShellBaseName => {
+			if let Some(shell_name) = &shell.shell_name {
+				Path::new(shell_name)
+					.file_name()
+					.map(|name| name.to_string_lossy().to_string())
+					.unwrap_or_default()
+			} else {
+				String::new()
+			}
+		},
+		brush_parser::prompt::PromptPiece::ShellRelease => {
+			std::format!("{VERSION_MAJOR}.{VERSION_MINOR}.{VERSION_PATCH}")
+		},
+		brush_parser::prompt::PromptPiece::ShellVersion => {
+			std::format!("{VERSION_MAJOR}.{VERSION_MINOR}")
+		},
+		brush_parser::prompt::PromptPiece::StartNonPrintingSequence => String::new(),
+		brush_parser::prompt::PromptPiece::TerminalDeviceBaseName => {
+			return error::unimp("prompt: terminal device base name");
+		},
+		brush_parser::prompt::PromptPiece::Time(time_fmt) => {
+			format_time(&chrono::Local::now(), &time_fmt)
+		},
+	};
 
-    Ok(formatted)
+	Ok(formatted)
 }
 
 fn format_current_working_directory(shell: &Shell, tilde_replaced: bool, basename: bool) -> String {
-    let mut working_dir_str = shell.working_dir().to_string_lossy().to_string();
+	let mut working_dir_str = shell.working_dir().to_string_lossy().to_string();
 
-    if tilde_replaced {
-        working_dir_str = shell.tilde_shorten(working_dir_str);
-    }
+	if tilde_replaced {
+		working_dir_str = shell.tilde_shorten(working_dir_str);
+	}
 
-    if basename {
-        if let Some(filename) = Path::new(&working_dir_str).file_name() {
-            working_dir_str = filename.to_string_lossy().to_string();
-        }
-    }
+	if basename {
+		if let Some(filename) = Path::new(&working_dir_str).file_name() {
+			working_dir_str = filename.to_string_lossy().to_string();
+		}
+	}
 
-    if cfg!(windows) {
-        working_dir_str = working_dir_str.replace('\\', "/");
-    }
+	if cfg!(windows) {
+		working_dir_str = working_dir_str.replace('\\', "/");
+	}
 
-    working_dir_str
+	working_dir_str
 }
 
 fn format_time<Tz: chrono::TimeZone>(
-    datetime: &chrono::DateTime<Tz>,
-    format: &brush_parser::prompt::PromptTimeFormat,
+	datetime: &chrono::DateTime<Tz>,
+	format: &brush_parser::prompt::PromptTimeFormat,
 ) -> String
 where
-    Tz::Offset: std::fmt::Display,
+	Tz::Offset: std::fmt::Display,
 {
-    let formatted = match format {
-        brush_parser::prompt::PromptTimeFormat::TwelveHourAM => datetime.format("%I:%M %p"),
-        brush_parser::prompt::PromptTimeFormat::TwelveHourHHMMSS => datetime.format("%I:%M:%S"),
-        brush_parser::prompt::PromptTimeFormat::TwentyFourHourHHMM => datetime.format("%H:%M"),
-        brush_parser::prompt::PromptTimeFormat::TwentyFourHourHHMMSS => datetime.format("%H:%M:%S"),
-    };
+	let formatted = match format {
+		brush_parser::prompt::PromptTimeFormat::TwelveHourAM => datetime.format("%I:%M %p"),
+		brush_parser::prompt::PromptTimeFormat::TwelveHourHHMMSS => datetime.format("%I:%M:%S"),
+		brush_parser::prompt::PromptTimeFormat::TwentyFourHourHHMM => datetime.format("%H:%M"),
+		brush_parser::prompt::PromptTimeFormat::TwentyFourHourHHMMSS => datetime.format("%H:%M:%S"),
+	};
 
-    formatted.to_string()
+	formatted.to_string()
 }
 
 fn format_date<Tz: chrono::TimeZone>(
-    datetime: &chrono::DateTime<Tz>,
-    format: &brush_parser::prompt::PromptDateFormat,
+	datetime: &chrono::DateTime<Tz>,
+	format: &brush_parser::prompt::PromptDateFormat,
 ) -> String
 where
-    Tz::Offset: std::fmt::Display,
+	Tz::Offset: std::fmt::Display,
 {
-    match format {
-        brush_parser::prompt::PromptDateFormat::WeekdayMonthDate => {
-            datetime.format("%a %b %d").to_string()
-        }
-        brush_parser::prompt::PromptDateFormat::Custom(fmt) => {
-            let fmt_items = chrono::format::StrftimeItems::new(fmt);
-            datetime.format_with_items(fmt_items).to_string()
-        }
-    }
+	match format {
+		brush_parser::prompt::PromptDateFormat::WeekdayMonthDate => {
+			datetime.format("%a %b %d").to_string()
+		},
+		brush_parser::prompt::PromptDateFormat::Custom(fmt) => {
+			let fmt_items = chrono::format::StrftimeItems::new(fmt);
+			datetime.format_with_items(fmt_items).to_string()
+		},
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_format_time() {
-        // Create a well-known test date/time.
-        let dt = chrono::DateTime::parse_from_rfc3339("2024-12-25T13:34:56.789Z").unwrap();
+	#[test]
+	fn test_format_time() {
+		// Create a well-known test date/time.
+		let dt = chrono::DateTime::parse_from_rfc3339("2024-12-25T13:34:56.789Z").unwrap();
 
-        assert_eq!(
-            format_time(&dt, &brush_parser::prompt::PromptTimeFormat::TwelveHourAM),
-            "01:34 PM"
-        );
+		assert_eq!(
+			format_time(&dt, &brush_parser::prompt::PromptTimeFormat::TwelveHourAM),
+			"01:34 PM"
+		);
 
-        assert_eq!(
-            format_time(
-                &dt,
-                &brush_parser::prompt::PromptTimeFormat::TwentyFourHourHHMMSS
-            ),
-            "13:34:56"
-        );
+		assert_eq!(
+			format_time(&dt, &brush_parser::prompt::PromptTimeFormat::TwentyFourHourHHMMSS),
+			"13:34:56"
+		);
 
-        assert_eq!(
-            format_time(
-                &dt,
-                &brush_parser::prompt::PromptTimeFormat::TwelveHourHHMMSS
-            ),
-            "01:34:56"
-        );
-    }
+		assert_eq!(
+			format_time(&dt, &brush_parser::prompt::PromptTimeFormat::TwelveHourHHMMSS),
+			"01:34:56"
+		);
+	}
 
-    #[test]
-    fn test_format_date() {
-        // Create a well-known test date/time.
-        let dt = chrono::DateTime::parse_from_rfc3339("2024-12-25T12:34:56.789Z").unwrap();
+	#[test]
+	fn test_format_date() {
+		// Create a well-known test date/time.
+		let dt = chrono::DateTime::parse_from_rfc3339("2024-12-25T12:34:56.789Z").unwrap();
 
-        assert_eq!(
-            format_date(
-                &dt,
-                &brush_parser::prompt::PromptDateFormat::WeekdayMonthDate
-            ),
-            "Wed Dec 25"
-        );
+		assert_eq!(
+			format_date(&dt, &brush_parser::prompt::PromptDateFormat::WeekdayMonthDate),
+			"Wed Dec 25"
+		);
 
-        assert_eq!(
-            format_date(
-                &dt,
-                &brush_parser::prompt::PromptDateFormat::Custom(String::from("%Y-%m-%d"))
-            ),
-            "2024-12-25"
-        );
+		assert_eq!(
+			format_date(
+				&dt,
+				&brush_parser::prompt::PromptDateFormat::Custom(String::from("%Y-%m-%d"))
+			),
+			"2024-12-25"
+		);
 
-        assert_eq!(
-            format_date(
-                &dt,
-                &brush_parser::prompt::PromptDateFormat::Custom(String::from(
-                    "%Y-%m-%d %H:%M:%S.%f"
-                ))
-            ),
-            "2024-12-25 12:34:56.789000000"
-        );
-    }
+		assert_eq!(
+			format_date(
+				&dt,
+				&brush_parser::prompt::PromptDateFormat::Custom(String::from("%Y-%m-%d %H:%M:%S.%f"))
+			),
+			"2024-12-25 12:34:56.789000000"
+		);
+	}
 }

--- a/crates/brush-core-vendored/src/regex.rs
+++ b/crates/brush-core-vendored/src/regex.rs
@@ -7,19 +7,19 @@ use crate::error;
 /// Represents a piece of a regular expression.
 #[derive(Clone, Debug)]
 pub(crate) enum RegexPiece {
-    /// A pattern that should be interpreted as a regular expression.
-    Pattern(String),
-    /// A literal string that should be matched exactly.
-    Literal(String),
+	/// A pattern that should be interpreted as a regular expression.
+	Pattern(String),
+	/// A literal string that should be matched exactly.
+	Literal(String),
 }
 
 impl RegexPiece {
-    fn to_regex_str(&self) -> Cow<'_, str> {
-        match self {
-            Self::Pattern(s) => Cow::Borrowed(s.as_str()),
-            Self::Literal(s) => escape_literal_regex_piece(s.as_str()),
-        }
-    }
+	fn to_regex_str(&self) -> Cow<'_, str> {
+		match self {
+			Self::Pattern(s) => Cow::Borrowed(s.as_str()),
+			Self::Literal(s) => escape_literal_regex_piece(s.as_str()),
+		}
+	}
 }
 
 type RegexWord = Vec<RegexPiece>;
@@ -27,171 +27,164 @@ type RegexWord = Vec<RegexPiece>;
 /// Encapsulates a regular expression usable in the shell.
 #[derive(Clone, Debug)]
 pub struct Regex {
-    pieces: RegexWord,
-    case_insensitive: bool,
-    multiline: bool,
+	pieces: RegexWord,
+	case_insensitive: bool,
+	multiline: bool,
 }
 
 impl From<RegexWord> for Regex {
-    fn from(pieces: RegexWord) -> Self {
-        Self {
-            pieces,
-            case_insensitive: false,
-            multiline: false,
-        }
-    }
+	fn from(pieces: RegexWord) -> Self {
+		Self { pieces, case_insensitive: false, multiline: false }
+	}
 }
 
 impl Regex {
-    /// Sets the regular expression's case sensitivity.
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - The new case sensitivity value.
-    pub const fn set_case_insensitive(mut self, value: bool) -> Self {
-        self.case_insensitive = value;
-        self
-    }
+	/// Sets the regular expression's case sensitivity.
+	///
+	/// # Arguments
+	///
+	/// * `value` - The new case sensitivity value.
+	pub const fn set_case_insensitive(mut self, value: bool) -> Self {
+		self.case_insensitive = value;
+		self
+	}
 
-    /// Enables (or disables) multiline support for this pattern.
-    /// This enables matching across lines as well as enables `.`
-    /// to match newline characters.
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - The new multiline value.
-    pub const fn set_multiline(mut self, value: bool) -> Self {
-        self.multiline = value;
-        self
-    }
+	/// Enables (or disables) multiline support for this pattern.
+	/// This enables matching across lines as well as enables `.`
+	/// to match newline characters.
+	///
+	/// # Arguments
+	///
+	/// * `value` - The new multiline value.
+	pub const fn set_multiline(mut self, value: bool) -> Self {
+		self.multiline = value;
+		self
+	}
 
-    /// Computes if the regular expression matches the given string.
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - The string to check for a match.
-    pub fn matches(&self, value: &str) -> Result<Option<Vec<Option<String>>>, error::Error> {
-        let regex_pattern: String = self
-            .pieces
-            .iter()
-            .map(|piece| piece.to_regex_str())
-            .collect();
+	/// Computes if the regular expression matches the given string.
+	///
+	/// # Arguments
+	///
+	/// * `value` - The string to check for a match.
+	pub fn matches(&self, value: &str) -> Result<Option<Vec<Option<String>>>, error::Error> {
+		let regex_pattern: String = self
+			.pieces
+			.iter()
+			.map(|piece| piece.to_regex_str())
+			.collect();
 
-        let re = compile_regex(regex_pattern, self.case_insensitive, self.multiline)?;
+		let re = compile_regex(regex_pattern, self.case_insensitive, self.multiline)?;
 
-        Ok(re.captures(value)?.map(|captures| {
-            captures
-                .iter()
-                .map(|c| c.map(|m| m.as_str().to_owned()))
-                .collect()
-        }))
-    }
+		Ok(re.captures(value)?.map(|captures| {
+			captures
+				.iter()
+				.map(|c| c.map(|m| m.as_str().to_owned()))
+				.collect()
+		}))
+	}
 }
 
 #[cached::proc_macro::cached(size = 64, result = true)]
 pub(crate) fn compile_regex(
-    regex_str: String,
-    case_insensitive: bool,
-    multiline: bool,
+	regex_str: String,
+	case_insensitive: bool,
+	multiline: bool,
 ) -> Result<fancy_regex::Regex, error::Error> {
-    // Handle identified cases where a shell-supported regex isn't supported directly by
-    // `fancy_regex` -- specifically, adding missing escape characters.
-    let mut regex_str = add_missing_escape_chars_to_regex(regex_str.as_str());
+	// Handle identified cases where a shell-supported regex isn't supported directly by
+	// `fancy_regex` -- specifically, adding missing escape characters.
+	let mut regex_str = add_missing_escape_chars_to_regex(regex_str.as_str());
 
-    // Handle multiline enablement.
-    if multiline {
-        // The fancy_regex crate internally seems to have flags that can be used
-        // to enable multiline support, but they're not exposed via its
-        // RegexBuilder. We instead just prefix with the right flags.
-        let updated_str = std::format!("(?ms){regex_str}");
-        regex_str = updated_str.into();
-    }
+	// Handle multiline enablement.
+	if multiline {
+		// The fancy_regex crate internally seems to have flags that can be used
+		// to enable multiline support, but they're not exposed via its
+		// RegexBuilder. We instead just prefix with the right flags.
+		let updated_str = std::format!("(?ms){regex_str}");
+		regex_str = updated_str.into();
+	}
 
-    let mut builder = fancy_regex::RegexBuilder::new(regex_str.as_ref());
-    builder.case_insensitive(case_insensitive);
+	let mut builder = fancy_regex::RegexBuilder::new(regex_str.as_ref());
+	builder.case_insensitive(case_insensitive);
 
-    match builder.build() {
-        Ok(re) => Ok(re),
-        Err(e) => Err(error::ErrorKind::InvalidRegexError(e, regex_str.to_string()).into()),
-    }
+	match builder.build() {
+		Ok(re) => Ok(re),
+		Err(e) => Err(error::ErrorKind::InvalidRegexError(e, regex_str.to_string()).into()),
+	}
 }
 
 fn add_missing_escape_chars_to_regex(s: &str) -> Cow<'_, str> {
-    // We may see a character class with an unescaped '[' (open bracket) character. We need
-    // to escape that character.
-    let mut in_escape = false;
-    let mut in_brackets = false;
-    let mut insertion_positions = vec![];
+	// We may see a character class with an unescaped '[' (open bracket) character. We need
+	// to escape that character.
+	let mut in_escape = false;
+	let mut in_brackets = false;
+	let mut insertion_positions = vec![];
 
-    let mut peekable = s.char_indices().peekable();
-    while let Some((byte_offset, c)) = peekable.next() {
-        let next_is_colon = peekable.peek().is_some_and(|(_, c)| *c == ':');
+	let mut peekable = s.char_indices().peekable();
+	while let Some((byte_offset, c)) = peekable.next() {
+		let next_is_colon = peekable.peek().is_some_and(|(_, c)| *c == ':');
 
-        match c {
-            '[' if !in_escape && !in_brackets => {
-                in_brackets = true;
-            }
-            '[' if !in_escape && in_brackets && !next_is_colon => {
-                // Need to escape.
-                insertion_positions.push(byte_offset);
-            }
-            ']' if !in_escape && in_brackets => {
-                in_brackets = false;
-            }
-            _ => (),
-        }
+		match c {
+			'[' if !in_escape && !in_brackets => {
+				in_brackets = true;
+			},
+			'[' if !in_escape && in_brackets && !next_is_colon => {
+				// Need to escape.
+				insertion_positions.push(byte_offset);
+			},
+			']' if !in_escape && in_brackets => {
+				in_brackets = false;
+			},
+			_ => (),
+		}
 
-        in_escape = !in_escape && c == '\\';
-    }
+		in_escape = !in_escape && c == '\\';
+	}
 
-    if insertion_positions.is_empty() {
-        return s.into();
-    }
+	if insertion_positions.is_empty() {
+		return s.into();
+	}
 
-    let mut updated = s.to_owned();
-    for pos in insertion_positions.iter().rev() {
-        updated.insert(*pos, '\\');
-    }
+	let mut updated = s.to_owned();
+	for pos in insertion_positions.iter().rev() {
+		updated.insert(*pos, '\\');
+	}
 
-    updated.into()
+	updated.into()
 }
 
 fn escape_literal_regex_piece(s: &str) -> Cow<'_, str> {
-    let mut result = String::new();
+	let mut result = String::new();
 
-    for c in s.chars() {
-        match c {
-            c if regex_char_is_special(c) => {
-                result.push('\\');
-                result.push(c);
-            }
-            c => result.push(c),
-        }
-    }
+	for c in s.chars() {
+		match c {
+			c if regex_char_is_special(c) => {
+				result.push('\\');
+				result.push(c);
+			},
+			c => result.push(c),
+		}
+	}
 
-    result.into()
+	result.into()
 }
 
 const fn regex_char_is_special(c: char) -> bool {
-    matches!(
-        c,
-        '\\' | '^' | '$' | '.' | '|' | '?' | '*' | '+' | '(' | ')' | '[' | ']' | '{' | '}'
-    )
+	matches!(c, '\\' | '^' | '$' | '.' | '|' | '?' | '*' | '+' | '(' | ')' | '[' | ']' | '{' | '}')
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_add_missing_escape_chars_to_regex() {
-        // Negative cases -- where we don't need to escape.
-        assert_eq!(add_missing_escape_chars_to_regex("a[b]"), "a[b]");
-        assert_eq!(add_missing_escape_chars_to_regex(r"a\[b\]"), r"a\[b\]");
-        assert_eq!(add_missing_escape_chars_to_regex(r"a[b\[]"), r"a[b\[]");
+	#[test]
+	fn test_add_missing_escape_chars_to_regex() {
+		// Negative cases -- where we don't need to escape.
+		assert_eq!(add_missing_escape_chars_to_regex("a[b]"), "a[b]");
+		assert_eq!(add_missing_escape_chars_to_regex(r"a\[b\]"), r"a\[b\]");
+		assert_eq!(add_missing_escape_chars_to_regex(r"a[b\[]"), r"a[b\[]");
 
-        // Positive case -- where we need to escape.
-        assert_eq!(add_missing_escape_chars_to_regex(r"a[b[]"), r"a[b\[]");
-        assert_eq!(add_missing_escape_chars_to_regex(r"a[[]"), r"a[\[]");
-    }
+		// Positive case -- where we need to escape.
+		assert_eq!(add_missing_escape_chars_to_regex(r"a[b[]"), r"a[b\[]");
+		assert_eq!(add_missing_escape_chars_to_regex(r"a[[]"), r"a[\[]");
+	}
 }

--- a/crates/brush-core-vendored/src/results.rs
+++ b/crates/brush-core-vendored/src/results.rs
@@ -5,267 +5,251 @@ use crate::{error, processes};
 /// Represents the result of executing a command or similar item.
 #[derive(Default)]
 pub struct ExecutionResult {
-    /// The control flow transition to apply after execution.
-    pub next_control_flow: ExecutionControlFlow,
-    /// The exit code resulting from execution.
-    pub exit_code: ExecutionExitCode,
+	/// The control flow transition to apply after execution.
+	pub next_control_flow: ExecutionControlFlow,
+	/// The exit code resulting from execution.
+	pub exit_code: ExecutionExitCode,
 }
 
 impl ExecutionResult {
-    /// Returns a new `ExecutionResult` with the given exit code.
-    ///
-    /// # Arguments
-    ///
-    /// * `exit_code` - The exit code of the command.
-    pub fn new(exit_code: u8) -> Self {
-        Self {
-            exit_code: exit_code.into(),
-            ..Self::default()
-        }
-    }
+	/// Returns a new `ExecutionResult` with the given exit code.
+	///
+	/// # Arguments
+	///
+	/// * `exit_code` - The exit code of the command.
+	pub fn new(exit_code: u8) -> Self {
+		Self { exit_code: exit_code.into(), ..Self::default() }
+	}
 
-    /// Returns a new `ExecutionResult` reflecting a process that was stopped.
-    pub fn stopped() -> Self {
-        // TODO: Decide how to sort this out in a platform-independent way.
-        const SIGTSTP: std::os::raw::c_int = 20;
+	/// Returns a new `ExecutionResult` reflecting a process that was stopped.
+	pub fn stopped() -> Self {
+		// TODO: Decide how to sort this out in a platform-independent way.
+		const SIGTSTP: std::os::raw::c_int = 20;
 
-        #[expect(clippy::cast_possible_truncation)]
-        Self::new(128 + SIGTSTP as u8)
-    }
+		#[expect(clippy::cast_possible_truncation)]
+		Self::new(128 + SIGTSTP as u8)
+	}
 
-    /// Returns a new `ExecutionResult` with an exit code of 0.
-    pub const fn success() -> Self {
-        Self {
-            next_control_flow: ExecutionControlFlow::Normal,
-            exit_code: ExecutionExitCode::Success,
-        }
-    }
+	/// Returns a new `ExecutionResult` with an exit code of 0.
+	pub const fn success() -> Self {
+		Self {
+			next_control_flow: ExecutionControlFlow::Normal,
+			exit_code: ExecutionExitCode::Success,
+		}
+	}
 
-    /// Returns a new `ExecutionResult` with a general error exit code.
-    pub const fn general_error() -> Self {
-        Self {
-            next_control_flow: ExecutionControlFlow::Normal,
-            exit_code: ExecutionExitCode::GeneralError,
-        }
-    }
+	/// Returns a new `ExecutionResult` with a general error exit code.
+	pub const fn general_error() -> Self {
+		Self {
+			next_control_flow: ExecutionControlFlow::Normal,
+			exit_code: ExecutionExitCode::GeneralError,
+		}
+	}
 
-    /// Returns whether the command was successful.
-    pub const fn is_success(&self) -> bool {
-        self.exit_code.is_success()
-    }
+	/// Returns whether the command was successful.
+	pub const fn is_success(&self) -> bool {
+		self.exit_code.is_success()
+	}
 
-    /// Returns whether the execution result indicates normal control flow.
-    /// Returns `false` if there is any control flow transition requested.
-    pub const fn is_normal_flow(&self) -> bool {
-        matches!(self.next_control_flow, ExecutionControlFlow::Normal)
-    }
+	/// Returns whether the execution result indicates normal control flow.
+	/// Returns `false` if there is any control flow transition requested.
+	pub const fn is_normal_flow(&self) -> bool {
+		matches!(self.next_control_flow, ExecutionControlFlow::Normal)
+	}
 
-    /// Returns whether the execution result indicates a loop break.
-    pub const fn is_break(&self) -> bool {
-        matches!(
-            self.next_control_flow,
-            ExecutionControlFlow::BreakLoop { .. }
-        )
-    }
+	/// Returns whether the execution result indicates a loop break.
+	pub const fn is_break(&self) -> bool {
+		matches!(self.next_control_flow, ExecutionControlFlow::BreakLoop { .. })
+	}
 
-    /// Returns whether the execution result indicates a loop continue.
-    pub const fn is_continue(&self) -> bool {
-        matches!(
-            self.next_control_flow,
-            ExecutionControlFlow::ContinueLoop { .. }
-        )
-    }
+	/// Returns whether the execution result indicates a loop continue.
+	pub const fn is_continue(&self) -> bool {
+		matches!(self.next_control_flow, ExecutionControlFlow::ContinueLoop { .. })
+	}
 
-    /// Returns whether the execution result indicates an early return
-    /// from a function or script, or an exit from the shell. Returns `false`
-    /// otherwise, including loop breaks or continues.
-    pub const fn is_return_or_exit(&self) -> bool {
-        matches!(
-            self.next_control_flow,
-            ExecutionControlFlow::ReturnFromFunctionOrScript | ExecutionControlFlow::ExitShell
-        )
-    }
+	/// Returns whether the execution result indicates an early return
+	/// from a function or script, or an exit from the shell. Returns `false`
+	/// otherwise, including loop breaks or continues.
+	pub const fn is_return_or_exit(&self) -> bool {
+		matches!(
+			self.next_control_flow,
+			ExecutionControlFlow::ReturnFromFunctionOrScript | ExecutionControlFlow::ExitShell
+		)
+	}
 }
 
 impl From<ExecutionExitCode> for ExecutionResult {
-    fn from(exit_code: ExecutionExitCode) -> Self {
-        Self {
-            next_control_flow: ExecutionControlFlow::Normal,
-            exit_code,
-        }
-    }
+	fn from(exit_code: ExecutionExitCode) -> Self {
+		Self { next_control_flow: ExecutionControlFlow::Normal, exit_code }
+	}
 }
 
 /// Represents an exit code from execution.
 #[derive(Clone, Copy, Default)]
 pub enum ExecutionExitCode {
-    /// Indicates successful execution.
-    #[default]
-    Success,
-    /// Indicates a general error.
-    GeneralError,
-    /// Indicates invalid usage.
-    InvalidUsage,
-    /// Cannot execute the command.
-    CannotExecute,
-    /// Indicates a command or similar item was not found.
-    NotFound,
-    /// Indicates execution was interrupted.
-    Interrupted,
-    /// Indicates unimplemented functionality was encountered.
-    Unimplemented,
-    /// A custom exit code.
-    Custom(u8),
+	/// Indicates successful execution.
+	#[default]
+	Success,
+	/// Indicates a general error.
+	GeneralError,
+	/// Indicates invalid usage.
+	InvalidUsage,
+	/// Cannot execute the command.
+	CannotExecute,
+	/// Indicates a command or similar item was not found.
+	NotFound,
+	/// Indicates execution was interrupted.
+	Interrupted,
+	/// Indicates unimplemented functionality was encountered.
+	Unimplemented,
+	/// A custom exit code.
+	Custom(u8),
 }
 
 impl ExecutionExitCode {
-    /// Returns whether the exit code indicates success.
-    pub const fn is_success(&self) -> bool {
-        matches!(self, Self::Success)
-    }
+	/// Returns whether the exit code indicates success.
+	pub const fn is_success(&self) -> bool {
+		matches!(self, Self::Success)
+	}
 }
 
 impl From<u8> for ExecutionExitCode {
-    fn from(code: u8) -> Self {
-        match code {
-            0 => Self::Success,
-            1 => Self::GeneralError,
-            2 => Self::InvalidUsage,
-            99 => Self::Unimplemented,
-            126 => Self::CannotExecute,
-            127 => Self::NotFound,
-            130 => Self::Interrupted,
-            code => Self::Custom(code),
-        }
-    }
+	fn from(code: u8) -> Self {
+		match code {
+			0 => Self::Success,
+			1 => Self::GeneralError,
+			2 => Self::InvalidUsage,
+			99 => Self::Unimplemented,
+			126 => Self::CannotExecute,
+			127 => Self::NotFound,
+			130 => Self::Interrupted,
+			code => Self::Custom(code),
+		}
+	}
 }
 
 impl From<ExecutionExitCode> for u8 {
-    fn from(code: ExecutionExitCode) -> Self {
-        Self::from(&code)
-    }
+	fn from(code: ExecutionExitCode) -> Self {
+		Self::from(&code)
+	}
 }
 
 impl From<&ExecutionExitCode> for u8 {
-    fn from(code: &ExecutionExitCode) -> Self {
-        match code {
-            ExecutionExitCode::Success => 0,
-            ExecutionExitCode::GeneralError => 1,
-            ExecutionExitCode::InvalidUsage => 2,
-            ExecutionExitCode::Unimplemented => 99,
-            ExecutionExitCode::CannotExecute => 126,
-            ExecutionExitCode::NotFound => 127,
-            ExecutionExitCode::Interrupted => 130,
-            ExecutionExitCode::Custom(code) => *code,
-        }
-    }
+	fn from(code: &ExecutionExitCode) -> Self {
+		match code {
+			ExecutionExitCode::Success => 0,
+			ExecutionExitCode::GeneralError => 1,
+			ExecutionExitCode::InvalidUsage => 2,
+			ExecutionExitCode::Unimplemented => 99,
+			ExecutionExitCode::CannotExecute => 126,
+			ExecutionExitCode::NotFound => 127,
+			ExecutionExitCode::Interrupted => 130,
+			ExecutionExitCode::Custom(code) => *code,
+		}
+	}
 }
 
 /// Represents a control flow transition to apply.
 #[derive(Clone, Copy, Default)]
 pub enum ExecutionControlFlow {
-    /// Continue normal execution.
-    #[default]
-    Normal,
-    /// Break out of an enclosing loop.
-    BreakLoop {
-        /// Identifies which level of nested loops to break out of. 0 indicates the innermost loop,
-        /// 1 indicates the next outer loop, and so on.
-        levels: usize,
-    },
-    /// Continue to the next iteration of an enclosing loop.
-    ContinueLoop {
-        /// Identifies which level of nested loops to continue. 0 indicates the innermost loop,
-        /// 1 indicates the next outer loop, and so on.
-        levels: usize,
-    },
-    /// Return from the current function or script.
-    ReturnFromFunctionOrScript,
-    /// Exit the shell.
-    ExitShell,
+	/// Continue normal execution.
+	#[default]
+	Normal,
+	/// Break out of an enclosing loop.
+	BreakLoop {
+		/// Identifies which level of nested loops to break out of. 0 indicates the innermost loop,
+		/// 1 indicates the next outer loop, and so on.
+		levels: usize,
+	},
+	/// Continue to the next iteration of an enclosing loop.
+	ContinueLoop {
+		/// Identifies which level of nested loops to continue. 0 indicates the innermost loop,
+		/// 1 indicates the next outer loop, and so on.
+		levels: usize,
+	},
+	/// Return from the current function or script.
+	ReturnFromFunctionOrScript,
+	/// Exit the shell.
+	ExitShell,
 }
 
 impl ExecutionControlFlow {
-    /// Attempts to decrement the loop levels for `BreakLoop` or `ContinueLoop`.
-    /// If the levels reach zero, transitions to `Normal`. If the control flow is not
-    /// a loop break or continue, no changes are made.
-    #[must_use]
-    pub const fn try_decrement_loop_levels(&self) -> Self {
-        match self {
-            Self::BreakLoop { levels: 0 } | Self::ContinueLoop { levels: 0 } => Self::Normal,
-            Self::BreakLoop { levels } => Self::BreakLoop {
-                levels: *levels - 1,
-            },
-            Self::ContinueLoop { levels } => Self::ContinueLoop {
-                levels: *levels - 1,
-            },
-            control_flow => *control_flow,
-        }
-    }
+	/// Attempts to decrement the loop levels for `BreakLoop` or `ContinueLoop`.
+	/// If the levels reach zero, transitions to `Normal`. If the control flow is not
+	/// a loop break or continue, no changes are made.
+	#[must_use]
+	pub const fn try_decrement_loop_levels(&self) -> Self {
+		match self {
+			Self::BreakLoop { levels: 0 } | Self::ContinueLoop { levels: 0 } => Self::Normal,
+			Self::BreakLoop { levels } => Self::BreakLoop { levels: *levels - 1 },
+			Self::ContinueLoop { levels } => Self::ContinueLoop { levels: *levels - 1 },
+			control_flow => *control_flow,
+		}
+	}
 }
 
 /// Represents the result of spawning an execution; captures both execution
 /// that immediately returns as well as execution that starts a process
 /// asynchronously.
 pub enum ExecutionSpawnResult {
-    /// Indicates that the execution completed.
-    Completed(ExecutionResult),
-    /// Indicates that a process was started and had not yet completed.
-    StartedProcess(processes::ChildProcess),
+	/// Indicates that the execution completed.
+	Completed(ExecutionResult),
+	/// Indicates that a process was started and had not yet completed.
+	StartedProcess(processes::ChildProcess),
 }
 
 impl From<ExecutionResult> for ExecutionSpawnResult {
-    fn from(result: ExecutionResult) -> Self {
-        Self::Completed(result)
-    }
+	fn from(result: ExecutionResult) -> Self {
+		Self::Completed(result)
+	}
 }
 
 use tokio_util::sync::CancellationToken;
 
 impl ExecutionSpawnResult {
-    /// Waits for the command to complete.
-    ///
-    /// # Arguments
-    ///
-    /// * `no_wait` - If true, do not wait for the command to complete; return immediately.
-    /// * `cancel_token` - Optional cancellation token; if triggered, kills the process.
-    pub async fn wait(
-        self,
-        no_wait: bool,
-        cancel_token: Option<CancellationToken>,
-    ) -> Result<ExecutionWaitResult, error::Error> {
-        match self {
-            Self::StartedProcess(mut child) => {
-                let process_wait_result = if !no_wait {
-                    // Wait for the process to exit or for a relevant signal, whichever happens
-                    // first.
-                    child.wait(cancel_token).await?
-                } else {
-                    processes::ProcessWaitResult::Stopped
-                };
+	/// Waits for the command to complete.
+	///
+	/// # Arguments
+	///
+	/// * `no_wait` - If true, do not wait for the command to complete; return immediately.
+	/// * `cancel_token` - Optional cancellation token; if triggered, kills the process.
+	pub async fn wait(
+		self,
+		no_wait: bool,
+		cancel_token: Option<CancellationToken>,
+	) -> Result<ExecutionWaitResult, error::Error> {
+		match self {
+			Self::StartedProcess(mut child) => {
+				let process_wait_result = if !no_wait {
+					// Wait for the process to exit or for a relevant signal, whichever happens
+					// first.
+					child.wait(cancel_token).await?
+				} else {
+					processes::ProcessWaitResult::Stopped
+				};
 
-                let wait_result = match process_wait_result {
-                    processes::ProcessWaitResult::Completed(output) => {
-                        ExecutionWaitResult::Completed(ExecutionResult::from(output))
-                    }
-                    processes::ProcessWaitResult::Stopped => ExecutionWaitResult::Stopped(child),
-                    processes::ProcessWaitResult::Cancelled => {
-                        // 130 = 128 + SIGINT (2), standard shell interrupted exit code
-                        ExecutionWaitResult::Completed(ExecutionResult::new(130))
-                    }
-                };
+				let wait_result = match process_wait_result {
+					processes::ProcessWaitResult::Completed(output) => {
+						ExecutionWaitResult::Completed(ExecutionResult::from(output))
+					},
+					processes::ProcessWaitResult::Stopped => ExecutionWaitResult::Stopped(child),
+					processes::ProcessWaitResult::Cancelled => {
+						// 130 = 128 + SIGINT (2), standard shell interrupted exit code
+						ExecutionWaitResult::Completed(ExecutionResult::new(130))
+					},
+				};
 
-                Ok(wait_result)
-            }
-            Self::Completed(result) => Ok(ExecutionWaitResult::Completed(result)),
-        }
-    }
+				Ok(wait_result)
+			},
+			Self::Completed(result) => Ok(ExecutionWaitResult::Completed(result)),
+		}
+	}
 }
 
 /// Represents the result of waiting for an execution to complete.
 pub enum ExecutionWaitResult {
-    /// Indicates that the execution completed.
-    Completed(ExecutionResult),
-    /// Indicates that the execution was stopped.
-    Stopped(processes::ChildProcess),
+	/// Indicates that the execution completed.
+	Completed(ExecutionResult),
+	/// Indicates that the execution was stopped.
+	Stopped(processes::ChildProcess),
 }

--- a/crates/brush-core-vendored/src/scripts.rs
+++ b/crates/brush-core-vendored/src/scripts.rs
@@ -5,242 +5,239 @@ use std::collections::VecDeque;
 /// Represents an executing script.
 #[derive(Clone, Debug)]
 pub enum CallType {
-    /// The script was sourced.
-    Sourced,
-    /// The script was executed.
-    Executed,
+	/// The script was sourced.
+	Sourced,
+	/// The script was executed.
+	Executed,
 }
 
 impl std::fmt::Display for CallType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Sourced => write!(f, "sourced"),
-            Self::Executed => write!(f, "executed"),
-        }
-    }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::Sourced => write!(f, "sourced"),
+			Self::Executed => write!(f, "executed"),
+		}
+	}
 }
 
 /// Represents a single frame in a script call stack.
 #[derive(Clone, Debug)]
 pub struct CallFrame {
-    /// The type of script call that resulted in this frame.
-    pub call_type: CallType,
-    /// The source of the script (e.g., file path).
-    pub source: String,
+	/// The type of script call that resulted in this frame.
+	pub call_type: CallType,
+	/// The source of the script (e.g., file path).
+	pub source: String,
 }
 
 /// Encapsulates a script call stack.
 #[derive(Clone, Debug, Default)]
 pub struct CallStack {
-    frames: VecDeque<CallFrame>,
+	frames: VecDeque<CallFrame>,
 }
 
 impl std::fmt::Display for CallStack {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.is_empty() {
-            return Ok(());
-        }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		if self.is_empty() {
+			return Ok(());
+		}
 
-        writeln!(f, "Script call stack (most recent first):")?;
+		writeln!(f, "Script call stack (most recent first):")?;
 
-        for (index, frame) in self.iter().enumerate() {
-            writeln!(f, "  #{}| {} ({})", index, frame.source, frame.call_type)?;
-        }
+		for (index, frame) in self.iter().enumerate() {
+			writeln!(f, "  #{}| {} ({})", index, frame.source, frame.call_type)?;
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 }
 
 impl CallStack {
-    /// Creates a new empty script call stack.
-    pub fn new() -> Self {
-        Self::default()
-    }
+	/// Creates a new empty script call stack.
+	pub fn new() -> Self {
+		Self::default()
+	}
 
-    /// Removes the top from from the stack. If the stack is empty, does nothing and
-    /// returns `None`; otherwise, returns the removed call frame.
-    pub fn pop(&mut self) -> Option<CallFrame> {
-        self.frames.pop_front()
-    }
+	/// Removes the top from from the stack. If the stack is empty, does nothing and
+	/// returns `None`; otherwise, returns the removed call frame.
+	pub fn pop(&mut self) -> Option<CallFrame> {
+		self.frames.pop_front()
+	}
 
-    /// Pushes a new frame onto the stack.
-    ///
-    /// # Arguments
-    ///
-    /// * `call_type` - The type of script call (sourced or executed).
-    /// * `source` - The source of the script (e.g., file path).
-    pub fn push(&mut self, call_type: CallType, source: impl Into<String>) {
-        self.frames.push_front(CallFrame {
-            call_type,
-            source: source.into(),
-        });
-    }
+	/// Pushes a new frame onto the stack.
+	///
+	/// # Arguments
+	///
+	/// * `call_type` - The type of script call (sourced or executed).
+	/// * `source` - The source of the script (e.g., file path).
+	pub fn push(&mut self, call_type: CallType, source: impl Into<String>) {
+		self
+			.frames
+			.push_front(CallFrame { call_type, source: source.into() });
+	}
 
-    /// Returns whether or not the current script stack frame is a sourced script.
-    pub fn in_sourced_script(&self) -> bool {
-        self.frames
-            .front()
-            .is_some_and(|frame| matches!(frame.call_type, CallType::Sourced))
-    }
+	/// Returns whether or not the current script stack frame is a sourced script.
+	pub fn in_sourced_script(&self) -> bool {
+		self
+			.frames
+			.front()
+			.is_some_and(|frame| matches!(frame.call_type, CallType::Sourced))
+	}
 
-    /// Returns the current depth of the script call stack.
-    pub fn depth(&self) -> usize {
-        self.frames.len()
-    }
+	/// Returns the current depth of the script call stack.
+	pub fn depth(&self) -> usize {
+		self.frames.len()
+	}
 
-    /// Returns whether or not the script call stack is empty.
-    pub fn is_empty(&self) -> bool {
-        self.frames.is_empty()
-    }
+	/// Returns whether or not the script call stack is empty.
+	pub fn is_empty(&self) -> bool {
+		self.frames.is_empty()
+	}
 
-    /// Returns an iterator over the script call frames, starting from the most
-    /// recent.
-    pub fn iter(&self) -> impl Iterator<Item = &CallFrame> {
-        self.frames.iter()
-    }
+	/// Returns an iterator over the script call frames, starting from the most
+	/// recent.
+	pub fn iter(&self) -> impl Iterator<Item = &CallFrame> {
+		self.frames.iter()
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_call_type_display() {
-        assert_eq!(CallType::Sourced.to_string(), "sourced");
-        assert_eq!(CallType::Executed.to_string(), "executed");
-    }
+	#[test]
+	fn test_call_type_display() {
+		assert_eq!(CallType::Sourced.to_string(), "sourced");
+		assert_eq!(CallType::Executed.to_string(), "executed");
+	}
 
-    #[test]
-    fn test_call_stack_new() {
-        let stack = CallStack::new();
-        assert!(stack.is_empty());
-        assert_eq!(stack.depth(), 0);
-    }
+	#[test]
+	fn test_call_stack_new() {
+		let stack = CallStack::new();
+		assert!(stack.is_empty());
+		assert_eq!(stack.depth(), 0);
+	}
 
-    #[test]
-    fn test_call_stack_default() {
-        let stack = CallStack::default();
-        assert!(stack.is_empty());
-        assert_eq!(stack.depth(), 0);
-    }
+	#[test]
+	fn test_call_stack_default() {
+		let stack = CallStack::default();
+		assert!(stack.is_empty());
+		assert_eq!(stack.depth(), 0);
+	}
 
-    #[test]
-    fn test_call_stack_push_pop() {
-        let mut stack = CallStack::new();
+	#[test]
+	fn test_call_stack_push_pop() {
+		let mut stack = CallStack::new();
 
-        stack.push(CallType::Sourced, "script1.sh");
-        assert!(!stack.is_empty());
-        assert_eq!(stack.depth(), 1);
+		stack.push(CallType::Sourced, "script1.sh");
+		assert!(!stack.is_empty());
+		assert_eq!(stack.depth(), 1);
 
-        stack.push(CallType::Executed, "script2.sh");
-        assert_eq!(stack.depth(), 2);
+		stack.push(CallType::Executed, "script2.sh");
+		assert_eq!(stack.depth(), 2);
 
-        let frame = stack.pop().unwrap();
-        assert_eq!(frame.source, "script2.sh");
-        assert!(matches!(frame.call_type, CallType::Executed));
-        assert_eq!(stack.depth(), 1);
+		let frame = stack.pop().unwrap();
+		assert_eq!(frame.source, "script2.sh");
+		assert!(matches!(frame.call_type, CallType::Executed));
+		assert_eq!(stack.depth(), 1);
 
-        let frame = stack.pop().unwrap();
-        assert_eq!(frame.source, "script1.sh");
-        assert!(matches!(frame.call_type, CallType::Sourced));
-        assert_eq!(stack.depth(), 0);
-        assert!(stack.is_empty());
-    }
+		let frame = stack.pop().unwrap();
+		assert_eq!(frame.source, "script1.sh");
+		assert!(matches!(frame.call_type, CallType::Sourced));
+		assert_eq!(stack.depth(), 0);
+		assert!(stack.is_empty());
+	}
 
-    #[test]
-    fn test_call_stack_pop_empty() {
-        let mut stack = CallStack::new();
-        assert!(stack.pop().is_none());
-    }
+	#[test]
+	fn test_call_stack_pop_empty() {
+		let mut stack = CallStack::new();
+		assert!(stack.pop().is_none());
+	}
 
-    #[test]
-    fn test_in_sourced_script() {
-        let mut stack = CallStack::new();
-        assert!(!stack.in_sourced_script());
+	#[test]
+	fn test_in_sourced_script() {
+		let mut stack = CallStack::new();
+		assert!(!stack.in_sourced_script());
 
-        stack.push(CallType::Executed, "script1.sh");
-        assert!(!stack.in_sourced_script());
+		stack.push(CallType::Executed, "script1.sh");
+		assert!(!stack.in_sourced_script());
 
-        stack.push(CallType::Sourced, "script2.sh");
-        assert!(stack.in_sourced_script());
+		stack.push(CallType::Sourced, "script2.sh");
+		assert!(stack.in_sourced_script());
 
-        stack.pop();
-        assert!(!stack.in_sourced_script());
-    }
+		stack.pop();
+		assert!(!stack.in_sourced_script());
+	}
 
-    #[test]
-    fn test_call_stack_iter() {
-        let mut stack = CallStack::new();
-        stack.push(CallType::Sourced, "script1.sh");
-        stack.push(CallType::Executed, "script2.sh");
-        stack.push(CallType::Sourced, "script3.sh");
+	#[test]
+	fn test_call_stack_iter() {
+		let mut stack = CallStack::new();
+		stack.push(CallType::Sourced, "script1.sh");
+		stack.push(CallType::Executed, "script2.sh");
+		stack.push(CallType::Sourced, "script3.sh");
 
-        let frames: Vec<_> = stack.iter().collect();
-        assert_eq!(frames.len(), 3);
-        assert_eq!(frames[0].source, "script3.sh");
-        assert_eq!(frames[1].source, "script2.sh");
-        assert_eq!(frames[2].source, "script1.sh");
-    }
+		let frames: Vec<_> = stack.iter().collect();
+		assert_eq!(frames.len(), 3);
+		assert_eq!(frames[0].source, "script3.sh");
+		assert_eq!(frames[1].source, "script2.sh");
+		assert_eq!(frames[2].source, "script1.sh");
+	}
 
-    #[test]
-    fn test_call_stack_display_empty() {
-        let stack = CallStack::new();
-        assert_eq!(stack.to_string(), "");
-    }
+	#[test]
+	fn test_call_stack_display_empty() {
+		let stack = CallStack::new();
+		assert_eq!(stack.to_string(), "");
+	}
 
-    #[test]
-    fn test_call_stack_display_with_frames() {
-        let mut stack = CallStack::new();
-        stack.push(CallType::Sourced, "script1.sh");
-        stack.push(CallType::Executed, "script2.sh");
+	#[test]
+	fn test_call_stack_display_with_frames() {
+		let mut stack = CallStack::new();
+		stack.push(CallType::Sourced, "script1.sh");
+		stack.push(CallType::Executed, "script2.sh");
 
-        let output = stack.to_string();
-        assert!(output.contains("Script call stack (most recent first):"));
-        assert!(output.contains("#0| script2.sh (executed)"));
-        assert!(output.contains("#1| script1.sh (sourced)"));
-    }
+		let output = stack.to_string();
+		assert!(output.contains("Script call stack (most recent first):"));
+		assert!(output.contains("#0| script2.sh (executed)"));
+		assert!(output.contains("#1| script1.sh (sourced)"));
+	}
 
-    #[test]
-    fn test_call_frame_clone() {
-        let frame1 = CallFrame {
-            call_type: CallType::Sourced,
-            source: "test.sh".to_string(),
-        };
-        let frame2 = frame1.clone();
+	#[test]
+	fn test_call_frame_clone() {
+		let frame1 = CallFrame { call_type: CallType::Sourced, source: "test.sh".to_string() };
+		let frame2 = frame1.clone();
 
-        assert_eq!(frame1.source, frame2.source);
-        assert!(matches!(frame1.call_type, CallType::Sourced));
-        assert!(matches!(frame2.call_type, CallType::Sourced));
-    }
+		assert_eq!(frame1.source, frame2.source);
+		assert!(matches!(frame1.call_type, CallType::Sourced));
+		assert!(matches!(frame2.call_type, CallType::Sourced));
+	}
 
-    #[test]
-    fn test_call_stack_clone() {
-        let mut stack1 = CallStack::new();
-        stack1.push(CallType::Sourced, "script1.sh");
-        stack1.push(CallType::Executed, "script2.sh");
+	#[test]
+	fn test_call_stack_clone() {
+		let mut stack1 = CallStack::new();
+		stack1.push(CallType::Sourced, "script1.sh");
+		stack1.push(CallType::Executed, "script2.sh");
 
-        let stack2 = stack1.clone();
-        assert_eq!(stack1.depth(), stack2.depth());
+		let stack2 = stack1.clone();
+		assert_eq!(stack1.depth(), stack2.depth());
 
-        let frames1: Vec<_> = stack1.iter().map(|f| &f.source).collect();
-        let frames2: Vec<_> = stack2.iter().map(|f| &f.source).collect();
-        assert_eq!(frames1, frames2);
-    }
+		let frames1: Vec<_> = stack1.iter().map(|f| &f.source).collect();
+		let frames2: Vec<_> = stack2.iter().map(|f| &f.source).collect();
+		assert_eq!(frames1, frames2);
+	}
 
-    #[test]
-    fn test_push_with_string_types() {
-        let mut stack = CallStack::new();
+	#[test]
+	fn test_push_with_string_types() {
+		let mut stack = CallStack::new();
 
-        // Test with &str
-        stack.push(CallType::Sourced, "script1.sh");
+		// Test with &str
+		stack.push(CallType::Sourced, "script1.sh");
 
-        // Test with String
-        stack.push(CallType::Executed, String::from("script2.sh"));
+		// Test with String
+		stack.push(CallType::Executed, String::from("script2.sh"));
 
-        // Test with owned string reference
-        let owned = "script3.sh".to_string();
-        stack.push(CallType::Sourced, &owned);
+		// Test with owned string reference
+		let owned = "script3.sh".to_string();
+		stack.push(CallType::Sourced, &owned);
 
-        assert_eq!(stack.depth(), 3);
-    }
+		assert_eq!(stack.depth(), 3);
+	}
 }

--- a/crates/brush-core-vendored/src/shell.rs
+++ b/crates/brush-core-vendored/src/shell.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
-use std::ffi::OsStr;
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -15,12 +15,12 @@ use crate::options::RuntimeOptions;
 use crate::results::ExecutionSpawnResult;
 use crate::variables::{self, ShellVariable};
 use crate::{
-    ExecutionControlFlow, ExecutionExitCode, ExecutionResult, ProcessGroupPolicy, history,
-    interfaces, pathcache, pathsearch, scripts, trace_categories, wellknownvars,
+	ExecutionControlFlow, ExecutionExitCode, ExecutionResult, ProcessGroupPolicy, history,
+	interfaces, pathcache, pathsearch, scripts, trace_categories, wellknownvars,
 };
 use crate::{
-    builtins, commands, completion, env, error, expansion, functions, jobs, keywords, openfiles,
-    prompt, sys::users, traps,
+	builtins, commands, completion, env, error, expansion, functions, jobs, keywords, openfiles,
+	prompt, sys::users, traps,
 };
 
 /// Type for storing a key bindings helper.
@@ -34,212 +34,216 @@ pub type ShellFd = i32;
 
 /// Represents an instance of a shell.
 pub struct Shell {
-    /// Trap handler configuration for the shell.
-    pub traps: traps::TrapHandlerConfig,
+	/// Trap handler configuration for the shell.
+	pub traps: traps::TrapHandlerConfig,
 
-    /// Manages files opened and accessible via redirection operators.
-    open_files: openfiles::OpenFiles,
+	/// Manages files opened and accessible via redirection operators.
+	open_files: openfiles::OpenFiles,
 
-    /// The current working directory.
-    working_dir: PathBuf,
+	/// The current working directory.
+	working_dir: PathBuf,
 
-    /// The shell environment, containing shell variables.
-    pub env: ShellEnvironment,
+	/// The shell environment, containing shell variables.
+	pub env: ShellEnvironment,
 
-    /// Shell function definitions.
-    funcs: functions::FunctionEnv,
+	/// Shell function definitions.
+	funcs: functions::FunctionEnv,
 
-    /// Runtime shell options.
-    pub options: RuntimeOptions,
+	/// Runtime shell options.
+	pub options: RuntimeOptions,
 
-    /// State of managed jobs.
-    pub jobs: jobs::JobManager,
+	/// State of managed jobs.
+	pub jobs: jobs::JobManager,
 
-    /// Shell aliases.
-    pub aliases: HashMap<String, String>,
+	/// Shell aliases.
+	pub aliases: HashMap<String, String>,
 
-    /// The status of the last completed command.
-    last_exit_status: u8,
+	/// The status of the last completed command.
+	last_exit_status: u8,
 
-    /// The status of each of the commands in the last pipeline.
-    pub last_pipeline_statuses: Vec<u8>,
+	/// The status of each of the commands in the last pipeline.
+	pub last_pipeline_statuses: Vec<u8>,
 
-    /// Clone depth from the original ancestor shell.
-    depth: usize,
+	/// Clone depth from the original ancestor shell.
+	depth: usize,
 
-    /// Shell name (a.k.a. $0)
-    pub shell_name: Option<String>,
+	/// Shell name (a.k.a. $0)
+	pub shell_name: Option<String>,
 
-    /// Shell version
-    version: Option<String>,
+	/// Shell version
+	version: Option<String>,
 
-    /// Positional parameters stack ($1 and beyond)
-    pub positional_parameters: Vec<String>,
+	/// Positional parameters stack ($1 and beyond)
+	pub positional_parameters: Vec<String>,
 
-    /// Detailed display string for the shell
-    product_display_str: Option<String>,
+	/// Detailed display string for the shell
+	product_display_str: Option<String>,
 
-    /// Script call stack.
-    script_call_stack: scripts::CallStack,
+	/// Script call stack.
+	script_call_stack: scripts::CallStack,
 
-    /// Function call stack.
-    function_call_stack: functions::CallStack,
+	/// Function call stack.
+	function_call_stack: functions::CallStack,
 
-    /// Directory stack used by pushd et al.
-    pub directory_stack: Vec<PathBuf>,
+	/// Directory stack used by pushd et al.
+	pub directory_stack: Vec<PathBuf>,
 
-    /// Current line number being processed.
-    current_line_number: u32,
+	/// Current line number being processed.
+	current_line_number: u32,
 
-    /// Completion configuration.
-    pub completion_config: completion::Config,
+	/// Completion configuration.
+	pub completion_config: completion::Config,
 
-    /// Shell built-in commands.
-    builtins: HashMap<String, builtins::Registration>,
+	/// Shell built-in commands.
+	builtins: HashMap<String, builtins::Registration>,
 
-    /// Shell program location cache.
-    pub program_location_cache: pathcache::PathCache,
+	/// Shell program location cache.
+	pub program_location_cache: pathcache::PathCache,
 
-    /// Last "SECONDS" captured time.
-    last_stopwatch_time: std::time::SystemTime,
+	/// Last "SECONDS" captured time.
+	last_stopwatch_time: std::time::SystemTime,
 
-    /// Last "SECONDS" offset requested.
-    last_stopwatch_offset: u32,
+	/// Last "SECONDS" offset requested.
+	last_stopwatch_offset: u32,
 
-    /// Key bindings for the shell, optionally implemented by an interactive shell.
-    key_bindings: Option<KeyBindingsHelper>,
+	/// Key bindings for the shell, optionally implemented by an interactive shell.
+	key_bindings: Option<KeyBindingsHelper>,
 
-    /// History of commands executed in the shell.
-    history: Option<history::History>,
+	/// History of commands executed in the shell.
+	history: Option<history::History>,
 
-    /// Error formatter for customizing error display.
-    error_formatter: ErrorFormatterHelper,
+	/// Error formatter for customizing error display.
+	error_formatter: ErrorFormatterHelper,
 }
 
 impl Clone for Shell {
-    fn clone(&self) -> Self {
-        Self {
-            traps: self.traps.clone(),
-            open_files: self.open_files.clone(),
-            working_dir: self.working_dir.clone(),
-            env: self.env.clone(),
-            funcs: self.funcs.clone(),
-            options: self.options.clone(),
-            jobs: jobs::JobManager::new(),
-            aliases: self.aliases.clone(),
-            last_exit_status: self.last_exit_status,
-            last_pipeline_statuses: self.last_pipeline_statuses.clone(),
-            positional_parameters: self.positional_parameters.clone(),
-            shell_name: self.shell_name.clone(),
-            version: self.version.clone(),
-            product_display_str: self.product_display_str.clone(),
-            function_call_stack: self.function_call_stack.clone(),
-            script_call_stack: self.script_call_stack.clone(),
-            directory_stack: self.directory_stack.clone(),
-            current_line_number: self.current_line_number,
-            completion_config: self.completion_config.clone(),
-            builtins: self.builtins.clone(),
-            program_location_cache: self.program_location_cache.clone(),
-            last_stopwatch_time: self.last_stopwatch_time,
-            last_stopwatch_offset: self.last_stopwatch_offset,
-            key_bindings: self.key_bindings.clone(),
-            history: self.history.clone(),
-            error_formatter: self.error_formatter.clone(),
-            depth: self.depth + 1,
-        }
-    }
+	fn clone(&self) -> Self {
+		Self {
+			traps: self.traps.clone(),
+			open_files: self.open_files.clone(),
+			working_dir: self.working_dir.clone(),
+			env: self.env.clone(),
+			funcs: self.funcs.clone(),
+			options: self.options.clone(),
+			jobs: jobs::JobManager::new(),
+			aliases: self.aliases.clone(),
+			last_exit_status: self.last_exit_status,
+			last_pipeline_statuses: self.last_pipeline_statuses.clone(),
+			positional_parameters: self.positional_parameters.clone(),
+			shell_name: self.shell_name.clone(),
+			version: self.version.clone(),
+			product_display_str: self.product_display_str.clone(),
+			function_call_stack: self.function_call_stack.clone(),
+			script_call_stack: self.script_call_stack.clone(),
+			directory_stack: self.directory_stack.clone(),
+			current_line_number: self.current_line_number,
+			completion_config: self.completion_config.clone(),
+			builtins: self.builtins.clone(),
+			program_location_cache: self.program_location_cache.clone(),
+			last_stopwatch_time: self.last_stopwatch_time,
+			last_stopwatch_offset: self.last_stopwatch_offset,
+			key_bindings: self.key_bindings.clone(),
+			history: self.history.clone(),
+			error_formatter: self.error_formatter.clone(),
+			depth: self.depth + 1,
+		}
+	}
 }
 
 impl AsRef<Self> for Shell {
-    fn as_ref(&self) -> &Self {
-        self
-    }
+	fn as_ref(&self) -> &Self {
+		self
+	}
 }
 
 impl AsMut<Self> for Shell {
-    fn as_mut(&mut self) -> &mut Self {
-        self
-    }
+	fn as_mut(&mut self) -> &mut Self {
+		self
+	}
 }
 
 pub use shell_builder::State as ShellBuilderState;
 
 impl<S: shell_builder::IsComplete> ShellBuilder<S> {
-    /// Returns a new shell instance created with the options provided
-    pub async fn build(self) -> Result<Shell, error::Error> {
-        let options = self.build_settings();
+	/// Returns a new shell instance created with the options provided
+	pub async fn build(self) -> Result<Shell, error::Error> {
+		let options = self.build_settings();
 
-        Shell::new(options).await
-    }
+		Shell::new(options).await
+	}
 }
 
 impl<S: shell_builder::State> ShellBuilder<S> {
-    /// Add a disabled option
-    pub fn disable_option(mut self, option: impl Into<String>) -> Self {
-        self.disabled_options.push(option.into());
-        self
-    }
+	/// Add a disabled option
+	pub fn disable_option(mut self, option: impl Into<String>) -> Self {
+		self.disabled_options.push(option.into());
+		self
+	}
 
-    /// Add an enabled option
-    pub fn enable_option(mut self, option: impl Into<String>) -> Self {
-        self.enabled_options.push(option.into());
-        self
-    }
+	/// Add an enabled option
+	pub fn enable_option(mut self, option: impl Into<String>) -> Self {
+		self.enabled_options.push(option.into());
+		self
+	}
 
-    /// Add many disabled options
-    pub fn disable_options(mut self, options: impl IntoIterator<Item: Into<String>>) -> Self {
-        self.disabled_options
-            .extend(options.into_iter().map(Into::into));
-        self
-    }
+	/// Add many disabled options
+	pub fn disable_options(mut self, options: impl IntoIterator<Item: Into<String>>) -> Self {
+		self
+			.disabled_options
+			.extend(options.into_iter().map(Into::into));
+		self
+	}
 
-    /// Add many enabled options
-    pub fn enable_options(mut self, options: impl IntoIterator<Item: Into<String>>) -> Self {
-        self.enabled_options
-            .extend(options.into_iter().map(Into::into));
-        self
-    }
+	/// Add many enabled options
+	pub fn enable_options(mut self, options: impl IntoIterator<Item: Into<String>>) -> Self {
+		self
+			.enabled_options
+			.extend(options.into_iter().map(Into::into));
+		self
+	}
 
-    /// Add a disabled shopt option
-    pub fn disable_shopt_option(mut self, option: impl Into<String>) -> Self {
-        self.disabled_shopt_options.push(option.into());
-        self
-    }
+	/// Add a disabled shopt option
+	pub fn disable_shopt_option(mut self, option: impl Into<String>) -> Self {
+		self.disabled_shopt_options.push(option.into());
+		self
+	}
 
-    /// Add an enabled shopt option
-    pub fn enable_shopt_option(mut self, option: impl Into<String>) -> Self {
-        self.enabled_shopt_options.push(option.into());
-        self
-    }
+	/// Add an enabled shopt option
+	pub fn enable_shopt_option(mut self, option: impl Into<String>) -> Self {
+		self.enabled_shopt_options.push(option.into());
+		self
+	}
 
-    /// Add many disabled shopt options
-    pub fn disable_shopt_options(mut self, options: impl IntoIterator<Item: Into<String>>) -> Self {
-        self.disabled_shopt_options
-            .extend(options.into_iter().map(Into::into));
-        self
-    }
+	/// Add many disabled shopt options
+	pub fn disable_shopt_options(mut self, options: impl IntoIterator<Item: Into<String>>) -> Self {
+		self
+			.disabled_shopt_options
+			.extend(options.into_iter().map(Into::into));
+		self
+	}
 
-    /// Add many enabled shopt options
-    pub fn enable_shopt_options(mut self, options: impl IntoIterator<Item: Into<String>>) -> Self {
-        self.enabled_shopt_options
-            .extend(options.into_iter().map(Into::into));
-        self
-    }
+	/// Add many enabled shopt options
+	pub fn enable_shopt_options(mut self, options: impl IntoIterator<Item: Into<String>>) -> Self {
+		self
+			.enabled_shopt_options
+			.extend(options.into_iter().map(Into::into));
+		self
+	}
 
-    /// Add a single builtin registration
-    pub fn builtin(mut self, name: impl Into<String>, reg: builtins::Registration) -> Self {
-        self.builtins.insert(name.into(), reg);
-        self
-    }
+	/// Add a single builtin registration
+	pub fn builtin(mut self, name: impl Into<String>, reg: builtins::Registration) -> Self {
+		self.builtins.insert(name.into(), reg);
+		self
+	}
 
-    /// Add many builtin registrations
-    pub fn builtins(
-        mut self,
-        builtins: impl IntoIterator<Item = (String, builtins::Registration)>,
-    ) -> Self {
-        self.builtins.extend(builtins);
-        self
-    }
+	/// Add many builtin registrations
+	pub fn builtins(
+		mut self,
+		builtins: impl IntoIterator<Item = (String, builtins::Registration)>,
+	) -> Self {
+		self.builtins.extend(builtins);
+		self
+	}
 }
 
 /// Options for creating a new shell.
@@ -259,1434 +263,1426 @@ impl<S: shell_builder::State> ShellBuilder<S> {
     )
 )]
 pub struct CreateOptions {
-    /// Disabled options.
-    #[builder(field)]
-    pub disabled_options: Vec<String>,
-    /// Enabled options.
-    #[builder(field)]
-    pub enabled_options: Vec<String>,
-    /// Disabled shopt options.
-    #[builder(field)]
-    pub disabled_shopt_options: Vec<String>,
-    /// Enabled shopt options.
-    #[builder(field)]
-    pub enabled_shopt_options: Vec<String>,
-    /// Registered builtins.
-    #[builder(field)]
-    pub builtins: HashMap<String, builtins::Registration>,
-    /// Disallow overwriting regular files via output redirection.
-    #[builder(default)]
-    pub disallow_overwriting_regular_files_via_output_redirection: bool,
-    /// Do not execute commands.
-    #[builder(default)]
-    pub do_not_execute_commands: bool,
-    /// Exit after one command.
-    #[builder(default)]
-    pub exit_after_one_command: bool,
-    /// Whether the shell is interactive.
-    #[builder(default)]
-    pub interactive: bool,
-    /// Whether the shell is a login shell.
-    #[builder(default)]
-    pub login: bool,
-    /// Whether to skip using a readline-like interface for input.
-    #[builder(default)]
-    pub no_editing: bool,
-    /// Whether to skip sourcing the system profile.
-    #[builder(default)]
-    pub no_profile: bool,
-    /// Whether to skip sourcing the user's rc file.
-    #[builder(default)]
-    pub no_rc: bool,
-    /// Explicit override of rc file to load in interactive mode.
-    pub rc_file: Option<PathBuf>,
-    /// Whether to skip inheriting environment variables from the calling process.
-    #[builder(default)]
-    pub do_not_inherit_env: bool,
-    /// Provides a set of initial open files to be tracked by the shell.
-    pub fds: Option<HashMap<ShellFd, openfiles::OpenFile>>,
-    /// Whether the shell is in POSIX compliance mode.
-    #[builder(default)]
-    pub posix: bool,
-    /// Whether to print commands and arguments as they are read.
-    #[builder(default)]
-    pub print_commands_and_arguments: bool,
-    /// Whether commands are being read from stdin.
-    #[builder(default)]
-    pub read_commands_from_stdin: bool,
-    /// The name of the shell.
-    pub shell_name: Option<String>,
-    /// Optionally provides a display string describing the version and variant of the shell.
-    pub shell_product_display_str: Option<String>,
-    /// Whether to run in maximal POSIX sh compatibility mode.
-    #[builder(default)]
-    pub sh_mode: bool,
-    /// Whether to print verbose output.
-    #[builder(default)]
-    pub verbose: bool,
-    /// Maximum function call depth.
-    pub max_function_call_depth: Option<usize>,
-    /// Key bindings helper for the shell to use.
-    pub key_bindings: Option<KeyBindingsHelper>,
-    /// Error formatter helper for the shell to use.
-    pub error_formatter: Option<ErrorFormatterHelper>,
-    /// Brush implementation version.
-    pub shell_version: Option<String>,
+	/// Disabled options.
+	#[builder(field)]
+	pub disabled_options: Vec<String>,
+	/// Enabled options.
+	#[builder(field)]
+	pub enabled_options: Vec<String>,
+	/// Disabled shopt options.
+	#[builder(field)]
+	pub disabled_shopt_options: Vec<String>,
+	/// Enabled shopt options.
+	#[builder(field)]
+	pub enabled_shopt_options: Vec<String>,
+	/// Registered builtins.
+	#[builder(field)]
+	pub builtins: HashMap<String, builtins::Registration>,
+	/// Disallow overwriting regular files via output redirection.
+	#[builder(default)]
+	pub disallow_overwriting_regular_files_via_output_redirection: bool,
+	/// Do not execute commands.
+	#[builder(default)]
+	pub do_not_execute_commands: bool,
+	/// Exit after one command.
+	#[builder(default)]
+	pub exit_after_one_command: bool,
+	/// Whether the shell is interactive.
+	#[builder(default)]
+	pub interactive: bool,
+	/// Whether the shell is a login shell.
+	#[builder(default)]
+	pub login: bool,
+	/// Whether to skip using a readline-like interface for input.
+	#[builder(default)]
+	pub no_editing: bool,
+	/// Whether to skip sourcing the system profile.
+	#[builder(default)]
+	pub no_profile: bool,
+	/// Whether to skip sourcing the user's rc file.
+	#[builder(default)]
+	pub no_rc: bool,
+	/// Explicit override of rc file to load in interactive mode.
+	pub rc_file: Option<PathBuf>,
+	/// Whether to skip inheriting environment variables from the calling process.
+	#[builder(default)]
+	pub do_not_inherit_env: bool,
+	/// Provides a set of initial open files to be tracked by the shell.
+	pub fds: Option<HashMap<ShellFd, openfiles::OpenFile>>,
+	/// Whether the shell is in POSIX compliance mode.
+	#[builder(default)]
+	pub posix: bool,
+	/// Whether to print commands and arguments as they are read.
+	#[builder(default)]
+	pub print_commands_and_arguments: bool,
+	/// Whether commands are being read from stdin.
+	#[builder(default)]
+	pub read_commands_from_stdin: bool,
+	/// The name of the shell.
+	pub shell_name: Option<String>,
+	/// Optionally provides a display string describing the version and variant of the shell.
+	pub shell_product_display_str: Option<String>,
+	/// Whether to run in maximal POSIX sh compatibility mode.
+	#[builder(default)]
+	pub sh_mode: bool,
+	/// Whether to print verbose output.
+	#[builder(default)]
+	pub verbose: bool,
+	/// Maximum function call depth.
+	pub max_function_call_depth: Option<usize>,
+	/// Key bindings helper for the shell to use.
+	pub key_bindings: Option<KeyBindingsHelper>,
+	/// Error formatter helper for the shell to use.
+	pub error_formatter: Option<ErrorFormatterHelper>,
+	/// Brush implementation version.
+	pub shell_version: Option<String>,
 }
 
 impl Shell {
-    /// Create an instance of [Shell] using the builder syntax
-    pub fn builder() -> ShellBuilder<shell_builder::Empty> {
-        CreateOptions::builder()
-    }
-
-    /// Returns a new shell instance created with the given options.
-    ///
-    /// # Arguments
-    ///
-    /// * `options` - The options to use when creating the shell.
-    pub async fn new(options: CreateOptions) -> Result<Self, error::Error> {
-        // Instantiate the shell with some defaults.
-        let mut shell = Self {
-            traps: traps::TrapHandlerConfig::default(),
-            open_files: openfiles::OpenFiles::new(),
-            // Populate working directory from the host environment.
-            working_dir: std::env::current_dir()?,
-            env: env::ShellEnvironment::new(),
-            funcs: functions::FunctionEnv::default(),
-            options: RuntimeOptions::defaults_from(&options),
-            jobs: jobs::JobManager::new(),
-            aliases: HashMap::default(),
-            last_exit_status: 0,
-            last_pipeline_statuses: vec![0],
-            positional_parameters: vec![],
-            shell_name: options.shell_name,
-            version: options.shell_version,
-            product_display_str: options.shell_product_display_str,
-            function_call_stack: functions::CallStack::new(),
-            script_call_stack: scripts::CallStack::new(),
-            directory_stack: vec![],
-            current_line_number: 0,
-            completion_config: completion::Config::default(),
-            builtins: options.builtins,
-            program_location_cache: pathcache::PathCache::default(),
-            last_stopwatch_time: std::time::SystemTime::now(),
-            last_stopwatch_offset: 0,
-            key_bindings: options.key_bindings,
-            history: None,
-            error_formatter: options
-                .error_formatter
-                .unwrap_or_else(|| Arc::new(Mutex::new(error::DefaultErrorFormatter::new()))),
-            depth: 0,
-        };
-
-        // Add in any open files provided.
-        if let Some(fds) = options.fds {
-            shell.open_files.update_from(fds.into_iter());
-        }
-
-        // TODO: Without this a script that sets extglob will fail because we
-        // parse the entire script with the same settings.
-        shell.options.extended_globbing = true;
-
-        // Initialize environment.
-        wellknownvars::initialize_vars(&mut shell, options.do_not_inherit_env)?;
-
-        // Set up history, if relevant.
-        if shell.options.enable_command_history {
-            if let Some(history_path) = shell.history_file_path() {
-                let mut options = std::fs::File::options();
-                options.read(true);
-
-                if let Ok(history_file) =
-                    shell.open_file(&options, history_path, &shell.default_exec_params())
-                {
-                    shell.history = Some(history::History::import(history_file)?);
-                }
-            }
-
-            if shell.history.is_none() {
-                shell.history = Some(history::History::default());
-            }
-        }
-
-        // Load profiles/configuration.
-        shell
-            .load_config(
-                options.no_profile,
-                options.no_rc,
-                options.rc_file.as_deref(),
-            )
-            .await?;
-
-        Ok(shell)
-    }
-
-    /// Returns the current source line number being processed.
-    pub const fn current_line_number(&self) -> u32 {
-        self.current_line_number
-    }
-
-    /// Returns the shell's official version string (if available).
-    pub const fn version(&self) -> &Option<String> {
-        &self.version
-    }
-
-    /// Returns the exit status of the last command executed in this shell.
-    pub const fn last_result(&self) -> u8 {
-        self.last_exit_status
-    }
-
-    /// Returns a reference to the current function call stack for the shell.
-    pub const fn function_call_stack(&self) -> &functions::CallStack {
-        &self.function_call_stack
-    }
-
-    /// Returns a reference to the current script call stack for the shell.
-    pub const fn script_call_stack(&self) -> &scripts::CallStack {
-        &self.script_call_stack
-    }
-
-    /// Returns a mutable reference to the last exit status.
-    pub const fn last_exit_status_mut(&mut self) -> &mut u8 {
-        &mut self.last_exit_status
-    }
-
-    /// Returns the key bindings helper for the shell.
-    pub const fn key_bindings(&self) -> &Option<KeyBindingsHelper> {
-        &self.key_bindings
-    }
-
-    /// Returns the registered builtins for the shell.
-    pub const fn builtins(&self) -> &HashMap<String, builtins::Registration> {
-        &self.builtins
-    }
-
-    /// Returns the shell's current working directory.
-    pub fn working_dir(&self) -> &Path {
-        &self.working_dir
-    }
-
-    /// Returns a mutable reference to the shell's current working directory.
-    /// This is only accessible within the crate.
-    pub(crate) const fn working_dir_mut(&mut self) -> &mut PathBuf {
-        &mut self.working_dir
-    }
-
-    /// Returns the product display name for this shell.
-    pub const fn product_display_str(&self) -> &Option<String> {
-        &self.product_display_str
-    }
-
-    /// Returns the function definition environment for this shell.
-    pub const fn funcs(&self) -> &functions::FunctionEnv {
-        &self.funcs
-    }
-
-    /// Tries to undefine a function in the shell's environment. Returns whether or
-    /// not a definition was removed.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the function to undefine.
-    pub fn undefine_func(&mut self, name: &str) -> bool {
-        self.funcs.remove(name).is_some()
-    }
-
-    /// Defines a function in the shell's environment. If a function already exists
-    /// with the given name, it is replaced with the new definition.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the function to define.
-    /// * `definition` - The function's definition.
-    pub fn define_func(
-        &mut self,
-        name: impl Into<String>,
-        definition: brush_parser::ast::FunctionDefinition,
-    ) {
-        self.funcs.update(name.into(), definition.into());
-    }
-
-    /// Tries to return a mutable reference to the registration for a named function.
-    /// Returns `None` if no such function was found.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the function to lookup
-    pub fn func_mut(&mut self, name: &str) -> Option<&mut functions::Registration> {
-        self.funcs.get_mut(name)
-    }
-
-    /// Tries to define a function in the shell's environment using the given
-    /// string as its body.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the function
-    /// * `body_text` - The body of the function, expected to start with "()".
-    pub fn define_func_from_str(
-        &mut self,
-        name: impl Into<String>,
-        body_text: &str,
-    ) -> Result<(), error::Error> {
-        let name = name.into();
-
-        let mut parser = create_parser(body_text.as_bytes(), &self.parser_options());
-        let func_body = parser.parse_function_parens_and_body().map_err(|e| {
-            error::Error::from(error::ErrorKind::FunctionParseError(name.clone(), e))
-        })?;
-
-        let def = brush_parser::ast::FunctionDefinition {
-            fname: name.clone().into(),
-            body: func_body,
-            source: String::new(),
-        };
-
-        self.define_func(name, def);
-
-        Ok(())
-    }
-
-    /// Returns the last "SECONDS" captured time.
-    pub const fn last_stopwatch_time(&self) -> std::time::SystemTime {
-        self.last_stopwatch_time
-    }
-
-    /// Returns the last "SECONDS" offset requested.
-    pub const fn last_stopwatch_offset(&self) -> u32 {
-        self.last_stopwatch_offset
-    }
-
-    async fn load_config(
-        &mut self,
-        skip_profile: bool,
-        skip_rc: bool,
-        rc_file: Option<&Path>,
-    ) -> Result<(), error::Error> {
-        let mut params = self.default_exec_params();
-        params.process_group_policy = interp::ProcessGroupPolicy::SameProcessGroup;
-
-        if self.options.login_shell {
-            // --noprofile means skip this.
-            if skip_profile {
-                return Ok(());
-            }
-
-            //
-            // Source /etc/profile if it exists.
-            //
-            // Next source the first of these that exists and is readable (if any):
-            //     * ~/.bash_profile
-            //     * ~/.bash_login
-            //     * ~/.profile
-            //
-            self.source_if_exists(Path::new("/etc/profile"), &params)
-                .await?;
-            if let Some(home_path) = self.home_dir() {
-                if self.options.sh_mode {
-                    self.source_if_exists(home_path.join(".profile").as_path(), &params)
-                        .await?;
-                } else {
-                    if !self
-                        .source_if_exists(home_path.join(".bash_profile").as_path(), &params)
-                        .await?
-                    {
-                        if !self
-                            .source_if_exists(home_path.join(".bash_login").as_path(), &params)
-                            .await?
-                        {
-                            self.source_if_exists(home_path.join(".profile").as_path(), &params)
-                                .await?;
-                        }
-                    }
-                }
-            }
-        } else {
-            if self.options.interactive {
-                // --norc means skip this. Also skip in sh mode.
-                if skip_rc || self.options.sh_mode {
-                    return Ok(());
-                }
-
-                // If an rc file was specified, then source it.
-                if let Some(rc_file) = rc_file {
-                    // If an explicit rc file is provided, source it.
-                    self.source_if_exists(rc_file, &params).await?;
-                } else {
-                    //
-                    // Otherwise, for non-login interactive shells, load in this order:
-                    //
-                    //     /etc/bash.bashrc
-                    //     ~/.bashrc
-                    //
-                    self.source_if_exists(Path::new("/etc/bash.bashrc"), &params)
-                        .await?;
-                    if let Some(home_path) = self.home_dir() {
-                        self.source_if_exists(home_path.join(".bashrc").as_path(), &params)
-                            .await?;
-                        self.source_if_exists(home_path.join(".brushrc").as_path(), &params)
-                            .await?;
-                    }
-                }
-            } else {
-                let env_var_name = if self.options.sh_mode {
-                    "ENV"
-                } else {
-                    "BASH_ENV"
-                };
-
-                if self.env.is_set(env_var_name) {
-                    //
-                    // TODO: look at $ENV/BASH_ENV; source its expansion if that file exists
-                    //
-                    return error::unimp(
-                        "load config from $ENV/BASH_ENV for non-interactive, non-login shell",
-                    );
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn source_if_exists(
-        &mut self,
-        path: impl AsRef<Path>,
-        params: &ExecutionParameters,
-    ) -> Result<bool, error::Error> {
-        let path = path.as_ref();
-        if path.exists() {
-            self.source_script(path, std::iter::empty::<String>(), params)
-                .await?;
-            Ok(true)
-        } else {
-            tracing::debug!("skipping non-existent file: {}", path.display());
-            Ok(false)
-        }
-    }
-
-    /// Source the given file as a shell script, returning the execution result.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - The path to the file to source.
-    /// * `args` - The arguments to pass to the script as positional parameters.
-    /// * `params` - Execution parameters.
-    pub async fn source_script<S: AsRef<str>, P: AsRef<Path>, I: Iterator<Item = S>>(
-        &mut self,
-        path: P,
-        args: I,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        self.parse_and_execute_script_file(path.as_ref(), args, params, scripts::CallType::Sourced)
-            .await
-    }
-
-    /// Parse and execute the given file as a shell script, returning the execution result.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - The path to the file to source.
-    /// * `args` - The arguments to pass to the script as positional parameters.
-    /// * `params` - Execution parameters.
-    /// * `call_type` - The type of script call being made.
-    async fn parse_and_execute_script_file<S: AsRef<str>, P: AsRef<Path>, I: Iterator<Item = S>>(
-        &mut self,
-        path: P,
-        args: I,
-        params: &ExecutionParameters,
-        call_type: scripts::CallType,
-    ) -> Result<ExecutionResult, error::Error> {
-        let path = path.as_ref();
-        tracing::debug!("sourcing: {}", path.display());
-
-        let mut options = std::fs::File::options();
-        options.read(true);
-
-        let opened_file: openfiles::OpenFile = self
-            .open_file(&options, path, params)
-            .map_err(|e| error::ErrorKind::FailedSourcingFile(path.to_owned(), e))?;
-
-        if opened_file.is_dir() {
-            return Err(error::ErrorKind::FailedSourcingFile(
-                path.to_owned(),
-                std::io::Error::from(std::io::ErrorKind::IsADirectory),
-            )
-            .into());
-        }
-
-        let source_info = brush_parser::SourceInfo {
-            source: path.to_string_lossy().to_string(),
-        };
-
-        let mut result = self
-            .source_file(opened_file, &source_info, args, params, call_type)
-            .await?;
-
-        // Handle control flow at script execution boundary. If execution completed
-        // with a `return`, we need to clear it since it's already been "used". All
-        // other control flow types are preserved.
-        if matches!(
-            result.next_control_flow,
-            ExecutionControlFlow::ReturnFromFunctionOrScript
-        ) {
-            result.next_control_flow = ExecutionControlFlow::Normal;
-        }
-
-        Ok(result)
-    }
-
-    /// Source the given file as a shell script, returning the execution result.
-    ///
-    /// # Arguments
-    ///
-    /// * `file` - The file to source.
-    /// * `source_info` - Information about the source of the script.
-    /// * `args` - The arguments to pass to the script as positional parameters.
-    /// * `params` - Execution parameters.
-    /// * `call_type` - The type of script call being made.
-    async fn source_file<F: Read, S: AsRef<str>, I: Iterator<Item = S>>(
-        &mut self,
-        file: F,
-        source_info: &brush_parser::SourceInfo,
-        args: I,
-        params: &ExecutionParameters,
-        call_type: scripts::CallType,
-    ) -> Result<ExecutionResult, error::Error> {
-        let mut reader = std::io::BufReader::new(file);
-        let mut parser =
-            brush_parser::Parser::new(&mut reader, &self.parser_options(), source_info);
-
-        tracing::debug!(target: trace_categories::PARSE, "Parsing sourced file: {}", source_info.source);
-        let parse_result = parser.parse_program();
-
-        let mut other_positional_parameters: Vec<_> = args.map(|s| s.as_ref().to_owned()).collect();
-        let mut other_shell_name = Some(source_info.source.clone());
-        let positional_params_given = !other_positional_parameters.is_empty();
-
-        // TODO: Find a cleaner way to change args.
-        std::mem::swap(&mut self.shell_name, &mut other_shell_name);
-
-        // NOTE: We only shadow the original positional parameters if any were explicitly given
-        // for the script sourcing.
-        if positional_params_given {
-            std::mem::swap(
-                &mut self.positional_parameters,
-                &mut other_positional_parameters,
-            );
-        }
-
-        self.script_call_stack
-            .push(call_type, source_info.source.clone());
-
-        let result = self
-            .run_parsed_result(parse_result, source_info, params)
-            .await;
-
-        self.script_call_stack.pop();
-
-        // Restore.
-        std::mem::swap(&mut self.shell_name, &mut other_shell_name);
-
-        // We only restore the original positional parameters if we needed to shadow them.
-        if positional_params_given {
-            std::mem::swap(
-                &mut self.positional_parameters,
-                &mut other_positional_parameters,
-            );
-        }
-
-        result
-    }
-
-    /// Invokes a function defined in this shell, returning the resulting exit status.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the function to invoke.
-    /// * `args` - The arguments to pass to the function.
-    /// * `params` - Execution parameters to use for the invocation.
-    pub async fn invoke_function<N: AsRef<str>, I: IntoIterator<Item = A>, A: AsRef<str>>(
-        &mut self,
-        name: N,
-        args: I,
-        params: &ExecutionParameters,
-    ) -> Result<u8, error::Error> {
-        let name = name.as_ref();
-        let command_name = String::from(name);
-
-        let func_registration = self
-            .funcs
-            .get(name)
-            .ok_or_else(|| error::ErrorKind::FunctionNotFound(name.to_owned()))?;
-
-        let func = func_registration.definition.clone();
-
-        let context = commands::ExecutionContext {
-            shell: self,
-            command_name,
-            params: params.clone(),
-        };
-
-        let command_args = args
-            .into_iter()
-            .map(|s| commands::CommandArg::String(String::from(s.as_ref())))
-            .collect::<Vec<_>>();
-
-        match commands::invoke_shell_function(func, context, &command_args).await? {
-            ExecutionSpawnResult::StartedProcess(_) => {
-                error::unimp("child spawned from function invocation")
-            }
-            ExecutionSpawnResult::Completed(result) => Ok(result.exit_code.into()),
-        }
-    }
-
-    /// Executes the given string as a shell program, returning the resulting exit status.
-    ///
-    /// # Arguments
-    ///
-    /// * `command` - The command to execute.
-    /// * `params` - Execution parameters.
-    pub async fn run_string<S: Into<String>>(
-        &mut self,
-        command: S,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        // TODO: Actually track line numbers; this is something of a hack, assuming each time
-        // this function is invoked we are on the next line of the input. For one thing,
-        // each string we run could be multiple lines.
-        self.current_line_number += 1;
-
-        let parse_result = self.parse_string(command.into());
-        let source_info = brush_parser::SourceInfo {
-            source: String::from("main"),
-        };
-        self.run_parsed_result(parse_result, &source_info, params)
-            .await
-    }
-
-    /// Parses the given reader as a shell program, returning the resulting Abstract Syntax Tree
-    /// for the program.
-    pub fn parse<R: Read>(
-        &self,
-        reader: R,
-    ) -> Result<brush_parser::ast::Program, brush_parser::ParseError> {
-        let mut parser = create_parser(reader, &self.parser_options());
-
-        tracing::debug!(target: trace_categories::PARSE, "Parsing reader as program...");
-        parser.parse_program()
-    }
-
-    /// Parses the given string as a shell program, returning the resulting Abstract Syntax Tree
-    /// for the program.
-    ///
-    /// # Arguments
-    ///
-    /// * `s` - The string to parse as a program.
-    pub fn parse_string<S: Into<String>>(
-        &self,
-        s: S,
-    ) -> Result<brush_parser::ast::Program, brush_parser::ParseError> {
-        parse_string_impl(s.into(), self.parser_options())
-    }
-
-    /// Applies basic shell expansion to the provided string.
-    ///
-    /// # Arguments
-    ///
-    /// * `s` - The string to expand.
-    pub async fn basic_expand_string<S: AsRef<str>>(
-        &mut self,
-        params: &ExecutionParameters,
-        s: S,
-    ) -> Result<String, error::Error> {
-        let result = expansion::basic_expand_str(self, params, s.as_ref()).await?;
-        Ok(result)
-    }
-
-    /// Applies full shell expansion and field splitting to the provided string; returns
-    /// a sequence of fields.
-    ///
-    /// # Arguments
-    ///
-    /// * `s` - The string to expand and split.
-    pub async fn full_expand_and_split_string<S: AsRef<str>>(
-        &mut self,
-        params: &ExecutionParameters,
-        s: S,
-    ) -> Result<Vec<String>, error::Error> {
-        let result = expansion::full_expand_and_split_str(self, params, s.as_ref()).await?;
-        Ok(result)
-    }
-
-    /// Returns the default execution parameters for this shell.
-    pub fn default_exec_params(&self) -> ExecutionParameters {
-        ExecutionParameters::default()
-    }
-
-    /// Executes the given script file, returning the resulting exit status.
-    ///
-    /// # Arguments
-    ///
-    /// * `script_path` - The path to the script file to execute.
-    /// * `args` - The arguments to pass to the script as positional parameters.
-    pub async fn run_script<S: AsRef<str>, P: AsRef<Path>, I: Iterator<Item = S>>(
-        &mut self,
-        script_path: P,
-        args: I,
-    ) -> Result<ExecutionResult, error::Error> {
-        let params = self.default_exec_params();
-        let result = self
-            .parse_and_execute_script_file(
-                script_path.as_ref(),
-                args,
-                &params,
-                scripts::CallType::Executed,
-            )
-            .await?;
-
-        let _ = self.on_exit().await;
-
-        Ok(result)
-    }
-
-    /// Runs any exit steps for the shell.
-    pub async fn on_exit(&mut self) -> Result<(), error::Error> {
-        self.invoke_exit_trap_handler_if_registered().await?;
-
-        Ok(())
-    }
-
-    async fn invoke_exit_trap_handler_if_registered(
-        &mut self,
-    ) -> Result<ExecutionResult, error::Error> {
-        let Some(handler) = self.traps.handlers.get(&traps::TrapSignal::Exit).cloned() else {
-            return Ok(ExecutionResult::success());
-        };
-
-        // TODO: Confirm whether trap handlers should be executed in the same process group.
-        let mut params = self.default_exec_params();
-        params.process_group_policy = ProcessGroupPolicy::SameProcessGroup;
-
-        let orig_last_exit_status = self.last_exit_status;
-        self.traps.handler_depth += 1;
-
-        let result = self.run_string(handler, &params).await;
-
-        self.traps.handler_depth -= 1;
-        self.last_exit_status = orig_last_exit_status;
-
-        result
-    }
-
-    pub(crate) async fn run_parsed_result(
-        &mut self,
-        parse_result: Result<brush_parser::ast::Program, brush_parser::ParseError>,
-        source_info: &brush_parser::SourceInfo,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        // If parsing succeeded, run the program.
-        let result = match parse_result {
-            Ok(prog) => self.run_program(prog, params).await,
-            Err(parse_err) => Err(error::Error::from(error::ErrorKind::ParseError(
-                parse_err,
-                source_info.clone(),
-            ))),
-        };
-
-        // Report any errors.
-        match result {
-            Ok(result) => Ok(result),
-            Err(err) => {
-                let _ = self.display_error(&mut params.stderr(self), &err).await;
-                let exit_code = ExecutionExitCode::from(&err);
-                *self.last_exit_status_mut() = exit_code.into();
-                Ok(exit_code.into())
-            }
-        }
-    }
-
-    /// Executes the given parsed shell program, returning the resulting exit status.
-    ///
-    /// # Arguments
-    ///
-    /// * `program` - The program to execute.
-    /// * `params` - Execution parameters.
-    pub async fn run_program(
-        &mut self,
-        program: brush_parser::ast::Program,
-        params: &ExecutionParameters,
-    ) -> Result<ExecutionResult, error::Error> {
-        program.execute(self, params).await
-    }
-
-    const fn default_prompt(&self) -> &'static str {
-        if self.options.sh_mode {
-            "$ "
-        } else {
-            "brush$ "
-        }
-    }
-
-    /// Composes the shell's post-input, pre-command prompt, applying all appropriate expansions.
-    pub async fn compose_precmd_prompt(&mut self) -> Result<String, error::Error> {
-        self.expand_prompt_var("PS0", "").await
-    }
-
-    /// Composes the shell's prompt, applying all appropriate expansions.
-    pub async fn compose_prompt(&mut self) -> Result<String, error::Error> {
-        self.expand_prompt_var("PS1", self.default_prompt()).await
-    }
-
-    /// Compose's the shell's alternate-side prompt, applying all appropriate expansions.
-    pub async fn compose_alt_side_prompt(&mut self) -> Result<String, error::Error> {
-        // This is a brush extension.
-        self.expand_prompt_var("BRUSH_PS_ALT", "").await
-    }
-
-    /// Composes the shell's continuation prompt.
-    pub async fn compose_continuation_prompt(&mut self) -> Result<String, error::Error> {
-        self.expand_prompt_var("PS2", "> ").await
-    }
-
-    async fn expand_prompt_var(
-        &mut self,
-        var_name: &str,
-        default: &str,
-    ) -> Result<String, error::Error> {
-        //
-        // TODO(prompt): bash appears to do this in a subshell; we need to investigate
-        // if that's required.
-        //
-
-        // Retrieve the spec.
-        let prompt_spec = self.parameter_or_default(var_name, default);
-        if prompt_spec.is_empty() {
-            return Ok(String::new());
-        }
-
-        // Expand it.
-        let params = self.default_exec_params();
-        prompt::expand_prompt(self, &params, prompt_spec.into_owned()).await
-    }
-
-    fn parameter_or_default<'a>(&'a self, name: &str, default: &'a str) -> Cow<'a, str> {
-        self.env_str(name).unwrap_or_else(|| default.into())
-    }
-
-    /// Returns the options that should be used for parsing shell programs; reflects
-    /// the current configuration state of the shell and may change over time.
-    pub const fn parser_options(&self) -> brush_parser::ParserOptions {
-        brush_parser::ParserOptions {
-            enable_extended_globbing: self.options.extended_globbing,
-            posix_mode: self.options.posix_mode,
-            sh_mode: self.options.sh_mode,
-            tilde_expansion: true,
-        }
-    }
-
-    /// Returns whether or not the shell is actively executing in a sourced script.
-    pub fn in_sourced_script(&self) -> bool {
-        self.script_call_stack.in_sourced_script()
-    }
-
-    /// Returns whether or not the shell is actively executing in a shell function.
-    pub fn in_function(&self) -> bool {
-        !self.function_call_stack.is_empty()
-    }
-
-    /// Updates the shell's internal tracking state to reflect that a new shell
-    /// function is being entered.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the function being entered.
-    /// * `function_def` - The definition of the function being entered.
-    pub(crate) fn enter_function(
-        &mut self,
-        name: &str,
-        function_def: &Arc<brush_parser::ast::FunctionDefinition>,
-    ) -> Result<(), error::Error> {
-        if let Some(max_call_depth) = self.options.max_function_call_depth {
-            if self.function_call_stack.depth() >= max_call_depth {
-                return Err(error::ErrorKind::MaxFunctionCallDepthExceeded.into());
-            }
-        }
-
-        if tracing::enabled!(target: trace_categories::FUNCTIONS, tracing::Level::DEBUG) {
-            let depth = self.function_call_stack.depth();
-            let prefix = repeated_char_str(' ', depth);
-            tracing::debug!(target: trace_categories::FUNCTIONS, "Entering func [depth={depth}]: {prefix}{name}");
-        }
-
-        self.function_call_stack.push(name, function_def);
-        self.env.push_scope(env::EnvironmentScope::Local);
-
-        Ok(())
-    }
-
-    /// Updates the shell's internal tracking state to reflect that the shell
-    /// has exited the top-most function on its call stack.
-    pub(crate) fn leave_function(&mut self) -> Result<(), error::Error> {
-        self.env.pop_scope(env::EnvironmentScope::Local)?;
-
-        if let Some(exited_call) = self.function_call_stack.pop() {
-            if tracing::enabled!(target: trace_categories::FUNCTIONS, tracing::Level::DEBUG) {
-                let depth = self.function_call_stack.depth();
-                let prefix = repeated_char_str(' ', depth);
-                tracing::debug!(target: trace_categories::FUNCTIONS, "Exiting func  [depth={depth}]: {prefix}{}", exited_call.function_name);
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Returns the path to the history file used by the shell, if one is set.
-    pub fn history_file_path(&self) -> Option<PathBuf> {
-        self.env_str("HISTFILE")
-            .map(|s| PathBuf::from(s.into_owned()))
-    }
-
-    /// Returns the path to the history file used by the shell, if one is set.
-    pub fn history_time_format(&self) -> Option<String> {
-        self.env_str("HISTTIMEFORMAT").map(|s| s.into_owned())
-    }
-
-    /// Saves history back to any backing storage.
-    pub fn save_history(&mut self) -> Result<(), error::Error> {
-        if let Some(history_file_path) = self.history_file_path() {
-            if let Some(history) = &mut self.history {
-                // See if there's *any* time format configured. That triggers writing out timestamps.
-                let write_timestamps = self.env.is_set("HISTTIMEFORMAT");
-
-                // TODO: Observe options.append_to_history_file
-                history.flush(
-                    history_file_path,
-                    true, /*append?*/
-                    true, /*unsaved items only?*/
-                    write_timestamps,
-                )?;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Adds a command to history.
-    pub fn add_to_history(&mut self, command: &str) -> Result<(), error::Error> {
-        if let Some(history) = &mut self.history {
-            // Trim.
-            let command = command.trim();
-
-            // For now, discard empty commands.
-            if command.is_empty() {
-                return Ok(());
-            }
-
-            // Add it to history.
-            history.add(history::Item {
-                id: 0,
-                command_line: command.to_owned(),
-                timestamp: Some(chrono::Utc::now()),
-                dirty: true,
-            })?;
-        }
-
-        Ok(())
-    }
-
-    /// Tries to retrieve a variable from the shell's environment, converting it into its
-    /// string form.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to retrieve.
-    pub fn env_str(&self, name: &str) -> Option<Cow<'_, str>> {
-        self.env.get_str(name, self)
-    }
-
-    /// Tries to retrieve a variable from the shell's environment.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to retrieve.
-    pub fn env_var(&self, name: &str) -> Option<&ShellVariable> {
-        self.env.get(name).map(|(_, var)| var)
-    }
-
-    /// Tries to set a global variable in the shell's environment.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the variable to add.
-    /// * `var` - The variable contents to add.
-    pub fn set_env_global(&mut self, name: &str, var: ShellVariable) -> Result<(), error::Error> {
-        self.env.set_global(name, var)
-    }
-
-    /// Register a builtin to the shell's environment.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The in-shell name of the builtin.
-    /// * `registration` - The registration handle for the builtin.
-    pub fn register_builtin<S: Into<String>>(
-        &mut self,
-        name: S,
-        registration: builtins::Registration,
-    ) {
-        self.builtins.insert(name.into(), registration);
-    }
-
-    /// Tries to retrieve a mutable reference to an existing builtin registration.
-    /// Returns `None` if no such registration exists.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the builtin to lookup.
-    pub fn builtin_mut(&mut self, name: &str) -> Option<&mut builtins::Registration> {
-        self.builtins.get_mut(name)
-    }
-
-    /// Returns the current value of the IFS variable, or the default value if it is not set.
-    pub fn ifs(&self) -> Cow<'_, str> {
-        self.env_str("IFS").unwrap_or_else(|| " \t\n".into())
-    }
-
-    /// Returns the first character of the IFS variable, or a space if it is not set.
-    pub(crate) fn get_ifs_first_char(&self) -> char {
-        self.ifs().chars().next().unwrap_or(' ')
-    }
-
-    /// Generates command completions for the shell.
-    ///
-    /// # Arguments
-    ///
-    /// * `input` - The input string to generate completions for.
-    /// * `position` - The position in the input string to generate completions at.
-    pub async fn complete(
-        &mut self,
-        input: &str,
-        position: usize,
-    ) -> Result<completion::Completions, error::Error> {
-        let completion_config = self.completion_config.clone();
-        completion_config
-            .get_completions(self, input, position)
-            .await
-    }
-
-    /// Finds executables in the shell's current default PATH, matching the given glob pattern.
-    ///
-    /// # Arguments
-    ///
-    /// * `required_glob_pattern` - The glob pattern to match against.
-    pub fn find_executables_in_path<'a>(
-        &'a self,
-        filename: &'a str,
-    ) -> impl Iterator<Item = PathBuf> + 'a {
-        let path_var = self.env.get_str("PATH", self).unwrap_or_default();
-        let paths = std::env::split_paths(OsStr::new(path_var.as_ref()))
-            .map(|path| path.to_string_lossy().trim_matches('"').to_string());
-
-        pathsearch::search_for_executable(paths.into_iter(), filename)
-    }
-
-    /// Finds executables in the shell's current default PATH, with filenames matching the
-    /// given prefix.
-    ///
-    /// # Arguments
-    ///
-    /// * `filename_prefix` - The prefix to match against executable filenames.
-    pub fn find_executables_in_path_with_prefix(
-        &self,
-        filename_prefix: &str,
-        case_insensitive: bool,
-    ) -> impl Iterator<Item = PathBuf> {
-        let path_var = self.env.get_str("PATH", self).unwrap_or_default();
-        let paths = std::env::split_paths(OsStr::new(path_var.as_ref()))
-            .map(|path| path.to_string_lossy().trim_matches('"').to_string());
-
-        pathsearch::search_for_executable_with_prefix(
-            paths.into_iter(),
-            filename_prefix,
-            case_insensitive,
-        )
-    }
-
-    /// Determines whether the given filename is the name of an executable in one of the
-    /// directories in the shell's current PATH. If found, returns the path.
-    ///
-    /// # Arguments
-    ///
-    /// * `candidate_name` - The name of the file to look for.
-    pub fn find_first_executable_in_path<S: AsRef<str>>(
-        &self,
-        candidate_name: S,
-    ) -> Option<PathBuf> {
-        let path_var = self.env_str("PATH").unwrap_or_default();
-        let paths = std::env::split_paths(OsStr::new(path_var.as_ref()))
-            .map(|path| path.to_string_lossy().trim_matches('"').to_string());
-        pathsearch::search_for_executable(paths.into_iter(), candidate_name.as_ref()).next()
-    }
-
-    /// Uses the shell's hash-based path cache to check whether the given filename is the name
-    /// of an executable in one of the directories in the shell's current PATH. If found,
-    /// ensures the path is in the cache and returns it.
-    ///
-    /// # Arguments
-    ///
-    /// * `candidate_name` - The name of the file to look for.
-    pub fn find_first_executable_in_path_using_cache<S: AsRef<str>>(
-        &mut self,
-        candidate_name: S,
-    ) -> Option<PathBuf> {
-        if let Some(cached_path) = self.program_location_cache.get(&candidate_name) {
-            Some(cached_path)
-        } else if let Some(found_path) = self.find_first_executable_in_path(&candidate_name) {
-            self.program_location_cache
-                .set(&candidate_name, found_path.clone());
-            Some(found_path)
-        } else {
-            None
-        }
-    }
-
-    /// Gets the absolute form of the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - The path to get the absolute form of.
-    pub fn absolute_path(&self, path: impl AsRef<Path>) -> PathBuf {
-        let path = path.as_ref();
-        if path.as_os_str().is_empty() || path.is_absolute() {
-            path.to_owned()
-        } else {
-            self.working_dir().join(path)
-        }
-    }
-
-    /// Opens the given file, using the context of this shell and the provided execution parameters.
-    ///
-    /// # Arguments
-    ///
-    /// * `options` - The options to use opening the file.
-    /// * `path` - The path to the file to open; may be relative to the shell's working directory.
-    /// * `params` - Execution parameters.
-    pub(crate) fn open_file(
-        &self,
-        options: &std::fs::OpenOptions,
-        path: impl AsRef<Path>,
-        params: &ExecutionParameters,
-    ) -> Result<openfiles::OpenFile, std::io::Error> {
-        let path_to_open = self.absolute_path(path.as_ref());
-
-        // See if this is a reference to a file descriptor, in which case the actual
-        // /dev/fd* file path for this process may not match with what's in the execution
-        // parameters.
-        if let Some(parent) = path_to_open.parent() {
-            if parent == Path::new("/dev/fd") {
-                if let Some(filename) = path_to_open.file_name() {
-                    if let Ok(fd_num) = filename.to_string_lossy().to_string().parse::<ShellFd>() {
-                        if let Some(open_file) = params.try_fd(self, fd_num) {
-                            return open_file.try_clone();
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(options.open(path_to_open)?.into())
-    }
-
-    /// Sets the shell's current working directory to the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `target_dir` - The path to set as the working directory.
-    pub fn set_working_dir(&mut self, target_dir: impl AsRef<Path>) -> Result<(), error::Error> {
-        let abs_path = self.absolute_path(target_dir.as_ref());
-
-        match std::fs::metadata(&abs_path) {
-            Ok(m) => {
-                if !m.is_dir() {
-                    return Err(error::ErrorKind::NotADirectory(abs_path).into());
-                }
-            }
-            Err(e) => {
-                return Err(e.into());
-            }
-        }
-
-        // Normalize the path (but don't canonicalize it).
-        let cleaned_path = abs_path.normalize();
-
-        let pwd = cleaned_path.to_string_lossy().to_string();
-
-        self.env.update_or_add(
-            "PWD",
-            variables::ShellValueLiteral::Scalar(pwd),
-            |var| {
-                var.export();
-                Ok(())
-            },
-            EnvironmentLookup::Anywhere,
-            EnvironmentScope::Global,
-        )?;
-        let oldpwd = std::mem::replace(self.working_dir_mut(), cleaned_path);
-
-        self.env.update_or_add(
-            "OLDPWD",
-            variables::ShellValueLiteral::Scalar(oldpwd.to_string_lossy().to_string()),
-            |var| {
-                var.export();
-                Ok(())
-            },
-            EnvironmentLookup::Anywhere,
-            EnvironmentScope::Global,
-        )?;
-
-        Ok(())
-    }
-
-    /// Tilde-shortens the given string, replacing the user's home directory with a tilde.
-    ///
-    /// # Arguments
-    ///
-    /// * `s` - The string to shorten.
-    pub fn tilde_shorten(&self, s: String) -> String {
-        if let Some(home_dir) = self.home_dir() {
-            if let Some(stripped) = s.strip_prefix(home_dir.to_string_lossy().as_ref()) {
-                return format!("~{stripped}");
-            }
-        }
-        s
-    }
-
-    /// Returns the shell's current home directory, if available.
-    pub(crate) fn home_dir(&self) -> Option<PathBuf> {
-        if let Some(home) = self.env.get_str("HOME", self) {
-            Some(PathBuf::from(home.to_string()))
-        } else {
-            // HOME isn't set, so let's sort it out ourselves.
-            users::get_current_user_home_dir()
-        }
-    }
-
-    /// Replaces the shell's currently configured open files with the given set.
-    /// Typically only used by exec-like builtins.
-    ///
-    /// # Arguments
-    ///
-    /// * `open_files` - The new set of open files to use.
-    pub fn replace_open_files(
-        &mut self,
-        open_fds: impl Iterator<Item = (ShellFd, openfiles::OpenFile)>,
-    ) {
-        self.open_files = openfiles::OpenFiles::from(open_fds);
-    }
-
-    pub(crate) const fn persistent_open_files(&self) -> &openfiles::OpenFiles {
-        &self.open_files
-    }
-
-    /// Returns a value that can be used to write to the shell's currently configured
-    /// standard output stream using `write!` at al.
-    pub fn stdout(&self) -> impl std::io::Write {
-        self.open_files.try_stdout().cloned().unwrap()
-    }
-
-    /// Returns a value that can be used to write to the shell's currently configured
-    /// standard error stream using `write!` et al.
-    pub fn stderr(&self) -> impl std::io::Write {
-        self.open_files.try_stderr().cloned().unwrap()
-    }
-
-    /// Outputs `set -x` style trace output for a command.
-    ///
-    /// # Arguments
-    ///
-    /// * `command` - The command to trace.
-    pub(crate) async fn trace_command<S: AsRef<str>>(
-        &mut self,
-        params: &ExecutionParameters,
-        command: S,
-    ) -> Result<(), error::Error> {
-        // Expand the PS4 prompt variable to get our prefix.
-        let ps4 = self.as_mut().expand_prompt_var("PS4", "").await?;
-        let mut prefix = ps4;
-
-        // Add additional depth-based prefixes using the first character of PS4.
-        let additional_depth = self.script_call_stack.depth() + self.depth;
-        if let Some(c) = prefix.chars().next() {
-            for _ in 0..additional_depth {
-                prefix.insert(0, c);
-            }
-        }
-
-        // Resolve which file descriptor to use for tracing. We default to stderr.
-        let mut trace_file = params.try_stderr(self);
-
-        // If BASH_XTRACEFD is set and refers to a valid file descriptor, use that instead.
-        if let Some((_, xtracefd_var)) = self.env.get("BASH_XTRACEFD") {
-            let xtracefd_value = xtracefd_var.value().to_cow_str(self);
-            if let Ok(fd) = xtracefd_value.parse::<ShellFd>() {
-                if let Some(file) = self.open_files.try_fd(fd) {
-                    trace_file = Some(file.clone());
-                }
-            }
-        }
-
-        // If we have a valid trace file, write to it.
-        if let Some(trace_file) = trace_file {
-            let mut trace_file = trace_file.try_clone()?;
-            writeln!(trace_file, "{prefix}{}", command.as_ref())?;
-        }
-
-        Ok(())
-    }
-
-    /// Returns the keywords that are reserved by the shell.
-    pub(crate) fn get_keywords(&self) -> Vec<String> {
-        if self.options.sh_mode {
-            keywords::SH_MODE_KEYWORDS.iter().cloned().collect()
-        } else {
-            keywords::KEYWORDS.iter().cloned().collect()
-        }
-    }
-
-    /// Checks if the given string is a keyword reserved in this shell.
-    ///
-    /// # Arguments
-    ///
-    /// * `s` - The string to check.
-    pub fn is_keyword(&self, s: &str) -> bool {
-        if self.options.sh_mode {
-            keywords::SH_MODE_KEYWORDS.contains(s)
-        } else {
-            keywords::KEYWORDS.contains(s)
-        }
-    }
-
-    /// Checks for completed jobs in the shell, reporting any changes found.
-    pub fn check_for_completed_jobs(&mut self) -> Result<(), error::Error> {
-        let results = self.jobs.poll()?;
-
-        if self.options.enable_job_control {
-            for (job, _result) in results {
-                writeln!(self.stderr(), "{job}")?;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Evaluate the given arithmetic expression, returning the result.
-    pub fn eval_arithmetic(
-        &mut self,
-        expr: &brush_parser::ast::ArithmeticExpr,
-    ) -> Result<i64, error::Error> {
-        Ok(expr.eval(self)?)
-    }
-
-    /// Updates the shell state to reflect the given edit buffer contents.
-    ///
-    /// # Arguments
-    ///
-    /// * `contents` - The contents of the edit buffer.
-    /// * `cursor` - The cursor position in the edit buffer.
-    pub fn set_edit_buffer(&mut self, contents: String, cursor: usize) -> Result<(), error::Error> {
-        self.env
-            .set_global("READLINE_LINE", ShellVariable::new(contents))?;
-
-        self.env
-            .set_global("READLINE_POINT", ShellVariable::new(cursor.to_string()))?;
-
-        Ok(())
-    }
-
-    /// Returns the contents of the shell's edit buffer, if any. The buffer
-    /// state is cleared from the shell.
-    pub fn pop_edit_buffer(&mut self) -> Result<Option<(String, usize)>, error::Error> {
-        let line = self
-            .env
-            .unset("READLINE_LINE")?
-            .map(|line| line.value().to_cow_str(self).to_string());
-
-        let point = self
-            .env
-            .unset("READLINE_POINT")?
-            .and_then(|point| point.value().to_cow_str(self).parse::<usize>().ok())
-            .unwrap_or(0);
-
-        if let Some(line) = line {
-            Ok(Some((line, point)))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Returns the shell's history, if it exists.
-    pub const fn history(&self) -> Option<&history::History> {
-        self.history.as_ref()
-    }
-
-    /// Returns a mutable reference to the shell's history, if it exists.
-    pub const fn history_mut(&mut self) -> Option<&mut history::History> {
-        self.history.as_mut()
-    }
-
-    /// Returns whether or not this shell is a subshell.
-    pub const fn is_subshell(&self) -> bool {
-        self.depth > 0
-    }
-
-    /// Returns the current subshell depth; 0 is returned if this shell is not a subshell.
-    pub const fn depth(&self) -> usize {
-        self.depth
-    }
-
-    /// Displays the given error to the user, using the shell's error display mechanisms.
-    ///
-    /// # Arguments
-    ///
-    /// * `file_table` - The open file table to use for any file descriptor references.
-    /// * `err` - The error to display.
-    pub async fn display_error(
-        &self,
-        file: &mut impl std::io::Write,
-        err: &error::Error,
-    ) -> Result<(), error::Error> {
-        let str = self.error_formatter.lock().await.format_error(err, self);
-        write!(file, "{str}")?;
-
-        Ok(())
-    }
+	/// Create an instance of [Shell] using the builder syntax
+	pub fn builder() -> ShellBuilder<shell_builder::Empty> {
+		CreateOptions::builder()
+	}
+
+	/// Returns a new shell instance created with the given options.
+	///
+	/// # Arguments
+	///
+	/// * `options` - The options to use when creating the shell.
+	pub async fn new(options: CreateOptions) -> Result<Self, error::Error> {
+		// Instantiate the shell with some defaults.
+		let mut shell = Self {
+			traps: traps::TrapHandlerConfig::default(),
+			open_files: openfiles::OpenFiles::new(),
+			// Populate working directory from the host environment.
+			working_dir: std::env::current_dir()?,
+			env: env::ShellEnvironment::new(),
+			funcs: functions::FunctionEnv::default(),
+			options: RuntimeOptions::defaults_from(&options),
+			jobs: jobs::JobManager::new(),
+			aliases: HashMap::default(),
+			last_exit_status: 0,
+			last_pipeline_statuses: vec![0],
+			positional_parameters: vec![],
+			shell_name: options.shell_name,
+			version: options.shell_version,
+			product_display_str: options.shell_product_display_str,
+			function_call_stack: functions::CallStack::new(),
+			script_call_stack: scripts::CallStack::new(),
+			directory_stack: vec![],
+			current_line_number: 0,
+			completion_config: completion::Config::default(),
+			builtins: options.builtins,
+			program_location_cache: pathcache::PathCache::default(),
+			last_stopwatch_time: std::time::SystemTime::now(),
+			last_stopwatch_offset: 0,
+			key_bindings: options.key_bindings,
+			history: None,
+			error_formatter: options
+				.error_formatter
+				.unwrap_or_else(|| Arc::new(Mutex::new(error::DefaultErrorFormatter::new()))),
+			depth: 0,
+		};
+
+		// Add in any open files provided.
+		if let Some(fds) = options.fds {
+			shell.open_files.update_from(fds.into_iter());
+		}
+
+		// TODO: Without this a script that sets extglob will fail because we
+		// parse the entire script with the same settings.
+		shell.options.extended_globbing = true;
+
+		// Initialize environment.
+		wellknownvars::initialize_vars(&mut shell, options.do_not_inherit_env)?;
+
+		// Set up history, if relevant.
+		if shell.options.enable_command_history {
+			if let Some(history_path) = shell.history_file_path() {
+				let mut options = std::fs::File::options();
+				options.read(true);
+
+				if let Ok(history_file) =
+					shell.open_file(&options, history_path, &shell.default_exec_params())
+				{
+					shell.history = Some(history::History::import(history_file)?);
+				}
+			}
+
+			if shell.history.is_none() {
+				shell.history = Some(history::History::default());
+			}
+		}
+
+		// Load profiles/configuration.
+		shell
+			.load_config(options.no_profile, options.no_rc, options.rc_file.as_deref())
+			.await?;
+
+		Ok(shell)
+	}
+
+	/// Returns the current source line number being processed.
+	pub const fn current_line_number(&self) -> u32 {
+		self.current_line_number
+	}
+
+	/// Returns the shell's official version string (if available).
+	pub const fn version(&self) -> &Option<String> {
+		&self.version
+	}
+
+	/// Returns the exit status of the last command executed in this shell.
+	pub const fn last_result(&self) -> u8 {
+		self.last_exit_status
+	}
+
+	/// Returns a reference to the current function call stack for the shell.
+	pub const fn function_call_stack(&self) -> &functions::CallStack {
+		&self.function_call_stack
+	}
+
+	/// Returns a reference to the current script call stack for the shell.
+	pub const fn script_call_stack(&self) -> &scripts::CallStack {
+		&self.script_call_stack
+	}
+
+	/// Returns a mutable reference to the last exit status.
+	pub const fn last_exit_status_mut(&mut self) -> &mut u8 {
+		&mut self.last_exit_status
+	}
+
+	/// Returns the key bindings helper for the shell.
+	pub const fn key_bindings(&self) -> &Option<KeyBindingsHelper> {
+		&self.key_bindings
+	}
+
+	/// Returns the registered builtins for the shell.
+	pub const fn builtins(&self) -> &HashMap<String, builtins::Registration> {
+		&self.builtins
+	}
+
+	/// Returns the shell's current working directory.
+	pub fn working_dir(&self) -> &Path {
+		&self.working_dir
+	}
+
+	/// Returns a mutable reference to the shell's current working directory.
+	/// This is only accessible within the crate.
+	pub(crate) const fn working_dir_mut(&mut self) -> &mut PathBuf {
+		&mut self.working_dir
+	}
+
+	/// Returns the product display name for this shell.
+	pub const fn product_display_str(&self) -> &Option<String> {
+		&self.product_display_str
+	}
+
+	/// Returns the function definition environment for this shell.
+	pub const fn funcs(&self) -> &functions::FunctionEnv {
+		&self.funcs
+	}
+
+	/// Tries to undefine a function in the shell's environment. Returns whether or
+	/// not a definition was removed.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the function to undefine.
+	pub fn undefine_func(&mut self, name: &str) -> bool {
+		self.funcs.remove(name).is_some()
+	}
+
+	/// Defines a function in the shell's environment. If a function already exists
+	/// with the given name, it is replaced with the new definition.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the function to define.
+	/// * `definition` - The function's definition.
+	pub fn define_func(
+		&mut self,
+		name: impl Into<String>,
+		definition: brush_parser::ast::FunctionDefinition,
+	) {
+		self.funcs.update(name.into(), definition.into());
+	}
+
+	/// Tries to return a mutable reference to the registration for a named function.
+	/// Returns `None` if no such function was found.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the function to lookup
+	pub fn func_mut(&mut self, name: &str) -> Option<&mut functions::Registration> {
+		self.funcs.get_mut(name)
+	}
+
+	/// Tries to define a function in the shell's environment using the given
+	/// string as its body.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the function
+	/// * `body_text` - The body of the function, expected to start with "()".
+	pub fn define_func_from_str(
+		&mut self,
+		name: impl Into<String>,
+		body_text: &str,
+	) -> Result<(), error::Error> {
+		let name = name.into();
+
+		let mut parser = create_parser(body_text.as_bytes(), &self.parser_options());
+		let func_body = parser
+			.parse_function_parens_and_body()
+			.map_err(|e| error::Error::from(error::ErrorKind::FunctionParseError(name.clone(), e)))?;
+
+		let def = brush_parser::ast::FunctionDefinition {
+			fname: name.clone().into(),
+			body: func_body,
+			source: String::new(),
+		};
+
+		self.define_func(name, def);
+
+		Ok(())
+	}
+
+	/// Returns the last "SECONDS" captured time.
+	pub const fn last_stopwatch_time(&self) -> std::time::SystemTime {
+		self.last_stopwatch_time
+	}
+
+	/// Returns the last "SECONDS" offset requested.
+	pub const fn last_stopwatch_offset(&self) -> u32 {
+		self.last_stopwatch_offset
+	}
+
+	async fn load_config(
+		&mut self,
+		skip_profile: bool,
+		skip_rc: bool,
+		rc_file: Option<&Path>,
+	) -> Result<(), error::Error> {
+		let mut params = self.default_exec_params();
+		params.process_group_policy = interp::ProcessGroupPolicy::SameProcessGroup;
+
+		if self.options.login_shell {
+			// --noprofile means skip this.
+			if skip_profile {
+				return Ok(());
+			}
+
+			//
+			// Source /etc/profile if it exists.
+			//
+			// Next source the first of these that exists and is readable (if any):
+			//     * ~/.bash_profile
+			//     * ~/.bash_login
+			//     * ~/.profile
+			//
+			self
+				.source_if_exists(Path::new("/etc/profile"), &params)
+				.await?;
+			if let Some(home_path) = self.home_dir() {
+				if self.options.sh_mode {
+					self
+						.source_if_exists(home_path.join(".profile").as_path(), &params)
+						.await?;
+				} else {
+					if !self
+						.source_if_exists(home_path.join(".bash_profile").as_path(), &params)
+						.await?
+					{
+						if !self
+							.source_if_exists(home_path.join(".bash_login").as_path(), &params)
+							.await?
+						{
+							self
+								.source_if_exists(home_path.join(".profile").as_path(), &params)
+								.await?;
+						}
+					}
+				}
+			}
+		} else {
+			if self.options.interactive {
+				// --norc means skip this. Also skip in sh mode.
+				if skip_rc || self.options.sh_mode {
+					return Ok(());
+				}
+
+				// If an rc file was specified, then source it.
+				if let Some(rc_file) = rc_file {
+					// If an explicit rc file is provided, source it.
+					self.source_if_exists(rc_file, &params).await?;
+				} else {
+					//
+					// Otherwise, for non-login interactive shells, load in this order:
+					//
+					//     /etc/bash.bashrc
+					//     ~/.bashrc
+					//
+					self
+						.source_if_exists(Path::new("/etc/bash.bashrc"), &params)
+						.await?;
+					if let Some(home_path) = self.home_dir() {
+						self
+							.source_if_exists(home_path.join(".bashrc").as_path(), &params)
+							.await?;
+						self
+							.source_if_exists(home_path.join(".brushrc").as_path(), &params)
+							.await?;
+					}
+				}
+			} else {
+				let env_var_name = if self.options.sh_mode {
+					"ENV"
+				} else {
+					"BASH_ENV"
+				};
+
+				if self.env.is_set(env_var_name) {
+					//
+					// TODO: look at $ENV/BASH_ENV; source its expansion if that file exists
+					//
+					return error::unimp(
+						"load config from $ENV/BASH_ENV for non-interactive, non-login shell",
+					);
+				}
+			}
+		}
+
+		Ok(())
+	}
+
+	async fn source_if_exists(
+		&mut self,
+		path: impl AsRef<Path>,
+		params: &ExecutionParameters,
+	) -> Result<bool, error::Error> {
+		let path = path.as_ref();
+		if path.exists() {
+			self
+				.source_script(path, std::iter::empty::<String>(), params)
+				.await?;
+			Ok(true)
+		} else {
+			tracing::debug!("skipping non-existent file: {}", path.display());
+			Ok(false)
+		}
+	}
+
+	/// Source the given file as a shell script, returning the execution result.
+	///
+	/// # Arguments
+	///
+	/// * `path` - The path to the file to source.
+	/// * `args` - The arguments to pass to the script as positional parameters.
+	/// * `params` - Execution parameters.
+	pub async fn source_script<S: AsRef<str>, P: AsRef<Path>, I: Iterator<Item = S>>(
+		&mut self,
+		path: P,
+		args: I,
+		params: &ExecutionParameters,
+	) -> Result<ExecutionResult, error::Error> {
+		self
+			.parse_and_execute_script_file(path.as_ref(), args, params, scripts::CallType::Sourced)
+			.await
+	}
+
+	/// Parse and execute the given file as a shell script, returning the execution result.
+	///
+	/// # Arguments
+	///
+	/// * `path` - The path to the file to source.
+	/// * `args` - The arguments to pass to the script as positional parameters.
+	/// * `params` - Execution parameters.
+	/// * `call_type` - The type of script call being made.
+	async fn parse_and_execute_script_file<S: AsRef<str>, P: AsRef<Path>, I: Iterator<Item = S>>(
+		&mut self,
+		path: P,
+		args: I,
+		params: &ExecutionParameters,
+		call_type: scripts::CallType,
+	) -> Result<ExecutionResult, error::Error> {
+		let path = path.as_ref();
+		tracing::debug!("sourcing: {}", path.display());
+
+		let mut options = std::fs::File::options();
+		options.read(true);
+
+		let opened_file: openfiles::OpenFile = self
+			.open_file(&options, path, params)
+			.map_err(|e| error::ErrorKind::FailedSourcingFile(path.to_owned(), e))?;
+
+		if opened_file.is_dir() {
+			return Err(
+				error::ErrorKind::FailedSourcingFile(
+					path.to_owned(),
+					std::io::Error::from(std::io::ErrorKind::IsADirectory),
+				)
+				.into(),
+			);
+		}
+
+		let source_info = brush_parser::SourceInfo { source: path.to_string_lossy().to_string() };
+
+		let mut result = self
+			.source_file(opened_file, &source_info, args, params, call_type)
+			.await?;
+
+		// Handle control flow at script execution boundary. If execution completed
+		// with a `return`, we need to clear it since it's already been "used". All
+		// other control flow types are preserved.
+		if matches!(result.next_control_flow, ExecutionControlFlow::ReturnFromFunctionOrScript) {
+			result.next_control_flow = ExecutionControlFlow::Normal;
+		}
+
+		Ok(result)
+	}
+
+	/// Source the given file as a shell script, returning the execution result.
+	///
+	/// # Arguments
+	///
+	/// * `file` - The file to source.
+	/// * `source_info` - Information about the source of the script.
+	/// * `args` - The arguments to pass to the script as positional parameters.
+	/// * `params` - Execution parameters.
+	/// * `call_type` - The type of script call being made.
+	async fn source_file<F: Read, S: AsRef<str>, I: Iterator<Item = S>>(
+		&mut self,
+		file: F,
+		source_info: &brush_parser::SourceInfo,
+		args: I,
+		params: &ExecutionParameters,
+		call_type: scripts::CallType,
+	) -> Result<ExecutionResult, error::Error> {
+		let mut reader = std::io::BufReader::new(file);
+		let mut parser = brush_parser::Parser::new(&mut reader, &self.parser_options(), source_info);
+
+		tracing::debug!(target: trace_categories::PARSE, "Parsing sourced file: {}", source_info.source);
+		let parse_result = parser.parse_program();
+
+		let mut other_positional_parameters: Vec<_> = args.map(|s| s.as_ref().to_owned()).collect();
+		let mut other_shell_name = Some(source_info.source.clone());
+		let positional_params_given = !other_positional_parameters.is_empty();
+
+		// TODO: Find a cleaner way to change args.
+		std::mem::swap(&mut self.shell_name, &mut other_shell_name);
+
+		// NOTE: We only shadow the original positional parameters if any were explicitly given
+		// for the script sourcing.
+		if positional_params_given {
+			std::mem::swap(&mut self.positional_parameters, &mut other_positional_parameters);
+		}
+
+		self
+			.script_call_stack
+			.push(call_type, source_info.source.clone());
+
+		let result = self
+			.run_parsed_result(parse_result, source_info, params)
+			.await;
+
+		self.script_call_stack.pop();
+
+		// Restore.
+		std::mem::swap(&mut self.shell_name, &mut other_shell_name);
+
+		// We only restore the original positional parameters if we needed to shadow them.
+		if positional_params_given {
+			std::mem::swap(&mut self.positional_parameters, &mut other_positional_parameters);
+		}
+
+		result
+	}
+
+	/// Invokes a function defined in this shell, returning the resulting exit status.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the function to invoke.
+	/// * `args` - The arguments to pass to the function.
+	/// * `params` - Execution parameters to use for the invocation.
+	pub async fn invoke_function<N: AsRef<str>, I: IntoIterator<Item = A>, A: AsRef<str>>(
+		&mut self,
+		name: N,
+		args: I,
+		params: &ExecutionParameters,
+	) -> Result<u8, error::Error> {
+		let name = name.as_ref();
+		let command_name = String::from(name);
+
+		let func_registration = self
+			.funcs
+			.get(name)
+			.ok_or_else(|| error::ErrorKind::FunctionNotFound(name.to_owned()))?;
+
+		let func = func_registration.definition.clone();
+
+		let context =
+			commands::ExecutionContext { shell: self, command_name, params: params.clone() };
+
+		let command_args = args
+			.into_iter()
+			.map(|s| commands::CommandArg::String(String::from(s.as_ref())))
+			.collect::<Vec<_>>();
+
+		match commands::invoke_shell_function(func, context, &command_args).await? {
+			ExecutionSpawnResult::StartedProcess(_) => {
+				error::unimp("child spawned from function invocation")
+			},
+			ExecutionSpawnResult::Completed(result) => Ok(result.exit_code.into()),
+		}
+	}
+
+	/// Executes the given string as a shell program, returning the resulting exit status.
+	///
+	/// # Arguments
+	///
+	/// * `command` - The command to execute.
+	/// * `params` - Execution parameters.
+	pub async fn run_string<S: Into<String>>(
+		&mut self,
+		command: S,
+		params: &ExecutionParameters,
+	) -> Result<ExecutionResult, error::Error> {
+		// TODO: Actually track line numbers; this is something of a hack, assuming each time
+		// this function is invoked we are on the next line of the input. For one thing,
+		// each string we run could be multiple lines.
+		self.current_line_number += 1;
+
+		let parse_result = self.parse_string(command.into());
+		let source_info = brush_parser::SourceInfo { source: String::from("main") };
+		self
+			.run_parsed_result(parse_result, &source_info, params)
+			.await
+	}
+
+	/// Parses the given reader as a shell program, returning the resulting Abstract Syntax Tree
+	/// for the program.
+	pub fn parse<R: Read>(
+		&self,
+		reader: R,
+	) -> Result<brush_parser::ast::Program, brush_parser::ParseError> {
+		let mut parser = create_parser(reader, &self.parser_options());
+
+		tracing::debug!(target: trace_categories::PARSE, "Parsing reader as program...");
+		parser.parse_program()
+	}
+
+	/// Parses the given string as a shell program, returning the resulting Abstract Syntax Tree
+	/// for the program.
+	///
+	/// # Arguments
+	///
+	/// * `s` - The string to parse as a program.
+	pub fn parse_string<S: Into<String>>(
+		&self,
+		s: S,
+	) -> Result<brush_parser::ast::Program, brush_parser::ParseError> {
+		parse_string_impl(s.into(), self.parser_options())
+	}
+
+	/// Applies basic shell expansion to the provided string.
+	///
+	/// # Arguments
+	///
+	/// * `s` - The string to expand.
+	pub async fn basic_expand_string<S: AsRef<str>>(
+		&mut self,
+		params: &ExecutionParameters,
+		s: S,
+	) -> Result<String, error::Error> {
+		let result = expansion::basic_expand_str(self, params, s.as_ref()).await?;
+		Ok(result)
+	}
+
+	/// Applies full shell expansion and field splitting to the provided string; returns
+	/// a sequence of fields.
+	///
+	/// # Arguments
+	///
+	/// * `s` - The string to expand and split.
+	pub async fn full_expand_and_split_string<S: AsRef<str>>(
+		&mut self,
+		params: &ExecutionParameters,
+		s: S,
+	) -> Result<Vec<String>, error::Error> {
+		let result = expansion::full_expand_and_split_str(self, params, s.as_ref()).await?;
+		Ok(result)
+	}
+
+	/// Returns the default execution parameters for this shell.
+	pub fn default_exec_params(&self) -> ExecutionParameters {
+		ExecutionParameters::default()
+	}
+
+	/// Executes the given script file, returning the resulting exit status.
+	///
+	/// # Arguments
+	///
+	/// * `script_path` - The path to the script file to execute.
+	/// * `args` - The arguments to pass to the script as positional parameters.
+	pub async fn run_script<S: AsRef<str>, P: AsRef<Path>, I: Iterator<Item = S>>(
+		&mut self,
+		script_path: P,
+		args: I,
+	) -> Result<ExecutionResult, error::Error> {
+		let params = self.default_exec_params();
+		let result = self
+			.parse_and_execute_script_file(
+				script_path.as_ref(),
+				args,
+				&params,
+				scripts::CallType::Executed,
+			)
+			.await?;
+
+		let _ = self.on_exit().await;
+
+		Ok(result)
+	}
+
+	/// Runs any exit steps for the shell.
+	pub async fn on_exit(&mut self) -> Result<(), error::Error> {
+		self.invoke_exit_trap_handler_if_registered().await?;
+
+		Ok(())
+	}
+
+	async fn invoke_exit_trap_handler_if_registered(
+		&mut self,
+	) -> Result<ExecutionResult, error::Error> {
+		let Some(handler) = self.traps.handlers.get(&traps::TrapSignal::Exit).cloned() else {
+			return Ok(ExecutionResult::success());
+		};
+
+		// TODO: Confirm whether trap handlers should be executed in the same process group.
+		let mut params = self.default_exec_params();
+		params.process_group_policy = ProcessGroupPolicy::SameProcessGroup;
+
+		let orig_last_exit_status = self.last_exit_status;
+		self.traps.handler_depth += 1;
+
+		let result = self.run_string(handler, &params).await;
+
+		self.traps.handler_depth -= 1;
+		self.last_exit_status = orig_last_exit_status;
+
+		result
+	}
+
+	pub(crate) async fn run_parsed_result(
+		&mut self,
+		parse_result: Result<brush_parser::ast::Program, brush_parser::ParseError>,
+		source_info: &brush_parser::SourceInfo,
+		params: &ExecutionParameters,
+	) -> Result<ExecutionResult, error::Error> {
+		// If parsing succeeded, run the program.
+		let result = match parse_result {
+			Ok(prog) => self.run_program(prog, params).await,
+			Err(parse_err) => {
+				Err(error::Error::from(error::ErrorKind::ParseError(parse_err, source_info.clone())))
+			},
+		};
+
+		// Report any errors.
+		match result {
+			Ok(result) => Ok(result),
+			Err(err) => {
+				let _ = self.display_error(&mut params.stderr(self), &err).await;
+				let exit_code = ExecutionExitCode::from(&err);
+				*self.last_exit_status_mut() = exit_code.into();
+				Ok(exit_code.into())
+			},
+		}
+	}
+
+	/// Executes the given parsed shell program, returning the resulting exit status.
+	///
+	/// # Arguments
+	///
+	/// * `program` - The program to execute.
+	/// * `params` - Execution parameters.
+	pub async fn run_program(
+		&mut self,
+		program: brush_parser::ast::Program,
+		params: &ExecutionParameters,
+	) -> Result<ExecutionResult, error::Error> {
+		program.execute(self, params).await
+	}
+
+	const fn default_prompt(&self) -> &'static str {
+		if self.options.sh_mode {
+			"$ "
+		} else {
+			"brush$ "
+		}
+	}
+
+	/// Composes the shell's post-input, pre-command prompt, applying all appropriate expansions.
+	pub async fn compose_precmd_prompt(&mut self) -> Result<String, error::Error> {
+		self.expand_prompt_var("PS0", "").await
+	}
+
+	/// Composes the shell's prompt, applying all appropriate expansions.
+	pub async fn compose_prompt(&mut self) -> Result<String, error::Error> {
+		self.expand_prompt_var("PS1", self.default_prompt()).await
+	}
+
+	/// Compose's the shell's alternate-side prompt, applying all appropriate expansions.
+	pub async fn compose_alt_side_prompt(&mut self) -> Result<String, error::Error> {
+		// This is a brush extension.
+		self.expand_prompt_var("BRUSH_PS_ALT", "").await
+	}
+
+	/// Composes the shell's continuation prompt.
+	pub async fn compose_continuation_prompt(&mut self) -> Result<String, error::Error> {
+		self.expand_prompt_var("PS2", "> ").await
+	}
+
+	async fn expand_prompt_var(
+		&mut self,
+		var_name: &str,
+		default: &str,
+	) -> Result<String, error::Error> {
+		//
+		// TODO(prompt): bash appears to do this in a subshell; we need to investigate
+		// if that's required.
+		//
+
+		// Retrieve the spec.
+		let prompt_spec = self.parameter_or_default(var_name, default);
+		if prompt_spec.is_empty() {
+			return Ok(String::new());
+		}
+
+		// Expand it.
+		let params = self.default_exec_params();
+		prompt::expand_prompt(self, &params, prompt_spec.into_owned()).await
+	}
+
+	fn parameter_or_default<'a>(&'a self, name: &str, default: &'a str) -> Cow<'a, str> {
+		self.env_str(name).unwrap_or_else(|| default.into())
+	}
+
+	/// Returns the options that should be used for parsing shell programs; reflects
+	/// the current configuration state of the shell and may change over time.
+	pub const fn parser_options(&self) -> brush_parser::ParserOptions {
+		brush_parser::ParserOptions {
+			enable_extended_globbing: self.options.extended_globbing,
+			posix_mode: self.options.posix_mode,
+			sh_mode: self.options.sh_mode,
+			tilde_expansion: true,
+		}
+	}
+
+	/// Returns whether or not the shell is actively executing in a sourced script.
+	pub fn in_sourced_script(&self) -> bool {
+		self.script_call_stack.in_sourced_script()
+	}
+
+	/// Returns whether or not the shell is actively executing in a shell function.
+	pub fn in_function(&self) -> bool {
+		!self.function_call_stack.is_empty()
+	}
+
+	/// Updates the shell's internal tracking state to reflect that a new shell
+	/// function is being entered.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the function being entered.
+	/// * `function_def` - The definition of the function being entered.
+	pub(crate) fn enter_function(
+		&mut self,
+		name: &str,
+		function_def: &Arc<brush_parser::ast::FunctionDefinition>,
+	) -> Result<(), error::Error> {
+		if let Some(max_call_depth) = self.options.max_function_call_depth {
+			if self.function_call_stack.depth() >= max_call_depth {
+				return Err(error::ErrorKind::MaxFunctionCallDepthExceeded.into());
+			}
+		}
+
+		if tracing::enabled!(target: trace_categories::FUNCTIONS, tracing::Level::DEBUG) {
+			let depth = self.function_call_stack.depth();
+			let prefix = repeated_char_str(' ', depth);
+			tracing::debug!(target: trace_categories::FUNCTIONS, "Entering func [depth={depth}]: {prefix}{name}");
+		}
+
+		self.function_call_stack.push(name, function_def);
+		self.env.push_scope(env::EnvironmentScope::Local);
+
+		Ok(())
+	}
+
+	/// Updates the shell's internal tracking state to reflect that the shell
+	/// has exited the top-most function on its call stack.
+	pub(crate) fn leave_function(&mut self) -> Result<(), error::Error> {
+		self.env.pop_scope(env::EnvironmentScope::Local)?;
+
+		if let Some(exited_call) = self.function_call_stack.pop() {
+			if tracing::enabled!(target: trace_categories::FUNCTIONS, tracing::Level::DEBUG) {
+				let depth = self.function_call_stack.depth();
+				let prefix = repeated_char_str(' ', depth);
+				tracing::debug!(target: trace_categories::FUNCTIONS, "Exiting func  [depth={depth}]: {prefix}{}", exited_call.function_name);
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Returns the path to the history file used by the shell, if one is set.
+	pub fn history_file_path(&self) -> Option<PathBuf> {
+		self
+			.env_str("HISTFILE")
+			.map(|s| PathBuf::from(s.into_owned()))
+	}
+
+	/// Returns the path to the history file used by the shell, if one is set.
+	pub fn history_time_format(&self) -> Option<String> {
+		self.env_str("HISTTIMEFORMAT").map(|s| s.into_owned())
+	}
+
+	/// Saves history back to any backing storage.
+	pub fn save_history(&mut self) -> Result<(), error::Error> {
+		if let Some(history_file_path) = self.history_file_path() {
+			if let Some(history) = &mut self.history {
+				// See if there's *any* time format configured. That triggers writing out timestamps.
+				let write_timestamps = self.env.is_set("HISTTIMEFORMAT");
+
+				// TODO: Observe options.append_to_history_file
+				history.flush(
+					history_file_path,
+					true, /*append?*/
+					true, /*unsaved items only?*/
+					write_timestamps,
+				)?;
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Adds a command to history.
+	pub fn add_to_history(&mut self, command: &str) -> Result<(), error::Error> {
+		if let Some(history) = &mut self.history {
+			// Trim.
+			let command = command.trim();
+
+			// For now, discard empty commands.
+			if command.is_empty() {
+				return Ok(());
+			}
+
+			// Add it to history.
+			history.add(history::Item {
+				id: 0,
+				command_line: command.to_owned(),
+				timestamp: Some(chrono::Utc::now()),
+				dirty: true,
+			})?;
+		}
+
+		Ok(())
+	}
+
+	/// Tries to retrieve a variable from the shell's environment, converting it into its
+	/// string form.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to retrieve.
+	pub fn env_str(&self, name: &str) -> Option<Cow<'_, str>> {
+		self.env.get_str(name, self)
+	}
+
+	/// Tries to retrieve a variable from the shell's environment.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to retrieve.
+	pub fn env_var(&self, name: &str) -> Option<&ShellVariable> {
+		self.env.get(name).map(|(_, var)| var)
+	}
+
+	/// Tries to set a global variable in the shell's environment.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the variable to add.
+	/// * `var` - The variable contents to add.
+	pub fn set_env_global(&mut self, name: &str, var: ShellVariable) -> Result<(), error::Error> {
+		self.env.set_global(name, var)
+	}
+
+	/// Register a builtin to the shell's environment.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The in-shell name of the builtin.
+	/// * `registration` - The registration handle for the builtin.
+	pub fn register_builtin<S: Into<String>>(
+		&mut self,
+		name: S,
+		registration: builtins::Registration,
+	) {
+		self.builtins.insert(name.into(), registration);
+	}
+
+	/// Tries to retrieve a mutable reference to an existing builtin registration.
+	/// Returns `None` if no such registration exists.
+	///
+	/// # Arguments
+	///
+	/// * `name` - The name of the builtin to lookup.
+	pub fn builtin_mut(&mut self, name: &str) -> Option<&mut builtins::Registration> {
+		self.builtins.get_mut(name)
+	}
+
+	/// Returns the current value of the IFS variable, or the default value if it is not set.
+	pub fn ifs(&self) -> Cow<'_, str> {
+		self.env_str("IFS").unwrap_or_else(|| " \t\n".into())
+	}
+
+	/// Returns the first character of the IFS variable, or a space if it is not set.
+	pub(crate) fn get_ifs_first_char(&self) -> char {
+		self.ifs().chars().next().unwrap_or(' ')
+	}
+
+	/// Generates command completions for the shell.
+	///
+	/// # Arguments
+	///
+	/// * `input` - The input string to generate completions for.
+	/// * `position` - The position in the input string to generate completions at.
+	pub async fn complete(
+		&mut self,
+		input: &str,
+		position: usize,
+	) -> Result<completion::Completions, error::Error> {
+		let completion_config = self.completion_config.clone();
+		completion_config
+			.get_completions(self, input, position)
+			.await
+	}
+
+	/// Finds executables in the shell's current default PATH, matching the given glob pattern.
+	///
+	/// # Arguments
+	///
+	/// * `required_glob_pattern` - The glob pattern to match against.
+	pub fn find_executables_in_path<'a>(
+		&'a self,
+		filename: &'a str,
+	) -> impl Iterator<Item = PathBuf> + 'a {
+		let path_var = self.env.get_str("PATH", self).unwrap_or_default();
+		let paths = std::env::split_paths(OsStr::new(path_var.as_ref()))
+			.map(|path| path.to_string_lossy().trim_matches('"').to_string());
+
+		pathsearch::search_for_executable(paths.into_iter(), filename)
+	}
+
+	/// Finds executables in the shell's current default PATH, with filenames matching the
+	/// given prefix.
+	///
+	/// # Arguments
+	///
+	/// * `filename_prefix` - The prefix to match against executable filenames.
+	pub fn find_executables_in_path_with_prefix(
+		&self,
+		filename_prefix: &str,
+		case_insensitive: bool,
+	) -> impl Iterator<Item = PathBuf> {
+		let path_var = self.env.get_str("PATH", self).unwrap_or_default();
+		let paths = std::env::split_paths(OsStr::new(path_var.as_ref()))
+			.map(|path| path.to_string_lossy().trim_matches('"').to_string());
+
+		pathsearch::search_for_executable_with_prefix(
+			paths.into_iter(),
+			filename_prefix,
+			case_insensitive,
+		)
+	}
+
+	/// Determines whether the given filename is the name of an executable in one of the
+	/// directories in the shell's current PATH. If found, returns the path.
+	///
+	/// # Arguments
+	///
+	/// * `candidate_name` - The name of the file to look for.
+	pub fn find_first_executable_in_path<S: AsRef<str>>(
+		&self,
+		candidate_name: S,
+	) -> Option<PathBuf> {
+		let path_var = self.env_str("PATH").unwrap_or_default();
+		let paths = std::env::split_paths(OsStr::new(path_var.as_ref()))
+			.map(|path| path.to_string_lossy().trim_matches('"').to_string());
+		pathsearch::search_for_executable(paths.into_iter(), candidate_name.as_ref()).next()
+	}
+
+	/// Uses the shell's hash-based path cache to check whether the given filename is the name
+	/// of an executable in one of the directories in the shell's current PATH. If found,
+	/// ensures the path is in the cache and returns it.
+	///
+	/// # Arguments
+	///
+	/// * `candidate_name` - The name of the file to look for.
+	pub fn find_first_executable_in_path_using_cache<S: AsRef<str>>(
+		&mut self,
+		candidate_name: S,
+	) -> Option<PathBuf> {
+		if let Some(cached_path) = self.program_location_cache.get(&candidate_name) {
+			Some(cached_path)
+		} else if let Some(found_path) = self.find_first_executable_in_path(&candidate_name) {
+			self
+				.program_location_cache
+				.set(&candidate_name, found_path.clone());
+			Some(found_path)
+		} else {
+			None
+		}
+	}
+
+	/// Gets the absolute form of the given path.
+	///
+	/// # Arguments
+	///
+	/// * `path` - The path to get the absolute form of.
+	pub fn absolute_path(&self, path: impl AsRef<Path>) -> PathBuf {
+		let path = path.as_ref();
+		if path.as_os_str().is_empty() || path.is_absolute() {
+			path.to_owned()
+		} else {
+			self.working_dir().join(path)
+		}
+	}
+
+	/// Opens the given file, using the context of this shell and the provided execution parameters.
+	///
+	/// # Arguments
+	///
+	/// * `options` - The options to use opening the file.
+	/// * `path` - The path to the file to open; may be relative to the shell's working directory.
+	/// * `params` - Execution parameters.
+	pub(crate) fn open_file(
+		&self,
+		options: &std::fs::OpenOptions,
+		path: impl AsRef<Path>,
+		params: &ExecutionParameters,
+	) -> Result<openfiles::OpenFile, std::io::Error> {
+		let path_to_open = self.absolute_path(path.as_ref());
+
+		// See if this is a reference to a file descriptor, in which case the actual
+		// /dev/fd* file path for this process may not match with what's in the execution
+		// parameters.
+		if let Some(parent) = path_to_open.parent() {
+			if parent == Path::new("/dev/fd") {
+				if let Some(filename) = path_to_open.file_name() {
+					if let Ok(fd_num) = filename.to_string_lossy().to_string().parse::<ShellFd>() {
+						if let Some(open_file) = params.try_fd(self, fd_num) {
+							return open_file.try_clone();
+						}
+					}
+				}
+			}
+		}
+
+		Ok(options.open(path_to_open)?.into())
+	}
+
+	/// Sets the shell's current working directory to the given path.
+	///
+	/// # Arguments
+	///
+	/// * `target_dir` - The path to set as the working directory.
+	pub fn set_working_dir(&mut self, target_dir: impl AsRef<Path>) -> Result<(), error::Error> {
+		let abs_path = self.absolute_path(target_dir.as_ref());
+
+		match std::fs::metadata(&abs_path) {
+			Ok(m) => {
+				if !m.is_dir() {
+					return Err(error::ErrorKind::NotADirectory(abs_path).into());
+				}
+			},
+			Err(e) => {
+				return Err(e.into());
+			},
+		}
+
+		// Normalize the path (but don't canonicalize it).
+		let cleaned_path = abs_path.normalize();
+
+		let pwd = cleaned_path.to_string_lossy().to_string();
+
+		self.env.update_or_add(
+			"PWD",
+			variables::ShellValueLiteral::Scalar(pwd),
+			|var| {
+				var.export();
+				Ok(())
+			},
+			EnvironmentLookup::Anywhere,
+			EnvironmentScope::Global,
+		)?;
+		let oldpwd = std::mem::replace(self.working_dir_mut(), cleaned_path);
+
+		self.env.update_or_add(
+			"OLDPWD",
+			variables::ShellValueLiteral::Scalar(oldpwd.to_string_lossy().to_string()),
+			|var| {
+				var.export();
+				Ok(())
+			},
+			EnvironmentLookup::Anywhere,
+			EnvironmentScope::Global,
+		)?;
+
+		Ok(())
+	}
+
+	/// Tilde-shortens the given string, replacing the user's home directory with a tilde.
+	///
+	/// # Arguments
+	///
+	/// * `s` - The string to shorten.
+	pub fn tilde_shorten(&self, s: String) -> String {
+		if let Some(home_dir) = self.home_dir() {
+			if let Some(stripped) = s.strip_prefix(home_dir.to_string_lossy().as_ref()) {
+				return format!("~{stripped}");
+			}
+		}
+		s
+	}
+
+	/// Returns the shell's current home directory, if available.
+	pub(crate) fn home_dir(&self) -> Option<PathBuf> {
+		if let Some(home) = self.env.get_str("HOME", self) {
+			Some(PathBuf::from(home.to_string()))
+		} else {
+			// HOME isn't set, so let's sort it out ourselves.
+			users::get_current_user_home_dir()
+		}
+	}
+
+	/// Replaces the shell's currently configured open files with the given set.
+	/// Typically only used by exec-like builtins.
+	///
+	/// # Arguments
+	///
+	/// * `open_files` - The new set of open files to use.
+	pub fn replace_open_files(
+		&mut self,
+		open_fds: impl Iterator<Item = (ShellFd, openfiles::OpenFile)>,
+	) {
+		self.open_files = openfiles::OpenFiles::from(open_fds);
+	}
+
+	pub(crate) const fn persistent_open_files(&self) -> &openfiles::OpenFiles {
+		&self.open_files
+	}
+
+	/// Returns a value that can be used to write to the shell's currently configured
+	/// standard output stream using `write!` at al.
+	pub fn stdout(&self) -> impl std::io::Write {
+		self.open_files.try_stdout().cloned().unwrap()
+	}
+
+	/// Returns a value that can be used to write to the shell's currently configured
+	/// standard error stream using `write!` et al.
+	pub fn stderr(&self) -> impl std::io::Write {
+		self.open_files.try_stderr().cloned().unwrap()
+	}
+
+	/// Outputs `set -x` style trace output for a command.
+	///
+	/// # Arguments
+	///
+	/// * `command` - The command to trace.
+	pub(crate) async fn trace_command<S: AsRef<str>>(
+		&mut self,
+		params: &ExecutionParameters,
+		command: S,
+	) -> Result<(), error::Error> {
+		// Expand the PS4 prompt variable to get our prefix.
+		let ps4 = self.as_mut().expand_prompt_var("PS4", "").await?;
+		let mut prefix = ps4;
+
+		// Add additional depth-based prefixes using the first character of PS4.
+		let additional_depth = self.script_call_stack.depth() + self.depth;
+		if let Some(c) = prefix.chars().next() {
+			for _ in 0..additional_depth {
+				prefix.insert(0, c);
+			}
+		}
+
+		// Resolve which file descriptor to use for tracing. We default to stderr.
+		let mut trace_file = params.try_stderr(self);
+
+		// If BASH_XTRACEFD is set and refers to a valid file descriptor, use that instead.
+		if let Some((_, xtracefd_var)) = self.env.get("BASH_XTRACEFD") {
+			let xtracefd_value = xtracefd_var.value().to_cow_str(self);
+			if let Ok(fd) = xtracefd_value.parse::<ShellFd>() {
+				if let Some(file) = self.open_files.try_fd(fd) {
+					trace_file = Some(file.clone());
+				}
+			}
+		}
+
+		// If we have a valid trace file, write to it.
+		if let Some(trace_file) = trace_file {
+			let mut trace_file = trace_file.try_clone()?;
+			writeln!(trace_file, "{prefix}{}", command.as_ref())?;
+		}
+
+		Ok(())
+	}
+
+	/// Returns the keywords that are reserved by the shell.
+	pub(crate) fn get_keywords(&self) -> Vec<String> {
+		if self.options.sh_mode {
+			keywords::SH_MODE_KEYWORDS.iter().cloned().collect()
+		} else {
+			keywords::KEYWORDS.iter().cloned().collect()
+		}
+	}
+
+	/// Checks if the given string is a keyword reserved in this shell.
+	///
+	/// # Arguments
+	///
+	/// * `s` - The string to check.
+	pub fn is_keyword(&self, s: &str) -> bool {
+		if self.options.sh_mode {
+			keywords::SH_MODE_KEYWORDS.contains(s)
+		} else {
+			keywords::KEYWORDS.contains(s)
+		}
+	}
+
+	/// Checks for completed jobs in the shell, reporting any changes found.
+	pub fn check_for_completed_jobs(&mut self) -> Result<(), error::Error> {
+		let results = self.jobs.poll()?;
+
+		if self.options.enable_job_control {
+			for (job, _result) in results {
+				writeln!(self.stderr(), "{job}")?;
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Evaluate the given arithmetic expression, returning the result.
+	pub fn eval_arithmetic(
+		&mut self,
+		expr: &brush_parser::ast::ArithmeticExpr,
+	) -> Result<i64, error::Error> {
+		Ok(expr.eval(self)?)
+	}
+
+	/// Updates the shell state to reflect the given edit buffer contents.
+	///
+	/// # Arguments
+	///
+	/// * `contents` - The contents of the edit buffer.
+	/// * `cursor` - The cursor position in the edit buffer.
+	pub fn set_edit_buffer(&mut self, contents: String, cursor: usize) -> Result<(), error::Error> {
+		self
+			.env
+			.set_global("READLINE_LINE", ShellVariable::new(contents))?;
+
+		self
+			.env
+			.set_global("READLINE_POINT", ShellVariable::new(cursor.to_string()))?;
+
+		Ok(())
+	}
+
+	/// Returns the contents of the shell's edit buffer, if any. The buffer
+	/// state is cleared from the shell.
+	pub fn pop_edit_buffer(&mut self) -> Result<Option<(String, usize)>, error::Error> {
+		let line = self
+			.env
+			.unset("READLINE_LINE")?
+			.map(|line| line.value().to_cow_str(self).to_string());
+
+		let point = self
+			.env
+			.unset("READLINE_POINT")?
+			.and_then(|point| point.value().to_cow_str(self).parse::<usize>().ok())
+			.unwrap_or(0);
+
+		if let Some(line) = line {
+			Ok(Some((line, point)))
+		} else {
+			Ok(None)
+		}
+	}
+
+	/// Returns the shell's history, if it exists.
+	pub const fn history(&self) -> Option<&history::History> {
+		self.history.as_ref()
+	}
+
+	/// Returns a mutable reference to the shell's history, if it exists.
+	pub const fn history_mut(&mut self) -> Option<&mut history::History> {
+		self.history.as_mut()
+	}
+
+	/// Returns whether or not this shell is a subshell.
+	pub const fn is_subshell(&self) -> bool {
+		self.depth > 0
+	}
+
+	/// Returns the current subshell depth; 0 is returned if this shell is not a subshell.
+	pub const fn depth(&self) -> usize {
+		self.depth
+	}
+
+	/// Displays the given error to the user, using the shell's error display mechanisms.
+	///
+	/// # Arguments
+	///
+	/// * `file_table` - The open file table to use for any file descriptor references.
+	/// * `err` - The error to display.
+	pub async fn display_error(
+		&self,
+		file: &mut impl std::io::Write,
+		err: &error::Error,
+	) -> Result<(), error::Error> {
+		let str = self.error_formatter.lock().await.format_error(err, self);
+		write!(file, "{str}")?;
+
+		Ok(())
+	}
 }
 
 #[cached::proc_macro::cached(size = 64, result = true)]
 fn parse_string_impl(
-    s: String,
-    parser_options: brush_parser::ParserOptions,
+	s: String,
+	parser_options: brush_parser::ParserOptions,
 ) -> Result<brush_parser::ast::Program, brush_parser::ParseError> {
-    let mut parser = create_parser(s.as_bytes(), &parser_options);
+	let mut parser = create_parser(s.as_bytes(), &parser_options);
 
-    tracing::debug!(target: trace_categories::PARSE, "Parsing string as program...");
-    parser.parse_program()
+	tracing::debug!(target: trace_categories::PARSE, "Parsing string as program...");
+	parser.parse_program()
 }
 
 fn create_parser<R: Read>(
-    r: R,
-    parser_options: &brush_parser::ParserOptions,
+	r: R,
+	parser_options: &brush_parser::ParserOptions,
 ) -> brush_parser::Parser<std::io::BufReader<R>> {
-    let reader = std::io::BufReader::new(r);
-    let source_info = brush_parser::SourceInfo {
-        source: String::from("main"),
-    };
+	let reader = std::io::BufReader::new(r);
+	let source_info = brush_parser::SourceInfo { source: String::from("main") };
 
-    brush_parser::Parser::new(reader, parser_options, &source_info)
+	brush_parser::Parser::new(reader, parser_options, &source_info)
 }
 
 fn repeated_char_str(c: char, count: usize) -> String {
-    (0..count).map(|_| c).collect()
+	(0..count).map(|_| c).collect()
 }

--- a/crates/brush-core-vendored/src/sys/fs.rs
+++ b/crates/brush-core-vendored/src/sys/fs.rs
@@ -4,28 +4,28 @@ pub use super::platform::fs::*;
 
 /// Extension trait for path-related filesystem operations.
 pub trait PathExt {
-    /// Returns true if the path exists and is readable by the current user.
-    fn readable(&self) -> bool;
-    /// Returns true if the path exists and is writable by the current user.
-    fn writable(&self) -> bool;
-    /// Returns true if the path exists and is executable by the current user.
-    fn executable(&self) -> bool;
+	/// Returns true if the path exists and is readable by the current user.
+	fn readable(&self) -> bool;
+	/// Returns true if the path exists and is writable by the current user.
+	fn writable(&self) -> bool;
+	/// Returns true if the path exists and is executable by the current user.
+	fn executable(&self) -> bool;
 
-    /// Returns true if the path exists and is a block device.
-    fn exists_and_is_block_device(&self) -> bool;
-    /// Returns true if the path exists and is a character device.
-    fn exists_and_is_char_device(&self) -> bool;
-    /// Returns true if the path exists and is a FIFO (named pipe).
-    fn exists_and_is_fifo(&self) -> bool;
-    /// Returns true if the path exists and is a socket.
-    fn exists_and_is_socket(&self) -> bool;
-    /// Returns true if the path exists and has the setgid bit set.
-    fn exists_and_is_setgid(&self) -> bool;
-    /// Returns true if the path exists and has the setuid bit set.
-    fn exists_and_is_setuid(&self) -> bool;
-    /// Returns true if the path exists and has the sticky bit set.
-    fn exists_and_is_sticky_bit(&self) -> bool;
+	/// Returns true if the path exists and is a block device.
+	fn exists_and_is_block_device(&self) -> bool;
+	/// Returns true if the path exists and is a character device.
+	fn exists_and_is_char_device(&self) -> bool;
+	/// Returns true if the path exists and is a FIFO (named pipe).
+	fn exists_and_is_fifo(&self) -> bool;
+	/// Returns true if the path exists and is a socket.
+	fn exists_and_is_socket(&self) -> bool;
+	/// Returns true if the path exists and has the setgid bit set.
+	fn exists_and_is_setgid(&self) -> bool;
+	/// Returns true if the path exists and has the setuid bit set.
+	fn exists_and_is_setuid(&self) -> bool;
+	/// Returns true if the path exists and has the sticky bit set.
+	fn exists_and_is_sticky_bit(&self) -> bool;
 
-    /// Returns the device ID and inode number for the path.
-    fn get_device_and_inode(&self) -> Result<(u64, u64), crate::error::Error>;
+	/// Returns the device ID and inode number for the path.
+	fn get_device_and_inode(&self) -> Result<(u64, u64), crate::error::Error>;
 }

--- a/crates/brush-core-vendored/src/sys/hostname.rs
+++ b/crates/brush-core-vendored/src/sys/hostname.rs
@@ -1,3 +1,3 @@
 pub(crate) fn get() -> std::io::Result<std::ffi::OsString> {
-    hostname::get()
+	hostname::get()
 }

--- a/crates/brush-core-vendored/src/sys/stubs/commands.rs
+++ b/crates/brush-core-vendored/src/sys/stubs/commands.rs
@@ -6,84 +6,84 @@ use crate::{ShellFd, error, openfiles};
 
 /// Extension trait for Unix-like command extensions.
 pub trait CommandExt {
-    /// Sets the zeroth argument (argv[0]) of the command.
-    ///
-    /// # Arguments
-    ///
-    /// * `arg` - The argument to set as argv[0].
-    fn arg0<S>(&mut self, arg: S) -> &mut Self
-    where
-        S: AsRef<OsStr>;
+	/// Sets the zeroth argument (argv[0]) of the command.
+	///
+	/// # Arguments
+	///
+	/// * `arg` - The argument to set as argv[0].
+	fn arg0<S>(&mut self, arg: S) -> &mut Self
+	where
+		S: AsRef<OsStr>;
 
-    /// Sets the process group ID of the command.
-    ///
-    /// # Arguments
-    ///
-    /// * `pgroup` - The process group ID to set.
-    fn process_group(&mut self, pgroup: i32) -> &mut Self;
+	/// Sets the process group ID of the command.
+	///
+	/// # Arguments
+	///
+	/// * `pgroup` - The process group ID to set.
+	fn process_group(&mut self, pgroup: i32) -> &mut Self;
 }
 
 impl CommandExt for std::process::Command {
-    fn arg0<S>(&mut self, _arg: S) -> &mut Self
-    where
-        S: AsRef<OsStr>,
-    {
-        // NOTE: no-op.
-        self
-    }
+	fn arg0<S>(&mut self, _arg: S) -> &mut Self
+	where
+		S: AsRef<OsStr>,
+	{
+		// NOTE: no-op.
+		self
+	}
 
-    fn process_group(&mut self, _pgroup: i32) -> &mut Self {
-        // NOTE: no-op.
-        self
-    }
+	fn process_group(&mut self, _pgroup: i32) -> &mut Self {
+		// NOTE: no-op.
+		self
+	}
 }
 
 /// Extension trait for Unix-like exit status extensions.
 pub trait ExitStatusExt {
-    /// Returns the signal that terminated the process, if any.
-    fn signal(&self) -> Option<i32>;
+	/// Returns the signal that terminated the process, if any.
+	fn signal(&self) -> Option<i32>;
 }
 
 impl ExitStatusExt for std::process::ExitStatus {
-    fn signal(&self) -> Option<i32> {
-        None
-    }
+	fn signal(&self) -> Option<i32> {
+		None
+	}
 }
 
 /// Extension trait for injecting file descriptors into commands.
 pub trait CommandFdInjectionExt {
-    /// Injects the given open files as file descriptors into the command.
-    ///
-    /// # Arguments
-    ///
-    /// * `open_files` - A mapping of child file descriptors to open files.
-    fn inject_fds(
-        &mut self,
-        open_files: impl Iterator<Item = (ShellFd, openfiles::OpenFile)>,
-    ) -> Result<(), error::Error>;
+	/// Injects the given open files as file descriptors into the command.
+	///
+	/// # Arguments
+	///
+	/// * `open_files` - A mapping of child file descriptors to open files.
+	fn inject_fds(
+		&mut self,
+		open_files: impl Iterator<Item = (ShellFd, openfiles::OpenFile)>,
+	) -> Result<(), error::Error>;
 }
 
 impl CommandFdInjectionExt for std::process::Command {
-    fn inject_fds(
-        &mut self,
-        mut open_files: impl Iterator<Item = (ShellFd, openfiles::OpenFile)>,
-    ) -> Result<(), error::Error> {
-        if open_files.next().is_some() {
-            return Err(error::ErrorKind::NotSupportedOnThisPlatform("fd redirections").into());
-        }
+	fn inject_fds(
+		&mut self,
+		mut open_files: impl Iterator<Item = (ShellFd, openfiles::OpenFile)>,
+	) -> Result<(), error::Error> {
+		if open_files.next().is_some() {
+			return Err(error::ErrorKind::NotSupportedOnThisPlatform("fd redirections").into());
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 }
 
 /// Extension trait for arranging for commands to take the foreground.
 pub trait CommandFgControlExt {
-    /// Arranges for the command to take the foreground when it is executed.
-    fn take_foreground(&mut self);
+	/// Arranges for the command to take the foreground when it is executed.
+	fn take_foreground(&mut self);
 }
 
 impl CommandFgControlExt for std::process::Command {
-    fn take_foreground(&mut self) {
-        // NOTE: This is a no-op.
-    }
+	fn take_foreground(&mut self) {
+		// NOTE: This is a no-op.
+	}
 }

--- a/crates/brush-core-vendored/src/sys/stubs/fd.rs
+++ b/crates/brush-core-vendored/src/sys/stubs/fd.rs
@@ -4,10 +4,10 @@ use crate::{ShellFd, error, openfiles};
 
 /// Stub implementation for platforms that do not support enumerating file descriptors.
 pub fn try_iter_open_fds() -> impl Iterator<Item = (ShellFd, openfiles::OpenFile)> {
-    std::iter::empty()
+	std::iter::empty()
 }
 
 /// Stub implementation for platforms that do not support opening file descriptors.
 pub fn try_get_file_for_open_fd(_fd: ShellFd) -> Option<openfiles::OpenFile> {
-    None
+	None
 }

--- a/crates/brush-core-vendored/src/sys/stubs/fs.rs
+++ b/crates/brush-core-vendored/src/sys/stubs/fs.rs
@@ -4,76 +4,76 @@ use crate::error;
 
 #[cfg(not(windows))]
 impl crate::sys::fs::PathExt for std::path::Path {
-    fn readable(&self) -> bool {
-        true
-    }
+	fn readable(&self) -> bool {
+		true
+	}
 
-    fn writable(&self) -> bool {
-        true
-    }
+	fn writable(&self) -> bool {
+		true
+	}
 
-    fn executable(&self) -> bool {
-        true
-    }
+	fn executable(&self) -> bool {
+		true
+	}
 
-    fn exists_and_is_block_device(&self) -> bool {
-        false
-    }
+	fn exists_and_is_block_device(&self) -> bool {
+		false
+	}
 
-    fn exists_and_is_char_device(&self) -> bool {
-        false
-    }
+	fn exists_and_is_char_device(&self) -> bool {
+		false
+	}
 
-    fn exists_and_is_fifo(&self) -> bool {
-        false
-    }
+	fn exists_and_is_fifo(&self) -> bool {
+		false
+	}
 
-    fn exists_and_is_socket(&self) -> bool {
-        false
-    }
+	fn exists_and_is_socket(&self) -> bool {
+		false
+	}
 
-    fn exists_and_is_setgid(&self) -> bool {
-        false
-    }
+	fn exists_and_is_setgid(&self) -> bool {
+		false
+	}
 
-    fn exists_and_is_setuid(&self) -> bool {
-        false
-    }
+	fn exists_and_is_setuid(&self) -> bool {
+		false
+	}
 
-    fn exists_and_is_sticky_bit(&self) -> bool {
-        false
-    }
+	fn exists_and_is_sticky_bit(&self) -> bool {
+		false
+	}
 
-    fn get_device_and_inode(&self) -> Result<(u64, u64), crate::error::Error> {
-        Ok((0, 0))
-    }
+	fn get_device_and_inode(&self) -> Result<(u64, u64), crate::error::Error> {
+		Ok((0, 0))
+	}
 }
 
 pub(crate) trait MetadataExt {
-    fn gid(&self) -> u32 {
-        0
-    }
+	fn gid(&self) -> u32 {
+		0
+	}
 
-    fn uid(&self) -> u32 {
-        0
-    }
+	fn uid(&self) -> u32 {
+		0
+	}
 }
 
 impl MetadataExt for std::fs::Metadata {}
 
 pub(crate) fn get_default_executable_search_paths() -> Vec<String> {
-    vec![]
+	vec![]
 }
 
 /// Returns the default paths where standard Unix utilities are typically installed.
 /// This is a stub implementation that returns an empty vector.
 pub fn get_default_standard_utils_paths() -> Vec<String> {
-    vec![]
+	vec![]
 }
 
 /// Opens a null file that will discard all I/O.
 ///
 /// This is a stub implementation that returns an error.
 pub fn open_null_file() -> Result<std::fs::File, error::Error> {
-    Err(error::ErrorKind::NotSupportedOnThisPlatform("opening null file").into())
+	Err(error::ErrorKind::NotSupportedOnThisPlatform("opening null file").into())
 }

--- a/crates/brush-core-vendored/src/sys/stubs/input.rs
+++ b/crates/brush-core-vendored/src/sys/stubs/input.rs
@@ -7,5 +7,5 @@ use crate::{error, interfaces};
 ///
 /// This is a stub implementation that always returns `None`.
 pub fn try_get_key_from_key_code(_key_code: &[u8]) -> Option<interfaces::Key> {
-    None
+	None
 }

--- a/crates/brush-core-vendored/src/sys/stubs/network.rs
+++ b/crates/brush-core-vendored/src/sys/stubs/network.rs
@@ -1,3 +1,3 @@
 pub(crate) fn get_hostname() -> std::io::Result<std::ffi::OsString> {
-    Ok("".into())
+	Ok("".into())
 }

--- a/crates/brush-core-vendored/src/sys/stubs/pipes.rs
+++ b/crates/brush-core-vendored/src/sys/stubs/pipes.rs
@@ -3,23 +3,23 @@
 pub(crate) struct PipeReader {}
 
 impl PipeReader {
-    /// Tries to clone the reader.
-    pub fn try_clone(&self) -> std::io::Result<Self> {
-        Ok((*self).clone())
-    }
+	/// Tries to clone the reader.
+	pub fn try_clone(&self) -> std::io::Result<Self> {
+		Ok((*self).clone())
+	}
 }
 
 impl From<PipeReader> for std::process::Stdio {
-    fn from(_reader: PipeReader) -> Self {
-        Self::null()
-    }
+	fn from(_reader: PipeReader) -> Self {
+		Self::null()
+	}
 }
 
 impl std::io::Read for PipeReader {
-    fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
-        // TODO: implement
-        Ok(0)
-    }
+	fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+		// TODO: implement
+		Ok(0)
+	}
 }
 
 /// Stub implementation o a pipe writer.
@@ -27,29 +27,29 @@ impl std::io::Read for PipeReader {
 pub(crate) struct PipeWriter {}
 
 impl PipeWriter {
-    /// Tries to clone the writer.
-    pub fn try_clone(&self) -> std::io::Result<Self> {
-        Ok((*self).clone())
-    }
+	/// Tries to clone the writer.
+	pub fn try_clone(&self) -> std::io::Result<Self> {
+		Ok((*self).clone())
+	}
 }
 
 impl From<PipeWriter> for std::process::Stdio {
-    fn from(_writer: PipeWriter) -> Self {
-        Self::null()
-    }
+	fn from(_writer: PipeWriter) -> Self {
+		Self::null()
+	}
 }
 
 impl std::io::Write for PipeWriter {
-    fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
-        // TODO: implement
-        Ok(0)
-    }
+	fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+		// TODO: implement
+		Ok(0)
+	}
 
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
+	fn flush(&mut self) -> std::io::Result<()> {
+		Ok(())
+	}
 }
 
 pub(crate) fn pipe() -> std::io::Result<(PipeReader, PipeWriter)> {
-    Ok((PipeReader {}, PipeWriter {}))
+	Ok((PipeReader {}, PipeWriter {}))
 }

--- a/crates/brush-core-vendored/src/sys/stubs/process.rs
+++ b/crates/brush-core-vendored/src/sys/stubs/process.rs
@@ -4,31 +4,31 @@ pub(crate) type ProcessId = i32;
 
 /// Provides access to a child process.
 pub struct Child {
-    inner: std::process::Child,
+	inner: std::process::Child,
 }
 
 pub(crate) use std::process::ExitStatus;
 pub(crate) use std::process::Output;
 
 impl Child {
-    /// Returns the process ID of the child process, if available.
-    pub fn id(&self) -> Option<u32> {
-        None
-    }
+	/// Returns the process ID of the child process, if available.
+	pub fn id(&self) -> Option<u32> {
+		None
+	}
 
-    /// Asynchronously waits for the child process to exit.
-    pub async fn wait(&mut self) -> std::io::Result<ExitStatus> {
-        self.inner.wait()
-    }
+	/// Asynchronously waits for the child process to exit.
+	pub async fn wait(&mut self) -> std::io::Result<ExitStatus> {
+		self.inner.wait()
+	}
 
-    /// Asynchronously waits for the child process to exit and collects its
-    /// output.
-    pub async fn wait_with_output(self) -> std::io::Result<Output> {
-        self.inner.wait_with_output()
-    }
+	/// Asynchronously waits for the child process to exit and collects its
+	/// output.
+	pub async fn wait_with_output(self) -> std::io::Result<Output> {
+		self.inner.wait_with_output()
+	}
 }
 
 pub(crate) fn spawn(mut command: std::process::Command) -> std::io::Result<Child> {
-    let child = command.spawn()?;
-    Ok(Child { inner: child })
+	let child = command.spawn()?;
+	Ok(Child { inner: child })
 }

--- a/crates/brush-core-vendored/src/sys/stubs/resource.rs
+++ b/crates/brush-core-vendored/src/sys/stubs/resource.rs
@@ -7,7 +7,7 @@ use crate::error;
 /// This is a stub implementation that returns zero durations.
 pub fn get_self_user_and_system_time()
 -> Result<(std::time::Duration, std::time::Duration), error::Error> {
-    Ok((std::time::Duration::ZERO, std::time::Duration::ZERO))
+	Ok((std::time::Duration::ZERO, std::time::Duration::ZERO))
 }
 
 /// Returns the user and system CPU time used by child processes.
@@ -15,5 +15,5 @@ pub fn get_self_user_and_system_time()
 /// This is a stub implementation that returns zero durations.
 pub fn get_children_user_and_system_time()
 -> Result<(std::time::Duration, std::time::Duration), error::Error> {
-    Ok((std::time::Duration::ZERO, std::time::Duration::ZERO))
+	Ok((std::time::Duration::ZERO, std::time::Duration::ZERO))
 }

--- a/crates/brush-core-vendored/src/sys/stubs/signal.rs
+++ b/crates/brush-core-vendored/src/sys/stubs/signal.rs
@@ -22,119 +22,121 @@ pub enum Signal {
 }
 
 impl Signal {
-    /// Returns an iterator over all possible signals.
-    pub fn iterator() -> impl Iterator<Item = Self> {
-        #[cfg(windows)]
-        return [Self::Terminate, Self::Kill, Self::Interrupt].into_iter();
-        #[cfg(not(windows))]
-        return std::iter::empty();
-    }
+	/// Returns an iterator over all possible signals.
+	pub fn iterator() -> impl Iterator<Item = Self> {
+		#[cfg(windows)]
+		return [Self::Terminate, Self::Kill, Self::Interrupt].into_iter();
+		#[cfg(not(windows))]
+		return std::iter::empty();
+	}
 
-    /// Converts the signal into its corresponding name as a `&'static str`.
-    pub const fn as_str(self) -> &'static str {
-        #[cfg(windows)]
-        {
-            return match self {
-                Self::Terminate => "TERM",
-                Self::Kill => "KILL",
-                Self::Interrupt => "INT",
-            };
-        }
-        #[cfg(not(windows))]
-        ""
-    }
+	/// Converts the signal into its corresponding name as a `&'static str`.
+	pub const fn as_str(self) -> &'static str {
+		#[cfg(windows)]
+		{
+			return match self {
+				Self::Terminate => "TERM",
+				Self::Kill => "KILL",
+				Self::Interrupt => "INT",
+			};
+		}
+		#[cfg(not(windows))]
+		""
+	}
 
-    /// Creates a `Signal` from a string representation.
-    pub fn from_str(s: &str) -> Result<Self, error::Error> {
-        #[cfg(windows)]
-        {
-            return match s.to_ascii_uppercase().as_str() {
-                "TERM" | "SIGTERM" => Ok(Self::Terminate),
-                "KILL" | "SIGKILL" => Ok(Self::Kill),
-                "INT" | "SIGINT" => Ok(Self::Interrupt),
-                _ => Err(error::ErrorKind::InvalidSignal(s.into()).into()),
-            };
-        }
-        #[cfg(not(windows))]
-        Err(error::ErrorKind::InvalidSignal(s.into()).into())
-    }
+	/// Creates a `Signal` from a string representation.
+	pub fn from_str(s: &str) -> Result<Self, error::Error> {
+		#[cfg(windows)]
+		{
+			return match s.to_ascii_uppercase().as_str() {
+				"TERM" | "SIGTERM" => Ok(Self::Terminate),
+				"KILL" | "SIGKILL" => Ok(Self::Kill),
+				"INT" | "SIGINT" => Ok(Self::Interrupt),
+				_ => Err(error::ErrorKind::InvalidSignal(s.into()).into()),
+			};
+		}
+		#[cfg(not(windows))]
+		Err(error::ErrorKind::InvalidSignal(s.into()).into())
+	}
 }
 
 impl TryFrom<i32> for Signal {
-    type Error = error::Error;
+	type Error = error::Error;
 
-    fn try_from(value: i32) -> Result<Self, Self::Error> {
-        Err(error::ErrorKind::InvalidSignal(std::format!("{value}")).into())
-    }
+	fn try_from(value: i32) -> Result<Self, Self::Error> {
+		Err(error::ErrorKind::InvalidSignal(std::format!("{value}")).into())
+	}
 }
 
 pub(crate) fn continue_process(_pid: sys::process::ProcessId) -> Result<(), error::Error> {
-    Err(error::ErrorKind::NotSupportedOnThisPlatform("continuing process").into())
+	Err(error::ErrorKind::NotSupportedOnThisPlatform("continuing process").into())
 }
 
 /// Sends a signal to a specific process.
 ///
 /// This is a stub implementation that returns an error.
 pub fn kill_process(
-    _pid: sys::process::ProcessId,
-    _signal: traps::TrapSignal,
+	_pid: sys::process::ProcessId,
+	_signal: traps::TrapSignal,
 ) -> Result<(), error::Error> {
-    #[cfg(windows)]
-    {
-        use windows_sys::Win32::Foundation::CloseHandle;
-        use windows_sys::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+	#[cfg(windows)]
+	{
+		use windows_sys::Win32::Foundation::CloseHandle;
+		use windows_sys::Win32::System::Threading::{
+			OpenProcess, PROCESS_TERMINATE, TerminateProcess,
+		};
 
-        let pid = _pid as u32;
-        unsafe {
-            let handle = OpenProcess(PROCESS_TERMINATE, 0, pid);
-            if handle.is_null() {
-                return Err(error::ErrorKind::FailedToSendSignal.into());
-            }
-            let ok = TerminateProcess(handle, 1);
-            let _ = CloseHandle(handle);
-            if ok == 0 {
-                return Err(error::ErrorKind::FailedToSendSignal.into());
-            }
-        }
-        return Ok(());
-    }
-    #[cfg(not(windows))]
-    Err(error::ErrorKind::NotSupportedOnThisPlatform("killing process").into())
+		let pid = _pid as u32;
+		unsafe {
+			let handle = OpenProcess(PROCESS_TERMINATE, 0, pid);
+			if handle.is_null() {
+				return Err(error::ErrorKind::FailedToSendSignal.into());
+			}
+			let ok = TerminateProcess(handle, 1);
+			let _ = CloseHandle(handle);
+			if ok == 0 {
+				return Err(error::ErrorKind::FailedToSendSignal.into());
+			}
+		}
+		return Ok(());
+	}
+	#[cfg(not(windows))]
+	Err(error::ErrorKind::NotSupportedOnThisPlatform("killing process").into())
 }
 
 pub(crate) fn lead_new_process_group() -> Result<(), error::Error> {
-    Ok(())
+	Ok(())
 }
 
 pub(crate) struct FakeSignal {}
 
 impl FakeSignal {
-    fn new() -> Self {
-        Self {}
-    }
+	fn new() -> Self {
+		Self {}
+	}
 
-    pub async fn recv(&self) {
-        futures::future::pending::<()>().await;
-    }
+	pub async fn recv(&self) {
+		futures::future::pending::<()>().await;
+	}
 }
 
 pub(crate) fn tstp_signal_listener() -> Result<FakeSignal, error::Error> {
-    Ok(FakeSignal::new())
+	Ok(FakeSignal::new())
 }
 
 pub(crate) fn chld_signal_listener() -> Result<FakeSignal, error::Error> {
-    Ok(FakeSignal::new())
+	Ok(FakeSignal::new())
 }
 
 pub(crate) async fn await_ctrl_c() -> std::io::Result<()> {
-    FakeSignal::new().recv().await;
-    Ok(())
+	FakeSignal::new().recv().await;
+	Ok(())
 }
 
 pub(crate) fn mask_sigttou() -> Result<(), error::Error> {
-    Ok(())
+	Ok(())
 }
 
 pub(crate) fn poll_for_stopped_children() -> Result<bool, error::Error> {
-    Ok(false)
+	Ok(false)
 }

--- a/crates/brush-core-vendored/src/sys/stubs/terminal.rs
+++ b/crates/brush-core-vendored/src/sys/stubs/terminal.rs
@@ -8,65 +8,65 @@ pub struct Config;
 
 #[allow(clippy::unused_self)]
 impl Config {
-    /// Creates a new `Config` from the actual terminal attributes of the terminal associated
-    /// with the given file descriptor.
-    ///
-    /// # Arguments
-    ///
-    /// * `_fd` - The file descriptor of the terminal.
-    pub fn from_term<Fd>(_fd: Fd) -> Result<Self, error::Error> {
-        Ok(Self)
-    }
+	/// Creates a new `Config` from the actual terminal attributes of the terminal associated
+	/// with the given file descriptor.
+	///
+	/// # Arguments
+	///
+	/// * `_fd` - The file descriptor of the terminal.
+	pub fn from_term<Fd>(_fd: Fd) -> Result<Self, error::Error> {
+		Ok(Self)
+	}
 
-    /// Applies the terminal settings to the terminal associated with the given file descriptor.
-    ///
-    /// # Arguments
-    ///
-    /// * `_fd` - The file descriptor of the terminal.
-    pub fn apply_to_term<Fd>(&self, _fd: Fd) -> Result<(), error::Error> {
-        Ok(())
-    }
+	/// Applies the terminal settings to the terminal associated with the given file descriptor.
+	///
+	/// # Arguments
+	///
+	/// * `_fd` - The file descriptor of the terminal.
+	pub fn apply_to_term<Fd>(&self, _fd: Fd) -> Result<(), error::Error> {
+		Ok(())
+	}
 
-    /// Applies the given high-level terminal settings to this configuration. Does not modify any
-    /// terminal itself.
-    ///
-    /// # Arguments
-    ///
-    /// * `_settings` - The high-level terminal settings to apply to this configuration.
-    pub fn update(&mut self, _settings: &terminal::Settings) {}
+	/// Applies the given high-level terminal settings to this configuration. Does not modify any
+	/// terminal itself.
+	///
+	/// # Arguments
+	///
+	/// * `_settings` - The high-level terminal settings to apply to this configuration.
+	pub fn update(&mut self, _settings: &terminal::Settings) {}
 }
 
 /// Get the process ID of this process's parent.
 ///
 /// This is a stub implementation that returns `None`.
 pub fn get_parent_process_id() -> Option<sys::process::ProcessId> {
-    None
+	None
 }
 
 /// Get the process group ID for this process's process group.
 ///
 /// This is a stub implementation that returns `None`.
 pub fn get_process_group_id() -> Option<sys::process::ProcessId> {
-    None
+	None
 }
 
 /// Get the foreground process ID of the attached terminal.
 ///
 /// This is a stub implementation that returns `None`.
 pub fn get_foreground_pid() -> Option<sys::process::ProcessId> {
-    None
+	None
 }
 
 /// Move the specified process to the foreground of the attached terminal.
 ///
 /// This is a stub implementation that takes no action.
 pub fn move_to_foreground(_pid: sys::process::ProcessId) -> Result<(), error::Error> {
-    Ok(())
+	Ok(())
 }
 
 /// Moves the current process to the foreground of the attached terminal.
 ///
 /// This is a stub implementation that returns `None`.
 pub fn move_self_to_foreground() -> Result<(), error::Error> {
-    Ok(())
+	Ok(())
 }

--- a/crates/brush-core-vendored/src/sys/stubs/users.rs
+++ b/crates/brush-core-vendored/src/sys/stubs/users.rs
@@ -2,45 +2,45 @@ use crate::error;
 use std::path::PathBuf;
 
 pub(crate) fn get_user_home_dir(_username: &str) -> Option<PathBuf> {
-    None
+	None
 }
 
 pub(crate) fn get_current_user_home_dir() -> Option<PathBuf> {
-    None
+	None
 }
 
 pub(crate) fn is_root() -> bool {
-    false
+	false
 }
 
 pub(crate) fn get_current_uid() -> Result<u32, error::Error> {
-    Err(error::ErrorKind::NotSupportedOnThisPlatform("getting current uid").into())
+	Err(error::ErrorKind::NotSupportedOnThisPlatform("getting current uid").into())
 }
 
 pub(crate) fn get_current_gid() -> Result<u32, error::Error> {
-    Err(error::ErrorKind::NotSupportedOnThisPlatform("getting current gid").into())
+	Err(error::ErrorKind::NotSupportedOnThisPlatform("getting current gid").into())
 }
 
 pub(crate) fn get_effective_uid() -> Result<u32, error::Error> {
-    Err(error::ErrorKind::NotSupportedOnThisPlatform("getting effective uid").into())
+	Err(error::ErrorKind::NotSupportedOnThisPlatform("getting effective uid").into())
 }
 
 pub(crate) fn get_effective_gid() -> Result<u32, error::Error> {
-    Err(error::ErrorKind::NotSupportedOnThisPlatform("getting effective gid").into())
+	Err(error::ErrorKind::NotSupportedOnThisPlatform("getting effective gid").into())
 }
 
 pub(crate) fn get_current_username() -> Result<String, error::Error> {
-    Err(error::ErrorKind::NotSupportedOnThisPlatform("getting current username").into())
+	Err(error::ErrorKind::NotSupportedOnThisPlatform("getting current username").into())
 }
 
 pub(crate) fn get_user_group_ids() -> Result<Vec<u32>, error::Error> {
-    Ok(vec![])
+	Ok(vec![])
 }
 
 pub(crate) fn get_all_users() -> Result<Vec<String>, error::Error> {
-    Ok(vec![])
+	Ok(vec![])
 }
 
 pub(crate) fn get_all_groups() -> Result<Vec<String>, error::Error> {
-    Ok(vec![])
+	Ok(vec![])
 }

--- a/crates/brush-core-vendored/src/sys/tokio_process.rs
+++ b/crates/brush-core-vendored/src/sys/tokio_process.rs
@@ -4,7 +4,7 @@ pub(crate) type ProcessId = i32;
 pub(crate) use tokio::process::Child;
 
 pub(crate) fn spawn(command: std::process::Command) -> std::io::Result<Child> {
-    let mut command = tokio::process::Command::from(command);
-    command.kill_on_drop(true);
-    command.spawn()
+	let mut command = tokio::process::Command::from(command);
+	command.kill_on_drop(true);
+	command.spawn()
 }

--- a/crates/brush-core-vendored/src/sys/unix.rs
+++ b/crates/brush-core-vendored/src/sys/unix.rs
@@ -13,13 +13,13 @@ pub(crate) mod users;
 /// Platform-specific errors.
 #[derive(Debug, thiserror::Error)]
 pub enum PlatformError {
-    /// A system error occurred.
-    #[error("system error: {0}")]
-    ErrnoError(#[from] nix::errno::Errno),
+	/// A system error occurred.
+	#[error("system error: {0}")]
+	ErrnoError(#[from] nix::errno::Errno),
 }
 
 impl From<nix::errno::Errno> for error::ErrorKind {
-    fn from(err: nix::errno::Errno) -> Self {
-        PlatformError::ErrnoError(err).into()
-    }
+	fn from(err: nix::errno::Errno) -> Self {
+		PlatformError::ErrnoError(err).into()
+	}
 }

--- a/crates/brush-core-vendored/src/sys/unix/fd.rs
+++ b/crates/brush-core-vendored/src/sys/unix/fd.rs
@@ -16,33 +16,33 @@ const FD_DIR_PATH: &str = "/dev/fd";
 /// If the platform does not support enumerating file descriptors, an empty iterator
 /// is returned. This function will skip any file descriptors that cannot be opened.
 pub fn try_iter_open_fds() -> impl Iterator<Item = (ShellFd, openfiles::OpenFile)> {
-    let mut opened_entries = vec![];
+	let mut opened_entries = vec![];
 
-    if let Ok(fd_dir) = std::fs::read_dir(FD_DIR_PATH) {
-        for entry in fd_dir.into_iter().flatten() {
-            if let Ok(filename) = entry.file_name().into_string() {
-                if let Ok(fd_num) = filename.parse::<RawFd>() {
-                    // SAFETY:
-                    // We are trying to open the file descriptor we found listed
-                    // in the filesystem, but there's a risk that it's not the same one
-                    // that we enumerated or that it's since been closed. For the purposes
-                    // of this function, either of those outcomes are acceptable. We
-                    // simply skip any fds that we can't open, and the function's purpose
-                    // is to make a best-effort attempt to open all available fds.
-                    if let Ok(file) = unsafe { open_file_by_fd(fd_num) } {
-                        opened_entries.push((fd_num, file));
-                    }
-                }
-            }
-        }
-    }
+	if let Ok(fd_dir) = std::fs::read_dir(FD_DIR_PATH) {
+		for entry in fd_dir.into_iter().flatten() {
+			if let Ok(filename) = entry.file_name().into_string() {
+				if let Ok(fd_num) = filename.parse::<RawFd>() {
+					// SAFETY:
+					// We are trying to open the file descriptor we found listed
+					// in the filesystem, but there's a risk that it's not the same one
+					// that we enumerated or that it's since been closed. For the purposes
+					// of this function, either of those outcomes are acceptable. We
+					// simply skip any fds that we can't open, and the function's purpose
+					// is to make a best-effort attempt to open all available fds.
+					if let Ok(file) = unsafe { open_file_by_fd(fd_num) } {
+						opened_entries.push((fd_num, file));
+					}
+				}
+			}
+		}
+	}
 
-    opened_entries.into_iter()
+	opened_entries.into_iter()
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub fn iter_fds() -> Result<impl Iterator<Item = (ShellFd, openfiles::OpenFile)>, error::Error> {
-    Ok(std::iter::empty())
+	Ok(std::iter::empty())
 }
 
 /// Attempts to retrieve an `OpenFile` representation for the given already-open file descriptor.
@@ -55,21 +55,21 @@ pub fn iter_fds() -> Result<impl Iterator<Item = (ShellFd, openfiles::OpenFile)>
 ///
 /// * `fd` - The file descriptor to open.
 pub fn try_get_file_for_open_fd(fd: RawFd) -> Option<openfiles::OpenFile> {
-    // SAFETY:
-    // We are trying to open the file descriptor provided by the caller. There's a risk that the fd
-    // is invalid or has been closed since it was enumerated. For the purposes of this function,
-    // we simply return None if we can't open it. There's also a risk that the fd has been closed
-    // and re-used for a different file; again, for the purposes of this function, we accept that
-    // risk and document it as part of the function's contract.
-    unsafe { open_file_by_fd(fd).ok() }
+	// SAFETY:
+	// We are trying to open the file descriptor provided by the caller. There's a risk that the fd
+	// is invalid or has been closed since it was enumerated. For the purposes of this function,
+	// we simply return None if we can't open it. There's also a risk that the fd has been closed
+	// and re-used for a different file; again, for the purposes of this function, we accept that
+	// risk and document it as part of the function's contract.
+	unsafe { open_file_by_fd(fd).ok() }
 }
 
 unsafe fn open_file_by_fd(fd: RawFd) -> Result<openfiles::OpenFile, error::Error> {
-    // SAFETY: We are creating a BorrowedFd from a file descriptor. Callers typically
-    // enumerate available file descriptors from procfs, devfs, or similar, but there's
-    // still a risk that the fd has become invalid or closed since then -- or that this
-    // function gets used incorrectly.
-    let borrowed_fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(fd) };
-    let owned_fd = borrowed_fd.try_clone_to_owned()?;
-    Ok(std::fs::File::from(owned_fd).into())
+	// SAFETY: We are creating a BorrowedFd from a file descriptor. Callers typically
+	// enumerate available file descriptors from procfs, devfs, or similar, but there's
+	// still a risk that the fd has become invalid or closed since then -- or that this
+	// function gets used incorrectly.
+	let borrowed_fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(fd) };
+	let owned_fd = borrowed_fd.try_clone_to_owned()?;
+	Ok(std::fs::File::from(owned_fd).into())
 }

--- a/crates/brush-core-vendored/src/sys/unix/input.rs
+++ b/crates/brush-core-vendored/src/sys/unix/input.rs
@@ -7,65 +7,65 @@ use terminfo::capability as cap;
 use crate::{error, interfaces};
 
 macro_rules! key {
-    ( $terminfo:expr , $our_key:expr, $terminfo_key:ty ) => {{
-        (
-            $our_key,
-            $terminfo
-                .get::<$terminfo_key>()
-                .map(|k| k.expand().to_vec()),
-        )
-    }};
+	( $terminfo:expr , $our_key:expr, $terminfo_key:ty ) => {{
+		(
+			$our_key,
+			$terminfo
+				.get::<$terminfo_key>()
+				.map(|k| k.expand().to_vec()),
+		)
+	}};
 }
 
 fn build_terminfo_key_map() -> HashMap<Vec<u8>, interfaces::Key> {
-    let mut map: HashMap<Vec<u8>, interfaces::Key> = HashMap::new();
+	let mut map: HashMap<Vec<u8>, interfaces::Key> = HashMap::new();
 
-    if let Ok(ti) = terminfo::Database::from_env() {
-        // Iterate over key capabilities and populate the map
-        let key_capabilities = [
-            key!(ti, interfaces::Key::F(1), cap::KeyF1<'_>),
-            key!(ti, interfaces::Key::F(2), cap::KeyF2<'_>),
-            key!(ti, interfaces::Key::F(3), cap::KeyF3<'_>),
-            key!(ti, interfaces::Key::F(4), cap::KeyF4<'_>),
-            key!(ti, interfaces::Key::F(5), cap::KeyF5<'_>),
-            key!(ti, interfaces::Key::F(6), cap::KeyF6<'_>),
-            key!(ti, interfaces::Key::F(7), cap::KeyF7<'_>),
-            key!(ti, interfaces::Key::F(8), cap::KeyF8<'_>),
-            key!(ti, interfaces::Key::F(9), cap::KeyF9<'_>),
-            key!(ti, interfaces::Key::F(10), cap::KeyF10<'_>),
-            key!(ti, interfaces::Key::F(11), cap::KeyF11<'_>),
-            key!(ti, interfaces::Key::F(12), cap::KeyF12<'_>),
-            key!(ti, interfaces::Key::Backspace, cap::KeyBackspace<'_>),
-            key!(ti, interfaces::Key::Enter, cap::KeyEnter<'_>),
-            key!(ti, interfaces::Key::Left, cap::KeyLeft<'_>),
-            key!(ti, interfaces::Key::Right, cap::KeyRight<'_>),
-            key!(ti, interfaces::Key::Up, cap::KeyUp<'_>),
-            key!(ti, interfaces::Key::Down, cap::KeyDown<'_>),
-            key!(ti, interfaces::Key::Home, cap::KeyHome<'_>),
-            key!(ti, interfaces::Key::End, cap::KeyEnd<'_>),
-            key!(ti, interfaces::Key::PageUp, cap::KeyPPage<'_>),
-            key!(ti, interfaces::Key::PageDown, cap::KeyNPage<'_>),
-            key!(ti, interfaces::Key::BackTab, cap::BackTab<'_>),
-            // It's not clear if these belong here, because they're not
-            // strictly "key" capabilities.
-            key!(ti, interfaces::Key::Up, cap::CursorUp<'_>),
-            key!(ti, interfaces::Key::Down, cap::CursorDown<'_>),
-            key!(ti, interfaces::Key::Left, cap::CursorLeft<'_>),
-            key!(ti, interfaces::Key::Right, cap::CursorRight<'_>),
-        ];
+	if let Ok(ti) = terminfo::Database::from_env() {
+		// Iterate over key capabilities and populate the map
+		let key_capabilities = [
+			key!(ti, interfaces::Key::F(1), cap::KeyF1<'_>),
+			key!(ti, interfaces::Key::F(2), cap::KeyF2<'_>),
+			key!(ti, interfaces::Key::F(3), cap::KeyF3<'_>),
+			key!(ti, interfaces::Key::F(4), cap::KeyF4<'_>),
+			key!(ti, interfaces::Key::F(5), cap::KeyF5<'_>),
+			key!(ti, interfaces::Key::F(6), cap::KeyF6<'_>),
+			key!(ti, interfaces::Key::F(7), cap::KeyF7<'_>),
+			key!(ti, interfaces::Key::F(8), cap::KeyF8<'_>),
+			key!(ti, interfaces::Key::F(9), cap::KeyF9<'_>),
+			key!(ti, interfaces::Key::F(10), cap::KeyF10<'_>),
+			key!(ti, interfaces::Key::F(11), cap::KeyF11<'_>),
+			key!(ti, interfaces::Key::F(12), cap::KeyF12<'_>),
+			key!(ti, interfaces::Key::Backspace, cap::KeyBackspace<'_>),
+			key!(ti, interfaces::Key::Enter, cap::KeyEnter<'_>),
+			key!(ti, interfaces::Key::Left, cap::KeyLeft<'_>),
+			key!(ti, interfaces::Key::Right, cap::KeyRight<'_>),
+			key!(ti, interfaces::Key::Up, cap::KeyUp<'_>),
+			key!(ti, interfaces::Key::Down, cap::KeyDown<'_>),
+			key!(ti, interfaces::Key::Home, cap::KeyHome<'_>),
+			key!(ti, interfaces::Key::End, cap::KeyEnd<'_>),
+			key!(ti, interfaces::Key::PageUp, cap::KeyPPage<'_>),
+			key!(ti, interfaces::Key::PageDown, cap::KeyNPage<'_>),
+			key!(ti, interfaces::Key::BackTab, cap::BackTab<'_>),
+			// It's not clear if these belong here, because they're not
+			// strictly "key" capabilities.
+			key!(ti, interfaces::Key::Up, cap::CursorUp<'_>),
+			key!(ti, interfaces::Key::Down, cap::CursorDown<'_>),
+			key!(ti, interfaces::Key::Left, cap::CursorLeft<'_>),
+			key!(ti, interfaces::Key::Right, cap::CursorRight<'_>),
+		];
 
-        for (key, v) in key_capabilities {
-            if let Some(Ok(v)) = v {
-                map.insert(v.clone(), key.clone());
-            }
-        }
-    }
+		for (key, v) in key_capabilities {
+			if let Some(Ok(v)) = v {
+				map.insert(v.clone(), key.clone());
+			}
+		}
+	}
 
-    map
+	map
 }
 
 pub(crate) static TERMINFO_KEY_MAP: LazyLock<HashMap<Vec<u8>, interfaces::Key>> =
-    LazyLock::new(build_terminfo_key_map);
+	LazyLock::new(build_terminfo_key_map);
 
 /// Translates a key code (byte sequence) into a `Key` enum value. Returns `None`
 /// if the key code is not recognized.
@@ -74,11 +74,11 @@ pub(crate) static TERMINFO_KEY_MAP: LazyLock<HashMap<Vec<u8>, interfaces::Key>> 
 ///
 /// * `key_code`: The byte sequence representing the key code.
 pub fn try_get_key_from_key_code(key_code: &[u8]) -> Option<interfaces::Key> {
-    if let Some(key) = TERMINFO_KEY_MAP.get(key_code) {
-        Some(key.clone())
-    } else if key_code.len() == 1 && !key_code[0].is_ascii_control() {
-        Some(interfaces::Key::Character(key_code[0] as char))
-    } else {
-        None
-    }
+	if let Some(key) = TERMINFO_KEY_MAP.get(key_code) {
+		Some(key.clone())
+	} else if key_code.len() == 1 && !key_code[0].is_ascii_control() {
+		Some(interfaces::Key::Character(key_code[0] as char))
+	} else {
+		None
+	}
 }

--- a/crates/brush-core-vendored/src/sys/unix/network.rs
+++ b/crates/brush-core-vendored/src/sys/unix/network.rs
@@ -1,3 +1,3 @@
 pub(crate) fn get_hostname() -> std::io::Result<std::ffi::OsString> {
-    crate::sys::hostname::get()
+	crate::sys::hostname::get()
 }

--- a/crates/brush-core-vendored/src/sys/unix/resource.rs
+++ b/crates/brush-core-vendored/src/sys/unix/resource.rs
@@ -6,26 +6,20 @@ use crate::error;
 /// expressed as a tuple containing user time and system time, in that order.
 pub fn get_self_user_and_system_time()
 -> Result<(std::time::Duration, std::time::Duration), error::Error> {
-    let usage = nix::sys::resource::getrusage(nix::sys::resource::UsageWho::RUSAGE_SELF)?;
-    Ok((
-        convert_rusage_time(usage.user_time()),
-        convert_rusage_time(usage.system_time()),
-    ))
+	let usage = nix::sys::resource::getrusage(nix::sys::resource::UsageWho::RUSAGE_SELF)?;
+	Ok((convert_rusage_time(usage.user_time()), convert_rusage_time(usage.system_time())))
 }
 
 /// Returns the user and system CPU time used by child processes; expressed
 /// as a tuple containing user time and system time, in that order.
 pub fn get_children_user_and_system_time()
 -> Result<(std::time::Duration, std::time::Duration), error::Error> {
-    let usage = nix::sys::resource::getrusage(nix::sys::resource::UsageWho::RUSAGE_CHILDREN)?;
-    Ok((
-        convert_rusage_time(usage.user_time()),
-        convert_rusage_time(usage.system_time()),
-    ))
+	let usage = nix::sys::resource::getrusage(nix::sys::resource::UsageWho::RUSAGE_CHILDREN)?;
+	Ok((convert_rusage_time(usage.user_time()), convert_rusage_time(usage.system_time())))
 }
 
 const fn convert_rusage_time(time: nix::sys::time::TimeVal) -> std::time::Duration {
-    #[allow(clippy::cast_sign_loss)]
-    #[allow(clippy::cast_possible_truncation)]
-    std::time::Duration::new(time.tv_sec() as u64, time.tv_usec() as u32 * 1000)
+	#[allow(clippy::cast_sign_loss)]
+	#[allow(clippy::cast_possible_truncation)]
+	std::time::Duration::new(time.tv_sec() as u64, time.tv_usec() as u32 * 1000)
 }

--- a/crates/brush-core-vendored/src/sys/unix/signal.rs
+++ b/crates/brush-core-vendored/src/sys/unix/signal.rs
@@ -5,9 +5,9 @@ use crate::{error, sys, traps};
 pub(crate) use nix::sys::signal::Signal;
 
 pub(crate) fn continue_process(pid: sys::process::ProcessId) -> Result<(), error::Error> {
-    nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), nix::sys::signal::SIGCONT)
-        .map_err(|_errno| error::ErrorKind::FailedToSendSignal)?;
-    Ok(())
+	nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), nix::sys::signal::SIGCONT)
+		.map_err(|_errno| error::ErrorKind::FailedToSendSignal)?;
+	Ok(())
 }
 
 /// Sends a signal to a specific process.
@@ -16,87 +16,85 @@ pub(crate) fn continue_process(pid: sys::process::ProcessId) -> Result<(), error
 /// * `pid` - The process ID to send the signal to
 /// * `signal` - The signal to send (must be a real signal, not a trap signal)
 pub fn kill_process(
-    pid: sys::process::ProcessId,
-    signal: traps::TrapSignal,
+	pid: sys::process::ProcessId,
+	signal: traps::TrapSignal,
 ) -> Result<(), error::Error> {
-    let translated_signal = match signal {
-        traps::TrapSignal::Signal(signal) => signal,
-        traps::TrapSignal::Debug
-        | traps::TrapSignal::Err
-        | traps::TrapSignal::Exit
-        | traps::TrapSignal::Return => {
-            return Err(error::ErrorKind::InvalidSignal(signal.to_string()).into());
-        }
-    };
+	let translated_signal = match signal {
+		traps::TrapSignal::Signal(signal) => signal,
+		traps::TrapSignal::Debug
+		| traps::TrapSignal::Err
+		| traps::TrapSignal::Exit
+		| traps::TrapSignal::Return => {
+			return Err(error::ErrorKind::InvalidSignal(signal.to_string()).into());
+		},
+	};
 
-    nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), translated_signal)
-        .map_err(|_errno| error::ErrorKind::FailedToSendSignal)?;
+	nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), translated_signal)
+		.map_err(|_errno| error::ErrorKind::FailedToSendSignal)?;
 
-    Ok(())
+	Ok(())
 }
 
 pub(crate) fn lead_new_process_group() -> Result<(), error::Error> {
-    nix::unistd::setpgid(nix::unistd::Pid::from_raw(0), nix::unistd::Pid::from_raw(0))?;
-    Ok(())
+	nix::unistd::setpgid(nix::unistd::Pid::from_raw(0), nix::unistd::Pid::from_raw(0))?;
+	Ok(())
 }
 
 pub(crate) fn tstp_signal_listener() -> Result<tokio::signal::unix::Signal, error::Error> {
-    let signal = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::from_raw(
-        nix::libc::SIGTSTP,
-    ))?;
-    Ok(signal)
+	let signal =
+		tokio::signal::unix::signal(tokio::signal::unix::SignalKind::from_raw(nix::libc::SIGTSTP))?;
+	Ok(signal)
 }
 
 pub(crate) fn chld_signal_listener() -> Result<tokio::signal::unix::Signal, error::Error> {
-    let signal = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::child())?;
-    Ok(signal)
+	let signal = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::child())?;
+	Ok(signal)
 }
 
 pub(crate) use tokio::signal::ctrl_c as await_ctrl_c;
 
 pub(crate) fn mask_sigttou() -> Result<(), error::Error> {
-    let ignore = nix::sys::signal::SigAction::new(
-        nix::sys::signal::SigHandler::SigIgn,
-        nix::sys::signal::SaFlags::empty(),
-        nix::sys::signal::SigSet::empty(),
-    );
+	let ignore = nix::sys::signal::SigAction::new(
+		nix::sys::signal::SigHandler::SigIgn,
+		nix::sys::signal::SaFlags::empty(),
+		nix::sys::signal::SigSet::empty(),
+	);
 
-    // SAFETY:
-    // Setting the signal action should be safe here. The unsafe concerns
-    // for calling `sigaction` are primarily around ensuring that any provided
-    // signal handler functions are only performing operations that are
-    // safe to do in a signal handler context. Here we are not providing
-    // a custom handler, just asking the OS to ignore the signal.
-    unsafe { nix::sys::signal::sigaction(nix::sys::signal::Signal::SIGTTOU, &ignore) }?;
+	// SAFETY:
+	// Setting the signal action should be safe here. The unsafe concerns
+	// for calling `sigaction` are primarily around ensuring that any provided
+	// signal handler functions are only performing operations that are
+	// safe to do in a signal handler context. Here we are not providing
+	// a custom handler, just asking the OS to ignore the signal.
+	unsafe { nix::sys::signal::sigaction(nix::sys::signal::Signal::SIGTTOU, &ignore) }?;
 
-    Ok(())
+	Ok(())
 }
 
 pub(crate) fn poll_for_stopped_children() -> Result<bool, error::Error> {
-    let mut found_stopped = false;
+	let mut found_stopped = false;
 
-    loop {
-        let wait_status = waitid_all(
-            nix::sys::wait::WaitPidFlag::WUNTRACED | nix::sys::wait::WaitPidFlag::WNOHANG,
-        );
-        match wait_status {
-            Ok(nix::sys::wait::WaitStatus::Stopped(_stopped_pid, _signal)) => {
-                found_stopped = true;
-            }
-            Ok(_) => break,
-            Err(nix::errno::Errno::ECHILD) => break,
-            Err(e) => return Err(e.into()),
-        }
-    }
+	loop {
+		let wait_status =
+			waitid_all(nix::sys::wait::WaitPidFlag::WUNTRACED | nix::sys::wait::WaitPidFlag::WNOHANG);
+		match wait_status {
+			Ok(nix::sys::wait::WaitStatus::Stopped(_stopped_pid, _signal)) => {
+				found_stopped = true;
+			},
+			Ok(_) => break,
+			Err(nix::errno::Errno::ECHILD) => break,
+			Err(e) => return Err(e.into()),
+		}
+	}
 
-    Ok(found_stopped)
+	Ok(found_stopped)
 }
 
 #[cfg(not(target_os = "macos"))]
 fn waitid_all(
-    flags: nix::sys::wait::WaitPidFlag,
+	flags: nix::sys::wait::WaitPidFlag,
 ) -> Result<nix::sys::wait::WaitStatus, nix::errno::Errno> {
-    nix::sys::wait::waitid(nix::sys::wait::Id::All, flags)
+	nix::sys::wait::waitid(nix::sys::wait::Id::All, flags)
 }
 
 //
@@ -107,56 +105,56 @@ fn waitid_all(
 
 #[cfg(target_os = "macos")]
 fn waitid_all(
-    flags: nix::sys::wait::WaitPidFlag,
+	flags: nix::sys::wait::WaitPidFlag,
 ) -> Result<nix::sys::wait::WaitStatus, nix::errno::Errno> {
-    // SAFETY:
-    // Code copied from nix::sys::wait implementation of waitid for other platforms.
-    let siginfo = unsafe {
-        // Memory is zeroed rather than uninitialized, as not all platforms
-        // initialize the memory in the StillAlive case
-        let mut siginfo: nix::libc::siginfo_t = std::mem::zeroed();
-        nix::errno::Errno::result(nix::libc::waitid(
-            nix::libc::P_ALL,
-            0,
-            &raw mut siginfo,
-            flags.bits(),
-        ))?;
-        siginfo
-    };
+	// SAFETY:
+	// Code copied from nix::sys::wait implementation of waitid for other platforms.
+	let siginfo = unsafe {
+		// Memory is zeroed rather than uninitialized, as not all platforms
+		// initialize the memory in the StillAlive case
+		let mut siginfo: nix::libc::siginfo_t = std::mem::zeroed();
+		nix::errno::Errno::result(nix::libc::waitid(
+			nix::libc::P_ALL,
+			0,
+			&raw mut siginfo,
+			flags.bits(),
+		))?;
+		siginfo
+	};
 
-    siginfo_to_wait_status(siginfo)
+	siginfo_to_wait_status(siginfo)
 }
 
 #[cfg(target_os = "macos")]
 fn siginfo_to_wait_status(
-    siginfo: nix::libc::siginfo_t,
+	siginfo: nix::libc::siginfo_t,
 ) -> Result<nix::sys::wait::WaitStatus, nix::errno::Errno> {
-    // SAFETY:
-    // Code copied from nix::sys::wait implementation of waitid for other platforms.
-    let si_pid = unsafe { siginfo.si_pid() };
-    if si_pid == 0 {
-        return Ok(nix::sys::wait::WaitStatus::StillAlive);
-    }
+	// SAFETY:
+	// Code copied from nix::sys::wait implementation of waitid for other platforms.
+	let si_pid = unsafe { siginfo.si_pid() };
+	if si_pid == 0 {
+		return Ok(nix::sys::wait::WaitStatus::StillAlive);
+	}
 
-    let pid = nix::unistd::Pid::from_raw(si_pid);
+	let pid = nix::unistd::Pid::from_raw(si_pid);
 
-    // SAFETY:
-    // Code copied from nix::sys::wait implementation of waitid for other platforms.
-    let si_status = unsafe { siginfo.si_status() };
+	// SAFETY:
+	// Code copied from nix::sys::wait implementation of waitid for other platforms.
+	let si_status = unsafe { siginfo.si_status() };
 
-    let status = match siginfo.si_code {
-        nix::libc::CLD_EXITED => nix::sys::wait::WaitStatus::Exited(pid, si_status),
-        nix::libc::CLD_KILLED | nix::libc::CLD_DUMPED => nix::sys::wait::WaitStatus::Signaled(
-            pid,
-            nix::sys::signal::Signal::try_from(si_status)?,
-            siginfo.si_code == nix::libc::CLD_DUMPED,
-        ),
-        nix::libc::CLD_STOPPED => {
-            nix::sys::wait::WaitStatus::Stopped(pid, nix::sys::signal::Signal::try_from(si_status)?)
-        }
-        nix::libc::CLD_CONTINUED => nix::sys::wait::WaitStatus::Continued(pid),
-        _ => return Err(nix::errno::Errno::EINVAL),
-    };
+	let status = match siginfo.si_code {
+		nix::libc::CLD_EXITED => nix::sys::wait::WaitStatus::Exited(pid, si_status),
+		nix::libc::CLD_KILLED | nix::libc::CLD_DUMPED => nix::sys::wait::WaitStatus::Signaled(
+			pid,
+			nix::sys::signal::Signal::try_from(si_status)?,
+			siginfo.si_code == nix::libc::CLD_DUMPED,
+		),
+		nix::libc::CLD_STOPPED => {
+			nix::sys::wait::WaitStatus::Stopped(pid, nix::sys::signal::Signal::try_from(si_status)?)
+		},
+		nix::libc::CLD_CONTINUED => nix::sys::wait::WaitStatus::Continued(pid),
+		_ => return Err(nix::errno::Errno::EINVAL),
+	};
 
-    Ok(status)
+	Ok(status)
 }

--- a/crates/brush-core-vendored/src/sys/unix/terminal.rs
+++ b/crates/brush-core-vendored/src/sys/unix/terminal.rs
@@ -6,105 +6,105 @@ use std::{io::IsTerminal, os::fd::AsFd};
 /// Terminal configuration.
 #[derive(Clone, Debug)]
 pub struct Config {
-    termios: nix::sys::termios::Termios,
+	termios: nix::sys::termios::Termios,
 }
 
 impl Config {
-    /// Creates a new `Config` from the actual terminal attributes of the terminal associated
-    /// with the given file descriptor.
-    ///
-    /// # Arguments
-    ///
-    /// * `fd` - The file descriptor of the terminal.
-    pub fn from_term(fd: impl AsFd) -> Result<Self, error::Error> {
-        let termios = nix::sys::termios::tcgetattr(fd)?;
-        Ok(Self { termios })
-    }
+	/// Creates a new `Config` from the actual terminal attributes of the terminal associated
+	/// with the given file descriptor.
+	///
+	/// # Arguments
+	///
+	/// * `fd` - The file descriptor of the terminal.
+	pub fn from_term(fd: impl AsFd) -> Result<Self, error::Error> {
+		let termios = nix::sys::termios::tcgetattr(fd)?;
+		Ok(Self { termios })
+	}
 
-    /// Applies the terminal settings to the terminal associated with the given file descriptor.
-    ///
-    /// # Arguments
-    ///
-    /// * `fd` - The file descriptor of the terminal.
-    pub fn apply_to_term(&self, fd: impl AsFd) -> Result<(), error::Error> {
-        nix::sys::termios::tcsetattr(fd, nix::sys::termios::SetArg::TCSANOW, &self.termios)?;
-        Ok(())
-    }
+	/// Applies the terminal settings to the terminal associated with the given file descriptor.
+	///
+	/// # Arguments
+	///
+	/// * `fd` - The file descriptor of the terminal.
+	pub fn apply_to_term(&self, fd: impl AsFd) -> Result<(), error::Error> {
+		nix::sys::termios::tcsetattr(fd, nix::sys::termios::SetArg::TCSANOW, &self.termios)?;
+		Ok(())
+	}
 
-    /// Applies the given high-level terminal settings to this configuration. Does not modify any
-    /// terminal itself.
-    ///
-    /// # Arguments
-    ///
-    /// * `settings` - The high-level terminal settings to apply to this configuration.
-    pub fn update(&mut self, settings: &terminal::Settings) {
-        if let Some(echo_input) = &settings.echo_input {
-            if *echo_input {
-                self.termios.local_flags |= nix::sys::termios::LocalFlags::ECHO;
-            } else {
-                self.termios.local_flags -= nix::sys::termios::LocalFlags::ECHO;
-            }
-        }
+	/// Applies the given high-level terminal settings to this configuration. Does not modify any
+	/// terminal itself.
+	///
+	/// # Arguments
+	///
+	/// * `settings` - The high-level terminal settings to apply to this configuration.
+	pub fn update(&mut self, settings: &terminal::Settings) {
+		if let Some(echo_input) = &settings.echo_input {
+			if *echo_input {
+				self.termios.local_flags |= nix::sys::termios::LocalFlags::ECHO;
+			} else {
+				self.termios.local_flags -= nix::sys::termios::LocalFlags::ECHO;
+			}
+		}
 
-        if let Some(line_input) = &settings.line_input {
-            if *line_input {
-                self.termios.local_flags |= nix::sys::termios::LocalFlags::ICANON;
-            } else {
-                self.termios.local_flags -= nix::sys::termios::LocalFlags::ICANON;
-            }
-        }
+		if let Some(line_input) = &settings.line_input {
+			if *line_input {
+				self.termios.local_flags |= nix::sys::termios::LocalFlags::ICANON;
+			} else {
+				self.termios.local_flags -= nix::sys::termios::LocalFlags::ICANON;
+			}
+		}
 
-        if let Some(interrupt_signals) = &settings.interrupt_signals {
-            if *interrupt_signals {
-                self.termios.local_flags |= nix::sys::termios::LocalFlags::ISIG;
-            } else {
-                self.termios.local_flags -= nix::sys::termios::LocalFlags::ISIG;
-            }
-        }
+		if let Some(interrupt_signals) = &settings.interrupt_signals {
+			if *interrupt_signals {
+				self.termios.local_flags |= nix::sys::termios::LocalFlags::ISIG;
+			} else {
+				self.termios.local_flags -= nix::sys::termios::LocalFlags::ISIG;
+			}
+		}
 
-        if let Some(output_nl_as_nlcr) = &settings.output_nl_as_nlcr {
-            if *output_nl_as_nlcr {
-                self.termios.output_flags |=
-                    nix::sys::termios::OutputFlags::OPOST | nix::sys::termios::OutputFlags::ONLCR;
-            } else {
-                self.termios.output_flags -= nix::sys::termios::OutputFlags::ONLCR;
-            }
-        }
-    }
+		if let Some(output_nl_as_nlcr) = &settings.output_nl_as_nlcr {
+			if *output_nl_as_nlcr {
+				self.termios.output_flags |=
+					nix::sys::termios::OutputFlags::OPOST | nix::sys::termios::OutputFlags::ONLCR;
+			} else {
+				self.termios.output_flags -= nix::sys::termios::OutputFlags::ONLCR;
+			}
+		}
+	}
 }
 
 /// Get the process ID of this process's parent.
 pub fn get_parent_process_id() -> Option<sys::process::ProcessId> {
-    Some(nix::unistd::getppid().as_raw())
+	Some(nix::unistd::getppid().as_raw())
 }
 
 /// Get the process group ID for this process's process group.
 pub fn get_process_group_id() -> Option<sys::process::ProcessId> {
-    Some(nix::unistd::getpgrp().as_raw())
+	Some(nix::unistd::getpgrp().as_raw())
 }
 
 /// Get the foreground process ID of the attached terminal.
 pub fn get_foreground_pid() -> Option<sys::process::ProcessId> {
-    nix::unistd::tcgetpgrp(std::io::stdin())
-        .ok()
-        .map(|pgid| pgid.as_raw())
+	nix::unistd::tcgetpgrp(std::io::stdin())
+		.ok()
+		.map(|pgid| pgid.as_raw())
 }
 
 /// Move the specified process to the foreground of the attached terminal.
 pub fn move_to_foreground(pid: sys::process::ProcessId) -> Result<(), error::Error> {
-    nix::unistd::tcsetpgrp(std::io::stdin(), nix::unistd::Pid::from_raw(pid))?;
-    Ok(())
+	nix::unistd::tcsetpgrp(std::io::stdin(), nix::unistd::Pid::from_raw(pid))?;
+	Ok(())
 }
 
 /// Moves the current process to the foreground of the attached terminal.
 pub fn move_self_to_foreground() -> Result<(), error::Error> {
-    if std::io::stdin().is_terminal() {
-        let pgid = nix::unistd::getpgid(None)?;
+	if std::io::stdin().is_terminal() {
+		let pgid = nix::unistd::getpgid(None)?;
 
-        // TODO: jobs: This sometimes fails with ENOTTY even though we checked that stdin is a
-        // terminal. We should investigate why this is happening.
-        let _ = nix::unistd::tcsetpgrp(std::io::stdin(), pgid);
-    }
+		// TODO: jobs: This sometimes fails with ENOTTY even though we checked that stdin is a
+		// terminal. We should investigate why this is happening.
+		let _ = nix::unistd::tcsetpgrp(std::io::stdin(), pgid);
+	}
 
-    Ok(())
+	Ok(())
 }

--- a/crates/brush-core-vendored/src/sys/unix/users.rs
+++ b/crates/brush-core-vendored/src/sys/unix/users.rs
@@ -4,69 +4,69 @@ use std::path::PathBuf;
 use uzers::os::unix::UserExt;
 
 pub(crate) fn is_root() -> bool {
-    uzers::get_current_uid() == 0
+	uzers::get_current_uid() == 0
 }
 
 pub(crate) fn get_user_home_dir(username: &str) -> Option<PathBuf> {
-    if let Some(user_info) = uzers::get_user_by_name(username) {
-        return Some(user_info.home_dir().to_path_buf());
-    }
+	if let Some(user_info) = uzers::get_user_by_name(username) {
+		return Some(user_info.home_dir().to_path_buf());
+	}
 
-    None
+	None
 }
 
 pub(crate) fn get_current_user_home_dir() -> Option<PathBuf> {
-    if let Some(username) = uzers::get_current_username() {
-        if let Some(user_info) = uzers::get_user_by_name(&username) {
-            return Some(user_info.home_dir().to_path_buf());
-        }
-    }
+	if let Some(username) = uzers::get_current_username() {
+		if let Some(user_info) = uzers::get_user_by_name(&username) {
+			return Some(user_info.home_dir().to_path_buf());
+		}
+	}
 
-    None
+	None
 }
 
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_current_uid() -> Result<u32, error::Error> {
-    Ok(uzers::get_current_uid())
+	Ok(uzers::get_current_uid())
 }
 
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_current_gid() -> Result<u32, error::Error> {
-    Ok(uzers::get_current_gid())
+	Ok(uzers::get_current_gid())
 }
 
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_effective_uid() -> Result<u32, error::Error> {
-    Ok(uzers::get_effective_uid())
+	Ok(uzers::get_effective_uid())
 }
 
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_effective_gid() -> Result<u32, error::Error> {
-    Ok(uzers::get_effective_gid())
+	Ok(uzers::get_effective_gid())
 }
 
 pub(crate) fn get_current_username() -> Result<String, error::Error> {
-    let username = uzers::get_current_username().ok_or_else(|| error::ErrorKind::NoCurrentUser)?;
-    Ok(username.to_string_lossy().to_string())
+	let username = uzers::get_current_username().ok_or_else(|| error::ErrorKind::NoCurrentUser)?;
+	Ok(username.to_string_lossy().to_string())
 }
 
 pub(crate) fn get_user_group_ids() -> Result<Vec<u32>, error::Error> {
-    let username = uzers::get_current_username().ok_or_else(|| error::ErrorKind::NoCurrentUser)?;
-    let gid = uzers::get_current_gid();
-    let groups = uzers::get_user_groups(&username, gid).unwrap_or_default();
-    Ok(groups.into_iter().map(|g| g.gid()).collect())
+	let username = uzers::get_current_username().ok_or_else(|| error::ErrorKind::NoCurrentUser)?;
+	let gid = uzers::get_current_gid();
+	let groups = uzers::get_user_groups(&username, gid).unwrap_or_default();
+	Ok(groups.into_iter().map(|g| g.gid()).collect())
 }
 
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_all_users() -> Result<Vec<String>, error::Error> {
-    // TODO(#475): uzers::all_users() is available but unsafe
-    tracing::debug!(target: trace_categories::UNIMPLEMENTED, "get_all_users");
-    Ok(vec![])
+	// TODO(#475): uzers::all_users() is available but unsafe
+	tracing::debug!(target: trace_categories::UNIMPLEMENTED, "get_all_users");
+	Ok(vec![])
 }
 
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_all_groups() -> Result<Vec<String>, error::Error> {
-    // TODO(#475): uzers::all_groups() is available but unsafe
-    tracing::debug!(target: trace_categories::UNIMPLEMENTED, "get_all_groups");
-    Ok(vec![])
+	// TODO(#475): uzers::all_groups() is available but unsafe
+	tracing::debug!(target: trace_categories::UNIMPLEMENTED, "get_all_groups");
+	Ok(vec![])
 }

--- a/crates/brush-core-vendored/src/sys/windows.rs
+++ b/crates/brush-core-vendored/src/sys/windows.rs
@@ -7,8 +7,8 @@ pub use crate::sys::stubs::resource;
 
 /// Signal processing utilities
 pub mod signal {
-    pub use crate::sys::stubs::signal::*;
-    pub(crate) use tokio::signal::ctrl_c as await_ctrl_c;
+	pub use crate::sys::stubs::signal::*;
+	pub(crate) use tokio::signal::ctrl_c as await_ctrl_c;
 }
 
 pub mod terminal;

--- a/crates/brush-core-vendored/src/sys/windows/fs.rs
+++ b/crates/brush-core-vendored/src/sys/windows/fs.rs
@@ -56,8 +56,8 @@ impl crate::sys::fs::PathExt for std::path::Path {
 	fn get_device_and_inode(&self) -> Result<(u64, u64), crate::error::Error> {
 		let metadata = self.metadata()?;
 		let volume_serial_number =
-            u64::from(std::os::windows::fs::MetadataExt::volume_serial_number(&metadata).unwrap_or(0));
-        let file_index = std::os::windows::fs::MetadataExt::file_index(&metadata).unwrap_or(0);
+			u64::from(std::os::windows::fs::MetadataExt::volume_serial_number(&metadata).unwrap_or(0));
+		let file_index = std::os::windows::fs::MetadataExt::file_index(&metadata).unwrap_or(0);
 		Ok((volume_serial_number, file_index))
 	}
 }
@@ -93,8 +93,7 @@ pub(crate) fn get_default_executable_search_paths() -> Vec<String> {
 	if paths.is_empty() {
 		if let Some(env_path) = std::env::var_os("PATH") {
 			paths.extend(
-				std::env::split_paths(&env_path)
-					.map(|path| path.to_string_lossy().to_string()),
+				std::env::split_paths(&env_path).map(|path| path.to_string_lossy().to_string()),
 			);
 		}
 	}
@@ -112,7 +111,10 @@ pub fn get_default_standard_utils_paths() -> Vec<String> {
 
 /// Opens a null file that will discard all I/O.
 pub fn open_null_file() -> Result<std::fs::File, error::Error> {
-	let f = std::fs::File::options().read(true).write(true).open("NUL")?;
+	let f = std::fs::File::options()
+		.read(true)
+		.write(true)
+		.open("NUL")?;
 
 	Ok(f)
 }
@@ -151,7 +153,10 @@ pub(crate) fn executable_extensions() -> &'static [String] {
 			.collect::<Vec<_>>();
 
 		if exts.is_empty() {
-			exts = fallback.iter().map(|ext| (*ext).to_string()).collect::<Vec<_>>();
+			exts = fallback
+				.iter()
+				.map(|ext| (*ext).to_string())
+				.collect::<Vec<_>>();
 			return exts;
 		}
 

--- a/crates/brush-core-vendored/src/sys/windows/network.rs
+++ b/crates/brush-core-vendored/src/sys/windows/network.rs
@@ -1,3 +1,3 @@
 pub(crate) fn get_hostname() -> std::io::Result<std::ffi::OsString> {
-    crate::sys::hostname::get()
+	crate::sys::hostname::get()
 }

--- a/crates/brush-core-vendored/src/sys/windows/terminal.rs
+++ b/crates/brush-core-vendored/src/sys/windows/terminal.rs
@@ -5,12 +5,12 @@ use windows_sys::Win32::{
 	Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE},
 	System::{
 		Console::{
-			GetConsoleMode, GetConsoleWindow, GetStdHandle, SetConsoleMode,
-			ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT,
-			ENABLE_PROCESSED_OUTPUT, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+			ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT, ENABLE_PROCESSED_OUTPUT,
+			GetConsoleMode, GetConsoleWindow, GetStdHandle, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+			SetConsoleMode,
 		},
 		Diagnostics::ToolHelp::{
-			CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+			CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW,
 			TH32CS_SNAPPROCESS,
 		},
 		Threading::GetCurrentProcessId,
@@ -39,10 +39,7 @@ impl Config {
 		let input_mode = console_mode(input_handle)?;
 		let output_mode = console_mode(output_handle)?;
 
-		Ok(Self {
-			input_mode,
-			output_mode,
-		})
+		Ok(Self { input_mode, output_mode })
 	}
 
 	/// Applies the terminal settings to the terminal associated with the given file descriptor.
@@ -159,7 +156,7 @@ pub fn get_foreground_pid() -> Option<sys::process::ProcessId> {
 		// SAFETY: GetForegroundWindow has no safety requirements.
 		unsafe { GetForegroundWindow() }
 	};
-    if hwnd.is_null() {
+	if hwnd.is_null() {
 		return None;
 	}
 
@@ -177,7 +174,7 @@ pub fn move_to_foreground(_pid: sys::process::ProcessId) -> Result<(), error::Er
 		// SAFETY: GetConsoleWindow has no safety requirements.
 		unsafe { GetConsoleWindow() }
 	};
-    if !hwnd.is_null() {
+	if !hwnd.is_null() {
 		let _ = {
 			// SAFETY: hwnd is a console window handle when non-zero.
 			unsafe { SetForegroundWindow(hwnd) }
@@ -212,7 +209,7 @@ fn console_output_handle() -> Result<HANDLE, error::Error> {
 }
 
 fn validate_handle(handle: HANDLE) -> Result<HANDLE, error::Error> {
-    if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+	if handle.is_null() || handle == INVALID_HANDLE_VALUE {
 		return Err(std::io::Error::last_os_error().into());
 	}
 

--- a/crates/brush-core-vendored/src/sys/windows/users.rs
+++ b/crates/brush-core-vendored/src/sys/windows/users.rs
@@ -3,9 +3,9 @@
 use crate::error;
 use std::{mem::MaybeUninit, path::PathBuf, sync::OnceLock};
 use windows_sys::Win32::{
-    Foundation::{CloseHandle, HANDLE},
-    Security::{GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY},
-    System::Threading::{GetCurrentProcess, OpenProcessToken},
+	Foundation::{CloseHandle, HANDLE},
+	Security::{GetTokenInformation, TOKEN_ELEVATION, TOKEN_QUERY, TokenElevation},
+	System::Threading::{GetCurrentProcess, OpenProcessToken},
 };
 
 //
@@ -13,70 +13,70 @@ use windows_sys::Win32::{
 //
 
 pub(crate) fn get_user_home_dir(username: &str) -> Option<PathBuf> {
-    homedir::home(username).unwrap_or_default()
+	homedir::home(username).unwrap_or_default()
 }
 
 pub(crate) fn get_current_user_home_dir() -> Option<PathBuf> {
-    homedir::my_home().unwrap_or_default()
+	homedir::my_home().unwrap_or_default()
 }
 
 pub(crate) fn is_root() -> bool {
-    static IS_ROOT: OnceLock<bool> = OnceLock::new();
-    *IS_ROOT.get_or_init(|| {
-        // SAFETY: Windows APIs are called with valid handles and buffers.
-        unsafe {
-            let mut elevation = MaybeUninit::<TOKEN_ELEVATION>::zeroed();
-            let mut return_length = 0u32;
-            let status = GetTokenInformation(
-                (!3 as HANDLE), // GetCurrentProcessToken(),
-                TokenElevation,
-                elevation.as_mut_ptr().cast(),
-                std::mem::size_of::<TOKEN_ELEVATION>() as u32,
-                &mut return_length,
-            );
-            if status == 0 {
-                return false;
-            }
-            elevation.assume_init().TokenIsElevated != 0
-        }
-    })
+	static IS_ROOT: OnceLock<bool> = OnceLock::new();
+	*IS_ROOT.get_or_init(|| {
+		// SAFETY: Windows APIs are called with valid handles and buffers.
+		unsafe {
+			let mut elevation = MaybeUninit::<TOKEN_ELEVATION>::zeroed();
+			let mut return_length = 0u32;
+			let status = GetTokenInformation(
+				(!3 as HANDLE), // GetCurrentProcessToken(),
+				TokenElevation,
+				elevation.as_mut_ptr().cast(),
+				std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+				&mut return_length,
+			);
+			if status == 0 {
+				return false;
+			}
+			elevation.assume_init().TokenIsElevated != 0
+		}
+	})
 }
 
 pub(crate) fn get_current_uid() -> Result<u32, error::Error> {
-    Err(error::ErrorKind::NotSupportedOnThisPlatform("getting current uid").into())
+	Err(error::ErrorKind::NotSupportedOnThisPlatform("getting current uid").into())
 }
 
 pub(crate) fn get_current_gid() -> Result<u32, error::Error> {
-    Err(error::ErrorKind::NotSupportedOnThisPlatform("getting current gid").into())
+	Err(error::ErrorKind::NotSupportedOnThisPlatform("getting current gid").into())
 }
 
 pub(crate) fn get_effective_uid() -> Result<u32, error::Error> {
-    Err(error::ErrorKind::NotSupportedOnThisPlatform("getting effective uid").into())
+	Err(error::ErrorKind::NotSupportedOnThisPlatform("getting effective uid").into())
 }
 
 pub(crate) fn get_effective_gid() -> Result<u32, error::Error> {
-    Err(error::ErrorKind::NotSupportedOnThisPlatform("getting effective gid").into())
+	Err(error::ErrorKind::NotSupportedOnThisPlatform("getting effective gid").into())
 }
 
 pub(crate) fn get_current_username() -> Result<String, error::Error> {
-    let username = whoami::fallible::username()?;
-    Ok(username)
+	let username = whoami::fallible::username()?;
+	Ok(username)
 }
 
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn get_user_group_ids() -> Result<Vec<u32>, error::Error> {
-    // TODO: implement some version of this for Windows
-    Ok(vec![])
+	// TODO: implement some version of this for Windows
+	Ok(vec![])
 }
 
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_all_users() -> Result<Vec<String>, error::Error> {
-    // TODO: implement some version of this for Windows
-    Ok(vec![])
+	// TODO: implement some version of this for Windows
+	Ok(vec![])
 }
 
 #[expect(clippy::unnecessary_wraps)]
 pub(crate) fn get_all_groups() -> Result<Vec<String>, error::Error> {
-    // TODO: implement some version of this for Windows
-    Ok(vec![])
+	// TODO: implement some version of this for Windows
+	Ok(vec![])
 }

--- a/crates/brush-core-vendored/src/terminal.rs
+++ b/crates/brush-core-vendored/src/terminal.rs
@@ -4,89 +4,89 @@ use crate::{error, openfiles, sys};
 
 /// Encapsulates the state of a controlled terminal.
 pub struct TerminalControl {
-    prev_fg_pid: Option<sys::process::ProcessId>,
+	prev_fg_pid: Option<sys::process::ProcessId>,
 }
 
 impl TerminalControl {
-    /// Acquire the terminal for the shell.
-    pub fn acquire() -> Result<Self, error::Error> {
-        let prev_fg_pid = sys::terminal::get_foreground_pid();
+	/// Acquire the terminal for the shell.
+	pub fn acquire() -> Result<Self, error::Error> {
+		let prev_fg_pid = sys::terminal::get_foreground_pid();
 
-        // Break out into new process group.
-        // TODO: jobs: Investigate why this sometimes fails with EPERM.
-        let _ = sys::signal::lead_new_process_group();
+		// Break out into new process group.
+		// TODO: jobs: Investigate why this sometimes fails with EPERM.
+		let _ = sys::signal::lead_new_process_group();
 
-        // Take ownership.
-        sys::terminal::move_self_to_foreground()?;
+		// Take ownership.
+		sys::terminal::move_self_to_foreground()?;
 
-        // Mask out SIGTTOU.
-        sys::signal::mask_sigttou()?;
+		// Mask out SIGTTOU.
+		sys::signal::mask_sigttou()?;
 
-        Ok(Self { prev_fg_pid })
-    }
+		Ok(Self { prev_fg_pid })
+	}
 
-    fn try_release(&mut self) {
-        // Restore the previous foreground process group.
-        if let Some(pid) = self.prev_fg_pid {
-            if sys::terminal::move_to_foreground(pid).is_ok() {
-                self.prev_fg_pid = None;
-            }
-        }
-    }
+	fn try_release(&mut self) {
+		// Restore the previous foreground process group.
+		if let Some(pid) = self.prev_fg_pid {
+			if sys::terminal::move_to_foreground(pid).is_ok() {
+				self.prev_fg_pid = None;
+			}
+		}
+	}
 }
 
 impl Drop for TerminalControl {
-    fn drop(&mut self) {
-        self.try_release();
-    }
+	fn drop(&mut self) {
+		self.try_release();
+	}
 }
 
 /// Describes high-level terminal settings that can be requested.
 #[derive(Default, bon::Builder)]
 pub struct Settings {
-    /// Whether to enable input echoing.
-    pub echo_input: Option<bool>,
-    /// Whether to enable line input (sometimes known as canonical mode).
-    pub line_input: Option<bool>,
-    /// Whether to disable interrupt signals and instead yield the control characters.
-    pub interrupt_signals: Option<bool>,
-    /// Whether to output newline characters as CRLF pairs.
-    pub output_nl_as_nlcr: Option<bool>,
+	/// Whether to enable input echoing.
+	pub echo_input: Option<bool>,
+	/// Whether to enable line input (sometimes known as canonical mode).
+	pub line_input: Option<bool>,
+	/// Whether to disable interrupt signals and instead yield the control characters.
+	pub interrupt_signals: Option<bool>,
+	/// Whether to output newline characters as CRLF pairs.
+	pub output_nl_as_nlcr: Option<bool>,
 }
 
 /// Guard that automatically restores terminal settings on drop.
 pub struct AutoModeGuard {
-    initial: sys::terminal::Config,
-    file: openfiles::OpenFile,
+	initial: sys::terminal::Config,
+	file: openfiles::OpenFile,
 }
 
 impl AutoModeGuard {
-    /// Creates a new `AutoModeGuard` for the given file.
-    ///
-    /// # Arguments
-    ///
-    /// * `file` - The file representing the terminal to control.
-    pub fn new(file: openfiles::OpenFile) -> Result<Self, error::Error> {
-        let initial = sys::terminal::Config::from_term(&file)?;
-        Ok(Self { initial, file })
-    }
+	/// Creates a new `AutoModeGuard` for the given file.
+	///
+	/// # Arguments
+	///
+	/// * `file` - The file representing the terminal to control.
+	pub fn new(file: openfiles::OpenFile) -> Result<Self, error::Error> {
+		let initial = sys::terminal::Config::from_term(&file)?;
+		Ok(Self { initial, file })
+	}
 
-    /// Applies the given terminal settings.
-    ///
-    /// # Arguments
-    ///
-    /// * `settings` - The terminal settings to apply.
-    pub fn apply_settings(&self, settings: &Settings) -> Result<(), error::Error> {
-        let mut config = sys::terminal::Config::from_term(&self.file)?;
-        config.update(settings);
-        config.apply_to_term(&self.file)?;
+	/// Applies the given terminal settings.
+	///
+	/// # Arguments
+	///
+	/// * `settings` - The terminal settings to apply.
+	pub fn apply_settings(&self, settings: &Settings) -> Result<(), error::Error> {
+		let mut config = sys::terminal::Config::from_term(&self.file)?;
+		config.update(settings);
+		config.apply_to_term(&self.file)?;
 
-        Ok(())
-    }
+		Ok(())
+	}
 }
 
 impl Drop for AutoModeGuard {
-    fn drop(&mut self) {
-        let _ = self.initial.apply_to_term(&self.file);
-    }
+	fn drop(&mut self) {
+		let _ = self.initial.apply_to_term(&self.file);
+	}
 }

--- a/crates/brush-core-vendored/src/tests.rs
+++ b/crates/brush-core-vendored/src/tests.rs
@@ -12,26 +12,26 @@ use crate::{ExecutionParameters, Shell, error, extendedtests};
 /// * `shell` - The shell context in which to evaluate the expression.
 /// * `params` - The execution parameters to use during evaluation.
 pub fn eval_expr(
-    expr: &brush_parser::ast::TestExpr,
-    shell: &mut Shell,
-    params: &ExecutionParameters,
+	expr: &brush_parser::ast::TestExpr,
+	shell: &mut Shell,
+	params: &ExecutionParameters,
 ) -> Result<bool, error::Error> {
-    match expr {
-        brush_parser::ast::TestExpr::False => Ok(false),
-        brush_parser::ast::TestExpr::Literal(s) => Ok(!s.is_empty()),
-        brush_parser::ast::TestExpr::And(left, right) => {
-            Ok(eval_expr(left, shell, params)? && eval_expr(right, shell, params)?)
-        }
-        brush_parser::ast::TestExpr::Or(left, right) => {
-            Ok(eval_expr(left, shell, params)? || eval_expr(right, shell, params)?)
-        }
-        brush_parser::ast::TestExpr::Not(expr) => Ok(!eval_expr(expr, shell, params)?),
-        brush_parser::ast::TestExpr::Parenthesized(expr) => eval_expr(expr, shell, params),
-        brush_parser::ast::TestExpr::UnaryTest(op, operand) => {
-            extendedtests::apply_unary_predicate_to_str(op, operand, shell, params)
-        }
-        brush_parser::ast::TestExpr::BinaryTest(op, left, right) => {
-            extendedtests::apply_binary_predicate_to_strs(op, left.as_str(), right.as_str(), shell)
-        }
-    }
+	match expr {
+		brush_parser::ast::TestExpr::False => Ok(false),
+		brush_parser::ast::TestExpr::Literal(s) => Ok(!s.is_empty()),
+		brush_parser::ast::TestExpr::And(left, right) => {
+			Ok(eval_expr(left, shell, params)? && eval_expr(right, shell, params)?)
+		},
+		brush_parser::ast::TestExpr::Or(left, right) => {
+			Ok(eval_expr(left, shell, params)? || eval_expr(right, shell, params)?)
+		},
+		brush_parser::ast::TestExpr::Not(expr) => Ok(!eval_expr(expr, shell, params)?),
+		brush_parser::ast::TestExpr::Parenthesized(expr) => eval_expr(expr, shell, params),
+		brush_parser::ast::TestExpr::UnaryTest(op, operand) => {
+			extendedtests::apply_unary_predicate_to_str(op, operand, shell, params)
+		},
+		brush_parser::ast::TestExpr::BinaryTest(op, left, right) => {
+			extendedtests::apply_binary_predicate_to_strs(op, left.as_str(), right.as_str(), shell)
+		},
+	}
 }

--- a/crates/brush-core-vendored/src/timing.rs
+++ b/crates/brush-core-vendored/src/timing.rs
@@ -3,63 +3,51 @@
 use crate::error;
 
 struct StopwatchTime {
-    now: std::time::SystemTime,
-    self_user: std::time::Duration,
-    self_system: std::time::Duration,
-    children_user: std::time::Duration,
-    children_system: std::time::Duration,
+	now: std::time::SystemTime,
+	self_user: std::time::Duration,
+	self_system: std::time::Duration,
+	children_user: std::time::Duration,
+	children_system: std::time::Duration,
 }
 
 impl StopwatchTime {
-    #[allow(clippy::unchecked_time_subtraction)]
-    fn minus(&self, other: &Self) -> Result<StopwatchTiming, error::Error> {
-        let user = (self.self_user - other.self_user) + (self.children_user - other.children_user);
-        let system =
-            (self.self_system - other.self_system) + (self.children_system - other.children_system);
+	#[allow(clippy::unchecked_time_subtraction)]
+	fn minus(&self, other: &Self) -> Result<StopwatchTiming, error::Error> {
+		let user = (self.self_user - other.self_user) + (self.children_user - other.children_user);
+		let system =
+			(self.self_system - other.self_system) + (self.children_system - other.children_system);
 
-        Ok(StopwatchTiming {
-            wall: self.now.duration_since(other.now)?,
-            user,
-            system,
-        })
-    }
+		Ok(StopwatchTiming { wall: self.now.duration_since(other.now)?, user, system })
+	}
 }
 
 pub(crate) struct Stopwatch {
-    start: StopwatchTime,
+	start: StopwatchTime,
 }
 
 impl Stopwatch {
-    pub fn stop(&self) -> Result<StopwatchTiming, error::Error> {
-        let end = get_current_stopwatch_time()?;
-        end.minus(&self.start)
-    }
+	pub fn stop(&self) -> Result<StopwatchTiming, error::Error> {
+		let end = get_current_stopwatch_time()?;
+		end.minus(&self.start)
+	}
 }
 pub(crate) struct StopwatchTiming {
-    pub wall: std::time::Duration,
-    pub user: std::time::Duration,
-    pub system: std::time::Duration,
+	pub wall: std::time::Duration,
+	pub user: std::time::Duration,
+	pub system: std::time::Duration,
 }
 
 pub(crate) fn start_timing() -> Result<Stopwatch, error::Error> {
-    Ok(Stopwatch {
-        start: get_current_stopwatch_time()?,
-    })
+	Ok(Stopwatch { start: get_current_stopwatch_time()? })
 }
 
 fn get_current_stopwatch_time() -> Result<StopwatchTime, error::Error> {
-    let now = std::time::SystemTime::now();
-    let (self_user, self_system) = crate::sys::resource::get_self_user_and_system_time()?;
-    let (children_user, children_system) =
-        crate::sys::resource::get_children_user_and_system_time()?;
+	let now = std::time::SystemTime::now();
+	let (self_user, self_system) = crate::sys::resource::get_self_user_and_system_time()?;
+	let (children_user, children_system) =
+		crate::sys::resource::get_children_user_and_system_time()?;
 
-    Ok(StopwatchTime {
-        now,
-        self_user,
-        self_system,
-        children_user,
-        children_system,
-    })
+	Ok(StopwatchTime { now, self_user, self_system, children_user, children_system })
 }
 
 /// Format the given duration in a non-POSIX-y way.
@@ -68,10 +56,10 @@ fn get_current_stopwatch_time() -> Result<StopwatchTime, error::Error> {
 ///
 /// * `duration` - The duration to format.
 pub fn format_duration_non_posixly(duration: &std::time::Duration) -> String {
-    let minutes = duration.as_secs() / 60;
-    let seconds = duration.as_secs() % 60;
-    let millis = duration.subsec_millis();
-    format!("{minutes}m{seconds}.{millis:03}s")
+	let minutes = duration.as_secs() / 60;
+	let seconds = duration.as_secs() % 60;
+	let millis = duration.subsec_millis();
+	format!("{minutes}m{seconds}.{millis:03}s")
 }
 
 /// Format the given duration in a POSIX-y way.
@@ -80,58 +68,28 @@ pub fn format_duration_non_posixly(duration: &std::time::Duration) -> String {
 ///
 /// * `duration` - The duration to format.
 pub fn format_duration_posixly(duration: &std::time::Duration) -> String {
-    let seconds = duration.as_secs();
-    let ten_millis = duration.subsec_millis() / 10;
-    format!("{seconds}.{ten_millis:02}")
+	let seconds = duration.as_secs();
+	let ten_millis = duration.subsec_millis() / 10;
+	format!("{seconds}.{ten_millis:02}")
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::time::Duration;
+	use super::*;
+	use std::time::Duration;
 
-    #[test]
-    fn test_format_time() {
-        assert_eq!(
-            format_duration_non_posixly(&Duration::from_millis(0)),
-            "0m0.000s"
-        );
-        assert_eq!(
-            format_duration_non_posixly(&Duration::from_millis(1)),
-            "0m0.001s"
-        );
-        assert_eq!(
-            format_duration_non_posixly(&Duration::from_millis(123)),
-            "0m0.123s"
-        );
-        assert_eq!(
-            format_duration_non_posixly(&Duration::from_millis(1234)),
-            "0m1.234s"
-        );
-        assert_eq!(
-            format_duration_non_posixly(&Duration::from_millis(12345)),
-            "0m12.345s"
-        );
-        assert_eq!(
-            format_duration_non_posixly(&Duration::from_millis(123_456)),
-            "2m3.456s"
-        );
-        assert_eq!(
-            format_duration_non_posixly(&Duration::from_millis(1_234_567)),
-            "20m34.567s"
-        );
+	#[test]
+	fn test_format_time() {
+		assert_eq!(format_duration_non_posixly(&Duration::from_millis(0)), "0m0.000s");
+		assert_eq!(format_duration_non_posixly(&Duration::from_millis(1)), "0m0.001s");
+		assert_eq!(format_duration_non_posixly(&Duration::from_millis(123)), "0m0.123s");
+		assert_eq!(format_duration_non_posixly(&Duration::from_millis(1234)), "0m1.234s");
+		assert_eq!(format_duration_non_posixly(&Duration::from_millis(12345)), "0m12.345s");
+		assert_eq!(format_duration_non_posixly(&Duration::from_millis(123_456)), "2m3.456s");
+		assert_eq!(format_duration_non_posixly(&Duration::from_millis(1_234_567)), "20m34.567s");
 
-        assert_eq!(
-            format_duration_non_posixly(&Duration::from_micros(1)),
-            "0m0.000s"
-        );
-        assert_eq!(
-            format_duration_non_posixly(&Duration::from_micros(999)),
-            "0m0.000s"
-        );
-        assert_eq!(
-            format_duration_non_posixly(&Duration::from_micros(1000)),
-            "0m0.001s"
-        );
-    }
+		assert_eq!(format_duration_non_posixly(&Duration::from_micros(1)), "0m0.000s");
+		assert_eq!(format_duration_non_posixly(&Duration::from_micros(999)), "0m0.000s");
+		assert_eq!(format_duration_non_posixly(&Duration::from_micros(1000)), "0m0.001s");
+	}
 }

--- a/crates/brush-core-vendored/src/traps.rs
+++ b/crates/brush-core-vendored/src/traps.rs
@@ -10,47 +10,47 @@ use crate::{error, sys};
 /// Type of signal that can be trapped in the shell.
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub enum TrapSignal {
-    /// A system signal.
-    Signal(sys::signal::Signal),
-    /// The `DEBUG` trap.
-    Debug,
-    /// The `ERR` trap.
-    Err,
-    /// The `EXIT` trap.
-    Exit,
-    /// The `RETURN` trp.
-    Return,
+	/// A system signal.
+	Signal(sys::signal::Signal),
+	/// The `DEBUG` trap.
+	Debug,
+	/// The `ERR` trap.
+	Err,
+	/// The `EXIT` trap.
+	Exit,
+	/// The `RETURN` trp.
+	Return,
 }
 
 impl Display for TrapSignal {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.write_str(self.as_str())
+	}
 }
 
 impl TrapSignal {
-    /// Returns all possible values of [`TrapSignal`].
-    pub fn iterator() -> impl Iterator<Item = Self> {
-        const SIGNALS: &[TrapSignal] = &[TrapSignal::Debug, TrapSignal::Err, TrapSignal::Exit];
+	/// Returns all possible values of [`TrapSignal`].
+	pub fn iterator() -> impl Iterator<Item = Self> {
+		const SIGNALS: &[TrapSignal] = &[TrapSignal::Debug, TrapSignal::Err, TrapSignal::Exit];
 
-        let iter = itertools::chain!(
-            SIGNALS.iter().copied(),
-            sys::signal::Signal::iterator().map(TrapSignal::Signal)
-        );
+		let iter = itertools::chain!(
+			SIGNALS.iter().copied(),
+			sys::signal::Signal::iterator().map(TrapSignal::Signal)
+		);
 
-        iter
-    }
+		iter
+	}
 
-    /// Converts [`TrapSignal`] into its corresponding signal name as a [`&'static str`](str)
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Signal(s) => s.as_str(),
-            Self::Debug => "DEBUG",
-            Self::Err => "ERR",
-            Self::Exit => "EXIT",
-            Self::Return => "RETURN",
-        }
-    }
+	/// Converts [`TrapSignal`] into its corresponding signal name as a [`&'static str`](str)
+	pub const fn as_str(self) -> &'static str {
+		match self {
+			Self::Signal(s) => s.as_str(),
+			Self::Debug => "DEBUG",
+			Self::Err => "ERR",
+			Self::Exit => "EXIT",
+			Self::Return => "RETURN",
+		}
+	}
 }
 
 /// Formats [`Iterator<Item = TrapSignal>`](TrapSignal)  to the provided writer.
@@ -60,70 +60,70 @@ impl TrapSignal {
 /// * `f` - Any type that implements [`std::io::Write`].
 /// * `it` - An iterator over the signals that will be formatted into the `f`.
 pub fn format_signals(
-    mut f: impl std::io::Write,
-    it: impl Iterator<Item = TrapSignal>,
+	mut f: impl std::io::Write,
+	it: impl Iterator<Item = TrapSignal>,
 ) -> Result<(), error::Error> {
-    let it = it
-        .filter_map(|s| i32::try_from(s).ok().map(|n| (s, n)))
-        .sorted_by(|a, b| Ord::cmp(&a.1, &b.1))
-        .format_with("\n", |s, f| f(&format_args!("{}) {}", s.1, s.0)));
-    write!(f, "{it}")?;
-    Ok(())
+	let it = it
+		.filter_map(|s| i32::try_from(s).ok().map(|n| (s, n)))
+		.sorted_by(|a, b| Ord::cmp(&a.1, &b.1))
+		.format_with("\n", |s, f| f(&format_args!("{}) {}", s.1, s.0)));
+	write!(f, "{it}")?;
+	Ok(())
 }
 
 // implement s.parse::<TrapSignal>()
 impl FromStr for TrapSignal {
-    type Err = error::Error;
-    fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
-        if let Ok(n) = s.parse::<i32>() {
-            Self::try_from(n)
-        } else {
-            Self::try_from(s)
-        }
-    }
+	type Err = error::Error;
+	fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
+		if let Ok(n) = s.parse::<i32>() {
+			Self::try_from(n)
+		} else {
+			Self::try_from(s)
+		}
+	}
 }
 
 // from a signal number
 impl TryFrom<i32> for TrapSignal {
-    type Error = error::Error;
-    fn try_from(value: i32) -> Result<Self, Self::Error> {
-        // NOTE: DEBUG and ERR are real-time signals, defined based on NSIG or SIGRTMAX (is not
-        // available on bsd-like systems),
-        // and don't have persistent numbers across platforms, so we skip them here.
-        Ok(match value {
-            0 => Self::Exit,
-            value => Self::Signal(
-                sys::signal::Signal::try_from(value)
-                    .map_err(|_| error::ErrorKind::InvalidSignal(value.to_string()))?,
-            ),
-        })
-    }
+	type Error = error::Error;
+	fn try_from(value: i32) -> Result<Self, Self::Error> {
+		// NOTE: DEBUG and ERR are real-time signals, defined based on NSIG or SIGRTMAX (is not
+		// available on bsd-like systems),
+		// and don't have persistent numbers across platforms, so we skip them here.
+		Ok(match value {
+			0 => Self::Exit,
+			value => Self::Signal(
+				sys::signal::Signal::try_from(value)
+					.map_err(|_| error::ErrorKind::InvalidSignal(value.to_string()))?,
+			),
+		})
+	}
 }
 
 // from a signal name
 impl TryFrom<&str> for TrapSignal {
-    type Error = error::Error;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        #[allow(unused_mut, reason = "only mutated on some platforms")]
-        let mut s = value.to_ascii_uppercase();
+	type Error = error::Error;
+	fn try_from(value: &str) -> Result<Self, Self::Error> {
+		#[allow(unused_mut, reason = "only mutated on some platforms")]
+		let mut s = value.to_ascii_uppercase();
 
-        Ok(match s.as_str() {
-            "DEBUG" => Self::Debug,
-            "ERR" => Self::Err,
-            "EXIT" => Self::Exit,
-            "RETURN" => Self::Return,
-            _ => {
-                // Bash compatibility:
-                // support for signal names without the `SIG` prefix, for example `HUP` -> `SIGHUP`
-                if !s.starts_with("SIG") {
-                    s.insert_str(0, "SIG");
-                }
-                sys::signal::Signal::from_str(s.as_str())
-                    .map(TrapSignal::Signal)
-                    .map_err(|_| error::ErrorKind::InvalidSignal(value.into()))?
-            }
-        })
-    }
+		Ok(match s.as_str() {
+			"DEBUG" => Self::Debug,
+			"ERR" => Self::Err,
+			"EXIT" => Self::Exit,
+			"RETURN" => Self::Return,
+			_ => {
+				// Bash compatibility:
+				// support for signal names without the `SIG` prefix, for example `HUP` -> `SIGHUP`
+				if !s.starts_with("SIG") {
+					s.insert_str(0, "SIG");
+				}
+				sys::signal::Signal::from_str(s.as_str())
+					.map(TrapSignal::Signal)
+					.map_err(|_| error::ErrorKind::InvalidSignal(value.into()))?
+			},
+		})
+	}
 }
 
 /// Error type used when failing to convert a `TrapSignal` to a number.
@@ -131,58 +131,59 @@ impl TryFrom<&str> for TrapSignal {
 pub struct TrapSignalNumberError;
 
 impl TryFrom<TrapSignal> for i32 {
-    type Error = TrapSignalNumberError;
-    fn try_from(value: TrapSignal) -> Result<Self, Self::Error> {
-        Ok(match value {
-            TrapSignal::Signal(s) => s as Self,
-            TrapSignal::Exit => 0,
-            _ => return Err(TrapSignalNumberError),
-        })
-    }
+	type Error = TrapSignalNumberError;
+	fn try_from(value: TrapSignal) -> Result<Self, Self::Error> {
+		Ok(match value {
+			TrapSignal::Signal(s) => s as Self,
+			TrapSignal::Exit => 0,
+			_ => return Err(TrapSignalNumberError),
+		})
+	}
 }
 
 /// Configuration for trap handlers in the shell.
 #[derive(Clone, Default)]
 pub struct TrapHandlerConfig {
-    /// Registered handlers for traps; maps signal type to command.
-    pub(crate) handlers: HashMap<TrapSignal, String>,
-    /// Current depth of the handler stack.
-    pub(crate) handler_depth: i32,
+	/// Registered handlers for traps; maps signal type to command.
+	pub(crate) handlers: HashMap<TrapSignal, String>,
+	/// Current depth of the handler stack.
+	pub(crate) handler_depth: i32,
 }
 
 impl TrapHandlerConfig {
-    /// Iterates over the registered handlers for trap signals.
-    pub fn iter_handlers(&self) -> impl Iterator<Item = (TrapSignal, &str)> {
-        self.handlers
-            .iter()
-            .map(|(signal, cmd)| (*signal, cmd.as_str()))
-    }
+	/// Iterates over the registered handlers for trap signals.
+	pub fn iter_handlers(&self) -> impl Iterator<Item = (TrapSignal, &str)> {
+		self
+			.handlers
+			.iter()
+			.map(|(signal, cmd)| (*signal, cmd.as_str()))
+	}
 
-    /// Tries to find the handler associated with the given signal.
-    ///
-    /// # Arguments
-    ///
-    /// * `signal_type` - The type of signal to get the handler for.
-    pub fn get_handler(&self, signal_type: TrapSignal) -> Option<&str> {
-        self.handlers.get(&signal_type).map(|s| s.as_str())
-    }
+	/// Tries to find the handler associated with the given signal.
+	///
+	/// # Arguments
+	///
+	/// * `signal_type` - The type of signal to get the handler for.
+	pub fn get_handler(&self, signal_type: TrapSignal) -> Option<&str> {
+		self.handlers.get(&signal_type).map(|s| s.as_str())
+	}
 
-    /// Registers a handler for a trap signal.
-    ///
-    /// # Arguments
-    ///
-    /// * `signal_type` - The type of signal to register a handler for.
-    /// * `command` - The command to execute when the signal is trapped.
-    pub fn register_handler(&mut self, signal_type: TrapSignal, command: String) {
-        let _ = self.handlers.insert(signal_type, command);
-    }
+	/// Registers a handler for a trap signal.
+	///
+	/// # Arguments
+	///
+	/// * `signal_type` - The type of signal to register a handler for.
+	/// * `command` - The command to execute when the signal is trapped.
+	pub fn register_handler(&mut self, signal_type: TrapSignal, command: String) {
+		let _ = self.handlers.insert(signal_type, command);
+	}
 
-    /// Removes handlers for a trap signal.
-    ///
-    /// # Arguments
-    ///
-    /// * `signal_type` - The type of signal to remove handlers for.
-    pub fn remove_handlers(&mut self, signal_type: TrapSignal) {
-        self.handlers.remove(&signal_type);
-    }
+	/// Removes handlers for a trap signal.
+	///
+	/// # Arguments
+	///
+	/// * `signal_type` - The type of signal to remove handlers for.
+	pub fn remove_handlers(&mut self, signal_type: TrapSignal) {
+		self.handlers.remove(&signal_type);
+	}
 }

--- a/crates/brush-core-vendored/src/variables.rs
+++ b/crates/brush-core-vendored/src/variables.rs
@@ -10,579 +10,556 @@ use crate::{error, escape};
 /// A shell variable.
 #[derive(Clone, Debug)]
 pub struct ShellVariable {
-    /// The value currently associated with the variable.
-    value: ShellValue,
-    /// Whether or not the variable is marked as exported to child processes.
-    exported: bool,
-    /// Whether or not the variable is marked as read-only.
-    readonly: bool,
-    /// Whether or not the variable should be enumerated in the shell's environment.
-    enumerable: bool,
-    /// The transformation to apply to the variable's value when it is updated.
-    transform_on_update: ShellVariableUpdateTransform,
-    /// Whether or not the variable is marked as being traced.
-    trace: bool,
-    /// Whether or not the variable should be treated as an integer.
-    treat_as_integer: bool,
-    /// Whether or not the variable should be treated as a name reference.
-    treat_as_nameref: bool,
+	/// The value currently associated with the variable.
+	value: ShellValue,
+	/// Whether or not the variable is marked as exported to child processes.
+	exported: bool,
+	/// Whether or not the variable is marked as read-only.
+	readonly: bool,
+	/// Whether or not the variable should be enumerated in the shell's environment.
+	enumerable: bool,
+	/// The transformation to apply to the variable's value when it is updated.
+	transform_on_update: ShellVariableUpdateTransform,
+	/// Whether or not the variable is marked as being traced.
+	trace: bool,
+	/// Whether or not the variable should be treated as an integer.
+	treat_as_integer: bool,
+	/// Whether or not the variable should be treated as a name reference.
+	treat_as_nameref: bool,
 }
 
 /// Kind of transformation to apply to a variable's value when it is updated.
 #[derive(Clone, Copy, Debug)]
 pub enum ShellVariableUpdateTransform {
-    /// No transformation.
-    None,
-    /// Convert the value to lowercase.
-    Lowercase,
-    /// Convert the value to uppercase.
-    Uppercase,
-    /// Convert the value to lowercase, with the first character capitalized.
-    Capitalize,
+	/// No transformation.
+	None,
+	/// Convert the value to lowercase.
+	Lowercase,
+	/// Convert the value to uppercase.
+	Uppercase,
+	/// Convert the value to lowercase, with the first character capitalized.
+	Capitalize,
 }
 
 impl Default for ShellVariable {
-    fn default() -> Self {
-        Self {
-            value: ShellValue::String(String::new()),
-            exported: false,
-            readonly: false,
-            enumerable: true,
-            transform_on_update: ShellVariableUpdateTransform::None,
-            trace: false,
-            treat_as_integer: false,
-            treat_as_nameref: false,
-        }
-    }
+	fn default() -> Self {
+		Self {
+			value: ShellValue::String(String::new()),
+			exported: false,
+			readonly: false,
+			enumerable: true,
+			transform_on_update: ShellVariableUpdateTransform::None,
+			trace: false,
+			treat_as_integer: false,
+			treat_as_nameref: false,
+		}
+	}
 }
 
 impl ShellVariable {
-    /// Returns a new shell variable, initialized with the given value.
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - The value to associate with the variable.
-    pub fn new<I: Into<ShellValue>>(value: I) -> Self {
-        Self {
-            value: value.into(),
-            ..Self::default()
-        }
-    }
+	/// Returns a new shell variable, initialized with the given value.
+	///
+	/// # Arguments
+	///
+	/// * `value` - The value to associate with the variable.
+	pub fn new<I: Into<ShellValue>>(value: I) -> Self {
+		Self { value: value.into(), ..Self::default() }
+	}
 
-    /// Returns the value associated with the variable.
-    pub const fn value(&self) -> &ShellValue {
-        &self.value
-    }
+	/// Returns the value associated with the variable.
+	pub const fn value(&self) -> &ShellValue {
+		&self.value
+	}
 
-    /// Returns whether or not the variable is exported to child processes.
-    pub const fn is_exported(&self) -> bool {
-        self.exported
-    }
+	/// Returns whether or not the variable is exported to child processes.
+	pub const fn is_exported(&self) -> bool {
+		self.exported
+	}
 
-    /// Marks the variable as exported to child processes.
-    pub const fn export(&mut self) -> &mut Self {
-        self.exported = true;
-        self
-    }
+	/// Marks the variable as exported to child processes.
+	pub const fn export(&mut self) -> &mut Self {
+		self.exported = true;
+		self
+	}
 
-    /// Marks the variable as not exported to child processes.
-    pub const fn unexport(&mut self) -> &mut Self {
-        self.exported = false;
-        self
-    }
+	/// Marks the variable as not exported to child processes.
+	pub const fn unexport(&mut self) -> &mut Self {
+		self.exported = false;
+		self
+	}
 
-    /// Returns whether or not the variable is read-only.
-    pub const fn is_readonly(&self) -> bool {
-        self.readonly
-    }
+	/// Returns whether or not the variable is read-only.
+	pub const fn is_readonly(&self) -> bool {
+		self.readonly
+	}
 
-    /// Marks the variable as read-only.
-    pub const fn set_readonly(&mut self) -> &mut Self {
-        self.readonly = true;
-        self
-    }
+	/// Marks the variable as read-only.
+	pub const fn set_readonly(&mut self) -> &mut Self {
+		self.readonly = true;
+		self
+	}
 
-    /// Marks the variable as not read-only.
-    pub fn unset_readonly(&mut self) -> Result<&mut Self, error::Error> {
-        if self.readonly {
-            return Err(error::ErrorKind::ReadonlyVariable.into());
-        }
+	/// Marks the variable as not read-only.
+	pub fn unset_readonly(&mut self) -> Result<&mut Self, error::Error> {
+		if self.readonly {
+			return Err(error::ErrorKind::ReadonlyVariable.into());
+		}
 
-        self.readonly = false;
-        Ok(self)
-    }
+		self.readonly = false;
+		Ok(self)
+	}
 
-    /// Returns whether or not the variable is traced.
-    pub const fn is_trace_enabled(&self) -> bool {
-        self.trace
-    }
+	/// Returns whether or not the variable is traced.
+	pub const fn is_trace_enabled(&self) -> bool {
+		self.trace
+	}
 
-    /// Marks the variable as traced.
-    pub const fn enable_trace(&mut self) -> &mut Self {
-        self.trace = true;
-        self
-    }
+	/// Marks the variable as traced.
+	pub const fn enable_trace(&mut self) -> &mut Self {
+		self.trace = true;
+		self
+	}
 
-    /// Marks the variable as not traced.
-    pub const fn disable_trace(&mut self) -> &mut Self {
-        self.trace = false;
-        self
-    }
+	/// Marks the variable as not traced.
+	pub const fn disable_trace(&mut self) -> &mut Self {
+		self.trace = false;
+		self
+	}
 
-    /// Returns whether or not the variable should be enumerated in the shell's environment.
-    pub const fn is_enumerable(&self) -> bool {
-        self.enumerable
-    }
+	/// Returns whether or not the variable should be enumerated in the shell's environment.
+	pub const fn is_enumerable(&self) -> bool {
+		self.enumerable
+	}
 
-    /// Marks the variable as not enumerable in the shell's environment.
-    pub const fn hide_from_enumeration(&mut self) -> &mut Self {
-        self.enumerable = false;
-        self
-    }
+	/// Marks the variable as not enumerable in the shell's environment.
+	pub const fn hide_from_enumeration(&mut self) -> &mut Self {
+		self.enumerable = false;
+		self
+	}
 
-    /// Return the update transform associated with the variable.
-    pub const fn get_update_transform(&self) -> ShellVariableUpdateTransform {
-        self.transform_on_update
-    }
+	/// Return the update transform associated with the variable.
+	pub const fn get_update_transform(&self) -> ShellVariableUpdateTransform {
+		self.transform_on_update
+	}
 
-    /// Set the update transform associated with the variable.
-    pub const fn set_update_transform(&mut self, transform: ShellVariableUpdateTransform) {
-        self.transform_on_update = transform;
-    }
+	/// Set the update transform associated with the variable.
+	pub const fn set_update_transform(&mut self, transform: ShellVariableUpdateTransform) {
+		self.transform_on_update = transform;
+	}
 
-    /// Returns whether or not the variable should be treated as an integer.
-    pub const fn is_treated_as_integer(&self) -> bool {
-        self.treat_as_integer
-    }
+	/// Returns whether or not the variable should be treated as an integer.
+	pub const fn is_treated_as_integer(&self) -> bool {
+		self.treat_as_integer
+	}
 
-    /// Marks the variable as being treated as an integer.
-    pub const fn treat_as_integer(&mut self) -> &mut Self {
-        self.treat_as_integer = true;
-        self
-    }
+	/// Marks the variable as being treated as an integer.
+	pub const fn treat_as_integer(&mut self) -> &mut Self {
+		self.treat_as_integer = true;
+		self
+	}
 
-    /// Marks the variable as not being treated as an integer.
-    pub const fn unset_treat_as_integer(&mut self) -> &mut Self {
-        self.treat_as_integer = false;
-        self
-    }
+	/// Marks the variable as not being treated as an integer.
+	pub const fn unset_treat_as_integer(&mut self) -> &mut Self {
+		self.treat_as_integer = false;
+		self
+	}
 
-    /// Returns whether or not the variable should be treated as a name reference.
-    pub const fn is_treated_as_nameref(&self) -> bool {
-        self.treat_as_nameref
-    }
+	/// Returns whether or not the variable should be treated as a name reference.
+	pub const fn is_treated_as_nameref(&self) -> bool {
+		self.treat_as_nameref
+	}
 
-    /// Marks the variable as being treated as a name reference.
-    pub const fn treat_as_nameref(&mut self) -> &mut Self {
-        self.treat_as_nameref = true;
-        self
-    }
+	/// Marks the variable as being treated as a name reference.
+	pub const fn treat_as_nameref(&mut self) -> &mut Self {
+		self.treat_as_nameref = true;
+		self
+	}
 
-    /// Marks the variable as not being treated as a name reference.
-    pub const fn unset_treat_as_nameref(&mut self) -> &mut Self {
-        self.treat_as_nameref = false;
-        self
-    }
+	/// Marks the variable as not being treated as a name reference.
+	pub const fn unset_treat_as_nameref(&mut self) -> &mut Self {
+		self.treat_as_nameref = false;
+		self
+	}
 
-    /// Converts the variable to an indexed array.
-    pub fn convert_to_indexed_array(&mut self) -> Result<(), error::Error> {
-        match self.value() {
-            ShellValue::IndexedArray(_) => Ok(()),
-            ShellValue::AssociativeArray(_) => {
-                Err(error::ErrorKind::ConvertingAssociativeArrayToIndexedArray.into())
-            }
-            _ => {
-                let mut new_values = BTreeMap::new();
-                new_values.insert(
-                    0,
-                    self.value.to_cow_str_without_dynamic_support().to_string(),
-                );
-                self.value = ShellValue::IndexedArray(new_values);
-                Ok(())
-            }
-        }
-    }
+	/// Converts the variable to an indexed array.
+	pub fn convert_to_indexed_array(&mut self) -> Result<(), error::Error> {
+		match self.value() {
+			ShellValue::IndexedArray(_) => Ok(()),
+			ShellValue::AssociativeArray(_) => {
+				Err(error::ErrorKind::ConvertingAssociativeArrayToIndexedArray.into())
+			},
+			_ => {
+				let mut new_values = BTreeMap::new();
+				new_values.insert(0, self.value.to_cow_str_without_dynamic_support().to_string());
+				self.value = ShellValue::IndexedArray(new_values);
+				Ok(())
+			},
+		}
+	}
 
-    /// Converts the variable to an associative array.
-    pub fn convert_to_associative_array(&mut self) -> Result<(), error::Error> {
-        match self.value() {
-            ShellValue::AssociativeArray(_) => Ok(()),
-            ShellValue::IndexedArray(_) => {
-                Err(error::ErrorKind::ConvertingIndexedArrayToAssociativeArray.into())
-            }
-            _ => {
-                let mut new_values: BTreeMap<String, String> = BTreeMap::new();
-                new_values.insert(
-                    String::from("0"),
-                    self.value.to_cow_str_without_dynamic_support().to_string(),
-                );
-                self.value = ShellValue::AssociativeArray(new_values);
-                Ok(())
-            }
-        }
-    }
+	/// Converts the variable to an associative array.
+	pub fn convert_to_associative_array(&mut self) -> Result<(), error::Error> {
+		match self.value() {
+			ShellValue::AssociativeArray(_) => Ok(()),
+			ShellValue::IndexedArray(_) => {
+				Err(error::ErrorKind::ConvertingIndexedArrayToAssociativeArray.into())
+			},
+			_ => {
+				let mut new_values: BTreeMap<String, String> = BTreeMap::new();
+				new_values.insert(
+					String::from("0"),
+					self.value.to_cow_str_without_dynamic_support().to_string(),
+				);
+				self.value = ShellValue::AssociativeArray(new_values);
+				Ok(())
+			},
+		}
+	}
 
-    /// Assign the given value to the variable, conditionally appending to the preexisting value.
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - The value to assign to the variable.
-    /// * `append` - Whether or not to append the value to the preexisting value.
-    
-    pub fn assign(&mut self, value: ShellValueLiteral, append: bool) -> Result<(), error::Error> {
-        if self.is_readonly() {
-            return Err(error::ErrorKind::ReadonlyVariable.into());
-        }
+	/// Assign the given value to the variable, conditionally appending to the preexisting value.
+	///
+	/// # Arguments
+	///
+	/// * `value` - The value to assign to the variable.
+	/// * `append` - Whether or not to append the value to the preexisting value.
 
-        let value = self.convert_value_literal_for_assignment(value);
+	pub fn assign(&mut self, value: ShellValueLiteral, append: bool) -> Result<(), error::Error> {
+		if self.is_readonly() {
+			return Err(error::ErrorKind::ReadonlyVariable.into());
+		}
 
-        if append {
-            match (&self.value, &value) {
-                // If we're appending an array to a declared-but-unset variable (or appending
-                // anything to a declared-but-unset array), then fill it out first.
-                (ShellValue::Unset(_), ShellValueLiteral::Array(_))
-                | (
-                    ShellValue::Unset(
-                        ShellValueUnsetType::IndexedArray | ShellValueUnsetType::AssociativeArray,
-                    ),
-                    _,
-                ) => {
-                    self.assign(ShellValueLiteral::Array(ArrayLiteral(vec![])), false)?;
-                }
-                // If we're appending a scalar to a declared-but-unset variable, then
-                // start with the empty string. This will result in the right thing happening,
-                // even in treat-as-integer cases.
-                (ShellValue::Unset(_), ShellValueLiteral::Scalar(_)) => {
-                    self.assign(ShellValueLiteral::Scalar(String::new()), false)?;
-                }
-                // If we're trying to append an array to a string, we first promote the string to be
-                // an array with the string being present at index 0.
-                (ShellValue::String(_), ShellValueLiteral::Array(_)) => {
-                    self.convert_to_indexed_array()?;
-                }
-                _ => (),
-            }
+		let value = self.convert_value_literal_for_assignment(value);
 
-            let treat_as_int = self.is_treated_as_integer();
-            let update_transform = self.get_update_transform();
+		if append {
+			match (&self.value, &value) {
+				// If we're appending an array to a declared-but-unset variable (or appending
+				// anything to a declared-but-unset array), then fill it out first.
+				(ShellValue::Unset(_), ShellValueLiteral::Array(_))
+				| (
+					ShellValue::Unset(
+						ShellValueUnsetType::IndexedArray | ShellValueUnsetType::AssociativeArray,
+					),
+					_,
+				) => {
+					self.assign(ShellValueLiteral::Array(ArrayLiteral(vec![])), false)?;
+				},
+				// If we're appending a scalar to a declared-but-unset variable, then
+				// start with the empty string. This will result in the right thing happening,
+				// even in treat-as-integer cases.
+				(ShellValue::Unset(_), ShellValueLiteral::Scalar(_)) => {
+					self.assign(ShellValueLiteral::Scalar(String::new()), false)?;
+				},
+				// If we're trying to append an array to a string, we first promote the string to be
+				// an array with the string being present at index 0.
+				(ShellValue::String(_), ShellValueLiteral::Array(_)) => {
+					self.convert_to_indexed_array()?;
+				},
+				_ => (),
+			}
 
-            match &mut self.value {
-                ShellValue::String(base) => match value {
-                    ShellValueLiteral::Scalar(suffix) => {
-                        if treat_as_int {
-                            let int_value = base.parse::<i64>().unwrap_or(0)
-                                + suffix.parse::<i64>().unwrap_or(0);
-                            base.clear();
-                            base.push_str(int_value.to_string().as_str());
-                        } else {
-                            base.push_str(suffix.as_str());
-                            Self::apply_value_transforms(base, treat_as_int, update_transform);
-                        }
-                        Ok(())
-                    }
-                    ShellValueLiteral::Array(_) => {
-                        // This case was already handled (see above).
-                        Ok(())
-                    }
-                },
-                ShellValue::IndexedArray(existing_values) => match value {
-                    ShellValueLiteral::Scalar(new_value) => {
-                        self.assign_at_index(String::from("0"), new_value, append)
-                    }
-                    ShellValueLiteral::Array(new_values) => {
-                        ShellValue::update_indexed_array_from_literals(existing_values, new_values);
-                        Ok(())
-                    }
-                },
-                ShellValue::AssociativeArray(existing_values) => match value {
-                    ShellValueLiteral::Scalar(new_value) => {
-                        self.assign_at_index(String::from("0"), new_value, append)
-                    }
-                    ShellValueLiteral::Array(new_values) => {
-                        ShellValue::update_associative_array_from_literals(
-                            existing_values,
-                            new_values,
-                        )
-                    }
-                },
-                ShellValue::Unset(_) => unreachable!("covered in conversion above"),
-                // TODO(dynamic): implement appending to dynamic vars
-                ShellValue::Dynamic { .. } => Ok(()),
-            }
-        } else {
-            match (&self.value, value) {
-                // If we're updating an array value with a string, then treat it as an update to
-                // just the "0"-indexed element of the array.
-                (
-                    ShellValue::IndexedArray(_)
-                    | ShellValue::AssociativeArray(_)
-                    | ShellValue::Unset(
-                        ShellValueUnsetType::AssociativeArray | ShellValueUnsetType::IndexedArray,
-                    ),
-                    ShellValueLiteral::Scalar(s),
-                ) => self.assign_at_index(String::from("0"), s, false),
+			let treat_as_int = self.is_treated_as_integer();
+			let update_transform = self.get_update_transform();
 
-                // If we're updating an indexed array value with an array, then preserve the array
-                // type. We also default to using an indexed array if we are
-                // assigning an array to a previously string-holding variable.
-                (
-                    ShellValue::IndexedArray(_)
-                    | ShellValue::Unset(
-                        ShellValueUnsetType::IndexedArray | ShellValueUnsetType::Untyped,
-                    )
-                    | ShellValue::String(_)
-                    | ShellValue::Dynamic { .. },
-                    ShellValueLiteral::Array(literal_values),
-                ) => {
-                    self.value = ShellValue::indexed_array_from_literals(literal_values);
-                    Ok(())
-                }
+			match &mut self.value {
+				ShellValue::String(base) => match value {
+					ShellValueLiteral::Scalar(suffix) => {
+						if treat_as_int {
+							let int_value =
+								base.parse::<i64>().unwrap_or(0) + suffix.parse::<i64>().unwrap_or(0);
+							base.clear();
+							base.push_str(int_value.to_string().as_str());
+						} else {
+							base.push_str(suffix.as_str());
+							Self::apply_value_transforms(base, treat_as_int, update_transform);
+						}
+						Ok(())
+					},
+					ShellValueLiteral::Array(_) => {
+						// This case was already handled (see above).
+						Ok(())
+					},
+				},
+				ShellValue::IndexedArray(existing_values) => match value {
+					ShellValueLiteral::Scalar(new_value) => {
+						self.assign_at_index(String::from("0"), new_value, append)
+					},
+					ShellValueLiteral::Array(new_values) => {
+						ShellValue::update_indexed_array_from_literals(existing_values, new_values);
+						Ok(())
+					},
+				},
+				ShellValue::AssociativeArray(existing_values) => match value {
+					ShellValueLiteral::Scalar(new_value) => {
+						self.assign_at_index(String::from("0"), new_value, append)
+					},
+					ShellValueLiteral::Array(new_values) => {
+						ShellValue::update_associative_array_from_literals(existing_values, new_values)
+					},
+				},
+				ShellValue::Unset(_) => unreachable!("covered in conversion above"),
+				// TODO(dynamic): implement appending to dynamic vars
+				ShellValue::Dynamic { .. } => Ok(()),
+			}
+		} else {
+			match (&self.value, value) {
+				// If we're updating an array value with a string, then treat it as an update to
+				// just the "0"-indexed element of the array.
+				(
+					ShellValue::IndexedArray(_)
+					| ShellValue::AssociativeArray(_)
+					| ShellValue::Unset(
+						ShellValueUnsetType::AssociativeArray | ShellValueUnsetType::IndexedArray,
+					),
+					ShellValueLiteral::Scalar(s),
+				) => self.assign_at_index(String::from("0"), s, false),
 
-                // If we're updating an associative array value with an array, then preserve the
-                // array type.
-                (
-                    ShellValue::AssociativeArray(_)
-                    | ShellValue::Unset(ShellValueUnsetType::AssociativeArray),
-                    ShellValueLiteral::Array(literal_values),
-                ) => {
-                    self.value = ShellValue::associative_array_from_literals(literal_values)?;
-                    Ok(())
-                }
+				// If we're updating an indexed array value with an array, then preserve the array
+				// type. We also default to using an indexed array if we are
+				// assigning an array to a previously string-holding variable.
+				(
+					ShellValue::IndexedArray(_)
+					| ShellValue::Unset(ShellValueUnsetType::IndexedArray | ShellValueUnsetType::Untyped)
+					| ShellValue::String(_)
+					| ShellValue::Dynamic { .. },
+					ShellValueLiteral::Array(literal_values),
+				) => {
+					self.value = ShellValue::indexed_array_from_literals(literal_values);
+					Ok(())
+				},
 
-                // Handle updates to dynamic values; for now we just drop them.
-                // TODO(dynamic): Allow updates to dynamic values
-                (ShellValue::Dynamic { .. }, _) => Ok(()),
+				// If we're updating an associative array value with an array, then preserve the
+				// array type.
+				(
+					ShellValue::AssociativeArray(_)
+					| ShellValue::Unset(ShellValueUnsetType::AssociativeArray),
+					ShellValueLiteral::Array(literal_values),
+				) => {
+					self.value = ShellValue::associative_array_from_literals(literal_values)?;
+					Ok(())
+				},
 
-                // Assign a scalar value to a scalar or unset (and untyped) variable.
-                (ShellValue::String(_) | ShellValue::Unset(_), ShellValueLiteral::Scalar(s)) => {
-                    self.value = ShellValue::String(s);
-                    Ok(())
-                }
-            }
-        }
-    }
+				// Handle updates to dynamic values; for now we just drop them.
+				// TODO(dynamic): Allow updates to dynamic values
+				(ShellValue::Dynamic { .. }, _) => Ok(()),
 
-    /// Assign the given value to the variable at the given index, conditionally appending to the
-    /// preexisting value present at that element within the value.
-    ///
-    /// # Arguments
-    ///
-    /// * `array_index` - The index at which to assign the value.
-    /// * `value` - The value to assign to the variable at the given index.
-    /// * `append` - Whether or not to append the value to the preexisting value stored at the given
-    ///   index.
-    pub fn assign_at_index(
-        &mut self,
-        array_index: String,
-        value: String,
-        append: bool,
-    ) -> Result<(), error::Error> {
-        match &self.value {
-            ShellValue::Unset(_) => {
-                self.assign(ShellValueLiteral::Array(ArrayLiteral(vec![])), false)?;
-            }
-            ShellValue::String(_) => {
-                self.convert_to_indexed_array()?;
-            }
-            _ => (),
-        }
+				// Assign a scalar value to a scalar or unset (and untyped) variable.
+				(ShellValue::String(_) | ShellValue::Unset(_), ShellValueLiteral::Scalar(s)) => {
+					self.value = ShellValue::String(s);
+					Ok(())
+				},
+			}
+		}
+	}
 
-        let treat_as_int = self.is_treated_as_integer();
-        let value = self.convert_value_str_for_assignment(value);
+	/// Assign the given value to the variable at the given index, conditionally appending to the
+	/// preexisting value present at that element within the value.
+	///
+	/// # Arguments
+	///
+	/// * `array_index` - The index at which to assign the value.
+	/// * `value` - The value to assign to the variable at the given index.
+	/// * `append` - Whether or not to append the value to the preexisting value stored at the given
+	///   index.
+	pub fn assign_at_index(
+		&mut self,
+		array_index: String,
+		value: String,
+		append: bool,
+	) -> Result<(), error::Error> {
+		match &self.value {
+			ShellValue::Unset(_) => {
+				self.assign(ShellValueLiteral::Array(ArrayLiteral(vec![])), false)?;
+			},
+			ShellValue::String(_) => {
+				self.convert_to_indexed_array()?;
+			},
+			_ => (),
+		}
 
-        match &mut self.value {
-            ShellValue::IndexedArray(arr) => {
-                let key: u64 = array_index.parse().unwrap_or(0);
+		let treat_as_int = self.is_treated_as_integer();
+		let value = self.convert_value_str_for_assignment(value);
 
-                if append {
-                    let existing_value = arr.get(&key).map_or_else(|| "", |v| v.as_str());
+		match &mut self.value {
+			ShellValue::IndexedArray(arr) => {
+				let key: u64 = array_index.parse().unwrap_or(0);
 
-                    let mut new_value;
-                    if treat_as_int {
-                        new_value = (existing_value.parse::<i64>().unwrap_or(0)
-                            + value.parse::<i64>().unwrap_or(0))
-                        .to_string();
-                    } else {
-                        new_value = existing_value.to_owned();
-                        new_value.push_str(value.as_str());
-                    }
+				if append {
+					let existing_value = arr.get(&key).map_or_else(|| "", |v| v.as_str());
 
-                    arr.insert(key, new_value);
-                } else {
-                    arr.insert(key, value);
-                }
+					let mut new_value;
+					if treat_as_int {
+						new_value = (existing_value.parse::<i64>().unwrap_or(0)
+							+ value.parse::<i64>().unwrap_or(0))
+						.to_string();
+					} else {
+						new_value = existing_value.to_owned();
+						new_value.push_str(value.as_str());
+					}
 
-                Ok(())
-            }
-            ShellValue::AssociativeArray(arr) => {
-                if append {
-                    let existing_value = arr
-                        .get(array_index.as_str())
-                        .map_or_else(|| "", |v| v.as_str());
+					arr.insert(key, new_value);
+				} else {
+					arr.insert(key, value);
+				}
 
-                    let mut new_value;
-                    if treat_as_int {
-                        new_value = (existing_value.parse::<i64>().unwrap_or(0)
-                            + value.parse::<i64>().unwrap_or(0))
-                        .to_string();
-                    } else {
-                        new_value = existing_value.to_owned();
-                        new_value.push_str(value.as_str());
-                    }
+				Ok(())
+			},
+			ShellValue::AssociativeArray(arr) => {
+				if append {
+					let existing_value = arr
+						.get(array_index.as_str())
+						.map_or_else(|| "", |v| v.as_str());
 
-                    arr.insert(array_index, new_value.clone());
-                } else {
-                    arr.insert(array_index, value);
-                }
-                Ok(())
-            }
-            _ => {
-                tracing::error!("assigning to index {array_index} of {:?}", self.value);
-                error::unimp("assigning to index of non-array variable")
-            }
-        }
-    }
+					let mut new_value;
+					if treat_as_int {
+						new_value = (existing_value.parse::<i64>().unwrap_or(0)
+							+ value.parse::<i64>().unwrap_or(0))
+						.to_string();
+					} else {
+						new_value = existing_value.to_owned();
+						new_value.push_str(value.as_str());
+					}
 
-    fn convert_value_literal_for_assignment(&self, value: ShellValueLiteral) -> ShellValueLiteral {
-        match value {
-            ShellValueLiteral::Scalar(s) => {
-                ShellValueLiteral::Scalar(self.convert_value_str_for_assignment(s))
-            }
-            ShellValueLiteral::Array(literals) => ShellValueLiteral::Array(ArrayLiteral(
-                literals
-                    .0
-                    .into_iter()
-                    .map(|(k, v)| (k, self.convert_value_str_for_assignment(v)))
-                    .collect(),
-            )),
-        }
-    }
+					arr.insert(array_index, new_value.clone());
+				} else {
+					arr.insert(array_index, value);
+				}
+				Ok(())
+			},
+			_ => {
+				tracing::error!("assigning to index {array_index} of {:?}", self.value);
+				error::unimp("assigning to index of non-array variable")
+			},
+		}
+	}
 
-    fn convert_value_str_for_assignment(&self, mut s: String) -> String {
-        Self::apply_value_transforms(
-            &mut s,
-            self.is_treated_as_integer(),
-            self.get_update_transform(),
-        );
+	fn convert_value_literal_for_assignment(&self, value: ShellValueLiteral) -> ShellValueLiteral {
+		match value {
+			ShellValueLiteral::Scalar(s) => {
+				ShellValueLiteral::Scalar(self.convert_value_str_for_assignment(s))
+			},
+			ShellValueLiteral::Array(literals) => ShellValueLiteral::Array(ArrayLiteral(
+				literals
+					.0
+					.into_iter()
+					.map(|(k, v)| (k, self.convert_value_str_for_assignment(v)))
+					.collect(),
+			)),
+		}
+	}
 
-        s
-    }
+	fn convert_value_str_for_assignment(&self, mut s: String) -> String {
+		Self::apply_value_transforms(
+			&mut s,
+			self.is_treated_as_integer(),
+			self.get_update_transform(),
+		);
 
-    fn apply_value_transforms(
-        s: &mut String,
-        treat_as_int: bool,
-        update_transform: ShellVariableUpdateTransform,
-    ) {
-        if treat_as_int {
-            *s = (*s).parse::<i64>().unwrap_or(0).to_string();
-        } else {
-            match update_transform {
-                ShellVariableUpdateTransform::None => (),
-                ShellVariableUpdateTransform::Lowercase => *s = (*s).to_lowercase(),
-                ShellVariableUpdateTransform::Uppercase => *s = (*s).to_uppercase(),
-                ShellVariableUpdateTransform::Capitalize => {
-                    // This isn't really title-case; only the first character is capitalized.
-                    *s = s.to_lowercase();
-                    if let Some(c) = s.chars().next() {
-                        s.replace_range(0..1, &c.to_uppercase().to_string());
-                    }
-                }
-            }
-        }
-    }
+		s
+	}
 
-    /// Tries to unset the value stored at the given index in the variable. Returns
-    /// whether or not a value was unset.
-    ///
-    /// # Arguments
-    ///
-    /// * `index` - The index at which to unset the value.
-    pub fn unset_index(&mut self, index: &str) -> Result<bool, error::Error> {
-        match &mut self.value {
-            ShellValue::Unset(ty) => match ty {
-                ShellValueUnsetType::Untyped => Err(error::ErrorKind::NotArray.into()),
-                ShellValueUnsetType::AssociativeArray | ShellValueUnsetType::IndexedArray => {
-                    Ok(false)
-                }
-            },
-            ShellValue::String(_) => Err(error::ErrorKind::NotArray.into()),
-            ShellValue::AssociativeArray(values) => Ok(values.remove(index).is_some()),
-            ShellValue::IndexedArray(values) => {
-                let key = index.parse::<u64>().unwrap_or(0);
-                Ok(values.remove(&key).is_some())
-            }
-            ShellValue::Dynamic { .. } => Ok(false),
-        }
-    }
+	fn apply_value_transforms(
+		s: &mut String,
+		treat_as_int: bool,
+		update_transform: ShellVariableUpdateTransform,
+	) {
+		if treat_as_int {
+			*s = (*s).parse::<i64>().unwrap_or(0).to_string();
+		} else {
+			match update_transform {
+				ShellVariableUpdateTransform::None => (),
+				ShellVariableUpdateTransform::Lowercase => *s = (*s).to_lowercase(),
+				ShellVariableUpdateTransform::Uppercase => *s = (*s).to_uppercase(),
+				ShellVariableUpdateTransform::Capitalize => {
+					// This isn't really title-case; only the first character is capitalized.
+					*s = s.to_lowercase();
+					if let Some(c) = s.chars().next() {
+						s.replace_range(0..1, &c.to_uppercase().to_string());
+					}
+				},
+			}
+		}
+	}
 
-    /// Returns the variable's value; for dynamic values, this will resolve the value.
-    ///
-    /// # Arguments
-    ///
-    /// * `shell` - The shell in which the variable is being resolved.
-    pub fn resolve_value(&self, shell: &Shell) -> ShellValue {
-        // N.B. We do *not* specially handle a dynamic value that resolves to a dynamic value.
-        match &self.value {
-            ShellValue::Dynamic { getter, .. } => getter(shell),
-            _ => self.value.clone(),
-        }
-    }
+	/// Tries to unset the value stored at the given index in the variable. Returns
+	/// whether or not a value was unset.
+	///
+	/// # Arguments
+	///
+	/// * `index` - The index at which to unset the value.
+	pub fn unset_index(&mut self, index: &str) -> Result<bool, error::Error> {
+		match &mut self.value {
+			ShellValue::Unset(ty) => match ty {
+				ShellValueUnsetType::Untyped => Err(error::ErrorKind::NotArray.into()),
+				ShellValueUnsetType::AssociativeArray | ShellValueUnsetType::IndexedArray => Ok(false),
+			},
+			ShellValue::String(_) => Err(error::ErrorKind::NotArray.into()),
+			ShellValue::AssociativeArray(values) => Ok(values.remove(index).is_some()),
+			ShellValue::IndexedArray(values) => {
+				let key = index.parse::<u64>().unwrap_or(0);
+				Ok(values.remove(&key).is_some())
+			},
+			ShellValue::Dynamic { .. } => Ok(false),
+		}
+	}
 
-    /// Returns the canonical attribute flag string for this variable.
-    pub fn attribute_flags(&self, shell: &Shell) -> String {
-        let value = self.resolve_value(shell);
+	/// Returns the variable's value; for dynamic values, this will resolve the value.
+	///
+	/// # Arguments
+	///
+	/// * `shell` - The shell in which the variable is being resolved.
+	pub fn resolve_value(&self, shell: &Shell) -> ShellValue {
+		// N.B. We do *not* specially handle a dynamic value that resolves to a dynamic value.
+		match &self.value {
+			ShellValue::Dynamic { getter, .. } => getter(shell),
+			_ => self.value.clone(),
+		}
+	}
 
-        let mut result = String::new();
+	/// Returns the canonical attribute flag string for this variable.
+	pub fn attribute_flags(&self, shell: &Shell) -> String {
+		let value = self.resolve_value(shell);
 
-        if matches!(
-            value,
-            ShellValue::IndexedArray(_) | ShellValue::Unset(ShellValueUnsetType::IndexedArray)
-        ) {
-            result.push('a');
-        }
-        if matches!(
-            value,
-            ShellValue::AssociativeArray(_)
-                | ShellValue::Unset(ShellValueUnsetType::AssociativeArray)
-        ) {
-            result.push('A');
-        }
-        if matches!(
-            self.get_update_transform(),
-            ShellVariableUpdateTransform::Capitalize
-        ) {
-            result.push('c');
-        }
-        if self.is_treated_as_integer() {
-            result.push('i');
-        }
-        if self.is_treated_as_nameref() {
-            result.push('n');
-        }
-        if self.is_readonly() {
-            result.push('r');
-        }
-        if matches!(
-            self.get_update_transform(),
-            ShellVariableUpdateTransform::Lowercase
-        ) {
-            result.push('l');
-        }
-        if self.is_trace_enabled() {
-            result.push('t');
-        }
-        if matches!(
-            self.get_update_transform(),
-            ShellVariableUpdateTransform::Uppercase
-        ) {
-            result.push('u');
-        }
-        if self.is_exported() {
-            result.push('x');
-        }
+		let mut result = String::new();
 
-        result
-    }
+		if matches!(
+			value,
+			ShellValue::IndexedArray(_) | ShellValue::Unset(ShellValueUnsetType::IndexedArray)
+		) {
+			result.push('a');
+		}
+		if matches!(
+			value,
+			ShellValue::AssociativeArray(_) | ShellValue::Unset(ShellValueUnsetType::AssociativeArray)
+		) {
+			result.push('A');
+		}
+		if matches!(self.get_update_transform(), ShellVariableUpdateTransform::Capitalize) {
+			result.push('c');
+		}
+		if self.is_treated_as_integer() {
+			result.push('i');
+		}
+		if self.is_treated_as_nameref() {
+			result.push('n');
+		}
+		if self.is_readonly() {
+			result.push('r');
+		}
+		if matches!(self.get_update_transform(), ShellVariableUpdateTransform::Lowercase) {
+			result.push('l');
+		}
+		if self.is_trace_enabled() {
+			result.push('t');
+		}
+		if matches!(self.get_update_transform(), ShellVariableUpdateTransform::Uppercase) {
+			result.push('u');
+		}
+		if self.is_exported() {
+			result.push('x');
+		}
+
+		result
+	}
 }
 
 type DynamicValueGetter = fn(&Shell) -> ShellValue;
@@ -591,95 +568,93 @@ type DynamicValueSetter = fn(&Shell) -> ();
 /// A shell value.
 #[derive(Clone, Debug)]
 pub enum ShellValue {
-    /// A value that has been typed but not yet set.
-    Unset(ShellValueUnsetType),
-    /// A string.
-    String(String),
-    /// An associative array.
-    AssociativeArray(BTreeMap<String, String>),
-    /// An indexed array.
-    IndexedArray(BTreeMap<u64, String>),
-    /// A value that is dynamically computed.
-    Dynamic {
-        /// Function that can query the value.
-        getter: DynamicValueGetter,
-        /// Function that receives value update requests.
-        setter: DynamicValueSetter,
-    },
+	/// A value that has been typed but not yet set.
+	Unset(ShellValueUnsetType),
+	/// A string.
+	String(String),
+	/// An associative array.
+	AssociativeArray(BTreeMap<String, String>),
+	/// An indexed array.
+	IndexedArray(BTreeMap<u64, String>),
+	/// A value that is dynamically computed.
+	Dynamic {
+		/// Function that can query the value.
+		getter: DynamicValueGetter,
+		/// Function that receives value update requests.
+		setter: DynamicValueSetter,
+	},
 }
 
 /// The type of an unset shell value.
 #[derive(Clone, Debug)]
 pub enum ShellValueUnsetType {
-    /// The value is untyped.
-    Untyped,
-    /// The value is an associative array.
-    AssociativeArray,
-    /// The value is an indexed array.
-    IndexedArray,
+	/// The value is untyped.
+	Untyped,
+	/// The value is an associative array.
+	AssociativeArray,
+	/// The value is an indexed array.
+	IndexedArray,
 }
 
 /// A shell value literal; used for assignment.
 #[derive(Clone, Debug)]
 pub enum ShellValueLiteral {
-    /// A scalar value.
-    Scalar(String),
-    /// An array value.
-    Array(ArrayLiteral),
+	/// A scalar value.
+	Scalar(String),
+	/// An array value.
+	Array(ArrayLiteral),
 }
 
 impl ShellValueLiteral {
-    pub(crate) fn fmt_for_tracing(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Scalar(s) => Self::fmt_scalar_for_tracing(s.as_str(), f),
-            Self::Array(elements) => {
-                write!(f, "(")?;
-                for (i, (key, value)) in elements.0.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, " ")?;
-                    }
-                    if let Some(key) = key {
-                        write!(f, "[")?;
-                        Self::fmt_scalar_for_tracing(key.as_str(), f)?;
-                        write!(f, "]=")?;
-                    }
-                    Self::fmt_scalar_for_tracing(value.as_str(), f)?;
-                }
-                write!(f, ")")
-            }
-        }
-    }
+	pub(crate) fn fmt_for_tracing(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::Scalar(s) => Self::fmt_scalar_for_tracing(s.as_str(), f),
+			Self::Array(elements) => {
+				write!(f, "(")?;
+				for (i, (key, value)) in elements.0.iter().enumerate() {
+					if i > 0 {
+						write!(f, " ")?;
+					}
+					if let Some(key) = key {
+						write!(f, "[")?;
+						Self::fmt_scalar_for_tracing(key.as_str(), f)?;
+						write!(f, "]=")?;
+					}
+					Self::fmt_scalar_for_tracing(value.as_str(), f)?;
+				}
+				write!(f, ")")
+			},
+		}
+	}
 
-    fn fmt_scalar_for_tracing(s: &str, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let processed = escape::quote_if_needed(s, escape::QuoteMode::SingleQuote);
-        write!(f, "{processed}")
-    }
+	fn fmt_scalar_for_tracing(s: &str, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		let processed = escape::quote_if_needed(s, escape::QuoteMode::SingleQuote);
+		write!(f, "{processed}")
+	}
 }
 
 impl Display for ShellValueLiteral {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.fmt_for_tracing(f)
-    }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		self.fmt_for_tracing(f)
+	}
 }
 
 impl From<&str> for ShellValueLiteral {
-    fn from(value: &str) -> Self {
-        Self::Scalar(value.to_owned())
-    }
+	fn from(value: &str) -> Self {
+		Self::Scalar(value.to_owned())
+	}
 }
 
 impl From<String> for ShellValueLiteral {
-    fn from(value: String) -> Self {
-        Self::Scalar(value)
-    }
+	fn from(value: String) -> Self {
+		Self::Scalar(value)
+	}
 }
 
 impl From<Vec<&str>> for ShellValueLiteral {
-    fn from(value: Vec<&str>) -> Self {
-        Self::Array(ArrayLiteral(
-            value.into_iter().map(|s| (None, s.to_owned())).collect(),
-        ))
-    }
+	fn from(value: Vec<&str>) -> Self {
+		Self::Array(ArrayLiteral(value.into_iter().map(|s| (None, s.to_owned())).collect()))
+	}
 }
 
 /// An array literal.
@@ -689,345 +664,344 @@ pub struct ArrayLiteral(pub Vec<(Option<String>, String)>);
 /// Style for formatting a shell variable's value.
 #[derive(Copy, Clone, Debug)]
 pub enum FormatStyle {
-    /// Basic formatting.
-    Basic,
-    /// Formatting as appropriate in the `declare` built-in command.
-    DeclarePrint,
+	/// Basic formatting.
+	Basic,
+	/// Formatting as appropriate in the `declare` built-in command.
+	DeclarePrint,
 }
 
 impl ShellValue {
-    /// Returns whether or not the value is an array.
-    pub const fn is_array(&self) -> bool {
-        matches!(
-            self,
-            Self::IndexedArray(_)
-                | Self::AssociativeArray(_)
-                | Self::Unset(
-                    ShellValueUnsetType::IndexedArray | ShellValueUnsetType::AssociativeArray
-                )
-        )
-    }
+	/// Returns whether or not the value is an array.
+	pub const fn is_array(&self) -> bool {
+		matches!(
+			self,
+			Self::IndexedArray(_)
+				| Self::AssociativeArray(_)
+				| Self::Unset(
+					ShellValueUnsetType::IndexedArray | ShellValueUnsetType::AssociativeArray
+				)
+		)
+	}
 
-    /// Returns whether or not the value is set.
-    pub const fn is_set(&self) -> bool {
-        !matches!(self, Self::Unset(_))
-    }
+	/// Returns whether or not the value is set.
+	pub const fn is_set(&self) -> bool {
+		!matches!(self, Self::Unset(_))
+	}
 
-    /// Returns a new indexed array value constructed from the given slice of owned strings.
-    ///
-    /// # Arguments
-    ///
-    /// * `values` - The slice of strings to construct the indexed array from.
-    pub fn indexed_array_from_strings<S>(values: S) -> Self
-    where
-        S: IntoIterator<Item = String>,
-    {
-        let mut owned_values = BTreeMap::new();
-        for (i, value) in values.into_iter().enumerate() {
-            owned_values.insert(i as u64, value);
-        }
+	/// Returns a new indexed array value constructed from the given slice of owned strings.
+	///
+	/// # Arguments
+	///
+	/// * `values` - The slice of strings to construct the indexed array from.
+	pub fn indexed_array_from_strings<S>(values: S) -> Self
+	where
+		S: IntoIterator<Item = String>,
+	{
+		let mut owned_values = BTreeMap::new();
+		for (i, value) in values.into_iter().enumerate() {
+			owned_values.insert(i as u64, value);
+		}
 
-        Self::IndexedArray(owned_values)
-    }
+		Self::IndexedArray(owned_values)
+	}
 
-    /// Returns a new indexed array value constructed from the given slice of unowned strings.
-    ///
-    /// # Arguments
-    ///
-    /// * `values` - The slice of strings to construct the indexed array from.
-    pub fn indexed_array_from_strs(values: &[&str]) -> Self {
-        let mut owned_values = BTreeMap::new();
-        for (i, value) in values.iter().enumerate() {
-            owned_values.insert(i as u64, (*value).to_string());
-        }
+	/// Returns a new indexed array value constructed from the given slice of unowned strings.
+	///
+	/// # Arguments
+	///
+	/// * `values` - The slice of strings to construct the indexed array from.
+	pub fn indexed_array_from_strs(values: &[&str]) -> Self {
+		let mut owned_values = BTreeMap::new();
+		for (i, value) in values.iter().enumerate() {
+			owned_values.insert(i as u64, (*value).to_string());
+		}
 
-        Self::IndexedArray(owned_values)
-    }
+		Self::IndexedArray(owned_values)
+	}
 
-    /// Returns a new indexed array value constructed from the given literals.
-    ///
-    /// # Arguments
-    ///
-    /// * `literals` - The literals to construct the indexed array from.
-    pub fn indexed_array_from_literals(literals: ArrayLiteral) -> Self {
-        let mut values = BTreeMap::new();
-        Self::update_indexed_array_from_literals(&mut values, literals);
+	/// Returns a new indexed array value constructed from the given literals.
+	///
+	/// # Arguments
+	///
+	/// * `literals` - The literals to construct the indexed array from.
+	pub fn indexed_array_from_literals(literals: ArrayLiteral) -> Self {
+		let mut values = BTreeMap::new();
+		Self::update_indexed_array_from_literals(&mut values, literals);
 
-        Self::IndexedArray(values)
-    }
+		Self::IndexedArray(values)
+	}
 
-    fn update_indexed_array_from_literals(
-        existing_values: &mut BTreeMap<u64, String>,
-        literal_values: ArrayLiteral,
-    ) {
-        let mut new_key = if let Some((largest_index, _)) = existing_values.last_key_value() {
-            largest_index + 1
-        } else {
-            0
-        };
+	fn update_indexed_array_from_literals(
+		existing_values: &mut BTreeMap<u64, String>,
+		literal_values: ArrayLiteral,
+	) {
+		let mut new_key = if let Some((largest_index, _)) = existing_values.last_key_value() {
+			largest_index + 1
+		} else {
+			0
+		};
 
-        for (key, value) in literal_values.0 {
-            if let Some(key) = key {
-                new_key = key.parse().unwrap_or(0);
-            }
+		for (key, value) in literal_values.0 {
+			if let Some(key) = key {
+				new_key = key.parse().unwrap_or(0);
+			}
 
-            existing_values.insert(new_key, value);
-            new_key += 1;
-        }
-    }
+			existing_values.insert(new_key, value);
+			new_key += 1;
+		}
+	}
 
-    /// Returns a new associative array value constructed from the given literals.
-    ///
-    /// # Arguments
-    ///
-    /// * `literals` - The literals to construct the associative array from.
-    pub fn associative_array_from_literals(literals: ArrayLiteral) -> Result<Self, error::Error> {
-        let mut values = BTreeMap::new();
-        Self::update_associative_array_from_literals(&mut values, literals)?;
+	/// Returns a new associative array value constructed from the given literals.
+	///
+	/// # Arguments
+	///
+	/// * `literals` - The literals to construct the associative array from.
+	pub fn associative_array_from_literals(literals: ArrayLiteral) -> Result<Self, error::Error> {
+		let mut values = BTreeMap::new();
+		Self::update_associative_array_from_literals(&mut values, literals)?;
 
-        Ok(Self::AssociativeArray(values))
-    }
+		Ok(Self::AssociativeArray(values))
+	}
 
-    fn update_associative_array_from_literals(
-        existing_values: &mut BTreeMap<String, String>,
-        literal_values: ArrayLiteral,
-    ) -> Result<(), error::Error> {
-        let mut current_key = None;
-        for (key, value) in literal_values.0 {
-            if let Some(current_key) = current_key.take() {
-                if key.is_some() {
-                    return error::unimp("misaligned keys/values in associative array literal");
-                } else {
-                    existing_values.insert(current_key, value);
-                }
-            } else if let Some(key) = key {
-                existing_values.insert(key, value);
-            } else {
-                current_key = Some(value);
-            }
-        }
+	fn update_associative_array_from_literals(
+		existing_values: &mut BTreeMap<String, String>,
+		literal_values: ArrayLiteral,
+	) -> Result<(), error::Error> {
+		let mut current_key = None;
+		for (key, value) in literal_values.0 {
+			if let Some(current_key) = current_key.take() {
+				if key.is_some() {
+					return error::unimp("misaligned keys/values in associative array literal");
+				} else {
+					existing_values.insert(current_key, value);
+				}
+			} else if let Some(key) = key {
+				existing_values.insert(key, value);
+			} else {
+				current_key = Some(value);
+			}
+		}
 
-        if let Some(current_key) = current_key {
-            existing_values.insert(current_key, String::new());
-        }
+		if let Some(current_key) = current_key {
+			existing_values.insert(current_key, String::new());
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    /// Formats the value using the given style.
-    ///
-    /// # Arguments
-    ///
-    /// * `style` - The style to use for formatting the value.
-    pub fn format(&self, style: FormatStyle, shell: &Shell) -> Result<Cow<'_, str>, error::Error> {
-        match self {
-            Self::Unset(_) => Ok("".into()),
-            Self::String(s) => match style {
-                FormatStyle::Basic => Ok(escape::quote_if_needed(
-                    s.as_str(),
-                    escape::QuoteMode::SingleQuote,
-                )),
-                FormatStyle::DeclarePrint => {
-                    Ok(escape::force_quote(s.as_str(), escape::QuoteMode::DoubleQuote).into())
-                }
-            },
-            Self::AssociativeArray(values) => {
-                let mut result = String::new();
-                result.push('(');
+	/// Formats the value using the given style.
+	///
+	/// # Arguments
+	///
+	/// * `style` - The style to use for formatting the value.
+	pub fn format(&self, style: FormatStyle, shell: &Shell) -> Result<Cow<'_, str>, error::Error> {
+		match self {
+			Self::Unset(_) => Ok("".into()),
+			Self::String(s) => match style {
+				FormatStyle::Basic => {
+					Ok(escape::quote_if_needed(s.as_str(), escape::QuoteMode::SingleQuote))
+				},
+				FormatStyle::DeclarePrint => {
+					Ok(escape::force_quote(s.as_str(), escape::QuoteMode::DoubleQuote).into())
+				},
+			},
+			Self::AssociativeArray(values) => {
+				let mut result = String::new();
+				result.push('(');
 
-                for (key, value) in values {
-                    let formatted_key =
-                        escape::quote_if_needed(key.as_str(), escape::QuoteMode::DoubleQuote);
-                    let formatted_value =
-                        escape::force_quote(value.as_str(), escape::QuoteMode::DoubleQuote);
+				for (key, value) in values {
+					let formatted_key =
+						escape::quote_if_needed(key.as_str(), escape::QuoteMode::DoubleQuote);
+					let formatted_value =
+						escape::force_quote(value.as_str(), escape::QuoteMode::DoubleQuote);
 
-                    // N.B. We include an unconditional trailing space character (even after the
-                    // last entry in the associative array) to match standard
-                    // output behavior.
-                    write!(result, "[{formatted_key}]={formatted_value} ")?;
-                }
+					// N.B. We include an unconditional trailing space character (even after the
+					// last entry in the associative array) to match standard
+					// output behavior.
+					write!(result, "[{formatted_key}]={formatted_value} ")?;
+				}
 
-                result.push(')');
-                Ok(result.into())
-            }
-            Self::IndexedArray(values) => {
-                let mut result = String::new();
-                result.push('(');
+				result.push(')');
+				Ok(result.into())
+			},
+			Self::IndexedArray(values) => {
+				let mut result = String::new();
+				result.push('(');
 
-                for (i, (key, value)) in values.iter().enumerate() {
-                    if i > 0 {
-                        result.push(' ');
-                    }
+				for (i, (key, value)) in values.iter().enumerate() {
+					if i > 0 {
+						result.push(' ');
+					}
 
-                    let formatted_value =
-                        escape::force_quote(value.as_str(), escape::QuoteMode::DoubleQuote);
-                    write!(result, "[{key}]={formatted_value}")?;
-                }
+					let formatted_value =
+						escape::force_quote(value.as_str(), escape::QuoteMode::DoubleQuote);
+					write!(result, "[{key}]={formatted_value}")?;
+				}
 
-                result.push(')');
-                Ok(result.into())
-            }
-            Self::Dynamic { getter, .. } => {
-                let dynamic_value = getter(shell);
-                let result = dynamic_value.format(style, shell)?.to_string();
-                Ok(result.into())
-            }
-        }
-    }
+				result.push(')');
+				Ok(result.into())
+			},
+			Self::Dynamic { getter, .. } => {
+				let dynamic_value = getter(shell);
+				let result = dynamic_value.format(style, shell)?.to_string();
+				Ok(result.into())
+			},
+		}
+	}
 
-    /// Tries to retrieve the value stored at the given index in this variable.
-    ///
-    /// # Arguments
-    ///
-    /// * `index` - The index at which to retrieve the value.
-    pub fn get_at(&self, index: &str, shell: &Shell) -> Result<Option<Cow<'_, str>>, error::Error> {
-        match self {
-            Self::Unset(_) => Ok(None),
-            Self::String(s) => {
-                if index.parse::<u64>().unwrap_or(0) == 0 {
-                    Ok(Some(Cow::Borrowed(s)))
-                } else {
-                    Ok(None)
-                }
-            }
-            Self::AssociativeArray(values) => {
-                Ok(values.get(index).map(|s| Cow::Borrowed(s.as_str())))
-            }
-            Self::IndexedArray(values) => {
-                let mut index_value = index.parse::<i64>().unwrap_or(0);
+	/// Tries to retrieve the value stored at the given index in this variable.
+	///
+	/// # Arguments
+	///
+	/// * `index` - The index at which to retrieve the value.
+	pub fn get_at(&self, index: &str, shell: &Shell) -> Result<Option<Cow<'_, str>>, error::Error> {
+		match self {
+			Self::Unset(_) => Ok(None),
+			Self::String(s) => {
+				if index.parse::<u64>().unwrap_or(0) == 0 {
+					Ok(Some(Cow::Borrowed(s)))
+				} else {
+					Ok(None)
+				}
+			},
+			Self::AssociativeArray(values) => Ok(values.get(index).map(|s| Cow::Borrowed(s.as_str()))),
+			Self::IndexedArray(values) => {
+				let mut index_value = index.parse::<i64>().unwrap_or(0);
 
-                #[expect(clippy::cast_possible_wrap)]
-                if index_value < 0 {
-                    index_value += values.len() as i64;
-                    if index_value < 0 {
-                        return Err(error::ErrorKind::ArrayIndexOutOfRange(index_value).into());
-                    }
-                }
+				#[expect(clippy::cast_possible_wrap)]
+				if index_value < 0 {
+					index_value += values.len() as i64;
+					if index_value < 0 {
+						return Err(error::ErrorKind::ArrayIndexOutOfRange(index_value).into());
+					}
+				}
 
-                // Now that we've confirmed that the index is non-negative, we can safely convert it
-                // to a u64 without any fuss.
-                #[expect(clippy::cast_sign_loss)]
-                let index_value = index_value as u64;
+				// Now that we've confirmed that the index is non-negative, we can safely convert it
+				// to a u64 without any fuss.
+				#[expect(clippy::cast_sign_loss)]
+				let index_value = index_value as u64;
 
-                Ok(values.get(&index_value).map(|s| Cow::Borrowed(s.as_str())))
-            }
-            Self::Dynamic { getter, .. } => {
-                let dynamic_value = getter(shell);
-                let result = dynamic_value.get_at(index, shell)?;
-                Ok(result.map(|s| s.to_string().into()))
-            }
-        }
-    }
+				Ok(values.get(&index_value).map(|s| Cow::Borrowed(s.as_str())))
+			},
+			Self::Dynamic { getter, .. } => {
+				let dynamic_value = getter(shell);
+				let result = dynamic_value.get_at(index, shell)?;
+				Ok(result.map(|s| s.to_string().into()))
+			},
+		}
+	}
 
-    /// Returns the keys of the elements in this variable.
-    pub fn element_keys(&self, shell: &Shell) -> Vec<String> {
-        match self {
-            Self::Unset(_) => vec![],
-            Self::String(_) => vec!["0".to_owned()],
-            Self::AssociativeArray(array) => array.keys().map(|k| k.to_owned()).collect(),
-            Self::IndexedArray(array) => array.keys().map(|k| k.to_string()).collect(),
-            Self::Dynamic { getter, .. } => getter(shell).element_keys(shell),
-        }
-    }
+	/// Returns the keys of the elements in this variable.
+	pub fn element_keys(&self, shell: &Shell) -> Vec<String> {
+		match self {
+			Self::Unset(_) => vec![],
+			Self::String(_) => vec!["0".to_owned()],
+			Self::AssociativeArray(array) => array.keys().map(|k| k.to_owned()).collect(),
+			Self::IndexedArray(array) => array.keys().map(|k| k.to_string()).collect(),
+			Self::Dynamic { getter, .. } => getter(shell).element_keys(shell),
+		}
+	}
 
-    /// Returns the values of the elements in this variable.
-    pub fn element_values(&self, shell: &Shell) -> Vec<String> {
-        match self {
-            Self::Unset(_) => vec![],
-            Self::String(s) => vec![s.to_owned()],
-            Self::AssociativeArray(array) => array.values().map(|v| v.to_owned()).collect(),
-            Self::IndexedArray(array) => array.values().map(|v| v.to_owned()).collect(),
-            Self::Dynamic { getter, .. } => getter(shell).element_values(shell),
-        }
-    }
+	/// Returns the values of the elements in this variable.
+	pub fn element_values(&self, shell: &Shell) -> Vec<String> {
+		match self {
+			Self::Unset(_) => vec![],
+			Self::String(s) => vec![s.to_owned()],
+			Self::AssociativeArray(array) => array.values().map(|v| v.to_owned()).collect(),
+			Self::IndexedArray(array) => array.values().map(|v| v.to_owned()).collect(),
+			Self::Dynamic { getter, .. } => getter(shell).element_values(shell),
+		}
+	}
 
-    /// Converts this value to a string.
-    pub fn to_cow_str(&self, shell: &Shell) -> Cow<'_, str> {
-        self.try_get_cow_str(shell).unwrap_or(Cow::Borrowed(""))
-    }
+	/// Converts this value to a string.
+	pub fn to_cow_str(&self, shell: &Shell) -> Cow<'_, str> {
+		self.try_get_cow_str(shell).unwrap_or(Cow::Borrowed(""))
+	}
 
-    fn to_cow_str_without_dynamic_support(&self) -> Cow<'_, str> {
-        self.try_get_cow_str_without_dynamic_support()
-            .unwrap_or(Cow::Borrowed(""))
-    }
+	fn to_cow_str_without_dynamic_support(&self) -> Cow<'_, str> {
+		self
+			.try_get_cow_str_without_dynamic_support()
+			.unwrap_or(Cow::Borrowed(""))
+	}
 
-    /// Tries to convert this value to a string; returns `None` if the value is unset
-    /// or otherwise doesn't exist.
-    pub fn try_get_cow_str(&self, shell: &Shell) -> Option<Cow<'_, str>> {
-        match self {
-            Self::Dynamic { getter, .. } => {
-                let dynamic_value = getter(shell);
-                dynamic_value
-                    .try_get_cow_str(shell)
-                    .map(|s| s.to_string().into())
-            }
-            _ => self.try_get_cow_str_without_dynamic_support(),
-        }
-    }
+	/// Tries to convert this value to a string; returns `None` if the value is unset
+	/// or otherwise doesn't exist.
+	pub fn try_get_cow_str(&self, shell: &Shell) -> Option<Cow<'_, str>> {
+		match self {
+			Self::Dynamic { getter, .. } => {
+				let dynamic_value = getter(shell);
+				dynamic_value
+					.try_get_cow_str(shell)
+					.map(|s| s.to_string().into())
+			},
+			_ => self.try_get_cow_str_without_dynamic_support(),
+		}
+	}
 
-    fn try_get_cow_str_without_dynamic_support(&self) -> Option<Cow<'_, str>> {
-        match self {
-            Self::Unset(_) => None,
-            Self::String(s) => Some(Cow::Borrowed(s.as_str())),
-            Self::AssociativeArray(values) => values.get("0").map(|s| Cow::Borrowed(s.as_str())),
-            Self::IndexedArray(values) => values.get(&0).map(|s| Cow::Borrowed(s.as_str())),
-            Self::Dynamic { .. } => None,
-        }
-    }
+	fn try_get_cow_str_without_dynamic_support(&self) -> Option<Cow<'_, str>> {
+		match self {
+			Self::Unset(_) => None,
+			Self::String(s) => Some(Cow::Borrowed(s.as_str())),
+			Self::AssociativeArray(values) => values.get("0").map(|s| Cow::Borrowed(s.as_str())),
+			Self::IndexedArray(values) => values.get(&0).map(|s| Cow::Borrowed(s.as_str())),
+			Self::Dynamic { .. } => None,
+		}
+	}
 
-    /// Formats this value as a program string usable in an assignment.
-    ///
-    /// # Arguments
-    ///
-    /// * `index` - The index at which to retrieve the value, if indexing is to be performed.
-    pub fn to_assignable_str(&self, index: Option<&str>, shell: &Shell) -> String {
-        match self {
-            Self::Unset(_) => String::new(),
-            Self::String(s) => escape::force_quote(s.as_str(), escape::QuoteMode::SingleQuote),
-            Self::AssociativeArray(_) | Self::IndexedArray(_) => {
-                if let Some(index) = index {
-                    if let Ok(Some(value)) = self.get_at(index, shell) {
-                        escape::force_quote(value.as_ref(), escape::QuoteMode::SingleQuote)
-                    } else {
-                        String::new()
-                    }
-                } else {
-                    self.format(FormatStyle::DeclarePrint, shell)
-                        .unwrap()
-                        .into_owned()
-                }
-            }
-            Self::Dynamic { getter, .. } => getter(shell).to_assignable_str(index, shell),
-        }
-    }
+	/// Formats this value as a program string usable in an assignment.
+	///
+	/// # Arguments
+	///
+	/// * `index` - The index at which to retrieve the value, if indexing is to be performed.
+	pub fn to_assignable_str(&self, index: Option<&str>, shell: &Shell) -> String {
+		match self {
+			Self::Unset(_) => String::new(),
+			Self::String(s) => escape::force_quote(s.as_str(), escape::QuoteMode::SingleQuote),
+			Self::AssociativeArray(_) | Self::IndexedArray(_) => {
+				if let Some(index) = index {
+					if let Ok(Some(value)) = self.get_at(index, shell) {
+						escape::force_quote(value.as_ref(), escape::QuoteMode::SingleQuote)
+					} else {
+						String::new()
+					}
+				} else {
+					self
+						.format(FormatStyle::DeclarePrint, shell)
+						.unwrap()
+						.into_owned()
+				}
+			},
+			Self::Dynamic { getter, .. } => getter(shell).to_assignable_str(index, shell),
+		}
+	}
 }
 
 impl From<&str> for ShellValue {
-    fn from(value: &str) -> Self {
-        Self::String(value.to_owned())
-    }
+	fn from(value: &str) -> Self {
+		Self::String(value.to_owned())
+	}
 }
 
 impl From<&String> for ShellValue {
-    fn from(value: &String) -> Self {
-        Self::String(value.clone())
-    }
+	fn from(value: &String) -> Self {
+		Self::String(value.clone())
+	}
 }
 
 impl From<String> for ShellValue {
-    fn from(value: String) -> Self {
-        Self::String(value)
-    }
+	fn from(value: String) -> Self {
+		Self::String(value)
+	}
 }
 
 impl From<Vec<String>> for ShellValue {
-    fn from(values: Vec<String>) -> Self {
-        Self::indexed_array_from_strings(values)
-    }
+	fn from(values: Vec<String>) -> Self {
+		Self::indexed_array_from_strings(values)
+	}
 }
 
 impl From<Vec<&str>> for ShellValue {
-    fn from(values: Vec<&str>) -> Self {
-        Self::indexed_array_from_strs(values.as_slice())
-    }
+	fn from(values: Vec<&str>) -> Self {
+		Self::indexed_array_from_strs(values.as_slice())
+	}
 }

--- a/crates/brush-core-vendored/src/wellknownvars.rs
+++ b/crates/brush-core-vendored/src/wellknownvars.rs
@@ -9,509 +9,498 @@ const BASH_BUILD: u32 = 1;
 const BASH_RELEASE: &str = "release";
 const BASH_MACHINE: &str = "unknown";
 
-
 pub(crate) fn initialize_vars(
-    shell: &mut Shell,
-    do_not_inherit_env: bool,
+	shell: &mut Shell,
+	do_not_inherit_env: bool,
 ) -> Result<(), error::Error> {
-    // Seed parameters from environment (unless requested not to do so).
-    if !do_not_inherit_env {
-        for (k, v) in std::env::vars() {
-            // See if it's a function exported by an ancestor process.
-            if let Some(func_name) = k.strip_prefix("BASH_FUNC_") {
-                if let Some(func_name) = func_name.strip_suffix("%%") {
-                    // Intentionally best-effort; don't fail out of the shell if we can't
-                    // parse an incoming function.
-                    if shell.define_func_from_str(func_name, v.as_str()).is_ok() {
-                        shell.func_mut(func_name).unwrap().export();
-                    }
+	// Seed parameters from environment (unless requested not to do so).
+	if !do_not_inherit_env {
+		for (k, v) in std::env::vars() {
+			// See if it's a function exported by an ancestor process.
+			if let Some(func_name) = k.strip_prefix("BASH_FUNC_") {
+				if let Some(func_name) = func_name.strip_suffix("%%") {
+					// Intentionally best-effort; don't fail out of the shell if we can't
+					// parse an incoming function.
+					if shell.define_func_from_str(func_name, v.as_str()).is_ok() {
+						shell.func_mut(func_name).unwrap().export();
+					}
 
-                    continue;
-                }
-            }
+					continue;
+				}
+			}
 
-            let mut var = ShellVariable::new(ShellValue::String(v));
-            var.export();
-            shell.env.set_global(k, var)?;
-        }
-    }
+			let mut var = ShellVariable::new(ShellValue::String(v));
+			var.export();
+			shell.env.set_global(k, var)?;
+		}
+	}
 
-    let shell_version = shell.version().clone();
-    shell.env.set_global(
-        "BRUSH_VERSION",
-        ShellVariable::new(shell_version.unwrap_or_default()),
-    )?;
+	let shell_version = shell.version().clone();
+	shell
+		.env
+		.set_global("BRUSH_VERSION", ShellVariable::new(shell_version.unwrap_or_default()))?;
 
-    // TODO(#479): implement $_
+	// TODO(#479): implement $_
 
-    // BASH
-    if let Some(shell_name) = &shell.shell_name {
-        shell
-            .env
-            .set_global("BASH", ShellVariable::new(shell_name))?;
-    }
+	// BASH
+	if let Some(shell_name) = &shell.shell_name {
+		shell
+			.env
+			.set_global("BASH", ShellVariable::new(shell_name))?;
+	}
 
-    // BASHOPTS
-    let mut bashopts_var = ShellVariable::new(ShellValue::Dynamic {
-        getter: |shell| shell.options.shopt_optstr().into(),
-        setter: |_| (),
-    });
-    bashopts_var.set_readonly();
-    shell.env.set_global("BASHOPTS", bashopts_var)?;
+	// BASHOPTS
+	let mut bashopts_var = ShellVariable::new(ShellValue::Dynamic {
+		getter: |shell| shell.options.shopt_optstr().into(),
+		setter: |_| (),
+	});
+	bashopts_var.set_readonly();
+	shell.env.set_global("BASHOPTS", bashopts_var)?;
 
-    // BASHPID
-    #[cfg(not(target_family = "wasm"))]
-    {
-        let mut bashpid_var =
-            ShellVariable::new(ShellValue::String(std::process::id().to_string()));
-        bashpid_var.treat_as_integer();
-        shell.env.set_global("BASHPID", bashpid_var)?;
-    }
+	// BASHPID
+	#[cfg(not(target_family = "wasm"))]
+	{
+		let mut bashpid_var = ShellVariable::new(ShellValue::String(std::process::id().to_string()));
+		bashpid_var.treat_as_integer();
+		shell.env.set_global("BASHPID", bashpid_var)?;
+	}
 
-    // BASH_ALIASES
-    shell.env.set_global(
-        "BASH_ALIASES",
-        ShellVariable::new(ShellValue::Dynamic {
-            getter: |shell| {
-                let values = variables::ArrayLiteral(
-                    shell
-                        .aliases
-                        .iter()
-                        .map(|(k, v)| (Some(k.to_owned()), v.to_owned()))
-                        .collect::<Vec<_>>(),
-                );
+	// BASH_ALIASES
+	shell.env.set_global(
+		"BASH_ALIASES",
+		ShellVariable::new(ShellValue::Dynamic {
+			getter: |shell| {
+				let values = variables::ArrayLiteral(
+					shell
+						.aliases
+						.iter()
+						.map(|(k, v)| (Some(k.to_owned()), v.to_owned()))
+						.collect::<Vec<_>>(),
+				);
 
-                ShellValue::associative_array_from_literals(values).unwrap()
-            },
-            setter: |_| (),
-        }),
-    )?;
+				ShellValue::associative_array_from_literals(values).unwrap()
+			},
+			setter: |_| (),
+		}),
+	)?;
 
-    // TODO(vars): when extdebug is enabled, BASH_ARGC and BASH_ARGV are set to valid values
-    // TODO(vars): implement BASH_ARGC
-    // TODO(vars): implement BASH_ARGV
+	// TODO(vars): when extdebug is enabled, BASH_ARGC and BASH_ARGV are set to valid values
+	// TODO(vars): implement BASH_ARGC
+	// TODO(vars): implement BASH_ARGV
 
-    // BASH_ARGV0
-    shell.env.set_global(
-        "BASH_ARGV0",
-        ShellVariable::new(ShellValue::Dynamic {
-            getter: |shell| {
-                let argv0 = shell.shell_name.as_deref().unwrap_or_default();
-                argv0.to_string().into()
-            },
-            // TODO(vars): implement updating BASH_ARGV0
-            setter: |_| (),
-        }),
-    )?;
+	// BASH_ARGV0
+	shell.env.set_global(
+		"BASH_ARGV0",
+		ShellVariable::new(ShellValue::Dynamic {
+			getter: |shell| {
+				let argv0 = shell.shell_name.as_deref().unwrap_or_default();
+				argv0.to_string().into()
+			},
+			// TODO(vars): implement updating BASH_ARGV0
+			setter: |_| (),
+		}),
+	)?;
 
-    // TODO(vars): implement mutation of BASH_CMDS
-    shell.env.set_global(
-        "BASH_CMDS",
-        ShellVariable::new(ShellValue::Dynamic {
-            getter: |shell| shell.program_location_cache.to_value().unwrap(),
-            setter: |_| (),
-        }),
-    )?;
+	// TODO(vars): implement mutation of BASH_CMDS
+	shell.env.set_global(
+		"BASH_CMDS",
+		ShellVariable::new(ShellValue::Dynamic {
+			getter: |shell| shell.program_location_cache.to_value().unwrap(),
+			setter: |_| (),
+		}),
+	)?;
 
-    // TODO(vars): implement BASH_COMMAND
-    // TODO(vars): implement BASH_EXECUTIION_STRING
-    // TODO(vars): implement BASH_LINENO
+	// TODO(vars): implement BASH_COMMAND
+	// TODO(vars): implement BASH_EXECUTIION_STRING
+	// TODO(vars): implement BASH_LINENO
 
-    // BASH_SOURCE
-    shell.env.set_global(
-        "BASH_SOURCE",
-        ShellVariable::new(ShellValue::Dynamic {
-            getter: |shell| get_bash_source_value(shell),
-            setter: |_| (),
-        }),
-    )?;
+	// BASH_SOURCE
+	shell.env.set_global(
+		"BASH_SOURCE",
+		ShellVariable::new(ShellValue::Dynamic {
+			getter: |shell| get_bash_source_value(shell),
+			setter: |_| (),
+		}),
+	)?;
 
-    // BASH_SUBSHELL
-    shell.env.set_global(
-        "BASH_SUBSHELL",
-        ShellVariable::new(ShellValue::Dynamic {
-            getter: |shell| shell.depth().to_string().into(),
-            setter: |_| (),
-        }),
-    )?;
+	// BASH_SUBSHELL
+	shell.env.set_global(
+		"BASH_SUBSHELL",
+		ShellVariable::new(ShellValue::Dynamic {
+			getter: |shell| shell.depth().to_string().into(),
+			setter: |_| (),
+		}),
+	)?;
 
-    // BASH_VERSINFO
-    let mut bash_versinfo_var = ShellVariable::new(ShellValue::indexed_array_from_strs(
-        [
-            BASH_MAJOR.to_string().as_str(),
-            BASH_MINOR.to_string().as_str(),
-            BASH_PATCH.to_string().as_str(),
-            BASH_BUILD.to_string().as_str(),
-            BASH_RELEASE,
-            BASH_MACHINE,
-        ]
-        .as_slice(),
-    ));
-    bash_versinfo_var.set_readonly();
-    shell.env.set_global("BASH_VERSINFO", bash_versinfo_var)?;
+	// BASH_VERSINFO
+	let mut bash_versinfo_var = ShellVariable::new(ShellValue::indexed_array_from_strs(
+		[
+			BASH_MAJOR.to_string().as_str(),
+			BASH_MINOR.to_string().as_str(),
+			BASH_PATCH.to_string().as_str(),
+			BASH_BUILD.to_string().as_str(),
+			BASH_RELEASE,
+			BASH_MACHINE,
+		]
+		.as_slice(),
+	));
+	bash_versinfo_var.set_readonly();
+	shell.env.set_global("BASH_VERSINFO", bash_versinfo_var)?;
 
-    // BASH_VERSION
-    // This is the Bash interface version. See BRUSH_VERSION for its implementation version.
-    shell.env.set_global(
-        "BASH_VERSION",
-        ShellVariable::new(std::format!(
-            "{BASH_MAJOR}.{BASH_MINOR}.{BASH_PATCH}({BASH_BUILD})-{BASH_RELEASE}"
-        )),
-    )?;
+	// BASH_VERSION
+	// This is the Bash interface version. See BRUSH_VERSION for its implementation version.
+	shell.env.set_global(
+		"BASH_VERSION",
+		ShellVariable::new(std::format!(
+			"{BASH_MAJOR}.{BASH_MINOR}.{BASH_PATCH}({BASH_BUILD})-{BASH_RELEASE}"
+		)),
+	)?;
 
-    // COMP_WORDBREAKS
-    shell
-        .env
-        .set_global("COMP_WORDBREAKS", ShellVariable::new(" \t\n\"\'@><=;|&(:"))?;
+	// COMP_WORDBREAKS
+	shell
+		.env
+		.set_global("COMP_WORDBREAKS", ShellVariable::new(" \t\n\"\'@><=;|&(:"))?;
 
-    // DIRSTACK
-    shell.env.set_global(
-        "DIRSTACK",
-        ShellVariable::new(ShellValue::Dynamic {
-            getter: |shell| {
-                shell
-                    .directory_stack
-                    .iter()
-                    .map(|p| p.to_string_lossy().to_string())
-                    .collect::<Vec<_>>()
-                    .into()
-            },
-            setter: |_| (),
-        }),
-    )?;
+	// DIRSTACK
+	shell.env.set_global(
+		"DIRSTACK",
+		ShellVariable::new(ShellValue::Dynamic {
+			getter: |shell| {
+				shell
+					.directory_stack
+					.iter()
+					.map(|p| p.to_string_lossy().to_string())
+					.collect::<Vec<_>>()
+					.into()
+			},
+			setter: |_| (),
+		}),
+	)?;
 
-    // EPOCHREALTIME
-    shell.env.set_global(
-        "EPOCHREALTIME",
-        ShellVariable::new(ShellValue::Dynamic {
-            getter: |_shell| {
-                let now = std::time::SystemTime::now();
-                let since_epoch = now
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default();
-                since_epoch.as_secs_f64().to_string().into()
-            },
-            setter: |_| (),
-        }),
-    )?;
+	// EPOCHREALTIME
+	shell.env.set_global(
+		"EPOCHREALTIME",
+		ShellVariable::new(ShellValue::Dynamic {
+			getter: |_shell| {
+				let now = std::time::SystemTime::now();
+				let since_epoch = now
+					.duration_since(std::time::UNIX_EPOCH)
+					.unwrap_or_default();
+				since_epoch.as_secs_f64().to_string().into()
+			},
+			setter: |_| (),
+		}),
+	)?;
 
-    // EPOCHSECONDS
-    shell.env.set_global(
-        "EPOCHSECONDS",
-        ShellVariable::new(ShellValue::Dynamic {
-            getter: |_shell| {
-                let now = std::time::SystemTime::now();
-                let since_epoch = now
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default();
-                since_epoch.as_secs().to_string().into()
-            },
-            setter: |_| (),
-        }),
-    )?;
+	// EPOCHSECONDS
+	shell.env.set_global(
+		"EPOCHSECONDS",
+		ShellVariable::new(ShellValue::Dynamic {
+			getter: |_shell| {
+				let now = std::time::SystemTime::now();
+				let since_epoch = now
+					.duration_since(std::time::UNIX_EPOCH)
+					.unwrap_or_default();
+				since_epoch.as_secs().to_string().into()
+			},
+			setter: |_| (),
+		}),
+	)?;
 
-    // EUID
-    if let Ok(euid) = sys::users::get_effective_uid() {
-        let mut euid_var = ShellVariable::new(ShellValue::String(format!("{euid}")));
-        euid_var.treat_as_integer().set_readonly();
-        shell.env.set_global("EUID", euid_var)?;
-    }
+	// EUID
+	if let Ok(euid) = sys::users::get_effective_uid() {
+		let mut euid_var = ShellVariable::new(ShellValue::String(format!("{euid}")));
+		euid_var.treat_as_integer().set_readonly();
+		shell.env.set_global("EUID", euid_var)?;
+	}
 
-    // FUNCNAME
-    shell.env.set_global(
-        "FUNCNAME",
-        ShellVariable::new(ShellValue::Dynamic {
-            getter: |shell| get_funcname_value(shell),
-            setter: |_| (),
-        }),
-    )?;
+	// FUNCNAME
+	shell.env.set_global(
+		"FUNCNAME",
+		ShellVariable::new(ShellValue::Dynamic {
+			getter: |shell| get_funcname_value(shell),
+			setter: |_| (),
+		}),
+	)?;
 
-    // GROUPS
-    // N.B. We could compute this up front, but we choose to make it dynamic so that we
-    // don't have to make costly system calls if the user never accesses it.
-    shell.env.set_global(
-        "GROUPS",
-        ShellVariable::new(ShellValue::Dynamic {
-            getter: |_shell| {
-                let groups = get_current_user_gids();
-                ShellValue::indexed_array_from_strings(
-                    groups.into_iter().map(|gid| gid.to_string()),
-                )
-            },
-            setter: |_| (),
-        }),
-    )?;
+	// GROUPS
+	// N.B. We could compute this up front, but we choose to make it dynamic so that we
+	// don't have to make costly system calls if the user never accesses it.
+	shell.env.set_global(
+		"GROUPS",
+		ShellVariable::new(ShellValue::Dynamic {
+			getter: |_shell| {
+				let groups = get_current_user_gids();
+				ShellValue::indexed_array_from_strings(groups.into_iter().map(|gid| gid.to_string()))
+			},
+			setter: |_| (),
+		}),
+	)?;
 
-    // HISTCMD
-    let mut histcmd_var = ShellVariable::new(ShellValue::Dynamic {
-        getter: |shell| {
-            shell
-                .history()
-                .map_or_else(|| "0".into(), |h| h.count().to_string().into())
-        },
-        setter: |_| (),
-    });
-    histcmd_var.treat_as_integer();
-    shell.env.set_global("HISTCMD", histcmd_var)?;
+	// HISTCMD
+	let mut histcmd_var = ShellVariable::new(ShellValue::Dynamic {
+		getter: |shell| {
+			shell
+				.history()
+				.map_or_else(|| "0".into(), |h| h.count().to_string().into())
+		},
+		setter: |_| (),
+	});
+	histcmd_var.treat_as_integer();
+	shell.env.set_global("HISTCMD", histcmd_var)?;
 
-    // HISTFILE (if not already set)
-    if !shell.env.is_set("HISTFILE") {
-        if let Some(home_dir) = shell.home_dir() {
-            let histfile = home_dir.join(".brush_history");
-            shell.env.set_global(
-                "HISTFILE",
-                ShellVariable::new(ShellValue::String(histfile.to_string_lossy().to_string())),
-            )?;
-        }
-    }
+	// HISTFILE (if not already set)
+	if !shell.env.is_set("HISTFILE") {
+		if let Some(home_dir) = shell.home_dir() {
+			let histfile = home_dir.join(".brush_history");
+			shell.env.set_global(
+				"HISTFILE",
+				ShellVariable::new(ShellValue::String(histfile.to_string_lossy().to_string())),
+			)?;
+		}
+	}
 
-    // HOSTNAME
-    shell.env.set_global(
-        "HOSTNAME",
-        ShellVariable::new(
-            sys::network::get_hostname()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string(),
-        ),
-    )?;
+	// HOSTNAME
+	shell.env.set_global(
+		"HOSTNAME",
+		ShellVariable::new(
+			sys::network::get_hostname()
+				.unwrap_or_default()
+				.to_string_lossy()
+				.to_string(),
+		),
+	)?;
 
-    // HOSTTYPE
-    shell.env.set_global(
-        "HOSTTYPE",
-        ShellVariable::new(std::env::consts::ARCH.to_string()),
-    )?;
+	// HOSTTYPE
+	shell
+		.env
+		.set_global("HOSTTYPE", ShellVariable::new(std::env::consts::ARCH.to_string()))?;
 
-    // IFS
-    shell.env.set_global("IFS", ShellVariable::new(" \t\n"))?;
+	// IFS
+	shell.env.set_global("IFS", ShellVariable::new(" \t\n"))?;
 
-    // LINENO
-    shell.env.set_global(
-        "LINENO",
-        ShellVariable::new(ShellValue::Dynamic {
-            getter: |shell| shell.current_line_number().to_string().into(),
-            setter: |_| (),
-        }),
-    )?;
+	// LINENO
+	shell.env.set_global(
+		"LINENO",
+		ShellVariable::new(ShellValue::Dynamic {
+			getter: |shell| shell.current_line_number().to_string().into(),
+			setter: |_| (),
+		}),
+	)?;
 
-    // MACHTYPE
-    shell
-        .env
-        .set_global("MACHTYPE", ShellVariable::new(BASH_MACHINE))?;
+	// MACHTYPE
+	shell
+		.env
+		.set_global("MACHTYPE", ShellVariable::new(BASH_MACHINE))?;
 
-    // OLDPWD (initialization)
-    if !shell.env.is_set("OLDPWD") {
-        let mut oldpwd_var =
-            ShellVariable::new(ShellValue::Unset(variables::ShellValueUnsetType::Untyped));
-        oldpwd_var.export();
-        shell.env.set_global("OLDPWD", oldpwd_var)?;
-    }
+	// OLDPWD (initialization)
+	if !shell.env.is_set("OLDPWD") {
+		let mut oldpwd_var =
+			ShellVariable::new(ShellValue::Unset(variables::ShellValueUnsetType::Untyped));
+		oldpwd_var.export();
+		shell.env.set_global("OLDPWD", oldpwd_var)?;
+	}
 
-    // OPTERR
-    shell.env.set_global("OPTERR", ShellVariable::new("1"))?;
+	// OPTERR
+	shell.env.set_global("OPTERR", ShellVariable::new("1"))?;
 
-    // OPTIND
-    let mut optind_var = ShellVariable::new("1");
-    optind_var.treat_as_integer();
-    shell.env.set_global("OPTIND", optind_var)?;
+	// OPTIND
+	let mut optind_var = ShellVariable::new("1");
+	optind_var.treat_as_integer();
+	shell.env.set_global("OPTIND", optind_var)?;
 
-    // OSTYPE
-    let os_type = match std::env::consts::OS {
-        "linux" => "linux-gnu",
-        "windows" => "windows",
-        _ => "unknown",
-    };
-    shell
-        .env
-        .set_global("OSTYPE", ShellVariable::new(os_type))?;
+	// OSTYPE
+	let os_type = match std::env::consts::OS {
+		"linux" => "linux-gnu",
+		"windows" => "windows",
+		_ => "unknown",
+	};
+	shell
+		.env
+		.set_global("OSTYPE", ShellVariable::new(os_type))?;
 
-    // PATH (if not already set)
-    if !shell.env.is_set("PATH") {
-        let default_paths = sys::fs::get_default_executable_search_paths();
-        let default_path_str = std::env::join_paths(default_paths.iter())
-            .map(|paths| paths.to_string_lossy().to_string())
-            .unwrap_or_else(|_| default_paths.join(if cfg!(windows) { ";" } else { ":" }));
-        shell
-            .env
-            .set_global("PATH", ShellVariable::new(default_path_str))?;
-    }
+	// PATH (if not already set)
+	if !shell.env.is_set("PATH") {
+		let default_paths = sys::fs::get_default_executable_search_paths();
+		let default_path_str = std::env::join_paths(default_paths.iter())
+			.map(|paths| paths.to_string_lossy().to_string())
+			.unwrap_or_else(|_| default_paths.join(if cfg!(windows) { ";" } else { ":" }));
+		shell
+			.env
+			.set_global("PATH", ShellVariable::new(default_path_str))?;
+	}
 
-    // PIPESTATUS
-    // TODO: Investigate what happens if this gets unset.
-    // TODO: Investigate if this needs to be saved/preserved across prompt display.
-    shell.env.set_global(
-        "PIPESTATUS",
-        ShellVariable::new(ShellValue::Dynamic {
-            getter: |shell| {
-                ShellValue::indexed_array_from_strings(
-                    shell.last_pipeline_statuses.iter().map(|s| s.to_string()),
-                )
-            },
-            setter: |_| (),
-        }),
-    )?;
+	// PIPESTATUS
+	// TODO: Investigate what happens if this gets unset.
+	// TODO: Investigate if this needs to be saved/preserved across prompt display.
+	shell.env.set_global(
+		"PIPESTATUS",
+		ShellVariable::new(ShellValue::Dynamic {
+			getter: |shell| {
+				ShellValue::indexed_array_from_strings(
+					shell.last_pipeline_statuses.iter().map(|s| s.to_string()),
+				)
+			},
+			setter: |_| (),
+		}),
+	)?;
 
-    // PPID
-    if let Some(ppid) = sys::terminal::get_parent_process_id() {
-        let mut ppid_var = ShellVariable::new(ppid.to_string());
-        ppid_var.treat_as_integer().set_readonly();
-        shell.env.set_global("PPID", ppid_var)?;
-    }
+	// PPID
+	if let Some(ppid) = sys::terminal::get_parent_process_id() {
+		let mut ppid_var = ShellVariable::new(ppid.to_string());
+		ppid_var.treat_as_integer().set_readonly();
+		shell.env.set_global("PPID", ppid_var)?;
+	}
 
-    // RANDOM
-    let mut random_var = ShellVariable::new(ShellValue::Dynamic {
-        getter: get_random_value,
-        setter: |_| (),
-    });
-    random_var.treat_as_integer();
-    shell.env.set_global("RANDOM", random_var)?;
+	// RANDOM
+	let mut random_var =
+		ShellVariable::new(ShellValue::Dynamic { getter: get_random_value, setter: |_| () });
+	random_var.treat_as_integer();
+	shell.env.set_global("RANDOM", random_var)?;
 
-    // SECONDS
-    shell.env.set_global(
-        "SECONDS",
-        ShellVariable::new(ShellValue::Dynamic {
-            getter: |shell| {
-                let now = std::time::SystemTime::now();
-                let since_last = now
-                    .duration_since(shell.last_stopwatch_time())
-                    .unwrap_or_default();
-                let total_seconds = since_last.as_secs() + u64::from(shell.last_stopwatch_offset());
-                total_seconds.to_string().into()
-            },
-            // TODO(vars): implement updating SECONDS
-            setter: |_| (),
-        }),
-    )?;
+	// SECONDS
+	shell.env.set_global(
+		"SECONDS",
+		ShellVariable::new(ShellValue::Dynamic {
+			getter: |shell| {
+				let now = std::time::SystemTime::now();
+				let since_last = now
+					.duration_since(shell.last_stopwatch_time())
+					.unwrap_or_default();
+				let total_seconds = since_last.as_secs() + u64::from(shell.last_stopwatch_offset());
+				total_seconds.to_string().into()
+			},
+			// TODO(vars): implement updating SECONDS
+			setter: |_| (),
+		}),
+	)?;
 
-    // SHELL
-    if let Ok(exe_path) = std::env::current_exe() {
-        shell.env.set_global(
-            "SHELL",
-            ShellVariable::new(exe_path.to_string_lossy().to_string()),
-        )?;
-    }
+	// SHELL
+	if let Ok(exe_path) = std::env::current_exe() {
+		shell
+			.env
+			.set_global("SHELL", ShellVariable::new(exe_path.to_string_lossy().to_string()))?;
+	}
 
-    // SHELLOPTS
-    let mut shellopts_var = ShellVariable::new(ShellValue::Dynamic {
-        getter: |shell| shell.options.seto_optstr().into(),
-        setter: |_| (),
-    });
-    shellopts_var.set_readonly();
-    shell.env.set_global("SHELLOPTS", shellopts_var)?;
+	// SHELLOPTS
+	let mut shellopts_var = ShellVariable::new(ShellValue::Dynamic {
+		getter: |shell| shell.options.seto_optstr().into(),
+		setter: |_| (),
+	});
+	shellopts_var.set_readonly();
+	shell.env.set_global("SHELLOPTS", shellopts_var)?;
 
-    // SHLVL
-    let input_shlvl = shell.env_str("SHLVL").unwrap_or_else(|| "0".into());
-    let updated_shlvl = input_shlvl.as_ref().parse::<u32>().unwrap_or(0) + 1;
-    let mut shlvl_var = ShellVariable::new(updated_shlvl.to_string());
-    shlvl_var.export();
-    shell.env.set_global("SHLVL", shlvl_var)?;
+	// SHLVL
+	let input_shlvl = shell.env_str("SHLVL").unwrap_or_else(|| "0".into());
+	let updated_shlvl = input_shlvl.as_ref().parse::<u32>().unwrap_or(0) + 1;
+	let mut shlvl_var = ShellVariable::new(updated_shlvl.to_string());
+	shlvl_var.export();
+	shell.env.set_global("SHLVL", shlvl_var)?;
 
-    // SRANDOM
-    let mut random_var = ShellVariable::new(ShellValue::Dynamic {
-        getter: get_srandom_value,
-        setter: |_| (),
-    });
-    random_var.treat_as_integer();
-    shell.env.set_global("SRANDOM", random_var)?;
+	// SRANDOM
+	let mut random_var =
+		ShellVariable::new(ShellValue::Dynamic { getter: get_srandom_value, setter: |_| () });
+	random_var.treat_as_integer();
+	shell.env.set_global("SRANDOM", random_var)?;
 
-    // PS1 / PS2
-    if shell.options.interactive {
-        if !shell.env.is_set("PS1") {
-            shell
-                .env
-                .set_global("PS1", ShellVariable::new(r"\s-\v\$ "))?;
-        }
+	// PS1 / PS2
+	if shell.options.interactive {
+		if !shell.env.is_set("PS1") {
+			shell
+				.env
+				.set_global("PS1", ShellVariable::new(r"\s-\v\$ "))?;
+		}
 
-        if !shell.env.is_set("PS2") {
-            shell.env.set_global("PS2", ShellVariable::new("> "))?;
-        }
-    }
+		if !shell.env.is_set("PS2") {
+			shell.env.set_global("PS2", ShellVariable::new("> "))?;
+		}
+	}
 
-    // PS4
-    if !shell.env.is_set("PS4") {
-        shell.env.set_global("PS4", ShellVariable::new("+ "))?;
-    }
+	// PS4
+	if !shell.env.is_set("PS4") {
+		shell.env.set_global("PS4", ShellVariable::new("+ "))?;
+	}
 
-    //
-    // PWD
-    //
-    // Reflect our actual working directory. There's a chance
-    // we inherited an out-of-sync version of the variable. Future updates
-    // will be handled by set_working_dir().
-    //
-    let pwd = shell.working_dir().to_string_lossy().to_string();
-    let mut pwd_var = ShellVariable::new(pwd);
-    pwd_var.export();
-    shell.env.set_global("PWD", pwd_var)?;
+	//
+	// PWD
+	//
+	// Reflect our actual working directory. There's a chance
+	// we inherited an out-of-sync version of the variable. Future updates
+	// will be handled by set_working_dir().
+	//
+	let pwd = shell.working_dir().to_string_lossy().to_string();
+	let mut pwd_var = ShellVariable::new(pwd);
+	pwd_var.export();
+	shell.env.set_global("PWD", pwd_var)?;
 
-    // UID
-    if let Ok(uid) = sys::users::get_current_uid() {
-        let mut uid_var = ShellVariable::new(ShellValue::String(format!("{uid}")));
-        uid_var.treat_as_integer().set_readonly();
-        shell.env.set_global("UID", uid_var)?;
-    }
+	// UID
+	if let Ok(uid) = sys::users::get_current_uid() {
+		let mut uid_var = ShellVariable::new(ShellValue::String(format!("{uid}")));
+		uid_var.treat_as_integer().set_readonly();
+		shell.env.set_global("UID", uid_var)?;
+	}
 
-    Ok(())
+	Ok(())
 }
 
 /// Returns a list of the current user's group IDs, with the effective GID at the front.
 fn get_current_user_gids() -> Vec<u32> {
-    let mut groups = sys::users::get_user_group_ids().unwrap_or_default();
+	let mut groups = sys::users::get_user_group_ids().unwrap_or_default();
 
-    // If the effective GID is present but not in the first position in the list, then move
-    // it there.
-    if let Ok(gid) = sys::users::get_effective_gid() {
-        if let Some(index) = groups.iter().position(|&g| g == gid) {
-            if index > 0 {
-                // Move it to the front.
-                groups.remove(index);
-                groups.insert(0, gid);
-            }
-        }
-    }
+	// If the effective GID is present but not in the first position in the list, then move
+	// it there.
+	if let Ok(gid) = sys::users::get_effective_gid() {
+		if let Some(index) = groups.iter().position(|&g| g == gid) {
+			if index > 0 {
+				// Move it to the front.
+				groups.remove(index);
+				groups.insert(0, gid);
+			}
+		}
+	}
 
-    groups
+	groups
 }
 
 fn get_random_value(_shell: &Shell) -> ShellValue {
-    let mut rng = rand::rng();
-    let num = rng.random_range(0..32768);
-    let str = num.to_string();
-    str.into()
+	let mut rng = rand::rng();
+	let num = rng.random_range(0..32768);
+	let str = num.to_string();
+	str.into()
 }
 
 fn get_srandom_value(_shell: &Shell) -> ShellValue {
-    let mut rng = rand::rng();
-    let num: u32 = rng.random();
-    let str = num.to_string();
-    str.into()
+	let mut rng = rand::rng();
+	let num: u32 = rng.random();
+	let str = num.to_string();
+	str.into()
 }
 
 fn get_funcname_value(shell: &Shell) -> variables::ShellValue {
-    if shell.function_call_stack().is_empty() {
-        ShellValue::Unset(variables::ShellValueUnsetType::IndexedArray)
-    } else {
-        shell
-            .function_call_stack()
-            .iter()
-            .map(|s| s.function_name.as_str())
-            .collect::<Vec<_>>()
-            .into()
-    }
+	if shell.function_call_stack().is_empty() {
+		ShellValue::Unset(variables::ShellValueUnsetType::IndexedArray)
+	} else {
+		shell
+			.function_call_stack()
+			.iter()
+			.map(|s| s.function_name.as_str())
+			.collect::<Vec<_>>()
+			.into()
+	}
 }
 
 fn get_bash_source_value(shell: &Shell) -> variables::ShellValue {
-    if shell.function_call_stack().is_empty() {
-        let top_frame = shell.script_call_stack().iter().next();
-        top_frame
-            .map_or_else(Vec::new, |frame| vec![frame.source.as_ref()])
-            .into()
-    } else {
-        shell
-            .function_call_stack()
-            .iter()
-            .map(|s| s.function_definition.source.as_ref())
-            .collect::<Vec<_>>()
-            .into()
-    }
+	if shell.function_call_stack().is_empty() {
+		let top_frame = shell.script_call_stack().iter().next();
+		top_frame
+			.map_or_else(Vec::new, |frame| vec![frame.source.as_ref()])
+			.into()
+	} else {
+		shell
+			.function_call_stack()
+			.iter()
+			.map(|s| s.function_definition.source.as_ref())
+			.collect::<Vec<_>>()
+			.into()
+	}
 }

--- a/crates/pi-natives/src/chunk/mod.rs
+++ b/crates/pi-natives/src/chunk/mod.rs
@@ -1011,18 +1011,30 @@ mod tests {
 	#[test]
 	fn builds_structural_tree_for_each_supported_language() {
 		let cases = [
-			("astro", "---\nconst title = \"Hello\";\n---\n<Layout><h1>{title}</h1><script>console.log(title)</script></Layout>\n"),
+			(
+				"astro",
+				"---\nconst title = \"Hello\";\n---\n<Layout><h1>{title}</h1><script>console.log(title)</script></Layout>\n",
+			),
 			("bash", "build() { echo ok; }\n"),
 			("c", "#include <stdio.h>\nint main(void) { return 0; }\n"),
-			("cmake", "cmake_minimum_required(VERSION 3.28)\nproject(App)\nfunction(run_it NAME)\n  message(STATUS ${NAME})\nendfunction()\n"),
+			(
+				"cmake",
+				"cmake_minimum_required(VERSION 3.28)\nproject(App)\nfunction(run_it NAME)\n  message(STATUS ${NAME})\nendfunction()\n",
+			),
 			("cpp", "#include <vector>\nclass App {};\nint main() { return 0; }\n"),
 			("csharp", "using System;\nclass App { void Run() {} }\n"),
 			("clojure", "(ns demo.core)\n(defn greet [x] x)\n"),
 			("css", "@import \"a.css\";\n.app { color: red; }\n"),
 			("diff", "@@ -1,1 +1,1 @@\n-a\n+b\n"),
-			("dockerfile", "FROM alpine AS base\nARG PORT=3000\nRUN echo hi\nCMD [\"sh\", \"-c\", \"echo ok\"]\n"),
+			(
+				"dockerfile",
+				"FROM alpine AS base\nARG PORT=3000\nRUN echo hi\nCMD [\"sh\", \"-c\", \"echo ok\"]\n",
+			),
 			("elixir", "defmodule App do\n  def run(x) do\n    x\n  end\nend\n"),
-			("erlang", "-module(app).\n-export([run/1]).\nrun(X) ->\n    case X of\n        ok -> ok;\n        _ -> error\n    end.\n"),
+			(
+				"erlang",
+				"-module(app).\n-export([run/1]).\nrun(X) ->\n    case X of\n        ok -> ok;\n        _ -> error\n    end.\n",
+			),
 			("go", "package main\nimport \"fmt\"\nfunc main() { fmt.Println(\"ok\") }\n"),
 			("graphql", "type Query { hello: String }\nquery AppQuery { hello }\n"),
 			("handlebars", "{{#if ready}}<div class=\"ok\">{{name}}</div>{{/if}}\n"),
@@ -1048,8 +1060,14 @@ mod tests {
 			("odin", "package main\nmain :: proc() {}\n"),
 			("perl", "package App;\nuse strict;\nsub run { return 1; }\n"),
 			("php", "<?php\nclass App { function run() {} }\n"),
-			("powershell", "param([string]$Name)\nfunction Invoke-App { Write-Host $Name }\nInvoke-App\n"),
-			("protobuf", "syntax = \"proto3\";\nmessage App { string name = 1; }\nservice Api { rpc Run (App) returns (App); }\n"),
+			(
+				"powershell",
+				"param([string]$Name)\nfunction Invoke-App { Write-Host $Name }\nInvoke-App\n",
+			),
+			(
+				"protobuf",
+				"syntax = \"proto3\";\nmessage App { string name = 1; }\nservice Api { rpc Run (App) returns (App); }\n",
+			),
 			("python", "class App:\n    def run(self):\n        return 1\n"),
 			("r", "run <- function(x) { x + 1 }\nvalue <- run(1)\n"),
 			("regex", "[a-z]+"),
@@ -1069,7 +1087,10 @@ mod tests {
 			("tsx", "export function App() { return <div />; }\n"),
 			("typescript", "export function run(): void {}\n"),
 			("verilog", "module app; endmodule\n"),
-			("vue", "<template><div>{{ msg }}</div></template>\n<script setup>const msg = 'hi'</script>\n"),
+			(
+				"vue",
+				"<template><div>{{ msg }}</div></template>\n<script setup>const msg = 'hi'</script>\n",
+			),
 			("xml", "<root><item /></root>\n"),
 			("yaml", "apiVersion: v1\nmetadata:\n  name: app\n"),
 			("zig", "const std = @import(\"std\");\npub fn main() void {}\n"),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2026-03-27"
+channel = "nightly-2026-06-06"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]


### PR DESCRIPTION
Closes #1280

## Summary
- Update rust-toolchain.toml from nightly-2026-03-27 to nightly-2026-06-06 (fixes smallvec `#![feature]` error)
- Apply `cargo fmt` with nightly rustfmt (struct field alignment, vendored crate formatting)
- Inline collector registration in `ConcreteExtensionAPI` — `arr.push(collector)` cannot be turned into self-recursion by any bundler

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes  
- [x] `bun run check` passes (both check:ts and check:rs)
- [x] 321 internal-urls tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)