### PR TITLE
chore(chat-ui): drop comma-operator in ReferenceChips dedupe

### DIFF
--- a/packages/chat-ui/src/components/ReferenceChips.tsx
+++ b/packages/chat-ui/src/components/ReferenceChips.tsx
@@ -20,7 +20,11 @@ const KIND_TAG: Record<ChatReference["kind"], string> = { doc: "DOC", console: "
 export function ReferenceChips({ references }: ReferenceChipsProps) {
 	// Dedupe by URL, preserving first-seen order.
 	const seen = new Set<string>();
-	const unique = references.filter(r => (seen.has(r.url) ? false : (seen.add(r.url), true)));
+	const unique = references.filter(r => {
+		if (seen.has(r.url)) return false;
+		seen.add(r.url);
+		return true;
+	});
 	if (unique.length === 0) return null;
 
 	// Semantic <ul>/<li> (not role="list") — the anchor inside each <li> keeps its


### PR DESCRIPTION
Closes #2254.

Follow-up cleanup. `ReferenceChips.tsx` (from #2237) deduped with a comma-operator (`(seen.add(r.url), true)`), which the stricter **root** Biome config (governance sync #2248) flags as `lint/complexity/noCommaOperator`. It was a non-blocking **warning**, but it's code I introduced, so cleaning it at the source. Rewritten as an explicit block — identical first-seen-order dedupe, no hidden side effect.

## Verification
- Root `biome check ReferenceChips.tsx` → clean (was: 1 warning).
- Existing `ReferenceChips` tests green (5); `tsgo` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)