### PR TITLE
fix(manager): reclaim a stale control socket instead of crashing on EADDRINUSE

### DIFF
--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -76,6 +76,50 @@ export function workerArgv(): string[] {
 	return reexecArgv("worker");
 }
 
+/**
+ * Acquire the manager control socket, robust across Bun runtimes.
+ *
+ * The single-manager invariant needs three things at once: (1) never clobber a
+ * LIVE manager's socket, (2) reclaim a STALE socket left by a crashed/killed
+ * manager, and (3) survive a concurrent cold-start race. Bun's unix `listen` is
+ * NOT a reliable oracle here — dev `bun run` silently unlinks-and-rebinds a
+ * stale socket, while the COMPILED binary throws EADDRINUSE (xcsh #1846), which
+ * previously crashed the manager and silently killed all automation. So we drive
+ * it explicitly:
+ *
+ *   1. Probe for a live owner. If one answers → we lost; bail ("already-live").
+ *   2. Try to listen. If it binds → done ("bound").
+ *   3. On EADDRINUSE, RE-PROBE: a live answer now means a rival bound between
+ *      our probe and our listen → bail WITHOUT touching its socket. Otherwise
+ *      the file is confirmed stale → unlink it and retry listen once. A still-
+ *      failing retry (or any non-EADDRINUSE error) propagates loudly.
+ *
+ * Effects are injected so the branch logic is unit-tested deterministically
+ * (the compiled-only EADDRINUSE path is unreachable from a dev test otherwise).
+ */
+export async function acquireControlSocket(opts: {
+	sockPath: string;
+	probeLive: (sockPath: string) => Promise<boolean>;
+	listen: () => void;
+	unlink: (sockPath: string) => void;
+	isAddrInUse: (err: unknown) => boolean;
+}): Promise<"bound" | "already-live"> {
+	const { sockPath, probeLive, listen, unlink, isAddrInUse } = opts;
+	if (await probeLive(sockPath)) return "already-live";
+	try {
+		listen();
+		return "bound";
+	} catch (err) {
+		if (!isAddrInUse(err)) throw err;
+		// Bind collided. Distinguish a live rival (lost a cold-start race) from a
+		// stale file left by a crashed manager.
+		if (await probeLive(sockPath)) return "already-live";
+		unlink(sockPath); // confirmed stale → reclaim it
+		listen(); // retry once; a real failure now propagates
+		return "bound";
+	}
+}
+
 export default class Manager extends Command {
 	static description = "Run the detached control server that spawns/reaps per-tab workers; blocks forever";
 
@@ -180,39 +224,35 @@ export default class Manager extends Command {
 			},
 		};
 
-		// Single-manager invariant — probe liveness BEFORE binding.
-		//
-		// Two chrome-hosts can cold-start concurrently, both find no socket, and
-		// both spawn a manager. `Bun.listen({unix})` SILENTLY unlinks and rebinds
-		// any existing socket path — it does NOT throw EADDRINUSE even when a live
-		// manager is accepting on it (verified on Bun 1.3.x, in- and cross-process).
-		// So a naive `listen` would clobber the first manager's socket, leaving it
-		// orphaned on an unlinked path (blocking forever, leaking its worker ports)
-		// while a second live manager takes over — breaking "at most one manager".
-		//
-		// Guard by CONNECTING first: if a live manager answers, this process lost
-		// the race and exits WITHOUT touching the socket file (it belongs to the
-		// live manager). If nothing answers, the path is free or a STALE file from
-		// a crashed manager — either way `Bun.listen` safely (re)binds it (its own
-		// unlink-and-rebind reclaims the stale file; no explicit rm needed).
-		let liveOwner = false;
-		try {
-			const probe = await Promise.race([
-				Bun.connect({ unix: sockPath, socket: { data() {} } }),
-				new Promise<never>((_, reject) =>
-					setTimeout(() => reject(new Error("manager liveness probe timeout")), 500),
-				),
-			]);
-			liveOwner = true;
-			probe.end();
-		} catch {
-			/* nothing accepting → free path, or a stale socket file from a crashed manager */
-		}
-		if (liveOwner) {
+		// Single-manager invariant + stale-socket reclamation. A live manager is
+		// never clobbered (we probe first and again on collision); a stale socket
+		// from a crashed/killed manager is reclaimed rather than crashing on
+		// EADDRINUSE. See acquireControlSocket for the full rationale (xcsh #1846).
+		const probeLive = async (p: string): Promise<boolean> => {
+			try {
+				const probe = await Promise.race([
+					Bun.connect({ unix: p, socket: { data() {} } }),
+					new Promise<never>((_, reject) =>
+						setTimeout(() => reject(new Error("manager liveness probe timeout")), 500),
+					),
+				]);
+				probe.end();
+				return true;
+			} catch {
+				return false; // nothing accepting → free path, or a stale socket file
+			}
+		};
+		const outcome = await acquireControlSocket({
+			sockPath,
+			probeLive,
+			listen: () => Bun.listen(socketConfig),
+			unlink: p => fs.rmSync(p, { force: true }),
+			isAddrInUse: err => (err as { code?: string } | null)?.code === "EADDRINUSE",
+		});
+		if (outcome === "already-live") {
 			console.error(`[xcsh manager] another manager already live at ${sockPath}; exiting`);
 			process.exit(0);
 		}
-		Bun.listen(socketConfig);
 		console.error(`[xcsh manager] control socket listening at ${sockPath}`);
 
 		// Idle sweep: reap workers untouched for longer than the TTL.

--- a/packages/coding-agent/test/acquire-control-socket.test.ts
+++ b/packages/coding-agent/test/acquire-control-socket.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for `acquireControlSocket` — the manager's runtime-robust
+ * control-socket bind. Covers the single-manager invariant AND stale-socket
+ * reclamation without depending on Bun's runtime-specific unix-socket behavior
+ * (dev `bun run` silently rebinds a stale socket; the compiled binary throws
+ * EADDRINUSE — see xcsh #1846). Effects are injected so every branch is
+ * deterministic.
+ */
+import { expect, test } from "bun:test";
+import { acquireControlSocket } from "../src/commands/manager";
+
+const addrInUse = () => Object.assign(new Error("listen EADDRINUSE"), { code: "EADDRINUSE" });
+const isAddrInUse = (e: unknown): boolean => (e as { code?: string } | null)?.code === "EADDRINUSE";
+
+test("a live manager already owns the socket → already-live, never listens or unlinks", async () => {
+	const calls: string[] = [];
+	const outcome = await acquireControlSocket({
+		sockPath: "/tmp/x.sock",
+		probeLive: async () => true,
+		listen: () => calls.push("listen"),
+		unlink: () => calls.push("unlink"),
+		isAddrInUse,
+	});
+	expect(outcome).toBe("already-live");
+	expect(calls).toEqual([]); // must not touch the live manager's socket
+});
+
+test("free path → binds on the first listen, no unlink", async () => {
+	const calls: string[] = [];
+	const outcome = await acquireControlSocket({
+		sockPath: "/tmp/x.sock",
+		probeLive: async () => false,
+		listen: () => calls.push("listen"),
+		unlink: () => calls.push("unlink"),
+		isAddrInUse,
+	});
+	expect(outcome).toBe("bound");
+	expect(calls).toEqual(["listen"]);
+});
+
+test("stale socket file (no live owner) → EADDRINUSE, then unlink + retry listen → bound", async () => {
+	const calls: string[] = [];
+	let listens = 0;
+	const outcome = await acquireControlSocket({
+		sockPath: "/tmp/x.sock",
+		probeLive: async () => false, // dead on both probes
+		listen: () => {
+			calls.push("listen");
+			if (++listens === 1) throw addrInUse(); // compiled-runtime behavior on a stale socket
+		},
+		unlink: () => calls.push("unlink"),
+		isAddrInUse,
+	});
+	expect(outcome).toBe("bound");
+	expect(calls).toEqual(["listen", "unlink", "listen"]); // reclaimed the stale path, then bound
+});
+
+test("EADDRINUSE but a live manager appears on the re-probe (cold-start race) → already-live, no unlink", async () => {
+	const calls: string[] = [];
+	const probes = [false, true]; // free when we first probed; a rival bound before our listen
+	const outcome = await acquireControlSocket({
+		sockPath: "/tmp/x.sock",
+		probeLive: async () => probes.shift() ?? true,
+		listen: () => {
+			calls.push("listen");
+			throw addrInUse();
+		},
+		unlink: () => calls.push("unlink"),
+		isAddrInUse,
+	});
+	expect(outcome).toBe("already-live");
+	expect(calls).toEqual(["listen"]); // must NOT unlink a rival live manager's socket
+});
+
+test("a non-EADDRINUSE listen error propagates (real failure, never swallowed)", async () => {
+	await expect(
+		acquireControlSocket({
+			sockPath: "/tmp/x.sock",
+			probeLive: async () => false,
+			listen: () => {
+				throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+			},
+			unlink: () => {},
+			isAddrInUse,
+		}),
+	).rejects.toThrow("EACCES");
+});
+
+test("if the retry listen still fails, the error propagates (loud, not a phantom bind)", async () => {
+	await expect(
+		acquireControlSocket({
+			sockPath: "/tmp/x.sock",
+			probeLive: async () => false,
+			listen: () => {
+				throw addrInUse();
+			}, // throws every time
+			unlink: () => {},
+			isAddrInUse,
+		}),
+	).rejects.toThrow("EADDRINUSE");
+});

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -297,3 +297,38 @@ test("a second manager on the same socket detects the live first and self-exits 
 	await send({ type: "release", sessionId: "tab-solo" });
 	await send({ type: "release", sessionId: "tab-twin" });
 }, 90_000);
+
+test("a STALE control socket left by a crashed manager is reclaimed on next start (xcsh #1846)", async () => {
+	// Manager A binds, then is SIGKILL'd — SIGKILL runs no cleanup, so the unix
+	// socket file is left on disk with nothing listening (exactly what a crash,
+	// reboot, or `pkill -9` does). A successor manager on the same path must probe
+	// (no live owner), reclaim the stale file, bind, and provision normally —
+	// never crash on EADDRINUSE. (Dev `bun run` silently rebinds a stale socket, so
+	// this guards the full run() wiring end-to-end; the compiled-only EADDRINUSE
+	// branch is covered deterministically in acquire-control-socket.test.ts.)
+	await startManager();
+	mgr?.kill("SIGKILL");
+	await mgr?.exited;
+	mgr = undefined;
+	expect(fs.existsSync(sock)).toBe(true); // a crashed manager leaves its socket file behind
+
+	// Successor manager cold-starts on the SAME (now stale) socket path.
+	mgr = Bun.spawn(["bun", "src/cli.ts", "manager"], {
+		cwd: process.cwd(),
+		env: { ...process.env, XCSH_MANAGER_SOCK: sock },
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+	// A healthy manager blocks forever; a crash-on-EADDRINUSE would exit fast.
+	const outcome = await Promise.race([
+		mgr.exited,
+		new Promise<"alive">(resolve => setTimeout(() => resolve("alive"), 8000)),
+	]);
+	expect(outcome).toBe("alive");
+
+	// And it actually works: provision spawns a real worker.
+	await send({ type: "provision", sessionId: "tab-stale", tenant: "stale|staging" });
+	const port = await findTenant("stale", 80);
+	expect(port).not.toBeNull();
+	await send({ type: "release", sessionId: "tab-stale" });
+}, 60_000);


### PR DESCRIPTION
## What

The manager's single-manager startup probes-then-listens with **no explicit unlink**, relying on `Bun.listen({unix})` to silently rebind a stale socket. That holds in dev (`bun run`) but the **compiled binary throws `EADDRINUSE`** on a leftover socket from a crashed/killed manager — the manager crashes and **no workers are ever provisioned**, silently killing all browser automation until a human `rm`s `~/.xcsh/manager.sock`.

## Fix

New `acquireControlSocket(opts)`:
1. Probe for a live owner → bail `already-live` (never touch its socket).
2. `listen()` → `bound`.
3. On `EADDRINUSE`, **re-probe**: a live answer = cold-start race → bail without unlinking the rival's socket; otherwise the file is confirmed stale → `unlink` + retry `listen` once. Non-EADDRINUSE errors and a still-failing retry propagate loudly (never a phantom bind).

Preserves the single-manager invariant *and* makes the bind runtime-robust.

## Tests (TDD)

- `acquire-control-socket.test.ts` — **6 deterministic unit cases** (injected effects) covering live-owner, free-path, stale-reclaim, cold-start-race, non-EADDRINUSE propagation, and retry-still-fails. The compiled-only EADDRINUSE branch is unreachable from a dev integration test, hence the injection.
- `manager.int.test.ts` — new end-to-end case: SIGKILL a manager (leaves a stale socket), confirm the successor reclaims it and provisions a worker. Full suite: **7 pass**.
- `bunx tsc --noEmit` clean · biome clean.

## Repro this fixes

`pkill -9 xcsh…manager` (or crash/reboot) leaves `manager.sock`; next launch → `listen EADDRINUSE` → `ensureManager: unreachable → exit` → zero workers. Observed live 2026-07-03 on v19.56.0.

Closes #1846