### PR TITLE
fix: strip trailing slash from ResourceClient apiUrl (prevents host collapse)

### DIFF
--- a/packages/resource-management/src/resource-client.ts
+++ b/packages/resource-management/src/resource-client.ts
@@ -103,7 +103,11 @@ export class ResourceClient {
 	readonly #transport: HttpTransport;
 
 	constructor(options: ResourceClientOptions) {
-		this.#apiUrl = options.apiUrl;
+		// Strip trailing slash(es) so `#buildUrl`'s `${apiUrl}${path}` concat (path
+		// templates begin with `/api/...`) cannot emit `//`, which a consumer's
+		// `new URL()` would parse as a protocol-relative authority and collapse the
+		// request host to a bare label.
+		this.#apiUrl = options.apiUrl.replace(/\/+$/, "");
 		this.#defaultNamespace = options.namespace;
 		this.#resolvePayloadVars = options.resolvePayloadVars;
 		this.#transport = options.transport ?? new FetchTransport(options.apiToken);

--- a/packages/resource-management/test/resource-client-transport.test.ts
+++ b/packages/resource-management/test/resource-client-transport.test.ts
@@ -177,3 +177,43 @@ describe("ResourceClient with custom transport", () => {
 		expect(result.status).toBe("created");
 	});
 });
+
+describe("ResourceClient apiUrl normalization", () => {
+	test("a trailing-slash apiUrl does not produce a double slash in the request URL", async () => {
+		const transport = new MockTransport();
+		transport.response = {
+			httpStatus: 200,
+			body: { metadata: { name: "lb-1" }, spec: {} },
+		};
+
+		const client = new ResourceClient({
+			// Note the trailing slash: previously this yielded `.../api//api/...`.
+			apiUrl: "https://host.example.com/api/",
+			apiToken: "test-token",
+			namespace: "default",
+			transport,
+		});
+
+		await client.exportOne("http_loadbalancer", dummyResolvedKind, "lb-1", "default");
+
+		const url = transport.calls[0].url;
+		// The regression: a trailing slash must not introduce a `//` (which a consumer's
+		// `new URL()` would read as a protocol-relative authority, collapsing the host).
+		expect(url.slice("https://".length).includes("//")).toBe(false);
+		// With the trailing slash normalized away, the URL matches the non-trailing-slash
+		// form exactly (the leading `/api` is the path template; apiUrl supplies the rest).
+		expect(url).toBe("https://host.example.com/api/api/config/namespaces/default/http_loadbalancers/lb-1");
+	});
+
+	test("a trailing-slash apiUrl produces the same URL as one without", async () => {
+		async function urlFor(apiUrl: string): Promise<string> {
+			const transport = new MockTransport();
+			transport.response = { httpStatus: 200, body: { metadata: { name: "lb-1" }, spec: {} } };
+			const client = new ResourceClient({ apiUrl, apiToken: "test-token", namespace: "default", transport });
+			await client.exportOne("http_loadbalancer", dummyResolvedKind, "lb-1", "default");
+			return transport.calls[0].url;
+		}
+
+		expect(await urlFor("https://host.example.com/api/")).toBe(await urlFor("https://host.example.com/api"));
+	});
+});


### PR DESCRIPTION
## Summary

`ResourceClient.#buildUrl` builds request URLs by raw concatenation `${apiUrl}${path}`, where path templates begin with `/api/...`. When `apiUrl` ended with a slash (e.g. `https://host.example.com/api/`), the result contained a double slash (`.../api//api/...`).

A consumer that strips the base URL from the transport request and re-resolves the remainder with `new URL()` then sees a leading `//`, which is parsed as a **protocol-relative authority** — collapsing the request host to a bare label (e.g. `api`). This surfaced as a TLS altnames mismatch in the VS Code extension's resource export (vscode-xcsh#569).

## Fix

Normalize `apiUrl` once in the `ResourceClient` constructor by stripping trailing slash(es), so `#buildUrl` can never emit `//`. This is the origin fix; consumers (e.g. vscode-xcsh) also harden their own URL handling defensively.

## Tests

Added transport tests asserting a trailing-slash `apiUrl` produces no `//` and the same request URL as one without a trailing slash.

- Full `resource-management` suite: **141 pass / 0 fail**; `tsgo` types clean; biome clean.

Closes #1650