### PR TITLE
fix(welcome): restore symmetric F5 startup logo (skewed since #1852)

### DIFF
--- a/packages/coding-agent/src/modes/components/welcome.ts
+++ b/packages/coding-agent/src/modes/components/welcome.ts
@@ -8,6 +8,32 @@ import { theme } from "../../modes/theme/theme";
  * commands (/plugins, /context) so startup stays instant and never blocks or
  * live-updates. See docs/superpowers/specs for the fast-startup design.
  */
+// biome-ignore format: preserve ASCII art layout
+/** The F5 "ball" startup logo. Rows are vertically symmetric so the disk renders as a
+ * clean circle; keep it that way (see welcome-logo.test.ts). `▓`→red, `█`→white,
+ * `▒`→red stipple halo, `()|_`→red edge glyphs (see WelcomeComponent.#f5ColorLine). */
+export const F5_LOGO_ROWS: readonly string[] = [
+	"                   ________",
+	"              (▒▒▒▒▓▓▓▓▓▓▓▓▒▒▒▒)",
+	"         (▒▒▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒▒▒)",
+	"      (▒▒▓▓▓▓██████████▓▓▓▓█████████████)",
+	"    (▒▓▓▓▓██████▒▒▒▒▒███▓▓██████████████▒)",
+	"   (▒▓▓▓▓██████▒▓▓▓▓▓▒▒▒▓██▒▒▒▒▒▒▒▒▒▒▒▒▒▓▒)",
+	"  (▒▓▓▓▓▓██████▓▓▓▓▓▓▓▓▓██▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒)",
+	" (▒▓▓███████████████▓▓▓▓█████████████▓▓▓▓▓▓▒)",
+	"(▒▓▓▓▒▒▒███████▒▒▒▒▒▓▓▓████████████████▓▓▓▓▓▒)",
+	"|▒▓▓▓▓▓▓▒██████▓▓▓▓▓▓▓████████████████████▓▓▒|",
+	"|▒▓▓▓▓▓▓▓██████▓▓▓▓▓▓▓▒▒▒▒▒▒▒▒▒▒▒██████████▓▒|",
+	"(▒▓▓▓▓▓▓▓██████▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒▒████████▒▒)",
+	" (▒▓▓▓▓▓▓██████▓▓▓▓▓▓▓███▓▓▓▓▓▓▓▓▓▓▒▒▒████▒▒)",
+	"  (▒▓▓▓▓▓██████▓▓▓▓▓▓█████▓▓▓▓▓▓▓▓▓▓▓▓███▒▒)",
+	"   (▒▒██████████▓▓▓▓▓▒██████▓▓▓▓▓▓▓▓███▒▒▒)",
+	"    (▒▒▒▒▒██████████▓▓▒▒█████████████▒▒▓▒)",
+	"      (▒▓▓▒▒▒▒▒▒▒▒▒▒▓▓▓▓▒▒▒▒▒▒▒▒▒▒▒▒▒▓▒)",
+	"         (▒▒▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒▒▒)",
+	"              (▒▒▒▒▓▓▓▓▓▓▓▓▒▒▒▒)",
+];
+
 export class WelcomeComponent implements Component {
 	constructor(private readonly version: string) {}
 	invalidate(): void {}
@@ -20,28 +46,7 @@ export class WelcomeComponent implements Component {
 		if (boxWidth < 4) return [];
 		const leftCol = boxWidth - 2;
 
-		// biome-ignore format: preserve ASCII art layout
-		const f5Logo = [
-			"                   ________",
-			"              (▒▒▒▒▓▓▓▓▓▓▓▓▒▒▒▒)",
-			"         (▒▒▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒▒▒)",
-			"      (▒▒▓▓▓▓██████████▓▓▓▓███████████████)",
-			"    (▒▓▓▓▓██████▒▒▒▒▒███▓▓█████████████████▒)",
-			"   (▒▓▓▓▓██████▒▓▓▓▓▓▒▒▒▓██▒▒▒▒▒▒▒▒▒▒▒▒▒▓▒)",
-			"  (▒▓▓▓▓▓██████▓▓▓▓▓▓▓▓▓██▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒)",
-			" (▒▓▓████████████████▓▓▓▓████████████▓▓▓▓▓▓▒)",
-			"(▒▓▓▓▒▒▒███████▒▒▒▒▒▓▓▓████████████████▓▓▓▓▓▒)",
-			"|▒▓▓▓▓▓▓▒██████▓▓▓▓▓▓▓████████████████████▓▓▒|",
-			"|▒▓▓▓▓▓▓▓██████▓▓▓▓▓▓▓▒▒▒▒▒▒▒▒▒▒▒██████████▓▒|",
-			"(▒▓▓▓▓▓▓▓██████▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒▒██████████▒▒)",
-			" (▒▓▓▓▓▓▓██████▓▓▓▓▓▓▓███▓▓▓▓▓▓▓▓▓▒▒▒████▒▒)",
-			"  (▒▓▓▓▓▓██████▓▓▓▓▓▓██████▓▓▓▓▓▓▓▓▓▓▓▓████▒▒)",
-			"   (▒▒██████████▓▓▓▓▓▒██████▓▓▓▓▓▓▓▓██████▒▒▒)",
-			"    (▒▒▒▒▒██████████▓▓▒▒██████████████▒▒▓▒)",
-			"      (▒▓▓▒▒▒▒▒▒▒▒▒▒▒▓▓▓▓▒▒▒▒▒▒▒▒▒▒▒▒▒▒▓▒)",
-			"         (▒▒▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒▒▒)",
-			"              (▒▒▒▒▓▓▓▓▓▓▓▓▒▒▒▒)",
-		];
+		const f5Logo = F5_LOGO_ROWS;
 
 		const logoColored = f5Logo.map(line => this.#f5ColorLine(line));
 		const logoBlockPad = Math.max(0, Math.floor((leftCol - logoMaxWidth) / 2));

--- a/packages/coding-agent/test/welcome-logo.test.ts
+++ b/packages/coding-agent/test/welcome-logo.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { F5_LOGO_ROWS } from "@f5-sales-demo/xcsh/modes/components/welcome";
+
+/**
+ * Regression guard for the F5 startup logo (issue #1863).
+ *
+ * The logo rendered badly skewed after PR #1852 re-drew the bitmap into a
+ * vertically-ASYMMETRIC shape (mirror rows differed in width by up to 3 cells),
+ * so the disk was lopsided and the `( ) |` edge glyphs no longer traced a clean
+ * circle. A clean disk requires the circle rows to mirror top<->bottom in width
+ * and to form a single rise-then-fall (unimodal) profile. These pin that shape so
+ * a future redraw cannot silently skew the logo again.
+ */
+describe("F5 logo art (welcome screen)", () => {
+	// Row 0 is the "________" crown (intentionally not part of the disk); the rest is the circle.
+	const circle = F5_LOGO_ROWS.slice(1);
+	const width = (s: string): number => [...s].length;
+
+	it("has an even number of vertically-mirrored circle rows", () => {
+		expect(circle.length % 2).toBe(0);
+	});
+
+	it("is vertically symmetric — mirrored rows match width within 1 cell (a clean circle, not skewed)", () => {
+		const n = circle.length;
+		const offenders: string[] = [];
+		for (let i = 0; i < Math.floor(n / 2); i++) {
+			const top = width(circle[i]);
+			const bot = width(circle[n - 1 - i]);
+			if (Math.abs(top - bot) > 1)
+				offenders.push(`row ${i} (w=${top}) vs row ${n - 1 - i} (w=${bot}) differ by ${Math.abs(top - bot)}`);
+		}
+		expect(offenders).toEqual([]);
+	});
+
+	it("has a unimodal profile — widths rise to the middle then fall, with no dips", () => {
+		const w = circle.map(width);
+		const peak = Math.max(...w);
+		const firstPeak = w.indexOf(peak);
+		const lastPeak = w.lastIndexOf(peak);
+		for (let i = 1; i <= firstPeak; i++) expect(w[i]).toBeGreaterThanOrEqual(w[i - 1]);
+		for (let i = lastPeak + 1; i < w.length; i++) expect(w[i]).toBeLessThanOrEqual(w[i - 1]);
+	});
+});


### PR DESCRIPTION
Closes #1863.

## Regression
Since the welcome refactor (#1852/#1853), the `xcsh` startup F5 logo rendered **skewed/lopsided** with ragged, detached `( ) |` edge glyphs.

## Root cause (systematic-debugging)
#1852 left the rendering wrapper intact but **re-drew the `f5Logo` bitmap into a vertically-asymmetric shape**. Circle-row widths went jagged/non-mirrored — current `[…43,45,43,44,45,46,46,46,47,44,46,46…]` (6 mismatched top/bottom mirror pairs, diffs up to 3), so the disk was lopsided and the boundary glyphs no longer traced a clean circle. The pre-#1852 art was symmetric — `[32,36,41,42,43,44,45,46,46,46,46,45,44,43,42,40,36,32]` (a smooth rise-then-fall) — and rendered as a clean disk.

## Fix
- Restore the previous **symmetric** F5 logo bitmap (keeping the new logo-only + version-box layout).
- Extract the art to an exported `F5_LOGO_ROWS` const and add `test/welcome-logo.test.ts` pinning **vertical symmetry (mirror rows within 1 cell)** and a **unimodal width profile** — so a future redraw can't silently skew it again.

## Verification
- New guard test 3/3 (fails on the old skewed art, passes on the restored art — TDD red→green).
- Existing `welcome-component` tests still pass (render unchanged); biome + tsgo clean.
- Rendered output confirmed a clean, centered, symmetric disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)