### PR TITLE
fix(tui): defer input handler until terminal queries settle

### DIFF
--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -134,7 +134,6 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	start(onInput: (data: string) => void, onResize: () => void): void {
-		this.#inputHandler = onInput;
 		this.#resizeHandler = onResize;
 
 		// Register for emergency cleanup
@@ -186,6 +185,13 @@ export class ProcessTerminal implements Terminal {
 		// Start periodic OSC 11 re-query for terminals without Mode 2031
 		// (Warp, Alacritty, WezTerm, iTerm2). Self-disables once Mode 2031 fires.
 		this.#startOsc11Poll();
+
+		// Defer activating the user input handler until terminal capability
+		// queries have settled. Without this, query responses (Kitty, DA1,
+		// OSC 11) race into the editor as typed text.
+		setTimeout(() => {
+			this.#inputHandler = onInput;
+		}, 50);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Defer activating the user input handler by 50ms after terminal start() so query responses (Kitty, OSC 11, DA1) are processed before user input is accepted.

Closes #1372

## Why
Terminal capability queries race responses into the editor as literal text (`^[[?0u^[]11;rgb:...^[[?64;...c`). The input handler was set BEFORE queries were sent, so responses passed straight through to the editor.

## Test plan
- [x] `bun run check` passes
- [x] `bun dev` starts without gibberish in editor
- [x] Keystrokes still work after the 50ms settling period

🤖 Generated with [Claude Code](https://claude.com/claude-code)