### PR TITLE
refactor(coding-agent): remove dead welcome screen code (DRY cleanup)

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome-checks.ts
+++ b/packages/coding-agent/src/modes/components/welcome-checks.ts
@@ -223,11 +223,6 @@ export interface FixableService {
 	recheck: () => Promise<ServiceStatus>;
 }
 
-export interface RecommendedPluginStatus {
-	name: string;
-	installed: boolean;
-}
-
 export type UnifiedPluginState = "connected" | "unauthenticated" | "unavailable" | "installed" | "not_installed";
 
 export interface UnifiedPluginStatus {
@@ -315,41 +310,4 @@ export async function buildUnifiedPluginList(
 		if (orderDiff !== 0) return orderDiff;
 		return a.name.localeCompare(b.name);
 	});
-}
-
-export async function checkRecommendedPlugins(): Promise<RecommendedPluginStatus[]> {
-	try {
-		const mgr = new MarketplaceManager({
-			marketplacesRegistryPath: getMarketplacesRegistryPath(),
-			installedRegistryPath: getInstalledPluginsRegistryPath(),
-			marketplacesCacheDir: getMarketplacesCacheDir(),
-			pluginsCacheDir: getPluginsCacheDir(),
-			clearPluginRootsCache: () => {},
-		});
-
-		const [marketplaces, installedSummaries] = await Promise.all([
-			mgr.listMarketplaces(),
-			mgr.listInstalledPlugins(),
-		]);
-
-		const installedIds = new Set(installedSummaries.map(s => s.id));
-		const results: RecommendedPluginStatus[] = [];
-
-		for (const mkt of marketplaces) {
-			const available = await mgr.listAvailablePlugins(mkt.name).catch(() => []);
-			for (const entry of available) {
-				if (!entry.recommended) continue;
-				const pluginId = `${entry.name}@${mkt.name}`;
-				results.push({
-					name: normalizePluginDisplayName(entry.name),
-					installed: installedIds.has(pluginId),
-				});
-			}
-		}
-
-		return results.sort((a, b) => a.name.localeCompare(b.name));
-	} catch (err) {
-		logger.debug("checkRecommendedPlugins failed", { error: String(err) });
-		return [];
-	}
 }

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -2,7 +2,7 @@ import { type Component, padding, truncateToWidth, visibleWidth } from "@f5xc-sa
 import { APP_NAME, t } from "@f5xc-salesdemos/pi-utils";
 import { theme } from "../../modes/theme/theme";
 import { formatStatusIcon } from "../../services/f5xc-context-indicators";
-import type { ModelStatus, RecommendedPluginStatus, ServiceStatus, UnifiedPluginStatus } from "./welcome-checks";
+import type { ModelStatus, ServiceStatus, UnifiedPluginStatus } from "./welcome-checks";
 
 export interface UpdateStatus {
 	available: boolean;
@@ -15,7 +15,6 @@ export class WelcomeComponent implements Component {
 		private modelStatus: ModelStatus,
 		private services: ServiceStatus[] = [],
 		private updateStatus?: UpdateStatus,
-		private recommendedPlugins: RecommendedPluginStatus[] = [],
 		private plugins: UnifiedPluginStatus[] = [],
 	) {}
 	invalidate(): void {}
@@ -27,9 +26,6 @@ export class WelcomeComponent implements Component {
 	}
 	setUpdateStatus(status: UpdateStatus | undefined): void {
 		this.updateStatus = status;
-	}
-	setRecommendedPlugins(plugins: RecommendedPluginStatus[]): void {
-		this.recommendedPlugins = plugins;
 	}
 	setPlugins(plugins: UnifiedPluginStatus[]): void {
 		this.plugins = plugins;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -384,7 +384,6 @@ export class InteractiveMode implements InteractiveModeContext {
 				welcomeModelStatus,
 				services,
 				this.#initialUpdateStatus,
-				[],
 				plugins,
 			);
 

--- a/packages/coding-agent/test/welcome-component.test.ts
+++ b/packages/coding-agent/test/welcome-component.test.ts
@@ -252,14 +252,9 @@ describe("WelcomeComponent", () => {
 		});
 
 		it("renders unified plugins under Plugins header", () => {
-			const c = new WelcomeComponent(
-				"15.15.0",
-				model,
-				[ctxConnected],
-				undefined,
-				[],
-				[{ name: "Salesforce", state: "connected" }],
-			);
+			const c = new WelcomeComponent("15.15.0", model, [ctxConnected], undefined, [
+				{ name: "Salesforce", state: "connected" },
+			]);
 			const out = renderPlain(c).join("\n");
 			expect(out).toContain("F5 XC Context");
 			expect(out).toContain("Plugins");
@@ -275,17 +270,10 @@ describe("WelcomeComponent", () => {
 		});
 
 		it("renders all plugins in single Plugins section", () => {
-			const c = new WelcomeComponent(
-				"15.15.0",
-				model,
-				[ctxConnected],
-				undefined,
-				[],
-				[
-					{ name: "Salesforce", state: "connected" },
-					{ name: "Azure", state: "connected" },
-				],
-			);
+			const c = new WelcomeComponent("15.15.0", model, [ctxConnected], undefined, [
+				{ name: "Salesforce", state: "connected" },
+				{ name: "Azure", state: "connected" },
+			]);
 			const out = renderPlain(c).join("\n");
 			expect(out).toContain("Plugins");
 			expect(out).toContain("Salesforce");
@@ -294,14 +282,7 @@ describe("WelcomeComponent", () => {
 		});
 
 		it("defaults to Plugins header for unified section", () => {
-			const c = new WelcomeComponent(
-				"15.15.0",
-				model,
-				[],
-				undefined,
-				[],
-				[{ name: "MyPlugin", state: "connected" }],
-			);
+			const c = new WelcomeComponent("15.15.0", model, [], undefined, [{ name: "MyPlugin", state: "connected" }]);
 			const out = renderPlain(c).join("\n");
 			expect(out).toContain("Plugins");
 			expect(out).toContain("MyPlugin");

--- a/packages/coding-agent/test/welcome-health-checks.test.ts
+++ b/packages/coding-agent/test/welcome-health-checks.test.ts
@@ -23,7 +23,7 @@ describe("plugin health check states", () => {
 
 	it("connected state renders correctly", () => {
 		const p: UnifiedPluginStatus = { name: "TestPlugin", state: "connected" };
-		const c = new WelcomeComponent("15.15.0", model, [], undefined, [], [p]);
+		const c = new WelcomeComponent("15.15.0", model, [], undefined, [p]);
 		const out = renderPlain(c);
 		const line = out.find(l => l.includes("TestPlugin"));
 		expect(line).toBeDefined();
@@ -33,7 +33,7 @@ describe("plugin health check states", () => {
 
 	it("unauthenticated state renders with hint", () => {
 		const p: UnifiedPluginStatus = { name: "Salesforce", state: "unauthenticated", hint: "run: /sf-login" };
-		const c = new WelcomeComponent("15.15.0", model, [], undefined, [], [p]);
+		const c = new WelcomeComponent("15.15.0", model, [], undefined, [p]);
 		const out = renderPlain(c);
 		const line = out.find(l => l.includes("Salesforce"));
 		expect(line).toBeDefined();
@@ -43,7 +43,7 @@ describe("plugin health check states", () => {
 
 	it("unavailable state renders appropriately", () => {
 		const p: UnifiedPluginStatus = { name: "BrokenPlugin", state: "unavailable", hint: "service down" };
-		const c = new WelcomeComponent("15.15.0", model, [], undefined, [], [p]);
+		const c = new WelcomeComponent("15.15.0", model, [], undefined, [p]);
 		const out = renderPlain(c);
 		const line = out.find(l => l.includes("BrokenPlugin"));
 		expect(line).toBeDefined();
@@ -53,7 +53,7 @@ describe("plugin health check states", () => {
 
 	it("check() that throws returns unavailable", () => {
 		const p: UnifiedPluginStatus = { name: "FailingPlugin", state: "unavailable", hint: "check failed" };
-		const c = new WelcomeComponent("15.15.0", model, [], undefined, [], [p]);
+		const c = new WelcomeComponent("15.15.0", model, [], undefined, [p]);
 		const out = renderPlain(c);
 		const line = out.find(l => l.includes("FailingPlugin"));
 		expect(line).toBeDefined();
@@ -66,7 +66,7 @@ describe("plugin health check states", () => {
 			{ name: "AuthNeeded", state: "unauthenticated", hint: "login required" },
 			{ name: "DownPlugin", state: "unavailable", hint: "unreachable" },
 		];
-		const c = new WelcomeComponent("15.15.0", model, [], undefined, [], plugins);
+		const c = new WelcomeComponent("15.15.0", model, [], undefined, plugins);
 		const out = renderPlain(c);
 
 		const healthyLine = out.find(l => l.includes("HealthyPlugin"));
@@ -90,7 +90,7 @@ describe("plugin health check states", () => {
 
 	it("plugin with custom group still renders under Plugins header", () => {
 		const p: UnifiedPluginStatus = { name: "SalesforceAccounts", state: "connected", group: "CRM Tools" };
-		const c = new WelcomeComponent("15.15.0", model, [], undefined, [], [p]);
+		const c = new WelcomeComponent("15.15.0", model, [], undefined, [p]);
 		const out = renderPlain(c).join("\n");
 		expect(out).toContain("Plugins");
 		expect(out).toContain("SalesforceAccounts");

--- a/packages/coding-agent/test/welcome-recommended-plugins.test.ts
+++ b/packages/coding-agent/test/welcome-recommended-plugins.test.ts
@@ -21,7 +21,7 @@ describe("WelcomeComponent unified plugins section", () => {
 			{ name: "platform", state: "not_installed", hint: "run: /plugin setup" },
 		];
 
-		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, [], plugins);
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, plugins);
 		const lines = component.render(120);
 		const raw = lines.join("\n");
 
@@ -38,7 +38,7 @@ describe("WelcomeComponent unified plugins section", () => {
 			{ name: "platform", state: "not_installed", hint: "run: /plugin setup" },
 		];
 
-		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, [], plugins);
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, plugins);
 		const lines = component.render(120);
 		const raw = lines.join("\n");
 
@@ -51,7 +51,7 @@ describe("WelcomeComponent unified plugins section", () => {
 			{ name: "github", state: "installed" },
 		];
 
-		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, [], plugins);
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, plugins);
 		const lines = component.render(120);
 		const raw = lines.join("\n");
 
@@ -60,7 +60,7 @@ describe("WelcomeComponent unified plugins section", () => {
 	});
 
 	it("does not render plugins section when list is empty", () => {
-		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, [], []);
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, []);
 		const lines = component.render(120);
 		const raw = lines.join("\n");
 
@@ -83,7 +83,7 @@ describe("WelcomeComponent unified plugins section", () => {
 			{ name: "Salesforce", state: "unauthenticated", hint: "run: /salesforce:setup" },
 		];
 
-		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, [], plugins);
+		const component = new WelcomeComponent("19.2.0", MODEL_CONNECTED, [], undefined, plugins);
 		const lines = component.render(120);
 		const raw = lines.join("\n");
 


### PR DESCRIPTION
## Summary
- Delete unused `checkRecommendedPlugins()` function and `RecommendedPluginStatus` type from welcome-checks.ts
- Remove dead `recommendedPlugins` constructor param and setter from WelcomeComponent
- Update test files to match simplified constructor signature

Closes #1370

## Why
`buildUnifiedPluginList()` already handles everything `checkRecommendedPlugins()` did with richer output. The `recommendedPlugins` prop was never populated or rendered — only the `plugins` (UnifiedPluginStatus) prop is used. -86 lines of dead code removed.

## Test plan
- [x] `bun run check` passes (lint + types)
- [x] `grep -rn "checkRecommendedPlugins\|RecommendedPluginStatus" src/` returns zero hits
- [x] Constructor calls updated in all 3 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)