### PR TITLE
Resolve pre-existing biome lint warnings

### DIFF
--- a/packages/coding-agent/src/modes/components/plugins/plugin-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/plugins/plugin-dashboard.ts
@@ -400,7 +400,7 @@ export class PluginDashboard extends Container {
 	#buildLayout(): void {
 		this.clear();
 		this.addChild(new DynamicBorder());
-		this.addChild(new Text(theme.bold(theme.fg("contentAccent", " " + t("plugins.dashboard.title"))), 0, 0));
+		this.addChild(new Text(theme.bold(theme.fg("contentAccent", ` ${t("plugins.dashboard.title")}`)), 0, 0));
 		this.addChild(new Text(this.#renderTabBar(), 0, 0));
 		this.addChild(new Spacer(1));
 

--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -125,13 +125,13 @@ export class WelcomeComponent implements Component {
 	}
 
 	#measureStatusWidth(): number {
-		const lines: string[] = [" " + t("welcome.modelProvider"), ...this.#renderModelStatus()];
+		const lines: string[] = [` ${t("welcome.modelProvider")}`, ...this.#renderModelStatus()];
 		const coreServices = this.services.filter(s => !s._isPlugin);
 		for (const svc of coreServices) {
 			lines.push(this.#renderServiceLine(svc));
 		}
 		if (this.plugins.length > 0) {
-			lines.push(" " + t("welcome.plugins"));
+			lines.push(` ${t("welcome.plugins")}`);
 			for (const p of this.plugins) {
 				lines.push(this.#renderUnifiedPluginLine(p));
 			}

--- a/packages/coding-agent/src/tools/catalog-workflow-runner.ts
+++ b/packages/coding-agent/src/tools/catalog-workflow-runner.ts
@@ -120,7 +120,6 @@ export interface CatalogWorkflowRunnerDetails {
 
 const EXPECTED_SCHEMA = "urn:f5xc:console:workflow:v1";
 const DEFAULT_OBSERVABLE_DELAY_MS = 1500;
-const DEFAULT_STEP_TIMEOUT_S = 30;
 const MAX_WORKFLOW_DEPTH = 10;
 
 // =============================================================================

--- a/packages/coding-agent/test/catalog-workflow-runner-embedded.test.ts
+++ b/packages/coding-agent/test/catalog-workflow-runner-embedded.test.ts
@@ -76,7 +76,7 @@ describe("loadWorkflowYaml catalog_path branch", () => {
 	});
 
 	it("throws when catalog_path workflows directory does not exist", () => {
-		const missing = path.join(os.tmpdir(), "xcsh-no-such-dir-" + Date.now());
+		const missing = path.join(os.tmpdir(), `xcsh-no-such-dir-${Date.now()}`);
 		expect(() => loadWorkflowYaml({ catalog_path: missing, resource: "realres", operation: "create" })).toThrow(
 			/catalog workflows directory not found/i,
 		);

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -403,6 +403,7 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 				// one peeled out of a de-blobbed probe response) is not a keypress
 				// awaiting its tail and must not glue onto the next read.
 				const last = flushed[flushed.length - 1];
+				// biome-ignore lint/complexity/useOptionalChain: the explicit undefined check narrows `last` to string for isCompleteSequence(last) below; optional chaining would not.
 				if (last !== undefined && last.startsWith(ESC) && isCompleteSequence(last) === "incomplete") {
 					this.#pendingEscape = last;
 					this.#pendingEscapeAt = Date.now();


### PR DESCRIPTION
Closes #1492

Clears the pre-existing biome warnings seen in CI `check` logs (non-failing, but tidied up). Repo-wide biome warnings are now **0**.

## Changes
- **useTemplate** (string concat → template literal): `welcome.ts` (x2), `plugin-dashboard.ts`, `catalog-workflow-runner-embedded.test.ts` — behavior-equivalent.
- **noUnusedVariables**: removed dead `DEFAULT_STEP_TIMEOUT_S` in `catalog-workflow-runner.ts`. It had no references (siblings all used). ⚠️ It looks like an *unwired* default for the `timeout?` step field — if step-timeout defaulting was intended, that is a separate feature worth its own issue; this PR only removes the dead constant.
- **useOptionalChain**: `stdin-buffer.ts` suppressed with a documented `biome-ignore`. Applying the fix would break type narrowing — `isCompleteSequence(last)` needs `last` narrowed to `string`, which the explicit `last !== undefined` guard provides and optional chaining would not.

## Verification
- `biome check .` → 0 warnings.
- Touched files typecheck clean; affected tests pass (`catalog-workflow-runner-embedded` 9/9, `tui` 465/465).

🤖 Generated with [Claude Code](https://claude.com/claude-code)