### PR TITLE
feat(context): prompt for web-console username/password in the add wizard (#1752)

### DIFF
--- a/packages/coding-agent/src/modes/components/context-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/context-add-wizard.ts
@@ -1,6 +1,6 @@
 import { Container, Input, matchesKey, Spacer, Text, TruncatedText } from "@f5-sales-demo/pi-tui";
 import type { XCSHContext } from "../../services/xcsh-context";
-import { deriveTenantFromUrl } from "../../services/xcsh-env";
+import { deriveTenantFromUrl, isSensitiveEnvKey, XCSH_CONSOLE_PASSWORD, XCSH_USERNAME } from "../../services/xcsh-env";
 import { theme } from "../theme/theme";
 import { matchesAppInterrupt } from "../utils/keybinding-matchers";
 import { DynamicBorder } from "./dynamic-border";
@@ -28,18 +28,57 @@ export function validateWizardName(name: string): string | null {
 	return null;
 }
 
-type WizardStep = "url" | "token" | "name" | "validating" | "namespace" | "confirm" | "activate";
+type WizardStep =
+	| "url"
+	| "token"
+	| "name"
+	| "validating"
+	| "namespace"
+	| "username"
+	| "password"
+	| "confirm"
+	| "activate";
 
 interface WizardState {
 	url: string;
 	token: string;
 	name: string;
 	namespace: string;
+	/** Web-console login username (optional) — stored as the XCSH_USERNAME env var. */
+	username: string;
+	/** Web-console login password (optional) — stored as the XCSH_CONSOLE_PASSWORD env var. */
+	password: string;
+}
+
+/**
+ * Build the XCSHContext the wizard will persist from its collected state.
+ *
+ * The optional web-console credentials become generic env vars (XCSH_USERNAME /
+ * XCSH_CONSOLE_PASSWORD); any secret-looking key (the password) is auto-marked
+ * sensitive so it is masked in `/context show` and redacted on export. Exported
+ * so the persistence shape is unit-testable without driving the TUI.
+ */
+export function buildWizardContext(state: WizardState): XCSHContext {
+	const context: XCSHContext = {
+		name: state.name,
+		apiUrl: state.url,
+		apiToken: state.token,
+		defaultNamespace: state.namespace,
+	};
+	const env: Record<string, string> = {};
+	if (state.username) env[XCSH_USERNAME] = state.username;
+	if (state.password) env[XCSH_CONSOLE_PASSWORD] = state.password;
+	if (Object.keys(env).length > 0) {
+		context.env = env;
+		const sensitiveKeys = Object.keys(env).filter(isSensitiveEnvKey);
+		if (sensitiveKeys.length > 0) context.sensitiveKeys = sensitiveKeys;
+	}
+	return context;
 }
 
 export class ContextAddWizard extends Container {
 	#currentStep: WizardStep = "url";
-	#state: WizardState = { url: "", token: "", name: "", namespace: "default" };
+	#state: WizardState = { url: "", token: "", name: "", namespace: "default", username: "", password: "" };
 	#contentContainer: Container;
 	#inputField: Input | null = null;
 	#selectedIndex = 0;
@@ -103,6 +142,12 @@ export class ContextAddWizard extends Container {
 				break;
 			case "namespace":
 				this.#renderNamespaceStep();
+				break;
+			case "username":
+				this.#renderUsernameStep();
+				break;
+			case "password":
+				this.#renderPasswordStep();
 				break;
 			case "confirm":
 				this.#renderConfirmStep();
@@ -288,8 +333,40 @@ export class ContextAddWizard extends Container {
 		this.#contentContainer.addChild(new Text(theme.fg("muted", "[Enter to continue, Esc to go back]"), 0, 0));
 	}
 
+	#renderUsernameStep(): void {
+		this.#contentContainer.addChild(new Text(theme.fg("contentAccent", "Step 6: Web-Console Username")));
+		this.#contentContainer.addChild(new Spacer(1));
+		this.#contentContainer.addChild(new Text("Enter the web-console login username (optional):", 0, 0));
+		this.#contentContainer.addChild(new Spacer(1));
+
+		this.#inputField = new Input();
+		this.#inputField.setValue(this.#state.username);
+		this.#contentContainer.addChild(this.#inputField);
+		this.#contentContainer.addChild(new Spacer(1));
+
+		this.#contentContainer.addChild(
+			new Text(theme.fg("muted", "[Enter to continue (empty to skip), Esc to go back]"), 0, 0),
+		);
+	}
+
+	#renderPasswordStep(): void {
+		this.#contentContainer.addChild(new Text(theme.fg("contentAccent", "Step 7: Web-Console Password")));
+		this.#contentContainer.addChild(new Spacer(1));
+		this.#contentContainer.addChild(new Text("Enter the web-console login password (optional):", 0, 0));
+		this.#contentContainer.addChild(new Spacer(1));
+
+		this.#inputField = new Input();
+		this.#inputField.setValue(this.#state.password);
+		this.#contentContainer.addChild(this.#inputField);
+		this.#contentContainer.addChild(new Spacer(1));
+
+		this.#contentContainer.addChild(
+			new Text(theme.fg("muted", "[Enter to continue (empty to skip), Esc to go back]"), 0, 0),
+		);
+	}
+
 	#renderConfirmStep(): void {
-		this.#contentContainer.addChild(new Text(theme.fg("contentAccent", "Step 6: Confirm")));
+		this.#contentContainer.addChild(new Text(theme.fg("contentAccent", "Step 8: Confirm")));
 		this.#contentContainer.addChild(new Spacer(1));
 
 		// Summary table
@@ -298,6 +375,12 @@ export class ContextAddWizard extends Container {
 		const masked = this.#state.token.length > 4 ? `${"*".repeat(8)}${this.#state.token.slice(-4)}` : "****";
 		this.#contentContainer.addChild(new Text(`Token: ${masked}`, 0, 0));
 		this.#contentContainer.addChild(new Text(`Namespace: ${this.#state.namespace}`, 0, 0));
+		if (this.#state.username) {
+			this.#contentContainer.addChild(new Text(`Username: ${this.#state.username}`, 0, 0));
+		}
+		if (this.#state.password) {
+			this.#contentContainer.addChild(new Text(`Console Password: ${"*".repeat(8)}`, 0, 0));
+		}
 		this.#contentContainer.addChild(new Spacer(1));
 
 		this.#contentContainer.addChild(new Text("Save this context?", 0, 0));
@@ -318,7 +401,7 @@ export class ContextAddWizard extends Container {
 	}
 
 	#renderActivateStep(): void {
-		this.#contentContainer.addChild(new Text(theme.fg("contentAccent", "Step 7: Activate")));
+		this.#contentContainer.addChild(new Text(theme.fg("contentAccent", "Step 9: Activate")));
 		this.#contentContainer.addChild(new Spacer(1));
 		this.#contentContainer.addChild(new Text("Activate this context now?", 0, 0));
 		this.#contentContainer.addChild(new Spacer(1));
@@ -436,6 +519,19 @@ export class ContextAddWizard extends Container {
 			}
 			case "namespace": {
 				this.#state.namespace = value || "default";
+				this.#currentStep = "username";
+				break;
+			}
+			case "username": {
+				// Trimmed: usernames never carry meaningful surrounding whitespace.
+				this.#state.username = value;
+				this.#currentStep = "password";
+				break;
+			}
+			case "password": {
+				// Preserve the password exactly as typed — do NOT use the trimmed
+				// `value`, since a password may legitimately contain whitespace.
+				this.#state.password = this.#inputField.getValue();
 				this.#currentStep = "confirm";
 				this.#selectedIndex = 0;
 				break;
@@ -477,12 +573,7 @@ export class ContextAddWizard extends Container {
 				return;
 			}
 			case "activate": {
-				const context: XCSHContext = {
-					name: this.#state.name,
-					apiUrl: this.#state.url,
-					apiToken: this.#state.token,
-					defaultNamespace: this.#state.namespace,
-				};
+				const context = buildWizardContext(this.#state);
 				this.#onCompleteCallback(context, this.#selectedIndex === 0);
 				return;
 			}
@@ -521,8 +612,14 @@ export class ContextAddWizard extends Container {
 			case "namespace":
 				this.#currentStep = "name";
 				break;
-			case "confirm":
+			case "username":
 				this.#currentStep = "namespace";
+				break;
+			case "password":
+				this.#currentStep = "username";
+				break;
+			case "confirm":
+				this.#currentStep = "password";
 				break;
 			case "activate":
 				this.#currentStep = "confirm";

--- a/packages/coding-agent/test/context-add-wizard.test.ts
+++ b/packages/coding-agent/test/context-add-wizard.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "bun:test";
-import { validateWizardName, validateWizardUrl } from "@f5-sales-demo/xcsh/modes/components/context-add-wizard";
+import {
+	buildWizardContext,
+	validateWizardName,
+	validateWizardUrl,
+} from "@f5-sales-demo/xcsh/modes/components/context-add-wizard";
+
+const BASE_STATE = {
+	url: "https://acme.console.ves.volterra.io",
+	token: "tok-abc-1234",
+	name: "prod",
+	namespace: "system",
+	username: "",
+	password: "",
+};
 
 describe("validateWizardUrl", () => {
 	it("accepts valid HTTPS URL", () => {
@@ -49,5 +62,47 @@ describe("validateWizardName", () => {
 	it("rejects special characters", () => {
 		expect(validateWizardName("my context")).not.toBeNull();
 		expect(validateWizardName("prod@01")).not.toBeNull();
+	});
+});
+
+describe("buildWizardContext", () => {
+	it("builds the core fields and omits env when no credentials given", () => {
+		const ctx = buildWizardContext(BASE_STATE);
+		expect(ctx.name).toBe("prod");
+		expect(ctx.apiUrl).toBe("https://acme.console.ves.volterra.io");
+		expect(ctx.apiToken).toBe("tok-abc-1234");
+		expect(ctx.defaultNamespace).toBe("system");
+		expect(ctx.env).toBeUndefined();
+		expect(ctx.sensitiveKeys).toBeUndefined();
+	});
+
+	it("stores username + console password as env and auto-marks the password sensitive", () => {
+		const ctx = buildWizardContext({
+			...BASE_STATE,
+			username: "console-user@example.com",
+			password: "s3cret-console-pass",
+		});
+		expect(ctx.env).toEqual({
+			XCSH_USERNAME: "console-user@example.com",
+			XCSH_CONSOLE_PASSWORD: "s3cret-console-pass",
+		});
+		expect(ctx.sensitiveKeys).toEqual(["XCSH_CONSOLE_PASSWORD"]);
+	});
+
+	it("stores username alone without marking anything sensitive", () => {
+		const ctx = buildWizardContext({ ...BASE_STATE, username: "console-user@example.com" });
+		expect(ctx.env).toEqual({ XCSH_USERNAME: "console-user@example.com" });
+		expect(ctx.sensitiveKeys).toBeUndefined();
+	});
+
+	it("stores password alone and marks it sensitive", () => {
+		const ctx = buildWizardContext({ ...BASE_STATE, password: "s3cret-console-pass" });
+		expect(ctx.env).toEqual({ XCSH_CONSOLE_PASSWORD: "s3cret-console-pass" });
+		expect(ctx.sensitiveKeys).toEqual(["XCSH_CONSOLE_PASSWORD"]);
+	});
+
+	it("preserves a password exactly (no trimming)", () => {
+		const ctx = buildWizardContext({ ...BASE_STATE, password: "  pad ded  " });
+		expect(ctx.env?.XCSH_CONSOLE_PASSWORD).toBe("  pad ded  ");
 	});
 });

--- a/packages/coding-agent/test/xcsh-context-service.test.ts
+++ b/packages/coding-agent/test/xcsh-context-service.test.ts
@@ -482,6 +482,27 @@ describe("ContextService", () => {
 			expect(Number.isNaN(Date.parse(data.metadata.createdAt))).toBe(false);
 		});
 
+		it("persists env + sensitiveKeys (web-console credentials from the wizard)", async () => {
+			const service = ContextService.init(xcshConfigDir);
+			await service.createContext({
+				name: "auth-prof",
+				apiUrl: "https://auth.console.ves.volterra.io",
+				apiToken: "tok",
+				defaultNamespace: "system",
+				env: { XCSH_USERNAME: "console-user@example.com", XCSH_CONSOLE_PASSWORD: "s3cret" },
+				sensitiveKeys: ["XCSH_CONSOLE_PASSWORD"],
+			});
+
+			const data = JSON.parse(fs.readFileSync(path.join(xcshContextsDir, "auth-prof.json"), "utf-8"));
+			expect(data.env).toEqual({ XCSH_USERNAME: "console-user@example.com", XCSH_CONSOLE_PASSWORD: "s3cret" });
+			expect(data.sensitiveKeys).toEqual(["XCSH_CONSOLE_PASSWORD"]);
+
+			// And it round-trips back through the service loader.
+			const loaded = (await service.listContexts()).find(c => c.name === "auth-prof");
+			expect(loaded?.env?.XCSH_USERNAME).toBe("console-user@example.com");
+			expect(loaded?.sensitiveKeys).toEqual(["XCSH_CONSOLE_PASSWORD"]);
+		});
+
 		it("normalizes a pasted full URL to its origin on create", async () => {
 			const service = ContextService.init(xcshConfigDir);
 			await service.createContext({


### PR DESCRIPTION
## Summary
Closes #1752.

The interactive context-add wizard (`ContextAddWizard`) only collected URL → token → name → namespace, so it never captured the web-console login credentials `XCSH_USERNAME` / `XCSH_CONSOLE_PASSWORD`. This affected **both** the standalone xcsh TUI wizard and the VS Code panel (which embeds the same shell wizard over RPC). The VS Code *native* `addContext` command already prompts; this closes the shell-wizard gap.

## Change (single file + tests)
- Two new **optional** steps between Namespace and Confirm: **Username** and **Console Password** (skippable with empty Enter; full back/Esc navigation).
- Values are stored in the context's generic `env` map; the password is preserved **verbatim** (not trimmed) and auto-marked sensitive via the existing `isSensitiveEnvKey` rule, so it's masked in `/context show` and redacted on export. The confirm summary shows the username and a masked password.
- Persistence reuses `service.createContext` (already accepts `env`/`sensitiveKeys`) — no controller change.
- Extracted an exported pure `buildWizardContext(state)` so the persistence shape is unit-testable without driving the TUI.

No pi-utils change, no vscode change, no version bump (`XCSH_USERNAME`/`XCSH_CONSOLE_PASSWORD`/`isSensitiveEnvKey` already exist and are re-exported by `xcsh-env.ts`).

## Tests
- `buildWizardContext`: core fields only when no creds; username+password → `env` + `sensitiveKeys: [XCSH_CONSOLE_PASSWORD]`; username-only (no sensitive); password-only; password preserved untrimmed.
- `createContext`: new test asserts `env`/`sensitiveKeys` round-trip to disk and back through the loader.
- Full coding-agent context suites green; type-check + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)