### PR TITLE
Multi-session Phase 3: bridge port auto-selection

### DIFF
--- a/packages/coding-agent/scripts/generate-extension-capabilities.ts
+++ b/packages/coding-agent/scripts/generate-extension-capabilities.ts
@@ -54,6 +54,7 @@ const output = [
 	"export interface ExtensionCapabilities {",
 	"\treadonly version: string;",
 	"\treadonly contractVersion: string;",
+	"\treadonly multiPortDiscovery?: boolean;",
 	"\treadonly protocol: string;",
 	"\treadonly tools: readonly ExtensionToolDef[];",
 	"\treadonly features: Record<string, unknown>;",

--- a/packages/coding-agent/src/browser/capabilities.generated.ts
+++ b/packages/coding-agent/src/browser/capabilities.generated.ts
@@ -18,6 +18,7 @@ export interface ExtensionToolDef {
 export interface ExtensionCapabilities {
 	readonly version: string;
 	readonly contractVersion: string;
+	readonly multiPortDiscovery?: boolean;
 	readonly protocol: string;
 	readonly tools: readonly ExtensionToolDef[];
 	readonly features: Record<string, unknown>;

--- a/packages/coding-agent/src/browser/capabilities.generated.ts
+++ b/packages/coding-agent/src/browser/capabilities.generated.ts
@@ -25,7 +25,8 @@ export interface ExtensionCapabilities {
 
 export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 	"version": "0.1.0",
-	"contractVersion": "1.4.0",
+	"contractVersion": "1.5.0",
+	"multiPortDiscovery": true,
 	"protocol": "tool_request/result",
 	"tools": [
 		{
@@ -614,6 +615,16 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 			"flags": {}
 		},
 		{
+			"name": "diag_bridges",
+			"summary": "List discovered xcsh bridges (port, tenant, env, sessionId, lastSeen) for multi-session diagnostics.",
+			"category": "read",
+			"params": {
+				"type": "object",
+				"properties": {}
+			},
+			"flags": {}
+		},
+		{
 			"name": "capture_login_flow",
 			"summary": "Diagnostic: captured login redirect chain annotated with tenant/env (Phase 0b).",
 			"category": "read",
@@ -813,6 +824,6 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 	}
 };
 
-export const EXTENSION_CONTRACT_VERSION = "1.4.0";
+export const EXTENSION_CONTRACT_VERSION = "1.5.0";
 
-export const EXTENSION_TOOL_NAMES: readonly string[] = ["ping","capabilities","reload","debug_exec","detach","set_bridge_port","navigate","login","scroll_to","resize_window","tabs_list","tabs_create","tabs_close","click","click_element","click_xy","type_text","form_input","key_press","select_option","label_select","file_upload","read_ax","get_page_text","query_dom","find","wait_for","assert_text","screenshot","read_console","read_network","diag_suspension","capture_login_flow","wait_for_api_response","get_page_context","javascript_tool","browser_batch","set_explain_mode","annotate"];
+export const EXTENSION_TOOL_NAMES: readonly string[] = ["ping","capabilities","reload","debug_exec","detach","set_bridge_port","navigate","login","scroll_to","resize_window","tabs_list","tabs_create","tabs_close","click","click_element","click_xy","type_text","form_input","key_press","select_option","label_select","file_upload","read_ax","get_page_text","query_dom","find","wait_for","assert_text","screenshot","read_console","read_network","diag_suspension","diag_bridges","capture_login_flow","wait_for_api_response","get_page_context","javascript_tool","browser_batch","set_explain_mode","annotate"];

--- a/packages/coding-agent/src/browser/capabilities.json
+++ b/packages/coding-agent/src/browser/capabilities.json
@@ -1,6 +1,7 @@
 {
   "version": "0.1.0",
-  "contractVersion": "1.4.0",
+  "contractVersion": "1.5.0",
+  "multiPortDiscovery": true,
   "protocol": "tool_request/result",
   "tools": [
     {
@@ -532,6 +533,16 @@
     {
       "name": "diag_suspension",
       "summary": "Diagnostic: SW-lifecycle event buffer + suspension summary (Phase 0a).",
+      "category": "read",
+      "params": {
+        "type": "object",
+        "properties": {}
+      },
+      "flags": {}
+    },
+    {
+      "name": "diag_bridges",
+      "summary": "List discovered xcsh bridges (port, tenant, env, sessionId, lastSeen) for multi-session diagnostics.",
       "category": "read",
       "params": {
         "type": "object",

--- a/packages/coding-agent/src/browser/chat-conformance.json
+++ b/packages/coding-agent/src/browser/chat-conformance.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": "1.4.0",
+  "contractVersion": "1.5.0",
   "schemas": {
     "chat_request": {
       "type": "object",

--- a/packages/coding-agent/src/browser/extension-bridge.ts
+++ b/packages/coding-agent/src/browser/extension-bridge.ts
@@ -250,10 +250,12 @@ export class BridgeServer {
 		} else if (msg.type === "hello") {
 			// Identity handshake: tell the extension which tenant this process serves.
 			const info = this.#sessionInfo?.() ?? { tenant: null, env: null, apiUrl: null };
+			const { EXTENSION_CONTRACT_VERSION } = require("./capabilities.generated");
 			ws.send(
 				JSON.stringify({
 					type: "hello_ack",
 					sessionId: this.#sessionId,
+					contractVersion: EXTENSION_CONTRACT_VERSION,
 					tenant: info.tenant,
 					env: info.env,
 					apiUrl: info.apiUrl,

--- a/packages/coding-agent/src/browser/extension-bridge.ts
+++ b/packages/coding-agent/src/browser/extension-bridge.ts
@@ -178,56 +178,58 @@ export class BridgeServer {
 		this.#resolveClient(channelId)?.send(JSON.stringify(payload));
 	}
 
-	/** Bind the WebSocket server to a loopback port. Called by {@link startBridgeServer}. */
-	listen(port: number, opts?: { skipOriginCheck?: boolean }): void {
-		this.#server = Bun.serve({
-			port,
-			hostname: "127.0.0.1",
-			fetch: (req, server) => {
-				// Validate the Origin header: only the xcsh Chrome extension may connect.
-				// This restores the access-control guarantee that the Unix socket's 0o600
-				// permissions previously provided.
-				if (!opts?.skipOriginCheck) {
-					const origin = req.headers.get("origin") ?? "";
-					const { EXTENSION_ID } = require("../cli/chrome-cli");
-					if (origin !== `chrome-extension://${EXTENSION_ID}`) {
-						return new Response("Forbidden", { status: 403 });
+	#onOpen(ws: ServerWebSocket<undefined>): void {
+		// Assign a channel ID to each connection. For backwards compat (single
+		// extension), the first connection gets "default". Additional connections
+		// get "ch-1", "ch-2", etc. — supporting multi-tab parallelism.
+		const channelId = this.#clients.size === 0 ? "default" : `ch-${++this.#nextChannelIndex}`;
+		(ws as unknown as { channelId: string }).channelId = channelId;
+		this.#clients.set(channelId, ws);
+		// Start a heartbeat ping to keep the MV3 service worker alive.
+		// Chrome suspends idle SWs after ~30s; a ping every 15s prevents that.
+		if (!this.#heartbeat) {
+			this.#heartbeat = setInterval(() => {
+				for (const c of this.#clients.values()) {
+					try {
+						c.send(JSON.stringify({ type: "ping" }));
+					} catch {
+						/* client may have dropped */
 					}
 				}
-				if (server.upgrade(req)) return undefined;
-				return new Response("xcsh bridge: WebSocket only", { status: 426 });
-			},
-			websocket: {
-				open: ws => {
-					// Assign a channel ID to each connection. For backwards compat (single
-					// extension), the first connection gets "default". Additional connections
-					// get "ch-1", "ch-2", etc. — supporting multi-tab parallelism.
-					const channelId = this.#clients.size === 0 ? "default" : `ch-${++this.#nextChannelIndex}`;
-					(ws as unknown as { channelId: string }).channelId = channelId;
-					this.#clients.set(channelId, ws);
-					// Start a heartbeat ping to keep the MV3 service worker alive.
-					// Chrome suspends idle SWs after ~30s; a ping every 15s prevents that.
-					if (!this.#heartbeat) {
-						this.#heartbeat = setInterval(() => {
-							for (const c of this.#clients.values()) {
-								try {
-									c.send(JSON.stringify({ type: "ping" }));
-								} catch {
-									/* client may have dropped */
-								}
-							}
-						}, 15_000);
+			}, 15_000);
+		}
+		for (const cb of this.#onConnected) cb();
+	}
+
+	/** Try to bind the loopback WS server to `port`. Returns false on EADDRINUSE
+	 * (so the caller can try the next candidate); rethrows any other error. */
+	listen(port: number, opts?: { skipOriginCheck?: boolean }): boolean {
+		try {
+			this.#server = Bun.serve({
+				port,
+				hostname: "127.0.0.1",
+				fetch: (req, server) => {
+					if (!opts?.skipOriginCheck) {
+						const origin = req.headers.get("origin") ?? "";
+						const { EXTENSION_ID } = require("../cli/chrome-cli");
+						if (origin !== `chrome-extension://${EXTENSION_ID}`) {
+							return new Response("Forbidden", { status: 403 });
+						}
 					}
-					for (const cb of this.#onConnected) cb();
+					if (server.upgrade(req)) return undefined;
+					return new Response("xcsh bridge: WebSocket only", { status: 426 });
 				},
-				message: (ws, message) => {
-					this.#handleMessage(ws, message);
+				websocket: {
+					open: ws => this.#onOpen(ws),
+					message: (ws, message) => this.#handleMessage(ws, message),
+					close: ws => this.#onClose(ws),
 				},
-				close: ws => {
-					this.#onClose(ws);
-				},
-			},
-		});
+			});
+			return true;
+		} catch (e) {
+			if (e instanceof Error && /EADDRINUSE|address already in use|in use/i.test(e.message)) return false;
+			throw e;
+		}
 	}
 
 	#handleMessage(ws: ServerWebSocket<undefined>, message: string | Buffer): void {
@@ -312,12 +314,23 @@ export class BridgeServer {
 }
 
 /**
- * Start the {@link BridgeServer} on the resolved loopback port (explicit arg,
- * then `XCSH_BRIDGE_PORT`, then {@link DEFAULT_PORT}). The WebSocket transport
+ * Start the {@link BridgeServer} on the resolved loopback port. If a port is
+ * forced (explicit arg or `XCSH_BRIDGE_PORT`) it must be free — throws loudly
+ * if taken. Otherwise, auto-selects the lowest free port in the discovery range
+ * ({@link PORT_RANGE_START}–{@link PORT_RANGE_END}). The WebSocket transport
  * needs no filesystem setup — Chrome connects directly to `ws://127.0.0.1:<port>`.
  */
 export async function startBridgeServer(port?: number, opts?: { skipOriginCheck?: boolean }): Promise<BridgeServer> {
 	const server = new BridgeServer();
-	server.listen(resolvePort(port), opts);
-	return server;
+	const forced = resolveForcedPort(port);
+	if (forced !== null) {
+		if (!server.listen(forced, opts)) {
+			throw new Error(`XCSH_BRIDGE_PORT ${forced} is already in use — free it or pick another port`);
+		}
+		return server;
+	}
+	for (const candidate of portCandidates()) {
+		if (server.listen(candidate, opts)) return server;
+	}
+	throw new Error(`no free xcsh bridge port in ${PORT_RANGE_START}-${PORT_RANGE_END} — is another app on the range?`);
 }

--- a/packages/coding-agent/src/browser/extension-bridge.ts
+++ b/packages/coding-agent/src/browser/extension-bridge.ts
@@ -67,6 +67,25 @@ export function resolvePort(port?: number): number {
 	return DEFAULT_PORT;
 }
 
+/** Inclusive loopback discovery range for auto-selected bridge ports. */
+export const PORT_RANGE_START = 19222;
+export const PORT_RANGE_END = 19241;
+
+/** Every port in the discovery range, lowest first. */
+export function portCandidates(): number[] {
+	const out: number[] = [];
+	for (let p = PORT_RANGE_START; p <= PORT_RANGE_END; p++) out.push(p);
+	return out;
+}
+
+/** The explicitly forced port (arg → XCSH_BRIDGE_PORT), or null to auto-select. */
+export function resolveForcedPort(port?: number): number | null {
+	if (typeof port === "number" && Number.isFinite(port) && port > 0) return port;
+	const env = Number(process.env.XCSH_BRIDGE_PORT);
+	if (Number.isFinite(env) && env > 0) return env;
+	return null;
+}
+
 /**
  * Loopback WebSocket server bridging xcsh to the Chrome extension. Speaks JSON
  * over WS frames: requests `{type:"tool_request",...}`, replies

--- a/packages/coding-agent/src/cli/chrome-cli.ts
+++ b/packages/coding-agent/src/cli/chrome-cli.ts
@@ -7,7 +7,7 @@
  */
 
 import { acquirePage, type BrowserProviderStatus, CdpBrowserProvider } from "../browser";
-import { resolvePort } from "../browser/extension-bridge";
+import { PORT_RANGE_END, PORT_RANGE_START, resolveForcedPort } from "../browser/extension-bridge";
 
 type Settings = { get(key: string): unknown };
 
@@ -43,12 +43,17 @@ export async function runChromeCommand(action: ChromeAction, settings: Settings)
 	if (action === "status") return renderStatus(await provider.status());
 	if (action === "setup") {
 		// The extension connects directly over a loopback WebSocket — no native-messaging
-		// host manifest to install. Report the port so the user can point the extension at it.
-		const port = resolvePort();
+		// host manifest to install. A forced port is reported exactly; otherwise xcsh
+		// auto-selects the lowest free port in the discovery range at launch.
+		const forced = resolveForcedPort();
+		const where =
+			forced !== null
+				? `ws://127.0.0.1:${forced} (forced via XCSH_BRIDGE_PORT)`
+				: `the lowest free port in ${PORT_RANGE_START}-${PORT_RANGE_END} (printed in the xcsh startup banner)`;
 		return (
-			`The xcsh Chrome extension connects directly to xcsh over a loopback WebSocket on ` +
-			`ws://127.0.0.1:${port} (override with XCSH_BRIDGE_PORT).\n` +
-			`Install/keep the xcsh Chrome extension from the Web Store, then it can drive your real Chrome:\n  ${WEB_STORE_URL}`
+			`The xcsh Chrome extension connects directly to xcsh over a loopback WebSocket on ${where}.\n` +
+			`The extension scans that range and links each tenant's xcsh automatically.\n` +
+			`Install/keep the xcsh Chrome extension from the Web Store:\n  ${WEB_STORE_URL}`
 		);
 	}
 	// relaunch: self-consented rung 3 — force allowRelaunch regardless of the setting.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -816,6 +816,7 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 	let sessionReady = false;
 	if (process.env.XCSH_BROWSER_PROVIDER?.toLowerCase() === "extension") {
 		bridgeServer = await startBridgeServer();
+		console.error(`[xcsh] extension bridge listening on ws://127.0.0.1:${bridgeServer.port}`);
 		// Make the bridge globally available so ALL selectProvider() calls reuse it
 		// (prevents starting a conflicting second bridge on the same port).
 		setSharedBridgeServer(bridgeServer);

--- a/packages/coding-agent/test/browser/extension-bridge.test.ts
+++ b/packages/coding-agent/test/browser/extension-bridge.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "bun:test";
-import { PendingRequests } from "@f5-sales-demo/xcsh/browser/extension-bridge";
+import { describe, expect, it, test } from "bun:test";
+import {
+	PendingRequests,
+	PORT_RANGE_END,
+	PORT_RANGE_START,
+	portCandidates,
+	resolveForcedPort,
+} from "@f5-sales-demo/xcsh/browser/extension-bridge";
 
 describe("PendingRequests", () => {
 	it("resolves the matching id and ignores unknown ids", async () => {
@@ -24,5 +30,39 @@ describe("PendingRequests", () => {
 		const { promise } = p.create(1000);
 		p.rejectAll(new Error("disconnected"));
 		await expect(promise).rejects.toThrow(/disconnected/);
+	});
+});
+
+describe("port selection helpers", () => {
+	test("portCandidates is the full inclusive range", () => {
+		const c = portCandidates();
+		expect(c[0]).toBe(PORT_RANGE_START);
+		expect(c.at(-1)).toBe(PORT_RANGE_END);
+		expect(c.length).toBe(PORT_RANGE_END - PORT_RANGE_START + 1);
+	});
+
+	test("resolveForcedPort: explicit arg wins", () => {
+		expect(resolveForcedPort(20000)).toBe(20000);
+	});
+
+	test("resolveForcedPort: env when no arg", () => {
+		const prev = process.env.XCSH_BRIDGE_PORT;
+		process.env.XCSH_BRIDGE_PORT = "19230";
+		try {
+			expect(resolveForcedPort()).toBe(19230);
+		} finally {
+			if (prev === undefined) delete process.env.XCSH_BRIDGE_PORT;
+			else process.env.XCSH_BRIDGE_PORT = prev;
+		}
+	});
+
+	test("resolveForcedPort: null when neither set", () => {
+		const prev = process.env.XCSH_BRIDGE_PORT;
+		delete process.env.XCSH_BRIDGE_PORT;
+		try {
+			expect(resolveForcedPort()).toBeNull();
+		} finally {
+			if (prev !== undefined) process.env.XCSH_BRIDGE_PORT = prev;
+		}
 	});
 });

--- a/packages/coding-agent/test/browser/extension-bridge.test.ts
+++ b/packages/coding-agent/test/browser/extension-bridge.test.ts
@@ -66,3 +66,29 @@ describe("port selection helpers", () => {
 		}
 	});
 });
+
+import { startBridgeServer } from "../../src/browser/extension-bridge";
+
+describe("auto-select bind", () => {
+	test("two servers land on different ports in range", async () => {
+		const a = await startBridgeServer(undefined, { skipOriginCheck: true });
+		const b = await startBridgeServer(undefined, { skipOriginCheck: true });
+		try {
+			expect(a.port).toBeGreaterThanOrEqual(PORT_RANGE_START);
+			expect(b.port).toBeGreaterThanOrEqual(PORT_RANGE_START);
+			expect(a.port).not.toBe(b.port);
+		} finally {
+			await a.close();
+			await b.close();
+		}
+	});
+
+	test("forced port that is taken fails loud", async () => {
+		const a = await startBridgeServer(undefined, { skipOriginCheck: true });
+		try {
+			await expect(startBridgeServer(a.port, { skipOriginCheck: true })).rejects.toThrow();
+		} finally {
+			await a.close();
+		}
+	});
+});

--- a/packages/coding-agent/test/browser/extension-contract.test.ts
+++ b/packages/coding-agent/test/browser/extension-contract.test.ts
@@ -75,7 +75,13 @@ describe("extension contract drift guards", () => {
 	// forces it to be wrapped here or acknowledged in this list.
 	// query_dom is driven directly over the bridge (CDP fast-path used by the sweep's
 	// resolver scripts), not via the typed ExtensionPage client.
-	const KNOWN_UNWRAPPED = new Set(["wait_for_api_response", "query_dom", "diag_suspension", "capture_login_flow"]);
+	const KNOWN_UNWRAPPED = new Set([
+		"wait_for_api_response",
+		"query_dom",
+		"diag_suspension",
+		"capture_login_flow",
+		"diag_bridges",
+	]);
 
 	it("every tool the bridge client requests exists in the contract", () => {
 		const unknown = extractRequestedTools(providerSource).filter(t => !EXTENSION_TOOL_NAMES.includes(t));


### PR DESCRIPTION
Transport layer for multi-tenant session isolation: xcsh auto-selects a free loopback bridge port so multiple tenant processes coexist.

## What changed (additive MINOR contract 1.4.0 → 1.5.0)
- `startBridgeServer` auto-picks the lowest free port in `19222–19241` (`EADDRINUSE` retry); a forced `XCSH_BRIDGE_PORT` still wins and fails loud if taken; banner prints the bound port.
- `hello_ack` echoes `contractVersion`; capabilities regenerated to 1.5.0 (+`multiPortDiscovery` flag, `diag_bridges` tool).

## Verification
- `bun test` + `bunx tsc --noEmit` clean; per-task + whole-branch review (ready to merge).
- Live UAT (real Chrome + staging): auto-port selection incl. EADDRINUSE-skip, per-tenant `hello_ack`, contract echo — all confirmed.

## Note
Pairs with the extension PR (contract 1.5.0). This is the transport the deferred session-scoped auto-provisioning daemon builds on; the original "one process per tenant, manual launch" UX is superseded by the session-scoped-context direction (foundation in #1833).

Closes #1831

🤖 Generated with [Claude Code](https://claude.com/claude-code)