### PR TITLE
feat(chat-ui): composer parity for VS Code (slash / tools / thinking)

### DIFF
--- a/packages/chat-ui/src/components/Composer.tsx
+++ b/packages/chat-ui/src/components/Composer.tsx
@@ -24,12 +24,14 @@ import {
 	useState,
 } from "react";
 import { type Attachment, serializeAttachments } from "../attachments/model";
-import type { AttachCategory, InteractionMode, ModelOption } from "../types";
+import type { AttachCategory, InteractionMode, ModelOption, SlashCommand, ToolItem } from "../types";
 import { AttachMenu } from "./AttachMenu";
 import { PlusIcon, SendIcon, StopIcon } from "./icons";
 import { ModelSelector } from "./ModelSelector";
 import { ModeToggle } from "./ModeToggle";
+import { SlashCommandMenu } from "./SlashCommandMenu";
 import { StatusBar } from "./StatusBar";
+import { ToolsPickerMenu } from "./ToolsPickerMenu";
 
 /** Imperative handle a host uses to prefill / focus the uncontrolled editor. */
 export interface ComposerHandle {
@@ -68,6 +70,22 @@ export interface ComposerProps {
 	attachCategories?: AttachCategory[];
 	onRequestAttachment?: (categoryId: string) => void;
 	onRemoveAttachment?: (id: string) => void;
+	/**
+	 * Multi-select tools picker (VS Code parity). When `tools` + `onToolsConfirm`
+	 * are provided AND `attachCategories` includes an id `"tools"`, picking that
+	 * category opens a multi-select popup instead of round-tripping via
+	 * `onRequestAttachment`; confirming fires `onToolsConfirm(names)` so the host
+	 * builds the tools attachment and feeds it back through `attachments`.
+	 */
+	tools?: ToolItem[];
+	onToolsConfirm?: (names: string[]) => void;
+	/** Slash-command menu — a "/" button (rendered only when both are provided). */
+	slashCommands?: SlashCommand[];
+	onSlashSelect?: (command: string) => void;
+	/** Thinking-level control shown inside the mode menu (VS Code parity). */
+	thinkingLevels?: string[];
+	thinkingLevel?: string;
+	onThinkingChange?: (level: string) => void;
 	/** Status bar signals (embedded on the top border). */
 	contextPct?: number | null;
 	sessionLabel?: string;
@@ -115,6 +133,13 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		attachCategories,
 		onRequestAttachment,
 		onRemoveAttachment,
+		tools,
+		onToolsConfirm,
+		slashCommands,
+		onSlashSelect,
+		thinkingLevels,
+		thinkingLevel,
+		onThinkingChange,
 		contextPct = null,
 		sessionLabel = "",
 	},
@@ -122,7 +147,22 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 ) {
 	const editorRef = useRef<HTMLDivElement>(null);
 	const [text, setText] = useState("");
+	const [showToolsPicker, setShowToolsPicker] = useState(false);
 	const hasAttachments = (attachments?.length ?? 0) > 0;
+	const canPickTools = tools != null && onToolsConfirm != null;
+
+	// AttachMenu category pick: the "tools" category opens the multi-select picker
+	// (when tools are provided); every other category round-trips to the host.
+	const handleCategory = useCallback(
+		(id: string) => {
+			if (id === "tools" && canPickTools) {
+				setShowToolsPicker(true);
+				return;
+			}
+			onRequestAttachment?.(id);
+		},
+		[canPickTools, onRequestAttachment],
+	);
 
 	const submit = useCallback(() => {
 		const el = editorRef.current;
@@ -218,14 +258,37 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 				</div>
 			)}
 			<div className="input-footer">
-				{attachCategories && onRequestAttachment ? (
-					<AttachMenu categories={attachCategories} onSelect={onRequestAttachment} disabled={disabled} />
-				) : onAttach ? (
-					<button type="button" className="footer-btn" title="Attach" aria-label="Attach" onClick={onAttach}>
-						<PlusIcon />
-					</button>
-				) : null}
-				{modes && mode != null && onModeChange && <ModeToggle modes={modes} mode={mode} onChange={onModeChange} />}
+				<div className="attach-area" style={{ position: "relative" }}>
+					{showToolsPicker && tools && onToolsConfirm && (
+						<div style={{ position: "absolute", bottom: "100%", left: 0, marginBottom: 4, zIndex: 10 }}>
+							<ToolsPickerMenu
+								tools={tools}
+								onConfirm={onToolsConfirm}
+								onClose={() => setShowToolsPicker(false)}
+							/>
+						</div>
+					)}
+					{attachCategories ? (
+						<AttachMenu categories={attachCategories} onSelect={handleCategory} disabled={disabled} />
+					) : onAttach ? (
+						<button type="button" className="footer-btn" title="Attach" aria-label="Attach" onClick={onAttach}>
+							<PlusIcon />
+						</button>
+					) : null}
+				</div>
+				{slashCommands && onSlashSelect && (
+					<SlashCommandMenu commands={slashCommands} onSelect={onSlashSelect} disabled={disabled} />
+				)}
+				{modes && mode != null && onModeChange && (
+					<ModeToggle
+						modes={modes}
+						mode={mode}
+						onChange={onModeChange}
+						thinkingLevels={thinkingLevels}
+						thinkingLevel={thinkingLevel}
+						onThinkingChange={onThinkingChange}
+					/>
+				)}
 				<div className="footer-spacer" />
 				{models && model != null && onModelChange && (
 					<ModelSelector models={models} model={model} onSelect={onModelChange} disabled={disabled} />

--- a/packages/chat-ui/src/components/ModeToggle.tsx
+++ b/packages/chat-ui/src/components/ModeToggle.tsx
@@ -12,12 +12,28 @@ export interface ModeToggleProps {
 	modes: InteractionMode[];
 	mode: string;
 	onChange: (id: string) => void;
+	/**
+	 * Optional thinking-level control (VS Code parity). When all three are
+	 * provided, the menu shows a divider + a segmented level control below the
+	 * mode list. Office/Chrome omit these and get just the mode list.
+	 */
+	thinkingLevels?: string[];
+	thinkingLevel?: string;
+	onThinkingChange?: (level: string) => void;
 }
 
-export function ModeToggle({ modes, mode, onChange }: ModeToggleProps) {
+export function ModeToggle({
+	modes,
+	mode,
+	onChange,
+	thinkingLevels,
+	thinkingLevel,
+	onThinkingChange,
+}: ModeToggleProps) {
 	const { open, setOpen, toggle, menuRef, triggerRef } = useMenu();
 
 	const current = modes.find(m => m.id === mode);
+	const showThinking = thinkingLevels != null && thinkingLevel != null && onThinkingChange != null;
 
 	return (
 		<div className="mode-toggle" style={{ position: "relative" }}>
@@ -38,6 +54,24 @@ export function ModeToggle({ modes, mode, onChange }: ModeToggleProps) {
 							{m.blurb && <span className="menu-item-desc">{m.blurb}</span>}
 						</button>
 					))}
+					{showThinking && (
+						<div className="thinking-section">
+							<div className="menu-divider" />
+							<span className="thinking-label">Thinking level</span>
+							<div className="thinking-levels">
+								{thinkingLevels.map(level => (
+									<button
+										key={level}
+										type="button"
+										className={`thinking-level-btn ${level === thinkingLevel ? "active" : ""}`}
+										onClick={() => onThinkingChange(level)}
+									>
+										{level}
+									</button>
+								))}
+							</div>
+						</div>
+					)}
 				</div>
 			)}
 			<button

--- a/packages/chat-ui/src/components/SlashCommandMenu.tsx
+++ b/packages/chat-ui/src/components/SlashCommandMenu.tsx
@@ -1,0 +1,60 @@
+/**
+ * The composer's slash-command menu — a "/" trigger button + popup of
+ * host-provided {@link SlashCommand}s. Self-contained like {@link AttachMenu}:
+ * it renders the trigger and the menu; picking an item fires `onSelect(command)`
+ * and closes. The host submits the returned command string as the prompt.
+ * Keyboard/focus a11y comes from {@link useMenu}.
+ */
+import type { SlashCommand } from "../types";
+import { useMenu } from "./useMenu";
+
+export interface SlashCommandMenuProps {
+	commands: SlashCommand[];
+	onSelect: (command: string) => void;
+	disabled?: boolean;
+}
+
+export function SlashCommandMenu({ commands, onSelect, disabled }: SlashCommandMenuProps) {
+	const { open, setOpen, toggle, menuRef, triggerRef } = useMenu();
+	return (
+		<div className="slash-menu" style={{ position: "relative" }}>
+			{open && (
+				<div className="menu menu-up menu-left" role="menu" ref={menuRef}>
+					{commands.length === 0 ? (
+						<div className="menu-header">No commands</div>
+					) : (
+						commands.map(c => (
+							<button
+								key={c.command}
+								type="button"
+								role="menuitem"
+								className="menu-item"
+								onClick={() => {
+									onSelect(c.command);
+									setOpen(false);
+								}}
+							>
+								<span className="menu-item-command">{c.command}</span>
+								<span>{c.label}</span>
+								{c.description && <span className="menu-item-desc">{c.description}</span>}
+							</button>
+						))
+					)}
+				</div>
+			)}
+			<button
+				ref={triggerRef}
+				type="button"
+				className="footer-btn slash-btn"
+				title="Slash commands"
+				aria-label="Slash commands"
+				aria-haspopup="menu"
+				aria-expanded={open}
+				disabled={disabled}
+				onClick={toggle}
+			>
+				/
+			</button>
+		</div>
+	);
+}

--- a/packages/chat-ui/src/components/ToolsPickerMenu.tsx
+++ b/packages/chat-ui/src/components/ToolsPickerMenu.tsx
@@ -1,0 +1,71 @@
+/**
+ * Multi-select popover for the composer's "tools" attach category. Lists the
+ * host-provided {@link ToolItem}s; the user toggles a subset and confirms, firing
+ * `onConfirm(names)` so the host can build a tools attachment. Rendered by the
+ * {@link Composer} when the `tools` category is picked (controlled open state);
+ * `onClose` dismisses without attaching.
+ */
+import { useState } from "react";
+import type { ToolItem } from "../types";
+
+export interface ToolsPickerMenuProps {
+	tools: ToolItem[];
+	onConfirm: (names: string[]) => void;
+	onClose: () => void;
+}
+
+export function ToolsPickerMenu({ tools, onConfirm, onClose }: ToolsPickerMenuProps) {
+	const [selected, setSelected] = useState<Set<string>>(new Set());
+
+	const toggle = (name: string): void => {
+		setSelected(prev => {
+			const next = new Set(prev);
+			if (next.has(name)) {
+				next.delete(name);
+			} else {
+				next.add(name);
+			}
+			return next;
+		});
+	};
+
+	return (
+		<div className="menu menu-up menu-left tools-picker" role="menu">
+			{tools.length === 0 ? (
+				<div className="menu-header">No tools available</div>
+			) : (
+				<>
+					{tools.map(tool => {
+						const isSelected = selected.has(tool.name);
+						return (
+							<button
+								key={tool.name}
+								type="button"
+								className={`menu-item tool-item${isSelected ? " selected" : ""}`}
+								aria-pressed={isSelected}
+								onClick={() => toggle(tool.name)}
+							>
+								<span className="tool-item-indicator" aria-hidden="true">
+									{isSelected ? "✓" : "○"}
+								</span>
+								<span>{tool.label}</span>
+								{tool.description && <span className="menu-item-desc">{tool.description}</span>}
+							</button>
+						);
+					})}
+					<button
+						type="button"
+						className="tools-picker-confirm"
+						disabled={selected.size === 0}
+						onClick={() => {
+							onConfirm(Array.from(selected));
+							onClose();
+						}}
+					>
+						Attach ({selected.size})
+					</button>
+				</>
+			)}
+		</div>
+	);
+}

--- a/packages/chat-ui/src/index.ts
+++ b/packages/chat-ui/src/index.ts
@@ -44,8 +44,10 @@ export {
 	UserMessage,
 	type UserMessageProps,
 } from "./components/messages";
+export { SlashCommandMenu, type SlashCommandMenuProps } from "./components/SlashCommandMenu";
 export { StatusBar, type StatusBarProps } from "./components/StatusBar";
 export { ThinkingBlock, type ThinkingBlockProps } from "./components/ThinkingBlock";
+export { ToolsPickerMenu, type ToolsPickerMenuProps } from "./components/ToolsPickerMenu";
 export { ToolUseContent, type ToolUseContentProps } from "./components/ToolUseContent";
 // ── Transcript + message renderers ────────────────────────────────────────
 export { Transcript, type TranscriptProps } from "./components/Transcript";
@@ -84,5 +86,7 @@ export type {
 	ModelOption,
 	ReactNode,
 	SkillPill,
+	SlashCommand,
+	ToolItem,
 	ToolUseBlock,
 } from "./types";

--- a/packages/chat-ui/src/theme/panel.css.ts
+++ b/packages/chat-ui/src/theme/panel.css.ts
@@ -192,4 +192,27 @@ code { background:var(--code-bg); padding:1px 5px; border-radius:4px; }
   border-radius:6px; padding:6px 14px; cursor:pointer; font:inherit; }
 .gateway-settings-btn { align-self:flex-end; margin:6px 12px 0; background:none; color: var(--cool-gray);
   border:1px solid var(--subtle-gray); border-radius:6px; padding:2px 10px; cursor:pointer; font:inherit; font-size:12px; }
+
+/* ── Slash-command menu (VS Code parity) ────────────────────────────────── */
+.slash-btn { color: var(--cool-gray); font-weight:700; }
+.slash-btn:hover:not(:disabled) { color: var(--f5-red); }
+.menu-item .menu-item-command { color: var(--f5-red); font-weight:600; margin-right:6px; }
+
+/* ── Tools multi-select picker (VS Code parity) ─────────────────────────── */
+.tools-picker .tool-item { align-items:center; }
+.tools-picker .tool-item-indicator { width:14px; text-align:center; color: var(--cool-gray); }
+.tools-picker .tool-item.selected .tool-item-indicator { color: var(--signal-green); }
+.tools-picker-confirm { width:100%; margin-top:4px; background: var(--f5-red); color: var(--pure-white); border:none;
+  border-radius:6px; padding:5px 10px; cursor:pointer; font:inherit; font-size:12px; }
+.tools-picker-confirm:disabled { opacity:.5; cursor:default; }
+
+/* ── Thinking-level control inside the mode menu (VS Code parity) ────────── */
+.thinking-section { padding:6px 4px 2px; }
+.thinking-section .menu-divider { height:1px; background: var(--subtle-gray); margin:4px 0 8px; }
+.thinking-section .thinking-label { display:block; color: var(--cool-gray); font-size:11px; margin-bottom:4px; }
+.thinking-levels { display:flex; gap:4px; }
+.thinking-level-btn { flex:1; background: var(--deep-charcoal); color: var(--cool-gray); border:1px solid var(--subtle-gray);
+  border-radius:4px; padding:3px 0; cursor:pointer; font:inherit; font-size:11px; }
+.thinking-level-btn:hover { color: var(--bright-white); border-color: var(--f5-red); }
+.thinking-level-btn.active { background: var(--f5-red); color: var(--pure-white); border-color: var(--f5-red); }
 `;

--- a/packages/chat-ui/src/types.ts
+++ b/packages/chat-ui/src/types.ts
@@ -69,6 +69,28 @@ export interface AttachCategory {
 	description?: string;
 }
 
+/**
+ * A slash command shown in the composer's `/` menu. The host owns the command
+ * space; the shared UI renders `label`/`description` and reports the picked
+ * `command` string (e.g. "/status"), which the host submits as the prompt.
+ */
+export interface SlashCommand {
+	command: string;
+	label: string;
+	description?: string;
+}
+
+/**
+ * A selectable host tool for the composer's multi-select tools picker (opened by
+ * the `tools` attach category). The host feeds the list; the shared UI reports
+ * the chosen tool `name`s so the host can build a tools attachment.
+ */
+export interface ToolItem {
+	name: string;
+	label: string;
+	description?: string;
+}
+
 /** A rich assistant content block (text / tool_use / thinking). */
 export type ContentBlock =
 	| { type: "text"; text: string }

--- a/packages/chat-ui/test/composer-vscode-controls.test.tsx
+++ b/packages/chat-ui/test/composer-vscode-controls.test.tsx
@@ -1,0 +1,144 @@
+import { expect, test } from "bun:test";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { Composer } from "../src/components/Composer";
+import { ModeToggle } from "../src/components/ModeToggle";
+import { SlashCommandMenu } from "../src/components/SlashCommandMenu";
+import { ToolsPickerMenu } from "../src/components/ToolsPickerMenu";
+import type { AttachCategory, InteractionMode, SlashCommand, ToolItem } from "../src/types";
+
+const COMMANDS: SlashCommand[] = [
+	{ command: "/status", label: "Status", description: "Show integration health" },
+	{ command: "/context", label: "Context" },
+];
+const TOOLS: ToolItem[] = [
+	{ name: "vscode_read_file", label: "Read file", description: "Read a workspace file" },
+	{ name: "vscode_get_selection", label: "Get selection" },
+];
+const CATS: AttachCategory[] = [
+	{ id: "files", label: "Files" },
+	{ id: "tools", label: "Tools" },
+];
+
+test("SlashCommandMenu: '/' trigger opens the menu and onSelect fires the command", () => {
+	let picked = "";
+	render(<SlashCommandMenu commands={COMMANDS} onSelect={c => (picked = c)} />);
+	act(() => {
+		fireEvent.click(screen.getByRole("button", { name: /slash commands/i }));
+	});
+	expect(screen.getByRole("menu")).toBeDefined();
+	fireEvent.click(screen.getByRole("menuitem", { name: /status/i }));
+	expect(picked).toBe("/status");
+	expect(screen.queryByRole("menu")).toBeNull(); // closes after select
+});
+
+test("ToolsPickerMenu: multi-select, confirm disabled until a tool is chosen, then fires names", () => {
+	let confirmed: string[] = [];
+	render(<ToolsPickerMenu tools={TOOLS} onConfirm={n => (confirmed = n)} onClose={() => {}} />);
+	const confirm = screen.getByRole("button", { name: /attach \(0\)/i }) as HTMLButtonElement;
+	expect(confirm.disabled).toBe(true);
+	fireEvent.click(screen.getByRole("button", { name: /read file/i }));
+	fireEvent.click(screen.getByRole("button", { name: /get selection/i }));
+	const confirm2 = screen.getByRole("button", { name: /attach \(2\)/i }) as HTMLButtonElement;
+	expect(confirm2.disabled).toBe(false);
+	fireEvent.click(confirm2);
+	expect(confirmed).toEqual(["vscode_read_file", "vscode_get_selection"]);
+});
+
+test("ToolsPickerMenu: empty tools shows the empty note", () => {
+	render(<ToolsPickerMenu tools={[]} onConfirm={() => {}} onClose={() => {}} />);
+	expect(screen.getByText(/no tools available/i)).toBeDefined();
+});
+
+test("Composer: slashCommands render the '/' menu; selecting fires onSlashSelect", () => {
+	let picked = "";
+	render(
+		<Composer
+			streaming={false}
+			onSend={() => {}}
+			onStop={() => {}}
+			slashCommands={COMMANDS}
+			onSlashSelect={c => (picked = c)}
+		/>,
+	);
+	act(() => {
+		fireEvent.click(screen.getByRole("button", { name: /slash commands/i }));
+	});
+	fireEvent.click(screen.getByRole("menuitem", { name: /context/i }));
+	expect(picked).toBe("/context");
+});
+
+test("Composer: picking the 'tools' category opens the tools picker (not onRequestAttachment)", () => {
+	let requested = "";
+	let confirmed: string[] = [];
+	render(
+		<Composer
+			streaming={false}
+			onSend={() => {}}
+			onStop={() => {}}
+			attachCategories={CATS}
+			onRequestAttachment={id => (requested = id)}
+			tools={TOOLS}
+			onToolsConfirm={n => (confirmed = n)}
+		/>,
+	);
+	act(() => {
+		fireEvent.click(screen.getByRole("button", { name: /add context/i }));
+	});
+	fireEvent.click(screen.getByRole("menuitem", { name: /tools/i }));
+	// The tools category opened the multi-select picker rather than round-tripping.
+	expect(requested).toBe("");
+	fireEvent.click(screen.getByRole("button", { name: /read file/i }));
+	fireEvent.click(screen.getByRole("button", { name: /attach \(1\)/i }));
+	expect(confirmed).toEqual(["vscode_read_file"]);
+});
+
+test("Composer: a non-tools category still round-trips via onRequestAttachment", () => {
+	let requested = "";
+	render(
+		<Composer
+			streaming={false}
+			onSend={() => {}}
+			onStop={() => {}}
+			attachCategories={CATS}
+			onRequestAttachment={id => (requested = id)}
+			tools={TOOLS}
+			onToolsConfirm={() => {}}
+		/>,
+	);
+	act(() => {
+		fireEvent.click(screen.getByRole("button", { name: /add context/i }));
+	});
+	fireEvent.click(screen.getByRole("menuitem", { name: /files/i }));
+	expect(requested).toBe("files");
+});
+
+test("ModeToggle: thinking-level control renders in the menu and fires onThinkingChange", () => {
+	const modes: InteractionMode[] = [
+		{ id: "auto", label: "Auto" },
+		{ id: "confirm", label: "Confirm" },
+	];
+	let level = "";
+	render(
+		<ModeToggle
+			modes={modes}
+			mode="auto"
+			onChange={() => {}}
+			thinkingLevels={["low", "medium", "high"]}
+			thinkingLevel="medium"
+			onThinkingChange={l => (level = l)}
+		/>,
+	);
+	act(() => {
+		// The mode trigger's accessible name is the current mode label.
+		fireEvent.click(screen.getByRole("button", { name: "Auto" }));
+	});
+	expect(screen.getByText(/thinking level/i)).toBeDefined();
+	fireEvent.click(screen.getByRole("button", { name: /^high$/i }));
+	expect(level).toBe("high");
+});
+
+test("Composer: no slash/tools UI when the new props are absent (office/chrome unaffected)", () => {
+	const { container } = render(<Composer streaming={false} onSend={() => {}} onStop={() => {}} />);
+	expect(screen.queryByRole("button", { name: /slash commands/i })).toBeNull();
+	expect(container.querySelector(".tools-picker")).toBeNull();
+});


### PR DESCRIPTION
## Summary

Increment A of Phase 4b: enrich the shared `@f5-sales-demo/xcsh-chat-ui` Composer so the VS Code webview can adopt it (Increment B) without regressing its richer bespoke composer. All three additions are **optional and headless** — Office and Chrome render them only if their props are supplied, so nothing changes for existing consumers.

Closes #2154.

## Changes

- **`SlashCommandMenu`** (new) + `SlashCommand` type. Composer props `slashCommands` + `onSlashSelect` render a `/` footer button whose menu reports the picked command string.
- **`ToolsPickerMenu`** (new) + `ToolItem` type. Composer props `tools` + `onToolsConfirm`. When `attachCategories` includes id `"tools"` and these are provided, picking that category opens the multi-select picker (instead of round-tripping via `onRequestAttachment`); confirming fires `onToolsConfirm(names)`.
- **`ModeToggle`** gains optional `thinkingLevels` / `thinkingLevel` / `onThinkingChange` → a segmented level control below the mode list. VS Code's permission modes (auto/confirm/readonly) map onto the existing `modes` prop.
- **`PANEL_CSS`** styling for the new classes (`.slash-btn`, `.tools-picker*`, `.thinking-*`) in the terminal aesthetic.

## Verification (local)

- `bun run test` (chat-ui) — **102/102**, incl. 8 new TDD cases in `composer-vscode-controls.test.tsx` (slash menu, tools multi-select + empty state, tools-category-opens-picker vs non-tools round-trip, thinking-level, and the office/chrome no-op case).
- `bun run check` (chat-ui) — biome + tsgo (both tsconfigs) clean.
- office-pane (`workspace:*` consumer) `bun run check` clean — additive optional props, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)