### PR TITLE
test(bench): workflow_directed — invoke catalog_workflow_runner by resource/operation (fixes #1993)

### DIFF
--- a/packages/coding-agent/test/e2e/bench/multi-resource-report.test.ts
+++ b/packages/coding-agent/test/e2e/bench/multi-resource-report.test.ts
@@ -49,8 +49,10 @@ describe("workflowDirectedPrompt — steers the model to call catalog_workflow_r
 		originServer: "httpbin.org",
 		originPort: 80,
 	});
-	it("names the waap-full-stack-demo workflow by id", () => {
-		expect(prompt).toContain("waap-full-stack-demo");
+	it("directs catalog_workflow_runner to the demos/waap-full-stack workflow by resource+operation", () => {
+		expect(prompt).toContain("catalog_workflow_runner");
+		expect(prompt).toContain('resource "demos"');
+		expect(prompt).toContain('operation "waap-full-stack"');
 	});
 	it("passes the workflow's required params (app_name, domain, origin_server, origin_port)", () => {
 		expect(prompt).toContain(wf.appName);

--- a/packages/coding-agent/test/e2e/bench/multi-resource-report.ts
+++ b/packages/coding-agent/test/e2e/bench/multi-resource-report.ts
@@ -80,10 +80,14 @@ export function freePlanPrompt(names: ResourceNames): string {
  */
 export function workflowDirectedPrompt(wf: WorkflowNames, spec: WorkflowSpec): string {
 	const wafMode = spec.wafMode ?? "Blocking";
+	// The runnable workflow is keyed resource/operation = "demos/waap-full-stack" (its
+	// internal id is "waap-full-stack-demo", which is NOT a valid resource/operation and
+	// makes the model believe it doesn't exist). Give the exact tool coordinates so the
+	// model invokes catalog_workflow_runner directly instead of re-planning/refusing.
 	return (
-		`Use the "waap-full-stack-demo" workflow to build a full WAAP stack. ` +
-		`Call the catalog_workflow_runner tool directly with these params: ` +
-		`namespace ${spec.namespace}, app_name ${wf.appName}, domain ${spec.domain}, ` +
+		`Build a full WAAP stack (origin pool + app firewall + HTTP load balancer) by calling the ` +
+		`catalog_workflow_runner tool directly with resource "demos", operation "waap-full-stack", ` +
+		`and params: namespace ${spec.namespace}, app_name ${wf.appName}, domain ${spec.domain}, ` +
 		`origin_server ${spec.originServer}, origin_port ${spec.originPort}, waf_mode ${wafMode}. ` +
 		`Do not re-plan the dependencies — run the workflow.`
 	);


### PR DESCRIPTION
Fixes #1993.

## Root cause
`workflowDirectedPrompt` told the model to *"use the waap-full-stack-demo workflow"*. That string is the workflow's internal YAML `id` — **not** a valid `catalog_workflow_runner` coordinate. The tool loads workflows by `resource/operation` key, and the runnable key is **`demos/waap-full-stack`**:

```
loadWorkflowYaml({resource:'demos',  operation:'waap-full-stack'}) -> OK (6340 bytes)
loadWorkflowYaml({resource:'waap-full-stack-demo', operation:'create'}) -> "No embedded console workflow"
```

With no valid coordinate, the model either declared the workflow non-existent (*"there's no waap-full-stack-demo composite … it's single-resource"*) or re-planned the dependency graph itself — so `workflow_directed` created **0 resources every prior run**.

## Fix
The prompt now gives the exact tool call — `resource "demos"`, `operation "waap-full-stack"`, plus params — so the model invokes `catalog_workflow_runner` directly. Unit test updated to assert the resource/operation coordinates instead of the internal id.

## Live verification (staging)
With the fix the model invoked the workflow and the **full WAAP stack (origin pool + app firewall + HTTP load balancer) was created and independently API-verified**. Every run before this fix created nothing.

Note: the bench still *recorded* 2/3 on that run because the worker dropped mid-turn (`xcsh didn't respond in time — reconnecting`) and the LB landed after the verify grace window — that measurement gap is the separate worker-stability issue #1994, not this prompt fix.

tsgo + biome + 34 report unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)