### PR TITLE
feat(ui): mask secret entry for the API token and console password (#1755)

### DIFF
--- a/packages/coding-agent/src/modes/components/context-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/context-add-wizard.ts
@@ -184,6 +184,7 @@ export class ContextAddWizard extends Container {
 		this.#contentContainer.addChild(new Spacer(1));
 
 		this.#inputField = new Input();
+		this.#inputField.setMasked(true);
 		this.#inputField.setValue(this.#state.token);
 		this.#contentContainer.addChild(this.#inputField);
 		this.#contentContainer.addChild(new Spacer(1));
@@ -356,6 +357,7 @@ export class ContextAddWizard extends Container {
 		this.#contentContainer.addChild(new Spacer(1));
 
 		this.#inputField = new Input();
+		this.#inputField.setMasked(true);
 		this.#inputField.setValue(this.#state.password);
 		this.#contentContainer.addChild(this.#inputField);
 		this.#contentContainer.addChild(new Spacer(1));

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -16,6 +16,9 @@ import {
 
 const segmenter = getSegmenter();
 
+/** Glyph shown in place of each grapheme when an Input is masked (tokens/passwords). */
+const MASK_CHAR = "•";
+
 interface InputState {
 	value: string;
 	cursor: number;
@@ -27,6 +30,7 @@ interface InputState {
 export class Input implements Component, Focusable {
 	#value: string = "";
 	#cursor: number = 0; // Cursor position in the value
+	#masked: boolean = false; // When true, render obscures each grapheme with MASK_CHAR
 	onSubmit?: (value: string) => void;
 	onEscape?: () => void;
 
@@ -50,6 +54,31 @@ export class Input implements Component, Focusable {
 	setValue(value: string): void {
 		this.#value = value;
 		this.#cursor = Math.min(this.#cursor, value.length);
+	}
+
+	/**
+	 * Obscure the rendered text — for secret entry such as API tokens and
+	 * passwords. `getValue()` still returns the real text; only the on-screen
+	 * display (and horizontal-scroll/cursor math) operate on the masked form.
+	 */
+	setMasked(masked: boolean): void {
+		this.#masked = masked;
+	}
+
+	/** The string to render: the real value, or one MASK_CHAR per grapheme when masked. */
+	#displayValue(): string {
+		if (!this.#masked) return this.#value;
+		let count = 0;
+		for (const _seg of segmenter.segment(this.#value)) count++;
+		return MASK_CHAR.repeat(count);
+	}
+
+	/** Cursor offset within #displayValue(): grapheme count before the real cursor when masked. */
+	#displayCursor(): number {
+		if (!this.#masked) return this.#cursor;
+		let count = 0;
+		for (const _seg of segmenter.segment(this.#value.slice(0, this.#cursor))) count++;
+		return count;
 	}
 
 	handleInput(data: string): void {
@@ -378,9 +407,10 @@ export class Input implements Component, Focusable {
 			return [prompt];
 		}
 
-		const cursorIndex = this.#cursor;
+		const value = this.#displayValue();
+		const cursorIndex = this.#displayCursor();
 		// Ensure we always have a grapheme to invert at the cursor (space at end).
-		const displayValue = cursorIndex >= this.#value.length ? `${this.#value} ` : this.#value;
+		const displayValue = cursorIndex >= value.length ? `${value} ` : value;
 
 		const totalCols = visibleWidth(displayValue);
 		const cursorCols = visibleWidth(displayValue.slice(0, cursorIndex));

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -175,4 +175,68 @@ describe("Input component", () => {
 		const width = 40;
 		expect(renderedWidth(input, width)).toBeLessThanOrEqual(width);
 	});
+
+	describe("masked input (tokens / passwords)", () => {
+		// Build the SGR pattern without a literal ESC so the regex carries no control char.
+		const sgrRe = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+		const stripAnsi = (s: string): string => s.replaceAll(CURSOR_MARKER, "").replace(sgrRe, "");
+
+		it("getValue() still returns the real secret", () => {
+			const input = new Input();
+			input.setMasked(true);
+			input.setValue("super-secret-token");
+			expect(input.getValue()).toBe("super-secret-token");
+		});
+
+		it("render obscures the secret with bullet glyphs and leaks no real characters", () => {
+			const input = new Input();
+			input.focused = true;
+			input.setMasked(true);
+			input.setValue("hunter2");
+			input.handleInput("\x05"); // Ctrl+E (cursor to end)
+
+			const visible = stripAnsi(input.render(40)[0]);
+			expect(visible).toContain("•".repeat(7)); // one bullet per grapheme
+			expect(visible).not.toContain("hunter2");
+			expect(visible).not.toContain("hunter");
+		});
+
+		it("typed characters are masked but captured in the value", () => {
+			const input = new Input();
+			input.focused = true;
+			input.setMasked(true);
+			input.handleInput("p");
+			input.handleInput("a");
+			input.handleInput("ss");
+			expect(input.getValue()).toBe("pass");
+			const visible = stripAnsi(input.render(40)[0]);
+			expect(visible).not.toContain("pass");
+			expect(visible).toContain("•".repeat(4));
+		});
+
+		it("masked render width equals unmasked for ASCII (cursor math intact)", () => {
+			const masked = new Input();
+			masked.focused = true;
+			masked.setMasked(true);
+			masked.setValue("token-1234");
+			masked.handleInput("\x05");
+
+			const plain = new Input();
+			plain.focused = true;
+			plain.setValue("token-1234");
+			plain.handleInput("\x05");
+
+			expect(renderedWidth(masked, 40)).toBe(renderedWidth(plain, 40));
+		});
+
+		it("unmasked input renders the real text", () => {
+			const input = new Input();
+			input.focused = true;
+			input.setValue("visible");
+			input.handleInput("\x05");
+			const visible = stripAnsi(input.render(40)[0]);
+			expect(visible).toContain("visible");
+			expect(visible).not.toContain("•");
+		});
+	});
 });


### PR DESCRIPTION
## Summary
Closes #1755.

The TUI `Input` rendered typed characters in the clear, so the context add-wizard showed the **API token** and the new **web-console password** as plain text during entry. This adds a masked-entry mode and turns it on for both secret steps.

## Change
- `Input.setMasked(true)` — renders one `•` per grapheme instead of the real characters. `getValue()` still returns the real text; the horizontal-scroll and cursor math run on the masked form, so cursor positioning and viewport clamping stay correct (masked rendered width equals the unmasked width for ASCII).
- Wizard token + password steps call `setMasked(true)`.

No new exports/deps; no version bump.

## Tests (pi-tui `input.test.ts`)
- `getValue()` returns the real secret while masked.
- Render obscures the value with bullets and leaks no real characters; typed input is masked but captured.
- Masked vs unmasked rendered width is identical for ASCII (cursor math intact).
- Unmasked input is unchanged.
- Full `tui` + `coding-agent` wizard suites green; type-check + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)