### PR TITLE
fix: F5 XC API-spec retrieval ergonomics (glob-guard, in-spec search, cross-domain) + cycle & stale-specs fixes

### DIFF
--- a/packages/coding-agent/scripts/api-specs-version.ts
+++ b/packages/coding-agent/scripts/api-specs-version.ts
@@ -1,0 +1,20 @@
+/**
+ * Version helpers for selecting the api-specs-enriched source.
+ *
+ * Kept in a dedicated module (no side effects) so the freshness logic is unit-testable
+ * without importing generate-api-spec-index.ts, which runs the generator on load.
+ */
+
+/** Normalize a release tag (`v2.1.167`) or bare version (`2.1.167`) to a bare version. */
+export function normalizeSpecsTag(tag: string): string {
+	return tag.trim().replace(/^v/, "");
+}
+
+/**
+ * Whether a local api-specs-enriched checkout matches the latest release tag.
+ * A stale checkout must NOT be used, or local/dev builds silently pin to old specs.
+ */
+export function isLocalSpecsCurrent(localVersion: string | undefined, latestTag: string): boolean {
+	if (!localVersion) return false;
+	return normalizeSpecsTag(localVersion) === normalizeSpecsTag(latestTag);
+}

--- a/packages/coding-agent/scripts/generate-api-spec-index.ts
+++ b/packages/coding-agent/scripts/generate-api-spec-index.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { $ } from "bun";
+import { isLocalSpecsCurrent } from "./api-specs-version";
 
 interface SpecPathOperation {
 	operationId?: string;
@@ -183,15 +184,42 @@ async function downloadFromRelease(): Promise<string> {
 	return extractDir;
 }
 
+function readLocalSpecsVersion(specsDir: string): string | undefined {
+	try {
+		const index = JSON.parse(fs.readFileSync(path.join(specsDir, "index.json"), "utf-8")) as { version?: string };
+		return index.version;
+	} catch {
+		return undefined;
+	}
+}
+
 async function findSpecsDir(): Promise<string> {
 	const envDir = process.env.API_SPECS_DIR;
 	if (envDir && fs.existsSync(envDir)) {
+		// Explicit override — the caller is responsible for its freshness.
 		return envDir;
 	}
 
 	const localCheckout = path.resolve(import.meta.dir, "../../../../api-specs-enriched/docs/specifications/api");
 	if (fs.existsSync(localCheckout)) {
-		return localCheckout;
+		// Only build from the local checkout when it matches the latest release, so a
+		// stale checkout cannot silently pin the build to old specs. If GitHub is
+		// unreachable (offline dev), fall back to the local checkout with a warning.
+		try {
+			const latestTag = await resolveLatestTag();
+			const localVersion = readLocalSpecsVersion(localCheckout);
+			if (isLocalSpecsCurrent(localVersion, latestTag)) {
+				return localCheckout;
+			}
+			console.warn(
+				`Local api-specs-enriched checkout is stale (local ${localVersion ?? "unknown"} != latest ${latestTag}); building against the latest release instead.`,
+			);
+		} catch (err) {
+			console.warn(
+				`Could not verify the latest api-specs version (${err instanceof Error ? err.message : err}); using the local checkout.`,
+			);
+			return localCheckout;
+		}
 	}
 
 	return downloadFromRelease();

--- a/packages/coding-agent/src/edit/modes/chunk.ts
+++ b/packages/coding-agent/src/edit/modes/chunk.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as nodePath from "node:path";
 import type { AgentToolResult } from "@f5-sales-demo/pi-agent-core";
+import { StringEnum } from "@f5-sales-demo/pi-ai";
 import {
 	ChunkAnchorStyle,
 	ChunkEditOp,
@@ -12,7 +13,6 @@ import {
 	type EditOperation as NativeEditOperation,
 } from "@f5-sales-demo/pi-natives";
 import { $envpos } from "@f5-sales-demo/pi-utils";
-import { StringEnum } from "@f5-sales-demo/xcsh";
 import { type Static, Type } from "@sinclair/typebox";
 import type { BunFile } from "bun";
 import { LRUCache } from "lru-cache";

--- a/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
@@ -47,29 +47,25 @@ export function createApiSpecResolver(
 	return {
 		async resolve(url: InternalUrl): Promise<InternalResource> {
 			const pathname = url.rawPathname ?? url.pathname;
-			const domain = pathname.replace(/^\//, "").replace(/\/$/, "");
-
-			if (!domain) {
-				return makeResource(url, renderDomainIndex(index));
-			}
+			const requestedDomain = pathname.replace(/^\//, "").replace(/\/$/, "");
 
 			// Reserved sub-paths — checked before domain lookup
-			if (domain === "workflows" || domain.startsWith("workflows/")) {
-				const workflowId = domain.replace(/^workflows\/?/, "");
+			if (requestedDomain === "workflows" || requestedDomain.startsWith("workflows/")) {
+				const workflowId = requestedDomain.replace(/^workflows\/?/, "");
 				return makeResource(url, workflowId ? renderWorkflowDetail(workflowId, index) : renderWorkflowIndex(index));
 			}
 
-			if (domain === "errors" || domain.startsWith("errors/")) {
-				const errorKey = domain.replace(/^errors\/?/, "");
+			if (requestedDomain === "errors" || requestedDomain.startsWith("errors/")) {
+				const errorKey = requestedDomain.replace(/^errors\/?/, "");
 				return makeResource(url, errorKey ? renderErrorDetail(errorKey, index) : renderErrorIndex(index));
 			}
 
-			if (domain === "glossary" || domain.startsWith("glossary/")) {
+			if (requestedDomain === "glossary" || requestedDomain.startsWith("glossary/")) {
 				return makeResource(url, renderGlossary(index));
 			}
 
-			if (domain === "validation" || domain.startsWith("validation/")) {
-				const resourceKey = domain.replace(/^validation\/?/, "");
+			if (requestedDomain === "validation" || requestedDomain.startsWith("validation/")) {
+				const resourceKey = requestedDomain.replace(/^validation\/?/, "");
 				return makeResource(
 					url,
 					resourceKey
@@ -78,32 +74,55 @@ export function createApiSpecResolver(
 				);
 			}
 
-			const entry = index.domains.find(d => d.domain === domain);
-			if (!entry) {
-				return makeResource(url, renderUnknownDomain(domain, index));
+			const resourceName = url.searchParams.get("resource");
+
+			// Resolve the domain entry. When a resource is named against a wrong or
+			// omitted domain (e.g. `config?resource=http_loadbalancer`), fall back to
+			// the domain that actually owns that resource instead of erroring out.
+			let entry = requestedDomain ? index.domains.find(d => d.domain === requestedDomain) : undefined;
+			let resolutionNote: string | undefined;
+			if (!entry && resourceName) {
+				const owner = findDomainForResource(index, resourceName);
+				if (owner) {
+					entry = owner;
+					resolutionNote = requestedDomain
+						? `> Note: domain \`${requestedDomain}\` not found; resolved resource \`${resourceName}\` in domain \`${owner.domain}\`.`
+						: `> Note: no domain specified; resolved resource \`${resourceName}\` in domain \`${owner.domain}\`.`;
+				}
 			}
 
+			if (!entry) {
+				return makeResource(
+					url,
+					requestedDomain ? renderUnknownDomain(requestedDomain, index) : renderDomainIndex(index),
+				);
+			}
+
+			const domain = entry.domain;
+			const withNote = (content: string): string => (resolutionNote ? `${resolutionNote}\n\n${content}` : content);
+
 			try {
-				const resource = url.searchParams.get("resource");
 				const pathFilter = url.searchParams.get("path");
 
-				if (resource) {
+				if (resourceName) {
 					const crud = url.searchParams.get("crud") === "true";
 					const spec = lookup(domain);
-					const matchingPaths = filterPathsByResource(spec, resource, entry);
+					const matchingPaths = filterPathsByResource(spec, resourceName, entry);
 					if (Object.keys(matchingPaths).length === 0) {
-						return makeResource(url, renderUnknownResource(resource, entry, spec));
+						return makeResource(url, withNote(renderUnknownResource(resourceName, entry, spec)));
 					}
 					return makeResource(
 						url,
-						renderResourceSpec(
-							domain,
-							resource,
-							spec,
-							entry,
-							{ crudOnly: crud },
-							enrichments?.[domain],
-							validationData,
+						withNote(
+							renderResourceSpec(
+								domain,
+								resourceName,
+								spec,
+								entry,
+								{ crudOnly: crud },
+								enrichments?.[domain],
+								validationData,
+							),
 						),
 					);
 				}
@@ -121,6 +140,11 @@ export function createApiSpecResolver(
 			}
 		},
 	};
+}
+
+/** Find the domain entry that owns a resource by name (for cross-domain resolution). */
+function findDomainForResource(index: ApiSpecIndex, resourceName: string): ApiSpecDomainEntry | undefined {
+	return index.domains.find(d => d.resources.some(r => r.name === resourceName));
 }
 
 function makeResource(url: InternalUrl, content: string): InternalResource {

--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -121,7 +121,7 @@ export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolD
 			if (rawPath) {
 				const internalRouter = this.session.internalRouter;
 				if (internalRouter?.canHandle(rawPath)) {
-					if (hasGlobPathChars(rawPath)) {
+					if (hasGlobPathChars(rawPath.split("?", 1)[0] ?? rawPath)) {
 						throw new ToolError(`Glob patterns are not supported for internal URLs: ${rawPath}`);
 					}
 					const resource = await internalRouter.resolve(rawPath);

--- a/packages/coding-agent/src/tools/ast-grep.ts
+++ b/packages/coding-agent/src/tools/ast-grep.ts
@@ -108,7 +108,7 @@ export class AstGrepTool implements AgentTool<typeof astGrepSchema, AstGrepToolD
 			if (rawPath) {
 				const internalRouter = this.session.internalRouter;
 				if (internalRouter?.canHandle(rawPath)) {
-					if (hasGlobPathChars(rawPath)) {
+					if (hasGlobPathChars(rawPath.split("?", 1)[0] ?? rawPath)) {
 						throw new ToolError(`Glob patterns are not supported for internal URLs: ${rawPath}`);
 					}
 					const resource = await internalRouter.resolve(rawPath);

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -1,3 +1,5 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 import type {
 	AgentTool,
@@ -68,6 +70,29 @@ export interface GrepToolDetails {
 
 type GrepParams = Static<typeof grepSchema>;
 
+/**
+ * Materialize an in-memory internal resource (api-spec, api-catalog, docs, …) to a
+ * temp file so the native grep can search it. These resources render on demand and
+ * expose only a synthetic `sourcePath` (e.g. `xcsh://api-spec/virtual`), so there is
+ * no real file to search. The caller removes the temp dir once grep returns.
+ */
+async function materializeInternalContent(
+	resource: { content: string; contentType?: string },
+	rawPath: string,
+): Promise<{ dir: string; file: string }> {
+	const ext =
+		resource.contentType === "application/json" ? "json" : resource.contentType === "text/markdown" ? "md" : "txt";
+	const label =
+		rawPath
+			.replace(/^[a-z]+:\/\//i, "")
+			.replace(/[^a-zA-Z0-9._-]+/g, "_")
+			.slice(0, 80) || "internal";
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-grep-"));
+	const file = path.join(dir, `${label}.${ext}`);
+	await Bun.write(file, resource.content);
+	return { dir, file };
+}
+
 export class GrepTool implements AgentTool<typeof grepSchema, GrepToolDetails> {
 	readonly name = "grep";
 	readonly label = "Grep";
@@ -127,20 +152,29 @@ export class GrepTool implements AgentTool<typeof grepSchema, GrepToolDetails> {
 			};
 			let searchPath: string;
 			let scopePath: string;
+			let internalTempDir: { dir: string; file: string } | undefined;
 			let globFilter = glob ? normalizePathLikeInput(glob) || undefined : undefined;
 			const internalRouter = this.session.internalRouter;
 			if (searchDir?.trim()) {
 				const rawPath = normalizePathLikeInput(searchDir);
 				if (internalRouter?.canHandle(rawPath)) {
-					if (hasGlobPathChars(rawPath)) {
+					// A query string (?resource=…) is not a glob — only check the path portion.
+					if (hasGlobPathChars(rawPath.split("?", 1)[0] ?? rawPath)) {
 						throw new ToolError(`Glob patterns are not supported for internal URLs: ${rawPath}`);
 					}
 					const resource = await internalRouter.resolve(rawPath);
-					if (!resource.sourcePath) {
-						throw new ToolError(`Cannot grep internal URL without a backing file: ${rawPath}`);
+					const diskPath =
+						resource.sourcePath && !resource.sourcePath.includes("://") ? resource.sourcePath : undefined;
+					if (diskPath && (await Bun.file(diskPath).exists())) {
+						searchPath = diskPath;
+						scopePath = formatScopePath(searchPath);
+					} else {
+						// api-spec/api-catalog/etc. render in memory with a synthetic sourcePath;
+						// materialize the content so the native grep can search it.
+						internalTempDir = await materializeInternalContent(resource, rawPath);
+						searchPath = internalTempDir.file;
+						scopePath = rawPath;
 					}
-					searchPath = resource.sourcePath;
-					scopePath = formatScopePath(searchPath);
 				} else {
 					const multiSearchPath = await resolveMultiSearchPath(rawPath, this.session.cwd, globFilter);
 					if (multiSearchPath) {
@@ -202,6 +236,12 @@ export class GrepTool implements AgentTool<typeof grepSchema, GrepToolDetails> {
 					throw new ToolError(err.message);
 				}
 				throw err;
+			} finally {
+				// Non-chunk rendering below reads only match data, never the file, so the
+				// materialized temp copy of an internal resource can be removed now.
+				if (internalTempDir) {
+					await fs.rm(internalTempDir.dir, { recursive: true, force: true });
+				}
 			}
 
 			const formatPath = (filePath: string): string => {
@@ -277,7 +317,7 @@ export class GrepTool implements AgentTool<typeof grepSchema, GrepToolDetails> {
 				}
 				matchesByFile.get(relativePath)!.push(match);
 			}
-			if (chunkMode) {
+			if (chunkMode && !internalTempDir) {
 				const annotatedMatches = await Promise.all(
 					selectedMatches.map(match => {
 						const relativePath = match.path.startsWith("/") ? match.path.slice(1) : match.path;

--- a/packages/coding-agent/test/internal-urls/api-spec-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/api-spec-resolve.test.ts
@@ -1260,4 +1260,44 @@ describe("API Spec Resolver", () => {
 			expect(result.content).not.toContain("Quick Start");
 		});
 	});
+
+	describe("Cross-domain resource resolution (#3)", () => {
+		it("resolves a resource named against an unknown domain to its real domain", async () => {
+			const resolver = createApiSpecResolver(testIndex, testData);
+			// `config` is not a domain; dns_zone lives in `dns`.
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/config?resource=dns_zone"));
+			expect(result.content).toContain("dns_zone");
+			expect(result.content).toContain("Create DNS zone");
+			expect(result.content).not.toContain("Domain not found");
+		});
+
+		it("adds a resolution note when the requested domain was wrong", async () => {
+			const resolver = createApiSpecResolver(testIndex, testData);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/config?resource=dns_zone"));
+			expect(result.content).toContain("resolved resource");
+			expect(result.content).toContain("`dns`");
+			expect(result.content).toContain("`config`");
+		});
+
+		it("resolves a resource when no domain is specified", async () => {
+			const resolver = createApiSpecResolver(testIndex, testData);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/?resource=dns_zone"));
+			expect(result.content).toContain("dns_zone");
+			expect(result.content).toContain("Create DNS zone");
+			expect(result.content).toContain("resolved resource");
+		});
+
+		it("falls back to Domain not found when the resource exists nowhere", async () => {
+			const resolver = createApiSpecResolver(testIndex, testData);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/config?resource=not_a_real_resource"));
+			expect(result.content).toContain("Domain not found");
+		});
+
+		it("still lists the domain index when no domain and no resource are given", async () => {
+			const resolver = createApiSpecResolver(testIndex, testData);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/"));
+			expect(result.content).toContain("Domain");
+			expect(result.content).not.toContain("resolved resource");
+		});
+	});
 });

--- a/packages/coding-agent/test/scripts/api-specs-version.test.ts
+++ b/packages/coding-agent/test/scripts/api-specs-version.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { isLocalSpecsCurrent, normalizeSpecsTag } from "../../scripts/api-specs-version";
+
+describe("normalizeSpecsTag", () => {
+	it("strips a leading v", () => {
+		expect(normalizeSpecsTag("v2.1.167")).toBe("2.1.167");
+	});
+	it("leaves a bare version unchanged", () => {
+		expect(normalizeSpecsTag("2.1.167")).toBe("2.1.167");
+	});
+	it("trims surrounding whitespace", () => {
+		expect(normalizeSpecsTag("  v2.1.167  ")).toBe("2.1.167");
+	});
+});
+
+describe("isLocalSpecsCurrent", () => {
+	it("is true when the local version matches the latest tag", () => {
+		expect(isLocalSpecsCurrent("2.1.167", "v2.1.167")).toBe(true);
+	});
+	it("is true when neither side has a v prefix", () => {
+		expect(isLocalSpecsCurrent("2.1.167", "2.1.167")).toBe(true);
+	});
+	it("is false when the local checkout is behind the latest release", () => {
+		expect(isLocalSpecsCurrent("2.1.137", "v2.1.167")).toBe(false);
+	});
+	it("is false when the local version is unknown", () => {
+		expect(isLocalSpecsCurrent(undefined, "v2.1.167")).toBe(false);
+		expect(isLocalSpecsCurrent("", "v2.1.167")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/tools/ast-edit.test.ts
+++ b/packages/coding-agent/test/tools/ast-edit.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { adaptSchemaForStrict } from "@f5-sales-demo/pi-ai/utils/schema";
 import { sanitizeText } from "@f5-sales-demo/pi-natives";
 import { Settings } from "@f5-sales-demo/xcsh/config/settings";
+import { InternalUrlRouter } from "@f5-sales-demo/xcsh/internal-urls/router";
 import { ToolChoiceQueue } from "@f5-sales-demo/xcsh/session/tool-choice-queue";
 import { createTools, type ToolSession } from "@f5-sales-demo/xcsh/tools";
 import { astEditToolRenderer } from "@f5-sales-demo/xcsh/tools/ast-edit";
@@ -384,5 +385,35 @@ describe("ast-edit execute signals isWarning on 0 replacements", () => {
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
+	});
+});
+
+describe("ast_edit internal URL glob guard (#1)", () => {
+	it("does not treat a query string as a glob for internal URLs", async () => {
+		const router = new InternalUrlRouter();
+		router.register({
+			scheme: "spec",
+			async resolve() {
+				return { url: "spec://virtual?resource=x", content: "x", contentType: "text/plain" as const };
+			},
+		});
+		const tools = await createTools(createTestSession("/tmp/test", { internalRouter: router }));
+		const tool = tools.find(entry => entry.name === "ast_edit");
+		expect(tool).toBeDefined();
+
+		let error: Error | undefined;
+		try {
+			await tool!.execute("ast-edit-internal", {
+				ops: [{ pat: "foo($A)", out: "bar($A)" }],
+				lang: "typescript",
+				path: "spec://virtual?resource=http_loadbalancer",
+			});
+		} catch (e) {
+			error = e as Error;
+		}
+		// The `?` must NOT trip the glob guard; it reaches the no-backing-file path instead.
+		expect(error).toBeDefined();
+		expect(error!.message).not.toContain("Glob patterns are not supported");
+		expect(error!.message).toContain("without backing file");
 	});
 });

--- a/packages/coding-agent/test/tools/ast-grep.test.ts
+++ b/packages/coding-agent/test/tools/ast-grep.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { sanitizeText } from "@f5-sales-demo/pi-natives";
 import { Settings } from "@f5-sales-demo/xcsh/config/settings";
+import { InternalUrlRouter } from "@f5-sales-demo/xcsh/internal-urls/router";
 import { createTools, type ToolSession } from "@f5-sales-demo/xcsh/tools";
 import { astGrepToolRenderer } from "@f5-sales-demo/xcsh/tools/ast-grep";
 import { getThemeByName } from "../../src/modes/theme/theme";
@@ -260,5 +261,35 @@ describe("ast-grep execute signals isWarning on 0 matches", () => {
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
+	});
+});
+
+describe("ast_grep internal URL glob guard (#1)", () => {
+	it("does not treat a query string as a glob for internal URLs", async () => {
+		const router = new InternalUrlRouter();
+		router.register({
+			scheme: "spec",
+			async resolve() {
+				return { url: "spec://virtual?resource=x", content: "x", contentType: "text/plain" as const };
+			},
+		});
+		const tools = await createTools(createTestSession("/tmp/test", { internalRouter: router }));
+		const tool = tools.find(entry => entry.name === "ast_grep");
+		expect(tool).toBeDefined();
+
+		let error: Error | undefined;
+		try {
+			await tool!.execute("ast-grep-internal", {
+				pat: ["foo($A)"],
+				lang: "typescript",
+				path: "spec://virtual?resource=http_loadbalancer",
+			});
+		} catch (e) {
+			error = e as Error;
+		}
+		// The `?` must NOT trip the glob guard; it reaches the no-backing-file path instead.
+		expect(error).toBeDefined();
+		expect(error!.message).not.toContain("Glob patterns are not supported");
+		expect(error!.message).toContain("without backing file");
 	});
 });

--- a/packages/coding-agent/test/tools/grep-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/grep-internal-urls.test.ts
@@ -83,14 +83,14 @@ describe("GrepTool internal URL resolution", () => {
 		expect(text).not.toContain("INFO");
 	});
 
-	it("throws when internal URL has no sourcePath", async () => {
+	it("greps in-memory content when an internal URL has no backing file (#2)", async () => {
 		const router = new InternalUrlRouter();
 		router.register({
 			scheme: "agent",
 			async resolve() {
 				return {
 					url: "agent://0",
-					content: "some content",
+					content: "line one\nthe needle is here\nline three\n",
 					contentType: "text/plain" as const,
 				};
 			},
@@ -99,8 +99,51 @@ describe("GrepTool internal URL resolution", () => {
 		const session = createSession({ internalRouter: router });
 		const tool = new GrepTool(session);
 
-		expect(tool.execute("test-call", { pattern: "foo", path: "agent://0" })).rejects.toThrow(
-			"Cannot grep internal URL without a backing file",
+		const result = await tool.execute("test-call", { pattern: "needle", path: "agent://0" });
+		const text = getResultText(result);
+		expect(text).toContain("needle");
+	});
+
+	it("does not treat a query string as a glob for internal URLs (#1)", async () => {
+		const router = new InternalUrlRouter();
+		router.register({
+			scheme: "spec",
+			async resolve() {
+				return {
+					url: "spec://virtual?resource=http_loadbalancer",
+					content: "spec fields\n  request_logs: {}\n  other: 1\n",
+					contentType: "text/markdown" as const,
+					// synthetic, non-filesystem sourcePath (like api-spec/api-catalog)
+					sourcePath: "spec://virtual",
+				};
+			},
+		});
+
+		const session = createSession({ internalRouter: router });
+		const tool = new GrepTool(session);
+
+		// The `?` must NOT trigger "Glob patterns are not supported".
+		const result = await tool.execute("test-call", {
+			pattern: "request_logs",
+			path: "spec://virtual?resource=http_loadbalancer",
+		});
+		const text = getResultText(result);
+		expect(text).toContain("request_logs");
+	});
+
+	it("rejects real glob metacharacters in internal URL paths (#1)", async () => {
+		const router = new InternalUrlRouter();
+		router.register({
+			scheme: "spec",
+			async resolve() {
+				return { url: "spec://x", content: "x", contentType: "text/plain" as const };
+			},
+		});
+		const session = createSession({ internalRouter: router });
+		const tool = new GrepTool(session);
+
+		expect(tool.execute("test-call", { pattern: "foo", path: "spec://virtual*?resource=x" })).rejects.toThrow(
+			"Glob patterns are not supported for internal URLs",
 		);
 	});
 


### PR DESCRIPTION
Closes #1888.

## Context

A customer-facing xcsh session (customer wanting to log **legitimate requests**, not just WAF violations) exposed several API-spec *retrieval-ergonomics* defects. The knowledge is embedded in xcsh — the friction was reaching it, and a broken-looking error surfaced to the customer.

## Changes

1. **Glob-guard false positive (root cause of the customer-visible error).** `grep`/`ast-grep`/`ast-edit` ran `hasGlobPathChars()` on the raw internal URL, and `?` is a glob char — so every `xcsh://…?resource=…` URL was rejected. Now the query string is stripped before the check. Real glob chars (`*`,`[`,`{`) are still rejected.
2. **In-spec search.** `grep` now searches the resolved in-memory `content` of internal URLs (they expose a synthetic `sourcePath`), replacing blind `L1-L100 → L800` paging. Materializes to a temp file for the native grep, disables chunk mode for it, and cleans up. Generalizes to all `xcsh://` resources.
3. **Cross-domain resolution.** `api-spec/config?resource=http_loadbalancer` (wrong domain) and `api-spec/?resource=…` (no domain) now resolve to the domain that owns the resource, with a resolution note; falls back to "Domain not found" only when the resource exists nowhere.
4. **Pre-existing import cycle (TDZ).** `grep-internal-urls.test.ts` failed on a clean tree with `Cannot access 'grepToolRenderer' before initialization`: `edit/modes/chunk.ts` imported `StringEnum` from the whole-app barrel `@f5-sales-demo/xcsh`, forming `grep.ts → chunk.ts → src/index.ts → modes/components → renderers.ts → grep.ts`. Fixed by importing `StringEnum` directly from `@f5-sales-demo/pi-ai`.
5. **Stale-specs pin.** `findSpecsDir()` preferred a local `../api-specs-enriched` checkout with no freshness check, silently building against stale specs (local v2.1.137 vs upstream v2.1.167). Added a freshness check (extracted a unit-tested comparator) so builds use the latest specs; falls back to local only when offline.

## Request-logging tie-in (#4, upstream)

The concept→resource guided workflow (`enable_request_logging`) is delivered at the root cause — f5-sales-demo/api-specs-enriched#924 — and reaches xcsh's embedded index via the existing `enriched-specs-updated` repository_dispatch automation (no hand-committed generated files here).

## Testing

- `test/tools/grep-internal-urls.test.ts`, `test/tools/ast-grep.test.ts`, `test/tools/ast-edit.test.ts`, `test/internal-urls/api-spec-resolve.test.ts` — 100 passed (TDD: red → green).
- `test/scripts/api-specs-version.test.ts` — 7 passed (freshness comparator).
- `bunx biome check` clean; `tsgo -p tsconfig.json --noEmit` clean (exit 0).
- Verified `grep`/`read` against `xcsh://api-spec/virtual?resource=http_loadbalancer` no longer errors, and importing `grep.ts` alone no longer throws the TDZ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)