### PR TITLE
fix(office-pane): get_workbook_info uses getUsedRangeOrNullObject (empty sheet safe)

### DIFF
--- a/packages/office-pane/src/office/excel-tools.ts
+++ b/packages/office-pane/src/office/excel-tools.ts
@@ -42,8 +42,9 @@ export interface ExcelWorksheetLike {
 	/** The tab name shown in the Excel sheet tab bar. */
 	name: string;
 	getRange(address: string): ExcelRangeLike;
-	/** The rectangle covering all cells with content (for structural discovery). */
-	getUsedRange(): ExcelRangeLike;
+	/** The rectangle covering all cells with content (for structural discovery).
+	 * Use `getUsedRangeOrNullObject()` to avoid `ItemNotFound` on empty sheets. */
+	getUsedRangeOrNullObject(): ExcelRangeLike & { isNullObject?: boolean };
 	/** The Excel Tables anchored on this sheet. */
 	getTables(): ExcelNamedItemCollectionLike;
 	/** The sheet-scoped named ranges. */
@@ -317,8 +318,9 @@ export function createExcelHostTools(excel: ExcelLike = getExcel()): HostToolReg
 						await ctx.sync();
 						// Queue each sheet's used range, tables, and sheet-scoped names.
 						const staged = worksheets.items.map(ws => {
-							const used = ws.getUsedRange();
-							used.load("address");
+							// OrNullObject avoids ItemNotFound on completely empty sheets.
+							const used = ws.getUsedRangeOrNullObject();
+							used.load("address,isNullObject");
 							const tables = ws.getTables();
 							tables.load("items/name");
 							ws.names.load("items/name");
@@ -328,7 +330,7 @@ export function createExcelHostTools(excel: ExcelLike = getExcel()): HostToolReg
 						return {
 							sheets: staged.map(({ ws, used, tables }) => ({
 								name: ws.name,
-								usedRange: used.address ?? "",
+								usedRange: used.isNullObject ? "" : (used.address ?? ""),
 								tables: tables.items.map(t => t.name),
 								namedRanges: ws.names.items.map(n => n.name),
 							})),

--- a/packages/office-pane/test/excel-tools.test.ts
+++ b/packages/office-pane/test/excel-tools.test.ts
@@ -132,7 +132,7 @@ function fakeExcel(
 							numberFormat: sm.numberFormat?.[address],
 							valueTypes: sm.valueTypes?.[address],
 						}),
-					getUsedRange: () => makeRange(sm.usedRange ?? "", { read: () => [] }),
+					getUsedRangeOrNullObject: () => makeRange(sm.usedRange ?? "", { read: () => [] }),
 					getTables: () => ({
 						items: (sm.tables ?? []).map(n => ({ name: n })),
 						load(_props: string): void {},


### PR DESCRIPTION
Closes #2232

## Problem
`get_workbook_info` crashes on workbooks with empty sheets — `getUsedRange()` throws `ItemNotFound` on a sheet with no content in real Office.js. The operator hit this live.

## Fix
Use `getUsedRangeOrNullObject()` (returns a null-object proxy instead of throwing). Empty sheets report `usedRange: ""`, not a crash.

## Verification
excel-tools **31/0**; biome + tsgo clean; browser-safe build **154.9KB/256KB**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)