### PR TITLE
fix: store the context API URL as origin only (strip path/query/fragment)

### DIFF
--- a/packages/coding-agent/src/services/xcsh-context.ts
+++ b/packages/coding-agent/src/services/xcsh-context.ts
@@ -7,6 +7,7 @@ import { XCSHApiClient } from "./xcsh-api-client";
 import {
 	deriveTenantFromUrl,
 	hasEnvOverride,
+	normalizeApiUrl,
 	RESERVED_ENV_KEYS,
 	RESERVED_ENV_MESSAGES,
 	XCSH_API_TOKEN,
@@ -572,6 +573,8 @@ export class ContextService {
 		fs.mkdirSync(this.#configDir, { recursive: true, mode: 0o700 });
 		const data: XCSHContext = {
 			...context,
+			// Store the endpoint as origin only; callers append `/api/...` paths.
+			apiUrl: normalizeApiUrl(context.apiUrl),
 			version: CURRENT_SCHEMA_VERSION,
 			metadata: { createdAt: new Date().toISOString() },
 		};
@@ -1356,7 +1359,12 @@ export class ContextService {
 			}
 			const content = fs.readFileSync(filePath, "utf-8");
 			const parsed = JSON.parse(content);
-			return this.#validateContextShape(parsed, name);
+			const context = this.#validateContextShape(parsed, name);
+			// Heal pre-existing files whose apiUrl carries a path/query/trailing slash.
+			if (context && typeof context.apiUrl === "string") {
+				return { ...context, apiUrl: normalizeApiUrl(context.apiUrl) };
+			}
+			return context;
 		} catch (err) {
 			logger.warn("XCSH context read error", { name, error: String(err) });
 			return null;

--- a/packages/coding-agent/src/services/xcsh-env.ts
+++ b/packages/coding-agent/src/services/xcsh-env.ts
@@ -69,3 +69,25 @@ export function deriveTenantFromUrl(url: string): string | null {
 	const label = hostname.split(".")[0].toLowerCase();
 	return DNS_LABEL_RE.test(label) ? label : null;
 }
+
+/**
+ * Reduce an API URL to its origin (`https://host[:port]`) — the canonical stored
+ * form for a context endpoint.
+ *
+ * Strips any path, query, fragment, or trailing slash so the stored value is the
+ * bare origin: callers append `/api/...` (and other path patterns) themselves,
+ * keeping one consistent value that other tooling can reuse (e.g. a
+ * browser-automation login URL that cannot carry a suffix). This also prevents a
+ * pasted browser URL (e.g. `https://host/web/home?iss=...`) from corrupting the
+ * `${apiUrl}${path}` joins in XCSHApiClient / ResourceClient. Falls back to
+ * trailing-slash stripping for an unparseable value.
+ */
+export function normalizeApiUrl(url: string): string {
+	if (typeof url !== "string") return url;
+	const trimmed = url.trim();
+	try {
+		return new URL(trimmed).origin;
+	} catch {
+		return trimmed.replace(/\/+$/, "");
+	}
+}

--- a/packages/coding-agent/test/xcsh-context-service.test.ts
+++ b/packages/coding-agent/test/xcsh-context-service.test.ts
@@ -482,6 +482,19 @@ describe("ContextService", () => {
 			expect(Number.isNaN(Date.parse(data.metadata.createdAt))).toBe(false);
 		});
 
+		it("normalizes a pasted full URL to its origin on create", async () => {
+			const service = ContextService.init(xcshConfigDir);
+			await service.createContext({
+				name: "pasted-prof",
+				apiUrl: "https://new.console.ves.volterra.io/web/home?iss=https%3A%2F%2Flogin.example%2Frealms%2Fx",
+				apiToken: "tok",
+				defaultNamespace: "ns1",
+			});
+
+			const data = JSON.parse(fs.readFileSync(path.join(xcshContextsDir, "pasted-prof.json"), "utf-8"));
+			expect(data.apiUrl).toBe("https://new.console.ves.volterra.io");
+		});
+
 		it("creates contexts directory if it does not exist", async () => {
 			expect(fs.existsSync(xcshContextsDir)).toBe(false);
 

--- a/packages/coding-agent/test/xcsh-env.test.ts
+++ b/packages/coding-agent/test/xcsh-env.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
 	deriveTenantFromUrl,
 	hasEnvOverride,
+	normalizeApiUrl,
 	XCSH_API_TOKEN,
 	XCSH_API_URL,
 	XCSH_NAMESPACE,
@@ -96,6 +97,36 @@ describe("xcsh-env", () => {
 
 		it("returns '192' for an IP-address URL (documented edge case: numeric DNS labels are valid)", () => {
 			expect(deriveTenantFromUrl("https://192.168.1.1")).toBe("192");
+		});
+	});
+
+	describe("normalizeApiUrl", () => {
+		it("leaves an origin-only URL unchanged (idempotent)", () => {
+			expect(normalizeApiUrl("https://tenant.console.ves.volterra.io")).toBe(
+				"https://tenant.console.ves.volterra.io",
+			);
+		});
+
+		it("strips a trailing slash", () => {
+			expect(normalizeApiUrl("https://host.example.com/")).toBe("https://host.example.com");
+		});
+
+		it("strips an /api path suffix to the origin", () => {
+			expect(normalizeApiUrl("https://host.example.com/api")).toBe("https://host.example.com");
+		});
+
+		it("reduces a pasted full browser URL to its origin", () => {
+			const pasted =
+				"https://f5-amer-ent.console.ves.volterra.io/web/home?iss=https%3A%2F%2Flogin.ves.volterra.io%2Fauth%2Frealms%2Ff5-amer-ent-x";
+			expect(normalizeApiUrl(pasted)).toBe("https://f5-amer-ent.console.ves.volterra.io");
+		});
+
+		it("preserves a non-default port", () => {
+			expect(normalizeApiUrl("https://host.example.com:9443/api")).toBe("https://host.example.com:9443");
+		});
+
+		it("falls back to trailing-slash stripping for an unparseable value", () => {
+			expect(normalizeApiUrl("not-a-url/")).toBe("not-a-url");
 		});
 	});
 });

--- a/packages/resource-management/src/resource-client.ts
+++ b/packages/resource-management/src/resource-client.ts
@@ -103,7 +103,11 @@ export class ResourceClient {
 	readonly #transport: HttpTransport;
 
 	constructor(options: ResourceClientOptions) {
-		this.#apiUrl = options.apiUrl;
+		// Strip trailing slash(es) so `#buildUrl`'s `${apiUrl}${path}` concat (path
+		// templates begin with `/api/...`) cannot emit `//`, which a consumer's
+		// `new URL()` would parse as a protocol-relative authority and collapse the
+		// request host to a bare label.
+		this.#apiUrl = options.apiUrl.replace(/\/+$/, "");
 		this.#defaultNamespace = options.namespace;
 		this.#resolvePayloadVars = options.resolvePayloadVars;
 		this.#transport = options.transport ?? new FetchTransport(options.apiToken);

--- a/packages/resource-management/test/resource-client-transport.test.ts
+++ b/packages/resource-management/test/resource-client-transport.test.ts
@@ -177,3 +177,43 @@ describe("ResourceClient with custom transport", () => {
 		expect(result.status).toBe("created");
 	});
 });
+
+describe("ResourceClient apiUrl normalization", () => {
+	test("a trailing-slash apiUrl does not produce a double slash in the request URL", async () => {
+		const transport = new MockTransport();
+		transport.response = {
+			httpStatus: 200,
+			body: { metadata: { name: "lb-1" }, spec: {} },
+		};
+
+		const client = new ResourceClient({
+			// Note the trailing slash: previously this yielded `.../api//api/...`.
+			apiUrl: "https://host.example.com/api/",
+			apiToken: "test-token",
+			namespace: "default",
+			transport,
+		});
+
+		await client.exportOne("http_loadbalancer", dummyResolvedKind, "lb-1", "default");
+
+		const url = transport.calls[0].url;
+		// The regression: a trailing slash must not introduce a `//` (which a consumer's
+		// `new URL()` would read as a protocol-relative authority, collapsing the host).
+		expect(url.slice("https://".length).includes("//")).toBe(false);
+		// With the trailing slash normalized away, the URL matches the non-trailing-slash
+		// form exactly (the leading `/api` is the path template; apiUrl supplies the rest).
+		expect(url).toBe("https://host.example.com/api/api/config/namespaces/default/http_loadbalancers/lb-1");
+	});
+
+	test("a trailing-slash apiUrl produces the same URL as one without", async () => {
+		async function urlFor(apiUrl: string): Promise<string> {
+			const transport = new MockTransport();
+			transport.response = { httpStatus: 200, body: { metadata: { name: "lb-1" }, spec: {} } };
+			const client = new ResourceClient({ apiUrl, apiToken: "test-token", namespace: "default", transport });
+			await client.exportOne("http_loadbalancer", dummyResolvedKind, "lb-1", "default");
+			return transport.calls[0].url;
+		}
+
+		expect(await urlFor("https://host.example.com/api/")).toBe(await urlFor("https://host.example.com/api"));
+	});
+});


### PR DESCRIPTION
## Summary

The `/context` add-wizard and `context add` command stored the API URL exactly as typed. A user can paste a full console/browser URL (e.g. `https://f5-amer-ent.console.ves.volterra.io/web/home?iss=https%3A%2F%2Flogin.ves.volterra.io%2Fauth%2Frealms%2F...`); the path/query/fragment were kept and corrupted the `${apiUrl}${path}` joins in `XCSHApiClient` / `ResourceClient`. These context files are shared on disk (`~/.config/xcsh/contexts/`) and also read by the VS Code extension.

## Change

- New `normalizeApiUrl` helper in `xcsh-env.ts`: `new URL(input).origin` (scheme + host + non-default port) with a safe fallback.
- Applied in `ContextService.createContext` (write) and `#readContext` (heal pre-existing files on read).

**Origin-only is the canonical stored form** — callers append `/api` (and other path patterns) themselves, so the endpoint stays one consistent value reusable by other tooling (e.g. a browser-automation login URL that cannot carry a suffix).

## Tests

- `normalizeApiUrl`: origin idempotence, trailing slash, `/api` suffix, full pasted-browser-URL example, non-default port, unparseable fallback.
- `ContextService.createContext`: a pasted full URL is stored as origin only.
- Affected suites: **300 tests pass**, biome clean. (Pre-existing unrelated `check:types` errors in `test/resource-management/*` are not touched by this change.)

## Companion

VS Code extension counterpart: vscode-xcsh#579 / vscode-xcsh#580.

Closes #1656