### PR TITLE
feat(utils): host-agnostic /context resolver core + parity hardening (Phase 1)

### DIFF
--- a/packages/coding-agent/src/services/xcsh-context.ts
+++ b/packages/coding-agent/src/services/xcsh-context.ts
@@ -1,6 +1,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { ContextResolver, getXCSHConfigDir, logger } from "@f5xc-salesdemos/pi-utils";
+import {
+	ContextResolver,
+	getXCSHConfigDir,
+	logger,
+	RESERVED_CONTEXT_NAMES,
+	xcshContextPaths,
+} from "@f5xc-salesdemos/pi-utils";
 import { Settings } from "../config/settings";
 import { SECRET_ENV_PATTERNS } from "../secrets/index";
 import { XCSHApiClient } from "./xcsh-api-client";
@@ -19,28 +25,6 @@ import {
 export const CURRENT_SCHEMA_VERSION = 1;
 
 export const CURRENT_EXPORT_VERSION = 1;
-
-export const RESERVED_CONTEXT_NAMES = new Set([
-	"list",
-	"show",
-	"status",
-	"create",
-	"delete",
-	"rename",
-	"namespace",
-	"env",
-	"set",
-	"unset",
-	"add",
-	"remove",
-	"clear",
-	"activate",
-	"validate",
-	"export",
-	"import",
-	"wizard",
-	"help",
-]);
 
 export interface ExportBundle {
 	/** Export format version — distinct from per-context XCSHContext.version (schema version). */
@@ -387,7 +371,7 @@ export class ContextService {
 
 		// FR-201: Check for project-local context in .xcsh/contexts/
 		if (cwd) {
-			const resolver = new ContextResolver();
+			const resolver = new ContextResolver({ paths: xcshContextPaths });
 			const localResult = await resolver.resolve(cwd);
 			if (localResult && localResult.source === "local") {
 				const localContext = localResult.context as XCSHContext;

--- a/packages/coding-agent/test/context-completion.test.ts
+++ b/packages/coding-agent/test/context-completion.test.ts
@@ -214,7 +214,7 @@ describe("/context unset completion", () => {
 	it("value for multi-key mode preserves head so infra prepending produces the correct full argument", async () => {
 		await setupWithEnvContext();
 		const unset = getContextSubcommand("unset");
-		const items = unset.getArgumentCompletions!("XCSH_EMAIL F");
+		const items = unset.getArgumentCompletions!("XCSH_EMAIL XCSH_USER");
 		const pick = items?.find(i => i.label === "XCSH_USERNAME");
 		expect(pick).toBeDefined();
 		// Provider-scoped value: "XCSH_EMAIL XCSH_USERNAME ". Infra layer prepends "unset ".
@@ -227,7 +227,7 @@ describe("/context unset completion", () => {
 		// User typed XCSH_EMAIL in lowercase. unsetEnvVars matches case-sensitively
 		// (`key in env`), so a lowercase token would silently be skipped. The provider
 		// must rewrite the head to the canonical case before infra prepends.
-		const items = unset.getArgumentCompletions!("xcsh_email F");
+		const items = unset.getArgumentCompletions!("xcsh_email XCSH_USER");
 		const pick = items?.find(i => i.label === "XCSH_USERNAME");
 		expect(pick).toBeDefined();
 		expect(pick!.value).toBe("XCSH_EMAIL XCSH_USERNAME ");
@@ -240,7 +240,7 @@ describe("/context unset completion", () => {
 		// normalize it to, so it leaves the token exactly as the user typed. The
 		// handler will report "No matching variables found" rather than silently
 		// replacing the typo with a real key.
-		const items = unset.getArgumentCompletions!("NOPE_KEY F");
+		const items = unset.getArgumentCompletions!("NOPE_KEY XCSH_LB");
 		const pick = items?.find(i => i.label === "XCSH_LB_NAME");
 		expect(pick).toBeDefined();
 		expect(pick!.value).toBe("NOPE_KEY XCSH_LB_NAME ");

--- a/packages/coding-agent/test/core/python-prelude.test.ts
+++ b/packages/coding-agent/test/core/python-prelude.test.ts
@@ -25,15 +25,23 @@ const resolvePythonPath = (): string | null => {
 const pythonPath = resolvePythonPath();
 const hasKernelDeps = (() => {
 	if (!pythonPath) return false;
-	const result = Bun.spawnSync(
-		[
-			pythonPath,
-			"-c",
-			"import importlib.util,sys;sys.exit(0 if importlib.util.find_spec('kernel_gateway') and importlib.util.find_spec('ipykernel') else 1)",
-		],
-		{ stdin: "ignore", stdout: "pipe", stderr: "pipe" },
-	);
-	return result.exitCode === 0;
+	try {
+		// `pythonPath` may resolve to a dangling symlink (e.g. a Homebrew python
+		// upgraded out from under /opt/homebrew/bin/python3). Spawning it then throws
+		// ENOENT — guard so a broken interpreter skips the suite instead of erroring
+		// out of test collection at module load.
+		const result = Bun.spawnSync(
+			[
+				pythonPath,
+				"-c",
+				"import importlib.util,sys;sys.exit(0 if importlib.util.find_spec('kernel_gateway') and importlib.util.find_spec('ipykernel') else 1)",
+			],
+			{ stdin: "ignore", stdout: "pipe", stderr: "pipe" },
+		);
+		return result.exitCode === 0;
+	} catch {
+		return false;
+	}
 })();
 
 const shouldRun = Boolean(pythonPath) && hasKernelDeps;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -37,6 +37,7 @@ export * from "./tab-spacing";
 export * from "./temp";
 export * from "./type-guards";
 export * from "./which";
+export * from "./xcsh-context-paths";
 export * from "./xcsh-context-resolver";
 
 function isPlainObject(val: object): val is Record<string, unknown> {

--- a/packages/utils/src/xcsh-context-paths.ts
+++ b/packages/utils/src/xcsh-context-paths.ts
@@ -1,0 +1,23 @@
+import {
+	getLocalXCSHActiveContextPath,
+	getLocalXCSHContextPath,
+	getLocalXCSHContextsDir,
+	getXCSHActiveContextPath,
+	getXCSHContextPath,
+	getXCSHContextsDir,
+} from "./dirs";
+import type { ContextPathProvider } from "./xcsh-context-resolver";
+
+/**
+ * The xcsh host's path provider for {@link ContextResolver}, wired to the
+ * `dirs.ts` family (`~/.config/xcsh/...`). The VS Code extension supplies its
+ * own provider from `contextPaths.ts`; both must resolve identical directories.
+ */
+export const xcshContextPaths: ContextPathProvider = {
+	getContextsDir: getXCSHContextsDir,
+	getActiveContextPath: getXCSHActiveContextPath,
+	getContextPath: getXCSHContextPath,
+	getLocalContextsDir: (cwd: string) => getLocalXCSHContextsDir(cwd),
+	getLocalActiveContextPath: (cwd: string) => getLocalXCSHActiveContextPath(cwd),
+	getLocalContextPath: (name: string, cwd: string) => getLocalXCSHContextPath(name, cwd),
+};

--- a/packages/utils/src/xcsh-context-resolver.ts
+++ b/packages/utils/src/xcsh-context-resolver.ts
@@ -1,13 +1,6 @@
+import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import {
-	getLocalXCSHActiveContextPath,
-	getLocalXCSHContextPath,
-	getLocalXCSHContextsDir,
-	getXCSHActiveContextPath,
-	getXCSHContextPath,
-	getXCSHContextsDir,
-} from "./dirs";
 
 export interface XCSHContextData {
 	name: string;
@@ -54,6 +47,29 @@ export interface ResolvedContext {
 	context: XCSHContextData;
 	source: ContextSource;
 	sourcePath: string;
+}
+
+/**
+ * Host-supplied path helpers. xcsh injects the `dirs.ts` family; the VS Code
+ * extension injects its `contextPaths.ts` family. Keeping the resolver free of a
+ * direct `dirs.ts` import keeps this module runtime-agnostic (no Bun globals, no
+ * JSON imports) so it bundles cleanly into the VS Code extension via webpack.
+ */
+export interface ContextPathProvider {
+	getContextsDir(): string;
+	getActiveContextPath(): string;
+	getContextPath(name: string): string;
+	getLocalContextsDir(cwd: string): string;
+	getLocalActiveContextPath(cwd: string): string;
+	getLocalContextPath(name: string, cwd: string): string;
+}
+
+export type GitTracker = (filePath: string) => Promise<boolean>;
+
+export interface ResolverDeps {
+	paths: ContextPathProvider;
+	/** Optional override; defaults to a `node:child_process` implementation that runs under both Bun and Node. */
+	gitTracker?: GitTracker;
 }
 
 export function isPointerContext(data: unknown): data is PointerContext {
@@ -110,70 +126,126 @@ export function mergePointerOverrides(base: XCSHContextData, overrides: ContextO
 	return merged;
 }
 
+/**
+ * Subcommand names that must not be usable as context names — otherwise
+ * `/context <name>` could not disambiguate a switch from a subcommand. Single
+ * source of truth shared by both the resolver and the coding agent.
+ */
+export const RESERVED_CONTEXT_NAMES = new Set([
+	"list",
+	"show",
+	"status",
+	"create",
+	"delete",
+	"rename",
+	"namespace",
+	"env",
+	"set",
+	"unset",
+	"add",
+	"remove",
+	"clear",
+	"activate",
+	"validate",
+	"export",
+	"import",
+	"wizard",
+	"help",
+	"link",
+	"unlink",
+]);
+
 const CONTEXT_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
 
 export function isSafeContextName(name: string): boolean {
-	return CONTEXT_NAME_RE.test(name);
+	if (!CONTEXT_NAME_RE.test(name)) return false;
+	return !RESERVED_CONTEXT_NAMES.has(name.toLowerCase());
+}
+
+/**
+ * Normalize an API URL for safe path joining by stripping trailing slash(es).
+ *
+ * The shared resource library joins URLs by raw concatenation
+ * (`${apiUrl}${path}`) where path templates begin with `/api/...`. A trailing
+ * slash produces `https://host/api//api/...`; after the transport strips the
+ * base URL the remainder begins with `//`, which `new URL()` parses as a
+ * protocol-relative authority — collapsing the host to a bare label and breaking
+ * TLS altname verification. Stripping trailing slashes prevents this.
+ */
+export function normalizeApiUrl(apiUrl: string): string {
+	return typeof apiUrl === "string" ? apiUrl.replace(/\/+$/, "") : apiUrl;
+}
+
+function defaultGitTracker(filePath: string): Promise<boolean> {
+	try {
+		const dir = path.dirname(filePath);
+		const res = spawnSync("git", ["ls-files", "--error-unmatch", filePath], {
+			cwd: dir,
+			stdio: "ignore",
+		});
+		return Promise.resolve(res.status === 0);
+	} catch {
+		return Promise.resolve(false);
+	}
 }
 
 export class ContextResolver {
+	readonly #paths: ContextPathProvider;
+	readonly #gitTracker: GitTracker;
+
+	constructor(deps: ResolverDeps) {
+		this.#paths = deps.paths;
+		this.#gitTracker = deps.gitTracker ?? defaultGitTracker;
+	}
+
 	resolve(cwd: string): Promise<ResolvedContext | null> {
 		// Priority 1: environment variables
 		const envUrl = process.env.XCSH_API_URL;
 		const envToken = process.env.XCSH_API_TOKEN;
 		if (envUrl && envToken) {
-			return Promise.resolve({
-				context: {
-					name: "(env)",
-					apiUrl: envUrl,
-					apiToken: envToken,
-					defaultNamespace: process.env.XCSH_NAMESPACE ?? "system",
-				},
-				source: "env",
-				sourcePath: "environment variables",
-			});
+			return Promise.resolve(
+				this.#finalize(
+					{
+						name: "(env)",
+						apiUrl: envUrl,
+						apiToken: envToken,
+						defaultNamespace: process.env.XCSH_NAMESPACE ?? "system",
+					},
+					"env",
+					"environment variables",
+				),
+			);
 		}
 
 		// Priority 2: local .xcsh/contexts/
 		const localDir = this.findLocalContextsDir(cwd);
 		if (localDir) {
-			const localResult = this.#resolveFromDir(localDir, "local", cwd);
+			const localResult = this.#resolveFromDir("local", cwd);
 			if (localResult) return Promise.resolve(localResult);
 		}
 
 		// Priority 3: global ~/.config/xcsh/contexts/
-		const globalResult = this.#resolveGlobal();
-		return Promise.resolve(globalResult);
+		return Promise.resolve(this.#resolveGlobal());
 	}
 
 	findLocalContextsDir(cwd: string): string | null {
-		const dir = getLocalXCSHContextsDir(cwd);
+		const dir = this.#paths.getLocalContextsDir(cwd);
 		return fs.existsSync(dir) ? dir : null;
 	}
 
-	async checkGitTracking(filePath: string): Promise<boolean> {
-		try {
-			const dir = path.dirname(filePath);
-			const proc = Bun.spawn(["git", "ls-files", "--error-unmatch", filePath], {
-				cwd: dir,
-				stdout: "ignore",
-				stderr: "ignore",
-			});
-			const code = await proc.exited;
-			return code === 0;
-		} catch {
-			return false;
-		}
+	checkGitTracking(filePath: string): Promise<boolean> {
+		return this.#gitTracker(filePath);
 	}
 
-	#resolveFromDir(_contextsDir: string, source: ContextSource, cwd: string): ResolvedContext | null {
-		const activeContextPath = source === "local" ? getLocalXCSHActiveContextPath(cwd) : getXCSHActiveContextPath();
+	#resolveFromDir(source: ContextSource, cwd: string): ResolvedContext | null {
+		const activeContextPath =
+			source === "local" ? this.#paths.getLocalActiveContextPath(cwd) : this.#paths.getActiveContextPath();
 
 		const activeName = this.#readActivePointer(activeContextPath);
 		if (!activeName || !isSafeContextName(activeName)) return null;
 
 		const contextPath =
-			source === "local" ? getLocalXCSHContextPath(activeName, cwd) : getXCSHContextPath(activeName);
+			source === "local" ? this.#paths.getLocalContextPath(activeName, cwd) : this.#paths.getContextPath(activeName);
 
 		const data = this.#readJsonFile(contextPath);
 		if (!data) return null;
@@ -182,7 +254,7 @@ export class ContextResolver {
 		if (!validation.valid) return null;
 
 		if (isPointerContext(data)) {
-			return this.#resolvePointer(data, contextPath, cwd);
+			return this.#resolvePointer(data, contextPath);
 		}
 
 		if (isInlineContext(data)) {
@@ -194,25 +266,21 @@ export class ContextResolver {
 			) {
 				return null;
 			}
-			return {
-				context: data as unknown as XCSHContextData,
-				source,
-				sourcePath: contextPath,
-			};
+			return this.#finalize(data as unknown as XCSHContextData, source, contextPath);
 		}
 
 		return null;
 	}
 
 	#resolveGlobal(): ResolvedContext | null {
-		const globalContextsDir = getXCSHContextsDir();
+		const globalContextsDir = this.#paths.getContextsDir();
 		if (!fs.existsSync(globalContextsDir)) return null;
-		return this.#resolveFromDir(globalContextsDir, "global", "");
+		return this.#resolveFromDir("global", "");
 	}
 
-	#resolvePointer(pointer: PointerContext, pointerPath: string, _cwd: string): ResolvedContext | null {
+	#resolvePointer(pointer: PointerContext, pointerPath: string): ResolvedContext | null {
 		if (!isSafeContextName(pointer.context)) return null;
-		const globalPath = getXCSHContextPath(pointer.context);
+		const globalPath = this.#paths.getContextPath(pointer.context);
 		const globalData = this.#readJsonFile(globalPath);
 		if (!globalData) return null;
 
@@ -221,11 +289,15 @@ export class ContextResolver {
 			resolved = mergePointerOverrides(resolved, pointer.overrides);
 		}
 
-		return {
-			context: resolved,
-			source: "local",
-			sourcePath: pointerPath,
-		};
+		// A pointer always resolves through the local tier, so report "local".
+		return this.#finalize(resolved, "local", pointerPath);
+	}
+
+	/** Stamp source/path and normalize the resolved apiUrl uniformly across all sources. */
+	#finalize(context: XCSHContextData, source: ContextSource, sourcePath: string): ResolvedContext {
+		const normalized =
+			typeof context.apiUrl === "string" ? { ...context, apiUrl: normalizeApiUrl(context.apiUrl) } : context;
+		return { context: normalized, source, sourcePath };
 	}
 
 	#readActivePointer(filePath: string): string | null {

--- a/packages/utils/test/xcsh-context-resolver-resolve.test.ts
+++ b/packages/utils/test/xcsh-context-resolver-resolve.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { xcshContextPaths } from "../src/xcsh-context-paths";
 import { ContextResolver } from "../src/xcsh-context-resolver";
 
 describe("ContextResolver.resolve", () => {
@@ -34,7 +35,7 @@ describe("ContextResolver.resolve", () => {
 	});
 
 	it("returns null when no context is configured anywhere", async () => {
-		const resolver = new ContextResolver();
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
 		const result = await resolver.resolve(projectDir);
 		expect(result).toBeNull();
 	});
@@ -42,7 +43,7 @@ describe("ContextResolver.resolve", () => {
 	it("resolves env vars with highest priority", async () => {
 		process.env.XCSH_API_URL = "https://env.example.com";
 		process.env.XCSH_API_TOKEN = "env-token";
-		const resolver = new ContextResolver();
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
 		const result = await resolver.resolve(projectDir);
 		expect(result).not.toBeNull();
 		expect(result!.source).toBe("env");
@@ -70,7 +71,7 @@ describe("ContextResolver.resolve", () => {
 		fs.writeFileSync(path.join(localContextsDir, "local-dev.json"), JSON.stringify(localCtx), { mode: 0o600 });
 		fs.writeFileSync(path.join(localContextsDir, "active_context"), "local-dev", { mode: 0o600 });
 
-		const resolver = new ContextResolver();
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
 		const result = await resolver.resolve(projectDir);
 		expect(result).not.toBeNull();
 		expect(result!.source).toBe("local");
@@ -95,7 +96,7 @@ describe("ContextResolver.resolve", () => {
 		fs.writeFileSync(path.join(localContextsDir, "staging.json"), JSON.stringify(pointer), { mode: 0o600 });
 		fs.writeFileSync(path.join(localContextsDir, "active_context"), "staging", { mode: 0o600 });
 
-		const resolver = new ContextResolver();
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
 		const result = await resolver.resolve(projectDir);
 		expect(result).not.toBeNull();
 		expect(result!.source).toBe("local");
@@ -116,7 +117,7 @@ describe("ContextResolver.resolve", () => {
 		fs.writeFileSync(path.join(globalContextsDir, "fallback.json"), JSON.stringify(globalCtx), { mode: 0o600 });
 		fs.writeFileSync(path.join(globalConfigDir, "active_context"), "fallback", { mode: 0o600 });
 
-		const resolver = new ContextResolver();
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
 		const result = await resolver.resolve(projectDir);
 		expect(result).not.toBeNull();
 		expect(result!.source).toBe("global");
@@ -128,7 +129,7 @@ describe("ContextResolver.resolve", () => {
 		fs.writeFileSync(path.join(localContextsDir, "broken.json"), JSON.stringify(pointer), { mode: 0o600 });
 		fs.writeFileSync(path.join(localContextsDir, "active_context"), "broken", { mode: 0o600 });
 
-		const resolver = new ContextResolver();
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
 		const result = await resolver.resolve(projectDir);
 		expect(result).toBeNull();
 	});
@@ -143,7 +144,7 @@ describe("ContextResolver.resolve", () => {
 		fs.writeFileSync(path.join(globalContextsDir, "global-only.json"), JSON.stringify(globalCtx), { mode: 0o600 });
 		fs.writeFileSync(path.join(globalConfigDir, "active_context"), "global-only", { mode: 0o600 });
 
-		const resolver = new ContextResolver();
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
 		const result = await resolver.resolve(projectDir);
 		expect(result).not.toBeNull();
 		expect(result!.source).toBe("global");
@@ -157,7 +158,7 @@ describe("ContextResolver.resolve", () => {
 		fs.writeFileSync(path.join(localContextsDir, "local.json"), JSON.stringify(localCtx), { mode: 0o600 });
 		fs.writeFileSync(path.join(localContextsDir, "active_context"), "local", { mode: 0o600 });
 
-		const resolver = new ContextResolver();
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
 		const result = await resolver.resolve(projectDir);
 		expect(result!.source).toBe("env");
 	});
@@ -171,7 +172,7 @@ describe("ContextResolver.resolve", () => {
 		fs.writeFileSync(path.join(globalContextsDir, "fallback.json"), JSON.stringify(globalCtx), { mode: 0o600 });
 		fs.writeFileSync(path.join(globalConfigDir, "active_context"), "fallback", { mode: 0o600 });
 
-		const resolver = new ContextResolver();
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
 		const result = await resolver.resolve(projectDir);
 		expect(result!.source).toBe("global");
 	});
@@ -193,12 +194,57 @@ describe("ContextResolver.findLocalContextsDir", () => {
 	it("returns path when .xcsh/contexts/ exists in cwd", () => {
 		const ctxDir = path.join(tmpDir, ".xcsh", "contexts");
 		fs.mkdirSync(ctxDir, { recursive: true });
-		const resolver = new ContextResolver();
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
 		expect(resolver.findLocalContextsDir(tmpDir)).toBe(ctxDir);
 	});
 
 	it("returns null when no .xcsh/contexts/ exists", () => {
-		const resolver = new ContextResolver();
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
 		expect(resolver.findLocalContextsDir(tmpDir)).toBeNull();
+	});
+});
+
+describe("ContextResolver.resolve apiUrl normalization", () => {
+	let tmpDir: string;
+	let projectDir: string;
+	let localContextsDir: string;
+	const originalEnv = { ...process.env };
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-resolver-norm-"));
+		projectDir = path.join(tmpDir, "project");
+		localContextsDir = path.join(projectDir, ".xcsh", "contexts");
+		fs.mkdirSync(localContextsDir, { recursive: true, mode: 0o700 });
+		process.env.XDG_CONFIG_HOME = path.join(tmpDir, "global-config");
+		delete process.env.XCSH_API_URL;
+		delete process.env.XCSH_API_TOKEN;
+	});
+
+	afterEach(() => {
+		process.env = { ...originalEnv };
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("strips trailing slashes from the resolved apiUrl (local inline)", async () => {
+		const localCtx = {
+			name: "local-dev",
+			apiUrl: "https://local.example.com/",
+			apiToken: "l-tok",
+			defaultNamespace: "local-ns",
+		};
+		fs.writeFileSync(path.join(localContextsDir, "local-dev.json"), JSON.stringify(localCtx), { mode: 0o600 });
+		fs.writeFileSync(path.join(localContextsDir, "active_context"), "local-dev", { mode: 0o600 });
+
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
+		const result = await resolver.resolve(projectDir);
+		expect(result!.context.apiUrl).toBe("https://local.example.com");
+	});
+
+	it("strips trailing slashes from the resolved apiUrl (env)", async () => {
+		process.env.XCSH_API_URL = "https://env.example.com/";
+		process.env.XCSH_API_TOKEN = "env-token";
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
+		const result = await resolver.resolve(projectDir);
+		expect(result!.context.apiUrl).toBe("https://env.example.com");
 	});
 });

--- a/packages/utils/test/xcsh-context-resolver.test.ts
+++ b/packages/utils/test/xcsh-context-resolver.test.ts
@@ -3,7 +3,10 @@ import {
 	type ContextOverrides,
 	isInlineContext,
 	isPointerContext,
+	isSafeContextName,
 	mergePointerOverrides,
+	normalizeApiUrl,
+	RESERVED_CONTEXT_NAMES,
 	validateLocalContextFile,
 	type XCSHContextData,
 } from "../src/xcsh-context-resolver";
@@ -94,5 +97,41 @@ describe("mergePointerOverrides", () => {
 	it("returns base unchanged when overrides is empty", () => {
 		const merged = mergePointerOverrides(base, {});
 		expect(merged).toEqual(base);
+	});
+});
+
+describe("isSafeContextName", () => {
+	it("accepts valid names", () => {
+		expect(isSafeContextName("prod")).toBe(true);
+		expect(isSafeContextName("my-tenant_1")).toBe(true);
+		expect(isSafeContextName("--prod")).toBe(true);
+	});
+
+	it("rejects names failing the character/length rule", () => {
+		expect(isSafeContextName("")).toBe(false);
+		expect(isSafeContextName("has space")).toBe(false);
+		expect(isSafeContextName("../escape")).toBe(false);
+		expect(isSafeContextName("a".repeat(65))).toBe(false);
+	});
+
+	it("rejects reserved subcommand names (case-insensitive)", () => {
+		for (const reserved of RESERVED_CONTEXT_NAMES) {
+			expect(isSafeContextName(reserved)).toBe(false);
+			expect(isSafeContextName(reserved.toUpperCase())).toBe(false);
+		}
+		expect(isSafeContextName("link")).toBe(false);
+		expect(isSafeContextName("unlink")).toBe(false);
+	});
+});
+
+describe("normalizeApiUrl", () => {
+	it("strips trailing slashes", () => {
+		expect(normalizeApiUrl("https://x.example.com/")).toBe("https://x.example.com");
+		expect(normalizeApiUrl("https://x.example.com///")).toBe("https://x.example.com");
+	});
+
+	it("leaves URLs without trailing slash unchanged", () => {
+		expect(normalizeApiUrl("https://x.example.com")).toBe("https://x.example.com");
+		expect(normalizeApiUrl("https://x.example.com/api")).toBe("https://x.example.com/api");
 	});
 });

--- a/packages/utils/test/xcsh-git-tracking.test.ts
+++ b/packages/utils/test/xcsh-git-tracking.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { xcshContextPaths } from "../src/xcsh-context-paths";
 import { ContextResolver } from "../src/xcsh-context-resolver";
 
 describe("ContextResolver.checkGitTracking", () => {
@@ -22,7 +23,7 @@ describe("ContextResolver.checkGitTracking", () => {
 		const filePath = path.join(tmpDir, "untracked.json");
 		fs.writeFileSync(filePath, "{}");
 
-		const resolver = new ContextResolver();
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
 		const result = await resolver.checkGitTracking(filePath);
 		expect(result).toBe(false);
 	});
@@ -34,7 +35,7 @@ describe("ContextResolver.checkGitTracking", () => {
 		Bun.spawnSync(["git", "add", "tracked.json"], { cwd: tmpDir });
 		Bun.spawnSync(["git", "commit", "-m", "add", "--no-gpg-sign"], { cwd: tmpDir });
 
-		const resolver = new ContextResolver();
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
 		const result = await resolver.checkGitTracking(filePath);
 		expect(result).toBe(true);
 	});
@@ -43,7 +44,7 @@ describe("ContextResolver.checkGitTracking", () => {
 		const filePath = path.join(tmpDir, "no-git.json");
 		fs.writeFileSync(filePath, "{}");
 
-		const resolver = new ContextResolver();
+		const resolver = new ContextResolver({ paths: xcshContextPaths });
 		const result = await resolver.checkGitTracking(filePath);
 		expect(result).toBe(false);
 	});

--- a/patches/beautiful-mermaid@1.1.3.patch
+++ b/patches/beautiful-mermaid@1.1.3.patch
@@ -1,3 +1,20 @@
+diff --git a/node_modules/beautiful-mermaid/.bun-tag-5280fae387e74b66 b/.bun-tag-5280fae387e74b66
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/dist/index.js b/dist/index.js
+index e7e087bcb6f29d0d8f36cd558e0183bc0f162fcb..e90e52059458a6ddcb9a4e470f5a5327181579a2 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -2513,8 +2513,7 @@ function drawBoxWithGridDimensions(node, graph) {
+   box[to.x][to.y] = effectiveCorners.br;
+   const label = node.displayLabel;
+   const lines = splitLines(label);
+-  const textCenterY = from.y + Math.floor(h / 2);
+-  const startY = textCenterY - Math.floor((lines.length - 1) / 2);
++  const startY = from.y + 1 + Math.max(0, Math.floor((h - 2 - lines.length) / 2));
+   for (let i = 0; i < lines.length; i++) {
+     const line = lines[i];
+     const textX = from.x + Math.floor(w / 2) - Math.ceil(line.length / 2) + 1;
 diff --git a/src/ascii/draw.ts b/src/ascii/draw.ts
 index f8020f594fc9e27cc27eeecad17e2688c3900159..8f2e79d2a3cdacf20df83b33f54d55a15c652527 100644
 --- a/src/ascii/draw.ts


### PR DESCRIPTION
Closes #1662 (Phase 1 of the multi-phase effort tracked there).

## What

Refactors the per-folder `.xcsh/contexts/` resolver in `@f5xc-salesdemos/pi-utils` into a **host-agnostic, dependency-injected core** so the xcsh shell and the VS Code extension can share one implementation instead of maintaining drifting duplicates. This PR is the xcsh-side foundation; the VS Code extension will consume the published package in a follow-up.

### Parity core (`packages/utils`)
- `ContextResolver` now takes injected `{ paths, gitTracker? }`. It no longer imports `dirs.ts` or JSON and uses no `Bun.*` APIs, so it bundles cleanly into the VS Code extension (webpack) and runs under both Bun and Node.
- `checkGitTracking` uses `node:child_process.spawnSync` (works under Bun and Node).
- `RESERVED_CONTEXT_NAMES` is now single-sourced in utils (adds `link`/`unlink`); `isSafeContextName` rejects reserved names, matching the spec and the extension.
- `normalizeApiUrl` is applied to every resolved `apiUrl` (env/local/global/pointer).
- New `xcshContextPaths` provider (backed by `dirs.ts`); the coding agent constructs the resolver with it.

### Pre-existing CI fixes (discovered on `main`)
- **beautiful-mermaid**: the label-centering patch edited dead `src/ascii/draw.ts` instead of the shipped `dist/index.js`, so tall boxes rendered top-heavy. Patch regenerated against `dist`.
- **context-completion (×3)**: tests fed partial `"F"` but asserted keys that can't start with "F", contradicting the prefix-filtering the passing tests rely on. Corrected the partials; test intent (head preservation/normalization) unchanged.
- **python-prelude**: a dangling `python3` symlink crashed test collection at module load; the probe `spawnSync` is now guarded to skip instead of error.

## Test
- `packages/utils`: full suite green (171 pass); added reserved-name + apiUrl-normalization tests.
- `packages/coding-agent`: `/context` suite green (306 pass); `tsgo` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)