### PR TITLE
fix(office-pane): drop the Chrome-automation mode toggle; fix mode to educational

### DIFF
--- a/packages/office-pane/src/panel/ChatPanel.tsx
+++ b/packages/office-pane/src/panel/ChatPanel.tsx
@@ -19,11 +19,11 @@ import {
 	type SkillPill,
 	Transcript,
 } from "@f5-sales-demo/xcsh-chat-ui";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
-import type { InteractionMode, Transport } from "../core";
-import { MODE_OPTIONS, turnsToMessages } from "./adapt";
-import { DEFAULT_INTERACTION_MODE, useChatSession } from "./useChatSession";
+import type { Transport } from "../core";
+import { turnsToMessages } from "./adapt";
+import { useChatSession } from "./useChatSession";
 
 export interface ChatPanelProps {
 	transport: Transport;
@@ -78,7 +78,6 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 		provision,
 		onConnected,
 	});
-	const [mode, setMode] = useState<string>(DEFAULT_INTERACTION_MODE);
 	const composerRef = useRef<ComposerHandle>(null);
 
 	const messages = useMemo(() => turnsToMessages({ turns, status, reason, error }), [turns, status, reason, error]);
@@ -134,16 +133,15 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 		<>
 			<Header />
 			<Transcript messages={messages} streaming={streaming} onRetry={() => retry()} emptyState={emptyState} />
+			{/* No interaction-mode toggle: those modes are Chrome browser-automation
+			    only. The Office pane fixes the mode to `educational` (see useChatSession). */}
 			<Composer
 				ref={composerRef}
 				streaming={streaming}
 				disabled={!ready}
 				placeholder={ready ? undefined : PROVISIONING_PLACEHOLDER[provisioning]}
-				onSend={text => send(text, mode as InteractionMode)}
+				onSend={text => send(text)}
 				onStop={stop}
-				modes={MODE_OPTIONS}
-				mode={mode}
-				onModeChange={setMode}
 			/>
 		</>
 	);

--- a/packages/office-pane/src/panel/adapt.ts
+++ b/packages/office-pane/src/panel/adapt.ts
@@ -11,9 +11,8 @@
  *
  * Browser-safe: no node:* imports, no Office.js.
  */
-import type { ChatMessage, InteractionMode as UiMode } from "@f5-sales-demo/xcsh-chat-ui";
-import type { ChatErrorReason, InteractionMode } from "../core";
-import { INTERACTION_MODES } from "../core";
+import type { ChatMessage } from "@f5-sales-demo/xcsh-chat-ui";
+import type { ChatErrorReason } from "../core";
 import type { Turn } from "./useChatSession";
 
 /** Exhaustive human-readable message for every {@link ChatErrorReason}. */
@@ -103,11 +102,3 @@ export function turnsToMessages(view: SessionView): ChatMessage[] {
 
 	return msgs;
 }
-
-/** Title-case a lowercase interaction-mode id for the composer's mode toggle. */
-function label(id: InteractionMode): string {
-	return id.charAt(0).toUpperCase() + id.slice(1);
-}
-
-/** The interaction modes offered in the composer's mode toggle. */
-export const MODE_OPTIONS: UiMode[] = INTERACTION_MODES.map(id => ({ id, label: label(id) }));

--- a/packages/office-pane/src/panel/index.ts
+++ b/packages/office-pane/src/panel/index.ts
@@ -1,5 +1,5 @@
 export type { SessionView } from "./adapt";
-export { ERROR_MESSAGES, errorText, GENERIC_ERROR_MESSAGE, MODE_OPTIONS, turnsToMessages } from "./adapt";
+export { ERROR_MESSAGES, errorText, GENERIC_ERROR_MESSAGE, turnsToMessages } from "./adapt";
 export type { ChatPanelProps } from "./ChatPanel";
 export { ChatPanel } from "./ChatPanel";
 export type { BuiltTransport, GatewayGateProps } from "./GatewayGate";

--- a/packages/office-pane/src/panel/useChatSession.ts
+++ b/packages/office-pane/src/panel/useChatSession.ts
@@ -20,7 +20,14 @@ import {
 // Public types
 // ---------------------------------------------------------------------------
 
-export const DEFAULT_INTERACTION_MODE: InteractionMode = "configuration";
+/**
+ * The single chat mode the Office pane sends. The interaction modes are a
+ * Chrome browser-automation concept (they steer on-page overlays/annotations),
+ * so the Office pane exposes NO mode toggle and fixes the mode to `educational`
+ * ("Explain concepts… help the user understand") — the least-wrong fit for a
+ * document assistant, matching the Explain/Improve/Summarize starters.
+ */
+export const DEFAULT_INTERACTION_MODE: InteractionMode = "educational";
 
 /**
  * Post-connect lifecycle hooks. `provision` points xcsh's provider at the saved

--- a/packages/office-pane/test/ChatPanel.test.tsx
+++ b/packages/office-pane/test/ChatPanel.test.tsx
@@ -39,6 +39,23 @@ test("the empty state offers starter pills that PREFILL the composer without sen
 	expect(container.querySelector(".empty-logo")).toBeNull();
 });
 
+test("no Chrome-automation mode toggle; chats send the fixed 'educational' mode", async () => {
+	const mock = new MockTransport();
+	const { container } = render(<ChatPanel transport={mock} />);
+	const scope = within(container);
+	await settle();
+
+	// The interaction-mode toggle (Chrome browser-automation only) is gone.
+	expect(container.querySelector(".mode-btn")).toBeNull();
+
+	// Sending a message uses the fixed Office mode, not `configuration`.
+	fireEvent.click(scope.getByRole("button", { name: /summarize/i }));
+	fireEvent.click(scope.getByRole("button", { name: /send/i }));
+	const req = mock.sent.find((m): m is ChatRequestMsg => m.type === "chat_request");
+	if (!req) throw new Error("expected a chat_request to have been sent");
+	expect(req.mode).toBe("educational");
+});
+
 test("the composer cannot send a turn before provisioning resolves (configure_ack gate)", async () => {
 	const mock = new MockTransport();
 	// A provision that never resolves keeps the pane in 'configuring'.

--- a/packages/office-pane/test/adapt.test.ts
+++ b/packages/office-pane/test/adapt.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { CHAT_ERROR_REASONS } from "../src/core";
-import { ERROR_MESSAGES, errorText, MODE_OPTIONS, turnsToMessages } from "../src/panel/adapt";
+import { ERROR_MESSAGES, errorText, turnsToMessages } from "../src/panel/adapt";
 import type { AssistantTurn, Turn, UserTurn } from "../src/panel/useChatSession";
 
 function user(id: string, text: string): UserTurn {
@@ -101,20 +101,5 @@ describe("turnsToMessages", () => {
 		const msgs = turnsToMessages({ turns, status: "error", reason: "no-worker" });
 		expect(msgs).toHaveLength(2);
 		expect(msgs.filter(m => m.error)).toHaveLength(1);
-	});
-});
-
-describe("MODE_OPTIONS", () => {
-	test("exposes every interaction mode as a labelled option for the composer", () => {
-		expect(MODE_OPTIONS.map(m => m.id)).toEqual([
-			"educational",
-			"presentation",
-			"configuration",
-			"screenshot",
-			"annotation",
-		]);
-		for (const opt of MODE_OPTIONS) {
-			expect(opt.label.length).toBeGreaterThan(0);
-		}
 	});
 });


### PR DESCRIPTION
## Problem

Closes #2191. The Office composer showed a mode toggle — Educational / Presentation / Configuration / Screenshot / Annotation — which are the **Chrome browser-automation** interaction modes (they control on-page overlays/annotations and steer the agent toward F5 XC console tasks). In Office there's no page to annotate, so the toggle is confusing noise. Worse, the default `configuration` mode injected *"Help the user build or modify F5 XC configuration"* into every Office chat prompt (`composeChatPrompt` → `MODE_INSTRUCTIONS`).

## Change

- **`ChatPanel`**: remove the mode toggle (no `modes`/`mode`/`onModeChange` on the `Composer`).
- Fix the sent mode to **`educational`** ("Explain concepts… help the user understand") — the least-wrong existing mode for a document assistant, matching the Explain / Improve / Summarize starters (`DEFAULT_INTERACTION_MODE`).
- Delete the now-dead `MODE_OPTIONS` + `label()` from `adapt.ts`, its barrel export, and its test.

## Acceptance criteria (#2191)

- [x] The Office composer renders no interaction-mode toggle (`.mode-btn` absent).
- [x] Office chats send `mode: educational` (not `configuration`).
- [x] TDD unit coverage.

## Verification

office-pane **239/0**; biome + tsgo + browser-safe build green. (chat-ui unchanged.)

## Note (out of scope)

`composeChatPrompt` still prepends `CHROME_CHAT_SYSTEM_PROMPT` ("you are a Chrome browser assistant") for all bridge chats incl. Office. A host-aware prompt would further improve Office answers — flagged for a possible follow-up, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)