### PR TITLE
feat(mermaid): beautiful colorized TUI rendering

### DIFF
--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -2,7 +2,7 @@ import type { AssistantMessage, ImageContent, Usage } from "@f5xc-salesdemos/pi-
 import { Container, Image, ImageProtocol, Markdown, Spacer, TERMINAL, Text } from "@f5xc-salesdemos/pi-tui";
 import { formatNumber, logger } from "@f5xc-salesdemos/pi-utils";
 import { settings } from "../../config/settings";
-import { hasPendingMermaid, prerenderMermaid } from "../../modes/theme/mermaid-cache";
+import { hasPendingMermaid, mermaidThemeSignature, prerenderMermaid } from "../../modes/theme/mermaid-cache";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { resolveImageOptions } from "../../tools/render-utils";
 
@@ -86,10 +86,14 @@ export class AssistantMessageComponent extends Container {
 		}
 	}
 	#triggerMermaidPrerender(message: AssistantMessage): void {
-		if (!TERMINAL.imageProtocol || this.#prerenderInFlight) return;
+		// ASCII/Unicode mermaid renders in any terminal — do NOT gate on image protocol.
+		if (this.#prerenderInFlight) return;
 
+		const sig = mermaidThemeSignature(theme);
 		// Check if any text content has pending mermaid blocks
-		const hasPending = message.content.some(c => c.type === "text" && c.text.trim() && hasPendingMermaid(c.text));
+		const hasPending = message.content.some(
+			c => c.type === "text" && c.text.trim() && hasPendingMermaid(c.text, sig),
+		);
 		if (!hasPending) return;
 
 		this.#prerenderInFlight = true;
@@ -98,8 +102,8 @@ export class AssistantMessageComponent extends Container {
 		void (async () => {
 			try {
 				for (const content of message.content) {
-					if (content.type === "text" && content.text.trim() && hasPendingMermaid(content.text)) {
-						prerenderMermaid(content.text);
+					if (content.type === "text" && content.text.trim() && hasPendingMermaid(content.text, sig)) {
+						prerenderMermaid(content.text, theme);
 					}
 				}
 			} catch (error) {

--- a/packages/coding-agent/src/modes/theme/mermaid-cache.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-cache.ts
@@ -1,44 +1,84 @@
-import { extractMermaidBlocks, logger, renderMermaidAsciiSafe } from "@f5xc-salesdemos/pi-utils";
+import {
+	extractMermaidBlocks,
+	logger,
+	type MermaidAsciiRenderOptions,
+	type MermaidColorMode,
+	pickColorMode,
+	renderMermaidAsciiSafe,
+	tintMermaidNodes,
+} from "@f5xc-salesdemos/pi-utils";
+import { buildMermaidAsciiTheme, buildNodeAccents } from "./mermaid-palette";
+import type { Theme } from "./theme";
 
-const cache = new Map<bigint | number, string | null>();
+// Keyed by `${sourceHash}|${themeSignature}` so a theme switch re-renders rather
+// than serving a stale, differently-colored diagram.
+const cache = new Map<string, string | null>();
 
 let onRenderNeeded: (() => void) | null = null;
 
-/**
- * Set callback to trigger TUI re-render when mermaid ASCII renders become available.
- */
+/** Set callback to trigger a TUI re-render when new mermaid renders become available. */
 export function setMermaidRenderCallback(callback: (() => void) | null): void {
 	onRenderNeeded = callback;
 }
 
-/**
- * Get a pre-rendered mermaid ASCII diagram by hash.
- * Returns null if not cached or rendering failed.
- */
-export function getMermaidAscii(hash: bigint | number): string | null {
-	return cache.get(hash) ?? null;
+function colorModeFor(theme: Theme, override?: MermaidColorMode): MermaidColorMode {
+	if (override) return override;
+	return pickColorMode({ noColor: Boolean(Bun.env.NO_COLOR), trueColor: theme.getColorMode() === "truecolor" });
+}
+
+function paletteSignature(theme: Theme): string {
+	return `${JSON.stringify(buildMermaidAsciiTheme(theme))}|${buildNodeAccents(theme).join(",")}`;
+}
+
+/** Stable signature identifying a theme's mermaid appearance — used for cache keying. */
+export function mermaidThemeSignature(theme: Theme): string {
+	return `${colorModeFor(theme)}:${paletteSignature(theme)}`;
+}
+
+export interface RenderMermaidThemedOptions {
+	/** Force a color mode (otherwise derived from the theme + NO_COLOR). */
+	colorMode?: MermaidColorMode;
+	/** Extra layout options (padding, useAscii, …). */
+	render?: MermaidAsciiRenderOptions;
 }
 
 /**
- * Render all mermaid blocks in markdown text.
- * Caches results and calls render callback when new diagrams are available.
+ * Render mermaid source to a themed, per-node-tinted ASCII/Unicode string.
+ * Applies the theme's per-role palette, then the best-effort node-tint pass.
+ * Result is memoized per (source, theme, colorMode). Returns null on parse failure.
  */
-export function prerenderMermaid(markdown: string): void {
+export function renderMermaidThemed(source: string, theme: Theme, opts?: RenderMermaidThemedOptions): string | null {
+	const mode = colorModeFor(theme, opts?.colorMode);
+	const key = `${Bun.hash(source.trim())}|${mode}:${paletteSignature(theme)}`;
+	const cached = cache.get(key);
+	if (cached !== undefined) return cached;
+
+	const asciiTheme = buildMermaidAsciiTheme(theme);
+	const colored = renderMermaidAsciiSafe(source, { ...opts?.render, colorMode: mode, theme: asciiTheme });
+	if (colored == null) {
+		cache.set(key, null);
+		return null;
+	}
+	const result = mode === "none" ? colored : tintMermaidNodes(colored.split("\n"), buildNodeAccents(theme)).join("\n");
+	cache.set(key, result);
+	return result;
+}
+
+/** Get a pre-rendered mermaid diagram by source hash + theme signature, or null. */
+export function getMermaidAscii(hash: bigint | number, themeSig: string): string | null {
+	return cache.get(`${hash}|${themeSig}`) ?? null;
+}
+
+/** Render and cache every mermaid block in `markdown` for the given theme. */
+export function prerenderMermaid(markdown: string, theme: Theme): void {
 	const blocks = extractMermaidBlocks(markdown);
 	if (blocks.length === 0) return;
 
+	const sig = mermaidThemeSignature(theme);
 	let hasNew = false;
-
 	for (const { source, hash } of blocks) {
-		if (cache.has(hash)) continue;
-
-		const ascii = renderMermaidAsciiSafe(source);
-		if (ascii) {
-			cache.set(hash, ascii);
-			hasNew = true;
-		} else {
-			cache.set(hash, null);
-		}
+		if (cache.has(`${hash}|${sig}`)) continue;
+		if (renderMermaidThemed(source, theme) != null) hasNew = true;
 	}
 
 	if (hasNew && onRenderNeeded) {
@@ -52,17 +92,13 @@ export function prerenderMermaid(markdown: string): void {
 	}
 }
 
-/**
- * Check if markdown contains mermaid blocks that aren't cached yet.
- */
-export function hasPendingMermaid(markdown: string): boolean {
+/** Check whether `markdown` has mermaid blocks not yet cached for this theme. */
+export function hasPendingMermaid(markdown: string, themeSig: string): boolean {
 	const blocks = extractMermaidBlocks(markdown);
-	return blocks.some(({ hash }) => !cache.has(hash));
+	return blocks.some(({ hash }) => !cache.has(`${hash}|${themeSig}`));
 }
 
-/**
- * Clear the mermaid cache.
- */
+/** Clear the mermaid cache. */
 export function clearMermaidCache(): void {
 	cache.clear();
 }

--- a/packages/coding-agent/src/modes/theme/mermaid-palette.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-palette.ts
@@ -1,0 +1,43 @@
+/**
+ * Map the active xcsh UI theme onto a mermaid `AsciiTheme` (per-role hues) and a
+ * cycling list of node-accent ANSI escapes for the per-node tint pass. Reading the
+ * theme keeps diagrams on-brand and dark/light adaptive.
+ */
+import type { MermaidAsciiRenderOptions } from "@f5xc-salesdemos/pi-utils";
+import type { Theme } from "./theme";
+
+type AsciiTheme = NonNullable<MermaidAsciiRenderOptions["theme"]>;
+
+/**
+ * Per-role color palette: red node borders, gold labels, blue edges, green
+ * arrowheads. These show through wherever the per-node tint pass doesn't apply
+ * (edges, arrows, subgraph frames, and as the fallback when tinting is skipped).
+ */
+export function buildMermaidAsciiTheme(theme: Theme): AsciiTheme {
+	return {
+		fg: theme.getFgHex("mdHeading", "#febc38"), // node/edge labels
+		border: theme.getFgHex("accent", "#ca260a"), // node + subgraph borders
+		line: theme.getFgHex("mdLink", "#0088fa"), // edge lines
+		arrow: theme.getFgHex("success", "#00ff88"), // arrowheads
+		corner: theme.getFgHex("mdLink", "#0088fa"),
+		junction: theme.getFgHex("accent", "#ca260a"),
+	};
+}
+
+/**
+ * ANSI foreground escapes cycled across detected node boxes so each node reads as
+ * a distinct hue. Drawn from vivid, well-separated theme roles.
+ */
+export function buildNodeAccents(theme: Theme): string[] {
+	const roles = ["chromeAccent", "success", "warning", "mdLink", "accent"] as const;
+	const seen = new Set<string>();
+	const accents: string[] = [];
+	for (const role of roles) {
+		const ansi = theme.getFgAnsi(role);
+		if (!seen.has(ansi)) {
+			seen.add(ansi);
+			accents.push(ansi);
+		}
+	}
+	return accents;
+}

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -16,7 +16,7 @@ import { TypeCompiler } from "@sinclair/typebox/compiler";
 import chalk from "chalk";
 // Embed theme JSON files at build time
 import { defaultThemes } from "./defaults";
-import { getMermaidAscii } from "./mermaid-cache";
+import { getMermaidAscii, mermaidThemeSignature } from "./mermaid-cache";
 
 export { getLanguageFromPath } from "../../utils/lang-from-path";
 
@@ -2509,7 +2509,7 @@ export function getMarkdownTheme(): MarkdownTheme {
 		underline: (text: string) => theme.underline(text),
 		strikethrough: (text: string) => chalk.strikethrough(text),
 		symbols: getSymbolTheme(),
-		getMermaidAscii,
+		getMermaidAscii: (hash: bigint | number) => getMermaidAscii(hash, mermaidThemeSignature(theme)),
 		highlightCode: (code: string, lang?: string): string[] => {
 			const validLang = lang && nativeSupportsLanguage(lang) ? lang : undefined;
 			try {

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -1316,6 +1316,7 @@ const langMap: Record<string, SymbolKey> = {
 
 export class Theme {
 	#fgColors: Record<ThemeColor, string>;
+	#fgHex: Partial<Record<ThemeColor, string>>;
 	#bgColors: Record<ThemeBg, string>;
 	#symbols: SymbolMap;
 
@@ -1327,8 +1328,12 @@ export class Theme {
 		symbolOverrides: Partial<Record<SymbolKey, string>>,
 	) {
 		this.#fgColors = {} as Record<ThemeColor, string>;
+		this.#fgHex = {};
 		for (const [key, value] of Object.entries(fgColors) as [ThemeColor, string | number][]) {
 			this.#fgColors[key] = fgAnsi(value, mode);
+			// Retain the raw hex (when the role resolves to one) for consumers that need
+			// a color value rather than an ANSI escape — e.g. the mermaid AsciiTheme.
+			if (typeof value === "string" && value.startsWith("#")) this.#fgHex[key] = value;
 		}
 		// gutterError remains optional — neither shipped theme carries it
 		this.#fgColors.gutterError ??= this.#fgColors.error;
@@ -1384,6 +1389,15 @@ export class Theme {
 		const ansi = this.#fgColors[color];
 		if (!ansi) throw new Error(`Unknown theme color: ${color}`);
 		return ansi;
+	}
+
+	/**
+	 * Raw hex (e.g. "#ca260a") for a color role, for consumers that need a color
+	 * value rather than an ANSI escape (e.g. the mermaid AsciiTheme). Roles that
+	 * resolve to "" (default fg) or an ansi256 index yield `fallback`.
+	 */
+	getFgHex(color: ThemeColor, fallback = "#cccccc"): string {
+		return this.#fgHex[color] ?? fallback;
 	}
 
 	/** Convert a ThemeColor's fg ANSI code to a bg ANSI code (swap \x1b[38; → \x1b[48;). */

--- a/packages/coding-agent/src/tools/mermaid-renderer.ts
+++ b/packages/coding-agent/src/tools/mermaid-renderer.ts
@@ -1,7 +1,9 @@
-/** TUI renderer for the render_mermaid tool — bordered ASCII diagram output. */
+/** TUI renderer for the render_mermaid tool — bordered, themed, colorized diagram output. */
 import type { Component } from "@f5xc-salesdemos/pi-tui";
 import { Text } from "@f5xc-salesdemos/pi-tui";
+import { detectDiagramType, type MermaidDiagramType } from "@f5xc-salesdemos/pi-utils";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import { renderMermaidThemed } from "../modes/theme/mermaid-cache";
 import type { Theme } from "../modes/theme/theme";
 import { CachedOutputBlock, F5_TOOL_BORDER_COLOR, renderStatusLine } from "../tui";
 import type { RenderMermaidToolDetails } from "./render-mermaid";
@@ -9,6 +11,26 @@ import { addSection, formatErrorMessage, replaceTabs } from "./render-utils";
 
 const TOOL_TITLE = "Mermaid";
 const MAX_DIAGRAM_LINES = 40;
+
+/** Human-friendly caption for the diagram-type badge in the block header. */
+function diagramTypeLabel(type: MermaidDiagramType): string {
+	switch (type) {
+		case "flowchart":
+			return "flowchart";
+		case "sequence":
+			return "sequence diagram";
+		case "class":
+			return "class diagram";
+		case "er":
+			return "ER diagram";
+		case "state":
+			return "state diagram";
+		case "xychart":
+			return "xychart";
+		default:
+			return "diagram";
+	}
+}
 
 type MermaidRenderArgs = {
 	mermaid?: string;
@@ -31,7 +53,7 @@ export const mermaidRenderer = {
 		},
 		options: RenderResultOptions,
 		uiTheme: Theme,
-		_args?: MermaidRenderArgs,
+		args?: MermaidRenderArgs,
 	): Component {
 		const isError = result.isError === true;
 
@@ -44,11 +66,18 @@ export const mermaidRenderer = {
 		const meta: string[] = [];
 		const rawText = result.content?.find(c => c.type === "text")?.text ?? "";
 
-		// Strip artifact reference from display
+		// Strip artifact reference from the plain result text (fallback path).
 		const artifactIdx = rawText.indexOf("\n\nSaved artifact:");
-		const diagramText = artifactIdx >= 0 ? rawText.slice(0, artifactIdx) : rawText;
+		const plainText = artifactIdx >= 0 ? rawText.slice(0, artifactIdx) : rawText;
 
-		const diagramLines = diagramText.split("\n").map(line => replaceTabs(uiTheme.fg("toolOutput", line)));
+		// Prefer re-rendering from the original source: this yields the themed,
+		// per-role-colored, node-tinted diagram. Fall back to the plain result text.
+		const source = args?.mermaid?.trim();
+		const diagramText = (source ? renderMermaidThemed(source, uiTheme) : null) ?? plainText;
+		const caption = source ? diagramTypeLabel(detectDiagramType(source)) : "diagram";
+
+		// Keep the diagram's own colors — do NOT recolor each line a flat tool color.
+		const diagramLines = diagramText.split("\n").map(line => replaceTabs(line));
 		addSection(sections, "Diagram", diagramLines, uiTheme, MAX_DIAGRAM_LINES);
 
 		if (result.details?.artifactId) {
@@ -59,7 +88,7 @@ export const mermaidRenderer = {
 			{
 				title: TOOL_TITLE,
 				titleColor: "dim",
-				description: uiTheme.fg("muted", "diagram"),
+				description: uiTheme.fg("muted", caption),
 				meta: meta.length > 0 ? meta : undefined,
 			},
 			uiTheme,

--- a/packages/coding-agent/test/mermaid-cache.test.ts
+++ b/packages/coding-agent/test/mermaid-cache.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+	clearMermaidCache,
+	getMermaidAscii,
+	mermaidThemeSignature,
+	prerenderMermaid,
+	renderMermaidThemed,
+} from "@f5xc-salesdemos/xcsh/modes/theme/mermaid-cache";
+import { getThemeByName } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
+
+const SRC = "graph LR\n A[Login] --> B{Auth}\n B --> C[Home]";
+const ESC = "\x1b[";
+const sgr = (s: string): Set<string> => new Set(s.match(/\x1b\[[0-9;]*m/g) ?? []);
+
+beforeEach(() => clearMermaidCache());
+
+describe("renderMermaidThemed", () => {
+	it("produces colorized output with several distinct SGR colors", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const out = renderMermaidThemed(SRC, theme!, { colorMode: "truecolor" });
+		expect(out).not.toBeNull();
+		expect(out!).toContain(ESC);
+		expect(sgr(out!).size).toBeGreaterThanOrEqual(3);
+	});
+
+	it("emits no escapes under colorMode none", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const out = renderMermaidThemed(SRC, theme!, { colorMode: "none" });
+		expect(out).not.toBeNull();
+		expect(out!).not.toContain(ESC);
+	});
+});
+
+describe("theme-aware cache", () => {
+	it("caches separately per theme and retains ANSI (does not strip)", async () => {
+		const dark = (await getThemeByName("xcsh-dark"))!;
+		const light = (await getThemeByName("xcsh-light"))!;
+		const md = `\`\`\`mermaid\n${SRC}\n\`\`\``;
+
+		prerenderMermaid(md, dark);
+		prerenderMermaid(md, light);
+
+		const hash = Bun.hash(SRC);
+		const d = getMermaidAscii(hash, mermaidThemeSignature(dark));
+		const l = getMermaidAscii(hash, mermaidThemeSignature(light));
+
+		expect(d).not.toBeNull();
+		expect(l).not.toBeNull();
+		expect(d!).toContain(ESC); // colored, not stripped
+		expect(d).not.toBe(l); // different theme → different render
+	});
+
+	it("returns null for a signature that was never rendered", async () => {
+		const dark = (await getThemeByName("xcsh-dark"))!;
+		expect(getMermaidAscii(Bun.hash(SRC), mermaidThemeSignature(dark))).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/mermaid-palette.test.ts
+++ b/packages/coding-agent/test/mermaid-palette.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { buildMermaidAsciiTheme, buildNodeAccents } from "@f5xc-salesdemos/xcsh/modes/theme/mermaid-palette";
+import { getThemeByName } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
+
+const isHex = (s: string): boolean => /^#[0-9a-fA-F]{6}$/.test(s);
+
+describe("Theme.getFgHex", () => {
+	it("returns a hex string for a color role", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		expect(theme).toBeDefined();
+		expect(isHex(theme!.getFgHex("accent"))).toBe(true);
+	});
+
+	it("falls back when a role has no hex value", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		// `text` resolves to "" (default fg) — must yield the provided fallback.
+		expect(theme!.getFgHex("text", "#abcdef")).toBe("#abcdef");
+	});
+});
+
+describe("buildMermaidAsciiTheme", () => {
+	it("maps roles to a multi-hue, all-hex AsciiTheme", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const ascii = buildMermaidAsciiTheme(theme!);
+		for (const role of ["fg", "border", "line", "arrow"] as const) {
+			expect(isHex(ascii[role] as string)).toBe(true);
+		}
+		// Multi-hue: borders, edges, and arrows are not all the same color.
+		const distinct = new Set([ascii.fg, ascii.border, ascii.line, ascii.arrow]);
+		expect(distinct.size).toBeGreaterThanOrEqual(3);
+	});
+
+	it("differs between dark and light themes", async () => {
+		const dark = buildMermaidAsciiTheme((await getThemeByName("xcsh-dark"))!);
+		const light = buildMermaidAsciiTheme((await getThemeByName("xcsh-light"))!);
+		expect(JSON.stringify(dark)).not.toBe(JSON.stringify(light));
+	});
+});
+
+describe("buildNodeAccents", () => {
+	it("returns several distinct ANSI foreground escapes", async () => {
+		const theme = await getThemeByName("xcsh-dark");
+		const accents = buildNodeAccents(theme!);
+		expect(accents.length).toBeGreaterThanOrEqual(3);
+		// All are SGR foreground sequences.
+		for (const a of accents) expect(a).toMatch(/^\x1b\[[0-9;]*m$/);
+		// They are distinct.
+		expect(new Set(accents).size).toBe(accents.length);
+	});
+});

--- a/packages/coding-agent/test/mermaid-renderer.test.ts
+++ b/packages/coding-agent/test/mermaid-renderer.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { sanitizeText } from "@f5xc-salesdemos/pi-natives";
+import { clearMermaidCache } from "@f5xc-salesdemos/xcsh/modes/theme/mermaid-cache";
+import { buildNodeAccents } from "@f5xc-salesdemos/xcsh/modes/theme/mermaid-palette";
+import { getThemeByName } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
+import { mermaidRenderer } from "@f5xc-salesdemos/xcsh/tools/mermaid-renderer";
+
+const SRC = "graph LR\n A[Login] --> B[Auth]\n B --> C[Home]";
+
+beforeEach(() => clearMermaidCache());
+
+describe("mermaidRenderer.renderResult", () => {
+	it("re-renders the diagram from the call args (not the plain result text)", async () => {
+		const theme = (await getThemeByName("xcsh-dark"))!;
+		const result = { content: [{ type: "text", text: "PLACEHOLDER_SHOULD_NOT_APPEAR" }], isError: false };
+		const comp = mermaidRenderer.renderResult(result, { expanded: false, isPartial: false }, theme, { mermaid: SRC });
+		const plain = sanitizeText(comp.render(100).join("\n"));
+		expect(plain).toContain("Login");
+		expect(plain).not.toContain("PLACEHOLDER");
+	});
+
+	it("colorizes with per-node accents (not a single flat color)", async () => {
+		const theme = (await getThemeByName("xcsh-dark"))!;
+		const result = { content: [{ type: "text", text: "" }], isError: false };
+		const raw = mermaidRenderer
+			.renderResult(result, { expanded: false, isPartial: false }, theme, { mermaid: SRC })
+			.render(100)
+			.join("\n");
+		// At least one node-tint accent is present → the tint pass ran.
+		const accents = buildNodeAccents(theme);
+		expect(accents.some(a => raw.includes(a))).toBe(true);
+		// Many distinct SGR colors, unlike the old flat single-color render.
+		const distinct = new Set(raw.match(/\x1b\[[0-9;]*m/g) ?? []);
+		expect(distinct.size).toBeGreaterThanOrEqual(6);
+	});
+
+	it("shows a diagram-type caption and the tool title", async () => {
+		const theme = (await getThemeByName("xcsh-dark"))!;
+		const result = { content: [{ type: "text", text: "" }], isError: false };
+		const plain = sanitizeText(
+			mermaidRenderer
+				.renderResult(result, { expanded: false, isPartial: false }, theme, { mermaid: SRC })
+				.render(100)
+				.join("\n"),
+		);
+		expect(plain).toContain("Mermaid");
+		expect(plain.toLowerCase()).toContain("flowchart");
+	});
+});

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -328,7 +328,8 @@ export class Markdown implements Component {
 					const ascii = this.#theme.getMermaidAscii(hash);
 
 					if (ascii) {
-						for (const asciiLine of Bun.stripANSI(ascii).split("\n")) {
+						// Keep the diagram's themed ANSI colors — do not strip.
+						for (const asciiLine of ascii.split("\n")) {
 							lines.push(asciiLine);
 						}
 						if (nextTokenType && nextTokenType !== "space") {

--- a/packages/tui/test/markdown-mermaid.test.ts
+++ b/packages/tui/test/markdown-mermaid.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+import { Markdown } from "../src/components/markdown.js";
+import { defaultMarkdownTheme } from "./test-themes.js";
+
+// A prerendered, colored diagram (cyan box) as the mermaid cache would return.
+const CYAN = "\x1b[38;2;0;180;255m";
+const COLORED = [`${CYAN}┌──┐\x1b[0m`, `${CYAN}│A │\x1b[0m`, `${CYAN}└──┘\x1b[0m`].join("\n");
+
+describe("Markdown mermaid block", () => {
+	it("retains ANSI color from the prerendered diagram (does not strip)", () => {
+		const theme = { ...defaultMarkdownTheme, getMermaidAscii: () => COLORED };
+		const md = new Markdown("```mermaid\ngraph LR\n A --> B\n```", 0, 0, theme);
+		const out = md.render(80).join("\n");
+		expect(out).toContain(CYAN); // color preserved, not stripped
+		expect(out).toContain("┌──┐"); // diagram geometry rendered
+	});
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -21,6 +21,7 @@ export {
 export * from "./json";
 export * as logger from "./logger";
 export * from "./mermaid-ascii";
+export * from "./mermaid-color";
 export * from "./mime";
 export * from "./models-yml";
 export * from "./peek-file";

--- a/packages/utils/src/mermaid-color.ts
+++ b/packages/utils/src/mermaid-color.ts
@@ -1,0 +1,210 @@
+/**
+ * Mermaid color helpers — terminal color-mode selection, diagram-type detection,
+ * and a best-effort per-node tint pass for ASCII/Unicode mermaid output.
+ *
+ * `beautiful-mermaid` colorizes strictly by global character role (text/border/
+ * line/arrow/…), so per-node hues are not reachable through its API. `tintMermaidNodes`
+ * adds them as a post-pass: it detects node-box rectangles in the rendered output and
+ * overrides the foreground color of each box's border + label cells with a cycled accent.
+ * It is intentionally fail-safe — any ambiguity returns the input unchanged so the
+ * library's per-role coloring still shows through.
+ */
+
+/** Color mode subset we drive `beautiful-mermaid` with. */
+export type MermaidColorMode = "none" | "ansi256" | "truecolor";
+
+export interface ColorModeInput {
+	/** NO_COLOR set, output piped, or color explicitly disabled. */
+	noColor: boolean;
+	/** Terminal advertises 24-bit color. */
+	trueColor: boolean;
+}
+
+/** Choose the richest color mode the environment robustly supports. */
+export function pickColorMode({ noColor, trueColor }: ColorModeInput): MermaidColorMode {
+	if (noColor) return "none";
+	return trueColor ? "truecolor" : "ansi256";
+}
+
+export type MermaidDiagramType = "flowchart" | "sequence" | "class" | "er" | "state" | "xychart" | "unknown";
+
+/** Detect the diagram type from the first meaningful header line of mermaid source. */
+export function detectDiagramType(source: string): MermaidDiagramType {
+	for (const raw of source.split("\n")) {
+		const line = raw.trim();
+		// Skip blanks, YAML frontmatter fences, %%{init}%% directives, and %% comments.
+		if (line === "" || line === "---" || line.startsWith("%%")) continue;
+		// Skip frontmatter key/value lines (anything before we hit a known header).
+		if (/^(graph|flowchart)\b/.test(line)) return "flowchart";
+		if (/^sequenceDiagram\b/.test(line)) return "sequence";
+		if (/^classDiagram(-v2)?\b/.test(line)) return "class";
+		if (/^erDiagram\b/.test(line)) return "er";
+		if (/^stateDiagram(-v2)?\b/.test(line)) return "state";
+		if (/^xychart(-beta)?\b/.test(line)) return "xychart";
+		// A header-shaped token that isn't recognized → give up (avoid matching frontmatter values).
+		if (/^[A-Za-z]/.test(line) && !line.includes(":")) return "unknown";
+	}
+	return "unknown";
+}
+
+// ── per-node tint pass ──────────────────────────────────────────────────────
+
+interface Cell {
+	char: string;
+	/** Active foreground SGR sequence ("" = default). */
+	fg: string;
+}
+
+interface Rect {
+	top: number;
+	left: number;
+	bottom: number;
+	right: number;
+}
+
+const TL = new Set(["┌", "╭", "+"]);
+const isH = (ch: string): boolean => ch === "─" || ch === "-";
+const isV = (ch: string): boolean => ch === "│" || ch === "|";
+
+/** Parse a colored line into per-visible-cell {char, fg}, tracking the active fg color. */
+function parseCells(line: string): Cell[] {
+	const cells: Cell[] = [];
+	let fg = "";
+	const re = /\x1b\[[0-9;]*m/g;
+	let last = 0;
+	for (let m = re.exec(line); m !== null; m = re.exec(line)) {
+		for (const ch of line.slice(last, m.index)) cells.push({ char: ch, fg });
+		fg = nextFg(fg, m[0]);
+		last = re.lastIndex;
+	}
+	for (const ch of line.slice(last)) cells.push({ char: ch, fg });
+	return cells;
+}
+
+/** Compute the new active fg from an SGR sequence (only fg-affecting codes matter). */
+function nextFg(prev: string, seq: string): string {
+	const params = seq.slice(2, -1); // strip ESC[ and trailing m
+	if (params === "" || params === "0") return "";
+	if (params.startsWith("38;2;") || params.startsWith("38;5;")) return seq;
+	if (params === "39") return "";
+	if (/^(3[0-7]|9[0-7])$/.test(params)) return seq;
+	return prev; // bold/underline/bg/etc. — leave fg unchanged
+}
+
+/** Locate a single rectangle whose top-left corner is at (r,c), or null. */
+function readRect(grid: string[][], r: number, c: number): Rect | null {
+	const tl = grid[r]?.[c];
+	if (tl === undefined || !TL.has(tl)) return null;
+	const ascii = tl === "+";
+	const trCh = ascii ? "+" : tl === "╭" ? "╮" : "┐";
+	const blCh = ascii ? "+" : tl === "╭" ? "╰" : "└";
+	const brCh = ascii ? "+" : tl === "╭" ? "╯" : "┘";
+
+	const row = grid[r]!;
+	let right = -1;
+	for (let x = c + 1; x < row.length; x++) {
+		const ch = row[x]!;
+		if (ch === trCh) {
+			right = x;
+			break;
+		}
+		if (!isH(ch)) break;
+	}
+	if (right < c + 2) return null; // need interior width
+
+	let bottom = -1;
+	for (let y = r + 1; y < grid.length; y++) {
+		const ch = grid[y]?.[c];
+		if (ch === undefined) break;
+		if (ch === blCh) {
+			bottom = y;
+			break;
+		}
+		if (!isV(ch)) break;
+	}
+	if (bottom < r + 2) return null; // need interior height
+
+	if (grid[bottom]?.[right] !== brCh) return null;
+	// Verify bottom edge and right edge.
+	for (let x = c + 1; x < right; x++) if (!isH(grid[bottom]?.[x] ?? "")) return null;
+	for (let y = r + 1; y < bottom; y++) if (!isV(grid[y]?.[right] ?? "")) return null;
+
+	return { top: r, left: c, bottom, right };
+}
+
+function findRects(grid: string[][]): Rect[] {
+	const rects: Rect[] = [];
+	for (let r = 0; r < grid.length; r++) {
+		const row = grid[r]!;
+		for (let c = 0; c < row.length; c++) {
+			if (TL.has(row[c]!)) {
+				const rect = readRect(grid, r, c);
+				if (rect) rects.push(rect);
+			}
+		}
+	}
+	return rects;
+}
+
+function contains(a: Rect, b: Rect): boolean {
+	if (a === b) return false;
+	return a.top <= b.top && a.left <= b.left && a.bottom >= b.bottom && a.right >= b.right;
+}
+
+/**
+ * Tint each node box a cycled accent color. `coloredLines` is the role-colored
+ * mermaid render; `accentsAnsi` is a list of fg SGR escapes to cycle across nodes.
+ * Returns the input unchanged if no boxes are found or no accents are given.
+ */
+export function tintMermaidNodes(coloredLines: string[], accentsAnsi: string[]): string[] {
+	if (accentsAnsi.length === 0) return coloredLines;
+	try {
+		const rows = coloredLines.map(parseCells);
+		const grid = rows.map(cells => cells.map(cell => cell.char));
+		const rects = findRects(grid);
+		if (rects.length === 0) return coloredLines;
+
+		// Nodes are the innermost rectangles (a subgraph frame contains others → skip it).
+		const nodes = rects
+			.filter(rect => !rects.some(other => contains(rect, other)))
+			.sort((p, q) => p.top - q.top || p.left - q.left);
+		if (nodes.length === 0) return coloredLines;
+
+		// overrides: "r,c" → accent fg sequence.
+		const overrides = new Map<string, string>();
+		nodes.forEach((rect, i) => {
+			const accent = accentsAnsi[i % accentsAnsi.length]!;
+			for (let x = rect.left; x <= rect.right; x++) {
+				overrides.set(`${rect.top},${x}`, accent);
+				overrides.set(`${rect.bottom},${x}`, accent);
+			}
+			for (let y = rect.top; y <= rect.bottom; y++) {
+				overrides.set(`${y},${rect.left}`, accent);
+				overrides.set(`${y},${rect.right}`, accent);
+				for (let x = rect.left + 1; x < rect.right; x++) {
+					if ((grid[y]?.[x] ?? " ") !== " ") overrides.set(`${y},${x}`, accent);
+				}
+			}
+		});
+
+		return rows.map((cells, r) => {
+			const hasOverride = cells.some((_, c) => overrides.has(`${r},${c}`));
+			if (!hasOverride) return coloredLines[r]!;
+			let out = "";
+			let lastFg = "";
+			for (let c = 0; c < cells.length; c++) {
+				const cell = cells[c]!;
+				const fg = overrides.get(`${r},${c}`) ?? cell.fg;
+				if (fg !== lastFg) {
+					out += fg === "" ? "\x1b[39m" : fg;
+					lastFg = fg;
+				}
+				out += cell.char;
+			}
+			if (lastFg !== "") out += "\x1b[0m";
+			return out;
+		});
+	} catch {
+		return coloredLines;
+	}
+}

--- a/packages/utils/src/mermaid-color.ts
+++ b/packages/utils/src/mermaid-color.ts
@@ -65,6 +65,10 @@ interface Rect {
 const TL = new Set(["┌", "╭", "+"]);
 const isH = (ch: string): boolean => ch === "─" || ch === "-";
 const isV = (ch: string): boolean => ch === "│" || ch === "|";
+// Borders may carry an edge-attachment junction (a tee/cross) where an edge meets
+// the box; accept those so attached nodes are still detected and tinted.
+const isHBorder = (ch: string): boolean => isH(ch) || ch === "┬" || ch === "┴" || ch === "┼";
+const isVBorder = (ch: string): boolean => isV(ch) || ch === "├" || ch === "┤" || ch === "┼";
 
 /** Parse a colored line into per-visible-cell {char, fg}, tracking the active fg color. */
 function parseCells(line: string): Cell[] {
@@ -108,7 +112,7 @@ function readRect(grid: string[][], r: number, c: number): Rect | null {
 			right = x;
 			break;
 		}
-		if (!isH(ch)) break;
+		if (!isHBorder(ch)) break;
 	}
 	if (right < c + 2) return null; // need interior width
 
@@ -120,14 +124,14 @@ function readRect(grid: string[][], r: number, c: number): Rect | null {
 			bottom = y;
 			break;
 		}
-		if (!isV(ch)) break;
+		if (!isVBorder(ch)) break;
 	}
 	if (bottom < r + 2) return null; // need interior height
 
 	if (grid[bottom]?.[right] !== brCh) return null;
-	// Verify bottom edge and right edge.
-	for (let x = c + 1; x < right; x++) if (!isH(grid[bottom]?.[x] ?? "")) return null;
-	for (let y = r + 1; y < bottom; y++) if (!isV(grid[y]?.[right] ?? "")) return null;
+	// Verify bottom edge and right edge (junctions where edges attach are allowed).
+	for (let x = c + 1; x < right; x++) if (!isHBorder(grid[bottom]?.[x] ?? "")) return null;
+	for (let y = r + 1; y < bottom; y++) if (!isVBorder(grid[y]?.[right] ?? "")) return null;
 
 	return { top: r, left: c, bottom, right };
 }

--- a/packages/utils/test/mermaid-color.test.ts
+++ b/packages/utils/test/mermaid-color.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "bun:test";
+import { detectDiagramType, pickColorMode, tintMermaidNodes } from "../src/mermaid-color";
+
+const strip = (s: string): string => Bun.stripANSI(s);
+
+// A few sentinel ANSI foreground escapes used in tests.
+const CYAN = "\x1b[38;2;0;180;255m";
+const GREEN = "\x1b[38;2;0;255;136m";
+const EDGE = "\x1b[38;2;150;150;150m";
+
+describe("pickColorMode", () => {
+	it("returns none when noColor is set, regardless of trueColor", () => {
+		expect(pickColorMode({ noColor: true, trueColor: true })).toBe("none");
+		expect(pickColorMode({ noColor: true, trueColor: false })).toBe("none");
+	});
+
+	it("returns truecolor when the terminal supports it", () => {
+		expect(pickColorMode({ noColor: false, trueColor: true })).toBe("truecolor");
+	});
+
+	it("falls back to ansi256 when truecolor is unavailable", () => {
+		expect(pickColorMode({ noColor: false, trueColor: false })).toBe("ansi256");
+	});
+});
+
+describe("detectDiagramType", () => {
+	it("detects flowchart from graph and flowchart headers", () => {
+		expect(detectDiagramType("graph LR\n A --> B")).toBe("flowchart");
+		expect(detectDiagramType("flowchart TD\n A --> B")).toBe("flowchart");
+	});
+
+	it("detects sequence, class, er, state, and xychart", () => {
+		expect(detectDiagramType("sequenceDiagram\n A->>B: hi")).toBe("sequence");
+		expect(detectDiagramType("classDiagram\n class A")).toBe("class");
+		expect(detectDiagramType("erDiagram\n A ||--o{ B : has")).toBe("er");
+		expect(detectDiagramType("stateDiagram-v2\n [*] --> A")).toBe("state");
+		expect(detectDiagramType("xychart-beta\n bar [1,2,3]")).toBe("xychart");
+	});
+
+	it("skips frontmatter and %%{init}%% directives before the header", () => {
+		const src = "---\ntitle: X\n---\n%%{init: {'theme':'dark'}}%%\ngraph TD\n A-->B";
+		expect(detectDiagramType(src)).toBe("flowchart");
+	});
+
+	it("returns unknown for unrecognized input", () => {
+		expect(detectDiagramType("nonsense here")).toBe("unknown");
+	});
+});
+
+// Build a colored line from (text, fg) segments.
+function colored(segments: Array<[string, string]>): string {
+	return segments.map(([text, fg]) => (fg ? `${fg}${text}\x1b[0m` : text)).join("");
+}
+
+describe("tintMermaidNodes", () => {
+	const box = ["┌───┐", "│ A │", "└───┘"];
+
+	it("tints a single node box (border + label) with the first accent", () => {
+		const out = tintMermaidNodes(box, [CYAN]);
+		// Geometry is preserved exactly.
+		expect(out.map(strip)).toEqual(box);
+		// The accent now appears in the output.
+		expect(out.join("\n")).toContain(CYAN);
+		// The label 'A' is tinted with the accent.
+		expect(out[1]).toContain(`${CYAN}`);
+	});
+
+	it("gives two separate boxes two distinct accents", () => {
+		const twoBoxes = ["┌───┐   ┌───┐", "│ A │   │ B │", "└───┘   └───┘"];
+		const out = tintMermaidNodes(twoBoxes, [CYAN, GREEN]).join("\n");
+		expect(out).toContain(CYAN);
+		expect(out).toContain(GREEN);
+	});
+
+	it("leaves edge/arrow characters outside boxes at their original color", () => {
+		// A box on the left, then an edge segment colored EDGE outside it.
+		const lines = [
+			"┌───┐     ",
+			colored([
+				["│ A │", ""],
+				["──► ", EDGE],
+			]),
+			"└───┘     ",
+		];
+		const out = tintMermaidNodes(lines, [CYAN]).join("\n");
+		// Edge color survives; accent is also present (box was tinted).
+		expect(out).toContain(EDGE);
+		expect(out).toContain(CYAN);
+	});
+
+	it("detects and tints ASCII-mode boxes", () => {
+		const asciiBox = ["+---+", "| A |", "+---+"];
+		const out = tintMermaidNodes(asciiBox, [CYAN]);
+		expect(out.map(strip)).toEqual(asciiBox);
+		expect(out.join("\n")).toContain(CYAN);
+	});
+
+	it("tints every label row of a multi-line box", () => {
+		const tall = ["┌─────┐", "│ Top │", "│ Bot │", "└─────┘"];
+		const out = tintMermaidNodes(tall, [CYAN]);
+		expect(out[1]).toContain(CYAN);
+		expect(out[2]).toContain(CYAN);
+	});
+
+	it("fail-safe: returns input unchanged when no boxes are detected", () => {
+		const garbage = ["just some text", "A --> B no boxes", "~~~~~~~~"];
+		expect(tintMermaidNodes(garbage, [CYAN])).toEqual(garbage);
+	});
+
+	it("fail-safe: returns input unchanged when no accents are provided", () => {
+		expect(tintMermaidNodes(box, [])).toEqual(box);
+	});
+});

--- a/packages/utils/test/mermaid-color.test.ts
+++ b/packages/utils/test/mermaid-color.test.ts
@@ -102,6 +102,14 @@ describe("tintMermaidNodes", () => {
 		expect(out[2]).toContain(CYAN);
 	});
 
+	it("tints a box whose border has an edge-attachment junction", () => {
+		// A right-side tee (├) where an edge leaves the box must not defeat detection.
+		const lines = ["┌───┐", "│ A ├──►", "└───┘"];
+		const out = tintMermaidNodes(lines, [CYAN]);
+		expect(out[0]).toContain(CYAN);
+		expect(out[1]).toContain(CYAN);
+	});
+
 	it("fail-safe: returns input unchanged when no boxes are detected", () => {
 		const garbage = ["just some text", "A --> B no boxes", "~~~~~~~~"];
 		expect(tintMermaidNodes(garbage, [CYAN])).toEqual(garbage);


### PR DESCRIPTION
Closes #1563

## What & why

The mermaid feature rendered at prototype quality — flat, monochrome diagrams — even though the underlying `beautiful-mermaid` library supports rich per-role ANSI colorization and a themeable `AsciiTheme`. xcsh discarded all of it: it rendered with no color options, flat-painted every line one gray, and `Bun.stripANSI`'d inline blocks. This PR makes mermaid output state-of-the-art: on-brand, multi-hue, and per-node tinted, across both render paths.

Built test-first (TDD) throughout.

## Changes

**New pure utils — `packages/utils/src/mermaid-color.ts`**
- `pickColorMode` — `none` / `ansi256` / `truecolor` from terminal capability (+ `NO_COLOR`).
- `detectDiagramType` — flowchart / sequence / class / er / state / xychart.
- `tintMermaidNodes` — best-effort per-node accent tint over the role-colored render. Detects node-box rectangles (Unicode + ASCII, incl. edge-attachment junctions) and recolors each box's border + label a cycled accent. **Fail-safe**: any ambiguity returns the input unchanged.

**Theme → palette — `packages/coding-agent/src/modes/theme/mermaid-palette.ts`**
- `Theme.getFgHex` exposes raw role hex alongside the ANSI map.
- `buildMermaidAsciiTheme` maps the active theme to a multi-hue per-role `AsciiTheme` (red borders, gold labels, blue edges, green arrows) — dark/light adaptive.
- `buildNodeAccents` — cycling distinct node-accent escapes.

**Theme-aware cache — `mermaid-cache.ts`**
- `renderMermaidThemed` applies the palette + node tint, memoized per (source, theme, colorMode).
- Cache keyed by source hash + theme signature so theme switches re-render.

**Both render paths**
- Tool renderer (`mermaid-renderer.ts`): re-renders from the call's source for color, drops the flat recolor, adds a diagram-type caption. Model-facing output/artifact stays plain ASCII; colorization is display-only.
- Inline markdown (`markdown.ts`): stops stripping ANSI; prerender ungated from `TERMINAL.imageProtocol` so inline diagrams render in color on any terminal.

## Design note

`beautiful-mermaid` colorizes strictly by **global role** — per-node color isn't reachable through its API (it parses `classDef`/`style` but never consumes them during color emission). Per-node hues are therefore a best-effort xcsh post-pass with a fail-safe fallback to pure per-role coloring, as agreed in planning.

## Testing

- New tests: `mermaid-color` (15), `mermaid-palette` (5), `mermaid-cache` (4), `mermaid-renderer` (3), `markdown-mermaid` (1) — all green.
- Full suites: `utils` 130/130, `tui` 466/466. `coding-agent` only the pre-existing Puppeteer "real Chrome" E2E failures (Chrome can't install in the sandbox) — unrelated to this change.
- Typecheck clean for `utils`, `tui`, `coding-agent`.
- Manual render of `graph LR; A[Login]-->B{Auth}; B-->|ok|C[Home]; B-->|fail|A`: 7 distinct colors, per-node tints applied, `NO_COLOR` falls back to plain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)