### PR TITLE
fix(chat): trim trailing markdown/punctuation from bare-URL references (broken Sources link)

### DIFF
--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -555,7 +555,18 @@ function titleFromUrl(url: string): string {
 	}
 }
 
-function extractReferences(msg: AssistantMessage): ChatReference[] {
+/**
+ * Trailing characters a bare-URL match may greedily swallow at a markdown/prose
+ * boundary — markdown emphasis (`*_~`) and sentence/wrap punctuation. A real URL
+ * effectively never ends in these, so trimming them yields the intended link
+ * (e.g. `**https://…/llms.txt**` → `https://…/llms.txt`). The markdown-link branch
+ * is bounded by its closing `)` and needs no trimming.
+ */
+function trimTrailingMarkup(url: string): string {
+	return url.replace(/[*_~,.;:!?'")\]]+$/, "");
+}
+
+export function extractReferences(msg: AssistantMessage): ChatReference[] {
 	const refs: ChatReference[] = [];
 	const seen = new Set<string>();
 
@@ -572,7 +583,7 @@ function extractReferences(msg: AssistantMessage): ChatReference[] {
 
 		const bareUrlRegex = /(?<!\()(https?:\/\/[^\s)>\]]+)/g;
 		for (let match = bareUrlRegex.exec(block.text); match !== null; match = bareUrlRegex.exec(block.text)) {
-			const url = match[1];
+			const url = trimTrailingMarkup(match[1]);
 			if (seen.has(url)) continue;
 			seen.add(url);
 			refs.push({ kind: classifyReferenceKind(url), title: titleFromUrl(url), url });

--- a/packages/coding-agent/test/browser/extract-references.test.ts
+++ b/packages/coding-agent/test/browser/extract-references.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Reference extraction for the panel Sources chips (#2237) must not swallow
+ * trailing markdown emphasis / sentence punctuation into a bare URL. Regression
+ * found via live E2E UAT on v19.83.0 (a bolded link produced `.../llms.txt**`).
+ * See issue #2249.
+ */
+import { describe, expect, test } from "bun:test";
+import type { AssistantMessage } from "@f5-sales-demo/pi-ai";
+import { extractReferences } from "../../src/browser/chat-handler";
+
+/** Minimal AssistantMessage carrying a single text block. */
+function assistantText(text: string): AssistantMessage {
+	return { role: "assistant", content: [{ type: "text", text }] } as unknown as AssistantMessage;
+}
+
+describe("extractReferences", () => {
+	test("strips trailing markdown bold (**) from a bolded bare URL", () => {
+		const refs = extractReferences(assistantText("See **https://docs.cloud.f5.com/waf** for details."));
+		expect(refs).toHaveLength(1);
+		expect(refs[0].url).toBe("https://docs.cloud.f5.com/waf");
+		expect(refs[0].title).toBe("waf"); // clean, no trailing '*'
+	});
+
+	test("drops a sentence-final period after a bare URL", () => {
+		const refs = extractReferences(assistantText("Docs: https://docs.cloud.f5.com/api."));
+		expect(refs[0].url).toBe("https://docs.cloud.f5.com/api");
+	});
+
+	test("drops trailing wrap punctuation (comma, close paren from prose)", () => {
+		const refs = extractReferences(assistantText("(see https://docs.cloud.f5.com/lb), then continue"));
+		expect(refs[0].url).toBe("https://docs.cloud.f5.com/lb");
+	});
+
+	test("leaves a clean bare URL untouched", () => {
+		const refs = extractReferences(assistantText("https://docs.cloud.f5.com/waf"));
+		expect(refs[0].url).toBe("https://docs.cloud.f5.com/waf");
+	});
+
+	test("markdown-link references are unaffected", () => {
+		const refs = extractReferences(assistantText("[WAF guide](https://docs.cloud.f5.com/waf)"));
+		expect(refs).toHaveLength(1);
+		expect(refs[0].title).toBe("WAF guide");
+		expect(refs[0].url).toBe("https://docs.cloud.f5.com/waf");
+	});
+
+	test("dedupes a bolded and a plain occurrence of the same cleaned URL", () => {
+		const refs = extractReferences(
+			assistantText("**https://docs.cloud.f5.com/waf** and again https://docs.cloud.f5.com/waf"),
+		);
+		expect(refs).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
Closes #2249.

## Found via live UAT

While running an end-to-end UAT of the Sources feature (#2237) against the **installed v19.83.0 binary** (real `office serve` bridge + engine), asking "point me to the F5 Distributed Cloud WAF documentation" returned:

```
chat_done references: [{ kind:"doc", title:"llms.txt**", url:"https://f5-sales-demo.github.io/docs/llms.txt**" }]
```

The model's markdown **bold** around a bare URL (`**https://…/llms.txt**`) was swallowed into the URL → the Sources chip links to a 404.

## Root cause

`extractReferences` (`chat-handler.ts`) bare-URL regex char class `[^\s)>\]]` doesn't stop at markdown emphasis or sentence/wrap punctuation, so a trailing `**` (or `.`, `,`, `)`, …) is captured into the URL; `titleFromUrl` then derives a dirty title from it.

## Fix

Trim trailing `*_~,.;:!?'")]` from each captured **bare** URL before classify/title/dedupe. The markdown-link branch (`[t](url)`) is bounded by its closing `)` and is untouched.

## Tests (TDD)

`extractReferences` is now exported + unit-tested: bolded URL → clean; sentence-final period dropped; wrap punctuation dropped; clean bare URL untouched; markdown-link untouched; dedupe of a bolded + plain occurrence of the same cleaned URL. `tsgo` + `biome` clean.

## Note

This is a genuine defect the automated post-install UAT surfaced — the kind unit/component tests didn't catch because it only shows with real model output. The UAT probe otherwise passed (host-aware handshake; `history_hint` reset that new-chat #2244 drives — codeword remembered within a conversation, forgotten after the boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)