### PR TITLE
feat: generic xcsh://plugin/<name>/… internal-URL resolver

### DIFF
--- a/packages/coding-agent/src/internal-urls/index.ts
+++ b/packages/coding-agent/src/internal-urls/index.ts
@@ -35,6 +35,7 @@ export * from "./local-protocol";
 export * from "./mcp-protocol";
 export * from "./memory-protocol";
 export * from "./parse";
+export * from "./plugin-resolve";
 export * from "./profile-collectors";
 export * from "./router";
 export * from "./rule-protocol";

--- a/packages/coding-agent/src/internal-urls/plugin-resolve.test.ts
+++ b/packages/coding-agent/src/internal-urls/plugin-resolve.test.ts
@@ -74,8 +74,8 @@ describe("PluginResolver", () => {
 		await expect(resolver().resolve(u("xcsh://plugin/demo/file/../../etc/hosts"))).rejects.toThrow(/traversal/i);
 	});
 
-	test("resolution ignores prompt-gating (works with any roots source)", async () => {
-		// getPluginRoots is the only source; no dependency on enableXcshPlugins.
+	test("resolves purely from the injected getPluginRoots (no dependency on external flags)", async () => {
+		// Flag-independence at the sdk layer is guaranteed by listXcshPluginRoots not consulting enableXcshPlugins.
 		const r = await createPluginResolver(async () => roots).resolve(u("xcsh://plugin/demo"));
 		expect(JSON.parse(r.content).name).toBe("demo");
 	});

--- a/packages/coding-agent/src/internal-urls/plugin-resolve.test.ts
+++ b/packages/coding-agent/src/internal-urls/plugin-resolve.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseInternalUrl } from "./parse";
+import { createPluginResolver, type PluginRootLike } from "./plugin-resolve";
+import type { InternalUrl } from "./types";
+
+let root: string;
+let roots: PluginRootLike[];
+
+function u(input: string): InternalUrl {
+	return parseInternalUrl(input) as InternalUrl;
+}
+
+beforeAll(async () => {
+	root = await fs.mkdtemp(path.join(os.tmpdir(), "plugin-resolve-"));
+	await fs.mkdir(path.join(root, ".xcsh-plugin"), { recursive: true });
+	await fs.mkdir(path.join(root, "schema"), { recursive: true });
+	await fs.mkdir(path.join(root, "engine"), { recursive: true });
+	await fs.writeFile(
+		path.join(root, ".xcsh-plugin", "resources.json"),
+		JSON.stringify({
+			schema: "schema/s.json",
+			engine: { runtime: "bun", entry: "engine/cli.ts", commands: ["validate"] },
+		}),
+	);
+	await fs.writeFile(path.join(root, "schema", "s.json"), `{"title":"x"}`);
+	await fs.writeFile(path.join(root, "engine", "cli.ts"), `console.log("hi")`);
+	roots = [{ plugin: "demo", version: "9.9.9", path: root }];
+});
+
+afterAll(async () => {
+	await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("PluginResolver", () => {
+	const resolver = () => createPluginResolver(async () => roots);
+
+	test("schema returns application/json with a sourcePath inside the plugin root", async () => {
+		const r = await resolver().resolve(u("xcsh://plugin/demo/schema"));
+		expect(r.contentType).toBe("application/json");
+		expect(r.content).toContain(`"title"`);
+		expect(r.sourcePath).toBe(path.join(root, "schema", "s.json"));
+	});
+
+	test("contract returns the manifest verbatim with a sourcePath", async () => {
+		const r = await resolver().resolve(u("xcsh://plugin/demo/contract"));
+		expect(r.contentType).toBe("application/json");
+		expect(JSON.parse(r.content).schema).toBe("schema/s.json");
+		expect(r.sourcePath).toBe(path.join(root, ".xcsh-plugin", "resources.json"));
+	});
+
+	test("file/<relpath> resolves an arbitrary root-relative file", async () => {
+		const r = await resolver().resolve(u("xcsh://plugin/demo/file/engine/cli.ts"));
+		expect(r.sourcePath).toBe(path.join(root, "engine", "cli.ts"));
+		expect(r.content).toContain("hi");
+	});
+
+	test("engine returns the resolved entry path", async () => {
+		const r = await resolver().resolve(u("xcsh://plugin/demo/engine"));
+		const body = JSON.parse(r.content);
+		expect(body.entryPath).toBe(path.join(root, "engine", "cli.ts"));
+		expect(r.sourcePath).toBe(path.join(root, "engine", "cli.ts"));
+	});
+
+	test("uninstalled plugin throws listing installed names", async () => {
+		await expect(resolver().resolve(u("xcsh://plugin/nope/schema"))).rejects.toThrow(/not installed/i);
+	});
+
+	test("path traversal throws", async () => {
+		await expect(resolver().resolve(u("xcsh://plugin/demo/file/../../etc/hosts"))).rejects.toThrow(/traversal/i);
+	});
+
+	test("resolution ignores prompt-gating (works with any roots source)", async () => {
+		// getPluginRoots is the only source; no dependency on enableXcshPlugins.
+		const r = await createPluginResolver(async () => roots).resolve(u("xcsh://plugin/demo"));
+		expect(JSON.parse(r.content).name).toBe("demo");
+	});
+});

--- a/packages/coding-agent/src/internal-urls/plugin-resolve.test.ts
+++ b/packages/coding-agent/src/internal-urls/plugin-resolve.test.ts
@@ -27,6 +27,8 @@ beforeAll(async () => {
 	);
 	await fs.writeFile(path.join(root, "schema", "s.json"), `{"title":"x"}`);
 	await fs.writeFile(path.join(root, "engine", "cli.ts"), `console.log("hi")`);
+	// Symlink inside the plugin root pointing outside it (for escape-via-symlink test).
+	await fs.symlink(os.tmpdir(), path.join(root, "escape"));
 	roots = [{ plugin: "demo", version: "9.9.9", path: root }];
 });
 
@@ -76,5 +78,9 @@ describe("PluginResolver", () => {
 		// getPluginRoots is the only source; no dependency on enableXcshPlugins.
 		const r = await createPluginResolver(async () => roots).resolve(u("xcsh://plugin/demo"));
 		expect(JSON.parse(r.content).name).toBe("demo");
+	});
+
+	test("rejects escape via a symlink inside the plugin root", async () => {
+		await expect(resolver().resolve(u("xcsh://plugin/demo/file/escape/x"))).rejects.toThrow(/traversal/i);
 	});
 });

--- a/packages/coding-agent/src/internal-urls/plugin-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/plugin-resolve.ts
@@ -117,7 +117,14 @@ export class PluginResolver {
 		if (kind === "contract") {
 			const manifestPath = path.join(root.path, PLUGIN_MANIFEST_RELPATH);
 			const content = await this.#readFile(manifestPath);
-			return { url: url.href, content, contentType: "application/json", size: Buffer.byteLength(content, "utf-8"), sourcePath: manifestPath, notes: [] };
+			return {
+				url: url.href,
+				content,
+				contentType: "application/json",
+				size: Buffer.byteLength(content, "utf-8"),
+				sourcePath: manifestPath,
+				notes: [],
+			};
 		}
 
 		if (kind === "engine") {
@@ -128,8 +135,20 @@ export class PluginResolver {
 			}
 			const entryPath = await safeJoin(root.path, engine.entry);
 			await this.#assertExists(entryPath);
-			const body = JSON.stringify({ runtime: engine.runtime ?? null, entry: engine.entry, entryPath, commands: engine.commands ?? [] });
-			return { url: url.href, content: body, contentType: "application/json", size: Buffer.byteLength(body, "utf-8"), sourcePath: entryPath, notes: [] };
+			const body = JSON.stringify({
+				runtime: engine.runtime ?? null,
+				entry: engine.entry,
+				entryPath,
+				commands: engine.commands ?? [],
+			});
+			return {
+				url: url.href,
+				content: body,
+				contentType: "application/json",
+				size: Buffer.byteLength(body, "utf-8"),
+				sourcePath: entryPath,
+				notes: [],
+			};
 		}
 
 		if (kind === "file") {
@@ -137,7 +156,14 @@ export class PluginResolver {
 			if (!relativePath) throw new Error("xcsh://plugin/<name>/file/ requires a relative path");
 			const target = await safeJoin(root.path, relativePath);
 			const content = await this.#readFile(target);
-			return { url: url.href, content, contentType: contentTypeFor(target), size: Buffer.byteLength(content, "utf-8"), sourcePath: target, notes: [] };
+			return {
+				url: url.href,
+				content,
+				contentType: contentTypeFor(target),
+				size: Buffer.byteLength(content, "utf-8"),
+				sourcePath: target,
+				notes: [],
+			};
 		}
 
 		// Named resource key from the manifest (e.g. "schema", "example").
@@ -149,10 +175,19 @@ export class PluginResolver {
 		}
 		const target = await safeJoin(root.path, value);
 		const content = await this.#readFile(target);
-		return { url: url.href, content, contentType: contentTypeFor(target), size: Buffer.byteLength(content, "utf-8"), sourcePath: target, notes: [] };
+		return {
+			url: url.href,
+			content,
+			contentType: contentTypeFor(target),
+			size: Buffer.byteLength(content, "utf-8"),
+			sourcePath: target,
+			notes: [],
+		};
 	}
 
-	async #listPlugins(roots: readonly PluginRootLike[]): Promise<Array<{ name: string; version: string; hasContract: boolean }>> {
+	async #listPlugins(
+		roots: readonly PluginRootLike[],
+	): Promise<Array<{ name: string; version: string; hasContract: boolean }>> {
 		const out: Array<{ name: string; version: string; hasContract: boolean }> = [];
 		for (const r of roots) {
 			const manifestPath = path.join(r.path, PLUGIN_MANIFEST_RELPATH);
@@ -183,7 +218,13 @@ export class PluginResolver {
 
 	#json(url: InternalUrl, data: unknown): InternalResource {
 		const content = JSON.stringify(data);
-		return { url: url.href, content, contentType: "application/json", size: Buffer.byteLength(content, "utf-8"), notes: [] };
+		return {
+			url: url.href,
+			content,
+			contentType: "application/json",
+			size: Buffer.byteLength(content, "utf-8"),
+			notes: [],
+		};
 	}
 }
 

--- a/packages/coding-agent/src/internal-urls/plugin-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/plugin-resolve.ts
@@ -13,6 +13,7 @@
  * - xcsh://plugin/<name>/engine         -> manifest engine block, entry resolved to abs path
  * - xcsh://plugin/<name>/file/<relpath> -> any root-relative file
  */
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { validateRelativePath } from "./skill-protocol";
 import type { InternalResource, InternalUrl } from "./types";
@@ -36,8 +37,6 @@ interface EngineBlock {
 }
 
 interface ResourcesManifest {
-	schema?: string;
-	example?: string;
 	engine?: EngineBlock;
 	[key: string]: unknown;
 }
@@ -49,15 +48,34 @@ function contentTypeFor(filePath: string): InternalResource["contentType"] {
 	return "text/plain";
 }
 
-/** Join a root-relative path safely inside the plugin root; throws on traversal. */
-function safeJoin(root: string, relativePath: string): string {
-	validateRelativePath(relativePath);
-	const target = path.resolve(path.join(root, relativePath));
-	const resolvedRoot = path.resolve(root);
-	if (!target.startsWith(resolvedRoot + path.sep) && target !== resolvedRoot) {
+/** realpath that tolerates a missing leaf by resolving the nearest existing ancestor. */
+async function realpathAllowingMissing(p: string): Promise<string> {
+	try {
+		return await fs.realpath(p);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+		const parent = path.dirname(p);
+		if (parent === p) throw err;
+		const realParent = await realpathAllowingMissing(parent);
+		return path.join(realParent, path.basename(p));
+	}
+}
+
+/** Join a root-relative path safely inside the plugin root; throws on traversal (incl. via symlink). */
+async function safeJoin(root: string, relativePath: string): Promise<string> {
+	try {
+		validateRelativePath(relativePath);
+	} catch {
+		// validateRelativePath's message names skill:// URLs; re-throw with the correct scheme.
+		throw new Error("Path traversal (..) or absolute paths are not allowed in xcsh://plugin/ URLs");
+	}
+	const lexicalTarget = path.resolve(path.join(root, relativePath));
+	const resolvedRoot = await fs.realpath(root);
+	const realTarget = await realpathAllowingMissing(path.join(resolvedRoot, relativePath));
+	if (realTarget !== resolvedRoot && !realTarget.startsWith(resolvedRoot + path.sep)) {
 		throw new Error("Path traversal is not allowed in xcsh://plugin/ URLs");
 	}
-	return target;
+	return lexicalTarget;
 }
 
 export class PluginResolver {
@@ -108,7 +126,7 @@ export class PluginResolver {
 			if (!engine?.entry) {
 				throw new Error(`Plugin ${name} declares no engine.entry in ${PLUGIN_MANIFEST_RELPATH}`);
 			}
-			const entryPath = safeJoin(root.path, engine.entry);
+			const entryPath = await safeJoin(root.path, engine.entry);
 			await this.#assertExists(entryPath);
 			const body = JSON.stringify({ runtime: engine.runtime ?? null, entry: engine.entry, entryPath, commands: engine.commands ?? [] });
 			return { url: url.href, content: body, contentType: "application/json", size: Buffer.byteLength(body, "utf-8"), sourcePath: entryPath, notes: [] };
@@ -117,7 +135,7 @@ export class PluginResolver {
 		if (kind === "file") {
 			const relativePath = selector.slice(1).join("/");
 			if (!relativePath) throw new Error("xcsh://plugin/<name>/file/ requires a relative path");
-			const target = safeJoin(root.path, relativePath);
+			const target = await safeJoin(root.path, relativePath);
 			const content = await this.#readFile(target);
 			return { url: url.href, content, contentType: contentTypeFor(target), size: Buffer.byteLength(content, "utf-8"), sourcePath: target, notes: [] };
 		}
@@ -129,7 +147,7 @@ export class PluginResolver {
 			const keys = Object.keys(manifest).filter(k => typeof manifest[k] === "string");
 			throw new Error(`Unknown resource "${kind}" for plugin ${name}\nAvailable: ${keys.join(", ") || "none"}`);
 		}
-		const target = safeJoin(root.path, value);
+		const target = await safeJoin(root.path, value);
 		const content = await this.#readFile(target);
 		return { url: url.href, content, contentType: contentTypeFor(target), size: Buffer.byteLength(content, "utf-8"), sourcePath: target, notes: [] };
 	}

--- a/packages/coding-agent/src/internal-urls/plugin-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/plugin-resolve.ts
@@ -1,0 +1,174 @@
+/**
+ * Generic resolver for xcsh://plugin/<name>/... URLs.
+ *
+ * Framework-agnostic: it reads a plugin-declared manifest
+ * (.xcsh-plugin/resources.json) and maps declared keys to files on disk. It has
+ * NO knowledge of any specific plugin's domain.
+ *
+ * URL forms (host = "plugin", first path segment = plugin name):
+ * - xcsh://plugin                       -> list installed plugins
+ * - xcsh://plugin/<name>                -> plugin summary (version, declared keys)
+ * - xcsh://plugin/<name>/contract       -> the manifest verbatim
+ * - xcsh://plugin/<name>/schema         -> file at manifest key "schema"
+ * - xcsh://plugin/<name>/engine         -> manifest engine block, entry resolved to abs path
+ * - xcsh://plugin/<name>/file/<relpath> -> any root-relative file
+ */
+import * as path from "node:path";
+import { validateRelativePath } from "./skill-protocol";
+import type { InternalResource, InternalUrl } from "./types";
+
+/** Minimal shape the resolver needs from a discovered plugin root. */
+export interface PluginRootLike {
+	plugin: string;
+	version: string;
+	path: string;
+}
+
+export type GetPluginRoots = () => Promise<readonly PluginRootLike[]>;
+
+/** Manifest location, relative to a plugin root. */
+export const PLUGIN_MANIFEST_RELPATH = ".xcsh-plugin/resources.json";
+
+interface EngineBlock {
+	runtime?: string;
+	entry?: string;
+	commands?: string[];
+}
+
+interface ResourcesManifest {
+	schema?: string;
+	example?: string;
+	engine?: EngineBlock;
+	[key: string]: unknown;
+}
+
+function contentTypeFor(filePath: string): InternalResource["contentType"] {
+	const ext = path.extname(filePath).toLowerCase();
+	if (ext === ".json") return "application/json";
+	if (ext === ".md") return "text/markdown";
+	return "text/plain";
+}
+
+/** Join a root-relative path safely inside the plugin root; throws on traversal. */
+function safeJoin(root: string, relativePath: string): string {
+	validateRelativePath(relativePath);
+	const target = path.resolve(path.join(root, relativePath));
+	const resolvedRoot = path.resolve(root);
+	if (!target.startsWith(resolvedRoot + path.sep) && target !== resolvedRoot) {
+		throw new Error("Path traversal is not allowed in xcsh://plugin/ URLs");
+	}
+	return target;
+}
+
+export class PluginResolver {
+	constructor(private readonly getPluginRoots: GetPluginRoots) {}
+
+	async resolve(url: InternalUrl): Promise<InternalResource> {
+		// rawPathname preserves traversal markers; strip leading slash.
+		const rawPath = (url.rawPathname ?? url.pathname ?? "").replace(/^\/+/, "");
+		const segments = rawPath ? rawPath.split("/").map(s => decodeURIComponent(s)) : [];
+
+		const roots = await this.getPluginRoots();
+
+		// xcsh://plugin -> list installed plugins
+		if (segments.length === 0) {
+			return this.#json(url, await this.#listPlugins(roots));
+		}
+
+		const name = segments[0];
+		const root = roots.find(r => r.plugin === name);
+		if (!root) {
+			const installed = roots.map(r => r.plugin).join(", ") || "none";
+			throw new Error(`Plugin not installed: ${name}\nInstalled: ${installed}`);
+		}
+
+		const selector = segments.slice(1);
+
+		// xcsh://plugin/<name> -> summary
+		if (selector.length === 0) {
+			const manifest = await this.#readManifest(root.path);
+			return this.#json(url, {
+				name: root.plugin,
+				version: root.version,
+				resources: Object.keys(manifest),
+			});
+		}
+
+		const kind = selector[0];
+
+		if (kind === "contract") {
+			const manifestPath = path.join(root.path, PLUGIN_MANIFEST_RELPATH);
+			const content = await this.#readFile(manifestPath);
+			return { url: url.href, content, contentType: "application/json", size: Buffer.byteLength(content, "utf-8"), sourcePath: manifestPath, notes: [] };
+		}
+
+		if (kind === "engine") {
+			const manifest = await this.#readManifest(root.path);
+			const engine = manifest.engine;
+			if (!engine?.entry) {
+				throw new Error(`Plugin ${name} declares no engine.entry in ${PLUGIN_MANIFEST_RELPATH}`);
+			}
+			const entryPath = safeJoin(root.path, engine.entry);
+			await this.#assertExists(entryPath);
+			const body = JSON.stringify({ runtime: engine.runtime ?? null, entry: engine.entry, entryPath, commands: engine.commands ?? [] });
+			return { url: url.href, content: body, contentType: "application/json", size: Buffer.byteLength(body, "utf-8"), sourcePath: entryPath, notes: [] };
+		}
+
+		if (kind === "file") {
+			const relativePath = selector.slice(1).join("/");
+			if (!relativePath) throw new Error("xcsh://plugin/<name>/file/ requires a relative path");
+			const target = safeJoin(root.path, relativePath);
+			const content = await this.#readFile(target);
+			return { url: url.href, content, contentType: contentTypeFor(target), size: Buffer.byteLength(content, "utf-8"), sourcePath: target, notes: [] };
+		}
+
+		// Named resource key from the manifest (e.g. "schema", "example").
+		const manifest = await this.#readManifest(root.path);
+		const value = manifest[kind];
+		if (typeof value !== "string") {
+			const keys = Object.keys(manifest).filter(k => typeof manifest[k] === "string");
+			throw new Error(`Unknown resource "${kind}" for plugin ${name}\nAvailable: ${keys.join(", ") || "none"}`);
+		}
+		const target = safeJoin(root.path, value);
+		const content = await this.#readFile(target);
+		return { url: url.href, content, contentType: contentTypeFor(target), size: Buffer.byteLength(content, "utf-8"), sourcePath: target, notes: [] };
+	}
+
+	async #listPlugins(roots: readonly PluginRootLike[]): Promise<Array<{ name: string; version: string; hasContract: boolean }>> {
+		const out: Array<{ name: string; version: string; hasContract: boolean }> = [];
+		for (const r of roots) {
+			const manifestPath = path.join(r.path, PLUGIN_MANIFEST_RELPATH);
+			const hasContract = await Bun.file(manifestPath).exists();
+			out.push({ name: r.plugin, version: r.version, hasContract });
+		}
+		return out;
+	}
+
+	async #readManifest(root: string): Promise<ResourcesManifest> {
+		const manifestPath = path.join(root, PLUGIN_MANIFEST_RELPATH);
+		const file = Bun.file(manifestPath);
+		if (!(await file.exists())) {
+			throw new Error(`Plugin manifest not found: ${manifestPath} (expected ${PLUGIN_MANIFEST_RELPATH})`);
+		}
+		return JSON.parse(await file.text()) as ResourcesManifest;
+	}
+
+	async #readFile(absPath: string): Promise<string> {
+		const file = Bun.file(absPath);
+		if (!(await file.exists())) throw new Error(`File not found: ${absPath}`);
+		return file.text();
+	}
+
+	async #assertExists(absPath: string): Promise<void> {
+		if (!(await Bun.file(absPath).exists())) throw new Error(`File not found: ${absPath}`);
+	}
+
+	#json(url: InternalUrl, data: unknown): InternalResource {
+		const content = JSON.stringify(data);
+		return { url: url.href, content, contentType: "application/json", size: Buffer.byteLength(content, "utf-8"), notes: [] };
+	}
+}
+
+export function createPluginResolver(getPluginRoots: GetPluginRoots): PluginResolver {
+	return new PluginResolver(getPluginRoots);
+}

--- a/packages/coding-agent/src/internal-urls/xcsh-protocol.plugin.test.ts
+++ b/packages/coding-agent/src/internal-urls/xcsh-protocol.plugin.test.ts
@@ -1,0 +1,31 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseInternalUrl } from "./parse";
+import type { InternalUrl } from "./types";
+import { InternalDocsProtocolHandler } from "./xcsh-protocol";
+
+let root: string;
+
+beforeAll(async () => {
+	root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-plugin-"));
+	await fs.mkdir(path.join(root, ".xcsh-plugin"), { recursive: true });
+	await fs.writeFile(path.join(root, ".xcsh-plugin", "resources.json"), JSON.stringify({ schema: "s.json" }));
+	await fs.writeFile(path.join(root, "s.json"), `{"ok":true}`);
+});
+afterAll(async () => {
+	await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("InternalDocsProtocolHandler plugin host", () => {
+	const handler = new InternalDocsProtocolHandler({
+		getPluginRoots: async () => [{ plugin: "demo", version: "1.0.0", path: root }],
+	});
+
+	test("routes xcsh://plugin/<name>/schema", async () => {
+		const r = await handler.resolve(parseInternalUrl("xcsh://plugin/demo/schema") as InternalUrl);
+		expect(r.contentType).toBe("application/json");
+		expect(r.sourcePath).toBe(path.join(root, "s.json"));
+	});
+});

--- a/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
@@ -44,6 +44,7 @@ import { type ConsoleFieldMetadataData, EMPTY_CONSOLE_FIELD_METADATA } from "./c
 import { type ConsoleResolver, createConsoleResolver } from "./console-resolve";
 import { EMBEDDED_DOC_FILENAMES, EMBEDDED_DOCS } from "./docs-index.generated";
 import extensionApiContent from "./extension-api.md" with { type: "text" };
+import { createPluginResolver, type GetPluginRoots, type PluginResolver } from "./plugin-resolve";
 import { createTerraformResolver, type TerraformResolver } from "./terraform-resolve";
 import type { TerraformIndex } from "./terraform-types";
 import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
@@ -60,6 +61,7 @@ const USER_ROUTE = "user";
 const COMPUTER_ROUTE = "computer";
 const CONSOLE_HOST = "console";
 const EXTENSION_HOST = "extension";
+const PLUGIN_HOST = "plugin";
 const EMPTY_INDEX: ApiSpecIndex = { version: "unavailable", timestamp: "", domains: [] };
 const EMPTY_CATALOG_INDEX: ApiCatalogIndex = {
 	version: "unavailable",
@@ -265,6 +267,7 @@ export interface InternalDocsProtocolOptions {
 	readonly getContextStatus?: () => ContextStatus | null;
 	readonly apiSpecResolver?: ApiSpecResolver;
 	readonly apiCatalogResolver?: ApiCatalogResolver;
+	readonly getPluginRoots?: GetPluginRoots;
 }
 
 export class InternalDocsProtocolHandler implements ProtocolHandler {
@@ -275,6 +278,8 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 	#apiCatalogResolver: ApiCatalogResolver | null;
 	#terraformResolver: TerraformResolver | null;
 	#consoleResolver: ConsoleResolver | null = null;
+	#pluginResolver: PluginResolver | null = null;
+	readonly #getPluginRoots: GetPluginRoots | undefined;
 
 	constructor(options: InternalDocsProtocolOptions = {}) {
 		this.#resolveBuildInfo = options.resolveBuildInfo ?? getRuntimeBuildInfo;
@@ -282,6 +287,7 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 		this.#apiSpecResolver = options.apiSpecResolver ?? null;
 		this.#apiCatalogResolver = options.apiCatalogResolver ?? null;
 		this.#terraformResolver = null;
+		this.#getPluginRoots = options.getPluginRoots;
 	}
 
 	#getApiSpecResolver(): ApiSpecResolver {
@@ -325,6 +331,14 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 		return this.#consoleResolver;
 	}
 
+	#getPluginResolver(): PluginResolver {
+		if (!this.#pluginResolver) {
+			const getRoots = this.#getPluginRoots ?? (async () => []);
+			this.#pluginResolver = createPluginResolver(getRoots);
+		}
+		return this.#pluginResolver;
+	}
+
 	async resolve(url: InternalUrl): Promise<InternalResource> {
 		const host = url.rawHost || url.hostname;
 
@@ -342,6 +356,10 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 
 		if (host === TERRAFORM_HOST) {
 			return this.#getTerraformResolver().resolve(url);
+		}
+
+		if (host === PLUGIN_HOST) {
+			return this.#getPluginResolver().resolve(url);
 		}
 
 		if (host === BRANDING_HOST) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1,3 +1,4 @@
+import * as os from "node:os";
 import {
 	Agent,
 	type AgentEvent,
@@ -44,6 +45,7 @@ import { CursorExecHandlers } from "./cursor";
 import "./discovery";
 import { resolveConfigValue } from "./config/resolve-config-value";
 import { initializeWithSettings } from "./discovery";
+import { listXcshPluginRoots } from "./discovery/helpers";
 import { TtsrManager } from "./export/ttsr";
 import {
 	type CustomCommandsLoadResult,
@@ -1136,6 +1138,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						return null;
 					}
 				},
+				getPluginRoots: () => listXcshPluginRoots(os.homedir(), cwd).then(r => r.roots),
 			}),
 		);
 		internalRouter.register(new JobsProtocolHandler({ getAsyncJobManager: () => asyncJobManager }));

--- a/packages/coding-agent/src/tools/bash-skill-urls.ts
+++ b/packages/coding-agent/src/tools/bash-skill-urls.ts
@@ -11,9 +11,9 @@ const SKILL_URL_PATTERN = /'skill:\/\/[^'\s")`\\]+'|"skill:\/\/[^"\s')`\\]+"|ski
 
 /** Regex to find supported internal URL tokens in command text. */
 const INTERNAL_URL_PATTERN =
-	/'(?:skill|agent|artifact|plan|memory|rule|local):\/\/[^'\s")`\\]+'|"(?:skill|agent|artifact|plan|memory|rule|local):\/\/[^"\s')`\\]+"|(?:skill|agent|artifact|plan|memory|rule|local):\/\/[^\s'")`\\]+/g;
+	/'(?:skill|agent|artifact|plan|memory|rule|local|xcsh):\/\/[^'\s")`\\]+'|"(?:skill|agent|artifact|plan|memory|rule|local|xcsh):\/\/[^"\s')`\\]+"|(?:skill|agent|artifact|plan|memory|rule|local|xcsh):\/\/[^\s'")`\\]+/g;
 
-const SUPPORTED_INTERNAL_SCHEMES = ["skill", "agent", "artifact", "plan", "memory", "rule", "local"] as const;
+const SUPPORTED_INTERNAL_SCHEMES = ["skill", "agent", "artifact", "plan", "memory", "rule", "local", "xcsh"] as const;
 
 type SupportedInternalScheme = (typeof SUPPORTED_INTERNAL_SCHEMES)[number];
 

--- a/packages/coding-agent/src/tools/bash-skill-urls.xcsh.test.ts
+++ b/packages/coding-agent/src/tools/bash-skill-urls.xcsh.test.ts
@@ -20,4 +20,22 @@ describe("expandInternalUrls xcsh scheme", () => {
 		});
 		expect(out).toBe("bun '/abs/plugin/engine/cli.ts' score deal.json");
 	});
+
+	test("throws a friendly error when the resolved resource has no sourcePath", async () => {
+		const routerWithoutSourcePath = {
+			canHandle: (input: string) => input.startsWith("xcsh://"),
+			resolve: async (input: string): Promise<InternalResource> => ({
+				url: input,
+				content: "",
+				contentType: "application/json",
+				// list/summary endpoints (xcsh://plugin, xcsh://plugin/<name>) return no sourcePath
+			}),
+		};
+		await expect(
+			expandInternalUrls("bun xcsh://plugin/demo score x", {
+				skills: [],
+				internalRouter: routerWithoutSourcePath,
+			}),
+		).rejects.toThrow();
+	});
 });

--- a/packages/coding-agent/src/tools/bash-skill-urls.xcsh.test.ts
+++ b/packages/coding-agent/src/tools/bash-skill-urls.xcsh.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import type { InternalResource } from "../internal-urls/types";
+import { expandInternalUrls } from "./bash-skill-urls";
+
+describe("expandInternalUrls xcsh scheme", () => {
+	const router = {
+		canHandle: (input: string) => input.startsWith("xcsh://"),
+		resolve: async (input: string): Promise<InternalResource> => ({
+			url: input,
+			content: "",
+			contentType: "application/json",
+			sourcePath: "/abs/plugin/engine/cli.ts",
+		}),
+	};
+
+	test("expands an xcsh:// token to a shell-escaped absolute path", async () => {
+		const out = await expandInternalUrls("bun xcsh://plugin/demo/file/engine/cli.ts score deal.json", {
+			skills: [],
+			internalRouter: router,
+		});
+		expect(out).toBe("bun '/abs/plugin/engine/cli.ts' score deal.json");
+	});
+});


### PR DESCRIPTION
Closes #2142

## Summary

Adds a generic, framework-agnostic `xcsh://plugin/<name>/…` internal-URL capability so the agent can deterministically resolve an **installed** plugin's declared resources — with zero system-prompt cost and independent of skill prompt-gating. This is the foundation for optional framework plugins (first consumer: the MEDDPICC plugin) to be driven through the native protocol.

## What's included

- **`src/internal-urls/plugin-resolve.ts`** — new generic resolver. URI grammar: `xcsh://plugin`, `/<name>`, `/<name>/contract`, `/<name>/schema`, `/<name>/file/<relpath>`, `/<name>/engine`. Reads a plugin-declared manifest `.xcsh-plugin/resources.json`; maps declared keys → files. No domain knowledge.
- **`xcsh-protocol.ts`** — new `plugin` host branch in `InternalDocsProtocolHandler` (router is scheme-keyed; this is a host branch, not a new handler), placed before the doc-filename fallthrough.
- **`sdk.ts`** — injects `getPluginRoots` via the existing cached `listXcshPluginRoots()` (independent of `enableXcshPlugins`).
- **`bash-skill-urls.ts`** — teaches bash URL expansion the `xcsh` scheme so `bun xcsh://plugin/<name>/file/…` expands to a real path.
- Path-traversal guards including **symlink escape** hardening (realpath containment check), covered by a real-filesystem regression test.

## Testing

- `bun test src/internal-urls src/tools/bash-skill-urls.xcsh.test.ts` — green.
- `bun run check:types` — clean.
- Full pre-commit (biome, spelling, editorconfig, secrets, governance) — green on changed files.

## Notes

- Nothing added to the native system prompt; core stays framework-agnostic.
- The MEDDPICC plugin that consumes this ships in a separate PR (marketplace repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)