### PR TITLE
feat(office-pane): chat-shell parity — New-chat reset + streaming caret

### DIFF
--- a/packages/chat-ui/src/components/Transcript.tsx
+++ b/packages/chat-ui/src/components/Transcript.tsx
@@ -102,5 +102,8 @@ function renderMessage(
 		);
 	}
 	if (!m.text && streaming) return <ThinkingIndicator key={m.id} />;
-	return <AssistantMessage key={m.id} text={m.text} references={m.references} />;
+	// The caret marks the live turn — only the last row while the session streams.
+	return (
+		<AssistantMessage key={m.id} text={m.text} references={m.references} streaming={streaming && m.id === lastId} />
+	);
 }

--- a/packages/chat-ui/src/components/messages.tsx
+++ b/packages/chat-ui/src/components/messages.tsx
@@ -29,15 +29,18 @@ export interface AssistantMessageProps {
 	text: string;
 	/** Cited sources, rendered as a "Sources" chip row beneath the answer. */
 	references?: ChatReference[];
+	/** This is the live turn: render a blinking caret after the text (live-typing cue). */
+	streaming?: boolean;
 }
 
-export function AssistantMessage({ text, references }: AssistantMessageProps) {
+export function AssistantMessage({ text, references, streaming }: AssistantMessageProps) {
 	// renderMarkdown output is DOMPurify-sanitized (see markdown/sanitize.ts). The
 	// `markdown-root` class opts the assistant body into the block stylesheet
 	// (tables, headings, lists, code) — matching ContentBlockRenderer's text path.
 	return (
 		<GutterRow glyph={GLYPHS.assistant} glyphClass="g-assistant">
 			<MarkdownRenderer className="body markdown-root" text={text} />
+			{streaming ? <span className="stream-caret" aria-hidden="true" /> : null}
 			{references && references.length > 0 ? <ReferenceChips references={references} /> : null}
 		</GutterRow>
 	);

--- a/packages/chat-ui/src/theme/panel.css.ts
+++ b/packages/chat-ui/src/theme/panel.css.ts
@@ -26,6 +26,10 @@ body { background: var(--charcoal); color: var(--bright-white);
 /* ── Header bar ─────────────────────────────────────────────────────────── */
 .header { display:flex; align-items:center; gap:6px; padding:6px 10px; border-bottom:1px solid var(--subtle-gray); }
 .header-title { color: var(--bright-white); font-size:12px; letter-spacing:.04em; }
+.header-new-chat { margin-left:auto; background:transparent; color: var(--cool-gray); border:1px solid var(--subtle-gray);
+  border-radius:6px; padding:2px 10px; font:inherit; font-size:11px; cursor:pointer; }
+.header-new-chat:hover:not(:disabled) { color: var(--bright-white); border-color: var(--chrome-accent); }
+.header-new-chat:disabled { opacity:.4; cursor:default; }
 .header-spacer { flex:1; }
 .header-btn { position:relative; display:flex; align-items:center; justify-content:center; width:28px; height:28px;
   background:none; border:1px solid transparent; color: var(--cool-gray); border-radius:6px; cursor:pointer;
@@ -101,6 +105,11 @@ a.ref-chip:hover { border-color: var(--chrome-accent); }
 pre.code { background:var(--code-bg); border:1px solid var(--subtle-gray); border-radius:6px; padding:8px; overflow:auto; }
 code { background:var(--code-bg); padding:1px 5px; border-radius:4px; }
 .spin { animation: spin 1s steps(8) infinite; } @keyframes spin { to { opacity:.4 } }
+/* Live-typing caret on the streaming assistant row. */
+.stream-caret { display:inline-block; width:0.5em; height:1em; margin-left:2px; vertical-align:text-bottom;
+  background: var(--f5-red); animation: caret-blink 1s step-end infinite; }
+@keyframes caret-blink { 50% { opacity:0 } }
+@media (prefers-reduced-motion: reduce) { .stream-caret { animation:none } }
 .body.error .msg-retry { margin-left:8px; background:transparent; color: var(--f5-red); border:1px solid var(--f5-red);
   border-radius:6px; padding:1px 8px; cursor:pointer; font:inherit; font-size:0.85em; vertical-align:baseline; }
 

--- a/packages/chat-ui/test/Transcript.test.tsx
+++ b/packages/chat-ui/test/Transcript.test.tsx
@@ -87,6 +87,28 @@ test("a streaming assistant row with no text yet shows the thinking indicator", 
 	expect(screen.getByText(/Thinking/)).toBeDefined();
 });
 
+test("the LAST assistant row shows a blinking caret WHILE streaming (with partial text)", () => {
+	render(<Transcript messages={[msg({ id: "1", role: "assistant", text: "partial" })]} streaming={true} />);
+	expect(document.querySelector(".stream-caret")).not.toBeNull();
+});
+
+test("a settled assistant row shows NO caret", () => {
+	render(<Transcript messages={[msg({ id: "1", role: "assistant", text: "done" })]} streaming={false} />);
+	expect(document.querySelector(".stream-caret")).toBeNull();
+});
+
+test("only the LAST assistant row carries the streaming caret", () => {
+	const messages: ChatMessage[] = [
+		msg({ id: "1", role: "assistant", text: "earlier" }),
+		msg({ id: "2", role: "user", text: "next" }),
+		msg({ id: "3", role: "assistant", text: "streaming now" }),
+	];
+	render(<Transcript messages={messages} streaming={true} />);
+	// Exactly one caret, and it's on the last assistant row (#3).
+	expect(document.querySelectorAll(".stream-caret")).toHaveLength(1);
+	expect(screen.getByText(/streaming now/)).toBeDefined();
+});
+
 test("an error row on the LAST message offers Retry, firing onRetry with retryText", () => {
 	let retried = "";
 	const messages: ChatMessage[] = [

--- a/packages/office-pane/src/panel/ChatPanel.tsx
+++ b/packages/office-pane/src/panel/ChatPanel.tsx
@@ -57,12 +57,25 @@ const STARTERS: readonly (SkillPill & { text: string })[] = [
 	{ id: "summarize", label: "Summarize", hint: "Prefill a prompt", text: "Summarize this document." },
 ];
 
-/** The F5-branded terminal header, shared by the chat and config-error views. */
-function Header() {
+/** The F5-branded terminal header, shared by the chat and config-error views.
+ *  When `onNewChat` is supplied, a "New chat" affordance resets the conversation. */
+function Header({ onNewChat, canNewChat }: { onNewChat?: () => void; canNewChat?: boolean } = {}) {
 	return (
 		<div className="header">
 			<F5Logo variant="mark" size={20} />
 			<span className="header-title">xcsh</span>
+			{onNewChat ? (
+				<button
+					type="button"
+					className="header-new-chat"
+					onClick={onNewChat}
+					disabled={!canNewChat}
+					title="Start a new chat"
+					aria-label="New chat"
+				>
+					New chat
+				</button>
+			) : null}
 		</div>
 	);
 }
@@ -74,10 +87,10 @@ const PROVISIONING_PLACEHOLDER: Record<string, string> = {
 };
 
 export function ChatPanel({ transport, provision, onConnected, onReconfigure, onProviderConfigError }: ChatPanelProps) {
-	const { turns, send, stop, retry, status, reason, error, provisioning, provisionError } = useChatSession(transport, {
-		provision,
-		onConnected,
-	});
+	const { turns, send, stop, retry, newChat, status, reason, error, provisioning, provisionError } = useChatSession(
+		transport,
+		{ provision, onConnected },
+	);
 	const composerRef = useRef<ComposerHandle>(null);
 
 	const messages = useMemo(() => turnsToMessages({ turns, status, reason, error }), [turns, status, reason, error]);
@@ -131,7 +144,7 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 
 	return (
 		<>
-			<Header />
+			<Header onNewChat={newChat} canNewChat={ready && !streaming && turns.length > 0} />
 			<Transcript messages={messages} streaming={streaming} onRetry={() => retry()} emptyState={emptyState} />
 			{/* No interaction-mode toggle: those modes are Chrome browser-automation
 			    only. The Office pane fixes the mode to `educational` (see useChatSession). */}

--- a/packages/office-pane/src/panel/useChatSession.ts
+++ b/packages/office-pane/src/panel/useChatSession.ts
@@ -70,6 +70,10 @@ export interface ChatSessionResult {
 	send(text: string, mode?: InteractionMode): void;
 	stop(): void;
 	retry(): void;
+	/** Start a fresh conversation: clear the transcript and reset the engine's
+	 *  history (the next turn carries a new `history_hint`, which the bridge maps
+	 *  to `replaceMessages([])`). */
+	newChat(): void;
 	status: "idle" | "streaming" | "done" | "error";
 	/** Populated when status is 'error'; mirrors TurnState.reason for turn errors
 	 *  and is set to 'bridge-disconnected' for transport.connect() failures. */
@@ -98,6 +102,9 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 	const activeTurnIdRef = useRef<string | null>(null);
 	const lastUserTextRef = useRef<string>("");
 	const lastUserModeRef = useRef<InteractionMode>(DEFAULT_INTERACTION_MODE);
+	// Conversation boundary: sent on every chat_request; a NEW value tells the
+	// bridge to reset the engine's history (replaceMessages([])). Bumped by newChat().
+	const historyHintRef = useRef(1);
 	// Held in a ref so a changing callback identity doesn't re-run the connect effect.
 	const hooksRef = useRef(hooks);
 	hooksRef.current = hooks;
@@ -193,6 +200,7 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 					text,
 					context: null,
 					mode,
+					history_hint: `conv-${historyHintRef.current}`,
 				});
 			} catch (err) {
 				// A closed/failed transport throws synchronously (e.g. "Cannot send in
@@ -230,6 +238,16 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 		}
 	}, [send]);
 
+	const newChat = useCallback(() => {
+		// Bump the conversation boundary so the NEXT send resets the engine's history,
+		// clear the transcript, and forget the last prompt (nothing to retry into the
+		// fresh chat). Ids stay monotonic (counterRef is not reset) to avoid collisions.
+		historyHintRef.current += 1;
+		activeTurnIdRef.current = null;
+		lastUserTextRef.current = "";
+		setTurns([]);
+	}, []);
+
 	const lastAssistant = turns.findLast((t): t is AssistantTurn => t.kind === "assistant");
 
 	// connect() failures take precedence; fall back to the last assistant turn's status.
@@ -251,5 +269,5 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 		status = "idle";
 	}
 
-	return { turns, send, stop, retry, status, reason, error, provisioning, provisionError };
+	return { turns, send, stop, retry, newChat, status, reason, error, provisioning, provisionError };
 }

--- a/packages/office-pane/test/ChatPanel.test.tsx
+++ b/packages/office-pane/test/ChatPanel.test.tsx
@@ -19,6 +19,37 @@ test("renders the terminal shell: header, transcript live region, and composer",
 	expect(scope.getByText("xcsh")).toBeDefined();
 });
 
+test("New chat: disabled until there's a settled turn, then clears the transcript and resets history_hint", async () => {
+	const mock = new MockTransport();
+	const { container } = render(<ChatPanel transport={mock} />);
+	const scope = within(container);
+	await settle();
+
+	const newChatBtn = () => scope.getByRole("button", { name: /new chat/i }) as HTMLButtonElement;
+	// No turns yet → disabled.
+	expect(newChatBtn().disabled).toBe(true);
+
+	// Send a turn and settle it (chat_done) → not streaming, one turn → enabled.
+	fireEvent.click(scope.getByRole("button", { name: /summarize/i }));
+	fireEvent.click(scope.getByRole("button", { name: /send/i }));
+	const req1 = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request")[0];
+	if (!req1) throw new Error("expected chat_request");
+	await act(async () => {
+		mock.emit({ type: "chat_done", id: req1.id });
+	});
+	await waitFor(() => expect(newChatBtn().disabled).toBe(false));
+
+	// Click New chat → transcript clears (the user prompt row is gone).
+	fireEvent.click(newChatBtn());
+	await waitFor(() => expect(scope.queryByText("Summarize this document.")).toBeNull());
+
+	// The next turn starts a fresh conversation: a NEW history_hint.
+	fireEvent.click(scope.getByRole("button", { name: /summarize/i }));
+	fireEvent.click(scope.getByRole("button", { name: /send/i }));
+	const reqs = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request");
+	expect(reqs[reqs.length - 1].history_hint).not.toBe(req1.history_hint);
+});
+
 test("the empty state offers starter pills that PREFILL the composer without sending", async () => {
 	const mock = new MockTransport();
 	const { container } = render(<ChatPanel transport={mock} />);

--- a/packages/office-pane/test/useChatSession.test.tsx
+++ b/packages/office-pane/test/useChatSession.test.tsx
@@ -141,6 +141,52 @@ test("streaming deltas + chat_done accumulates text and sets status done", async
 	}
 });
 
+test("each chat_request carries a history_hint; newChat bumps it (engine resets history) and clears the transcript", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+
+	await act(async () => {
+		result.current.send("first");
+	});
+	const req1 = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request")[0];
+	if (!req1) throw new Error("expected chat_request");
+	expect(req1.history_hint).toBeTruthy();
+	expect(result.current.turns.length).toBeGreaterThan(0);
+
+	// New chat: transcript clears immediately.
+	await act(async () => {
+		result.current.newChat();
+	});
+	expect(result.current.turns).toHaveLength(0);
+
+	// The next turn carries a DIFFERENT history_hint, so the engine resets context.
+	await act(async () => {
+		result.current.send("second");
+	});
+	const reqs = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request");
+	const req2 = reqs[reqs.length - 1];
+	if (!req2) throw new Error("expected second chat_request");
+	expect(req2.history_hint).toBeTruthy();
+	expect(req2.history_hint).not.toBe(req1.history_hint);
+});
+
+test("within one conversation, successive turns reuse the SAME history_hint", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	await act(async () => {
+		result.current.send("a");
+	});
+	// settle the first turn so the second isn't queued at the engine (client-side send still emits)
+	const first = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request")[0];
+	if (!first) throw new Error("expected chat_request");
+	await act(async () => {
+		mock.emit({ type: "chat_done", id: first.id });
+		result.current.send("b");
+	});
+	const reqs = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request");
+	expect(reqs[0].history_hint).toBe(reqs[reqs.length - 1].history_hint);
+});
+
 test("chat_tool_notice folds live tool activity onto the active assistant turn", async () => {
 	const mock = new MockTransport();
 	const { result } = renderHook(() => useChatSession(mock));


### PR DESCRIPTION
Closes #2242.

Two Claude-for-Office chat-shell parity gaps in the Office pane.

## New-chat / conversation reset

The pane held **one** persistent conversation — no way to start fresh short of reloading. The engine already supports resets: a `chat_request` whose **`history_hint`** changes triggers `replaceMessages([])` (`chat-handler.ts:144`). The Office pane never set it, so history accumulated for the entire session.

- `useChatSession` now sends `history_hint` on every request and exposes **`newChat()`** — clears the transcript and bumps the hint so the *next* turn resets the engine's history. Ids stay monotonic (no collisions).
- A **"New chat"** button in the Header calls it, enabled only once there's a settled turn and not mid-stream.

## Streaming caret

The streaming assistant row ended abruptly. `AssistantMessage` gains a `streaming` flag; `Transcript` sets it on the **last** assistant row while the session streams → a blinking caret (live-typing cue). CSS-only blink, disabled under `prefers-reduced-motion`.

## Tests (TDD)

- `useChatSession.test.tsx` — every request carries `history_hint`; `newChat()` clears turns + bumps the hint; successive turns in one conversation reuse the same hint.
- `ChatPanel.test.tsx` — New chat disabled with no turns → enabled after a settled turn → clears the transcript → the next turn carries a fresh `history_hint`.
- `Transcript.test.tsx` — caret only on the last streaming row; none when settled; exactly one caret across rows.

## Verification

- chat-ui 204 tests green; office-pane 322 green; `tsgo` (per-package strict) clean; `biome check` exit 0; office build **156.6KB / 256KB** gz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)