### PR TITLE
fix(mermaid): render diagrams stand-alone (drop enclosing block frame)

### DIFF
--- a/packages/coding-agent/src/tools/mermaid-renderer.ts
+++ b/packages/coding-agent/src/tools/mermaid-renderer.ts
@@ -1,17 +1,17 @@
-/** TUI renderer for the render_mermaid tool — bordered, themed, colorized diagram output. */
+/** TUI renderer for the render_mermaid tool — stand-alone, themed, colorized diagram. */
 import type { Component } from "@f5xc-salesdemos/pi-tui";
-import { Text } from "@f5xc-salesdemos/pi-tui";
+import { Ellipsis, Text, truncateToWidth } from "@f5xc-salesdemos/pi-tui";
 import { detectDiagramType, type MermaidDiagramType } from "@f5xc-salesdemos/pi-utils";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { renderMermaidThemed } from "../modes/theme/mermaid-cache";
 import type { Theme } from "../modes/theme/theme";
-import { CachedOutputBlock, F5_TOOL_BORDER_COLOR, renderStatusLine } from "../tui";
+import { renderStatusLine } from "../tui";
 import type { RenderMermaidToolDetails } from "./render-mermaid";
-import { addSection, formatErrorMessage, replaceTabs } from "./render-utils";
+import { formatErrorMessage, replaceTabs } from "./render-utils";
 
 const TOOL_TITLE = "Mermaid";
 
-/** Human-friendly caption for the diagram-type badge in the block header. */
+/** Human-friendly caption for the diagram type, shown in the stand-alone caption line. */
 function diagramTypeLabel(type: MermaidDiagramType): string {
 	switch (type) {
 		case "flowchart":
@@ -50,19 +50,15 @@ export const mermaidRenderer = {
 			details?: RenderMermaidToolDetails;
 			isError?: boolean;
 		},
-		options: RenderResultOptions,
+		_options: RenderResultOptions,
 		uiTheme: Theme,
 		args?: MermaidRenderArgs,
 	): Component {
-		const isError = result.isError === true;
-
-		if (isError) {
+		if (result.isError === true) {
 			const errorText = result.content?.find(c => c.type === "text")?.text;
 			return new Text(formatErrorMessage(errorText, uiTheme), 0, 0);
 		}
 
-		const sections: Array<{ label?: string; lines: string[] }> = [];
-		const meta: string[] = [];
 		const rawText = result.content?.find(c => c.type === "text")?.text ?? "";
 
 		// Strip artifact reference from the plain result text (fallback path).
@@ -73,41 +69,29 @@ export const mermaidRenderer = {
 		// per-role-colored, node-tinted diagram. Fall back to the plain result text.
 		const source = args?.mermaid?.trim();
 		const diagramText = (source ? renderMermaidThemed(source, uiTheme) : null) ?? plainText;
-		const caption = source ? diagramTypeLabel(detectDiagramType(source)) : "diagram";
-
-		// Keep the diagram's own colors — do NOT recolor each line a flat tool color.
-		// Show the FULL diagram: truncating a diagram with "… N more lines" defeats the purpose.
+		const typeLabel = source ? diagramTypeLabel(detectDiagramType(source)) : "diagram";
 		const diagramLines = diagramText.split("\n").map(line => replaceTabs(line));
-		addSection(sections, "Diagram", diagramLines, uiTheme);
 
-		if (result.details?.artifactId) {
-			meta.push(uiTheme.fg("dim", `artifact:${result.details.artifactId.slice(0, 8)}`));
-		}
+		// Stand-alone: a single dim caption, then the diagram with NO enclosing frame.
+		// The diagram already carries its own boxes/subgraph frames — wrapping it in the
+		// F5 output block would nest two frames (and clip the inner one into a partial box).
+		const sep = uiTheme.fg("dim", uiTheme.sep.dot);
+		const artifactId = result.details?.artifactId;
+		const caption =
+			uiTheme.fg("dim", "mermaid") +
+			sep +
+			uiTheme.fg("muted", typeLabel) +
+			(artifactId ? sep + uiTheme.fg("dim", `artifact:${artifactId.slice(0, 8)}`) : "");
 
-		const header = renderStatusLine(
-			{
-				title: TOOL_TITLE,
-				titleColor: "dim",
-				description: uiTheme.fg("muted", caption),
-				meta: meta.length > 0 ? meta : undefined,
-			},
-			uiTheme,
-		);
-
-		const outputBlock = new CachedOutputBlock();
 		return {
 			render(width: number): string[] {
-				const state = options.isPartial ? "pending" : "success";
-				return outputBlock.render(
-					// Clip, don't wrap: a diagram is a fixed grid — word-wrapping reflows it
-					// and breaks alignment. Wide diagrams are truncated to the block width.
-					{ header, state, sections, width, borderColor: F5_TOOL_BORDER_COLOR, wrapContent: false },
-					uiTheme,
-				);
+				// Clip (don't wrap) each line to the width so a wide diagram never reflows
+				// (which would shatter its grid); the full diagram remains in the artifact.
+				const clip = Math.max(0, width);
+				const body = diagramLines.map(line => truncateToWidth(line.trimEnd(), clip, Ellipsis.Omit));
+				return [caption, "", ...body];
 			},
-			invalidate() {
-				outputBlock.invalidate();
-			},
+			invalidate() {},
 		};
 	},
 

--- a/packages/coding-agent/test/mermaid-renderer.test.ts
+++ b/packages/coding-agent/test/mermaid-renderer.test.ts
@@ -48,7 +48,7 @@ describe("mermaidRenderer.renderResult", () => {
 		expect(sanitizeText(lines)).toContain("Node 18");
 	});
 
-	it("shows a diagram-type caption and the tool title", async () => {
+	it("shows a stand-alone dim caption with no enclosing block frame", async () => {
 		const theme = (await getThemeByName("xcsh-dark"))!;
 		const result = { content: [{ type: "text", text: "" }], isError: false };
 		const plain = sanitizeText(
@@ -57,7 +57,34 @@ describe("mermaidRenderer.renderResult", () => {
 				.render(100)
 				.join("\n"),
 		);
-		expect(plain).toContain("Mermaid");
-		expect(plain.toLowerCase()).toContain("flowchart");
+		// caption present (lowercase, with the diagram type)
+		expect(plain.toLowerCase()).toContain("mermaid");
+		expect(plain).toContain("flowchart");
+		// NO enclosing F5 output block: neither the "├─ Diagram ─┤" section bar
+		// nor the "┌─ Mermaid … ─┐" header box.
+		expect(plain).not.toMatch(/─── Diagram ───/);
+		expect(plain).not.toMatch(/┌─+ Mermaid/);
+	});
+
+	it("clips a wide diagram to width without reflowing (row count is width-independent)", async () => {
+		const theme = (await getThemeByName("xcsh-dark"))!;
+		const wide = "graph LR\n A[Client] --> B[HTTP Load Balancer] --> C[Origin Pool] --> D[Health Check]";
+		const make = (w: number) =>
+			mermaidRenderer
+				.renderResult(
+					{ content: [{ type: "text", text: "" }], isError: false },
+					{ expanded: false, isPartial: false },
+					theme,
+					{
+						mermaid: wide,
+					},
+				)
+				.render(w);
+		const wideRender = make(200);
+		const narrowRender = make(40);
+		// Clipping (not wrapping) → same number of rows regardless of width.
+		expect(narrowRender.length).toBe(wideRender.length);
+		// No rendered line exceeds the width (so the terminal never wraps it).
+		for (const line of narrowRender) expect(Bun.stringWidth(sanitizeText(line))).toBeLessThanOrEqual(40);
 	});
 });


### PR DESCRIPTION
Closes #1591

## Problem
When the model wraps a diagram in a top-level `subgraph`, that subgraph draws its own frame, and `render_mermaid` then wrapped the whole thing in the F5 bordered output block — **two nested frames**. When the diagram is wider than the terminal, the block clipped the inner subgraph frame open on the right → an extraneous **partial frame** (reproduced at width 70).

## Fix
Render the diagram **stand-alone**: a single dim caption line — `mermaid · <type> · artifact:<id>` — then the diagram with **no enclosing border**. The diagram's own boxes/subgraph frames are the only frames → no nesting, no partial outer frame.

- Wide diagrams still **clip-not-wrap** to width (`truncateToWidth(..., Ellipsis.Omit)`) so they never reflow; the full diagram remains in the saved artifact.
- Scope: `packages/coding-agent/src/tools/mermaid-renderer.ts` only. Render pipeline (palette, node-tint, label-centering) unchanged. The generic `output-block.ts` `wrapContent` option stays (still exercised by `output-block-clip.test.ts`).

## Tests
- New/updated `mermaid-renderer.test.ts`: caption present + **no `─── Diagram ───` bar / no `┌─ Mermaid ─┐` box**; wide diagram clips (row count width-independent, no line exceeds width). Existing re-render-from-args, per-node-accent/≥6-SGR, and full-height tests stay green.
- Full mermaid + output-block + matrix suites green; `tsgo` clean; biome clean.

## Verified visually (bun -e)
width 120 & 70: dim caption, then the diagram's own single frame; at width 70 only the diagram's frame clips — no nested/partial outer frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)