### PR TITLE
feat(chat-ui): absorb the attachment picker into the shared Composer (Phase 4a)

### DIFF
--- a/packages/chat-ui/src/attachments/model.ts
+++ b/packages/chat-ui/src/attachments/model.ts
@@ -1,0 +1,122 @@
+/**
+ * The typed, multi-attachment model for the chat composer — the single shared
+ * home for what was previously DUPLICATED between the VS Code extension host and
+ * its webview (and mirrored ad hoc elsewhere). Every attachment carries a
+ * `content` string; the agent is text-only, so attachments serialize to labelled
+ * text blocks prepended to the user's message on submit.
+ *
+ * Framework-free + host-agnostic: no React, no host globals. The HOST sources
+ * attachments (file pickers, diagnostics, symbol search — all host-specific) and
+ * feeds the resulting {@link Attachment} objects to the shared Composer via props;
+ * this module owns only the shape, dedup/budget policy, and serialization.
+ */
+
+export type AttachmentKind = "file" | "folder" | "instructions" | "scm" | "problems" | "symbols" | "sessions" | "tools";
+
+export interface BaseAttachment {
+	/** Stable unique id for keys + removal. */
+	id: string;
+	kind: AttachmentKind;
+	/** Human-readable chip label. */
+	label: string;
+	/** Identity used to reject duplicate attachments. */
+	dedupKey: string;
+	/** Text folded into the next prompt. */
+	content: string;
+}
+
+export interface FileAttachment extends BaseAttachment {
+	kind: "file";
+	path: string;
+}
+export interface FolderAttachment extends BaseAttachment {
+	kind: "folder";
+	path: string;
+}
+export interface InstructionsAttachment extends BaseAttachment {
+	kind: "instructions";
+	sourcePath: string;
+}
+export interface ScmAttachment extends BaseAttachment {
+	kind: "scm";
+	repoRoot: string;
+}
+export interface ProblemsAttachment extends BaseAttachment {
+	kind: "problems";
+	/** 'workspace' or a file path. */
+	scope: string;
+}
+export interface SymbolsAttachment extends BaseAttachment {
+	kind: "symbols";
+	query: string;
+}
+export interface SessionsAttachment extends BaseAttachment {
+	kind: "sessions";
+	sessionId: string;
+}
+export interface ToolsAttachment extends BaseAttachment {
+	kind: "tools";
+	toolNames: string[];
+}
+
+export type Attachment =
+	| FileAttachment
+	| FolderAttachment
+	| InstructionsAttachment
+	| ScmAttachment
+	| ProblemsAttachment
+	| SymbolsAttachment
+	| SessionsAttachment
+	| ToolsAttachment;
+
+/** Combined attachment content budget per turn (512 KB). */
+export const MAX_ATTACHMENT_BYTES = 512 * 1024;
+
+const KIND_LABEL: Record<AttachmentKind, string> = {
+	file: "File",
+	folder: "Folder",
+	instructions: "Instructions",
+	scm: "Source Control",
+	problems: "Problems",
+	symbols: "Symbols",
+	sessions: "Session",
+	tools: "Tools",
+};
+
+/** UTF-8 byte length (matches a host's `Buffer.byteLength(s, "utf8")`). */
+export function byteLength(s: string): number {
+	return new TextEncoder().encode(s).length;
+}
+
+/** Render one attachment as a labelled text block for the prompt. */
+export function serializeAttachment(a: Attachment): string {
+	return `[${KIND_LABEL[a.kind]}: ${a.label}]\n\n${a.content}`;
+}
+
+/** Join all attachments into the prefix prepended to the user's message. */
+export function serializeAttachments(list: Attachment[]): string {
+	return list.map(serializeAttachment).join("\n\n");
+}
+
+/** Outcome of {@link addAttachment}. */
+export interface AddResult {
+	list: Attachment[];
+	added: boolean;
+	reason?: "duplicate" | "budget";
+}
+
+/**
+ * Return a new list with `incoming` appended, unless it duplicates an existing
+ * `dedupKey` or would push the combined content past {@link MAX_ATTACHMENT_BYTES}.
+ * On rejection the original list reference is returned unchanged.
+ */
+export function addAttachment(list: Attachment[], incoming: Attachment): AddResult {
+	if (list.some(a => a.dedupKey === incoming.dedupKey)) {
+		return { list, added: false, reason: "duplicate" };
+	}
+	const currentBytes = list.reduce((sum, a) => sum + byteLength(a.content), 0);
+	if (currentBytes + byteLength(incoming.content) > MAX_ATTACHMENT_BYTES) {
+		return { list, added: false, reason: "budget" };
+	}
+	return { list: [...list, incoming], added: true };
+}

--- a/packages/chat-ui/src/components/AttachMenu.tsx
+++ b/packages/chat-ui/src/components/AttachMenu.tsx
@@ -1,0 +1,61 @@
+/**
+ * The composer's "add context" button + category dropdown — the shared, headless
+ * parity of a chat attachment picker. Self-contained like {@link ModelSelector}:
+ * it renders the "+" trigger and the popup. Categories are host-provided
+ * ({@link AttachCategory}); picking one fires `onSelect(id)` and the host does the
+ * actual sourcing (file picker / diagnostics / symbol search). Keyboard/focus a11y
+ * comes from {@link useMenu}.
+ */
+import type { AttachCategory } from "../types";
+import { PlusIcon } from "./icons";
+import { useMenu } from "./useMenu";
+
+export interface AttachMenuProps {
+	categories: AttachCategory[];
+	onSelect: (id: string) => void;
+	disabled?: boolean;
+}
+
+export function AttachMenu({ categories, onSelect, disabled }: AttachMenuProps) {
+	const { open, setOpen, toggle, menuRef, triggerRef } = useMenu();
+	return (
+		<div className="attach-menu" style={{ position: "relative" }}>
+			{open && (
+				<div className="menu menu-up menu-left" role="menu" ref={menuRef}>
+					{categories.length === 0 ? (
+						<div className="menu-header">No sources</div>
+					) : (
+						categories.map(cat => (
+							<button
+								key={cat.id}
+								type="button"
+								role="menuitem"
+								className="menu-item"
+								onClick={() => {
+									onSelect(cat.id);
+									setOpen(false);
+								}}
+							>
+								<span>{cat.label}</span>
+								{cat.description && <span className="menu-item-desc">{cat.description}</span>}
+							</button>
+						))
+					)}
+				</div>
+			)}
+			<button
+				ref={triggerRef}
+				type="button"
+				className="footer-btn"
+				title="Add context"
+				aria-label="Add context"
+				aria-haspopup="menu"
+				aria-expanded={open}
+				disabled={disabled}
+				onClick={toggle}
+			>
+				<PlusIcon />
+			</button>
+		</div>
+	);
+}

--- a/packages/chat-ui/src/components/Composer.tsx
+++ b/packages/chat-ui/src/components/Composer.tsx
@@ -15,7 +15,9 @@
  * controlled-contenteditable churn and is framework-neutral under preact/compat.
  */
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
-import type { InteractionMode, ModelOption } from "../types";
+import { type Attachment, serializeAttachments } from "../attachments/model";
+import type { AttachCategory, InteractionMode, ModelOption } from "../types";
+import { AttachMenu } from "./AttachMenu";
 import { PlusIcon, SendIcon, StopIcon } from "./icons";
 import { ModelSelector } from "./ModelSelector";
 import { ModeToggle } from "./ModeToggle";
@@ -43,8 +45,21 @@ export interface ComposerProps {
 	models?: ModelOption[];
 	model?: string;
 	onModelChange?: (id: string) => void;
-	/** Attach affordance (rendered only when provided). */
+	/** Simple attach affordance — a bare "+" button (rendered only when provided,
+	 *  and only when the richer `attachCategories` picker is NOT in use). */
 	onAttach?: () => void;
+	/**
+	 * Attachment picker. When `attachCategories` is provided the "+" button opens
+	 * a category menu; picking one fires `onRequestAttachment(categoryId)` and the
+	 * HOST sources the attachment and feeds it back through the controlled
+	 * `attachments` array. `onRemoveAttachment` drops a chip. On submit the
+	 * attachments serialize to a labelled prefix prepended to the message; the host
+	 * clears its `attachments` state in its `onSend` handler.
+	 */
+	attachments?: Attachment[];
+	attachCategories?: AttachCategory[];
+	onRequestAttachment?: (categoryId: string) => void;
+	onRemoveAttachment?: (id: string) => void;
 	/** Status bar signals (embedded on the top border). */
 	contextPct?: number | null;
 	sessionLabel?: string;
@@ -83,6 +98,10 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		model,
 		onModelChange,
 		onAttach,
+		attachments,
+		attachCategories,
+		onRequestAttachment,
+		onRemoveAttachment,
 		contextPct = null,
 		sessionLabel = "",
 	},
@@ -90,15 +109,20 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 ) {
 	const editorRef = useRef<HTMLDivElement>(null);
 	const [text, setText] = useState("");
+	const hasAttachments = (attachments?.length ?? 0) > 0;
 
 	const submit = useCallback(() => {
 		const el = editorRef.current;
 		const value = (el?.textContent ?? text).trim();
-		if (!value || disabled) return;
-		onSend(value);
+		if ((!value && !hasAttachments) || disabled) return;
+		// Prepend the labelled attachment prefix; the host clears its `attachments`
+		// state on send. Attachments-only (no text) sends just the prefix.
+		const prefix = attachments && attachments.length > 0 ? serializeAttachments(attachments) : "";
+		const finalText = [prefix, value].filter(Boolean).join("\n\n");
+		onSend(finalText);
 		if (el) el.textContent = "";
 		setText("");
-	}, [text, disabled, onSend]);
+	}, [text, disabled, onSend, attachments, hasAttachments]);
 
 	const handleInput = useCallback(() => {
 		setText(editorRef.current?.textContent ?? "");
@@ -128,7 +152,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		if (!streaming && !disabled) editorRef.current?.focus();
 	}, [streaming, disabled]);
 
-	const canSend = text.trim().length > 0 && !disabled;
+	const canSend = (text.trim().length > 0 || hasAttachments) && !disabled;
 
 	return (
 		<form
@@ -160,12 +184,35 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 					}}
 				/>
 			</div>
+			{attachments && attachments.length > 0 && (
+				<div className="attachment-chips">
+					{attachments.map(a => (
+						<div key={a.id} className="attachment-chip">
+							<span className="attachment-chip-kind">{a.kind}</span>
+							<span className="attachment-chip-label">{a.label}</span>
+							{onRemoveAttachment && (
+								<button
+									type="button"
+									className="attachment-chip-remove"
+									title="Remove"
+									aria-label={`Remove ${a.label}`}
+									onClick={() => onRemoveAttachment(a.id)}
+								>
+									×
+								</button>
+							)}
+						</div>
+					))}
+				</div>
+			)}
 			<div className="input-footer">
-				{onAttach && (
+				{attachCategories && onRequestAttachment ? (
+					<AttachMenu categories={attachCategories} onSelect={onRequestAttachment} disabled={disabled} />
+				) : onAttach ? (
 					<button type="button" className="footer-btn" title="Attach" aria-label="Attach" onClick={onAttach}>
 						<PlusIcon />
 					</button>
-				)}
+				) : null}
 				{modes && mode != null && onModeChange && <ModeToggle modes={modes} mode={mode} onChange={onModeChange} />}
 				<div className="footer-spacer" />
 				{models && model != null && onModelChange && (

--- a/packages/chat-ui/src/index.ts
+++ b/packages/chat-ui/src/index.ts
@@ -2,7 +2,20 @@
 // Phase 1: the framework-free design-token layer.
 // Phase 2: the shared React-idiom chat components (headless of transport/state).
 
+// ── Attachments (model + picker) ──────────────────────────────────────────
+export {
+	type AddResult,
+	type Attachment,
+	type AttachmentKind,
+	addAttachment,
+	type BaseAttachment,
+	byteLength,
+	MAX_ATTACHMENT_BYTES,
+	serializeAttachment,
+	serializeAttachments,
+} from "./attachments/model";
 export { ActivationOverlay, type ActivationOverlayProps } from "./components/ActivationOverlay";
+export { AttachMenu, type AttachMenuProps } from "./components/AttachMenu";
 // ── Composer + footer controls + status bar ───────────────────────────────
 export { Composer, type ComposerHandle, type ComposerProps } from "./components/Composer";
 export { ContentBlockRenderer, type ContentBlockRendererProps } from "./components/ContentBlockRenderer";
@@ -59,6 +72,7 @@ export {
 // ── View-model + prop types ───────────────────────────────────────────────
 export type {
 	ActivationGate,
+	AttachCategory,
 	ChatMessage,
 	ChatRole,
 	ContentBlock,

--- a/packages/chat-ui/src/theme/panel.css.ts
+++ b/packages/chat-ui/src/theme/panel.css.ts
@@ -127,6 +127,17 @@ code { background:var(--code-bg); padding:1px 5px; border-radius:4px; }
 .statusbar .sep-l { position:absolute; left:-9.4px; top:0; height:100%; width:9.4px; z-index:1; clip-path:polygon(100% 0, 0 50%, 100% 100%); }
 .seg-spacer { flex:1; }
 
+/* ── Attachment chips + attach menu ─────────────────────────────────────── */
+.attachment-chips { display:flex; flex-wrap:wrap; gap:6px; padding:6px 12px 0; }
+.attachment-chip { display:flex; align-items:center; gap:6px; max-width:220px; padding:2px 8px;
+  background: var(--deep-charcoal); border:1px solid var(--subtle-gray); border-radius:12px; font-size:11px; }
+.attachment-chip-kind { color: var(--dim); text-transform:uppercase; font-size:9px; letter-spacing:.05em; }
+.attachment-chip-label { color: var(--bright-white); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.attachment-chip-remove { margin-left:2px; background:none; border:none; color: var(--dim); cursor:pointer;
+  font:inherit; font-size:13px; line-height:1; padding:0 2px; }
+.attachment-chip-remove:hover { color: var(--f5-red); }
+.attach-menu { position:relative; display:flex; }
+
 /* ── Composer (rounded, red-bordered box: editor + footer toolbar) ──────── */
 .composer { position:relative; display:flex; flex-direction:column; margin:20px 12px 10px; background: var(--deep-charcoal);
   border:1px solid var(--f5-red); border-radius:8px; }

--- a/packages/chat-ui/src/types.ts
+++ b/packages/chat-ui/src/types.ts
@@ -58,6 +58,17 @@ export interface SkillPill {
 	hint?: string;
 }
 
+/**
+ * A category in the composer's attach menu. The host owns the id space (it maps
+ * the picked id to its own attachment-sourcing) — the shared UI only renders the
+ * label/description and reports the selection.
+ */
+export interface AttachCategory {
+	id: string;
+	label: string;
+	description?: string;
+}
+
 /** A rich assistant content block (text / tool_use / thinking). */
 export type ContentBlock =
 	| { type: "text"; text: string }

--- a/packages/chat-ui/test/attachments.test.ts
+++ b/packages/chat-ui/test/attachments.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type Attachment,
+	addAttachment,
+	byteLength,
+	MAX_ATTACHMENT_BYTES,
+	serializeAttachment,
+	serializeAttachments,
+} from "../src/attachments/model";
+
+function file(id: string, over: Partial<Attachment> = {}): Attachment {
+	return {
+		id,
+		kind: "file",
+		label: `f${id}.ts`,
+		dedupKey: `file:${id}`,
+		content: "x",
+		...over,
+	} as Attachment;
+}
+
+describe("byteLength", () => {
+	test("counts UTF-8 bytes, not code units", () => {
+		expect(byteLength("abc")).toBe(3);
+		expect(byteLength("€")).toBe(3); // 3-byte UTF-8
+		expect(byteLength("🚀")).toBe(4);
+	});
+});
+
+describe("serializeAttachment(s)", () => {
+	test("renders one attachment as a labelled text block", () => {
+		const a = file("1", { label: "lb.ts", content: 'name: "my-lb"' });
+		expect(serializeAttachment(a)).toBe('[File: lb.ts]\n\nname: "my-lb"');
+	});
+
+	test("joins multiple attachments with a blank line", () => {
+		const out = serializeAttachments([file("1", { content: "A" }), file("2", { content: "B" })]);
+		expect(out).toBe("[File: f1.ts]\n\nA\n\n[File: f2.ts]\n\nB");
+	});
+
+	test("labels each kind with its human name", () => {
+		const folder = {
+			id: "d",
+			kind: "folder",
+			label: "src",
+			dedupKey: "folder:src",
+			content: "…",
+			path: "src",
+		} as Attachment;
+		expect(serializeAttachment(folder)).toStartWith("[Folder: src]");
+	});
+
+	test("empty list serializes to empty string", () => {
+		expect(serializeAttachments([])).toBe("");
+	});
+});
+
+describe("addAttachment", () => {
+	test("appends a new attachment", () => {
+		const r = addAttachment([], file("1"));
+		expect(r.added).toBe(true);
+		expect(r.list).toHaveLength(1);
+	});
+
+	test("rejects a duplicate dedupKey (returns the same list ref, reason=duplicate)", () => {
+		const list = [file("1")];
+		const r = addAttachment(list, file("1"));
+		expect(r.added).toBe(false);
+		expect(r.reason).toBe("duplicate");
+		expect(r.list).toBe(list);
+	});
+
+	test("rejects when the combined content would exceed MAX_ATTACHMENT_BYTES (reason=budget)", () => {
+		const big = file("1", { dedupKey: "file:big", content: "a".repeat(MAX_ATTACHMENT_BYTES - 1) });
+		const r1 = addAttachment([], big);
+		expect(r1.added).toBe(true);
+		const more = file("2", { dedupKey: "file:more", content: "bb" });
+		const r2 = addAttachment(r1.list, more);
+		expect(r2.added).toBe(false);
+		expect(r2.reason).toBe("budget");
+		expect(r2.list).toBe(r1.list);
+	});
+
+	test("allows filling exactly up to the budget", () => {
+		const exact = file("1", { dedupKey: "file:exact", content: "a".repeat(MAX_ATTACHMENT_BYTES) });
+		expect(addAttachment([], exact).added).toBe(true);
+	});
+});

--- a/packages/chat-ui/test/composer-attachments.test.tsx
+++ b/packages/chat-ui/test/composer-attachments.test.tsx
@@ -1,0 +1,100 @@
+import { expect, test } from "bun:test";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import type { Attachment } from "../src/attachments/model";
+import { AttachMenu } from "../src/components/AttachMenu";
+import { Composer } from "../src/components/Composer";
+import type { AttachCategory } from "../src/types";
+
+const CATEGORIES: AttachCategory[] = [
+	{ id: "files", label: "Files & Folders", description: "Attach workspace files" },
+	{ id: "problems", label: "Problems" },
+];
+
+function att(id: string, over: Partial<Attachment> = {}): Attachment {
+	return { id, kind: "file", label: `f${id}.ts`, dedupKey: `file:${id}`, content: `C${id}`, path: `f${id}.ts`, ...over } as Attachment;
+}
+
+test("AttachMenu opens on the + button and fires onSelect(id) with the category", () => {
+	let picked = "";
+	render(<AttachMenu categories={CATEGORIES} onSelect={id => (picked = id)} />);
+	act(() => {
+		fireEvent.click(screen.getByRole("button", { name: /add context/i }));
+	});
+	expect(screen.getByRole("menu")).toBeDefined();
+	fireEvent.click(screen.getByRole("menuitem", { name: /files & folders/i }));
+	expect(picked).toBe("files");
+	// menu closes after selection
+	expect(screen.queryByRole("menu")).toBeNull();
+});
+
+test("Composer renders attachment chips and removes one via onRemoveAttachment", () => {
+	let removed = "";
+	const attachments = [att("1"), att("2")];
+	render(
+		<Composer
+			streaming={false}
+			onSend={() => {}}
+			onStop={() => {}}
+			attachments={attachments}
+			onRemoveAttachment={id => (removed = id)}
+		/>,
+	);
+	expect(screen.getByText("f1.ts")).toBeDefined();
+	expect(screen.getByText("f2.ts")).toBeDefined();
+	fireEvent.click(screen.getByRole("button", { name: /remove f1\.ts/i }));
+	expect(removed).toBe("1");
+});
+
+test("submit prepends serialized attachments to the message text", () => {
+	let sent = "";
+	render(
+		<Composer streaming={false} onSend={t => (sent = t)} onStop={() => {}} attachments={[att("1", { label: "lb.ts", content: "cfg" })]} />,
+	);
+	const editor = screen.getByRole("textbox", { name: /message input/i });
+	editor.textContent = "explain this";
+	fireEvent.input(editor);
+	fireEvent.submit(editor.closest("form") as HTMLFormElement);
+	expect(sent).toBe("[File: lb.ts]\n\ncfg\n\nexplain this");
+});
+
+test("attachments-only (no typed text) can send, and sends just the prefix", () => {
+	let sent = "";
+	render(
+		<Composer streaming={false} onSend={t => (sent = t)} onStop={() => {}} attachments={[att("1", { label: "a.ts", content: "X" })]} />,
+	);
+	// Send is enabled despite the empty editor.
+	const send = screen.getByRole("button", { name: /send/i }) as HTMLButtonElement;
+	expect(send.disabled).toBe(false);
+	fireEvent.click(send);
+	expect(sent).toBe("[File: a.ts]\n\nX");
+});
+
+test("the picker replaces the bare attach button when categories are provided", () => {
+	const { rerender } = render(
+		<Composer streaming={false} onSend={() => {}} onStop={() => {}} onAttach={() => {}} />,
+	);
+	// Bare attach button when only onAttach is given.
+	expect(screen.getByRole("button", { name: /^attach$/i })).toBeDefined();
+
+	rerender(
+		<Composer
+			streaming={false}
+			onSend={() => {}}
+			onStop={() => {}}
+			onAttach={() => {}}
+			attachCategories={CATEGORIES}
+			onRequestAttachment={() => {}}
+		/>,
+	);
+	// The category picker ("Add context") takes over; the bare "Attach" is gone.
+	expect(screen.getByRole("button", { name: /add context/i })).toBeDefined();
+	expect(screen.queryByRole("button", { name: /^attach$/i })).toBeNull();
+});
+
+test("no attachment UI at all when no attach props are given (office/chrome unaffected)", () => {
+	const { container } = render(<Composer streaming={false} onSend={() => {}} onStop={() => {}} />);
+	const scope = within(container);
+	expect(scope.queryByRole("button", { name: /add context/i })).toBeNull();
+	expect(scope.queryByRole("button", { name: /^attach$/i })).toBeNull();
+	expect(container.querySelector(".attachment-chips")).toBeNull();
+});


### PR DESCRIPTION
Closes #2140. Phase 4a of the chat-UI unification — makes the shared `Composer` a **superset** so the VS Code adoption (Phase 4b) regresses nothing.

## Why

VS Code's `InputBar` has a full attachment picker (model + `AttachMenu` + chips + serialization). The shared `Composer` had only a bare `onAttach?` button. Fully adopting the shared Composer as-is would delete that shipped feature, so the shared one must absorb it first. The attachment **model is host-agnostic** — vscode's `attachmentTypes.ts` documents it's *duplicated* from the extension host — so consolidating it into chat-ui is exactly the DRY win the epic targets. Only the *sourcing* (file pickers, diagnostics, symbol search) is host-specific and stays host-side.

## What

- **`src/attachments/model.ts`** — `Attachment` union (8 kinds), `serializeAttachment(s)` (labelled text blocks), `addAttachment` (dedup by `dedupKey` + 512 KB budget → `AddResult`), `byteLength`. Pure, framework-free.
- **`AttachMenu`** — headless "+"-button + category dropdown (categories are props), self-contained like `ModelSelector`, keyboard-a11y via `useMenu`.
- **`Composer`** — new **optional** props `attachments` / `attachCategories` / `onRequestAttachment` / `onRemoveAttachment`. Renders chips + the picker only when provided; on submit prepends `serializeAttachments` (attachments-only sends just the prefix). The host owns the controlled `attachments` state.
- `AttachCategory` type, barrel exports, `.attachment-chip*` / `.attach-menu` styles in `PANEL_CSS`.

## Backward-compatible

With no attach props the `Composer` is byte-for-byte behaviourally unchanged → office-pane and Chrome are unaffected. **Verified: office-pane 228 tests still green** against this source.

## Verification

- chat-ui **94 tests** (attachments model 9 + composer-attachments 6 new); `check:ts` (workspace) clean; `biome` clean.

## Next

Phase 4b: VS Code `InputBar` → this enriched shared `Composer`, wiring its `sendRequestAttachment` / `attachment_added` protocol into the new props — no feature lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
