### PR TITLE
fix(tui): de-blob StdinBuffer.flush so capability-probe responses don't leak as text on cold launch

### DIFF
--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -398,9 +398,12 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 				}
 
 				// Remember a flushed incomplete escape so a continuation arriving in
-				// the next read can be reassembled (see process()).
+				// the next read can be reassembled (see process()). Only a genuinely
+				// incomplete trailing fragment qualifies — a complete sequence (e.g.
+				// one peeled out of a de-blobbed probe response) is not a keypress
+				// awaiting its tail and must not glue onto the next read.
 				const last = flushed[flushed.length - 1];
-				if (last !== undefined && last.startsWith(ESC)) {
+				if (last !== undefined && last.startsWith(ESC) && isCompleteSequence(last) === "incomplete") {
 					this.#pendingEscape = last;
 					this.#pendingEscapeAt = Date.now();
 				}
@@ -418,9 +421,42 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 			return [];
 		}
 
-		const sequences = [this.#buffer];
+		// Re-split the abandoned buffer into individual complete sequences instead
+		// of emitting it whole. Under render load a terminal *response* can arrive
+		// before its terminator (notably an OSC 11 reply missing its ST); the
+		// tokenizer then treats it as incomplete and, while scanning for the
+		// terminator, absorbs any following replies (DA1, Kitty) into one fragment.
+		// Emitting that as a single event defeats the terminal's anchored
+		// single-sequence matchers, so the whole blob leaks into the editor as text
+		// (#1446). Split an unterminated string sequence (OSC/DCS/APC) at an
+		// embedded ESC that introduces a new sequence so each reply is recognized
+		// and swallowed on its own.
+		const out: string[] = [];
+		let work = this.#buffer;
 		this.#buffer = "";
-		return sequences;
+
+		while (work.length > 0) {
+			const { sequences, remainder } = extractCompleteSequences(work);
+			out.push(...sequences);
+			if (remainder.length === 0) {
+				break;
+			}
+			// The remainder is an incomplete ESC-led fragment. If it absorbed a
+			// later sequence (an embedded ESC beyond the introducer), peel off the
+			// abandoned prefix and re-extract from the embedded boundary; otherwise
+			// it is a genuine trailing fragment (e.g. a lone Escape keypress or a
+			// half-arrived CSI) and is emitted as-is.
+			const embeddedEsc = remainder.indexOf(ESC, 1);
+			if (embeddedEsc > 0) {
+				out.push(remainder.slice(0, embeddedEsc));
+				work = remainder.slice(embeddedEsc);
+			} else {
+				out.push(remainder);
+				break;
+			}
+		}
+
+		return out;
 	}
 
 	clear(): void {

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -314,6 +314,37 @@ describe("StdinBuffer", () => {
 
 			expect(emittedSequences).toEqual(["\x1b[<35"]);
 		});
+
+		// Regression: a capability-probe leak on cold launch (#1446). Under render
+		// load an OSC 11 reply arrives before its ST terminator; the tokenizer's
+		// OSC rule, hunting for the terminator, absorbs the following DA1 reply into
+		// one incomplete fragment. On flush this must be re-split into the individual
+		// complete sequences — NOT emitted as a single un-parseable blob that the
+		// terminal's anchored single-sequence matchers then forward to the editor.
+		it("re-splits an abandoned OSC that absorbed a following DA1 reply", () => {
+			// OSC 11 reply WITHOUT terminator, immediately followed by a complete DA1.
+			processInput("\x1b]11;rgb:158e/193a/1e75\x1b[?64;1;2;4;6;17;18;21;22;52c");
+			const flushed = buffer.flush();
+
+			// The DA1 reply must come out as its own complete sequence so it can be
+			// recognized and swallowed; no single element may contain BOTH replies.
+			expect(flushed).toContain("\x1b[?64;1;2;4;6;17;18;21;22;52c");
+			expect(flushed.some(s => s.includes("]11;") && s.includes("?64;"))).toBe(false);
+		});
+
+		it("re-splits a kitty + OSC(no ST) + DA1 cold-launch probe blob", async () => {
+			// The exact concatenation seen leaking into the editor on first launch.
+			processInput("\x1b[?0u\x1b]11;rgb:158e/193a/1e75\x1b[?64;1;2;4;6;17;18;21;22;52c");
+			await Bun.sleep(15); // timeout flush
+
+			// Every emitted element must be a single complete probe response — none
+			// may carry more than one sequence (which would defeat the matchers).
+			const blob = emittedSequences.find(s => (s.match(/\x1b/g) ?? []).length > 1 && !s.includes("\x1b\\"));
+			expect(blob).toBeUndefined();
+			// The kitty and DA1 replies must each appear as their own clean sequence.
+			expect(emittedSequences).toContain("\x1b[?0u");
+			expect(emittedSequences).toContain("\x1b[?64;1;2;4;6;17;18;21;22;52c");
+		});
 	});
 
 	describe("Clear", () => {


### PR DESCRIPTION
Closes #1446

## Symptom
On a cold first launch (plugin init slows the welcome render), terminal capability-probe responses flashed into the editor input box as text, then a later render scrubbed them:

```
^[[?0u^[]11;rgb:158e/193a/1e75^[\^[[?64;1;2;4;6;17;18;21;22;52c
```

Kitty keyboard + OSC 11 background color + DA1 device attributes, concatenated. Intermittent (warm relaunch clean) — a load/timing race. Observed on v19.31.0.

## Root cause (confirmed empirically)
Under render load an OSC 11 reply arrives before its ST terminator. `StdinBuffer`'s tokenizer treats it as incomplete and, while scanning for the terminator, **absorbs the following DA1/Kitty replies into one fragment**. When the 50ms ESC-hold expires, `flush()` emitted that entire buffer as a **single `data` event**. The terminal-layer (`terminal.ts`) and TUI-layer (`tui.ts`) swallow guards are all **anchored single-sequence matchers** (`^…$`), so a multi-sequence blob matched none of them and fell through to the editor as text.

This is the long-standing "Window C / plugin-init" leak. Prior fixes covered the credential-fix stop/start cycle (#1410) and Ctrl+C fragmentation (#1415, #1432); this first-launch path was never fixed.

## Fix
`StdinBuffer.flush()` now **re-splits** the abandoned buffer into individual complete sequences — peeling an unterminated string sequence (OSC/DCS/APC) at an embedded ESC that introduces a new sequence — so each probe reply is emitted on its own and recognized/swallowed by the existing matchers. `pendingEscape` reassembly now arms only for a genuinely incomplete trailing fragment, so a complete sequence peeled out of a blob never glues onto the next read.

## Tests (TDD, RED→GREEN)
- `StdinBuffer` unit: flush of `OSC11(no ST) + DA1` re-splits instead of emitting one blob; the exact cold-launch `kitty + OSC + DA1` concatenation is split into clean per-sequence events. (Both failed before the fix.)
- Full workspace suite: **6049 pass / 0 fail** (7035 tests). No regressions to the partial-OSC, appearance-detection, lone-Escape, or fragmented-Ctrl+C behaviors.

## Verification
Mechanism proven by unit tests + full suite. Real-terminal confirmation pending: hammer Ctrl+C-free cold starts (ideally right after an update, when plugin init is heaviest) to confirm no `^[[?…` flash.