### PR TITLE
fix: make lsp.enabled a master switch, default off (prevents LSP OOM)

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1118,8 +1118,13 @@ export const SETTINGS_SCHEMA = {
 	// LSP
 	"lsp.enabled": {
 		type: "boolean",
-		default: true,
-		ui: { tab: "editing", label: "LSP", description: "Enable the lsp tool for language server protocol" },
+		default: false,
+		ui: {
+			tab: "editing",
+			label: "LSP",
+			description:
+				"Enable language server protocol (lsp tool, startup warmup, write/edit diagnostics). Off by default: a language server initialized against a very large workspace can stream unbounded output and exhaust memory.",
+		},
 	},
 
 	"lsp.formatOnWrite": {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -900,7 +900,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	let agent: Agent;
 	let session!: AgentSession;
 	let hasSession = false;
-	const enableLsp = options.enableLsp ?? true;
+	// LSP is opt-in: a language server initialized against a very large workspace
+	// (e.g. terraform-ls on a multi-repo tree) can stream unbounded output that is
+	// buffered without limit and exhausts process memory (OOM). `lsp.enabled` is
+	// the master switch — it gates the startup warmup and write/edit diagnostics.
+	const enableLsp = options.enableLsp ?? settings.get("lsp.enabled") ?? false;
 	const backgroundJobsEnabled = isBackgroundJobSupportEnabled(settings);
 	const asyncMaxJobs = Math.min(100, Math.max(1, settings.get("async.maxJobs") ?? 100));
 	const ASYNC_INLINE_RESULT_MAX_CHARS = 12_000;

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -61,7 +61,8 @@ describe("createTools", () => {
 		expect(names).toContain("write");
 		expect(names).toContain("grep");
 		expect(names).toContain("find");
-		expect(names).toContain("lsp");
+		// lsp is opt-in (lsp.enabled, default off) — see dedicated test below.
+		expect(names).not.toContain("lsp");
 		expect(names).toContain("notebook");
 		expect(names).toContain("task");
 		expect(names).toContain("todo_write");
@@ -122,6 +123,12 @@ describe("createTools", () => {
 		expect(names).toContain("bash");
 		expect(names).toContain("exit_plan_mode");
 		expect(names).not.toContain("python");
+	});
+
+	it("includes lsp tool when LSP is explicitly enabled", async () => {
+		const session = createTestSession({ settings: Settings.isolated({ "lsp.enabled": true }) });
+		const tools = await createTools(session);
+		expect(tools.map(t => t.name)).toContain("lsp");
 	});
 
 	it("excludes lsp tool when session disables LSP", async () => {


### PR DESCRIPTION
Closes #1559

## Symptom
Uncaught `RangeError: Out of memory` (Bun native stream sink `#getInternalBuffer`/`#pull`, in `processTicksAndRejections`) shortly after startup, regardless of user input. Reproduces reliably when running in a large multi-repo working directory.

## Root cause (proven, not hypothesized)
The startup LSP warmup (`sdk.ts`, gated only by `enableLsp && lsp.diagnosticsOnWrite`) auto-spawns a language server for the workspace. In a large tree (e.g. `~/GIT`, 293 `.tf` files across many repos), **`terraform-ls serve`** is rooted at that tree, streams large/continuous output, and its subprocess output accumulates **unbounded** in `ptree`'s `ChildProcess` → `arrayBuffers` balloons to ~65 GB → OOM.

Evidence (instrumented `--print` reproduction, captured locally):
- **Bisection:** disable the LSP spawn → `arrayBuffers` flat at 0–1 MB, no OOM; enable → 65 GB → crash.
- **Heap snapshot:** one `ChildProcess` retained **5,884 of 6,004** buffer objects.
- **Spawn log:** the only subprocess before the balloon is `terraform-ls serve`.

`lsp.enabled` existed but gated only the lsp *tool* — not the startup warmup or write/edit diagnostics — so it was not a real master switch.

## Fix
- Wire `lsp.enabled` into `enableLsp` (which gates warmup + write/edit/vim diagnostics) — making it a true master switch.
- Default `lsp.enabled` to **false** (opt-in). A language server can no longer be auto-started, so it can't OOM the process unless the user explicitly enables LSP.

**Behavior change:** LSP (diagnostics/format/tool) is now off unless `lsp.enabled: true`. Reversible per-user via that setting.

## Verification
- Exact reproduction: with the fix, `terraform-ls` is never spawned and `arrayBuffers` stays at **0**; no OOM.
- `createTools` test updated (lsp is opt-in) + new test that lsp is created when `lsp.enabled: true`.
- Full suite green except pre-existing Puppeteer/real-Chrome `extension-e2e` tests, which self-skip in CI.

## Follow-up (optional, if LSP is re-enabled later)
Bound the LSP transport's subprocess-output buffering so a flooding/misbehaving server closes the client instead of OOMing the app.