### PR TITLE
chore: bump version to v19.32.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "pi-natives"
-version = "19.32.0"
+version = "19.32.1"
 dependencies = [
  "arboard",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/brush-core-vendored", "crates/brush-builtins-vendored", "crat
 resolver = "3"
 
 [workspace.package]
-version = "19.32.0"
+version = "19.32.1"
 edition = "2024"
 license = "MIT"
 authors = ["Can Boluk"]

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/agent": {
       "name": "@f5xc-salesdemos/pi-agent-core",
-      "version": "19.32.0",
+      "version": "19.32.1",
       "dependencies": {
         "@f5xc-salesdemos/pi-ai": "workspace:*",
         "@f5xc-salesdemos/pi-utils": "workspace:*",
@@ -28,7 +28,7 @@
     },
     "packages/ai": {
       "name": "@f5xc-salesdemos/pi-ai",
-      "version": "19.32.0",
+      "version": "19.32.1",
       "bin": {
         "pi-ai": "./src/cli.ts",
       },
@@ -52,7 +52,7 @@
     },
     "packages/coding-agent": {
       "name": "@f5xc-salesdemos/xcsh",
-      "version": "19.32.0",
+      "version": "19.32.1",
       "bin": {
         "xcsh": "src/cli.ts",
       },
@@ -86,22 +86,22 @@
     },
     "packages/natives": {
       "name": "@f5xc-salesdemos/pi-natives",
-      "version": "19.32.0",
+      "version": "19.32.1",
       "devDependencies": {
         "@napi-rs/cli": "3.6.0",
         "@types/bun": "^1.3",
       },
       "optionalDependencies": {
-        "@f5xc-salesdemos/pi-natives-darwin-arm64": "19.32.0",
-        "@f5xc-salesdemos/pi-natives-darwin-x64": "19.32.0",
-        "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "19.32.0",
-        "@f5xc-salesdemos/pi-natives-linux-x64-gnu": "19.32.0",
-        "@f5xc-salesdemos/pi-natives-win32-x64-msvc": "19.32.0",
+        "@f5xc-salesdemos/pi-natives-darwin-arm64": "19.32.1",
+        "@f5xc-salesdemos/pi-natives-darwin-x64": "19.32.1",
+        "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "19.32.1",
+        "@f5xc-salesdemos/pi-natives-linux-x64-gnu": "19.32.1",
+        "@f5xc-salesdemos/pi-natives-win32-x64-msvc": "19.32.1",
       },
     },
     "packages/resource-management": {
       "name": "@f5xc-salesdemos/pi-resource-management",
-      "version": "19.32.0",
+      "version": "19.32.1",
       "dependencies": {
         "yaml": "2.9.0",
       },
@@ -111,7 +111,7 @@
     },
     "packages/stats": {
       "name": "@f5xc-salesdemos/xcsh-stats",
-      "version": "19.32.0",
+      "version": "19.32.1",
       "bin": {
         "xcsh-stats": "./src/index.ts",
       },
@@ -136,7 +136,7 @@
     },
     "packages/swarm-extension": {
       "name": "@f5xc-salesdemos/swarm-extension",
-      "version": "19.32.0",
+      "version": "19.32.1",
       "bin": {
         "xcsh-swarm": "src/cli.ts",
       },
@@ -152,7 +152,7 @@
     },
     "packages/tui": {
       "name": "@f5xc-salesdemos/pi-tui",
-      "version": "19.32.0",
+      "version": "19.32.1",
       "dependencies": {
         "@f5xc-salesdemos/pi-natives": "workspace:*",
         "@f5xc-salesdemos/pi-utils": "workspace:*",
@@ -191,7 +191,7 @@
     },
     "packages/utils": {
       "name": "@f5xc-salesdemos/pi-utils",
-      "version": "19.32.0",
+      "version": "19.32.1",
       "dependencies": {
         "@f5xc-salesdemos/i18n-core": "^1.0.0",
         "beautiful-mermaid": "^1.1",
@@ -720,7 +720,7 @@
 
     "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
-    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-agent-core",
-	"version": "19.32.0",
+	"version": "19.32.1",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-ai",
-	"version": "19.32.0",
+	"version": "19.32.1",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/xcsh",
-	"version": "19.32.0",
+	"version": "19.32.1",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/coding-agent/src/internal-urls/branding-index.generated.ts
+++ b/packages/coding-agent/src/internal-urls/branding-index.generated.ts
@@ -1,77 +1,88 @@
 // AUTO-GENERATED — do not edit. Run `bun generate-branding-index` to regenerate.
 
-export const BRANDING_VERSION = "1.0.0";
+export const BRANDING_VERSION = "2.0.0";
 
 export const BRANDING_CANONICAL = {
 	managed_kubernetes: {
-		long_form: "F5 XC Managed Kubernetes",
-		short_form: "XCKS",
-		full_acronym: "XC Kubernetes Service",
+		long_form: "Managed Kubernetes",
 		description:
-			"Enterprise-grade Kubernetes cluster management comparable to AWS EKS, Azure AKS, and Google GKE. Full cluster control with RBAC, pod security, and container registry management.\n",
+			"Enterprise-grade Kubernetes cluster management. Full cluster control with RBAC, pod security, and container registry management.\n",
 		legacy_names: ["AppStack", "VoltStack", "voltstack_site"],
 		comparable_to: ["AWS EKS", "Azure AKS", "Google GKE"],
-		use_cases: [
-			"Deploy and manage Kubernetes clusters on-premises or in cloud",
-			"Configure RBAC roles and cluster security policies",
-			"Manage container registries and pod security admission",
-			"Integrate with existing enterprise Kubernetes infrastructure",
-		],
 	},
-	container_services: {
-		long_form: "F5 XC Container Services",
-		short_form: "XCCS",
-		full_acronym: "XC Container Services",
+	virtual_kubernetes: {
+		long_form: "Virtual Kubernetes",
 		description:
-			"Simplified, multi-tenant container orchestration comparable to AWS ECS and Azure Container Services. Optimized for distributed edge deployments with restricted Kubernetes capabilities (no operators, CRDs, privileged mode).\n",
-		legacy_names: ["Virtual Kubernetes", "vK8s", "virtual_k8s"],
+			"Simplified, multi-tenant container orchestration. Optimized for distributed edge deployments with restricted Kubernetes capabilities.\n",
+		legacy_names: ["vK8s", "virtual_k8s"],
 		comparable_to: ["AWS ECS", "Azure Container Services", "Cloud Run"],
-		use_cases: [
-			"Deploy container workloads across distributed edge sites",
-			"Run multi-tenant containerized applications",
-			"Simplified container orchestration without K8s complexity",
-			"Edge-optimized container deployments",
-		],
 	},
 } as const;
 
-export const BRANDING_DEPRECATIONS = null;
+export const BRANDING_DEPRECATIONS = {
+	terraform_provider: {
+		deprecated: {
+			registry: "registry.terraform.io/providers/volterraedge/volterra",
+			source: "volterraedge/volterra",
+			github: "github.com/volterraedge/terraform-provider-volterra",
+			status: "active-but-deprecated",
+			last_version: "0.11.49",
+			downloads: "1M+",
+			note: "Still live on registry with no deprecation notice. High risk of AI model recommendation due to training data prevalence.\n",
+		},
+		canonical: {
+			registry: "registry.terraform.io/providers/f5xc-salesdemos/f5xc",
+			source: "f5xc-salesdemos/f5xc",
+			github: "github.com/f5xc-salesdemos/terraform-provider-f5xc",
+			docs: "https://f5xc-salesdemos.github.io/terraform-provider-f5xc/",
+			llms_txt: "https://f5xc-salesdemos.github.io/terraform-provider-f5xc/llms.txt",
+		},
+		required_providers_block:
+			'terraform {\n  required_providers {\n    f5xc = {\n      source = "f5xc-salesdemos/f5xc"\n    }\n  }\n}\n',
+	},
+	api_endpoint: {
+		deprecated: {
+			url: "console.ves.volterra.io",
+		},
+		canonical: {
+			note: "Tenant-specific. No hardcoded default. Require F5XC_API_URL env var.",
+		},
+	},
+	documentation: {
+		deprecated: {
+			note: "docs.cloud.f5.com references to Volterra provider point to the deprecated volterraedge/volterra registry.\n",
+		},
+		canonical: {
+			url: "https://f5xc-salesdemos.github.io/terraform-provider-f5xc/",
+		},
+	},
+} as const;
 
 export const BRANDING_GLOSSARY = {
-	XCKS: {
-		term: "XC Kubernetes Service",
-		definition: "F5's enterprise managed Kubernetes offering (comparable to AWS EKS, Azure AKS)",
-		legacy: "Formerly known as AppStack",
-	},
-	XCCS: {
-		term: "XC Container Services",
-		definition: "F5's multi-tenant container orchestration service (comparable to AWS ECS)",
-		legacy: "Formerly known as Virtual Kubernetes (vK8s)",
-	},
 	CE: {
 		term: "Customer Edge",
-		definition: "F5's edge deployment infrastructure for distributed applications",
+		definition: "F5 XC edge deployment infrastructure for distributed applications",
 	},
 	RE: {
 		term: "Regional Edge",
-		definition: "F5's globally distributed edge network infrastructure",
+		definition: "F5 XC globally distributed edge network infrastructure",
 	},
 } as const;
 
 export const BRANDING_DOMAIN = {
-	container_services: {
-		title: "XCCS - XC Container Services",
+	virtual_kubernetes: {
+		title: "Virtual Kubernetes",
 		description:
-			'F5 XC Container Services (XCCS) provides simplified, multi-tenant container orchestration comparable to AWS ECS and Azure Container Services. Optimized for distributed edge deployments with restricted Kubernetes capabilities. Formerly known as "Virtual Kubernetes" (vK8s).\n',
+			'Virtual Kubernetes provides simplified, multi-tenant container orchestration optimized for distributed edge deployments. Formerly known as "vK8s".\n',
 	},
 	managed_kubernetes: {
-		title: "XCKS - XC Kubernetes Service",
+		title: "Managed Kubernetes",
 		description:
-			'F5 XC Managed Kubernetes (XCKS) provides enterprise-grade Kubernetes cluster management comparable to AWS EKS, Azure AKS, and Google GKE. Full cluster control with RBAC, pod security, and container registry management. Formerly known as "AppStack".\n',
+			'Managed Kubernetes provides enterprise-grade cluster management with full RBAC, pod security, and container registry support. Formerly known as "AppStack".\n',
 	},
 	sites: {
 		title: "Customer Edge Sites",
 		description:
-			"Site deployment and management across cloud providers (AWS VPC, Azure VNET, GCP VPC), F5 XC Managed Kubernetes (XCKS, formerly AppStack) deployments, and Secure Mesh deployments for networking-focused edge sites.\n",
+			"Site deployment and management across cloud providers (AWS VPC, Azure VNET, GCP VPC), Managed Kubernetes deployments (formerly AppStack), and Secure Mesh deployments for networking-focused edge sites.\n",
 	},
 } as const;

--- a/packages/natives/npm/darwin-arm64/package.json
+++ b/packages/natives/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-darwin-arm64",
-	"version": "19.32.0",
+	"version": "19.32.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (macOS arm64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-x64/package.json
+++ b/packages/natives/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-darwin-x64",
-	"version": "19.32.0",
+	"version": "19.32.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (macOS x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-arm64-gnu/package.json
+++ b/packages/natives/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-linux-arm64-gnu",
-	"version": "19.32.0",
+	"version": "19.32.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Linux arm64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-x64-gnu/package.json
+++ b/packages/natives/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-linux-x64-gnu",
-	"version": "19.32.0",
+	"version": "19.32.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Linux x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/win32-x64-msvc/package.json
+++ b/packages/natives/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives-win32-x64-msvc",
-	"version": "19.32.0",
+	"version": "19.32.1",
 	"description": "Native addon for @f5xc-salesdemos/pi-natives (Windows x64)",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5xc-salesdemos/pi-natives",
-	"version": "19.32.0",
+	"version": "19.32.1",
 	"description": "Native Rust bindings for grep, clipboard, image processing, syntax highlighting, PTY, and shell operations via N-API",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",
@@ -56,11 +56,11 @@
 		}
 	},
 	"optionalDependencies": {
-		"@f5xc-salesdemos/pi-natives-linux-x64-gnu": "19.32.0",
-		"@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "19.32.0",
-		"@f5xc-salesdemos/pi-natives-darwin-x64": "19.32.0",
-		"@f5xc-salesdemos/pi-natives-darwin-arm64": "19.32.0",
-		"@f5xc-salesdemos/pi-natives-win32-x64-msvc": "19.32.0"
+		"@f5xc-salesdemos/pi-natives-linux-x64-gnu": "19.32.1",
+		"@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "19.32.1",
+		"@f5xc-salesdemos/pi-natives-darwin-x64": "19.32.1",
+		"@f5xc-salesdemos/pi-natives-darwin-arm64": "19.32.1",
+		"@f5xc-salesdemos/pi-natives-win32-x64-msvc": "19.32.1"
 	},
 	"files": [
 		"native",

--- a/packages/resource-management/package.json
+++ b/packages/resource-management/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-resource-management",
-	"version": "19.32.0",
+	"version": "19.32.1",
 	"description": "Shared resource management for F5 XC manifest parsing, validation, diff, and CRUD operations",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Robin Mordasiewicz",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/xcsh-stats",
-	"version": "19.32.0",
+	"version": "19.32.1",
 	"description": "Local observability dashboard for pi AI usage statistics",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/swarm-extension/package.json
+++ b/packages/swarm-extension/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/swarm-extension",
-	"version": "19.32.0",
+	"version": "19.32.1",
 	"description": "Swarm orchestration extension for xcsh",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Derek Rynd",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-tui",
-	"version": "19.32.0",
+	"version": "19.32.1",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-utils",
-	"version": "19.32.0",
+	"version": "19.32.1",
 	"description": "Shared utilities for pi packages",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",


### PR DESCRIPTION
Automated release PR generated by `scripts/release.ts`.

Bumps every public package and the Cargo workspace to `v19.32.1` and updates CHANGELOGs for the releasable commits since the last tag.

Once this PR squash-merges to `main`, `.github/workflows/tag-on-version-bump.yml` pushes the `v19.32.1` git tag, which triggers the downstream release chain (build → sign → publish).

### Releasable commits (1)

- fix(tui): de-blob StdinBuffer.flush so probe responses don't leak as text (#1447)

See `docs-control`'s onboarding note "Release automation: release PR pattern" for the governance rationale.