### PR TITLE
fix(mermaid): professional restrained color palette (drop the rainbow)

### DIFF
--- a/packages/coding-agent/src/modes/theme/mermaid-palette.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-palette.ts
@@ -1,7 +1,8 @@
 /**
- * Map the active xcsh UI theme onto a mermaid `AsciiTheme` (per-role hues) and a
- * cycling list of node-accent ANSI escapes for the per-node tint pass. Reading the
- * theme keeps diagrams on-brand and dark/light adaptive.
+ * Map the active xcsh UI theme onto a mermaid `AsciiTheme`. The palette is
+ * deliberately restrained and professional: neutral gray structure with a single
+ * F5-brand accent on the arrowheads — no rainbow of per-node colors. Reading the
+ * theme keeps it dark/light adaptive and on-brand.
  */
 import type { MermaidAsciiRenderOptions } from "@f5xc-salesdemos/pi-utils";
 import type { Theme } from "./theme";
@@ -9,35 +10,30 @@ import type { Theme } from "./theme";
 type AsciiTheme = NonNullable<MermaidAsciiRenderOptions["theme"]>;
 
 /**
- * Per-role color palette: red node borders, gold labels, blue edges, green
- * arrowheads. These show through wherever the per-node tint pass doesn't apply
- * (edges, arrows, subgraph frames, and as the fallback when tinting is skipped).
+ * Restrained per-role palette — neutral grays for the diagram structure, with one
+ * brand accent on the arrowheads:
+ *   labels  → neutral text gray
+ *   borders → soft gray
+ *   edges   → dim gray (recede behind the boxes)
+ *   arrows  → F5 brand accent (the single pop of color)
+ * Nodes render uniformly (see buildNodeAccents — no per-node tint).
  */
 export function buildMermaidAsciiTheme(theme: Theme): AsciiTheme {
 	return {
-		fg: theme.getFgHex("mdHeading", "#febc38"), // node/edge labels
-		border: theme.getFgHex("accent", "#ca260a"), // node + subgraph borders
-		line: theme.getFgHex("mdLink", "#0088fa"), // edge lines
-		arrow: theme.getFgHex("success", "#00ff88"), // arrowheads
-		corner: theme.getFgHex("mdLink", "#0088fa"),
-		junction: theme.getFgHex("accent", "#ca260a"),
+		fg: theme.getFgHex("toolOutput", "#9ca3b0"), // node + edge labels
+		border: theme.getFgHex("muted", "#9ca3b0"), // node + subgraph borders
+		line: theme.getFgHex("dim", "#6b7280"), // edge lines — subtle
+		arrow: theme.getFgHex("accent", "#ca260a"), // arrowheads — single brand accent
+		corner: theme.getFgHex("dim", "#6b7280"),
+		junction: theme.getFgHex("muted", "#9ca3b0"),
 	};
 }
 
 /**
- * ANSI foreground escapes cycled across detected node boxes so each node reads as
- * a distinct hue. Drawn from vivid, well-separated theme roles.
+ * Per-node accent colors for the tint pass. Intentionally EMPTY: a professional
+ * diagram reads as one consistent palette, not a different bright hue per box.
+ * With no accents, the tint pass is a no-op and nodes use the role colors above.
  */
-export function buildNodeAccents(theme: Theme): string[] {
-	const roles = ["chromeAccent", "success", "warning", "mdLink", "accent"] as const;
-	const seen = new Set<string>();
-	const accents: string[] = [];
-	for (const role of roles) {
-		const ansi = theme.getFgAnsi(role);
-		if (!seen.has(ansi)) {
-			seen.add(ansi);
-			accents.push(ansi);
-		}
-	}
-	return accents;
+export function buildNodeAccents(_theme: Theme): string[] {
+	return [];
 }

--- a/packages/coding-agent/test/mermaid-palette.test.ts
+++ b/packages/coding-agent/test/mermaid-palette.test.ts
@@ -19,15 +19,16 @@ describe("Theme.getFgHex", () => {
 });
 
 describe("buildMermaidAsciiTheme", () => {
-	it("maps roles to a multi-hue, all-hex AsciiTheme", async () => {
+	it("maps roles to a restrained all-hex palette (neutral structure + one accent)", async () => {
 		const theme = await getThemeByName("xcsh-dark");
 		const ascii = buildMermaidAsciiTheme(theme!);
 		for (const role of ["fg", "border", "line", "arrow"] as const) {
 			expect(isHex(ascii[role] as string)).toBe(true);
 		}
-		// Multi-hue: borders, edges, and arrows are not all the same color.
-		const distinct = new Set([ascii.fg, ascii.border, ascii.line, ascii.arrow]);
-		expect(distinct.size).toBeGreaterThanOrEqual(3);
+		// Professional, not rainbow: the arrow is the single accent and stands out from
+		// the neutral structure; edges recede behind the labels.
+		expect(ascii.arrow).not.toBe(ascii.border);
+		expect(ascii.line).not.toBe(ascii.fg);
 	});
 
 	it("differs between dark and light themes", async () => {
@@ -38,13 +39,8 @@ describe("buildMermaidAsciiTheme", () => {
 });
 
 describe("buildNodeAccents", () => {
-	it("returns several distinct ANSI foreground escapes", async () => {
+	it("returns no per-node accents (uniform, non-rainbow nodes)", async () => {
 		const theme = await getThemeByName("xcsh-dark");
-		const accents = buildNodeAccents(theme!);
-		expect(accents.length).toBeGreaterThanOrEqual(3);
-		// All are SGR foreground sequences.
-		for (const a of accents) expect(a).toMatch(/^\x1b\[[0-9;]*m$/);
-		// They are distinct.
-		expect(new Set(accents).size).toBe(accents.length);
+		expect(buildNodeAccents(theme!)).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/mermaid-renderer.test.ts
+++ b/packages/coding-agent/test/mermaid-renderer.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import { sanitizeText } from "@f5xc-salesdemos/pi-natives";
 import { clearMermaidCache } from "@f5xc-salesdemos/xcsh/modes/theme/mermaid-cache";
-import { buildNodeAccents } from "@f5xc-salesdemos/xcsh/modes/theme/mermaid-palette";
 import { getThemeByName } from "@f5xc-salesdemos/xcsh/modes/theme/theme";
 import { mermaidRenderer } from "@f5xc-salesdemos/xcsh/tools/mermaid-renderer";
 
@@ -19,19 +18,19 @@ describe("mermaidRenderer.renderResult", () => {
 		expect(plain).not.toContain("PLACEHOLDER");
 	});
 
-	it("colorizes with per-node accents (not a single flat color)", async () => {
+	it("colorizes with a restrained palette (the F5 accent, not a rainbow)", async () => {
 		const theme = (await getThemeByName("xcsh-dark"))!;
 		const result = { content: [{ type: "text", text: "" }], isError: false };
 		const raw = mermaidRenderer
 			.renderResult(result, { expanded: false, isPartial: false }, theme, { mermaid: SRC })
 			.render(100)
 			.join("\n");
-		// At least one node-tint accent is present → the tint pass ran.
-		const accents = buildNodeAccents(theme);
-		expect(accents.some(a => raw.includes(a))).toBe(true);
-		// Many distinct SGR colors, unlike the old flat single-color render.
-		const distinct = new Set(raw.match(/\x1b\[[0-9;]*m/g) ?? []);
-		expect(distinct.size).toBeGreaterThanOrEqual(6);
+		// The single brand accent (arrowheads / frame) is present…
+		expect(raw).toContain(theme.getFgAnsi("accent"));
+		// …and the diagram is colorized but NOT a rainbow — only a few distinct fg colors.
+		const fgColors = new Set(raw.match(/\x1b\[38;2;[0-9;]+m/g) ?? []);
+		expect(fgColors.size).toBeGreaterThanOrEqual(2);
+		expect(fgColors.size).toBeLessThanOrEqual(5);
 	});
 
 	it("renders the full diagram without a '… N more lines' truncation", async () => {


### PR DESCRIPTION
Closes #1602

## Problem
Too colorful ("clown theme"): a multi-hue per-role palette (red borders, gold labels, blue edges, green arrows) **plus** a 5-color rainbow per-node tint (every box a different bright color).

## Fix
A restrained, consistent, on-brand palette:
- **labels + borders** → neutral gray
- **edges** → dim gray (recede behind the boxes)
- **arrows** → single **F5-red** accent
- **nodes** → uniform (per-node rainbow removed; `buildNodeAccents` returns `[]`, making the tint pass a no-op)

Result: **3 colors instead of ~8** — professional and familiar, not flashy. Dark/light adaptive (reads theme roles).

## Tests
- palette: restrained all-hex mapping (arrow accent stands out; edges recede); `buildNodeAccents` returns `[]`.
- renderer: the F5 accent is present and only a few distinct colors (2–5), not a rainbow.
- 76 mermaid/markdown/matrix tests green; tsgo + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)