### PR TITLE
Per-tab workers: one worker per Chrome tab, tab-bound tool dispatch

### DIFF
--- a/packages/coding-agent/src/browser/extension-bridge.ts
+++ b/packages/coding-agent/src/browser/extension-bridge.ts
@@ -109,7 +109,13 @@ export class BridgeServer {
 	#sessionId = `sess-${crypto.randomUUID()}`;
 	/** Provider of this process's tenant identity, answering the `hello` handshake. */
 	#sessionInfo:
-		| (() => { tenant: string | null; env: string | null; apiUrl: string | null; contextBound: boolean })
+		| (() => {
+				tenant: string | null;
+				env: string | null;
+				apiUrl: string | null;
+				contextBound: boolean;
+				sessionId: string | null;
+		  })
 		| null = null;
 
 	/** The port the WebSocket server is listening on (0 = not bound). */
@@ -148,17 +154,30 @@ export class BridgeServer {
 	/** Set the tenant-identity provider that answers the extension's `hello`
 	 * handshake with `{ tenant, env, apiUrl }` for THIS xcsh process/context. */
 	setSessionInfo(
-		cb: () => { tenant: string | null; env: string | null; apiUrl: string | null; contextBound: boolean },
+		cb: () => {
+			tenant: string | null;
+			env: string | null;
+			apiUrl: string | null;
+			contextBound: boolean;
+			sessionId: string | null;
+		},
 	): void {
 		this.#sessionInfo = cb;
 	}
 
 	/** Push a tenant change to all connected panels (e.g. after `/context activate`). */
 	broadcastTenantChanged(): void {
-		const info = this.#sessionInfo?.() ?? { tenant: null, env: null, apiUrl: null, contextBound: false };
+		const info = this.#sessionInfo?.() ?? {
+			tenant: null,
+			env: null,
+			apiUrl: null,
+			contextBound: false,
+			sessionId: null,
+		};
 		for (const c of this.#clients.values()) {
 			try {
-				c.send(JSON.stringify({ type: "tenant_changed", sessionId: this.#sessionId, ...info }));
+				// `sessionId` (the tab-correlation key) comes from `info`, matching hello_ack.
+				c.send(JSON.stringify({ type: "tenant_changed", ...info }));
 			} catch {
 				/* client may have dropped */
 			}
@@ -253,12 +272,18 @@ export class BridgeServer {
 			ws.send(JSON.stringify({ type: "pong" }));
 		} else if (msg.type === "hello") {
 			// Identity handshake: tell the extension which tenant this process serves.
-			const info = this.#sessionInfo?.() ?? { tenant: null, env: null, apiUrl: null, contextBound: false };
+			const info = this.#sessionInfo?.() ?? {
+				tenant: null,
+				env: null,
+				apiUrl: null,
+				contextBound: false,
+				sessionId: null,
+			};
 			const { EXTENSION_CONTRACT_VERSION } = require("./capabilities.generated");
 			ws.send(
 				JSON.stringify({
 					type: "hello_ack",
-					sessionId: this.#sessionId,
+					sessionId: info.sessionId,
 					contractVersion: EXTENSION_CONTRACT_VERSION,
 					tenant: info.tenant,
 					env: info.env,

--- a/packages/coding-agent/src/browser/extension-bridge.ts
+++ b/packages/coding-agent/src/browser/extension-bridge.ts
@@ -105,8 +105,6 @@ export class BridgeServer {
 	#onMessage: Array<(msg: Record<string, unknown>) => void> = [];
 	/** Heartbeat interval that sends pings to keep the MV3 service worker alive (sweep + chat). */
 	#heartbeat: ReturnType<typeof setInterval> | null = null;
-	/** Stable per-process session id, advertised to the extension on `hello`. */
-	#sessionId = `sess-${crypto.randomUUID()}`;
 	/** Provider of this process's tenant identity, answering the `hello` handshake. */
 	#sessionInfo:
 		| (() => {
@@ -144,11 +142,6 @@ export class BridgeServer {
 	/** Register a listener for messages not handled by the built-in router (tool_result, ping). */
 	onMessage(cb: (msg: Record<string, unknown>) => void): void {
 		this.#onMessage.push(cb);
-	}
-
-	/** This process's stable session id (advertised on the `hello` handshake). */
-	get sessionId(): string {
-		return this.#sessionId;
 	}
 
 	/** Set the tenant-identity provider that answers the extension's `hello`

--- a/packages/coding-agent/src/commands/manager-core.ts
+++ b/packages/coding-agent/src/commands/manager-core.ts
@@ -1,7 +1,8 @@
 /** Pure worker-registry + control-protocol logic for the manager. No I/O. */
 
 export interface WorkerRec {
-	tenantKey: string; // "tenant|env"
+	sessionId: string; // per-tab session key, e.g. "tab-7"
+	tenant: string; // "tenant|env" — carried for the worker's context env, not the key
 	port: number;
 	pid: number;
 	lastSeen: number; // epoch ms
@@ -10,12 +11,15 @@ export interface WorkerRec {
 export type Registry = Map<string, WorkerRec>;
 
 export type ControlMsg =
-	| { type: "provision"; tenantKey: string }
-	| { type: "release"; tenantKey: string }
+	| { type: "provision"; sessionId: string; tenant: string }
+	| { type: "release"; sessionId: string }
 	| { type: "status" };
 
-function isTenantKey(v: unknown): v is string {
+function isTenant(v: unknown): v is string {
 	return typeof v === "string" && /^[^|]+\|[^|]+$/.test(v);
+}
+function isNonEmpty(v: unknown): v is string {
+	return typeof v === "string" && v.length > 0;
 }
 
 /** Validate an inbound control frame; null if malformed (fail closed). */
@@ -23,15 +27,15 @@ export function parseControlMsg(raw: unknown): ControlMsg | null {
 	if (!raw || typeof raw !== "object") return null;
 	const m = raw as Record<string, unknown>;
 	if (m.type === "status") return { type: "status" };
-	if ((m.type === "provision" || m.type === "release") && isTenantKey(m.tenantKey)) {
-		return { type: m.type, tenantKey: m.tenantKey };
-	}
+	if (m.type === "provision" && isNonEmpty(m.sessionId) && isTenant(m.tenant))
+		return { type: "provision", sessionId: m.sessionId, tenant: m.tenant };
+	if (m.type === "release" && isNonEmpty(m.sessionId)) return { type: "release", sessionId: m.sessionId };
 	return null;
 }
 
-/** Idempotency: only provision when there is no live worker for the key. */
-export function needsProvision(reg: Registry, tenantKey: string): boolean {
-	return !reg.has(tenantKey);
+/** Idempotency: only provision when there is no live worker for the sessionId. */
+export function needsProvision(reg: Registry, sessionId: string): boolean {
+	return !reg.has(sessionId);
 }
 
 /** Lowest free port in the range not already held by a worker. */
@@ -41,9 +45,9 @@ export function pickPort(reg: Registry, range: number[]): number | null {
 	return null;
 }
 
-/** Keys whose worker has been idle longer than idleMs. */
+/** sessionIds whose worker has been idle longer than idleMs. */
 export function staleKeys(reg: Registry, now: number, idleMs: number): string[] {
 	const out: string[] = [];
-	for (const w of reg.values()) if (now - w.lastSeen > idleMs) out.push(w.tenantKey);
+	for (const w of reg.values()) if (now - w.lastSeen > idleMs) out.push(w.sessionId);
 	return out;
 }

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -1,14 +1,16 @@
 /**
  * Manager mode — `xcsh manager`.
  *
- * A detached, long-lived control server that owns the fleet of per-tenant
+ * A detached, long-lived control server that owns the fleet of per-tab
  * `xcsh worker` processes. It listens on a UNIX SOCKET (`~/.xcsh/manager.sock`,
  * override `XCSH_MANAGER_SOCK`) for NDJSON control frames — one JSON object per
  * line — validated by the pure `manager-core` protocol:
  *
- *   {"type":"provision","tenantKey":"acme|staging"}  → spawn a worker (idempotent)
- *   {"type":"release","tenantKey":"acme|staging"}     → kill + forget the worker
- *   {"type":"status"}                                 → accepted; no-op sink
+ *   {"type":"provision","sessionId":"tab-7","tenant":"acme|staging"}
+ *        → spawn a worker for that sessionId (idempotent). The registry is keyed
+ *          on sessionId, so two tabs of the SAME tenant get two workers.
+ *   {"type":"release","sessionId":"tab-7"}  → kill + forget that session's worker
+ *   {"type":"status"}                        → accepted; no-op sink
  *
  * All registry/port/idempotency/idle policy is the pure `manager-core`; this file
  * is the thin I/O shell (socket, spawn, kill, timer) around it. A background sweep
@@ -84,29 +86,30 @@ export default class Manager extends Command {
 		const reg: Registry = new Map();
 		const range = portCandidates();
 
-		const reap = (tenantKey: string): void => {
-			const w = reg.get(tenantKey);
+		const reap = (sessionId: string): void => {
+			const w = reg.get(sessionId);
 			if (!w) return;
 			try {
 				process.kill(w.pid);
 			} catch {
 				/* already gone */
 			}
-			reg.delete(tenantKey);
+			reg.delete(sessionId);
 		};
 
-		const spawnWorker = (tenantKey: string): void => {
+		const spawnWorker = (msg: { sessionId: string; tenant: string }): void => {
 			// Registry-dedupe (pickPort) over only the ports free at the OS level.
 			const port = pickPort(reg, range.filter(isPortFree));
 			if (port === null) {
-				console.error(`[xcsh manager] port range exhausted; cannot provision ${tenantKey}`);
+				console.error(`[xcsh manager] port range exhausted; cannot provision ${msg.sessionId}`);
 				return;
 			}
 			const proc = Bun.spawn([process.execPath, ...workerArgv()], {
 				env: {
 					...process.env,
 					XCSH_BROWSER_PROVIDER: "extension",
-					XCSH_SESSION_TENANT: tenantKey,
+					XCSH_SESSION_ID: msg.sessionId,
+					XCSH_SESSION_TENANT: msg.tenant,
 					XCSH_BRIDGE_PORT: String(port),
 					// Isolate the worker's tenant binding: an ambient XCSH_API_URL in the
 					// manager's env would make sdk.ts skip the XCSH_SESSION_TENANT branch and
@@ -118,16 +121,22 @@ export default class Manager extends Command {
 				stdout: "ignore",
 				stderr: "ignore",
 			});
-			reg.set(tenantKey, { tenantKey, port, pid: proc.pid, lastSeen: Date.now() });
+			reg.set(msg.sessionId, {
+				sessionId: msg.sessionId,
+				tenant: msg.tenant,
+				port,
+				pid: proc.pid,
+				lastSeen: Date.now(),
+			});
 			// Reconcile a dead worker: when THIS process exits (crash, forced-port
 			// EADDRINUSE with no retry, etc.), drop its registry entry so the next
 			// provision respawns instead of finding a zombie. Guard on pid so an
-			// already-respawned entry for the same tenant is never clobbered.
+			// already-respawned entry for the same sessionId is never clobbered.
 			proc.exited.then(() => {
-				const cur = reg.get(tenantKey);
-				if (cur && cur.pid === proc.pid) reg.delete(tenantKey);
+				const cur = reg.get(msg.sessionId);
+				if (cur && cur.pid === proc.pid) reg.delete(msg.sessionId);
 			});
-			console.error(`[xcsh manager] provisioned ${tenantKey} → pid ${proc.pid} on port ${port}`);
+			console.error(`[xcsh manager] provisioned ${msg.sessionId} (${msg.tenant}) → pid ${proc.pid} on port ${port}`);
 		};
 
 		const handleFrame = (line: string): void => {
@@ -142,11 +151,11 @@ export default class Manager extends Command {
 			const msg = parseControlMsg(raw);
 			if (!msg) return; // fail closed on unknown/invalid frames
 			if (msg.type === "provision") {
-				if (needsProvision(reg, msg.tenantKey)) spawnWorker(msg.tenantKey);
-				const w = reg.get(msg.tenantKey);
+				if (needsProvision(reg, msg.sessionId)) spawnWorker(msg);
+				const w = reg.get(msg.sessionId);
 				if (w) w.lastSeen = Date.now(); // touch on every provision (keep-alive)
 			} else if (msg.type === "release") {
-				reap(msg.tenantKey);
+				reap(msg.sessionId);
 			}
 			// "status" is validated but currently a no-op sink.
 		};

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -77,7 +77,7 @@ export function workerArgv(): string[] {
 }
 
 export default class Manager extends Command {
-	static description = "Run the detached control server that spawns/reaps per-tenant workers; blocks forever";
+	static description = "Run the detached control server that spawns/reaps per-tab workers; blocks forever";
 
 	async run(): Promise<void> {
 		const sockPath = process.env.XCSH_MANAGER_SOCK ?? join(homedir(), ".xcsh", "manager.sock");

--- a/packages/coding-agent/src/commands/worker.ts
+++ b/packages/coding-agent/src/commands/worker.ts
@@ -32,7 +32,11 @@ export function sessionInfoForWorker(): {
 	env: string | null;
 	apiUrl: string | null;
 	contextBound: boolean;
+	sessionId: string | null;
 } {
+	// The tab session key the manager spawned this worker for; echoed in hello_ack
+	// so the extension can correlate a discovered worker back to the provisioned tab.
+	const sessionId = process.env.XCSH_SESSION_ID ?? null;
 	let apiUrl: string | null = null;
 	let contextBound = false;
 	try {
@@ -45,15 +49,15 @@ export function sessionInfoForWorker(): {
 	apiUrl = apiUrl ?? process.env.XCSH_API_URL ?? null;
 	if (apiUrl) {
 		const key = sessionKeyFromUrl(apiUrl);
-		return { tenant: key?.tenant ?? null, env: key?.env ?? null, apiUrl, contextBound };
+		return { tenant: key?.tenant ?? null, env: key?.env ?? null, apiUrl, contextBound, sessionId };
 	}
 	// Contextless: the worker's assigned tenant is carried in XCSH_SESSION_TENANT.
 	const raw = process.env.XCSH_SESSION_TENANT;
 	if (raw) {
 		const [tenant, env] = raw.split("|");
-		return { tenant: tenant || null, env: env || null, apiUrl: null, contextBound };
+		return { tenant: tenant || null, env: env || null, apiUrl: null, contextBound, sessionId };
 	}
-	return { tenant: null, env: null, apiUrl: null, contextBound };
+	return { tenant: null, env: null, apiUrl: null, contextBound, sessionId };
 }
 
 /** Browser-automation tool set — identical scoping to `main.ts`'s extension path.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -837,7 +837,14 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 				// Fall back to the env override when no context is active (env-only mode).
 				apiUrl = apiUrl ?? process.env.XCSH_API_URL ?? null;
 				const key = apiUrl ? sessionKeyFromUrl(apiUrl) : null;
-				return { tenant: key?.tenant ?? null, env: key?.env ?? null, apiUrl, contextBound };
+				// Interactive path has no per-tab XCSH_SESSION_ID; workers echo one, this doesn't.
+				return {
+					tenant: key?.tenant ?? null,
+					env: key?.env ?? null,
+					apiUrl,
+					contextBound,
+					sessionId: null,
+				};
 			};
 			bridgeServer.setSessionInfo(readInfo);
 			ContextService.onContextChange(() => bridgeServer?.broadcastTenantChanged());

--- a/packages/coding-agent/test/manager-core.test.ts
+++ b/packages/coding-agent/test/manager-core.test.ts
@@ -10,49 +10,56 @@ import {
 
 function reg(...recs: WorkerRec[]): Registry {
 	const m: Registry = new Map();
-	for (const r of recs) m.set(r.tenantKey, r);
+	for (const r of recs) m.set(r.sessionId, r);
 	return m;
 }
-const W = (tenantKey: string, port: number, lastSeen = 0): WorkerRec => ({ tenantKey, port, pid: 1, lastSeen });
+const W = (sessionId: string, port: number, lastSeen = 0): WorkerRec => ({
+	sessionId,
+	tenant: "acme|production",
+	port,
+	pid: 1,
+	lastSeen,
+});
 
 describe("parseControlMsg", () => {
 	test("valid provision/release/status", () => {
-		expect(parseControlMsg({ type: "provision", tenantKey: "a|staging" })).toEqual({
+		expect(parseControlMsg({ type: "provision", sessionId: "tab-7", tenant: "acme|staging" })).toEqual({
 			type: "provision",
-			tenantKey: "a|staging",
+			sessionId: "tab-7",
+			tenant: "acme|staging",
 		});
-		expect(parseControlMsg({ type: "release", tenantKey: "a|staging" })).toEqual({
-			type: "release",
-			tenantKey: "a|staging",
-		});
+		expect(parseControlMsg({ type: "release", sessionId: "tab-7" })).toEqual({ type: "release", sessionId: "tab-7" });
 		expect(parseControlMsg({ type: "status" })).toEqual({ type: "status" });
 	});
-	test("rejects junk / missing fields / bad tenantKey", () => {
-		expect(parseControlMsg({ type: "provision" })).toBeNull();
-		expect(parseControlMsg({ type: "nope", tenantKey: "a|staging" })).toBeNull();
-		expect(parseControlMsg({ type: "provision", tenantKey: "no-pipe" })).toBeNull();
+	test("rejects junk / missing fields / bad tenant", () => {
+		expect(parseControlMsg({ type: "provision", sessionId: "tab-7" })).toBeNull(); // no tenant
+		expect(parseControlMsg({ type: "provision", tenant: "acme|staging" })).toBeNull(); // no sessionId
+		expect(parseControlMsg({ type: "provision", sessionId: "tab-7", tenant: "no-pipe" })).toBeNull();
+		expect(parseControlMsg({ type: "release" })).toBeNull();
+		expect(parseControlMsg({ type: "nope", sessionId: "tab-7" })).toBeNull();
 		expect(parseControlMsg(null)).toBeNull();
 	});
 });
-
-describe("needsProvision (idempotent)", () => {
+describe("needsProvision (idempotent per sessionId)", () => {
 	test("true when no live worker, false when one exists", () => {
-		expect(needsProvision(reg(), "a|staging")).toBe(true);
-		expect(needsProvision(reg(W("a|staging", 19222)), "a|staging")).toBe(false);
+		expect(needsProvision(reg(), "tab-7")).toBe(true);
+		expect(needsProvision(reg(W("tab-7", 19222)), "tab-7")).toBe(false);
+	});
+	test("two same-tenant sids are independent", () => {
+		const r = reg(W("tab-7", 19222));
+		expect(needsProvision(r, "tab-8")).toBe(true); // same tenant, different tab → still needs its own worker
 	});
 });
-
 describe("pickPort", () => {
-	test("lowest free port in range", () => {
-		expect(pickPort(reg(W("a|staging", 19222)), [19222, 19223, 19224])).toBe(19223);
+	test("lowest free port", () => {
+		expect(pickPort(reg(W("tab-7", 19222)), [19222, 19223, 19224])).toBe(19223);
 	});
 	test("null when exhausted", () => {
 		expect(pickPort(reg(W("a", 19222), W("b", 19223)), [19222, 19223])).toBeNull();
 	});
 });
-
 describe("staleKeys", () => {
-	test("returns keys idle beyond ttl", () => {
+	test("returns sids idle beyond ttl", () => {
 		const now = 100_000;
 		expect(staleKeys(reg(W("a", 19222, now - 40_000), W("b", 19223, now - 5_000)), now, 30_000)).toEqual(["a"]);
 	});

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -117,13 +117,13 @@ test("provision spawns a worker advertising the tenant; release reaps it", async
 	for (let i = 0; i < 60 && !fs.existsSync(sock); i++) await Bun.sleep(100);
 	expect(fs.existsSync(sock)).toBe(true);
 
-	await send({ type: "provision", tenantKey: "acme|staging" });
+	await send({ type: "provision", sessionId: "tab-1", tenant: "acme|staging" });
 
 	const port = await findTenant("acme", 80);
 	expect(port).not.toBeNull();
 
 	// Release should reap the worker: the port stops answering the handshake.
-	await send({ type: "release", tenantKey: "acme|staging" });
+	await send({ type: "release", sessionId: "tab-1" });
 	let stillUp = true;
 	for (let i = 0; i < 40; i++) {
 		try {
@@ -135,6 +135,36 @@ test("provision spawns a worker advertising the tenant; release reaps it", async
 		await Bun.sleep(250);
 	}
 	expect(stillUp).toBe(false);
+}, 60_000);
+
+test("provision spawns one worker PER sessionId (two same-tenant tabs → two workers)", async () => {
+	await startManager();
+
+	// Two tabs of the SAME tenant, keyed by distinct sessionIds. The manager keys
+	// its registry on sessionId, not tenant, so each tab gets its OWN worker on its
+	// own range port — even though both advertise the same tenant "acme".
+	await send({ type: "provision", sessionId: "tab-101", tenant: "acme|staging" });
+	await send({ type: "provision", sessionId: "tab-102", tenant: "acme|staging" });
+
+	// Both workers should come up on distinct range ports, both advertising "acme".
+	const ports = new Set<number>();
+	await (async () => {
+		for (let i = 0; i < 80 && ports.size < 2; i++) {
+			for (const p of RANGE) {
+				try {
+					const a = await probe(p);
+					if (a.tenant === "acme") ports.add(p);
+				} catch {
+					/* worker not up yet on this port */
+				}
+			}
+			await Bun.sleep(250);
+		}
+	})();
+	expect(ports.size).toBe(2);
+
+	await send({ type: "release", sessionId: "tab-101" });
+	await send({ type: "release", sessionId: "tab-102" });
 }, 60_000);
 
 test("an ambient XCSH_API_URL in the manager env does NOT leak into the worker's tenant binding", async () => {
@@ -158,7 +188,7 @@ test("an ambient XCSH_API_URL in the manager env does NOT leak into the worker's
 	for (let i = 0; i < 60 && !fs.existsSync(sock); i++) await Bun.sleep(100);
 	expect(fs.existsSync(sock)).toBe(true);
 
-	await send({ type: "provision", tenantKey: "isolate|staging" });
+	await send({ type: "provision", sessionId: "tab-iso", tenant: "isolate|staging" });
 
 	// The worker must advertise the PROVISIONED tenant, not the ambient apiUrl's.
 	const port = await findTenant("isolate", 80);
@@ -166,7 +196,7 @@ test("an ambient XCSH_API_URL in the manager env does NOT leak into the worker's
 	const leaked = await findTenant("leaktenant", 4);
 	expect(leaked).toBeNull();
 
-	await send({ type: "release", tenantKey: "isolate|staging" });
+	await send({ type: "release", sessionId: "tab-iso" });
 }, 60_000);
 
 test("a provision frame split across two TCP writes is still parsed (NDJSON buffering)", async () => {
@@ -176,7 +206,7 @@ test("a provision frame split across two TCP writes is still parsed (NDJSON buff
 	// so the manager's data handler sees the frame across two separate reads.
 	// Without a per-connection buffer, neither half is valid JSON and the command
 	// is silently dropped → no worker ever comes up.
-	const frame = `${JSON.stringify({ type: "provision", tenantKey: "split|staging" })}\n`;
+	const frame = `${JSON.stringify({ type: "provision", sessionId: "tab-split", tenant: "split|staging" })}\n`;
 	const cut = Math.floor(frame.length / 2);
 	const c = await Bun.connect({ unix: sock, socket: { data() {} } });
 	c.write(frame.slice(0, cut));
@@ -188,13 +218,13 @@ test("a provision frame split across two TCP writes is still parsed (NDJSON buff
 	const port = await findTenant("split", 80);
 	expect(port).not.toBeNull();
 
-	await send({ type: "release", tenantKey: "split|staging" });
+	await send({ type: "release", sessionId: "tab-split" });
 }, 60_000);
 
 test("a worker that dies out of band is reconciled so the next provision respawns", async () => {
 	await startManager();
 
-	await send({ type: "provision", tenantKey: "revive|staging" });
+	await send({ type: "provision", sessionId: "tab-revive", tenant: "revive|staging" });
 	const first = await findTenant("revive", 80);
 	expect(first).not.toBeNull();
 
@@ -222,17 +252,17 @@ test("a worker that dies out of band is reconciled so the next provision respawn
 
 	// Re-provision the SAME tenant. Only possible to come back up if needsProvision
 	// flipped true — i.e. the dead worker was reconciled out of the registry.
-	await send({ type: "provision", tenantKey: "revive|staging" });
+	await send({ type: "provision", sessionId: "tab-revive", tenant: "revive|staging" });
 	const second = await findTenant("revive", 80);
 	expect(second).not.toBeNull();
 
-	await send({ type: "release", tenantKey: "revive|staging" });
+	await send({ type: "release", sessionId: "tab-revive" });
 }, 90_000);
 
 test("a second manager on the same socket detects the live first and self-exits without orphaning it", async () => {
 	// Manager A binds the socket and brings up a live worker.
 	await startManager();
-	await send({ type: "provision", tenantKey: "solo|a" });
+	await send({ type: "provision", sessionId: "tab-solo", tenant: "solo|a" });
 	const portA = await findTenant("solo", 80);
 	expect(portA).not.toBeNull();
 
@@ -256,7 +286,7 @@ test("a second manager on the same socket detects the live first and self-exits 
 
 	// A is UNHARMED: its socket still accepts control frames and still spawns
 	// workers — provision a different tenant and confirm a new worker appears.
-	await send({ type: "provision", tenantKey: "twin|a" });
+	await send({ type: "provision", sessionId: "tab-twin", tenant: "twin|a" });
 	const portTwin = await findTenant("twin", 80);
 	expect(portTwin).not.toBeNull();
 
@@ -264,6 +294,6 @@ test("a second manager on the same socket detects the live first and self-exits 
 	const ackSolo = await probe(portA as number);
 	expect(ackSolo.tenant).toBe("solo");
 
-	await send({ type: "release", tenantKey: "solo|a" });
-	await send({ type: "release", tenantKey: "twin|a" });
+	await send({ type: "release", sessionId: "tab-solo" });
+	await send({ type: "release", sessionId: "tab-twin" });
 }, 90_000);

--- a/packages/coding-agent/test/native-host.int.test.ts
+++ b/packages/coding-agent/test/native-host.int.test.ts
@@ -102,7 +102,7 @@ test("chrome-host ensures the manager and relays a provision frame", async () =>
 	});
 
 	const stdin = host.stdin as import("bun").FileSink;
-	stdin.write(encodeNm({ type: "provision", tenantKey: "acme|staging" }));
+	stdin.write(encodeNm({ type: "provision", sessionId: "tab-1", tenant: "acme|staging" }));
 	stdin.flush();
 
 	let up = false;

--- a/packages/coding-agent/test/worker-spawn.int.test.ts
+++ b/packages/coding-agent/test/worker-spawn.int.test.ts
@@ -29,6 +29,7 @@ test("xcsh worker binds the forced port and advertises its tenant via hello_ack"
 			XCSH_BROWSER_PROVIDER: "extension",
 			XCSH_BRIDGE_PORT: String(port),
 			XCSH_SESSION_TENANT: "probe-tenant|staging",
+			XCSH_SESSION_ID: "tab-probe",
 			XCSH_API_URL: "",
 		},
 		stdout: "ignore",
@@ -49,6 +50,8 @@ test("xcsh worker binds the forced port and advertises its tenant via hello_ack"
 	expect(ack.type).toBe("hello_ack");
 	// Contextless worker: tenant echoed from XCSH_SESSION_TENANT-derived session info.
 	expect(ack.tenant).toBe("probe-tenant");
+	// Worker echoes XCSH_SESSION_ID so the extension can correlate it to the provisioned tab.
+	expect(ack.sessionId).toBe("tab-probe");
 	// A contextless worker has no active context, so contextBound is false.
 	expect(ack.contextBound).toBe(false);
 }, 30_000);


### PR DESCRIPTION
Closes #1843.

Makes the **Chrome tab** the provisioning + binding unit (was: tenant). Fixes the UAT-found bug where browser automation ran in the wrong tab / duplicated across two same-tenant tabs.

## xcsh side (this PR)
- **`manager-core`** rekeyed from `tenantKey` to a per-tab `sessionId` (`sid = "tab-"+tabId`, derived by the extension). `WorkerRec { sessionId, tenant, port, pid, lastSeen }`; control frames `provision {sessionId, tenant}` / `release {sessionId}`; `parseControlMsg` fail-closed.
- **`xcsh manager`** spawns one worker per `sessionId` (two same-tenant tabs → two workers, integration-tested), env `XCSH_SESSION_ID` + `XCSH_SESSION_TENANT` + `XCSH_BRIDGE_PORT`, with `XCSH_API_URL`/`XCSH_API_TOKEN` isolation. Single-manager invariant / NDJSON buffering / idle-sweep unchanged.
- **`xcsh worker`** echoes `XCSH_SESSION_ID` as `hello_ack.sessionId` so the extension can correlate a discovered worker to its tab. Context binding by tenant is unchanged (both same-tenant workers load the same stored context).

Identity (auth/context) stays shared per tenant via the stored context; each worker is bound to one tab.

## Verification
- `bunx tsc -p tsconfig.json --noEmit` clean.
- 15 per-tab tests pass: `manager-core` unit; `manager.int` (two-workers-per-tenant); `worker-spawn.int` (sessionId echo); `native-host.int`.

Built subagent-driven (TDD per task, spec+quality review each, whole-branch review at the end — which composed the rekey chain end-to-end).

**Ships as a pair with** f5-sales-demo/xcsh-chrome-extension#136 (per-tab provision/release + tab-bound tool dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)