### PR TITLE
feat(coding-agent): report agent state to the herdr multiplexer

### DIFF
--- a/packages/coding-agent/src/browser/extension-page-actions.ts
+++ b/packages/coding-agent/src/browser/extension-page-actions.ts
@@ -501,7 +501,6 @@ export class ExtensionPageActions implements PageActions {
 		throw new Error(`waitFor "${selector}" timed out after ${ms}ms`);
 	}
 
-	// biome-ignore lint/suspicious/useAwait: signature is async (PageActions contract)
 	async screenshot(_file: string): Promise<void> {
 		// Intentionally a no-op for the extension provider. CDP captureScreenshot
 		// transiently FREEZES the MV3 service worker; in observable mode the runner

--- a/packages/coding-agent/src/extensibility/extensions/bundled/herdr-reporter.ts
+++ b/packages/coding-agent/src/extensibility/extensions/bundled/herdr-reporter.ts
@@ -1,0 +1,102 @@
+import type { ExtensionAPI } from "@f5-sales-demo/xcsh";
+
+/**
+ * herdr integration (bundled, default-on).
+ *
+ * Reports xcsh's live agent state to the herdr terminal multiplexer over its
+ * socket API so an xcsh pane shows up as a first-class "xcsh" assistant with an
+ * idle / working / blocked indicator.
+ *
+ * xcsh is a fork of pi; a user may have both installed, so this reporter always
+ * identifies itself as "xcsh" (never "pi") and claims pane authority via
+ * `--source xcsh` so herdr's passive pi-detection heuristics cannot mislabel the
+ * pane.
+ *
+ * The extension is completely inert unless it is running inside a herdr pane
+ * (detected via the `HERDR_PANE_ID` environment variable herdr injects), so it
+ * has zero effect for users who do not run xcsh under herdr.
+ */
+
+const HERDR_AGENT_LABEL = "xcsh";
+
+export default function herdrReporter(pi: ExtensionAPI): void {
+	const paneId = process.env.HERDR_PANE_ID;
+	if (!paneId) {
+		// Not running under herdr — do not register anything.
+		return;
+	}
+
+	let seq = 0;
+	// Tracks whether an interactive prompt is currently awaiting the user, so an
+	// agent_end that fires while a prompt is open is reported as blocked, not idle.
+	let promptOpen = false;
+
+	pi.setLabel(HERDR_AGENT_LABEL);
+
+	// Fire-and-forget: a missing or failing herdr CLI must never disturb the agent.
+	const runHerdr = (args: string[]): void => {
+		pi.exec("herdr", args).catch((err: unknown) => {
+			pi.logger.debug("herdr report failed", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		});
+	};
+
+	const report = (state: "idle" | "working" | "blocked"): void => {
+		runHerdr([
+			"pane",
+			"report-agent",
+			paneId,
+			"--source",
+			HERDR_AGENT_LABEL,
+			"--agent",
+			HERDR_AGENT_LABEL,
+			"--state",
+			state,
+			"--seq",
+			String(seq++),
+		]);
+	};
+
+	// Announce presence as soon as the session is initialized.
+	pi.on("session_start", () => {
+		report("idle");
+	});
+
+	// Busy while the agent loop is streaming a response.
+	pi.on("agent_start", () => {
+		report("working");
+	});
+
+	// Back to idle when the loop ends — unless we are waiting on a user prompt.
+	pi.on("agent_end", () => {
+		report(promptOpen ? "blocked" : "idle");
+	});
+
+	// An interactive prompt (permission gate, ask tool, confirm/input) is
+	// awaiting the user: that is herdr's "needs attention" (blocked) state.
+	pi.on("user_prompt_start", () => {
+		promptOpen = true;
+		report("blocked");
+	});
+
+	pi.on("user_prompt_end", (_event, ctx) => {
+		promptOpen = false;
+		report(ctx.isIdle() ? "idle" : "working");
+	});
+
+	// Relinquish pane authority so herdr stops showing xcsh once we exit.
+	pi.on("session_shutdown", () => {
+		runHerdr([
+			"pane",
+			"release-agent",
+			paneId,
+			"--source",
+			HERDR_AGENT_LABEL,
+			"--agent",
+			HERDR_AGENT_LABEL,
+			"--seq",
+			String(seq++),
+		]);
+	});
+}

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -20,6 +20,7 @@ import type { CustomMessage } from "../../session/messages";
 import { EventBus } from "../../utils/event-bus";
 import { getAllPluginExtensionPaths } from "../plugins/loader";
 import { resolvePath } from "../utils";
+import herdrReporter from "./bundled/herdr-reporter";
 import type {
 	Extension,
 	ExtensionAPI,
@@ -480,6 +481,37 @@ async function discoverExtensionsInDir(dir: string): Promise<string[]> {
 /**
  * Discover and load extensions from standard locations.
  */
+/** Extensions bundled with xcsh and loaded by default (before user extensions). */
+const BUNDLED_EXTENSIONS: ReadonlyArray<{ name: string; factory: ExtensionFactory }> = [
+	{ name: "herdr-reporter", factory: herdrReporter },
+];
+
+/**
+ * Load the extensions that ship with xcsh. They share the runtime and event bus
+ * of the discovered user extensions and are prepended so user extensions keep the
+ * ability to override. A bundled extension that throws is recorded as an error
+ * but never aborts the overall load.
+ */
+async function loadBundledExtensions(
+	result: LoadExtensionsResult,
+	cwd: string,
+	eventBus: EventBus,
+	isDisabled: (name: string) => boolean,
+): Promise<void> {
+	for (const { name, factory } of BUNDLED_EXTENSIONS) {
+		if (isDisabled(name)) continue;
+		try {
+			const extension = await loadExtensionFromFactory(factory, cwd, eventBus, result.runtime, `bundled:${name}`);
+			result.extensions.unshift(extension);
+		} catch (err) {
+			result.errors.push({
+				path: `bundled:${name}`,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+}
+
 export async function discoverAndLoadExtensions(
 	configuredPaths: string[],
 	cwd: string,
@@ -568,5 +600,8 @@ export async function discoverAndLoadExtensions(
 		addPath(resolved);
 	}
 
-	return loadExtensions(allPaths, cwd, eventBus);
+	const resolvedEventBus = eventBus ?? new EventBus();
+	const result = await loadExtensions(allPaths, cwd, resolvedEventBus);
+	await loadBundledExtensions(result, cwd, resolvedEventBus, isDisabledName);
+	return result;
 }

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -541,6 +541,26 @@ export interface MessageEndEvent {
 	message: AgentMessage;
 }
 
+/** Kind of interactive prompt currently awaiting the user. */
+export type UserPromptKind = "select" | "confirm" | "input";
+
+/**
+ * Fired when an interactive prompt (permission gate, `ask` tool, confirm/input
+ * dialog) is shown and is awaiting the user. Signals a "blocked / needs
+ * attention" state that is otherwise not observable from the agent event stream,
+ * since the session stays `isStreaming` while a prompt is open.
+ */
+export interface UserPromptStartEvent {
+	type: "user_prompt_start";
+	kind: UserPromptKind;
+}
+
+/** Fired when an interactive prompt resolves (answered, cancelled, or timed out). */
+export interface UserPromptEndEvent {
+	type: "user_prompt_end";
+	kind: UserPromptKind;
+}
+
 /** Fired when a tool starts executing */
 export interface ToolExecutionStartEvent {
 	type: "tool_execution_start";
@@ -817,6 +837,8 @@ export type ExtensionEvent =
 	| MessageStartEvent
 	| MessageUpdateEvent
 	| MessageEndEvent
+	| UserPromptStartEvent
+	| UserPromptEndEvent
 	| ToolExecutionStartEvent
 	| ToolExecutionUpdateEvent
 	| ToolExecutionEndEvent
@@ -1011,6 +1033,8 @@ export interface ExtensionAPI {
 	on(event: "message_start", handler: ExtensionHandler<MessageStartEvent>): void;
 	on(event: "message_update", handler: ExtensionHandler<MessageUpdateEvent>): void;
 	on(event: "message_end", handler: ExtensionHandler<MessageEndEvent>): void;
+	on(event: "user_prompt_start", handler: ExtensionHandler<UserPromptStartEvent>): void;
+	on(event: "user_prompt_end", handler: ExtensionHandler<UserPromptEndEvent>): void;
 	on(event: "tool_execution_start", handler: ExtensionHandler<ToolExecutionStartEvent>): void;
 	on(event: "tool_execution_update", handler: ExtensionHandler<ToolExecutionUpdateEvent>): void;
 	on(event: "tool_execution_end", handler: ExtensionHandler<ToolExecutionEndEvent>): void;

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -13,6 +13,7 @@ import type {
 	ExtensionWidgetContent,
 	ExtensionWidgetOptions,
 	TerminalInputHandler,
+	UserPromptKind,
 } from "../../extensibility/extensions";
 import { HookEditorComponent } from "../../modes/components/hook-editor";
 import { HookInputComponent } from "../../modes/components/hook-input";
@@ -652,6 +653,15 @@ export class ExtensionUiController {
 	/**
 	 * Show a selector for hooks.
 	 */
+	/**
+	 * Notify extensions that an interactive prompt is awaiting the user
+	 * (blocked / needs-attention) and, via the returned promise's settlement,
+	 * when it resolves. Fire-and-forget: reporting must never disturb the prompt.
+	 */
+	#emitPromptSignal(type: "user_prompt_start" | "user_prompt_end", kind: UserPromptKind): void {
+		this.ctx.session.extensionRunner?.emit({ type, kind }).catch(() => {});
+	}
+
 	showHookSelector(
 		title: string,
 		options: string[],
@@ -713,6 +723,7 @@ export class ExtensionUiController {
 		this.ctx.editorContainer.addChild(this.ctx.hookSelector);
 		this.ctx.ui.setFocus(this.ctx.hookSelector);
 		this.ctx.ui.requestRender();
+		this.#emitPromptSignal("user_prompt_start", "select");
 		if (dialogOptions?.signal) {
 			if (dialogOptions.signal.aborted) {
 				onAbort();
@@ -720,7 +731,7 @@ export class ExtensionUiController {
 				dialogOptions.signal.addEventListener("abort", onAbort, { once: true });
 			}
 		}
-		return promise;
+		return promise.finally(() => this.#emitPromptSignal("user_prompt_end", "select"));
 	}
 	/**
 	 * Hide the hook selector.
@@ -786,6 +797,7 @@ export class ExtensionUiController {
 		this.ctx.editorContainer.addChild(this.ctx.hookInput);
 		this.ctx.ui.setFocus(this.ctx.hookInput);
 		this.ctx.ui.requestRender();
+		this.#emitPromptSignal("user_prompt_start", "input");
 		if (dialogOptions?.signal) {
 			if (dialogOptions.signal.aborted) {
 				onAbort();
@@ -793,7 +805,7 @@ export class ExtensionUiController {
 				dialogOptions.signal.addEventListener("abort", onAbort, { once: true });
 			}
 		}
-		return promise;
+		return promise.finally(() => this.#emitPromptSignal("user_prompt_end", "input"));
 	}
 
 	/**

--- a/packages/coding-agent/test/e2e/extension-e2e.test.ts
+++ b/packages/coding-agent/test/e2e/extension-e2e.test.ts
@@ -26,7 +26,6 @@ if (isCI) {
 	describe.skip("Extension E2E (skipped in CI)", () => {
 		it("placeholder", () => {});
 	});
-	// biome-ignore lint: early exit in CI
 	process.exit(0);
 }
 

--- a/packages/coding-agent/test/herdr-reporter.test.ts
+++ b/packages/coding-agent/test/herdr-reporter.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { TempDir } from "@f5-sales-demo/pi-utils";
+import type { ExtensionAPI, ExtensionContext } from "@f5-sales-demo/xcsh";
+import herdrReporter from "@f5-sales-demo/xcsh/extensibility/extensions/bundled/herdr-reporter";
+import { discoverAndLoadExtensions } from "@f5-sales-demo/xcsh/extensibility/extensions/loader";
+import { filterUserExtensions } from "./utils/filter-user-extensions";
+
+type AnyHandler = (event: unknown, ctx: unknown) => void | Promise<void>;
+
+interface MockPi {
+	pi: ExtensionAPI;
+	handlers: Map<string, AnyHandler>;
+	execCalls: Array<{ command: string; args: string[] }>;
+	labels: string[];
+}
+
+function makeMockPi(): MockPi {
+	const handlers = new Map<string, AnyHandler>();
+	const execCalls: Array<{ command: string; args: string[] }> = [];
+	const labels: string[] = [];
+
+	const pi = {
+		on(event: string, handler: AnyHandler) {
+			handlers.set(event, handler);
+		},
+		setLabel(label: string) {
+			labels.push(label);
+		},
+		exec(command: string, args: string[]) {
+			execCalls.push({ command, args });
+			return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+		},
+		logger: { debug() {}, info() {}, warn() {}, error() {} },
+	} as unknown as ExtensionAPI;
+
+	return { pi, handlers, execCalls, labels };
+}
+
+const idleCtx = { isIdle: () => true } as unknown as ExtensionContext;
+const busyCtx = { isIdle: () => false } as unknown as ExtensionContext;
+
+const reportArgs = (state: string, seq: string): string[] => [
+	"pane",
+	"report-agent",
+	"pane-1",
+	"--source",
+	"xcsh",
+	"--agent",
+	"xcsh",
+	"--state",
+	state,
+	"--seq",
+	seq,
+];
+
+describe("herdr-reporter extension", () => {
+	const originalPaneId = process.env.HERDR_PANE_ID;
+
+	afterEach(() => {
+		if (originalPaneId === undefined) delete process.env.HERDR_PANE_ID;
+		else process.env.HERDR_PANE_ID = originalPaneId;
+	});
+
+	it("is inert (registers nothing) when not running under herdr", () => {
+		delete process.env.HERDR_PANE_ID;
+		const { pi, handlers, labels, execCalls } = makeMockPi();
+
+		herdrReporter(pi);
+
+		expect(handlers.size).toBe(0);
+		expect(labels).toEqual([]);
+		expect(execCalls).toEqual([]);
+	});
+
+	it("labels itself xcsh and reports the full state lifecycle under herdr", async () => {
+		process.env.HERDR_PANE_ID = "pane-1";
+		const { pi, handlers, execCalls, labels } = makeMockPi();
+
+		herdrReporter(pi);
+
+		expect(labels).toEqual(["xcsh"]);
+
+		await handlers.get("session_start")?.({}, idleCtx);
+		await handlers.get("agent_start")?.({}, idleCtx);
+		await handlers.get("agent_end")?.({ messages: [] }, idleCtx);
+
+		expect(execCalls[0]).toEqual({ command: "herdr", args: reportArgs("idle", "0") });
+		expect(execCalls[1]).toEqual({ command: "herdr", args: reportArgs("working", "1") });
+		expect(execCalls[2]).toEqual({ command: "herdr", args: reportArgs("idle", "2") });
+	});
+
+	it("reports blocked while a prompt is open, then restores working/idle", async () => {
+		process.env.HERDR_PANE_ID = "pane-1";
+		const { pi, handlers, execCalls } = makeMockPi();
+
+		herdrReporter(pi);
+
+		await handlers.get("user_prompt_start")?.({ kind: "select" }, busyCtx);
+		expect(execCalls.at(-1)).toEqual({ command: "herdr", args: reportArgs("blocked", "0") });
+
+		// agent_end while a prompt is still open stays blocked, not idle.
+		await handlers.get("agent_end")?.({ messages: [] }, busyCtx);
+		expect(execCalls.at(-1)).toEqual({ command: "herdr", args: reportArgs("blocked", "1") });
+
+		// prompt resolves while still streaming -> working.
+		await handlers.get("user_prompt_end")?.({ kind: "select" }, busyCtx);
+		expect(execCalls.at(-1)).toEqual({ command: "herdr", args: reportArgs("working", "2") });
+	});
+
+	it("releases pane authority on shutdown", async () => {
+		process.env.HERDR_PANE_ID = "pane-1";
+		const { pi, handlers, execCalls } = makeMockPi();
+
+		herdrReporter(pi);
+		await handlers.get("session_shutdown")?.({}, idleCtx);
+
+		expect(execCalls.at(-1)).toEqual({
+			command: "herdr",
+			args: ["pane", "release-agent", "pane-1", "--source", "xcsh", "--agent", "xcsh", "--seq", "0"],
+		});
+	});
+
+	it("ships as a bundled extension and registers handlers under herdr", async () => {
+		process.env.HERDR_PANE_ID = "pane-x";
+		const tempDir = TempDir.createSync("@herdr-ext-");
+		try {
+			const result = await discoverAndLoadExtensions([], tempDir.path());
+			const bundled = result.extensions.find(ext => ext.path === "bundled:herdr-reporter");
+			expect(bundled).toBeDefined();
+			expect(bundled?.handlers.has("agent_start")).toBe(true);
+			// bundled extensions are not user-authored, so the user filter drops them.
+			expect(filterUserExtensions(result.extensions).some(e => e.path === "bundled:herdr-reporter")).toBe(false);
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+
+	it("ships as a bundled extension but stays inert without herdr", async () => {
+		delete process.env.HERDR_PANE_ID;
+		const tempDir = TempDir.createSync("@herdr-ext-");
+		try {
+			const result = await discoverAndLoadExtensions([], tempDir.path());
+			const bundled = result.extensions.find(ext => ext.path === "bundled:herdr-reporter");
+			expect(bundled).toBeDefined();
+			expect(bundled?.handlers.size).toBe(0);
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+});

--- a/packages/coding-agent/test/internal-urls/console-field-metadata.test.ts
+++ b/packages/coding-agent/test/internal-urls/console-field-metadata.test.ts
@@ -32,14 +32,11 @@ describe("console field-requirements registry", () => {
 
 	test("xcsh://console/<resource> surfaces a Required fields section with constraints", async () => {
 		const resolver = createConsoleResolver(CONSOLE_CATALOG_DATA, CONSOLE_FIELD_METADATA);
-		const res = await resolver.resolve({
+		const url = Object.assign(new URL("xcsh://console/http-load-balancer"), {
 			rawHost: "console",
 			rawPathname: "/http-load-balancer",
-			pathname: "/http-load-balancer",
-			href: "xcsh://console/http-load-balancer",
-			searchParams: new URLSearchParams(),
-			// biome-ignore lint/suspicious/noExplicitAny: minimal InternalUrl stub for the test
-		} as any);
+		});
+		const res = await resolver.resolve(url);
 		expect(res.content).toContain("Required fields & constraints");
 		expect(res.content).toContain("Domains");
 		expect(res.content).toContain("`spec.domains`");

--- a/packages/coding-agent/test/utils/filter-user-extensions.ts
+++ b/packages/coding-agent/test/utils/filter-user-extensions.ts
@@ -1,11 +1,15 @@
 import { getConfigRootDir } from "@f5-sales-demo/pi-utils";
 
+// Extensions that ship with xcsh use a "bundled:" pseudo-path (no real file).
+// They are not user-authored, so tests asserting on user extensions ignore them.
+const BUNDLED_PREFIX = "bundled:";
+
 export function filterUserExtensions<T extends { path: string }>(extensions: T[]): T[] {
 	const configRoot = getConfigRootDir();
-	return extensions.filter(ext => !ext.path.startsWith(configRoot));
+	return extensions.filter(ext => !ext.path.startsWith(configRoot) && !ext.path.startsWith(BUNDLED_PREFIX));
 }
 
 export function filterUserExtensionErrors<T extends { path: string }>(errors: T[]): T[] {
 	const configRoot = getConfigRootDir();
-	return errors.filter(err => !err.path.startsWith(configRoot));
+	return errors.filter(err => !err.path.startsWith(configRoot) && !err.path.startsWith(BUNDLED_PREFIX));
 }


### PR DESCRIPTION
## Summary
Makes xcsh appear as a first-class **xcsh** assistant with a live **idle / working / blocked** indicator when run inside the [herdr](https://herdr.dev) terminal multiplexer.

herdr's agent-detection catalog is server-controlled, so a new "xcsh" agent can't be registered locally — and herdr's passive heuristics can mislabel xcsh (a fork of pi) as "pi". This uses herdr's **socket reporting API** instead, which is the supported path for a custom-labeled assistant.

## What it does
- New bundled, default-on extension `herdr-reporter`:
  - **Inert unless `HERDR_PANE_ID` is set** (zero effect outside herdr).
  - Reports state via `herdr pane report-agent --source xcsh --agent xcsh --state idle|working|blocked` on `session_start` / `agent_start` / `agent_end`, and `release-agent` on shutdown.
  - Always identifies as **xcsh** (never pi) and claims pane authority so a co-installed pi / passive pi-detection can't mislabel the pane.
  - Fire-and-forget: a missing/failing `herdr` CLI never disturbs the agent.
- New additive lifecycle events **`user_prompt_start` / `user_prompt_end`**, emitted from the interactive prompt choke point (select/input) so "awaiting the user" (permission gate, `ask` tool) is reported as **blocked** — xcsh had no signal for this since the session stays streaming while a prompt is open.
- Bundling via `loadBundledExtensions()` in `discoverAndLoadExtensions`, mirroring the custom-commands bundled pattern; loaded before user extensions so they can override.

## Testing
- New `test/herdr-reporter.test.ts` (6 tests): full state lifecycle, inert-without-herdr, and bundling/registration.
- `bun test` extension suites (discovery/runner/plugin-discovery) green.
- Typecheck (`tsgo --noEmit`) and `biome check .` clean.
- Full package suite: no new failures vs. baseline `main` (identical pre-existing environmental failures; +6 passing tests from this PR).

## Notes
- The second commit removes three **pre-existing stale biome suppressions** discovered while making the tree lint-clean (incl. replacing an `as any` test stub with a properly-typed `URL`-based one).
- Manual E2E to run before merge: launch herdr, run xcsh in a pane, confirm `herdr agent list` shows **xcsh** flipping idle → working → blocked → released.

Closes #1836

🤖 Generated with [Claude Code](https://claude.com/claude-code)