### PR TITLE
test: required-gate bundle/cycle guards + E2E UAT for internal-URL retrieval

### DIFF
--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -35,6 +35,7 @@
 		"check": "biome check . && bun run format-prompts -- --check && bun run check:types",
 		"check:types": "bun run generate-build-info && bun run generate-extension-capabilities && bun run generate-api-spec-index && bun run generate-branding-index && bun run generate-terraform-index && tsgo -p tsconfig.json --noEmit",
 		"lint": "biome lint .",
+		"check:bundle": "bun scripts/check-bundle.ts",
 		"test": "bun run generate-build-info && bun run generate-extension-capabilities && bun run generate-api-spec-index && bun run generate-console-catalog && bun run generate-console-field-metadata && bun test --max-concurrency 4",
 		"fix": "biome check --write --unsafe . && bun run format-prompts && bun run generate-docs-index && bun run generate-api-spec-index && bun run generate-build-info",
 		"fmt": "biome format --write . && bun run format-prompts",

--- a/packages/coding-agent/scripts/check-bundle.ts
+++ b/packages/coding-agent/scripts/check-bundle.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env bun
+/**
+ * Bundle guard: ensure the CLI entrypoint still bundles.
+ *
+ * Reproduces the `bun build --compile` module-graph analysis in ~1s so a
+ * `require()` into a top-level-await subgraph (or other bundle-breaking graph
+ * change) fails fast in a required CI gate — not only in the slower, optional
+ * install-methods build. See PRs #1888 → #1892 for the regression this guards.
+ *
+ * Runs as a standalone `bun` process (not under `bun test`, whose bundler
+ * resolver cannot resolve some lazily-imported specifiers). Exits non-zero on
+ * any bundle error.
+ */
+import * as path from "node:path";
+
+const cliEntry = path.resolve(import.meta.dir, "../src/cli.ts");
+
+const result = await Bun.build({
+	entrypoints: [cliEntry],
+	target: "bun",
+	define: { PI_COMPILED: "true" },
+	external: ["mupdf"],
+	throw: false,
+});
+
+if (!result.success) {
+	console.error("Bundle check FAILED — the CLI entrypoint does not bundle:\n");
+	for (const log of result.logs) console.error(String(log));
+	process.exit(1);
+}
+
+console.log("Bundle check passed — CLI entrypoint bundles cleanly.");

--- a/packages/coding-agent/test/internal-urls/request-logging-e2e.test.ts
+++ b/packages/coding-agent/test/internal-urls/request-logging-e2e.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@f5-sales-demo/xcsh/config/settings";
+import { InternalUrlRouter } from "@f5-sales-demo/xcsh/internal-urls/router";
+import { InternalDocsProtocolHandler } from "@f5-sales-demo/xcsh/internal-urls/xcsh-protocol";
+import type { ToolSession } from "@f5-sales-demo/xcsh/tools";
+import { GrepTool } from "@f5-sales-demo/xcsh/tools/grep";
+
+/**
+ * End-to-end UAT for the retrieval-ergonomics fixes, driven over the REAL
+ * `xcsh://` handler and the REAL embedded generated specs (not synthetic
+ * fixtures). This is the scenario from the customer session that motivated the
+ * work: reaching the `http_loadbalancer` configuration to answer a
+ * request-logging question.
+ */
+
+function realRouter(): InternalUrlRouter {
+	const router = new InternalUrlRouter();
+	router.register(new InternalDocsProtocolHandler());
+	return router;
+}
+
+function resultText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content
+		.filter(c => c.type === "text")
+		.map(c => c.text ?? "")
+		.join("\n");
+}
+
+describe("request-logging retrieval — end-to-end over real generated specs", () => {
+	let tmpDir: string;
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "rl-e2e-"));
+	});
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("resolves the real http_loadbalancer spec in the virtual domain", async () => {
+		const res = await realRouter().resolve("xcsh://api-spec/virtual?resource=http_loadbalancer");
+		expect(res.content).toContain("http_loadbalancer");
+		// Not the fallback renders.
+		expect(res.content).not.toMatch(/^# (Domain|Resource) not found/);
+	});
+
+	it("cross-domain resolves a wrong-domain request (config -> virtual) with a note", async () => {
+		const res = await realRouter().resolve("xcsh://api-spec/config?resource=http_loadbalancer");
+		expect(res.content).toContain("resolved resource");
+		expect(res.content).toContain("http_loadbalancer");
+		expect(res.content).not.toContain("# Domain not found");
+	});
+
+	it("grep finds a field inside the real spec via in-memory search (no glob error)", async () => {
+		const session = {
+			cwd: tmpDir,
+			hasUI: false,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated({ "grep.contextBefore": 0, "grep.contextAfter": 0 }),
+			internalRouter: realRouter(),
+		} as unknown as ToolSession;
+		const tool = new GrepTool(session);
+
+		// The `?` in the URL must not trip the glob guard, and the match must come
+		// from the resolved in-memory content (synthetic sourcePath, no real file).
+		const result = await tool.execute("rl-e2e", {
+			pattern: "http_loadbalancer",
+			path: "xcsh://api-spec/virtual?resource=http_loadbalancer",
+		});
+		expect(resultText(result)).toContain("http_loadbalancer");
+	});
+
+	it("renders the guided-workflow index (the path enable_request_logging uses once synced)", async () => {
+		const res = await realRouter().resolve("xcsh://api-spec/workflows/");
+		// An existing workflow proves the rendering path; enable_request_logging
+		// (api-specs-enriched#924) arrives here via the enriched-specs-updated sync.
+		expect(res.content).toContain("enable_waf_protection");
+	});
+});

--- a/packages/coding-agent/test/tools/compile-graph.test.ts
+++ b/packages/coding-agent/test/tools/compile-graph.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+
+/**
+ * Regression guards for the module-graph failure modes that shipped a broken
+ * `main` (PRs #1888 → #1892):
+ *
+ *  - A lazy `require("./read")` in renderers.ts pulled `chunk.ts → lru-cache`,
+ *    which has a top-level await. A sync `require()` cannot pull a TLA subgraph,
+ *    so `bun build --compile` failed — but only in the (non-required)
+ *    install-methods job, so it auto-merged. The bundle guard reproduces that
+ *    analysis in a required gate.
+ *
+ *  - An import cycle back into renderers.ts caused a `grepToolRenderer` TDZ when
+ *    a tool module was imported first. Importing the leaf modules standalone and
+ *    asserting their exports resolve catches that class at runtime.
+ */
+
+const PKG_ROOT = path.resolve(import.meta.dir, "../..");
+const SRC = path.join(PKG_ROOT, "src");
+
+describe("CLI entrypoint bundles (guards require-of-top-level-await)", () => {
+	// Runs the real Bun.build via scripts/check-bundle.ts in a fresh `bun`
+	// process — `bun test`'s bundler resolver can't resolve some lazily-imported
+	// specifiers, so an inline Bun.build here would be a false negative.
+	it("scripts/check-bundle.ts exits 0", () => {
+		const proc = Bun.spawnSync(["bun", "scripts/check-bundle.ts"], { cwd: PKG_ROOT, stderr: "pipe", stdout: "pipe" });
+		if (proc.exitCode !== 0) {
+			// Surface the bundler diagnostics (e.g. the require-of-TLA error).
+			throw new Error(`check-bundle failed:\n${proc.stderr.toString()}\n${proc.stdout.toString()}`);
+		}
+		expect(proc.exitCode).toBe(0);
+	}, 60_000);
+});
+
+describe("tool modules import standalone without a TDZ (guards import cycles)", () => {
+	// Importing these leaf-first is what previously tripped the renderers.ts <-
+	// read.ts / grep.ts cycles; a TDZ would throw on import.
+	it("grep.ts exports resolve", async () => {
+		const mod = await import(path.join(SRC, "tools/grep.ts"));
+		expect(typeof mod.GrepTool).toBe("function");
+		expect(mod.grepToolRenderer).toBeDefined();
+	});
+
+	it("read.ts exports resolve", async () => {
+		const mod = await import(path.join(SRC, "tools/read.ts"));
+		expect(mod.readToolRenderer).toBeDefined();
+	});
+
+	it("renderers.ts registry resolves the read + grep renderers", async () => {
+		const mod = await import(path.join(SRC, "tools/renderers.ts"));
+		expect(mod.toolRenderers).toBeDefined();
+		expect(mod.toolRenderers.read).toBeDefined();
+		expect(mod.toolRenderers.grep).toBeDefined();
+	});
+});


### PR DESCRIPTION
Closes #1895.

## Why

#1888 shipped a broken `main` — a `require("./read")` that `bun build --compile` rejects (top-level-await via `chunk.ts → lru-cache`). It was only caught by `install_methods`, a **non-required** check, so it auto-merged; fixed in #1892. This PR adds the missing **required-gate** guards and the **end-to-end UAT** so it can't recur and the real scenario is covered.

## What

- **`scripts/check-bundle.ts`** (+ `check:bundle`): runs `Bun.build` on the CLI entrypoint in a real `bun` context and fails on any bundle error — the `--compile` graph analysis in ~1s. (Inline `Bun.build` under `bun test` gives false negatives because its bundler resolver can't resolve some lazily-imported specifiers, hence the subprocess.)
- **`test/tools/compile-graph.test.ts`**: spawns `check:bundle` (bundle guard) and imports `grep.ts`/`read.ts`/`renderers.ts` standalone (TDZ/cycle guard). Lives in `bun test` → the **required `test` gate**, so a recurrence blocks merge with no branch-protection change. **Verified it fails when the `require("./read")` is restored** (exact TLA error).
- **`test/internal-urls/request-logging-e2e.test.ts`**: E2E UAT over the **real** `xcsh://` handler + **real** generated specs — resolves the real `http_loadbalancer` spec, cross-domain `config→virtual` (with note), in-memory `grep` on real content (no glob error), and renders the guided-workflow index (the path `enable_request_logging` from api-specs-enriched#924 uses once synced).

## Testing

- `bun test test/tools/compile-graph.test.ts test/internal-urls/request-logging-e2e.test.ts` — 8 passed.
- Negative check: restoring the `require("./read")` → bundle guard fails with the TLA error; reverted.
- biome + `tsgo -p tsconfig.json --noEmit` clean.

## Note

Branch protection / required checks are governance-managed (docs-control), so `install_methods` can't be promoted to required from this repo. Putting the guard in the required `test` gate achieves required-gate coverage in-repo; promoting `install_methods` via docs-control would be added defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)