### PR TITLE
feat: zero-downtime worker re-adoption + proactive update recycle (#1874 Tasks 6-7)

### DIFF
--- a/packages/coding-agent/src/cli/chrome-cli.ts
+++ b/packages/coding-agent/src/cli/chrome-cli.ts
@@ -7,14 +7,30 @@
  */
 
 import * as fs from "node:fs";
+import { homedir } from "node:os";
 import * as path from "node:path";
 import { acquirePage, type BrowserProviderStatus, CdpBrowserProvider } from "../browser";
 import { PORT_RANGE_END, PORT_RANGE_START, resolveForcedPort } from "../browser/extension-bridge";
 import { installNativeHost } from "../services/native-host-install";
 
+/** Ask a running manager to step down (control-socket `shutdown` frame). Resolves
+ * true if a manager answered the socket, false if none was running. Best-effort. */
+async function requestManagerShutdown(reason: "updated"): Promise<boolean> {
+	const sock = process.env.XCSH_MANAGER_SOCK ?? path.join(homedir(), ".xcsh", "manager.sock");
+	try {
+		const c = await Bun.connect({ unix: sock, socket: { data() {} } });
+		c.write(`${JSON.stringify({ type: "shutdown", reason })}\n`);
+		await Bun.sleep(50);
+		c.end();
+		return true;
+	} catch {
+		return false; // no manager listening
+	}
+}
+
 type Settings = { get(key: string): unknown };
 
-export type ChromeAction = "status" | "relaunch" | "setup" | "install-host";
+export type ChromeAction = "status" | "relaunch" | "setup" | "install-host" | "recycle";
 
 export const EXTENSION_ID = "klajkjdoehjidngligegnpknogmjjhkc";
 
@@ -115,6 +131,18 @@ export async function runChromeCommand(action: ChromeAction, settings: Settings)
 		const launchCommand = nativeHostLaunchCommand();
 		const manifestPath = installNativeHost({ launchCommand, extensionIds: [EXTENSION_ID] });
 		return `Native-messaging host manifest written to:\n  ${manifestPath}`;
+	}
+	if (action === "recycle") {
+		// Proactive post-upgrade recycle (#1874 Task 7): refresh the wrapper to the
+		// version-stable launcher, then ask any running (old) manager to step down so
+		// the new version takes effect NOW instead of on the next Chrome launch. The
+		// successor re-adopts live workers (zero-downtime). Both best-effort.
+		const launchCommand = nativeHostLaunchCommand();
+		installNativeHost({ launchCommand, extensionIds: [EXTENSION_ID] });
+		const stepped = await requestManagerShutdown("updated");
+		return stepped
+			? "Refreshed native-host wrapper; asked the running manager to recycle to this version."
+			: "Refreshed native-host wrapper; no manager was running (it will start fresh on next use).";
 	}
 	// relaunch: self-consented rung 3 — force allowRelaunch regardless of the setting.
 	const { mode } = await acquirePage({ settings, allowRelaunch: true });

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -315,6 +315,10 @@ function updateViaBrew(targetPath: string, expectedVersion: string): void {
 	console.log(chalk.yellow(`To update to ${expectedVersion}, run:`));
 	console.log(chalk.cyan(`  brew upgrade ${APP_NAME}`));
 	console.log(chalk.dim("\nThis ensures the update goes through your organization's Homebrew tap."));
+	// #1874 Task 7: brew upgrade runs out-of-band, so we can't recycle automatically.
+	// Nudge the one command that applies it to the Chrome extension immediately.
+	console.log(chalk.dim(`Then run  ${APP_NAME} chrome recycle  to apply it to the extension now`));
+	console.log(chalk.dim("(otherwise it takes effect the next time you open Chrome)."));
 }
 
 /**
@@ -412,6 +416,18 @@ export async function runUpdateCommand(opts: { force: boolean; check: boolean })
 			case "binary":
 				await updateViaBinaryAt(target.path, release.version);
 				break;
+		}
+
+		// #1874 Task 7: the binary just changed under a possibly-running OLD manager.
+		// Proactively recycle so the new version takes effect now instead of on the
+		// next Chrome launch — refresh the native-host wrapper + step the old manager
+		// down (its successor re-adopts live workers, zero-downtime). The just-updated
+		// `xcsh` on PATH is the new version. Best-effort, non-blocking; passive
+		// supersede covers it if this is skipped.
+		try {
+			Bun.spawn(["xcsh", "chrome", "recycle"], { stdout: "ignore", stderr: "ignore" });
+		} catch {
+			/* recycle is a convenience — never fail an update on it */
 		}
 	} catch (err) {
 		console.error(chalk.red(`Update failed: ${err}`));

--- a/packages/coding-agent/src/commands/chrome.ts
+++ b/packages/coding-agent/src/commands/chrome.ts
@@ -5,7 +5,7 @@ import { Args, Command } from "@f5-sales-demo/pi-utils/cli";
 import { type ChromeAction, runChromeCommand } from "../cli/chrome-cli";
 import { Settings, settings } from "../config/settings";
 
-const ACTIONS: ChromeAction[] = ["status", "relaunch", "setup", "install-host"];
+const ACTIONS: ChromeAction[] = ["status", "relaunch", "setup", "install-host", "recycle"];
 
 export default class Chrome extends Command {
 	static description = "Inspect or arrange the Chrome session xcsh drives for console automation";

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -54,6 +54,66 @@ function isPortFree(port: number): boolean {
 	}
 }
 
+/** The PID listening on a loopback bridge port, or 0 if unknown (best-effort via
+ * lsof). Used only to give a re-adopted worker a reapable pid; 0 means "manage by
+ * socket liveness, never signal" (see killPid's pid<=0 guard). */
+function pidListeningOn(port: number): number {
+	try {
+		const out = Bun.spawnSync(["lsof", "-t", `-iTCP:${port}`, "-sTCP:LISTEN"])
+			.stdout.toString()
+			.trim()
+			.split("\n")[0];
+		const pid = Number(out);
+		return Number.isInteger(pid) && pid > 0 ? pid : 0;
+	} catch {
+		return 0; // lsof unavailable — leave unknown
+	}
+}
+
+/** Complete the extension `hello` handshake against a bridge port (with the
+ * origin header the bridge requires), resolving the `hello_ack` frame or null.
+ * EXTENSION_ID is lazy-required so it stays off the manager's cold-start path. */
+function bridgeHello(port: number, timeoutMs = 400): Promise<Record<string, unknown> | null> {
+	return new Promise(resolve => {
+		let done = false;
+		const finish = (v: Record<string, unknown> | null) => {
+			if (done) return;
+			done = true;
+			resolve(v);
+		};
+		let ws: WebSocket;
+		try {
+			const { EXTENSION_ID } = require("../cli/chrome-cli");
+			ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+				headers: { Origin: `chrome-extension://${EXTENSION_ID}` },
+			} as unknown as string[]);
+		} catch {
+			return finish(null);
+		}
+		const close = () => {
+			try {
+				ws.close();
+			} catch {
+				/* already closing */
+			}
+		};
+		ws.onopen = () => ws.send(JSON.stringify({ type: "hello" }));
+		ws.onmessage = e => {
+			try {
+				finish(JSON.parse(String(e.data)) as Record<string, unknown>);
+			} catch {
+				finish(null);
+			}
+			close();
+		};
+		ws.onerror = () => finish(null);
+		setTimeout(() => {
+			close();
+			finish(null);
+		}, timeoutMs);
+	});
+}
+
 /**
  * The argv (AFTER `process.execPath`) to re-run THIS binary in `mode`.
  *
@@ -195,6 +255,34 @@ export default class Manager extends Command {
 			for (let i = 0; i < n; i++) spawnSpare();
 		};
 
+		/** Zero-downtime handoff (#1874 Task 6): on startup, discover bridge workers a
+		 * PRIOR (superseded) manager left running and re-register them, so a tab's
+		 * session survives the manager swap. Probes the whole range in parallel; a
+		 * bridge answering with a real per-tab sessionId (not the "spare" sentinel) and
+		 * a tenant+env is re-adopted. Spares/unknowns are ignored (the pool refills
+		 * them). Best-effort — never throws. */
+		const readoptWorkers = async (): Promise<void> => {
+			const found = await Promise.all(range.map(async port => ({ port, ack: await bridgeHello(port) })));
+			for (const { port, ack } of found) {
+				if (!ack) continue;
+				const sid = ack.sessionId;
+				const tenant = ack.tenant;
+				const env = ack.env;
+				if (typeof sid !== "string" || sid === "spare" || typeof tenant !== "string" || typeof env !== "string") {
+					continue; // spare sentinel or tenant-less bridge — not a re-adoptable session
+				}
+				if (reg.has(sid)) continue;
+				reg.set(sid, {
+					sessionId: sid,
+					tenant: `${tenant}|${env}`,
+					port,
+					pid: pidListeningOn(port),
+					lastSeen: Date.now(),
+				});
+				console.error(`[xcsh manager] re-adopted worker ${sid} (${tenant}|${env}) on port ${port}`);
+			}
+		};
+
 		/** Adopt a warm spare for a provision (bind over IPC). Returns false if none available. */
 		const adoptSpare = (msg: { sessionId: string; tenant: string }): boolean => {
 			const rec = pool.shift();
@@ -219,18 +307,8 @@ export default class Manager extends Command {
 			return true;
 		};
 
-		const reap = (sessionId: string): void => {
-			const w = reg.get(sessionId);
-			if (!w) return;
-			try {
-				process.kill(w.pid);
-			} catch {
-				/* already gone */
-			}
-			reg.delete(sessionId);
-		};
-
 		const killPid = (pid: number): void => {
+			if (pid <= 0) return; // 0/negative = unknown (re-adopted worker) — NEVER signal (kill(0) hits the group)
 			try {
 				process.kill(pid); // SIGTERM — spares exit at once; bound workers self-drain (worker.ts)
 			} catch {
@@ -238,21 +316,35 @@ export default class Manager extends Command {
 			}
 		};
 
+		const reap = (sessionId: string): void => {
+			const w = reg.get(sessionId);
+			if (!w) return;
+			killPid(w.pid);
+			reg.delete(sessionId);
+		};
+
 		/** Graceful teardown (#1874): stop accepting, terminate the (session-less)
-		 * spare pool at once, SIGTERM bound workers so they drain their in-flight turn,
-		 * drop the socket + liveness record, and exit. Idempotent. Bounded by each
-		 * worker's own drain ceiling — the manager frees the socket immediately so a
-		 * successor can bind without waiting on drains. */
+		 * spare pool at once, drop the socket + liveness record, and exit. Idempotent.
+		 *
+		 * Bound workers depend on the reason: on a HANDOFF (superseded/updated — a
+		 * successor manager is about to bind and re-adopt them), we LEAVE them running
+		 * so tab sessions survive the swap (zero-downtime, Task 6). Otherwise (manual
+		 * operator SIGTERM — no successor) we SIGTERM them so they drain + exit rather
+		 * than leak. The manager frees the socket immediately either way. */
 		const gracefulShutdown = (reason: string): void => {
 			if (shuttingDown) return;
 			shuttingDown = true;
 			accepting = false;
+			const handoff = reason === "superseded" || reason === "updated";
 			console.error(
-				`[xcsh manager] graceful shutdown (${reason}); reaping ${pool.length} spare(s) + ${reg.size} worker(s)`,
+				`[xcsh manager] graceful shutdown (${reason}); reaping ${pool.length} spare(s)` +
+					(handoff ? `, leaving ${reg.size} worker(s) for re-adoption` : ` + ${reg.size} worker(s)`),
 			);
 			for (const s of pool.splice(0)) killPid(s.pid);
-			for (const w of reg.values()) killPid(w.pid);
-			reg.clear();
+			if (!handoff) {
+				for (const w of reg.values()) killPid(w.pid);
+				reg.clear();
+			}
 			removeManagerState(sockPath);
 			try {
 				fs.rmSync(sockPath, { force: true });
@@ -408,6 +500,11 @@ export default class Manager extends Command {
 		// down gracefully instead of orphaning workers + a stale socket/state file.
 		process.on("SIGTERM", () => gracefulShutdown("manual"));
 		process.on("SIGINT", () => gracefulShutdown("manual"));
+
+		// Zero-downtime handoff: re-adopt any bound workers a superseded manager left
+		// running BEFORE filling the pool (so their ports aren't mistaken for free).
+		// Awaited but bounded (~parallel 400ms); the socket already accepts connections.
+		await readoptWorkers();
 
 		// Pre-warm the spare pool so provisions can adopt instead of cold-spawn.
 		if (poolTarget > 0) maintainPool();

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -294,6 +294,42 @@ test("graceful shutdown frame reaps spares, removes the socket + manager.json, e
 	expect(await request({ type: "hello" }, 800)).toBeNull();
 }, 30_000);
 
+test("superseded shutdown LEAVES bound workers alive for re-adoption; manual reaps them (#1874 Task 6)", async () => {
+	const getErr = await startManagerWithPool("1");
+	expect(await waitForStderr(getErr, "pre-warmed spare", 120)).toBe(true);
+	await send({ type: "provision", sessionId: "tab-7", tenant: "acme|staging" });
+	const port = await findTenant("acme", 80);
+	expect(port).not.toBeNull();
+
+	// Handoff reason → the worker's bridge must SURVIVE the manager exit (the
+	// successor will re-adopt it), so its port keeps answering the handshake.
+	await send({ type: "shutdown", reason: "superseded" });
+	let socketGone = false;
+	for (let i = 0; i < 100; i++) {
+		if (!fs.existsSync(sock)) {
+			socketGone = true;
+			break;
+		}
+		await Bun.sleep(100);
+	}
+	expect(socketGone).toBe(true); // manager exited
+	expect(getErr()).toContain("leaving 1 worker(s) for re-adoption");
+	const survived = await probe(port as number).then(
+		a => a.tenant === "acme",
+		() => false,
+	);
+	expect(survived).toBe(true); // zero-downtime: the worker outlived its manager
+
+	// Clean it up (no successor in this test) — SIGTERM the surviving worker's port.
+	for (const pid of await pidsOnPort(port as number)) {
+		try {
+			process.kill(pid);
+		} catch {
+			/* gone */
+		}
+	}
+}, 30_000);
+
 test("falls back to cold-spawn when the pool is disabled (XCSH_WORKER_POOL_SIZE=0)", async () => {
 	const getErr = await startManagerWithPool("0");
 

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -330,6 +330,30 @@ test("superseded shutdown LEAVES bound workers alive for re-adoption; manual rea
 	}
 }, 30_000);
 
+test("`chrome recycle` steps down the running manager for an upgrade (#1874 Task 7)", async () => {
+	await startManager();
+	// Temp HOME so the wrapper refresh writes to a throwaway Chrome dir, not the
+	// developer's real native-host manifest.
+	const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-recycle-home-"));
+	const rc = Bun.spawn(["bun", "src/cli.ts", "chrome", "recycle"], {
+		cwd: process.cwd(),
+		env: { ...process.env, HOME: fakeHome, XCSH_MANAGER_SOCK: sock },
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+	await rc.exited;
+	let gone = false;
+	for (let i = 0; i < 100; i++) {
+		if (!fs.existsSync(sock)) {
+			gone = true;
+			break;
+		}
+		await Bun.sleep(100);
+	}
+	expect(gone).toBe(true); // recycle sent {shutdown, reason:"updated"} → manager stepped down
+	fs.rmSync(fakeHome, { recursive: true, force: true });
+}, 30_000);
+
 test("falls back to cold-spawn when the pool is disabled (XCSH_WORKER_POOL_SIZE=0)", async () => {
 	const getErr = await startManagerWithPool("0");
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -282,3 +282,14 @@ case "$MODE" in
         fi
         ;;
 esac
+
+# #1874 Task 7: if this was a re-install/upgrade, proactively recycle so the new
+# version reaches the Chrome extension now (refresh the native-host wrapper +
+# step down a running old manager; the successor re-adopts live workers). Fully
+# best-effort — must never fail the install. Resolve xcsh from PATH or the
+# install dir; skip silently if not found (passive supersede covers it).
+XCSH_BIN="$(command -v xcsh 2>/dev/null || true)"
+[ -z "$XCSH_BIN" ] && [ -x "$INSTALL_DIR/xcsh" ] && XCSH_BIN="$INSTALL_DIR/xcsh"
+if [ -n "$XCSH_BIN" ]; then
+    "$XCSH_BIN" chrome recycle >/dev/null 2>&1 || true
+fi


### PR DESCRIPTION
Closes #1874 (final tasks 6 & 7 — completes the durable manager upgrade).

## Task 6 — zero-downtime worker re-adoption
Make an upgrade/supersede seamless for live tabs:
- On startup, `readoptWorkers()` probes the bridge range (parallel `hello`, origin header) and **re-registers** any bound worker a prior (superseded) manager left running — real per-tab `sessionId` + `tenant|env`; the `"spare"` sentinel is skipped. Runs after the socket is listening, before the pool fills.
- `gracefulShutdown` is now **reason-aware**: on a **handoff** (`superseded`/`updated` — a successor will re-adopt) it **leaves** bound workers running so tab sessions survive the swap; on **manual** shutdown it SIGTERMs them so they drain + exit rather than leak.
- Safety: `killPid` guards `pid<=0` (a re-adopted worker whose pid `lsof` couldn't resolve is managed by socket liveness — `process.kill(0)` would signal the whole group).

## Task 7 — proactive recycle after upgrade
- New **`xcsh chrome recycle`**: refresh the wrapper to the version-stable launcher + send the running manager `{shutdown, reason:"updated"}` so the new version takes effect **now** (successor re-adopts workers). Passive supersede stays the backstop.
- `update-cli` self-update paths spawn it on success; the brew path prints the one-liner; `install.sh` runs it best-effort post-install.

## Verified (manual, since the int harness is timing-flaky locally — green in CI)
- Orphaned bound worker → re-adopted by a fresh manager (`re-adopted worker tab-9 (acme|production)`), stays alive.
- `superseded` shutdown → worker **survives**; `manual` → worker reaped.
- `chrome recycle` → manager logs `graceful shutdown (updated)` and steps down; wrapper written to the (temp) Chrome dir.
- `bun run check:types` → 0 errors. New CI tests: handoff (superseded leaves worker) + recycle (manager steps down).

## #1874 complete
1 version-stable wrapper · 2 lifecycle helpers · 3 version identity · 4 graceful signals + drain · 5 version-aware supersede · **6 zero-downtime re-adoption** · **7 proactive recycle**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)