### PR TITLE
fix(tui): reassemble fragmented Ctrl+C regardless of stall size (gap-independent)

### DIFF
--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -22,6 +22,28 @@ const ESC = "\x1b";
 const BRACKETED_PASTE_START = "\x1b[200~";
 const BRACKETED_PASTE_END = "\x1b[201~";
 
+// How long after flushing an incomplete escape we will still stitch a late
+// continuation back onto it. Generous because the same render stall that split
+// the keypress also delays processing of its second half.
+const ESCAPE_CONTINUATION_WINDOW_MS = 2000;
+
+/**
+ * Does `combined` (a just-flushed incomplete-escape prefix joined with the next
+ * chunk) look like a fragmented CSI/SS3/OSC/DCS/APC sequence being stitched back
+ * together — as opposed to an Escape keypress followed by ordinary typed text?
+ * Only the former should be reassembled.
+ */
+function isEscapeContinuation(combined: string): boolean {
+	if (combined.length < 2 || !combined.startsWith(ESC)) {
+		return false;
+	}
+	// Only CSI (ESC [). That is the family that fragments as keyboard input —
+	// arrows, function keys, modifyOtherKeys (ESC[27;5;99~), kitty (ESC[99;5u).
+	// OSC/DCS/APC are string-terminated terminal *responses*, not fragmented
+	// keypresses, and must never be glued onto unrelated input.
+	return combined[1] === "[";
+}
+
 /**
  * Check if a string is a complete escape sequence or needs more data
  */
@@ -252,6 +274,11 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 	readonly #timeoutMs: number;
 	#pasteMode: boolean = false;
 	#pasteBuffer: string = "";
+	// An incomplete escape sequence we flushed on timeout, kept so a continuation
+	// arriving in the next read (a keypress fragmented across stdin reads by an
+	// extreme render stall) can be reassembled instead of leaking its tail as text.
+	#pendingEscape: string | null = null;
+	#pendingEscapeAt = 0;
 
 	constructor(options: StdinBufferOptions = {}) {
 		super();
@@ -277,6 +304,22 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			}
 		} else {
 			str = data;
+		}
+
+		// If we recently flushed an incomplete escape (its hold window expired before
+		// the rest of the keypress arrived), stitch this continuation back onto it so
+		// it parses as one sequence. The lone ESC was already delivered as a harmless
+		// Escape; here we recover the CSI/SS3 tail that would otherwise leak as text.
+		if (this.#pendingEscape !== null) {
+			const prefix = this.#pendingEscape;
+			this.#pendingEscape = null;
+			if (
+				!str.startsWith(ESC) && // a bare tail, not a fresh escape sequence of its own
+				Date.now() - this.#pendingEscapeAt < ESCAPE_CONTINUATION_WINDOW_MS &&
+				isEscapeContinuation(prefix + str)
+			) {
+				str = prefix + str;
+			}
 		}
 
 		if (str.length === 0 && this.#buffer.length === 0) {
@@ -353,6 +396,14 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 				for (const sequence of flushed) {
 					this.emit("data", sequence);
 				}
+
+				// Remember a flushed incomplete escape so a continuation arriving in
+				// the next read can be reassembled (see process()).
+				const last = flushed[flushed.length - 1];
+				if (last !== undefined && last.startsWith(ESC)) {
+					this.#pendingEscape = last;
+					this.#pendingEscapeAt = Date.now();
+				}
 			}, this.#timeoutMs);
 		}
 	}
@@ -380,6 +431,7 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		this.#buffer = "";
 		this.#pasteMode = false;
 		this.#pasteBuffer = "";
+		this.#pendingEscape = null;
 	}
 
 	getBuffer(): string {

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -446,5 +446,45 @@ describe("StdinBuffer", () => {
 			expect(out).toEqual(["\x1b"]);
 			buf.destroy();
 		});
+
+		it("reassembles a CSI sequence even when the continuation arrives AFTER the hold window", async () => {
+			// Under an extreme render stall the gap exceeds the hold, so the lone ESC
+			// flushes first. The continuation (CSI introducer) must still be stitched
+			// back onto it instead of leaking its tail as individual printable chars.
+			const buf = new StdinBuffer(); // default timeout (50ms)
+			const out: string[] = [];
+			buf.on("data", (s: string) => out.push(s));
+
+			buf.process("\x1b");
+			await Bun.sleep(80); // > hold → lone ESC flushes
+			buf.process("[27;5;99~"); // modifyOtherKeys Ctrl+C tail
+			await Bun.sleep(5);
+
+			// The full sequence must be reassembled (a leading lone ESC may have been
+			// delivered — harmless), and never leaked as separate printable chars.
+			expect(out).toContain("\x1b[27;5;99~");
+			expect(out).not.toContain("[");
+			expect(out).not.toContain("2");
+			expect(out).not.toContain("~");
+			buf.destroy();
+		});
+
+		it("does NOT reassemble ESC followed by ordinary typed text", async () => {
+			// A genuine Escape keypress followed by typing must not be glued into a
+			// bogus escape sequence — only CSI/SS3-style continuations reassemble.
+			const buf = new StdinBuffer();
+			const out: string[] = [];
+			buf.on("data", (s: string) => out.push(s));
+
+			buf.process("\x1b");
+			await Bun.sleep(80);
+			buf.process("hello");
+			await Bun.sleep(5);
+
+			expect(out[0]).toBe("\x1b"); // Escape delivered
+			expect(out.join("")).toContain("h"); // text not swallowed/merged
+			expect(out).not.toContain("\x1bhello");
+			buf.destroy();
+		});
 	});
 });


### PR DESCRIPTION
Closes #1431

## Problem

The Ctrl+C `^[[27;5;99~` gibberish **still reproduces on the released v19.30.1 binary** (modifyOtherKeys path), intermittently — it leaks on a busy cold start, a warmer run is clean. v19.29.5's 10ms→50ms hold fixes sub-50ms fragmentation, but an extreme welcome-screen render stall fragments the keypress with a gap **>50ms**, so the lone ESC flushes before the `[27;5;99~` tail and the tail leaks as individual printable chars.

## Fix

Make reassembly **gap-independent**. When `StdinBuffer` flushes an incomplete escape on timeout, it remembers it; if the next read is a **CSI continuation** (a bare tail, `ESC [ …`), it stitches them back into one sequence regardless of gap size. Restricted to **CSI only** (`[`) and only when the next chunk is a bare tail (not a fresh ESC sequence), so OSC/DCS/APC terminal responses and "Escape then typed text" are never glued.

## Verified in the running app

Drove the actual app in a pty (modifyOtherKeys forced, instrumented) and injected a fragmented Ctrl+C at a **120ms gap** — the case that previously leaked:

```
EMIT "\x1b"              ← lone ESC flushed (harmless)
EMIT "\x1b[27;5;99~"     ← reassembled whole sequence ✓
(no INSERT)              ← nothing inserted into the editor — no gibberish ✓
```

## Tests (RED→GREEN)

- `stdin-buffer.test.ts`: reassembles a CSI split whose continuation arrives **after** the hold window; does **not** reassemble ESC-then-text; partial OSC still does not swallow unrelated input (regression guard).
- `tui`: 463 pass, 0 fail · full `coding-agent` suite: 4733 pass, 0 fail.

## Known limitation

In the rare fragmented case a spurious lone Escape is delivered first, so that specific press is dropped rather than acting as Ctrl+C — no gibberish, but the press may not register. Clean follow-up if it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)