### PR TITLE
fix(test): case-insensitive URL assertion in TUI sanitization security test

### DIFF
--- a/packages/coding-agent/test/xcsh-security.test.ts
+++ b/packages/coding-agent/test/xcsh-security.test.ts
@@ -337,8 +337,9 @@ describe("XCSH security: TUI sanitization", () => {
 
 		const output = ctx.messages[0].text;
 		const plain = output.replace(/\x1b\[[0-9;]*m/g, "");
-		// \r\n stripped — "INJECTED" text remains inline but can't spoof a separate line
-		expect(plain).toContain("https://evil.ioINJECTED");
+		// \r\n stripped — "INJECTED" text remains inline but can't spoof a separate line.
+		// The display may normalize the URL to lowercase, so match case-insensitively.
+		expect(plain.toLowerCase()).toContain("https://evil.ioinjected");
 		// The URL and injected text stay on the same line within the frame
 		const contentLines = plain.split("\n").filter(l => l.includes("evil.io"));
 		expect(contentLines.length).toBe(1);


### PR DESCRIPTION
Closes #1786

The `/context list` TUI display normalizes URLs to lowercase, so the injected `INJECTED` text appears as `injected`. The security test asserted the exact uppercase string → consistent failure.

Fix: use `plain.toLowerCase().toContain(...)` since the security property being tested is that `\r\n` injection is stripped (no line-break spoofing), not casing.

12/12 security tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)