### PR TITLE
fix(mermaid): patch beautiful-mermaid so node labels aren't top-heavy

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -205,6 +205,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "beautiful-mermaid@1.1.3": "patches/beautiful-mermaid@1.1.3.patch",
+  },
   "overrides": {
     "ajv": "^8.20",
     "date-fns": "~4.1.0",

--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
 	"overrides": {
 		"ajv": "^8.20",
 		"date-fns": "~4.1.0"
+	},
+	"patchedDependencies": {
+		"beautiful-mermaid@1.1.3": "patches/beautiful-mermaid@1.1.3.patch"
 	}
 }

--- a/packages/utils/test/mermaid-label-centering.test.ts
+++ b/packages/utils/test/mermaid-label-centering.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { renderMermaidAsciiSafe } from "../src/mermaid-ascii";
+
+/**
+ * Guards the beautiful-mermaid patch (patches/beautiful-mermaid@1.1.3.patch):
+ * node labels must be vertically centered with equal-or-greater padding below,
+ * never top-heavy. Without the patch, tall boxes drop their label too low.
+ */
+describe("node label vertical centering", () => {
+	it("never places a label top-heavy in a tall box", () => {
+		// A short label sharing a rank with a tall 5-line sibling forces a tall box A.
+		const out = renderMermaidAsciiSafe("graph LR\nA[Client<br/>info] --> B[L0<br/>L1<br/>L2<br/>L3<br/>L4]", {
+			paddingX: 2,
+			paddingY: 1,
+		});
+		expect(out).not.toBeNull();
+		const lines = out!.split("\n");
+		const top = lines.findIndex(l => l[0] === "┌");
+		const bottom = lines.findIndex((l, i) => i > top && l[0] === "└");
+		const firstLabel = lines.findIndex(l => l.includes("Client"));
+		const lastLabel = lines
+			.map((l, i) => (l.includes("info") ? i : -1))
+			.filter(i => i >= 0)
+			.pop()!;
+
+		const above = firstLabel - (top + 1);
+		const below = bottom - 1 - lastLabel;
+		expect(above).toBeGreaterThanOrEqual(0);
+		expect(above).toBeLessThanOrEqual(below); // centered, biased slightly high — not top-heavy
+	});
+});

--- a/patches/beautiful-mermaid@1.1.3.patch
+++ b/patches/beautiful-mermaid@1.1.3.patch
@@ -1,0 +1,21 @@
+diff --git a/src/ascii/draw.ts b/src/ascii/draw.ts
+index f8020f594fc9e27cc27eeecad17e2688c3900159..8f2e79d2a3cdacf20df83b33f54d55a15c652527 100644
+--- a/src/ascii/draw.ts
++++ b/src/ascii/draw.ts
+@@ -96,11 +96,13 @@ function drawBoxWithGridDimensions(node: AsciiNode, graph: AsciiGraph): Canvas {
+   box[from.x]![to.y] = effectiveCorners.bl
+   box[to.x]![to.y] = effectiveCorners.br
+ 
+-  // Center the multi-line display label inside the box
++  // Center the multi-line display label inside the box.
++  // Place by equal interior padding (top border at from.y, bottom at from.y+h-1,
++  // interior height h-2). Math.floor biases a leftover odd row to the BOTTOM, so
++  // labels sit flush/slightly-high instead of dropping low for even-height boxes.
+   const label = node.displayLabel
+   const lines = splitLines(label)
+-  const textCenterY = from.y + Math.floor(h / 2)
+-  const startY = textCenterY - Math.floor((lines.length - 1) / 2)
++  const startY = from.y + 1 + Math.max(0, Math.floor((h - 2 - lines.length) / 2))
+ 
+   for (let i = 0; i < lines.length; i++) {
+     const line = lines[i]!


### PR DESCRIPTION
Closes #1579

## Problem
Text inside a node box sits lower than centered — more space above the label than below — so labels look like they have excess top padding (visual UAT nitpick).

## Root cause
beautiful-mermaid (`src/ascii/draw.ts`) places node labels with:
```js
const textCenterY = from.y + Math.floor(h / 2)
const startY = textCenterY - Math.floor((lines.length - 1) / 2)
```
`Math.floor(h/2)` lands below the true interior center, so even-height boxes / multi-line labels drop too low (e.g. an 8-tall box with a 2-line label: 3 rows above / 1 below).

## Fix
`bun patch` placing the label by equal interior padding, biasing a leftover odd row to the bottom:
```js
const startY = from.y + 1 + Math.max(0, Math.floor((h - 2 - lines.length) / 2))
```
Result: labels sit flush/slightly-high, never top-heavy (verified: the same box went from 3-above/2-below to 2-above/3-below).

Carried as `patches/beautiful-mermaid@1.1.3.patch` (applied via `patchedDependencies`; bun resolves the package's `"bun"` export → `src`, so dev, tests, and the compiled build all get it). Guarded by a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)