### PR TITLE
feat(office-pane): surface cited sources as a "Sources" chip row (References parity)

### DIFF
--- a/packages/chat-ui/src/components/ReferenceChips.tsx
+++ b/packages/chat-ui/src/components/ReferenceChips.tsx
@@ -1,0 +1,58 @@
+/**
+ * "Sources" chip row — the references the assistant cited (F5 docs pages and
+ * tenant-console deep links), surfaced beneath its answer for scannability.
+ * Parity with Claude for Office's References affordance.
+ *
+ * Each chip is a safe external link: URLs are gated through the same `isSafeUrl`
+ * the markdown sanitizer uses, so a non-http(s) URL renders as inert text rather
+ * than a clickable `javascript:`/`data:` sink. References are deduped by URL.
+ */
+import { isSafeUrl } from "../markdown/render";
+import type { ChatReference } from "../types";
+
+export interface ReferenceChipsProps {
+	references: ChatReference[];
+}
+
+/** Kind → short tag glyph, kept in the terminal aesthetic (no emoji). */
+const KIND_TAG: Record<ChatReference["kind"], string> = { doc: "DOC", console: "CON" };
+
+export function ReferenceChips({ references }: ReferenceChipsProps) {
+	// Dedupe by URL, preserving first-seen order.
+	const seen = new Set<string>();
+	const unique = references.filter(r => (seen.has(r.url) ? false : (seen.add(r.url), true)));
+	if (unique.length === 0) return null;
+
+	// Semantic <ul>/<li> (not role="list") — the anchor inside each <li> keeps its
+	// native `link` role, and the list a11y comes free from the element itself.
+	return (
+		<ul className="references" aria-label="Sources">
+			{unique.map(r => {
+				const tag = (
+					<span className="ref-tag" aria-hidden="true">
+						{KIND_TAG[r.kind]}
+					</span>
+				);
+				return (
+					<li key={r.url} className="ref-item">
+						{isSafeUrl(r.url) ? (
+							<a className={`ref-chip ref-${r.kind}`} href={r.url} target="_blank" rel="noopener noreferrer">
+								{tag}
+								<span className="ref-title">{r.title}</span>
+								<span className="ref-ext" aria-hidden="true">
+									↗
+								</span>
+							</a>
+						) : (
+							// Unsafe URLs are shown as inert text — never a clickable sink.
+							<span className={`ref-chip ref-${r.kind} ref-unsafe`}>
+								{tag}
+								<span className="ref-title">{r.title}</span>
+							</span>
+						)}
+					</li>
+				);
+			})}
+		</ul>
+	);
+}

--- a/packages/chat-ui/src/components/Transcript.tsx
+++ b/packages/chat-ui/src/components/Transcript.tsx
@@ -102,5 +102,5 @@ function renderMessage(
 		);
 	}
 	if (!m.text && streaming) return <ThinkingIndicator key={m.id} />;
-	return <AssistantMessage key={m.id} text={m.text} />;
+	return <AssistantMessage key={m.id} text={m.text} references={m.references} />;
 }

--- a/packages/chat-ui/src/components/messages.tsx
+++ b/packages/chat-ui/src/components/messages.tsx
@@ -6,7 +6,9 @@
 import type { ReactNode } from "react";
 import { GLYPHS } from "../theme/tokens";
 import { toolActivityLabel } from "../tools/activity-label";
+import type { ChatReference } from "../types";
 import { MarkdownRenderer } from "./MarkdownRenderer";
+import { ReferenceChips } from "./ReferenceChips";
 
 export interface GutterRowProps {
 	glyph: string;
@@ -25,15 +27,18 @@ export function GutterRow({ glyph, glyphClass, children }: GutterRowProps) {
 
 export interface AssistantMessageProps {
 	text: string;
+	/** Cited sources, rendered as a "Sources" chip row beneath the answer. */
+	references?: ChatReference[];
 }
 
-export function AssistantMessage({ text }: AssistantMessageProps) {
+export function AssistantMessage({ text, references }: AssistantMessageProps) {
 	// renderMarkdown output is DOMPurify-sanitized (see markdown/sanitize.ts). The
 	// `markdown-root` class opts the assistant body into the block stylesheet
 	// (tables, headings, lists, code) — matching ContentBlockRenderer's text path.
 	return (
 		<GutterRow glyph={GLYPHS.assistant} glyphClass="g-assistant">
 			<MarkdownRenderer className="body markdown-root" text={text} />
+			{references && references.length > 0 ? <ReferenceChips references={references} /> : null}
 		</GutterRow>
 	);
 }

--- a/packages/chat-ui/src/index.ts
+++ b/packages/chat-ui/src/index.ts
@@ -44,6 +44,7 @@ export {
 	UserMessage,
 	type UserMessageProps,
 } from "./components/messages";
+export { ReferenceChips, type ReferenceChipsProps } from "./components/ReferenceChips";
 export { SlashCommandMenu, type SlashCommandMenuProps } from "./components/SlashCommandMenu";
 export { StatusBar, type StatusBarProps } from "./components/StatusBar";
 export { ThinkingBlock, type ThinkingBlockProps } from "./components/ThinkingBlock";
@@ -79,6 +80,7 @@ export type {
 	ActivationGate,
 	AttachCategory,
 	ChatMessage,
+	ChatReference,
 	ChatRole,
 	ContentBlock,
 	GateStatus,

--- a/packages/chat-ui/src/theme/panel.css.ts
+++ b/packages/chat-ui/src/theme/panel.css.ts
@@ -83,6 +83,20 @@ body { background: var(--charcoal); color: var(--bright-white);
 .tool-activity[open] > summary::before { transform: rotate(90deg); }
 .tool-activity-detail { margin:4px 0 0 12px; padding:6px 8px; background: var(--code-bg); border:1px solid var(--subtle-gray);
   border-radius:6px; color: var(--cool-gray); font-size:11px; white-space:pre-wrap; overflow:auto; max-height:16em; }
+
+/* ── "Sources" chip row (cited F5 docs / console links) ─────────────────── */
+.references { display:flex; flex-wrap:wrap; gap:6px; margin-top:8px; padding:0; list-style:none; }
+.ref-item { display:inline-flex; }
+.ref-chip { display:inline-flex; align-items:center; gap:6px; padding:2px 8px; font-size:11px; text-decoration:none;
+  border:1px solid var(--subtle-gray); border-radius:999px; background: var(--deep-charcoal); color: var(--cool-gray);
+  max-width:100%; }
+a.ref-chip:hover { border-color: var(--chrome-accent); }
+.ref-tag { font-size:9px; letter-spacing:.5px; padding:0 4px; border-radius:4px; background: var(--subtle-gray);
+  color: var(--bright-white); flex:none; }
+.ref-console .ref-tag { background: var(--f5-red); }
+.ref-title { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; max-width:22ch; }
+.ref-ext { color: var(--dim); flex:none; }
+.ref-unsafe { opacity:.6; }
 .error { color: var(--alert-red); }
 pre.code { background:var(--code-bg); border:1px solid var(--subtle-gray); border-radius:6px; padding:8px; overflow:auto; }
 code { background:var(--code-bg); padding:1px 5px; border-radius:4px; }

--- a/packages/chat-ui/src/types.ts
+++ b/packages/chat-ui/src/types.ts
@@ -31,6 +31,15 @@ export interface ChatMessage {
 	error?: boolean;
 	/** When set on the last message, the Transcript offers a Retry button. */
 	retryText?: string;
+	/** assistant rows only: cited sources, rendered as a "Sources" chip row. */
+	references?: ChatReference[];
+}
+
+/** A source the assistant cited — an F5 docs page or a tenant-console deep link. */
+export interface ChatReference {
+	kind: "doc" | "console";
+	title: string;
+	url: string;
 }
 
 /** A conversation-mode option (the mode LIST is a host-provided prop). */

--- a/packages/chat-ui/test/ReferenceChips.test.tsx
+++ b/packages/chat-ui/test/ReferenceChips.test.tsx
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import { ReferenceChips } from "../src/components/ReferenceChips";
+import type { ChatReference } from "../src/types";
+
+const doc: ChatReference = { kind: "doc", title: "WAF overview", url: "https://docs.cloud.f5.com/waf" };
+const console: ChatReference = {
+	kind: "console",
+	title: "HTTP LB",
+	url: "https://acme.console.ves.volterra.io/lb",
+};
+
+test("renders a labelled Sources list with one chip per reference", () => {
+	render(<ReferenceChips references={[doc, console]} />);
+	const list = screen.getByRole("list", { name: /sources/i });
+	expect(list).toBeDefined();
+	expect(screen.getByText("WAF overview")).toBeDefined();
+	expect(screen.getByText("HTTP LB")).toBeDefined();
+});
+
+test("each chip is a safe external link (new tab, noopener) tagged by kind", () => {
+	render(<ReferenceChips references={[doc, console]} />);
+	const docLink = screen.getByRole("link", { name: /WAF overview/ }) as HTMLAnchorElement;
+	expect(docLink.getAttribute("href")).toBe(doc.url);
+	expect(docLink.getAttribute("target")).toBe("_blank");
+	expect(docLink.getAttribute("rel")).toContain("noopener");
+	expect(docLink.className).toContain("ref-doc");
+	const consoleLink = screen.getByRole("link", { name: /HTTP LB/ }) as HTMLAnchorElement;
+	expect(consoleLink.className).toContain("ref-console");
+});
+
+test("dedupes references by URL", () => {
+	render(<ReferenceChips references={[doc, { ...doc, title: "dupe" }]} />);
+	expect(screen.getAllByRole("link")).toHaveLength(1);
+});
+
+test("an unsafe (non-http) URL is rendered as plain text, not a link", () => {
+	const evil: ChatReference = { kind: "doc", title: "evil", url: "javascript:alert(1)" };
+	render(<ReferenceChips references={[evil]} />);
+	expect(screen.queryByRole("link")).toBeNull();
+	expect(screen.getByText("evil")).toBeDefined();
+});
+
+test("renders nothing when there are no references", () => {
+	const { container } = render(<ReferenceChips references={[]} />);
+	expect(container.firstChild).toBeNull();
+});

--- a/packages/office-pane/src/panel/adapt.ts
+++ b/packages/office-pane/src/panel/adapt.ts
@@ -93,10 +93,14 @@ export function turnsToMessages(view: SessionView): ChatMessage[] {
 			ok: a.ok,
 			running: a.running,
 		}));
+		// A completed turn carries the sources it cited (F5 docs / console links),
+		// which reduce.ts folds onto TurnState.references from the chat_done frame.
+		const references =
+			t.state.status === "done" && t.state.references.length > 0 ? [...t.state.references] : undefined;
 		const body: ChatMessage =
 			t.state.status === "error"
 				? { id: t.state.id, role: "assistant", text: errorText(t.state.reason, t.state.error), error: true }
-				: { id: t.state.id, role: "assistant", text: t.state.text };
+				: { id: t.state.id, role: "assistant", text: t.state.text, ...(references ? { references } : {}) };
 		return [...toolRows, body];
 	});
 

--- a/packages/office-pane/test/adapt.test.ts
+++ b/packages/office-pane/test/adapt.test.ts
@@ -156,4 +156,26 @@ describe("turnsToMessages", () => {
 		expect(last).toMatchObject({ id: "c-1", role: "assistant", error: true });
 		expect(last.retryText).toBe("go");
 	});
+
+	test("a done assistant turn carries its cited references onto the row", () => {
+		const refs = [
+			{ kind: "doc" as const, title: "WAF docs", url: "https://docs.cloud.f5.com/waf" },
+			{ kind: "console" as const, title: "HTTP LB", url: "https://acme.console.ves.volterra.io/lb" },
+		];
+		const turns: Turn[] = [user("u-1", "how?"), assistant("c-1", "See the docs.", { references: refs })];
+		const msgs = turnsToMessages({ turns, status: "done" });
+		expect(msgs[1]).toEqual({ id: "c-1", role: "assistant", text: "See the docs.", references: refs });
+	});
+
+	test("a streaming turn does not attach references (they arrive only on chat_done)", () => {
+		const turns: Turn[] = [user("u-1", "go"), assistant("c-1", "typing", { status: "streaming" })];
+		const msgs = turnsToMessages({ turns, status: "streaming" });
+		expect(msgs[1].references).toBeUndefined();
+	});
+
+	test("a done turn with no references gets no references field", () => {
+		const turns: Turn[] = [user("u-1", "hi"), assistant("c-1", "answer")];
+		const msgs = turnsToMessages({ turns, status: "done" });
+		expect(msgs[1].references).toBeUndefined();
+	});
 });


### PR DESCRIPTION
Closes #2236.

## What

A completed answer in the Office pane now shows a compact, scannable **"Sources"** chip row beneath it — the F5 docs pages and tenant-console deep links the assistant cited. Before, those sources existed only as inline links buried in the prose; the documented "References drawer" affordance (Claude-for-Office parity) never rendered.

## How (pane-side only — the data already flowed)

- The engine's `extractReferences()` already builds `ChatReference[]` (`{ kind: "doc" | "console"; title; url }`) on `chat_done`, and the Office pane's `reduce.ts` already stores them in `TurnState.references`. `turnsToMessages` was **dropping** them.
- **chat-ui `ReferenceChips`** — a semantic `<ul>/<li>` list of kind-tagged (`DOC`/`CON`) chips, deduped by URL, each a safe external link (`target=_blank`, `rel=noopener noreferrer`) gated through the same **`isSafeUrl`** the markdown sanitizer uses. A non-http(s) URL renders as inert text, never a clickable `javascript:`/`data:` sink.
- **`AssistantMessage`** renders the chips beneath the markdown body when the row carries references; `ChatMessage` gains `references?: ChatReference[]`.
- **`turnsToMessages`** attaches references to a **done** assistant turn only — not streaming, not error.

Lifts all three shared surfaces (office/chrome/vscode) per the chat-UI unification epic.

## Tests (TDD)

- `ReferenceChips.test.tsx` — labelled Sources list; safe new-tab links tagged by kind; dedupe by URL; unsafe URL → inert text (no link); empty → renders nothing.
- `adapt.test.ts` — references attach on a done turn; skipped on streaming; absent when empty.

## Verification

- chat-ui 201 tests green; office-pane 319 green.
- `tsgo` (per-package strict) clean — the office `ChatRefWire` and chat-ui `ChatReference` are structurally identical, so the adapt mapping type-checks.
- `biome check` exit 0 (incl. the a11y `useSemanticElements` rule — hence real `<ul>/<li>`, not `role="list"`); office build **156.3KB / 256KB** gz.
- Live-in-Excel visual confirmation is the operator's sideload step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)