### PR TITLE
fix(office-pane): Worksheet.tables is a property, not getTables() (get_workbook_info live crash)

### DIFF
--- a/packages/office-pane/src/office/excel-tools.ts
+++ b/packages/office-pane/src/office/excel-tools.ts
@@ -45,8 +45,10 @@ export interface ExcelWorksheetLike {
 	/** The rectangle covering all cells with content (for structural discovery).
 	 * Use `getUsedRangeOrNullObject()` to avoid `ItemNotFound` on empty sheets. */
 	getUsedRangeOrNullObject(): ExcelRangeLike & { isNullObject?: boolean };
-	/** The Excel Tables anchored on this sheet. */
-	getTables(): ExcelNamedItemCollectionLike;
+	/** The Excel Tables anchored on this sheet. Office.js exposes this as a
+	 * PROPERTY (`worksheet.tables`), NOT a `getTables()` method — the latter throws
+	 * "getTables is not a function" at runtime. */
+	tables: ExcelNamedItemCollectionLike;
 	/** The sheet-scoped named ranges. */
 	names: ExcelNamedItemCollectionLike;
 }
@@ -321,7 +323,7 @@ export function createExcelHostTools(excel: ExcelLike = getExcel()): HostToolReg
 							// OrNullObject avoids ItemNotFound on completely empty sheets.
 							const used = ws.getUsedRangeOrNullObject();
 							used.load("address,isNullObject");
-							const tables = ws.getTables();
+							const tables = ws.tables;
 							tables.load("items/name");
 							ws.names.load("items/name");
 							return { ws, used, tables };

--- a/packages/office-pane/test/excel-tools.test.ts
+++ b/packages/office-pane/test/excel-tools.test.ts
@@ -133,10 +133,11 @@ function fakeExcel(
 							valueTypes: sm.valueTypes?.[address],
 						}),
 					getUsedRangeOrNullObject: () => makeRange(sm.usedRange ?? "", { read: () => [] }),
-					getTables: () => ({
+					// Office.js Worksheet.tables is a PROPERTY (not a getTables() method).
+					tables: {
 						items: (sm.tables ?? []).map(n => ({ name: n })),
 						load(_props: string): void {},
-					}),
+					},
 					names: {
 						items: (sm.names ?? []).map(n => ({ name: n })),
 						load(_props: string): void {},


### PR DESCRIPTION
Closes #2258.

## Found in real Excel

v19.85.0, live pane: `get_workbook_info` fails on every workbook with
```
get_workbook_info failed: H.getTables is not a function.
```
The agent falls back to `list_sheets` + range reads (so answers still come through), but the flagship prefetch/structure tool never returns Tables/named-range structure.

## Root cause

Office.js `Worksheet` has **no `getTables()` method** — Excel Tables are the **property** `worksheet.tables` (`Excel.TableCollection`). The `ExcelWorksheetLike` seam declared `getTables()` and `fakeExcel` modeled it as a method, so tests passed against a fiction. Same mock-hides-reality class as the earlier `load("items")`→`load("items/name")` and Word `getComments()` fixes. (`workbook.tables.getItem(...)` elsewhere is correct — `Workbook.tables` IS a real property; only the worksheet-level call was wrong.)

## Fix

Seam `getTables(): ExcelNamedItemCollectionLike` → `tables: …` (property); `ws.getTables()` → `ws.tables`; mock exposes `tables` as a property so the seam faithfully models Office.js.

## Verification

31 excel-tools tests pass against the corrected shape; `tsgo` + `biome` clean. Real-Excel confirmation on the next release + sideload.

## Systemic follow-up

Per operator direction, a cross-functional Office.js API-correctness audit of all three surfaces (Excel/Word/PowerPoint) is underway to find any other method-vs-property / wrong-`load()` / requirement-set mismatches the mocks hide. Findings will land as their own fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)