### PR TITLE
refactor(browser): extract buildNarration into testable pure function

### DIFF
--- a/packages/coding-agent/src/browser/presentation-profile.ts
+++ b/packages/coding-agent/src/browser/presentation-profile.ts
@@ -36,3 +36,15 @@ export function resolveProfile(
 	const name = isProfileName(profile) ? profile : isProfileName(sessionDefault) ? sessionDefault : DEFAULT_PROFILE;
 	return { ...PROFILES[name], ...(overrides ?? {}) };
 }
+
+/** Build a human-readable narration string for a workflow step. Returns
+ * undefined when narration is `"none"` or the step has no description. */
+export function buildNarration(
+	narration: ResolvedAxes["narration"],
+	step: { action: string; selector?: string; description?: string; id?: string },
+): string | undefined {
+	if (narration === "none" || !step.description) return undefined;
+	const what =
+		step.action === "click" ? `Click "${step.selector ?? step.id}"` : `${step.action} ${step.selector ?? ""}`.trim();
+	return narration === "full" ? `${what} — ${step.description}` : step.description;
+}

--- a/packages/coding-agent/src/tools/catalog-workflow-runner.ts
+++ b/packages/coding-agent/src/tools/catalog-workflow-runner.ts
@@ -6,7 +6,7 @@ import { type Static, Type } from "@sinclair/typebox";
 import { parse as parseYaml } from "yaml";
 import { selectProvider } from "../browser";
 import type { PageActions } from "../browser/page-actions";
-import { resolveProfile } from "../browser/presentation-profile";
+import { buildNarration, resolveProfile } from "../browser/presentation-profile";
 import { CONSOLE_CATALOG_DATA } from "../internal-urls/console-catalog.generated";
 import catalogWorkflowRunnerDescription from "../prompts/tools/catalog-workflow-runner.md" with { type: "text" };
 import { ContextService } from "../services/xcsh-context";
@@ -323,14 +323,7 @@ export class CatalogWorkflowRunnerTool
 		};
 
 		// Instructor narration: build a human-readable explanation of the step.
-		if (options.narration !== "none" && step.description) {
-			const what =
-				step.action === "click"
-					? `Click "${step.selector ?? step.id}"`
-					: `${step.action} ${step.selector ?? ""}`.trim();
-			const why = step.description;
-			result.narration = options.narration === "full" ? `${what} — ${why}` : why;
-		}
+		result.narration = buildNarration(options.narration, step);
 
 		// On-page callout: in instructor mode with annotations, show the narration
 		// text near the step's target element before acting.

--- a/packages/coding-agent/test/browser/presentation-profile.test.ts
+++ b/packages/coding-agent/test/browser/presentation-profile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { PROFILES, resolveProfile } from "../../src/browser/presentation-profile";
+import { buildNarration, PROFILES, resolveProfile } from "../../src/browser/presentation-profile";
 
 describe("resolveProfile", () => {
 	it("resolves each named profile to its preset axes", () => {
@@ -36,5 +36,43 @@ describe("resolveProfile", () => {
 		const r = resolveProfile("fast");
 		expect(r.capture).toBe("off");
 		expect(r.annotations).toBe(false);
+	});
+});
+
+describe("buildNarration", () => {
+	it("returns undefined when narration is 'none'", () => {
+		expect(buildNarration("none", { action: "click", selector: "button", description: "Submit" })).toBeUndefined();
+	});
+
+	it("returns undefined when the step has no description", () => {
+		expect(buildNarration("full", { action: "click", selector: "button" })).toBeUndefined();
+	});
+
+	it("returns just the description for 'minimal'", () => {
+		expect(
+			buildNarration("minimal", {
+				action: "click",
+				selector: "button:text('Add')",
+				description: "Create the policy",
+			}),
+		).toBe("Create the policy");
+	});
+
+	it("returns 'what — why' for 'full' with a click action", () => {
+		expect(
+			buildNarration("full", { action: "click", selector: "button:text('Add')", description: "Create the policy" }),
+		).toBe("Click \"button:text('Add')\" — Create the policy");
+	});
+
+	it("returns 'action selector — why' for 'full' with a non-click action", () => {
+		expect(
+			buildNarration("full", { action: "fill", selector: "textbox[name='Name']", description: "Enter the name" }),
+		).toBe("fill textbox[name='Name'] — Enter the name");
+	});
+
+	it("handles missing selector gracefully", () => {
+		expect(buildNarration("full", { action: "navigate", description: "Go to the page", id: "nav1" })).toBe(
+			"navigate — Go to the page",
+		);
 	});
 });


### PR DESCRIPTION
Closes #1780

Closes a test coverage gap: the narration text generation was inline in the runner's `#executeStep` (untested). Now extracted as a pure, exported `buildNarration()` in `presentation-profile.ts` and TDD'd.

## Testing
- 6 new tests: `none` → undefined, missing description → undefined, `minimal` → description only, `full` → "what — why" for click and non-click, missing selector gracefully.
- **23/23** across all profile+contract+reference tests.
- **Zero `tsgo` errors** in `coding-agent` with full monorepo deps installed (verified — not a sandbox).
- Full suite: 1498 pass (321 fail / 329 errors are pre-existing, unrelated to my changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)