### PR TITLE
feat(coding-agent): disable web_search by default for PII safety

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1359,8 +1359,13 @@ export const SETTINGS_SCHEMA = {
 
 	"web_search.enabled": {
 		type: "boolean",
-		default: true,
-		ui: { tab: "tools", label: "Web Search", description: "Enable the web_search tool for web searching" },
+		default: false,
+		ui: {
+			tab: "tools",
+			label: "Web Search",
+			description:
+				"Enable the web_search tool for web searching (disabled by default to prevent accidental PII exposure via prompt injection)",
+		},
 	},
 	"web_search.verbose": {
 		type: "boolean",

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { type SettingPath, Settings } from "@f5xc-salesdemos/xcsh/config/settings";
+import { getDefault } from "@f5xc-salesdemos/xcsh/config/settings-schema";
 import { createTools, HIDDEN_TOOLS, type ToolSession } from "@f5xc-salesdemos/xcsh/tools";
 
 Bun.env.PI_PYTHON_SKIP_CHECK = "1";
@@ -64,7 +65,7 @@ describe("createTools", () => {
 		expect(names).toContain("notebook");
 		expect(names).toContain("task");
 		expect(names).toContain("todo_write");
-		expect(names).toContain("web_search");
+		expect(names).not.toContain("web_search");
 		expect(names).toContain("exit_plan_mode");
 		expect(names).not.toContain("fetch");
 		expect(names).not.toContain("vim");
@@ -240,6 +241,28 @@ describe("createTools", () => {
 		const names = tools.map(t => t.name);
 
 		expect(names).toContain("search_tool_bm25");
+	});
+
+	it("web_search.enabled defaults to false for PII safety", () => {
+		expect(getDefault("web_search.enabled")).toBe(false);
+	});
+
+	it("excludes web_search from default tools (disabled by default)", async () => {
+		const session = createTestSession();
+		const tools = await createTools(session);
+		const names = tools.map(t => t.name);
+		expect(names).not.toContain("web_search");
+	});
+
+	it("includes web_search when explicitly enabled via settings", async () => {
+		const session = createTestSession({
+			settings: createSettingsWithOverrides({
+				"web_search.enabled": true,
+			}),
+		});
+		const tools = await createTools(session);
+		const names = tools.map(t => t.name);
+		expect(names).toContain("web_search");
 	});
 
 	it("HIDDEN_TOOLS contains review tools", () => {


### PR DESCRIPTION
## Summary

- Change `web_search.enabled` default from `true` to `false` in the settings schema
- Update UI description to explain PII safety motivation
- Add 3 new tests (schema default, tool exclusion, explicit opt-in)
- Update existing default-tools test to match new default

Closes #1457

## Test plan

- [x] `getDefault("web_search.enabled")` returns `false`
- [x] Default tool list does not include `web_search`
- [x] `web_search.enabled: true` override includes the tool
- [x] Full test suite passes (4736 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)