### PR TITLE
docs: add multilingual readme in 12 languages

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -1,0 +1,29 @@
+🌐 [English](README.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [简体中文](README.zh-cn.md) | [繁體中文](README.zh-tw.md) | [Español](README.es.md) | [Português](README.pt-br.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Italiano](README.it.md) | **العربية** | [हिन्दी](README.hi.md) | [ไทย](README.th.md)
+
+# xcsh
+
+[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5xc-salesdemos/xcsh)](LICENSE)
+
+بيئة تطوير وأداة سطر أوامر مدعومة بالذكاء الاصطناعي
+
+## التوثيق
+
+التوثيق الكامل متاح على **[https://f5xc-salesdemos.github.io/xcsh/](https://f5xc-salesdemos.github.io/xcsh/)**.
+
+## البدء
+
+```bash
+git clone https://github.com/f5xc-salesdemos/xcsh.git
+```
+
+راجع [التوثيق](https://f5xc-salesdemos.github.io/xcsh/) لأدلة الإعداد والاستخدام التفصيلية.
+
+## المساهمة
+
+راجع [CONTRIBUTING.md](CONTRIBUTING.md) لقواعد سير العمل وتسمية الفروع ومتطلبات CI.
+
+## الرخصة
+
+راجع [LICENSE](LICENSE).

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,30 @@
+🌐 [English](README.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [简体中文](README.zh-cn.md) | [繁體中文](README.zh-tw.md) | [Español](README.es.md) | [Português](README.pt-br.md) | [Français](README.fr.md) | **Deutsch** | [Italiano](README.it.md) | [العربية](README.ar.md) | [हिन्दी](README.hi.md) | [ไทย](README.th.md)
+
+# xcsh
+
+[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5xc-salesdemos/xcsh)](LICENSE)
+
+KI-gestuetzte Entwicklungsumgebung und CLI-Werkzeug
+
+## Dokumentation
+
+Die vollstaendige Dokumentation ist verfuegbar unter **[https://f5xc-salesdemos.github.io/xcsh/](https://f5xc-salesdemos.github.io/xcsh/)**.
+
+## Erste Schritte
+
+```bash
+git clone https://github.com/f5xc-salesdemos/xcsh.git
+```
+
+Siehe die [Dokumentation](https://f5xc-salesdemos.github.io/xcsh/) fuer detaillierte Einrichtungs- und Nutzungsanleitungen.
+
+## Mitwirken
+
+Siehe [CONTRIBUTING.md](CONTRIBUTING.md) fuer Workflow-Regeln,
+Branch-Namenskonventionen und CI-Anforderungen.
+
+## Lizenz
+
+Siehe [LICENSE](LICENSE).

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,29 @@
+🌐 [English](README.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [简体中文](README.zh-cn.md) | [繁體中文](README.zh-tw.md) | **Español** | [Português](README.pt-br.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Italiano](README.it.md) | [العربية](README.ar.md) | [हिन्दी](README.hi.md) | [ไทย](README.th.md)
+
+# xcsh
+
+[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5xc-salesdemos/xcsh)](LICENSE)
+
+Entorno de desarrollo y herramienta CLI impulsados por IA
+
+## Documentación
+
+La documentación completa está disponible en **[https://f5xc-salesdemos.github.io/xcsh/](https://f5xc-salesdemos.github.io/xcsh/)**.
+
+## Primeros pasos
+
+```bash
+git clone https://github.com/f5xc-salesdemos/xcsh.git
+```
+
+Consulte la [documentación](https://f5xc-salesdemos.github.io/xcsh/) para guías detalladas de configuración y uso.
+
+## Contribuciones
+
+Consulte [CONTRIBUTING.md](CONTRIBUTING.md) para las reglas de flujo de trabajo, convenciones de nomenclatura de ramas y requisitos de CI.
+
+## Licencia
+
+Consulte [LICENSE](LICENSE).

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,30 @@
+🌐 [English](README.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [简体中文](README.zh-cn.md) | [繁體中文](README.zh-tw.md) | [Español](README.es.md) | [Português](README.pt-br.md) | **Français** | [Deutsch](README.de.md) | [Italiano](README.it.md) | [العربية](README.ar.md) | [हिन्दी](README.hi.md) | [ไทย](README.th.md)
+
+# xcsh
+
+[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5xc-salesdemos/xcsh)](LICENSE)
+
+Environnement de developpement et outil CLI propulses par l'IA
+
+## Documentation
+
+La documentation complete est disponible sur **[https://f5xc-salesdemos.github.io/xcsh/](https://f5xc-salesdemos.github.io/xcsh/)**.
+
+## Pour commencer
+
+```bash
+git clone https://github.com/f5xc-salesdemos/xcsh.git
+```
+
+Consultez la [documentation](https://f5xc-salesdemos.github.io/xcsh/) pour les guides detailles d'installation et d'utilisation.
+
+## Contribution
+
+Consultez [CONTRIBUTING.md](CONTRIBUTING.md) pour les regles de workflow,
+les conventions de nommage des branches et les exigences CI.
+
+## Licence
+
+Consultez [LICENSE](LICENSE).

--- a/README.hi.md
+++ b/README.hi.md
@@ -1,0 +1,29 @@
+🌐 [English](README.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [简体中文](README.zh-cn.md) | [繁體中文](README.zh-tw.md) | [Español](README.es.md) | [Português](README.pt-br.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Italiano](README.it.md) | [العربية](README.ar.md) | **हिन्दी** | [ไทย](README.th.md)
+
+# xcsh
+
+[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5xc-salesdemos/xcsh)](LICENSE)
+
+AI-संचालित विकास वातावरण और CLI टूल
+
+## दस्तावेज़ीकरण
+
+पूर्ण दस्तावेज़ीकरण **[https://f5xc-salesdemos.github.io/xcsh/](https://f5xc-salesdemos.github.io/xcsh/)** पर उपलब्ध है।
+
+## शुरू करें
+
+```bash
+git clone https://github.com/f5xc-salesdemos/xcsh.git
+```
+
+विस्तृत सेटअप और उपयोग गाइड के लिए [दस्तावेज़ीकरण](https://f5xc-salesdemos.github.io/xcsh/) देखें।
+
+## योगदान
+
+वर्कफ़्लो नियमों, ब्रांच नामकरण, और CI आवश्यकताओं के लिए [CONTRIBUTING.md](CONTRIBUTING.md) देखें।
+
+## लाइसेंस
+
+[LICENSE](LICENSE) देखें।

--- a/README.it.md
+++ b/README.it.md
@@ -1,0 +1,30 @@
+🌐 [English](README.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [简体中文](README.zh-cn.md) | [繁體中文](README.zh-tw.md) | [Español](README.es.md) | [Português](README.pt-br.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | **Italiano** | [العربية](README.ar.md) | [हिन्दी](README.hi.md) | [ไทย](README.th.md)
+
+# xcsh
+
+[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5xc-salesdemos/xcsh)](LICENSE)
+
+Ambiente di sviluppo e strumento CLI basati sull'intelligenza artificiale
+
+## Documentazione
+
+La documentazione completa e disponibile su **[https://f5xc-salesdemos.github.io/xcsh/](https://f5xc-salesdemos.github.io/xcsh/)**.
+
+## Per iniziare
+
+```bash
+git clone https://github.com/f5xc-salesdemos/xcsh.git
+```
+
+Consulta la [documentazione](https://f5xc-salesdemos.github.io/xcsh/) per le guide dettagliate di installazione e utilizzo.
+
+## Contribuire
+
+Consulta [CONTRIBUTING.md](CONTRIBUTING.md) per le regole sul workflow,
+le convenzioni di denominazione dei branch e i requisiti CI.
+
+## Licenza
+
+Consulta [LICENSE](LICENSE).

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,29 @@
+🌐 [English](README.md) | **日本語** | [한국어](README.ko.md) | [简体中文](README.zh-cn.md) | [繁體中文](README.zh-tw.md) | [Español](README.es.md) | [Português](README.pt-br.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Italiano](README.it.md) | [العربية](README.ar.md) | [हिन्दी](README.hi.md) | [ไทย](README.th.md)
+
+# xcsh
+
+[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5xc-salesdemos/xcsh)](LICENSE)
+
+AI を活用した開発環境および CLI ツール
+
+## ドキュメント
+
+完全なドキュメントは **[https://f5xc-salesdemos.github.io/xcsh/](https://f5xc-salesdemos.github.io/xcsh/)** でご覧いただけます。
+
+## はじめに
+
+```bash
+git clone https://github.com/f5xc-salesdemos/xcsh.git
+```
+
+詳細なセットアップと使用ガイドは[ドキュメント](https://f5xc-salesdemos.github.io/xcsh/)をご覧ください。
+
+## コントリビューション
+
+ワークフロールール、ブランチ命名規則、CI 要件については [CONTRIBUTING.md](CONTRIBUTING.md) をご覧ください。
+
+## ライセンス
+
+[LICENSE](LICENSE) をご覧ください。

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,29 @@
+🌐 [English](README.md) | [日本語](README.ja.md) | **한국어** | [简体中文](README.zh-cn.md) | [繁體中文](README.zh-tw.md) | [Español](README.es.md) | [Português](README.pt-br.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Italiano](README.it.md) | [العربية](README.ar.md) | [हिन्दी](README.hi.md) | [ไทย](README.th.md)
+
+# xcsh
+
+[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5xc-salesdemos/xcsh)](LICENSE)
+
+AI 기반 개발 환경 및 CLI 도구
+
+## 문서
+
+전체 문서는 **[https://f5xc-salesdemos.github.io/xcsh/](https://f5xc-salesdemos.github.io/xcsh/)**에서 확인할 수 있습니다.
+
+## 시작하기
+
+```bash
+git clone https://github.com/f5xc-salesdemos/xcsh.git
+```
+
+자세한 설정 및 사용 가이드는 [문서](https://f5xc-salesdemos.github.io/xcsh/)를 참조하세요.
+
+## 기여
+
+워크플로 규칙, 브랜치 이름 규칙, CI 요구 사항은 [CONTRIBUTING.md](CONTRIBUTING.md)를 참조하세요.
+
+## 라이선스
+
+[LICENSE](LICENSE)를 참조하세요.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+🌐 English | [日本語](README.ja.md) | [한국어](README.ko.md) | [简体中文](README.zh-cn.md) | [繁體中文](README.zh-tw.md) | [Español](README.es.md) | [Português](README.pt-br.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Italiano](README.it.md) | [العربية](README.ar.md) | [हिन्दी](README.hi.md) | [ไทย](README.th.md)
+
 # xcsh
 
 [![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml)

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,0 +1,29 @@
+🌐 [English](README.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [简体中文](README.zh-cn.md) | [繁體中文](README.zh-tw.md) | [Español](README.es.md) | **Português** | [Français](README.fr.md) | [Deutsch](README.de.md) | [Italiano](README.it.md) | [العربية](README.ar.md) | [हिन्दी](README.hi.md) | [ไทย](README.th.md)
+
+# xcsh
+
+[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5xc-salesdemos/xcsh)](LICENSE)
+
+Ambiente de desenvolvimento e ferramenta CLI com tecnologia de IA
+
+## Documentação
+
+A documentação completa está disponível em **[https://f5xc-salesdemos.github.io/xcsh/](https://f5xc-salesdemos.github.io/xcsh/)**.
+
+## Primeiros passos
+
+```bash
+git clone https://github.com/f5xc-salesdemos/xcsh.git
+```
+
+Consulte a [documentação](https://f5xc-salesdemos.github.io/xcsh/) para guias detalhados de configuração e uso.
+
+## Contribuições
+
+Consulte [CONTRIBUTING.md](CONTRIBUTING.md) para regras de fluxo de trabalho, convenções de nomenclatura de branches e requisitos de CI.
+
+## Licença
+
+Consulte [LICENSE](LICENSE).

--- a/README.th.md
+++ b/README.th.md
@@ -1,0 +1,29 @@
+🌐 [English](README.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [简体中文](README.zh-cn.md) | [繁體中文](README.zh-tw.md) | [Español](README.es.md) | [Português](README.pt-br.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Italiano](README.it.md) | [العربية](README.ar.md) | [हिन्दी](README.hi.md) | **ไทย**
+
+# xcsh
+
+[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5xc-salesdemos/xcsh)](LICENSE)
+
+สภาพแวดล้อมการพัฒนาและเครื่องมือ CLI ที่ขับเคลื่อนด้วย AI
+
+## เอกสาร
+
+เอกสารฉบับเต็มมีให้ที่ **[https://f5xc-salesdemos.github.io/xcsh/](https://f5xc-salesdemos.github.io/xcsh/)**
+
+## เริ่มต้นใช้งาน
+
+```bash
+git clone https://github.com/f5xc-salesdemos/xcsh.git
+```
+
+ดู[เอกสาร](https://f5xc-salesdemos.github.io/xcsh/)สำหรับคู่มือการตั้งค่าและการใช้งานโดยละเอียด
+
+## การมีส่วนร่วม
+
+ดู [CONTRIBUTING.md](CONTRIBUTING.md) สำหรับกฎเวิร์กโฟลว์ การตั้งชื่อ branch และข้อกำหนด CI
+
+## สัญญาอนุญาต
+
+ดู [LICENSE](LICENSE)

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1,0 +1,29 @@
+🌐 [English](README.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | **简体中文** | [繁體中文](README.zh-tw.md) | [Español](README.es.md) | [Português](README.pt-br.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Italiano](README.it.md) | [العربية](README.ar.md) | [हिन्दी](README.hi.md) | [ไทย](README.th.md)
+
+# xcsh
+
+[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5xc-salesdemos/xcsh)](LICENSE)
+
+AI 驱动的开发环境和 CLI 工具
+
+## 文档
+
+完整文档请访问 **[https://f5xc-salesdemos.github.io/xcsh/](https://f5xc-salesdemos.github.io/xcsh/)**。
+
+## 快速开始
+
+```bash
+git clone https://github.com/f5xc-salesdemos/xcsh.git
+```
+
+详细的设置和使用指南请参阅[文档](https://f5xc-salesdemos.github.io/xcsh/)。
+
+## 贡献
+
+有关工作流规则、分支命名和 CI 要求，请参阅 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+## 许可证
+
+请参阅 [LICENSE](LICENSE)。

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -1,0 +1,29 @@
+🌐 [English](README.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [简体中文](README.zh-cn.md) | **繁體中文** | [Español](README.es.md) | [Português](README.pt-br.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Italiano](README.it.md) | [العربية](README.ar.md) | [हिन्दी](README.hi.md) | [ไทย](README.th.md)
+
+# xcsh
+
+[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/xcsh/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5xc-salesdemos/xcsh)](LICENSE)
+
+AI 驅動的開發環境與 CLI 工具
+
+## 文件
+
+完整文件請參閱 **[https://f5xc-salesdemos.github.io/xcsh/](https://f5xc-salesdemos.github.io/xcsh/)**。
+
+## 開始使用
+
+```bash
+git clone https://github.com/f5xc-salesdemos/xcsh.git
+```
+
+請參閱[文件](https://f5xc-salesdemos.github.io/xcsh/)以取得詳細的設定與使用指南。
+
+## 貢獻
+
+請參閱 [CONTRIBUTING.md](CONTRIBUTING.md) 了解工作流程規則、分支命名規範和 CI 要求。
+
+## 授權條款
+
+請參閱 [LICENSE](LICENSE)。


### PR DESCRIPTION
Closes #1312

## Summary
- Add language switcher bar to README.md
- Create 12 translated README files: ja, ko, zh-cn, zh-tw, es, pt-br, fr, de, it, ar, hi, th

🤖 Generated with [Claude Code](https://claude.com/claude-code)