### PR TITLE
feat: unify Plugins and Recommended Plugins into single welcome section

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -228,6 +228,95 @@ export interface RecommendedPluginStatus {
 	installed: boolean;
 }
 
+export type UnifiedPluginState = "connected" | "unauthenticated" | "unavailable" | "installed" | "not_installed";
+
+export interface UnifiedPluginStatus {
+	name: string;
+	state: UnifiedPluginState;
+	hint?: string;
+	group?: string;
+}
+
+export interface ServiceStatusContributionInput {
+	name: string;
+	group?: string;
+	check: () => Promise<{ state: ServiceState; hint?: string }>;
+}
+
+export async function buildUnifiedPluginList(
+	contributions: ServiceStatusContributionInput[],
+): Promise<UnifiedPluginStatus[]> {
+	const map = new Map<string, UnifiedPluginStatus>();
+
+	for (const contribution of contributions) {
+		try {
+			const status = await contribution.check();
+			map.set(contribution.name.toLowerCase(), {
+				name: contribution.name,
+				state: status.state,
+				hint: status.hint,
+				group: contribution.group,
+			});
+		} catch {
+			map.set(contribution.name.toLowerCase(), {
+				name: contribution.name,
+				state: "unavailable",
+				hint: "check failed",
+				group: contribution.group,
+			});
+		}
+	}
+
+	try {
+		const mgr = new MarketplaceManager({
+			marketplacesRegistryPath: getMarketplacesRegistryPath(),
+			installedRegistryPath: getInstalledPluginsRegistryPath(),
+			marketplacesCacheDir: getMarketplacesCacheDir(),
+			pluginsCacheDir: getPluginsCacheDir(),
+			clearPluginRootsCache: () => {},
+		});
+
+		const [marketplaces, installedSummaries] = await Promise.all([
+			mgr.listMarketplaces(),
+			mgr.listInstalledPlugins(),
+		]);
+
+		const installedIds = new Set(installedSummaries.map(s => s.id));
+
+		for (const mkt of marketplaces) {
+			const available = await mgr.listAvailablePlugins(mkt.name).catch(() => []);
+			for (const entry of available) {
+				if (!entry.recommended) continue;
+				const displayName = normalizePluginDisplayName(entry.name);
+				const key = displayName.toLowerCase();
+				if (map.has(key)) continue;
+				const pluginId = `${entry.name}@${mkt.name}`;
+				map.set(key, {
+					name: displayName,
+					state: installedIds.has(pluginId) ? "installed" : "not_installed",
+					hint: installedIds.has(pluginId) ? undefined : "run: /plugin setup",
+				});
+			}
+		}
+	} catch (err) {
+		logger.debug("buildUnifiedPluginList marketplace check failed", { error: String(err) });
+	}
+
+	const stateOrder: Record<UnifiedPluginState, number> = {
+		connected: 0,
+		unauthenticated: 1,
+		unavailable: 2,
+		installed: 3,
+		not_installed: 4,
+	};
+
+	return [...map.values()].sort((a, b) => {
+		const orderDiff = stateOrder[a.state] - stateOrder[b.state];
+		if (orderDiff !== 0) return orderDiff;
+		return a.name.localeCompare(b.name);
+	});
+}
+
 export async function checkRecommendedPlugins(): Promise<RecommendedPluginStatus[]> {
 	try {
 		const mgr = new MarketplaceManager({

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -2,7 +2,7 @@ import { type Component, padding, truncateToWidth, visibleWidth } from "@f5xc-sa
 import { APP_NAME } from "@f5xc-salesdemos/pi-utils";
 import { theme } from "../../modes/theme/theme";
 import { formatStatusIcon } from "../../services/f5xc-context-indicators";
-import type { ModelStatus, RecommendedPluginStatus, ServiceStatus } from "./welcome-checks";
+import type { ModelStatus, RecommendedPluginStatus, ServiceStatus, UnifiedPluginStatus } from "./welcome-checks";
 
 export interface UpdateStatus {
 	available: boolean;
@@ -15,7 +15,8 @@ export class WelcomeComponent implements Component {
 		private modelStatus: ModelStatus,
 		private services: ServiceStatus[] = [],
 		private updateStatus?: UpdateStatus,
-		private recommendedPlugins: RecommendedPluginStatus[] = [],
+		private _recommendedPlugins: RecommendedPluginStatus[] = [],
+		private plugins: UnifiedPluginStatus[] = [],
 	) {}
 	invalidate(): void {}
 	setModelStatus(status: ModelStatus): void {
@@ -28,7 +29,10 @@ export class WelcomeComponent implements Component {
 		this.updateStatus = status;
 	}
 	setRecommendedPlugins(plugins: RecommendedPluginStatus[]): void {
-		this.recommendedPlugins = plugins;
+		this._recommendedPlugins = plugins;
+	}
+	setPlugins(plugins: UnifiedPluginStatus[]): void {
+		this.plugins = plugins;
 	}
 
 	render(termWidth: number): string[] {
@@ -127,23 +131,13 @@ export class WelcomeComponent implements Component {
 	#measureStatusWidth(): number {
 		const lines: string[] = [" Model Provider", ...this.#renderModelStatus()];
 		const coreServices = this.services.filter(s => !s._isPlugin);
-		const pluginServices = this.services.filter(s => s._isPlugin);
 		for (const svc of coreServices) {
 			lines.push(this.#renderServiceLine(svc));
 		}
-		if (pluginServices.length > 0) {
-			const groups = this.#groupPluginServices(pluginServices);
-			for (const [groupName] of groups) {
-				lines.push(` ${groupName}`);
-			}
-			for (const svc of pluginServices) {
-				lines.push(this.#renderServiceLine(svc));
-			}
-		}
-		if (this.recommendedPlugins.length > 0) {
-			lines.push(" Recommended Plugins");
-			for (const p of this.recommendedPlugins) {
-				lines.push(this.#renderRecommendedLine(p));
+		if (this.plugins.length > 0) {
+			lines.push(" Plugins");
+			for (const p of this.plugins) {
+				lines.push(this.#renderUnifiedPluginLine(p));
 			}
 		}
 		if (this.#showUpdateSection()) {
@@ -152,15 +146,15 @@ export class WelcomeComponent implements Component {
 		return Math.max(...lines.map(l => visibleWidth(l)));
 	}
 
-	#groupPluginServices(plugins: ServiceStatus[]): Map<string, ServiceStatus[]> {
-		const groups = new Map<string, ServiceStatus[]>();
-		for (const svc of plugins) {
-			const groupName = svc._group ?? "Plugins";
-			const list = groups.get(groupName) ?? [];
-			list.push(svc);
-			groups.set(groupName, list);
+	#renderUnifiedPluginLine(plugin: UnifiedPluginStatus): string {
+		if (plugin.state === "connected" || plugin.state === "installed") {
+			return ` ${formatStatusIcon("connected")} ${theme.fg("muted", plugin.name)}`;
 		}
-		return groups;
+		if (plugin.state === "not_installed") {
+			return ` ${theme.fg("dim", "·")} ${theme.fg("dim", plugin.name)}`;
+		}
+		const hint = plugin.hint ?? "";
+		return ` ${formatStatusIcon("warning")} ${theme.fg("muted", plugin.name)}  ${theme.fg("dim", hint)}`;
 	}
 
 	#buildStatusLines(rightCol: number): string[] {
@@ -172,34 +166,19 @@ export class WelcomeComponent implements Component {
 		lines.push(...this.#renderModelStatus());
 		lines.push("");
 		const coreServices = this.services.filter(s => !s._isPlugin);
-		const pluginServices = this.services.filter(s => s._isPlugin);
-		const hasContent =
-			coreServices.length > 0 ||
-			pluginServices.length > 0 ||
-			this.recommendedPlugins.length > 0 ||
-			this.#showUpdateSection();
+		const hasContent = coreServices.length > 0 || this.plugins.length > 0 || this.#showUpdateSection();
 		if (hasContent) {
 			lines.push(separator);
 			for (const svc of coreServices) {
 				lines.push(this.#renderServiceLine(svc));
 			}
-			if (pluginServices.length > 0) {
-				const groups = this.#groupPluginServices(pluginServices);
-				for (const [groupName, groupServices] of groups) {
-					lines.push("");
-					lines.push(` ${theme.fg("dim", groupName)}`);
-					for (const svc of groupServices) {
-						lines.push(this.#renderServiceLine(svc));
-					}
-				}
-			}
-			if (this.recommendedPlugins.length > 0) {
+			if (this.plugins.length > 0) {
 				lines.push("");
-				lines.push(` ${theme.fg("dim", "Recommended Plugins")}`);
-				for (const p of this.recommendedPlugins) {
-					lines.push(this.#renderRecommendedLine(p));
+				lines.push(` ${theme.fg("dim", "Plugins")}`);
+				for (const p of this.plugins) {
+					lines.push(this.#renderUnifiedPluginLine(p));
 				}
-				const missing = this.recommendedPlugins.filter(p => !p.installed);
+				const missing = this.plugins.filter(p => p.state === "not_installed");
 				if (missing.length > 0) {
 					lines.push(`   ${theme.fg("dim", "run: /plugin setup")}`);
 				}
@@ -211,13 +190,6 @@ export class WelcomeComponent implements Component {
 		}
 		lines.push("");
 		return lines;
-	}
-
-	#renderRecommendedLine(plugin: RecommendedPluginStatus): string {
-		if (plugin.installed) {
-			return ` ${formatStatusIcon("connected")} ${theme.fg("muted", plugin.name)}`;
-		}
-		return ` ${theme.fg("dim", "·")} ${theme.fg("dim", plugin.name)}`;
 	}
 
 	#showUpdateSection(): boolean {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -53,7 +53,7 @@ import { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
 import { type UpdateStatus, WelcomeComponent } from "./components/welcome";
 import {
-	checkRecommendedPlugins,
+	buildUnifiedPluginList,
 	type FixableService,
 	mapContextStatus,
 	runWelcomeChecks,
@@ -340,56 +340,31 @@ export class InteractiveMode implements InteractiveModeContext {
 				? [mapContextStatus(welcomeResult.context ?? { state: "no_context" })]
 				: [];
 
-		// Collect service statuses from plugins
-		if (this.session.extensionRunner) {
-			const pluginContributions = this.session.extensionRunner.getAllRegisteredServiceStatuses();
-			for (const contribution of pluginContributions) {
-				try {
-					const status = await contribution.check();
-					services.push({ name: contribution.name, ...status, _isPlugin: true, _group: contribution.group });
-				} catch {
-					services.push({
+		// Build unified plugin list from service status contributions + marketplace
+		const pluginContributions = this.session.extensionRunner?.getAllRegisteredServiceStatuses() ?? [];
+		const plugins = !startupQuiet ? await buildUnifiedPluginList(pluginContributions).catch(() => []) : [];
+
+		const fixableServices: FixableService[] = [];
+		for (const contribution of pluginContributions) {
+			if (contribution.fix) {
+				const plugin = plugins.find(p => p.name.toLowerCase() === contribution.name.toLowerCase());
+				if (plugin && plugin.state === "unauthenticated") {
+					fixableServices.push({
 						name: contribution.name,
-						state: "unavailable",
-						hint: "check failed",
-						_isPlugin: true,
-						_group: contribution.group,
+						prompt: contribution.fix.prompt,
+						command: contribution.fix.command,
+						recheck: async () => {
+							try {
+								const result = await contribution.check();
+								return { name: contribution.name, ...result };
+							} catch {
+								return { name: contribution.name, state: "unavailable" as const, hint: "recheck failed" };
+							}
+						},
 					});
 				}
 			}
 		}
-
-		const fixableServices: FixableService[] = [];
-
-		// Add fixable services from plugins
-		if (this.session.extensionRunner) {
-			const pluginContributions = this.session.extensionRunner.getAllRegisteredServiceStatuses();
-			for (const contribution of pluginContributions) {
-				if (contribution.fix) {
-					// Find the status we already checked above
-					const status = services.find(s => s.name === contribution.name);
-					if (status && status.state === "unauthenticated") {
-						fixableServices.push({
-							name: contribution.name,
-							prompt: contribution.fix.prompt,
-							command: contribution.fix.command,
-							recheck: async () => {
-								try {
-									const result = await contribution.check();
-									return { name: contribution.name, ...result };
-								} catch {
-									return { name: contribution.name, state: "unavailable" as const, hint: "recheck failed" };
-								}
-							},
-						});
-					}
-				}
-			}
-		}
-
-		const allRecommendedPlugins = !startupQuiet ? await checkRecommendedPlugins().catch(() => []) : [];
-		const pluginServiceNames = new Set(services.filter(s => s._isPlugin).map(s => s.name.toLowerCase()));
-		const recommendedPlugins = allRecommendedPlugins.filter(p => !pluginServiceNames.has(p.name.toLowerCase()));
 
 		if (!startupQuiet) {
 			this.#welcomeComponent = new WelcomeComponent(
@@ -397,7 +372,8 @@ export class InteractiveMode implements InteractiveModeContext {
 				welcomeResult.model,
 				services,
 				this.#initialUpdateStatus,
-				recommendedPlugins,
+				[],
+				plugins,
 			);
 
 			// Setup UI layout

--- a/packages/coding-agent/test/welcome-component.test.ts
+++ b/packages/coding-agent/test/welcome-component.test.ts
@@ -247,13 +247,15 @@ describe("WelcomeComponent", () => {
 			expect(out).not.toContain("Plugins");
 		});
 
-		it("renders plugin services under Plugins header", () => {
-			const pluginService: ServiceStatus = {
-				name: "Salesforce",
-				state: "connected",
-				_isPlugin: true,
-			};
-			const c = new WelcomeComponent("15.15.0", model, [ctxConnected, pluginService]);
+		it("renders unified plugins under Plugins header", () => {
+			const c = new WelcomeComponent(
+				"15.15.0",
+				model,
+				[ctxConnected],
+				undefined,
+				[],
+				[{ name: "Salesforce", state: "connected" }],
+			);
 			const out = renderPlain(c).join("\n");
 			expect(out).toContain("F5 XC Context");
 			expect(out).toContain("Plugins");
@@ -268,50 +270,34 @@ describe("WelcomeComponent", () => {
 			expect(out).not.toContain("Plugins");
 		});
 
-		it("renders multiple groups", () => {
-			const salesforce: ServiceStatus = {
-				name: "Salesforce",
-				state: "connected",
-				_isPlugin: true,
-				_group: "Cloud CRM",
-			};
-			const azure: ServiceStatus = {
-				name: "Azure",
-				state: "connected",
-				_isPlugin: true,
-				_group: "Cloud Providers",
-			};
-			const c = new WelcomeComponent("15.15.0", model, [ctxConnected, salesforce, azure]);
+		it("renders all plugins in single Plugins section", () => {
+			const c = new WelcomeComponent(
+				"15.15.0",
+				model,
+				[ctxConnected],
+				undefined,
+				[],
+				[
+					{ name: "Salesforce", state: "connected" },
+					{ name: "Azure", state: "connected" },
+				],
+			);
 			const out = renderPlain(c).join("\n");
-			expect(out).toContain("Cloud CRM");
-			expect(out).toContain("Cloud Providers");
+			expect(out).toContain("Plugins");
 			expect(out).toContain("Salesforce");
 			expect(out).toContain("Azure");
+			expect(out).not.toContain("Recommended");
 		});
 
-		it("groups services with same _group together", () => {
-			const sf1: ServiceStatus = { name: "SF Accounts", state: "connected", _isPlugin: true, _group: "Salesforce" };
-			const sf2: ServiceStatus = {
-				name: "SF Opportunities",
-				state: "connected",
-				_isPlugin: true,
-				_group: "Salesforce",
-			};
-			const c = new WelcomeComponent("15.15.0", model, [sf1, sf2]);
-			const out = renderPlain(c);
-			const lines = out.filter(
-				l => l.includes("Salesforce") || l.includes("SF Accounts") || l.includes("SF Opportunities"),
+		it("defaults to Plugins header for unified section", () => {
+			const c = new WelcomeComponent(
+				"15.15.0",
+				model,
+				[],
+				undefined,
+				[],
+				[{ name: "MyPlugin", state: "connected" }],
 			);
-			expect(lines.length).toBeGreaterThanOrEqual(3);
-		});
-
-		it("defaults to Plugins group when _group is undefined", () => {
-			const noGroup: ServiceStatus = {
-				name: "MyPlugin",
-				state: "connected",
-				_isPlugin: true,
-			};
-			const c = new WelcomeComponent("15.15.0", model, [noGroup]);
 			const out = renderPlain(c).join("\n");
 			expect(out).toContain("Plugins");
 			expect(out).toContain("MyPlugin");

--- a/packages/coding-agent/test/welcome-health-checks.test.ts
+++ b/packages/coding-agent/test/welcome-health-checks.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { WelcomeComponent } from "@f5xc-salesdemos/xcsh/modes/components/welcome";
-import type { ModelStatus, ServiceStatus } from "@f5xc-salesdemos/xcsh/modes/components/welcome-checks";
+import type { ModelStatus, UnifiedPluginStatus } from "@f5xc-salesdemos/xcsh/modes/components/welcome-checks";
 import { initTheme } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
 
 function stripAnsi(str: string): string {
@@ -18,55 +18,38 @@ describe("plugin health check states", () => {
 	const model: ModelStatus = { state: "connected", provider: "litellm", latencyMs: 100 };
 
 	it("connected state renders correctly", () => {
-		const svc: ServiceStatus = { name: "TestPlugin", state: "connected", _isPlugin: true };
-		const c = new WelcomeComponent("15.15.0", model, [svc]);
+		const p: UnifiedPluginStatus = { name: "TestPlugin", state: "connected" };
+		const c = new WelcomeComponent("15.15.0", model, [], undefined, [], [p]);
 		const out = renderPlain(c);
 		const line = out.find(l => l.includes("TestPlugin"));
 		expect(line).toBeDefined();
-		expect(line).toContain("✅"); // checkmark emoji
+		expect(line).toContain("✅");
 		expect(line).not.toContain("hint");
 	});
 
 	it("unauthenticated state renders with hint", () => {
-		const svc: ServiceStatus = {
-			name: "Salesforce",
-			state: "unauthenticated",
-			hint: "run: /sf-login",
-			_isPlugin: true,
-		};
-		const c = new WelcomeComponent("15.15.0", model, [svc]);
+		const p: UnifiedPluginStatus = { name: "Salesforce", state: "unauthenticated", hint: "run: /sf-login" };
+		const c = new WelcomeComponent("15.15.0", model, [], undefined, [], [p]);
 		const out = renderPlain(c);
 		const line = out.find(l => l.includes("Salesforce"));
 		expect(line).toBeDefined();
-		expect(line).toContain("⚠️"); // warning emoji
+		expect(line).toContain("⚠️");
 		expect(line).toContain("run: /sf-login");
 	});
 
 	it("unavailable state renders appropriately", () => {
-		const svc: ServiceStatus = {
-			name: "BrokenPlugin",
-			state: "unavailable",
-			hint: "service down",
-			_isPlugin: true,
-		};
-		const c = new WelcomeComponent("15.15.0", model, [svc]);
+		const p: UnifiedPluginStatus = { name: "BrokenPlugin", state: "unavailable", hint: "service down" };
+		const c = new WelcomeComponent("15.15.0", model, [], undefined, [], [p]);
 		const out = renderPlain(c);
 		const line = out.find(l => l.includes("BrokenPlugin"));
 		expect(line).toBeDefined();
-		expect(line).toContain("⚠️"); // warning emoji
+		expect(line).toContain("⚠️");
 		expect(line).toContain("service down");
 	});
 
 	it("check() that throws returns unavailable", () => {
-		// This test simulates what interactive-mode.ts does when check() throws:
-		// it catches and creates a ServiceStatus with state: unavailable
-		const svc: ServiceStatus = {
-			name: "FailingPlugin",
-			state: "unavailable",
-			hint: "check failed",
-			_isPlugin: true,
-		};
-		const c = new WelcomeComponent("15.15.0", model, [svc]);
+		const p: UnifiedPluginStatus = { name: "FailingPlugin", state: "unavailable", hint: "check failed" };
+		const c = new WelcomeComponent("15.15.0", model, [], undefined, [], [p]);
 		const out = renderPlain(c);
 		const line = out.find(l => l.includes("FailingPlugin"));
 		expect(line).toBeDefined();
@@ -74,20 +57,12 @@ describe("plugin health check states", () => {
 	});
 
 	it("mixed states render correctly per service", () => {
-		const connected: ServiceStatus = { name: "HealthyPlugin", state: "connected", _isPlugin: true };
-		const unauth: ServiceStatus = {
-			name: "AuthNeeded",
-			state: "unauthenticated",
-			hint: "login required",
-			_isPlugin: true,
-		};
-		const unavail: ServiceStatus = {
-			name: "DownPlugin",
-			state: "unavailable",
-			hint: "unreachable",
-			_isPlugin: true,
-		};
-		const c = new WelcomeComponent("15.15.0", model, [connected, unauth, unavail]);
+		const plugins: UnifiedPluginStatus[] = [
+			{ name: "HealthyPlugin", state: "connected" },
+			{ name: "AuthNeeded", state: "unauthenticated", hint: "login required" },
+			{ name: "DownPlugin", state: "unavailable", hint: "unreachable" },
+		];
+		const c = new WelcomeComponent("15.15.0", model, [], undefined, [], plugins);
 		const out = renderPlain(c);
 
 		const healthyLine = out.find(l => l.includes("HealthyPlugin"));
@@ -103,24 +78,17 @@ describe("plugin health check states", () => {
 	});
 
 	it("no plugins means no Plugins section", () => {
-		const coreService: ServiceStatus = { name: "F5 XC Context", state: "connected" };
-		const c = new WelcomeComponent("15.15.0", model, [coreService]);
+		const c = new WelcomeComponent("15.15.0", model, [{ name: "F5 XC Context", state: "connected" }]);
 		const out = renderPlain(c).join("\n");
 		expect(out).toContain("F5 XC Context");
 		expect(out).not.toContain("Plugins");
 	});
 
-	it("plugin with custom group renders under that group header", () => {
-		const svc: ServiceStatus = {
-			name: "SalesforceAccounts",
-			state: "connected",
-			_isPlugin: true,
-			_group: "CRM Tools",
-		};
-		const c = new WelcomeComponent("15.15.0", model, [svc]);
+	it("plugin with custom group still renders under Plugins header", () => {
+		const p: UnifiedPluginStatus = { name: "SalesforceAccounts", state: "connected", group: "CRM Tools" };
+		const c = new WelcomeComponent("15.15.0", model, [], undefined, [], [p]);
 		const out = renderPlain(c).join("\n");
-		expect(out).toContain("CRM Tools");
+		expect(out).toContain("Plugins");
 		expect(out).toContain("SalesforceAccounts");
-		expect(out).not.toContain("Plugins");
 	});
 });

--- a/packages/coding-agent/test/welcome-recommended-plugins.test.ts
+++ b/packages/coding-agent/test/welcome-recommended-plugins.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { WelcomeComponent } from "@f5xc-salesdemos/xcsh/modes/components/welcome";
-import type { RecommendedPluginStatus } from "@f5xc-salesdemos/xcsh/modes/components/welcome-checks";
+import type { UnifiedPluginStatus } from "@f5xc-salesdemos/xcsh/modes/components/welcome-checks";
 import { initTheme } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
 
 beforeAll(async () => {
@@ -9,67 +9,81 @@ beforeAll(async () => {
 
 const MODEL_CONNECTED = { state: "connected" as const, provider: "anthropic" };
 
-describe("WelcomeComponent recommended plugins", () => {
-	it("renders recommended plugins section when plugins are provided", () => {
-		const plugins: RecommendedPluginStatus[] = [
-			{ name: "github-ops", installed: true },
-			{ name: "platform", installed: false },
-			{ name: "brand", installed: true },
+describe("WelcomeComponent unified plugins section", () => {
+	it("renders a single Plugins section", () => {
+		const plugins: UnifiedPluginStatus[] = [
+			{ name: "Salesforce", state: "connected" },
+			{ name: "github", state: "installed" },
+			{ name: "platform", state: "not_installed", hint: "run: /plugin setup" },
 		];
 
-		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, plugins);
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, [], plugins);
 		const lines = component.render(120);
 		const raw = lines.join("\n");
 
-		expect(raw).toContain("Recommended Plugins");
-		expect(raw).toContain("github-ops");
-		expect(raw).toContain("platform");
-		expect(raw).toContain("brand");
-	});
-
-	it("shows /plugin setup hint when some plugins are missing", () => {
-		const plugins: RecommendedPluginStatus[] = [
-			{ name: "github-ops", installed: true },
-			{ name: "platform", installed: false },
-		];
-
-		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, plugins);
-		const lines = component.render(120);
-		const raw = lines.join("\n");
-
-		expect(raw).toContain("/plugin setup");
-	});
-
-	it("does not show /plugin setup hint when all plugins are installed", () => {
-		const plugins: RecommendedPluginStatus[] = [
-			{ name: "github-ops", installed: true },
-			{ name: "platform", installed: true },
-		];
-
-		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, plugins);
-		const lines = component.render(120);
-		const raw = lines.join("\n");
-
-		expect(raw).toContain("Recommended Plugins");
-		expect(raw).not.toContain("/plugin setup");
-	});
-
-	it("does not render recommended section when list is empty", () => {
-		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, []);
-		const lines = component.render(120);
-		const raw = lines.join("\n");
-
+		expect(raw).toContain("Plugins");
 		expect(raw).not.toContain("Recommended Plugins");
+		expect(raw).toContain("Salesforce");
+		expect(raw).toContain("github");
+		expect(raw).toContain("platform");
 	});
 
-	it("setRecommendedPlugins updates the rendered output", () => {
+	it("shows /plugin setup hint when some plugins are not installed", () => {
+		const plugins: UnifiedPluginStatus[] = [
+			{ name: "github", state: "installed" },
+			{ name: "platform", state: "not_installed", hint: "run: /plugin setup" },
+		];
+
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, [], plugins);
+		const lines = component.render(120);
+		const raw = lines.join("\n");
+
+		expect(raw).toContain("/plugin");
+	});
+
+	it("does not show /plugin setup hint when all plugins are installed or connected", () => {
+		const plugins: UnifiedPluginStatus[] = [
+			{ name: "Salesforce", state: "connected" },
+			{ name: "github", state: "installed" },
+		];
+
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, [], plugins);
+		const lines = component.render(120);
+		const raw = lines.join("\n");
+
+		expect(raw).toContain("Plugins");
+		expect(raw).not.toContain("/plugin");
+	});
+
+	it("does not render plugins section when list is empty", () => {
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, [], []);
+		const lines = component.render(120);
+		const raw = lines.join("\n");
+
+		expect(raw).not.toContain("Plugins");
+	});
+
+	it("setPlugins updates the rendered output", () => {
 		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED);
 		let lines = component.render(120);
-		expect(lines.join("\n")).not.toContain("Recommended Plugins");
+		expect(lines.join("\n")).not.toContain("Plugins");
 
-		component.setRecommendedPlugins([{ name: "firecrawl", installed: false }]);
+		component.setPlugins([{ name: "firecrawl", state: "not_installed", hint: "run: /plugin setup" }]);
 		lines = component.render(120);
-		expect(lines.join("\n")).toContain("Recommended Plugins");
+		expect(lines.join("\n")).toContain("Plugins");
 		expect(lines.join("\n")).toContain("firecrawl");
+	});
+
+	it("renders unauthenticated plugins with warning hint", () => {
+		const plugins: UnifiedPluginStatus[] = [
+			{ name: "Salesforce", state: "unauthenticated", hint: "run: /salesforce:setup" },
+		];
+
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, [], plugins);
+		const lines = component.render(120);
+		const raw = lines.join("\n");
+
+		expect(raw).toContain("Salesforce");
+		expect(raw).toContain("/salesforce:setup");
 	});
 });


### PR DESCRIPTION
Closes #1308

## Summary
- Single "Plugins" section replaces both "Plugins" and "Recommended Plugins"
- `UnifiedPluginStatus` with 5 states: connected, unauthenticated, unavailable, installed, not_installed
- `buildUnifiedPluginList()` merges service status contributions with marketplace recommended plugins
- No duplicate entries — each plugin appears exactly once with its functional status

## Test plan
- [x] 70 welcome-related tests pass
- [x] `bun run check` passes
- [ ] Start xcsh, verify single "Plugins" section with status icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)