### PR TITLE
fix(coding-agent): report to herdr over the socket, not the CLI

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/bundled/herdr-reporter.ts
+++ b/packages/coding-agent/src/extensibility/extensions/bundled/herdr-reporter.ts
@@ -1,23 +1,77 @@
+import { connect } from "node:net";
 import type { ExtensionAPI } from "@f5-sales-demo/xcsh";
 
 /**
  * herdr integration (bundled, default-on).
  *
- * Reports xcsh's live agent state to the herdr terminal multiplexer over its
- * socket API so an xcsh pane shows up as a first-class "xcsh" assistant with an
- * idle / working / blocked indicator.
+ * Reports xcsh's live agent state to the herdr terminal multiplexer so an xcsh
+ * pane shows up as a first-class "xcsh" assistant with an idle / working /
+ * blocked indicator.
+ *
+ * Transport: herdr injects `HERDR_SOCKET_PATH` into every pane, so state is
+ * reported by writing a newline-delimited JSON-RPC request straight to that unix
+ * socket. This is PATH-independent — unlike shelling out to the `herdr` CLI,
+ * which silently no-ops when herdr runs as a launchd/`brew services` server and
+ * spawns panes without `/opt/homebrew/bin` on PATH. If `HERDR_SOCKET_PATH` is
+ * somehow unset, we fall back to the `herdr` CLI.
  *
  * xcsh is a fork of pi; a user may have both installed, so this reporter always
  * identifies itself as "xcsh" (never "pi") and claims pane authority via
- * `--source xcsh` so herdr's passive pi-detection heuristics cannot mislabel the
- * pane.
+ * `source: "xcsh"` so herdr's passive pi-detection heuristics cannot mislabel
+ * the pane.
  *
  * The extension is completely inert unless it is running inside a herdr pane
- * (detected via the `HERDR_PANE_ID` environment variable herdr injects), so it
- * has zero effect for users who do not run xcsh under herdr.
+ * (detected via `HERDR_PANE_ID`), so it has zero effect for users who do not run
+ * xcsh under herdr.
  */
 
 const HERDR_AGENT_LABEL = "xcsh";
+const REPORT_METHOD = "pane.report_agent";
+const RELEASE_METHOD = "pane.release_agent";
+const SOCKET_TIMEOUT_MS = 2000;
+
+/**
+ * Write one newline-delimited JSON-RPC request to herdr's unix socket and close.
+ * Fire-and-forget: the response is ignored and every failure path is reported
+ * via `onError` without throwing, so a dead socket never disturbs the agent.
+ */
+function sendToHerdrSocket(
+	socketPath: string,
+	method: string,
+	params: Record<string, unknown>,
+	onError: (err: unknown) => void,
+): void {
+	const conn = connect({ path: socketPath });
+	// Never let a report keep xcsh's event loop alive.
+	conn.unref();
+	conn.once("error", err => {
+		onError(err);
+		conn.destroy();
+	});
+	conn.once("connect", () => {
+		conn.end(`${JSON.stringify({ id: "xcsh:herdr-reporter", method, params })}\n`);
+	});
+	conn.setTimeout(SOCKET_TIMEOUT_MS, () => conn.destroy());
+}
+
+/** Translate a JSON-RPC report/release into `herdr` CLI arguments (fallback). */
+function toCliArgs(method: string, params: Record<string, unknown>): string[] {
+	const subcommand = method === REPORT_METHOD ? "report-agent" : "release-agent";
+	const args = [
+		"pane",
+		subcommand,
+		String(params.pane_id),
+		"--source",
+		String(params.source),
+		"--agent",
+		String(params.agent),
+	];
+	if (params.state !== undefined) {
+		args.push("--state", String(params.state));
+	}
+	args.push("--seq", String(params.seq));
+	return args;
+}
 
 export default function herdrReporter(pi: ExtensionAPI): void {
 	const paneId = process.env.HERDR_PANE_ID;
@@ -33,29 +87,30 @@ export default function herdrReporter(pi: ExtensionAPI): void {
 
 	pi.setLabel(HERDR_AGENT_LABEL);
 
-	// Fire-and-forget: a missing or failing herdr CLI must never disturb the agent.
-	const runHerdr = (args: string[]): void => {
-		pi.exec("herdr", args).catch((err: unknown) => {
-			pi.logger.debug("herdr report failed", {
-				error: err instanceof Error ? err.message : String(err),
-			});
+	const onError = (err: unknown): void => {
+		pi.logger.debug("herdr report failed", {
+			error: err instanceof Error ? err.message : String(err),
 		});
 	};
 
+	const send = (method: string, params: Record<string, unknown>): void => {
+		const socketPath = process.env.HERDR_SOCKET_PATH;
+		if (socketPath) {
+			sendToHerdrSocket(socketPath, method, params, onError);
+			return;
+		}
+		// Fallback for the rare case herdr did not inject a socket path.
+		pi.exec("herdr", toCliArgs(method, params)).catch(onError);
+	};
+
 	const report = (state: "idle" | "working" | "blocked"): void => {
-		runHerdr([
-			"pane",
-			"report-agent",
-			paneId,
-			"--source",
-			HERDR_AGENT_LABEL,
-			"--agent",
-			HERDR_AGENT_LABEL,
-			"--state",
+		send(REPORT_METHOD, {
+			pane_id: paneId,
+			source: HERDR_AGENT_LABEL,
+			agent: HERDR_AGENT_LABEL,
 			state,
-			"--seq",
-			String(seq++),
-		]);
+			seq: seq++,
+		});
 	};
 
 	// Announce presence as soon as the session is initialized.
@@ -87,16 +142,11 @@ export default function herdrReporter(pi: ExtensionAPI): void {
 
 	// Relinquish pane authority so herdr stops showing xcsh once we exit.
 	pi.on("session_shutdown", () => {
-		runHerdr([
-			"pane",
-			"release-agent",
-			paneId,
-			"--source",
-			HERDR_AGENT_LABEL,
-			"--agent",
-			HERDR_AGENT_LABEL,
-			"--seq",
-			String(seq++),
-		]);
+		send(RELEASE_METHOD, {
+			pane_id: paneId,
+			source: HERDR_AGENT_LABEL,
+			agent: HERDR_AGENT_LABEL,
+			seq: seq++,
+		});
 	});
 }

--- a/packages/coding-agent/test/herdr-reporter.test.ts
+++ b/packages/coding-agent/test/herdr-reporter.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
 import { TempDir } from "@f5-sales-demo/pi-utils";
 import type { ExtensionAPI, ExtensionContext } from "@f5-sales-demo/xcsh";
 import herdrReporter from "@f5-sales-demo/xcsh/extensibility/extensions/bundled/herdr-reporter";
@@ -39,26 +43,76 @@ function makeMockPi(): MockPi {
 const idleCtx = { isIdle: () => true } as unknown as ExtensionContext;
 const busyCtx = { isIdle: () => false } as unknown as ExtensionContext;
 
-const reportArgs = (state: string, seq: string): string[] => [
-	"pane",
-	"report-agent",
-	"pane-1",
-	"--source",
-	"xcsh",
-	"--agent",
-	"xcsh",
-	"--state",
-	state,
-	"--seq",
-	seq,
-];
+/** A throwaway unix-socket server that records the JSON-RPC requests it receives. */
+interface FakeHerdr {
+	socketPath: string;
+	received: Array<{ id: string; method: string; params: Record<string, unknown> }>;
+	close: () => Promise<void>;
+}
+
+function startFakeHerdr(): Promise<FakeHerdr> {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "herdr-sock-"));
+	const socketPath = path.join(dir, "herdr.sock");
+	const received: FakeHerdr["received"] = [];
+	const sockets = new Set<net.Socket>();
+	const server = net.createServer(sock => {
+		sockets.add(sock);
+		sock.on("close", () => sockets.delete(sock));
+		sock.on("error", () => {});
+		let buf = "";
+		sock.on("data", chunk => {
+			buf += chunk.toString();
+			let nl = buf.indexOf("\n");
+			while (nl >= 0) {
+				const line = buf.slice(0, nl);
+				buf = buf.slice(nl + 1);
+				if (line.trim()) received.push(JSON.parse(line));
+				nl = buf.indexOf("\n");
+			}
+		});
+	});
+	return new Promise(resolve => {
+		server.listen(socketPath, () => {
+			resolve({
+				socketPath,
+				received,
+				// Destroy any fire-and-forget client sockets so server.close() completes.
+				close: () =>
+					new Promise<void>(res => {
+						for (const s of sockets) s.destroy();
+						server.close(() => {
+							fs.rmSync(dir, { recursive: true, force: true });
+							res();
+						});
+					}),
+			});
+		});
+	});
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+	const start = Date.now();
+	while (!cond()) {
+		if (Date.now() - start > timeoutMs) throw new Error("timed out waiting for condition");
+		await new Promise(r => setTimeout(r, 10));
+	}
+}
+
+const reportMsg = (state: string, seq: number) => ({
+	id: "xcsh:herdr-reporter",
+	method: "pane.report_agent",
+	params: { pane_id: "w1:p1", source: "xcsh", agent: "xcsh", state, seq },
+});
 
 describe("herdr-reporter extension", () => {
 	const originalPaneId = process.env.HERDR_PANE_ID;
+	const originalSocket = process.env.HERDR_SOCKET_PATH;
 
 	afterEach(() => {
 		if (originalPaneId === undefined) delete process.env.HERDR_PANE_ID;
 		else process.env.HERDR_PANE_ID = originalPaneId;
+		if (originalSocket === undefined) delete process.env.HERDR_SOCKET_PATH;
+		else process.env.HERDR_SOCKET_PATH = originalSocket;
 	});
 
 	it("is inert (registers nothing) when not running under herdr", () => {
@@ -72,51 +126,102 @@ describe("herdr-reporter extension", () => {
 		expect(execCalls).toEqual([]);
 	});
 
-	it("labels itself xcsh and reports the full state lifecycle under herdr", async () => {
-		process.env.HERDR_PANE_ID = "pane-1";
-		const { pi, handlers, execCalls, labels } = makeMockPi();
+	it("reports the full state lifecycle over HERDR_SOCKET_PATH (no herdr CLI)", async () => {
+		const herdr = await startFakeHerdr();
+		try {
+			process.env.HERDR_PANE_ID = "w1:p1";
+			process.env.HERDR_SOCKET_PATH = herdr.socketPath;
+			const { pi, handlers, execCalls, labels } = makeMockPi();
+
+			herdrReporter(pi);
+			expect(labels).toEqual(["xcsh"]);
+
+			await handlers.get("session_start")?.({}, idleCtx);
+			await handlers.get("agent_start")?.({}, idleCtx);
+			await handlers.get("agent_end")?.({ messages: [] }, idleCtx);
+
+			await waitFor(() => herdr.received.length >= 3);
+			expect(herdr.received[0]).toEqual(reportMsg("idle", 0));
+			expect(herdr.received[1]).toEqual(reportMsg("working", 1));
+			expect(herdr.received[2]).toEqual(reportMsg("idle", 2));
+			// Socket transport must not shell out to the CLI.
+			expect(execCalls).toEqual([]);
+		} finally {
+			await herdr.close();
+		}
+	});
+
+	it("reports blocked over the socket while a prompt is open, then restores state", async () => {
+		const herdr = await startFakeHerdr();
+		try {
+			process.env.HERDR_PANE_ID = "w1:p1";
+			process.env.HERDR_SOCKET_PATH = herdr.socketPath;
+			const { pi, handlers } = makeMockPi();
+
+			herdrReporter(pi);
+
+			await handlers.get("user_prompt_start")?.({ kind: "select" }, busyCtx);
+			await handlers.get("agent_end")?.({ messages: [] }, busyCtx);
+			await handlers.get("user_prompt_end")?.({ kind: "select" }, busyCtx);
+
+			await waitFor(() => herdr.received.length >= 3);
+			expect(herdr.received[0]).toEqual(reportMsg("blocked", 0));
+			expect(herdr.received[1]).toEqual(reportMsg("blocked", 1));
+			expect(herdr.received[2]).toEqual(reportMsg("working", 2));
+		} finally {
+			await herdr.close();
+		}
+	});
+
+	it("releases pane authority over the socket on shutdown", async () => {
+		const herdr = await startFakeHerdr();
+		try {
+			process.env.HERDR_PANE_ID = "w1:p1";
+			process.env.HERDR_SOCKET_PATH = herdr.socketPath;
+			const { pi, handlers } = makeMockPi();
+
+			herdrReporter(pi);
+			await handlers.get("session_shutdown")?.({}, idleCtx);
+
+			await waitFor(() => herdr.received.length >= 1);
+			expect(herdr.received[0]).toEqual({
+				id: "xcsh:herdr-reporter",
+				method: "pane.release_agent",
+				params: { pane_id: "w1:p1", source: "xcsh", agent: "xcsh", seq: 0 },
+			});
+		} finally {
+			await herdr.close();
+		}
+	});
+
+	it("falls back to the herdr CLI when HERDR_SOCKET_PATH is unset", async () => {
+		process.env.HERDR_PANE_ID = "w1:p1";
+		delete process.env.HERDR_SOCKET_PATH;
+		const { pi, handlers, execCalls } = makeMockPi();
 
 		herdrReporter(pi);
-
-		expect(labels).toEqual(["xcsh"]);
-
-		await handlers.get("session_start")?.({}, idleCtx);
 		await handlers.get("agent_start")?.({}, idleCtx);
-		await handlers.get("agent_end")?.({ messages: [] }, idleCtx);
-
-		expect(execCalls[0]).toEqual({ command: "herdr", args: reportArgs("idle", "0") });
-		expect(execCalls[1]).toEqual({ command: "herdr", args: reportArgs("working", "1") });
-		expect(execCalls[2]).toEqual({ command: "herdr", args: reportArgs("idle", "2") });
-	});
-
-	it("reports blocked while a prompt is open, then restores working/idle", async () => {
-		process.env.HERDR_PANE_ID = "pane-1";
-		const { pi, handlers, execCalls } = makeMockPi();
-
-		herdrReporter(pi);
-
-		await handlers.get("user_prompt_start")?.({ kind: "select" }, busyCtx);
-		expect(execCalls.at(-1)).toEqual({ command: "herdr", args: reportArgs("blocked", "0") });
-
-		// agent_end while a prompt is still open stays blocked, not idle.
-		await handlers.get("agent_end")?.({ messages: [] }, busyCtx);
-		expect(execCalls.at(-1)).toEqual({ command: "herdr", args: reportArgs("blocked", "1") });
-
-		// prompt resolves while still streaming -> working.
-		await handlers.get("user_prompt_end")?.({ kind: "select" }, busyCtx);
-		expect(execCalls.at(-1)).toEqual({ command: "herdr", args: reportArgs("working", "2") });
-	});
-
-	it("releases pane authority on shutdown", async () => {
-		process.env.HERDR_PANE_ID = "pane-1";
-		const { pi, handlers, execCalls } = makeMockPi();
-
-		herdrReporter(pi);
 		await handlers.get("session_shutdown")?.({}, idleCtx);
 
-		expect(execCalls.at(-1)).toEqual({
+		expect(execCalls[0]).toEqual({
 			command: "herdr",
-			args: ["pane", "release-agent", "pane-1", "--source", "xcsh", "--agent", "xcsh", "--seq", "0"],
+			args: [
+				"pane",
+				"report-agent",
+				"w1:p1",
+				"--source",
+				"xcsh",
+				"--agent",
+				"xcsh",
+				"--state",
+				"working",
+				"--seq",
+				"0",
+			],
+		});
+		expect(execCalls[1]).toEqual({
+			command: "herdr",
+			args: ["pane", "release-agent", "w1:p1", "--source", "xcsh", "--agent", "xcsh", "--seq", "1"],
 		});
 	});
 
@@ -128,7 +233,6 @@ describe("herdr-reporter extension", () => {
 			const bundled = result.extensions.find(ext => ext.path === "bundled:herdr-reporter");
 			expect(bundled).toBeDefined();
 			expect(bundled?.handlers.has("agent_start")).toBe(true);
-			// bundled extensions are not user-authored, so the user filter drops them.
 			expect(filterUserExtensions(result.extensions).some(e => e.path === "bundled:herdr-reporter")).toBe(false);
 		} finally {
 			tempDir.removeSync();


### PR DESCRIPTION
## Summary
Hardens the bundled `herdr-reporter` (from #1836) to report state over herdr's unix socket (`HERDR_SOCKET_PATH`) instead of shelling out to the `herdr` CLI, removing the dependency on `herdr` being on the pane's `PATH`.

## Why
The CLI approach silently no-ops when herdr runs as a launchd / `brew services` server: spawned panes get a minimal `PATH` without `/opt/homebrew/bin`, so `herdr` isn't found. This was observed live during the v19.55.0 rollout — a launchd-spawned xcsh pane didn't report until `PATH` was injected. (Fixes #1840.)

## What changed
- Report by writing the newline-delimited JSON-RPC request (`pane.report_agent` / `pane.release_agent`) directly to `HERDR_SOCKET_PATH` (always injected by herdr into panes).
- Socket is `unref()`'d so a report never keeps xcsh's event loop alive; all failures stay `logger.debug`, never thrown.
- Falls back to the `herdr` CLI only if `HERDR_SOCKET_PATH` is unset.
- Still fully inert unless `HERDR_PANE_ID` is set.

## Testing
- Unit tests drive the socket transport **end-to-end against a real `node:net` unix-socket server** (full idle/working/blocked lifecycle, release-on-shutdown), plus the CLI-fallback and inert paths. `7/7` pass.
- Extension suites (discovery/runner/plugin) green; full `biome check .` clean (1269 files); `tsgo` 0 errors.
- **Validated against the real herdr server**: the exact JSON-RPC is accepted (`{"result":{"type":"ok"}}`) and flips the pane's `agent_status` to `working` — with **no `herdr` binary on PATH**, confirming the original launchd issue is resolved.

## Wire format (captured from the herdr CLI, for reference)
```
{"id":"...","method":"pane.report_agent","params":{"pane_id","source","agent","state","seq"}}\n
{"id":"...","method":"pane.release_agent","params":{"pane_id","source","agent","seq"}}\n
```

Closes #1840

🤖 Generated with [Claude Code](https://claude.com/claude-code)