### PR TITLE
feat(coding-agent): machine-readable reason on chat_error (contract 1.6.0)

### DIFF
--- a/packages/coding-agent/src/browser/capabilities.generated.ts
+++ b/packages/coding-agent/src/browser/capabilities.generated.ts
@@ -26,7 +26,7 @@ export interface ExtensionCapabilities {
 
 export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 	"version": "0.1.0",
-	"contractVersion": "1.5.0",
+	"contractVersion": "1.6.0",
 	"multiPortDiscovery": true,
 	"protocol": "tool_request/result",
 	"tools": [
@@ -626,6 +626,26 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 			"flags": {}
 		},
 		{
+			"name": "diag_activation",
+			"summary": "Diagnostic: per-gate tab-activation readiness timings (bridge/worker/page), cold/warm.",
+			"category": "read",
+			"params": {
+				"type": "object",
+				"properties": {}
+			},
+			"flags": {}
+		},
+		{
+			"name": "diag_ttft",
+			"summary": "Diagnostic: init→first-token timeline (per-stage ms, total, dominant, cold/warm).",
+			"category": "read",
+			"params": {
+				"type": "object",
+				"properties": {}
+			},
+			"flags": {}
+		},
+		{
 			"name": "capture_login_flow",
 			"summary": "Diagnostic: captured login redirect chain annotated with tenant/env (Phase 0b).",
 			"category": "read",
@@ -825,6 +845,6 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 	}
 };
 
-export const EXTENSION_CONTRACT_VERSION = "1.5.0";
+export const EXTENSION_CONTRACT_VERSION = "1.6.0";
 
-export const EXTENSION_TOOL_NAMES: readonly string[] = ["ping","capabilities","reload","debug_exec","detach","set_bridge_port","navigate","login","scroll_to","resize_window","tabs_list","tabs_create","tabs_close","click","click_element","click_xy","type_text","form_input","key_press","select_option","label_select","file_upload","read_ax","get_page_text","query_dom","find","wait_for","assert_text","screenshot","read_console","read_network","diag_suspension","diag_bridges","capture_login_flow","wait_for_api_response","get_page_context","javascript_tool","browser_batch","set_explain_mode","annotate"];
+export const EXTENSION_TOOL_NAMES: readonly string[] = ["ping","capabilities","reload","debug_exec","detach","set_bridge_port","navigate","login","scroll_to","resize_window","tabs_list","tabs_create","tabs_close","click","click_element","click_xy","type_text","form_input","key_press","select_option","label_select","file_upload","read_ax","get_page_text","query_dom","find","wait_for","assert_text","screenshot","read_console","read_network","diag_suspension","diag_bridges","diag_activation","diag_ttft","capture_login_flow","wait_for_api_response","get_page_context","javascript_tool","browser_batch","set_explain_mode","annotate"];

--- a/packages/coding-agent/src/browser/capabilities.json
+++ b/packages/coding-agent/src/browser/capabilities.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "contractVersion": "1.5.0",
+  "contractVersion": "1.6.0",
   "multiPortDiscovery": true,
   "protocol": "tool_request/result",
   "tools": [
@@ -543,6 +543,26 @@
     {
       "name": "diag_bridges",
       "summary": "List discovered xcsh bridges (port, tenant, env, sessionId, lastSeen) for multi-session diagnostics.",
+      "category": "read",
+      "params": {
+        "type": "object",
+        "properties": {}
+      },
+      "flags": {}
+    },
+    {
+      "name": "diag_activation",
+      "summary": "Diagnostic: per-gate tab-activation readiness timings (bridge/worker/page), cold/warm.",
+      "category": "read",
+      "params": {
+        "type": "object",
+        "properties": {}
+      },
+      "flags": {}
+    },
+    {
+      "name": "diag_ttft",
+      "summary": "Diagnostic: init→first-token timeline (per-stage ms, total, dominant, cold/warm).",
       "category": "read",
       "params": {
         "type": "object",

--- a/packages/coding-agent/src/browser/chat-conformance.json
+++ b/packages/coding-agent/src/browser/chat-conformance.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": "1.5.0",
+  "contractVersion": "1.6.0",
   "schemas": {
     "chat_request": {
       "type": "object",
@@ -210,6 +210,19 @@
         },
         "error": {
           "type": "string"
+        },
+        "reason": {
+          "anyOf": [
+            { "const": "bridge-disconnected", "type": "string" },
+            { "const": "bridge-unresponsive", "type": "string" },
+            { "const": "no-worker", "type": "string" },
+            { "const": "session-busy", "type": "string" },
+            { "const": "session-disposed", "type": "string" },
+            { "const": "token-expired", "type": "string" },
+            { "const": "token-expiring", "type": "string" },
+            { "const": "provider-4xx", "type": "string" },
+            { "const": "provider-5xx", "type": "string" }
+          ]
         }
       }
     },
@@ -433,7 +446,8 @@
       "chat_error": {
         "type": "chat_error",
         "id": "c-1111",
-        "error": "HTTP 403 forbidden"
+        "error": "HTTP 403 forbidden",
+        "reason": "provider-4xx"
       },
       "chat_tool_notice": {
         "type": "chat_tool_notice",

--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -4,6 +4,7 @@ import {
 	type ChatDelta,
 	type ChatDone,
 	type ChatError,
+	type ChatErrorReason,
 	type ChatReference,
 	type ChatRequest,
 	type InteractionMode,
@@ -45,7 +46,12 @@ export class ChatHandler {
 
 		this.#server.onDisconnected(() => {
 			for (const chat of this.#activeChats.values()) {
-				this.#sendTerminal(chat, { type: "chat_error", id: chat.id, error: "bridge disconnected" });
+				this.#sendTerminal(chat, {
+					type: "chat_error",
+					id: chat.id,
+					error: "bridge disconnected",
+					reason: "bridge-disconnected",
+				});
 				chat.unsubscribe();
 			}
 			this.#activeChats.clear();
@@ -56,7 +62,12 @@ export class ChatHandler {
 		const { id } = req;
 
 		if (this.#session.isStreaming || this.#activeChats.size > 0) {
-			this.#server.send({ type: "chat_error", id, error: "session busy" } satisfies ChatError);
+			this.#server.send({
+				type: "chat_error",
+				id,
+				error: "session busy",
+				reason: "session-busy",
+			} satisfies ChatError);
 			return;
 		}
 
@@ -88,7 +99,7 @@ export class ChatHandler {
 			await this.#session.prompt(prompt, { expandPromptTemplates: false, synthetic: false });
 		} catch (err: unknown) {
 			const message = err instanceof Error ? err.message : "unknown error";
-			this.#sendTerminal(chat, { type: "chat_error", id, error: message });
+			this.#sendTerminal(chat, { type: "chat_error", id, error: message, reason: classifyChatErrorReason(message) });
 		} finally {
 			if (!chat.terminalSent) {
 				this.#sendTerminal(chat, { type: "chat_done", id });
@@ -145,15 +156,22 @@ export class ChatHandler {
 				}
 			} else if (ame.type === "error") {
 				const errorMsg = ame.error?.errorMessage ?? "LLM error";
-				this.#sendTerminal(chat, { type: "chat_error", id: chat.id, error: errorMsg });
+				this.#sendTerminal(chat, {
+					type: "chat_error",
+					id: chat.id,
+					error: errorMsg,
+					reason: classifyChatErrorReason(errorMsg),
+				});
 			}
 		} else if (event.type === "message_end" && event.message.role === "assistant") {
 			const msg = event.message as AssistantMessage;
 			if (msg.stopReason === "error") {
+				const errorMsg = msg.errorMessage ?? "assistant error";
 				this.#sendTerminal(chat, {
 					type: "chat_error",
 					id: chat.id,
-					error: msg.errorMessage ?? "assistant error",
+					error: errorMsg,
+					reason: classifyChatErrorReason(errorMsg),
 				});
 			} else {
 				const references = extractReferences(msg);
@@ -186,11 +204,39 @@ export class ChatHandler {
 
 	dispose(): void {
 		for (const chat of this.#activeChats.values()) {
-			this.#sendTerminal(chat, { type: "chat_error", id: chat.id, error: "session disposed" });
+			this.#sendTerminal(chat, {
+				type: "chat_error",
+				id: chat.id,
+				error: "session disposed",
+				reason: "session-disposed",
+			});
 			chat.unsubscribe();
 		}
 		this.#activeChats.clear();
 	}
+}
+
+/** Best-effort classification of an upstream/provider error message into a
+ * ChatErrorReason so the panel can pick a distinct, actionable message. Returns
+ * undefined for an unclassified error (the panel then shows the raw error text).
+ * Token checks run before the generic 4xx check (a 401 is more useful as an
+ * expired-token hint than a bare client error). */
+export function classifyChatErrorReason(message: string): ChatErrorReason | undefined {
+	const m = message.toLowerCase();
+	if (/\btoken\b[^.]*\b(expir|invalid)|\b(expir|invalid)[^.]*\btoken\b|aws sso|\/context (create|validate)/.test(m)) {
+		return "token-expired";
+	}
+	if (
+		/\b5\d\d\b|internal server error|bad gateway|service unavailable|gateway timeout|econnreset|etimedout|socket hang up|network error/.test(
+			m,
+		)
+	) {
+		return "provider-5xx";
+	}
+	if (/\b4\d\d\b|forbidden|unauthorized|invalid model|bad request|not found|too many requests|rate limit/.test(m)) {
+		return "provider-4xx";
+	}
+	return undefined;
 }
 
 /**

--- a/packages/coding-agent/src/browser/chat-protocol.ts
+++ b/packages/coding-agent/src/browser/chat-protocol.ts
@@ -80,10 +80,30 @@ export interface ChatDone {
 	references?: ChatReference[];
 }
 
+/** Machine-readable cause of a terminal chat_error, so the panel can render a
+ * distinct, actionable message (and decide whether to auto-recover) instead of a
+ * generic failure. Additive/optional on the wire (contract 1.6.0); an omitted
+ * reason means an unclassified error (legacy behavior — show the error text).
+ * Shared vocabulary with the extension (keep both lists identical). */
+export const CHAT_ERROR_REASONS = [
+	"bridge-disconnected", // the worker's bridge closed mid-turn
+	"bridge-unresponsive", // the socket looked open but the worker never answered
+	"no-worker", // no worker is running for this tab
+	"session-busy", // a turn is already in flight for this session
+	"session-disposed", // the worker session was torn down
+	"token-expired", // F5 XC API token expired
+	"token-expiring", // F5 XC API token is about to expire
+	"provider-4xx", // upstream provider rejected the request (client error)
+	"provider-5xx", // upstream provider failed (server error) — retryable
+] as const;
+
+export type ChatErrorReason = (typeof CHAT_ERROR_REASONS)[number];
+
 export interface ChatError {
 	type: "chat_error";
 	id: string;
 	error: string;
+	reason?: ChatErrorReason;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/coding-agent/test/browser/extension-contract.test.ts
+++ b/packages/coding-agent/test/browser/extension-contract.test.ts
@@ -81,6 +81,10 @@ describe("extension contract drift guards", () => {
 		"diag_suspension",
 		"capture_login_flow",
 		"diag_bridges",
+		// Read-only diagnostic tools (activation-readiness + TTFT timelines) surfaced
+		// by the extension and driven via diagnostics UI, not the typed page client.
+		"diag_activation",
+		"diag_ttft",
 	]);
 
 	it("every tool the bridge client requests exists in the contract", () => {

--- a/packages/coding-agent/test/chat-handler-reason.test.ts
+++ b/packages/coding-agent/test/chat-handler-reason.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test";
+import { ChatHandler, classifyChatErrorReason } from "@f5-sales-demo/xcsh/browser/chat-handler";
+import type { BridgeServer } from "@f5-sales-demo/xcsh/browser/extension-bridge";
+import type { AgentSession, AgentSessionEvent } from "@f5-sales-demo/xcsh/session/agent-session";
+
+/** Harness exposing the bridge onMessage/onDisconnected hooks and captured sends,
+ * with a prompt() that can be made to reject. */
+function makeFakes(opts: { isStreaming?: boolean; promptRejects?: string } = {}) {
+	const sent: Record<string, unknown>[] = [];
+	let onMsg: (m: Record<string, unknown>) => void = () => {};
+	let onDisc: () => void = () => {};
+	const server = {
+		send: (p: unknown) => sent.push(p as Record<string, unknown>),
+		onMessage: (cb: (m: Record<string, unknown>) => void) => {
+			onMsg = cb;
+		},
+		onDisconnected: (cb: () => void) => {
+			onDisc = cb;
+		},
+	} as unknown as BridgeServer;
+	const session = {
+		isStreaming: opts.isStreaming ?? false,
+		agent: { replaceMessages() {}, abort() {} },
+		subscribe: (_cb: (e: AgentSessionEvent) => void) => () => {},
+		prompt: async () => {
+			if (opts.promptRejects) throw new Error(opts.promptRejects);
+		},
+	} as unknown as AgentSession;
+	return { sent, server, session, fire: (m: Record<string, unknown>) => onMsg(m), disconnect: () => onDisc() };
+}
+
+const errorsOf = (sent: Record<string, unknown>[]) => sent.filter(f => f.type === "chat_error");
+
+describe("classifyChatErrorReason", () => {
+	it("maps token-expiry phrasing to token-expired", () => {
+		expect(classifyChatErrorReason("Token is expired. Run aws sso login")).toBe("token-expired");
+		expect(classifyChatErrorReason("F5 XC API token expired — run /context create")).toBe("token-expired");
+	});
+	it("maps 5xx / network failures to provider-5xx (retryable)", () => {
+		expect(classifyChatErrorReason("HTTP 503 Service Unavailable")).toBe("provider-5xx");
+		expect(classifyChatErrorReason("socket hang up")).toBe("provider-5xx");
+	});
+	it("maps 4xx / bad-model to provider-4xx", () => {
+		expect(classifyChatErrorReason("HTTP 400 Invalid model name")).toBe("provider-4xx");
+		expect(classifyChatErrorReason("403 forbidden")).toBe("provider-4xx");
+	});
+	it("returns undefined for an unclassified error (panel shows raw text)", () => {
+		expect(classifyChatErrorReason("something weird happened")).toBeUndefined();
+	});
+});
+
+describe("ChatHandler emits a machine-readable reason on every terminal chat_error", () => {
+	it("session-busy → reason 'session-busy'", async () => {
+		const { sent, server, session, fire } = makeFakes({ isStreaming: true });
+		new ChatHandler(server, session).attach();
+		await fire({ type: "chat_request", id: "c-1", text: "hi", context: null, mode: "educational" });
+		await new Promise(r => setTimeout(r, 5));
+		expect(errorsOf(sent)).toEqual([
+			{ type: "chat_error", id: "c-1", error: "session busy", reason: "session-busy" },
+		]);
+	});
+
+	it("bridge disconnect mid-turn → reason 'bridge-disconnected'", async () => {
+		const { sent, server, session, fire, disconnect } = makeFakes({ promptRejects: undefined });
+		new ChatHandler(server, session).attach();
+		// Start a turn but keep it pending by never resolving deltas; then disconnect.
+		void fire({ type: "chat_request", id: "c-2", text: "hi", context: null, mode: "educational" });
+		disconnect();
+		const err = errorsOf(sent).find(e => e.reason === "bridge-disconnected");
+		expect(err).toEqual({
+			type: "chat_error",
+			id: "c-2",
+			error: "bridge disconnected",
+			reason: "bridge-disconnected",
+		});
+	});
+
+	it("prompt rejection → classified reason (provider-4xx)", async () => {
+		const { sent, server, session, fire } = makeFakes({ promptRejects: "HTTP 400 Invalid model name" });
+		new ChatHandler(server, session).attach();
+		await fire({ type: "chat_request", id: "c-3", text: "hi", context: null, mode: "educational" });
+		await new Promise(r => setTimeout(r, 5));
+		const err = errorsOf(sent).find(e => e.id === "c-3" && e.type === "chat_error");
+		expect(err?.reason).toBe("provider-4xx");
+	});
+
+	it("dispose with an in-flight turn → reason 'session-disposed'", async () => {
+		const { sent, server, session, fire } = makeFakes();
+		const handler = new ChatHandler(server, session);
+		handler.attach();
+		void fire({ type: "chat_request", id: "c-4", text: "hi", context: null, mode: "educational" });
+		handler.dispose();
+		const err = errorsOf(sent).find(e => e.reason === "session-disposed");
+		expect(err).toEqual({ type: "chat_error", id: "c-4", error: "session disposed", reason: "session-disposed" });
+	});
+});


### PR DESCRIPTION
Adds an additive, optional `reason` to `chat_error` so the extension panel can render distinct, actionable failures and drive auto-recovery. Foundational for the "Turn aborted." self-heal effort.

## Changes
- `chat-protocol.ts`: shared closed vocabulary `CHAT_ERROR_REASONS` + `ChatErrorReason`; `reason?` on `ChatError`.
- `chat-handler.ts`: tags every terminal emit; `classifyChatErrorReason` (token / 4xx / 5xx / network).
- `chat-conformance.json`: `reason` schema + example, contract **1.6.0**.
- `capabilities.json` / `capabilities.generated.ts`: re-vendored from the extension at 1.6.0 (also syncs the `diag_activation` / `diag_ttft` read-only descriptors).

## Tests
`classifyChatErrorReason` mapping; each terminal emit carries the correct reason; xcsh chat-conformance suite green; strict `tsgo` + biome clean.

## Cross-repo (ship together)
Paired with extension PR (same vocabulary, generated `chat-conformance.json`, `CONTRACT_VERSION` bump). Minor/additive — `planHelloAck` rejects only on MAJOR mismatch, so 1.5 ↔ 1.6 interoperate during rollout.

Closes #1926

🤖 Generated with [Claude Code](https://claude.com/claude-code)