### PR TITLE
fix: honest CI test gate — stop process.exit masking xcsh failures (#1903)

### DIFF
--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -36,7 +36,7 @@
 		"check:types": "bun run generate-build-info && bun run generate-extension-capabilities && bun run generate-api-spec-index && bun run generate-branding-index && bun run generate-terraform-index && tsgo -p tsconfig.json --noEmit",
 		"lint": "biome lint .",
 		"check:bundle": "bun scripts/check-bundle.ts",
-		"test": "bun run generate-build-info && bun run generate-extension-capabilities && bun run generate-api-spec-index && bun run generate-console-catalog && bun run generate-console-field-metadata && bun test --max-concurrency 4",
+		"test": "bun run generate-build-info && bun run generate-extension-capabilities && bun run generate-api-spec-index && bun run generate-console-catalog && bun run generate-console-field-metadata && bun scripts/bun-test-guarded.ts --max-concurrency 4",
 		"fix": "biome check --write --unsafe . && bun run format-prompts && bun run generate-docs-index && bun run generate-api-spec-index && bun run generate-build-info",
 		"fmt": "biome format --write . && bun run format-prompts",
 		"format-prompts": "bun scripts/format-prompts.ts",

--- a/packages/coding-agent/scripts/bun-test-guarded.ts
+++ b/packages/coding-agent/scripts/bun-test-guarded.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env bun
+/**
+ * Guarded `bun test` runner.
+ *
+ * Runs `bun test <args…>` and enforces one extra invariant: if the run exits 0
+ * it MUST have printed a "Ran N tests" summary. A test module that calls
+ * `process.exit(0)` terminates the whole runner with a success code BEFORE the
+ * summary prints, silently masking every failure that already ran (this made the
+ * required CI `test` job a no-op gate — issue #1903). Exit code alone can't catch
+ * that regression; the missing summary can.
+ *
+ * Behaviour:
+ *  - child exits non-zero  → propagate it (real failures already fail the job).
+ *  - child exits 0 WITH a summary ("Ran N tests" / "No tests found") → pass.
+ *  - child exits 0 WITHOUT a summary → fail (exit 1): a test aborted the runner.
+ *
+ * stderr (where bun writes results) is streamed through unchanged so CI logs are
+ * identical; we only tee it to scan for the summary line.
+ */
+const args = process.argv.slice(2);
+
+// Use the running bun (process.execPath), not a PATH lookup of "bun", so the
+// guard works in any environment the parent runs in.
+const proc = Bun.spawn([process.execPath, "test", ...args], {
+	stdout: "inherit",
+	stderr: "pipe",
+	env: process.env,
+});
+
+const SUMMARY = /Ran \d+ tests?\b|No tests found/;
+const decoder = new TextDecoder();
+// Keep a small rolling tail so a summary line split across two chunks is still
+// matched, without buffering the entire (potentially large) stderr stream.
+let tail = "";
+
+for await (const chunk of proc.stderr as ReadableStream<Uint8Array>) {
+	process.stderr.write(chunk); // stream through unchanged
+	tail = (tail + decoder.decode(chunk, { stream: true })).slice(-4096);
+}
+
+const sawSummary = SUMMARY.test(tail);
+const code = await proc.exited;
+
+if (code !== 0) process.exit(code);
+
+if (!sawSummary) {
+	process.stderr.write(
+		'\n\x1b[31mtest-guard: `bun test` exited 0 but printed no "Ran N tests" summary.\x1b[0m\n' +
+			"A test module likely called process.exit() and aborted the runner, masking failures (see #1903).\n",
+	);
+	process.exit(1);
+}
+
+process.exit(0);

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -327,6 +327,11 @@ export async function resolvePromptInput(input: string | undefined, description:
 export interface LoadContextFilesOptions {
 	/** Working directory to start walking up from. Default: getProjectDir() */
 	cwd?: string;
+	/**
+	 * Explicit disabled extension IDs to apply instead of the global settings default.
+	 * Pass `[]` to force discovery independent of any process-wide settings state.
+	 */
+	disabledExtensions?: string[];
 }
 
 function dedupeExactContextFiles(
@@ -351,7 +356,10 @@ export async function loadProjectContextFiles(
 ): Promise<Array<{ path: string; content: string; depth?: number }>> {
 	const resolvedCwd = options.cwd ?? getProjectDir();
 
-	const result = await loadCapability(contextFileCapability.id, { cwd: resolvedCwd });
+	const result = await loadCapability(contextFileCapability.id, {
+		cwd: resolvedCwd,
+		disabledExtensions: options.disabledExtensions,
+	});
 
 	// Convert ContextFile items and preserve depth info
 	const files = result.items.map(item => {
@@ -436,6 +444,11 @@ export interface BuildSystemPromptOptions {
 	cwd?: string;
 	/** Pre-loaded context files (skips discovery if provided). */
 	contextFiles?: Array<{ path: string; content: string; depth?: number }>;
+	/**
+	 * Explicit disabled extension IDs applied to context-file discovery instead of the
+	 * global settings default. Pass `[]` to discover independent of process-wide settings.
+	 */
+	disabledExtensions?: string[];
 	/** Skills provided directly to system prompt construction. */
 	skills?: Skill[];
 	/** Pre-loaded rulebook rules (descriptions, excluding TTSR and always-apply). */
@@ -519,7 +532,10 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		});
 		const contextFilesPromise = providedContextFiles
 			? Promise.resolve(providedContextFiles)
-			: logger.time("loadProjectContextFiles", loadProjectContextFiles, { cwd: resolvedCwd });
+			: logger.time("loadProjectContextFiles", loadProjectContextFiles, {
+					cwd: resolvedCwd,
+					disabledExtensions: options.disabledExtensions,
+				});
 		const agentsMdSearchPromise = logger.time("buildAgentsMdSearch", buildAgentsMdSearch, resolvedCwd);
 		const mergedSkillsSettings = {
 			...skillsSettings,

--- a/packages/coding-agent/test/discovery/xcsh-md-init-file.test.ts
+++ b/packages/coding-agent/test/discovery/xcsh-md-init-file.test.ts
@@ -64,7 +64,13 @@ describe("XCSH.md is the agent init file", () => {
 		fs.mkdirSync(configDir, { recursive: true });
 		fs.writeFileSync(path.join(configDir, "XCSH.md"), "PROJECT_XCSH_MARKER");
 
-		const result = await loadCapability<ContextFile>(contextFileCapability.id, { cwd: tempDir });
+		const result = await loadCapability<ContextFile>(contextFileCapability.id, {
+			cwd: tempDir,
+			// Explicit empty list so discovery is immune to any process-wide `disabledExtensions`
+			// left in the shared capability `settings` global by a concurrently-scheduled test file
+			// (bun runs all files in one process under --max-concurrency).
+			disabledExtensions: [],
+		});
 		const item = result.items.find(i => i.path === path.join(configDir, "XCSH.md"));
 		expect(item?.content).toBe("PROJECT_XCSH_MARKER");
 	});
@@ -74,7 +80,13 @@ describe("XCSH.md is the agent init file", () => {
 		fs.mkdirSync(userDir, { recursive: true });
 		fs.writeFileSync(path.join(userDir, "XCSH.md"), "USER_XCSH_MARKER");
 
-		const result = await loadCapability<ContextFile>(contextFileCapability.id, { cwd: tempDir });
+		const result = await loadCapability<ContextFile>(contextFileCapability.id, {
+			cwd: tempDir,
+			// Explicit empty list so discovery is immune to any process-wide `disabledExtensions`
+			// left in the shared capability `settings` global by a concurrently-scheduled test file
+			// (bun runs all files in one process under --max-concurrency).
+			disabledExtensions: [],
+		});
 		const userItem = result.items.find(i => i.level === "user");
 		expect(userItem?.path).toBe(path.join(userDir, "XCSH.md"));
 		expect(userItem?.content).toBe("USER_XCSH_MARKER");
@@ -85,28 +97,40 @@ describe("XCSH.md is the agent init file", () => {
 		fs.mkdirSync(configDir, { recursive: true });
 		fs.writeFileSync(path.join(configDir, "AGENTS.md"), "LEGACY_SHOULD_BE_IGNORED");
 
-		const result = await loadCapability<ContextFile>(contextFileCapability.id, { cwd: tempDir });
+		const result = await loadCapability<ContextFile>(contextFileCapability.id, {
+			cwd: tempDir,
+			// Explicit empty list so discovery is immune to any process-wide `disabledExtensions`
+			// left in the shared capability `settings` global by a concurrently-scheduled test file
+			// (bun runs all files in one process under --max-concurrency).
+			disabledExtensions: [],
+		});
 		expect(result.items).toHaveLength(0);
 	});
 
 	it("discovers a repo-root XCSH.md by default", async () => {
 		fs.writeFileSync(path.join(tempDir, "XCSH.md"), "ROOT_XCSH_MARKER");
 
-		const files = await loadProjectContextFiles({ cwd: tempDir });
+		const files = await loadProjectContextFiles({ cwd: tempDir, disabledExtensions: [] });
 		expect(files.map(f => f.path)).toContain(path.join(tempDir, "XCSH.md"));
 	});
 
 	it("ignores a repo-root AGENTS.md", async () => {
 		fs.writeFileSync(path.join(tempDir, "AGENTS.md"), "LEGACY_ROOT_IGNORED");
 
-		const files = await loadProjectContextFiles({ cwd: tempDir });
+		const files = await loadProjectContextFiles({ cwd: tempDir, disabledExtensions: [] });
 		expect(files.map(f => f.path)).not.toContain(path.join(tempDir, "AGENTS.md"));
 	});
 
 	it("injects repo-root XCSH.md content into the system prompt <context> block", async () => {
 		fs.writeFileSync(path.join(tempDir, "XCSH.md"), "XCSH_CONTEXT_MARKER_42");
 
-		const prompt = await buildSystemPrompt({ cwd: tempDir, skills: [], rules: [], toolNames: [] });
+		const prompt = await buildSystemPrompt({
+			cwd: tempDir,
+			skills: [],
+			rules: [],
+			toolNames: [],
+			disabledExtensions: [],
+		});
 		expect(prompt).toContain("XCSH_CONTEXT_MARKER_42");
 	});
 
@@ -116,7 +140,13 @@ describe("XCSH.md is the agent init file", () => {
 		fs.writeFileSync(path.join(sub, "XCSH.md"), "# service rules");
 		fs.writeFileSync(path.join(sub, "AGENTS.md"), "# legacy service rules");
 
-		const prompt = await buildSystemPrompt({ cwd: tempDir, skills: [], rules: [], toolNames: [] });
+		const prompt = await buildSystemPrompt({
+			cwd: tempDir,
+			skills: [],
+			rules: [],
+			toolNames: [],
+			disabledExtensions: [],
+		});
 		expect(prompt).toContain("service/XCSH.md");
 		expect(prompt).not.toContain("service/AGENTS.md");
 	});

--- a/packages/coding-agent/test/e2e/extension-e2e.test.ts
+++ b/packages/coding-agent/test/e2e/extension-e2e.test.ts
@@ -20,17 +20,14 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 
 // E2E tests require a display + the real Chrome extension loaded — skip in CI.
+// IMPORTANT: never `process.exit()` from a test module. It terminates the whole
+// `bun test` runner with that exit code, masking every other test's result (a
+// `process.exit(0)` here silently turned the entire xcsh suite green in CI — see
+// issue #1903). Skip cleanly with `describe.skipIf(isCI)` and import puppeteer
+// dynamically inside `beforeAll` so it never loads on a runner without Chrome.
 const isCI = !!process.env.CI || !!process.env.GITHUB_ACTIONS;
-if (isCI) {
-	console.log("Skipping E2E tests in CI (no display / no extension).");
-	describe.skip("Extension E2E (skipped in CI)", () => {
-		it("placeholder", () => {});
-	});
-	process.exit(0);
-}
 
 import type { Browser, WebWorker } from "puppeteer";
-import puppeteer from "puppeteer";
 import { type BridgeServer, startBridgeServer } from "../../src/browser/extension-bridge";
 
 const EXT_PATH = "/Users/r.mordasiewicz/GIT/web-search/xcsh-chrome-extension/dist";
@@ -44,174 +41,178 @@ let server: BridgeServer;
 let worker: WebWorker | null = null;
 
 // --- Lifecycle ---
+// The whole suite is skipped in CI (no display / no Chrome). `skipIf` means the
+// hooks below never run there, so the dynamic puppeteer import stays inert.
+describe.skipIf(isCI)("Extension E2E (real Chrome via Puppeteer)", () => {
+	beforeAll(async () => {
+		// 1. Start the bridge server (xcsh side of the native-messaging pipeline).
+		server = await startBridgeServer();
 
-beforeAll(async () => {
-	// 1. Start the bridge server (xcsh side of the native-messaging pipeline).
-	server = await startBridgeServer();
+		// 2. Launch Chrome with the extension loaded via Puppeteer 24.x API.
+		const puppeteer = (await import("puppeteer")).default;
+		browser = await puppeteer.launch({
+			headless: false,
+			pipe: true, // required for enableExtensions with path list
+			enableExtensions: [EXT_PATH],
+		});
 
-	// 2. Launch Chrome with the extension loaded via Puppeteer 24.x API.
-	browser = await puppeteer.launch({
-		headless: false,
-		pipe: true, // required for enableExtensions with path list
-		enableExtensions: [EXT_PATH],
-	});
-
-	// 3. Wait for the extension's service worker to start.
-	const swTarget = await browser.waitForTarget(
-		t => t.type() === "service_worker" && t.url().includes("service-worker"),
-		{ timeout: 20_000 },
-	);
-	worker = await swTarget.worker();
-
-	// 4. Wait for the bridge connection (SW → native host → xcsh socket).
-	const deadline = Date.now() + 30_000;
-	while (Date.now() < deadline && !server.connected) {
-		await sleep(500);
-	}
-}, 60_000);
-
-afterAll(async () => {
-	await browser?.close().catch(() => {});
-	await server?.close().catch(() => {});
-}, 15_000);
-
-// --- Helper ---
-
-async function tool(name: string, params: Record<string, unknown> = {}, timeout = 30_000) {
-	const r = await server.request(name, params, timeout);
-	if (r.is_error) throw new Error(`${name}: ${JSON.stringify(r.content)}`);
-	return r.content as Record<string, unknown>;
-}
-
-// --- Level 3: E2E Tests ---
-
-describe("Extension E2E (Puppeteer + real Chrome)", () => {
-	it("extension loads and service worker starts", () => {
-		expect(worker).not.toBeNull();
-	}, 30_000);
-
-	it("bridge connects via native messaging", () => {
-		expect(server.connected).toBe(true);
-	}, 30_000);
-
-	it("ping round-trip through the full pipeline", async () => {
-		const pong = await tool("ping");
-		expect(pong).toMatchObject({ ok: true, version: "0.1.0" });
-	}, 30_000);
-
-	it("navigate opens a console tab", async () => {
-		const nav = await tool("navigate", { url: CONSOLE_URL }, 45_000);
-		expect(nav).toHaveProperty("tabId");
-	}, 60_000);
-
-	it("read_ax returns a non-trivial AX tree from the console", async () => {
-		const tree = (await tool("read_ax", {}, 30_000)) as { role?: string; children?: unknown[] };
-		expect(tree).toHaveProperty("role");
-		// Count nodes
-		const flat: string[] = [];
-		(function walk(n: any) {
-			if (!n) return;
-			flat.push(`${n.role}:${n.name?.slice(0, 30)}`);
-			(n.children || []).forEach(walk);
-		})(tree);
-		expect(flat.length).toBeGreaterThan(10);
-	}, 45_000);
-
-	it("read_ax response fits under the 1MB native-messaging limit", async () => {
-		const tree = await tool("read_ax", {}, 30_000);
-		const size = JSON.stringify(tree).length;
-		expect(size).toBeLessThan(900_000);
-	}, 45_000);
-
-	it("find resolves a text selector on the console", async () => {
-		const found = (await tool("find", { selector: "text('HTTP Load Balancers')" }, 30_000)) as {
-			refs?: Array<{ ref: string }>;
-		};
-		expect(found.refs?.length).toBeGreaterThan(0);
-	}, 45_000);
-
-	it("get_page_text returns content", async () => {
-		const pt = (await tool("get_page_text", {}, 15_000)) as { text?: string };
-		expect((pt.text ?? "").length).toBeGreaterThan(50);
-	}, 30_000);
-
-	it("javascript_tool returns the page title", async () => {
-		const j = (await tool("javascript_tool", { code: "document.title" }, 15_000)) as { result?: string };
-		expect(j.result).toContain("Load Balancers");
-	}, 30_000);
-
-	it("tabs_list shows the console tab", async () => {
-		const t = (await tool("tabs_list", {}, 10_000)) as { tabs?: unknown[] };
-		expect((t.tabs ?? []).length).toBeGreaterThan(0);
-	}, 30_000);
-
-	it("screenshot returns data or a clear size error (never a silent timeout)", async () => {
-		let gotData = false;
-		let gotSizeError = false;
-		try {
-			const s = (await tool("screenshot", {}, 15_000)) as { data?: string };
-			if (s.data && s.data.length > 0) gotData = true;
-		} catch (e: unknown) {
-			const msg = (e as Error).message;
-			if (/too large|size|900/i.test(msg)) gotSizeError = true;
-			else throw e; // unexpected error — re-throw
-		}
-		expect(gotData || gotSizeError).toBe(true);
-	}, 30_000);
-
-	it("click resolves a ref and dispatches a mouse event", async () => {
-		const found = (await tool("find", { selector: "tab:text('Add HTTP Load Balancer')" }, 30_000)) as {
-			refs?: Array<{ ref: string }>;
-		};
-		expect(found.refs?.length).toBeGreaterThan(0);
-		const ref = found.refs![0].ref;
-		const click = (await tool("click", { ref }, 15_000)) as { clicked: string; x: number; y: number };
-		expect(click.clicked).toBe(ref);
-		expect(typeof click.x).toBe("number");
-	}, 45_000);
-
-	it("navigate dedup — skips when tab URL already matches target", async () => {
-		// First navigate to a URL, then navigate to the same URL — should be instant (dedup).
-		const start = Date.now();
-		await tool("navigate", { url: CONSOLE_URL }, 30_000);
-		const elapsed = Date.now() - start;
-		// A dedup should return in <2s (no waitForNavigation / waitForSettle).
-		expect(elapsed).toBeLessThan(5000);
-	}, 45_000);
-
-	it("resize_window works", async () => {
-		const r = await tool("resize_window", { width: 1280, height: 900 }, 10_000);
-		expect(r).toMatchObject({ resized: { width: 1280, height: 900 } });
-	}, 15_000);
-
-	it("detach cleans up the debugger", async () => {
-		const d = await tool("detach", {}, 10_000);
-		expect(d).toMatchObject({ detached: true });
-	}, 15_000);
-});
-
-describe("Service Worker termination + recovery (eyeo pattern)", () => {
-	it("SW survives termination: stop → reconnect → ping", async () => {
-		// Stop the SW (Google's official pattern).
-		if (worker) await worker.close();
-
-		// Wait for reconnect (the SW's 30s alarm restarts it + reconnects native port).
-		const deadline = Date.now() + 45_000;
-		while (Date.now() < deadline) {
-			if (server.connected) break;
-			await sleep(1000);
-		}
-		expect(server.connected).toBe(true);
-
-		// Ping after recovery.
-		const pong = await tool("ping", {}, 10_000);
-		expect(pong).toMatchObject({ ok: true });
-
-		// Re-acquire the worker reference for subsequent tests.
+		// 3. Wait for the extension's service worker to start.
 		const swTarget = await browser.waitForTarget(
 			t => t.type() === "service_worker" && t.url().includes("service-worker"),
-			{ timeout: 15_000 },
+			{ timeout: 20_000 },
 		);
 		worker = await swTarget.worker();
-	}, 90_000);
-});
+
+		// 4. Wait for the bridge connection (SW → native host → xcsh socket).
+		const deadline = Date.now() + 30_000;
+		while (Date.now() < deadline && !server.connected) {
+			await sleep(500);
+		}
+	}, 60_000);
+
+	afterAll(async () => {
+		await browser?.close().catch(() => {});
+		await server?.close().catch(() => {});
+	}, 15_000);
+
+	// --- Helper ---
+
+	async function tool(name: string, params: Record<string, unknown> = {}, timeout = 30_000) {
+		const r = await server.request(name, params, timeout);
+		if (r.is_error) throw new Error(`${name}: ${JSON.stringify(r.content)}`);
+		return r.content as Record<string, unknown>;
+	}
+
+	// --- Level 3: E2E Tests ---
+
+	describe("Extension E2E (Puppeteer + real Chrome)", () => {
+		it("extension loads and service worker starts", () => {
+			expect(worker).not.toBeNull();
+		}, 30_000);
+
+		it("bridge connects via native messaging", () => {
+			expect(server.connected).toBe(true);
+		}, 30_000);
+
+		it("ping round-trip through the full pipeline", async () => {
+			const pong = await tool("ping");
+			expect(pong).toMatchObject({ ok: true, version: "0.1.0" });
+		}, 30_000);
+
+		it("navigate opens a console tab", async () => {
+			const nav = await tool("navigate", { url: CONSOLE_URL }, 45_000);
+			expect(nav).toHaveProperty("tabId");
+		}, 60_000);
+
+		it("read_ax returns a non-trivial AX tree from the console", async () => {
+			const tree = (await tool("read_ax", {}, 30_000)) as { role?: string; children?: unknown[] };
+			expect(tree).toHaveProperty("role");
+			// Count nodes
+			const flat: string[] = [];
+			(function walk(n: any) {
+				if (!n) return;
+				flat.push(`${n.role}:${n.name?.slice(0, 30)}`);
+				(n.children || []).forEach(walk);
+			})(tree);
+			expect(flat.length).toBeGreaterThan(10);
+		}, 45_000);
+
+		it("read_ax response fits under the 1MB native-messaging limit", async () => {
+			const tree = await tool("read_ax", {}, 30_000);
+			const size = JSON.stringify(tree).length;
+			expect(size).toBeLessThan(900_000);
+		}, 45_000);
+
+		it("find resolves a text selector on the console", async () => {
+			const found = (await tool("find", { selector: "text('HTTP Load Balancers')" }, 30_000)) as {
+				refs?: Array<{ ref: string }>;
+			};
+			expect(found.refs?.length).toBeGreaterThan(0);
+		}, 45_000);
+
+		it("get_page_text returns content", async () => {
+			const pt = (await tool("get_page_text", {}, 15_000)) as { text?: string };
+			expect((pt.text ?? "").length).toBeGreaterThan(50);
+		}, 30_000);
+
+		it("javascript_tool returns the page title", async () => {
+			const j = (await tool("javascript_tool", { code: "document.title" }, 15_000)) as { result?: string };
+			expect(j.result).toContain("Load Balancers");
+		}, 30_000);
+
+		it("tabs_list shows the console tab", async () => {
+			const t = (await tool("tabs_list", {}, 10_000)) as { tabs?: unknown[] };
+			expect((t.tabs ?? []).length).toBeGreaterThan(0);
+		}, 30_000);
+
+		it("screenshot returns data or a clear size error (never a silent timeout)", async () => {
+			let gotData = false;
+			let gotSizeError = false;
+			try {
+				const s = (await tool("screenshot", {}, 15_000)) as { data?: string };
+				if (s.data && s.data.length > 0) gotData = true;
+			} catch (e: unknown) {
+				const msg = (e as Error).message;
+				if (/too large|size|900/i.test(msg)) gotSizeError = true;
+				else throw e; // unexpected error — re-throw
+			}
+			expect(gotData || gotSizeError).toBe(true);
+		}, 30_000);
+
+		it("click resolves a ref and dispatches a mouse event", async () => {
+			const found = (await tool("find", { selector: "tab:text('Add HTTP Load Balancer')" }, 30_000)) as {
+				refs?: Array<{ ref: string }>;
+			};
+			expect(found.refs?.length).toBeGreaterThan(0);
+			const ref = found.refs![0].ref;
+			const click = (await tool("click", { ref }, 15_000)) as { clicked: string; x: number; y: number };
+			expect(click.clicked).toBe(ref);
+			expect(typeof click.x).toBe("number");
+		}, 45_000);
+
+		it("navigate dedup — skips when tab URL already matches target", async () => {
+			// First navigate to a URL, then navigate to the same URL — should be instant (dedup).
+			const start = Date.now();
+			await tool("navigate", { url: CONSOLE_URL }, 30_000);
+			const elapsed = Date.now() - start;
+			// A dedup should return in <2s (no waitForNavigation / waitForSettle).
+			expect(elapsed).toBeLessThan(5000);
+		}, 45_000);
+
+		it("resize_window works", async () => {
+			const r = await tool("resize_window", { width: 1280, height: 900 }, 10_000);
+			expect(r).toMatchObject({ resized: { width: 1280, height: 900 } });
+		}, 15_000);
+
+		it("detach cleans up the debugger", async () => {
+			const d = await tool("detach", {}, 10_000);
+			expect(d).toMatchObject({ detached: true });
+		}, 15_000);
+	});
+
+	describe("Service Worker termination + recovery (eyeo pattern)", () => {
+		it("SW survives termination: stop → reconnect → ping", async () => {
+			// Stop the SW (Google's official pattern).
+			if (worker) await worker.close();
+
+			// Wait for reconnect (the SW's 30s alarm restarts it + reconnects native port).
+			const deadline = Date.now() + 45_000;
+			while (Date.now() < deadline) {
+				if (server.connected) break;
+				await sleep(1000);
+			}
+			expect(server.connected).toBe(true);
+
+			// Ping after recovery.
+			const pong = await tool("ping", {}, 10_000);
+			expect(pong).toMatchObject({ ok: true });
+
+			// Re-acquire the worker reference for subsequent tests.
+			const swTarget = await browser.waitForTarget(
+				t => t.type() === "service_worker" && t.url().includes("service-worker"),
+				{ timeout: 15_000 },
+			);
+			worker = await swTarget.worker();
+		}, 90_000);
+	});
+}); // describe.skipIf(isCI) — Extension E2E

--- a/packages/coding-agent/test/helpers/env.ts
+++ b/packages/coding-agent/test/helpers/env.ts
@@ -1,0 +1,18 @@
+/**
+ * Restore `process.env` to a captured snapshot IN PLACE.
+ *
+ * Do NOT do `process.env = { ...snapshot }`. In Bun, `process.env` and `Bun.env`
+ * are the same object, and `$env` (packages/utils) captures `Bun.env` at module
+ * load. Reassigning `process.env` replaces it with a fresh object, permanently
+ * disconnecting it from `Bun.env`/`$env`. After that, later writes such as
+ * `process.env.EXA_API_KEY = "..."` are invisible to `getEnvApiKey()` and every
+ * other `$env` reader — silently breaking unrelated test files that share the
+ * one `bun test` process. That defect turned the whole web-search suite red in CI
+ * (see issue #1903). Mutating in place preserves the object identity.
+ */
+export function restoreEnv(snapshot: Record<string, string | undefined>): void {
+	for (const key of Object.keys(process.env)) {
+		if (!(key in snapshot)) delete process.env[key];
+	}
+	Object.assign(process.env, snapshot);
+}

--- a/packages/coding-agent/test/interactive-mode-lsp-startup.test.ts
+++ b/packages/coding-agent/test/interactive-mode-lsp-startup.test.ts
@@ -39,6 +39,12 @@ describe("InteractiveMode welcome banner status checks", () => {
 		tempDir = TempDir.createSync("@pi-interactive-mode-welcome-");
 		await Settings.init({ inMemory: true, cwd: tempDir.path() });
 		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		// Register an in-memory provider credential so hasActiveLlmProvider() is true
+		// regardless of ambient env. Otherwise the banner renders the "no LLM provider
+		// — run /login" gate (which contains "Model Provider"), failing this test on any
+		// runner without an ANTHROPIC_API_KEY (e.g. CI). No network — init only does the
+		// instant local credential check. (#1903)
+		authStorage.setRuntimeApiKey("anthropic", "sk-ant-test-key");
 		const modelRegistry = new ModelRegistry(authStorage);
 		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");

--- a/packages/coding-agent/test/mermaid-renderer.test.ts
+++ b/packages/coding-agent/test/mermaid-renderer.test.ts
@@ -28,7 +28,10 @@ describe("mermaidRenderer.renderResult", () => {
 		// The single brand accent (arrowheads / frame) is present…
 		expect(raw).toContain(theme.getFgAnsi("accent"));
 		// …and the diagram is colorized but NOT a rainbow — only a few distinct fg colors.
-		const fgColors = new Set(raw.match(/\x1b\[38;2;[0-9;]+m/g) ?? []);
+		// Match both truecolor (\x1b[38;2;R;G;Bm) and 256-color (\x1b[38;5;Nm) fg codes:
+		// the theme's color depth follows the terminal (COLORTERM/TERM), so CI/non-truecolor
+		// runners emit 256-color codes. The "restrained palette" property is depth-agnostic.
+		const fgColors = new Set(raw.match(/\x1b\[38;(?:2;[0-9;]+|5;[0-9]+)m/g) ?? []);
 		expect(fgColors.size).toBeGreaterThanOrEqual(2);
 		expect(fgColors.size).toBeLessThanOrEqual(5);
 	});

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -84,6 +84,10 @@ describe("status line path segment", () => {
 			expect(rendered.content).not.toContain("home-link");
 			expect(rendered.content).not.toContain(`${path.sep}Projects${path.sep}`);
 		} finally {
+			// Restore CWD BEFORE deleting the dirs we chdir'd into. Under
+			// --max-concurrency the shared bun-test process must never be left in a
+			// deleted CWD, or a concurrent test's cwd/repo-root discovery fails. (#1903)
+			setProjectDir(originalProjectDir);
 			fs.rmSync(aliasRoot, { recursive: true, force: true });
 			fs.rmSync(realProjectDir, { recursive: true, force: true });
 		}
@@ -108,6 +112,8 @@ describe("status line path segment", () => {
 			expect(rendered.content).toContain(path.basename(livePath));
 			expect(rendered.content).not.toContain(path.basename(stalePath));
 		} finally {
+			// Restore CWD before deleting the chdir'd dirs (see note above). (#1903)
+			setProjectDir(originalProjectDir);
 			fs.rmSync(stalePath, { recursive: true, force: true });
 			fs.rmSync(livePath, { recursive: true, force: true });
 		}

--- a/packages/coding-agent/test/xcsh-context-command-local.test.ts
+++ b/packages/coding-agent/test/xcsh-context-command-local.test.ts
@@ -10,6 +10,11 @@ registerLocales(locales);
 import { setProjectDir } from "@f5-sales-demo/pi-utils";
 import { ContextService } from "../src/services/xcsh-context";
 import { handleContextCommand } from "../src/services/xcsh-context-command";
+import { restoreEnv } from "./helpers/env";
+
+// setProjectDir() below does a process-global chdir(); capture the real CWD once,
+// before any test runs, so afterEach can restore it before deleting tmpDir. (#1903)
+const ORIGINAL_CWD = process.cwd();
 
 describe("/context list with local contexts", () => {
 	let tmpDir: string;
@@ -49,7 +54,11 @@ describe("/context list with local contexts", () => {
 
 	afterEach(() => {
 		ContextService._resetForTest();
-		process.env = { ...originalEnv };
+		restoreEnv(originalEnv);
+		// Restore CWD before deleting tmpDir: setProjectDir() chdir'd the shared
+		// `bun test` process into it; leaving the process in a since-deleted dir
+		// breaks every later shell init + subprocess spawn run concurrently. (#1903)
+		setProjectDir(ORIGINAL_CWD);
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 	});
 
@@ -113,7 +122,11 @@ describe("/context link", () => {
 
 	afterEach(() => {
 		ContextService._resetForTest();
-		process.env = { ...originalEnv };
+		restoreEnv(originalEnv);
+		// Restore CWD before deleting tmpDir: setProjectDir() chdir'd the shared
+		// `bun test` process into it; leaving the process in a since-deleted dir
+		// breaks every later shell init + subprocess spawn run concurrently. (#1903)
+		setProjectDir(ORIGINAL_CWD);
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 	});
 
@@ -202,7 +215,11 @@ describe("/context unlink", () => {
 
 	afterEach(() => {
 		ContextService._resetForTest();
-		process.env = { ...originalEnv };
+		restoreEnv(originalEnv);
+		// Restore CWD before deleting tmpDir: setProjectDir() chdir'd the shared
+		// `bun test` process into it; leaving the process in a since-deleted dir
+		// breaks every later shell init + subprocess spawn run concurrently. (#1903)
+		setProjectDir(ORIGINAL_CWD);
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 	});
 

--- a/packages/coding-agent/test/xcsh-context-resolver-integration.test.ts
+++ b/packages/coding-agent/test/xcsh-context-resolver-integration.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { _resetSettingsForTest, Settings } from "@f5-sales-demo/xcsh/config/settings";
 import { ContextService } from "@f5-sales-demo/xcsh/services/xcsh-context";
+import { restoreEnv } from "./helpers/env";
 
 describe("ContextService with local contexts", () => {
 	let tmpDir: string;
@@ -36,7 +37,7 @@ describe("ContextService with local contexts", () => {
 	afterEach(() => {
 		_resetSettingsForTest();
 		ContextService._resetForTest();
-		process.env = { ...originalEnv };
+		restoreEnv(originalEnv);
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 	});
 

--- a/packages/coding-agent/test/xcsh-integration.test.ts
+++ b/packages/coding-agent/test/xcsh-integration.test.ts
@@ -356,11 +356,22 @@ describe("XCSH authentication end-to-end integration", () => {
 		const service = ContextService.init(xcshConfigDir);
 		await service.loadActive();
 
-		const result = await executeBash('echo "$XCSH_API_URL"', {
+		// apiUrl is intentionally reduced to its origin on read (normalizeApiUrl),
+		// so XCSH_API_URL never carries the path/query — a pasted URL with a query
+		// string is healed, not propagated. The special characters that must
+		// survive the env → bash handoff live in the namespace (spaces) and token
+		// (`=`, `&`), which are NOT normalized.
+		const nsResult = await executeBash('echo "$XCSH_NAMESPACE"', {
 			cwd: projectDir,
 			timeout: 5000,
 		});
-		expect(result.output.trim()).toBe(specialUrl);
+		expect(nsResult.output.trim()).toBe("ns with spaces");
+
+		const urlResult = await executeBash('echo "$XCSH_API_URL"', {
+			cwd: projectDir,
+			timeout: 5000,
+		});
+		expect(urlResult.output.trim()).toBe(new URL(specialUrl).origin);
 	});
 
 	it("env map vars are available in bash subprocess", async () => {


### PR DESCRIPTION
Closes #1903 (work-in-progress; opened as draft to surface the true CI failure set).

## What
Root-cause + full honest-CI cleanup for the finding in #1903: a `process.exit(0)` in `test/e2e/extension-e2e.test.ts` masked the entire xcsh suite's failures in CI, making the required `test` job a no-op gate.

## Progress
- [x] Remove the `process.exit(0)` footgun; skip the e2e suite via `describe.skipIf(isCI)` + dynamic puppeteer import (verified: `18 skip / 0 fail`, exit 0 under CI=1).
- [ ] Triage the now-unmasked CI failures: `skipIf(CI)` for genuinely environment-unavailable tests (Chrome/display, litellm server, paid API keys, real network/ports), **fix** anything that is a real bug.
- [ ] Add a recurrence guard: fail the job if the xcsh test run does not print its `Ran N tests` summary.
- [ ] Verify CI runs to completion & is green; a deliberately broken assertion turns it red.

This first push intentionally contains only the footgun fix so CI reveals the authoritative unmasked failure inventory for the ubuntu runner.