### PR TITLE
chore: bump pi-resource-management to v19.31.1

### DIFF
--- a/packages/resource-management/package.json
+++ b/packages/resource-management/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-resource-management",
-	"version": "19.31.0",
+	"version": "19.31.1",
 	"description": "Shared resource management for F5 XC manifest parsing, validation, diff, and CRUD operations",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Robin Mordasiewicz",


### PR DESCRIPTION
## Summary
- Bump version to trigger npm publish of HttpTransport adapter, MinimalExportFilter, and clean manifest exports

Closes #1445
Required by: f5xc-salesdemos/vscode-f5xc-tools#422

🤖 Generated with [Claude Code](https://claude.com/claude-code)