### PR TITLE
fix(tui): late Kitty reply must disable the modifyOtherKeys fallback (#1454)

### DIFF
--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -304,6 +304,15 @@ export class ProcessTerminal implements Terminal {
 						clearTimeout(this.#modifyOtherKeysTimeout);
 						this.#modifyOtherKeysTimeout = undefined;
 					}
+					// A late reply (heavy first-launch startup widens the query
+					// window past the 150ms fallback) can arrive after the
+					// modifyOtherKeys fallback already committed. Kitty supersedes
+					// it, so tear the fallback down — leaving both active breaks the
+					// single-protocol encoding contract in keys.ts (#1454).
+					if (this.#modifyOtherKeysActive) {
+						this.#safeWrite("\x1b[>4;0m");
+						this.#modifyOtherKeysActive = false;
+					}
 					this.#kittyProtocolActive = true;
 					setKittyProtocolActive(true);
 					this.#safeWrite("\x1b[>7u");

--- a/packages/tui/test/terminal-response-filter.test.ts
+++ b/packages/tui/test/terminal-response-filter.test.ts
@@ -488,4 +488,32 @@ describe("Terminal response filtering — no gibberish in editor", () => {
 			terminal.stop();
 		});
 	});
+
+	describe("late Kitty reply supersedes the modifyOtherKeys fallback (#1454)", () => {
+		// On a heavy first launch (marketplace refresh + upgradeAllPlugins) the
+		// Kitty query reply can arrive AFTER the 150ms modifyOtherKeys fallback
+		// timeout has already fired. When the late reply enables Kitty it must
+		// also DISABLE the modifyOtherKeys fallback — otherwise both keyboard
+		// protocols are active at once and the terminal↔parser encoding contract
+		// (keys.ts is parameterized on a single kittyProtocolActive flag) breaks,
+		// so Ctrl+C / Ctrl+V / paste stop acting.
+		it("disables modifyOtherKeys when a Kitty reply arrives after the 150ms timeout", () => {
+			const { terminal, writes } = setupTerminal();
+
+			// Let the 150ms fallback fire: no Kitty reply yet → modifyOtherKeys on.
+			vi.advanceTimersByTime(200);
+			expect(writes.join("")).toContain("\x1b[>4;2m"); // fallback committed
+
+			writes.length = 0;
+			// Late Kitty reply arrives (terminal was slow during heavy startup).
+			process.stdin.emit("data", "\x1b[?0u");
+
+			const out = writes.join("");
+			expect(out).toContain("\x1b[>7u"); // Kitty enabled
+			expect(out).toContain("\x1b[>4;0m"); // modifyOtherKeys fallback disabled
+			expect(terminal.kittyProtocolActive).toBe(true);
+
+			terminal.stop();
+		});
+	});
 });


### PR DESCRIPTION
## Problem

Fixes #1454.

On a heavy first launch (marketplace refresh + `upgradeAllPlugins` widening the pre-interactive startup window), the Kitty keyboard-protocol query reply can arrive **after** the 150ms modifyOtherKeys fallback timeout has already fired and committed the fallback (`\x1b[>4;2m`). The Kitty-response handler in `terminal.ts` then enabled Kitty (`\x1b[>7u`) but **never tore the fallback down**, leaving *both* keyboard protocols active at once.

`keys.ts` decodes input against a single `kittyProtocolActive` flag, so a dual-active state breaks the terminal↔parser encoding contract — **Ctrl+C / Ctrl+V / paste stop acting**, which is the symptom reported in #1454.

## Root cause (verified, not assumed)

Investigated empirically against current `main`:

- The **probe-response *leak*** half of #1454 (gibberish bytes reaching the editor) is **already resolved** by #1447's de-blob `flush()` — a diagnostic harness feeding concatenated / unterminated / split probe blobs after settling leaks nothing (`leaked=""` in every case).
- The **remaining** defect is timing: a Kitty reply arriving **after** the 150ms fallback leaves modifyOtherKeys enabled alongside Kitty. Reproduced deterministically (reply at 200ms/500ms → both `\x1b[>4;2m` and `\x1b[>7u` written, no `\x1b[>4;0m`).

## Fix

When a late Kitty reply activates the protocol, disable the already-committed modifyOtherKeys fallback first (`\x1b[>4;0m` + clear the flag), mirroring the teardown in `stop()`. Kitty cleanly supersedes the fallback regardless of reply timing — no timeout-tuning guesswork.

## Test (TDD)

Added a regression test in `terminal-response-filter.test.ts`: a post-timeout Kitty reply must emit both `\x1b[>7u` and `\x1b[>4;0m` and leave exactly one protocol active. Verified RED before the fix (only `\x1b[>7u` was written), GREEN after.

## Verification

- `bun test` in `packages/tui`: **474 pass / 0 fail**.
- `bun run check:ts` (biome + tsgo, all workspaces): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
