### PR TITLE
refactor(sandbox): drop unused sandbox.denyRead/denyWrite settings

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -150,10 +150,9 @@ export interface ModelTagsSettings {
 	[key: string]: ModelTagDef;
 }
 
-// Typed defaults for array/record settings — named constants avoid `as` casts
-// under `as const` while still letting SettingValue infer the correct element type.
+// Typed defaults for array settings — named constants avoid `as` casts under
+// `as const` while still letting SettingValue infer the correct element type.
 const EMPTY_STRING_ARRAY: string[] = [];
-const EMPTY_STRING_RECORD: Record<string, string> = {};
 const DEFAULT_CYCLE_ORDER: string[] = ["smol", "default", "slow"];
 /**
  * Binary-baked default model role. Ships in the binary so a fresh install needs

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1807,11 +1807,10 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 	// Extra roots (beyond the CWD subtree) the session may read/write. Config/CLI only —
-	// e.g. `--allow-path <dir>` maps into both. Deny rules always win over allow.
+	// e.g. `--allow-path <dir>` maps into both. The hardcoded cross-session leak-denies
+	// (other sessions' memories/sessions and the shared tenant contexts) always win.
 	"sandbox.allowRead": { type: "array", default: [] as string[] },
 	"sandbox.allowWrite": { type: "array", default: [] as string[] },
-	"sandbox.denyRead": { type: "array", default: [] as string[] },
-	"sandbox.denyWrite": { type: "array", default: [] as string[] },
 
 	// Provider selection
 	"providers.webSearch": {

--- a/packages/coding-agent/src/extensibility/extensions/bundled/sandbox-guard.ts
+++ b/packages/coding-agent/src/extensibility/extensions/bundled/sandbox-guard.ts
@@ -42,8 +42,6 @@ export default function sandboxGuard(pi: ExtensionAPI): void {
 			enabled: true,
 			allowRead: readSetting<string[]>("sandbox.allowRead", []),
 			allowWrite: readSetting<string[]>("sandbox.allowWrite", []),
-			denyRead: readSetting<string[]>("sandbox.denyRead", []),
-			denyWrite: readSetting<string[]>("sandbox.denyWrite", []),
 		});
 		cache = { cwd, policy };
 		return policy;

--- a/packages/coding-agent/src/sandbox/policy.ts
+++ b/packages/coding-agent/src/sandbox/policy.ts
@@ -104,8 +104,6 @@ export interface DefaultSandboxOptions {
 	extraAllowRoots?: string[];
 	allowRead?: string[];
 	allowWrite?: string[];
-	denyRead?: string[];
-	denyWrite?: string[];
 }
 
 /**
@@ -149,7 +147,6 @@ export function buildDefaultSandboxPolicy(opts: DefaultSandboxOptions): SandboxP
 		...leakDenies,
 		...extraAllow,
 		...expand(opts.allowRead, true),
-		...expand(opts.denyRead, false),
 	];
 
 	const write: SandboxRule[] = [
@@ -158,7 +155,6 @@ export function buildDefaultSandboxPolicy(opts: DefaultSandboxOptions): SandboxP
 		...leakDenies,
 		...extraAllow,
 		...expand(opts.allowWrite, true),
-		...expand(opts.denyWrite, false),
 	];
 
 	return new SandboxPolicy({ enabled: opts.enabled ?? true, cwd, read, write });

--- a/packages/coding-agent/test/sandbox-policy.test.ts
+++ b/packages/coding-agent/test/sandbox-policy.test.ts
@@ -129,4 +129,22 @@ describe("buildDefaultSandboxPolicy (wired to dirs)", () => {
 		expect(p.isAllowed("/shared/ref/data.csv", "read")).toBe(true);
 		expect(p.isAllowed("/shared/ref/data.csv", "write")).toBe(true);
 	});
+
+	// Regression: removing the user-configurable deny* lists must not let a user
+	// allow (allowRead/allowWrite, e.g. --allow-path) re-expose the hardcoded
+	// cross-session leak-denies. The leak-deny and the user allow land at the same
+	// path depth, and deny wins the tie — so the memory/session/context dirs stay
+	// sealed even when a broad allow names them directly.
+	it("leak-denies beat a user allow at the same path (no bypass without deny*)", () => {
+		const p = buildDefaultSandboxPolicy({
+			cwd: "/work/custA",
+			allowRead: [getMemoriesDir(), getSessionsDir(), getXCSHContextsDir()],
+			allowWrite: [getMemoriesDir()],
+			extraAllowRoots: [getSessionsDir()],
+		});
+		expect(p.isAllowed(path.join(getMemoriesDir(), "--work-custB--", "MEMORY.md"), "read")).toBe(false);
+		expect(p.isAllowed(path.join(getSessionsDir(), "-other", "s.jsonl"), "read")).toBe(false);
+		expect(p.isAllowed(path.join(getXCSHContextsDir(), "acme.json"), "read")).toBe(false);
+		expect(p.isAllowed(path.join(getMemoriesDir(), "--work-custB--", "MEMORY.md"), "write")).toBe(false);
+	});
 });

--- a/packages/coding-agent/test/sandbox-policy.test.ts
+++ b/packages/coding-agent/test/sandbox-policy.test.ts
@@ -129,11 +129,4 @@ describe("buildDefaultSandboxPolicy (wired to dirs)", () => {
 		expect(p.isAllowed("/shared/ref/data.csv", "read")).toBe(true);
 		expect(p.isAllowed("/shared/ref/data.csv", "write")).toBe(true);
 	});
-
-	it("honors configured denyRead overriding an allow within the cwd", () => {
-		const cwd = "/work/custA";
-		const p = buildDefaultSandboxPolicy({ cwd, denyRead: [path.join(cwd, "vault")] });
-		expect(p.isAllowed(path.join(cwd, "ok.md"), "read")).toBe(true);
-		expect(p.isAllowed(path.join(cwd, "vault", "key.pem"), "read")).toBe(false);
-	});
 });


### PR DESCRIPTION
## What

Removes the user-facing `sandbox.denyRead` / `sandbox.denyWrite` settings and their end-to-end plumbing, shipped speculatively in #2202.

## Why (YAGNI)

The sandbox's design goal is **CWD-subtree confinement**. The genuine cross-session leak-denies (other sessions' `~/.xcsh/agent/memories` & `.../sessions`, and the shared `~/.config/xcsh/contexts`) are **hardcoded** as `leakDenies` in `buildDefaultSandboxPolicy`. The `deny*` settings had **no `/settings` UI**, defaulted to `[]`, and only served an "allow-this-tree-except-a-subpath" case nobody requested — extra cognitive load on a security control for no earned benefit.

## Changes

- `config/settings-schema.ts` — drop the two `sandbox.deny*` keys.
- `extensibility/extensions/bundled/sandbox-guard.ts` — drop the two `readSetting` reads.
- `sandbox/policy.ts` — drop the `denyRead?`/`denyWrite?` `DefaultSandboxOptions` fields and the two `expand(opts.deny*, false)` lines.
- `test/sandbox-policy.test.ts` — drop the obsolete `denyRead` unit test.

## Preserved (verified by retained tests)

- Hardcoded `leakDenies` + deny-then-allow longest-prefix precedence (`sandbox-policy.test.ts` lines ~68, ~113).
- `sandbox.enabled`, `sandbox.allowRead`/`allowWrite`, `--no-sandbox`, `--allow-path`.

## Verification

- `bun run check:types` → exit 0.
- Sandbox suite: **42 pass / 0 fail** (was 43; −1 removed test).
- `grep` confirms zero dangling `deny*` references.

## Follow-up (not in scope)

`DefaultSandboxOptions.extraAllowRoots` looks similarly dead (only a test sets it; guard/CLI use `allowRead`/`allowWrite`) — flagged for a separate decision.

Closes #2205