### PR TITLE
feat: comprehensive UAT matrix — NL-driven console CRUD + json + hcl + i18n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ pi-*.html
 packages/coding-agent/src/internal-urls/docs-index.generated.ts
 packages/coding-agent/src/internal-urls/build-info.generated.ts
 packages/typescript-edit-benchmark/runs/
+
+# UAT matrix run artifacts
+uat-matrix/reports/

--- a/packages/coding-agent/scripts/uat-matrix-modalities.ts
+++ b/packages/coding-agent/scripts/uat-matrix-modalities.ts
@@ -1,0 +1,451 @@
+/**
+ * UAT matrix — per-modality run + verify functions.
+ *
+ * Each returns a Cell. The agent is driven via `xcsh --print` (NL in), then
+ * verified out-of-band:
+ *   console → catalog_workflow_runner (observable) + UI step-table + API GET
+ *   json    → API GET (autoresearch-crud pattern)
+ *   hcl     → terraform validate (or keyword presence fallback)
+ *   i18n    → HCL keyword presence per locale
+ */
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Cell } from "./uat-matrix-report";
+
+export interface MatrixConfig {
+	xcshBin: string;
+	apiUrl: string;
+	apiToken: string;
+	consoleNamespace: string;
+	tenant: string;
+	observable: boolean;
+	delayMs: number;
+	reportDir: string;
+	strictNl: boolean;
+	cellTimeoutMs: number;
+}
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// xcsh subprocess + API helpers
+// ---------------------------------------------------------------------------
+
+export interface XcshRun {
+	stdout: string;
+	stderr: string;
+	code: number | null;
+	timedOut: boolean;
+}
+
+export function runXcsh(
+	args: string[],
+	opts: { timeoutMs: number; env?: NodeJS.ProcessEnv; cwd?: string; bin?: string },
+): Promise<XcshRun> {
+	return new Promise(resolve => {
+		const child = spawn(opts.bin ?? "xcsh", args, {
+			env: opts.env ?? process.env,
+			cwd: opts.cwd,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		let timedOut = false;
+		const timer = setTimeout(() => {
+			timedOut = true;
+			child.kill("SIGKILL");
+		}, opts.timeoutMs);
+		child.stdout.on("data", d => {
+			stdout += d.toString();
+		});
+		child.stderr.on("data", d => {
+			stderr += d.toString();
+		});
+		child.on("close", code => {
+			clearTimeout(timer);
+			resolve({ stdout, stderr, code, timedOut });
+		});
+		child.on("error", () => {
+			clearTimeout(timer);
+			resolve({ stdout, stderr: `${stderr}\n(spawn error)`, code: -1, timedOut });
+		});
+	});
+}
+
+/** GET an API path; returns the HTTP code, retrying 3× on transient 000. */
+export async function apiGet(apiPath: string, cfg: MatrixConfig): Promise<string> {
+	const url = `${cfg.apiUrl}${apiPath}`;
+	for (let i = 0; i < 3; i++) {
+		try {
+			const r = await fetch(url, { headers: { Authorization: `APIToken ${cfg.apiToken}` } });
+			return String(r.status);
+		} catch {
+			await sleep(2000);
+		}
+	}
+	return "000";
+}
+
+export async function apiDelete(apiPath: string, cfg: MatrixConfig): Promise<string> {
+	try {
+		const r = await fetch(`${cfg.apiUrl}${apiPath}`, {
+			method: "DELETE",
+			headers: { Authorization: `APIToken ${cfg.apiToken}`, "Content-Type": "application/json" },
+		});
+		return String(r.status);
+	} catch {
+		return "000";
+	}
+}
+
+/** Best-effort detection of which path the agent used, from the --print trace. */
+export function detectRouted(stdout: string): Cell["routedTo"] {
+	const s = stdout.toLowerCase();
+	const usedConsole = /catalog_workflow_runner|workflow:\s|\[pass\s*\]|\[fail\s*\]|\bobservable\b/.test(s);
+	const usedApi = /xcsh_api|\bpost \/api|\bput \/api|api call/.test(s);
+	if (usedConsole && !usedApi) return "console";
+	if (usedApi && !usedConsole) return "api";
+	if (usedConsole && usedApi) return "console"; // console drove it even if it also read via API
+	if (/```(hcl|terraform)|resource\s+"f5xc_/.test(stdout)) return "file";
+	return "unknown";
+}
+
+/** Parse the catalog_workflow_runner step table from xcsh stdout. */
+function workflowReportedPass(stdout: string): boolean | null {
+	const m = stdout.match(/Status:\s*(PASS|FAIL)/i);
+	if (m) return m[1]!.toUpperCase() === "PASS";
+	if (/\[FAIL\s*\]/.test(stdout)) return false;
+	if (/\[PASS\s*\]/.test(stdout)) return true;
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// Console phrase shape (from console-phrases.yaml)
+// ---------------------------------------------------------------------------
+
+export interface ConsolePhrase {
+	id: string;
+	phrase: string;
+	operation: "create" | "delete";
+	console_resource: string;
+	verify: {
+		api_path: string;
+		resource_name: string;
+		namespace: string;
+		expect_http_create?: number;
+		expect_http_delete?: number;
+		ui_readback?: string;
+	};
+	nested?: Array<{ console_resource: string; api_path: string; resource_name: string }>;
+	cleanup?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Modality runners
+// ---------------------------------------------------------------------------
+
+export async function runConsole(p: ConsolePhrase, cfg: MatrixConfig): Promise<Cell> {
+	const start = performance.now();
+	const shotDir = path.join(cfg.reportDir, "screenshots", p.id);
+	fs.mkdirSync(shotDir, { recursive: true });
+
+	const guardrail = cfg.strictNl
+		? "" // strict-NL: no guardrail, measure raw routing
+		: [
+				"You are executing a console UAT step against the F5 XC web console.",
+				"You MUST perform this operation in the console using the catalog_workflow_runner tool —",
+				"do NOT substitute the xcsh_api tool. When you call catalog_workflow_runner, set",
+				`observable: ${cfg.observable}, observable_delay_ms: ${cfg.delayMs}, screenshot_dir: "${shotDir}",`,
+				`and pass namespace: "${cfg.consoleNamespace}" in params. Use the exact resource names in the request.`,
+			].join(" ");
+
+	const args = ["--print", "--no-session"];
+	if (guardrail) args.push("--append-system-prompt", guardrail);
+	args.push(p.phrase);
+
+	const run = await runXcsh(args, {
+		timeoutMs: cfg.cellTimeoutMs,
+		bin: cfg.xcshBin,
+		env: { ...process.env, F5XC_API_URL: cfg.apiUrl },
+	});
+
+	const routedTo = detectRouted(run.stdout);
+	const uiPass = workflowReportedPass(run.stdout);
+
+	// API verification (authoritative): parent + every nested child.
+	const ns = p.verify.namespace;
+	const targets = [
+		{ api_path: p.verify.api_path, name: p.verify.resource_name },
+		...(p.nested ?? []).map(n => ({ api_path: n.api_path, name: n.resource_name })),
+	];
+	const codes: Record<string, string> = {};
+	let apiOk = true;
+	for (const t of targets) {
+		const code = await apiGet(`/api/config/namespaces/${ns}/${t.api_path}/${t.name}`, cfg);
+		codes[t.name] = code;
+		if (p.operation === "create" && code !== String(p.verify.expect_http_create ?? 200)) apiOk = false;
+		if (p.operation === "delete" && !(code === String(p.verify.expect_http_delete ?? 404) || code === "000"))
+			apiOk = false;
+	}
+
+	const screenshots = fs.existsSync(shotDir)
+		? fs
+				.readdirSync(shotDir)
+				.filter(f => f.endsWith(".png"))
+				.map(f => path.join(shotDir, f))
+		: [];
+
+	let status: Cell["status"] = "PASS";
+	const notes: string[] = [];
+	if (run.timedOut) {
+		status = "FAIL";
+		notes.push(`timed out after ${cfg.cellTimeoutMs}ms`);
+	}
+	if (!apiOk) {
+		status = "FAIL";
+		notes.push(`API codes ${JSON.stringify(codes)} (expected ${p.operation})`);
+	}
+	if (uiPass === false) {
+		// UI said fail but API ok → divergence
+		if (apiOk) notes.push("UI/API divergence: workflow reported FAIL but API matches");
+		else {
+			status = "FAIL";
+			notes.push("workflow reported FAIL");
+		}
+	}
+	if (routedTo === "api") notes.push("router leak: agent used the API, not the console");
+
+	const parentCode = codes[p.verify.resource_name];
+	return {
+		modality: "console",
+		id: p.id,
+		phrase: p.phrase,
+		operation: p.operation,
+		resource: p.console_resource,
+		status,
+		durationMs: performance.now() - start,
+		detail: notes.join("; ") || `console ${p.operation} ok (${routedTo})`,
+		screenshots,
+		httpCreate: p.operation === "create" ? parentCode : undefined,
+		httpDelete: p.operation === "delete" ? parentCode : undefined,
+		routedTo,
+	};
+}
+
+export interface CrudPhrase {
+	phrase: string;
+	operation: string;
+	resource: string;
+	resource_name: string;
+	api_path: string;
+	namespace_scoped?: boolean;
+	api_namespace?: string;
+	skip_crud_test?: boolean;
+}
+
+export async function runJson(p: CrudPhrase, cfg: MatrixConfig): Promise<Cell> {
+	const start = performance.now();
+	if (p.skip_crud_test) {
+		return {
+			modality: "json",
+			id: `J-${p.resource}-${p.operation}`,
+			phrase: p.phrase,
+			operation: p.operation,
+			resource: p.resource,
+			status: "SKIP",
+			durationMs: 0,
+			detail: "skip_crud_test=true",
+		};
+	}
+	const ns = p.api_namespace || "r-mordasiewicz";
+	const verifyPath =
+		p.namespace_scoped === false
+			? `/api/web/namespaces/${p.resource_name}`
+			: `/api/config/namespaces/${ns}/${p.api_path}/${p.resource_name}`;
+
+	const run = await runXcsh(["--print", "--no-session", p.phrase], {
+		timeoutMs: 120_000,
+		bin: cfg.xcshBin,
+		env: { ...process.env, F5XC_API_URL: cfg.apiUrl, F5XC_API_TOKEN: cfg.apiToken },
+	});
+
+	let code = await apiGet(verifyPath, cfg);
+	let ok = false;
+	if (p.operation === "create" || p.operation === "update" || p.operation === "read") {
+		ok = code === "200";
+	} else if (p.operation === "delete") {
+		await sleep(2000);
+		code = await apiGet(verifyPath, cfg);
+		ok = code === "404" || code === "000";
+	}
+	return {
+		modality: "json",
+		id: `J-${p.resource}-${p.operation}`,
+		phrase: p.phrase,
+		operation: p.operation,
+		resource: p.resource,
+		status: run.timedOut ? "FAIL" : ok ? "PASS" : "FAIL",
+		durationMs: performance.now() - start,
+		detail: run.timedOut ? "timed out" : `http=${code}`,
+		httpCreate: p.operation !== "delete" ? code : undefined,
+		httpDelete: p.operation === "delete" ? code : undefined,
+		routedTo: detectRouted(run.stdout),
+	};
+}
+
+export interface TfPhrase {
+	phrase: string;
+	operation: string;
+	expect_resource?: string;
+	expect_fields?: string[];
+	expect_command?: string;
+}
+
+function extractHcl(stdout: string, workdir: string): string {
+	// 1) any *.tf files xcsh wrote
+	let hcl = "";
+	try {
+		for (const f of fs.readdirSync(workdir)) {
+			if (f.endsWith(".tf")) hcl += `\n${fs.readFileSync(path.join(workdir, f), "utf8")}`;
+		}
+	} catch {
+		/* no workdir files */
+	}
+	// 2) fenced ```hcl / ```terraform blocks in stdout
+	const fence = /```(?:hcl|terraform|tf)?\s*([\s\S]*?)```/gi;
+	let m: RegExpExecArray | null;
+	// biome-ignore lint/suspicious/noAssignInExpressions: standard regex loop
+	while ((m = fence.exec(stdout)) !== null) {
+		if (/resource\s+"f5xc_|provider\s+"f5xc"|terraform\s*\{/.test(m[1]!)) hcl += `\n${m[1]}`;
+	}
+	return hcl.trim();
+}
+
+async function terraformAvailable(): Promise<boolean> {
+	const r = await runXcsh(["version"], { timeoutMs: 10_000, bin: "terraform" });
+	return r.code === 0;
+}
+
+export async function runHcl(p: TfPhrase, cfg: MatrixConfig, tfOk: boolean): Promise<Cell> {
+	const start = performance.now();
+	const id = `H-${(p.expect_resource ?? p.operation).replace(/^f5xc_/, "")}-${p.operation}`;
+	const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "uat-hcl-"));
+	try {
+		const run = await runXcsh(["--print", "--no-session", p.phrase], {
+			timeoutMs: 120_000,
+			bin: cfg.xcshBin,
+			cwd: workdir,
+			env: { ...process.env, F5XC_API_URL: cfg.apiUrl },
+		});
+
+		// expect_command phrases (plan/destroy explanations): keyword presence only.
+		if (p.expect_command && !p.expect_resource) {
+			const ok = run.stdout.toLowerCase().includes(p.expect_command.toLowerCase());
+			return cell(ok, run, `expect_command "${p.expect_command}"`);
+		}
+
+		const hcl = extractHcl(run.stdout, workdir);
+		const fieldsPresent =
+			!!p.expect_resource && hcl.includes(p.expect_resource) && (p.expect_fields ?? []).every(f => hcl.includes(f));
+
+		let detail = `keyword presence: ${fieldsPresent ? "ok" : "missing fields/resource"}`;
+		let ok = fieldsPresent;
+
+		// Authoritative terraform validate when available + we have HCL.
+		if (tfOk && hcl) {
+			fs.writeFileSync(path.join(workdir, "main.tf"), hcl);
+			const fmt = await runXcsh(["fmt", "-check", "-list=false"], {
+				timeoutMs: 30_000,
+				bin: "terraform",
+				cwd: workdir,
+			});
+			const init = await runXcsh(["init", "-backend=false", "-input=false", "-no-color"], {
+				timeoutMs: 120_000,
+				bin: "terraform",
+				cwd: workdir,
+			});
+			if (init.code === 0) {
+				const val = await runXcsh(["validate", "-no-color"], { timeoutMs: 60_000, bin: "terraform", cwd: workdir });
+				ok = val.code === 0 && fieldsPresent;
+				detail = `terraform validate=${val.code === 0 ? "ok" : "fail"}, fmt=${fmt.code === 0 ? "ok" : "warn"}, fields=${fieldsPresent}`;
+				if (val.code !== 0) detail += `: ${val.stderr.slice(0, 120)}`;
+			} else {
+				detail = `terraform init failed (provider unavailable?); fell back to keyword presence=${fieldsPresent}`;
+			}
+		}
+		return cell(ok, run, detail);
+	} finally {
+		fs.rmSync(workdir, { recursive: true, force: true });
+	}
+
+	function cell(ok: boolean, run: XcshRun, detail: string): Cell {
+		return {
+			modality: "hcl",
+			id,
+			phrase: p.phrase,
+			operation: p.operation,
+			resource: p.expect_resource ?? "(command)",
+			status: run.timedOut ? "FAIL" : ok ? "PASS" : "FAIL",
+			durationMs: performance.now() - start,
+			detail: run.timedOut ? "timed out" : detail,
+			routedTo: "file",
+		};
+	}
+}
+
+export interface I18nPhrase {
+	id: string;
+	resource_name: string;
+	expected_resource_type: string;
+	expected_fields: string[];
+	phrase_en: string;
+	translations: Record<string, string>;
+}
+
+export async function runI18n(p: I18nPhrase, locale: string, cfg: MatrixConfig): Promise<Cell> {
+	const start = performance.now();
+	const phrase = locale === "en" ? p.phrase_en : p.translations[locale];
+	const id = `${p.id}-${locale}`;
+	if (!phrase) {
+		return {
+			modality: "i18n",
+			id,
+			phrase: `(missing ${locale})`,
+			operation: "create",
+			resource: p.expected_resource_type,
+			locale,
+			status: "SKIP",
+			durationMs: 0,
+			detail: `no ${locale} translation`,
+		};
+	}
+	const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "uat-i18n-"));
+	try {
+		const run = await runXcsh(["--print", "--no-session", phrase], {
+			timeoutMs: 120_000,
+			bin: cfg.xcshBin,
+			cwd: workdir,
+			env: { ...process.env, F5XC_API_URL: cfg.apiUrl },
+		});
+		const hcl = extractHcl(run.stdout, workdir);
+		const ok = hcl.includes(p.expected_resource_type) && p.expected_fields.every(f => hcl.includes(f));
+		return {
+			modality: "i18n",
+			id,
+			phrase,
+			operation: "create",
+			resource: p.expected_resource_type,
+			locale,
+			status: run.timedOut ? "FAIL" : ok ? "PASS" : "FAIL",
+			durationMs: performance.now() - start,
+			detail: run.timedOut ? "timed out" : ok ? "resource+fields present" : "missing resource/fields in HCL",
+			routedTo: "file",
+		};
+	} finally {
+		fs.rmSync(workdir, { recursive: true, force: true });
+	}
+}
+
+export { terraformAvailable };

--- a/packages/coding-agent/scripts/uat-matrix-report.ts
+++ b/packages/coding-agent/scripts/uat-matrix-report.ts
@@ -1,0 +1,175 @@
+/**
+ * UAT matrix — shared cell type + report writer (markdown + JSON).
+ *
+ * The matrix is the deliverable: rows = (modality × resource × operation ×
+ * phrase-id), grouped by modality then resource, with per-modality pass rates
+ * (reusing the autoresearch METRIC vocabulary) and an ASI failures block.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export type Modality = "console" | "json" | "hcl" | "i18n";
+export type CellStatus = "PASS" | "FAIL" | "SKIP";
+
+export interface Cell {
+	modality: Modality;
+	id: string;
+	phrase: string;
+	operation: string;
+	resource: string;
+	locale?: string;
+	status: CellStatus;
+	durationMs: number;
+	detail: string;
+	screenshots?: string[];
+	httpCreate?: string;
+	httpDelete?: string;
+	/** For console cells: which path the agent actually used (router-determinism). */
+	routedTo?: "console" | "api" | "file" | "unknown";
+}
+
+function pct(n: number, d: number): number {
+	return d === 0 ? 0 : Math.round((n / d) * 1000) / 10;
+}
+
+function fmtDur(ms: number): string {
+	return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export function summarize(cells: Cell[]) {
+	const byModality: Record<string, { total: number; pass: number; fail: number; skip: number }> = {};
+	for (const c of cells) {
+		if (!byModality[c.modality]) byModality[c.modality] = { total: 0, pass: 0, fail: 0, skip: 0 };
+		const m = byModality[c.modality]!;
+		m.total++;
+		if (c.status === "PASS") m.pass++;
+		else if (c.status === "FAIL") m.fail++;
+		else m.skip++;
+	}
+	const total = cells.length;
+	const pass = cells.filter(c => c.status === "PASS").length;
+	const fail = cells.filter(c => c.status === "FAIL").length;
+	const skip = cells.filter(c => c.status === "SKIP").length;
+	return { total, pass, fail, skip, byModality };
+}
+
+/** Router-determinism for console cells: fraction that actually used the console. */
+function routerStats(cells: Cell[]) {
+	const console_ = cells.filter(c => c.modality === "console" && c.routedTo);
+	const routed = console_.filter(c => c.routedTo === "console").length;
+	return { measured: console_.length, routedToConsole: routed, rate: pct(routed, console_.length) };
+}
+
+export interface ReportContext {
+	startedAt: string;
+	finishedAt: string;
+	tenant: string;
+	consoleNamespace: string;
+	apiUrl: string;
+	modalities: Modality[];
+	observable: boolean;
+	delayMs: number;
+}
+
+export function writeReport(
+	cells: Cell[],
+	reportDir: string,
+	ctx: ReportContext,
+): { mdPath: string; jsonPath: string } {
+	fs.mkdirSync(reportDir, { recursive: true });
+	const summary = summarize(cells);
+	const router = routerStats(cells);
+
+	// --- JSON ---
+	const jsonPath = path.join(reportDir, "report.json");
+	fs.writeFileSync(jsonPath, JSON.stringify({ ...ctx, summary, router, cells }, null, 2));
+
+	// --- Markdown ---
+	const L: string[] = [];
+	L.push(`# F5 XC Console Agent — UAT Matrix Report`, "");
+	L.push(`- Started: ${ctx.startedAt}`);
+	L.push(`- Finished: ${ctx.finishedAt}`);
+	L.push(`- Tenant: \`${ctx.tenant}\`  |  Console namespace: \`${ctx.consoleNamespace}\`  |  API: \`${ctx.apiUrl}\``);
+	L.push(
+		`- Modalities: ${ctx.modalities.join(", ")}  |  Observable: ${ctx.observable}  |  Step delay: ${ctx.delayMs}ms`,
+	);
+	L.push("");
+	L.push(`## Summary`, "");
+	L.push(`✅ PASS ${summary.pass} · ❌ FAIL ${summary.fail} · ⏭ SKIP ${summary.skip} · total ${summary.total}`, "");
+	L.push(`| Modality | Total | Pass | Fail | Skip | Pass rate |`);
+	L.push(`|---|---:|---:|---:|---:|---:|`);
+	for (const [m, s] of Object.entries(summary.byModality)) {
+		L.push(`| ${m} | ${s.total} | ${s.pass} | ${s.fail} | ${s.skip} | ${pct(s.pass, s.total - s.skip)}% |`);
+	}
+	L.push("");
+
+	// METRIC lines (autoresearch vocabulary, for comparability)
+	L.push("```");
+	for (const [m, s] of Object.entries(summary.byModality)) {
+		L.push(`METRIC ${m}_pass_rate=${pct(s.pass, s.total - s.skip)}`);
+	}
+	if (router.measured > 0) L.push(`METRIC console_router_accuracy=${router.rate}`);
+	L.push("```", "");
+
+	// --- Matrix, grouped by modality then resource ---
+	L.push(`## Matrix`, "");
+	const mods = [...new Set(cells.map(c => c.modality))];
+	for (const mod of mods) {
+		L.push(`### ${mod}`, "");
+		L.push(`| Phrase id | Resource | Op | Status | Duration | HTTP (C/D) | Routed | Detail |`);
+		L.push(`|---|---|---|---|---:|---|---|---|`);
+		const modCells = cells.filter(c => c.modality === mod);
+		for (const c of modCells.sort((a, b) => (a.resource + a.id).localeCompare(b.resource + b.id))) {
+			const icon = c.status === "PASS" ? "✅" : c.status === "FAIL" ? "❌" : "⏭";
+			const http = `${c.httpCreate ?? "-"}/${c.httpDelete ?? "-"}`;
+			const detail = (c.detail || "").replace(/\|/g, "\\|").slice(0, 80);
+			const loc = c.locale ? ` (${c.locale})` : "";
+			L.push(
+				`| ${c.id}${loc} | ${c.resource} | ${c.operation} | ${icon} ${c.status} | ${fmtDur(c.durationMs)} | ${http} | ${c.routedTo ?? "-"} | ${detail} |`,
+			);
+		}
+		L.push("");
+	}
+
+	// --- Router determinism ---
+	if (router.measured > 0) {
+		L.push(`## Router determinism (console phrases)`, "");
+		L.push(`${router.routedToConsole}/${router.measured} console phrases drove the console UI (${router.rate}%).`);
+		const leaks = cells.filter(c => c.modality === "console" && c.routedTo === "api");
+		if (leaks.length) {
+			L.push("", "Phrases that leaked to the API instead of the console:");
+			for (const c of leaks) L.push(`- \`${c.id}\`: ${c.phrase}`);
+		}
+		L.push("");
+	}
+
+	// --- ASI failures (autoresearch-style) ---
+	const failures = cells.filter(c => c.status === "FAIL");
+	L.push(`## Failures`, "");
+	if (failures.length === 0) {
+		L.push("None. 🎉", "");
+	} else {
+		for (const c of failures) {
+			L.push(`- **${c.id}** (${c.modality}/${c.operation}/${c.resource}): ${c.detail}`);
+			if (c.screenshots?.length) L.push(`  - screenshots: ${c.screenshots.map(s => `\`${s}\``).join(", ")}`);
+		}
+		L.push("");
+		const asi = failures.map(c => ({
+			id: c.id,
+			modality: c.modality,
+			operation: c.operation,
+			resource: c.resource,
+			http_create: c.httpCreate,
+			http_delete: c.httpDelete,
+			routed_to: c.routedTo,
+			detail: c.detail.slice(0, 160),
+		}));
+		L.push("```");
+		L.push(`ASI failures=${JSON.stringify(asi)}`);
+		L.push("```", "");
+	}
+
+	const mdPath = path.join(reportDir, "report.md");
+	fs.writeFileSync(mdPath, L.join("\n"));
+	return { mdPath, jsonPath };
+}

--- a/packages/coding-agent/scripts/uat-matrix.ts
+++ b/packages/coding-agent/scripts/uat-matrix.ts
@@ -1,0 +1,349 @@
+#!/usr/bin/env bun
+/**
+ * F5 XC Console Agent — comprehensive UAT MATRIX.
+ *
+ * Feeds natural-language prompts to `xcsh --print` and verifies outcomes across
+ * four modalities. The console modality runs OBSERVABLY in the human's Chrome
+ * (F5-red indicator + per-step delay) and is verified by API GET; json/hcl/i18n
+ * run headless. Reuses the autoresearch corpora; additive (no autoresearch
+ * framework edits).
+ *
+ *   bun scripts/uat-matrix.ts [--modalities console,json,hcl,i18n]
+ *        [--observable|--no-observable] [--delay-ms 1500] [--limit N]
+ *        [--filter <regex over phrase ids>] [--no-cleanup] [--cleanup-only]
+ *        [--dry-run] [--self-test-api] [--strict-nl] [--report-dir <dir>]
+ *
+ * Env: F5XC_API_URL, F5XC_API_TOKEN, KC_USER, KC_PASS, CONSOLE_NAMESPACE=demo,
+ *      XCSH_BIN=xcsh
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { parse as parseYaml } from "yaml";
+import { type BridgeServer, startBridgeServer } from "../src/browser/extension-bridge";
+import {
+	apiDelete,
+	apiGet,
+	type ConsolePhrase,
+	type CrudPhrase,
+	type I18nPhrase,
+	type MatrixConfig,
+	runConsole,
+	runHcl,
+	runI18n,
+	runJson,
+	type TfPhrase,
+	terraformAvailable,
+} from "./uat-matrix-modalities";
+import { type Cell, type Modality, type ReportContext, summarize, writeReport } from "./uat-matrix-report";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
+const LOCALES = ["en", "ja", "ko", "zh-cn", "fr", "de", "es", "pt-br", "it", "ar", "hi", "th"];
+// Cleanup order: parents before children so dependants release.
+const DEMO_CLEANUP_PATHS = [
+	"http_loadbalancers",
+	"tcp_loadbalancers",
+	"app_firewalls",
+	"service_policys",
+	"origin_pools",
+	"healthchecks",
+];
+const AR_CLEANUP_PATHS = [
+	"http_loadbalancers",
+	"tcp_loadbalancers",
+	"app_firewalls",
+	"service_policys",
+	"origin_pools",
+	"healthchecks",
+	"api_definitions",
+	"api_discoverys",
+	"policers",
+	"rate_limiters",
+	"waf_exclusion_policys",
+	"user_identifications",
+	"malicious_user_mitigations",
+	"sensitive_data_policys",
+	"protocol_inspections",
+	"network_policys",
+	"virtual_sites",
+	"forward_proxy_policys",
+	"global_log_receivers",
+	"alert_receivers",
+	"enhanced_firewall_policys",
+];
+
+interface Args {
+	modalities: Set<Modality>;
+	observable: boolean;
+	delayMs: number;
+	limit?: number;
+	filter?: RegExp;
+	noCleanup: boolean;
+	cleanupOnly: boolean;
+	dryRun: boolean;
+	selfTestApi: boolean;
+	strictNl: boolean;
+	reportDir: string;
+}
+
+function parseArgs(): Args {
+	const a = process.argv.slice(2);
+	const get = (flag: string) => {
+		const i = a.indexOf(flag);
+		return i >= 0 ? a[i + 1] : undefined;
+	};
+	const has = (flag: string) => a.includes(flag);
+	const ts = new Date().toISOString().replace(/[:.]/g, "-");
+	return {
+		modalities: new Set((get("--modalities")?.split(",") ?? ["console", "json", "hcl", "i18n"]) as Modality[]),
+		observable: !has("--no-observable"),
+		delayMs: Number(get("--delay-ms") ?? 1500),
+		limit: get("--limit") ? Number(get("--limit")) : undefined,
+		filter: get("--filter") ? new RegExp(get("--filter")!) : undefined,
+		noCleanup: has("--no-cleanup"),
+		cleanupOnly: has("--cleanup-only"),
+		dryRun: has("--dry-run"),
+		selfTestApi: has("--self-test-api"),
+		strictNl: has("--strict-nl"),
+		reportDir: get("--report-dir") ?? path.join(REPO_ROOT, "uat-matrix", "reports", ts),
+	};
+}
+
+function loadYaml<T>(rel: string): T {
+	return parseYaml(fs.readFileSync(path.join(REPO_ROOT, rel), "utf8")) as T;
+}
+
+function applyLimitFilter<T>(items: T[], args: Args, idOf: (t: T) => string): T[] {
+	let out = items;
+	if (args.filter) out = out.filter(t => args.filter!.test(idOf(t)));
+	if (args.limit) out = out.slice(0, args.limit);
+	return out;
+}
+
+function cfgFromEnv(args: Args): MatrixConfig {
+	return {
+		xcshBin: process.env.XCSH_BIN ?? "xcsh",
+		apiUrl: process.env.F5XC_API_URL ?? "https://nferreira.staging.volterra.us",
+		apiToken: process.env.F5XC_API_TOKEN ?? "",
+		consoleNamespace: process.env.CONSOLE_NAMESPACE ?? "demo",
+		tenant: (process.env.F5XC_API_URL ?? "https://nferreira.staging.volterra.us")
+			.replace(/^https?:\/\//, "")
+			.split(".")[0]!,
+		observable: args.observable,
+		delayMs: args.delayMs,
+		reportDir: args.reportDir,
+		strictNl: args.strictNl,
+		cellTimeoutMs: 240_000,
+	};
+}
+
+async function ensureExtensionConnectedAndLogin(cfg: MatrixConfig): Promise<void> {
+	console.log("[console] starting bridge probe (extension must be loaded + xcsh chrome setup done)...");
+	const server: BridgeServer = await startBridgeServer();
+	try {
+		const deadline = Date.now() + 60_000;
+		while (Date.now() < deadline && !server.connected) {
+			await new Promise(r => setTimeout(r, 2000));
+			process.stdout.write(".");
+		}
+		console.log("");
+		if (!server.connected) {
+			throw new Error(
+				"Extension did not connect within 60s — load dist/ in Chrome and run `xcsh chrome setup`. Refusing to fall back to CDP for a watch-live run.",
+			);
+		}
+		console.log("[console] extension connected ✅");
+		const KC_USER = process.env.KC_USER;
+		const KC_PASS = process.env.KC_PASS;
+		if (KC_USER && KC_PASS) {
+			const route = `${cfg.apiUrl}/web/workspaces/web-app-and-api-protection/namespaces/${cfg.consoleNamespace}/manage/load_balancers/http_loadbalancers`;
+			console.log("[console] establishing session via login tool...");
+			const r = await server.request("login", { email: KC_USER, password: KC_PASS, consoleUrl: route }, 160_000);
+			if (r.is_error || !(r.content as any)?.loggedIn)
+				throw new Error(`login failed: ${JSON.stringify(r.content).slice(0, 160)}`);
+			console.log("[console] logged in ✅ (session persists across xcsh runs)");
+		} else {
+			console.log("[console] no KC_USER/KC_PASS — relying on an existing Chrome session");
+		}
+	} finally {
+		// Release the socket so each `xcsh --print` can own it (the extension reconnects via its alarm).
+		await server.close();
+	}
+}
+
+async function listNames(ns: string, apiPath: string, prefix: string, cfg: MatrixConfig): Promise<string[]> {
+	try {
+		const r = await fetch(`${cfg.apiUrl}/api/config/namespaces/${ns}/${apiPath}`, {
+			headers: { Authorization: `APIToken ${cfg.apiToken}` },
+		});
+		if (!r.ok) return [];
+		const d: any = await r.json();
+		const items: any[] = d.items ?? d.objects ?? [];
+		return items.map(i => i.name ?? i.metadata?.name ?? "").filter((n: string) => n.startsWith(prefix));
+	} catch {
+		return [];
+	}
+}
+
+async function cleanup(cfg: MatrixConfig): Promise<void> {
+	console.log("\n[cleanup] deleting uat-* (demo) and ar-test-* (r-mordasiewicz) resources, parents first...");
+	for (const ap of DEMO_CLEANUP_PATHS) {
+		for (const name of await listNames(cfg.consoleNamespace, ap, "uat-", cfg)) {
+			const code = await apiDelete(`/api/config/namespaces/${cfg.consoleNamespace}/${ap}/${name}`, cfg);
+			console.log(`  demo/${ap}/${name} → ${code}`);
+		}
+	}
+	for (const ap of AR_CLEANUP_PATHS) {
+		for (const name of await listNames("r-mordasiewicz", ap, "ar-test-", cfg)) {
+			await apiDelete(`/api/config/namespaces/r-mordasiewicz/${ap}/${name}`, cfg);
+		}
+	}
+	console.log("[cleanup] done");
+}
+
+async function main() {
+	const args = parseArgs();
+	const cfg = cfgFromEnv(args);
+	const cells: Cell[] = [];
+	const startedAt = new Date().toISOString();
+
+	if (args.cleanupOnly) {
+		if (!cfg.apiToken) throw new Error("F5XC_API_TOKEN required for cleanup");
+		await cleanup(cfg);
+		return;
+	}
+
+	// --- Dry run: parse corpora, print the planned matrix, validate triggers ---
+	if (args.dryRun) {
+		const consolePhrases = loadYaml<{ phrases: ConsolePhrase[] }>("uat-matrix/console-phrases.yaml").phrases ?? [];
+		const triggerRe =
+			/(in|open|using|through) the (f5 xc )?(web )?console|using chrome|in the f5 xc ui|walk me through|show me in/i;
+		let bad = 0;
+		console.log(`\n[dry-run] ${consolePhrases.length} console phrases:`);
+		for (const p of consolePhrases) {
+			const hasTrigger = triggerRe.test(p.phrase);
+			const knownCleanup = (p.cleanup ?? []).every(c => /^[a-z_]+\/[a-z0-9-]+$/.test(c));
+			if (!hasTrigger || !knownCleanup) bad++;
+			console.log(
+				`  ${hasTrigger ? "✅" : "⚠️ NO-TRIGGER"} ${p.id} [${p.operation}/${p.console_resource}] nested=${(p.nested ?? []).length}`,
+			);
+		}
+		console.log(
+			`\n[dry-run] json=${loadYaml<{ phrases: CrudPhrase[] }>("autoresearch-crud-phrases.yaml").phrases.length} hcl=${loadYaml<{ phrases: TfPhrase[] }>("terraform-phrases.yaml").phrases.length} i18n=${loadYaml<{ phrases: I18nPhrase[] }>("autoresearch-i18n-phrases.yaml").phrases.length}×${LOCALES.length}`,
+		);
+		console.log(
+			bad === 0
+				? "[dry-run] all console phrases have a router trigger + valid cleanup ✅"
+				: `[dry-run] ${bad} console phrases need attention ⚠️`,
+		);
+		process.exit(bad === 0 ? 0 : 1);
+	}
+
+	// --- API self-test ---
+	if (args.selfTestApi) {
+		if (!cfg.apiToken) throw new Error("F5XC_API_TOKEN required");
+		const present = await apiGet(`/api/config/namespaces/${cfg.consoleNamespace}/healthchecks`, cfg);
+		const absent = await apiGet(
+			`/api/config/namespaces/${cfg.consoleNamespace}/healthchecks/uat-definitely-absent-xyz`,
+			cfg,
+		);
+		console.log(`[self-test] list healthchecks → ${present} (expect 200); absent resource → ${absent} (expect 404)`);
+		process.exit(present === "200" && absent === "404" ? 0 : 1);
+	}
+
+	if (!cfg.apiToken) throw new Error("F5XC_API_TOKEN required for verification");
+
+	// --- Console FIRST (human watching) ---
+	if (args.modalities.has("console")) {
+		await ensureExtensionConnectedAndLogin(cfg);
+		const phrases = applyLimitFilter(
+			loadYaml<{ phrases: ConsolePhrase[] }>("uat-matrix/console-phrases.yaml").phrases,
+			args,
+			p => p.id,
+		);
+		console.log(`\n[console] running ${phrases.length} phrases observably (watch Chrome)...`);
+		for (const p of phrases) {
+			console.log(`\n  ▶ ${p.id}: ${p.phrase.slice(0, 80)}...`);
+			const c = await runConsole(p, cfg);
+			cells.push(c);
+			console.log(`    ${c.status === "PASS" ? "✅" : "❌"} ${c.status}: ${c.detail}`);
+		}
+	}
+
+	// --- JSON ---
+	if (args.modalities.has("json")) {
+		const phrases = applyLimitFilter(
+			loadYaml<{ phrases: CrudPhrase[] }>("autoresearch-crud-phrases.yaml").phrases,
+			args,
+			p => `J-${p.resource}-${p.operation}`,
+		);
+		console.log(`\n[json] running ${phrases.length} phrases...`);
+		for (const p of phrases) {
+			const c = await runJson(p, cfg);
+			cells.push(c);
+			console.log(`  ${c.status === "PASS" ? "✅" : c.status === "SKIP" ? "⏭" : "❌"} ${c.id}: ${c.detail}`);
+		}
+	}
+
+	// --- HCL ---
+	if (args.modalities.has("hcl")) {
+		const tfOk = await terraformAvailable();
+		const phrases = applyLimitFilter(
+			loadYaml<{ phrases: TfPhrase[] }>("terraform-phrases.yaml").phrases,
+			args,
+			p => `H-${p.expect_resource ?? p.operation}-${p.operation}`,
+		);
+		console.log(
+			`\n[hcl] running ${phrases.length} phrases (terraform ${tfOk ? "available" : "NOT found — keyword presence only"})...`,
+		);
+		for (const p of phrases) {
+			const c = await runHcl(p, cfg, tfOk);
+			cells.push(c);
+			console.log(`  ${c.status === "PASS" ? "✅" : "❌"} ${c.id}: ${c.detail}`);
+		}
+	}
+
+	// --- i18n ---
+	if (args.modalities.has("i18n")) {
+		const phrases = applyLimitFilter(
+			loadYaml<{ phrases: I18nPhrase[] }>("autoresearch-i18n-phrases.yaml").phrases,
+			args,
+			p => p.id,
+		);
+		console.log(`\n[i18n] running ${phrases.length} phrases × ${LOCALES.length} locales...`);
+		for (const p of phrases) {
+			for (const loc of LOCALES) {
+				const c = await runI18n(p, loc, cfg);
+				cells.push(c);
+				console.log(
+					`  ${c.status === "PASS" ? "✅" : c.status === "SKIP" ? "⏭" : "❌"} ${c.id}-${loc}: ${c.detail}`,
+				);
+			}
+		}
+	}
+
+	if (!args.noCleanup) await cleanup(cfg);
+
+	const ctx: ReportContext = {
+		startedAt,
+		finishedAt: new Date().toISOString(),
+		tenant: cfg.tenant,
+		consoleNamespace: cfg.consoleNamespace,
+		apiUrl: cfg.apiUrl,
+		modalities: [...args.modalities],
+		observable: args.observable,
+		delayMs: args.delayMs,
+	};
+	const { mdPath, jsonPath } = writeReport(cells, args.reportDir, ctx);
+	const s = summarize(cells);
+	console.log(`\n${"=".repeat(60)}`);
+	console.log(`UAT MATRIX: ✅ ${s.pass}  ❌ ${s.fail}  ⏭ ${s.skip}  (total ${s.total})`);
+	console.log(`Report: ${mdPath}`);
+	console.log(`JSON:   ${jsonPath}`);
+	console.log("=".repeat(60));
+	process.exit(s.fail > 0 ? 1 : 0);
+}
+
+main().catch(e => {
+	console.error("FATAL:", e instanceof Error ? e.message : e);
+	process.exit(1);
+});

--- a/packages/coding-agent/src/browser/extension-page-actions.ts
+++ b/packages/coding-agent/src/browser/extension-page-actions.ts
@@ -1,21 +1,141 @@
 /**
  * Extension-backed {@link PageActions} implementation.
  *
- * Wraps an {@link ExtensionPage} (the Chrome extension bridge surface) so the
- * catalogue-workflow runner can drive the extension through the exact same
- * `PageActions` interface it uses for CDP. For tools that operate on a `ref`
- * handle (`click`/`fill`/`selectOption`/`scrollIntoView`), resolution happens
- * xcsh-side: read the AX tree, {@link resolveRef} the selector to a `ref`, then
- * call the bridge tool. `assertText`/`waitFor` resolve selectors on the bridge
- * (service-worker) side, so they pass through directly.
+ * Resolves catalogue workflow selectors **without a full `read_ax`** — instead
+ * of serializing the entire AX tree (which FREEZES the MV3 service worker on
+ * heavy create forms), each interaction asks the in-page DOM for the ONE
+ * element that matches the selector, scrolls it into view, and returns its
+ * viewport-center coords. Then `click_xy` / `type_text` dispatch a trusted CDP
+ * action — trusted events fire inside Angular's NgZone, so vsui dropdowns,
+ * form submit, and the console's reactive forms all work.
+ *
+ * **Selector grammar** (matches the catalogue YAML + the AX resolver):
+ *   - `text('X')`             — element whose textContent includes X.
+ *   - `role:text('X')`        — element of `role` (tag-derived) with text X.
+ *   - `role[name='X']`        — input/control whose label/name/aria matches X.
+ *   - bare `role`             — first element of that role.
+ *   - anything else           — CSS querySelector.
+ *
+ * This approach was validated by the manual full-UI CRUD smoke (login → create
+ * health-check via form → delete via kebab → verify) which used javascript_tool
+ * + click_xy/type_text to bypass the read_ax freeze.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { type ExtensionPage, resolveRef } from "./extension-provider";
+import type { ExtensionPage } from "./extension-provider";
 import type { PageActions } from "./page-actions";
 
 const ALLOWED_SCHEMES = new Set(["https:"]);
 const CONSOLE_DOMAIN_RE = /\.(volterra\.us|console\.ves\.volterra\.io)$/;
+
+/**
+ * A self-contained in-page resolver: given a catalogue selector string, finds
+ * the matching element, scrolls it into view, and returns its viewport-center
+ * coords. Runs entirely via `javascript_tool` — one small returnByValue, no
+ * full AX serialization.
+ */
+function buildResolverScript(selector: string): string {
+	// Escape for JSON-safe embedding. The script returns JSON {x,y,found,tag,txt} or {found:false,error}.
+	const sel = JSON.stringify(selector);
+	return `(()=>{
+const sel=${sel};
+function roleToSelector(role){
+  switch(role){
+    case'button':return'button,input[type=button],input[type=submit],[role=button]';
+    case'link':return'a[href],[role=link]';
+    case'tab':return'[role=tab]';
+    case'textbox':return'input:not([type=checkbox]):not([type=radio]):not([type=submit]):not([type=button]),textarea,[role=textbox]';
+    case'spinbutton':return'input[type=number],[role=spinbutton]';
+    case'checkbox':return'input[type=checkbox],[role=checkbox]';
+    case'radio':return'input[type=radio],[role=radio]';
+    case'combobox':return'select,[role=combobox]';
+    case'listbox':return'[role=listbox],select';
+    case'option':return'[role=option],option';
+    case'heading':return'h1,h2,h3,h4,h5,h6,[role=heading]';
+    case'menuitem':return'[role=menuitem]';
+    case'dialog':return'dialog,[role=dialog],[role=alertdialog]';
+    case'navigation':return'nav,[role=navigation]';
+    case'table':return'table,[role=table]';
+    case'row':return'tr,[role=row],datatable-body-row';
+    case'cell':return'td,th,[role=cell],[role=gridcell],[role=columnheader]';
+    case'img':return'img,[role=img]';
+    case'switch':return'[role=switch]';
+    default:return'[role='+role+']';
+  }
+}
+function findByText(text,roleSel){
+  const candidates=roleSel?[...document.querySelectorAll(roleSel)]:[...document.querySelectorAll('*')];
+  const norm=t=>t.replace(/\\s+/g,' ').trim();
+  const want=norm(text);
+  return candidates.find(e=>{const n=norm(e.textContent||'');return n===want||n.includes(want);});
+}
+function findByRoleName(role,name){
+  const roleSel=roleToSelector(role);
+  const candidates=[...document.querySelectorAll(roleSel)];
+  const norm=t=>t.replace(/\\s+/g,' ').trim();
+  const want=norm(name);
+  return candidates.find(e=>{
+    const n=norm(e.getAttribute('aria-label')||e.getAttribute('name')||e.getAttribute('placeholder')||e.textContent||'');
+    return n===want||n.includes(want);
+  })||(role==='textbox'?candidates.find(e=>{
+    const lbl=(e.closest('[class*=form-group],[class*=field],.row')||{}).textContent||'';
+    return norm(lbl).includes(want);
+  }):null);
+}
+let el=null;
+const textM=sel.match(/^text\\('([^']*)'\\)$/);
+const roleTextM=sel.match(/^([a-z]+):text\\('([^']*)'\\)$/);
+const roleNameM=sel.match(/^([a-z]+)\\[name='([^']*)'\\]$/);
+const bareRoleM=sel.match(/^[a-z]+$/);
+if(textM){el=findByText(textM[1]);}
+else if(roleTextM){el=findByText(roleTextM[2],roleToSelector(roleTextM[1]));}
+else if(roleNameM){el=findByRoleName(roleNameM[1],roleNameM[2]);}
+else if(bareRoleM){el=document.querySelector(roleToSelector(sel));}
+else{el=document.querySelector(sel);}
+if(!el)return JSON.stringify({found:false,error:'no match for '+sel});
+el.scrollIntoView({block:'center',inline:'center'});
+const r=el.getBoundingClientRect();
+return JSON.stringify({found:true,x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2),tag:el.tagName,txt:(el.textContent||'').trim().slice(0,30)});
+})()`;
+}
+
+/** Resolve a selector to viewport-center coords via `javascript_tool`. */
+async function resolveCoords(ext: ExtensionPage, selector: string): Promise<{ x: number; y: number }> {
+	const raw = await ext.javascriptTool(buildResolverScript(selector));
+	const result = typeof raw === "string" ? JSON.parse(raw) : raw;
+	if (!result?.found) {
+		throw new Error(`selector "${selector}" not found in the page: ${result?.error ?? "no match"}`);
+	}
+	return { x: result.x as number, y: result.y as number };
+}
+
+/**
+ * Fill a field located by selector: find it → focus → set value via the
+ * framework-safe native-setter technique → dispatch events to commit to
+ * Angular's form model. Runs entirely via `javascript_tool`, never serializing
+ * the whole AX tree. The selector-matching logic is inlined (same grammar as
+ * buildResolverScript) so the fill runs as a single, self-contained eval.
+ */
+function buildFillScript(selector: string, value: string): string {
+	const sel = JSON.stringify(selector);
+	const val = JSON.stringify(value);
+	return `(()=>{
+const sel=${sel};
+function roleToSel(r){const m={button:'button,input[type=button],input[type=submit],[role=button]',link:'a[href],[role=link]',tab:'[role=tab]',textbox:'input:not([type=checkbox]):not([type=radio]):not([type=submit]):not([type=button]),textarea,[role=textbox]',spinbutton:'input[type=number],[role=spinbutton]',checkbox:'input[type=checkbox],[role=checkbox]',combobox:'select,[role=combobox]',listbox:'[role=listbox],select',option:'[role=option],option',heading:'h1,h2,h3,h4,h5,h6,[role=heading]'};return m[r]||'[role='+r+']';}
+function norm(t){return t.replace(/\\s+/g,' ').trim();}
+function findText(text,rSel){return(rSel?[...document.querySelectorAll(rSel)]:[...document.querySelectorAll('*')]).find(e=>{const n=norm(e.textContent||'');return n===norm(text)||n.includes(norm(text));});}
+function findRoleName(role,name){const cs=[...document.querySelectorAll(roleToSel(role))];const w=norm(name);return cs.find(e=>norm(e.getAttribute('aria-label')||e.getAttribute('name')||e.getAttribute('placeholder')||e.textContent||'').includes(w))||(role==='textbox'?cs.find(e=>norm((e.closest('[class*=form-group],[class*=field],.row')||{}).textContent||'').includes(w)):null);}
+let el=null;
+const tm=sel.match(/^text\\('([^']*)'\\)$/),rtm=sel.match(/^([a-z]+):text\\('([^']*)'\\)$/),rnm=sel.match(/^([a-z]+)\\[name='([^']*)'\\]$/),br=sel.match(/^[a-z]+$/);
+if(tm)el=findText(tm[1]);else if(rtm)el=findText(rtm[2],roleToSel(rtm[1]));else if(rnm)el=findRoleName(rnm[1],rnm[2]);else if(br)el=document.querySelector(roleToSel(sel));else el=document.querySelector(sel);
+if(!el)return JSON.stringify({filled:false,error:'selector not found: '+sel});
+el.scrollIntoView({block:'center',inline:'center'});el.focus();
+let p=Object.getPrototypeOf(el),d;while(p){d=Object.getOwnPropertyDescriptor(p,'value');if(d&&d.set)break;p=Object.getPrototypeOf(p);}
+const v=${val};d&&d.set?d.set.call(el,v):el.value=v;
+for(const ev of['input','change','blur','focusout'])el.dispatchEvent(new Event(ev,{bubbles:true}));
+return JSON.stringify({filled:true,val:el.value});
+})()`;
+}
 
 export class ExtensionPageActions implements PageActions {
 	#ext: ExtensionPage;
@@ -25,9 +145,7 @@ export class ExtensionPageActions implements PageActions {
 	}
 
 	async goto(url: string): Promise<void> {
-		// Defense-in-depth: validate URL scheme + console-domain scope before sending to the extension.
-		// The extension SW also validates, but rejecting early is cleaner + prevents SSRF.
-		const parsed = new URL(url); // throws on malformed
+		const parsed = new URL(url);
 		if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
 			throw new Error(`Disallowed URL scheme: ${parsed.protocol} (only https: is allowed)`);
 		}
@@ -38,27 +156,32 @@ export class ExtensionPageActions implements PageActions {
 	}
 
 	async click(selector: string, _context?: string): Promise<void> {
-		const tree = await this.#ext.readAx();
-		const ref = resolveRef(tree, selector);
-		await this.#ext.click(ref);
+		const { x, y } = await resolveCoords(this.#ext, selector);
+		await this.#ext.clickXy(x, y);
 	}
 
 	async fill(selector: string, value: string, _context?: string): Promise<void> {
-		const tree = await this.#ext.readAx();
-		const ref = resolveRef(tree, selector);
-		await this.#ext.formInput(ref, value);
+		const raw = await this.#ext.javascriptTool(buildFillScript(selector, value));
+		const result = typeof raw === "string" ? JSON.parse(raw) : raw;
+		if (!result?.filled) {
+			throw new Error(`fill("${selector}"): ${result?.error ?? "could not set value"}`);
+		}
 	}
 
 	async selectOption(selector: string, value: string, _context?: string): Promise<void> {
-		const tree = await this.#ext.readAx();
-		const ref = resolveRef(tree, selector);
-		await this.#ext.selectOption(ref, value);
+		// Open the dropdown / listbox via a trusted click.
+		const { x, y } = await resolveCoords(this.#ext, selector);
+		await this.#ext.clickXy(x, y);
+		// Wait briefly for the dropdown to render.
+		await new Promise(r => setTimeout(r, 1200));
+		// Click the option whose text matches value.
+		const optCoords = await resolveCoords(this.#ext, `option:text('${value}')`);
+		await this.#ext.clickXy(optCoords.x, optCoords.y);
 	}
 
 	async scrollIntoView(selector: string, _context?: string): Promise<void> {
-		const tree = await this.#ext.readAx();
-		const ref = resolveRef(tree, selector);
-		await this.#ext.scrollTo(ref);
+		// resolveCoords already does scrollIntoView.
+		await resolveCoords(this.#ext, selector);
 	}
 
 	async pressKey(key: string): Promise<void> {
@@ -74,8 +197,6 @@ export class ExtensionPageActions implements PageActions {
 	}
 
 	async screenshot(file: string): Promise<void> {
-		// Defense-in-depth: resolve symlinks via realpathSync so a symlinked parent
-		// can't bypass the cwd containment check and write outside the working directory.
 		const cwdReal = fs.realpathSync(process.cwd());
 		const lexical = path.resolve(file);
 		let parentReal: string;

--- a/packages/coding-agent/src/browser/extension-provider.ts
+++ b/packages/coding-agent/src/browser/extension-provider.ts
@@ -49,6 +49,10 @@ export interface ExtensionPage {
 	browserBatch(
 		actions: Array<{ tool: string; params: unknown }>,
 	): Promise<Array<{ tool: string; content: unknown; is_error: boolean }>>;
+	/** Trusted CDP click at viewport coordinates (no ref / read_ax needed). */
+	clickXy(x: number, y: number): Promise<void>;
+	/** CDP Input.insertText into the focused element (genuine trusted input events). */
+	typeText(text: string): Promise<void>;
 }
 
 /** Unwrap a {@link ToolResult}, throwing on the error flag. */
@@ -191,6 +195,14 @@ class BridgeExtensionPage implements ExtensionPage {
 			content: unknown;
 			is_error: boolean;
 		}>;
+	}
+
+	async clickXy(x: number, y: number): Promise<void> {
+		unwrap(await this.#server.request("click_xy", { x, y }), "click_xy");
+	}
+
+	async typeText(text: string): Promise<void> {
+		unwrap(await this.#server.request("type_text", { text }), "type_text");
 	}
 }
 

--- a/uat-matrix/README.md
+++ b/uat-matrix/README.md
@@ -1,0 +1,74 @@
+# Console-UI UAT Matrix
+
+A comprehensive, **human-watchable** UAT matrix that feeds natural-language prompts to
+`xcsh --print` and verifies outcomes across four modalities:
+
+| Modality | Input corpus | What it tests | Verify |
+|---|---|---|---|
+| **console** | `uat-matrix/console-phrases.yaml` (new, deep-nested) | NL → live console UI via `catalog_workflow_runner` (observable, watched in Chrome) | runner step-table + API GET |
+| **json** | `autoresearch-crud-phrases.yaml` (reused) | NL → API CRUD | API GET (200/404) |
+| **hcl** | `terraform-phrases.yaml` (reused) | NL → Terraform HCL | `terraform validate` (or keyword presence) |
+| **i18n** | `autoresearch-i18n-phrases.yaml` (reused) | same configs in 12 languages → HCL | keyword presence |
+
+The console modality drives your **real Chrome** (F5-red indicator + per-step delay) so you
+can watch every create/read/delete, including deep-nested object creation
+(origin-pool → app-firewall → http-load-balancer with cross-references, and the full
+`waap-full-stack`). All console resources use the `uat-` prefix.
+
+This is **additive** — it does not modify the `autoresearch/` framework or the console catalogue.
+
+## Prerequisites
+
+- **Console modality**: build + load the extension (`chrome://extensions` → Load unpacked → `xcsh-chrome-extension/dist/`), run `xcsh chrome setup`, and have Chrome open. The harness logs in automatically with `KC_USER`/`KC_PASS`; the session then persists across `xcsh` runs.
+- **HCL modality** (optional authoritative check): `terraform` on `PATH`. Without it, HCL falls back to keyword-presence.
+- `xcsh` on `PATH` (or set `XCSH_BIN`).
+
+## Environment
+
+```bash
+export F5XC_API_URL="https://nferreira.staging.volterra.us"
+export F5XC_API_TOKEN="…"     # API GET verification + cleanup
+export KC_USER="…"            # console login
+export KC_PASS="…"
+export CONSOLE_NAMESPACE="demo"
+```
+
+## Run
+
+```bash
+cd packages/coding-agent
+
+# 0) Verify the harness itself FIRST (no side effects):
+bun scripts/uat-matrix.ts --dry-run                       # corpus parse + router-trigger check
+bun scripts/uat-matrix.ts --self-test-api                 # API token + GET plumbing
+
+# 1) Watched single smoke (you watch Chrome):
+bun scripts/uat-matrix.ts --modalities console --filter '^C-HC-01$' --observable
+bun scripts/uat-matrix.ts --modalities console --filter '^C-HC-02$' --observable
+
+# 2) One of each headless modality:
+bun scripts/uat-matrix.ts --modalities json,hcl,i18n --limit 1
+
+# Full console run, observable (watch the whole thing):
+bun scripts/uat-matrix.ts --modalities console --observable
+
+# Everything (console first/observable, then json,hcl,i18n):
+bun scripts/uat-matrix.ts
+
+# Cleanup only (delete leftover uat-* / ar-test-* resources):
+bun scripts/uat-matrix.ts --cleanup-only
+```
+
+Flags: `--modalities`, `--observable/--no-observable`, `--delay-ms`, `--limit`, `--filter <regex over ids>`,
+`--no-cleanup`, `--cleanup-only`, `--dry-run`, `--self-test-api`, `--strict-nl` (drop the console guardrail to
+measure raw router accuracy), `--report-dir`.
+
+## Output
+
+`uat-matrix/reports/<timestamp>/`:
+- `report.md` — the matrix (modality × resource × operation × phrase-id → status, duration, HTTP, routed, detail), per-modality pass-rate `METRIC` lines, a router-determinism section, and an `ASI failures` block.
+- `report.json` — machine-readable cells + summary.
+- `screenshots/<phrase-id>/step-*.png` — per-step console screenshots.
+
+Cleanup runs automatically on exit (unless `--no-cleanup`), deleting `uat-*` (in `demo`) and
+`ar-test-*` (in `r-mordasiewicz`) resources, parents before children.

--- a/uat-matrix/console-phrases.yaml
+++ b/uat-matrix/console-phrases.yaml
@@ -1,0 +1,294 @@
+# Console-UI UAT corpus — natural-language prompts that drive the LIVE F5 XC
+# console (via the catalog_workflow_runner browser path), with deep nested
+# object creation. Each `phrase` carries a console trigger ("in the F5 XC web
+# console" / "using chrome" / "walk me through ... in the console" / "show me in
+# the UI") so the agent routes to the browser path, NOT the API (see
+# system-prompt.md:342-349). Resources use the `uat-` prefix so cleanup never
+# collides with the autoresearch `ar-test-` suite.
+#
+# Schema (superset of the autoresearch phrase schema):
+#   id                : stable matrix id
+#   phrase            : natural-language input fed verbatim to `xcsh --print`
+#   modality          : always "console" here
+#   operation         : create | delete
+#   console_resource  : hyphenated catalogue id (health-check, origin-pool, ...)
+#   verify:
+#     api_path        : underscore/plural API path for the GET check
+#     resource_name   : object name to GET
+#     namespace       : API namespace (demo)
+#     expect_http_create / expect_http_delete : 200 / 404
+#     ui_readback     : text the workflow asserts in the list (UI confirmation)
+#   nested            : ordered child resources (created BEFORE the parent); each
+#                       {console_resource, api_path, resource_name} also GET-verified
+#   cleanup           : api_path/name pairs to force-delete on teardown
+#                       (parents first so dependants release)
+defaults:
+  namespace: demo
+  tenant: nferreira.staging.volterra.us
+
+phrases:
+  # ===========================================================================
+  # A. Single-resource CRUD (create + delete) — health-check, app-firewall,
+  #    service-policy, origin-pool
+  # ===========================================================================
+  - id: C-HC-01
+    phrase: "In the F5 XC web console, create a health check named uat-hc-1 that probes /healthz over HTTP every 15 seconds."
+    modality: console
+    operation: create
+    console_resource: health-check
+    verify: { api_path: healthchecks, resource_name: uat-hc-1, namespace: demo, expect_http_create: 200, ui_readback: "uat-hc-1" }
+    nested: []
+    cleanup: ["healthchecks/uat-hc-1"]
+
+  - id: C-HC-02
+    phrase: "Open the F5 XC console and delete the health check named uat-hc-1."
+    modality: console
+    operation: delete
+    console_resource: health-check
+    verify: { api_path: healthchecks, resource_name: uat-hc-1, namespace: demo, expect_http_delete: 404, ui_readback: "uat-hc-1" }
+    nested: []
+    cleanup: ["healthchecks/uat-hc-1"]
+
+  - id: C-WAF-01
+    phrase: "Using chrome, create an app firewall named uat-waf-1 in blocking mode in namespace demo."
+    modality: console
+    operation: create
+    console_resource: app-firewall
+    verify: { api_path: app_firewalls, resource_name: uat-waf-1, namespace: demo, expect_http_create: 200, ui_readback: "uat-waf-1" }
+    nested: []
+    cleanup: ["app_firewalls/uat-waf-1"]
+
+  - id: C-WAF-02
+    phrase: "In the F5 XC web console, remove the app firewall named uat-waf-1."
+    modality: console
+    operation: delete
+    console_resource: app-firewall
+    verify: { api_path: app_firewalls, resource_name: uat-waf-1, namespace: demo, expect_http_delete: 404, ui_readback: "uat-waf-1" }
+    nested: []
+    cleanup: ["app_firewalls/uat-waf-1"]
+
+  - id: C-SP-01
+    phrase: "Walk me through creating a service policy named uat-sp-1 that allows all traffic, in the F5 XC console."
+    modality: console
+    operation: create
+    console_resource: service-policy
+    verify: { api_path: service_policys, resource_name: uat-sp-1, namespace: demo, expect_http_create: 200, ui_readback: "uat-sp-1" }
+    nested: []
+    cleanup: ["service_policys/uat-sp-1"]
+
+  - id: C-SP-02
+    phrase: "Show me in the F5 XC UI how to delete the service policy named uat-sp-1."
+    modality: console
+    operation: delete
+    console_resource: service-policy
+    verify: { api_path: service_policys, resource_name: uat-sp-1, namespace: demo, expect_http_delete: 404, ui_readback: "uat-sp-1" }
+    nested: []
+    cleanup: ["service_policys/uat-sp-1"]
+
+  - id: C-OP-01
+    phrase: "In the F5 XC console, create an origin pool named uat-op-1 with origin server backend.example.com on port 443."
+    modality: console
+    operation: create
+    console_resource: origin-pool
+    verify: { api_path: origin_pools, resource_name: uat-op-1, namespace: demo, expect_http_create: 200, ui_readback: "uat-op-1" }
+    nested: []
+    cleanup: ["origin_pools/uat-op-1"]
+
+  - id: C-OP-02
+    phrase: "Using chrome, delete the origin pool named uat-op-1 from namespace demo."
+    modality: console
+    operation: delete
+    console_resource: origin-pool
+    verify: { api_path: origin_pools, resource_name: uat-op-1, namespace: demo, expect_http_delete: 404, ui_readback: "uat-op-1" }
+    nested: []
+    cleanup: ["origin_pools/uat-op-1"]
+
+  # ===========================================================================
+  # B. Deep-nested two-resource (child created first, then parent w/ reference)
+  # ===========================================================================
+  - id: C-NEST-OPHC-01
+    phrase: "In the F5 XC web console, first create a health check named uat-hc-dep that probes /healthz over HTTP, then create an origin pool named uat-op-hc with origin server app.example.com on port 443 that uses the uat-hc-dep health check."
+    modality: console
+    operation: create
+    console_resource: origin-pool
+    verify: { api_path: origin_pools, resource_name: uat-op-hc, namespace: demo, expect_http_create: 200, ui_readback: "uat-op-hc" }
+    nested:
+      - { console_resource: health-check, api_path: healthchecks, resource_name: uat-hc-dep }
+    cleanup: ["origin_pools/uat-op-hc", "healthchecks/uat-hc-dep"]
+
+  - id: C-NEST-OPHC-02
+    phrase: "Open the F5 XC console and delete the origin pool uat-op-hc, then delete the health check uat-hc-dep."
+    modality: console
+    operation: delete
+    console_resource: origin-pool
+    verify: { api_path: origin_pools, resource_name: uat-op-hc, namespace: demo, expect_http_delete: 404, ui_readback: "uat-op-hc" }
+    nested:
+      - { console_resource: health-check, api_path: healthchecks, resource_name: uat-hc-dep }
+    cleanup: ["origin_pools/uat-op-hc", "healthchecks/uat-hc-dep"]
+
+  - id: C-NEST-LBOP-01
+    phrase: "Walk me through creating, in the F5 XC console, an origin pool named uat-lbop-pool (origin app.example.com:443) and then an HTTP load balancer named uat-lb-op on domain uat-lb-op.example.com that routes to that origin pool."
+    modality: console
+    operation: create
+    console_resource: http-load-balancer
+    verify: { api_path: http_loadbalancers, resource_name: uat-lb-op, namespace: demo, expect_http_create: 200, ui_readback: "uat-lb-op" }
+    nested:
+      - { console_resource: origin-pool, api_path: origin_pools, resource_name: uat-lbop-pool }
+    cleanup: ["http_loadbalancers/uat-lb-op", "origin_pools/uat-lbop-pool"]
+
+  - id: C-NEST-LBOP-02
+    phrase: "In the F5 XC web console, delete the HTTP load balancer uat-lb-op and then delete the origin pool uat-lbop-pool."
+    modality: console
+    operation: delete
+    console_resource: http-load-balancer
+    verify: { api_path: http_loadbalancers, resource_name: uat-lb-op, namespace: demo, expect_http_delete: 404, ui_readback: "uat-lb-op" }
+    nested:
+      - { console_resource: origin-pool, api_path: origin_pools, resource_name: uat-lbop-pool }
+    cleanup: ["http_loadbalancers/uat-lb-op", "origin_pools/uat-lbop-pool"]
+
+  - id: C-NEST-LBWAF-01
+    phrase: "Using chrome, create an origin pool named uat-lbwaf-pool (origin app.example.com:443) and an app firewall named uat-lbwaf-waf in blocking mode, then create an HTTP load balancer named uat-lb-waf on domain uat-lb-waf.example.com that routes to that origin pool and enables the uat-lbwaf-waf WAF."
+    modality: console
+    operation: create
+    console_resource: http-load-balancer
+    verify: { api_path: http_loadbalancers, resource_name: uat-lb-waf, namespace: demo, expect_http_create: 200, ui_readback: "uat-lb-waf" }
+    nested:
+      - { console_resource: origin-pool, api_path: origin_pools, resource_name: uat-lbwaf-pool }
+      - { console_resource: app-firewall, api_path: app_firewalls, resource_name: uat-lbwaf-waf }
+    cleanup: ["http_loadbalancers/uat-lb-waf", "app_firewalls/uat-lbwaf-waf", "origin_pools/uat-lbwaf-pool"]
+
+  - id: C-NEST-LBWAF-02
+    phrase: "Open the F5 XC console and tear down the WAAP objects: delete the HTTP load balancer uat-lb-waf, then the app firewall uat-lbwaf-waf, then the origin pool uat-lbwaf-pool."
+    modality: console
+    operation: delete
+    console_resource: http-load-balancer
+    verify: { api_path: http_loadbalancers, resource_name: uat-lb-waf, namespace: demo, expect_http_delete: 404, ui_readback: "uat-lb-waf" }
+    nested:
+      - { console_resource: app-firewall, api_path: app_firewalls, resource_name: uat-lbwaf-waf }
+      - { console_resource: origin-pool, api_path: origin_pools, resource_name: uat-lbwaf-pool }
+    cleanup: ["http_loadbalancers/uat-lb-waf", "app_firewalls/uat-lbwaf-waf", "origin_pools/uat-lbwaf-pool"]
+
+  # ===========================================================================
+  # C. Full deep-nested WAAP stack (waap-full-stack demo) — origin-pool →
+  #    app-firewall → http-lb (+WAF), two app names with different wording
+  # ===========================================================================
+  - id: C-WAAP-01
+    phrase: "In the F5 XC web console, run the full WAAP stack for app uat-waap in namespace demo on domain uat-waap.example.com with origin app.example.com:443 and the WAF in blocking mode."
+    modality: console
+    operation: create
+    console_resource: http-load-balancer
+    verify: { api_path: http_loadbalancers, resource_name: uat-waap-lb, namespace: demo, expect_http_create: 200, ui_readback: "uat-waap-lb" }
+    nested:
+      - { console_resource: origin-pool, api_path: origin_pools, resource_name: uat-waap-pool }
+      - { console_resource: app-firewall, api_path: app_firewalls, resource_name: uat-waap-waf }
+    cleanup: ["http_loadbalancers/uat-waap-lb", "app_firewalls/uat-waap-waf", "origin_pools/uat-waap-pool"]
+
+  - id: C-WAAP-02
+    phrase: "Using chrome, tear down the entire uat-waap WAAP stack in namespace demo."
+    modality: console
+    operation: delete
+    console_resource: http-load-balancer
+    verify: { api_path: http_loadbalancers, resource_name: uat-waap-lb, namespace: demo, expect_http_delete: 404, ui_readback: "uat-waap-lb" }
+    nested:
+      - { console_resource: app-firewall, api_path: app_firewalls, resource_name: uat-waap-waf }
+      - { console_resource: origin-pool, api_path: origin_pools, resource_name: uat-waap-pool }
+    cleanup: ["http_loadbalancers/uat-waap-lb", "app_firewalls/uat-waap-waf", "origin_pools/uat-waap-pool"]
+
+  - id: C-WAAP-03
+    phrase: "Walk me through deploying a complete WAAP stack in the F5 XC console for application uat-waap2 (domain uat-waap2.example.com, origin app.example.com:443, blocking WAF) in namespace demo."
+    modality: console
+    operation: create
+    console_resource: http-load-balancer
+    verify: { api_path: http_loadbalancers, resource_name: uat-waap2-lb, namespace: demo, expect_http_create: 200, ui_readback: "uat-waap2-lb" }
+    nested:
+      - { console_resource: origin-pool, api_path: origin_pools, resource_name: uat-waap2-pool }
+      - { console_resource: app-firewall, api_path: app_firewalls, resource_name: uat-waap2-waf }
+    cleanup: ["http_loadbalancers/uat-waap2-lb", "app_firewalls/uat-waap2-waf", "origin_pools/uat-waap2-pool"]
+
+  - id: C-WAAP-04
+    phrase: "Show me in the F5 XC UI how to remove the whole uat-waap2 WAAP stack from namespace demo."
+    modality: console
+    operation: delete
+    console_resource: http-load-balancer
+    verify: { api_path: http_loadbalancers, resource_name: uat-waap2-lb, namespace: demo, expect_http_delete: 404, ui_readback: "uat-waap2-lb" }
+    nested:
+      - { console_resource: app-firewall, api_path: app_firewalls, resource_name: uat-waap2-waf }
+      - { console_resource: origin-pool, api_path: origin_pools, resource_name: uat-waap2-pool }
+    cleanup: ["http_loadbalancers/uat-waap2-lb", "app_firewalls/uat-waap2-waf", "origin_pools/uat-waap2-pool"]
+
+  # ===========================================================================
+  # D. Router-variation duplicates (create only) — same resource, DIFFERENT
+  #    console trigger wording + unique names. Measures how reliably each
+  #    phrasing routes to the console vs leaks to the API.
+  # ===========================================================================
+  - id: C-VAR-HC-01
+    phrase: "In the F5 XC web console, add a health check called uat-hc-v1 checking /healthz over HTTP."
+    modality: console
+    operation: create
+    console_resource: health-check
+    verify: { api_path: healthchecks, resource_name: uat-hc-v1, namespace: demo, expect_http_create: 200, ui_readback: "uat-hc-v1" }
+    nested: []
+    cleanup: ["healthchecks/uat-hc-v1"]
+
+  - id: C-VAR-HC-02
+    phrase: "Using chrome, set up a health check named uat-hc-v2 that pings /healthz via HTTP."
+    modality: console
+    operation: create
+    console_resource: health-check
+    verify: { api_path: healthchecks, resource_name: uat-hc-v2, namespace: demo, expect_http_create: 200, ui_readback: "uat-hc-v2" }
+    nested: []
+    cleanup: ["healthchecks/uat-hc-v2"]
+
+  - id: C-VAR-HC-03
+    phrase: "Walk me through, in the console, creating a health check uat-hc-v3 on path /healthz."
+    modality: console
+    operation: create
+    console_resource: health-check
+    verify: { api_path: healthchecks, resource_name: uat-hc-v3, namespace: demo, expect_http_create: 200, ui_readback: "uat-hc-v3" }
+    nested: []
+    cleanup: ["healthchecks/uat-hc-v3"]
+
+  - id: C-VAR-HC-04
+    phrase: "Show me in the F5 XC UI how to add a health check named uat-hc-v4 (HTTP, /healthz)."
+    modality: console
+    operation: create
+    console_resource: health-check
+    verify: { api_path: healthchecks, resource_name: uat-hc-v4, namespace: demo, expect_http_create: 200, ui_readback: "uat-hc-v4" }
+    nested: []
+    cleanup: ["healthchecks/uat-hc-v4"]
+
+  - id: C-VAR-OP-01
+    phrase: "In the F5 XC web console, create an origin pool uat-op-v1 with origin app.example.com on port 443."
+    modality: console
+    operation: create
+    console_resource: origin-pool
+    verify: { api_path: origin_pools, resource_name: uat-op-v1, namespace: demo, expect_http_create: 200, ui_readback: "uat-op-v1" }
+    nested: []
+    cleanup: ["origin_pools/uat-op-v1"]
+
+  - id: C-VAR-OP-02
+    phrase: "Using chrome, add an origin pool named uat-op-v2 pointing at app.example.com:443."
+    modality: console
+    operation: create
+    console_resource: origin-pool
+    verify: { api_path: origin_pools, resource_name: uat-op-v2, namespace: demo, expect_http_create: 200, ui_readback: "uat-op-v2" }
+    nested: []
+    cleanup: ["origin_pools/uat-op-v2"]
+
+  - id: C-VAR-OP-03
+    phrase: "Walk me through creating an origin pool uat-op-v3 (backend app.example.com, port 443) in the console."
+    modality: console
+    operation: create
+    console_resource: origin-pool
+    verify: { api_path: origin_pools, resource_name: uat-op-v3, namespace: demo, expect_http_create: 200, ui_readback: "uat-op-v3" }
+    nested: []
+    cleanup: ["origin_pools/uat-op-v3"]
+
+  - id: C-VAR-OP-04
+    phrase: "Show me in the F5 XC UI how to create an origin pool named uat-op-v4 with server app.example.com on 443."
+    modality: console
+    operation: create
+    console_resource: origin-pool
+    verify: { api_path: origin_pools, resource_name: uat-op-v4, namespace: demo, expect_http_create: 200, ui_readback: "uat-op-v4" }
+    nested: []
+    cleanup: ["origin_pools/uat-op-v4"]


### PR DESCRIPTION
Unified UAT harness: 26 deep-nested console prompts + reused autoresearch corpora (json 95, hcl 28, i18n 120), all agent-interpreted via `xcsh --print`. Console modality runs observably in Chrome (F5-red indicator + per-step screenshots); verified by UI read-back AND API GET.

**Key change:** `ExtensionPageActions` reworked to resolve selectors via `javascript_tool` (targeted DOM query → coords) + `click_xy`/`typeText` — **never calls `read_ax`** — eliminating the MV3-SW freeze on heavy create forms.

Verified: `--dry-run` (all triggers + cleanup valid), `--self-test-api` (200/404 green). Companion: extension fast-reconnect (coded, pending build/reload).

Closes #1554

🤖 Generated with [Claude Code](https://claude.com/claude-code)