### PR TITLE
feat(coding-agent): let the librarian research documentation sites

### DIFF
--- a/packages/coding-agent/src/prompts/agents/librarian.md
+++ b/packages/coding-agent/src/prompts/agents/librarian.md
@@ -17,24 +17,25 @@ output:
         properties:
           repo:
             metadata:
-              description: GitHub repo (owner/name) or package name
+              description: GitHub repo (owner/name), package name, or documentation site/domain
             type: string
           path:
             metadata:
-              description: File path within the repo or node_modules
+              description: File path within the repo or node_modules, or the full page URL for a documentation source
             type: string
-          line_start:
-            metadata:
-              description: First relevant line (1-indexed)
-            type: number
-          line_end:
-            metadata:
-              description: Last relevant line (1-indexed)
-            type: number
           excerpt:
             metadata:
               description: Verbatim code or doc excerpt proving the claim
             type: string
+        optionalProperties:
+          line_start:
+            metadata:
+              description: First relevant line (1-indexed); omit for documentation sources
+            type: number
+          line_end:
+            metadata:
+              description: Last relevant line (1-indexed); omit for documentation sources
+            type: number
     api:
       metadata:
         description: Extracted API signatures, types, or config relevant to the question
@@ -79,7 +80,7 @@ Before acting, determine what kind of question this is:
 - **Conceptual**: "How do I use X?", "Best practice for Y?" — Prioritize types, docs, and usage examples.
 - **Implementation**: "How does X implement Y?", "Show me the source of Z" — Clone and read the actual code.
 - **Behavioral**: "Why does X behave this way?", "What's the default for Y?" — Read implementation, find where values are set, check tests.
-- **Documentation**: "What are the configured steps for X?", "What does the vendor doc say about Y?" — Fetch authoritative documentation pages and quote them verbatim.
+- **Documentation**: "What are the steps to configure X?", "What does the vendor doc say about Y?" — Fetch authoritative documentation pages and quote them verbatim.
 
 ## 2. Locate the source (local first)
 - **Check local dependencies first**: Look in `node_modules/<package>`, `vendor/`, or similar. If the library is already installed, read it there — no clone needed. Prioritize `.d.ts` type definitions and exported types.
@@ -118,6 +119,6 @@ Before acting, determine what kind of question this is:
 </directives>
 
 <critical>
-Source code is truth. Documentation is aspiration. Training data is history.
+Source code is truth. READMEs are aspiration; official vendor documentation is authoritative for documentation questions. Training data is history.
 You **MUST** keep going until you have a definitive, source-verified answer.
 </critical>

--- a/packages/coding-agent/src/prompts/agents/librarian.md
+++ b/packages/coding-agent/src/prompts/agents/librarian.md
@@ -1,6 +1,6 @@
 ---
 name: librarian
-description: Researches external libraries and APIs by reading source code. Returns definitive, source-verified answers.
+description: Researches external libraries, APIs, and authoritative documentation by reading source code and vendor docs. Returns definitive, source-verified answers.
 tools: read, grep, find, bash, lsp, web_search, ast_grep
 model: pi/smol
 thinking-level: minimal
@@ -79,10 +79,12 @@ Before acting, determine what kind of question this is:
 - **Conceptual**: "How do I use X?", "Best practice for Y?" — Prioritize types, docs, and usage examples.
 - **Implementation**: "How does X implement Y?", "Show me the source of Z" — Clone and read the actual code.
 - **Behavioral**: "Why does X behave this way?", "What's the default for Y?" — Read implementation, find where values are set, check tests.
+- **Documentation**: "What are the configured steps for X?", "What does the vendor doc say about Y?" — Fetch authoritative documentation pages and quote them verbatim.
 
 ## 2. Locate the source (local first)
 - **Check local dependencies first**: Look in `node_modules/<package>`, `vendor/`, or similar. If the library is already installed, read it there — no clone needed. Prioritize `.d.ts` type definitions and exported types.
 - **Otherwise clone**: Use `web_search` to find the canonical repo, then `git clone --depth 1 <url> /tmp/librarian-<name>`.
+- **For documentation questions**: Use `web_search` to find the authoritative page (official docs or vendor portal), then use `read` on the URL to fetch page content. Quote verbatim excerpts with their exact URLs and cross-reference at least two pages.
 - **For a specific version**: Clone then `git checkout tags/<version>`, or read the locally installed version.
 
 ## 3. Investigate

--- a/packages/coding-agent/test/task/librarian-agent.test.ts
+++ b/packages/coding-agent/test/task/librarian-agent.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { getBundledAgent } from "../../src/task/agents";
+
+describe("librarian agent definition", () => {
+	it("advertises documentation research in its description", () => {
+		const librarian = getBundledAgent("librarian");
+		expect(librarian).toBeDefined();
+		expect(librarian?.description.toLowerCase()).toContain("documentation");
+	});
+
+	it("has a documentation-research branch in its procedure", () => {
+		const librarian = getBundledAgent("librarian");
+		expect(librarian?.systemPrompt).toContain("For documentation questions");
+	});
+});

--- a/packages/coding-agent/test/task/librarian-agent.test.ts
+++ b/packages/coding-agent/test/task/librarian-agent.test.ts
@@ -12,4 +12,25 @@ describe("librarian agent definition", () => {
 		const librarian = getBundledAgent("librarian");
 		expect(librarian?.systemPrompt).toContain("For documentation questions");
 	});
+
+	it("treats source line numbers as optional (for documentation citations)", () => {
+		const librarian = getBundledAgent("librarian");
+		const output = librarian?.output as {
+			properties?: {
+				sources?: {
+					elements?: {
+						properties?: Record<string, unknown>;
+						optionalProperties?: Record<string, unknown>;
+					};
+				};
+			};
+		};
+		const elements = output?.properties?.sources?.elements;
+		expect(elements?.properties?.line_start).toBeUndefined();
+		expect(elements?.properties?.line_end).toBeUndefined();
+		expect(elements?.optionalProperties?.line_start).toBeDefined();
+		expect(elements?.optionalProperties?.line_end).toBeDefined();
+		// code fields remain required
+		expect(elements?.properties?.excerpt).toBeDefined();
+	});
 });


### PR DESCRIPTION
## Summary
The `librarian` agent researched libraries only by cloning/reading source repos, so tasks asking it to quote authoritative documentation had no procedure. This adds a documentation-research branch and widens the `sources` schema so documentation citations are well-formed.

Follow-up to the `web_search` default fix (#2159/#2160), which exposed this gap.

## Details
- `librarian.md`: description now covers documentation; a **Documentation** classify category; a **For documentation questions** procedure step (find via `web_search`, fetch page content via `read` on the URL, quote verbatim excerpts with exact URLs, cross-reference ≥2 pages).
- Schema widening: `sources` line numbers (`line_start`/`line_end`) moved to `optionalProperties` (documentation pages have none); `repo`/`path` descriptions broadened to cover documentation site/URL. Structure otherwise unchanged.
- Closing guidance softened so official vendor documentation is authoritative for documentation questions, keeping source-code preference for implementation/behavioral questions.
- Tests: definition test asserts the description + procedure cover documentation and that line numbers are optional while `excerpt` stays required.

## Verification
- `bun test test/task/librarian-agent.test.ts` — 3 pass, 0 fail; `test/task/` slice — 53 pass, 0 fail.
- textlint (terminology) clean; Biome clean.

Closes #2168