### PR TITLE
test: make auto-compaction attribution tests provider-independent (#2054)

### DIFF
--- a/packages/coding-agent/test/agent-session-auto-compaction-x-initiator.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-x-initiator.test.ts
@@ -50,8 +50,17 @@ function captureCompactionCalls(marker: string) {
 	const capturedOptions: Array<SimpleStreamOptions | undefined> = [];
 	const originalCompleteSimple = ai.completeSimple;
 	vi.spyOn(ai, "completeSimple").mockImplementation(async (...args) => {
-		const [model, context, options] = args;
-		if (model.provider === "github-copilot" && contextContainsMarker(context, marker)) {
+		const [, context, options] = args;
+		// Match on the unique per-test marker, NOT the provider. Auto-compaction
+		// picks its summarization model from a candidate list (see
+		// AgentSession.#getCompactionModelCandidates), and the winner depends on
+		// which providers happen to have credentials in the environment — a dev
+		// machine with e.g. OPENAI_API_KEY set selects a different (real, unmocked)
+		// model than CI, which previously let the summarization call hit the network
+		// and time out. The marker uniquely identifies THIS test's compaction
+		// context regardless of the chosen model, so intercept on that and never
+		// touch the network.
+		if (contextContainsMarker(context, marker)) {
 			capturedOptions.push(options);
 			return createAssistantMessage("Compacted summary") as never;
 		}


### PR DESCRIPTION
Closes #2054

## Problem

The two `auto-compaction` cases in `test/agent-session-auto-compaction-x-initiator.test.ts` timed out (5s) on developer machines but passed in CI. The manual-compaction cases passed everywhere.

**Root cause:** the mock gated its intercept on `model.provider === "github-copilot"`. Auto-compaction doesn't necessarily summarize with the session model — `AgentSession.#getCompactionModelCandidates()` picks the first candidate with an API key, resolved via `authStorage.getApiKey`, which falls back to ambient env/stored credentials:
- **CI**: only the test's `github-copilot` runtime key exists → copilot candidate wins → mock intercepts → pass.
- **Dev machine**: another provider with ambient creds (Anthropic normally; OpenAI for some users) wins → its `completeSimple` is **not** intercepted → the summarization hits the real network → 5s timeout.

Manual compaction uses the copilot session model directly, so its mock always matched — hence only the auto cases failed.

## Fix

Match the mock on the unique per-test **marker** (already in the seeded context) rather than the provider. The marker identifies this test's compaction context regardless of which candidate model the environment selects, so the call is always intercepted and never touches the network. Production behavior is unchanged — auto-compaction already passes `initiatorOverride: "agent"`; only the test was environment-fragile.

## Verification

- **4/4 pass** with this machine's ambient credentials (`OPENAI_API_KEY` set + stored Anthropic) — the exact condition that previously hung — in ~2s.
- **4/4 pass** with a cleaned CI-like env (`env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY …`).
- Stable across repeated runs; `tsgo` typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)