### PR TITLE
fix(coding-agent): multi-resource prompt — proceed between steps, don't inspect

### DIFF
--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -287,14 +287,20 @@ BEHAVIOR:
 
 BROWSER AUTOMATION (when the user asks to create/modify/navigate resources):
 - You are IN a Chrome browser. The active console tab is your workspace — use IT.
-- For create/modify/delete: call catalog_workflow_runner IMMEDIATELY with ONE tool call:
+- For create/modify/delete: call catalog_workflow_runner IMMEDIATELY with ONE tool call per resource:
   {"resource": "health-check", "operation": "create", "params": {"name": "foo", "namespace": "demo"}, "presentation": "guided"}
-  That's it. ONE tool call. Do NOT read API specs first, do NOT create todos, do NOT orchestrate multi-step tool chains. The catalog_workflow_runner handles ALL the form navigation internally.
+  Do NOT read API specs first, do NOT create todos, do NOT orchestrate multi-step tool chains. The catalog_workflow_runner handles ALL the form navigation internally.
 - Say a brief text message BEFORE the tool call: "Creating health check **foo** — watch the browser." Then call the tool. Nothing else.
 - The human is WATCHING the form automation (fingerprint-before-click, highlights, ~1.5s/step). Do NOT use background API calls.
 - The browser may be at 85% zoom — automation handles coordinates at any zoom.
 - The console catalog has workflows for 100+ F5 XC resources.
 - Do NOT open new tabs — drive the existing console tab.
+
+MULTI-RESOURCE REQUESTS (when the user asks to create several resources in one prompt):
+- Create resources in DEPENDENCY ORDER: health checks first, then origin pools (which reference health checks), then load balancers (which reference origin pools and app firewalls).
+- After each catalog_workflow_runner call completes, IMMEDIATELY proceed to the next resource. Do NOT inspect, verify, click into, or navigate to the resource you just created. Do NOT open the JSON view. Do NOT read the page to confirm — the tool already confirmed success. Move directly to the next creation.
+- Between resources, say ONE short line: "Health check created. Now creating origin pool **bar** — watch the browser." Then call the next tool.
+- NEVER navigate to a list/detail/JSON view between creations. Stay on the automation path.
 
 SAFETY — NEVER DO THESE:
 - NEVER kill, stop, or manage processes on port 19222 — that is YOUR OWN bridge. Killing it kills you.


### PR DESCRIPTION
When a user asks to create multiple resources in one prompt, the LLM created the first then wasted minutes navigating into the JSON inspector to verify it instead of proceeding. Observed live: health check created → LLM opened JSON view → stuck there while origin pool + LB were never started.

## Fix
Add `MULTI-RESOURCE REQUESTS` guidance to `CHROME_CHAT_SYSTEM_PROMPT`:
- Create in **dependency order** (health checks → origin pools → load balancers)
- **Immediately proceed** after each `catalog_workflow_runner` completes — do NOT inspect, verify, click-into, or open JSON view between steps
- One short transition line between resources ("Health check created. Now creating origin pool…")
- **Never navigate** to a list/detail/JSON view between creations — stay on the automation path

## Verification
29 chat-handler tests pass; `tsgo` + biome clean. Real-world verification: user sends multi-resource prompt → LLM should create each resource in sequence without inspecting intermediate results.

Closes #1950

🤖 Generated with [Claude Code](https://claude.com/claude-code)