### PR TITLE
fix: deduplicate plugins in welcome screen service status vs recommended

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -387,7 +387,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			}
 		}
 
-		const recommendedPlugins = !startupQuiet ? await checkRecommendedPlugins().catch(() => []) : [];
+		const allRecommendedPlugins = !startupQuiet ? await checkRecommendedPlugins().catch(() => []) : [];
+		const pluginServiceNames = new Set(services.filter(s => s._isPlugin).map(s => s.name.toLowerCase()));
+		const recommendedPlugins = allRecommendedPlugins.filter(p => !pluginServiceNames.has(p.name.toLowerCase()));
 
 		if (!startupQuiet) {
 			this.#welcomeComponent = new WelcomeComponent(


### PR DESCRIPTION
Closes #1303

## Summary
- Filter recommended plugins that already have a service status registered under "Plugins"
- Prevents duplicate entries in the welcome screen for marketplace plugins that register both

## Test plan
- [x] 321 tests pass, `bun run check` passes
- [ ] Start xcsh, verify Salesforce appears only once in welcome screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)