### PR TITLE
Add one-shot workflow to provision Apple secrets into claude-office

### DIFF
--- a/.github/workflows/provision-claude-office-secrets.yml
+++ b/.github/workflows/provision-claude-office-secrets.yml
@@ -1,0 +1,75 @@
+name: provision-claude-office-secrets
+
+# One-shot, MANUALLY-triggered job that copies this repo's Apple code-signing
+# secrets into another repo (default: f5-sales-demo/claude-office) so its release
+# pipeline can Developer ID-sign and notarize its binaries.
+#
+# Why a workflow: GitHub secrets are write-only, so the values cannot be read
+# back out with `gh`. They *are* available to a job at runtime, so this job
+# relays them into the target repo with `gh secret set` (which encrypts each
+# value client-side before upload).
+#
+# Requirements:
+#   - A repo secret PROVISION_TOKEN on THIS repo: a PAT with "Secrets: write"
+#     (Actions secrets) on the target repo. A fine-grained PAT scoped to just
+#     the target repo is recommended (least privilege). Do NOT hardcode a token
+#     in this file. (You can instead point GH_TOKEN at an existing token secret
+#     such as REPO_SETTINGS_TOKEN by editing the one line below.)
+#
+# This is provisioning tooling, not part of the build. Treat it as a one-shot:
+# run it once, confirm with `gh secret list -R <target>`, then DELETE this file.
+# While present it is a standing path that copies signing secrets to another
+# repo, so anyone who can trigger/edit workflows here could repoint it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_repo:
+        description: "Target repo (owner/name) to receive the Apple secrets"
+        required: true
+        default: "f5-sales-demo/claude-office"
+
+permissions: {}
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.PROVISION_TOKEN }}
+      TARGET_REPO: ${{ inputs.target_repo }}
+      APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+    steps:
+      - name: Copy Apple signing secrets to the target repo
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::PROVISION_TOKEN is not set on this repo. Create a PAT with"
+            echo "::error::'Secrets: write' on ${TARGET_REPO} and add it as secret PROVISION_TOKEN."
+            exit 1
+          fi
+
+          # Secret values come from the secrets context and are auto-masked in logs;
+          # gh secret set does not print them. Names are echoed for confirmation only.
+          set_secret() {
+            name="$1"; value="$2"
+            if [ -z "$value" ]; then
+              echo "::error::source secret ${name} is empty on this repo — nothing to copy"; exit 1
+            fi
+            printf '%s' "$value" | gh secret set "$name" -R "$TARGET_REPO"
+            echo "  set ${name} on ${TARGET_REPO}"
+          }
+
+          echo "Provisioning Apple signing secrets into ${TARGET_REPO}:"
+          set_secret APPLE_CERTIFICATE_BASE64   "$APPLE_CERTIFICATE_BASE64"
+          set_secret APPLE_CERTIFICATE_PASSWORD "$APPLE_CERTIFICATE_PASSWORD"
+          set_secret APPLE_ID                   "$APPLE_ID"
+          set_secret APPLE_PASSWORD             "$APPLE_PASSWORD"
+          set_secret APPLE_TEAM_ID              "$APPLE_TEAM_ID"
+
+          echo "Done. Verify with:  gh secret list -R ${TARGET_REPO}"
+          echo "Then DELETE this workflow file (.github/workflows/provision-claude-office-secrets.yml)."


### PR DESCRIPTION
## Summary

Adds a **manually-triggered, one-shot** workflow that copies this repo's 5 `APPLE_*` code-signing secrets into a target repo (default `f5-sales-demo/claude-office`), so that repo's new Developer ID signing + notarization release pipeline can run.

GitHub secrets are write-only, so the values can't be read back with `gh` to copy by hand — but they're available to a job at runtime, so this relays them with `gh secret set` (each value encrypted client-side before upload, auto-masked in logs).

## Safety properties
- **No hardcoded token.** Auth comes from a `PROVISION_TOKEN` repo secret — a PAT with `Secrets: write` on the target repo (fine-grained / least-privilege recommended). One line can instead point it at an existing token secret.
- `permissions: {}` — the job requests no `GITHUB_TOKEN` scope.
- `target_repo` is a `workflow_dispatch` input consumed via `env:` (`$TARGET_REPO`), never interpolated into the `run:` block — no injection surface.
- Fails fast if `PROVISION_TOKEN` or any source secret is empty.

## How to use
1. Create a PAT with `Secrets: write` on `f5-sales-demo/claude-office`; add it here as secret `PROVISION_TOKEN`.
2. Merge this PR (workflow_dispatch requires the file on the default branch).
3. Actions → **provision-claude-office-secrets** → Run workflow.
4. Verify: `gh secret list -R f5-sales-demo/claude-office`.
5. **Delete this workflow file** — it's provisioning tooling, not part of the build. While present it's a standing path that copies signing secrets to another repo.

Closes #2034

🤖 Generated with [Claude Code](https://claude.com/claude-code)