### PR TITLE
feat(browser): presentation profiles — generalize observable into named behavioural profiles

### DIFF
--- a/packages/coding-agent/src/browser/presentation-profile.ts
+++ b/packages/coding-agent/src/browser/presentation-profile.ts
@@ -1,0 +1,38 @@
+/**
+ * Presentation profiles — named bundles of browser-behaviour axes the agent
+ * picks per the human's intent. Pure + chrome-free; the runner consumes the
+ * resolved axes. See docs/superpowers/specs/2026-06-28-presentation-profiles.md.
+ */
+export type ProfileName = "fast" | "guided" | "instructor" | "capture";
+
+export interface ResolvedAxes {
+	readonly paceMs: number;
+	readonly annotations: boolean;
+	readonly narration: "none" | "minimal" | "full";
+	readonly capture: "off" | "per-step";
+	readonly surface: "inherit" | "visible" | "headless";
+}
+
+export const PROFILES: Record<ProfileName, ResolvedAxes> = {
+	fast: { paceMs: 0, annotations: false, narration: "none", capture: "off", surface: "inherit" },
+	guided: { paceMs: 1500, annotations: true, narration: "minimal", capture: "off", surface: "visible" },
+	instructor: { paceMs: 2200, annotations: true, narration: "full", capture: "off", surface: "visible" },
+	capture: { paceMs: 800, annotations: true, narration: "minimal", capture: "per-step", surface: "headless" },
+};
+
+const DEFAULT_PROFILE: ProfileName = "fast";
+
+export function isProfileName(v: unknown): v is ProfileName {
+	return typeof v === "string" && Object.hasOwn(PROFILES, v);
+}
+
+/** Resolve axes. Precedence: per-run profile > session default > `fast`; then
+ * per-axis overrides merge on top. */
+export function resolveProfile(
+	profile?: string,
+	overrides?: Partial<ResolvedAxes>,
+	sessionDefault?: string,
+): ResolvedAxes {
+	const name = isProfileName(profile) ? profile : isProfileName(sessionDefault) ? sessionDefault : DEFAULT_PROFILE;
+	return { ...PROFILES[name], ...(overrides ?? {}) };
+}

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1401,6 +1401,16 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"browser.presentation": {
+		type: "string",
+		default: "fast",
+		ui: {
+			tab: "tools",
+			label: "Presentation Profile",
+			description: "Default browser presentation profile: fast | guided | instructor | capture",
+		},
+	},
+
 	"browser.connectUrl": {
 		type: "string",
 		default: undefined,

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -299,6 +299,16 @@ Most tools resolve custom protocol URLs to internal resources (not web URLs):
 - `xcsh://console/` — F5 XC admin-console catalogue: UI routes, form sections, and deterministic browser-automation workflows.
   - `xcsh://console/<resource>` — console route pattern, menu path, and available operations.
   - `xcsh://console/<resource>/<operation>` — the exact ordered UI steps (selectors) for that operation.
+- `xcsh://extension` — Chrome extension bridge tool API reference: which tool to use (click, typeahead, input, navigation) for each automation task.
+
+### Presentation profile
+
+`catalog_workflow_runner` takes a `presentation` profile (defaults to the session setting `browser.presentation`, default `fast`):
+- `fast` — just do it, no on-screen annotations (default).
+- `guided` — when the human wants to **watch / be shown** where things happen: human-paced, with a fingerprint on each click.
+- `instructor` — when the human wants to **understand** (why/what/where): guided pacing + narrate each step.
+- `capture` — when producing **annotated screenshots** for later viewing.
+Set a session-wide default with `set_presentation_profile`.
 
   When the user needs to **make an API call** (create, read, update, delete):
   1. `xcsh://api-catalog/?resource={resource_name}&compact=true` → get endpoint path, method,

--- a/packages/coding-agent/src/prompts/tools/catalog-workflow-runner.md
+++ b/packages/coding-agent/src/prompts/tools/catalog-workflow-runner.md
@@ -4,7 +4,7 @@ Runs a workflow from the F5 XC console catalog against a live browser session.
 - The console workflow catalogue is embedded in xcsh; `catalog_path` is optional and only needed to override with a local checkout
 - Executes browser automation steps sequentially (navigate, click, fill, assert, etc.) against the browser attached via `browser.connectUrl` (co-drive headed) or a background target (autonomous + screenshots)
 - Resolves {param} placeholders from the provided params map
-- Supports conditional steps, sub-steps, and observable mode with screenshots
+- Supports conditional steps, sub-steps, and presentation profiles (fast / guided / instructor / capture)
 - Use this tool when you need to automate F5 XC console operations defined in catalog workflows
 </instruction>
 

--- a/packages/coding-agent/src/tools/catalog-workflow-runner.ts
+++ b/packages/coding-agent/src/tools/catalog-workflow-runner.ts
@@ -6,6 +6,7 @@ import { type Static, Type } from "@sinclair/typebox";
 import { parse as parseYaml } from "yaml";
 import { selectProvider } from "../browser";
 import type { PageActions } from "../browser/page-actions";
+import { resolveProfile } from "../browser/presentation-profile";
 import { CONSOLE_CATALOG_DATA } from "../internal-urls/console-catalog.generated";
 import catalogWorkflowRunnerDescription from "../prompts/tools/catalog-workflow-runner.md" with { type: "text" };
 import { ContextService } from "../services/xcsh-context";
@@ -29,10 +30,15 @@ const catalogWorkflowRunnerSchema = Type.Object({
 			description: "Workflow parameters (name, namespace, etc.) for {placeholder} resolution",
 		}),
 	),
-	observable: Type.Optional(Type.Boolean({ description: "Enable slow execution with screenshots after each step" })),
-	observable_delay_ms: Type.Optional(
-		Type.Number({ description: "Delay between steps in observable mode (default 1500)" }),
+	presentation: Type.Optional(
+		Type.Union(
+			["fast", "guided", "instructor", "capture"].map(p => Type.Literal(p)),
+			{
+				description: "Presentation profile for this run; overrides the session default (browser.presentation).",
+			},
+		),
 	),
+	pace_ms: Type.Optional(Type.Number({ description: "Override the profile's inter-step delay (ms)." })),
 	screenshot_dir: Type.Optional(Type.String({ description: "Directory to save screenshots" })),
 	base_url: Type.Optional(Type.String({ description: "XCSH console base URL; falls back to XCSH_API_URL env var" })),
 });
@@ -113,7 +119,6 @@ export interface CatalogWorkflowRunnerDetails {
 // =============================================================================
 
 const EXPECTED_SCHEMA = "urn:xcsh:console:workflow:v1";
-const DEFAULT_OBSERVABLE_DELAY_MS = 1500;
 const MAX_WORKFLOW_DEPTH = 10;
 
 // =============================================================================
@@ -294,8 +299,7 @@ export class CatalogWorkflowRunnerTool
 		baseUrl: string,
 		page: PageActions,
 		options: {
-			observable: boolean;
-			observableDelayMs: number;
+			paceMs: number;
 			screenshotDir?: string;
 			stepIndex: number;
 			catalogPath?: string;
@@ -521,24 +525,9 @@ export class CatalogWorkflowRunnerTool
 				}
 			}
 
-			// Observable mode: delay + screenshot
-			if (options.observable && result.status !== "fail") {
-				await new Promise(resolve => setTimeout(resolve, options.observableDelayMs));
-				if (options.screenshotDir) {
-					const safeId = step.id.replace(/[^a-z0-9-]/gi, "-");
-					const obsPath = path.resolve(options.screenshotDir, `step-${options.stepIndex}-${safeId}.png`);
-					if (obsPath.startsWith(path.resolve(options.screenshotDir) + path.sep)) {
-						try {
-							await page.screenshot(obsPath);
-							result.screenshotPath = obsPath;
-						} catch (e) {
-							logger.warn("catalog-workflow-runner: observable screenshot failed", {
-								step: step.id,
-								error: e instanceof Error ? e.message : String(e),
-							});
-						}
-					}
-				}
+			// Inter-step pacing for human-paced (annotated) runs.
+			if (options.paceMs > 0 && result.status !== "fail") {
+				await new Promise(resolve => setTimeout(resolve, options.paceMs));
 			}
 		} catch (e) {
 			result.status = "fail";
@@ -619,8 +608,6 @@ export class CatalogWorkflowRunnerTool
 			}
 
 			// Options
-			const observable = inputParams.observable ?? false;
-			const observableDelayMs = inputParams.observable_delay_ms ?? DEFAULT_OBSERVABLE_DELAY_MS;
 			const screenshotDir = inputParams.screenshot_dir;
 
 			// Ensure screenshot directory exists
@@ -633,10 +620,12 @@ export class CatalogWorkflowRunnerTool
 			const acquired = await provider.acquire(baseUrl);
 			const page = acquired.page;
 
-			// Observable (human-paced) runs are demonstrations for a watching human —
-			// turn on the extension's explain mode so each click blooms a fingerprint
-			// overlay (and other annotations apply). No-op on backends without it.
-			if (observable && page.setExplainMode) await page.setExplainMode(true).catch(() => {});
+			const axes = resolveProfile(
+				inputParams.presentation,
+				inputParams.pace_ms !== undefined ? { paceMs: inputParams.pace_ms } : undefined,
+				this.#toolSession.settings.get("browser.presentation") as string | undefined,
+			);
+			if (axes.annotations && page.setExplainMode) await page.setExplainMode(true).catch(() => {});
 
 			// Execute steps
 			const stepResults: StepResult[] = [];
@@ -655,8 +644,7 @@ export class CatalogWorkflowRunnerTool
 					// the browser). Non-idempotent steps are safe to retry here because
 					// they failed (the action did not take effect).
 					const opts = {
-						observable,
-						observableDelayMs,
+						paceMs: axes.paceMs,
 						screenshotDir,
 						stepIndex: i,
 						catalogPath: inputParams.catalog_path,
@@ -681,8 +669,7 @@ export class CatalogWorkflowRunnerTool
 					}
 				}
 			} finally {
-				// Leave explain mode off so a later fast (non-observable) run isn't annotated.
-				if (observable && page.setExplainMode) await page.setExplainMode(false).catch(() => {});
+				if (axes.annotations && page.setExplainMode) await page.setExplainMode(false).catch(() => {});
 				await acquired.release();
 			}
 

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -43,6 +43,7 @@ import { createReportToolIssueTool, isAutoQaEnabled } from "./report-tool-issue"
 import { ResolveTool } from "./resolve";
 import { reportFindingTool } from "./review";
 import { SearchToolBm25Tool } from "./search-tool-bm25";
+import { SetPresentationProfileTool } from "./set-presentation-profile";
 import { loadSshTool } from "./ssh";
 import { SubmitResultTool } from "./submit-result";
 import { type TodoPhase, TodoWriteTool } from "./todo-write";
@@ -231,6 +232,7 @@ export const BUILTIN_TOOLS: Record<string, ToolFactory> = {
 	search_tool_bm25: SearchToolBm25Tool.createIf,
 	write: s => new WriteTool(s),
 	xcsh_api: s => new XcshApiTool(s),
+	set_presentation_profile: s => new SetPresentationProfileTool(s),
 };
 
 export const HIDDEN_TOOLS: Record<string, ToolFactory> = {

--- a/packages/coding-agent/src/tools/set-presentation-profile.ts
+++ b/packages/coding-agent/src/tools/set-presentation-profile.ts
@@ -1,0 +1,42 @@
+import type { AgentTool, AgentToolResult } from "@f5-sales-demo/pi-agent-core";
+import { StringEnum } from "@f5-sales-demo/pi-ai";
+import { type Static, Type } from "@sinclair/typebox";
+import { isProfileName } from "../browser/presentation-profile";
+import type { ToolSession } from "./index";
+import { ToolError } from "./tool-errors";
+
+const setPresentationProfileSchema = Type.Object(
+	{
+		profile: StringEnum(["fast", "guided", "instructor", "capture"], {
+			description: "Presentation profile to apply for this session: fast | guided | instructor | capture",
+		}),
+	},
+	{ additionalProperties: false },
+);
+
+type SetPresentationProfileParams = Static<typeof setPresentationProfileSchema>;
+
+export class SetPresentationProfileTool implements AgentTool<typeof setPresentationProfileSchema, { profile: string }> {
+	readonly name = "set_presentation_profile";
+	readonly label = "SetPresentationProfile";
+	readonly description =
+		"Set the browser presentation profile for this session (fast, guided, instructor, or capture). Controls pacing, annotations, narration, and capture behaviour.";
+	readonly parameters = setPresentationProfileSchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {}
+
+	async execute(
+		_toolCallId: string,
+		{ profile }: SetPresentationProfileParams,
+	): Promise<AgentToolResult<{ profile: string }>> {
+		if (!isProfileName(profile)) {
+			throw new ToolError(`Invalid profile "${profile}". Must be one of: fast, guided, instructor, capture.`);
+		}
+		this.session.settings.set("browser.presentation", profile);
+		return {
+			content: [{ type: "text", text: `Presentation profile set to "${profile}".` }],
+			details: { profile },
+		};
+	}
+}

--- a/packages/coding-agent/test/browser/presentation-profile.test.ts
+++ b/packages/coding-agent/test/browser/presentation-profile.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { PROFILES, resolveProfile } from "../../src/browser/presentation-profile";
+
+describe("resolveProfile", () => {
+	it("resolves each named profile to its preset axes", () => {
+		expect(resolveProfile("guided")).toEqual(PROFILES.guided);
+		expect(resolveProfile("instructor")).toEqual(PROFILES.instructor);
+		expect(resolveProfile("capture")).toEqual(PROFILES.capture);
+		expect(resolveProfile("fast")).toEqual(PROFILES.fast);
+	});
+	it("falls back to fast for an unknown or missing name", () => {
+		expect(resolveProfile("nope")).toEqual(PROFILES.fast);
+		expect(resolveProfile(undefined)).toEqual(PROFILES.fast);
+	});
+	it("uses the session default when no per-run profile is given", () => {
+		expect(resolveProfile(undefined, undefined, "guided")).toEqual(PROFILES.guided);
+	});
+	it("lets a per-run profile beat the session default", () => {
+		expect(resolveProfile("fast", undefined, "guided")).toEqual(PROFILES.fast);
+	});
+	it("merges per-axis overrides over the resolved base", () => {
+		const r = resolveProfile("guided", { paceMs: 2500 });
+		expect(r.paceMs).toBe(2500);
+		expect(r.annotations).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #1768

Replaces `catalog_workflow_runner`'s `observable` boolean with a **presentation profile** system — the spine for the guided/instructor/fast/capture behaviours.

## What
- **Profile model** (`src/browser/presentation-profile.ts`, pure, TDD'd) — 4 named presets (fast/guided/instructor/capture) mapping to 5 axes (paceMs, annotations, narration, capture, surface), with per-axis overrides + session-default + per-run resolution. `resolveProfile()` is the tested core (5 tests: presets, unknown→fast, session-default, per-run beats default, override merge).
- **Session default** — `browser.presentation` setting (default `fast`) + a `set_presentation_profile` tool.
- **Runner** — **clean break**: retires `observable`/`observable_delay_ms`; adds `presentation` + `pace_ms`; resolves axes once per run; wires **pacing** (paceMs→inter-step delay) and **annotations** (annotations→`setExplainMode` on/off). Observable's per-step screenshot removed (returns with the `capture` axis in a follow-up).
- **System-prompt guidance** — tells the agent when to pick each profile.
- **Stale doc fixed** — tool description updated from "observable mode" → "presentation profiles".

Defined-but-deferred axes: `narration` (sub-project #3), per-step `highlight` (#2), `capture`/`surface` (#4). They exist in `ResolvedAxes` (model-complete), wired in those follow-ups.

## Testing
- `bun test test/browser/presentation-profile.test.ts` ✅ 5/5 — resolveProfile (presets, fallback, precedence, override merge).
- Per-task reviews (4 tasks, all SPEC ✅ / QUALITY Approved) + a final whole-branch review (opus): **MERGE WITH FIXES** — the one fix (stale "observable" doc ref) is applied.
- biome clean on all touched files; tsgo (filtered) confirms zero new logic errors; full monorepo check runs in CI.

## Accumulated Minors (accepted as-is per final review)
- Redundant `isProfileName` guard in the tool's execute (harmless defense behind schema enum).
- Tool label `"SetPresentationProfile"` (PascalCase — consistent with an existing label faction).
- `settings.get(...) as string | undefined` cast (unnecessary but harmless — the setting is already typed `string`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)