### PR TITLE
fix(coding-agent): default web_search on so research subagents get the tool

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1371,12 +1371,11 @@ export const SETTINGS_SCHEMA = {
 
 	"web_search.enabled": {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: {
 			tab: "tools",
 			label: "Web Search",
-			description:
-				"Enable the web_search tool for web searching (disabled by default to prevent accidental PII exposure via prompt injection)",
+			description: "Enable the web_search tool for web searching.",
 		},
 	},
 	"web_search.verbose": {

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -66,7 +66,7 @@ describe("createTools", () => {
 		expect(names).toContain("notebook");
 		expect(names).toContain("task");
 		expect(names).toContain("todo_write");
-		expect(names).not.toContain("web_search");
+		expect(names).toContain("web_search");
 		expect(names).toContain("exit_plan_mode");
 		expect(names).not.toContain("fetch");
 		expect(names).not.toContain("vim");
@@ -250,15 +250,15 @@ describe("createTools", () => {
 		expect(names).toContain("search_tool_bm25");
 	});
 
-	it("web_search.enabled defaults to false for PII safety", () => {
-		expect(getDefault("web_search.enabled")).toBe(false);
+	it("web_search.enabled defaults to true", () => {
+		expect(getDefault("web_search.enabled")).toBe(true);
 	});
 
-	it("excludes web_search from default tools (disabled by default)", async () => {
+	it("includes web_search in default tools (enabled by default)", async () => {
 		const session = createTestSession();
 		const tools = await createTools(session);
 		const names = tools.map(t => t.name);
-		expect(names).not.toContain("web_search");
+		expect(names).toContain("web_search");
 	});
 
 	it("includes web_search when explicitly enabled via settings", async () => {


### PR DESCRIPTION
## Summary

`web_search.enabled` defaulted to `false`, and the subagent tool gate (`packages/coding-agent/src/tools/index.ts`) **silently drops** any tool an agent declares but that is disabled. The bundled `librarian` lists `web_search` as its primary research tool, so it was spawned without it, could never produce a schema-valid `submit_result`, and aborted after the reminder retries were exhausted:

> `SYSTEM WARNING: Subagent exited without calling submit_result tool after 3 reminders.`

This flips `web_search.enabled` to default `true` so agents that declare the tool actually receive it. (`fetch.enabled` / read-URL was already `true`.)

## Changes

- `settings-schema.ts`: `web_search.enabled` default `false` → `true`; reword the now-inaccurate description (dropped the "disabled by default to prevent PII" text).
- `test/tools/index.test.ts`: update the three assertions that pinned the old default (default value, default-tools inclusion, core-tools list). The explicit-disable and explicit-enable path tests are unchanged.

## Verification

- `bun test test/tools/index.test.ts` — green (TDD: assertions flipped first and confirmed red against the old default, then green after the flip).
- Full `packages/coding-agent` suite: **5585 pass, 541 skip, 0 fail** (525 files).
- Biome clean on changed files; no CHANGELOG edit (release-managed in this repo), so no textlint prose risk.

## Scope

Deliberately narrow per issue: only the default flip + description + tests. Silent tool-stripping diagnostics, reminder-exhaustion salvage, and the librarian's source-repo-vs-docs-site design mismatch are noted as residual and left out of scope.

Closes #2159
