### PR TITLE
feat: add /manifest command and toManifest() export utilities

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -185,6 +185,32 @@ Use these values when constructing API payloads and resource names.
 Available F5 XC documentation topics: {{knowledgeTopics}}.
 {{/if}}
 {{/if}}
+
+## Resource Manifest Format
+
+When a user asks you to write, export, or save a resource manifest, produce a clean `{kind, metadata, spec}` JSON file that is compatible with the `/apply` slash command.
+
+**Format:**
+```json
+{
+  "kind": "<resource_kind>",
+  "metadata": {
+    "name": "<resource_name>",
+    "namespace": "<namespace>"
+  },
+  "spec": { ... }
+}
+```
+
+**Rules:**
+- `kind` — the resource type in snake_case (e.g., `http_loadbalancer`, `origin_pool`, `app_firewall`)
+- `metadata` — include only: `name`, `namespace`, `labels`, `annotations`, `description`, `disable`
+- `spec` — include the full spec from the API response
+- **Exclude:** `system_metadata`, `status`, and any other server-managed fields
+- The output must round-trip through `/apply -f` without errors
+
+When fetching a resource from the API, strip the server-added metadata fields and inject the `kind` field (which the API response does not include). The `/manifest` slash command does this automatically.
+
 {{#if userProfile}}
 ## Primary Human
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1476,6 +1476,24 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 		},
 	},
 	{
+		name: "manifest",
+		description: "Export live F5 XC resources as {kind, metadata, spec} manifest files",
+		inlineHint: "<kind> [name] [-n namespace] [-o json|yaml] [-f output-path] [--all]",
+		allowArgs: true,
+		getArgumentCompletions(prefix: string) {
+			try {
+				const { getExportKindCompletions } = require("./export-command") as typeof import("./export-command");
+				return getExportKindCompletions(prefix);
+			} catch {
+				return null;
+			}
+		},
+		handle: async (command, runtime) => {
+			const { handleExportResourceCommand } = await import("./export-command");
+			await handleExportResourceCommand(command, runtime.ctx);
+		},
+	},
+	{
 		name: "context",
 		description: t("commands.context.description"),
 		allowArgs: true,

--- a/packages/coding-agent/src/slash-commands/export-command.ts
+++ b/packages/coding-agent/src/slash-commands/export-command.ts
@@ -1,0 +1,163 @@
+import type { AutocompleteItem } from "@f5xc-salesdemos/pi-tui";
+import type { InteractiveModeContext } from "../modes/types";
+
+interface ParsedBuiltinSlashCommand {
+	name: string;
+	args: string;
+	text: string;
+}
+
+function getExportKindCompletions(prefix: string): AutocompleteItem[] | null {
+	try {
+		const { kindResolver } = require("../resource-management/index") as typeof import("../resource-management/index");
+		const kinds = kindResolver.getKindsWithApiPaths();
+		const lower = prefix.toLowerCase();
+		const items = kinds
+			.filter(k => k.toLowerCase().startsWith(lower))
+			.slice(0, 20)
+			.map(k => ({ value: `${k} `, label: k }));
+		return items.length > 0 ? items : null;
+	} catch {
+		return null;
+	}
+}
+
+export async function handleExportResourceCommand(
+	command: ParsedBuiltinSlashCommand,
+	ctx: InteractiveModeContext,
+): Promise<void> {
+	ctx.editor.addToHistory(command.text);
+	ctx.editor.setText("");
+
+	const { parseExportArgs, ResourceClient, KindResolutionError, toManifest, formatManifestOutput } = await import(
+		"@f5xc-salesdemos/pi-resource-management"
+	);
+	const { kindResolver } = await import("../resource-management/index");
+
+	const parsed = parseExportArgs(command.args);
+	if ("error" in parsed) {
+		ctx.showStatus(parsed.error);
+		return;
+	}
+
+	const { ContextService } = await import("../services/f5xc-context");
+	const { createContextEnv } = await import("../services/context-env");
+	const { settings } = await import("../config/settings");
+
+	let svc: typeof ContextService.prototype;
+	try {
+		svc = ContextService.instance;
+	} catch {
+		ctx.showStatus("No F5 XC context active. Run /context create to configure one first.");
+		return;
+	}
+
+	const status = svc.getStatus();
+	if (!status.isConfigured) {
+		ctx.showStatus("No F5 XC context active. Run /context create to configure one first.");
+		return;
+	}
+
+	const contextEnv = createContextEnv(settings);
+	const apiUrl = contextEnv.get("F5XC_API_URL");
+	const apiToken = contextEnv.get("F5XC_API_TOKEN");
+	const defaultNamespace = contextEnv.get("F5XC_NAMESPACE") ?? "";
+
+	if (!apiUrl || !apiToken) {
+		ctx.showStatus("Missing API credentials. Check your context configuration.");
+		return;
+	}
+
+	const ns = parsed.namespace ?? defaultNamespace;
+	const client = new ResourceClient({
+		apiUrl,
+		apiToken,
+		namespace: ns,
+	});
+
+	if (parsed.outputFormat === "hcl") {
+		ctx.showStatus(
+			'HCL export requires AI-assisted transformation. Use a conversational request instead:\n  "Export my-lb as Terraform HCL"',
+		);
+		return;
+	}
+
+	const fmt = parsed.outputFormat as "json" | "yaml";
+
+	try {
+		const manifests: Array<{ kind: string; metadata: Record<string, unknown>; spec: Record<string, unknown> }> = [];
+
+		if (parsed.all) {
+			const result = await client.exportAll(kindResolver, ns, (kind, count) => {
+				ctx.showStatus(`Exporting ${kind} (${count} found)...`);
+			});
+
+			for (const err of result.errors) {
+				ctx.showStatus(`Warning: ${err.kind}: ${err.error.message}`);
+			}
+
+			manifests.push(...result.manifests);
+		} else if (parsed.kind && parsed.name) {
+			const resolved = kindResolver.resolveKind(parsed.kind);
+			const result = await client.exportOne(parsed.kind, resolved, parsed.name, ns);
+			if (result.error) {
+				ctx.showStatus(`Error: ${result.error.message}`);
+				return;
+			}
+			manifests.push(result.manifest!);
+		} else if (parsed.kind) {
+			const resolved = kindResolver.resolveKind(parsed.kind);
+			const getResult = await client.get(resolved, undefined, ns);
+			if (getResult.error) {
+				ctx.showStatus(`Error: ${getResult.error.message}`);
+				return;
+			}
+			if (!getResult.items || getResult.items.length === 0) {
+				ctx.showStatus(`No ${parsed.kind} resources found.`);
+				return;
+			}
+			for (const item of getResult.items) {
+				manifests.push(toManifest(item, parsed.kind));
+			}
+		}
+
+		if (manifests.length === 0) {
+			ctx.showStatus("No resources found to export.");
+			return;
+		}
+
+		const output = formatManifestOutput(manifests, fmt);
+
+		if (parsed.outputFile) {
+			const { writeFile, mkdir } = await import("node:fs/promises");
+			const { dirname } = await import("node:path");
+			const isDir = parsed.outputFile.endsWith("/");
+
+			if (isDir) {
+				await mkdir(parsed.outputFile, { recursive: true });
+				const ext = fmt === "yaml" ? "yaml" : "json";
+				for (const m of manifests) {
+					const filename = `${m.kind}-${(m.metadata.name as string) ?? "unknown"}.${ext}`;
+					const filepath = `${parsed.outputFile}${filename}`;
+					const content = formatManifestOutput([m], fmt);
+					await writeFile(filepath, content, "utf-8");
+				}
+				ctx.showStatus(`Exported ${manifests.length} resource(s) to ${parsed.outputFile}`);
+			} else {
+				await mkdir(dirname(parsed.outputFile), { recursive: true });
+				await writeFile(parsed.outputFile, output, "utf-8");
+				ctx.showStatus(`Exported ${manifests.length} resource(s) to ${parsed.outputFile}`);
+			}
+		} else {
+			ctx.showStatus(output);
+		}
+	} catch (err) {
+		if (err instanceof KindResolutionError) {
+			ctx.showStatus(`Error: ${err.message}`);
+		} else {
+			ctx.showStatus(`Unexpected error: ${(err as Error).message}`);
+		}
+	}
+}
+
+export { getExportKindCompletions };

--- a/packages/coding-agent/src/slash-commands/export-command.ts
+++ b/packages/coding-agent/src/slash-commands/export-command.ts
@@ -130,15 +130,22 @@ export async function handleExportResourceCommand(
 
 		if (parsed.outputFile) {
 			const { writeFile, mkdir } = await import("node:fs/promises");
-			const { dirname } = await import("node:path");
+			const { dirname, resolve, sep } = await import("node:path");
 			const isDir = parsed.outputFile.endsWith("/");
 
 			if (isDir) {
 				await mkdir(parsed.outputFile, { recursive: true });
+				const baseDir = resolve(parsed.outputFile);
 				const ext = fmt === "yaml" ? "yaml" : "json";
 				for (const m of manifests) {
-					const filename = `${m.kind}-${(m.metadata.name as string) ?? "unknown"}.${ext}`;
-					const filepath = `${parsed.outputFile}${filename}`;
+					const safeKind = m.kind.replace(/[/\\]/g, "_");
+					const safeName = ((m.metadata.name as string) ?? "unknown").replace(/[/\\]/g, "_");
+					const filename = `${safeKind}-${safeName}.${ext}`;
+					const filepath = resolve(parsed.outputFile, filename);
+					if (!filepath.startsWith(baseDir + sep) && filepath !== baseDir) {
+						ctx.showStatus(`Skipping unsafe resource name: ${m.metadata.name}`);
+						continue;
+					}
 					const content = formatManifestOutput([m], fmt);
 					await writeFile(filepath, content, "utf-8");
 				}

--- a/packages/resource-management/src/arg-parser.ts
+++ b/packages/resource-management/src/arg-parser.ts
@@ -1,6 +1,7 @@
-import type { ParsedResourceArgs } from "./types";
+import type { ParsedExportArgs, ParsedResourceArgs } from "./types";
 
 const VALID_OUTPUT_FORMATS = new Set(["json", "yaml", "table", "wide"]);
+const VALID_EXPORT_FORMATS = new Set(["json", "yaml", "hcl"]);
 const VALID_DRY_RUN_MODES = new Set(["client", "server"]);
 
 export function parseResourceArgs(argsString: string): ParsedResourceArgs | { error: string } {
@@ -69,5 +70,62 @@ export function parseResourceArgs(argsString: string): ParsedResourceArgs | { er
 		force,
 		kind: positionals[0],
 		name: positionals[1],
+	};
+}
+
+export function parseExportArgs(argsString: string): ParsedExportArgs | { error: string } {
+	const tokens = argsString.split(/\s+/).filter(Boolean);
+	let namespace: string | undefined;
+	let outputFormat: ParsedExportArgs["outputFormat"] = "json";
+	let outputFile: string | undefined;
+	let all = false;
+	const positionals: string[] = [];
+
+	for (let i = 0; i < tokens.length; i++) {
+		const token = tokens[i];
+
+		if (token === "-n" || token === "--namespace") {
+			if (i + 1 >= tokens.length) return { error: `${token} requires a namespace value.` };
+			namespace = tokens[++i];
+		} else if (token.startsWith("-n") && token.length > 2 && token[2] !== "-") {
+			namespace = token.slice(2);
+		} else if (token === "-o" || token === "--output") {
+			if (i + 1 >= tokens.length) return { error: `${token} requires a format value (json, yaml, hcl).` };
+			const fmt = tokens[++i];
+			if (!VALID_EXPORT_FORMATS.has(fmt)) {
+				return { error: `Invalid output format: "${fmt}". Must be one of: json, yaml, hcl.` };
+			}
+			outputFormat = fmt as ParsedExportArgs["outputFormat"];
+		} else if (token.startsWith("-o") && token.length > 2 && token[2] !== "-") {
+			const fmt = token.slice(2);
+			if (!VALID_EXPORT_FORMATS.has(fmt)) {
+				return { error: `Invalid output format: "${fmt}". Must be one of: json, yaml, hcl.` };
+			}
+			outputFormat = fmt as ParsedExportArgs["outputFormat"];
+		} else if (token === "-f" || token === "--file") {
+			if (i + 1 >= tokens.length) return { error: `${token} requires an output file path.` };
+			outputFile = tokens[++i];
+		} else if (token.startsWith("-f") && token.length > 2 && token[2] !== "-") {
+			outputFile = token.slice(2);
+		} else if (token === "--all") {
+			all = true;
+		} else if (token.startsWith("-")) {
+			return { error: `Unknown flag: "${token}".` };
+		} else {
+			positionals.push(token);
+		}
+	}
+
+	if (!all && positionals.length === 0) {
+		return { error: "Specify a resource kind, or use --all to export all resources." };
+	}
+
+	return {
+		kind: positionals[0],
+		name: positionals[1],
+		namespace,
+		outputFormat,
+		outputFile,
+		all,
 	};
 }

--- a/packages/resource-management/src/index.ts
+++ b/packages/resource-management/src/index.ts
@@ -1,7 +1,9 @@
-export { parseResourceArgs } from "./arg-parser";
+export { parseExportArgs, parseResourceArgs } from "./arg-parser";
 export { computeResourceDiff, formatDiff } from "./diff-engine";
 export { ManifestFileError, readManifestFiles } from "./file-reader";
 export { createKindResolver, KindResolutionError } from "./kind-resolver";
+export type { ExportedManifest, ManifestOutputFormat } from "./manifest-export";
+export { formatManifestOutput, toManifest, toManifestList } from "./manifest-export";
 export { ManifestParseError, parseManifests } from "./manifest-parser";
 export { formatValidationErrors, validateManifest, validateManifests } from "./manifest-validator";
 export {
@@ -20,6 +22,7 @@ export type {
 	KindResolver,
 	ManifestValidationResult,
 	OperationResult,
+	ParsedExportArgs,
 	ParsedResourceArgs,
 	ResolvedKind,
 	ResourceClientOptions,

--- a/packages/resource-management/src/manifest-export.ts
+++ b/packages/resource-management/src/manifest-export.ts
@@ -1,0 +1,49 @@
+import { stringify as yamlStringify } from "yaml";
+
+const METADATA_KEEP_KEYS = new Set(["name", "namespace", "labels", "annotations", "description", "disable"]);
+
+export interface ExportedManifest {
+	kind: string;
+	metadata: Record<string, unknown>;
+	spec: Record<string, unknown>;
+}
+
+export function toManifest(apiResponse: Record<string, unknown>, kind: string): ExportedManifest {
+	const rawMeta = (apiResponse.metadata ?? {}) as Record<string, unknown>;
+	const metadata: Record<string, unknown> = {};
+
+	for (const key of Object.keys(rawMeta)) {
+		if (METADATA_KEEP_KEYS.has(key)) {
+			const val = rawMeta[key];
+			if (val !== undefined && val !== null) {
+				if (typeof val === "object" && !Array.isArray(val) && Object.keys(val as object).length === 0) continue;
+				metadata[key] = val;
+			}
+		}
+	}
+
+	const spec = (apiResponse.spec ?? {}) as Record<string, unknown>;
+
+	return { kind, metadata, spec };
+}
+
+export function toManifestList(apiListResponse: Record<string, unknown>, kind: string): ExportedManifest[] {
+	const items = Array.isArray(apiListResponse.items) ? (apiListResponse.items as Record<string, unknown>[]) : [];
+	return items.map(item => toManifest(item, kind));
+}
+
+export type ManifestOutputFormat = "json" | "yaml";
+
+export function formatManifestOutput(manifests: ExportedManifest[], format: ManifestOutputFormat): string {
+	if (format === "yaml") {
+		if (manifests.length === 1) {
+			return yamlStringify(manifests[0]);
+		}
+		return manifests.map(m => yamlStringify(m)).join("---\n");
+	}
+
+	if (manifests.length === 1) {
+		return JSON.stringify(manifests[0], null, 2);
+	}
+	return JSON.stringify(manifests, null, 2);
+}

--- a/packages/resource-management/src/resource-client.ts
+++ b/packages/resource-management/src/resource-client.ts
@@ -1,8 +1,11 @@
 import { computeResourceDiff } from "./diff-engine";
+import type { ExportedManifest } from "./manifest-export";
+import { toManifest, toManifestList } from "./manifest-export";
 
 const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
 
 import type {
+	KindResolver,
 	OperationResult,
 	ResolvedKind,
 	ResourceClientOptions,
@@ -120,6 +123,53 @@ export class ResourceClient {
 		const body = result.body!;
 		const items = Array.isArray(body.items) ? (body.items as Record<string, unknown>[]) : [];
 		return { items };
+	}
+
+	async exportOne(
+		kind: string,
+		resolved: ResolvedKind,
+		name: string,
+		namespaceOverride?: string,
+	): Promise<{ manifest?: ExportedManifest; error?: ResourceError }> {
+		const namespace = namespaceOverride ?? this.#defaultNamespace;
+		const url = this.#buildUrl(resolved.paths.get, namespace, name);
+		const result = await this.#fetchResource(url);
+		if (result.error) return { error: result.error };
+		return { manifest: toManifest(result.body!, kind) };
+	}
+
+	async exportAll(
+		kindResolver: KindResolver,
+		namespaceOverride?: string,
+		onProgress?: (kind: string, count: number) => void,
+	): Promise<{ manifests: ExportedManifest[]; errors: Array<{ kind: string; error: ResourceError }> }> {
+		const namespace = namespaceOverride ?? this.#defaultNamespace;
+		const kinds = kindResolver.getKindsWithApiPaths();
+		const manifests: ExportedManifest[] = [];
+		const errors: Array<{ kind: string; error: ResourceError }> = [];
+
+		for (const kind of kinds) {
+			try {
+				const resolved = kindResolver.resolveKind(kind);
+				const url = this.#buildUrl(resolved.paths.list, namespace);
+				const result = await this.#fetchResource(url);
+
+				if (result.error) {
+					errors.push({ kind, error: result.error });
+					continue;
+				}
+
+				const exported = toManifestList(result.body!, kind);
+				if (exported.length > 0) {
+					manifests.push(...exported);
+					onProgress?.(kind, exported.length);
+				}
+			} catch {
+				errors.push({ kind, error: { kind: "api", message: `Failed to export ${kind}` } });
+			}
+		}
+
+		return { manifests, errors };
 	}
 
 	async diff(

--- a/packages/resource-management/src/types.ts
+++ b/packages/resource-management/src/types.ts
@@ -65,6 +65,15 @@ export interface ParsedResourceArgs {
 	name?: string;
 }
 
+export interface ParsedExportArgs {
+	kind?: string;
+	name?: string;
+	namespace?: string;
+	outputFormat: "json" | "yaml" | "hcl";
+	outputFile?: string;
+	all: boolean;
+}
+
 export interface ResolvedKind {
 	kind: string;
 	domain: string;

--- a/packages/resource-management/test/export-args.test.ts
+++ b/packages/resource-management/test/export-args.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import { parseExportArgs } from "../src/arg-parser";
+
+describe("parseExportArgs", () => {
+	test("parses kind only", () => {
+		const result = parseExportArgs("http_loadbalancer");
+		expect(result).toEqual({
+			kind: "http_loadbalancer",
+			name: undefined,
+			namespace: undefined,
+			outputFormat: "json",
+			outputFile: undefined,
+			all: false,
+		});
+	});
+
+	test("parses kind and name", () => {
+		const result = parseExportArgs("http_loadbalancer my-lb");
+		expect(result).toEqual({
+			kind: "http_loadbalancer",
+			name: "my-lb",
+			namespace: undefined,
+			outputFormat: "json",
+			outputFile: undefined,
+			all: false,
+		});
+	});
+
+	test("parses namespace flag", () => {
+		const result = parseExportArgs("http_loadbalancer my-lb -n production");
+		expect("error" in result).toBe(false);
+		if (!("error" in result)) {
+			expect(result.namespace).toBe("production");
+		}
+	});
+
+	test("parses short namespace flag", () => {
+		const result = parseExportArgs("origin_pool -nproduction");
+		expect("error" in result).toBe(false);
+		if (!("error" in result)) {
+			expect(result.namespace).toBe("production");
+		}
+	});
+
+	test("parses output format json", () => {
+		const result = parseExportArgs("origin_pool -o json");
+		expect("error" in result).toBe(false);
+		if (!("error" in result)) {
+			expect(result.outputFormat).toBe("json");
+		}
+	});
+
+	test("parses output format yaml", () => {
+		const result = parseExportArgs("origin_pool -o yaml");
+		expect("error" in result).toBe(false);
+		if (!("error" in result)) {
+			expect(result.outputFormat).toBe("yaml");
+		}
+	});
+
+	test("parses output format hcl", () => {
+		const result = parseExportArgs("origin_pool -o hcl");
+		expect("error" in result).toBe(false);
+		if (!("error" in result)) {
+			expect(result.outputFormat).toBe("hcl");
+		}
+	});
+
+	test("parses short output format", () => {
+		const result = parseExportArgs("origin_pool -oyaml");
+		expect("error" in result).toBe(false);
+		if (!("error" in result)) {
+			expect(result.outputFormat).toBe("yaml");
+		}
+	});
+
+	test("rejects invalid output format", () => {
+		const result = parseExportArgs("origin_pool -o table");
+		expect("error" in result).toBe(true);
+		if ("error" in result) {
+			expect(result.error).toContain("Invalid output format");
+		}
+	});
+
+	test("parses output file flag", () => {
+		const result = parseExportArgs("http_loadbalancer my-lb -f output.json");
+		expect("error" in result).toBe(false);
+		if (!("error" in result)) {
+			expect(result.outputFile).toBe("output.json");
+		}
+	});
+
+	test("parses short output file flag", () => {
+		const result = parseExportArgs("origin_pool -fmanifests/");
+		expect("error" in result).toBe(false);
+		if (!("error" in result)) {
+			expect(result.outputFile).toBe("manifests/");
+		}
+	});
+
+	test("parses --all flag", () => {
+		const result = parseExportArgs("--all");
+		expect("error" in result).toBe(false);
+		if (!("error" in result)) {
+			expect(result.all).toBe(true);
+			expect(result.kind).toBeUndefined();
+		}
+	});
+
+	test("parses --all with output file", () => {
+		const result = parseExportArgs("--all -f backup/ -o yaml");
+		expect("error" in result).toBe(false);
+		if (!("error" in result)) {
+			expect(result.all).toBe(true);
+			expect(result.outputFile).toBe("backup/");
+			expect(result.outputFormat).toBe("yaml");
+		}
+	});
+
+	test("errors on no args", () => {
+		const result = parseExportArgs("");
+		expect("error" in result).toBe(true);
+		if ("error" in result) {
+			expect(result.error).toContain("Specify a resource kind");
+		}
+	});
+
+	test("errors on unknown flag", () => {
+		const result = parseExportArgs("origin_pool --unknown");
+		expect("error" in result).toBe(true);
+		if ("error" in result) {
+			expect(result.error).toContain("Unknown flag");
+		}
+	});
+
+	test("errors when -n missing value", () => {
+		const result = parseExportArgs("origin_pool -n");
+		expect("error" in result).toBe(true);
+	});
+
+	test("errors when -o missing value", () => {
+		const result = parseExportArgs("origin_pool -o");
+		expect("error" in result).toBe(true);
+	});
+
+	test("errors when -f missing value", () => {
+		const result = parseExportArgs("origin_pool -f");
+		expect("error" in result).toBe(true);
+	});
+
+	test("parses all flags together", () => {
+		const result = parseExportArgs("http_loadbalancer my-lb -n prod -o yaml -f lb.yaml");
+		expect("error" in result).toBe(false);
+		if (!("error" in result)) {
+			expect(result.kind).toBe("http_loadbalancer");
+			expect(result.name).toBe("my-lb");
+			expect(result.namespace).toBe("prod");
+			expect(result.outputFormat).toBe("yaml");
+			expect(result.outputFile).toBe("lb.yaml");
+			expect(result.all).toBe(false);
+		}
+	});
+});

--- a/packages/resource-management/test/manifest-export.test.ts
+++ b/packages/resource-management/test/manifest-export.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, test } from "bun:test";
+import { formatManifestOutput, toManifest, toManifestList } from "../src/manifest-export";
+
+describe("toManifest", () => {
+	test("extracts kind, metadata, and spec from API response", () => {
+		const apiResponse = {
+			metadata: {
+				name: "my-lb",
+				namespace: "default",
+				labels: { env: "prod" },
+				description: "My load balancer",
+			},
+			system_metadata: {
+				uid: "abc-123",
+				creation_timestamp: "2026-01-01T00:00:00Z",
+				creator_id: "user@example.com",
+				tenant: "my-tenant",
+			},
+			spec: {
+				domains: ["example.com"],
+				http: { dns_volterra_managed: false, port: 80 },
+			},
+			status: { state: "active" },
+		};
+
+		const result = toManifest(apiResponse, "http_loadbalancer");
+
+		expect(result.kind).toBe("http_loadbalancer");
+		expect(result.metadata).toEqual({
+			name: "my-lb",
+			namespace: "default",
+			labels: { env: "prod" },
+			description: "My load balancer",
+		});
+		expect(result.spec).toEqual({
+			domains: ["example.com"],
+			http: { dns_volterra_managed: false, port: 80 },
+		});
+	});
+
+	test("strips system_metadata and status", () => {
+		const apiResponse = {
+			metadata: { name: "test", namespace: "ns" },
+			system_metadata: { uid: "x", creation_timestamp: "2026-01-01T00:00:00Z" },
+			spec: { foo: "bar" },
+			status: { phase: "ready" },
+		};
+
+		const result = toManifest(apiResponse, "origin_pool");
+
+		expect(result).not.toHaveProperty("system_metadata");
+		expect(result).not.toHaveProperty("status");
+		expect(Object.keys(result)).toEqual(["kind", "metadata", "spec"]);
+	});
+
+	test("keeps only allowed metadata fields", () => {
+		const apiResponse = {
+			metadata: {
+				name: "test",
+				namespace: "ns",
+				labels: { a: "b" },
+				annotations: { x: "y" },
+				description: "desc",
+				disable: true,
+				unknown_field: "should be dropped",
+				internal_id: 123,
+			},
+			spec: {},
+		};
+
+		const result = toManifest(apiResponse, "app_firewall");
+
+		expect(Object.keys(result.metadata).sort()).toEqual([
+			"annotations",
+			"description",
+			"disable",
+			"labels",
+			"name",
+			"namespace",
+		]);
+	});
+
+	test("omits empty objects from metadata", () => {
+		const apiResponse = {
+			metadata: {
+				name: "test",
+				namespace: "ns",
+				labels: {},
+				annotations: {},
+			},
+			spec: {},
+		};
+
+		const result = toManifest(apiResponse, "healthcheck");
+
+		expect(result.metadata).toEqual({ name: "test", namespace: "ns" });
+	});
+
+	test("omits null and undefined metadata values", () => {
+		const apiResponse = {
+			metadata: {
+				name: "test",
+				namespace: "ns",
+				description: null,
+				disable: undefined,
+			},
+			spec: { key: "value" },
+		};
+
+		const result = toManifest(apiResponse, "origin_pool");
+
+		expect(result.metadata).toEqual({ name: "test", namespace: "ns" });
+	});
+
+	test("handles empty spec", () => {
+		const result = toManifest({ metadata: { name: "x", namespace: "y" }, spec: {} }, "app_firewall");
+		expect(result.spec).toEqual({});
+	});
+
+	test("handles missing metadata and spec", () => {
+		const result = toManifest({}, "unknown_kind");
+		expect(result.kind).toBe("unknown_kind");
+		expect(result.metadata).toEqual({});
+		expect(result.spec).toEqual({});
+	});
+
+	test("preserves full spec including server-added defaults", () => {
+		const apiResponse = {
+			metadata: { name: "fw", namespace: "ns" },
+			spec: {
+				user_field: "value",
+				monitoring: {},
+				default_detection_settings: { setting: true },
+			},
+		};
+
+		const result = toManifest(apiResponse, "app_firewall");
+
+		expect(result.spec).toEqual({
+			user_field: "value",
+			monitoring: {},
+			default_detection_settings: { setting: true },
+		});
+	});
+});
+
+describe("toManifestList", () => {
+	test("transforms list response items", () => {
+		const listResponse = {
+			items: [
+				{ metadata: { name: "a", namespace: "ns" }, spec: { x: 1 } },
+				{ metadata: { name: "b", namespace: "ns" }, spec: { y: 2 } },
+			],
+		};
+
+		const result = toManifestList(listResponse, "origin_pool");
+
+		expect(result).toHaveLength(2);
+		expect(result[0].kind).toBe("origin_pool");
+		expect(result[0].metadata).toEqual({ name: "a", namespace: "ns" });
+		expect(result[1].metadata).toEqual({ name: "b", namespace: "ns" });
+	});
+
+	test("returns empty array for empty list", () => {
+		expect(toManifestList({ items: [] }, "origin_pool")).toEqual([]);
+	});
+
+	test("returns empty array when items is missing", () => {
+		expect(toManifestList({}, "origin_pool")).toEqual([]);
+	});
+
+	test("strips system_metadata from each item", () => {
+		const listResponse = {
+			items: [
+				{
+					metadata: { name: "a", namespace: "ns" },
+					system_metadata: { uid: "x" },
+					spec: {},
+					status: {},
+				},
+			],
+		};
+
+		const result = toManifestList(listResponse, "healthcheck");
+
+		expect(result[0]).not.toHaveProperty("system_metadata");
+		expect(result[0]).not.toHaveProperty("status");
+	});
+});
+
+describe("formatManifestOutput", () => {
+	const singleManifest = {
+		kind: "http_loadbalancer",
+		metadata: { name: "my-lb", namespace: "default" },
+		spec: { domains: ["example.com"] },
+	};
+
+	test("formats single manifest as JSON", () => {
+		const output = formatManifestOutput([singleManifest], "json");
+		const parsed = JSON.parse(output);
+		expect(parsed.kind).toBe("http_loadbalancer");
+		expect(parsed.metadata.name).toBe("my-lb");
+	});
+
+	test("formats multiple manifests as JSON array", () => {
+		const second = { kind: "origin_pool", metadata: { name: "pool" }, spec: {} };
+		const output = formatManifestOutput([singleManifest, second], "json");
+		const parsed = JSON.parse(output);
+		expect(Array.isArray(parsed)).toBe(true);
+		expect(parsed).toHaveLength(2);
+	});
+
+	test("formats single manifest as YAML", () => {
+		const output = formatManifestOutput([singleManifest], "yaml");
+		expect(output).toContain("kind: http_loadbalancer");
+		expect(output).toContain("name: my-lb");
+	});
+
+	test("formats multiple manifests as multi-doc YAML", () => {
+		const second = { kind: "origin_pool", metadata: { name: "pool" }, spec: {} };
+		const output = formatManifestOutput([singleManifest, second], "yaml");
+		expect(output).toContain("---");
+		expect(output).toContain("kind: http_loadbalancer");
+		expect(output).toContain("kind: origin_pool");
+	});
+});


### PR DESCRIPTION
## Summary

- Add `toManifest()` / `toManifestList()` / `formatManifestOutput()` to the shared `pi-resource-management` package for transforming API responses into clean `{kind, metadata, spec}` manifests
- Add `parseExportArgs()` for parsing `/manifest` command arguments
- Add `exportOne()` / `exportAll()` methods to `ResourceClient`
- Register `/manifest` slash command with kind autocomplete, supporting single resource, by-kind, full namespace (`--all`), JSON/YAML output, stdout or file (`-f`) destination
- Add manifest format awareness to the AI agent system prompt so conversational requests produce `/apply`-compatible output
- 35 new unit tests for `toManifest`, `toManifestList`, `formatManifestOutput`, and `parseExportArgs`

Closes #1433

## Test plan

- [x] `bun test packages/resource-management/test/` — 76 tests pass (35 new)
- [x] TypeScript type-check passes for both packages
- [ ] `/manifest http_loadbalancer my-lb` — exports single resource as clean JSON
- [ ] `/manifest origin_pool -o yaml -f pools.yaml` — exports all origin_pools as YAML file
- [ ] `/manifest --all -f backup/` — exports all resources into directory
- [ ] Ask AI "find my load balancer and write the manifest" — produces `/apply`-compatible file

🤖 Generated with [Claude Code](https://claude.com/claude-code)