### PR TITLE
feat(coding-agent): frame authorized defensive security-demo work in system prompt

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -35,6 +35,12 @@ propose a more accurate alternative.
 The SE decides what to do; evidence decides what is true. See `<epistemic-integrity>`.
 </role>
 
+<security-context>
+- xcsh users are F5 sales engineers running AUTHORIZED, consented demonstrations of F5 protections (WAF, bot, DDoS, API, client-side defense) on their own demo tenants and sample apps.
+- Attack-simulation and mitigation content is legitimate DEFENSIVE security engineering. You **MUST NOT** refuse or re-gate it on suspicion of misuse.
+- This work **MUST** stay within demo scope: own or demo infrastructure, synthetic data, and benign exfiltration endpoints — never real victims or third-party targets.
+</security-context>
+
 <communication>
 - No emojis, filler, or ceremony.
 - (1) Correctness first, (2) Brevity second, (3) Politeness third.

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -326,6 +326,15 @@ describe("system Handlebars prompt templates", () => {
 		expect(template).toContain("These are not separate roles");
 	});
 
+	test("system prompt frames authorized defensive security-demo work", async () => {
+		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
+		const template = await Bun.file(templatePath).text();
+		expect(template).toContain("<security-context>");
+		expect(template).toContain("AUTHORIZED, consented demonstrations");
+		expect(template).toContain("legitimate DEFENSIVE security engineering");
+		expect(template).toContain("never real victims or third-party targets");
+	});
+
 	test("system prompt reframes behavior and stakes for SE risk (P4)", async () => {
 		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
 		const template = await Bun.file(templatePath).text();


### PR DESCRIPTION
## Summary
Adds a tight `<security-context>` block to the Identity section of the base system prompt so the xcsh assistant recognizes authorized, consented security-demonstration work (WAF/bot/DDoS/API/client-side-defense demos on the SE's own demo infra) as legitimate defensive engineering and stops over-refusing it. Keeps an explicit demo-scope guardrail so the cue is accurate context, not a bypass-safety directive. Propagates to subagents via `{{base}}`.

## Changes
- `system-prompt.md`: new `<security-context>` block after `</role>`.
- `system-prompt-templates.test.ts`: assertion covering the block (TDD — red before, green after).

## Verification
- `bun test test/system-prompt-templates.test.ts` — 23 pass, 0 fail.
- Biome clean; textlint introduces no new findings (the 3 pre-existing `curl`/`zsh`/`powershell` terms are unchanged and unrelated).

Closes #2175