### PR TITLE
feat(browser): per-step highlight-before-click in annotated profiles

### DIFF
--- a/packages/coding-agent/src/browser/extension-page-actions.ts
+++ b/packages/coding-agent/src/browser/extension-page-actions.ts
@@ -254,12 +254,20 @@ export class ExtensionPageActions implements PageActions {
 	}
 
 	async showCallout(selector: string, text: string): Promise<void> {
-		// Resolve the selector to coords (same pattern as highlightElement), then
-		// draw a text callout overlay above the target.
 		const js = `(function(){const el=(${buildElementResolverScript(selector)});if(!el)return null;const r=el.getBoundingClientRect();return{x:Math.round(r.x+r.width/2),y:Math.round(r.y),w:Math.round(r.width),h:Math.round(r.height)}})()`;
 		const rect = (await this.#ext.javascriptTool(js)) as { x: number; y: number } | null;
 		if (rect) {
 			await this.#ext.annotate({ kind: "callout", x: rect.x, y: rect.y, text });
+		}
+	}
+
+	async highlightElement(selector: string): Promise<void> {
+		// Resolve the selector to the target's bounding rect, then draw a highlight
+		// overlay ('look here' box) around it. Uses the same JS resolver as click.
+		const js = `(function(){const el=(${buildElementResolverScript(selector)});if(!el)return null;const r=el.getBoundingClientRect();return{x:Math.round(r.x),y:Math.round(r.y),w:Math.round(r.width),h:Math.round(r.height)}})()`;
+		const rect = (await this.#ext.javascriptTool(js)) as { x: number; y: number; w: number; h: number } | null;
+		if (rect) {
+			await this.#ext.annotate({ kind: "highlight", x: rect.x, y: rect.y, w: rect.w, h: rect.h });
 		}
 	}
 

--- a/packages/coding-agent/src/browser/page-actions.ts
+++ b/packages/coding-agent/src/browser/page-actions.ts
@@ -22,4 +22,7 @@ export interface PageActions {
 	/** Extension-only: show an explanatory text callout near a target element
 	 * (instructor narration). The text fades after ~2s. */
 	showCallout?(selector: string, text: string): Promise<void>;
+	/** Extension-only: highlight an element's bounding box ('look here' cue
+	 * before clicking in guided/instructor profiles). */
+	highlightElement?(selector: string): Promise<void>;
 }

--- a/packages/coding-agent/src/tools/catalog-workflow-runner.ts
+++ b/packages/coding-agent/src/tools/catalog-workflow-runner.ts
@@ -377,6 +377,11 @@ export class CatalogWorkflowRunnerTool
 				}
 				case "click": {
 					if (!resolvedSelector) throw new ToolError(`Step "${step.id}": click requires selector`);
+					// In annotated profiles, highlight the target before clicking
+					// ('look here' → pause → click).
+					if (options.annotations && page.highlightElement) {
+						await page.highlightElement(resolvedSelector).catch(() => {});
+					}
 					await page.click(resolvedSelector, resolvedContext);
 					break;
 				}


### PR DESCRIPTION
Closes #1776

In **guided/instructor** profiles, the runner now **highlights the target element before each click** — a "look here" cue so a human watcher sees where the agent is about to act.

## What
- `PageActions.highlightElement?(selector)` — optional extension-only method.
- `ExtensionPageActions.highlightElement` resolves the catalogue selector → bounding rect (JS, same resolver as click) → calls `annotate({kind:"highlight", x,y,w,h})`.
- Runner click step: when `options.annotations` is on, calls `page.highlightElement(selector)` before `page.click(selector)`.

Minimal delta — the `annotate` wrapping, `annotations` flag, and allowlist change are already in main via #1775.

17/17 tests; biome clean. Full CI runs the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)