### PR TITLE
feat(chrome): allow both unpacked + CWS extension IDs in native host

### DIFF
--- a/packages/coding-agent/src/cli/chrome-cli.ts
+++ b/packages/coding-agent/src/cli/chrome-cli.ts
@@ -15,7 +15,14 @@ type Settings = { get(key: string): unknown };
 
 export type ChromeAction = "status" | "relaunch" | "setup";
 
+// Unpacked (keyed) build — installed from a GitHub release. The manifest `key`
+// pins this deterministic ID.
 export const EXTENSION_ID = "khlalklompggpfnmeclpligmcbknkemg";
+// Chrome Web Store build — the store assigns this ID (no `key` field).
+export const EXTENSION_ID_CWS = "klajkjdoehjidngligegnpknogmjjhkc";
+// Both are allowed in the native-host manifest so the bridge works regardless of
+// how the user installed the extension.
+export const EXTENSION_IDS = [EXTENSION_ID, EXTENSION_ID_CWS];
 
 const NATIVE_HOST_NAME = "com.f5xc.xcsh.chrome_host";
 
@@ -29,7 +36,7 @@ export function writeNativeHostManifest(opts: {
 	platform?: NodeJS.Platform;
 	home?: string;
 	xcshBinPath: string;
-	extensionId: string;
+	extensionIds: string[];
 	write?: (p: string, c: string) => void;
 }): { manifestPath: string } {
 	const platform = opts.platform ?? process.platform;
@@ -43,7 +50,7 @@ export function writeNativeHostManifest(opts: {
 		path: opts.xcshBinPath,
 		args: ["chrome-host"],
 		type: "stdio",
-		allowed_origins: [`chrome-extension://${opts.extensionId}/`],
+		allowed_origins: opts.extensionIds.map(id => `chrome-extension://${id}/`),
 	};
 	const write =
 		opts.write ??
@@ -77,9 +84,9 @@ export async function runChromeCommand(action: ChromeAction, settings: Settings)
 	if (action === "setup") {
 		const { manifestPath } = writeNativeHostManifest({
 			xcshBinPath: process.execPath,
-			extensionId: EXTENSION_ID,
+			extensionIds: EXTENSION_IDS,
 		});
-		return `Installed native-messaging host manifest at ${manifestPath} (extension ${EXTENSION_ID}). Load the xcsh Chrome extension, then it can drive your real Chrome.`;
+		return `Installed native-messaging host manifest at ${manifestPath} (extensions ${EXTENSION_IDS.join(", ")}). Load the xcsh Chrome extension, then it can drive your real Chrome.`;
 	}
 	// relaunch: self-consented rung 3 — force allowRelaunch regardless of the setting.
 	const { mode } = await acquirePage({ settings, allowRelaunch: true });

--- a/packages/coding-agent/test/cli/chrome-setup.test.ts
+++ b/packages/coding-agent/test/cli/chrome-setup.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from "bun:test";
 import { writeNativeHostManifest } from "@f5xc-salesdemos/xcsh/cli/chrome-cli";
 
 describe("writeNativeHostManifest", () => {
-	it("writes the macOS native-host manifest with allowed_origins for the extension", () => {
+	it("writes the macOS native-host manifest with allowed_origins for each extension id", () => {
 		let path = "",
 			content = "";
 		const r = writeNativeHostManifest({
 			platform: "darwin",
 			home: "/Users/u",
 			xcshBinPath: "/usr/local/bin/xcsh",
-			extensionId: "abcdefghabcdefghabcdefghabcdefgh",
+			extensionIds: ["abcdefghabcdefghabcdefghabcdefgh", "ponmlkjihgfedcbaponmlkjihgfedcba"],
 			write: (p, c) => {
 				path = p;
 				content = c;
@@ -25,7 +25,10 @@ describe("writeNativeHostManifest", () => {
 			type: "stdio",
 			path: "/usr/local/bin/xcsh",
 			args: ["chrome-host"],
-			allowed_origins: ["chrome-extension://abcdefghabcdefghabcdefghabcdefgh/"],
+			allowed_origins: [
+				"chrome-extension://abcdefghabcdefghabcdefghabcdefgh/",
+				"chrome-extension://ponmlkjihgfedcbaponmlkjihgfedcba/",
+			],
 		});
 	});
 	it("uses the linux native-host dir", () => {
@@ -33,7 +36,7 @@ describe("writeNativeHostManifest", () => {
 			platform: "linux",
 			home: "/home/u",
 			xcshBinPath: "/x",
-			extensionId: "e",
+			extensionIds: ["e"],
 			write: () => {},
 		});
 		expect(r.manifestPath).toBe("/home/u/.config/google-chrome/NativeMessagingHosts/com.f5xc.xcsh.chrome_host.json");


### PR DESCRIPTION
Native host allowed_origins now includes both the unpacked (keyed) and Chrome Web Store extension IDs, so native messaging works for either install method. Closes #1530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)