### PR TITLE
refactor: replace inline locale data with i18n-core imports

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -181,6 +181,7 @@
       "name": "@f5xc-salesdemos/pi-utils",
       "version": "19.28.1",
       "dependencies": {
+        "@f5xc-salesdemos/i18n-core": "^1.0.0",
         "beautiful-mermaid": "^1.1",
         "handlebars": "^4.7.9",
         "winston": "^3.19",
@@ -307,11 +308,23 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
+    "@f5xc-salesdemos/i18n-core": ["@f5xc-salesdemos/i18n-core@1.0.0", "", {}, "sha512-N/D+tnvaR6QgfLR7XlkMp+aoZsxIkQtPsEbPzFQXXEFdvq0Aj6A7Y1kxHxx4aDv6YRMYze1ZJDPIPzlIYy2w5g=="],
+
     "@f5xc-salesdemos/pi-agent-core": ["@f5xc-salesdemos/pi-agent-core@workspace:packages/agent"],
 
     "@f5xc-salesdemos/pi-ai": ["@f5xc-salesdemos/pi-ai@workspace:packages/ai"],
 
     "@f5xc-salesdemos/pi-natives": ["@f5xc-salesdemos/pi-natives@workspace:packages/natives"],
+
+    "@f5xc-salesdemos/pi-natives-darwin-arm64": ["@f5xc-salesdemos/pi-natives-darwin-arm64@19.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LsVAx+BU3mLvgQTp4RqnZP14801QS8u6hYBpUr7ivCfXgDgBQV/IHcMSDTmif43IJmg23qEqAywgI2eg6zm3Vg=="],
+
+    "@f5xc-salesdemos/pi-natives-darwin-x64": ["@f5xc-salesdemos/pi-natives-darwin-x64@19.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-CoA7QsjKkHYHsJ4gz9Ff4p4+LE2zQIn9bb6m4BdIX2hHE7v3cPMV6+tTI+BOQhKVZbrk1MM+kJDO2vJ5KNXXBQ=="],
+
+    "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": ["@f5xc-salesdemos/pi-natives-linux-arm64-gnu@19.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-kt+Wo9gzT/cvR25/44qP5xI6HOZ82ZUay2KNIagIQHG0+en+ff0ic+ttKVXE/e7AnvqsjNsGsS+RgPofVk4MZg=="],
+
+    "@f5xc-salesdemos/pi-natives-linux-x64-gnu": ["@f5xc-salesdemos/pi-natives-linux-x64-gnu@19.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-rYjeyUXDeXO2O+9y+G1wQbFfLJCXL3bAyTT99Y4xngXDZQ5EBq6IMR+1ko390OQnLQlZCDXoL+MkM5dQO0mivA=="],
+
+    "@f5xc-salesdemos/pi-natives-win32-x64-msvc": ["@f5xc-salesdemos/pi-natives-win32-x64-msvc@19.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-0KbQuRs/St8geyAmu55Pkhxz0hNdveYSaucF4hMdR+lm/emOs5Scs3IccsJtfkKT2MAk7bKKo3GBKjcXmrlFDQ=="],
 
     "@f5xc-salesdemos/pi-tui": ["@f5xc-salesdemos/pi-tui@workspace:packages/tui"],
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -31,6 +31,7 @@
 		"fmt": "biome format --write ."
 	},
 	"dependencies": {
+		"@f5xc-salesdemos/i18n-core": "^1.0.0",
 		"beautiful-mermaid": "^1.1",
 		"handlebars": "^4.7.9",
 		"winston": "^3.19",

--- a/packages/utils/src/i18n.ts
+++ b/packages/utils/src/i18n.ts
@@ -1,28 +1,15 @@
+import {
+	getLocaleDisplayName,
+	LOCALE_DISPLAY_NAMES,
+	mapToSupportedLocale,
+	normalizeLocale,
+} from "@f5xc-salesdemos/i18n-core";
 import { $pickenv } from "./env";
+
+export { getLocaleDisplayName, LOCALE_DISPLAY_NAMES, mapToSupportedLocale };
 
 type LocaleMap = Record<string, string>;
 type LocaleBundle = Record<string, LocaleMap>;
-
-export const LOCALE_DISPLAY_NAMES: Record<string, string> = {
-	ar: "Arabic",
-	de: "German",
-	en: "English",
-	es: "Spanish",
-	fr: "French",
-	hi: "Hindi",
-	it: "Italian",
-	ja: "Japanese",
-	ko: "Korean",
-	"pt-br": "Brazilian Portuguese",
-	th: "Thai",
-	"zh-cn": "Simplified Chinese",
-	"zh-tw": "Traditional Chinese",
-};
-
-export function getLocaleDisplayName(locale: string): string | undefined {
-	const normalized = locale.toLowerCase().replace(/_/g, "-").split(".")[0];
-	return LOCALE_DISPLAY_NAMES[normalized];
-}
 
 let currentLocale = "en";
 let bundles: LocaleBundle = {};
@@ -86,35 +73,6 @@ export function t(key: string, params?: Record<string, string | number>): string
 		const val = params[name];
 		return val !== undefined ? String(val) : match;
 	});
-}
-
-/**
- * Map an OS locale code (macOS AppleLanguages, Linux LANG) to a supported xcsh locale.
- * Handles Apple script subtags (zh-Hans, zh-Hant) and regional variants (pt-BR, en-US).
- * Returns undefined if no supported locale matches.
- */
-export function mapToSupportedLocale(osLocale: string): string | undefined {
-	const normalized = normalizeLocale(osLocale);
-
-	if (bundles[normalized]) return normalized;
-
-	// Apple uses zh-hans / zh-hant (script subtags) instead of zh-cn / zh-tw
-	if (normalized.startsWith("zh-hans")) return bundles["zh-cn"] ? "zh-cn" : undefined;
-	if (normalized.startsWith("zh-hant")) return bundles["zh-tw"] ? "zh-tw" : undefined;
-
-	// Try with region: pt-br, en-us, etc.
-	const withRegion = normalized.split("-").slice(0, 2).join("-");
-	if (bundles[withRegion]) return withRegion;
-
-	// Fall back to base language: pt-br → pt, en-us → en
-	const base = normalized.split("-")[0];
-	if (bundles[base]) return base;
-
-	return undefined;
-}
-
-function normalizeLocale(raw: string): string {
-	return raw.toLowerCase().replace(/_/g, "-").split(".")[0];
 }
 
 function parseSystemLocale(raw: string | undefined): string | undefined {


### PR DESCRIPTION
## Summary
- Import `LOCALE_DISPLAY_NAMES`, `getLocaleDisplayName`, `mapToSupportedLocale`, `normalizeLocale` from `@f5xc-salesdemos/i18n-core`
- Remove local implementations of these functions/constants
- Re-export for backwards compatibility
- Runtime functions (`t`, `setLocale`, `initI18n`, `registerLocales`) remain local

Closes #1384

## Test plan
- [ ] Run `bun test` in packages/utils
- [ ] Run `scripts/validate-i18n.ts` to verify key parity
- [ ] Run `autoresearch-i18n.sh` T1/T2 tests across all 13 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)