### PR TITLE
fix(ci): publish on embedded spec/defaults refresh (chore: → fix:)

### DIFF
--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -90,7 +90,11 @@ jobs:
           git add -f packages/coding-agent/src/internal-urls/api-spec-index.generated.ts
           git add -f packages/coding-agent/src/internal-urls/api-catalog-index.generated.ts
           git add -f packages/resource-management/src/defaults-metadata.generated.ts
-          git commit -m "chore(coding-agent): update embedded API specs to ${SPEC_VERSION}"
+          # fix: (not chore:) so the embedded-spec/defaults refresh triggers an
+          # auto-release and publishes @f5xc-salesdemos/pi-resource-management with
+          # the fresh defaults table — otherwise consumers stay stale (auto-release
+          # in ci.yml skips chore:). The squash-merge commit uses this message.
+          git commit -m "fix(coding-agent): update embedded API specs to ${SPEC_VERSION}"
           git push origin "$BRANCH"
           ISSUE_URL=$(gh issue create \
             --title "chore: update embedded API specs to ${SPEC_VERSION}" \
@@ -99,7 +103,7 @@ jobs:
           gh pr create \
             --base main \
             --head "$BRANCH" \
-            --title "chore(coding-agent): update embedded API specs to ${SPEC_VERSION}" \
+            --title "fix(coding-agent): update embedded API specs to ${SPEC_VERSION}" \
             --body "Automated update triggered by upstream api-specs-enriched release.
 
           This PR updates the embedded API spec index and catalog to ${SPEC_VERSION}.


### PR DESCRIPTION
Closes #1525

## Problem

`api-spec-update.yml` regenerates the embedded API spec indexes **and** the minimum-settings defaults table, then opens an auto-merging PR committed as `chore(coding-agent): …`. The auto-release job (`ci.yml`: `!startsWith(head_commit.message, 'chore:')`) **skips `chore:`** — so refreshed specs/defaults land on `main` but never publish to npm, leaving consumers (vscode via Dependabot) stale until an unrelated release.

## Fix

Use `fix(coding-agent):` for the refresh **commit** (the squash-merge commit message) and **PR title**, so a real spec/defaults change triggers a patch auto-release → publishes `@f5xc-salesdemos/pi-resource-management` with the fresh table → vscode's daily Dependabot `f5xc-shared-libs` group bumps automatically.

api-specs-enriched only releases on upstream change, so release cadence stays bounded. Completes the fully-automated freshness chain: api-specs release → dispatch → xcsh regenerate+commit → **publish** → consumers bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)