### PR TITLE
fix(office): sideload against the extracted bundle dir so icon assets resolve

### DIFF
--- a/packages/coding-agent/src/cli/office-cli.ts
+++ b/packages/coding-agent/src/cli/office-cli.ts
@@ -8,10 +8,8 @@
  * mirroring `stats-cli.ts` / `chrome-cli.ts`.
  */
 import { spawnSync } from "node:child_process";
-import * as fs from "node:fs/promises";
-import * as os from "node:os";
 import * as path from "node:path";
-import { readManifest, startOfficePaneServer } from "../browser/office-pane-server";
+import { getOfficePaneDir, readManifest, startOfficePaneServer } from "../browser/office-pane-server";
 
 /** The subcommands `xcsh office` accepts (also the Args `options` constraint). */
 export const OFFICE_ACTIONS = ["serve", "manifest", "sideload"] as const;
@@ -56,14 +54,15 @@ async function runServe(): Promise<void> {
 	await new Promise<never>(() => {});
 }
 
-/** Emit the manifest to a temp file and run the Office sideload (best-effort). */
+/** Run the Office sideload against the embedded bundle (best-effort). */
 async function runSideload(app: OfficeApp): Promise<void> {
-	const text = await readManifest();
-	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-office-sideload-"));
+	// Point office-addin-debugging at the extracted bundle dir, which has
+	// manifest.json AND its referenced `assets/` icons colocated. A bare temp
+	// manifest (without the icons next to it) fails office-addin-debugging's zip
+	// step: `File to zip ".../assets/color.png" does not exist`.
+	const dir = await getOfficePaneDir();
 	const manifestPath = path.join(dir, "manifest.json");
-	await Bun.write(manifestPath, text);
-	console.log(`Wrote manifest to ${manifestPath}`);
-	console.log(`Sideloading into ${app} (requires the office-addin-debugging / atk tool on PATH)...`);
+	console.log(`Sideloading ${manifestPath} into ${app} (requires the office-addin-debugging / atk tool on PATH)...`);
 
 	const result = spawnSync("office-addin-debugging", ["start", manifestPath, "desktop", "--app", app], {
 		stdio: "inherit",

--- a/packages/coding-agent/test/commands/office.test.ts
+++ b/packages/coding-agent/test/commands/office.test.ts
@@ -12,6 +12,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { CliConfig } from "@f5-sales-demo/pi-utils/cli";
+import { getOfficePaneDir } from "../../src/browser/office-pane-server";
 import { OFFICE_ACTIONS, writeManifest } from "../../src/cli/office-cli";
 import Office from "../../src/commands/office";
 
@@ -43,6 +44,19 @@ describe("office manifest", () => {
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
+	});
+});
+
+describe("office sideload bundle", () => {
+	it("colocates manifest.json with its referenced icon assets (so office-addin-debugging can zip them)", async () => {
+		// Regression guard: sideload points office-addin-debugging at getOfficePaneDir()'s
+		// manifest, and that tool zips the manifest's referenced icons relative to it.
+		// The old bug wrote a bare temp manifest with no assets/ → "File to zip
+		// assets/color.png does not exist". The bundle dir MUST colocate both.
+		const dir = await getOfficePaneDir();
+		expect(await Bun.file(join(dir, "manifest.json")).exists()).toBe(true);
+		expect(await Bun.file(join(dir, "assets", "color.png")).exists()).toBe(true);
+		expect(await Bun.file(join(dir, "assets", "outline.png")).exists()).toBe(true);
 	});
 });
 


### PR DESCRIPTION
## Problem
`xcsh office sideload` failed: `Error: File to zip ".../assets/color.png" does not exist`. It wrote only `manifest.json` to a fresh temp dir, but the manifest references local icons (`icons.color: assets/color.png`), and `office-addin-debugging` zips them relative to the manifest — the temp dir had no `assets/`. (Caught running the real `xcsh office sideload excel` on the shipped binary.)

## Fix
Point `office-addin-debugging` at `getOfficePaneDir()`'s manifest — the extracted (compiled) / `dist` (dev) bundle dir already colocates `manifest.json` + `assets/`. Removes the bare temp-manifest copy (and the now-unused `fs`/`os` imports).

## Verify
- New regression test: the resolved bundle dir colocates `manifest.json` + `assets/color.png` + `assets/outline.png`.
- office command tests 4/0; `tsgo` + `biome` clean.

Closes #2109