### PR TITLE
feat(browser): per-step highlight-before-click in annotated profiles

### DIFF
--- a/packages/coding-agent/src/browser/extension-page-actions.ts
+++ b/packages/coding-agent/src/browser/extension-page-actions.ts
@@ -253,6 +253,18 @@ export class ExtensionPageActions implements PageActions {
 		await this.#ext.setExplainMode(enabled);
 	}
 
+	async highlightElement(selector: string): Promise<void> {
+		// Resolve the selector to the element's bounding rect (reusing the same
+		// resolver the click path uses), then draw a highlight overlay. Uses
+		// javascriptTool (evaluateWithRecovery) which can defocus an input — fine
+		// for a pre-click "look here" cue since the click immediately follows.
+		const js = `(function(){const el=(${buildElementResolverScript(selector)});if(!el)return null;const r=el.getBoundingClientRect();return{x:Math.round(r.x),y:Math.round(r.y),w:Math.round(r.width),h:Math.round(r.height)}})()`;
+		const rect = (await this.#ext.javascriptTool(js)) as { x: number; y: number; w: number; h: number } | null;
+		if (rect) {
+			await this.#ext.annotate({ kind: "highlight", x: rect.x, y: rect.y, w: rect.w, h: rect.h });
+		}
+	}
+
 	async click(selector: string, _context?: string): Promise<void> {
 		// Deterministic click: resolve the selector to the live element, then let the
 		// extension derive geometry from the renderer (DOM.getContentQuads) and

--- a/packages/coding-agent/src/browser/extension-provider.ts
+++ b/packages/coding-agent/src/browser/extension-provider.ts
@@ -78,6 +78,9 @@ export interface ExtensionPage {
 	/** Toggle the extension's "explain mode" — the gate for on-page annotation
 	 * overlays (fingerprints/highlights), used during human-paced walkthroughs. */
 	setExplainMode(enabled: boolean): Promise<void>;
+	/** Draw an annotation overlay (requires explain mode). For highlight, pass a
+	 * ref that the extension resolves to a bounding rect, or explicit geometry. */
+	annotate(spec: { kind: string; ref?: string; x?: number; y?: number; w?: number; h?: number }): Promise<void>;
 }
 
 /** Unwrap a {@link ToolResult}, throwing on the error flag. */
@@ -158,6 +161,10 @@ class BridgeExtensionPage implements ExtensionPage {
 
 	async setExplainMode(enabled: boolean): Promise<void> {
 		unwrap(await this.#server.request("set_explain_mode", { enabled }), "set_explain_mode");
+	}
+
+	async annotate(spec: { kind: string; ref?: string; x?: number; y?: number; w?: number; h?: number }): Promise<void> {
+		unwrap(await this.#server.request("annotate", spec), "annotate");
 	}
 
 	async formInput(ref: string, value: string): Promise<void> {

--- a/packages/coding-agent/src/browser/page-actions.ts
+++ b/packages/coding-agent/src/browser/page-actions.ts
@@ -19,4 +19,9 @@ export interface PageActions {
 	 * (fingerprints/highlights) show during human-paced (observable) runs.
 	 * Backends that don't support it (CDP/Puppeteer) omit this method. */
 	setExplainMode?(enabled: boolean): Promise<void>;
+	/** Extension-only: highlight an element's bounding box (a "look here"
+	 * cue before clicking). The runner calls this before click steps in
+	 * guided/instructor profiles. The extension resolves the selector to a
+	 * rect via `annotate { kind: "highlight", ref }`. */
+	highlightElement?(selector: string): Promise<void>;
 }

--- a/packages/coding-agent/src/tools/catalog-workflow-runner.ts
+++ b/packages/coding-agent/src/tools/catalog-workflow-runner.ts
@@ -300,6 +300,7 @@ export class CatalogWorkflowRunnerTool
 		page: PageActions,
 		options: {
 			paceMs: number;
+			annotations: boolean;
 			screenshotDir?: string;
 			stepIndex: number;
 			catalogPath?: string;
@@ -355,6 +356,11 @@ export class CatalogWorkflowRunnerTool
 				}
 				case "click": {
 					if (!resolvedSelector) throw new ToolError(`Step "${step.id}": click requires selector`);
+					// In annotated profiles (guided/instructor), highlight the target
+					// before clicking so a human watcher sees "look here" → pause → click.
+					if (options.annotations && page.highlightElement) {
+						await page.highlightElement(resolvedSelector).catch(() => {});
+					}
 					await page.click(resolvedSelector, resolvedContext);
 					break;
 				}
@@ -645,6 +651,7 @@ export class CatalogWorkflowRunnerTool
 					// they failed (the action did not take effect).
 					const opts = {
 						paceMs: axes.paceMs,
+						annotations: axes.annotations,
 						screenshotDir,
 						stepIndex: i,
 						catalogPath: inputParams.catalog_path,

--- a/packages/coding-agent/test/browser/extension-contract.test.ts
+++ b/packages/coding-agent/test/browser/extension-contract.test.ts
@@ -73,7 +73,7 @@ describe("extension contract drift guards", () => {
 	// Non-meta tools the typed client intentionally does NOT wrap yet (driven
 	// elsewhere, or part of a later behavioural layer). Adding a new extension tool
 	// forces it to be wrapped here or acknowledged in this list.
-	const KNOWN_UNWRAPPED = new Set(["wait_for_api_response", "annotate"]);
+	const KNOWN_UNWRAPPED = new Set(["wait_for_api_response"]);
 
 	it("every tool the bridge client requests exists in the contract", () => {
 		const unknown = extractRequestedTools(providerSource).filter(t => !EXTENSION_TOOL_NAMES.includes(t));


### PR DESCRIPTION
Closes #1772

Before each click step in **guided/instructor** profiles, the runner now **highlights the target** ('look here' → pause → click), so a human watcher sees where the agent is about to act.

## What
- **`ExtensionPage.annotate(spec)`** — wrap the `annotate` bridge tool in the typed client (drift guard now enforces it — removed from allowlist).
- **`PageActions.highlightElement?(selector)`** — optional capability; `ExtensionPageActions` resolves the catalogue selector to a bounding rect (via `javascriptTool` + `getBoundingClientRect`) and calls `annotate({kind:"highlight", x,y,w,h})`.
- **Runner** click step: when `options.annotations` is on, calls `page.highlightElement(selector)` before `page.click(selector)`.

## Testing
- Drift guard: RED (removed annotate from allowlist) → GREEN (wrapped). 10/10.
- Profile tests: 5/5.
- biome clean. Full `check:types`/`test` runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)