### PR TITLE
fix: use Bun.which("bun") for robust bun path resolution in spawn calls

### DIFF
--- a/packages/coding-agent/src/extensibility/plugins/installer.ts
+++ b/packages/coding-agent/src/extensibility/plugins/installer.ts
@@ -45,7 +45,7 @@ export async function installPlugin(packageName: string): Promise<InstalledPlugi
 	}
 
 	// Run npm install in plugins directory
-	const proc = Bun.spawn([process.execPath, "install", packageName], {
+	const proc = Bun.spawn([Bun.which("bun") ?? process.execPath, "install", packageName], {
 		cwd: PLUGINS_DIR,
 		stdin: "ignore",
 		stdout: "pipe",
@@ -87,7 +87,7 @@ export async function uninstallPlugin(name: string): Promise<void> {
 
 	await ensurePluginsDir();
 
-	const proc = Bun.spawn([process.execPath, "uninstall", name], {
+	const proc = Bun.spawn([Bun.which("bun") ?? process.execPath, "uninstall", name], {
 		cwd: PLUGINS_DIR,
 		stdin: "ignore",
 		stdout: "pipe",

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -156,7 +156,7 @@ export class PluginManager {
 		}
 
 		// Run npm install
-		const proc = Bun.spawn([process.execPath, "install", spec.packageName], {
+		const proc = Bun.spawn([Bun.which("bun") ?? process.execPath, "install", spec.packageName], {
 			cwd: getPluginsDir(),
 			stdin: "ignore",
 			stdout: "pipe",
@@ -237,7 +237,7 @@ export class PluginManager {
 		validatePackageName(name);
 		await this.#ensurePackageJson();
 
-		const proc = Bun.spawn([process.execPath, "uninstall", name], {
+		const proc = Bun.spawn([Bun.which("bun") ?? process.execPath, "uninstall", name], {
 			cwd: getPluginsDir(),
 			stdin: "ignore",
 			stdout: "pipe",
@@ -634,7 +634,7 @@ export class PluginManager {
 
 	async #fixMissingPlugin(): Promise<boolean> {
 		try {
-			const proc = Bun.spawn([process.execPath, "install"], {
+			const proc = Bun.spawn([Bun.which("bun") ?? process.execPath, "install"], {
 				cwd: getPluginsDir(),
 				stdin: "ignore",
 				stdout: "pipe",

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -174,7 +174,7 @@ export class RpcClient {
 			args.push(...this.options.args);
 		}
 
-		this.#process = ptree.spawn([process.execPath, cliPath, ...args], {
+		this.#process = ptree.spawn([Bun.which("bun") ?? process.execPath, cliPath, ...args], {
 			cwd: this.options.cwd,
 			env: { ...Bun.env, ...this.options.env },
 			stdin: "pipe",


### PR DESCRIPTION
Closes #1799

Follow-up to #1798: `process.execPath` resolved to `/home/runner/.bun/bin/bun` in CI which doesn't exist (the setup action's actual binary is elsewhere). `Bun.which("bun")` does a proper PATH lookup and finds the actual binary (including the `/usr/local/bin/bun` symlink from #1795).

All 6 spawn call sites now use `Bun.which("bun") ?? process.execPath`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)