### PR TITLE
feat(coding-agent): add browser automation to self-awareness surfaces

### DIFF
--- a/packages/coding-agent/autoresearch-measure-selfaware.ts
+++ b/packages/coding-agent/autoresearch-measure-selfaware.ts
@@ -185,6 +185,14 @@ if (capSection.includes("agent") || capSection.includes("deal") || capSection.in
 	notes.push("PP12: capabilities section omits SE-specific agents");
 }
 
+// PP13: Capabilities mention browser/console automation
+if (capSection.includes("browser") || capSection.includes("chrome") || capSection.includes("catalog_workflow")) {
+	positivePatterns++;
+} else {
+	score -= 4;
+	notes.push("PP13: capabilities section omits Chrome browser/console automation");
+}
+
 // ─── Layer 3: Version chain consistency ───
 
 let versionChainOk = 1;

--- a/packages/coding-agent/src/internal-urls/build-info-runtime.ts
+++ b/packages/coding-agent/src/internal-urls/build-info-runtime.ts
@@ -210,6 +210,7 @@ export function renderAboutDoc(info: RuntimeBuildInfo, context: ContextStatus | 
 		"",
 		"SE specialization: F5 XC API integration (xcsh_api, api-catalog, api-spec),",
 		"F5 XC federated product docs (llms.txt hierarchy),",
+		"F5 XC console browser automation (catalog_workflow_runner, xcsh://console/ workflow catalog),",
 		"user/computer profiling (xcsh://user, xcsh://computer),",
 		"SE-specific subagents (deal-analyst, status-operator, cli-operator, github-ops).",
 		"",

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -21,7 +21,8 @@ presentations, technical discovery questions, POC/proof-of-concept validation pl
 account planning, and competitive positioning.
 
 Technical depth: network protocols across all OSI layers, API design, security analysis
-(DDoS, SSL/TLS, MITM, traffic forensics), infrastructure as code, and network automation.
+(DDoS, SSL/TLS, MITM, traffic forensics), infrastructure as code, network automation,
+and F5 XC console browser automation.
 These are not separate roles — the SE work requires the technical depth, and the
 technical depth exists to serve the SE work.
 Judgment: earned from production network incidents, security investigations, live


### PR DESCRIPTION
## Summary

- Add F5 XC console browser automation to the `<role>` identity block in system-prompt.md
- Add browser automation to `xcsh://about` capabilities section in build-info-runtime.ts
- Add PP13 self-awareness validation check in autoresearch-measure-selfaware.ts

Closes #1681