### PR TITLE
feat(office-pane): PowerPoint tool depth — 4 new tools (presentation info, shapes, layout, shape editing)

### DIFF
--- a/packages/coding-agent/src/browser/host-profiles.ts
+++ b/packages/coding-agent/src/browser/host-profiles.ts
@@ -123,6 +123,11 @@ CONTEXT: You can only access the open presentation. Think in slides, shapes, and
 - Make pinpoint, per-slide edits. Do NOT regenerate the whole deck to change one thing.
 - Refer to slides by number so the user can follow along.
 
+TOOLS: Discover the deck before you answer, then reach for the tool that matches the task:
+- Call \`get_presentation_info\` FIRST to discover all slides, their layouts, and shape counts before answering — do not guess the structure.
+- Use \`read_slide_shapes\` to see all shapes on a slide with their text + position, \`read_slide_layout\` for the layout/master applied to a slide, and \`modify_shape_text\` to edit the text of a named shape.
+- Use \`read_slides\` for a quick text-only scan of the whole deck, and \`add_text_box\`/\`add_slide\` to create new content.
+
 BEHAVIOR:
 - Respond concisely with markdown. The task pane is narrow — avoid long code blocks.
 - Read the presentation to answer questions about it; do not guess.

--- a/packages/coding-agent/test/browser/host-profiles.test.ts
+++ b/packages/coding-agent/test/browser/host-profiles.test.ts
@@ -66,6 +66,24 @@ describe("host profiles", () => {
 		expect(t.toLowerCase()).toContain("slide");
 	});
 
+	it("powerpoint prompt advertises the depth-tool catalog and get_presentation_info-first prefetch", () => {
+		const t = HOST_PROFILES.powerpoint.systemPrompt;
+		// Prefetch hint: discover structure first.
+		expect(t).toContain("get_presentation_info");
+		expect(t.toLowerCase()).toContain("first");
+		// Depth + read/write tools are named so the model knows to reach for them.
+		for (const name of [
+			"read_slide_shapes",
+			"read_slide_layout",
+			"modify_shape_text",
+			"read_slides",
+			"add_text_box",
+			"add_slide",
+		]) {
+			expect(t).toContain(name);
+		}
+	});
+
 	it("word prompt thinks in the document", () => {
 		const t = HOST_PROFILES.word.systemPrompt;
 		expect(t).toContain("document");

--- a/packages/office-pane/src/office/powerpoint-tools.ts
+++ b/packages/office-pane/src/office/powerpoint-tools.ts
@@ -15,6 +15,7 @@ import { type AgentToolResult, HostToolDispatcher, type HostToolRegistration, ty
 // --- Minimal structural views of the PowerPoint.run context we depend on. ---
 
 export interface PptTextRangeLike {
+	/** Writable — assign to rewrite the shape's text (modify_shape_text). */
 	text: string;
 }
 export interface PptTextFrameLike {
@@ -24,8 +25,14 @@ export interface PptTextFrameLike {
 	load(properties: string): void;
 }
 export interface PptShapeLike {
+	/** Shape name (e.g. 'Title 1','TextBox 3'); the addressing key for modify_shape_text. */
+	name?: string;
 	/** ShapeType string (e.g. 'textBox','table','group'); tables/groups throw on textFrame access. */
 	type?: string;
+	left?: number;
+	top?: number;
+	width?: number;
+	height?: number;
 	textFrame?: PptTextFrameLike;
 }
 export interface PptShapeCollectionLike {
@@ -34,8 +41,17 @@ export interface PptShapeCollectionLike {
 	/** Add a text box with the given text to the slide. */
 	addTextBox(text: string): PptShapeLike;
 }
+/** A layout or master reference exposing a loadable `name`. */
+export interface PptNamedRefLike {
+	name: string;
+	load(properties: string): void;
+}
 export interface PptSlideLike {
 	shapes: PptShapeCollectionLike;
+	/** The slide layout applied to this slide. */
+	layout: PptNamedRefLike;
+	/** The slide master behind this slide's layout. */
+	slideMaster: PptNamedRefLike;
 }
 export interface PptSlideCollectionLike {
 	items: PptSlideLike[];
@@ -127,6 +143,97 @@ async function readAllSlideText(ppt: PowerPointLike): Promise<string[]> {
 	});
 }
 
+/** A single slide's structural summary in {@link readPresentationInfo}. */
+export interface SlideSummary {
+	index: number;
+	layoutName: string;
+	shapesCount: number;
+}
+
+/** Structural overview of the whole deck: slide count + per-slide layout/shape counts. */
+async function readPresentationInfo(ppt: PowerPointLike): Promise<{ slideCount: number; slides: SlideSummary[] }> {
+	return ppt.run(async ctx => {
+		const slides = ctx.presentation.slides;
+		slides.load("items");
+		await ctx.sync();
+
+		for (const slide of slides.items) {
+			slide.layout.load("name");
+			slide.shapes.load("items");
+		}
+		await ctx.sync();
+
+		return {
+			slideCount: slides.items.length,
+			slides: slides.items.map((slide, index) => ({
+				index,
+				layoutName: slide.layout?.name ?? "",
+				shapesCount: slide.shapes.items.length,
+			})),
+		};
+	});
+}
+
+/** A single shape's detail in {@link readSlideShapes}. */
+export interface ShapeDetail {
+	name: string;
+	type: string;
+	text?: string;
+	left: number;
+	top: number;
+	width: number;
+	height: number;
+}
+
+/** Read every shape on a slide with its name, type, text (when text-bearing), and geometry. */
+async function readSlideShapes(ppt: PowerPointLike, slideIndex: number): Promise<ShapeDetail[]> {
+	return ppt.run(async ctx => {
+		const slide = ctx.presentation.slides.getItemAt(slideIndex);
+		slide.shapes.load("items/name,type,left,top,width,height");
+		await ctx.sync();
+
+		const shapes = slide.shapes.items;
+		// Only load text for text-bearing shapes; a table's textFrame throws at sync.
+		for (const shape of shapes) {
+			if (!NON_TEXT_SHAPE_TYPES.has(shape.type ?? "")) {
+				shape.textFrame?.load("hasText,textRange/text");
+			}
+		}
+		await ctx.sync();
+
+		return shapes.map(shape => {
+			const textual = !NON_TEXT_SHAPE_TYPES.has(shape.type ?? "") && shape.textFrame?.hasText;
+			const text = textual ? (shape.textFrame?.textRange?.text ?? "") : "";
+			const detail: ShapeDetail = {
+				name: shape.name ?? "",
+				type: shape.type ?? "",
+				left: shape.left ?? 0,
+				top: shape.top ?? 0,
+				width: shape.width ?? 0,
+				height: shape.height ?? 0,
+			};
+			if (text.trim().length > 0) {
+				detail.text = text;
+			}
+			return detail;
+		});
+	});
+}
+
+/** Read the layout + master names applied to a slide. */
+async function readSlideLayout(
+	ppt: PowerPointLike,
+	slideIndex: number,
+): Promise<{ layoutName: string; masterName: string }> {
+	return ppt.run(async ctx => {
+		const slide = ctx.presentation.slides.getItemAt(slideIndex);
+		slide.layout.load("name");
+		slide.slideMaster.load("name");
+		await ctx.sync();
+		return { layoutName: slide.layout?.name ?? "", masterName: slide.slideMaster?.name ?? "" };
+	});
+}
+
 /**
  * Build the PowerPoint host-tool registrations. Pass to
  * {@link HostToolDispatcher.register} or use {@link registerPowerPointTools}.
@@ -147,6 +254,127 @@ export function createPowerPointHostTools(ppt: PowerPointLike = getPowerPoint())
 					throw new Error(describePptError("read_slides", err));
 				}
 				return textResult(JSON.stringify(slides), { slides });
+			},
+		},
+		{
+			definition: {
+				name: "get_presentation_info",
+				description:
+					"Structural overview of the open presentation: slide count and, per slide, its 0-based index, layout name, and shape count. Call this FIRST to discover the deck.",
+				parameters: { type: "object", properties: {} },
+			},
+			handler: async () => {
+				let info: { slideCount: number; slides: SlideSummary[] };
+				try {
+					info = await readPresentationInfo(ppt);
+				} catch (err) {
+					throw new Error(describePptError("get_presentation_info", err));
+				}
+				return textResult(JSON.stringify(info), info);
+			},
+		},
+		{
+			definition: {
+				name: "read_slide_shapes",
+				description:
+					"Read every shape on a slide (by 0-based slideIndex) with its name, type, text (when text-bearing), and geometry (left/top/width/height).",
+				parameters: {
+					type: "object",
+					properties: {
+						slideIndex: { type: "number", description: "0-based slide index to read." },
+					},
+					required: ["slideIndex"],
+				},
+			},
+			handler: async args => {
+				if (typeof args.slideIndex !== "number") {
+					throw new Error('read_slide_shapes requires a numeric "slideIndex"');
+				}
+				let shapes: ShapeDetail[];
+				try {
+					shapes = await readSlideShapes(ppt, args.slideIndex);
+				} catch (err) {
+					throw new Error(describePptError("read_slide_shapes", err));
+				}
+				return textResult(JSON.stringify(shapes), { shapes });
+			},
+		},
+		{
+			definition: {
+				name: "read_slide_layout",
+				description: "Read the layout name and slide-master name applied to a slide (by 0-based slideIndex).",
+				parameters: {
+					type: "object",
+					properties: {
+						slideIndex: { type: "number", description: "0-based slide index to inspect." },
+					},
+					required: ["slideIndex"],
+				},
+			},
+			handler: async args => {
+				if (typeof args.slideIndex !== "number") {
+					throw new Error('read_slide_layout requires a numeric "slideIndex"');
+				}
+				let layout: { layoutName: string; masterName: string };
+				try {
+					layout = await readSlideLayout(ppt, args.slideIndex);
+				} catch (err) {
+					throw new Error(describePptError("read_slide_layout", err));
+				}
+				return textResult(JSON.stringify(layout), layout);
+			},
+		},
+		{
+			definition: {
+				name: "modify_shape_text",
+				description:
+					"Replace the text of an existing shape on a slide, addressed by its name (from read_slide_shapes/get_presentation_info).",
+				parameters: {
+					type: "object",
+					properties: {
+						slideIndex: { type: "number", description: "0-based slide index containing the shape." },
+						shapeName: { type: "string", description: "The name of the shape to edit." },
+						text: { type: "string", description: "The new text for the shape." },
+					},
+					required: ["slideIndex", "shapeName", "text"],
+				},
+			},
+			handler: async args => {
+				if (typeof args.slideIndex !== "number") {
+					throw new Error('modify_shape_text requires a numeric "slideIndex"');
+				}
+				const shapeName = typeof args.shapeName === "string" ? args.shapeName : "";
+				if (!shapeName.trim()) {
+					throw new Error('modify_shape_text requires a non-empty "shapeName"');
+				}
+				if (typeof args.text !== "string") {
+					throw new Error('modify_shape_text requires a "text" string');
+				}
+				const text = args.text;
+				const slideIndex = args.slideIndex;
+				try {
+					await ppt.run(async ctx => {
+						const slide = ctx.presentation.slides.getItemAt(slideIndex);
+						slide.shapes.load("items/name");
+						await ctx.sync();
+						const shape = slide.shapes.items.find(s => s.name === shapeName);
+						if (!shape) {
+							throw new Error(`no shape named "${shapeName}" on slide ${slideIndex}`);
+						}
+						if (!shape.textFrame) {
+							throw new Error(`shape "${shapeName}" on slide ${slideIndex} has no text frame`);
+						}
+						shape.textFrame.textRange.text = text;
+						await ctx.sync();
+					});
+				} catch (err) {
+					throw new Error(describePptError("modify_shape_text", err));
+				}
+				return textResult(`Set the text of shape "${shapeName}" on slide ${slideIndex}.`, {
+					slideIndex,
+					shapeName,
+					text,
+				});
 			},
 		},
 		{

--- a/packages/office-pane/test/powerpoint-tools.test.ts
+++ b/packages/office-pane/test/powerpoint-tools.test.ts
@@ -15,18 +15,38 @@ import {
 } from "../src/office/powerpoint-tools";
 
 interface FakeShape {
+	name: string;
 	type: string;
+	left: number;
+	top: number;
+	width: number;
+	height: number;
 	textFrame?: { hasText: boolean; textRange: { text: string }; load(props: string): void };
 }
 interface FakeSlide {
 	shapes: FakeShape[];
+	layoutName: string;
+	masterName: string;
 }
 
-/** In-memory PowerPoint.run fake: slides = arrays of shape texts. */
+/**
+ * In-memory PowerPoint.run fake: slides = arrays of shape texts. Each shape is
+ * auto-named ("Shape 1", "Shape 2", …) with deterministic geometry; each slide
+ * gets a distinct layout name ("Layout 0", …) and a shared master so the depth
+ * tools (get_presentation_info / read_slide_layout / read_slide_shapes /
+ * modify_shape_text) are exercisable without an Office runtime.
+ */
 function fakePpt(initial: string[][] = []): PowerPointLike & { slides: FakeSlide[]; selectedIndex: number } {
-	const slides: FakeSlide[] = initial.map(texts => ({
-		shapes: texts.map(t => ({
+	const slides: FakeSlide[] = initial.map((texts, si) => ({
+		layoutName: `Layout ${si}`,
+		masterName: "Office Theme",
+		shapes: texts.map((t, i) => ({
+			name: `Shape ${i + 1}`,
 			type: "textBox",
+			left: i * 10,
+			top: i * 20,
+			width: 100,
+			height: 50,
 			textFrame: { hasText: t.length > 0, textRange: { text: t }, load() {} },
 		})),
 	}));
@@ -38,12 +58,24 @@ function fakePpt(initial: string[][] = []): PowerPointLike & { slides: FakeSlide
 		},
 		load(_p: string) {},
 		addTextBox(text: string): FakeShape {
-			const shape: FakeShape = { type: "textBox", textFrame: { hasText: true, textRange: { text }, load() {} } };
+			const shape: FakeShape = {
+				name: `Shape ${slide.shapes.length + 1}`,
+				type: "textBox",
+				left: 0,
+				top: 0,
+				width: 100,
+				height: 50,
+				textFrame: { hasText: true, textRange: { text }, load() {} },
+			};
 			slide.shapes.push(shape);
 			return shape;
 		},
 	});
-	const slideView = (slide: FakeSlide) => ({ shapes: shapeCollection(slide) });
+	const slideView = (slide: FakeSlide) => ({
+		shapes: shapeCollection(slide),
+		layout: { name: slide.layoutName, load(_p: string) {} },
+		slideMaster: { name: slide.masterName, load(_p: string) {} },
+	});
 
 	return {
 		...box,
@@ -56,7 +88,7 @@ function fakePpt(initial: string[][] = []): PowerPointLike & { slides: FakeSlide
 						},
 						load(_p: string) {},
 						add() {
-							slides.push({ shapes: [] });
+							slides.push({ shapes: [], layoutName: `Layout ${slides.length}`, masterName: "Office Theme" });
 						},
 						getItemAt(i: number) {
 							return slideView(slides[i] as FakeSlide);
@@ -86,19 +118,29 @@ function flush(): Promise<void> {
 }
 
 describe("powerpoint-tools", () => {
-	it("advertises read_slides, add_text_box, add_slide", () => {
+	const ALL_TOOL_NAMES = [
+		"add_slide",
+		"add_text_box",
+		"get_presentation_info",
+		"modify_shape_text",
+		"read_slide_layout",
+		"read_slide_shapes",
+		"read_slides",
+	];
+
+	it("advertises the read/write + depth tools", () => {
 		const names = createPowerPointHostTools(fakePpt())
 			.map(t => t.definition.name)
 			.sort();
-		expect(names).toEqual(["add_slide", "add_text_box", "read_slides"]);
+		expect(names).toEqual(ALL_TOOL_NAMES);
 	});
 
-	it("registerPowerPointTools pushes the three tools via set_host_tools", () => {
+	it("registerPowerPointTools pushes every tool via set_host_tools", () => {
 		const t = new MockTransport();
 		const d = new HostToolDispatcher(t);
 		registerPowerPointTools(d, fakePpt());
 		const frame = t.sent.find(m => m.type === "set_host_tools") as SetHostToolsMsg | undefined;
-		expect(frame?.tools.map(x => x.name).sort()).toEqual(["add_slide", "add_text_box", "read_slides"]);
+		expect(frame?.tools.map(x => x.name).sort()).toEqual(ALL_TOOL_NAMES);
 		d.dispose();
 	});
 
@@ -258,6 +300,214 @@ describe("powerpoint-tools", () => {
 		expect(txt).toContain("read_slides");
 		expect(txt).toContain("GeneralException");
 		expect(txt).toContain("errorLocation");
+		d.dispose();
+	});
+
+	it("get_presentation_info returns slide count + per-slide layout and shape counts", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerPowerPointTools(d, fakePpt([["Title A", "Body A"], ["Title B"]]));
+
+		t.emit({ type: "host_tool_call", id: "gi", toolCallId: "tgi", toolName: "get_presentation_info", arguments: {} });
+		await flush();
+
+		const reply = callFrom(t);
+		expect(reply?.isError).toBeUndefined();
+		const info = JSON.parse(firstText(reply) ?? "{}");
+		expect(info.slideCount).toBe(2);
+		expect(info.slides).toHaveLength(2);
+		expect(info.slides[0]).toMatchObject({ index: 0, layoutName: "Layout 0", shapesCount: 2 });
+		expect(info.slides[1]).toMatchObject({ index: 1, layoutName: "Layout 1", shapesCount: 1 });
+		d.dispose();
+	});
+
+	it("read_slide_shapes returns each shape's name, type, text, and geometry", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerPowerPointTools(d, fakePpt([["Hello"], ["Only slide 1", "Second box"]]));
+
+		t.emit({
+			type: "host_tool_call",
+			id: "rs",
+			toolCallId: "trs",
+			toolName: "read_slide_shapes",
+			arguments: { slideIndex: 1 },
+		});
+		await flush();
+
+		const reply = callFrom(t);
+		expect(reply?.isError).toBeUndefined();
+		const shapes = JSON.parse(firstText(reply) ?? "[]");
+		expect(shapes).toHaveLength(2);
+		expect(shapes[0]).toMatchObject({ name: "Shape 1", type: "textBox", text: "Only slide 1", left: 0, top: 0 });
+		expect(shapes[1]).toMatchObject({ name: "Shape 2", text: "Second box", left: 10, top: 20 });
+		d.dispose();
+	});
+
+	it("read_slide_shapes skips a table's textFrame but still lists the shape", async () => {
+		const t = new MockTransport();
+		let touchedTableTextFrame = false;
+		const withTable: PowerPointLike = {
+			run: async batch => {
+				const tableShape = {
+					name: "Table 1",
+					type: "table",
+					left: 5,
+					top: 6,
+					width: 200,
+					height: 100,
+					get textFrame() {
+						touchedTableTextFrame = true;
+						throw new Error("InvalidArgument");
+					},
+				};
+				const textShape = {
+					name: "Body 1",
+					type: "textBox",
+					left: 1,
+					top: 2,
+					width: 3,
+					height: 4,
+					textFrame: { hasText: true, textRange: { text: "Real content" }, load() {} },
+				};
+				const slide = {
+					shapes: { items: [tableShape, textShape], load() {}, addTextBox() {} },
+					layout: { name: "L", load() {} },
+					slideMaster: { name: "M", load() {} },
+				};
+				const ctx = {
+					presentation: {
+						slides: { items: [slide], load() {}, add() {}, getItemAt: () => slide },
+						getSelectedSlides: () => ({ getItemAt: () => slide }),
+					},
+					sync: async () => {},
+				};
+				return batch(ctx as unknown as PptContextLike);
+			},
+		};
+		const d = new HostToolDispatcher(t);
+		registerPowerPointTools(d, withTable);
+
+		t.emit({
+			type: "host_tool_call",
+			id: "rst",
+			toolCallId: "trst",
+			toolName: "read_slide_shapes",
+			arguments: { slideIndex: 0 },
+		});
+		await flush();
+
+		const reply = callFrom(t);
+		expect(reply?.isError).toBeUndefined();
+		const shapes = JSON.parse(firstText(reply) ?? "[]");
+		expect(shapes).toHaveLength(2);
+		expect(shapes[0]).toMatchObject({ name: "Table 1", type: "table" });
+		expect(shapes[0].text).toBeUndefined();
+		expect(shapes[1]).toMatchObject({ name: "Body 1", text: "Real content" });
+		expect(touchedTableTextFrame).toBe(false);
+		d.dispose();
+	});
+
+	it("read_slide_shapes requires a numeric slideIndex", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerPowerPointTools(d, fakePpt([["x"]]));
+
+		t.emit({
+			type: "host_tool_call",
+			id: "rsi",
+			toolCallId: "trsi",
+			toolName: "read_slide_shapes",
+			arguments: {},
+		});
+		await flush();
+
+		const reply = callFrom(t);
+		expect(reply?.isError).toBe(true);
+		expect(firstText(reply)?.toLowerCase()).toContain("slideindex");
+		d.dispose();
+	});
+
+	it("read_slide_layout returns the layout and master names for a slide", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerPowerPointTools(d, fakePpt([["a"], ["b"]]));
+
+		t.emit({
+			type: "host_tool_call",
+			id: "rl",
+			toolCallId: "trl",
+			toolName: "read_slide_layout",
+			arguments: { slideIndex: 1 },
+		});
+		await flush();
+
+		const reply = callFrom(t);
+		expect(reply?.isError).toBeUndefined();
+		const layout = JSON.parse(firstText(reply) ?? "{}");
+		expect(layout).toMatchObject({ layoutName: "Layout 1", masterName: "Office Theme" });
+		d.dispose();
+	});
+
+	it("modify_shape_text rewrites the text of a named shape", async () => {
+		const t = new MockTransport();
+		const ppt = fakePpt([["Old title"], ["untouched"]]);
+		const d = new HostToolDispatcher(t);
+		registerPowerPointTools(d, ppt);
+
+		t.emit({
+			type: "host_tool_call",
+			id: "ms",
+			toolCallId: "tms",
+			toolName: "modify_shape_text",
+			arguments: { slideIndex: 0, shapeName: "Shape 1", text: "New title" },
+		});
+		await flush();
+
+		const reply = callFrom(t);
+		expect(reply?.isError).toBeUndefined();
+		expect(ppt.slides[0]?.shapes[0]?.textFrame?.textRange.text).toBe("New title");
+		expect(ppt.slides[1]?.shapes[0]?.textFrame?.textRange.text).toBe("untouched");
+		d.dispose();
+	});
+
+	it("modify_shape_text errors when no shape matches the name", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerPowerPointTools(d, fakePpt([["Only shape"]]));
+
+		t.emit({
+			type: "host_tool_call",
+			id: "mm",
+			toolCallId: "tmm",
+			toolName: "modify_shape_text",
+			arguments: { slideIndex: 0, shapeName: "Nope", text: "x" },
+		});
+		await flush();
+
+		const reply = callFrom(t);
+		expect(reply?.isError).toBe(true);
+		expect(firstText(reply)).toContain("Nope");
+		d.dispose();
+	});
+
+	it("modify_shape_text requires slideIndex, shapeName, and text", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerPowerPointTools(d, fakePpt([["Shape here"]]));
+
+		t.emit({
+			type: "host_tool_call",
+			id: "mv",
+			toolCallId: "tmv",
+			toolName: "modify_shape_text",
+			arguments: { slideIndex: 0, shapeName: "Shape 1" },
+		});
+		await flush();
+
+		const reply = callFrom(t);
+		expect(reply?.isError).toBe(true);
+		expect(firstText(reply)?.toLowerCase()).toContain("text");
 		d.dispose();
 	});
 


### PR DESCRIPTION
## Problem
Closes #2220. PPT pane had 3 basic tools. Claude for PPT accesses slide layouts, masters, shapes with details, and edits existing shapes. Phase 3 of the tool-parity roadmap.

## Change (3 → 7 PPT tools)
- **get_presentation_info** — slide count + per-slide layout name + shape count. Prompt: call FIRST.
- **read_slide_shapes** — all shapes on a slide (name, type, text, position/size).
- **read_slide_layout** — layout + master name for a slide.
- **modify_shape_text** — edit text in a named shape.
- **Prompt hint** — TOOLS catalog in the PPT host-profile.

## Verification
powerpoint-tools **18/0** (9 new); office-pane **283/0**; biome + tsgo clean; browser-safe build **153.8KB/256KB**. host-profiles **13/0**. TDD throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)