### PR TITLE
Reuse REPO_SETTINGS_TOKEN in provisioning workflow (fix unset PROVISION_TOKEN)

### DIFF
--- a/.github/workflows/provision-claude-office-secrets.yml
+++ b/.github/workflows/provision-claude-office-secrets.yml
@@ -35,7 +35,11 @@ jobs:
   provision:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.PROVISION_TOKEN }}
+      # Reuse a token secret already stored in this repo (no new PAT to create or
+      # type). REPO_SETTINGS_TOKEN is expected to carry Secrets:write on the target;
+      # if it does not, the run fails clearly and you can swap this to another secret
+      # (e.g. RELEASE_TOKEN) or set a dedicated PROVISION_TOKEN.
+      GH_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
       TARGET_REPO: ${{ inputs.target_repo }}
       APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
       APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -48,8 +52,8 @@ jobs:
           set -euo pipefail
 
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::PROVISION_TOKEN is not set on this repo. Create a PAT with"
-            echo "::error::'Secrets: write' on ${TARGET_REPO} and add it as secret PROVISION_TOKEN."
+            echo "::error::GH_TOKEN is empty — the referenced token secret is not set on this repo."
+            echo "::error::Point GH_TOKEN at a secret holding a token with 'Secrets: write' on ${TARGET_REPO}."
             exit 1
           fi
 


### PR DESCRIPTION
The `provision-claude-office-secrets` workflow (merged in #2035) authenticated with `secrets.PROVISION_TOKEN`, which isn't set on this repo — so the first `workflow_dispatch` run failed at the token guard (correctly, before writing any secret). The `REPO_SETTINGS_TOKEN` change was on the PR branch but the auto-merge squashed at the first commit before it landed.

This switches `GH_TOKEN` to the existing `secrets.REPO_SETTINGS_TOKEN` so no new PAT is needed. If that token lacks `Secrets: write` on the target, the run fails with a clear message and the line can be pointed at another secret.

Closes #2036