### PR TITLE
fix(browser): commit fill values to framework-patched inputs + runner param map

### DIFF
--- a/packages/coding-agent/src/browser/actions.ts
+++ b/packages/coding-agent/src/browser/actions.ts
@@ -1,5 +1,14 @@
 import type { Page } from "puppeteer";
+import { commitInputValue } from "./input-commit";
 import { resolve } from "./resolver";
+
+/** Delay after a fill to let blur-triggered framework revalidation complete. */
+const SETTLE_AFTER_FILL_MS = 600;
+
+/** Resolve after `ms` milliseconds (a small, explicit settle for SPA timing). */
+function settle(ms: number): Promise<void> {
+	return new Promise(resolveSettle => setTimeout(resolveSettle, ms));
+}
 
 /** XC-SPA-aware: wait until the console's loading/spinner indicators clear. */
 export async function waitForXcSettled(page: Page, timeoutMs = 15000): Promise<void> {
@@ -54,13 +63,22 @@ export async function fill(page: Page, selector: string, value: string, context?
 	await withRetry(async () => {
 		const h = await resolve(page, selector, context);
 		try {
-			await h.click({ clickCount: 3 }).catch(() => h.focus()); // select existing text (or focus)
-			await page.keyboard.press("Backspace").catch(() => {}); // clear selection
-			await page.keyboard.type(value, { delay: 10 }); // real key events -> Angular updates
+			await h.focus().catch(() => {});
+			// Set the value through the native value setter + framework events
+			// (input/change/blur/focusout). This replaces any existing value and is
+			// the robust path for framework-bound controls — including the console's
+			// vsui-input over ngx-datatable, whose patched value descriptor swallows
+			// plain keystrokes so they never reach the Angular model. (Use the `type`
+			// action for fields that must observe individual keystrokes.)
+			await h.evaluate(commitInputValue, value);
 		} finally {
 			await h.dispose().catch(() => {});
 		}
 	});
+	// Let the framework's blur-triggered revalidation run before the next action
+	// (Angular `updateOn: 'blur'` controls update validity asynchronously, so an
+	// immediate Save would otherwise still see the field as invalid).
+	await settle(SETTLE_AFTER_FILL_MS);
 }
 
 export async function selectOption(page: Page, selector: string, value: string, context?: string): Promise<void> {

--- a/packages/coding-agent/src/browser/index.ts
+++ b/packages/coding-agent/src/browser/index.ts
@@ -2,5 +2,6 @@ export * from "./actions";
 export * from "./ax";
 export * from "./cdp-core";
 export * from "./dom-context";
+export * from "./input-commit";
 export * from "./resolver";
 export * from "./selector";

--- a/packages/coding-agent/src/browser/input-commit.ts
+++ b/packages/coding-agent/src/browser/input-commit.ts
@@ -1,0 +1,52 @@
+/**
+ * Commit a value into a form control so that a framework which patched the
+ * element's `value` descriptor still observes the change.
+ *
+ * Why this exists: the F5XC console's `vsui-input` (e.g. over the HTTP-LB
+ * "Domains" ngx-datatable cell) overrides the native `<input>` `value`
+ * descriptor with its own accessor. Typing real keystrokes — or assigning
+ * `el.value = …` directly — leaves the text in the DOM but never reaches the
+ * Angular reactive-form model, so the form reports the field as still empty.
+ *
+ * The fix, verified live against the staging console: write through the
+ * *prototype's* native value setter (skipping any instance-level patch), then
+ * dispatch bubbling `input` and `change` events so the framework's own change
+ * detection runs.
+ *
+ * This module is intentionally dependency-free (DOM only) so it can be both
+ * unit-tested (linkedom/fakes) and DRY-injected into the live page via
+ * `.toString()` — the same pattern used by dom-context/dt-context.
+ */
+
+interface CommittableElement {
+	value: string;
+	ownerDocument?: { defaultView?: { Event?: typeof Event } | null } | null;
+	dispatchEvent(event: unknown): unknown;
+}
+
+export function commitInputValue(el: CommittableElement, value: string): void {
+	// Walk the prototype chain (starting ABOVE the instance) for the `value`
+	// setter. Starting above the instance is what bypasses a framework's
+	// instance-level patch and reaches the real (native) accessor.
+	let descriptor: PropertyDescriptor | undefined;
+	let proto: object | null = Object.getPrototypeOf(el);
+	while (proto) {
+		descriptor = Object.getOwnPropertyDescriptor(proto, "value");
+		if (descriptor) break;
+		proto = Object.getPrototypeOf(proto);
+	}
+	if (descriptor?.set) descriptor.set.call(el, value);
+	else el.value = value;
+
+	const view = el.ownerDocument?.defaultView ?? undefined;
+	const EventCtor = view?.Event ?? (typeof Event !== "undefined" ? Event : undefined);
+	if (EventCtor) {
+		// `input`/`change` cover controls that update on value change; `blur`/
+		// `focusout` cover Angular controls configured `updateOn: 'blur'` (the
+		// console's vsui-input commits to the model on blur, not on keystroke).
+		el.dispatchEvent(new EventCtor("input", { bubbles: true }));
+		el.dispatchEvent(new EventCtor("change", { bubbles: true }));
+		el.dispatchEvent(new EventCtor("blur", { bubbles: false }));
+		el.dispatchEvent(new EventCtor("focusout", { bubbles: true }));
+	}
+}

--- a/packages/coding-agent/src/tools/catalog-workflow-runner.ts
+++ b/packages/coding-agent/src/tools/catalog-workflow-runner.ts
@@ -59,15 +59,18 @@ interface WorkflowDefinition {
 	description?: string;
 	resource: string;
 	operation: string;
-	params?: WorkflowParamDef[];
+	// Catalogue `params` is a map keyed by the parameter name (see
+	// urn:f5xc:console:workflow:v1), not a list.
+	params?: Record<string, WorkflowParamDef>;
 	steps: WorkflowStep[];
 }
 
 interface WorkflowParamDef {
-	name: string;
 	required?: boolean;
 	default?: unknown;
 	description?: string;
+	type?: string;
+	example?: unknown;
 }
 
 interface WorkflowStep {
@@ -288,10 +291,10 @@ export class CatalogWorkflowRunnerTool
 	#validateParams(workflow: WorkflowDefinition, params: Record<string, unknown>): void {
 		if (!workflow.params) return;
 		const missing: string[] = [];
-		for (const paramDef of workflow.params) {
-			if (paramDef.required && !(paramDef.name in params)) {
+		for (const [name, paramDef] of Object.entries(workflow.params)) {
+			if (paramDef.required && !(name in params)) {
 				if (paramDef.default !== undefined) continue;
-				missing.push(paramDef.name);
+				missing.push(name);
 			}
 		}
 		if (missing.length > 0) {
@@ -443,9 +446,9 @@ export class CatalogWorkflowRunnerTool
 					}
 					// Apply defaults from child workflow param definitions
 					if (childWorkflow.params) {
-						for (const paramDef of childWorkflow.params) {
-							if (!(paramDef.name in childParams) && paramDef.default !== undefined) {
-								childParams[paramDef.name] = paramDef.default;
+						for (const [name, paramDef] of Object.entries(childWorkflow.params)) {
+							if (!(name in childParams) && paramDef.default !== undefined) {
+								childParams[name] = paramDef.default;
 							}
 						}
 					}
@@ -553,9 +556,9 @@ export class CatalogWorkflowRunnerTool
 
 			// Apply defaults from workflow param definitions
 			if (workflow.params) {
-				for (const paramDef of workflow.params) {
-					if (!(paramDef.name in params) && paramDef.default !== undefined) {
-						params[paramDef.name] = paramDef.default;
+				for (const [name, paramDef] of Object.entries(workflow.params)) {
+					if (!(name in params) && paramDef.default !== undefined) {
+						params[name] = paramDef.default;
 					}
 				}
 			}

--- a/packages/coding-agent/test/browser/input-commit.test.ts
+++ b/packages/coding-agent/test/browser/input-commit.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import { commitInputValue } from "@f5xc-salesdemos/xcsh/browser/input-commit";
+
+// Minimal fake Event capturing type + bubbles.
+class FakeEvent {
+	type: string;
+	bubbles: boolean;
+	constructor(type: string, opts?: { bubbles?: boolean }) {
+		this.type = type;
+		this.bubbles = !!opts?.bubbles;
+	}
+}
+
+describe("commitInputValue", () => {
+	it("sets value and dispatches bubbling input then change", () => {
+		const events: { type: string; bubbles: boolean }[] = [];
+		let stored = "";
+		const el = {
+			get value() {
+				return stored;
+			},
+			set value(v: string) {
+				stored = v;
+			},
+			ownerDocument: { defaultView: { Event: FakeEvent } },
+			dispatchEvent(e: FakeEvent) {
+				events.push({ type: e.type, bubbles: e.bubbles });
+				return true;
+			},
+		};
+		commitInputValue(el as never, "app.example.com");
+		expect(stored).toBe("app.example.com");
+		expect(events.map(e => e.type)).toEqual(["input", "change", "blur", "focusout"]);
+	});
+
+	it("uses the prototype value setter, bypassing an instance-patched descriptor", () => {
+		// Simulate a framework (e.g. vsui-input) that patched the element's OWN
+		// `value` descriptor so plain assignment never reaches the real model.
+		let nativeStored = "";
+		const proto = {};
+		Object.defineProperty(proto, "value", {
+			configurable: true,
+			get() {
+				return nativeStored;
+			},
+			set(v: string) {
+				nativeStored = v;
+			},
+		});
+		const el: Record<string, unknown> = Object.create(proto);
+		let patchedCalled = false;
+		Object.defineProperty(el, "value", {
+			configurable: true,
+			get() {
+				return nativeStored;
+			},
+			set() {
+				patchedCalled = true; // framework patch swallows the write
+			},
+		});
+		const events: string[] = [];
+		el.ownerDocument = { defaultView: { Event: FakeEvent } };
+		el.dispatchEvent = (e: FakeEvent) => {
+			events.push(e.type);
+			return true;
+		};
+		commitInputValue(el as never, "x.example.com");
+		expect(nativeStored).toBe("x.example.com"); // prototype (native) setter used
+		expect(patchedCalled).toBe(false); // instance patch bypassed
+		expect(events).toEqual(["input", "change", "blur", "focusout"]);
+	});
+});

--- a/packages/coding-agent/test/catalog-workflow-runner-embedded.test.ts
+++ b/packages/coding-agent/test/catalog-workflow-runner-embedded.test.ts
@@ -3,9 +3,28 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { CONSOLE_CATALOG_DATA } from "@f5xc-salesdemos/xcsh/internal-urls/console-catalog.generated";
-import { loadWorkflowYaml } from "@f5xc-salesdemos/xcsh/tools/catalog-workflow-runner";
+import { CatalogWorkflowRunnerTool, loadWorkflowYaml } from "@f5xc-salesdemos/xcsh/tools/catalog-workflow-runner";
 
 const catalogIsEmpty = Object.keys(CONSOLE_CATALOG_DATA.workflows).length === 0;
+
+// Catalogue `params` is a map keyed by name (urn:f5xc:console:workflow:v1).
+// Validation runs before any browser session opens, so this exercises the map
+// iteration without driving a real browser (it threw "{} is not iterable" when
+// the runner wrongly treated params as a list).
+describe.skipIf(catalogIsEmpty)("CatalogWorkflowRunnerTool map-style param validation", () => {
+	const tool = new CatalogWorkflowRunnerTool({ settings: { get: () => undefined } } as never);
+
+	it("reports missing required params from the catalogue param map", async () => {
+		await expect(
+			tool.execute("t", {
+				resource: "http-load-balancer",
+				operation: "create",
+				params: {},
+				base_url: "https://example.console.ves.volterra.io",
+			} as never),
+		).rejects.toThrow(/Missing required workflow params:.*(namespace|name|domains)/);
+	});
+});
 
 describe("loadWorkflowYaml", () => {
 	it.skipIf(catalogIsEmpty)("loads embedded workflow text when no catalog_path is given", () => {


### PR DESCRIPTION
## Summary
Two engine fixes that make the console browser-automation core drive the F5XC HTTP-LB **create** workflow to a persisted result (live-verified on staging, API parity 200).

### 1. `fill` commits to framework-patched inputs
The console's `vsui-input` (over ngx-datatable, e.g. the HTTP-LB **Domains** cell) patches the native `<input>` value descriptor, so `keyboard.type` (and plain `el.value=`) leave text in the DOM but never reach the Angular model — Save reports "Domains is required".

`fill` now sets the value via the **native prototype value setter** and dispatches `input`/`change`/`blur`/`focusout` (new pure, injectable `commitInputValue`), then settles briefly so Angular `updateOn:'blur'` revalidation completes before the next action. Use the `type` action for fields that must observe individual keystrokes.

### 2. Catalog workflow runner reads the param **map**
The catalogue schema (`urn:f5xc:console:workflow:v1`) defines `params` as a map keyed by name, but the runner iterated it as a list (`for...of`) — throwing `{} is not iterable` on any workflow with params. Fixed in validation, defaults, and child-workflow handling.

## Tests (TDD)
- `input-commit.test.ts` — value+event contract; prototype-setter bypass of an instance-patched descriptor.
- runner map-style param validation test (would throw `{} is not iterable` before the fix).
- Full suite: **4820 pass / 0 fail**.

## Live verification
The real `CatalogWorkflowRunnerTool` drove `http-load-balancer/create` end-to-end against the staging tenant: navigate → add-tab → fill-name → fill-domain → save **all pass**, resource created and **API-verified (200)**.

## Cross-repo note
The matching catalogue authoring fixes (Domains default-row, save context, fill/values) live in the **console** repo's `http-load-balancer/create.yaml` (separate PR). xcsh's embedded catalogue picks them up on the next regeneration from console main.

Closes #1491

🤖 Generated with [Claude Code](https://claude.com/claude-code)