### PR TITLE
fix(worker): advertise known tenant even when apiUrl is unparseable (#1872)

### DIFF
--- a/packages/coding-agent/src/commands/worker.ts
+++ b/packages/coding-agent/src/commands/worker.ts
@@ -23,7 +23,7 @@ import { initializeWithSettings } from "../discovery";
 import { createAgentSession } from "../sdk";
 import { activateTenantContext } from "../services/session-context-binding";
 import { ContextService } from "../services/xcsh-context";
-import { sessionKeyFromUrl } from "../services/xcsh-env";
+import { deriveTenantEnv } from "../services/xcsh-env";
 
 /** Mutable worker identity. Seeded from env at spawn (backward compat); replaced by a
  * late IPC bind on a pre-warmed spare. `null` fields fall back to env, then the "spare"
@@ -64,17 +64,13 @@ export function sessionInfoForWorker(): {
 		/* ContextService not initialized — fall through to the tenant key; contextBound stays false. */
 	}
 	apiUrl = apiUrl ?? process.env.XCSH_API_URL ?? null;
-	if (apiUrl) {
-		const key = sessionKeyFromUrl(apiUrl);
-		return { tenant: key?.tenant ?? null, env: key?.env ?? null, apiUrl, contextBound, sessionId };
-	}
-	// Contextless: advertise the tenant carried by the bind (or spawn env).
-	const raw = boundIdentity?.tenantKey ?? process.env.XCSH_SESSION_TENANT;
-	if (raw) {
-		const [tenant, env] = raw.split("|");
-		return { tenant: tenant || null, env: env || null, apiUrl: null, contextBound, sessionId };
-	}
-	return { tenant: null, env: null, apiUrl: null, contextBound, sessionId };
+	// Prefer the apiUrl-derived key (active context wins), but fall back to the
+	// tenant this worker was assigned (IPC bind or spawn env) so an apiUrl whose
+	// host we can't parse never blanks a KNOWN tenant — which would make the
+	// extension drop the bridge and show "No xcsh running for this tenant" (#1872).
+	const tenantKey = boundIdentity?.tenantKey ?? process.env.XCSH_SESSION_TENANT ?? null;
+	const { tenant, env } = deriveTenantEnv(apiUrl, tenantKey);
+	return { tenant, env, apiUrl, contextBound, sessionId };
 }
 
 /** Browser-automation tool set — identical scoping to `main.ts`'s extension path.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -815,7 +815,7 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 		// tenant), so the panel can lock its session and route per tenant.
 		{
 			const { ContextService } = await import("./services/xcsh-context");
-			const { sessionKeyFromUrl } = await import("./services/xcsh-env");
+			const { deriveTenantEnv } = await import("./services/xcsh-env");
 			const readInfo = () => {
 				let apiUrl: string | null = null;
 				let contextBound = false;
@@ -828,15 +828,13 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 				}
 				// Fall back to the env override when no context is active (env-only mode).
 				apiUrl = apiUrl ?? process.env.XCSH_API_URL ?? null;
-				const key = apiUrl ? sessionKeyFromUrl(apiUrl) : null;
+				// Prefer the apiUrl-derived key; fall back to the assigned tenant key so an
+				// unparseable apiUrl never blanks a known tenant (#1872). Same contract as
+				// the worker path (sessionInfoForWorker).
+				const tenantKey = process.env.XCSH_SESSION_TENANT ?? null;
+				const { tenant, env } = deriveTenantEnv(apiUrl, tenantKey);
 				// Interactive path has no per-tab XCSH_SESSION_ID; workers echo one, this doesn't.
-				return {
-					tenant: key?.tenant ?? null,
-					env: key?.env ?? null,
-					apiUrl,
-					contextBound,
-					sessionId: null,
-				};
+				return { tenant, env, apiUrl, contextBound, sessionId: null };
 			};
 			bridgeServer.setSessionInfo(readInfo);
 			ContextService.onContextChange(() => bridgeServer?.broadcastTenantChanged());

--- a/packages/coding-agent/src/services/xcsh-env.ts
+++ b/packages/coding-agent/src/services/xcsh-env.ts
@@ -129,6 +129,31 @@ export function sessionKeyFromUrl(url: string | undefined): SessionKey | null {
 }
 
 /**
+ * Resolve the `{tenant, env}` a worker advertises to the extension's `hello`
+ * handshake. Prefers the session key parsed from `apiUrl` (the live/active
+ * context is authoritative) but falls back to the worker's assigned tenant key
+ * (`"tenant|env"`, from `boundIdentity.tenantKey` / `XCSH_SESSION_TENANT`) when
+ * `apiUrl` is absent OR its host doesn't parse to a key.
+ *
+ * The fallback is load-bearing (#1872): the extension's `liveTenants` filter
+ * keeps a bridge only when BOTH `tenant` and `env` are set, so returning
+ * `{tenant:null, env:null}` for a worker that KNOWS its tenant (e.g. an
+ * activated context whose stored `apiUrl` isn't `<tenant>.console.ves.volterra.io`)
+ * silently drops the bridge and the panel shows "No xcsh running for this tenant".
+ */
+export function deriveTenantEnv(
+	apiUrl: string | null,
+	tenantKey: string | null | undefined,
+): { tenant: string | null; env: string | null } {
+	const key = apiUrl ? sessionKeyFromUrl(apiUrl) : null;
+	const [assignedTenant, assignedEnv] = (tenantKey ?? "").split("|");
+	return {
+		tenant: key?.tenant ?? (assignedTenant || null),
+		env: key?.env ?? (assignedEnv || null),
+	};
+}
+
+/**
  * Reduce an API URL to its origin (`https://host[:port]`) — the canonical stored
  * form for a context endpoint.
  *

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -107,6 +107,27 @@ async function findTenant(tenant: string, tries: number): Promise<number | null>
 }
 
 /**
+ * Poll the range for a hello_ack advertising BOTH `tenant` AND `env`, returning
+ * the full frame. #1872 guard: the extension's `liveTenants` filter keeps a
+ * bridge only when both fields are set, so asserting `tenant` alone (findTenant)
+ * would miss a regression that blanks `env` — the exact failure that shipped.
+ */
+async function findFrame(tenant: string, env: string, tries: number): Promise<Record<string, unknown> | null> {
+	for (let i = 0; i < tries; i++) {
+		for (const p of RANGE) {
+			try {
+				const ack = await probe(p);
+				if (ack.tenant === tenant && ack.env === env) return ack;
+			} catch {
+				/* worker not up yet on this port */
+			}
+		}
+		await Bun.sleep(250);
+	}
+	return null;
+}
+
+/**
  * Spawn a manager with a pre-warm pool size and capture its stderr live.
  *
  * The WS `hello_ack` "spare" probe used by worker-spawn.int.test.ts is
@@ -182,6 +203,22 @@ test("adopts a warm spare on provision, then replenishes the pool (XCSH_WORKER_P
 	await send({ type: "release", sessionId: "tab-7" });
 }, 60_000);
 
+test("adopted spare's hello_ack advertises BOTH tenant AND env (#1872 contract)", async () => {
+	// The adoption path (#1862) late-binds via IPC and activates the tenant
+	// context. Assert the ACTUAL frame — not just the "adopted spare" stderr — so a
+	// regression that blanks `env` (e.g. an unparseable stored apiUrl overriding the
+	// bound tenant key) is caught here instead of silently on the extension, which
+	// filters any bridge missing tenant OR env and shows "No xcsh running".
+	const getErr = await startManagerWithPool("1");
+	expect(await waitForStderr(getErr, "pre-warmed spare", 120)).toBe(true);
+	await send({ type: "provision", sessionId: "tab-7", tenant: "acme|staging" });
+	expect(await waitForStderr(getErr, "adopted spare", 120)).toBe(true);
+	const ack = await findFrame("acme", "staging", 80);
+	expect(ack).not.toBeNull();
+	expect(ack).toMatchObject({ tenant: "acme", env: "staging" });
+	await send({ type: "release", sessionId: "tab-7" });
+}, 60_000);
+
 test("falls back to cold-spawn when the pool is disabled (XCSH_WORKER_POOL_SIZE=0)", async () => {
 	const getErr = await startManagerWithPool("0");
 
@@ -216,6 +253,8 @@ test("provision spawns a worker advertising the tenant; release reaps it", async
 
 	const port = await findTenant("acme", 80);
 	expect(port).not.toBeNull();
+	// #1872: the cold-spawn frame must carry env too (not just tenant).
+	expect(await probe(port as number)).toMatchObject({ tenant: "acme", env: "staging" });
 
 	// Release should reap the worker: the port stops answering the handshake.
 	await send({ type: "release", sessionId: "tab-1" });

--- a/packages/coding-agent/test/xcsh-env.test.ts
+++ b/packages/coding-agent/test/xcsh-env.test.ts
@@ -77,6 +77,34 @@ describe("xcsh-env", () => {
 			expect(sessionKeyFromUrl("https://192.168.1.10/web/home")).toBeNull();
 			expect(sessionKeyFromUrl(undefined)).toBeNull();
 		});
+
+		// Cross-repo parity guard (#1872). This GOLDEN table is asserted verbatim in
+		// the Chrome extension's test/session-key-parity.test.ts against ITS copy of
+		// sessionKeyFromUrl (src/tab-binding.ts). The two implementations must agree
+		// on every cell — a discovered worker's key must match the tab's key, or the
+		// panel gate shows "No xcsh running for this tenant". Change one, change both.
+		const GOLDEN: Array<[string | undefined, { tenant: string; env: "production" | "staging" } | null]> = [
+			["https://acme.console.ves.volterra.io/web/x", { tenant: "acme", env: "production" }],
+			["https://acme.staging.volterra.us/web/home", { tenant: "acme", env: "staging" }],
+			["https://f5-amer-ent.console.ves.volterra.io/web/home?iss=x", { tenant: "f5-amer-ent", env: "production" }],
+			[
+				"https://login.ves.volterra.io/auth/realms/acme-abc123/protocol/openid-connect/auth",
+				{ tenant: "acme", env: "production" },
+			],
+			[
+				"https://login-staging.volterra.us/auth/realms/acme-x/protocol/openid-connect/auth",
+				{ tenant: "acme", env: "staging" },
+			],
+			["https://console.ves.volterra.io/web/devportal/domain", null],
+			["https://login.ves.volterra.io/auth/realms/volterra/protocol/openid-connect/auth", null],
+			["https://acme.ves.volterra.io", null],
+			["https://192.168.1.10/web/home", null],
+			["https://api.gateway.internal", null],
+			[undefined, null],
+		];
+		it.each(GOLDEN)("parity: %s", (url, expected) => {
+			expect(sessionKeyFromUrl(url)).toEqual(expected);
+		});
 	});
 
 	// Guards the extension tenant-advertisement contract (#1872): the worker's

--- a/packages/coding-agent/test/xcsh-env.test.ts
+++ b/packages/coding-agent/test/xcsh-env.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
+	deriveTenantEnv,
 	deriveTenantFromUrl,
 	hasEnvOverride,
 	normalizeApiUrl,
@@ -75,6 +76,73 @@ describe("xcsh-env", () => {
 			).toBeNull();
 			expect(sessionKeyFromUrl("https://192.168.1.10/web/home")).toBeNull();
 			expect(sessionKeyFromUrl(undefined)).toBeNull();
+		});
+	});
+
+	// Guards the extension tenant-advertisement contract (#1872): the worker's
+	// hello_ack must carry BOTH tenant and env whenever the tenant is known, or
+	// the extension's `liveTenants` filter (needs tenant && env) drops the bridge
+	// and the panel shows "No xcsh running for this tenant". `deriveTenantEnv`
+	// prefers the apiUrl-derived key but MUST fall back to the assigned tenant key
+	// so an unparseable apiUrl never blanks a known tenant.
+	describe("deriveTenantEnv", () => {
+		// [label, apiUrl, tenantKey, expectedTenant, expectedEnv]
+		const M: Array<[string, string | null, string | null | undefined, string | null, string | null]> = [
+			// apiUrl parses → apiUrl wins (the live/active context is authoritative)
+			[
+				"console apiUrl + tenantKey → apiUrl wins",
+				"https://acme.console.ves.volterra.io",
+				"acme|production",
+				"acme",
+				"production",
+			],
+			[
+				"staging apiUrl → staging env",
+				"https://acme.staging.volterra.us/web/home",
+				"acme|production",
+				"acme",
+				"staging",
+			],
+			[
+				"apiUrl tenant overrides a stale tenantKey",
+				"https://real.console.ves.volterra.io",
+				"stale|staging",
+				"real",
+				"production",
+			],
+			// apiUrl present but UNPARSEABLE → fall back to tenantKey (the #1872 fix)
+			[
+				"non-console apiUrl + tenantKey → FALLBACK",
+				"https://acme.ves.volterra.io",
+				"acme|production",
+				"acme",
+				"production",
+			],
+			[
+				"bare console host + tenantKey → FALLBACK",
+				"https://console.ves.volterra.io",
+				"acme|production",
+				"acme",
+				"production",
+			],
+			[
+				"unparseable apiUrl + staging tenantKey → FALLBACK",
+				"https://api.gateway.internal",
+				"acme|staging",
+				"acme",
+				"staging",
+			],
+			// no apiUrl → tenantKey (contextless bound worker / adopted spare)
+			["no apiUrl + tenantKey", null, "acme|production", "acme", "production"],
+			// nothing known → null (unbound spare / interactive no-context)
+			["no apiUrl + no tenantKey → null", null, null, null, null],
+			["unparseable apiUrl + no tenantKey → null", "https://api.gateway.internal", null, null, null],
+			["unparseable apiUrl + empty tenantKey → null", "https://api.gateway.internal", "", null, null],
+			// malformed tenantKey (missing env half) → tenant only, env null
+			["tenantKey without env half → tenant only", null, "acme", "acme", null],
+		];
+		it.each(M)("%s", (_label, apiUrl, tenantKey, tenant, env) => {
+			expect(deriveTenantEnv(apiUrl, tenantKey)).toEqual({ tenant, env });
 		});
 	});
 


### PR DESCRIPTION
Closes #1872

## Symptom
Published Chrome extension (1.20.9) shows **"No xcsh running for this tenant"** on a live F5 XC console tab even though a worker is provisioned and the panel is **connected** (stuck in `panelInactive`).

## Root cause (reproduced against compiled v19.58.1)
`sessionInfoForWorker()` (worker.ts) and interactive `readInfo` (main.ts) took the `apiUrl` branch and, when `sessionKeyFromUrl(apiUrl)` returned `null` (host isn't `<tenant>.console.ves.volterra.io`), returned `{tenant:null, env:null}` — **discarding the tenant the worker already knew** from `XCSH_SESSION_TENANT`/`boundIdentity.tenantKey`. The extension's `liveTenants` filter keeps a bridge only when **both** `tenant && env` are set, so the bridge was dropped.

| apiUrl + `XCSH_SESSION_TENANT=f5-amer-ent\|production` | before | after |
|---|---|---|
| `…console.ves.volterra.io` | `f5-amer-ent/production` ✓ | ✓ |
| `…ves.volterra.io` (no `.console`) | **`null/null`** ✗ | `f5-amer-ent/production` ✓ |
| bare `console.ves.volterra.io` | **`null/null`** ✗ | `f5-amer-ent/production` ✓ |

## Fix
Extract `deriveTenantEnv(apiUrl, tenantKey)` — prefer the apiUrl-derived key (active context wins) but **fall back** to the assigned tenant key so an unparseable apiUrl never blanks a known tenant. Wired into both `worker.ts` and `main.ts`. Preserves the #1862 pre-warm/late-bind work.

## Why it shipped green (guardrails added)
The producer→consumer contract was never asserted end-to-end: `manager.int.test.ts` verified adoption via **stderr strings** and its `findTenant` probe checked `ack.tenant` but **never `ack.env`** — the field that broke.
- `deriveTenantEnv` matrix — 11 cells (apiUrl-wins, fallback, no-key, malformed).
- `manager.int.test.ts` now asserts the **real** adopted-spare AND cold-spawn `hello_ack` frames carry **both** tenant AND env.

## Verification
- `bun test test/xcsh-env.test.ts` → 34 pass. `bun test test/manager.int.test.ts` → 10 pass. `bun test test/worker-spawn.int.test.ts` → pass. `bun run check:types` → 0 errors.
- Re-probed the compiled binary post-fix: cells B and C now advertise `f5-amer-ent/production`.

A companion extension-repo PR adds the `liveTenants` gate matrix + `sessionKeyFromUrl` cross-repo parity guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)