### PR TITLE
fix(ci): ensure bun exists at process.execPath for subprocess spawns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,9 +299,14 @@ jobs:
       - name: Ensure bun is reachable at every path subprocesses may use
         run: |
           BUN_REAL=$(readlink -f "$(which bun)")
+          echo "bun real path: $BUN_REAL"
+          echo "process.execPath will be: $(bun -e 'console.log(process.execPath)')"
           sudo ln -sf "$BUN_REAL" /usr/local/bin/bun
-          sudo mkdir -p /home/runner/.bun/bin
-          sudo ln -sf "$BUN_REAL" /home/runner/.bun/bin/bun
+          if [ "$BUN_REAL" != "/home/runner/.bun/bin/bun" ]; then
+            sudo mkdir -p /home/runner/.bun/bin
+            sudo ln -sf "$BUN_REAL" /home/runner/.bun/bin/bun
+          fi
+          ls -la /usr/local/bin/bun /home/runner/.bun/bin/bun 2>/dev/null || true
       - run: bun install --frozen-lockfile
       - run: bun run build:native
       - name: Test workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,8 +296,12 @@ jobs:
       # Ensure bun is on a PATH that child processes (posix_spawn, native shell
       # addon) always inherit — setup-bun adds to $GITHUB_PATH which steps see,
       # but spawned subprocesses may not. /usr/local/bin is always on PATH.
-      - name: Symlink bun to /usr/local/bin
-        run: sudo ln -sf "$(which bun)" /usr/local/bin/bun
+      - name: Ensure bun is reachable at every path subprocesses may use
+        run: |
+          BUN_REAL=$(readlink -f "$(which bun)")
+          sudo ln -sf "$BUN_REAL" /usr/local/bin/bun
+          sudo mkdir -p /home/runner/.bun/bin
+          sudo ln -sf "$BUN_REAL" /home/runner/.bun/bin/bun
       - run: bun install --frozen-lockfile
       - run: bun run build:native
       - name: Test workspace


### PR DESCRIPTION
## Summary

- Resolve the real bun binary path with `readlink -f` and symlink to both `/usr/local/bin/bun` (PATH resolution) and `/home/runner/.bun/bin/bun` (process.execPath resolution)
- `process.execPath` returns `/home/runner/.bun/bin/bun` but that path may not persist between CI steps, causing `ENOENT: posix_spawn` in subprocess-spawning tests
- This unblocks release PR #1763 (v19.52.0) which has 87 test failures all rooted in this issue

## Test plan

- [ ] CI test job on this PR passes (the test job itself exercises the subprocess spawns)
- [ ] After merge, update release PR #1763 branch — all tests should pass
- [ ] Release PR merges and triggers the full release chain

Closes #1799

🤖 Generated with [Claude Code](https://claude.com/claude-code)