### PR TITLE
feat(office-pane): gate chat on configure_ack + surface configure failures

### DIFF
--- a/packages/chat-ui/src/components/GatewayGate.tsx
+++ b/packages/chat-ui/src/components/GatewayGate.tsx
@@ -3,14 +3,23 @@
  * headless: no Transport / store / ChatPanel imports (those stay per-host). The
  * host owns the persisted config (passes it in as `config`, persists via
  * `onSaveConfig`); this gate only decides whether to show the
- * {@link GatewayConfigForm} or the host-rendered chat (`children(config)`), plus
- * a Settings affordance to reconfigure.
+ * {@link GatewayConfigForm} or the host-rendered chat (`children(config, api)`),
+ * plus a Settings affordance to reconfigure. `api.reconfigure()` lets the child
+ * reopen the (prefilled) form itself — e.g. a configure-error banner's recovery
+ * action — without routing through the generic Settings button.
  *
  * Browser-safe: no node:* imports, no Office.js.
  */
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import type { GatewayConfigDraft, GatewayValidateResult, ReactNode } from "../types";
 import { GatewayConfigForm } from "./GatewayConfigForm";
+
+/** Imperative capabilities handed to the chat child so it can drive the gate. */
+export interface GatewayGateChildApi {
+	/** Reopen the config form (prefilled via `configToDraft`) — e.g. a recovery
+	 *  action on a configure-error banner. */
+	reconfigure: () => void;
+}
 
 export interface GatewayGateProps<T> {
 	/** The host's currently persisted config, or null when unconfigured. */
@@ -19,7 +28,7 @@ export interface GatewayGateProps<T> {
 	/** Host persists the new config (and re-renders with an updated `config`). */
 	onSaveConfig: (config: T) => void;
 	/** Renders the chat over a configured gateway. */
-	children: (config: T) => ReactNode;
+	children: (config: T, api: GatewayGateChildApi) => ReactNode;
 	/** First-run prefill (e.g. a manifest `gateway_url`). */
 	initial?: Partial<GatewayConfigDraft>;
 	/**
@@ -42,6 +51,7 @@ export function GatewayGate<T>({
 	defaultModel,
 }: GatewayGateProps<T>) {
 	const [editing, setEditing] = useState(false);
+	const reconfigure = useCallback(() => setEditing(true), []);
 
 	if (!config || editing) {
 		// When editing an existing config, prefill from it (via configToDraft);
@@ -63,10 +73,10 @@ export function GatewayGate<T>({
 
 	return (
 		<>
-			<button type="button" className="gateway-settings-btn" onClick={() => setEditing(true)}>
+			<button type="button" className="gateway-settings-btn" onClick={reconfigure}>
 				Settings
 			</button>
-			{children(config)}
+			{children(config, { reconfigure })}
 		</>
 	);
 }

--- a/packages/chat-ui/src/index.ts
+++ b/packages/chat-ui/src/index.ts
@@ -23,7 +23,7 @@ export { ContextChip, type ContextChipProps } from "./components/ContextChip";
 export { EmptyState, type EmptyStateProps } from "./components/EmptyState";
 // ── Gateway config ────────────────────────────────────────────────────────
 export { GatewayConfigForm, type GatewayConfigFormProps } from "./components/GatewayConfigForm";
-export { GatewayGate, type GatewayGateProps } from "./components/GatewayGate";
+export { GatewayGate, type GatewayGateChildApi, type GatewayGateProps } from "./components/GatewayGate";
 // ── Shell (header / empty state / context chip / activation overlay) ───────
 export { HeaderBar, type HeaderBarProps } from "./components/HeaderBar";
 export { PlusIcon, SendIcon, StopIcon } from "./components/icons";

--- a/packages/chat-ui/src/theme/panel.css.ts
+++ b/packages/chat-ui/src/theme/panel.css.ts
@@ -192,6 +192,11 @@ code { background:var(--code-bg); padding:1px 5px; border-radius:4px; }
   border-radius:6px; padding:6px 14px; cursor:pointer; font:inherit; }
 .gateway-settings-btn { align-self:flex-end; margin:6px 12px 0; background:none; color: var(--cool-gray);
   border:1px solid var(--subtle-gray); border-radius:6px; padding:2px 10px; cursor:pointer; font:inherit; font-size:12px; }
+/* Config-error recovery view (a rejected provider configure — #2134). */
+.gateway-config-error { display:flex; flex-direction:column; align-items:flex-start; gap:8px; margin:16px 12px;
+  padding:12px 14px; background: var(--deep-charcoal); border:1px solid var(--alert-red); border-radius:8px; }
+.gateway-config-error-title { color: var(--alert-red); font-weight:600; margin:0; }
+.gateway-config-error-detail { color: var(--bright-white); font-size:12px; margin:0; word-break:break-word; }
 
 /* ── Slash-command menu (VS Code parity) ────────────────────────────────── */
 .slash-btn { color: var(--cool-gray); font-weight:700; }

--- a/packages/chat-ui/test/GatewayGate.test.tsx
+++ b/packages/chat-ui/test/GatewayGate.test.tsx
@@ -81,3 +81,23 @@ test("without configToDraft the reopened form is blank (falls back to initial)",
 	fireEvent.click(screen.getByRole("button", { name: /settings/i }));
 	expect((screen.getByLabelText(/gateway url/i) as HTMLInputElement).value).toBe("");
 });
+
+test("children get a reconfigure() that reopens the PREFILLED form (recovery path for a bad config)", () => {
+	const cfg: Cfg = { baseUrl: "https://gw/anthropic", token: "t" };
+	render(
+		<GatewayGate<Cfg> config={cfg} validate={validate} onSaveConfig={() => {}} configToDraft={c => c}>
+			{(c, { reconfigure }) => (
+				<div>
+					chat over {c.baseUrl}
+					<button type="button" onClick={reconfigure}>
+						fix gateway
+					</button>
+				</div>
+			)}
+		</GatewayGate>,
+	);
+	// The child (e.g. a configure-error banner) drives reconfigure itself — not the
+	// generic Settings button — and lands on the prefilled form.
+	fireEvent.click(screen.getByRole("button", { name: /fix gateway/i }));
+	expect((screen.getByLabelText(/gateway url/i) as HTMLInputElement).value).toBe("https://gw/anthropic");
+});

--- a/packages/office-pane/src/office/transport-factory.ts
+++ b/packages/office-pane/src/office/transport-factory.ts
@@ -5,14 +5,16 @@
  *
  *  - create a `LoopbackBridgeTransport` to the local xcsh bridge;
  *  - wire the host-appropriate Office.js document tools;
- *  - on connect, point xcsh's provider at the saved gateway via the `configure`
- *    frame BEFORE advertising the host tools (both need an open socket), but only
- *    when the bridge advertised the capability (`canConfigureProvider`) — else the
- *    awaited `configure()` would hang until disconnect against a bridge that
- *    never answers `configure_ack`;
- *  - a `configure` rejection is logged and does NOT block host-tool advertisement
- *    (the session still works against xcsh's baked-in default provider). Surfacing
- *    that failure into the panel is tracked in #2134.
+ *  - expose a `provision()` that points xcsh's provider at the saved gateway via
+ *    the `configure` frame, but only when the bridge advertised the capability
+ *    (`canConfigureProvider`) — else `provision` is absent (nothing to configure,
+ *    and an awaited `configure()` against a bridge that never answers would hang);
+ *  - expose `onConnected()` that advertises the host tools.
+ *
+ * The panel (`useChatSession`) sequences these: connect → provision → onConnected,
+ * gating chat until provisioning resolves. A `configure` rejection PROPAGATES out
+ * of `provision()` (it is no longer swallowed here) so the panel surfaces it as a
+ * non-silent error instead of proceeding against xcsh's baked-in default (#2134).
  *
  * The concrete transport + host-tool wiring are injected (defaulting to the real
  * ones) so tests exercise the ordering/gating/error paths with no Office runtime.
@@ -58,18 +60,14 @@ export function makeBuildTransport(
 		const wired = deps.wireHostTools(host, transport);
 		return {
 			transport,
-			onConnected: () => {
-				void (async () => {
-					if (transport.canConfigureProvider) {
-						try {
-							await transport.configure({ baseUrl: config.baseUrl, token: config.token, model: config.model });
-						} catch (err) {
-							console.error("[transport-factory] provider configure failed:", err);
-						}
+			// Only when the bridge can configure; a rejection propagates (the panel
+			// surfaces it) rather than being swallowed here.
+			provision: transport.canConfigureProvider
+				? async () => {
+						await transport.configure({ baseUrl: config.baseUrl, token: config.token, model: config.model });
 					}
-					wired.onConnected();
-				})();
-			},
+				: undefined,
+			onConnected: () => wired.onConnected(),
 		};
 	};
 }

--- a/packages/office-pane/src/panel/ChatPanel.tsx
+++ b/packages/office-pane/src/panel/ChatPanel.tsx
@@ -27,8 +27,15 @@ import { DEFAULT_INTERACTION_MODE, useChatSession } from "./useChatSession";
 
 export interface ChatPanelProps {
 	transport: Transport;
-	/** Fired once after the transport connects — e.g. to advertise host tools. */
+	/**
+	 * Point xcsh's provider at the saved gateway before chat is enabled. Runs after
+	 * connect(); a rejection gates chat and shows the config-error recovery view.
+	 */
+	provision?: () => Promise<void>;
+	/** Fired once after provisioning succeeds — e.g. to advertise host tools. */
 	onConnected?: () => void;
+	/** Recovery action for a configure failure — reopens the gateway config form. */
+	onReconfigure?: () => void;
 }
 
 /** Host-agnostic starter prompts; picking one prefills (not sends) the composer. */
@@ -43,13 +50,55 @@ const STARTERS: readonly (SkillPill & { text: string })[] = [
 	{ id: "summarize", label: "Summarize", hint: "Prefill a prompt", text: "Summarize this document." },
 ];
 
-export function ChatPanel({ transport, onConnected }: ChatPanelProps) {
-	const { turns, send, stop, retry, status, reason, error } = useChatSession(transport, onConnected);
+/** The F5-branded terminal header, shared by the chat and config-error views. */
+function Header() {
+	return (
+		<div className="header">
+			<F5Logo variant="mark" size={20} />
+			<span className="header-title">xcsh</span>
+		</div>
+	);
+}
+
+/** Composer placeholder while the gateway connection is being established. */
+const PROVISIONING_PLACEHOLDER: Record<string, string> = {
+	connecting: "Connecting to xcsh…",
+	configuring: "Configuring gateway…",
+};
+
+export function ChatPanel({ transport, provision, onConnected, onReconfigure }: ChatPanelProps) {
+	const { turns, send, stop, retry, status, reason, error, provisioning, provisionError } = useChatSession(transport, {
+		provision,
+		onConnected,
+	});
 	const [mode, setMode] = useState<string>(DEFAULT_INTERACTION_MODE);
 	const composerRef = useRef<ComposerHandle>(null);
 
 	const messages = useMemo(() => turnsToMessages({ turns, status, reason, error }), [turns, status, reason, error]);
 	const streaming = status === "streaming";
+
+	// A rejected provider `configure` is a non-silent, recoverable state: show the
+	// reason and a Reconfigure action instead of a chat that would silently talk to
+	// xcsh's baked-in default provider. #2134.
+	if (provisioning === "error") {
+		return (
+			<>
+				<Header />
+				<div className="gateway-config-error" role="alert">
+					<p className="gateway-config-error-title">Couldn't configure the gateway.</p>
+					<p className="gateway-config-error-detail">
+						{provisionError ?? "The provider configuration was rejected."}
+					</p>
+					<button type="button" className="msg-retry" onClick={() => onReconfigure?.()}>
+						Reconfigure
+					</button>
+				</div>
+			</>
+		);
+	}
+
+	// Chat is gated until provisioning resolves so a turn can't race `configure_ack`.
+	const ready = provisioning === "ready";
 
 	const emptyState = (
 		<EmptyState
@@ -60,14 +109,13 @@ export function ChatPanel({ transport, onConnected }: ChatPanelProps) {
 
 	return (
 		<>
-			<div className="header">
-				<F5Logo variant="mark" size={20} />
-				<span className="header-title">xcsh</span>
-			</div>
+			<Header />
 			<Transcript messages={messages} streaming={streaming} onRetry={() => retry()} emptyState={emptyState} />
 			<Composer
 				ref={composerRef}
 				streaming={streaming}
+				disabled={!ready}
+				placeholder={ready ? undefined : PROVISIONING_PLACEHOLDER[provisioning]}
 				onSend={text => send(text, mode as InteractionMode)}
 				onStop={stop}
 				modes={MODE_OPTIONS}

--- a/packages/office-pane/src/panel/GatewayGate.tsx
+++ b/packages/office-pane/src/panel/GatewayGate.tsx
@@ -27,9 +27,19 @@ import {
 } from "../core";
 import { ChatPanel } from "./ChatPanel";
 
-/** A transport plus the optional post-connect hook (e.g. advertise host tools). */
+/** A transport plus the optional post-connect lifecycle hooks. */
 export interface BuiltTransport {
 	transport: Transport;
+	/**
+	 * Point xcsh's provider at the saved gateway (the single-engine `configure`
+	 * round-trip). Runs after `connect()` and BEFORE {@link onConnected}; resolves
+	 * on `configure_ack` and REJECTS on `configure_error` / mid-configure
+	 * disconnect so the panel can surface the failure instead of proceeding
+	 * silently against xcsh's baked-in default provider (#2134). Absent when the
+	 * bridge did not advertise the capability (nothing to configure).
+	 */
+	provision?: () => Promise<void>;
+	/** Advertise host tools once provisioning succeeds (needs an open socket). */
 	onConnected?: () => void;
 }
 
@@ -82,7 +92,16 @@ export function GatewayGate({ store, buildTransport, initial }: GatewayGateProps
 			configToDraft={cfg => cfg}
 			defaultModel={DEFAULT_GATEWAY_MODEL}
 		>
-			{() => (built ? <ChatPanel transport={built.transport} onConnected={built.onConnected} /> : null)}
+			{(_cfg, { reconfigure }) =>
+				built ? (
+					<ChatPanel
+						transport={built.transport}
+						provision={built.provision}
+						onConnected={built.onConnected}
+						onReconfigure={reconfigure}
+					/>
+				) : null
+			}
 		</SharedGatewayGate>
 	);
 }

--- a/packages/office-pane/src/panel/index.ts
+++ b/packages/office-pane/src/panel/index.ts
@@ -4,5 +4,12 @@ export type { ChatPanelProps } from "./ChatPanel";
 export { ChatPanel } from "./ChatPanel";
 export type { BuiltTransport, GatewayGateProps } from "./GatewayGate";
 export { GatewayGate } from "./GatewayGate";
-export type { AssistantTurn, ChatSessionResult, Turn, UserTurn } from "./useChatSession";
+export type {
+	AssistantTurn,
+	ChatSessionHooks,
+	ChatSessionResult,
+	Provisioning,
+	Turn,
+	UserTurn,
+} from "./useChatSession";
 export { DEFAULT_INTERACTION_MODE, useChatSession } from "./useChatSession";

--- a/packages/office-pane/src/panel/useChatSession.ts
+++ b/packages/office-pane/src/panel/useChatSession.ts
@@ -22,6 +22,25 @@ import {
 
 export const DEFAULT_INTERACTION_MODE: InteractionMode = "configuration";
 
+/**
+ * Post-connect lifecycle hooks. `provision` points xcsh's provider at the saved
+ * gateway (the `configure` round-trip) and runs BEFORE `onConnected`; the session
+ * sequences connect → provision → onConnected and gates chat until it resolves.
+ */
+export interface ChatSessionHooks {
+	provision?: () => Promise<void>;
+	onConnected?: () => void;
+}
+
+/**
+ * Provisioning lifecycle, distinct from the chat `status`:
+ * - `connecting`  — awaiting `transport.connect()`
+ * - `configuring` — connected, running `provision()` (the gateway `configure`)
+ * - `ready`       — provisioned; chat is enabled and host tools are advertised
+ * - `error`       — `provision()` rejected (configure_error / mid-configure drop)
+ */
+export type Provisioning = "connecting" | "configuring" | "ready" | "error";
+
 export interface UserTurn {
 	kind: "user";
 	id: string;
@@ -47,34 +66,59 @@ export interface ChatSessionResult {
 	/** Raw error text when status is 'error'; the fallback shown when `reason`
 	 *  is absent (an unclassified error), so the banner is never silent. */
 	error?: string;
+	/** Provisioning lifecycle — chat is gated until this is 'ready'. */
+	provisioning: Provisioning;
+	/** Set when provisioning is 'error' (a rejected provider `configure`); the
+	 *  panel renders it as a non-silent, recoverable error rather than proceeding. */
+	provisionError?: string;
 }
 
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
-export function useChatSession(transport: Transport, onConnected?: () => void): ChatSessionResult {
+export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): ChatSessionResult {
 	const [turns, setTurns] = useState<Turn[]>([]);
 	// Holds a connect() rejection; reset whenever transport changes.
 	const [connectErr, setConnectErr] = useState<{ reason: ChatErrorReason; message: string } | null>(null);
+	const [provisioning, setProvisioning] = useState<Provisioning>("connecting");
+	const [provisionError, setProvisionError] = useState<string | undefined>(undefined);
 	const counterRef = useRef(0);
 	const activeTurnIdRef = useRef<string | null>(null);
 	const lastUserTextRef = useRef<string>("");
 	const lastUserModeRef = useRef<InteractionMode>(DEFAULT_INTERACTION_MODE);
 	// Held in a ref so a changing callback identity doesn't re-run the connect effect.
-	const onConnectedRef = useRef(onConnected);
-	onConnectedRef.current = onConnected;
+	const hooksRef = useRef(hooks);
+	hooksRef.current = hooks;
 
 	useEffect(() => {
 		let mounted = true;
-		// Reset any prior connect error when the transport instance changes.
+		// Reset lifecycle state when the transport instance changes.
 		setConnectErr(null);
+		setProvisioning("connecting");
+		setProvisionError(undefined);
 		transport
 			.connect()
-			.then(() => {
-				// Fire the connected hook once the transport is open, so callers can
-				// advertise host tools (set_host_tools requires an open socket).
-				if (mounted) onConnectedRef.current?.();
+			.then(async () => {
+				if (!mounted) return;
+				// Connected → point xcsh's provider at the gateway before enabling chat.
+				setProvisioning("configuring");
+				try {
+					await hooksRef.current?.provision?.();
+				} catch (err: unknown) {
+					// A rejected provider configure is surfaced (never swallowed): chat
+					// stays gated and host tools are NOT advertised. #2134.
+					console.error("[useChatSession] provider configure failed:", err);
+					if (mounted) {
+						setProvisionError(err instanceof Error ? err.message : String(err));
+						setProvisioning("error");
+					}
+					return;
+				}
+				if (!mounted) return;
+				// Provisioned → enable chat, then advertise host tools (needs an open socket).
+				setProvisioning("ready");
+				hooksRef.current?.onConnected?.();
 			})
 			.catch((err: unknown) => {
 				console.error("[useChatSession] transport.connect() failed:", err);
@@ -182,5 +226,5 @@ export function useChatSession(transport: Transport, onConnected?: () => void): 
 		status = "idle";
 	}
 
-	return { turns, send, stop, retry, status, reason, error };
+	return { turns, send, stop, retry, status, reason, error, provisioning, provisionError };
 }

--- a/packages/office-pane/test/ChatPanel.test.tsx
+++ b/packages/office-pane/test/ChatPanel.test.tsx
@@ -1,7 +1,14 @@
 import { expect, test } from "bun:test";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MockTransport } from "../src/core";
 import { ChatPanel } from "../src/panel";
+
+/** Flush the connect→provision→ready microtask chain. */
+async function settle(): Promise<void> {
+	await act(async () => {
+		await new Promise(r => setTimeout(r, 0));
+	});
+}
 
 test("renders the terminal shell: header, transcript live region, and composer", () => {
 	const { container } = render(<ChatPanel transport={new MockTransport()} />);
@@ -12,10 +19,12 @@ test("renders the terminal shell: header, transcript live region, and composer",
 	expect(scope.getByText("xcsh")).toBeDefined();
 });
 
-test("the empty state offers starter pills that PREFILL the composer without sending", () => {
+test("the empty state offers starter pills that PREFILL the composer without sending", async () => {
 	const mock = new MockTransport();
 	const { container } = render(<ChatPanel transport={mock} />);
 	const scope = within(container);
+	// Once provisioned (no provision hook → ready after connect), the composer is enabled.
+	await settle();
 
 	const pill = scope.getByRole("button", { name: /summarize/i });
 	fireEvent.click(pill);
@@ -26,4 +35,43 @@ test("the empty state offers starter pills that PREFILL the composer without sen
 	// Send is enabled for the user to submit when they choose to.
 	expect(mock.sent.filter(m => m.type === "chat_request")).toHaveLength(0);
 	expect((scope.getByRole("button", { name: /send/i }) as HTMLButtonElement).disabled).toBe(false);
+});
+
+test("the composer cannot send a turn before provisioning resolves (configure_ack gate)", async () => {
+	const mock = new MockTransport();
+	// A provision that never resolves keeps the pane in 'configuring'.
+	const provision = () => new Promise<void>(() => {});
+	const { container } = render(<ChatPanel transport={mock} provision={provision} />);
+	const scope = within(container);
+	await settle();
+
+	// Editor is non-editable and the Send button is disabled while configuring.
+	const editor = scope.getByRole("textbox", { name: /message input/i });
+	expect(editor.getAttribute("contenteditable")).toBe("false");
+	expect((scope.getByRole("button", { name: /send/i }) as HTMLButtonElement).disabled).toBe(true);
+	// Even an Enter keypress can't push a turn through the gate.
+	fireEvent.keyDown(editor, { key: "Enter" });
+	expect(mock.sent.filter(m => m.type === "chat_request")).toHaveLength(0);
+});
+
+test("a rejected provision renders a NON-SILENT config error with a Reconfigure recovery action", async () => {
+	const mock = new MockTransport();
+	let reconfigured = 0;
+	const provision = () => Promise.reject(new Error("configure_error: token expired"));
+	const { container } = render(
+		<ChatPanel transport={mock} provision={provision} onReconfigure={() => (reconfigured += 1)} />,
+	);
+	const scope = within(container);
+
+	// The failure is surfaced as an alert carrying the reason — not swallowed to console.
+	const alert = await waitFor(() => scope.getByRole("alert"));
+	expect(alert.textContent).toMatch(/token expired/i);
+
+	// The recovery action reopens the gateway config.
+	const reconfigure = scope.getByRole("button", { name: /reconfigure/i });
+	fireEvent.click(reconfigure);
+	expect(reconfigured).toBe(1);
+
+	// Chat is NOT presented while unconfigured.
+	expect(scope.queryByRole("textbox", { name: /message input/i })).toBeNull();
 });

--- a/packages/office-pane/test/GatewayGate.test.tsx
+++ b/packages/office-pane/test/GatewayGate.test.tsx
@@ -9,7 +9,7 @@
  * transport built from the config) once one is.
  */
 import { expect, test } from "bun:test";
-import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { type GatewayConfig, MemoryGatewayConfigStore, MockTransport, normalizeGatewayConfig } from "../src/core";
 import { GatewayGate } from "../src/panel/GatewayGate";
 
@@ -145,6 +145,32 @@ test("reconfiguring via Settings disposes the superseded transport (no socket le
 	expect(built).toHaveLength(2);
 	expect(built[0].state).toBe("closed");
 	expect(built[1].state).not.toBe("closed");
+});
+
+test("a failed provider configure surfaces the error and Reconfigure reopens the prefilled form (#2134)", async () => {
+	const store = new MemoryGatewayConfigStore();
+	store.save(CONFIG);
+	render(
+		<GatewayGate
+			store={store}
+			buildTransport={() => ({
+				transport: new MockTransport(),
+				// Simulates the bridge answering configure_error (e.g. a bad token).
+				provision: () => Promise.reject(new Error("configure_error: invalid token")),
+			})}
+		/>,
+	);
+
+	// The failure is a visible, non-silent alert — chat is NOT shown.
+	const alert = await waitFor(() => screen.getByRole("alert"));
+	expect(within(alert).getByText(/invalid token/i)).toBeDefined();
+	expect(screen.queryByLabelText(/message input/i)).toBeNull();
+
+	// Reconfigure lands on the config form, prefilled from the stored config.
+	await act(async () => {
+		fireEvent.click(screen.getByRole("button", { name: /reconfigure/i }));
+	});
+	expect((screen.getByLabelText(/gateway url/i) as HTMLInputElement).value).toBe("https://gw.example/anthropic");
 });
 
 // A validation failure keeps the form up and surfaces the actionable message.

--- a/packages/office-pane/test/transport-factory.test.ts
+++ b/packages/office-pane/test/transport-factory.test.ts
@@ -5,9 +5,6 @@ import { makeBuildTransport } from "../src/office/transport-factory";
 
 const CONFIG: GatewayConfig = { baseUrl: "https://gw/anthropic", token: "t", model: "m" };
 
-/** Flush the async on-connect IIFE (a macrotask tick). */
-const tick = (): Promise<void> => new Promise(r => setTimeout(r, 0));
-
 /**
  * A ConfigurableTransport stub that records a shared call-order log (so ordering
  * vs. host-tool advertisement is observable) and the config it was given.
@@ -40,25 +37,41 @@ function build(host: OfficeHost, stub: ReturnType<typeof makeStub>) {
 }
 
 describe("makeBuildTransport", () => {
-	test("configure() runs BEFORE host tools are advertised, with the saved config", async () => {
+	test("provision() configures xcsh's provider with the saved config, resolving on ack", async () => {
 		const stub = makeStub();
-		build("Excel", stub).onConnected?.();
-		await tick();
-		expect(stub.calls).toEqual(["configure", "advertise"]);
+		const built = build("Excel", stub);
+		await built.provision?.();
+		expect(stub.calls).toEqual(["configure"]);
 		expect(stub.config()).toEqual({ baseUrl: "https://gw/anthropic", token: "t", model: "m" });
 	});
 
-	test("a rejected configure() still advertises host tools (degrade, don't silently break)", async () => {
-		const stub = makeStub({ configureRejects: true });
-		build("Word", stub).onConnected?.();
-		await tick();
+	test("provision runs BEFORE host tools are advertised (the panel sequences provision → onConnected)", async () => {
+		const stub = makeStub();
+		const built = build("Word", stub);
+		// The panel awaits provision() then calls onConnected(); replicate that order here.
+		await built.provision?.();
+		built.onConnected?.();
 		expect(stub.calls).toEqual(["configure", "advertise"]);
 	});
 
-	test("skips configure() when the bridge did not advertise the capability", async () => {
+	test("a rejected configure PROPAGATES from provision() (not swallowed) so the panel can surface it", async () => {
+		const stub = makeStub({ configureRejects: true });
+		const built = build("Word", stub);
+		expect(built.provision).toBeDefined();
+		await expect(built.provision?.()).rejects.toThrow(/configure_error/);
+		// Host tools are NOT advertised as a side effect of provision failing.
+		expect(stub.calls).toEqual(["configure"]);
+	});
+
+	test("provision is undefined when the bridge did not advertise the capability (xcsh keeps its default)", () => {
 		const stub = makeStub({ canConfigure: false });
-		build("PowerPoint", stub).onConnected?.();
-		await tick();
+		const built = build("PowerPoint", stub);
+		expect(built.provision).toBeUndefined();
+	});
+
+	test("onConnected advertises the host-appropriate document tools", () => {
+		const stub = makeStub();
+		build("Excel", stub).onConnected?.();
 		expect(stub.calls).toEqual(["advertise"]);
 	});
 

--- a/packages/office-pane/test/useChatSession.test.tsx
+++ b/packages/office-pane/test/useChatSession.test.tsx
@@ -24,13 +24,74 @@ test("onConnected fires exactly once after the transport connects", async () => 
 	let count = 0;
 	await act(async () => {
 		renderHook(() =>
-			useChatSession(mock, () => {
-				count += 1;
+			useChatSession(mock, {
+				onConnected: () => {
+					count += 1;
+				},
 			}),
 		);
 		await new Promise(r => setTimeout(r, 0));
 	});
 	expect(count).toBe(1);
+});
+
+test("with no provision, provisioning settles to 'ready' after connect (chat enabled)", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	await waitFor(() => {
+		expect(result.current.provisioning).toBe("ready");
+	});
+	expect(result.current.provisionError).toBeUndefined();
+});
+
+test("provision() runs BEFORE onConnected, and only then does provisioning become 'ready'", async () => {
+	const mock = new MockTransport();
+	const order: string[] = [];
+	let resolveProvision: () => void = () => {};
+	const provision = () =>
+		new Promise<void>(r => {
+			order.push("provision");
+			resolveProvision = r;
+		});
+	const { result } = renderHook(() =>
+		useChatSession(mock, { provision, onConnected: () => order.push("onConnected") }),
+	);
+
+	// While provision is pending, chat is gated and host tools are NOT advertised.
+	await waitFor(() => {
+		expect(result.current.provisioning).toBe("configuring");
+	});
+	expect(order).toEqual(["provision"]);
+
+	// Resolving the ack advances to ready and fires onConnected exactly once, after provision.
+	await act(async () => {
+		resolveProvision();
+		await new Promise(r => setTimeout(r, 0));
+	});
+	await waitFor(() => {
+		expect(result.current.provisioning).toBe("ready");
+	});
+	expect(order).toEqual(["provision", "onConnected"]);
+});
+
+test("a rejected provision surfaces provisioning='error' + provisionError and does NOT advertise host tools", async () => {
+	const mock = new MockTransport();
+	let advertised = false;
+	const provision = () => Promise.reject(new Error("configure_error: bad token"));
+	const { result } = renderHook(() =>
+		useChatSession(mock, {
+			provision,
+			onConnected: () => {
+				advertised = true;
+			},
+		}),
+	);
+
+	await waitFor(() => {
+		expect(result.current.provisioning).toBe("error");
+	});
+	expect(result.current.provisionError).toMatch(/configure_error: bad token/);
+	expect(advertised).toBe(false);
 });
 
 test("a reason-less chat_error surfaces status=error with raw error text (no silent state)", async () => {


### PR DESCRIPTION
## Problem

Closes #2134. The single-engine `configure` round-trip (Claude-for-Office gateway parity) had two lifecycle gaps flagged in the Phase-3 review:

1. **Configure failure was console-only, then the pane proceeded anyway** — a `configure_error` (or mid-configure disconnect) was `console.error`'d and host tools were advertised regardless, so the pane silently ran against xcsh's baked-in default provider. Violated the "never silent" posture.
2. **A chat could be sent before `configure_ack`** — the composer was interactive immediately on connect, so a first turn could race the provider config.

## Change

- **`transport-factory`**: split the fire-and-forget on-connect IIFE into a `provision()` step (the `configure` round-trip, absent when the bridge can't configure) separate from `onConnected` (host-tool advertise). A rejected `configure` now **propagates** out of `provision()` instead of being swallowed.
- **`useChatSession`**: sequences `connect → configuring → ready`, exposing `provisioning` + `provisionError`. On a `provision` rejection it goes to `error` and does **not** advertise host tools / enable chat.
- **`ChatPanel`**: composer is `disabled` (with a "Configuring gateway…" placeholder) until `provisioning === "ready"` — a turn can't race `configure_ack`. A rejected configure renders a **non-silent `role="alert"` config-error** carrying the reason, with a **Reconfigure** recovery action.
- **Shared `GatewayGate`** (`@f5-sales-demo/xcsh-chat-ui`): hands its children a `reconfigure()` so the error banner reopens the **prefilled** config form (not the generic Settings button, not a blank form).

## Acceptance criteria (#2134)

- [x] A `configure_error` / mid-configure disconnect renders a non-silent panel error with a recovery action.
- [x] The composer cannot send a turn before `configure_ack` (gated composer + Enter-key blocked).
- [x] `makeBuildTransport` is unit-tested for ordering + failure propagation.

## Verification

- TDD across `transport-factory` / `useChatSession` / `ChatPanel` / `GatewayGate` (office + chat-ui).
- `chat-ui` **103/0**, `office-pane` **236/0**; `biome check` clean; `tsgo` type-check clean; office-pane browser-safe build (no `node:` builtins) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)