### PR TITLE
fix(coding-agent): manager self-recycles when its binary was removed by an upgrade

### DIFF
--- a/packages/coding-agent/src/commands/manager-core.ts
+++ b/packages/coding-agent/src/commands/manager-core.ts
@@ -131,6 +131,25 @@ export function touchLastSeen(reg: Registry, sessionId: string | undefined, now:
 	return true;
 }
 
+/** True iff this manager should self-recycle because it is running a STALE on-disk
+ * binary. Only for a COMPILED install: after `brew upgrade` + `brew cleanup`, the old
+ * versioned binary the manager was launched from is DELETED, yet the process lingers
+ * on the freed inode — and can no longer spawn workers/spares (spawn ENOENT), which
+ * surfaces as the extension's "xcsh didn't start". Detecting the deleted binary lets
+ * the manager step down so a fresh one (launched from the version-stable PATH wrapper)
+ * takes over. Dev (`bun src/cli.ts`) has a live interpreter execPath → never stale.
+ * Fail-closed: any error from `exists` → NOT stale, so uncertainty never triggers a
+ * recycle loop. Only the unambiguous deleted-binary signal is used (a version/realpath
+ * drift signal was deliberately NOT added — false positives would flap-recycle). */
+export function binaryIsStale(opts: { compiled: boolean; execPath: string; exists: (p: string) => boolean }): boolean {
+	if (!opts.compiled) return false;
+	try {
+		return !opts.exists(opts.execPath);
+	} catch {
+		return false;
+	}
+}
+
 /** The NDJSON keepalive an actively-chatting worker writes to the manager control
  * socket to refresh its `lastSeen` (consumed by `touchLastSeen`). Null for the
  * unbound `spare` sentinel or an empty id — a spare has no session to keep alive. */

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -26,8 +26,11 @@ import { Command } from "@f5-sales-demo/pi-utils/cli";
 // slows the manager's cold start — keep the daemon's module graph minimal).
 import { VERSION } from "@f5-sales-demo/pi-utils/dirs";
 import { portCandidates } from "../browser/extension-bridge";
+// Lean standalone fn (compiled-runtime detection) — no heavy graph, safe for the daemon.
+import { detectCompiledRuntime } from "../internal-urls/build-info-runtime";
 import { removeManagerState, writeManagerState } from "../services/manager-state";
 import {
+	binaryIsStale,
 	needsProvision,
 	parseControlMsg,
 	pickPort,
@@ -208,6 +211,17 @@ export default class Manager extends Command {
 		// via env ONLY so the supersede integration tests can stand up an "old" manager
 		// (production always reports the real binary VERSION).
 		const selfVersion = process.env.XCSH_MANAGER_VERSION || VERSION;
+
+		// Durable-upgrade self-recycle (#upgrade-recycle): a compiled manager whose
+		// on-disk binary was removed by `brew upgrade`+`brew cleanup` lingers on the
+		// freed inode but can no longer spawn workers (ENOENT) → it must step down so a
+		// fresh manager (from the version-stable PATH wrapper) takes over. Dev is never
+		// compiled → never stale. `XCSH_FORCE_STALE=1` lets the dev-mode integration test
+		// exercise the recycle path (same env-override convention as XCSH_MANAGER_VERSION).
+		const compiled = detectCompiledRuntime(import.meta.url, Bun.env);
+		const isSelfStale = (): boolean =>
+			process.env.XCSH_FORCE_STALE === "1" ||
+			binaryIsStale({ compiled, execPath: process.execPath, exists: fs.existsSync });
 
 		// Lifecycle gate (#1874): once we begin graceful shutdown we stop accepting
 		// provisions (the host retries the successor manager) and never double-run
@@ -430,12 +444,21 @@ export default class Manager extends Command {
 			const msg = parseControlMsg(raw);
 			if (!msg) return; // fail closed on unknown/invalid frames
 			if (msg.type === "provision") {
-				// Draining: refuse new work so the host retries the successor manager.
-				if (!accepting) {
+				// Draining, OR self-stale (our binary was removed by an upgrade): refuse
+				// this provision so the host retries the successor manager — spawning now
+				// would ENOENT on the deleted binary. If stale-but-still-accepting, step
+				// down immediately so the fresh manager takes over in seconds (not on the
+				// ≤60s sweep). Reuses the existing draining reply/contract.
+				const stale = accepting && isSelfStale();
+				if (!accepting || stale) {
 					try {
 						socket.write(`${JSON.stringify({ type: "draining" })}\n`);
 					} catch {
 						/* client hung up */
+					}
+					if (stale) {
+						console.error("[xcsh manager] binary is stale (upgraded/removed) — recycling on provision");
+						gracefulShutdown("updated");
 					}
 					return;
 				}
@@ -537,8 +560,15 @@ export default class Manager extends Command {
 		// Pre-warm the spare pool so provisions can adopt instead of cold-spawn.
 		if (poolTarget > 0) maintainPool();
 
-		// Idle sweep: reap workers untouched for longer than the TTL.
+		// Idle sweep: reap workers untouched for longer than the TTL. Also self-recycle
+		// if our own binary went stale (upgrade removed it) — a lingering deleted-binary
+		// manager can't spawn workers, so step down for a fresh one (#upgrade-recycle).
 		setInterval(() => {
+			if (isSelfStale()) {
+				console.error("[xcsh manager] binary is stale (upgraded/removed) — recycling on sweep");
+				gracefulShutdown("updated");
+				return;
+			}
 			for (const key of staleKeys(reg, Date.now(), IDLE_MS)) reap(key);
 		}, SWEEP_MS);
 

--- a/packages/coding-agent/test/manager-core.test.ts
+++ b/packages/coding-agent/test/manager-core.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, test } from "bun:test";
 import { sparesToSpawn } from "@f5-sales-demo/xcsh/commands/manager-core";
 import {
+	binaryIsStale,
 	keepaliveFrame,
 	type ManagerState,
 	needsProvision,
@@ -153,6 +154,34 @@ describe("touchLastSeen", () => {
 		expect(touchLastSeen(r, "ghost", 999)).toBe(false);
 		expect(touchLastSeen(r, undefined, 999)).toBe(false);
 		expect(r.get("tab-7")?.lastSeen).toBe(5); // untouched
+	});
+});
+
+// Durable-upgrade self-recycle (#upgrade-recycle): a COMPILED manager whose on-disk
+// binary was removed (brew cleanup after `brew upgrade`) can no longer spawn workers
+// (spawn ENOENT), so it must step down and let a fresh manager take over. Dev
+// (`bun src/cli.ts`, compiled=false) is never stale; fail-closed on any fs error so
+// uncertainty never triggers a recycle loop.
+describe("binaryIsStale", () => {
+	const exists = (present: boolean) => () => present;
+	test("compiled + binary missing → stale (the brew-cleanup case)", () => {
+		expect(
+			binaryIsStale({ compiled: true, execPath: "/opt/homebrew/Cellar/xcsh/old/bin/xcsh", exists: exists(false) }),
+		).toBe(true);
+	});
+	test("compiled + binary present → not stale", () => {
+		expect(
+			binaryIsStale({ compiled: true, execPath: "/opt/homebrew/Cellar/xcsh/cur/bin/xcsh", exists: exists(true) }),
+		).toBe(false);
+	});
+	test("dev (not compiled) is never stale, even if the path is missing", () => {
+		expect(binaryIsStale({ compiled: false, execPath: "/usr/local/bin/bun", exists: exists(false) })).toBe(false);
+	});
+	test("fail-closed: a throwing exists() is treated as NOT stale (never recycle on uncertainty)", () => {
+		const throws = () => {
+			throw new Error("fs blew up");
+		};
+		expect(binaryIsStale({ compiled: true, execPath: "/x", exists: throws })).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -108,13 +108,13 @@ async function request(msg: unknown, timeoutMs = 2000): Promise<Record<string, u
 }
 
 /** Spawn a fresh manager on a temp socket and wait for it to bind. */
-async function startManager(): Promise<void> {
+async function startManager(extraEnv: Record<string, string> = {}): Promise<void> {
 	sock = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-mgr-")), "manager.sock");
 	mgr = Bun.spawn(["bun", "src/cli.ts", "manager"], {
 		cwd: process.cwd(),
 		// Cold-spawn tests below assert on the 4-port RANGE; disable the pre-warm pool
 		// so spares don't occupy those ports. Pool behavior is covered by its own tests.
-		env: { ...process.env, XCSH_MANAGER_SOCK: sock, XCSH_WORKER_POOL_SIZE: "0" },
+		env: { ...process.env, XCSH_MANAGER_SOCK: sock, XCSH_WORKER_POOL_SIZE: "0", ...extraEnv },
 		stdout: "ignore",
 		stderr: "ignore",
 	});
@@ -709,3 +709,35 @@ test("warm adopt emits worker_boot span with cold=false", async () => {
 	expect(wb!.cold).toBe(false);
 	expect(wb!.sid).toBe("tab-777");
 }, 60_000);
+
+// #upgrade-recycle: a manager whose binary was removed by `brew upgrade`+`brew cleanup`
+// can no longer spawn workers, so it must step down on the next provision (XCSH_FORCE_STALE
+// simulates the deleted binary in the dev harness, which is otherwise never "compiled").
+test("a manager on a STALE binary refuses the next provision (draining) and steps down", async () => {
+	await startManager({ XCSH_FORCE_STALE: "1" });
+	// Spawning would ENOENT on the deleted binary → the provision is refused with the
+	// existing `draining` contract so the host retries the successor manager.
+	const reply = await request({ type: "provision", sessionId: "tab-1", tenant: "acme|staging" });
+	expect(reply).toEqual({ type: "draining" });
+	// gracefulShutdown("updated") removes the socket + manager.json and exits.
+	let gone = false;
+	for (let i = 0; i < 50; i++) {
+		if (!fs.existsSync(sock)) {
+			gone = true;
+			break;
+		}
+		await Bun.sleep(100);
+	}
+	expect(gone).toBe(true);
+}, 30_000);
+
+test("a HEALTHY manager (present binary) never recycles — provisions normally, stays up", async () => {
+	await startManager(); // dev binary present → not stale
+	// A normal provision writes NO control reply (only draining does) → request times out → null.
+	const reply = await request({ type: "provision", sessionId: "tab-1", tenant: "acme|staging" }, 1500);
+	expect(reply).toBeNull(); // NOT draining — the manager served it
+	// Still alive: socket persists and the hello handshake still answers.
+	expect(fs.existsSync(sock)).toBe(true);
+	const ack = await request({ type: "hello" });
+	expect(ack?.type).toBe("manager_hello_ack");
+}, 30_000);


### PR DESCRIPTION
Fixes the stale-manager-after-`brew upgrade` bug (the "xcsh didn't start" churn). The old manager lingered on a **deleted** Cellar binary and couldn't spawn workers; nothing detected it because the #1874 supersede is client-side, one-shot, and binary-blind.

## What changed
- `manager-core.ts`: pure `binaryIsStale({compiled, execPath, exists})` → `compiled && !exists(execPath)`, **fail-closed** on any error.
- `manager.ts`: `compiled` via `detectCompiledRuntime` at startup; self-recycle (`gracefulShutdown("updated")`, workers preserved) in the idle sweep **and** opportunistically on the next `provision` (reply `draining` + step down — spawning would ENOENT). `XCSH_FORCE_STALE=1` test hook.

## Why this is the keystone
Recycling the manager cascades: socket closes → the old chrome-host already exits on socket close → SW reconnects on next provision → fresh chrome-host from the version-stable PATH wrapper → fresh manager with a valid binary. No spawn-path rewrite, no version skew.

## Safety (given tonight's watchdog regression)
Only the **unambiguous deleted-binary** signal — realpath/version-drift deliberately omitted (false positives would flap-recycle). Fail-closed on fs uncertainty. Dev (`bun src/cli.ts`) is never compiled → never stale.

## Tests
- `binaryIsStale` table (compiled/dev × present/missing/throws).
- Integration: a stale manager refuses the next provision (`draining`) and steps down (socket freed); a **healthy** manager never recycles (provisions normally, stays up, hello still answers).
- `bunx tsgo` + biome clean.
- Real-machine (documented follow-up): actual compiled `fs.existsSync(process.execPath)` after a real `brew upgrade`/`brew cleanup`.

Closes #1930 · first of 3 in the upgrade-recycle effort (extension gate budget + brew post_install to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)