### PR TITLE
fix(console): emit full SPA route by concatenating route_prefix with route_pattern

### DIFF
--- a/packages/coding-agent/src/internal-urls/console-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/console-resolve.ts
@@ -61,7 +61,12 @@ function renderResource(resource: string, catalog: ConsoleCatalogData): string {
 	const doc = (parseYaml(raw) ?? {}) as Record<string, unknown>;
 	const console_ = (doc.console ?? {}) as Record<string, unknown>;
 	const lines = [`# ${(doc.label as string | undefined) ?? key}`, ""];
-	if (console_.route_pattern) lines.push(`**Route:** \`${console_.route_pattern}\``, "");
+	if (console_.route_pattern) {
+		const fullRoute = console_.route_prefix
+			? `${console_.route_prefix}${console_.route_pattern}`
+			: console_.route_pattern;
+		lines.push(`**Route:** \`${fullRoute}\``, "");
+	}
 	if (Array.isArray(console_.menu_path)) lines.push(`**Menu:** ${(console_.menu_path as string[]).join(" › ")}`, "");
 	const ops = operationsFor(key, catalog);
 	if (ops.length) {

--- a/packages/coding-agent/test/internal-urls/console-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/console-resolve.test.ts
@@ -11,7 +11,7 @@ const catalog = {
 	},
 	resources: {
 		"http-load-balancer":
-			"id: http-load-balancer\nlabel: HTTP Load Balancers\nconsole:\n  route_pattern: /namespaces/{namespace}/manage/load_balancers/http_loadbalancers\n  menu_path: [Web App & API Protection, Manage, Load Balancers, HTTP Load Balancers]\n",
+			"id: http-load-balancer\nlabel: HTTP Load Balancers\nconsole:\n  route_prefix: /web/workspaces/web-app-and-api-protection\n  route_pattern: /namespaces/{namespace}/manage/load_balancers/http_loadbalancers\n  menu_path: [Web App & API Protection, Manage, Load Balancers, HTTP Load Balancers]\n",
 	},
 	routes: {},
 	navigation: null,
@@ -28,8 +28,24 @@ describe("createConsoleResolver", () => {
 	it("renders a resource's route and operations", async () => {
 		const r = createConsoleResolver(catalog);
 		const res = await r.resolve(parseInternalUrl("xcsh://console/http-load-balancer") as never);
-		expect(res.content).toContain("/manage/load_balancers/http_loadbalancers");
+		expect(res.content).toContain(
+			"/web/workspaces/web-app-and-api-protection/namespaces/{namespace}/manage/load_balancers/http_loadbalancers",
+		);
 		expect(res.content).toContain("create");
+	});
+
+	it("renders route_pattern alone when route_prefix is absent", async () => {
+		const noPrefix = {
+			...catalog,
+			resources: {
+				"bare-resource":
+					"id: bare-resource\nlabel: Bare Resource\nconsole:\n  route_pattern: /some/bare/path\n  menu_path: [Admin, Bare]\n",
+			},
+		};
+		const r = createConsoleResolver(noPrefix);
+		const res = await r.resolve(parseInternalUrl("xcsh://console/bare-resource") as never);
+		expect(res.content).toContain("/some/bare/path");
+		expect(res.content).not.toContain("/web/workspaces/");
 	});
 
 	it("renders ordered workflow steps for a resource/operation", async () => {


### PR DESCRIPTION
## Summary

Closes #1515

`console-resolve.ts` rendered only `route_pattern` (e.g., `/personal-management/api_credentials`) when displaying console resource routes via `xcsh://console/<resource>`. The `route_prefix` field (e.g., `/web/workspaces/administration`) was present in the catalog data for all 101 resources but never consumed. This produced incomplete paths that hit Keycloak-protected server-side endpoints instead of the SPA router, causing "Invalid CSRF token" errors.

- **`console-resolve.ts`**: Changed L64 to concatenate `route_prefix + route_pattern` when `route_prefix` exists, falling back to `route_pattern` alone when absent.
- **`console-resolve.test.ts`**: Added `route_prefix` to the test fixture to match real catalog shape, updated the route assertion to verify the full SPA path, and added a new test confirming the fallback when `route_prefix` is absent.

## Test plan

- [x] 8 console-resolve tests pass (1 updated assertion + 1 new fallback test + 6 existing)
- [x] Biome check clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)