### PR TITLE
fix(tui): prevent Kitty key events from leaking as editor text

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -439,6 +439,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		// Offer to fix expired cloud credentials before entering the main loop
 		if (fixableServices.length > 0) {
 			await this.#offerCredentialFixes(fixableServices, services);
+			// Clear any gibberish that accumulated in the editor during the
+			// stop/start cycles (Kitty protocol re-negotiation can leave
+			// raw escape sequences in the input buffer).
+			this.editor.setText("");
 		}
 
 		// Restore mode from session (e.g. plan mode on resume)

--- a/packages/tui/src/keys.ts
+++ b/packages/tui/src/keys.ts
@@ -367,6 +367,10 @@ function decodeKittyPrintable(data: string): string | undefined {
 export function extractPrintableText(data: string): string | undefined {
 	const kittyText = decodeKittyPrintable(data);
 	if (kittyText) return kittyText;
+	// Reject raw Kitty CSI-u sequences that decodeKittyPrintable didn't handle
+	// (e.g. release events arriving while protocol is in a transitional state).
+	// Without this, the fallback below would insert the escape sequence as text.
+	if (/^\x1b\[\d+(?:[;:]\d+)*u$/.test(data)) return undefined;
 	if (data.length === 0 || hasControlChars(data)) return undefined;
 	return data;
 }

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -136,4 +136,25 @@ describe("extractPrintableText", () => {
 	it("preserves Kitty CSI-u text-field decoding for supported modifiers", () => {
 		expect(extractPrintableText("\x1b[97;1;229u")).toBe("å");
 	});
+
+	it("rejects raw Kitty key press sequences (Ctrl+C)", () => {
+		expect(extractPrintableText("\x1b[99;5u")).toBeUndefined();
+	});
+
+	it("rejects raw Kitty key release sequences (Ctrl+C release)", () => {
+		expect(extractPrintableText("\x1b[99;5:3u")).toBeUndefined();
+	});
+
+	it("rejects Kitty key repeat sequences", () => {
+		expect(extractPrintableText("\x1b[99;5:2u")).toBeUndefined();
+	});
+
+	it("allows Kitty plain key events that produce printable text", () => {
+		expect(extractPrintableText("\x1b[97u")).toBe("a");
+	});
+
+	it("rejects Kitty release events with complex modifier+event format", () => {
+		expect(extractPrintableText("\x1b[99;5:3u")).toBeUndefined();
+		expect(extractPrintableText("\x1b[27;2:3u")).toBeUndefined();
+	});
 });

--- a/packages/tui/test/terminal-response-filter.test.ts
+++ b/packages/tui/test/terminal-response-filter.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { extractPrintableText } from "@f5xc-salesdemos/pi-tui/keys";
 import { ProcessTerminal } from "@f5xc-salesdemos/pi-tui/terminal";
 
 const stdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
@@ -388,6 +389,46 @@ describe("Terminal response filtering — no gibberish in editor", () => {
 			}
 
 			expect(received).toEqual([]);
+
+			terminal.stop();
+		});
+	});
+
+	describe("Kitty key events never become editor text (extractPrintableText guard)", () => {
+		it("Kitty Ctrl+C press is not printable text", () => {
+			expect(extractPrintableText("\x1b[99;5u")).toBeUndefined();
+		});
+
+		it("Kitty Ctrl+C release is not printable text", () => {
+			expect(extractPrintableText("\x1b[99;5:3u")).toBeUndefined();
+		});
+
+		it("Kitty modified/release key events are not printable text", () => {
+			expect(extractPrintableText("\x1b[27;2:3u")).toBeUndefined();
+			expect(extractPrintableText("\x1b[99;5:2u")).toBeUndefined();
+		});
+
+		it("capability responses after stop/start are still filtered at terminal level", () => {
+			const { terminal, received } = setupTerminal();
+			vi.advanceTimersByTime(60);
+			process.stdin.emit("data", "\x1b[?1u");
+
+			terminal.stop();
+			received.length = 0;
+			terminal.start(
+				data => received.push(data),
+				() => {},
+			);
+			vi.advanceTimersByTime(60);
+
+			process.stdin.emit("data", "\x1b[?0u");
+			process.stdin.emit("data", "\x1b]11;rgb:158e/193a/1e75\x07");
+			process.stdin.emit("data", "\x1b[?64;1;2;4;6;17;18;21;22;52c");
+
+			const all = received.join("");
+			expect(all).not.toContain("?0u");
+			expect(all).not.toContain("rgb:");
+			expect(all).not.toContain("64;1;2;4;6");
 
 			terminal.stop();
 		});


### PR DESCRIPTION
## Summary
Prevent Kitty CSI-u key events from appearing as literal text in the editor during stop/start cycles.

Closes #1397

## Root cause
During plugin credential fixes on first run after upgrade, `ui.stop()` / `ui.start()` cycles disable and re-negotiate Kitty protocol. Key events arriving in the transition window bypass `isKeyRelease()` (which checks `kittyProtocolActive`), and `extractPrintableText()` falls through to the raw text path, inserting escape sequences as literal editor text.

## Fixes
1. **keys.ts**: Guard `extractPrintableText()` to reject unhandled CSI-u sequences
2. **interactive-mode.ts**: Clear editor text after credential fix cycles complete
3. **Tests**: 8 new tests covering Kitty key event rejection and stop/start scenarios

## Test plan
- [x] 5868 tests pass, 0 fail
- [x] `bun run check` clean
- [x] New tests verify: Ctrl+C press/release rejected, modified key events rejected, printable keys still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)