### PR TITLE
test: vendor host-tool contract goldens + version bump v1.8.0 (#2073)

### DIFF
--- a/packages/coding-agent/src/browser/capabilities.generated.ts
+++ b/packages/coding-agent/src/browser/capabilities.generated.ts
@@ -26,7 +26,7 @@ export interface ExtensionCapabilities {
 
 export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 	"version": "0.1.0",
-	"contractVersion": "1.7.0",
+	"contractVersion": "1.8.0",
 	"multiPortDiscovery": true,
 	"protocol": "tool_request/result",
 	"tools": [
@@ -130,7 +130,7 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 		},
 		{
 			"name": "login",
-			"summary": "Drive the F5 XC OIDC/Keycloak login end-to-end.",
+			"summary": "Drive the F5 XC OIDC/Keycloak login end-to-end (production + staging consoles).",
 			"category": "navigation",
 			"params": {
 				"type": "object",
@@ -825,7 +825,13 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 				"chat_done",
 				"chat_error",
 				"chat_stop",
-				"chat_tool_notice"
+				"chat_tool_notice",
+				"set_host_tools",
+				"set_host_tools_ack",
+				"host_tool_call",
+				"host_tool_update",
+				"host_tool_result",
+				"host_tool_cancel"
 			],
 			"description": "User ↔ xcsh chat over the bridge. The extension side panel sends chat_request (with mode and page-context snapshot); xcsh streams chat_delta tokens then a terminal chat_done (with reference links) or chat_error. Chat ids are prefixed \"c-\". Tool calls during a turn use the normal tool_request flow. chat_stop halts a streaming response. chat_tool_notice is emitted by the EXTENSION (the service worker) to the panel as a best-effort UI signal when a tool runs during a turn — it is NOT sent by xcsh; xcsh must not produce it to avoid double-rendering in the panel.",
 			"promptHints": {
@@ -845,6 +851,6 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 	}
 };
 
-export const EXTENSION_CONTRACT_VERSION = "1.7.0";
+export const EXTENSION_CONTRACT_VERSION = "1.8.0";
 
 export const EXTENSION_TOOL_NAMES: readonly string[] = ["ping","capabilities","reload","debug_exec","detach","set_bridge_port","navigate","login","scroll_to","resize_window","tabs_list","tabs_create","tabs_close","click","click_element","click_xy","type_text","form_input","key_press","select_option","label_select","file_upload","read_ax","get_page_text","query_dom","find","wait_for","assert_text","screenshot","read_console","read_network","diag_suspension","diag_bridges","diag_activation","diag_ttft","capture_login_flow","wait_for_api_response","get_page_context","javascript_tool","browser_batch","set_explain_mode","annotate"];

--- a/packages/coding-agent/src/browser/capabilities.json
+++ b/packages/coding-agent/src/browser/capabilities.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "contractVersion": "1.7.0",
+  "contractVersion": "1.8.0",
   "multiPortDiscovery": true,
   "protocol": "tool_request/result",
   "tools": [
@@ -100,7 +100,7 @@
     },
     {
       "name": "login",
-      "summary": "Drive the F5 XC OIDC/Keycloak login end-to-end.",
+      "summary": "Drive the F5 XC OIDC/Keycloak login end-to-end (production + staging consoles).",
       "category": "navigation",
       "params": {
         "type": "object",
@@ -727,7 +727,20 @@
       "contextTool": "get_page_context",
       "transport": "websocket-bridge",
       "modes": ["educational", "presentation", "configuration", "screenshot", "annotation"],
-      "messages": ["chat_request", "chat_delta", "chat_done", "chat_error", "chat_stop", "chat_tool_notice"],
+      "messages": [
+        "chat_request",
+        "chat_delta",
+        "chat_done",
+        "chat_error",
+        "chat_stop",
+        "chat_tool_notice",
+        "set_host_tools",
+        "set_host_tools_ack",
+        "host_tool_call",
+        "host_tool_update",
+        "host_tool_result",
+        "host_tool_cancel"
+      ],
       "description": "User ↔ xcsh chat over the bridge. The extension side panel sends chat_request (with mode and page-context snapshot); xcsh streams chat_delta tokens then a terminal chat_done (with reference links) or chat_error. Chat ids are prefixed \"c-\". Tool calls during a turn use the normal tool_request flow. chat_stop halts a streaming response. chat_tool_notice is emitted by the EXTENSION (the service worker) to the panel as a best-effort UI signal when a tool runs during a turn — it is NOT sent by xcsh; xcsh must not produce it to avoid double-rendering in the panel.",
       "promptHints": {
         "role": "You are xcsh, the AI assistant embedded in the F5 Distributed Cloud (XC) console side panel. The user is viewing a live console page; help them drive automation and understand settings and their purpose.",

--- a/packages/coding-agent/src/browser/chat-conformance.json
+++ b/packages/coding-agent/src/browser/chat-conformance.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": "1.7.0",
+  "contractVersion": "1.8.0",
   "schemas": {
     "chat_request": {
       "type": "object",
@@ -290,6 +290,179 @@
         }
       }
     },
+    "set_host_tools": {
+      "type": "object",
+      "required": ["type", "tools"],
+      "properties": {
+        "type": {
+          "const": "set_host_tools",
+          "type": "string"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "description", "parameters"],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "parameters": {
+                "type": "object",
+                "patternProperties": {
+                  "^(.*)$": {}
+                }
+              },
+              "hidden": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      }
+    },
+    "set_host_tools_ack": {
+      "type": "object",
+      "required": ["type", "toolNames"],
+      "properties": {
+        "type": {
+          "const": "set_host_tools_ack",
+          "type": "string"
+        },
+        "toolNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "host_tool_call": {
+      "type": "object",
+      "required": ["type", "id", "toolCallId", "toolName", "arguments"],
+      "properties": {
+        "type": {
+          "const": "host_tool_call",
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "toolCallId": {
+          "type": "string"
+        },
+        "toolName": {
+          "type": "string"
+        },
+        "arguments": {
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {}
+          }
+        }
+      }
+    },
+    "host_tool_update": {
+      "type": "object",
+      "required": ["type", "id", "partialResult"],
+      "properties": {
+        "type": {
+          "const": "host_tool_update",
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "partialResult": {
+          "type": "object",
+          "required": ["content"],
+          "properties": {
+            "content": {
+              "type": "array",
+              "items": {
+                "additionalProperties": true,
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "details": {
+              "type": "object",
+              "patternProperties": {
+                "^(.*)$": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "host_tool_result": {
+      "type": "object",
+      "required": ["type", "id", "result"],
+      "properties": {
+        "type": {
+          "const": "host_tool_result",
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "result": {
+          "type": "object",
+          "required": ["content"],
+          "properties": {
+            "content": {
+              "type": "array",
+              "items": {
+                "additionalProperties": true,
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "details": {
+              "type": "object",
+              "patternProperties": {
+                "^(.*)$": {}
+              }
+            }
+          }
+        },
+        "isError": {
+          "type": "boolean"
+        }
+      }
+    },
+    "host_tool_cancel": {
+      "type": "object",
+      "required": ["type", "id", "targetId"],
+      "properties": {
+        "type": {
+          "const": "host_tool_cancel",
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "targetId": {
+          "type": "string"
+        }
+      }
+    },
     "page_context_snapshot": {
       "type": "object",
       "required": ["v", "capturedAt", "tabId", "url", "path", "title", "ax", "api", "truncated"],
@@ -499,6 +672,67 @@
       "chat_keepalive": {
         "type": "chat_keepalive",
         "id": "c-1111"
+      },
+      "set_host_tools": {
+        "type": "set_host_tools",
+        "tools": [
+          {
+            "name": "office_read_range",
+            "label": "Read range",
+            "description": "Read a cell range from the active worksheet.",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "range": {
+                  "type": "string"
+                }
+              },
+              "required": ["range"]
+            }
+          }
+        ]
+      },
+      "set_host_tools_ack": {
+        "type": "set_host_tools_ack",
+        "toolNames": ["office_read_range"]
+      },
+      "host_tool_call": {
+        "type": "host_tool_call",
+        "id": "7295551234567890",
+        "toolCallId": "call_abc",
+        "toolName": "office_read_range",
+        "arguments": {
+          "range": "A1:B2"
+        }
+      },
+      "host_tool_update": {
+        "type": "host_tool_update",
+        "id": "7295551234567890",
+        "partialResult": {
+          "content": [
+            {
+              "type": "text",
+              "text": "reading range…"
+            }
+          ]
+        }
+      },
+      "host_tool_result": {
+        "type": "host_tool_result",
+        "id": "7295551234567890",
+        "result": {
+          "content": [
+            {
+              "type": "text",
+              "text": "A1=1, B1=2, A2=3, B2=4"
+            }
+          ]
+        }
+      },
+      "host_tool_cancel": {
+        "type": "host_tool_cancel",
+        "id": "7295551234567891",
+        "targetId": "7295551234567890"
       }
     },
     "invalid": [
@@ -647,6 +881,40 @@
             "truncated": false
           },
           "truncated": false
+        }
+      },
+      {
+        "schema": "set_host_tools",
+        "why": "tool missing description",
+        "value": {
+          "type": "set_host_tools",
+          "tools": [
+            {
+              "name": "x",
+              "parameters": {}
+            }
+          ]
+        }
+      },
+      {
+        "schema": "host_tool_call",
+        "why": "missing toolName",
+        "value": {
+          "type": "host_tool_call",
+          "id": "1",
+          "toolCallId": "c",
+          "arguments": {}
+        }
+      },
+      {
+        "schema": "host_tool_result",
+        "why": "result.content is not an array",
+        "value": {
+          "type": "host_tool_result",
+          "id": "1",
+          "result": {
+            "content": "nope"
+          }
         }
       }
     ]

--- a/packages/coding-agent/test/browser/chat-conformance.test.ts
+++ b/packages/coding-agent/test/browser/chat-conformance.test.ts
@@ -4,7 +4,13 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { isChatRequest, isChatStop } from "@f5-sales-demo/xcsh/browser/chat-protocol";
+import {
+	isChatRequest,
+	isChatStop,
+	isHostToolResult,
+	isHostToolUpdate,
+	isSetHostTools,
+} from "@f5-sales-demo/xcsh/browser/chat-protocol";
 import Ajv from "ajv";
 import conformance from "../../src/browser/chat-conformance.json";
 
@@ -74,6 +80,32 @@ describe("chat-conformance: xcsh parsers reject invalid examples", () => {
 			});
 		}
 	}
+});
+
+describe("chat-conformance: xcsh host-tool guards accept/reject the goldens", () => {
+	it("isSetHostTools accepts the set_host_tools golden", () => {
+		expect(isSetHostTools(validExamples.set_host_tools as Record<string, unknown>)).toBe(true);
+	});
+
+	it("isHostToolResult accepts the host_tool_result golden", () => {
+		expect(isHostToolResult(validExamples.host_tool_result as Record<string, unknown>)).toBe(true);
+	});
+
+	it("isHostToolUpdate accepts the host_tool_update golden", () => {
+		expect(isHostToolUpdate(validExamples.host_tool_update as Record<string, unknown>)).toBe(true);
+	});
+
+	// isHostToolResult/isHostToolUpdate are deep guards (require an AgentToolResult
+	// `content[]`), so they reject the malformed golden. isSetHostTools is shallow
+	// by design (type + tools-is-array) — deep tool-definition validation is the
+	// schema's job, not the guard's — so it is not asserted here.
+	it("isHostToolResult rejects a result with non-array content", () => {
+		for (const { schema: schemaKey, value } of invalidExamples) {
+			if (schemaKey === "host_tool_result") {
+				expect(isHostToolResult(value as Record<string, unknown>)).toBe(false);
+			}
+		}
+	});
 });
 
 describe("chat-conformance: xcsh outbound frames validate against schemas", () => {


### PR DESCRIPTION
Closes #2073 (completes #2046).

## Why

PR #2071 shipped the WS host-tool channel (types, guards, `ChatHandler` wiring, tests) and closed #2046 — but skipped one of #2046's acceptance criteria: *bump `CONTRACT_VERSION`; regenerate `capabilities.json` + `chat-conformance.json` with golden examples.* On `main`, the vendored artifacts were still `1.7.0` with **zero** host-tool entries, so the code supported host tools while the published contract advertised nothing (silent-drift risk the conformance harness exists to catch).

## Changes

- Re-vendor `capabilities.json` + `capabilities.generated.ts` + `chat-conformance.json` from the extension source of truth (companion PR f5-sales-demo/xcsh-chrome-extension#279), now `1.8.0` with the 6 messages: `set_host_tools`, `set_host_tools_ack`, `host_tool_call`, `host_tool_update`, `host_tool_result`, `host_tool_cancel`.
- `chat-conformance.test.ts`: the data-driven loop now validates the 6 new schemas against golden valid/invalid examples automatically; added explicit coverage for xcsh's own guards (`isSetHostTools` shallow; `isHostToolResult`/`isHostToolUpdate` deep — require an `AgentToolResult` `content[]`).

No product-code changes — the host-tool types/guards/handler already landed in #2071.

## Verification

- `bun test test/browser/` → 258 pass / 0 fail (incl. the 6 new schema+golden validations and guard coverage).
- `extension-contract.test.ts` version-equality + drift guard pass; conformance `contractVersion` (1.8.0) === capabilities.
- `tsgo` typecheck + biome clean.

⚠️ Merge order: land the extension PR (#279) first so the vendored artifacts match the source of truth; this PR's vendored files were generated from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)