### PR TITLE
fix(tui): stop re-probing terminal capabilities on restart (gibberish)

### DIFF
--- a/packages/coding-agent/test/fixtures/pty-restart-fixture.ts
+++ b/packages/coding-agent/test/fixtures/pty-restart-fixture.ts
@@ -1,0 +1,47 @@
+// Fixture: drives ProcessTerminal through the credential-fix lifecycle
+// (start → stop → start) inside a real PTY so the parent test can observe what
+// the terminal writes across a stop/start cycle and inject capability-probe
+// responses on a real TTY (raw-mode echo off, cooked-mode echo on).
+//
+// Run by packages/coding-agent/test/terminal-restart-pty.test.ts via PtySession.
+// Emits __MARKER__ lines on stdout so the parent can synchronize injection and
+// segment the captured output. Never import this from app code.
+import { ProcessTerminal } from "@f5xc-salesdemos/pi-tui/terminal";
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+async function main(): Promise<void> {
+	const terminal = new ProcessTerminal();
+
+	// Round 1 — initial capability handshake. start() writes the kitty query,
+	// OSC 11 query + DA1 sentinel, etc. to the PTY. The parent injects responses
+	// when it sees the handshake so capabilities become "known".
+	terminal.start(
+		() => {},
+		() => {},
+	);
+	await sleep(300); // 50ms input-handler defer + margin for parent injection
+	process.stdout.write("\n__HANDSHAKE_ANSWERED__\n");
+	await sleep(150);
+
+	// Credential-fix cycle: stop() drops to cooked mode (as before a
+	// stdio:"inherit" subprocess), then start() resumes raw mode.
+	terminal.stop();
+	process.stdout.write("__STOPPED__\n");
+	await sleep(200);
+
+	terminal.start(
+		() => {},
+		() => {},
+	);
+	await sleep(300);
+	process.stdout.write("__RESTARTED__\n");
+
+	await sleep(100);
+	terminal.stop();
+	process.stdout.write("__DONE__\n");
+	await sleep(50);
+	process.exit(0);
+}
+
+void main();

--- a/packages/coding-agent/test/terminal-restart-pty.test.ts
+++ b/packages/coding-agent/test/terminal-restart-pty.test.ts
@@ -1,0 +1,85 @@
+// PTY integration test for the terminal "gibberish" leak.
+//
+// The unit tests (packages/tui/test/terminal-response-filter.test.ts) assert the
+// restart-no-re-probe behavior against a mocked process.stdin. This test proves
+// the same property end-to-end on a REAL pseudo-terminal — real setRawMode, real
+// cooked/raw echo semantics — which the mock cannot exercise.
+//
+// Root cause: the ui.stop() → cooked-mode subprocess → ui.start() credential-fix
+// cycle re-sends the whole capability handshake on restart. That second response
+// round lands while the terminal is echoing (cooked mode) and paints the doubled
+// gibberish. Once capabilities are known, the restart must not re-send the
+// response-generating queries.
+import { describe, expect, it } from "bun:test";
+import path from "node:path";
+import { PtySession } from "@f5xc-salesdemos/pi-natives";
+
+const PKG_ROOT = path.resolve(import.meta.dir, "..");
+const FIXTURE = path.join(import.meta.dir, "fixtures", "pty-restart-fixture.ts");
+
+// Distinct so query (no digit) and response (with digit) never alias:
+const KITTY_QUERY = "\x1b[?u"; // app → terminal
+const OSC11_QUERY = "\x1b]11;?"; // app → terminal
+const KITTY_RESPONSE = "\x1b[?1u"; // terminal → app (injected)
+const OSC11_RESPONSE = "\x1b]11;rgb:0000/0000/0000\x07"; // terminal → app (injected)
+const DA1_RESPONSE = "\x1b[?1;2c"; // terminal → app (injected)
+
+async function runFixture(): Promise<string> {
+	const session = new PtySession();
+	let buf = "";
+	let injected = false;
+
+	const finished = session.start(
+		{ command: `bun ${FIXTURE}`, cwd: PKG_ROOT, timeoutMs: 10_000, cols: 80, rows: 24 },
+		(_err, chunk) => {
+			buf += chunk ?? "";
+			// Inject the round-1 responses as soon as the initial handshake is seen,
+			// so capabilities become "known" before the stop/start cycle.
+			if (!injected && buf.includes(KITTY_QUERY)) {
+				injected = true;
+				session.write(KITTY_RESPONSE + OSC11_RESPONSE + DA1_RESPONSE);
+			}
+		},
+	);
+
+	try {
+		await finished;
+	} finally {
+		try {
+			session.kill();
+		} catch {
+			/* already exited */
+		}
+	}
+	return buf;
+}
+
+describe("ProcessTerminal restart does not re-probe (real PTY)", () => {
+	it("the credential-fix stop/start cycle does not re-send the capability handshake", async () => {
+		if (process.platform === "win32" || !Bun.which("bun")) return;
+
+		const out = await runFixture();
+
+		// Sanity: the fixture ran the full lifecycle and the first handshake fired.
+		expect(out).toContain("__STOPPED__");
+		expect(out).toContain("__RESTARTED__");
+		expect(out).toContain(KITTY_QUERY); // initial probe happened
+
+		// The restart segment must not contain fresh response-generating queries —
+		// those are what produce the doubled gibberish in cooked mode.
+		const restartSegment = out.slice(out.indexOf("__STOPPED__"));
+		expect(restartSegment).not.toContain(KITTY_QUERY);
+		expect(restartSegment).not.toContain(OSC11_QUERY);
+	}, 15_000);
+
+	it("injected probe responses are not echoed back while in raw mode", async () => {
+		if (process.platform === "win32" || !Bun.which("bun")) return;
+
+		const out = await runFixture();
+		// In raw mode the PTY echo is off and ProcessTerminal consumes the probe
+		// responses, so the injected response bytes must never appear in output.
+		const beforeStop = out.slice(0, out.indexOf("__STOPPED__"));
+		expect(beforeStop).not.toContain("\x1b[?1u"); // echoed kitty response
+		expect(beforeStop).not.toContain("rgb:0000/0000/0000"); // echoed OSC 11 response
+	}, 15_000);
+});

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -120,6 +120,15 @@ export class ProcessTerminal implements Terminal {
 	#osc11PollTimer?: Timer;
 	#mode2031Active = false;
 	#mode2031DebounceTimer?: Timer;
+	// Capability-probe results that persist across stop()/start() cycles. After
+	// the first handshake, a restart (e.g. the credential-fix ui.stop()→cooked
+	// subprocess→ui.start() cycle) must re-enable protocols WITHOUT re-querying:
+	// a re-query's response lands during the cooked-mode window and the terminal
+	// echoes it as visible "gibberish". These flags are deliberately NOT reset in
+	// stop() — they remember what we already learned about the terminal.
+	#hasProbedCapabilities = false;
+	#kittySupported = false;
+	#modifyOtherKeysSupported = false;
 
 	get kittyProtocolActive(): boolean {
 		return this.#kittyProtocolActive;
@@ -165,8 +174,11 @@ export class ProcessTerminal implements Terminal {
 		// events that lose modifier information. Must run after setRawMode(true)
 		// since that resets console mode flags.
 		this.#enableWindowsVTInput();
-		// Query and enable Kitty keyboard protocol
-		// The query handler intercepts input temporarily, then installs the user's handler
+		// Query and enable Kitty keyboard protocol.
+		// The query handler intercepts input temporarily, then installs the user's handler.
+		// On a restart this re-enables the protocol directly from the cached result
+		// instead of re-querying (a re-query response would echo as gibberish during
+		// a stop/start cooked-mode window).
 		// See: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
 		this.#queryAndEnableKittyProtocol();
 
@@ -175,7 +187,13 @@ export class ProcessTerminal implements Terminal {
 		// sequences in order, so if DA1 arrives before OSC 11 response,
 		// the terminal does not support OSC 11. This avoids indefinite hangs.
 		// Technique used by Neovim, bat, fish, and terminal-colorsaurus.
-		this.#queryBackgroundColor();
+		//
+		// Only on the FIRST start: on a restart we keep the cached appearance and
+		// rely on Mode 2031 notifications / the OSC 11 poll to pick up any change,
+		// so the query response can never leak during a stop/start cycle.
+		if (!this.#hasProbedCapabilities) {
+			this.#queryBackgroundColor();
+		}
 
 		// Subscribe to Mode 2031 appearance change notifications.
 		// When the terminal reports a change, we re-query OSC 11 to get the
@@ -185,6 +203,9 @@ export class ProcessTerminal implements Terminal {
 		// Start periodic OSC 11 re-query for terminals without Mode 2031
 		// (Warp, Alacritty, WezTerm, iTerm2). Self-disables once Mode 2031 fires.
 		this.#startOsc11Poll();
+
+		// Capabilities are now probed; subsequent start() calls re-enable from cache.
+		this.#hasProbedCapabilities = true;
 
 		// Defer activating the user input handler until terminal capability
 		// queries have settled. Without this, query responses (Kitty, DA1,
@@ -273,6 +294,8 @@ export class ProcessTerminal implements Terminal {
 			// Kitty protocol response — always swallow, enable protocol on first match
 			const kittyMatch = sequence.match(kittyResponsePattern);
 			if (kittyMatch) {
+				// Remember support so a restart can re-enable without re-querying.
+				this.#kittySupported = true;
 				if (!this.#kittyProtocolActive) {
 					if (this.#modifyOtherKeysTimeout) {
 						clearTimeout(this.#modifyOtherKeysTimeout);
@@ -451,6 +474,22 @@ export class ProcessTerminal implements Terminal {
 	#queryAndEnableKittyProtocol(): void {
 		this.#setupStdinBuffer();
 		process.stdin.on("data", this.#stdinDataHandler!);
+
+		// Restart path: capabilities are already known. Re-enable the keyboard
+		// protocol directly — no query means no response means nothing to echo as
+		// gibberish during the cooked-mode window of a stop/start cycle.
+		if (this.#hasProbedCapabilities) {
+			if (this.#kittySupported) {
+				this.#kittyProtocolActive = true;
+				setKittyProtocolActive(true);
+				this.#safeWrite("\x1b[>7u");
+			} else if (this.#modifyOtherKeysSupported) {
+				this.#safeWrite("\x1b[>4;2m");
+				this.#modifyOtherKeysActive = true;
+			}
+			return;
+		}
+
 		this.#safeWrite("\x1b[?u");
 		this.#modifyOtherKeysTimeout = setTimeout(() => {
 			this.#modifyOtherKeysTimeout = undefined;
@@ -459,6 +498,7 @@ export class ProcessTerminal implements Terminal {
 			}
 			this.#safeWrite("\x1b[>4;2m");
 			this.#modifyOtherKeysActive = true;
+			this.#modifyOtherKeysSupported = true;
 		}, 150);
 	}
 

--- a/packages/tui/test/terminal-response-filter.test.ts
+++ b/packages/tui/test/terminal-response-filter.test.ts
@@ -433,4 +433,59 @@ describe("Terminal response filtering — no gibberish in editor", () => {
 			terminal.stop();
 		});
 	});
+
+	describe("restart suppresses capability re-probing (root cause of doubled gibberish)", () => {
+		// The doubled gibberish comes from the ui.stop() → cooked-mode subprocess →
+		// ui.start() cycle re-sending the WHOLE capability handshake, producing a
+		// SECOND response round that lands while the filtered reader is torn down.
+		// In cooked mode the terminal echoes those bytes itself (kernel-level — no
+		// JS filter can intercept). Once capabilities are known, a restart must not
+		// re-send response-generating queries, so there is no second round to leak.
+		function completeHandshake(): void {
+			vi.advanceTimersByTime(60);
+			process.stdin.emit("data", "\x1b[?1u"); // kitty supported → protocol active
+			process.stdin.emit("data", "\x1b]11;rgb:0000/0000/0000\x07"); // bg color known
+			process.stdin.emit("data", "\x1b[?1;2c"); // DA1
+		}
+
+		it("second start() after a completed handshake does not re-query kitty, OSC 11, or DA1", () => {
+			const { terminal, writes } = setupTerminal();
+			completeHandshake();
+
+			// Plugin credential-fix cycle: stop → (cooked-mode subprocess) → start.
+			terminal.stop();
+			writes.length = 0; // examine only the restart's writes
+
+			terminal.start(
+				() => {},
+				() => {},
+			);
+
+			const out = writes.join("");
+			expect(out).not.toContain("\x1b[?u"); // Kitty query → response \x1b[?0u
+			expect(out).not.toContain("\x1b]11;?"); // OSC 11 query → response \x1b]11;rgb:...
+			expect(out).not.toContain("\x1b[c"); // DA1 sentinel → response \x1b[?...c
+
+			terminal.stop();
+		});
+
+		it("restart re-enables Kitty protocol without a query when support is already known", () => {
+			const { terminal, writes } = setupTerminal();
+			completeHandshake();
+
+			// stop() disables Kitty (\x1b[<u); the restart must re-enable it
+			// directly — no query means no response means nothing to echo.
+			terminal.stop();
+			writes.length = 0;
+
+			terminal.start(
+				() => {},
+				() => {},
+			);
+
+			expect(writes.join("")).toContain("\x1b[>7u"); // Kitty enable, no query
+
+			terminal.stop();
+		});
+	});
 });


### PR DESCRIPTION
Closes #1404

## Problem

Terminal "gibberish" (capability-probe responses on screen, often **doubled**) persists on v19.29.2 despite #1373 / #1376 / #1380 / #1398. Those all hardened the JS stdin reader/filter — but the leak happens when that reader is **torn down**, and you cannot filter bytes you are not reading.

## Root cause

The credential-fix cycle (`interactive-mode.ts` `#offerCredentialFixes`): `ui.stop()` → `Bun.spawn(stdio:"inherit")` cooked-mode subprocess → `ui.start()`. The **second `ProcessTerminal.start()` re-sent the entire capability handshake** (`\x1b[?u`, `\x1b]11;?`, `\x1b[c`). That second response round lands while the terminal is in **cooked mode and echoes input itself (kernel-level — unreachable by any JS filter)** → the doubled gibberish. Also reproduces "phased" on the first launch after a marketplace plugin upgrade (`main.ts:719-747`).

## Fix

Cache capability results across stop/start in `ProcessTerminal` (`#hasProbedCapabilities`, `#kittySupported`, `#modifyOtherKeysSupported`; **not** reset in `stop()`). On restart, re-enable Kitty directly (`\x1b[>7u`, no query) and skip the OSC 11 query (rely on Mode 2031 / poll for changes). No re-query → no second response round → nothing to echo. +43/-3 in `terminal.ts`.

## Tests (RED before fix, GREEN after)

- **Unit/lifecycle** (`packages/tui/test/terminal-response-filter.test.ts`): restart emits no `\x1b[?u` / `\x1b]11;?` / `\x1b[c`, and re-enables Kitty via `\x1b[>7u`.
- **Real PTY** (`packages/coding-agent/test/terminal-restart-pty.test.ts` + `test/fixtures/pty-restart-fixture.ts`): drives `start→stop→start` in a pseudo-terminal via `PtySession`, injects probe responses, asserts no re-probe on restart and no echoed gibberish.

## Verification

- `tui`: 455 pass, 0 fail
- `coding-agent`: 4645 pass, 404 skip, 0 fail
- biome clean

## Not included (deliberate)

`drain-before-stop` (await `drainInput()` before `ui.stop()`) — omitted because it can't be given an honest failing test that isn't OS-echo-timing-dependent. Can follow up with an interaction test if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)