### PR TITLE
fix(office serve): bound the XCSH.md walk + hoist it out of prompt rebuilds (large-CWD stall)

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -112,6 +112,7 @@ import { SessionManager } from "./session/session-manager";
 import { closeAllConnections } from "./ssh/connection-manager";
 import { unmountAll } from "./ssh/sshfs-mount";
 import {
+	buildAgentsMdSearch,
 	buildSystemPrompt as buildSystemPromptInternal,
 	buildSystemPromptToolMetadata,
 	loadProjectContextFiles as loadContextFilesInternal,
@@ -965,6 +966,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		async () => options.contextFiles ?? (await discoverContextFiles(cwd, agentDir)),
 	);
 
+	// Walk the CWD for nested XCSH.md ONCE per session — the walk is bounded but not
+	// free, so hoisting it here keeps every tool-refresh prompt rebuild off the tree
+	// (a large cwd like $HOME must never re-stall on set_host_tools). #2245.
+	const agentsMdSearch = await logger.time("buildAgentsMdSearch", buildAgentsMdSearch, cwd);
+
 	let agent: Agent;
 	let session!: AgentSession;
 	let hasSession = false;
@@ -1596,6 +1602,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				cwd,
 				skills,
 				contextFiles,
+				agentsMdSearch,
 				tools: promptTools,
 				toolNames,
 				rules: rulebookRules,
@@ -1626,6 +1633,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					cwd,
 					skills,
 					contextFiles,
+					agentsMdSearch,
 					tools: promptTools,
 					toolNames,
 					rules: rulebookRules,

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -108,13 +108,28 @@ const AGENTS_MD_MIN_DEPTH = 1;
 const AGENTS_MD_MAX_DEPTH = 4;
 const AGENTS_MD_LIMIT = 200;
 const SYSTEM_PROMPT_PREP_TIMEOUT_MS = 5000;
+// The walk's `limit` caps DISCOVERED files, not directories VISITED — so a dir
+// with ~no XCSH.md (e.g. serving from $HOME) would otherwise traverse the entire
+// tree to AGENTS_MD_MAX_DEPTH and stall prep. These bound the traversal itself:
+// a directory-visit budget AND a wall-clock deadline, both well inside the 5s
+// prep timeout, so discovery stays fast regardless of how few matches exist.
+const AGENTS_MD_MAX_DIRS = 4000;
+const AGENTS_MD_WALK_BUDGET_MS = 1500;
 const AGENTS_MD_EXCLUDED_DIRS = new Set(["node_modules", ".git"]);
 
-interface AgentsMdSearch {
+/** A cited context-file search result (the nested XCSH.md files under the cwd). */
+export interface AgentsMdSearch {
 	scopePath: string;
 	limit: number;
 	pattern: string;
 	files: string[];
+}
+
+/** Mutable traversal budget shared across the recursive walk. */
+interface WalkBudget {
+	readonly maxDirs: number;
+	readonly deadline: number;
+	dirsVisited: number;
 }
 
 function normalizePath(value: string): string {
@@ -131,11 +146,24 @@ async function collectAgentsMdFiles(
 	dir: string,
 	depth: number,
 	limit: number,
+	maxDepth: number,
 	discovered: Set<string>,
+	budget: WalkBudget,
 ): Promise<void> {
-	if (depth > AGENTS_MD_MAX_DEPTH || discovered.size >= limit) {
+	// Stop on any bound: depth, enough matches, the directory-visit budget, or the
+	// wall-clock deadline. The last two keep a match-poor tree (e.g. $HOME) bounded.
+	if (
+		depth > maxDepth ||
+		discovered.size >= limit ||
+		budget.dirsVisited >= budget.maxDirs ||
+		Date.now() >= budget.deadline
+	) {
 		return;
 	}
+	// Reserve this directory's slot SYNCHRONOUSLY (before the readdir await) so a
+	// concurrent Promise.all fan-out can't blow past the budget: every scheduled
+	// sibling sees the updated count before it yields, making the cap effectively hard.
+	budget.dirsVisited++;
 
 	let entries: fs.Dirent[];
 	try {
@@ -157,7 +185,7 @@ async function collectAgentsMdFiles(
 		}
 	}
 
-	if (depth === AGENTS_MD_MAX_DEPTH) {
+	if (depth === maxDepth) {
 		return;
 	}
 
@@ -168,24 +196,47 @@ async function collectAgentsMdFiles(
 
 	await Promise.all(
 		childDirs.map(async child => {
-			if (discovered.size >= limit) return;
-			await collectAgentsMdFiles(root, path.join(dir, child), depth + 1, limit, discovered);
+			if (discovered.size >= limit || budget.dirsVisited >= budget.maxDirs || Date.now() >= budget.deadline) return;
+			await collectAgentsMdFiles(root, path.join(dir, child), depth + 1, limit, maxDepth, discovered, budget);
 		}),
 	);
 }
 
-async function listAgentsMdFiles(root: string, limit: number): Promise<string[]> {
+/** Options for {@link discoverAgentsMdFiles} (all bounded by defaults). */
+export interface DiscoverAgentsMdOptions {
+	limit?: number;
+	maxDepth?: number;
+	maxDirs?: number;
+	budgetMs?: number;
+}
+
+/**
+ * Walk `root` (bounded by depth, match-limit, directory budget, and a wall-clock
+ * deadline) collecting nested `XCSH.md` paths. Returns the sorted matches plus the
+ * number of directories visited (for observability/tests). Never throws.
+ */
+export async function discoverAgentsMdFiles(
+	root: string,
+	opts: DiscoverAgentsMdOptions = {},
+): Promise<{ files: string[]; dirsVisited: number }> {
+	const limit = opts.limit ?? AGENTS_MD_LIMIT;
+	const maxDepth = opts.maxDepth ?? AGENTS_MD_MAX_DEPTH;
+	const budget: WalkBudget = {
+		maxDirs: opts.maxDirs ?? AGENTS_MD_MAX_DIRS,
+		deadline: Date.now() + (opts.budgetMs ?? AGENTS_MD_WALK_BUDGET_MS),
+		dirsVisited: 0,
+	};
 	try {
 		const discovered = new Set<string>();
-		await collectAgentsMdFiles(root, root, 0, limit, discovered);
-		return Array.from(discovered).sort().slice(0, limit);
+		await collectAgentsMdFiles(root, root, 0, limit, maxDepth, discovered, budget);
+		return { files: Array.from(discovered).sort().slice(0, limit), dirsVisited: budget.dirsVisited };
 	} catch {
-		return [];
+		return { files: [], dirsVisited: budget.dirsVisited };
 	}
 }
 
-async function buildAgentsMdSearch(cwd: string): Promise<AgentsMdSearch> {
-	const files = await listAgentsMdFiles(cwd, AGENTS_MD_LIMIT);
+export async function buildAgentsMdSearch(cwd: string): Promise<AgentsMdSearch> {
+	const { files } = await discoverAgentsMdFiles(cwd);
 	return {
 		scopePath: ".",
 		limit: AGENTS_MD_LIMIT,
@@ -449,6 +500,9 @@ export interface BuildSystemPromptOptions {
 	cwd?: string;
 	/** Pre-loaded context files (skips discovery if provided). */
 	contextFiles?: Array<{ path: string; content: string; depth?: number }>;
+	/** Pre-computed nested-XCSH.md search (skips the CWD walk if provided). Hoisted
+	 *  once per session so tool-refresh rebuilds never re-walk the tree. */
+	agentsMdSearch?: AgentsMdSearch;
 	/**
 	 * Explicit disabled extension IDs applied to context-file discovery instead of the
 	 * global settings default. Pass `[]` to discover independent of process-wide settings.
@@ -519,6 +573,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		toolNames: providedToolNames,
 		cwd,
 		contextFiles: providedContextFiles,
+		agentsMdSearch: providedAgentsMdSearch,
 		skills: providedSkills,
 		rules,
 		alwaysApplyRules,
@@ -541,7 +596,9 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 					cwd: resolvedCwd,
 					disabledExtensions: options.disabledExtensions,
 				});
-		const agentsMdSearchPromise = logger.time("buildAgentsMdSearch", buildAgentsMdSearch, resolvedCwd);
+		const agentsMdSearchPromise = providedAgentsMdSearch
+			? Promise.resolve(providedAgentsMdSearch)
+			: logger.time("buildAgentsMdSearch", buildAgentsMdSearch, resolvedCwd);
 		const mergedSkillsSettings = {
 			...skillsSettings,
 			customDirectories: [...(skillsSettings?.customDirectories ?? []), ...(options.contextSkillDirs ?? [])],

--- a/packages/coding-agent/test/discovery/agents-md-walk.test.ts
+++ b/packages/coding-agent/test/discovery/agents-md-walk.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The XCSH.md discovery walk must be BOUNDED (a huge CWD like $HOME must not
+ * stall system-prompt prep), and it must be HOISTABLE so tool-refresh rebuilds
+ * don't re-walk the tree. See issue #2245.
+ */
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildSystemPrompt, discoverAgentsMdFiles } from "@f5-sales-demo/xcsh/system-prompt";
+import { registerCodingAgentPromptHelpers } from "../../src/config/prompt-templates";
+
+/** Build a wide/deep tree of `breadth^depth` dirs with NO XCSH.md anywhere. */
+function makeWideTree(root: string, breadth: number, depth: number): number {
+	let dirs = 0;
+	const recurse = (dir: string, d: number): void => {
+		if (d === 0) return;
+		for (let i = 0; i < breadth; i++) {
+			const child = path.join(dir, `d${i}`);
+			fs.mkdirSync(child, { recursive: true });
+			dirs++;
+			recurse(child, d - 1);
+		}
+	};
+	recurse(root, depth);
+	return dirs;
+}
+
+describe("discoverAgentsMdFiles (bounded walk)", () => {
+	let tempDir = "";
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-walk-"));
+	});
+	afterEach(() => {
+		if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("stops at the directory budget in a large tree with no XCSH.md", async () => {
+		const total = makeWideTree(tempDir, 4, 4); // 4+16+64+256 = 340 dirs
+		expect(total).toBeGreaterThan(300);
+		const { files, dirsVisited } = await discoverAgentsMdFiles(tempDir, { maxDirs: 20 });
+		expect(files).toHaveLength(0);
+		// The visit budget caps traversal well below the full tree.
+		expect(dirsVisited).toBeLessThanOrEqual(21); // budget + the root
+		expect(dirsVisited).toBeLessThan(total);
+	});
+
+	it("a zero time budget stops almost immediately", async () => {
+		makeWideTree(tempDir, 4, 3);
+		const { dirsVisited } = await discoverAgentsMdFiles(tempDir, { budgetMs: 0 });
+		expect(dirsVisited).toBeLessThanOrEqual(1);
+	});
+
+	it("still discovers a nested XCSH.md that is within budget", async () => {
+		const sub = path.join(tempDir, "service");
+		fs.mkdirSync(sub, { recursive: true });
+		fs.writeFileSync(path.join(sub, "XCSH.md"), "# rules");
+		const { files } = await discoverAgentsMdFiles(tempDir);
+		expect(files).toContain("service/XCSH.md");
+	});
+});
+
+describe("buildSystemPrompt hoists agentsMdSearch (no re-walk)", () => {
+	let tempDir = "";
+	beforeAll(() => {
+		registerCodingAgentPromptHelpers();
+	});
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-hoist-"));
+	});
+	afterEach(() => {
+		if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("uses a provided agentsMdSearch instead of walking the cwd", async () => {
+		// cwd has NO XCSH.md, but a provided search names one — it must appear in the
+		// prompt, proving the walk was bypassed (a fresh walk of cwd would find nothing).
+		const prompt = await buildSystemPrompt({
+			cwd: tempDir,
+			skills: [],
+			rules: [],
+			toolNames: [],
+			disabledExtensions: [],
+			agentsMdSearch: {
+				scopePath: ".",
+				limit: 200,
+				pattern: "XCSH.md depth 1-4",
+				files: ["provided-only/XCSH.md"],
+			},
+		});
+		expect(prompt).toContain("provided-only/XCSH.md");
+	});
+});


### PR DESCRIPTION
Closes #2245.

## Problem

`xcsh office serve` from a large working dir (e.g. `$HOME`) makes the task pane stall ~5s per prompt build, repeatedly — it presents as a failed/hung connection. From a small dir it's instant.

**Root cause:** the nested-`XCSH.md` discovery walk (`collectAgentsMdFiles`, `system-prompt.ts`) recursively `readdir`s the CWD to depth 4, and its `AGENTS_MD_LIMIT` (200) caps **discovered files**, not **directories visited**. `$HOME` has ~zero `XCSH.md`, so the short-circuit never fires and it traverses the entire tree — tens of thousands of `readdir`s on libuv's fs threadpool.

Two compounding defects (found via a dedicated investigation), both fixed at the source:

1. **Re-walked on every rebuild.** Unlike `skills`/`rules`/`contextFiles`, `agentsMdSearch` had no "provided" bypass, so `set_host_tools` → `refreshRpcHostTools` → `#rebuildSystemPrompt` re-ran the full walk each time (Office advertises its tool set on connect → a refresh → another walk). **Fix:** add `agentsMdSearch?` to `BuildSystemPromptOptions` (conditional exactly like `contextFiles`); compute it **once per session** in `sdk.ts` and pass it into both rebuild calls. The walk now runs at most once per session, never on a tool refresh.
2. **Unbounded traversal.** **Fix:** a directory-visit budget (`AGENTS_MD_MAX_DIRS=4000`) + wall-clock deadline (`1500ms`, well inside the 5s prep timeout), reserved **synchronously** before each `readdir` so the concurrent `Promise.all` fan-out can't overshoot. `discoverAgentsMdFiles` is exported returning `{files, dirsVisited}` for tests.

(There *is* a 5s race guarding both build paths — added in `91db4bd18` — so today it degrades rather than hangs forever; but leaked losing-walks pile up on the threadpool and present as a hang. Fixes 1+2 make the walk bounded and once-per-session; AbortSignal cancellation of the losing walk is a noted lower-priority follow-up.)

## Tests (TDD)

- `agents-md-walk.test.ts` — dir budget caps a 340-dir zero-match tree to ~20; a zero time budget stops at ~1; an in-budget nested `XCSH.md` is still discovered; a **provided** `agentsMdSearch` is used instead of walking the cwd (hoist).
- Existing `xcsh-md-init-file` + `system-prompt-dedup` discovery tests unchanged (17 pass total).

## Verification

- 17 discovery/system-prompt tests green; `tsgo -p tsconfig.json` clean; `biome check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)