### PR TITLE
fix: make release pipeline resilient to transient tag-push failures

### DIFF
--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -119,5 +119,21 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "${TAG}" "${SHA}"
-          git push origin "${TAG}"
+          # Retry ONLY the push: a transient GitHub failure (e.g. HTTP 500) must not
+          # fail the job and strand the repo bumped-but-untagged. Create the tag once
+          # above; push with bounded exponential backoff (5 attempts, delays 5/10/20/40s
+          # between them).
+          attempt=1
+          max_attempts=5
+          delay=5
+          until git push origin "${TAG}"; do
+            if [ "${attempt}" -ge "${max_attempts}" ]; then
+              echo "::error::Failed to push tag ${TAG} after ${max_attempts} attempts. The bump commit ${SHA} is untagged; re-run this workflow via workflow_dispatch with commit_sha=${SHA} once GitHub recovers."
+              exit 1
+            fi
+            echo "Tag push attempt ${attempt} failed; retrying in ${delay}s…"
+            sleep "${delay}"
+            attempt=$((attempt + 1))
+            delay=$((delay * 2))
+          done
           echo "Pushed tag ${TAG} -> ${SHA} — tag-gated release chain will now fire."

--- a/packages/coding-agent/test/scripts/release-classify.test.ts
+++ b/packages/coding-agent/test/scripts/release-classify.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { classifyReleaseAction } from "../../../../scripts/release";
+
+/**
+ * Self-healing auto-release decision (#deterministic-ci).
+ *
+ * A transient GitHub 500 on `git push origin v<X.Y.Z>` in tag-on-version-bump.yml
+ * can leave the repo bumped-in-tree (e.g. 19.69.0) but UNTAGGED. On the next push,
+ * `release.ts auto` recomputes the same target, the version bump is a no-op, and the
+ * empty `git commit` used to crash-loop the release job. `classifyReleaseAction`
+ * distinguishes the three states so the auto-release path can self-heal instead of
+ * crashing: a real release, an already-released version, or a bumped-but-untagged
+ * version needing the tag workflow re-run. Pure + deterministic.
+ */
+describe("classifyReleaseAction", () => {
+	it("target > inRepo → 'release' (normal bump, proceed)", () => {
+		expect(classifyReleaseAction({ target: "19.70.0", inRepoVersion: "19.69.0", tagExists: false })).toBe("release");
+	});
+
+	it("target == inRepo and tag exists → 'already-released'", () => {
+		expect(classifyReleaseAction({ target: "19.69.0", inRepoVersion: "19.69.0", tagExists: true })).toBe(
+			"already-released",
+		);
+	});
+
+	it("target == inRepo and tag missing → 'bumped-untagged' (transient tag-push failure)", () => {
+		expect(classifyReleaseAction({ target: "19.69.0", inRepoVersion: "19.69.0", tagExists: false })).toBe(
+			"bumped-untagged",
+		);
+	});
+});

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -326,6 +326,19 @@ async function openReleasePR(version: string, commits: string[]): Promise<void> 
 
 	console.log("Committing version bump…");
 	await $`git add .`;
+
+	// Defense-in-depth: a no-op bump (repo already at v<version>) stages nothing, and
+	// `git commit` would then throw `nothing to commit`. Detect the empty stage, print
+	// the bumped-untagged remediation, tear down the throwaway release branch, and return
+	// without committing so this can never crash-loop the release job.
+	const staged = (await $`git diff --cached --name-only`.text()).trim();
+	if (!staged) {
+		console.log(bumpedUntaggedGuidance(version));
+		await $`git checkout main`;
+		await $`git branch -D ${branch}`;
+		return;
+	}
+
 	await $`git commit -m ${`chore: bump version to v${version}`}`;
 
 	console.log(`Pushing ${branch} to origin…`);
@@ -479,6 +492,25 @@ async function detectVersionBump(): Promise<{ version: string; bump: BumpType; c
 	};
 }
 
+/** Self-healing auto-release decision. A transient tag-push failure (e.g. HTTP 500 on
+ * `git push origin v<target>`) can leave the repo bumped-in-tree but UNTAGGED. On the
+ * next push `auto-release` recomputes the same `target`, the version bump is a no-op,
+ * and the empty `git commit` would crash-loop the release job. This pure function maps
+ * (target, inRepoVersion, tagExists) to the action the auto-release path should take:
+ *   - "release"          → target advances past the in-repo version; do the bump + PR.
+ *   - "already-released" → target already shipped (bumped AND tagged); nothing to do.
+ *   - "bumped-untagged"  → bumped in-tree but tag missing; the tag workflow needs a
+ *                          re-run — do NOT open an empty release PR. */
+export type ReleaseAction = "release" | "already-released" | "bumped-untagged";
+export function classifyReleaseAction(opts: {
+	target: string; // computed next version, no leading v
+	inRepoVersion: string; // current packages/coding-agent/package.json version
+	tagExists: boolean; // whether tag v<target> already exists (local or origin)
+}): ReleaseAction {
+	if (opts.target !== opts.inRepoVersion) return "release";
+	return opts.tagExists ? "already-released" : "bumped-untagged";
+}
+
 /** Idempotent reconcile plan for the set of open `release/vX.Y.Z` PRs. There must be
  * exactly ONE canonical next version (or none): any open release PR whose version
  * isn't `target` is a stale/superseded phantom (e.g. a v19.63.0 stranded after a
@@ -493,6 +525,33 @@ export function planReleaseReconcile(opts: { openReleaseVersions: string[]; targ
 	const toClose = opts.openReleaseVersions.filter(v => v !== opts.target);
 	const toCreate = opts.target && !opts.openReleaseVersions.includes(opts.target) ? opts.target : null;
 	return { toCreate, toClose };
+}
+
+/** Current in-repo version from the canonical package.json (no leading v). */
+async function readInRepoVersion(): Promise<string> {
+	const pkg = await Bun.file("packages/coding-agent/package.json").json();
+	return String(pkg.version).replace(/^v/, "");
+}
+
+/** Whether tag `v<version>` already exists locally or on origin (best-effort). */
+async function tagExists(version: string): Promise<boolean> {
+	const local = await $`git rev-parse -q --verify refs/tags/v${version}`.quiet().nothrow();
+	if (local.exitCode === 0) return true;
+	const remote = (await $`git ls-remote --tags origin refs/tags/v${version}`.quiet().nothrow().text()).trim();
+	return remote.length > 0;
+}
+
+/** Actionable guidance when the repo is bumped-in-tree but tag `v<version>` is missing
+ * (a likely transient tag-push failure). Printed by both the auto-release guard and the
+ * openReleasePR empty-stage defense so the operator sees the same remediation either way. */
+function bumpedUntaggedGuidance(version: string): string {
+	return [
+		`v${version} is already bumped in-tree but tag v${version} is missing`,
+		"  (likely a transient tag-push failure in tag-on-version-bump.yml).",
+		"  Remediate: re-run the \"Tag on version bump\" workflow via workflow_dispatch",
+		`  with commit_sha set to the "chore: bump version to v${version}" bump commit.`,
+		"  Not opening an empty release PR.",
+	].join("\n");
 }
 
 /** Versions of the currently-open `release/vX.Y.Z` PRs (best-effort; [] on error). */
@@ -545,6 +604,24 @@ async function cmdAutoRelease(): Promise<void> {
 		console.log(`  - ${c}`);
 	}
 	console.log();
+
+	// Self-heal: if the computed target already equals the in-repo version, the bump was
+	// already applied. Either it fully shipped (tag present → nothing to do) or the tag
+	// push failed transiently (tag missing → guide the operator, never open an empty PR).
+	const inRepoVersion = await readInRepoVersion();
+	const action = classifyReleaseAction({
+		target: result.version,
+		inRepoVersion,
+		tagExists: await tagExists(result.version),
+	});
+	if (action === "already-released") {
+		console.log(`v${result.version} already released — nothing to do.`);
+		process.exit(0);
+	}
+	if (action === "bumped-untagged") {
+		console.log(bumpedUntaggedGuidance(result.version));
+		process.exit(0);
+	}
 
 	if (plan.toCreate) {
 		await cmdRelease(result.version, result.commits);


### PR DESCRIPTION
Closes #2156

## Problem

A transient GitHub `remote: Internal Server Error` (HTTP 500) on `git push origin v19.69.0` in `tag-on-version-bump.yml` — a step with **no retry** — failed the tag job when the v19.69.0 bump (#2135) merged. The tag was never created, so the tag-gated release chain never fired (no npm/Homebrew), and `scripts/release.ts` then **crash-looped** on every push (the no-op version bump produced an empty `git commit`). One transient 500 permanently wedged all releases.

## Fix (root-cause, self-healing)

1. **`tag-on-version-bump.yml`** — the tag is created once, and the `git push` now retries with exponential backoff (5 attempts, 5→80s) so a transient 500 no longer fails the job. Untrusted-input safety (`env:`-only TAG/SHA) and `set -euo pipefail` preserved; retried via `until` condition-position so `set -e` doesn't abort on a failed attempt.
2. **`scripts/release.ts`** — new pure, unit-tested `classifyReleaseAction()` (`release | already-released | bumped-untagged`). Auto-release now reads the in-repo version + tag existence and, when already at target (bumped-but-untagged), **exits 0 with actionable guidance** instead of crashing. Defense-in-depth: `openReleasePR` guards the empty stage and returns without `git commit`, so the `nothing to commit` ShellError is unreachable by two independent routes.

## Testing

- New `packages/coding-agent/test/scripts/release-classify.test.ts` (RED→GREEN), all 3 states; `bun test packages/coding-agent/test/scripts/` = 18 pass.
- `bun run check:types` clean; `actionlint` on the workflow exit 0; embedded shell `shfmt`/`shellcheck` clean.

## Operational note

The stuck state was already recovered out-of-band: `v19.69.0` was backfilled via `tag-on-version-bump.yml` `workflow_dispatch`, firing the release chain. This PR prevents recurrence.

## Follow-ups (minor, non-blocking)

- `tagExists()` evaluated eagerly on the happy path (could be lazy).
- empty-stage guard assumes a local `main` ref (only reachable if the primary guard is bypassed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)