### PR TITLE
feat(browser): instructor narration — conversational per-step text + on-page callouts

### DIFF
--- a/packages/coding-agent/src/browser/extension-page-actions.ts
+++ b/packages/coding-agent/src/browser/extension-page-actions.ts
@@ -253,6 +253,16 @@ export class ExtensionPageActions implements PageActions {
 		await this.#ext.setExplainMode(enabled);
 	}
 
+	async showCallout(selector: string, text: string): Promise<void> {
+		// Resolve the selector to coords (same pattern as highlightElement), then
+		// draw a text callout overlay above the target.
+		const js = `(function(){const el=(${buildElementResolverScript(selector)});if(!el)return null;const r=el.getBoundingClientRect();return{x:Math.round(r.x+r.width/2),y:Math.round(r.y),w:Math.round(r.width),h:Math.round(r.height)}})()`;
+		const rect = (await this.#ext.javascriptTool(js)) as { x: number; y: number } | null;
+		if (rect) {
+			await this.#ext.annotate({ kind: "callout", x: rect.x, y: rect.y, text });
+		}
+	}
+
 	async click(selector: string, _context?: string): Promise<void> {
 		// Deterministic click: resolve the selector to the live element, then let the
 		// extension derive geometry from the renderer (DOM.getContentQuads) and

--- a/packages/coding-agent/src/browser/extension-provider.ts
+++ b/packages/coding-agent/src/browser/extension-provider.ts
@@ -78,6 +78,15 @@ export interface ExtensionPage {
 	/** Toggle the extension's "explain mode" — the gate for on-page annotation
 	 * overlays (fingerprints/highlights), used during human-paced walkthroughs. */
 	setExplainMode(enabled: boolean): Promise<void>;
+	annotate(spec: {
+		kind: string;
+		ref?: string;
+		x?: number;
+		y?: number;
+		w?: number;
+		h?: number;
+		text?: string;
+	}): Promise<void>;
 }
 
 /** Unwrap a {@link ToolResult}, throwing on the error flag. */
@@ -158,6 +167,18 @@ class BridgeExtensionPage implements ExtensionPage {
 
 	async setExplainMode(enabled: boolean): Promise<void> {
 		unwrap(await this.#server.request("set_explain_mode", { enabled }), "set_explain_mode");
+	}
+
+	async annotate(spec: {
+		kind: string;
+		ref?: string;
+		x?: number;
+		y?: number;
+		w?: number;
+		h?: number;
+		text?: string;
+	}): Promise<void> {
+		unwrap(await this.#server.request("annotate", spec), "annotate");
 	}
 
 	async formInput(ref: string, value: string): Promise<void> {

--- a/packages/coding-agent/src/browser/page-actions.ts
+++ b/packages/coding-agent/src/browser/page-actions.ts
@@ -19,4 +19,7 @@ export interface PageActions {
 	 * (fingerprints/highlights) show during human-paced (observable) runs.
 	 * Backends that don't support it (CDP/Puppeteer) omit this method. */
 	setExplainMode?(enabled: boolean): Promise<void>;
+	/** Extension-only: show an explanatory text callout near a target element
+	 * (instructor narration). The text fades after ~2s. */
+	showCallout?(selector: string, text: string): Promise<void>;
 }

--- a/packages/coding-agent/src/tools/catalog-workflow-runner.ts
+++ b/packages/coding-agent/src/tools/catalog-workflow-runner.ts
@@ -97,6 +97,9 @@ export interface StepResult {
 	stepId: string;
 	action: string;
 	description?: string;
+	/** Instructor narration: a human-readable explanation of what this step does
+	 * and why, emitted when the narration axis is "minimal" or "full". */
+	narration?: string;
 	status: "pass" | "fail" | "skipped";
 	durationMs: number;
 	error?: string;
@@ -300,6 +303,8 @@ export class CatalogWorkflowRunnerTool
 		page: PageActions,
 		options: {
 			paceMs: number;
+			annotations: boolean;
+			narration: "none" | "minimal" | "full";
 			capture: "off" | "per-step";
 			screenshotDir?: string;
 			stepIndex: number;
@@ -316,6 +321,22 @@ export class CatalogWorkflowRunnerTool
 			status: "pass",
 			durationMs: 0,
 		};
+
+		// Instructor narration: build a human-readable explanation of the step.
+		if (options.narration !== "none" && step.description) {
+			const what =
+				step.action === "click"
+					? `Click "${step.selector ?? step.id}"`
+					: `${step.action} ${step.selector ?? ""}`.trim();
+			const why = step.description;
+			result.narration = options.narration === "full" ? `${what} — ${why}` : why;
+		}
+
+		// On-page callout: in instructor mode with annotations, show the narration
+		// text near the step's target element before acting.
+		if (result.narration && options.annotations && step.selector && page.showCallout) {
+			await page.showCallout(step.selector, result.narration).catch(() => {});
+		}
 
 		try {
 			throwIfAborted(signal);
@@ -661,6 +682,8 @@ export class CatalogWorkflowRunnerTool
 					// they failed (the action did not take effect).
 					const opts = {
 						paceMs: axes.paceMs,
+						annotations: axes.annotations,
+						narration: axes.narration,
 						capture: axes.capture,
 						screenshotDir,
 						stepIndex: i,

--- a/packages/coding-agent/test/browser/extension-contract.test.ts
+++ b/packages/coding-agent/test/browser/extension-contract.test.ts
@@ -73,7 +73,7 @@ describe("extension contract drift guards", () => {
 	// Non-meta tools the typed client intentionally does NOT wrap yet (driven
 	// elsewhere, or part of a later behavioural layer). Adding a new extension tool
 	// forces it to be wrapped here or acknowledged in this list.
-	const KNOWN_UNWRAPPED = new Set(["wait_for_api_response", "annotate"]);
+	const KNOWN_UNWRAPPED = new Set(["wait_for_api_response"]);
 
 	it("every tool the bridge client requests exists in the contract", () => {
 		const unknown = extractRequestedTools(providerSource).filter(t => !EXTENSION_TOOL_NAMES.includes(t));


### PR DESCRIPTION
Closes #1774

Both narration channels for the **instructor** profile:

## Conversational narration (Part A)
- `StepResult.narration` — a human-readable per-step explanation (what + why), built from the step's action/selector/description. `"full"` = `"Click 'Add Policy' — Create the exclusion policy entry"`; `"minimal"` = just the description. The agent echoes it in chat.

## On-page callout (Part B)
- `PageActions.showCallout?(selector, text)` — optional extension-only method. `ExtensionPageActions` resolves the selector → coords (same pattern as `highlightElement`) and calls `annotate({kind:'callout', x, y, text})`.
- The runner emits a callout before each step when `narration !== "none"` + `annotations` + `step.selector` exist.
- The callout overlay renderer is the `callout` kind in the extension's overlay library (**extension PR #97**).

## Also
- Wraps `annotate` in `ExtensionPage`/`BridgeExtensionPage` (drift guard enforces — removed from allowlist).
- Passes `narration` + `annotations` axes through to `#executeStep` options.

## Testing
- Drift guard: RED (annotate removed from allowlist) → GREEN (wrapped). 10/10.
- Profile tests: 7/7.
- biome clean. Full CI runs the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)