### PR TITLE
TTFT Phase 2 (xcsh): emit chat + cold-start spans over the bridge

### DIFF
--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -14,12 +14,16 @@ import {
 import { CONSOLE_ROUTES } from "./console-routes.generated";
 import type { BridgeServer } from "./extension-bridge";
 import { interpretPageState } from "./page-state-interpreter";
+import { chatSpans } from "./ttft-spans";
 
 interface ActiveChat {
 	id: string;
 	seq: number;
 	terminalSent: boolean;
 	unsubscribe: () => void;
+	entryAt: number;
+	promptAt: number | null;
+	spanEmitted: boolean;
 }
 
 export class ChatHandler {
@@ -61,7 +65,15 @@ export class ChatHandler {
 			this.#activeHistoryHint = req.history_hint;
 		}
 
-		const chat: ActiveChat = { id, seq: 0, terminalSent: false, unsubscribe: () => {} };
+		const chat: ActiveChat = {
+			id,
+			seq: 0,
+			terminalSent: false,
+			unsubscribe: () => {},
+			entryAt: Date.now(),
+			promptAt: null,
+			spanEmitted: false,
+		};
 		this.#activeChats.set(id, chat);
 
 		const unsubscribe = this.#session.subscribe((event: AgentSessionEvent) => {
@@ -72,6 +84,7 @@ export class ChatHandler {
 		const prompt = composeChatPrompt(req.text, req.context, req.mode);
 
 		try {
+			chat.promptAt = Date.now();
 			await this.#session.prompt(prompt, { expandPromptTemplates: false, synthetic: false });
 		} catch (err: unknown) {
 			const message = err instanceof Error ? err.message : "unknown error";
@@ -121,6 +134,15 @@ export class ChatHandler {
 					seq: chat.seq++,
 					delta: ame.delta,
 				} satisfies ChatDelta);
+				// TTFT Phase 2: first token out — emit the chat-segment spans once, keyed by
+				// the c- turn id. chat.promptAt is set (prompt() was awaited before any event);
+				// guard against re-emit on later deltas.
+				if (!chat.spanEmitted && chat.promptAt !== null) {
+					chat.spanEmitted = true;
+					for (const s of chatSpans(chat.id, chat.entryAt, chat.promptAt, Date.now())) {
+						this.#server.send(s);
+					}
+				}
 			} else if (ame.type === "error") {
 				const errorMsg = ame.error?.errorMessage ?? "LLM error";
 				this.#sendTerminal(chat, { type: "chat_error", id: chat.id, error: errorMsg });

--- a/packages/coding-agent/src/browser/ttft-spans.ts
+++ b/packages/coding-agent/src/browser/ttft-spans.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure TTFT span-frame builders for Phase 2. The worker emits these over the bridge
+ * WS; the extension records them (proc:'xcsh') and summarizeTtft stitches them into
+ * the init->first-token timeline. Chrome-free, so they unit-test in isolation.
+ */
+export interface SpanFrame {
+	type: "span";
+	stage: string;
+	ms: number;
+	id?: string;
+	sid?: string;
+	cold?: boolean;
+}
+
+const clamp = (ms: number): number => (ms > 0 ? ms : 0);
+
+/**
+ * Decompose one chat turn's route->first-token into two disjoint spans that sum to
+ * (firstDeltaAt - entryAt): provider_ttft (prompt issued -> first token) and
+ * chat_handler (the xcsh routing/compose/emit overhead = entry -> prompt issued).
+ */
+export function chatSpans(id: string, entryAt: number, promptAt: number, firstDeltaAt: number): SpanFrame[] {
+	const providerMs = clamp(firstDeltaAt - promptAt);
+	const handlerMs = clamp(firstDeltaAt - entryAt - providerMs);
+	return [
+		{ type: "span", stage: "provider_ttft", ms: providerMs, id },
+		{ type: "span", stage: "chat_handler", ms: handlerMs, id },
+	];
+}
+
+/** Build the per-session cold-start spans, tagged with the session id + authoritative cold. */
+export function coldStartSpans(
+	sid: string,
+	cold: boolean,
+	managerProvisionMs: number,
+	workerBootMs: number,
+): SpanFrame[] {
+	return [
+		{ type: "span", stage: "manager_provision", ms: clamp(managerProvisionMs), sid, cold },
+		{ type: "span", stage: "worker_boot", ms: clamp(workerBootMs), sid, cold },
+	];
+}

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -284,11 +284,17 @@ export default class Manager extends Command {
 		};
 
 		/** Adopt a warm spare for a provision (bind over IPC). Returns false if none available. */
-		const adoptSpare = (msg: { sessionId: string; tenant: string }): boolean => {
+		const adoptSpare = (msg: { sessionId: string; tenant: string }, managerProvisionMs: number): boolean => {
 			const rec = pool.shift();
 			if (!rec) return false;
 			// `send` exists because the spare was spawned with an `ipc` handler.
-			(rec.proc as { send(m: unknown): void }).send({ type: "bind", sessionId: msg.sessionId, tenant: msg.tenant });
+			(rec.proc as { send(m: unknown): void }).send({
+				type: "bind",
+				sessionId: msg.sessionId,
+				tenant: msg.tenant,
+				provisionMs: managerProvisionMs, // TTFT Phase 2: relayed manager_provision (warm)
+				cold: false, // authoritative: warm adopt
+			});
 			reg.set(msg.sessionId, {
 				sessionId: msg.sessionId,
 				tenant: msg.tenant,
@@ -354,7 +360,7 @@ export default class Manager extends Command {
 			process.exit(0);
 		};
 
-		const spawnWorker = (msg: { sessionId: string; tenant: string }): void => {
+		const spawnWorker = (msg: { sessionId: string; tenant: string }, managerProvisionMs: number): void => {
 			// Registry-dedupe (pickPort) over only the ports free at the OS level.
 			const port = pickPort(reg, range.filter(isPortFree));
 			if (port === null) {
@@ -374,6 +380,12 @@ export default class Manager extends Command {
 					// spawned tenant key is authoritative (undefined removes the var in Bun).
 					XCSH_API_URL: undefined,
 					XCSH_API_TOKEN: undefined,
+					// TTFT Phase 2: relay cold-start timing to the worker (only it has a WS to
+					// the extension). Wall-clock spawn instant + manager_provision ms; COLD=1
+					// marks the authoritative cold spawn.
+					XCSH_TTFT_SPAWN_AT: String(Date.now()),
+					XCSH_TTFT_PROVISION_MS: String(managerProvisionMs),
+					XCSH_TTFT_COLD: "1",
 				},
 				stdout: "ignore",
 				stderr: "ignore",
@@ -417,8 +429,10 @@ export default class Manager extends Command {
 					}
 					return;
 				}
+				const provisionReceivedAt = Date.now(); // TTFT Phase 2: start of manager_provision
 				if (needsProvision(reg, msg.sessionId)) {
-					if (!adoptSpare(msg)) spawnWorker(msg); // adopt a warm spare, else cold-spawn (fallback)
+					const managerProvisionMs = Date.now() - provisionReceivedAt;
+					if (!adoptSpare(msg, managerProvisionMs)) spawnWorker(msg, managerProvisionMs); // adopt a warm spare, else cold-spawn (fallback)
 				}
 				const w = reg.get(msg.sessionId);
 				if (w) w.lastSeen = Date.now(); // touch on every provision (keep-alive)

--- a/packages/coding-agent/src/commands/worker.ts
+++ b/packages/coding-agent/src/commands/worker.ts
@@ -19,6 +19,7 @@ import { ChatHandler } from "../browser/chat-handler";
 import { startBridgeServer } from "../browser/extension-bridge";
 import { createExtensionBridgeTools, EXTENSION_AGENT_TOOL_NAMES } from "../browser/extension-bridge-tools";
 import { setSharedBridgeServer } from "../browser/provider";
+import { coldStartSpans, type SpanFrame } from "../browser/ttft-spans";
 import { initializeWithSettings } from "../discovery";
 import { createAgentSession } from "../sdk";
 import { activateTenantContext } from "../services/session-context-binding";
@@ -109,6 +110,12 @@ export default class Worker extends Command {
 		// Spans only accumulate while recording; nothing prints unless PI_TIMING is set,
 		// and each logger.time() returns its wrapped value unchanged — so a normal
 		// `xcsh worker` run is behaviorally identical to before.
+		// TTFT Phase 2: the manager stamps XCSH_TTFT_SPAWN_AT at Bun.spawn for a cold
+		// spawn; worker_boot(cold) = bridge-listening instant - spawn instant (captures
+		// fork + runtime init, which logger.startTiming below misses).
+		const spawnAtEnv = Number(process.env.XCSH_TTFT_SPAWN_AT);
+		const coldSpawn = process.env.XCSH_TTFT_COLD === "1";
+		const managerProvisionMsEnv = Number(process.env.XCSH_TTFT_PROVISION_MS);
 		logger.startTiming();
 
 		process.env.XCSH_BROWSER_PROVIDER = "extension";
@@ -142,15 +149,48 @@ export default class Worker extends Command {
 		bridge.setSessionInfo(sessionInfoForWorker);
 		ContextService.onContextChange(() => bridge.broadcastTenantChanged());
 
+		// TTFT Phase 2: buffer the per-session cold-start spans and flush them once a
+		// client is actually connected. bridge.send() silently no-ops with no client, so
+		// the flush is gated on `clientConnected` — a cold-boot flush before the extension
+		// connects would otherwise burn the once-latch and lose the spans. Cold path is
+		// populated now (env); warm path by the {bind} handler below.
+		let coldStartBuffer: SpanFrame[] = [];
+		let coldStartSent = false;
+		let clientConnected = false;
+		const flushColdStart = (): void => {
+			if (coldStartSent || !clientConnected || coldStartBuffer.length === 0) return;
+			for (const s of coldStartBuffer) bridge.send(s);
+			coldStartSent = true;
+		};
+		bridge.onConnected(() => {
+			clientConnected = true;
+			flushColdStart();
+		});
+
+		if (coldSpawn && process.env.XCSH_SESSION_ID && Number.isFinite(spawnAtEnv)) {
+			const workerBootMs = Date.now() - spawnAtEnv; // spawn -> bridge listening
+			const mgrMs = Number.isFinite(managerProvisionMsEnv) ? managerProvisionMsEnv : 0;
+			coldStartBuffer = coldStartSpans(process.env.XCSH_SESSION_ID, true, mgrMs, workerBootMs);
+			// No flush here: at cold boot the extension has not connected yet; onConnected flushes.
+		}
+
 		// Pre-warm pool late-bind: the manager (our parent) sends {bind} over Bun IPC to adopt
 		// this spare for a tab. Apply the identity, activate the tenant's context LIVE, then
 		// re-announce via broadcastTenantChanged (now carrying the real sessionId).
 		process.on("message", (raw: unknown) => {
-			const m = raw as { type?: unknown; sessionId?: unknown; tenant?: unknown };
+			const m = raw as {
+				type?: unknown;
+				sessionId?: unknown;
+				tenant?: unknown;
+				provisionMs?: unknown;
+				cold?: unknown;
+			};
 			if (m?.type !== "bind" || typeof m.sessionId !== "string" || typeof m.tenant !== "string") return;
 			// Capture the narrowed values — TS widens `m.*` back to `unknown` inside the async closure.
 			const sessionId = m.sessionId;
 			const tenant = m.tenant;
+			const bindAt = Date.now(); // TTFT Phase 2: start of warm worker_boot (bind -> bound)
+			const relayedProvisionMs = typeof m.provisionMs === "number" ? m.provisionMs : 0;
 			setWorkerIdentity(sessionId, tenant);
 			void (async () => {
 				try {
@@ -162,6 +202,9 @@ export default class Worker extends Command {
 				// Ack adoption complete (identity applied + context activated + re-announced).
 				// The manager ignores it today; the bench uses it to time adoption latency.
 				process.send?.({ type: "bound", sessionId });
+				// TTFT Phase 2: warm adopt cold-start spans (worker_boot = bind -> bound).
+				coldStartBuffer = coldStartSpans(sessionId, false, relayedProvisionMs, Date.now() - bindAt);
+				flushColdStart();
 			})();
 		});
 

--- a/packages/coding-agent/src/commands/worker.ts
+++ b/packages/coding-agent/src/commands/worker.ts
@@ -162,6 +162,8 @@ export default class Worker extends Command {
 			for (const s of coldStartBuffer) bridge.send(s);
 			coldStartSent = true;
 		};
+		// onConnected (raw WS open) is the deliberate flush trigger: no hello hook is exposed
+		// today, and the bridge's origin check already gates opens to the extension.
 		bridge.onConnected(() => {
 			clientConnected = true;
 			flushColdStart();

--- a/packages/coding-agent/test/chat-handler-ttft.test.ts
+++ b/packages/coding-agent/test/chat-handler-ttft.test.ts
@@ -3,7 +3,7 @@ import { ChatHandler } from "@f5-sales-demo/xcsh/browser/chat-handler";
 import type { BridgeServer } from "@f5-sales-demo/xcsh/browser/extension-bridge";
 import type { AgentSession, AgentSessionEvent } from "@f5-sales-demo/xcsh/session/agent-session";
 
-function makeFakes() {
+function makeFakes(deltas: string[] = ["Hi"]) {
 	const sent: Record<string, unknown>[] = [];
 	let onMsg: (m: Record<string, unknown>) => void = () => {};
 	let listener: ((e: AgentSessionEvent) => void) | null = null;
@@ -22,10 +22,12 @@ function makeFakes() {
 			return () => {};
 		},
 		prompt: async () => {
-			listener?.({
-				type: "message_update",
-				assistantMessageEvent: { type: "text_delta", delta: "Hi" },
-			} as AgentSessionEvent);
+			for (const delta of deltas) {
+				listener?.({
+					type: "message_update",
+					assistantMessageEvent: { type: "text_delta", delta },
+				} as AgentSessionEvent);
+			}
 		},
 	} as unknown as AgentSession;
 	return { sent, server, session, fire: (m: Record<string, unknown>) => onMsg(m) };
@@ -47,5 +49,16 @@ describe("ChatHandler TTFT spans", () => {
 			expect(s.ms as number).toBeGreaterThanOrEqual(0);
 		}
 		expect(spans.length).toBe(2);
+	});
+
+	it("emits the chat spans only once even when multiple text_deltas arrive", async () => {
+		// Spec §7 once-latch: the first text_delta latches the TTFT/handler spans; every
+		// subsequent delta in the same turn must NOT re-emit them. Two deltas → still 2 spans.
+		const { sent, server, session, fire } = makeFakes(["A", "B"]);
+		new ChatHandler(server, session).attach();
+		await fire({ type: "chat_request", id: "c-2", text: "hi", context: null, mode: "educational" });
+		await new Promise(r => setTimeout(r, 10));
+
+		expect(sent.filter(f => f.type === "span").length).toBe(2);
 	});
 });

--- a/packages/coding-agent/test/chat-handler-ttft.test.ts
+++ b/packages/coding-agent/test/chat-handler-ttft.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { ChatHandler } from "@f5-sales-demo/xcsh/browser/chat-handler";
+import type { BridgeServer } from "@f5-sales-demo/xcsh/browser/extension-bridge";
+import type { AgentSession, AgentSessionEvent } from "@f5-sales-demo/xcsh/session/agent-session";
+
+function makeFakes() {
+	const sent: Record<string, unknown>[] = [];
+	let onMsg: (m: Record<string, unknown>) => void = () => {};
+	let listener: ((e: AgentSessionEvent) => void) | null = null;
+	const server = {
+		send: (p: unknown) => sent.push(p as Record<string, unknown>),
+		onMessage: (cb: (m: Record<string, unknown>) => void) => {
+			onMsg = cb;
+		},
+		onDisconnected: () => {},
+	} as unknown as BridgeServer;
+	const session = {
+		isStreaming: false,
+		agent: { replaceMessages() {}, abort() {} },
+		subscribe: (cb: (e: AgentSessionEvent) => void) => {
+			listener = cb;
+			return () => {};
+		},
+		prompt: async () => {
+			listener?.({
+				type: "message_update",
+				assistantMessageEvent: { type: "text_delta", delta: "Hi" },
+			} as AgentSessionEvent);
+		},
+	} as unknown as AgentSession;
+	return { sent, server, session, fire: (m: Record<string, unknown>) => onMsg(m) };
+}
+
+describe("ChatHandler TTFT spans", () => {
+	it("emits provider_ttft + chat_handler span frames tagged with the turn id, once", async () => {
+		const { sent, server, session, fire } = makeFakes();
+		new ChatHandler(server, session).attach();
+		await fire({ type: "chat_request", id: "c-1", text: "hi", context: null, mode: "educational" });
+		await new Promise(r => setTimeout(r, 10));
+
+		const spans = sent.filter(f => f.type === "span");
+		const stages = spans.map(s => s.stage).sort();
+		expect(stages).toEqual(["chat_handler", "provider_ttft"]);
+		for (const s of spans) {
+			expect(s.id).toBe("c-1");
+			expect(typeof s.ms).toBe("number");
+			expect(s.ms as number).toBeGreaterThanOrEqual(0);
+		}
+		expect(spans.length).toBe(2);
+	});
+});

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -15,7 +15,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { VERSION } from "@f5-sales-demo/pi-utils";
-import { probe } from "./helpers/bridge-probe";
+import { PROBE_ORIGIN, probe } from "./helpers/bridge-probe";
 
 let mgr: import("bun").Subprocess | undefined;
 // A SECOND manager on the same socket (single-manager-invariant test). It is
@@ -218,6 +218,51 @@ function count(s: string, sub: string): number {
 		i = s.indexOf(sub, i + sub.length);
 	}
 	return n;
+}
+
+/** Poll captured manager stderr for a "on port <N>" line matching `re`. Avoids the
+ *  bridge probe (which would consume the worker's first-connect cold-start flush). */
+async function waitForPort(getErr: () => string, re: RegExp, tries = 80): Promise<number | null> {
+	for (let i = 0; i < tries; i++) {
+		const m = getErr().match(re);
+		if (m) return Number(m[1]);
+		await Bun.sleep(100);
+	}
+	return null;
+}
+
+/** Connect ONE persistent client (extension Origin) as the worker's first client and
+ *  collect `span` frames flushed on connect. onmessage is attached synchronously at
+ *  construction so nothing is missed. */
+async function collectSpans(port: number, want: number, timeoutMs: number): Promise<Array<Record<string, unknown>>> {
+	const ws = new WebSocket(`ws://127.0.0.1:${port}`, { headers: { Origin: PROBE_ORIGIN } } as unknown as string[]);
+	const spans: Array<Record<string, unknown>> = [];
+	return await new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			try {
+				ws.close();
+			} catch {}
+			resolve(spans);
+		}, timeoutMs);
+		ws.onopen = () => ws.send(JSON.stringify({ type: "hello" }));
+		ws.onmessage = ev => {
+			const m = JSON.parse(String(ev.data)) as Record<string, unknown>;
+			if (m.type === "span") {
+				spans.push(m);
+				if (spans.length >= want) {
+					clearTimeout(timer);
+					try {
+						ws.close();
+					} catch {}
+					resolve(spans);
+				}
+			}
+		};
+		ws.onerror = () => {
+			clearTimeout(timer);
+			reject(new Error("ws connect failed"));
+		};
+	});
 }
 
 test("adopts a warm spare on provision, then replenishes the pool (XCSH_WORKER_POOL_SIZE=1)", async () => {
@@ -602,4 +647,32 @@ test("a STALE control socket left by a crashed manager is reclaimed on next star
 	const port = await findTenant("stale", 80);
 	expect(port).not.toBeNull();
 	await send({ type: "release", sessionId: "tab-stale" });
+}, 60_000);
+
+test("cold spawn emits manager_provision + worker_boot spans with cold=true", async () => {
+	const getErr = await startManagerWithPool("0"); // no spares -> cold spawn
+	await send({ type: "provision", sessionId: "tab-501", tenant: "acme", env: "production" });
+	const port = await waitForPort(getErr, /provisioned tab-501 .* on port (\d+)/);
+	expect(port).not.toBeNull();
+
+	const spans = await collectSpans(port as number, 2, 3000);
+	const byStage = Object.fromEntries(spans.map(s => [String(s.stage), s]));
+	expect(byStage.manager_provision).toBeDefined(); // NOTE: ~0ms by construction; assert presence, NOT a duration
+	expect(byStage.worker_boot).toBeDefined();
+	expect(byStage.worker_boot.cold).toBe(true);
+	expect(byStage.worker_boot.sid).toBe("tab-501");
+	expect(typeof byStage.worker_boot.ms).toBe("number");
+}, 60_000);
+
+test("warm adopt emits worker_boot span with cold=false", async () => {
+	const getErr = await startManagerWithPool("1"); // one warm spare -> adopt
+	await send({ type: "provision", sessionId: "tab-777", tenant: "acme", env: "production" });
+	const port = await waitForPort(getErr, /adopted spare pid \d+ on port (\d+) as tab-777/);
+	expect(port).not.toBeNull();
+
+	const spans = await collectSpans(port as number, 2, 3000);
+	const wb = spans.find(s => s.stage === "worker_boot");
+	expect(wb).toBeDefined();
+	expect(wb!.cold).toBe(false);
+	expect(wb!.sid).toBe("tab-777");
 }, 60_000);

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -232,37 +232,66 @@ async function waitForPort(getErr: () => string, re: RegExp, tries = 80): Promis
 }
 
 /** Connect ONE persistent client (extension Origin) as the worker's first client and
- *  collect `span` frames flushed on connect. onmessage is attached synchronously at
- *  construction so nothing is missed. */
+ *  collect `span` frames flushed on connect. Retries the CONNECT until the (freshly
+ *  cold-spawned) worker has bound its port — a refused attempt never opens, so it does
+ *  not consume the on-connect flush; only a successful open becomes the first client.
+ *  onmessage is attached synchronously so an immediate flush is not missed. */
 async function collectSpans(port: number, want: number, timeoutMs: number): Promise<Array<Record<string, unknown>>> {
-	const ws = new WebSocket(`ws://127.0.0.1:${port}`, { headers: { Origin: PROBE_ORIGIN } } as unknown as string[]);
-	const spans: Array<Record<string, unknown>> = [];
-	return await new Promise((resolve, reject) => {
-		const timer = setTimeout(() => {
-			try {
-				ws.close();
-			} catch {}
-			resolve(spans);
-		}, timeoutMs);
-		ws.onopen = () => ws.send(JSON.stringify({ type: "hello" }));
-		ws.onmessage = ev => {
-			const m = JSON.parse(String(ev.data)) as Record<string, unknown>;
-			if (m.type === "span") {
-				spans.push(m);
-				if (spans.length >= want) {
-					clearTimeout(timer);
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const result = await new Promise<Array<Record<string, unknown>> | null>(resolve => {
+			const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+				headers: { Origin: PROBE_ORIGIN },
+			} as unknown as string[]);
+			const collected: Array<Record<string, unknown>> = [];
+			let opened = false;
+			const timer = setTimeout(
+				() => {
 					try {
 						ws.close();
 					} catch {}
-					resolve(spans);
+					resolve(opened ? collected : null);
+				},
+				Math.max(0, deadline - Date.now()),
+			);
+			ws.onopen = () => {
+				opened = true;
+				ws.send(JSON.stringify({ type: "hello" }));
+			};
+			ws.onmessage = ev => {
+				const m = JSON.parse(String(ev.data)) as Record<string, unknown>;
+				if (m.type === "span") {
+					collected.push(m);
+					if (collected.length >= want) {
+						clearTimeout(timer);
+						try {
+							ws.close();
+						} catch {}
+						resolve(collected);
+					}
 				}
-			}
-		};
-		ws.onerror = () => {
-			clearTimeout(timer);
-			reject(new Error("ws connect failed"));
-		};
-	});
+			};
+			ws.onerror = () => {
+				clearTimeout(timer);
+				try {
+					ws.close();
+				} catch {}
+				// If we had already opened (and thus consumed the worker's first-client
+				// flush), return whatever we collected rather than retrying a second
+				// client that would receive nothing; only a never-opened attempt retries.
+				resolve(opened ? collected : null);
+			};
+			ws.onclose = () => {
+				if (!opened) {
+					clearTimeout(timer);
+					resolve(null);
+				}
+			};
+		});
+		if (result !== null) return result; // opened (first client); return whatever was collected
+		await Bun.sleep(150); // worker not listening yet — retry the connect (no client was established)
+	}
+	return [];
 }
 
 test("adopts a warm spare on provision, then replenishes the pool (XCSH_WORKER_POOL_SIZE=1)", async () => {
@@ -655,7 +684,7 @@ test("cold spawn emits manager_provision + worker_boot spans with cold=true", as
 	const port = await waitForPort(getErr, /provisioned tab-501 .* on port (\d+)/);
 	expect(port).not.toBeNull();
 
-	const spans = await collectSpans(port as number, 2, 3000);
+	const spans = await collectSpans(port as number, 2, 8000);
 	const byStage = Object.fromEntries(spans.map(s => [String(s.stage), s]));
 	expect(byStage.manager_provision).toBeDefined(); // NOTE: ~0ms by construction; assert presence, NOT a duration
 	expect(byStage.worker_boot).toBeDefined();
@@ -670,7 +699,11 @@ test("warm adopt emits worker_boot span with cold=false", async () => {
 	const port = await waitForPort(getErr, /adopted spare pid \d+ on port (\d+) as tab-777/);
 	expect(port).not.toBeNull();
 
-	const spans = await collectSpans(port as number, 2, 3000);
+	// The collectSpans timeout must cover activateTenantContext, which runs inside the
+	// bind closure AFTER the "adopted" log is printed (the port is logged before the
+	// worker finishes binding + activating). Keep it generous so a future tightening
+	// of this budget does not introduce a flake on a slow adopt.
+	const spans = await collectSpans(port as number, 2, 8000);
 	const wb = spans.find(s => s.stage === "worker_boot");
 	expect(wb).toBeDefined();
 	expect(wb!.cold).toBe(false);

--- a/packages/coding-agent/test/ttft-spans.test.ts
+++ b/packages/coding-agent/test/ttft-spans.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { chatSpans, coldStartSpans } from "@f5-sales-demo/xcsh/browser/ttft-spans";
+
+describe("chatSpans", () => {
+	it("splits route->first-token into disjoint provider_ttft + chat_handler summing to the whole", () => {
+		const spans = chatSpans("c-1", 100, 130, 430); // provider_ttft=300, chat_handler=30
+		expect(spans).toEqual([
+			{ type: "span", stage: "provider_ttft", ms: 300, id: "c-1" },
+			{ type: "span", stage: "chat_handler", ms: 30, id: "c-1" },
+		]);
+		expect(spans[0].ms + spans[1].ms).toBe(430 - 100);
+	});
+
+	it("clamps negatives to 0 (guards against clock jitter)", () => {
+		const spans = chatSpans("c-2", 100, 130, 120); // firstDelta before prompt
+		expect(spans[0].ms).toBe(0);
+	});
+});
+
+describe("coldStartSpans", () => {
+	it("builds sid-tagged manager_provision + worker_boot carrying the cold flag", () => {
+		expect(coldStartSpans("tab-7", true, 5, 800)).toEqual([
+			{ type: "span", stage: "manager_provision", ms: 5, sid: "tab-7", cold: true },
+			{ type: "span", stage: "worker_boot", ms: 800, sid: "tab-7", cold: true },
+		]);
+		expect(coldStartSpans("tab-9", false, 2, 5)[1]).toEqual({
+			type: "span",
+			stage: "worker_boot",
+			ms: 5,
+			sid: "tab-9",
+			cold: false,
+		});
+	});
+});


### PR DESCRIPTION
## What & why

TTFT Phase 2 (xcsh side). Instruments the previously-dark xcsh half of the init→first-token pipeline so the Chrome extension stitches it into `diag_ttft`. The worker (the only xcsh process with a live bridge WS to the extension) emits uniform `{type:'span',stage,ms,id?,sid?,cold?}` frames the extension already records (`proc:'xcsh'`). Paired with the already-merged extension PR (envelope + authoritative-cold reporting).

### Chat segment (per-turn, tagged `c-` id) — `src/browser/chat-handler.ts`
On the first `text_delta` of a turn, emit two disjoint spans that sum to route→first-token:
- `provider_ttft` = prompt issued → first token (model + agent-loop wait)
- `chat_handler` = the xcsh routing/compose/emit overhead
Emitted once (latched), after the user-facing `chat_delta` (no added token latency). **No pi-ai changes.**

### Cold-start segment (per-session, tagged `tab-<id>` sid + authoritative `cold`)
- `src/commands/manager.ts`: brackets provision-received → adopt/spawn decision as `manager_provision`; relays it + the authoritative `cold` (spawn→true, adopt→false) to the worker via spawn env (cold) or the `{bind}` IPC message (warm).
- `src/commands/worker.ts`: computes `worker_boot` (cold: spawn→bridge-listening via the manager's spawn stamp; warm: bind→bound) and flushes `manager_provision`+`worker_boot` once a client connects — exactly-once, gated on a connected client, fail-closed with no client.
- Pure frame builders in `src/browser/ttft-spans.ts` (`chatSpans`, `coldStartSpans`).

Additive throughout — adopt/spawn/bind/readopt and the chat paths are unchanged.

## Testing
- `test/ttft-spans.test.ts` (pure builders), `test/chat-handler-ttft.test.ts` (chat spans + a permanent once-latch test that fails if the latch is removed), `test/manager.int.test.ts` (cold-spawn → `cold:true`; warm-adopt → `cold:false`, over a real manager + worker; the collector reads the worker port from manager stderr so it is the worker's first client and receives the on-connect flush).
- `bun run check:types` clean; safe suites 7 pass locally. The real-worker integration tests are validated here in CI (they could not be run on the shared dev machine without killing another developer's live workers).
- TDD per task; each task independently reviewed (spec + quality) plus a whole-branch review (all findings fixed: cold-test connect retry, permanent latch test).

Part of the TTFT benchmarking initiative (Phase 2).

Closes #1894
