### PR TITLE
fix: copy bun to stable path and use bunExecPath for subprocess spawns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,17 +296,11 @@ jobs:
       # Ensure bun is on a PATH that child processes (posix_spawn, native shell
       # addon) always inherit — setup-bun adds to $GITHUB_PATH which steps see,
       # but spawned subprocesses may not. /usr/local/bin is always on PATH.
-      - name: Ensure bun is reachable at every path subprocesses may use
+      - name: Copy bun to /usr/local/bin so subprocesses always find it
         run: |
-          BUN_REAL=$(readlink -f "$(which bun)")
-          echo "bun real path: $BUN_REAL"
-          echo "process.execPath will be: $(bun -e 'console.log(process.execPath)')"
-          sudo ln -sf "$BUN_REAL" /usr/local/bin/bun
-          if [ "$BUN_REAL" != "/home/runner/.bun/bin/bun" ]; then
-            sudo mkdir -p /home/runner/.bun/bin
-            sudo ln -sf "$BUN_REAL" /home/runner/.bun/bin/bun
-          fi
-          ls -la /usr/local/bin/bun /home/runner/.bun/bin/bun 2>/dev/null || true
+          sudo cp "$(which bun)" /usr/local/bin/bun
+          sudo chmod +x /usr/local/bin/bun
+          /usr/local/bin/bun --version
       - run: bun install --frozen-lockfile
       - run: bun run build:native
       - name: Test workspace

--- a/packages/coding-agent/src/bun-path.ts
+++ b/packages/coding-agent/src/bun-path.ts
@@ -1,0 +1,7 @@
+import { existsSync } from "node:fs";
+
+const STABLE_BUN_PATH = "/usr/local/bin/bun";
+
+export const bunExecPath: string = existsSync(STABLE_BUN_PATH)
+	? STABLE_BUN_PATH
+	: (Bun.which("bun") ?? process.execPath);

--- a/packages/coding-agent/src/extensibility/plugins/installer.ts
+++ b/packages/coding-agent/src/extensibility/plugins/installer.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getAgentDir, getProjectDir, isEnoent } from "@f5-sales-demo/pi-utils";
+import { bunExecPath } from "../../bun-path";
 import { extractPackageName } from "./parser";
 import type { InstalledPlugin } from "./types";
 
@@ -45,7 +46,7 @@ export async function installPlugin(packageName: string): Promise<InstalledPlugi
 	}
 
 	// Run npm install in plugins directory
-	const proc = Bun.spawn([Bun.which("bun") ?? process.execPath, "install", packageName], {
+	const proc = Bun.spawn([bunExecPath, "install", packageName], {
 		cwd: PLUGINS_DIR,
 		stdin: "ignore",
 		stdout: "pipe",
@@ -87,7 +88,7 @@ export async function uninstallPlugin(name: string): Promise<void> {
 
 	await ensurePluginsDir();
 
-	const proc = Bun.spawn([Bun.which("bun") ?? process.execPath, "uninstall", name], {
+	const proc = Bun.spawn([bunExecPath, "uninstall", name], {
 		cwd: PLUGINS_DIR,
 		stdin: "ignore",
 		stdout: "pipe",

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -10,6 +10,7 @@ import {
 	isEnoent,
 	logger,
 } from "@f5-sales-demo/pi-utils";
+import { bunExecPath } from "../../bun-path";
 import { extractPackageName, parsePluginSpec } from "./parser";
 import type {
 	DoctorCheck,
@@ -156,7 +157,7 @@ export class PluginManager {
 		}
 
 		// Run npm install
-		const proc = Bun.spawn([Bun.which("bun") ?? process.execPath, "install", spec.packageName], {
+		const proc = Bun.spawn([bunExecPath, "install", spec.packageName], {
 			cwd: getPluginsDir(),
 			stdin: "ignore",
 			stdout: "pipe",
@@ -237,7 +238,7 @@ export class PluginManager {
 		validatePackageName(name);
 		await this.#ensurePackageJson();
 
-		const proc = Bun.spawn([Bun.which("bun") ?? process.execPath, "uninstall", name], {
+		const proc = Bun.spawn([bunExecPath, "uninstall", name], {
 			cwd: getPluginsDir(),
 			stdin: "ignore",
 			stdout: "pipe",
@@ -634,7 +635,7 @@ export class PluginManager {
 
 	async #fixMissingPlugin(): Promise<boolean> {
 		try {
-			const proc = Bun.spawn([Bun.which("bun") ?? process.execPath, "install"], {
+			const proc = Bun.spawn([bunExecPath, "install"], {
 				cwd: getPluginsDir(),
 				stdin: "ignore",
 				stdout: "pipe",

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -6,6 +6,7 @@
 import type { AgentEvent, AgentMessage, AgentToolResult, ThinkingLevel } from "@f5-sales-demo/pi-agent-core";
 import type { ImageContent, Model } from "@f5-sales-demo/pi-ai";
 import { isRecord, ptree, readJsonl } from "@f5-sales-demo/pi-utils";
+import { bunExecPath } from "../../bun-path";
 import type { BashResult } from "../../exec/bash-executor";
 import type { SessionStats } from "../../session/agent-session";
 import type { CompactionResult } from "../../session/compaction";
@@ -174,7 +175,7 @@ export class RpcClient {
 			args.push(...this.options.args);
 		}
 
-		this.#process = ptree.spawn([Bun.which("bun") ?? process.execPath, cliPath, ...args], {
+		this.#process = ptree.spawn([bunExecPath, cliPath, ...args], {
 			cwd: this.options.cwd,
 			env: { ...Bun.env, ...this.options.env },
 			stdin: "pipe",


### PR DESCRIPTION
## Summary

- **CI**: copy bun to `/usr/local/bin/bun` (not symlink) so the binary persists even if the temp source is cleaned up
- **Code**: new `bunExecPath` utility in `src/bun-path.ts` prefers `/usr/local/bin/bun` when it exists, falling back to `Bun.which` then `process.execPath`
- Replace all `Bun.which("bun") ?? process.execPath` calls with `bunExecPath`

### Root cause

Both `process.execPath` and `Bun.which("bun")` resolve to `/tmp/bun-node-*/bun` in CI — a temp-extracted binary that gets cleaned up before subprocess spawns execute. Symlinks to that temp path also break since the target disappears.

## Test plan

- [ ] CI test job passes (subprocess-spawning tests exercise the fix)
- [ ] After merge, update release PR #1763 branch — tests should pass
- [ ] Release PR merges and triggers v19.52.0 release chain

Closes #1803

🤖 Generated with [Claude Code](https://claude.com/claude-code)