### PR TITLE
chore: bump version to v19.63.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "pi-natives"
-version = "19.62.0"
+version = "19.63.0"
 dependencies = [
  "arboard",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/brush-core-vendored", "crates/brush-builtins-vendored", "crat
 resolver = "3"
 
 [workspace.package]
-version = "19.62.0"
+version = "19.63.0"
 edition = "2024"
 license = "MIT"
 authors = ["Can Boluk"]

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/agent": {
       "name": "@f5-sales-demo/pi-agent-core",
-      "version": "19.62.0",
+      "version": "19.63.0",
       "dependencies": {
         "@f5-sales-demo/pi-ai": "workspace:*",
         "@f5-sales-demo/pi-utils": "workspace:*",
@@ -28,7 +28,7 @@
     },
     "packages/ai": {
       "name": "@f5-sales-demo/pi-ai",
-      "version": "19.62.0",
+      "version": "19.63.0",
       "bin": {
         "pi-ai": "./src/cli.ts",
       },
@@ -52,7 +52,7 @@
     },
     "packages/coding-agent": {
       "name": "@f5-sales-demo/xcsh",
-      "version": "19.62.0",
+      "version": "19.63.0",
       "bin": {
         "xcsh": "src/cli.ts",
       },
@@ -86,22 +86,22 @@
     },
     "packages/natives": {
       "name": "@f5-sales-demo/pi-natives",
-      "version": "19.62.0",
+      "version": "19.63.0",
       "devDependencies": {
         "@napi-rs/cli": "3.6.0",
         "@types/bun": "^1.3",
       },
       "optionalDependencies": {
-        "@f5-sales-demo/pi-natives-darwin-arm64": "19.62.0",
-        "@f5-sales-demo/pi-natives-darwin-x64": "19.62.0",
-        "@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.62.0",
-        "@f5-sales-demo/pi-natives-linux-x64-gnu": "19.62.0",
-        "@f5-sales-demo/pi-natives-win32-x64-msvc": "19.62.0",
+        "@f5-sales-demo/pi-natives-darwin-arm64": "19.63.0",
+        "@f5-sales-demo/pi-natives-darwin-x64": "19.63.0",
+        "@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.63.0",
+        "@f5-sales-demo/pi-natives-linux-x64-gnu": "19.63.0",
+        "@f5-sales-demo/pi-natives-win32-x64-msvc": "19.63.0",
       },
     },
     "packages/resource-management": {
       "name": "@f5-sales-demo/pi-resource-management",
-      "version": "19.62.0",
+      "version": "19.63.0",
       "dependencies": {
         "yaml": "2.9.0",
       },
@@ -111,7 +111,7 @@
     },
     "packages/stats": {
       "name": "@f5-sales-demo/xcsh-stats",
-      "version": "19.62.0",
+      "version": "19.63.0",
       "bin": {
         "xcsh-stats": "./src/index.ts",
       },
@@ -136,7 +136,7 @@
     },
     "packages/swarm-extension": {
       "name": "@f5-sales-demo/swarm-extension",
-      "version": "19.62.0",
+      "version": "19.63.0",
       "bin": {
         "xcsh-swarm": "src/cli.ts",
       },
@@ -152,7 +152,7 @@
     },
     "packages/tui": {
       "name": "@f5-sales-demo/pi-tui",
-      "version": "19.62.0",
+      "version": "19.63.0",
       "dependencies": {
         "@f5-sales-demo/pi-natives": "workspace:*",
         "@f5-sales-demo/pi-utils": "workspace:*",
@@ -191,7 +191,7 @@
     },
     "packages/utils": {
       "name": "@f5-sales-demo/pi-utils",
-      "version": "19.62.0",
+      "version": "19.63.0",
       "dependencies": {
         "@f5-sales-demo/i18n-core": "^1.0.0",
         "beautiful-mermaid": "^1.1",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-agent-core",
-	"version": "19.62.0",
+	"version": "19.63.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-ai",
-	"version": "19.62.0",
+	"version": "19.63.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/xcsh",
-	"version": "19.62.0",
+	"version": "19.63.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-arm64/package.json
+++ b/packages/natives/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-darwin-arm64",
-	"version": "19.62.0",
+	"version": "19.63.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (macOS arm64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-x64/package.json
+++ b/packages/natives/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-darwin-x64",
-	"version": "19.62.0",
+	"version": "19.63.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (macOS x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-arm64-gnu/package.json
+++ b/packages/natives/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-linux-arm64-gnu",
-	"version": "19.62.0",
+	"version": "19.63.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Linux arm64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-x64-gnu/package.json
+++ b/packages/natives/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-linux-x64-gnu",
-	"version": "19.62.0",
+	"version": "19.63.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Linux x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/win32-x64-msvc/package.json
+++ b/packages/natives/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-win32-x64-msvc",
-	"version": "19.62.0",
+	"version": "19.63.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Windows x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives",
-	"version": "19.62.0",
+	"version": "19.63.0",
 	"description": "Native Rust bindings for grep, clipboard, image processing, syntax highlighting, PTY, and shell operations via N-API",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",
@@ -56,11 +56,11 @@
 		}
 	},
 	"optionalDependencies": {
-		"@f5-sales-demo/pi-natives-linux-x64-gnu": "19.62.0",
-		"@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.62.0",
-		"@f5-sales-demo/pi-natives-darwin-x64": "19.62.0",
-		"@f5-sales-demo/pi-natives-darwin-arm64": "19.62.0",
-		"@f5-sales-demo/pi-natives-win32-x64-msvc": "19.62.0"
+		"@f5-sales-demo/pi-natives-linux-x64-gnu": "19.63.0",
+		"@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.63.0",
+		"@f5-sales-demo/pi-natives-darwin-x64": "19.63.0",
+		"@f5-sales-demo/pi-natives-darwin-arm64": "19.63.0",
+		"@f5-sales-demo/pi-natives-win32-x64-msvc": "19.63.0"
 	},
 	"files": [
 		"native",

--- a/packages/resource-management/package.json
+++ b/packages/resource-management/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-resource-management",
-	"version": "19.62.0",
+	"version": "19.63.0",
 	"description": "Shared resource management for F5 XC manifest parsing, validation, diff, and CRUD operations",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Robin Mordasiewicz",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/xcsh-stats",
-	"version": "19.62.0",
+	"version": "19.63.0",
 	"description": "Local observability dashboard for pi AI usage statistics",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/swarm-extension/package.json
+++ b/packages/swarm-extension/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/swarm-extension",
-	"version": "19.62.0",
+	"version": "19.63.0",
 	"description": "Swarm orchestration extension for xcsh",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Derek Rynd",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-tui",
-	"version": "19.62.0",
+	"version": "19.63.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-utils",
-	"version": "19.62.0",
+	"version": "19.63.0",
 	"description": "Shared utilities for pi packages",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",


### PR DESCRIPTION
Automated release PR generated by `scripts/release.ts`.

Bumps every public package and the Cargo workspace to `v19.63.0` and updates CHANGELOGs for the releasable commits since the last tag.

Once this PR squash-merges to `main`, `.github/workflows/tag-on-version-bump.yml` pushes the `v19.63.0` git tag, which triggers the downstream release chain (build → sign → publish).

### Releasable commits (2)

- feat(ci): brew post_install recycles the manager on upgrade (#1933)
- fix(coding-agent): manager self-recycles when its binary was removed by an upgrade (#1931)

See `docs-control`'s onboarding note "Release automation: release PR pattern" for the governance rationale.