### PR TITLE
perf(startup): instrument + benchmark extension loading (measure before optimizing)

### DIFF
--- a/packages/coding-agent/bench/extension-loading.ts
+++ b/packages/coding-agent/bench/extension-loading.ts
@@ -1,0 +1,64 @@
+/**
+ * Baseline benchmark for extension loading — the dominant remaining cost in the
+ * blocking startup span (createAgentSession → discoverAndLoadExtensions).
+ *
+ * Run manually:  bun packages/coding-agent/bench/extension-loading.ts
+ *
+ * Reports (self-measured with Bun.nanoseconds() — logger.time spans are not
+ * programmatically readable):
+ *  - cold discoverAndLoadExtensions incl. the one-time app-barrel self-import
+ *  - loadExtensions marginal cost as extension count grows (barrel already warm),
+ *    which reveals the sequential-loop scaling a future Promise.all would address.
+ *
+ * Dynamic import() caches modules, so every fixture uses a UNIQUE filename to
+ * measure real cold-import cost rather than cache hits.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getProjectAgentDir, TempDir } from "@f5-sales-demo/pi-utils";
+import { discoverAndLoadExtensions, loadExtensions } from "../src/extensibility/extensions/loader";
+
+const tempDir = TempDir.createSync("@pi-ext-bench-");
+const extensionsDir = path.join(getProjectAgentDir(tempDir.path()), "extensions");
+fs.mkdirSync(extensionsDir, { recursive: true });
+
+let uid = 0;
+const extSource = (id: string) => `
+	export default function (pi) {
+		const { Type } = pi.typebox;
+		pi.registerTool({
+			name: "tool_${id}",
+			label: "tool_${id}",
+			description: "bench tool",
+			parameters: Type.Object({}),
+			execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+		});
+	}
+`;
+const writeExts = (count: number): string[] =>
+	Array.from({ length: count }, () => {
+		const name = `bench_${uid++}.ts`;
+		const p = path.join(extensionsDir, name);
+		fs.writeFileSync(p, extSource(String(uid)));
+		return p;
+	});
+
+async function measure(label: string, fn: () => Promise<unknown>): Promise<void> {
+	const start = Bun.nanoseconds();
+	await fn();
+	const elapsedMs = (Bun.nanoseconds() - start) / 1e6;
+	console.log(`${label}: ${elapsedMs.toFixed(2)}ms`);
+}
+
+// 1. Cold full discovery+load (first run pays the app-barrel self-import).
+await measure("discoverAndLoadExtensions (cold, incl. barrel + bundled)", () =>
+	discoverAndLoadExtensions([], tempDir.path()),
+);
+
+// 2. Marginal per-extension cost with the barrel already warm.
+for (const n of [1, 4, 8, 16]) {
+	const paths = writeExts(n);
+	await measure(`loadExtensions N=${n} (warm barrel)`, () => loadExtensions(paths, tempDir.path()));
+}
+
+tempDir.removeSync();

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -284,7 +284,7 @@ async function loadExtension(
 	const resolvedPath = resolvePath(extensionPath, cwd);
 
 	try {
-		const module = await import(resolvedPath);
+		const module = await logger.time("ext:loadModule", () => import(resolvedPath));
 		const factory = (module.default ?? module) as ExtensionFactory;
 
 		if (typeof factory !== "function") {
@@ -295,7 +295,13 @@ async function loadExtension(
 		}
 
 		const extension = createExtension(extensionPath, resolvedPath);
-		const api = new ConcreteExtensionAPI(await import("@f5-sales-demo/xcsh"), extension, runtime, cwd, eventBus);
+		const api = new ConcreteExtensionAPI(
+			await logger.time("ext:barrelImport", () => import("@f5-sales-demo/xcsh")),
+			extension,
+			runtime,
+			cwd,
+			eventBus,
+		);
 		await factory(api);
 
 		return { extension, error: null };
@@ -316,7 +322,13 @@ export async function loadExtensionFromFactory(
 	name = "<inline>",
 ): Promise<Extension> {
 	const extension = createExtension(name, name);
-	const api = new ConcreteExtensionAPI(await import("@f5-sales-demo/xcsh"), extension, runtime, cwd, eventBus);
+	const api = new ConcreteExtensionAPI(
+		await logger.time("ext:barrelImport", () => import("@f5-sales-demo/xcsh")),
+		extension,
+		runtime,
+		cwd,
+		eventBus,
+	);
 	await factory(api);
 	return extension;
 }
@@ -540,7 +552,9 @@ export async function discoverAndLoadExtensions(
 	};
 
 	// 1. Discover extension modules via capability API (native .omp/.pi only)
-	const discovered = await loadCapability<ExtensionModule>(extensionModuleCapability.id, { cwd });
+	const discovered = await logger.time("ext:discoverCapability", () =>
+		loadCapability<ExtensionModule>(extensionModuleCapability.id, { cwd }),
+	);
 	for (const ext of discovered.items) {
 		if (ext._source.provider !== "native") continue;
 		if (isDisabledName(ext.name)) continue;
@@ -548,29 +562,31 @@ export async function discoverAndLoadExtensions(
 	}
 
 	// 2. Discover extension entry points from installed plugins (node_modules path)
-	addPaths(await getAllPluginExtensionPaths(cwd));
+	addPaths(await logger.time("ext:pluginPaths", () => getAllPluginExtensionPaths(cwd)));
 
 	// 2b. Discover extension entry points from marketplace-cached plugins
-	for (const root of getPreloadedPluginRoots()) {
-		try {
-			const pkgPath = path.join(root.path, "package.json");
-			const pkg = await Bun.file(pkgPath).json();
-			const manifest = pkg?.xcsh ?? pkg?.pi;
-			const extensions = manifest?.extensions;
-			if (Array.isArray(extensions)) {
-				for (const entry of extensions) {
-					if (typeof entry !== "string") continue;
-					if (path.isAbsolute(entry) || entry.includes("..")) continue;
-					const resolved = path.resolve(root.path, entry);
-					if (!resolved.startsWith(root.path + path.sep) && resolved !== root.path) continue;
-					if (isDisabledName(getExtensionNameFromPath(resolved))) continue;
-					addPath(resolved);
+	await logger.time("ext:marketplaceRoots", async () => {
+		for (const root of getPreloadedPluginRoots()) {
+			try {
+				const pkgPath = path.join(root.path, "package.json");
+				const pkg = await Bun.file(pkgPath).json();
+				const manifest = pkg?.xcsh ?? pkg?.pi;
+				const extensions = manifest?.extensions;
+				if (Array.isArray(extensions)) {
+					for (const entry of extensions) {
+						if (typeof entry !== "string") continue;
+						if (path.isAbsolute(entry) || entry.includes("..")) continue;
+						const resolved = path.resolve(root.path, entry);
+						if (!resolved.startsWith(root.path + path.sep) && resolved !== root.path) continue;
+						if (isDisabledName(getExtensionNameFromPath(resolved))) continue;
+						addPath(resolved);
+					}
 				}
+			} catch {
+				// No package.json or invalid — skip
 			}
-		} catch {
-			// No package.json or invalid — skip
 		}
-	}
+	});
 
 	// 3. Explicitly configured paths
 	for (const configuredPath of configuredPaths) {
@@ -601,7 +617,7 @@ export async function discoverAndLoadExtensions(
 	}
 
 	const resolvedEventBus = eventBus ?? new EventBus();
-	const result = await loadExtensions(allPaths, cwd, resolvedEventBus);
-	await loadBundledExtensions(result, cwd, resolvedEventBus, isDisabledName);
+	const result = await logger.time("ext:loadLoop", () => loadExtensions(allPaths, cwd, resolvedEventBus));
+	await logger.time("ext:loadBundled", () => loadBundledExtensions(result, cwd, resolvedEventBus, isDisabledName));
 	return result;
 }

--- a/packages/coding-agent/test/extension-loading-contract.test.ts
+++ b/packages/coding-agent/test/extension-loading-contract.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getProjectAgentDir, TempDir } from "@f5-sales-demo/pi-utils";
+import { discoverAndLoadExtensions, loadExtensions } from "@f5-sales-demo/xcsh/extensibility/extensions/loader";
+import { filterUserExtensionErrors, filterUserExtensions } from "./utils/filter-user-extensions";
+
+/**
+ * Characterization tests for the extension-loading contract.
+ *
+ * These pin the behavior that a future performance optimization (parallelizing
+ * the load loop, pre-warming the app barrel, caching discovery) MUST preserve.
+ * They assert against current behavior and are expected to stay green through
+ * any such optimization — the "don't lose required functionality" guard.
+ */
+describe("extension loading contract", () => {
+	let tempDir: TempDir;
+	let extensionsDir: string;
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-ext-contract-");
+		extensionsDir = path.join(getProjectAgentDir(tempDir.path()), "extensions");
+		fs.mkdirSync(extensionsDir, { recursive: true });
+	});
+	afterEach(() => {
+		tempDir.removeSync();
+	});
+
+	/** Write an extension source file into extensions/ and return its absolute path. */
+	const writeExt = (name: string, body: string): string => {
+		const p = path.join(extensionsDir, name);
+		fs.writeFileSync(p, body);
+		return p;
+	};
+
+	const toolAndCommand = (id: string) => `
+		export default function (pi) {
+			const { Type } = pi.typebox;
+			pi.registerCommand("cmd_${id}", { handler: async () => {} });
+			pi.registerTool({
+				name: "tool_${id}",
+				label: "tool_${id}",
+				description: "Test tool ${id}",
+				parameters: Type.Object({}),
+				execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+			});
+		}
+	`;
+
+	const providerExt = (name: string) => `
+		export default function (pi) {
+			pi.registerProvider("${name}", { models: [] });
+		}
+	`;
+
+	// --- Registration contract ---
+
+	it("registers tools and commands from a loaded extension, with no errors", async () => {
+		writeExt("foo.ts", toolAndCommand("foo"));
+
+		const result = await discoverAndLoadExtensions([], tempDir.path());
+		const extensions = filterUserExtensions(result.extensions);
+		const errors = filterUserExtensionErrors(result.errors);
+
+		expect(errors).toHaveLength(0);
+		expect(extensions).toHaveLength(1);
+		expect([...extensions[0].tools.keys()]).toContain("tool_foo");
+		expect([...extensions[0].commands.keys()]).toContain("cmd_foo");
+	});
+
+	it("surfaces service-status and flag registrations on the loaded extension", async () => {
+		writeExt(
+			"svc.ts",
+			`
+			export default function (pi) {
+				pi.registerServiceStatus({ name: "MySvc", check: async () => ({ state: "connected" }) });
+				pi.registerFlag("myflag", { type: "boolean", default: true });
+			}
+		`,
+		);
+
+		const result = await discoverAndLoadExtensions([], tempDir.path());
+		const ext = filterUserExtensions(result.extensions)[0];
+
+		expect(ext).toBeDefined();
+		expect([...ext.serviceStatuses.keys()]).toContain("MySvc");
+		expect([...ext.flags.keys()]).toContain("myflag");
+	});
+
+	// --- Ordering contract (the property most at risk under parallelization) ---
+	// loadExtensions() takes an explicit ordered path list; the result must follow it.
+
+	it("preserves input path order in the loaded extensions", async () => {
+		const paths = [
+			writeExt("a.ts", toolAndCommand("a")),
+			writeExt("b.ts", toolAndCommand("b")),
+			writeExt("c.ts", toolAndCommand("c")),
+		];
+
+		const result = await loadExtensions(paths, tempDir.path());
+
+		expect(result.errors).toHaveLength(0);
+		expect(result.extensions.map(e => path.basename(e.path))).toEqual(["a.ts", "b.ts", "c.ts"]);
+	});
+
+	it("preserves input order of provider registrations with correct sourceId", async () => {
+		const paths = [
+			writeExt("p1.ts", providerExt("prov_one")),
+			writeExt("p2.ts", providerExt("prov_two")),
+			writeExt("p3.ts", providerExt("prov_three")),
+		];
+
+		const result = await loadExtensions(paths, tempDir.path());
+		const regs = result.runtime.pendingProviderRegistrations;
+
+		expect(regs.map(r => r.name)).toEqual(["prov_one", "prov_two", "prov_three"]);
+		expect(regs.map(r => path.basename(r.sourceId))).toEqual(["p1.ts", "p2.ts", "p3.ts"]);
+	});
+
+	// --- Partial-failure isolation ---
+
+	it("captures a throwing extension in errors without blocking the others", async () => {
+		const paths = [
+			writeExt("ok1.ts", toolAndCommand("ok1")),
+			writeExt("boom.ts", `export default function () { throw new Error("kaboom"); }`),
+			writeExt("ok2.ts", toolAndCommand("ok2")),
+		];
+
+		const result = await loadExtensions(paths, tempDir.path());
+
+		expect(result.extensions.map(e => path.basename(e.path))).toEqual(["ok1.ts", "ok2.ts"]);
+		expect(result.errors).toHaveLength(1);
+		expect(path.basename(result.errors[0].path)).toBe("boom.ts");
+		expect(result.errors[0].error).toMatch(/kaboom/);
+	});
+
+	it("captures a non-function export as an error without blocking the others", async () => {
+		const paths = [writeExt("bad.ts", `export default 42;`), writeExt("good.ts", toolAndCommand("good"))];
+
+		const result = await loadExtensions(paths, tempDir.path());
+
+		expect(result.extensions.map(e => path.basename(e.path))).toEqual(["good.ts"]);
+		expect(result.errors.map(e => path.basename(e.path))).toEqual(["bad.ts"]);
+	});
+
+	// --- Perf guard (catastrophic-regression only; NOT a tight budget) ---
+	// Generous bound following test/tools/render-mermaid-tool.test.ts — single run,
+	// large margin. Guards against a pathological load-time regression, not micro-perf.
+
+	it("cold-loads a fixture set within a generous time budget", async () => {
+		const paths = Array.from({ length: 6 }, (_, i) => writeExt(`perf${i}.ts`, toolAndCommand(`perf${i}`)));
+
+		const start = Bun.nanoseconds();
+		const result = await loadExtensions(paths, tempDir.path());
+		const elapsedMs = (Bun.nanoseconds() - start) / 1e6;
+
+		expect(result.extensions).toHaveLength(6);
+		expect(result.errors).toHaveLength(0);
+		// Catastrophic-regression guard; typical dev load is well under this.
+		expect(elapsedMs).toBeLessThan(20_000);
+	});
+});


### PR DESCRIPTION
Closes #1855

Measurement-first pass on the next startup target — `createAgentSession` → `discoverAndLoadExtensions` (~888ms in **dev**). **No optimization in this PR**; it adds the instrumentation, the functional guard, and the baseline data to decide what (if anything) to optimize.

## Changes
- **`loader.ts`** — `logger.time("ext:*")` sub-spans around the barrel self-import, per-extension import, the capability/plugin/marketplace discovery phases, the load loop, and bundled load. Pure instrumentation (each call still runs once, in order).
- **`test/extension-loading-contract.test.ts`** — characterization tests pinning the loading contract a future optimization must keep green: tool/command + service-status/flag registration, **deterministic load ordering** and **provider-registration ordering** (via `loadExtensions`' explicit path list — the property most at risk under parallelization), partial-failure isolation, plus a generous catastrophic-regression perf guard.
- **`bench/extension-loading.ts`** — baseline benchmark (`Bun.nanoseconds()`), unique fixture files per run to defeat the module cache.

## Baseline data (the point of this PR)

| Measurement | Result |
|---|---|
| Isolated bench, cold `discoverAndLoadExtensions` (empty project) | **~583ms** — dominated by the one-time app-barrel self-import |
| Isolated bench, `loadExtensions` load loop, 16 extensions | **~2–4ms** — the sequential loop is **not** a bottleneck |
| Real startup `discoverAndLoadExtensions`, **dev** (`bun src/cli.ts`) | ~389ms |
| Real startup `discoverAndLoadExtensions`, **compiled** (`dist/xcsh`) | **~165ms** |

**Takeaways for the follow-up:**
- The dev 888ms figure **overstates the compiled/production cost ~2.4×** (transpile-on-the-fly). Users run the compiled binary where extension loading is ~165ms.
- **Load-loop parallelization is a non-target** (~2–4ms for 16 extensions).
- In isolation the app-barrel self-import dominates; in-situ it's pre-warmed by earlier startup imports, so `ext:barrelImport` falls under the 5ms noise floor and the cost spreads across real extension module evaluation.

## How to reproduce
- Bench: `bun packages/coding-agent/bench/extension-loading.ts`
- Dev spans: `PI_TIMING=x bun --cwd=packages/coding-agent src/cli.ts` → read `ext:*` from stderr
- Compiled spans (after `bun --cwd=packages/coding-agent run build`): `PI_TIMING=x ./packages/coding-agent/dist/xcsh`

Note: the compiled numbers above came from a **stale** prebuilt `dist/xcsh` (pre-instrumentation), so it shows the outer `discoverAndLoadExtensions` total but not the new `ext:*` sub-spans. A rebuild will surface the compiled barrel-vs-eval split — the data that decides whether a barrel pre-warm/lazy-`api.pi` change is worth it.

## Verification
- `tsgo --noEmit`: 0 errors · `biome check`: clean.
- `bun test packages/coding-agent/test/extension-loading-contract.test.ts` → 7 pass.
- `bun test .../extensions-discovery.test.ts .../extensions-runner.test.ts` → still green (instrumentation changed no behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)