### PR TITLE
feat: multi-session handshake + tenant identity; bug-1 automation resolver/click fixes

### DIFF
--- a/packages/coding-agent/scripts/sweep-harness.ts
+++ b/packages/coding-agent/scripts/sweep-harness.ts
@@ -29,7 +29,13 @@ import * as yaml from "yaml";
 import { type BridgeServer, startBridgeServer } from "../src/browser/extension-bridge";
 import { ExtensionBrowserProvider } from "../src/browser/extension-provider";
 import { isScopedOut, paramsFor } from "../src/sweep/sweep-params";
-import { apiItemPath, type SweepOperation, scoreOperation, type Verdict } from "../src/sweep/sweep-scoring";
+import {
+	apiCollectionPath,
+	apiItemPath,
+	type SweepOperation,
+	scoreOperation,
+	type Verdict,
+} from "../src/sweep/sweep-scoring";
 import { CatalogWorkflowRunnerTool } from "../src/tools/catalog-workflow-runner";
 
 /** Banked walker-generated + API-validated specs, used to drive JSON-tab create. */

--- a/packages/coding-agent/src/browser/capabilities.generated.ts
+++ b/packages/coding-agent/src/browser/capabilities.generated.ts
@@ -604,6 +604,26 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 			}
 		},
 		{
+			"name": "diag_suspension",
+			"summary": "Diagnostic: SW-lifecycle event buffer + suspension summary (Phase 0a).",
+			"category": "read",
+			"params": {
+				"type": "object",
+				"properties": {}
+			},
+			"flags": {}
+		},
+		{
+			"name": "capture_login_flow",
+			"summary": "Diagnostic: captured login redirect chain annotated with tenant/env (Phase 0b).",
+			"category": "read",
+			"params": {
+				"type": "object",
+				"properties": {}
+			},
+			"flags": {}
+		},
+		{
 			"name": "wait_for_api_response",
 			"summary": "Wait for a network response whose URL matches a pattern.",
 			"category": "read",
@@ -795,4 +815,4 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 
 export const EXTENSION_CONTRACT_VERSION = "1.4.0";
 
-export const EXTENSION_TOOL_NAMES: readonly string[] = ["ping","capabilities","reload","debug_exec","detach","set_bridge_port","navigate","login","scroll_to","resize_window","tabs_list","tabs_create","tabs_close","click","click_element","click_xy","type_text","form_input","key_press","select_option","label_select","file_upload","read_ax","get_page_text","query_dom","find","wait_for","assert_text","screenshot","read_console","read_network","wait_for_api_response","get_page_context","javascript_tool","browser_batch","set_explain_mode","annotate"];
+export const EXTENSION_TOOL_NAMES: readonly string[] = ["ping","capabilities","reload","debug_exec","detach","set_bridge_port","navigate","login","scroll_to","resize_window","tabs_list","tabs_create","tabs_close","click","click_element","click_xy","type_text","form_input","key_press","select_option","label_select","file_upload","read_ax","get_page_text","query_dom","find","wait_for","assert_text","screenshot","read_console","read_network","diag_suspension","capture_login_flow","wait_for_api_response","get_page_context","javascript_tool","browser_batch","set_explain_mode","annotate"];

--- a/packages/coding-agent/src/browser/capabilities.json
+++ b/packages/coding-agent/src/browser/capabilities.json
@@ -530,6 +530,26 @@
       }
     },
     {
+      "name": "diag_suspension",
+      "summary": "Diagnostic: SW-lifecycle event buffer + suspension summary (Phase 0a).",
+      "category": "read",
+      "params": {
+        "type": "object",
+        "properties": {}
+      },
+      "flags": {}
+    },
+    {
+      "name": "capture_login_flow",
+      "summary": "Diagnostic: captured login redirect chain annotated with tenant/env (Phase 0b).",
+      "category": "read",
+      "params": {
+        "type": "object",
+        "properties": {}
+      },
+      "flags": {}
+    },
+    {
       "name": "wait_for_api_response",
       "summary": "Wait for a network response whose URL matches a pattern.",
       "category": "read",

--- a/packages/coding-agent/src/browser/cdp-page-actions.ts
+++ b/packages/coding-agent/src/browser/cdp-page-actions.ts
@@ -17,7 +17,10 @@ export class CdpPageActions implements PageActions {
 		});
 	}
 
-	async click(selector: string, context?: string): Promise<void> {
+	async click(selector: string, context?: string, _opts?: { native?: boolean }): Promise<void> {
+		// CDP/Puppeteer has no trusted-vs-native split — a Puppeteer click already
+		// dispatches real events to the resolved element; the `native` escalation
+		// hint is an extension-only concern, so ignore it here.
 		await actions.click(this.#page, selector, context);
 	}
 

--- a/packages/coding-agent/src/browser/extension-bridge.ts
+++ b/packages/coding-agent/src/browser/extension-bridge.ts
@@ -86,6 +86,10 @@ export class BridgeServer {
 	#onMessage: Array<(msg: Record<string, unknown>) => void> = [];
 	/** Heartbeat interval that sends pings to keep the MV3 service worker alive (sweep + chat). */
 	#heartbeat: ReturnType<typeof setInterval> | null = null;
+	/** Stable per-process session id, advertised to the extension on `hello`. */
+	#sessionId = `sess-${crypto.randomUUID()}`;
+	/** Provider of this process's tenant identity, answering the `hello` handshake. */
+	#sessionInfo: (() => { tenant: string | null; env: string | null; apiUrl: string | null }) | null = null;
 
 	/** The port the WebSocket server is listening on (0 = not bound). */
 	get port(): number {
@@ -113,6 +117,29 @@ export class BridgeServer {
 	/** Register a listener for messages not handled by the built-in router (tool_result, ping). */
 	onMessage(cb: (msg: Record<string, unknown>) => void): void {
 		this.#onMessage.push(cb);
+	}
+
+	/** This process's stable session id (advertised on the `hello` handshake). */
+	get sessionId(): string {
+		return this.#sessionId;
+	}
+
+	/** Set the tenant-identity provider that answers the extension's `hello`
+	 * handshake with `{ tenant, env, apiUrl }` for THIS xcsh process/context. */
+	setSessionInfo(cb: () => { tenant: string | null; env: string | null; apiUrl: string | null }): void {
+		this.#sessionInfo = cb;
+	}
+
+	/** Push a tenant change to all connected panels (e.g. after `/context activate`). */
+	broadcastTenantChanged(): void {
+		const info = this.#sessionInfo?.() ?? { tenant: null, env: null, apiUrl: null };
+		for (const c of this.#clients.values()) {
+			try {
+				c.send(JSON.stringify({ type: "tenant_changed", sessionId: this.#sessionId, ...info }));
+			} catch {
+				/* client may have dropped */
+			}
+		}
 	}
 
 	/**
@@ -199,6 +226,19 @@ export class BridgeServer {
 			});
 		} else if (msg.type === "ping") {
 			ws.send(JSON.stringify({ type: "pong" }));
+		} else if (msg.type === "hello") {
+			// Identity handshake: tell the extension which tenant this process serves.
+			const info = this.#sessionInfo?.() ?? { tenant: null, env: null, apiUrl: null };
+			ws.send(
+				JSON.stringify({
+					type: "hello_ack",
+					sessionId: this.#sessionId,
+					tenant: info.tenant,
+					env: info.env,
+					apiUrl: info.apiUrl,
+					pid: process.pid,
+				}),
+			);
 		} else {
 			for (const cb of this.#onMessage) cb(msg as Record<string, unknown>);
 		}

--- a/packages/coding-agent/src/browser/extension-page-actions.ts
+++ b/packages/coding-agent/src/browser/extension-page-actions.ts
@@ -76,14 +76,25 @@ function findByText(text,roleSel){
   const all=roleSel?[...document.querySelectorAll(roleSel)]:[...document.querySelectorAll('*')];
   const norm=t=>t.replace(/\\u0421/g,'C').replace(/\\s+/g,' ').trim();
   const want=norm(text);
-  // Match by text FIRST (cheap, no layout), then prefer a VISIBLE match — a
-  // hidden/template duplicate (e.g. an off-screen 'Delete' button) resolves to
-  // rect 0,0 and the trusted click misses. Computing visibility only on the few
-  // text matches avoids forcing a full-page reflow per call.
+  // A bare text() query matches wrapper <div>s too (an ancestor's textContent
+  // contains its children's), so the OUTERMOST wins by document order — clicking
+  // that wrapper is a no-op and e.g. an "Add …" control never opens its form.
+  // Prefer, in order: (1) an INTERACTIVE match (button/link/tab/input/…) — the
+  // real semantic click target, robust for the trusted CDP click — else the
+  // INNERMOST match (drop any element that contains another match); then a
+  // VISIBLE one (a hidden/template duplicate resolves to rect 0,0 and misses).
+  const CLICKABLE='a[href],button,input,select,textarea,[role=button],[role=tab],[role=link],[role=menuitem],[role=menuitemcheckbox],[role=option],[role=checkbox],[role=switch],[onclick],[tabindex]';
+  const pick=list=>{
+    if(!list.length)return null;
+    const clickable=list.filter(e=>e.matches&&e.matches(CLICKABLE));
+    const tier=clickable.length?clickable:list;
+    const inner=tier.filter(e=>!tier.some(o=>o!==e&&e.contains(o)));
+    const pool=inner.length?inner:tier;
+    return pool.find(isVisible)||pool[0];
+  };
   const exact=all.filter(e=>norm(e.textContent||'')===want);
-  if(exact.length)return exact.find(isVisible)||exact[0];
-  const sub=all.filter(e=>norm(e.textContent||'').includes(want));
-  return sub.find(isVisible)||sub[0];
+  if(exact.length)return pick(exact);
+  return pick(all.filter(e=>norm(e.textContent||'').includes(want)));
 }
 function findByRoleName(role,name){
   const roleSel=roleToSelector(role);
@@ -294,22 +305,38 @@ export class ExtensionPageActions implements PageActions {
 		}
 	}
 
-	async click(selector: string, _context?: string): Promise<void> {
+	async click(selector: string, _context?: string, opts?: { native?: boolean }): Promise<void> {
+		// Escalation path: a synthetic DOM .click() dispatched straight to the
+		// element's handler. Some vsui controls (e.g. the role=tab "Add …" button)
+		// ignore the trusted CDP mouse dispatch entirely and only react to this —
+		// the mirror of the controls that NEED real events (dropdowns/submit). The
+		// runner uses it on click-step retries after the real click didn't take.
+		if (opts?.native) {
+			const res = await evalJson(this.#ext, buildNativeClickScript(selector));
+			if (res?.clicked) return;
+			throw new Error(`native click "${selector}" not found: ${res?.error ?? "no match"}`);
+		}
 		// Deterministic click: resolve the selector to the live element, then let the
 		// extension derive geometry from the renderer (DOM.getContentQuads) and
 		// hit-test the point (document.elementFromPoint) before dispatching. This
 		// replaces the JS getBoundingClientRect coords + 300ms settle heuristic —
 		// the hit-test is the gate now (it fails loudly on occlusion instead of
 		// landing mid-transition or on an overlay).
+		await this.#clickElementWithFallback(selector);
+	}
+
+	/**
+	 * Trusted CDP click with a native-DOM fallback on "not hittable". The hit-test
+	 * fails when the target is occluded (a footer button under the open side panel)
+	 * OR off-viewport (elementFromPoint returns "none" for a point past the window
+	 * width — the console's right-pane fields sit at large x). A native .click()
+	 * scrolls the element into view (inline:center) and dispatches straight to its
+	 * handler, clearing both cases. Shared by click() and fill()'s focus step.
+	 */
+	async #clickElementWithFallback(selector: string): Promise<void> {
 		try {
 			await this.#ext.clickElement(buildElementResolverScript(selector));
 		} catch (e) {
-			// OCCLUSION FALLBACK: the hit-test fails "not hittable" when an overlay
-			// covers the target — most often a footer Save/submit button when the
-			// xcsh chat side panel is open (it occupies the bottom-right where the
-			// button lives, and the sticky footer can't scroll out of the occluded
-			// zone). A native DOM .click() dispatches straight to the element's
-			// handler, so automation succeeds even with the panel open.
 			if (/not hittable/i.test(e instanceof Error ? e.message : String(e))) {
 				const res = await evalJson(this.#ext, buildNativeClickScript(selector));
 				if (res?.clicked) return;
@@ -351,8 +378,10 @@ export class ExtensionPageActions implements PageActions {
 		// value-setters (buildFillScript) set the DOM but leave the model empty,
 		// causing "This field is required" even when the value is visible. Trusted CDP
 		// Input.insertText fires keydown/input/keyup inside NgZone, so Angular sees it.
-		// 1. Click to focus (Angular transitions pristine → dirty/touched).
-		await this.#ext.clickElement(buildElementResolverScript(selector));
+		// 1. Click to focus (Angular transitions pristine → dirty/touched). Uses the
+		// native fallback so an off-viewport field (elementFromPoint "none") is
+		// scrolled into view and focused instead of throwing "not hittable".
+		await this.#clickElementWithFallback(selector);
 		await new Promise(r => setTimeout(r, 200));
 		// 2. Clear any pre-existing text so re-fills are clean.
 		const curLen = typeof probe.val === "string" ? probe.val.length : 0;
@@ -407,7 +436,9 @@ export class ExtensionPageActions implements PageActions {
 		// All options appear on click; the option is clicked directly below.
 		const resolved = await withTimeout(evalJson(this.#ext, buildResolverScript(selector)), 10_000, "resolve-listbox");
 		if (!resolved?.found) throw new Error(`selectOption: selector "${selector}" not found`);
-		await withTimeout(this.#ext.clickElement(buildElementResolverScript(selector)), 10_000, "click-listbox");
+		// Native fallback so an off-viewport listbox (elementFromPoint "none") is
+		// scrolled into view and opened rather than throwing "not hittable".
+		await withTimeout(this.#clickElementWithFallback(selector), 10_000, "click-listbox");
 		await new Promise(r => setTimeout(r, 1200));
 		// Click the option whose text matches value (exact-first via the resolver).
 		// Best-effort: if it never renders, fall through — the default value usually

--- a/packages/coding-agent/src/browser/extension-provider.ts
+++ b/packages/coding-agent/src/browser/extension-provider.ts
@@ -34,7 +34,7 @@ export interface ExtensionPage {
 	screenshot(): Promise<string>;
 	// Phase 1 additions:
 	formInput(ref: string, value: string): Promise<void>;
-	keyPress(key: string): Promise<void>;
+	keyPress(key: string, opts?: { modifiers?: string[] }): Promise<void>;
 	selectOption(ref: string, value: string): Promise<void>;
 	scrollTo(ref: string): Promise<void>;
 	waitFor(selector: string, context?: string, timeoutMs?: number): Promise<string>;
@@ -192,8 +192,8 @@ class BridgeExtensionPage implements ExtensionPage {
 		unwrap(await this.#server.request("form_input", { ref, value }), "form_input");
 	}
 
-	async keyPress(key: string): Promise<void> {
-		unwrap(await this.#server.request("key_press", { key }), "key_press");
+	async keyPress(key: string, opts?: { modifiers?: string[] }): Promise<void> {
+		unwrap(await this.#server.request("key_press", { key, modifiers: opts?.modifiers }), "key_press");
 	}
 
 	async selectOption(ref: string, value: string): Promise<void> {

--- a/packages/coding-agent/src/browser/page-actions.ts
+++ b/packages/coding-agent/src/browser/page-actions.ts
@@ -7,7 +7,10 @@
  */
 export interface PageActions {
 	goto(url: string, opts?: { waitUntil?: string; timeout?: number }): Promise<void>;
-	click(selector: string, context?: string): Promise<void>;
+	/** `opts.native` forces a synthetic DOM `.click()` instead of the trusted CDP
+	 * mouse dispatch — the escalation for controls that ignore real mouse events
+	 * (used by the runner on click-step retries). Backends free to ignore it. */
+	click(selector: string, context?: string, opts?: { native?: boolean }): Promise<void>;
 	fill(selector: string, value: string, context?: string): Promise<void>;
 	selectOption(selector: string, value: string, context?: string): Promise<void>;
 	scrollIntoView(selector: string, context?: string): Promise<void>;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -819,6 +819,27 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 		// Make the bridge globally available so ALL selectProvider() calls reuse it
 		// (prevents starting a conflicting second bridge on the same port).
 		setSharedBridgeServer(bridgeServer);
+		// Tenant identity for the `hello` handshake — tells the extension which
+		// tenant/env THIS xcsh process serves (one process = one context = one
+		// tenant), so the panel can lock its session and route per tenant.
+		{
+			const { ContextService } = await import("./services/xcsh-context");
+			const { sessionKeyFromUrl } = await import("./services/xcsh-env");
+			const readInfo = () => {
+				let apiUrl: string | null = null;
+				try {
+					apiUrl = ContextService.instance.activeApiUrl;
+				} catch {
+					/* ContextService not initialized */
+				}
+				// Fall back to the env override when no context is active (env-only mode).
+				apiUrl = apiUrl ?? process.env.XCSH_API_URL ?? null;
+				const key = apiUrl ? sessionKeyFromUrl(apiUrl) : null;
+				return { tenant: key?.tenant ?? null, env: key?.env ?? null, apiUrl };
+			};
+			bridgeServer.setSessionInfo(readInfo);
+			ContextService.onContextChange(() => bridgeServer?.broadcastTenantChanged());
+		}
 		// Warm-up handler: respond to early chat_request before the session loads.
 		// Deactivates once sessionReady=true (the real ChatHandler takes over).
 		bridgeServer.onMessage(msg => {

--- a/packages/coding-agent/src/services/xcsh-env.ts
+++ b/packages/coding-agent/src/services/xcsh-env.ts
@@ -84,6 +84,50 @@ export function deriveTenantFromUrl(url: string): string | null {
 	return DNS_LABEL_RE.test(label) ? label : null;
 }
 
+/** A tenant's unique session identity. Mirrors the extension's `sessionKeyFromUrl`
+ * (xcsh-chrome-extension/src/tab-binding.ts) — keep the two in sync. */
+export interface SessionKey {
+	tenant: string;
+	env: "production" | "staging";
+}
+
+/**
+ * Map a console/login URL to its `(tenant, environment)` session key, or null.
+ * Fail-closed and STRICTER than {@link deriveTenantFromUrl}: staging and
+ * production of the same tenant name are distinct keys; the shared SaaS console
+ * and `volterra` realm, IPs, and unrecognized hosts return null. Used by the
+ * bridge handshake to tell the extension which tenant this xcsh process serves.
+ */
+export function sessionKeyFromUrl(url: string | undefined): SessionKey | null {
+	if (!url) return null;
+	let hostname: string;
+	let path: string;
+	try {
+		const u = new URL(url);
+		hostname = u.hostname.toLowerCase();
+		path = u.pathname;
+	} catch {
+		return null;
+	}
+	const staging = hostname.match(/^([a-z0-9-]+)\.staging\.volterra\.us$/);
+	if (staging && DNS_LABEL_RE.test(staging[1])) return { tenant: staging[1], env: "staging" };
+	const prod = hostname.match(/^([a-z0-9-]+)\.console\.ves\.volterra\.io$/);
+	if (prod && DNS_LABEL_RE.test(prod[1])) return { tenant: prod[1], env: "production" };
+	const isLoginHost =
+		hostname === "login.ves.volterra.io" ||
+		hostname === "login-staging.volterra.us" ||
+		/^login(-[a-z0-9]+)?\.volterra\.(us|io)$/.test(hostname);
+	const oidc = path.match(/^\/auth\/realms\/([^/]+)\/protocol\/openid-connect/i);
+	if (isLoginHost && oidc) {
+		const realm = oidc[1].toLowerCase();
+		if (realm === "volterra") return null;
+		const tenant = realm.replace(/-[a-z0-9]+$/, "");
+		const env: "production" | "staging" = hostname.includes("staging") ? "staging" : "production";
+		return DNS_LABEL_RE.test(tenant) ? { tenant, env } : null;
+	}
+	return null;
+}
+
 /**
  * Reduce an API URL to its origin (`https://host[:port]`) — the canonical stored
  * form for a context endpoint.

--- a/packages/coding-agent/src/tools/catalog-workflow-runner.ts
+++ b/packages/coding-agent/src/tools/catalog-workflow-runner.ts
@@ -334,6 +334,11 @@ export class CatalogWorkflowRunnerTool
 			stepIndex: number;
 			catalogPath?: string;
 			depth: number;
+			/** Retry attempt (0 = first). Click steps escalate to a native DOM click
+			 * on retry: some vsui controls (a role=tab "Add …" button) ignore the
+			 * trusted CDP mouse dispatch and only react to a synthetic click, while
+			 * others need the real events — so try real first, native on retry. */
+			attempt?: number;
 		},
 		signal?: AbortSignal,
 	): Promise<StepResult> {
@@ -399,7 +404,7 @@ export class CatalogWorkflowRunnerTool
 					if (options.annotations && page.highlightElement) {
 						await page.highlightElement(resolvedSelector).catch(() => {});
 					}
-					await page.click(resolvedSelector, resolvedContext);
+					await page.click(resolvedSelector, resolvedContext, { native: (options.attempt ?? 0) >= 1 });
 					break;
 				}
 				case "fill": {
@@ -743,6 +748,7 @@ export class CatalogWorkflowRunnerTool
 				if (action === "skip") {
 					stepResults.push({
 						stepId: "pre-create-check",
+						action: "pre-create-check",
 						description: `${inputParams.resource} "${params.name}" already exists — skipped (idempotent)`,
 						status: "pass",
 						durationMs: 0,
@@ -778,7 +784,7 @@ export class CatalogWorkflowRunnerTool
 						catalogPath: inputParams.catalog_path,
 						depth: 0,
 					};
-					let stepResult = await this.#executeStep(step, params, baseUrl, page, opts, signal);
+					let stepResult = await this.#executeStep(step, params, baseUrl, page, { ...opts, attempt: 0 }, signal);
 					for (let attempt = 1; attempt <= 2 && stepResult.status === "fail"; attempt++) {
 						throwIfAborted(signal);
 						logger.warn("catalog-workflow-runner: retrying failed step", {
@@ -787,7 +793,7 @@ export class CatalogWorkflowRunnerTool
 							error: stepResult.error,
 						});
 						await new Promise(r => setTimeout(r, 1000 * attempt));
-						stepResult = await this.#executeStep(step, params, baseUrl, page, opts, signal);
+						stepResult = await this.#executeStep(step, params, baseUrl, page, { ...opts, attempt }, signal);
 					}
 					stepResults.push(stepResult);
 

--- a/packages/coding-agent/test/browser/resolver.test.ts
+++ b/packages/coding-agent/test/browser/resolver.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { parseHTML } from "linkedom";
+import { buildElementResolverScript } from "../../src/browser/extension-page-actions";
+
+/**
+ * Evaluate the REAL resolver script (the string sent to the page) against a
+ * linkedom DOM fixture. linkedom implements querySelectorAll/contains/matches;
+ * getBoundingClientRect returns zeros and offsetParent is undefined (so the
+ * script's isVisible() treats elements as visible), and scrollIntoView is
+ * shimmed because linkedom lacks it.
+ */
+function resolveElement(html: string, selector: string): { id: string; tag: string } | null {
+	const { document } = parseHTML(`<html><body>${html}</body></html>`);
+	for (const el of document.querySelectorAll("*")) {
+		(el as unknown as { scrollIntoView: () => void }).scrollIntoView = () => {};
+	}
+	const code = buildElementResolverScript(selector); // "(()=>{ ... return el; })()"
+	const fn = new Function("document", `return ${code};`);
+	const el = fn(document) as { id?: string; tagName?: string } | null;
+	return el ? { id: el.id ?? "", tag: (el.tagName ?? "").toLowerCase() } : null;
+}
+
+describe("buildElementResolverScript — text() element preference", () => {
+	// Bug 1 root cause: the F5 console renders "Add Health Check" as a <button>
+	// wrapped in container <div>s whose only text is that label. findByText
+	// searched all elements and returned the FIRST (outermost) match by document
+	// order — a non-interactive <div> — so the trusted click was a no-op and the
+	// create form never opened. It must pick the innermost matching element (the
+	// button / its span), which is what actually handles the click.
+	test("prefers the interactive element over an outer container", () => {
+		const el = resolveElement(
+			`<div id="wrap"><button id="btn">Add Health Check</button></div>`,
+			"text('Add Health Check')",
+		);
+		expect(el).not.toBeNull();
+		expect(el?.id).toBe("btn");
+	});
+
+	test("resolves to the interactive control, not the inner text span it wraps", () => {
+		// The real F5 console renders "Add Health Check" as <button role=tab>
+		// wrapping label <span>s. The click target must be the button (a robust,
+		// semantic hit target) — not the innermost span, which makes the trusted
+		// CDP click flaky.
+		const el = resolveElement(
+			`<div id="outer"><button id="tab" role="tab"><div class="btn-label"><span id="label">Add Health Check</span></div></button></div>`,
+			"text('Add Health Check')",
+		);
+		expect(el?.id).toBe("tab");
+	});
+
+	test("falls back to the innermost element when no match is interactive", () => {
+		// Readiness gates like wait_for text('Health Checks') target plain text.
+		const el = resolveElement(`<div id="page"><h1 id="title">Health Checks</h1></div>`, "text('Health Checks')");
+		expect(el?.id).toBe("title");
+	});
+
+	test("still resolves a plain single match", () => {
+		const el = resolveElement(`<button id="only">Save</button>`, "text('Save')");
+		expect(el?.id).toBe("only");
+	});
+});

--- a/packages/coding-agent/test/xcsh-env.test.ts
+++ b/packages/coding-agent/test/xcsh-env.test.ts
@@ -3,6 +3,7 @@ import {
 	deriveTenantFromUrl,
 	hasEnvOverride,
 	normalizeApiUrl,
+	sessionKeyFromUrl,
 	XCSH_API_TOKEN,
 	XCSH_API_URL,
 	XCSH_NAMESPACE,
@@ -53,6 +54,27 @@ describe("xcsh-env", () => {
 		it("returns false when only XCSH_API_URL is set (URL alone is not an override)", () => {
 			process.env[XCSH_API_URL] = "https://acme.console.ves.volterra.io";
 			expect(hasEnvOverride()).toBe(false);
+		});
+	});
+
+	describe("sessionKeyFromUrl", () => {
+		it("keys staging and production of the same tenant distinctly", () => {
+			expect(sessionKeyFromUrl("https://acme.staging.volterra.us/web/home")).toEqual({
+				tenant: "acme",
+				env: "staging",
+			});
+			expect(sessionKeyFromUrl("https://acme.console.ves.volterra.io/web/x")).toEqual({
+				tenant: "acme",
+				env: "production",
+			});
+		});
+		it("fails closed on the shared SaaS console/realm, IPs, and junk", () => {
+			expect(sessionKeyFromUrl("https://console.ves.volterra.io/web/devportal/domain")).toBeNull();
+			expect(
+				sessionKeyFromUrl("https://login.ves.volterra.io/auth/realms/volterra/protocol/openid-connect/auth"),
+			).toBeNull();
+			expect(sessionKeyFromUrl("https://192.168.1.10/web/home")).toBeNull();
+			expect(sessionKeyFromUrl(undefined)).toBeNull();
 		});
 	});
 


### PR DESCRIPTION
Closes #1828

Runner + bridge side of the multi-session work, plus the bug-1 (visual automation didn't drive the form) root-cause fixes. Stacked on `feat/sweep-coverage`.

## Bug 1 (visual automation)
- **Resolver**: `findByText` prefers the innermost **interactive** element (the real button/tab), not an outer wrapper `<div>` or bare text span — so `text()` clicks land on the control that opens the form.
- **Click**: native-click escalation on retry for vsui controls that ignore the trusted CDP dispatch; shared `#clickElementWithFallback` (`scrollIntoView inline:center`) so off-viewport fields resolve instead of "not hittable". `fill`/`selectOption` use it too.

## Multi-session (Phase 1)
- `sessionKeyFromUrl(url) → {tenant, env}` in `xcsh-env.ts` (mirrors the extension).
- `BridgeServer`: `hello`/`hello_ack` + `setSessionInfo` + `broadcastTenantChanged`.
- `main.ts` advertises this process's tenant (`ContextService.activeApiUrl`), re-advertises on `onContextChange`.

## Also
- 3 pre-existing CI-blocking type errors fixed (`sweep-harness` import, pre-create-check `action`, `keyPress` modifiers).
- `capabilities.{generated.ts,json}` regenerated for the extension's new diagnostic tools.

## Verification
Full 9-step health-check create verified green E2E (API-confirmed). 192 tests pass; 0 typecheck errors (was 3 pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)