### PR TITLE
test(bench): fix findPanel Page-handle acquisition for native side panel

### DIFF
--- a/packages/coding-agent/test/e2e/harness/panel-harness.ts
+++ b/packages/coding-agent/test/e2e/harness/panel-harness.ts
@@ -493,13 +493,19 @@ export async function findPanel(
 	if (!target) {
 		throw new Error(`Side panel never opened within ${timeoutMs}ms (click the xcsh toolbar icon to open it).`);
 	}
-	// A freshly-discovered target's `.page()` can be null until Puppeteer wraps it;
-	// `browser.pages()` returns the attached Page objects, so poll that as the source
-	// of truth (falling back to `target.page()`).
+	// Resolve a Page handle for the panel target. A NATIVE Chrome side panel is a
+	// `page`-type target Puppeteer does NOT auto-attach to, so `browser.pages()` (only
+	// attached pages) never lists it and `target.page()` stays null — `target.asPage()`
+	// forces attachment. Re-resolve the target each iteration because the panel reloads
+	// during provisioning, which invalidates an earlier handle. ~30s window.
 	let pg: Page | null = null;
-	for (let i = 0; i < 30 && !pg; i++) {
+	for (let i = 0; i < 60 && !pg; i++) {
+		const t = browser.targets().find(isPanel) ?? target;
 		const pages = await browser.pages().catch(() => [] as Page[]);
-		pg = pages.find(p => p.url().includes("side-panel.html")) ?? (await target.page().catch(() => null));
+		pg =
+			pages.find(p => p.url().includes("side-panel.html")) ??
+			(await t.page().catch(() => null)) ??
+			(await (typeof t.asPage === "function" ? t.asPage() : Promise.resolve(null)).catch(() => null));
 		if (!pg) await sleep(500);
 	}
 	if (!pg) throw new Error("Side panel target found but no Page handle appeared.");


### PR DESCRIPTION
Fixes #1991.

## Problem
During live multi-resource bench UAT, after the operator clicks the xcsh toolbar icon and the **native side panel** opens, `findPanel` found the side-panel target but threw `Side panel target found but no Page handle appeared.`

## Root cause
A native Chrome side panel is a `page`-type target Puppeteer does **not auto-attach** to, so `browser.pages()` never lists it and `target.page()` stays `null`. `target.asPage()` forces attachment.

## Fix
Re-resolve the panel target each poll iteration (the panel reloads during provisioning) and add `target.asPage()` as the forcing fallback after `browser.pages()`/`target.page()`; widen the window 15s → ~30s.

## Verification
- Live against staging: after the fix, `findPanel` returns a usable panel Page (`{input:true, send:true}`) and the bench proceeds into the measured turn; pre-fix it threw every time.
- Separately confirmed `sidePanel.open()` cannot be automated (Chrome rejects CDP `userGesture:true`), so the single operator click stays — this fix unblocks everything after it.
- `tsgo` (exit 0), `biome` clean, 15 harness + 34 report unit tests pass.

## Scope
Harness-only, CI-inert (not a `*.test.ts`, no static puppeteer import). No change to committed `main` behavior beyond the E2E driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)