### PR TITLE
fix: release lockfile update must not re-resolve yanked deps (auto-release)

### DIFF
--- a/packages/coding-agent/test/scripts/release-lockfile.test.ts
+++ b/packages/coding-agent/test/scripts/release-lockfile.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+
+/**
+ * Regression guard for the release lockfile-update step (#1898).
+ *
+ * `scripts/release.ts` bumps versions and then relocks. It MUST use
+ * `cargo update --workspace` (relocks only workspace members, preserves
+ * registry resolutions) rather than `cargo generate-lockfile` (re-resolves the
+ * whole graph). The latter both defeats the "preserve existing resolutions"
+ * intent AND fails when a locked dependency has since been yanked from
+ * crates.io — which broke the auto-release job (tree-sitter-perl-next was
+ * yanked). This guard keeps the release path from regressing to the
+ * yank-prone command.
+ */
+
+const RELEASE_TS = path.resolve(import.meta.dir, "../../../../scripts/release.ts");
+
+describe("release.ts lockfile update is yank-safe", () => {
+	it("uses `cargo update --workspace` and not `cargo generate-lockfile`", async () => {
+		const source = await Bun.file(RELEASE_TS).text();
+		expect(source).toContain("cargo update --workspace");
+		expect(source).not.toContain("cargo generate-lockfile");
+	});
+});

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -261,10 +261,15 @@ async function applyVersionBumpToFiles(version: string): Promise<void> {
 	console.log();
 
 	// 4. Update lockfiles (preserve existing resolutions to avoid pulling
-	// newer transitive deps that diverge from the tested main branch)
+	// newer transitive deps that diverge from the tested main branch).
+	// `cargo update --workspace` only relocks the bumped workspace members and
+	// leaves registry deps untouched. Do NOT regenerate the lockfile from
+	// scratch here: a full re-resolve both defeats the stated intent above AND
+	// fails when a locked dependency has since been yanked from crates.io
+	// (e.g. tree-sitter-perl-next 0.1.0/0.1.1 are both yanked).
 	console.log("Updating lockfiles...");
 	await $`bun install`;
-	await $`cargo generate-lockfile`;
+	await $`cargo update --workspace`;
 	console.log();
 
 	// 5. Update changelogs


### PR DESCRIPTION
Closes #1898.

## Why

`auto-release` fails on every non-`chore:` push to `main`: `scripts/release.ts` runs `cargo generate-lockfile`, which re-resolves the whole graph from scratch and refuses the **now-yanked** `tree-sitter-perl-next` (both 0.1.0 and 0.1.1 are yanked from crates.io). The `native`/`test` builds are unaffected because `Cargo.lock` pins the yanked 0.1.0 (yanked-from-lock is allowed by cargo). It also contradicted the step's own comment: "preserve existing resolutions."

## Change

Replace `cargo generate-lockfile` with **`cargo update --workspace`**, which relocks only the bumped workspace members and leaves registry resolutions untouched — matching the documented intent and sidestepping the yank. Adds a regression guard test asserting the release path stays on the yank-safe command.

## Why this over vendoring / a version bump

- Vendoring the exact 0.1.0 source works for `generate-lockfile` but adds an 18 MB `parser.c` and made the `test` job's `build:native` fail (exit 101), so it trades one CI failure for another.
- The crate's git tag and the canonical `tree-sitter-perl` 1.1.2 now require `tree-sitter 0.26.x`; xcsh pins `0.25`, so neither is a drop-in without a 55-grammar core bump.
- This one-line change is the minimal, root-cause fix for the actual failing step, and makes the command match its own stated intent.

## Testing

- Verified locally: after bumping the workspace version, `cargo update --workspace` syncs `pi-natives 19.61.0 → <new>` in the lock **with no yank error** (whereas `cargo generate-lockfile` fails with "version 0.1.0 is yanked").
- `test/scripts/release-lockfile.test.ts` guards against regressing to the from-scratch command.

## Follow-up (separate initiative)

xcsh's `pi-natives` has diverged substantially from upstream `can1357/oh-my-pi` (which restructured it and dropped this grammar). A full native-engine sync/modernization — which would also retire the yanked grammar — is tracked separately.