### PR TITLE
chore: bump version to v19.64.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "pi-natives"
-version = "19.63.9"
+version = "19.64.0"
 dependencies = [
  "arboard",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/brush-core-vendored", "crates/brush-builtins-vendored", "crat
 resolver = "3"
 
 [workspace.package]
-version = "19.63.9"
+version = "19.64.0"
 edition = "2024"
 license = "MIT"
 authors = ["Can Boluk"]

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/agent": {
       "name": "@f5-sales-demo/pi-agent-core",
-      "version": "19.63.9",
+      "version": "19.64.0",
       "dependencies": {
         "@f5-sales-demo/pi-ai": "workspace:*",
         "@f5-sales-demo/pi-utils": "workspace:*",
@@ -28,7 +28,7 @@
     },
     "packages/ai": {
       "name": "@f5-sales-demo/pi-ai",
-      "version": "19.63.9",
+      "version": "19.64.0",
       "bin": {
         "pi-ai": "./src/cli.ts",
       },
@@ -52,7 +52,7 @@
     },
     "packages/coding-agent": {
       "name": "@f5-sales-demo/xcsh",
-      "version": "19.63.9",
+      "version": "19.64.0",
       "bin": {
         "xcsh": "src/cli.ts",
       },
@@ -86,22 +86,22 @@
     },
     "packages/natives": {
       "name": "@f5-sales-demo/pi-natives",
-      "version": "19.63.9",
+      "version": "19.64.0",
       "devDependencies": {
         "@napi-rs/cli": "3.6.0",
         "@types/bun": "^1.3",
       },
       "optionalDependencies": {
-        "@f5-sales-demo/pi-natives-darwin-arm64": "19.63.9",
-        "@f5-sales-demo/pi-natives-darwin-x64": "19.63.9",
-        "@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.63.9",
-        "@f5-sales-demo/pi-natives-linux-x64-gnu": "19.63.9",
-        "@f5-sales-demo/pi-natives-win32-x64-msvc": "19.63.9",
+        "@f5-sales-demo/pi-natives-darwin-arm64": "19.64.0",
+        "@f5-sales-demo/pi-natives-darwin-x64": "19.64.0",
+        "@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.64.0",
+        "@f5-sales-demo/pi-natives-linux-x64-gnu": "19.64.0",
+        "@f5-sales-demo/pi-natives-win32-x64-msvc": "19.64.0",
       },
     },
     "packages/resource-management": {
       "name": "@f5-sales-demo/pi-resource-management",
-      "version": "19.63.9",
+      "version": "19.64.0",
       "dependencies": {
         "yaml": "2.9.0",
       },
@@ -111,7 +111,7 @@
     },
     "packages/stats": {
       "name": "@f5-sales-demo/xcsh-stats",
-      "version": "19.63.9",
+      "version": "19.64.0",
       "bin": {
         "xcsh-stats": "./src/index.ts",
       },
@@ -136,7 +136,7 @@
     },
     "packages/swarm-extension": {
       "name": "@f5-sales-demo/swarm-extension",
-      "version": "19.63.9",
+      "version": "19.64.0",
       "bin": {
         "xcsh-swarm": "src/cli.ts",
       },
@@ -152,7 +152,7 @@
     },
     "packages/tui": {
       "name": "@f5-sales-demo/pi-tui",
-      "version": "19.63.9",
+      "version": "19.64.0",
       "dependencies": {
         "@f5-sales-demo/pi-natives": "workspace:*",
         "@f5-sales-demo/pi-utils": "workspace:*",
@@ -191,7 +191,7 @@
     },
     "packages/utils": {
       "name": "@f5-sales-demo/pi-utils",
-      "version": "19.63.9",
+      "version": "19.64.0",
       "dependencies": {
         "@f5-sales-demo/i18n-core": "^1.0.0",
         "beautiful-mermaid": "^1.1",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-agent-core",
-	"version": "19.63.9",
+	"version": "19.64.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-ai",
-	"version": "19.63.9",
+	"version": "19.64.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/xcsh",
-	"version": "19.63.9",
+	"version": "19.64.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/coding-agent/src/internal-urls/terraform-index.generated.ts
+++ b/packages/coding-agent/src/internal-urls/terraform-index.generated.ts
@@ -5,8 +5,8 @@ import type { TerraformIndex } from "./terraform-types";
 export const TERRAFORM_INDEX: TerraformIndex = {
 	version: "0.1.0",
 	provider: {
-		source: "f5-sales-demo/f5xc",
-		registry: "https://registry.terraform.io/providers/f5-sales-demo/f5xc",
+		source: "f5-sales-demo/xcsh",
+		registry: "https://registry.terraform.io/providers/f5-sales-demo/xcsh",
 		required_block:
 			'terraform {\n  required_providers {\n    xcsh = {\n      source = "f5-sales-demo/xcsh"\n    }\n  }\n}',
 		config_block: 'provider "xcsh" {}',
@@ -30,9 +30,10 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			name: "Security",
 			slug: "security",
 			description: "WAF, bot defense, rate limiting, firewall policies, and security controls",
-			resource_count: 26,
+			resource_count: 27,
 			resources: [
 				"app_firewall",
+				"alert_gen_policy",
 				"alert_policy",
 				"bgp_routing_policy",
 				"bot_defense_app_infrastructure",
@@ -147,11 +148,47 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			],
 		},
 		{
+			name: "DNS",
+			slug: "dns",
+			description: "DNS domains, zones, compliance checks, and DNS proxy configuration",
+			resource_count: 7,
+			resources: [
+				"dns_compliance_checks",
+				"dns_domain",
+				"dns_lb_health_check",
+				"dns_lb_pool",
+				"dns_load_balancer",
+				"dns_proxy",
+				"dns_zone",
+			],
+		},
+		{
+			name: "Uncategorized",
+			slug: "uncategorized",
+			description: "Resources pending categorization",
+			resource_count: 6,
+			resources: [
+				"application_profiles",
+				"authorization_server",
+				"bot_infrastructure",
+				"mitigated_domain",
+				"protected_application",
+				"protected_domain",
+			],
+		},
+		{
 			name: "API Security",
 			slug: "api-security",
 			description: "API definition, discovery, testing, and security controls for web APIs",
 			resource_count: 5,
 			resources: ["api_crawler", "api_definition", "api_discovery", "api_testing", "app_api_group"],
+		},
+		{
+			name: "Monitoring",
+			slug: "monitoring",
+			description: "Log receivers, alert policies, APM, and global logging configuration",
+			resource_count: 5,
+			resources: ["alert_receiver", "alert_template", "apm", "global_log_receiver", "log_receiver"],
 		},
 		{
 			name: "Applications",
@@ -166,13 +203,6 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "TLS certificates, certificate chains, CRLs, and trusted CA lists",
 			resource_count: 4,
 			resources: ["certificate", "certificate_chain", "crl", "trusted_ca_list"],
-		},
-		{
-			name: "Monitoring",
-			slug: "monitoring",
-			description: "Log receivers, alert policies, APM, and global logging configuration",
-			resource_count: 4,
-			resources: ["alert_receiver", "apm", "global_log_receiver", "log_receiver"],
 		},
 		{
 			name: "VPN",
@@ -196,32 +226,18 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			resources: ["bigip_http_proxy", "data_group", "irule"],
 		},
 		{
-			name: "DNS",
-			slug: "dns",
-			description: "DNS domains, zones, compliance checks, and DNS proxy configuration",
-			resource_count: 3,
-			resources: ["dns_compliance_checks", "dns_domain", "dns_proxy"],
-		},
-		{
 			name: "Cloud Resources",
 			slug: "cloud-resources",
 			description: "Cloud elastic IPs, address allocators, and geo-location resources",
-			resource_count: 2,
-			resources: ["address_allocator", "cloud_elastic_ip"],
+			resource_count: 3,
+			resources: ["address_allocator", "cloud_elastic_ip", "geo_location_set"],
 		},
 		{
 			name: "Organization",
 			slug: "organization",
 			description: "Namespaces, tenant configuration, and organizational settings",
-			resource_count: 2,
-			resources: ["namespace", "tenant_configuration"],
-		},
-		{
-			name: "Uncategorized",
-			slug: "uncategorized",
-			description: "Resources pending categorization",
-			resource_count: 2,
-			resources: ["application_profiles", "authorization_server"],
+			resource_count: 3,
+			resources: ["allowed_domain", "namespace", "tenant_configuration"],
 		},
 		{
 			name: "Integrations",
@@ -251,7 +267,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Address Allocator will create an address allocator object in 'system' namespace of the user",
 			required: ["name", "namespace", "mode"],
 			minimal_config:
-				'resource "xcsh_address_allocator" "example" {\n  name      = "example-address-allocator"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  address_allocation_scheme {\n  }\n}',
+				'resource "xcsh_address_allocator" "example" {\n  name      = "example-address-allocator"\n  namespace = "staging"\n\n  address_pool = ["example-value"]\n  mode         = "LOCAL"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -263,18 +279,29 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				"Advertise_policy object controls how and where a service represented by a given virtual_host object is advertised to consumers. configuration",
 			required: ["name", "namespace", "address", "protocol", "skip_xff_append"],
 			minimal_config:
-				'resource "xcsh_advertise_policy" "example" {\n  name      = "example-advertise-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  public_ip {\n  }\n  tls_parameters {\n  }\n  client_certificate_optional {\n  }\n}',
+				'resource "xcsh_advertise_policy" "example" {\n  name      = "example-advertise-policy"\n  namespace = "staging"\n\n  address         = "example-value"\n  protocol        = "example-value"\n  skip_xff_append = true\n}',
 			dependencies: {
 				requires: [],
 			},
 			import_syntax: "terraform import xcsh_advertise_policy.example namespace/name",
+		},
+		alert_gen_policy: {
+			category: "security",
+			description: "Alert Generation Policy",
+			required: ["name", "namespace", "alert_status"],
+			minimal_config:
+				'resource "xcsh_alert_gen_policy" "example" {\n  name      = "example-alert-gen-policy"\n  namespace = "staging"\n\n  alert_status = "ALERT_ACTIVE"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_alert_gen_policy.example namespace/name",
 		},
 		alert_policy: {
 			category: "security",
 			description: "New Alert Policy Object",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_alert_policy" "example" {\n  name      = "example-alert-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  receivers {\n    name      = "slack-receiver"\n    namespace = "staging"\n  }\n\n  routes {\n    any {}\n    send {}\n  }\n\n  notification_parameters {\n    default {}\n    group_wait     = "30s"\n    group_interval = "1m"\n  }\n}',
+				'resource "xcsh_alert_policy" "example" {\n  name      = "example-alert-policy"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -283,20 +310,42 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		alert_receiver: {
 			category: "monitoring",
 			description: "New Alert Receiver object",
-			required: ["name", "namespace"],
+			required: ["name", "namespace", "receiver_choice"],
 			minimal_config:
-				'resource "xcsh_alert_receiver" "example" {\n  name      = "example-alert-receiver"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  slack {\n    url = "`https://your-slack-webhook-url"`\n  }\n}',
+				'resource "xcsh_alert_receiver" "example" {\n  name      = "example-alert-receiver"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
 			import_syntax: "terraform import xcsh_alert_receiver.example namespace/name",
+		},
+		alert_template: {
+			category: "monitoring",
+			description: "Domain to protect",
+			required: ["name", "namespace", "alert_message", "alert_message_details", "alert_name", "severity"],
+			minimal_config:
+				'resource "xcsh_alert_template" "example" {\n  name      = "example-alert-template"\n  namespace = "staging"\n\n  alert_message         = "example-value"\n  alert_message_details = "example-value"\n  alert_name            = "example-value"\n  severity              = "MINOR"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_alert_template.example namespace/name",
+		},
+		allowed_domain: {
+			category: "organization",
+			description: "Allowed domain",
+			required: ["name", "namespace", "allowed_domain"],
+			minimal_config:
+				'resource "xcsh_allowed_domain" "example" {\n  name      = "example-allowed-domain"\n  namespace = "staging"\n\n  allowed_domain = "example-value"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_allowed_domain.example namespace/name",
 		},
 		api_crawler: {
 			category: "api-security",
 			description: "API Crawler resource",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_api_crawler" "example" {\n  name      = "example-api-crawler"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  domains {\n  }\n  simple_login {\n  }\n  password {\n  }\n}',
+				'resource "xcsh_api_crawler" "example" {\n  name      = "example-api-crawler"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -306,15 +355,8 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "api-security",
 			description: "API Definition",
 			required: ["name", "namespace"],
-			server_defaults: [
-				"swagger_specs",
-				"api_inventory_exclusion_list",
-				"api_inventory_inclusion_list",
-				"non_api_endpoints",
-				"strict_schema_origin",
-			],
 			minimal_config:
-				'resource "xcsh_api_definition" "example" {\n  name      = "example-api-definition"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  swagger_specs = ["string:///base64-openapi-spec"]\n\n  non_validation_mode {}\n}',
+				'resource "xcsh_api_definition" "example" {\n  name      = "example-api-definition"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: ["namespace"],
 			},
@@ -323,10 +365,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		api_discovery: {
 			category: "api-security",
 			description: "API discovery creates a new object in the storage backend for metadata.namespace",
-			required: ["name", "namespace"],
-			server_defaults: ["custom_auth_types"],
+			required: ["name", "namespace", "user_defined_api_discovery_policy"],
 			minimal_config:
-				'resource "xcsh_api_discovery" "example" {\n  name      = "example-api-discovery"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  custom_auth_types {\n  }\n}',
+				'resource "xcsh_api_discovery" "example" {\n  name      = "example-api-discovery"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -337,7 +378,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "API Testing resource",
 			required: ["name", "namespace", "custom_header_value"],
 			minimal_config:
-				'resource "xcsh_api_testing" "example" {\n  name      = "example-api-testing"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  domains {\n  }\n  credentials {\n  }\n  admin {\n  }\n}',
+				'resource "xcsh_api_testing" "example" {\n  name      = "example-api-testing"\n  namespace = "staging"\n\n  custom_header_value = "example-value"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -347,8 +388,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "monitoring",
 			description: "New APM as a service with configured parameters",
 			required: ["name", "namespace"],
-			minimal_config:
-				'resource "xcsh_apm" "example" {\n  name      = "example-apm"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  aws_site_type_choice {\n  }\n  apm_aws_site {\n  }\n  admin_password {\n  }\n}',
+			minimal_config: 'resource "xcsh_apm" "example" {\n  name      = "example-apm"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -359,7 +399,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "App_api_group creates a new object in the storage backend for metadata.namespace",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_app_api_group" "example" {\n  name      = "example-app-api-group"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  elements {\n  }\n  bigip_virtual_server {\n  }\n  cdn_loadbalancer {\n  }\n}',
+				'resource "xcsh_app_api_group" "example" {\n  name      = "example-app-api-group"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -369,33 +409,8 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "security",
 			description: "Application Firewall",
 			required: ["name", "namespace"],
-			oneof_groups: [
-				{
-					fields: ["blocking", "monitoring"],
-				},
-				{
-					fields: ["blocking_page", "use_default_blocking_page"],
-				},
-				{
-					fields: ["bot_protection_setting", "default_bot_setting"],
-				},
-				{
-					fields: ["ai_risk_based_blocking", "default_detection_settings", "detection_settings"],
-				},
-				{
-					fields: ["allow_all_response_codes", "allowed_response_codes"],
-				},
-			],
-			server_defaults: [
-				"allow_all_response_codes",
-				"default_anonymization",
-				"default_detection_settings",
-				"disable_ai_enhancements",
-				"monitoring",
-				"use_default_blocking_page",
-			],
 			minimal_config:
-				'resource "xcsh_app_firewall" "example" {\n  name      = "example-app-firewall"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  // One of the arguments from this list "blocking monitoring" must be set\n\n  blocking {}\n\n  // One of the arguments from this list "blocking_page use_default_blocking_page" must be set\n\n  use_default_blocking_page {}\n\n  // One of the arguments from this list "bot_protection_setting default_bot_setting" must be set\n\n  bot_protection_setting {\n    malicious_bot_action  = "BLOCK"\n    suspicious_bot_action = "REPORT"\n    good_bot_action       = "REPORT"\n  }\n\n  // One of the arguments from this list "ai_risk_based_blocking default_detection_settings detection_settings" must be set\n\n  default_detection_settings {}\n\n  // One of the arguments from this list "allow_all_response_codes allowed_response_codes" must be set\n\n  allow_all_response_codes {}\n}',
+				'resource "xcsh_app_firewall" "example" {\n  name      = "example-app-firewall"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: ["namespace"],
 			},
@@ -406,7 +421,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "App setting configuration in namespace metadata.namespace",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_app_setting" "example" {\n  name      = "example-app-setting"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  app_type_settings {\n  }\n  app_type_ref {\n  }\n  business_logic_markup_setting {\n  }\n}',
+				'resource "xcsh_app_setting" "example" {\n  name      = "example-app-setting"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -417,7 +432,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "App type will create the configuration in namespace metadata.namespace",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_app_type" "example" {\n  name      = "example-app-type"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  business_logic_markup_setting {\n  }\n  disable_spec {\n  }\n  discovered_api_settings {\n  }\n}',
+				'resource "xcsh_app_type" "example" {\n  name      = "example-app-type"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -428,7 +443,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Application Profiles in a given namespace. If one already exists it will give an error",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_application_profiles" "example" {\n  name      = "example-application-profiles"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  advanced_tcp_profile {\n  }\n  disable_tcp_advanced_profile {\n  }\n  enable_tcp_advanced_profile {\n  }\n}',
+				'resource "xcsh_application_profiles" "example" {\n  name      = "example-application-profiles"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -439,7 +454,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Authentication resource",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_authentication" "example" {\n  name      = "example-authentication"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  cookie_params {\n  }\n  auth_hmac {\n  }\n  prim_key {\n  }\n}',
+				'resource "xcsh_authentication" "example" {\n  name      = "example-authentication"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -450,7 +465,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Authorization_server creates a new object in the storage backend for metadata.namespace",
 			required: ["name", "namespace", "jwks_uri"],
 			minimal_config:
-				'resource "xcsh_authorization_server" "example" {\n  name      = "example-authorization-server"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n}',
+				'resource "xcsh_authorization_server" "example" {\n  name      = "example-authorization-server"\n  namespace = "staging"\n\n  jwks_uri = "example-value"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -461,7 +476,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Deploying F5 sites connected via AWS Transit Gateway",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_aws_tgw_site" "example" {\n  name      = "example-aws-tgw-site"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  aws_region = "us-west-2"\n\n  aws_cred {\n    name      = "aws-credentials"\n    namespace = "staging"\n  }\n\n  vpc {\n    new_vpc {\n      name_tag     = "xcsh-tgw-vpc"\n      primary_ipv4 = "10.0.0.0/16"\n    }\n  }\n\n  tgw {\n    new_tgw {\n      name = "xcsh-tgw"\n    }\n  }\n\n  instance_type = "t3.xlarge"\n\n  services_vpc {\n    aws_certified_hw = "aws-byol-voltmesh"\n    az_nodes {\n      aws_az_name = "us-west-2a"\n      inside_subnet {\n        subnet_param {\n          ipv4 = "10.0.1.0/24"\n        }\n      }\n      outside_subnet {\n        subnet_param {\n          ipv4 = "10.0.2.0/24"\n        }\n      }\n      workload_subnet {\n        subnet_param {\n          ipv4 = "10.0.3.0/24"\n        }\n      }\n    }\n  }\n\n  no_worker_nodes {}\n}',
+				'resource "xcsh_aws_tgw_site" "example" {\n  name      = "example-aws-tgw-site"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -472,7 +487,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Deploying F5 sites within AWS VPC environments",
 			required: ["name", "namespace", "address", "aws_region", "disk_size", "instance_type", "ssh_key"],
 			minimal_config:
-				'resource "xcsh_aws_vpc_site" "example" {\n  name      = "example-aws-vpc-site"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  aws_region = "us-west-2"\n\n  aws_cred {\n    name      = "aws-credentials"\n    namespace = "staging"\n  }\n\n  vpc {\n    new_vpc {\n      name_tag     = "xcsh-vpc"\n      primary_ipv4 = "10.0.0.0/16"\n    }\n  }\n\n  instance_type = "t3.xlarge"\n\n  ingress_egress_gw {\n    aws_certified_hw = "aws-byol-multi-nic-voltmesh"\n    az_nodes {\n      aws_az_name = "us-west-2a"\n      inside_subnet {\n        subnet_param {\n          ipv4 = "10.0.1.0/24"\n        }\n      }\n      outside_subnet {\n        subnet_param {\n          ipv4 = "10.0.2.0/24"\n        }\n      }\n    }\n  }\n\n  no_worker_nodes {}\n}',
+				'resource "xcsh_aws_vpc_site" "example" {\n  name      = "example-aws-vpc-site"\n  namespace = "staging"\n\n  aws_region    = "example-value"\n  instance_type = "example-value"\n  ssh_key       = "example-value"\n  address       = "example-value"\n  disk_size     = 1\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -482,9 +497,8 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "sites",
 			description: "Deploying F5 sites within Azure Virtual Network environments",
 			required: ["name", "namespace", "machine_type", "resource_group", "ssh_key"],
-			server_defaults: ["disk_size", "block_all_services", "logs_streaming_disabled", "no_worker_nodes", "tags"],
 			minimal_config:
-				'resource "xcsh_azure_vnet_site" "example" {\n  name      = "example-Azure-vnet-site"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  azure_region = "westus2"\n\n  azure_cred {\n    name      = "Azure-credentials"\n    namespace = "staging"\n  }\n\n  resource_group = "xcsh-rg"\n\n  vnet {\n    new_vnet {\n      name         = "xcsh-vnet"\n      primary_ipv4 = "10.0.0.0/16"\n    }\n  }\n\n  machine_type = "Standard_D3_v2"\n\n  ingress_egress_gw {\n    azure_certified_hw = "Azure-byol-multi-nic-voltmesh"\n    az_nodes {\n      azure_az = "1"\n      inside_subnet {\n        subnet_param {\n          ipv4 = "10.0.1.0/24"\n        }\n      }\n      outside_subnet {\n        subnet_param {\n          ipv4 = "10.0.2.0/24"\n        }\n      }\n    }\n  }\n\n  no_worker_nodes {}\n}',
+				'resource "xcsh_azure_vnet_site" "example" {\n  name      = "example-Azure-vnet-site"\n  namespace = "staging"\n\n  machine_type   = "example-value"\n  resource_group = "example-value"\n  ssh_key        = "example-value"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -495,8 +509,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description:
 				"Bgp object is the configuration for peering with external bgp servers. it is created by users in system namespace. configuration",
 			required: ["name", "namespace"],
-			minimal_config:
-				'resource "xcsh_bgp" "example" {\n  name      = "example-bgp"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  bgp_router_id = "192.168.1.1"\n\n  bgp_peers {\n    metadata {\n      name = "upstream-peer"\n    }\n    spec {\n      peer_asn     = 65000\n      peer_address = "192.168.1.2"\n    }\n  }\n\n  local_asn = 65001\n\n  site {\n    name      = "example-site"\n    namespace = "staging"\n  }\n}',
+			minimal_config: 'resource "xcsh_bgp" "example" {\n  name      = "example-bgp"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -507,7 +520,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Bgp_asn_set creates a new object in the storage backend for metadata.namespace",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_bgp_asn_set" "example" {\n  name      = "example-bgp-asn-set"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n}',
+				'resource "xcsh_bgp_asn_set" "example" {\n  name      = "example-bgp-asn-set"\n  namespace = "staging"\n\n  as_numbers = [1]\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -516,10 +529,10 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		bgp_routing_policy: {
 			category: "security",
 			description:
-				"Bgp routing policy is a list of rules containing match criteria and action to be applied. these rules help control routes which are imported or exported to bgp peers. configuration",
+				"Bgp routing policy is a list of rules containing match criteria and action to be applied. these rules help contol routes which are imported or exported to bgp peers. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_bgp_routing_policy" "example" {\n  name      = "example-bgp-routing-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  rules {\n  }\n  action {\n  }\n  aggregate {\n  }\n}',
+				'resource "xcsh_bgp_routing_policy" "example" {\n  name      = "example-bgp-routing-policy"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -530,7 +543,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "BIG-IP HTTP Proxy in a given namespace. If one already exists, it will give an error",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_bigip_http_proxy" "example" {\n  name      = "example-bigip-http-proxy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  advanced_profile {\n  }\n  disable_spec {\n  }\n  enable_default_profile {\n  }\n}',
+				'resource "xcsh_bigip_http_proxy" "example" {\n  name      = "example-bigip-http-proxy"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -541,18 +554,29 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Bot Defense App Infrastructure in a given namespace",
 			required: ["name", "namespace", "environment_type", "traffic_type"],
 			minimal_config:
-				'resource "xcsh_bot_defense_app_infrastructure" "example" {\n  name      = "example-bot-defense-app-infrastructure"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  cloud_hosted {\n  }\n  egress {\n  }\n  ingress {\n  }\n}',
+				'resource "xcsh_bot_defense_app_infrastructure" "example" {\n  name      = "example-bot-defense-app-infrastructure"\n  namespace = "staging"\n\n  environment_type = "PRODUCTION"\n  traffic_type     = "WEB"\n}',
 			dependencies: {
 				requires: [],
 			},
 			import_syntax: "terraform import xcsh_bot_defense_app_infrastructure.example namespace/name",
+		},
+		bot_infrastructure: {
+			category: "uncategorized",
+			description: "Bot Infrastructure",
+			required: ["name", "namespace", "traffic_type"],
+			minimal_config:
+				'resource "xcsh_bot_infrastructure" "example" {\n  name      = "example-bot-infrastructure"\n  namespace = "staging"\n\n  traffic_type = "WEB"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_bot_infrastructure.example namespace/name",
 		},
 		cdn_cache_rule: {
 			category: "load-balancing",
 			description: "CDN loadbalancer specification. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_cdn_cache_rule" "example" {\n  name      = "example-CDN-cache-rule"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  cache_rules {\n  }\n  cache_bypass {\n  }\n  eligible_for_cache {\n  }\n}',
+				'resource "xcsh_cdn_cache_rule" "example" {\n  name      = "example-CDN-cache-rule"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -563,7 +587,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Content delivery and edge caching with load balancing",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_cdn_loadbalancer" "example" {\n  name      = "example-CDN-loadbalancer"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  domains = ["CDN.example.com"]\n\n  origin_pool {\n    public_name {\n      dns_name = "origin.example.com"\n    }\n    follow_origin_redirect = true\n    no_tls {}\n  }\n\n  cache_ttl_options {\n    cache_ttl_default = "1h"\n  }\n\n  https_auto_cert {\n    http_redirect = true\n  }\n\n  add_location = true\n}',
+				'resource "xcsh_cdn_loadbalancer" "example" {\n  name      = "example-CDN-loadbalancer"\n  namespace = "staging"\n\n  domains = ["example-value"]\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -574,7 +598,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "CDN purge command specification. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_cdn_purge_command" "example" {\n  name      = "example-CDN-purge-command"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  hard_purge {\n  }\n  purge_all {\n  }\n  soft_purge {\n  }\n}',
+				'resource "xcsh_cdn_purge_command" "example" {\n  name      = "example-CDN-purge-command"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -583,9 +607,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		certificate: {
 			category: "certificates",
 			description: "Certificate. configuration",
-			required: ["name", "namespace", "certificate_url"],
+			required: ["name", "namespace", "certificate_url", "private_key"],
 			minimal_config:
-				'resource "xcsh_certificate" "example" {\n  name      = "example-certificate"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  certificate_url = "string:///LS0tLS1CRUdJTi..."\n  private_key {\n    clear_secret_info {\n      url = "string:///LS0tLS1CRUdJTi..."\n    }\n  }\n}',
+				'resource "xcsh_certificate" "example" {\n  name      = "example-certificate"\n  namespace = "staging"\n\n  certificate_url = "example-value"\n}',
 			dependencies: {
 				requires: ["namespace"],
 			},
@@ -596,7 +620,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Certificate chain configuration for TLS",
 			required: ["name", "namespace", "certificate_url"],
 			minimal_config:
-				'resource "xcsh_certificate_chain" "example" {\n  name      = "example-certificate-chain"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n}',
+				'resource "xcsh_certificate_chain" "example" {\n  name      = "example-certificate-chain"\n  namespace = "staging"\n\n  certificate_url = "example-value"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -607,7 +631,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Establishing connectivity to cloud provider networks",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_cloud_connect" "example" {\n  name      = "example-cloud-connect"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  aws_provider {\n  }\n  aws_tgw_site {\n  }\n  cred {\n  }\n}',
+				'resource "xcsh_cloud_connect" "example" {\n  name      = "example-cloud-connect"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -618,7 +642,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Api to create cloud_credentials object. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_cloud_credentials" "example" {\n  name      = "example-cloud-credentials"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  aws_secret_key {\n    access_key = "AKIAIOSFODNN7EXAMPLE"\n    secret_key {\n      clear_secret_info {\n        url = "string:///d0phbmVzc2VjcmV0a2V5"\n      }\n    }\n  }\n}',
+				'resource "xcsh_cloud_credentials" "example" {\n  name      = "example-cloud-credentials"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -629,7 +653,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Cloud Elastic IP creates Cloud Elastic IP object Object is attached to a site",
 			required: ["name", "namespace", "item_count"],
 			minimal_config:
-				'resource "xcsh_cloud_elastic_ip" "example" {\n  name      = "example-cloud-elastic-ip"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  site_ref {\n  }\n}',
+				'resource "xcsh_cloud_elastic_ip" "example" {\n  name      = "example-cloud-elastic-ip"\n  namespace = "staging"\n\n  item_count = 1\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -640,7 +664,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "New CloudLink with configured parameters",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_cloud_link" "example" {\n  name      = "example-cloud-link"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  aws {\n  }\n  aws_cred {\n  }\n  byoc {\n  }\n}',
+				'resource "xcsh_cloud_link" "example" {\n  name      = "example-cloud-link"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -659,7 +683,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				"loadbalancer_algorithm",
 			],
 			minimal_config:
-				'resource "xcsh_cluster" "example" {\n  name      = "example-cluster"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  auto_http_config {\n  }\n  circuit_breaker {\n  }\n  default_subset {\n  }\n}',
+				'resource "xcsh_cluster" "example" {\n  name      = "example-cluster"\n  namespace = "staging"\n\n  connection_timeout     = 1\n  endpoint_selection     = "DISTRIBUTED"\n  fallback_policy        = "NO_FALLBACK"\n  http_idle_timeout      = 1\n  loadbalancer_algorithm = "ROUND_ROBIN"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -670,7 +694,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "App type will create the configuration in namespace metadata.namespace",
 			required: ["name", "namespace", "port", "username"],
 			minimal_config:
-				'resource "xcsh_cminstance" "example" {\n  name      = "example-cminstance"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  api_token {\n  }\n  blindfold_secret_info {\n  }\n  clear_secret_info {\n  }\n}',
+				'resource "xcsh_cminstance" "example" {\n  name      = "example-cminstance"\n  namespace = "staging"\n\n  port     = 1\n  username = "example-value"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -681,7 +705,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Integration details",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_code_base_integration" "example" {\n  name      = "example-code-base-integration"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  code_base_integration {\n  }\n  azure_repos {\n  }\n  access_token {\n  }\n}',
+				'resource "xcsh_code_base_integration" "example" {\n  name      = "example-code-base-integration"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -692,7 +716,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Container image registry configuration",
 			required: ["name", "namespace", "email", "registry", "user_name"],
 			minimal_config:
-				'resource "xcsh_container_registry" "example" {\n  name      = "example-container-registry"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  password {\n  }\n  blindfold_secret_info {\n  }\n  clear_secret_info {\n  }\n}',
+				'resource "xcsh_container_registry" "example" {\n  name      = "example-container-registry"\n  namespace = "staging"\n\n  registry  = "example-value"\n  user_name = "example-value"\n  email     = "example-value"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -703,7 +727,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Api to create crl object. configuration",
 			required: ["name", "namespace", "refresh_interval", "server_address", "server_port", "timeout"],
 			minimal_config:
-				'resource "xcsh_crl" "example" {\n  name      = "example-crl"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  http_access {\n  }\n}',
+				'resource "xcsh_crl" "example" {\n  name      = "example-crl"\n  namespace = "staging"\n\n  refresh_interval = 1\n  server_address   = "example-value"\n  server_port      = 1\n  timeout          = 1\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -714,7 +738,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Data group in a given namespace. If one already exists it will give an error",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_data_group" "example" {\n  name      = "example-data-group"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  address_records {\n  }\n  records {\n  }\n  integer_records {\n  }\n}',
+				'resource "xcsh_data_group" "example" {\n  name      = "example-data-group"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -725,7 +749,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Data_type creates a new object in the storage backend for metadata.namespace",
 			required: ["name", "namespace", "is_pii", "is_sensitive_data"],
 			minimal_config:
-				'resource "xcsh_data_type" "example" {\n  name      = "example-data-type"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  rules {\n  }\n  key_pattern {\n  }\n  exact_values {\n  }\n}',
+				'resource "xcsh_data_type" "example" {\n  name      = "example-data-type"\n  namespace = "staging"\n\n  compliances       = ["example-value"]\n  is_pii            = true\n  is_sensitive_data = true\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -734,9 +758,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		dc_cluster_group: {
 			category: "networking",
 			description: "DC Cluster group in given namespace",
-			required: ["name", "namespace"],
+			required: ["name"],
 			minimal_config:
-				'resource "xcsh_dc_cluster_group" "example" {\n  name      = "example-dc-cluster-group"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  type {\n  }\n  control_and_data_plane_mesh {\n  }\n  data_plane_mesh {\n  }\n}',
+				'resource "xcsh_dc_cluster_group" "example" {\n  name      = "example-dc-cluster-group"\n  namespace = "system"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -747,7 +771,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Api to create discovery object for a site or virtual site in system namespace. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_discovery" "example" {\n  name      = "example-discovery"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  discovery_k8s {\n    access_info {\n      kubeconfig_url {\n        clear_secret_info {\n          url = "string:///base64-kubeconfig"\n        }\n      }\n      isolated {}\n    }\n    publish_info {\n      disable {}\n    }\n  }\n\n  where {\n    site {\n      ref {\n        name      = "example-site"\n        namespace = "staging"\n      }\n      network_type = "VIRTUAL_NETWORK_SITE_LOCAL_INSIDE"\n    }\n  }\n}',
+				'resource "xcsh_discovery" "example" {\n  name      = "example-discovery"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -759,7 +783,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				"DNS Compliance Checks Specification in a given namespace. If one already exists it will give an error",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_dns_compliance_checks" "example" {\n  name      = "example-dns-compliance-checks"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n}',
+				'resource "xcsh_dns_compliance_checks" "example" {\n  name      = "example-dns-compliance-checks"\n  namespace = "staging"\n\n  domain_denylist                      = ["example-value"]\n  disallowed_query_type_list           = ["example-value"]\n  disallowed_resource_record_type_list = ["example-value"]\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -768,31 +792,75 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		dns_domain: {
 			category: "dns",
 			description: "DNS Domain in a given namespace. If one already exist it will give a error",
-			required: ["name", "namespace", "dnssec_mode"],
+			required: ["name", "dnssec_mode"],
 			minimal_config:
-				'resource "xcsh_dns_domain" "example" {\n  name      = "example-dns-domain"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  volterra_managed {\n  }\n}',
+				'resource "xcsh_dns_domain" "example" {\n  name      = "example-dns-domain"\n  namespace = "system"\n\n  dnssec_mode = "DNSSEC_DISABLE"\n}',
 			dependencies: {
 				requires: [],
 			},
 			import_syntax: "terraform import xcsh_dns_domain.example namespace/name",
 		},
+		dns_lb_health_check: {
+			category: "dns",
+			description: "DNS Load Balancer Health Check in a given namespace. If one already exist it will give a error",
+			required: ["name"],
+			minimal_config:
+				'resource "xcsh_dns_lb_health_check" "example" {\n  name      = "example-dns-lb-health-check"\n  namespace = "system"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_dns_lb_health_check.example namespace/name",
+		},
+		dns_lb_pool: {
+			category: "dns",
+			description: "DNS Load Balancer Pool in a given namespace. If one already exist it will give a error",
+			required: ["name", "load_balancing_mode"],
+			minimal_config:
+				'resource "xcsh_dns_lb_pool" "example" {\n  name      = "example-dns-lb-pool"\n  namespace = "system"\n\n  load_balancing_mode = "ROUND_ROBIN"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_dns_lb_pool.example namespace/name",
+		},
+		dns_load_balancer: {
+			category: "dns",
+			description: "DNS Load Balancer in a given namespace. If one already exist it will give a error",
+			required: ["name"],
+			minimal_config:
+				'resource "xcsh_dns_load_balancer" "example" {\n  name      = "example-dns-load-balancer"\n  namespace = "system"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_dns_load_balancer.example namespace/name",
+		},
 		dns_proxy: {
 			category: "dns",
 			description: "DNS Proxy in a given namespace. If one already exists it will give an error",
-			required: ["name", "namespace", "transport_type"],
+			required: ["name", "transport_type"],
 			minimal_config:
-				'resource "xcsh_dns_proxy" "example" {\n  name      = "example-dns-proxy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  cache_profile {\n  }\n  disable_cache_profile {\n  }\n  ddos_profile {\n  }\n}',
+				'resource "xcsh_dns_proxy" "example" {\n  name      = "example-dns-proxy"\n  namespace = "system"\n\n  transport_type = "UDP"\n}',
 			dependencies: {
 				requires: [],
 			},
 			import_syntax: "terraform import xcsh_dns_proxy.example namespace/name",
+		},
+		dns_zone: {
+			category: "dns",
+			description: "DNS Zone in a given namespace. If one already exist it will give a error",
+			required: ["name"],
+			minimal_config:
+				'resource "xcsh_dns_zone" "example" {\n  name      = "example-dns-zone"\n  namespace = "system"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_dns_zone.example namespace/name",
 		},
 		endpoint: {
 			category: "load-balancing",
 			description: "Endpoint will create the object in the storage backend for namespace metadata.namespace",
 			required: ["name", "namespace", "health_check_port", "port", "protocol"],
 			minimal_config:
-				'resource "xcsh_endpoint" "example" {\n  name      = "example-endpoint"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  dns_name_advanced {\n  }\n  service_info {\n  }\n  service_selector {\n  }\n}',
+				'resource "xcsh_endpoint" "example" {\n  name      = "example-endpoint"\n  namespace = "staging"\n\n  health_check_port = 1\n  port              = 1\n  protocol          = "example-value"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -802,9 +870,8 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "security",
 			description: "Enhanced firewall policy specification. configuration",
 			required: ["name", "namespace"],
-			server_defaults: ["allow_all"],
 			minimal_config:
-				'resource "xcsh_enhanced_firewall_policy" "example" {\n  name      = "example-enhanced-firewall-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  rule_list {\n    rules {\n      metadata {\n        name = "allow-web-traffic"\n      }\n      allow {}\n      advanced_action {\n        action = "LOG"\n      }\n      source_prefix_list {\n        ip_prefix_set {\n          name      = "trusted-ips"\n          namespace = "staging"\n        }\n      }\n      all_traffic {}\n    }\n  }\n}',
+				'resource "xcsh_enhanced_firewall_policy" "example" {\n  name      = "example-enhanced-firewall-policy"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -815,7 +882,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "External_connector configuration specification. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_external_connector" "example" {\n  name      = "example-external-connector"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  ce_site_reference {\n  }\n  gre {\n  }\n  gre_parameters {\n  }\n}',
+				'resource "xcsh_external_connector" "example" {\n  name      = "example-external-connector"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -825,9 +892,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "security",
 			description:
 				"Object, object contains rules to protect site from denial of service It has destination{destination IP, destination port) and references to",
-			required: ["name", "namespace"],
+			required: ["name"],
 			minimal_config:
-				'resource "xcsh_fast_acl" "example" {\n  name      = "example-fast-acl"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  protocol_policer {\n  }\n  re_acl {\n  }\n  all_public_vips {\n  }\n}',
+				'resource "xcsh_fast_acl" "example" {\n  name      = "example-fast-acl"\n  namespace = "system"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -836,9 +903,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		fast_acl_rule: {
 			category: "security",
 			description: "New Fast ACL rule, has specification to match source IP, source port and action to apply",
-			required: ["name", "namespace"],
+			required: ["name"],
 			minimal_config:
-				'resource "xcsh_fast_acl_rule" "example" {\n  name      = "example-fast-acl-rule"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  port {\n  }\n  all {\n  }\n  dns {\n  }\n}',
+				'resource "xcsh_fast_acl_rule" "example" {\n  name      = "example-fast-acl-rule"\n  namespace = "system"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -849,7 +916,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Specification",
 			required: ["name", "namespace", "context_key"],
 			minimal_config:
-				'resource "xcsh_filter_set" "example" {\n  name      = "example-filter-set"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  filter_fields {\n  }\n  date_field {\n  }\n  absolute {\n  }\n}',
+				'resource "xcsh_filter_set" "example" {\n  name      = "example-filter-set"\n  namespace = "staging"\n\n  context_key = "example-value"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -867,7 +934,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				"volterra_software_version",
 			],
 			minimal_config:
-				'resource "xcsh_fleet" "example" {\n  name      = "example-fleet"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  fleet_label = "env=production"\n\n  inside_virtual_network {\n    name      = "inside-network"\n    namespace = "staging"\n  }\n\n  outside_virtual_network {\n    name      = "outside-network"\n    namespace = "staging"\n  }\n\n  default_config {}\n}',
+				'resource "xcsh_fleet" "example" {\n  name      = "example-fleet"\n  namespace = "staging"\n\n  fleet_label                          = "example-value"\n  enable_default_fleet_config_download = true\n  operating_system_version             = "example-value"\n  volterra_software_version            = "example-value"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -878,7 +945,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Forward proxy policy specification. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_forward_proxy_policy" "example" {\n  name      = "example-forward-proxy-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  proxy_label_selector {\n    expressions = ["app in (web, api)"]\n  }\n\n  drp_http_connect {\n    any_proxy {}\n    rule_list {\n      rules {\n        metadata {\n          name = "allow-external"\n        }\n        spec {\n          action = "ALLOW"\n          dst_list {\n            any_dst {}\n          }\n        }\n      }\n    }\n  }\n}',
+				'resource "xcsh_forward_proxy_policy" "example" {\n  name      = "example-forward-proxy-policy"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -889,7 +956,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Forwarding class is created by users in system namespace. configuration",
 			required: ["name", "namespace", "queue_id_to_use", "interface_group"],
 			minimal_config:
-				'resource "xcsh_forwarding_class" "example" {\n  name      = "example-forwarding-class"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  dscp {\n  }\n  dscp_based_queue {\n  }\n  no_marking {\n  }\n}',
+				'resource "xcsh_forwarding_class" "example" {\n  name      = "example-forwarding-class"\n  namespace = "staging"\n\n  interface_group = "ANY_AVAILABLE_INTERFACE"\n  queue_id_to_use = "DSCP_BEST_EFFORT"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -900,19 +967,29 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Deploying F5 sites within Google Cloud VPC environments",
 			required: ["name", "namespace", "address", "disk_size", "gcp_region", "instance_type", "ssh_key"],
 			minimal_config:
-				'resource "xcsh_gcp_vpc_site" "example" {\n  name      = "example-gcp-vpc-site"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  gcp_region = "us-west1"\n\n  cloud_credentials {\n    name      = "gcp-credentials"\n    namespace = "staging"\n  }\n\n  instance_type = "n1-standard-4"\n\n  ingress_egress_gw {\n    gcp_certified_hw = "gcp-byol-multi-nic-voltmesh"\n    node_number      = 1\n    inside_network {\n      new_network {\n        name = "inside-network"\n      }\n    }\n    outside_network {\n      new_network {\n        name = "outside-network"\n      }\n    }\n    inside_subnet {\n      new_subnet {\n        subnet_name  = "inside-subnet"\n        primary_ipv4 = "10.0.1.0/24"\n      }\n    }\n    outside_subnet {\n      new_subnet {\n        subnet_name  = "outside-subnet"\n        primary_ipv4 = "10.0.2.0/24"\n      }\n    }\n  }\n\n  no_worker_nodes {}\n}',
+				'resource "xcsh_gcp_vpc_site" "example" {\n  name      = "example-gcp-vpc-site"\n  namespace = "staging"\n\n  gcp_region    = "example-value"\n  instance_type = "example-value"\n  ssh_key       = "example-value"\n  address       = "example-value"\n  disk_size     = 1\n}',
 			dependencies: {
 				requires: [],
 			},
 			import_syntax: "terraform import xcsh_gcp_vpc_site.example namespace/name",
 		},
+		geo_location_set: {
+			category: "cloud-resources",
+			description: "Geolocation Set",
+			required: ["name"],
+			minimal_config:
+				'resource "xcsh_geo_location_set" "example" {\n  name      = "example-geo-location-set"\n  namespace = "system"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_geo_location_set.example namespace/name",
+		},
 		global_log_receiver: {
 			category: "monitoring",
 			description: "New Global Log Receiver object",
-			required: ["name", "namespace"],
-			server_defaults: ["ns_current"],
+			required: ["name", "namespace", "log_type", "receiver_choice"],
 			minimal_config:
-				'resource "xcsh_global_log_receiver" "example" {\n  name      = "example-global-log-receiver"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  audit_logs {\n  }\n  aws_cloud_watch_receiver {\n  }\n  aws_cred {\n  }\n}',
+				'resource "xcsh_global_log_receiver" "example" {\n  name      = "example-global-log-receiver"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -922,23 +999,10 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "load-balancing",
 			description:
 				"Healthcheck object defines method to determine if the given endpoint is healthy. single healthcheck object can be referred to by one or many cluster objects. configuration",
-			required: ["name", "namespace", "healthy_threshold", "interval", "timeout", "unhealthy_threshold"],
-			oneof_groups: [
-				{
-					fields: ["http_health_check", "tcp_health_check", "udp_icmp_health_check"],
-				},
-				{
-					parent: "http_health_check",
-					fields: ["host_header", "use_origin_server_name"],
-				},
-				{
-					parent: "http_health_check",
-					fields: ["headers", "request_headers_to_remove"],
-				},
-			],
-			server_defaults: ["jitter_percent"],
+			required: ["name", "namespace", "interval", "timeout", "healthy_threshold", "unhealthy_threshold"],
+			server_defaults: ["jitter_percent", "use_http2"],
 			minimal_config:
-				'resource "xcsh_healthcheck" "example" {\n  name      = "example-healthcheck"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  // One of the arguments from this list "http_health_check tcp_health_check udp_icmp_health_check" must be set\n\n  http_health_check {\n    // One of the arguments from this list "host_header use_origin_server_name" must be set\n\n    use_origin_server_name {}\n\n    path                  = "/health"\n    use_http2             = false\n    expected_status_codes = ["200"]\n\n    // One of the arguments from this list "headers request_headers_to_remove" must be set\n\n    headers {}\n  }\n\n  healthy_threshold   = 3\n  unhealthy_threshold = 3\n  interval            = 15\n  timeout             = 5\n}',
+				'resource "xcsh_healthcheck" "example" {\n  name      = "example-healthcheck"\n  namespace = "staging"\n\n  healthy_threshold   = 1\n  interval            = 1\n  timeout             = 1\n  unhealthy_threshold = 1\n}',
 			dependencies: {
 				requires: ["namespace"],
 				used_by: ["origin_pool"],
@@ -948,112 +1012,10 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		http_loadbalancer: {
 			category: "load-balancing",
 			description: "Load balancing HTTP/HTTPS traffic with advanced routing and security",
-			required: ["name", "namespace"],
-			oneof_groups: [
-				{
-					fields: [
-						"advertise_custom",
-						"advertise_on_public",
-						"advertise_on_public_default_vip",
-						"do_not_advertise",
-					],
-				},
-				{
-					fields: ["api_specification", "disable_api_definition"],
-				},
-				{
-					fields: ["disable_api_discovery", "enable_api_discovery"],
-				},
-				{
-					fields: ["api_testing", "disable_api_testing"],
-				},
-				{
-					fields: [
-						"captcha_challenge",
-						"enable_challenge",
-						"js_challenge",
-						"no_challenge",
-						"policy_based_challenge",
-					],
-				},
-				{
-					fields: [
-						"cookie_stickiness",
-						"least_active",
-						"random",
-						"ring_hash",
-						"round_robin",
-						"source_ip_stickiness",
-					],
-				},
-				{
-					fields: ["http", "https", "https_auto_cert"],
-				},
-				{
-					parent: "https_auto_cert",
-					fields: ["default_header", "no_headers", "server_name"],
-				},
-				{
-					parent: "tls_config",
-					fields: ["custom_security", "default_security", "low_security", "medium_security"],
-				},
-				{
-					parent: "https_auto_cert",
-					fields: ["no_mtls", "use_mtls"],
-				},
-				{
-					fields: ["disable_malicious_user_detection", "enable_malicious_user_detection"],
-				},
-				{
-					fields: ["disable_malware_protection", "malware_protection_settings"],
-				},
-				{
-					fields: ["api_rate_limit", "disable_rate_limit", "rate_limit"],
-				},
-				{
-					fields: ["default_sensitive_data_policy", "sensitive_data_policy"],
-				},
-				{
-					fields: ["active_service_policies", "no_service_policies", "service_policies_from_namespace"],
-				},
-				{
-					fields: ["disable_threat_mesh", "enable_threat_mesh"],
-				},
-				{
-					fields: ["disable_trust_client_ip_headers", "enable_trust_client_ip_headers"],
-				},
-				{
-					fields: ["user_id_client_ip", "user_identification"],
-				},
-				{
-					fields: ["app_firewall", "disable_waf"],
-				},
-				{
-					fields: ["bot_defense", "bot_defense_advanced", "disable_bot_defense"],
-				},
-			],
-			server_defaults: [
-				"add_location",
-				"endpoint_selection",
-				"loadbalancer_algorithm",
-				"healthcheck",
-				"no_tls",
-				"same_as_endpoint_port",
-				"default_sensitive_data_policy",
-				"disable_api_definition",
-				"disable_api_discovery",
-				"disable_api_testing",
-				"disable_malware_protection",
-				"disable_rate_limit",
-				"disable_threat_mesh",
-				"disable_trust_client_ip_headers",
-				"l7_ddos_protection",
-				"round_robin",
-				"service_policies_from_namespace",
-				"user_id_client_ip",
-			],
+			required: ["name", "namespace", "domains"],
+			server_defaults: ["connection_timeout", "http_idle_timeout"],
 			minimal_config:
-				'resource "xcsh_http_loadbalancer" "example" {\n  name      = "example-http-loadbalancer"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  // One of the arguments from this list "advertise_custom advertise_on_public advertise_on_public_default_vip do_not_advertise" must be set\n\n  advertise_on_public_default_vip {}\n\n  // One of the arguments from this list "api_specification disable_api_definition" must be set\n\n  disable_api_definition {}\n\n  // One of the arguments from this list "disable_api_discovery enable_api_discovery" must be set\n\n  disable_api_discovery {}\n\n  // One of the arguments from this list "api_testing disable_api_testing" must be set\n\n  disable_api_testing {}\n\n  // One of the arguments from this list "captcha_challenge enable_challenge js_challenge no_challenge policy_based_challenge" must be set\n\n  no_challenge {}\n\n  domains = ["app.example.com", "`www.example.com"`]\n\n  // One of the arguments from this list "cookie_stickiness least_active random ring_hash round_robin source_ip_stickiness" must be set\n\n  round_robin {}\n\n  // One of the arguments from this list "http https https_auto_cert" must be set\n\n  https_auto_cert {\n    http_redirect = true\n    add_hsts      = true\n\n    // One of the arguments from this list "default_header no_headers server_name" must be set\n\n    default_header {}\n\n    tls_config {\n      // One of the arguments from this list "custom_security default_security low_security medium_security" must be set\n\n      default_security {}\n    }\n\n    // One of the arguments from this list "no_mtls use_mtls" must be set\n\n    no_mtls {}\n  }\n\n  // One of the arguments from this list "disable_malicious_user_detection enable_malicious_user_detection" must be set\n\n  enable_malicious_user_detection {}\n\n  // One of the arguments from this list "disable_malware_protection malware_protection_settings" must be set\n\n}',
+				'resource "xcsh_http_loadbalancer" "example" {\n  name      = "example-http-loadbalancer"\n  namespace = "staging"\n\n  domains = ["example-value"]\n}',
 			dependencies: {
 				requires: ["namespace", "origin_pool"],
 				used_by: ["route"],
@@ -1064,8 +1026,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "vpn",
 			description: "Ike phase1 profile specification. configuration",
 			required: ["name", "namespace"],
-			minimal_config:
-				'resource "xcsh_ike1" "example" {\n  name      = "example-ike1"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  ike_keylifetime_hours {\n  }\n  ike_keylifetime_minutes {\n  }\n  reauth_disabled {\n  }\n}',
+			minimal_config: 'resource "xcsh_ike1" "example" {\n  name      = "example-ike1"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1075,8 +1036,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "vpn",
 			description: "Ike phase2 profile specification. configuration",
 			required: ["name", "namespace"],
-			minimal_config:
-				'resource "xcsh_ike2" "example" {\n  name      = "example-ike2"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  dh_group_set {\n  }\n  disable_pfs {\n  }\n  ike_keylifetime_hours {\n  }\n}',
+			minimal_config: 'resource "xcsh_ike2" "example" {\n  name      = "example-ike2"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1087,7 +1047,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Ike phase1 profile specification. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_ike_phase1_profile" "example" {\n  name      = "example-ike-phase1-profile"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  ike_keylifetime_hours {\n  }\n  ike_keylifetime_minutes {\n  }\n  reauth_disabled {\n  }\n}',
+				'resource "xcsh_ike_phase1_profile" "example" {\n  name      = "example-ike-phase1-profile"\n  namespace = "staging"\n\n  authentication_algos = ["example-value"]\n  dh_group             = ["example-value"]\n  encryption_algos     = ["example-value"]\n  prf                  = ["example-value"]\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1098,7 +1058,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Ike phase2 profile specification. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_ike_phase2_profile" "example" {\n  name      = "example-ike-phase2-profile"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  dh_group_set {\n  }\n  disable_pfs {\n  }\n  ike_keylifetime_hours {\n  }\n}',
+				'resource "xcsh_ike_phase2_profile" "example" {\n  name      = "example-ike-phase2-profile"\n  namespace = "staging"\n\n  authentication_algos = ["example-value"]\n  encryption_algos     = ["example-value"]\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1109,7 +1069,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Ip_prefix_set creates a new object in the storage backend for metadata.namespace",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_ip_prefix_set" "example" {\n  name      = "example-ip-prefix-set"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  prefix = ["192.168.1.0/24", "10.0.0.0/8"]\n}',
+				'resource "xcsh_ip_prefix_set" "example" {\n  name      = "example-ip-prefix-set"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1120,7 +1080,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "IRule in a given namespace. If one already exists it will give an error",
 			required: ["name", "namespace", "description", "description_spec", "irule"],
 			minimal_config:
-				'resource "xcsh_irule" "example" {\n  name      = "example-irule"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n}',
+				'resource "xcsh_irule" "example" {\n  name      = "example-irule"\n  namespace = "staging"\n\n  description_spec = "example-value"\n  irule            = "example-value"\n  description      = "example-value"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1130,19 +1090,8 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "kubernetes",
 			description: "K8s_cluster will create the object in the storage backend for namespace metadata.namespace",
 			required: ["name", "namespace"],
-			server_defaults: [
-				"cluster_scoped_access_deny",
-				"no_cluster_wide_apps",
-				"no_global_access",
-				"no_insecure_registries",
-				"no_local_access",
-				"use_default_cluster_role_bindings",
-				"use_default_cluster_roles",
-				"use_default_psp",
-				"vk8s_namespace_access_deny",
-			],
 			minimal_config:
-				'resource "xcsh_k8s_cluster" "example" {\n  name      = "example-k8s-cluster"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  use_custom_cluster_role_bindings {\n    cluster_role_bindings {\n      name      = "admin-binding"\n      namespace = "staging"\n    }\n  }\n\n  cluster_wide_app_list {\n    cluster_wide_apps {\n      name      = "nginx-ingress"\n      namespace = "staging"\n    }\n  }\n\n  local_access_config {\n    local_domain = "cluster.local"\n    default_port {}\n  }\n\n  global_access_enable {}\n}',
+				'resource "xcsh_k8s_cluster" "example" {\n  name      = "example-k8s-cluster"\n  namespace = "system"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1151,9 +1100,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		k8s_cluster_role: {
 			category: "kubernetes",
 			description: "K8s_cluster_role will create the object in the storage backend for namespace metadata.namespace",
-			required: ["name", "namespace"],
+			required: ["name"],
 			minimal_config:
-				'resource "xcsh_k8s_cluster_role" "example" {\n  name      = "example-k8s-cluster-role"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  k8s_cluster_role_selector {\n  }\n  policy_rule_list {\n  }\n  policy_rule {\n  }\n}',
+				'resource "xcsh_k8s_cluster_role" "example" {\n  name      = "example-k8s-cluster-role"\n  namespace = "system"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1163,9 +1112,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "kubernetes",
 			description:
 				"K8s_cluster_role_binding will create the object in the storage backend for namespace metadata.namespace",
-			required: ["name", "namespace"],
+			required: ["name"],
 			minimal_config:
-				'resource "xcsh_k8s_cluster_role_binding" "example" {\n  name      = "example-k8s-cluster-role-binding"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  subjects {\n  }\n  service_account {\n  }\n  k8s_cluster_role {\n  }\n}',
+				'resource "xcsh_k8s_cluster_role_binding" "example" {\n  name      = "example-k8s-cluster-role-binding"\n  namespace = "system"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1176,7 +1125,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "K8s_pod_security_admission will create the object in the storage backend",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_k8s_pod_security_admission" "example" {\n  name      = "example-k8s-pod-security-admission"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  pod_security_admission_specs {\n  }\n  audit {\n  }\n  baseline {\n  }\n}',
+				'resource "xcsh_k8s_pod_security_admission" "example" {\n  name      = "example-k8s-pod-security-admission"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1188,7 +1137,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				"K8s_pod_security_policy will create the object in the storage backend for namespace metadata.namespace",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_k8s_pod_security_policy" "example" {\n  name      = "example-k8s-pod-security-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  psp_spec {\n  }\n  allowed_capabilities {\n  }\n  allowed_host_paths {\n  }\n}',
+				'resource "xcsh_k8s_pod_security_policy" "example" {\n  name      = "example-k8s-pod-security-policy"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1199,7 +1148,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "New Log Receiver object",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_log_receiver" "example" {\n  name      = "example-log-receiver"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  http_receiver {\n    uri = "`https://logs.example.com/ingest"`\n    batch {\n      max_bytes       = 1048576\n      max_events      = 100\n      timeout_seconds = 5\n    }\n    no_tls_verify_hostname {}\n    no_compression {}\n  }\n}',
+				'resource "xcsh_log_receiver" "example" {\n  name      = "example-log-receiver"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1209,20 +1158,30 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "security",
 			description: "Malicious_user_mitigation creates a new object in the storage backend for metadata.namespace",
 			required: ["name", "namespace"],
-			server_defaults: ["mitigation_type"],
 			minimal_config:
-				'resource "xcsh_malicious_user_mitigation" "example" {\n  name      = "example-malicious-user-mitigation"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  mitigation_type {\n    rules {\n      threat_level {\n        high {}\n      }\n      mitigation_action {\n        block_temporarily {}\n      }\n    }\n  }\n}',
+				'resource "xcsh_malicious_user_mitigation" "example" {\n  name      = "example-malicious-user-mitigation"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
 			import_syntax: "terraform import xcsh_malicious_user_mitigation.example namespace/name",
+		},
+		mitigated_domain: {
+			category: "uncategorized",
+			description: "Mitigated Domain",
+			required: ["name", "namespace", "mitigated_domain"],
+			minimal_config:
+				'resource "xcsh_mitigated_domain" "example" {\n  name      = "example-mitigated-domain"\n  namespace = "staging"\n\n  mitigated_domain = "example-value"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_mitigated_domain.example namespace/name",
 		},
 		namespace: {
 			category: "organization",
 			description: "New namespace. Name of the object is name of the namespace",
 			required: ["name"],
 			minimal_config:
-				'resource "xcsh_namespace" "example" {\n  name      = "example-namespace"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  description = "Example namespace for application workloads"\n}',
+				'resource "xcsh_namespace" "example" {\n  name      = "example-namespace"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 				used_by: [
@@ -1246,7 +1205,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Nat policy create specification configures nat policy with multiple rules,. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_nat_policy" "example" {\n  name      = "example-nat-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  rules {\n  }\n  action {\n  }\n  dynamic {\n  }\n}',
+				'resource "xcsh_nat_policy" "example" {\n  name      = "example-nat-policy"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1257,7 +1216,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Network connector is created by users in system namespace. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_network_connector" "example" {\n  name      = "example-network-connector"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  sli_to_global_dr {\n    global_vn {\n      name      = "global-network"\n      namespace = "staging"\n    }\n  }\n\n  disable_forward_proxy {}\n}',
+				'resource "xcsh_network_connector" "example" {\n  name      = "example-network-connector"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1267,9 +1226,8 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "security",
 			description: "Network firewall is created by users in system namespace. configuration",
 			required: ["name", "namespace"],
-			server_defaults: ["disable_fast_acl", "disable_forward_proxy_policy", "disable_network_policy"],
 			minimal_config:
-				'resource "xcsh_network_firewall" "example" {\n  name      = "example-network-firewall"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  active_enhanced_firewall_policies {\n  }\n  enhanced_firewall_policies {\n  }\n  active_fast_acls {\n  }\n}',
+				'resource "xcsh_network_firewall" "example" {\n  name      = "example-network-firewall"\n  namespace = "system"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1281,7 +1239,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				"Network interface represents configuration of a network device. it is created by users in system namespace. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_network_interface" "example" {\n  name      = "example-network-interface"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  dedicated_interface {\n  }\n  cluster {\n  }\n  is_primary {\n  }\n}',
+				'resource "xcsh_network_interface" "example" {\n  name      = "example-network-interface"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1292,7 +1250,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "New network policy with configured parameters in specified namespace",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_network_policy" "example" {\n  name      = "example-network-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  endpoint {\n    any {}\n  }\n\n  ingress_rules {\n    metadata {\n      name = "allow-http"\n    }\n    spec {\n      action = "ALLOW"\n      any    = {}\n    }\n  }\n\n  egress_rules {\n    metadata {\n      name = "allow-all-egress"\n    }\n    spec {\n      action = "ALLOW"\n      any    = {}\n    }\n  }\n}',
+				'resource "xcsh_network_policy" "example" {\n  name      = "example-network-policy"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1303,7 +1261,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Network policy rule with configured parameters in specified namespace",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_network_policy_rule" "example" {\n  name      = "example-network-policy-rule"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  advanced_action {\n  }\n  ip_prefix_set {\n  }\n  ref {\n  }\n}',
+				'resource "xcsh_network_policy_rule" "example" {\n  name      = "example-network-policy-rule"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1314,7 +1272,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Network policy view specification. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_network_policy_view" "example" {\n  name      = "example-network-policy-view"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  egress_rules {\n  }\n  adv_action {\n  }\n  all_tcp_traffic {\n  }\n}',
+				'resource "xcsh_network_policy_view" "example" {\n  name      = "example-network-policy-view"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1325,7 +1283,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "New NFV service with configured parameters",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_nfv_service" "example" {\n  name      = "example-nfv-service"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  disable_https_management {\n  }\n  disable_ssh_access {\n  }\n  enabled_ssh_access {\n  }\n}',
+				'resource "xcsh_nfv_service" "example" {\n  name      = "example-nfv-service"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1337,7 +1295,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				"Api to create nginx service discovery object for a site or virtual site in system namespace. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_nginx_service_discovery" "example" {\n  name      = "example-nginx-service-discovery"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  discovery_target {\n  }\n  config_sync_group {\n  }\n  nginx_instance {\n  }\n}',
+				'resource "xcsh_nginx_service_discovery" "example" {\n  name      = "example-nginx-service-discovery"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1346,59 +1304,10 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		origin_pool: {
 			category: "load-balancing",
 			description: "Defining backend server pools for load balancer targets",
-			required: ["name", "namespace"],
-			oneof_groups: [
-				{
-					parent: "origin_servers",
-					fields: [
-						"consul_service",
-						"custom_endpoint_object",
-						"k8s_service",
-						"private_ip",
-						"private_name",
-						"public_ip",
-						"public_name",
-						"vn_private_ip",
-						"vn_private_name",
-					],
-				},
-				{
-					parent: "k8s_service",
-					fields: ["inside_network", "outside_network", "vk8s_networks"],
-				},
-				{
-					parent: "site_locator",
-					fields: ["site", "virtual_site"],
-				},
-				{
-					fields: ["no_tls", "use_tls"],
-				},
-				{
-					parent: "use_tls",
-					fields: ["disable_sni", "sni", "use_host_header_as_sni"],
-				},
-				{
-					parent: "tls_config",
-					fields: ["custom_security", "default_security", "low_security", "medium_security"],
-				},
-				{
-					parent: "use_tls",
-					fields: ["no_mtls", "use_mtls", "use_mtls_obj"],
-				},
-				{
-					parent: "use_tls",
-					fields: ["skip_server_verification", "use_server_verification", "volterra_trusted_ca"],
-				},
-			],
-			server_defaults: [
-				"endpoint_selection",
-				"loadbalancer_algorithm",
-				"healthcheck",
-				"no_tls",
-				"same_as_endpoint_port",
-			],
+			required: ["name", "namespace", "origin_servers", "port"],
+			server_defaults: ["connection_timeout", "http_idle_timeout"],
 			minimal_config:
-				'resource "xcsh_origin_pool" "example" {\n  name      = "example-origin-pool"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  // Origin servers configuration\n  origin_servers {\n    // One of the arguments from this list "consul_service custom_endpoint_object k8s_service private_ip private_name public_ip public_name vn_private_ip vn_private_name" must be set\n\n    public_name {\n      dns_name         = "origin.example.com"\n      refresh_interval = 60\n    }\n  }\n\n  origin_servers {\n    // One of the arguments from this list "consul_service custom_endpoint_object k8s_service private_ip private_name public_ip public_name vn_private_ip vn_private_name" must be set\n\n    k8s_service {\n      service_name = "backend-svc"\n\n      // One of the arguments from this list "inside_network outside_network vk8s_networks" must be set\n\n      vk8s_networks {}\n\n      site_locator {\n        // One of the arguments from this list "site virtual_site" must be set\n\n        site {\n          name      = "example-site"\n          namespace = "staging"\n        }\n      }\n    }\n  }\n\n  port = 443\n\n  // One of the arguments from this list "no_tls use_tls" must be set\n\n  use_tls {\n    // One of the arguments from this list "disable_sni sni use_host_header_as_sni" must be set\n\n    sni = "backend.example.com"\n\n    tls_config {\n      // One of the arguments from this list "custom_security default_security low_security medium_security" must be set\n\n      default_security {}\n    }\n\n    // One of the arguments from this list "no_mtls use_mtls use_mtls_obj" must be set\n\n    no_mtls {}\n\n    // One of the arguments from this list "skip_server_verification use_server_verification volterra_trusted_ca" must be set\n\n    volterra_trusted_ca {}\n  }\n\n  // Health check configuration\n  healthcheck {\n    name      = "example-healthcheck"\n    namespace = "staging"\n  }\n\n  // Load balancing configuration\n}',
+				'resource "xcsh_origin_pool" "example" {\n  name      = "example-origin-pool"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: ["namespace", "healthcheck"],
 				used_by: ["http_loadbalancer", "tcp_loadbalancer", "udp_loadbalancer"],
@@ -1409,9 +1318,8 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "service-mesh",
 			description: "New policer with traffic rate limits",
 			required: ["name", "namespace", "burst_size", "committed_information_rate"],
-			server_defaults: ["policer_mode", "policer_type"],
 			minimal_config:
-				'resource "xcsh_policer" "example" {\n  name      = "example-policer"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n}',
+				'resource "xcsh_policer" "example" {\n  name      = "example-policer"\n  namespace = "staging"\n\n  burst_size                 = 1\n  committed_information_rate = 1\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1422,20 +1330,41 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Network policy based routing create specification. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_policy_based_routing" "example" {\n  name      = "example-policy-based-routing"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  forwarding_class_list {\n  }\n  forward_proxy_pbr {\n  }\n  forward_proxy_pbr_rules {\n  }\n}',
+				'resource "xcsh_policy_based_routing" "example" {\n  name      = "example-policy-based-routing"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
 			import_syntax: "terraform import xcsh_policy_based_routing.example namespace/name",
 		},
+		protected_application: {
+			category: "uncategorized",
+			description: "Applications protected by Bot Defense",
+			required: ["name", "namespace", "region"],
+			minimal_config:
+				'resource "xcsh_protected_application" "example" {\n  name      = "example-protected-application"\n  namespace = "staging"\n\n  region = "US"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_protected_application.example namespace/name",
+		},
+		protected_domain: {
+			category: "uncategorized",
+			description: "Domain to protect",
+			required: ["name", "namespace", "protected_domain"],
+			minimal_config:
+				'resource "xcsh_protected_domain" "example" {\n  name      = "example-protected-domain"\n  namespace = "staging"\n\n  protected_domain = "example-value"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_protected_domain.example namespace/name",
+		},
 		protocol_inspection: {
 			category: "security",
 			description:
 				"Protocol Inspection Specification in a given namespace. If one already exists it will give an error",
-			required: ["name", "namespace"],
-			server_defaults: ["action"],
+			required: ["name", "namespace", "enable_disable_compliance_checks", "enable_disable_signatures"],
 			minimal_config:
-				'resource "xcsh_protocol_inspection" "example" {\n  name      = "example-protocol-inspection"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  enable_disable_compliance_checks {\n  }\n  disable_compliance_checks {\n  }\n  enable_compliance_checks {\n  }\n}',
+				'resource "xcsh_protocol_inspection" "example" {\n  name      = "example-protocol-inspection"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1445,9 +1374,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "security",
 			description:
 				"Protocol_policer object, protocol_policer object contains list of L4 protocol match condition and corresponding traffic rate limits",
-			required: ["name", "namespace"],
+			required: ["name"],
 			minimal_config:
-				'resource "xcsh_protocol_policer" "example" {\n  name      = "example-protocol-policer"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  protocol_policer {\n  }\n  policer {\n  }\n  protocol {\n  }\n}',
+				'resource "xcsh_protocol_policer" "example" {\n  name      = "example-protocol-policer"\n  namespace = "system"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1458,7 +1387,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Tcp loadbalancer create specification. configuration",
 			required: ["name", "namespace", "connection_timeout"],
 			minimal_config:
-				'resource "xcsh_proxy" "example" {\n  name      = "example-proxy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  proxy_url = "`http://proxy.example.com:8080"`\n}',
+				'resource "xcsh_proxy" "example" {\n  name      = "example-proxy"\n  namespace = "staging"\n\n  connection_timeout = 1\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1468,9 +1397,8 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "security",
 			description: "Rate_limiter creates a new object in the storage backend for metadata.namespace",
 			required: ["name", "namespace"],
-			server_defaults: ["user_identification"],
 			minimal_config:
-				'resource "xcsh_rate_limiter" "example" {\n  name      = "example-rate-limiter"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  limits {\n    total_number     = 100\n    unit             = "MINUTE"\n    burst_multiplier = 10\n  }\n}',
+				'resource "xcsh_rate_limiter" "example" {\n  name      = "example-rate-limiter"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: ["namespace"],
 			},
@@ -1479,10 +1407,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		rate_limiter_policy: {
 			category: "security",
 			description: "Rate limiter policy create specification. configuration",
-			required: ["name", "namespace"],
-			server_defaults: ["rules"],
+			required: ["name", "namespace", "burst_size", "committed_information_rate"],
 			minimal_config:
-				'resource "xcsh_rate_limiter_policy" "example" {\n  name      = "example-rate-limiter-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  any_server {\n  }\n  server_name_matcher {\n  }\n  server_selector {\n  }\n}',
+				'resource "xcsh_rate_limiter_policy" "example" {\n  name      = "example-rate-limiter-policy"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1493,8 +1420,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description:
 				"Route object in a given namespace. Route object is list of route rules. Each rule has match condition to match incoming requests and actions to take on matching requests",
 			required: ["name", "namespace"],
-			minimal_config:
-				'resource "xcsh_route" "example" {\n  name      = "example-route"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  routes {\n    match {\n      path {\n        prefix = "/api/"\n      }\n    }\n    route_destination {\n      destinations {\n        cluster {\n          name      = "api-cluster"\n          namespace = "staging"\n        }\n        weight = 100\n      }\n    }\n  }\n}',
+			minimal_config: 'resource "xcsh_route" "example" {\n  name      = "example-route"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: ["namespace", "http_loadbalancer"],
 			},
@@ -1505,7 +1431,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Secret_management_access creates a new object in storage backend for metadata.namespace",
 			required: ["name", "namespace", "provider_name"],
 			minimal_config:
-				'resource "xcsh_secret_management_access" "example" {\n  name      = "example-secret-management-access"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  access_info {\n  }\n  rest_auth_info {\n  }\n  basic_auth {\n  }\n}',
+				'resource "xcsh_secret_management_access" "example" {\n  name      = "example-secret-management-access"\n  namespace = "staging"\n\n  provider_name = "example-value"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1516,7 +1442,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Deploying secure mesh edge sites with distributed security capabilities",
 			required: ["name", "namespace", "address", "volterra_certified_hw"],
 			minimal_config:
-				'resource "xcsh_securemesh_site" "example" {\n  name      = "example-securemesh-site"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  generic {\n    not_managed {\n      node_list {\n        hostname  = "node1.example.com"\n        public_ip = "203.0.113.10"\n        type      = "Control"\n      }\n    }\n  }\n\n  master_nodes_count = 1\n\n  default_fleet_config {}\n\n  disable_ha {}\n}',
+				'resource "xcsh_securemesh_site" "example" {\n  name      = "example-securemesh-site"\n  namespace = "staging"\n\n  volterra_certified_hw = "example-value"\n  worker_nodes          = ["example-value"]\n  address               = "example-value"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1527,7 +1453,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Deploying secure mesh edge sites with enhanced security and networking features",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_securemesh_site_v2" "example" {\n  name      = "example-securemesh-site-v2"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  performance_enhancement_mode {\n  }\n  perf_mode_l3_enhanced {\n  }\n  jumbo {\n  }\n}',
+				'resource "xcsh_securemesh_site_v2" "example" {\n  name      = "example-securemesh-site-v2"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1538,7 +1464,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Segment. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_segment" "example" {\n  name      = "example-segment"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  disable_spec {\n  }\n  enable {\n  }\n}',
+				'resource "xcsh_segment" "example" {\n  name      = "example-segment"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1548,9 +1474,8 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "security",
 			description: "Sensitive_data_policy creates a new object in the storage backend for metadata.namespace",
 			required: ["name", "namespace"],
-			server_defaults: ["compliances", "disabled_predefined_data_types", "custom_data_types"],
 			minimal_config:
-				'resource "xcsh_sensitive_data_policy" "example" {\n  name      = "example-sensitive-data-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  custom_data_types {\n  }\n  custom_data_type_ref {\n  }\n}',
+				'resource "xcsh_sensitive_data_policy" "example" {\n  name      = "example-sensitive-data-policy"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1560,17 +1485,8 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "security",
 			description: "Service_policy creates a new object in the storage backend for metadata.namespace",
 			required: ["name", "namespace"],
-			oneof_groups: [
-				{
-					fields: ["allow_all_requests", "allow_list", "deny_all_requests", "deny_list", "rule_list"],
-				},
-				{
-					fields: ["any_server", "server_name", "server_name_matcher", "server_selector"],
-				},
-			],
-			server_defaults: ["port_matcher", "any_server"],
 			minimal_config:
-				'resource "xcsh_service_policy" "example" {\n  name      = "example-service-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  // One of the arguments from this list "allow_all_requests allow_list deny_all_requests deny_list rule_list" must be set\n\n  rule_list {\n    rules {\n      metadata {\n        name = "allow-api"\n      }\n      spec {\n        action = "ALLOW"\n        any_client {}\n        any_ip {}\n        path {\n          prefix_values = ["/api/"]\n        }\n      }\n    }\n  }\n\n  // One of the arguments from this list "any_server server_name server_name_matcher server_selector" must be set\n\n  any_server {}\n}',
+				'resource "xcsh_service_policy" "example" {\n  name      = "example-service-policy"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: ["namespace"],
 			},
@@ -1580,9 +1496,8 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "security",
 			description: "Service_policy_rule creates a new object in the storage backend for metadata.namespace",
 			required: ["name", "namespace"],
-			server_defaults: ["port_matcher"],
 			minimal_config:
-				'resource "xcsh_service_policy_rule" "example" {\n  name      = "example-service-policy-rule"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  any_asn {\n  }\n  any_client {\n  }\n  any_ip {\n  }\n}',
+				'resource "xcsh_service_policy_rule" "example" {\n  name      = "example-service-policy-rule"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1593,7 +1508,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Virtual site object in given namespace",
 			required: ["name", "namespace", "site_type"],
 			minimal_config:
-				'resource "xcsh_site" "example" {\n  name      = "example-site"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  site_selector {\n  }\n}',
+				'resource "xcsh_site" "example" {\n  name      = "example-site"\n  namespace = "staging"\n\n  site_type = "INVALID"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1604,7 +1519,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Site Mesh Group in system namespace of user",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_site_mesh_group" "example" {\n  name      = "example-site-mesh-group"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  type = "SITE_MESH_GROUP_TYPE_FULL_MESH"\n\n  full_mesh {\n    control_and_data_plane_mesh {}\n  }\n\n  hub {}\n\n  virtual_site {\n    name      = "example-virtual-site"\n    namespace = "staging"\n  }\n}',
+				'resource "xcsh_site_mesh_group" "example" {\n  name      = "example-site-mesh-group"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1621,7 +1536,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				"connect_to_internet",
 			],
 			minimal_config:
-				'resource "xcsh_srv6_network_slice" "example" {\n  name      = "example-srv6-network-slice"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n}',
+				'resource "xcsh_srv6_network_slice" "example" {\n  name      = "example-srv6-network-slice"\n  namespace = "staging"\n\n  sid_prefixes                   = ["example-value"]\n  connect_to_access_networks     = true\n  connect_to_enterprise_networks = true\n  connect_to_internet            = true\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1633,7 +1548,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				"Subnet object contains configuration for an interface of a vm/pod. it is created in user or shared namespace. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_subnet" "example" {\n  name      = "example-subnet"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  site_subnet_params {\n  }\n  dhcp {\n  }\n  site {\n  }\n}',
+				'resource "xcsh_subnet" "example" {\n  name      = "example-subnet"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1642,28 +1557,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		tcp_loadbalancer: {
 			category: "load-balancing",
 			description: "Load balancing TCP traffic across origin pools",
-			required: ["name", "namespace"],
-			oneof_groups: [
-				{
-					fields: [
-						"advertise_custom",
-						"advertise_on_public",
-						"advertise_on_public_default_vip",
-						"do_not_advertise",
-					],
-				},
-			],
-			server_defaults: [
-				"dns_volterra_managed",
-				"idle_timeout",
-				"hash_policy_choice_round_robin",
-				"no_sni",
-				"retract_cluster",
-				"service_policies_from_namespace",
-				"tcp",
-			],
+			required: ["name", "namespace", "origin_pools"],
 			minimal_config:
-				'resource "xcsh_tcp_loadbalancer" "example" {\n  name      = "example-tcp-loadbalancer"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  listen_port = 8443\n\n  // One of the arguments from this list "advertise_custom advertise_on_public advertise_on_public_default_vip do_not_advertise" must be set\n\n  advertise_on_public_default_vip {}\n\n  origin_pools_weights {\n    pool {\n      name      = "example-tcp-pool"\n      namespace = "staging"\n    }\n    weight = 1\n  }\n\n  dns_volterra_managed = true\n\n  retract_cluster {}\n}',
+				'resource "xcsh_tcp_loadbalancer" "example" {\n  name      = "example-tcp-loadbalancer"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: ["namespace", "origin_pool"],
 			},
@@ -1674,7 +1570,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Tenant configuration specification. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_tenant_configuration" "example" {\n  name      = "example-tenant-configuration"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  basic_configuration {\n  }\n  brute_force_detection {\n  }\n  brute_force_detection_settings {\n  }\n}',
+				'resource "xcsh_tenant_configuration" "example" {\n  name      = "example-tenant-configuration"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1685,7 +1581,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Trusted certificate authority list management",
 			required: ["name", "namespace", "trusted_ca_url"],
 			minimal_config:
-				'resource "xcsh_trusted_ca_list" "example" {\n  name      = "example-trusted-ca-list"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  trusted_ca_url = "string:///LS0tLS1CRUdJTi..."\n}',
+				'resource "xcsh_trusted_ca_list" "example" {\n  name      = "example-trusted-ca-list"\n  namespace = "staging"\n\n  trusted_ca_url = "example-value"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1696,7 +1592,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Tunnel in a given namespace. If one already exist it will give a error",
 			required: ["name", "namespace", "tunnel_type"],
 			minimal_config:
-				'resource "xcsh_tunnel" "example" {\n  name      = "example-tunnel"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  tunnel_type = "IPSEC_PSK"\n}',
+				'resource "xcsh_tunnel" "example" {\n  name      = "example-tunnel"\n  namespace = "staging"\n\n  tunnel_type = "IPSEC_PSK"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1707,7 +1603,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Load balancing UDP traffic across origin pools",
 			required: ["name", "namespace", "dns_volterra_managed", "enable_per_packet_load_balancing", "idle_timeout"],
 			minimal_config:
-				'resource "xcsh_udp_loadbalancer" "example" {\n  name      = "example-udp-loadbalancer"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  domains                          = ["dns.example.com"]\n  listen_port                      = 53\n  idle_timeout                     = 30000\n  enable_per_packet_load_balancing = true\n\n  dns_volterra_managed = true\n\n  advertise_on_public_default_vip {}\n}',
+				'resource "xcsh_udp_loadbalancer" "example" {\n  name      = "example-udp-loadbalancer"\n  namespace = "staging"\n\n  domains                          = ["example-value"]\n  dns_volterra_managed             = true\n  enable_per_packet_load_balancing = true\n  idle_timeout                     = 1\n}',
 			dependencies: {
 				requires: ["namespace", "origin_pool"],
 			},
@@ -1718,7 +1614,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "New USB policy object",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_usb_policy" "example" {\n  name      = "example-usb-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  allowed_devices {\n  }\n}',
+				'resource "xcsh_usb_policy" "example" {\n  name      = "example-usb-policy"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1727,9 +1623,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		user_identification: {
 			category: "security",
 			description: "User_identification creates a new object in the storage backend for metadata.namespace",
-			required: ["name", "namespace"],
+			required: ["name", "namespace", "rules"],
 			minimal_config:
-				'resource "xcsh_user_identification" "example" {\n  name      = "example-user-identification"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  rules {\n    client_ip {}\n  }\n}',
+				'resource "xcsh_user_identification" "example" {\n  name      = "example-user-identification"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1750,7 +1646,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				"proxy",
 			],
 			minimal_config:
-				'resource "xcsh_virtual_host" "example" {\n  name      = "example-virtual-host"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  domains                     = ["app.example.com"]\n  proxy                       = "DNS_PROXY"\n  idle_timeout                = 30000\n  connection_idle_timeout     = 120000\n  max_request_header_size     = 32768\n  add_location                = false\n  disable_dns_resolve         = false\n  disable_default_error_pages = false\n  request_headers_to_remove   = []\n  response_headers_to_remove  = []\n  request_cookies_to_remove   = []\n  response_cookies_to_remove  = []\n}',
+				'resource "xcsh_virtual_host" "example" {\n  name      = "example-virtual-host"\n  namespace = "staging"\n\n  domains                     = ["example-value"]\n  request_cookies_to_remove   = ["example-value"]\n  request_headers_to_remove   = ["example-value"]\n  response_cookies_to_remove  = ["example-value"]\n  response_headers_to_remove  = ["example-value"]\n  add_location                = true\n  connection_idle_timeout     = 1\n  disable_default_error_pages = true\n  disable_dns_resolve         = true\n  idle_timeout                = 1\n  max_request_header_size     = 1\n  proxy                       = "UDP_PROXY"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1761,7 +1657,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Virtual_k8s will create the object in the storage backend for namespace metadata.namespace",
 			required: ["name", "namespace"],
 			minimal_config:
-				'resource "xcsh_virtual_k8s" "example" {\n  name      = "example-virtual-k8s"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  default_flavor_ref {\n  }\n  disabled {\n  }\n  isolated {\n  }\n}',
+				'resource "xcsh_virtual_k8s" "example" {\n  name      = "example-virtual-k8s"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1770,9 +1666,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		virtual_network: {
 			category: "networking",
 			description: "Virtual network in given namespace",
-			required: ["name", "namespace", "legacy_type"],
+			required: ["name", "legacy_type"],
 			minimal_config:
-				'resource "xcsh_virtual_network" "example" {\n  name      = "example-virtual-network"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  legacy_type = "VIRTUAL_NETWORK_SITE_LOCAL"\n}',
+				'resource "xcsh_virtual_network" "example" {\n  name      = "example-virtual-network"\n  namespace = "system"\n\n  legacy_type = "VIRTUAL_NETWORK_SITE_LOCAL"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1781,9 +1677,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		virtual_site: {
 			category: "sites",
 			description: "Virtual site object in given namespace",
-			required: ["name", "namespace", "site_type"],
+			required: ["name", "namespace", "site_type", "site_selector"],
 			minimal_config:
-				'resource "xcsh_virtual_site" "example" {\n  name      = "example-virtual-site"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  site_type = "CUSTOMER_EDGE"\n\n  site_selector {\n    expressions = ["region in (us-west-2, us-east-1)"]\n  }\n}',
+				'resource "xcsh_virtual_site" "example" {\n  name      = "example-virtual-site"\n  namespace = "staging"\n\n  site_type = "INVALID"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1794,7 +1690,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Deploying Volterra stack sites for edge computing",
 			required: ["name", "namespace", "address", "volterra_certified_hw"],
 			minimal_config:
-				'resource "xcsh_voltstack_site" "example" {\n  name      = "example-voltstack-site"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  volterra_certified_hw = "kvm-voltstack-combo"\n  worker_nodes          = []\n  address               = "123 Main St, Example City, EX 12345"\n\n  k8s_cluster {\n    name      = "example-k8s-cluster"\n    namespace = "staging"\n  }\n}',
+				'resource "xcsh_voltstack_site" "example" {\n  name      = "example-voltstack-site"\n  namespace = "staging"\n\n  volterra_certified_hw = "example-value"\n  worker_nodes          = ["example-value"]\n  address               = "example-value"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1803,19 +1699,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		waf_exclusion_policy: {
 			category: "security",
 			description: "WAF exclusion policy",
-			required: ["name", "namespace"],
-			oneof_groups: [
-				{
-					parent: "waf_exclusion_rules",
-					fields: ["any_domain", "exact_value", "suffix_value"],
-				},
-				{
-					parent: "waf_exclusion_rules",
-					fields: ["any_path", "path_prefix", "path_regex"],
-				},
-			],
+			required: ["name", "namespace", "waf_exclusion_rules"],
 			minimal_config:
-				'resource "xcsh_waf_exclusion_policy" "example" {\n  name      = "example-waf-exclusion-policy"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  waf_exclusion_rules {\n    // One of the arguments from this list "any_domain exact_value suffix_value" must be set\n\n    any_domain {}\n\n    // One of the arguments from this list "any_path path_prefix path_regex" must be set\n\n    any_path {}\n  }\n}',
+				'resource "xcsh_waf_exclusion_policy" "example" {\n  name      = "example-waf-exclusion-policy"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1825,13 +1711,8 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			category: "kubernetes",
 			description: "Workload. configuration",
 			required: ["name", "namespace"],
-			oneof_groups: [
-				{
-					fields: ["job", "service", "stateful_service"],
-				},
-			],
 			minimal_config:
-				'resource "xcsh_workload" "example" {\n  name      = "example-workload"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  // One of the arguments from this list "job service stateful_service" must be set\n\n  service {\n    containers {\n      name = "web"\n      image {\n        name        = "nginx"\n        pull_policy = "IMAGE_PULL_POLICY_ALWAYS"\n        public {}\n      }\n    }\n    deploy_options {\n      default_virtual_sites {}\n    }\n  }\n}',
+				'resource "xcsh_workload" "example" {\n  name      = "example-workload"\n  namespace = "staging"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1842,7 +1723,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Workload_flavor",
 			required: ["name", "namespace", "ephemeral_storage", "memory", "vcpus"],
 			minimal_config:
-				'resource "xcsh_workload_flavor" "example" {\n  name      = "example-workload-flavor"\n  namespace = "staging"\n\n  labels = {\n    environment = "production"\n    managed_by  = "terraform"\n  }\n\n  annotations = {\n    "owner" = "platform-team"\n  }\n\n  vcpus             = 1\n  memory            = "1024"\n  ephemeral_storage = "1024"\n}',
+				'resource "xcsh_workload_flavor" "example" {\n  name      = "example-workload-flavor"\n  namespace = "staging"\n\n  ephemeral_storage = "example-value"\n  memory            = "example-value"\n  vcpus             = 1\n}',
 			dependencies: {
 				requires: [],
 			},

--- a/packages/natives/npm/darwin-arm64/package.json
+++ b/packages/natives/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-darwin-arm64",
-	"version": "19.63.9",
+	"version": "19.64.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (macOS arm64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-x64/package.json
+++ b/packages/natives/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-darwin-x64",
-	"version": "19.63.9",
+	"version": "19.64.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (macOS x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-arm64-gnu/package.json
+++ b/packages/natives/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-linux-arm64-gnu",
-	"version": "19.63.9",
+	"version": "19.64.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Linux arm64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-x64-gnu/package.json
+++ b/packages/natives/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-linux-x64-gnu",
-	"version": "19.63.9",
+	"version": "19.64.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Linux x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/win32-x64-msvc/package.json
+++ b/packages/natives/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-win32-x64-msvc",
-	"version": "19.63.9",
+	"version": "19.64.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Windows x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives",
-	"version": "19.63.9",
+	"version": "19.64.0",
 	"description": "Native Rust bindings for grep, clipboard, image processing, syntax highlighting, PTY, and shell operations via N-API",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",
@@ -56,11 +56,11 @@
 		}
 	},
 	"optionalDependencies": {
-		"@f5-sales-demo/pi-natives-linux-x64-gnu": "19.63.9",
-		"@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.63.9",
-		"@f5-sales-demo/pi-natives-darwin-x64": "19.63.9",
-		"@f5-sales-demo/pi-natives-darwin-arm64": "19.63.9",
-		"@f5-sales-demo/pi-natives-win32-x64-msvc": "19.63.9"
+		"@f5-sales-demo/pi-natives-linux-x64-gnu": "19.64.0",
+		"@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.64.0",
+		"@f5-sales-demo/pi-natives-darwin-x64": "19.64.0",
+		"@f5-sales-demo/pi-natives-darwin-arm64": "19.64.0",
+		"@f5-sales-demo/pi-natives-win32-x64-msvc": "19.64.0"
 	},
 	"files": [
 		"native",

--- a/packages/resource-management/package.json
+++ b/packages/resource-management/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-resource-management",
-	"version": "19.63.9",
+	"version": "19.64.0",
 	"description": "Shared resource management for F5 XC manifest parsing, validation, diff, and CRUD operations",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Robin Mordasiewicz",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/xcsh-stats",
-	"version": "19.63.9",
+	"version": "19.64.0",
 	"description": "Local observability dashboard for pi AI usage statistics",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/swarm-extension/package.json
+++ b/packages/swarm-extension/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/swarm-extension",
-	"version": "19.63.9",
+	"version": "19.64.0",
 	"description": "Swarm orchestration extension for xcsh",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Derek Rynd",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-tui",
-	"version": "19.63.9",
+	"version": "19.64.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-utils",
-	"version": "19.63.9",
+	"version": "19.64.0",
 	"description": "Shared utilities for pi packages",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",


### PR DESCRIPTION
Automated release PR generated by `scripts/release.ts`.

Bumps every public package and the Cargo workspace to `v19.64.0` and updates CHANGELOGs for the releasable commits since the last tag.

Once this PR squash-merges to `main`, `.github/workflows/tag-on-version-bump.yml` pushes the `v19.64.0` git tag, which triggers the downstream release chain (build → sign → publish).

_No commit list captured (manual invocation)._

See `docs-control`'s onboarding note "Release automation: release PR pattern" for the governance rationale.