### PR TITLE
feat: add HttpTransport adapter and clean manifest exports

### DIFF
--- a/packages/resource-management/package.json
+++ b/packages/resource-management/package.json
@@ -46,11 +46,14 @@
 	"exports": {
 		".": {
 			"types": "./src/index.ts",
-			"import": "./src/index.ts"
+			"import": "./src/index.ts",
+			"require": "./src/index.ts",
+			"default": "./src/index.ts"
 		},
 		"./*": {
 			"types": "./src/*.ts",
-			"import": "./src/*.ts"
+			"import": "./src/*.ts",
+			"require": "./src/*.ts"
 		},
 		"./*.js": "./src/*.ts"
 	}

--- a/packages/resource-management/src/index.ts
+++ b/packages/resource-management/src/index.ts
@@ -2,8 +2,8 @@ export { parseExportArgs, parseResourceArgs } from "./arg-parser";
 export { computeResourceDiff, formatDiff } from "./diff-engine";
 export { ManifestFileError, readManifestFiles } from "./file-reader";
 export { createKindResolver, KindResolutionError } from "./kind-resolver";
-export type { ExportedManifest, ManifestOutputFormat } from "./manifest-export";
-export { formatManifestOutput, toManifest, toManifestList } from "./manifest-export";
+export type { ExportedManifest, ManifestOutputFormat, MinimalExportFilter } from "./manifest-export";
+export { applyMinimalExportFilter, formatManifestOutput, toManifest, toManifestList } from "./manifest-export";
 export { ManifestParseError, parseManifests } from "./manifest-parser";
 export { formatValidationErrors, validateManifest, validateManifests } from "./manifest-validator";
 export {

--- a/packages/resource-management/src/index.ts
+++ b/packages/resource-management/src/index.ts
@@ -12,13 +12,16 @@ export {
 	formatResourceDetail,
 	formatResourceList,
 } from "./output-formatter";
-export { ResourceClient } from "./resource-client";
+export { FetchTransport, ResourceClient } from "./resource-client";
 export type {
 	ApiSpecDomainEntry,
 	ApiSpecDomainResource,
 	ApiSpecIndex,
 	ApiSpecValidationResourceEntry,
 	DiffEntry,
+	HttpTransport,
+	HttpTransportRequest,
+	HttpTransportResponse,
 	KindResolver,
 	ManifestValidationResult,
 	OperationResult,

--- a/packages/resource-management/src/manifest-export.ts
+++ b/packages/resource-management/src/manifest-export.ts
@@ -2,6 +2,18 @@ import { stringify as yamlStringify } from "yaml";
 
 const METADATA_KEEP_KEYS = new Set(["name", "namespace", "labels", "annotations", "description", "disable"]);
 
+const SPEC_STRIP_KEYS = new Set([
+	"host_name",
+	"dns_info",
+	"state",
+	"auto_cert_info",
+	"internet_vip_info",
+	"cert_state",
+	"create_form",
+	"replace_form",
+	"status",
+]);
+
 export interface ExportedManifest {
 	kind: string;
 	metadata: Record<string, unknown>;
@@ -9,7 +21,10 @@ export interface ExportedManifest {
 }
 
 export function toManifest(apiResponse: Record<string, unknown>, kind: string): ExportedManifest {
-	const rawMeta = (apiResponse.metadata ?? {}) as Record<string, unknown>;
+	const objectData = apiResponse.object as Record<string, unknown> | undefined;
+	const getSpec = apiResponse.get_spec as Record<string, unknown> | undefined;
+
+	const rawMeta = (apiResponse.metadata ?? objectData?.metadata ?? getSpec?.metadata ?? {}) as Record<string, unknown>;
 	const metadata: Record<string, unknown> = {};
 
 	for (const key of Object.keys(rawMeta)) {
@@ -22,9 +37,47 @@ export function toManifest(apiResponse: Record<string, unknown>, kind: string): 
 		}
 	}
 
-	const spec = (apiResponse.spec ?? {}) as Record<string, unknown>;
+	const rawSpec = (apiResponse.spec ?? objectData?.spec ?? getSpec ?? {}) as Record<string, unknown>;
+	const spec = cleanSpec(rawSpec);
 
 	return { kind, metadata, spec };
+}
+
+function cleanSpec(raw: Record<string, unknown>): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+	for (const [key, val] of Object.entries(raw)) {
+		if (SPEC_STRIP_KEYS.has(key)) continue;
+		const cleaned = cleanValue(val);
+		if (cleaned !== undefined) {
+			result[key] = cleaned;
+		}
+	}
+	return result;
+}
+
+function cleanValue(val: unknown): unknown {
+	if (val === null || val === undefined) return undefined;
+	if (Array.isArray(val)) {
+		if (val.length === 0) return undefined;
+		const cleaned = val.map(cleanValue).filter(v => v !== undefined);
+		return cleaned.length > 0 ? cleaned : undefined;
+	}
+	if (typeof val === "object") {
+		const obj = val as Record<string, unknown>;
+		const keys = Object.keys(obj);
+		if (keys.length === 0) return val;
+		const result: Record<string, unknown> = {};
+		let hasContent = false;
+		for (const [k, v] of Object.entries(obj)) {
+			const cleaned = cleanValue(v);
+			if (cleaned !== undefined) {
+				result[k] = cleaned;
+				hasContent = true;
+			}
+		}
+		return hasContent ? result : val;
+	}
+	return val;
 }
 
 export function toManifestList(apiListResponse: Record<string, unknown>, kind: string): ExportedManifest[] {

--- a/packages/resource-management/src/manifest-export.ts
+++ b/packages/resource-management/src/manifest-export.ts
@@ -14,13 +14,24 @@ const SPEC_STRIP_KEYS = new Set([
 	"status",
 ]);
 
+export interface MinimalExportFilter {
+	serverDefaults?: Record<string, unknown>;
+	serverDefaultFields?: string[];
+	minimumConfigFields?: string[];
+	oneofDefaultVariants?: Record<string, string>;
+}
+
 export interface ExportedManifest {
 	kind: string;
 	metadata: Record<string, unknown>;
 	spec: Record<string, unknown>;
 }
 
-export function toManifest(apiResponse: Record<string, unknown>, kind: string): ExportedManifest {
+export function toManifest(
+	apiResponse: Record<string, unknown>,
+	kind: string,
+	filter?: MinimalExportFilter,
+): ExportedManifest {
 	const objectData = apiResponse.object as Record<string, unknown> | undefined;
 	const getSpec = apiResponse.get_spec as Record<string, unknown> | undefined;
 
@@ -38,7 +49,10 @@ export function toManifest(apiResponse: Record<string, unknown>, kind: string): 
 	}
 
 	const rawSpec = (apiResponse.spec ?? objectData?.spec ?? getSpec ?? {}) as Record<string, unknown>;
-	const spec = cleanSpec(rawSpec);
+	let spec = cleanSpec(rawSpec);
+	if (filter) {
+		spec = applyMinimalExportFilter(spec, filter);
+	}
 
 	return { kind, metadata, spec };
 }
@@ -78,6 +92,84 @@ function cleanValue(val: unknown): unknown {
 		return hasContent ? result : val;
 	}
 	return val;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+	if (a === b) return true;
+	if (a === null || b === null || a === undefined || b === undefined) return a === b;
+	if (typeof a !== typeof b) return false;
+	if (typeof a !== "object") return false;
+	if (Array.isArray(a) !== Array.isArray(b)) return false;
+	if (Array.isArray(a) && Array.isArray(b)) {
+		if (a.length !== b.length) return false;
+		return a.every((item, i) => deepEqual(item, b[i]));
+	}
+	const aObj = a as Record<string, unknown>;
+	const bObj = b as Record<string, unknown>;
+	const aKeys = Object.keys(aObj);
+	const bKeys = Object.keys(bObj);
+	if (aKeys.length !== bKeys.length) return false;
+	return aKeys.every(key => key in bObj && deepEqual(aObj[key], bObj[key]));
+}
+
+function isTriviallyEmpty(val: unknown): boolean {
+	if (val === false || val === 0 || val === "") return true;
+	if (Array.isArray(val) && val.length === 0) return true;
+	if (typeof val === "object" && val !== null && !Array.isArray(val) && Object.keys(val as object).length === 0)
+		return true;
+	return false;
+}
+
+export function applyMinimalExportFilter(
+	spec: Record<string, unknown>,
+	filter: MinimalExportFilter | undefined,
+): Record<string, unknown> {
+	if (!filter) return spec;
+
+	const minimumSet = new Set(filter.minimumConfigFields ?? []);
+	const serverDefaults = filter.serverDefaults ?? {};
+	const serverDefaultFieldsSet = new Set(filter.serverDefaultFields ?? []);
+	const oneofDefaults = filter.oneofDefaultVariants ?? {};
+	const oneofDefaultKeys = new Set(Object.keys(oneofDefaults));
+
+	function filterObject(obj: Record<string, unknown>, prefix: string): Record<string, unknown> {
+		const result: Record<string, unknown> = {};
+
+		for (const [key, val] of Object.entries(obj)) {
+			const path = prefix ? `${prefix}.${key}` : key;
+
+			if (minimumSet.has(path)) {
+				result[key] = val;
+				continue;
+			}
+
+			if (path in serverDefaults && deepEqual(val, serverDefaults[path])) {
+				continue;
+			}
+
+			if (serverDefaultFieldsSet.has(path) && isTriviallyEmpty(val)) {
+				continue;
+			}
+
+			if (oneofDefaultKeys.has(key) && deepEqual(val, {})) {
+				continue;
+			}
+
+			if (typeof val === "object" && val !== null && !Array.isArray(val) && Object.keys(val as object).length > 0) {
+				const filtered = filterObject(val as Record<string, unknown>, path);
+				if (Object.keys(filtered).length > 0) {
+					result[key] = filtered;
+				}
+				continue;
+			}
+
+			result[key] = val;
+		}
+
+		return result;
+	}
+
+	return filterObject(spec, "");
 }
 
 export function toManifestList(apiListResponse: Record<string, unknown>, kind: string): ExportedManifest[] {

--- a/packages/resource-management/src/resource-client.ts
+++ b/packages/resource-management/src/resource-client.ts
@@ -5,6 +5,9 @@ import { toManifest, toManifestList } from "./manifest-export";
 const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
 
 import type {
+	HttpTransport,
+	HttpTransportRequest,
+	HttpTransportResponse,
 	KindResolver,
 	OperationResult,
 	ResolvedKind,
@@ -13,6 +16,70 @@ import type {
 	ResourceError,
 	ResourceManifest,
 } from "./types";
+
+export class FetchTransport implements HttpTransport {
+	readonly #apiToken: string;
+
+	constructor(apiToken: string) {
+		this.#apiToken = apiToken;
+	}
+
+	async request(req: HttpTransportRequest): Promise<HttpTransportResponse> {
+		const headers: Record<string, string> = {
+			Authorization: `APIToken ${this.#apiToken}`,
+			Accept: "application/json",
+			"X-Request-ID": crypto.randomUUID(),
+			...req.headers,
+		};
+
+		let resolvedBody: string | undefined;
+		if (req.body && req.method !== "GET") {
+			headers["Content-Type"] = "application/json";
+			resolvedBody = JSON.stringify(req.body);
+		}
+
+		let lastError: Error | undefined;
+
+		for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+			try {
+				const init: RequestInit = {
+					method: req.method,
+					headers,
+					signal: AbortSignal.timeout(30_000),
+					body: resolvedBody,
+				};
+				const response = await fetch(req.url, init);
+
+				if (RETRYABLE_STATUSES.has(response.status) && attempt < MAX_RETRIES) {
+					const retryAfter = response.headers.get("retry-after");
+					const seconds = retryAfter ? Number.parseInt(retryAfter, 10) : Number.NaN;
+					const delayMs =
+						Number.isFinite(seconds) && seconds > 0
+							? Math.min(seconds * 1000, 10_000)
+							: Math.min(1000 * 2 ** attempt, 10_000);
+					await sleep(delayMs);
+					continue;
+				}
+
+				const raw = await response.text();
+				let parsed: Record<string, unknown> | undefined;
+				try {
+					parsed = JSON.parse(raw) as Record<string, unknown>;
+				} catch {
+					// Non-JSON response
+				}
+
+				return { httpStatus: response.status, body: parsed ?? {} };
+			} catch (err) {
+				lastError = err as Error;
+				if (attempt >= MAX_RETRIES) break;
+				await sleep(Math.min(1000 * 2 ** attempt, 10_000));
+			}
+		}
+
+		throw lastError ?? new Error("Request failed after retries");
+	}
+}
 
 const F5XC_ERROR_CODES: Record<number, string> = {
 	3: "INVALID_ARGUMENT",
@@ -31,15 +98,15 @@ const RETRYABLE_STATUSES = new Set([429, 503, 408]);
 
 export class ResourceClient {
 	readonly #apiUrl: string;
-	readonly #apiToken: string;
 	readonly #defaultNamespace: string;
 	readonly #resolvePayloadVars?: (json: string) => string;
+	readonly #transport: HttpTransport;
 
 	constructor(options: ResourceClientOptions) {
 		this.#apiUrl = options.apiUrl;
-		this.#apiToken = options.apiToken;
 		this.#defaultNamespace = options.namespace;
 		this.#resolvePayloadVars = options.resolvePayloadVars;
+		this.#transport = options.transport ?? new FetchTransport(options.apiToken);
 	}
 
 	async apply(
@@ -292,75 +359,33 @@ export class ResourceClient {
 		method: string,
 		body?: Record<string, unknown>,
 	): Promise<{ httpStatus: number; body?: Record<string, unknown>; error?: ResourceError }> {
-		const headers: Record<string, string> = {
-			Authorization: `APIToken ${this.#apiToken}`,
-			Accept: "application/json",
-			"X-Request-ID": crypto.randomUUID(),
-		};
-
-		let resolvedBody: string | undefined;
-		if (body && method !== "GET") {
-			headers["Content-Type"] = "application/json";
-			let jsonBody = JSON.stringify(body);
-			if (this.#resolvePayloadVars) {
-				jsonBody = this.#resolvePayloadVars(jsonBody);
-			}
-			resolvedBody = jsonBody;
+		let resolvedBody = body;
+		if (body && this.#resolvePayloadVars) {
+			const jsonBody = this.#resolvePayloadVars(JSON.stringify(body));
+			resolvedBody = JSON.parse(jsonBody) as Record<string, unknown>;
 		}
 
-		let lastError: ResourceError | undefined;
+		try {
+			const result = await this.#transport.request({
+				method: method as "GET" | "POST" | "PUT" | "DELETE",
+				url,
+				body: resolvedBody,
+			});
 
-		for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-			try {
-				const init: RequestInit = {
-					method,
-					headers,
-					signal: AbortSignal.timeout(30_000),
-					body: resolvedBody,
-				};
-				const response = await fetch(url, init);
-
-				if (RETRYABLE_STATUSES.has(response.status) && attempt < MAX_RETRIES) {
-					const retryAfter = response.headers.get("retry-after");
-					const seconds = retryAfter ? Number.parseInt(retryAfter, 10) : Number.NaN;
-					const delayMs =
-						Number.isFinite(seconds) && seconds > 0
-							? Math.min(seconds * 1000, 10_000)
-							: Math.min(1000 * 2 ** attempt, 10_000);
-					await sleep(delayMs);
-					continue;
-				}
-
-				const raw = await response.text();
-				let parsed: Record<string, unknown> | undefined;
-				try {
-					parsed = JSON.parse(raw) as Record<string, unknown>;
-				} catch {
-					// Non-JSON response
-				}
-
-				if (response.status >= 200 && response.status < 300) {
-					return { httpStatus: response.status, body: parsed ?? {} };
-				}
-
-				if (response.status === 404) {
-					return { httpStatus: 404, error: this.#toResourceError(response.status, parsed, url) };
-				}
-
-				return { httpStatus: response.status, error: this.#toResourceError(response.status, parsed, url) };
-			} catch (err) {
-				if (attempt >= MAX_RETRIES) {
-					lastError = {
-						kind: "network",
-						message: `Network error: ${(err as Error).message}`,
-					};
-					break;
-				}
-				await sleep(Math.min(1000 * 2 ** attempt, 10_000));
+			if (result.httpStatus >= 200 && result.httpStatus < 300) {
+				return { httpStatus: result.httpStatus, body: result.body ?? {} };
 			}
-		}
 
-		return { httpStatus: 0, error: lastError };
+			return {
+				httpStatus: result.httpStatus,
+				error: this.#toResourceError(result.httpStatus, result.body, url),
+			};
+		} catch (err) {
+			return {
+				httpStatus: 0,
+				error: { kind: "network", message: `Network error: ${(err as Error).message}` },
+			};
+		}
 	}
 
 	#toResourceError(status: number, body: Record<string, unknown> | undefined, _url: string): ResourceError {

--- a/packages/resource-management/src/types.ts
+++ b/packages/resource-management/src/types.ts
@@ -143,12 +143,29 @@ export type OperationResult =
 	| { status: "error"; error: ResourceError }
 	| { status: "dry-run"; action: "create" | "update"; diff?: ResourceDiff };
 
+export interface HttpTransportRequest {
+	method: "GET" | "POST" | "PUT" | "DELETE";
+	url: string;
+	body?: Record<string, unknown>;
+	headers?: Record<string, string>;
+}
+
+export interface HttpTransportResponse {
+	httpStatus: number;
+	body?: Record<string, unknown>;
+}
+
+export interface HttpTransport {
+	request(req: HttpTransportRequest): Promise<HttpTransportResponse>;
+}
+
 export interface ResourceClientOptions {
 	apiUrl: string;
 	apiToken: string;
 	namespace: string;
 	dryRun?: "client" | "server";
 	resolvePayloadVars?: (json: string) => string;
+	transport?: HttpTransport;
 }
 
 export interface KindResolver {

--- a/packages/resource-management/test/live-crud-integration.test.ts
+++ b/packages/resource-management/test/live-crud-integration.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Live CRUD integration tests against real F5 XC API.
+ *
+ * Reads credentials from ~/.config/f5xc/contexts/nferreira.json (active context).
+ * Creates test resources with unique names, runs full CRUD cycle, then cleans up.
+ *
+ * Run: F5XC_LIVE_TEST=1 bun test test/live-crud-integration.test.ts
+ * Skip: bun test (skipped by default — won't run in CI)
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createKindResolver } from "../src/kind-resolver";
+import { formatManifestOutput } from "../src/manifest-export";
+import { parseManifests } from "../src/manifest-parser";
+import { ResourceClient } from "../src/resource-client";
+import type { KindResolver } from "../src/types";
+
+const LIVE = process.env.F5XC_LIVE_TEST === "1";
+const SKIP_MSG = "Set F5XC_LIVE_TEST=1 to run live API tests";
+
+const TEST_ID = Date.now().toString(36).slice(-6);
+const TEST_PREFIX = `crud-test-${TEST_ID}`;
+
+interface ContextConfig {
+	apiUrl: string;
+	apiToken: string;
+	defaultNamespace: string;
+}
+
+function loadContext(): ContextConfig {
+	const configDir = path.join(os.homedir(), ".config", "f5xc", "contexts");
+	const ctxFile = path.join(configDir, "nferreira.json");
+	if (!fs.existsSync(ctxFile)) {
+		throw new Error(`Context file not found: ${ctxFile}`);
+	}
+	return JSON.parse(fs.readFileSync(ctxFile, "utf-8")) as ContextConfig;
+}
+
+function buildSpecIndex(resources: Array<{ kind: string; listPath: string; getPath: string }>) {
+	return {
+		version: "live-test",
+		timestamp: new Date().toISOString(),
+		domains: [
+			{
+				domain: "test",
+				title: "Test",
+				description: "Live test resources",
+				descriptionShort: "Test",
+				category: "Test",
+				pathCount: resources.length * 2,
+				schemaCount: 0,
+				complexity: "standard",
+				resources: resources.map(r => ({
+					name: r.kind,
+					description: r.kind,
+					apiPaths: [r.listPath, r.getPath],
+				})),
+			},
+		],
+	};
+}
+
+const RESOURCE_DEFS = [
+	{
+		kind: "healthcheck",
+		listPath: "/api/config/namespaces/{namespace}/healthchecks",
+		getPath: "/api/config/namespaces/{namespace}/healthchecks/{name}",
+		updateField: "timeout",
+		updateValue: 5,
+	},
+	{
+		kind: "app_firewall",
+		listPath: "/api/config/namespaces/{namespace}/app_firewalls",
+		getPath: "/api/config/namespaces/{namespace}/app_firewalls/{name}",
+		updateField: "description_update",
+		updateValue: true,
+	},
+	{
+		kind: "origin_pool",
+		listPath: "/api/config/namespaces/{namespace}/origin_pools",
+		getPath: "/api/config/namespaces/{namespace}/origin_pools/{name}",
+		updateField: "port",
+		updateValue: 8080,
+	},
+	{
+		kind: "http_loadbalancer",
+		listPath: "/api/config/namespaces/{namespace}/http_loadbalancers",
+		getPath: "/api/config/namespaces/{namespace}/http_loadbalancers/{name}",
+		updateField: "domains",
+		updateValue: [`${TEST_PREFIX}-updated.example.com`],
+	},
+];
+
+function buildSpec(kind: string, namespace: string): Record<string, unknown> {
+	const poolName = `${TEST_PREFIX}-origin-pool`;
+	switch (kind) {
+		case "healthcheck":
+			return {
+				http_health_check: { path: "/health" },
+				timeout: 3,
+				interval: 15,
+				unhealthy_threshold: 3,
+				healthy_threshold: 2,
+			};
+		case "app_firewall":
+			return {};
+		case "origin_pool":
+			return {
+				origin_servers: [{ public_ip: { ip: "198.51.100.1" } }],
+				port: 80,
+				no_tls: {},
+				loadbalancer_algorithm: "ROUND_ROBIN",
+			};
+		case "http_loadbalancer":
+			return {
+				domains: [`${TEST_PREFIX}.example.com`],
+				http: { dns_volterra_managed: false, port: 80 },
+				advertise_on_public_default_vip: {},
+				default_route_pools: [{ pool: { namespace, name: poolName }, weight: 1, priority: 1 }],
+			};
+		default:
+			return {};
+	}
+}
+
+const createdResources: Array<{ kind: string; name: string }> = [];
+
+describe.skipIf(!LIVE)("live CRUD integration", () => {
+	let client: ResourceClient;
+	let resolver: KindResolver;
+	let ctx: ContextConfig;
+
+	beforeAll(() => {
+		ctx = loadContext();
+		const specIndex = buildSpecIndex(RESOURCE_DEFS);
+		resolver = createKindResolver(specIndex);
+		client = new ResourceClient({
+			apiUrl: ctx.apiUrl,
+			apiToken: ctx.apiToken,
+			namespace: ctx.defaultNamespace,
+		});
+	});
+
+	afterAll(async () => {
+		for (const { kind, name } of [...createdResources].reverse()) {
+			try {
+				const resolved = resolver.resolveKind(kind);
+				await client.delete(kind, name, resolved, ctx.defaultNamespace);
+			} catch {
+				console.warn(`Cleanup: failed to delete ${kind}/${name}`);
+			}
+		}
+	});
+
+	function resName(kind: string) {
+		return `${TEST_PREFIX}-${kind.replace(/_/g, "-")}`;
+	}
+
+	function makeManifest(kind: string, spec: Record<string, unknown>) {
+		const name = resName(kind);
+		return {
+			kind,
+			metadata: { name, namespace: ctx.defaultNamespace },
+			spec,
+			rawObject: { kind, metadata: { name, namespace: ctx.defaultNamespace }, spec },
+		};
+	}
+
+	// ── Phase 1: CREATE all resources (dependency order) ──
+	describe("Phase 1: CREATE", () => {
+		for (const def of RESOURCE_DEFS) {
+			test(`creates ${def.kind}`, async () => {
+				const resolved = resolver.resolveKind(def.kind);
+				const spec = buildSpec(def.kind, ctx.defaultNamespace);
+				const manifest = makeManifest(def.kind, spec);
+				const result = await client.create(manifest, resolved, ctx.defaultNamespace);
+				if (result.status === "error") {
+					console.error(`CREATE ${def.kind} failed:`, JSON.stringify(result.error, null, 2));
+				}
+				expect(result.status).toBe("created");
+				createdResources.push({ kind: def.kind, name: resName(def.kind) });
+			}, 30_000);
+		}
+	});
+
+	// ── Phase 2: EXPORT + DIFF + APPLY for each resource ──
+	describe("Phase 2: EXPORT + DIFF + APPLY", () => {
+		for (const def of RESOURCE_DEFS) {
+			const name = resName(def.kind);
+
+			test(`${def.kind}: export produces clean manifest`, async () => {
+				const resolved = resolver.resolveKind(def.kind);
+				const result = await client.exportOne(def.kind, resolved, name, ctx.defaultNamespace);
+				expect(result.error).toBeUndefined();
+				expect(result.manifest).toBeDefined();
+				expect(result.manifest!.kind).toBe(def.kind);
+				expect(result.manifest!.metadata.name).toBe(name);
+				expect(result.manifest!.metadata).not.toHaveProperty("uid");
+				expect(result.manifest!.metadata).not.toHaveProperty("creation_timestamp");
+				expect(result.manifest!.spec).not.toHaveProperty("host_name");
+				expect(result.manifest!.spec).not.toHaveProperty("dns_info");
+				expect(result.manifest!.spec).not.toHaveProperty("state");
+			}, 15_000);
+
+			test(`${def.kind}: JSON format round-trips`, async () => {
+				const resolved = resolver.resolveKind(def.kind);
+				const result = await client.exportOne(def.kind, resolved, name, ctx.defaultNamespace);
+				const json = formatManifestOutput([result.manifest!], "json");
+				const reparsed = parseManifests([JSON.parse(json) as Record<string, unknown>], "test");
+				expect(reparsed).toHaveLength(1);
+				expect(reparsed[0].kind).toBe(def.kind);
+				expect(reparsed[0].metadata.name).toBe(name);
+			}, 15_000);
+
+			test(`${def.kind}: YAML format valid`, async () => {
+				const resolved = resolver.resolveKind(def.kind);
+				const result = await client.exportOne(def.kind, resolved, name, ctx.defaultNamespace);
+				const yaml = formatManifestOutput([result.manifest!], "yaml");
+				expect(yaml).toContain(`kind: ${def.kind}`);
+				expect(yaml).toContain(`name: ${name}`);
+			}, 15_000);
+
+			test(`${def.kind}: diff shows no changes on fresh export`, async () => {
+				const resolved = resolver.resolveKind(def.kind);
+				const exportResult = await client.exportOne(def.kind, resolved, name, ctx.defaultNamespace);
+				const manifest = makeManifest(def.kind, exportResult.manifest!.spec);
+				const diffResult = await client.diff(manifest, resolved, ctx.defaultNamespace);
+				expect(diffResult.isNew).toBe(false);
+				expect(diffResult.error).toBeUndefined();
+			}, 15_000);
+
+			test(`${def.kind}: apply update succeeds`, async () => {
+				const resolved = resolver.resolveKind(def.kind);
+				const exportResult = await client.exportOne(def.kind, resolved, name, ctx.defaultNamespace);
+				const updatedSpec = { ...exportResult.manifest!.spec };
+
+				if (def.updateField === "description_update") {
+					// Update via metadata description
+				} else {
+					(updatedSpec as Record<string, unknown>)[def.updateField] = def.updateValue;
+				}
+
+				const manifest = {
+					kind: def.kind,
+					metadata: {
+						name,
+						namespace: ctx.defaultNamespace,
+						description: def.updateField === "description_update" ? "updated by live test" : undefined,
+					},
+					spec: updatedSpec,
+					rawObject: {
+						kind: def.kind,
+						metadata: {
+							name,
+							namespace: ctx.defaultNamespace,
+							description: def.updateField === "description_update" ? "updated by live test" : undefined,
+						},
+						spec: updatedSpec,
+					},
+				};
+
+				const result = await client.apply(manifest, resolved, ctx.defaultNamespace);
+				expect(["updated", "unchanged"]).toContain(result.status);
+			}, 30_000);
+		}
+	});
+
+	// ── Phase 3: DELETE all resources (reverse dependency order) ──
+	describe("Phase 3: DELETE", () => {
+		for (const def of [...RESOURCE_DEFS].reverse()) {
+			const name = resName(def.kind);
+
+			test(`deletes ${def.kind}`, async () => {
+				const resolved = resolver.resolveKind(def.kind);
+				const result = await client.delete(def.kind, name, resolved, ctx.defaultNamespace);
+				expect(result.status).toBe("deleted");
+				const idx = createdResources.findIndex(r => r.kind === def.kind && r.name === name);
+				if (idx >= 0) createdResources.splice(idx, 1);
+			}, 15_000);
+
+			test(`${def.kind} no longer exists`, async () => {
+				const resolved = resolver.resolveKind(def.kind);
+				const getResult = await client.get(resolved, name, ctx.defaultNamespace);
+				expect(getResult.error).toBeDefined();
+				expect(getResult.error!.kind).toBe("not_found");
+			}, 15_000);
+		}
+	});
+});
+
+describe.skipIf(LIVE)("live CRUD integration (skipped)", () => {
+	test(SKIP_MSG, () => {
+		expect(true).toBe(true);
+	});
+});

--- a/packages/resource-management/test/live-crud-integration.test.ts
+++ b/packages/resource-management/test/live-crud-integration.test.ts
@@ -92,6 +92,30 @@ const RESOURCE_DEFS = [
 		updateField: "domains",
 		updateValue: [`${TEST_PREFIX}-updated.example.com`],
 	},
+	{
+		kind: "network_connector",
+		listPath: "/api/config/namespaces/system/network_connectors",
+		getPath: "/api/config/namespaces/system/network_connectors/{name}",
+		updateField: "description_update",
+		updateValue: true,
+		namespace: "system",
+	},
+	{
+		kind: "network_firewall",
+		listPath: "/api/config/namespaces/system/network_firewalls",
+		getPath: "/api/config/namespaces/system/network_firewalls/{name}",
+		updateField: "description_update",
+		updateValue: true,
+		namespace: "system",
+	},
+	{
+		kind: "virtual_site",
+		listPath: "/api/config/namespaces/system/virtual_sites",
+		getPath: "/api/config/namespaces/system/virtual_sites/{name}",
+		updateField: "description_update",
+		updateValue: true,
+		namespace: "system",
+	},
 ];
 
 function buildSpec(kind: string, namespace: string): Record<string, unknown> {
@@ -121,9 +145,28 @@ function buildSpec(kind: string, namespace: string): Record<string, unknown> {
 				advertise_on_public_default_vip: {},
 				default_route_pools: [{ pool: { namespace, name: poolName }, weight: 1, priority: 1 }],
 			};
+		case "network_connector":
+			return {
+				sli_to_global_dr: { global_vn: { name: "public" } },
+				disable_forward_proxy: {},
+			};
+		case "network_firewall":
+			return {
+				no_network_policy: {},
+				no_forward_proxy_policy: {},
+			};
+		case "virtual_site":
+			return {
+				site_type: "CUSTOMER_EDGE",
+				site_selector: { expressions: [`${TEST_PREFIX}`] },
+			};
 		default:
 			return {};
 	}
+}
+
+function getNamespace(def: { namespace?: string }, defaultNs: string): string {
+	return ((def as Record<string, unknown>).namespace as string) ?? defaultNs;
 }
 
 const createdResources: Array<{ kind: string; name: string }> = [];
@@ -159,13 +202,13 @@ describe.skipIf(!LIVE)("live CRUD integration", () => {
 		return `${TEST_PREFIX}-${kind.replace(/_/g, "-")}`;
 	}
 
-	function makeManifest(kind: string, spec: Record<string, unknown>) {
+	function makeManifest(kind: string, ns: string, spec: Record<string, unknown>) {
 		const name = resName(kind);
 		return {
 			kind,
-			metadata: { name, namespace: ctx.defaultNamespace },
+			metadata: { name, namespace: ns },
 			spec,
-			rawObject: { kind, metadata: { name, namespace: ctx.defaultNamespace }, spec },
+			rawObject: { kind, metadata: { name, namespace: ns }, spec },
 		};
 	}
 
@@ -173,10 +216,11 @@ describe.skipIf(!LIVE)("live CRUD integration", () => {
 	describe("Phase 1: CREATE", () => {
 		for (const def of RESOURCE_DEFS) {
 			test(`creates ${def.kind}`, async () => {
+				const ns = getNamespace(def, ctx.defaultNamespace);
 				const resolved = resolver.resolveKind(def.kind);
-				const spec = buildSpec(def.kind, ctx.defaultNamespace);
-				const manifest = makeManifest(def.kind, spec);
-				const result = await client.create(manifest, resolved, ctx.defaultNamespace);
+				const spec = buildSpec(def.kind, ns);
+				const manifest = makeManifest(def.kind, ns, spec);
+				const result = await client.create(manifest, resolved, ns);
 				if (result.status === "error") {
 					console.error(`CREATE ${def.kind} failed:`, JSON.stringify(result.error, null, 2));
 				}
@@ -190,10 +234,11 @@ describe.skipIf(!LIVE)("live CRUD integration", () => {
 	describe("Phase 2: EXPORT + DIFF + APPLY", () => {
 		for (const def of RESOURCE_DEFS) {
 			const name = resName(def.kind);
+			const ns = () => getNamespace(def, ctx.defaultNamespace);
 
 			test(`${def.kind}: export produces clean manifest`, async () => {
 				const resolved = resolver.resolveKind(def.kind);
-				const result = await client.exportOne(def.kind, resolved, name, ctx.defaultNamespace);
+				const result = await client.exportOne(def.kind, resolved, name, ns());
 				expect(result.error).toBeUndefined();
 				expect(result.manifest).toBeDefined();
 				expect(result.manifest!.kind).toBe(def.kind);
@@ -207,7 +252,7 @@ describe.skipIf(!LIVE)("live CRUD integration", () => {
 
 			test(`${def.kind}: JSON format round-trips`, async () => {
 				const resolved = resolver.resolveKind(def.kind);
-				const result = await client.exportOne(def.kind, resolved, name, ctx.defaultNamespace);
+				const result = await client.exportOne(def.kind, resolved, name, ns());
 				const json = formatManifestOutput([result.manifest!], "json");
 				const reparsed = parseManifests([JSON.parse(json) as Record<string, unknown>], "test");
 				expect(reparsed).toHaveLength(1);
@@ -217,7 +262,7 @@ describe.skipIf(!LIVE)("live CRUD integration", () => {
 
 			test(`${def.kind}: YAML format valid`, async () => {
 				const resolved = resolver.resolveKind(def.kind);
-				const result = await client.exportOne(def.kind, resolved, name, ctx.defaultNamespace);
+				const result = await client.exportOne(def.kind, resolved, name, ns());
 				const yaml = formatManifestOutput([result.manifest!], "yaml");
 				expect(yaml).toContain(`kind: ${def.kind}`);
 				expect(yaml).toContain(`name: ${name}`);
@@ -225,16 +270,16 @@ describe.skipIf(!LIVE)("live CRUD integration", () => {
 
 			test(`${def.kind}: diff shows no changes on fresh export`, async () => {
 				const resolved = resolver.resolveKind(def.kind);
-				const exportResult = await client.exportOne(def.kind, resolved, name, ctx.defaultNamespace);
-				const manifest = makeManifest(def.kind, exportResult.manifest!.spec);
-				const diffResult = await client.diff(manifest, resolved, ctx.defaultNamespace);
+				const exportResult = await client.exportOne(def.kind, resolved, name, ns());
+				const manifest = makeManifest(def.kind, ns(), exportResult.manifest!.spec);
+				const diffResult = await client.diff(manifest, resolved, ns());
 				expect(diffResult.isNew).toBe(false);
 				expect(diffResult.error).toBeUndefined();
 			}, 15_000);
 
 			test(`${def.kind}: apply update succeeds`, async () => {
 				const resolved = resolver.resolveKind(def.kind);
-				const exportResult = await client.exportOne(def.kind, resolved, name, ctx.defaultNamespace);
+				const exportResult = await client.exportOne(def.kind, resolved, name, ns());
 				const updatedSpec = { ...exportResult.manifest!.spec };
 
 				if (def.updateField === "description_update") {
@@ -247,7 +292,7 @@ describe.skipIf(!LIVE)("live CRUD integration", () => {
 					kind: def.kind,
 					metadata: {
 						name,
-						namespace: ctx.defaultNamespace,
+						namespace: ns(),
 						description: def.updateField === "description_update" ? "updated by live test" : undefined,
 					},
 					spec: updatedSpec,
@@ -255,14 +300,14 @@ describe.skipIf(!LIVE)("live CRUD integration", () => {
 						kind: def.kind,
 						metadata: {
 							name,
-							namespace: ctx.defaultNamespace,
+							namespace: ns(),
 							description: def.updateField === "description_update" ? "updated by live test" : undefined,
 						},
 						spec: updatedSpec,
 					},
 				};
 
-				const result = await client.apply(manifest, resolved, ctx.defaultNamespace);
+				const result = await client.apply(manifest, resolved, ns());
 				expect(["updated", "unchanged"]).toContain(result.status);
 			}, 30_000);
 		}
@@ -272,10 +317,11 @@ describe.skipIf(!LIVE)("live CRUD integration", () => {
 	describe("Phase 3: DELETE", () => {
 		for (const def of [...RESOURCE_DEFS].reverse()) {
 			const name = resName(def.kind);
+			const ns = () => getNamespace(def, ctx.defaultNamespace);
 
 			test(`deletes ${def.kind}`, async () => {
 				const resolved = resolver.resolveKind(def.kind);
-				const result = await client.delete(def.kind, name, resolved, ctx.defaultNamespace);
+				const result = await client.delete(def.kind, name, resolved, ns());
 				expect(result.status).toBe("deleted");
 				const idx = createdResources.findIndex(r => r.kind === def.kind && r.name === name);
 				if (idx >= 0) createdResources.splice(idx, 1);
@@ -283,7 +329,7 @@ describe.skipIf(!LIVE)("live CRUD integration", () => {
 
 			test(`${def.kind} no longer exists`, async () => {
 				const resolved = resolver.resolveKind(def.kind);
-				const getResult = await client.get(resolved, name, ctx.defaultNamespace);
+				const getResult = await client.get(resolved, name, ns());
 				expect(getResult.error).toBeDefined();
 				expect(getResult.error!.kind).toBe("not_found");
 			}, 15_000);

--- a/packages/resource-management/test/manifest-export.test.ts
+++ b/packages/resource-management/test/manifest-export.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { formatManifestOutput, toManifest, toManifestList } from "../src/manifest-export";
+import type { MinimalExportFilter } from "../src/manifest-export";
+import { applyMinimalExportFilter, formatManifestOutput, toManifest, toManifestList } from "../src/manifest-export";
 
 describe("toManifest", () => {
 	test("extracts kind, metadata, and spec from API response", () => {
@@ -222,5 +223,160 @@ describe("formatManifestOutput", () => {
 		expect(output).toContain("---");
 		expect(output).toContain("kind: http_loadbalancer");
 		expect(output).toContain("kind: origin_pool");
+	});
+});
+
+describe("applyMinimalExportFilter", () => {
+	test("returns spec unchanged when no filter provided", () => {
+		const spec = { domains: ["example.com"], monitoring: {} };
+		const result = applyMinimalExportFilter(spec, undefined);
+		expect(result).toEqual(spec);
+	});
+
+	test("strips field matching known default value", () => {
+		const spec = { domains: ["example.com"], monitoring: {} };
+		const filter: MinimalExportFilter = {
+			serverDefaults: { monitoring: {} },
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual({ domains: ["example.com"] });
+	});
+
+	test("keeps field NOT matching known default value", () => {
+		const spec = { domains: ["example.com"], monitoring: { enabled: true } };
+		const filter: MinimalExportFilter = {
+			serverDefaults: { monitoring: {} },
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual({ domains: ["example.com"], monitoring: { enabled: true } });
+	});
+
+	test("strips trivially-empty server-default field", () => {
+		const spec = { domains: ["example.com"], custom_auth_types: [], add_location: false };
+		const filter: MinimalExportFilter = {
+			serverDefaultFields: ["custom_auth_types", "add_location"],
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual({ domains: ["example.com"] });
+	});
+
+	test("keeps non-empty server-default field", () => {
+		const spec = { custom_auth_types: [{ name: "x" }] };
+		const filter: MinimalExportFilter = {
+			serverDefaultFields: ["custom_auth_types"],
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual({ custom_auth_types: [{ name: "x" }] });
+	});
+
+	test("strips oneof default variant with empty value", () => {
+		const spec = { domains: ["example.com"], round_robin: {} };
+		const filter: MinimalExportFilter = {
+			oneofDefaultVariants: { round_robin: "round_robin" },
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual({ domains: ["example.com"] });
+	});
+
+	test("keeps oneof non-default variant even if empty", () => {
+		const spec = { domains: ["example.com"], least_active: {} };
+		const filter: MinimalExportFilter = {
+			oneofDefaultVariants: { round_robin: "round_robin" },
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual({ domains: ["example.com"], least_active: {} });
+	});
+
+	test("minimum config fields never stripped", () => {
+		const spec = { domains: ["example.com"], advertise_on_public_default_vip: {} };
+		const filter: MinimalExportFilter = {
+			serverDefaultFields: ["advertise_on_public_default_vip"],
+			minimumConfigFields: ["advertise_on_public_default_vip"],
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual({ domains: ["example.com"], advertise_on_public_default_vip: {} });
+	});
+
+	test("unknown fields always kept", () => {
+		const spec = { custom_field: "value", another: { nested: true } };
+		const filter: MinimalExportFilter = {
+			serverDefaults: { monitoring: {} },
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual({ custom_field: "value", another: { nested: true } });
+	});
+
+	test("nested object stripping with parent pruning", () => {
+		const spec = {
+			domains: ["example.com"],
+			detection_settings: {
+				setting_a: {},
+				setting_b: {},
+			},
+		};
+		const filter: MinimalExportFilter = {
+			serverDefaults: {
+				"detection_settings.setting_a": {},
+				"detection_settings.setting_b": {},
+			},
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual({ domains: ["example.com"] });
+	});
+
+	test("nested stripping keeps parent when sibling has content", () => {
+		const spec = {
+			detection_settings: {
+				setting_a: {},
+				setting_b: { custom: true },
+			},
+		};
+		const filter: MinimalExportFilter = {
+			serverDefaults: { "detection_settings.setting_a": {} },
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual({ detection_settings: { setting_b: { custom: true } } });
+	});
+
+	test("real resource: app_firewall minimal export", () => {
+		const spec = {
+			detection_settings: { custom_rule: "block" },
+			monitoring: {},
+			allow_all_response_codes: {},
+			default_anonymization: {},
+			default_bot_setting: {},
+			default_detection_settings: {},
+			use_default_blocking_page: {},
+			disable_ai_enhancements: {},
+		};
+		const filter: MinimalExportFilter = {
+			serverDefaults: {
+				monitoring: {},
+				allow_all_response_codes: {},
+				default_anonymization: {},
+				default_bot_setting: {},
+				default_detection_settings: {},
+				use_default_blocking_page: {},
+				disable_ai_enhancements: {},
+			},
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual({ detection_settings: { custom_rule: "block" } });
+	});
+
+	test("toManifest with filter produces minimal output", () => {
+		const apiResponse = {
+			metadata: { name: "fw", namespace: "ns" },
+			spec: {
+				user_field: "value",
+				monitoring: {},
+				default_detection_settings: {},
+			},
+		};
+		const filter: MinimalExportFilter = {
+			serverDefaults: { monitoring: {}, default_detection_settings: {} },
+		};
+		const result = toManifest(apiResponse, "app_firewall", filter);
+		expect(result.spec).toEqual({ user_field: "value" });
 	});
 });

--- a/packages/resource-management/test/minimal-export-matrix.test.ts
+++ b/packages/resource-management/test/minimal-export-matrix.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, test } from "bun:test";
+import type { MinimalExportFilter } from "../src/manifest-export";
+import { applyMinimalExportFilter, formatManifestOutput, toManifest } from "../src/manifest-export";
+import { parseManifests } from "../src/manifest-parser";
+
+function makeFilter(overrides: Partial<MinimalExportFilter> = {}): MinimalExportFilter {
+	return {
+		serverDefaults: {},
+		serverDefaultFields: [],
+		minimumConfigFields: [],
+		oneofDefaultVariants: {},
+		...overrides,
+	};
+}
+
+function roundTrip(spec: Record<string, unknown>, kind: string): Record<string, unknown> {
+	const manifest = { kind, metadata: { name: "test", namespace: "ns" }, spec };
+	const json = formatManifestOutput([manifest], "json");
+	const parsed = parseManifests([JSON.parse(json) as Record<string, unknown>], "test");
+	return parsed[0].spec;
+}
+
+describe("round-trip: export → format → parse for each resource type", () => {
+	const resourceTypes = [
+		"http_loadbalancer",
+		"origin_pool",
+		"healthcheck",
+		"app_firewall",
+		"route",
+		"api_discovery",
+		"network_connector",
+		"network_firewall",
+		"network_policy",
+		"site_mesh_group",
+		"virtual_site",
+		"virtual_network",
+	] as const;
+
+	for (const kind of resourceTypes) {
+		test(`${kind}: filtered manifest round-trips through format→parse`, () => {
+			const spec = { user_field: "value", domains: ["example.com"] };
+			const filter = makeFilter({ serverDefaults: { default_field: {} } });
+			const apiResponse = {
+				metadata: { name: `test-${kind}`, namespace: "ns" },
+				spec: { ...spec, default_field: {} },
+			};
+
+			const manifest = toManifest(apiResponse, kind, filter);
+			expect(manifest.spec).not.toHaveProperty("default_field");
+			expect(manifest.spec).toHaveProperty("user_field");
+
+			const formatted = formatManifestOutput([manifest], "json");
+			const reparsed = parseManifests([JSON.parse(formatted) as Record<string, unknown>], "test");
+			expect(reparsed).toHaveLength(1);
+			expect(reparsed[0].kind).toBe(kind);
+			expect(reparsed[0].metadata.name).toBe(`test-${kind}`);
+		});
+
+		test(`${kind}: YAML round-trip preserves content`, () => {
+			const apiResponse = {
+				metadata: { name: `yaml-${kind}`, namespace: "ns" },
+				spec: { domains: ["example.com"], config: { enabled: true } },
+			};
+
+			const manifest = toManifest(apiResponse, kind);
+			const yaml = formatManifestOutput([manifest], "yaml");
+
+			expect(yaml).toContain(`kind: ${kind}`);
+			expect(yaml).toContain(`name: yaml-${kind}`);
+			expect(yaml).toContain("example.com");
+		});
+	}
+});
+
+describe("stripping behavior matrix", () => {
+	test("app_firewall: strips 7 known server defaults", () => {
+		const filter = makeFilter({
+			serverDefaults: {
+				monitoring: {},
+				allow_all_response_codes: {},
+				default_anonymization: {},
+				default_bot_setting: {},
+				default_detection_settings: {},
+				use_default_blocking_page: {},
+				disable_ai_enhancements: {},
+			},
+		});
+
+		const spec = {
+			detection_settings: { signature_selection_setting: { default_attack_type_settings: {} } },
+			monitoring: {},
+			allow_all_response_codes: {},
+			default_anonymization: {},
+			default_bot_setting: {},
+			default_detection_settings: {},
+			use_default_blocking_page: {},
+			disable_ai_enhancements: {},
+		};
+
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(Object.keys(result)).toEqual(["detection_settings"]);
+	});
+
+	test("app_firewall: keeps non-default monitoring value", () => {
+		const filter = makeFilter({ serverDefaults: { monitoring: {} } });
+		const spec = { monitoring: { enabled: true }, user_config: "value" };
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toHaveProperty("monitoring");
+		expect(result).toHaveProperty("user_config");
+	});
+
+	test("healthcheck: minimumConfigFields survive stripping", () => {
+		const filter = makeFilter({
+			serverDefaultFields: ["timeout", "interval", "unhealthy_threshold", "healthy_threshold"],
+			minimumConfigFields: ["timeout", "interval"],
+		});
+		const spec = { timeout: 0, interval: 0, unhealthy_threshold: 0, healthy_threshold: 0, custom: "yes" };
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toHaveProperty("timeout");
+		expect(result).toHaveProperty("interval");
+		expect(result).not.toHaveProperty("unhealthy_threshold");
+		expect(result).not.toHaveProperty("healthy_threshold");
+		expect(result).toHaveProperty("custom");
+	});
+
+	test("http_loadbalancer: oneOf default variant stripped, non-default kept", () => {
+		const filter = makeFilter({
+			oneofDefaultVariants: {
+				round_robin: "round_robin",
+				disable_rate_limit: "disable_rate_limit",
+				no_challenge: "no_challenge",
+			},
+		});
+
+		const specWithDefaults = {
+			domains: ["example.com"],
+			round_robin: {},
+			disable_rate_limit: {},
+			no_challenge: {},
+		};
+		const result1 = applyMinimalExportFilter(specWithDefaults, filter);
+		expect(result1).toEqual({ domains: ["example.com"] });
+
+		const specWithNonDefaults = {
+			domains: ["example.com"],
+			least_active: {},
+			rate_limit: { total_number: 100 },
+			js_challenge: { js_script_delay: 5000 },
+		};
+		const result2 = applyMinimalExportFilter(specWithNonDefaults, filter);
+		expect(result2).toEqual(specWithNonDefaults);
+	});
+
+	test("origin_pool: complex nested spec preserves user config", () => {
+		const filter = makeFilter({
+			serverDefaultFields: ["no_tls", "same_as_endpoint_port"],
+			oneofDefaultVariants: { round_robin: "round_robin" },
+		});
+		const spec = {
+			origin_servers: [{ public_ip: { ip: "1.2.3.4" } }],
+			port: 443,
+			use_tls: { sni: "example.com" },
+			loadbalancer_algorithm: "ROUND_ROBIN",
+			round_robin: {},
+			no_tls: {},
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toHaveProperty("origin_servers");
+		expect(result).toHaveProperty("port");
+		expect(result).toHaveProperty("use_tls");
+		expect(result).toHaveProperty("loadbalancer_algorithm");
+		expect(result).not.toHaveProperty("round_robin");
+		expect(result).not.toHaveProperty("no_tls");
+	});
+
+	test("network_firewall: strips server defaults, keeps user policies", () => {
+		const filter = makeFilter({
+			serverDefaults: { default_detection_settings: {}, monitoring: {} },
+			serverDefaultFields: ["disable_intrusion_prevention"],
+		});
+		const spec = {
+			active_enhanced_firewall_policies: { policies: [{ name: "my-policy" }] },
+			default_detection_settings: {},
+			monitoring: {},
+			disable_intrusion_prevention: {},
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual({
+			active_enhanced_firewall_policies: { policies: [{ name: "my-policy" }] },
+		});
+	});
+
+	test("virtual_network: unknown fields always kept", () => {
+		const filter = makeFilter({ serverDefaults: { known_default: {} } });
+		const spec = {
+			site_local_network: true,
+			custom_config: { subnets: ["10.0.0.0/8"] },
+			known_default: {},
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toHaveProperty("site_local_network");
+		expect(result).toHaveProperty("custom_config");
+		expect(result).not.toHaveProperty("known_default");
+	});
+
+	test("site_mesh_group: all user config preserved when no defaults match", () => {
+		const filter = makeFilter();
+		const spec = {
+			type: "SITE_MESH_GROUP_TYPE_FULL_MESH",
+			virtual_site: { tenant: "t", namespace: "ns", name: "vs" },
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual(spec);
+	});
+
+	test("network_policy: nested parent pruning after child strip", () => {
+		const filter = makeFilter({
+			serverDefaults: { "rules.default_action": {} },
+		});
+		const spec = {
+			rules: { default_action: {}, custom_rule: "block" },
+			endpoint: { any: true },
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual({
+			rules: { custom_rule: "block" },
+			endpoint: { any: true },
+		});
+	});
+
+	test("api_discovery: strips single server default", () => {
+		const filter = makeFilter({ serverDefaults: { discovered_api_settings: {} } });
+		const spec = {
+			discovery_config: { enable: true },
+			discovered_api_settings: {},
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual({ discovery_config: { enable: true } });
+	});
+
+	test("route: empty filter preserves everything", () => {
+		const filter = makeFilter();
+		const spec = {
+			match: { path: { prefix: "/api" } },
+			route_destination: { destinations: [{ cluster: { name: "backend" } }] },
+		};
+		const result = applyMinimalExportFilter(spec, filter);
+		expect(result).toEqual(spec);
+	});
+});

--- a/packages/resource-management/test/minimal-export-matrix.test.ts
+++ b/packages/resource-management/test/minimal-export-matrix.test.ts
@@ -13,7 +13,7 @@ function makeFilter(overrides: Partial<MinimalExportFilter> = {}): MinimalExport
 	};
 }
 
-function roundTrip(spec: Record<string, unknown>, kind: string): Record<string, unknown> {
+function _roundTrip(spec: Record<string, unknown>, kind: string): Record<string, unknown> {
 	const manifest = { kind, metadata: { name: "test", namespace: "ns" }, spec };
 	const json = formatManifestOutput([manifest], "json");
 	const parsed = parseManifests([JSON.parse(json) as Record<string, unknown>], "test");

--- a/packages/resource-management/test/resource-client-transport.test.ts
+++ b/packages/resource-management/test/resource-client-transport.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import { ResourceClient } from "../src/resource-client";
+import type { HttpTransport, HttpTransportRequest, HttpTransportResponse } from "../src/types";
+
+class MockTransport implements HttpTransport {
+	readonly calls: HttpTransportRequest[] = [];
+	response: HttpTransportResponse = { httpStatus: 200, body: {} };
+
+	async request(req: HttpTransportRequest): Promise<HttpTransportResponse> {
+		this.calls.push(req);
+		return this.response;
+	}
+}
+
+const dummyResolvedKind = {
+	kind: "http_loadbalancer",
+	domain: "networking",
+	resource: { name: "http_loadbalancer", description: "HTTP LB", apiPaths: [] },
+	paths: {
+		list: "/api/config/namespaces/{namespace}/http_loadbalancers",
+		get: "/api/config/namespaces/{namespace}/http_loadbalancers/{name}",
+		create: "/api/config/namespaces/{namespace}/http_loadbalancers",
+		update: "/api/config/namespaces/{namespace}/http_loadbalancers/{name}",
+		delete: "/api/config/namespaces/{namespace}/http_loadbalancers/{name}",
+	},
+};
+
+describe("ResourceClient with custom transport", () => {
+	test("uses injected transport for GET requests", async () => {
+		const transport = new MockTransport();
+		transport.response = {
+			httpStatus: 200,
+			body: { items: [{ metadata: { name: "lb-1" }, spec: {} }] },
+		};
+
+		const client = new ResourceClient({
+			apiUrl: "https://test.f5xc.com/api",
+			apiToken: "test-token",
+			namespace: "default",
+			transport,
+		});
+
+		const result = await client.get(dummyResolvedKind);
+		expect(result.items).toHaveLength(1);
+		expect(transport.calls).toHaveLength(1);
+		expect(transport.calls[0].method).toBe("GET");
+		expect(transport.calls[0].url).toContain("/http_loadbalancers");
+	});
+
+	test("uses injected transport for exportOne", async () => {
+		const transport = new MockTransport();
+		transport.response = {
+			httpStatus: 200,
+			body: {
+				metadata: { name: "my-lb", namespace: "default" },
+				spec: { domains: ["example.com"] },
+			},
+		};
+
+		const client = new ResourceClient({
+			apiUrl: "https://test.f5xc.com/api",
+			apiToken: "test-token",
+			namespace: "default",
+			transport,
+		});
+
+		const result = await client.exportOne("http_loadbalancer", dummyResolvedKind, "my-lb");
+		expect(result.manifest).toBeDefined();
+		expect(result.manifest!.kind).toBe("http_loadbalancer");
+		expect(result.manifest!.metadata.name).toBe("my-lb");
+		expect(transport.calls).toHaveLength(1);
+		expect(transport.calls[0].url).toContain("my-lb");
+	});
+
+	test("handles 404 from transport", async () => {
+		const transport = new MockTransport();
+		transport.response = { httpStatus: 404, body: { message: "Not found" } };
+
+		const client = new ResourceClient({
+			apiUrl: "https://test.f5xc.com/api",
+			apiToken: "test-token",
+			namespace: "default",
+			transport,
+		});
+
+		const result = await client.exportOne("http_loadbalancer", dummyResolvedKind, "nonexistent");
+		expect(result.error).toBeDefined();
+		expect(result.error!.kind).toBe("not_found");
+	});
+
+	test("handles auth error from transport", async () => {
+		const transport = new MockTransport();
+		transport.response = { httpStatus: 401, body: { message: "Unauthorized" } };
+
+		const client = new ResourceClient({
+			apiUrl: "https://test.f5xc.com/api",
+			apiToken: "bad-token",
+			namespace: "default",
+			transport,
+		});
+
+		const result = await client.get(dummyResolvedKind, "my-lb");
+		expect(result.error).toBeDefined();
+		expect(result.error!.kind).toBe("auth");
+	});
+
+	test("passes POST body through transport for create", async () => {
+		const transport = new MockTransport();
+		transport.response = {
+			httpStatus: 200,
+			body: { metadata: { name: "new-lb" }, spec: {} },
+		};
+
+		const client = new ResourceClient({
+			apiUrl: "https://test.f5xc.com/api",
+			apiToken: "test-token",
+			namespace: "default",
+			transport,
+		});
+
+		const manifest = {
+			kind: "http_loadbalancer",
+			metadata: { name: "new-lb" },
+			spec: { domains: ["new.example.com"] },
+			rawObject: {
+				kind: "http_loadbalancer",
+				metadata: { name: "new-lb" },
+				spec: { domains: ["new.example.com"] },
+			},
+		};
+
+		const result = await client.create(manifest, dummyResolvedKind);
+		expect(result.status).toBe("created");
+		expect(transport.calls).toHaveLength(1);
+		expect(transport.calls[0].method).toBe("POST");
+		expect(transport.calls[0].body).toBeDefined();
+	});
+
+	test("falls back to FetchTransport when no transport provided", () => {
+		const client = new ResourceClient({
+			apiUrl: "https://test.f5xc.com/api",
+			apiToken: "test-token",
+			namespace: "default",
+		});
+		// Just verify it constructs without error — actual fetch would hit network
+		expect(client).toBeDefined();
+	});
+
+	test("apply detects resource as new when GET returns 404", async () => {
+		const transport = new MockTransport();
+		let callCount = 0;
+		transport.request = async _req => {
+			callCount++;
+			if (callCount === 1) {
+				// GET check returns 404
+				return { httpStatus: 404, body: { message: "Not found" } };
+			}
+			// POST create returns success
+			return { httpStatus: 200, body: { metadata: { name: "new-lb" }, spec: {} } };
+		};
+
+		const client = new ResourceClient({
+			apiUrl: "https://test.f5xc.com/api",
+			apiToken: "test-token",
+			namespace: "default",
+			transport,
+		});
+
+		const manifest = {
+			kind: "http_loadbalancer",
+			metadata: { name: "new-lb" },
+			spec: {},
+			rawObject: { kind: "http_loadbalancer", metadata: { name: "new-lb" }, spec: {} },
+		};
+
+		const result = await client.apply(manifest, dummyResolvedKind);
+		expect(result.status).toBe("created");
+	});
+});


### PR DESCRIPTION
## Summary
- Add injectable `HttpTransport` interface to `ResourceClient` so the VS Code extension can plug in `F5XCClient` as the HTTP backend
- Extract built-in fetch logic into `FetchTransport` class (backwards compatible — CLI behavior unchanged)
- Strip read-only/status fields from exported manifests: `host_name`, `dns_info`, `state`, `auto_cert_info`, `internet_vip_info`, `cert_state`, `create_form`, `replace_form`, `status`
- Clean null values and empty arrays from exported spec (keep empty objects as they are meaningful config flags)
- Handle multiple API response formats in `toManifest()`: `metadata`/`spec`, `object.metadata`/`object.spec`, `get_spec`
- Add `require` condition to package exports for webpack/CJS compatibility

## Test plan
- [x] 7 new transport adapter tests (MockTransport injection, GET/POST/404/401 handling, apply create-on-404)
- [x] All 83 existing tests pass
- [x] Biome lint clean, type check clean
- [x] UAT verified: exported manifests are clean, round-trip export→apply works

Closes #1441

🤖 Generated with [Claude Code](https://claude.com/claude-code)