### PR TITLE
TTFT Phase 4 · A1: attribute provider_ttft (bench-local instrumentation)

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -336,11 +336,17 @@ async function streamAssistantResponse(
 			signal,
 		}),
 	);
+	const tAfterStream = performance.now();
 
 	let partialMessage: AssistantMessage | null = null;
 	let addedPartial = false;
+	let firstDeltaMarked = false;
 
 	for await (const event of response) {
+		if (!firstDeltaMarked && event.type === "text_delta") {
+			firstDeltaMarked = true;
+			logger.ttftMark("ttft.first-token-wait", performance.now() - tAfterStream);
+		}
 		// Check for abort signal before processing each event
 		if (signal?.aborted) {
 			const errorMessage = "Request was aborted";

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -10,6 +10,7 @@ import {
 	type ToolResultMessage,
 	validateToolArguments,
 } from "@f5-sales-demo/pi-ai";
+import { logger } from "@f5-sales-demo/pi-utils";
 import type {
 	AgentContext,
 	AgentEvent,
@@ -218,7 +219,7 @@ async function runLoop(
 
 			// Refresh prompt/tool context from live state before each model call
 			if (config.syncContextBeforeModelCall) {
-				await config.syncContextBeforeModelCall(currentContext);
+				await logger.ttftAttr("ttft.sync-context", () => config.syncContextBeforeModelCall!(currentContext));
 			}
 
 			// Stream assistant response
@@ -306,18 +307,18 @@ async function streamAssistantResponse(
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
 	if (config.transformContext) {
-		messages = await config.transformContext(messages, signal);
+		messages = await logger.ttftAttr("ttft.transform-context", () => config.transformContext!(messages, signal));
 	}
 
 	// Convert to LLM-compatible messages (AgentMessage[] → Message[])
-	const llmMessages = await config.convertToLlm(messages);
+	const llmMessages = await logger.ttftAttr("ttft.convert-to-llm", () => config.convertToLlm(messages));
 	const normalizedMessages = normalizeMessagesForProvider(llmMessages, config.model);
 
 	// Build LLM context
 	const llmContext: Context = {
 		systemPrompt: context.systemPrompt,
 		messages: normalizedMessages,
-		tools: normalizeTools(context.tools, !!config.intentTracing),
+		tools: logger.ttftAttr("ttft.normalize-tools", () => normalizeTools(context.tools, !!config.intentTracing)),
 	};
 
 	const streamFunction = streamFn || streamSimple;
@@ -327,12 +328,14 @@ async function streamAssistantResponse(
 		(config.getApiKey ? await config.getApiKey(config.model.provider) : undefined) || config.apiKey;
 
 	const dynamicToolChoice = config.getToolChoice?.();
-	const response = await streamFunction(config.model, llmContext, {
-		...config,
-		apiKey: resolvedApiKey,
-		toolChoice: dynamicToolChoice ?? config.toolChoice,
-		signal,
-	});
+	const response = await logger.ttftAttr("ttft.stream-fn", () =>
+		streamFunction(config.model, llmContext, {
+			...config,
+			apiKey: resolvedApiKey,
+			toolChoice: dynamicToolChoice ?? config.toolChoice,
+			signal,
+		}),
+	);
 
 	let partialMessage: AssistantMessage | null = null;
 	let addedPartial = false;

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -20,6 +20,7 @@ import {
 	type ToolChoice,
 	type ToolResultMessage,
 } from "@f5-sales-demo/pi-ai";
+import { logger } from "@f5-sales-demo/pi-utils";
 import { agentLoop, agentLoopContinue } from "./agent-loop";
 import type {
 	AgentContext,
@@ -711,81 +712,85 @@ export class Agent {
 
 		const reasoning = this.#state.thinkingLevel;
 
-		const context: AgentContext = {
-			systemPrompt: this.#state.systemPrompt,
-			messages: this.#state.messages.slice(),
-			tools: this.#state.tools,
-		};
+		const { context, config } = logger.ttftAttr("ttft.runloop-setup", () => {
+			const context: AgentContext = {
+				systemPrompt: this.#state.systemPrompt,
+				messages: this.#state.messages.slice(),
+				tools: this.#state.tools,
+			};
 
-		const cursorOnToolResult =
-			this.#cursorExecHandlers || this.#cursorOnToolResult
-				? async (message: ToolResultMessage) => {
-						let finalMessage = message;
-						if (this.#cursorOnToolResult) {
-							try {
-								const updated = await this.#cursorOnToolResult(message);
-								if (updated) {
-									finalMessage = updated;
-								}
-							} catch {}
+			const cursorOnToolResult =
+				this.#cursorExecHandlers || this.#cursorOnToolResult
+					? async (message: ToolResultMessage) => {
+							let finalMessage = message;
+							if (this.#cursorOnToolResult) {
+								try {
+									const updated = await this.#cursorOnToolResult(message);
+									if (updated) {
+										finalMessage = updated;
+									}
+								} catch {}
+							}
+							// Buffer tool result with current text length for correct ordering later.
+							// Cursor executes tools server-side during streaming, so the assistant message
+							// already incorporates results. We buffer here and emit in correct order
+							// when the assistant message ends.
+							const textLength = this.#getAssistantTextLength(this.#state.streamMessage);
+							this.#cursorToolResultBuffer.push({ toolResult: finalMessage, textLengthAtCall: textLength });
+							return finalMessage;
 						}
-						// Buffer tool result with current text length for correct ordering later.
-						// Cursor executes tools server-side during streaming, so the assistant message
-						// already incorporates results. We buffer here and emit in correct order
-						// when the assistant message ends.
-						const textLength = this.#getAssistantTextLength(this.#state.streamMessage);
-						this.#cursorToolResultBuffer.push({ toolResult: finalMessage, textLengthAtCall: textLength });
-						return finalMessage;
+					: undefined;
+
+			const getToolChoice = () =>
+				this.#getToolChoice?.() ?? refreshToolChoiceForActiveTools(options?.toolChoice, this.#state.tools);
+
+			const config: AgentLoopConfig = {
+				model,
+				reasoning,
+				temperature: this.#temperature,
+				topP: this.#topP,
+				topK: this.#topK,
+				minP: this.#minP,
+				presencePenalty: this.#presencePenalty,
+				repetitionPenalty: this.#repetitionPenalty,
+				serviceTier: this.#serviceTier,
+				interruptMode: this.#interruptMode,
+				sessionId: this.#sessionId,
+				providerSessionState: this.#providerSessionState,
+				thinkingBudgets: this.#thinkingBudgets,
+				maxRetryDelayMs: this.#maxRetryDelayMs,
+				kimiApiFormat: this.#kimiApiFormat,
+				preferWebsockets: this.#preferWebsockets,
+				convertToLlm: this.#convertToLlm,
+				transformContext: this.#transformContext,
+				onPayload: this.#onPayload,
+				getApiKey: this.getApiKey,
+				getToolContext: this.#getToolContext,
+				syncContextBeforeModelCall: async context => {
+					if (this.#listeners.size > 0) {
+						await Bun.sleep(0);
 					}
-				: undefined;
+					context.systemPrompt = this.#state.systemPrompt;
+					context.tools = this.#state.tools;
+				},
+				cursorExecHandlers: this.#cursorExecHandlers,
+				cursorOnToolResult,
+				transformToolCallArguments: this.#transformToolCallArguments,
+				intentTracing: this.#intentTracing,
+				onAssistantMessageEvent: this.#onAssistantMessageEvent,
+				getToolChoice,
+				getSteeringMessages: async () => {
+					if (skipInitialSteeringPoll) {
+						skipInitialSteeringPoll = false;
+						return [];
+					}
+					return this.#dequeueSteeringMessages();
+				},
+				getFollowUpMessages: async () => this.#dequeueFollowUpMessages(),
+			};
 
-		const getToolChoice = () =>
-			this.#getToolChoice?.() ?? refreshToolChoiceForActiveTools(options?.toolChoice, this.#state.tools);
-
-		const config: AgentLoopConfig = {
-			model,
-			reasoning,
-			temperature: this.#temperature,
-			topP: this.#topP,
-			topK: this.#topK,
-			minP: this.#minP,
-			presencePenalty: this.#presencePenalty,
-			repetitionPenalty: this.#repetitionPenalty,
-			serviceTier: this.#serviceTier,
-			interruptMode: this.#interruptMode,
-			sessionId: this.#sessionId,
-			providerSessionState: this.#providerSessionState,
-			thinkingBudgets: this.#thinkingBudgets,
-			maxRetryDelayMs: this.#maxRetryDelayMs,
-			kimiApiFormat: this.#kimiApiFormat,
-			preferWebsockets: this.#preferWebsockets,
-			convertToLlm: this.#convertToLlm,
-			transformContext: this.#transformContext,
-			onPayload: this.#onPayload,
-			getApiKey: this.getApiKey,
-			getToolContext: this.#getToolContext,
-			syncContextBeforeModelCall: async context => {
-				if (this.#listeners.size > 0) {
-					await Bun.sleep(0);
-				}
-				context.systemPrompt = this.#state.systemPrompt;
-				context.tools = this.#state.tools;
-			},
-			cursorExecHandlers: this.#cursorExecHandlers,
-			cursorOnToolResult,
-			transformToolCallArguments: this.#transformToolCallArguments,
-			intentTracing: this.#intentTracing,
-			onAssistantMessageEvent: this.#onAssistantMessageEvent,
-			getToolChoice,
-			getSteeringMessages: async () => {
-				if (skipInitialSteeringPoll) {
-					skipInitialSteeringPoll = false;
-					return [];
-				}
-				return this.#dequeueSteeringMessages();
-			},
-			getFollowUpMessages: async () => this.#dequeueFollowUpMessages(),
-		};
+			return { context, config };
+		});
 
 		let partial: AgentMessage | null = null;
 

--- a/packages/coding-agent/bench/ttft-attr.test.ts
+++ b/packages/coding-agent/bench/ttft-attr.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { medianByStage, parseAttrLines } from "./ttft-attr";
+
+describe("parseAttrLines", () => {
+  it("keeps the FIRST occurrence of each stage and ignores duplicates + noise", () => {
+    const out = parseAttrLines([
+      "unrelated log",
+      "[ttft-attr] ttft.normalize-tools 12.5",
+      "[ttft-attr] ttft.stream-fn 3",
+      "[ttft-attr] ttft.normalize-tools 99",   // later dup — ignored
+      "garbage [ttft-attr] malformed",
+    ]);
+    expect(out).toEqual({ "ttft.normalize-tools": 12.5, "ttft.stream-fn": 3 });
+  });
+
+  it("returns {} for no matches", () => {
+    expect(parseAttrLines(["nothing here"])).toEqual({});
+  });
+});
+
+describe("medianByStage", () => {
+  it("medians per stage across runs (odd + even)", () => {
+    const out = medianByStage([
+      { a: 10, b: 4 },
+      { a: 20, b: 8 },
+      { a: 30 },              // b missing this run
+    ]);
+    expect(out.a).toBe(20);   // median(10,20,30)
+    expect(out.b).toBe(6);    // median(4,8)
+  });
+
+  it("returns {} for empty input", () => {
+    expect(medianByStage([])).toEqual({});
+  });
+});

--- a/packages/coding-agent/bench/ttft-attr.ts
+++ b/packages/coding-agent/bench/ttft-attr.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure parsing/aggregation for TTFT A1 attribution. The worker emits
+ * `[ttft-attr] <stage> <ms>` on stderr (see pi-utils ttftAttr); the bench captures
+ * those lines and reduces them here. Chrome-free + I/O-free, so unit-tests in isolation.
+ */
+const LINE = /^\[ttft-attr\] (\S+) (\d+(?:\.\d+)?)$/;
+
+/** First occurrence of each stage wins (later model-call iterations are post-first-token). */
+export function parseAttrLines(lines: string[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const line of lines) {
+    const m = LINE.exec(line.trim());
+    if (!m) continue;
+    const stage = m[1];
+    if (stage in out) continue;
+    out[stage] = Number(m[2]);
+  }
+  return out;
+}
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+export function medianByStage(perRun: Record<string, number>[]): Record<string, number> {
+  const stages = new Set<string>();
+  for (const r of perRun) for (const k of Object.keys(r)) stages.add(k);
+  const out: Record<string, number> = {};
+  for (const stage of stages) {
+    const vals = perRun.map(r => r[stage]).filter((v): v is number => typeof v === "number");
+    if (vals.length) out[stage] = median(vals);
+  }
+  return out;
+}

--- a/packages/coding-agent/bench/ttft.ts
+++ b/packages/coding-agent/bench/ttft.ts
@@ -31,9 +31,10 @@ interface RunSample {
   stages: StageBreakdown;
 }
 
-function spawnManager(poolSize: string): { sock: string; getErr: () => string; kill: () => void } {
+function spawnManager(poolSize: string): { sock: string; attrFile: string; getErr: () => string; kill: () => void } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-ttft-"));
   const sock = path.join(dir, "manager.sock");
+  const attrFile = path.join(dir, "attr.log");
   const proc = Bun.spawn(["bun", CLI, "manager"], {
     cwd: path.join(import.meta.dir, ".."),
     env: {
@@ -42,8 +43,11 @@ function spawnManager(poolSize: string): { sock: string; getErr: () => string; k
       XCSH_WORKER_POOL_SIZE: poolSize,
       XCSH_BENCH_EXTENSION: EXT,
       // TTFT A1: gate the manager (and, via ...process.env spread at the worker spawn, the
-      // worker) to inherit worker stderr so its `[ttft-attr]` lines flow into getErr(). Timing-only.
+      // worker) to emit `[ttft-attr]` lines, and route them to a per-run FILE. Routing them
+      // into the manager-stderr pipe (stderr:"inherit") hung the chat turn, so the worker
+      // appends to XCSH_TTFT_ATTR_FILE instead — read back in runOnce. Timing-only.
       XCSH_TTFT_ATTRIBUTION: "1",
+      XCSH_TTFT_ATTR_FILE: attrFile,
     },
     stdout: "ignore",
     stderr: "pipe",
@@ -62,7 +66,7 @@ function spawnManager(poolSize: string): { sock: string; getErr: () => string; k
       /* torn down on kill */
     }
   })();
-  return { sock, getErr: () => err, kill: () => { try { proc.kill(); } catch {} } };
+  return { sock, attrFile, getErr: () => err, kill: () => { try { proc.kill(); } catch {} } };
 }
 
 async function sendProvision(sock: string): Promise<void> {
@@ -172,11 +176,14 @@ async function runOnce(poolSize: string, portRe: RegExp): Promise<{ sample: RunS
     await sendProvision(mgr.sock);
     const port = await waitForPort(mgr.getErr, portRe, CONNECT_DEADLINE_MS);
     const sample = await connectAndMeasure(port, t0, TURN_DEADLINE_MS);
-    // TTFT A1: let the worker's `[ttft-attr]` stderr flush into getErr() before we parse.
-    // Fresh manager per run ⇒ getErr() is per-run isolated; parseAttrLines keeps the first
-    // occurrence per stage, so the 400ms chat_request resends don't corrupt it.
-    await sleep(150);
-    const attr = parseAttrLines(mgr.getErr().split("\n"));
+    // TTFT A1: let the worker finish the turn and flush its `[ttft-attr]` file appends
+    // before we read. Fresh manager+dir per run ⇒ the attr file is per-run isolated;
+    // parseAttrLines keeps the first occurrence per stage, so the 400ms chat_request
+    // resends don't corrupt it. (Routing via manager-stderr pipe hung the turn — file only.)
+    await sleep(300);
+    const attr = fs.existsSync(mgr.attrFile)
+      ? parseAttrLines(fs.readFileSync(mgr.attrFile, "utf8").split("\n"))
+      : {};
     return { sample, attr };
   } finally {
     mgr.kill();

--- a/packages/coding-agent/bench/ttft.ts
+++ b/packages/coding-agent/bench/ttft.ts
@@ -15,6 +15,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { EXTENSION_ID } from "../src/cli/chrome-cli";
+import { medianByStage, parseAttrLines } from "./ttft-attr";
 import { type BenchResult, compareToBaseline, median, type ModeResult, type StageBreakdown } from "./ttft-report";
 
 const CLI = path.join(import.meta.dir, "../src/cli.ts");
@@ -35,7 +36,15 @@ function spawnManager(poolSize: string): { sock: string; getErr: () => string; k
   const sock = path.join(dir, "manager.sock");
   const proc = Bun.spawn(["bun", CLI, "manager"], {
     cwd: path.join(import.meta.dir, ".."),
-    env: { ...process.env, XCSH_MANAGER_SOCK: sock, XCSH_WORKER_POOL_SIZE: poolSize, XCSH_BENCH_EXTENSION: EXT },
+    env: {
+      ...process.env,
+      XCSH_MANAGER_SOCK: sock,
+      XCSH_WORKER_POOL_SIZE: poolSize,
+      XCSH_BENCH_EXTENSION: EXT,
+      // TTFT A1: gate the manager (and, via ...process.env spread at the worker spawn, the
+      // worker) to inherit worker stderr so its `[ttft-attr]` lines flow into getErr(). Timing-only.
+      XCSH_TTFT_ATTRIBUTION: "1",
+    },
     stdout: "ignore",
     stderr: "pipe",
   });
@@ -154,7 +163,7 @@ async function connectAndMeasure(port: number, t0: number, deadlineMs: number): 
   throw new Error("worker never accepted a connection before the deadline");
 }
 
-async function runOnce(poolSize: string, portRe: RegExp): Promise<RunSample> {
+async function runOnce(poolSize: string, portRe: RegExp): Promise<{ sample: RunSample; attr: Record<string, number> }> {
   const mgr = spawnManager(poolSize);
   try {
     await waitForSocket(mgr.sock, 10_000); // manager must bind its control socket before we provision
@@ -162,29 +171,47 @@ async function runOnce(poolSize: string, portRe: RegExp): Promise<RunSample> {
     const t0 = Bun.nanoseconds();
     await sendProvision(mgr.sock);
     const port = await waitForPort(mgr.getErr, portRe, CONNECT_DEADLINE_MS);
-    return await connectAndMeasure(port, t0, TURN_DEADLINE_MS);
+    const sample = await connectAndMeasure(port, t0, TURN_DEADLINE_MS);
+    // TTFT A1: let the worker's `[ttft-attr]` stderr flush into getErr() before we parse.
+    // Fresh manager per run ⇒ getErr() is per-run isolated; parseAttrLines keeps the first
+    // occurrence per stage, so the 400ms chat_request resends don't corrupt it.
+    await sleep(150);
+    const attr = parseAttrLines(mgr.getErr().split("\n"));
+    return { sample, attr };
   } finally {
     mgr.kill();
     await sleep(200);
   }
 }
 
-async function runMode(poolSize: string, portRe: RegExp, runs: number): Promise<ModeResult> {
+interface ModeRun {
+  mode: ModeResult;
+  attribution: Record<string, number>; // TTFT A1: median per-stage `[ttft-attr]`, NOT in the baseline
+}
+
+async function runMode(poolSize: string, portRe: RegExp, runs: number): Promise<ModeRun> {
   const samples: RunSample[] = [];
+  const attrRecords: Record<string, number>[] = [];
   for (let i = 0; i < runs + 1; i++) {
-    const s = await runOnce(poolSize, portRe);
-    if (i > 0) samples.push(s); // discard a warm-up run
+    const { sample, attr } = await runOnce(poolSize, portRe);
+    if (i > 0) {
+      samples.push(sample); // discard a warm-up run
+      attrRecords.push(attr);
+    }
   }
   const pick = (f: (s: RunSample) => number): number => median(samples.map(f));
   return {
-    ttft_ms: pick(s => s.ttft_ms),
-    stages: {
-      manager_provision: pick(s => s.stages.manager_provision),
-      worker_boot: pick(s => s.stages.worker_boot),
-      chat_handler: pick(s => s.stages.chat_handler),
-      provider_ttft: pick(s => s.stages.provider_ttft),
+    mode: {
+      ttft_ms: pick(s => s.ttft_ms),
+      stages: {
+        manager_provision: pick(s => s.stages.manager_provision),
+        worker_boot: pick(s => s.stages.worker_boot),
+        chat_handler: pick(s => s.stages.chat_handler),
+        provider_ttft: pick(s => s.stages.provider_ttft),
+      },
+      runs,
     },
-    runs,
+    attribution: medianByStage(attrRecords),
   };
 }
 
@@ -213,10 +240,37 @@ const runs = numArg("--runs", 5);
 const tolerance = numArg("--tolerance", 30);
 const minAbsMs = numArg("--min-abs-ms", 15);
 
-const result: BenchResult = {
-  cold: await runMode("0", /provisioned tab-bench .* on port (\d+)/, runs),
-  warm: await runMode("1", /adopted spare pid \d+ on port (\d+) as tab-bench/, runs),
-};
+const coldRun = await runMode("0", /provisioned tab-bench .* on port (\d+)/, runs);
+const warmRun = await runMode("1", /adopted spare pid \d+ on port (\d+) as tab-bench/, runs);
+const result: BenchResult = { cold: coldRun.mode, warm: warmRun.mode };
+
+/**
+ * TTFT A1: print a per-mode breakdown of `provider_ttft` from the worker's `[ttft-attr]`
+ * lines. Additive stdout ONLY — never merged into `result`/the baseline, so `--check` /
+ * `--update-baseline` stay byte-for-byte unchanged.
+ *
+ * `(unattributed)` = provider_ttft − sum(every stage EXCEPT the `ttft.agent-loop-total`
+ * roll-up). agent-loop-total wraps the six loop leaves (runloop-setup, sync/transform/
+ * convert-to-llm, normalize-tools, stream-fn); summing it AND them would double-count, so
+ * it is excluded from the additive sum but still shown as a row (report, don't hide).
+ */
+function printAttribution(label: string, providerTtft: number, attr: Record<string, number>): void {
+  console.log(`\n=== ${label} provider_ttft attribution ===`);
+  const sorted = Object.entries(attr).sort((a, b) => b[1] - a[1]);
+  if (sorted.length === 0 || providerTtft <= 0) {
+    console.log(providerTtft <= 0 ? "  no attribution captured (provider_ttft is 0)" : "  no attribution captured");
+    return;
+  }
+  console.log(`provider_ttft: ${providerTtft.toFixed(1)}ms`);
+  const row = (name: string, ms: number): string =>
+    `  ${name.padEnd(30)} ${ms.toFixed(1).padStart(8)}ms  (${((ms / providerTtft) * 100).toFixed(1)}%)`;
+  for (const [stage, ms] of sorted) console.log(row(stage, ms));
+  const accounted = sorted.reduce((s, [stage, ms]) => (stage === "ttft.agent-loop-total" ? s : s + ms), 0);
+  console.log(row("(unattributed)", providerTtft - accounted));
+}
+
+printAttribution("cold", result.cold.stages.provider_ttft, coldRun.attribution);
+printAttribution("warm", result.warm.stages.provider_ttft, warmRun.attribution);
 
 if (flag("--update-baseline")) {
   fs.writeFileSync(BASELINE, `${JSON.stringify(result, null, 2)}\n`);

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -238,10 +238,7 @@ export default class Manager extends Command {
 				},
 				ipc() {}, // enable Bun parent→child IPC; no worker→manager messages needed today
 				stdout: "ignore",
-				// TTFT A1 (timing/diagnostic only): when the attribution flag is set the bench
-				// spawns the manager with stderr piped, so inheriting the worker's stderr routes
-				// its `[ttft-attr]` lines into that pipe. Production leaves it "ignore" (unchanged).
-				stderr: process.env.XCSH_TTFT_ATTRIBUTION === "1" ? "inherit" : "ignore",
+				stderr: "ignore",
 			});
 			const rec: SpareRec = { proc, port, pid: proc.pid };
 			pool.push(rec);
@@ -391,10 +388,7 @@ export default class Manager extends Command {
 					XCSH_TTFT_COLD: "1",
 				},
 				stdout: "ignore",
-				// TTFT A1 (timing/diagnostic only): see the spare-spawn note above — when the
-				// attribution flag is set, inherit the worker's stderr so its `[ttft-attr]` lines
-				// reach the bench's manager-stderr pipe. Production leaves it "ignore" (unchanged).
-				stderr: process.env.XCSH_TTFT_ATTRIBUTION === "1" ? "inherit" : "ignore",
+				stderr: "ignore",
 			});
 			reg.set(msg.sessionId, {
 				sessionId: msg.sessionId,

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -238,7 +238,10 @@ export default class Manager extends Command {
 				},
 				ipc() {}, // enable Bun parent→child IPC; no worker→manager messages needed today
 				stdout: "ignore",
-				stderr: "ignore",
+				// TTFT A1 (timing/diagnostic only): when the attribution flag is set the bench
+				// spawns the manager with stderr piped, so inheriting the worker's stderr routes
+				// its `[ttft-attr]` lines into that pipe. Production leaves it "ignore" (unchanged).
+				stderr: process.env.XCSH_TTFT_ATTRIBUTION === "1" ? "inherit" : "ignore",
 			});
 			const rec: SpareRec = { proc, port, pid: proc.pid };
 			pool.push(rec);
@@ -388,7 +391,10 @@ export default class Manager extends Command {
 					XCSH_TTFT_COLD: "1",
 				},
 				stdout: "ignore",
-				stderr: "ignore",
+				// TTFT A1 (timing/diagnostic only): see the spare-spawn note above — when the
+				// attribution flag is set, inherit the worker's stderr so its `[ttft-attr]` lines
+				// reach the bench's manager-stderr pipe. Production leaves it "ignore" (unchanged).
+				stderr: process.env.XCSH_TTFT_ATTRIBUTION === "1" ? "inherit" : "ignore",
 			});
 			reg.set(msg.sessionId, {
 				sessionId: msg.sessionId,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2658,9 +2658,11 @@ export class AgentSession {
 				);
 			}
 
-			// Validate API key
+			// Validate API key. Capture the guard-narrowed model into a local: TS narrowing
+			// of the `this.model` getter does not persist into the ttftAttr closure below.
+			const model = this.model;
 			const apiKey = await logger.ttftAttr("ttft.getapikey", () =>
-				this.#modelRegistry.getApiKey(this.model, this.sessionId),
+				this.#modelRegistry.getApiKey(model, this.sessionId),
 			);
 			if (!apiKey) {
 				throw new Error(
@@ -2716,10 +2718,12 @@ export class AgentSession {
 				messages.push(...fileMentionMessages);
 			}
 
-			// Emit before_agent_start extension event
+			// Emit before_agent_start extension event. Capture the narrowed runner into a
+			// local: the `this.#extensionRunner` guard does not narrow inside the closure.
 			if (this.#extensionRunner) {
+				const runner = this.#extensionRunner;
 				const result = await logger.ttftAttr("ttft.before-agent-start-hook", () =>
-					this.#extensionRunner.emitBeforeAgentStart(expandedText, options?.images, this.#baseSystemPrompt),
+					runner.emitBeforeAgentStart(expandedText, options?.images, this.#baseSystemPrompt),
 				);
 				if (result?.messages) {
 					const promptAttribution: "user" | "agent" | undefined =

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2659,7 +2659,9 @@ export class AgentSession {
 			}
 
 			// Validate API key
-			const apiKey = await this.#modelRegistry.getApiKey(this.model, this.sessionId);
+			const apiKey = await logger.ttftAttr("ttft.getapikey", () =>
+				this.#modelRegistry.getApiKey(this.model, this.sessionId),
+			);
 			if (!apiKey) {
 				throw new Error(
 					`No API key found for ${this.model.provider}.\n\n` +
@@ -2674,20 +2676,23 @@ export class AgentSession {
 			}
 
 			// Build messages array (session context, eager todo prelude, then active prompt message)
-			const messages: AgentMessage[] = [];
-			const planReferenceMessage = await this.#buildPlanReferenceMessage?.();
-			if (planReferenceMessage) {
-				messages.push(planReferenceMessage);
-			}
-			const planModeMessage = await this.#buildPlanModeMessage();
-			if (planModeMessage) {
-				messages.push(planModeMessage);
-			}
-			if (options?.prependMessages) {
-				messages.push(...options.prependMessages);
-			}
+			const messages: AgentMessage[] = await logger.ttftAttr("ttft.build-context", async () => {
+				const built: AgentMessage[] = [];
+				const planReferenceMessage = await this.#buildPlanReferenceMessage?.();
+				if (planReferenceMessage) {
+					built.push(planReferenceMessage);
+				}
+				const planModeMessage = await this.#buildPlanModeMessage();
+				if (planModeMessage) {
+					built.push(planModeMessage);
+				}
+				if (options?.prependMessages) {
+					built.push(...options.prependMessages);
+				}
 
-			messages.push(message);
+				built.push(message);
+				return built;
+			});
 
 			// Early bail-out: if a newer abort/prompt cycle started during setup,
 			// return before mutating shared state (nextTurn messages, system prompt).
@@ -2713,10 +2718,8 @@ export class AgentSession {
 
 			// Emit before_agent_start extension event
 			if (this.#extensionRunner) {
-				const result = await this.#extensionRunner.emitBeforeAgentStart(
-					expandedText,
-					options?.images,
-					this.#baseSystemPrompt,
+				const result = await logger.ttftAttr("ttft.before-agent-start-hook", () =>
+					this.#extensionRunner.emitBeforeAgentStart(expandedText, options?.images, this.#baseSystemPrompt),
 				);
 				if (result?.messages) {
 					const promptAttribution: "user" | "agent" | undefined =
@@ -2747,7 +2750,9 @@ export class AgentSession {
 			}
 
 			const agentPromptOptions = options?.toolChoice ? { toolChoice: options.toolChoice } : undefined;
-			await this.#promptAgentWithIdleRetry(messages, agentPromptOptions);
+			await logger.ttftAttr("ttft.agent-loop-total", () =>
+				this.#promptAgentWithIdleRetry(messages, agentPromptOptions),
+			);
 			if (!options?.skipPostPromptRecoveryWait) {
 				await this.#waitForPostPromptRecovery();
 			}

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -209,14 +209,15 @@ function isAttrOn(): boolean {
 }
 
 /**
- * Emit one attribution line. Transport is FILE when XCSH_TTFT_ATTR_FILE is set (append),
- * else stderr. Wrapped so a bad path / I/O error can NEVER throw into the caller — routing
- * this into a pipe (stderr:"inherit") was shown to hang the chat turn, so a per-run file is
- * the safe transport and any failure here must stay invisible to the hot path.
+ * Emit one attribution line for a pre-computed duration. Transport is FILE when
+ * XCSH_TTFT_ATTR_FILE is set (append), else stderr. Wrapped so a bad path / I/O error can NEVER
+ * throw into the caller — routing this into a pipe (stderr:"inherit") was shown to hang the chat
+ * turn, so a per-run file is the safe transport and any failure here must stay invisible to the
+ * hot path.
  */
-function emitAttr(label: string, start: number): void {
+function emitAttrLine(label: string, ms: number): void {
 	try {
-		const line = `[ttft-attr] ${label} ${performance.now() - start}`;
+		const line = `[ttft-attr] ${label} ${ms}`;
 		const file = process.env.XCSH_TTFT_ATTR_FILE;
 		if (file) {
 			fs.appendFileSync(file, `${line}\n`);
@@ -226,6 +227,11 @@ function emitAttr(label: string, start: number): void {
 	} catch {
 		/* swallow — attribution emission must never throw into the caller */
 	}
+}
+
+/** Emit an attribution line for the elapsed time since {@link start}. */
+function emitAttr(label: string, start: number): void {
+	emitAttrLine(label, performance.now() - start);
 }
 
 /**
@@ -248,4 +254,14 @@ export function ttftAttr<T, A extends unknown[]>(label: string, fn: (...args: A)
 		emitAttr(label, start);
 		throw error;
 	}
+}
+
+/**
+ * TTFT Phase-4 A1 attribution mark for a PRE-COMPUTED duration (not fn-wrapping).
+ * When XCSH_TTFT_ATTRIBUTION=1, emits one `[ttft-attr] <label> <ms>` line via the shared
+ * transport ({@link emitAttrLine}); a no-op otherwise. Never throws — safe on the hot path.
+ */
+export function ttftMark(label: string, ms: number): void {
+	if (!isAttrOn()) return;
+	emitAttrLine(label, ms);
 }

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -208,8 +208,24 @@ function isAttrOn(): boolean {
 	return process.env.XCSH_TTFT_ATTRIBUTION === "1";
 }
 
+/**
+ * Emit one attribution line. Transport is FILE when XCSH_TTFT_ATTR_FILE is set (append),
+ * else stderr. Wrapped so a bad path / I/O error can NEVER throw into the caller — routing
+ * this into a pipe (stderr:"inherit") was shown to hang the chat turn, so a per-run file is
+ * the safe transport and any failure here must stay invisible to the hot path.
+ */
 function emitAttr(label: string, start: number): void {
-	console.error(`[ttft-attr] ${label} ${performance.now() - start}`);
+	try {
+		const line = `[ttft-attr] ${label} ${performance.now() - start}`;
+		const file = process.env.XCSH_TTFT_ATTR_FILE;
+		if (file) {
+			fs.appendFileSync(file, `${line}\n`);
+		} else {
+			console.error(line);
+		}
+	} catch {
+		/* swallow — attribution emission must never throw into the caller */
+	}
 }
 
 /**

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -202,3 +202,34 @@ export function time<T, A extends unknown[]>(op: string, fn?: (...args: A) => T,
 		return fn(...args);
 	}
 }
+
+/** True when TTFT attribution emission is enabled (bench sets XCSH_TTFT_ATTRIBUTION=1). */
+function isAttrOn(): boolean {
+	return process.env.XCSH_TTFT_ATTRIBUTION === "1";
+}
+
+function emitAttr(label: string, start: number): void {
+	console.error(`[ttft-attr] ${label} ${performance.now() - start}`);
+}
+
+/**
+ * TTFT Phase-4 A1 attribution timer. Runs `fn`, returns its value unchanged.
+ * When XCSH_TTFT_ATTRIBUTION=1, emits one `[ttft-attr] <label> <ms>` stderr line on
+ * completion (await-accurate for Promises; synchronous otherwise; emits-then-rethrows on throw).
+ * Pure pass-through with zero output otherwise — safe on the production hot path.
+ */
+export function ttftAttr<T, A extends unknown[]>(label: string, fn: (...args: A) => T, ...args: A): T {
+	if (!isAttrOn()) return fn(...args);
+	const start = performance.now();
+	try {
+		const result = fn(...args);
+		if (result instanceof Promise) {
+			return result.finally(() => emitAttr(label, start)) as T;
+		}
+		emitAttr(label, start);
+		return result;
+	} catch (error) {
+		emitAttr(label, start);
+		throw error;
+	}
+}

--- a/packages/utils/test/ttft-attr.test.ts
+++ b/packages/utils/test/ttft-attr.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { ttftAttr } from "../src/logger";
+import { ttftAttr, ttftMark } from "../src/logger";
 
 describe("ttftAttr", () => {
 	it("is a pure pass-through with no output when the flag is unset", () => {
@@ -91,6 +91,47 @@ describe("ttftAttr", () => {
 		process.env.XCSH_TTFT_ATTR_FILE = "/nonexistent-dir-xyz/attr.log";
 		try {
 			expect(ttftAttr("ttft.e", () => 7)).toBe(7);
+		} finally {
+			delete process.env.XCSH_TTFT_ATTRIBUTION;
+			delete process.env.XCSH_TTFT_ATTR_FILE;
+		}
+	});
+});
+
+describe("ttftMark", () => {
+	it("writes a pre-computed [ttft-attr] line to XCSH_TTFT_ATTR_FILE when enabled", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ttft-mark-"));
+		const file = path.join(dir, "attr.log");
+		process.env.XCSH_TTFT_ATTRIBUTION = "1";
+		process.env.XCSH_TTFT_ATTR_FILE = file;
+		try {
+			ttftMark("ttft.m", 123.4);
+			const contents = fs.readFileSync(file, "utf8");
+			expect(contents).toMatch(/^\[ttft-attr\] ttft\.m 123\.4$/m);
+		} finally {
+			delete process.env.XCSH_TTFT_ATTRIBUTION;
+			delete process.env.XCSH_TTFT_ATTR_FILE;
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("produces no output when the flag is unset", () => {
+		delete process.env.XCSH_TTFT_ATTRIBUTION;
+		delete process.env.XCSH_TTFT_ATTR_FILE;
+		const err = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			ttftMark("ttft.m", 1);
+			expect(err).not.toHaveBeenCalled();
+		} finally {
+			err.mockRestore();
+		}
+	});
+
+	it("never throws when the file transport path is unwritable", () => {
+		process.env.XCSH_TTFT_ATTRIBUTION = "1";
+		process.env.XCSH_TTFT_ATTR_FILE = "/nonexistent-dir-xyz/a.log";
+		try {
+			expect(() => ttftMark("ttft.m", 1)).not.toThrow();
 		} finally {
 			delete process.env.XCSH_TTFT_ATTRIBUTION;
 			delete process.env.XCSH_TTFT_ATTR_FILE;

--- a/packages/utils/test/ttft-attr.test.ts
+++ b/packages/utils/test/ttft-attr.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { ttftAttr } from "../src/logger";
 
 describe("ttftAttr", () => {
 	it("is a pure pass-through with no output when the flag is unset", () => {
 		delete process.env.XCSH_TTFT_ATTRIBUTION;
+		delete process.env.XCSH_TTFT_ATTR_FILE;
 		const err = spyOn(console, "error").mockImplementation(() => {});
 		try {
 			expect(ttftAttr("ttft.x", (a: number, b: number) => a + b, 2, 3)).toBe(5);
@@ -15,6 +19,7 @@ describe("ttftAttr", () => {
 
 	it("emits one [ttft-attr] line for a sync fn when enabled and returns the value", () => {
 		process.env.XCSH_TTFT_ATTRIBUTION = "1";
+		delete process.env.XCSH_TTFT_ATTR_FILE;
 		const err = spyOn(console, "error").mockImplementation(() => {});
 		try {
 			expect(ttftAttr("ttft.sync", () => 42)).toBe(42);
@@ -30,6 +35,7 @@ describe("ttftAttr", () => {
 
 	it("is await-accurate for a Promise fn (emits after it resolves)", async () => {
 		process.env.XCSH_TTFT_ATTRIBUTION = "1";
+		delete process.env.XCSH_TTFT_ATTR_FILE;
 		const err = spyOn(console, "error").mockImplementation(() => {});
 		try {
 			const v = await ttftAttr("ttft.async", async () => {
@@ -48,6 +54,7 @@ describe("ttftAttr", () => {
 
 	it("emits then rethrows when the fn throws", () => {
 		process.env.XCSH_TTFT_ATTRIBUTION = "1";
+		delete process.env.XCSH_TTFT_ATTR_FILE;
 		const err = spyOn(console, "error").mockImplementation(() => {});
 		try {
 			expect(() =>
@@ -60,6 +67,33 @@ describe("ttftAttr", () => {
 		} finally {
 			err.mockRestore();
 			delete process.env.XCSH_TTFT_ATTRIBUTION;
+		}
+	});
+
+	it("appends the [ttft-attr] line to XCSH_TTFT_ATTR_FILE when set (file transport)", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ttft-attr-"));
+		const file = path.join(dir, "attr.log");
+		process.env.XCSH_TTFT_ATTRIBUTION = "1";
+		process.env.XCSH_TTFT_ATTR_FILE = file;
+		try {
+			expect(ttftAttr("ttft.f", () => 1)).toBe(1);
+			const contents = fs.readFileSync(file, "utf8");
+			expect(contents).toMatch(/^\[ttft-attr\] ttft\.f \d/m);
+		} finally {
+			delete process.env.XCSH_TTFT_ATTRIBUTION;
+			delete process.env.XCSH_TTFT_ATTR_FILE;
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("never throws when the file transport path is unwritable", () => {
+		process.env.XCSH_TTFT_ATTRIBUTION = "1";
+		process.env.XCSH_TTFT_ATTR_FILE = "/nonexistent-dir-xyz/attr.log";
+		try {
+			expect(ttftAttr("ttft.e", () => 7)).toBe(7);
+		} finally {
+			delete process.env.XCSH_TTFT_ATTRIBUTION;
+			delete process.env.XCSH_TTFT_ATTR_FILE;
 		}
 	});
 });

--- a/packages/utils/test/ttft-attr.test.ts
+++ b/packages/utils/test/ttft-attr.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { ttftAttr } from "../src/logger";
+
+describe("ttftAttr", () => {
+	it("is a pure pass-through with no output when the flag is unset", () => {
+		delete process.env.XCSH_TTFT_ATTRIBUTION;
+		const err = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			expect(ttftAttr("ttft.x", (a: number, b: number) => a + b, 2, 3)).toBe(5);
+			expect(err).not.toHaveBeenCalled();
+		} finally {
+			err.mockRestore();
+		}
+	});
+
+	it("emits one [ttft-attr] line for a sync fn when enabled and returns the value", () => {
+		process.env.XCSH_TTFT_ATTRIBUTION = "1";
+		const err = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			expect(ttftAttr("ttft.sync", () => 42)).toBe(42);
+			const lines = err.mock.calls.map(c => String(c[0]));
+			const hit = lines.filter(l => l.startsWith("[ttft-attr] ttft.sync "));
+			expect(hit.length).toBe(1);
+			expect(Number(hit[0].split(" ")[2])).toBeGreaterThanOrEqual(0);
+		} finally {
+			err.mockRestore();
+			delete process.env.XCSH_TTFT_ATTRIBUTION;
+		}
+	});
+
+	it("is await-accurate for a Promise fn (emits after it resolves)", async () => {
+		process.env.XCSH_TTFT_ATTRIBUTION = "1";
+		const err = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			const v = await ttftAttr("ttft.async", async () => {
+				await Bun.sleep(15);
+				return "ok";
+			});
+			expect(v).toBe("ok");
+			const hit = err.mock.calls.map(c => String(c[0])).filter(l => l.startsWith("[ttft-attr] ttft.async "));
+			expect(hit.length).toBe(1);
+			expect(Number(hit[0].split(" ")[2])).toBeGreaterThanOrEqual(10);
+		} finally {
+			err.mockRestore();
+			delete process.env.XCSH_TTFT_ATTRIBUTION;
+		}
+	});
+
+	it("emits then rethrows when the fn throws", () => {
+		process.env.XCSH_TTFT_ATTRIBUTION = "1";
+		const err = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			expect(() =>
+				ttftAttr("ttft.boom", () => {
+					throw new Error("nope");
+				}),
+			).toThrow("nope");
+			const hit = err.mock.calls.map(c => String(c[0])).filter(l => l.startsWith("[ttft-attr] ttft.boom "));
+			expect(hit.length).toBe(1);
+		} finally {
+			err.mockRestore();
+			delete process.env.XCSH_TTFT_ATTRIBUTION;
+		}
+	});
+});


### PR DESCRIPTION
Closes #1910

## What

Phase 4 · A1 diagnostic instrumentation to attribute the opaque ~4s `provider_ttft` in the hermetic TTFT benchmark. **Attribution only — no optimization, no production behavior change.**

- `@f5-sales-demo/pi-utils`: env-gated `ttftAttr(label, fn, …)` + `ttftMark(label, ms)` — inert unless `XCSH_TTFT_ATTRIBUTION=1`; emit `[ttft-attr] <label> <ms>` to `XCSH_TTFT_ATTR_FILE` (append) or stderr; never throw into the caller.
- Wrapped the prompt→first-token path with `ttft.*` stages across `coding-agent/session/agent-session.ts` and `packages/agent/{agent,agent-loop}.ts`, plus `ttft.first-token-wait`.
- `bench/ttft.ts`: sets the flag + a per-run attr file, parses via the pure `bench/ttft-attr.ts` (first-occurrence + median), prints a per-mode attribution table. `BenchResult`/baseline/`--check` are byte-for-byte unchanged.

## Key finding

The ~4–5s `provider_ttft` is **NOT agent-loop or model compute** — every compute stage (context build, transform, convert, tool-normalize, the model call) is **<5 ms**. **99.6% (cold) / 99.7% (warm)** is `ttft.first-token-wait`: time in the `for await` loop **after `streamFunction()` returns, before the first `text_delta` is consumed**, even though the instant stand-in provider pushes+ends all events synchronously. The delta throttle is ruled out (`#throttleMs=50`, immediate first flush) and the wait is highly variable run-to-run → **worker event-loop contention** (a concurrent background task starving the loop).

Also corrected the handoff premise: `createAgentSession` / system-prompt build / tool registration all run at **worker boot** (billed to `worker_boot`), not `provider_ttft` — so "pre-warm session" cannot move this stage.

**A2 lead:** bisect the `createAgentSession` background tasks that run into the first turn — `startMemoryStartupTask`, `void svc.getOrRefreshIndex()` (sdk.ts:1477), Python prelude warmup — then defer/yield the winner. (Full numbers + method: `.superpowers/research/ttft-provider-ttft-attribution.md`.)

## Testing

- `packages/utils` ttftAttr/ttftMark: 9/9 (file transport, stderr fallback, never-throw, await-accurate, sync).
- `bench/ttft-attr.ts` pure parser/median: 4/4.
- `bun run check:types` clean; `bun test packages/agent` 25/0; chat-roundtrip 2/0; manager.int 16/16.
- E2E `bench/ttft.ts --runs 5` green; ports clear before/after; attribution table verified.

## Notes

An initial transport attempt (routing worker stderr into the bench's manager pipe via `stderr:"inherit"`) **hung the chat turn** and was reverted — `manager.ts` is unchanged vs base; the worker writes to a file instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
