### PR TITLE
fix(office-pane): drop the duplicate F5 logo in the empty state

### DIFF
--- a/packages/chat-ui/src/components/EmptyState.tsx
+++ b/packages/chat-ui/src/components/EmptyState.tsx
@@ -11,14 +11,20 @@ export interface EmptyStateProps {
 	pills: SkillPill[];
 	onPick: (id: string) => void;
 	heading?: string;
-	/** Overrides the default ASCII F5 logo. */
-	logo?: ReactNode;
+	/**
+	 * Logo shown above the heading. Omit for the default ASCII F5 logo, pass a
+	 * node to override it, or pass `false` to render NO logo — e.g. when a
+	 * persistent header already carries the brand (avoids a duplicate F5 logo).
+	 */
+	logo?: ReactNode | false;
 }
 
 export function EmptyState({ pills, onPick, heading = "Get started with these skills:", logo }: EmptyStateProps) {
+	// `undefined` → default logo; `false` → no logo; any node → that node.
+	const logoNode = logo === undefined ? <F5Logo variant="ascii" /> : logo;
 	return (
 		<div className="empty-state">
-			<div className="empty-logo">{logo ?? <F5Logo variant="ascii" />}</div>
+			{logoNode ? <div className="empty-logo">{logoNode}</div> : null}
 			{pills.length > 0 && (
 				<>
 					<div className="empty-heading">{heading}</div>

--- a/packages/chat-ui/test/EmptyState.test.tsx
+++ b/packages/chat-ui/test/EmptyState.test.tsx
@@ -25,3 +25,12 @@ test("hides the heading when there are no pills", () => {
 	render(<EmptyState pills={[]} onPick={() => {}} />);
 	expect(screen.queryByText("Get started with these skills:")).toBeNull();
 });
+
+test("renders NO logo (and no empty wrapper) when logo={false}", () => {
+	const { container } = render(<EmptyState pills={PILLS} onPick={() => {}} logo={false} />);
+	// No F5 logo, and the .empty-logo wrapper is absent (no gap).
+	expect(screen.queryByRole("img", { name: /f5 logo/i })).toBeNull();
+	expect(container.querySelector(".empty-logo")).toBeNull();
+	// Pills + heading still render.
+	expect(screen.getByText("Get started with these skills:")).toBeDefined();
+});

--- a/packages/office-pane/src/panel/ChatPanel.tsx
+++ b/packages/office-pane/src/panel/ChatPanel.tsx
@@ -125,6 +125,8 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 		<EmptyState
 			pills={STARTERS.map(({ id, label, hint }) => ({ id, label, hint }))}
 			onPick={id => composerRef.current?.setText(STARTERS.find(s => s.id === id)?.text ?? "")}
+			// The persistent Header already shows the F5 brand — don't duplicate it here.
+			logo={false}
 		/>
 	);
 

--- a/packages/office-pane/test/ChatPanel.test.tsx
+++ b/packages/office-pane/test/ChatPanel.test.tsx
@@ -35,6 +35,8 @@ test("the empty state offers starter pills that PREFILL the composer without sen
 	// Send is enabled for the user to submit when they choose to.
 	expect(mock.sent.filter(m => m.type === "chat_request")).toHaveLength(0);
 	expect((scope.getByRole("button", { name: /send/i }) as HTMLButtonElement).disabled).toBe(false);
+	// No duplicate F5 logo in the empty state — the persistent Header carries the brand.
+	expect(container.querySelector(".empty-logo")).toBeNull();
 });
 
 test("the composer cannot send a turn before provisioning resolves (configure_ack gate)", async () => {


### PR DESCRIPTION
## Problem

Closes #2178. The Office pane's empty state showed a large F5 logo right below the header's F5 mark + "xcsh" — two stacked F5 logos (operator flagged it live). Claude for Office keeps a single small header brand, no big duplicate above the skills.

## Change

- **shared `EmptyState`**: `logo` now accepts `false` → renders **no** logo and **no** empty `.empty-logo` wrapper (avoids a gap). `undefined` still defaults to the ASCII F5 logo; a node still overrides. Other surfaces (chrome/vscode) unchanged.
- **office `ChatPanel`**: passes `logo={false}` — the persistent `Header` already carries the F5 brand, so the empty state is just the skills heading + pills (Claude-parity layout).

## Acceptance criteria (#2178)

- [x] `EmptyState` renders with no logo / no empty wrapper when `logo={false}`.
- [x] Office empty state shows heading + pills under the header, no second F5 logo.
- [x] Default `EmptyState` still shows the F5 logo (other surfaces unchanged).
- [x] TDD unit coverage.

## Verification

TDD (EmptyState suppression + office empty-state integration assertion). chat-ui **106/0**, office-pane **239/0**; biome + tsgo + browser-safe build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)