### PR TITLE
feat(office-pane): chat-first pane — gateway config optional, not a forced login

### DIFF
--- a/packages/chat-ui/src/components/GatewayGate.tsx
+++ b/packages/chat-ui/src/components/GatewayGate.tsx
@@ -2,11 +2,19 @@
  * Config-or-chat orchestration, reskinned to the terminal aesthetic and made
  * headless: no Transport / store / ChatPanel imports (those stay per-host). The
  * host owns the persisted config (passes it in as `config`, persists via
- * `onSaveConfig`); this gate only decides whether to show the
- * {@link GatewayConfigForm} or the host-rendered chat (`children(config, api)`),
- * plus a Settings affordance to reconfigure. `api.reconfigure()` lets the child
- * reopen the (prefilled) form itself — e.g. a configure-error banner's recovery
- * action — without routing through the generic Settings button.
+ * `onSaveConfig`); this gate decides whether to show the {@link GatewayConfigForm}
+ * or the host-rendered chat (`children(config, api)`), plus a Settings affordance
+ * to reconfigure. `api.reconfigure()` lets the child reopen the (prefilled) form
+ * itself — e.g. a configure-error banner's recovery action — without routing
+ * through the generic Settings button.
+ *
+ * Two modes:
+ *  - **config-required** (default): a missing config forces the form first (the
+ *    gateway is mandatory before chat).
+ *  - **chat-first** (`optional`): a missing config renders the chat anyway, with
+ *    config demoted to the optional Settings affordance. For a single-engine host
+ *    (xcsh) whose agent already has provider credentials, so the pane should not
+ *    gate on a redundant login; `children` may then be called with `config: null`.
  *
  * Browser-safe: no node:* imports, no Office.js.
  */
@@ -27,8 +35,14 @@ export interface GatewayGateProps<T> {
 	validate: (draft: GatewayConfigDraft) => GatewayValidateResult<T>;
 	/** Host persists the new config (and re-renders with an updated `config`). */
 	onSaveConfig: (config: T) => void;
-	/** Renders the chat over a configured gateway. */
-	children: (config: T, api: GatewayGateChildApi) => ReactNode;
+	/** Renders the chat. In chat-first (`optional`) mode `config` may be null. */
+	children: (config: T | null, api: GatewayGateChildApi) => ReactNode;
+	/**
+	 * Chat-first mode: a missing config does NOT force the form — render `children`
+	 * (chat) with config demoted to the Settings affordance. Default false
+	 * (config-required: a missing config shows the form first).
+	 */
+	optional?: boolean;
 	/** First-run prefill (e.g. a manifest `gateway_url`). */
 	initial?: Partial<GatewayConfigDraft>;
 	/**
@@ -46,6 +60,7 @@ export function GatewayGate<T>({
 	validate,
 	onSaveConfig,
 	children,
+	optional = false,
 	initial,
 	configToDraft,
 	defaultModel,
@@ -53,7 +68,9 @@ export function GatewayGate<T>({
 	const [editing, setEditing] = useState(false);
 	const reconfigure = useCallback(() => setEditing(true), []);
 
-	if (!config || editing) {
+	// The form shows on explicit edit, or on first run ONLY when config is required.
+	// In chat-first (optional) mode a missing config falls through to the chat.
+	if (editing || (!config && !optional)) {
 		// When editing an existing config, prefill from it (via configToDraft);
 		// on first run there is no config, so fall back to the `initial` prefill.
 		const prefill = editing && config ? (configToDraft?.(config) ?? initial) : initial;
@@ -66,7 +83,9 @@ export function GatewayGate<T>({
 					onSaveConfig(cfg);
 					setEditing(false);
 				}}
-				onCancel={config ? () => setEditing(false) : undefined}
+				// Cancellable back to chat when there's a config to fall back to, or
+				// when chat works without one (optional/chat-first mode).
+				onCancel={config || optional ? () => setEditing(false) : undefined}
 			/>
 		);
 	}

--- a/packages/chat-ui/test/GatewayGate.test.tsx
+++ b/packages/chat-ui/test/GatewayGate.test.tsx
@@ -26,7 +26,7 @@ test("shows the config form when unconfigured, then the chat after a save", () =
 					stored = c;
 				}}
 			>
-				{cfg => <div>chat over {cfg.baseUrl}</div>}
+				{cfg => <div>chat over {cfg?.baseUrl}</div>}
 			</GatewayGate>
 		);
 	}
@@ -49,7 +49,7 @@ test("the Settings button reopens the config form over an existing config", () =
 	const cfg: Cfg = { baseUrl: "https://gw/anthropic", token: "t" };
 	render(
 		<GatewayGate<Cfg> config={cfg} validate={validate} onSaveConfig={() => {}}>
-			{c => <div>chat over {c.baseUrl}</div>}
+			{c => <div>chat over {c?.baseUrl}</div>}
 		</GatewayGate>,
 	);
 	expect(screen.getByText(/chat over/)).toBeDefined();
@@ -64,7 +64,7 @@ test("configToDraft prefills the form from the current config when reopened via 
 	const cfg: Cfg = { baseUrl: "https://gw/anthropic", token: "t" };
 	render(
 		<GatewayGate<Cfg> config={cfg} validate={validate} onSaveConfig={() => {}} configToDraft={c => c}>
-			{c => <div>chat over {c.baseUrl}</div>}
+			{c => <div>chat over {c?.baseUrl}</div>}
 		</GatewayGate>,
 	);
 	fireEvent.click(screen.getByRole("button", { name: /settings/i }));
@@ -75,7 +75,7 @@ test("without configToDraft the reopened form is blank (falls back to initial)",
 	const cfg: Cfg = { baseUrl: "https://gw/anthropic", token: "t" };
 	render(
 		<GatewayGate<Cfg> config={cfg} validate={validate} onSaveConfig={() => {}}>
-			{c => <div>chat over {c.baseUrl}</div>}
+			{c => <div>chat over {c?.baseUrl}</div>}
 		</GatewayGate>,
 	);
 	fireEvent.click(screen.getByRole("button", { name: /settings/i }));
@@ -88,7 +88,7 @@ test("children get a reconfigure() that reopens the PREFILLED form (recovery pat
 		<GatewayGate<Cfg> config={cfg} validate={validate} onSaveConfig={() => {}} configToDraft={c => c}>
 			{(c, { reconfigure }) => (
 				<div>
-					chat over {c.baseUrl}
+					chat over {c?.baseUrl}
 					<button type="button" onClick={reconfigure}>
 						fix gateway
 					</button>
@@ -100,4 +100,30 @@ test("children get a reconfigure() that reopens the PREFILLED form (recovery pat
 	// generic Settings button — and lands on the prefilled form.
 	fireEvent.click(screen.getByRole("button", { name: /fix gateway/i }));
 	expect((screen.getByLabelText(/gateway url/i) as HTMLInputElement).value).toBe("https://gw/anthropic");
+});
+
+test("optional (chat-first): with NO config, renders the chat (config null) — not the form", () => {
+	render(
+		<GatewayGate<Cfg> config={null} validate={validate} onSaveConfig={() => {}} optional>
+			{cfg => <div>chat cfg={cfg === null ? "null" : cfg.baseUrl}</div>}
+		</GatewayGate>,
+	);
+	// Chat-first: no forced form; children rendered with a null config.
+	expect(screen.getByText("chat cfg=null")).toBeDefined();
+	expect(screen.queryByRole("button", { name: /save|connect/i })).toBeNull();
+	// Config is still reachable via Settings.
+	expect(screen.getByRole("button", { name: /settings/i })).toBeDefined();
+});
+
+test("optional (chat-first): Settings opens the form and Cancel returns to chat even with no config", () => {
+	render(
+		<GatewayGate<Cfg> config={null} validate={validate} onSaveConfig={() => {}} optional>
+			{() => <div>the chat</div>}
+		</GatewayGate>,
+	);
+	fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+	expect(screen.getByRole("button", { name: /save|connect/i })).toBeDefined();
+	// Cancellable back to chat despite there being no stored config.
+	fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+	expect(screen.getByText("the chat")).toBeDefined();
 });

--- a/packages/office-pane/src/office/host-adapter.ts
+++ b/packages/office-pane/src/office/host-adapter.ts
@@ -62,8 +62,9 @@ export async function initOfficeHost(office: OfficeLike = getOffice()): Promise<
 /** What {@link mountGate} needs to render the config-or-chat gate. */
 export interface MountGateOptions {
 	store: GatewayConfigStore;
-	/** Build the transport for a saved config (creates it, wires host tools, configures xcsh). */
-	buildTransport: (config: GatewayConfig) => BuiltTransport;
+	/** Build the transport for the current config (creates it, wires host tools, and
+	 *  configures xcsh when a config is present). A `null` config is chat-first. */
+	buildTransport: (config: GatewayConfig | null) => BuiltTransport;
 	/** Optional first-run form prefill (e.g. a manifest `gateway_url`). */
 	initial?: Partial<GatewayConfigInput>;
 }

--- a/packages/office-pane/src/office/transport-factory.ts
+++ b/packages/office-pane/src/office/transport-factory.ts
@@ -47,26 +47,33 @@ const defaultDeps: TransportFactoryDeps = {
 };
 
 /**
- * Build the `buildTransport` factory the GatewayGate calls once per saved config.
- * Captures the detected {@link OfficeHost} so each built transport advertises the
- * right document tools.
+ * Build the `buildTransport` factory the GatewayGate calls once per config
+ * identity. Captures the detected {@link OfficeHost} so each built transport
+ * advertises the right document tools.
+ *
+ * A `null` config is the CHAT-FIRST default (no stored pane config): the built
+ * transport just connects and chats over xcsh's already-configured provider — no
+ * `provision` step. A non-null config additionally points xcsh's provider at the
+ * saved gateway via {@link BuiltTransport.provision}.
  */
 export function makeBuildTransport(
 	host: OfficeHost,
 	deps: TransportFactoryDeps = defaultDeps,
-): (config: GatewayConfig) => BuiltTransport {
-	return (config: GatewayConfig): BuiltTransport => {
+): (config: GatewayConfig | null) => BuiltTransport {
+	return (config: GatewayConfig | null): BuiltTransport => {
 		const transport = deps.createTransport();
 		const wired = deps.wireHostTools(host, transport);
 		return {
 			transport,
-			// Only when the bridge can configure; a rejection propagates (the panel
-			// surfaces it) rather than being swallowed here.
-			provision: transport.canConfigureProvider
-				? async () => {
-						await transport.configure({ baseUrl: config.baseUrl, token: config.token, model: config.model });
-					}
-				: undefined,
+			// Provision only when there IS a config to apply AND the bridge can
+			// configure; a rejection propagates (the panel surfaces it) rather than
+			// being swallowed here. No config → chat over xcsh's existing provider.
+			provision:
+				config && transport.canConfigureProvider
+					? async () => {
+							await transport.configure({ baseUrl: config.baseUrl, token: config.token, model: config.model });
+						}
+					: undefined,
 			onConnected: () => wired.onConnected(),
 		};
 	};

--- a/packages/office-pane/src/panel/ChatPanel.tsx
+++ b/packages/office-pane/src/panel/ChatPanel.tsx
@@ -19,7 +19,7 @@ import {
 	type SkillPill,
 	Transcript,
 } from "@f5-sales-demo/xcsh-chat-ui";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import type { InteractionMode, Transport } from "../core";
 import { MODE_OPTIONS, turnsToMessages } from "./adapt";
@@ -36,6 +36,13 @@ export interface ChatPanelProps {
 	onConnected?: () => void;
 	/** Recovery action for a configure failure — reopens the gateway config form. */
 	onReconfigure?: () => void;
+	/**
+	 * Fired once per error episode when a chat turn fails because the configured
+	 * provider rejected the request (`provider-4xx` — a bad/absent gateway token),
+	 * so the host can auto-open the gateway config. Distinct from `onReconfigure`
+	 * (a connect-time `configure` rejection).
+	 */
+	onProviderConfigError?: () => void;
 }
 
 /** Host-agnostic starter prompts; picking one prefills (not sends) the composer. */
@@ -66,7 +73,7 @@ const PROVISIONING_PLACEHOLDER: Record<string, string> = {
 	configuring: "Configuring gateway…",
 };
 
-export function ChatPanel({ transport, provision, onConnected, onReconfigure }: ChatPanelProps) {
+export function ChatPanel({ transport, provision, onConnected, onReconfigure, onProviderConfigError }: ChatPanelProps) {
 	const { turns, send, stop, retry, status, reason, error, provisioning, provisionError } = useChatSession(transport, {
 		provision,
 		onConnected,
@@ -76,6 +83,20 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure }: 
 
 	const messages = useMemo(() => turnsToMessages({ turns, status, reason, error }), [turns, status, reason, error]);
 	const streaming = status === "streaming";
+
+	// Auto-open the gateway config when a turn fails because the configured provider
+	// rejected us (provider-4xx = bad/absent gateway token). Fire once per episode;
+	// a subsequent retry (status leaves 'error') re-arms it.
+	const providerRejected = status === "error" && reason === "provider-4xx";
+	const promptedRef = useRef(false);
+	useEffect(() => {
+		if (providerRejected && !promptedRef.current) {
+			promptedRef.current = true;
+			onProviderConfigError?.();
+		} else if (!providerRejected) {
+			promptedRef.current = false;
+		}
+	}, [providerRejected, onProviderConfigError]);
 
 	// A rejected provider `configure` is a non-silent, recoverable state: show the
 	// reason and a Reconfigure action instead of a chat that would silently talk to

--- a/packages/office-pane/src/panel/GatewayGate.tsx
+++ b/packages/office-pane/src/panel/GatewayGate.tsx
@@ -9,6 +9,12 @@
  * `normalizeGatewayConfig`. The shared gate owns the config-vs-chat decision, the
  * form, and the Settings affordance.
  *
+ * CHAT-FIRST: the shared gate runs in `optional` mode — an unconfigured pane opens
+ * straight into chat over xcsh's already-configured provider (no forced login),
+ * with the gateway form demoted to Settings. A stored config additionally points
+ * xcsh's provider at that gateway (the `configure` round-trip). If a turn fails
+ * because the provider rejected us (`provider-4xx`), the config form auto-opens.
+ *
  * Browser-safe: no node:* imports, no Office.js.
  */
 
@@ -45,8 +51,10 @@ export interface BuiltTransport {
 
 export interface GatewayGateProps {
 	store: GatewayConfigStore;
-	/** Build the transport for a saved config. */
-	buildTransport: (config: GatewayConfig) => BuiltTransport;
+	/** Build the transport for the current config. A `null` config is the
+	 *  chat-first default — connect and chat over xcsh's existing provider,
+	 *  without a `configure` (provision) step. */
+	buildTransport: (config: GatewayConfig | null) => BuiltTransport;
 	/** Optional prefill for the first-run form (e.g. a manifest `gateway_url`). */
 	initial?: Partial<GatewayConfigInput>;
 }
@@ -70,14 +78,15 @@ function validate(draft: GatewayConfigDraft): GatewayValidateResult<GatewayConfi
 export function GatewayGate({ store, buildTransport, initial }: GatewayGateProps) {
 	const [config, setConfig] = useState<GatewayConfig | null>(() => store.load());
 
-	// Build the transport once per config identity — not per render. buildTransport
+	// Build the transport once per config identity — not per render. A null config
+	// (chat-first) still builds a transport (connect only, no provision). buildTransport
 	// is intentionally omitted from the deps: a new config is the only thing that
 	// should rebuild the transport.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: rebuild only on config change
-	const built = useMemo<BuiltTransport | null>(() => (config ? buildTransport(config) : null), [config]);
+	const built = useMemo<BuiltTransport>(() => buildTransport(config), [config]);
 
 	// Tear down a superseded transport (on reconfigure) and on unmount.
-	useEffect(() => () => built?.transport.dispose(), [built]);
+	useEffect(() => () => built.transport.dispose(), [built]);
 
 	return (
 		<SharedGatewayGate<GatewayConfig>
@@ -87,21 +96,23 @@ export function GatewayGate({ store, buildTransport, initial }: GatewayGateProps
 				store.save(cfg);
 				setConfig(cfg);
 			}}
+			// Chat-first: an unconfigured pane opens straight into chat (xcsh already
+			// has provider creds); the form is the optional Settings affordance.
+			optional
 			initial={initial}
 			// GatewayConfig is a superset of the draft — reopen Settings prefilled.
 			configToDraft={cfg => cfg}
 			defaultModel={DEFAULT_GATEWAY_MODEL}
 		>
-			{(_cfg, { reconfigure }) =>
-				built ? (
-					<ChatPanel
-						transport={built.transport}
-						provision={built.provision}
-						onConnected={built.onConnected}
-						onReconfigure={reconfigure}
-					/>
-				) : null
-			}
+			{(_cfg, { reconfigure }) => (
+				<ChatPanel
+					transport={built.transport}
+					provision={built.provision}
+					onConnected={built.onConnected}
+					onReconfigure={reconfigure}
+					onProviderConfigError={reconfigure}
+				/>
+			)}
 		</SharedGatewayGate>
 	);
 }

--- a/packages/office-pane/test/ChatPanel.test.tsx
+++ b/packages/office-pane/test/ChatPanel.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { MockTransport } from "../src/core";
+import { type ChatRequestMsg, MockTransport } from "../src/core";
 import { ChatPanel } from "../src/panel";
 
 /** Flush the connect→provision→ready microtask chain. */
@@ -74,4 +74,25 @@ test("a rejected provision renders a NON-SILENT config error with a Reconfigure 
 
 	// Chat is NOT presented while unconfigured.
 	expect(scope.queryByRole("textbox", { name: /message input/i })).toBeNull();
+});
+
+test("auto-opens the gateway config when a turn fails with provider-4xx (bad gateway token)", async () => {
+	const mock = new MockTransport();
+	let opened = 0;
+	const { container } = render(<ChatPanel transport={mock} onProviderConfigError={() => (opened += 1)} />);
+	const scope = within(container);
+	await settle();
+
+	// Prefill via a starter pill, then send.
+	fireEvent.click(scope.getByRole("button", { name: /summarize/i }));
+	fireEvent.click(scope.getByRole("button", { name: /send/i }));
+	const req = mock.sent.find((m): m is ChatRequestMsg => m.type === "chat_request");
+	if (!req) throw new Error("expected a chat_request to have been sent");
+
+	// The worker rejects the turn because the configured provider said 4xx.
+	await act(async () => {
+		mock.emit({ type: "chat_error", id: req.id, reason: "provider-4xx", error: "401 Unauthorized" });
+	});
+
+	expect(opened).toBe(1);
 });

--- a/packages/office-pane/test/GatewayGate.test.tsx
+++ b/packages/office-pane/test/GatewayGate.test.tsx
@@ -4,13 +4,22 @@
  * The office wrapper owns the office concerns (persist via GatewayConfigStore,
  * build/tear-down the transport, validate via core's normalizeGatewayConfig) over
  * the shared headless `@f5-sales-demo/xcsh-chat-ui` gate, which owns the
- * config-vs-chat decision, the form, and the Settings affordance. Together they
- * show the gateway config form when no config is stored, or the ChatPanel (over a
- * transport built from the config) once one is.
+ * config-vs-chat decision, the form, and the Settings affordance.
+ *
+ * CHAT-FIRST (#2171): the pane runs the shared gate in `optional` mode — an
+ * unconfigured pane opens straight into chat over xcsh's existing provider, with
+ * the gateway form demoted to Settings. A stored config additionally configures
+ * xcsh's provider; a `provider-4xx` turn error auto-opens the form.
  */
 import { expect, test } from "bun:test";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { type GatewayConfig, MemoryGatewayConfigStore, MockTransport, normalizeGatewayConfig } from "../src/core";
+import {
+	type ChatRequestMsg,
+	type GatewayConfig,
+	MemoryGatewayConfigStore,
+	MockTransport,
+	normalizeGatewayConfig,
+} from "../src/core";
 import { GatewayGate } from "../src/panel/GatewayGate";
 
 const CONFIG = normalizeGatewayConfig({ baseUrl: "https://gw.example/anthropic", token: "t" });
@@ -19,16 +28,37 @@ function fill(label: RegExp, value: string): void {
 	fireEvent.change(screen.getByLabelText(label), { target: { value } });
 }
 
-test("with no stored config, renders the config form (not the chat)", () => {
+/** Flush the connect→(provision)→ready microtask chain. */
+async function settle(): Promise<void> {
+	await act(async () => {
+		await new Promise(r => setTimeout(r, 0));
+	});
+}
+
+test("chat-first: with NO stored config, opens the chat directly (not the form), built with a null config", () => {
 	const store = new MemoryGatewayConfigStore();
-	render(<GatewayGate store={store} buildTransport={() => ({ transport: new MockTransport() })} />);
-	expect(screen.getByLabelText(/gateway url/i)).toBeDefined();
-	expect(screen.queryByLabelText(/message input/i)).toBeNull();
+	const built: (GatewayConfig | null)[] = [];
+	render(
+		<GatewayGate
+			store={store}
+			buildTransport={cfg => {
+				built.push(cfg);
+				return { transport: new MockTransport() };
+			}}
+		/>,
+	);
+	// Chat-first: message input shown, NO forced gateway form.
+	expect(screen.getByLabelText(/message input/i)).toBeDefined();
+	expect(screen.queryByLabelText(/gateway url/i)).toBeNull();
+	// Transport built with a null config — chat runs over xcsh's existing provider.
+	expect(built).toEqual([null]);
+	// Config is still reachable via Settings.
+	expect(screen.getByRole("button", { name: /settings/i })).toBeDefined();
 });
 
-test("saving a config persists it and switches to the chat over the built transport", async () => {
+test("saving a config via Settings persists it and rebuilds the transport from it", async () => {
 	const store = new MemoryGatewayConfigStore();
-	const built: GatewayConfig[] = [];
+	const built: (GatewayConfig | null)[] = [];
 	render(
 		<GatewayGate
 			store={store}
@@ -39,24 +69,28 @@ test("saving a config persists it and switches to the chat over the built transp
 		/>,
 	);
 
+	// Chat-first opens on chat → open Settings to reach the form.
+	await act(async () => {
+		fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+	});
 	fill(/gateway url/i, "https://gw.example/anthropic");
 	fill(/token/i, "sk-1");
 	await act(async () => {
 		fireEvent.click(screen.getByRole("button", { name: /save|connect/i }));
 	});
 
-	// Persisted and transport built from the saved config.
+	// Persisted, and the transport rebuilt from the saved config (built first with
+	// null for chat-first, then with the config).
 	expect(store.load()?.token).toBe("sk-1");
-	expect(built).toHaveLength(1);
-	expect(built[0].baseUrl).toBe("https://gw.example/anthropic");
-	// Chat is now shown.
+	expect(built[0]).toBeNull();
+	expect(built[built.length - 1]?.baseUrl).toBe("https://gw.example/anthropic");
 	expect(screen.getByLabelText(/message input/i)).toBeDefined();
 });
 
-test("with a stored config, renders the chat directly and builds the transport from it", () => {
+test("with a stored config, renders the chat and builds the transport from it", () => {
 	const store = new MemoryGatewayConfigStore();
 	store.save(CONFIG);
-	const built: GatewayConfig[] = [];
+	const built: (GatewayConfig | null)[] = [];
 	render(
 		<GatewayGate
 			store={store}
@@ -173,11 +207,45 @@ test("a failed provider configure surfaces the error and Reconfigure reopens the
 	expect((screen.getByLabelText(/gateway url/i) as HTMLInputElement).value).toBe("https://gw.example/anthropic");
 });
 
+test("a provider-4xx turn error auto-opens the gateway config form (#2171 auth recovery)", async () => {
+	const store = new MemoryGatewayConfigStore();
+	store.save(CONFIG);
+	let mock: MockTransport | undefined;
+	render(
+		<GatewayGate
+			store={store}
+			buildTransport={() => {
+				mock = new MockTransport();
+				return { transport: mock };
+			}}
+		/>,
+	);
+	// Provisioning settles to ready (no provision hook), chat is shown.
+	await settle();
+	expect(screen.getByLabelText(/message input/i)).toBeDefined();
+
+	// Send a turn, then the provider rejects it with a 4xx (bad gateway token).
+	fireEvent.click(screen.getByRole("button", { name: /summarize/i }));
+	fireEvent.click(screen.getByRole("button", { name: /send/i }));
+	const req = mock?.sent.find((m): m is ChatRequestMsg => m.type === "chat_request");
+	if (!req) throw new Error("expected a chat_request to have been sent");
+	await act(async () => {
+		mock?.emit({ type: "chat_error", id: req.id, reason: "provider-4xx", error: "401 Unauthorized" });
+	});
+
+	// The gateway config form auto-opened, prefilled from the stored config.
+	expect((screen.getByLabelText(/gateway url/i) as HTMLInputElement).value).toBe("https://gw.example/anthropic");
+});
+
 // A validation failure keeps the form up and surfaces the actionable message.
 test("an invalid config surfaces the validator error and stays on the form", async () => {
 	const store = new MemoryGatewayConfigStore();
 	render(<GatewayGate store={store} buildTransport={() => ({ transport: new MockTransport() })} />);
 
+	// Chat-first → open Settings to reach the form.
+	await act(async () => {
+		fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+	});
 	fill(/gateway url/i, "http://insecure.example/anthropic");
 	fill(/token/i, "sk-1");
 	await act(async () => {

--- a/packages/office-pane/test/host-adapter.test.ts
+++ b/packages/office-pane/test/host-adapter.test.ts
@@ -89,7 +89,7 @@ test('unknown or absent host maps to the "unknown" fallback without throwing', a
 	expect((await initOfficeHost(unrecognized)).host).toBe("unknown");
 });
 
-test("mountGate with no stored config renders the gateway form and marks the root .xcsh-panel", async () => {
+test("mountGate with no stored config renders the chat (chat-first) and marks the root .xcsh-panel", async () => {
 	const container = document.createElement("div");
 	container.id = "root";
 	document.body.appendChild(container);
@@ -104,8 +104,11 @@ test("mountGate with no stored config renders the gateway form and marks the roo
 
 	expect(container.classList.contains("xcsh-panel")).toBe(true);
 	const scope = within(container);
-	expect(scope.getByLabelText(/gateway url/i)).toBeDefined();
-	expect(scope.queryByLabelText(/message input/i)).toBeNull();
+	// Chat-first: an unconfigured pane opens on chat, NOT a forced gateway form.
+	expect(scope.getByRole("textbox", { name: /message input/i })).toBeDefined();
+	expect(scope.queryByLabelText(/gateway url/i)).toBeNull();
+	// The gateway form is still reachable via Settings.
+	expect(scope.getByRole("button", { name: /settings/i })).toBeDefined();
 });
 
 test("mountGate with a stored config renders the chat over the built transport", async () => {
@@ -116,7 +119,7 @@ test("mountGate with a stored config renders the chat over the built transport",
 
 	const store = new MemoryGatewayConfigStore();
 	store.save(normalizeGatewayConfig({ baseUrl: "https://gw.example/anthropic", token: "t" }));
-	const built: GatewayConfig[] = [];
+	const built: (GatewayConfig | null)[] = [];
 
 	mountedRoot = await act(async () =>
 		mountGate(container, {
@@ -131,5 +134,5 @@ test("mountGate with a stored config renders the chat over the built transport",
 	const scope = within(container);
 	expect(scope.getByRole("textbox", { name: /message input/i })).toBeDefined();
 	expect(built).toHaveLength(1);
-	expect(built[0].baseUrl).toBe("https://gw.example/anthropic");
+	expect(built[0]?.baseUrl).toBe("https://gw.example/anthropic");
 });

--- a/packages/office-pane/test/transport-factory.test.ts
+++ b/packages/office-pane/test/transport-factory.test.ts
@@ -80,4 +80,17 @@ describe("makeBuildTransport", () => {
 		const built = build("Excel", stub);
 		expect(built.transport).toBe(stub.transport);
 	});
+
+	test("a NULL config (chat-first default) builds a transport with NO provision (uses xcsh's provider)", () => {
+		const stub = makeStub();
+		const built = makeBuildTransport("Excel", {
+			createTransport: () => stub.transport,
+			wireHostTools: () => ({ onConnected: () => stub.calls.push("advertise") }),
+		})(null);
+		expect(built.transport).toBe(stub.transport);
+		expect(built.provision).toBeUndefined();
+		// Host tools are still advertised on connect.
+		built.onConnected?.();
+		expect(stub.calls).toEqual(["advertise"]);
+	});
 });


### PR DESCRIPTION
## Problem

Closes #2171. The Office task pane forced the **Gateway URL + Token** form on first run before letting the user chat — but xcsh is the single engine and the user's local xcsh is usually **already logged in**. Making them re-enter a gateway looked like a redundant login wall (observed live in Excel on 19.70.2). The gateway config's real job is **distribution** to un-configured SEs, so it should be optional, not a gate.

## Change (operator decision: "chat first, config optional")

- **`transport-factory`**: `makeBuildTransport` accepts a `null` config (chat-first default) → builds a connect-only transport with **no `provision`**, so chat runs over xcsh's existing provider. A non-null config still points xcsh's provider at the gateway (`configure`).
- **shared `GatewayGate`** (`@f5-sales-demo/xcsh-chat-ui`): new **`optional`** (chat-first) mode — a missing config renders the chat (children) with config demoted to the **Settings** affordance instead of forcing the form. `children` may be called with `config: null` (widened signature); default stays config-required.
- **`ChatPanel`**: new `onProviderConfigError` fires once when a turn fails with `provider-4xx` (the gateway rejected us — bad/absent token) so the host can auto-open the config. The #2134 connect-time configure gate + error surfacing is preserved.
- **office `GatewayGate`**: runs the shared gate in `optional` mode, builds the transport for `null` too, and wires `onReconfigure` + `onProviderConfigError` → the prefilled form.

## Acceptance criteria (#2171)

- [x] Pane with no stored config renders the chat directly — NOT the gateway form.
- [x] A Settings affordance opens the (prefilled) gateway form; saving persists it and `configure`s xcsh.
- [x] A stored config still gates chat until `configure_ack` and surfaces a rejected configure (#2134 intact).
- [x] An auth/provider-config chat error (`provider-4xx`) auto-opens the config form.
- [x] TDD unit coverage for all four.

## Verification

- TDD across `transport-factory` / `useChatSession` / `ChatPanel` / `GatewayGate` / `host-adapter` (office + chat-ui).
- `chat-ui` **105/0**, `office-pane` **239/0**; `biome` clean; `tsgo` clean; office-pane browser-safe build (no `node:` builtins) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)