### PR TITLE
fix: reset temperature to 1 when Anthropic thinking is enabled

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1436,6 +1436,9 @@ function buildParams(
 				params.output_config = { effort };
 			}
 		}
+		// Anthropic requires temperature=1 when thinking is enabled; override any
+		// caller-supplied value (e.g. temperature=0 set for deterministic non-interactive mode).
+		params.temperature = 1;
 	}
 
 	const metadataUserId = resolveAnthropicMetadataUserId(options?.metadata?.user_id, isOAuthToken);


### PR DESCRIPTION
## Summary

- `temperature=0` set in v19.26.0 for deterministic non-interactive mode caused 400 errors on all `claude-opus-4-x` calls — Anthropic API rejects `temperature != 1` when extended thinking is active
- Fix: in the Anthropic provider, after the thinking block is built, override `temperature = 1` to satisfy the API constraint
- `temperature=0` still applies correctly for non-thinking models (e.g. Sonnet, Haiku)

## Root cause

The temperature=0 override in `main.ts` is applied unconditionally before the provider sees it. The Anthropic provider then passes it straight through even when `thinking: { type: "adaptive" }` is set, causing `400 "temperature may only be set to 1 when thinking is enabled"`.

## Test plan
- [ ] xcsh `--print --no-session` with claude-opus-4-x (thinking) returns HCL without 400 error
- [ ] xcsh `--print --no-session` with non-thinking model still uses temperature=0
- [ ] CI passes

Closes #1361

🤖 Generated with [Claude Code](https://claude.com/claude-code)