### PR TITLE
ci: fix Console Catalog Drift Guard (short-SHA checkout + format-before-diff)

### DIFF
--- a/.github/workflows/console-catalog-drift.yml
+++ b/.github/workflows/console-catalog-drift.yml
@@ -8,6 +8,7 @@ name: Console Catalog Drift Guard
 # RECORDED version (not console main), so it never false-fails just because the
 # console repo advanced — that case is handled by console-catalog-update.yml.
 on:
+  workflow_dispatch: {} # allow manual re-runs (the path-filtered triggers below only fire on catalog changes)
   pull_request:
     paths:
       - "packages/coding-agent/src/internal-urls/console-catalog.generated.ts"
@@ -26,17 +27,27 @@ jobs:
 
       - name: Read the console version the committed catalog records
         id: ver
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           V=$(grep -o 'CONSOLE_CATALOG_VERSION = "[^"]*"' \
             packages/coding-agent/src/internal-urls/console-catalog.generated.ts | grep -o '"[^"]*"' | tr -d '"')
           echo "::notice::Committed catalog records console version: $V"
-          # Only treat it as checkable if it is a git-sha shape — never feed an
-          # arbitrary string into checkout `ref:` (ref-injection guard).
+          # Only proceed if it is a git-sha shape — never feed an arbitrary string
+          # into checkout `ref:` (ref-injection guard).
           if printf '%s' "$V" | grep -Eq '^[0-9a-f]{7,40}$'; then
-            echo "version=$V" >> "$GITHUB_OUTPUT"
-            echo "checkable=true" >> "$GITHUB_OUTPUT"
+            # actions/checkout `ref:` needs a FULL 40-char SHA — a short SHA is treated
+            # as a branch/tag name and fails ("could not be found"). Expand via the API,
+            # then re-validate the resolved value is a 40-char SHA before using it.
+            FULL=$(gh api "repos/f5-sales-demo/console/commits/${V}" --jq '.sha' 2>/dev/null || true)
+            if printf '%s' "$FULL" | grep -Eq '^[0-9a-f]{40}$'; then
+              { echo "ref=$FULL"; echo "version=$V"; echo "checkable=true"; } >> "$GITHUB_OUTPUT"
+              echo "::notice::Resolved console version ${V} → ${FULL} for checkout."
+            else
+              echo "checkable=false" >> "$GITHUB_OUTPUT"
+              echo "::warning::Could not resolve console commit ${V} to a full SHA — skipping drift check."
+            fi
           else
-            echo "version=$V" >> "$GITHUB_OUTPUT"
             echo "checkable=false" >> "$GITHUB_OUTPUT"
             echo "::notice::Version is not a pinned sha (local/dev) — skipping drift check."
           fi
@@ -46,7 +57,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: f5-sales-demo/console
-          ref: ${{ steps.ver.outputs.version }}
+          ref: ${{ steps.ver.outputs.ref }}
           path: console
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -68,10 +79,14 @@ jobs:
           CONSOLE_CATALOG_VERSION: ${{ steps.ver.outputs.version }}
         run: |
           bun run generate-console-catalog
+          # The committed catalog is biome-formatted; the generator emits raw JSON, so
+          # format the regenerated file the same way before diffing (else formatting
+          # noise reads as drift). Mirrors how the committed catalog is produced.
+          bunx biome format --write src/internal-urls/console-catalog.generated.ts
           if ! git -C "${{ github.workspace }}" diff --quiet -- \
               packages/coding-agent/src/internal-urls/console-catalog.generated.ts; then
             echo "::error::Committed console catalog does NOT match regenerating from console@${{ steps.ver.outputs.version }}."
-            echo "::error::Do not hand-edit generated files. Run: cd packages/coding-agent && bun run generate-console-catalog"
+            echo "::error::Do not hand-edit generated files. Run: cd packages/coding-agent && bun run generate-console-catalog && bunx biome format --write src/internal-urls/console-catalog.generated.ts"
             git -C "${{ github.workspace }}" --no-pager diff --stat -- packages/coding-agent/src/internal-urls/console-catalog.generated.ts
             exit 1
           fi

--- a/.github/workflows/console-catalog-update.yml
+++ b/.github/workflows/console-catalog-update.yml
@@ -58,9 +58,15 @@ jobs:
         env:
           CONSOLE_CATALOG_DIR: ${{ github.workspace }}/console
         run: |
-          export CONSOLE_CATALOG_VERSION="$(git -C "${{ github.workspace }}/console" rev-parse --short HEAD)"
+          # Full SHA (not --short): the drift guard feeds this to actions/checkout `ref:`,
+          # which cannot resolve a short SHA (treats it as a branch/tag name).
+          CONSOLE_CATALOG_VERSION="$(git -C "${{ github.workspace }}/console" rev-parse HEAD)"
+          export CONSOLE_CATALOG_VERSION
           echo "::notice::Regenerating console catalog at console@${CONSOLE_CATALOG_VERSION}"
           bun run generate-console-catalog
+          # The generator emits raw JSON; format it (biome) so the committed catalog is
+          # lint-clean and byte-identical to what the drift guard reproduces.
+          bunx biome format --write src/internal-urls/console-catalog.generated.ts
 
       - name: Verify generated files exist
         run: |
@@ -74,7 +80,7 @@ jobs:
             echo "::notice::No changes — console catalog already up to date"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            echo "catalog_version=$(git -C console rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+            echo "catalog_version=$(git -C console rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Configure git


### PR DESCRIPTION
## Problem

`Console Catalog Drift Guard` has been red on `main`. Two bugs, the first masking the second:

1. **Short-SHA checkout.** The guard reads `CONSOLE_CATALOG_VERSION` (currently `d7fe2d0`, a 7-char short SHA) and feeds it to `actions/checkout` `ref:`. checkout treats a non-40-char value as a branch/tag → `A branch or tag with the name 'd7fe2d0' could not be found`. The console checkout failed and the actual drift check never ran.
2. **Format-before-diff.** The committed catalog is biome-formatted (tabs/single-quote), but `generate-console-catalog` emits raw `JSON.stringify` (2-space/double-quote). So even once the checkout worked, `git diff` would flag pure formatting as drift.

## Fix

`console-catalog-drift.yml`:
- Resolve the recorded SHA to a **full 40-char SHA** via `gh api repos/f5-sales-demo/console/commits/<sha>` (re-validated against `^[0-9a-f]{40}$` before use — no unvalidated input reaches `ref:`), and check out that.
- Run `bunx biome format --write` on the regenerated catalog before diffing.
- Add `workflow_dispatch` so the guard can be re-run manually (its path-filtered triggers only fire on catalog changes).

`console-catalog-update.yml` (upstream cause, so it can't recur):
- Record the **full** SHA (`git rev-parse HEAD`, drop `--short`).
- biome-format the regenerated catalog before committing.

## Verification

Locally reproduced the guard: checked out `console@d7fe2d0`, ran `generate-console-catalog`, then `bunx biome format --write` → the result is **byte-identical to the committed catalog (empty diff)**, confirming the catalog is faithful and the only issues were the checkout ref and missing format step. `actionlint` clean on both files. After merge I'll run the guard via `workflow_dispatch` to confirm green end-to-end.

Closes #1978

🤖 Generated with [Claude Code](https://claude.com/claude-code)