### PR TITLE
fix(mermaid): guard render_mermaid against pathfinder OOM/hang

### DIFF
--- a/packages/coding-agent/src/modes/theme/mermaid-cache.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-cache.ts
@@ -3,6 +3,7 @@ import {
 	logger,
 	type MermaidAsciiRenderOptions,
 	type MermaidColorMode,
+	mermaidSourceExceedsLimit,
 	pickColorMode,
 	renderMermaidAsciiSafe,
 	tintMermaidNodes,
@@ -48,6 +49,10 @@ export interface RenderMermaidThemedOptions {
  * Result is memoized per (source, theme, colorMode). Returns null on parse failure.
  */
 export function renderMermaidThemed(source: string, theme: Theme, opts?: RenderMermaidThemedOptions): string | null {
+	// Oversized graphs can hang the synchronous pathfinder for tens of seconds; skip
+	// them so the display falls back to the raw code block instead of freezing the UI.
+	if (mermaidSourceExceedsLimit(source)) return null;
+
 	const mode = colorModeFor(theme, opts?.colorMode);
 	// Layout options (useAscii, padding, …) change the output, so they must be part
 	// of the key. Omitted when absent so the key matches mermaidThemeSignature() —

--- a/packages/coding-agent/src/tools/render-mermaid.ts
+++ b/packages/coding-agent/src/tools/render-mermaid.ts
@@ -4,7 +4,12 @@ import type {
 	AgentToolResult,
 	AgentToolUpdateCallback,
 } from "@f5xc-salesdemos/pi-agent-core";
-import { type MermaidAsciiRenderOptions, prompt, renderMermaidAscii } from "@f5xc-salesdemos/pi-utils";
+import {
+	type MermaidAsciiRenderOptions,
+	mermaidSourceExceedsLimit,
+	prompt,
+	renderMermaidAsciiSafe,
+} from "@f5xc-salesdemos/pi-utils";
 import { type Static, Type } from "@sinclair/typebox";
 import renderMermaidDescription from "../prompts/tools/render-mermaid.md" with { type: "text" };
 import type { ToolSession } from "./index";
@@ -55,7 +60,24 @@ export class RenderMermaidTool implements AgentTool<typeof renderMermaidSchema, 
 		_onUpdate?: AgentToolUpdateCallback<RenderMermaidToolDetails>,
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<RenderMermaidToolDetails>> {
-		const ascii = renderMermaidAscii(params.mermaid, sanitizeRenderConfig(params.config));
+		// Reject oversized graphs up front: beautiful-mermaid's pathfinder can hang
+		// for tens of seconds and then throw `RangeError: Out of memory` on them.
+		// Throwing here (fast) surfaces a clean tool error the agent can recover from.
+		if (mermaidSourceExceedsLimit(params.mermaid)) {
+			throw new Error(
+				"Mermaid diagram is too large to render safely. Reduce the number of nodes/edges and try again.",
+			);
+		}
+
+		// Safe variant: a parse failure or memory blow-up becomes null rather than a
+		// raw RangeError, so we can throw a clear, actionable message instead.
+		const ascii = renderMermaidAsciiSafe(params.mermaid, sanitizeRenderConfig(params.config));
+		if (ascii == null || ascii.trim() === "") {
+			throw new Error(
+				"Failed to render the Mermaid diagram — the syntax may be unsupported or too complex. Use newline-separated statements (no ';') and try a simpler diagram.",
+			);
+		}
+
 		const { path: artifactPath, id: artifactId } =
 			(await this.session.allocateOutputArtifact?.("render_mermaid")) ?? {};
 		if (artifactPath) {

--- a/packages/coding-agent/test/tools/render-mermaid-tool.test.ts
+++ b/packages/coding-agent/test/tools/render-mermaid-tool.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { RenderMermaidTool } from "@f5xc-salesdemos/xcsh/tools/render-mermaid";
+
+const tool = new RenderMermaidTool({} as never);
+const textOf = (r: { content: Array<{ type: string; text?: string }> }) =>
+	r.content.find(c => c.type === "text")?.text ?? "";
+
+describe("RenderMermaidTool.execute robustness", () => {
+	it("renders a valid diagram", async () => {
+		const r = await tool.execute("t", { mermaid: "graph LR\nA[Client] --> B[Origin]" });
+		expect(textOf(r)).toContain("Client");
+	});
+
+	it("throws a clear (catchable) error for un-renderable input", async () => {
+		expect(tool.execute("t", { mermaid: "this is definitely not a mermaid diagram %%%%" })).rejects.toThrow(
+			/render|simpl|unsupported/i,
+		);
+	});
+
+	it("rejects an oversized diagram fast instead of hanging the pathfinder", async () => {
+		const huge = `graph TD\n${Array.from({ length: 2000 }, (_, i) => `N${i} --> N${i + 1}`).join("\n")}`;
+		const start = Bun.nanoseconds();
+		await expect(tool.execute("t", { mermaid: huge })).rejects.toThrow(/large/i);
+		// The guard must short-circuit — nowhere near the ~23s OOM hang.
+		expect((Bun.nanoseconds() - start) / 1e6).toBeLessThan(1000);
+	});
+});

--- a/packages/utils/src/mermaid-color.ts
+++ b/packages/utils/src/mermaid-color.ts
@@ -26,6 +26,23 @@ export function pickColorMode({ noColor, trueColor }: ColorModeInput): MermaidCo
 	return trueColor ? "truecolor" : "ansi256";
 }
 
+/**
+ * Complexity ceiling for mermaid sources. beautiful-mermaid's ASCII edge router
+ * (A* pathfinder) can allocate unbounded memory and hang for tens of seconds —
+ * then throw `RangeError: Out of memory` — on large/dense graphs. Callers should
+ * reject sources past this limit BEFORE rendering rather than attempt the layout.
+ */
+export const MERMAID_MAX_CHARS = 20000;
+export const MERMAID_MAX_LINES = 400;
+
+/** True when a mermaid source is too large to render safely (see limits above). */
+export function mermaidSourceExceedsLimit(source: string): boolean {
+	if (source.length > MERMAID_MAX_CHARS) return true;
+	let lines = 1;
+	for (let i = 0; i < source.length; i++) if (source.charCodeAt(i) === 10 && ++lines > MERMAID_MAX_LINES) return true;
+	return false;
+}
+
 export type MermaidDiagramType = "flowchart" | "sequence" | "class" | "er" | "state" | "xychart" | "unknown";
 
 /** Detect the diagram type from the first meaningful header line of mermaid source. */

--- a/packages/utils/test/mermaid-color.test.ts
+++ b/packages/utils/test/mermaid-color.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { detectDiagramType, pickColorMode, tintMermaidNodes } from "../src/mermaid-color";
+import {
+	detectDiagramType,
+	MERMAID_MAX_LINES,
+	mermaidSourceExceedsLimit,
+	pickColorMode,
+	tintMermaidNodes,
+} from "../src/mermaid-color";
 
 const strip = (s: string): string => Bun.stripANSI(s);
 
@@ -20,6 +26,21 @@ describe("pickColorMode", () => {
 
 	it("falls back to ansi256 when truecolor is unavailable", () => {
 		expect(pickColorMode({ noColor: false, trueColor: false })).toBe("ansi256");
+	});
+});
+
+describe("mermaidSourceExceedsLimit", () => {
+	it("passes normal diagrams", () => {
+		expect(mermaidSourceExceedsLimit("graph LR\nA --> B --> C")).toBe(false);
+	});
+
+	it("flags graphs with too many lines (pathfinder OOM guard)", () => {
+		const huge = `graph TD\n${Array.from({ length: MERMAID_MAX_LINES + 50 }, (_, i) => `N${i}-->N${i + 1}`).join("\n")}`;
+		expect(mermaidSourceExceedsLimit(huge)).toBe(true);
+	});
+
+	it("flags very long sources by character count", () => {
+		expect(mermaidSourceExceedsLimit(`graph LR\nA-->B %% ${"x".repeat(20001)}`)).toBe(true);
 	});
 });
 


### PR DESCRIPTION
Closes #1572

## Problem
In an interactive session, asking for a moderately complex diagram made `render_mermaid` **freeze ~20+ seconds and then error with "Out of memory,"** leaving the app unresponsive.

## Root cause
`beautiful-mermaid`'s ASCII A* edge router (`src/ascii/pathfinder.ts`) allocates unbounded memory on large/dense graphs — it spins for tens of seconds, then throws `RangeError: Out of memory`. Reproduced deterministically with a ~2000-node chain (hangs ~23s, then OOMs). The tool's `execute()` used the **unsafe** renderer with no size bound.

(Unrelated to the LSP OOM work, which is already on main and disabled-by-default.)

## Fix
- **`pi-utils`**: shared `mermaidSourceExceedsLimit` guard (20k chars / 400 lines).
- **`render_mermaid` execute()**: reject oversized sources *fast* (clean catchable throw), and use `renderMermaidAsciiSafe` so any parse/memory failure throws an actionable message instead of a raw RangeError after a long hang.
- **`renderMermaidThemed` (display)**: skip oversized sources → inline blocks fall back to the raw code fence instead of freezing the UI.

## Tests
- `render-mermaid-tool.test.ts`: valid renders; un-renderable input throws a clear error; **oversized rejects in <1s** (vs the ~23s OOM hang).
- `mermaidSourceExceedsLimit` unit tests.
- Full mermaid suite green (73 tests); typecheck clean (utils + coding-agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)