### PR TITLE
fix: chat bridge follow-ups — history_hint, type accuracy, extractReferences

### DIFF
--- a/packages/coding-agent/src/browser/chat-conformance.json
+++ b/packages/coding-agent/src/browser/chat-conformance.json
@@ -1,0 +1,595 @@
+{
+  "contractVersion": "1.2.0",
+  "schemas": {
+    "chat_request": {
+      "type": "object",
+      "required": ["type", "id", "text", "context", "mode"],
+      "properties": {
+        "type": {
+          "const": "chat_request",
+          "type": "string"
+        },
+        "id": {
+          "pattern": "^c-",
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "context": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "required": ["v", "capturedAt", "tabId", "url", "path", "title", "ax", "api", "truncated"],
+              "properties": {
+                "v": {
+                  "const": 1,
+                  "type": "number"
+                },
+                "capturedAt": {
+                  "type": "number"
+                },
+                "tabId": {
+                  "type": "number"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "ax": {
+                  "anyOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "additionalProperties": true,
+                      "type": "object",
+                      "required": ["role"],
+                      "properties": {
+                        "role": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "api": {
+                  "anyOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "type": "object",
+                      "required": ["url", "status", "resourceType", "body", "truncated"],
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        },
+                        "resourceType": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "body": {},
+                        "truncated": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "truncated": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        },
+        "mode": {
+          "anyOf": [
+            {
+              "const": "educational",
+              "type": "string"
+            },
+            {
+              "const": "presentation",
+              "type": "string"
+            },
+            {
+              "const": "configuration",
+              "type": "string"
+            },
+            {
+              "const": "screenshot",
+              "type": "string"
+            },
+            {
+              "const": "annotation",
+              "type": "string"
+            }
+          ]
+        },
+        "history_hint": {
+          "type": "string"
+        }
+      }
+    },
+    "chat_stop": {
+      "type": "object",
+      "required": ["type", "id"],
+      "properties": {
+        "type": {
+          "const": "chat_stop",
+          "type": "string"
+        },
+        "id": {
+          "pattern": "^c-",
+          "type": "string"
+        }
+      }
+    },
+    "chat_delta": {
+      "type": "object",
+      "required": ["type", "id", "seq", "delta"],
+      "properties": {
+        "type": {
+          "const": "chat_delta",
+          "type": "string"
+        },
+        "id": {
+          "pattern": "^c-",
+          "type": "string"
+        },
+        "seq": {
+          "type": "number"
+        },
+        "delta": {
+          "type": "string"
+        }
+      }
+    },
+    "chat_done": {
+      "type": "object",
+      "required": ["type", "id"],
+      "properties": {
+        "type": {
+          "const": "chat_done",
+          "type": "string"
+        },
+        "id": {
+          "pattern": "^c-",
+          "type": "string"
+        },
+        "references": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["kind", "title", "url"],
+            "properties": {
+              "kind": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "chat_error": {
+      "type": "object",
+      "required": ["type", "id", "error"],
+      "properties": {
+        "type": {
+          "const": "chat_error",
+          "type": "string"
+        },
+        "id": {
+          "pattern": "^c-",
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "chat_tool_notice": {
+      "type": "object",
+      "required": ["type", "id", "tool", "ok"],
+      "properties": {
+        "type": {
+          "const": "chat_tool_notice",
+          "type": "string"
+        },
+        "id": {
+          "pattern": "^c-",
+          "type": "string"
+        },
+        "tool": {
+          "type": "string"
+        },
+        "ok": {
+          "type": "boolean"
+        },
+        "detail": {
+          "type": "string"
+        }
+      }
+    },
+    "page_context_snapshot": {
+      "type": "object",
+      "required": ["v", "capturedAt", "tabId", "url", "path", "title", "ax", "api", "truncated"],
+      "properties": {
+        "v": {
+          "const": 1,
+          "type": "number"
+        },
+        "capturedAt": {
+          "type": "number"
+        },
+        "tabId": {
+          "type": "number"
+        },
+        "url": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "ax": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "additionalProperties": true,
+              "type": "object",
+              "required": ["role"],
+              "properties": {
+                "role": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "api": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "required": ["url", "status", "resourceType", "body", "truncated"],
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "number"
+                },
+                "resourceType": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "body": {},
+                "truncated": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        },
+        "truncated": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "examples": {
+    "valid": {
+      "page_context_snapshot": {
+        "v": 1,
+        "capturedAt": 1719000000000,
+        "tabId": 7,
+        "url": "https://acme.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
+        "path": "/web/namespaces/default/http_loadbalancers/lb1",
+        "title": "lb1 — Distributed Cloud",
+        "ax": {
+          "role": "WebArea",
+          "name": "lb1",
+          "children": [
+            {
+              "role": "button",
+              "name": "Edit",
+              "ref": "e12"
+            }
+          ]
+        },
+        "api": {
+          "url": "/api/config/namespaces/default/http_loadbalancers/lb1",
+          "status": 200,
+          "resourceType": "http_loadbalancers",
+          "body": {
+            "metadata": {
+              "name": "lb1"
+            },
+            "spec": {
+              "domains": ["lb1.example.com"]
+            }
+          },
+          "truncated": false
+        },
+        "truncated": false
+      },
+      "chat_request": {
+        "type": "chat_request",
+        "id": "c-1111",
+        "text": "What does this load balancer do?",
+        "context": {
+          "v": 1,
+          "capturedAt": 1719000000000,
+          "tabId": 7,
+          "url": "https://acme.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
+          "path": "/web/namespaces/default/http_loadbalancers/lb1",
+          "title": "lb1 — Distributed Cloud",
+          "ax": {
+            "role": "WebArea",
+            "name": "lb1",
+            "children": [
+              {
+                "role": "button",
+                "name": "Edit",
+                "ref": "e12"
+              }
+            ]
+          },
+          "api": {
+            "url": "/api/config/namespaces/default/http_loadbalancers/lb1",
+            "status": 200,
+            "resourceType": "http_loadbalancers",
+            "body": {
+              "metadata": {
+                "name": "lb1"
+              },
+              "spec": {
+                "domains": ["lb1.example.com"]
+              }
+            },
+            "truncated": false
+          },
+          "truncated": false
+        },
+        "mode": "educational",
+        "history_hint": "conv-1"
+      },
+      "chat_request_no_context": {
+        "type": "chat_request",
+        "id": "c-2222",
+        "text": "help me build a WAF policy",
+        "context": null,
+        "mode": "configuration"
+      },
+      "chat_stop": {
+        "type": "chat_stop",
+        "id": "c-1111"
+      },
+      "chat_delta": {
+        "type": "chat_delta",
+        "id": "c-1111",
+        "seq": 0,
+        "delta": "This LB "
+      },
+      "chat_delta_1": {
+        "type": "chat_delta",
+        "id": "c-1111",
+        "seq": 1,
+        "delta": "routes traffic."
+      },
+      "chat_done": {
+        "type": "chat_done",
+        "id": "c-1111",
+        "references": [
+          {
+            "kind": "doc",
+            "title": "HTTP LB",
+            "url": "https://docs.cloud.f5.com/docs/how-to"
+          }
+        ]
+      },
+      "chat_done_no_refs": {
+        "type": "chat_done",
+        "id": "c-1111"
+      },
+      "chat_error": {
+        "type": "chat_error",
+        "id": "c-1111",
+        "error": "HTTP 403 forbidden"
+      },
+      "chat_tool_notice": {
+        "type": "chat_tool_notice",
+        "id": "c-1111",
+        "tool": "navigate",
+        "ok": true
+      }
+    },
+    "invalid": [
+      {
+        "schema": "chat_request",
+        "why": "id missing c- prefix",
+        "value": {
+          "type": "chat_request",
+          "id": "x-1111",
+          "text": "What does this load balancer do?",
+          "context": {
+            "v": 1,
+            "capturedAt": 1719000000000,
+            "tabId": 7,
+            "url": "https://acme.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
+            "path": "/web/namespaces/default/http_loadbalancers/lb1",
+            "title": "lb1 — Distributed Cloud",
+            "ax": {
+              "role": "WebArea",
+              "name": "lb1",
+              "children": [
+                {
+                  "role": "button",
+                  "name": "Edit",
+                  "ref": "e12"
+                }
+              ]
+            },
+            "api": {
+              "url": "/api/config/namespaces/default/http_loadbalancers/lb1",
+              "status": 200,
+              "resourceType": "http_loadbalancers",
+              "body": {
+                "metadata": {
+                  "name": "lb1"
+                },
+                "spec": {
+                  "domains": ["lb1.example.com"]
+                }
+              },
+              "truncated": false
+            },
+            "truncated": false
+          },
+          "mode": "educational",
+          "history_hint": "conv-1"
+        }
+      },
+      {
+        "schema": "chat_request",
+        "why": "unknown mode",
+        "value": {
+          "type": "chat_request",
+          "id": "c-1111",
+          "text": "What does this load balancer do?",
+          "context": {
+            "v": 1,
+            "capturedAt": 1719000000000,
+            "tabId": 7,
+            "url": "https://acme.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
+            "path": "/web/namespaces/default/http_loadbalancers/lb1",
+            "title": "lb1 — Distributed Cloud",
+            "ax": {
+              "role": "WebArea",
+              "name": "lb1",
+              "children": [
+                {
+                  "role": "button",
+                  "name": "Edit",
+                  "ref": "e12"
+                }
+              ]
+            },
+            "api": {
+              "url": "/api/config/namespaces/default/http_loadbalancers/lb1",
+              "status": 200,
+              "resourceType": "http_loadbalancers",
+              "body": {
+                "metadata": {
+                  "name": "lb1"
+                },
+                "spec": {
+                  "domains": ["lb1.example.com"]
+                }
+              },
+              "truncated": false
+            },
+            "truncated": false
+          },
+          "mode": "wizard",
+          "history_hint": "conv-1"
+        }
+      },
+      {
+        "schema": "chat_request",
+        "why": "missing text",
+        "value": {
+          "type": "chat_request",
+          "id": "c-1",
+          "context": null,
+          "mode": "educational"
+        }
+      },
+      {
+        "schema": "chat_delta",
+        "why": "missing seq",
+        "value": {
+          "type": "chat_delta",
+          "id": "c-1",
+          "delta": "x"
+        }
+      },
+      {
+        "schema": "page_context_snapshot",
+        "why": "wrong version",
+        "value": {
+          "v": 2,
+          "capturedAt": 1719000000000,
+          "tabId": 7,
+          "url": "https://acme.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
+          "path": "/web/namespaces/default/http_loadbalancers/lb1",
+          "title": "lb1 — Distributed Cloud",
+          "ax": {
+            "role": "WebArea",
+            "name": "lb1",
+            "children": [
+              {
+                "role": "button",
+                "name": "Edit",
+                "ref": "e12"
+              }
+            ]
+          },
+          "api": {
+            "url": "/api/config/namespaces/default/http_loadbalancers/lb1",
+            "status": 200,
+            "resourceType": "http_loadbalancers",
+            "body": {
+              "metadata": {
+                "name": "lb1"
+              },
+              "spec": {
+                "domains": ["lb1.example.com"]
+              }
+            },
+            "truncated": false
+          },
+          "truncated": false
+        }
+      }
+    ]
+  }
+}

--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -24,6 +24,7 @@ export class ChatHandler {
 	#server: BridgeServer;
 	#session: AgentSession;
 	#activeChats = new Map<string, ActiveChat>();
+	#activeHistoryHint: string | undefined;
 
 	constructor(server: BridgeServer, session: AgentSession) {
 		this.#server = server;
@@ -51,6 +52,11 @@ export class ChatHandler {
 		if (this.#session.isStreaming || this.#activeChats.size > 0) {
 			this.#server.send({ type: "chat_error", id, error: "session busy" } satisfies ChatError);
 			return;
+		}
+
+		if (req.history_hint && req.history_hint !== this.#activeHistoryHint) {
+			this.#session.agent.replaceMessages([]);
+			this.#activeHistoryHint = req.history_hint;
 		}
 
 		const chat: ActiveChat = { id, seq: 0, terminalSent: false, unsubscribe: () => {} };
@@ -153,7 +159,9 @@ export function composeChatPrompt(text: string, context: PageContextSnapshot | n
 		parts.push(`Title: ${context.title}`);
 
 		if (context.api) {
-			parts.push(`API resource (${context.api.resourceType}, status ${context.api.status}): ${context.api.url}`);
+			parts.push(
+				`API resource (${context.api.resourceType ?? "unknown"}, status ${context.api.status}): ${context.api.url}`,
+			);
 			if (context.api.body) {
 				const body =
 					typeof context.api.body === "string" ? context.api.body : JSON.stringify(context.api.body, null, 2);
@@ -181,15 +189,48 @@ export function composeChatPrompt(text: string, context: PageContextSnapshot | n
 	return parts.join("\n");
 }
 
+export function classifyReferenceKind(url: string): "doc" | "console" {
+	try {
+		const parsed = new URL(url);
+		if (/\.console\.ves\.volterra\.io$/.test(parsed.hostname)) return "console";
+		if (parsed.hostname === "docs.cloud.f5.com" || parsed.pathname.startsWith("/docs")) return "doc";
+	} catch {
+		/* malformed URL — default to doc */
+	}
+	return "doc";
+}
+
+function titleFromUrl(url: string): string {
+	try {
+		const parsed = new URL(url);
+		const segments = parsed.pathname.split("/").filter(Boolean);
+		return segments.length > 0 ? segments[segments.length - 1] : parsed.hostname;
+	} catch {
+		return url;
+	}
+}
+
 function extractReferences(msg: AssistantMessage): ChatReference[] {
 	const refs: ChatReference[] = [];
+	const seen = new Set<string>();
+
 	for (const block of msg.content) {
 		if (block.type !== "text") continue;
-		const urlRegex = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
-		for (let match = urlRegex.exec(block.text); match !== null; match = urlRegex.exec(block.text)) {
+
+		const mdLinkRegex = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+		for (let match = mdLinkRegex.exec(block.text); match !== null; match = mdLinkRegex.exec(block.text)) {
 			const [, title, url] = match;
-			const kind = url.includes("docs.cloud.f5.com") || url.includes("docs.") ? "doc" : "console";
-			refs.push({ kind, title, url });
+			if (seen.has(url)) continue;
+			seen.add(url);
+			refs.push({ kind: classifyReferenceKind(url), title, url });
+		}
+
+		const bareUrlRegex = /(?<!\()(https?:\/\/[^\s)>\]]+)/g;
+		for (let match = bareUrlRegex.exec(block.text); match !== null; match = bareUrlRegex.exec(block.text)) {
+			const url = match[1];
+			if (seen.has(url)) continue;
+			seen.add(url);
+			refs.push({ kind: classifyReferenceKind(url), title: titleFromUrl(url), url });
 		}
 	}
 	return refs;

--- a/packages/coding-agent/src/browser/chat-protocol.ts
+++ b/packages/coding-agent/src/browser/chat-protocol.ts
@@ -10,7 +10,7 @@
 export interface PageContextApi {
 	url: string;
 	status: number;
-	resourceType: string;
+	resourceType: string | null;
 	body: unknown;
 	truncated: boolean;
 }
@@ -55,7 +55,7 @@ export interface ChatRequest {
 	text: string;
 	context: PageContextSnapshot | null;
 	mode: InteractionMode;
-	history_hint: string;
+	history_hint?: string;
 }
 
 export interface ChatStop {

--- a/packages/coding-agent/test/browser/chat-conformance.test.ts
+++ b/packages/coding-agent/test/browser/chat-conformance.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Conformance tests: validate xcsh's chat protocol types and serializers
+ * against the extension's published chat-conformance.json artifact.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { isChatRequest, isChatStop } from "@f5-sales-demo/xcsh/browser/chat-protocol";
+import Ajv from "ajv";
+import conformance from "../../src/browser/chat-conformance.json";
+
+const ajv = new Ajv({ strict: false });
+
+const schemas = conformance.schemas as Record<string, object>;
+const validExamples = conformance.examples.valid as Record<string, unknown>;
+const invalidExamples = conformance.examples.invalid as Array<{
+	schema: string;
+	why: string;
+	value: unknown;
+}>;
+
+describe("chat-conformance: valid examples validate against schemas", () => {
+	for (const [name, example] of Object.entries(validExamples)) {
+		const schemaKey = name.replace(/_no_\w+$|_\d+$/g, "");
+		const schema = schemas[schemaKey];
+		if (!schema) continue;
+
+		it(`${name} validates against ${schemaKey} schema`, () => {
+			const validate = ajv.compile(schema);
+			const valid = validate(example);
+			if (!valid) {
+				throw new Error(`Validation failed: ${JSON.stringify(validate.errors)}`);
+			}
+			expect(valid).toBe(true);
+		});
+	}
+});
+
+describe("chat-conformance: invalid examples are rejected by schemas", () => {
+	for (const { schema: schemaKey, why, value } of invalidExamples) {
+		const schema = schemas[schemaKey];
+		if (!schema) continue;
+
+		it(`${schemaKey}: ${why}`, () => {
+			const validate = ajv.compile(schema);
+			expect(validate(value)).toBe(false);
+		});
+	}
+});
+
+describe("chat-conformance: xcsh parsers accept valid examples", () => {
+	it("isChatRequest accepts valid chat_request example", () => {
+		expect(isChatRequest(validExamples.chat_request as Record<string, unknown>)).toBe(true);
+	});
+
+	it("isChatRequest accepts valid chat_request_no_context example", () => {
+		expect(isChatRequest(validExamples.chat_request_no_context as Record<string, unknown>)).toBe(true);
+	});
+
+	it("isChatStop accepts valid chat_stop example", () => {
+		expect(isChatStop(validExamples.chat_stop as Record<string, unknown>)).toBe(true);
+	});
+});
+
+describe("chat-conformance: xcsh parsers reject invalid examples", () => {
+	for (const { schema: schemaKey, why, value } of invalidExamples) {
+		if (schemaKey === "chat_request") {
+			it(`isChatRequest rejects: ${why}`, () => {
+				expect(isChatRequest(value as Record<string, unknown>)).toBe(false);
+			});
+		}
+		if (schemaKey === "chat_stop") {
+			it(`isChatStop rejects: ${why}`, () => {
+				expect(isChatStop(value as Record<string, unknown>)).toBe(false);
+			});
+		}
+	}
+});
+
+describe("chat-conformance: xcsh outbound frames validate against schemas", () => {
+	it("chat_delta frame validates", () => {
+		const frame = { type: "chat_delta", id: "c-test", seq: 0, delta: "hello" };
+		const validate = ajv.compile(schemas.chat_delta);
+		expect(validate(frame)).toBe(true);
+	});
+
+	it("chat_done frame validates", () => {
+		const frame = {
+			type: "chat_done",
+			id: "c-test",
+			references: [{ kind: "doc", title: "Test", url: "https://docs.cloud.f5.com/test" }],
+		};
+		const validate = ajv.compile(schemas.chat_done);
+		expect(validate(frame)).toBe(true);
+	});
+
+	it("chat_done frame without references validates", () => {
+		const frame = { type: "chat_done", id: "c-test" };
+		const validate = ajv.compile(schemas.chat_done);
+		expect(validate(frame)).toBe(true);
+	});
+
+	it("chat_error frame validates", () => {
+		const frame = { type: "chat_error", id: "c-test", error: "something broke" };
+		const validate = ajv.compile(schemas.chat_error);
+		expect(validate(frame)).toBe(true);
+	});
+});
+
+describe("chat-conformance: contract version matches", () => {
+	it("conformance artifact version matches capabilities contract version", () => {
+		const capabilities = require("../../src/browser/capabilities.json");
+		expect(conformance.contractVersion).toBe(capabilities.contractVersion);
+	});
+});

--- a/packages/coding-agent/test/browser/chat-handler.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.test.ts
@@ -113,6 +113,6 @@ describe("classifyReferenceKind", () => {
 	});
 
 	it("defaults unknown URLs to doc", () => {
-		expect(classifyReferenceKind("https://github.com/f5/repo")).toBe("doc");
+		expect(classifyReferenceKind("https://github.com/f5-sales-demo/xcsh")).toBe("doc");
 	});
 });

--- a/packages/coding-agent/test/browser/chat-handler.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { composeChatPrompt } from "@f5-sales-demo/xcsh/browser/chat-handler";
+import { classifyReferenceKind, composeChatPrompt } from "@f5-sales-demo/xcsh/browser/chat-handler";
 import type { PageContextSnapshot } from "@f5-sales-demo/xcsh/browser/chat-protocol";
 
 describe("composeChatPrompt", () => {
@@ -61,6 +61,23 @@ describe("composeChatPrompt", () => {
 		expect(result).toContain("[Page context was truncated]");
 	});
 
+	it("handles null resourceType gracefully", () => {
+		const context: PageContextSnapshot = {
+			v: 1,
+			capturedAt: 1719000000000,
+			tabId: 1,
+			url: "https://example.com",
+			path: "/",
+			title: "Test",
+			ax: null,
+			api: { url: "/api/test", status: 200, resourceType: null, body: {}, truncated: false },
+			truncated: false,
+		};
+		const result = composeChatPrompt("hi", context, "educational");
+		expect(result).toContain("unknown, status 200");
+		expect(result).not.toContain("null");
+	});
+
 	it("handles null api and ax gracefully", () => {
 		const context: PageContextSnapshot = {
 			v: 1,
@@ -77,5 +94,25 @@ describe("composeChatPrompt", () => {
 		expect(result).toContain("URL: https://example.com");
 		expect(result).not.toContain("API resource");
 		expect(result).not.toContain("Accessibility tree");
+	});
+});
+
+describe("classifyReferenceKind", () => {
+	it("classifies console.ves.volterra.io as console", () => {
+		expect(classifyReferenceKind("https://tenant.console.ves.volterra.io/web/ns/default/http_loadbalancers")).toBe(
+			"console",
+		);
+	});
+
+	it("classifies docs.cloud.f5.com as doc", () => {
+		expect(classifyReferenceKind("https://docs.cloud.f5.com/docs/how-to/app-networking")).toBe("doc");
+	});
+
+	it("classifies /docs paths as doc", () => {
+		expect(classifyReferenceKind("https://example.com/docs/reference/api")).toBe("doc");
+	});
+
+	it("defaults unknown URLs to doc", () => {
+		expect(classifyReferenceKind("https://github.com/f5/repo")).toBe("doc");
 	});
 });

--- a/packages/coding-agent/test/browser/chat-protocol.test.ts
+++ b/packages/coding-agent/test/browser/chat-protocol.test.ts
@@ -73,6 +73,17 @@ describe("isChatRequest", () => {
 			).toBe(true);
 		}
 	});
+
+	it("accepts chat_request without history_hint (optional field)", () => {
+		expect(
+			isChatRequest({
+				type: "chat_request",
+				id: "c-abc",
+				text: "hello",
+				mode: "educational",
+			}),
+		).toBe(true);
+	});
 });
 
 describe("isChatStop", () => {


### PR DESCRIPTION
## Summary

- Track `history_hint` and reset conversation context on change to prevent cross-conversation bleed (#1816)
- Align vendored types with extension contract: `resourceType` nullable, `history_hint` optional (#1817)
- Improve `extractReferences`: detect bare URLs, deduplicate, classify doc-vs-console by hostname (#1818)
- Vendor `chat-conformance.json` and add 26 conformance tests validating xcsh parsers and serializers against the extension's published schemas + golden examples (#1819)

Closes #1816, closes #1817, closes #1818, closes #1819

## Test plan

- [x] `composeChatPrompt` handles null `resourceType` without rendering "null"
- [x] `isChatRequest` accepts messages without `history_hint`
- [x] `classifyReferenceKind` for console, docs, /docs paths, and unknown URLs
- [x] 26 conformance tests: valid examples validate, invalid examples rejected, xcsh parsers accept/reject correctly, outbound frames validate, contract version matches
- [x] All existing tests pass (integration roundtrip, contract, bridge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)