### PR TITLE
Host-tool channel on the WS chat-protocol + fix premature chat_done on tool turns

### DIFF
--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -536,6 +536,14 @@
 			"types": "./src/extensibility/hooks/*.ts",
 			"import": "./src/extensibility/hooks/*.ts"
 		},
+		"./host-tools": {
+			"types": "./src/host-tools/index.ts",
+			"import": "./src/host-tools/index.ts"
+		},
+		"./host-tools/*": {
+			"types": "./src/host-tools/*.ts",
+			"import": "./src/host-tools/*.ts"
+		},
 		"./*.js": "./src/*.ts"
 	}
 }

--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -1,4 +1,10 @@
 import type { AssistantMessage } from "@f5-sales-demo/pi-ai";
+import {
+	isRpcHostToolResult,
+	isRpcHostToolUpdate,
+	normalizeHostToolDefinitions,
+	RpcHostToolBridge,
+} from "../host-tools";
 import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
 import {
 	type ChatDelta,
@@ -8,10 +14,15 @@ import {
 	type ChatKeepalive,
 	type ChatReference,
 	type ChatRequest,
+	type HostToolResult,
+	type HostToolUpdate,
 	type InteractionMode,
 	isChatRequest,
 	isChatStop,
+	isSetHostTools,
 	type PageContextSnapshot,
+	type SetHostTools,
+	type SetHostToolsAck,
 } from "./chat-protocol";
 import { CONSOLE_ROUTES } from "./console-routes.generated";
 import type { BridgeServer } from "./extension-bridge";
@@ -55,10 +66,16 @@ export class ChatHandler {
 	// Only one pending request at a time (newest wins — a third prompt while one is
 	// queued replaces it, so the user's latest intent always runs next).
 	#pendingRequest: ChatRequest | null = null;
+	// Transport-neutral host-tool bridge (A1): maps `set_host_tools` definitions to
+	// AgentTools whose execute() round-trips a `host_tool_call` back to the WS client
+	// and awaits the correlated `host_tool_result`. Reused verbatim from the stdio RPC
+	// driver — the only WS-specific wiring is the `send()` output sink below.
+	#hostToolBridge: RpcHostToolBridge;
 
 	constructor(server: BridgeServer, session: AgentSession) {
 		this.#server = server;
 		this.#session = session;
+		this.#hostToolBridge = new RpcHostToolBridge(frame => this.#server.send(frame));
 	}
 
 	/** Register a callback fired when a chat turn is accepted (used by the worker's
@@ -71,10 +88,17 @@ export class ChatHandler {
 		this.#server.onMessage(msg => {
 			if (isChatRequest(msg)) this.#handleChatRequest(msg as unknown as ChatRequest);
 			else if (isChatStop(msg)) this.#handleChatStop(msg as unknown as { id: string });
+			// Host-tool channel (#2046): register client tools, then route the client's
+			// result/update frames back to the correlated pending call in the bridge.
+			else if (isSetHostTools(msg)) this.#handleSetHostTools(msg as unknown as SetHostTools);
+			else if (isRpcHostToolResult(msg)) this.#hostToolBridge.handleResult(msg as unknown as HostToolResult);
+			else if (isRpcHostToolUpdate(msg)) this.#hostToolBridge.handleUpdate(msg as unknown as HostToolUpdate);
 		});
 
 		this.#server.onDisconnected(() => {
 			this.#pendingRequest = null; // abandon any queued prompt — the bridge is gone
+			// Fail any in-flight host-tool call — the client that would answer it is gone.
+			this.#hostToolBridge.rejectAllPending("bridge disconnected before host tool completed");
 			for (const chat of this.#activeChats.values()) {
 				this.#sendTerminal(chat, {
 					type: "chat_error",
@@ -232,6 +256,19 @@ export class ChatHandler {
 		}
 	}
 
+	/** Register the client's host tools with the session, then ack so the client can
+	 * await registration before its first prompt. Mirrors the stdio `set_host_tools`
+	 * command handler (rpc-mode.ts): normalize → bridge.setTools → refreshRpcHostTools. */
+	async #handleSetHostTools(msg: SetHostTools): Promise<void> {
+		const tools = normalizeHostToolDefinitions(msg.tools);
+		const rpcTools = this.#hostToolBridge.setTools(tools);
+		await this.#session.refreshRpcHostTools(rpcTools);
+		this.#server.send({
+			type: "set_host_tools_ack",
+			toolNames: tools.map(tool => tool.name),
+		} satisfies SetHostToolsAck);
+	}
+
 	#handleChatStop(stop: { id: string }): void {
 		const chat = this.#activeChats.get(stop.id);
 		if (!chat) return;
@@ -252,6 +289,8 @@ export class ChatHandler {
 
 	dispose(): void {
 		this.#pendingRequest = null; // abandon any queued prompt — don't replay into a dead session
+		// Fail any in-flight host-tool call — the session is going away.
+		this.#hostToolBridge.rejectAllPending("bridge disconnected before host tool completed");
 		for (const chat of this.#activeChats.values()) {
 			this.#sendTerminal(chat, {
 				type: "chat_error",

--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -245,6 +245,14 @@ export class ChatHandler {
 					error: errorMsg,
 					reason: classifyChatErrorReason(errorMsg),
 				});
+			} else if (msg.stopReason === "toolUse" || msg.content.some(part => part.type === "toolCall")) {
+				// INTERMEDIATE tool-use step: the agent loop emits message_end for this
+				// assistant message BEFORE running the tool. Do NOT terminate the turn here
+				// — that would drop the tool notices, the tool round-trip, and the post-tool
+				// narration under the terminalSent guard. The single chat_done fires on the
+				// FINAL assistant message_end below (normal completion), with the finally
+				// backstop in #handleChatRequest guaranteeing exactly-once terminal semantics.
+				return;
 			} else {
 				const references = extractReferences(msg);
 				this.#sendTerminal(chat, {

--- a/packages/coding-agent/src/browser/chat-protocol.ts
+++ b/packages/coding-agent/src/browser/chat-protocol.ts
@@ -161,6 +161,13 @@ export type HostToolUpdate = RpcHostToolUpdate;
 /** Inbound: the client completes a pending call with an `AgentToolResult`. */
 export type HostToolResult = RpcHostToolResult;
 
+/** Outbound: acks a `set_host_tools` registration so the client can await it
+ * before sending its first prompt. Carries the names actually registered. */
+export interface SetHostToolsAck {
+	type: "set_host_tools_ack";
+	toolNames: string[];
+}
+
 // ---------------------------------------------------------------------------
 // Validators
 // ---------------------------------------------------------------------------

--- a/packages/coding-agent/src/browser/chat-protocol.ts
+++ b/packages/coding-agent/src/browser/chat-protocol.ts
@@ -3,6 +3,16 @@
  * Contract source of truth: capabilities.json v1.2.0.
  */
 
+import {
+	isRpcHostToolResult,
+	isRpcHostToolUpdate,
+	type RpcHostToolCallRequest,
+	type RpcHostToolCancelRequest,
+	type RpcHostToolDefinition,
+	type RpcHostToolResult,
+	type RpcHostToolUpdate,
+} from "../host-tools";
+
 // ---------------------------------------------------------------------------
 // Page context snapshot (auto-attached by extension to every chat_request)
 // ---------------------------------------------------------------------------
@@ -116,6 +126,42 @@ export interface ChatKeepalive {
 }
 
 // ---------------------------------------------------------------------------
+// Host-tool channel (contract 1.8.0)
+//
+// The host-tool channel lets the agent delegate a registered tool's execution
+// to whatever host is driving the WS bridge (the chrome extension, an Office
+// add-in, etc.). The frames are FIELD-IDENTICAL to the transport-neutral
+// `RpcHostTool*` vocabulary (`src/host-tools/`), so they are re-exported here
+// rather than re-declared — one vocabulary across every transport, no drift.
+//
+// CRITICAL: `host_tool_result.result` and `host_tool_update.partialResult` are
+// `AgentToolResult` values — a `content[]` array — NOT a `{ data }` object. The
+// guards below delegate to the neutral `isRpcHostToolResult`/`isRpcHostToolUpdate`,
+// which require `content` to be an array.
+// ---------------------------------------------------------------------------
+
+/** A host-tool definition advertised by the client via `set_host_tools`. */
+export type HostToolDefinition = RpcHostToolDefinition;
+
+/** Inbound: the client registers the host tools it can execute. */
+export interface SetHostTools {
+	type: "set_host_tools";
+	tools: HostToolDefinition[];
+}
+
+/** Outbound: the agent asks the client to execute a registered host tool. */
+export type HostToolCall = RpcHostToolCallRequest;
+
+/** Outbound: the agent aborts a pending host-tool call. */
+export type HostToolCancel = RpcHostToolCancelRequest;
+
+/** Inbound: the client streams a partial `AgentToolResult` for a pending call. */
+export type HostToolUpdate = RpcHostToolUpdate;
+
+/** Inbound: the client completes a pending call with an `AgentToolResult`. */
+export type HostToolResult = RpcHostToolResult;
+
+// ---------------------------------------------------------------------------
 // Validators
 // ---------------------------------------------------------------------------
 
@@ -135,4 +181,18 @@ export function isChatRequest(msg: Record<string, unknown>): boolean {
 
 export function isChatStop(msg: Record<string, unknown>): boolean {
 	return msg.type === "chat_stop" && hasChatIdPrefix(msg.id);
+}
+
+export function isSetHostTools(msg: Record<string, unknown>): boolean {
+	return msg.type === "set_host_tools" && Array.isArray(msg.tools);
+}
+
+/** Delegates to the neutral guard, which requires `result.content` to be an array. */
+export function isHostToolResult(msg: Record<string, unknown>): boolean {
+	return isRpcHostToolResult(msg);
+}
+
+/** Delegates to the neutral guard, which requires `partialResult.content` to be an array. */
+export function isHostToolUpdate(msg: Record<string, unknown>): boolean {
+	return isRpcHostToolUpdate(msg);
 }

--- a/packages/coding-agent/src/host-tools/host-tools.ts
+++ b/packages/coding-agent/src/host-tools/host-tools.ts
@@ -1,15 +1,15 @@
 import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@f5-sales-demo/pi-agent-core";
 import { Snowflake } from "@f5-sales-demo/pi-utils";
 import type { Static, TSchema } from "@sinclair/typebox";
-import { applyToolProxy } from "../../extensibility/tool-proxy";
-import type { Theme } from "../../modes/theme/theme";
+import { applyToolProxy } from "../extensibility/tool-proxy";
+import type { Theme } from "../modes/theme/theme";
 import type {
 	RpcHostToolCallRequest,
 	RpcHostToolCancelRequest,
 	RpcHostToolDefinition,
 	RpcHostToolResult,
 	RpcHostToolUpdate,
-} from "./rpc-types";
+} from "./types";
 
 type RpcHostToolOutput = (frame: RpcHostToolCallRequest | RpcHostToolCancelRequest) => void;
 
@@ -35,6 +35,35 @@ export function isRpcHostToolUpdate(value: unknown): value is RpcHostToolUpdate 
 	if (!value || typeof value !== "object") return false;
 	const frame = value as { type?: unknown; id?: unknown; partialResult?: unknown };
 	return frame.type === "host_tool_update" && typeof frame.id === "string" && isAgentToolResult(frame.partialResult);
+}
+
+/**
+ * Validate + normalize incoming host-tool definitions (trim names/labels/descriptions,
+ * enforce non-empty name/description and a JSON-Schema `parameters` object). Shared by
+ * every transport driver that accepts a `set_host_tools` frame.
+ */
+export function normalizeHostToolDefinitions(tools: RpcHostToolDefinition[]): RpcHostToolDefinition[] {
+	return tools.map((tool, index) => {
+		const name = typeof tool.name === "string" ? tool.name.trim() : "";
+		if (!name) {
+			throw new Error(`Host tool at index ${index} must provide a non-empty name`);
+		}
+		const description = typeof tool.description === "string" ? tool.description.trim() : "";
+		if (!description) {
+			throw new Error(`Host tool "${name}" must provide a non-empty description`);
+		}
+		if (!tool.parameters || typeof tool.parameters !== "object" || Array.isArray(tool.parameters)) {
+			throw new Error(`Host tool "${name}" must provide a JSON Schema object`);
+		}
+		const label = typeof tool.label === "string" && tool.label.trim() ? tool.label.trim() : name;
+		return {
+			name,
+			label,
+			description,
+			parameters: tool.parameters,
+			hidden: tool.hidden === true,
+		};
+	});
 }
 
 class RpcHostToolAdapter<TParams extends TSchema = TSchema, TTheme extends Theme = Theme>

--- a/packages/coding-agent/src/host-tools/index.ts
+++ b/packages/coding-agent/src/host-tools/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Transport-neutral host-tool core.
+ *
+ * The host-tool channel lets the agent delegate the execution of registered
+ * tools to whatever host is driving the session (a stdio RPC client, the WS
+ * chat bridge, etc.). The bridge, adapter, guards, and wire types here carry no
+ * transport specifics — a driver supplies only an `output: (frame) => void`
+ * sink — so every transport reuses them verbatim.
+ */
+export {
+	isRpcHostToolResult,
+	isRpcHostToolUpdate,
+	normalizeHostToolDefinitions,
+	RpcHostToolBridge,
+} from "./host-tools";
+export type {
+	RpcHostToolCallRequest,
+	RpcHostToolCancelRequest,
+	RpcHostToolDefinition,
+	RpcHostToolResult,
+	RpcHostToolUpdate,
+} from "./types";

--- a/packages/coding-agent/src/host-tools/types.ts
+++ b/packages/coding-agent/src/host-tools/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Host-tool wire types (transport-neutral).
+ *
+ * These frames describe the bidirectional host-tool channel: the agent asks the
+ * host to execute a registered tool, and the host streams updates / a result
+ * back. They are shared verbatim across transports (stdio RPC and the WS chat
+ * bridge), so they live outside of any single transport driver.
+ */
+import type { AgentToolResult } from "@f5-sales-demo/pi-agent-core";
+
+export interface RpcHostToolDefinition {
+	name: string;
+	label?: string;
+	description: string;
+	parameters: Record<string, unknown>;
+	hidden?: boolean;
+}
+
+/** Emitted by the agent when it needs the host to execute a registered tool. */
+export interface RpcHostToolCallRequest {
+	type: "host_tool_call";
+	id: string;
+	toolCallId: string;
+	toolName: string;
+	arguments: Record<string, unknown>;
+}
+
+/** Emitted by the agent when a pending host tool call should be aborted. */
+export interface RpcHostToolCancelRequest {
+	type: "host_tool_cancel";
+	id: string;
+	targetId: string;
+}
+
+/** Sent by the host to stream partial tool updates back to the agent. */
+export interface RpcHostToolUpdate {
+	type: "host_tool_update";
+	id: string;
+	partialResult: AgentToolResult<unknown>;
+}
+
+/** Sent by the host to complete a pending tool call. */
+export interface RpcHostToolResult {
+	type: "host_tool_result";
+	id: string;
+	result: AgentToolResult<unknown>;
+	isError?: boolean;
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -16,17 +16,21 @@ import type {
 	ExtensionUIDialogOptions,
 	ExtensionWidgetOptions,
 } from "../../extensibility/extensions";
+import {
+	isRpcHostToolResult,
+	isRpcHostToolUpdate,
+	normalizeHostToolDefinitions,
+	RpcHostToolBridge,
+} from "../../host-tools";
 import { type Theme, theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import { mapContextStatus, runWelcomeChecks } from "../components/welcome-checks";
-import { isRpcHostToolResult, isRpcHostToolUpdate, RpcHostToolBridge } from "./host-tools";
 import type {
 	RpcCommand,
 	RpcExtensionUIRequest,
 	RpcExtensionUIResponse,
 	RpcHostToolCallRequest,
 	RpcHostToolCancelRequest,
-	RpcHostToolDefinition,
 	RpcResponse,
 	RpcSessionState,
 } from "./rpc-types";
@@ -42,30 +46,6 @@ export type PendingExtensionRequest = {
 type RpcOutput = (
 	obj: RpcResponse | RpcExtensionUIRequest | RpcHostToolCallRequest | RpcHostToolCancelRequest | object,
 ) => void;
-
-function normalizeHostToolDefinitions(tools: RpcHostToolDefinition[]): RpcHostToolDefinition[] {
-	return tools.map((tool, index) => {
-		const name = typeof tool.name === "string" ? tool.name.trim() : "";
-		if (!name) {
-			throw new Error(`Host tool at index ${index} must provide a non-empty name`);
-		}
-		const description = typeof tool.description === "string" ? tool.description.trim() : "";
-		if (!description) {
-			throw new Error(`Host tool "${name}" must provide a non-empty description`);
-		}
-		if (!tool.parameters || typeof tool.parameters !== "object" || Array.isArray(tool.parameters)) {
-			throw new Error(`Host tool "${name}" must provide a JSON Schema object`);
-		}
-		const label = typeof tool.label === "string" && tool.label.trim() ? tool.label.trim() : name;
-		return {
-			name,
-			label,
-			description,
-			parameters: tool.parameters,
-			hidden: tool.hidden === true,
-		};
-	});
-}
 
 function shouldEmitRpcTitles(): boolean {
 	const raw = $env.PI_RPC_EMIT_TITLE;

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -4,9 +4,18 @@
  * Commands are sent as JSON lines on stdin.
  * Responses and events are emitted as JSON lines on stdout.
  */
-import type { AgentMessage, AgentToolResult, ThinkingLevel } from "@f5-sales-demo/pi-agent-core";
+import type { AgentMessage, ThinkingLevel } from "@f5-sales-demo/pi-agent-core";
 import type { Effort, ImageContent, Model } from "@f5-sales-demo/pi-ai";
 import type { BashResult } from "../../exec/bash-executor";
+// The host-tool wire types are transport-neutral and live in the shared host-tool
+// core so both the stdio RPC driver and the WS chat bridge use one vocabulary.
+import type {
+	RpcHostToolCallRequest,
+	RpcHostToolCancelRequest,
+	RpcHostToolDefinition,
+	RpcHostToolResult,
+	RpcHostToolUpdate,
+} from "../../host-tools/types";
 import type { SessionStats } from "../../session/agent-session";
 import type { CompactionResult } from "../../session/compaction";
 import type { TodoPhase } from "../../tools/todo-write";
@@ -266,44 +275,14 @@ export type RpcExtensionUIRequest =
 // Host Tool Frames (bidirectional)
 // ============================================================================
 
-export interface RpcHostToolDefinition {
-	name: string;
-	label?: string;
-	description: string;
-	parameters: Record<string, unknown>;
-	hidden?: boolean;
-}
-
-/** Emitted by the RPC server when it needs the host to execute a registered tool. */
-export interface RpcHostToolCallRequest {
-	type: "host_tool_call";
-	id: string;
-	toolCallId: string;
-	toolName: string;
-	arguments: Record<string, unknown>;
-}
-
-/** Emitted by the RPC server when a pending host tool call should be aborted. */
-export interface RpcHostToolCancelRequest {
-	type: "host_tool_cancel";
-	id: string;
-	targetId: string;
-}
-
-/** Sent by the host to stream partial tool updates back to the RPC server. */
-export interface RpcHostToolUpdate {
-	type: "host_tool_update";
-	id: string;
-	partialResult: AgentToolResult<unknown>;
-}
-
-/** Sent by the host to complete a pending tool call. */
-export interface RpcHostToolResult {
-	type: "host_tool_result";
-	id: string;
-	result: AgentToolResult<unknown>;
-	isError?: boolean;
-}
+// Re-exported here for RPC consumers (imported above for use within this module).
+export type {
+	RpcHostToolCallRequest,
+	RpcHostToolCancelRequest,
+	RpcHostToolDefinition,
+	RpcHostToolResult,
+	RpcHostToolUpdate,
+};
 
 // ============================================================================
 // Extension UI Commands (stdin)

--- a/packages/coding-agent/test/browser/chat-handler.host-tools.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.host-tools.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentTool, AgentToolResult } from "@f5-sales-demo/pi-agent-core";
+import { ChatHandler } from "@f5-sales-demo/xcsh/browser/chat-handler";
+import type { BridgeServer } from "@f5-sales-demo/xcsh/browser/extension-bridge";
+import type { AgentSession } from "@f5-sales-demo/xcsh/session/agent-session";
+
+/**
+ * A2/A3 host-tool wiring tests for `ChatHandler`.
+ *
+ * A fake `BridgeServer` captures every `send()` frame and lets the test drive the
+ * inbound `onMessage`/`onDisconnected` paths, while a stub `AgentSession` captures
+ * the `AgentTool[]` handed to `refreshRpcHostTools` so the test can invoke the
+ * produced tool's `execute()` directly (that is how the agent loop drives a host
+ * tool in production — the adapter's `execute` funnels into the bridge).
+ */
+class FakeBridgeServer {
+	sent: Array<Record<string, unknown>> = [];
+	#onMessage: Array<(m: Record<string, unknown>) => void> = [];
+	#onDisconnected: Array<() => void> = [];
+
+	send(payload: unknown): void {
+		this.sent.push(payload as Record<string, unknown>);
+	}
+	onMessage(cb: (m: Record<string, unknown>) => void): void {
+		this.#onMessage.push(cb);
+	}
+	onDisconnected(cb: () => void): void {
+		this.#onDisconnected.push(cb);
+	}
+
+	// ---- test drivers ----
+	emit(msg: Record<string, unknown>): void {
+		for (const cb of this.#onMessage) cb(msg);
+	}
+	disconnect(): void {
+		for (const cb of this.#onDisconnected) cb();
+	}
+	ofType(type: string): Array<Record<string, unknown>> {
+		return this.sent.filter(frame => frame.type === type);
+	}
+}
+
+class FakeAgentSession {
+	refreshedTools: AgentTool[] | null = null;
+	isStreaming = false;
+	agent = {
+		abort(): void {},
+		replaceMessages(): void {},
+	};
+	subscribe(): () => void {
+		return () => {};
+	}
+	async prompt(): Promise<void> {}
+	async refreshRpcHostTools(tools: AgentTool[]): Promise<void> {
+		this.refreshedTools = tools;
+	}
+}
+
+function makeHandler(): { handler: ChatHandler; server: FakeBridgeServer; session: FakeAgentSession } {
+	const server = new FakeBridgeServer();
+	const session = new FakeAgentSession();
+	const handler = new ChatHandler(server as unknown as BridgeServer, session as unknown as AgentSession);
+	handler.attach();
+	return { handler, server, session };
+}
+
+const ECHO_DEF = {
+	name: "echo",
+	description: "Echo back the provided message",
+	parameters: { type: "object", properties: { message: { type: "string" } } },
+};
+
+function setHostTools(server: FakeBridgeServer): void {
+	server.emit({ type: "set_host_tools", tools: [ECHO_DEF] });
+}
+
+const okResult: AgentToolResult<unknown> = { content: [{ type: "text", text: "pong" }] };
+
+describe("ChatHandler host-tool wiring (#2046 A3)", () => {
+	it("(1) set_host_tools → registers mapped tools and sends an ack", async () => {
+		const { server, session } = makeHandler();
+		setHostTools(server);
+		// refreshRpcHostTools runs on the microtask queue (async handler); flush it.
+		await Promise.resolve();
+
+		expect(session.refreshedTools).not.toBeNull();
+		expect(session.refreshedTools?.map(t => t.name)).toEqual(["echo"]);
+
+		const acks = server.ofType("set_host_tools_ack");
+		expect(acks).toHaveLength(1);
+		expect(acks[0].toolNames).toEqual(["echo"]);
+	});
+
+	it("(2) invoking the registered AgentTool emits a host_tool_call frame", async () => {
+		const { server, session } = makeHandler();
+		setHostTools(server);
+		await Promise.resolve();
+
+		const tool = session.refreshedTools?.[0];
+		expect(tool).toBeDefined();
+		// Drive the tool exactly as the agent loop would.
+		void tool?.execute("tc-1", { message: "hi" });
+
+		const calls = server.ofType("host_tool_call");
+		expect(calls).toHaveLength(1);
+		expect(calls[0].toolName).toBe("echo");
+		expect(calls[0].toolCallId).toBe("tc-1");
+		expect(calls[0].arguments).toEqual({ message: "hi" });
+		expect(typeof calls[0].id).toBe("string");
+	});
+
+	it("(3) a matching host_tool_result resolves the tool's execute promise", async () => {
+		const { server, session } = makeHandler();
+		setHostTools(server);
+		await Promise.resolve();
+
+		const tool = session.refreshedTools?.[0];
+		const execution = tool?.execute("tc-1", { message: "hi" });
+
+		const callId = server.ofType("host_tool_call")[0].id as string;
+		server.emit({ type: "host_tool_result", id: callId, result: okResult });
+
+		await expect(execution).resolves.toEqual(okResult);
+	});
+
+	it("(4) aborting mid-flight emits a host_tool_cancel frame and rejects", async () => {
+		const { server, session } = makeHandler();
+		setHostTools(server);
+		await Promise.resolve();
+
+		const tool = session.refreshedTools?.[0];
+		const controller = new AbortController();
+		const execution = tool?.execute("tc-1", { message: "hi" }, controller.signal);
+
+		const callId = server.ofType("host_tool_call")[0].id as string;
+		controller.abort();
+
+		const cancels = server.ofType("host_tool_cancel");
+		expect(cancels).toHaveLength(1);
+		expect(cancels[0].targetId).toBe(callId);
+
+		await expect(execution).rejects.toThrow(/aborted/i);
+	});
+
+	it("(5a) onDisconnected rejects pending host-tool calls", async () => {
+		const { server, session } = makeHandler();
+		setHostTools(server);
+		await Promise.resolve();
+
+		const tool = session.refreshedTools?.[0];
+		const execution = tool?.execute("tc-1", { message: "hi" });
+		expect(server.ofType("host_tool_call")).toHaveLength(1);
+
+		server.disconnect();
+
+		await expect(execution).rejects.toThrow(/bridge disconnected/i);
+	});
+
+	it("(5b) dispose() rejects pending host-tool calls", async () => {
+		const { handler, server, session } = makeHandler();
+		setHostTools(server);
+		await Promise.resolve();
+
+		const tool = session.refreshedTools?.[0];
+		const execution = tool?.execute("tc-1", { message: "hi" });
+		expect(server.ofType("host_tool_call")).toHaveLength(1);
+
+		handler.dispose();
+
+		await expect(execution).rejects.toThrow(/bridge disconnected/i);
+	});
+});

--- a/packages/coding-agent/test/browser/chat-handler.tool-turn.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.tool-turn.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent } from "@f5-sales-demo/pi-agent-core";
+import { type AssistantMessage, getBundledModel, type ToolCall } from "@f5-sales-demo/pi-ai";
+import { AssistantMessageEventStream } from "@f5-sales-demo/pi-ai/utils/event-stream";
+import { Snowflake } from "@f5-sales-demo/pi-utils";
+import { ChatHandler } from "@f5-sales-demo/xcsh/browser/chat-handler";
+import type { BridgeServer } from "@f5-sales-demo/xcsh/browser/extension-bridge";
+import { ModelRegistry } from "@f5-sales-demo/xcsh/config/model-registry";
+import { Settings } from "@f5-sales-demo/xcsh/config/settings";
+import { AgentSession } from "@f5-sales-demo/xcsh/session/agent-session";
+import { AuthStorage } from "@f5-sales-demo/xcsh/session/auth-storage";
+import { SessionManager } from "@f5-sales-demo/xcsh/session/session-manager";
+
+/**
+ * #2046 A6 — a tool-calling turn driven through the REAL WS `chat_request` path must
+ * stream FULLY: the terminal `chat_done` fires exactly once, at TRUE turn completion,
+ * NOT on the intermediate `toolUse` assistant `message_end`.
+ *
+ * Regression guarded: `ChatHandler.#handleSessionEvent` used to send `chat_done` on the
+ * first non-error assistant `message_end`. On a tool-calling turn the agent loop emits a
+ * `message_end` for the intermediate assistant message with `stopReason === "toolUse"`
+ * (it carries a `toolCall` content part) BEFORE the tool runs — so `chat_done` fired
+ * early and the `terminalSent` guard then DROPPED every later frame (tool notices, the
+ * tool round-trip, and post-tool narration).
+ *
+ * Everything below the stub model is the real machinery: a real `ChatHandler` + real
+ * `AgentSession`, driven through the `chat_request` `onMessage` path (as the WS client
+ * would). The stub model narrates, calls the registered `echo` host tool, then — once
+ * the injected result flows back — narrates again and completes on `stopReason: "stop"`.
+ */
+
+class FakeBridgeServer {
+	sent: Array<Record<string, unknown>> = [];
+	#onMessage: Array<(m: Record<string, unknown>) => void> = [];
+	#onDisconnected: Array<() => void> = [];
+
+	send(payload: unknown): void {
+		this.sent.push(payload as Record<string, unknown>);
+	}
+	onMessage(cb: (m: Record<string, unknown>) => void): void {
+		this.#onMessage.push(cb);
+	}
+	onDisconnected(cb: () => void): void {
+		this.#onDisconnected.push(cb);
+	}
+
+	// ---- test drivers ----
+	emit(msg: Record<string, unknown>): void {
+		for (const cb of this.#onMessage) cb(msg);
+	}
+	ofType(type: string): Array<Record<string, unknown>> {
+		return this.sent.filter(frame => frame.type === type);
+	}
+	/** First index in send-order of a frame of `type`, or -1. */
+	indexOf(type: string): number {
+		return this.sent.findIndex(frame => frame.type === type);
+	}
+	/** Index of the first `chat_delta` whose delta equals `delta`, or -1. */
+	deltaIndex(delta: string): number {
+		return this.sent.findIndex(frame => frame.type === "chat_delta" && frame.delta === delta);
+	}
+}
+
+const ECHO_DEF = {
+	name: "echo",
+	description: "Echo back the provided text",
+	parameters: {
+		type: "object",
+		properties: { text: { type: "string" } },
+		required: ["text"],
+	},
+};
+
+const ECHO_CALL_ID = "call_echo_1";
+const ECHO_INPUT = "hello host tool";
+const ECHO_OUTPUT = `echoed: ${ECHO_INPUT}`;
+const PRE_NARRATION = "Echoing your text now — watch. ";
+const POST_NARRATION = "All done, the echo came back.";
+
+function baseAssistant(
+	content: AssistantMessage["content"],
+	stopReason: AssistantMessage["stopReason"],
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(5);
+	}
+	throw new Error("Timed out waiting for condition");
+}
+
+describe("#2046 A6 — chat_done defers to the final assistant message on a tool turn", () => {
+	let session: AgentSession;
+	let handler: ChatHandler;
+	let server: FakeBridgeServer;
+	let tempDir: string;
+	const authStorages: AuthStorage[] = [];
+	let callCount: number;
+
+	beforeEach(() => {
+		tempDir = path.join(os.tmpdir(), `pi-a6-tool-turn-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		callCount = 0;
+	});
+
+	afterEach(async () => {
+		handler?.dispose();
+		if (session) await session.dispose();
+		for (const authStorage of authStorages.splice(0)) authStorage.close();
+		if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+	});
+
+	/**
+	 * @param toolTurn when true the first model call narrates then calls `echo`
+	 *   (stopReason "toolUse"); the second call narrates then completes ("stop").
+	 *   When false a single call narrates then completes ("stop") — a plain turn.
+	 */
+	async function makeSession(toolTurn: boolean): Promise<AgentSession> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: ECHO_CALL_ID,
+			name: "echo",
+			arguments: { text: ECHO_INPUT },
+		};
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: "Test", tools: [] },
+			streamFn: (_model, _context) => {
+				callCount++;
+				const isFirstCall = callCount === 1;
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					if (toolTurn && isFirstCall) {
+						// Turn 1: narrate, then call the registered host tool. The message that
+						// ENDS this call carries a toolCall part with stopReason "toolUse".
+						stream.push({ type: "start", partial: baseAssistant([], "toolUse") });
+						stream.push({
+							type: "text_delta",
+							contentIndex: 0,
+							delta: PRE_NARRATION,
+							partial: baseAssistant([{ type: "text", text: PRE_NARRATION }], "toolUse"),
+						});
+						const msg = baseAssistant([{ type: "text", text: PRE_NARRATION }, toolCall], "toolUse");
+						stream.push({ type: "done", reason: "toolUse", message: msg });
+					} else {
+						// Final call: narrate the result, then complete on stopReason "stop".
+						stream.push({ type: "start", partial: baseAssistant([], "stop") });
+						stream.push({
+							type: "text_delta",
+							contentIndex: 0,
+							delta: POST_NARRATION,
+							partial: baseAssistant([{ type: "text", text: POST_NARRATION }], "stop"),
+						});
+						const msg = baseAssistant([{ type: "text", text: POST_NARRATION }], "stop");
+						stream.push({ type: "done", reason: "stop", message: msg });
+					}
+				});
+				return stream;
+			},
+		});
+
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+
+		return new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+	}
+
+	it("streams the whole tool turn and sends exactly one chat_done AFTER the tool + post-tool narration", async () => {
+		session = await makeSession(true);
+		server = new FakeBridgeServer();
+		handler = new ChatHandler(server as unknown as BridgeServer, session);
+		handler.attach();
+
+		// Register the echo host tool through the real onMessage path (as a WS client would).
+		server.emit({ type: "set_host_tools", tools: [ECHO_DEF] });
+		await waitFor(() => server.ofType("set_host_tools_ack").length === 1);
+		expect(session.getActiveToolNames()).toContain("echo");
+
+		// Drive the turn through the REAL chat_request path (not session.prompt directly).
+		server.emit({
+			type: "chat_request",
+			id: "c-tool-1",
+			text: "please echo something",
+			context: null,
+			mode: "configuration",
+		});
+
+		// The tool executes and round-trips a real host_tool_call frame.
+		await waitFor(() => server.ofType("host_tool_call").length === 1);
+		const call = server.ofType("host_tool_call")[0];
+		expect(call.toolName).toBe("echo");
+		// The turn must NOT be terminal yet — chat_done must not have fired on the toolUse step.
+		expect(server.ofType("chat_done")).toHaveLength(0);
+
+		// Inject the matching host_tool_result, which lets the turn continue and finish.
+		server.emit({
+			type: "host_tool_result",
+			id: call.id as string,
+			result: { content: [{ type: "text", text: ECHO_OUTPUT }] },
+		});
+
+		// The turn completes: exactly one terminal chat_done arrives.
+		await waitFor(() => server.ofType("chat_done").length === 1);
+		expect(server.ofType("chat_done")).toHaveLength(1);
+		expect(server.ofType("chat_error")).toHaveLength(0);
+
+		// FRAME ORDER / TIMING — the load-bearing assertions this fix restores:
+		const preIdx = server.deltaIndex(PRE_NARRATION);
+		const postIdx = server.deltaIndex(POST_NARRATION);
+		const toolCallIdx = server.indexOf("host_tool_call");
+		const doneIdx = server.indexOf("chat_done");
+
+		// Pre-tool narration streamed before the tool call.
+		expect(preIdx).toBeGreaterThanOrEqual(0);
+		expect(preIdx).toBeLessThan(toolCallIdx);
+		// A tool-activity notice for echo was forwarded (dropped by the old premature-done bug).
+		const echoNotices = server.ofType("chat_tool_notice").filter(f => f.tool === "echo");
+		expect(echoNotices.length).toBeGreaterThanOrEqual(1);
+		// Post-tool narration streamed AFTER the tool call (dropped by the old bug).
+		expect(postIdx).toBeGreaterThan(toolCallIdx);
+		// The single chat_done is the LAST relevant frame — after the tool AND after post-tool narration.
+		expect(doneIdx).toBeGreaterThan(toolCallIdx);
+		expect(doneIdx).toBeGreaterThan(postIdx);
+		// No frames dropped after the tool step: post narration and done both present.
+		expect(server.ofType("chat_delta").some(f => f.delta === POST_NARRATION)).toBe(true);
+	});
+
+	it("still sends exactly one chat_done on a plain (no-tool) turn — no regression", async () => {
+		session = await makeSession(false);
+		server = new FakeBridgeServer();
+		handler = new ChatHandler(server as unknown as BridgeServer, session);
+		handler.attach();
+
+		server.emit({
+			type: "chat_request",
+			id: "c-plain-1",
+			text: "just say something",
+			context: null,
+			mode: "configuration",
+		});
+
+		await waitFor(() => server.ofType("chat_done").length === 1);
+		expect(server.ofType("chat_done")).toHaveLength(1);
+		expect(server.ofType("chat_error")).toHaveLength(0);
+		expect(server.ofType("host_tool_call")).toHaveLength(0);
+		// The narration streamed, and chat_done came after it.
+		const deltaIdx = server.deltaIndex(POST_NARRATION);
+		expect(deltaIdx).toBeGreaterThanOrEqual(0);
+		expect(server.indexOf("chat_done")).toBeGreaterThan(deltaIdx);
+	});
+});

--- a/packages/coding-agent/test/browser/chat-protocol.host-tools.test.ts
+++ b/packages/coding-agent/test/browser/chat-protocol.host-tools.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "bun:test";
+import { isHostToolResult, isHostToolUpdate, isSetHostTools } from "@f5-sales-demo/xcsh/browser/chat-protocol";
+
+// A well-formed AgentToolResult carries a `content[]` array (NOT a `{ data }`
+// object). The host-tool guards must lock this shape so a malformed client
+// reply is rejected at the door rather than hanging a pending call.
+const validResult = {
+	content: [{ type: "text", text: "ok" }],
+	details: {},
+};
+
+describe("isSetHostTools", () => {
+	it("accepts a set_host_tools with a tools array", () => {
+		expect(
+			isSetHostTools({
+				type: "set_host_tools",
+				tools: [
+					{
+						name: "read_range",
+						description: "Read a range",
+						parameters: { type: "object" },
+					},
+				],
+			}),
+		).toBe(true);
+	});
+
+	it("accepts a set_host_tools with an empty tools array", () => {
+		expect(isSetHostTools({ type: "set_host_tools", tools: [] })).toBe(true);
+	});
+
+	it("rejects set_host_tools missing tools", () => {
+		expect(isSetHostTools({ type: "set_host_tools" })).toBe(false);
+	});
+
+	it("rejects set_host_tools whose tools is not an array", () => {
+		expect(isSetHostTools({ type: "set_host_tools", tools: { name: "x" } })).toBe(false);
+	});
+
+	it("rejects wrong type", () => {
+		expect(isSetHostTools({ type: "chat_request", tools: [] })).toBe(false);
+	});
+});
+
+describe("isHostToolResult", () => {
+	it("accepts a host_tool_result whose result.content is an array", () => {
+		expect(
+			isHostToolResult({
+				type: "host_tool_result",
+				id: "h-1",
+				result: validResult,
+			}),
+		).toBe(true);
+	});
+
+	it("accepts a host_tool_result with isError", () => {
+		expect(
+			isHostToolResult({
+				type: "host_tool_result",
+				id: "h-1",
+				result: validResult,
+				isError: true,
+			}),
+		).toBe(true);
+	});
+
+	it("rejects a host_tool_result whose result has no content array (the {data} shape)", () => {
+		expect(
+			isHostToolResult({
+				type: "host_tool_result",
+				id: "h-1",
+				result: { data: "ok" },
+			}),
+		).toBe(false);
+	});
+
+	it("rejects a host_tool_result whose result.content is not an array", () => {
+		expect(
+			isHostToolResult({
+				type: "host_tool_result",
+				id: "h-1",
+				result: { content: "ok" },
+			}),
+		).toBe(false);
+	});
+
+	it("rejects a non-string id", () => {
+		expect(
+			isHostToolResult({
+				type: "host_tool_result",
+				id: 123,
+				result: validResult,
+			}),
+		).toBe(false);
+	});
+
+	it("rejects wrong type", () => {
+		expect(
+			isHostToolResult({
+				type: "host_tool_update",
+				id: "h-1",
+				result: validResult,
+			}),
+		).toBe(false);
+	});
+});
+
+describe("isHostToolUpdate", () => {
+	it("accepts a host_tool_update whose partialResult.content is an array", () => {
+		expect(
+			isHostToolUpdate({
+				type: "host_tool_update",
+				id: "h-1",
+				partialResult: validResult,
+			}),
+		).toBe(true);
+	});
+
+	it("rejects a host_tool_update whose partialResult has no content array", () => {
+		expect(
+			isHostToolUpdate({
+				type: "host_tool_update",
+				id: "h-1",
+				partialResult: { data: "ok" },
+			}),
+		).toBe(false);
+	});
+
+	it("rejects a host_tool_update whose partialResult.content is not an array", () => {
+		expect(
+			isHostToolUpdate({
+				type: "host_tool_update",
+				id: "h-1",
+				partialResult: { content: {} },
+			}),
+		).toBe(false);
+	});
+
+	it("rejects a non-string id", () => {
+		expect(
+			isHostToolUpdate({
+				type: "host_tool_update",
+				id: 123,
+				partialResult: validResult,
+			}),
+		).toBe(false);
+	});
+
+	it("rejects wrong type", () => {
+		expect(
+			isHostToolUpdate({
+				type: "host_tool_result",
+				id: "h-1",
+				partialResult: validResult,
+			}),
+		).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/browser/host-tool-echo.e2e.test.ts
+++ b/packages/coding-agent/test/browser/host-tool-echo.e2e.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent } from "@f5-sales-demo/pi-agent-core";
+import { type AssistantMessage, type Context, getBundledModel, type ToolCall } from "@f5-sales-demo/pi-ai";
+import { AssistantMessageEventStream } from "@f5-sales-demo/pi-ai/utils/event-stream";
+import { Snowflake } from "@f5-sales-demo/pi-utils";
+import { ChatHandler } from "@f5-sales-demo/xcsh/browser/chat-handler";
+import type { BridgeServer } from "@f5-sales-demo/xcsh/browser/extension-bridge";
+import { ModelRegistry } from "@f5-sales-demo/xcsh/config/model-registry";
+import { Settings } from "@f5-sales-demo/xcsh/config/settings";
+import { AgentSession } from "@f5-sales-demo/xcsh/session/agent-session";
+import { AuthStorage } from "@f5-sales-demo/xcsh/session/auth-storage";
+import { SessionManager } from "@f5-sales-demo/xcsh/session/session-manager";
+
+/**
+ * A4 — the acceptance gate for #2046: an END-TO-END proof that a WS-registered host
+ * tool is actually exposed to the agent and driven through the FULL loop.
+ *
+ * Drive path used: the PREFERRED **real-model** path. A deterministic stub model
+ * (`Agent.streamFn`, following the `agent-session-concurrent.test.ts` pattern) emits
+ * a genuine `toolCall` for `echo` on its first turn, then — once the tool result has
+ * flowed back into the context — completes on its second turn. Everything else is the
+ * real machinery:
+ *   - a real `ChatHandler` + a real `AgentSession` + a fake `BridgeServer` capturing send();
+ *   - registration goes through the ChatHandler `onMessage` `set_host_tools` path
+ *     (→ bridge.setTools → session.refreshRpcHostTools), exactly as the WS client would;
+ *   - the agent turn invokes the registered `echo` tool → the RpcHostToolAdapter routes
+ *     through the ChatHandler-owned `RpcHostToolBridge` → a real `host_tool_call` frame is
+ *     emitted through `send()`;
+ *   - the matching `host_tool_result` (a proper `AgentToolResult` with `content[]`) is
+ *     injected back through `onMessage`, resolving the pending call;
+ *   - the tool output then flows back into the turn: the model is called a SECOND time
+ *     with the echo result in context, and the turn completes.
+ *
+ * No production code is added — A1–A3 built the module, frames, guards, and ChatHandler
+ * wiring; this test only exercises them end-to-end.
+ */
+
+class FakeBridgeServer {
+	sent: Array<Record<string, unknown>> = [];
+	#onMessage: Array<(m: Record<string, unknown>) => void> = [];
+	#onDisconnected: Array<() => void> = [];
+
+	send(payload: unknown): void {
+		this.sent.push(payload as Record<string, unknown>);
+	}
+	onMessage(cb: (m: Record<string, unknown>) => void): void {
+		this.#onMessage.push(cb);
+	}
+	onDisconnected(cb: () => void): void {
+		this.#onDisconnected.push(cb);
+	}
+
+	// ---- test drivers ----
+	emit(msg: Record<string, unknown>): void {
+		for (const cb of this.#onMessage) cb(msg);
+	}
+	ofType(type: string): Array<Record<string, unknown>> {
+		return this.sent.filter(frame => frame.type === type);
+	}
+}
+
+const ECHO_DEF = {
+	name: "echo",
+	description: "Echo back the provided text",
+	parameters: {
+		type: "object",
+		properties: { text: { type: "string" } },
+		required: ["text"],
+	},
+};
+
+const ECHO_CALL_ID = "call_echo_1";
+const ECHO_INPUT = "hello host tool";
+const ECHO_OUTPUT = `echoed: ${ECHO_INPUT}`;
+
+function baseAssistant(
+	content: AssistantMessage["content"],
+	stopReason: AssistantMessage["stopReason"],
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(5);
+	}
+	throw new Error("Timed out waiting for condition");
+}
+
+describe("#2046 A4 — echo host tool end-to-end over the WS channel", () => {
+	let session: AgentSession;
+	let handler: ChatHandler;
+	let server: FakeBridgeServer;
+	let tempDir: string;
+	const authStorages: AuthStorage[] = [];
+	// Captured per model call so the test can prove the tool result flowed back in.
+	const callContexts: Context[] = [];
+
+	beforeEach(() => {
+		tempDir = path.join(os.tmpdir(), `pi-a4-host-tool-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		callContexts.length = 0;
+	});
+
+	afterEach(async () => {
+		handler?.dispose();
+		if (session) await session.dispose();
+		for (const authStorage of authStorages.splice(0)) authStorage.close();
+		if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+	});
+
+	async function makeSession(): Promise<AgentSession> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: ECHO_CALL_ID,
+			name: "echo",
+			arguments: { text: ECHO_INPUT },
+		};
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: "Test", tools: [] },
+			streamFn: (_model, context) => {
+				callContexts.push({ ...context, messages: [...context.messages] });
+				const stream = new AssistantMessageEventStream();
+				const isFirstCall = callContexts.length === 1;
+				queueMicrotask(() => {
+					if (isFirstCall) {
+						// Turn 1: the model decides to call the registered host tool.
+						const msg = baseAssistant([toolCall], "toolUse");
+						stream.push({ type: "start", partial: msg });
+						stream.push({ type: "done", reason: "toolUse", message: msg });
+					} else {
+						// Turn 2: the echo result is now in context — the model finishes.
+						const msg = baseAssistant([{ type: "text", text: "done" }], "stop");
+						stream.push({ type: "start", partial: msg });
+						stream.push({ type: "done", reason: "stop", message: msg });
+					}
+				});
+				return stream;
+			},
+		});
+
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+
+		return new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+	}
+
+	it("registers echo via set_host_tools, the agent calls it, the injected result completes the turn", async () => {
+		session = await makeSession();
+		server = new FakeBridgeServer();
+		handler = new ChatHandler(server as unknown as BridgeServer, session);
+		handler.attach();
+
+		// 1. Register the host tool through the real ChatHandler onMessage path (as a WS
+		//    client would), and wait for the ack that proves refreshRpcHostTools finished.
+		server.emit({ type: "set_host_tools", tools: [ECHO_DEF] });
+		await waitFor(() => server.ofType("set_host_tools_ack").length === 1);
+		expect(server.ofType("set_host_tools_ack")[0].toolNames).toEqual(["echo"]);
+		// The tool is now exposed to the agent.
+		expect(session.getActiveToolNames()).toContain("echo");
+
+		// 2. Drive a real agent turn. The stub model emits a genuine toolCall for `echo`;
+		//    the agent executes the registered adapter, which round-trips a host_tool_call.
+		const turn = session.prompt("please echo something");
+
+		// 3. The agent's tool execution emits a real host_tool_call frame through send().
+		await waitFor(() => server.ofType("host_tool_call").length === 1);
+		const call = server.ofType("host_tool_call")[0];
+		expect(call.toolName).toBe("echo");
+		expect(call.toolCallId).toBe(ECHO_CALL_ID);
+		expect(call.arguments).toEqual({ text: ECHO_INPUT });
+		expect(typeof call.id).toBe("string");
+
+		// 4. Inject the matching host_tool_result (a proper AgentToolResult) via onMessage.
+		server.emit({
+			type: "host_tool_result",
+			id: call.id as string,
+			result: { content: [{ type: "text", text: ECHO_OUTPUT }] },
+		});
+
+		// 5. The turn COMPLETES using that result: prompt() resolves, the model was called a
+		//    second time, and the echo output is present in that second call's context —
+		//    proving the host tool's output flowed back into the agent loop.
+		await turn;
+		expect(session.isStreaming).toBe(false);
+		expect(callContexts).toHaveLength(2);
+		const secondContext = JSON.stringify(callContexts[1].messages);
+		expect(secondContext).toContain(ECHO_OUTPUT);
+		expect(secondContext).toContain(ECHO_CALL_ID);
+	});
+});

--- a/packages/coding-agent/test/rpc-host-tools.test.ts
+++ b/packages/coding-agent/test/rpc-host-tools.test.ts
@@ -3,13 +3,13 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentEvent } from "@f5-sales-demo/pi-agent-core";
-import { defineRpcClientTool, RpcClient } from "@f5-sales-demo/xcsh/modes";
-import { RpcHostToolBridge } from "@f5-sales-demo/xcsh/modes/rpc/host-tools";
 import type {
 	RpcHostToolCallRequest,
 	RpcHostToolCancelRequest,
 	RpcHostToolUpdate,
-} from "@f5-sales-demo/xcsh/modes/rpc/rpc-types";
+} from "@f5-sales-demo/xcsh/host-tools";
+import { RpcHostToolBridge } from "@f5-sales-demo/xcsh/host-tools";
+import { defineRpcClientTool, RpcClient } from "@f5-sales-demo/xcsh/modes";
 
 const tempPaths: string[] = [];
 


### PR DESCRIPTION
Closes #2046

Brings the **host-tool channel** to the WebSocket chat-protocol so a WS consumer (Office add-in, Chrome extension) can register tools that run **in the client** and have the agent invoke them — the mechanism the VS Code stdio RPC already uses. This is the xcsh-only functional implementation; the contract-version bump + goldens (A5) and the chrome-ext mirror (#272) are the coordinated follow-on (see "Deferred").

**Change (all additive; agent loop / AgentSession / RpcHostToolBridge behavior unchanged):**
- **Refactor:** lifted the transport-neutral host-tool core (`RpcHostToolBridge` + `RpcHostTool*` types + `normalizeHostToolDefinitions`) out of `modes/rpc/` into `src/host-tools/`, so the stdio-RPC and WS drivers share one implementation (stdio public surface preserved via re-exports).
- **Protocol:** added `set_host_tools` / `host_tool_call` / `host_tool_cancel` / `host_tool_update` / `host_tool_result` frames + guards to `browser/chat-protocol.ts`, aliased to the neutral types. **`result`/`partialResult` are `AgentToolResult` (a `content[]` array), NOT `{data}`** — reusing the neutral `content[]`-enforcing guards.
- **Wiring:** `ChatHandler` constructs the bridge with `output = server.send`, dispatches `set_host_tools` → `refreshRpcHostTools` (+ `set_host_tools_ack`), routes `host_tool_result`/`update` to the bridge, and rejects pending calls on both disconnect and dispose. Correlation/cancellation are handled by the reused bridge.
- **Bug fix (pre-existing, also fixes Chrome browser-tool streaming):** `ChatHandler` was sending terminal `chat_done` on the **intermediate `toolUse`** assistant message, silently dropping tool notices, the tool result, and post-tool narration. Now `chat_done` fires exactly once on the **final** assistant message (`stopReason: "stop"`), with the `finally` backstop as the safety net.

**Verified:** full `test/browser/*` **245 pass / 0 fail** (incl. an end-to-end echo host-tool over a real `AgentSession` turn, and a tool-turn test asserting frame order + exactly-one `chat_done` over the real `chat_request` path); `bun run check:ts` (per-package strict) exit 0; biome clean. No generated `*.ts` committed.

**Deferred (coordinated follow-on, tracked):** the contract bump to **1.8.0** + `hello_ack` advertisement + conformance/capabilities goldens (source of truth is chrome-ext) ship together with the **chrome-ext mirror #272**; and a `set_host_tools_error` nack (stdio-parity for malformed input) bundles with that PR. The channel is dormant (no consumer sends `set_host_tools`) until then, so these frames are purely additive/backward-compatible for a 1.7.0 client.
