### PR TITLE
fix: preserve bun.lock during release to avoid dependency divergence

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -260,9 +260,9 @@ async function applyVersionBumpToFiles(version: string): Promise<void> {
 	}
 	console.log();
 
-	// 4. Regenerate lockfiles
-	console.log("Regenerating lockfiles...");
-	await $`rm -f bun.lock`;
+	// 4. Update lockfiles (preserve existing resolutions to avoid pulling
+	// newer transitive deps that diverge from the tested main branch)
+	console.log("Updating lockfiles...");
 	await $`bun install`;
 	await $`cargo generate-lockfile`;
 	console.log();


### PR DESCRIPTION
## Summary

The release script deleted `bun.lock` and regenerated from scratch (`rm -f bun.lock && bun install`), which pulled newer transitive deps that diverged from main's tested resolution. This caused 99 test failures on the release branch that didn't reproduce on main — the debug workflow confirmed tests pass individually but fail under `ci:test:full` when the lockfile has different dependency versions.

Fix: remove `rm -f bun.lock`. `bun install` alone updates workspace package versions without pulling new external deps.

## Test plan

- [ ] After merge, trigger auto-release (delete `release/v19.52.0` branch first if it exists)
- [ ] The new release PR should have a `bun.lock` that only differs from main in workspace package versions
- [ ] CI tests should pass on the release branch

Closes #1809

🤖 Generated with [Claude Code](https://claude.com/claude-code)