### PR TITLE
feat(browser): wire capture axis — per-step screenshots gated by profile

### DIFF
--- a/packages/coding-agent/src/tools/catalog-workflow-runner.ts
+++ b/packages/coding-agent/src/tools/catalog-workflow-runner.ts
@@ -300,6 +300,7 @@ export class CatalogWorkflowRunnerTool
 		page: PageActions,
 		options: {
 			paceMs: number;
+			capture: "off" | "per-step";
 			screenshotDir?: string;
 			stepIndex: number;
 			catalogPath?: string;
@@ -529,6 +530,21 @@ export class CatalogWorkflowRunnerTool
 			if (options.paceMs > 0 && result.status !== "fail") {
 				await new Promise(resolve => setTimeout(resolve, options.paceMs));
 			}
+
+			// Per-step capture: screenshot after each successful step when the
+			// capture axis is "per-step" and a screenshot directory is provided.
+			if (options.capture === "per-step" && options.screenshotDir && result.status !== "fail") {
+				try {
+					const safeId = step.id.replace(/[^a-z0-9-]/gi, "-");
+					const capturePath = path.resolve(options.screenshotDir, `step-${options.stepIndex}-${safeId}.png`);
+					if (capturePath.startsWith(path.resolve(options.screenshotDir) + path.sep)) {
+						await page.screenshot(capturePath);
+						result.screenshotPath = capturePath;
+					}
+				} catch {
+					// Best-effort capture; don't fail the step for a screenshot issue.
+				}
+			}
 		} catch (e) {
 			result.status = "fail";
 			result.error = e instanceof Error ? e.message : String(e);
@@ -645,6 +661,7 @@ export class CatalogWorkflowRunnerTool
 					// they failed (the action did not take effect).
 					const opts = {
 						paceMs: axes.paceMs,
+						capture: axes.capture,
 						screenshotDir,
 						stepIndex: i,
 						catalogPath: inputParams.catalog_path,

--- a/packages/coding-agent/test/browser/presentation-profile.test.ts
+++ b/packages/coding-agent/test/browser/presentation-profile.test.ts
@@ -23,4 +23,18 @@ describe("resolveProfile", () => {
 		expect(r.paceMs).toBe(2500);
 		expect(r.annotations).toBe(true);
 	});
+
+	it("capture profile enables per-step capture + annotations + headless", () => {
+		const r = resolveProfile("capture");
+		expect(r.capture).toBe("per-step");
+		expect(r.annotations).toBe(true);
+		expect(r.surface).toBe("headless");
+		expect(r.paceMs).toBe(800);
+	});
+
+	it("fast profile disables capture and annotations", () => {
+		const r = resolveProfile("fast");
+		expect(r.capture).toBe("off");
+		expect(r.annotations).toBe(false);
+	});
 });


### PR DESCRIPTION
Closes #1770

Wires the `capture` axis from the presentation-profile system (merged in #1769). When resolved `axes.capture === "per-step"` (the `capture` profile) AND `screenshot_dir` is provided, each successful step gets a post-step screenshot — re-adding what `observable` had, now properly gated by the profile.

## Changes
- `catalog-workflow-runner.ts`: pass `capture` axis through to `#executeStep` options; after the inter-step pacing block, if `capture === "per-step"` + `screenshotDir`, take a screenshot (path-escape guarded, best-effort).
- `test/browser/presentation-profile.test.ts`: 2 new tests (capture preset: per-step + annotations + headless; fast preset: capture off + annotations off). 7/7.

biome clean; 7/7 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)