### PR TITLE
feat(office-pane): Word tool depth — 6 new tools (paragraphs, selection, comments, tracked changes)

### DIFF
--- a/packages/coding-agent/src/browser/host-profiles.ts
+++ b/packages/coding-agent/src/browser/host-profiles.ts
@@ -144,6 +144,12 @@ CONTEXT: You can only access the open document. Think in paragraphs, the current
 - Describe your edits so the user can review them, and prefer changes the user can accept or reject.
 - When the user refers to "the selection" (or "this"), act on the current selection.
 
+TOOLS: Discover the document before you answer, then reach for the tool that matches the shape of the request:
+- Call \`get_document_info\` FIRST to discover the document structure (sections, headings, comment and tracked-change presence, counts) before answering.
+- Use \`read_paragraphs\` for styled paragraph content, \`read_selection\` for the current selection, \`get_comments\` for comments, and \`get_tracked_changes\` for revisions.
+- Use \`read_document\` when you need the full plain text.
+- Use \`insert_paragraph\` to add content at a specific location (start, end, or before/after the selection), and \`insert_text\` for inline text within a paragraph.
+
 BEHAVIOR:
 - Respond concisely with markdown. The task pane is narrow — avoid long code blocks.
 - Read the document to answer questions about it; do not guess.

--- a/packages/coding-agent/test/browser/host-profiles.test.ts
+++ b/packages/coding-agent/test/browser/host-profiles.test.ts
@@ -71,6 +71,24 @@ describe("host profiles", () => {
 		expect(t).toContain("document");
 	});
 
+	it("word prompt advertises the depth-tool catalog and get_document_info-first prefetch", () => {
+		const t = HOST_PROFILES.word.systemPrompt;
+		// Prefetch hint: discover structure first.
+		expect(t).toContain("get_document_info");
+		expect(t.toLowerCase()).toContain("first");
+		// Depth tools are named so the model knows to reach for them.
+		for (const name of [
+			"read_paragraphs",
+			"read_selection",
+			"get_comments",
+			"get_tracked_changes",
+			"insert_paragraph",
+			"insert_text",
+		]) {
+			expect(t).toContain(name);
+		}
+	});
+
 	it("isClientHost accepts the wire values and rejects others", () => {
 		for (const host of CLIENT_HOSTS) expect(isClientHost(host)).toBe(true);
 		expect(isClientHost("outlook")).toBe(false);

--- a/packages/office-pane/src/office/word-tools.ts
+++ b/packages/office-pane/src/office/word-tools.ts
@@ -75,10 +75,10 @@ export interface WordBodyLike {
 	insertParagraph(text: string, location: WordParagraphLocation): void;
 	/** The document's paragraphs (loaded via `load("items/text,style")`). */
 	paragraphs: WordParagraphCollectionLike;
-	/** The document's comments. */
-	comments: WordCommentCollectionLike;
-	/** The document's tracked changes (revisions). */
-	trackedChanges: WordTrackedChangeCollectionLike;
+	/** The document's comments (Word API 1.4 — method, not property). */
+	getComments(): WordCommentCollectionLike;
+	/** The document's tracked changes (Word API 1.6 — method, not property). */
+	getTrackedChanges(): WordTrackedChangeCollectionLike;
 }
 export interface WordRangeLike {
 	/** Loaded selection text (available after load('text') + sync). */
@@ -272,8 +272,8 @@ export function createWordHostTools(word: WordLike = getWord()): HostToolRegistr
 						const sections = ctx.document.sections;
 						body.load("text");
 						body.paragraphs.load("items/text,style");
-						body.comments.load("items/content");
-						body.trackedChanges.load("items/type");
+						body.getComments().load("items/content");
+						body.getTrackedChanges().load("items/type");
 						sections.load("items");
 						await ctx.sync();
 						const headings: { text: string; level: number }[] = [];
@@ -287,8 +287,8 @@ export function createWordHostTools(word: WordLike = getWord()): HostToolRegistr
 							wordCount: countWords(body.text),
 							sectionCount: sections.items.length,
 							paragraphCount: body.paragraphs.items.length,
-							hasComments: body.comments.items.length > 0,
-							hasTrackedChanges: body.trackedChanges.items.length > 0,
+							hasComments: body.getComments().items.length > 0,
+							hasTrackedChanges: body.getTrackedChanges().items.length > 0,
 							headings,
 						};
 					});
@@ -363,7 +363,7 @@ export function createWordHostTools(word: WordLike = getWord()): HostToolRegistr
 				let comments: { content: string; author: string }[];
 				try {
 					comments = await word.run(async ctx => {
-						const collection = ctx.document.body.comments;
+						const collection = ctx.document.body.getComments();
 						collection.load("items/content,authorName");
 						await ctx.sync();
 						return collection.items.map(c => ({ content: c.content, author: c.authorName }));
@@ -386,7 +386,7 @@ export function createWordHostTools(word: WordLike = getWord()): HostToolRegistr
 				let changes: { text: string; type: string; author: string }[];
 				try {
 					changes = await word.run(async ctx => {
-						const collection = ctx.document.body.trackedChanges;
+						const collection = ctx.document.body.getTrackedChanges();
 						collection.load("items/text,type,authorName");
 						await ctx.sync();
 						return collection.items.map(c => ({ text: c.text, type: c.type, author: c.authorName }));

--- a/packages/office-pane/src/office/word-tools.ts
+++ b/packages/office-pane/src/office/word-tools.ts
@@ -272,8 +272,10 @@ export function createWordHostTools(word: WordLike = getWord()): HostToolRegistr
 						const sections = ctx.document.sections;
 						body.load("text");
 						body.paragraphs.load("items/text,style");
-						body.getComments().load("items/content");
-						body.getTrackedChanges().load("items/type");
+						const comments = body.getComments();
+						const tracked = body.getTrackedChanges();
+						comments.load("items/content");
+						tracked.load("items/type");
 						sections.load("items");
 						await ctx.sync();
 						const headings: { text: string; level: number }[] = [];
@@ -287,8 +289,8 @@ export function createWordHostTools(word: WordLike = getWord()): HostToolRegistr
 							wordCount: countWords(body.text),
 							sectionCount: sections.items.length,
 							paragraphCount: body.paragraphs.items.length,
-							hasComments: body.getComments().items.length > 0,
-							hasTrackedChanges: body.getTrackedChanges().items.length > 0,
+							hasComments: comments.items.length > 0,
+							hasTrackedChanges: tracked.items.length > 0,
 							headings,
 						};
 					});

--- a/packages/office-pane/src/office/word-tools.ts
+++ b/packages/office-pane/src/office/word-tools.ts
@@ -14,21 +14,85 @@ import { type AgentToolResult, HostToolDispatcher, type HostToolRegistration, ty
 
 // --- Minimal structural views of the Word.run context we depend on. ---
 
-/** Word `InsertLocation` values we use (string enum on the wire). */
+/** Word `InsertLocation` values `insertText` uses (string enum on the wire). */
 type WordInsertLocation = "Start" | "End" | "Replace";
+
+/** Word `InsertLocation` values `insertParagraph` uses. */
+type WordParagraphLocation = "Start" | "End" | "Before" | "After";
+
+/** A single paragraph — the subset the paragraph tools read. */
+export interface WordParagraphLike {
+	/** Paragraph text (loaded via `load("items/text,style")`). */
+	text: string;
+	/** The paragraph's style name (e.g. "Heading 1", "Normal"). */
+	style: string;
+}
+
+/** A loadable collection of paragraphs. */
+export interface WordParagraphCollectionLike {
+	items: WordParagraphLike[];
+	load(properties: string): void;
+}
+
+/** A single comment — the subset `get_comments` reads. */
+export interface WordCommentLike {
+	content: string;
+	authorName: string;
+}
+
+/** A loadable collection of comments. */
+export interface WordCommentCollectionLike {
+	items: WordCommentLike[];
+	load(properties: string): void;
+}
+
+/** A single tracked change (revision) — the subset `get_tracked_changes` reads. */
+export interface WordTrackedChangeLike {
+	text: string;
+	/** Revision type, e.g. "Inserted" or "Deleted". */
+	type: string;
+	authorName: string;
+}
+
+/** A loadable collection of tracked changes. */
+export interface WordTrackedChangeCollectionLike {
+	items: WordTrackedChangeLike[];
+	load(properties: string): void;
+}
+
+/** A loadable collection of sections (only the count is used). */
+export interface WordSectionCollectionLike {
+	items: unknown[];
+	load(properties: string): void;
+}
 
 export interface WordBodyLike {
 	/** Loaded document text (available after load('text') + sync). */
 	text: string;
 	load(properties: string): void;
 	insertText(text: string, location: WordInsertLocation): void;
+	/** Insert a new paragraph relative to the body (Start/End). */
+	insertParagraph(text: string, location: WordParagraphLocation): void;
+	/** The document's paragraphs (loaded via `load("items/text,style")`). */
+	paragraphs: WordParagraphCollectionLike;
+	/** The document's comments. */
+	comments: WordCommentCollectionLike;
+	/** The document's tracked changes (revisions). */
+	trackedChanges: WordTrackedChangeCollectionLike;
 }
 export interface WordRangeLike {
+	/** Loaded selection text (available after load('text') + sync). */
+	text: string;
+	load(properties: string): void;
 	insertText(text: string, location: WordInsertLocation): void;
+	/** Insert a new paragraph relative to the selection (Before/After). */
+	insertParagraph(text: string, location: WordParagraphLocation): void;
 }
 export interface WordDocumentLike {
 	body: WordBodyLike;
 	getSelection(): WordRangeLike;
+	/** The document's sections (only the count is read). */
+	sections: WordSectionCollectionLike;
 }
 export interface WordContextLike {
 	document: WordDocumentLike;
@@ -81,6 +145,37 @@ function toInsertLocation(location: string): WordInsertLocation | null {
 		default:
 			return null;
 	}
+}
+
+/** Map the friendly `location` arg to a Word paragraph InsertLocation (or null if invalid). */
+function toParagraphLocation(location: string): WordParagraphLocation | null {
+	switch (location) {
+		case "end":
+			return "End";
+		case "start":
+			return "Start";
+		case "before-selection":
+			return "Before";
+		case "after-selection":
+			return "After";
+		default:
+			return null;
+	}
+}
+
+/** Count whitespace-delimited words in a run of text. */
+function countWords(text: string): number {
+	const trimmed = text.trim();
+	return trimmed ? trimmed.split(/\s+/).length : 0;
+}
+
+/** Extract the heading level (1-based) from a paragraph style like "Heading 2", or null if not a heading. */
+function headingLevel(style: string): number | null {
+	if (!/heading/i.test(style)) {
+		return null;
+	}
+	const match = style.match(/(\d+)/);
+	return match ? Number.parseInt(match[1], 10) : 1;
 }
 
 /**
@@ -151,6 +246,201 @@ export function createWordHostTools(word: WordLike = getWord()): HostToolRegistr
 					throw new Error(describeWordError("insert_text", err));
 				}
 				return textResult(`Inserted text (${requested}).`, { text, location: requested });
+			},
+		},
+		{
+			definition: {
+				name: "get_document_info",
+				description:
+					"Discover the structure of the open Word document: word/section/paragraph counts, whether it has " +
+					"comments or tracked changes, and its heading outline. Call this FIRST to orient yourself before " +
+					"answering a question about the document.",
+				parameters: { type: "object", properties: {} },
+			},
+			handler: async () => {
+				let info: {
+					wordCount: number;
+					sectionCount: number;
+					paragraphCount: number;
+					hasComments: boolean;
+					hasTrackedChanges: boolean;
+					headings: { text: string; level: number }[];
+				};
+				try {
+					info = await word.run(async ctx => {
+						const body = ctx.document.body;
+						const sections = ctx.document.sections;
+						body.load("text");
+						body.paragraphs.load("items/text,style");
+						body.comments.load("items/content");
+						body.trackedChanges.load("items/type");
+						sections.load("items");
+						await ctx.sync();
+						const headings: { text: string; level: number }[] = [];
+						for (const p of body.paragraphs.items) {
+							const level = headingLevel(p.style);
+							if (level !== null) {
+								headings.push({ text: p.text, level });
+							}
+						}
+						return {
+							wordCount: countWords(body.text),
+							sectionCount: sections.items.length,
+							paragraphCount: body.paragraphs.items.length,
+							hasComments: body.comments.items.length > 0,
+							hasTrackedChanges: body.trackedChanges.items.length > 0,
+							headings,
+						};
+					});
+				} catch (err) {
+					throw new Error(describeWordError("get_document_info", err));
+				}
+				return textResult(JSON.stringify(info), info);
+			},
+		},
+		{
+			definition: {
+				name: "read_paragraphs",
+				description:
+					"Read the document's paragraphs with their styles, in document order. Returns a slice starting at " +
+					"startIndex (default 0) of at most count paragraphs (default 50); use this for styled paragraph content.",
+				parameters: {
+					type: "object",
+					properties: {
+						startIndex: { type: "number", description: "Zero-based index of the first paragraph (default 0)." },
+						count: { type: "number", description: "Maximum number of paragraphs to return (default 50)." },
+					},
+				},
+			},
+			handler: async args => {
+				const startIndex =
+					typeof args.startIndex === "number" && args.startIndex >= 0 ? Math.floor(args.startIndex) : 0;
+				const count = typeof args.count === "number" && args.count > 0 ? Math.floor(args.count) : 50;
+				let paragraphs: { index: number; text: string; style: string }[];
+				try {
+					paragraphs = await word.run(async ctx => {
+						const collection = ctx.document.body.paragraphs;
+						collection.load("items/text,style");
+						await ctx.sync();
+						return collection.items
+							.slice(startIndex, startIndex + count)
+							.map((p, offset) => ({ index: startIndex + offset, text: p.text, style: p.style }));
+					});
+				} catch (err) {
+					throw new Error(describeWordError("read_paragraphs", err));
+				}
+				return textResult(JSON.stringify(paragraphs), { paragraphs });
+			},
+		},
+		{
+			definition: {
+				name: "read_selection",
+				description: "Read the text of the current selection in the document (what the user has highlighted).",
+				parameters: { type: "object", properties: {} },
+			},
+			handler: async () => {
+				let text: string;
+				try {
+					text = await word.run(async ctx => {
+						const selection = ctx.document.getSelection();
+						selection.load("text");
+						await ctx.sync();
+						return selection.text;
+					});
+				} catch (err) {
+					throw new Error(describeWordError("read_selection", err));
+				}
+				return textResult(text, { text });
+			},
+		},
+		{
+			definition: {
+				name: "get_comments",
+				description: "Read the comments in the document, each with its content and author.",
+				parameters: { type: "object", properties: {} },
+			},
+			handler: async () => {
+				let comments: { content: string; author: string }[];
+				try {
+					comments = await word.run(async ctx => {
+						const collection = ctx.document.body.comments;
+						collection.load("items/content,authorName");
+						await ctx.sync();
+						return collection.items.map(c => ({ content: c.content, author: c.authorName }));
+					});
+				} catch (err) {
+					throw new Error(describeWordError("get_comments", err));
+				}
+				return textResult(JSON.stringify(comments), { comments });
+			},
+		},
+		{
+			definition: {
+				name: "get_tracked_changes",
+				description:
+					"Read the tracked changes (revisions) in the document, each with its text, type (Inserted/Deleted), " +
+					"and author.",
+				parameters: { type: "object", properties: {} },
+			},
+			handler: async () => {
+				let changes: { text: string; type: string; author: string }[];
+				try {
+					changes = await word.run(async ctx => {
+						const collection = ctx.document.body.trackedChanges;
+						collection.load("items/text,type,authorName");
+						await ctx.sync();
+						return collection.items.map(c => ({ text: c.text, type: c.type, author: c.authorName }));
+					});
+				} catch (err) {
+					throw new Error(describeWordError("get_tracked_changes", err));
+				}
+				return textResult(JSON.stringify(changes), { changes });
+			},
+		},
+		{
+			definition: {
+				name: "insert_paragraph",
+				description:
+					"Insert a new paragraph at a specific location: the start or end of the document (default 'end'), " +
+					"or before/after the current selection. Use insert_text for inline text within a paragraph.",
+				parameters: {
+					type: "object",
+					properties: {
+						text: { type: "string", description: "The paragraph text to insert." },
+						location: {
+							type: "string",
+							enum: ["start", "end", "before-selection", "after-selection"],
+							description: "Where to insert the paragraph; defaults to 'end'.",
+						},
+					},
+					required: ["text"],
+				},
+			},
+			handler: async args => {
+				const text = typeof args.text === "string" ? args.text : "";
+				if (!text.trim()) {
+					throw new Error('insert_paragraph requires a non-empty "text"');
+				}
+				const requested = typeof args.location === "string" ? args.location : "end";
+				const location = toParagraphLocation(requested);
+				if (location === null) {
+					throw new Error(
+						`insert_paragraph: unknown location "${requested}" (use start, end, before-selection, or after-selection)`,
+					);
+				}
+				try {
+					await word.run(async ctx => {
+						if (location === "Before" || location === "After") {
+							ctx.document.getSelection().insertParagraph(text, location);
+						} else {
+							ctx.document.body.insertParagraph(text, location);
+						}
+						await ctx.sync();
+					});
+				} catch (err) {
+					throw new Error(describeWordError("insert_paragraph", err));
+				}
+				return textResult(`Inserted paragraph (${requested}).`, { text, location: requested });
 			},
 		},
 	];

--- a/packages/office-pane/test/word-tools.test.ts
+++ b/packages/office-pane/test/word-tools.test.ts
@@ -14,9 +14,56 @@ import {
 	wireWordHostTools,
 } from "../src/office/word-tools";
 
-/** In-memory Word.run fake: a document body string + a selection sink. */
-function fakeWord(initialText = ""): WordLike & { text: string; inserts: Array<{ text: string; location: string }> } {
-	const state = { text: initialText, inserts: [] as Array<{ text: string; location: string }> };
+/**
+ * Structural metadata for the {@link fakeWord} mock — the higher-order surfaces
+ * (#2216 Word depth tools) the flat body-text store can't express: styled
+ * paragraphs, comments, tracked changes, the section count, and the current
+ * selection text.
+ */
+interface FakeWordMeta {
+	/** Styled paragraphs, in document order. */
+	paragraphs?: { text: string; style: string }[];
+	/** Document comments. */
+	comments?: { content: string; authorName: string }[];
+	/** Tracked changes (revisions). */
+	trackedChanges?: { text: string; type: string; authorName: string }[];
+	/** Number of sections (defaults to 1). */
+	sectionCount?: number;
+	/** The current selection's text. */
+	selection?: string;
+}
+
+/**
+ * In-memory Word.run fake: a document body string + a selection sink, plus the
+ * optional structural surfaces (paragraphs, comments, tracked changes, sections,
+ * selection text) the depth tools read. `inserts` records `insertText` calls and
+ * `paragraphInserts` records `insertParagraph` calls (from body or selection).
+ */
+function fakeWord(
+	initialText = "",
+	meta: FakeWordMeta = {},
+): WordLike & {
+	text: string;
+	inserts: Array<{ text: string; location: string }>;
+	paragraphInserts: Array<{ text: string; location: string }>;
+} {
+	const state = {
+		text: initialText,
+		inserts: [] as Array<{ text: string; location: string }>,
+		paragraphInserts: [] as Array<{ text: string; location: string }>,
+	};
+	const paragraphs = {
+		items: (meta.paragraphs ?? []).map(p => ({ ...p })),
+		load(_p: string) {},
+	};
+	const comments = {
+		items: (meta.comments ?? []).map(c => ({ ...c })),
+		load(_p: string) {},
+	};
+	const trackedChanges = {
+		items: (meta.trackedChanges ?? []).map(tc => ({ ...tc })),
+		load(_p: string) {},
+	};
 	const body = {
 		get text() {
 			return state.text;
@@ -27,10 +74,25 @@ function fakeWord(initialText = ""): WordLike & { text: string; inserts: Array<{
 			if (location === "End") state.text += text;
 			else if (location === "Start") state.text = text + state.text;
 		},
+		insertParagraph(text: string, location: string) {
+			state.paragraphInserts.push({ text, location });
+		},
+		paragraphs,
+		comments,
+		trackedChanges,
+	};
+	const sections = {
+		items: Array.from({ length: meta.sectionCount ?? 1 }, () => ({})),
+		load(_p: string) {},
 	};
 	const selection = {
+		text: meta.selection ?? "",
+		load(_p: string) {},
 		insertText(text: string, location: string) {
 			state.inserts.push({ text, location });
+		},
+		insertParagraph(text: string, location: string) {
+			state.paragraphInserts.push({ text, location });
 		},
 	};
 	return {
@@ -40,9 +102,12 @@ function fakeWord(initialText = ""): WordLike & { text: string; inserts: Array<{
 		get inserts() {
 			return state.inserts;
 		},
+		get paragraphInserts() {
+			return state.paragraphInserts;
+		},
 		run: async <T>(batch: (ctx: WordContextLike) => Promise<T>): Promise<T> => {
 			const ctx = {
-				document: { body, getSelection: () => selection },
+				document: { body, getSelection: () => selection, sections },
 				sync: async () => {},
 			};
 			return batch(ctx as unknown as WordContextLike);
@@ -63,11 +128,22 @@ function flush(): Promise<void> {
 }
 
 describe("word-tools", () => {
-	it("advertises read_document and insert_text", () => {
+	const ALL_TOOL_NAMES = [
+		"get_comments",
+		"get_document_info",
+		"get_tracked_changes",
+		"insert_paragraph",
+		"insert_text",
+		"read_document",
+		"read_paragraphs",
+		"read_selection",
+	];
+
+	it("advertises the full Word tool catalog", () => {
 		const names = createWordHostTools(fakeWord())
 			.map(t => t.definition.name)
 			.sort();
-		expect(names).toEqual(["insert_text", "read_document"]);
+		expect(names).toEqual(ALL_TOOL_NAMES);
 	});
 
 	it("registerWordTools pushes the tools via set_host_tools", () => {
@@ -75,7 +151,7 @@ describe("word-tools", () => {
 		const d = new HostToolDispatcher(t);
 		registerWordTools(d, fakeWord());
 		const frame = t.sent.find(m => m.type === "set_host_tools") as SetHostToolsMsg | undefined;
-		expect(frame?.tools.map(x => x.name).sort()).toEqual(["insert_text", "read_document"]);
+		expect(frame?.tools.map(x => x.name).sort()).toEqual(ALL_TOOL_NAMES);
 		d.dispose();
 	});
 
@@ -210,6 +286,262 @@ describe("word-tools", () => {
 		expect(txt).toContain("read_document");
 		expect(txt).toContain("GeneralException");
 		expect(txt).toContain("errorLocation");
+		d.dispose();
+	});
+
+	it("get_document_info summarizes structure, headings, comments and tracked changes", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerWordTools(
+			d,
+			fakeWord("The quick brown fox jumps", {
+				paragraphs: [
+					{ text: "Title", style: "Heading 1" },
+					{ text: "Subhead", style: "Heading 2" },
+					{ text: "Body text here", style: "Normal" },
+				],
+				comments: [{ content: "fix this", authorName: "Reviewer" }],
+				trackedChanges: [{ text: "insert", type: "Inserted", authorName: "Editor" }],
+				sectionCount: 2,
+			}),
+		);
+
+		t.emit({ type: "host_tool_call", id: "d1", toolCallId: "t1", toolName: "get_document_info", arguments: {} });
+		await flush();
+
+		const reply = callFrom(t);
+		expect(reply?.isError).toBeUndefined();
+		const info = JSON.parse(firstText(reply) ?? "{}");
+		expect(info.wordCount).toBe(5);
+		expect(info.sectionCount).toBe(2);
+		expect(info.paragraphCount).toBe(3);
+		expect(info.hasComments).toBe(true);
+		expect(info.hasTrackedChanges).toBe(true);
+		expect(info.headings).toEqual([
+			{ text: "Title", level: 1 },
+			{ text: "Subhead", level: 2 },
+		]);
+		d.dispose();
+	});
+
+	it("get_document_info reports empty structure for a plain document", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerWordTools(d, fakeWord("", { paragraphs: [{ text: "", style: "Normal" }] }));
+
+		t.emit({ type: "host_tool_call", id: "d2", toolCallId: "t2", toolName: "get_document_info", arguments: {} });
+		await flush();
+
+		const info = JSON.parse(firstText(callFrom(t)) ?? "{}");
+		expect(info.wordCount).toBe(0);
+		expect(info.sectionCount).toBe(1);
+		expect(info.hasComments).toBe(false);
+		expect(info.hasTrackedChanges).toBe(false);
+		expect(info.headings).toEqual([]);
+		d.dispose();
+	});
+
+	it("read_paragraphs returns indexed paragraphs with styles", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerWordTools(
+			d,
+			fakeWord("", {
+				paragraphs: [
+					{ text: "One", style: "Heading 1" },
+					{ text: "Two", style: "Normal" },
+					{ text: "Three", style: "Normal" },
+				],
+			}),
+		);
+
+		t.emit({ type: "host_tool_call", id: "p1", toolCallId: "t1", toolName: "read_paragraphs", arguments: {} });
+		await flush();
+
+		const paras = JSON.parse(firstText(callFrom(t)) ?? "[]");
+		expect(paras).toEqual([
+			{ index: 0, text: "One", style: "Heading 1" },
+			{ index: 1, text: "Two", style: "Normal" },
+			{ index: 2, text: "Three", style: "Normal" },
+		]);
+		d.dispose();
+	});
+
+	it("read_paragraphs honors startIndex and count", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerWordTools(
+			d,
+			fakeWord("", {
+				paragraphs: [
+					{ text: "a", style: "Normal" },
+					{ text: "b", style: "Normal" },
+					{ text: "c", style: "Normal" },
+					{ text: "d", style: "Normal" },
+				],
+			}),
+		);
+
+		t.emit({
+			type: "host_tool_call",
+			id: "p2",
+			toolCallId: "t2",
+			toolName: "read_paragraphs",
+			arguments: { startIndex: 1, count: 2 },
+		});
+		await flush();
+
+		const paras = JSON.parse(firstText(callFrom(t)) ?? "[]");
+		expect(paras).toEqual([
+			{ index: 1, text: "b", style: "Normal" },
+			{ index: 2, text: "c", style: "Normal" },
+		]);
+		d.dispose();
+	});
+
+	it("read_selection returns the current selection text", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerWordTools(d, fakeWord("full body", { selection: "selected phrase" }));
+
+		t.emit({ type: "host_tool_call", id: "s1", toolCallId: "t1", toolName: "read_selection", arguments: {} });
+		await flush();
+
+		const reply = callFrom(t);
+		expect(reply?.isError).toBeUndefined();
+		expect(firstText(reply)).toContain("selected phrase");
+		d.dispose();
+	});
+
+	it("get_comments returns comments with authors", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerWordTools(
+			d,
+			fakeWord("", {
+				comments: [
+					{ content: "first note", authorName: "Alice" },
+					{ content: "second note", authorName: "Bob" },
+				],
+			}),
+		);
+
+		t.emit({ type: "host_tool_call", id: "c1", toolCallId: "t1", toolName: "get_comments", arguments: {} });
+		await flush();
+
+		const comments = JSON.parse(firstText(callFrom(t)) ?? "[]");
+		expect(comments).toEqual([
+			{ content: "first note", author: "Alice" },
+			{ content: "second note", author: "Bob" },
+		]);
+		d.dispose();
+	});
+
+	it("get_tracked_changes returns revisions with type and author", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerWordTools(
+			d,
+			fakeWord("", {
+				trackedChanges: [
+					{ text: "added", type: "Inserted", authorName: "Alice" },
+					{ text: "removed", type: "Deleted", authorName: "Bob" },
+				],
+			}),
+		);
+
+		t.emit({ type: "host_tool_call", id: "tc1", toolCallId: "t1", toolName: "get_tracked_changes", arguments: {} });
+		await flush();
+
+		const changes = JSON.parse(firstText(callFrom(t)) ?? "[]");
+		expect(changes).toEqual([
+			{ text: "added", type: "Inserted", author: "Alice" },
+			{ text: "removed", type: "Deleted", author: "Bob" },
+		]);
+		d.dispose();
+	});
+
+	it("insert_paragraph appends at the end by default", async () => {
+		const t = new MockTransport();
+		const doc = fakeWord("body");
+		const d = new HostToolDispatcher(t);
+		registerWordTools(d, doc);
+
+		t.emit({
+			type: "host_tool_call",
+			id: "ip1",
+			toolCallId: "t1",
+			toolName: "insert_paragraph",
+			arguments: { text: "New para" },
+		});
+		await flush();
+
+		expect(callFrom(t)?.isError).toBeUndefined();
+		expect(doc.paragraphInserts).toContainEqual({ text: "New para", location: "End" });
+		d.dispose();
+	});
+
+	it("insert_paragraph maps location to Word insert locations", async () => {
+		const cases: Array<[string, string]> = [
+			["start", "Start"],
+			["end", "End"],
+			["before-selection", "Before"],
+			["after-selection", "After"],
+		];
+		let n = 0;
+		for (const [loc, expected] of cases) {
+			n += 1;
+			const t = new MockTransport();
+			const doc = fakeWord("body");
+			const d = new HostToolDispatcher(t);
+			registerWordTools(d, doc);
+
+			t.emit({
+				type: "host_tool_call",
+				id: `ip-${n}`,
+				toolCallId: `t-${n}`,
+				toolName: "insert_paragraph",
+				arguments: { text: "P", location: loc },
+			});
+			await flush();
+
+			expect(callFrom(t)?.isError).toBeUndefined();
+			expect(doc.paragraphInserts).toContainEqual({ text: "P", location: expected });
+			d.dispose();
+		}
+	});
+
+	it("insert_paragraph with no text answers isError (never hangs)", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerWordTools(d, fakeWord());
+
+		t.emit({ type: "host_tool_call", id: "ip9", toolCallId: "t9", toolName: "insert_paragraph", arguments: {} });
+		await flush();
+
+		const reply = callFrom(t);
+		expect(reply?.isError).toBe(true);
+		expect(firstText(reply)?.toLowerCase()).toContain("text");
+		d.dispose();
+	});
+
+	it("insert_paragraph rejects an unknown location", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerWordTools(d, fakeWord("x"));
+
+		t.emit({
+			type: "host_tool_call",
+			id: "ip10",
+			toolCallId: "t10",
+			toolName: "insert_paragraph",
+			arguments: { text: "y", location: "sideways" },
+		});
+		await flush();
+
+		const reply = callFrom(t);
+		expect(reply?.isError).toBe(true);
+		expect(firstText(reply)?.toLowerCase()).toContain("location");
 		d.dispose();
 	});
 

--- a/packages/office-pane/test/word-tools.test.ts
+++ b/packages/office-pane/test/word-tools.test.ts
@@ -78,8 +78,8 @@ function fakeWord(
 			state.paragraphInserts.push({ text, location });
 		},
 		paragraphs,
-		comments,
-		trackedChanges,
+		getComments: () => comments,
+		getTrackedChanges: () => trackedChanges,
 	};
 	const sections = {
 		items: Array.from({ length: meta.sectionCount ?? 1 }, () => ({})),


### PR DESCRIPTION
## Problem
Closes #2216. Word pane had 2 flat tools (read_document, insert_text). Claude for Word accesses paragraphs with styles, the selection, comments, tracked changes, and sections. Phase 2 of the tool-parity roadmap.

## Change (2 → 8 Word tools)
- **get_document_info** — structural overview (word count, sections, paragraphs, headings with levels, has comments/tracked changes). Prompt tells agent to call FIRST.
- **read_paragraphs** — paragraphs with styles (heading levels), paginated (startIndex + count).
- **read_selection** — current text selection.
- **get_comments** — document comments (content + author).
- **get_tracked_changes** — tracked changes (text + type + author).
- **insert_paragraph** — location-controlled (start/end/before-selection/after-selection).
- **Prompt hint** — TOOLS catalog in the Word host-profile.

## Verification
word-tools **21/0** (13 new); office-pane **286/0**; biome + tsgo clean; browser-safe build **154KB/256KB**. host-profiles **13/0**. TDD throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)