### PR TITLE
feat(bridge): set_host_tools_error nack for malformed host-tool registration (#2072)

### DIFF
--- a/packages/coding-agent/src/browser/capabilities.generated.ts
+++ b/packages/coding-agent/src/browser/capabilities.generated.ts
@@ -828,6 +828,7 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 				"chat_tool_notice",
 				"set_host_tools",
 				"set_host_tools_ack",
+				"set_host_tools_error",
 				"host_tool_call",
 				"host_tool_update",
 				"host_tool_result",

--- a/packages/coding-agent/src/browser/capabilities.json
+++ b/packages/coding-agent/src/browser/capabilities.json
@@ -736,6 +736,7 @@
         "chat_tool_notice",
         "set_host_tools",
         "set_host_tools_ack",
+        "set_host_tools_error",
         "host_tool_call",
         "host_tool_update",
         "host_tool_result",

--- a/packages/coding-agent/src/browser/chat-conformance.json
+++ b/packages/coding-agent/src/browser/chat-conformance.json
@@ -343,6 +343,19 @@
         }
       }
     },
+    "set_host_tools_error": {
+      "type": "object",
+      "required": ["type", "error"],
+      "properties": {
+        "type": {
+          "const": "set_host_tools_error",
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
     "host_tool_call": {
       "type": "object",
       "required": ["type", "id", "toolCallId", "toolName", "arguments"],
@@ -695,6 +708,10 @@
       "set_host_tools_ack": {
         "type": "set_host_tools_ack",
         "toolNames": ["office_read_range"]
+      },
+      "set_host_tools_error": {
+        "type": "set_host_tools_error",
+        "error": "Host tool \"office_read_range\" must provide a non-empty description"
       },
       "host_tool_call": {
         "type": "host_tool_call",

--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -23,6 +23,7 @@ import {
 	type PageContextSnapshot,
 	type SetHostTools,
 	type SetHostToolsAck,
+	type SetHostToolsError,
 } from "./chat-protocol";
 import { CONSOLE_ROUTES } from "./console-routes.generated";
 import type { BridgeServer } from "./extension-bridge";
@@ -268,13 +269,22 @@ export class ChatHandler {
 	 * await registration before its first prompt. Mirrors the stdio `set_host_tools`
 	 * command handler (rpc-mode.ts): normalize → bridge.setTools → refreshRpcHostTools. */
 	async #handleSetHostTools(msg: SetHostTools): Promise<void> {
-		const tools = normalizeHostToolDefinitions(msg.tools);
-		const rpcTools = this.#hostToolBridge.setTools(tools);
-		await this.#session.refreshRpcHostTools(rpcTools);
-		this.#server.send({
-			type: "set_host_tools_ack",
-			toolNames: tools.map(tool => tool.name),
-		} satisfies SetHostToolsAck);
+		try {
+			const tools = normalizeHostToolDefinitions(msg.tools);
+			const rpcTools = this.#hostToolBridge.setTools(tools);
+			await this.#session.refreshRpcHostTools(rpcTools);
+			this.#server.send({
+				type: "set_host_tools_ack",
+				toolNames: tools.map(tool => tool.name),
+			} satisfies SetHostToolsAck);
+		} catch (err) {
+			// Nack instead of throwing (stdio parity — rpc-mode nacks): a client
+			// awaiting set_host_tools_ack would otherwise hang on malformed input.
+			this.#server.send({
+				type: "set_host_tools_error",
+				error: err instanceof Error ? err.message : String(err),
+			} satisfies SetHostToolsError);
+		}
 	}
 
 	#handleChatStop(stop: { id: string }): void {

--- a/packages/coding-agent/src/browser/chat-protocol.ts
+++ b/packages/coding-agent/src/browser/chat-protocol.ts
@@ -168,6 +168,14 @@ export interface SetHostToolsAck {
 	toolNames: string[];
 }
 
+/** Outbound: nacks a `set_host_tools` registration that failed to normalize (bad
+ * definition, name conflict). Emitted instead of the ack so a client awaiting
+ * registration gets a clear error rather than hanging (stdio-parity nack). */
+export interface SetHostToolsError {
+	type: "set_host_tools_error";
+	error: string;
+}
+
 // ---------------------------------------------------------------------------
 // Validators
 // ---------------------------------------------------------------------------

--- a/packages/coding-agent/test/browser/chat-handler.host-tools.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.host-tools.test.ts
@@ -169,4 +169,21 @@ describe("ChatHandler host-tool wiring (#2046 A3)", () => {
 
 		await expect(execution).rejects.toThrow(/bridge disconnected/i);
 	});
+
+	it("(6) malformed set_host_tools emits set_host_tools_error (nack), never an ack", async () => {
+		const { server, session } = makeHandler();
+		// A tool with no description → normalizeHostToolDefinitions throws. Without a
+		// nack, a client awaiting set_host_tools_ack would hang forever.
+		server.emit({ type: "set_host_tools", tools: [{ name: "bad", parameters: {} }] });
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(server.ofType("set_host_tools_ack")).toHaveLength(0);
+		const errs = server.ofType("set_host_tools_error");
+		expect(errs).toHaveLength(1);
+		expect(typeof errs[0].error).toBe("string");
+		expect(errs[0].error).toMatch(/description/i);
+		// Registration never happened, so the prior tool set is untouched.
+		expect(session.refreshedTools).toBeNull();
+	});
 });


### PR DESCRIPTION
Closes #2072.

## Problem

The WS host-tool channel has `set_host_tools` → `set_host_tools_ack`, but no failure path. `ChatHandler.#handleSetHostTools` is fire-and-forget, so when `normalizeHostToolDefinitions` throws on malformed tool definitions, it becomes an **unhandled rejection** and a client `await`ing `set_host_tools_ack` **hangs forever**. The stdio RPC path already nacks a bad `set_host_tools`; this brings the WS path to parity.

## Change

- `chat-protocol.ts`: `SetHostToolsError { type: 'set_host_tools_error'; error: string }` — the 7th host-tool message (contract stays `1.8.0`, additive within the channel).
- `chat-handler.ts`: wrap `#handleSetHostTools` in try/catch; on failure emit `set_host_tools_error` (with the thrown message) instead of throwing.
- Re-vendor `capabilities.json` + `capabilities.generated.ts` + `chat-conformance.json` from the extension source of truth (companion **f5-sales-demo/xcsh-chrome-extension#285**).

## Testing

- New handler test (6): a malformed `set_host_tools` emits exactly one `set_host_tools_error`, **never** an ack, and leaves the registered tool set untouched. TDD — red before the try/catch, green after.
- Conformance test validates the new `set_host_tools_error` schema + golden automatically; drift guard + version-equality pass.
- `bun test test/browser/` → 260 pass / 0 fail; `tsgo` + Biome clean.

Completes the xcsh-actionable items of #2072. The remaining item 4 (transport `host_tool_call` dispatch + registering Office.js document tools) is **office-xcsh Phase 5** — downstream-consumer work in a different repo.

⚠️ Merge order: land the extension PR (#285) first so the vendored artifacts trace to the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)