### PR TITLE
fix(office-pane): Word TrackedChange.author (not authorName) + type "Added" (not "Inserted")

### DIFF
--- a/packages/office-pane/src/office/word-tools.ts
+++ b/packages/office-pane/src/office/word-tools.ts
@@ -49,9 +49,11 @@ export interface WordCommentCollectionLike {
 /** A single tracked change (revision) — the subset `get_tracked_changes` reads. */
 export interface WordTrackedChangeLike {
 	text: string;
-	/** Revision type, e.g. "Inserted" or "Deleted". */
+	/** Word.TrackedChangeType: "Added" | "Deleted" | "Formatted" | "None"
+	 *  (an insertion is "Added", NOT "Inserted"). */
 	type: string;
-	authorName: string;
+	/** Office.js `TrackedChange.author` (NOT `authorName` — that's on Comment). */
+	author: string;
 }
 
 /** A loadable collection of tracked changes. */
@@ -380,7 +382,7 @@ export function createWordHostTools(word: WordLike = getWord()): HostToolRegistr
 			definition: {
 				name: "get_tracked_changes",
 				description:
-					"Read the tracked changes (revisions) in the document, each with its text, type (Inserted/Deleted), " +
+					"Read the tracked changes (revisions) in the document, each with its text, type (Added/Deleted/Formatted), " +
 					"and author.",
 				parameters: { type: "object", properties: {} },
 			},
@@ -389,9 +391,9 @@ export function createWordHostTools(word: WordLike = getWord()): HostToolRegistr
 				try {
 					changes = await word.run(async ctx => {
 						const collection = ctx.document.body.getTrackedChanges();
-						collection.load("items/text,type,authorName");
+						collection.load("items/text,type,author");
 						await ctx.sync();
-						return collection.items.map(c => ({ text: c.text, type: c.type, author: c.authorName }));
+						return collection.items.map(c => ({ text: c.text, type: c.type, author: c.author }));
 					});
 				} catch (err) {
 					throw new Error(describeWordError("get_tracked_changes", err));

--- a/packages/office-pane/test/word-tools.test.ts
+++ b/packages/office-pane/test/word-tools.test.ts
@@ -26,7 +26,7 @@ interface FakeWordMeta {
 	/** Document comments. */
 	comments?: { content: string; authorName: string }[];
 	/** Tracked changes (revisions). */
-	trackedChanges?: { text: string; type: string; authorName: string }[];
+	trackedChanges?: { text: string; type: string; author: string }[];
 	/** Number of sections (defaults to 1). */
 	sectionCount?: number;
 	/** The current selection's text. */
@@ -301,7 +301,7 @@ describe("word-tools", () => {
 					{ text: "Body text here", style: "Normal" },
 				],
 				comments: [{ content: "fix this", authorName: "Reviewer" }],
-				trackedChanges: [{ text: "insert", type: "Inserted", authorName: "Editor" }],
+				trackedChanges: [{ text: "insert", type: "Added", author: "Editor" }],
 				sectionCount: 2,
 			}),
 		);
@@ -444,8 +444,8 @@ describe("word-tools", () => {
 			d,
 			fakeWord("", {
 				trackedChanges: [
-					{ text: "added", type: "Inserted", authorName: "Alice" },
-					{ text: "removed", type: "Deleted", authorName: "Bob" },
+					{ text: "added", type: "Added", author: "Alice" },
+					{ text: "removed", type: "Deleted", author: "Bob" },
 				],
 			}),
 		);
@@ -455,7 +455,7 @@ describe("word-tools", () => {
 
 		const changes = JSON.parse(firstText(callFrom(t)) ?? "[]");
 		expect(changes).toEqual([
-			{ text: "added", type: "Inserted", author: "Alice" },
+			{ text: "added", type: "Added", author: "Alice" },
 			{ text: "removed", type: "Deleted", author: "Bob" },
 		]);
 		d.dispose();


### PR DESCRIPTION
Closes #2261. From the cross-functional Office.js API audit.

Two divergences in `word-tools.ts` tracked-changes path, both hidden by the mock:

1. **`TrackedChange.authorName` doesn't exist** → real property is **`author`**. Loading `items/text,type,authorName` makes real Word reject the invalid-property load at `ctx.sync()` (or return blank), so `get_tracked_changes` never yields a correct author. (`authorName` is on `Word.Comment`, not `TrackedChange` — the comment path is correct and untouched.)
2. **type value `"Inserted"` → `"Added"`** — `Word.TrackedChangeType` = `None|Added|Deleted|Formatted`; an insertion is `"Added"`. The tool description + mock claimed `"Inserted"`, which real Word never emits.

Fix corrects the seam, the `load()`/read, the tool description, **and** the mock fixtures/assertions so the fake matches real Office.js.

Verification: 21 word-tools tests pass against the corrected shape; `tsgo` + `biome` clean.

Part of the systemic audit sweep (Excel #2260 + this + a PowerPoint crash fix incoming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)