### PR TITLE
feat(bridge): runtime provider configuration frame (configure/configure_ack/configure_error) (#2095)

### DIFF
--- a/packages/coding-agent/src/browser/capabilities.generated.ts
+++ b/packages/coding-agent/src/browser/capabilities.generated.ts
@@ -26,7 +26,7 @@ export interface ExtensionCapabilities {
 
 export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 	"version": "0.1.0",
-	"contractVersion": "1.8.0",
+	"contractVersion": "1.9.0",
 	"multiPortDiscovery": true,
 	"protocol": "tool_request/result",
 	"tools": [
@@ -832,7 +832,10 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 				"host_tool_call",
 				"host_tool_update",
 				"host_tool_result",
-				"host_tool_cancel"
+				"host_tool_cancel",
+				"configure",
+				"configure_ack",
+				"configure_error"
 			],
 			"description": "User ↔ xcsh chat over the bridge. The extension side panel sends chat_request (with mode and page-context snapshot); xcsh streams chat_delta tokens then a terminal chat_done (with reference links) or chat_error. Chat ids are prefixed \"c-\". Tool calls during a turn use the normal tool_request flow. chat_stop halts a streaming response. chat_tool_notice is emitted by the EXTENSION (the service worker) to the panel as a best-effort UI signal when a tool runs during a turn — it is NOT sent by xcsh; xcsh must not produce it to avoid double-rendering in the panel.",
 			"promptHints": {
@@ -852,6 +855,6 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 	}
 };
 
-export const EXTENSION_CONTRACT_VERSION = "1.8.0";
+export const EXTENSION_CONTRACT_VERSION = "1.9.0";
 
 export const EXTENSION_TOOL_NAMES: readonly string[] = ["ping","capabilities","reload","debug_exec","detach","set_bridge_port","navigate","login","scroll_to","resize_window","tabs_list","tabs_create","tabs_close","click","click_element","click_xy","type_text","form_input","key_press","select_option","label_select","file_upload","read_ax","get_page_text","query_dom","find","wait_for","assert_text","screenshot","read_console","read_network","diag_suspension","diag_bridges","diag_activation","diag_ttft","capture_login_flow","wait_for_api_response","get_page_context","javascript_tool","browser_batch","set_explain_mode","annotate"];

--- a/packages/coding-agent/src/browser/capabilities.json
+++ b/packages/coding-agent/src/browser/capabilities.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "contractVersion": "1.8.0",
+  "contractVersion": "1.9.0",
   "multiPortDiscovery": true,
   "protocol": "tool_request/result",
   "tools": [
@@ -740,7 +740,10 @@
         "host_tool_call",
         "host_tool_update",
         "host_tool_result",
-        "host_tool_cancel"
+        "host_tool_cancel",
+        "configure",
+        "configure_ack",
+        "configure_error"
       ],
       "description": "User ↔ xcsh chat over the bridge. The extension side panel sends chat_request (with mode and page-context snapshot); xcsh streams chat_delta tokens then a terminal chat_done (with reference links) or chat_error. Chat ids are prefixed \"c-\". Tool calls during a turn use the normal tool_request flow. chat_stop halts a streaming response. chat_tool_notice is emitted by the EXTENSION (the service worker) to the panel as a best-effort UI signal when a tool runs during a turn — it is NOT sent by xcsh; xcsh must not produce it to avoid double-rendering in the panel.",
       "promptHints": {

--- a/packages/coding-agent/src/browser/chat-conformance.json
+++ b/packages/coding-agent/src/browser/chat-conformance.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": "1.8.0",
+  "contractVersion": "1.9.0",
   "schemas": {
     "chat_request": {
       "type": "object",
@@ -349,6 +349,52 @@
       "properties": {
         "type": {
           "const": "set_host_tools_error",
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "configure": {
+      "type": "object",
+      "required": ["type", "token"],
+      "properties": {
+        "type": {
+          "const": "configure",
+          "type": "string"
+        },
+        "baseUrl": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model": {
+          "type": "string"
+        }
+      }
+    },
+    "configure_ack": {
+      "type": "object",
+      "required": ["type", "model"],
+      "properties": {
+        "type": {
+          "const": "configure_ack",
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        }
+      }
+    },
+    "configure_error": {
+      "type": "object",
+      "required": ["type", "error"],
+      "properties": {
+        "type": {
+          "const": "configure_error",
           "type": "string"
         },
         "error": {
@@ -713,6 +759,24 @@
         "type": "set_host_tools_error",
         "error": "Host tool \"office_read_range\" must provide a non-empty description"
       },
+      "configure": {
+        "type": "configure",
+        "baseUrl": "https://f5ai.pd.f5net.com/anthropic",
+        "token": "sk-example-token-123",
+        "model": "claude-opus-4-8"
+      },
+      "configure_no_baseUrl": {
+        "type": "configure",
+        "token": "sk-example-token-123"
+      },
+      "configure_ack": {
+        "type": "configure_ack",
+        "model": "claude-opus-4-8"
+      },
+      "configure_error": {
+        "type": "configure_error",
+        "error": "No model anthropic/claude-opus-4-8 available"
+      },
       "host_tool_call": {
         "type": "host_tool_call",
         "id": "7295551234567890",
@@ -932,6 +996,23 @@
           "result": {
             "content": "nope"
           }
+        }
+      },
+      {
+        "schema": "configure",
+        "why": "token missing",
+        "value": {
+          "type": "configure",
+          "baseUrl": "https://f5ai.pd.f5net.com/anthropic",
+          "model": "claude-opus-4-8"
+        }
+      },
+      {
+        "schema": "configure",
+        "why": "token empty",
+        "value": {
+          "type": "configure",
+          "token": ""
         }
       }
     ]

--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -310,13 +310,26 @@ export class ChatHandler {
 			const [provider, defaultModelId] = DEFAULT_MODEL_ROLE.split("/");
 
 			if (msg.baseUrl) {
+				// SSRF guard: only an `https:` gateway URL may be dialed. Validate BEFORE
+				// registerProvider so a bad URL becomes a configure_error nack (never a
+				// silently-ignored frame that hangs the client). We deliberately do NOT
+				// block loopback/RFC-1918 targets: an operator-chosen INTERNAL gateway is
+				// the whole point (the F5 LiteLLM gateway, and the claude-office CORS proxy
+				// at https://127-0-0-1.local-ip.sh:8443 are legitimate targets).
+				//
+				// Accepted residual (user-requested tradeoff): the operator points xcsh at
+				// THEIR OWN gateway with THEIR OWN token over a loopback-only, TLS,
+				// Origin-checked bridge (extension-bridge `isAllowedBridgeOrigin`), https is
+				// enforced here, and the token is session-only (never persisted to disk).
+				const baseUrl = requireHttpsUrl(msg.baseUrl);
+
 				// baseUrl + apiKey, no models[] → sets the in-memory runtime API key AND
 				// overrides the existing provider models' baseUrl/headers (reusing their
 				// metadata). Nothing is persisted to disk.
 				registry.registerProvider(
 					provider,
 					{
-						baseUrl: msg.baseUrl,
+						baseUrl,
 						apiKey: msg.token,
 						headers: { "anthropic-beta": "context-1m-2025-08-07" },
 					},
@@ -379,6 +392,24 @@ export class ChatHandler {
 		}
 		this.#activeChats.clear();
 	}
+}
+
+/** SSRF guard for the `configure` frame's optional gateway `baseUrl`: the URL must
+ * parse and use `https:`. Returns the ORIGINAL string unchanged on success (no
+ * normalization — the operator's exact gateway path is preserved); throws (→ becomes
+ * a `configure_error` nack) for a malformed or non-https URL. Loopback/private hosts
+ * are intentionally NOT blocked — the target is an operator-chosen internal gateway. */
+export function requireHttpsUrl(raw: string): string {
+	let parsed: URL;
+	try {
+		parsed = new URL(raw);
+	} catch {
+		throw new Error(`configure baseUrl is not a valid URL: ${raw}`);
+	}
+	if (parsed.protocol !== "https:") {
+		throw new Error(`configure baseUrl must use https (got "${parsed.protocol}")`);
+	}
+	return raw;
 }
 
 /** Best-effort classification of an upstream/provider error message into a

--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessage } from "@f5-sales-demo/pi-ai";
+import { DEFAULT_MODEL_ROLE } from "../config/settings-schema";
 import {
 	isRpcHostToolResult,
 	isRpcHostToolUpdate,
@@ -14,11 +15,15 @@ import {
 	type ChatKeepalive,
 	type ChatReference,
 	type ChatRequest,
+	type Configure,
+	type ConfigureAck,
+	type ConfigureError,
 	type HostToolResult,
 	type HostToolUpdate,
 	type InteractionMode,
 	isChatRequest,
 	isChatStop,
+	isConfigure,
 	isSetHostTools,
 	type PageContextSnapshot,
 	type SetHostTools,
@@ -92,6 +97,9 @@ export class ChatHandler {
 			// Host-tool channel (#2046): register client tools, then route the client's
 			// result/update frames back to the correlated pending call in the bridge.
 			else if (isSetHostTools(msg)) this.#handleSetHostTools(msg as unknown as SetHostTools);
+			// Provider configuration channel (#2095): swap the LLM provider/model in
+			// session memory at runtime (never persisted), then ack or nack.
+			else if (isConfigure(msg)) this.#handleConfigure(msg as unknown as Configure);
 			else if (isRpcHostToolResult(msg)) this.#hostToolBridge.handleResult(msg as unknown as HostToolResult);
 			else if (isRpcHostToolUpdate(msg)) this.#hostToolBridge.handleUpdate(msg as unknown as HostToolUpdate);
 		});
@@ -284,6 +292,57 @@ export class ChatHandler {
 				type: "set_host_tools_error",
 				error: err instanceof Error ? err.message : String(err),
 			} satisfies SetHostToolsError);
+		}
+	}
+
+	/** Configure the LLM provider at runtime from a bridge client (#2095), then ack
+	 * with the selected model so the client can await it before its first prompt.
+	 * SESSION/RUNTIME MEMORY ONLY — the token is never written to models.yml or the
+	 * SQLite credential store. Mirrors #handleSetHostTools's try/ack-or-nack shape;
+	 * never throws out of the handler (a nack keeps a waiting client from hanging).
+	 *
+	 * The baked F5 gateway registers its models under the "anthropic" provider
+	 * (DEFAULT_MODEL_ROLE = "anthropic/claude-opus-4-8"), so that is the provider we
+	 * (re)configure here. */
+	async #handleConfigure(msg: Configure): Promise<void> {
+		try {
+			const registry = this.#session.modelRegistry;
+			const [provider, defaultModelId] = DEFAULT_MODEL_ROLE.split("/");
+
+			if (msg.baseUrl) {
+				// baseUrl + apiKey, no models[] → sets the in-memory runtime API key AND
+				// overrides the existing provider models' baseUrl/headers (reusing their
+				// metadata). Nothing is persisted to disk.
+				registry.registerProvider(
+					provider,
+					{
+						baseUrl: msg.baseUrl,
+						apiKey: msg.token,
+						headers: { "anthropic-beta": "context-1m-2025-08-07" },
+					},
+					"office-configure",
+				);
+			} else {
+				// Key-only: reuse the baked F5 gateway; set just the non-persistent runtime key.
+				registry.authStorage.setRuntimeApiKey(provider, msg.token);
+			}
+
+			const modelId = msg.model ?? this.#session.model?.id ?? defaultModelId;
+			const model = registry.find(provider, modelId);
+			if (!model) {
+				throw new Error(`No model ${provider}/${modelId} available`);
+			}
+			// setModel validates the API key and throws if missing → becomes configure_error.
+			await this.#session.setModel(model);
+
+			this.#server.send({ type: "configure_ack", model: model.id } satisfies ConfigureAck);
+		} catch (err) {
+			// Nack instead of throwing (set_host_tools parity): a client awaiting
+			// configure_ack would otherwise hang on a bad frame or missing key.
+			this.#server.send({
+				type: "configure_error",
+				error: err instanceof Error ? err.message : String(err),
+			} satisfies ConfigureError);
 		}
 	}
 

--- a/packages/coding-agent/src/browser/chat-protocol.ts
+++ b/packages/coding-agent/src/browser/chat-protocol.ts
@@ -177,6 +177,43 @@ export interface SetHostToolsError {
 }
 
 // ---------------------------------------------------------------------------
+// Provider configuration channel (contract 1.9.0)
+//
+// Lets a bridge client (the Chrome extension, the office-xcsh add-in) configure
+// xcsh's LLM provider at runtime — after the socket is connected — without
+// restarting the worker and WITHOUT persisting the token to disk. xcsh stays the
+// intelligence engine; this only swaps the provider credentials/model in session
+// memory. Single config in-flight, so — like `set_host_tools` — there is no `id`
+// correlation field. Mirrors the set_host_tools ack/nack shape exactly.
+// ---------------------------------------------------------------------------
+
+/** Inbound: the client configures the LLM provider. `token` is required and
+ * non-empty. `baseUrl` (optional) is an Anthropic-compatible gateway base; when
+ * omitted, the baked F5 gateway is reused and only the runtime API key is set.
+ * `model` (optional) selects the model id; when omitted, the session default is
+ * kept. The token lives in session/runtime memory only — never written to disk. */
+export interface Configure {
+	type: "configure";
+	baseUrl?: string;
+	token: string;
+	model?: string;
+}
+
+/** Outbound: acks a `configure` with the model id actually selected, so the
+ * client can await configuration before its first prompt. */
+export interface ConfigureAck {
+	type: "configure_ack";
+	model: string;
+}
+
+/** Outbound: nacks a `configure` that failed (bad frame, unknown model, missing
+ * API key). Emitted instead of the ack so a client awaiting it never hangs. */
+export interface ConfigureError {
+	type: "configure_error";
+	error: string;
+}
+
+// ---------------------------------------------------------------------------
 // Validators
 // ---------------------------------------------------------------------------
 
@@ -200,6 +237,18 @@ export function isChatStop(msg: Record<string, unknown>): boolean {
 
 export function isSetHostTools(msg: Record<string, unknown>): boolean {
 	return msg.type === "set_host_tools" && Array.isArray(msg.tools);
+}
+
+/** True for a well-formed `configure` frame: a non-empty string `token` is required;
+ * `baseUrl`/`model`, when present, must be strings. */
+export function isConfigure(msg: Record<string, unknown>): boolean {
+	return (
+		msg.type === "configure" &&
+		typeof msg.token === "string" &&
+		msg.token.length > 0 &&
+		(msg.baseUrl === undefined || typeof msg.baseUrl === "string") &&
+		(msg.model === undefined || typeof msg.model === "string")
+	);
 }
 
 /** Delegates to the neutral guard, which requires `result.content` to be an array. */

--- a/packages/coding-agent/src/browser/extension-bridge.ts
+++ b/packages/coding-agent/src/browser/extension-bridge.ts
@@ -398,6 +398,7 @@ export class BridgeServer {
 					contextBound: info.contextBound,
 					pid: process.pid,
 					wssPort: this.wssPort,
+					canConfigureProvider: true,
 				}),
 			);
 		} else {

--- a/packages/coding-agent/test/browser/chat-conformance.test.ts
+++ b/packages/coding-agent/test/browser/chat-conformance.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "bun:test";
 import {
 	isChatRequest,
 	isChatStop,
+	isConfigure,
 	isHostToolResult,
 	isHostToolUpdate,
 	isSetHostTools,
@@ -103,6 +104,24 @@ describe("chat-conformance: xcsh host-tool guards accept/reject the goldens", ()
 		for (const { schema: schemaKey, value } of invalidExamples) {
 			if (schemaKey === "host_tool_result") {
 				expect(isHostToolResult(value as Record<string, unknown>)).toBe(false);
+			}
+		}
+	});
+});
+
+describe("chat-conformance: xcsh configure guard accepts/rejects the goldens", () => {
+	it("isConfigure accepts the configure golden (baseUrl + token + model)", () => {
+		expect(isConfigure(validExamples.configure as Record<string, unknown>)).toBe(true);
+	});
+
+	it("isConfigure accepts the key-only configure golden (no baseUrl)", () => {
+		expect(isConfigure(validExamples.configure_no_baseUrl as Record<string, unknown>)).toBe(true);
+	});
+
+	it("isConfigure rejects the invalid configure goldens (missing/empty token)", () => {
+		for (const { schema: schemaKey, value } of invalidExamples) {
+			if (schemaKey === "configure") {
+				expect(isConfigure(value as Record<string, unknown>)).toBe(false);
 			}
 		}
 	});

--- a/packages/coding-agent/test/browser/chat-handler.configure.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.configure.test.ts
@@ -180,6 +180,51 @@ describe("ChatHandler configure frame (#2095)", () => {
 		expect(typeof errs[0].error).toBe("string");
 	});
 
+	it("(e) non-https baseUrl → configure_error, registerProvider never called (SSRF guard)", async () => {
+		const { server, session } = makeHandler();
+		expect(() =>
+			server.emit({ type: "configure", baseUrl: "http://evil.internal/anthropic", token: "sk-x" }),
+		).not.toThrow();
+		await flush();
+
+		expect(session.modelRegistry.registerProviderCalls).toHaveLength(0);
+		expect(session.modelRegistry.runtimeApiKeys).toHaveLength(0);
+		expect(session.setModelCalls).toHaveLength(0);
+		expect(server.ofType("configure_ack")).toHaveLength(0);
+		const errs = server.ofType("configure_error");
+		expect(errs).toHaveLength(1);
+		expect(String(errs[0].error)).toMatch(/https/i);
+	});
+
+	it("(e2) malformed baseUrl → configure_error, registerProvider never called", async () => {
+		const { server, session } = makeHandler();
+		expect(() => server.emit({ type: "configure", baseUrl: "not-a-url", token: "sk-x" })).not.toThrow();
+		await flush();
+
+		expect(session.modelRegistry.registerProviderCalls).toHaveLength(0);
+		expect(server.ofType("configure_ack")).toHaveLength(0);
+		expect(server.ofType("configure_error")).toHaveLength(1);
+	});
+
+	it("(e3) https loopback gateway (local-ip.sh) is allowed — registerProvider called", async () => {
+		const { server, session } = makeHandler();
+		// The claude-office CORS proxy is a LEGITIMATE internal target; loopback/private
+		// hosts must NOT be blocked.
+		server.emit({
+			type: "configure",
+			baseUrl: "https://127-0-0-1.local-ip.sh:8443/anthropic",
+			token: "sk-x",
+			model: "claude-opus-4-8",
+		});
+		await flush();
+
+		expect(session.modelRegistry.registerProviderCalls).toHaveLength(1);
+		expect(session.modelRegistry.registerProviderCalls[0].config.baseUrl).toBe(
+			"https://127-0-0-1.local-ip.sh:8443/anthropic",
+		);
+		expect(server.ofType("configure_ack")[0].model).toBe("claude-opus-4-8");
+	});
+
 	it("(d) missing/empty token → frame rejected (no ack, no error, no side effects)", async () => {
 		const { server, session } = makeHandler();
 		server.emit({ type: "configure", baseUrl: "https://f5ai.pd.f5net.com/anthropic" }); // no token

--- a/packages/coding-agent/test/browser/chat-handler.configure.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.configure.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "bun:test";
+import { ChatHandler } from "@f5-sales-demo/xcsh/browser/chat-handler";
+import type { BridgeServer } from "@f5-sales-demo/xcsh/browser/extension-bridge";
+import type { AgentSession } from "@f5-sales-demo/xcsh/session/agent-session";
+
+/**
+ * `configure` frame wiring tests for `ChatHandler` (runtime provider configuration,
+ * mirroring the `set_host_tools` precedent #2046).
+ *
+ * A fake `BridgeServer` captures every `send()` frame and drives the inbound
+ * `onMessage` path. A stub `AgentSession` exposes a fake `modelRegistry`
+ * (registerProvider / find / authStorage.setRuntimeApiKey) plus `setModel`, so the
+ * test can assert the session-only, non-persistent provider swap and the ack/nack.
+ */
+class FakeBridgeServer {
+	sent: Array<Record<string, unknown>> = [];
+	#onMessage: Array<(m: Record<string, unknown>) => void> = [];
+	#onDisconnected: Array<() => void> = [];
+
+	send(payload: unknown): void {
+		this.sent.push(payload as Record<string, unknown>);
+	}
+	onMessage(cb: (m: Record<string, unknown>) => void): void {
+		this.#onMessage.push(cb);
+	}
+	onDisconnected(cb: () => void): void {
+		this.#onDisconnected.push(cb);
+	}
+
+	emit(msg: Record<string, unknown>): void {
+		for (const cb of this.#onMessage) cb(msg);
+	}
+	ofType(type: string): Array<Record<string, unknown>> {
+		return this.sent.filter(frame => frame.type === type);
+	}
+}
+
+interface RegisterProviderCall {
+	providerName: string;
+	config: Record<string, unknown>;
+	sourceId?: string;
+}
+
+class FakeModelRegistry {
+	registerProviderCalls: RegisterProviderCall[] = [];
+	runtimeApiKeys: Array<{ provider: string; apiKey: string }> = [];
+	// The models this registry can resolve; provider "anthropic" is the baked F5 default.
+	models: Array<{ provider: string; id: string }> = [
+		{ provider: "anthropic", id: "claude-opus-4-8" },
+		{ provider: "anthropic", id: "claude-sonnet-4-5" },
+	];
+
+	authStorage = {
+		setRuntimeApiKey: (provider: string, apiKey: string): void => {
+			this.runtimeApiKeys.push({ provider, apiKey });
+		},
+	};
+
+	registerProvider(providerName: string, config: Record<string, unknown>, sourceId?: string): void {
+		this.registerProviderCalls.push({ providerName, config, sourceId });
+	}
+
+	find(provider: string, modelId: string): { provider: string; id: string } | undefined {
+		return this.models.find(m => m.provider === provider && m.id === modelId);
+	}
+}
+
+class FakeAgentSession {
+	setModelCalls: Array<{ provider: string; id: string }> = [];
+	isStreaming = false;
+	modelRegistry = new FakeModelRegistry();
+	// Current default model (used when `configure` omits `model`).
+	model = { provider: "anthropic", id: "claude-opus-4-8" };
+	agent = {
+		abort(): void {},
+		replaceMessages(): void {},
+	};
+	/** When set, setModel rejects — simulates a missing/invalid API key. */
+	setModelError: Error | null = null;
+
+	subscribe(): () => void {
+		return () => {};
+	}
+	async prompt(): Promise<void> {}
+	async setModel(model: { provider: string; id: string }): Promise<void> {
+		if (this.setModelError) throw this.setModelError;
+		this.setModelCalls.push(model);
+	}
+}
+
+function makeHandler(): { handler: ChatHandler; server: FakeBridgeServer; session: FakeAgentSession } {
+	const server = new FakeBridgeServer();
+	const session = new FakeAgentSession();
+	const handler = new ChatHandler(server as unknown as BridgeServer, session as unknown as AgentSession);
+	handler.attach();
+	return { handler, server, session };
+}
+
+// Flush the microtask queue so the async #handleConfigure completes.
+async function flush(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("ChatHandler configure frame (#2095)", () => {
+	it("(a) baseUrl+token+model → registerProvider with the gateway config, setModel, configure_ack", async () => {
+		const { server, session } = makeHandler();
+		server.emit({
+			type: "configure",
+			baseUrl: "https://f5ai.pd.f5net.com/anthropic",
+			token: "sk-test-123",
+			model: "claude-sonnet-4-5",
+		});
+		await flush();
+
+		expect(session.modelRegistry.registerProviderCalls).toHaveLength(1);
+		const call = session.modelRegistry.registerProviderCalls[0];
+		expect(call.providerName).toBe("anthropic");
+		expect(call.config.baseUrl).toBe("https://f5ai.pd.f5net.com/anthropic");
+		expect(call.config.apiKey).toBe("sk-test-123");
+		expect(call.config.headers).toEqual({ "anthropic-beta": "context-1m-2025-08-07" });
+		expect(call.sourceId).toBe("office-configure");
+		// No models[] → registerProvider overrides the existing anthropic models, not persisted.
+		expect(call.config.models).toBeUndefined();
+
+		expect(session.setModelCalls).toEqual([{ provider: "anthropic", id: "claude-sonnet-4-5" }]);
+
+		const acks = server.ofType("configure_ack");
+		expect(acks).toHaveLength(1);
+		expect(acks[0].model).toBe("claude-sonnet-4-5");
+		expect(server.ofType("configure_error")).toHaveLength(0);
+	});
+
+	it("(a2) model omitted → selects the session's current default model id", async () => {
+		const { server, session } = makeHandler();
+		server.emit({
+			type: "configure",
+			baseUrl: "https://f5ai.pd.f5net.com/anthropic",
+			token: "sk-test-123",
+		});
+		await flush();
+
+		expect(session.setModelCalls).toEqual([{ provider: "anthropic", id: "claude-opus-4-8" }]);
+		expect(server.ofType("configure_ack")[0].model).toBe("claude-opus-4-8");
+	});
+
+	it("(b) key-only (no baseUrl) → setRuntimeApiKey path, no registerProvider", async () => {
+		const { server, session } = makeHandler();
+		server.emit({ type: "configure", token: "sk-key-only", model: "claude-opus-4-8" });
+		await flush();
+
+		expect(session.modelRegistry.registerProviderCalls).toHaveLength(0);
+		expect(session.modelRegistry.runtimeApiKeys).toEqual([{ provider: "anthropic", apiKey: "sk-key-only" }]);
+		expect(session.setModelCalls).toEqual([{ provider: "anthropic", id: "claude-opus-4-8" }]);
+		expect(server.ofType("configure_ack")[0].model).toBe("claude-opus-4-8");
+	});
+
+	it("(c) setModel throws (missing key) → configure_error, no throw escapes, no ack", async () => {
+		const { server, session } = makeHandler();
+		session.setModelError = new Error("No API key for anthropic/claude-opus-4-8");
+		// Must not throw synchronously or asynchronously out of the handler.
+		expect(() => server.emit({ type: "configure", token: "sk-bad" })).not.toThrow();
+		await flush();
+
+		expect(server.ofType("configure_ack")).toHaveLength(0);
+		const errs = server.ofType("configure_error");
+		expect(errs).toHaveLength(1);
+		expect(errs[0].error).toBe("No API key for anthropic/claude-opus-4-8");
+	});
+
+	it("(c2) unknown model id → configure_error (find returns undefined), no throw escapes", async () => {
+		const { server, session } = makeHandler();
+		expect(() => server.emit({ type: "configure", token: "sk-x", model: "no-such-model" })).not.toThrow();
+		await flush();
+
+		expect(session.setModelCalls).toHaveLength(0);
+		expect(server.ofType("configure_ack")).toHaveLength(0);
+		const errs = server.ofType("configure_error");
+		expect(errs).toHaveLength(1);
+		expect(typeof errs[0].error).toBe("string");
+	});
+
+	it("(d) missing/empty token → frame rejected (no ack, no error, no side effects)", async () => {
+		const { server, session } = makeHandler();
+		server.emit({ type: "configure", baseUrl: "https://f5ai.pd.f5net.com/anthropic" }); // no token
+		server.emit({ type: "configure", token: "" }); // empty token
+		await flush();
+
+		expect(session.modelRegistry.registerProviderCalls).toHaveLength(0);
+		expect(session.modelRegistry.runtimeApiKeys).toHaveLength(0);
+		expect(session.setModelCalls).toHaveLength(0);
+		expect(server.ofType("configure_ack")).toHaveLength(0);
+		expect(server.ofType("configure_error")).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## What

Adds a runtime **provider-configuration** frame to the xcsh WebSocket bridge so a client (the Chrome extension, the Office add-in) can set xcsh's LLM provider **after** the socket is connected — no worker restart, no on-disk token. This is the **permanent, native home** for provider config as the Office add-in consolidates into xcsh.

New frames (contract **1.8.0 → 1.9.0**), mirroring the `set_host_tools` precedent (#2046) end to end (no `id` correlation — single config in-flight):

- Inbound `configure`: `{ type: "configure", baseUrl?: string, token: string, model?: string }` (`token` required, non-empty).
- Outbound `configure_ack`: `{ type: "configure_ack", model: string }` — the model actually selected.
- Outbound `configure_error`: `{ type: "configure_error", error: string }`.
- `hello_ack` gains `canConfigureProvider: true`.

## xcsh stays the intelligence engine

This only swaps the provider **credentials/model in session memory**. The agent loop, tools, and session are unchanged — there is **no agentless/bypass path**.

## Session-only token handling (never persisted)

`#handleConfigure` (provider id `anthropic`, from `DEFAULT_MODEL_ROLE = anthropic/claude-opus-4-8`):

- `baseUrl` provided → `modelRegistry.registerProvider("anthropic", { baseUrl, apiKey: token, headers: { "anthropic-beta": "context-1m-2025-08-07" } }, "office-configure")` — sets the in-memory runtime API key **and** overrides the existing anthropic models' baseUrl/headers (no `models[]`).
- `baseUrl` omitted → `authStorage.setRuntimeApiKey("anthropic", token)` — reuse the baked F5 gateway; non-persistent.
- Resolve model id (`msg.model` → session default → `DEFAULT_MODEL_ROLE`), `registry.find(provider, id)`, then `await session.setModel(model)` (validates the key; a throw becomes `configure_error`).
- The handler **never throws out** — it nacks with `configure_error`, so a client awaiting the ack never hangs.

The token is **never** written to `models.yml` or the SQLite credential store — session/runtime memory only.

## Security

- **SSRF guard (HIGH, fixed):** a `configure.baseUrl` is validated in `#handleConfigure` **before** `registerProvider` — it must parse and use `https:`. Malformed / non-https → `configure_error` (never an unvalidated URL passed to `registerProvider`). Loopback/RFC-1918 hosts are intentionally **not** blocked: an operator-chosen internal gateway is the whole point (the F5 LiteLLM gateway, and the claude-office CORS proxy at `https://127-0-0-1.local-ip.sh:8443`, are legitimate targets).
- **Origin authz (already closed):** the bridge already restricts the WebSocket upgrade to an allowlist via `isAllowedBridgeOrigin` (extension-bridge.ts) — the Chrome extension origin plus `https:` add-in origins under `local-ip.sh` — on a loopback-only wss listener. So a `configure` frame can only arrive over an Origin-checked, TLS, loopback connection. No additional gate needed.
- **Accepted residual (user-requested tradeoff):** the operator points xcsh at their own gateway with their own token over a loopback-only, TLS, Origin-checked bridge; https is enforced; the token is session-only.

## Tests / verification

- `chat-handler.configure.test.ts`: baseUrl+token+model → `registerProvider` + `setModel` + `configure_ack`; model-omitted → session default; key-only → `setRuntimeApiKey`; `setModel` throws → `configure_error` (no escape); unknown model → `configure_error`; empty token → `isConfigure` rejects; **non-https baseUrl → `configure_error` (no registerProvider); malformed URL → `configure_error`; https loopback gateway → allowed.**
- Conformance goldens (`chat-conformance.json`) + `capabilities.json` / regenerated `capabilities.generated.ts` (EXTENSION_CONTRACT_VERSION → 1.9.0).
- `bun run check:ts` — exit 0. `biome ci .` — exit 0. `bun test packages/coding-agent/test/browser/` — 278 pass.

Closes #2095

🤖 Generated with [Claude Code](https://claude.com/claude-code)
