### PR TITLE
fix(mermaid): single F5 frame (tool + inline) and fix inline width reflow

### DIFF
--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -10,13 +10,15 @@ import {
 	supportsLanguage as nativeSupportsLanguage,
 } from "@f5xc-salesdemos/pi-natives";
 import type { EditorTheme, MarkdownTheme, SelectListTheme, SymbolTheme } from "@f5xc-salesdemos/pi-tui";
-import { adjustHsv, getCustomThemesDir, isEnoent, logger } from "@f5xc-salesdemos/pi-utils";
+import { adjustHsv, detectDiagramType, getCustomThemesDir, isEnoent, logger } from "@f5xc-salesdemos/pi-utils";
 import { type Static, Type } from "@sinclair/typebox";
 import { TypeCompiler } from "@sinclair/typebox/compiler";
 import chalk from "chalk";
+import { buildMermaidBlockOptions, diagramTypeLabel } from "../../tools/mermaid-renderer";
+import { renderOutputBlock } from "../../tui";
 // Embed theme JSON files at build time
 import { defaultThemes } from "./defaults";
-import { getMermaidAscii, mermaidThemeSignature } from "./mermaid-cache";
+import { getMermaidAscii, mermaidThemeSignature, renderMermaidThemed } from "./mermaid-cache";
 
 export { getLanguageFromPath } from "../../utils/lang-from-path";
 
@@ -2510,6 +2512,14 @@ export function getMarkdownTheme(): MarkdownTheme {
 		strikethrough: (text: string) => chalk.strikethrough(text),
 		symbols: getSymbolTheme(),
 		getMermaidAscii: (hash: bigint | number) => getMermaidAscii(hash, mermaidThemeSignature(theme)),
+		renderMermaidBlock: (source: string, width: number): string[] | null => {
+			const diagram = renderMermaidThemed(source, theme);
+			if (!diagram) return null;
+			return renderOutputBlock(
+				buildMermaidBlockOptions(diagram, { width, theme, typeLabel: diagramTypeLabel(detectDiagramType(source)) }),
+				theme,
+			);
+		},
 		highlightCode: (code: string, lang?: string): string[] => {
 			const validLang = lang && nativeSupportsLanguage(lang) ? lang : undefined;
 			try {

--- a/packages/coding-agent/src/tools/mermaid-renderer.ts
+++ b/packages/coding-agent/src/tools/mermaid-renderer.ts
@@ -1,18 +1,18 @@
-/** TUI renderer for the render_mermaid tool — stand-alone, themed, colorized diagram. */
+/** TUI renderer for the render_mermaid tool — single F5-framed, themed, colorized diagram. */
 import type { Component } from "@f5xc-salesdemos/pi-tui";
-import { Ellipsis, Text, truncateToWidth } from "@f5xc-salesdemos/pi-tui";
+import { Text } from "@f5xc-salesdemos/pi-tui";
 import { detectDiagramType, type MermaidDiagramType } from "@f5xc-salesdemos/pi-utils";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { renderMermaidThemed } from "../modes/theme/mermaid-cache";
 import type { Theme } from "../modes/theme/theme";
-import { renderStatusLine } from "../tui";
+import { CachedOutputBlock, F5_TOOL_BORDER_COLOR, type OutputBlockOptions, renderStatusLine } from "../tui";
 import type { RenderMermaidToolDetails } from "./render-mermaid";
 import { formatErrorMessage, replaceTabs } from "./render-utils";
 
 const TOOL_TITLE = "Mermaid";
 
-/** Human-friendly caption for the diagram type, shown in the stand-alone caption line. */
-function diagramTypeLabel(type: MermaidDiagramType): string {
+/** Human-friendly caption for the diagram type, shown in the F5 frame header. */
+export function diagramTypeLabel(type: MermaidDiagramType): string {
 	switch (type) {
 		case "flowchart":
 			return "flowchart";
@@ -29,6 +29,34 @@ function diagramTypeLabel(type: MermaidDiagramType): string {
 		default:
 			return "diagram";
 	}
+}
+
+/**
+ * Build the F5 output-block options that frame a themed/colored mermaid diagram.
+ * Shared by the render_mermaid tool result AND inline ```mermaid markdown blocks, so
+ * every mermaid render gets the SAME single F5 frame — and the diagram is clipped
+ * (wrapContent: false), never wrapped, so a wide diagram can't reflow or overflow.
+ */
+export function buildMermaidBlockOptions(
+	diagramText: string,
+	opts: { width: number; theme: Theme; typeLabel: string; artifactId?: string },
+): OutputBlockOptions {
+	// Unlabeled section: the header already reads "Mermaid · <type>", so a "Diagram"
+	// bar would be redundant. The diagram keeps its own colors; we only normalize tabs.
+	const sections = [{ lines: diagramText.split("\n").map(line => replaceTabs(line)) }];
+	const meta = opts.artifactId ? [opts.theme.fg("dim", `artifact:${opts.artifactId.slice(0, 8)}`)] : undefined;
+	const header = renderStatusLine(
+		{ title: TOOL_TITLE, titleColor: "dim", description: opts.theme.fg("muted", opts.typeLabel), meta },
+		opts.theme,
+	);
+	return {
+		header,
+		state: "success",
+		sections,
+		width: opts.width,
+		borderColor: F5_TOOL_BORDER_COLOR,
+		wrapContent: false,
+	};
 }
 
 type MermaidRenderArgs = {
@@ -60,38 +88,27 @@ export const mermaidRenderer = {
 		}
 
 		const rawText = result.content?.find(c => c.type === "text")?.text ?? "";
-
 		// Strip artifact reference from the plain result text (fallback path).
 		const artifactIdx = rawText.indexOf("\n\nSaved artifact:");
 		const plainText = artifactIdx >= 0 ? rawText.slice(0, artifactIdx) : rawText;
 
-		// Prefer re-rendering from the original source: this yields the themed,
-		// per-role-colored, node-tinted diagram. Fall back to the plain result text.
+		// Prefer re-rendering from the original source: themed, per-node-tinted, colored.
 		const source = args?.mermaid?.trim();
 		const diagramText = (source ? renderMermaidThemed(source, uiTheme) : null) ?? plainText;
 		const typeLabel = source ? diagramTypeLabel(detectDiagramType(source)) : "diagram";
-		const diagramLines = diagramText.split("\n").map(line => replaceTabs(line));
-
-		// Stand-alone: a single dim caption, then the diagram with NO enclosing frame.
-		// The diagram already carries its own boxes/subgraph frames — wrapping it in the
-		// F5 output block would nest two frames (and clip the inner one into a partial box).
-		const sep = uiTheme.fg("dim", uiTheme.sep.dot);
 		const artifactId = result.details?.artifactId;
-		const caption =
-			uiTheme.fg("dim", "mermaid") +
-			sep +
-			uiTheme.fg("muted", typeLabel) +
-			(artifactId ? sep + uiTheme.fg("dim", `artifact:${artifactId.slice(0, 8)}`) : "");
 
+		const block = new CachedOutputBlock();
 		return {
 			render(width: number): string[] {
-				// Clip (don't wrap) each line to the width so a wide diagram never reflows
-				// (which would shatter its grid); the full diagram remains in the artifact.
-				const clip = Math.max(0, width);
-				const body = diagramLines.map(line => truncateToWidth(line.trimEnd(), clip, Ellipsis.Omit));
-				return [caption, "", ...body];
+				return block.render(
+					buildMermaidBlockOptions(diagramText, { width, theme: uiTheme, typeLabel, artifactId }),
+					uiTheme,
+				);
 			},
-			invalidate() {},
+			invalidate() {
+				block.invalidate();
+			},
 		};
 	},
 

--- a/packages/coding-agent/test/mermaid-renderer.test.ts
+++ b/packages/coding-agent/test/mermaid-renderer.test.ts
@@ -48,22 +48,22 @@ describe("mermaidRenderer.renderResult", () => {
 		expect(sanitizeText(lines)).toContain("Node 18");
 	});
 
-	it("shows a stand-alone dim caption with no enclosing block frame", async () => {
+	it("renders inside the single F5 frame with a type caption (no redundant Diagram bar)", async () => {
 		const theme = (await getThemeByName("xcsh-dark"))!;
 		const result = { content: [{ type: "text", text: "" }], isError: false };
-		const plain = sanitizeText(
-			mermaidRenderer
-				.renderResult(result, { expanded: false, isPartial: false }, theme, { mermaid: SRC })
-				.render(100)
-				.join("\n"),
-		);
-		// caption present (lowercase, with the diagram type)
-		expect(plain.toLowerCase()).toContain("mermaid");
+		const lines = mermaidRenderer
+			.renderResult(result, { expanded: false, isPartial: false }, theme, { mermaid: SRC })
+			.render(100);
+		const plain = sanitizeText(lines.join("\n"));
+		// Single F5 frame: top border box on the first line, with the Mermaid + type caption.
+		expect(sanitizeText(lines[0]!)).toMatch(/^┌/);
+		expect(plain).toContain("Mermaid");
 		expect(plain).toContain("flowchart");
-		// NO enclosing F5 output block: neither the "├─ Diagram ─┤" section bar
-		// nor the "┌─ Mermaid … ─┐" header box.
-		expect(plain).not.toMatch(/─── Diagram ───/);
-		expect(plain).not.toMatch(/┌─+ Mermaid/);
+		// every framed line is exactly the block width (aligned frame)
+		const W = 100;
+		for (const line of lines) expect(Bun.stringWidth(sanitizeText(line))).toBe(W);
+		// no redundant "─── Diagram ───" section bar (header already names the type)
+		expect(plain).not.toMatch(/── Diagram ──/);
 	});
 
 	it("clips a wide diagram to width without reflowing (row count is width-independent)", async () => {

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -2,7 +2,15 @@ import { marked, type Token, type Tokens } from "marked";
 import type { SymbolTheme } from "../symbols";
 import { TERMINAL } from "../terminal-capabilities";
 import type { Component } from "../tui";
-import { applyBackgroundToLine, padding, replaceTabs, visibleWidth, wrapTextWithAnsi } from "../utils";
+import {
+	applyBackgroundToLine,
+	Ellipsis,
+	padding,
+	replaceTabs,
+	truncateToWidth,
+	visibleWidth,
+	wrapTextWithAnsi,
+} from "../utils";
 
 /**
  * Default text styling for markdown content.
@@ -48,6 +56,12 @@ export interface MarkdownTheme {
 	 * Return null to fall back to fenced code rendering.
 	 */
 	getMermaidAscii?: (sourceHash: bigint | number) => string | null;
+	/**
+	 * Render a mermaid block (by source) inside the host's framed chrome, clipped to
+	 * `width`. Returns the framed lines, or null to fall back to `getMermaidAscii` /
+	 * fenced code rendering. Lets inline ```mermaid blocks match the render_mermaid tool.
+	 */
+	renderMermaidBlock?: (source: string, width: number) => string[] | null;
 	symbols: SymbolTheme;
 }
 
@@ -322,20 +336,32 @@ export class Markdown implements Component {
 			}
 
 			case "code": {
-				// Handle mermaid diagrams with ASCII rendering when available
-				if (token.lang === "mermaid" && this.#theme.getMermaidAscii) {
-					const hash = Bun.hash(token.text.trim());
-					const ascii = this.#theme.getMermaidAscii(hash);
-
-					if (ascii) {
-						// Keep the diagram's themed ANSI colors — do not strip.
-						for (const asciiLine of ascii.split("\n")) {
-							lines.push(asciiLine);
-						}
+				if (token.lang === "mermaid") {
+					// Preferred: render in the host's single F5 frame (themed + clipped),
+					// consistent with the render_mermaid tool. The frame clips to width.
+					const framed = this.#theme.renderMermaidBlock?.(token.text, width);
+					if (framed && framed.length > 0) {
+						for (const framedLine of framed) lines.push(framedLine);
 						if (nextTokenType && nextTokenType !== "space") {
 							lines.push("");
 						}
 						break;
+					}
+
+					// Fallback: prerendered ASCII. CLIP (not wrap) each row to width so a
+					// wide diagram keeps its grid instead of reflowing across lines.
+					if (this.#theme.getMermaidAscii) {
+						const hash = Bun.hash(token.text.trim());
+						const ascii = this.#theme.getMermaidAscii(hash);
+						if (ascii) {
+							for (const asciiLine of ascii.split("\n")) {
+								lines.push(truncateToWidth(asciiLine, width, Ellipsis.Omit));
+							}
+							if (nextTokenType && nextTokenType !== "space") {
+								lines.push("");
+							}
+							break;
+						}
 					}
 				}
 

--- a/packages/tui/test/markdown-mermaid.test.ts
+++ b/packages/tui/test/markdown-mermaid.test.ts
@@ -14,4 +14,27 @@ describe("Markdown mermaid block", () => {
 		expect(out).toContain(CYAN); // color preserved, not stripped
 		expect(out).toContain("┌──┐"); // diagram geometry rendered
 	});
+
+	it("clips (does not reflow) a wide inline mermaid diagram to the render width", () => {
+		const strip = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+		// A 3-row diagram far wider than the render width.
+		const wide = [`┌${"─".repeat(200)}┐`, `│ Node${" ".repeat(195)}│`, `└${"─".repeat(200)}┘`].join("\n");
+		const theme = { ...defaultMarkdownTheme, getMermaidAscii: () => wide };
+		const md = new Markdown("```mermaid\ngraph LR\n A --> B\n```", 0, 0, theme);
+		const W = 40;
+		const lines = md.render(W);
+		// CLIP, not WRAP: a 3-row diagram must stay ~3 rows, not balloon (word-wrap → ~14).
+		expect(lines.length).toBeLessThanOrEqual(5);
+		// And no line exceeds the width.
+		for (const line of lines) expect(Bun.stringWidth(strip(line))).toBeLessThanOrEqual(W);
+	});
+
+	it("frames an inline mermaid block when renderMermaidBlock is provided", () => {
+		const framed = ["┌─ Mermaid · flowchart ─┐", "│ A --> B               │", "└───────────────────────┘"];
+		const theme = { ...defaultMarkdownTheme, renderMermaidBlock: () => framed };
+		const md = new Markdown("```mermaid\ngraph LR\n A --> B\n```", 0, 0, theme);
+		const out = md.render(40).join("\n");
+		expect(out).toContain("Mermaid · flowchart");
+		expect(out).toContain("┌─ Mermaid");
+	});
 });


### PR DESCRIPTION
Closes #1595
Supersedes the stand-alone behavior from #1592.

## What you reported
- The mermaid render should have our **single F5 red frame** chrome (consistent with other custom tools), and the diagram should **not** add its own redundant outer border.
- The **width calculation was wrong** — find the root cause.

## Root cause of the width bug
Inline mermaid code blocks render through the **markdown renderer, which word-wraps content to width**. A diagram is a fixed character grid, so wrapping **reflows** it — a 3-row diagram ballooned to ~14 rows (confirmed by repro), which is the mangled/overflow you saw. The tool path clipped fine; the inline path reflowed.

## Fix
- **Shared `buildMermaidBlockOptions`** frames a themed/colored diagram in the single F5 output block: header `Mermaid · <type>`, no redundant "Diagram" bar, `wrapContent: false` so the diagram is **clipped, never wrapped**.
- **Tool result** uses it → restores the single F5 frame.
- **Inline blocks**: new `MarkdownTheme.renderMermaidBlock(source, width)` renders the SAME framed/clipped block; markdown uses it. The `getMermaidAscii` fallback now **clips** (`Ellipsis.Omit`) instead of reflowing.

Both paths now produce one identical F5 frame, clipped to width, never reflowed.

## Tests
- renderer: asserts single F5 frame (top `┌`, `Mermaid` + type caption), every line == block width, no `── Diagram ──` bar.
- markdown: wide inline diagram **clips not reflows** (3 rows stay ~3, not ~14); inline block is **framed** via `renderMermaidBlock`.
- 102 mermaid/markdown/output-block/matrix tests green; `tsgo` clean (coding-agent + tui); biome clean.
- e2e: real `getMarkdownTheme().renderMermaidBlock` frames an inline diagram, all lines ≤ width.

## Known follow-up (not in this PR)
A diagram the model wraps in a single top-level `subgraph` still draws that subgraph frame inside the F5 block (two frames). Stripping that redundant outer subgraph frame is a separate, riskier change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)