### PR TITLE
refactor(coding-agent): stop rendering curl examples in api-catalog/api-spec resolvers

### DIFF
--- a/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-catalog-resolve.ts
@@ -44,7 +44,7 @@ export function createApiCatalogResolver(
 							if (categorySummaries.some(c => c.name === catName)) {
 								try {
 									const cat = lookup(catName);
-									return makeResource(url, renderCatalogDetail(cat, index, { compact }));
+									return makeResource(url, renderCatalogDetail(cat, { compact }));
 								} catch {
 									break;
 								}
@@ -77,7 +77,7 @@ export function createApiCatalogResolver(
 
 			try {
 				const cat = lookup(category);
-				return makeResource(url, renderCatalogDetail(cat, index, { compact }));
+				return makeResource(url, renderCatalogDetail(cat, { compact }));
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				return makeResource(url, `# Error loading ${category}\n\n${message}\n`);
@@ -200,7 +200,7 @@ function formatDefault(defaultVal: unknown, serverDefault: boolean | undefined):
 	return serverDefault ? `${val} (server)` : val;
 }
 
-function renderCatalogDetail(cat: ApiCatalogCategory, index: ApiCatalogIndex, options?: { compact?: boolean }): string {
+function renderCatalogDetail(cat: ApiCatalogCategory, options?: { compact?: boolean }): string {
 	const sections: string[] = [`# ${cat.displayName}`, "", `${cat.operations.length} operations.`];
 	let fieldConstraintsRenderedForOp: string | null = null;
 	let fieldConstraintsFingerprint: string | null = null;
@@ -228,20 +228,6 @@ function renderCatalogDetail(cat: ApiCatalogCategory, index: ApiCatalogIndex, op
 				sections.push(`Required fields: ${(minConfig.required_fields as string[]).join(", ")}`);
 			}
 		}
-
-		sections.push("", "### Curl Example", "", "```bash");
-		const tokenVar = `$${index.auth.tokenSource}`;
-		const authHeader = `${index.auth.headerName}: ${index.auth.headerTemplate.replace("$TOKEN", tokenVar).replace("{token}", tokenVar)}`;
-		sections.push(`curl -X ${op.method.toUpperCase()} "$${index.auth.baseUrlSource}${op.path}" \\`);
-		sections.push(`  -H "${authHeader}" \\`);
-		if (op.method.toUpperCase() !== "GET" && op.method.toUpperCase() !== "DELETE") {
-			sections.push('  -H "Content-Type: application/json" \\');
-			sections.push("  -d @payload.json");
-		} else {
-			const lastLine = sections[sections.length - 1];
-			sections[sections.length - 1] = lastLine.replace(/ \\$/, "");
-		}
-		sections.push("```");
 
 		// Minimum Configuration (Tier 1)
 		if (op.minimumPayload) {

--- a/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/api-spec-resolve.ts
@@ -476,9 +476,8 @@ function renderMinimumConfigSection(mc: ApiSpecMinimumConfiguration): string {
 		sections.push("### YAML Example", "", "```yaml", mc.example_yaml, "```", "");
 	}
 
-	if (mc.example_curl) {
-		sections.push("### curl Example", "", "```bash", mc.example_curl, "```", "");
-	}
+	// Deliberately no curl example — the agent uses the xcsh_api tool for F5 XC API
+	// calls and can synthesize a curl from method/path/payload on explicit human request.
 
 	return sections.join("\n");
 }

--- a/packages/coding-agent/test/internal-urls/api-catalog-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/api-catalog-resolve.test.ts
@@ -103,12 +103,11 @@ describe("API Catalog Resolver", () => {
 		expect(result.content).toContain("medium");
 	});
 
-	it("renders curl template for operations", async () => {
+	it("does not render curl for operations (agent uses the xcsh_api tool)", async () => {
 		const resolver = createApiCatalogResolver(testCatalogIndex, testCategorySummaries, testCatalogData);
 		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/dns-zone"));
-		expect(result.content).toContain("curl");
-		expect(result.content).toContain("$XCSH_API_URL");
-		expect(result.content).toContain("$XCSH_API_TOKEN");
+		expect(result.content).not.toContain("curl");
+		expect(result.content).not.toContain("Curl Example");
 	});
 
 	it("returns helpful error for unknown category", async () => {
@@ -283,7 +282,7 @@ describe("API Catalog Resolver", () => {
 		expect(result.content).not.toContain("### Minimum Configuration");
 		expect(result.content).not.toContain("### Field Constraints");
 		expect(result.content).not.toContain("### OneOf Groups");
-		expect(result.content).toContain("### Curl Example");
+		expect(result.content).not.toContain("Curl Example");
 	});
 
 	it("deduplicates field constraints for POST/PUT with differing provenance timestamps", async () => {
@@ -417,7 +416,7 @@ describe("API Catalog Resolver", () => {
 		const resolver = createApiCatalogResolver(testCatalogIndex, summaries, data);
 		const result = await resolver.resolve(parseUrl("xcsh://api-catalog/test-resources?compact=true"));
 		expect(result.content).toContain("### Minimum Configuration");
-		expect(result.content).toContain("### Curl Example");
+		expect(result.content).not.toContain("Curl Example");
 		expect(result.content).toContain("### OneOf Groups");
 		expect(result.content).not.toContain("### Field Constraints");
 	});

--- a/packages/coding-agent/test/internal-urls/api-spec-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/api-spec-resolve.test.ts
@@ -1307,7 +1307,9 @@ describe("API Spec Resolver", () => {
 			expect(result.content).toContain("metadata.name");
 			expect(result.content).toContain("metadata.namespace");
 			expect(result.content).toContain("example");
-			expect(result.content).toContain("curl");
+			// example_curl is present in the enrichment fixture but must NOT be rendered —
+			// the agent uses xcsh_api and can synthesize curl on explicit human request.
+			expect(result.content).not.toContain("curl");
 		});
 
 		it("does not render Quick Start when no min-config data exists", async () => {


### PR DESCRIPTION
## Summary

Follow-up to the deprecation-guardrails work (#2009). The agent's API path is the built-in `xcsh_api` tool (hard rule: never construct curl for F5 XC API calls), but the internal-URL resolvers still handed it curl on the primary paths:

- `xcsh://api-catalog/{category}` rendered a **synthesized** "### Curl Example" for every operation, **even in `?compact=true`** (the CRUD path).
- `xcsh://api-spec/{domain}?resource=` rendered a **curated** `example_curl` in the Minimum Configuration section.

Both are removed. **No information is lost:** the output still carries method, path, the uniform auth pattern, and the payload (`example_json`/`example_yaml`), so the agent can synthesize a curl on explicit human request — while its own calls go through `xcsh_api`. Also drops the now-unused `index` argument from `renderCatalogDetail`.

Embedded `example_curl` data is left in place (harmless); trimming it from the upstream enricher is tracked in f5-sales-demo/api-specs-enriched.

## Testing
- Updated 4 assertions (catalog + api-spec) to require curl is **absent** even when `example_curl` data is present; 88 resolver tests green.
- Verified against real embedded data: `xcsh://api-catalog/?resource=http_loadbalancer` and `xcsh://api-spec/dns?resource=dns_zone` no longer contain curl but retain method/path and the JSON payload.
- `tsgo --noEmit` and `biome check` clean.

Closes #2016

🤖 Generated with [Claude Code](https://claude.com/claude-code)