### PR TITLE
feat(office-pane): Excel tool parity — 9 tools (multi-sheet + prefetch + formulas/tables/metadata)

### DIFF
--- a/packages/coding-agent/src/browser/host-profiles.ts
+++ b/packages/coding-agent/src/browser/host-profiles.ts
@@ -97,6 +97,12 @@ CONTEXT: You can only access the open workbook. Think in cells, ranges, and — 
 - Warn the user before overwriting existing cell contents.
 - Cite specific cells and ranges precisely (e.g. A1, Sheet1!B2:B10) so the user can follow along.
 
+TOOLS: Discover the workbook before you answer, then reach for the tool that matches the shape of the data:
+- Call \`get_workbook_info\` FIRST to discover every sheet, its used range, Excel Tables, and named ranges before answering a workbook question — do not guess the structure.
+- Use \`read_table\` for structured Excel Tables (it tracks the real extent), \`get_formulas\` to see the formulas behind cells, \`get_cell_metadata\` for cell types/number formats, and \`read_named_range\` to read a defined name.
+- Use \`sort_filter_table\` to sort or filter a Table by column.
+- Use \`read_range\`/\`write_range\` for arbitrary cell ranges (bare or sheet-qualified like Sheet2!A1:B10), and \`list_sheets\` when you only need the tab names.
+
 BEHAVIOR:
 - Respond concisely with markdown. The task pane is narrow — avoid long code blocks.
 - Read the workbook to answer questions about its data; do not guess.

--- a/packages/coding-agent/test/browser/host-profiles.test.ts
+++ b/packages/coding-agent/test/browser/host-profiles.test.ts
@@ -49,6 +49,17 @@ describe("host profiles", () => {
 		expect(t.toLowerCase()).toContain("formula");
 	});
 
+	it("excel prompt advertises the depth-tool catalog and get_workbook_info-first prefetch", () => {
+		const t = HOST_PROFILES.excel.systemPrompt;
+		// Prefetch hint: discover structure first.
+		expect(t).toContain("get_workbook_info");
+		expect(t.toLowerCase()).toContain("first");
+		// Depth tools are named so the model knows to reach for them.
+		for (const name of ["read_table", "get_formulas", "get_cell_metadata", "read_named_range", "sort_filter_table"]) {
+			expect(t).toContain(name);
+		}
+	});
+
 	it("powerpoint prompt thinks in slides", () => {
 		const t = HOST_PROFILES.powerpoint.systemPrompt;
 		expect(t).toContain("presentation");

--- a/packages/office-pane/src/office/excel-tools.ts
+++ b/packages/office-pane/src/office/excel-tools.ts
@@ -98,9 +98,9 @@ export interface ExcelRequestContextLike {
  * Handles quoted sheet names: `'My Sheet'!A1` → sheet `My Sheet`.
  */
 export function parseSheetAddress(input: string): { sheet: string | null; range: string } {
-	// Quoted sheet name: 'Sheet Name'!A1:B3
-	const quoted = input.match(/^'([^']+)'!(.+)$/);
-	if (quoted) return { sheet: quoted[1], range: quoted[2] };
+	// Quoted sheet name: 'Sheet Name'!A1:B3 (Excel doubles internal apostrophes: 'John''s'!A1)
+	const quoted = input.match(/^'((?:[^']|'')+)'!(.+)$/);
+	if (quoted) return { sheet: quoted[1].replace(/''/g, "'"), range: quoted[2] };
 	// Unquoted: Sheet2!A1:B3
 	const unquoted = input.match(/^([A-Za-z0-9_. -]+)!(.+)$/);
 	if (unquoted) return { sheet: unquoted[1], range: unquoted[2] };
@@ -203,7 +203,7 @@ export function createExcelHostTools(excel: ExcelLike = getExcel()): HostToolReg
 				let names: string[];
 				try {
 					names = await excel.run(async ctx => {
-						ctx.workbook.worksheets.load("items");
+						ctx.workbook.worksheets.load("items/name");
 						await ctx.sync();
 						return ctx.workbook.worksheets.items.map(ws => ws.name);
 					});
@@ -312,7 +312,7 @@ export function createExcelHostTools(excel: ExcelLike = getExcel()): HostToolReg
 				try {
 					info = await excel.run(async ctx => {
 						const worksheets = ctx.workbook.worksheets;
-						worksheets.load("items");
+						worksheets.load("items/name");
 						ctx.workbook.names.load("items/name");
 						await ctx.sync();
 						// Queue each sheet's used range, tables, and sheet-scoped names.

--- a/packages/office-pane/src/office/excel-tools.ts
+++ b/packages/office-pane/src/office/excel-tools.ts
@@ -13,10 +13,26 @@
  */
 import { type AgentToolResult, HostToolDispatcher, type HostToolRegistration, type Transport } from "../core";
 
+/** A loadable collection of `{ name }` items (tables, columns, named ranges). */
+export interface ExcelNamedItemCollectionLike {
+	/** After `load("items/name")` + `sync()`, the array of `{ name }` entries. */
+	items: { name: string }[];
+	/** Queue a property (e.g. `"items/name"`) to load on the next `sync()`. */
+	load(properties: string): void;
+}
+
 /** A worksheet range — the subset of `Excel.Range` these tools touch. */
 export interface ExcelRangeLike {
+	/** The range's A1 address (sheet-qualified), loaded via `load("address")`. */
+	address: string;
 	/** 2D grid of cell values (rows of columns). */
 	values: unknown[][];
+	/** 2D grid of cell formulas (rows of columns), loaded via `load("formulas")`. */
+	formulas: unknown[][];
+	/** 2D grid of number-format strings, loaded via `load("numberFormat")`. */
+	numberFormat: string[][];
+	/** 2D grid of value-type tags, loaded via `load("valueTypes")`. */
+	valueTypes: unknown[][];
 	/** Queue a property (e.g. `"values"`) to load on the next `sync()`. */
 	load(properties: string): void;
 }
@@ -26,6 +42,30 @@ export interface ExcelWorksheetLike {
 	/** The tab name shown in the Excel sheet tab bar. */
 	name: string;
 	getRange(address: string): ExcelRangeLike;
+	/** The rectangle covering all cells with content (for structural discovery). */
+	getUsedRange(): ExcelRangeLike;
+	/** The Excel Tables anchored on this sheet. */
+	getTables(): ExcelNamedItemCollectionLike;
+	/** The sheet-scoped named ranges. */
+	names: ExcelNamedItemCollectionLike;
+}
+
+/** A single column of an Excel Table — the subset these tools touch. */
+export interface ExcelTableColumnLike {
+	name: string;
+	/** Zero-based column index within the table. */
+	index: number;
+	/** Auto-filter for this column. */
+	filter: { apply(criteria: { filterOn: string; values: string[] }): void };
+}
+
+/** An Excel Table — the subset the table tools touch. */
+export interface ExcelTableLike {
+	name: string;
+	getRange(): ExcelRangeLike;
+	columns: ExcelNamedItemCollectionLike & { getItem(name: string): ExcelTableColumnLike };
+	/** Table sort surface. */
+	sort: { apply(fields: { key: number; ascending: boolean }[]): void };
 }
 
 /** The worksheets collection — active sheet, by-name lookup, and enumeration. */
@@ -41,7 +81,13 @@ export interface ExcelWorksheetCollectionLike {
 
 /** The subset of the `Excel.RequestContext` batch object these tools use. */
 export interface ExcelRequestContextLike {
-	workbook: { worksheets: ExcelWorksheetCollectionLike };
+	workbook: {
+		worksheets: ExcelWorksheetCollectionLike;
+		/** Workbook-level named ranges: enumerable and resolvable by name. */
+		names: ExcelNamedItemCollectionLike & { getItem(name: string): { getRange(): ExcelRangeLike } };
+		/** Workbook-level Excel Tables, resolvable by name. */
+		tables: { getItem(name: string): ExcelTableLike };
+	};
 	/** Flush queued reads/writes to the document. */
 	sync(): Promise<void>;
 }
@@ -112,6 +158,15 @@ function requireAddress(args: Record<string, unknown>): string {
 		throw new Error('read/write requires a non-empty "address" (e.g. "A1:B3")');
 	}
 	return address;
+}
+
+/** Read `arguments.name` as a non-empty identifier (table / named-range name), or throw. */
+function requireName(args: Record<string, unknown>): string {
+	const name = typeof args.name === "string" ? args.name.trim() : "";
+	if (!name) {
+		throw new Error('this tool requires a non-empty "name"');
+	}
+	return name;
 }
 
 // Leading characters Excel treats as the start of a formula. A string cell
@@ -238,6 +293,254 @@ export function createExcelHostTools(excel: ExcelLike = getExcel()): HostToolReg
 					throw new Error(describeExcelError("write_range", raw, err));
 				}
 				return textResult(`Wrote ${values.length} row(s) to ${raw}.`, { address: raw });
+			},
+		},
+		{
+			definition: {
+				name: "get_workbook_info",
+				description:
+					"Discover the full structure of the open workbook: every worksheet with its used range, " +
+					"Excel Tables, and sheet-scoped named ranges, plus the workbook-level named ranges. " +
+					"Call this FIRST to orient yourself before answering a workbook question.",
+				parameters: { type: "object", properties: {} },
+			},
+			handler: async () => {
+				let info: {
+					sheets: { name: string; usedRange: string; tables: string[]; namedRanges: string[] }[];
+					workbookNamedRanges: string[];
+				};
+				try {
+					info = await excel.run(async ctx => {
+						const worksheets = ctx.workbook.worksheets;
+						worksheets.load("items");
+						ctx.workbook.names.load("items/name");
+						await ctx.sync();
+						// Queue each sheet's used range, tables, and sheet-scoped names.
+						const staged = worksheets.items.map(ws => {
+							const used = ws.getUsedRange();
+							used.load("address");
+							const tables = ws.getTables();
+							tables.load("items/name");
+							ws.names.load("items/name");
+							return { ws, used, tables };
+						});
+						await ctx.sync();
+						return {
+							sheets: staged.map(({ ws, used, tables }) => ({
+								name: ws.name,
+								usedRange: used.address ?? "",
+								tables: tables.items.map(t => t.name),
+								namedRanges: ws.names.items.map(n => n.name),
+							})),
+							workbookNamedRanges: ctx.workbook.names.items.map(n => n.name),
+						};
+					});
+				} catch (err) {
+					throw new Error(`get_workbook_info failed: ${err instanceof Error ? err.message : String(err)}`);
+				}
+				return textResult(JSON.stringify(info), info);
+			},
+		},
+		{
+			definition: {
+				name: "get_formulas",
+				description:
+					"Read the FORMULAS (not the computed values) of a range. Supports sheet-qualified addresses " +
+					'(e.g. "Sheet2!A1:B10") or a bare address for the active sheet. Use this to inspect how ' +
+					"cells are calculated before changing them.",
+				parameters: {
+					type: "object",
+					properties: {
+						address: {
+							type: "string",
+							description: 'A1-style range address, optionally sheet-qualified: "A1:B3" or "Sheet2!A1:B10".',
+						},
+					},
+					required: ["address"],
+				},
+			},
+			handler: async args => {
+				const raw = requireAddress(args);
+				const { sheet, range: rangeAddr } = parseSheetAddress(raw);
+				let formulas: unknown[][];
+				try {
+					formulas = await excel.run(async ctx => {
+						const ws = resolveWorksheet(ctx.workbook.worksheets, sheet);
+						const range = ws.getRange(rangeAddr);
+						range.load("formulas");
+						await ctx.sync();
+						return range.formulas;
+					});
+				} catch (err) {
+					throw new Error(describeExcelError("get_formulas", raw, err));
+				}
+				return textResult(JSON.stringify(formulas), { address: raw, formulas });
+			},
+		},
+		{
+			definition: {
+				name: "read_table",
+				description:
+					"Read the data of a named Excel Table (structured table), returning its body values, " +
+					"column names, and address. Prefer this over read_range for Tables — it tracks the table's " +
+					"real extent as rows are added or removed.",
+				parameters: {
+					type: "object",
+					properties: {
+						name: { type: "string", description: 'The Excel Table name (e.g. "Table1").' },
+					},
+					required: ["name"],
+				},
+			},
+			handler: async args => {
+				const name = requireName(args);
+				let data: { values: unknown[][]; address: string; columns: string[] };
+				try {
+					data = await excel.run(async ctx => {
+						const table = ctx.workbook.tables.getItem(name);
+						const range = table.getRange();
+						range.load("values,address");
+						table.columns.load("items/name");
+						await ctx.sync();
+						return {
+							values: range.values,
+							address: range.address ?? "",
+							columns: table.columns.items.map(c => c.name),
+						};
+					});
+				} catch (err) {
+					throw new Error(describeExcelError("read_table", name, err));
+				}
+				return textResult(JSON.stringify(data.values), { name, ...data });
+			},
+		},
+		{
+			definition: {
+				name: "get_cell_metadata",
+				description:
+					"Read the number formats and value types of a range (e.g. which cells are currency, dates, " +
+					"percentages, text, or errors). Supports sheet-qualified addresses or a bare address for the " +
+					"active sheet. Use this to understand how data is typed and displayed.",
+				parameters: {
+					type: "object",
+					properties: {
+						address: {
+							type: "string",
+							description: 'A1-style range address, optionally sheet-qualified: "A1:B3" or "Sheet2!A1:B10".',
+						},
+					},
+					required: ["address"],
+				},
+			},
+			handler: async args => {
+				const raw = requireAddress(args);
+				const { sheet, range: rangeAddr } = parseSheetAddress(raw);
+				let metadata: { numberFormat: string[][]; valueTypes: unknown[][] };
+				try {
+					metadata = await excel.run(async ctx => {
+						const ws = resolveWorksheet(ctx.workbook.worksheets, sheet);
+						const range = ws.getRange(rangeAddr);
+						range.load("numberFormat,valueTypes");
+						await ctx.sync();
+						return { numberFormat: range.numberFormat, valueTypes: range.valueTypes };
+					});
+				} catch (err) {
+					throw new Error(describeExcelError("get_cell_metadata", raw, err));
+				}
+				return textResult(JSON.stringify(metadata), { address: raw, ...metadata });
+			},
+		},
+		{
+			definition: {
+				name: "read_named_range",
+				description:
+					"Read the values of a defined name (named range) by its name. Resolves the name to its " +
+					"range anywhere in the workbook and returns the values and address.",
+				parameters: {
+					type: "object",
+					properties: {
+						name: { type: "string", description: 'The defined name / named range (e.g. "my_range").' },
+					},
+					required: ["name"],
+				},
+			},
+			handler: async args => {
+				const name = requireName(args);
+				let data: { values: unknown[][]; address: string };
+				try {
+					data = await excel.run(async ctx => {
+						const range = ctx.workbook.names.getItem(name).getRange();
+						range.load("values,address");
+						await ctx.sync();
+						return { values: range.values, address: range.address ?? "" };
+					});
+				} catch (err) {
+					throw new Error(describeExcelError("read_named_range", name, err));
+				}
+				return textResult(JSON.stringify(data.values), { name, ...data });
+			},
+		},
+		{
+			definition: {
+				name: "sort_filter_table",
+				description:
+					"Sort and/or filter a named Excel Table by column. Provide sortColumn to sort (sortAscending " +
+					"defaults to true), and/or filterColumn + filterValues to show only rows whose column matches " +
+					"one of the values. At least one of sortColumn or filterColumn is required.",
+				parameters: {
+					type: "object",
+					properties: {
+						name: { type: "string", description: "The Excel Table name." },
+						sortColumn: { type: "string", description: "Column name to sort by." },
+						sortAscending: {
+							type: "boolean",
+							description: "Sort direction; true (ascending) by default.",
+						},
+						filterColumn: { type: "string", description: "Column name to filter." },
+						filterValues: {
+							type: "array",
+							description: "Values to keep visible in filterColumn.",
+							items: { type: "string" },
+						},
+					},
+					required: ["name"],
+				},
+			},
+			handler: async args => {
+				const name = requireName(args);
+				const sortColumn = typeof args.sortColumn === "string" ? args.sortColumn.trim() : "";
+				const sortAscending = typeof args.sortAscending === "boolean" ? args.sortAscending : true;
+				const filterColumn = typeof args.filterColumn === "string" ? args.filterColumn.trim() : "";
+				const filterValues = Array.isArray(args.filterValues)
+					? args.filterValues.filter((v): v is string => typeof v === "string")
+					: [];
+				if (!sortColumn && !filterColumn) {
+					throw new Error('sort_filter_table requires "sortColumn" and/or "filterColumn"');
+				}
+				const applied: string[] = [];
+				try {
+					await excel.run(async ctx => {
+						const table = ctx.workbook.tables.getItem(name);
+						if (sortColumn) {
+							table.columns.load("items/name");
+							await ctx.sync();
+							const key = table.columns.items.findIndex(c => c.name === sortColumn);
+							if (key < 0) {
+								throw new Error(`column "${sortColumn}" not found in table "${name}"`);
+							}
+							table.sort.apply([{ key, ascending: sortAscending }]);
+							applied.push(`sorted by ${sortColumn} ${sortAscending ? "ascending" : "descending"}`);
+						}
+						if (filterColumn) {
+							table.columns.getItem(filterColumn).filter.apply({ filterOn: "Values", values: filterValues });
+							applied.push(`filtered ${filterColumn} to ${filterValues.length} value(s)`);
+						}
+						await ctx.sync();
+					});
+				} catch (err) {
+					throw new Error(describeExcelError("sort_filter_table", name, err));
+				}
+				return textResult(`Table ${name}: ${applied.join("; ")}.`, { name, applied });
 			},
 		},
 	];

--- a/packages/office-pane/src/office/excel-tools.ts
+++ b/packages/office-pane/src/office/excel-tools.ts
@@ -21,11 +21,50 @@ export interface ExcelRangeLike {
 	load(properties: string): void;
 }
 
+/** A single worksheet — the subset these tools touch. */
+export interface ExcelWorksheetLike {
+	/** The tab name shown in the Excel sheet tab bar. */
+	name: string;
+	getRange(address: string): ExcelRangeLike;
+}
+
+/** The worksheets collection — active sheet, by-name lookup, and enumeration. */
+export interface ExcelWorksheetCollectionLike {
+	getActiveWorksheet(): ExcelWorksheetLike;
+	/** Look up a worksheet by its tab name (for cross-sheet reads like `Sheet2!A1:B3`). */
+	getItem(name: string): ExcelWorksheetLike;
+	/** After `load("items")` + `sync()`, the array of all worksheets. */
+	items: ExcelWorksheetLike[];
+	/** Queue a property (e.g. `"items"`) to load on the next `sync()`. */
+	load(properties: string): void;
+}
+
 /** The subset of the `Excel.RequestContext` batch object these tools use. */
 export interface ExcelRequestContextLike {
-	workbook: { worksheets: { getActiveWorksheet(): { getRange(address: string): ExcelRangeLike } } };
+	workbook: { worksheets: ExcelWorksheetCollectionLike };
 	/** Flush queued reads/writes to the document. */
 	sync(): Promise<void>;
+}
+
+/**
+ * Parse a potentially sheet-qualified A1 address. `Sheet2!A1:B3` → `{ sheet: "Sheet2", range: "A1:B3" }`.
+ * A bare `A1:B3` → `{ sheet: null, range: "A1:B3" }` (active sheet).
+ * Handles quoted sheet names: `'My Sheet'!A1` → sheet `My Sheet`.
+ */
+export function parseSheetAddress(input: string): { sheet: string | null; range: string } {
+	// Quoted sheet name: 'Sheet Name'!A1:B3
+	const quoted = input.match(/^'([^']+)'!(.+)$/);
+	if (quoted) return { sheet: quoted[1], range: quoted[2] };
+	// Unquoted: Sheet2!A1:B3
+	const unquoted = input.match(/^([A-Za-z0-9_. -]+)!(.+)$/);
+	if (unquoted) return { sheet: unquoted[1], range: unquoted[2] };
+	// No sheet prefix → active sheet.
+	return { sheet: null, range: input };
+}
+
+/** Resolve a worksheet from the collection: by name if specified, else the active one. */
+function resolveWorksheet(worksheets: ExcelWorksheetCollectionLike, sheetName: string | null): ExcelWorksheetLike {
+	return sheetName ? worksheets.getItem(sheetName) : worksheets.getActiveWorksheet();
 }
 
 /** The `Excel.run` seam — injected so the tools need no Office runtime in tests. */
@@ -99,42 +138,76 @@ export function createExcelHostTools(excel: ExcelLike = getExcel()): HostToolReg
 	return [
 		{
 			definition: {
+				name: "list_sheets",
+				description:
+					"List all worksheet (tab) names in the open workbook. " +
+					"Call this FIRST to discover the workbook structure before reading specific sheets.",
+				parameters: { type: "object", properties: {} },
+			},
+			handler: async () => {
+				let names: string[];
+				try {
+					names = await excel.run(async ctx => {
+						ctx.workbook.worksheets.load("items");
+						await ctx.sync();
+						return ctx.workbook.worksheets.items.map(ws => ws.name);
+					});
+				} catch (err) {
+					throw new Error(`list_sheets failed: ${err instanceof Error ? err.message : String(err)}`);
+				}
+				return textResult(JSON.stringify(names), { sheets: names });
+			},
+		},
+		{
+			definition: {
 				name: "read_range",
-				description: "Read the cell values of a range on the active Excel worksheet.",
+				description:
+					"Read the cell values of a range. Supports sheet-qualified addresses " +
+					'(e.g. "Sheet2!A1:B10" or "\'My Sheet\'!C1:D5") to read ANY worksheet, ' +
+					'or a bare address (e.g. "A1:B3") to read the active sheet.',
 				parameters: {
 					type: "object",
 					properties: {
-						address: { type: "string", description: 'A1-style range address, e.g. "A1:B3".' },
+						address: {
+							type: "string",
+							description: 'A1-style range address, optionally sheet-qualified: "A1:B3" or "Sheet2!A1:B10".',
+						},
 					},
 					required: ["address"],
 				},
 			},
 			handler: async args => {
-				const address = requireAddress(args);
+				const raw = requireAddress(args);
+				const { sheet, range: rangeAddr } = parseSheetAddress(raw);
 				let values: unknown[][];
 				try {
 					values = await excel.run(async ctx => {
-						const range = ctx.workbook.worksheets.getActiveWorksheet().getRange(address);
+						const ws = resolveWorksheet(ctx.workbook.worksheets, sheet);
+						const range = ws.getRange(rangeAddr);
 						range.load("values");
 						await ctx.sync();
 						return range.values;
 					});
 				} catch (err) {
-					throw new Error(describeExcelError("read_range", address, err));
+					throw new Error(describeExcelError("read_range", raw, err));
 				}
-				return textResult(JSON.stringify(values), { address, values });
+				return textResult(JSON.stringify(values), { address: raw, values });
 			},
 		},
 		{
 			definition: {
 				name: "write_range",
 				description:
-					"Write a 2D grid of literal values to a range on the active Excel worksheet. " +
+					"Write a 2D grid of literal values to a range. Supports sheet-qualified addresses " +
+					'(e.g. "Sheet2!A1:B3") to write ANY worksheet, or a bare address for the active sheet. ' +
 					"Values are written as text/numbers; strings that look like formulas are stored literally (not evaluated).",
 				parameters: {
 					type: "object",
 					properties: {
-						address: { type: "string", description: 'A1-style range address, e.g. "A1:B3".' },
+						address: {
+							type: "string",
+							description: 'A1-style range address, optionally sheet-qualified: "A1:B3" or "Sheet2!A1:B10".',
+						},
 						values: {
 							type: "array",
 							description: "Rows of column values; its shape must match the address.",
@@ -145,7 +218,8 @@ export function createExcelHostTools(excel: ExcelLike = getExcel()): HostToolReg
 				},
 			},
 			handler: async args => {
-				const address = requireAddress(args);
+				const raw = requireAddress(args);
+				const { sheet, range: rangeAddr } = parseSheetAddress(raw);
 				if (!Array.isArray(args.values)) {
 					throw new Error('write_range requires "values" as a 2D array (rows of columns)');
 				}
@@ -155,14 +229,15 @@ export function createExcelHostTools(excel: ExcelLike = getExcel()): HostToolReg
 				);
 				try {
 					await excel.run(async ctx => {
-						const range = ctx.workbook.worksheets.getActiveWorksheet().getRange(address);
+						const ws = resolveWorksheet(ctx.workbook.worksheets, sheet);
+						const range = ws.getRange(rangeAddr);
 						range.values = values;
 						await ctx.sync();
 					});
 				} catch (err) {
-					throw new Error(describeExcelError("write_range", address, err));
+					throw new Error(describeExcelError("write_range", raw, err));
 				}
-				return textResult(`Wrote ${values.length} row(s) to ${address}.`, { address });
+				return textResult(`Wrote ${values.length} row(s) to ${raw}.`, { address: raw });
 			},
 		},
 	];

--- a/packages/office-pane/test/excel-tools.test.ts
+++ b/packages/office-pane/test/excel-tools.test.ts
@@ -27,43 +27,146 @@ import {
  * return whatever was seeded; writes mutate the store.
  */
 /**
+ * Structural metadata for the {@link fakeExcel} mock — the higher-order surfaces
+ * (#2212 depth tools) the flat address→values store can't express: per-sheet
+ * used ranges, tables and named ranges; workbook-level named ranges and tables;
+ * and per-address formulas / number formats / value types.
+ */
+interface FakeExcelMeta {
+	/** Per-sheet structural info keyed by tab name. */
+	sheetMeta?: Record<
+		string,
+		{
+			usedRange?: string;
+			/** Table names living on this sheet. */
+			tables?: string[];
+			/** Sheet-scoped named range names. */
+			names?: string[];
+			/** address → 2D formula grid. */
+			formulas?: Record<string, unknown[][]>;
+			/** address → 2D number-format grid. */
+			numberFormat?: Record<string, string[][]>;
+			/** address → 2D value-type grid. */
+			valueTypes?: Record<string, unknown[][]>;
+		}
+	>;
+	/** Workbook-level named ranges: name → { address, values }. */
+	namedRanges?: Record<string, { address: string; values: unknown[][] }>;
+	/** Workbook-level tables: name → { address, values, columns }. */
+	tables?: Record<string, { address: string; values: unknown[][]; columns?: string[] }>;
+}
+
+/** A captured `sort.apply` / `filter.apply` invocation (for sort_filter_table assertions). */
+interface FakeExcelOps {
+	sorts: { table: string; fields: { key: number; ascending: boolean }[] }[];
+	filters: { table: string; column: string; criteria: { filterOn: string; values: string[] } }[];
+}
+
+/**
  * A multi-sheet `Excel.run` fake. Each key in `sheets` is a tab name whose value
  * is `{ address: values }`. The first key is the "active" sheet. `cells` tracks
  * the address→values store for the active sheet (backward compat with existing tests).
+ * The optional `meta` argument layers on the higher-order structural surfaces
+ * (tables, named ranges, formulas, cell metadata) the depth tools read; `ops`
+ * records the sort/filter calls those tools make.
  */
 function fakeExcel(
 	seed: Record<string, unknown[][]> = {},
 	sheets?: Record<string, Record<string, unknown[][]>>,
-): ExcelLike & { cells: Record<string, unknown[][]> } {
+	meta: FakeExcelMeta = {},
+): ExcelLike & { cells: Record<string, unknown[][]>; ops: FakeExcelOps } {
 	// Backward compat: if `sheets` isn't provided, wrap seed as the sole "Sheet1".
 	const sheetStore: Record<string, Record<string, unknown[][]>> = sheets ?? { Sheet1: { ...seed } };
 	const sheetNames = Object.keys(sheetStore);
 	const activeName = sheetNames[0] ?? "Sheet1";
 	// `cells` aliases the active sheet's store (existing tests read/assert it).
 	const cells = sheetStore[activeName] ?? {};
+	const ops: FakeExcelOps = { sorts: [], filters: [] };
+	const namedRanges = meta.namedRanges ?? {};
+	const tables = meta.tables ?? {};
+
+	// A range whose loaded facets read from the given per-address maps.
+	const makeRange = (
+		address: string,
+		opts: {
+			read?: () => unknown[][];
+			write?: (v: unknown[][]) => void;
+			formulas?: unknown[][];
+			numberFormat?: string[][];
+			valueTypes?: unknown[][];
+		} = {},
+	) => ({
+		address,
+		get values(): unknown[][] {
+			return opts.read?.() ?? [];
+		},
+		set values(v: unknown[][]) {
+			opts.write?.(v);
+		},
+		formulas: opts.formulas ?? [],
+		numberFormat: opts.numberFormat ?? [],
+		valueTypes: opts.valueTypes ?? [],
+		load(_props: string): void {
+			/* fake resolves lazily via the getters above */
+		},
+	});
 
 	return {
 		cells,
+		ops,
 		run: async <T>(batch: (ctx: never) => Promise<T>): Promise<T> => {
 			const makeSheet = (name: string) => {
 				const store = sheetStore[name];
 				if (!store) throw new Error(`Sheet "${name}" not found`);
+				const sm = meta.sheetMeta?.[name] ?? {};
 				return {
 					name,
-					getRange: (address: string) => {
-						let pendingRead: { values: unknown[][] } | null = null;
-						return {
-							get values(): unknown[][] {
-								return pendingRead?.values ?? [];
-							},
-							set values(v: unknown[][]) {
+					getRange: (address: string) =>
+						makeRange(address, {
+							read: () => store[address] ?? [],
+							write: v => {
 								store[address] = v;
 								if (name === activeName) cells[address] = v;
 							},
-							load(_props: string): void {
-								pendingRead = { values: store[address] ?? [] };
+							formulas: sm.formulas?.[address],
+							numberFormat: sm.numberFormat?.[address],
+							valueTypes: sm.valueTypes?.[address],
+						}),
+					getUsedRange: () => makeRange(sm.usedRange ?? "", { read: () => [] }),
+					getTables: () => ({
+						items: (sm.tables ?? []).map(n => ({ name: n })),
+						load(_props: string): void {},
+					}),
+					names: {
+						items: (sm.names ?? []).map(n => ({ name: n })),
+						load(_props: string): void {},
+					},
+				};
+			};
+			const makeTable = (name: string) => {
+				const t = tables[name];
+				if (!t) throw new Error(`Table "${name}" not found`);
+				const cols = t.columns ?? [];
+				return {
+					name,
+					getRange: () => makeRange(t.address, { read: () => t.values }),
+					columns: {
+						items: cols.map(c => ({ name: c })),
+						load(_props: string): void {},
+						getItem: (col: string) => ({
+							name: col,
+							index: cols.indexOf(col),
+							filter: {
+								apply(criteria: { filterOn: string; values: string[] }): void {
+									ops.filters.push({ table: name, column: col, criteria });
+								},
 							},
-						};
+						}),
+					},
+					sort: {
+						apply(fields: { key: number; ascending: boolean }[]): void {
+							ops.sorts.push({ table: name, fields });
+						},
 					},
 				};
 			};
@@ -72,10 +175,22 @@ function fakeExcel(
 					worksheets: {
 						getActiveWorksheet: () => makeSheet(activeName),
 						getItem: (name: string) => makeSheet(name),
-						items: sheetNames.map(n => ({ name: n, getRange: makeSheet(n).getRange })),
+						items: sheetNames.map(n => makeSheet(n)),
 						load(_props: string): void {
 							/* items already populated */
 						},
+					},
+					names: {
+						items: Object.keys(namedRanges).map(n => ({ name: n })),
+						load(_props: string): void {},
+						getItem: (name: string) => {
+							const nr = namedRanges[name];
+							if (!nr) throw new Error(`Named range "${name}" not found`);
+							return { getRange: () => makeRange(nr.address, { read: () => nr.values }) };
+						},
+					},
+					tables: {
+						getItem: (name: string) => makeTable(name),
 					},
 				},
 				sync: async (): Promise<void> => {},
@@ -101,23 +216,35 @@ function flush(): Promise<void> {
 }
 
 describe("excel-tools", () => {
-	it("createExcelHostTools advertises read_range and write_range with JSON-schema params", () => {
+	const ALL_TOOL_NAMES = [
+		"get_cell_metadata",
+		"get_formulas",
+		"get_workbook_info",
+		"list_sheets",
+		"read_named_range",
+		"read_range",
+		"read_table",
+		"sort_filter_table",
+		"write_range",
+	];
+
+	it("createExcelHostTools advertises the full Excel tool set with JSON-schema params", () => {
 		const tools = createExcelHostTools(fakeExcel());
 		const names = tools.map(t => t.definition.name).sort();
-		expect(names).toEqual(["list_sheets", "read_range", "write_range"]);
+		expect(names).toEqual(ALL_TOOL_NAMES);
 		for (const t of tools) {
 			expect(t.definition.parameters).toMatchObject({ type: "object" });
 		}
 	});
 
-	it("registerExcelTools pushes both tools to the agent via set_host_tools", () => {
+	it("registerExcelTools pushes every tool to the agent via set_host_tools", () => {
 		const t = new MockTransport();
 		const d = new HostToolDispatcher(t);
 		registerExcelTools(d, fakeExcel());
 
 		const frame = t.sent.find(m => m.type === "set_host_tools") as SetHostToolsMsg | undefined;
 		expect(frame).toBeDefined();
-		expect(frame?.tools.map(x => x.name).sort()).toEqual(["list_sheets", "read_range", "write_range"]);
+		expect(frame?.tools.map(x => x.name).sort()).toEqual(ALL_TOOL_NAMES);
 		d.dispose();
 	});
 
@@ -218,7 +345,17 @@ describe("excel-tools", () => {
 
 		onConnected(); // simulates ChatPanel's post-connect hook
 		const frame = t.sent.find(m => m.type === "set_host_tools") as SetHostToolsMsg | undefined;
-		expect(frame?.tools.map(x => x.name).sort()).toEqual(["list_sheets", "read_range", "write_range"]);
+		expect(frame?.tools.map(x => x.name).sort()).toEqual([
+			"get_cell_metadata",
+			"get_formulas",
+			"get_workbook_info",
+			"list_sheets",
+			"read_named_range",
+			"read_range",
+			"read_table",
+			"sort_filter_table",
+			"write_range",
+		]);
 
 		// A host_tool_call is serviced end-to-end.
 		t.emit({
@@ -379,6 +516,219 @@ describe("multi-sheet support (#2212)", () => {
 			.handler({ address: "Sheet2!A1:B1" }, dummyCtx);
 		const text = result.content[0].type === "text" ? result.content[0].text : "";
 		expect(JSON.parse(text)).toEqual([["hello", "world"]]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Phase 0 — get_workbook_info (prefetch) + Phase 1 — Excel depth tools (#2212)
+// ---------------------------------------------------------------------------
+
+/** Resolve a tool's handler by name (throws if the tool isn't registered → RED). */
+function tool(excel: ExcelLike, name: string) {
+	const found = createExcelHostTools(excel).find(t => t.definition.name === name);
+	if (!found) throw new Error(`tool "${name}" is not registered`);
+	return found;
+}
+
+/** Parse a handler's first text content block as JSON. */
+async function callJson(excel: ExcelLike, name: string, args: Record<string, unknown>): Promise<unknown> {
+	const result = await tool(excel, name).handler(args, dummyCtx);
+	const text = result.content[0].type === "text" ? result.content[0].text : "";
+	return JSON.parse(text);
+}
+
+describe("get_workbook_info (Phase 0 prefetch)", () => {
+	it("returns per-sheet used ranges, tables, named ranges, and workbook-level named ranges", async () => {
+		const excel = fakeExcel(
+			{},
+			{
+				Sheet1: { "A1:B1": [["x", "y"]] },
+				Data: { "A1:A1": [[1]] },
+			},
+			{
+				sheetMeta: {
+					Sheet1: { usedRange: "A1:Z22", tables: ["Table1"], names: ["sheet_local"] },
+					Data: { usedRange: "A1:C9", tables: [], names: [] },
+				},
+				namedRanges: { global_name: { address: "Sheet1!A1:B1", values: [["x", "y"]] } },
+			},
+		);
+		const info = (await callJson(excel, "get_workbook_info", {})) as {
+			sheets: { name: string; usedRange: string; tables: string[]; namedRanges: string[] }[];
+			workbookNamedRanges: string[];
+		};
+		expect(info.sheets).toEqual([
+			{ name: "Sheet1", usedRange: "A1:Z22", tables: ["Table1"], namedRanges: ["sheet_local"] },
+			{ name: "Data", usedRange: "A1:C9", tables: [], namedRanges: [] },
+		]);
+		expect(info.workbookNamedRanges).toEqual(["global_name"]);
+	});
+
+	it("carries the structure in details for the panel/agent", async () => {
+		const excel = fakeExcel({}, { Sheet1: {} }, { sheetMeta: { Sheet1: { usedRange: "A1:A1" } } });
+		const result = await tool(excel, "get_workbook_info").handler({}, dummyCtx);
+		const details = result.details as { sheets: unknown[]; workbookNamedRanges: unknown[] } | undefined;
+		expect(details?.sheets.length).toBe(1);
+		expect(Array.isArray(details?.workbookNamedRanges)).toBe(true);
+	});
+});
+
+describe("get_formulas (Phase 1)", () => {
+	it("reads the formulas (not values) of a range", async () => {
+		const excel = fakeExcel(
+			{},
+			{ Sheet1: { "A1:A2": [[3], [7]] } },
+			{ sheetMeta: { Sheet1: { formulas: { "A1:A2": [["=1+2"], ["=SUM(A1)"]] } } } },
+		);
+		const formulas = await callJson(excel, "get_formulas", { address: "A1:A2" });
+		expect(formulas).toEqual([["=1+2"], ["=SUM(A1)"]]);
+	});
+
+	it("honors a sheet-qualified address", async () => {
+		const excel = fakeExcel(
+			{},
+			{ Sheet1: {}, Calc: {} },
+			{ sheetMeta: { Calc: { formulas: { "B2:B2": [["=A2*2"]] } } } },
+		);
+		const formulas = await callJson(excel, "get_formulas", { address: "Calc!B2:B2" });
+		expect(formulas).toEqual([["=A2*2"]]);
+	});
+
+	it("throws (dispatcher → isError) on a missing address", async () => {
+		const excel = fakeExcel();
+		expect(tool(excel, "get_formulas").handler({}, dummyCtx)).rejects.toThrow(/address/i);
+	});
+});
+
+describe("read_table (Phase 1)", () => {
+	it("reads a named Excel Table's data and columns", async () => {
+		const excel = fakeExcel(
+			{},
+			{ Sheet1: {} },
+			{
+				tables: {
+					Sales: {
+						address: "Sheet1!A1:B3",
+						values: [
+							["Region", "Total"],
+							["East", 10],
+							["West", 20],
+						],
+						columns: ["Region", "Total"],
+					},
+				},
+			},
+		);
+		const result = await tool(excel, "read_table").handler({ name: "Sales" }, dummyCtx);
+		const text = result.content[0].type === "text" ? result.content[0].text : "";
+		expect(JSON.parse(text)).toEqual([
+			["Region", "Total"],
+			["East", 10],
+			["West", 20],
+		]);
+		const details = result.details as { name: string; address: string; columns: string[] } | undefined;
+		expect(details?.name).toBe("Sales");
+		expect(details?.address).toBe("Sheet1!A1:B3");
+		expect(details?.columns).toEqual(["Region", "Total"]);
+	});
+
+	it("throws (dispatcher → isError) on a missing name", async () => {
+		const excel = fakeExcel();
+		expect(tool(excel, "read_table").handler({}, dummyCtx)).rejects.toThrow(/name/i);
+	});
+});
+
+describe("get_cell_metadata (Phase 1)", () => {
+	it("reads numberFormat and valueTypes for a range", async () => {
+		const excel = fakeExcel(
+			{},
+			{ Sheet1: { "A1:B1": [[1, "txt"]] } },
+			{
+				sheetMeta: {
+					Sheet1: {
+						numberFormat: { "A1:B1": [["0.00", "General"]] },
+						valueTypes: { "A1:B1": [["Double", "String"]] },
+					},
+				},
+			},
+		);
+		const meta = (await callJson(excel, "get_cell_metadata", { address: "A1:B1" })) as {
+			numberFormat: string[][];
+			valueTypes: unknown[][];
+		};
+		expect(meta.numberFormat).toEqual([["0.00", "General"]]);
+		expect(meta.valueTypes).toEqual([["Double", "String"]]);
+	});
+});
+
+describe("read_named_range (Phase 1)", () => {
+	it("reads a named range by its defined name", async () => {
+		const excel = fakeExcel(
+			{},
+			{ Sheet1: {} },
+			{ namedRanges: { my_range: { address: "Sheet1!C1:C2", values: [[42], [43]] } } },
+		);
+		const result = await tool(excel, "read_named_range").handler({ name: "my_range" }, dummyCtx);
+		const text = result.content[0].type === "text" ? result.content[0].text : "";
+		expect(JSON.parse(text)).toEqual([[42], [43]]);
+		const details = result.details as { name: string; address: string } | undefined;
+		expect(details?.address).toBe("Sheet1!C1:C2");
+	});
+
+	it("throws (dispatcher → isError) on a missing name", async () => {
+		const excel = fakeExcel();
+		expect(tool(excel, "read_named_range").handler({}, dummyCtx)).rejects.toThrow(/name/i);
+	});
+});
+
+describe("sort_filter_table (Phase 1)", () => {
+	it("sorts a table by a named column, resolving the column index", async () => {
+		const excel = fakeExcel(
+			{},
+			{ Sheet1: {} },
+			{ tables: { T: { address: "A1:B3", values: [], columns: ["Name", "Score"] } } },
+		);
+		await tool(excel, "sort_filter_table").handler(
+			{ name: "T", sortColumn: "Score", sortAscending: false },
+			dummyCtx,
+		);
+		expect(excel.ops.sorts).toEqual([{ table: "T", fields: [{ key: 1, ascending: false }] }]);
+	});
+
+	it("defaults sort to ascending", async () => {
+		const excel = fakeExcel(
+			{},
+			{ Sheet1: {} },
+			{ tables: { T: { address: "A1:B3", values: [], columns: ["Name", "Score"] } } },
+		);
+		await tool(excel, "sort_filter_table").handler({ name: "T", sortColumn: "Name" }, dummyCtx);
+		expect(excel.ops.sorts).toEqual([{ table: "T", fields: [{ key: 0, ascending: true }] }]);
+	});
+
+	it("filters a table column by values", async () => {
+		const excel = fakeExcel(
+			{},
+			{ Sheet1: {} },
+			{ tables: { T: { address: "A1:B3", values: [], columns: ["Region", "Score"] } } },
+		);
+		await tool(excel, "sort_filter_table").handler(
+			{ name: "T", filterColumn: "Region", filterValues: ["East", "West"] },
+			dummyCtx,
+		);
+		expect(excel.ops.filters).toEqual([
+			{ table: "T", column: "Region", criteria: { filterOn: "Values", values: ["East", "West"] } },
+		]);
+	});
+
+	it("throws when neither a sort nor a filter is requested", async () => {
+		const excel = fakeExcel(
+			{},
+			{ Sheet1: {} },
+			{ tables: { T: { address: "A1:B3", values: [], columns: ["Region"] } } },
+		);
+		expect(tool(excel, "sort_filter_table").handler({ name: "T" }, dummyCtx)).rejects.toThrow(
+			/sortColumn|filterColumn/i,
+		);
 	});
 });
 

--- a/packages/office-pane/test/excel-tools.test.ts
+++ b/packages/office-pane/test/excel-tools.test.ts
@@ -26,38 +26,59 @@ import {
  * address→values map. Mirrors the load/sync gating of real Office.js: reads
  * return whatever was seeded; writes mutate the store.
  */
-function fakeExcel(seed: Record<string, unknown[][]> = {}): ExcelLike & { cells: Record<string, unknown[][]> } {
-	const cells: Record<string, unknown[][]> = { ...seed };
+/**
+ * A multi-sheet `Excel.run` fake. Each key in `sheets` is a tab name whose value
+ * is `{ address: values }`. The first key is the "active" sheet. `cells` tracks
+ * the address→values store for the active sheet (backward compat with existing tests).
+ */
+function fakeExcel(
+	seed: Record<string, unknown[][]> = {},
+	sheets?: Record<string, Record<string, unknown[][]>>,
+): ExcelLike & { cells: Record<string, unknown[][]> } {
+	// Backward compat: if `sheets` isn't provided, wrap seed as the sole "Sheet1".
+	const sheetStore: Record<string, Record<string, unknown[][]>> = sheets ?? { Sheet1: { ...seed } };
+	const sheetNames = Object.keys(sheetStore);
+	const activeName = sheetNames[0] ?? "Sheet1";
+	// `cells` aliases the active sheet's store (existing tests read/assert it).
+	const cells = sheetStore[activeName] ?? {};
+
 	return {
 		cells,
 		run: async <T>(batch: (ctx: never) => Promise<T>): Promise<T> => {
-			let pendingAddress = "";
-			let pendingRead: { values: unknown[][] } | null = null;
-			const range = (address: string) => ({
-				get values(): unknown[][] {
-					return pendingRead?.values ?? [];
-				},
-				set values(v: unknown[][]) {
-					cells[address] = v;
-				},
-				load(_props: string): void {
-					pendingRead = { values: cells[address] ?? [] };
-				},
-			});
+			const makeSheet = (name: string) => {
+				const store = sheetStore[name];
+				if (!store) throw new Error(`Sheet "${name}" not found`);
+				return {
+					name,
+					getRange: (address: string) => {
+						let pendingRead: { values: unknown[][] } | null = null;
+						return {
+							get values(): unknown[][] {
+								return pendingRead?.values ?? [];
+							},
+							set values(v: unknown[][]) {
+								store[address] = v;
+								if (name === activeName) cells[address] = v;
+							},
+							load(_props: string): void {
+								pendingRead = { values: store[address] ?? [] };
+							},
+						};
+					},
+				};
+			};
 			const ctx = {
 				workbook: {
 					worksheets: {
-						getActiveWorksheet: () => ({
-							getRange: (address: string) => {
-								pendingAddress = address;
-								return range(address);
-							},
-						}),
+						getActiveWorksheet: () => makeSheet(activeName),
+						getItem: (name: string) => makeSheet(name),
+						items: sheetNames.map(n => ({ name: n, getRange: makeSheet(n).getRange })),
+						load(_props: string): void {
+							/* items already populated */
+						},
 					},
 				},
-				sync: async (): Promise<void> => {
-					void pendingAddress;
-				},
+				sync: async (): Promise<void> => {},
 			};
 			return batch(ctx as never);
 		},
@@ -83,7 +104,7 @@ describe("excel-tools", () => {
 	it("createExcelHostTools advertises read_range and write_range with JSON-schema params", () => {
 		const tools = createExcelHostTools(fakeExcel());
 		const names = tools.map(t => t.definition.name).sort();
-		expect(names).toEqual(["read_range", "write_range"]);
+		expect(names).toEqual(["list_sheets", "read_range", "write_range"]);
 		for (const t of tools) {
 			expect(t.definition.parameters).toMatchObject({ type: "object" });
 		}
@@ -96,7 +117,7 @@ describe("excel-tools", () => {
 
 		const frame = t.sent.find(m => m.type === "set_host_tools") as SetHostToolsMsg | undefined;
 		expect(frame).toBeDefined();
-		expect(frame?.tools.map(x => x.name).sort()).toEqual(["read_range", "write_range"]);
+		expect(frame?.tools.map(x => x.name).sort()).toEqual(["list_sheets", "read_range", "write_range"]);
 		d.dispose();
 	});
 
@@ -197,7 +218,7 @@ describe("excel-tools", () => {
 
 		onConnected(); // simulates ChatPanel's post-connect hook
 		const frame = t.sent.find(m => m.type === "set_host_tools") as SetHostToolsMsg | undefined;
-		expect(frame?.tools.map(x => x.name).sort()).toEqual(["read_range", "write_range"]);
+		expect(frame?.tools.map(x => x.name).sort()).toEqual(["list_sheets", "read_range", "write_range"]);
 
 		// A host_tool_call is serviced end-to-end.
 		t.emit({
@@ -260,5 +281,118 @@ describe("excel-tools", () => {
 		expect(reply?.isError).toBe(true);
 		expect(firstText(reply)?.toLowerCase()).toContain("address");
 		d.dispose();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Multi-sheet (#2212)
+// ---------------------------------------------------------------------------
+
+import { parseSheetAddress } from "../src/office/excel-tools";
+
+const dummyCtx = { signal: AbortSignal.timeout(5000), toolCallId: "test" } as import("../src/core").HostToolContext;
+
+describe("multi-sheet support (#2212)", () => {
+	it("list_sheets returns all worksheet tab names", async () => {
+		const excel = fakeExcel(
+			{},
+			{
+				"Performance Datasheet": { "A1:B1": [["RPS", 31613]] },
+				"Environment-Details": { "A1:B1": [["Platform", "AWS"]] },
+			},
+		);
+		const tools = createExcelHostTools(excel);
+		const listSheets = tools.find(t => t.definition.name === "list_sheets");
+		expect(listSheets).toBeDefined();
+		const result = await listSheets!.handler({}, dummyCtx);
+		const text = result.content[0].type === "text" ? result.content[0].text : "";
+		expect(JSON.parse(text)).toEqual(["Performance Datasheet", "Environment-Details"]);
+	});
+
+	it("read_range with a sheet-qualified address reads THAT sheet, not the active one", async () => {
+		const excel = fakeExcel(
+			{},
+			{
+				Sheet1: { "A1:B1": [["active", "data"]] },
+				"Environment-Details": { "A1:B1": [["Platform", "AWS"]] },
+			},
+		);
+		const tools = createExcelHostTools(excel);
+		const readRange = tools.find(t => t.definition.name === "read_range")!;
+		// Sheet-qualified: reads Environment-Details, not the active Sheet1.
+		const result = await readRange.handler({ address: "Environment-Details!A1:B1" }, dummyCtx);
+		const text = result.content[0].type === "text" ? result.content[0].text : "";
+		expect(JSON.parse(text)).toEqual([["Platform", "AWS"]]);
+	});
+
+	it("read_range with a quoted sheet name works ('My Sheet'!A1:B1)", async () => {
+		const excel = fakeExcel(
+			{},
+			{
+				Sheet1: {},
+				"My Sheet": { "A1:B1": [["quoted", "access"]] },
+			},
+		);
+		const tools = createExcelHostTools(excel);
+		const result = await tools
+			.find(t => t.definition.name === "read_range")!
+			.handler({ address: "'My Sheet'!A1:B1" }, dummyCtx);
+		const text = result.content[0].type === "text" ? result.content[0].text : "";
+		expect(JSON.parse(text)).toEqual([["quoted", "access"]]);
+	});
+
+	it("read_range with a bare address (no sheet prefix) still reads the active sheet", async () => {
+		const excel = fakeExcel(
+			{},
+			{
+				Active: { "A1:A1": [[42]] },
+				Other: { "A1:A1": [[99]] },
+			},
+		);
+		const tools = createExcelHostTools(excel);
+		const result = await tools.find(t => t.definition.name === "read_range")!.handler({ address: "A1:A1" }, dummyCtx);
+		const text = result.content[0].type === "text" ? result.content[0].text : "";
+		expect(JSON.parse(text)).toEqual([[42]]);
+	});
+
+	it("write_range with a sheet-qualified address writes THAT sheet", async () => {
+		const excel = fakeExcel(
+			{},
+			{
+				Sheet1: {},
+				Sheet2: {},
+			},
+		);
+		const tools = createExcelHostTools(excel);
+		await tools
+			.find(t => t.definition.name === "write_range")!
+			.handler(
+				{
+					address: "Sheet2!A1:B1",
+					values: [["hello", "world"]],
+				},
+				dummyCtx,
+			);
+		// Read it back from Sheet2 to confirm.
+		const result = await tools
+			.find(t => t.definition.name === "read_range")!
+			.handler({ address: "Sheet2!A1:B1" }, dummyCtx);
+		const text = result.content[0].type === "text" ? result.content[0].text : "";
+		expect(JSON.parse(text)).toEqual([["hello", "world"]]);
+	});
+});
+
+describe("parseSheetAddress", () => {
+	it("parses a bare address as active-sheet", () => {
+		expect(parseSheetAddress("A1:B3")).toEqual({ sheet: null, range: "A1:B3" });
+	});
+	it("parses an unquoted sheet prefix", () => {
+		expect(parseSheetAddress("Sheet2!A1:B10")).toEqual({ sheet: "Sheet2", range: "A1:B10" });
+	});
+	it("parses a quoted sheet prefix with spaces", () => {
+		expect(parseSheetAddress("'My Sheet'!C1:D5")).toEqual({ sheet: "My Sheet", range: "C1:D5" });
+	});
+	it("handles dotted/numeric sheet names", () => {
+		expect(parseSheetAddress("Data.2024!A1:Z100")).toEqual({ sheet: "Data.2024", range: "A1:Z100" });
 	});
 });


### PR DESCRIPTION
## Problem
Closes #2212. A/B vs Claude for Office: Claude has ~13 higher-order Excel tools (tables, formulas, named ranges, prefetch) while xcsh had 3 flat tools. Claude said "I'll read both sheets" because it discovers workbook structure; xcsh couldn't.

## Change (3 → 9 Excel tools)
**Multi-sheet:** `list_sheets` (tab names), cross-sheet `read_range`/`write_range` via `parseSheetAddress` (`Sheet2!A1:B10`, `'My Sheet'!C1:D5`).

**Phase 0 (prefetch):** `get_workbook_info` — full workbook structural overview (sheets + used ranges + Excel Tables + named ranges). The prompt tells the agent to call it FIRST.

**Phase 1 (depth):** `get_formulas` (formula arrays), `read_table` (named Excel Table + columns), `sort_filter_table` (sort/filter by column), `get_cell_metadata` (numberFormat + valueTypes), `read_named_range` (defined name → values).

**Seam extensions:** `ExcelWorksheetLike` (getUsedRange/getTables/names), `ExcelRangeLike` (formulas/numberFormat/valueTypes/address), new `ExcelNamedItemCollectionLike`/`ExcelTableLike`/`ExcelTableColumnLike`.

**Prompt hint:** TOOLS catalog in the Excel host-profile so the agent proactively uses the full tool set.

## Verification
excel-tools **31/0** (14 new); office-pane **275/0**; biome + tsgo clean; browser-safe build **153KB/256KB**. host-profiles **12/0**. TDD throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)