### PR TITLE
fix(config): restrict context env injection to the XCSH_ namespace (#1692)

### DIFF
--- a/packages/coding-agent/src/services/xcsh-context.ts
+++ b/packages/coding-agent/src/services/xcsh-context.ts
@@ -13,6 +13,7 @@ import { XCSHApiClient } from "./xcsh-api-client";
 import {
 	deriveTenantFromUrl,
 	hasEnvOverride,
+	isInjectableContextEnvKey,
 	normalizeApiUrl,
 	RESERVED_ENV_KEYS,
 	RESERVED_ENV_MESSAGES,
@@ -1388,10 +1389,13 @@ export class ContextService {
 		// Inject context profile name for API tool identity surfacing
 		merged[XCSH_CONTEXT_NAME] = context.name;
 
-		// Inject all additional env vars from context.env map
+		// Inject additional env vars from context.env. Allowlist: only XCSH_-namespaced
+		// non-reserved keys may reach the subprocess — a project-local context file is
+		// untrusted input, so anything outside the XCSH_ namespace (LD_PRELOAD,
+		// NODE_OPTIONS, PATH, …) is refused and can never run code.
 		if (context.env) {
 			for (const [key, value] of Object.entries(context.env)) {
-				if (!process.env[key] && !(RESERVED_ENV_KEYS.has(key) && key in merged)) merged[key] = value;
+				if (isInjectableContextEnvKey(key) && !process.env[key]) merged[key] = value;
 			}
 		}
 

--- a/packages/coding-agent/src/services/xcsh-env.ts
+++ b/packages/coding-agent/src/services/xcsh-env.ts
@@ -6,6 +6,7 @@
  */
 import {
 	AUTH_ENV_KEYS,
+	isInjectableContextEnvKey,
 	isSensitiveEnvKey,
 	RESERVED_ENV_KEYS,
 	SECRET_ENV_PATTERNS,
@@ -20,6 +21,7 @@ import {
 
 export {
 	AUTH_ENV_KEYS,
+	isInjectableContextEnvKey,
 	isSensitiveEnvKey,
 	RESERVED_ENV_KEYS,
 	SECRET_ENV_PATTERNS,

--- a/packages/coding-agent/test/xcsh-context-service.test.ts
+++ b/packages/coding-agent/test/xcsh-context-service.test.ts
@@ -690,6 +690,33 @@ describe("ContextService", () => {
 			expect(bashEnv.XCSH_ROOT_DOMAIN).toBe("example.com");
 		});
 
+		it("never injects process-hijacking env keys from a context", async () => {
+			const malicious: XCSHContext = {
+				...TEST_CONTEXT,
+				name: "malicious",
+				env: {
+					LD_PRELOAD: "/tmp/evil.so",
+					DYLD_INSERT_LIBRARIES: "/tmp/evil.dylib",
+					NODE_OPTIONS: "--require /tmp/evil.js",
+					PATH: "/tmp/evil/bin",
+					XCSH_SAFE: "ok",
+				},
+			};
+			writeContext(xcshContextsDir, malicious);
+			writeActiveContext(xcshConfigDir, malicious.name);
+
+			const service = ContextService.init(xcshConfigDir);
+			await service.loadActive();
+
+			const bashEnv = Settings.instance.get("bash.environment") as Record<string, string>;
+			// Dangerous keys are dropped; benign XCSH_ vars still flow through.
+			expect(bashEnv.LD_PRELOAD).toBeUndefined();
+			expect(bashEnv.DYLD_INSERT_LIBRARIES).toBeUndefined();
+			expect(bashEnv.NODE_OPTIONS).toBeUndefined();
+			expect(bashEnv.PATH).toBeUndefined();
+			expect(bashEnv.XCSH_SAFE).toBe("ok");
+		});
+
 		it("XCSH_TENANT is auto-derived from apiUrl hostname", async () => {
 			writeContext(xcshContextsDir, TEST_CONTEXT);
 			writeActiveContext(xcshConfigDir, TEST_CONTEXT.name);

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5xc-salesdemos/pi-utils",
-	"version": "19.47.0",
+	"version": "19.48.0",
 	"description": "Shared utilities for pi packages",
 	"homepage": "https://github.com/f5xc-salesdemos/xcsh",
 	"author": "Can Boluk",

--- a/packages/utils/src/xcsh-env-names.ts
+++ b/packages/utils/src/xcsh-env-names.ts
@@ -47,3 +47,23 @@ export const SECRET_ENV_PATTERNS = /(?:KEY|SECRET|TOKEN|PASSWORD|PASS|AUTH|CREDE
 export function isSensitiveEnvKey(key: string): boolean {
 	return SECRET_ENV_PATTERNS.test(key);
 }
+
+/** Prefix that namespaces every context-owned environment variable. */
+export const XCSH_ENV_PREFIX = "XCSH_";
+
+/**
+ * True iff a context's `env` entry may be injected into a spawned subprocess.
+ *
+ * This is an allowlist (default-deny): only `XCSH_`-namespaced, non-reserved keys
+ * are injectable. A project-local `.xcsh/contexts/*.json` is untrusted input, so a
+ * denylist of "dangerous" names is unsafe — it is impossible to enumerate every
+ * process/interpreter-hijacking variable (LD_PRELOAD, DYLD_INSERT_LIBRARIES,
+ * NODE_OPTIONS, NODE_PATH, PATH, PYTHONHOME, JAVA_TOOL_OPTIONS, CLASSPATH, …).
+ * Restricting injection to the `XCSH_` namespace blocks all of them by
+ * construction, since none are `XCSH_`-prefixed. Reserved keys (XCSH_API_URL,
+ * XCSH_API_TOKEN, XCSH_NAMESPACE, XCSH_TENANT, XCSH_CONTEXT_NAME) are excluded too —
+ * the host sets those itself from the context's typed fields.
+ */
+export function isInjectableContextEnvKey(key: string): boolean {
+	return key.startsWith(XCSH_ENV_PREFIX) && !RESERVED_ENV_KEYS.has(key);
+}

--- a/packages/utils/test/xcsh-env-names.test.ts
+++ b/packages/utils/test/xcsh-env-names.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	AUTH_ENV_KEYS,
+	isInjectableContextEnvKey,
 	isSensitiveEnvKey,
 	RESERVED_ENV_KEYS,
 	SECRET_ENV_PATTERNS,
@@ -61,5 +62,49 @@ describe("isSensitiveEnvKey", () => {
 
 	it("delegates to SECRET_ENV_PATTERNS", () => {
 		expect(isSensitiveEnvKey("FOO_TOKEN")).toBe(SECRET_ENV_PATTERNS.test("FOO_TOKEN"));
+	});
+});
+
+describe("isInjectableContextEnvKey", () => {
+	it("allows XCSH_-namespaced non-reserved keys (incl. the auth credentials)", () => {
+		expect(isInjectableContextEnvKey(XCSH_USERNAME)).toBe(true);
+		expect(isInjectableContextEnvKey(XCSH_CONSOLE_PASSWORD)).toBe(true);
+		expect(isInjectableContextEnvKey("XCSH_EMAIL")).toBe(true);
+		expect(isInjectableContextEnvKey("XCSH_LB_NAME")).toBe(true);
+	});
+
+	it("refuses reserved control keys even though they are XCSH_-prefixed", () => {
+		expect(isInjectableContextEnvKey(XCSH_API_URL)).toBe(false);
+		expect(isInjectableContextEnvKey(XCSH_API_TOKEN)).toBe(false);
+		expect(isInjectableContextEnvKey(XCSH_NAMESPACE)).toBe(false);
+		expect(isInjectableContextEnvKey(XCSH_TENANT)).toBe(false);
+		expect(isInjectableContextEnvKey(XCSH_CONTEXT_NAME)).toBe(false);
+	});
+
+	it("refuses every non-XCSH key — including process/interpreter hijack vars", () => {
+		for (const key of [
+			"LD_PRELOAD",
+			"LD_LIBRARY_PATH",
+			"DYLD_INSERT_LIBRARIES",
+			"BASH_FUNC_evil%%",
+			"PATH",
+			"IFS",
+			"BASH_ENV",
+			"NODE_OPTIONS",
+			"NODE_PATH",
+			"PYTHONPATH",
+			"PYTHONHOME",
+			"JAVA_TOOL_OPTIONS",
+			"CLASSPATH",
+			"PERL5OPT",
+			"RUBYOPT",
+			"GIT_SSH_COMMAND",
+			"HTTPS_PROXY",
+			"HTTP_PROXY",
+		]) {
+			expect(isInjectableContextEnvKey(key)).toBe(false);
+		}
+		// Case matters: env names are case-sensitive on POSIX and the namespace is uppercase.
+		expect(isInjectableContextEnvKey("xcsh_email")).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary
Closes #1692.

A context's generic `env` map is injected into spawned subprocesses (the shell's `bash.environment`), but only the 5 `RESERVED_ENV_KEYS` were excluded. A malicious project-local `.xcsh/contexts/*.json` (untrusted input when opening a cloned repo) could set `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS`, `NODE_PATH`, `PATH`, `PYTHONHOME`, `JAVA_TOOL_OPTIONS`, `CLASSPATH`, etc. and run arbitrary code the moment a context activates. Surfaced as HIGH findings by automated security review; the shell had the identical hole.

## Fix — allowlist, not denylist
Because a context file is **untrusted input**, a denylist of "dangerous" names is unsafe — the set of process/interpreter-hijacking variables can't be fully enumerated (the first denylist draft already missed `NODE_PATH`, `PYTHONHOME`, `JAVA_TOOL_OPTIONS`, `CLASSPATH`, proxy vars, …).

- Add `isInjectableContextEnvKey()` (default-deny) to `@f5xc-salesdemos/pi-utils`: permits only `XCSH_`-namespaced, **non-reserved** keys. Every hijack variable is blocked by construction (none are `XCSH_`-prefixed). This matches the product convention — all context env vars (`XCSH_USERNAME`, `XCSH_CONSOLE_PASSWORD`, `XCSH_EMAIL`, `XCSH_LB_NAME`, …) are already `XCSH_`-namespaced.
- Apply it at injection in the shell's `#applyToSettings`.
- Bumps `pi-utils` to **19.48.0**; the VS Code extension consumes the same predicate (vscode-xcsh#624).

**Behavior note:** a context's `env` may now only contribute `XCSH_*` variables to the subprocess; non-`XCSH_` keys are no longer injected. (Storage/resolution is unchanged — this is purely the injection boundary.)

## Tests
- pi-utils: `isInjectableContextEnvKey` — XCSH_ non-reserved allowed; reserved + every non-XCSH key (incl. LD_PRELOAD/NODE_OPTIONS/PATH/PYTHONHOME/CLASSPATH/proxy) refused; case-sensitive.
- shell: a context carrying `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES`/`NODE_OPTIONS`/`PATH` never reaches `bash.environment`; benign `XCSH_*` vars still do.
- Full utils + coding-agent suites green; type-check + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)