### PR TITLE
fix: reject incomplete hostnames in context URL validation

### DIFF
--- a/packages/coding-agent/src/modes/components/context-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/context-add-wizard.ts
@@ -12,6 +12,10 @@ export function validateWizardUrl(url: string): string | null {
 	try {
 		const parsed = new URL(url);
 		if (parsed.protocol !== "https:") return "URL must use HTTPS";
+		const labels = parsed.hostname.replace(/\.$/, "").split(".");
+		if (labels.length < 2 || labels.some(l => l.length === 0)) {
+			return "URL must include a full domain (e.g., tenant.console.ves.volterra.io)";
+		}
 		return null;
 	} catch {
 		return "Invalid URL format";

--- a/packages/coding-agent/src/services/f5xc-context-command.ts
+++ b/packages/coding-agent/src/services/f5xc-context-command.ts
@@ -349,6 +349,11 @@ async function handleCreate(ctx: CommandContext, service: ContextService, args: 
 			ctx.showError(t("context.create.invalidUrl"));
 			return;
 		}
+		const labels = parsed.hostname.replace(/\.$/, "").split(".");
+		if (labels.length < 2 || labels.some(l => l.length === 0)) {
+			ctx.showError(t("context.create.invalidUrl"));
+			return;
+		}
 	} catch {
 		ctx.showError(t("context.create.invalidUrl"));
 		return;

--- a/packages/coding-agent/test/context-add-wizard.test.ts
+++ b/packages/coding-agent/test/context-add-wizard.test.ts
@@ -17,6 +17,19 @@ describe("validateWizardUrl", () => {
 	it("rejects empty string", () => {
 		expect(validateWizardUrl("")).not.toBeNull();
 	});
+
+	it("rejects incomplete hostname with trailing dot only", () => {
+		expect(validateWizardUrl("https://api.")).not.toBeNull();
+	});
+
+	it("rejects single-label hostname without domain", () => {
+		expect(validateWizardUrl("https://localhost")).not.toBeNull();
+	});
+
+	it("accepts valid multi-label hostname", () => {
+		expect(validateWizardUrl("https://api.example.com")).toBeNull();
+		expect(validateWizardUrl("https://acme.console.ves.volterra.io")).toBeNull();
+	});
 });
 
 describe("validateWizardName", () => {


### PR DESCRIPTION
## Summary

Closes #1472

- Add a DNS-labels check to `validateWizardUrl()` requiring at least 2 non-empty hostname labels
- Mirror the same check in the CLI `handleCreate()` inline validation
- Add test cases for incomplete hostnames (`https://api.`, `https://localhost`)

URLs like `https://api.` pass `new URL()` parsing and the HTTPS protocol check, but cause TLS certificate mismatch errors at export time. This catches them at context creation.

## Test plan

- [x] New tests: incomplete hostname rejected, single-label rejected, valid multi-label accepted
- [x] All 11 wizard tests pass
- [x] All 85 context-command tests pass
- [x] All 399 f5xc-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)