### PR TITLE
fix(mermaid): full-height, compact, clean-clipped diagram rendering

### DIFF
--- a/packages/coding-agent/src/modes/theme/mermaid-cache.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-cache.ts
@@ -63,7 +63,16 @@ export function renderMermaidThemed(source: string, theme: Theme, opts?: RenderM
 	if (cached !== undefined) return cached;
 
 	const asciiTheme = buildMermaidAsciiTheme(theme);
-	const colored = renderMermaidAsciiSafe(source, { ...opts?.render, colorMode: mode, theme: asciiTheme });
+	// Compact defaults: beautiful-mermaid's paddingX/paddingY of 5 spreads nodes far
+	// apart and bloats the diagram. Tighter spacing reads more elegantly and helps it
+	// fit the transcript width. Callers can still override via opts.render.
+	const colored = renderMermaidAsciiSafe(source, {
+		paddingX: 2,
+		paddingY: 1,
+		...opts?.render,
+		colorMode: mode,
+		theme: asciiTheme,
+	});
 	if (colored == null) {
 		cache.set(key, null);
 		return null;

--- a/packages/coding-agent/src/tools/mermaid-renderer.ts
+++ b/packages/coding-agent/src/tools/mermaid-renderer.ts
@@ -10,7 +10,6 @@ import type { RenderMermaidToolDetails } from "./render-mermaid";
 import { addSection, formatErrorMessage, replaceTabs } from "./render-utils";
 
 const TOOL_TITLE = "Mermaid";
-const MAX_DIAGRAM_LINES = 40;
 
 /** Human-friendly caption for the diagram-type badge in the block header. */
 function diagramTypeLabel(type: MermaidDiagramType): string {
@@ -77,8 +76,9 @@ export const mermaidRenderer = {
 		const caption = source ? diagramTypeLabel(detectDiagramType(source)) : "diagram";
 
 		// Keep the diagram's own colors — do NOT recolor each line a flat tool color.
+		// Show the FULL diagram: truncating a diagram with "… N more lines" defeats the purpose.
 		const diagramLines = diagramText.split("\n").map(line => replaceTabs(line));
-		addSection(sections, "Diagram", diagramLines, uiTheme, MAX_DIAGRAM_LINES);
+		addSection(sections, "Diagram", diagramLines, uiTheme);
 
 		if (result.details?.artifactId) {
 			meta.push(uiTheme.fg("dim", `artifact:${result.details.artifactId.slice(0, 8)}`));

--- a/packages/coding-agent/src/tui/output-block.ts
+++ b/packages/coding-agent/src/tui/output-block.ts
@@ -6,7 +6,7 @@ import type { Theme, ThemeColor } from "../modes/theme/theme";
 import { getImageLineMask } from "../utils/image-passthrough";
 import type { State } from "./types";
 import type { RenderCache } from "./utils";
-import { getStateBgColor, Hasher, padToWidth, truncateToWidth } from "./utils";
+import { Ellipsis, getStateBgColor, Hasher, padToWidth, truncateToWidth } from "./utils";
 
 /**
  * Border color override for F5-branded tool renderers.
@@ -109,7 +109,9 @@ export function renderOutputBlock(options: OutputBlockOptions, theme: Theme): st
 			}
 			const wrappedLines = wrapContent
 				? wrapTextWithAnsi(line.trimEnd(), contentWidth)
-				: [truncateToWidth(line.trimEnd(), contentWidth)];
+				: // Clip cleanly with no trailing ellipsis — a column of "…" down the
+					// right edge of a clipped diagram is clutter, not information.
+					[truncateToWidth(line.trimEnd(), contentWidth, Ellipsis.Omit)];
 			for (const wrappedLine of wrappedLines) {
 				const innerPadding = padding(Math.max(0, contentWidth - visibleWidth(wrappedLine)));
 				const fullLine = `${contentPrefix}${wrappedLine}${innerPadding}${contentSuffix}`;

--- a/packages/coding-agent/test/mermaid-renderer.test.ts
+++ b/packages/coding-agent/test/mermaid-renderer.test.ts
@@ -34,6 +34,20 @@ describe("mermaidRenderer.renderResult", () => {
 		expect(distinct.size).toBeGreaterThanOrEqual(6);
 	});
 
+	it("renders the full diagram without a '… N more lines' truncation", async () => {
+		const theme = (await getThemeByName("xcsh-dark"))!;
+		// A tall vertical chain that renders to well over 40 lines.
+		const chain = `graph TB\n${Array.from({ length: 18 }, (_, i) => `N${i}[Node ${i}] --> N${i + 1}[Node ${i + 1}]`).join("\n")}`;
+		const result = { content: [{ type: "text", text: "" }], isError: false };
+		const lines = mermaidRenderer
+			.renderResult(result, { expanded: false, isPartial: false }, theme, { mermaid: chain })
+			.render(120)
+			.join("\n");
+		expect(lines).not.toContain("more lines");
+		// the last node is present → nothing was cut off the bottom
+		expect(sanitizeText(lines)).toContain("Node 18");
+	});
+
 	it("shows a diagram-type caption and the tool title", async () => {
 		const theme = (await getThemeByName("xcsh-dark"))!;
 		const result = { content: [{ type: "text", text: "" }], isError: false };

--- a/packages/coding-agent/test/output-block-clip.test.ts
+++ b/packages/coding-agent/test/output-block-clip.test.ts
@@ -26,5 +26,8 @@ describe("renderOutputBlock content overflow", () => {
 		// the content row preserves the left of the diagram (not a reflowed remainder)
 		expect(strip(out[1]!)).toContain("┌── Client");
 		expect(strip(out[1]!)).not.toContain("Endpoint"); // far-right was clipped, not wrapped to a new line
+		// clean clip: no trailing ellipsis column
+		expect(strip(out[1]!)).not.toContain("…");
+		expect(strip(out[1]!)).not.toMatch(/\.\.\.$/);
 	});
 });


### PR DESCRIPTION
Closes #1577

Three elegance fixes found during visual UAT of real F5 XC diagrams.

## 1. Stop truncating the diagram vertically
The tool block capped diagrams at 40 lines and appended `… N more lines`. Truncating a diagram defeats the point — removed the cap so it renders in full.

## 2. Compact, less-oversized layout
beautiful-mermaid's default `paddingX/paddingY` of 5 spreads nodes far apart and bloats the diagram. Compact defaults (`paddingX:2, paddingY:1`) in `renderMermaidThemed` shrink it (GSLB sample **73×55 → 67×43**) so it reads elegantly and fits the transcript. Callers can still override.

## 3. Clean horizontal clip (no dotted column)
Clipping wide lines used `truncateToWidth`'s default ellipsis → a column of `…` down the right edge. Now clips with `Ellipsis.Omit` — a clean cut.

## Tests
- renderer: tall chain renders fully (no `more lines`, last node present).
- output block: `wrapContent:false` clips with no `…`.
- full mermaid + output-block + matrix suites green; typecheck clean.

Known limitation (library-side, not addressed): beautiful-mermaid collides adjacent subgraph titles ("RulesS…Poolsdpoints").

🤖 Generated with [Claude Code](https://claude.com/claude-code)