### PR TITLE
feat(office): supersede a stale serve on start + `office recycle` (post-upgrade parity)

### DIFF
--- a/packages/coding-agent/src/browser/office-serve-lifecycle.ts
+++ b/packages/coding-agent/src/browser/office-serve-lifecycle.ts
@@ -1,0 +1,118 @@
+/**
+ * Supersede / recycle a foreground `xcsh office serve`.
+ *
+ * `office serve` binds a FIXED :8444 listener, so after a `brew upgrade` the old
+ * serve squats the port on the stale binary and a fresh `office serve` dies with
+ * "port 8444 in use". These helpers let the new serve step the old one down on
+ * start (supersede), and give `office recycle` (run from brew post_install) a way
+ * to stop the stale serve so the next start is clean — the office analog of
+ * `chrome recycle`.
+ *
+ * Safety: we only ever signal a PID that (a) actually holds :8444 AND (b) looks
+ * like an `office serve` (its `ps` command line contains "office serve"). A
+ * foreign holder is reported, never killed — so PID reuse can't make us signal an
+ * unrelated process.
+ */
+import { OFFICE_PANE_PORT } from "./office-pane-server";
+
+/** Injectable seams so the wait/signal logic is unit-testable without real procs. */
+export interface ServeLifecycleDeps {
+	/** PID listening on `port`, or 0 if none/unknown (best-effort via lsof). */
+	pidListeningOn: (port: number) => number;
+	/** Whether `pid`'s command line is an `xcsh office serve`. */
+	isOfficeServe: (pid: number) => boolean;
+	/** Send a signal to `pid` (process.kill). */
+	signal: (pid: number, sig: NodeJS.Signals) => void;
+	/** Await `ms` (setTimeout in prod; immediate in tests). */
+	sleep: (ms: number) => Promise<void>;
+}
+
+export interface SupersedeResult {
+	/** True when a stale serve was found and stepped down. */
+	superseded: boolean;
+	/** The stale PID we signalled (present only when superseded). */
+	pid?: number;
+}
+
+const WAIT_MS = 3000;
+const POLL_MS = 100;
+
+/** PID listening on `port`, or 0 (best-effort; lsof unavailable → 0). */
+function pidListeningOn(port: number): number {
+	try {
+		const out = Bun.spawnSync(["lsof", "-t", `-iTCP:${port}`, "-sTCP:LISTEN"])
+			.stdout.toString()
+			.trim()
+			.split("\n")[0];
+		const pid = Number(out);
+		return Number.isInteger(pid) && pid > 0 ? pid : 0;
+	} catch {
+		return 0;
+	}
+}
+
+/** Whether `pid`'s full command line is an `xcsh office serve` (ps, best-effort). */
+function isOfficeServe(pid: number): boolean {
+	try {
+		const out = Bun.spawnSync(["ps", "-p", String(pid), "-o", "command="]).stdout.toString();
+		return /office\s+serve/.test(out);
+	} catch {
+		return false;
+	}
+}
+
+const defaultDeps: ServeLifecycleDeps = {
+	pidListeningOn,
+	isOfficeServe,
+	signal: (pid, sig) => process.kill(pid, sig),
+	sleep: ms => new Promise(resolve => setTimeout(resolve, ms)),
+};
+
+/** SIGTERM `pid` and poll until `port` is released by it, or throw on timeout. */
+async function signalAndWait(pid: number, port: number, deps: ServeLifecycleDeps): Promise<void> {
+	deps.signal(pid, "SIGTERM");
+	for (let waited = 0; waited < WAIT_MS; waited += POLL_MS) {
+		await deps.sleep(POLL_MS);
+		const now = deps.pidListeningOn(port);
+		if (now <= 0 || now !== pid) return; // freed (or a different serve took over)
+	}
+	throw new Error(`Timed out waiting for the stale office serve (PID ${pid}) to release port ${port}.`);
+}
+
+/**
+ * Step down a stale `office serve` holding `port` so a fresh serve can bind.
+ * No-op when the port is free. Throws (without signalling) when the holder is not
+ * an office serve — the caller should surface that rather than kill a stranger.
+ */
+export async function supersedeStaleServe(
+	port = OFFICE_PANE_PORT,
+	deps: ServeLifecycleDeps = defaultDeps,
+): Promise<SupersedeResult> {
+	const pid = deps.pidListeningOn(port);
+	if (pid <= 0 || pid === process.pid) return { superseded: false };
+	if (!deps.isOfficeServe(pid)) {
+		throw new Error(
+			`Port ${port} is held by PID ${pid}, which isn't an xcsh office serve. Stop it manually, then retry.`,
+		);
+	}
+	await signalAndWait(pid, port, deps);
+	return { superseded: true, pid };
+}
+
+/**
+ * Stop a running `office serve` (if any) — used by `office recycle` and brew
+ * post_install so an upgrade clears the stale serve. Returns a human message;
+ * never throws for the ordinary cases (nothing running / foreign holder).
+ */
+export async function recycleOfficeServe(
+	port = OFFICE_PANE_PORT,
+	deps: ServeLifecycleDeps = defaultDeps,
+): Promise<string> {
+	const pid = deps.pidListeningOn(port);
+	if (pid <= 0) return "No xcsh office serve is running.";
+	if (!deps.isOfficeServe(pid)) {
+		return `Port ${port} is held by PID ${pid}, which isn't an xcsh office serve — leaving it alone.`;
+	}
+	await signalAndWait(pid, port, deps);
+	return `Stopped the running office serve (PID ${pid}). Start it again with \`xcsh office serve\`.`;
+}

--- a/packages/coding-agent/src/cli/office-cli.ts
+++ b/packages/coding-agent/src/cli/office-cli.ts
@@ -13,13 +13,15 @@ import { LOCALIP_HOST } from "../browser/bridge-cert";
 import { type HeadlessChatBridge, startHeadlessChatBridge } from "../browser/headless-bridge";
 import {
 	getOfficePaneDir,
+	OFFICE_PANE_PORT,
 	type OfficePaneServer,
 	readManifest,
 	startOfficePaneServer,
 } from "../browser/office-pane-server";
+import { recycleOfficeServe, supersedeStaleServe } from "../browser/office-serve-lifecycle";
 
 /** The subcommands `xcsh office` accepts (also the Args `options` constraint). */
-export const OFFICE_ACTIONS = ["serve", "manifest", "sideload"] as const;
+export const OFFICE_ACTIONS = ["serve", "manifest", "sideload", "recycle"] as const;
 export type OfficeAction = (typeof OFFICE_ACTIONS)[number];
 
 /** Desktop Office apps a sideload can target. */
@@ -50,9 +52,10 @@ export async function writeManifest(outPath?: string): Promise<string> {
 export interface OfficeServeDeps {
 	startOfficePaneServer: typeof startOfficePaneServer;
 	startHeadlessChatBridge: typeof startHeadlessChatBridge;
+	supersedeStaleServe: typeof supersedeStaleServe;
 }
 
-const defaultServeDeps: OfficeServeDeps = { startOfficePaneServer, startHeadlessChatBridge };
+const defaultServeDeps: OfficeServeDeps = { startOfficePaneServer, startHeadlessChatBridge, supersedeStaleServe };
 
 /** A running `office serve`: the pane file server, the (optional) chat bridge, and
  *  a teardown that disposes both. */
@@ -70,6 +73,14 @@ export interface OfficeServeHandle {
  * Extracted from {@link runServe} so the start/teardown wiring is unit-testable.
  */
 export async function startOfficeServe(deps: OfficeServeDeps = defaultServeDeps): Promise<OfficeServeHandle> {
+	// Step down a stale serve squatting :8444 (e.g. left over from before a
+	// `brew upgrade`) so this start binds cleanly instead of "port 8444 in use".
+	const superseded = await deps.supersedeStaleServe(OFFICE_PANE_PORT);
+	if (superseded.superseded) {
+		console.log(
+			`Superseded a previous office serve (PID ${superseded.pid}) that was holding port ${OFFICE_PANE_PORT}.`,
+		);
+	}
 	const server = await deps.startOfficePaneServer();
 	let chat: HeadlessChatBridge | null = null;
 	try {
@@ -169,6 +180,9 @@ export async function runOfficeCommand(args: OfficeCommandArgs): Promise<void> {
 		}
 		case "sideload":
 			await runSideload(args.app ?? "excel");
+			return;
+		case "recycle":
+			console.log(await recycleOfficeServe());
 			return;
 	}
 }

--- a/packages/coding-agent/src/commands/office.ts
+++ b/packages/coding-agent/src/commands/office.ts
@@ -9,7 +9,7 @@ export default class Office extends Command {
 
 	static args = {
 		action: Args.string({
-			description: "serve | manifest | sideload",
+			description: "serve | manifest | sideload | recycle",
 			required: false,
 			options: OFFICE_ACTIONS,
 		}),
@@ -31,6 +31,7 @@ export default class Office extends Command {
 			console.log("  serve     Start the https://127-0-0-1.local-ip.sh:8444 task-pane listener");
 			console.log("  manifest  Print (or -o write) the add-in manifest.json");
 			console.log("  sideload  Sideload the add-in into a desktop Office app");
+			console.log("  recycle   Stop a running serve (so the next `serve` starts clean after an upgrade)");
 			return;
 		}
 		await runOfficeCommand({

--- a/packages/coding-agent/test/browser/office-serve-lifecycle.test.ts
+++ b/packages/coding-agent/test/browser/office-serve-lifecycle.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import {
+	recycleOfficeServe,
+	type ServeLifecycleDeps,
+	supersedeStaleServe,
+} from "../../src/browser/office-serve-lifecycle";
+
+/**
+ * Build deps where `pidListeningOn` returns each element of `pids` on successive
+ * calls (last value repeats). `signal` records calls; `isOfficeServe` is fixed.
+ */
+function fakeDeps(pids: number[], isOffice: boolean) {
+	const signalled: Array<{ pid: number; sig: string }> = [];
+	let i = 0;
+	const deps: ServeLifecycleDeps = {
+		pidListeningOn: () => pids[Math.min(i++, pids.length - 1)] ?? 0,
+		isOfficeServe: () => isOffice,
+		signal: (pid, sig) => signalled.push({ pid, sig: String(sig) }),
+		sleep: async () => {},
+	};
+	return { deps, signalled };
+}
+
+describe("supersedeStaleServe", () => {
+	test("no holder → no-op, nothing signalled", async () => {
+		const { deps, signalled } = fakeDeps([0], true);
+		const r = await supersedeStaleServe(8444, deps);
+		expect(r).toEqual({ superseded: false });
+		expect(signalled).toHaveLength(0);
+	});
+
+	test("a stale office serve → SIGTERM, waits for the port to free, reports superseded", async () => {
+		// First probe finds PID 9739 (holder); after the signal the port frees (0).
+		const { deps, signalled } = fakeDeps([9739, 9739, 0], true);
+		const r = await supersedeStaleServe(8444, deps);
+		expect(r).toEqual({ superseded: true, pid: 9739 });
+		expect(signalled).toEqual([{ pid: 9739, sig: "SIGTERM" }]);
+	});
+
+	test("a NON-office holder is reported and NEVER signalled", async () => {
+		const { deps, signalled } = fakeDeps([4321], false);
+		await expect(supersedeStaleServe(8444, deps)).rejects.toThrow(/isn't an xcsh office serve/);
+		expect(signalled).toHaveLength(0);
+	});
+
+	test("a holder that never releases the port → timeout error (after signalling)", async () => {
+		const { deps, signalled } = fakeDeps([9739], true); // always the same pid
+		await expect(supersedeStaleServe(8444, deps)).rejects.toThrow(/release port 8444/);
+		expect(signalled).toEqual([{ pid: 9739, sig: "SIGTERM" }]);
+	});
+});
+
+describe("recycleOfficeServe", () => {
+	test("no serve running → clear no-op message, nothing signalled", async () => {
+		const { deps, signalled } = fakeDeps([0], true);
+		const msg = await recycleOfficeServe(8444, deps);
+		expect(msg).toMatch(/No xcsh office serve is running/i);
+		expect(signalled).toHaveLength(0);
+	});
+
+	test("a running office serve → SIGTERM + confirmation once the port frees", async () => {
+		const { deps, signalled } = fakeDeps([9739, 0], true);
+		const msg = await recycleOfficeServe(8444, deps);
+		expect(msg).toMatch(/Stopped the running office serve/i);
+		expect(signalled).toEqual([{ pid: 9739, sig: "SIGTERM" }]);
+	});
+
+	test("a foreign holder is left alone (not signalled)", async () => {
+		const { deps, signalled } = fakeDeps([4321], false);
+		const msg = await recycleOfficeServe(8444, deps);
+		expect(msg).toMatch(/isn't an xcsh office serve/i);
+		expect(signalled).toHaveLength(0);
+	});
+});

--- a/packages/coding-agent/test/office-cli.test.ts
+++ b/packages/coding-agent/test/office-cli.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import { type OfficeServeDeps, startOfficeServe } from "../src/cli/office-cli";
 
+/** A supersede seam that records it ran and reports nothing stale (no-op). */
+function noopSupersede() {
+	const calls: Array<number | undefined> = [];
+	const fn: OfficeServeDeps["supersedeStaleServe"] = async port => {
+		calls.push(port);
+		return { superseded: false };
+	};
+	return { fn, calls };
+}
+
 function fakePaneServer() {
 	const state = { stopped: false };
 	return {
@@ -21,6 +31,7 @@ describe("startOfficeServe", () => {
 	test("starts BOTH the pane server and the chat bridge; dispose tears down both", async () => {
 		const pane = fakePaneServer();
 		const chat = { disposed: false };
+		const supersede = noopSupersede();
 		const deps: OfficeServeDeps = {
 			startOfficePaneServer: (async () => pane.server) as OfficeServeDeps["startOfficePaneServer"],
 			startHeadlessChatBridge: (async () => ({
@@ -29,11 +40,14 @@ describe("startOfficeServe", () => {
 					chat.disposed = true;
 				},
 			})) as unknown as OfficeServeDeps["startHeadlessChatBridge"],
+			supersedeStaleServe: supersede.fn,
 		};
 
 		const handle = await startOfficeServe(deps);
 		expect(handle.server).toBe(pane.server);
 		expect(handle.chat).not.toBeNull();
+		// A stale serve is always stepped down before binding the pane.
+		expect(supersede.calls).toEqual([8444]);
 
 		await handle.dispose();
 		expect(chat.disposed).toBe(true);
@@ -47,6 +61,7 @@ describe("startOfficeServe", () => {
 			startHeadlessChatBridge: (async () => {
 				throw new Error("bridge boom");
 			}) as unknown as OfficeServeDeps["startHeadlessChatBridge"],
+			supersedeStaleServe: noopSupersede().fn,
 		};
 
 		const handle = await startOfficeServe(deps);
@@ -55,5 +70,26 @@ describe("startOfficeServe", () => {
 
 		await handle.dispose();
 		expect(pane.state.stopped).toBe(true);
+	});
+
+	test("a supersede failure (foreign holder on :8444) propagates — serve does NOT bind over a stranger", async () => {
+		const pane = fakePaneServer();
+		let paneStarted = false;
+		const deps: OfficeServeDeps = {
+			startOfficePaneServer: (async () => {
+				paneStarted = true;
+				return pane.server;
+			}) as OfficeServeDeps["startOfficePaneServer"],
+			startHeadlessChatBridge: (async () => ({
+				bridge: { port: 19222, wssPort: 19322 },
+				dispose: async () => {},
+			})) as unknown as OfficeServeDeps["startHeadlessChatBridge"],
+			supersedeStaleServe: (async () => {
+				throw new Error("Port 8444 is held by PID 4321, which isn't an xcsh office serve.");
+			}) as OfficeServeDeps["supersedeStaleServe"],
+		};
+
+		await expect(startOfficeServe(deps)).rejects.toThrow(/isn't an xcsh office serve/);
+		expect(paneStarted).toBe(false);
 	});
 });

--- a/scripts/ci-release-homebrew.ts
+++ b/scripts/ci-release-homebrew.ts
@@ -166,8 +166,12 @@ class Xcsh < Formula
   # just-installed binary, so the new version drives it. Best-effort — rescued so a
   # sandboxed or offline post_install can never fail the upgrade; the manager also
   # self-recycles on its next sweep/provision.
+  #
+  # Likewise stop a running "office serve" holding :8444 on the now-replaced binary,
+  # so the next "xcsh office serve" starts clean instead of "port 8444 in use".
   def post_install
     system bin/"xcsh", "chrome", "recycle"
+    system bin/"xcsh", "office", "recycle"
   rescue StandardError
     nil
   end

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -292,4 +292,7 @@ XCSH_BIN="$(command -v xcsh 2>/dev/null || true)"
 [ -z "$XCSH_BIN" ] && [ -x "$INSTALL_DIR/xcsh" ] && XCSH_BIN="$INSTALL_DIR/xcsh"
 if [ -n "$XCSH_BIN" ]; then
     "$XCSH_BIN" chrome recycle >/dev/null 2>&1 || true
+    # Also stop a running "office serve" squatting :8444 on the replaced binary, so
+    # the next `xcsh office serve` starts clean instead of "port 8444 in use".
+    "$XCSH_BIN" office recycle >/dev/null 2>&1 || true
 fi


### PR DESCRIPTION
Closes #2240.

## Problem

`xcsh office serve` binds a **fixed** `:8444` listener. After `brew upgrade`, the previously-running serve keeps squatting `:8444` on the *old* binary, so a fresh `office serve` dies with `Failed to start server. Is port 8444 in use?` — the exact error hit in practice. `brew upgrade`'s `post_install` already runs `xcsh chrome recycle` to hand the Chrome manager to the new binary; office had no equivalent.

## Solution (model: supersede-on-start, foreground)

serve stays a foreground process in your terminal. Added:

- **`office-serve-lifecycle.ts`** — `supersedeStaleServe` (SIGTERM the stale holder → poll until `:8444` frees → let the caller bind) and `recycleOfficeServe` (stop a running serve). Both only ever signal a PID that **actually holds `:8444`** AND whose `ps` command line is an `office serve`; a foreign holder is reported and **never** killed, so PID reuse can't make us signal a stranger. Injectable seams (`pidListeningOn`/`isOfficeServe`/`signal`/`sleep`) keep the wait logic unit-tested.
- **`startOfficeServe`** supersedes before binding — re-running `office serve` after an upgrade just works instead of erroring; a foreign-holder failure aborts rather than binding over a stranger.
- **`xcsh office recycle`** — new action mirroring `chrome recycle`.
- **`post_install` + `install.sh`** now run `office recycle` best-effort alongside `chrome recycle`, so an upgrade clears the stale serve automatically.

Port-holder detection reuses the Chrome manager's `lsof -t -iTCP:<port> -sTCP:LISTEN` idiom. Superseding the serve process frees `:8444` **and** its wss bridge (same process).

## Tests (TDD)

- `office-serve-lifecycle.test.ts` — supersede: free → no-op; xcsh holder → SIGTERM + wait; foreign holder → throws, never signals; never-frees → timeout. recycle: none running; running → stop; foreign → left alone.
- `office-cli.test.ts` — supersede runs before the pane binds; a foreign-holder supersede failure aborts the serve (pane never starts).

## Verification

- 14 office tests green (`office-serve-lifecycle` 7, `office-cli` 4, `commands/office` 3); `tsgo -p tsconfig.json` clean; `biome check` exit 0.
- Reproduces the fix for the real `:8444 in use` failure. Live post-upgrade behavior lands once released (the formula/install.sh `office recycle` runs on the next `brew upgrade`).

## Non-goals

- Background/daemonized serve (the managed-service model was considered and declined — foreground retained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)