### PR TITLE
feat(sandbox): confine sessions to their CWD subtree (Phase 1)

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -12,6 +12,10 @@ export type Mode = "text" | "json" | "rpc" | "acp";
 export interface Args {
 	cwd?: string;
 	allowHome?: boolean;
+	/** Disable the session filesystem sandbox (widen to unrestricted access). */
+	noSandbox?: boolean;
+	/** Extra directories the session may read AND write, beyond its CWD subtree (repeatable). */
+	allowPath?: string[];
 	provider?: string;
 	model?: string;
 	smol?: string;
@@ -69,6 +73,11 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 			result.version = true;
 		} else if (arg === "--allow-home") {
 			result.allowHome = true;
+		} else if (arg === "--no-sandbox") {
+			result.noSandbox = true;
+		} else if (arg === "--allow-path" && i + 1 < args.length) {
+			result.allowPath = result.allowPath ?? [];
+			result.allowPath.push(args[++i]);
 		} else if (arg === "--mode" && i + 1 < args.length) {
 			const mode = args[++i];
 			if (mode === "text" || mode === "json" || mode === "rpc" || mode === "acp") {
@@ -267,6 +276,10 @@ ${chalk.bold("Available Tools (default-enabled unless noted):")}
   todo_write    - Manage todo/task lists
   web_search    - Search the web
   ask           - Ask user questions (interactive mode only)
+
+${chalk.bold("Sandbox Options:")}
+  --no-sandbox               Disable session filesystem isolation (allow access outside the CWD)
+  --allow-path <path>        Grant read+write access to an extra directory (repeatable)
 
 ${chalk.bold("Plugin Options:")}
   --plugin-dir <path>        Load plugin from directory (repeatable)

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1812,16 +1812,6 @@ export const SETTINGS_SCHEMA = {
 	"sandbox.allowWrite": { type: "array", default: [] as string[] },
 	"sandbox.denyRead": { type: "array", default: [] as string[] },
 	"sandbox.denyWrite": { type: "array", default: [] as string[] },
-	// Phase 2 (opt-in, reserved): wrap Bash in an OS-level filesystem sandbox.
-	"sandbox.bashOsSandbox.enabled": {
-		type: "boolean",
-		default: false,
-		ui: {
-			tab: "sandbox",
-			label: "OS-level Bash sandbox",
-			description: "Reserved (Phase 2): enforce the boundary on Bash subprocesses at the OS level",
-		},
-	},
 
 	// Provider selection
 	"providers.webSearch": {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -24,7 +24,8 @@ export type SettingTab =
 	| "editing"
 	| "tools"
 	| "tasks"
-	| "providers";
+	| "providers"
+	| "sandbox";
 
 /** Tab display metadata - icon is resolved via theme.symbol() */
 export type TabMetadata = { label: string; icon: `tab.${string}` };
@@ -39,6 +40,7 @@ export const SETTING_TABS: SettingTab[] = [
 	"tools",
 	"tasks",
 	"providers",
+	"sandbox",
 ];
 
 /** Tab display metadata - icon is a symbol key from theme.ts (tab.*) */
@@ -51,6 +53,7 @@ export const TAB_METADATA: Record<SettingTab, { label: string; icon: `tab.${stri
 	tools: { label: "Tools", icon: "tab.tools" },
 	tasks: { label: "Tasks", icon: "tab.tasks" },
 	providers: { label: "Providers", icon: "tab.providers" },
+	sandbox: { label: "Sandbox", icon: "tab.sandbox" },
 };
 
 /** Status line segment identifiers */
@@ -1788,6 +1791,36 @@ export const SETTINGS_SCHEMA = {
 		type: "boolean",
 		default: true,
 		ui: { tab: "providers", label: "Hide Secrets", description: "Obfuscate secrets before sending to AI providers" },
+	},
+
+	// Session filesystem isolation. Confines the file tools (read/write/edit/find/grep)
+	// and the Bash working directory to the session's CWD subtree plus a curated global
+	// allowlist, so concurrent sessions in different customer folders cannot read or
+	// write each other's files, secrets, or memory. See src/sandbox/.
+	"sandbox.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "sandbox",
+			label: "Filesystem isolation",
+			description: "Confine file tools to the working directory subtree (blocks cross-session access)",
+		},
+	},
+	// Extra roots (beyond the CWD subtree) the session may read/write. Config/CLI only —
+	// e.g. `--allow-path <dir>` maps into both. Deny rules always win over allow.
+	"sandbox.allowRead": { type: "array", default: [] as string[] },
+	"sandbox.allowWrite": { type: "array", default: [] as string[] },
+	"sandbox.denyRead": { type: "array", default: [] as string[] },
+	"sandbox.denyWrite": { type: "array", default: [] as string[] },
+	// Phase 2 (opt-in, reserved): wrap Bash in an OS-level filesystem sandbox.
+	"sandbox.bashOsSandbox.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "sandbox",
+			label: "OS-level Bash sandbox",
+			description: "Reserved (Phase 2): enforce the boundary on Bash subprocesses at the OS level",
+		},
 	},
 
 	// Provider selection

--- a/packages/coding-agent/src/extensibility/extensions/bundled/sandbox-guard.ts
+++ b/packages/coding-agent/src/extensibility/extensions/bundled/sandbox-guard.ts
@@ -1,0 +1,62 @@
+import type { ExtensionAPI } from "@f5-sales-demo/xcsh";
+import { settings } from "../../../config/settings";
+import { evaluateToolCall } from "../../../sandbox/enforce";
+import { buildDefaultSandboxPolicy, type SandboxPolicy } from "../../../sandbox/policy";
+
+/**
+ * Session filesystem sandbox (bundled, default-on).
+ *
+ * Confines the model-invoked file tools (read/write/edit/find/grep) and the Bash
+ * working directory to the session's CWD subtree plus a curated global allowlist, so
+ * concurrent sessions in different customer folders cannot read or write each other's
+ * files, secrets, or memory. Enforcement is a `tool_call` gate: the extension wrapper
+ * blocks the tool when this returns `{ block: true }`, and fails safe (a thrown handler
+ * also blocks).
+ *
+ * The boundary is derived from `ctx.cwd` (always the live session's directory) plus the
+ * `sandbox.*` settings. Controlled by `sandbox.enabled` (default true); widened per run
+ * with `--allow-path` / `--no-sandbox` or the `sandbox.allow*` settings.
+ */
+export default function sandboxGuard(pi: ExtensionAPI): void {
+	// One policy per cwd — rebuilt only when the working directory changes.
+	let cache: { cwd: string; policy: SandboxPolicy } | undefined;
+
+	// The global settings proxy throws before Settings.init() (e.g. some SDK/test
+	// contexts). Fall back to the given default there so the guard never hard-fails —
+	// and defaults to disabled, since a session without settings has not opted in.
+	function readSetting<T>(key: string, fallback: T): T {
+		try {
+			const value = (settings as unknown as { get(k: string): unknown }).get(key);
+			return value === undefined ? fallback : (value as T);
+		} catch {
+			return fallback;
+		}
+	}
+
+	function policyFor(cwd: string): SandboxPolicy | undefined {
+		if (!readSetting<boolean>("sandbox.enabled", false)) return undefined;
+		if (cache?.cwd === cwd) return cache.policy;
+		const policy = buildDefaultSandboxPolicy({
+			cwd,
+			enabled: true,
+			allowRead: readSetting<string[]>("sandbox.allowRead", []),
+			allowWrite: readSetting<string[]>("sandbox.allowWrite", []),
+			denyRead: readSetting<string[]>("sandbox.denyRead", []),
+			denyWrite: readSetting<string[]>("sandbox.denyWrite", []),
+		});
+		cache = { cwd, policy };
+		return policy;
+	}
+
+	pi.on("tool_call", (event, ctx) => {
+		const policy = policyFor(ctx.cwd);
+		if (!policy) return undefined;
+		const decision = evaluateToolCall({
+			toolName: event.toolName,
+			input: event.input as Record<string, unknown>,
+			cwd: ctx.cwd,
+			policy,
+		});
+		return decision.block ? { block: true, reason: decision.reason } : undefined;
+	});
+}

--- a/packages/coding-agent/src/extensibility/extensions/bundled/sandbox-guard.ts
+++ b/packages/coding-agent/src/extensibility/extensions/bundled/sandbox-guard.ts
@@ -22,8 +22,7 @@ export default function sandboxGuard(pi: ExtensionAPI): void {
 	let cache: { cwd: string; policy: SandboxPolicy } | undefined;
 
 	// The global settings proxy throws before Settings.init() (e.g. some SDK/test
-	// contexts). Fall back to the given default there so the guard never hard-fails —
-	// and defaults to disabled, since a session without settings has not opted in.
+	// contexts). Fall back to the given default there so the guard never hard-fails.
 	function readSetting<T>(key: string, fallback: T): T {
 		try {
 			const value = (settings as unknown as { get(k: string): unknown }).get(key);
@@ -34,7 +33,9 @@ export default function sandboxGuard(pi: ExtensionAPI): void {
 	}
 
 	function policyFor(cwd: string): SandboxPolicy | undefined {
-		if (!readSetting<boolean>("sandbox.enabled", false)) return undefined;
+		// Fail closed: if `sandbox.enabled` can't be read, keep isolation on rather than
+		// silently disabling it. In a normal session settings resolves the true default.
+		if (!readSetting<boolean>("sandbox.enabled", true)) return undefined;
 		if (cache?.cwd === cwd) return cache.policy;
 		const policy = buildDefaultSandboxPolicy({
 			cwd,

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -21,6 +21,7 @@ import { EventBus } from "../../utils/event-bus";
 import { getAllPluginExtensionPaths } from "../plugins/loader";
 import { resolvePath } from "../utils";
 import herdrReporter from "./bundled/herdr-reporter";
+import sandboxGuard from "./bundled/sandbox-guard";
 import type {
 	Extension,
 	ExtensionAPI,
@@ -496,6 +497,7 @@ async function discoverExtensionsInDir(dir: string): Promise<string[]> {
 /** Extensions bundled with xcsh and loaded by default (before user extensions). */
 const BUNDLED_EXTENSIONS: ReadonlyArray<{ name: string; factory: ExtensionFactory }> = [
 	{ name: "herdr-reporter", factory: herdrReporter },
+	{ name: "sandbox-guard", factory: sandboxGuard },
 ];
 
 /**

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -604,7 +604,16 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 	}
 
 	const cwd = getProjectDir();
-	await logger.time("settings:init", Settings.init, { cwd });
+	const sandboxOverrides: Partial<Record<SettingPath, unknown>> = {};
+	if (parsedArgs.noSandbox) sandboxOverrides["sandbox.enabled"] = false;
+	if (parsedArgs.allowPath?.length) {
+		sandboxOverrides["sandbox.allowRead"] = parsedArgs.allowPath;
+		sandboxOverrides["sandbox.allowWrite"] = parsedArgs.allowPath;
+	}
+	await logger.time("settings:init", Settings.init, {
+		cwd,
+		overrides: Object.keys(sandboxOverrides).length > 0 ? sandboxOverrides : undefined,
+	});
 
 	// F5 XC context is session-scoped: nothing loads at startup. We still init the
 	// ContextService singleton so /context commands and the session bootstrap work.

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -191,7 +191,8 @@ export type SymbolKey =
 	| "tab.editing"
 	| "tab.tools"
 	| "tab.tasks"
-	| "tab.providers";
+	| "tab.providers"
+	| "tab.sandbox";
 
 type SymbolMap = Record<SymbolKey, string>;
 
@@ -356,6 +357,7 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	"tab.tools": "🔧",
 	"tab.tasks": "📦",
 	"tab.providers": "🌐",
+	"tab.sandbox": "🔒",
 };
 
 const NERD_SYMBOLS: SymbolMap = {
@@ -616,6 +618,7 @@ const NERD_SYMBOLS: SymbolMap = {
 	"tab.tools": "󰠭",
 	"tab.tasks": "󰐱",
 	"tab.providers": "󰖟",
+	"tab.sandbox": "󰌾",
 };
 
 const ASCII_SYMBOLS: SymbolMap = {
@@ -778,6 +781,7 @@ const ASCII_SYMBOLS: SymbolMap = {
 	"tab.tools": "[T]",
 	"tab.tasks": "[K]",
 	"tab.providers": "[P]",
+	"tab.sandbox": "[S]",
 };
 
 const SYMBOL_PRESETS: Record<SymbolPreset, SymbolMap> = {

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -54,7 +54,7 @@ const TOOL_PATHS: Record<string, PathArgSpec[]> = {
 	notebook: [{ keys: ["notebook_path"], access: "write" }],
 	inspect_image: [{ keys: ["path"], access: "read" }],
 	display_image: [{ keys: ["path"], access: "read" }],
-	vim: [{ keys: ["file"], access: "write" }], // reads and writes the same file
+	lsp: [{ keys: ["file"], access: "read" }], // read for most actions; rename-apply writes
 	puppeteer: [{ keys: ["path"], access: "write" }], // screenshot destination
 	catalog_workflow_runner: [
 		{ keys: ["catalog_path"], access: "read" },
@@ -187,9 +187,12 @@ function evaluateCodeTool(check: ToolCallCheck, fields: string[]): ToolCallDecis
 }
 
 /**
- * The `edit` tool writes to one or more targets. Depending on mode it sends a top-level
- * `file_path`/`path` and/or an `edits` array whose entries each carry their own `path`
- * and (hashline) a `move` rename destination. Every one is a write target.
+ * The `edit` tool is mode-dependent; every mode writes. Targets, across modes:
+ *  - vim mode: top-level `file`
+ *  - replace/patch/hashline/chunk: each `edits[]` entry's `path`
+ *  - hashline rename: `edits[].move`; patch rename: `edits[].rename`
+ * (Chunk paths embed a `:selector#hash~` suffix, but a `..`/absolute escape still resolves
+ * out of tree via the leading segments, so no stripping is needed for the boundary check.)
  */
 function evaluateEdit(check: ToolCallCheck): ToolCallDecision {
 	const { input, cwd, policy } = check;
@@ -197,19 +200,41 @@ function evaluateEdit(check: ToolCallCheck): ToolCallDecision {
 	const add = (value: unknown): void => {
 		if (typeof value === "string" && value.length > 0) targets.push(value);
 	};
+	add(input.file); // vim mode
 	add(input.file_path);
 	add(input.path);
 	if (Array.isArray(input.edits)) {
 		for (const entry of input.edits) {
 			if (entry && typeof entry === "object") {
-				add((entry as Record<string, unknown>).path);
-				add((entry as Record<string, unknown>).move);
+				const e = entry as Record<string, unknown>;
+				add(e.path);
+				add(e.move); // hashline rename
+				add(e.rename); // patch rename
 			}
 		}
 	}
 	for (const target of targets) {
 		const resolved = resolveToCwd(target, cwd);
 		if (!policy.isAllowed(resolved, "write")) return deny(policy, resolved, "write");
+	}
+	return ALLOW;
+}
+
+/**
+ * `generate_image` reads local files named in its `input[]` array (each `{ path?, data? }`)
+ * and sends the bytes to an external API — so an out-of-tree path is both a read escape
+ * and an exfiltration. Registered dynamically (not in BUILTIN_TOOLS).
+ */
+function evaluateGenerateImage(check: ToolCallCheck): ToolCallDecision {
+	const { input, cwd, policy } = check;
+	if (Array.isArray(input.input)) {
+		for (const entry of input.input) {
+			const value = entry && typeof entry === "object" ? (entry as Record<string, unknown>).path : undefined;
+			if (typeof value === "string" && value.length > 0) {
+				const resolved = resolveToCwd(value, cwd);
+				if (!policy.isAllowed(resolved, "read")) return deny(policy, resolved, "read");
+			}
+		}
 	}
 	return ALLOW;
 }
@@ -236,6 +261,7 @@ export function evaluateToolCall(check: ToolCallCheck): ToolCallDecision {
 	if (codeFields) return evaluateCodeTool(check, codeFields);
 
 	if (toolName === "edit") return evaluateEdit(check);
+	if (toolName === "generate_image") return evaluateGenerateImage(check);
 
 	const searchSpec = SEARCH_TOOLS[toolName];
 	if (searchSpec) return evaluateSearchTool(check, searchSpec);

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -11,6 +11,7 @@
  * of absolute paths inside a Bash command are NOT caught here — that gap is closed by
  * the opt-in OS-level Bash sandbox (Phase 2).
  */
+import * as path from "node:path";
 import { resolveToCwd } from "../tools/path-utils";
 import type { SandboxAccess, SandboxPolicy } from "./policy";
 
@@ -71,12 +72,40 @@ function deny(policy: SandboxPolicy, resolved: string, access: SandboxAccess): T
 	return { block: true, reason: policy.describe(resolved, access) };
 }
 
-/** Whitespace-delimited tokens containing a `..` segment, unquoted. */
-function traversalTokens(command: string): string[] {
+/**
+ * Standard OS directories a Bash subprocess may legitimately read or traverse
+ * (interpreters, libraries, device files) and which hold no customer data. The file
+ * tools stay strictly confined to the policy; only Bash command scanning treats these
+ * as benign, so commands like `cat /etc/os-release` or `/usr/bin/env node` are not
+ * falsely blocked. Notably excludes /tmp, /var, /private, and home — those can hold
+ * per-session or per-user data.
+ */
+const SYSTEM_READ_ROOTS = [
+	"/usr",
+	"/bin",
+	"/sbin",
+	"/lib",
+	"/lib64",
+	"/opt",
+	"/etc",
+	"/dev",
+	"/proc",
+	"/sys",
+	"/System",
+	"/Library",
+];
+
+function isSystemPath(resolved: string): boolean {
+	return SYSTEM_READ_ROOTS.some(root => resolved === root || resolved.startsWith(`${root}${path.sep}`));
+}
+
+/** Unquoted, whitespace-delimited tokens that look like filesystem paths. */
+function pathLikeTokens(command: string): string[] {
 	return command
 		.split(/\s+/)
 		.map(tok => tok.replace(/^["']|["']$/g, ""))
-		.filter(tok => /(^|[/\\])\.\.([/\\]|$)/.test(tok));
+		.filter(tok => tok.length > 0)
+		.filter(tok => path.isAbsolute(tok) || tok.startsWith("~") || /(^|[/\\])\.\.([/\\]|$)/.test(tok));
 }
 
 function evaluateBash(check: ToolCallCheck): ToolCallDecision {
@@ -88,10 +117,16 @@ function evaluateBash(check: ToolCallCheck): ToolCallDecision {
 		if (!policy.isAllowed(resolved, "read")) return deny(policy, resolved, "read");
 	}
 
+	// Best-effort scan of the command for path tokens (absolute, `~`, or `..`) that
+	// escape the boundary. OS system paths are exempt; the opt-in OS-level Phase 2
+	// sandbox is the airtight enforcement for Bash.
+	const base = bashCwd ? resolveToCwd(bashCwd, cwd) : cwd;
 	const command = typeof input.command === "string" ? input.command : "";
-	for (const token of traversalTokens(command)) {
-		const resolved = resolveToCwd(token, bashCwd ? resolveToCwd(bashCwd, cwd) : cwd);
-		if (!policy.isAllowed(resolved, "read")) return deny(policy, resolved, "read");
+	for (const token of pathLikeTokens(command)) {
+		const resolved = resolveToCwd(token, base);
+		if (!policy.isAllowed(resolved, "read") && !isSystemPath(resolved)) {
+			return deny(policy, resolved, "read");
+		}
 	}
 
 	return ALLOW;

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -55,7 +55,6 @@ const TOOL_PATHS: Record<string, PathArgSpec[]> = {
 	inspect_image: [{ keys: ["path"], access: "read" }],
 	display_image: [{ keys: ["path"], access: "read" }],
 	lsp: [{ keys: ["file"], access: "read" }], // read for most actions; rename-apply writes
-	puppeteer: [{ keys: ["path"], access: "write" }], // screenshot destination
 	catalog_workflow_runner: [
 		{ keys: ["catalog_path"], access: "read" },
 		{ keys: ["screenshot_dir"], access: "write" },
@@ -239,6 +238,44 @@ function evaluateGenerateImage(check: ToolCallCheck): ToolCallDecision {
 	return ALLOW;
 }
 
+const REMOTE_URL_SCHEME = /^(https?|about|data|chrome|chrome-extension|blob|ws|wss):/i;
+
+/**
+ * If a browser navigation target refers to the LOCAL filesystem, return the path to
+ * check; otherwise undefined (remote/benign scheme). Covers file: URLs, the filesystem:
+ * wrapper, and bare/relative/absolute paths that `goto` would resolve against disk.
+ */
+function navLocalPath(raw: string): string | undefined {
+	const url = raw.trim();
+	if (!url || REMOTE_URL_SCHEME.test(url)) return undefined;
+	if (url.toLowerCase().startsWith("file:")) return url; // resolveToCwd → stripFileUrl
+	if (url.toLowerCase().startsWith("filesystem:")) return url.slice("filesystem:".length);
+	if (path.isAbsolute(url) || url.startsWith("~") || url.startsWith(".")) return url;
+	return undefined; // domain-like host or unknown scheme → not local disk
+}
+
+/**
+ * `puppeteer` (the browser tool) writes screenshots to `path` and navigates to `url`.
+ * A file:// / local navigation target followed by get_text/evaluate/screenshot returns
+ * another session's file contents to the model, so local navigation is a read escape.
+ */
+function evaluatePuppeteer(check: ToolCallCheck): ToolCallDecision {
+	const { input, cwd, policy } = check;
+	const screenshot = firstString(input, ["path"]);
+	if (screenshot) {
+		const resolved = resolveToCwd(screenshot, cwd);
+		if (!policy.isAllowed(resolved, "write")) return deny(policy, resolved, "write");
+	}
+	if (typeof input.url === "string") {
+		const local = navLocalPath(input.url);
+		if (local) {
+			const resolved = resolveToCwd(local, cwd);
+			if (!policy.isAllowed(resolved, "read")) return deny(policy, resolved, "read");
+		}
+	}
+	return ALLOW;
+}
+
 function evaluateSearchTool(check: ToolCallCheck, spec: SearchSpec): ToolCallDecision {
 	const { input, cwd, policy } = check;
 	const raw = typeof input[spec.key] === "string" ? (input[spec.key] as string) : "";
@@ -262,6 +299,7 @@ export function evaluateToolCall(check: ToolCallCheck): ToolCallDecision {
 
 	if (toolName === "edit") return evaluateEdit(check);
 	if (toolName === "generate_image") return evaluateGenerateImage(check);
+	if (toolName === "puppeteer") return evaluatePuppeteer(check);
 
 	const searchSpec = SEARCH_TOOLS[toolName];
 	if (searchSpec) return evaluateSearchTool(check, searchSpec);

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -39,13 +39,33 @@ interface PathArgSpec {
 	/** Candidate input keys, tried in order; first non-empty string wins. */
 	keys: string[];
 	access: SandboxAccess;
+	/** Exempt OS system paths (for tools that legitimately execute system binaries). */
+	systemExempt?: boolean;
 }
 
-/** Tools that touch a single explicit path argument. */
-const TOOL_PATHS: Record<string, PathArgSpec> = {
-	read: { keys: ["file_path", "path"], access: "read" },
-	write: { keys: ["file_path", "path"], access: "write" },
-	notebook: { keys: ["notebook_path"], access: "write" },
+/**
+ * Tools that touch explicit path argument(s). Each tool lists one or more specs; every
+ * present path is checked. Remote/in-memory path-looking args (xcsh_api HTTP paths,
+ * ssh remote cwd) are intentionally absent.
+ */
+const TOOL_PATHS: Record<string, PathArgSpec[]> = {
+	read: [{ keys: ["file_path", "path"], access: "read" }],
+	write: [{ keys: ["file_path", "path"], access: "write" }],
+	notebook: [{ keys: ["notebook_path"], access: "write" }],
+	inspect_image: [{ keys: ["path"], access: "read" }],
+	display_image: [{ keys: ["path"], access: "read" }],
+	vim: [{ keys: ["file"], access: "write" }], // reads and writes the same file
+	puppeteer: [{ keys: ["path"], access: "write" }], // screenshot destination
+	catalog_workflow_runner: [
+		{ keys: ["catalog_path"], access: "read" },
+		{ keys: ["screenshot_dir"], access: "write" },
+	],
+	// debug executes an arbitrary program and reads source files; system binaries are ok.
+	debug: [
+		{ keys: ["program"], access: "read", systemExempt: true },
+		{ keys: ["file"], access: "read", systemExempt: true },
+		{ keys: ["cwd"], access: "read", systemExempt: true },
+	],
 };
 
 interface SearchSpec {
@@ -220,13 +240,16 @@ export function evaluateToolCall(check: ToolCallCheck): ToolCallDecision {
 	const searchSpec = SEARCH_TOOLS[toolName];
 	if (searchSpec) return evaluateSearchTool(check, searchSpec);
 
-	const spec = TOOL_PATHS[toolName];
-	if (!spec) return ALLOW;
+	const specs = TOOL_PATHS[toolName];
+	if (!specs) return ALLOW;
 
-	const raw = firstString(input, spec.keys);
-	if (!raw) return ALLOW; // optional path → defaults to cwd, which is allowed
-
-	const resolved = resolveToCwd(raw, cwd);
-	if (!policy.isAllowed(resolved, spec.access)) return deny(policy, resolved, spec.access);
+	for (const spec of specs) {
+		const raw = firstString(input, spec.keys);
+		if (!raw) continue; // optional path → defaults to cwd, which is allowed
+		const resolved = resolveToCwd(raw, cwd);
+		if (policy.isAllowed(resolved, spec.access)) continue;
+		if (spec.systemExempt && isSystemPath(resolved)) continue;
+		return deny(policy, resolved, spec.access);
+	}
 	return ALLOW;
 }

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -1,0 +1,129 @@
+/**
+ * Pure evaluation of a tool call against a SandboxPolicy.
+ *
+ * Maps each path-taking tool to its path argument(s) and access mode, resolves the
+ * path relative to the session cwd, and asks the policy whether it is allowed. Kept
+ * free of settings/runtime so it is fully unit-testable; the bundled `sandbox-guard`
+ * extension is a thin wrapper that supplies cwd, settings, and the policy.
+ *
+ * Bash handling is best-effort (Phase 1): the `cwd` parameter is checked precisely,
+ * and the command string is scanned for `../` traversals that escape the tree. Reads
+ * of absolute paths inside a Bash command are NOT caught here — that gap is closed by
+ * the opt-in OS-level Bash sandbox (Phase 2).
+ */
+import { resolveToCwd } from "../tools/path-utils";
+import type { SandboxAccess, SandboxPolicy } from "./policy";
+
+export interface ToolCallCheck {
+	toolName: string;
+	input: Record<string, unknown>;
+	cwd: string;
+	policy: SandboxPolicy;
+}
+
+export interface ToolCallDecision {
+	block: boolean;
+	reason?: string;
+}
+
+const ALLOW: ToolCallDecision = { block: false };
+
+interface PathArgSpec {
+	/** Candidate input keys, tried in order; first non-empty string wins. */
+	keys: string[];
+	access: SandboxAccess;
+}
+
+/** Tools that touch a single explicit path argument. */
+const TOOL_PATHS: Record<string, PathArgSpec> = {
+	read: { keys: ["file_path", "path"], access: "read" },
+	grep: { keys: ["path"], access: "read" },
+	ast_grep: { keys: ["path"], access: "read" },
+	write: { keys: ["file_path", "path"], access: "write" },
+	edit: { keys: ["file_path", "path"], access: "write" },
+	ast_edit: { keys: ["path"], access: "write" },
+	notebook: { keys: ["notebook_path"], access: "write" },
+};
+
+const GLOB_CHARS = ["*", "?", "[", "{"];
+
+function firstString(input: Record<string, unknown>, keys: string[]): string | undefined {
+	for (const key of keys) {
+		const value = input[key];
+		if (typeof value === "string" && value.length > 0) return value;
+	}
+	return undefined;
+}
+
+/** Derive the fixed directory prefix of a glob pattern (before the first glob char). */
+function globBase(pattern: string): string {
+	let cut = pattern.length;
+	for (const char of GLOB_CHARS) {
+		const idx = pattern.indexOf(char);
+		if (idx >= 0 && idx < cut) cut = idx;
+	}
+	const prefix = pattern.slice(0, cut);
+	const sep = Math.max(prefix.lastIndexOf("/"), prefix.lastIndexOf("\\"));
+	return sep >= 0 ? prefix.slice(0, sep) : "";
+}
+
+function deny(policy: SandboxPolicy, resolved: string, access: SandboxAccess): ToolCallDecision {
+	return { block: true, reason: policy.describe(resolved, access) };
+}
+
+/** Whitespace-delimited tokens containing a `..` segment, unquoted. */
+function traversalTokens(command: string): string[] {
+	return command
+		.split(/\s+/)
+		.map(tok => tok.replace(/^["']|["']$/g, ""))
+		.filter(tok => /(^|[/\\])\.\.([/\\]|$)/.test(tok));
+}
+
+function evaluateBash(check: ToolCallCheck): ToolCallDecision {
+	const { input, cwd, policy } = check;
+
+	const bashCwd = typeof input.cwd === "string" ? input.cwd : undefined;
+	if (bashCwd) {
+		const resolved = resolveToCwd(bashCwd, cwd);
+		if (!policy.isAllowed(resolved, "read")) return deny(policy, resolved, "read");
+	}
+
+	const command = typeof input.command === "string" ? input.command : "";
+	for (const token of traversalTokens(command)) {
+		const resolved = resolveToCwd(token, bashCwd ? resolveToCwd(bashCwd, cwd) : cwd);
+		if (!policy.isAllowed(resolved, "read")) return deny(policy, resolved, "read");
+	}
+
+	return ALLOW;
+}
+
+/**
+ * Decide whether a tool call is allowed under the policy. Tools with no recognized
+ * path argument are always allowed.
+ */
+export function evaluateToolCall(check: ToolCallCheck): ToolCallDecision {
+	const { toolName, input, cwd, policy } = check;
+	if (!policy.enabled) return ALLOW;
+
+	if (toolName === "bash") return evaluateBash(check);
+
+	if (toolName === "find") {
+		const base = globBase(typeof input.pattern === "string" ? input.pattern : "");
+		const candidates = [base, typeof input.path === "string" ? input.path : ""].filter(Boolean);
+		for (const candidate of candidates) {
+			const resolved = resolveToCwd(candidate, cwd);
+			if (!policy.isAllowed(resolved, "read")) return deny(policy, resolved, "read");
+		}
+		return ALLOW;
+	}
+
+	const spec = TOOL_PATHS[toolName];
+	if (!spec) return ALLOW;
+
+	const raw = firstString(input, spec.keys);
+	if (!raw) return ALLOW; // optional path → defaults to cwd, which is allowed
+
+	const resolved = resolveToCwd(raw, cwd);
+	if (!policy.isAllowed(resolved, spec.access)) return deny(policy, resolved, spec.access);
+	return ALLOW;
+}

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -45,7 +45,6 @@ interface PathArgSpec {
 const TOOL_PATHS: Record<string, PathArgSpec> = {
 	read: { keys: ["file_path", "path"], access: "read" },
 	write: { keys: ["file_path", "path"], access: "write" },
-	edit: { keys: ["file_path", "path"], access: "write" },
 	notebook: { keys: ["notebook_path"], access: "write" },
 };
 
@@ -167,6 +166,34 @@ function evaluateCodeTool(check: ToolCallCheck, fields: string[]): ToolCallDecis
 	return ALLOW;
 }
 
+/**
+ * The `edit` tool writes to one or more targets. Depending on mode it sends a top-level
+ * `file_path`/`path` and/or an `edits` array whose entries each carry their own `path`
+ * and (hashline) a `move` rename destination. Every one is a write target.
+ */
+function evaluateEdit(check: ToolCallCheck): ToolCallDecision {
+	const { input, cwd, policy } = check;
+	const targets: string[] = [];
+	const add = (value: unknown): void => {
+		if (typeof value === "string" && value.length > 0) targets.push(value);
+	};
+	add(input.file_path);
+	add(input.path);
+	if (Array.isArray(input.edits)) {
+		for (const entry of input.edits) {
+			if (entry && typeof entry === "object") {
+				add((entry as Record<string, unknown>).path);
+				add((entry as Record<string, unknown>).move);
+			}
+		}
+	}
+	for (const target of targets) {
+		const resolved = resolveToCwd(target, cwd);
+		if (!policy.isAllowed(resolved, "write")) return deny(policy, resolved, "write");
+	}
+	return ALLOW;
+}
+
 function evaluateSearchTool(check: ToolCallCheck, spec: SearchSpec): ToolCallDecision {
 	const { input, cwd, policy } = check;
 	const raw = typeof input[spec.key] === "string" ? (input[spec.key] as string) : "";
@@ -187,6 +214,8 @@ export function evaluateToolCall(check: ToolCallCheck): ToolCallDecision {
 
 	const codeFields = CODE_FIELDS[toolName];
 	if (codeFields) return evaluateCodeTool(check, codeFields);
+
+	if (toolName === "edit") return evaluateEdit(check);
 
 	const searchSpec = SEARCH_TOOLS[toolName];
 	if (searchSpec) return evaluateSearchTool(check, searchSpec);

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -6,13 +6,19 @@
  * free of settings/runtime so it is fully unit-testable; the bundled `sandbox-guard`
  * extension is a thin wrapper that supplies cwd, settings, and the policy.
  *
- * Bash handling is best-effort (Phase 1): the `cwd` parameter is checked precisely,
- * and the command string is scanned for `../` traversals that escape the tree. Reads
- * of absolute paths inside a Bash command are NOT caught here — that gap is closed by
- * the opt-in OS-level Bash sandbox (Phase 2).
+ * Search tools (`find`/`grep`/`ast_grep`/`ast_edit`) accept comma-/whitespace-delimited
+ * multi-path inputs that the tools split (via `splitTopLevel`) and search from a common
+ * base directory. We split the same way and policy-check EVERY token's base, so a
+ * multi-path input cannot smuggle a sibling directory past the gate.
+ *
+ * Arbitrary-code tools (`bash`, `python`) cannot be fully contained in-process: this
+ * checks the `cwd` argument precisely and scans the command/code for path tokens
+ * (bare, quoted, `~`, `..`, absolute) that escape the tree. OS system paths are exempt.
+ * This is best-effort; the opt-in OS-level sandbox (Phase 2) is the airtight enforcement
+ * for both bash and python.
  */
 import * as path from "node:path";
-import { resolveToCwd } from "../tools/path-utils";
+import { parseFindPattern, parseSearchPath, resolveToCwd, splitTopLevel } from "../tools/path-utils";
 import type { SandboxAccess, SandboxPolicy } from "./policy";
 
 export interface ToolCallCheck {
@@ -38,47 +44,38 @@ interface PathArgSpec {
 /** Tools that touch a single explicit path argument. */
 const TOOL_PATHS: Record<string, PathArgSpec> = {
 	read: { keys: ["file_path", "path"], access: "read" },
-	grep: { keys: ["path"], access: "read" },
-	ast_grep: { keys: ["path"], access: "read" },
 	write: { keys: ["file_path", "path"], access: "write" },
 	edit: { keys: ["file_path", "path"], access: "write" },
-	ast_edit: { keys: ["path"], access: "write" },
 	notebook: { keys: ["notebook_path"], access: "write" },
 };
 
-const GLOB_CHARS = ["*", "?", "[", "{"];
-
-function firstString(input: Record<string, unknown>, keys: string[]): string | undefined {
-	for (const key of keys) {
-		const value = input[key];
-		if (typeof value === "string" && value.length > 0) return value;
-	}
-	return undefined;
+interface SearchSpec {
+	/** Input key holding the (possibly multi-) path or glob list. */
+	key: string;
+	/** Extract the base directory of one token (matches the tool's own resolver). */
+	base: (token: string) => string;
+	access: SandboxAccess;
 }
 
-/** Derive the fixed directory prefix of a glob pattern (before the first glob char). */
-function globBase(pattern: string): string {
-	let cut = pattern.length;
-	for (const char of GLOB_CHARS) {
-		const idx = pattern.indexOf(char);
-		if (idx >= 0 && idx < cut) cut = idx;
-	}
-	const prefix = pattern.slice(0, cut);
-	const sep = Math.max(prefix.lastIndexOf("/"), prefix.lastIndexOf("\\"));
-	return sep >= 0 ? prefix.slice(0, sep) : "";
-}
+/** Tools that accept multi-path search inputs split from a common base directory. */
+const SEARCH_TOOLS: Record<string, SearchSpec> = {
+	find: { key: "pattern", base: token => parseFindPattern(token).basePath, access: "read" },
+	grep: { key: "path", base: token => parseSearchPath(token).basePath, access: "read" },
+	ast_grep: { key: "path", base: token => parseSearchPath(token).basePath, access: "read" },
+	ast_edit: { key: "path", base: token => parseSearchPath(token).basePath, access: "write" },
+};
 
-function deny(policy: SandboxPolicy, resolved: string, access: SandboxAccess): ToolCallDecision {
-	return { block: true, reason: policy.describe(resolved, access) };
-}
+/** Arbitrary-code tools whose command/code strings are scanned best-effort. */
+const CODE_FIELDS: Record<string, string[]> = {
+	bash: ["command"],
+	python: ["code"],
+};
 
 /**
- * Standard OS directories a Bash subprocess may legitimately read or traverse
- * (interpreters, libraries, device files) and which hold no customer data. The file
- * tools stay strictly confined to the policy; only Bash command scanning treats these
- * as benign, so commands like `cat /etc/os-release` or `/usr/bin/env node` are not
- * falsely blocked. Notably excludes /tmp, /var, /private, and home — those can hold
- * per-session or per-user data.
+ * Standard OS directories a subprocess may legitimately read or traverse (interpreters,
+ * libraries, device files) and which hold no customer data. Only the code-tool scan
+ * treats these as benign; the file tools stay strictly confined to the policy. Notably
+ * excludes /tmp, /var, /private, and home — those can hold per-session or per-user data.
  */
 const SYSTEM_READ_ROOTS = [
 	"/usr",
@@ -99,36 +96,84 @@ function isSystemPath(resolved: string): boolean {
 	return SYSTEM_READ_ROOTS.some(root => resolved === root || resolved.startsWith(`${root}${path.sep}`));
 }
 
-/** Unquoted, whitespace-delimited tokens that look like filesystem paths. */
-function pathLikeTokens(command: string): string[] {
-	return command
-		.split(/\s+/)
-		.map(tok => tok.replace(/^["']|["']$/g, ""))
-		.filter(tok => tok.length > 0)
-		.filter(tok => path.isAbsolute(tok) || tok.startsWith("~") || /(^|[/\\])\.\.([/\\]|$)/.test(tok));
+function firstString(input: Record<string, unknown>, keys: string[]): string | undefined {
+	for (const key of keys) {
+		const value = input[key];
+		if (typeof value === "string" && value.length > 0) return value;
+	}
+	return undefined;
 }
 
-function evaluateBash(check: ToolCallCheck): ToolCallDecision {
+function deny(policy: SandboxPolicy, resolved: string, access: SandboxAccess): ToolCallDecision {
+	return { block: true, reason: policy.describe(resolved, access) };
+}
+
+function looksLikePath(token: string): boolean {
+	return path.isAbsolute(token) || token.startsWith("~") || /(^|[/\\])\.\.([/\\]|$)/.test(token);
+}
+
+/** Path-like tokens in a command/code string: bare (whitespace-split) and quoted. */
+function codePathTokens(command: string): string[] {
+	const tokens = new Set<string>();
+	for (const raw of command.split(/\s+/)) tokens.add(raw.replace(/^["']|["']$/g, ""));
+	for (const match of command.matchAll(/["']([^"']+)["']/g)) tokens.add(match[1]);
+	return [...tokens].filter(token => token.length > 0 && looksLikePath(token));
+}
+
+/** Base directories a search input would actually search, split like the tools do. */
+function searchBases(raw: string, base: (token: string) => string): string[] {
+	const trimmed = raw.trim();
+	if (!trimmed) return [];
+	const tokens = new Set<string>();
+	// Union of comma and whitespace splits — over-splitting only adds harmless in-tree
+	// checks; it can never hide an out-of-tree token from the gate.
+	for (const separator of ["comma", "whitespace"] as const) {
+		for (const token of splitTopLevel(trimmed, separator)) {
+			const cleaned = token.trim();
+			if (cleaned) tokens.add(base(cleaned));
+		}
+	}
+	return [...tokens];
+}
+
+function evaluateCodeTool(check: ToolCallCheck, fields: string[]): ToolCallDecision {
 	const { input, cwd, policy } = check;
 
-	const bashCwd = typeof input.cwd === "string" ? input.cwd : undefined;
-	if (bashCwd) {
-		const resolved = resolveToCwd(bashCwd, cwd);
-		if (!policy.isAllowed(resolved, "read")) return deny(policy, resolved, "read");
-	}
+	const rawCwd = typeof input.cwd === "string" ? input.cwd : undefined;
+	const base = rawCwd ? resolveToCwd(rawCwd, cwd) : cwd;
+	if (rawCwd && !policy.isAllowed(base, "read")) return deny(policy, base, "read");
 
-	// Best-effort scan of the command for path tokens (absolute, `~`, or `..`) that
-	// escape the boundary. OS system paths are exempt; the opt-in OS-level Phase 2
-	// sandbox is the airtight enforcement for Bash.
-	const base = bashCwd ? resolveToCwd(bashCwd, cwd) : cwd;
-	const command = typeof input.command === "string" ? input.command : "";
-	for (const token of pathLikeTokens(command)) {
-		const resolved = resolveToCwd(token, base);
-		if (!policy.isAllowed(resolved, "read") && !isSystemPath(resolved)) {
-			return deny(policy, resolved, "read");
+	const commands: string[] = [];
+	for (const field of fields) {
+		if (typeof input[field] === "string") commands.push(input[field] as string);
+	}
+	// python also accepts a `cells` array of { code }.
+	if (Array.isArray(input.cells)) {
+		for (const cell of input.cells) {
+			const code = (cell as { code?: unknown })?.code;
+			if (typeof code === "string") commands.push(code);
 		}
 	}
 
+	for (const command of commands) {
+		for (const token of codePathTokens(command)) {
+			const resolved = resolveToCwd(token, base);
+			if (!policy.isAllowed(resolved, "read") && !isSystemPath(resolved)) {
+				return deny(policy, resolved, "read");
+			}
+		}
+	}
+
+	return ALLOW;
+}
+
+function evaluateSearchTool(check: ToolCallCheck, spec: SearchSpec): ToolCallDecision {
+	const { input, cwd, policy } = check;
+	const raw = typeof input[spec.key] === "string" ? (input[spec.key] as string) : "";
+	for (const basePath of searchBases(raw, spec.base)) {
+		const resolved = resolveToCwd(basePath, cwd);
+		if (!policy.isAllowed(resolved, spec.access)) return deny(policy, resolved, spec.access);
+	}
 	return ALLOW;
 }
 
@@ -140,17 +185,11 @@ export function evaluateToolCall(check: ToolCallCheck): ToolCallDecision {
 	const { toolName, input, cwd, policy } = check;
 	if (!policy.enabled) return ALLOW;
 
-	if (toolName === "bash") return evaluateBash(check);
+	const codeFields = CODE_FIELDS[toolName];
+	if (codeFields) return evaluateCodeTool(check, codeFields);
 
-	if (toolName === "find") {
-		const base = globBase(typeof input.pattern === "string" ? input.pattern : "");
-		const candidates = [base, typeof input.path === "string" ? input.path : ""].filter(Boolean);
-		for (const candidate of candidates) {
-			const resolved = resolveToCwd(candidate, cwd);
-			if (!policy.isAllowed(resolved, "read")) return deny(policy, resolved, "read");
-		}
-		return ALLOW;
-	}
+	const searchSpec = SEARCH_TOOLS[toolName];
+	if (searchSpec) return evaluateSearchTool(check, searchSpec);
 
 	const spec = TOOL_PATHS[toolName];
 	if (!spec) return ALLOW;

--- a/packages/coding-agent/src/sandbox/policy.ts
+++ b/packages/coding-agent/src/sandbox/policy.ts
@@ -12,7 +12,6 @@
  * The boundary only gates model-invoked tools. Internal subsystems (memory pipeline,
  * session manager, settings) do not go through the file tools, so they are unaffected.
  */
-import * as os from "node:os";
 import * as path from "node:path";
 import {
 	getAgentDir,
@@ -99,7 +98,7 @@ export interface DefaultSandboxOptions {
 	cwd: string;
 	/** Defaults to true — isolation is enforced by default. */
 	enabled?: boolean;
-	/** Session temp dir; defaults to os.tmpdir(). */
+	/** A session-specific temp dir to allow (read+write). NOT the shared OS temp dir. */
 	tmpDir?: string;
 	/** Extra roots (read+write) — e.g. from `--allow-path`. */
 	extraAllowRoots?: string[];
@@ -110,15 +109,20 @@ export interface DefaultSandboxOptions {
 }
 
 /**
- * Build the default session policy: confine reads/writes to the CWD subtree + session
- * temp, plus a curated global allowlist (plugin cache, user-level skills, operator
- * profile/settings) for reads. Cross-session leak surfaces under `~/.xcsh` and the
- * shared global tenant contexts are explicitly denied, so even a broad user-configured
- * allow cannot re-expose another customer's memory, session, or credentials.
+ * Build the default session policy: confine reads/writes to the CWD subtree, plus a
+ * curated global allowlist (plugin cache, user-level skills, operator profile/settings)
+ * for reads. Cross-session leak surfaces under `~/.xcsh` and the shared global tenant
+ * contexts are explicitly denied, so even a broad user-configured allow cannot re-expose
+ * another customer's memory, session, or credentials.
+ *
+ * Note: the OS temp dir is deliberately NOT allowlisted. It is shared across all
+ * sessions, so allowing it would let one customer's session read another's scratch
+ * files. The agent should work in temp directories under its CWD; internal tool temp
+ * usage bypasses this boundary (it is not a model-invoked path). A specific session
+ * temp dir can still be granted via `tmpDir`.
  */
 export function buildDefaultSandboxPolicy(opts: DefaultSandboxOptions): SandboxPolicy {
 	const cwd = path.resolve(opts.cwd);
-	const tmpDir = opts.tmpDir ?? os.tmpdir();
 	const configRoot = getConfigRootDir();
 	const skillsDir = path.join(getAgentDir(), "skills");
 
@@ -131,10 +135,12 @@ export function buildDefaultSandboxPolicy(opts: DefaultSandboxOptions): SandboxP
 	// precedence makes these win over any broader allow.
 	const leakDenies = [deny(getMemoriesDir()), deny(getSessionsDir()), deny(getXCSHContextsDir())];
 	const extraAllow = expand(opts.extraAllowRoots, true);
+	// Only allowed if a specific (non-shared) session temp dir is passed in.
+	const sessionTmp = opts.tmpDir ? [allow(opts.tmpDir)] : [];
 
 	const read: SandboxRule[] = [
 		allow(cwd),
-		allow(tmpDir),
+		...sessionTmp,
 		allow(getPluginsDir()), // plugin engines/schemas (e.g. meddpicc)
 		allow(skillsDir), // user-level skills
 		allow(path.join(configRoot, "user-profile.json")),
@@ -148,7 +154,7 @@ export function buildDefaultSandboxPolicy(opts: DefaultSandboxOptions): SandboxP
 
 	const write: SandboxRule[] = [
 		allow(cwd),
-		allow(tmpDir),
+		...sessionTmp,
 		...leakDenies,
 		...extraAllow,
 		...expand(opts.allowWrite, true),

--- a/packages/coding-agent/src/sandbox/policy.ts
+++ b/packages/coding-agent/src/sandbox/policy.ts
@@ -1,0 +1,159 @@
+/**
+ * SandboxPolicy — resolves whether a file path is inside the current session's
+ * read/write boundary.
+ *
+ * The model is longest-prefix-wins over an ordered set of allow/deny rules, with
+ * deny beating allow on an exact-depth tie (fail-safe). A path matched by no rule
+ * is denied (default-deny outside the working tree). This mirrors the deny-then-allow
+ * precedence used by Anthropic's sandbox-runtime, but is enforced in-process for the
+ * structured file tools (read/write/edit/find/grep) and the Bash `cwd`, rather than at
+ * the OS level.
+ *
+ * The boundary only gates model-invoked tools. Internal subsystems (memory pipeline,
+ * session manager, settings) do not go through the file tools, so they are unaffected.
+ */
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	getAgentDir,
+	getConfigRootDir,
+	getMemoriesDir,
+	getPluginsDir,
+	getSessionsDir,
+	getXCSHContextsDir,
+	normalizePathForComparison,
+	pathIsWithin,
+} from "@f5-sales-demo/pi-utils";
+import { expandPath } from "../tools/path-utils";
+
+export type SandboxAccess = "read" | "write";
+
+export interface SandboxRule {
+	/** Absolute directory or file this rule governs. */
+	root: string;
+	/** true = allow, false = deny. */
+	allow: boolean;
+}
+
+export interface SandboxPolicyConfig {
+	enabled: boolean;
+	/** Session working directory, used for messaging and as the primary allowed root. */
+	cwd: string;
+	read: SandboxRule[];
+	write: SandboxRule[];
+}
+
+interface NormalizedRule {
+	root: string;
+	depth: number;
+	allow: boolean;
+}
+
+function normalizeRule(rule: SandboxRule): NormalizedRule {
+	const normalized = normalizePathForComparison(rule.root);
+	return {
+		root: rule.root,
+		depth: normalized.split(path.sep).filter(Boolean).length,
+		allow: rule.allow,
+	};
+}
+
+export class SandboxPolicy {
+	readonly enabled: boolean;
+	readonly cwd: string;
+	readonly #read: NormalizedRule[];
+	readonly #write: NormalizedRule[];
+
+	constructor(config: SandboxPolicyConfig) {
+		this.enabled = config.enabled;
+		this.cwd = config.cwd;
+		this.#read = config.read.map(normalizeRule);
+		this.#write = config.write.map(normalizeRule);
+	}
+
+	/**
+	 * Whether `candidate` (an absolute, already-resolved path) may be accessed for
+	 * the given mode. Callers must resolve `~`/relative/`..` first (see resolveToCwd).
+	 */
+	isAllowed(candidate: string, access: SandboxAccess): boolean {
+		if (!this.enabled) return true;
+		const rules = access === "write" ? this.#write : this.#read;
+		let best: NormalizedRule | undefined;
+		for (const rule of rules) {
+			if (!pathIsWithin(rule.root, candidate)) continue;
+			const deeper = !best || rule.depth > best.depth;
+			const denyTie = best !== undefined && rule.depth === best.depth && best.allow && !rule.allow;
+			if (deeper || denyTie) best = rule;
+		}
+		return best?.allow ?? false;
+	}
+
+	/** Human-readable reason surfaced to the model when a path is blocked. */
+	describe(candidate: string, access: SandboxAccess): string {
+		return `Path is outside this session's ${access} boundary (working directory: ${this.cwd}): ${candidate}. Use --allow-path or the sandbox.allow* settings to widen it, or --no-sandbox to disable isolation.`;
+	}
+}
+
+export interface DefaultSandboxOptions {
+	/** Session working directory. */
+	cwd: string;
+	/** Defaults to true — isolation is enforced by default. */
+	enabled?: boolean;
+	/** Session temp dir; defaults to os.tmpdir(). */
+	tmpDir?: string;
+	/** Extra roots (read+write) — e.g. from `--allow-path`. */
+	extraAllowRoots?: string[];
+	allowRead?: string[];
+	allowWrite?: string[];
+	denyRead?: string[];
+	denyWrite?: string[];
+}
+
+/**
+ * Build the default session policy: confine reads/writes to the CWD subtree + session
+ * temp, plus a curated global allowlist (plugin cache, user-level skills, operator
+ * profile/settings) for reads. Cross-session leak surfaces under `~/.xcsh` and the
+ * shared global tenant contexts are explicitly denied, so even a broad user-configured
+ * allow cannot re-expose another customer's memory, session, or credentials.
+ */
+export function buildDefaultSandboxPolicy(opts: DefaultSandboxOptions): SandboxPolicy {
+	const cwd = path.resolve(opts.cwd);
+	const tmpDir = opts.tmpDir ?? os.tmpdir();
+	const configRoot = getConfigRootDir();
+	const skillsDir = path.join(getAgentDir(), "skills");
+
+	const allow = (root: string): SandboxRule => ({ root, allow: true });
+	const deny = (root: string): SandboxRule => ({ root, allow: false });
+	const expand = (roots: string[] | undefined, allowed: boolean): SandboxRule[] =>
+		(roots ?? []).map(r => ({ root: expandPath(r), allow: allowed }));
+
+	// Denied even though some sit under otherwise-allowlisted roots. Longest-prefix
+	// precedence makes these win over any broader allow.
+	const leakDenies = [deny(getMemoriesDir()), deny(getSessionsDir()), deny(getXCSHContextsDir())];
+	const extraAllow = expand(opts.extraAllowRoots, true);
+
+	const read: SandboxRule[] = [
+		allow(cwd),
+		allow(tmpDir),
+		allow(getPluginsDir()), // plugin engines/schemas (e.g. meddpicc)
+		allow(skillsDir), // user-level skills
+		allow(path.join(configRoot, "user-profile.json")),
+		allow(path.join(configRoot, "computer-profile.json")),
+		allow(path.join(configRoot, "settings.json")),
+		...leakDenies,
+		...extraAllow,
+		...expand(opts.allowRead, true),
+		...expand(opts.denyRead, false),
+	];
+
+	const write: SandboxRule[] = [
+		allow(cwd),
+		allow(tmpDir),
+		...leakDenies,
+		...extraAllow,
+		...expand(opts.allowWrite, true),
+		...expand(opts.denyWrite, false),
+	];
+
+	return new SandboxPolicy({ enabled: opts.enabled ?? true, cwd, read, write });
+}

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -244,9 +244,9 @@ export function combineSearchGlobs(prefixGlob?: string, suffixGlob?: string): st
 	return `${normalizedPrefix}/${normalizedSuffix}`;
 }
 
-type TopLevelSeparator = "comma" | "whitespace";
+export type TopLevelSeparator = "comma" | "whitespace";
 
-function splitTopLevel(value: string, separator: TopLevelSeparator): string[] {
+export function splitTopLevel(value: string, separator: TopLevelSeparator): string[] {
 	const parts: string[] = [];
 	let current = "";
 	let braceDepth = 0;

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -83,12 +83,12 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "/usr/bin/env node app.js" }).block).toBe(false);
 	});
 
-	it("gates the other filesystem tools (inspect_image, vim, puppeteer, catalog, debug)", () => {
+	it("gates the other filesystem tools (image/lsp/puppeteer/catalog/debug)", () => {
 		expect(check("inspect_image", { path: "/work/custB/pic.png" }).block).toBe(true);
 		expect(check("inspect_image", { path: "shot.png" }).block).toBe(false);
 		expect(check("display_image", { path: "../custB/pic.png" }).block).toBe(true);
-		expect(check("vim", { file: "/work/custB/notes.txt" }).block).toBe(true);
-		expect(check("vim", { file: "notes.txt" }).block).toBe(false);
+		expect(check("lsp", { file: "/work/custB/app.ts" }).block).toBe(true);
+		expect(check("lsp", { file: "app.ts" }).block).toBe(false);
 		expect(check("puppeteer", { action: "screenshot", path: "/work/custB/out.png" }).block).toBe(true);
 		expect(check("catalog_workflow_runner", { screenshot_dir: "/work/custB/shots" }).block).toBe(true);
 		expect(check("catalog_workflow_runner", { catalog_path: "../custB/catalog" }).block).toBe(true);
@@ -96,6 +96,18 @@ describe("evaluateToolCall", () => {
 		expect(check("debug", { program: "/usr/bin/lldb" }).block).toBe(false);
 		expect(check("debug", { program: "/work/custB/bin" }).block).toBe(true);
 		expect(check("debug", { cwd: "/work/custB" }).block).toBe(true);
+	});
+
+	it("gates generate_image input paths (read + external exfiltration vector)", () => {
+		expect(check("generate_image", { subject: "x", input: [{ path: "/work/custB/logo.png" }] }).block).toBe(true);
+		expect(check("generate_image", { subject: "x", input: [{ path: "logo.png" }] }).block).toBe(false);
+		expect(check("generate_image", { subject: "x", input: [{ data: "base64..." }] }).block).toBe(false);
+	});
+
+	it("gates the edit tool across modes (vim-mode top-level file, patch rename)", () => {
+		expect(check("edit", { file: "/work/custB/notes.txt" }).block).toBe(true); // vim mode
+		expect(check("edit", { file: "notes.txt" }).block).toBe(false);
+		expect(check("edit", { edits: [{ path: "a.ts", rename: "../custB/b.ts" }] }).block).toBe(true); // patch rename
 	});
 
 	it("ignores tools with no path argument (incl. remote xcsh_api/ssh paths)", () => {

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { evaluateToolCall } from "@f5-sales-demo/xcsh/sandbox/enforce";
+import { SandboxPolicy } from "@f5-sales-demo/xcsh/sandbox/policy";
+
+const CWD = "/work/custA";
+
+function makePolicy(enabled = true): SandboxPolicy {
+	return new SandboxPolicy({
+		enabled,
+		cwd: CWD,
+		read: [
+			{ root: CWD, allow: true },
+			{ root: "/opt/xcsh/plugins", allow: true }, // stand-in for plugin cache
+		],
+		write: [{ root: CWD, allow: true }],
+	});
+}
+
+function check(toolName: string, input: Record<string, unknown>, enabled = true) {
+	return evaluateToolCall({ toolName, input, cwd: CWD, policy: makePolicy(enabled) });
+}
+
+describe("evaluateToolCall", () => {
+	it("allows read of in-tree file, blocks out-of-tree", () => {
+		expect(check("read", { file_path: "notes.md" }).block).toBe(false);
+		expect(check("read", { file_path: "/work/custB/secret.json" }).block).toBe(true);
+		expect(check("read", { file_path: "../custB/secret.json" }).block).toBe(true);
+	});
+
+	it("gates write-family tools (write, edit, notebook, ast_edit) for writes", () => {
+		for (const tool of ["write", "edit"]) {
+			expect(check(tool, { file_path: "out.ts" }).block).toBe(false);
+			expect(check(tool, { file_path: "/etc/hosts" }).block).toBe(true);
+		}
+		expect(check("notebook", { notebook_path: "nb.ipynb" }).block).toBe(false);
+		expect(check("notebook", { notebook_path: "/work/custB/nb.ipynb" }).block).toBe(true);
+		expect(check("ast_edit", { path: "/work/custB" }).block).toBe(true);
+	});
+
+	it("treats plugin cache as readable (meddpicc engine) but not writable", () => {
+		expect(check("read", { file_path: "/opt/xcsh/plugins/meddpicc/cli.ts" }).block).toBe(false);
+		expect(check("write", { file_path: "/opt/xcsh/plugins/x" }).block).toBe(true);
+	});
+
+	it("search tools: absent path defaults to cwd (allowed); explicit out-of-tree blocked", () => {
+		expect(check("grep", { pattern: "TODO" }).block).toBe(false);
+		expect(check("grep", { pattern: "TODO", path: "/work/custB" }).block).toBe(true);
+		expect(check("ast_grep", { path: "/etc" }).block).toBe(true);
+	});
+
+	it("find: pattern base escaping the tree is blocked; in-tree glob allowed", () => {
+		expect(check("find", { pattern: "**/*.ts" }).block).toBe(false);
+		expect(check("find", { pattern: "src/**/*.ts" }).block).toBe(false);
+		expect(check("find", { pattern: "../custB/**/*.json" }).block).toBe(true);
+		expect(check("find", { pattern: "/work/custB/**" }).block).toBe(true);
+	});
+
+	it("bash: rejects a cwd outside the boundary", () => {
+		expect(check("bash", { command: "ls", cwd: "/work/custB" }).block).toBe(true);
+		expect(check("bash", { command: "ls", cwd: "sub/dir" }).block).toBe(false);
+		expect(check("bash", { command: "ls" }).block).toBe(false);
+	});
+
+	it("bash: best-effort blocks ../ traversal escaping the tree (Phase 1)", () => {
+		expect(check("bash", { command: "cat ../custB/secrets.env" }).block).toBe(true);
+		expect(check("bash", { command: "cat ./sub/../notes.md" }).block).toBe(false); // stays in-tree
+		expect(check("bash", { command: "grep -r TODO ." }).block).toBe(false);
+	});
+
+	it("ignores tools with no path argument", () => {
+		expect(check("calc", { expression: "1+1" }).block).toBe(false);
+		expect(check("todo_write", { todos: [] }).block).toBe(false);
+	});
+
+	it("is a no-op when the policy is disabled", () => {
+		expect(check("read", { file_path: "/etc/passwd" }, false).block).toBe(false);
+		expect(check("bash", { command: "cat ../custB/x" }, false).block).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -90,6 +90,11 @@ describe("evaluateToolCall", () => {
 		expect(check("lsp", { file: "/work/custB/app.ts" }).block).toBe(true);
 		expect(check("lsp", { file: "app.ts" }).block).toBe(false);
 		expect(check("puppeteer", { action: "screenshot", path: "/work/custB/out.png" }).block).toBe(true);
+		// goto navigation to a local-file target in a sibling is a read escape; remote URLs are fine.
+		expect(check("puppeteer", { action: "goto", url: "file:///work/custB/secret.html" }).block).toBe(true);
+		expect(check("puppeteer", { action: "goto", url: "../custB/secret.html" }).block).toBe(true);
+		expect(check("puppeteer", { action: "goto", url: "https://example.com" }).block).toBe(false);
+		expect(check("puppeteer", { action: "goto", url: "file:///work/custA/page.html" }).block).toBe(false);
 		expect(check("catalog_workflow_runner", { screenshot_dir: "/work/custB/shots" }).block).toBe(true);
 		expect(check("catalog_workflow_runner", { catalog_path: "../custB/catalog" }).block).toBe(true);
 		// debug executes arbitrary programs: a system binary is fine, a sibling is not.

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -83,9 +83,26 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "/usr/bin/env node app.js" }).block).toBe(false);
 	});
 
-	it("ignores tools with no path argument", () => {
+	it("gates the other filesystem tools (inspect_image, vim, puppeteer, catalog, debug)", () => {
+		expect(check("inspect_image", { path: "/work/custB/pic.png" }).block).toBe(true);
+		expect(check("inspect_image", { path: "shot.png" }).block).toBe(false);
+		expect(check("display_image", { path: "../custB/pic.png" }).block).toBe(true);
+		expect(check("vim", { file: "/work/custB/notes.txt" }).block).toBe(true);
+		expect(check("vim", { file: "notes.txt" }).block).toBe(false);
+		expect(check("puppeteer", { action: "screenshot", path: "/work/custB/out.png" }).block).toBe(true);
+		expect(check("catalog_workflow_runner", { screenshot_dir: "/work/custB/shots" }).block).toBe(true);
+		expect(check("catalog_workflow_runner", { catalog_path: "../custB/catalog" }).block).toBe(true);
+		// debug executes arbitrary programs: a system binary is fine, a sibling is not.
+		expect(check("debug", { program: "/usr/bin/lldb" }).block).toBe(false);
+		expect(check("debug", { program: "/work/custB/bin" }).block).toBe(true);
+		expect(check("debug", { cwd: "/work/custB" }).block).toBe(true);
+	});
+
+	it("ignores tools with no path argument (incl. remote xcsh_api/ssh paths)", () => {
 		expect(check("calc", { expression: "1+1" }).block).toBe(false);
 		expect(check("todo_write", { todos: [] }).block).toBe(false);
+		expect(check("xcsh_api", { path: "/api/web/namespaces/x" }).block).toBe(false);
+		expect(check("ssh", { host: "h", command: "ls", cwd: "/remote/dir" }).block).toBe(false);
 	});
 
 	it("is a no-op when the policy is disabled", () => {

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -67,6 +67,13 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "grep -r TODO ." }).block).toBe(false);
 	});
 
+	it("bash: blocks absolute-path escapes, exempts OS system paths", () => {
+		expect(check("bash", { command: "cat /work/custB/secrets.env" }).block).toBe(true);
+		expect(check("bash", { command: "cat ~/.ssh/id_rsa" }).block).toBe(true);
+		expect(check("bash", { command: "cat /etc/os-release" }).block).toBe(false);
+		expect(check("bash", { command: "/usr/bin/env node app.js" }).block).toBe(false);
+	});
+
 	it("ignores tools with no path argument", () => {
 		expect(check("calc", { expression: "1+1" }).block).toBe(false);
 		expect(check("todo_write", { todos: [] }).block).toBe(false);

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -83,4 +83,24 @@ describe("evaluateToolCall", () => {
 		expect(check("read", { file_path: "/etc/passwd" }, false).block).toBe(false);
 		expect(check("bash", { command: "cat ../custB/x" }, false).block).toBe(false);
 	});
+
+	it("blocks multi-path search inputs that smuggle a sibling via the common base", () => {
+		// The tools split on top-level comma/whitespace and search the common base.
+		expect(check("grep", { pattern: "TOKEN", path: ".,../custB" }).block).toBe(true);
+		expect(check("find", { pattern: "*.md,../custB" }).block).toBe(true);
+		expect(check("ast_grep", { path: ".,/work/custB" }).block).toBe(true);
+		expect(check("ast_edit", { path: ".,../custB" }).block).toBe(true); // cross-session write
+	});
+
+	it("allows legitimate multi-path search inputs that stay in-tree", () => {
+		expect(check("grep", { pattern: "TOKEN", path: "src,lib" }).block).toBe(false);
+		expect(check("find", { pattern: "src/**/*.ts,lib/**/*.ts" }).block).toBe(false);
+	});
+
+	it("gates the python tool like bash (cwd + code scan)", () => {
+		expect(check("python", { code: "open('/work/custB/secret')" }).block).toBe(true);
+		expect(check("python", { code: "x=1", cwd: "/work/custB" }).block).toBe(true);
+		expect(check("python", { code: "open('notes.md')" }).block).toBe(false);
+		expect(check("python", { cells: [{ code: "open('../custB/x')" }] }).block).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -27,14 +27,23 @@ describe("evaluateToolCall", () => {
 		expect(check("read", { file_path: "../custB/secret.json" }).block).toBe(true);
 	});
 
-	it("gates write-family tools (write, edit, notebook, ast_edit) for writes", () => {
-		for (const tool of ["write", "edit"]) {
-			expect(check(tool, { file_path: "out.ts" }).block).toBe(false);
-			expect(check(tool, { file_path: "/etc/hosts" }).block).toBe(true);
-		}
+	it("gates write-family tools (write, notebook, ast_edit) for writes", () => {
+		expect(check("write", { file_path: "out.ts" }).block).toBe(false);
+		expect(check("write", { file_path: "/etc/hosts" }).block).toBe(true);
 		expect(check("notebook", { notebook_path: "nb.ipynb" }).block).toBe(false);
 		expect(check("notebook", { notebook_path: "/work/custB/nb.ipynb" }).block).toBe(true);
 		expect(check("ast_edit", { path: "/work/custB" }).block).toBe(true);
+	});
+
+	it("gates the edit tool's per-entry paths and move destinations (default edits[] shape)", () => {
+		// Default hashline/chunk/replace modes send an edits[] array, not top-level file_path.
+		expect(check("edit", { edits: [{ path: "notes.md", old_text: "a", new_text: "b" }] }).block).toBe(false);
+		expect(check("edit", { edits: [{ path: "/work/custB/x.ts", old_text: "a", new_text: "b" }] }).block).toBe(true);
+		expect(check("edit", { edits: [{ path: "../custB/x.ts" }] }).block).toBe(true);
+		// A move/rename destination outside the tree is a write escape.
+		expect(check("edit", { edits: [{ path: "notes.md", move: "../custB/evil.ts" }] }).block).toBe(true);
+		// Legacy top-level path is still covered.
+		expect(check("edit", { file_path: "/etc/hosts" }).block).toBe(true);
 	});
 
 	it("treats plugin cache as readable (meddpicc engine) but not writable", () => {

--- a/packages/coding-agent/test/sandbox-guard.test.ts
+++ b/packages/coding-agent/test/sandbox-guard.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { _resetSettingsForTest, Settings } from "@f5-sales-demo/xcsh/config/settings";
+import sandboxGuard from "@f5-sales-demo/xcsh/extensibility/extensions/bundled/sandbox-guard";
+
+const CWD = "/work/custA";
+
+interface ToolCallEvent {
+	type: "tool_call";
+	toolName: string;
+	toolCallId: string;
+	input: Record<string, unknown>;
+}
+type Handler = (event: ToolCallEvent, ctx: { cwd: string }) => unknown;
+
+/** Invoke the factory with a stub `pi` and capture its tool_call handler. */
+function captureHandler(): Handler | undefined {
+	let handler: Handler | undefined;
+	const pi = {
+		on(event: string, h: Handler) {
+			if (event === "tool_call") handler = h;
+		},
+	};
+	sandboxGuard(pi as unknown as Parameters<typeof sandboxGuard>[0]);
+	return handler;
+}
+
+async function initSandbox(enabled: boolean): Promise<void> {
+	_resetSettingsForTest();
+	await Settings.init({ inMemory: true, cwd: CWD, overrides: { "sandbox.enabled": enabled } });
+}
+
+function call(handler: Handler, toolName: string, input: Record<string, unknown>): unknown {
+	return handler({ type: "tool_call", toolName, toolCallId: "1", input }, { cwd: CWD });
+}
+
+describe("sandbox-guard bundled extension", () => {
+	afterEach(() => _resetSettingsForTest());
+
+	it("registers a tool_call handler", () => {
+		expect(typeof captureHandler()).toBe("function");
+	});
+
+	it("blocks an out-of-tree read when enabled", async () => {
+		await initSandbox(true);
+		const handler = captureHandler()!;
+		expect(await call(handler, "read", { file_path: "/work/custB/secret" })).toMatchObject({ block: true });
+	});
+
+	it("allows an in-tree read when enabled", async () => {
+		await initSandbox(true);
+		const handler = captureHandler()!;
+		expect(await call(handler, "read", { file_path: "notes.md" })).toBeUndefined();
+	});
+
+	it("is a no-op when sandbox.enabled is false (--no-sandbox)", async () => {
+		await initSandbox(false);
+		const handler = captureHandler()!;
+		expect(await call(handler, "read", { file_path: "/work/custB/secret" })).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getAgentDir, getPluginsDir, TempDir } from "@f5-sales-demo/pi-utils";
+import { discoverAndLoadExtensions } from "@f5-sales-demo/xcsh/extensibility/extensions/loader";
+import { getMemoryRoot } from "@f5-sales-demo/xcsh/memories";
+import { evaluateToolCall } from "@f5-sales-demo/xcsh/sandbox/enforce";
+import { buildDefaultSandboxPolicy } from "@f5-sales-demo/xcsh/sandbox/policy";
+
+let tmp: TempDir;
+let parent: string;
+let custA: string;
+let custB: string;
+
+beforeAll(() => {
+	tmp = TempDir.createSync("xcsh-sbx-iso-");
+	parent = tmp.absolute();
+	custA = path.join(parent, "custA");
+	custB = path.join(parent, "custB");
+	fs.mkdirSync(custA, { recursive: true });
+	fs.mkdirSync(custB, { recursive: true });
+	fs.writeFileSync(path.join(custA, "notes.md"), "a");
+	fs.writeFileSync(path.join(custB, "secret.env"), "TOKEN=b");
+});
+
+afterAll(() => tmp.removeSync());
+
+function reads(cwd: string, filePath: string): boolean {
+	const policy = buildDefaultSandboxPolicy({ cwd });
+	return evaluateToolCall({ toolName: "read", input: { file_path: filePath }, cwd, policy }).block;
+}
+
+describe("two-customer isolation", () => {
+	it("a session in custA cannot read custB, but can read its own files", () => {
+		expect(reads(custA, path.join(custB, "secret.env"))).toBe(true);
+		expect(reads(custA, path.join(custA, "notes.md"))).toBe(false);
+	});
+
+	it("a parent-folder session sees both customer subfolders (automatic)", () => {
+		expect(reads(parent, path.join(custA, "notes.md"))).toBe(false);
+		expect(reads(parent, path.join(custB, "secret.env"))).toBe(false);
+	});
+
+	it("blocks a Bash `../` traversal from custA into custB", () => {
+		const policy = buildDefaultSandboxPolicy({ cwd: custA });
+		const decision = evaluateToolCall({
+			toolName: "bash",
+			input: { command: "cat ../custB/secret.env" },
+			cwd: custA,
+			policy,
+		});
+		expect(decision.block).toBe(true);
+	});
+});
+
+describe("functionality preservation under the sandbox", () => {
+	it("keeps the plugin cache readable (e.g. the meddpicc engine)", () => {
+		expect(reads(custA, path.join(getPluginsDir(), "cache", "plugins", "meddpicc", "engine", "cli.ts"))).toBe(false);
+	});
+
+	it("keeps user-level skills readable", () => {
+		expect(reads(custA, path.join(getAgentDir(), "skills", "account-planning", "SKILL.md"))).toBe(false);
+	});
+
+	it("still blocks unrelated home dotfiles (e.g. ~/.ssh)", () => {
+		expect(reads(custA, path.join(os.homedir(), ".ssh", "id_rsa"))).toBe(true);
+	});
+});
+
+describe("memory isolation (belt-and-suspenders)", () => {
+	it("partitions the memory store per working directory", () => {
+		expect(getMemoryRoot(getAgentDir(), custA)).not.toBe(getMemoryRoot(getAgentDir(), custB));
+	});
+
+	it("does not expose any session's raw memory store to the file tools", () => {
+		// The memory pipeline is an internal subsystem that bypasses the file-tool
+		// boundary; the model-invoked tools cannot read the raw store for any cwd.
+		expect(reads(custA, path.join(getMemoryRoot(getAgentDir(), custB), "MEMORY.md"))).toBe(true);
+		expect(reads(custA, path.join(getMemoryRoot(getAgentDir(), custA), "MEMORY.md"))).toBe(true);
+	});
+});
+
+describe("bundled registration", () => {
+	it("loads the sandbox-guard extension by default", async () => {
+		const result = await discoverAndLoadExtensions([], custA);
+		expect(result.extensions.some(ext => ext.path === "bundled:sandbox-guard")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -42,15 +42,22 @@ describe("two-customer isolation", () => {
 		expect(reads(parent, path.join(custB, "secret.env"))).toBe(false);
 	});
 
-	it("blocks a Bash `../` traversal from custA into custB", () => {
+	it("blocks Bash reads of custB from custA (relative and absolute)", () => {
 		const policy = buildDefaultSandboxPolicy({ cwd: custA });
-		const decision = evaluateToolCall({
+		const relative = evaluateToolCall({
 			toolName: "bash",
 			input: { command: "cat ../custB/secret.env" },
 			cwd: custA,
 			policy,
 		});
-		expect(decision.block).toBe(true);
+		const absolute = evaluateToolCall({
+			toolName: "bash",
+			input: { command: `cat ${path.join(custB, "secret.env")}` },
+			cwd: custA,
+			policy,
+		});
+		expect(relative.block).toBe(true);
+		expect(absolute.block).toBe(true);
 	});
 });
 

--- a/packages/coding-agent/test/sandbox-policy.test.ts
+++ b/packages/coding-agent/test/sandbox-policy.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	getMemoriesDir,
+	getPluginsDir,
+	getSessionsDir,
+	getXCSHContextsDir,
+	setAgentDir,
+} from "@f5-sales-demo/pi-utils";
+import { buildDefaultSandboxPolicy, SandboxPolicy } from "@f5-sales-demo/xcsh/sandbox/policy";
+
+/**
+ * Build a hermetic policy from explicit rule roots — no filesystem, no globals.
+ * Rule roots are matched with longest-prefix-wins; deny beats allow on a tie.
+ */
+function policy(read: Array<[string, boolean]>, write: Array<[string, boolean]>, enabled = true): SandboxPolicy {
+	return new SandboxPolicy({
+		enabled,
+		cwd: "/work/custA",
+		read: read.map(([root, allow]) => ({ root, allow })),
+		write: write.map(([root, allow]) => ({ root, allow })),
+	});
+}
+
+describe("SandboxPolicy (pure)", () => {
+	it("allows everything when disabled", () => {
+		const p = policy([["/work/custA", true]], [["/work/custA", true]], false);
+		expect(p.isAllowed("/etc/passwd", "read")).toBe(true);
+		expect(p.isAllowed("/anywhere/else", "write")).toBe(true);
+	});
+
+	it("allows paths inside the cwd subtree (including nested)", () => {
+		const p = policy([["/work/custA", true]], [["/work/custA", true]]);
+		expect(p.isAllowed("/work/custA", "read")).toBe(true);
+		expect(p.isAllowed("/work/custA/notes.md", "read")).toBe(true);
+		expect(p.isAllowed("/work/custA/deep/nested/file.txt", "write")).toBe(true);
+	});
+
+	it("blocks sibling customer folders", () => {
+		const p = policy([["/work/custA", true]], [["/work/custA", true]]);
+		expect(p.isAllowed("/work/custB/secrets.json", "read")).toBe(false);
+		expect(p.isAllowed("/work/custB/secrets.json", "write")).toBe(false);
+	});
+
+	it("blocks parent and absolute escapes", () => {
+		const p = policy([["/work/custA", true]], [["/work/custA", true]]);
+		expect(p.isAllowed("/work", "read")).toBe(false);
+		expect(p.isAllowed("/etc/passwd", "read")).toBe(false);
+		expect(p.isAllowed("/work/custA/../custB/x", "read")).toBe(false); // resolves outside
+	});
+
+	it("parent-folder session sees all customer subfolders (automatic)", () => {
+		const parent = new SandboxPolicy({
+			enabled: true,
+			cwd: "/work",
+			read: [{ root: "/work", allow: true }],
+			write: [{ root: "/work", allow: true }],
+		});
+		expect(parent.isAllowed("/work/custA/x", "read")).toBe(true);
+		expect(parent.isAllowed("/work/custB/x", "read")).toBe(true);
+	});
+
+	it("longest-prefix wins: deny a subdir inside a broadly-allowed root", () => {
+		const p = policy(
+			[
+				["/home/u/.xcsh", true], // broad allow (e.g. a misconfigured widening)
+				["/home/u/.xcsh/agent/memories", false], // deeper deny
+			],
+			[["/work/custA", true]],
+		);
+		expect(p.isAllowed("/home/u/.xcsh/plugins/x", "read")).toBe(true);
+		expect(p.isAllowed("/home/u/.xcsh/agent/memories/other/MEMORY.md", "read")).toBe(false);
+	});
+
+	it("deny wins on an exact-depth tie", () => {
+		const p = policy(
+			[
+				["/x/y", true],
+				["/x/y", false],
+			],
+			[["/work/custA", true]],
+		);
+		expect(p.isAllowed("/x/y/f", "read")).toBe(false);
+	});
+
+	it("default-denies paths matched by no rule", () => {
+		const p = policy([["/work/custA", true]], [["/work/custA", true]]);
+		expect(p.isAllowed("/opt/tool/data", "read")).toBe(false);
+	});
+});
+
+describe("buildDefaultSandboxPolicy (wired to dirs)", () => {
+	const savedAgentDir = process.env.PI_CODING_AGENT_DIR;
+	let agentDir: string;
+
+	beforeEach(() => {
+		agentDir = path.join(os.tmpdir(), `xcsh-sbx-${process.pid}-${Math.floor(performance.now())}`, "agent");
+		setAgentDir(agentDir);
+	});
+
+	afterEach(() => {
+		if (savedAgentDir) setAgentDir(savedAgentDir);
+	});
+
+	it("allows the cwd subtree and the plugin cache for reads", () => {
+		const cwd = "/work/custA";
+		const p = buildDefaultSandboxPolicy({ cwd });
+		expect(p.isAllowed(path.join(cwd, "file.md"), "read")).toBe(true);
+		expect(p.isAllowed(path.join(getPluginsDir(), "cache/plugins/meddpicc/engine/cli.ts"), "read")).toBe(true);
+	});
+
+	it("denies other sessions' memories, sessions, and global tenant contexts", () => {
+		const p = buildDefaultSandboxPolicy({ cwd: "/work/custA" });
+		expect(p.isAllowed(path.join(getMemoriesDir(), "--work-custB--", "MEMORY.md"), "read")).toBe(false);
+		expect(p.isAllowed(path.join(getSessionsDir(), "-other", "s.jsonl"), "read")).toBe(false);
+		expect(p.isAllowed(path.join(getXCSHContextsDir(), "acme.json"), "read")).toBe(false);
+	});
+
+	it("confines writes to the cwd subtree (plugin cache is read-only)", () => {
+		const cwd = "/work/custA";
+		const p = buildDefaultSandboxPolicy({ cwd });
+		expect(p.isAllowed(path.join(cwd, "out.txt"), "write")).toBe(true);
+		expect(p.isAllowed(path.join(getPluginsDir(), "x"), "write")).toBe(false);
+	});
+
+	it("honors extraAllowRoots (--allow-path) for cross-customer parent tasks", () => {
+		const p = buildDefaultSandboxPolicy({ cwd: "/work/custA", extraAllowRoots: ["/shared/ref"] });
+		expect(p.isAllowed("/shared/ref/data.csv", "read")).toBe(true);
+		expect(p.isAllowed("/shared/ref/data.csv", "write")).toBe(true);
+	});
+
+	it("honors configured denyRead overriding an allow within the cwd", () => {
+		const cwd = "/work/custA";
+		const p = buildDefaultSandboxPolicy({ cwd, denyRead: [path.join(cwd, "vault")] });
+		expect(p.isAllowed(path.join(cwd, "ok.md"), "read")).toBe(true);
+		expect(p.isAllowed(path.join(cwd, "vault", "key.pem"), "read")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Adds **default-on session filesystem isolation** so concurrent xcsh sessions — each bound to a customer directory holding sensitive env vars, tokens, and PII — can no longer read or write each other's files, secrets, or memory. Previously nothing confined the file tools to the working directory (`resolveToCwd()` passed absolute paths and `../` through unchecked).

Closes #2200.

## Design (layered, mirrors Anthropic's model, tuned for xcsh)

- **`SandboxPolicy`** (`src/sandbox/policy.ts`) — longest-prefix-wins allow/deny (deny beats allow on ties; default-deny outside the tree). Allowed roots = the session **CWD subtree** + session temp + a curated global allowlist (plugin cache incl. meddpicc engine, user-level skills, operator profile/settings). Cross-session leak surfaces are **denied even under broader allows**: other cwds' `~/.xcsh/agent/memories|sessions` and the shared `~/.config/xcsh/contexts`.
- **`evaluateToolCall`** (`src/sandbox/enforce.ts`) — pure mapping of `read`/`write`/`edit`/`find`/`grep` path args + Bash `cwd`/`../`-traversal to policy checks. Fully unit-tested.
- **`sandbox-guard`** — bundled, default-on `tool_call` gate reading `ctx.cwd` + `sandbox.*` settings; blocks out-of-bounds calls and fails safe (a throwing handler blocks).
- **Config** — `sandbox.*` settings + a **Sandbox** `/settings` tab; `--no-sandbox` and `--allow-path <dir>` CLI opt-outs (mirroring `--allow-home`).

**Parent/child semantics (automatic):** a parent-folder session sees all customer subfolders; a session opened inside one customer folder sees only itself. No markers — it falls out of the CWD-subtree rule.

## Why filesystem-only (no OS/network sandbox in Phase 1)

Full OS sandboxing would break xcsh's Unix-socket IPC (`manager.sock`, `chrome-bridge.sock`), browser automation (`open`/Apple Events), and F5 XC API/network calls. The in-process file-tool gate delivers the read/write isolation between customers with minimal friction. The OS-level, **filesystem-only** Bash sandbox (`@anthropic-ai/sandbox-runtime`) is deferred to **Phase 2 (opt-in)** — `sandbox.bashOsSandbox.enabled` is reserved for it.

## Verification

- **34 sandbox unit/integration tests** across policy, enforcement, the bundled guard (via the real factory + global settings), and a two-customer fixture (custA blocked from custB; parent sees both). Memory partitioning and functionality-preservation (plugin cache, user skills readable; `~/.ssh` blocked) asserted.
- Real-loader regression test asserts `sandbox-guard` loads by default.
- `bun run check:types` (tsgo) clean; biome clean; CLI `--help` renders the new flags.

## Follow-up (Phase 2, separate issue)

OS-level filesystem-only Bash sandbox with `excludedCommands` and graceful fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
