### PR TITLE
fix(ttft): make the bench hermetic — force the bench-instant model

### DIFF
--- a/packages/coding-agent/bench/ttft-baseline.json
+++ b/packages/coding-agent/bench/ttft-baseline.json
@@ -1,21 +1,21 @@
 {
   "cold": {
-    "ttft_ms": 5956.566417,
+    "ttft_ms": 1840.108417,
     "stages": {
       "manager_provision": 0,
-      "worker_boot": 849,
-      "chat_handler": 0,
-      "provider_ttft": 4237
+      "worker_boot": 816,
+      "chat_handler": 1,
+      "provider_ttft": 16
     },
     "runs": 5
   },
   "warm": {
-    "ttft_ms": 3649.036625,
+    "ttft_ms": 66.78525,
     "stages": {
       "manager_provision": 0,
       "worker_boot": 4,
       "chat_handler": 0,
-      "provider_ttft": 3592
+      "provider_ttft": 10
     },
     "runs": 5
   }

--- a/packages/coding-agent/src/commands/worker.ts
+++ b/packages/coding-agent/src/commands/worker.ts
@@ -233,6 +233,23 @@ export default class Worker extends Command {
 			...(process.env.XCSH_BENCH_EXTENSION ? { additionalExtensionPaths: [process.env.XCSH_BENCH_EXTENSION] } : {}),
 		});
 
+		// TTFT Phase 3 hermeticity: the bench-instant stand-in provider is registered while
+		// createAgentSession loads the bench extension (additionalExtensionPaths), which is
+		// AFTER the default-model role is resolved — so the worker would otherwise fall back
+		// to a real provider and the benchmark would measure live network TTFT, not xcsh
+		// overhead. In bench mode, explicitly select bench-instant now that it is registered.
+		// Gated on XCSH_BENCH_EXTENSION → completely inert for a normal `xcsh worker`.
+		if (process.env.XCSH_BENCH_EXTENSION) {
+			const benchModel = session.modelRegistry.find("bench-instant", "bench-instant");
+			if (benchModel) {
+				await session.setModel(benchModel);
+			} else {
+				console.error(
+					"[xcsh worker] BENCH ERROR: bench-instant model not registered — benchmark would measure a real provider",
+				);
+			}
+		}
+
 		const chatHandler = new ChatHandler(bridge, session);
 		chatHandler.attach();
 


### PR DESCRIPTION
Closes #1912

## Problem
The Phase-3 hermetic TTFT bench never selected its own `bench-instant` stand-in: it registers during extension load (`sdk.ts:1274`), AFTER default-model resolution (`sdk.ts:851`). So the worker fell back to the dev's real model (`anthropic/claude-opus-4-6`, via leaked `~/.xcsh` creds + the bench's `...process.env`), and `provider_ttft` (~3.5–4s, variable) measured **live Anthropic latency, not xcsh overhead**. Proven with a model probe (`anthropic/claude-opus-4-6`) and by forcing `bench-instant` → `provider_ttft` collapses to ~11ms.

## Fix
`worker.ts` bench mode (`XCSH_BENCH_EXTENSION` — inert for a normal `xcsh worker`): `session.setModel(bench-instant)` after `createAgentSession`, once registered; loud BENCH ERROR (no silent real-model fallback) if missing. Baseline re-captured hermetically.

## Corrected baseline (real xcsh cost)
| | cold | warm |
|---|---|---|
| ttft_ms | 1840ms (was 5957) | 67ms (was 3649) |
| worker_boot | 816ms | 4ms |
| provider_ttft | 16ms (was ~4000) | 10ms |

Takeaways: xcsh routing/agent-loop overhead is ~11ms (negligible); the ~4s a user waits is the LLM's network latency (outside xcsh); the only real xcsh cold-start cost is worker spawn + `createAgentSession` (~1.8s cold, already mitigated to ~67ms by the pre-warm pool). This corrects the Phase-4 A1 interpretation (the "event-loop contention" reading assumed the stand-in was active).

## Testing
`bun run check:ts` EXIT 0 (per-package strict + biome). Hermetic `bench/ttft.ts --runs 5`: `provider_ttft` ~11ms, no BENCH ERROR, ports clear before/after. Change gated on bench env → production worker unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
