### PR TITLE
refactor(coding-agent): disambiguate API-docs deprecation guardrail wording

### DIFF
--- a/packages/coding-agent/src/deprecations.ts
+++ b/packages/coding-agent/src/deprecations.ts
@@ -81,7 +81,7 @@ export function renderDeprecationGuardrails(): string {
 		"These deprecations are non-negotiable. Full detail lives at `xcsh://branding` and `xcsh://branding/volterra`, but the rules below apply even when that protocol is never consulted.",
 		"",
 		`- **Never use \`${vesctl}\`.** It is the abandoned, unsupported legacy CLI; \`${xcshCmd}\` is its modern replacement. Never propose, generate, or run \`${vesctl}\`. For F5 XC API calls use the \`xcsh_api\` tool (never raw \`curl\`); for console automation use \`catalog_workflow_runner\`.`,
-		`- **The legacy API docs are deprecated.** Never link or fetch \`${legacyApiUrl}\`. The canonical API reference is \`${enrichedUrl}\`, and the enriched specs are already embedded in this binary — prefer \`xcsh://api-catalog/\` and \`xcsh://api-spec/\` before fetching anything.`,
+		`- **The legacy API docs are deprecated.** Never link or fetch \`${legacyApiUrl}\`; the canonical human-facing API documentation site is \`${enrichedUrl}\`. For your own API work you rarely need either — the enriched OpenAPI specs ship embedded in this binary: use \`xcsh://api-catalog/\` (operations/CRUD) and \`xcsh://api-spec/\` (schemas) per the routing rules above.`,
 		`- **"${deadBrand}" is a retired brand name.** The product is **${currentBrand}**; never write "${deadBrand}" as a product name or recommend ${deadBrand}-labeled tooling. BUT \`volterra_*\` API keys, \`*.volterra.io\`/\`*.volterra.us\` hostnames, and schema identifiers are **required functional identifiers** — use them verbatim, exactly as the API expects. Only the brand name is dead, not the identifiers.`,
 	].join("\n");
 }


### PR DESCRIPTION
## Summary

Follow-up to #2009. The API-docs deprecation guardrail conflated three distinct things in one sentence: the `api-specs-enriched` GitHub **repo**, its **Pages docs site** (`f5-sales-demo.github.io/api-specs-enriched/en/`), and the specs **embedded** in the binary (served over `xcsh://api-spec/` and `xcsh://api-catalog/`).

Reworded `renderDeprecationGuardrails()` so the bullet:
- keeps the deprecation mapping (`docs.cloud.f5.com/docs-v2/api` → the canonical human docs site),
- and separately notes the embedded OpenAPI specs are reached via `xcsh://api-catalog/` (CRUD) and `xcsh://api-spec/` (schemas), cross-referencing the existing routing section instead of restating it.

Prompt-text only; no behavior change. Existing deprecation + system-prompt guardrail tests pass.

Closes #2013

🤖 Generated with [Claude Code](https://claude.com/claude-code)