### PR TITLE
Extension bridge: dual-listen wss on 127-0-0-1.local-ip.sh (Office add-in / WKWebView support)

### DIFF
--- a/packages/coding-agent/src/browser/bridge-cert.ts
+++ b/packages/coding-agent/src/browser/bridge-cert.ts
@@ -1,0 +1,276 @@
+/**
+ * Bridge TLS certificate provisioning for the `wss://` extension-bridge listener.
+ *
+ * Ported from `claude-office/proxy.mjs` (`certDaysLeft` / `provisionPublicCert` /
+ * self-signed fallback / `loadCtx` / SNI selection) into idiomatic TypeScript.
+ *
+ * The bridge terminates TLS with a **publicly-trusted `*.local-ip.sh`** Let's
+ * Encrypt certificate served on the host `127-0-0-1.local-ip.sh` (which resolves
+ * to 127.0.0.1). Because the cert chains to a public CA and the hostname matches
+ * the `*.local-ip.sh` SAN, WebKit/Chromium open `wss://127-0-0-1.local-ip.sh:<port>`
+ * with TLS verification ON and **no local trust / MDM step**. A self-signed
+ * localhost cert is a dev-only fallback (it will NOT satisfy WebKit).
+ *
+ * Design: a clean PURE-vs-I/O split. The freshness gate ({@link certDaysLeft},
+ * {@link isCertStale}), default-cert selection ({@link selectServerCert}) and SNI
+ * routing ({@link isLocalIpServerName}, {@link selectSniContext}) are pure and unit
+ * tested without sockets, fs, or a keychain. The I/O entry points
+ * ({@link provisionPublicCert}, {@link provisionSelfSigned}, {@link loadCtx}) accept
+ * injectable `fetch`/`fs`/validation dependencies so the download + write path is
+ * tested with mocks.
+ */
+import { execFileSync } from "node:child_process";
+import { X509Certificate } from "node:crypto";
+import {
+	chmodSync as nodeChmodSync,
+	existsSync as nodeExistsSync,
+	mkdirSync as nodeMkdirSync,
+	readFileSync as nodeReadFileSync,
+	writeFileSync as nodeWriteFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { createSecureContext, type SecureContext } from "node:tls";
+import { getXCSHConfigDir } from "@f5-sales-demo/pi-utils";
+
+// ---- public constants (safe to ship) ----------------------------------------
+
+/** local-ip.sh publicly-trusted `*.local-ip.sh` certificate (PEM). */
+export const LOCALIP_CERT_URL = "https://local-ip.sh/server.pem";
+/** local-ip.sh matching private key (PEM). */
+export const LOCALIP_KEY_URL = "https://local-ip.sh/server.key";
+/** The only hostname that resolves to 127.0.0.1 AND matches the `*.local-ip.sh` SAN. */
+export const LOCALIP_HOST = "127-0-0-1.local-ip.sh";
+/** Weekly background refresh interval for the provisioned public cert. */
+export const REFRESH_MS = 7 * 24 * 60 * 60 * 1000;
+/** Refresh the cert once it is within this many days of expiry. */
+export const CERT_STALE_THRESHOLD_DAYS = 30;
+
+// ---- storage paths (under getXCSHConfigDir()/bridge/) ------------------------
+
+/** Directory holding the bridge's provisioned certs (`<cfg>/bridge`). */
+export function bridgeCertDir(): string {
+	return join(getXCSHConfigDir(), "bridge");
+}
+/** Path to the public `*.local-ip.sh` certificate. */
+export function publicCertPath(): string {
+	return join(bridgeCertDir(), "localip.pem");
+}
+/** Path to the public `*.local-ip.sh` private key. */
+export function publicKeyPath(): string {
+	return join(bridgeCertDir(), "localip.key");
+}
+/** Path to the self-signed localhost certificate (dev fallback). */
+export function selfSignedCertPath(): string {
+	return join(bridgeCertDir(), "localhost.pem");
+}
+/** Path to the self-signed localhost private key (dev fallback). */
+export function selfSignedKeyPath(): string {
+	return join(bridgeCertDir(), "localhost.key");
+}
+
+// ---- pure: freshness ---------------------------------------------------------
+
+/**
+ * Days remaining until the certificate's `notAfter`, or `-1` if the input is not
+ * a parseable X.509 certificate. A parseable-but-expired cert returns a negative
+ * (fractional) number, distinct from the `-1` garbage sentinel.
+ */
+export function certDaysLeft(pem: string | Buffer): number {
+	try {
+		const validTo = new Date(new X509Certificate(pem).validTo).getTime();
+		return (validTo - Date.now()) / 86_400_000;
+	} catch {
+		return -1;
+	}
+}
+
+/** A cert is stale (should be re-provisioned) once it is within the threshold of expiry. */
+export function isCertStale(pem: string | Buffer, thresholdDays = CERT_STALE_THRESHOLD_DAYS): boolean {
+	return certDaysLeft(pem) < thresholdDays;
+}
+
+// ---- pure: content validation ------------------------------------------------
+
+/** Heuristic guard that a downloaded body is a PEM certificate (not an HTML error page). */
+export function looksLikeCertPem(body: string): boolean {
+	return body.includes("BEGIN CERTIFICATE");
+}
+/** Heuristic guard that a downloaded body is a PEM private key. */
+export function looksLikeKeyPem(body: string): boolean {
+	return body.includes("PRIVATE KEY");
+}
+
+// ---- pure: default-cert selection --------------------------------------------
+
+/** Which cert the listener should serve by default, given which pairs are available. */
+export function selectServerCert(available: { public: boolean; selfSigned: boolean }): "public" | "self-signed" | null {
+	if (available.public) return "public";
+	if (available.selfSigned) return "self-signed";
+	return null;
+}
+
+// ---- pure: SNI routing -------------------------------------------------------
+
+/** True only for a `*.local-ip.sh` subdomain (never the bare apex, never a lookalike). */
+export function isLocalIpServerName(name: string | null | undefined): boolean {
+	return typeof name === "string" && name.endsWith(".local-ip.sh");
+}
+
+/**
+ * Pick the TLS context for an incoming SNI servername: the public `*.local-ip.sh`
+ * context for a matching name, otherwise the self-signed/localhost context. Falls
+ * back to whichever context is present when the preferred one is missing.
+ */
+export function selectSniContext(
+	servername: string | null | undefined,
+	ctx: { localIp: SecureContext | null; selfSigned: SecureContext | null },
+): SecureContext | null {
+	if (isLocalIpServerName(servername) && ctx.localIp) return ctx.localIp;
+	return ctx.selfSigned ?? ctx.localIp;
+}
+
+// ---- I/O: dependency seams ---------------------------------------------------
+
+type FetchResponse = { ok: boolean; status: number; text(): Promise<string> };
+
+/** Injectable I/O dependencies (real implementations used when omitted). */
+export interface CertIoDeps {
+	certFile?: string;
+	keyFile?: string;
+	fetch?: (url: string) => Promise<FetchResponse>;
+	existsSync?: (path: string) => boolean;
+	readFileSync?: (path: string) => Buffer;
+	writeFileSync?: (path: string, data: string, opts?: { mode?: number }) => void;
+	mkdirSync?: (path: string, opts: { recursive: boolean }) => void;
+	/** Validate that the cert and key form a matching pair (throws on mismatch). */
+	validatePair?: (cert: string, key: string) => void;
+}
+
+function defaultValidatePair(cert: string, key: string): void {
+	// Throws on key/cert mismatch — the same guard claude-office relies on.
+	createSecureContext({ cert, key });
+}
+
+export type ProvisionReason = "fresh" | "provisioned" | "invalid-content" | "provision-failed";
+
+export interface ProvisionResult {
+	/** Whether a network fetch was attempted (false when the existing cert was fresh). */
+	fetched: boolean;
+	/** Whether new cert/key files were written to disk. */
+	written: boolean;
+	reason: ProvisionReason;
+}
+
+/**
+ * Ensure a fresh public `*.local-ip.sh` cert+key exist on disk.
+ *
+ * Mirrors `claude-office`'s `provisionPublicCert`: keep the existing cert when it
+ * is present and not stale ({@link isCertStale}); otherwise fetch cert+key and
+ * write them ONLY when the download is well-formed PEM AND the pair validates.
+ * Never throws — provisioning is best-effort; on any failure the existing (or
+ * self-signed) cert is left in place.
+ */
+export async function provisionPublicCert(deps: CertIoDeps = {}): Promise<ProvisionResult> {
+	const certFile = deps.certFile ?? publicCertPath();
+	const keyFile = deps.keyFile ?? publicKeyPath();
+	const exists = deps.existsSync ?? nodeExistsSync;
+	const read = deps.readFileSync ?? nodeReadFileSync;
+	const write = deps.writeFileSync ?? ((p, d, o) => nodeWriteFileSync(p, d, o));
+	const mkdirp = deps.mkdirSync ?? ((p, o) => nodeMkdirSync(p, o));
+	const doFetch = deps.fetch ?? ((url: string) => fetch(url) as Promise<FetchResponse>);
+	const validate = deps.validatePair ?? defaultValidatePair;
+
+	// Freshness gate: an existing, non-stale cert is kept as-is (no network hit).
+	if (exists(certFile) && exists(keyFile) && !isCertStale(read(certFile))) {
+		return { fetched: false, written: false, reason: "fresh" };
+	}
+
+	try {
+		const [cert, key] = await Promise.all([
+			doFetch(LOCALIP_CERT_URL).then(r => {
+				if (!r.ok) throw new Error(`cert HTTP ${r.status}`);
+				return r.text();
+			}),
+			doFetch(LOCALIP_KEY_URL).then(r => {
+				if (!r.ok) throw new Error(`key HTTP ${r.status}`);
+				return r.text();
+			}),
+		]);
+		if (!looksLikeCertPem(cert) || !looksLikeKeyPem(key)) {
+			return { fetched: true, written: false, reason: "invalid-content" };
+		}
+		validate(cert, key); // throws on key/cert mismatch
+		mkdirp(dirname(certFile), { recursive: true });
+		write(certFile, cert);
+		write(keyFile, key, { mode: 0o600 });
+		return { fetched: true, written: true, reason: "provisioned" };
+	} catch {
+		// Keep the existing / self-signed cert; never let provisioning crash boot.
+		return { fetched: true, written: false, reason: "provision-failed" };
+	}
+}
+
+/**
+ * Generate a self-signed localhost cert+key (dev-only fallback) if absent.
+ * Returns true when a usable pair exists afterwards. Requires `openssl` on PATH.
+ */
+export function provisionSelfSigned(deps: CertIoDeps = {}): boolean {
+	const certFile = deps.certFile ?? selfSignedCertPath();
+	const keyFile = deps.keyFile ?? selfSignedKeyPath();
+	const exists = deps.existsSync ?? nodeExistsSync;
+	const mkdirp = deps.mkdirSync ?? ((p, o) => nodeMkdirSync(p, o));
+
+	if (exists(certFile) && exists(keyFile)) return true;
+	try {
+		mkdirp(dirname(certFile), { recursive: true });
+		execFileSync(
+			"openssl",
+			[
+				"req",
+				"-x509",
+				"-newkey",
+				"rsa:2048",
+				"-sha256",
+				"-days",
+				"800",
+				"-nodes",
+				"-keyout",
+				keyFile,
+				"-out",
+				certFile,
+				"-subj",
+				"/CN=localhost",
+				"-addext",
+				"subjectAltName=DNS:localhost,IP:127.0.0.1",
+				"-addext",
+				"extendedKeyUsage=serverAuth",
+				"-addext",
+				"basicConstraints=critical,CA:FALSE",
+			],
+			{ stdio: "ignore" },
+		);
+		nodeChmodSync(keyFile, 0o600);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Load a {@link SecureContext} from a cert/key file pair, or `null` if the files
+ * are missing or fail to load (e.g. a mismatched pair).
+ */
+export function loadCtx(
+	certFile: string,
+	keyFile: string,
+	deps: Pick<CertIoDeps, "existsSync" | "readFileSync"> = {},
+): SecureContext | null {
+	const exists = deps.existsSync ?? nodeExistsSync;
+	const read = deps.readFileSync ?? nodeReadFileSync;
+	if (!exists(certFile) || !exists(keyFile)) return null;
+	try {
+		return createSecureContext({ cert: read(certFile), key: read(keyFile) });
+	} catch {
+		return null;
+	}
+}

--- a/packages/coding-agent/src/browser/bridge-cert.ts
+++ b/packages/coding-agent/src/browser/bridge-cert.ts
@@ -274,3 +274,103 @@ export function loadCtx(
 		return null;
 	}
 }
+
+/**
+ * Load a cert/key file pair as PEM strings for the `wss` listener, or `null` when
+ * the files are missing/unreadable or the content is not well-formed PEM. Unlike
+ * {@link loadCtx} this returns the raw PEM (which is what `Bun.serve({ tls })` wants).
+ */
+export function loadPemPair(
+	certFile: string,
+	keyFile: string,
+	deps: Pick<CertIoDeps, "existsSync" | "readFileSync"> = {},
+): ResolvedBridgeTls | null {
+	const exists = deps.existsSync ?? nodeExistsSync;
+	const read = deps.readFileSync ?? nodeReadFileSync;
+	if (!exists(certFile) || !exists(keyFile)) return null;
+	try {
+		const cert = read(certFile).toString("utf8");
+		const key = read(keyFile).toString("utf8");
+		if (!looksLikeCertPem(cert) || !looksLikeKeyPem(key)) return null;
+		return { cert, key };
+	} catch {
+		return null;
+	}
+}
+
+// ---- boot seam: provision + refresh + resolve TLS material -------------------
+
+/** PEM cert/key material for the additive `wss` listener (matches `BridgeTls`). */
+export interface ResolvedBridgeTls {
+	cert: string;
+	key: string;
+}
+
+/** Process-wide latch so the weekly refresh timer is armed at most once. */
+let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Arm the weekly background refresh of the public cert (idempotent — latched to
+ * fire at most once per process). The timer is `.unref()`d so it never keeps the
+ * process alive, and each tick is best-effort ({@link provisionPublicCert} never
+ * throws). A no-op after the first call.
+ */
+export function startBridgeCertRefresh(io: CertIoDeps = {}): void {
+	if (refreshTimer) return;
+	refreshTimer = setInterval(() => {
+		void provisionPublicCert(io);
+	}, REFRESH_MS);
+	// Do not hold the event loop open just for the refresh cadence.
+	refreshTimer.unref?.();
+}
+
+/** Injectable seams for {@link resolveBridgeTls} (real implementations when omitted). */
+export interface ResolveBridgeTlsDeps {
+	/** Provision the public `*.local-ip.sh` cert (the network path). */
+	provision?: (io?: CertIoDeps) => Promise<ProvisionResult>;
+	/** Provision the self-signed dev fallback. */
+	provisionSelfSigned?: (io?: CertIoDeps) => boolean;
+	/** Read a cert/key pair off disk as PEM strings, or null when unavailable. */
+	loadPair?: (certFile: string, keyFile: string) => ResolvedBridgeTls | null;
+	/** Arm the weekly refresh timer (idempotent). */
+	startRefresh?: (io?: CertIoDeps) => void;
+	/** Underlying fetch/fs seams forwarded to provisioning + loading. */
+	io?: CertIoDeps;
+}
+
+/**
+ * Resolve the TLS material for the bridge's `wss` listener, provisioning it first.
+ *
+ * IMPORTANT — TTFT: this awaits {@link provisionPublicCert}, which may perform a
+ * network fetch on a cold/stale cache. Callers MUST run it OUTSIDE (before) the
+ * `session:bridgeListen` `logger.time(...)` span so a cold fetch never inflates
+ * the measured bridge-ready time. Because provisioning is provision-once-cached, a
+ * warm boot is a fast on-disk cache hit and adds no measurable latency.
+ *
+ * Preference order: the publicly-trusted `*.local-ip.sh` cert, then a self-signed
+ * dev cert. Returns `undefined` when neither can be provisioned or loaded (offline
+ * / `local-ip.sh` unreachable / no `openssl`) so the bridge starts **ws-only** —
+ * the caller passes `undefined` as the `tls` option and the bridge does not crash.
+ * Never throws.
+ */
+export async function resolveBridgeTls(deps: ResolveBridgeTlsDeps = {}): Promise<ResolvedBridgeTls | undefined> {
+	const io = deps.io ?? {};
+	const provision = deps.provision ?? provisionPublicCert;
+	const provisionFallback = deps.provisionSelfSigned ?? provisionSelfSigned;
+	const load = deps.loadPair ?? ((certFile: string, keyFile: string) => loadPemPair(certFile, keyFile, io));
+	const startRefresh = deps.startRefresh ?? startBridgeCertRefresh;
+
+	// Network path (best-effort, never throws) — run by the caller before the TTFT span.
+	await provision(io);
+	// Keep the cert fresh in the background; latched so this only arms one timer.
+	startRefresh(io);
+
+	// Prefer the publicly-trusted cert; the self-signed pair is a dev-only fallback.
+	const pub = load(io.certFile ?? publicCertPath(), io.keyFile ?? publicKeyPath());
+	if (pub) return pub;
+	if (provisionFallback(io)) {
+		const self = load(selfSignedCertPath(), selfSignedKeyPath());
+		if (self) return self;
+	}
+	return undefined;
+}

--- a/packages/coding-agent/src/browser/extension-bridge.ts
+++ b/packages/coding-agent/src/browser/extension-bridge.ts
@@ -83,6 +83,51 @@ export const WSS_PORT_OFFSET = 100;
 export const WSS_RANGE_START = 19322;
 export const WSS_RANGE_END = 19341;
 
+/**
+ * Add-in origin allowlist suffixes for the bridge gate. An `https:` origin whose
+ * host is EXACTLY one of these, OR ends with the dot-prefixed suffix `.<suffix>`
+ * (so `evil-local-ip.sh` is NOT matched by `local-ip.sh`), is treated as a
+ * trusted Office add-in / bridge host.
+ *
+ * Seeded with `local-ip.sh` — the validated add-in/bridge host proven by the UAT
+ * (the `*.local-ip.sh` Let's Encrypt cert host that WebKit + Chromium open with
+ * TLS verification ON and zero trust/MDM steps).
+ *
+ * TODO(#2045)(office-xcsh): enumerate the production Office task-pane host and
+ * the SharePoint SPFx host origins here once the Phase 4 add-in host origin is
+ * fixed. Do NOT hardcode guessed Office origins — add each only when validated.
+ * This MUST stay an allowlist — never `*`.
+ */
+export const ADDIN_ALLOWED_ORIGIN_SUFFIXES = ["local-ip.sh"] as const;
+
+/**
+ * Pure origin-gate predicate for the bridge (shared by the ws + wss listeners).
+ * Returns true ONLY for:
+ *   (a) the Chrome extension origin `chrome-extension://${EXTENSION_ID}`
+ *       (unchanged behavior for the Chrome ext), OR
+ *   (b) an `https:` Office add-in origin whose host is exactly, or a dot-prefixed
+ *       subdomain of, an entry in {@link ADDIN_ALLOWED_ORIGIN_SUFFIXES}.
+ *
+ * It is a strict ALLOWLIST — never `*`. The dot-prefixed suffix guard means
+ * `https://evil-local-ip.sh` is REJECTED while `https://x.local-ip.sh` passes,
+ * and the `https:`-only requirement rejects `http://x.local-ip.sh`.
+ */
+export function isAllowedBridgeOrigin(origin: string | null | undefined): boolean {
+	if (!origin) return false;
+	// Lazy require avoids a top-level import cycle (chrome-cli imports this module).
+	const { EXTENSION_ID } = require("../cli/chrome-cli") as { EXTENSION_ID: string };
+	if (origin === `chrome-extension://${EXTENSION_ID}`) return true;
+	let url: URL;
+	try {
+		url = new URL(origin);
+	} catch {
+		return false;
+	}
+	if (url.protocol !== "https:") return false;
+	const host = url.hostname;
+	return ADDIN_ALLOWED_ORIGIN_SUFFIXES.some(suffix => host === suffix || host.endsWith(`.${suffix}`));
+}
+
 /** TLS material (PEM strings) for the additive `wss` listener. */
 export interface BridgeTls {
 	cert: string;
@@ -257,15 +302,31 @@ export class BridgeServer {
 	listen(port: number, opts?: BridgeListenOpts): boolean {
 		// Extract the fetch + websocket handlers to locals so BOTH the ws and the wss
 		// listeners share ONE implementation (DRY). Behavior is unchanged from before.
+		const { EXTENSION_ID } = require("../cli/chrome-cli") as { EXTENSION_ID: string };
 		const fetch = (req: Request, server: Server<undefined>): Response | undefined => {
-			if (!opts?.skipOriginCheck) {
-				const origin = req.headers.get("origin") ?? "";
-				const { EXTENSION_ID } = require("../cli/chrome-cli");
-				if (origin !== `chrome-extension://${EXTENSION_ID}`) {
-					return new Response("Forbidden", { status: 403 });
-				}
+			const origin = req.headers.get("origin");
+			// SUPERSET gate: the Chrome ext origin stays allowed (Chrome path preserved);
+			// add-in `.local-ip.sh` origins are ADDITIONALLY allowed. Allowlist, never `*`.
+			if (!opts?.skipOriginCheck && !isAllowedBridgeOrigin(origin)) {
+				return new Response("Forbidden", { status: 403 });
 			}
-			if (server.upgrade(req)) return undefined;
+			// For an ALLOWED cross-origin (non-ext) add-in origin, opt into Private Network
+			// Access + reflect the origin (scoped, never `*`) so a public `https:` add-in
+			// origin may open the loopback socket. The chrome-extension origin path is
+			// unchanged (no extra headers).
+			if (origin && origin !== `chrome-extension://${EXTENSION_ID}` && isAllowedBridgeOrigin(origin)) {
+				if (
+					server.upgrade(req, {
+						headers: {
+							"Access-Control-Allow-Private-Network": "true",
+							"Access-Control-Allow-Origin": origin,
+						},
+					})
+				)
+					return undefined;
+			} else if (server.upgrade(req)) {
+				return undefined;
+			}
 			return new Response("xcsh bridge: WebSocket only", { status: 426 });
 		};
 		const websocket = {

--- a/packages/coding-agent/src/browser/extension-bridge.ts
+++ b/packages/coding-agent/src/browser/extension-bridge.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { Server, ServerWebSocket } from "bun";
+import { LOCALIP_HOST } from "./bridge-cert";
 
 export interface ToolResult {
 	content: unknown;
@@ -71,6 +72,30 @@ export function resolvePort(port?: number): number {
 export const PORT_RANGE_START = 19222;
 export const PORT_RANGE_END = 19241;
 
+/**
+ * Fixed offset from a bound ws port to its paired `wss` port. The wss listener is
+ * ADDITIVE: when the bridge binds ws port P (in {@link PORT_RANGE_START}–{@link
+ * PORT_RANGE_END}), it also binds wss on P + {@link WSS_PORT_OFFSET}, so discovery
+ * stays trivial (ws 19222 ↔ wss 19322) and the ws/wss pair can never desync.
+ */
+export const WSS_PORT_OFFSET = 100;
+/** Inclusive discovery range for the paired `wss` listeners (ws range + offset). */
+export const WSS_RANGE_START = 19322;
+export const WSS_RANGE_END = 19341;
+
+/** TLS material (PEM strings) for the additive `wss` listener. */
+export interface BridgeTls {
+	cert: string;
+	key: string;
+}
+
+/** Options shared by {@link BridgeServer.listen} and {@link startBridgeServer}. */
+export interface BridgeListenOpts {
+	skipOriginCheck?: boolean;
+	/** When present, an additive `wss` listener is started on port + {@link WSS_PORT_OFFSET}. */
+	tls?: BridgeTls;
+}
+
 /** Every port in the discovery range, lowest first. */
 export function portCandidates(): number[] {
 	const out: number[] = [];
@@ -96,6 +121,8 @@ export function resolveForcedPort(port?: number): number | null {
 export class BridgeServer {
 	#pending = new PendingRequests();
 	#server: Server<undefined> | null = null;
+	/** Additive TLS listener on port + {@link WSS_PORT_OFFSET} (null when ws-only). */
+	#wssServer: Server<undefined> | null = null;
 	/** Multi-client: keyed by channelId (default channel = "default"). */
 	#clients = new Map<string, ServerWebSocket<undefined>>();
 	#nextChannelIndex = 0;
@@ -119,6 +146,11 @@ export class BridgeServer {
 	/** The port the WebSocket server is listening on (0 = not bound). */
 	get port(): number {
 		return this.#server?.port ?? 0;
+	}
+
+	/** The port the additive `wss` server is listening on (0 = ws-only / not bound). */
+	get wssPort(): number {
+		return this.#wssServer?.port ?? 0;
 	}
 
 	/** True when at least one client is connected (backwards compat). */
@@ -217,33 +249,54 @@ export class BridgeServer {
 		for (const cb of this.#onConnected) cb();
 	}
 
-	/** Try to bind the loopback WS server to `port`. Returns false on EADDRINUSE
-	 * (so the caller can try the next candidate); rethrows any other error. */
-	listen(port: number, opts?: { skipOriginCheck?: boolean }): boolean {
+	/** Try to bind the loopback WS server to `port`. When `opts.tls` is supplied an
+	 * ADDITIVE `wss` listener is also bound on `port + WSS_PORT_OFFSET`, sharing ONE
+	 * fetch/websocket implementation with the ws listener. Returns false on EADDRINUSE
+	 * on EITHER listener (so the caller can try the next candidate); rethrows any other
+	 * error. The ws listener + origin gate are byte-for-byte identical to the ws-only path. */
+	listen(port: number, opts?: BridgeListenOpts): boolean {
+		// Extract the fetch + websocket handlers to locals so BOTH the ws and the wss
+		// listeners share ONE implementation (DRY). Behavior is unchanged from before.
+		const fetch = (req: Request, server: Server<undefined>): Response | undefined => {
+			if (!opts?.skipOriginCheck) {
+				const origin = req.headers.get("origin") ?? "";
+				const { EXTENSION_ID } = require("../cli/chrome-cli");
+				if (origin !== `chrome-extension://${EXTENSION_ID}`) {
+					return new Response("Forbidden", { status: 403 });
+				}
+			}
+			if (server.upgrade(req)) return undefined;
+			return new Response("xcsh bridge: WebSocket only", { status: 426 });
+		};
+		const websocket = {
+			open: (ws: ServerWebSocket<undefined>) => this.#onOpen(ws),
+			message: (ws: ServerWebSocket<undefined>, message: string | Buffer) => this.#handleMessage(ws, message),
+			close: (ws: ServerWebSocket<undefined>) => this.#onClose(ws),
+		};
 		try {
-			this.#server = Bun.serve({
-				port,
-				hostname: "127.0.0.1",
-				fetch: (req, server) => {
-					if (!opts?.skipOriginCheck) {
-						const origin = req.headers.get("origin") ?? "";
-						const { EXTENSION_ID } = require("../cli/chrome-cli");
-						if (origin !== `chrome-extension://${EXTENSION_ID}`) {
-							return new Response("Forbidden", { status: 403 });
-						}
-					}
-					if (server.upgrade(req)) return undefined;
-					return new Response("xcsh bridge: WebSocket only", { status: 426 });
-				},
-				websocket: {
-					open: ws => this.#onOpen(ws),
-					message: (ws, message) => this.#handleMessage(ws, message),
-					close: ws => this.#onClose(ws),
-				},
-			});
+			this.#server = Bun.serve({ port, hostname: "127.0.0.1", fetch, websocket });
+			// Additive wss listener: only when cert material is available. Absent TLS
+			// leaves the bridge ws-only (no crash). EADDRINUSE here → false (same try).
+			if (opts?.tls?.cert && opts.tls.key) {
+				this.#wssServer = Bun.serve({
+					port: port + WSS_PORT_OFFSET,
+					hostname: "127.0.0.1",
+					tls: { cert: opts.tls.cert, key: opts.tls.key, serverName: LOCALIP_HOST },
+					fetch,
+					websocket,
+				});
+			}
 			return true;
 		} catch (e) {
-			if (e instanceof Error && /EADDRINUSE|address already in use|in use/i.test(e.message)) return false;
+			if (e instanceof Error && /EADDRINUSE|address already in use|in use/i.test(e.message)) {
+				// Roll back any partially-bound listener so a retry on the next candidate
+				// starts clean (no leaked ws server when only the wss bind collided).
+				this.#server?.stop(true);
+				this.#server = null;
+				this.#wssServer?.stop(true);
+				this.#wssServer = null;
+				return false;
+			}
 			throw e;
 		}
 	}
@@ -283,6 +336,7 @@ export class BridgeServer {
 					apiUrl: info.apiUrl,
 					contextBound: info.contextBound,
 					pid: process.pid,
+					wssPort: this.wssPort,
 				}),
 			);
 		} else {
@@ -335,6 +389,8 @@ export class BridgeServer {
 		this.#clients.clear();
 		this.#server?.stop(true);
 		this.#server = null;
+		this.#wssServer?.stop(true);
+		this.#wssServer = null;
 	}
 }
 
@@ -345,7 +401,7 @@ export class BridgeServer {
  * ({@link PORT_RANGE_START}–{@link PORT_RANGE_END}). The WebSocket transport
  * needs no filesystem setup — Chrome connects directly to `ws://127.0.0.1:<port>`.
  */
-export async function startBridgeServer(port?: number, opts?: { skipOriginCheck?: boolean }): Promise<BridgeServer> {
+export async function startBridgeServer(port?: number, opts?: BridgeListenOpts): Promise<BridgeServer> {
 	const server = new BridgeServer();
 	const forced = resolveForcedPort(port);
 	if (forced !== null) {

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -97,6 +97,9 @@ function bridgeHello(port: number, timeoutMs = 400): Promise<Record<string, unkn
 		let ws: WebSocket;
 		try {
 			const { EXTENSION_ID } = require("../cli/chrome-cli");
+			// Intentionally ws:// — the bridge's ws listener remains up under dual-listen,
+			// and this internal re-adoption client needs no TLS. Moving it to wss:// is
+			// deferred to the ws-sunset PR (#2045 follow-up); do not change here.
 			ws = new WebSocket(`ws://127.0.0.1:${port}`, {
 				headers: { Origin: `chrome-extension://${EXTENSION_ID}` },
 			} as unknown as string[]);

--- a/packages/coding-agent/src/commands/worker.ts
+++ b/packages/coding-agent/src/commands/worker.ts
@@ -17,6 +17,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { getProjectDir, getXCSHConfigDir, logger } from "@f5-sales-demo/pi-utils";
 import { Command } from "@f5-sales-demo/pi-utils/cli";
+import { LOCALIP_HOST, resolveBridgeTls } from "../browser/bridge-cert";
 import { ChatHandler } from "../browser/chat-handler";
 import { startBridgeServer } from "../browser/extension-bridge";
 import { createExtensionBridgeTools, EXTENSION_AGENT_TOOL_NAMES } from "../browser/extension-bridge-tools";
@@ -152,12 +153,23 @@ export default class Worker extends Command {
 		// Quiet startup: skip the welcome screen + blocking plugin "Fix now?" prompts.
 		settings.override("startup.quiet", true);
 
+		// Provision the wss cert BEFORE the session:bridgeListen span — its only
+		// network path (a cold/stale-cache fetch) must NOT inflate the measured
+		// bridge-ready time; a warm boot is a fast on-disk cache hit. `undefined`
+		// (offline / local-ip.sh unreachable) → the bridge starts ws-only (no crash).
+		const tls = await resolveBridgeTls();
+
 		// INSTANT-ON: start the bridge before the heavy session init so the extension
 		// can connect immediately. Honors XCSH_BRIDGE_PORT (forced) or auto-selects.
 		// session:bridgeListen — time-to-"bridge-ready": the extension can connect and
 		// complete the hello/hello_ack handshake once this resolves (INSTANT-ON path).
-		const bridge = await logger.time("session:bridgeListen", startBridgeServer);
-		console.error(`[xcsh worker] extension bridge listening on ws://127.0.0.1:${bridge.port}`);
+		const bridge = await logger.time("session:bridgeListen", () =>
+			startBridgeServer(undefined, tls ? { tls } : undefined),
+		);
+		console.error(
+			`[xcsh worker] extension bridge listening on ws://127.0.0.1:${bridge.port}` +
+				(bridge.wssPort ? ` + wss://${LOCALIP_HOST}:${bridge.wssPort}` : ""),
+		);
 		setSharedBridgeServer(bridge);
 		bridge.setSessionInfo(sessionInfoForWorker);
 		ContextService.onContextChange(() => bridge.broadcastTenantChanged());

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -21,6 +21,7 @@ import {
 	VERSION,
 } from "@f5-sales-demo/pi-utils";
 import chalk from "chalk";
+import { LOCALIP_HOST, resolveBridgeTls } from "./browser/bridge-cert";
 import { ChatHandler } from "./browser/chat-handler";
 import { type BridgeServer, startBridgeServer } from "./browser/extension-bridge";
 import { setSharedBridgeServer } from "./browser/provider";
@@ -805,8 +806,14 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 	let bridgeServer: BridgeServer | null = null;
 	let sessionReady = false;
 	if (process.env.XCSH_BROWSER_PROVIDER?.toLowerCase() === "extension") {
-		bridgeServer = await startBridgeServer();
-		console.error(`[xcsh] extension bridge listening on ws://127.0.0.1:${bridgeServer.port}`);
+		// Provision the wss cert before binding (network path is provision-once-cached).
+		// `undefined` (offline / local-ip.sh unreachable) → the bridge starts ws-only.
+		const tls = await resolveBridgeTls();
+		bridgeServer = await startBridgeServer(undefined, tls ? { tls } : undefined);
+		console.error(
+			`[xcsh] extension bridge listening on ws://127.0.0.1:${bridgeServer.port}` +
+				(bridgeServer.wssPort ? ` + wss://${LOCALIP_HOST}:${bridgeServer.wssPort}` : ""),
+		);
 		// Make the bridge globally available so ALL selectProvider() calls reuse it
 		// (prevents starting a conflicting second bridge on the same port).
 		setSharedBridgeServer(bridgeServer);

--- a/packages/coding-agent/test/browser/bridge-cert.test.ts
+++ b/packages/coding-agent/test/browser/bridge-cert.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "bun:test";
+import type { SecureContext } from "node:tls";
+import {
+	certDaysLeft,
+	isCertStale,
+	isLocalIpServerName,
+	LOCALIP_CERT_URL,
+	LOCALIP_HOST,
+	LOCALIP_KEY_URL,
+	provisionPublicCert,
+	REFRESH_MS,
+	selectServerCert,
+	selectSniContext,
+} from "../../src/browser/bridge-cert";
+
+// ---------------------------------------------------------------------------
+// Fixtures — self-signed certs minted with OpenSSL (`-not_after`), inlined so
+// the test needs no network, no keychain, and no committed fixture file. Only
+// the CERTIFICATE is needed here (certDaysLeft parses notAfter); the matching
+// private keys are intentionally omitted — validation is mocked in the I/O tests.
+// ---------------------------------------------------------------------------
+
+// notAfter = 2099-01-01 → always thousands of days out (fresh).
+const PEM_VALID = `-----BEGIN CERTIFICATE-----
+MIIDVjCCAj6gAwIBAgIUYX5EN2WyI87LjRqmqsKYYWmVK7wwDQYJKoZIhvcNAQEL
+BQAwIDEeMBwGA1UEAwwVMTI3LTAtMC0xLmxvY2FsLWlwLnNoMCAXDTI1MDEwMTAw
+MDAwMFoYDzIwOTkwMTAxMDAwMDAwWjAgMR4wHAYDVQQDDBUxMjctMC0wLTEubG9j
+YWwtaXAuc2gwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCtxZ21KjN7
+BjZziSonwDSkBbpbsBWBvhcp+L0C8OcgymQQI6auvDKhnEev/VG56T5MVyddlvuf
+QD+tLi9RgQI0FodZ6g5SOKPRfRqDTMzKMxfzk3khFHqI04N21YkLxseTQl3PFjud
+wquN6yWCajKjSD0FjMv0fKCqUNk5ekcnKRwzDXEtAdXWfLkyshQ0NpcZZANKyYxi
+/mBxYEJBwJsotnbd2tpmpMTP251D4RKg+qSFPyYXOLU8Rt50C1MtW5xK81pvkY05
+lCWRi9G08UtbB29NDY1maSubCFGpJYKESlIrun1JZBYRHavA17wSCpk5VIiBx2jD
+0k28cQJuF3SLAgMBAAGjgYUwgYIwHQYDVR0OBBYEFJqs6WsJyFOhxbt5P6czucn0
+jhg3MB8GA1UdIwQYMBaAFJqs6WsJyFOhxbt5P6czucn0jhg3MA8GA1UdEwEB/wQF
+MAMBAf8wLwYDVR0RBCgwJoIVMTI3LTAtMC0xLmxvY2FsLWlwLnNogg0qLmxvY2Fs
+LWlwLnNoMA0GCSqGSIb3DQEBCwUAA4IBAQBUVqKdmEwVoq92AkfimWPluTgn5XKu
+K3s6CiymNysUERO51qBR+ksdj3Hi1Eq4ffY4AGUYfCkPxWFkwkbR0uVp7HJViZ9i
+4rSjcd9fsUhvGTDg5MA8K9AhjyQyIegHjkn211F/NuKo1ms5s/AKMMBBxsdEfo3o
+8X42J2UN1zKqQcuSiv/8zUE0uitL3HA4YZ5prArVgmyyW5OTJfTEifn7x3q4nnSI
+iiGo65W1zY6qlUYDmEkdExDcFZLeOAZhmuvbcQp9bP6Br2EXTsZ00f4prsHT49iQ
+qMRvV9WxPlZkQ0Izl2p5ASE5RaO4Hd0TLx8/Txl3w02m7patYVDNesch
+-----END CERTIFICATE-----
+`;
+
+// notAfter = 2020-02-01 → long expired (parseable, so days-left is negative,
+// distinct from the -1 garbage sentinel).
+const PEM_EXPIRED = `-----BEGIN CERTIFICATE-----
+MIIDOzCCAiOgAwIBAgIUdsmyyZjvh3hLBP2eunkLIhu7hr0wDQYJKoZIhvcNAQEL
+BQAwIDEeMBwGA1UEAwwVMTI3LTAtMC0xLmxvY2FsLWlwLnNoMB4XDTIwMDEwMTAw
+MDAwMFoXDTIwMDIwMTAwMDAwMFowIDEeMBwGA1UEAwwVMTI3LTAtMC0xLmxvY2Fs
+LWlwLnNoMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArMb7QK0HSiCR
+NQL8q0tg0nXE73xTAt5rzQgTDZIpnpFjdqkL55pk4RVIOm8PUBcgzFVo4O3w0qoH
+jJvHBGCd7g6Yz2AeZSyM6jdiztdNA+DbN7xbj1hiZUItlUtIQUvOlhqnJzShVopZ
+r9CvIcaJLQ/Es+1h2rdQejIhOlUezGQhTn8r2DdJePbFyHNX37R629CaG/bOhTQx
+Gd/x9nKjHqB29ZMAgqTdYkMuh76cjKYVvZg1ClMyYrvWqWkkvM1cvGBnocTy1juu
+94f7/5OpzsqBEj4ojjLVmKWnsf54T87NMq8HIH7HofYmtkxej4xcamMahXwNDFRy
+lzdOeMxqyQIDAQABo20wazAdBgNVHQ4EFgQU02UpEZLV8sKiuWMsM3YaXXcfGVcw
+HwYDVR0jBBgwFoAU02UpEZLV8sKiuWMsM3YaXXcfGVcwDwYDVR0TAQH/BAUwAwEB
+/zAYBgNVHREEETAPgg0qLmxvY2FsLWlwLnNoMA0GCSqGSIb3DQEBCwUAA4IBAQBk
+Z0ctua9NRYkWg2GpiGLqRtVq63qJmVyRLVBGEJLPTsPa5pZU1gf1QwdA5ewzSEDf
+1TC52GnayunqdE7UL8I8QMA5G5r6goYELybufRPJHBJj/1ZY60g50b3kCXQDJY3H
+kjUDinYZyWOQAS9RZbow0sWEuVhVkrfEdPp/YM574QDtPP08jj6018Kobh7S3+zr
+JMHN6Lqx2y0kWZFDr7fWAofPrIjDOToA4lC2cLrx69NOI01HzXFjE8aHYOxbNkXK
+qHGSacVsTmO8vNTsIXQ12EXe6CY5kjGJswAxYT4d0sKMhQSuvTXZlp4n5gXNJT8O
+I3RSvgDHdBEdBPKIEUNK
+-----END CERTIFICATE-----
+`;
+
+describe("constants", () => {
+	it("expose the local-ip.sh provisioning endpoints and host", () => {
+		expect(LOCALIP_CERT_URL).toBe("https://local-ip.sh/server.pem");
+		expect(LOCALIP_KEY_URL).toBe("https://local-ip.sh/server.key");
+		expect(LOCALIP_HOST).toBe("127-0-0-1.local-ip.sh");
+	});
+	it("refreshes weekly", () => {
+		expect(REFRESH_MS).toBe(7 * 24 * 60 * 60 * 1000);
+	});
+});
+
+describe("certDaysLeft", () => {
+	it("returns a large positive number for a long-lived cert", () => {
+		expect(certDaysLeft(PEM_VALID)).toBeGreaterThan(30);
+	});
+	it("returns a negative number for a parseable but expired cert", () => {
+		expect(certDaysLeft(PEM_EXPIRED)).toBeLessThan(0);
+	});
+	it("returns -1 for garbage input", () => {
+		expect(certDaysLeft("not a certificate at all")).toBe(-1);
+		expect(certDaysLeft("")).toBe(-1);
+	});
+	it("accepts a Buffer as well as a string", () => {
+		expect(certDaysLeft(Buffer.from(PEM_VALID))).toBeGreaterThan(30);
+	});
+});
+
+describe("isCertStale", () => {
+	it("treats a far-future cert as fresh (>30d)", () => {
+		expect(isCertStale(PEM_VALID)).toBe(false);
+	});
+	it("treats an expired cert as stale (<30d)", () => {
+		expect(isCertStale(PEM_EXPIRED)).toBe(true);
+	});
+	it("treats garbage as stale", () => {
+		expect(isCertStale("garbage")).toBe(true);
+	});
+});
+
+describe("selectServerCert", () => {
+	it("prefers the public cert when present", () => {
+		expect(selectServerCert({ public: true, selfSigned: true })).toBe("public");
+		expect(selectServerCert({ public: true, selfSigned: false })).toBe("public");
+	});
+	it("falls back to self-signed when the public cert is absent", () => {
+		expect(selectServerCert({ public: false, selfSigned: true })).toBe("self-signed");
+	});
+	it("returns null when neither cert is available", () => {
+		expect(selectServerCert({ public: false, selfSigned: false })).toBeNull();
+	});
+});
+
+describe("isLocalIpServerName", () => {
+	it("matches *.local-ip.sh subdomains only", () => {
+		expect(isLocalIpServerName("127-0-0-1.local-ip.sh")).toBe(true);
+		expect(isLocalIpServerName("anything.local-ip.sh")).toBe(true);
+		expect(isLocalIpServerName("local-ip.sh")).toBe(false);
+		expect(isLocalIpServerName("localhost")).toBe(false);
+		expect(isLocalIpServerName("evil-local-ip.sh")).toBe(false);
+		expect(isLocalIpServerName(undefined)).toBe(false);
+		expect(isLocalIpServerName(null)).toBe(false);
+	});
+});
+
+describe("selectSniContext", () => {
+	const localIp = { id: "localip" } as unknown as SecureContext;
+	const selfSigned = { id: "self" } as unknown as SecureContext;
+
+	it("returns the local-ip context for a *.local-ip.sh servername", () => {
+		expect(selectSniContext("127-0-0-1.local-ip.sh", { localIp, selfSigned })).toBe(localIp);
+	});
+	it("returns the self-signed context for any other servername", () => {
+		expect(selectSniContext("localhost", { localIp, selfSigned })).toBe(selfSigned);
+		expect(selectSniContext(undefined, { localIp, selfSigned })).toBe(selfSigned);
+	});
+	it("falls back to self-signed when the local-ip context is missing", () => {
+		expect(selectSniContext("x.local-ip.sh", { localIp: null, selfSigned })).toBe(selfSigned);
+	});
+	it("falls back to the local-ip context when self-signed is missing", () => {
+		expect(selectSniContext("localhost", { localIp, selfSigned: null })).toBe(localIp);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// provisionPublicCert — I/O path exercised with injected fetch + fs so no
+// network / no keychain is touched. Asserts the freshness gate and the
+// "write only on stale AND valid content" guard ported from claude-office.
+// ---------------------------------------------------------------------------
+
+function fakeFetch(body: string) {
+	let calls = 0;
+	const fn = (async (_url: string) => {
+		calls++;
+		return { ok: true, status: 200, text: async () => body };
+	}) as (url: string) => Promise<{ ok: boolean; status: number; text(): Promise<string> }>;
+	return { fn, calls: () => calls };
+}
+
+function fakeFs(existing: Record<string, string>) {
+	const writes: Array<{ path: string; data: string; mode?: number }> = [];
+	const store = { ...existing };
+	return {
+		writes,
+		deps: {
+			existsSync: (p: string) => p in store,
+			readFileSync: (p: string) => Buffer.from(store[p] ?? ""),
+			writeFileSync: (p: string, data: string, opts?: { mode?: number }) => {
+				store[p] = data;
+				writes.push({ path: p, data, mode: opts?.mode });
+			},
+			mkdirSync: (_p: string, _o: { recursive: boolean }) => {},
+		},
+	};
+}
+
+const CERT_FILE = "/tmp/xcsh-test/bridge/localip.pem";
+const KEY_FILE = "/tmp/xcsh-test/bridge/localip.key";
+const VALID_KEY = "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n";
+
+describe("provisionPublicCert", () => {
+	it("skips the refetch when the existing cert is fresh (>30d)", async () => {
+		const fetcher = fakeFetch("");
+		const fs = fakeFs({ [CERT_FILE]: PEM_VALID, [KEY_FILE]: VALID_KEY });
+		const result = await provisionPublicCert({
+			certFile: CERT_FILE,
+			keyFile: KEY_FILE,
+			fetch: fetcher.fn,
+			validatePair: () => {},
+			...fs.deps,
+		});
+		expect(fetcher.calls()).toBe(0);
+		expect(result.written).toBe(false);
+		expect(result.reason).toBe("fresh");
+		expect(fs.writes.length).toBe(0);
+	});
+
+	it("refetches and writes when the existing cert is stale AND content is valid", async () => {
+		// Distinct cert + key bodies keyed by URL.
+		const certFetcher = (async (url: string) => ({
+			ok: true,
+			status: 200,
+			text: async () => (url === LOCALIP_KEY_URL ? VALID_KEY : PEM_VALID),
+		})) as (url: string) => Promise<{ ok: boolean; status: number; text(): Promise<string> }>;
+		const fs = fakeFs({ [CERT_FILE]: PEM_EXPIRED, [KEY_FILE]: VALID_KEY });
+		let validated = false;
+		const result = await provisionPublicCert({
+			certFile: CERT_FILE,
+			keyFile: KEY_FILE,
+			fetch: certFetcher,
+			validatePair: () => {
+				validated = true;
+			},
+			...fs.deps,
+		});
+		expect(validated).toBe(true);
+		expect(result.written).toBe(true);
+		expect(result.reason).toBe("provisioned");
+		// Both cert and key written; key written with 0600.
+		const certWrite = fs.writes.find(w => w.path === CERT_FILE);
+		const keyWrite = fs.writes.find(w => w.path === KEY_FILE);
+		expect(certWrite?.data).toContain("BEGIN CERTIFICATE");
+		expect(keyWrite?.data).toContain("PRIVATE KEY");
+		expect(keyWrite?.mode).toBe(0o600);
+	});
+
+	it("does NOT write when the downloaded content is invalid", async () => {
+		const badFetcher = (async () => ({
+			ok: true,
+			status: 200,
+			text: async () => "<html>404 not found</html>",
+		})) as (url: string) => Promise<{ ok: boolean; status: number; text(): Promise<string> }>;
+		const fs = fakeFs({ [CERT_FILE]: PEM_EXPIRED, [KEY_FILE]: VALID_KEY });
+		const result = await provisionPublicCert({
+			certFile: CERT_FILE,
+			keyFile: KEY_FILE,
+			fetch: badFetcher,
+			validatePair: () => {},
+			...fs.deps,
+		});
+		expect(result.written).toBe(false);
+		expect(result.reason).toBe("invalid-content");
+		expect(fs.writes.length).toBe(0);
+	});
+
+	it("keeps the existing cert (no throw) when the fetch fails", async () => {
+		const failFetcher = (async () => {
+			throw new Error("network down");
+		}) as (url: string) => Promise<{ ok: boolean; status: number; text(): Promise<string> }>;
+		const fs = fakeFs({ [CERT_FILE]: PEM_EXPIRED, [KEY_FILE]: VALID_KEY });
+		const result = await provisionPublicCert({
+			certFile: CERT_FILE,
+			keyFile: KEY_FILE,
+			fetch: failFetcher,
+			validatePair: () => {},
+			...fs.deps,
+		});
+		expect(result.written).toBe(false);
+		expect(result.reason).toBe("provision-failed");
+		expect(fs.writes.length).toBe(0);
+	});
+
+	it("does NOT write when the key/cert pair fails validation", async () => {
+		const goodFetcher = (async (url: string) => ({
+			ok: true,
+			status: 200,
+			text: async () => (url === LOCALIP_KEY_URL ? VALID_KEY : PEM_VALID),
+		})) as (url: string) => Promise<{ ok: boolean; status: number; text(): Promise<string> }>;
+		const fs = fakeFs({ [CERT_FILE]: PEM_EXPIRED, [KEY_FILE]: VALID_KEY });
+		const result = await provisionPublicCert({
+			certFile: CERT_FILE,
+			keyFile: KEY_FILE,
+			fetch: goodFetcher,
+			validatePair: () => {
+				throw new Error("key values mismatch");
+			},
+			...fs.deps,
+		});
+		expect(result.written).toBe(false);
+		expect(result.reason).toBe("provision-failed");
+		expect(fs.writes.length).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/browser/bridge-cert.test.ts
+++ b/packages/coding-agent/test/browser/bridge-cert.test.ts
@@ -8,7 +8,10 @@ import {
 	LOCALIP_HOST,
 	LOCALIP_KEY_URL,
 	provisionPublicCert,
+	publicCertPath,
+	publicKeyPath,
 	REFRESH_MS,
+	resolveBridgeTls,
 	selectServerCert,
 	selectSniContext,
 } from "../../src/browser/bridge-cert";
@@ -287,5 +290,83 @@ describe("provisionPublicCert", () => {
 		expect(result.written).toBe(false);
 		expect(result.reason).toBe("provision-failed");
 		expect(fs.writes.length).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// resolveBridgeTls — the boot seam wired into worker.ts / main.ts. It runs the
+// (network) provisioning step, kicks the weekly refresh once, then loads the
+// cert/key off disk. Returns {cert,key} when material is available, or undefined
+// so the bridge starts WS-ONLY (Task 2 handles no-tls → ws-only, no crash).
+// Every I/O + timer dependency is injected so this stays a pure unit test.
+// ---------------------------------------------------------------------------
+
+const PUB_CERT = publicCertPath();
+const PUB_KEY = publicKeyPath();
+
+describe("resolveBridgeTls", () => {
+	it("returns the public cert material when provisioning succeeds", async () => {
+		let refreshStarts = 0;
+		const tls = await resolveBridgeTls({
+			provision: async () => ({ fetched: true, written: true, reason: "provisioned" }),
+			provisionSelfSigned: () => {
+				throw new Error("self-signed fallback must NOT run when the public cert is present");
+			},
+			loadPair: (certFile, keyFile) =>
+				certFile === PUB_CERT && keyFile === PUB_KEY ? { cert: "PUBLIC-CERT-PEM", key: "PUBLIC-KEY-PEM" } : null,
+			startRefresh: () => {
+				refreshStarts++;
+			},
+		});
+		expect(tls).toEqual({ cert: "PUBLIC-CERT-PEM", key: "PUBLIC-KEY-PEM" });
+		expect(refreshStarts).toBe(1);
+	});
+
+	it("provisions ONCE, before loading, and always kicks the weekly refresh", async () => {
+		const order: string[] = [];
+		await resolveBridgeTls({
+			provision: async () => {
+				order.push("provision");
+				return { fetched: false, written: false, reason: "fresh" };
+			},
+			startRefresh: () => order.push("refresh"),
+			loadPair: () => {
+				order.push("load");
+				return { cert: "C", key: "K" };
+			},
+		});
+		// Network provisioning must happen before the on-disk load (cache-hit read),
+		// and the refresh timer is started every call (its own latch makes it idempotent).
+		expect(order).toEqual(["provision", "refresh", "load"]);
+	});
+
+	it("falls back to the self-signed cert when the public cert is absent", async () => {
+		const tls = await resolveBridgeTls({
+			provision: async () => ({ fetched: true, written: false, reason: "provision-failed" }),
+			loadPair: certFile => (certFile === PUB_CERT ? null : { cert: "SELF-CERT-PEM", key: "SELF-KEY-PEM" }),
+			provisionSelfSigned: () => true,
+			startRefresh: () => {},
+		});
+		expect(tls).toEqual({ cert: "SELF-CERT-PEM", key: "SELF-KEY-PEM" });
+	});
+
+	it("returns undefined (→ ws-only) when NO cert can be provisioned or loaded", async () => {
+		const tls = await resolveBridgeTls({
+			provision: async () => ({ fetched: true, written: false, reason: "provision-failed" }),
+			loadPair: () => null,
+			provisionSelfSigned: () => false,
+			startRefresh: () => {},
+		});
+		expect(tls).toBeUndefined();
+	});
+
+	it("returns undefined when self-signed provisioning succeeds but its files fail to load", async () => {
+		const tls = await resolveBridgeTls({
+			provision: async () => ({ fetched: true, written: false, reason: "provision-failed" }),
+			loadPair: () => null,
+			provisionSelfSigned: () => true,
+			startRefresh: () => {},
+		});
+		expect(tls).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/browser/extension-bridge.test.ts
+++ b/packages/coding-agent/test/browser/extension-bridge.test.ts
@@ -68,11 +68,20 @@ describe("port selection helpers", () => {
 });
 
 import { execFileSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { mkdtempSync, readFileSync } from "node:fs";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { connect as tlsConnect } from "node:tls";
-import { startBridgeServer, WSS_PORT_OFFSET } from "../../src/browser/extension-bridge";
+import {
+	ADDIN_ALLOWED_ORIGIN_SUFFIXES,
+	isAllowedBridgeOrigin,
+	startBridgeServer,
+	WSS_PORT_OFFSET,
+} from "../../src/browser/extension-bridge";
+import { EXTENSION_ID } from "../../src/cli/chrome-cli";
 
 describe("auto-select bind", () => {
 	test("two servers land on different ports in range", async () => {
@@ -212,6 +221,137 @@ describe("dual-listen ws + wss", () => {
 		try {
 			expect(server.port).toBeGreaterThanOrEqual(PORT_RANGE_START);
 			expect(server.wssPort).toBe(0);
+		} finally {
+			await server.close();
+		}
+	});
+});
+
+describe("isAllowedBridgeOrigin (pure predicate)", () => {
+	test("the Chrome extension origin is allowed (unchanged behavior)", () => {
+		expect(isAllowedBridgeOrigin(`chrome-extension://${EXTENSION_ID}`)).toBe(true);
+	});
+
+	test("https *.local-ip.sh add-in origins are allowed", () => {
+		expect(isAllowedBridgeOrigin("https://x.local-ip.sh")).toBe(true);
+		expect(isAllowedBridgeOrigin("https://127-0-0-1.local-ip.sh:8443")).toBe(true);
+	});
+
+	test("look-alike host without the dot-prefixed suffix is rejected", () => {
+		expect(isAllowedBridgeOrigin("https://evil-local-ip.sh")).toBe(false);
+	});
+
+	test("non-https local-ip.sh origin is rejected (must be https)", () => {
+		expect(isAllowedBridgeOrigin("http://x.local-ip.sh")).toBe(false);
+	});
+
+	test("an unrelated https origin is rejected", () => {
+		expect(isAllowedBridgeOrigin("https://random.example.com")).toBe(false);
+	});
+
+	test("null / empty / undefined is rejected", () => {
+		expect(isAllowedBridgeOrigin(null)).toBe(false);
+		expect(isAllowedBridgeOrigin("")).toBe(false);
+		expect(isAllowedBridgeOrigin(undefined)).toBe(false);
+	});
+
+	test("the allowlist is seeded with local-ip.sh and is never a wildcard", () => {
+		expect(ADDIN_ALLOWED_ORIGIN_SUFFIXES).toContain("local-ip.sh");
+		expect(ADDIN_ALLOWED_ORIGIN_SUFFIXES).not.toContain("*");
+	});
+});
+
+interface UpgradeResult {
+	status: number;
+	headers: Record<string, string | string[] | undefined>;
+}
+
+/**
+ * Drive a raw WebSocket upgrade handshake and resolve the response status +
+ * headers WITHOUT exchanging frames. For wss, the client TRUSTS the fixture cert
+ * as its CA (explicit `ca`) — NEVER `rejectUnauthorized:false` / any TLS bypass.
+ */
+function upgradeHandshake(o: { secure: boolean; port: number; origin?: string; ca?: string }): Promise<UpgradeResult> {
+	return new Promise((resolve, reject) => {
+		const headers: Record<string, string> = {
+			Connection: "Upgrade",
+			Upgrade: "websocket",
+			"Sec-WebSocket-Key": randomBytes(16).toString("base64"),
+			"Sec-WebSocket-Version": "13",
+		};
+		if (o.origin) headers.Origin = o.origin;
+		const common = { host: "127.0.0.1", port: o.port, path: "/", headers };
+		const req = o.secure ? httpsRequest({ ...common, ca: o.ca, servername: "127.0.0.1" }) : httpRequest(common);
+		const timer = setTimeout(() => {
+			req.destroy();
+			reject(new Error("upgrade timeout"));
+		}, 5000);
+		req.on("upgrade", (res, socket) => {
+			clearTimeout(timer);
+			socket.destroy();
+			resolve({ status: res.statusCode ?? 0, headers: res.headers });
+		});
+		req.on("response", res => {
+			clearTimeout(timer);
+			res.resume();
+			resolve({ status: res.statusCode ?? 0, headers: res.headers });
+		});
+		req.on("error", err => {
+			clearTimeout(timer);
+			reject(err);
+		});
+		req.end();
+	});
+}
+
+describe("bridge origin gate (real listeners, gate ENABLED)", () => {
+	test("wss upgrade with an allowed add-in Origin succeeds + carries PNA + scoped ACAO", async () => {
+		const fixture = makeFixtureCert();
+		const server = await startBridgeServer(undefined, { tls: fixture });
+		try {
+			const res = await upgradeHandshake({
+				secure: true,
+				port: server.wssPort,
+				origin: "https://x.local-ip.sh",
+				ca: fixture.cert,
+			});
+			expect(res.status).toBe(101);
+			expect(res.headers["access-control-allow-private-network"]).toBe("true");
+			expect(res.headers["access-control-allow-origin"]).toBe("https://x.local-ip.sh");
+		} finally {
+			await server.close();
+		}
+	});
+
+	test("a disallowed Origin is rejected with 403", async () => {
+		const fixture = makeFixtureCert();
+		const server = await startBridgeServer(undefined, { tls: fixture });
+		try {
+			const res = await upgradeHandshake({
+				secure: true,
+				port: server.wssPort,
+				origin: "https://random.example.com",
+				ca: fixture.cert,
+			});
+			expect(res.status).toBe(403);
+		} finally {
+			await server.close();
+		}
+	});
+
+	// Regression: the Chrome extension origin STILL passes the gate on the ws
+	// listener, and its response behavior is unchanged (no PNA / scoped-ACAO).
+	test("the chrome-extension origin still passes the gate (ws), unchanged response", async () => {
+		const server = await startBridgeServer(undefined, {});
+		try {
+			const res = await upgradeHandshake({
+				secure: false,
+				port: server.port,
+				origin: `chrome-extension://${EXTENSION_ID}`,
+			});
+			expect(res.status).toBe(101);
+			expect(res.headers["access-control-allow-private-network"]).toBeUndefined();
+			expect(res.headers["access-control-allow-origin"]).toBeUndefined();
 		} finally {
 			await server.close();
 		}

--- a/packages/coding-agent/test/browser/extension-bridge.test.ts
+++ b/packages/coding-agent/test/browser/extension-bridge.test.ts
@@ -199,14 +199,11 @@ describe("dual-listen ws + wss", () => {
 		const server = await startBridgeServer(undefined, { skipOriginCheck: true, tls: fixture });
 		try {
 			const authorized = await new Promise<boolean>((resolve, reject) => {
-				const socket = tlsConnect(
-					{ host: "127.0.0.1", port: server.wssPort, ca: fixture.cert, servername: "127.0.0.1" },
-					() => {
-						const ok = socket.authorized;
-						socket.end();
-						resolve(ok);
-					},
-				);
+				const socket = tlsConnect({ host: "127.0.0.1", port: server.wssPort, ca: fixture.cert }, () => {
+					const ok = socket.authorized;
+					socket.end();
+					resolve(ok);
+				});
 				socket.on("error", reject);
 			});
 			expect(authorized).toBe(true);
@@ -281,7 +278,7 @@ function upgradeHandshake(o: { secure: boolean; port: number; origin?: string; c
 		};
 		if (o.origin) headers.Origin = o.origin;
 		const common = { host: "127.0.0.1", port: o.port, path: "/", headers };
-		const req = o.secure ? httpsRequest({ ...common, ca: o.ca, servername: "127.0.0.1" }) : httpRequest(common);
+		const req = o.secure ? httpsRequest({ ...common, ca: o.ca }) : httpRequest(common);
 		const timer = setTimeout(() => {
 			req.destroy();
 			reject(new Error("upgrade timeout"));

--- a/packages/coding-agent/test/browser/extension-bridge.test.ts
+++ b/packages/coding-agent/test/browser/extension-bridge.test.ts
@@ -67,7 +67,12 @@ describe("port selection helpers", () => {
 	});
 });
 
-import { startBridgeServer } from "../../src/browser/extension-bridge";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect as tlsConnect } from "node:tls";
+import { startBridgeServer, WSS_PORT_OFFSET } from "../../src/browser/extension-bridge";
 
 describe("auto-select bind", () => {
 	test("two servers land on different ports in range", async () => {
@@ -89,6 +94,126 @@ describe("auto-select bind", () => {
 			await expect(startBridgeServer(a.port, { skipOriginCheck: true })).rejects.toThrow();
 		} finally {
 			await a.close();
+		}
+	});
+});
+
+/** Mint an ephemeral self-signed cert (SAN incl. 127.0.0.1) for the wss listener. No bypass. */
+function makeFixtureCert(): { cert: string; key: string } {
+	const dir = mkdtempSync(join(tmpdir(), "xcsh-bridge-cert-"));
+	const certFile = join(dir, "cert.pem");
+	const keyFile = join(dir, "key.pem");
+	execFileSync(
+		"openssl",
+		[
+			"req",
+			"-x509",
+			"-newkey",
+			"rsa:2048",
+			"-sha256",
+			"-days",
+			"2",
+			"-nodes",
+			"-keyout",
+			keyFile,
+			"-out",
+			certFile,
+			"-subj",
+			"/CN=localhost",
+			"-addext",
+			"subjectAltName=DNS:localhost,IP:127.0.0.1",
+			"-addext",
+			"extendedKeyUsage=serverAuth",
+			"-addext",
+			"basicConstraints=critical,CA:FALSE",
+		],
+		{ stdio: "ignore" },
+	);
+	return { cert: readFileSync(certFile, "utf8"), key: readFileSync(keyFile, "utf8") };
+}
+
+/** Drive one `hello` → `hello_ack` round-trip over a WebSocket URL, resolving the ack frame. */
+function helloRoundTrip(url: string): Promise<Record<string, unknown>> {
+	return new Promise((resolve, reject) => {
+		const ws = new WebSocket(url);
+		const timer = setTimeout(() => {
+			ws.close();
+			reject(new Error("hello_ack timeout"));
+		}, 5000);
+		ws.addEventListener("open", () => ws.send(JSON.stringify({ type: "hello" })));
+		ws.addEventListener("message", ev => {
+			const msg = JSON.parse(typeof ev.data === "string" ? ev.data : "") as Record<string, unknown>;
+			if (msg.type === "hello_ack") {
+				clearTimeout(timer);
+				ws.close();
+				resolve(msg);
+			}
+		});
+		ws.addEventListener("error", () => {
+			clearTimeout(timer);
+			reject(new Error("ws error"));
+		});
+	});
+}
+
+describe("dual-listen ws + wss", () => {
+	test("binds ws in range AND wss at port + WSS_PORT_OFFSET", async () => {
+		const server = await startBridgeServer(undefined, { skipOriginCheck: true, tls: makeFixtureCert() });
+		try {
+			expect(server.port).toBeGreaterThanOrEqual(PORT_RANGE_START);
+			expect(server.port).toBeLessThanOrEqual(PORT_RANGE_END);
+			expect(WSS_PORT_OFFSET).toBe(100);
+			expect(server.wssPort).toBe(server.port + WSS_PORT_OFFSET);
+		} finally {
+			await server.close();
+		}
+	});
+
+	// Regression guard for the Chrome extension path: plain ws:// must keep working
+	// unchanged even with the wss listener enabled.
+	test("plain ws:// hello handshake is unchanged", async () => {
+		const server = await startBridgeServer(undefined, { skipOriginCheck: true, tls: makeFixtureCert() });
+		try {
+			const ack = await helloRoundTrip(`ws://127.0.0.1:${server.port}`);
+			expect(ack.type).toBe("hello_ack");
+			expect(ack.pid).toBe(process.pid);
+			expect(ack.wssPort).toBe(server.wssPort);
+		} finally {
+			await server.close();
+		}
+	});
+
+	// TLS correctness with NO bypass: a client that explicitly TRUSTS the fixture cert
+	// as its CA must find the wss listener's presented cert `authorized === true`.
+	test("wss listener presents a cert that validates against the injected CA", async () => {
+		const fixture = makeFixtureCert();
+		const server = await startBridgeServer(undefined, { skipOriginCheck: true, tls: fixture });
+		try {
+			const authorized = await new Promise<boolean>((resolve, reject) => {
+				const socket = tlsConnect(
+					{ host: "127.0.0.1", port: server.wssPort, ca: fixture.cert, servername: "127.0.0.1" },
+					() => {
+						const ok = socket.authorized;
+						socket.end();
+						resolve(ok);
+					},
+				);
+				socket.on("error", reject);
+			});
+			expect(authorized).toBe(true);
+		} finally {
+			await server.close();
+		}
+	});
+
+	// A bridge started WITHOUT cert material stays ws-only (no wss listener, no crash).
+	test("no tls → ws-only, wssPort is 0", async () => {
+		const server = await startBridgeServer(undefined, { skipOriginCheck: true });
+		try {
+			expect(server.port).toBeGreaterThanOrEqual(PORT_RANGE_START);
+			expect(server.wssPort).toBe(0);
+		} finally {
+			await server.close();
 		}
 	});
 });


### PR DESCRIPTION
Closes #2045

Adds an ADDITIVE `wss` listener to the extension bridge so an Office add-in / SPFx web part (ordinary https pages, incl. macOS WKWebView where plain `ws://` is blocked as mixed content) can open a loopback WebSocket — with NO MDM/admin/local-trust step.

**Mechanism (validated):** terminate TLS with the publicly-trusted `*.local-ip.sh` Let's Encrypt cert on hostname `127-0-0-1.local-ip.sh` (resolves to 127.0.0.1), ported from f5-sales-demo/claude-office. UAT proves WebKit+Chromium open it with verification ON and no bypass; negative control (IP literal, not in SAN) fails.

**Change (dual-listen, strictly additive):**
- `bridge-cert.ts`: local-ip.sh cert provisioning (download/validate/refresh/SNI + self-signed fallback), pure/IO split.
- bridge dual-listens ws (unchanged — Chrome ext) + wss on `wsPort+100` (19322–19341); `wssPort` added to `hello_ack`.
- origin gate widened to a scoped allowlist for `https://*.local-ip.sh` + PNA/scoped-ACAO; chrome-extension path unchanged.
- worker/main provision the cert OUTSIDE the `session:bridgeListen` TTFT span; offline → ws-only, no crash. `manager` bridgeHello stays ws.

**Verified:** full `bun test` 5500/0; `ci:test:smoke` 0; `check:ts` 0; biome clean. No TLS-verification bypass anywhere (tests trust a fixture CA explicitly). Chrome-ext `ws://` path byte-for-byte unchanged (regression-tested).

**Follow-ups (non-blocking):** pin exact production Office/SPFx origins before broad rollout; tighten apex-vs-subdomain match; roll back the ws listener on a non-EADDRINUSE rethrow; sunset `ws://` once all consumers move to wss.
