### PR TITLE
fix(ci): make auto-release idempotent (supersede stale phantom release PRs)

### DIFF
--- a/packages/coding-agent/test/scripts/release-reconcile.test.ts
+++ b/packages/coding-agent/test/scripts/release-reconcile.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { planReleaseReconcile } from "../../../../scripts/release";
+
+/**
+ * Idempotent auto-release reconcile (#deterministic-ci).
+ *
+ * `auto-release` runs `release.ts auto` on each non-chore main push. Running it for
+ * a fix (→ patch) and then a feat (→ minor) used to leave TWO release branches
+ * (e.g. v19.62.1 AND v19.63.0); when the patch merged first, the minor was stranded
+ * as a CONFLICTING phantom. There must be exactly ONE canonical next version (or
+ * none), so `planReleaseReconcile` closes every open release PR that isn't the
+ * target and creates the target only when it isn't already open. Pure + deterministic:
+ * the same (open PRs, target) always yields the same plan, so re-running converges.
+ */
+describe("planReleaseReconcile", () => {
+	it("closes stale phantom release PRs, keeps/creates only the canonical target", () => {
+		// The exact bug: v19.63.0 stranded after v19.62.1 shipped the same commits.
+		expect(planReleaseReconcile({ openReleaseVersions: ["19.63.0"], target: "19.62.2" })).toEqual({
+			toCreate: "19.62.2",
+			toClose: ["19.63.0"],
+		});
+	});
+
+	it("creates the target when no release PR is open", () => {
+		expect(planReleaseReconcile({ openReleaseVersions: [], target: "19.62.2" })).toEqual({
+			toCreate: "19.62.2",
+			toClose: [],
+		});
+	});
+
+	it("is idempotent: the target already open → nothing to create or close", () => {
+		expect(planReleaseReconcile({ openReleaseVersions: ["19.62.2"], target: "19.62.2" })).toEqual({
+			toCreate: null,
+			toClose: [],
+		});
+	});
+
+	it("no releasable commits (target null) → closes ALL open release PRs (phantoms), creates nothing", () => {
+		expect(planReleaseReconcile({ openReleaseVersions: ["19.63.0", "19.62.2"], target: null })).toEqual({
+			toCreate: null,
+			toClose: ["19.63.0", "19.62.2"],
+		});
+	});
+
+	it("closes multiple stale versions while keeping the canonical one open", () => {
+		expect(
+			planReleaseReconcile({ openReleaseVersions: ["19.62.2", "19.63.0", "20.0.0"], target: "19.62.2" }),
+		).toEqual({ toCreate: null, toClose: ["19.63.0", "20.0.0"] });
+	});
+});

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -479,13 +479,63 @@ async function detectVersionBump(): Promise<{ version: string; bump: BumpType; c
 	};
 }
 
+/** Idempotent reconcile plan for the set of open `release/vX.Y.Z` PRs. There must be
+ * exactly ONE canonical next version (or none): any open release PR whose version
+ * isn't `target` is a stale/superseded phantom (e.g. a v19.63.0 stranded after a
+ * v19.62.1 shipped the same commit range) and must be closed; the target is created
+ * only when it isn't already open. Pure + deterministic — running it repeatedly on
+ * the same (open PRs, target) always yields the same plan, so `auto-release`
+ * converges instead of accumulating conflicting release branches. */
+export function planReleaseReconcile(opts: { openReleaseVersions: string[]; target: string | null }): {
+	toCreate: string | null;
+	toClose: string[];
+} {
+	const toClose = opts.openReleaseVersions.filter(v => v !== opts.target);
+	const toCreate = opts.target && !opts.openReleaseVersions.includes(opts.target) ? opts.target : null;
+	return { toCreate, toClose };
+}
+
+/** Versions of the currently-open `release/vX.Y.Z` PRs (best-effort; [] on error). */
+async function listOpenReleaseVersions(): Promise<string[]> {
+	try {
+		const out = await $`gh pr list --state open --limit 50 --json headRefName`.text();
+		const prs = JSON.parse(out) as { headRefName: string }[];
+		return prs
+			.map(p => p.headRefName)
+			.filter(b => /^release\/v\d+\.\d+\.\d+$/.test(b))
+			.map(b => b.replace(/^release\/v/, ""));
+	} catch {
+		return [];
+	}
+}
+
+/** Close a stale/superseded release PR and delete its branch (best-effort, non-fatal). */
+async function closeStaleReleasePR(version: string): Promise<void> {
+	const branch = `release/v${version}`;
+	console.log(`Superseding stale release PR ${branch}…`);
+	try {
+		await $`gh pr close ${branch} --delete-branch --comment ${"Superseded by the canonical auto-release target (idempotent reconcile); these commits are covered by a newer release PR or an already-published tag."}`;
+	} catch (e) {
+		console.warn(`  (could not close ${branch}: ${e}) — non-fatal`);
+	}
+}
+
 async function cmdAutoRelease(): Promise<void> {
 	console.log("\n=== Auto Release Detection ===\n");
 
 	const result = await detectVersionBump();
+	const target = result?.version ?? null;
+
+	// Idempotent reconcile: converge to exactly one canonical release PR (or none),
+	// closing any stale/phantom release PRs a prior run left behind. Deterministic —
+	// re-running with the same repo state yields the same open-release-PR set, so a
+	// stranded conflicting release branch is cleaned programmatically, not by hand.
+	const openVersions = await listOpenReleaseVersions();
+	const plan = planReleaseReconcile({ openReleaseVersions: openVersions, target });
+	for (const v of plan.toClose) await closeStaleReleasePR(v);
 
 	if (!result) {
-		console.log("No releasable changes since last tag. Skipping release.");
+		console.log("No releasable changes since last tag. No release PR needed.");
 		process.exit(0);
 	}
 
@@ -496,34 +546,42 @@ async function cmdAutoRelease(): Promise<void> {
 	}
 	console.log();
 
-	await cmdRelease(result.version, result.commits);
+	if (plan.toCreate) {
+		await cmdRelease(result.version, result.commits);
+	} else {
+		console.log(`Release PR for v${result.version} is already open — nothing to create.`);
+	}
 }
 
 // =============================================================================
 // Main
 // =============================================================================
 
-const arg = process.argv[2];
+// Guarded so the module can be imported by tests (planReleaseReconcile) without
+// running the CLI dispatch; only executes when invoked directly (`bun scripts/…`).
+if (import.meta.main) {
+	const arg = process.argv[2];
 
-if (!arg) {
-	console.error("Usage:");
-	console.error("  bun scripts/release.ts <version>   Open a release PR that bumps to <version>");
-	console.error("  bun scripts/release.ts auto        Detect version from conventional commits + open release PR");
-	console.error("  bun scripts/release.ts watch       Watch CI for current commit");
-	process.exit(1);
-}
+	if (!arg) {
+		console.error("Usage:");
+		console.error("  bun scripts/release.ts <version>   Open a release PR that bumps to <version>");
+		console.error("  bun scripts/release.ts auto        Detect version from conventional commits + open release PR");
+		console.error("  bun scripts/release.ts watch       Watch CI for current commit");
+		process.exit(1);
+	}
 
-if (arg === "watch") {
-	await cmdWatch();
-} else if (arg === "auto") {
-	await cmdAutoRelease();
-} else if (/^\d+\.\d+\.\d+/.test(arg)) {
-	await cmdRelease(arg);
-} else {
-	console.error(`Unknown command or invalid version: ${arg}`);
-	console.error("Usage:");
-	console.error("  bun scripts/release.ts <version>   Open a release PR that bumps to <version>");
-	console.error("  bun scripts/release.ts auto        Detect version from conventional commits + open release PR");
-	console.error("  bun scripts/release.ts watch       Watch CI for current commit");
-	process.exit(1);
+	if (arg === "watch") {
+		await cmdWatch();
+	} else if (arg === "auto") {
+		await cmdAutoRelease();
+	} else if (/^\d+\.\d+\.\d+/.test(arg)) {
+		await cmdRelease(arg);
+	} else {
+		console.error(`Unknown command or invalid version: ${arg}`);
+		console.error("Usage:");
+		console.error("  bun scripts/release.ts <version>   Open a release PR that bumps to <version>");
+		console.error("  bun scripts/release.ts auto        Detect version from conventional commits + open release PR");
+		console.error("  bun scripts/release.ts watch       Watch CI for current commit");
+		process.exit(1);
+	}
 }


### PR DESCRIPTION
Fixes the non-deterministic auto-release that stranded a conflicting phantom `release/v19.63.0` (#1935) after `v19.62.1` shipped the same commits. Per the "programmatic, idempotent, deterministic CI — no manual bandaids" principle.

## Root cause
`openReleasePR` only bailed for the *same* version, so an overlapping `fix`(patch) + `feat`(minor) opened **two** release branches; the one that didn't merge first became a conflicting phantom requiring a manual rebase.

## Fix
- Pure, tested `planReleaseReconcile({openReleaseVersions, target})` → `{toCreate, toClose}`: one canonical target (or none); close every open release PR ≠ target; create the target only when absent.
- `cmdAutoRelease` now reconciles on every run — lists open `release/v*` PRs, closes stale ones (`gh pr close --delete-branch`, best-effort/non-fatal), creates the canonical one only if missing. **Re-running converges** to a single correct release PR (or none).
- Guard the CLI dispatch behind `import.meta.main` so the module is importable for tests; verified the CLI still dispatches when run directly (no-arg → usage + exit 1).

## Verified
- `planReleaseReconcile` unit tests (phantom-close, create-when-absent, idempotent-noop, target-null-closes-all, multi-stale). Existing `release-lockfile` test still green. `tsgo` (tools) + biome clean.
- **Behaviorally confirmed on the live repo**: the reconcile closed the real stranded phantom `release/v19.63.0` (#1935) deterministically — `target=null` (nothing unreleased since v19.62.1) → closed it, created nothing.

Closes #1936