### PR TITLE
Session-scoped context foundation (CLI-first)

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -617,16 +617,14 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 	const cwd = getProjectDir();
 	await logger.time("settings:init", Settings.init, { cwd });
 
-	// F5 XC context loading — optional, never blocks startup.
-	// NOTE: This runs in the CLI path only. SDK consumers using createAgentSession()
-	// directly must call ContextService.init(configDir).loadActive() themselves.
+	// F5 XC context is session-scoped: nothing loads at startup. We still init the
+	// ContextService singleton so /context commands and the session bootstrap work.
 	try {
 		const { ContextService } = await import("./services/xcsh-context");
 		const { getXCSHConfigDir } = await import("@f5-sales-demo/pi-utils");
-		const contextService = ContextService.init(getXCSHConfigDir());
-		await contextService.loadActive(cwd);
+		ContextService.init(getXCSHConfigDir());
 	} catch {
-		// F5 XC auth is optional — silently continue if anything fails
+		// ContextService optional (SDK consumers / tests) — continue.
 	}
 
 	if (parsedArgs.mode === "rpc") {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -771,6 +771,41 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const existingSession = logger.time("loadSessionContext", () =>
 		deobfuscateSessionContext(sessionManager.buildSessionContext(), obfuscator),
 	);
+
+	// --- Session-scoped context bootstrap ------------------------------------
+	// No context is auto-loaded at startup. The session decides: a RESUMED session
+	// re-activates the context recorded in its context_change log; a NEW session
+	// smart-auto-binds (folder-local, else the single context, else ask). Loading
+	// is via the existing activate(); auth is validated but never blocks resume.
+	try {
+		const { ContextService } = await import("./services/xcsh-context");
+		const { resolveAutoBind, chooseSessionContext } = await import("./services/session-context-binding");
+		const svc = ContextService.instance; // inited in main.ts (throws for SDK/tests → caught)
+		if (!process.env.XCSH_API_URL) {
+			const bound = existingSession.activeContextName; // resumed binding, if any
+			const available = (await svc.listContexts()).map(c => c.name);
+			const folderContext = await svc.resolveFolderContextName(cwd);
+			const autoBind = resolveAutoBind({ kind: "cli", availableContexts: available, folderContext });
+			const choice = chooseSessionContext(bound, autoBind);
+			if ("activate" in choice) {
+				try {
+					await svc.activate(choice.activate); // fires onContextChange → records context_change
+					await svc.validateToken(); // authenticate; non-blocking
+				} catch (err) {
+					// Context deleted since last use, or auth failed → surface, never block.
+					logger.warn("XCSH: session context bootstrap could not fully activate", {
+						context: choice.activate,
+						error: String(err),
+					});
+				}
+			}
+			// choice.needsSelection / choice.none → leave unbound; the /context status
+			// line and tools already prompt "run /context activate".
+		}
+	} catch {
+		// ContextService not initialized (SDK consumers / tests) — skip bootstrap.
+	}
+
 	const existingBranch = logger.time("getSessionBranch", () => sessionManager.getBranch());
 	const hasExistingSession = existingBranch.length > 0;
 	const hasThinkingEntry = existingBranch.some(entry => entry.type === "thinking_level_change");

--- a/packages/coding-agent/src/services/session-context-binding.ts
+++ b/packages/coding-agent/src/services/session-context-binding.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure decisions for session-scoped context binding. No I/O — the caller
+ * gathers inputs (available contexts, folder-local context, tenant key) and
+ * performs the activation. Key-agnostic so the deferred extension/daemon phase
+ * reuses it unchanged.
+ */
+
+export type SessionKind = "cli" | "extension";
+
+export interface AutoBindInput {
+	kind: SessionKind;
+	/** Names of all available (global) contexts. */
+	availableContexts: string[];
+	/** CLI: the folder-local context name resolved from `.xcsh/`, if any. */
+	folderContext?: string | null;
+	/** Extension: the tenant|env key of the focused tab. */
+	tenantKey?: string | null;
+	/** Extension: contextName → its tenant|env key (derived from apiUrl). */
+	contextTenantKeys?: Record<string, string>;
+}
+
+export type AutoBindResult = { kind: "bind"; contextName: string } | { kind: "needsSelection" } | { kind: "none" };
+
+/** Decide which context (if any) a NEW session should auto-bind. */
+export function resolveAutoBind(input: AutoBindInput): AutoBindResult {
+	if (input.kind === "extension") {
+		if (!input.tenantKey) return { kind: "none" };
+		const match = Object.entries(input.contextTenantKeys ?? {}).find(([, key]) => key === input.tenantKey);
+		return match ? { kind: "bind", contextName: match[0] } : { kind: "needsSelection" };
+	}
+	// cli
+	if (input.folderContext) return { kind: "bind", contextName: input.folderContext };
+	if (input.availableContexts.length === 1) return { kind: "bind", contextName: input.availableContexts[0] };
+	if (input.availableContexts.length === 0) return { kind: "none" };
+	return { kind: "needsSelection" };
+}
+
+export type SessionContextChoice = { activate: string } | { needsSelection: true } | { none: true };
+
+/** Resume (boundContextName present) wins; otherwise fall back to the auto-bind result. */
+export function chooseSessionContext(
+	boundContextName: string | undefined,
+	autoBind: AutoBindResult,
+): SessionContextChoice {
+	if (boundContextName) return { activate: boundContextName };
+	if (autoBind.kind === "bind") return { activate: autoBind.contextName };
+	if (autoBind.kind === "needsSelection") return { needsSelection: true };
+	return { none: true };
+}

--- a/packages/coding-agent/src/services/xcsh-context.ts
+++ b/packages/coding-agent/src/services/xcsh-context.ts
@@ -493,9 +493,6 @@ export class ContextService {
 
 		this.#assertCompatibleVersion(context);
 
-		// NFR-402: write active_context first — if it fails, don't update settings
-		this.#atomicWrite(this.activeContextPath, name);
-
 		if (this.#activeContext && this.#activeContext.name !== name) {
 			this.#previousContextName = this.#activeContext.name;
 		}

--- a/packages/coding-agent/src/services/xcsh-context.ts
+++ b/packages/coding-agent/src/services/xcsh-context.ts
@@ -363,6 +363,19 @@ export class ContextService {
 		return this.#activeContext?.defaultNamespace ?? null;
 	}
 
+	/** The project-local (`.xcsh/`) context NAME for `cwd`, or null. No activation,
+	 * no settings mutation — a pure lookup used by the session bootstrap. */
+	async resolveFolderContextName(cwd: string): Promise<string | null> {
+		try {
+			const resolver = new ContextResolver({ paths: xcshContextPaths });
+			const local = await resolver.resolve(cwd);
+			if (local && local.source === "local") return (local.context as XCSHContext).name ?? null;
+		} catch {
+			/* no local context */
+		}
+		return null;
+	}
+
 	async loadActive(cwd?: string): Promise<XCSHContext | null> {
 		// FR-102: XCSH_API_URL is the signal to skip context loading entirely.
 		// Subprocesses inherit process.env, so they already see the env vars directly.

--- a/packages/coding-agent/src/services/xcsh-context.ts
+++ b/packages/coding-agent/src/services/xcsh-context.ts
@@ -429,19 +429,10 @@ export class ContextService {
 		// sync form keeps createContext/deleteContext race-free with no coordination.
 		await this.listContexts();
 
-		let contextName = this.#readActiveContextName();
-
-		// FR-104: auto-activate if exactly one context exists
-		let autoActivated = false;
-		if (!contextName) {
-			const contexts = this.#listContextFiles();
-			if (contexts.length === 1) {
-				contextName = contexts[0].replace(/\.json$/, "");
-				autoActivated = true;
-			} else {
-				return null;
-			}
-		}
+		const contextName = this.#readActiveContextName();
+		// Session-scoped: no auto-activate of a lone context. Without an explicit
+		// active_context pointer there is no global default to load.
+		if (!contextName) return null;
 
 		// Read the context JSON
 		const context = this.#readContext(contextName);
@@ -458,12 +449,6 @@ export class ContextService {
 				error: String(err),
 			});
 			return null;
-		}
-
-		// Only persist active_context after the context validates
-		if (autoActivated) {
-			this.#atomicWrite(this.activeContextPath, contextName);
-			logger.debug("XCSH: auto-activated single context", { name: contextName });
 		}
 
 		this.#activeContext = context;

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -258,12 +258,16 @@ describe("MCP startup message suppression (fork preference)", () => {
 
 // ─── F5 XC Context Auto-Loading ───────────────────────────────────────────
 
-describe("F5 XC context auto-loading at CLI startup (PR #69)", () => {
-	it("main.ts imports and calls ContextService at startup", async () => {
+// Session-scoped context: startup no longer calls loadActive() (FR-104 removed).
+// main.ts still inits the singleton so /context commands and the session bootstrap work,
+// but context loading is deferred to createAgentSession's bootstrap (new behaviour).
+describe("F5 XC context session-scoped init at CLI startup (PR #69 → session-scoped clean break)", () => {
+	it("main.ts imports and inits ContextService at startup (no loadActive)", async () => {
 		const src = await fs.readFile(path.join(import.meta.dir, "../src/main.ts"), "utf8");
 		expect(src).toContain("xcsh-context");
 		expect(src).toContain("ContextService.init");
-		expect(src).toContain("loadActive");
+		// loadActive is NOT called at startup — context is session-scoped and bootstrapped by createAgentSession.
+		expect(src).not.toContain("loadActive");
 	});
 
 	it("main.ts imports getXCSHConfigDir for context directory", async () => {

--- a/packages/coding-agent/test/sdk-context-integration.test.ts
+++ b/packages/coding-agent/test/sdk-context-integration.test.ts
@@ -183,13 +183,24 @@ describe("createAgentSession context tracking", () => {
 	});
 
 	it("scenario 4: session starts with NO context; mid-session activate emits both context_change and custom_message", async () => {
+		// Two contexts → bootstrap resolveAutoBind returns needsSelection (not bind),
+		// so the session genuinely starts with no active context.  This lets us verify
+		// that a mid-session activate() correctly emits both context_change (for replay)
+		// and custom_message (so the LLM gains context it never had at startup).
 		await ContextService.instance.createContext({
 			name: "prod",
 			apiUrl: "https://acme-corp.console.ves.volterra.io/api",
 			apiToken: "tok",
 			defaultNamespace: "production",
 		});
-		// No activate() yet — session launches with no active context.
+		await ContextService.instance.createContext({
+			name: "staging",
+			apiUrl: "https://acme-corp-staging.console.ves.volterra.io/api",
+			apiToken: "tok-staging",
+			defaultNamespace: "staging",
+		});
+		// No activate() yet — with ≥2 contexts the bootstrap does not auto-bind,
+		// so the session genuinely starts with no active context.
 
 		const { session } = await createAgentSession({
 			cwd,

--- a/packages/coding-agent/test/sdk-context-integration.test.ts
+++ b/packages/coding-agent/test/sdk-context-integration.test.ts
@@ -6,6 +6,7 @@ import { Snowflake } from "@f5-sales-demo/pi-utils";
 import { _resetSettingsForTest, Settings } from "@f5-sales-demo/xcsh/config/settings";
 import { createAgentSession } from "@f5-sales-demo/xcsh/sdk";
 import { ContextService } from "@f5-sales-demo/xcsh/services/xcsh-context";
+import { SessionManager } from "@f5-sales-demo/xcsh/session/session-manager";
 
 describe("createAgentSession context tracking", () => {
 	const tempDirs: string[] = [];
@@ -390,6 +391,92 @@ describe("createAgentSession context tracking", () => {
 
 		// sessionAManager should be untouched since its listener was unregistered on dispose.
 		expect(sessionAManager.getEntries()).toHaveLength(sessionAEntryCountAtDispose);
+	});
+
+	it("bootstrap: fresh session with exactly one context auto-binds it (not pre-activated)", async () => {
+		await ContextService.instance.createContext({
+			name: "solo",
+			apiUrl: "https://solo-corp.console.ves.volterra.io/api",
+			apiToken: "tok",
+			defaultNamespace: "default",
+		});
+		// NOTE: do NOT activate — the bootstrap must.
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			settings,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+		try {
+			expect(ContextService.instance.getStatus().activeContextName).toBe("solo");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("bootstrap: fresh session with multiple contexts and no folder link stays unbound", async () => {
+		for (const n of ["alpha", "beta"])
+			await ContextService.instance.createContext({
+				name: n,
+				apiUrl: `https://${n}.console.ves.volterra.io/api`,
+				apiToken: "tok",
+				defaultNamespace: "default",
+			});
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			settings,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+		try {
+			expect(ContextService.instance.getStatus().activeContextName ?? null).toBeNull();
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("bootstrap RESUME: re-activates the session's bound context, winning over ambiguous auto-bind", async () => {
+		// Two contexts → a fresh auto-bind would be ambiguous (unbound). But a resumed
+		// session whose log bound "beta" must re-activate beta.
+		for (const n of ["alpha", "beta"])
+			await ContextService.instance.createContext({
+				name: n,
+				apiUrl: `https://${n}.console.ves.volterra.io/api`,
+				apiToken: "tok",
+				defaultNamespace: "default",
+			});
+		const sm = SessionManager.create(cwd, SessionManager.getDefaultSessionDir(cwd, agentDir));
+		sm.appendContextChange("beta", "beta", "default"); // simulate a prior activation of beta
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			settings,
+			sessionManager: sm,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+		try {
+			expect(ContextService.instance.getStatus().activeContextName).toBe("beta");
+		} finally {
+			await session.dispose();
+		}
 	});
 
 	it("scenario 8: mid-session /context namespace emits context_change + custom_message", async () => {

--- a/packages/coding-agent/test/session-context-binding.test.ts
+++ b/packages/coding-agent/test/session-context-binding.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { type AutoBindResult, chooseSessionContext, resolveAutoBind } from "../src/services/session-context-binding";
+
+describe("resolveAutoBind — cli", () => {
+	test("folder-linked context wins", () => {
+		expect(resolveAutoBind({ kind: "cli", availableContexts: ["a", "b"], folderContext: "b" })).toEqual({
+			kind: "bind",
+			contextName: "b",
+		});
+	});
+	test("exactly one context auto-binds", () => {
+		expect(resolveAutoBind({ kind: "cli", availableContexts: ["only"], folderContext: null })).toEqual({
+			kind: "bind",
+			contextName: "only",
+		});
+	});
+	test("multiple contexts, no link → needsSelection", () => {
+		expect(resolveAutoBind({ kind: "cli", availableContexts: ["a", "b"], folderContext: null })).toEqual({
+			kind: "needsSelection",
+		});
+	});
+	test("no contexts → none", () => {
+		expect(resolveAutoBind({ kind: "cli", availableContexts: [], folderContext: null })).toEqual({ kind: "none" });
+	});
+});
+
+describe("resolveAutoBind — extension", () => {
+	test("matches a context by tenant key", () => {
+		expect(
+			resolveAutoBind({
+				kind: "extension",
+				availableContexts: ["acme", "globex"],
+				tenantKey: "globex|production",
+				contextTenantKeys: { acme: "acme|staging", globex: "globex|production" },
+			}),
+		).toEqual({ kind: "bind", contextName: "globex" });
+	});
+	test("no tenant match → needsSelection", () => {
+		expect(
+			resolveAutoBind({
+				kind: "extension",
+				availableContexts: ["acme"],
+				tenantKey: "globex|production",
+				contextTenantKeys: { acme: "acme|staging" },
+			}),
+		).toEqual({ kind: "needsSelection" });
+	});
+	test("no tenant key → none", () => {
+		expect(resolveAutoBind({ kind: "extension", availableContexts: ["acme"], tenantKey: null })).toEqual({
+			kind: "none",
+		});
+	});
+});
+
+describe("chooseSessionContext", () => {
+	const bindA: AutoBindResult = { kind: "bind", contextName: "a" };
+	test("resume: bound name wins over auto-bind", () => {
+		expect(chooseSessionContext("resumed", bindA)).toEqual({ activate: "resumed" });
+	});
+	test("new: falls back to auto-bind result", () => {
+		expect(chooseSessionContext(undefined, bindA)).toEqual({ activate: "a" });
+	});
+	test("new + needsSelection", () => {
+		expect(chooseSessionContext(undefined, { kind: "needsSelection" })).toEqual({ needsSelection: true });
+	});
+	test("new + none", () => {
+		expect(chooseSessionContext(undefined, { kind: "none" })).toEqual({ none: true });
+	});
+});

--- a/packages/coding-agent/test/session-context-foundation.int.test.ts
+++ b/packages/coding-agent/test/session-context-foundation.int.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { _resetSettingsForTest, Settings } from "../src/config/settings";
+import { chooseSessionContext, resolveAutoBind } from "../src/services/session-context-binding";
 import { ContextService } from "../src/services/xcsh-context";
 
 let cfg: string;
@@ -24,6 +26,64 @@ describe("foundation: no startup auto-load", () => {
 		writeContext("solo", "https://solo.console.ves.volterra.io");
 		const svc = ContextService.init(cfg);
 		// Under the clean break, initializing the service must NOT load a context.
+		expect(svc.getStatus().activeContextName ?? null).toBeNull();
+	});
+});
+
+describe("foundation: bind decisions over real contexts", () => {
+	beforeEach(async () => {
+		await Settings.init({ inMemory: true, cwd: cfg });
+	});
+	afterEach(() => {
+		_resetSettingsForTest();
+	});
+
+	test("fresh folder + one context → auto-binds and activates", async () => {
+		writeContext("solo", "https://solo.console.ves.volterra.io");
+		const svc = ContextService.init(cfg);
+		const available = (await svc.listContexts()).map(c => c.name);
+		const choice = chooseSessionContext(
+			undefined,
+			resolveAutoBind({ kind: "cli", availableContexts: available, folderContext: null }),
+		);
+		expect(choice).toEqual({ activate: "solo" });
+		if ("activate" in choice) await svc.activate(choice.activate);
+		expect(svc.getStatus().activeContextName).toBe("solo");
+	});
+
+	test("fresh folder + multiple contexts, no link → unbound (needsSelection)", async () => {
+		writeContext("a", "https://a.console.ves.volterra.io");
+		writeContext("b", "https://b.console.ves.volterra.io");
+		const svc = ContextService.init(cfg);
+		const available = (await svc.listContexts()).map(c => c.name);
+		const choice = chooseSessionContext(
+			undefined,
+			resolveAutoBind({ kind: "cli", availableContexts: available, folderContext: null }),
+		);
+		expect(choice).toEqual({ needsSelection: true });
+		expect(svc.getStatus().activeContextName ?? null).toBeNull();
+	});
+
+	test("resume: bound name re-activates regardless of count", async () => {
+		writeContext("a", "https://a.console.ves.volterra.io");
+		writeContext("b", "https://b.console.ves.volterra.io");
+		const svc = ContextService.init(cfg);
+		const choice = chooseSessionContext(
+			"b",
+			resolveAutoBind({ kind: "cli", availableContexts: ["a", "b"], folderContext: null }),
+		);
+		expect(choice).toEqual({ activate: "b" });
+		if ("activate" in choice) await svc.activate(choice.activate);
+		expect(svc.getStatus().activeContextName).toBe("b");
+	});
+
+	test("resume: deleted bound context → activate throws, handled as unbound", async () => {
+		const svc = ContextService.init(cfg); // no contexts on disk
+		const choice = chooseSessionContext("ghost", { kind: "none" });
+		expect(choice).toEqual({ activate: "ghost" });
+		if ("activate" in choice) {
+			await expect(svc.activate(choice.activate)).rejects.toThrow(); // caught + surfaced by the bootstrap
+		}
 		expect(svc.getStatus().activeContextName ?? null).toBeNull();
 	});
 });

--- a/packages/coding-agent/test/session-context-foundation.int.test.ts
+++ b/packages/coding-agent/test/session-context-foundation.int.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ContextService } from "../src/services/xcsh-context";
+
+let cfg: string;
+beforeEach(() => {
+	cfg = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-cfg-"));
+	fs.mkdirSync(path.join(cfg, "contexts"), { recursive: true });
+	delete process.env.XCSH_API_URL;
+});
+afterEach(() => fs.rmSync(cfg, { recursive: true, force: true }));
+
+function writeContext(name: string, apiUrl: string): void {
+	fs.writeFileSync(
+		path.join(cfg, "contexts", `${name}.json`),
+		JSON.stringify({ schemaVersion: 1, name, apiUrl, apiToken: "t", defaultNamespace: "default" }),
+	);
+}
+
+describe("foundation: no startup auto-load", () => {
+	test("fresh init with one context does NOT auto-activate", async () => {
+		writeContext("solo", "https://solo.console.ves.volterra.io");
+		const svc = ContextService.init(cfg);
+		// Under the clean break, initializing the service must NOT load a context.
+		expect(svc.getStatus().activeContextName ?? null).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/xcsh-context-service.test.ts
+++ b/packages/coding-agent/test/xcsh-context-service.test.ts
@@ -145,19 +145,19 @@ describe("ContextService", () => {
 			expect(bashEnv.XCSH_NAMESPACE).toBe(TEST_CONTEXT.defaultNamespace);
 		});
 
-		it("auto-activates the single context when no active_context exists", async () => {
+		it("returns null when no active_context file exists (single-context auto-activate removed)", async () => {
+			// FR-104 removed: loadActive no longer auto-activates a lone context.
+			// Session bootstrap (createAgentSession) handles smart auto-binding instead.
 			writeContext(xcshContextsDir, TEST_CONTEXT);
 			// No active_context file
 
 			const service = ContextService.init(xcshConfigDir);
 			const result = await service.loadActive();
 
-			expect(result).not.toBeNull();
-			expect(result?.name).toBe(TEST_CONTEXT.name);
-
-			// Should have written active_context
-			const written = fs.readFileSync(path.join(xcshConfigDir, "active_context"), "utf-8");
-			expect(written).toBe(TEST_CONTEXT.name);
+			// Must return null — no active_context pointer means no global default.
+			expect(result).toBeNull();
+			// active_context must NOT have been written.
+			expect(fs.existsSync(path.join(xcshConfigDir, "active_context"))).toBe(false);
 		});
 
 		it("does not auto-activate when multiple contexts exist", async () => {

--- a/packages/coding-agent/test/xcsh-context-service.test.ts
+++ b/packages/coding-agent/test/xcsh-context-service.test.ts
@@ -306,7 +306,7 @@ describe("ContextService", () => {
 	});
 
 	describe("activate", () => {
-		it("reads context, writes active_context, and updates settings", async () => {
+		it("updates in-memory state and settings without writing active_context (session log is source of truth)", async () => {
 			writeContext(xcshContextsDir, TEST_CONTEXT);
 			writeContext(xcshContextsDir, TEST_CONTEXT_2);
 			writeActiveContext(xcshConfigDir, TEST_CONTEXT.name);
@@ -317,9 +317,12 @@ describe("ContextService", () => {
 			const result = await service.activate(TEST_CONTEXT_2.name);
 			expect(result.name).toBe(TEST_CONTEXT_2.name);
 
-			// active_context file should be updated
-			const written = fs.readFileSync(path.join(xcshConfigDir, "active_context"), "utf-8");
-			expect(written).toBe(TEST_CONTEXT_2.name);
+			// active_context file must NOT be updated — session log is now the sole binding record
+			const onDisk = fs.readFileSync(path.join(xcshConfigDir, "active_context"), "utf-8");
+			expect(onDisk).toBe(TEST_CONTEXT.name);
+
+			// in-memory state reflects the new context
+			expect(service.getStatus().activeContextName).toBe(TEST_CONTEXT_2.name);
 
 			// settings should reflect new context
 			const bashEnv = Settings.instance.get("bash.environment") as Record<string, string>;

--- a/packages/coding-agent/test/xcsh-integration.test.ts
+++ b/packages/coding-agent/test/xcsh-integration.test.ts
@@ -193,7 +193,9 @@ describe("XCSH authentication end-to-end integration", () => {
 		expect(bashResult.output.trim()).toBe("works");
 	});
 
-	it("auto-activates single context when no active_context file exists", async () => {
+	it("returns null when no active_context file exists (single-context auto-activate removed)", async () => {
+		// FR-104 removed: loadActive no longer auto-activates a lone context.
+		// Session bootstrap (createAgentSession) handles smart auto-binding instead.
 		// Setup: one context, no active_context
 		fs.mkdirSync(xcshContextsDir, { recursive: true });
 		fs.writeFileSync(
@@ -211,19 +213,17 @@ describe("XCSH authentication end-to-end integration", () => {
 		const service = ContextService.init(xcshConfigDir);
 		const result = await service.loadActive();
 
-		expect(result).not.toBeNull();
-		expect(result?.name).toBe("production");
+		// Must return null — no active_context pointer means no global default.
+		expect(result).toBeNull();
+		// active_context must NOT have been written.
+		expect(fs.existsSync(path.join(xcshConfigDir, "active_context"))).toBe(false);
 
-		// Should have created active_context file
-		const activeContextContent = fs.readFileSync(path.join(xcshConfigDir, "active_context"), "utf-8");
-		expect(activeContextContent).toBe("production");
-
-		// Credentials should be in bash environment
-		const bashResult = await executeBash("echo $XCSH_API_URL", {
+		// Bash still works normally — no credentials injected since nothing activated.
+		const bashResult = await executeBash("echo works", {
 			cwd: projectDir,
 			timeout: 5000,
 		});
-		expect(bashResult.output.trim()).toBe(TEST_URL);
+		expect(bashResult.output.trim()).toBe("works");
 	});
 
 	it("T-005: active_context references missing JSON — no credentials injected", async () => {
@@ -250,7 +250,10 @@ describe("XCSH authentication end-to-end integration", () => {
 	});
 
 	it("T-014: active_context file is plain text with no trailing newline", async () => {
-		// Setup: single context triggers auto-activation
+		// Session-scoped change: auto-activation is removed; active_context is written by
+		// /context activate (xcsh-context-command). This test validates that a correctly
+		// written active_context file (no newline) is read back exactly by loadActive.
+		// The format contract (no trailing newline) is still enforced — we just set it up explicitly.
 		fs.mkdirSync(xcshContextsDir, { recursive: true });
 		fs.writeFileSync(
 			path.join(xcshContextsDir, "production.json"),
@@ -262,11 +265,18 @@ describe("XCSH authentication end-to-end integration", () => {
 			}),
 			{ mode: 0o600 },
 		);
+		// Write active_context without newline (as /context activate would do via writeActiveContextName)
+		fs.mkdirSync(xcshConfigDir, { recursive: true });
+		fs.writeFileSync(path.join(xcshConfigDir, "active_context"), "production", { mode: 0o644 });
 
 		const service = ContextService.init(xcshConfigDir);
-		await service.loadActive(); // auto-activates
+		const result = await service.loadActive();
 
-		// Read raw bytes — no newline allowed (VS Code extension compatibility)
+		// Loads successfully from the explicit active_context pointer.
+		expect(result).not.toBeNull();
+		expect(result?.name).toBe("production");
+
+		// Verify the file itself has no trailing newline (VS Code extension compatibility).
 		const raw = fs.readFileSync(path.join(xcshConfigDir, "active_context"));
 		const text = raw.toString("utf-8");
 		expect(text).toBe("production");


### PR DESCRIPTION
Makes the F5 XC context a property of the **session** instead of a process-global loaded at startup.

## What changed (clean break — pre-release, no compat/migration)
- Startup no longer auto-loads a context (`main.ts` keeps `ContextService.init`, drops `loadActive`). FR-104 single-context auto-activate removed.
- `/context activate` is session-scoped: loads the context AND records it in the session's `context_change` log (sole binding record).
- `activate()` no longer writes the global `active_context` pointer.
- New `createAgentSession` bootstrap: **resume** re-activates the context from the session log (`buildSessionContext().activeContextName`); **new** session smart-auto-binds (folder-local / single context, else ask). Auth validated **non-blocking**. `XCSH_API_URL` env-override skips it.
- New pure `services/session-context-binding.ts` (`resolveAutoBind`/`chooseSessionContext`) — CLI wired+tested; extension path present but unwired (deferred).

## Verification
- `bunx tsc --noEmit` clean; per-task + whole-branch review (opus: ready to merge).
- Unit + integration + 11 `createAgentSession` scenarios incl. bootstrap auto-bind and the **core resume promise** (resumed session re-activates its bound context, winning over ambiguous auto-bind).
- One active context per process; concurrent per-session isolation + extension/daemon auto-provisioning are deferred follow-ups this foundation is built for.

## Deferred Minor follow-ups
- `renameContext()` vestigial `active_context` write; `loadActive()` dead global-pointer reader — cleanup, not correctness.

Closes #1832

🤖 Generated with [Claude Code](https://claude.com/claude-code)