### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,3 @@ pi-*.html
 packages/coding-agent/src/internal-urls/docs-index.generated.ts
 packages/coding-agent/src/internal-urls/build-info.generated.ts
 packages/typescript-edit-benchmark/runs/
-
-# UAT matrix run artifacts
-uat-matrix/reports/


### PR DESCRIPTION
Closes #1609

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .gitignore