### PR TITLE
fix(tui): refine Result section styling and add 400/422 error guidance

### DIFF
--- a/packages/coding-agent/src/tools/xcsh-api-renderer.ts
+++ b/packages/coding-agent/src/tools/xcsh-api-renderer.ts
@@ -350,34 +350,32 @@ export const xcshApiToolRenderer = {
 		// Section: Result — human-readable glyph status at the bottom of the panel
 		{
 			const resultLines: string[] = [];
-			const successIcon = uiTheme.styledSymbol("status.success", "success");
+			const infoIcon = uiTheme.styledSymbol("status.success", "chromeAccent");
 			const errorIcon = uiTheme.styledSymbol("status.error", "error");
 
 			if (isError) {
 				const apiMessage =
 					parsed && typeof parsed.message === "string" ? stripProtobufPrefix(parsed.message) : undefined;
 				const errorLabel = apiMessage ?? (status > 0 ? `Request failed (${status})` : "Request failed");
-				resultLines.push(`${errorIcon} ${uiTheme.fg("error", errorLabel)}`);
-				if (guidance) resultLines.push(`  ${uiTheme.fg("warning", `Try: ${guidance}`)}`);
+				resultLines.push(`${errorIcon} ${uiTheme.fg("warning", errorLabel)}`);
+				if (guidance) resultLines.push(`  ${uiTheme.fg("dim", `Try: ${guidance}`)}`);
 			} else if (details?.mutationVerb && details?.resourceLabel) {
-				resultLines.push(
-					`${successIcon} ${uiTheme.fg("success", `${details.mutationVerb} ${details.resourceLabel}`)}`,
-				);
+				resultLines.push(`${infoIcon} ${details.mutationVerb} ${details.resourceLabel}`);
 			} else if (method === "GET" && parsed) {
 				const items = parsed.items;
 				if (Array.isArray(items)) {
 					const rawType = pathParts.at(-1) ?? "items";
 					const typeLabel = humanizeResourceType(rawType);
 					const plural = items.length === 1 ? typeLabel : `${typeLabel}s`;
-					resultLines.push(`${successIcon} ${uiTheme.fg("success", `${items.length} ${plural}`)}`);
+					resultLines.push(`${infoIcon} ${items.length} ${plural}`);
 				} else {
 					const rawType = pathParts.at(-2) ?? "";
 					const name = resourceName ?? "";
 					const label = rawType && name ? `${humanizeResourceType(rawType)} '${name}'` : displayPath;
-					resultLines.push(`${successIcon} ${uiTheme.fg("success", `Loaded ${label}`)}`);
+					resultLines.push(`${infoIcon} Loaded ${label}`);
 				}
 			} else if (status >= 200 && status < 300) {
-				resultLines.push(`${successIcon} ${uiTheme.fg("success", "OK")}`);
+				resultLines.push(`${infoIcon} OK`);
 			}
 
 			if (resultLines.length > 0) addSection("Result", resultLines);

--- a/packages/coding-agent/src/tools/xcsh-api.ts
+++ b/packages/coding-agent/src/tools/xcsh-api.ts
@@ -643,6 +643,10 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 			}
 			case 409:
 				return `Resource already exists${ctxHint}. Use PUT to replace the existing resource, or DELETE it first before creating a new one.`;
+			case 400:
+				return `Bad request${ctxHint}. Check the payload for missing required fields or invalid values.`;
+			case 422:
+				return `Validation failed${ctxHint}. The request payload has field-level errors — check the message above.`;
 			case 429:
 				return `API rate limit exceeded${ctxHint}. Wait briefly and retry the request.`;
 			default:


### PR DESCRIPTION
## Summary

- Use subtle chromeAccent (blue) glyph with default text color for success results — less visually noisy than green
- Error text uses warning hue, Try: hints use dim — the glyph carries the status, text stays readable
- Add `statusGuidance` for 400 (Bad Request) and 422 (Validation) errors so they get actionable Try: hints

Follow-up to #1387.

Closes #1392

## Test plan

- [x] 8/8 renderer tests pass
- [x] 18/18 API tool tests pass
- [x] Visual UAT: success Result line shows blue ✔ with default text
- [ ] Visual UAT: error Result line shows red ✘ with amber text and dim hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>