### PR TITLE
chore(ci): add diagnostic step to verify bun binary before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,13 @@ jobs:
           /usr/local/bin/bun --version
       - run: bun install --frozen-lockfile
       - run: bun run build:native
+      - name: Verify bun binary exists before tests
+        run: |
+          echo "which bun: $(which bun)"
+          echo "file type: $(file /usr/local/bin/bun)"
+          echo "ls -la: $(ls -la /usr/local/bin/bun)"
+          echo "bun.path.ts resolves to: $(bun -e "const{existsSync}=require('fs');console.log(existsSync('/usr/local/bin/bun')?'/usr/local/bin/bun':'fallback')")"
+          /usr/local/bin/bun --version
       - name: Test workspace
         run: bun run ci:test:full
       - name: CLI smoke test


### PR DESCRIPTION
## Summary

Add a diagnostic step before tests to verify `/usr/local/bin/bun` exists and is a real binary (not a script with a stale shebang). This will help identify whether the binary is being deleted during `bun install` or `build:native`.

Closes #1806

🤖 Generated with [Claude Code](https://claude.com/claude-code)