### PR TITLE
fix: use process.execPath instead of hardcoded 'bun' in spawn calls

### DIFF
--- a/packages/coding-agent/src/extensibility/plugins/installer.ts
+++ b/packages/coding-agent/src/extensibility/plugins/installer.ts
@@ -45,7 +45,7 @@ export async function installPlugin(packageName: string): Promise<InstalledPlugi
 	}
 
 	// Run npm install in plugins directory
-	const proc = Bun.spawn(["bun", "install", packageName], {
+	const proc = Bun.spawn([process.execPath, "install", packageName], {
 		cwd: PLUGINS_DIR,
 		stdin: "ignore",
 		stdout: "pipe",
@@ -87,7 +87,7 @@ export async function uninstallPlugin(name: string): Promise<void> {
 
 	await ensurePluginsDir();
 
-	const proc = Bun.spawn(["bun", "uninstall", name], {
+	const proc = Bun.spawn([process.execPath, "uninstall", name], {
 		cwd: PLUGINS_DIR,
 		stdin: "ignore",
 		stdout: "pipe",

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -156,7 +156,7 @@ export class PluginManager {
 		}
 
 		// Run npm install
-		const proc = Bun.spawn(["bun", "install", spec.packageName], {
+		const proc = Bun.spawn([process.execPath, "install", spec.packageName], {
 			cwd: getPluginsDir(),
 			stdin: "ignore",
 			stdout: "pipe",
@@ -237,7 +237,7 @@ export class PluginManager {
 		validatePackageName(name);
 		await this.#ensurePackageJson();
 
-		const proc = Bun.spawn(["bun", "uninstall", name], {
+		const proc = Bun.spawn([process.execPath, "uninstall", name], {
 			cwd: getPluginsDir(),
 			stdin: "ignore",
 			stdout: "pipe",
@@ -634,7 +634,7 @@ export class PluginManager {
 
 	async #fixMissingPlugin(): Promise<boolean> {
 		try {
-			const proc = Bun.spawn(["bun", "install"], {
+			const proc = Bun.spawn([process.execPath, "install"], {
 				cwd: getPluginsDir(),
 				stdin: "ignore",
 				stdout: "pipe",

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -174,7 +174,7 @@ export class RpcClient {
 			args.push(...this.options.args);
 		}
 
-		this.#process = ptree.spawn(["bun", cliPath, ...args], {
+		this.#process = ptree.spawn([process.execPath, cliPath, ...args], {
 			cwd: this.options.cwd,
 			env: { ...Bun.env, ...this.options.env },
 			stdin: "pipe",


### PR DESCRIPTION
Closes #1796

`posix_spawn('bun')` fails with `ENOENT` in CI (and any environment where bun isn't on the default PATH). `process.execPath` resolves to the full absolute path of the currently-running bun binary — always works.

6 call sites fixed:
- `rpc-client.ts:177` — RPC child process (the `rpc-host-tools` test failure)
- `plugins/manager.ts` — plugin install/uninstall (3 sites)
- `plugins/installer.ts` — package install/uninstall (2 sites)

Also fixes the `xcsh-auth` test failures (`Failed to initialize shell: No such file or directory`) since those also spawn via the same code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)