### PR TITLE
perf(session): instrument + benchmark per-tab extension session load/unload

### DIFF
--- a/packages/coding-agent/bench/extension-session.ts
+++ b/packages/coding-agent/bench/extension-session.ts
@@ -1,0 +1,223 @@
+/**
+ * Baseline benchmark for per-tab extension SESSION load/unload — the metric behind
+ * "make session loading/unloading as fast as possible".
+ *
+ * A per-tab session is a worker PROCESS the manager spawns (manager.ts:151,
+ * `Bun.spawn([execPath, "worker"], …)`, one per tab). This benchmark spawns real
+ * workers the same way and self-times the lifecycle, complementing #1856's in-process
+ * extension-loader benchmark (bench/extension-loading.ts).
+ *
+ * Run manually:  bun packages/coding-agent/bench/extension-session.ts
+ *
+ * Reports (self-measured with Bun.nanoseconds(), median of N runs):
+ *  - bridge-ready:  spawn → the bridge is LISTENING (the INSTANT-ON latency before the
+ *                   extension can connect; bridge starts before the heavy session init —
+ *                   main.ts:797 / worker.ts:114). Detected with an HTTP probe: the worker
+ *                   enforces an Origin check, so a real hello/hello_ack needs the
+ *                   extension's origin — but a bound port answering HTTP (403/426) is a
+ *                   faithful "port is up and accepting" proxy.
+ *  - session-ready: spawn → ChatHandler attached. Measured by running the worker with
+ *                   PI_TIMING=x, which prints the session:* span split then exits(0)
+ *                   right after attach(). This is the true per-tab session-load cost.
+ *  - unload:        graceful SIGTERM AFTER session-ready → process exit. Exercises the
+ *                   real teardown (chatHandler.dispose + bridge.close, worker.ts:143-150)
+ *                   the manager's `release` triggers — not a raw kill mid-init.
+ *
+ * Dev (bun src/cli.ts worker) and, if present, the compiled binary (dist/xcsh worker)
+ * — the compiled number is the real per-tab floor users pay, per PR #1856 (~165ms
+ * binary cold-start). Because each tab = a fresh worker process boot, binary-startup
+ * wins propagate directly to session-ready. That link is what this benchmark quantifies.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const CLI = path.join(import.meta.dir, "../src/cli.ts");
+const COMPILED = path.join(import.meta.dir, "../dist/xcsh");
+const RUNS = 5; // cheap phases (bridge-ready, unload)
+const SESSION_RUNS = 3; // session-ready spawns a full createAgentSession — fewer runs
+const CONNECT_TIMEOUT_MS = 1_000;
+const READY_DEADLINE_MS = 30_000;
+const SESSION_DEADLINE_MS = 60_000;
+// Settle window before the graceful-unload SIGTERM: long enough that createAgentSession
+// + attach() have completed (session-ready lands ~0.2-1s after spawn) so the worker's
+// SIGTERM handler is installed. NOT part of any measured interval.
+const UNLOAD_SETTLE_MS = 2_500;
+
+const sleep = (ms: number): Promise<void> => new Promise(r => setTimeout(r, ms));
+
+const median = (xs: number[]): number => {
+	const s = [...xs].sort((a, b) => a - b);
+	const m = Math.floor(s.length / 2);
+	return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+};
+
+/** Find a free port in the manager's discovery range (19222-19241) to force via
+ * XCSH_BRIDGE_PORT — mirrors manager.ts so resolveForcedPort accepts it. */
+function pickFreePort(): number {
+	for (let p = 19222; p <= 19241; p++) {
+		try {
+			const s = Bun.serve({ port: p, hostname: "127.0.0.1", fetch: () => new Response("") });
+			s.stop(true);
+			return p;
+		} catch {
+			/* in use — try next */
+		}
+	}
+	throw new Error("no free port in 19222-19241 (is a manager or another app on the range?)");
+}
+
+function spawnWorker(cmd: string[], port: number, extraEnv: Record<string, string>) {
+	return Bun.spawn(cmd, {
+		env: {
+			...process.env,
+			XCSH_BROWSER_PROVIDER: "extension",
+			XCSH_SESSION_ID: "tab-bench",
+			XCSH_SESSION_TENANT: "acme|staging",
+			XCSH_BRIDGE_PORT: String(port),
+			// Isolate the tenant binding exactly as manager.ts does (undefined removes the var).
+			XCSH_API_URL: undefined,
+			XCSH_API_TOKEN: undefined,
+			...extraEnv,
+		},
+		stdout: "ignore",
+		stderr: extraEnv.PI_TIMING ? "pipe" : "ignore",
+	});
+}
+
+/** True once the bridge is listening. The worker enforces an Origin check
+ * (startBridgeServer with no skipOriginCheck), so a fake WS client is rejected — but
+ * ANY HTTP response (403 bad-origin / 426 upgrade-required) proves the port is bound
+ * and answering. Connection-refused (fetch throws) means not-yet. This is an
+ * origin-independent, faithful "extension can connect" signal. */
+async function bridgeListening(port: number): Promise<boolean> {
+	try {
+		await fetch(`http://127.0.0.1:${port}`, { signal: AbortSignal.timeout(CONNECT_TIMEOUT_MS) });
+		return true; // got an HTTP status → the bridge server is up
+	} catch {
+		return false; // ECONNREFUSED / timeout → not listening yet
+	}
+}
+
+/** Poll until the bridge is listening or the deadline passes. */
+async function waitBridgeReady(port: number, deadlineMs: number): Promise<boolean> {
+	const end = Bun.nanoseconds() + deadlineMs * 1e6;
+	while (Bun.nanoseconds() < end) {
+		if (await bridgeListening(port)) return true;
+		await sleep(25);
+	}
+	return false;
+}
+
+async function measureBridgeReady(cmd: string[]): Promise<number> {
+	const port = pickFreePort();
+	const t0 = Bun.nanoseconds();
+	const proc = spawnWorker(cmd, port, {});
+	try {
+		if (!(await waitBridgeReady(port, READY_DEADLINE_MS))) throw new Error("bridge never became ready");
+		return (Bun.nanoseconds() - t0) / 1e6;
+	} finally {
+		proc.kill();
+		await proc.exited;
+	}
+}
+
+async function measureSessionReady(cmd: string[]): Promise<{ ms: number; spans: string }> {
+	const port = pickFreePort();
+	const t0 = Bun.nanoseconds();
+	// PI_TIMING=x → worker prints session:* spans then exit(0) right after attach().
+	const proc = spawnWorker(cmd, port, { PI_TIMING: "x" });
+	// .catch so a stream torn down by kill() never becomes an unhandled rejection.
+	const stderrText = new Response(proc.stderr as ReadableStream).text().catch(() => "");
+	// proc.exited resolves to the exit code; race it against the deadline.
+	const outcome = await Promise.race([proc.exited, sleep(SESSION_DEADLINE_MS).then(() => "timeout" as const)]);
+	if (outcome === "timeout") {
+		proc.kill();
+		await proc.exited;
+		await stderrText;
+		throw new Error("session never became ready (createAgentSession did not complete — model/login configured?)");
+	}
+	// A crashed/failed worker exits FAST and non-zero — never record that as a quick success.
+	if (outcome !== 0) {
+		await stderrText;
+		throw new Error(`worker exited ${outcome} before session-ready (see stderr — model/login configured?)`);
+	}
+	const ms = (Bun.nanoseconds() - t0) / 1e6;
+	const spans =
+		(await stderrText)
+			.split("\n")
+			.map(l => l.trim())
+			.filter(l => l.includes("session:"))
+			.join("  ") || "(no session:* spans over the 5ms log threshold)";
+	return { ms, spans };
+}
+
+async function measureUnload(cmd: string[]): Promise<number> {
+	const port = pickFreePort();
+	const proc = spawnWorker(cmd, port, {});
+	try {
+		if (!(await waitBridgeReady(port, READY_DEADLINE_MS))) throw new Error("bridge never became ready");
+		// Wait past session-ready so the worker's SIGTERM handler is installed (worker.ts
+		// registers it only after createAgentSession + attach). Without this we'd measure a
+		// default-action kill mid-init, not the graceful dispose the manager's release triggers.
+		await sleep(UNLOAD_SETTLE_MS);
+		const t1 = Bun.nanoseconds();
+		proc.kill(); // SIGTERM → graceful shutdown() (chatHandler.dispose + bridge.close → exit 0)
+		await proc.exited;
+		return (Bun.nanoseconds() - t1) / 1e6;
+	} finally {
+		try {
+			proc.kill();
+		} catch {
+			/* already gone */
+		}
+		await proc.exited;
+	}
+}
+
+async function repeat(n: number, fn: () => Promise<number>): Promise<number[]> {
+	const out: number[] = [];
+	for (let i = 0; i < n; i++) out.push(await fn());
+	return out;
+}
+
+async function runSuite(label: string, cmd: string[]): Promise<void> {
+	console.log(`\n=== ${label} ===`);
+
+	try {
+		const bridge = await repeat(RUNS, () => measureBridgeReady(cmd));
+		console.log(`bridge-ready (spawn → listening):      ${median(bridge).toFixed(1)}ms  (median of ${RUNS})`);
+	} catch (e) {
+		console.log(`bridge-ready: N/A — ${(e as Error).message}`);
+	}
+
+	try {
+		const session: number[] = [];
+		let spans = "";
+		for (let i = 0; i < SESSION_RUNS; i++) {
+			const r = await measureSessionReady(cmd);
+			session.push(r.ms);
+			spans = r.spans;
+		}
+		console.log(`session-ready (spawn → attached):      ${median(session).toFixed(1)}ms  (median of ${SESSION_RUNS})`);
+		console.log(`  span split (last run): ${spans}`);
+	} catch (e) {
+		console.log(`session-ready: N/A — ${(e as Error).message}`);
+	}
+
+	try {
+		const unload = await repeat(RUNS, () => measureUnload(cmd));
+		console.log(`unload (graceful SIGTERM → exit):      ${median(unload).toFixed(1)}ms  (median of ${RUNS})`);
+	} catch (e) {
+		console.log(`unload: N/A — ${(e as Error).message}`);
+	}
+}
+
+await runSuite("dev (bun src/cli.ts worker)", [process.execPath, CLI, "worker"]);
+
+if (fs.existsSync(COMPILED)) {
+	await runSuite("compiled (dist/xcsh worker)", [COMPILED, "worker"]);
+} else {
+	console.log(`\n(compiled binary ${path.relative(process.cwd(), COMPILED)} not found — run \`bun run build\` to include it)`);
+}
+
+process.exit(0);

--- a/packages/coding-agent/src/commands/worker.ts
+++ b/packages/coding-agent/src/commands/worker.ts
@@ -13,7 +13,7 @@
  * `XCSH_SESSION_TENANT` so it advertises its assigned tenant even before a context
  * is bound. This lets the extension panel lock onto the right tenant immediately.
  */
-import { getProjectDir, getXCSHConfigDir } from "@f5-sales-demo/pi-utils";
+import { getProjectDir, getXCSHConfigDir, logger } from "@f5-sales-demo/pi-utils";
 import { Command } from "@f5-sales-demo/pi-utils/cli";
 import { ChatHandler } from "../browser/chat-handler";
 import { startBridgeServer } from "../browser/extension-bridge";
@@ -90,6 +90,12 @@ export default class Worker extends Command {
 	static description = "Run a headless extension-bridge worker (no TUI); blocks until SIGTERM";
 
 	async run(): Promise<void> {
+		// Record the per-tab session-boot timeline (parity with main.ts:runRootCommand).
+		// Spans only accumulate while recording; nothing prints unless PI_TIMING is set,
+		// and each logger.time() returns its wrapped value unchanged — so a normal
+		// `xcsh worker` run is behaviorally identical to before.
+		logger.startTiming();
+
 		process.env.XCSH_BROWSER_PROVIDER = "extension";
 
 		const cwd = getProjectDir();
@@ -113,7 +119,9 @@ export default class Worker extends Command {
 
 		// INSTANT-ON: start the bridge before the heavy session init so the extension
 		// can connect immediately. Honors XCSH_BRIDGE_PORT (forced) or auto-selects.
-		const bridge = await startBridgeServer();
+		// session:bridgeListen — time-to-"bridge-ready": the extension can connect and
+		// complete the hello/hello_ack handshake once this resolves (INSTANT-ON path).
+		const bridge = await logger.time("session:bridgeListen", startBridgeServer);
 		console.error(`[xcsh worker] extension bridge listening on ws://127.0.0.1:${bridge.port}`);
 		setSharedBridgeServer(bridge);
 		bridge.setSessionInfo(sessionInfoForWorker);
@@ -124,7 +132,10 @@ export default class Worker extends Command {
 		// the browser (without this the agent only has catalog_workflow_runner and
 		// merely narrates "Navigating…"). Include their names in the tool scope.
 		const extensionTools = createExtensionBridgeTools(bridge);
-		const { session } = await createAgentSession({
+		// session:createAgentSession — the heavy step between bridge-ready and
+		// session-ready (model registry, tools, context bootstrap). Wrapped as a span
+		// (parity with main.ts:892) so PI_TIMING reveals the per-tab session-load split.
+		const { session } = await logger.time("session:createAgentSession", createAgentSession, {
 			cwd,
 			hasUI: false,
 			toolNames: [...new Set([...BROWSER_TOOL_NAMES, ...EXTENSION_AGENT_TOOL_NAMES])],
@@ -138,6 +149,17 @@ export default class Worker extends Command {
 
 		const chatHandler = new ChatHandler(bridge, session);
 		chatHandler.attach();
+
+		// session-ready. Emit the per-tab boot breakdown when requested (parity with
+		// main.ts:1002-1009). PI_TIMING=x prints then exits — used by bench/extension-session.ts
+		// to measure total worker cold-start; otherwise this is a no-op.
+		if (process.env.PI_TIMING) {
+			logger.printTimings();
+			if (process.env.PI_TIMING === "x") {
+				process.exit(0);
+			}
+		}
+		logger.endTiming();
 
 		let shuttingDown = false;
 		const shutdown = () => {

--- a/packages/coding-agent/test/extension-session-contract.test.ts
+++ b/packages/coding-agent/test/extension-session-contract.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { TempDir } from "@f5-sales-demo/pi-utils";
+import { BridgeServer } from "@f5-sales-demo/xcsh/browser/extension-bridge";
+import { sessionInfoForWorker } from "@f5-sales-demo/xcsh/commands/worker";
+import { ContextService } from "@f5-sales-demo/xcsh/services/xcsh-context";
+
+/**
+ * Characterization tests for the per-tab extension SESSION contract.
+ *
+ * A per-tab "session" is a worker process the manager spawns (Bun.spawn, keyed
+ * `tab-<id>`); the extension correlates that tab to its worker through the
+ * hello/hello_ack handshake. These pin the handshake + session-identity behavior a
+ * future startup/session-load optimization MUST preserve — the "don't lose required
+ * functionality" guard (the extension-side sibling of the extension-loading contract
+ * from #1856). Tested in isolation: no worker spawn, no model, no network.
+ */
+
+/** The hello_ack frame the extension consumes (extension-bridge.ts:276-287). */
+interface HelloAck {
+	type: string;
+	sessionId: string | null;
+	contractVersion: string;
+	tenant: string | null;
+	env: string | null;
+	apiUrl: string | null;
+	contextBound: boolean;
+	pid: number;
+}
+
+/** Open a fake extension client, send `hello`, resolve the parsed `hello_ack`. */
+function handshake(port: number, timeoutMs = 5_000): Promise<HelloAck> {
+	return new Promise<HelloAck>((resolve, reject) => {
+		const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+		const timer = setTimeout(() => {
+			ws.close();
+			reject(new Error("hello_ack timeout"));
+		}, timeoutMs);
+		ws.addEventListener("open", () => ws.send(JSON.stringify({ type: "hello" })));
+		ws.addEventListener("message", ev => {
+			let msg: HelloAck;
+			try {
+				msg = JSON.parse(String(ev.data));
+			} catch {
+				return;
+			}
+			if (msg.type !== "hello_ack") return;
+			clearTimeout(timer);
+			ws.close();
+			resolve(msg);
+		});
+		ws.addEventListener("error", () => {
+			clearTimeout(timer);
+			reject(new Error("ws error"));
+		});
+	});
+}
+
+describe("extension session contract", () => {
+	// sessionInfoForWorker consults the ContextService SINGLETON before the env fallback.
+	// 13 other test files init that singleton, and Bun runs the suite in one process — so
+	// pin it to a fresh EMPTY config dir here (no stored contexts → activeApiUrl null,
+	// no active context) to make the contextless env-parsing path deterministic regardless
+	// of file load order. (init() re-points the singleton, matching how the context tests
+	// isolate themselves.)
+	let ctxDir: TempDir;
+	beforeEach(() => {
+		ctxDir = TempDir.createSync("@pi-session-ctx-");
+		ContextService.init(ctxDir.path());
+	});
+	afterEach(() => {
+		ctxDir.removeSync();
+	});
+
+	// --- sessionInfoForWorker: the per-tab routing key derived from spawn env ---
+
+	describe("sessionInfoForWorker", () => {
+		let saved: Record<string, string | undefined>;
+		beforeEach(() => {
+			saved = {
+				XCSH_SESSION_ID: process.env.XCSH_SESSION_ID,
+				XCSH_SESSION_TENANT: process.env.XCSH_SESSION_TENANT,
+				XCSH_API_URL: process.env.XCSH_API_URL,
+			};
+			process.env.XCSH_SESSION_ID = "tab-7";
+			process.env.XCSH_SESSION_TENANT = "acme|staging";
+			delete process.env.XCSH_API_URL;
+		});
+		afterEach(() => {
+			for (const [k, v] of Object.entries(saved)) {
+				if (v === undefined) delete process.env[k];
+				else process.env[k] = v;
+			}
+		});
+
+		it("echoes XCSH_SESSION_ID as the tab-correlation sessionId and parses the tenant", () => {
+			const info = sessionInfoForWorker();
+			expect(info.sessionId).toBe("tab-7");
+			expect(info.tenant).toBe("acme");
+			expect(info.env).toBe("staging");
+			expect(info.apiUrl).toBeNull();
+			expect(info.contextBound).toBe(false);
+		});
+
+		it("returns all-null identity when no session env is set", () => {
+			delete process.env.XCSH_SESSION_ID;
+			delete process.env.XCSH_SESSION_TENANT;
+			const info = sessionInfoForWorker();
+			expect(info.sessionId).toBeNull();
+			expect(info.tenant).toBeNull();
+			expect(info.env).toBeNull();
+			expect(info.contextBound).toBe(false);
+		});
+	});
+
+	// --- hello/hello_ack handshake in isolation (BridgeServer is a pure transport) ---
+
+	describe("hello_ack handshake", () => {
+		let server: BridgeServer;
+		let saved: Record<string, string | undefined>;
+		beforeEach(() => {
+			saved = {
+				XCSH_SESSION_ID: process.env.XCSH_SESSION_ID,
+				XCSH_SESSION_TENANT: process.env.XCSH_SESSION_TENANT,
+				XCSH_API_URL: process.env.XCSH_API_URL,
+			};
+			process.env.XCSH_SESSION_ID = "tab-7";
+			process.env.XCSH_SESSION_TENANT = "acme|staging";
+			delete process.env.XCSH_API_URL;
+			server = new BridgeServer();
+			// port 0 = OS-ephemeral; skipOriginCheck so a non-extension client may connect.
+			expect(server.listen(0, { skipOriginCheck: true })).toBe(true);
+			server.setSessionInfo(sessionInfoForWorker);
+		});
+		afterEach(async () => {
+			await server.close();
+			for (const [k, v] of Object.entries(saved)) {
+				if (v === undefined) delete process.env[k];
+				else process.env[k] = v;
+			}
+		});
+
+		it("answers hello with the worker's session identity and a major-1 contract", async () => {
+			const ack = await handshake(server.port);
+
+			expect(ack.type).toBe("hello_ack");
+			expect(ack.sessionId).toBe("tab-7");
+			expect(ack.tenant).toBe("acme");
+			expect(ack.env).toBe("staging");
+			expect(ack.contextBound).toBe(false);
+			// The extension requires contract major 1 to bind + route (session-routing).
+			expect(Number(ack.contractVersion.split(".")[0])).toBe(1);
+			expect(typeof ack.pid).toBe("number");
+		});
+
+		// --- Perf guard (catastrophic-regression only; NOT a tight budget) ---
+		it("completes the handshake within a generous time budget", async () => {
+			const start = Bun.nanoseconds();
+			const ack = await handshake(server.port);
+			const elapsedMs = (Bun.nanoseconds() - start) / 1e6;
+
+			expect(ack.type).toBe("hello_ack");
+			// Generous bound — guards against a pathological handshake regression, not micro-perf.
+			expect(elapsedMs).toBeLessThan(5_000);
+		});
+	});
+});


### PR DESCRIPTION
Closes #1858. Extends #1856 (issue #1855) from the CLI's extension **loader** to the extension's **per-tab session** lifecycle. **Measurement only — no optimization** (same discipline as #1856).

## Why

A per-tab "session" is a **worker OS process** the manager spawns (`manager.ts` `Bun.spawn([execPath, "worker"], …)`, keyed `tab-<id>`). Each worker boots the binary → starts the WS bridge (`startBridgeServer`) → runs its own `createAgentSession` → `ChatHandler.attach()`. So **per-tab session load ≈ worker cold-start ≈ binary startup** — exactly what #1856 targets. This PR quantifies that link.

## What

- **`worker.ts`** — `logger.startTiming()` + `session:bridgeListen` / `session:createAgentSession` spans + a `PI_TIMING` print/exit block, mirroring `main.ts:553` / `:1002-1009`. **Behavior-preserving**: `logger.time(op, fn, …)` returns the wrapped value unchanged, and nothing prints unless `PI_TIMING` is set — a normal `xcsh worker` run is unchanged.
- **`test/extension-session-contract.test.ts`** — the per-tab functionality guard. Pins the `hello_ack` handshake (the `sessionId` echo is the extension's per-tab routing key) + `sessionInfoForWorker` env parsing. Isolated: no worker spawn, no model, no network; order-robust (fresh `ContextService.init`).
- **`bench/extension-session.ts`** — spawns **real** workers (dev + compiled) and times bridge-ready / session-ready (`PI_TIMING=x` span split) / graceful-unload. Every pid cleaned up; every wait deadlined. `bench/` is excluded from tsconfig/test/build.

## Baseline

| phase (median) | dev | compiled |
|---|---|---|
| bridge-ready (spawn→listening) | ~1000ms | ~745ms |
| session-ready (spawn→attached) | ~1060ms | ~800ms |
| `session:createAgentSession` span | ~190ms | ~170ms |
| unload (graceful SIGTERM→exit) | ~23ms | ~28ms |

Compilation (an #1856-class startup win) shaves **~260ms** off per-tab session load — startup optimization propagates to session load. Measure-first surprise: `createAgentSession` (~170ms) is only ~20% of session-load; **process cold-start + pre-bridge init dominates** — the real lever for a follow-up, contract-guarded optimization.

## Verification

- `bun test packages/coding-agent/test/extension-session-contract.test.ts` → 4/4 green (also verified cross-file: no `ContextService` singleton bleed).
- `PI_TIMING=x … xcsh worker` → emits `session:createAgentSession` then exits 0; `session:bridgeListen` is sub-5ms (under the log threshold — INSTANT-ON holds).
- `bun packages/coding-agent/bench/extension-session.ts` → the table above.
- biome clean; `tsgo` clean for these files (the one project type error is a pre-existing ajv version skew in `packages/ai`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)