### PR TITLE
fix(mermaid): clip wide diagrams in output block instead of word-wrapping

### DIFF
--- a/packages/coding-agent/src/tools/mermaid-renderer.ts
+++ b/packages/coding-agent/src/tools/mermaid-renderer.ts
@@ -98,7 +98,12 @@ export const mermaidRenderer = {
 		return {
 			render(width: number): string[] {
 				const state = options.isPartial ? "pending" : "success";
-				return outputBlock.render({ header, state, sections, width, borderColor: F5_TOOL_BORDER_COLOR }, uiTheme);
+				return outputBlock.render(
+					// Clip, don't wrap: a diagram is a fixed grid — word-wrapping reflows it
+					// and breaks alignment. Wide diagrams are truncated to the block width.
+					{ header, state, sections, width, borderColor: F5_TOOL_BORDER_COLOR, wrapContent: false },
+					uiTheme,
+				);
 			},
 			invalidate() {
 				outputBlock.invalidate();

--- a/packages/coding-agent/src/tui/output-block.ts
+++ b/packages/coding-agent/src/tui/output-block.ts
@@ -23,6 +23,12 @@ export interface OutputBlockOptions {
 	applyBg?: boolean;
 	/** Override the state-derived border color. Always takes precedence, including on error. Use for branded core tools. */
 	borderColor?: ThemeColor;
+	/**
+	 * Word-wrap content lines to fit the inner width (default). Set false to CLIP
+	 * (truncate) instead — required for pre-formatted grid content like mermaid
+	 * diagrams, where wrapping reflows characters and destroys alignment.
+	 */
+	wrapContent?: boolean;
 }
 
 export function renderOutputBlock(options: OutputBlockOptions, theme: Theme): string[] {
@@ -34,6 +40,7 @@ export function renderOutputBlock(options: OutputBlockOptions, theme: Theme): st
 		width,
 		applyBg = true,
 		borderColor: borderColorOverride,
+		wrapContent = true,
 	} = options;
 	const h = theme.boxSharp.horizontal;
 	const v = theme.boxSharp.vertical;
@@ -100,7 +107,9 @@ export function renderOutputBlock(options: OutputBlockOptions, theme: Theme): st
 				lines.push(line);
 				continue;
 			}
-			const wrappedLines = wrapTextWithAnsi(line.trimEnd(), contentWidth);
+			const wrappedLines = wrapContent
+				? wrapTextWithAnsi(line.trimEnd(), contentWidth)
+				: [truncateToWidth(line.trimEnd(), contentWidth)];
 			for (const wrappedLine of wrappedLines) {
 				const innerPadding = padding(Math.max(0, contentWidth - visibleWidth(wrappedLine)));
 				const fullLine = `${contentPrefix}${wrappedLine}${innerPadding}${contentSuffix}`;
@@ -150,6 +159,7 @@ export class CachedOutputBlock {
 		h.optional(options.state);
 		h.bool(options.applyBg ?? true);
 		h.optional(options.borderColor);
+		h.bool(options.wrapContent ?? true);
 		if (options.sections) {
 			for (const s of options.sections) {
 				h.optional(s.label);

--- a/packages/coding-agent/test/output-block-clip.test.ts
+++ b/packages/coding-agent/test/output-block-clip.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { visibleWidth } from "@f5xc-salesdemos/pi-tui";
+import { getThemeByName } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
+import { renderOutputBlock } from "@f5xc-salesdemos/xcsh/tui/output-block";
+
+const WIDTH = 40;
+// A single diagram-ish line far wider than the inner content width.
+const WIDE = `┌── Client ──┐${"─".repeat(120)}┐ 11. Connect to Selected Endpoint`;
+const strip = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+describe("renderOutputBlock content overflow", () => {
+	it("word-wraps wide content by default (multiple rows)", async () => {
+		const theme = (await getThemeByName("xcsh-dark"))!;
+		const out = renderOutputBlock({ width: WIDTH, sections: [{ lines: [WIDE] }] }, theme);
+		// top + (>1 wrapped content rows) + bottom
+		expect(out.length).toBeGreaterThan(3);
+	});
+
+	it("clips wide content to one row when wrapContent is false (no reflow)", async () => {
+		const theme = (await getThemeByName("xcsh-dark"))!;
+		const out = renderOutputBlock({ width: WIDTH, sections: [{ lines: [WIDE] }], wrapContent: false }, theme);
+		// top + exactly ONE content row + bottom
+		expect(out.length).toBe(3);
+		// every emitted row is exactly the block width — the box stays aligned
+		for (const row of out) expect(visibleWidth(row)).toBe(WIDTH);
+		// the content row preserves the left of the diagram (not a reflowed remainder)
+		expect(strip(out[1]!)).toContain("┌── Client");
+		expect(strip(out[1]!)).not.toContain("Endpoint"); // far-right was clipped, not wrapped to a new line
+	});
+});


### PR DESCRIPTION
Closes #1574

## Problem
Inside the F5-branded `render_mermaid` block, wide diagrams were **word-wrapped** to the inner width. A diagram is a fixed character grid, so wrapping reflows it — the leftover word lands at column 0 of the next row — shattering alignment and pushing content past the right border (see the GSLB example: "Endpoint" wrapped to the far left).

## Root cause
`renderOutputBlock` always word-wraps section content via `wrapTextWithAnsi(line, contentWidth)`.

## Fix
- Add `wrapContent?: boolean` (default **true**, preserving all existing callers) to `OutputBlockOptions`. When false, **clip** each line to the inner width with `truncateToWidth` instead of wrapping.
- The mermaid renderer passes `wrapContent: false` → wide diagrams are truncated to the block width with borders staying aligned. The full diagram remains available as the saved artifact.

## Tests
- New `output-block-clip.test.ts`: default still wraps (multiple rows); `wrapContent:false` yields exactly one clipped row, every row == block width, left of the diagram preserved.
- End-to-end via the renderer: at widths 60 and 100, all rows equal the block width and the row count stays constant (clip, not reflow).
- Existing output-block + mermaid-renderer tests still green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)