### PR TITLE
fix: cap subprocess/git output collection to prevent OOM crash

### DIFF
--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1,7 +1,14 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { $which, isEnoent, Snowflake } from "@f5xc-salesdemos/pi-utils";
+import {
+	$which,
+	isEnoent,
+	logger,
+	OutputTooLargeError,
+	readStreamCappedText,
+	Snowflake,
+} from "@f5xc-salesdemos/pi-utils";
 import {
 	parseDiffHunks as parseCommitDiffHunks,
 	parseFileDiffs,
@@ -202,11 +209,32 @@ async function runCommand(
 		throw new Error("Failed to capture git command output.");
 	}
 
-	const [stdout, stderr, exitCode] = await Promise.all([
-		new Response(child.stdout).text(),
-		new Response(child.stderr).text(),
-		child.exited,
-	]);
+	// Cap output collection: a large diff/log/show on a big repo can otherwise
+	// buffer unbounded and crash the whole process with RangeError: Out of memory.
+	const source = `git ${commandArgs.join(" ")}`;
+	let stdout: string;
+	let stderr: string;
+	let exitCode: number;
+	try {
+		const [out, err, code] = await Promise.all([
+			readStreamCappedText(child.stdout, { source, signal: options.signal }),
+			readStreamCappedText(child.stderr, { source, signal: options.signal }),
+			child.exited,
+		]);
+		stdout = out;
+		stderr = err;
+		exitCode = code;
+	} catch (err) {
+		if (err instanceof OutputTooLargeError) {
+			logger.warn("git command output exceeded memory cap — aborting", { source, maxBytes: err.maxBytes });
+		}
+		try {
+			child.kill();
+		} catch {
+			// child may have already exited
+		}
+		throw err;
+	}
 
 	return { exitCode: exitCode ?? 0, stdout, stderr };
 }
@@ -1378,11 +1406,33 @@ export const github = {
 			if (!child.stdout || !child.stderr) {
 				throw new ToolError("Failed to capture GitHub CLI output.");
 			}
-			const [stdout, stderr, exitCode] = await Promise.all([
-				new Response(child.stdout).text(),
-				new Response(child.stderr).text(),
-				child.exited,
-			]);
+			const ghSource = `gh ${args.join(" ")}`;
+			let stdout: string;
+			let stderr: string;
+			let exitCode: number;
+			try {
+				const [out, err, code] = await Promise.all([
+					readStreamCappedText(child.stdout, { source: ghSource, signal }),
+					readStreamCappedText(child.stderr, { source: ghSource, signal }),
+					child.exited,
+				]);
+				stdout = out;
+				stderr = err;
+				exitCode = code;
+			} catch (err) {
+				if (err instanceof OutputTooLargeError) {
+					logger.warn("gh command output exceeded memory cap — aborting", {
+						source: ghSource,
+						maxBytes: err.maxBytes,
+					});
+				}
+				try {
+					child.kill();
+				} catch {
+					// child may have already exited
+				}
+				throw err;
+			}
 			throwIfAborted(signal);
 			const trim = options?.trimOutput !== false;
 			return {

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -178,6 +178,18 @@ function ensureAvailable(): void {
 	}
 }
 
+/**
+ * Redact credential material from a command line before it is used as a log /
+ * error label. Strips URL userinfo (https://user:token@host) and values that
+ * follow sensitive flags so tokens embedded in args (e.g. an authenticated clone
+ * URL or `--token X`) never reach logs or error messages.
+ */
+function redactCommandForLog(commandLine: string): string {
+	return commandLine
+		.replace(/([a-z][a-z0-9+.-]*:\/\/)[^/@\s]*@/gi, "$1<redacted>@")
+		.replace(/(--(?:token|password|secret|auth|api-key)(?:=|\s+))\S+/gi, "$1<redacted>");
+}
+
 function formatCommandFailure(
 	args: readonly string[],
 	result: Pick<GitCommandResult, "exitCode" | "stdout" | "stderr">,
@@ -211,7 +223,7 @@ async function runCommand(
 
 	// Cap output collection: a large diff/log/show on a big repo can otherwise
 	// buffer unbounded and crash the whole process with RangeError: Out of memory.
-	const source = `git ${commandArgs.join(" ")}`;
+	const source = redactCommandForLog(`git ${commandArgs.join(" ")}`);
 	let stdout: string;
 	let stderr: string;
 	let exitCode: number;
@@ -1406,7 +1418,7 @@ export const github = {
 			if (!child.stdout || !child.stderr) {
 				throw new ToolError("Failed to capture GitHub CLI output.");
 			}
-			const ghSource = `gh ${args.join(" ")}`;
+			const ghSource = redactCommandForLog(`gh ${args.join(" ")}`);
 			let stdout: string;
 			let stderr: string;
 			let exitCode: number;

--- a/packages/utils/src/ptree.ts
+++ b/packages/utils/src/ptree.ts
@@ -8,6 +8,7 @@
  */
 import type { Spawn, Subprocess } from "bun";
 import { terminate } from "./procmgr";
+import { DEFAULT_MAX_OUTPUT_BYTES, readStreamCapped, readStreamCappedText } from "./stream";
 
 type InMask = "pipe" | "ignore" | Buffer | Uint8Array | null;
 
@@ -72,6 +73,8 @@ export interface WaitOptions {
 	allowNonZero?: boolean;
 	allowAbort?: boolean;
 	stderr?: "full" | "buffer";
+	/** Max bytes of stdout to buffer before throwing OutputTooLargeError (default 50 MiB). */
+	maxOutputBytes?: number;
 }
 
 /** Result from wait and exec. */
@@ -97,6 +100,8 @@ export class ChildProcess<In extends InMask = InMask> {
 	#nothrow = false;
 	#stderrTail = "";
 	#stderrChunks: Uint8Array[] = [];
+	#stderrBytes = 0;
+	#stderrTruncated = false;
 	#exitReason?: Exception;
 	#exitReasonPending?: Exception;
 	#stderrDone: Promise<void>;
@@ -122,7 +127,15 @@ export class ChildProcess<In extends InMask = InMask> {
 		this.#stderrDone = (async () => {
 			try {
 				for await (const chunk of stderrStream) {
-					this.#stderrChunks.push(chunk);
+					// Bound the retained full-stderr buffer so a subprocess that floods
+					// stderr can't exhaust the heap. Keep draining (to avoid pipe
+					// deadlock) but stop retaining chunks past the cap; #stderrTail keeps
+					// the last 32KB regardless.
+					if (this.#stderrBytes < DEFAULT_MAX_OUTPUT_BYTES) {
+						this.#stderrChunks.push(chunk);
+						this.#stderrBytes += chunk.byteLength;
+						if (this.#stderrBytes >= DEFAULT_MAX_OUTPUT_BYTES) this.#stderrTruncated = true;
+					}
 					this.#stderrTail += dec.decode(chunk, { stream: true });
 					trim();
 				}
@@ -220,44 +233,71 @@ export class ChildProcess<In extends InMask = InMask> {
 
 	// ── Output helpers ───────────────────────────────────────────────────
 
+	/**
+	 * Fully read stdout into memory, bounded by a hard byte cap. Throws
+	 * OutputTooLargeError past the cap instead of growing the heap until the
+	 * process dies with `RangeError: Out of memory`.
+	 */
+	#readStdoutCapped(): Promise<Uint8Array> {
+		return readStreamCapped(this.stdout, { source: "subprocess stdout" });
+	}
+
 	async text(): Promise<string> {
-		const p = new Response(this.stdout).text();
+		const p = readStreamCappedText(this.stdout, { source: "subprocess stdout" });
 		if (this.#nothrow) return p;
 		const [text] = await Promise.all([p, this.exitedCleanly]);
 		return text;
 	}
 
 	async blob(): Promise<Blob> {
-		const p = new Response(this.stdout).blob();
+		const p = this.#readStdoutCapped().then(bytes => new Blob([bytes]));
 		if (this.#nothrow) return p;
 		const [blob] = await Promise.all([p, this.exitedCleanly]);
 		return blob;
 	}
 
 	async json(): Promise<unknown> {
-		return new Response(this.stdout).json();
+		return JSON.parse(await readStreamCappedText(this.stdout, { source: "subprocess stdout" }));
 	}
 
 	async arrayBuffer(): Promise<ArrayBuffer> {
-		return new Response(this.stdout).arrayBuffer();
+		const bytes = await this.#readStdoutCapped();
+		return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 	}
 
 	async bytes(): Promise<Uint8Array> {
-		return new Response(this.stdout).bytes();
+		return this.#readStdoutCapped();
 	}
 
 	// ── Wait ─────────────────────────────────────────────────────────────
 
 	async wait(opts?: WaitOptions): Promise<ExecResult> {
-		const { allowNonZero = false, allowAbort = false, stderr: stderrMode = "buffer" } = opts ?? {};
+		const { allowNonZero = false, allowAbort = false, stderr: stderrMode = "buffer", maxOutputBytes } = opts ?? {};
 
-		const stdoutP = new Response(this.stdout).text();
+		const stdoutP = readStreamCappedText(this.stdout, { source: "subprocess stdout", maxBytes: maxOutputBytes });
 		const stderrP =
 			stderrMode === "full"
-				? this.#stderrDone.then(() => new TextDecoder().decode(Buffer.concat(this.#stderrChunks)))
+				? this.#stderrDone.then(() => {
+						const text = new TextDecoder().decode(Buffer.concat(this.#stderrChunks));
+						return this.#stderrTruncated
+							? `${text}\n…[stderr truncated at ${DEFAULT_MAX_OUTPUT_BYTES} bytes]`
+							: text;
+					})
 				: this.#stderrDone.then(() => this.#stderrTail);
 
-		const [stdout, stderr] = await Promise.all([stdoutP, stderrP]);
+		let stdout: string;
+		let stderr: string;
+		try {
+			[stdout, stderr] = await Promise.all([stdoutP, stderrP]);
+		} catch (err) {
+			// Output collection failed (e.g. OutputTooLargeError). Terminate the child
+			// and consume its exit/stderr promises so the kill's rejection isn't left
+			// unhandled (which would otherwise trip the global crash handler).
+			this.kill();
+			void this.#exited.catch(() => {});
+			void this.#stderrDone.catch(() => {});
+			throw err;
+		}
 
 		let exitError: Exception | undefined;
 		try {
@@ -345,11 +385,11 @@ export interface ExecOptions extends Omit<ChildSpawnOptions, "stderr" | "stdin">
 
 /** Spawn, wait, and return captured output. */
 export async function exec(cmd: string[], opts?: ExecOptions): Promise<ExecResult> {
-	const { input, stderr, allowAbort, allowNonZero, ...spawnOpts } = opts ?? {};
+	const { input, stderr, allowAbort, allowNonZero, maxOutputBytes, ...spawnOpts } = opts ?? {};
 	const stdin = typeof input === "string" ? Buffer.from(input) : input;
 	const resolved: ChildSpawnOptions = stdin === undefined ? spawnOpts : { ...spawnOpts, stdin };
 	using child = spawn(cmd, resolved);
-	return await child.wait({ stderr, allowAbort, allowNonZero });
+	return await child.wait({ stderr, allowAbort, allowNonZero, maxOutputBytes });
 }
 
 // ── Signal combinators ───────────────────────────────────────────────────────

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -1,5 +1,83 @@
 import { createAbortableStream } from "./abortable";
 
+/**
+ * Default ceiling for fully buffering a stream into memory (50 MiB). Reading an
+ * unbounded subprocess/HTTP stream into one buffer can exhaust the heap and crash
+ * the process with `RangeError: Out of memory`; this bounds that.
+ */
+export const DEFAULT_MAX_OUTPUT_BYTES = 50 * 1024 * 1024;
+
+/** Thrown when a capped stream read exceeds its byte limit. */
+export class OutputTooLargeError extends Error {
+	constructor(
+		readonly maxBytes: number,
+		readonly source?: string,
+	) {
+		super(`Output exceeded ${maxBytes} bytes${source ? ` (${source})` : ""}`);
+		this.name = "OutputTooLargeError";
+	}
+}
+
+export interface ReadStreamCappedOptions {
+	/** Maximum bytes to buffer before throwing OutputTooLargeError (default 50 MiB). */
+	maxBytes?: number;
+	/** Short label (e.g. the command/URL) included in the error and any log. */
+	source?: string;
+	/** Abort signal; aborting cancels the reader and rejects. */
+	signal?: AbortSignal;
+}
+
+/**
+ * Read a ReadableStream fully into a single Uint8Array, enforcing a hard byte
+ * cap. On exceeding the cap the reader is cancelled and `OutputTooLargeError` is
+ * thrown — the size is checked BEFORE retaining each chunk, so memory never
+ * exceeds the cap (unlike `new Response(stream).text()`, which buffers unbounded).
+ */
+export async function readStreamCapped(
+	stream: ReadableStream<Uint8Array>,
+	options: ReadStreamCappedOptions = {},
+): Promise<Uint8Array> {
+	const { maxBytes = DEFAULT_MAX_OUTPUT_BYTES, source, signal } = options;
+	const reader = stream.getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	try {
+		while (true) {
+			if (signal?.aborted) {
+				await reader.cancel();
+				throw signal.reason instanceof Error ? signal.reason : new Error("aborted");
+			}
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (!value || value.byteLength === 0) continue;
+			total += value.byteLength;
+			if (total > maxBytes) {
+				await reader.cancel();
+				throw new OutputTooLargeError(maxBytes, source);
+			}
+			chunks.push(value);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const chunk of chunks) {
+		out.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return out;
+}
+
+/** Like {@link readStreamCapped} but decodes the result as UTF-8 text. */
+export async function readStreamCappedText(
+	stream: ReadableStream<Uint8Array>,
+	options: ReadStreamCappedOptions = {},
+): Promise<string> {
+	return new TextDecoder().decode(await readStreamCapped(stream, options));
+}
+
 const LF = 0x0a;
 type JsonlChunkResult = {
 	values: unknown[];

--- a/packages/utils/test/ptree-cap.test.ts
+++ b/packages/utils/test/ptree-cap.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { OutputTooLargeError, ptree } from "../src/index";
+
+// Regression for issue #1552: subprocess stdout was collected via
+// `new Response(stream).text()` with no cap, so a command emitting huge output
+// grew the heap until `RangeError: Out of memory` crashed the whole process.
+// ptree now bounds collection and throws OutputTooLargeError instead.
+describe("ptree.exec output cap", () => {
+	it("throws OutputTooLargeError when stdout exceeds the cap", async () => {
+		await expect(
+			ptree.exec(["bun", "-e", "process.stdout.write('x'.repeat(200000))"], {
+				maxOutputBytes: 1024,
+				allowNonZero: true,
+			}),
+		).rejects.toBeInstanceOf(OutputTooLargeError);
+	});
+
+	it("returns full stdout when under the cap", async () => {
+		const result = await ptree.exec(["bun", "-e", "process.stdout.write('hello world')"], {
+			maxOutputBytes: 1024,
+		});
+		expect(result.stdout).toBe("hello world");
+	});
+
+	it("caps an unbounded (infinite) producer without OOM", async () => {
+		// A producer that never stops — the cap must cancel the reader and throw
+		// rather than buffer forever.
+		await expect(
+			ptree.exec(["bun", "-e", "while(true){process.stdout.write('y'.repeat(4096))}"], {
+				maxOutputBytes: 64 * 1024,
+				allowNonZero: true,
+				allowAbort: true,
+			}),
+		).rejects.toBeInstanceOf(OutputTooLargeError);
+	});
+});

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import { sanitizeText } from "@f5xc-salesdemos/pi-natives";
-import { parseJsonlLenient, readJsonl, readLines, readSseJson } from "../src/stream";
+import {
+	OutputTooLargeError,
+	parseJsonlLenient,
+	readJsonl,
+	readLines,
+	readSseJson,
+	readStreamCapped,
+	readStreamCappedText,
+} from "../src/stream";
 
 const encoder = new TextEncoder();
 
@@ -161,5 +169,62 @@ describe("readSseJson", () => {
 
 		const output = await collectAsync(readSseJson(stream));
 		expect(output).toEqual([{ a: 1 }]);
+	});
+});
+
+describe("readStreamCapped", () => {
+	function byteStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+		return new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		});
+	}
+
+	it("returns the full bytes when the stream is under the cap", async () => {
+		const out = await readStreamCapped(byteStream([encoder.encode("hello world")]), { maxBytes: 1024 });
+		expect(new TextDecoder().decode(out)).toBe("hello world");
+	});
+
+	it("concatenates multiple chunks in order", async () => {
+		const out = await readStreamCapped(
+			byteStream([encoder.encode("ab"), encoder.encode("cd"), encoder.encode("ef")]),
+			{
+				maxBytes: 1024,
+			},
+		);
+		expect(new TextDecoder().decode(out)).toBe("abcdef");
+	});
+
+	it("throws OutputTooLargeError when the stream exceeds the cap", async () => {
+		const chunk = new Uint8Array(1024); // 1 KiB
+		const chunks = Array.from({ length: 10 }, () => chunk); // 10 KiB total
+		await expect(readStreamCapped(byteStream(chunks), { maxBytes: 4096, source: "test-cmd" })).rejects.toBeInstanceOf(
+			OutputTooLargeError,
+		);
+	});
+
+	it("OutputTooLargeError carries the cap and source label", async () => {
+		const big = new Uint8Array(8192);
+		try {
+			await readStreamCapped(byteStream([big]), { maxBytes: 1024, source: "git diff" });
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(OutputTooLargeError);
+			expect((err as OutputTooLargeError).maxBytes).toBe(1024);
+			expect((err as OutputTooLargeError).source).toBe("git diff");
+		}
+	});
+
+	it("readStreamCappedText decodes UTF-8 under the cap", async () => {
+		const out = await readStreamCappedText(byteStream([encoder.encode("café ☕")]), { maxBytes: 1024 });
+		expect(out).toBe("café ☕");
+	});
+
+	it("rejects when the signal is already aborted", async () => {
+		const ac = new AbortController();
+		ac.abort();
+		await expect(readStreamCapped(byteStream([encoder.encode("x")]), { signal: ac.signal })).rejects.toBeTruthy();
 	});
 });


### PR DESCRIPTION
Closes #1552

## Symptom
xcsh crashed the whole process with an uncaught `RangeError: Out of memory` (Bun native stream sink `#getInternalBuffer`/`#pull`, inside `processTicksAndRejections` — i.e. a background async task) while the user was merely typing.

## Root cause
Subprocess and git/gh output were collected via `new Response(stream).text()` with **no size cap**:
- `utils/git.ts` `runCommand` + the `gh` runner — every git op; a large diff/log/show in a big repo buffers unbounded.
- `utils/ptree.ts` `ChildProcess.text()/wait()/arrayBuffer()/bytes()`; `wait()` with `stderr:"full"` did `Buffer.concat(#stderrChunks)` over an unbounded array.

A background task reading a large/flooding stream grew the heap until the process died. The `bash`/`read`/`fetch` tools were already bounded — this closes the subprocess/git gap.

## Fix
- **Shared bounded reader** (`packages/utils/src/stream.ts`): `readStreamCapped` / `readStreamCappedText` throw `OutputTooLargeError` past a hard cap (default 50 MiB), checking size **before** retaining each chunk (no `Buffer.concat` doubling). Generalizes the existing `readResponseWithLimit` pattern.
- **ptree**: all stdout collectors route through it; `#stderrChunks` is bounded (with a truncation marker); new `maxOutputBytes` option. `wait()` now terminates the child and consumes `#exited`/`#stderrDone` on a collection error so the kill's rejection is never left **unhandled** (which would otherwise trip the global crash handler).
- **git.ts**: `runCommand` + `gh` runner use the capped reader and `warn`-log the command + cap on overflow (names the culprit if it recurs).

Prevention is the fix — a genuine OOM is unrecoverable once thrown; the existing global `uncaughtException` guard remains the last resort.

## Tests
- `stream.test.ts`: capped reader (under cap, multi-chunk, over-cap throws, error carries cap+source, abort).
- `ptree-cap.test.ts`: `ptree.exec` with a low cap throws on oversized stdout, returns full output under cap, and caps an **infinite** producer without OOM.
- Full workspace suite: 6276 pass. The only failures are the new Puppeteer/real-Chrome `extension-e2e` tests, which **self-skip in CI** (`isCI` guard) and fail locally only because this box has no Chrome — unrelated to this change.