### PR TITLE
feat(engine): host-aware bridge — per-app prompts + tool scope (chrome/excel/ppt/word)

### DIFF
--- a/packages/coding-agent/src/browser/capabilities.generated.ts
+++ b/packages/coding-agent/src/browser/capabilities.generated.ts
@@ -26,7 +26,7 @@ export interface ExtensionCapabilities {
 
 export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 	"version": "0.1.0",
-	"contractVersion": "1.9.0",
+	"contractVersion": "1.10.0",
 	"multiPortDiscovery": true,
 	"protocol": "tool_request/result",
 	"tools": [
@@ -855,6 +855,6 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 	}
 };
 
-export const EXTENSION_CONTRACT_VERSION = "1.9.0";
+export const EXTENSION_CONTRACT_VERSION = "1.10.0";
 
 export const EXTENSION_TOOL_NAMES: readonly string[] = ["ping","capabilities","reload","debug_exec","detach","set_bridge_port","navigate","login","scroll_to","resize_window","tabs_list","tabs_create","tabs_close","click","click_element","click_xy","type_text","form_input","key_press","select_option","label_select","file_upload","read_ax","get_page_text","query_dom","find","wait_for","assert_text","screenshot","read_console","read_network","diag_suspension","diag_bridges","diag_activation","diag_ttft","capture_login_flow","wait_for_api_response","get_page_context","javascript_tool","browser_batch","set_explain_mode","annotate"];

--- a/packages/coding-agent/src/browser/capabilities.json
+++ b/packages/coding-agent/src/browser/capabilities.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "contractVersion": "1.9.0",
+  "contractVersion": "1.10.0",
   "multiPortDiscovery": true,
   "protocol": "tool_request/result",
   "tools": [

--- a/packages/coding-agent/src/browser/chat-conformance.json
+++ b/packages/coding-agent/src/browser/chat-conformance.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": "1.9.0",
+  "contractVersion": "1.10.0",
   "schemas": {
     "chat_request": {
       "type": "object",

--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -32,6 +32,7 @@ import {
 } from "./chat-protocol";
 import { CONSOLE_ROUTES } from "./console-routes.generated";
 import type { BridgeServer } from "./extension-bridge";
+import { type ClientHost, hostProfile } from "./host-profiles";
 import { interpretPageState } from "./page-state-interpreter";
 import { chatSpans } from "./ttft-spans";
 
@@ -163,7 +164,7 @@ export class ChatHandler {
 		});
 		chat.unsubscribe = unsubscribe;
 
-		const prompt = composeChatPrompt(req.text, req.context, req.mode);
+		const prompt = composeChatPrompt(req.text, req.context, req.mode, this.#server.clientHost);
 
 		try {
 			chat.promptAt = Date.now();
@@ -435,49 +436,6 @@ export function classifyChatErrorReason(message: string): ChatErrorReason | unde
 	return undefined;
 }
 
-/**
- * Chrome-extension self-awareness prompt. Injected when xcsh is serving a browser
- * chat (not the CLI TUI). Tells the LLM it's in a Chrome side panel alongside the
- * F5 XC console, what tools it has, and how to behave differently from the CLI.
- */
-const CHROME_CHAT_SYSTEM_PROMPT = `[System: You are xcsh, an AI assistant for the F5 Distributed Cloud console, running as a Chrome browser side panel — not a terminal CLI.
-
-CRITICAL: ALWAYS respond with TEXT FIRST. Do NOT jump straight to tool calls. The user sees a chat panel and expects a conversational text response, not silence while tools run in the background. For questions ("what page am I on?", "what is this?"), answer with text using the page context below — no tools needed. Only use tools when the user explicitly asks you to DO something (create, navigate, click, modify).
-
-CONTEXT: The user sees a small chat window alongside the F5 XC admin console. You receive page-aware context each turn: the current URL (interpreted as workspace/resource/CRUD operation/namespace), the API resource JSON, and the accessibility tree. USE THIS CONTEXT to answer questions — don't call tools to find information you already have.
-
-BEHAVIOR:
-- Respond concisely with markdown. The chat panel is narrow — avoid long code blocks.
-- You KNOW which page the user is on (injected below). Don't ask "what page are you on?" — tell them.
-- For questions about the page/resource: answer from the injected context. No tools.
-- If a blocking popup/survey appears, dismiss it by clicking the close button.
-- If on the LOGIN page: use the login tool to log in. The login tool handles ALL environments — production (*.console.ves.volterra.io) AND staging (*.staging.volterra.us, login-staging.volterra.us). Do NOT claim the login tool is broken, unsupported, or doesn't work for staging — it does.
-
-BROWSER AUTOMATION (when the user asks to create/modify/navigate resources):
-- You are IN a Chrome browser. The active console tab is your workspace — use IT.
-- For create/modify/delete: call catalog_workflow_runner IMMEDIATELY with ONE tool call per resource:
-  {"resource": "health-check", "operation": "create", "params": {"name": "foo", "namespace": "demo"}, "presentation": "guided"}
-  Do NOT read API specs first, do NOT create todos, do NOT orchestrate multi-step tool chains. The catalog_workflow_runner handles ALL the form navigation internally.
-- Say a brief text message BEFORE the tool call: "Creating health check **foo** — watch the browser." Then call the tool. Nothing else.
-- The human is WATCHING the form automation (fingerprint-before-click, highlights, ~1.5s/step). Do NOT use background API calls.
-- The browser may be at 85% zoom — automation handles coordinates at any zoom.
-- The console catalog has workflows for 100+ F5 XC resources.
-- Do NOT open new tabs — drive the existing console tab.
-
-MULTI-RESOURCE REQUESTS (when the user asks to create several resources in one prompt):
-- Create resources in DEPENDENCY ORDER: health checks first, then origin pools (which reference health checks), then load balancers (which reference origin pools and app firewalls).
-- After each catalog_workflow_runner call completes, IMMEDIATELY proceed to the next resource. Do NOT inspect, verify, click into, or navigate to the resource you just created. Do NOT open the JSON view. Do NOT read the page to confirm — the tool already confirmed success. Move directly to the next creation.
-- Between resources, say ONE short line: "Health check created. Now creating origin pool **bar** — watch the browser." Then call the next tool.
-- NEVER navigate to a list/detail/JSON view between creations. Stay on the automation path.
-
-SAFETY — NEVER DO THESE:
-- NEVER kill, stop, or manage processes on port 19222 — that is YOUR OWN bridge. Killing it kills you.
-- NEVER run lsof, fuser, kill, or pkill on the bridge port. You ARE the bridge.
-- NEVER use bash/shell tools to manage xcsh processes, ports, or the debugger connection.
-- NEVER run commands that would terminate your own process or the WebSocket server.]
-
-`;
-
 const MODE_INSTRUCTIONS: Record<InteractionMode, string> = {
 	educational: "Explain concepts and settings in depth. Help the user understand what they're looking at and why.",
 	presentation: "Guide a structured walkthrough. Narrate each step clearly for a live audience.",
@@ -486,77 +444,94 @@ const MODE_INSTRUCTIONS: Record<InteractionMode, string> = {
 	annotation: "Create on-page teaching annotations that highlight key elements and explain their purpose.",
 };
 
-export function composeChatPrompt(text: string, context: PageContextSnapshot | null, mode: InteractionMode): string {
+export function composeChatPrompt(
+	text: string,
+	context: PageContextSnapshot | null,
+	mode: InteractionMode,
+	host: ClientHost | null,
+): string {
 	const parts: string[] = [];
 
-	// Chrome-extension self-awareness: establishes the agent's browser context.
-	parts.push(CHROME_CHAT_SYSTEM_PROMPT);
-	parts.push(`[Chat mode: ${mode}] ${MODE_INSTRUCTIONS[mode]}`);
+	// Host-aware self-awareness: the Chrome extension gets the browser panel prompt;
+	// an Office add-in (excel/powerpoint/word) gets its document-assistant prompt. A
+	// null/unannounced host falls back to the Chrome profile.
+	const profile = hostProfile(host);
+	parts.push(profile.systemPrompt);
 
-	if (context) {
-		// Interpret the raw URL into structured page state (workspace, resource,
-		// CRUD operation, namespace) using deterministic route-pattern matching
-		// against console_ui.yaml — the LLM sees "origin_pool LIST in demo" not a
-		// raw URL it must guess about.
-		const pageState = interpretPageState(context.url, null, CONSOLE_ROUTES);
-
-		parts.push("");
-		parts.push(`[Page context — captured at ${new Date(context.capturedAt).toISOString()}]`);
-
-		// Tenant + environment (the LLM knows WHICH tenant on WHICH environment).
-		if (pageState.tenant || pageState.environment) {
-			parts.push(`Tenant: ${pageState.tenant ?? "unknown"} (${pageState.environment ?? "unknown"} environment)`);
-		}
-
-		// Structured page state (the interpreted context the LLM acts on).
-		if (pageState.operation === "login") {
-			parts.push("Page: LOGIN — session expired or first login. The user is on the Keycloak authentication page.");
-			parts.push(
-				"Use the login tool with their email and password to log in. The login tool handles both production and staging Keycloak (including login-staging.volterra.us). Do NOT bypass it or claim it doesn't support staging.",
-			);
-		} else if (pageState.resource) {
-			const opLabel = pageState.operation.toUpperCase();
-			const nsLabel = pageState.namespace ? ` in namespace "${pageState.namespace}"` : "";
-			const nameLabel = pageState.resourceName ? ` — instance "${pageState.resourceName}"` : "";
-			parts.push(`Page: ${pageState.resource} ${opLabel}${nameLabel} (workspace: ${pageState.workspace}${nsLabel})`);
-		} else {
-			parts.push(`Page: ${context.title} (unrecognized resource)`);
-		}
-		if (pageState.modalBlocking) {
-			parts.push(`⚠ Modal blocking: ${pageState.modalText ?? "unknown overlay"}`);
-		}
-		parts.push(`URL: ${context.url}`);
-		parts.push(`Title: ${context.title}`);
-
-		if (context.api) {
-			parts.push(
-				`API resource (${context.api.resourceType ?? "unknown"}, status ${context.api.status}): ${context.api.url}`,
-			);
-			if (context.api.body) {
-				const body =
-					typeof context.api.body === "string" ? context.api.body : JSON.stringify(context.api.body, null, 2);
-				parts.push(body);
-			}
-			if (context.api.truncated) {
-				parts.push("[API body was truncated]");
-			}
-		}
-
-		if (context.ax) {
-			const ax = typeof context.ax === "string" ? context.ax : JSON.stringify(context.ax);
-			parts.push(`Accessibility tree: ${ax}`);
-		}
-
-		if (context.truncated) {
-			parts.push("[Page context was truncated]");
-		}
-
-		parts.push("---");
+	// Browser hosts ALSO get an interaction mode + the page-context block. Document
+	// hosts get NEITHER: Office sends no page context and has no browser modes; its
+	// tools + document state arrive at runtime via set_host_tools.
+	if (profile.kind === "browser") {
+		parts.push(`[Chat mode: ${mode}] ${MODE_INSTRUCTIONS[mode]}`);
+		if (context) composeBrowserPageContext(parts, context);
 	}
 
 	parts.push("");
 	parts.push(text);
 	return parts.join("\n");
+}
+
+/** Append the Chrome-only page-context block (interpreted page state + API body +
+ * accessibility tree) to `parts`. Browser hosts only — Office sends no context. */
+function composeBrowserPageContext(parts: string[], context: PageContextSnapshot): void {
+	// Interpret the raw URL into structured page state (workspace, resource,
+	// CRUD operation, namespace) using deterministic route-pattern matching
+	// against console_ui.yaml — the LLM sees "origin_pool LIST in demo" not a
+	// raw URL it must guess about.
+	const pageState = interpretPageState(context.url, null, CONSOLE_ROUTES);
+
+	parts.push("");
+	parts.push(`[Page context — captured at ${new Date(context.capturedAt).toISOString()}]`);
+
+	// Tenant + environment (the LLM knows WHICH tenant on WHICH environment).
+	if (pageState.tenant || pageState.environment) {
+		parts.push(`Tenant: ${pageState.tenant ?? "unknown"} (${pageState.environment ?? "unknown"} environment)`);
+	}
+
+	// Structured page state (the interpreted context the LLM acts on).
+	if (pageState.operation === "login") {
+		parts.push("Page: LOGIN — session expired or first login. The user is on the Keycloak authentication page.");
+		parts.push(
+			"Use the login tool with their email and password to log in. The login tool handles both production and staging Keycloak (including login-staging.volterra.us). Do NOT bypass it or claim it doesn't support staging.",
+		);
+	} else if (pageState.resource) {
+		const opLabel = pageState.operation.toUpperCase();
+		const nsLabel = pageState.namespace ? ` in namespace "${pageState.namespace}"` : "";
+		const nameLabel = pageState.resourceName ? ` — instance "${pageState.resourceName}"` : "";
+		parts.push(`Page: ${pageState.resource} ${opLabel}${nameLabel} (workspace: ${pageState.workspace}${nsLabel})`);
+	} else {
+		parts.push(`Page: ${context.title} (unrecognized resource)`);
+	}
+	if (pageState.modalBlocking) {
+		parts.push(`⚠ Modal blocking: ${pageState.modalText ?? "unknown overlay"}`);
+	}
+	parts.push(`URL: ${context.url}`);
+	parts.push(`Title: ${context.title}`);
+
+	if (context.api) {
+		parts.push(
+			`API resource (${context.api.resourceType ?? "unknown"}, status ${context.api.status}): ${context.api.url}`,
+		);
+		if (context.api.body) {
+			const body =
+				typeof context.api.body === "string" ? context.api.body : JSON.stringify(context.api.body, null, 2);
+			parts.push(body);
+		}
+		if (context.api.truncated) {
+			parts.push("[API body was truncated]");
+		}
+	}
+
+	if (context.ax) {
+		const ax = typeof context.ax === "string" ? context.ax : JSON.stringify(context.ax);
+		parts.push(`Accessibility tree: ${ax}`);
+	}
+
+	if (context.truncated) {
+		parts.push("[Page context was truncated]");
+	}
+
+	parts.push("---");
 }
 
 export function classifyReferenceKind(url: string): "doc" | "console" {

--- a/packages/coding-agent/src/browser/chat-protocol.ts
+++ b/packages/coding-agent/src/browser/chat-protocol.ts
@@ -15,6 +15,11 @@ import type {
 	RpcHostToolUpdate,
 } from "../host-tools/types";
 
+// The client host announced on the `hello` handshake (contract 1.10.0). Re-exported
+// (type-only, fully erased) so browser-safe consumers — the office-pane bundle —
+// can share the wire vocabulary without importing the host-profiles prompt data.
+export type { ClientHost } from "./host-profiles";
+
 // ---------------------------------------------------------------------------
 // Page context snapshot (auto-attached by extension to every chat_request)
 // ---------------------------------------------------------------------------

--- a/packages/coding-agent/src/browser/extension-bridge-tools.ts
+++ b/packages/coding-agent/src/browser/extension-bridge-tools.ts
@@ -97,3 +97,19 @@ export const BROWSER_TOOL_NAMES: readonly string[] = [
 	"annotate",
 	"set_explain_mode",
 ];
+
+/**
+ * Builtin agent tools scoped into the headless OFFICE bridge (`xcsh office serve`).
+ * The Office task pane drives a document (Excel/PowerPoint/Word), NOT a browser, so
+ * it must get NONE of the {@link BROWSER_TOOL_NAMES} — those would be hallucinated
+ * against a host with no browser to drive. The document's own tools arrive at
+ * runtime over the bridge via `set_host_tools`; this list is only the minimal
+ * general-purpose, host-neutral builtin toolset a document assistant can safely use.
+ *
+ * NOTE: an EMPTY list cannot express "no builtin tools" — createAgentSession/createTools
+ * treat `[]` as "unscoped" and hand back the FULL builtin registry (bash/edit/python/
+ * browser/…). So we pass an explicit minimal set instead. `calc` is the one builtin
+ * that is pure computation — no browser, no shell, no filesystem, no network — and is
+ * genuinely useful for spreadsheet/document math.
+ */
+export const OFFICE_TOOL_NAMES: readonly string[] = ["calc"];

--- a/packages/coding-agent/src/browser/extension-bridge.ts
+++ b/packages/coding-agent/src/browser/extension-bridge.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Server, ServerWebSocket } from "bun";
 import { LOCALIP_HOST } from "./bridge-cert";
+import { type ClientHost, isClientHost } from "./host-profiles";
 
 export interface ToolResult {
 	content: unknown;
@@ -177,6 +178,9 @@ export class BridgeServer {
 	#onMessage: Array<(msg: Record<string, unknown>) => void> = [];
 	/** Heartbeat interval that sends pings to keep the MV3 service worker alive (sweep + chat). */
 	#heartbeat: ReturnType<typeof setInterval> | null = null;
+	/** The client host learned from the `hello` handshake (null until a client
+	 * announces one; the Chrome extension omits it → stays null → chrome profile). */
+	#clientHost: ClientHost | null = null;
 	/** Provider of this process's tenant identity, answering the `hello` handshake. */
 	#sessionInfo:
 		| (() => {
@@ -201,6 +205,12 @@ export class BridgeServer {
 	/** True when at least one client is connected (backwards compat). */
 	get connected(): boolean {
 		return this.#clients.size > 0;
+	}
+
+	/** The client host announced by the connected client's `hello` (null until a
+	 * client announces one). Read by the ChatHandler to pick the host-aware prompt. */
+	get clientHost(): ClientHost | null {
+		return this.#clientHost;
 	}
 
 	/** Number of connected extension clients (channels). */
@@ -364,7 +374,7 @@ export class BridgeServer {
 
 	#handleMessage(ws: ServerWebSocket<undefined>, message: string | Buffer): void {
 		const text = typeof message === "string" ? message : message.toString("utf8");
-		let msg: { type?: string; id?: string; content?: unknown; is_error?: boolean };
+		let msg: { type?: string; id?: string; content?: unknown; is_error?: boolean; host?: unknown };
 		try {
 			msg = JSON.parse(text);
 		} catch {
@@ -379,6 +389,11 @@ export class BridgeServer {
 			ws.send(JSON.stringify({ type: "pong" }));
 		} else if (msg.type === "hello") {
 			// Identity handshake: tell the extension which tenant this process serves.
+			// Record the announced client host (contract 1.10.0): Office sends its
+			// lowercased Office.context.host ("excel"|"powerpoint"|"word"); the Chrome
+			// extension omits it → clientHost stays null → the browser profile. Invalid
+			// values are ignored (null retained). Echoed back so the client can confirm.
+			if (isClientHost(msg.host)) this.#clientHost = msg.host;
 			const info = this.#sessionInfo?.() ?? {
 				tenant: null,
 				env: null,
@@ -396,6 +411,7 @@ export class BridgeServer {
 					env: info.env,
 					apiUrl: info.apiUrl,
 					contextBound: info.contextBound,
+					host: this.#clientHost,
 					pid: process.pid,
 					wssPort: this.wssPort,
 					canConfigureProvider: true,

--- a/packages/coding-agent/src/browser/headless-bridge.ts
+++ b/packages/coding-agent/src/browser/headless-bridge.ts
@@ -21,7 +21,7 @@ import { deriveTenantEnv } from "../services/xcsh-env";
 import { resolveBridgeTls } from "./bridge-cert";
 import { ChatHandler } from "./chat-handler";
 import { type BridgeServer, startBridgeServer } from "./extension-bridge";
-import { BROWSER_TOOL_NAMES, createExtensionBridgeTools, EXTENSION_AGENT_TOOL_NAMES } from "./extension-bridge-tools";
+import { OFFICE_TOOL_NAMES } from "./extension-bridge-tools";
 import { setSharedBridgeServer } from "./provider";
 
 /** A running headless bridge + a teardown that disposes the chat handler and
@@ -67,7 +67,6 @@ export interface HeadlessBridgeDeps {
 	resolveBridgeTls: typeof resolveBridgeTls;
 	startBridgeServer: typeof startBridgeServer;
 	setSharedBridgeServer: typeof setSharedBridgeServer;
-	createExtensionBridgeTools: typeof createExtensionBridgeTools;
 	createAgentSession: typeof createAgentSession;
 	ChatHandlerCtor: typeof ChatHandler;
 }
@@ -95,7 +94,6 @@ const defaultDeps: HeadlessBridgeDeps = {
 	resolveBridgeTls,
 	startBridgeServer,
 	setSharedBridgeServer,
-	createExtensionBridgeTools,
 	createAgentSession,
 	ChatHandlerCtor: ChatHandler,
 };
@@ -130,15 +128,17 @@ export async function startHeadlessChatBridge(deps: HeadlessBridgeDeps = default
 	// selectProvider() reuses a dead bridge. The caller (startOfficeServe) treats
 	// the rethrow as a non-fatal "pane only" fallback.
 	try {
-		// Turn the extension's browser actions into bridge-proxying CustomTools, then
-		// create ONE headless session scoped to the browser tools (Office document
-		// tools arrive at runtime via set_host_tools).
-		const extensionTools = deps.createExtensionBridgeTools(bridge);
+		// Create ONE headless Office session scoped to the minimal general builtin set
+		// (OFFICE_TOOL_NAMES) with NO browser tools — neither the browser BUILTINS
+		// (navigate/click/…) nor the bridge-proxying browser CUSTOM tools, both of which
+		// would be hallucinated in a document task pane (there is no browser to drive).
+		// The document's own tools (Excel/Word/PowerPoint) arrive at runtime via
+		// set_host_tools; chat over xcsh's configured provider needs no browser tooling.
 		const { session } = await deps.createAgentSession({
 			cwd,
 			hasUI: false,
-			toolNames: [...new Set([...BROWSER_TOOL_NAMES, ...EXTENSION_AGENT_TOOL_NAMES])],
-			customTools: extensionTools,
+			toolNames: [...OFFICE_TOOL_NAMES],
+			customTools: [],
 			// Headless: no MCP/LSP/extension discovery — lean, no network/blocking prompts.
 			enableMCP: false,
 			enableLsp: false,

--- a/packages/coding-agent/src/browser/host-profiles.ts
+++ b/packages/coding-agent/src/browser/host-profiles.ts
@@ -1,0 +1,164 @@
+/**
+ * Host-aware system prompts for the bridge chat engine.
+ *
+ * The same `hello`/`hello_ack` bridge serves two very different clients: the
+ * Chrome extension (a browser side panel driving the F5 XC console) and the
+ * Office add-in task pane (Excel / PowerPoint / Word, driving the open
+ * document). A `host` field on the handshake tells the engine which one it is,
+ * so `composeChatPrompt` can inject the RIGHT self-awareness prompt instead of
+ * unconditionally telling every client it is a Chrome browser panel.
+ *
+ * Browser-safe: pure string/data module, no node/bun imports — so it can be
+ * type-imported by the office-pane's browser bundle via the native contract.
+ */
+
+/**
+ * The client hosts the bridge can serve, as lowercase wire values. Office maps
+ * its `Office.context.host` ("Excel"|"PowerPoint"|"Word") to these; the Chrome
+ * extension is "chrome". Outlook is intentionally absent — the add-in omits the
+ * host for hosts without a document assistant, so the engine falls back to the
+ * default profile.
+ */
+export type ClientHost = "chrome" | "excel" | "powerpoint" | "word";
+
+/** Every {@link ClientHost} value, for iteration + validation. */
+export const CLIENT_HOSTS: readonly ClientHost[] = ["chrome", "excel", "powerpoint", "word"];
+
+/** Runtime guard: true when `v` is a valid {@link ClientHost} wire value. */
+export function isClientHost(v: unknown): v is ClientHost {
+	return typeof v === "string" && (CLIENT_HOSTS as readonly string[]).includes(v);
+}
+
+/**
+ * A host profile pairs a `kind` (browser vs document) with the self-awareness
+ * system prompt for that host. `kind` gates browser-only behavior in
+ * `composeChatPrompt` (interaction modes + the page-context block) — document
+ * hosts get neither.
+ */
+export interface HostProfile {
+	kind: "browser" | "document";
+	systemPrompt: string;
+}
+
+/**
+ * Chrome-extension self-awareness prompt. Injected when xcsh is serving a browser
+ * chat (not the CLI TUI). Tells the LLM it's in a Chrome side panel alongside the
+ * F5 XC console, what tools it has, and how to behave differently from the CLI.
+ */
+export const CHROME_CHAT_SYSTEM_PROMPT = `[System: You are xcsh, an AI assistant for the F5 Distributed Cloud console, running as a Chrome browser side panel — not a terminal CLI.
+
+CRITICAL: ALWAYS respond with TEXT FIRST. Do NOT jump straight to tool calls. The user sees a chat panel and expects a conversational text response, not silence while tools run in the background. For questions ("what page am I on?", "what is this?"), answer with text using the page context below — no tools needed. Only use tools when the user explicitly asks you to DO something (create, navigate, click, modify).
+
+CONTEXT: The user sees a small chat window alongside the F5 XC admin console. You receive page-aware context each turn: the current URL (interpreted as workspace/resource/CRUD operation/namespace), the API resource JSON, and the accessibility tree. USE THIS CONTEXT to answer questions — don't call tools to find information you already have.
+
+BEHAVIOR:
+- Respond concisely with markdown. The chat panel is narrow — avoid long code blocks.
+- You KNOW which page the user is on (injected below). Don't ask "what page are you on?" — tell them.
+- For questions about the page/resource: answer from the injected context. No tools.
+- If a blocking popup/survey appears, dismiss it by clicking the close button.
+- If on the LOGIN page: use the login tool to log in. The login tool handles ALL environments — production (*.console.ves.volterra.io) AND staging (*.staging.volterra.us, login-staging.volterra.us). Do NOT claim the login tool is broken, unsupported, or doesn't work for staging — it does.
+
+BROWSER AUTOMATION (when the user asks to create/modify/navigate resources):
+- You are IN a Chrome browser. The active console tab is your workspace — use IT.
+- For create/modify/delete: call catalog_workflow_runner IMMEDIATELY with ONE tool call per resource:
+  {"resource": "health-check", "operation": "create", "params": {"name": "foo", "namespace": "demo"}, "presentation": "guided"}
+  Do NOT read API specs first, do NOT create todos, do NOT orchestrate multi-step tool chains. The catalog_workflow_runner handles ALL the form navigation internally.
+- Say a brief text message BEFORE the tool call: "Creating health check **foo** — watch the browser." Then call the tool. Nothing else.
+- The human is WATCHING the form automation (fingerprint-before-click, highlights, ~1.5s/step). Do NOT use background API calls.
+- The browser may be at 85% zoom — automation handles coordinates at any zoom.
+- The console catalog has workflows for 100+ F5 XC resources.
+- Do NOT open new tabs — drive the existing console tab.
+
+MULTI-RESOURCE REQUESTS (when the user asks to create several resources in one prompt):
+- Create resources in DEPENDENCY ORDER: health checks first, then origin pools (which reference health checks), then load balancers (which reference origin pools and app firewalls).
+- After each catalog_workflow_runner call completes, IMMEDIATELY proceed to the next resource. Do NOT inspect, verify, click into, or navigate to the resource you just created. Do NOT open the JSON view. Do NOT read the page to confirm — the tool already confirmed success. Move directly to the next creation.
+- Between resources, say ONE short line: "Health check created. Now creating origin pool **bar** — watch the browser." Then call the next tool.
+- NEVER navigate to a list/detail/JSON view between creations. Stay on the automation path.
+
+SAFETY — NEVER DO THESE:
+- NEVER kill, stop, or manage processes on port 19222 — that is YOUR OWN bridge. Killing it kills you.
+- NEVER run lsof, fuser, kill, or pkill on the bridge port. You ARE the bridge.
+- NEVER use bash/shell tools to manage xcsh processes, ports, or the debugger connection.
+- NEVER run commands that would terminate your own process or the WebSocket server.]
+
+`;
+
+/**
+ * Excel task-pane self-awareness prompt. The assistant works the OPEN workbook
+ * via host tools (arriving at runtime over the bridge), thinking in cells,
+ * ranges, and formula dependencies.
+ */
+const EXCEL_CHAT_SYSTEM_PROMPT = `[System: You are xcsh, an AI assistant running as a task pane inside Microsoft Excel — not a terminal CLI. You help the user with the OPEN workbook using the Excel host tools available to you.
+
+CRITICAL: ALWAYS respond with TEXT FIRST — the user sees a chat pane and expects a conversational reply, not silence while tools run. Answer questions from the data you read; only WRITE to the workbook when the user asks you to.
+
+CONTEXT: You can only access the open workbook. Think in cells, ranges, and — above all — FORMULAS and their dependencies:
+- Preserve formula relationships. When you change a cell, let dependent cells recompute; do not overwrite a formula with its current value unless asked.
+- Warn the user before overwriting existing cell contents.
+- Cite specific cells and ranges precisely (e.g. A1, Sheet1!B2:B10) so the user can follow along.
+
+BEHAVIOR:
+- Respond concisely with markdown. The task pane is narrow — avoid long code blocks.
+- Read the workbook to answer questions about its data; do not guess.
+- Make edits only when asked, one clear change at a time, and say what you changed and where.]
+
+`;
+
+/**
+ * PowerPoint task-pane self-awareness prompt. The assistant works the OPEN
+ * presentation via host tools, thinking in slides, shapes, and the slide master.
+ */
+const POWERPOINT_CHAT_SYSTEM_PROMPT = `[System: You are xcsh, an AI assistant running as a task pane inside Microsoft PowerPoint — not a terminal CLI. You help the user with the OPEN presentation using the PowerPoint host tools available to you.
+
+CRITICAL: ALWAYS respond with TEXT FIRST — the user sees a chat pane and expects a conversational reply, not silence while tools run. Answer questions from what you read; only edit the deck when the user asks you to.
+
+CONTEXT: You can only access the open presentation. Think in slides, shapes, and the slide master:
+- Conform any new content to the deck's existing template, fonts, and colors — do not introduce a different look.
+- Make pinpoint, per-slide edits. Do NOT regenerate the whole deck to change one thing.
+- Refer to slides by number so the user can follow along.
+
+BEHAVIOR:
+- Respond concisely with markdown. The task pane is narrow — avoid long code blocks.
+- Read the presentation to answer questions about it; do not guess.
+- Make edits only when asked, one clear change at a time, and say which slide you changed.]
+
+`;
+
+/**
+ * Word task-pane self-awareness prompt. The assistant works the OPEN document
+ * via host tools, thinking in paragraphs, the selection, comments, and tracked
+ * changes.
+ */
+const WORD_CHAT_SYSTEM_PROMPT = `[System: You are xcsh, an AI assistant running as a task pane inside Microsoft Word — not a terminal CLI. You help the user with the OPEN document using the Word host tools available to you.
+
+CRITICAL: ALWAYS respond with TEXT FIRST — the user sees a chat pane and expects a conversational reply, not silence while tools run. Answer questions from what you read; only edit the document when the user asks you to.
+
+CONTEXT: You can only access the open document. Think in paragraphs, the current selection, comments, and tracked changes:
+- Preserve the document's styles and numbering — do not flatten formatting.
+- Describe your edits so the user can review them, and prefer changes the user can accept or reject.
+- When the user refers to "the selection" (or "this"), act on the current selection.
+
+BEHAVIOR:
+- Respond concisely with markdown. The task pane is narrow — avoid long code blocks.
+- Read the document to answer questions about it; do not guess.
+- Make edits only when asked, one clear change at a time, and say what you changed.]
+
+`;
+
+/** The self-awareness profile per client host. */
+export const HOST_PROFILES: Record<ClientHost, HostProfile> = {
+	chrome: { kind: "browser", systemPrompt: CHROME_CHAT_SYSTEM_PROMPT },
+	excel: { kind: "document", systemPrompt: EXCEL_CHAT_SYSTEM_PROMPT },
+	powerpoint: { kind: "document", systemPrompt: POWERPOINT_CHAT_SYSTEM_PROMPT },
+	word: { kind: "document", systemPrompt: WORD_CHAT_SYSTEM_PROMPT },
+};
+
+/** The host assumed when a client does not announce one (the Chrome extension,
+ * whose handshake predates the `host` field). */
+export const DEFAULT_HOST: ClientHost = "chrome";
+
+/** Resolve the profile for a host, falling back to the {@link DEFAULT_HOST}
+ * profile for a null/undefined host (an unannounced or non-document client). */
+export function hostProfile(host: ClientHost | null | undefined): HostProfile {
+	return HOST_PROFILES[host ?? DEFAULT_HOST];
+}

--- a/packages/coding-agent/test/browser/chat-handler.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.test.ts
@@ -9,7 +9,7 @@ import type { PageContextSnapshot } from "@f5-sales-demo/xcsh/browser/chat-proto
 
 describe("composeChatPrompt", () => {
 	it("includes mode instruction and user text", () => {
-		const result = composeChatPrompt("what is this?", null, "educational");
+		const result = composeChatPrompt("what is this?", null, "educational", null);
 		expect(result).toContain("[Chat mode: educational]");
 		expect(result).toContain("Explain concepts");
 		expect(result).toContain("what is this?");
@@ -33,7 +33,7 @@ describe("composeChatPrompt", () => {
 			},
 			truncated: false,
 		};
-		const result = composeChatPrompt("explain this LB", context, "educational");
+		const result = composeChatPrompt("explain this LB", context, "educational", null);
 		expect(result).toContain("URL: https://tenant.console.ves.volterra.io");
 		expect(result).toContain("Title: my-lb");
 		expect(result).toContain("http_loadbalancers");
@@ -44,7 +44,7 @@ describe("composeChatPrompt", () => {
 	it("handles all five interaction modes", () => {
 		const modes = ["educational", "presentation", "configuration", "screenshot", "annotation"] as const;
 		for (const mode of modes) {
-			const result = composeChatPrompt("test", null, mode);
+			const result = composeChatPrompt("test", null, mode, null);
 			expect(result).toContain(`[Chat mode: ${mode}]`);
 		}
 	});
@@ -61,7 +61,7 @@ describe("composeChatPrompt", () => {
 			api: { url: "/api/test", status: 200, resourceType: "test", body: {}, truncated: true },
 			truncated: true,
 		};
-		const result = composeChatPrompt("hi", context, "configuration");
+		const result = composeChatPrompt("hi", context, "configuration", null);
 		expect(result).toContain("[API body was truncated]");
 		expect(result).toContain("[Page context was truncated]");
 	});
@@ -78,7 +78,7 @@ describe("composeChatPrompt", () => {
 			api: { url: "/api/test", status: 200, resourceType: null, body: {}, truncated: false },
 			truncated: false,
 		};
-		const result = composeChatPrompt("hi", context, "educational");
+		const result = composeChatPrompt("hi", context, "educational", null);
 		expect(result).toContain("unknown, status 200");
 		expect(result).not.toContain("null");
 	});
@@ -95,12 +95,59 @@ describe("composeChatPrompt", () => {
 			api: null,
 			truncated: false,
 		};
-		const result = composeChatPrompt("hi", context, "presentation");
+		const result = composeChatPrompt("hi", context, "presentation", null);
 		expect(result).toContain("URL: https://example.com");
 		// When api/ax are null, the PER-TURN context sections should not appear
 		// (the system prompt mentions "API resource" generically — that's fine).
 		expect(result).not.toContain("API resource (");
 		expect(result).not.toContain("Accessibility tree:");
+	});
+
+	it("host 'chrome' is identical to a null host (browser prompt + mode line)", () => {
+		const chrome = composeChatPrompt("hi", null, "educational", "chrome");
+		const legacy = composeChatPrompt("hi", null, "educational", null);
+		expect(chrome).toBe(legacy);
+		expect(chrome).toContain("Chrome browser side panel");
+		expect(chrome).toContain("[Chat mode: educational]");
+	});
+
+	it("host 'excel' uses the Excel document prompt, no Chrome text, no mode line", () => {
+		const result = composeChatPrompt("sum column B", null, "educational", "excel");
+		expect(result).toContain("Microsoft Excel");
+		expect(result).toContain("workbook");
+		expect(result).toContain("sum column B");
+		// Document hosts get NO Chrome self-awareness and NO browser interaction mode.
+		expect(result).not.toContain("Chrome");
+		expect(result).not.toContain("[Chat mode:");
+		expect(result).not.toContain("catalog_workflow_runner");
+	});
+
+	it("document hosts drop the page-context block even when a context is passed", () => {
+		const context: PageContextSnapshot = {
+			v: 1,
+			capturedAt: 1719000000000,
+			tabId: 1,
+			url: "https://example.com",
+			path: "/",
+			title: "Test",
+			ax: null,
+			api: { url: "/api/test", status: 200, resourceType: "test", body: { a: 1 }, truncated: false },
+			truncated: false,
+		};
+		const result = composeChatPrompt("hi", context, "educational", "word");
+		expect(result).toContain("Microsoft Word");
+		// The Chrome-only page-context sections must NOT be injected for a document host.
+		expect(result).not.toContain("[Page context —");
+		expect(result).not.toContain("URL: https://example.com");
+		expect(result).not.toContain("[Chat mode:");
+	});
+
+	it("powerpoint uses the PowerPoint document prompt", () => {
+		const result = composeChatPrompt("tidy slide 3", null, "presentation", "powerpoint");
+		expect(result).toContain("Microsoft PowerPoint");
+		expect(result).toContain("presentation");
+		expect(result).not.toContain("Chrome");
+		expect(result).not.toContain("[Chat mode:");
 	});
 });
 

--- a/packages/coding-agent/test/browser/host-profiles.test.ts
+++ b/packages/coding-agent/test/browser/host-profiles.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import {
+	CLIENT_HOSTS,
+	type ClientHost,
+	DEFAULT_HOST,
+	HOST_PROFILES,
+	hostProfile,
+	isClientHost,
+} from "@f5-sales-demo/xcsh/browser/host-profiles";
+
+/** Substrings that must NEVER leak into a document (Office) host prompt — they
+ * are Chrome-extension-only concepts that would confuse an Office assistant. */
+const BROWSER_ONLY_TERMS = ["Chrome", "browser", "port 19222", "catalog_workflow_runner"] as const;
+
+describe("host profiles", () => {
+	it("exposes every ClientHost in CLIENT_HOSTS", () => {
+		expect([...CLIENT_HOSTS].sort()).toEqual(["chrome", "excel", "powerpoint", "word"]);
+	});
+
+	it("has a profile for every ClientHost", () => {
+		for (const host of CLIENT_HOSTS) {
+			expect(HOST_PROFILES[host]).toBeDefined();
+			expect(typeof HOST_PROFILES[host].systemPrompt).toBe("string");
+			expect(HOST_PROFILES[host].systemPrompt.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("chrome is a browser profile that mentions Chrome", () => {
+		const p = HOST_PROFILES.chrome;
+		expect(p.kind).toBe("browser");
+		expect(p.systemPrompt).toContain("Chrome");
+	});
+
+	for (const host of ["excel", "powerpoint", "word"] as const) {
+		it(`${host} is a document profile that mentions its app and no browser-only terms`, () => {
+			const p = HOST_PROFILES[host];
+			expect(p.kind).toBe("document");
+			const app = { excel: "Excel", powerpoint: "PowerPoint", word: "Word" }[host];
+			expect(p.systemPrompt).toContain(app);
+			for (const term of BROWSER_ONLY_TERMS) {
+				expect(p.systemPrompt).not.toContain(term);
+			}
+		});
+	}
+
+	it("excel prompt thinks in cells/ranges/formulas", () => {
+		const t = HOST_PROFILES.excel.systemPrompt;
+		expect(t).toContain("workbook");
+		expect(t.toLowerCase()).toContain("formula");
+	});
+
+	it("powerpoint prompt thinks in slides", () => {
+		const t = HOST_PROFILES.powerpoint.systemPrompt;
+		expect(t).toContain("presentation");
+		expect(t.toLowerCase()).toContain("slide");
+	});
+
+	it("word prompt thinks in the document", () => {
+		const t = HOST_PROFILES.word.systemPrompt;
+		expect(t).toContain("document");
+	});
+
+	it("isClientHost accepts the wire values and rejects others", () => {
+		for (const host of CLIENT_HOSTS) expect(isClientHost(host)).toBe(true);
+		expect(isClientHost("outlook")).toBe(false);
+		expect(isClientHost("Excel")).toBe(false);
+		expect(isClientHost(null)).toBe(false);
+		expect(isClientHost(undefined)).toBe(false);
+		expect(isClientHost(42)).toBe(false);
+	});
+
+	it("hostProfile falls back to the DEFAULT_HOST (chrome) for null/undefined", () => {
+		expect(DEFAULT_HOST).toBe("chrome");
+		expect(hostProfile(null)).toBe(HOST_PROFILES.chrome);
+		expect(hostProfile(undefined)).toBe(HOST_PROFILES.chrome);
+		const excel: ClientHost = "excel";
+		expect(hostProfile(excel)).toBe(HOST_PROFILES.excel);
+	});
+});

--- a/packages/coding-agent/test/extension-session-contract.test.ts
+++ b/packages/coding-agent/test/extension-session-contract.test.ts
@@ -15,7 +15,7 @@ import { ContextService } from "@f5-sales-demo/xcsh/services/xcsh-context";
  * from #1856). Tested in isolation: no worker spawn, no model, no network.
  */
 
-/** The hello_ack frame the extension consumes (extension-bridge.ts:276-287). */
+/** The hello_ack frame the extension consumes (extension-bridge.ts). */
 interface HelloAck {
 	type: string;
 	sessionId: string | null;
@@ -24,18 +24,22 @@ interface HelloAck {
 	env: string | null;
 	apiUrl: string | null;
 	contextBound: boolean;
+	host: string | null;
 	pid: number;
 }
 
-/** Open a fake extension client, send `hello`, resolve the parsed `hello_ack`. */
-function handshake(port: number, timeoutMs = 5_000): Promise<HelloAck> {
+/** Open a fake client, send `hello` (optionally announcing a client host), resolve
+ * the parsed `hello_ack`. */
+function handshake(port: number, timeoutMs = 5_000, host?: string): Promise<HelloAck> {
 	return new Promise<HelloAck>((resolve, reject) => {
 		const ws = new WebSocket(`ws://127.0.0.1:${port}`);
 		const timer = setTimeout(() => {
 			ws.close();
 			reject(new Error("hello_ack timeout"));
 		}, timeoutMs);
-		ws.addEventListener("open", () => ws.send(JSON.stringify({ type: "hello" })));
+		ws.addEventListener("open", () =>
+			ws.send(JSON.stringify(host === undefined ? { type: "hello" } : { type: "hello", host })),
+		);
 		ws.addEventListener("message", ev => {
 			let msg: HelloAck;
 			try {
@@ -163,6 +167,23 @@ describe("extension session contract", () => {
 			// The extension requires contract major 1 to bind + route (session-routing).
 			expect(Number(ack.contractVersion.split(".")[0])).toBe(1);
 			expect(typeof ack.pid).toBe("number");
+		});
+
+		it("defaults host to null when the client announces none (Chrome extension)", async () => {
+			const ack = await handshake(server.port);
+			expect(ack.host).toBeNull();
+		});
+
+		it("echoes a valid announced client host (Office add-in)", async () => {
+			const ack = await handshake(server.port, 5_000, "excel");
+			expect(ack.host).toBe("excel");
+			expect(server.clientHost).toBe("excel");
+		});
+
+		it("ignores an invalid announced host (retains null)", async () => {
+			const ack = await handshake(server.port, 5_000, "outlook");
+			expect(ack.host).toBeNull();
+			expect(server.clientHost).toBeNull();
 		});
 
 		// --- Perf guard (catastrophic-regression only; NOT a tight budget) ---

--- a/packages/coding-agent/test/headless-bridge.test.ts
+++ b/packages/coding-agent/test/headless-bridge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { BridgeServer } from "../src/browser/extension-bridge";
-import { BROWSER_TOOL_NAMES } from "../src/browser/extension-bridge-tools";
+import { BROWSER_TOOL_NAMES, OFFICE_TOOL_NAMES } from "../src/browser/extension-bridge-tools";
 import {
 	type HeadlessBridgeDeps,
 	sessionInfoForOfficeServe,
@@ -59,9 +59,6 @@ function makeDeps(opts: { tls?: unknown; sessionThrows?: boolean } = {}) {
 			log.push(b === null ? "clearShared" : "setShared");
 			calls.push(b === null ? "setShared:null" : b === bridge ? "setShared:same" : "setShared:other");
 		}) as HeadlessBridgeDeps["setSharedBridgeServer"],
-		createExtensionBridgeTools: (() => [
-			"extension-tool",
-		]) as unknown as HeadlessBridgeDeps["createExtensionBridgeTools"],
 		createAgentSession: (async (o: Record<string, unknown>) => {
 			log.push("createSession");
 			sessionOpts = o;
@@ -92,14 +89,20 @@ describe("startHeadlessChatBridge", () => {
 		expect(h.calls).toContain("setShared:same");
 		expect(h.calls).toContain("setSessionInfo");
 
-		// ONE headless session, scoped to the browser tools, no MCP/LSP/discovery.
+		// ONE headless Office session, scoped to the minimal general tool set (NO
+		// browser builtin tools — they'd be hallucinated in a document task pane;
+		// document tools arrive at runtime via set_host_tools), no MCP/LSP/discovery.
 		const o = h.sessionOpts();
 		expect(o?.hasUI).toBe(false);
 		expect(o?.enableMCP).toBe(false);
 		expect(o?.enableLsp).toBe(false);
 		expect(o?.disableExtensionDiscovery).toBe(true);
-		expect(o?.customTools).toEqual(["extension-tool"]);
-		for (const name of BROWSER_TOOL_NAMES) expect(o?.toolNames as string[]).toContain(name);
+		// Office session carries NO browser tools — no builtins beyond OFFICE_TOOL_NAMES
+		// and no bridge-proxying browser custom tools (they'd be hallucinated in a pane).
+		expect(o?.customTools).toEqual([]);
+		expect(o?.toolNames).toEqual([...OFFICE_TOOL_NAMES]);
+		// No browser builtin tool leaks into the Office session.
+		for (const name of BROWSER_TOOL_NAMES) expect(o?.toolNames as string[]).not.toContain(name);
 
 		// ChatHandler constructed with (bridge, session) and attached.
 		expect(h.chatCtor()?.bridge).toBe(h.bridge);

--- a/packages/office-pane/src/core/transport/loopback.ts
+++ b/packages/office-pane/src/core/transport/loopback.ts
@@ -10,6 +10,7 @@
  * tolerance cannot be expressed through the factory API.
  */
 
+import type { ClientHost } from "@f5-sales-demo/xcsh/browser/chat-protocol";
 import {
 	isChatDelta,
 	isChatDone,
@@ -39,6 +40,9 @@ const DEFAULT_HOST = "127-0-0-1.local-ip.sh";
 interface HelloMsg {
 	type: "hello";
 	version: string;
+	/** The client host (contract 1.10.0) so the engine picks the document-assistant
+	 * prompt for this Office app. Omitted for hosts without a profile (Outlook). */
+	host?: ClientHost;
 }
 
 interface HelloAckMsg {
@@ -85,6 +89,12 @@ export interface LoopbackBridgeOptions {
 	 */
 	discoveryTimeoutMs?: number;
 	/**
+	 * The client host announced on the `hello` handshake (contract 1.10.0), so
+	 * xcsh injects the document-assistant prompt for this Office app. Omitted for
+	 * a host without a profile (Outlook/unknown) → the engine's default profile.
+	 */
+	clientHost?: ClientHost;
+	/**
 	 * TEST-ONLY: inject a WebSocket factory to exercise logic without a real
 	 * wss server. This must never be used to disable TLS verification — the
 	 * factory signature does not accept cert options by design.
@@ -128,6 +138,8 @@ export class LoopbackBridgeTransport implements ConfigurableTransport {
 	private readonly _discoveryPorts: number[] | null;
 	private readonly _discoveryTimeoutMs: number;
 	private readonly _wsFactory: WebSocketFactory;
+	/** Client host announced on `hello` (undefined = announce none → default profile). */
+	private readonly _clientHost: ClientHost | undefined;
 
 	constructor(opts: LoopbackBridgeOptions = {}) {
 		this._host = opts.host ?? DEFAULT_HOST;
@@ -135,6 +147,16 @@ export class LoopbackBridgeTransport implements ConfigurableTransport {
 		this._discoveryPorts = opts.port === undefined ? wssPortCandidates() : null;
 		this._discoveryTimeoutMs = opts.discoveryTimeoutMs ?? 4000;
 		this._wsFactory = opts._webSocketFactory ?? ((url: string) => new WebSocket(url));
+		this._clientHost = opts.clientHost;
+	}
+
+	/** Build the `hello` frame, announcing the client host when one is configured. */
+	private _helloFrame(): HelloMsg {
+		return {
+			type: "hello",
+			version: HELLO_VERSION,
+			...(this._clientHost ? { host: this._clientHost } : {}),
+		};
 	}
 
 	get state(): "idle" | "connecting" | "open" | "closed" {
@@ -214,8 +236,7 @@ export class LoopbackBridgeTransport implements ConfigurableTransport {
 			this._ws = ws;
 
 			ws.onopen = () => {
-				const hello: HelloMsg = { type: "hello", version: HELLO_VERSION };
-				ws.send(JSON.stringify(hello));
+				ws.send(JSON.stringify(this._helloFrame()));
 			};
 
 			ws.onmessage = (event: MessageEvent) => {
@@ -329,7 +350,7 @@ export class LoopbackBridgeTransport implements ConfigurableTransport {
 				};
 
 				ws.onopen = () => {
-					ws.send(JSON.stringify({ type: "hello", version: HELLO_VERSION } satisfies HelloMsg));
+					ws.send(JSON.stringify(this._helloFrame()));
 				};
 				ws.onmessage = (event: MessageEvent) => {
 					if (done) return;

--- a/packages/office-pane/src/office/transport-factory.ts
+++ b/packages/office-pane/src/office/transport-factory.ts
@@ -21,6 +21,7 @@
  *
  * Browser-safe: no node:* imports, no Office.js.
  */
+import type { ClientHost } from "@f5-sales-demo/xcsh/browser/chat-protocol";
 import { type ConfigurableTransport, type GatewayConfig, LoopbackBridgeTransport, type Transport } from "../core";
 import type { BuiltTransport } from "../panel";
 import { wireExcelHostTools } from "./excel-tools";
@@ -28,16 +29,36 @@ import type { OfficeHost } from "./host-adapter";
 import { wirePowerPointHostTools } from "./powerpoint-tools";
 import { wireWordHostTools } from "./word-tools";
 
+/**
+ * Map the detected {@link OfficeHost} to the lowercase {@link ClientHost} wire
+ * value the bridge understands. Hosts without a document-assistant profile
+ * (Outlook / unknown) map to `undefined` so the `hello` handshake omits the host
+ * and the engine falls back to its default profile.
+ */
+export function officeHostToClientHost(host: OfficeHost): ClientHost | undefined {
+	switch (host) {
+		case "Excel":
+			return "excel";
+		case "PowerPoint":
+			return "powerpoint";
+		case "Word":
+			return "word";
+		default:
+			return undefined;
+	}
+}
+
 /** Injectable seams (defaulted to the real ones) so the factory is unit-testable. */
 export interface TransportFactoryDeps {
-	/** Create the concrete bridge transport (a `ConfigurableTransport`). */
-	createTransport: () => ConfigurableTransport;
+	/** Create the concrete bridge transport (a `ConfigurableTransport`), announcing
+	 * the client host so xcsh picks the document-assistant prompt. */
+	createTransport: (clientHost?: ClientHost) => ConfigurableTransport;
 	/** Wire the host-appropriate document tools; returns the post-connect advertiser. */
 	wireHostTools: (host: OfficeHost, transport: Transport) => { onConnected: () => void };
 }
 
 const defaultDeps: TransportFactoryDeps = {
-	createTransport: () => new LoopbackBridgeTransport(),
+	createTransport: clientHost => new LoopbackBridgeTransport({ clientHost }),
 	wireHostTools: (host, transport) =>
 		host === "PowerPoint"
 			? wirePowerPointHostTools(transport)
@@ -60,8 +81,9 @@ export function makeBuildTransport(
 	host: OfficeHost,
 	deps: TransportFactoryDeps = defaultDeps,
 ): (config: GatewayConfig | null) => BuiltTransport {
+	const clientHost = officeHostToClientHost(host);
 	return (config: GatewayConfig | null): BuiltTransport => {
-		const transport = deps.createTransport();
+		const transport = deps.createTransport(clientHost);
 		const wired = deps.wireHostTools(host, transport);
 		return {
 			transport,

--- a/packages/office-pane/test/loopback.test.ts
+++ b/packages/office-pane/test/loopback.test.ts
@@ -146,6 +146,42 @@ describe("LoopbackBridgeTransport — connection lifecycle", () => {
 		await p;
 	});
 
+	it("(3a) hello announces the configured client host", async () => {
+		const { factory, capture } = makeFactory();
+		const t = new LoopbackBridgeTransport({ port: 19222, clientHost: "excel", _webSocketFactory: factory });
+		const p = t.connect();
+		const ws = capture();
+		ws.triggerOpen();
+		const hello = JSON.parse(ws.sent[0] ?? "{}");
+		expect(hello.type).toBe("hello");
+		expect(hello.host).toBe("excel");
+		ws.receive(JSON.stringify({ type: "hello_ack" }));
+		await p;
+	});
+
+	it("(3b) hello omits host when no client host is configured", async () => {
+		const { factory, capture } = makeFactory();
+		const t = new LoopbackBridgeTransport({ port: 19222, _webSocketFactory: factory });
+		const p = t.connect();
+		const ws = capture();
+		ws.triggerOpen();
+		const hello = JSON.parse(ws.sent[0] ?? "{}");
+		expect("host" in hello).toBe(false);
+		ws.receive(JSON.stringify({ type: "hello_ack" }));
+		await p;
+	});
+
+	it("(3c) discovery-mode hello also announces the configured client host", () => {
+		const { factory, byPort } = makeDiscoveryFactory();
+		const t = new LoopbackBridgeTransport({ clientHost: "word", _webSocketFactory: factory, discoveryTimeoutMs: 50 });
+		void t.connect();
+		const ws = byPort.get(19322);
+		ws?.triggerOpen();
+		const hello = JSON.parse(ws?.sent[0] ?? "{}");
+		expect(hello.host).toBe("word");
+		t.dispose();
+	});
+
 	it("(4) connect() rejects on WebSocket error before hello_ack", async () => {
 		const { factory, capture } = makeFactory();
 		const t = new LoopbackBridgeTransport({ port: 19222, _webSocketFactory: factory });

--- a/packages/office-pane/test/transport-factory.test.ts
+++ b/packages/office-pane/test/transport-factory.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import type { ClientHost } from "@f5-sales-demo/xcsh/browser/chat-protocol";
 import type { ConfigurableTransport, GatewayConfig, ProviderConfigure } from "../src/core";
 import type { OfficeHost } from "../src/office/host-adapter";
-import { makeBuildTransport } from "../src/office/transport-factory";
+import { makeBuildTransport, officeHostToClientHost } from "../src/office/transport-factory";
 
 const CONFIG: GatewayConfig = { baseUrl: "https://gw/anthropic", token: "t", model: "m" };
 
@@ -35,6 +36,16 @@ function build(host: OfficeHost, stub: ReturnType<typeof makeStub>) {
 		wireHostTools: () => ({ onConnected: () => stub.calls.push("advertise") }),
 	})(CONFIG);
 }
+
+describe("officeHostToClientHost", () => {
+	test("maps Office hosts to lowercase wire values, omitting hosts without a profile", () => {
+		expect(officeHostToClientHost("Excel")).toBe("excel");
+		expect(officeHostToClientHost("PowerPoint")).toBe("powerpoint");
+		expect(officeHostToClientHost("Word")).toBe("word");
+		expect(officeHostToClientHost("Outlook")).toBeUndefined();
+		expect(officeHostToClientHost("unknown")).toBeUndefined();
+	});
+});
 
 describe("makeBuildTransport", () => {
 	test("provision() configures xcsh's provider with the saved config, resolving on ack", async () => {
@@ -79,6 +90,32 @@ describe("makeBuildTransport", () => {
 		const stub = makeStub();
 		const built = build("Excel", stub);
 		expect(built.transport).toBe(stub.transport);
+	});
+
+	test("passes the mapped client host to createTransport so the bridge learns the Office app", () => {
+		const seen: (ClientHost | undefined)[] = [];
+		const stub = makeStub();
+		makeBuildTransport("PowerPoint", {
+			createTransport: (clientHost?: ClientHost) => {
+				seen.push(clientHost);
+				return stub.transport;
+			},
+			wireHostTools: () => ({ onConnected: () => {} }),
+		})(CONFIG);
+		expect(seen).toEqual(["powerpoint"]);
+	});
+
+	test("passes undefined to createTransport for a host without a profile (Outlook)", () => {
+		const seen: (ClientHost | undefined)[] = [];
+		const stub = makeStub();
+		makeBuildTransport("Outlook", {
+			createTransport: (clientHost?: ClientHost) => {
+				seen.push(clientHost);
+				return stub.transport;
+			},
+			wireHostTools: () => ({ onConnected: () => {} }),
+		})(CONFIG);
+		expect(seen).toEqual([undefined]);
 	});
 
 	test("a NULL config (chat-first default) builds a transport with NO provision (uses xcsh's provider)", () => {


### PR DESCRIPTION
## Problem

Closes #2193. The shared bridge agent was host-blind: the Chrome extension and the Office add-in (Excel/PowerPoint/Word) share one `hello`/`hello_ack` handshake that carried **no host identity**. So `composeChatPrompt` injected the Chrome browser system prompt ("you are in a Chrome browser side panel… never kill port 19222…") + a Chrome interaction mode for **every** turn, including Office. Claude itself ships **four distinct per-app assistants** (Chrome browser-automation; Excel cells/formulas; PowerPoint slides/master; Word paragraphs/tracked-changes) — xcsh must be contextual too.

## Change (built natively into xcsh; no dependency on the claude-office shim)

- **`browser/host-profiles.ts` (new)** — `ClientHost = chrome|excel|powerpoint|word` (the canonical `Office.context.host` values, lowercased), `HostProfile{kind,systemPrompt}`, `HOST_PROFILES`, `hostProfile()` (chrome default). Chrome prompt moved verbatim; the three Office prompts mirror Claude's documented per-app behavior.
- **`composeChatPrompt(text,context,mode,host)`** — browser hosts get the interaction-mode line + page-context block; document hosts get neither. `ChatHandler` passes `server.clientHost`.
- **Handshake** — `hello.host` (client) → bridge validates (`isClientHost`), records `clientHost`, echoes `host` in `hello_ack`. The Office pane sends its `Office.context.host` (Excel→excel/…; Outlook/unknown omitted → chrome default). **Contract 1.9.0 → 1.10.0** (additive; clients gate on major): `capabilities.json` + regenerated `capabilities.generated.ts` + `chat-conformance.json` + contract goldens.
- **Office tool scope** — the `xcsh office serve` session is scoped to `OFFICE_TOOL_NAMES=["calc"]` (empty `toolNames` returns the FULL builtin registry incl. bash/edit/browser — verified, not safe) and **no** browser custom tools; document tools arrive at runtime via `set_host_tools`.

## Acceptance criteria (#2193)

- [x] `hello.host` sent by the Office pane, recorded by the bridge, echoed in `hello_ack`.
- [x] Excel/PPT/Word chats get a per-app document prompt — not the Chrome prompt, no browser mode line.
- [x] Chrome chats unchanged (browser prompt + modes + page-state).
- [x] Office session carries no browser tools (builtin or custom).
- [x] Contract 1.10.0 across all synced files; conformance drift guard green.
- [x] Unknown/absent host → chrome default (no regression for un-updated clients).
- [x] TDD across host-profiles, composeChatPrompt(host), handshake, office tool-scope.

## Verification

coding-agent touched-suite **47/0**, `tsgo` exit 0, biome clean; office-pane **245/0** + `check` clean (includes the conformance drift guard); contract **1.10.0** aligned across `capabilities.json` / `capabilities.generated.ts` / `chat-conformance.json`.

## Follow-ups (separate, noted in #2193)

- Chrome extension repo: send explicit `host:"chrome"` on `hello`.
- Per-host interaction-mode vocabularies + capabilities `promptHints` per host.
- Host-aware trust/safety posture (untrusted-web vs user-document).

🤖 Generated with [Claude Code](https://claude.com/claude-code)