### PR TITLE
Isolate F5XCApiClient from shared globalThis.fetch (fix flaky 429 test)

### DIFF
--- a/packages/coding-agent/src/services/f5xc-api-client.ts
+++ b/packages/coding-agent/src/services/f5xc-api-client.ts
@@ -13,6 +13,9 @@ export class F5XCApiError extends Error {
 	}
 }
 
+/** The fetch call signature the client depends on (a structural subset of `typeof fetch`). */
+export type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
 export interface F5XCNamespace {
 	name: string;
 }
@@ -35,6 +38,15 @@ export interface F5XCApiClientOptions {
 	maxRetries?: number;
 	baseDelayMs?: number;
 	maxDelayMs?: number;
+	/**
+	 * Optional fetch implementation. When provided, the client uses exactly this
+	 * function and never reads `globalThis.fetch` — which keeps tests hermetic:
+	 * another concurrently-running test file (`bun test --max-concurrency`) can
+	 * reassign `globalThis.fetch` mid-request without corrupting this client.
+	 * When omitted, the client defers to `globalThis.fetch` dynamically at call
+	 * time (preserving the default production/integration behavior).
+	 */
+	fetch?: FetchFn;
 }
 
 export class F5XCApiClient {
@@ -44,6 +56,7 @@ export class F5XCApiClient {
 	#maxRetries: number;
 	#baseDelayMs: number;
 	#maxDelayMs: number;
+	#fetch: FetchFn;
 
 	constructor(opts: F5XCApiClientOptions) {
 		this.#apiUrl = opts.apiUrl.replace(/\/+$/, "");
@@ -52,6 +65,7 @@ export class F5XCApiClient {
 		this.#maxRetries = opts.maxRetries ?? 3;
 		this.#baseDelayMs = opts.baseDelayMs ?? 500;
 		this.#maxDelayMs = opts.maxDelayMs ?? 10_000;
+		this.#fetch = opts.fetch ?? ((input, init) => globalThis.fetch(input, init));
 	}
 
 	#isRetryable(status: number): boolean {
@@ -71,7 +85,7 @@ export class F5XCApiClient {
 			let response: Response;
 			try {
 				const start = performance.now();
-				response = await fetch(url, {
+				response = await this.#fetch(url, {
 					method: "GET",
 					headers,
 					signal: AbortSignal.timeout(this.#timeoutMs),

--- a/packages/coding-agent/test/f5xc-api-client.test.ts
+++ b/packages/coding-agent/test/f5xc-api-client.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { F5XCApiClient, F5XCApiError } from "@f5xc-salesdemos/xcsh/services/f5xc-api-client";
 
 const TEST_API_URL = "https://test-tenant.console.ves.volterra.io";
@@ -23,25 +23,16 @@ describe("F5XCApiError", () => {
 });
 
 describe("F5XCApiClient", () => {
-	let originalFetch: typeof globalThis.fetch;
-
-	beforeEach(() => {
-		originalFetch = globalThis.fetch;
-	});
-
-	afterEach(() => {
-		globalThis.fetch = originalFetch;
-	});
-
 	describe("URL normalization", () => {
 		it("strips trailing slashes from apiUrl", async () => {
 			let capturedUrl = "";
-			globalThis.fetch = (async (input: string | URL | Request) => {
+			const fetchMock = (async (input: string | URL | Request) => {
 				capturedUrl = String(input);
 				return new Response(JSON.stringify({ items: [] }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: "https://test.example.io///",
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 0,
@@ -54,12 +45,13 @@ describe("F5XCApiClient", () => {
 	describe("listNamespaces", () => {
 		it("throws auth error on 401 without retrying", async () => {
 			let fetchCount = 0;
-			globalThis.fetch = (async () => {
+			const fetchMock = (async () => {
 				fetchCount++;
 				return new Response(JSON.stringify({ message: "unauthorized" }), { status: 401 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: TEST_API_URL,
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 3,
@@ -79,12 +71,13 @@ describe("F5XCApiClient", () => {
 
 		it("throws auth error on 403 without retrying", async () => {
 			let fetchCount = 0;
-			globalThis.fetch = (async () => {
+			const fetchMock = (async () => {
 				fetchCount++;
 				return new Response(JSON.stringify({ message: "forbidden" }), { status: 403 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: TEST_API_URL,
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 3,
@@ -104,7 +97,7 @@ describe("F5XCApiClient", () => {
 
 		it("retries on 503 then returns data on success", async () => {
 			let fetchCount = 0;
-			globalThis.fetch = (async () => {
+			const fetchMock = (async () => {
 				fetchCount++;
 				if (fetchCount <= 2) {
 					return new Response(JSON.stringify({}), { status: 503 });
@@ -113,6 +106,7 @@ describe("F5XCApiClient", () => {
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: TEST_API_URL,
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 3,
@@ -127,12 +121,13 @@ describe("F5XCApiClient", () => {
 
 		it("throws server error after exhausting retries on 503", async () => {
 			let fetchCount = 0;
-			globalThis.fetch = (async () => {
+			const fetchMock = (async () => {
 				fetchCount++;
 				return new Response(JSON.stringify({}), { status: 503 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: TEST_API_URL,
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 2,
@@ -153,12 +148,13 @@ describe("F5XCApiClient", () => {
 		});
 
 		it("throws network error on fetch timeout", async () => {
-			globalThis.fetch = (async () => {
+			const fetchMock = (async () => {
 				const err = new DOMException("The operation was aborted", "AbortError");
 				throw err;
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: TEST_API_URL,
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 0,
@@ -177,7 +173,7 @@ describe("F5XCApiClient", () => {
 
 		it("respects Retry-After header on 429", async () => {
 			let fetchCount = 0;
-			globalThis.fetch = (async () => {
+			const fetchMock = (async () => {
 				fetchCount++;
 				if (fetchCount === 1) {
 					return new Response(JSON.stringify({}), {
@@ -189,6 +185,7 @@ describe("F5XCApiClient", () => {
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: TEST_API_URL,
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 1,
@@ -201,14 +198,55 @@ describe("F5XCApiClient", () => {
 			expect(fetchCount).toBe(2);
 		});
 
+		it("uses the captured fetch even if globalThis.fetch is reassigned mid-request", async () => {
+			// Regression for cross-file flakiness: with `bun test --max-concurrency`,
+			// another test file can reassign globalThis.fetch while this client is mid-retry.
+			// The client must keep using its injected/captured fetch and never read the global.
+			const saved = globalThis.fetch;
+			let injectedCalls = 0;
+			let globalCalls = 0;
+			const injected = (async () => {
+				injectedCalls++;
+				if (injectedCalls === 1) {
+					return new Response(JSON.stringify({}), { status: 429, headers: { "Retry-After": "1" } });
+				}
+				return new Response(JSON.stringify({ items: [{ name: "ns1" }] }), { status: 200 });
+			}) as unknown as typeof globalThis.fetch;
+
+			const client = new F5XCApiClient({
+				fetch: injected,
+				apiUrl: TEST_API_URL,
+				apiToken: TEST_API_TOKEN,
+				maxRetries: 1,
+				baseDelayMs: 1,
+				maxDelayMs: 1,
+			});
+
+			try {
+				const pending = client.listNamespaces();
+				// Clobber the global the way a concurrently-running test file would.
+				globalThis.fetch = (async () => {
+					globalCalls++;
+					return new Response(JSON.stringify({ items: [{ name: "WRONG" }] }), { status: 200 });
+				}) as unknown as typeof globalThis.fetch;
+				const result = await pending;
+				expect(result).toEqual([{ name: "ns1" }]);
+				expect(injectedCalls).toBe(2);
+				expect(globalCalls).toBe(0);
+			} finally {
+				globalThis.fetch = saved;
+			}
+		});
+
 		it("silently filters items missing name field", async () => {
-			globalThis.fetch = (async () => {
+			const fetchMock = (async () => {
 				return new Response(JSON.stringify({ items: [{ notName: "x" }, { name: "valid" }, { name: 42 }, null] }), {
 					status: 200,
 				});
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: TEST_API_URL,
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 0,
@@ -219,11 +257,12 @@ describe("F5XCApiClient", () => {
 		});
 
 		it("returns empty array when response has no items array", async () => {
-			globalThis.fetch = (async () => {
+			const fetchMock = (async () => {
 				return new Response(JSON.stringify({ something: "else" }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: TEST_API_URL,
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 0,
@@ -234,11 +273,12 @@ describe("F5XCApiClient", () => {
 		});
 
 		it("returns parsed namespaces on 200", async () => {
-			globalThis.fetch = (async () => {
+			const fetchMock = (async () => {
 				return new Response(JSON.stringify({ items: [{ name: "ns1" }, { name: "ns2" }] }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: TEST_API_URL,
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 0,
@@ -251,11 +291,12 @@ describe("F5XCApiClient", () => {
 
 	describe("getNamespaceStatus", () => {
 		it("returns parsed status on 200", async () => {
-			globalThis.fetch = (async () => {
+			const fetchMock = (async () => {
 				return new Response(JSON.stringify({ name: "production", phase: "Active" }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: TEST_API_URL,
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 0,
@@ -266,11 +307,12 @@ describe("F5XCApiClient", () => {
 		});
 
 		it("throws auth error on 401", async () => {
-			globalThis.fetch = (async () => {
+			const fetchMock = (async () => {
 				return new Response(JSON.stringify({}), { status: 401 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: TEST_API_URL,
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 0,
@@ -286,11 +328,12 @@ describe("F5XCApiClient", () => {
 		});
 
 		it("throws server error when required fields are missing", async () => {
-			globalThis.fetch = (async () => {
+			const fetchMock = (async () => {
 				return new Response(JSON.stringify({ unrelated: true }), { status: 200 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: TEST_API_URL,
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 0,
@@ -309,7 +352,7 @@ describe("F5XCApiClient", () => {
 	describe("listObjects", () => {
 		it("returns parsed objects on 200", async () => {
 			let capturedUrl = "";
-			globalThis.fetch = (async (input: string | URL | Request) => {
+			const fetchMock = (async (input: string | URL | Request) => {
 				capturedUrl = String(input);
 				return new Response(
 					JSON.stringify({
@@ -323,6 +366,7 @@ describe("F5XCApiClient", () => {
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: TEST_API_URL,
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 0,
@@ -337,11 +381,12 @@ describe("F5XCApiClient", () => {
 		});
 
 		it("throws auth error on 401", async () => {
-			globalThis.fetch = (async () => {
+			const fetchMock = (async () => {
 				return new Response(JSON.stringify({}), { status: 401 });
 			}) as unknown as typeof globalThis.fetch;
 
 			const client = new F5XCApiClient({
+				fetch: fetchMock,
 				apiUrl: TEST_API_URL,
 				apiToken: TEST_API_TOKEN,
 				maxRetries: 0,


### PR DESCRIPTION
Closes #1489

## Problem
`F5XCApiClient > listNamespaces > respects Retry-After header on 429` flaked in CI (`expect(fetchCount).toBe(2)` got 4). The test script runs `bun test --max-concurrency 4`, which runs test **files** concurrently in one process; 7 files reassign the shared `globalThis.fetch`. The 429 test sleeps ~1s (`Retry-After: 1`) — a wide window during which another file clobbers the global, corrupting the count. `f5xc-context.ts` already had a comment + `maxRetries: 0` mitigation acknowledging this hazard.

## Fix
- `F5XCApiClient` gains an optional injectable `fetch` (`FetchFn`). When injected, the client uses exactly that function and never reads `globalThis.fetch` → hermetic tests, immune to concurrent global reassignment. When omitted, it defers to `globalThis.fetch` dynamically at call time → **unchanged** production and integration behavior.
- Converted `test/f5xc-api-client.test.ts` to inject `fetch` per client (removed all `globalThis.fetch` mutation and the `beforeEach`/`afterEach` global save/restore).
- Added a regression test that reassigns `globalThis.fetch` mid-request and asserts the client ignores it (verified it fails against the pre-fix code).

## Verification
- 18/18 client tests pass; stable across 6 consecutive `--max-concurrency 4` runs.
- All 7 fetch-mocking test files pass together (364 tests) — integration tests that mock the global late still work via the dynamic default.
- `f5xc-api-client.ts` + test typecheck clean; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)