### PR TITLE
feat(utils): normalize resolver apiUrl to origin + cross-host parity fixtures

### DIFF
--- a/packages/utils/src/xcsh-context-resolver.ts
+++ b/packages/utils/src/xcsh-context-resolver.ts
@@ -163,17 +163,28 @@ export function isSafeContextName(name: string): boolean {
 }
 
 /**
- * Normalize an API URL for safe path joining by stripping trailing slash(es).
+ * Normalize an API URL to its origin (`https://host[:port]`) — the canonical
+ * stored form for a context endpoint, shared verbatim by the xcsh shell and the
+ * VS Code extension.
  *
- * The shared resource library joins URLs by raw concatenation
- * (`${apiUrl}${path}`) where path templates begin with `/api/...`. A trailing
- * slash produces `https://host/api//api/...`; after the transport strips the
- * base URL the remainder begins with `//`, which `new URL()` parses as a
- * protocol-relative authority — collapsing the host to a bare label and breaking
- * TLS altname verification. Stripping trailing slashes prevents this.
+ * The stored value must be the bare origin only: no path, query, fragment, or
+ * trailing slash. Callers append `/api/...` themselves, so the endpoint stays a
+ * single consistent value. This also defuses the protocol-relative host
+ * collapse: the shared resource library joins URLs by raw concatenation
+ * (`${apiUrl}${path}`), and a leftover path or trailing slash would produce a
+ * `//` that `new URL()` parses as an authority — collapsing the host to a bare
+ * label and breaking TLS altname verification.
  */
 export function normalizeApiUrl(apiUrl: string): string {
-	return typeof apiUrl === "string" ? apiUrl.replace(/\/+$/, "") : apiUrl;
+	if (typeof apiUrl !== "string") return apiUrl;
+	const trimmed = apiUrl.trim();
+	try {
+		return new URL(trimmed).origin;
+	} catch {
+		// Not a parseable absolute URL (input validation should prevent this);
+		// fall back to stripping trailing slashes so we never worsen a bad value.
+		return trimmed.replace(/\/+$/, "");
+	}
 }
 
 function defaultGitTracker(filePath: string): Promise<boolean> {

--- a/packages/utils/test/xcsh-context-parity.test.ts
+++ b/packages/utils/test/xcsh-context-parity.test.ts
@@ -1,0 +1,209 @@
+// packages/utils/test/xcsh-context-parity.test.ts
+//
+// GOLDEN PARITY FIXTURES — keep byte-identical with the VS Code extension's
+// copy at vscode-xcsh `src/test/unit/contextParity.test.ts`. Both drive the
+// SAME shared resolver (xcsh injects `xcshContextPaths`; the extension injects
+// its `contextPaths` provider) and MUST produce identical outcomes. If you change
+// a fixture or expectation here, change it there in the same PR — that is the
+// whole point of this guard.
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { xcshContextPaths } from "../src/xcsh-context-paths";
+import { ContextResolver } from "../src/xcsh-context-resolver";
+
+export interface ParityFixture {
+	name: string;
+	env?: Record<string, string>;
+	/** Files under <project>/.xcsh/contexts/ (name → contents). */
+	local?: Record<string, string>;
+	localActive?: string;
+	/** Files under <global>/contexts/ (name → contents). */
+	global?: Record<string, string>;
+	globalActive?: string;
+	expect: null | {
+		source: "env" | "local" | "global";
+		name?: string;
+		apiUrl?: string;
+		defaultNamespace?: string;
+		env?: Record<string, string>;
+	};
+}
+
+// The shared, host-agnostic expectations.
+export const PARITY_FIXTURES: ParityFixture[] = [
+	{
+		name: "env vars win and are reduced to origin",
+		env: {
+			XCSH_API_URL: "https://env.example.com/web/home?iss=x#f",
+			XCSH_API_TOKEN: "env-tok",
+			XCSH_NAMESPACE: "ns",
+		},
+		local: {
+			"dev.json": JSON.stringify({
+				name: "dev",
+				apiUrl: "https://l.example.com",
+				apiToken: "t",
+				defaultNamespace: "d",
+			}),
+		},
+		localActive: "dev",
+		expect: { source: "env", apiUrl: "https://env.example.com", defaultNamespace: "ns" },
+	},
+	{
+		name: "local inline over global; apiUrl reduced to origin",
+		local: {
+			"dev.json": JSON.stringify({
+				name: "dev",
+				apiUrl: "https://local.example.com/api/",
+				apiToken: "l",
+				defaultNamespace: "local-ns",
+			}),
+		},
+		localActive: "dev",
+		global: {
+			"prod.json": JSON.stringify({
+				name: "prod",
+				apiUrl: "https://global.example.com",
+				apiToken: "g",
+				defaultNamespace: "g-ns",
+			}),
+		},
+		globalActive: "prod",
+		expect: { source: "local", name: "dev", apiUrl: "https://local.example.com", defaultNamespace: "local-ns" },
+	},
+	{
+		name: "local pointer resolves through to global with merged overrides",
+		global: {
+			"prod.json": JSON.stringify({
+				name: "prod",
+				apiUrl: "https://prod.example.com",
+				apiToken: "p",
+				defaultNamespace: "system",
+				env: { GLOBAL: "g" },
+			}),
+		},
+		local: {
+			"staging.json": JSON.stringify({
+				context: "prod",
+				overrides: { defaultNamespace: "my-ns", env: { LOCAL: "l" } },
+			}),
+		},
+		localActive: "staging",
+		expect: {
+			source: "local",
+			apiUrl: "https://prod.example.com",
+			defaultNamespace: "my-ns",
+			env: { GLOBAL: "g", LOCAL: "l" },
+		},
+	},
+	{
+		name: "pointer to a missing global yields no context",
+		local: { "broken.json": JSON.stringify({ context: "does-not-exist" }) },
+		localActive: "broken",
+		expect: null,
+	},
+	{
+		name: "file with both context and apiUrl is rejected; falls through to global",
+		local: { "bad.json": JSON.stringify({ context: "prod", apiUrl: "https://x.example.com" }) },
+		localActive: "bad",
+		global: {
+			"fallback.json": JSON.stringify({
+				name: "fallback",
+				apiUrl: "https://fb.example.com",
+				apiToken: "f",
+				defaultNamespace: "fb",
+			}),
+		},
+		globalActive: "fallback",
+		expect: { source: "global", name: "fallback", apiUrl: "https://fb.example.com" },
+	},
+	{
+		name: "reserved active-context name is rejected; falls through to global",
+		local: {
+			"list.json": JSON.stringify({
+				name: "list",
+				apiUrl: "https://x.example.com",
+				apiToken: "t",
+				defaultNamespace: "d",
+			}),
+		},
+		localActive: "list",
+		global: {
+			"fallback.json": JSON.stringify({
+				name: "fallback",
+				apiUrl: "https://fb.example.com",
+				apiToken: "f",
+				defaultNamespace: "fb",
+			}),
+		},
+		globalActive: "fallback",
+		expect: { source: "global", name: "fallback" },
+	},
+	{
+		name: "inline context missing a required field is rejected",
+		local: { "partial.json": JSON.stringify({ name: "partial", apiUrl: "https://x.example.com" }) },
+		localActive: "partial",
+		expect: null,
+	},
+];
+
+describe("context resolution parity (xcsh host)", () => {
+	let tmpDir: string;
+	let projectDir: string;
+	const originalEnv = { ...process.env };
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-parity-"));
+		projectDir = path.join(tmpDir, "project");
+		fs.mkdirSync(path.join(projectDir, ".xcsh", "contexts"), { recursive: true, mode: 0o700 });
+		fs.mkdirSync(path.join(tmpDir, "global-config", "xcsh", "contexts"), { recursive: true, mode: 0o700 });
+		process.env.XDG_CONFIG_HOME = path.join(tmpDir, "global-config");
+		delete process.env.XCSH_API_URL;
+		delete process.env.XCSH_API_TOKEN;
+		delete process.env.XCSH_NAMESPACE;
+	});
+
+	afterEach(() => {
+		process.env = { ...originalEnv };
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	for (const fx of PARITY_FIXTURES) {
+		it(fx.name, async () => {
+			const localCtxDir = path.join(projectDir, ".xcsh", "contexts");
+			const globalCtxDir = path.join(tmpDir, "global-config", "xcsh", "contexts");
+			for (const [file, body] of Object.entries(fx.local ?? {})) {
+				fs.writeFileSync(path.join(localCtxDir, file), body, { mode: 0o600 });
+			}
+			if (fx.localActive)
+				fs.writeFileSync(path.join(localCtxDir, "active_context"), fx.localActive, { mode: 0o600 });
+			for (const [file, body] of Object.entries(fx.global ?? {})) {
+				fs.writeFileSync(path.join(globalCtxDir, file), body, { mode: 0o600 });
+			}
+			if (fx.globalActive) {
+				fs.writeFileSync(path.join(tmpDir, "global-config", "xcsh", "active_context"), fx.globalActive, {
+					mode: 0o600,
+				});
+			}
+			for (const [k, v] of Object.entries(fx.env ?? {})) process.env[k] = v;
+
+			const resolver = new ContextResolver({ paths: xcshContextPaths });
+			const result = await resolver.resolve(projectDir);
+
+			if (fx.expect === null) {
+				expect(result).toBeNull();
+				return;
+			}
+			expect(result).not.toBeNull();
+			expect(result?.source).toBe(fx.expect.source);
+			if (fx.expect.name !== undefined) expect(result?.context.name).toBe(fx.expect.name);
+			if (fx.expect.apiUrl !== undefined) expect(result?.context.apiUrl).toBe(fx.expect.apiUrl);
+			if (fx.expect.defaultNamespace !== undefined) {
+				expect(result?.context.defaultNamespace).toBe(fx.expect.defaultNamespace);
+			}
+			if (fx.expect.env !== undefined) expect(result?.context.env).toEqual(fx.expect.env);
+		});
+	}
+});

--- a/packages/utils/test/xcsh-context-resolver.test.ts
+++ b/packages/utils/test/xcsh-context-resolver.test.ts
@@ -125,13 +125,19 @@ describe("isSafeContextName", () => {
 });
 
 describe("normalizeApiUrl", () => {
-	it("strips trailing slashes", () => {
+	it("reduces a URL to its origin", () => {
 		expect(normalizeApiUrl("https://x.example.com/")).toBe("https://x.example.com");
 		expect(normalizeApiUrl("https://x.example.com///")).toBe("https://x.example.com");
+		expect(normalizeApiUrl("https://x.example.com/api")).toBe("https://x.example.com");
+		expect(normalizeApiUrl("https://x.example.com/web/home?iss=tok#frag")).toBe("https://x.example.com");
 	});
 
-	it("leaves URLs without trailing slash unchanged", () => {
+	it("leaves a bare origin unchanged and preserves an explicit port", () => {
 		expect(normalizeApiUrl("https://x.example.com")).toBe("https://x.example.com");
-		expect(normalizeApiUrl("https://x.example.com/api")).toBe("https://x.example.com/api");
+		expect(normalizeApiUrl("https://x.example.com:8443/path")).toBe("https://x.example.com:8443");
+	});
+
+	it("falls back to trailing-slash strip for an unparseable value", () => {
+		expect(normalizeApiUrl("not a url/")).toBe("not a url");
 	});
 });


### PR DESCRIPTION
Closes #1672.

## What
1. **`normalizeApiUrl` → origin.** The shared resolver's `normalizeApiUrl` reduced a URL to only its trailing-slash-stripped form, while both hosts' storage layers already reduce apiUrl to its origin (xcsh #1657, vscode #580). This upgrades the shared function to origin-stripping (with a trailing-slash fallback for unparseable values), so the *resolved* apiUrl is identical across hosts even for a raw `XCSH_API_URL` env var that contains a path. This is the last behavior where the two resolvers diverged.
2. **Golden parity fixtures.** `packages/utils/test/xcsh-context-parity.test.ts` asserts resolution outcomes for env/local-inline/pointer+overrides/missing-global/both-fields-invalid/reserved-name/missing-field. The fixture set is kept **byte-identical** with the VS Code extension's copy so the two dependency-injected hosts can't silently drift.

## Test
Full `packages/utils` suite green (179); `packages/coding-agent` context suite green (277); utils `tsgo` typecheck clean.

## Follow-up
After this releases (`pi-utils` 19.45.1), the extension bumps the dep, drops its now-redundant adapter-level origin post-process, and adds the mirrored parity test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)