### PR TITLE
feat(ci): brew post_install recycles the manager on upgrade

### DIFF
--- a/packages/coding-agent/test/scripts/homebrew-formula.test.ts
+++ b/packages/coding-agent/test/scripts/homebrew-formula.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { generateFormula } from "../../../../scripts/ci-release-homebrew";
+
+/**
+ * Guard for the brew `post_install` recycle hook (#upgrade-recycle).
+ *
+ * `brew upgrade` drops the new binary + repoints the symlink but runs no xcsh hook,
+ * so the old detached manager lingered on the replaced binary. The generated formula
+ * now carries a `post_install` that runs `xcsh chrome recycle` (refresh the native-
+ * messaging wrapper + step the old manager down) using the just-installed binary. It
+ * is rescue-wrapped so a sandboxed/offline post_install can never fail the upgrade —
+ * the manager also self-recycles on its next sweep/provision (xcsh #1930).
+ */
+describe("homebrew formula post_install recycle", () => {
+	const formula = generateFormula(
+		"19.99.0",
+		"v19.99.0",
+		new Map([
+			["xcsh-darwin-x64.zip", "aaa"],
+			["xcsh-darwin-arm64.zip", "bbb"],
+			["xcsh-linux-x64.tar.gz", "ccc"],
+			["xcsh-linux-arm64.tar.gz", "ddd"],
+		]),
+	);
+
+	it("emits a rescue-wrapped post_install that runs `xcsh chrome recycle`", () => {
+		expect(formula).toContain("def post_install");
+		expect(formula).toContain('system bin/"xcsh", "chrome", "recycle"');
+		expect(formula).toContain("rescue StandardError"); // never fails the upgrade
+	});
+
+	it("still installs the binary for every arch and carries the version", () => {
+		expect(formula.match(/bin\.install "xcsh"/g)?.length).toBe(4); // 2 macOS + 2 linux
+		expect(formula).toContain('version "19.99.0"');
+	});
+});

--- a/scripts/ci-release-homebrew.ts
+++ b/scripts/ci-release-homebrew.ts
@@ -109,7 +109,7 @@ async function computeChecksums(): Promise<Map<string, string>> {
 	return checksums;
 }
 
-function generateFormula(version: string, tag: string, checksums: Map<string, string>): string {
+export function generateFormula(version: string, tag: string, checksums: Map<string, string>): string {
 	const sha = (archive: string) => checksums.get(archive) || "MISSING_SHA256";
 
 	return `# typed: false
@@ -158,6 +158,18 @@ class Xcsh < Formula
         bin.install "xcsh"
       end
     end
+  end
+
+  # After brew (re)installs the binary, recycle the running manager so the upgrade
+  # takes effect immediately: refresh the native-messaging wrapper and ask the old
+  # manager to step down (it lingers on the now-replaced binary otherwise). Uses the
+  # just-installed binary, so the new version drives it. Best-effort — rescued so a
+  # sandboxed or offline post_install can never fail the upgrade; the manager also
+  # self-recycles on its next sweep/provision.
+  def post_install
+    system bin/"xcsh", "chrome", "recycle"
+  rescue StandardError
+    nil
   end
 end
 `;
@@ -218,4 +230,6 @@ async function main(): Promise<void> {
 	}
 }
 
-await main();
+// Guard so the module can be imported by tests (generateFormula) without running the
+// release side-effects; only executes when invoked directly (`bun scripts/…`).
+if (import.meta.main) await main();


### PR DESCRIPTION
`brew upgrade` runs no xcsh hook today, so the old manager lingers on the replaced binary until a lazy Chrome relaunch. Add a rescue-wrapped `post_install` to the generated formula that recycles immediately with the **new** binary. Part 3 of the upgrade-recycle effort (keystone = manager self-recycle, xcsh #1931; gate budget, ext #234).

## What changed (`scripts/ci-release-homebrew.ts`)
- `generateFormula` emits a class-level `post_install` → `system bin/"xcsh", "chrome", "recycle"`, wrapped `rescue StandardError; nil` so a sandboxed/offline post_install can never fail `brew upgrade`.
- `export function generateFormula` + `if (import.meta.main) await main()` so the module is unit-testable without running the release side-effects.

## Why safe / layered
`chrome recycle` refreshes the native-messaging wrapper + best-effort `requestManagerShutdown("updated")` (already time-bounded/try-catch). If brew's sandbox blocks the `~/Library` write or the `~/.xcsh/manager.sock` connect, it silently no-ops and **PR1's manager self-recycle still recovers** on the next sweep/provision.

## Tests
- New formula snapshot test: asserts the rescue-wrapped `post_install`, 4× `bin.install`, version. `tsgo` (workspace + tools) + biome clean. Rendered formula verified as valid Ruby.
- **Real-machine follow-up:** whether brew's `post_install` sandbox permits the wrapper write + socket connect — documented; PR1 backstops either way.

Closes #1932

🤖 Generated with [Claude Code](https://claude.com/claude-code)