### PR TITLE
feat(browser): observable workflow runs enable explain mode

### DIFF
--- a/packages/coding-agent/src/browser/extension-page-actions.ts
+++ b/packages/coding-agent/src/browser/extension-page-actions.ts
@@ -249,6 +249,10 @@ export class ExtensionPageActions implements PageActions {
 		await this.#ext.navigate(url);
 	}
 
+	async setExplainMode(enabled: boolean): Promise<void> {
+		await this.#ext.setExplainMode(enabled);
+	}
+
 	async click(selector: string, _context?: string): Promise<void> {
 		// Deterministic click: resolve the selector to the live element, then let the
 		// extension derive geometry from the renderer (DOM.getContentQuads) and

--- a/packages/coding-agent/src/browser/extension-provider.ts
+++ b/packages/coding-agent/src/browser/extension-provider.ts
@@ -75,6 +75,9 @@ export interface ExtensionPage {
 		value: string;
 		optionCount: number;
 	}>;
+	/** Toggle the extension's "explain mode" — the gate for on-page annotation
+	 * overlays (fingerprints/highlights), used during human-paced walkthroughs. */
+	setExplainMode(enabled: boolean): Promise<void>;
 }
 
 /** Unwrap a {@link ToolResult}, throwing on the error flag. */
@@ -151,6 +154,10 @@ class BridgeExtensionPage implements ExtensionPage {
 
 	async screenshot(): Promise<string> {
 		return unwrap(await this.#server.request("screenshot", {}), "screenshot") as string;
+	}
+
+	async setExplainMode(enabled: boolean): Promise<void> {
+		unwrap(await this.#server.request("set_explain_mode", { enabled }), "set_explain_mode");
 	}
 
 	async formInput(ref: string, value: string): Promise<void> {

--- a/packages/coding-agent/src/browser/page-actions.ts
+++ b/packages/coding-agent/src/browser/page-actions.ts
@@ -15,4 +15,8 @@ export interface PageActions {
 	assertText(selector: string, expected: string, context?: string): Promise<void>;
 	waitFor(selector: string, context?: string, timeoutMs?: number): Promise<void>;
 	screenshot(file: string): Promise<void>;
+	/** Extension-only: toggle "explain mode" so on-page annotation overlays
+	 * (fingerprints/highlights) show during human-paced (observable) runs.
+	 * Backends that don't support it (CDP/Puppeteer) omit this method. */
+	setExplainMode?(enabled: boolean): Promise<void>;
 }

--- a/packages/coding-agent/src/tools/catalog-workflow-runner.ts
+++ b/packages/coding-agent/src/tools/catalog-workflow-runner.ts
@@ -633,6 +633,11 @@ export class CatalogWorkflowRunnerTool
 			const acquired = await provider.acquire(baseUrl);
 			const page = acquired.page;
 
+			// Observable (human-paced) runs are demonstrations for a watching human —
+			// turn on the extension's explain mode so each click blooms a fingerprint
+			// overlay (and other annotations apply). No-op on backends without it.
+			if (observable && page.setExplainMode) await page.setExplainMode(true).catch(() => {});
+
 			// Execute steps
 			const stepResults: StepResult[] = [];
 			let failedAtStep: string | undefined;
@@ -676,6 +681,8 @@ export class CatalogWorkflowRunnerTool
 					}
 				}
 			} finally {
+				// Leave explain mode off so a later fast (non-observable) run isn't annotated.
+				if (observable && page.setExplainMode) await page.setExplainMode(false).catch(() => {});
 				await acquired.release();
 			}
 

--- a/packages/coding-agent/test/browser/extension-contract.test.ts
+++ b/packages/coding-agent/test/browser/extension-contract.test.ts
@@ -73,7 +73,7 @@ describe("extension contract drift guards", () => {
 	// Non-meta tools the typed client intentionally does NOT wrap yet (driven
 	// elsewhere, or part of a later behavioural layer). Adding a new extension tool
 	// forces it to be wrapped here or acknowledged in this list.
-	const KNOWN_UNWRAPPED = new Set(["wait_for_api_response", "set_explain_mode", "annotate"]);
+	const KNOWN_UNWRAPPED = new Set(["wait_for_api_response", "annotate"]);
 
 	it("every tool the bridge client requests exists in the contract", () => {
 		const unknown = extractRequestedTools(providerSource).filter(t => !EXTENSION_TOOL_NAMES.includes(t));


### PR DESCRIPTION
Closes #1766

The extension's explain-mode + annotation overlays (fingerprint-on-click, highlights) were built (`xcsh-chrome-extension`) and consumed (#1762) but **never turned on**. This wires them to the natural trigger that already exists: `catalog_workflow_runner`'s **observable** ("slow execution for a watching human") mode.

## What
- **`ExtensionPage.setExplainMode()`** — wrap the `set_explain_mode` bridge tool in the typed client. The drift guard now *enforces* it's wrapped (removed from the allowlist).
- **`PageActions.setExplainMode?()`** — an optional capability on the shared surface; only the extension backend implements it (CDP/Puppeteer omits it, so the runner's guard skips it).
- **`catalog_workflow_runner`** — when `observable` is on, flip explain mode **on** before the steps and **off** in `finally`. Each click in a slow walkthrough now blooms a fingerprint overlay; fast automation stays clean.

Smallest activation of the annotation feature. Richer behaviour (per-step highlight-before-click, named profiles, narration, headless annotated capture) is a separate design.

## Testing (TDD)
- The **drift guard drove the wrapping**: removing `set_explain_mode` from the allowlist made the guard go RED ("not wrapped"), wrapping it in `BridgeExtensionPage` made it GREEN. `bun test test/browser/extension-contract.test.ts` ✅ 10/10.
- biome clean on changed lines (one pre-existing ineffective-suppression warning on the untouched `screenshot` no-op). Full monorepo `check:types`/`test` runs in CI (workspace not installed in my sandbox; no logic errors in my files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)