### PR TITLE
fix(ci): symlink bun to /usr/local/bin so subprocesses find it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,11 @@ jobs:
           sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep imagemagick
           sudo ln -s "$(which fdfind)" /usr/local/bin/fd
           sudo ln -sf /usr/bin/convert /usr/local/bin/magick
+      # Ensure bun is on a PATH that child processes (posix_spawn, native shell
+      # addon) always inherit — setup-bun adds to $GITHUB_PATH which steps see,
+      # but spawned subprocesses may not. /usr/local/bin is always on PATH.
+      - name: Symlink bun to /usr/local/bin
+        run: sudo ln -sf "$(which bun)" /usr/local/bin/bun
       - run: bun install --frozen-lockfile
       - run: bun run build:native
       - name: Test workspace


### PR DESCRIPTION
Closes #1796

Tests that spawn child processes fail with `ENOENT: posix_spawn 'bun'` because `oven-sh/setup-bun` adds bun to `$GITHUB_PATH` (visible to subsequent workflow steps) but spawned subprocesses via `posix_spawn` or the native shell addon may not inherit the full PATH.

Fix: symlink bun to `/usr/local/bin/bun` — always on PATH for all processes. Matches the existing pattern for `fd` and `magick` in the same workflow.