### PR TITLE
fix(worker): register the extension's browser tools so the agent can drive

### DIFF
--- a/packages/coding-agent/scripts/worker-tools-harness.ts
+++ b/packages/coding-agent/scripts/worker-tools-harness.ts
@@ -1,0 +1,151 @@
+// Headless worker-tool harness — no Chrome, no F5 login.
+//
+// Spawns a real `xcsh worker`, connects a MOCK extension bridge client (exactly
+// the hello handshake + origin the real service worker uses), sends a chat_request
+// asking it to navigate, and observes:
+//   (a) which tools the worker's agent actually has (from the daily log), and
+//   (b) whether the agent emits a `navigate` tool_request over the bridge.
+//
+// This isolates the "agent responds but never drives" bug to the WORKER's tool
+// registration, deterministically and repeatably.
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// XCSH_DEV=1 → run the local source build (`bun src/cli.ts worker`) so source
+// edits are testable; otherwise the installed Homebrew binary.
+const XCSH_REPO = new URL("..", import.meta.url).pathname; // packages/coding-agent
+const DEV = process.env.XCSH_DEV === "1";
+const SPAWN_CMD = DEV ? ["bun", "src/cli.ts", "worker"] : ["/opt/homebrew/bin/xcsh", "worker"];
+const SPAWN_CWD = DEV ? XCSH_REPO : process.cwd();
+const EXT_ID = "klajkjdoehjidngligegnpknogmjjhkc";
+const ORIGIN = `chrome-extension://${EXT_ID}`; // bridge origin check: exact, no trailing slash
+const PORT = 19260; // away from the real backend range (19222-19241)
+const TENANT = process.env.HARNESS_TENANT ?? "f5-sales-demo|production";
+const PROMPT = process.env.HARNESS_PROMPT ?? "Navigate the browser to the origin pools list.";
+
+function log(...a: unknown[]) {
+	console.log("[harness]", ...a);
+}
+
+// 1) Spawn the worker with a forced bridge port + tenant identity.
+const worker = Bun.spawn(SPAWN_CMD, {
+	cwd: SPAWN_CWD,
+	env: {
+		...process.env,
+		XCSH_BRIDGE_PORT: String(PORT),
+		XCSH_SESSION_ID: "tab-9999",
+		XCSH_SESSION_TENANT: TENANT,
+	},
+	stdout: "pipe",
+	stderr: "pipe",
+});
+log(`spawned worker pid=${worker.pid} (${DEV ? "DEV build" : "homebrew"}), port=${PORT}, tenant=${TENANT}`);
+
+// Stream worker stderr; resolve when the bridge is listening.
+let bridgeUp = false;
+const decoder = new TextDecoder();
+(async () => {
+	for await (const chunk of worker.stderr) {
+		const s = decoder.decode(chunk);
+		for (const line of s.split("\n")) {
+			if (line.trim()) log("worker⟩", line.trim());
+			if (line.includes("extension bridge listening")) bridgeUp = true;
+		}
+	}
+})();
+
+// Wait for the bridge, then give the (heavier) agent session time to init + attach
+// the chat handler (chatHandler.attach() runs AFTER createAgentSession).
+for (let i = 0; i < 120 && !bridgeUp; i++) await Bun.sleep(250);
+if (!bridgeUp) {
+	log("FAIL: bridge never came up");
+	worker.kill();
+	process.exit(1);
+}
+log("bridge up; waiting 12s for agent session init…");
+await Bun.sleep(12_000);
+
+// 2) Connect the mock extension client with the correct Origin.
+const toolRequests: string[] = [];
+let chatText = "";
+let chatErr: string | null = null;
+let done = false;
+
+const ws = new WebSocket(`ws://127.0.0.1:${PORT}`, { headers: { Origin: ORIGIN } } as unknown as string[]);
+ws.onopen = () => {
+	log("client connected; sending hello");
+	ws.send(JSON.stringify({ type: "hello", contractVersion: "1.5.0", extensionId: "harness" }));
+};
+ws.onerror = () => log("client ws error (origin rejected?)");
+ws.onmessage = e => {
+	let m: Record<string, unknown>;
+	try {
+		m = JSON.parse(e.data as string);
+	} catch {
+		return;
+	}
+	switch (m.type) {
+		case "hello_ack":
+			log(`hello_ack: tenant=${m.tenant} sessionId=${m.sessionId} contractVersion=${m.contractVersion}`);
+			log(`sending chat_request: "${PROMPT}"`);
+			ws.send(
+				JSON.stringify({
+					type: "chat_request",
+					id: "c-harness-1",
+					text: PROMPT,
+					context: null,
+					mode: "configuration",
+				}),
+			);
+			break;
+		case "tool_request":
+			log(`◆ TOOL_REQUEST from agent: tool="${m.tool}" id=${m.id}`);
+			toolRequests.push(m.tool as string);
+			// Reply so the agent's turn can proceed.
+			ws.send(JSON.stringify({ type: "tool_result", id: m.id, content: "ok (harness stub)", is_error: false }));
+			break;
+		case "chat_delta":
+			chatText += (m.delta as string) ?? "";
+			break;
+		case "chat_done":
+			done = true;
+			break;
+		case "chat_error":
+			chatErr = (m.error as string) ?? "unknown";
+			done = true;
+			break;
+	}
+};
+
+// 3) Wait for the turn to finish (or time out).
+for (let i = 0; i < 240 && !done; i++) await Bun.sleep(250);
+
+// 4) Read the worker's actual tool set from the daily log.
+let activeTools = "(not found in daily log)";
+try {
+	const logPath = join(homedir(), ".xcsh", "logs", `xcsh.${new Date().toISOString().slice(0, 10)}.log`);
+	const text = await Bun.file(logPath).text();
+	const lines = text.split("\n").filter(l => l.includes(`"pid":${worker.pid}`) && l.includes("activeToolNames"));
+	if (lines.length) {
+		const parsed = JSON.parse(lines[lines.length - 1]);
+		activeTools = JSON.stringify(parsed.activeToolNames);
+	}
+} catch {}
+
+console.log("\n==================== RESULT ====================");
+console.log("agent tool_requests emitted :", toolRequests.length ? toolRequests.join(", ") : "(none)");
+console.log("worker activeToolNames       :", activeTools);
+console.log("has navigate tool?           :", activeTools.includes('"navigate"') ? "YES" : "NO");
+console.log("emitted a navigate?          :", toolRequests.includes("navigate") ? "YES" : "NO");
+console.log("chat error                   :", chatErr ?? "(none)");
+console.log("agent said (first 240 chars) :", chatText.slice(0, 240).replace(/\n/g, " "));
+if (toolRequests.includes("navigate")) console.log("\n[PASS] worker agent HAS + CALLS navigate — tool registration OK");
+else console.log("\n[FAIL] worker never called navigate — browser tools missing from the agent");
+console.log("===============================================");
+
+try {
+	ws.close();
+} catch {}
+worker.kill();
+await Bun.sleep(300);
+process.exit(0);

--- a/packages/coding-agent/src/browser/extension-bridge-tools.ts
+++ b/packages/coding-agent/src/browser/extension-bridge-tools.ts
@@ -1,0 +1,71 @@
+/**
+ * Agent tools for the Chrome extension's browser actions.
+ *
+ * The extension advertises a fixed set of tools (EXTENSION_CAPABILITIES.tools:
+ * navigate, click, read_ax, type_text, …). Before this factory, those names were
+ * requested by the worker (BROWSER_TOOL_NAMES) but never registered as agent
+ * tools — so the agent could only run the form-driven `catalog_workflow_runner`
+ * and had no way to `navigate`/`click`, i.e. it replied "Navigating…" and never
+ * drove the browser. This turns each advertised tool into a `CustomTool` whose
+ * `execute` proxies the call to the connected extension over the bridge.
+ */
+import type { AgentToolResult, AgentToolUpdateCallback } from "@f5-sales-demo/pi-agent-core";
+import type { TSchema } from "@sinclair/typebox";
+import type { CustomTool, CustomToolContext } from "../extensibility/custom-tools/types";
+import { EXTENSION_CAPABILITIES, type ExtensionToolDef } from "./capabilities.generated";
+import type { BridgeServer } from "./extension-bridge";
+
+/**
+ * Extension tools that are transport/diagnostic plumbing, not agent actions —
+ * never exposed to the LLM. Everything else in EXTENSION_CAPABILITIES becomes a
+ * callable agent tool.
+ */
+const INTERNAL_TOOLS = new Set<string>([
+	"ping",
+	"capabilities",
+	"reload",
+	"debug_exec",
+	"detach",
+	"set_bridge_port",
+	"diag_suspension",
+	"diag_bridges",
+]);
+
+/** Build a CustomTool that proxies one extension tool to `bridge.request`. */
+function bridgeTool(bridge: BridgeServer, def: ExtensionToolDef): CustomTool<TSchema, unknown> {
+	return {
+		name: def.name,
+		label: def.name,
+		description: def.summary,
+		// The extension's JSON-Schema `params` is a TypeBox-compatible schema object.
+		parameters: (def.params ?? { type: "object", properties: {} }) as unknown as TSchema,
+		async execute(
+			_toolCallId: string,
+			params: unknown,
+			_onUpdate: AgentToolUpdateCallback<unknown, TSchema> | undefined,
+			_ctx: CustomToolContext,
+			_signal?: AbortSignal,
+		): Promise<AgentToolResult<unknown, TSchema>> {
+			const res = await bridge.request(def.name, (params ?? {}) as Record<string, unknown>);
+			const raw = typeof res.content === "string" ? res.content : JSON.stringify(res.content);
+			// AgentToolResult has no isError flag — surface the extension's error in the
+			// text so the model sees the failure and can react.
+			const text = res.is_error ? `Error: ${raw}` : raw;
+			return { content: [{ type: "text" as const, text }] };
+		},
+	};
+}
+
+/**
+ * Every agent-facing extension tool as a bridge-proxying CustomTool. Pass the
+ * result to `createAgentSession({ customTools })` so the worker's agent can drive
+ * the browser. Requires `bridge` (the worker's live extension-bridge server).
+ */
+export function createExtensionBridgeTools(bridge: BridgeServer): CustomTool<TSchema, unknown>[] {
+	return EXTENSION_CAPABILITIES.tools.filter(def => !INTERNAL_TOOLS.has(def.name)).map(def => bridgeTool(bridge, def));
+}
+
+/** Names of the agent-facing extension tools (for tool-scoping / tests). */
+export const EXTENSION_AGENT_TOOL_NAMES: readonly string[] = EXTENSION_CAPABILITIES.tools
+	.filter(def => !INTERNAL_TOOLS.has(def.name))
+	.map(def => def.name);

--- a/packages/coding-agent/src/commands/worker.ts
+++ b/packages/coding-agent/src/commands/worker.ts
@@ -17,6 +17,7 @@ import { getProjectDir, getXCSHConfigDir } from "@f5-sales-demo/pi-utils";
 import { Command } from "@f5-sales-demo/pi-utils/cli";
 import { ChatHandler } from "../browser/chat-handler";
 import { startBridgeServer } from "../browser/extension-bridge";
+import { createExtensionBridgeTools, EXTENSION_AGENT_TOOL_NAMES } from "../browser/extension-bridge-tools";
 import { setSharedBridgeServer } from "../browser/provider";
 import { initializeWithSettings } from "../discovery";
 import { createAgentSession } from "../sdk";
@@ -118,10 +119,16 @@ export default class Worker extends Command {
 		bridge.setSessionInfo(sessionInfoForWorker);
 		ContextService.onContextChange(() => bridge.broadcastTenantChanged());
 
+		// The extension's browser actions (navigate/click/read_ax/…) are not builtin
+		// tools — turn each into a bridge-proxying CustomTool so the agent can drive
+		// the browser (without this the agent only has catalog_workflow_runner and
+		// merely narrates "Navigating…"). Include their names in the tool scope.
+		const extensionTools = createExtensionBridgeTools(bridge);
 		const { session } = await createAgentSession({
 			cwd,
 			hasUI: false,
-			toolNames: BROWSER_TOOL_NAMES,
+			toolNames: [...new Set([...BROWSER_TOOL_NAMES, ...EXTENSION_AGENT_TOOL_NAMES])],
+			customTools: extensionTools,
 			// Headless worker: no MCP discovery, no LSP warmup, no extension discovery —
 			// keep startup lean and free of network calls / blocking prompts.
 			enableMCP: false,

--- a/packages/coding-agent/test/extension-bridge-tools.test.ts
+++ b/packages/coding-agent/test/extension-bridge-tools.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Guard for the extension→agent tool bridge. Regression defense for "agent
+ * responds but never drives": the worker requested browser tool names
+ * (navigate/click/…) that were never registered, so the agent could only run
+ * catalog_workflow_runner. `createExtensionBridgeTools` turns every agent-facing
+ * extension capability into a bridge-proxying CustomTool. These tests assert the
+ * core actions exist, internal plumbing is excluded, and calls proxy to the
+ * bridge — no LLM/Chrome required. (End-to-end is covered by the manual
+ * ~/xcsh-uat/worker-tools-harness.ts, which needs a live model.)
+ */
+import { describe, expect, test } from "bun:test";
+import type { BridgeServer } from "../src/browser/extension-bridge";
+import { createExtensionBridgeTools, EXTENSION_AGENT_TOOL_NAMES } from "../src/browser/extension-bridge-tools";
+
+function mockBridge(reply: { content: unknown; is_error: boolean }): BridgeServer {
+	return { request: async () => reply } as unknown as BridgeServer;
+}
+const okBridge = mockBridge({ content: "done", is_error: false });
+
+describe("createExtensionBridgeTools", () => {
+	const tools = createExtensionBridgeTools(okBridge);
+	const names = tools.map(t => t.name);
+
+	test("registers the core browser actions as agent tools", () => {
+		for (const n of ["navigate", "click", "read_ax", "type_text", "screenshot", "login", "query_dom", "scroll_to"]) {
+			expect(names).toContain(n);
+		}
+	});
+
+	test("excludes internal/diagnostic plumbing", () => {
+		for (const n of [
+			"ping",
+			"capabilities",
+			"set_bridge_port",
+			"debug_exec",
+			"detach",
+			"diag_bridges",
+			"diag_suspension",
+		]) {
+			expect(names).not.toContain(n);
+		}
+	});
+
+	test("EXTENSION_AGENT_TOOL_NAMES matches the produced tool set", () => {
+		expect(new Set(EXTENSION_AGENT_TOOL_NAMES)).toEqual(new Set(names));
+		expect(names.length).toBeGreaterThan(15);
+	});
+
+	test("each tool proxies to bridge.request and returns the content as text", async () => {
+		const nav = tools.find(t => t.name === "navigate");
+		expect(nav).toBeDefined();
+		const res = await nav?.execute("id", { url: "https://x" }, undefined, {} as never, undefined);
+		expect((res?.content[0] as { text: string }).text).toBe("done");
+	});
+
+	test("surfaces a bridge error in the result text (no isError flag on AgentToolResult)", async () => {
+		const t = createExtensionBridgeTools(mockBridge({ content: "boom", is_error: true })).find(
+			x => x.name === "click",
+		);
+		const res = await t?.execute("id", {}, undefined, {} as never, undefined);
+		expect((res?.content[0] as { text: string }).text).toContain("Error: ");
+	});
+});


### PR DESCRIPTION
## Problem
The per-tab worker's agent had **no discrete browser tools**. `BROWSER_TOOL_NAMES` requested `navigate/click/read_ax/…` but those aren't builtins and nothing wired the extension's advertised capabilities into the agent — so the agent kept only `catalog_workflow_runner` and a free-form "navigate to X" had no tool to call (it narrated "Navigating…" and never drove). Root-caused via a headless harness: `activeToolNames = [catalog_workflow_runner, find, generate_image]`, no navigate emitted.

## Fix
`createExtensionBridgeTools(bridge)` maps every agent-facing `EXTENSION_CAPABILITIES.tools` entry to a `CustomTool` proxying `bridge.request(name, params)` (internal/diagnostic excluded; errors surfaced in result text — `AgentToolResult` has no isError). `worker.ts` passes them via `createAgentSession({ customTools })` and scopes them in.

## Tests
- `test/extension-bridge-tools.test.ts` — unit guard (core tools present, internals excluded, proxy + error mapping), **no LLM/Chrome**.
- `scripts/worker-tools-harness.ts` — headless E2E: spawns a real worker + mock bridge client, drives a turn. **Before:** 3 tools, no navigate. **After:** 34 tools incl. navigate; agent emits a navigate tool_request → `[PASS]`.
- `bunx tsc` clean · biome clean.

Closes #1849