### PR TITLE
fix(tui): hold fragmented escape sequences so Ctrl+C doesn't leak as text

### DIFF
--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -224,8 +224,15 @@ function extractCompleteSequences(buffer: string): { sequences: string[]; remain
 
 export type StdinBufferOptions = {
 	/**
-	 * Maximum time to wait for sequence completion (default: 10ms)
-	 * After this time, the buffer is flushed even if incomplete
+	 * Maximum time to wait for sequence completion (default: 50ms)
+	 * After this time, the buffer is flushed even if incomplete.
+	 *
+	 * This is effectively the "ESC hold" window: a lone ESC (the Escape key)
+	 * registers after this delay, and a multi-byte escape sequence fragmented
+	 * across stdin reads (common under heavy render load) has this long to
+	 * reassemble before its tail would leak as individual printable characters.
+	 * 50ms is the standard ESC timeout — long enough to survive multi-frame
+	 * stalls, short enough to feel instant.
 	 */
 	timeout?: number;
 };
@@ -248,7 +255,7 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 
 	constructor(options: StdinBufferOptions = {}) {
 		super();
-		this.#timeoutMs = options.timeout ?? 10;
+		this.#timeoutMs = options.timeout ?? 50;
 	}
 
 	process(data: string | Buffer): void {

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -274,7 +274,10 @@ export class ProcessTerminal implements Terminal {
 	 * to handle the case where the response arrives split across multiple events.
 	 */
 	#setupStdinBuffer(): void {
-		this.#stdinBuffer = new StdinBuffer({ timeout: 10 });
+		// Use the default ESC-hold window (50ms) so escape sequences fragmented
+		// across stdin reads under render load reassemble instead of leaking their
+		// tail as editor text (e.g. modifyOtherKeys Ctrl+C \x1b[27;5;99~).
+		this.#stdinBuffer = new StdinBuffer();
 
 		// Kitty protocol response pattern: \x1b[?<flags>u
 		const kittyResponsePattern = /^\x1b\[\?(\d+)u$/;

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -112,6 +112,15 @@ describe("parseKey", () => {
 		expect(parseKey("\x1b[99;9u")).toBeUndefined();
 		setKittyProtocolActive(false);
 	});
+
+	it("decodes modifyOtherKeys Ctrl+C so it can quit instead of leaking as text", () => {
+		// Sent by terminals using the xterm modifyOtherKeys fallback (no Kitty).
+		// Must resolve to ctrl+c whether or not Kitty negotiation succeeded.
+		expect(parseKey("\x1b[27;5;99~")).toBe("ctrl+c");
+		setKittyProtocolActive(true);
+		expect(parseKey("\x1b[27;5;99~")).toBe("ctrl+c");
+		setKittyProtocolActive(false);
+	});
 });
 
 describe("extractPrintableText", () => {
@@ -139,6 +148,10 @@ describe("extractPrintableText", () => {
 
 	it("rejects raw Kitty key press sequences (Ctrl+C)", () => {
 		expect(extractPrintableText("\x1b[99;5u")).toBeUndefined();
+	});
+
+	it("rejects modifyOtherKeys Ctrl+C so it never becomes editor text", () => {
+		expect(extractPrintableText("\x1b[27;5;99~")).toBeUndefined();
 	});
 
 	it("rejects raw Kitty key release sequences (Ctrl+C release)", () => {

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -413,4 +413,38 @@ describe("StdinBuffer", () => {
 			expect(emittedSequences).toEqual([]);
 		});
 	});
+
+	describe("Fragmented escape sequence reassembly", () => {
+		// Under heavy render load (e.g. the welcome screen) a single keypress's
+		// bytes can arrive across multiple stdin reads. With too short a hold, the
+		// lone ESC flushes and the tail leaks as individual printable characters
+		// (e.g. Ctrl+C in modifyOtherKeys form: \x1b[27;5;99~ -> "[27;5;99~" in the
+		// editor). The default hold window must tolerate a multi-frame gap so the
+		// sequence reassembles and parses as one key.
+		it("reassembles a CSI sequence split across reads within the default hold window", async () => {
+			const buf = new StdinBuffer(); // default timeout
+			const out: string[] = [];
+			buf.on("data", (s: string) => out.push(s));
+
+			buf.process("\x1b");
+			await Bun.sleep(25); // longer than a render frame, shorter than the hold
+			buf.process("[27;5;99~");
+			await Bun.sleep(5);
+
+			expect(out).toEqual(["\x1b[27;5;99~"]);
+			buf.destroy();
+		});
+
+		it("still flushes a lone Escape keypress after the hold window", async () => {
+			const buf = new StdinBuffer(); // default timeout
+			const out: string[] = [];
+			buf.on("data", (s: string) => out.push(s));
+
+			buf.process("\x1b");
+			await Bun.sleep(80); // past the hold window
+
+			expect(out).toEqual(["\x1b"]);
+			buf.destroy();
+		});
+	});
 });


### PR DESCRIPTION
Closes #1414

## Problem

On a direct terminal, Ctrl+C at the welcome screen inserts `^[[27;5;99~` (repeated per press) and does **not** quit. `\x1b[27;5;99~` is Ctrl+C in xterm **modifyOtherKeys** encoding.

## Root cause (reproduced)

The `StdinBuffer` flushes an incomplete escape sequence after a **10ms** timeout. Under the welcome screen's render load, a keypress's bytes arrive across stdin reads with a gap > 10ms: the lone `\x1b` flushes, then the tail (`[27;5;99~`) arrives as plain bytes and is emitted as **individual printable characters** → inserted as editor text. The whole sequence is never seen, so `parseKey` never returns "ctrl+c" (no quit, no filter).

Isolation confirms each unit is correct on its own (`parseKey("\x1b[27;5;99~")` → "ctrl+c", `extractPrintableText` → undefined); only the *fragmented* delivery leaks. This is **pre-existing** and the **same fragmentation mechanism** behind the earlier capability-response gibberish.

## Fix

Raise the StdinBuffer "ESC hold" window from 10ms → **50ms** (the standard ESC timeout) so fragmented sequences reassemble before their tail can leak. A lone Escape keypress still registers after the hold. Also hardens against the earlier gibberish class.

## Tests (RED→GREEN)

- `stdin-buffer.test.ts`: a CSI sequence split across reads reassembles within the hold window; a lone Escape still flushes after it.
- `keys.test.ts`: `parseKey("\x1b[27;5;99~")` → "ctrl+c"; `extractPrintableText("\x1b[27;5;99~")` → undefined.

## Verification

- `tui`: 459 pass, 0 fail
- `coding-agent`: 4645 pass, 404 skip, 0 fail
- biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)