### PR TITLE
feat: durable manager upgrade — version-stable wrapper + version identity (#1874)

### DIFF
--- a/packages/coding-agent/src/cli/chrome-cli.ts
+++ b/packages/coding-agent/src/cli/chrome-cli.ts
@@ -56,10 +56,15 @@ export function nativeHostLaunchCommand(
 	execPath: string = process.execPath,
 	resolveXcshBin: () => string | null = defaultResolveXcshBin,
 ): string[] {
+	// Prefer a VERSION-STABLE launcher on PATH (e.g. the Homebrew symlink
+	// /opt/homebrew/bin/xcsh) for BOTH compiled and bun installs. This keeps the
+	// native-messaging wrapper working across `brew upgrade`s instead of pinning
+	// the install-time versioned path (…/Cellar/xcsh/<v>/bin/xcsh), which froze
+	// the extension on an old version until install-host was re-run (#1874).
+	const xcsh = resolveXcshBin();
+	if (xcsh) return [xcsh];
 	const base = path.basename(execPath).toLowerCase();
 	if (base.startsWith("bun")) {
-		const xcsh = resolveXcshBin();
-		if (xcsh) return [xcsh];
 		const script = argv[1];
 		if (script && (script.endsWith(".ts") || script.endsWith(".js") || script.endsWith(".mjs"))) {
 			return [execPath, path.resolve(script)];

--- a/packages/coding-agent/src/commands/manager-core.ts
+++ b/packages/coding-agent/src/commands/manager-core.ts
@@ -10,10 +10,26 @@ export interface WorkerRec {
 
 export type Registry = Map<string, WorkerRec>;
 
+/** Reasons a manager is asked to step down (#1874). Closed set — fail closed. */
+export type ShutdownReason = "superseded" | "updated" | "manual";
+const SHUTDOWN_REASONS = new Set<string>(["superseded", "updated", "manual"]);
+
 export type ControlMsg =
 	| { type: "provision"; sessionId: string; tenant: string }
 	| { type: "release"; sessionId: string }
-	| { type: "status" };
+	| { type: "status" }
+	| { type: "hello" }
+	| { type: "shutdown"; reason: ShutdownReason };
+
+/** The manager's on-disk liveness record (`~/.xcsh/manager.json`), used for
+ * observability and as the escalation target (pid) when a superseded manager
+ * won't release the socket. The control-socket `hello` answer is authoritative. */
+export interface ManagerState {
+	pid: number;
+	version: string;
+	socket: string;
+	startedAt: number;
+}
 
 function isTenant(v: unknown): v is string {
 	return typeof v === "string" && /^[^|]+\|[^|]+$/.test(v);
@@ -30,7 +46,54 @@ export function parseControlMsg(raw: unknown): ControlMsg | null {
 	if (m.type === "provision" && isNonEmpty(m.sessionId) && isTenant(m.tenant))
 		return { type: "provision", sessionId: m.sessionId, tenant: m.tenant };
 	if (m.type === "release" && isNonEmpty(m.sessionId)) return { type: "release", sessionId: m.sessionId };
+	if (m.type === "hello") return { type: "hello" };
+	if (m.type === "shutdown" && typeof m.reason === "string" && SHUTDOWN_REASONS.has(m.reason))
+		return { type: "shutdown", reason: m.reason as ShutdownReason };
 	return null;
+}
+
+/** Parse a plain `major.minor.patch` version into a numeric tuple, or null. */
+function parseSemver(v: string | null | undefined): [number, number, number] | null {
+	if (typeof v !== "string") return null;
+	const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v.trim());
+	if (!m) return null;
+	return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** True iff `ourVersion` is a valid version strictly greater than a valid
+ * `runningVersion` — the trigger to replace an older manager. Fails closed
+ * (false) on equal/newer/any-unparseable input, so we never downgrade or flap. */
+export function shouldSupersede(runningVersion: string | null, ourVersion: string): boolean {
+	const a = parseSemver(runningVersion);
+	const b = parseSemver(ourVersion);
+	if (!a || !b) return false;
+	for (let i = 0; i < 3; i++) {
+		if (b[i] > a[i]) return true;
+		if (b[i] < a[i]) return false;
+	}
+	return false; // equal
+}
+
+/** Serialize the manager liveness record for `~/.xcsh/manager.json`. */
+export function serializeManagerState(s: ManagerState): string {
+	return JSON.stringify({ pid: s.pid, version: s.version, socket: s.socket, startedAt: s.startedAt });
+}
+
+/** Parse `~/.xcsh/manager.json`; null on corrupt/missing/ill-shaped input
+ * (a positive pid, non-empty version + socket, and finite startedAt required). */
+export function parseManagerState(text: string): ManagerState | null {
+	let raw: unknown;
+	try {
+		raw = JSON.parse(text);
+	} catch {
+		return null;
+	}
+	if (!raw || typeof raw !== "object") return null;
+	const m = raw as Record<string, unknown>;
+	if (typeof m.pid !== "number" || !Number.isInteger(m.pid) || m.pid <= 0) return null;
+	if (!isNonEmpty(m.version) || !isNonEmpty(m.socket)) return null;
+	if (typeof m.startedAt !== "number" || !Number.isFinite(m.startedAt)) return null;
+	return { pid: m.pid, version: m.version, socket: m.socket, startedAt: m.startedAt };
 }
 
 /** Idempotency: only provision when there is no live worker for the sessionId. */

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -20,7 +20,11 @@ import * as fs from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { Command } from "@f5-sales-demo/pi-utils/cli";
+// Lean subpath (not the package barrel, which pulls the winston logger graph and
+// slows the manager's cold start — keep the daemon's module graph minimal).
+import { VERSION } from "@f5-sales-demo/pi-utils/dirs";
 import { portCandidates } from "../browser/extension-bridge";
+import { writeManagerState } from "../services/manager-state";
 import { needsProvision, parseControlMsg, pickPort, type Registry, sparesToSpawn, staleKeys } from "./manager-core";
 
 /** Reap a worker idle longer than this (ms). */
@@ -257,7 +261,7 @@ export default class Manager extends Command {
 			console.error(`[xcsh manager] provisioned ${msg.sessionId} (${msg.tenant}) → pid ${proc.pid} on port ${port}`);
 		};
 
-		const handleFrame = (line: string): void => {
+		const handleFrame = (line: string, socket: { write(data: string): void }): void => {
 			const trimmed = line.trim();
 			if (!trimmed) return;
 			let raw: unknown;
@@ -276,6 +280,14 @@ export default class Manager extends Command {
 				if (w) w.lastSeen = Date.now(); // touch on every provision (keep-alive)
 			} else if (msg.type === "release") {
 				reap(msg.sessionId);
+			} else if (msg.type === "hello") {
+				// Identity handshake (#1874): a newer native-host reads our version to
+				// decide whether to supersede us. Answer over the same connection.
+				try {
+					socket.write(`${JSON.stringify({ type: "manager_hello_ack", version: VERSION, pid: process.pid })}\n`);
+				} catch {
+					/* client hung up mid-handshake — ignore */
+				}
 			}
 			// "status" is validated but currently a no-op sink.
 		};
@@ -292,7 +304,7 @@ export default class Manager extends Command {
 					const combined = (buffers.get(socket) ?? "") + data.toString("utf8");
 					const parts = combined.split("\n");
 					buffers.set(socket, parts.pop() ?? ""); // keep the incomplete trailing fragment
-					for (const line of parts) handleFrame(line);
+					for (const line of parts) handleFrame(line, socket as { write(data: string): void });
 				},
 				close(socket: object): void {
 					buffers.delete(socket);
@@ -330,6 +342,10 @@ export default class Manager extends Command {
 			process.exit(0);
 		}
 		console.error(`[xcsh manager] control socket listening at ${sockPath}`);
+
+		// Publish our liveness record (#1874) so a newer native-host can see which
+		// version owns the socket (and, if it must supersede us, find our pid).
+		writeManagerState(sockPath, { pid: process.pid, version: VERSION, socket: sockPath, startedAt: Date.now() });
 
 		// Pre-warm the spare pool so provisions can adopt instead of cold-spawn.
 		if (poolTarget > 0) maintainPool();

--- a/packages/coding-agent/src/services/manager-state.ts
+++ b/packages/coding-agent/src/services/manager-state.ts
@@ -17,9 +17,12 @@ export function managerStatePathFor(sockPath: string): string {
 export function writeManagerState(sockPath: string, state: ManagerState): void {
 	const p = managerStatePathFor(sockPath);
 	try {
-		fs.mkdirSync(dirname(p), { recursive: true });
+		// Restrictive modes: ~/.xcsh holds credentials (contexts/tokens), so the dir
+		// must be user-only (0700) if we're the one creating it, and the record
+		// user-only (0600) regardless of umask. rename() preserves the tmp's mode.
+		fs.mkdirSync(dirname(p), { recursive: true, mode: 0o700 });
 		const tmp = `${p}.${process.pid}.tmp`;
-		fs.writeFileSync(tmp, serializeManagerState(state));
+		fs.writeFileSync(tmp, serializeManagerState(state), { mode: 0o600 });
 		fs.renameSync(tmp, p);
 	} catch {
 		/* advisory only — the socket is the source of truth */

--- a/packages/coding-agent/src/services/manager-state.ts
+++ b/packages/coding-agent/src/services/manager-state.ts
@@ -1,0 +1,45 @@
+/** Filesystem side of the manager liveness record (`manager.json`), kept next to
+ * the control socket so a test's temp socket dir gets its own state file. The
+ * record is advisory/observability + the escalation target (pid) when a
+ * superseded manager won't release the socket; the control-socket `hello` answer
+ * is authoritative. Pure (de)serialization lives in commands/manager-core. */
+import * as fs from "node:fs";
+import { dirname, join } from "node:path";
+import { type ManagerState, parseManagerState, serializeManagerState } from "../commands/manager-core";
+
+/** `manager.json` alongside the given control socket. */
+export function managerStatePathFor(sockPath: string): string {
+	return join(dirname(sockPath), "manager.json");
+}
+
+/** Atomically write the liveness record (temp + rename so readers never see a
+ * torn file). Best-effort: never throws — a failed write must not crash boot. */
+export function writeManagerState(sockPath: string, state: ManagerState): void {
+	const p = managerStatePathFor(sockPath);
+	try {
+		fs.mkdirSync(dirname(p), { recursive: true });
+		const tmp = `${p}.${process.pid}.tmp`;
+		fs.writeFileSync(tmp, serializeManagerState(state));
+		fs.renameSync(tmp, p);
+	} catch {
+		/* advisory only — the socket is the source of truth */
+	}
+}
+
+/** Read + validate the record, or null if absent/corrupt. */
+export function readManagerState(sockPath: string): ManagerState | null {
+	try {
+		return parseManagerState(fs.readFileSync(managerStatePathFor(sockPath), "utf8"));
+	} catch {
+		return null;
+	}
+}
+
+/** Remove the record on graceful shutdown. Best-effort. */
+export function removeManagerState(sockPath: string): void {
+	try {
+		fs.rmSync(managerStatePathFor(sockPath), { force: true });
+	} catch {
+		/* best effort */
+	}
+}

--- a/packages/coding-agent/test/chrome-cli.test.ts
+++ b/packages/coding-agent/test/chrome-cli.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { nativeHostLaunchCommand } from "@f5-sales-demo/xcsh/cli/chrome-cli";
+
+// #1874: the native-messaging wrapper must launch a VERSION-STABLE xcsh (the
+// PATH/symlink, e.g. /opt/homebrew/bin/xcsh) — never a versioned Cellar path
+// like /opt/homebrew/Cellar/xcsh/<v>/bin/xcsh, which freezes the extension on
+// the install-time version across `brew upgrade`s.
+describe("nativeHostLaunchCommand (#1874 version-stable launcher)", () => {
+	const CELLAR = "/opt/homebrew/Cellar/xcsh/19.58.1/bin/xcsh";
+	const STABLE = "/opt/homebrew/bin/xcsh";
+
+	it("compiled install prefers the PATH/symlink xcsh over the versioned execPath", () => {
+		expect(nativeHostLaunchCommand([CELLAR], CELLAR, () => STABLE)).toEqual([STABLE]);
+	});
+
+	it("compiled install NEVER emits a Cellar path when PATH resolves", () => {
+		const cmd = nativeHostLaunchCommand([CELLAR], CELLAR, () => STABLE);
+		expect(cmd.some(s => s.includes("/Cellar/"))).toBe(false);
+	});
+
+	it("compiled install falls back to execPath when no PATH xcsh resolves", () => {
+		expect(nativeHostLaunchCommand([CELLAR], CELLAR, () => null)).toEqual([CELLAR]);
+	});
+
+	it("bun install prefers the PATH xcsh", () => {
+		const bun = "/usr/local/bin/bun";
+		expect(nativeHostLaunchCommand([bun, "src/cli.ts"], bun, () => STABLE)).toEqual([STABLE]);
+	});
+
+	it("bun+script with no PATH xcsh uses the resolved dev script", () => {
+		const bun = "/usr/local/bin/bun";
+		expect(nativeHostLaunchCommand([bun, "src/cli.ts"], bun, () => null)).toEqual([bun, path.resolve("src/cli.ts")]);
+	});
+
+	it("bun with neither PATH xcsh nor a script falls back to execPath", () => {
+		const bun = "/usr/local/bin/bun";
+		expect(nativeHostLaunchCommand([bun], bun, () => null)).toEqual([bun]);
+	});
+});

--- a/packages/coding-agent/test/manager-core.test.ts
+++ b/packages/coding-agent/test/manager-core.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it, test } from "bun:test";
 import { sparesToSpawn } from "@f5-sales-demo/xcsh/commands/manager-core";
 import {
+	type ManagerState,
 	needsProvision,
 	parseControlMsg,
+	parseManagerState,
 	pickPort,
 	type Registry,
+	serializeManagerState,
+	shouldSupersede,
 	staleKeys,
 	type WorkerRec,
 } from "../src/commands/manager-core";
@@ -39,6 +43,62 @@ describe("parseControlMsg", () => {
 		expect(parseControlMsg({ type: "release" })).toBeNull();
 		expect(parseControlMsg({ type: "nope", sessionId: "tab-7" })).toBeNull();
 		expect(parseControlMsg(null)).toBeNull();
+	});
+	// #1874 lifecycle frames.
+	test("accepts hello and shutdown{reason}", () => {
+		expect(parseControlMsg({ type: "hello" })).toEqual({ type: "hello" });
+		expect(parseControlMsg({ type: "shutdown", reason: "superseded" })).toEqual({
+			type: "shutdown",
+			reason: "superseded",
+		});
+		expect(parseControlMsg({ type: "shutdown", reason: "updated" })).toEqual({ type: "shutdown", reason: "updated" });
+		expect(parseControlMsg({ type: "shutdown", reason: "manual" })).toEqual({ type: "shutdown", reason: "manual" });
+	});
+	test("rejects shutdown with an unknown/missing reason (fail closed)", () => {
+		expect(parseControlMsg({ type: "shutdown" })).toBeNull();
+		expect(parseControlMsg({ type: "shutdown", reason: "hax" })).toBeNull();
+		expect(parseControlMsg({ type: "shutdown", reason: 3 })).toBeNull();
+	});
+});
+
+// #1874: version-aware supersede — a NEWER binary replaces an older running
+// manager; equal/newer/malformed never supersede (fail closed, no flapping).
+describe("shouldSupersede", () => {
+	it("true only when ourVersion is strictly greater", () => {
+		expect(shouldSupersede("19.56.2", "19.58.1")).toBe(true);
+		expect(shouldSupersede("19.58.0", "19.58.1")).toBe(true);
+		expect(shouldSupersede("18.99.99", "19.0.0")).toBe(true);
+	});
+	it("false on equal or newer running version", () => {
+		expect(shouldSupersede("19.58.1", "19.58.1")).toBe(false);
+		expect(shouldSupersede("19.58.2", "19.58.1")).toBe(false);
+		expect(shouldSupersede("20.0.0", "19.58.1")).toBe(false);
+	});
+	it("false (fail closed) on null / malformed versions", () => {
+		expect(shouldSupersede(null, "19.58.1")).toBe(false);
+		expect(shouldSupersede("", "19.58.1")).toBe(false);
+		expect(shouldSupersede("garbage", "19.58.1")).toBe(false);
+		expect(shouldSupersede("19.58", "19.58.1")).toBe(false);
+		expect(shouldSupersede("19.56.2", "notsemver")).toBe(false);
+	});
+});
+
+describe("manager state file round-trip", () => {
+	const s: ManagerState = {
+		pid: 4242,
+		version: "19.58.1",
+		socket: "/home/u/.xcsh/manager.sock",
+		startedAt: 1_700_000,
+	};
+	it("serialize → parse is identity", () => {
+		expect(parseManagerState(serializeManagerState(s))).toEqual(s);
+	});
+	it("returns null on corrupt / missing / bad-shape input", () => {
+		expect(parseManagerState("{not json")).toBeNull();
+		expect(parseManagerState("{}")).toBeNull();
+		expect(parseManagerState(JSON.stringify({ pid: -1, version: "1.0.0", socket: "/s", startedAt: 1 }))).toBeNull();
+		expect(parseManagerState(JSON.stringify({ pid: 5, version: "", socket: "/s", startedAt: 1 }))).toBeNull();
+		expect(parseManagerState(JSON.stringify({ pid: 5, version: "1.0.0", startedAt: 1 }))).toBeNull();
 	});
 });
 describe("needsProvision (idempotent per sessionId)", () => {

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -14,6 +14,7 @@ import { afterEach, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { VERSION } from "@f5-sales-demo/pi-utils";
 import { probe } from "./helpers/bridge-probe";
 
 let mgr: import("bun").Subprocess | undefined;
@@ -69,6 +70,41 @@ async function send(msg: unknown): Promise<void> {
 	c.write(`${JSON.stringify(msg)}\n`);
 	await Bun.sleep(50);
 	c.end();
+}
+
+/** Request/response over the control socket: send a frame, resolve the first
+ * reply line (or null on timeout). Used for the `hello` identity handshake. */
+async function request(msg: unknown, timeoutMs = 2000): Promise<Record<string, unknown> | null> {
+	return await new Promise(resolve => {
+		let buf = "";
+		let done = false;
+		const finish = (v: Record<string, unknown> | null) => {
+			if (done) return;
+			done = true;
+			resolve(v);
+		};
+		Bun.connect({
+			unix: sock,
+			socket: {
+				open(c) {
+					c.write(`${JSON.stringify(msg)}\n`);
+				},
+				data(c, chunk) {
+					buf += chunk.toString("utf8");
+					const nl = buf.indexOf("\n");
+					if (nl >= 0) {
+						try {
+							finish(JSON.parse(buf.slice(0, nl)));
+						} catch {
+							finish(null);
+						}
+						c.end();
+					}
+				},
+			},
+		}).catch(() => finish(null));
+		setTimeout(() => finish(null), timeoutMs);
+	});
 }
 
 /** Spawn a fresh manager on a temp socket and wait for it to bind. */
@@ -218,6 +254,22 @@ test("adopted spare's hello_ack advertises BOTH tenant AND env (#1872 contract)"
 	expect(ack).toMatchObject({ tenant: "acme", env: "staging" });
 	await send({ type: "release", sessionId: "tab-7" });
 }, 60_000);
+
+test("answers the hello handshake with its version + pid and publishes manager.json (#1874)", async () => {
+	await startManager();
+
+	const ack = await request({ type: "hello" });
+	expect(ack).not.toBeNull();
+	expect(ack).toMatchObject({ type: "manager_hello_ack", version: VERSION });
+	expect(typeof ack?.pid).toBe("number");
+
+	// Liveness record sits next to the socket and carries THIS manager's version.
+	const statePath = path.join(path.dirname(sock), "manager.json");
+	expect(fs.existsSync(statePath)).toBe(true);
+	const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+	expect(state).toMatchObject({ version: VERSION, socket: sock, pid: ack?.pid });
+	expect(typeof state.startedAt).toBe("number");
+}, 30_000);
 
 test("falls back to cold-spawn when the pool is disabled (XCSH_WORKER_POOL_SIZE=0)", async () => {
 	const getErr = await startManagerWithPool("0");


### PR DESCRIPTION
Closes #1874 (incremental — see Remaining below).

## Problem
The Chrome extension was silently pinned to an **old** xcsh version across `brew upgrade`s. Root cause (found on a live machine — installed 19.58.1, manager daemon 19.56.2, up 1d+): the native-messaging wrapper hardcoded the versioned Cellar path, so every Chrome launch ran the old binary; the single-manager invariant is version-blind; the manager has no signal handling; no update path recycles it.

## This PR (foundation + the root-cause fix)
1. **Version-stable wrapper** — `nativeHostLaunchCommand` now prefers the PATH/symlink `xcsh` (e.g. `/opt/homebrew/bin/xcsh`, which Homebrew repoints on upgrade) over the versioned `execPath`, for both compiled and bun installs. **This is the core fix** — upgrades now reach the extension. Unit matrix in `test/chrome-cli.test.ts` (compiled→symlink, never a Cellar path; fallbacks).
2. **Pure lifecycle helpers** (`manager-core`) — `shouldSupersede` (fail-closed semver), `ManagerState` serialize/parse, `parseControlMsg` extended for `hello`/`shutdown{reason}`. 17 unit cells.
3. **Version identity** — manager writes `~/.xcsh/manager.json {pid,version,socket,startedAt}` on bind and answers `{type:"hello"}` with `{type:"manager_hello_ack",version,pid}` (VERSION from the lean `pi-utils/dirs` subpath, not the barrel). `manager.int` assertion added; also verified manually.

## Remaining (same branch, incremental commits to follow)
4. Graceful SIGTERM/SIGINT + `shutdown` frame → stop accepting, reap spares, **bounded-drain** bound workers, unlink socket+state, exit 0.
5. Version-aware **supersede** in native-host (`hello` → `shouldSupersede` → step down → spawn new).
6. Zero-downtime worker **re-adoption** on manager startup.
7. Update integration (`update-cli`/`install.sh` refresh wrapper + signal recycle).

## Test note
`manager.int` / `native-host*.int` spawn real subprocesses; the `bun src/cli.ts` cold-transpile is **timing-flaky in some local sandboxes** (exceeds the fixed socket-wait budget under load) but is **green in CI**. Task 3 behavior was verified manually here (hello ack + manager.json). `bun run check:types` → 0 errors.

Design: `docs/superpowers/specs/2026-07-05-xcsh-durable-manager-upgrade-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)