### PR TITLE
fix(internal-urls): wire xcsh://extension to serve extension-api.md

### DIFF
--- a/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
@@ -43,6 +43,7 @@ import { type ConsoleCatalogData, EMPTY_CONSOLE_CATALOG } from "./console-catalo
 import { type ConsoleFieldMetadataData, EMPTY_CONSOLE_FIELD_METADATA } from "./console-field-metadata-types";
 import { type ConsoleResolver, createConsoleResolver } from "./console-resolve";
 import { EMBEDDED_DOC_FILENAMES, EMBEDDED_DOCS } from "./docs-index.generated";
+import extensionApiContent from "./extension-api.md" with { type: "text" };
 import { createTerraformResolver, type TerraformResolver } from "./terraform-resolve";
 import type { TerraformIndex } from "./terraform-types";
 import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
@@ -57,6 +58,7 @@ const TERRAFORM_HOST = "terraform";
 const USER_ROUTE = "user";
 const COMPUTER_ROUTE = "computer";
 const CONSOLE_HOST = "console";
+const EXTENSION_HOST = "extension";
 const EMPTY_INDEX: ApiSpecIndex = { version: "unavailable", timestamp: "", domains: [] };
 const EMPTY_CATALOG_INDEX: ApiCatalogIndex = {
 	version: "unavailable",
@@ -353,6 +355,10 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 			return this.#resolveComputerProfile(url);
 		}
 
+		if (host === EXTENSION_HOST) {
+			return this.#resolveExtension(url);
+		}
+
 		const pathname = url.rawPathname ?? url.pathname;
 		const filename = host ? (pathname && pathname !== "/" ? host + pathname : host) : "";
 
@@ -361,6 +367,19 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 		}
 
 		return this.#readDoc(filename, url);
+	}
+
+	/** Serve the Chrome extension bridge tool API reference. The hand-written
+	 * guidance (extension-api.md) is imported at compile time and served on demand
+	 * at `xcsh://extension`. */
+	#resolveExtension(url: InternalUrl): InternalResource {
+		return {
+			url: url.href,
+			content: extensionApiContent,
+			contentType: "text/markdown",
+			size: Buffer.byteLength(extensionApiContent, "utf-8"),
+			sourcePath: `${SCHEME_PREFIX}${EXTENSION_HOST}`,
+		};
 	}
 
 	async #resolveUserProfile(url: InternalUrl): Promise<InternalResource> {


### PR DESCRIPTION
Closes #1778

The system prompt promises `xcsh://extension` (the Chrome extension bridge tool API reference) but the protocol handler was never wired — the model's `read` would fail silently.

This imports `extension-api.md` at compile time (`with { type: "text" }`) and serves it as a static markdown resource at `xcsh://extension`. Simple, self-contained.

**No duplication:** `xcsh://console` resolves the console workflow catalog; `xcsh://extension` resolves the extension bridge tool reference. Different content, different purpose.

biome clean. One file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)