### PR TITLE
docs: link language switcher to rendered docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-🌐 English | [日本語](README.ja.md) | [한국어](README.ko.md) | [简体中文](README.zh-cn.md) | [繁體中文](README.zh-tw.md) | [Español](README.es.md) | [Português](README.pt-br.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Italiano](README.it.md) | [العربية](README.ar.md) | [हिन्दी](README.hi.md) | [ไทย](README.th.md)
+🌐 English | [日本語](https://f5xc-salesdemos.github.io/xcsh/ja/) | [한국어](https://f5xc-salesdemos.github.io/xcsh/ko/) | [简体中文](https://f5xc-salesdemos.github.io/xcsh/zh-cn/) | [繁體中文](https://f5xc-salesdemos.github.io/xcsh/zh-tw/) | [Español](https://f5xc-salesdemos.github.io/xcsh/es/) | [Português](https://f5xc-salesdemos.github.io/xcsh/pt-br/) | [Français](https://f5xc-salesdemos.github.io/xcsh/fr/) | [Deutsch](https://f5xc-salesdemos.github.io/xcsh/de/) | [Italiano](https://f5xc-salesdemos.github.io/xcsh/it/) | [العربية](https://f5xc-salesdemos.github.io/xcsh/ar/) | [हिन्दी](https://f5xc-salesdemos.github.io/xcsh/hi/) | [ไทย](https://f5xc-salesdemos.github.io/xcsh/th/)
 
 # xcsh
 


### PR DESCRIPTION
Closes #1328

## Summary
Language switcher links now point to the rendered Astro docs site (e.g., `f5xc-salesdemos.github.io/xcsh/ja/`) instead of GitHub source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)