### PR TITLE
fix(tui): drain terminal input before cooked-mode subprocess (gibberish residual)

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -952,7 +952,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			);
 			if (!confirmed) continue;
 
-			this.ui.stop();
+			// Drain pending terminal input (e.g. an in-flight OSC 11 poll response)
+			// before dropping raw mode, so it is consumed here instead of echoed as
+			// gibberish by the terminal while the cooked-mode subprocess runs.
+			await this.ui.suspendForSubprocess();
 			try {
 				const proc = Bun.spawn(service.command, {
 					stdin: "inherit",

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -503,6 +503,10 @@ export class ProcessTerminal implements Terminal {
 	}
 
 	async drainInput(maxMs = 1000, idleMs = 50): Promise<void> {
+		// Stop the periodic OSC 11 poll first. drainInput precedes relinquishing
+		// the TTY (exit, or a cooked-mode subprocess); a poll query fired now would
+		// have its response echoed as gibberish once raw mode is gone.
+		this.#stopOsc11Poll();
 		if (this.#kittyProtocolActive) {
 			// Disable Kitty keyboard protocol first so any late key releases
 			// do not generate new Kitty escape sequences.

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -580,6 +580,18 @@ export class TUI extends Container {
 		this.terminal.stop();
 	}
 
+	/**
+	 * Suspend the UI to hand the TTY to a cooked-mode subprocess (e.g. an
+	 * interactive `aws sso login`). Drains pending terminal input while still in
+	 * raw mode, then stops — so a late capability-probe response (notably the
+	 * periodic OSC 11 poll) cannot be echoed as gibberish during the cooked-mode
+	 * window. Pair with start() once the subprocess exits.
+	 */
+	async suspendForSubprocess(maxDrainMs = 150): Promise<void> {
+		await this.terminal.drainInput(maxDrainMs);
+		this.stop();
+	}
+
 	requestRender(force = false): void {
 		if (force) {
 			this.#previousLines = [];

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -244,4 +244,24 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 
 		terminal.stop();
 	});
+
+	it("drainInput stops the OSC 11 poll so no query can leak during a cooked-mode suspend", async () => {
+		vi.useFakeTimers();
+		const { terminal, queryCount } = setupTerminal();
+
+		// Settle the initial handshake so no query is in flight.
+		process.stdin.emit("data", "\x1b]11;rgb:0000/0000/0000\x07");
+		process.stdin.emit("data", "\x1b[?1;2c");
+		const baseline = queryCount(); // initial OSC 11 query only
+
+		// Draining to relinquish the TTY to a subprocess must also stop the poll —
+		// otherwise a poll query fired during/after the cooked-mode window has its
+		// response echoed as gibberish (the v19.29.3 residual).
+		await terminal.drainInput(0);
+
+		vi.advanceTimersByTime(10_000); // several 2s poll intervals
+		expect(queryCount()).toBe(baseline);
+
+		terminal.stop();
+	});
 });

--- a/packages/tui/test/tui-suspend.test.ts
+++ b/packages/tui/test/tui-suspend.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "bun:test";
+import { TUI } from "@f5xc-salesdemos/pi-tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+// The credential-fix flow suspends the UI to run a cooked-mode subprocess
+// (`aws sso login`). It MUST drain pending terminal input while still in raw
+// mode before stopping — otherwise a late OSC 11 poll response is echoed by the
+// terminal as gibberish during the cooked-mode window (the v19.29.3 residual).
+describe("TUI.suspendForSubprocess", () => {
+	it("drains input before stopping so a pending probe response is consumed in raw mode", async () => {
+		const term = new VirtualTerminal(80, 24);
+		const tui = new TUI(term);
+		tui.start();
+		await Bun.sleep(0);
+
+		const order: string[] = [];
+		vi.spyOn(term, "drainInput").mockImplementation(async () => {
+			order.push("drain");
+		});
+		vi.spyOn(term, "stop").mockImplementation(() => {
+			order.push("stop");
+		});
+
+		await tui.suspendForSubprocess();
+
+		expect(order).toEqual(["drain", "stop"]);
+		vi.restoreAllMocks();
+	});
+});


### PR DESCRIPTION
Closes #1409

## Problem

v19.29.3 (#1405) removed the **doubled** gibberish and the Kitty `^[[?0u`, but a single residual remained on the AWS-SSO "Fix now?" path — only OSC 11 + DA1, right before `aws sso login`:

```
^[]11;rgb:158e/193a/1e75^[\^[[?64;1;2;4;6;17;18;21;22;52c Attempting to open your default browser...
```

## Root cause

"OSC 11 + DA1 only, no Kitty" is the tell: Kitty is queried once; **OSC 11 is re-queried every 2s by a background poll**. `#offerCredentialFixes` called `ui.stop()` directly (no drain), then `Bun.spawn(stdio:"inherit")` dropped to cooked mode — and an **in-flight poll response echoed** during that window (kernel-level, past the torn-down JS reader).

## Fix

Drain pending input (raw mode) before relinquishing the TTY:
- `ProcessTerminal.drainInput()` also stops the OSC 11 poll.
- New `TUI.suspendForSubprocess()` = drain → stop.
- `#offerCredentialFixes` awaits `ui.suspendForSubprocess()` instead of `ui.stop()`.

## Tests

- `terminal-appearance.test.ts`: `drainInput()` stops the OSC 11 poll (RED→GREEN).
- `tui-suspend.test.ts`: `TUI.suspendForSubprocess()` drains before stopping (RED→GREEN).

**Honest coverage note:** the cooked-mode *echo* is a terminal/kernel behavior **not reproducible** in the `PtySession` harness (verified empirically — the harness doesn't echo across the raw→cooked transition). So an earlier draft PTY echo test was removed because it could not fail. The fix is covered by the drain-ordering + poll-stop contracts above plus manual real-terminal verification.

## Verification

- `tui`: 457 pass, 0 fail
- `coding-agent`: 4645 pass, 404 skip, 0 fail
- biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)