### PR TITLE
fix(coding-agent): keep actively-chatting workers alive (idle-reap → "Turn aborted.")

### DIFF
--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -31,10 +31,17 @@ export class ChatHandler {
 	#session: AgentSession;
 	#activeChats = new Map<string, ActiveChat>();
 	#activeHistoryHint: string | undefined;
+	#onTurnStart: (() => void) | undefined;
 
 	constructor(server: BridgeServer, session: AgentSession) {
 		this.#server = server;
 		this.#session = session;
+	}
+
+	/** Register a callback fired when a chat turn is accepted (used by the worker's
+	 * manager keepalive to refresh lastSeen at turn start). */
+	onTurnStart(cb: () => void): void {
+		this.#onTurnStart = cb;
 	}
 
 	attach(): void {
@@ -75,6 +82,7 @@ export class ChatHandler {
 			spanEmitted: false,
 		};
 		this.#activeChats.set(id, chat);
+		this.#onTurnStart?.();
 
 		const unsubscribe = this.#session.subscribe((event: AgentSessionEvent) => {
 			this.#handleSessionEvent(chat, event);

--- a/packages/coding-agent/src/commands/manager-core.ts
+++ b/packages/coding-agent/src/commands/manager-core.ts
@@ -17,7 +17,9 @@ const SHUTDOWN_REASONS = new Set<string>(["superseded", "updated", "manual"]);
 export type ControlMsg =
 	| { type: "provision"; sessionId: string; tenant: string }
 	| { type: "release"; sessionId: string }
-	| { type: "status" }
+	// An sid-less status is the legacy no-op sink; an sid-carrying status is a
+	// keepalive from an actively-chatting worker (see keepaliveFrame/touchLastSeen).
+	| { type: "status"; sessionId?: string }
 	| { type: "hello" }
 	| { type: "shutdown"; reason: ShutdownReason };
 
@@ -42,7 +44,8 @@ function isNonEmpty(v: unknown): v is string {
 export function parseControlMsg(raw: unknown): ControlMsg | null {
 	if (!raw || typeof raw !== "object") return null;
 	const m = raw as Record<string, unknown>;
-	if (m.type === "status") return { type: "status" };
+	if (m.type === "status")
+		return isNonEmpty(m.sessionId) ? { type: "status", sessionId: m.sessionId } : { type: "status" };
 	if (m.type === "provision" && isNonEmpty(m.sessionId) && isTenant(m.tenant))
 		return { type: "provision", sessionId: m.sessionId, tenant: m.tenant };
 	if (m.type === "release" && isNonEmpty(m.sessionId)) return { type: "release", sessionId: m.sessionId };
@@ -113,6 +116,27 @@ export function staleKeys(reg: Registry, now: number, idleMs: number): string[] 
 	const out: string[] = [];
 	for (const w of reg.values()) if (now - w.lastSeen > idleMs) out.push(w.sessionId);
 	return out;
+}
+
+/** Refresh a worker's `lastSeen` from a keepalive/status frame; true iff a known
+ * session was touched. The manager never sees chat traffic (it flows worker↔
+ * bridge↔extension), so an actively-used session would otherwise be idle-reaped
+ * mid-conversation. An actively-chatting worker emits `keepaliveFrame` to drive
+ * this, keeping its session out of `staleKeys`. */
+export function touchLastSeen(reg: Registry, sessionId: string | undefined, now: number): boolean {
+	if (!sessionId) return false;
+	const w = reg.get(sessionId);
+	if (!w) return false;
+	w.lastSeen = now;
+	return true;
+}
+
+/** The NDJSON keepalive an actively-chatting worker writes to the manager control
+ * socket to refresh its `lastSeen` (consumed by `touchLastSeen`). Null for the
+ * unbound `spare` sentinel or an empty id — a spare has no session to keep alive. */
+export function keepaliveFrame(sessionId: string): string | null {
+	if (!sessionId || sessionId === "spare") return null;
+	return `${JSON.stringify({ type: "status", sessionId })}\n`;
 }
 
 /** How many new spares to spawn now to reach `target`, without exceeding the port

--- a/packages/coding-agent/src/commands/manager-keepalive.ts
+++ b/packages/coding-agent/src/commands/manager-keepalive.ts
@@ -1,0 +1,117 @@
+/**
+ * Worker→manager keepalive client.
+ *
+ * The manager idle-reaps a worker whose `lastSeen` is older than `IDLE_MS`, and
+ * `lastSeen` is refreshed ONLY when the manager receives a control frame. Chat
+ * traffic flows worker↔bridge↔extension and never reaches the manager, so an
+ * actively-used-then-briefly-idle session used to be reaped mid-conversation
+ * (the "Turn aborted." after a break). This client emits a `status{sessionId}`
+ * keepalive over the manager's UNIX control socket while a turn is in flight and
+ * at each turn start, so the manager's sweep leaves an in-use session alive.
+ *
+ * The socket lifecycle (connect/reconnect) is injected as a `Connector` so the
+ * scheduling/emit logic is unit-testable without a real socket; the worker wires
+ * a `Bun.connect` transport. Best-effort throughout: if the manager socket is
+ * down (e.g. mid-supersede) emits are dropped and the next emit reconnects — so
+ * after a manager handoff the keepalive re-targets the successor manager, which
+ * has already re-adopted this worker.
+ */
+import { keepaliveFrame } from "./manager-core";
+
+/** A live connection to the manager control socket. */
+export interface KeepaliveTransport {
+	write(data: string): void;
+	close(): void;
+}
+
+/** Opens a transport; `onClose` MUST be invoked when the connection drops so the
+ * keepalive knows to reconnect on its next emit. Returns null if it cannot open. */
+export type Connector = (onClose: () => void) => Promise<KeepaliveTransport | null>;
+
+export interface ManagerKeepaliveDeps {
+	connect: Connector;
+	/** Current worker session id (may transition from "spare" to a real id). */
+	sessionId: () => string;
+	/** True while a chat turn is in flight. */
+	busy: () => boolean;
+}
+
+export class ManagerKeepalive {
+	#deps: ManagerKeepaliveDeps;
+	#transport: KeepaliveTransport | null = null;
+	#connecting = false;
+	#pending = false; // a keepalive is due once a connection is (re)established
+	#stopped = false;
+
+	constructor(deps: ManagerKeepaliveDeps) {
+		this.#deps = deps;
+	}
+
+	/** Periodic tick (driven by the worker's interval): emit iff a turn is busy. */
+	tick(): void {
+		if (this.#deps.busy()) this.#emit();
+	}
+
+	/** One-shot emit at the start of each turn — refreshes lastSeen immediately so
+	 * a session with long think-time between turns is never reaped between them. */
+	turnStart(): void {
+		this.#emit();
+	}
+
+	/** Stop emitting and close any open transport. */
+	stop(): void {
+		this.#stopped = true;
+		this.#pending = false;
+		this.#transport?.close();
+		this.#transport = null;
+	}
+
+	#emit(): void {
+		if (this.#stopped) return;
+		const frame = keepaliveFrame(this.#deps.sessionId());
+		if (!frame) return; // spare / unbound → nothing to keep alive (also skips connecting)
+		if (this.#transport) {
+			try {
+				this.#transport.write(frame);
+			} catch {
+				this.#transport = null; // dead socket → drop and reconnect on next emit
+				this.#pending = true;
+				void this.#ensureConnected();
+			}
+			return;
+		}
+		this.#pending = true;
+		void this.#ensureConnected();
+	}
+
+	async #ensureConnected(): Promise<void> {
+		if (this.#stopped || this.#transport || this.#connecting) return;
+		this.#connecting = true;
+		let t: KeepaliveTransport | null = null;
+		try {
+			t = await this.#deps.connect(() => {
+				this.#transport = null; // socket dropped → next emit reconnects
+			});
+		} catch {
+			t = null;
+		}
+		this.#connecting = false;
+		if (!t) return; // manager unreachable — best-effort, a later emit retries
+		if (this.#stopped) {
+			t.close();
+			return;
+		}
+		this.#transport = t;
+		if (this.#pending) {
+			this.#pending = false;
+			const frame = keepaliveFrame(this.#deps.sessionId());
+			if (frame) {
+				try {
+					this.#transport.write(frame);
+				} catch {
+					this.#transport = null;
+				}
+			}
+		}
+	}
+}

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -11,6 +11,8 @@
  *          on sessionId, so two tabs of the SAME tenant get two workers.
  *   {"type":"release","sessionId":"tab-7"}  → kill + forget that session's worker
  *   {"type":"status"}                        → accepted; no-op sink
+ *   {"type":"status","sessionId":"tab-7"}    → keepalive: refresh that worker's
+ *          lastSeen so an actively-chatting session is not idle-reaped
  *
  * All registry/port/idempotency/idle policy is the pure `manager-core`; this file
  * is the thin I/O shell (socket, spawn, kill, timer) around it. A background sweep
@@ -25,7 +27,15 @@ import { Command } from "@f5-sales-demo/pi-utils/cli";
 import { VERSION } from "@f5-sales-demo/pi-utils/dirs";
 import { portCandidates } from "../browser/extension-bridge";
 import { removeManagerState, writeManagerState } from "../services/manager-state";
-import { needsProvision, parseControlMsg, pickPort, type Registry, sparesToSpawn, staleKeys } from "./manager-core";
+import {
+	needsProvision,
+	parseControlMsg,
+	pickPort,
+	type Registry,
+	sparesToSpawn,
+	staleKeys,
+	touchLastSeen,
+} from "./manager-core";
 
 /** Reap a worker idle longer than this (ms). */
 const IDLE_MS = 20 * 60_000;
@@ -434,8 +444,13 @@ export default class Manager extends Command {
 					const managerProvisionMs = Date.now() - provisionReceivedAt;
 					if (!adoptSpare(msg, managerProvisionMs)) spawnWorker(msg, managerProvisionMs); // adopt a warm spare, else cold-spawn (fallback)
 				}
-				const w = reg.get(msg.sessionId);
-				if (w) w.lastSeen = Date.now(); // touch on every provision (keep-alive)
+				touchLastSeen(reg, msg.sessionId, Date.now()); // touch on every provision (keep-alive)
+			} else if (msg.type === "status") {
+				// Keepalive from an actively-chatting worker (#idle-reap): refresh
+				// lastSeen so the idle sweep never reaps a session that is in use.
+				// Chat traffic never reaches the manager, so this is the only signal
+				// that an otherwise-quiet-to-the-manager worker is still working.
+				touchLastSeen(reg, msg.sessionId, Date.now());
 			} else if (msg.type === "release") {
 				reap(msg.sessionId);
 			} else if (msg.type === "shutdown") {
@@ -452,7 +467,6 @@ export default class Manager extends Command {
 					/* client hung up mid-handshake — ignore */
 				}
 			}
-			// "status" is validated but currently a no-op sink.
 		};
 
 		// Per-connection NDJSON buffer: a control frame can be split across two TCP

--- a/packages/coding-agent/src/commands/worker.ts
+++ b/packages/coding-agent/src/commands/worker.ts
@@ -13,6 +13,8 @@
  * `XCSH_SESSION_TENANT` so it advertises its assigned tenant even before a context
  * is bound. This lets the extension panel lock onto the right tenant immediately.
  */
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { getProjectDir, getXCSHConfigDir, logger } from "@f5-sales-demo/pi-utils";
 import { Command } from "@f5-sales-demo/pi-utils/cli";
 import { ChatHandler } from "../browser/chat-handler";
@@ -25,6 +27,7 @@ import { createAgentSession } from "../sdk";
 import { activateTenantContext } from "../services/session-context-binding";
 import { ContextService } from "../services/xcsh-context";
 import { deriveTenantEnv } from "../services/xcsh-env";
+import { type KeepaliveTransport, ManagerKeepalive } from "./manager-keepalive";
 
 /** Mutable worker identity. Seeded from env at spawn (backward compat); replaced by a
  * late IPC bind on a pre-warmed spare. `null` fields fall back to env, then the "spare"
@@ -76,6 +79,16 @@ export function sessionInfoForWorker(): {
 
 /** Hard ceiling for draining an in-flight chat turn on SIGTERM before teardown (#1874). */
 const WORKER_DRAIN_TIMEOUT_MS = 10_000;
+
+/** How often the worker pings the manager while a turn is in flight, refreshing its
+ * lastSeen so an actively-chatting session is never idle-reaped. Comfortably under
+ * the manager's IDLE_MS (20 min); a turn also pings once at its start. */
+const KEEPALIVE_MS = 60_000;
+
+/** The manager control socket (same derivation as native-host / chrome-cli). */
+function managerSockPath(): string {
+	return process.env.XCSH_MANAGER_SOCK ?? join(homedir(), ".xcsh", "manager.sock");
+}
 
 /** Browser-automation tool set — identical scoping to `main.ts`'s extension path.
  * With scoped tools the ONLY way to create a resource is the form-driven workflow
@@ -274,6 +287,38 @@ export default class Worker extends Command {
 		const chatHandler = new ChatHandler(bridge, session);
 		chatHandler.attach();
 
+		// Manager keepalive: while a turn is in flight (and at each turn start), ping
+		// the manager control socket so it refreshes this worker's lastSeen and its
+		// idle sweep does not reap an actively-used session mid-conversation. Chat
+		// traffic never reaches the manager, so this is the only liveness signal.
+		// Best-effort + self-reconnecting: a dropped socket (e.g. manager supersede)
+		// is re-opened on the next emit, re-targeting the successor manager.
+		const keepalive = new ManagerKeepalive({
+			sessionId: () => sessionInfoForWorker().sessionId ?? "spare",
+			busy: () => chatHandler.busy,
+			connect: async onClose => {
+				try {
+					const sock = await Bun.connect({
+						unix: managerSockPath(),
+						socket: { data() {}, close: () => onClose(), error: () => onClose() },
+					});
+					const transport: KeepaliveTransport = {
+						write: data => {
+							sock.write(data);
+						},
+						close: () => {
+							sock.end();
+						},
+					};
+					return transport;
+				} catch {
+					return null; // manager not reachable — a later emit retries
+				}
+			},
+		});
+		chatHandler.onTurnStart(() => keepalive.turnStart());
+		const keepaliveTimer = setInterval(() => keepalive.tick(), KEEPALIVE_MS);
+
 		// session-ready. Emit the per-tab boot breakdown when requested (parity with
 		// main.ts:1002-1009). PI_TIMING=x prints then exits — used by bench/extension-session.ts
 		// to measure total worker cold-start; otherwise this is a no-op.
@@ -287,6 +332,8 @@ export default class Worker extends Command {
 
 		let shuttingDown = false;
 		const teardown = () => {
+			clearInterval(keepaliveTimer);
+			keepalive.stop();
 			chatHandler.dispose();
 			void bridge.close().finally(() => process.exit(0));
 		};

--- a/packages/coding-agent/test/chat-handler-ttft.test.ts
+++ b/packages/coding-agent/test/chat-handler-ttft.test.ts
@@ -62,3 +62,32 @@ describe("ChatHandler TTFT spans", () => {
 		expect(sent.filter(f => f.type === "span").length).toBe(2);
 	});
 });
+
+describe("ChatHandler onTurnStart hook", () => {
+	it("fires the registered callback once when a turn is accepted (drives the manager keepalive)", async () => {
+		const { server, session, fire } = makeFakes();
+		let starts = 0;
+		const handler = new ChatHandler(server, session);
+		handler.onTurnStart(() => {
+			starts += 1;
+		});
+		handler.attach();
+		await fire({ type: "chat_request", id: "c-1", text: "hi", context: null, mode: "educational" });
+		await new Promise(r => setTimeout(r, 10));
+		expect(starts).toBe(1);
+	});
+
+	it("does not fire for a rejected (session-busy) turn", async () => {
+		const { server, session, fire } = makeFakes();
+		(session as unknown as { isStreaming: boolean }).isStreaming = true; // already streaming → busy
+		let starts = 0;
+		const handler = new ChatHandler(server, session);
+		handler.onTurnStart(() => {
+			starts += 1;
+		});
+		handler.attach();
+		await fire({ type: "chat_request", id: "c-2", text: "hi", context: null, mode: "educational" });
+		await new Promise(r => setTimeout(r, 10));
+		expect(starts).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/manager-core.test.ts
+++ b/packages/coding-agent/test/manager-core.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, test } from "bun:test";
 import { sparesToSpawn } from "@f5-sales-demo/xcsh/commands/manager-core";
 import {
+	keepaliveFrame,
 	type ManagerState,
 	needsProvision,
 	parseControlMsg,
@@ -10,6 +11,7 @@ import {
 	serializeManagerState,
 	shouldSupersede,
 	staleKeys,
+	touchLastSeen,
 	type WorkerRec,
 } from "../src/commands/manager-core";
 
@@ -35,6 +37,14 @@ describe("parseControlMsg", () => {
 		});
 		expect(parseControlMsg({ type: "release", sessionId: "tab-7" })).toEqual({ type: "release", sessionId: "tab-7" });
 		expect(parseControlMsg({ type: "status" })).toEqual({ type: "status" });
+	});
+	// Keepalive-on-chat: a status frame MAY carry the chatting worker's sessionId
+	// so the manager can refresh its lastSeen (chat traffic never reaches the
+	// manager otherwise). An sid-less status stays the legacy no-op sink.
+	test("status carries an optional sessionId", () => {
+		expect(parseControlMsg({ type: "status", sessionId: "tab-7" })).toEqual({ type: "status", sessionId: "tab-7" });
+		expect(parseControlMsg({ type: "status", sessionId: "" })).toEqual({ type: "status" }); // empty → sink
+		expect(parseControlMsg({ type: "status", sessionId: 3 })).toEqual({ type: "status" }); // non-string → sink
 	});
 	test("rejects junk / missing fields / bad tenant", () => {
 		expect(parseControlMsg({ type: "provision", sessionId: "tab-7" })).toBeNull(); // no tenant
@@ -123,6 +133,36 @@ describe("staleKeys", () => {
 	test("returns sids idle beyond ttl", () => {
 		const now = 100_000;
 		expect(staleKeys(reg(W("a", 19222, now - 40_000), W("b", 19223, now - 5_000)), now, 30_000)).toEqual(["a"]);
+	});
+});
+
+// Keepalive-on-chat (#idle-reap): the worker sends a `status{sessionId}` frame
+// while actively chatting; the manager refreshes lastSeen so its idle sweep does
+// not reap a session that is in use. Chat frames never reach the manager, so
+// without this an actively-used-then-briefly-idle worker gets swept mid-use.
+describe("touchLastSeen", () => {
+	test("refreshes a known session so staleKeys no longer reaps it", () => {
+		const now = 1_000_000;
+		const r = reg(W("tab-7", 19222, now - 40_000));
+		expect(staleKeys(r, now, 30_000)).toEqual(["tab-7"]); // stale before the keepalive
+		expect(touchLastSeen(r, "tab-7", now)).toBe(true);
+		expect(staleKeys(r, now, 30_000)).toEqual([]); // kept alive by the keepalive
+	});
+	test("ignores an unknown or absent sessionId (no throw, returns false)", () => {
+		const r = reg(W("tab-7", 19222, 5));
+		expect(touchLastSeen(r, "ghost", 999)).toBe(false);
+		expect(touchLastSeen(r, undefined, 999)).toBe(false);
+		expect(r.get("tab-7")?.lastSeen).toBe(5); // untouched
+	});
+});
+
+describe("keepaliveFrame", () => {
+	test("builds an NDJSON status frame carrying the sessionId", () => {
+		expect(keepaliveFrame("tab-7")).toBe('{"type":"status","sessionId":"tab-7"}\n');
+	});
+	test("returns null for the unbound spare sentinel or an empty id (nothing to keep alive)", () => {
+		expect(keepaliveFrame("spare")).toBeNull();
+		expect(keepaliveFrame("")).toBeNull();
 	});
 });
 

--- a/packages/coding-agent/test/manager-keepalive.test.ts
+++ b/packages/coding-agent/test/manager-keepalive.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import { type KeepaliveTransport, ManagerKeepalive } from "../src/commands/manager-keepalive";
+
+/** A transport that records every frame written and whether it was closed. */
+function fakeTransport() {
+	const writes: string[] = [];
+	let closed = false;
+	const t: KeepaliveTransport = {
+		write: (d: string) => {
+			writes.push(d);
+		},
+		close: () => {
+			closed = true;
+		},
+	};
+	return { t, writes, isClosed: () => closed };
+}
+
+/** A connector that hands out the given transports in order and lets a test fire
+ * the onClose callback for any prior connection (simulating a dropped socket). */
+function fakeConnector(transports: ReturnType<typeof fakeTransport>[]) {
+	let calls = 0;
+	const closers: Array<() => void> = [];
+	const connect = async (onClose: () => void): Promise<KeepaliveTransport | null> => {
+		closers.push(onClose);
+		const rec = transports[calls] ?? transports[transports.length - 1];
+		calls += 1;
+		return rec.t;
+	};
+	return { connect, calls: () => calls, fireClose: (i: number) => closers[i]?.() };
+}
+
+/** Let queued microtasks + the async connect promise settle. */
+const flush = () => new Promise<void>(r => setTimeout(r, 0));
+
+describe("ManagerKeepalive", () => {
+	it("emits a keepalive frame at turn start for a bound session", async () => {
+		const tp = fakeTransport();
+		const conn = fakeConnector([tp]);
+		const ka = new ManagerKeepalive({ connect: conn.connect, sessionId: () => "tab-7", busy: () => false });
+		ka.turnStart();
+		await flush();
+		expect(tp.writes).toEqual(['{"type":"status","sessionId":"tab-7"}\n']);
+	});
+
+	it("emits on tick while busy and stays silent while idle", async () => {
+		const tp = fakeTransport();
+		const conn = fakeConnector([tp]);
+		let busy = false;
+		const ka = new ManagerKeepalive({ connect: conn.connect, sessionId: () => "tab-7", busy: () => busy });
+		ka.tick(); // idle → nothing
+		await flush();
+		expect(tp.writes).toEqual([]);
+		busy = true;
+		ka.tick();
+		await flush();
+		ka.tick();
+		await flush();
+		expect(tp.writes.length).toBe(2);
+	});
+
+	it("never emits (and never connects) for the unbound spare sentinel", async () => {
+		const tp = fakeTransport();
+		const conn = fakeConnector([tp]);
+		const ka = new ManagerKeepalive({ connect: conn.connect, sessionId: () => "spare", busy: () => true });
+		ka.turnStart();
+		ka.tick();
+		await flush();
+		expect(tp.writes).toEqual([]);
+		expect(conn.calls()).toBe(0);
+	});
+
+	it("reconnects and resumes emitting after the socket drops (manager supersede)", async () => {
+		const tp1 = fakeTransport();
+		const tp2 = fakeTransport();
+		const conn = fakeConnector([tp1, tp2]);
+		const ka = new ManagerKeepalive({ connect: conn.connect, sessionId: () => "tab-7", busy: () => true });
+		ka.turnStart();
+		await flush();
+		expect(tp1.writes.length).toBe(1);
+		conn.fireClose(0); // successor manager superseded us → our socket closed
+		ka.tick();
+		await flush();
+		expect(conn.calls()).toBe(2); // re-targeted the successor manager
+		expect(tp2.writes.length).toBe(1); // keepalive resumed on the new connection
+	});
+
+	it("stop() closes the transport and halts further emits", async () => {
+		const tp = fakeTransport();
+		const conn = fakeConnector([tp]);
+		const ka = new ManagerKeepalive({ connect: conn.connect, sessionId: () => "tab-7", busy: () => true });
+		ka.turnStart();
+		await flush();
+		ka.stop();
+		expect(tp.isClosed()).toBe(true);
+		ka.tick();
+		await flush();
+		expect(tp.writes.length).toBe(1); // no writes after stop
+	});
+});


### PR DESCRIPTION
Fixes the standalone root cause behind a bare **`Turn aborted.`** after an idle break: the manager idle-reaped an actively-used worker because chat traffic never refreshes its manager-side `lastSeen`.

## What changed
- `manager-core.ts`: `status` control frame carries an optional `sessionId`; new pure `touchLastSeen` + `keepaliveFrame`.
- `manager.ts`: `handleFrame` refreshes `lastSeen` on a `status{sessionId}` keepalive (and provision now reuses `touchLastSeen`). `IDLE_MS`/`SWEEP_MS` unchanged — a genuinely idle (hours) session still reaps.
- `manager-keepalive.ts` (new): transport-injected `ManagerKeepalive` — emits while a turn is in flight and at turn start, skips the `spare` sentinel, self-reconnects after a socket drop (manager supersede).
- `worker.ts`: wires the keepalive over the manager UNIX control socket via `Bun.connect`; stopped on teardown.
- `chat-handler.ts`: `onTurnStart` hook fired when a turn is accepted.

## Why it's safe / standalone
No wire/contract change, no extension dependency. Delivers value on its own — an active chat session is no longer reaped. Truly-idle sessions still reap (the client self-heal + auto-resend for that case ships in later PRs of this effort).

## Tests (TDD)
- Pure: `touchLastSeen` + `staleKeys` reap-skips-active; `status` sessionId parse; `keepaliveFrame` gating.
- `ManagerKeepalive`: emit-while-busy / idle-silent / spare-skip / reconnect-after-supersede / stop.
- `ChatHandler.onTurnStart`: fires on accept, not on session-busy reject.
- `bunx tsgo` strict + biome clean. Existing manager integration suite unchanged (one pre-existing warm-adopt timing failure reproduces on `main`, unrelated).

Closes #1924

🤖 Generated with [Claude Code](https://claude.com/claude-code)
