### PR TITLE
fix: portable sleep in pi-resource-management

### DIFF
--- a/packages/resource-management/package.json
+++ b/packages/resource-management/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-resource-management",
-	"version": "19.29.5",
+	"version": "19.30.0",
 	"description": "Shared resource management for F5 XC manifest parsing, validation, diff, and CRUD operations",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Robin Mordasiewicz",

--- a/packages/resource-management/src/resource-client.ts
+++ b/packages/resource-management/src/resource-client.ts
@@ -1,4 +1,7 @@
 import { computeResourceDiff } from "./diff-engine";
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
 import type {
 	OperationResult,
 	ResolvedKind,
@@ -285,7 +288,7 @@ export class ResourceClient {
 						Number.isFinite(seconds) && seconds > 0
 							? Math.min(seconds * 1000, 10_000)
 							: Math.min(1000 * 2 ** attempt, 10_000);
-					await Bun.sleep(delayMs);
+					await sleep(delayMs);
 					continue;
 				}
 
@@ -314,7 +317,7 @@ export class ResourceClient {
 					};
 					break;
 				}
-				await Bun.sleep(Math.min(1000 * 2 ** attempt, 10_000));
+				await sleep(Math.min(1000 * 2 ** attempt, 10_000));
 			}
 		}
 

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -34,6 +34,7 @@ const packageDirs: PublishPackage[] = [
 	{ dir: "packages/natives" },
 	{ dir: "packages/tui" },
 	{ dir: "packages/stats" },
+	{ dir: "packages/resource-management" },
 	{ dir: "packages/agent" },
 	{ dir: "packages/coding-agent" },
 ];


### PR DESCRIPTION
## Summary

- Replace `Bun.sleep()` with portable `setTimeout`-based sleep in resource-client.ts
- Bump pi-resource-management version to 19.30.0

Required for VS Code extension consumption (Node.js runtime).

Closes #1424

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>