### PR TITLE
feat(office-pane): live tool-activity rows in the transcript (Claude for Office parity)

### DIFF
--- a/packages/chat-ui/src/components/Transcript.tsx
+++ b/packages/chat-ui/src/components/Transcript.tsx
@@ -89,7 +89,8 @@ function renderMessage(
 	onRetry?: (text: string) => void,
 ): ReactNode {
 	if (m.role === "user") return <UserMessage key={m.id} text={m.text} />;
-	if (m.role === "tool") return <ToolMessage key={m.id} tool={m.tool ?? "tool"} ok={m.ok ?? true} text={m.text} />;
+	if (m.role === "tool")
+		return <ToolMessage key={m.id} tool={m.tool ?? "tool"} ok={m.ok ?? true} text={m.text} running={m.running} />;
 	if (m.error) {
 		const canRetry = !!m.retryText && m.id === lastId && !!onRetry;
 		return (

--- a/packages/chat-ui/src/components/messages.tsx
+++ b/packages/chat-ui/src/components/messages.tsx
@@ -5,6 +5,7 @@
  */
 import type { ReactNode } from "react";
 import { GLYPHS } from "../theme/tokens";
+import { toolActivityLabel } from "../tools/activity-label";
 import { MarkdownRenderer } from "./MarkdownRenderer";
 
 export interface GutterRowProps {
@@ -55,12 +56,38 @@ export interface ToolMessageProps {
 	tool: string;
 	ok: boolean;
 	text: string;
+	/** The call is still in flight — render a live spinner instead of a settled glyph. */
+	running?: boolean;
 }
 
-export function ToolMessage({ tool, ok, text }: ToolMessageProps) {
+/**
+ * A compact tool-activity row (parity with Claude for Office's "Read data ›"):
+ * a humanized label + a status affordance. Raw payload text, when present, is
+ * tucked behind a native `<details>` disclosure so the transcript stays scannable;
+ * activity rows with no payload (the Office host-tool lifecycle, which the pane
+ * observes call-side only) render a plain line.
+ */
+export function ToolMessage({ tool, ok, text, running }: ToolMessageProps) {
+	const label = toolActivityLabel(tool);
+	const glyphClass = running ? "g-tool-run spin" : ok ? "g-tool-ok" : "g-tool-err";
+	const status = <span className="tool-activity-status">{running ? "…" : ok ? "✓" : "✗"}</span>;
+
 	return (
-		<GutterRow glyph={GLYPHS.assistant} glyphClass={ok ? "g-tool-ok" : "g-tool-err"}>
-			<div className="body tool-body">{`${tool}: ${ok ? "✓" : "✗"} ${text}`}</div>
+		<GutterRow glyph={GLYPHS.assistant} glyphClass={glyphClass}>
+			{text ? (
+				<details className="tool-activity">
+					<summary className="tool-activity-summary">
+						<span className="tool-activity-label">{label}</span>
+						{status}
+					</summary>
+					<pre className="tool-activity-detail">{text}</pre>
+				</details>
+			) : (
+				<div className="body tool-activity-line">
+					<span className="tool-activity-label">{label}</span>
+					{status}
+				</div>
+			)}
 		</GutterRow>
 	);
 }

--- a/packages/chat-ui/src/index.ts
+++ b/packages/chat-ui/src/index.ts
@@ -71,6 +71,8 @@ export {
 	injectTokens,
 	UI_COLORS,
 } from "./theme/tokens";
+// ── Tool activity ─────────────────────────────────────────────────────────
+export { toolActivityLabel } from "./tools/activity-label";
 
 // ── View-model + prop types ───────────────────────────────────────────────
 export type {

--- a/packages/chat-ui/src/theme/panel.css.ts
+++ b/packages/chat-ui/src/theme/panel.css.ts
@@ -65,11 +65,24 @@ body { background: var(--charcoal); color: var(--bright-white);
 .g-thinking, .g-user { color: var(--f5-red); }
 .g-tool-ok { color: var(--chrome-accent); }
 .g-tool-err, .g-error { color: var(--alert-red); }
+.g-tool-run { color: var(--warm-amber); }
 .content .body a { color: var(--chrome-accent); }
 .msg-user { background: var(--deep-charcoal); border-left:3px solid var(--f5-red); }
 .user-body { font-style: italic; color: var(--bright-white); }
 .thinking { color: var(--dim); }
 .tool-body { color: var(--cool-gray); font-size:12px; }
+
+/* ── Compact tool-activity row ("Read data ›" parity) ───────────────────── */
+.tool-activity-line, .tool-activity-summary { display:flex; align-items:center; gap:6px; font-size:12px; }
+.tool-activity-label { color: var(--cool-gray); }
+.tool-activity-status { color: var(--dim); font-size:11px; }
+.tool-activity { margin:0; }
+.tool-activity > summary { cursor:pointer; list-style:none; color: var(--cool-gray); }
+.tool-activity > summary::-webkit-details-marker { display:none; }
+.tool-activity > summary::before { content:"›"; color: var(--dim); margin-right:4px; transition: transform .12s ease; display:inline-block; }
+.tool-activity[open] > summary::before { transform: rotate(90deg); }
+.tool-activity-detail { margin:4px 0 0 12px; padding:6px 8px; background: var(--code-bg); border:1px solid var(--subtle-gray);
+  border-radius:6px; color: var(--cool-gray); font-size:11px; white-space:pre-wrap; overflow:auto; max-height:16em; }
 .error { color: var(--alert-red); }
 pre.code { background:var(--code-bg); border:1px solid var(--subtle-gray); border-radius:6px; padding:8px; overflow:auto; }
 code { background:var(--code-bg); padding:1px 5px; border-radius:4px; }

--- a/packages/chat-ui/src/tools/activity-label.ts
+++ b/packages/chat-ui/src/tools/activity-label.ts
@@ -1,0 +1,53 @@
+/**
+ * Humanize a host-tool name into a compact activity label for the transcript —
+ * the "Read data ›" affordance Claude for Office shows while it works. The Office
+ * host tools have an explicit, curated mapping (present-tense, no raw function
+ * names); anything else (browser-automation tools, future tools) falls back to a
+ * Title-cased de-snake of the name so the line is never a bare identifier.
+ *
+ * Pure and framework-free — unit-tested in isolation.
+ */
+
+/** Curated labels for the Office.js host tools (Excel / Word / PowerPoint). */
+const LABELS: Readonly<Record<string, string>> = {
+	// Excel
+	get_workbook_info: "Reading workbook structure",
+	list_sheets: "Listing sheets",
+	read_range: "Reading cells",
+	read_table: "Reading table",
+	get_formulas: "Reading formulas",
+	get_cell_metadata: "Reading cell formatting",
+	read_named_range: "Reading named range",
+	write_range: "Writing cells",
+	sort_filter_table: "Sorting table",
+	// Word
+	read_document: "Reading document",
+	get_document_info: "Reading document structure",
+	read_paragraphs: "Reading paragraphs",
+	read_selection: "Reading selection",
+	get_comments: "Reading comments",
+	get_tracked_changes: "Reading tracked changes",
+	insert_text: "Inserting text",
+	insert_paragraph: "Inserting paragraph",
+	// PowerPoint
+	read_slides: "Reading slides",
+	get_presentation_info: "Reading presentation structure",
+	read_slide_shapes: "Reading slide shapes",
+	read_slide_layout: "Reading slide layout",
+	add_slide: "Adding slide",
+	add_text_box: "Adding text box",
+	modify_shape_text: "Editing shape text",
+};
+
+/** Title-case the first word of a de-snaked name: `take_screenshot` → `Take screenshot`. */
+function humanize(name: string): string {
+	const words = name.split("_").filter(Boolean).join(" ");
+	return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/** A friendly, compact activity label for a host-tool call. */
+export function toolActivityLabel(toolName: string): string {
+	const key = toolName.trim();
+	if (!key) return "Working";
+	return LABELS[key] ?? humanize(key);
+}

--- a/packages/chat-ui/src/types.ts
+++ b/packages/chat-ui/src/types.ts
@@ -25,6 +25,8 @@ export interface ChatMessage {
 	/** tool rows only: the tool name and whether it succeeded. */
 	tool?: string;
 	ok?: boolean;
+	/** tool rows only: the call is still in flight (renders a live spinner). */
+	running?: boolean;
 	/** Render this row as an error (system gutter, alert-red body). */
 	error?: boolean;
 	/** When set on the last message, the Transcript offers a Retry button. */

--- a/packages/chat-ui/test/Transcript.test.tsx
+++ b/packages/chat-ui/test/Transcript.test.tsx
@@ -11,12 +11,64 @@ test("renders user, assistant, and tool rows in the terminal gutter grid", () =>
 	const messages: ChatMessage[] = [
 		msg({ id: "1", role: "user", text: "hello there" }),
 		msg({ id: "2", role: "assistant", text: "hi **friend**" }),
-		msg({ id: "3", role: "tool", tool: "read", ok: true, text: "done" }),
+		msg({ id: "3", role: "tool", tool: "read_range", ok: true, text: "done" }),
 	];
 	render(<Transcript messages={messages} streaming={false} />);
 	expect(screen.getByText("hello there")).toBeDefined();
 	expect(screen.getByText(/hi/)).toBeDefined();
-	expect(screen.getByText(/read: ✓ done/)).toBeDefined();
+	// Tool rows show the humanized activity label (not the raw function name).
+	expect(screen.getByText("Reading cells")).toBeDefined();
+});
+
+test("a tool row humanizes the tool name and hides raw detail behind a disclosure", () => {
+	render(
+		<Transcript
+			messages={[msg({ id: "1", role: "tool", tool: "get_workbook_info", ok: true, text: '{"sheets":3}' })]}
+			streaming={false}
+		/>,
+	);
+	// Friendly label is visible…
+	expect(screen.getByText("Reading workbook structure")).toBeDefined();
+	// …and the raw payload lives in a collapsed <details> (present but not expanded).
+	const details = document.querySelector("details.tool-activity") as HTMLDetailsElement;
+	expect(details).not.toBeNull();
+	expect(details.open).toBe(false);
+	expect(details.textContent).toContain('{"sheets":3}');
+});
+
+test("a running tool row shows the label with a live spinner and no error glyph", () => {
+	render(
+		<Transcript
+			messages={[msg({ id: "1", role: "tool", tool: "read_table", ok: true, text: "", running: true })]}
+			streaming={true}
+		/>,
+	);
+	expect(screen.getByText("Reading table")).toBeDefined();
+	// A running row uses the spinner gutter class, not the ok/err glyphs.
+	expect(document.querySelector(".g-tool-run")).not.toBeNull();
+	expect(document.querySelector(".g-tool-err")).toBeNull();
+});
+
+test("a detail-less tool row renders a plain activity line (no disclosure)", () => {
+	render(
+		<Transcript
+			messages={[msg({ id: "1", role: "tool", tool: "read_slides", ok: true, text: "" })]}
+			streaming={false}
+		/>,
+	);
+	expect(screen.getByText("Reading slides")).toBeDefined();
+	expect(document.querySelector("details.tool-activity")).toBeNull();
+});
+
+test("a failed tool row shows the error glyph", () => {
+	render(
+		<Transcript
+			messages={[msg({ id: "1", role: "tool", tool: "write_range", ok: false, text: "denied" })]}
+			streaming={false}
+		/>,
+	);
+	expect(screen.getByText("Writing cells")).toBeDefined();
+	expect(document.querySelector(".g-tool-err")).not.toBeNull();
 });
 
 test("the transcript is a labelled polite live region (a11y carried from the Fluent hosts)", () => {

--- a/packages/chat-ui/test/tool-activity-label.test.ts
+++ b/packages/chat-ui/test/tool-activity-label.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { toolActivityLabel } from "../src/tools/activity-label";
+
+describe("toolActivityLabel", () => {
+	test("maps every Excel host tool to a friendly present-tense label", () => {
+		expect(toolActivityLabel("get_workbook_info")).toBe("Reading workbook structure");
+		expect(toolActivityLabel("list_sheets")).toBe("Listing sheets");
+		expect(toolActivityLabel("read_range")).toBe("Reading cells");
+		expect(toolActivityLabel("read_table")).toBe("Reading table");
+		expect(toolActivityLabel("get_formulas")).toBe("Reading formulas");
+		expect(toolActivityLabel("get_cell_metadata")).toBe("Reading cell formatting");
+		expect(toolActivityLabel("read_named_range")).toBe("Reading named range");
+		expect(toolActivityLabel("write_range")).toBe("Writing cells");
+		expect(toolActivityLabel("sort_filter_table")).toBe("Sorting table");
+	});
+
+	test("maps every Word host tool to a friendly label", () => {
+		expect(toolActivityLabel("read_document")).toBe("Reading document");
+		expect(toolActivityLabel("get_document_info")).toBe("Reading document structure");
+		expect(toolActivityLabel("read_paragraphs")).toBe("Reading paragraphs");
+		expect(toolActivityLabel("read_selection")).toBe("Reading selection");
+		expect(toolActivityLabel("get_comments")).toBe("Reading comments");
+		expect(toolActivityLabel("get_tracked_changes")).toBe("Reading tracked changes");
+		expect(toolActivityLabel("insert_text")).toBe("Inserting text");
+		expect(toolActivityLabel("insert_paragraph")).toBe("Inserting paragraph");
+	});
+
+	test("maps every PowerPoint host tool to a friendly label", () => {
+		expect(toolActivityLabel("read_slides")).toBe("Reading slides");
+		expect(toolActivityLabel("get_presentation_info")).toBe("Reading presentation structure");
+		expect(toolActivityLabel("read_slide_shapes")).toBe("Reading slide shapes");
+		expect(toolActivityLabel("read_slide_layout")).toBe("Reading slide layout");
+		expect(toolActivityLabel("add_slide")).toBe("Adding slide");
+		expect(toolActivityLabel("add_text_box")).toBe("Adding text box");
+		expect(toolActivityLabel("modify_shape_text")).toBe("Editing shape text");
+	});
+
+	test("humanizes unknown snake_case tool names gracefully (browser/other tools)", () => {
+		expect(toolActivityLabel("navigate")).toBe("Navigate");
+		expect(toolActivityLabel("read_page")).toBe("Read page");
+		expect(toolActivityLabel("take_screenshot")).toBe("Take screenshot");
+	});
+
+	test("trims and tolerates empty / whitespace tool names without throwing", () => {
+		expect(toolActivityLabel("")).toBe("Working");
+		expect(toolActivityLabel("   ")).toBe("Working");
+	});
+});

--- a/packages/office-pane/src/panel/adapt.ts
+++ b/packages/office-pane/src/panel/adapt.ts
@@ -81,13 +81,24 @@ export function turnsToMessages(view: SessionView): ChatMessage[] {
 	const { turns, status, reason, error } = view;
 	const lastUserText = [...turns].reverse().find((t): t is Extract<Turn, { kind: "user" }> => t.kind === "user")?.text;
 
-	const msgs: ChatMessage[] = turns.map(t =>
-		t.kind === "user"
-			? { id: t.id, role: "user", text: t.text }
-			: t.state.status === "error"
+	const msgs: ChatMessage[] = turns.flatMap(t => {
+		if (t.kind === "user") return [{ id: t.id, role: "user", text: t.text } as ChatMessage];
+		// Live tool-activity rows precede the assistant's text for the same turn, so
+		// the reader sees "Reading workbook structure…" then the answer streams in.
+		const toolRows: ChatMessage[] = t.activities.map((a, i) => ({
+			id: `${t.state.id}-tool-${i}`,
+			role: "tool",
+			text: "",
+			tool: a.tool,
+			ok: a.ok,
+			running: a.running,
+		}));
+		const body: ChatMessage =
+			t.state.status === "error"
 				? { id: t.state.id, role: "assistant", text: errorText(t.state.reason, t.state.error), error: true }
-				: { id: t.state.id, role: "assistant", text: t.state.text },
-	);
+				: { id: t.state.id, role: "assistant", text: t.state.text };
+		return [...toolRows, body];
+	});
 
 	// A connect-level error isn't reflected in any assistant turn — surface it.
 	const lastIsError = msgs.length > 0 && msgs[msgs.length - 1].error === true;

--- a/packages/office-pane/src/panel/tool-activity.ts
+++ b/packages/office-pane/src/panel/tool-activity.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure tool-activity folding for the transcript's live "Reading data…" rows.
+ *
+ * xcsh's chat-handler emits a `chat_tool_notice` on every tool_execution_start
+ * and tool_execution_end (host tools AND engine tools), carrying `{ tool, ok }`
+ * but NO per-call id. So start↔end are paired by tool name: a notice whose tool
+ * already has a still-running activity SETTLES it; otherwise it STARTS a new one.
+ * Sequential same-tool calls therefore become distinct rows (settle, then start),
+ * which is exactly what a reader wants to see.
+ *
+ * Browser-safe: no node:* imports, no Office.js. Framework-free + immutable.
+ */
+import type { ChatToolNoticeMsg } from "../core";
+
+export interface ToolActivity {
+	readonly tool: string;
+	readonly running: boolean;
+	readonly ok: boolean;
+}
+
+/** Fold one `chat_tool_notice` into a turn's ordered activity list. */
+export function foldToolNotice(activities: readonly ToolActivity[], notice: ChatToolNoticeMsg): ToolActivity[] {
+	const idx = activities.findIndex(a => a.running && a.tool === notice.tool);
+	if (idx >= 0) {
+		const next = activities.slice();
+		next[idx] = { ...next[idx], running: false, ok: notice.ok };
+		return next;
+	}
+	return [...activities, { tool: notice.tool, running: true, ok: notice.ok }];
+}
+
+/**
+ * Settle any still-running activities — called when the turn reaches a terminal
+ * frame (chat_done / chat_error) so an unclosed activity never spins forever.
+ * Returns the same reference when nothing is running (avoids a needless re-render).
+ */
+export function settleActivities(activities: readonly ToolActivity[]): ToolActivity[] {
+	if (!activities.some(a => a.running)) return activities as ToolActivity[];
+	return activities.map(a => (a.running ? { ...a, running: false } : a));
+}

--- a/packages/office-pane/src/panel/useChatSession.ts
+++ b/packages/office-pane/src/panel/useChatSession.ts
@@ -15,6 +15,7 @@ import {
 	type Transport,
 	type TurnState,
 } from "../core";
+import { foldToolNotice, settleActivities, type ToolActivity } from "./tool-activity";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -57,6 +58,9 @@ export interface UserTurn {
 export interface AssistantTurn {
 	kind: "assistant";
 	state: TurnState;
+	/** Live tool-activity rows for this turn, folded from `chat_tool_notice`
+	 *  (both host and engine tools), in call order. */
+	activities: ToolActivity[];
 }
 
 export type Turn = UserTurn | AssistantTurn;
@@ -139,13 +143,26 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 		const unsub = transport.onMessage(msg => {
 			// Narrow to ChatStreamMsg via the discriminated union on `type`.
 			if (msg.type === "chat_delta" || msg.type === "chat_done" || msg.type === "chat_error") {
+				const terminal = msg.type === "chat_done" || msg.type === "chat_error";
 				setTurns(prev =>
 					prev.map(turn => {
 						if (turn.kind === "assistant" && turn.state.id === msg.id) {
-							return { kind: "assistant", state: reduceChatTurn(turn.state, msg) };
+							// A terminal frame settles any activity still marked running.
+							const activities = terminal ? settleActivities(turn.activities) : turn.activities;
+							return { kind: "assistant", state: reduceChatTurn(turn.state, msg), activities };
 						}
 						return turn;
 					}),
+				);
+			} else if (msg.type === "chat_tool_notice") {
+				// Live tool activity: fold the notice into its turn's activity list so
+				// the transcript shows "Reading data…" while xcsh works (Claude parity).
+				setTurns(prev =>
+					prev.map(turn =>
+						turn.kind === "assistant" && turn.state.id === msg.id
+							? { kind: "assistant", state: turn.state, activities: foldToolNotice(turn.activities, msg) }
+							: turn,
+					),
 				);
 			}
 		});
@@ -165,7 +182,7 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 			activeTurnIdRef.current = id;
 
 			const userTurn: UserTurn = { kind: "user", id: `u-${counterRef.current}`, text };
-			const assistantTurn: AssistantTurn = { kind: "assistant", state: initTurn(id) };
+			const assistantTurn: AssistantTurn = { kind: "assistant", state: initTurn(id), activities: [] };
 
 			setTurns(prev => [...prev, userTurn, assistantTurn]);
 
@@ -191,6 +208,7 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 							? {
 									kind: "assistant",
 									state: { ...turn.state, status: "error", error: message, reason: "bridge-disconnected" },
+									activities: turn.activities,
 								}
 							: turn,
 					),

--- a/packages/office-pane/test/adapt.test.ts
+++ b/packages/office-pane/test/adapt.test.ts
@@ -8,10 +8,16 @@ function user(id: string, text: string): UserTurn {
 	return { kind: "user", id, text };
 }
 
-function assistant(id: string, text: string, over: Partial<AssistantTurn["state"]> = {}): AssistantTurn {
+function assistant(
+	id: string,
+	text: string,
+	over: Partial<AssistantTurn["state"]> = {},
+	activities: AssistantTurn["activities"] = [],
+): AssistantTurn {
 	return {
 		kind: "assistant",
 		state: { id, text, status: "done", references: [], lastSeq: text.length - 1, pending: {}, ...over },
+		activities,
 	};
 }
 
@@ -101,5 +107,53 @@ describe("turnsToMessages", () => {
 		const msgs = turnsToMessages({ turns, status: "error", reason: "no-worker" });
 		expect(msgs).toHaveLength(2);
 		expect(msgs.filter(m => m.error)).toHaveLength(1);
+	});
+
+	test("emits tool-activity rows BEFORE the assistant text of the same turn, in call order", () => {
+		const turns: Turn[] = [
+			user("u-1", "summarize"),
+			assistant("c-1", "Here is the summary.", {}, [
+				{ tool: "get_workbook_info", running: false, ok: true },
+				{ tool: "read_range", running: false, ok: true },
+			]),
+		];
+		const msgs = turnsToMessages({ turns, status: "done" });
+		expect(msgs).toEqual([
+			{ id: "u-1", role: "user", text: "summarize" },
+			{ id: "c-1-tool-0", role: "tool", text: "", tool: "get_workbook_info", ok: true, running: false },
+			{ id: "c-1-tool-1", role: "tool", text: "", tool: "read_range", ok: true, running: false },
+			{ id: "c-1", role: "assistant", text: "Here is the summary." },
+		]);
+	});
+
+	test("a still-running activity on a streaming turn renders a running tool row before the thinking body", () => {
+		const turns: Turn[] = [
+			user("u-1", "read it"),
+			assistant("c-1", "", { status: "streaming" }, [{ tool: "read_table", running: true, ok: true }]),
+		];
+		const msgs = turnsToMessages({ turns, status: "streaming" });
+		expect(msgs[1]).toEqual({
+			id: "c-1-tool-0",
+			role: "tool",
+			text: "",
+			tool: "read_table",
+			ok: true,
+			running: true,
+		});
+		expect(msgs[2]).toMatchObject({ id: "c-1", role: "assistant", text: "" });
+	});
+
+	test("tool rows precede the body so an errored turn still gets its Retry on the last row", () => {
+		const turns: Turn[] = [
+			user("u-1", "go"),
+			assistant("c-1", "", { status: "error", reason: "provider-5xx" }, [
+				{ tool: "get_workbook_info", running: false, ok: true },
+			]),
+		];
+		const msgs = turnsToMessages({ turns, status: "error", reason: "provider-5xx" });
+		expect(msgs[1]).toMatchObject({ role: "tool", tool: "get_workbook_info" });
+		const last = msgs[msgs.length - 1];
+		expect(last).toMatchObject({ id: "c-1", role: "assistant", error: true });
+		expect(last.retryText).toBe("go");
 	});
 });

--- a/packages/office-pane/test/tool-activity.test.ts
+++ b/packages/office-pane/test/tool-activity.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import type { ChatToolNoticeMsg } from "../src/core";
+import { foldToolNotice, settleActivities, type ToolActivity } from "../src/panel/tool-activity";
+
+function notice(tool: string, ok = true): ChatToolNoticeMsg {
+	return { type: "chat_tool_notice", id: "c-1", tool, ok };
+}
+
+describe("foldToolNotice", () => {
+	test("a first notice for a tool STARTS a running activity", () => {
+		const next = foldToolNotice([], notice("get_workbook_info"));
+		expect(next).toEqual([{ tool: "get_workbook_info", running: true, ok: true }]);
+	});
+
+	test("a second notice for the same tool SETTLES the running activity (carrying its ok)", () => {
+		const started = foldToolNotice([], notice("read_range"));
+		const settled = foldToolNotice(started, notice("read_range", true));
+		expect(settled).toEqual([{ tool: "read_range", running: false, ok: true }]);
+	});
+
+	test("a failing end notice settles the activity as not-ok", () => {
+		const started = foldToolNotice([], notice("write_range"));
+		const settled = foldToolNotice(started, notice("write_range", false));
+		expect(settled).toEqual([{ tool: "write_range", running: false, ok: false }]);
+	});
+
+	test("distinct tools accumulate as separate rows in call order", () => {
+		let acts: ToolActivity[] = [];
+		acts = foldToolNotice(acts, notice("get_workbook_info"));
+		acts = foldToolNotice(acts, notice("get_workbook_info")); // end
+		acts = foldToolNotice(acts, notice("read_range"));
+		expect(acts).toEqual([
+			{ tool: "get_workbook_info", running: false, ok: true },
+			{ tool: "read_range", running: true, ok: true },
+		]);
+	});
+
+	test("sequential calls to the SAME tool produce two distinct rows", () => {
+		let acts: ToolActivity[] = [];
+		acts = foldToolNotice(acts, notice("read_range")); // start #1
+		acts = foldToolNotice(acts, notice("read_range")); // end #1
+		acts = foldToolNotice(acts, notice("read_range")); // start #2
+		expect(acts).toEqual([
+			{ tool: "read_range", running: false, ok: true },
+			{ tool: "read_range", running: true, ok: true },
+		]);
+	});
+
+	test("does not mutate the input array", () => {
+		const acts: ToolActivity[] = [];
+		foldToolNotice(acts, notice("x"));
+		expect(acts).toEqual([]);
+	});
+});
+
+describe("settleActivities", () => {
+	test("marks every still-running activity as settled", () => {
+		const acts: ToolActivity[] = [
+			{ tool: "a", running: true, ok: true },
+			{ tool: "b", running: false, ok: true },
+		];
+		expect(settleActivities(acts)).toEqual([
+			{ tool: "a", running: false, ok: true },
+			{ tool: "b", running: false, ok: true },
+		]);
+	});
+
+	test("returns the same reference when nothing is running (no needless churn)", () => {
+		const acts: ToolActivity[] = [{ tool: "a", running: false, ok: true }];
+		expect(settleActivities(acts)).toBe(acts);
+	});
+});

--- a/packages/office-pane/test/useChatSession.test.tsx
+++ b/packages/office-pane/test/useChatSession.test.tsx
@@ -141,6 +141,65 @@ test("streaming deltas + chat_done accumulates text and sets status done", async
 	}
 });
 
+test("chat_tool_notice folds live tool activity onto the active assistant turn", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+
+	await act(async () => {
+		result.current.send("summarize the workbook");
+	});
+	const id = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request")[0]?.id;
+	if (!id) throw new Error("expected chat_request in mock.sent");
+
+	// Tool starts → a running activity appears on the turn.
+	await act(async () => {
+		mock.emit({ type: "chat_tool_notice", id, tool: "get_workbook_info", ok: true, detail: "…: running…" });
+	});
+	let turn = result.current.turns.find(t => t.kind === "assistant");
+	if (turn?.kind !== "assistant") throw new Error("no assistant turn");
+	expect(turn.activities).toEqual([{ tool: "get_workbook_info", running: true, ok: true }]);
+
+	// Tool ends → it settles; the next tool starts running.
+	await act(async () => {
+		mock.emit({ type: "chat_tool_notice", id, tool: "get_workbook_info", ok: true, detail: "…: done" });
+		mock.emit({ type: "chat_tool_notice", id, tool: "read_range", ok: true, detail: "…: running…" });
+	});
+	turn = result.current.turns.find(t => t.kind === "assistant");
+	if (turn?.kind !== "assistant") throw new Error("no assistant turn");
+	expect(turn.activities).toEqual([
+		{ tool: "get_workbook_info", running: false, ok: true },
+		{ tool: "read_range", running: true, ok: true },
+	]);
+
+	// chat_done settles any still-running activity (no eternal spinner).
+	await act(async () => {
+		mock.emit({ type: "chat_delta", id, seq: 0, delta: "Done." });
+		mock.emit({ type: "chat_done", id });
+	});
+	turn = result.current.turns.find(t => t.kind === "assistant");
+	if (turn?.kind !== "assistant") throw new Error("no assistant turn");
+	expect(turn.activities.every(a => !a.running)).toBe(true);
+	expect(turn.state.text).toBe("Done.");
+});
+
+test("a failing chat_tool_notice end marks the activity not-ok", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	await act(async () => {
+		result.current.send("write it");
+	});
+	const id = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request")[0]?.id;
+	if (!id) throw new Error("expected chat_request in mock.sent");
+
+	await act(async () => {
+		mock.emit({ type: "chat_tool_notice", id, tool: "write_range", ok: true, detail: "…: running…" });
+		mock.emit({ type: "chat_tool_notice", id, tool: "write_range", ok: false, detail: "…: failed" });
+	});
+	const turn = result.current.turns.find(t => t.kind === "assistant");
+	if (turn?.kind !== "assistant") throw new Error("no assistant turn");
+	expect(turn.activities).toEqual([{ tool: "write_range", running: false, ok: false }]);
+});
+
 test("send() on a throwing (closed) transport surfaces an error turn — no perpetual spinner", async () => {
 	// A transport whose connect() resolves but send() throws (state 'closed').
 	const closedTransport: Transport = {


### PR DESCRIPTION
Closes #2234.

## What

The Office pane now shows a live, humanized **"Reading data…"** activity line while xcsh works — parity with Claude for Office. Before this, the pane rendered nothing during tool use: the 24 Office.js host tools ran invisibly and the user stared at a spinner until the final answer streamed.

## How (pane-side only — no engine/bridge/protocol change)

- **Signal (already flowing, was dropped):** xcsh's `chat-handler` emits a `chat_tool_notice` on every `tool_execution_start`/`tool_execution_end` — host tools **and** engine tools. The loopback transport already forwards these to `onMessage`; the pane just never rendered them.
- **`useChatSession`** folds each notice onto the active assistant turn. The notice has no per-call id, so start↔end pair by **tool name**: a notice whose tool already has a running activity *settles* it (carrying `ok`); otherwise it *starts* a new one. Sequential same-tool calls become distinct rows. A terminal frame (`chat_done`/`chat_error`) settles any still-running activity so nothing spins forever.
- **`turnsToMessages`** expands each assistant turn into `[tool rows…, body]`, so activity precedes the answer and the error/Retry logic still lands on the last row.
- **chat-ui `toolActivityLabel`** maps the Office tool names → friendly labels (`get_workbook_info` → "Reading workbook structure", `write_range` → "Writing cells", …) with a graceful `snake_case`→Title-case fallback for browser/other tools.
- **`ToolMessage`** now renders the humanized label + a running spinner + status glyph, with raw payload (when present) behind a collapsed `<details>` disclosure — replacing the flat `"${tool}: ✓ ${text}"` line. This lifts all three shared surfaces (office/chrome/vscode) per the chat-UI unification epic.

## Tests (TDD)

- `tool-activity-label.test.ts` — every Office tool mapped + fallback + empty-name guard.
- `tool-activity.test.ts` — pure `foldToolNotice`/`settleActivities` (start, settle, fail, sequential same-tool, immutability).
- `useChatSession.test.tsx` — notices fold onto the turn; failing end marks not-ok; `chat_done` settles running.
- `adapt.test.ts` — tool rows precede the body, in call order; streaming + error-retry ordering preserved.
- `Transcript.test.tsx` — humanized label, running spinner class, collapsible detail, error glyph, detail-less plain line.

## Verification

- chat-ui: 196 tests green (118 + 78 markdown); office-pane: 316 green.
- `tsgo` (per-package strict) clean; `biome check` clean; office build **155.8KB / 256KB** gz budget.
- Live-in-Excel visual confirmation is the operator's sideload step (automated coverage is above).

## Non-goals

- Per-tool streamed output detail (the pane observes notices, not the outbound `host_tool_result`; a later dispatcher `onActivity` hook could add precise payloads). Activities settle at the turn boundary.
- Citation chips / References drawer — separate item; references already render inline as markdown links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)