### PR TITLE
fix: unbreak release build — replace require("./read") with ESM import

### DIFF
--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -25,6 +25,7 @@ import { inspectImageToolRenderer } from "./inspect-image-renderer";
 import { mermaidRenderer } from "./mermaid-renderer";
 import { notebookToolRenderer } from "./notebook";
 import { pythonToolRenderer } from "./python";
+import { readToolRenderer } from "./read";
 import { resolveToolRenderer } from "./resolve";
 import { searchToolBm25Renderer } from "./search-tool-bm25";
 import { sshToolRenderer } from "./ssh";
@@ -60,11 +61,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
 	notebook: notebookToolRenderer as ToolRenderer,
 	display_image: displayImageToolRenderer as ToolRenderer,
 	inspect_image: inspectImageToolRenderer as ToolRenderer,
-	// Lazy getter to break circular dependency: renderers.ts <- read.ts
-	get read(): ToolRenderer {
-		// eslint-disable-next-line @typescript-eslint/no-require-imports
-		return require("./read").readToolRenderer as ToolRenderer;
-	},
+	read: readToolRenderer as ToolRenderer,
 	resolve: resolveToolRenderer as ToolRenderer,
 	search_tool_bm25: searchToolBm25Renderer as ToolRenderer,
 	ssh: sshToolRenderer as ToolRenderer,


### PR DESCRIPTION
Closes #1892.

## Context

PR #1889 auto-merged with its first commit before a follow-up compile fix could be added, leaving `main`'s release build broken. `bun build --compile` fails at `renderers.ts:66`:

> `require("./read")` transitively pulls `read.ts → chunk.ts → lru-cache`, which has a **top-level await** — a sync `require()` cannot pull a TLA subgraph.

The `require("./read")` was a lazy cycle-break for `renderers.ts ← read.ts`. That cycle ran through `chunk.ts → @f5-sales-demo/xcsh (barrel) → modes/components → renderers.ts`; #1889 removed chunk.ts's barrel import (TDZ fix), so the cycle no longer exists — but the `require()` stayed and now breaks `--compile`. `bun test` (interpreted) tolerates it, which is why only `install_methods` caught it.

## Change

Replace the `require("./read")` getter with a normal `import { readToolRenderer } from "./read"`. ESM imports of TLA modules are allowed, and `read.ts` no longer imports `renderers.ts`, so there is no cycle to work around.

## Testing

- `bun build --compile --define PI_COMPILED=true --external mupdf --root ../.. ./src/cli.ts` — produces the 164M binary (previously errored).
- `import("./src/tools/renderers.ts")` resolves with no TDZ; `toolRenderers.read` present.
- biome + `tsgo -p tsconfig.json --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)