### PR TITLE
test(bench): multi-resource performance benchmark (TTFT → completion across techniques)

### DIFF
--- a/packages/coding-agent/test/e2e/bench/multi-resource-bench.ts
+++ b/packages/coding-agent/test/e2e/bench/multi-resource-bench.ts
@@ -117,16 +117,27 @@ async function api(method: string, path: string): Promise<{ status: number }> {
 	return { status: res?.status ?? 0 };
 }
 
-/** Poll GET until 200 or timeout — a resource appears shortly after the UI turn-done. */
-async function apiGetOk(path: string, timeoutMs = 120_000): Promise<number> {
+/**
+ * Poll ALL expected resources against the config API under a single shared
+ * deadline — returns as soon as every one is 200, else waits out one timeout.
+ * (Polling each resource sequentially would make a FAILED run — e.g. free-plan
+ * creating nothing — wait timeoutMs per resource, i.e. minutes × N.)
+ */
+async function verifyResources(expected: ExpectedResource[], timeoutMs = 120_000): Promise<Record<string, number>> {
+	const statuses: Record<string, number> = {};
+	for (const e of expected) statuses[e.key] = 0;
 	const deadline = Date.now() + timeoutMs;
-	let status = 0;
 	while (Date.now() < deadline) {
-		({ status } = await api("GET", path));
-		if (status === 200) return status;
+		await Promise.all(
+			expected.map(async e => {
+				if (statuses[e.key] !== 200)
+					statuses[e.key] = (await api("GET", resourcePath(NS, e.resource, e.name))).status;
+			}),
+		);
+		if (expected.every(e => statuses[e.key] === 200)) break;
 		await sleep(5000);
 	}
-	return status;
+	return statuses;
 }
 
 // ── Browser-side timeline observer ───────────────────────────────────────────
@@ -227,10 +238,9 @@ async function runTechnique(panel: Page, technique: TechniqueId, run: number): P
 	const totalMs = Date.now() - tStart;
 	const events = await readTimeline(panel);
 
-	// Verify each expected resource via the config API (poll until 200 or timeout).
+	// Verify the expected resources via the config API (all under one shared deadline).
 	const expected = expectedResources(technique, currentSuffix);
-	const statuses: Record<string, number> = {};
-	for (const e of expected) statuses[e.key] = await apiGetOk(resourcePath(NS, e.resource, e.name));
+	const statuses = await verifyResources(expected);
 
 	return reduceTimeline(events, { technique, run, ttftMs, totalMs, statuses });
 }

--- a/packages/coding-agent/test/e2e/bench/multi-resource-bench.ts
+++ b/packages/coding-agent/test/e2e/bench/multi-resource-bench.ts
@@ -1,0 +1,369 @@
+/**
+ * LIVE multi-resource performance benchmark — drives the REAL xcsh side panel to
+ * build a multi-resource F5 XC config three different ways and measures each:
+ * TTFT (send → first token) → console automation → completion, plus tool counts,
+ * annotate overhead, per-tool timeline, created resources, and errors.
+ *
+ * Model + lifecycle mirror the panel E2E test (connect() to a real Chrome, operator
+ * opens the native side panel once). Pure metric logic lives in multi-resource-report.ts
+ * (unit-tested, CI-safe); this file is the live driver and NEVER runs in CI:
+ *   - it is not a *.test.ts, so `bun test` never picks it up;
+ *   - `puppeteer` loads only via the harness's dynamic import, so it is import-safe
+ *     for lint/typecheck;
+ *   - it self-gates on `canRunLive` and exits early without creds / on CI.
+ *
+ * Prerequisites (same as extension-panel-e2e.test.ts): extension built with the dev
+ * key, native host installed (`xcsh chrome setup`), VPN up, and — when the Chrome
+ * window opens — click the xcsh toolbar icon to open the panel.
+ *
+ * Run:
+ *   XCSH_STAGING_API_URL=https://nferreira.staging.volterra.us \
+ *   XCSH_STAGING_API_TOKEN=<token> \
+ *   XCSH_STAGING_USERNAME=r.mordasiewicz@f5.com \
+ *   XCSH_STAGING_PASSWORD=<pw> \
+ *   bun test/e2e/bench/multi-resource-bench.ts [--runs 3] [--only workflow_directed]
+ *        [--out results.json] [--check] [--update-baseline] [--gate-resources]
+ *        [--tolerance 30] [--min-abs-ms 15]
+ */
+import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { Browser, Page } from "puppeteer";
+import {
+	attachDiagnostics,
+	type ChromeSession,
+	canRunLive,
+	findPanel,
+	launchAndConnect,
+	openConsoleAndLogin,
+	resetConversation,
+	resourceNames,
+	resourcePath,
+	sendPrompt,
+	setMode,
+	waitForPanelReady,
+	waitForTurnDone,
+} from "../harness/panel-harness";
+import {
+	aggregate,
+	type BenchResultFile,
+	compareToBaseline,
+	type ExpectedResource,
+	expectedResources,
+	formatTable,
+	freePlanPrompt,
+	type MultiBenchResult,
+	type RunMetrics,
+	reduceTimeline,
+	sequentialPrompts,
+	type TechniqueId,
+	type TimelineEvent,
+	workflowDirectedPrompt,
+	workflowNames,
+} from "./multi-resource-report";
+
+// ── CLI parsing (mirrors bench/ttft.ts) ──────────────────────────────────────
+function arg(name: string): string | undefined {
+	const i = process.argv.indexOf(name);
+	return i >= 0 ? (process.argv[i + 1] ?? "") : undefined;
+}
+function flag(name: string): boolean {
+	return process.argv.includes(name);
+}
+function numArg(name: string, def: number): number {
+	const v = arg(name);
+	if (v === undefined) return def;
+	const n = Number(v);
+	return Number.isFinite(n) && n > 0 ? n : def;
+}
+
+const RUNS = numArg("--runs", 3);
+const TOLERANCE = numArg("--tolerance", 30);
+const MIN_ABS_MS = numArg("--min-abs-ms", 15);
+const ONLY = arg("--only") as TechniqueId | undefined;
+const OUT = arg("--out");
+const GATE_RESOURCES = flag("--gate-resources");
+const DO_CHECK = flag("--check");
+const DO_UPDATE = flag("--update-baseline");
+
+const ALL_TECHNIQUES: TechniqueId[] = ["workflow_directed", "free_plan", "sequential"];
+const TECHNIQUES = ONLY ? [ONLY] : ALL_TECHNIQUES;
+
+// ── Env / gate ───────────────────────────────────────────────────────────────
+const API_URL = process.env.XCSH_STAGING_API_URL;
+const API_TOKEN = process.env.XCSH_STAGING_API_TOKEN;
+const USERNAME = process.env.XCSH_STAGING_USERNAME;
+const PASSWORD = process.env.XCSH_STAGING_PASSWORD;
+const NS = process.env.XCSH_STAGING_NAMESPACE ?? "r-mordasiewicz";
+const CONSOLE_URL =
+	process.env.XCSH_STAGING_CONSOLE_URL ??
+	`${API_URL}/web/workspaces/web-app-and-api-protection/namespaces/${NS}/manage/load_balancers/http_loadbalancers`;
+const PROFILE_DIR = process.env.XCSH_E2E_PROFILE ?? join(tmpdir(), "xcsh-e2e-profile");
+const ARTIFACTS = resolve(import.meta.dir, "../.artifacts");
+const BASELINE = resolve(import.meta.dir, "multi-resource-baseline.json");
+const SUFFIX = Date.now().toString(36).slice(-6);
+
+// Per-turn deadline: workflow-directed multi-resource completes in ~325s; give headroom.
+const TURN_TIMEOUT_MS = numArg("--turn-timeout-ms", 600_000);
+// Deletion order honours the F5 XC reference chain (LB → WAF → pool → health check).
+const CLEANUP_COLLECTION_ORDER = ["http_loadbalancers", "app_firewalls", "origin_pools", "healthchecks"];
+
+const AUTH = { Authorization: `APIToken ${API_TOKEN}` };
+const sleep = (ms: number): Promise<void> => new Promise(r => setTimeout(r, ms));
+const log = (msg: string): void => console.log(`[bench] ${msg}`);
+
+async function api(method: string, path: string): Promise<{ status: number }> {
+	const res = await fetch(`${API_URL}${path}`, { method, headers: AUTH }).catch(() => null);
+	return { status: res?.status ?? 0 };
+}
+
+/** Poll GET until 200 or timeout — a resource appears shortly after the UI turn-done. */
+async function apiGetOk(path: string, timeoutMs = 120_000): Promise<number> {
+	const deadline = Date.now() + timeoutMs;
+	let status = 0;
+	while (Date.now() < deadline) {
+		({ status } = await api("GET", path));
+		if (status === 200) return status;
+		await sleep(5000);
+	}
+	return status;
+}
+
+// ── Browser-side timeline observer ───────────────────────────────────────────
+
+/**
+ * Install a MutationObserver on `#messages` that stamps each added row (class +
+ * body text) relative to now (= just before the send). Passive capture — read back
+ * once after the turn is done, so it never races waitForTurnDone's CDP polling.
+ */
+async function injectTimelineObserver(panel: Page): Promise<void> {
+	// Structural DOM types only (no DOM lib in this package's tsconfig; mirrors the
+	// harness's `globalThis as unknown as {…}` pattern for page.evaluate callbacks).
+	await panel.evaluate(() => {
+		type Ev = { t_ms: number; className: string; body: string };
+		type El = {
+			className?: string;
+			nodeType: number;
+			innerText?: string;
+			textContent?: string | null;
+			matches?(sel: string): boolean;
+			querySelector(sel: string): El | null;
+			querySelectorAll?(sel: string): ArrayLike<El>;
+		};
+		type MutRec = { addedNodes: ArrayLike<El> };
+		type Obs = { observe(target: El, opts: { childList: boolean; subtree: boolean }): void; disconnect(): void };
+		const g = globalThis as unknown as {
+			__xcshBench?: { base: number; events: Ev[]; obs?: Obs };
+			document: { querySelector(sel: string): El | null };
+			performance: { now(): number };
+			MutationObserver: new (cb: (muts: MutRec[]) => void) => Obs;
+		};
+		g.__xcshBench?.obs?.disconnect();
+		const base = g.performance.now();
+		const events: Ev[] = [];
+		const record = (node: El): void => {
+			const rows = node.matches?.(".row") ? [node] : Array.from(node.querySelectorAll?.(".row") ?? []);
+			for (const row of rows) {
+				const gutter = row.querySelector(".gutter");
+				const body = row.querySelector(".body");
+				events.push({
+					t_ms: g.performance.now() - base,
+					className: gutter?.className ?? "",
+					body: body?.innerText ?? body?.textContent ?? "",
+				});
+			}
+		};
+		const messages = g.document.querySelector("#messages");
+		const obs = new g.MutationObserver((muts: MutRec[]) => {
+			for (const mut of muts)
+				for (const n of Array.from(mut.addedNodes)) {
+					if (n.nodeType === 1) record(n);
+				}
+		});
+		if (messages) obs.observe(messages, { childList: true, subtree: true });
+		g.__xcshBench = { base, events, obs };
+	});
+}
+
+async function readTimeline(panel: Page): Promise<TimelineEvent[]> {
+	return panel.evaluate(() => {
+		const g = globalThis as unknown as { __xcshBench?: { events: TimelineEvent[] } };
+		return g.__xcshBench?.events ?? [];
+	}) as Promise<TimelineEvent[]>;
+}
+
+// ── One measured run of a technique ──────────────────────────────────────────
+
+// currentSuffix is set per run so the prompt builders + expectedResources agree.
+let currentSuffix = SUFFIX;
+
+function techniquePrompts(technique: TechniqueId): string[] {
+	if (technique === "workflow_directed") {
+		return [
+			workflowDirectedPrompt(workflowNames(currentSuffix), {
+				namespace: NS,
+				domain: `${currentSuffix}.example.com`,
+				originServer: "httpbin.org",
+				originPort: 80,
+			}),
+		];
+	}
+	// free_plan / sequential use the harness's resourceNames (byte-equal to the e2e prompt).
+	const names = resourceNames(currentSuffix);
+	return technique === "sequential" ? sequentialPrompts(names) : [freePlanPrompt(names)];
+}
+
+async function runTechnique(panel: Page, technique: TechniqueId, run: number): Promise<RunMetrics> {
+	const prompts = techniquePrompts(technique);
+	await injectTimelineObserver(panel);
+	const tStart = Date.now();
+	let ttftMs = 0;
+	for (let i = 0; i < prompts.length; i++) {
+		const sendStart = Date.now();
+		await sendPrompt(panel, prompts[i]);
+		if (i === 0) ttftMs = Date.now() - sendStart; // send → first token (#stop appears)
+		await waitForTurnDone(panel, TURN_TIMEOUT_MS);
+	}
+	const totalMs = Date.now() - tStart;
+	const events = await readTimeline(panel);
+
+	// Verify each expected resource via the config API (poll until 200 or timeout).
+	const expected = expectedResources(technique, currentSuffix);
+	const statuses: Record<string, number> = {};
+	for (const e of expected) statuses[e.key] = await apiGetOk(resourcePath(NS, e.resource, e.name));
+
+	return reduceTimeline(events, { technique, run, ttftMs, totalMs, statuses });
+}
+
+/** Fresh conversation for an independent measurement: reset (except the very first
+ * turn), wait ready, set execution mode, and warm the worker with a trivial turn
+ * (a reset forces a slow re-provision, so the measured turn should run warm). */
+async function prepareFreshTurn(browser: Browser, panelRef: { panel: Page }, isFirst: boolean): Promise<void> {
+	if (!isFirst) panelRef.panel = await resetConversation(browser);
+	await waitForPanelReady(panelRef.panel);
+	await setMode(panelRef.panel, "configuration");
+	await sendPrompt(panelRef.panel, "what page is this?");
+	await waitForTurnDone(panelRef.panel, 120_000);
+}
+
+// ── Cleanup ──────────────────────────────────────────────────────────────────
+async function cleanup(created: ExpectedResource[]): Promise<void> {
+	const ordered = [...created].sort(
+		(a, b) => CLEANUP_COLLECTION_ORDER.indexOf(a.resource) - CLEANUP_COLLECTION_ORDER.indexOf(b.resource),
+	);
+	for (const e of ordered) await api("DELETE", resourcePath(NS, e.resource, e.name)).catch(() => {});
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+async function main(): Promise<void> {
+	if (!canRunLive(process.env)) {
+		console.error(
+			"multi-resource-bench: live gate not met (needs XCSH_STAGING_API_URL/API_TOKEN/USERNAME/PASSWORD and not CI). Skipping.",
+		);
+		process.exit(0);
+	}
+	fs.mkdirSync(PROFILE_DIR, { recursive: true });
+	fs.mkdirSync(ARTIFACTS, { recursive: true });
+
+	let session: ChromeSession | undefined;
+	const created: ExpectedResource[] = [];
+	const runsByTechnique = new Map<TechniqueId, RunMetrics[]>();
+
+	try {
+		session = await launchAndConnect(PROFILE_DIR, { consoleUrl: CONSOLE_URL, port: 9222 });
+		await attachDiagnostics(session.browser, join(ARTIFACTS, `bench-sw-${SUFFIX}.log`));
+		await openConsoleAndLogin(session.browser, {
+			consoleUrl: CONSOLE_URL,
+			username: USERNAME as string,
+			password: PASSWORD as string,
+			onLoginRequired: () => log("⚠️  Log in to staging in the open Chrome window (co-drive)…"),
+		});
+		const panelRef = {
+			panel: await findPanel(session.browser, {
+				onOpenRequired: () => log("👉 Click the xcsh toolbar icon to open the side panel."),
+			}),
+		};
+
+		let first = true;
+		for (const technique of TECHNIQUES) {
+			const samples: RunMetrics[] = [];
+			// run 0 is a discarded warm-up; runs 1..RUNS are measured (mirrors ttft.ts runs+1).
+			for (let run = 0; run <= RUNS; run++) {
+				await prepareFreshTurn(session.browser, panelRef, first);
+				first = false;
+				if (run === 0) {
+					log(`${technique}: warm-up done (discarded)`);
+					continue;
+				}
+				currentSuffix = `${SUFFIX}${technique[0]}${run}`;
+				log(`${technique}: run ${run}/${RUNS} (suffix ${currentSuffix})…`);
+				const m = await runTechnique(panelRef.panel, technique, run);
+				samples.push(m);
+				created.push(...expectedResources(technique, currentSuffix));
+				log(
+					`${technique}: run ${run} ttft=${m.ttft_ms}ms total=${m.total_ms}ms tools=${m.tool_count} ` +
+						`resources=${Object.values(m.resources_created).filter(Boolean).length}/${Object.keys(m.resources_created).length} errors=${m.errors.length}`,
+				);
+			}
+			runsByTechnique.set(technique, samples);
+		}
+	} finally {
+		if (created.length) {
+			log(`cleaning up ${created.length} resources…`);
+			await cleanup(created).catch(() => {});
+		}
+		await session?.browser.disconnect().catch(() => {});
+		session?.proc.kill();
+	}
+
+	// Aggregate + report.
+	const result: MultiBenchResult = {};
+	const perRun: RunMetrics[] = [];
+	for (const [technique, samples] of runsByTechnique) {
+		if (samples.length) result[technique] = aggregate(samples);
+		perRun.push(...samples);
+	}
+
+	console.log(
+		`\n${formatTable(result, fs.existsSync(BASELINE) && (DO_CHECK || DO_UPDATE) ? loadBaseline() : undefined)}`,
+	);
+
+	if (OUT) {
+		const file: BenchResultFile = { generatedSuffix: SUFFIX, runs: RUNS, perRun, aggregate: result };
+		fs.writeFileSync(OUT, `${JSON.stringify(file, null, 2)}\n`);
+		log(`wrote ${OUT}`);
+	}
+
+	if (DO_UPDATE) {
+		fs.writeFileSync(BASELINE, `${JSON.stringify(result, null, 2)}\n`);
+		log(`baseline updated → ${BASELINE}`);
+		process.exit(0);
+	}
+
+	if (DO_CHECK) {
+		if (!fs.existsSync(BASELINE)) {
+			console.error("no baseline — run with --update-baseline first");
+			process.exit(1);
+		}
+		const { resourceRegressions } = compareToBaseline(loadBaseline(), result, {
+			tolerancePct: TOLERANCE,
+			minAbsMs: MIN_ABS_MS,
+		});
+		if (GATE_RESOURCES && resourceRegressions.length) {
+			console.error(`\nRESOURCE REGRESSION: ${resourceRegressions.join("; ")}`);
+			process.exit(1);
+		}
+		console.log(
+			GATE_RESOURCES
+				? "\nOK — no resource regression"
+				: "\n(report-only; pass --gate-resources to gate on resource drops)",
+		);
+	}
+	process.exit(0);
+}
+
+function loadBaseline(): MultiBenchResult {
+	return JSON.parse(fs.readFileSync(BASELINE, "utf8")) as MultiBenchResult;
+}
+
+await main();

--- a/packages/coding-agent/test/e2e/bench/multi-resource-report.test.ts
+++ b/packages/coding-agent/test/e2e/bench/multi-resource-report.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Hermetic unit tests for the pure logic of the multi-resource performance
+ * benchmark. No Chrome, no creds, no network — these run in CI (bun test globs
+ * *.test.ts across the package). The live driver (multi-resource-bench.ts) is
+ * gated separately and never runs here.
+ *
+ * Run: bun test test/e2e/bench/multi-resource-report.test.ts
+ */
+import { describe, expect, it } from "bun:test";
+import { resourceNames } from "../harness/panel-harness";
+import {
+	aggregate,
+	classifyToolRow,
+	compareToBaseline,
+	expectedResources,
+	formatTable,
+	freePlanPrompt,
+	isErrorRow,
+	type MultiBenchResult,
+	type RunMetrics,
+	reduceTimeline,
+	resourcesCreated,
+	sequentialPrompts,
+	type TimelineEvent,
+	workflowDirectedPrompt,
+	workflowNames,
+} from "./multi-resource-report";
+
+const NAMES = resourceNames("abc123");
+
+describe("freePlanPrompt — byte-equal to the extension-panel-e2e multi-resource prompt", () => {
+	it("matches the exact concatenation used by the live e2e test", () => {
+		// Mirror of extension-panel-e2e.test.ts:165-169. If that prompt changes,
+		// this test must change with it — the benchmark measures the SAME prompt.
+		const expected =
+			`create an http load balancer named ${NAMES.lb} ` +
+			`with an origin pool named ${NAMES.pool} with a dns member pointing to httpbin.org ` +
+			`with a health check named ${NAMES.hc} with an http path of /healthz ` +
+			`and apply an app firewall named ${NAMES.waf} on the load balancer`;
+		expect(freePlanPrompt(NAMES)).toBe(expected);
+	});
+});
+
+describe("workflowDirectedPrompt — steers the model to call catalog_workflow_runner", () => {
+	const wf = workflowNames("abc123");
+	const prompt = workflowDirectedPrompt(wf, {
+		namespace: "r-mordasiewicz",
+		domain: "app.example.com",
+		originServer: "httpbin.org",
+		originPort: 80,
+	});
+	it("names the waap-full-stack-demo workflow by id", () => {
+		expect(prompt).toContain("waap-full-stack-demo");
+	});
+	it("passes the workflow's required params (app_name, domain, origin_server, origin_port)", () => {
+		expect(prompt).toContain(wf.appName);
+		expect(prompt).toContain("app.example.com");
+		expect(prompt).toContain("httpbin.org");
+		expect(prompt).toContain("80");
+	});
+});
+
+describe("sequentialPrompts — one dependency-ordered prompt per resource", () => {
+	const prompts = sequentialPrompts(NAMES);
+	it("yields four prompts", () => {
+		expect(prompts).toHaveLength(4);
+	});
+	it("orders them health check → origin pool → app firewall → load balancer", () => {
+		expect(prompts[0]).toContain(NAMES.hc);
+		expect(prompts[1]).toContain(NAMES.pool);
+		expect(prompts[2]).toContain(NAMES.waf);
+		expect(prompts[3]).toContain(NAMES.lb);
+	});
+	it("references the pool's health check and the LB's pool + waf so the deps resolve", () => {
+		expect(prompts[1]).toContain(NAMES.hc); // pool uses the health check
+		expect(prompts[3]).toContain(NAMES.pool); // lb uses the pool
+		expect(prompts[3]).toContain(NAMES.waf); // lb applies the waf
+	});
+});
+
+describe("classifyToolRow — parse a #messages tool row into {toolName, ok, skipped}", () => {
+	it("parses a successful tool row (g-tool-ok, ✓)", () => {
+		expect(classifyToolRow("gutter g-tool-ok", "navigate: ✓ opened load balancers")).toEqual({
+			toolName: "navigate",
+			ok: true,
+			skipped: false,
+		});
+	});
+	it("parses a failed tool row (g-tool-err, ✗)", () => {
+		expect(classifyToolRow("gutter g-tool-err", "fill: ✗ selector not found")).toEqual({
+			toolName: "fill",
+			ok: false,
+			skipped: false,
+		});
+	});
+	it("flags a skipped annotate as skipped (still ok)", () => {
+		expect(classifyToolRow("gutter g-tool-ok", "annotate: ✓ skipped: explain mode off")).toEqual({
+			toolName: "annotate",
+			ok: true,
+			skipped: true,
+		});
+	});
+	it("returns null for a non-tool row (assistant / error / user)", () => {
+		expect(classifyToolRow("gutter g-assistant", "here is what I did")).toBeNull();
+		expect(classifyToolRow("gutter g-error", "Turn aborted.")).toBeNull();
+		expect(classifyToolRow("gutter g-user", "create a load balancer")).toBeNull();
+	});
+});
+
+describe("isErrorRow — an error row that isn't the transient starting/resend flash", () => {
+	it("true for a real error", () => {
+		expect(isErrorRow("gutter g-error", "Turn aborted.")).toBe(true);
+	});
+	it("false for the transient 'starting… resend' self-heal message", () => {
+		expect(isErrorRow("gutter g-error", "xcsh is starting for this tab — one moment, then resend.")).toBe(false);
+	});
+	it("false for a non-error row", () => {
+		expect(isErrorRow("gutter g-tool-ok", "navigate: ✓ done")).toBe(false);
+	});
+});
+
+describe("expectedResources — per-technique expected resource set", () => {
+	it("free_plan expects 4 resources (hc, pool, lb, waf) on the right collections", () => {
+		const exp = expectedResources("free_plan", "abc123");
+		expect(exp.map(e => e.key).sort()).toEqual(["hc", "lb", "pool", "waf"]);
+		const byKey = Object.fromEntries(exp.map(e => [e.key, e]));
+		expect(byKey.hc.resource).toBe("healthchecks");
+		expect(byKey.pool.resource).toBe("origin_pools");
+		expect(byKey.lb.resource).toBe("http_loadbalancers");
+		expect(byKey.waf.resource).toBe("app_firewalls");
+		expect(byKey.pool.name).toBe(NAMES.pool);
+	});
+	it("sequential expects the same 4 resources as free_plan", () => {
+		expect(expectedResources("sequential", "abc123")).toEqual(expectedResources("free_plan", "abc123"));
+	});
+	it("workflow_directed expects only 3 (pool, waf, lb) with {app_name}- names", () => {
+		const exp = expectedResources("workflow_directed", "abc123");
+		expect(exp.map(e => e.key).sort()).toEqual(["lb", "pool", "waf"]);
+		const wf = workflowNames("abc123");
+		expect(exp.find(e => e.key === "pool")?.name).toBe(wf.pool);
+		expect(exp.find(e => e.key === "lb")?.name).toBe(wf.lb);
+	});
+});
+
+describe("resourcesCreated — GET status map → per-key booleans over the expected set", () => {
+	it("200 → true, anything else → false", () => {
+		const exp = expectedResources("free_plan", "abc123");
+		const got = resourcesCreated({ hc: 200, pool: 200, lb: 404, waf: 0 }, exp);
+		expect(got).toEqual({ hc: true, pool: true, lb: false, waf: false });
+	});
+	it("treats a missing key as not created", () => {
+		const exp = expectedResources("workflow_directed", "abc123");
+		expect(resourcesCreated({ pool: 200 }, exp)).toEqual({ pool: true, waf: false, lb: false });
+	});
+});
+
+describe("workflowNames — deterministic {app_name}-scoped names", () => {
+	it("is a pure function of the suffix", () => {
+		expect(workflowNames("x")).toEqual(workflowNames("x"));
+	});
+	it("prefixes every resource with the app name", () => {
+		const wf = workflowNames("x");
+		expect(wf.pool.startsWith(wf.appName)).toBe(true);
+		expect(wf.waf.startsWith(wf.appName)).toBe(true);
+		expect(wf.lb.startsWith(wf.appName)).toBe(true);
+	});
+});
+
+describe("reduceTimeline — DOM events + headline → RunMetrics", () => {
+	const events: TimelineEvent[] = [
+		{ t_ms: 100, className: "gutter g-user", body: "create stuff" },
+		{ t_ms: 3200, className: "gutter g-tool-ok", body: "catalog_workflow_runner: ✓ ran waap-full-stack-demo" },
+		{ t_ms: 12000, className: "gutter g-tool-ok", body: "navigate: ✓ opened form" },
+		{ t_ms: 15000, className: "gutter g-tool-ok", body: "annotate: ✓ skipped: explain mode off" },
+		{ t_ms: 16000, className: "gutter g-tool-err", body: "fill: ✗ transient" },
+		{ t_ms: 20000, className: "gutter g-error", body: "xcsh is starting for this tab — one moment, then resend." },
+		{ t_ms: 21000, className: "gutter g-error", body: "Turn aborted." },
+		{ t_ms: 22000, className: "gutter g-assistant", body: "done" },
+	];
+	const m = reduceTimeline(events, {
+		technique: "workflow_directed",
+		run: 1,
+		ttftMs: 3000,
+		totalMs: 22500,
+		statuses: { pool: 200, waf: 200, lb: 200 },
+	});
+
+	it("passes through headline metrics", () => {
+		expect(m.technique).toBe("workflow_directed");
+		expect(m.run).toBe(1);
+		expect(m.ttft_ms).toBe(3000);
+		expect(m.total_ms).toBe(22500);
+	});
+	it("counts only tool rows", () => {
+		expect(m.tool_count).toBe(4); // 2 ok non-annotate + 1 annotate + 1 err
+	});
+	it("splits annotate into drawn vs skipped", () => {
+		expect(m.annotate_skipped).toBe(1);
+		expect(m.annotate_drawn).toBe(0);
+	});
+	it("collects real errors but drops the transient starting/resend flash", () => {
+		expect(m.errors).toEqual(["Turn aborted."]);
+	});
+	it("builds a tool timeline with timestamps", () => {
+		expect(m.timeline[0]).toEqual({ t_ms: 3200, toolName: "catalog_workflow_runner", ok: true });
+		expect(m.timeline).toHaveLength(4);
+	});
+	it("maps resources_created over the technique's expected set", () => {
+		expect(m.resources_created).toEqual({ pool: true, waf: true, lb: true });
+	});
+});
+
+function mkRun(over: Partial<RunMetrics>): RunMetrics {
+	return {
+		technique: "free_plan",
+		run: 1,
+		ttft_ms: 100,
+		total_ms: 1000,
+		tool_count: 5,
+		annotate_drawn: 0,
+		annotate_skipped: 0,
+		resources_created: { hc: true, pool: true, lb: true, waf: true },
+		errors: [],
+		timeline: [],
+		...over,
+	};
+}
+
+describe("aggregate — median per numeric metric + resource creation counts", () => {
+	const runs = [
+		mkRun({
+			ttft_ms: 100,
+			total_ms: 1000,
+			tool_count: 4,
+			resources_created: { hc: true, pool: true, lb: false, waf: true },
+		}),
+		mkRun({
+			ttft_ms: 200,
+			total_ms: 2000,
+			tool_count: 6,
+			resources_created: { hc: true, pool: true, lb: true, waf: true },
+		}),
+		mkRun({
+			ttft_ms: 300,
+			total_ms: 3000,
+			tool_count: 8,
+			resources_created: { hc: true, pool: false, lb: true, waf: true },
+		}),
+	];
+	const agg = aggregate(runs);
+	it("medians ttft/total/tool_count", () => {
+		expect(agg.ttft_ms).toBe(200);
+		expect(agg.total_ms).toBe(2000);
+		expect(agg.tool_count).toBe(6);
+	});
+	it("counts, per resource, how many runs created it", () => {
+		expect(agg.resources_created).toEqual({ hc: 3, pool: 2, lb: 2, waf: 3 });
+	});
+	it("records the median per-run resource count", () => {
+		// per-run counts: 3, 4, 3 → median 3
+		expect(agg.resource_count_median).toBe(3);
+	});
+	it("carries runs count and technique", () => {
+		expect(agg.runs).toBe(3);
+		expect(agg.technique).toBe("free_plan");
+	});
+});
+
+describe("compareToBaseline — resource drops gate, timing only reports", () => {
+	const base: MultiBenchResult = {
+		workflow_directed: aggregate([
+			mkRun({
+				technique: "workflow_directed",
+				ttft_ms: 3000,
+				total_ms: 300000,
+				resources_created: { pool: true, waf: true, lb: true },
+			}),
+		]),
+	};
+	it("flags a resource-count regression when a technique creates fewer than baseline", () => {
+		const cur: MultiBenchResult = {
+			workflow_directed: aggregate([
+				mkRun({
+					technique: "workflow_directed",
+					ttft_ms: 3000,
+					total_ms: 300000,
+					resources_created: { pool: true, waf: false, lb: false },
+				}),
+			]),
+		};
+		const { resourceRegressions } = compareToBaseline(base, cur, { tolerancePct: 30, minAbsMs: 15 });
+		expect(resourceRegressions.length).toBe(1);
+		expect(resourceRegressions[0]).toContain("workflow_directed");
+	});
+	it("does NOT flag a resource regression when the count holds", () => {
+		const cur: MultiBenchResult = {
+			workflow_directed: aggregate([
+				mkRun({
+					technique: "workflow_directed",
+					ttft_ms: 3000,
+					total_ms: 300000,
+					resources_created: { pool: true, waf: true, lb: true },
+				}),
+			]),
+		};
+		expect(compareToBaseline(base, cur, { tolerancePct: 30, minAbsMs: 15 }).resourceRegressions).toEqual([]);
+	});
+	it("never puts timing in the gating list — even a huge slowdown only appears as a reported delta", () => {
+		const cur: MultiBenchResult = {
+			workflow_directed: aggregate([
+				mkRun({
+					technique: "workflow_directed",
+					ttft_ms: 90000,
+					total_ms: 900000,
+					resources_created: { pool: true, waf: true, lb: true },
+				}),
+			]),
+		};
+		const res = compareToBaseline(base, cur, { tolerancePct: 30, minAbsMs: 15 });
+		expect(res.resourceRegressions).toEqual([]);
+		expect(res.timingDeltas.some(d => d.metric === "ttft_ms" && d.deltaPct > 100)).toBe(true);
+	});
+});
+
+describe("formatTable — human-readable comparison", () => {
+	const cur: MultiBenchResult = {
+		workflow_directed: aggregate([mkRun({ technique: "workflow_directed" })]),
+		free_plan: aggregate([mkRun({ technique: "free_plan" })]),
+	};
+	it("returns a string naming the techniques and key columns", () => {
+		const table = formatTable(cur);
+		expect(table).toContain("workflow_directed");
+		expect(table).toContain("free_plan");
+		expect(table.toLowerCase()).toContain("ttft");
+	});
+});

--- a/packages/coding-agent/test/e2e/bench/multi-resource-report.ts
+++ b/packages/coding-agent/test/e2e/bench/multi-resource-report.ts
@@ -1,0 +1,386 @@
+/**
+ * Pure, IO-free logic for the multi-resource performance benchmark. No Chrome,
+ * no network — unit-tested in multi-resource-report.test.ts and safe to import
+ * in CI. The live driver (multi-resource-bench.ts) supplies the raw inputs
+ * (wall-clock timings + captured DOM rows + API statuses); everything here is a
+ * deterministic function of those inputs.
+ *
+ * Mirrors the hermetic-vs-live split of bench/ttft.ts + bench/ttft-report.ts,
+ * and reuses `median` and the harness's `resourceNames` rather than re-deriving.
+ */
+import { median } from "../../../bench/ttft-report";
+import { type ResourceNames, resourceNames } from "../harness/panel-harness";
+
+/** The three ways to drive a multi-resource build we compare. */
+export type TechniqueId = "workflow_directed" | "free_plan" | "sequential";
+
+/** Short keys for the resources a technique creates. */
+export type ResourceKey = "hc" | "pool" | "lb" | "waf";
+
+/** F5 XC config-API collection for each resource key (mirrors staging-crud paths). */
+const RESOURCE_COLLECTION: Record<ResourceKey, string> = {
+	hc: "healthchecks",
+	pool: "origin_pools",
+	lb: "http_loadbalancers",
+	waf: "app_firewalls",
+};
+
+/** A resource a technique is expected to create, with its collection + concrete name. */
+export interface ExpectedResource {
+	key: ResourceKey;
+	resource: string;
+	name: string;
+}
+
+/** {app_name}-scoped names for the workflow-directed technique. The waap-full-stack-demo
+ * workflow names its resources `{app_name}-pool` / `-waf` / `-lb` (no standalone named
+ * health check), so this technique's expected set is 3, not 4. */
+export interface WorkflowNames {
+	appName: string;
+	pool: string;
+	waf: string;
+	lb: string;
+}
+
+export function workflowNames(suffix: string): WorkflowNames {
+	const appName = `e2e-wf-${suffix}`;
+	return { appName, pool: `${appName}-pool`, waf: `${appName}-waf`, lb: `${appName}-lb` };
+}
+
+/** Params the waap-full-stack-demo workflow needs beyond app_name. */
+export interface WorkflowSpec {
+	namespace: string;
+	domain: string;
+	/** Origin server — a HOSTNAME (the workflow's DNS-name field rejects raw IPs). */
+	originServer: string;
+	originPort: number;
+	wafMode?: string;
+}
+
+// ── Prompt builders ──────────────────────────────────────────────────────────
+
+/**
+ * Byte-equal to the multi-resource prompt in extension-panel-e2e.test.ts:165-169.
+ * The benchmark's free-plan technique must measure the SAME prompt the live e2e
+ * test uses; a test asserts this equality so the two never drift.
+ */
+export function freePlanPrompt(names: ResourceNames): string {
+	return (
+		`create an http load balancer named ${names.lb} ` +
+		`with an origin pool named ${names.pool} with a dns member pointing to httpbin.org ` +
+		`with a health check named ${names.hc} with an http path of /healthz ` +
+		`and apply an app firewall named ${names.waf} on the load balancer`
+	);
+}
+
+/**
+ * Steer the model to call `catalog_workflow_runner` with the pre-defined
+ * `waap-full-stack-demo` workflow (dependency chain baked in → ~3s first token)
+ * instead of re-deriving the graph itself (>120s extended thinking).
+ */
+export function workflowDirectedPrompt(wf: WorkflowNames, spec: WorkflowSpec): string {
+	const wafMode = spec.wafMode ?? "Blocking";
+	return (
+		`Use the "waap-full-stack-demo" workflow to build a full WAAP stack. ` +
+		`Call the catalog_workflow_runner tool directly with these params: ` +
+		`namespace ${spec.namespace}, app_name ${wf.appName}, domain ${spec.domain}, ` +
+		`origin_server ${spec.originServer}, origin_port ${spec.originPort}, waf_mode ${wafMode}. ` +
+		`Do not re-plan the dependencies — run the workflow.`
+	);
+}
+
+/** Four dependency-ordered single-resource prompts: health check → origin pool →
+ * app firewall → load balancer (each references the ones it depends on by name). */
+export function sequentialPrompts(names: ResourceNames): string[] {
+	return [
+		`create a health check named ${names.hc} with an http path of /healthz`,
+		`create an origin pool named ${names.pool} with a dns member pointing to httpbin.org ` +
+			`with a health check named ${names.hc}`,
+		`create an app firewall named ${names.waf}`,
+		`create an http load balancer named ${names.lb} with an origin pool named ${names.pool} ` +
+			`and apply an app firewall named ${names.waf} on the load balancer`,
+	];
+}
+
+// ── Expected-resource descriptors ────────────────────────────────────────────
+
+/** The resource keys a technique is expected to create. Workflow-directed omits a
+ * standalone health check (the workflow embeds it in the pool). */
+export function techniqueResourceKeys(technique: TechniqueId): ResourceKey[] {
+	return technique === "workflow_directed" ? ["pool", "waf", "lb"] : ["hc", "pool", "lb", "waf"];
+}
+
+function nameForKey(technique: TechniqueId, suffix: string, key: ResourceKey): string {
+	if (technique === "workflow_directed") {
+		const wf = workflowNames(suffix);
+		return key === "pool" ? wf.pool : key === "waf" ? wf.waf : wf.lb;
+	}
+	const n = resourceNames(suffix);
+	return key === "hc" ? n.hc : key === "pool" ? n.pool : key === "lb" ? n.lb : n.waf;
+}
+
+export function expectedResources(technique: TechniqueId, suffix: string): ExpectedResource[] {
+	return techniqueResourceKeys(technique).map(key => ({
+		key,
+		resource: RESOURCE_COLLECTION[key],
+		name: nameForKey(technique, suffix, key),
+	}));
+}
+
+/** GET-status map → per-key booleans over a technique's expected set (200 = created). */
+export function resourcesCreated(
+	statuses: Record<string, number>,
+	expected: ExpectedResource[],
+): Record<string, boolean> {
+	const out: Record<string, boolean> = {};
+	for (const e of expected) out[e.key] = statuses[e.key] === 200;
+	return out;
+}
+
+// ── DOM row parsing ──────────────────────────────────────────────────────────
+
+/** A row captured from the panel's `#messages` list by the browser-side observer. */
+export interface TimelineEvent {
+	/** Milliseconds since the send click (observer base). */
+	t_ms: number;
+	/** The gutter element's class string, e.g. "gutter g-tool-ok". */
+	className: string;
+	/** The row's `.body` text content. */
+	body: string;
+}
+
+export interface ToolRow {
+	toolName: string;
+	ok: boolean;
+	skipped: boolean;
+}
+
+/** Parse a tool-notice row (`g-tool-ok`/`g-tool-err`, body `"{tool}: ✓/✗ {text}"`).
+ * Returns null for any non-tool row (assistant, error, user, thinking). */
+export function classifyToolRow(className: string, body: string): ToolRow | null {
+	const ok = /\bg-tool-ok\b/.test(className);
+	const err = /\bg-tool-err\b/.test(className);
+	if (!ok && !err) return null;
+	const m = /^(.+?):\s*[✓✗]\s*([\s\S]*)$/.exec(body);
+	const toolName = m ? m[1].trim() : body.trim();
+	const text = m ? m[2] : "";
+	return { toolName, ok, skipped: /\bskip/i.test(text) };
+}
+
+/** True for a real error row — excludes the transient "starting… / resend" self-heal
+ * flash (which the harness's sendPrompt also text-matches away). */
+export function isErrorRow(className: string, body: string): boolean {
+	return /\bg-error\b/.test(className) && !/starting|resend/i.test(body);
+}
+
+// ── Per-run metrics ──────────────────────────────────────────────────────────
+
+export interface ToolTimelineEntry {
+	t_ms: number;
+	toolName: string;
+	ok: boolean;
+}
+
+export interface RunMetrics {
+	technique: TechniqueId;
+	run: number;
+	ttft_ms: number;
+	total_ms: number;
+	tool_count: number;
+	annotate_drawn: number;
+	annotate_skipped: number;
+	resources_created: Record<string, boolean>;
+	errors: string[];
+	timeline: ToolTimelineEntry[];
+}
+
+export interface RunHeadline {
+	technique: TechniqueId;
+	run: number;
+	/** Wall-clock send → first token (`#stop` appears). */
+	ttftMs: number;
+	/** Wall-clock send → turn done (`#send` back, `#stop` gone). */
+	totalMs: number;
+	/** GET status per resource key, from the post-turn API poll. */
+	statuses: Record<string, number>;
+}
+
+/** Reduce captured DOM events + wall-clock headline + API statuses into one run's metrics. */
+export function reduceTimeline(events: TimelineEvent[], h: RunHeadline): RunMetrics {
+	const timeline: ToolTimelineEntry[] = [];
+	const errors: string[] = [];
+	let tool_count = 0;
+	let annotate_drawn = 0;
+	let annotate_skipped = 0;
+
+	for (const ev of events) {
+		const tool = classifyToolRow(ev.className, ev.body);
+		if (tool) {
+			tool_count++;
+			timeline.push({ t_ms: ev.t_ms, toolName: tool.toolName, ok: tool.ok });
+			if (tool.toolName === "annotate") {
+				if (tool.skipped) annotate_skipped++;
+				else annotate_drawn++;
+			}
+			continue;
+		}
+		if (isErrorRow(ev.className, ev.body)) errors.push(ev.body);
+	}
+
+	const resources_created: Record<string, boolean> = {};
+	for (const key of techniqueResourceKeys(h.technique)) resources_created[key] = h.statuses[key] === 200;
+
+	return {
+		technique: h.technique,
+		run: h.run,
+		ttft_ms: h.ttftMs,
+		total_ms: h.totalMs,
+		tool_count,
+		annotate_drawn,
+		annotate_skipped,
+		resources_created,
+		errors,
+		timeline,
+	};
+}
+
+// ── Aggregation across runs ──────────────────────────────────────────────────
+
+export interface TechniqueResult {
+	technique: TechniqueId;
+	runs: number;
+	ttft_ms: number;
+	total_ms: number;
+	tool_count: number;
+	annotate_drawn: number;
+	annotate_skipped: number;
+	/** How many of the N runs created each resource key. */
+	resources_created: Record<string, number>;
+	/** Median per-run count of created resources — the robust reliability signal. */
+	resource_count_median: number;
+	errors_count: number;
+}
+
+export type MultiBenchResult = { [K in TechniqueId]?: TechniqueResult };
+
+/** The full JSON artifact written by `--out`: every run plus the aggregate. */
+export interface BenchResultFile {
+	generatedSuffix: string;
+	runs: number;
+	perRun: RunMetrics[];
+	aggregate: MultiBenchResult;
+}
+
+/** Median every numeric metric across a technique's runs; tally resource creation. */
+export function aggregate(runs: RunMetrics[]): TechniqueResult {
+	const pick = (f: (r: RunMetrics) => number): number => median(runs.map(f));
+	const keys = new Set<string>();
+	for (const r of runs) for (const k of Object.keys(r.resources_created)) keys.add(k);
+	const resources_created: Record<string, number> = {};
+	for (const k of keys) resources_created[k] = runs.filter(r => r.resources_created[k]).length;
+	const resource_count_median = median(runs.map(r => Object.values(r.resources_created).filter(Boolean).length));
+	return {
+		technique: runs[0].technique,
+		runs: runs.length,
+		ttft_ms: pick(r => r.ttft_ms),
+		total_ms: pick(r => r.total_ms),
+		tool_count: pick(r => r.tool_count),
+		annotate_drawn: pick(r => r.annotate_drawn),
+		annotate_skipped: pick(r => r.annotate_skipped),
+		resources_created,
+		resource_count_median,
+		errors_count: pick(r => r.errors.length),
+	};
+}
+
+// ── Baseline comparison ──────────────────────────────────────────────────────
+
+export interface TimingDelta {
+	technique: TechniqueId;
+	metric: string;
+	baseline: number;
+	current: number;
+	deltaPct: number;
+	/** Exceeds both tolerances — shown emphasised, but NEVER gates the exit code. */
+	flagged: boolean;
+}
+
+export interface CompareOptions {
+	tolerancePct: number;
+	minAbsMs: number;
+}
+
+const TIMING_METRICS = ["ttft_ms", "total_ms", "tool_count"] as const;
+
+/**
+ * Compare current medians to a baseline. Timing deltas are REPORT-ONLY (provider
+ * latency dominates and is un-optimizable, so gating on it false-positives). The
+ * only gating signal is `resourceRegressions`: a technique that creates fewer
+ * resources than baseline — surfaced for the opt-in `--gate-resources` exit code.
+ */
+export function compareToBaseline(
+	base: MultiBenchResult,
+	cur: MultiBenchResult,
+	opts: CompareOptions,
+): { timingDeltas: TimingDelta[]; resourceRegressions: string[] } {
+	const timingDeltas: TimingDelta[] = [];
+	const resourceRegressions: string[] = [];
+	for (const technique of Object.keys(cur) as TechniqueId[]) {
+		const b = base[technique];
+		const c = cur[technique];
+		if (!b || !c) continue;
+		for (const metric of TIMING_METRICS) {
+			const bv = b[metric];
+			const cv = c[metric];
+			const deltaPct = bv === 0 ? (cv > 0 ? Number.POSITIVE_INFINITY : 0) : ((cv - bv) / bv) * 100;
+			const flagged = deltaPct > opts.tolerancePct && cv - bv > opts.minAbsMs;
+			timingDeltas.push({ technique, metric, baseline: bv, current: cv, deltaPct, flagged });
+		}
+		if (c.resource_count_median < b.resource_count_median) {
+			resourceRegressions.push(`${technique}: resources ${b.resource_count_median} → ${c.resource_count_median}`);
+		}
+	}
+	return { timingDeltas, resourceRegressions };
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+const TECHNIQUE_ORDER: TechniqueId[] = ["workflow_directed", "free_plan", "sequential"];
+
+const pad = (s: string, n: number): string => s.padEnd(n);
+const num = (n: number): string => (Number.isFinite(n) ? n.toFixed(0) : "—");
+
+/** A stdout comparison table (one row per technique), optionally with a Δ-vs-baseline block. */
+export function formatTable(cur: MultiBenchResult, base?: MultiBenchResult): string {
+	const lines: string[] = [];
+	lines.push(
+		`${pad("technique", 20)}${pad("TTFT(ms)", 10)}${pad("total(ms)", 11)}${pad("tools", 7)}` +
+			`${pad("annot(d/s)", 12)}${pad("res(med)", 10)}${pad("errors", 7)}`,
+	);
+	lines.push("-".repeat(77));
+	for (const t of TECHNIQUE_ORDER) {
+		const r = cur[t];
+		if (!r) continue;
+		lines.push(
+			`${pad(t, 20)}${pad(num(r.ttft_ms), 10)}${pad(num(r.total_ms), 11)}${pad(num(r.tool_count), 7)}` +
+				`${pad(`${r.annotate_drawn}/${r.annotate_skipped}`, 12)}${pad(num(r.resource_count_median), 10)}${pad(num(r.errors_count), 7)}`,
+		);
+	}
+	if (base) {
+		const { timingDeltas, resourceRegressions } = compareToBaseline(base, cur, { tolerancePct: 30, minAbsMs: 15 });
+		lines.push("");
+		lines.push("=== Δ vs baseline (timing report-only; resources gate) ===");
+		for (const d of timingDeltas) {
+			const sign = d.deltaPct >= 0 ? "+" : "";
+			const mark = d.flagged ? "  ⚠" : "";
+			lines.push(
+				`  ${pad(`${d.technique}.${d.metric}`, 32)} ${num(d.baseline)} → ${num(d.current)} (${sign}${d.deltaPct.toFixed(1)}%)${mark}`,
+			);
+		}
+		if (resourceRegressions.length) {
+			lines.push("");
+			lines.push(`  RESOURCE REGRESSION: ${resourceRegressions.join("; ")}`);
+		}
+	}
+	return lines.join("\n");
+}


### PR DESCRIPTION
## What

Adds a live, `canRunLive`-gated performance benchmark that drives the real xcsh side panel to build a multi-resource F5 XC config three ways and measures each:

- **workflow-directed** — steers the model to call `catalog_workflow_runner` with `waap-full-stack-demo` (deps pre-defined → ~3s first token)
- **free-plan** — the mega-prompt the model must plan itself (byte-equal to the `extension-panel-e2e` multi-resource prompt)
- **sequential** — four dependency-ordered single-resource prompts

Per run it captures `ttft_ms`, `total_ms`, `tool_count`, `annotate_drawn`/`annotate_skipped`, `resources_created` (verified via the config API), `errors`, and a per-tool timeline.

## Structure (mirrors `bench/ttft.ts` + `bench/ttft-report.ts`)

- `test/e2e/bench/multi-resource-report.ts` — **pure, IO-free** logic: prompt builders, DOM-row parsing (`classifyToolRow`/`isErrorRow`), `reduceTimeline`, per-technique expected-resource descriptors, `aggregate`, `compareToBaseline`, `formatTable`. Reuses `median` from `bench/ttft-report` and `resourceNames` from the panel harness.
- `test/e2e/bench/multi-resource-report.test.ts` — **34 hermetic unit tests**, run in CI (no Chrome/creds).
- `test/e2e/bench/multi-resource-bench.ts` — the **live CLI driver** reusing the panel harness. `puppeteer` loads only via the harness's dynamic import, so the file is import-safe in CI; it self-gates on `canRunLive` and exits cleanly without creds.

CLI mirrors `ttft.ts`: `--runs` (default 3), `--out`, `--check`, `--update-baseline`, `--tolerance`, `--min-abs-ms`, plus `--only <technique>` and `--gate-resources`. `--check` is report-only by default (provider latency dominates and is un-optimizable — gating on timing would false-positive); `--gate-resources` opt-in exits non-zero only on a resource-count drop.

## Verification

- `bun test test/e2e/bench/multi-resource-report.test.ts` — **34 pass** (hermetic).
- `bun test test/e2e/panel-harness.test.ts` — 15 pass (unchanged).
- `tsgo -p tsconfig.json --noEmit` — clean (strict).
- `biome check test/e2e/bench/` — clean.
- Gate check: running the CLI without creds prints the skip message and exits 0 (no Chrome launched).

## Follow-up — populate the baseline (human-gated live run)

This PR lands the harness + tests CI-green. The committed `multi-resource-baseline.json` requires one live run (VPN + `XCSH_STAGING_*` creds + operator opens the side panel — Puppeteer can't trigger the toolbar), tracked in #1975:

```
XCSH_STAGING_API_URL=… XCSH_STAGING_API_TOKEN=… XCSH_STAGING_USERNAME=… XCSH_STAGING_PASSWORD=… \
  bun test/e2e/bench/multi-resource-bench.ts --runs 3 --update-baseline
```

Closes #1973

🤖 Generated with [Claude Code](https://claude.com/claude-code)