### PR TITLE
fix: restore welcome screen live-update for plugin re-authentication

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -196,6 +196,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#eventBus?: EventBus;
 	#eventBusUnsubscribers: Array<() => void> = [];
 	#welcomeComponent?: WelcomeComponent;
+	#currentPlugins: import("./components/welcome-checks").UnifiedPluginStatus[] = [];
 
 	constructor(
 		session: AgentSession,
@@ -343,6 +344,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// Build unified plugin list from service status contributions + marketplace
 		const pluginContributions = this.session.extensionRunner?.getAllRegisteredServiceStatuses() ?? [];
 		const plugins = !startupQuiet ? await buildUnifiedPluginList(pluginContributions).catch(() => []) : [];
+		this.#currentPlugins = plugins;
 
 		const fixableServices: FixableService[] = [];
 		for (const contribution of pluginContributions) {
@@ -953,8 +955,17 @@ export class InteractiveMode implements InteractiveModeContext {
 			if (idx !== -1) {
 				currentServices[idx] = updated;
 				this.#welcomeComponent?.setServices([...currentServices]);
-				this.ui.requestRender();
 			}
+			const pluginIdx = this.#currentPlugins.findIndex(p => p.name.toLowerCase() === service.name.toLowerCase());
+			if (pluginIdx !== -1) {
+				this.#currentPlugins[pluginIdx] = {
+					...this.#currentPlugins[pluginIdx],
+					state: updated.state,
+					hint: updated.hint,
+				};
+				this.#welcomeComponent?.setPlugins([...this.#currentPlugins]);
+			}
+			this.ui.requestRender();
 		}
 	}
 


### PR DESCRIPTION
Closes #1321

## Summary
- Store `#currentPlugins` as mutable instance field so `#offerCredentialFixes` can update it
- After successful recheck, update matching entry in `#currentPlugins` and call `setPlugins()`
- Welcome screen now dynamically reflects status changes when a wizard renews auth

## Test plan
- [x] 70 welcome tests pass
- [x] `bun run check` passes
- [ ] Start xcsh with expired AWS SSO, run `/aws:setup`, verify welcome screen updates to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)