### PR TITLE
fix(chat-ui): type shared components for preact/compat

### DIFF
--- a/packages/chat-ui/src/components/Composer.tsx
+++ b/packages/chat-ui/src/components/Composer.tsx
@@ -14,7 +14,15 @@
  * `ref.current.setText(text)` / `ref.current.focus()`. This avoids
  * controlled-contenteditable churn and is framework-neutral under preact/compat.
  */
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import {
+	forwardRef,
+	type KeyboardEvent as ReactKeyboardEvent,
+	useCallback,
+	useEffect,
+	useImperativeHandle,
+	useRef,
+	useState,
+} from "react";
 import { type Attachment, serializeAttachments } from "../attachments/model";
 import type { AttachCategory, InteractionMode, ModelOption } from "../types";
 import { AttachMenu } from "./AttachMenu";
@@ -67,9 +75,14 @@ export interface ComposerProps {
 
 /** True while an IME composition is active, so Enter confirms a candidate
  * (CJK etc.) instead of sending a half-typed message. Handles both the React
- * synthetic event (`nativeEvent`) and the raw event preact/compat passes. */
-function isImeComposing(e: React.KeyboardEvent): boolean {
-	const native = e.nativeEvent ?? (e as unknown as KeyboardEvent);
+ * synthetic event (`nativeEvent`) and the raw event preact/compat passes. The
+ * explicit element generic keeps it valid under both React's `KeyboardEvent<T>`
+ * and preact/compat's `TargetedKeyboardEvent<T>` (which requires the argument). */
+function isImeComposing(e: ReactKeyboardEvent<HTMLElement>): boolean {
+	// `nativeEvent` exists on the React synthetic event but NOT on preact/compat's
+	// event type — access it through an optional cast so this compiles under both:
+	// React reads the wrapped DOM event; preact falls back to the (already-raw) event.
+	const native = (e as unknown as { nativeEvent?: KeyboardEvent }).nativeEvent ?? (e as unknown as KeyboardEvent);
 	return Boolean(native?.isComposing) || (e as unknown as { keyCode?: number }).keyCode === 229;
 }
 
@@ -174,7 +187,6 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 					aria-multiline="true"
 					tabIndex={0}
 					data-placeholder={placeholder}
-					suppressContentEditableWarning
 					onInput={handleInput}
 					onKeyDown={e => {
 						if (e.key === "Enter" && !e.shiftKey && !isImeComposing(e)) {

--- a/packages/chat-ui/src/components/GatewayConfigForm.tsx
+++ b/packages/chat-ui/src/components/GatewayConfigForm.tsx
@@ -50,12 +50,12 @@ export function GatewayConfigForm<T>({ validate, onSave, initial, defaultModel, 
 					type="url"
 					value={baseUrl}
 					placeholder="https://127-0-0-1.local-ip.sh:8443/anthropic"
-					onChange={e => setBaseUrl(e.target.value)}
+					onChange={e => setBaseUrl(e.currentTarget.value)}
 				/>
 			</div>
 			<div className="gateway-field">
 				<label htmlFor="gateway-token">Token</label>
-				<input id="gateway-token" type="password" value={token} onChange={e => setToken(e.target.value)} />
+				<input id="gateway-token" type="password" value={token} onChange={e => setToken(e.currentTarget.value)} />
 			</div>
 			<div className="gateway-field">
 				<label htmlFor="gateway-model">Model</label>
@@ -63,7 +63,7 @@ export function GatewayConfigForm<T>({ validate, onSave, initial, defaultModel, 
 					id="gateway-model"
 					value={model}
 					placeholder={defaultModel ?? ""}
-					onChange={e => setModel(e.target.value)}
+					onChange={e => setModel(e.currentTarget.value)}
 				/>
 				{defaultModel && <span className="gateway-hint">Optional — defaults to {defaultModel}</span>}
 			</div>


### PR DESCRIPTION
## Summary

Make the shared `@f5-sales-demo/xcsh-chat-ui` components type-check under **preact/compat**, not just React. They were authored React-only; the Chrome extension (Phase 5, the first Preact consumer) vendors the source and compiles it via `react`→`preact/compat`, surfacing type errors office (React 18) + vscode (React 19) never hit. No behavior change; React hosts stay green.

Closes #2148.

## Changes

- `GatewayConfigForm.tsx`: `e.target.value` → `e.currentTarget.value` (×3) — `currentTarget` is typed as the bound `<input>` in both React and preact.
- `Composer.tsx`:
  - `isImeComposing(e: React.KeyboardEvent)` → `ReactKeyboardEvent<HTMLElement>` via an aliased `import { type KeyboardEvent as ReactKeyboardEvent }` (avoids shadowing the DOM `KeyboardEvent` used in the casts; preact/compat's `TargetedKeyboardEvent<T>` requires the generic arg).
  - read `nativeEvent` through an optional cast so it compiles under both (React reads the wrapped DOM event; preact falls back to the already-raw event).
  - drop `suppressContentEditableWarning` — the contenteditable div has no React-managed children (so React never warns), and preact does not type the prop.

## Verification

- `packages/chat-ui`: `biome check .` + `tsgo -p tsconfig.json` + `tsgo -p tsconfig.client.json` clean; **94/94** package tests pass.
- The vendored copy type-checks + renders under preact/compat in the Chrome extension (f5-sales-demo/xcsh-chrome-extension#305: 404/404 tests, both UATs pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)