### PR TITLE
feat(runner): run-workflow and scroll step-action handlers

### DIFF
--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -1367,9 +1367,23 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 					return toolResult(details).text(`Pressed ${key}`).done();
 				}
 				case "scroll": {
+					const page = await this.#ensurePage(params);
+					if (params.selector) {
+						const resolvedSelector = normalizeSelector(params.selector as string);
+						const locator = page.locator(resolvedSelector).setTimeout(timeoutMs);
+						const handle = (await untilAborted(signal, () => locator.waitHandle())) as ElementHandle;
+						await untilAborted(signal, () =>
+							handle.evaluate((el: Element) =>
+								(el as unknown as { scrollIntoView(arg?: { block?: string }): void }).scrollIntoView({
+									block: "center",
+								}),
+							),
+						);
+						await handle.dispose();
+						return toolResult(details).text(`Scrolled ${params.selector} into view`).done();
+					}
 					const deltaY = ensureParam(params.delta_y, "delta_y", params.action);
 					const deltaX = params.delta_x ?? 0;
-					const page = await this.#ensurePage(params);
 					await untilAborted(signal, () => page.mouse.wheel({ deltaX, deltaY }));
 					return toolResult(details).text(`Scrolled by ${deltaX}, ${deltaY}`).done();
 				}

--- a/packages/coding-agent/src/tools/catalog-workflow-runner.ts
+++ b/packages/coding-agent/src/tools/catalog-workflow-runner.ts
@@ -468,6 +468,7 @@ export class CatalogWorkflowRunnerTool
 							}
 						}
 					}
+					this.#validateParams(childWorkflow, childParams);
 					for (const childStep of childWorkflow.steps) {
 						const r = await this.#executeStep(
 							childStep,

--- a/packages/coding-agent/src/tools/catalog-workflow-runner.ts
+++ b/packages/coding-agent/src/tools/catalog-workflow-runner.ts
@@ -73,6 +73,8 @@ interface WorkflowStep {
 	condition?: string;
 	then?: WorkflowStep[];
 	timeout?: number;
+	workflow?: string;
+	with?: Record<string, string>;
 }
 
 // =============================================================================
@@ -107,6 +109,7 @@ export interface CatalogWorkflowRunnerDetails {
 const EXPECTED_SCHEMA = "urn:f5xc:console:workflow:v1";
 const DEFAULT_OBSERVABLE_DELAY_MS = 1500;
 const DEFAULT_STEP_TIMEOUT_S = 30;
+const MAX_WORKFLOW_DEPTH = 10;
 
 // =============================================================================
 // Helpers
@@ -202,6 +205,29 @@ function formatDuration(ms: number): string {
 	return `${(ms / 1000).toFixed(1)}s`;
 }
 
+/**
+ * Parse a workflow reference of the form "resource/operation".
+ * Both segments must be non-empty and match ^[a-z0-9][a-z0-9-]*$.
+ * Throws ToolError for malformed refs.
+ */
+export function parseWorkflowRef(ref: string): { resource: string; operation: string } {
+	const SAFE = /^[a-z0-9][a-z0-9-]*$/;
+	const parts = ref.split("/");
+	if (parts.length !== 2) {
+		throw new ToolError(`Invalid workflow ref "${ref}": must be "resource/operation" with exactly one slash`);
+	}
+	const [resource, operation] = parts as [string, string];
+	if (!resource || !operation) {
+		throw new ToolError(`Invalid workflow ref "${ref}": both resource and operation must be non-empty`);
+	}
+	if (!SAFE.test(resource) || !SAFE.test(operation)) {
+		throw new ToolError(
+			`Invalid workflow ref "${ref}": segments must be lowercase alphanumeric/hyphen only (no uppercase, underscores, or leading hyphens)`,
+		);
+	}
+	return { resource, operation };
+}
+
 // =============================================================================
 // Tool Class
 // =============================================================================
@@ -286,7 +312,14 @@ export class CatalogWorkflowRunnerTool
 		step: WorkflowStep,
 		params: Record<string, unknown>,
 		baseUrl: string,
-		options: { observable: boolean; observableDelayMs: number; screenshotDir?: string; stepIndex: number },
+		options: {
+			observable: boolean;
+			observableDelayMs: number;
+			screenshotDir?: string;
+			stepIndex: number;
+			catalogPath?: string;
+			depth: number;
+		},
 		signal?: AbortSignal,
 	): Promise<StepResult> {
 		const start = performance.now();
@@ -396,6 +429,59 @@ export class CatalogWorkflowRunnerTool
 				case "wait": {
 					if (!resolvedSelector) throw new ToolError(`Step "${step.id}": wait requires selector`);
 					await this.#browserAction("wait_for_selector", { selector: resolvedSelector, timeout }, signal);
+					break;
+				}
+				case "scroll": {
+					if (!resolvedSelector) throw new ToolError(`Step "${step.id}": scroll requires selector`);
+					await this.#browserAction("scroll", { selector: resolvedSelector, timeout }, signal);
+					break;
+				}
+				case "run-workflow": {
+					if (!step.workflow) throw new ToolError(`Step "${step.id}": run-workflow requires workflow`);
+					if (options.depth >= MAX_WORKFLOW_DEPTH) {
+						throw new ToolError(`run-workflow nesting too deep (possible cycle) at step ${step.id}`);
+					}
+					const { resource, operation } = parseWorkflowRef(step.workflow);
+					const childParams: Record<string, unknown> = {};
+					for (const [k, v] of Object.entries(step.with ?? {})) {
+						childParams[k] = resolvePlaceholders(v, params);
+					}
+					const childYaml = loadWorkflowYaml({
+						catalog_path: options.catalogPath,
+						resource,
+						operation,
+					});
+					const childWorkflow = parseYaml(childYaml) as WorkflowDefinition;
+					if (childWorkflow.schema !== EXPECTED_SCHEMA) {
+						throw new ToolError(
+							`Child workflow "${step.workflow}" has invalid schema: expected "${EXPECTED_SCHEMA}", got "${childWorkflow.schema}"`,
+						);
+					}
+					if (!childWorkflow.steps || !Array.isArray(childWorkflow.steps)) {
+						throw new ToolError(`Child workflow "${step.workflow}" has no steps array`);
+					}
+					// Apply defaults from child workflow param definitions
+					if (childWorkflow.params) {
+						for (const paramDef of childWorkflow.params) {
+							if (!(paramDef.name in childParams) && paramDef.default !== undefined) {
+								childParams[paramDef.name] = paramDef.default;
+							}
+						}
+					}
+					for (const childStep of childWorkflow.steps) {
+						const r = await this.#executeStep(
+							childStep,
+							childParams,
+							baseUrl,
+							{ ...options, depth: options.depth + 1 },
+							signal,
+						);
+						if (r.status === "fail") {
+							throw new ToolError(
+								`run-workflow "${step.workflow}" failed at child step "${childStep.id}": ${r.error}`,
+							);
+						}
+					}
 					break;
 				}
 				default:
@@ -517,7 +603,14 @@ export class CatalogWorkflowRunnerTool
 					step,
 					params,
 					baseUrl,
-					{ observable, observableDelayMs, screenshotDir, stepIndex: i },
+					{
+						observable,
+						observableDelayMs,
+						screenshotDir,
+						stepIndex: i,
+						catalogPath: inputParams.catalog_path,
+						depth: 0,
+					},
 					signal,
 				);
 				stepResults.push(stepResult);

--- a/packages/coding-agent/test/catalog-workflow-runner-parse-ref.test.ts
+++ b/packages/coding-agent/test/catalog-workflow-runner-parse-ref.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import { parseWorkflowRef } from "@f5xc-salesdemos/xcsh/tools/catalog-workflow-runner";
+
+describe("parseWorkflowRef", () => {
+	// -------------------------------------------------------------------------
+	// Valid cases
+	// -------------------------------------------------------------------------
+
+	it("parses a valid resource/operation ref", () => {
+		expect(parseWorkflowRef("origin-pool/create")).toEqual({
+			resource: "origin-pool",
+			operation: "create",
+		});
+	});
+
+	it("parses a simple single-segment resource and operation", () => {
+		expect(parseWorkflowRef("http-load-balancer/delete")).toEqual({
+			resource: "http-load-balancer",
+			operation: "delete",
+		});
+	});
+
+	it("parses refs where both segments are single lowercase words", () => {
+		expect(parseWorkflowRef("site/view")).toEqual({ resource: "site", operation: "view" });
+	});
+
+	it("parses refs with numbers in segments", () => {
+		expect(parseWorkflowRef("site2/create2")).toEqual({ resource: "site2", operation: "create2" });
+	});
+
+	// -------------------------------------------------------------------------
+	// Invalid: empty / missing slash
+	// -------------------------------------------------------------------------
+
+	it("throws for an empty string", () => {
+		expect(() => parseWorkflowRef("")).toThrow(/invalid workflow ref/i);
+	});
+
+	it("throws when there is no slash (bare operation)", () => {
+		expect(() => parseWorkflowRef("create")).toThrow(/invalid workflow ref/i);
+	});
+
+	// -------------------------------------------------------------------------
+	// Invalid: too many slashes
+	// -------------------------------------------------------------------------
+
+	it("throws when there are two slashes (a/b/c)", () => {
+		expect(() => parseWorkflowRef("a/b/c")).toThrow(/invalid workflow ref/i);
+	});
+
+	it("throws for a deep path with traversal characters", () => {
+		expect(() => parseWorkflowRef("../x/y")).toThrow(/invalid workflow ref/i);
+	});
+
+	// -------------------------------------------------------------------------
+	// Invalid: empty segment
+	// -------------------------------------------------------------------------
+
+	it("throws when resource is empty (/create)", () => {
+		expect(() => parseWorkflowRef("/create")).toThrow(/invalid workflow ref/i);
+	});
+
+	it("throws when operation is empty (create/)", () => {
+		expect(() => parseWorkflowRef("create/")).toThrow(/invalid workflow ref/i);
+	});
+
+	// -------------------------------------------------------------------------
+	// Invalid: bad characters (uppercase, underscore, traversal)
+	// -------------------------------------------------------------------------
+
+	it("throws for uppercase letters in resource (Origin_Pool/create)", () => {
+		expect(() => parseWorkflowRef("Origin_Pool/create")).toThrow(/invalid workflow ref/i);
+	});
+
+	it("throws for underscores in resource", () => {
+		expect(() => parseWorkflowRef("origin_pool/create")).toThrow(/invalid workflow ref/i);
+	});
+
+	it("throws for traversal path in resource (../x segment)", () => {
+		// "../x" contains dots; the regex requires start with [a-z0-9]
+		expect(() => parseWorkflowRef("../x")).toThrow(/invalid workflow ref/i);
+	});
+});


### PR DESCRIPTION
Closes #1479

## What
Adds the two missing step-action handlers to `catalog_workflow_runner` so the embedded composite demo workflows (e.g. `demos/waap-full-stack`) execute end-to-end.

- **`scroll`** — `BrowserTool.scroll` now accepts an optional `selector` (scroll element into view via `scrollIntoView`), keeping the existing delta-wheel behavior when no selector is given. The runner's `scroll` step maps `selector:` → this.
- **`run-workflow`** — invoke another catalogue workflow as a sub-step: `{ action: "run-workflow", workflow: "<resource>/<operation>", with: {param overrides} }`.
  - New exported pure helper `parseWorkflowRef` (single `/`, both segments `^[a-z0-9][a-z0-9-]*$`, `ToolError` on malformed).
  - `#executeStep` threads `catalogPath` + `depth`; **cycle guard** `MAX_WORKFLOW_DEPTH = 10` fires before any I/O.
  - `with` resolved via `resolvePlaceholders` into isolated child params; child loaded via `loadWorkflowYaml` (double charset guard → no path traversal); child params validated via `#validateParams`; child steps run at `depth+1`; failure propagates with child step id.

## Verification
- 22 runner tests pass incl. `parseWorkflowRef` rejection cases; `tsgo` typecheck clean.
- Browser-driving paths (selector scroll, recursive execution) are integration-verified live under #1480 — no browser unit test, consistent with the rest of this tool.

## Safety
Browser change is purely additive (no existing action touched). Recursion bounded by the depth guard (self-referential workflow terminates at depth 10); `step.workflow` cannot traverse paths (parseWorkflowRef + loadWorkflowYaml charset guards).

## Follow-up (minor, → #1481)
Nested `run-workflow` child screenshots reuse the parent step naming; could collide if a child has screenshot steps. Low impact; tracked with the other polish items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)