### PR TITLE
feat(engine): host-authoritative behavior + port-collision fix + principled behavior eval

### DIFF
--- a/packages/coding-agent/src/browser/capabilities.generated.ts
+++ b/packages/coding-agent/src/browser/capabilities.generated.ts
@@ -26,7 +26,7 @@ export interface ExtensionCapabilities {
 
 export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 	"version": "0.1.0",
-	"contractVersion": "1.10.0",
+	"contractVersion": "1.11.0",
 	"multiPortDiscovery": true,
 	"protocol": "tool_request/result",
 	"tools": [
@@ -786,6 +786,29 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 		}
 	],
 	"features": {
+		"handshake": {
+			"serveKind": [
+				"office",
+				"browser"
+			],
+			"officePortRange": [
+				19242,
+				19261
+			],
+			"officeWssPortRange": [
+				19342,
+				19361
+			],
+			"browserPortRange": [
+				19222,
+				19241
+			],
+			"browserWssPortRange": [
+				19322,
+				19341
+			],
+			"description": "hello_ack advertises serveKind — how the bridge was STARTED (office-serve vs Chrome worker), distinct from the client's announced host. `xcsh office serve` binds the dedicated office port range and advertises serveKind:\"office\"; the Chrome worker binds the browser range and advertises \"browser\". The Office pane scans only the office wss range AND filters on serveKind:\"office\", so it can never adopt a Chrome worker (a serveKind absent/null is treated as ineligible)."
+		},
 		"explainMode": {
 			"tool": "set_explain_mode",
 			"default": false,
@@ -855,6 +878,6 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 	}
 };
 
-export const EXTENSION_CONTRACT_VERSION = "1.10.0";
+export const EXTENSION_CONTRACT_VERSION = "1.11.0";
 
 export const EXTENSION_TOOL_NAMES: readonly string[] = ["ping","capabilities","reload","debug_exec","detach","set_bridge_port","navigate","login","scroll_to","resize_window","tabs_list","tabs_create","tabs_close","click","click_element","click_xy","type_text","form_input","key_press","select_option","label_select","file_upload","read_ax","get_page_text","query_dom","find","wait_for","assert_text","screenshot","read_console","read_network","diag_suspension","diag_bridges","diag_activation","diag_ttft","capture_login_flow","wait_for_api_response","get_page_context","javascript_tool","browser_batch","set_explain_mode","annotate"];

--- a/packages/coding-agent/src/browser/capabilities.json
+++ b/packages/coding-agent/src/browser/capabilities.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "contractVersion": "1.10.0",
+  "contractVersion": "1.11.0",
   "multiPortDiscovery": true,
   "protocol": "tool_request/result",
   "tools": [
@@ -703,6 +703,14 @@
     }
   ],
   "features": {
+    "handshake": {
+      "serveKind": ["office", "browser"],
+      "officePortRange": [19242, 19261],
+      "officeWssPortRange": [19342, 19361],
+      "browserPortRange": [19222, 19241],
+      "browserWssPortRange": [19322, 19341],
+      "description": "hello_ack advertises serveKind — how the bridge was STARTED (office-serve vs Chrome worker), distinct from the client's announced host. `xcsh office serve` binds the dedicated office port range and advertises serveKind:\"office\"; the Chrome worker binds the browser range and advertises \"browser\". The Office pane scans only the office wss range AND filters on serveKind:\"office\", so it can never adopt a Chrome worker (a serveKind absent/null is treated as ineligible)."
+    },
     "explainMode": {
       "tool": "set_explain_mode",
       "default": false,

--- a/packages/coding-agent/src/browser/chat-conformance.json
+++ b/packages/coding-agent/src/browser/chat-conformance.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": "1.10.0",
+  "contractVersion": "1.11.0",
   "schemas": {
     "chat_request": {
       "type": "object",

--- a/packages/coding-agent/src/browser/extension-bridge.ts
+++ b/packages/coding-agent/src/browser/extension-bridge.ts
@@ -69,9 +69,36 @@ export function resolvePort(port?: number): number {
 	return DEFAULT_PORT;
 }
 
-/** Inclusive loopback discovery range for auto-selected bridge ports. */
+/** Inclusive loopback discovery range for auto-selected bridge ports (Chrome worker). */
 export const PORT_RANGE_START = 19222;
 export const PORT_RANGE_END = 19241;
+
+/**
+ * Dedicated loopback ws range for `xcsh office serve` bridges — DISJOINT from the
+ * Chrome worker range above. Its paired wss listeners land at +{@link WSS_PORT_OFFSET}
+ * (19342–19361). Giving office-serve its own range means a Chrome worker and an
+ * office bridge can never contend for a port, so the office pane (which scans only
+ * the office wss range) can never adopt a Chrome worker. The Chrome fleet's range
+ * is UNCHANGED — zero blast radius on browser automation.
+ */
+export const OFFICE_PORT_RANGE_START = 19242;
+export const OFFICE_PORT_RANGE_END = 19261;
+
+/** An inclusive port range for auto-select. */
+export interface PortRange {
+	start: number;
+	end: number;
+}
+
+/** The Chrome-worker auto-select range (the default). */
+export const CHROME_PORT_RANGE: PortRange = { start: PORT_RANGE_START, end: PORT_RANGE_END };
+
+/** The office-serve auto-select range. */
+export const OFFICE_PORT_RANGE: PortRange = { start: OFFICE_PORT_RANGE_START, end: OFFICE_PORT_RANGE_END };
+
+/** How a bridge was STARTED — its intrinsic scope (distinct from the connecting
+ * client's announced host). Echoed in hello_ack so the office pane can filter. */
+export type ServeKind = "office" | "browser";
 
 /**
  * Fixed offset from a bound ws port to its paired `wss` port. The wss listener is
@@ -140,12 +167,14 @@ export interface BridgeListenOpts {
 	skipOriginCheck?: boolean;
 	/** When present, an additive `wss` listener is started on port + {@link WSS_PORT_OFFSET}. */
 	tls?: BridgeTls;
+	/** Auto-select range for {@link startBridgeServer}; defaults to {@link CHROME_PORT_RANGE}. */
+	range?: PortRange;
 }
 
-/** Every port in the discovery range, lowest first. */
-export function portCandidates(): number[] {
+/** Every port in the given range (default {@link CHROME_PORT_RANGE}), lowest first. */
+export function portCandidates(range: PortRange = CHROME_PORT_RANGE): number[] {
 	const out: number[] = [];
-	for (let p = PORT_RANGE_START; p <= PORT_RANGE_END; p++) out.push(p);
+	for (let p = range.start; p <= range.end; p++) out.push(p);
 	return out;
 }
 
@@ -181,6 +210,10 @@ export class BridgeServer {
 	/** The client host learned from the `hello` handshake (null until a client
 	 * announces one; the Chrome extension omits it → stays null → chrome profile). */
 	#clientHost: ClientHost | null = null;
+	/** How THIS bridge was started (its intrinsic scope). Defaults to "browser" (the
+	 * Chrome worker); office-serve calls {@link setServeKind}("office"). Echoed in
+	 * hello_ack so the office pane's discovery filter never adopts a Chrome worker. */
+	#serveKind: ServeKind = "browser";
 	/** Provider of this process's tenant identity, answering the `hello` handshake. */
 	#sessionInfo:
 		| (() => {
@@ -211,6 +244,17 @@ export class BridgeServer {
 	 * client announces one). Read by the ChatHandler to pick the host-aware prompt. */
 	get clientHost(): ClientHost | null {
 		return this.#clientHost;
+	}
+
+	/** How this bridge was started ("browser" by default; "office" for office-serve). */
+	get serveKind(): ServeKind {
+		return this.#serveKind;
+	}
+
+	/** Declare this bridge's intrinsic scope. Called once at startup by the host
+	 * bootstrap (office-serve → "office"; the Chrome worker → "browser"). */
+	setServeKind(kind: ServeKind): void {
+		this.#serveKind = kind;
 	}
 
 	/** Number of connected extension clients (channels). */
@@ -412,6 +456,7 @@ export class BridgeServer {
 					apiUrl: info.apiUrl,
 					contextBound: info.contextBound,
 					host: this.#clientHost,
+					serveKind: this.#serveKind,
 					pid: process.pid,
 					wssPort: this.wssPort,
 					canConfigureProvider: true,
@@ -488,8 +533,9 @@ export async function startBridgeServer(port?: number, opts?: BridgeListenOpts):
 		}
 		return server;
 	}
-	for (const candidate of portCandidates()) {
+	const range = opts?.range ?? CHROME_PORT_RANGE;
+	for (const candidate of portCandidates(range)) {
 		if (server.listen(candidate, opts)) return server;
 	}
-	throw new Error(`no free xcsh bridge port in ${PORT_RANGE_START}-${PORT_RANGE_END} — is another app on the range?`);
+	throw new Error(`no free xcsh bridge port in ${range.start}-${range.end} — is another app on the range?`);
 }

--- a/packages/coding-agent/src/browser/headless-bridge.ts
+++ b/packages/coding-agent/src/browser/headless-bridge.ts
@@ -20,7 +20,7 @@ import { ContextService } from "../services/xcsh-context";
 import { deriveTenantEnv } from "../services/xcsh-env";
 import { resolveBridgeTls } from "./bridge-cert";
 import { ChatHandler } from "./chat-handler";
-import { type BridgeServer, startBridgeServer } from "./extension-bridge";
+import { type BridgeServer, OFFICE_PORT_RANGE, startBridgeServer } from "./extension-bridge";
 import { OFFICE_TOOL_NAMES } from "./extension-bridge-tools";
 import { setSharedBridgeServer } from "./provider";
 
@@ -110,7 +110,13 @@ export async function startHeadlessChatBridge(deps: HeadlessBridgeDeps = default
 	// Provision the wss cert before binding (warm boot = on-disk cache hit);
 	// `undefined` (offline) → the bridge starts ws-only.
 	const tls = await deps.resolveBridgeTls();
-	const bridge = await deps.startBridgeServer(undefined, tls ? { tls } : undefined);
+	// Office-serve binds the DEDICATED office range (disjoint from the Chrome worker
+	// range) so the two can never collide on a port.
+	const bridge = await deps.startBridgeServer(undefined, { ...(tls ? { tls } : {}), range: OFFICE_PORT_RANGE });
+	// Advertise this bridge's intrinsic scope UNCONDITIONALLY so the office pane's
+	// discovery filter (requireServeKind:"office") can adopt it and never a Chrome
+	// worker — the starvation-guard the port-isolation UAT pins.
+	bridge.setServeKind("office");
 	// Reuse this bridge for any in-process selectProvider() (no conflicting second bridge).
 	deps.setSharedBridgeServer(bridge);
 	bridge.setSessionInfo(sessionInfoForOfficeServe);

--- a/packages/coding-agent/src/browser/host-profiles.ts
+++ b/packages/coding-agent/src/browser/host-profiles.ts
@@ -45,7 +45,8 @@ export interface HostProfile {
  * chat (not the CLI TUI). Tells the LLM it's in a Chrome side panel alongside the
  * F5 XC console, what tools it has, and how to behave differently from the CLI.
  */
-export const CHROME_CHAT_SYSTEM_PROMPT = `[System: You are xcsh, an AI assistant for the F5 Distributed Cloud console, running as a Chrome browser side panel — not a terminal CLI.
+export const CHROME_CHAT_SYSTEM_PROMPT = `<system-directive>
+You are still xcsh, the F5 Distributed Cloud technical coworker defined in your role above; this session is a Chrome side panel alongside the F5 XC console — an additional surface, not a new identity. Keep your xcsh/F5 purpose and adopt this browser context on top of it.
 
 CRITICAL: ALWAYS respond with TEXT FIRST. Do NOT jump straight to tool calls. The user sees a chat panel and expects a conversational text response, not silence while tools run in the background. For questions ("what page am I on?", "what is this?"), answer with text using the page context below — no tools needed. Only use tools when the user explicitly asks you to DO something (create, navigate, click, modify).
 
@@ -79,7 +80,8 @@ SAFETY — NEVER DO THESE:
 - NEVER kill, stop, or manage processes on port 19222 — that is YOUR OWN bridge. Killing it kills you.
 - NEVER run lsof, fuser, kill, or pkill on the bridge port. You ARE the bridge.
 - NEVER use bash/shell tools to manage xcsh processes, ports, or the debugger connection.
-- NEVER run commands that would terminate your own process or the WebSocket server.]
+- NEVER run commands that would terminate your own process or the WebSocket server.
+</system-directive>
 
 `;
 
@@ -88,7 +90,8 @@ SAFETY — NEVER DO THESE:
  * via host tools (arriving at runtime over the bridge), thinking in cells,
  * ranges, and formula dependencies.
  */
-const EXCEL_CHAT_SYSTEM_PROMPT = `[System: You are xcsh, an AI assistant running as a task pane inside Microsoft Excel — not a terminal CLI. You help the user with the OPEN workbook using the Excel host tools available to you.
+const EXCEL_CHAT_SYSTEM_PROMPT = `<system-directive>
+You are still xcsh, the F5 Distributed Cloud technical coworker defined in your role above. This session reaches you through a Microsoft Excel task pane instead of the terminal — an additional surface, not a new identity. Help the F5 SE with the OPEN workbook (often demo data, MEDDPICC sheets, account plans, pricing models) using the Excel host tools available to you. Keep your xcsh/F5 purpose AND adopt the Excel context on top of it.
 
 CRITICAL: ALWAYS respond with TEXT FIRST — the user sees a chat pane and expects a conversational reply, not silence while tools run. Answer questions from the data you read; only WRITE to the workbook when the user asks you to.
 
@@ -106,7 +109,8 @@ TOOLS: Discover the workbook before you answer, then reach for the tool that mat
 BEHAVIOR:
 - Respond concisely with markdown. The task pane is narrow — avoid long code blocks.
 - Read the workbook to answer questions about its data; do not guess.
-- Make edits only when asked, one clear change at a time, and say what you changed and where.]
+- Make edits only when asked, one clear change at a time, and say what you changed and where.
+</system-directive>
 
 `;
 
@@ -114,7 +118,8 @@ BEHAVIOR:
  * PowerPoint task-pane self-awareness prompt. The assistant works the OPEN
  * presentation via host tools, thinking in slides, shapes, and the slide master.
  */
-const POWERPOINT_CHAT_SYSTEM_PROMPT = `[System: You are xcsh, an AI assistant running as a task pane inside Microsoft PowerPoint — not a terminal CLI. You help the user with the OPEN presentation using the PowerPoint host tools available to you.
+const POWERPOINT_CHAT_SYSTEM_PROMPT = `<system-directive>
+You are still xcsh, the F5 Distributed Cloud technical coworker defined in your role above. This session reaches you through a Microsoft PowerPoint task pane instead of the terminal — an additional surface, not a new identity. Help the F5 SE with the OPEN presentation (often a customer deck, demo walkthrough, or QBR) using the PowerPoint host tools available to you. Keep your xcsh/F5 purpose AND adopt the PowerPoint context on top of it.
 
 CRITICAL: ALWAYS respond with TEXT FIRST — the user sees a chat pane and expects a conversational reply, not silence while tools run. Answer questions from what you read; only edit the deck when the user asks you to.
 
@@ -131,7 +136,8 @@ TOOLS: Discover the deck before you answer, then reach for the tool that matches
 BEHAVIOR:
 - Respond concisely with markdown. The task pane is narrow — avoid long code blocks.
 - Read the presentation to answer questions about it; do not guess.
-- Make edits only when asked, one clear change at a time, and say which slide you changed.]
+- Make edits only when asked, one clear change at a time, and say which slide you changed.
+</system-directive>
 
 `;
 
@@ -140,7 +146,8 @@ BEHAVIOR:
  * via host tools, thinking in paragraphs, the selection, comments, and tracked
  * changes.
  */
-const WORD_CHAT_SYSTEM_PROMPT = `[System: You are xcsh, an AI assistant running as a task pane inside Microsoft Word — not a terminal CLI. You help the user with the OPEN document using the Word host tools available to you.
+const WORD_CHAT_SYSTEM_PROMPT = `<system-directive>
+You are still xcsh, the F5 Distributed Cloud technical coworker defined in your role above. This session reaches you through a Microsoft Word task pane instead of the terminal — an additional surface, not a new identity. Help the F5 SE with the OPEN document (often a proposal, SOW, discovery write-up, or technical brief) using the Word host tools available to you. Keep your xcsh/F5 purpose AND adopt the Word context on top of it.
 
 CRITICAL: ALWAYS respond with TEXT FIRST — the user sees a chat pane and expects a conversational reply, not silence while tools run. Answer questions from what you read; only edit the document when the user asks you to.
 
@@ -158,7 +165,8 @@ TOOLS: Discover the document before you answer, then reach for the tool that mat
 BEHAVIOR:
 - Respond concisely with markdown. The task pane is narrow — avoid long code blocks.
 - Read the document to answer questions about it; do not guess.
-- Make edits only when asked, one clear change at a time, and say what you changed.]
+- Make edits only when asked, one clear change at a time, and say what you changed.
+</system-directive>
 
 `;
 

--- a/packages/coding-agent/src/commands/worker.ts
+++ b/packages/coding-agent/src/commands/worker.ts
@@ -152,6 +152,9 @@ export default class Worker extends Command {
 			`[xcsh worker] extension bridge listening on ws://127.0.0.1:${bridge.port}` +
 				(bridge.wssPort ? ` + wss://${LOCALIP_HOST}:${bridge.wssPort}` : ""),
 		);
+		// This is the Chrome-extension worker: advertise "browser" so the office pane's
+		// serveKind filter never adopts it (explicit; "browser" is also the default).
+		bridge.setServeKind("browser");
 		setSharedBridgeServer(bridge);
 		bridge.setSessionInfo(sessionInfoForWorker);
 		ContextService.onContextChange(() => bridge.broadcastTenantChanged());

--- a/packages/coding-agent/test/browser/chat-handler.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.test.ts
@@ -107,7 +107,7 @@ describe("composeChatPrompt", () => {
 		const chrome = composeChatPrompt("hi", null, "educational", "chrome");
 		const legacy = composeChatPrompt("hi", null, "educational", null);
 		expect(chrome).toBe(legacy);
-		expect(chrome).toContain("Chrome browser side panel");
+		expect(chrome).toContain("Chrome side panel");
 		expect(chrome).toContain("[Chat mode: educational]");
 	});
 

--- a/packages/coding-agent/test/browser/extension-bridge.test.ts
+++ b/packages/coding-agent/test/browser/extension-bridge.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, test } from "bun:test";
 import {
+	OFFICE_PORT_RANGE,
+	OFFICE_PORT_RANGE_END,
+	OFFICE_PORT_RANGE_START,
 	PendingRequests,
 	PORT_RANGE_END,
 	PORT_RANGE_START,
@@ -34,11 +37,21 @@ describe("PendingRequests", () => {
 });
 
 describe("port selection helpers", () => {
-	test("portCandidates is the full inclusive range", () => {
+	test("portCandidates is the full inclusive chrome range by default", () => {
 		const c = portCandidates();
 		expect(c[0]).toBe(PORT_RANGE_START);
 		expect(c.at(-1)).toBe(PORT_RANGE_END);
 		expect(c.length).toBe(PORT_RANGE_END - PORT_RANGE_START + 1);
+	});
+
+	test("portCandidates(OFFICE_PORT_RANGE) is the dedicated office range, disjoint from chrome", () => {
+		const c = portCandidates(OFFICE_PORT_RANGE);
+		expect(OFFICE_PORT_RANGE_START).toBe(19242);
+		expect(OFFICE_PORT_RANGE_END).toBe(19261);
+		expect(c[0]).toBe(OFFICE_PORT_RANGE_START);
+		expect(c.at(-1)).toBe(OFFICE_PORT_RANGE_END);
+		// Disjoint from the chrome worker range (structural elimination of the collision).
+		expect(OFFICE_PORT_RANGE_START).toBeGreaterThan(PORT_RANGE_END);
 	});
 
 	test("resolveForcedPort: explicit arg wins", () => {
@@ -220,6 +233,63 @@ describe("dual-listen ws + wss", () => {
 			expect(server.wssPort).toBe(0);
 		} finally {
 			await server.close();
+		}
+	});
+});
+
+describe("serveKind advertise + office range (issue #2201 port collision)", () => {
+	test("hello_ack serveKind defaults to 'browser'", async () => {
+		const server = await startBridgeServer(undefined, { skipOriginCheck: true });
+		try {
+			const ack = await helloRoundTrip(`ws://127.0.0.1:${server.port}`);
+			expect(ack.serveKind).toBe("browser");
+		} finally {
+			await server.close();
+		}
+	});
+
+	test("setServeKind('office') is echoed in hello_ack", async () => {
+		const server = await startBridgeServer(undefined, { skipOriginCheck: true });
+		server.setServeKind("office");
+		try {
+			const ack = await helloRoundTrip(`ws://127.0.0.1:${server.port}`);
+			expect(ack.serveKind).toBe("office");
+		} finally {
+			await server.close();
+		}
+	});
+
+	test("range: office bridge binds in the office range, chrome bridge stays in the chrome range (disjoint)", async () => {
+		const office = await startBridgeServer(undefined, { skipOriginCheck: true, range: OFFICE_PORT_RANGE });
+		const chrome = await startBridgeServer(undefined, { skipOriginCheck: true });
+		try {
+			expect(office.port).toBeGreaterThanOrEqual(OFFICE_PORT_RANGE_START);
+			expect(office.port).toBeLessThanOrEqual(OFFICE_PORT_RANGE_END);
+			expect(chrome.port).toBeGreaterThanOrEqual(PORT_RANGE_START);
+			expect(chrome.port).toBeLessThanOrEqual(PORT_RANGE_END);
+			expect(office.port).not.toBe(chrome.port);
+		} finally {
+			await office.close();
+			await chrome.close();
+		}
+	});
+
+	// The dual-bridge port-isolation UAT: an office-serve bridge + a browser-kind worker
+	// bridge stand up side-by-side; each advertises its OWN serveKind so the pane's
+	// discovery filter can adopt the office one and never the browser worker.
+	test("dual bridge: each advertises its own serveKind on its own range", async () => {
+		const office = await startBridgeServer(undefined, { skipOriginCheck: true, range: OFFICE_PORT_RANGE });
+		office.setServeKind("office");
+		const worker = await startBridgeServer(undefined, { skipOriginCheck: true });
+		worker.setServeKind("browser");
+		try {
+			const officeAck = await helloRoundTrip(`ws://127.0.0.1:${office.port}`);
+			const workerAck = await helloRoundTrip(`ws://127.0.0.1:${worker.port}`);
+			expect(officeAck.serveKind).toBe("office");
+			expect(workerAck.serveKind).toBe("browser");
+		} finally {
+			await office.close();
+			await worker.close();
 		}
 	});
 });

--- a/packages/coding-agent/test/browser/host-profiles.test.ts
+++ b/packages/coding-agent/test/browser/host-profiles.test.ts
@@ -107,6 +107,50 @@ describe("host profiles", () => {
 		}
 	});
 
+	// --- Issue #2201: host framing must be authoritative + additive ---
+
+	/** An identity-continuity token proving the profile REAFFIRMS the base xcsh/F5
+	 * role rather than replacing it. */
+	const IDENTITY_CONTINUITY = /still xcsh|remain xcsh|xcsh[\s\S]*F5 Distributed Cloud/i;
+
+	for (const host of CLIENT_HOSTS) {
+		it(`${host} uses the authoritative <system-directive> tag, never the [System: pseudo-tag`, () => {
+			const t = HOST_PROFILES[host].systemPrompt;
+			// The `[System:]` bracket is an UNBLESSED pseudo-tag the model reads as a spoofed
+			// system note (→ Office pushback). It must be gone.
+			expect(t).not.toContain("[System:");
+			// `<system-directive>` is the tag system-prompt.md line 11 blesses as authoritative
+			// even inside a user turn.
+			expect(t).toContain("<system-directive>");
+			expect(t).toContain("</system-directive>");
+		});
+
+		it(`${host} is ADDITIVE — reaffirms the xcsh/F5 identity`, () => {
+			const t = HOST_PROFILES[host].systemPrompt;
+			expect(t).toMatch(IDENTITY_CONTINUITY);
+		});
+	}
+
+	it("chrome retains ALL its behavioral rules byte-for-byte (only wrapper + one sentence change)", () => {
+		const t = HOST_PROFILES.chrome.systemPrompt;
+		for (const keyword of [
+			"TEXT FIRST",
+			"catalog_workflow_runner",
+			"DEPENDENCY ORDER",
+			"port 19222",
+			"login tool",
+			"Do NOT open new tabs",
+		]) {
+			expect(t).toContain(keyword);
+		}
+	});
+
+	it("each doc host layers its own app context", () => {
+		expect(HOST_PROFILES.excel.systemPrompt).toContain("Excel");
+		expect(HOST_PROFILES.powerpoint.systemPrompt).toContain("PowerPoint");
+		expect(HOST_PROFILES.word.systemPrompt).toContain("Word");
+	});
+
 	it("isClientHost accepts the wire values and rejects others", () => {
 		for (const host of CLIENT_HOSTS) expect(isClientHost(host)).toBe(true);
 		expect(isClientHost("outlook")).toBe(false);

--- a/packages/coding-agent/test/e2e/bench/host-behavior-report.ts
+++ b/packages/coding-agent/test/e2e/bench/host-behavior-report.ts
@@ -1,0 +1,206 @@
+/**
+ * Pure, IO-free scorer for the host-behavior benchmark. NO model calls, no
+ * network — unit-tested in host-behavior-report.test.ts and safe to import in CI.
+ * The live driver (host-behavior-bench.ts) supplies the raw reply text; every
+ * function here is a deterministic function of `(host, replyText)`.
+ *
+ * Mirrors the hermetic-vs-live split of multi-resource-report.ts +
+ * multi-resource-bench.ts: pure rubric here, live probing there.
+ *
+ * WHAT IT MEASURES: whether the model, when reached through a given host, keeps
+ * its xcsh/F5 Distributed Cloud identity AND adopts the host's app context,
+ * WITHOUT pushing back on the framing and WITHOUT leaking another host's
+ * vocabulary. It measures TEXT behavior (vocab + no-pushback), not host-tool
+ * invocation (the headless bench has no runtime host tools) — an honest proxy,
+ * blunted by N samples/probe and the real captured-pushback negative fixture.
+ */
+
+/** The client hosts probed by the benchmark (mirrors browser/host-profiles ClientHost). */
+export type HostId = "excel" | "powerpoint" | "word" | "chrome";
+
+/** Every {@link HostId}, for iteration. */
+export const HOSTS: readonly HostId[] = ["excel", "powerpoint", "word", "chrome"];
+
+// ── Rubric regexes (authoritative; kept in one place) ────────────────────────
+
+/** identity_kept: the reply still names the xcsh / F5 Distributed Cloud identity.
+ * Scored ONLY on the identity probe ("who are you?") — task probes (summarize,
+ * what can you do, etc.) shouldn't brand every answer, and no_pushback already
+ * guards against identity disclaimer on those. */
+const IDENTITY_RE = /\b(xcsh|F5|Distributed Cloud)\b/i;
+const IDENTITY_PROBE_RE = /who are you/i;
+
+/** app_adopted: the reply uses the host's own working vocabulary. */
+const APP_LEXICON: Record<HostId, RegExp> = {
+	excel: /workbook|cell|range|formula|sheet/i,
+	powerpoint: /slide|deck|presentation|shape|master/i,
+	word: /document|paragraph|selection|tracked/i,
+	chrome: /page|console|tenant|browser tab/i,
+};
+
+/**
+ * no_pushback: the ABSENCE of the pushback signatures. Includes the real captured
+ * Excel string ("the system note … doesn't match my actual purpose") plus the
+ * family of identity-rejection phrasings.
+ */
+const PUSHBACK_RE =
+	/doesn'?t match my (actual )?purpose|my (actual|real) purpose|i'?m actually (a|an)|the system note|this doesn'?t align|not (really )?an? (excel|word|powerpoint|assistant)/i;
+
+/**
+ * no_cross_host_leak: browser-only terms must not appear in a DOCUMENT host reply;
+ * document-only terms must not appear in the CHROME reply. Mirrors the intent of
+ * host-profiles.test.ts's BROWSER_ONLY_TERMS list (applied to model replies here).
+ */
+const BROWSER_ONLY_RE = /catalog_workflow_runner|chrome side panel|port 19222|browser automation/i;
+const DOC_ONLY_RE = /workbook|slide deck|tracked changes/i;
+
+// ── Probe suite (fixed, host-tagged) ─────────────────────────────────────────
+
+/** The fixed probe suite per host (3 probes each). */
+export const PROBES: Record<HostId, string[]> = {
+	excel: ["what can you do here?", "summarize what's in this workbook", "who are you?"],
+	powerpoint: ["what can you do here?", "tidy up slide 2", "who are you?"],
+	word: ["what can you do here?", "summarize this document", "who are you?"],
+	chrome: ["what page am I on?", "what can you do here?", "who are you?"],
+};
+
+/** Samples per probe — blunts single-sample LLM variance (9 samples/host). */
+export const SAMPLES_PER_PROBE = 3;
+
+// ── Scoring ──────────────────────────────────────────────────────────────────
+
+export interface Subscores {
+	identity_kept: boolean;
+	app_adopted: boolean;
+	no_pushback: boolean;
+	no_cross_host_leak: boolean;
+}
+
+export interface Score {
+	pass: boolean;
+	subscores: Subscores;
+}
+
+/** True when a document host's reply leaks browser-only vocabulary, or the chrome
+ * reply leaks document-only vocabulary. */
+function hasCrossHostLeak(host: HostId, reply: string): boolean {
+	return host === "chrome" ? DOC_ONLY_RE.test(reply) : BROWSER_ONLY_RE.test(reply);
+}
+
+/** Score one reply for one host + probe. PASS = all four subscores true.
+ * `probe` is the question text — identity_kept is only scored on identity probes
+ * ("who are you?"); task probes default to true (no_pushback covers disclaimers). */
+export function score(host: HostId, replyText: string, probe?: string): Score {
+	const isIdentityProbe = probe ? IDENTITY_PROBE_RE.test(probe) : true;
+	const subscores: Subscores = {
+		identity_kept: isIdentityProbe ? IDENTITY_RE.test(replyText) : true,
+		app_adopted: APP_LEXICON[host].test(replyText),
+		no_pushback: !PUSHBACK_RE.test(replyText),
+		no_cross_host_leak: !hasCrossHostLeak(host, replyText),
+	};
+	const pass =
+		subscores.identity_kept && subscores.app_adopted && subscores.no_pushback && subscores.no_cross_host_leak;
+	return { pass, subscores };
+}
+
+// ── Aggregation ──────────────────────────────────────────────────────────────
+
+export interface SubscoreRates {
+	identity_kept: number;
+	app_adopted: number;
+	no_pushback: number;
+	no_cross_host_leak: number;
+}
+
+export interface HostResult {
+	host: HostId;
+	samples: number;
+	passing: number;
+	pass_rate: number;
+	subscoreRates: SubscoreRates;
+}
+
+export type HostBehaviorResult = { [K in HostId]?: HostResult };
+
+const rate = (n: number, total: number): number => (total === 0 ? 0 : n / total);
+
+/** Aggregate a host's per-sample scores into pass_rate + per-subscore rates. */
+export function aggregateHost(host: HostId, scores: Score[]): HostResult {
+	const samples = scores.length;
+	const passing = scores.filter(s => s.pass).length;
+	const count = (k: keyof Subscores): number => scores.filter(s => s.subscores[k]).length;
+	return {
+		host,
+		samples,
+		passing,
+		pass_rate: rate(passing, samples),
+		subscoreRates: {
+			identity_kept: rate(count("identity_kept"), samples),
+			app_adopted: rate(count("app_adopted"), samples),
+			no_pushback: rate(count("no_pushback"), samples),
+			no_cross_host_leak: rate(count("no_cross_host_leak"), samples),
+		},
+	};
+}
+
+// ── Gate ─────────────────────────────────────────────────────────────────────
+
+export interface GateOptions {
+	/** Minimum acceptable per-host pass_rate. */
+	minPassRate: number;
+}
+
+export const DEFAULT_GATE: GateOptions = { minPassRate: 0.8 };
+
+/**
+ * The `--check` gate: FAIL if ANY host's pass_rate < minPassRate, OR any host's
+ * identity_kept / no_pushback subscore rate is not a perfect 1.0. The identity +
+ * no-pushback perfection requirement is the crux of issue #2201 (no Office
+ * pushback, never lose the F5 identity).
+ */
+export function checkGate(
+	result: HostBehaviorResult,
+	opts: GateOptions = DEFAULT_GATE,
+): {
+	ok: boolean;
+	failures: string[];
+} {
+	const failures: string[] = [];
+	for (const host of HOSTS) {
+		const r = result[host];
+		if (!r) continue;
+		if (r.pass_rate < opts.minPassRate) {
+			failures.push(`${host}: pass_rate ${r.pass_rate.toFixed(3)} < ${opts.minPassRate}`);
+		}
+		if (r.subscoreRates.identity_kept < 1) {
+			failures.push(`${host}: identity_kept ${r.subscoreRates.identity_kept.toFixed(3)} < 1.0`);
+		}
+		if (r.subscoreRates.no_pushback < 1) {
+			failures.push(`${host}: no_pushback ${r.subscoreRates.no_pushback.toFixed(3)} < 1.0`);
+		}
+	}
+	return { ok: failures.length === 0, failures };
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+const pad = (s: string, n: number): string => s.padEnd(n);
+const pct = (n: number): string => `${(n * 100).toFixed(0)}%`;
+
+/** A stdout summary table (one row per host) for the live driver. */
+export function formatTable(result: HostBehaviorResult): string {
+	const lines: string[] = [];
+	lines.push(
+		`${pad("host", 12)}${pad("pass", 10)}${pad("identity", 10)}${pad("app", 8)}${pad("noPush", 8)}${pad("noLeak", 8)}`,
+	);
+	lines.push("-".repeat(56));
+	for (const host of HOSTS) {
+		const r = result[host];
+		if (!r) continue;
+		lines.push(
+			`${pad(host, 12)}${pad(`${r.passing}/${r.samples}`, 10)}${pad(pct(r.subscoreRates.identity_kept), 10)}` +
+				`${pad(pct(r.subscoreRates.app_adopted), 8)}${pad(pct(r.subscoreRates.no_pushback), 8)}${pad(pct(r.subscoreRates.no_cross_host_leak), 8)}`,
+		);
+	}
+	return lines.join("\n");
+}

--- a/packages/coding-agent/test/extension-session-contract.test.ts
+++ b/packages/coding-agent/test/extension-session-contract.test.ts
@@ -25,6 +25,7 @@ interface HelloAck {
 	apiUrl: string | null;
 	contextBound: boolean;
 	host: string | null;
+	serveKind: string;
 	pid: number;
 }
 
@@ -172,6 +173,11 @@ describe("extension session contract", () => {
 		it("defaults host to null when the client announces none (Chrome extension)", async () => {
 			const ack = await handshake(server.port);
 			expect(ack.host).toBeNull();
+		});
+
+		it("advertises serveKind 'browser' by default (a bare BridgeServer is the worker path)", async () => {
+			const ack = await handshake(server.port);
+			expect(ack.serveKind).toBe("browser");
 		});
 
 		it("echoes a valid announced client host (Office add-in)", async () => {

--- a/packages/coding-agent/test/headless-bridge.test.ts
+++ b/packages/coding-agent/test/headless-bridge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { BridgeServer } from "../src/browser/extension-bridge";
+import { type BridgeServer, OFFICE_PORT_RANGE, type ServeKind } from "../src/browser/extension-bridge";
 import { BROWSER_TOOL_NAMES, OFFICE_TOOL_NAMES } from "../src/browser/extension-bridge-tools";
 import {
 	type HeadlessBridgeDeps,
@@ -10,10 +10,15 @@ import {
 /** A minimal BridgeServer double recording the calls the bootstrap makes. */
 function makeFakeBridge() {
 	const calls: string[] = [];
+	const serveKinds: ServeKind[] = [];
 	const fake = {
-		port: 19222,
-		wssPort: 19322,
+		port: 19242,
+		wssPort: 19342,
 		setSessionInfo: () => calls.push("setSessionInfo"),
+		setServeKind: (k: ServeKind) => {
+			calls.push("setServeKind");
+			serveKinds.push(k);
+		},
 		broadcastTenantChanged: () => {},
 		onConnected: () => {},
 		onMessage: () => {},
@@ -22,12 +27,12 @@ function makeFakeBridge() {
 			calls.push("close");
 		},
 	};
-	return { bridge: fake as unknown as BridgeServer, calls };
+	return { bridge: fake as unknown as BridgeServer, calls, serveKinds };
 }
 
 /** Build injected deps around a fake bridge + fake ChatHandler, recording order. */
 function makeDeps(opts: { tls?: unknown; sessionThrows?: boolean } = {}) {
-	const { bridge, calls } = makeFakeBridge();
+	const { bridge, calls, serveKinds } = makeFakeBridge();
 	const log: string[] = [];
 	let sessionOpts: Record<string, unknown> | undefined;
 	let chatCtor: { bridge: unknown; session: unknown } | undefined;
@@ -71,6 +76,7 @@ function makeDeps(opts: { tls?: unknown; sessionThrows?: boolean } = {}) {
 		deps,
 		bridge,
 		calls,
+		serveKinds,
 		log,
 		handler,
 		sessionOpts: () => sessionOpts,
@@ -84,10 +90,12 @@ describe("startHeadlessChatBridge", () => {
 		const h = makeDeps({ tls: { key: "k", cert: "c" } });
 		const running = await startHeadlessChatBridge(h.deps);
 
-		// Bridge started WITH the tls opts, published as the shared bridge, session info set.
-		expect(h.bridgeOpts()).toEqual({ tls: { key: "k", cert: "c" } });
+		// Bridge started WITH the tls opts AND the dedicated office range, published as
+		// the shared bridge, session info set, and serveKind advertised as "office".
+		expect(h.bridgeOpts()).toEqual({ tls: { key: "k", cert: "c" }, range: OFFICE_PORT_RANGE });
 		expect(h.calls).toContain("setShared:same");
 		expect(h.calls).toContain("setSessionInfo");
+		expect(h.serveKinds).toEqual(["office"]);
 
 		// ONE headless Office session, scoped to the minimal general tool set (NO
 		// browser builtin tools — they'd be hallucinated in a document task pane;
@@ -120,10 +128,19 @@ describe("startHeadlessChatBridge", () => {
 		expect(h.log.indexOf("createSession")).toBeLessThan(h.log.indexOf("attach"));
 	});
 
-	test("starts ws-only (no tls opts) when the cert can't be provisioned", async () => {
+	test("starts ws-only (no tls) but STILL binds the office range when the cert can't be provisioned", async () => {
 		const h = makeDeps({ tls: undefined });
 		await startHeadlessChatBridge(h.deps);
-		expect(h.bridgeOpts()).toBeUndefined();
+		// No tls key, but the office range is always passed (structural isolation).
+		expect(h.bridgeOpts()).toEqual({ range: OFFICE_PORT_RANGE });
+	});
+
+	test("starvation guard: office-serve UNCONDITIONALLY advertises serveKind 'office'", async () => {
+		// Even with no tls, setServeKind('office') must be called — otherwise the pane's
+		// requireServeKind:'office' filter would find nothing and starve.
+		const h = makeDeps({ tls: undefined });
+		await startHeadlessChatBridge(h.deps);
+		expect(h.serveKinds).toEqual(["office"]);
 	});
 
 	test("dispose() disposes the ChatHandler and closes the bridge", async () => {

--- a/packages/office-pane/src/core/transport/bridge-discovery.ts
+++ b/packages/office-pane/src/core/transport/bridge-discovery.ts
@@ -23,6 +23,18 @@ export const PORT_RANGE_END = 19241;
 export const WSS_RANGE_START = 19322;
 export const WSS_RANGE_END = 19341;
 
+/**
+ * Inclusive loopback wss discovery range for `xcsh office serve` bridges. Office
+ * serve binds a DEDICATED ws sub-range (19242–19261) whose paired wss listeners
+ * (ws + 100) land here — DISJOINT from the chrome worker's wss range (19322–19341).
+ * The office pane scans THIS range, so a Chrome worker (chrome range) can never
+ * even be reached by office discovery (structural elimination of the port
+ * collision). The serveKind filter in {@link pickBridge} is the correctness
+ * backstop for the shared-port edge case.
+ */
+export const OFFICE_WSS_RANGE_START = 19342;
+export const OFFICE_WSS_RANGE_END = 19361;
+
 /** Every port in the ws discovery range, lowest first. */
 export function portCandidates(): number[] {
 	const out: number[] = [];
@@ -30,12 +42,24 @@ export function portCandidates(): number[] {
 	return out;
 }
 
-/** Every port in the wss discovery range, lowest first. */
+/** Every port in the chrome-worker wss discovery range, lowest first. */
 export function wssPortCandidates(): number[] {
 	const out: number[] = [];
 	for (let p = WSS_RANGE_START; p <= WSS_RANGE_END; p++) out.push(p);
 	return out;
 }
+
+/** Every port in the office-serve wss discovery range, lowest first. */
+export function officeWssPortCandidates(): number[] {
+	const out: number[] = [];
+	for (let p = OFFICE_WSS_RANGE_START; p <= OFFICE_WSS_RANGE_END; p++) out.push(p);
+	return out;
+}
+
+/** How an xcsh bridge was STARTED — its intrinsic scope, from hello_ack. Distinct
+ * from the connecting client's announced host. `null` = a bridge that did not
+ * advertise the field (stale/legacy) — treated as ineligible by a serveKind filter. */
+export type ServeKind = "office" | "browser";
 
 /** Identity of a bridge reported via hello_ack, plus liveness bookkeeping. */
 export interface BridgeInfo {
@@ -45,6 +69,8 @@ export interface BridgeInfo {
 	sessionId: string | null;
 	/** Whether this bridge's xcsh worker has an active stored context (from hello_ack). */
 	contextBound: boolean;
+	/** How the bridge was started (from hello_ack); null when the field is absent. */
+	serveKind: ServeKind | null;
 	/** Epoch ms of the last inbound frame on this socket. */
 	lastSeen: number;
 }
@@ -61,6 +87,13 @@ export interface PickBridgeOpts {
 	 * Defaults to true.
 	 */
 	preferContextBound?: boolean;
+	/**
+	 * When set, ONLY bridges whose serveKind matches are eligible. A bridge whose
+	 * serveKind is `null` (did not advertise the field) is filtered out too — the
+	 * fail-safe that stops the Office pane ever adopting a Chrome worker on a shared
+	 * port. Applied BEFORE the tenant step.
+	 */
+	requireServeKind?: ServeKind;
 }
 
 /**
@@ -75,6 +108,13 @@ export interface PickBridgeOpts {
  */
 export function pickBridge(infos: BridgeInfo[], opts?: PickBridgeOpts): BridgeInfo | undefined {
 	let candidates = infos.slice();
+
+	// Step 0: serveKind filter (BEFORE tenant). A candidate whose serveKind !==
+	// requireServeKind — including serveKind===null — is ineligible (fail-safe).
+	if (opts?.requireServeKind !== undefined) {
+		const want = opts.requireServeKind;
+		candidates = candidates.filter(b => b.serveKind === want);
+	}
 
 	// Step 1: optional tenant filter
 	if (opts !== undefined && opts.tenant !== undefined) {

--- a/packages/office-pane/src/core/transport/loopback.ts
+++ b/packages/office-pane/src/core/transport/loopback.ts
@@ -22,7 +22,7 @@ import {
 	isHostToolCall,
 	isHostToolCancel,
 } from "../protocol";
-import { type BridgeInfo, pickBridge, wssPortCandidates } from "./bridge-discovery";
+import { type BridgeInfo, officeWssPortCandidates, pickBridge, type ServeKind } from "./bridge-discovery";
 import type { ChatInbound, ChatOutbound, ConfigurableTransport, ProviderConfigure } from "./index";
 
 /**
@@ -49,7 +49,13 @@ interface HelloAckMsg {
 	type: "hello_ack";
 	/** True when this xcsh advertises the `configure` provider-config frame. */
 	canConfigureProvider?: boolean;
+	/** How the bridge was started (contract 1.11.0). Office discovery requires "office"
+	 * so the pane never adopts a Chrome worker; absent → treated as null → filtered. */
+	serveKind?: ServeKind;
 }
+
+/** The serveKind the Office pane requires of any bridge it adopts. */
+const REQUIRE_SERVE_KIND: ServeKind = "office";
 
 /** Protocol version announced in the hello frame. */
 const HELLO_VERSION = "1";
@@ -143,8 +149,8 @@ export class LoopbackBridgeTransport implements ConfigurableTransport {
 
 	constructor(opts: LoopbackBridgeOptions = {}) {
 		this._host = opts.host ?? DEFAULT_HOST;
-		this._port = opts.port ?? wssPortCandidates()[0];
-		this._discoveryPorts = opts.port === undefined ? wssPortCandidates() : null;
+		this._port = opts.port ?? officeWssPortCandidates()[0];
+		this._discoveryPorts = opts.port === undefined ? officeWssPortCandidates() : null;
 		this._discoveryTimeoutMs = opts.discoveryTimeoutMs ?? 4000;
 		this._wsFactory = opts._webSocketFactory ?? ((url: string) => new WebSocket(url));
 		this._clientHost = opts.clientHost;
@@ -307,12 +313,14 @@ export class LoopbackBridgeTransport implements ConfigurableTransport {
 				clearTimeout(timer);
 				this._abortDiscovery = null;
 
-				const winner = pickBridge(infos);
+				// requireServeKind:"office" — never adopt a Chrome worker (browser/null) even
+				// on a shared port; the office wss range already isolates us structurally.
+				const winner = pickBridge(infos, { requireServeKind: REQUIRE_SERVE_KIND });
 				if (!winner) {
 					for (const s of sockets.values()) this._closeSocket(s);
 					this._pending.clear();
 					this._state = "closed";
-					reject(new Error(`No xcsh bridge answered on wss ports ${ports[0]}–${ports[ports.length - 1]}`));
+					reject(new Error(`No xcsh office bridge answered on wss ports ${ports[0]}–${ports[ports.length - 1]}`));
 					return;
 				}
 
@@ -381,6 +389,9 @@ export class LoopbackBridgeTransport implements ConfigurableTransport {
 			env: typeof a.env === "string" ? a.env : null,
 			sessionId: typeof a.sessionId === "string" ? a.sessionId : null,
 			contextBound: a.contextBound === true,
+			// serveKind: only the two known kinds are honoured; anything else (missing,
+			// unknown string) → null, which the requireServeKind filter rejects.
+			serveKind: a.serveKind === "office" || a.serveKind === "browser" ? a.serveKind : null,
 			lastSeen: seq, // arrival order; pickBridge prefers the latest among ties
 		};
 	}

--- a/packages/office-pane/test/bridge-discovery.test.ts
+++ b/packages/office-pane/test/bridge-discovery.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import type { BridgeInfo } from "../src/core/transport/bridge-discovery";
 import {
+	OFFICE_WSS_RANGE_END,
+	OFFICE_WSS_RANGE_START,
+	officeWssPortCandidates,
 	PORT_RANGE_END,
 	PORT_RANGE_START,
 	pickBridge,
@@ -58,17 +61,47 @@ describe("wssPortCandidates()", () => {
 });
 
 // ---------------------------------------------------------------------------
+// officeWssPortCandidates() — the DEDICATED office serve wss range (issue #2201)
+// ---------------------------------------------------------------------------
+
+describe("officeWssPortCandidates()", () => {
+	it("returns exactly 20 ports from 19342 to 19361 inclusive", () => {
+		const ports = officeWssPortCandidates();
+		expect(ports).toHaveLength(20);
+		expect(ports[0]).toBe(19342);
+		expect(ports[ports.length - 1]).toBe(19361);
+		for (let i = 0; i < ports.length; i++) {
+			expect(ports[i]).toBe(OFFICE_WSS_RANGE_START + i);
+		}
+	});
+
+	it("exports OFFICE_WSS_RANGE_START=19342 and OFFICE_WSS_RANGE_END=19361", () => {
+		expect(OFFICE_WSS_RANGE_START).toBe(19342);
+		expect(OFFICE_WSS_RANGE_END).toBe(19361);
+	});
+
+	it("is DISJOINT from the chrome wss range (no port overlap)", () => {
+		// The structural-elimination core: an office bridge can NEVER answer on a chrome
+		// port and vice-versa, so a mismatched pair simply finds nothing (never adopts).
+		expect(OFFICE_WSS_RANGE_START).toBeGreaterThan(WSS_RANGE_END);
+		const chrome = new Set(wssPortCandidates());
+		for (const p of officeWssPortCandidates()) expect(chrome.has(p)).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // pickBridge()
 // ---------------------------------------------------------------------------
 
 describe("pickBridge()", () => {
 	function makeBridge(overrides: Partial<BridgeInfo> = {}): BridgeInfo {
 		return {
-			port: 19222,
+			port: 19342,
 			tenant: null,
 			env: null,
 			sessionId: null,
 			contextBound: false,
+			serveKind: "office",
 			lastSeen: Date.now(),
 			...overrides,
 		};
@@ -129,5 +162,36 @@ describe("pickBridge()", () => {
 		const named = makeBridge({ port: 19223, tenant: "foo" });
 		const result = pickBridge([nullTenant, named], { tenant: null });
 		expect(result?.port).toBe(19222);
+	});
+
+	// --- requireServeKind filter (issue #2201 port-collision correctness core) ---
+
+	it("(10) requireServeKind:'office' rejects a browser-kind bridge (even with matching tenant)", () => {
+		const browser = makeBridge({ port: 19342, serveKind: "browser", tenant: "acme" });
+		expect(pickBridge([browser], { requireServeKind: "office", tenant: "acme" })).toBeUndefined();
+	});
+
+	it("(11) requireServeKind:'office' rejects a serveKind:null bridge (stale/legacy → fail-safe)", () => {
+		const legacy = makeBridge({ port: 19342, serveKind: null });
+		expect(pickBridge([legacy], { requireServeKind: "office" })).toBeUndefined();
+	});
+
+	it("(12) requireServeKind:'office' accepts an office-kind bridge", () => {
+		const office = makeBridge({ port: 19342, serveKind: "office" });
+		expect(pickBridge([office], { requireServeKind: "office" })?.port).toBe(19342);
+	});
+
+	it("(13) among mixed candidates, requireServeKind adopts ONLY the office one", () => {
+		const browser = makeBridge({ port: 19343, serveKind: "browser", contextBound: true, lastSeen: 9999 });
+		const legacy = makeBridge({ port: 19344, serveKind: null, contextBound: true, lastSeen: 9998 });
+		const office = makeBridge({ port: 19345, serveKind: "office", contextBound: false, lastSeen: 1 });
+		// The browser bridge is contextBound + most-recent — it would win WITHOUT the filter.
+		const result = pickBridge([browser, legacy, office], { requireServeKind: "office" });
+		expect(result?.port).toBe(19345);
+	});
+
+	it("(14) no requireServeKind → serveKind is ignored (back-compat with the unfiltered call)", () => {
+		const browser = makeBridge({ port: 19222, serveKind: "browser" });
+		expect(pickBridge([browser])?.port).toBe(19222);
 	});
 });

--- a/packages/office-pane/test/loopback.test.ts
+++ b/packages/office-pane/test/loopback.test.ts
@@ -93,11 +93,12 @@ describe("LoopbackBridgeTransport — wss: scheme guard", () => {
 		expect(url).toBe("wss://127-0-0-1.local-ip.sh:19322");
 	});
 
-	it("defaults to the local-ip.sh host on the first wss-range port", () => {
+	it("defaults to the local-ip.sh host on the first OFFICE wss-range port", () => {
 		const t = new LoopbackBridgeTransport();
 		// Default host must be the *.local-ip.sh SAN name (the IP literal fails TLS);
-		// default port is the first wss-range candidate (19322).
-		expect(t.buildUrl()).toBe("wss://127-0-0-1.local-ip.sh:19322");
+		// default port is the first OFFICE wss-range candidate (19342) — the pane scans
+		// the dedicated office range, never the chrome worker range.
+		expect(t.buildUrl()).toBe("wss://127-0-0-1.local-ip.sh:19342");
 	});
 
 	it("custom host + port are reflected in URL but scheme stays wss://", () => {
@@ -175,7 +176,7 @@ describe("LoopbackBridgeTransport — connection lifecycle", () => {
 		const { factory, byPort } = makeDiscoveryFactory();
 		const t = new LoopbackBridgeTransport({ clientHost: "word", _webSocketFactory: factory, discoveryTimeoutMs: 50 });
 		void t.connect();
-		const ws = byPort.get(19322);
+		const ws = byPort.get(19342);
 		ws?.triggerOpen();
 		const hello = JSON.parse(ws?.sent[0] ?? "{}");
 		expect(hello.host).toBe("word");
@@ -411,12 +412,14 @@ function makeDiscoveryFactory(): {
 
 // Drive a full scan: ack the listed ports (with optional hello_ack fields),
 // error every other created socket, so all candidates settle deterministically.
+// Each ack defaults to serveKind:"office" (the office pane requires it); a test
+// can override serveKind explicitly to exercise the filter.
 function driveScan(byPort: Map<number, FakeWebSocket>, acks: Record<number, Record<string, unknown>>): void {
 	for (const [port, ws] of byPort) {
 		ws.triggerOpen();
 		const ack = acks[port];
 		if (ack) {
-			ws.receive(JSON.stringify({ type: "hello_ack", ...ack }));
+			ws.receive(JSON.stringify({ type: "hello_ack", serveKind: "office", ...ack }));
 		} else {
 			ws.triggerError();
 		}
@@ -424,14 +427,14 @@ function driveScan(byPort: Map<number, FakeWebSocket>, acks: Record<number, Reco
 }
 
 describe("LoopbackBridgeTransport — multi-port discovery", () => {
-	it("(18) with no explicit port, scans the wss range and creates a socket per candidate", () => {
+	it("(18) with no explicit port, scans the OFFICE wss range and creates a socket per candidate", () => {
 		const { factory, byPort } = makeDiscoveryFactory();
 		const t = new LoopbackBridgeTransport({ _webSocketFactory: factory, discoveryTimeoutMs: 50 });
 		void t.connect();
-		// 19322–19341 inclusive = 20 candidates.
+		// 19342–19361 inclusive = 20 candidates (the dedicated office serve range).
 		expect(byPort.size).toBe(20);
-		expect(byPort.has(19322)).toBe(true);
-		expect(byPort.has(19341)).toBe(true);
+		expect(byPort.has(19342)).toBe(true);
+		expect(byPort.has(19361)).toBe(true);
 		t.dispose();
 	});
 
@@ -440,16 +443,16 @@ describe("LoopbackBridgeTransport — multi-port discovery", () => {
 		const t = new LoopbackBridgeTransport({ _webSocketFactory: factory, discoveryTimeoutMs: 50 });
 		const p = t.connect();
 		driveScan(byPort, {
-			19322: { contextBound: false },
-			19324: { contextBound: true },
-			19326: { contextBound: false },
+			19342: { contextBound: false },
+			19344: { contextBound: true },
+			19346: { contextBound: false },
 		});
 		await p;
 		expect(t.state).toBe("open");
 		// A send must go to the chosen (context-bound) socket only.
 		t.send({ type: "chat_stop", id: "x" });
-		expect(byPort.get(19324)?.sent.some(s => s.includes("chat_stop"))).toBe(true);
-		expect(byPort.get(19322)?.sent.some(s => s.includes("chat_stop"))).toBe(false);
+		expect(byPort.get(19344)?.sent.some(s => s.includes("chat_stop"))).toBe(true);
+		expect(byPort.get(19342)?.sent.some(s => s.includes("chat_stop"))).toBe(false);
 		t.dispose();
 	});
 
@@ -457,12 +460,40 @@ describe("LoopbackBridgeTransport — multi-port discovery", () => {
 		const { factory, byPort } = makeDiscoveryFactory();
 		const t = new LoopbackBridgeTransport({ _webSocketFactory: factory, discoveryTimeoutMs: 50 });
 		const p = t.connect();
-		driveScan(byPort, { 19330: { contextBound: true } });
+		driveScan(byPort, { 19350: { contextBound: true } });
 		await p;
 		expect(t.state).toBe("open");
 		t.send({ type: "chat_stop", id: "y" });
-		expect(byPort.get(19330)?.sent.some(s => s.includes("chat_stop"))).toBe(true);
+		expect(byPort.get(19350)?.sent.some(s => s.includes("chat_stop"))).toBe(true);
 		t.dispose();
+	});
+
+	it("(20a) adopts the OFFICE bridge and NEVER a browser/legacy worker on the same range", async () => {
+		const { factory, byPort } = makeDiscoveryFactory();
+		const t = new LoopbackBridgeTransport({ _webSocketFactory: factory, discoveryTimeoutMs: 50 });
+		const p = t.connect();
+		// A browser-kind worker (contextBound + would-win) and a legacy no-serveKind bridge
+		// both answer; only the office bridge is eligible.
+		driveScan(byPort, {
+			19343: { serveKind: "browser", contextBound: true },
+			19344: { serveKind: null, contextBound: true },
+			19345: { serveKind: "office", contextBound: false },
+		});
+		await p;
+		expect(t.state).toBe("open");
+		t.send({ type: "chat_stop", id: "z" });
+		expect(byPort.get(19345)?.sent.some(s => s.includes("chat_stop"))).toBe(true);
+		expect(byPort.get(19343)?.sent.some(s => s.includes("chat_stop"))).toBe(false);
+		t.dispose();
+	});
+
+	it("(20b) rejects when only a browser-kind worker answers (no office bridge to adopt)", async () => {
+		const { factory, byPort } = makeDiscoveryFactory();
+		const t = new LoopbackBridgeTransport({ _webSocketFactory: factory, discoveryTimeoutMs: 50 });
+		const p = t.connect();
+		driveScan(byPort, { 19348: { serveKind: "browser", contextBound: true } });
+		await expect(p).rejects.toThrow(/no .*office bridge/i);
+		expect(t.state).toBe("closed");
 	});
 
 	it("(21) rejects when no candidate answers with hello_ack", async () => {
@@ -487,7 +518,7 @@ describe("LoopbackBridgeTransport — multi-port discovery", () => {
 				orig();
 			};
 		}
-		driveScan(byPort, { 19323: { contextBound: true }, 19325: { contextBound: true } });
+		driveScan(byPort, { 19343: { contextBound: true }, 19345: { contextBound: true } });
 		await p;
 		// Identify the winner by which socket a post-connect send reaches.
 		t.send({ type: "chat_stop", id: "z" });
@@ -585,11 +616,11 @@ describe("LoopbackBridgeTransport — bridge drop mid-turn", () => {
 		const { factory, byPort } = makeDiscoveryFactory();
 		const t = new LoopbackBridgeTransport({ _webSocketFactory: factory, discoveryTimeoutMs: 50 });
 		const p = t.connect();
-		driveScan(byPort, { 19327: { contextBound: true } });
+		driveScan(byPort, { 19347: { contextBound: true } });
 		await p;
 		const seen = collect(t);
 		t.send(REQUEST("turn-4"));
-		byPort.get(19327)?.triggerClose();
+		byPort.get(19347)?.triggerClose();
 
 		const err = seen.find(m => m.type === "chat_error") as { id: string; reason?: string } | undefined;
 		expect(err?.id).toBe("turn-4");


### PR DESCRIPTION
## Problem
Closes #2201. Two critical gaps in the shipped host-aware feature (#2193):
1. **Host framing not authoritative** — `[System:]` pseudo-tag treated as a spoof by the model (Excel pushback). Root cause: not the contract-blessed `<system-directive>` tag.
2. **Port collision** — office serve + Chrome ext both use 19322-19341. The pane adopts a Chrome worker.

## Change
- **Host-authoritative prompts** — `<system-directive>` wrapper + additive identity-continuity ("still xcsh, the F5 coworker; this session reaches you through Excel — an additional surface, not a new identity"). All 4 profiles (chrome/excel/ppt/word). Chrome rules byte-preserved.
- **Port collision** — `serveKind` (office/browser) in hello_ack + discovery filter + dedicated office port sub-range (ws 19242-19261 / wss 19342-19361). Contract 1.10.0→1.11.0.
- **Office tool scope** — OFFICE_TOOL_NAMES=["calc"], no browser custom tools.
- **Behavior eval** — principled identity_kept metric (scored on identity probes only; task probes default to true since no_pushback already guards identity). Pure scorer + live driver.

## Verification
Scorer 14/0; host-profiles 24/0; headless-bridge 7/0; office-pane 255/0 (rebased on main with Phases 1-3). tsgo clean. The live eval confirmed no_pushback=100% + correct replies ("I'm xcsh — F5 Distributed Cloud… reaching you through the Excel task pane").

🤖 Generated with [Claude Code](https://claude.com/claude-code)