### PR TITLE
fix: discover extension entry points from marketplace-cached plugins

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -12,7 +12,7 @@ import type { TSchema } from "@sinclair/typebox";
 import * as TypeBox from "@sinclair/typebox";
 import { type ExtensionModule, extensionModuleCapability } from "../../capability/extension-module";
 import { loadCapability } from "../../discovery";
-import { getExtensionNameFromPath } from "../../discovery/helpers";
+import { getExtensionNameFromPath, getPreloadedPluginRoots } from "../../discovery/helpers";
 import type { ExecOptions } from "../../exec/exec";
 import { execCommand } from "../../exec/exec";
 import { PROFILE_COLLECTORS, type ProfileCollector } from "../../internal-urls/profile-collectors";
@@ -515,8 +515,28 @@ export async function discoverAndLoadExtensions(
 		addPath(ext.path);
 	}
 
-	// 2. Discover extension entry points from installed plugins
+	// 2. Discover extension entry points from installed plugins (node_modules path)
 	addPaths(await getAllPluginExtensionPaths(cwd));
+
+	// 2b. Discover extension entry points from marketplace-cached plugins
+	for (const root of getPreloadedPluginRoots()) {
+		try {
+			const pkgPath = path.join(root.path, "package.json");
+			const pkg = await Bun.file(pkgPath).json();
+			const manifest = pkg?.xcsh ?? pkg?.pi;
+			const extensions = manifest?.extensions;
+			if (Array.isArray(extensions)) {
+				for (const entry of extensions) {
+					if (typeof entry !== "string") continue;
+					const resolved = path.join(root.path, entry);
+					if (isDisabledName(getExtensionNameFromPath(resolved))) continue;
+					addPath(resolved);
+				}
+			}
+		} catch {
+			// No package.json or invalid — skip
+		}
+	}
 
 	// 3. Explicitly configured paths
 	for (const configuredPath of configuredPaths) {

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -528,7 +528,9 @@ export async function discoverAndLoadExtensions(
 			if (Array.isArray(extensions)) {
 				for (const entry of extensions) {
 					if (typeof entry !== "string") continue;
-					const resolved = path.join(root.path, entry);
+					if (path.isAbsolute(entry) || entry.includes("..")) continue;
+					const resolved = path.resolve(root.path, entry);
+					if (!resolved.startsWith(root.path + path.sep) && resolved !== root.path) continue;
 					if (isDisabledName(getExtensionNameFromPath(resolved))) continue;
 					addPath(resolved);
 				}


### PR DESCRIPTION
Closes #1297

## Summary
- Scans `getPreloadedPluginRoots()` for `package.json` `xcsh.extensions` entries
- Marketplace-cached plugins now have their extension factories loaded alongside node_modules plugins
- This is the root cause of the Salesforce profile collector never registering at runtime

## Test plan
- [x] 321 tests pass
- [x] `bun run check` passes
- [ ] Start xcsh, verify salesforce plugin factory runs and collector registers

🤖 Generated with [Claude Code](https://claude.com/claude-code)