### PR TITLE
fix(test): harden bridge probe() against telemetry frames racing hello_ack

### DIFF
--- a/packages/coding-agent/test/helpers/bridge-probe.test.ts
+++ b/packages/coding-agent/test/helpers/bridge-probe.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { probe } from "./bridge-probe";
+
+/**
+ * Regression for #2207: the extension bridge multiplexes typed frames on one
+ * WebSocket — `hello_ack` (the handshake answer) plus `span` TTFT telemetry.
+ * During a cold worker spawn a `session_build` span can be pushed BEFORE the
+ * `hello_ack`; probe() must return the ack, not whatever frame arrives first.
+ */
+describe("bridge probe() frame demultiplexing", () => {
+	it("returns hello_ack even when a telemetry span races ahead of it", async () => {
+		const ack = { type: "hello_ack", tenant: "acme", env: "staging", sessionId: "tab-1" };
+		const span = { type: "span", stage: "session_build", ms: 745, sid: "tab-1", cold: true };
+		const server = Bun.serve({
+			port: 0,
+			fetch(req, srv) {
+				if (srv.upgrade(req)) return undefined;
+				return new Response("expected websocket upgrade", { status: 400 });
+			},
+			websocket: {
+				open(ws) {
+					// Emit the span FIRST to reproduce the cold-start interleaving.
+					ws.send(JSON.stringify(span));
+					ws.send(JSON.stringify(ack));
+				},
+				message() {},
+			},
+		});
+		try {
+			const frame = await probe(server.port);
+			expect(frame).toMatchObject({ type: "hello_ack", tenant: "acme", env: "staging" });
+		} finally {
+			server.stop(true);
+		}
+	});
+
+	it("still returns hello_ack when it is the only frame", async () => {
+		const ack = { type: "hello_ack", tenant: "acme", env: "prod", sessionId: "tab-2" };
+		const server = Bun.serve({
+			port: 0,
+			fetch(req, srv) {
+				if (srv.upgrade(req)) return undefined;
+				return new Response("expected websocket upgrade", { status: 400 });
+			},
+			websocket: {
+				open(ws) {
+					ws.send(JSON.stringify(ack));
+				},
+				message() {},
+			},
+		});
+		try {
+			const frame = await probe(server.port);
+			expect(frame).toMatchObject({ type: "hello_ack", tenant: "acme", env: "prod" });
+		} finally {
+			server.stop(true);
+		}
+	});
+});

--- a/packages/coding-agent/test/helpers/bridge-probe.test.ts
+++ b/packages/coding-agent/test/helpers/bridge-probe.test.ts
@@ -27,7 +27,7 @@ describe("bridge probe() frame demultiplexing", () => {
 			},
 		});
 		try {
-			const frame = await probe(server.port);
+			const frame = await probe(server.port as number);
 			expect(frame).toMatchObject({ type: "hello_ack", tenant: "acme", env: "staging" });
 		} finally {
 			server.stop(true);
@@ -50,7 +50,7 @@ describe("bridge probe() frame demultiplexing", () => {
 			},
 		});
 		try {
-			const frame = await probe(server.port);
+			const frame = await probe(server.port as number);
 			expect(frame).toMatchObject({ type: "hello_ack", tenant: "acme", env: "prod" });
 		} finally {
 			server.stop(true);

--- a/packages/coding-agent/test/helpers/bridge-probe.ts
+++ b/packages/coding-agent/test/helpers/bridge-probe.ts
@@ -35,8 +35,20 @@ export function probe(port: number, timeoutMs = 500): Promise<Record<string, unk
 		}, timeoutMs);
 		ws.onopen = () => ws.send(JSON.stringify({ type: "hello", contractVersion: "1.5.0", extensionId: "probe" }));
 		ws.onmessage = e => {
+			// The bridge multiplexes typed frames on this socket: the `hello_ack`
+			// handshake answer plus `type:"span"` TTFT telemetry emitted during a
+			// (cold) session build. Only the ack answers this probe — skip any other
+			// frame and keep waiting so a span that races ahead of the ack can't be
+			// mistaken for it (#2207).
+			let frame: Record<string, unknown>;
+			try {
+				frame = JSON.parse(e.data as string) as Record<string, unknown>;
+			} catch {
+				return; // ignore malformed frames; wait for the ack or the timeout
+			}
+			if (frame.type !== "hello_ack") return;
 			clearTimeout(timer);
-			resolve(JSON.parse(e.data as string) as Record<string, unknown>);
+			resolve(frame);
 			ws.close();
 		};
 		ws.onerror = () => {


### PR DESCRIPTION
## Problem

Release CI (`test` job) flaked intermittently on `manager.int.test.ts:479`: `expect(await probe(port)).toMatchObject({ tenant: "acme", env: "staging" })` received `{ type: "span", stage: "session_build", cold: true, ms: 745, sid: "tab-1" }`.

## Root cause

The extension bridge multiplexes typed frames on a single WebSocket:
- `{ type: "hello_ack", tenant, env, sessionId }` — the handshake answer (`browser/extension-bridge.ts:407`)
- `{ type: "span", stage: "session_build", ... }` — TTFT telemetry (`browser/ttft-spans.ts:39`)

`test/helpers/bridge-probe.ts` `probe()` resolved on the **first** `onmessage`, assuming it was the ack. On a **cold** worker spawn the `session_build` span can be pushed before the ack and win the race, so probe returned the span. Nondeterministic → flaky release gate.

## Fix

Demultiplex by frame type: ignore any frame whose `type` is not `hello_ack` and keep waiting until the ack arrives or the timeout fires. Contained to the shared test helper — **no product/protocol change** (spans on the bridge WS are legitimate).

## Verification (TDD)

- New `test/helpers/bridge-probe.test.ts` stands up a stub WS server that emits a `span` **before** the `hello_ack`. It reproduced the exact CI failure object (**red**) and now returns the ack (**green**).
- Both `probe` consumers pass: `manager.int.test.ts` (3/3) and `worker-spawn.int.test.ts`.
- `bun run check:types` exit 0; Biome clean.

Closes #2207