### PR TITLE
fix(chat): trim trailing markdown code backtick from bare-URL references (#2256)

### DIFF
--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -557,13 +557,14 @@ function titleFromUrl(url: string): string {
 
 /**
  * Trailing characters a bare-URL match may greedily swallow at a markdown/prose
- * boundary — markdown emphasis (`*_~`) and sentence/wrap punctuation. A real URL
- * effectively never ends in these, so trimming them yields the intended link
- * (e.g. `**https://…/llms.txt**` → `https://…/llms.txt`). The markdown-link branch
- * is bounded by its closing `)` and needs no trimming.
+ * boundary — markdown emphasis + code (`*_~` and backtick) and sentence/wrap
+ * punctuation. A real URL effectively never ends in these, so trimming them yields
+ * the intended link (e.g. `**https://…/llms.txt**` or a code-wrapped
+ * `` `https://…/llms.txt` `` → `https://…/llms.txt`). The markdown-link branch is
+ * bounded by its closing `)` and needs no trimming.
  */
 function trimTrailingMarkup(url: string): string {
-	return url.replace(/[*_~,.;:!?'")\]]+$/, "");
+	return url.replace(/[*_~`,.;:!?'")\]}>]+$/, "");
 }
 
 export function extractReferences(msg: AssistantMessage): ChatReference[] {

--- a/packages/coding-agent/test/browser/extract-references.test.ts
+++ b/packages/coding-agent/test/browser/extract-references.test.ts
@@ -36,6 +36,25 @@ describe("extractReferences", () => {
 		expect(refs[0].url).toBe("https://docs.cloud.f5.com/waf");
 	});
 
+	test("strips a trailing markdown code backtick from a code-wrapped bare URL (#2256)", () => {
+		const refs = extractReferences(assistantText("Docs: `https://docs.cloud.f5.com/waf` — enjoy"));
+		expect(refs).toHaveLength(1);
+		expect(refs[0].url).toBe("https://docs.cloud.f5.com/waf");
+		expect(refs[0].title).toBe("waf");
+	});
+
+	test("handles the exact v19.85.0 UAT strings (backtick-wrapped docs URLs)", () => {
+		const refs = extractReferences(
+			assistantText(
+				"See `https://f5-sales-demo.github.io/docs/llms.txt` and `https://f5-sales-demo.github.io/api-specs-enriched/en/`",
+			),
+		);
+		expect(refs.map(r => r.url)).toEqual([
+			"https://f5-sales-demo.github.io/docs/llms.txt",
+			"https://f5-sales-demo.github.io/api-specs-enriched/en/",
+		]);
+	});
+
 	test("markdown-link references are unaffected", () => {
 		const refs = extractReferences(assistantText("[WAF guide](https://docs.cloud.f5.com/waf)"));
 		expect(refs).toHaveLength(1);


### PR DESCRIPTION
Closes #2256.

## Found via live UAT on v19.85.0

Running the automated reference UAT against the **installed v19.85.0** binary (serve from `$HOME`), the model wrapped the F5 docs URLs in markdown **inline code** (backticks). #2250 handled `**bold**`, but `trimTrailingMarkup` omitted the backtick, so:

```
{ url: "https://f5-sales-demo.github.io/docs/llms.txt`" }
{ url: "https://f5-sales-demo.github.io/api-specs-enriched/en/`" }
```

The trailing `` ` `` bled into the URL → Sources chip 404. Same class as #2250, different wrapper.

## Fix

Extend the trailing-trim char class to include the code backtick (plus `}`/`>`):
`` /[*_~`,.;:!?'")\]}>]+$/ ``. A real URL never ends in these; leading wrappers aren't captured (the bare-URL regex starts at `https`).

## Tests

Added: code-wrapped bare URL → clean; the exact two v19.85.0 UAT strings → clean. The #2250 bold/period/paren cases and markdown-link refs still pass (8 total). `tsgo` + `biome` clean.

## Verification note

This is the *second* variant of the reference-wrapping bug the post-install UAT surfaced (bold → #2250, code → this). The UAT that caught it otherwise **passed** on v19.85.0: `set_host_tools_ack` in **321ms from `$HOME`** (confirming the #2246 CWD-stall fix — the op that used to hang), and the `history_hint` reset (new-chat #2244) worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)