### PR TITLE
fix(coding-agent): correct api-spec release asset name prefix

### DIFF
--- a/packages/coding-agent/scripts/generate-api-spec-index.ts
+++ b/packages/coding-agent/scripts/generate-api-spec-index.ts
@@ -150,7 +150,7 @@ async function downloadFromRelease(): Promise<string> {
 	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "api-specs-"));
 	downloadedTmpDir = tmpDir;
 	const tag = process.env.API_SPECS_TAG ?? (await resolveLatestTag());
-	const zipName = `xcsh-api-specs-${tag}.zip`;
+	const zipName = `f5xc-api-specs-${tag}.zip`;
 	const downloadUrl = `https://github.com/${REPO}/releases/download/${tag}/${zipName}`;
 
 	console.log(`Downloading API specs from ${downloadUrl}...`);


### PR DESCRIPTION
## Summary

- Fix the release asset filename from `xcsh-api-specs-{tag}.zip` to `f5xc-api-specs-{tag}.zip` to match the actual asset name in api-specs-enriched releases
- This was causing 404 errors when the `api-spec-update` workflow tried to download specs from the latest release

## Test plan

- [ ] After merge, trigger an `enriched-specs-updated` dispatch from api-specs-enriched
- [ ] Verify the workflow successfully downloads specs and creates a PR updating to v2.1.166

Closes #1790

🤖 Generated with [Claude Code](https://claude.com/claude-code)