### PR TITLE
perf(startup): benchmark barrel-import cost — compiled cost is a cache-hit (#1868)

### DIFF
--- a/packages/coding-agent/bench/barrel-import-cost.ts
+++ b/packages/coding-agent/bench/barrel-import-cost.ts
@@ -1,0 +1,76 @@
+/**
+ * Barrel-import cost benchmark for #1868.
+ *
+ * Measures `await import("@f5-sales-demo/xcsh")` — the full app barrel that the
+ * extension / custom-tool / custom-command / hook loaders import to build the
+ * `pi` API object. #1868 asks whether decoupling the loaders from that barrel is
+ * worth a refactor; this benchmark supplies the number.
+ *
+ * Run manually:  bun packages/coding-agent/bench/barrel-import-cost.ts
+ *
+ * Two regimes that differ by orders of magnitude — report both:
+ *
+ *  - DEV (source transpile): a fresh `bun` process imports the barrel cold.
+ *    This is the cost paid in `bun test` isolation — the figure #1867's
+ *    `beforeAll` warm-up in extensions-runner.test.ts hides.
+ *
+ *  - COMPILED (bundled binary): by the time any loader runs, cli.ts → main.ts
+ *    has already evaluated most of the barrel's re-exported module graph, so the
+ *    loader's `import()` is a near cache-hit. In-context it measures BELOW the
+ *    logger's 5ms span threshold (LOGGED_TIMING_THRESHOLD_MS), so `ext:barrelImport`
+ *    never appears in PI_TIMING output. That sub-5ms cost is the UPPER BOUND on
+ *    what the #1868 decouple could save from compiled startup.
+ *
+ * import() caches per-process, so every sample is a FRESH process.
+ */
+import * as path from "node:path";
+
+const PKG_DIR = path.resolve(import.meta.dir, "..");
+const COMPILED = path.join(PKG_DIR, "dist", "xcsh");
+const N = 7;
+
+function median(xs: number[]): number {
+	const s = [...xs].sort((a, b) => a - b);
+	const m = Math.floor(s.length / 2);
+	return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+// DEV: fresh `bun -e` process times a single cold barrel import and prints ms.
+const DEV_PROBE = `const t=Bun.nanoseconds();await import("@f5-sales-demo/xcsh");console.log(((Bun.nanoseconds()-t)/1e6).toFixed(2));`;
+
+function devColdImportMs(): number {
+	const proc = Bun.spawnSync([process.execPath, "-e", DEV_PROBE], { cwd: PKG_DIR, stderr: "ignore" });
+	const out = proc.stdout.toString().trim().split("\n").pop() ?? "";
+	const ms = Number.parseFloat(out);
+	if (!Number.isFinite(ms)) throw new Error(`dev probe returned no number: ${JSON.stringify(out)}`);
+	return ms;
+}
+
+const devSamples = Array.from({ length: N }, devColdImportMs);
+console.log(`dev cold barrel import (fresh process, N=${N}):`);
+console.log(`  samples: ${devSamples.map((x) => x.toFixed(0)).join(", ")}ms`);
+console.log(`  median:  ${median(devSamples).toFixed(1)}ms  (first run is coldest — transpile cache)`);
+
+// COMPILED: run the binary under PI_TIMING=x; the barrel import is sub-threshold
+// (<5ms), so we assert its absence and report the containing ext:loadLoop span
+// as the ceiling that already refutes any hundreds-of-ms barrel claim.
+if (await Bun.file(COMPILED).exists()) {
+	const proc = Bun.spawnSync([COMPILED], {
+		env: { ...process.env, PI_TIMING: "x" },
+		stdin: "ignore",
+		stderr: "pipe",
+		stdout: "ignore",
+	});
+	const timings = proc.stderr.toString();
+	const barrel = timings.match(/ext:barrelImport:\s*([\d.]+)ms/);
+	const loadLoop = timings.match(/ext:loadLoop:\s*([\d.]+)ms/);
+	console.log(`\ncompiled in-context (${path.relative(PKG_DIR, COMPILED)}, PI_TIMING=x):`);
+	if (barrel) {
+		console.log(`  ext:barrelImport: ${barrel[1]}ms (exceeded 5ms threshold — investigate)`);
+	} else {
+		console.log(`  ext:barrelImport: <5ms (sub-threshold — not emitted; near cache-hit)`);
+	}
+	console.log(`  ext:loadLoop:     ${loadLoop ? `${loadLoop[1]}ms` : "n/a"} (contains barrelImport → hard ceiling)`);
+} else {
+	console.log(`\ncompiled: skipped — ${path.relative(PKG_DIR, COMPILED)} not found (run \`bun run build\`)`);
+}


### PR DESCRIPTION
Closes #1868

## What

Adds `packages/coding-agent/bench/barrel-import-cost.ts` — a durable benchmark that measures `await import("@f5-sales-demo/xcsh")`, the app barrel the extension / custom-tool / custom-command / hook loaders import to build the `pi` API. **Measurement only — no runtime behavior change.**

This resolves the measurement question in #1868 and records the decision: **defer the decouple** (see below).

## Why

#1868 proposes decoupling the loaders from the full app barrel, estimating a "~340ms compiled" cost. Before committing to a breaking API refactor (the `.pi` field has a live consumer in `swarm-extension`), this quantifies the real cost.

## Verified findings

| Regime | `ext:barrelImport` | Context |
|---|---|---|
| **compiled (in-context)** | **~0.008ms** first, ~0.002ms after | inside `ext:loadLoop` 150–220ms, `createAgentSession` ~300ms |
| **dev (cold source transpile, fresh proc)** | **~800ms median** | the `bun test` isolation cost |

Method: the loader already wraps the import in `logger.time("ext:barrelImport", …)`. The span is **absent** from normal `PI_TIMING` output because `recordAsyncSpan` drops sub-`LOGGED_TIMING_THRESHOLD_MS` (5ms) spans (`packages/utils/src/logger.ts:99,171`). A throwaway build with the threshold lowered exposed the exact ~0.008ms value (reverted; not in this PR).

**Root cause:** in the compiled bundle `cli.ts → main.ts` already evaluates the barrel's re-exported module graph before extension discovery runs, so the loader's `import()` is a cache-hit.

## Conclusion — defer

- The "~340ms compiled" estimate is off by ~40,000×. The compiled decouple would save **~microseconds** — immaterial against a ~300ms `createAgentSession`.
- The only real cost is **dev/test transpile (~800ms cold)**, already mitigated by #1867's `beforeAll` warm-up in `extensions-runner.test.ts`.
- If the decouple is ever pursued purely for API hygiene, open a fresh, correctly-scoped issue (the original premise here is refuted; see the issue comment for corrections and the live `swarm-extension` `.pi` consumer).

## Test

`bun packages/coding-agent/bench/barrel-import-cost.ts` → prints dev median + compiled in-context spans. Bench dir is excluded from tsconfig/biome (same as existing benches), so no type/lint surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)