### PR TITLE
feat(coding-agent): tell subagents which declared tools are unavailable

### DIFF
--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1030,6 +1030,29 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				await session.setActiveToolsByName(filteredSubagentTools);
 			}
 
+			// Surface tools the agent declared but that are unavailable this session,
+			// so the model can report the blocker instead of silently stalling.
+			const declaredTools = agent.tools ?? [];
+			let unavailableToolsNotice = "";
+			if (declaredTools.length > 0) {
+				const activeToolSet = new Set(session.getActiveToolNames());
+				const execSatisfied = activeToolSet.has("python") || activeToolSet.has("bash");
+				const managedToolNames = new Set(["submit_result", "todo_write", "resolve", "task"]);
+				const unavailableTools = declaredTools.filter(name => {
+					if (activeToolSet.has(name)) return false;
+					if (managedToolNames.has(name)) return false;
+					if (name === "exec") return !execSatisfied;
+					return true;
+				});
+				if (unavailableTools.length > 0) {
+					unavailableToolsNotice =
+						"<system-reminder>\n" +
+						`These tools you may expect are unavailable in this session (disabled in settings): ${unavailableTools.join(", ")}. ` +
+						"Do not attempt to use them. If a capability you need is missing, call submit_result with result.error describing the blocker.\n" +
+						"</system-reminder>\n\n";
+				}
+			}
+
 			session.sessionManager.appendSessionInit({
 				systemPrompt: session.agent.state.systemPrompt,
 				task,
@@ -1126,7 +1149,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				}
 			});
 
-			await session.prompt(task, { attribution: "agent" });
+			await session.prompt(`${unavailableToolsNotice}${task}`, { attribution: "agent" });
 			await session.waitForIdle();
 
 			const reminderToolChoice = buildNamedToolChoice("submit_result", session.model);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1038,16 +1038,18 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				const activeToolSet = new Set(session.getActiveToolNames());
 				const execSatisfied = activeToolSet.has("python") || activeToolSet.has("bash");
 				const managedToolNames = new Set(["submit_result", "todo_write", "resolve", "task"]);
+				const isSafeToolName = (name: string) => /^[a-zA-Z0-9_-]+$/.test(name);
 				const unavailableTools = declaredTools.filter(name => {
 					if (activeToolSet.has(name)) return false;
 					if (managedToolNames.has(name)) return false;
+					if (!isSafeToolName(name)) return false;
 					if (name === "exec") return !execSatisfied;
 					return true;
 				});
 				if (unavailableTools.length > 0) {
 					unavailableToolsNotice =
 						"<system-reminder>\n" +
-						`These tools you may expect are unavailable in this session (disabled in settings): ${unavailableTools.join(", ")}. ` +
+						`These tools you may expect are unavailable in this session: ${unavailableTools.join(", ")}. ` +
 						"Do not attempt to use them. If a capability you need is missing, call submit_result with result.error describing the blocker.\n" +
 						"</system-reminder>\n\n";
 				}

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -38,6 +38,7 @@ function createMockSession(
 		emit: (event: AgentSessionEvent) => void;
 		state: { messages: AssistantMessage[] };
 	}) => void,
+	activeToolNames: string[] = ["read", "submit_result"],
 ): AgentSession {
 	const listeners: Array<(event: AgentSessionEvent) => void> = [];
 	const state = { messages: [] as AssistantMessage[] };
@@ -55,7 +56,7 @@ function createMockSession(
 		sessionManager: {
 			appendSessionInit: () => {},
 		},
-		getActiveToolNames: () => ["read", "submit_result"],
+		getActiveToolNames: () => activeToolNames,
 		setActiveToolsByName: async (_toolNames: string[]) => {},
 		subscribe: (listener: (event: AgentSessionEvent) => void) => {
 			listeners.push(listener);
@@ -435,5 +436,56 @@ describe("runSubprocess submit_result reminders", () => {
 
 		expect(prompts[0]).toBe("do work");
 		expect(prompts[0]).not.toContain("unavailable in this session");
+	});
+
+	it("reports exec as unavailable when neither python nor bash is active", async () => {
+		const prompts: string[] = [];
+		const session = createMockSession(
+			({ text, emit }) => {
+				prompts.push(text);
+				emit({
+					type: "tool_execution_end",
+					toolCallId: "tool-ok",
+					toolName: "submit_result",
+					result: {
+						content: [{ type: "text", text: "Result submitted." }],
+						details: { status: "success", data: { ok: true } },
+					},
+					isError: false,
+				});
+			},
+			["read", "submit_result"],
+		);
+		mockCreateAgentSession(session);
+
+		await runSubprocess({ ...baseOptions, id: "subagent-exec-missing", agent: { ...baseAgent, tools: ["exec"] } });
+
+		expect(prompts[0]).toContain("exec");
+		expect(prompts[0]).toContain("unavailable in this session");
+	});
+
+	it("treats exec as available when bash is active", async () => {
+		const prompts: string[] = [];
+		const session = createMockSession(
+			({ text, emit }) => {
+				prompts.push(text);
+				emit({
+					type: "tool_execution_end",
+					toolCallId: "tool-ok",
+					toolName: "submit_result",
+					result: {
+						content: [{ type: "text", text: "Result submitted." }],
+						details: { status: "success", data: { ok: true } },
+					},
+					isError: false,
+				});
+			},
+			["bash", "submit_result"],
+		);
+		mockCreateAgentSession(session);
+
+		await runSubprocess({ ...baseOptions, id: "subagent-exec-ok", agent: { ...baseAgent, tools: ["exec"] } });
+
+		expect(prompts[0]).toBe("do work");
 	});
 });

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -382,4 +382,58 @@ describe("runSubprocess submit_result reminders", () => {
 		expect(result.aborted).toBe(false);
 		expect(result.output).toContain('"ok": true');
 	});
+
+	it("prepends a notice when a declared tool is unavailable this session", async () => {
+		const prompts: string[] = [];
+		const session = createMockSession(({ text, emit }) => {
+			prompts.push(text);
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-ok",
+				toolName: "submit_result",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		mockCreateAgentSession(session);
+
+		await runSubprocess({
+			...baseOptions,
+			id: "subagent-notice",
+			agent: { ...baseAgent, tools: ["read", "web_search"] },
+		});
+
+		expect(prompts[0]).toContain("web_search");
+		expect(prompts[0]).toContain("unavailable in this session");
+	});
+
+	it("does not add a notice when all declared tools are available", async () => {
+		const prompts: string[] = [];
+		const session = createMockSession(({ text, emit }) => {
+			prompts.push(text);
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-ok",
+				toolName: "submit_result",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		mockCreateAgentSession(session);
+
+		await runSubprocess({
+			...baseOptions,
+			id: "subagent-no-notice",
+			agent: { ...baseAgent, tools: ["read"] },
+		});
+
+		expect(prompts[0]).toBe("do work");
+		expect(prompts[0]).not.toContain("unavailable in this session");
+	});
 });


### PR DESCRIPTION
## Summary
When a subagent declares a tool that is disabled in settings, tool resolution silently drops it, so the agent stalls into the opaque reminder-exhaustion abort instead of reporting the gap. This prepends a `<system-reminder>` notice to the subagent's first task prompt listing the unavailable declared tools and instructing it to call `submit_result` with `result.error` when a needed capability is missing.

Follow-up to the `web_search` default fix (#2159/#2160), which exposed this silent-stripping defect.

## Details
- `executor.ts` (`runSubagent`): compute declared(`agent.tools`) − active(`getActiveToolNames()`), excluding managed names (`submit_result`, `todo_write`, `resolve`, `task`) and treating `exec` as satisfied when `python`/`bash` is active. Tool names are sanitized against `^[a-zA-Z0-9_-]+$` before interpolation (prevents prompt-injection via a plugin-declared tool name). First prompt only; reminder prompts unchanged.
- Tests: notice present when a declared tool is inactive; absent when all active; `exec` alias covered both ways.

## Verification
- `bun test test/task/executor-subagent-reminders.test.ts` — 13 pass, 0 fail.
- Biome clean on changed files.

Closes #2164