### PR TITLE
chore: use example- prefix for sample resource names

### DIFF
--- a/packages/coding-agent/examples/sdk/04-skills.ts
+++ b/packages/coding-agent/examples/sdk/04-skills.ts
@@ -18,7 +18,7 @@ const filteredSkills = allSkills.filter(s => s.name.includes("browser") || s.nam
 
 // Or define custom skills inline
 const customSkill: Skill = {
-	name: "my-skill",
+	name: "example-skill",
 	description: "Custom project instructions",
 	filePath: "/virtual/SKILL.md",
 	baseDir: "/virtual",

--- a/packages/swarm-extension/README.md
+++ b/packages/swarm-extension/README.md
@@ -76,7 +76,7 @@ Every swarm is a single YAML file with a top-level `swarm` key:
 
 ```yaml
 swarm:
-  name: my-pipeline # Identifier (state stored in .swarm_<name>/)
+  name: example-pipeline # Identifier (state stored in .swarm_<name>/)
   workspace: ./workspace # Working directory (relative to YAML file location)
   mode: pipeline # pipeline | parallel | sequential
   target_count: 10 # Iterations (pipeline mode only, default: 1)


### PR DESCRIPTION
Standardizes two user-facing sample names on the ecosystem `example-` convention:
- `packages/swarm-extension/README.md`: `my-pipeline` -> `example-pipeline`
- `packages/coding-agent/examples/sdk/04-skills.ts`: `my-skill` -> `example-skill`

Left unchanged: real component names (e.g. the `demo-components` skill) and numbered `test-N` case names.

Closes #1468