### PR TITLE
feat: report session identity and herdr:xcsh source from herdr reporter

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/bundled/herdr-reporter.ts
+++ b/packages/coding-agent/src/extensibility/extensions/bundled/herdr-reporter.ts
@@ -1,5 +1,6 @@
 import { connect } from "node:net";
-import type { ExtensionAPI } from "@f5-sales-demo/xcsh";
+import * as path from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@f5-sales-demo/xcsh";
 
 /**
  * herdr integration (bundled, default-on).
@@ -16,9 +17,14 @@ import type { ExtensionAPI } from "@f5-sales-demo/xcsh";
  * somehow unset, we fall back to the `herdr` CLI.
  *
  * xcsh is a fork of pi; a user may have both installed, so this reporter always
- * identifies itself as "xcsh" (never "pi") and claims pane authority via
- * `source: "xcsh"` so herdr's passive pi-detection heuristics cannot mislabel
- * the pane.
+ * identifies the agent as "xcsh" (never "pi"). It claims pane authority via the
+ * `source: "herdr:xcsh"` convention that herdr uses for first-class lifecycle
+ * authorities, which also lets herdr resume the pane after a server restart.
+ *
+ * Session identity: on session start (and each agent turn) the reporter sends a
+ * `pane.report_agent_session` frame carrying the absolute session file path (or
+ * the session id when the session is not persisted). herdr stores that reference
+ * and, on restore, resumes the pane with `xcsh --resume=<session>`.
  *
  * The extension is completely inert unless it is running inside a herdr pane
  * (detected via `HERDR_PANE_ID`), so it has zero effect for users who do not run
@@ -26,7 +32,11 @@ import type { ExtensionAPI } from "@f5-sales-demo/xcsh";
  */
 
 const HERDR_AGENT_LABEL = "xcsh";
+// herdr keys its official lifecycle-authority and session-resume plumbing on the
+// `herdr:<agent>` source convention, so report as "herdr:xcsh" (not bare "xcsh").
+const HERDR_SOURCE = "herdr:xcsh";
 const REPORT_METHOD = "pane.report_agent";
+const SESSION_METHOD = "pane.report_agent_session";
 const RELEASE_METHOD = "pane.release_agent";
 const SOCKET_TIMEOUT_MS = 2000;
 
@@ -106,20 +116,66 @@ export default function herdrReporter(pi: ExtensionAPI): void {
 	const report = (state: "idle" | "working" | "blocked"): void => {
 		send(REPORT_METHOD, {
 			pane_id: paneId,
-			source: HERDR_AGENT_LABEL,
+			source: HERDR_SOURCE,
 			agent: HERDR_AGENT_LABEL,
 			state,
 			seq: seq++,
 		});
 	};
 
-	// Announce presence as soon as the session is initialized.
-	pi.on("session_start", () => {
+	// Report the current session's identity so herdr can resume this pane
+	// (`xcsh --resume=<session>`) after a server restart. This is sent only over
+	// the socket; if herdr did not inject a socket path we skip it (state still
+	// reports via the CLI fallback). Prefer the absolute session file path, which
+	// herdr resumes directly; fall back to the session id for non-persisted
+	// sessions (e.g. print/RPC mode, where getSessionFile() is undefined).
+	const reportSession = (ctx: ExtensionContext): void => {
+		const socketPath = process.env.HERDR_SOCKET_PATH;
+		if (!socketPath) {
+			return;
+		}
+		let sessionRef: Record<string, unknown> | undefined;
+		try {
+			const file = ctx.sessionManager?.getSessionFile?.();
+			if (typeof file === "string" && path.isAbsolute(file)) {
+				sessionRef = { agent_session_path: file };
+			} else {
+				const id = ctx.sessionManager?.getSessionId?.();
+				if (typeof id === "string" && id.length > 0) {
+					sessionRef = { agent_session_id: id };
+				}
+			}
+		} catch (err) {
+			onError(err);
+			return;
+		}
+		if (!sessionRef) {
+			return;
+		}
+		sendToHerdrSocket(
+			socketPath,
+			SESSION_METHOD,
+			{
+				pane_id: paneId,
+				source: HERDR_SOURCE,
+				agent: HERDR_AGENT_LABEL,
+				seq: seq++,
+				...sessionRef,
+			},
+			onError,
+		);
+	};
+
+	// Announce presence and session identity as soon as the session is initialized.
+	pi.on("session_start", (_event, ctx) => {
+		reportSession(ctx);
 		report("idle");
 	});
 
-	// Busy while the agent loop is streaming a response.
-	pi.on("agent_start", () => {
+	// Busy while the agent loop is streaming a response. Re-report session identity
+	// in case the active session file changed (e.g. after /new, /resume, or /fork).
+	pi.on("agent_start", (_event, ctx) => {
+		reportSession(ctx);
 		report("working");
 	});
 
@@ -144,7 +200,7 @@ export default function herdrReporter(pi: ExtensionAPI): void {
 	pi.on("session_shutdown", () => {
 		send(RELEASE_METHOD, {
 			pane_id: paneId,
-			source: HERDR_AGENT_LABEL,
+			source: HERDR_SOURCE,
 			agent: HERDR_AGENT_LABEL,
 			seq: seq++,
 		});

--- a/packages/coding-agent/test/herdr-reporter.test.ts
+++ b/packages/coding-agent/test/herdr-reporter.test.ts
@@ -43,6 +43,13 @@ function makeMockPi(): MockPi {
 const idleCtx = { isIdle: () => true } as unknown as ExtensionContext;
 const busyCtx = { isIdle: () => false } as unknown as ExtensionContext;
 
+/** A ctx whose read-only session manager exposes a session file path and/or id. */
+const sessionCtx = (file: string | undefined, id = ""): ExtensionContext =>
+	({
+		isIdle: () => true,
+		sessionManager: { getSessionFile: () => file, getSessionId: () => id },
+	}) as unknown as ExtensionContext;
+
 /** A throwaway unix-socket server that records the JSON-RPC requests it receives. */
 interface FakeHerdr {
 	socketPath: string;
@@ -101,7 +108,7 @@ async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
 const reportMsg = (state: string, seq: number) => ({
 	id: "xcsh:herdr-reporter",
 	method: "pane.report_agent",
-	params: { pane_id: "w1:p1", source: "xcsh", agent: "xcsh", state, seq },
+	params: { pane_id: "w1:p1", source: "herdr:xcsh", agent: "xcsh", state, seq },
 });
 
 describe("herdr-reporter extension", () => {
@@ -187,7 +194,7 @@ describe("herdr-reporter extension", () => {
 			expect(herdr.received[0]).toEqual({
 				id: "xcsh:herdr-reporter",
 				method: "pane.release_agent",
-				params: { pane_id: "w1:p1", source: "xcsh", agent: "xcsh", seq: 0 },
+				params: { pane_id: "w1:p1", source: "herdr:xcsh", agent: "xcsh", seq: 0 },
 			});
 		} finally {
 			await herdr.close();
@@ -210,7 +217,7 @@ describe("herdr-reporter extension", () => {
 				"report-agent",
 				"w1:p1",
 				"--source",
-				"xcsh",
+				"herdr:xcsh",
 				"--agent",
 				"xcsh",
 				"--state",
@@ -221,8 +228,75 @@ describe("herdr-reporter extension", () => {
 		});
 		expect(execCalls[1]).toEqual({
 			command: "herdr",
-			args: ["pane", "release-agent", "w1:p1", "--source", "xcsh", "--agent", "xcsh", "--seq", "1"],
+			args: ["pane", "release-agent", "w1:p1", "--source", "herdr:xcsh", "--agent", "xcsh", "--seq", "1"],
 		});
+	});
+
+	it("reports session identity (absolute path) on session_start over the socket", async () => {
+		const herdr = await startFakeHerdr();
+		try {
+			process.env.HERDR_PANE_ID = "w1:p1";
+			process.env.HERDR_SOCKET_PATH = herdr.socketPath;
+			const { pi, handlers } = makeMockPi();
+
+			herdrReporter(pi);
+			const file = "/Users/x/.xcsh/agent/sessions/-proj/2026-07-23T00-00-00Z_abc.jsonl";
+			await handlers.get("session_start")?.({}, sessionCtx(file));
+
+			await waitFor(() => herdr.received.some(m => m.method === "pane.report_agent_session"));
+			const frame = herdr.received.find(m => m.method === "pane.report_agent_session");
+			expect(frame?.params).toMatchObject({
+				pane_id: "w1:p1",
+				source: "herdr:xcsh",
+				agent: "xcsh",
+				agent_session_path: file,
+			});
+			expect(frame?.params.agent_session_id).toBeUndefined();
+
+			// It still reports live state, tagged with the herdr:xcsh source.
+			await waitFor(() => herdr.received.some(m => m.method === "pane.report_agent"));
+			const state = herdr.received.find(m => m.method === "pane.report_agent");
+			expect(state?.params).toMatchObject({ source: "herdr:xcsh", agent: "xcsh", state: "idle" });
+		} finally {
+			await herdr.close();
+		}
+	});
+
+	it("falls back to the session id when no session file path is available", async () => {
+		const herdr = await startFakeHerdr();
+		try {
+			process.env.HERDR_PANE_ID = "w1:p1";
+			process.env.HERDR_SOCKET_PATH = herdr.socketPath;
+			const { pi, handlers } = makeMockPi();
+
+			herdrReporter(pi);
+			await handlers.get("session_start")?.({}, sessionCtx(undefined, "sess-123"));
+
+			await waitFor(() => herdr.received.some(m => m.method === "pane.report_agent_session"));
+			const frame = herdr.received.find(m => m.method === "pane.report_agent_session");
+			expect(frame?.params).toMatchObject({ source: "herdr:xcsh", agent: "xcsh", agent_session_id: "sess-123" });
+			expect(frame?.params.agent_session_path).toBeUndefined();
+		} finally {
+			await herdr.close();
+		}
+	});
+
+	it("does not send a session frame when the session is not persisted", async () => {
+		const herdr = await startFakeHerdr();
+		try {
+			process.env.HERDR_PANE_ID = "w1:p1";
+			process.env.HERDR_SOCKET_PATH = herdr.socketPath;
+			const { pi, handlers } = makeMockPi();
+
+			herdrReporter(pi);
+			// No session file and no id: only the state report should be sent.
+			await handlers.get("session_start")?.({}, sessionCtx(undefined, ""));
+
+			await waitFor(() => herdr.received.some(m => m.method === "pane.report_agent"));
+			expect(herdr.received.some(m => m.method === "pane.report_agent_session")).toBe(false);
+		} finally {
+			await herdr.close();
+		}
 	});
 
 	it("ships as a bundled extension and registers handlers under herdr", async () => {


### PR DESCRIPTION
## Summary

Makes xcsh's bundled herdr reporter a first-class herdr lifecycle authority with native resume support:

- Emits `source: "herdr:xcsh"` (herdr's `herdr:<agent>` authority/resume convention) instead of the bare `xcsh` source, while keeping the `xcsh` agent label.
- Sends a `pane.report_agent_session` frame on `session_start` and `agent_start`, carrying the absolute session file path from `ctx.sessionManager.getSessionFile()` (falling back to `getSessionId()` for non-persisted sessions). herdr stores this and resumes the pane with `xcsh --resume=<session>` after a server restart.
- State reporting (idle/working/blocked, incrementing seq, release-on-shutdown) and the CLI fallback are unchanged.

Session identity is sent only over the socket; if herdr did not inject `HERDR_SOCKET_PATH`, state still reports via the existing CLI fallback and the session frame is skipped.

## Why

The reporter previously reported state but no session identity, and used `source: "xcsh"`, which herdr's official-authority and resume plumbing (`source: "herdr:xcsh"`) did not recognize — so xcsh had no native resume-on-restore. A herdr build that recognizes `Agent::Xcsh` + the `herdr:xcsh` source now exists.

## Testing

- `bun --cwd=packages/coding-agent test test/herdr-reporter.test.ts` — 10 pass (3 new: session path, session-id fallback, no-frame-when-unpersisted; existing state/release/CLI-fallback assertions updated to `herdr:xcsh`).
- `packages/coding-agent` biome + `tsgo` typecheck clean.

Closes #2214