### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,7 +176,6 @@ handoff.md
 packages/*/dist/
 packages/*/dist-chrome/
 packages/*/dist-firefox/
-packages/*/test/__visual__/
 *.tsbuildinfo
 *.node
 *.b64.js


### PR DESCRIPTION
Closes #2229

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .gitignore