### PR TITLE
fix(browser): add visible-mode guidance and surface actual mode in tool output

### DIFF
--- a/packages/coding-agent/src/prompts/tools/browser.md
+++ b/packages/coding-agent/src/prompts/tools/browser.md
@@ -2,6 +2,8 @@ Navigates, clicks, types, scrolls, drags, queries DOM content, and captures scre
 
 <instruction>
 - `"open"` starts a headless session (or implicitly on first action); `"goto"` navigates to `url`; `"close"` releases the browser
+- The browser launches in **headless** mode by default (no visible window). If the user asks to "open Chrome", "show a browser", or needs to see the browser window, tell them to run `/browser visible` first — this switches to a visible Chrome window. Use `/browser headless` to switch back.
+- `catalog_workflow_runner` always uses a visible Chrome session — it does not share this setting.
 - `"observe"` captures a numbered accessibility snapshot — prefer `click_id`/`type_id`/`fill_id` using returned `element_id` values; flags: `include_all`, `viewport_only`
 - `"click"`, `"type"`, `"fill"`, `"press"`, `"scroll"`, `"drag"` for selector-based interactions — prefer ARIA/text selectors (`p-aria/[name="Sign in"]`, `p-text/Continue`) over brittle CSS
 - `"click_id"`, `"type_id"`, `"fill_id"` to interact with observed elements without selectors

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -961,11 +961,12 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 					const page = await untilAborted(signal, () => this.#resetBrowser(params));
 					const viewport = page.viewport();
 					details.viewport = viewport ?? DEFAULT_VIEWPORT;
-					return toolResult(details).text("Opened headless browser session").done();
+					const mode = this.#currentHeadless ? "headless" : "visible";
+					return toolResult(details).text(`Opened browser session (${mode})`).done();
 				}
 				case "close": {
 					await untilAborted(signal, () => this.#closeBrowser());
-					return toolResult(details).text("Closed headless browser session").done();
+					return toolResult(details).text("Closed browser session").done();
 				}
 				case "goto": {
 					const url = ensureParam(params.url, "url", params.action);

--- a/packages/coding-agent/test/tools/browser-prompt.test.ts
+++ b/packages/coding-agent/test/tools/browser-prompt.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import browserDescription from "../../src/prompts/tools/browser.md" with { type: "text" };
+
+describe("browser.md prompt", () => {
+	it("mentions /browser visible for switching to visible mode", () => {
+		expect(browserDescription).toContain("/browser visible");
+	});
+
+	it("documents headless as the default launch mode", () => {
+		expect(browserDescription).toContain("headless");
+	});
+});


### PR DESCRIPTION
## Summary

Closes #1513

- **Updated `browser.md` prompt** with two new bullets: explains that the browser launches headless by default, documents `/browser visible` and `/browser headless` for mode switching, and notes that `catalog_workflow_runner` uses a separate visible session.
- **Fixed hardcoded mode strings in `browser.ts`**: the `open` action now reports the actual mode (`headless` or `visible`) instead of always saying "headless". The `close` action drops the mode qualifier entirely (irrelevant for a closed browser).
- **Added `browser-prompt.test.ts`**: regression test asserting `browser.md` mentions `/browser visible` and documents headless as the default.

### What's NOT in scope (deferred)

- Changing `browser.headless` default from `true` to `false` — flagged as discussion in the issue; the prompt fix resolves the core UX problem without a behavioral change for all users.

## Test plan

- [x] New `browser-prompt.test.ts` — 2 passing assertions
- [x] Existing `browser-readable.test.ts` — 2 passing
- [x] Existing `system-prompt-api-spec.test.ts` — 9 passing (API spec subset)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)