### PR TITLE
fix: make context-command homepage link relative (#2040)

### DIFF
--- a/docs/ar/index.md
+++ b/docs/ar/index.md
@@ -7,7 +7,7 @@ sidebar:
   order: 0
   label: نظرة عامة
 i18n:
-  sourceHash: b9288f42bf46
+  sourceHash: 9e7a0aa5e28b
   translator: machine
 ---
 
@@ -16,7 +16,7 @@ xcsh هي واجهة سطر أوامر للتطوير مدعومة بالذكا�
 
 ## من أين تبدأ
 
-- **[سياقات F5 XC](/runtime-tools/context-command)** — الاتصال بمستأجري F5 Distributed Cloud.
+- **[سياقات F5 XC](runtime-tools/context-command)** — الاتصال بمستأجري F5 Distributed Cloud.
   إنشاء السياقات، والتبديل بينها، وإدارة مساحات الأسماء وبيانات الاعتماد.
 - **الإعداد** — كيفية اكتشاف xcsh للإعداد وحله وتطبيق طبقاته.
 - **بيئة التشغيل والأدوات** — بيئات تشغيل أدوات bash / notebook / resolve وواجهة أوامر الشرطة المائلة.

--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -7,7 +7,7 @@ sidebar:
   order: 0
   label: Überblick
 i18n:
-  sourceHash: b9288f42bf46
+  sourceHash: 9e7a0aa5e28b
   translator: machine
 ---
 
@@ -20,7 +20,7 @@ Plattform-Packaging für Linux, macOS und Windows.
 
 ## Wo Sie beginnen sollten
 
-- **[F5 XC Kontexte](/runtime-tools/context-command)** — Verbindung zu F5 Distributed Cloud
+- **[F5 XC Kontexte](runtime-tools/context-command)** — Verbindung zu F5 Distributed Cloud
   Tenants herstellen. Kontexte erstellen, zwischen ihnen wechseln, Namespaces und Anmeldeinformationen verwalten.
 - **Konfiguration** — wie xcsh Konfigurationen erkennt, auflöst und schichtet.
 - **Laufzeit & Tools** — die Bash- / Notebook- / Resolve-Tool-Laufzeitumgebungen und die

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -15,7 +15,7 @@ packaging targeting Linux, macOS, and Windows.
 
 ## Where to start
 
-- **[F5 XC Contexts](/runtime-tools/context-command)** — connect to F5 Distributed Cloud
+- **[F5 XC Contexts](runtime-tools/context-command)** — connect to F5 Distributed Cloud
   tenants. Create contexts, switch between them, manage namespaces and credentials.
 - **Configuration** — how xcsh discovers, resolves, and layers configuration.
 - **Runtime & Tools** — the bash / notebook / resolve tool runtimes and the

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -8,7 +8,7 @@ sidebar:
   order: 0
   label: Descripción general
 i18n:
-  sourceHash: b9288f42bf46
+  sourceHash: 9e7a0aa5e28b
   translator: machine
 ---
 
@@ -21,7 +21,7 @@ empaquetado de plataforma dirigido a Linux, macOS y Windows.
 
 ## Por dónde empezar
 
-- **[Contextos F5 XC](/runtime-tools/context-command)** — conectarse a tenants de F5 Distributed Cloud.
+- **[Contextos F5 XC](runtime-tools/context-command)** — conectarse a tenants de F5 Distributed Cloud.
   Crear contextos, alternar entre ellos, gestionar espacios de nombres y credenciales.
 - **Configuración** — cómo xcsh descubre, resuelve y organiza por capas la configuración.
 - **Runtime y herramientas** — los runtimes de bash / notebook / herramienta resolve y la

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -7,7 +7,7 @@ sidebar:
   order: 0
   label: Vue d'ensemble
 i18n:
-  sourceHash: b9288f42bf46
+  sourceHash: 9e7a0aa5e28b
   translator: machine
 ---
 
@@ -16,7 +16,7 @@ xcsh est un CLI de développement alimenté par l'IA, doté d'un agent de codage
 
 ## Par où commencer
 
-- **[Contextes F5 XC](/runtime-tools/context-command)** — connectez-vous aux tenants F5 Distributed Cloud. Créez des contextes, basculez entre eux, gérez les espaces de noms et les identifiants.
+- **[Contextes F5 XC](runtime-tools/context-command)** — connectez-vous aux tenants F5 Distributed Cloud. Créez des contextes, basculez entre eux, gérez les espaces de noms et les identifiants.
 - **Configuration** — comment xcsh découvre, résout et superpose la configuration.
 - **Runtime et outils** — les environnements d'exécution bash / notebook / resolve et la surface des commandes slash.
 - **Sessions** — journal d'entrées en ajout seul, navigation arborescente, compaction et système de mémoire autonome.

--- a/docs/hi/index.md
+++ b/docs/hi/index.md
@@ -8,7 +8,7 @@ sidebar:
   order: 0
   label: अवलोकन
 i18n:
-  sourceHash: b9288f42bf46
+  sourceHash: 9e7a0aa5e28b
   translator: machine
 ---
 
@@ -21,7 +21,7 @@ Rust नेटिव लेयर (`pi-natives`) शामिल है। य�
 
 ## शुरू कहाँ से करें
 
-- **[F5 XC कंटेक्स्ट](/runtime-tools/context-command)** — F5 Distributed Cloud
+- **[F5 XC कंटेक्स्ट](runtime-tools/context-command)** — F5 Distributed Cloud
   टेनेंट से कनेक्ट करें। कंटेक्स्ट बनाएँ, उनके बीच स्विच करें, नेमस्पेस और क्रेडेंशियल प्रबंधित करें।
 - **कॉन्फ़िगरेशन** — xcsh किस प्रकार कॉन्फ़िगरेशन को खोजता, हल करता और लेयर करता है।
 - **रनटाइम और उपकरण** — bash / नोटबुक / रिज़ॉल्व उपकरण रनटाइम और

--- a/docs/it/index.md
+++ b/docs/it/index.md
@@ -8,7 +8,7 @@ sidebar:
   order: 0
   label: Panoramica
 i18n:
-  sourceHash: b9288f42bf46
+  sourceHash: 9e7a0aa5e28b
   translator: machine
 ---
 
@@ -21,7 +21,7 @@ packaging multipiattaforma per Linux, macOS e Windows.
 
 ## Da dove iniziare
 
-- **[Contesti F5 XC](/runtime-tools/context-command)** — connessione ai tenant F5 Distributed Cloud.
+- **[Contesti F5 XC](runtime-tools/context-command)** — connessione ai tenant F5 Distributed Cloud.
   Creazione di contesti, passaggio tra di essi, gestione di namespace e credenziali.
 - **Configurazione** — come xcsh individua, risolve e stratifica la configurazione.
 - **Runtime e Strumenti** — i runtime degli strumenti bash / notebook / resolve e la

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -6,7 +6,7 @@ sidebar:
   order: 0
   label: 概要
 i18n:
-  sourceHash: b9288f42bf46
+  sourceHash: 9e7a0aa5e28b
   translator: machine
 ---
 
@@ -14,7 +14,7 @@ xcshは、TypeScriptコーディングエージェントとRustネイティブ�
 
 ## はじめに
 
-- **[F5 XC コンテキスト](/runtime-tools/context-command)** — F5 Distributed Cloudテナントに接続します。コンテキストの作成、切り替え、名前空間と資格情報の管理を行います。
+- **[F5 XC コンテキスト](runtime-tools/context-command)** — F5 Distributed Cloudテナントに接続します。コンテキストの作成、切り替え、名前空間と資格情報の管理を行います。
 - **設定** — xcshが設定を検出、解決、およびレイヤー化する方法。
 - **ランタイムとツール** — bash / notebook / resolveツールランタイムとスラッシュコマンドの表面。
 - **セッション** — 追記専用エントリログ、ツリーナビゲーション、コンパクション、および自律メモリシステム。

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -7,7 +7,7 @@ sidebar:
   order: 0
   label: 개요
 i18n:
-  sourceHash: b9288f42bf46
+  sourceHash: 9e7a0aa5e28b
   translator: machine
 ---
 
@@ -18,7 +18,7 @@ Python IPython 도구, 완전한 MCP 지원, 스킬 시스템, 그리고 Linux, 
 
 ## 시작하기
 
-- **[F5 XC 컨텍스트](/runtime-tools/context-command)** — F5 Distributed Cloud
+- **[F5 XC 컨텍스트](runtime-tools/context-command)** — F5 Distributed Cloud
   테넌트에 연결합니다. 컨텍스트를 생성하고, 전환하며, 네임스페이스와 자격 증명을 관리합니다.
 - **구성** — xcsh가 구성을 탐색, 해석, 계층화하는 방법입니다.
 - **런타임 및 도구** — bash / 노트북 / resolve 도구 런타임과

--- a/docs/pt-br/index.md
+++ b/docs/pt-br/index.md
@@ -8,7 +8,7 @@ sidebar:
   order: 0
   label: Visão Geral
 i18n:
-  sourceHash: b9288f42bf46
+  sourceHash: 9e7a0aa5e28b
   translator: machine
 ---
 
@@ -21,7 +21,7 @@ empacotamento multiplataforma para Linux, macOS e Windows.
 
 ## Por onde começar
 
-- **[Contextos F5 XC](/runtime-tools/context-command)** — conecte-se a tenants do F5 Distributed Cloud.
+- **[Contextos F5 XC](runtime-tools/context-command)** — conecte-se a tenants do F5 Distributed Cloud.
   Crie contextos, alterne entre eles, gerencie namespaces e credenciais.
 - **Configuração** — como o xcsh descobre, resolve e organiza a configuração em camadas.
 - **Runtime e Ferramentas** — os runtimes de bash / notebook / resolve tool e a

--- a/docs/th/index.md
+++ b/docs/th/index.md
@@ -7,7 +7,7 @@ sidebar:
   order: 0
   label: ภาพรวม
 i18n:
-  sourceHash: b9288f42bf46
+  sourceHash: 9e7a0aa5e28b
   translator: machine
 ---
 
@@ -20,7 +20,7 @@ runtime ที่แข็งแกร่ง, เซสชันแบบยา�
 
 ## จุดเริ่มต้น
 
-- **[F5 XC Contexts](/runtime-tools/context-command)** — เชื่อมต่อกับ F5 Distributed Cloud
+- **[F5 XC Contexts](runtime-tools/context-command)** — เชื่อมต่อกับ F5 Distributed Cloud
   tenants สร้าง contexts, สลับระหว่าง contexts, จัดการ namespaces และ credentials
 - **การกำหนดค่า** — วิธีที่ xcsh ค้นหา, resolve และจัดเลเยอร์การกำหนดค่า
 - **Runtime และเครื่องมือ** — รันไทม์ของ bash / notebook / resolve tool และ

--- a/docs/zh-cn/index.md
+++ b/docs/zh-cn/index.md
@@ -5,7 +5,7 @@ sidebar:
   order: 0
   label: 概述
 i18n:
-  sourceHash: b9288f42bf46
+  sourceHash: 9e7a0aa5e28b
   translator: machine
 ---
 
@@ -18,7 +18,7 @@ Linux、macOS 和 Windows 的平台打包。
 
 ## 从哪里开始
 
-- **[F5 XC 上下文](/runtime-tools/context-command)** — 连接到 F5 Distributed Cloud
+- **[F5 XC 上下文](runtime-tools/context-command)** — 连接到 F5 Distributed Cloud
   租户。创建上下文、在上下文间切换、管理命名空间和凭据。
 - **配置** — xcsh 如何发现、解析和分层配置。
 - **运行时与工具** — bash / notebook / resolve 工具运行时以及

--- a/docs/zh-tw/index.md
+++ b/docs/zh-tw/index.md
@@ -5,7 +5,7 @@ sidebar:
   order: 0
   label: 概覽
 i18n:
-  sourceHash: b9288f42bf46
+  sourceHash: 9e7a0aa5e28b
   translator: machine
 ---
 
@@ -14,7 +14,7 @@ xcsh 是一個具備 AI 驅動的開發 CLI，搭配 TypeScript 編碼代理與 
 
 ## 從何開始
 
-- **[F5 XC 情境](/runtime-tools/context-command)** — 連線至 F5 Distributed Cloud 租戶。建立情境、切換情境、管理命名空間與憑證。
+- **[F5 XC 情境](runtime-tools/context-command)** — 連線至 F5 Distributed Cloud 租戶。建立情境、切換情境、管理命名空間與憑證。
 - **設定** — xcsh 如何探索、解析及分層設定。
 - **執行環境與工具** — bash / notebook / resolve 工具執行環境以及斜線命令介面。
 - **會話** — 僅附加的項目日誌、樹狀導覽、壓縮，以及自主記憶系統。


### PR DESCRIPTION
## Summary

`[F5 XC Contexts](/runtime-tools/context-command)` on the docs homepage dropped the `/xcsh/` base path and 404'd. Removed the leading slash across all 13 locale `index.md` files so it resolves relative to the base.

## Verification

- `grep -rn '](/runtime-tools/context-command)' docs` → **0** residual.
- Local translation-freshness audit → **fresh** (re-stamped sourceHash for the changed English file).
- Post-merge: link resolves 200 under `/xcsh/`.

Fixes #2040