### PR TITLE
feat(prompt): generic plugin-capability pointer (L0 of progressive hints)

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -306,6 +306,9 @@ Most tools resolve custom protocol URLs to internal resources (not web URLs):
   - `xcsh://console/<resource>` — console route pattern, menu path, and available operations.
   - `xcsh://console/<resource>/<operation>` — the exact ordered UI steps (selectors) for that operation.
 - `xcsh://extension` — Chrome extension bridge tool API reference: which tool to use (click, typeahead, input, navigation) for each automation task.
+{{#if hasPlugins}}
+Installed plugins expose capabilities, schemas, and executable helpers on demand. Read `xcsh://plugin` to list installed plugins and `xcsh://plugin/<name>` for a plugin's summary and how to go deeper — pull this in only when a task matches a plugin's domain.
+{{/if}}
 
 ### Presentation profile
 

--- a/packages/coding-agent/src/system-prompt.plugin-pointer.test.ts
+++ b/packages/coding-agent/src/system-prompt.plugin-pointer.test.ts
@@ -1,0 +1,38 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import { prompt } from "@f5-sales-demo/pi-utils";
+import { registerCodingAgentPromptHelpers } from "./config/prompt-templates";
+
+// L0 of the MEDDPICC progressive-hints ladder: a single framework-agnostic line
+// telling the agent that installed plugins expose capabilities/schemas via
+// `xcsh://plugin/<name>`. It is gated on the `hasPlugins` render variable that
+// `buildSystemPrompt` computes from discovered plugin roots.
+//
+// Seam: the Handlebars-compile path (`prompt.render(template, data)`) — the same
+// seam every other conditional-rendering assertion in this package uses. It is
+// deterministic (no dependency on what is installed under the real home dir) and
+// exercises the exact template conditional this task adds. `buildSystemPrompt`
+// resolves plugins from `os.homedir()` and takes no `home` override, so a
+// true-case fixture through it would be non-deterministic.
+
+const systemPromptPath = path.resolve(import.meta.dir, "prompts/system/system-prompt.md");
+
+describe("L0 plugin-capability pointer", () => {
+	beforeAll(() => {
+		registerCodingAgentPromptHelpers();
+	});
+
+	test("renders the generic pointer when a plugin is present, naming no plugin", async () => {
+		const template = await Bun.file(systemPromptPath).text();
+		const rendered = prompt.render(template, { hasPlugins: true });
+		expect(rendered).toContain("xcsh://plugin");
+		// Generic/reusable: it must not name any specific plugin.
+		expect(rendered).not.toContain("meddpicc");
+	});
+
+	test("omits the pointer entirely when no plugins are present", async () => {
+		const template = await Bun.file(systemPromptPath).text();
+		const rendered = prompt.render(template, { hasPlugins: false });
+		expect(rendered).not.toContain("xcsh://plugin");
+	});
+});

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -13,6 +13,7 @@ import { systemPromptCapability } from "./capability/system-prompt";
 import type { SkillsSettings } from "./config/settings";
 import { renderDeprecationGuardrails } from "./deprecations";
 import { type ContextFile, loadCapability, type SystemPrompt as SystemPromptFile } from "./discovery";
+import { listXcshPluginRoots } from "./discovery/helpers";
 import { isApplicableToContext, loadSkills, type Skill } from "./extensibility/skills";
 import customSystemPromptTemplate from "./prompts/system/custom-system-prompt.md" with { type: "text" };
 import systemPromptTemplate from "./prompts/system/system-prompt.md" with { type: "text" };
@@ -555,6 +556,13 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 					? loadSkills({ ...mergedSkillsSettings, cwd: resolvedCwd }).then(result => result.skills)
 					: Promise.resolve([]);
 
+		// L0 plugin-capability pointer: gate a generic `xcsh://plugin` hint on ≥1
+		// discoverable plugin. Discovery is cached and reads one small registry file,
+		// so this is effectively free; it fails safe to `false` (no hint) on error.
+		const hasPluginsPromise: Promise<boolean> = listXcshPluginRoots(os.homedir(), resolvedCwd)
+			.then(result => result.roots.length > 0)
+			.catch(() => false);
+
 		return Promise.all([
 			resolvePromptInput(customPrompt, "system prompt"),
 			resolvePromptInput(appendSystemPrompt, "append system prompt"),
@@ -562,6 +570,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 			contextFilesPromise,
 			agentsMdSearchPromise,
 			skillsPromise,
+			hasPluginsPromise,
 		]).then(
 			([
 				resolvedCustomPrompt,
@@ -570,6 +579,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 				contextFiles,
 				agentsMdSearch,
 				skills,
+				hasPlugins,
 			]) => ({
 				resolvedCustomPrompt,
 				resolvedAppendPrompt,
@@ -577,6 +587,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 				contextFiles,
 				agentsMdSearch,
 				skills,
+				hasPlugins,
 			}),
 		);
 	})();
@@ -601,6 +612,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		files: [],
 	};
 	let skills: Skill[] = providedSkills ?? [];
+	let hasPlugins = false;
 
 	if (prepResult.type === "timeout") {
 		logger.warn("System prompt preparation timed out; using minimal startup context", {
@@ -623,6 +635,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		contextFiles = dedupeExactContextFiles(prepResult.value.contextFiles);
 		agentsMdSearch = prepResult.value.agentsMdSearch;
 		skills = prepResult.value.skills;
+		hasPlugins = prepResult.value.hasPlugins;
 	}
 
 	const date = new Date().toISOString().slice(0, 10);
@@ -679,6 +692,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		agentsMdSearch,
 		skills: contextFilteredSkills,
 		rules: rules ?? [],
+		hasPlugins,
 		alwaysApplyRules: injectedAlwaysApplyRules,
 		date,
 		dateTime,


### PR DESCRIPTION
Closes #2185

Adds one framework-agnostic line to the system prompt telling the agent that installed plugins expose capabilities/schemas via `xcsh://plugin/<name>`, so it can drill in on demand. **Rendered only when ≥1 plugin is discoverable** (`hasPlugins` from `listXcshPluginRoots`, computed in the existing parallel prep race, fail-safe to false), **names no plugin**, zero cost when none installed.

This is the L0 entry of the MEDDPICC progressive-hints ladder (companion: the marketplace meddpicc engine `hint` command / `next` flow, merged separately) — but it's generic and reusable by any framework plugin.

## Verified
- New `system-prompt.plugin-pointer.test.ts` (2 tests: present→contains `xcsh://plugin` & not `meddpicc`; absent→omitted) + 46 system-prompt regression tests pass; `tsgo --noEmit` clean; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)