### PR TITLE
fix: restore user-profile seed collectors so xcsh://user?seed=true populates (#2043)

### DIFF
--- a/packages/coding-agent/src/internal-urls/profile-collectors.ts
+++ b/packages/coding-agent/src/internal-urls/profile-collectors.ts
@@ -1,4 +1,4 @@
-import { logger } from "@f5-sales-demo/pi-utils";
+import { $which, logger } from "@f5-sales-demo/pi-utils";
 import { $ } from "bun";
 
 import type { UserProfile } from "./user-profile";
@@ -17,7 +17,230 @@ export interface ProfileCollector {
 }
 
 // ---------------------------------------------------------------------------
-// System (macOS)
+// Shared helpers (pure — unit-tested directly, no I/O)
+// ---------------------------------------------------------------------------
+
+/**
+ * Split a full name into given + family. The first whitespace token is the
+ * given name; everything after it is the family name. Blank input yields {}.
+ */
+export function splitFullName(full: string): { givenName?: string; familyName?: string } {
+	const trimmed = full.trim();
+	if (!trimmed) return {};
+	const parts = trimmed.split(/\s+/);
+	const out: { givenName?: string; familyName?: string } = { givenName: parts[0] };
+	if (parts.length > 1) out.familyName = parts.slice(1).join(" ");
+	return out;
+}
+
+// ---------------------------------------------------------------------------
+// Salesforce
+// ---------------------------------------------------------------------------
+
+const SALESFORCE_SOQL_FIELDS =
+	"Id, Username, FirstName, LastName, Email, Title, Department, Division, CompanyName, " +
+	"ManagerId, Manager.Name, Manager.Email, Street, City, State, PostalCode, Country, Phone, MobilePhone";
+
+/** Map a single Salesforce `User` SOQL record onto profile fields. */
+export function parseSalesforceUserRecord(rec: Record<string, unknown>): Partial<UserProfile> {
+	const profile: Partial<UserProfile> = {};
+
+	if (rec.FirstName) profile.givenName = rec.FirstName as string;
+	if (rec.LastName) profile.familyName = rec.LastName as string;
+	if (rec.Email) profile.email = rec.Email as string;
+
+	const phone = (rec.Phone || rec.MobilePhone) as string | undefined;
+	if (phone) profile.telephone = phone;
+
+	if (rec.Title) profile.jobTitle = rec.Title as string;
+	if (rec.Department) profile.department = rec.Department as string;
+	if (rec.Division) profile.division = rec.Division as string;
+
+	profile.worksFor = { name: (rec.CompanyName as string) || "F5" };
+
+	const mgr = rec.Manager as Record<string, unknown> | undefined;
+	if (mgr && (mgr.Name || mgr.Email)) {
+		profile.manager = {};
+		if (mgr.Name) Object.assign(profile.manager, splitFullName(mgr.Name as string));
+		if (mgr.Email) profile.manager.email = mgr.Email as string;
+	}
+
+	const street = rec.Street as string | undefined;
+	const city = rec.City as string | undefined;
+	const state = rec.State as string | undefined;
+	const postalCode = rec.PostalCode as string | undefined;
+	const country = rec.Country as string | undefined;
+	if (street || city || state || postalCode || country) {
+		profile.address = {};
+		if (street) profile.address.streetAddress = street;
+		if (city) profile.address.addressLocality = city;
+		if (state) profile.address.addressRegion = state;
+		if (postalCode) profile.address.postalCode = postalCode;
+		if (country) profile.address.addressCountry = country;
+	}
+
+	if (rec.Id) profile.identifiers = { ...profile.identifiers, salesforceId: rec.Id as string };
+
+	return profile;
+}
+
+const salesforceCollector: ProfileCollector = {
+	id: "salesforce",
+	name: "Salesforce",
+	authoritativeFields: ["givenName", "familyName", "email", "jobTitle", "department", "division", "worksFor"],
+
+	async available(): Promise<boolean> {
+		if (!$which("sf")) return false;
+		try {
+			const proc = await $`sf org display --json`.quiet().nothrow();
+			if (proc.exitCode !== 0) return false;
+			const parsed = JSON.parse(proc.stdout.toString()) as Record<string, unknown>;
+			const result = parsed.result as Record<string, unknown> | undefined;
+			return typeof result?.username === "string" && result.username.length > 0;
+		} catch {
+			return false;
+		}
+	},
+
+	async collect(): Promise<Partial<UserProfile>> {
+		try {
+			const orgProc = await $`sf org display --json`.quiet().nothrow();
+			if (orgProc.exitCode !== 0) return {};
+			const orgData = JSON.parse(orgProc.stdout.toString()) as Record<string, unknown>;
+			const orgResult = orgData.result as Record<string, unknown> | undefined;
+			const username = orgResult?.username as string | undefined;
+			if (!username) return {};
+
+			const soql = `SELECT ${SALESFORCE_SOQL_FIELDS} FROM User WHERE Username = '${username}'`;
+			const queryProc = await $`sf data query --query ${soql} --json`.quiet().nothrow();
+			if (queryProc.exitCode !== 0) return {};
+
+			const queryData = JSON.parse(queryProc.stdout.toString()) as Record<string, unknown>;
+			const queryResult = queryData.result as Record<string, unknown> | undefined;
+			const records = queryResult?.records as Record<string, unknown>[] | undefined;
+			const rec = records?.[0];
+			if (!rec) return {};
+
+			return parseSalesforceUserRecord(rec);
+		} catch (err: unknown) {
+			logger.debug("salesforce collector failed", { error: err });
+			return {};
+		}
+	},
+};
+
+// ---------------------------------------------------------------------------
+// GitHub
+// ---------------------------------------------------------------------------
+
+/** Map `gh api user` JSON output onto profile fields. */
+export function parseGithubUserJson(stdout: string): Partial<UserProfile> {
+	let data: Record<string, unknown>;
+	try {
+		data = JSON.parse(stdout) as Record<string, unknown>;
+	} catch {
+		return {};
+	}
+
+	const profile: Partial<UserProfile> = {};
+	const sameAs: string[] = [];
+
+	const login = data.login as string | undefined;
+	if (login) {
+		profile.identifiers = { ...profile.identifiers, github: login };
+		sameAs.push(`https://github.com/${login}`);
+	}
+
+	const name = data.name as string | undefined;
+	if (name) Object.assign(profile, splitFullName(name));
+
+	const email = data.email as string | undefined;
+	if (email) profile.email = email;
+
+	const bio = data.bio as string | undefined;
+	if (bio) profile.description = bio;
+
+	const blog = data.blog as string | undefined;
+	if (blog) {
+		profile.url = blog;
+		sameAs.push(blog);
+	}
+
+	const twitterUsername = data.twitter_username as string | undefined;
+	if (twitterUsername) {
+		profile.identifiers = { ...profile.identifiers, twitter: twitterUsername };
+		sameAs.push(`https://x.com/${twitterUsername}`);
+	}
+
+	if (sameAs.length > 0) profile.sameAs = sameAs;
+
+	return profile;
+}
+
+const githubCollector: ProfileCollector = {
+	id: "github",
+	name: "GitHub",
+
+	async available(): Promise<boolean> {
+		if (!$which("gh")) return false;
+		try {
+			const proc = await $`gh auth status`.quiet().nothrow();
+			return proc.exitCode === 0;
+		} catch {
+			return false;
+		}
+	},
+
+	async collect(): Promise<Partial<UserProfile>> {
+		try {
+			const proc = await $`gh api user`.quiet().nothrow();
+			if (proc.exitCode !== 0) return {};
+			return parseGithubUserJson(proc.stdout.toString());
+		} catch (err: unknown) {
+			logger.debug("github collector failed", { error: err });
+			return {};
+		}
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Git (local config)
+// ---------------------------------------------------------------------------
+
+const gitCollector: ProfileCollector = {
+	id: "git",
+	name: "Git",
+
+	async available(): Promise<boolean> {
+		return Boolean($which("git"));
+	},
+
+	async collect(): Promise<Partial<UserProfile>> {
+		try {
+			const profile: Partial<UserProfile> = {};
+
+			const nameProc = await $`git config --get user.name`.quiet().nothrow();
+			if (nameProc.exitCode === 0) {
+				const name = nameProc.stdout.toString().trim();
+				if (name) Object.assign(profile, splitFullName(name));
+			}
+
+			const emailProc = await $`git config --get user.email`.quiet().nothrow();
+			if (emailProc.exitCode === 0) {
+				const email = emailProc.stdout.toString().trim();
+				if (email) profile.email = email;
+			}
+
+			return profile;
+		} catch (err: unknown) {
+			logger.debug("git collector failed", { error: err });
+			return {};
+		}
+	},
+};
+
+// ---------------------------------------------------------------------------
+// System (identity + UI languages)
 // ---------------------------------------------------------------------------
 
 async function detectDarwinLanguages(): Promise<string[]> {
@@ -56,6 +279,23 @@ function detectLinuxLanguages(): string[] {
 	return languages;
 }
 
+/** Best-effort full name from the OS account record (macOS `id -F`, Linux GECOS). */
+async function detectSystemFullName(): Promise<string> {
+	if (process.platform === "darwin") {
+		const proc = await $`id -F`.quiet().nothrow();
+		if (proc.exitCode === 0) return proc.stdout.toString().trim();
+		return "";
+	}
+
+	// Linux: GECOS field (comma-separated) of the passwd entry for the current user.
+	const user = process.env.USER || process.env.LOGNAME;
+	if (!user || !$which("getent")) return "";
+	const proc = await $`getent passwd ${user}`.quiet().nothrow();
+	if (proc.exitCode !== 0) return "";
+	const gecos = proc.stdout.toString().trim().split(":")[6] ?? "";
+	return gecos.split(",")[0]?.trim() ?? "";
+}
+
 const systemCollector: ProfileCollector = {
 	id: "system",
 	name: "System",
@@ -65,23 +305,32 @@ const systemCollector: ProfileCollector = {
 	},
 
 	async collect(): Promise<Partial<UserProfile>> {
+		const profile: Partial<UserProfile> = {};
+		try {
+			const fullName = await detectSystemFullName();
+			if (fullName) Object.assign(profile, splitFullName(fullName));
+		} catch (err: unknown) {
+			logger.debug("system collector: name detection failed", { error: err });
+		}
 		try {
 			const languages = process.platform === "darwin" ? await detectDarwinLanguages() : detectLinuxLanguages();
-
-			if (languages.length === 0) return {};
-			return { knowsLanguage: languages };
+			if (languages.length > 0) profile.knowsLanguage = languages;
 		} catch (err: unknown) {
-			logger.debug("system collector failed", { error: err });
-			return {};
+			logger.debug("system collector: language detection failed", { error: err });
 		}
+		return profile;
 	},
 };
 
 // ---------------------------------------------------------------------------
 // Registry
+//
+// Order encodes seed priority: `mergeProfile` is first-wins for scalar fields,
+// so higher-trust identity sources come first (Salesforce → GitHub → git →
+// system). Plugins may append more via `registerProfileCollector`.
 // ---------------------------------------------------------------------------
 
-const _collectors: ProfileCollector[] = [systemCollector];
+const _collectors: ProfileCollector[] = [salesforceCollector, githubCollector, gitCollector, systemCollector];
 
 export const PROFILE_COLLECTORS: readonly ProfileCollector[] = _collectors;
 

--- a/packages/coding-agent/src/internal-urls/user-profile.ts
+++ b/packages/coding-agent/src/internal-urls/user-profile.ts
@@ -45,7 +45,7 @@ export interface UserProfile {
 	description?: string;
 	image?: string;
 	sameAs?: string[];
-	identifiers?: { github?: string; twitter?: string };
+	identifiers?: { github?: string; twitter?: string; salesforceId?: string };
 	/** User-authored: short role label, e.g. 'SE', 'AE', 'CSM', 'SA'. Set manually. */
 	role?: string;
 	/**
@@ -65,7 +65,7 @@ export interface UserProfile {
 	/** User-authored: quarterly quota target in dollars. Used for coverage ratio calculations. */
 	quota?: number;
 	observations?: UserProfileObservation[];
-	sources?: { github?: string; system?: string; conversation?: string };
+	sources?: { github?: string; system?: string; conversation?: string; git?: string; salesforce?: string };
 	updatedAt?: string;
 	/** Tracks which collector ID authoritatively owns each top-level field. */
 	_fieldOwnership?: Record<string, string>;
@@ -120,28 +120,59 @@ export function mergeProfile(target: UserProfile, source: Partial<UserProfile>):
 	}
 }
 
-export async function seedProfile(): Promise<UserProfile> {
+/** Outcome of a single collector during a seed run — surfaced to the session. */
+export interface SeedCollectorResult {
+	id: string;
+	name: string;
+	status: "collected" | "unavailable" | "error";
+	/** Profile fields the collector contributed (only when status === "collected"). */
+	fields?: string[];
+	/** Error message when status === "error". */
+	error?: string;
+}
+
+export interface SeedResult {
+	profile: UserProfile;
+	results: SeedCollectorResult[];
+}
+
+export async function seedProfile(): Promise<SeedResult> {
 	const profile = await loadProfile();
 	if (!profile.sources) profile.sources = {};
+
+	const results: SeedCollectorResult[] = [];
 
 	for (const collector of PROFILE_COLLECTORS) {
 		try {
 			const isAvailable = await collector.available();
 			if (!isAvailable) {
 				logger.debug(`Profile collector '${collector.id}' not available, skipping`);
+				results.push({ id: collector.id, name: collector.name, status: "unavailable" });
 				continue;
 			}
 			const partial = await collector.collect();
 			mergeProfile(profile, partial);
 			(profile.sources as Record<string, string>)[collector.id] = new Date().toISOString();
 			logger.debug(`Profile collector '${collector.id}' completed`);
+			results.push({
+				id: collector.id,
+				name: collector.name,
+				status: "collected",
+				fields: Object.keys(partial),
+			});
 		} catch (err: unknown) {
 			logger.debug(`Profile collector '${collector.id}' failed`, { error: err });
+			results.push({
+				id: collector.id,
+				name: collector.name,
+				status: "error",
+				error: err instanceof Error ? err.message : String(err),
+			});
 		}
 	}
 
 	await saveProfile(profile);
-	return profile;
+	return { profile, results };
 }
 
 const META_FIELDS = new Set(["sources", "observations", "updatedAt", "_fieldOwnership"]);
@@ -219,17 +250,44 @@ function hasValues(obj: Record<string, unknown> | undefined): boolean {
 	return Object.values(obj).some(v => v !== undefined && v !== null && v !== "");
 }
 
+const SOURCE_LABELS: Record<string, string> = {
+	github: "GitHub",
+	system: "System",
+	conversation: "Conversation",
+	git: "Git",
+	salesforce: "Salesforce",
+};
+
+function titleCase(id: string): string {
+	return id.charAt(0).toUpperCase() + id.slice(1);
+}
+
+/**
+ * Render a per-collector seed report so a no-op seed is diagnosable in-session
+ * (which sources ran, which were unavailable, which errored) instead of
+ * silently returning an empty template.
+ */
+export function renderSeedReport(results: SeedCollectorResult[]): string {
+	if (results.length === 0) return "";
+	const lines = ["\n## Seed Report\n"];
+	for (const r of results) {
+		if (r.status === "collected") {
+			const fields = r.fields && r.fields.length > 0 ? ` — ${r.fields.join(", ")}` : " — no fields";
+			lines.push(`- **${r.name}:** collected${fields}`);
+		} else if (r.status === "unavailable") {
+			lines.push(`- **${r.name}:** unavailable (skipped)`);
+		} else {
+			lines.push(`- **${r.name}:** error — ${r.error ?? "unknown error"}`);
+		}
+	}
+	return lines.join("\n");
+}
+
 export function renderProfileMarkdown(profile: UserProfile): string {
 	const sections: string[] = [];
 
 	sections.push("# User Profile\n");
-
-	const isEmpty = !profile.givenName && !profile.familyName && !profile.email && !profile.jobTitle;
-	if (isEmpty) {
-		sections.push("No profile data yet. Use `xcsh://user?seed=true` to populate from GitHub and system sources.\n");
-		sections.push("Profile facts can also be added progressively during conversation.\n");
-		return sections.join("\n");
-	}
+	const headerOnly = sections.length;
 
 	// Identity
 	const identityLines: string[] = [];
@@ -347,14 +405,24 @@ export function renderProfileMarkdown(profile: UserProfile): string {
 		}
 	}
 
-	// Sources
+	// No content sections were produced — show the seed hint instead of an
+	// empty shell (and never render an orphan Sources footer).
+	if (sections.length === headerOnly) {
+		sections.push(
+			"No profile data yet. Use `xcsh://user?seed=true` to populate from Salesforce, GitHub, git, and system sources.\n",
+		);
+		sections.push("Profile facts can also be added progressively during conversation.\n");
+		return sections.join("\n");
+	}
+
+	// Sources — render every recorded source timestamp, not just a fixed subset.
 	if (profile.sources && hasValues(profile.sources as unknown as Record<string, unknown>)) {
 		sections.push("\n---\n");
 		sections.push("**Sources:**");
 		const srcLines: string[] = [];
-		if (profile.sources.github) srcLines.push(`GitHub: ${profile.sources.github}`);
-		if (profile.sources.system) srcLines.push(`System: ${profile.sources.system}`);
-		if (profile.sources.conversation) srcLines.push(`Conversation: ${profile.sources.conversation}`);
+		for (const [id, ts] of Object.entries(profile.sources as Record<string, string>)) {
+			if (ts) srcLines.push(`${SOURCE_LABELS[id] ?? titleCase(id)}: ${ts}`);
+		}
 		sections.push(srcLines.join(" | "));
 		if (profile.updatedAt) sections.push(`\n*Last updated: ${profile.updatedAt}*`);
 	}

--- a/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
@@ -47,7 +47,8 @@ import extensionApiContent from "./extension-api.md" with { type: "text" };
 import { createTerraformResolver, type TerraformResolver } from "./terraform-resolve";
 import type { TerraformIndex } from "./terraform-types";
 import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
-import { loadProfile, renderProfileMarkdown, seedProfile } from "./user-profile";
+import type { UserProfile } from "./user-profile";
+import { loadProfile, renderProfileMarkdown, renderSeedReport, seedProfile } from "./user-profile";
 
 const SCHEME_PREFIX = "xcsh://";
 const ABOUT_ROUTE = "about";
@@ -386,8 +387,16 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 		const params = new URLSearchParams(url.search);
 		const shouldSeed = params.get("seed") === "true";
 
-		const profile = shouldSeed ? await seedProfile() : await loadProfile();
-		const content = renderProfileMarkdown(profile);
+		let profile: UserProfile;
+		let seedReport = "";
+		if (shouldSeed) {
+			const seeded = await seedProfile();
+			profile = seeded.profile;
+			seedReport = renderSeedReport(seeded.results);
+		} else {
+			profile = await loadProfile();
+		}
+		const content = renderProfileMarkdown(profile) + seedReport;
 
 		const hasOwnership = profile._fieldOwnership && Object.keys(profile._fieldOwnership).length > 0;
 		const notes: string[] = [

--- a/packages/coding-agent/test/internal-urls/profile-collectors.test.ts
+++ b/packages/coding-agent/test/internal-urls/profile-collectors.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import type { ProfileCollector } from "../../src/internal-urls/profile-collectors";
-import { PROFILE_COLLECTORS } from "../../src/internal-urls/profile-collectors";
+import {
+	PROFILE_COLLECTORS,
+	parseGithubUserJson,
+	parseSalesforceUserRecord,
+	splitFullName,
+} from "../../src/internal-urls/profile-collectors";
 
 describe("PROFILE_COLLECTORS registry", () => {
 	it("exports a non-empty readonly array", () => {
@@ -24,9 +29,25 @@ describe("PROFILE_COLLECTORS registry", () => {
 		expect(new Set(ids).size).toBe(ids.length);
 	});
 
-	it("collector ids match expected set", () => {
+	it("registers salesforce, github, git, and system identity collectors", () => {
 		const ids = PROFILE_COLLECTORS.map((c: ProfileCollector) => c.id);
+		expect(ids).toContain("salesforce");
+		expect(ids).toContain("github");
+		expect(ids).toContain("git");
 		expect(ids).toContain("system");
+	});
+
+	it("orders salesforce → github → git → system so higher-trust sources win scalar merges", () => {
+		const ids = PROFILE_COLLECTORS.map((c: ProfileCollector) => c.id);
+		expect(ids.indexOf("salesforce")).toBeLessThan(ids.indexOf("github"));
+		expect(ids.indexOf("github")).toBeLessThan(ids.indexOf("git"));
+		expect(ids.indexOf("git")).toBeLessThan(ids.indexOf("system"));
+	});
+
+	it("marks salesforce as authoritative for corporate identity fields", () => {
+		const sf = PROFILE_COLLECTORS.find((c: ProfileCollector) => c.id === "salesforce");
+		expect(sf?.authoritativeFields).toBeDefined();
+		expect(sf?.authoritativeFields).toContain("jobTitle");
 	});
 });
 
@@ -64,4 +85,115 @@ describe("ProfileCollector interface contract", () => {
 			expect(result).not.toBeNull();
 		}
 	}, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// splitFullName — shared name-splitting helper
+// ---------------------------------------------------------------------------
+
+describe("splitFullName", () => {
+	it("splits a two-part name into given + family", () => {
+		expect(splitFullName("Ada Lovelace")).toEqual({ givenName: "Ada", familyName: "Lovelace" });
+	});
+
+	it("keeps everything after the first token as the family name", () => {
+		expect(splitFullName("Ada B Lovelace")).toEqual({ givenName: "Ada", familyName: "B Lovelace" });
+	});
+
+	it("returns only givenName for a single-token name", () => {
+		expect(splitFullName("Cher")).toEqual({ givenName: "Cher" });
+	});
+
+	it("returns empty object for blank input", () => {
+		expect(splitFullName("")).toEqual({});
+		expect(splitFullName("   ")).toEqual({});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// parseGithubUserJson — maps `gh api user` output
+// ---------------------------------------------------------------------------
+
+describe("parseGithubUserJson", () => {
+	it("maps login, name, email, bio, blog, and twitter", () => {
+		const stdout = JSON.stringify({
+			login: "ada-lovelace",
+			name: "Ada Lovelace",
+			email: "ada@example.com",
+			bio: "Mathematician",
+			blog: "https://ada.dev",
+			twitter_username: "ada_dev",
+		});
+
+		const p = parseGithubUserJson(stdout);
+
+		expect(p.identifiers?.github).toBe("ada-lovelace");
+		expect(p.givenName).toBe("Ada");
+		expect(p.familyName).toBe("Lovelace");
+		expect(p.email).toBe("ada@example.com");
+		expect(p.description).toBe("Mathematician");
+		expect(p.url).toBe("https://ada.dev");
+		expect(p.identifiers?.twitter).toBe("ada_dev");
+		expect(p.sameAs).toContain("https://github.com/ada-lovelace");
+		expect(p.sameAs).toContain("https://x.com/ada_dev");
+	});
+
+	it("returns empty object on malformed JSON", () => {
+		expect(parseGithubUserJson("not json")).toEqual({});
+	});
+
+	it("omits fields that are absent", () => {
+		const p = parseGithubUserJson(JSON.stringify({ login: "solo" }));
+		expect(p.identifiers?.github).toBe("solo");
+		expect(p.email).toBeUndefined();
+		expect(p.givenName).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// parseSalesforceUserRecord — maps a User SOQL record
+// ---------------------------------------------------------------------------
+
+describe("parseSalesforceUserRecord", () => {
+	it("maps identity, employment, manager, and address fields", () => {
+		const rec = {
+			Id: "005000000000001",
+			FirstName: "Robin",
+			LastName: "Mordasiewicz",
+			Email: "r.mordasiewicz@f5.com",
+			Title: "Solutions Engineer",
+			Department: "Sales",
+			Division: "Americas",
+			CompanyName: "F5",
+			Manager: { Name: "Jane Boss", Email: "jane@f5.com" },
+			Street: "1 Main St",
+			City: "Toronto",
+			State: "ON",
+			PostalCode: "M1A1A1",
+			Country: "Canada",
+			Phone: "+1-555-0100",
+		};
+
+		const p = parseSalesforceUserRecord(rec);
+
+		expect(p.givenName).toBe("Robin");
+		expect(p.familyName).toBe("Mordasiewicz");
+		expect(p.email).toBe("r.mordasiewicz@f5.com");
+		expect(p.jobTitle).toBe("Solutions Engineer");
+		expect(p.department).toBe("Sales");
+		expect(p.division).toBe("Americas");
+		expect(p.worksFor?.name).toBe("F5");
+		expect(p.manager?.givenName).toBe("Jane");
+		expect(p.manager?.familyName).toBe("Boss");
+		expect(p.manager?.email).toBe("jane@f5.com");
+		expect(p.address?.addressLocality).toBe("Toronto");
+		expect(p.address?.addressCountry).toBe("Canada");
+		expect(p.telephone).toBe("+1-555-0100");
+		expect(p.identifiers?.salesforceId).toBe("005000000000001");
+	});
+
+	it("defaults organization to F5 when CompanyName is absent", () => {
+		const p = parseSalesforceUserRecord({ FirstName: "A", LastName: "B" });
+		expect(p.worksFor?.name).toBe("F5");
+	});
 });

--- a/packages/coding-agent/test/internal-urls/reconcile-from-collectors.test.ts
+++ b/packages/coding-agent/test/internal-urls/reconcile-from-collectors.test.ts
@@ -46,6 +46,16 @@ function makeMockCollector(overrides: Partial<ProfileCollector> & { id: string }
 	};
 }
 
+/** Disable every built-in collector so tests never shell out to real CLIs. */
+const BUILTIN_COLLECTOR_IDS = ["salesforce", "github", "git", "system"];
+function suppressBuiltins(): void {
+	for (const c of PROFILE_COLLECTORS) {
+		if (BUILTIN_COLLECTOR_IDS.includes(c.id)) {
+			vi.spyOn(c, "available").mockResolvedValue(false);
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // reconcileFromCollectors
 // ---------------------------------------------------------------------------
@@ -71,8 +81,7 @@ describe("reconcileFromCollectors", () => {
 		});
 
 		// Suppress built-in system collector
-		const systemCollector = PROFILE_COLLECTORS.find(c => c.id === "system");
-		if (systemCollector) vi.spyOn(systemCollector, "available").mockResolvedValue(false);
+		suppressBuiltins();
 
 		registerAndTrack(
 			makeMockCollector({
@@ -96,8 +105,7 @@ describe("reconcileFromCollectors", () => {
 			_fieldOwnership: {},
 		});
 
-		const systemCollector = PROFILE_COLLECTORS.find(c => c.id === "system");
-		if (systemCollector) vi.spyOn(systemCollector, "available").mockResolvedValue(false);
+		suppressBuiltins();
 
 		registerAndTrack(
 			makeMockCollector({
@@ -125,8 +133,7 @@ describe("reconcileFromCollectors", () => {
 			_fieldOwnership: { role: "user" },
 		});
 
-		const systemCollector = PROFILE_COLLECTORS.find(c => c.id === "system");
-		if (systemCollector) vi.spyOn(systemCollector, "available").mockResolvedValue(false);
+		suppressBuiltins();
 
 		registerAndTrack(
 			makeMockCollector({
@@ -145,8 +152,7 @@ describe("reconcileFromCollectors", () => {
 	it("skips unavailable collectors", async () => {
 		const io = mockIO({});
 
-		const systemCollector = PROFILE_COLLECTORS.find(c => c.id === "system");
-		if (systemCollector) vi.spyOn(systemCollector, "available").mockResolvedValue(false);
+		suppressBuiltins();
 
 		registerAndTrack(
 			makeMockCollector({
@@ -166,8 +172,7 @@ describe("reconcileFromCollectors", () => {
 	it("isolates a throwing collector — profile still saves", async () => {
 		const io = mockIO({});
 
-		const systemCollector = PROFILE_COLLECTORS.find(c => c.id === "system");
-		if (systemCollector) vi.spyOn(systemCollector, "available").mockResolvedValue(false);
+		suppressBuiltins();
 
 		registerAndTrack(
 			makeMockCollector({
@@ -188,8 +193,7 @@ describe("reconcileFromCollectors", () => {
 	it("records source timestamp for successful collectors", async () => {
 		mockIO({});
 
-		const systemCollector = PROFILE_COLLECTORS.find(c => c.id === "system");
-		if (systemCollector) vi.spyOn(systemCollector, "available").mockResolvedValue(false);
+		suppressBuiltins();
 
 		registerAndTrack(
 			makeMockCollector({
@@ -212,8 +216,7 @@ describe("reconcileFromCollectors", () => {
 			givenName: "Robin",
 		});
 
-		const systemCollector = PROFILE_COLLECTORS.find(c => c.id === "system");
-		if (systemCollector) vi.spyOn(systemCollector, "available").mockResolvedValue(false);
+		suppressBuiltins();
 
 		registerAndTrack(
 			makeMockCollector({
@@ -234,8 +237,7 @@ describe("reconcileFromCollectors", () => {
 			givenName: "Robin",
 		});
 
-		const systemCollector = PROFILE_COLLECTORS.find(c => c.id === "system");
-		if (systemCollector) vi.spyOn(systemCollector, "available").mockResolvedValue(false);
+		suppressBuiltins();
 
 		registerAndTrack(
 			makeMockCollector({

--- a/packages/coding-agent/test/internal-urls/seed-profile.test.ts
+++ b/packages/coding-agent/test/internal-urls/seed-profile.test.ts
@@ -38,6 +38,13 @@ function collector(id: string) {
 	return c;
 }
 
+/** Force every collector unavailable so tests stay hermetic (no real CLI shell-outs). */
+function disableAllCollectors(): void {
+	for (const c of PROFILE_COLLECTORS) {
+		vi.spyOn(c, "available").mockResolvedValue(false);
+	}
+}
+
 // ---------------------------------------------------------------------------
 // seedProfile
 // ---------------------------------------------------------------------------
@@ -47,17 +54,17 @@ describe("seedProfile", () => {
 
 	it("skips unavailable collectors and omits their source timestamp", async () => {
 		const io = mockIO();
+		disableAllCollectors();
 
-		vi.spyOn(collector("system"), "available").mockResolvedValue(false);
+		const { profile } = await seedProfile();
 
-		await seedProfile();
-
-		const written = io.lastWritten();
-		expect(written.sources?.system).toBeUndefined();
+		expect(profile.sources?.system).toBeUndefined();
+		expect(io.lastWritten().sources?.system).toBeUndefined();
 	});
 
 	it("isolates a throwing collector — others still run and profile saves", async () => {
 		const io = mockIO();
+		disableAllCollectors();
 
 		vi.spyOn(collector("system"), "available").mockResolvedValue(true);
 		vi.spyOn(collector("system"), "collect").mockResolvedValue({ knowsLanguage: ["en-US"] });
@@ -71,26 +78,68 @@ describe("seedProfile", () => {
 
 	it("records source timestamps within the call window", async () => {
 		mockIO();
+		disableAllCollectors();
 
 		vi.spyOn(collector("system"), "available").mockResolvedValue(true);
 		vi.spyOn(collector("system"), "collect").mockResolvedValue({});
 
 		const before = Date.now();
-		const result = await seedProfile();
+		const { profile } = await seedProfile();
 		const after = Date.now();
 
-		const ts = new Date(result.sources!.system!).getTime();
+		const ts = new Date(profile.sources!.system!).getTime();
 		expect(ts).toBeGreaterThanOrEqual(before);
 		expect(ts).toBeLessThanOrEqual(after);
 	});
 
 	it("saves profile to disk exactly once", async () => {
 		const io = mockIO();
-
-		vi.spyOn(collector("system"), "available").mockResolvedValue(false);
+		disableAllCollectors();
 
 		await seedProfile();
 
 		expect(io.writeCallCount()).toBe(1);
+	});
+
+	// -----------------------------------------------------------------------
+	// New: seed populates identity fields and reports per-collector outcome
+	// -----------------------------------------------------------------------
+
+	it("populates identity fields from an available collector", async () => {
+		mockIO();
+		disableAllCollectors();
+
+		vi.spyOn(collector("git"), "available").mockResolvedValue(true);
+		vi.spyOn(collector("git"), "collect").mockResolvedValue({
+			givenName: "Ada",
+			familyName: "Lovelace",
+			email: "ada@example.com",
+		});
+
+		const { profile } = await seedProfile();
+
+		expect(profile.givenName).toBe("Ada");
+		expect(profile.familyName).toBe("Lovelace");
+		expect(profile.email).toBe("ada@example.com");
+	});
+
+	it("returns a per-collector results report (collected / unavailable / error)", async () => {
+		mockIO();
+		disableAllCollectors();
+
+		vi.spyOn(collector("git"), "available").mockResolvedValue(true);
+		vi.spyOn(collector("git"), "collect").mockResolvedValue({ givenName: "Ada" });
+
+		vi.spyOn(collector("github"), "available").mockResolvedValue(true);
+		vi.spyOn(collector("github"), "collect").mockRejectedValue(new Error("gh exploded"));
+
+		const { results } = await seedProfile();
+
+		const byId = Object.fromEntries(results.map(r => [r.id, r]));
+		expect(byId.git.status).toBe("collected");
+		expect(byId.git.fields).toContain("givenName");
+		expect(byId.github.status).toBe("error");
+		expect(byId.github.error).toContain("gh exploded");
+		expect(byId.system.status).toBe("unavailable");
 	});
 });

--- a/packages/coding-agent/test/internal-urls/user-profile.test.ts
+++ b/packages/coding-agent/test/internal-urls/user-profile.test.ts
@@ -89,6 +89,20 @@ describe("renderProfileMarkdown", () => {
 		expect(md).toContain("xcsh://user?seed=true");
 	});
 
+	it("renders collected content instead of the empty hint when only knowsLanguage is set", () => {
+		const md = renderProfileMarkdown({ knowsLanguage: ["English", "French"] });
+		expect(md).not.toContain("No profile data yet");
+		expect(md).toContain("## Demographics");
+		expect(md).toContain("English, French");
+	});
+
+	it("renders collected content instead of the empty hint when only a github identifier is set", () => {
+		const md = renderProfileMarkdown({ identifiers: { github: "ada-lovelace" } });
+		expect(md).not.toContain("No profile data yet");
+		expect(md).toContain("## Online Presence");
+		expect(md).toContain("ada-lovelace");
+	});
+
 	it("renders populated profile with all sections", () => {
 		const profile: UserProfile = {
 			givenName: "Ada",
@@ -206,6 +220,23 @@ describe("renderProfileMarkdown", () => {
 		expect(md).toContain("GitHub:");
 		expect(md).toContain("System:");
 		expect(md).toContain("*Last updated:");
+	});
+
+	it("renders git and salesforce source timestamps in the footer", () => {
+		const profile: UserProfile = {
+			givenName: "Tester",
+			sources: {
+				git: "2026-02-01T00:00:00Z",
+				salesforce: "2026-02-02T00:00:00Z",
+			} as UserProfile["sources"],
+			updatedAt: "2026-03-01T00:00:00Z",
+		};
+
+		const md = renderProfileMarkdown(profile);
+
+		expect(md).toContain("**Sources:**");
+		expect(md.toLowerCase()).toContain("git:");
+		expect(md.toLowerCase()).toContain("salesforce:");
 	});
 });
 

--- a/packages/coding-agent/test/internal-urls/xcsh-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/xcsh-protocol.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { InternalDocsProtocolHandler, InternalUrlRouter } from "../../src/internal-urls";
 import { createApiSpecResolver } from "../../src/internal-urls/api-spec-resolve";
 import type { RuntimeBuildInfo } from "../../src/internal-urls/build-info-runtime";
 import { EMBEDDED_DOC_FILENAMES } from "../../src/internal-urls/docs-index.generated";
+import { PROFILE_COLLECTORS } from "../../src/internal-urls/profile-collectors";
 
 function injectedInfo(overrides: Partial<RuntimeBuildInfo> = {}): RuntimeBuildInfo {
 	return {
@@ -227,10 +228,63 @@ describe("xcsh://user", () => {
 		expect(hasProfile || hasSeedHint).toBe(true);
 	});
 
-	it("sourcePath is xcsh://user regardless of seed query param", async () => {
-		const resource = await createRouter().resolve("xcsh://user?seed=true");
-		expect(resource.sourcePath).toBe("xcsh://user");
-	}, 30_000);
+	describe("?seed=true", () => {
+		afterEach(() => vi.restoreAllMocks());
+
+		/**
+		 * Stateful in-memory profile store so a seed write is visible to the
+		 * following read, and no real ~/.xcsh/user-profile.json is touched.
+		 */
+		function mockProfileStore(): void {
+			let stored: object = {};
+			vi.spyOn(Bun, "file").mockReturnValue({
+				json: () => Promise.resolve(stored),
+			} as unknown as ReturnType<typeof Bun.file>);
+			vi.spyOn(Bun, "write").mockImplementation((async (_dest: unknown, data: unknown) => {
+				stored = JSON.parse(String(data)) as object;
+				return String(data).length;
+			}) as typeof Bun.write);
+		}
+
+		it("seeds the profile so a subsequent read returns a populated (non-empty) profile", async () => {
+			mockProfileStore();
+			for (const c of PROFILE_COLLECTORS) vi.spyOn(c, "available").mockResolvedValue(false);
+			vi.spyOn(PROFILE_COLLECTORS.find(c => c.id === "git")!, "available").mockResolvedValue(true);
+			vi.spyOn(PROFILE_COLLECTORS.find(c => c.id === "git")!, "collect").mockResolvedValue({
+				givenName: "Ada",
+				familyName: "Lovelace",
+				email: "ada@example.com",
+			});
+
+			const router = createRouter();
+			const seeded = await router.resolve("xcsh://user?seed=true");
+			expect(seeded.content).toContain("Ada Lovelace");
+
+			const read = await router.resolve("xcsh://user");
+			expect(read.content).not.toContain("No profile data yet");
+			expect(read.content).toContain("Ada Lovelace");
+			expect(read.content).toContain("ada@example.com");
+		});
+
+		it("renders a Seed Report describing each collector outcome", async () => {
+			mockProfileStore();
+			for (const c of PROFILE_COLLECTORS) vi.spyOn(c, "available").mockResolvedValue(false);
+
+			const resource = await createRouter().resolve("xcsh://user?seed=true");
+			expect(resource.content).toContain("Seed Report");
+			// every registered collector reports a status
+			for (const c of PROFILE_COLLECTORS) {
+				expect(resource.content).toContain(c.name);
+			}
+		});
+
+		it("keeps sourcePath as xcsh://user regardless of seed query param", async () => {
+			mockProfileStore();
+			for (const c of PROFILE_COLLECTORS) vi.spyOn(c, "available").mockResolvedValue(false);
+			const resource = await createRouter().resolve("xcsh://user?seed=true");
+			expect(resource.sourcePath).toBe("xcsh://user");
+		});
+	});
 });
 
 describe("xcsh://computer", () => {


### PR DESCRIPTION
Closes #2043

## Problem

`xcsh://user?seed=true` was a **silent no-op** — the profile stayed the empty "No profile data yet" template even with Salesforce, GitHub, git, and system all authenticated.

**Root cause (verified in code, not guessed):** routing and the read/write path were fine (single shared `PROFILE_PATH`, no mismatch). The **identity collectors no longer existed** — commits #1060 (extract Salesforce) and #1072 (remove GitHub/GitLab tools) stripped them from `profile-collectors.ts`, leaving only a languages-only `systemCollector`. The `registerProfileCollector` extension API had **zero consumers** (no plugins directory). So seeding never set identity fields, and `renderProfileMarkdown`'s `isEmpty` gate (name/email/jobTitle only) always returned the empty template. Per-collector errors were swallowed at `logger.debug`, hence silent.

## Changes

- **Restore four dependency-free collectors in core** (`profile-collectors.ts`): `salesforce` (`sf`), `github` (`gh`), `git` (`git config`), and system identity (`id -F` / GECOS) alongside language detection. Registry order encodes seed priority; `salesforce` marked authoritative for corporate identity. Field-mapping extracted into pure, unit-tested functions (`splitFullName`, `parseGithubUserJson`, `parseSalesforceUserRecord`).
- **Surface the seed outcome**: `seedProfile()` returns `{ profile, results }`; the handler renders a **Seed Report** (collected / unavailable / error per source) so a no-op is diagnosable instead of a misleading template.
- **Fix the `isEmpty` gate**: show the seed hint only when no content section was produced; partial seeds (languages, github id) now render. Sources footer renders every recorded source dynamically.

## Testing

- New pure-parser + registry tests, `{ profile, results }` shape tests, render-when-partial tests, and a real **seed → read → assert-non-empty** smoke test through `InternalUrlRouter`. Reconcile tests made hermetic against the enlarged registry.
- `377 pass` across `test/internal-urls`; typecheck + biome clean.
- **End-to-end on macOS** (all four sources authenticated): from an empty `~/.xcsh/user-profile.json`, `xcsh://user?seed=true` produced a fully populated profile (Identity/Employment/Address/Demographics/Online Presence) + Seed Report showing all four collectors `collected`, and the subsequent plain `xcsh://user` read returned the populated profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)