### PR TITLE
feat(tui): human-first XC-API response rendering with glyph status indicators

### DIFF
--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -666,3 +666,12 @@ export function addSection(
 		sections.push({ label: titled, lines });
 	}
 }
+
+export function humanizeResourceType(raw: string): string {
+	return raw
+		.replace(/^http_/, "")
+		.replace(/^tcp_/, "TCP ")
+		.replace(/_/g, " ")
+		.replace(/([a-z])(balancer|checker)/gi, "$1 $2")
+		.replace(/s$/, "");
+}

--- a/packages/coding-agent/src/tools/xcsh-api-renderer.ts
+++ b/packages/coding-agent/src/tools/xcsh-api-renderer.ts
@@ -8,6 +8,7 @@ import { CachedOutputBlock, F5_TOOL_BORDER_COLOR, renderStatusLine } from "../tu
 import {
 	formatErrorMessage,
 	formatTimestamp,
+	humanizeResourceType,
 	addSection as pushSection,
 	replaceTabs,
 	stripEmpty,
@@ -91,7 +92,15 @@ function splitResultContent(textContent: string, isError: boolean): { json?: str
 
 	if (!isError) {
 		const pretty = tryPrettyJson(body);
-		return pretty ? { json: pretty, raw: body } : { raw: body };
+		if (pretty) return { json: pretty, raw: body };
+		// Body may contain "compactJSON\n\nAI guidance text" — split and discard guidance for display
+		const split = body.indexOf("\n\n");
+		if (split >= 0) {
+			const jsonPart = body.slice(0, split);
+			const prettyPart = tryPrettyJson(jsonPart);
+			if (prettyPart) return { json: prettyPart, raw: body };
+		}
+		return { raw: body };
 	}
 
 	// Error: body is "compactJSON\n\nguidanceText"
@@ -263,15 +272,10 @@ export const xcshApiToolRenderer = {
 		const emptyList = Array.isArray(parsed?.items) && (parsed!.items as unknown[]).length === 0;
 
 		if ((emptyBody || emptyList) && !guidance) {
-			// Contextual success message based on HTTP method and response shape
-			let successMessage = emptyList ? "No items found." : "Empty response";
-			const rn = resourceName ? ` \u2018${resourceName}\u2019` : "";
-			if (!emptyList && status >= 200 && status < 300) {
-				if (method === "DELETE") successMessage = `Resource${rn} deleted successfully.`;
-				else if (method === "POST") successMessage = `Resource${rn} created successfully.`;
-				else if (method === "PUT" || method === "PATCH") successMessage = `Resource${rn} updated successfully.`;
+			if (emptyList) {
+				addSection("Response", [uiTheme.fg("dim", "No items found.")]);
 			}
-			addSection("Response", [uiTheme.fg("dim", successMessage)]);
+			// Empty mutation bodies ({}) are handled by the Result section below \u2014 no Response section needed
 		} else if (json && parsed) {
 			// Branch 1: List response with named items — compact summary
 			const items = parsed.items;
@@ -343,15 +347,40 @@ export const xcshApiToolRenderer = {
 			);
 		}
 
-		// Section 4: Error guidance (for HTTP error responses)
-		if (guidance) {
-			// Extract the API's specific error message from JSON body for prominent display
-			const guidanceLines: string[] = [];
-			const apiMessage =
-				parsed && typeof parsed.message === "string" ? stripProtobufPrefix(parsed.message) : undefined;
-			if (apiMessage) guidanceLines.push(uiTheme.fg("error", apiMessage));
-			guidanceLines.push(uiTheme.fg("warning", guidance));
-			addSection("Guidance", guidanceLines);
+		// Section: Result — human-readable glyph status at the bottom of the panel
+		{
+			const resultLines: string[] = [];
+			const successIcon = uiTheme.styledSymbol("status.success", "success");
+			const errorIcon = uiTheme.styledSymbol("status.error", "error");
+
+			if (isError) {
+				const apiMessage =
+					parsed && typeof parsed.message === "string" ? stripProtobufPrefix(parsed.message) : undefined;
+				const errorLabel = apiMessage ?? (status > 0 ? `Request failed (${status})` : "Request failed");
+				resultLines.push(`${errorIcon} ${uiTheme.fg("error", errorLabel)}`);
+				if (guidance) resultLines.push(`  ${uiTheme.fg("warning", `Try: ${guidance}`)}`);
+			} else if (details?.mutationVerb && details?.resourceLabel) {
+				resultLines.push(
+					`${successIcon} ${uiTheme.fg("success", `${details.mutationVerb} ${details.resourceLabel}`)}`,
+				);
+			} else if (method === "GET" && parsed) {
+				const items = parsed.items;
+				if (Array.isArray(items)) {
+					const rawType = pathParts.at(-1) ?? "items";
+					const typeLabel = humanizeResourceType(rawType);
+					const plural = items.length === 1 ? typeLabel : `${typeLabel}s`;
+					resultLines.push(`${successIcon} ${uiTheme.fg("success", `${items.length} ${plural}`)}`);
+				} else {
+					const rawType = pathParts.at(-2) ?? "";
+					const name = resourceName ?? "";
+					const label = rawType && name ? `${humanizeResourceType(rawType)} '${name}'` : displayPath;
+					resultLines.push(`${successIcon} ${uiTheme.fg("success", `Loaded ${label}`)}`);
+				}
+			} else if (status >= 200 && status < 300) {
+				resultLines.push(`${successIcon} ${uiTheme.fg("success", "OK")}`);
+			}
+
+			if (resultLines.length > 0) addSection("Result", resultLines);
 		}
 
 		// --- Render with CachedOutputBlock ---

--- a/packages/coding-agent/src/tools/xcsh-api.ts
+++ b/packages/coding-agent/src/tools/xcsh-api.ts
@@ -5,6 +5,7 @@ import { type Static, Type } from "@sinclair/typebox";
 import xcshApiDescription from "../prompts/tools/xcsh-api.md" with { type: "text" };
 import { type ContextEnv, createContextEnv } from "../services/context-env";
 import type { ToolSession } from ".";
+import { humanizeResourceType } from "./render-utils";
 
 // Namespace filtering driven by x-f5xc-namespace-profile from enriched API specs.
 
@@ -108,6 +109,10 @@ export interface XcshApiToolDetails {
 	batchTotalItems?: number;
 	/** The resolved JSON body string sent to the API (after $F5XC_* expansion). */
 	resolvedPayload?: string;
+	/** Human-readable verb for mutation results. */
+	mutationVerb?: "Created" | "Updated" | "Deleted";
+	/** Human-readable resource label, e.g. "load balancer 'rm-headers'". */
+	resourceLabel?: string;
 }
 
 type XcshApiResult = AgentToolResult<XcshApiToolDetails> & { isError?: boolean };
@@ -817,13 +822,6 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 				// Label changes help the model echo type names in its response (Finding 13).
 				// INTERACTION EFFECT: this change + TCP protocol label are synergistic (Finding 31).
 				const pathSegs = resolvedPath.split("/").filter(Boolean);
-				const humanizeResourceType = (raw: string): string =>
-					raw
-						.replace(/^http_/, "")
-						.replace(/^tcp_/, "TCP ")
-						.replace(/_/g, " ")
-						.replace(/([a-z])(balancer|checker)/gi, "$1 $2")
-						.replace(/s$/, "");
 				let resourceLabel: string;
 				if (params.method === "POST") {
 					const rawType = pathSegs.at(-1) ?? "";
@@ -835,6 +833,9 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 					const rawType = pathSegs.at(-2) ?? "";
 					resourceLabel = name && rawType ? `${humanizeResourceType(rawType)} ${name}` : resolvedPath;
 				}
+				detail.mutationVerb = verb as "Created" | "Updated" | "Deleted";
+				detail.resourceLabel = resourceLabel;
+
 				// POST returns the full resource; PUT/DELETE return {}.
 				// Only claim response contains the resource for POST to avoid misleading the model.
 				const resourceHint =

--- a/packages/coding-agent/test/tools/xcsh-api-renderer.test.ts
+++ b/packages/coding-agent/test/tools/xcsh-api-renderer.test.ts
@@ -88,7 +88,7 @@ describe("xcshApiToolRenderer.renderResult", () => {
 		expect(rendered).toContain("Something went wrong");
 	});
 
-	it("renders error with guidance section for HTTP error responses", async () => {
+	it("renders error with Result glyph and actionable hint", async () => {
 		const theme = await getThemeByName("xcsh-dark");
 		const result = {
 			content: [
@@ -111,7 +111,82 @@ describe("xcshApiToolRenderer.renderResult", () => {
 		});
 		const rendered = stripAnsi(component.render(120).join("\n"));
 		expect(rendered).toContain("404");
-		expect(rendered).toContain("Guidance");
-		expect(rendered).toContain("Resource not found");
+		expect(rendered).toContain("Result");
+		expect(rendered).toContain("not found");
+		expect(rendered).toContain("Try:");
+	});
+
+	it("renders mutation success with glyph and verb", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const result = {
+			content: [
+				{
+					type: "text",
+					text: "200 OK\n\n{}\n\nUpdated load balancer rm-headers successfully. No verification GET is needed.",
+				},
+			],
+			details: {
+				status: 200,
+				url: "https://api.example.com/api/config/namespaces/default/http_loadbalancers/rm-headers",
+				method: "PUT",
+				requestId: "test-put",
+				mutationVerb: "Updated" as const,
+				resourceLabel: "load balancer rm-headers",
+			},
+			isError: false,
+		};
+		const component = xcshApiToolRenderer.renderResult(result as any, { expanded: false, isPartial: false }, theme!, {
+			method: "PUT",
+			path: "/api/config/namespaces/default/http_loadbalancers/rm-headers",
+		});
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("Result");
+		expect(rendered).toContain("Updated load balancer rm-headers");
+		expect(rendered).not.toContain("No verification GET");
+		expect(rendered).not.toContain("{}");
+	});
+
+	it("renders GET single resource with glyph", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const result = {
+			content: [{ type: "text", text: '200 OK\n\n{"metadata":{"name":"my-lb","namespace":"default"},"spec":{}}' }],
+			details: {
+				status: 200,
+				url: "https://api.example.com/api/config/namespaces/default/http_loadbalancers/my-lb",
+				method: "GET",
+				requestId: "test-get",
+			},
+			isError: false,
+		};
+		const component = xcshApiToolRenderer.renderResult(result as any, { expanded: false, isPartial: false }, theme!, {
+			method: "GET",
+			path: "/api/config/namespaces/default/http_loadbalancers/my-lb",
+		});
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("Result");
+		expect(rendered).toContain("Loaded");
+		expect(rendered).toContain("my-lb");
+	});
+
+	it("renders GET list with item count in glyph", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const items = [{ name: "lb-1" }, { name: "lb-2" }, { name: "lb-3" }];
+		const result = {
+			content: [{ type: "text", text: `200 OK\n\n${JSON.stringify({ items })}` }],
+			details: {
+				status: 200,
+				url: "https://api.example.com/api/config/namespaces/default/http_loadbalancers",
+				method: "GET",
+				requestId: "test-list",
+			},
+			isError: false,
+		};
+		const component = xcshApiToolRenderer.renderResult(result as any, { expanded: false, isPartial: false }, theme!, {
+			method: "GET",
+			path: "/api/config/namespaces/default/http_loadbalancers",
+		});
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("Result");
+		expect(rendered).toContain("3");
 	});
 });


### PR DESCRIPTION
## Summary

- Replace machine-oriented XC-API TUI output with clean glyph-based Result section
- Mutations show `✔ Updated/Created/Deleted` with resource label — no raw `{}`, no AI guidance text
- GET responses show `✔ Loaded {resource}` or `✔ {count} {type}s`
- Errors show `✘ {message}` with `Try: {actionable hint}`
- Full colorized JSON output preserved — only the status messaging changed

## Test plan

- [x] 8/8 renderer tests pass (4 new tests added)
- [x] 5047 total tests pass, 0 failures
- [x] Type check clean
- [x] Lint clean
- [ ] Manual: PUT mutation shows `✔ Updated load balancer 'name'` with no `{}`
- [ ] Manual: GET shows `✔ Loaded` with resource label
- [ ] Manual: 404 shows `✘` with error and `Try:` hint

Closes #1386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>