### PR TITLE
fix(prompt): inject console URL for correct environment routing

### DIFF
--- a/packages/coding-agent/src/prompts/system/custom-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/custom-system-prompt.md
@@ -33,6 +33,8 @@ Main branch: {{git.mainBranch}}
 ## F5 XC Platform Context
 
 You are currently connected to F5 XC tenant: {{context.tenant}}, namespace: {{context.namespace}}.
+{{#if context.apiUrl}}Console URL: {{context.apiUrl}}.
+When navigating to the F5 XC console, you **MUST** use this URL as the base. Do NOT construct a URL from the tenant name — different environments use different domain patterns.{{/if}}
 Credential source: {{context.credentialSource}}.
 Auth status: {{context.authStatus}}.
 All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -170,6 +170,8 @@ Configs you didn't validate become incidents. Assumptions you didn't test fail u
 ## F5 XC Platform Context
 
 You are currently connected to F5 XC tenant: {{context.tenant}}, namespace: {{context.namespace}}.
+{{#if context.apiUrl}}Console URL: {{context.apiUrl}}.
+When navigating to the F5 XC console, you **MUST** use this URL as the base. Do NOT construct a URL from the tenant name — different environments use different domain patterns.{{/if}}
 Credential source: {{context.credentialSource}}.
 Auth status: {{context.authStatus}}.
 All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1371,6 +1371,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						namespace: string;
 						credentialSource: string;
 						authStatus: string;
+						apiUrl?: string;
 						envVars?: Record<string, string>;
 				  }
 				| undefined;
@@ -1387,6 +1388,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						namespace: status.activeContextNamespace ?? "default",
 						credentialSource: status.credentialSource,
 						authStatus: status.authStatus,
+						apiUrl: status.activeContextUrl ?? undefined,
 					};
 					const sensitiveKeys = contextServiceRef?.instance?.getActiveSensitiveKeys();
 					const ctxEnv = createContextEnv(settings, sensitiveKeys?.size ? { sensitiveKeys } : undefined);

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -348,6 +348,7 @@ describe("system Handlebars prompt templates", () => {
 				namespace: "production",
 				credentialSource: "context",
 				authStatus: "connected",
+				apiUrl: "https://acme-corp.console.ves.volterra.io",
 			},
 		});
 		expect(rendered).toContain("## F5 XC Platform Context");
@@ -357,6 +358,8 @@ describe("system Handlebars prompt templates", () => {
 		expect(rendered).toContain(
 			"All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.",
 		);
+		expect(rendered).toContain("Console URL: https://acme-corp.console.ves.volterra.io.");
+		expect(rendered).toContain("**MUST** use this URL as the base");
 	});
 
 	test("custom-system-prompt omits the F5 XC context block when context is absent", async () => {
@@ -377,6 +380,7 @@ describe("system Handlebars prompt templates", () => {
 				namespace: "production",
 				credentialSource: "context",
 				authStatus: "connected",
+				apiUrl: "https://acme-corp.console.ves.volterra.io",
 			},
 		});
 		expect(rendered).toContain("## F5 XC Platform Context");
@@ -386,6 +390,8 @@ describe("system Handlebars prompt templates", () => {
 		expect(rendered).toContain(
 			"All F5 XC operations should target this tenant and namespace unless explicitly told otherwise.",
 		);
+		expect(rendered).toContain("Console URL: https://acme-corp.console.ves.volterra.io.");
+		expect(rendered).toContain("**MUST** use this URL as the base");
 	});
 
 	test("system-prompt omits the F5 XC context block when context is absent", async () => {
@@ -394,6 +400,22 @@ describe("system Handlebars prompt templates", () => {
 		const rendered = prompt.render(template, { ...baseRenderContext, context: undefined });
 		expect(rendered).not.toContain("## F5 XC Platform Context");
 		expect(rendered).not.toContain("All F5 XC operations should target");
+	});
+
+	test("system-prompt omits console URL line when apiUrl is absent", async () => {
+		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
+		const template = await Bun.file(templatePath).text();
+		const rendered = prompt.render(template, {
+			...baseRenderContext,
+			context: {
+				tenant: "acme-corp",
+				namespace: "production",
+				credentialSource: "context",
+				authStatus: "connected",
+			},
+		});
+		expect(rendered).toContain("## F5 XC Platform Context");
+		expect(rendered).not.toContain("Console URL:");
 	});
 
 	test("context block renders for env-backed sessions (credentialSource='environment', no context name)", async () => {


### PR DESCRIPTION
## Summary

Closes #1514

The agent could not determine the correct console URL for staging environments because only the tenant name was injected into the system prompt. It would guess `{tenant}.console.ves.volterra.io` (production pattern), which fails for staging tenants that use `{tenant}.staging.volterra.us`.

- **`sdk.ts`**: Added `apiUrl` to `contextForPrompt`, populated from `ContextService.getStatus().activeContextUrl`. This bypasses the `PROMPT_HIDDEN` filter (which blocks the raw `F5XC_API_URL` env var) by injecting the URL as a structured template variable instead.
- **`system-prompt.md` + `custom-system-prompt.md`**: Added a `{{#if context.apiUrl}}` guarded block that renders the console URL and a **MUST**-use directive telling the agent to use it as the browser base URL.
- **Tests**: Updated 2 existing context-present tests with `apiUrl` assertions, added 1 new test confirming the console URL line is omitted when `apiUrl` is absent.

## Test plan

- [x] 5 context-related template tests pass (2 updated + 1 new + 2 existing omit tests)
- [x] 9 API spec tests pass (regression check)
- [x] Biome check clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)