### PR TITLE
TTFT Phase 3 (xcsh): hermetic manager→worker→chat benchmark + baseline

### DIFF
--- a/packages/coding-agent/bench/bench-instant-extension.ts
+++ b/packages/coding-agent/bench/bench-instant-extension.ts
@@ -1,0 +1,56 @@
+/**
+ * Bench-only pi extension: a deterministic "instant" LLM provider for the hermetic
+ * TTFT benchmark. Registers a keyed `bench-instant` model whose stream emits a first
+ * token immediately with zero network and no real credentials — so a headless worker
+ * (with no real provider keys) selects it deterministically and a chat turn produces a
+ * first `chat_delta` measuring only xcsh-controllable cost. Loaded via
+ * XCSH_BENCH_EXTENSION → additionalExtensionPaths (see worker.ts); inert otherwise.
+ */
+import type { ExtensionAPI } from "@f5-sales-demo/xcsh";
+import type { AssistantMessage, Context, Model } from "@f5-sales-demo/pi-ai";
+import { AssistantMessageEventStream } from "@f5-sales-demo/pi-ai/utils/event-stream";
+
+function instantStream(model: Model<never>, _context: Context): AssistantMessageEventStream {
+  const stream = new AssistantMessageEventStream();
+  const output: AssistantMessage = {
+    role: "assistant",
+    content: [{ type: "text", text: "ok" }],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 1,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+  stream.push({ type: "start", partial: output });
+  stream.push({ type: "text_start", contentIndex: 0, partial: output });
+  stream.push({ type: "text_delta", contentIndex: 0, delta: "ok", partial: output });
+  stream.push({ type: "text_end", contentIndex: 0, content: "ok", partial: output });
+  stream.push({ type: "done", reason: "stop", message: output });
+  stream.end();
+  return stream;
+}
+
+export default function benchInstantExtension(pi: ExtensionAPI): void {
+  pi.registerProvider("bench-instant", {
+    api: "bench-instant" as Model["api"],
+    apiKey: "BENCH_KEY",
+    baseUrl: "http://localhost",
+    streamSimple: instantStream as never,
+    models: [
+      {
+        id: "bench-instant",
+        name: "Bench Instant",
+        api: "bench-instant" as Model["api"],
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 8192,
+      },
+    ],
+  });
+}

--- a/packages/coding-agent/bench/ttft-baseline.json
+++ b/packages/coding-agent/bench/ttft-baseline.json
@@ -1,0 +1,22 @@
+{
+  "cold": {
+    "ttft_ms": 5956.566417,
+    "stages": {
+      "manager_provision": 0,
+      "worker_boot": 849,
+      "chat_handler": 0,
+      "provider_ttft": 4237
+    },
+    "runs": 5
+  },
+  "warm": {
+    "ttft_ms": 3649.036625,
+    "stages": {
+      "manager_provision": 0,
+      "worker_boot": 4,
+      "chat_handler": 0,
+      "provider_ttft": 3592
+    },
+    "runs": 5
+  }
+}

--- a/packages/coding-agent/bench/ttft-report.ts
+++ b/packages/coding-agent/bench/ttft-report.ts
@@ -30,13 +30,22 @@ export function median(xs: number[]): number {
 const STAGE_KEYS: Array<keyof StageBreakdown> = ["manager_provision", "worker_boot", "chat_handler", "provider_ttft"];
 const MODES: Array<keyof BenchResult> = ["cold", "warm"];
 
-/** Metrics slower than baseline by more than `tolerancePct` percent. Empty = within tolerance.
- *  A metric at exactly +tolerancePct is NOT a regression (strict greater-than). */
-export function compareToBaseline(baseline: BenchResult, current: BenchResult, tolerancePct: number): Regression[] {
+/** Metrics slower than baseline by more than `tolerancePct` percent AND by more than
+ *  `minAbsMs` absolute ms. Both guards are required so near-zero stages (provider_ttft,
+ *  manager_provision ≈ 0) don't spuriously regress on sub-ms noise. Empty = within tolerance.
+ *  Strict greater-than on both. */
+export function compareToBaseline(
+  baseline: BenchResult,
+  current: BenchResult,
+  tolerancePct: number,
+  minAbsMs = 3,
+): Regression[] {
   const regressions: Regression[] = [];
   const check = (metric: string, b: number, c: number): void => {
     const deltaPct = b === 0 ? (c > 0 ? Infinity : 0) : ((c - b) / b) * 100;
-    if (deltaPct > tolerancePct) regressions.push({ metric, baseline: b, current: c, deltaPct });
+    if (c - b > minAbsMs && deltaPct > tolerancePct) {
+      regressions.push({ metric, baseline: b, current: c, deltaPct });
+    }
   };
   for (const mode of MODES) {
     check(`${mode}.ttft_ms`, baseline[mode].ttft_ms, current[mode].ttft_ms);

--- a/packages/coding-agent/bench/ttft-report.ts
+++ b/packages/coding-agent/bench/ttft-report.ts
@@ -1,0 +1,46 @@
+/** Pure types + comparator for the hermetic TTFT benchmark. No IO — unit-testable. */
+export interface StageBreakdown {
+  manager_provision: number;
+  worker_boot: number;
+  chat_handler: number;
+  provider_ttft: number;
+}
+export interface ModeResult {
+  ttft_ms: number;
+  stages: StageBreakdown;
+  runs: number;
+}
+export interface BenchResult {
+  cold: ModeResult;
+  warm: ModeResult;
+}
+export interface Regression {
+  metric: string;
+  baseline: number;
+  current: number;
+  deltaPct: number;
+}
+
+export function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+const STAGE_KEYS: Array<keyof StageBreakdown> = ["manager_provision", "worker_boot", "chat_handler", "provider_ttft"];
+const MODES: Array<keyof BenchResult> = ["cold", "warm"];
+
+/** Metrics slower than baseline by more than `tolerancePct` percent. Empty = within tolerance.
+ *  A metric at exactly +tolerancePct is NOT a regression (strict greater-than). */
+export function compareToBaseline(baseline: BenchResult, current: BenchResult, tolerancePct: number): Regression[] {
+  const regressions: Regression[] = [];
+  const check = (metric: string, b: number, c: number): void => {
+    const deltaPct = b === 0 ? (c > 0 ? Infinity : 0) : ((c - b) / b) * 100;
+    if (deltaPct > tolerancePct) regressions.push({ metric, baseline: b, current: c, deltaPct });
+  };
+  for (const mode of MODES) {
+    check(`${mode}.ttft_ms`, baseline[mode].ttft_ms, current[mode].ttft_ms);
+    for (const k of STAGE_KEYS) check(`${mode}.${k}`, baseline[mode].stages[k], current[mode].stages[k]);
+  }
+  return regressions;
+}

--- a/packages/coding-agent/bench/ttft.ts
+++ b/packages/coding-agent/bench/ttft.ts
@@ -1,0 +1,208 @@
+/**
+ * Hermetic TTFT benchmark: real manager → worker → chat turn with the bench-instant
+ * stand-in provider (no Chrome, no live model, no credentials). Times provision→first
+ * chat_delta (cold = pool 0 / spawn, warm = pool 1 / adopt) and records the Phase-2
+ * per-stage span breakdown collected off the same WS. JSON out; --check diffs a
+ * committed baseline (local optimization-loop gate, NOT CI).
+ *
+ * WARNING: spawns a manager whose readoptWorkers probes ports 19222-19241 — only run
+ * when NO other xcsh worker/manager is live on this machine, or it will adopt/reap them.
+ *
+ * Run:  bun packages/coding-agent/bench/ttft.ts [--check] [--update-baseline]
+ *            [--out <file>] [--tolerance <pct>] [--runs <n>]
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { EXTENSION_ID } from "../src/cli/chrome-cli";
+import { type BenchResult, compareToBaseline, median, type ModeResult, type StageBreakdown } from "./ttft-report";
+
+const CLI = path.join(import.meta.dir, "../src/cli.ts");
+const EXT = path.join(import.meta.dir, "bench-instant-extension.ts");
+const BASELINE = path.join(import.meta.dir, "ttft-baseline.json");
+const ORIGIN = `chrome-extension://${EXTENSION_ID}`;
+const CONNECT_DEADLINE_MS = 15_000;
+const TURN_DEADLINE_MS = 15_000;
+const sleep = (ms: number): Promise<void> => new Promise(r => setTimeout(r, ms));
+
+interface RunSample {
+  ttft_ms: number;
+  stages: StageBreakdown;
+}
+
+function spawnManager(poolSize: string): { sock: string; getErr: () => string; kill: () => void } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-ttft-"));
+  const sock = path.join(dir, "manager.sock");
+  const proc = Bun.spawn(["bun", CLI, "manager"], {
+    cwd: path.join(import.meta.dir, ".."),
+    env: { ...process.env, XCSH_MANAGER_SOCK: sock, XCSH_WORKER_POOL_SIZE: poolSize, XCSH_BENCH_EXTENSION: EXT },
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  let err = "";
+  void (async () => {
+    const reader = (proc.stderr as ReadableStream<Uint8Array>).getReader();
+    const dec = new TextDecoder();
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        err += dec.decode(value, { stream: true });
+      }
+    } catch {
+      /* torn down on kill */
+    }
+  })();
+  return { sock, getErr: () => err, kill: () => { try { proc.kill(); } catch {} } };
+}
+
+async function sendProvision(sock: string): Promise<void> {
+  const c = await Bun.connect({ unix: sock, socket: { data() {} } });
+  c.write(`${JSON.stringify({ type: "provision", sessionId: "tab-bench", tenant: "acme", env: "production" })}\n`);
+  await sleep(50);
+  c.end();
+}
+
+async function waitForPort(getErr: () => string, re: RegExp, deadlineMs: number): Promise<number> {
+  const end = Date.now() + deadlineMs;
+  while (Date.now() < end) {
+    const m = getErr().match(re);
+    if (m) return Number(m[1]);
+    await sleep(100);
+  }
+  throw new Error(`worker port never appeared in manager stderr (looking for ${re})`);
+}
+
+const STAGE_NAMES = new Set(["manager_provision", "worker_boot", "chat_handler", "provider_ttft"]);
+
+/** Connect as the worker's FIRST client (retry the connect until it binds — a refused
+ *  attempt never opens, so it does not consume the on-connect cold-start flush), send a
+ *  chat_request, and collect the first chat_delta latency (from t0) + the span stages. */
+async function connectAndMeasure(port: number, t0: number, deadlineMs: number): Promise<RunSample> {
+  const stages: Partial<StageBreakdown> = {};
+  const end = Date.now() + deadlineMs;
+  while (Date.now() < end) {
+    const sample = await new Promise<RunSample | null>(resolve => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}`, { headers: { Origin: ORIGIN } } as unknown as string[]);
+      let opened = false;
+      let ttft = 0;
+      const done = (): void => {
+        if (ttft > 0 && STAGE_NAMES.size === Object.keys(stages).length) {
+          clearTimeout(timer);
+          try { ws.close(); } catch {}
+          resolve({ ttft_ms: ttft, stages: stages as StageBreakdown });
+        }
+      };
+      const timer = setTimeout(() => {
+        try { ws.close(); } catch {}
+        resolve(opened ? { ttft_ms: ttft, stages: stages as StageBreakdown } : null);
+      }, Math.max(0, end - Date.now()));
+      ws.onopen = () => {
+        opened = true;
+        ws.send(JSON.stringify({ type: "hello" }));
+        ws.send(JSON.stringify({ type: "chat_request", id: "c-bench", text: "ping", context: null, mode: "educational" }));
+      };
+      ws.onmessage = ev => {
+        const m = JSON.parse(String(ev.data)) as { type?: string; stage?: string; ms?: number };
+        if (m.type === "chat_delta" && ttft === 0) {
+          ttft = (Bun.nanoseconds() - t0) / 1e6;
+          done();
+        } else if (m.type === "span" && typeof m.stage === "string" && typeof m.ms === "number" && STAGE_NAMES.has(m.stage)) {
+          (stages as Record<string, number>)[m.stage] = m.ms;
+          done();
+        }
+      };
+      ws.onerror = () => {
+        clearTimeout(timer);
+        try { ws.close(); } catch {}
+        resolve(opened ? { ttft_ms: ttft, stages: stages as StageBreakdown } : null);
+      };
+      ws.onclose = () => { if (!opened) { clearTimeout(timer); resolve(null); } };
+    });
+    if (sample !== null) return sample;
+    await sleep(150);
+  }
+  throw new Error("worker never accepted a connection before the deadline");
+}
+
+async function runOnce(poolSize: string, portRe: RegExp): Promise<RunSample> {
+  const mgr = spawnManager(poolSize);
+  try {
+    if (poolSize !== "0") await sleep(2500); // let the spare finish booting so provision adopts it
+    const t0 = Bun.nanoseconds();
+    await sendProvision(mgr.sock);
+    const port = await waitForPort(mgr.getErr, portRe, CONNECT_DEADLINE_MS);
+    return await connectAndMeasure(port, t0, TURN_DEADLINE_MS);
+  } finally {
+    mgr.kill();
+    await sleep(200);
+  }
+}
+
+async function runMode(poolSize: string, portRe: RegExp, runs: number): Promise<ModeResult> {
+  const samples: RunSample[] = [];
+  for (let i = 0; i < runs + 1; i++) {
+    const s = await runOnce(poolSize, portRe);
+    if (i > 0) samples.push(s); // discard a warm-up run
+  }
+  const pick = (f: (s: RunSample) => number): number => median(samples.map(f));
+  return {
+    ttft_ms: pick(s => s.ttft_ms),
+    stages: {
+      manager_provision: pick(s => s.stages.manager_provision),
+      worker_boot: pick(s => s.stages.worker_boot),
+      chat_handler: pick(s => s.stages.chat_handler),
+      provider_ttft: pick(s => s.stages.provider_ttft),
+    },
+    runs,
+  };
+}
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? (process.argv[i + 1] ?? "") : undefined;
+}
+function flag(name: string): boolean {
+  return process.argv.includes(name);
+}
+
+const runs = Number(arg("--runs") ?? "5");
+const tolerance = Number(arg("--tolerance") ?? "15");
+
+const result: BenchResult = {
+  cold: await runMode("0", /provisioned tab-bench .* on port (\d+)/, runs),
+  warm: await runMode("1", /adopted spare pid \d+ on port (\d+) as tab-bench/, runs),
+};
+
+if (flag("--update-baseline")) {
+  fs.writeFileSync(BASELINE, `${JSON.stringify(result, null, 2)}\n`);
+  console.log(`baseline updated → ${path.relative(process.cwd(), BASELINE)}`);
+  process.exit(0);
+}
+
+const outFile = arg("--out");
+if (outFile) fs.writeFileSync(outFile, `${JSON.stringify(result, null, 2)}\n`);
+
+if (flag("--check")) {
+  const baseline = JSON.parse(fs.readFileSync(BASELINE, "utf8")) as BenchResult;
+  const regs = compareToBaseline(baseline, result, tolerance);
+  console.log(JSON.stringify(result, null, 2));
+  console.log(`\n=== regression check (tolerance ${tolerance}%) ===`);
+  for (const mode of ["cold", "warm"] as const) {
+    for (const k of ["ttft_ms", "manager_provision", "worker_boot", "chat_handler", "provider_ttft"] as const) {
+      const b = k === "ttft_ms" ? baseline[mode].ttft_ms : baseline[mode].stages[k];
+      const c = k === "ttft_ms" ? result[mode].ttft_ms : result[mode].stages[k];
+      const d = b === 0 ? 0 : ((c - b) / b) * 100;
+      console.log(`  ${mode}.${k}: ${b.toFixed(1)} → ${c.toFixed(1)} (${d >= 0 ? "+" : ""}${d.toFixed(1)}%)`);
+    }
+  }
+  if (regs.length > 0) {
+    console.error(`\nREGRESSION: ${regs.map(r => `${r.metric} +${r.deltaPct.toFixed(1)}%`).join(", ")}`);
+    process.exit(1);
+  }
+  console.log("\nOK — within tolerance");
+  process.exit(0);
+}
+
+console.log(JSON.stringify(result, null, 2));
+process.exit(0);

--- a/packages/coding-agent/bench/ttft.ts
+++ b/packages/coding-agent/bench/ttft.ts
@@ -192,6 +192,10 @@ const outFile = arg("--out");
 if (outFile) fs.writeFileSync(outFile, `${JSON.stringify(result, null, 2)}\n`);
 
 if (flag("--check")) {
+  if (!fs.existsSync(BASELINE)) {
+    console.error(`no baseline at ${path.relative(process.cwd(), BASELINE)} — run with --update-baseline first`);
+    process.exit(1);
+  }
   const baseline = JSON.parse(fs.readFileSync(BASELINE, "utf8")) as BenchResult;
   const regs = compareToBaseline(baseline, result, tolerance);
   console.log(JSON.stringify(result, null, 2));

--- a/packages/coding-agent/bench/ttft.ts
+++ b/packages/coding-agent/bench/ttft.ts
@@ -58,9 +58,20 @@ function spawnManager(poolSize: string): { sock: string; getErr: () => string; k
 
 async function sendProvision(sock: string): Promise<void> {
   const c = await Bun.connect({ unix: sock, socket: { data() {} } });
-  c.write(`${JSON.stringify({ type: "provision", sessionId: "tab-bench", tenant: "acme", env: "production" })}\n`);
+  // The manager's parseControlMsg requires a piped "tenant|env" string (isTenant);
+  // a bare tenant is rejected and the provision silently dropped.
+  c.write(`${JSON.stringify({ type: "provision", sessionId: "tab-bench", tenant: "acme|production" })}\n`);
   await sleep(50);
   c.end();
+}
+
+async function waitForSocket(sock: string, deadlineMs: number): Promise<void> {
+  const end = Date.now() + deadlineMs;
+  while (Date.now() < end) {
+    if (fs.existsSync(sock)) return;
+    await sleep(50);
+  }
+  throw new Error(`manager control socket never appeared: ${sock}`);
 }
 
 async function waitForPort(getErr: () => string, re: RegExp, deadlineMs: number): Promise<number> {
@@ -86,16 +97,22 @@ async function connectAndMeasure(port: number, t0: number, deadlineMs: number): 
       const ws = new WebSocket(`ws://127.0.0.1:${port}`, { headers: { Origin: ORIGIN } } as unknown as string[]);
       let opened = false;
       let ttft = 0;
+      let resend: ReturnType<typeof setInterval> | undefined;
+      const chatReq = JSON.stringify({ type: "chat_request", id: "c-bench", text: "ping", context: null, mode: "educational" });
+      const cleanup = (): void => {
+        clearTimeout(timer);
+        if (resend) clearInterval(resend);
+        try { ws.close(); } catch {}
+      };
       const complete = (): boolean => ttft > 0 && STAGE_NAMES.size === Object.keys(stages).length;
       const done = (): void => {
         if (complete()) {
-          clearTimeout(timer);
-          try { ws.close(); } catch {}
+          cleanup();
           resolve({ ttft_ms: ttft, stages: stages as StageBreakdown });
         }
       };
       const timer = setTimeout(() => {
-        try { ws.close(); } catch {}
+        cleanup();
         // Opened but the turn never completed → fail loudly rather than median a
         // partial (0 ttft / undefined stages) sample. Never opened → retry the connect.
         if (opened) reject(new Error(`turn incomplete before deadline (ttft=${ttft}, stages=${Object.keys(stages).join(",")})`));
@@ -104,22 +121,32 @@ async function connectAndMeasure(port: number, t0: number, deadlineMs: number): 
       ws.onopen = () => {
         opened = true;
         ws.send(JSON.stringify({ type: "hello" }));
-        ws.send(JSON.stringify({ type: "chat_request", id: "c-bench", text: "ping", context: null, mode: "educational" }));
+        ws.send(chatReq);
+        // On a COLD spawn, createAgentSession (hence ChatHandler.attach) completes AFTER
+        // hello_ack, so an early chat_request is dropped by the not-yet-attached worker.
+        // Resend until the first chat_delta; once a turn is streaming, extra requests get
+        // a harmless "session busy" reply (ignored here).
+        resend = setInterval(() => {
+          if (ttft === 0) { try { ws.send(chatReq); } catch {} }
+        }, 400);
       };
       ws.onmessage = ev => {
         const m = JSON.parse(String(ev.data)) as { type?: string; stage?: string; ms?: number };
-        if (m.type === "chat_delta" && ttft === 0) { ttft = (Bun.nanoseconds() - t0) / 1e6; done(); }
-        else if (m.type === "span" && typeof m.stage === "string" && typeof m.ms === "number" && STAGE_NAMES.has(m.stage)) {
-          (stages as Record<string, number>)[m.stage] = m.ms; done();
+        if (m.type === "chat_delta" && ttft === 0) {
+          ttft = (Bun.nanoseconds() - t0) / 1e6;
+          if (resend) clearInterval(resend);
+          done();
+        } else if (m.type === "span" && typeof m.stage === "string" && typeof m.ms === "number" && STAGE_NAMES.has(m.stage)) {
+          (stages as Record<string, number>)[m.stage] = m.ms;
+          done();
         }
       };
       ws.onerror = () => {
-        clearTimeout(timer);
-        try { ws.close(); } catch {}
+        cleanup();
         if (opened) reject(new Error("ws error after open before turn completed"));
         else resolve(null);
       };
-      ws.onclose = () => { if (!opened) { clearTimeout(timer); resolve(null); } };
+      ws.onclose = () => { if (!opened) { cleanup(); resolve(null); } };
     });
     if (sample !== null) return sample;
     await sleep(150);
@@ -130,6 +157,7 @@ async function connectAndMeasure(port: number, t0: number, deadlineMs: number): 
 async function runOnce(poolSize: string, portRe: RegExp): Promise<RunSample> {
   const mgr = spawnManager(poolSize);
   try {
+    await waitForSocket(mgr.sock, 10_000); // manager must bind its control socket before we provision
     if (poolSize !== "0") await sleep(2500); // let the spare finish booting so provision adopts it
     const t0 = Bun.nanoseconds();
     await sendProvision(mgr.sock);
@@ -175,7 +203,15 @@ const numArg = (name: string, def: number): number => {
   return Number.isFinite(n) && n > 0 ? n : def;
 };
 const runs = numArg("--runs", 5);
-const tolerance = numArg("--tolerance", 15);
+// Empirically tuned to this wall-clock micro-benchmark's noise floor (measured over
+// repeated runs): sub-~15ms stages (warm worker_boot, manager_provision, chat_handler)
+// jitter by several ms, and the agent-loop first-prompt provider_ttft swings ~±25%
+// run-to-run. So the local gate requires BOTH a >30% relative AND a >15ms absolute
+// regression — it catches gross regressions (the Phase-4 targets: cold worker_boot,
+// provider_ttft) without false-positiving on ms/agent-loop noise. Override per-run with
+// --tolerance / --min-abs-ms; the printed diff table always shows exact Δ% for finer judgment.
+const tolerance = numArg("--tolerance", 30);
+const minAbsMs = numArg("--min-abs-ms", 15);
 
 const result: BenchResult = {
   cold: await runMode("0", /provisioned tab-bench .* on port (\d+)/, runs),
@@ -197,9 +233,9 @@ if (flag("--check")) {
     process.exit(1);
   }
   const baseline = JSON.parse(fs.readFileSync(BASELINE, "utf8")) as BenchResult;
-  const regs = compareToBaseline(baseline, result, tolerance);
+  const regs = compareToBaseline(baseline, result, tolerance, minAbsMs);
   console.log(JSON.stringify(result, null, 2));
-  console.log(`\n=== regression check (tolerance ${tolerance}%) ===`);
+  console.log(`\n=== regression check (tolerance ${tolerance}% + ${minAbsMs}ms floor) ===`);
   for (const mode of ["cold", "warm"] as const) {
     for (const k of ["ttft_ms", "manager_provision", "worker_boot", "chat_handler", "provider_ttft"] as const) {
       const b = k === "ttft_ms" ? baseline[mode].ttft_ms : baseline[mode].stages[k];

--- a/packages/coding-agent/bench/ttft.ts
+++ b/packages/coding-agent/bench/ttft.ts
@@ -82,12 +82,13 @@ async function connectAndMeasure(port: number, t0: number, deadlineMs: number): 
   const stages: Partial<StageBreakdown> = {};
   const end = Date.now() + deadlineMs;
   while (Date.now() < end) {
-    const sample = await new Promise<RunSample | null>(resolve => {
+    const sample = await new Promise<RunSample | null>((resolve, reject) => {
       const ws = new WebSocket(`ws://127.0.0.1:${port}`, { headers: { Origin: ORIGIN } } as unknown as string[]);
       let opened = false;
       let ttft = 0;
+      const complete = (): boolean => ttft > 0 && STAGE_NAMES.size === Object.keys(stages).length;
       const done = (): void => {
-        if (ttft > 0 && STAGE_NAMES.size === Object.keys(stages).length) {
+        if (complete()) {
           clearTimeout(timer);
           try { ws.close(); } catch {}
           resolve({ ttft_ms: ttft, stages: stages as StageBreakdown });
@@ -95,7 +96,10 @@ async function connectAndMeasure(port: number, t0: number, deadlineMs: number): 
       };
       const timer = setTimeout(() => {
         try { ws.close(); } catch {}
-        resolve(opened ? { ttft_ms: ttft, stages: stages as StageBreakdown } : null);
+        // Opened but the turn never completed → fail loudly rather than median a
+        // partial (0 ttft / undefined stages) sample. Never opened → retry the connect.
+        if (opened) reject(new Error(`turn incomplete before deadline (ttft=${ttft}, stages=${Object.keys(stages).join(",")})`));
+        else resolve(null);
       }, Math.max(0, end - Date.now()));
       ws.onopen = () => {
         opened = true;
@@ -104,18 +108,16 @@ async function connectAndMeasure(port: number, t0: number, deadlineMs: number): 
       };
       ws.onmessage = ev => {
         const m = JSON.parse(String(ev.data)) as { type?: string; stage?: string; ms?: number };
-        if (m.type === "chat_delta" && ttft === 0) {
-          ttft = (Bun.nanoseconds() - t0) / 1e6;
-          done();
-        } else if (m.type === "span" && typeof m.stage === "string" && typeof m.ms === "number" && STAGE_NAMES.has(m.stage)) {
-          (stages as Record<string, number>)[m.stage] = m.ms;
-          done();
+        if (m.type === "chat_delta" && ttft === 0) { ttft = (Bun.nanoseconds() - t0) / 1e6; done(); }
+        else if (m.type === "span" && typeof m.stage === "string" && typeof m.ms === "number" && STAGE_NAMES.has(m.stage)) {
+          (stages as Record<string, number>)[m.stage] = m.ms; done();
         }
       };
       ws.onerror = () => {
         clearTimeout(timer);
         try { ws.close(); } catch {}
-        resolve(opened ? { ttft_ms: ttft, stages: stages as StageBreakdown } : null);
+        if (opened) reject(new Error("ws error after open before turn completed"));
+        else resolve(null);
       };
       ws.onclose = () => { if (!opened) { clearTimeout(timer); resolve(null); } };
     });
@@ -166,8 +168,14 @@ function flag(name: string): boolean {
   return process.argv.includes(name);
 }
 
-const runs = Number(arg("--runs") ?? "5");
-const tolerance = Number(arg("--tolerance") ?? "15");
+const numArg = (name: string, def: number): number => {
+  const v = arg(name);
+  if (v === undefined) return def;
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : def;
+};
+const runs = numArg("--runs", 5);
+const tolerance = numArg("--tolerance", 15);
 
 const result: BenchResult = {
   cold: await runMode("0", /provisioned tab-bench .* on port (\d+)/, runs),

--- a/packages/coding-agent/src/commands/worker.ts
+++ b/packages/coding-agent/src/commands/worker.ts
@@ -228,6 +228,9 @@ export default class Worker extends Command {
 			enableMCP: false,
 			enableLsp: false,
 			disableExtensionDiscovery: true,
+			// TTFT Phase 3: load the hermetic bench stand-in provider when the benchmark
+			// sets XCSH_BENCH_EXTENSION (absolute path). Inert for normal workers.
+			...(process.env.XCSH_BENCH_EXTENSION ? { additionalExtensionPaths: [process.env.XCSH_BENCH_EXTENSION] } : {}),
 		});
 
 		const chatHandler = new ChatHandler(bridge, session);

--- a/packages/coding-agent/test/bench-instant-extension.test.ts
+++ b/packages/coding-agent/test/bench-instant-extension.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import benchExtension from "../bench/bench-instant-extension";
+
+describe("bench-instant extension", () => {
+	it("registers a bench-instant model whose stream emits a text_delta then done", async () => {
+		let captured: { name: string; config: Record<string, any> } | null = null;
+		const pi = {
+			registerProvider: (name: string, config: Record<string, any>) => {
+				captured = { name, config };
+			},
+			events: {},
+		} as unknown as Parameters<typeof benchExtension>[0];
+
+		benchExtension(pi);
+
+		expect(captured!.name).toBe("bench-instant");
+		expect(captured!.config.models[0].id).toBe("bench-instant");
+		expect(captured!.config.apiKey).toBeTruthy();
+
+		const stream = captured!.config.streamSimple(
+			{ id: "bench-instant", provider: "bench-instant", api: "bench-instant" },
+			{ messages: [] },
+		);
+		const events: Array<{ type: string; delta?: string }> = [];
+		for await (const ev of stream) events.push(ev);
+		const delta = events.find(e => e.type === "text_delta");
+		expect(delta?.delta).toBe("ok");
+		expect(events.some(e => e.type === "done")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -680,7 +680,7 @@ test("a STALE control socket left by a crashed manager is reclaimed on next star
 
 test("cold spawn emits manager_provision + worker_boot spans with cold=true", async () => {
 	const getErr = await startManagerWithPool("0"); // no spares -> cold spawn
-	await send({ type: "provision", sessionId: "tab-501", tenant: "acme", env: "production" });
+	await send({ type: "provision", sessionId: "tab-501", tenant: "acme|production" });
 	const port = await waitForPort(getErr, /provisioned tab-501 .* on port (\d+)/);
 	expect(port).not.toBeNull();
 
@@ -695,7 +695,7 @@ test("cold spawn emits manager_provision + worker_boot spans with cold=true", as
 
 test("warm adopt emits worker_boot span with cold=false", async () => {
 	const getErr = await startManagerWithPool("1"); // one warm spare -> adopt
-	await send({ type: "provision", sessionId: "tab-777", tenant: "acme", env: "production" });
+	await send({ type: "provision", sessionId: "tab-777", tenant: "acme|production" });
 	const port = await waitForPort(getErr, /adopted spare pid \d+ on port (\d+) as tab-777/);
 	expect(port).not.toBeNull();
 

--- a/packages/coding-agent/test/ttft-report.test.ts
+++ b/packages/coding-agent/test/ttft-report.test.ts
@@ -40,4 +40,30 @@ describe("compareToBaseline", () => {
 		cur.warm.ttft_ms = 20 * 1.15; // exactly +15%
 		expect(compareToBaseline(base, cur, 15)).toEqual([]);
 	});
+	it("does not flag a near-zero stage that grows by a large percent but a tiny absolute", () => {
+		const cur = clone(base);
+		cur.cold.stages.provider_ttft = 2; // 1 → 2ms = +100% but only +1ms absolute
+		cur.warm.stages.manager_provision = 5; // 2 → 5ms = +150% but +3ms (not > 3)
+		expect(compareToBaseline(base, cur, 15)).toEqual([]);
+	});
+
+	it("flags a near-zero stage only when the absolute jump also exceeds the floor", () => {
+		const cur = clone(base);
+		cur.cold.stages.provider_ttft = 10; // 1 → 10ms = +900% and +9ms > 3
+		const regs = compareToBaseline(base, cur, 15);
+		expect(regs.map(r => r.metric)).toEqual(["cold.provider_ttft"]);
+	});
+
+	it("handles a zero baseline: below the abs floor is ignored, a real jump is flagged (Infinity deltaPct)", () => {
+		const zero = clone(base);
+		zero.cold.stages.manager_provision = 0;
+		const small = clone(zero);
+		small.cold.stages.manager_provision = 2; // +2ms ≤ 3 → ignored
+		expect(compareToBaseline(zero, small, 15)).toEqual([]);
+		const big = clone(zero);
+		big.cold.stages.manager_provision = 50; // +50ms > 3, deltaPct Infinity
+		const regs = compareToBaseline(zero, big, 15);
+		expect(regs.map(r => r.metric)).toEqual(["cold.manager_provision"]);
+		expect(regs[0].deltaPct).toBe(Infinity);
+	});
 });

--- a/packages/coding-agent/test/ttft-report.test.ts
+++ b/packages/coding-agent/test/ttft-report.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { type BenchResult, compareToBaseline, median } from "../bench/ttft-report";
+
+const base: BenchResult = {
+	cold: {
+		ttft_ms: 800,
+		stages: { manager_provision: 2, worker_boot: 780, chat_handler: 8, provider_ttft: 1 },
+		runs: 5,
+	},
+	warm: { ttft_ms: 20, stages: { manager_provision: 2, worker_boot: 5, chat_handler: 8, provider_ttft: 1 }, runs: 5 },
+};
+const clone = (r: BenchResult): BenchResult => JSON.parse(JSON.stringify(r));
+
+describe("median", () => {
+	it("returns the middle of odd- and even-length sets", () => {
+		expect(median([3, 1, 2])).toBe(2);
+		expect(median([1, 2, 3, 4])).toBe(2.5);
+	});
+});
+
+describe("compareToBaseline", () => {
+	it("no regression when current equals baseline", () => {
+		expect(compareToBaseline(base, clone(base), 15)).toEqual([]);
+	});
+	it("no regression when faster", () => {
+		const cur = clone(base);
+		cur.cold.stages.worker_boot = 600;
+		cur.cold.ttft_ms = 620;
+		expect(compareToBaseline(base, cur, 15)).toEqual([]);
+	});
+	it("flags a stage that regressed beyond tolerance, naming the culprit", () => {
+		const cur = clone(base);
+		cur.cold.stages.worker_boot = 780 * 1.2; // +20% > 15%
+		const regs = compareToBaseline(base, cur, 15);
+		expect(regs.map(r => r.metric)).toContain("cold.worker_boot");
+		expect(regs.find(r => r.metric === "cold.worker_boot")!.deltaPct).toBeGreaterThan(15);
+	});
+	it("does not flag exactly at the tolerance boundary", () => {
+		const cur = clone(base);
+		cur.warm.ttft_ms = 20 * 1.15; // exactly +15%
+		expect(compareToBaseline(base, cur, 15)).toEqual([]);
+	});
+});

--- a/packages/coding-agent/tsconfig.json
+++ b/packages/coding-agent/tsconfig.json
@@ -3,6 +3,7 @@
 	"include": [
 		"src",
 		"test",
-		"scripts"
+		"scripts",
+		"bench"
 	]
 }


### PR DESCRIPTION
## What & why

TTFT Phase 3 — a hermetic, Chrome-free, credential-free benchmark that drives a real **manager → worker → chat turn** with a stand-in instant LLM, times **provision→first-token** (cold=spawn / warm=adopt), records the Phase-2 per-stage breakdown, emits JSON, and diffs a committed baseline. The measurement engine for the Phase-4 optimize→re-measure loop.

### Components (all `packages/coding-agent/`)
- `bench/bench-instant-extension.ts` — a default-export pi extension registering a keyed `bench-instant` provider whose stream emits a first token synchronously (zero network, no credentials). With no real provider keys present, a headless worker selects it deterministically.
- `src/commands/worker.ts` — env-gated forward of `XCSH_BENCH_EXTENSION` into `createAgentSession`'s `additionalExtensionPaths` (inert unless set).
- `bench/ttft-report.ts` — pure result types + `median` + `compareToBaseline` (per-mode/per-stage regression with a percent tolerance + absolute-ms floor).
- `bench/ttft.ts` — the manager-driven harness (provision over the control socket → discover the worker port from stderr → connect a WS client that also collects the Phase-2 span frames → time the first `chat_delta`). `--check` (local gate) / `--update-baseline` / `--out` / `--tolerance` / `--min-abs-ms` / `--runs`.
- `bench/ttft-baseline.json` — committed reference.
- `packages/coding-agent/tsconfig.json` — add `bench` to `include` so the harness is type-checked.

### Verified end-to-end (run locally)
- cold `worker_boot` ~849ms vs warm ~4ms — the adopt-vs-spawn cold-start difference the benchmark exists to measure.
- `provider_ttft` ~3.5–4s in both modes — the agent-loop first-prompt overhead the instant provider exposes (a Phase-4 target).
- `--check` passes against its own baseline; the gate is local-only (not CI), tuned to the measured noise floor (>30% AND >15ms).

### Also fixed (pre-existing, found by running the E2E)
The two Phase-2 B5 `manager.int` tests (#1897) sent a bare `tenant:"acme"`, which `isTenant` rejects (`tenant|env` required) → the provision was silently dropped and the tests failed; they escaped notice because CI does not exercise that real-subprocess integration file. Corrected to `"acme|production"`; both now pass and genuinely verify the cold/warm span emission.

## Testing
- `bun run check:types` clean (now covers `bench/`); `bun test` green (new pure unit tests: extension + comparator, 9 tests; the fixed B5 integration tests pass locally).
- Harness E2E validated locally + baseline captured (spawns real managers/workers on 19222–41 — not run in CI). Subagent-driven per task + whole-branch review + a focused review of the E2E fixes.

Part of the TTFT benchmarking initiative (Phase 3).

Closes #1900
