### PR TITLE
feat(context): share auth-env recognition via pi-utils (#1683)

### DIFF
--- a/packages/coding-agent/src/secrets/index.ts
+++ b/packages/coding-agent/src/secrets/index.ts
@@ -1,10 +1,11 @@
 import * as path from "node:path";
-import { isEnoent, logger } from "@f5xc-salesdemos/pi-utils";
+import { isEnoent, logger, SECRET_ENV_PATTERNS } from "@f5xc-salesdemos/pi-utils";
 import { YAML } from "bun";
 import type { SecretEntry } from "./obfuscator";
 import { compileSecretRegex } from "./regex";
 
 export { deobfuscateSessionContext, obfuscateMessages, type SecretEntry, SecretObfuscator } from "./obfuscator";
+export { SECRET_ENV_PATTERNS };
 
 /**
  * Load secrets from project-local and global secrets.yml files.
@@ -28,9 +29,6 @@ export async function loadSecrets(cwd: string, agentDir: string): Promise<Secret
 
 /** Minimum env var value length to consider as a secret. */
 const MIN_ENV_VALUE_LENGTH = 8;
-
-/** Env var name patterns that indicate secret values. */
-export const SECRET_ENV_PATTERNS = /(?:KEY|SECRET|TOKEN|PASSWORD|PASS|AUTH|CREDENTIAL|PRIVATE|OAUTH)(?:_|$)/i;
 
 /**
  * Collect environment variable values that look like secrets.

--- a/packages/coding-agent/src/services/xcsh-context-command.ts
+++ b/packages/coding-agent/src/services/xcsh-context-command.ts
@@ -8,19 +8,18 @@ import {
 	isSafeContextName,
 	t,
 } from "@f5xc-salesdemos/pi-utils";
-import { SECRET_ENV_PATTERNS } from "../secrets/index";
 import { expandTilde } from "../tools/path-utils";
 import { ContextError, ContextService, CURRENT_SCHEMA_VERSION } from "./xcsh-context";
 import { formatStatusIcon } from "./xcsh-context-indicators";
 import {
+	AUTH_ENV_KEYS,
 	deriveTenantFromUrl,
+	isSensitiveEnvKey,
 	RESERVED_ENV_KEYS,
 	XCSH_API_TOKEN,
 	XCSH_API_URL,
-	XCSH_CONSOLE_PASSWORD,
 	XCSH_NAMESPACE,
 	XCSH_TENANT,
-	XCSH_USERNAME,
 } from "./xcsh-env";
 import {
 	formatAuthIndicator,
@@ -327,10 +326,6 @@ async function handleActivatePrevious(ctx: CommandContext, service: ContextServi
 	}
 }
 
-function isSensitiveKey(key: string): boolean {
-	return SECRET_ENV_PATTERNS.test(key);
-}
-
 async function handleShow(ctx: CommandContext, service: ContextService, name?: string): Promise<void> {
 	const targetName = name || service.getStatus().activeContextName;
 	if (!targetName) {
@@ -358,11 +353,11 @@ async function handleShow(ctx: CommandContext, service: ContextService, name?: s
 	];
 
 	// Auth-related env vars
-	const authKeys: string[] = [XCSH_USERNAME, XCSH_CONSOLE_PASSWORD];
+	const authKeys: readonly string[] = AUTH_ENV_KEYS;
 	for (const key of authKeys) {
 		const value = context.env?.[key];
 		if (value) {
-			rows.push({ key: sanitize(key), value: isSensitiveKey(key) ? service.maskToken(value) : sanitize(value) });
+			rows.push({ key: sanitize(key), value: isSensitiveEnvKey(key) ? service.maskToken(value) : sanitize(value) });
 		}
 	}
 
@@ -377,7 +372,7 @@ async function handleShow(ctx: CommandContext, service: ContextService, name?: s
 	if (context.env) {
 		for (const [key, value] of Object.entries(context.env)) {
 			if (authKeys.includes(key) || RESERVED_ENV_KEYS.has(key)) continue;
-			rows.push({ key: sanitize(key), value: isSensitiveKey(key) ? service.maskToken(value) : sanitize(value) });
+			rows.push({ key: sanitize(key), value: isSensitiveEnvKey(key) ? service.maskToken(value) : sanitize(value) });
 		}
 	}
 
@@ -741,7 +736,7 @@ async function handleEnvList(ctx: CommandContext, service: ContextService): Prom
 	}
 	const rows: TableRow[] = [];
 	for (const [key, value] of Object.entries(context.env)) {
-		const sensitive = isSensitiveKey(key) || (context.sensitiveKeys ?? []).includes(key);
+		const sensitive = isSensitiveEnvKey(key) || (context.sensitiveKeys ?? []).includes(key);
 		rows.push({ key: sanitize(key), value: sensitive ? service.maskToken(value) : sanitize(value) });
 	}
 	ctx.showStatus(renderXCSHTable(`${contextName} env`, rows), { dim: false });
@@ -766,7 +761,7 @@ async function handleEnvSet(ctx: CommandContext, service: ContextService, args: 
 		bodyLines.push(`Set ${keys.length} variable${keys.length > 1 ? "s" : ""} on '${contextName}':`);
 		for (const key of keys) {
 			const lock = result.sensitive.includes(key) ? " (auto-sensitive)" : "";
-			const displayValue = isSensitiveKey(key) ? "***" : vars[key];
+			const displayValue = isSensitiveEnvKey(key) ? "***" : vars[key];
 			bodyLines.push(`  ${key}=${displayValue}${lock}`);
 		}
 		ctx.showStatus(renderContextMessage(contextName, bodyLines.join("\n")), { dim: false });

--- a/packages/coding-agent/src/services/xcsh-env.ts
+++ b/packages/coding-agent/src/services/xcsh-env.ts
@@ -1,24 +1,36 @@
 /**
- * F5 XC environment variable names. Typed `as const` so bracket access like
- * `process.env[XCSH_API_URL]` type-checks correctly. Single source of truth —
- * every consumer imports these instead of repeating the string literal.
+ * F5 XC environment variable names + the reserved-key set. The single source of
+ * truth lives in `@f5xc-salesdemos/pi-utils` (`xcsh-env-names`) so the shell and
+ * the VS Code extension agree on the exact same names; re-exported here for the
+ * shell's existing import paths.
  */
-export const XCSH_API_URL = "XCSH_API_URL" as const;
-export const XCSH_API_TOKEN = "XCSH_API_TOKEN" as const;
-export const XCSH_NAMESPACE = "XCSH_NAMESPACE" as const;
-export const XCSH_TENANT = "XCSH_TENANT" as const;
-export const XCSH_USERNAME = "XCSH_USERNAME" as const;
-export const XCSH_CONSOLE_PASSWORD = "XCSH_CONSOLE_PASSWORD" as const;
-/** Active context profile name. Read-only metadata injected by ContextService. */
-export const XCSH_CONTEXT_NAME = "XCSH_CONTEXT_NAME" as const;
-
-export const RESERVED_ENV_KEYS: ReadonlySet<string> = new Set([
-	XCSH_NAMESPACE,
-	XCSH_API_URL,
+import {
+	AUTH_ENV_KEYS,
+	isSensitiveEnvKey,
+	RESERVED_ENV_KEYS,
+	SECRET_ENV_PATTERNS,
 	XCSH_API_TOKEN,
-	XCSH_TENANT,
+	XCSH_API_URL,
+	XCSH_CONSOLE_PASSWORD,
 	XCSH_CONTEXT_NAME,
-]);
+	XCSH_NAMESPACE,
+	XCSH_TENANT,
+	XCSH_USERNAME,
+} from "@f5xc-salesdemos/pi-utils";
+
+export {
+	AUTH_ENV_KEYS,
+	isSensitiveEnvKey,
+	RESERVED_ENV_KEYS,
+	SECRET_ENV_PATTERNS,
+	XCSH_API_TOKEN,
+	XCSH_API_URL,
+	XCSH_CONSOLE_PASSWORD,
+	XCSH_CONTEXT_NAME,
+	XCSH_NAMESPACE,
+	XCSH_TENANT,
+	XCSH_USERNAME,
+};
 
 export const RESERVED_ENV_MESSAGES: Readonly<Record<string, string>> = {
 	[XCSH_NAMESPACE]: `${XCSH_NAMESPACE} is managed by defaultNamespace. Use /context namespace <value> to change it.`,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-utils",
-	"version": "19.46.1",
+	"version": "19.47.0",
 	"description": "Shared utilities for pi packages",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -39,6 +39,7 @@ export * from "./type-guards";
 export * from "./which";
 export * from "./xcsh-context-paths";
 export * from "./xcsh-context-resolver";
+export * from "./xcsh-env-names";
 
 function isPlainObject(val: object): val is Record<string, unknown> {
 	return Object.getPrototypeOf(val) === Object.prototype || Array.isArray(val);

--- a/packages/utils/src/xcsh-env-names.ts
+++ b/packages/utils/src/xcsh-env-names.ts
@@ -1,0 +1,49 @@
+/**
+ * Canonical F5 XC context environment-variable names and the secret-detection
+ * rule, shared by every host (the xcsh shell and the VS Code extension) so both
+ * agree on which keys are reserved, which are recognized auth credentials, and
+ * which values must be masked.
+ *
+ * This module is intentionally dependency-free (no Bun/Node APIs) so a CommonJS
+ * `require()` from the extension can load it without dragging in the Bun-only
+ * barrel. Names are typed `as const` so bracket access like
+ * `process.env[XCSH_API_URL]` type-checks correctly.
+ */
+
+export const XCSH_API_URL = "XCSH_API_URL" as const;
+export const XCSH_API_TOKEN = "XCSH_API_TOKEN" as const;
+export const XCSH_NAMESPACE = "XCSH_NAMESPACE" as const;
+export const XCSH_TENANT = "XCSH_TENANT" as const;
+export const XCSH_USERNAME = "XCSH_USERNAME" as const;
+export const XCSH_CONSOLE_PASSWORD = "XCSH_CONSOLE_PASSWORD" as const;
+/** Active context profile name. Read-only metadata injected by ContextService. */
+export const XCSH_CONTEXT_NAME = "XCSH_CONTEXT_NAME" as const;
+
+/**
+ * Control env vars owned by the context itself (apiUrl/apiToken/defaultNamespace
+ * → XCSH_API_URL/XCSH_API_TOKEN/XCSH_NAMESPACE), derived (XCSH_TENANT), or
+ * injected at activation (XCSH_CONTEXT_NAME). A context's custom `env` map must
+ * never set these — they would be ignored or clobbered by the resolver.
+ */
+export const RESERVED_ENV_KEYS: ReadonlySet<string> = new Set([
+	XCSH_NAMESPACE,
+	XCSH_API_URL,
+	XCSH_API_TOKEN,
+	XCSH_TENANT,
+	XCSH_CONTEXT_NAME,
+]);
+
+/**
+ * Recognized web-console login credentials. Unlike RESERVED_ENV_KEYS these live
+ * in the context's generic `env` map (a user sets them like any other variable),
+ * but hosts surface them in a dedicated "Auth" section, in display order.
+ */
+export const AUTH_ENV_KEYS: readonly string[] = [XCSH_USERNAME, XCSH_CONSOLE_PASSWORD];
+
+/** Env var name patterns that indicate a secret value (mask in output, redact on export). */
+export const SECRET_ENV_PATTERNS = /(?:KEY|SECRET|TOKEN|PASSWORD|PASS|AUTH|CREDENTIAL|PRIVATE|OAUTH)(?:_|$)/i;
+
+/** True iff an env var NAME looks like it holds a secret (e.g. XCSH_CONSOLE_PASSWORD). */
+export function isSensitiveEnvKey(key: string): boolean {
+	return SECRET_ENV_PATTERNS.test(key);
+}

--- a/packages/utils/test/xcsh-context-parity.test.ts
+++ b/packages/utils/test/xcsh-context-parity.test.ts
@@ -147,6 +147,37 @@ export const PARITY_FIXTURES: ParityFixture[] = [
 		localActive: "partial",
 		expect: null,
 	},
+	{
+		// Auth credentials (XCSH_USERNAME / XCSH_CONSOLE_PASSWORD) and other generic
+		// vars live in the context's `env` map; resolution must preserve them
+		// byte-identically in both hosts. (Auto-marking these sensitive is host-level,
+		// not resolver-level, so it is asserted in host unit tests, not here.)
+		name: "auth + generic env keys survive resolution unchanged",
+		local: {
+			"auth.json": JSON.stringify({
+				name: "auth",
+				apiUrl: "https://auth.example.com",
+				apiToken: "t",
+				defaultNamespace: "d",
+				env: {
+					XCSH_USERNAME: "console-user@example.com",
+					XCSH_CONSOLE_PASSWORD: "s3cr3t-console-pass",
+					XCSH_EMAIL: "user@example.com",
+				},
+			}),
+		},
+		localActive: "auth",
+		expect: {
+			source: "local",
+			name: "auth",
+			apiUrl: "https://auth.example.com",
+			env: {
+				XCSH_USERNAME: "console-user@example.com",
+				XCSH_CONSOLE_PASSWORD: "s3cr3t-console-pass",
+				XCSH_EMAIL: "user@example.com",
+			},
+		},
+	},
 ];
 
 describe("context resolution parity (xcsh host)", () => {

--- a/packages/utils/test/xcsh-env-names.test.ts
+++ b/packages/utils/test/xcsh-env-names.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import {
+	AUTH_ENV_KEYS,
+	isSensitiveEnvKey,
+	RESERVED_ENV_KEYS,
+	SECRET_ENV_PATTERNS,
+	XCSH_API_TOKEN,
+	XCSH_API_URL,
+	XCSH_CONSOLE_PASSWORD,
+	XCSH_CONTEXT_NAME,
+	XCSH_NAMESPACE,
+	XCSH_TENANT,
+	XCSH_USERNAME,
+} from "../src/xcsh-env-names";
+
+describe("env name constants", () => {
+	it("expose the canonical XCSH_ names", () => {
+		expect(XCSH_API_URL).toBe("XCSH_API_URL");
+		expect(XCSH_API_TOKEN).toBe("XCSH_API_TOKEN");
+		expect(XCSH_NAMESPACE).toBe("XCSH_NAMESPACE");
+		expect(XCSH_TENANT).toBe("XCSH_TENANT");
+		expect(XCSH_USERNAME).toBe("XCSH_USERNAME");
+		expect(XCSH_CONSOLE_PASSWORD).toBe("XCSH_CONSOLE_PASSWORD");
+		expect(XCSH_CONTEXT_NAME).toBe("XCSH_CONTEXT_NAME");
+	});
+});
+
+describe("RESERVED_ENV_KEYS", () => {
+	it("contains the five control keys and excludes the auth keys", () => {
+		expect(RESERVED_ENV_KEYS.has(XCSH_API_URL)).toBe(true);
+		expect(RESERVED_ENV_KEYS.has(XCSH_API_TOKEN)).toBe(true);
+		expect(RESERVED_ENV_KEYS.has(XCSH_NAMESPACE)).toBe(true);
+		expect(RESERVED_ENV_KEYS.has(XCSH_TENANT)).toBe(true);
+		expect(RESERVED_ENV_KEYS.has(XCSH_CONTEXT_NAME)).toBe(true);
+		// Auth credentials are generic env entries, NOT reserved.
+		expect(RESERVED_ENV_KEYS.has(XCSH_USERNAME)).toBe(false);
+		expect(RESERVED_ENV_KEYS.has(XCSH_CONSOLE_PASSWORD)).toBe(false);
+	});
+});
+
+describe("AUTH_ENV_KEYS", () => {
+	it("lists username then console password in display order", () => {
+		expect([...AUTH_ENV_KEYS]).toEqual([XCSH_USERNAME, XCSH_CONSOLE_PASSWORD]);
+	});
+});
+
+describe("isSensitiveEnvKey", () => {
+	it("treats the console password as sensitive but the username as not", () => {
+		expect(isSensitiveEnvKey(XCSH_CONSOLE_PASSWORD)).toBe(true);
+		expect(isSensitiveEnvKey(XCSH_USERNAME)).toBe(false);
+	});
+
+	it("matches the documented secret name patterns", () => {
+		expect(isSensitiveEnvKey("XCSH_API_TOKEN")).toBe(true);
+		expect(isSensitiveEnvKey("MY_SECRET")).toBe(true);
+		expect(isSensitiveEnvKey("DB_PASSWORD")).toBe(true);
+		expect(isSensitiveEnvKey("PRIVATE_KEY")).toBe(true);
+		expect(isSensitiveEnvKey("XCSH_EMAIL")).toBe(false);
+		expect(isSensitiveEnvKey("XCSH_LB_NAME")).toBe(false);
+	});
+
+	it("delegates to SECRET_ENV_PATTERNS", () => {
+		expect(isSensitiveEnvKey("FOO_TOKEN")).toBe(SECRET_ENV_PATTERNS.test("FOO_TOKEN"));
+	});
+});


### PR DESCRIPTION
## Summary
Closes #1683.

Promotes the canonical `XCSH_*` env-name constants, `RESERVED_ENV_KEYS`, `AUTH_ENV_KEYS`, `SECRET_ENV_PATTERNS`, and `isSensitiveEnvKey()` into a new dependency-free pi-utils module (`xcsh-env-names`) so the xcsh shell and the VS Code extension share **one** source of truth for the web-console auth credentials (`XCSH_USERNAME` / `XCSH_CONSOLE_PASSWORD`) and the secret-detection rule.

The shell is rewired onto the shared module with **no behavior change**:
- `xcsh-env.ts` re-exports the names + helpers from pi-utils (no local literals).
- `secrets/index.ts` imports `SECRET_ENV_PATTERNS` from pi-utils.
- `xcsh-context-command.ts` uses `AUTH_ENV_KEYS` + `isSensitiveEnvKey` for the `/context show` Auth section.

Bumps `pi-utils` to **19.47.0** so the vscode-xcsh parity PR can consume it.

## Tests
- New `xcsh-env-names.test.ts` (constants, reserved set, auth keys, secret detection).
- Extended golden parity fixture: auth + generic env keys survive resolution unchanged.
- Full utils + coding-agent context/env/secret suites green; type-check + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)