### PR TITLE
feat(coding-agent): build progressive deprecation awareness into guardrails

### DIFF
--- a/packages/coding-agent/src/deprecations.ts
+++ b/packages/coding-agent/src/deprecations.ts
@@ -1,0 +1,87 @@
+// Behavioral deprecation guardrails, derived from the single source of truth
+// (api-specs-enriched/config/branding.yaml → branding-index.generated.ts).
+//
+// This module is the ONE seam every surface consumes so deprecation facts are
+// authored once and never hand-duplicated:
+//   - the always-on system prompt (renderDeprecationGuardrails)
+//   - the xcsh://branding/* protocol (via xcsh-protocol.ts, same generated data)
+//   - the CLI-Quick-Start renderer (isDisallowedCliCommand / getDeprecatedClis)
+
+import { BRANDING_DEPRECATIONS } from "./internal-urls/branding-index.generated";
+
+interface DeprecationEntry {
+	deprecated: Record<string, string>;
+	canonical: Record<string, string>;
+}
+
+const DEPRECATIONS = BRANDING_DEPRECATIONS as unknown as Record<string, DeprecationEntry>;
+
+/** Markers that identify a command as targeting the F5 XC API. */
+const F5XC_API_MARKERS = [
+	"f5xc_api_url",
+	"f5xc_api_token",
+	"apitoken",
+	".volterra.io",
+	".volterra.us",
+	"console.ves",
+	"/api/config/",
+	"/api/data/",
+	"/api/web/",
+	"/api/shape/",
+	"/api/ml/",
+	"/api/register/",
+];
+
+// xcsh-native guidance substituted wherever a deprecated command would appear.
+// Intentionally does NOT echo the deprecated tool name — the substitution exists
+// precisely so that name never reaches the user through this surface.
+export const XCSH_NATIVE_API_GUIDANCE =
+	"Use the `xcsh_api` tool for F5 Distributed Cloud API calls — the spec's legacy CLI example is not supported in xcsh.";
+
+/** Deprecated CLI commands, sourced from branding deprecation data (e.g. ["vesctl"]). */
+export function getDeprecatedClis(): string[] {
+	const clis = new Set<string>();
+	for (const entry of Object.values(DEPRECATIONS)) {
+		const command = entry.deprecated?.command;
+		if (command) clis.add(command.trim().toLowerCase());
+	}
+	return [...clis];
+}
+
+/**
+ * True if a command must never be surfaced as an instruction: it invokes a
+ * deprecated CLI (e.g. vesctl), or it is a raw `curl` against the F5 XC API.
+ */
+export function isDisallowedCliCommand(command: string): boolean {
+	const lower = command.trim().toLowerCase();
+	if (!lower) return false;
+	const leadingToken = lower.split(/\s+/)[0] ?? "";
+	if (getDeprecatedClis().includes(leadingToken)) return true;
+	if (leadingToken === "curl" && F5XC_API_MARKERS.some(marker => lower.includes(marker))) return true;
+	return false;
+}
+
+/**
+ * Concise, always-on deprecation block for the system prompt. Concrete values
+ * come from the embedded branding data; the behavioral rules are stable prose.
+ */
+export function renderDeprecationGuardrails(): string {
+	const cli = DEPRECATIONS.cli;
+	const apiDocs = DEPRECATIONS.api_documentation;
+	const brand = DEPRECATIONS.product_brand;
+
+	const vesctl = cli?.deprecated.command ?? "vesctl";
+	const xcshCmd = cli?.canonical.command ?? "xcsh";
+	const legacyApiUrl = apiDocs?.deprecated.url ?? "https://docs.cloud.f5.com/docs-v2/api";
+	const enrichedUrl = apiDocs?.canonical.url ?? "https://f5-sales-demo.github.io/api-specs-enriched/en/";
+	const deadBrand = brand?.deprecated.name ?? "Volterra";
+	const currentBrand = brand?.canonical.name ?? "F5 Distributed Cloud";
+
+	return [
+		"These deprecations are non-negotiable. Full detail lives at `xcsh://branding` and `xcsh://branding/volterra`, but the rules below apply even when that protocol is never consulted.",
+		"",
+		`- **Never use \`${vesctl}\`.** It is the abandoned, unsupported legacy CLI; \`${xcshCmd}\` is its modern replacement. Never propose, generate, or run \`${vesctl}\`. For F5 XC API calls use the \`xcsh_api\` tool (never raw \`curl\`); for console automation use \`catalog_workflow_runner\`.`,
+		`- **The legacy API docs are deprecated.** Never link or fetch \`${legacyApiUrl}\`. The canonical API reference is \`${enrichedUrl}\`, and the enriched specs are already embedded in this binary — prefer \`xcsh://api-catalog/\` and \`xcsh://api-spec/\` before fetching anything.`,
+		`- **"${deadBrand}" is a retired brand name.** The product is **${currentBrand}**; never write "${deadBrand}" as a product name or recommend ${deadBrand}-labeled tooling. BUT \`volterra_*\` API keys, \`*.volterra.io\`/\`*.volterra.us\` hostnames, and schema identifiers are **required functional identifiers** — use them verbatim, exactly as the API expects. Only the brand name is dead, not the identifiers.`,
+	].join("\n");
+}

--- a/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
@@ -1,3 +1,4 @@
+import { isDisallowedCliCommand, XCSH_NATIVE_API_GUIDANCE } from "../deprecations";
 import type {
 	ApiSpecDomainEnrichments,
 	ApiSpecDomainEntry,
@@ -265,16 +266,27 @@ function renderDomainDetail(domain: string, entry: ApiSpecDomainEntry, spec: Ope
 	if (entry.cliMetadata?.quickStart?.command) {
 		const cli = entry.cliMetadata;
 		sections.push("", "## CLI Quick Start", "");
-		sections.push(`\`${cli.quickStart.command}\` — ${cli.quickStart.description}`);
+		// Never surface a deprecated CLI (e.g. vesctl) or raw curl against the F5 XC
+		// API as an instruction — even if the upstream spec carries one. Substitute
+		// xcsh-native guidance instead.
+		if (isDisallowedCliCommand(cli.quickStart.command)) {
+			sections.push(`${cli.quickStart.description} — ${XCSH_NATIVE_API_GUIDANCE}`);
+		} else {
+			sections.push(`\`${cli.quickStart.command}\` — ${cli.quickStart.description}`);
+		}
 		const validWorkflows = cli.commonWorkflows?.filter(wf => wf.name) ?? [];
 		if (validWorkflows.length > 0) {
 			sections.push("", "### Common Workflows");
 			for (const wf of validWorkflows) {
-				if (wf.commands?.length) {
+				const allowedCommands = (wf.commands ?? []).filter(cmd => !isDisallowedCliCommand(cmd));
+				if (allowedCommands.length > 0) {
 					sections.push("", `**${wf.name}:**`);
-					for (const cmd of wf.commands) {
+					for (const cmd of allowedCommands) {
 						sections.push(`- \`${cmd}\``);
 					}
+				} else if (wf.commands?.length) {
+					// Every command in this workflow was deprecated/disallowed.
+					sections.push("", `**${wf.name}:** ${XCSH_NATIVE_API_GUIDANCE}`);
 				} else {
 					sections.push(`- ${wf.name}`);
 				}

--- a/packages/coding-agent/src/internal-urls/branding-index.generated.ts
+++ b/packages/coding-agent/src/internal-urls/branding-index.generated.ts
@@ -56,6 +56,37 @@ export const BRANDING_DEPRECATIONS = {
 			url: "https://f5-sales-demo.github.io/terraform-provider-xcsh/",
 		},
 	},
+	cli: {
+		deprecated: {
+			command: "vesctl",
+			status: "abandoned",
+			note: "Legacy Volterra CLI, abandoned years ago and unsupported. xcsh must never propose, generate, or run vesctl. High risk of AI model recommendation due to training-data prevalence.\n",
+		},
+		canonical: {
+			command: "xcsh",
+			note: "xcsh is the modern, supported replacement for vesctl. For F5 XC API calls use the xcsh_api tool (never curl); for console automation use the catalog_workflow_runner tool.\n",
+		},
+	},
+	api_documentation: {
+		deprecated: {
+			url: "https://docs.cloud.f5.com/docs-v2/api",
+			note: "Legacy F5 XC API documentation set. Deprecated — never link or fetch it for API references.\n",
+		},
+		canonical: {
+			url: "https://f5-sales-demo.github.io/api-specs-enriched/en/",
+			note: "Enriched API specs are embedded in the xcsh binary — prefer xcsh://api-catalog/ and xcsh://api-spec/ before fetching any URL.\n",
+		},
+	},
+	product_brand: {
+		deprecated: {
+			name: "Volterra",
+			note: 'Volterra was the company F5 acquired; the brand is retired. Never use "Volterra" as a product name in prose or recommend Volterra-labeled tooling.\n',
+		},
+		canonical: {
+			name: "F5 Distributed Cloud",
+			note: "volterra_* API keys, *.volterra.io / *.volterra.us hostnames, and schema identifiers are required functional identifiers — use them verbatim; only the product/brand name is deprecated, not these identifiers.\n",
+		},
+	},
 } as const;
 
 export const BRANDING_GLOSSARY = {

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -408,7 +408,11 @@ If that also 404s, the product has no documentation — acknowledge this to the 
 and answers the question, OR when T3 and T5 have been checked without resolution.
 Only then is web search permitted — label external results as supplementary.
 
-## Terraform Provider Override
+## Deprecation guardrails
+
+%%DEPRECATION_GUARDRAILS%%
+
+### Terraform provider
 
 HARD OVERRIDE — F5 Distributed Cloud Terraform Provider:
 - NEVER reference, recommend, or generate Terraform code using:

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -11,10 +11,14 @@ import { $ } from "bun";
 import { contextFileCapability } from "./capability/context-file";
 import { systemPromptCapability } from "./capability/system-prompt";
 import type { SkillsSettings } from "./config/settings";
+import { renderDeprecationGuardrails } from "./deprecations";
 import { type ContextFile, loadCapability, type SystemPrompt as SystemPromptFile } from "./discovery";
 import { isApplicableToContext, loadSkills, type Skill } from "./extensibility/skills";
 import customSystemPromptTemplate from "./prompts/system/custom-system-prompt.md" with { type: "text" };
 import systemPromptTemplate from "./prompts/system/system-prompt.md" with { type: "text" };
+
+/** Sentinel in system-prompt.md replaced with the rendered deprecation guardrails. */
+const DEPRECATION_GUARDRAILS_MARKER = "%%DEPRECATION_GUARDRAILS%%";
 
 let _buildMeta: { version: string; repoSlug: string } | null = null;
 
@@ -693,6 +697,14 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		knowledgeTopics: options.knowledgeTopics,
 	};
 	let rendered = prompt.render(resolvedCustomPrompt ? customSystemPromptTemplate : systemPromptTemplate, data);
+
+	// Deprecation guardrails are always-on: replace the section marker in the default
+	// template, or append when the active template has none (e.g. a fully custom system
+	// prompt), so the rules apply on every code path — not only when xcsh:// is consulted.
+	const deprecationGuardrails = renderDeprecationGuardrails();
+	rendered = rendered.includes(DEPRECATION_GUARDRAILS_MARKER)
+		? rendered.replace(DEPRECATION_GUARDRAILS_MARKER, deprecationGuardrails)
+		: `${rendered}\n\n## Deprecation guardrails\n\n${deprecationGuardrails}`;
 
 	// When autoqa is active the report_tool_issue tool is in the tool set — nudge the agent.
 	if (toolNames.includes("report_tool_issue")) {

--- a/packages/coding-agent/test/deprecations.test.ts
+++ b/packages/coding-agent/test/deprecations.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getDeprecatedClis,
+	isDisallowedCliCommand,
+	renderDeprecationGuardrails,
+	XCSH_NATIVE_API_GUIDANCE,
+} from "@f5-sales-demo/xcsh/deprecations";
+
+describe("getDeprecatedClis", () => {
+	test("includes vesctl from branding data", () => {
+		expect(getDeprecatedClis()).toContain("vesctl");
+	});
+
+	test("is lowercased and deduplicated", () => {
+		const clis = getDeprecatedClis();
+		expect(clis).toEqual(clis.map(c => c.toLowerCase()));
+		expect(new Set(clis).size).toBe(clis.length);
+	});
+});
+
+describe("isDisallowedCliCommand", () => {
+	test("flags a vesctl command", () => {
+		expect(isDisallowedCliCommand("vesctl dns list")).toBe(true);
+	});
+
+	test("flags a curl against the F5 XC API", () => {
+		expect(isDisallowedCliCommand("curl $F5XC_API_URL/api/config/namespaces/default/http_loadbalancers")).toBe(true);
+	});
+
+	test("allows a normal non-F5XC command", () => {
+		expect(isDisallowedCliCommand("kubectl get pods")).toBe(false);
+	});
+
+	test("allows a curl to an unrelated host", () => {
+		expect(isDisallowedCliCommand("curl https://example.com/health")).toBe(false);
+	});
+
+	test("is case- and whitespace-insensitive on the leading token", () => {
+		expect(isDisallowedCliCommand("  VESCTL  dns list ")).toBe(true);
+	});
+});
+
+describe("renderDeprecationGuardrails", () => {
+	const block = renderDeprecationGuardrails();
+
+	test("forbids vesctl and points to xcsh_api", () => {
+		expect(block).toContain("vesctl");
+		expect(block).toContain("xcsh_api");
+	});
+
+	test("remaps the legacy API-docs URL to the enriched canonical URL", () => {
+		expect(block).toContain("docs.cloud.f5.com/docs-v2/api");
+		expect(block).toContain("f5-sales-demo.github.io/api-specs-enriched/en/");
+	});
+
+	test("captures the Volterra brand-vs-identifier nuance", () => {
+		expect(block).toContain("Volterra");
+		expect(block).toContain("F5 Distributed Cloud");
+		expect(block).toContain("volterra_*");
+	});
+
+	test("points to xcsh://branding for full detail", () => {
+		expect(block).toContain("xcsh://branding");
+	});
+});
+
+describe("XCSH_NATIVE_API_GUIDANCE", () => {
+	test("names the xcsh-native replacement path", () => {
+		expect(XCSH_NATIVE_API_GUIDANCE).toContain("xcsh_api");
+	});
+});

--- a/packages/coding-agent/test/embedded-specs-guard.test.ts
+++ b/packages/coding-agent/test/embedded-specs-guard.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+// Guard: the enriched API specs must ship embedded in the binary, and neither the
+// deprecated legacy API-docs path nor the abandoned `vesctl` CLI may leak into the
+// embedded spec/catalog data. (branding-index.generated.ts legitimately names both
+// as deprecations, so it is intentionally NOT scanned here.)
+
+const INTERNAL_URLS_DIR = path.resolve(import.meta.dir, "../src/internal-urls");
+const SPEC_INDEX = path.join(INTERNAL_URLS_DIR, "api-spec-index.generated.ts");
+const CATALOG_INDEX = path.join(INTERNAL_URLS_DIR, "api-catalog-index.generated.ts");
+
+const FORBIDDEN = ["docs-v2/api", "docs.cloud.f5.com/docs-v2/api", "vesctl"];
+
+describe("embedded enriched API specs", () => {
+	it("ships the api-spec index embedded and non-trivial", () => {
+		expect(existsSync(SPEC_INDEX)).toBe(true);
+		// The embedded OpenAPI payload is tens of MB; guard against an emptied/stub file.
+		expect(statSync(SPEC_INDEX).size).toBeGreaterThan(1_000_000);
+		const text = readFileSync(SPEC_INDEX, "utf-8");
+		expect(text).toContain("export const API_SPEC_DATA");
+		expect(text).toContain("export const API_SPEC_INDEX");
+		expect(text).toContain("export const API_SPEC_VERSION");
+	});
+
+	it("ships the api-catalog index embedded", () => {
+		expect(existsSync(CATALOG_INDEX)).toBe(true);
+		expect(statSync(CATALOG_INDEX).size).toBeGreaterThan(100_000);
+		expect(readFileSync(CATALOG_INDEX, "utf-8")).toContain("export const API_CATALOG_DATA");
+	});
+
+	it("contains no deprecated legacy API-docs URL or vesctl references", () => {
+		for (const file of [SPEC_INDEX, CATALOG_INDEX]) {
+			const text = readFileSync(file, "utf-8");
+			for (const needle of FORBIDDEN) {
+				expect(text.includes(needle), `${path.basename(file)} must not contain "${needle}"`).toBe(false);
+			}
+		}
+	});
+});

--- a/packages/coding-agent/test/internal-urls/api-spec-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/api-spec-resolve.test.ts
@@ -374,7 +374,7 @@ describe("API Spec Resolver", () => {
 			expect(result.content).toContain("Use batch operations");
 		});
 
-		it("renders CLI metadata when present", async () => {
+		it("suppresses deprecated vesctl commands and substitutes xcsh-native guidance", async () => {
 			const indexWithCli: ApiSpecIndex = {
 				...testIndex,
 				domains: [
@@ -395,8 +395,64 @@ describe("API Spec Resolver", () => {
 			};
 			const resolver = createApiSpecResolver(indexWithCli, testData);
 			const result = await resolver.resolve(parseUrl("xcsh://api-spec/dns"));
+			// The deprecated CLI must never surface as an instruction...
+			expect(result.content).not.toContain("vesctl");
+			// ...but the surrounding context and xcsh-native guidance are preserved.
 			expect(result.content).toContain("CLI Quick Start");
-			expect(result.content).toContain("vesctl dns list");
+			expect(result.content).toContain("List all zones");
+			expect(result.content).toContain("Create zone");
+			expect(result.content).toContain("xcsh_api");
+		});
+
+		it("suppresses raw curl against the F5 XC API", async () => {
+			const indexWithCurl: ApiSpecIndex = {
+				...testIndex,
+				domains: [
+					{
+						...testIndex.domains[0],
+						cliMetadata: {
+							quickStart: {
+								command: "curl $F5XC_API_URL/api/config/namespaces/default/dns_domains",
+								description: "List all zones",
+								expectedOutput: "zone list",
+							},
+							commonWorkflows: [],
+							troubleshooting: [],
+						},
+					},
+					testIndex.domains[1],
+				],
+			};
+			const resolver = createApiSpecResolver(indexWithCurl, testData);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/dns"));
+			expect(result.content).not.toContain("curl");
+			expect(result.content).toContain("xcsh_api");
+		});
+
+		it("renders non-deprecated CLI metadata verbatim", async () => {
+			const indexWithCli: ApiSpecIndex = {
+				...testIndex,
+				domains: [
+					{
+						...testIndex.domains[0],
+						cliMetadata: {
+							quickStart: {
+								command: "xcsh dns list",
+								description: "List all zones",
+								expectedOutput: "zone list",
+							},
+							commonWorkflows: [{ name: "Create zone", commands: ["xcsh dns create --name test"] }],
+							troubleshooting: [{ symptom: "Zone not found", fix: "Check namespace" }],
+						},
+					},
+					testIndex.domains[1],
+				],
+			};
+			const resolver = createApiSpecResolver(indexWithCli, testData);
+			const result = await resolver.resolve(parseUrl("xcsh://api-spec/dns"));
+			expect(result.content).toContain("CLI Quick Start");
+			expect(result.content).toContain("xcsh dns list");
+			expect(result.content).toContain("xcsh dns create --name test");
 			expect(result.content).toContain("Create zone");
 		});
 

--- a/packages/coding-agent/test/internal-urls/branding-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/branding-protocol.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { parseInternalUrl } from "../../src/internal-urls/parse";
+import { InternalDocsProtocolHandler } from "../../src/internal-urls/xcsh-protocol";
+
+// Verifies the data-driven deprecations (authored in branding.yaml) surface through
+// the xcsh://branding protocol — the progressive-disclosure counterpart to the
+// always-on system-prompt guardrails.
+describe("xcsh://branding host", () => {
+	it("overview surfaces the cli, api-docs, and brand deprecations", async () => {
+		const handler = new InternalDocsProtocolHandler();
+		const res = await handler.resolve(parseInternalUrl("xcsh://branding") as never);
+		expect(res.content).toContain("vesctl");
+		expect(res.content).toContain("docs.cloud.f5.com/docs-v2/api");
+		expect(res.content).toContain("api-specs-enriched/en/");
+		expect(res.content).toContain("Volterra");
+	});
+
+	it("volterra page maps deprecated tooling to canonical replacements", async () => {
+		const handler = new InternalDocsProtocolHandler();
+		const res = await handler.resolve(parseInternalUrl("xcsh://branding/volterra") as never);
+		expect(res.content).toContain("vesctl");
+		expect(res.content).toContain("F5 Distributed Cloud");
+		expect(res.content).toContain("api-specs-enriched/en/");
+	});
+});

--- a/packages/coding-agent/test/system-prompt-deprecations.test.ts
+++ b/packages/coding-agent/test/system-prompt-deprecations.test.ts
@@ -1,0 +1,34 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { registerCodingAgentPromptHelpers } from "../src/config/prompt-templates";
+import { buildSystemPrompt } from "../src/system-prompt";
+
+beforeAll(() => {
+	registerCodingAgentPromptHelpers();
+});
+
+// The guardrails MUST be present on every rendered system prompt — including code
+// paths that never consult the xcsh:// protocol.
+describe("system prompt deprecation guardrails", () => {
+	it("forbids vesctl and routes API calls to xcsh_api", async () => {
+		const rendered = await buildSystemPrompt({ tools: new Map() });
+		expect(rendered).toContain("vesctl");
+		expect(rendered).toContain("xcsh_api");
+	});
+
+	it("remaps the legacy API-docs URL to the embedded/enriched canonical URL", async () => {
+		const rendered = await buildSystemPrompt({ tools: new Map() });
+		expect(rendered).toContain("docs.cloud.f5.com/docs-v2/api");
+		expect(rendered).toContain("f5-sales-demo.github.io/api-specs-enriched/en/");
+	});
+
+	it("captures the Volterra brand-vs-identifier nuance", async () => {
+		const rendered = await buildSystemPrompt({ tools: new Map() });
+		expect(rendered).toContain("F5 Distributed Cloud");
+		expect(rendered).toContain("volterra_*");
+	});
+
+	it("renders no leftover template placeholder", async () => {
+		const rendered = await buildSystemPrompt({ tools: new Map() });
+		expect(rendered).not.toContain("{{deprecationGuardrails}}");
+	});
+});


### PR DESCRIPTION
## Summary

Makes three F5 XC deprecations unmissable to the agent, authored **once** in `api-specs-enriched/config/branding.yaml` (see f5-sales-demo/api-specs-enriched#972) and flowed through the embedded branding index to three surfaces via one behavioral helper — `packages/coding-agent/src/deprecations.ts` (DRY):

1. **`vesctl`** — the abandoned legacy CLI — is forbidden; `xcsh`/`xcsh_api` is the replacement.
2. **Legacy API docs** `docs.cloud.f5.com/docs-v2/api` → canonical `f5-sales-demo.github.io/api-specs-enriched/en/`, with a reminder that the enriched specs are already embedded (prefer `xcsh://api-catalog/`, `xcsh://api-spec/`).
3. **"Volterra" brand** is retired → **F5 Distributed Cloud**, while `volterra_*` API keys and `*.volterra.io`/`*.volterra.us` hostnames remain required functional identifiers.

### Surfaces
- **Always-on system prompt** — a `## Deprecation guardrails` section rendered from branding data and injected post-render, so it applies on every code path (not only when `xcsh://` is consulted), including custom prompts. The existing Terraform override is folded under it.
- **`xcsh://branding/*`** — already data-driven; the new entries surface automatically (now covered by tests).
- **CLI Quick Start renderer** (`api-spec-resolve.ts`) — suppresses/rewrites deprecated `vesctl` and raw F5 XC `curl` commands to xcsh-native guidance, even if an upstream spec carries them.

### Guard
- New CI test asserts the enriched API specs stay embedded (50 MB index present) and contain no `docs-v2/api` or `vesctl` leaks.

## Testing
- `bun test` — new/updated suites green (deprecations, system-prompt guardrails, branding protocol, embedded-specs guard, inverted api-spec-resolve vesctl assertion).
- Rendered the real system prompt and confirmed the guardrails section with no leftover sentinel.
- `tsgo --noEmit` and `biome check` clean; prompt formatter clean.

Depends on f5-sales-demo/api-specs-enriched#972 for the upstream source of truth (this PR's regenerated `branding-index.generated.ts` already contains the entries; xcsh CI does not regenerate branding-index during tests).

Closes #2008

🤖 Generated with [Claude Code](https://claude.com/claude-code)