### PR TITLE
Auto-provisioning: native-host + manager + per-tenant workers

### DIFF
--- a/packages/coding-agent/src/browser/extension-bridge.ts
+++ b/packages/coding-agent/src/browser/extension-bridge.ts
@@ -108,7 +108,9 @@ export class BridgeServer {
 	/** Stable per-process session id, advertised to the extension on `hello`. */
 	#sessionId = `sess-${crypto.randomUUID()}`;
 	/** Provider of this process's tenant identity, answering the `hello` handshake. */
-	#sessionInfo: (() => { tenant: string | null; env: string | null; apiUrl: string | null }) | null = null;
+	#sessionInfo:
+		| (() => { tenant: string | null; env: string | null; apiUrl: string | null; contextBound: boolean })
+		| null = null;
 
 	/** The port the WebSocket server is listening on (0 = not bound). */
 	get port(): number {
@@ -145,13 +147,15 @@ export class BridgeServer {
 
 	/** Set the tenant-identity provider that answers the extension's `hello`
 	 * handshake with `{ tenant, env, apiUrl }` for THIS xcsh process/context. */
-	setSessionInfo(cb: () => { tenant: string | null; env: string | null; apiUrl: string | null }): void {
+	setSessionInfo(
+		cb: () => { tenant: string | null; env: string | null; apiUrl: string | null; contextBound: boolean },
+	): void {
 		this.#sessionInfo = cb;
 	}
 
 	/** Push a tenant change to all connected panels (e.g. after `/context activate`). */
 	broadcastTenantChanged(): void {
-		const info = this.#sessionInfo?.() ?? { tenant: null, env: null, apiUrl: null };
+		const info = this.#sessionInfo?.() ?? { tenant: null, env: null, apiUrl: null, contextBound: false };
 		for (const c of this.#clients.values()) {
 			try {
 				c.send(JSON.stringify({ type: "tenant_changed", sessionId: this.#sessionId, ...info }));
@@ -249,7 +253,7 @@ export class BridgeServer {
 			ws.send(JSON.stringify({ type: "pong" }));
 		} else if (msg.type === "hello") {
 			// Identity handshake: tell the extension which tenant this process serves.
-			const info = this.#sessionInfo?.() ?? { tenant: null, env: null, apiUrl: null };
+			const info = this.#sessionInfo?.() ?? { tenant: null, env: null, apiUrl: null, contextBound: false };
 			const { EXTENSION_CONTRACT_VERSION } = require("./capabilities.generated");
 			ws.send(
 				JSON.stringify({
@@ -259,6 +263,7 @@ export class BridgeServer {
 					tenant: info.tenant,
 					env: info.env,
 					apiUrl: info.apiUrl,
+					contextBound: info.contextBound,
 					pid: process.pid,
 				}),
 			);

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -52,6 +52,7 @@ const commands: CommandEntry[] = [
 	{ name: "commit", load: () => import("./commands/commit").then(m => m.default) },
 	{ name: "config", load: () => import("./commands/config").then(m => m.default) },
 	{ name: "chrome", load: () => import("./commands/chrome").then(m => m.default) },
+	{ name: "chrome-host", load: () => import("./commands/native-host").then(m => m.default) },
 	{ name: "grep", load: () => import("./commands/grep").then(m => m.default) },
 	{ name: "grievances", load: () => import("./commands/grievances").then(m => m.default) },
 	{ name: "read", load: () => import("./commands/read").then(m => m.default) },

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -93,11 +93,17 @@ export function runCli(argv: string[]): Promise<void> {
 	// Everything else that isn't a known subcommand routes to "launch".
 	const first = argv[0];
 	const runArgv =
-		first === "--help" || first === "-h" || first === "--version" || first === "-v" || first === "help"
-			? argv
-			: isSubcommand(first)
+		// Chrome launches the native-messaging host with the calling extension's
+		// origin (chrome-extension://…/) as the first arg. Route that to the
+		// `chrome-host` relay — a safety net if a manifest `path` points straight at
+		// the binary instead of the launcher wrapper.
+		first?.startsWith("chrome-extension://")
+			? ["chrome-host", ...argv]
+			: first === "--help" || first === "-h" || first === "--version" || first === "-v" || first === "help"
 				? argv
-				: ["launch", ...argv];
+				: isSubcommand(first)
+					? argv
+					: ["launch", ...argv];
 	return run({ bin: APP_NAME, version: VERSION, argv: runArgv, commands, help: showHelp });
 }
 

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -62,6 +62,7 @@ const commands: CommandEntry[] = [
 	{ name: "ssh", load: () => import("./commands/ssh").then(m => m.default) },
 	{ name: "stats", load: () => import("./commands/stats").then(m => m.default) },
 	{ name: "update", load: () => import("./commands/update").then(m => m.default) },
+	{ name: "worker", load: () => import("./commands/worker").then(m => m.default) },
 	{ name: "search", load: () => import("./commands/web-search").then(m => m.default), aliases: ["q"] },
 ];
 

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -56,6 +56,7 @@ const commands: CommandEntry[] = [
 	{ name: "grievances", load: () => import("./commands/grievances").then(m => m.default) },
 	{ name: "read", load: () => import("./commands/read").then(m => m.default) },
 	{ name: "jupyter", load: () => import("./commands/jupyter").then(m => m.default) },
+	{ name: "manager", load: () => import("./commands/manager").then(m => m.default) },
 	{ name: "plugin", load: () => import("./commands/plugin").then(m => m.default) },
 	{ name: "setup", load: () => import("./commands/setup").then(m => m.default) },
 	{ name: "shell", load: () => import("./commands/shell").then(m => m.default) },

--- a/packages/coding-agent/src/cli/chrome-cli.ts
+++ b/packages/coding-agent/src/cli/chrome-cli.ts
@@ -6,6 +6,8 @@
  * touching Chrome, settings, or the network.
  */
 
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { acquirePage, type BrowserProviderStatus, CdpBrowserProvider } from "../browser";
 import { PORT_RANGE_END, PORT_RANGE_START, resolveForcedPort } from "../browser/extension-bridge";
 import { installNativeHost } from "../services/native-host-install";
@@ -22,6 +24,49 @@ export const EXTENSION_ID = "klajkjdoehjidngligegnpknogmjjhkc";
  * have a one-click install path instead of a dead end.
  */
 export const WEB_STORE_URL = `https://chromewebstore.google.com/detail/${EXTENSION_ID}`;
+
+/** Find a compiled `xcsh` binary on PATH (self-contained; survives Chrome's stripped env). */
+function defaultResolveXcshBin(): string | null {
+	const dirs = (process.env.PATH ?? "").split(path.delimiter).filter(Boolean);
+	for (const dir of dirs) {
+		const candidate = path.join(dir, "xcsh");
+		try {
+			fs.accessSync(candidate, fs.constants.X_OK);
+			return candidate;
+		} catch {
+			/* not on this PATH entry */
+		}
+	}
+	return null;
+}
+
+/**
+ * Resolve the exec prefix Chrome's launcher wrapper should invoke to reach the
+ * `chrome-host` relay (the wrapper appends `chrome-host "$@"`).
+ *
+ * Compiled: `process.execPath` IS the xcsh binary → ["<xcsh>"].
+ * Dev (`bun /abs/src/cli.ts …`): `process.execPath` is bun, which fails under
+ * Chrome's stripped env for a `.ts` entry — so prefer a compiled `xcsh` on PATH
+ * when resolvable; otherwise fall back to ["<bun>", "<abs entry script>"]. The
+ * script is resolved to an ABSOLUTE path because Chrome launches the host from an
+ * arbitrary working directory.
+ */
+export function nativeHostLaunchCommand(
+	argv: string[] = process.argv,
+	execPath: string = process.execPath,
+	resolveXcshBin: () => string | null = defaultResolveXcshBin,
+): string[] {
+	const base = path.basename(execPath).toLowerCase();
+	if (base.startsWith("bun")) {
+		const xcsh = resolveXcshBin();
+		if (xcsh) return [xcsh];
+		const script = argv[1];
+		if (script && (script.endsWith(".ts") || script.endsWith(".js") || script.endsWith(".mjs"))) {
+			return [execPath, path.resolve(script)];
+		}
+	}
+	return [execPath];
+}
 
 export function renderStatus(s: BrowserProviderStatus): string {
 	const yn = (b: boolean) => (b ? "yes" : "no");
@@ -58,9 +103,12 @@ export async function runChromeCommand(action: ChromeAction, settings: Settings)
 		);
 	}
 	if (action === "install-host") {
-		// Use the running binary path when compiled; fall back to process.execPath otherwise.
-		const xcshBinPath = process.execPath;
-		const manifestPath = installNativeHost({ xcshBinPath, extensionIds: [EXTENSION_ID] });
+		// Chrome ignores a manifest `args` field and can't select the `chrome-host`
+		// subcommand, so the manifest `path` points at a generated wrapper that execs
+		// the resolved xcsh with `chrome-host`. Resolve the launch prefix here (reads
+		// process.execPath/argv/PATH); installNativeHost stays a pure writer.
+		const launchCommand = nativeHostLaunchCommand();
+		const manifestPath = installNativeHost({ launchCommand, extensionIds: [EXTENSION_ID] });
 		return `Native-messaging host manifest written to:\n  ${manifestPath}`;
 	}
 	// relaunch: self-consented rung 3 — force allowRelaunch regardless of the setting.

--- a/packages/coding-agent/src/cli/chrome-cli.ts
+++ b/packages/coding-agent/src/cli/chrome-cli.ts
@@ -8,10 +8,11 @@
 
 import { acquirePage, type BrowserProviderStatus, CdpBrowserProvider } from "../browser";
 import { PORT_RANGE_END, PORT_RANGE_START, resolveForcedPort } from "../browser/extension-bridge";
+import { installNativeHost } from "../services/native-host-install";
 
 type Settings = { get(key: string): unknown };
 
-export type ChromeAction = "status" | "relaunch" | "setup";
+export type ChromeAction = "status" | "relaunch" | "setup" | "install-host";
 
 export const EXTENSION_ID = "klajkjdoehjidngligegnpknogmjjhkc";
 
@@ -55,6 +56,12 @@ export async function runChromeCommand(action: ChromeAction, settings: Settings)
 			`The extension scans that range and links each tenant's xcsh automatically.\n` +
 			`Install/keep the xcsh Chrome extension from the Web Store:\n  ${WEB_STORE_URL}`
 		);
+	}
+	if (action === "install-host") {
+		// Use the running binary path when compiled; fall back to process.execPath otherwise.
+		const xcshBinPath = process.execPath;
+		const manifestPath = installNativeHost({ xcshBinPath, extensionIds: [EXTENSION_ID] });
+		return `Native-messaging host manifest written to:\n  ${manifestPath}`;
 	}
 	// relaunch: self-consented rung 3 — force allowRelaunch regardless of the setting.
 	const { mode } = await acquirePage({ settings, allowRelaunch: true });

--- a/packages/coding-agent/src/commands/chrome.ts
+++ b/packages/coding-agent/src/commands/chrome.ts
@@ -5,7 +5,7 @@ import { Args, Command } from "@f5-sales-demo/pi-utils/cli";
 import { type ChromeAction, runChromeCommand } from "../cli/chrome-cli";
 import { Settings, settings } from "../config/settings";
 
-const ACTIONS: ChromeAction[] = ["status", "relaunch", "setup"];
+const ACTIONS: ChromeAction[] = ["status", "relaunch", "setup", "install-host"];
 
 export default class Chrome extends Command {
 	static description = "Inspect or arrange the Chrome session xcsh drives for console automation";

--- a/packages/coding-agent/src/commands/manager-core.ts
+++ b/packages/coding-agent/src/commands/manager-core.ts
@@ -1,0 +1,49 @@
+/** Pure worker-registry + control-protocol logic for the manager. No I/O. */
+
+export interface WorkerRec {
+	tenantKey: string; // "tenant|env"
+	port: number;
+	pid: number;
+	lastSeen: number; // epoch ms
+}
+
+export type Registry = Map<string, WorkerRec>;
+
+export type ControlMsg =
+	| { type: "provision"; tenantKey: string }
+	| { type: "release"; tenantKey: string }
+	| { type: "status" };
+
+function isTenantKey(v: unknown): v is string {
+	return typeof v === "string" && /^[^|]+\|[^|]+$/.test(v);
+}
+
+/** Validate an inbound control frame; null if malformed (fail closed). */
+export function parseControlMsg(raw: unknown): ControlMsg | null {
+	if (!raw || typeof raw !== "object") return null;
+	const m = raw as Record<string, unknown>;
+	if (m.type === "status") return { type: "status" };
+	if ((m.type === "provision" || m.type === "release") && isTenantKey(m.tenantKey)) {
+		return { type: m.type, tenantKey: m.tenantKey };
+	}
+	return null;
+}
+
+/** Idempotency: only provision when there is no live worker for the key. */
+export function needsProvision(reg: Registry, tenantKey: string): boolean {
+	return !reg.has(tenantKey);
+}
+
+/** Lowest free port in the range not already held by a worker. */
+export function pickPort(reg: Registry, range: number[]): number | null {
+	const used = new Set([...reg.values()].map(w => w.port));
+	for (const p of range) if (!used.has(p)) return p;
+	return null;
+}
+
+/** Keys whose worker has been idle longer than idleMs. */
+export function staleKeys(reg: Registry, now: number, idleMs: number): string[] {
+	const out: string[] = [];
+	for (const w of reg.values()) if (now - w.lastSeen > idleMs) out.push(w.tenantKey);
+	return out;
+}

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -108,6 +108,12 @@ export default class Manager extends Command {
 					XCSH_BROWSER_PROVIDER: "extension",
 					XCSH_SESSION_TENANT: tenantKey,
 					XCSH_BRIDGE_PORT: String(port),
+					// Isolate the worker's tenant binding: an ambient XCSH_API_URL in the
+					// manager's env would make sdk.ts skip the XCSH_SESSION_TENANT branch and
+					// bind hello_ack.tenant from the env apiUrl instead. Clear both so the
+					// spawned tenant key is authoritative (undefined removes the var in Bun).
+					XCSH_API_URL: undefined,
+					XCSH_API_TOKEN: undefined,
 				},
 				stdout: "ignore",
 				stderr: "ignore",

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -80,12 +80,6 @@ export default class Manager extends Command {
 	async run(): Promise<void> {
 		const sockPath = process.env.XCSH_MANAGER_SOCK ?? join(homedir(), ".xcsh", "manager.sock");
 		fs.mkdirSync(dirname(sockPath), { recursive: true });
-		// Recreate the socket: a stale file from a crashed manager would make bind fail.
-		try {
-			fs.rmSync(sockPath, { force: true });
-		} catch {
-			/* nothing to remove */
-		}
 
 		const reg: Registry = new Map();
 		const range = portCandidates();
@@ -156,20 +150,54 @@ export default class Manager extends Command {
 		// trailing fragment until the rest of it arrives. Keyed by socket (WeakMap
 		// so a closed connection's buffer is collected without manual bookkeeping).
 		const buffers = new WeakMap<object, string>();
-		Bun.listen({
+		const socketConfig = {
 			unix: sockPath,
 			socket: {
-				data(socket, data): void {
+				data(socket: object, data: Buffer): void {
 					const combined = (buffers.get(socket) ?? "") + data.toString("utf8");
 					const parts = combined.split("\n");
 					buffers.set(socket, parts.pop() ?? ""); // keep the incomplete trailing fragment
 					for (const line of parts) handleFrame(line);
 				},
-				close(socket): void {
+				close(socket: object): void {
 					buffers.delete(socket);
 				},
 			},
-		});
+		};
+
+		// Single-manager invariant — probe liveness BEFORE binding.
+		//
+		// Two chrome-hosts can cold-start concurrently, both find no socket, and
+		// both spawn a manager. `Bun.listen({unix})` SILENTLY unlinks and rebinds
+		// any existing socket path — it does NOT throw EADDRINUSE even when a live
+		// manager is accepting on it (verified on Bun 1.3.x, in- and cross-process).
+		// So a naive `listen` would clobber the first manager's socket, leaving it
+		// orphaned on an unlinked path (blocking forever, leaking its worker ports)
+		// while a second live manager takes over — breaking "at most one manager".
+		//
+		// Guard by CONNECTING first: if a live manager answers, this process lost
+		// the race and exits WITHOUT touching the socket file (it belongs to the
+		// live manager). If nothing answers, the path is free or a STALE file from
+		// a crashed manager — either way `Bun.listen` safely (re)binds it (its own
+		// unlink-and-rebind reclaims the stale file; no explicit rm needed).
+		let liveOwner = false;
+		try {
+			const probe = await Promise.race([
+				Bun.connect({ unix: sockPath, socket: { data() {} } }),
+				new Promise<never>((_, reject) =>
+					setTimeout(() => reject(new Error("manager liveness probe timeout")), 500),
+				),
+			]);
+			liveOwner = true;
+			probe.end();
+		} catch {
+			/* nothing accepting → free path, or a stale socket file from a crashed manager */
+		}
+		if (liveOwner) {
+			console.error(`[xcsh manager] another manager already live at ${sockPath}; exiting`);
+			process.exit(0);
+		}
+		Bun.listen(socketConfig);
 		console.error(`[xcsh manager] control socket listening at ${sockPath}`);
 
 		// Idle sweep: reap workers untouched for longer than the TTL.

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -49,23 +49,29 @@ function isPortFree(port: number): boolean {
 }
 
 /**
- * The argv (AFTER `process.execPath`) to re-run THIS binary in `worker` mode.
+ * The argv (AFTER `process.execPath`) to re-run THIS binary in `mode`.
  *
  * Dev: launched as `bun /abs/src/cli.ts manager`, so `process.argv[1]` is the
- * script path → `["/abs/src/cli.ts", "worker"]`, and `process.execPath` is bun.
+ * script path → `["/abs/src/cli.ts", <mode>]`, and `process.execPath` is bun.
  *
  * Compiled: `process.execPath` IS the xcsh binary and `process.argv[1]` is the
- * subcommand (e.g. "manager"), not a script file → `["worker"]`.
+ * subcommand (e.g. "manager"), not a script file → `[<mode>]`.
  *
- * We detect dev by the script extension so the integration test — which runs
- * `bun src/cli.ts manager` — spawns a genuinely working worker.
+ * We detect dev by the script extension so the integration tests — which run
+ * `bun src/cli.ts <mode>` — re-exec a genuinely working subcommand. Shared by
+ * the manager (worker re-exec) and the chrome-host (manager re-exec).
  */
-export function workerArgv(): string[] {
+export function reexecArgv(mode: "worker" | "manager"): string[] {
 	const script = process.argv[1];
 	if (script && (script.endsWith(".ts") || script.endsWith(".js") || script.endsWith(".mjs"))) {
-		return [script, "worker"];
+		return [script, mode];
 	}
-	return ["worker"];
+	return [mode];
+}
+
+/** The argv (AFTER `process.execPath`) to re-run THIS binary in `worker` mode. */
+export function workerArgv(): string[] {
+	return reexecArgv("worker");
 }
 
 export default class Manager extends Command {

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -1,0 +1,158 @@
+/**
+ * Manager mode — `xcsh manager`.
+ *
+ * A detached, long-lived control server that owns the fleet of per-tenant
+ * `xcsh worker` processes. It listens on a UNIX SOCKET (`~/.xcsh/manager.sock`,
+ * override `XCSH_MANAGER_SOCK`) for NDJSON control frames — one JSON object per
+ * line — validated by the pure `manager-core` protocol:
+ *
+ *   {"type":"provision","tenantKey":"acme|staging"}  → spawn a worker (idempotent)
+ *   {"type":"release","tenantKey":"acme|staging"}     → kill + forget the worker
+ *   {"type":"status"}                                 → accepted; no-op sink
+ *
+ * All registry/port/idempotency/idle policy is the pure `manager-core`; this file
+ * is the thin I/O shell (socket, spawn, kill, timer) around it. A background sweep
+ * reaps workers idle longer than the TTL. The process blocks forever.
+ */
+import * as fs from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { Command } from "@f5-sales-demo/pi-utils/cli";
+import { portCandidates } from "../browser/extension-bridge";
+import { needsProvision, parseControlMsg, pickPort, type Registry, staleKeys } from "./manager-core";
+
+/** Reap a worker idle longer than this (ms). */
+const IDLE_MS = 20 * 60_000;
+/** How often the idle sweep runs (ms). */
+const SWEEP_MS = 60_000;
+
+/**
+ * Whether a loopback TCP port is bindable RIGHT NOW. `pickPort` only dedupes
+ * against the manager's own registry; a range port can still be held by another
+ * app, a stale worker, or a second manager. We pre-filter the range with this so
+ * a spawned worker (which binds its forced `XCSH_BRIDGE_PORT` strictly) never
+ * lands on an occupied port and dies. Bun.listen binds and throws synchronously,
+ * so this stays sync — keeping provision idempotency race-free.
+ */
+function isPortFree(port: number): boolean {
+	try {
+		const listener = Bun.listen({
+			hostname: "127.0.0.1",
+			port,
+			socket: { data() {}, open() {}, close() {}, error() {} },
+		});
+		listener.stop(true);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * The argv (AFTER `process.execPath`) to re-run THIS binary in `worker` mode.
+ *
+ * Dev: launched as `bun /abs/src/cli.ts manager`, so `process.argv[1]` is the
+ * script path → `["/abs/src/cli.ts", "worker"]`, and `process.execPath` is bun.
+ *
+ * Compiled: `process.execPath` IS the xcsh binary and `process.argv[1]` is the
+ * subcommand (e.g. "manager"), not a script file → `["worker"]`.
+ *
+ * We detect dev by the script extension so the integration test — which runs
+ * `bun src/cli.ts manager` — spawns a genuinely working worker.
+ */
+export function workerArgv(): string[] {
+	const script = process.argv[1];
+	if (script && (script.endsWith(".ts") || script.endsWith(".js") || script.endsWith(".mjs"))) {
+		return [script, "worker"];
+	}
+	return ["worker"];
+}
+
+export default class Manager extends Command {
+	static description = "Run the detached control server that spawns/reaps per-tenant workers; blocks forever";
+
+	async run(): Promise<void> {
+		const sockPath = process.env.XCSH_MANAGER_SOCK ?? join(homedir(), ".xcsh", "manager.sock");
+		fs.mkdirSync(dirname(sockPath), { recursive: true });
+		// Recreate the socket: a stale file from a crashed manager would make bind fail.
+		try {
+			fs.rmSync(sockPath, { force: true });
+		} catch {
+			/* nothing to remove */
+		}
+
+		const reg: Registry = new Map();
+		const range = portCandidates();
+
+		const reap = (tenantKey: string): void => {
+			const w = reg.get(tenantKey);
+			if (!w) return;
+			try {
+				process.kill(w.pid);
+			} catch {
+				/* already gone */
+			}
+			reg.delete(tenantKey);
+		};
+
+		const spawnWorker = (tenantKey: string): void => {
+			// Registry-dedupe (pickPort) over only the ports free at the OS level.
+			const port = pickPort(reg, range.filter(isPortFree));
+			if (port === null) {
+				console.error(`[xcsh manager] port range exhausted; cannot provision ${tenantKey}`);
+				return;
+			}
+			const proc = Bun.spawn([process.execPath, ...workerArgv()], {
+				env: {
+					...process.env,
+					XCSH_BROWSER_PROVIDER: "extension",
+					XCSH_SESSION_TENANT: tenantKey,
+					XCSH_BRIDGE_PORT: String(port),
+				},
+				stdout: "ignore",
+				stderr: "ignore",
+			});
+			reg.set(tenantKey, { tenantKey, port, pid: proc.pid, lastSeen: Date.now() });
+			console.error(`[xcsh manager] provisioned ${tenantKey} → pid ${proc.pid} on port ${port}`);
+		};
+
+		const handleFrame = (line: string): void => {
+			const trimmed = line.trim();
+			if (!trimmed) return;
+			let raw: unknown;
+			try {
+				raw = JSON.parse(trimmed);
+			} catch {
+				return; // malformed line — ignore, keep serving
+			}
+			const msg = parseControlMsg(raw);
+			if (!msg) return; // fail closed on unknown/invalid frames
+			if (msg.type === "provision") {
+				if (needsProvision(reg, msg.tenantKey)) spawnWorker(msg.tenantKey);
+				const w = reg.get(msg.tenantKey);
+				if (w) w.lastSeen = Date.now(); // touch on every provision (keep-alive)
+			} else if (msg.type === "release") {
+				reap(msg.tenantKey);
+			}
+			// "status" is validated but currently a no-op sink.
+		};
+
+		Bun.listen({
+			unix: sockPath,
+			socket: {
+				data(_socket, data): void {
+					for (const line of data.toString("utf8").split("\n")) handleFrame(line);
+				},
+			},
+		});
+		console.error(`[xcsh manager] control socket listening at ${sockPath}`);
+
+		// Idle sweep: reap workers untouched for longer than the TTL.
+		setInterval(() => {
+			for (const key of staleKeys(reg, Date.now(), IDLE_MS)) reap(key);
+		}, SWEEP_MS);
+
+		// Detached, long-lived: block until the process is torn down.
+		await new Promise<never>(() => {});
+	}
+}

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -113,6 +113,14 @@ export default class Manager extends Command {
 				stderr: "ignore",
 			});
 			reg.set(tenantKey, { tenantKey, port, pid: proc.pid, lastSeen: Date.now() });
+			// Reconcile a dead worker: when THIS process exits (crash, forced-port
+			// EADDRINUSE with no retry, etc.), drop its registry entry so the next
+			// provision respawns instead of finding a zombie. Guard on pid so an
+			// already-respawned entry for the same tenant is never clobbered.
+			proc.exited.then(() => {
+				const cur = reg.get(tenantKey);
+				if (cur && cur.pid === proc.pid) reg.delete(tenantKey);
+			});
 			console.error(`[xcsh manager] provisioned ${tenantKey} → pid ${proc.pid} on port ${port}`);
 		};
 
@@ -137,11 +145,22 @@ export default class Manager extends Command {
 			// "status" is validated but currently a no-op sink.
 		};
 
+		// Per-connection NDJSON buffer: a control frame can be split across two TCP
+		// reads, so we only parse complete newline-terminated lines and retain any
+		// trailing fragment until the rest of it arrives. Keyed by socket (WeakMap
+		// so a closed connection's buffer is collected without manual bookkeeping).
+		const buffers = new WeakMap<object, string>();
 		Bun.listen({
 			unix: sockPath,
 			socket: {
-				data(_socket, data): void {
-					for (const line of data.toString("utf8").split("\n")) handleFrame(line);
+				data(socket, data): void {
+					const combined = (buffers.get(socket) ?? "") + data.toString("utf8");
+					const parts = combined.split("\n");
+					buffers.set(socket, parts.pop() ?? ""); // keep the incomplete trailing fragment
+					for (const line of parts) handleFrame(line);
+				},
+				close(socket): void {
+					buffers.delete(socket);
 				},
 			},
 		});

--- a/packages/coding-agent/src/commands/native-host.ts
+++ b/packages/coding-agent/src/commands/native-host.ts
@@ -59,7 +59,14 @@ export default class ChromeHost extends Command {
 					socketBuffer = socketBuffer.slice(newlineIndex + 1);
 					if (line.length > 0) {
 						dbg(`socket→chrome ${line.length}B`);
-						process.stdout.write(encodeNm(JSON.parse(line)));
+						// Guard the parse/encode: a malformed manager line would otherwise
+						// throw INSIDE this Bun socket callback. Drop it (trace only) — never
+						// surface the error on stdout, which is the native-messaging stream.
+						try {
+							process.stdout.write(encodeNm(JSON.parse(line)));
+						} catch {
+							dbg("socket→chrome drop: malformed line");
+						}
 					}
 					newlineIndex = socketBuffer.indexOf("\n");
 				}

--- a/packages/coding-agent/src/commands/native-host.ts
+++ b/packages/coding-agent/src/commands/native-host.ts
@@ -1,0 +1,141 @@
+/**
+ * `chrome-host` — native-messaging relay subcommand.
+ *
+ * Launched by Chrome as the native-messaging host. It is a thin relay between
+ * Chrome's stdio (native-messaging framing: 4-byte LE length + JSON) and the
+ * long-lived `xcsh manager` control server's UNIX socket (newline-delimited
+ * JSON). No business logic lives here.
+ *
+ * Unlike a plain relay, the host ENSURES the manager before relaying: if the
+ * control socket can't be connected (manager not yet running), it spawns a
+ * DETACHED, long-lived `xcsh manager` and retries with a short backoff. The
+ * ensure is idempotent — if the first connect succeeds no manager is spawned,
+ * so we never launch two. If the manager still can't be reached after the
+ * backoff we exit cleanly (0); the extension retries the whole bootstrap.
+ */
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { Command } from "@f5-sales-demo/pi-utils/cli";
+import { decodeNm, encodeNm } from "../browser/native-messaging";
+import { reexecArgv } from "./manager";
+
+/** Manager control socket — MUST match `commands/manager.ts` exactly. */
+const SOCKET_PATH = process.env.XCSH_MANAGER_SOCK ?? join(homedir(), ".xcsh", "manager.sock");
+
+/** Connect-retry budget after (re)spawning the manager: ~2s total. */
+const CONNECT_RETRIES = 20;
+const CONNECT_BACKOFF_MS = 100;
+
+// Diagnostic relay tracing, OFF unless ~/.xcsh/chrome-host-debug exists. Security:
+// writes to a 0600 file in the user's home, lifecycle + byte-counts ONLY — never
+// message content — and never to stdout (that would corrupt the NM stream).
+function dbg(msg: string): void {
+	try {
+		const fs = require("node:fs");
+		const home = process.env.HOME || homedir();
+		if (!fs.existsSync(join(home, ".xcsh", "chrome-host-debug"))) return;
+		const fd = fs.openSync(join(home, ".xcsh", "chrome-host.log"), "a", 0o600);
+		fs.appendFileSync(fd, `${new Date().toISOString()} pid=${process.pid} ${msg}\n`);
+		fs.closeSync(fd);
+	} catch {
+		/* logging must never break the relay */
+	}
+}
+
+type Sock = Awaited<ReturnType<typeof Bun.connect>>;
+
+export default class ChromeHost extends Command {
+	static description = "Native-messaging relay between Chrome and the xcsh manager socket (internal)";
+
+	async run(): Promise<void> {
+		let socketBuffer = "";
+		const socketHandlers = {
+			data(_sock: Sock, chunk: Uint8Array): void {
+				// Manager → Chrome: NDJSON lines → native-messaging frames.
+				socketBuffer += new TextDecoder().decode(chunk);
+				let newlineIndex = socketBuffer.indexOf("\n");
+				while (newlineIndex !== -1) {
+					const line = socketBuffer.slice(0, newlineIndex);
+					socketBuffer = socketBuffer.slice(newlineIndex + 1);
+					if (line.length > 0) {
+						dbg(`socket→chrome ${line.length}B`);
+						process.stdout.write(encodeNm(JSON.parse(line)));
+					}
+					newlineIndex = socketBuffer.indexOf("\n");
+				}
+			},
+			close(): void {
+				dbg("manager socket closed → exit");
+				process.exit(0);
+			},
+			error(): void {
+				dbg("manager socket error → exit");
+				process.exit(0);
+			},
+		};
+
+		dbg(`start sock=${SOCKET_PATH} argc=${process.argv.length}`);
+		const socket = await this.ensureManager(socketHandlers);
+		if (!socket) {
+			// Manager unreachable after ensure — exit cleanly; the extension retries.
+			dbg("ensureManager: unreachable → exit");
+			process.exit(0);
+		}
+
+		// Chrome stdin → manager: native-messaging frames → NDJSON lines.
+		dbg("reading chrome stdin");
+		let stdinBuffer: Uint8Array<ArrayBufferLike> = new Uint8Array(0);
+		for await (const chunk of process.stdin) {
+			const bytes = new Uint8Array(chunk);
+			const next = new Uint8Array(stdinBuffer.length + bytes.length);
+			next.set(stdinBuffer, 0);
+			next.set(bytes, stdinBuffer.length);
+			const { messages, rest } = decodeNm(next);
+			stdinBuffer = rest;
+			for (const msg of messages) {
+				dbg(`chrome→socket ${JSON.stringify(msg).length}B`);
+				socket.write(`${JSON.stringify(msg)}\n`);
+			}
+		}
+
+		// Chrome closed stdin — tear down and exit.
+		dbg("chrome stdin EOF → exit");
+		socket.end();
+		process.exit(0);
+	}
+
+	/**
+	 * Connect to the manager, spawning a detached one if the first connect fails.
+	 * Idempotent: a successful first connect spawns nothing (never two managers).
+	 * Returns the connected socket, or undefined if unreachable after backoff.
+	 */
+	private async ensureManager(socket: Parameters<typeof Bun.connect>[0]["socket"]): Promise<Sock | undefined> {
+		try {
+			dbg("connect: first attempt");
+			return await Bun.connect({ unix: SOCKET_PATH, socket });
+		} catch {
+			dbg("connect: failed → spawn detached manager");
+		}
+
+		// Spawn the manager DETACHED and long-lived. It is NOT awaited/retained so
+		// it outlives this host process; on macOS killing the host does not kill it.
+		Bun.spawn([process.execPath, ...reexecArgv("manager")], {
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+
+		// Retry-connect with a short backoff while the manager binds its socket.
+		for (let i = 0; i < CONNECT_RETRIES; i++) {
+			await Bun.sleep(CONNECT_BACKOFF_MS);
+			try {
+				const s = await Bun.connect({ unix: SOCKET_PATH, socket });
+				dbg(`connect: succeeded after ${i + 1} retries`);
+				return s;
+			} catch {
+				/* manager not bound yet — keep retrying */
+			}
+		}
+		return undefined;
+	}
+}

--- a/packages/coding-agent/src/commands/worker.ts
+++ b/packages/coding-agent/src/commands/worker.ts
@@ -27,25 +27,33 @@ import { sessionKeyFromUrl } from "../services/xcsh-env";
  * worker is contextless we parse `XCSH_SESSION_TENANT` (`tenant|env`) so the panel
  * still learns which tenant this process serves (apiUrl stays null). Must be sync —
  * the bridge invokes it synchronously while answering `hello`. */
-export function sessionInfoForWorker(): { tenant: string | null; env: string | null; apiUrl: string | null } {
+export function sessionInfoForWorker(): {
+	tenant: string | null;
+	env: string | null;
+	apiUrl: string | null;
+	contextBound: boolean;
+} {
 	let apiUrl: string | null = null;
+	let contextBound = false;
 	try {
 		apiUrl = ContextService.instance.activeApiUrl;
+		// A worker is "context-bound" when it has an active stored context (not just an env-derived apiUrl).
+		contextBound = ContextService.instance.getStatus().activeContextName != null;
 	} catch {
-		/* ContextService not initialized — fall through to env. */
+		/* ContextService not initialized — fall through to env; contextBound stays false. */
 	}
 	apiUrl = apiUrl ?? process.env.XCSH_API_URL ?? null;
 	if (apiUrl) {
 		const key = sessionKeyFromUrl(apiUrl);
-		return { tenant: key?.tenant ?? null, env: key?.env ?? null, apiUrl };
+		return { tenant: key?.tenant ?? null, env: key?.env ?? null, apiUrl, contextBound };
 	}
 	// Contextless: the worker's assigned tenant is carried in XCSH_SESSION_TENANT.
 	const raw = process.env.XCSH_SESSION_TENANT;
 	if (raw) {
 		const [tenant, env] = raw.split("|");
-		return { tenant: tenant || null, env: env || null, apiUrl: null };
+		return { tenant: tenant || null, env: env || null, apiUrl: null, contextBound };
 	}
-	return { tenant: null, env: null, apiUrl: null };
+	return { tenant: null, env: null, apiUrl: null, contextBound };
 }
 
 /** Browser-automation tool set — identical scoping to `main.ts`'s extension path.

--- a/packages/coding-agent/src/commands/worker.ts
+++ b/packages/coding-agent/src/commands/worker.ts
@@ -1,0 +1,136 @@
+/**
+ * Headless worker mode — `xcsh worker`.
+ *
+ * A non-interactive process that starts the Chrome-extension bridge, creates ONE
+ * agent session bound to this worker's tenant (`XCSH_SESSION_TENANT`, matched to a
+ * context by the session-context bootstrap in `createAgentSession`), attaches the
+ * chat handler, and blocks until SIGTERM/SIGINT. It mirrors the extension-bridge
+ * startup path in `main.ts` (bridge → setSessionInfo → browser-only tool scoping →
+ * createAgentSession → ChatHandler.attach) MINUS the TUI.
+ *
+ * Unlike the interactive path — whose `hello_ack` tenant is derived purely from the
+ * active context's apiUrl (null when contextless) — the worker also falls back to
+ * `XCSH_SESSION_TENANT` so it advertises its assigned tenant even before a context
+ * is bound. This lets the extension panel lock onto the right tenant immediately.
+ */
+import { getProjectDir, getXCSHConfigDir } from "@f5-sales-demo/pi-utils";
+import { Command } from "@f5-sales-demo/pi-utils/cli";
+import { ChatHandler } from "../browser/chat-handler";
+import { startBridgeServer } from "../browser/extension-bridge";
+import { setSharedBridgeServer } from "../browser/provider";
+import { initializeWithSettings } from "../discovery";
+import { createAgentSession } from "../sdk";
+import { ContextService } from "../services/xcsh-context";
+import { sessionKeyFromUrl } from "../services/xcsh-env";
+
+/** Tenant identity for the `hello` handshake. The active context wins; when the
+ * worker is contextless we parse `XCSH_SESSION_TENANT` (`tenant|env`) so the panel
+ * still learns which tenant this process serves (apiUrl stays null). Must be sync —
+ * the bridge invokes it synchronously while answering `hello`. */
+export function sessionInfoForWorker(): { tenant: string | null; env: string | null; apiUrl: string | null } {
+	let apiUrl: string | null = null;
+	try {
+		apiUrl = ContextService.instance.activeApiUrl;
+	} catch {
+		/* ContextService not initialized — fall through to env. */
+	}
+	apiUrl = apiUrl ?? process.env.XCSH_API_URL ?? null;
+	if (apiUrl) {
+		const key = sessionKeyFromUrl(apiUrl);
+		return { tenant: key?.tenant ?? null, env: key?.env ?? null, apiUrl };
+	}
+	// Contextless: the worker's assigned tenant is carried in XCSH_SESSION_TENANT.
+	const raw = process.env.XCSH_SESSION_TENANT;
+	if (raw) {
+		const [tenant, env] = raw.split("|");
+		return { tenant: tenant || null, env: env || null, apiUrl: null };
+	}
+	return { tenant: null, env: null, apiUrl: null };
+}
+
+/** Browser-automation tool set — identical scoping to `main.ts`'s extension path.
+ * With scoped tools the ONLY way to create a resource is the form-driven workflow
+ * runner, which is exactly what the human watching the browser wants. */
+const BROWSER_TOOL_NAMES = [
+	"catalog_workflow_runner",
+	"navigate",
+	"click",
+	"click_element",
+	"fill",
+	"type_text",
+	"screenshot",
+	"login",
+	"read_ax",
+	"get_page_context",
+	"query_dom",
+	"find",
+	"wait_for",
+	"key_press",
+	"select_option",
+	"label_select",
+	"scroll_to",
+	"annotate",
+	"set_explain_mode",
+];
+
+export default class Worker extends Command {
+	static description = "Run a headless extension-bridge worker (no TUI); blocks until SIGTERM";
+
+	async run(): Promise<void> {
+		process.env.XCSH_BROWSER_PROVIDER = "extension";
+
+		const cwd = getProjectDir();
+		const { Settings, settings } = await import("../config/settings");
+		await Settings.init({ cwd });
+
+		// Init the ContextService singleton so the session-context bootstrap (Task 3)
+		// can match XCSH_SESSION_TENANT to a stored context, and so sessionInfoForWorker
+		// can read the active apiUrl once bound.
+		try {
+			ContextService.init(getXCSHConfigDir());
+		} catch {
+			/* already initialized / unavailable — continue. */
+		}
+
+		// Provider persistence for model discovery (parity with main.ts).
+		initializeWithSettings(settings);
+
+		// Quiet startup: skip the welcome screen + blocking plugin "Fix now?" prompts.
+		settings.override("startup.quiet", true);
+
+		// INSTANT-ON: start the bridge before the heavy session init so the extension
+		// can connect immediately. Honors XCSH_BRIDGE_PORT (forced) or auto-selects.
+		const bridge = await startBridgeServer();
+		console.error(`[xcsh worker] extension bridge listening on ws://127.0.0.1:${bridge.port}`);
+		setSharedBridgeServer(bridge);
+		bridge.setSessionInfo(sessionInfoForWorker);
+		ContextService.onContextChange(() => bridge.broadcastTenantChanged());
+
+		const { session } = await createAgentSession({
+			cwd,
+			hasUI: false,
+			toolNames: BROWSER_TOOL_NAMES,
+			// Headless worker: no MCP discovery, no LSP warmup, no extension discovery —
+			// keep startup lean and free of network calls / blocking prompts.
+			enableMCP: false,
+			enableLsp: false,
+			disableExtensionDiscovery: true,
+		});
+
+		const chatHandler = new ChatHandler(bridge, session);
+		chatHandler.attach();
+
+		let shuttingDown = false;
+		const shutdown = () => {
+			if (shuttingDown) return;
+			shuttingDown = true;
+			chatHandler.dispose();
+			void bridge.close().finally(() => process.exit(0));
+		};
+		process.on("SIGTERM", shutdown);
+		process.on("SIGINT", shutdown);
+
+		// Block until a signal tears us down.
+		await new Promise<never>(() => {});
+	}
+}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -826,15 +826,18 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 			const { sessionKeyFromUrl } = await import("./services/xcsh-env");
 			const readInfo = () => {
 				let apiUrl: string | null = null;
+				let contextBound = false;
 				try {
 					apiUrl = ContextService.instance.activeApiUrl;
+					// Context-bound when a stored context is active (not just an env-derived apiUrl).
+					contextBound = ContextService.instance.getStatus().activeContextName != null;
 				} catch {
 					/* ContextService not initialized */
 				}
 				// Fall back to the env override when no context is active (env-only mode).
 				apiUrl = apiUrl ?? process.env.XCSH_API_URL ?? null;
 				const key = apiUrl ? sessionKeyFromUrl(apiUrl) : null;
-				return { tenant: key?.tenant ?? null, env: key?.env ?? null, apiUrl };
+				return { tenant: key?.tenant ?? null, env: key?.env ?? null, apiUrl, contextBound };
 			};
 			bridgeServer.setSessionInfo(readInfo);
 			ContextService.onContextChange(() => bridgeServer?.broadcastTenantChanged());

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -783,9 +783,28 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const svc = ContextService.instance; // inited in main.ts (throws for SDK/tests → caught)
 		if (!process.env.XCSH_API_URL) {
 			const bound = existingSession.activeContextName; // resumed binding, if any
-			const available = (await svc.listContexts()).map(c => c.name);
-			const folderContext = await svc.resolveFolderContextName(cwd);
-			const autoBind = resolveAutoBind({ kind: "cli", availableContexts: available, folderContext });
+			const contexts = await svc.listContexts();
+			const available = contexts.map(c => c.name);
+			const tenantKey = process.env.XCSH_SESSION_TENANT;
+			let autoBind: ReturnType<typeof resolveAutoBind>;
+			if (tenantKey) {
+				// Extension worker: match a context to this worker's tenant.
+				const { sessionKeyFromUrl } = await import("./services/xcsh-env");
+				const contextTenantKeys: Record<string, string> = {};
+				for (const c of contexts) {
+					const key = c.apiUrl ? sessionKeyFromUrl(c.apiUrl) : null;
+					if (key) contextTenantKeys[c.name] = `${key.tenant}|${key.env}`;
+				}
+				autoBind = resolveAutoBind({
+					kind: "extension",
+					availableContexts: available,
+					tenantKey,
+					contextTenantKeys,
+				});
+			} else {
+				const folderContext = await svc.resolveFolderContextName(cwd);
+				autoBind = resolveAutoBind({ kind: "cli", availableContexts: available, folderContext });
+			}
 			const choice = chooseSessionContext(bound, autoBind);
 			if ("activate" in choice) {
 				try {

--- a/packages/coding-agent/src/services/native-host-install.ts
+++ b/packages/coding-agent/src/services/native-host-install.ts
@@ -12,24 +12,52 @@ function nativeHostDir(home: string, platform: NodeJS.Platform): string {
 	throw new Error(`native-host install unsupported on platform '${platform}' (macOS/Linux only)`);
 }
 
-/** Idempotently write the user-level NM host manifest. Returns the manifest path. */
+/** Single-quote a token for a POSIX `sh` command line (safe for spaces/specials). */
+function shQuote(token: string): string {
+	return `'${token.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Idempotently write the user-level NM host manifest AND its launcher wrapper.
+ * Returns the manifest path.
+ *
+ * Chrome native-messaging manifests support ONLY {name, description, path, type,
+ * allowed_origins} — Chrome does NOT honor an `args` field, and when it launches
+ * the host it passes the calling extension's origin as argv[1] to `path`. So the
+ * manifest CANNOT point straight at the xcsh binary (that would run the default
+ * `launch`/TUI, never `chrome-host`). Instead `path` points at a generated
+ * executable wrapper that execs the real xcsh with the `chrome-host` subcommand
+ * and forwards Chrome's args ("$@"). `launchCommand` is the resolved exec prefix
+ * (e.g. ["/usr/local/bin/xcsh"] compiled, or ["/path/bun", "/abs/src/cli.ts"] in
+ * dev) — resolved by the CLI layer so this stays a pure writer.
+ */
 export function installNativeHost(opts: {
-	xcshBinPath: string;
+	launchCommand: string[];
 	extensionIds: string[];
 	home?: string;
 	platform?: NodeJS.Platform;
 }): string {
+	if (opts.launchCommand.length === 0) throw new Error("installNativeHost: launchCommand must not be empty");
 	const home = opts.home ?? os.homedir();
-	const dir = nativeHostDir(home, opts.platform ?? process.platform);
+	const platform = opts.platform ?? process.platform;
+	const dir = nativeHostDir(home, platform);
 	const manifestPath = path.join(dir, `${NATIVE_HOST_NAME}.json`);
+	const wrapperPath = path.join(dir, `${NATIVE_HOST_NAME}.sh`);
+	fs.mkdirSync(dir, { recursive: true });
+
+	// Executable launcher: exec the real xcsh with `chrome-host`, forwarding
+	// Chrome's origin arg via "$@". 0o755 so Chrome can execute it directly.
+	const wrapper = `#!/bin/sh\nexec ${opts.launchCommand.map(shQuote).join(" ")} chrome-host "$@"\n`;
+	fs.writeFileSync(wrapperPath, wrapper, { mode: 0o755 });
+	fs.chmodSync(wrapperPath, 0o755); // writeFileSync mode is subject to umask; force it.
+
 	const manifest = {
 		name: NATIVE_HOST_NAME,
 		description: "xcsh Chrome native-messaging host (auto-provisioning bootstrap)",
-		path: opts.xcshBinPath,
+		path: wrapperPath,
 		type: "stdio",
 		allowed_origins: opts.extensionIds.map(id => `chrome-extension://${id}/`),
 	};
-	fs.mkdirSync(dir, { recursive: true });
 	fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 	return manifestPath;
 }

--- a/packages/coding-agent/src/services/native-host-install.ts
+++ b/packages/coding-agent/src/services/native-host-install.ts
@@ -1,0 +1,35 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/** Chrome native-messaging host name (matches the pre-WS-transition host). */
+export const NATIVE_HOST_NAME = "com.xcsh.xcsh.chrome_host";
+
+function nativeHostDir(home: string, platform: NodeJS.Platform): string {
+	if (platform === "darwin")
+		return path.join(home, "Library", "Application Support", "Google", "Chrome", "NativeMessagingHosts");
+	if (platform === "linux") return path.join(home, ".config", "google-chrome", "NativeMessagingHosts");
+	throw new Error(`native-host install unsupported on platform '${platform}' (macOS/Linux only)`);
+}
+
+/** Idempotently write the user-level NM host manifest. Returns the manifest path. */
+export function installNativeHost(opts: {
+	xcshBinPath: string;
+	extensionIds: string[];
+	home?: string;
+	platform?: NodeJS.Platform;
+}): string {
+	const home = opts.home ?? os.homedir();
+	const dir = nativeHostDir(home, opts.platform ?? process.platform);
+	const manifestPath = path.join(dir, `${NATIVE_HOST_NAME}.json`);
+	const manifest = {
+		name: NATIVE_HOST_NAME,
+		description: "xcsh Chrome native-messaging host (auto-provisioning bootstrap)",
+		path: opts.xcshBinPath,
+		type: "stdio",
+		allowed_origins: opts.extensionIds.map(id => `chrome-extension://${id}/`),
+	};
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+	return manifestPath;
+}

--- a/packages/coding-agent/test/helpers/bridge-probe.ts
+++ b/packages/coding-agent/test/helpers/bridge-probe.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared test helper: the `hello` / `hello_ack` WebSocket handshake against an
+ * extension-bridge worker.
+ *
+ * The bridge runs WITH origin checking (mirroring main.ts / the worker), so the
+ * probe presents the extension's `Origin` header. The origin is derived from
+ * `EXTENSION_ID` — the SAME source the worker's origin check reads — so the two
+ * can never drift.
+ *
+ * Consumed by both `worker-spawn.int.test.ts` (Task 4) and `manager.int.test.ts`
+ * (Task 5); do not inline a copy.
+ */
+import { EXTENSION_ID } from "@f5-sales-demo/xcsh/cli/chrome-cli";
+
+/** The `Origin` header the bridge's origin check expects. */
+export const PROBE_ORIGIN = `chrome-extension://${EXTENSION_ID}`;
+
+/**
+ * Perform ONE `hello` / `hello_ack` handshake against the bridge on `port`.
+ * Resolves the parsed ack frame, or rejects on socket error / timeout. Callers
+ * wrap this in a retry loop while a worker is still coming up.
+ */
+export function probe(port: number, timeoutMs = 500): Promise<Record<string, unknown>> {
+	return new Promise<Record<string, unknown>>((resolve, reject) => {
+		const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+			headers: { Origin: PROBE_ORIGIN },
+		} as unknown as string[]);
+		const timer = setTimeout(() => {
+			try {
+				ws.close();
+			} catch {
+				/* already closing */
+			}
+			reject(new Error("probe timeout"));
+		}, timeoutMs);
+		ws.onopen = () => ws.send(JSON.stringify({ type: "hello", contractVersion: "1.5.0", extensionId: "probe" }));
+		ws.onmessage = e => {
+			clearTimeout(timer);
+			resolve(JSON.parse(e.data as string) as Record<string, unknown>);
+			ws.close();
+		};
+		ws.onerror = () => {
+			clearTimeout(timer);
+			reject(new Error("ws error"));
+		};
+	});
+}

--- a/packages/coding-agent/test/manager-core.test.ts
+++ b/packages/coding-agent/test/manager-core.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import {
+	needsProvision,
+	parseControlMsg,
+	pickPort,
+	type Registry,
+	staleKeys,
+	type WorkerRec,
+} from "../src/commands/manager-core";
+
+function reg(...recs: WorkerRec[]): Registry {
+	const m: Registry = new Map();
+	for (const r of recs) m.set(r.tenantKey, r);
+	return m;
+}
+const W = (tenantKey: string, port: number, lastSeen = 0): WorkerRec => ({ tenantKey, port, pid: 1, lastSeen });
+
+describe("parseControlMsg", () => {
+	test("valid provision/release/status", () => {
+		expect(parseControlMsg({ type: "provision", tenantKey: "a|staging" })).toEqual({
+			type: "provision",
+			tenantKey: "a|staging",
+		});
+		expect(parseControlMsg({ type: "release", tenantKey: "a|staging" })).toEqual({
+			type: "release",
+			tenantKey: "a|staging",
+		});
+		expect(parseControlMsg({ type: "status" })).toEqual({ type: "status" });
+	});
+	test("rejects junk / missing fields / bad tenantKey", () => {
+		expect(parseControlMsg({ type: "provision" })).toBeNull();
+		expect(parseControlMsg({ type: "nope", tenantKey: "a|staging" })).toBeNull();
+		expect(parseControlMsg({ type: "provision", tenantKey: "no-pipe" })).toBeNull();
+		expect(parseControlMsg(null)).toBeNull();
+	});
+});
+
+describe("needsProvision (idempotent)", () => {
+	test("true when no live worker, false when one exists", () => {
+		expect(needsProvision(reg(), "a|staging")).toBe(true);
+		expect(needsProvision(reg(W("a|staging", 19222)), "a|staging")).toBe(false);
+	});
+});
+
+describe("pickPort", () => {
+	test("lowest free port in range", () => {
+		expect(pickPort(reg(W("a|staging", 19222)), [19222, 19223, 19224])).toBe(19223);
+	});
+	test("null when exhausted", () => {
+		expect(pickPort(reg(W("a", 19222), W("b", 19223)), [19222, 19223])).toBeNull();
+	});
+});
+
+describe("staleKeys", () => {
+	test("returns keys idle beyond ttl", () => {
+		const now = 100_000;
+		expect(staleKeys(reg(W("a", 19222, now - 40_000), W("b", 19223, now - 5_000)), now, 30_000)).toEqual(["a"]);
+	});
+});

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Integration test: `xcsh manager` control-socket server.
+ *
+ * Spawns a REAL manager subprocess (`bun src/cli.ts manager`) with a temp unix
+ * control socket, sends a `provision` NDJSON frame over that socket, then proves
+ * the manager spawned a REAL `xcsh worker` by probing the bridge port range for a
+ * `hello_ack` advertising the provisioned tenant. Finally sends `release` and
+ * proves the worker is reaped (the port goes silent).
+ *
+ * The worker's tenant advertisement flows: manager → XCSH_SESSION_TENANT env →
+ * worker's contextless `sessionInfoForWorker()` → `hello_ack.tenant`.
+ */
+import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { probe } from "./helpers/bridge-probe";
+
+let mgr: import("bun").Subprocess | undefined;
+let sock = "";
+
+afterEach(() => {
+	mgr?.kill();
+	mgr = undefined;
+	if (sock) {
+		try {
+			fs.rmSync(sock, { force: true });
+		} catch {
+			/* best effort */
+		}
+	}
+});
+
+/** Send one NDJSON control frame over the manager's unix socket. */
+async function send(msg: unknown): Promise<void> {
+	const c = await Bun.connect({ unix: sock, socket: { data() {} } });
+	c.write(`${JSON.stringify(msg)}\n`);
+	await Bun.sleep(50);
+	c.end();
+}
+
+// Workers are assigned the LOWEST free range port (19222 up); the T4 worker test
+// pins 19239, so polling the low end of the range avoids colliding with it.
+const RANGE = [19222, 19223, 19224, 19225];
+
+/** Poll the range for a hello_ack advertising `tenant`. */
+async function findTenant(tenant: string, tries: number): Promise<number | null> {
+	for (let i = 0; i < tries; i++) {
+		for (const p of RANGE) {
+			try {
+				const ack = await probe(p);
+				if (ack.tenant === tenant) return p;
+			} catch {
+				/* worker not up yet on this port */
+			}
+		}
+		await Bun.sleep(250);
+	}
+	return null;
+}
+
+test("provision spawns a worker advertising the tenant; release reaps it", async () => {
+	sock = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-mgr-")), "manager.sock");
+	mgr = Bun.spawn(["bun", "src/cli.ts", "manager"], {
+		cwd: process.cwd(),
+		env: { ...process.env, XCSH_MANAGER_SOCK: sock },
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+
+	// Wait for the manager to bind its control socket.
+	for (let i = 0; i < 60 && !fs.existsSync(sock); i++) await Bun.sleep(100);
+	expect(fs.existsSync(sock)).toBe(true);
+
+	await send({ type: "provision", tenantKey: "acme|staging" });
+
+	const port = await findTenant("acme", 80);
+	expect(port).not.toBeNull();
+
+	// Release should reap the worker: the port stops answering the handshake.
+	await send({ type: "release", tenantKey: "acme|staging" });
+	let stillUp = true;
+	for (let i = 0; i < 40; i++) {
+		try {
+			await probe(port as number);
+		} catch {
+			stillUp = false;
+			break;
+		}
+		await Bun.sleep(250);
+	}
+	expect(stillUp).toBe(false);
+}, 60_000);

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -137,6 +137,38 @@ test("provision spawns a worker advertising the tenant; release reaps it", async
 	expect(stillUp).toBe(false);
 }, 60_000);
 
+test("an ambient XCSH_API_URL in the manager env does NOT leak into the worker's tenant binding", async () => {
+	// The manager runs with an ambient XCSH_API_URL for a DIFFERENT tenant. The
+	// worker reads process.env.XCSH_API_URL directly (sessionInfoForWorker), so if
+	// the manager spread it into the worker's env the handshake would advertise
+	// "leaktenant" (from the apiUrl), NOT the provisioned XCSH_SESSION_TENANT.
+	// spawnWorker clears XCSH_API_URL/XCSH_API_TOKEN so the tenant key is authoritative.
+	sock = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-mgr-")), "manager.sock");
+	mgr = Bun.spawn(["bun", "src/cli.ts", "manager"], {
+		cwd: process.cwd(),
+		env: {
+			...process.env,
+			XCSH_MANAGER_SOCK: sock,
+			XCSH_API_URL: "https://leaktenant.console.ves.volterra.io",
+			XCSH_API_TOKEN: "ambient-should-not-leak",
+		},
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+	for (let i = 0; i < 60 && !fs.existsSync(sock); i++) await Bun.sleep(100);
+	expect(fs.existsSync(sock)).toBe(true);
+
+	await send({ type: "provision", tenantKey: "isolate|staging" });
+
+	// The worker must advertise the PROVISIONED tenant, not the ambient apiUrl's.
+	const port = await findTenant("isolate", 80);
+	expect(port).not.toBeNull();
+	const leaked = await findTenant("leaktenant", 4);
+	expect(leaked).toBeNull();
+
+	await send({ type: "release", tenantKey: "isolate|staging" });
+}, 60_000);
+
 test("a provision frame split across two TCP writes is still parsed (NDJSON buffering)", async () => {
 	await startManager();
 

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -19,9 +19,35 @@ import { probe } from "./helpers/bridge-probe";
 let mgr: import("bun").Subprocess | undefined;
 let sock = "";
 
-afterEach(() => {
+// Workers are separate processes the manager spawns; killing the manager does
+// NOT reap them. Sweep the discovery range and kill any leftover worker so a
+// failed/interrupted test can't leak a bound port into the next one. Never kill
+// this test process itself (it holds outbound probe connections on these ports).
+async function pidsOnPort(port: number): Promise<number[]> {
+	try {
+		const out = await new Response(Bun.spawn(["lsof", "-ti", `tcp:${port}`]).stdout).text();
+		return out
+			.trim()
+			.split("\n")
+			.map(s => Number(s.trim()))
+			.filter(n => Number.isInteger(n) && n > 0 && n !== process.pid);
+	} catch {
+		return []; // lsof unavailable — nothing we can enumerate
+	}
+}
+
+afterEach(async () => {
 	mgr?.kill();
 	mgr = undefined;
+	for (const p of RANGE) {
+		for (const pid of await pidsOnPort(p)) {
+			try {
+				process.kill(pid);
+			} catch {
+				/* already gone */
+			}
+		}
+	}
 	if (sock) {
 		try {
 			fs.rmSync(sock, { force: true });
@@ -37,6 +63,19 @@ async function send(msg: unknown): Promise<void> {
 	c.write(`${JSON.stringify(msg)}\n`);
 	await Bun.sleep(50);
 	c.end();
+}
+
+/** Spawn a fresh manager on a temp socket and wait for it to bind. */
+async function startManager(): Promise<void> {
+	sock = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-mgr-")), "manager.sock");
+	mgr = Bun.spawn(["bun", "src/cli.ts", "manager"], {
+		cwd: process.cwd(),
+		env: { ...process.env, XCSH_MANAGER_SOCK: sock },
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+	for (let i = 0; i < 60 && !fs.existsSync(sock); i++) await Bun.sleep(100);
+	expect(fs.existsSync(sock)).toBe(true);
 }
 
 // Workers are assigned the LOWEST free range port (19222 up); the T4 worker test
@@ -91,3 +130,63 @@ test("provision spawns a worker advertising the tenant; release reaps it", async
 	}
 	expect(stillUp).toBe(false);
 }, 60_000);
+
+test("a provision frame split across two TCP writes is still parsed (NDJSON buffering)", async () => {
+	await startManager();
+
+	// Write ONE provision frame in two chunks split mid-JSON with a gap between,
+	// so the manager's data handler sees the frame across two separate reads.
+	// Without a per-connection buffer, neither half is valid JSON and the command
+	// is silently dropped → no worker ever comes up.
+	const frame = `${JSON.stringify({ type: "provision", tenantKey: "split|staging" })}\n`;
+	const cut = Math.floor(frame.length / 2);
+	const c = await Bun.connect({ unix: sock, socket: { data() {} } });
+	c.write(frame.slice(0, cut));
+	await Bun.sleep(80);
+	c.write(frame.slice(cut));
+	await Bun.sleep(50);
+	c.end();
+
+	const port = await findTenant("split", 80);
+	expect(port).not.toBeNull();
+
+	await send({ type: "release", tenantKey: "split|staging" });
+}, 60_000);
+
+test("a worker that dies out of band is reconciled so the next provision respawns", async () => {
+	await startManager();
+
+	await send({ type: "provision", tenantKey: "revive|staging" });
+	const first = await findTenant("revive", 80);
+	expect(first).not.toBeNull();
+
+	// Kill the worker OUT OF BAND (not via release) by discovering its pid from
+	// the bound port. The registry still holds a zombie entry until the manager's
+	// exit handler reconciles it.
+	const pids = await pidsOnPort(first as number);
+	expect(pids.length).toBeGreaterThan(0); // lsof must resolve the worker pid on macOS
+	for (const pid of pids) process.kill(pid);
+
+	// Confirm the worker is actually dead (port goes silent) before re-provisioning;
+	// this also guarantees the manager's `proc.exited` handler has run.
+	let dead = false;
+	for (let i = 0; i < 40; i++) {
+		try {
+			await probe(first as number);
+		} catch {
+			dead = true;
+			break;
+		}
+		await Bun.sleep(250);
+	}
+	expect(dead).toBe(true);
+	await Bun.sleep(250); // let the exit handler drop the zombie registry entry
+
+	// Re-provision the SAME tenant. Only possible to come back up if needsProvision
+	// flipped true — i.e. the dead worker was reconciled out of the registry.
+	await send({ type: "provision", tenantKey: "revive|staging" });
+	const second = await findTenant("revive", 80);
+	expect(second).not.toBeNull();
+
+	await send({ type: "release", tenantKey: "revive|staging" });
+}, 90_000);

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -17,6 +17,10 @@ import * as path from "node:path";
 import { probe } from "./helpers/bridge-probe";
 
 let mgr: import("bun").Subprocess | undefined;
+// A SECOND manager on the same socket (single-manager-invariant test). It is
+// expected to detect the first and self-exit; tracked only so a regression that
+// leaves it blocking forever is still reaped by afterEach.
+let mgrB: import("bun").Subprocess | undefined;
 let sock = "";
 
 // Workers are separate processes the manager spawns; killing the manager does
@@ -39,6 +43,8 @@ async function pidsOnPort(port: number): Promise<number[]> {
 afterEach(async () => {
 	mgr?.kill();
 	mgr = undefined;
+	mgrB?.kill();
+	mgrB = undefined;
 	for (const p of RANGE) {
 		for (const pid of await pidsOnPort(p)) {
 			try {
@@ -189,4 +195,43 @@ test("a worker that dies out of band is reconciled so the next provision respawn
 	expect(second).not.toBeNull();
 
 	await send({ type: "release", tenantKey: "revive|staging" });
+}, 90_000);
+
+test("a second manager on the same socket detects the live first and self-exits without orphaning it", async () => {
+	// Manager A binds the socket and brings up a live worker.
+	await startManager();
+	await send({ type: "provision", tenantKey: "solo|a" });
+	const portA = await findTenant("solo", 80);
+	expect(portA).not.toBeNull();
+
+	// Manager B cold-starts on the SAME socket. Its bind collides; it must probe,
+	// discover A is live, and exit(0) WITHOUT unlinking A's socket. Under the old
+	// rm-then-listen startup B would instead clobber A's socket and block forever
+	// as a second live manager, orphaning A.
+	mgrB = Bun.spawn(["bun", "src/cli.ts", "manager"], {
+		cwd: process.cwd(),
+		env: { ...process.env, XCSH_MANAGER_SOCK: sock },
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+
+	// B must exit quickly (a live manager blocks forever). exitCode 0 = clean bail.
+	const outcome = await Promise.race([
+		mgrB.exited,
+		new Promise<"blocked">(resolve => setTimeout(() => resolve("blocked"), 10_000)),
+	]);
+	expect(outcome).toBe(0);
+
+	// A is UNHARMED: its socket still accepts control frames and still spawns
+	// workers — provision a different tenant and confirm a new worker appears.
+	await send({ type: "provision", tenantKey: "twin|a" });
+	const portTwin = await findTenant("twin", 80);
+	expect(portTwin).not.toBeNull();
+
+	// And A never lost its original socket: the first worker is still reachable.
+	const ackSolo = await probe(portA as number);
+	expect(ackSolo.tenant).toBe("solo");
+
+	await send({ type: "release", tenantKey: "solo|a" });
+	await send({ type: "release", tenantKey: "twin|a" });
 }, 90_000);

--- a/packages/coding-agent/test/native-host-install.test.ts
+++ b/packages/coding-agent/test/native-host-install.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { installNativeHost, NATIVE_HOST_NAME } from "../src/services/native-host-install";
+
+describe("installNativeHost", () => {
+	test("writes a user-level stdio manifest allowlisting the extension (macOS)", () => {
+		const home = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-nmh-"));
+		const p = installNativeHost({
+			xcshBinPath: "/usr/local/bin/xcsh",
+			extensionIds: ["klajkjdoehjidngligegnpknogmjjhkc"],
+			home,
+			platform: "darwin",
+		});
+		expect(p).toBe(
+			path.join(
+				home,
+				"Library",
+				"Application Support",
+				"Google",
+				"Chrome",
+				"NativeMessagingHosts",
+				`${NATIVE_HOST_NAME}.json`,
+			),
+		);
+		const m = JSON.parse(fs.readFileSync(p, "utf8"));
+		expect(m.name).toBe(NATIVE_HOST_NAME);
+		expect(m.type).toBe("stdio");
+		expect(m.path).toBe("/usr/local/bin/xcsh");
+		expect(m.allowed_origins).toEqual(["chrome-extension://klajkjdoehjidngligegnpknogmjjhkc/"]);
+		fs.rmSync(home, { recursive: true, force: true });
+	});
+	test("throws on unsupported platform", () => {
+		expect(() =>
+			installNativeHost({ xcshBinPath: "/x", extensionIds: ["a"], home: "/tmp", platform: "win32" }),
+		).toThrow();
+	});
+});

--- a/packages/coding-agent/test/native-host-install.test.ts
+++ b/packages/coding-agent/test/native-host-install.test.ts
@@ -5,35 +5,57 @@ import * as path from "node:path";
 import { installNativeHost, NATIVE_HOST_NAME } from "../src/services/native-host-install";
 
 describe("installNativeHost", () => {
-	test("writes a user-level stdio manifest allowlisting the extension (macOS)", () => {
+	test("manifest path points at an executable wrapper that execs chrome-host (macOS)", () => {
 		const home = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-nmh-"));
 		const p = installNativeHost({
-			xcshBinPath: "/usr/local/bin/xcsh",
+			launchCommand: ["/usr/local/bin/xcsh"],
 			extensionIds: ["klajkjdoehjidngligegnpknogmjjhkc"],
 			home,
 			platform: "darwin",
 		});
-		expect(p).toBe(
-			path.join(
-				home,
-				"Library",
-				"Application Support",
-				"Google",
-				"Chrome",
-				"NativeMessagingHosts",
-				`${NATIVE_HOST_NAME}.json`,
-			),
-		);
+		const nmhDir = path.join(home, "Library", "Application Support", "Google", "Chrome", "NativeMessagingHosts");
+		expect(p).toBe(path.join(nmhDir, `${NATIVE_HOST_NAME}.json`));
 		const m = JSON.parse(fs.readFileSync(p, "utf8"));
 		expect(m.name).toBe(NATIVE_HOST_NAME);
 		expect(m.type).toBe("stdio");
-		expect(m.path).toBe("/usr/local/bin/xcsh");
 		expect(m.allowed_origins).toEqual(["chrome-extension://klajkjdoehjidngligegnpknogmjjhkc/"]);
+		// `path` must NOT point straight at the binary — Chrome ignores `args` and
+		// would run the default launch/TUI. It points at a generated wrapper.
+		expect(m.path).not.toBe("/usr/local/bin/xcsh");
+		expect(m.path).toBe(path.join(nmhDir, `${NATIVE_HOST_NAME}.sh`));
+		// The wrapper exists, is executable, and execs the real binary with chrome-host.
+		const wrapper = fs.readFileSync(m.path, "utf8");
+		expect(wrapper.startsWith("#!/bin/sh")).toBe(true);
+		expect(wrapper).toContain("'/usr/local/bin/xcsh'");
+		expect(wrapper).toContain("chrome-host");
+		expect(wrapper).toContain(`"$@"`);
+		expect(fs.statSync(m.path).mode & 0o111).not.toBe(0); // has an execute bit
 		fs.rmSync(home, { recursive: true, force: true });
 	});
+
+	test("dev launch prefix (bun + entry script) is baked into the wrapper", () => {
+		const home = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-nmh-"));
+		const p = installNativeHost({
+			launchCommand: ["/opt/bun/bin/bun", "/abs/src/cli.ts"],
+			extensionIds: ["a"],
+			home,
+			platform: "linux",
+		});
+		const m = JSON.parse(fs.readFileSync(p, "utf8"));
+		const wrapper = fs.readFileSync(m.path, "utf8");
+		expect(wrapper).toContain("'/opt/bun/bin/bun' '/abs/src/cli.ts' chrome-host");
+		fs.rmSync(home, { recursive: true, force: true });
+	});
+
 	test("throws on unsupported platform", () => {
 		expect(() =>
-			installNativeHost({ xcshBinPath: "/x", extensionIds: ["a"], home: "/tmp", platform: "win32" }),
+			installNativeHost({ launchCommand: ["/x"], extensionIds: ["a"], home: "/tmp", platform: "win32" }),
+		).toThrow();
+	});
+
+	test("throws on empty launchCommand", () => {
+		expect(() =>
+			installNativeHost({ launchCommand: [], extensionIds: ["a"], home: "/tmp", platform: "darwin" }),
 		).toThrow();
 	});
 });

--- a/packages/coding-agent/test/native-host-launch.int.test.ts
+++ b/packages/coding-agent/test/native-host-launch.int.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Integration test: the REAL Chrome launch seam.
+ *
+ * `native-host.int.test.ts` proves the relay by running `bun src/cli.ts
+ * chrome-host` directly — but that BYPASSES the manifest, which is exactly the
+ * seam that was broken (Chrome can't select a subcommand, and ignores `args`).
+ *
+ * This test installs the manifest+wrapper via the real `installNativeHost`, then
+ * LAUNCHES the host the way Chrome does: it execs the manifest's `path` (the
+ * generated wrapper) with the calling extension's origin as argv — NOT by naming
+ * `chrome-host`. It then writes an NM `provision` frame to stdin and asserts the
+ * manager control socket APPEARS, proving the wrapper actually reached the relay
+ * which ensured the manager. This fails if `path` points at the bare binary.
+ */
+import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { encodeNm } from "../src/browser/native-messaging";
+import { nativeHostLaunchCommand } from "../src/cli/chrome-cli";
+import { installNativeHost } from "../src/services/native-host-install";
+
+let host: import("bun").Subprocess | undefined;
+let dir = "";
+let sock = "";
+
+async function pgrep(...args: string[]): Promise<number[]> {
+	try {
+		const out = await new Response(Bun.spawn(["pgrep", ...args]).stdout).text();
+		return out
+			.trim()
+			.split("\n")
+			.map(s => Number(s.trim()))
+			.filter(n => Number.isInteger(n) && n > 0 && n !== process.pid);
+	} catch {
+		return [];
+	}
+}
+
+async function managerPids(target: string): Promise<number[]> {
+	try {
+		const out = await new Response(Bun.spawn(["lsof", "-t", target]).stdout).text();
+		return out
+			.trim()
+			.split("\n")
+			.map(s => Number(s.trim()))
+			.filter(n => Number.isInteger(n) && n > 0 && n !== process.pid);
+	} catch {
+		return [];
+	}
+}
+
+function killPid(pid: number): void {
+	try {
+		process.kill(pid);
+	} catch {
+		/* already gone */
+	}
+}
+
+afterEach(async () => {
+	host?.kill();
+	host = undefined;
+	// The manager is DETACHED and its worker blocks forever; discover both via the
+	// temp socket and reap them (mirrors native-host.int.test.ts).
+	if (sock && fs.existsSync(sock)) {
+		const mgrs = await managerPids(sock);
+		for (let i = 0; i < 100; i++) {
+			const workers = (await Promise.all(mgrs.map(m => pgrep("-P", String(m))))).flat();
+			if (workers.length > 0) {
+				for (const w of workers) killPid(w);
+				break;
+			}
+			await Bun.sleep(100);
+		}
+		for (const m of mgrs) killPid(m);
+	}
+	if (dir) {
+		try {
+			fs.rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* best effort */
+		}
+	}
+	dir = "";
+	sock = "";
+}, 30_000);
+
+test("Chrome-style launch of the installed wrapper reaches the relay and ensures the manager", async () => {
+	dir = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-nmh-launch-"));
+	const home = path.join(dir, "home");
+	sock = path.join(dir, "manager.sock");
+
+	// Resolve the DEV launch prefix (bun + abs entry script) deterministically —
+	// force resolveXcshBin to null so we exercise the `bun src/cli.ts` fallback
+	// regardless of whether a compiled `xcsh` happens to be on PATH.
+	const launchCommand = nativeHostLaunchCommand(
+		[process.execPath, path.resolve("src/cli.ts")],
+		process.execPath,
+		() => null,
+	);
+	const manifestPath = installNativeHost({
+		launchCommand,
+		extensionIds: ["klajkjdoehjidngligegnpknogmjjhkc"],
+		home,
+		platform: process.platform,
+	});
+	const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as { path: string };
+
+	// Launch EXACTLY as Chrome does: exec the manifest `path` (the wrapper) with
+	// the calling extension origin as the first argument — never naming chrome-host.
+	host = Bun.spawn([manifest.path, "chrome-extension://klajkjdoehjidngligegnpknogmjjhkc/"], {
+		cwd: process.cwd(),
+		env: { ...process.env, XCSH_MANAGER_SOCK: sock },
+		stdin: "pipe",
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+
+	const stdin = host.stdin as import("bun").FileSink;
+	stdin.write(encodeNm({ type: "provision", tenantKey: "acme|staging" }));
+	stdin.flush();
+
+	let up = false;
+	for (let i = 0; i < 50; i++) {
+		if (fs.existsSync(sock)) {
+			up = true;
+			break;
+		}
+		await Bun.sleep(100);
+	}
+	expect(up).toBe(true); // wrapper → chrome-host → ensured manager (real Chrome path)
+}, 30_000);

--- a/packages/coding-agent/test/native-host.int.test.ts
+++ b/packages/coding-agent/test/native-host.int.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Integration test: `xcsh chrome-host` native-messaging relay.
+ *
+ * Chrome launches `chrome-host` as its native-messaging host. Before relaying it
+ * must ENSURE a detached `xcsh manager` is running: if the manager control socket
+ * is absent/unreachable it spawns one (detached, long-lived) and connects. This
+ * test spawns the host with a temp `XCSH_MANAGER_SOCK`, writes an NM-encoded
+ * `provision` frame to its stdin, and asserts the manager socket APPEARS — proof
+ * the host auto-spawned the manager.
+ *
+ * The spawned manager is DETACHED (it outlives the host on purpose), so killing
+ * the host does NOT reap it. afterEach discovers the manager via `lsof` on the
+ * temp socket and kills it, then removes the temp dir.
+ */
+import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { encodeNm } from "../src/browser/native-messaging";
+
+let host: import("bun").Subprocess | undefined;
+let dir = "";
+let sock = "";
+
+/** PIDs from `pgrep <args>`. Excludes this test process. */
+async function pgrep(...args: string[]): Promise<number[]> {
+	try {
+		const out = await new Response(Bun.spawn(["pgrep", ...args]).stdout).text();
+		return out
+			.trim()
+			.split("\n")
+			.map(s => Number(s.trim()))
+			.filter(n => Number.isInteger(n) && n > 0 && n !== process.pid);
+	} catch {
+		return []; // pgrep unavailable / no match
+	}
+}
+
+/** PIDs holding the temp unix socket open (the detached manager). */
+async function managerPids(target: string): Promise<number[]> {
+	try {
+		const out = await new Response(Bun.spawn(["lsof", "-t", target]).stdout).text();
+		return out
+			.trim()
+			.split("\n")
+			.map(s => Number(s.trim()))
+			.filter(n => Number.isInteger(n) && n > 0 && n !== process.pid);
+	} catch {
+		return [];
+	}
+}
+
+function killPid(pid: number): void {
+	try {
+		process.kill(pid);
+	} catch {
+		/* already gone */
+	}
+}
+
+afterEach(async () => {
+	host?.kill();
+	host = undefined;
+	// The manager is DETACHED; killing the host doesn't reap it, and killing the
+	// manager doesn't reap the worker it spawned. The worker blocks forever, so it
+	// stays a LIVE CHILD of the manager until we kill the manager — poll the manager
+	// for that child (cheap pgrep, no port scan), kill the worker, then the manager.
+	// The socket-appears assertion can win BEFORE the worker is spawned, so poll
+	// briefly; the manager is about to die and won't respawn, so this is race-free.
+	if (sock && fs.existsSync(sock)) {
+		const mgrs = await managerPids(sock);
+		for (let i = 0; i < 100; i++) {
+			const workers = (await Promise.all(mgrs.map(m => pgrep("-P", String(m))))).flat();
+			if (workers.length > 0) {
+				for (const w of workers) killPid(w);
+				break;
+			}
+			await Bun.sleep(100);
+		}
+		for (const m of mgrs) killPid(m);
+	}
+	if (dir) {
+		try {
+			fs.rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* best effort */
+		}
+	}
+	dir = "";
+	sock = "";
+}, 30_000);
+
+test("chrome-host ensures the manager and relays a provision frame", async () => {
+	dir = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-nmh-"));
+	sock = path.join(dir, "manager.sock");
+	host = Bun.spawn(["bun", "src/cli.ts", "chrome-host"], {
+		cwd: process.cwd(),
+		env: { ...process.env, XCSH_MANAGER_SOCK: sock },
+		stdin: "pipe",
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+
+	const stdin = host.stdin as import("bun").FileSink;
+	stdin.write(encodeNm({ type: "provision", tenantKey: "acme|staging" }));
+	stdin.flush();
+
+	let up = false;
+	for (let i = 0; i < 50; i++) {
+		if (fs.existsSync(sock)) {
+			up = true;
+			break;
+		}
+		await Bun.sleep(100);
+	}
+	expect(up).toBe(true); // manager auto-spawned by the host
+}, 30_000);

--- a/packages/coding-agent/test/sdk-context-integration.test.ts
+++ b/packages/coding-agent/test/sdk-context-integration.test.ts
@@ -534,4 +534,66 @@ describe("createAgentSession context tracking", () => {
 			await session.dispose();
 		}
 	});
+
+	it("bootstrap: XCSH_SESSION_TENANT binds the context matching that tenant (extension worker)", async () => {
+		await ContextService.instance.createContext({
+			name: "prod",
+			apiUrl: "https://acme-corp.console.ves.volterra.io/api",
+			apiToken: "t",
+			defaultNamespace: "default",
+		});
+		process.env.XCSH_SESSION_TENANT = "acme-corp|production";
+		try {
+			const { session } = await createAgentSession({
+				cwd,
+				agentDir,
+				settings,
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+			});
+			try {
+				expect(ContextService.instance.getStatus().activeContextName).toBe("prod");
+			} finally {
+				await session.dispose();
+			}
+		} finally {
+			delete process.env.XCSH_SESSION_TENANT;
+		}
+	});
+
+	it("bootstrap: XCSH_SESSION_TENANT with no matching context → contextless (unbound)", async () => {
+		await ContextService.instance.createContext({
+			name: "other",
+			apiUrl: "https://other.console.ves.volterra.io/api",
+			apiToken: "t",
+			defaultNamespace: "default",
+		});
+		process.env.XCSH_SESSION_TENANT = "acme-corp|production";
+		try {
+			const { session } = await createAgentSession({
+				cwd,
+				agentDir,
+				settings,
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+			});
+			try {
+				expect(ContextService.instance.getStatus().activeContextName ?? null).toBeNull();
+			} finally {
+				await session.dispose();
+			}
+		} finally {
+			delete process.env.XCSH_SESSION_TENANT;
+		}
+	});
 });

--- a/packages/coding-agent/test/worker-spawn.int.test.ts
+++ b/packages/coding-agent/test/worker-spawn.int.test.ts
@@ -12,7 +12,7 @@
  * tenant in `hello_ack`, derived from `XCSH_SESSION_TENANT` (`tenant|env`).
  */
 import { afterEach, expect, test } from "bun:test";
-import { EXTENSION_ID } from "@f5-sales-demo/xcsh/cli/chrome-cli";
+import { probe } from "./helpers/bridge-probe";
 
 let proc: import("bun").Subprocess | undefined;
 afterEach(() => {
@@ -35,24 +35,10 @@ test("xcsh worker binds the forced port and advertises its tenant via hello_ack"
 		stderr: "ignore",
 	});
 
-	const origin = `chrome-extension://${EXTENSION_ID}`;
 	const ack = await (async () => {
 		for (let i = 0; i < 60; i++) {
 			try {
-				const r = await new Promise<Record<string, unknown>>((res, rej) => {
-					const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
-						headers: { Origin: origin },
-					} as unknown as string[]);
-					ws.onopen = () =>
-						ws.send(JSON.stringify({ type: "hello", contractVersion: "1.5.0", extensionId: "probe" }));
-					ws.onmessage = e => {
-						res(JSON.parse(e.data as string));
-						ws.close();
-					};
-					ws.onerror = () => rej(new Error("ws"));
-					setTimeout(() => rej(new Error("t")), 500);
-				});
-				return r;
+				return await probe(port);
 			} catch {
 				await Bun.sleep(250);
 			}

--- a/packages/coding-agent/test/worker-spawn.int.test.ts
+++ b/packages/coding-agent/test/worker-spawn.int.test.ts
@@ -49,4 +49,6 @@ test("xcsh worker binds the forced port and advertises its tenant via hello_ack"
 	expect(ack.type).toBe("hello_ack");
 	// Contextless worker: tenant echoed from XCSH_SESSION_TENANT-derived session info.
 	expect(ack.tenant).toBe("probe-tenant");
+	// A contextless worker has no active context, so contextBound is false.
+	expect(ack.contextBound).toBe(false);
 }, 30_000);

--- a/packages/coding-agent/test/worker-spawn.int.test.ts
+++ b/packages/coding-agent/test/worker-spawn.int.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Integration test: `xcsh worker` headless mode.
+ *
+ * Spawns a REAL worker subprocess (`bun src/cli.ts worker`), waits for its
+ * extension bridge to bind the forced `XCSH_BRIDGE_PORT`, then performs the
+ * `hello` / `hello_ack` handshake over a real WebSocket. The worker starts the
+ * bridge WITH origin checking (mirroring main.ts), so the probe presents the
+ * extension's `Origin` header — imported from the same source as the worker's
+ * check so the two never drift.
+ *
+ * The load-bearing assertion is that a CONTEXTLESS worker still advertises its
+ * tenant in `hello_ack`, derived from `XCSH_SESSION_TENANT` (`tenant|env`).
+ */
+import { afterEach, expect, test } from "bun:test";
+import { EXTENSION_ID } from "@f5-sales-demo/xcsh/cli/chrome-cli";
+
+let proc: import("bun").Subprocess | undefined;
+afterEach(() => {
+	proc?.kill();
+	proc = undefined;
+});
+
+test("xcsh worker binds the forced port and advertises its tenant via hello_ack", async () => {
+	const port = 19239;
+	proc = Bun.spawn(["bun", "src/cli.ts", "worker"], {
+		cwd: process.cwd(),
+		env: {
+			...process.env,
+			XCSH_BROWSER_PROVIDER: "extension",
+			XCSH_BRIDGE_PORT: String(port),
+			XCSH_SESSION_TENANT: "probe-tenant|staging",
+			XCSH_API_URL: "",
+		},
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+
+	const origin = `chrome-extension://${EXTENSION_ID}`;
+	const ack = await (async () => {
+		for (let i = 0; i < 60; i++) {
+			try {
+				const r = await new Promise<Record<string, unknown>>((res, rej) => {
+					const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+						headers: { Origin: origin },
+					} as unknown as string[]);
+					ws.onopen = () =>
+						ws.send(JSON.stringify({ type: "hello", contractVersion: "1.5.0", extensionId: "probe" }));
+					ws.onmessage = e => {
+						res(JSON.parse(e.data as string));
+						ws.close();
+					};
+					ws.onerror = () => rej(new Error("ws"));
+					setTimeout(() => rej(new Error("t")), 500);
+				});
+				return r;
+			} catch {
+				await Bun.sleep(250);
+			}
+		}
+		throw new Error("worker never came up");
+	})();
+
+	expect(ack.type).toBe("hello_ack");
+	// Contextless worker: tenant echoed from XCSH_SESSION_TENANT-derived session info.
+	expect(ack.tenant).toBe("probe-tenant");
+}, 30_000);


### PR DESCRIPTION
Closes #1835.

Opening an F5 XC tenant tab in Chrome now brings up an `xcsh` worker for that tenant on its own — no manual per-tenant launch. NM carries only control frames; all data stays on the existing Phase-3 WebSocket transport.

## What's here (xcsh side, T1–T6 + T8)
- **`chrome install-host`** (`services/native-host-install.ts` + `cli/chrome-cli.ts`) — writes a user-level NM host manifest (`com.xcsh.xcsh.chrome_host`, no sudo). The manifest `path` is a generated `0o755` wrapper that execs the resolved `xcsh chrome-host "$@"` (Chrome ignores manifest `args` and passes the extension origin as argv, so a wrapper + a `cli.ts` `chrome-extension://` origin safety-net are what actually reach the relay). Injection-safe POSIX quoting.
- **`manager-core.ts`** — pure registry + control protocol (parse/pickPort/needsProvision/staleKeys), fail-closed.
- **`xcsh manager`** — unix-socket control server at `~/.xcsh/manager.sock`; spawns/reaps per-tenant workers, idle-sweep (~20min), single-manager invariant (bind-first liveness probe, since Bun's `Bun.listen({unix})` silently rebinds), NDJSON per-conn buffering, dead-worker reconciliation. Worker env is isolated (`XCSH_API_URL`/`XCSH_API_TOKEN` cleared so `XCSH_SESSION_TENANT` is authoritative).
- **`xcsh worker`** — headless bridge + one agent session + chat handler; binds the forced port; advertises tenant + `contextBound` in `hello_ack`; context auto-loaded by tenant when `XCSH_SESSION_TENANT` matches a saved context, else contextless.
- **`xcsh chrome-host`** — NM relay + ensure-detached-manager (control-only; data stays on WS).
- **sdk bootstrap** — binds a context by tenant (`resolveAutoBind` extension branch) when `XCSH_SESSION_TENANT` is set.

## Verification
- `bunx tsc -p tsconfig.json --noEmit` clean.
- 31 auto-provisioning tests pass (unit: native-host-install, manager-core, sdk-context-integration; integration: worker-spawn, manager, native-host, **native-host-launch** — the launch-seam test drives the *real written manifest wrapper* with an origin arg, proven RED→GREEN).

Built subagent-driven (TDD per task, spec+quality review each, whole-branch review at the end; the whole-branch review caught the manifest-launch break, now fixed + regression-guarded).

**Ships as a pair with** f5-sales-demo/xcsh-chrome-extension#134 (NM bootstrap client + contextless MOTD hint + `nativeMessaging` permission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)