### PR TITLE
fix(mermaid): expand node spacing toward the available width

### DIFF
--- a/packages/coding-agent/src/modes/theme/mermaid-cache.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-cache.ts
@@ -41,6 +41,33 @@ export interface RenderMermaidThemedOptions {
 	colorMode?: MermaidColorMode;
 	/** Extra layout options (padding, useAscii, …). */
 	render?: MermaidAsciiRenderOptions;
+	/**
+	 * Available content width. When set (and paddingX isn't overridden), node spacing
+	 * is expanded toward this width so the diagram uses the available space instead of
+	 * rendering tiny — capped so small diagrams don't sprawl.
+	 */
+	targetWidth?: number;
+}
+
+const DEFAULT_PADDING_X = 2;
+const DEFAULT_PADDING_Y = 1;
+// Candidate horizontal spacings (ascending). Widening paddingX grows width WITHOUT
+// growing height, so we can use much of the terminal; capped so a tiny diagram
+// doesn't sprawl into absurdly long edges on a very wide terminal.
+const PADDING_X_CANDIDATES = [1, 2, 4, 6, 8, 10, 12, 16, 20, 24];
+
+/** Largest candidate paddingX whose rendered width still fits targetWidth (>= smallest). */
+function pickPaddingXForWidth(source: string, targetWidth: number): number {
+	let best = PADDING_X_CANDIDATES[0]!;
+	for (const px of PADDING_X_CANDIDATES) {
+		const out = renderMermaidAsciiSafe(source, { colorMode: "none", paddingX: px, paddingY: DEFAULT_PADDING_Y });
+		if (out == null) break;
+		let w = 0;
+		for (const line of out.split("\n")) w = Math.max(w, Bun.stringWidth(line));
+		if (w <= targetWidth) best = px;
+		else break; // wider candidates only grow; stop early (also avoids costly large-padding renders)
+	}
+	return best;
 }
 
 /**
@@ -54,25 +81,27 @@ export function renderMermaidThemed(source: string, theme: Theme, opts?: RenderM
 	if (mermaidSourceExceedsLimit(source)) return null;
 
 	const mode = colorModeFor(theme, opts?.colorMode);
-	// Layout options (useAscii, padding, …) change the output, so they must be part
-	// of the key. Omitted when absent so the key matches mermaidThemeSignature() —
-	// the no-options form used by the inline-markdown prerender/lookup path.
-	const optsSig = opts?.render && Object.keys(opts.render).length > 0 ? `|${JSON.stringify(opts.render)}` : "";
+	const baseRender = opts?.render ?? {};
+	// Resolve horizontal spacing: explicit override wins; else expand toward the target
+	// width (capped) so the diagram uses the space; else the compact default.
+	const paddingX =
+		baseRender.paddingX ??
+		(opts?.targetWidth !== undefined ? pickPaddingXForWidth(source, opts.targetWidth) : DEFAULT_PADDING_X);
+	const renderOpts: MermaidAsciiRenderOptions = { paddingY: DEFAULT_PADDING_Y, ...baseRender, paddingX };
+
+	// Layout options change the output, so they must be part of the key — but the
+	// compact DEFAULT is treated as "no options" so the key still matches
+	// mermaidThemeSignature()/getMermaidAscii() (the inline prerender/lookup path).
+	const sigObj: Record<string, unknown> = { ...renderOpts };
+	if (sigObj.paddingX === DEFAULT_PADDING_X) delete sigObj.paddingX;
+	if (sigObj.paddingY === DEFAULT_PADDING_Y) delete sigObj.paddingY;
+	const optsSig = Object.keys(sigObj).length > 0 ? `|${JSON.stringify(sigObj)}` : "";
 	const key = `${Bun.hash(source.trim())}|${mode}:${paletteSignature(theme)}${optsSig}`;
 	const cached = cache.get(key);
 	if (cached !== undefined) return cached;
 
 	const asciiTheme = buildMermaidAsciiTheme(theme);
-	// Compact defaults: beautiful-mermaid's paddingX/paddingY of 5 spreads nodes far
-	// apart and bloats the diagram. Tighter spacing reads more elegantly and helps it
-	// fit the transcript width. Callers can still override via opts.render.
-	const colored = renderMermaidAsciiSafe(source, {
-		paddingX: 2,
-		paddingY: 1,
-		...opts?.render,
-		colorMode: mode,
-		theme: asciiTheme,
-	});
+	const colored = renderMermaidAsciiSafe(source, { ...renderOpts, colorMode: mode, theme: asciiTheme });
 	if (colored == null) {
 		cache.set(key, null);
 		return null;

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -2513,7 +2513,7 @@ export function getMarkdownTheme(): MarkdownTheme {
 		symbols: getSymbolTheme(),
 		getMermaidAscii: (hash: bigint | number) => getMermaidAscii(hash, mermaidThemeSignature(theme)),
 		renderMermaidBlock: (source: string, width: number): string[] | null => {
-			const diagram = renderMermaidThemed(source, theme);
+			const diagram = renderMermaidThemed(source, theme, { targetWidth: Math.max(20, width - 4) });
 			if (!diagram) return null;
 			return renderOutputBlock(
 				buildMermaidBlockOptions(diagram, { width, theme, typeLabel: diagramTypeLabel(detectDiagramType(source)) }),

--- a/packages/coding-agent/src/tools/mermaid-renderer.ts
+++ b/packages/coding-agent/src/tools/mermaid-renderer.ts
@@ -101,13 +101,16 @@ export const mermaidRenderer = {
 
 		// Prefer re-rendering from the original source: themed, per-node-tinted, colored.
 		const source = args?.mermaid?.trim();
-		const diagramText = (source ? renderMermaidThemed(source, uiTheme) : null) ?? plainText;
 		const typeLabel = source ? diagramTypeLabel(detectDiagramType(source)) : "diagram";
 		const artifactId = result.details?.artifactId;
 
 		const block = new CachedOutputBlock();
 		return {
 			render(width: number): string[] {
+				// Expand the diagram toward the available width (inside the frame), then
+				// size the frame snugly around the result.
+				const targetWidth = Math.max(20, width - 4);
+				const diagramText = (source ? renderMermaidThemed(source, uiTheme, { targetWidth }) : null) ?? plainText;
 				return block.render(
 					buildMermaidBlockOptions(diagramText, { width, theme: uiTheme, typeLabel, artifactId }),
 					uiTheme,

--- a/packages/coding-agent/test/mermaid-cache.test.ts
+++ b/packages/coding-agent/test/mermaid-cache.test.ts
@@ -14,6 +14,27 @@ const sgr = (s: string): Set<string> => new Set(s.match(/\x1b\[[0-9;]*m/g) ?? []
 
 beforeEach(() => clearMermaidCache());
 
+describe("adaptive width (targetWidth)", () => {
+	const wmax = (s: string): number => Math.max(...s.split("\n").map(l => Bun.stringWidth(l)));
+
+	it("widens node spacing toward the target width (less conservative)", async () => {
+		const theme = (await getThemeByName("xcsh-dark"))!;
+		const src = "graph LR\n A[Client] --> B[GSLB] --> C[Pool] --> D[Origin]";
+		const compact = renderMermaidThemed(src, theme, { colorMode: "none" })!; // default paddingX
+		const wide = renderMermaidThemed(src, theme, { colorMode: "none", targetWidth: 200 })!;
+		expect(wmax(wide)).toBeGreaterThan(wmax(compact)); // spread out to use more width
+		expect(wmax(wide)).toBeLessThanOrEqual(200); // …but within the target
+	});
+
+	it("uses the smallest spacing for a tight target (no wider than the default)", async () => {
+		const theme = (await getThemeByName("xcsh-dark"))!;
+		const src = "graph LR\n A[Client] --> B[GSLB] --> C[Pool] --> D[Origin]";
+		const compact = renderMermaidThemed(src, theme, { colorMode: "none" })!; // default paddingX 2
+		const tight = renderMermaidThemed(src, theme, { colorMode: "none", targetWidth: 30 })!; // → smallest paddingX
+		expect(wmax(tight)).toBeLessThanOrEqual(wmax(compact));
+	});
+});
+
 describe("renderMermaidThemed", () => {
 	it("produces colorized output with several distinct SGR colors", async () => {
 		const theme = await getThemeByName("xcsh-dark");


### PR DESCRIPTION
Closes #1600

## Problem
Diagrams rendered at a fixed compact `paddingX:2` and stayed small — a wide terminal was mostly empty (a GSLB diagram used ~30–48% of the width). They should take up more of the available width.

## Fix
`renderMermaidThemed` now accepts `targetWidth` and picks the largest `paddingX` (from a capped candidate list, 1..24) whose rendered width still fits. Key insight: widening `paddingX` grows **width without height**, so:
- the GSLB sample roughly **doubles** (75 → 145 wide; fills 73% at avail=200) with the **same height**,
- a tiny 2-node diagram stays a reasonable ~44 wide (the cap prevents sparse sprawl).

Both the render_mermaid tool result and inline ```mermaid blocks pass the available width; the snug frame then sizes around the result. The measurement loop renders in `none` mode and early-breaks, and is bounded by the existing oversize guard.

## Tests
- adaptive: a diagram widens toward a 200 target (wider than the compact default) but stays within it; a tight target falls back to the smallest spacing.
- 58 mermaid/markdown/matrix tests green; tsgo + biome clean.

## Note
On a very wide terminal the cap (paddingX 24) means the diagram fills a large portion but not 100% — going further would create absurdly long edges between far-apart nodes. Happy to tune the cap if you want it denser or looser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)