### PR TITLE
fix(ci): remove stale generated files before regeneration in api-spec-update

### DIFF
--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -40,6 +40,13 @@ jobs:
           echo "Upstream version: ${PAYLOAD_VERSION:-unknown}"
           echo "Trigger source: ${PAYLOAD_SOURCE:-unknown}"
 
+      - name: Remove stale generated files so the script downloads fresh specs
+        run: |
+          rm -f packages/coding-agent/src/internal-urls/api-spec-index.generated.ts
+          rm -f packages/coding-agent/src/internal-urls/api-catalog-index.generated.ts
+          rm -f packages/coding-agent/src/internal-urls/terraform-index.generated.ts
+          rm -f packages/resource-management/src/defaults-metadata.generated.ts
+
       - name: Regenerate API spec index from latest release
         working-directory: packages/coding-agent
         run: bun run generate-api-spec-index


### PR DESCRIPTION
## Summary

- Remove stale generated files before running generate scripts in the `api-spec-update.yml` workflow
- The `generate-api-spec-index` script has a CI early-exit guard that skips regeneration when generated files already exist, preventing the workflow from downloading fresh specs from the latest `api-specs-enriched` release
- This caused the embedded API spec version to stay pinned at v2.1.146 instead of updating to the latest (currently v2.1.166)

## Test plan

- [ ] After merge, trigger a `repository_dispatch` event from `api-specs-enriched` (or wait for the next release)
- [ ] Verify the resulting PR in xcsh shows `API_SPEC_VERSION` matching the latest `api-specs-enriched` release (v2.1.166+), not v2.1.146
- [ ] Verify the `generate-terraform-index` and `generate-defaults` scripts also produce updated output

Closes #1788

🤖 Generated with [Claude Code](https://claude.com/claude-code)