### PR TITLE
fix(mermaid): size the F5 frame to the diagram (snug padded frame)

### DIFF
--- a/packages/coding-agent/src/tools/mermaid-renderer.ts
+++ b/packages/coding-agent/src/tools/mermaid-renderer.ts
@@ -1,6 +1,6 @@
 /** TUI renderer for the render_mermaid tool — single F5-framed, themed, colorized diagram. */
 import type { Component } from "@f5xc-salesdemos/pi-tui";
-import { Text } from "@f5xc-salesdemos/pi-tui";
+import { Text, visibleWidth } from "@f5xc-salesdemos/pi-tui";
 import { detectDiagramType, type MermaidDiagramType } from "@f5xc-salesdemos/pi-utils";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { renderMermaidThemed } from "../modes/theme/mermaid-cache";
@@ -43,17 +43,24 @@ export function buildMermaidBlockOptions(
 ): OutputBlockOptions {
 	// Unlabeled section: the header already reads "Mermaid · <type>", so a "Diagram"
 	// bar would be redundant. The diagram keeps its own colors; we only normalize tabs.
-	const sections = [{ lines: diagramText.split("\n").map(line => replaceTabs(line)) }];
+	const lines = diagramText.split("\n").map(line => replaceTabs(line));
 	const meta = opts.artifactId ? [opts.theme.fg("dim", `artifact:${opts.artifactId.slice(0, 8)}`)] : undefined;
 	const header = renderStatusLine(
 		{ title: TOOL_TITLE, titleColor: "dim", description: opts.theme.fg("muted", opts.typeLabel), meta },
 		opts.theme,
 	);
+	// Size the frame SNUGLY to the diagram (+ one space of padding each side), capped at
+	// the available width and kept wide enough for the header caption — so the diagram
+	// feels enclosed in a small padded frame instead of spanning the whole terminal
+	// (tiny diagram) or clipping against the right border (wide diagram).
+	const maxDiagramWidth = lines.reduce((max, line) => Math.max(max, visibleWidth(line)), 0);
+	const desired = Math.max(maxDiagramWidth + 4, visibleWidth(header) + 8);
+	const width = Math.min(opts.width, Math.max(1, desired));
 	return {
 		header,
 		state: "success",
-		sections,
-		width: opts.width,
+		sections: [{ lines }],
+		width,
 		borderColor: F5_TOOL_BORDER_COLOR,
 		wrapContent: false,
 	};

--- a/packages/coding-agent/test/mermaid-renderer.test.ts
+++ b/packages/coding-agent/test/mermaid-renderer.test.ts
@@ -48,20 +48,24 @@ describe("mermaidRenderer.renderResult", () => {
 		expect(sanitizeText(lines)).toContain("Node 18");
 	});
 
-	it("renders inside the single F5 frame with a type caption (no redundant Diagram bar)", async () => {
+	it("renders inside a snug single F5 frame (hugs the diagram, not the full width)", async () => {
 		const theme = (await getThemeByName("xcsh-dark"))!;
 		const result = { content: [{ type: "text", text: "" }], isError: false };
 		const lines = mermaidRenderer
 			.renderResult(result, { expanded: false, isPartial: false }, theme, { mermaid: SRC })
-			.render(100);
+			.render(200);
 		const plain = sanitizeText(lines.join("\n"));
 		// Single F5 frame: top border box on the first line, with the Mermaid + type caption.
 		expect(sanitizeText(lines[0]!)).toMatch(/^┌/);
 		expect(plain).toContain("Mermaid");
 		expect(plain).toContain("flowchart");
-		// every framed line is exactly the block width (aligned frame)
-		const W = 100;
-		for (const line of lines) expect(Bun.stringWidth(sanitizeText(line))).toBe(W);
+		// Rectangular frame: every line is the SAME width…
+		const widths = new Set(lines.map(l => Bun.stringWidth(sanitizeText(l))));
+		expect(widths.size).toBe(1);
+		// …and that width is SNUG (hugs the small diagram), far less than the 200 available.
+		const frameWidth = [...widths][0]!;
+		expect(frameWidth).toBeLessThan(90);
+		expect(frameWidth).toBeGreaterThan(15);
 		// no redundant "─── Diagram ───" section bar (header already names the type)
 		expect(plain).not.toMatch(/── Diagram ──/);
 	});


### PR DESCRIPTION
Closes #1597

## Problem
The mermaid F5 frame was drawn at the full available (terminal) width: a small diagram sat cramped-left in a huge frame, and a wide diagram clipped abruptly against the right border. It should feel enclosed in a small padded frame.

## Fix
`buildMermaidBlockOptions` now sizes the frame to the diagram:
`width = min(available, max(diagramWidth + 4, headerWidth + 8))`
- `+4`: one space of padding on each side of the diagram inside the frame.
- `headerWidth + 8`: keep it wide enough for the `Mermaid · <type>` caption.
- `min(available, …)`: never exceed available — so the inline markdown path can't re-wrap the frame, and a genuinely-too-wide diagram still clips cleanly at the edge.

Applies to BOTH the render_mermaid tool and inline ```mermaid blocks (shared helper).

## Verified
- 77-wide diagram at avail=240 → frame **81 wide** (was 240), 1-space padding each side.
- Inline small diagram at avail=200 → frame **26 wide**, all lines <= 200.
- renderer test: rectangular frame, snug (< 90) at avail=200, single F5 frame, no Diagram bar.
- 102 mermaid/markdown/output-block/matrix tests green; tsgo + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)