### PR TITLE
test: add handleCreate() hostname validation coverage

### DIFF
--- a/packages/coding-agent/test/f5xc-context-command.test.ts
+++ b/packages/coding-agent/test/f5xc-context-command.test.ts
@@ -429,6 +429,30 @@ describe("/context slash command handler", () => {
 		expect(ctx.messages[0].text).toContain("HTTPS");
 	});
 
+	it("/context create with incomplete hostname rejects URL", async () => {
+		ContextService.init(f5xcConfigDir);
+
+		const ctx = createMockCtx();
+		await handleContextCommand(
+			{ name: "context", args: "create valid https://api. tok", text: "/context create ..." },
+			ctx,
+		);
+
+		expect(ctx.messages[0].type).toBe("error");
+	});
+
+	it("/context create with single-label hostname rejects URL", async () => {
+		ContextService.init(f5xcConfigDir);
+
+		const ctx = createMockCtx();
+		await handleContextCommand(
+			{ name: "context", args: "create valid https://localhost tok", text: "/context create ..." },
+			ctx,
+		);
+
+		expect(ctx.messages[0].type).toBe("error");
+	});
+
 	it("/context create with duplicate name shows error", async () => {
 		writeContext(f5xcContextsDir, TEST_CONTEXT);
 		ContextService.init(f5xcConfigDir);


### PR DESCRIPTION
## Summary

Closes #1475

Adds two missing tests for the CLI `/context create` hostname validation added in #1472:
- Incomplete hostname (`https://api.`) — rejected
- Single-label hostname (`https://localhost`) — rejected

Verified TDD-style: both tests fail when the labels check is commented out, pass when restored.

## Test plan

- [x] 87/87 context-command tests pass (85 existing + 2 new)
- [x] Both new tests confirmed to fail without the fix (red-green verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)