### PR TITLE
fix(office-pane): PowerPoint ShapeType is PascalCase — allowlist text-bearing shapes (read_slides crash)

### DIFF
--- a/packages/office-pane/src/office/powerpoint-tools.ts
+++ b/packages/office-pane/src/office/powerpoint-tools.ts
@@ -27,7 +27,9 @@ export interface PptTextFrameLike {
 export interface PptShapeLike {
 	/** Shape name (e.g. 'Title 1','TextBox 3'); the addressing key for modify_shape_text. */
 	name?: string;
-	/** ShapeType string (e.g. 'textBox','table','group'); tables/groups throw on textFrame access. */
+	/** PowerPoint.ShapeType — PascalCase ('TextBox','Table','Image','GeometricShape',…).
+	 *  Only text-bearing types (see TEXT_BEARING_SHAPE_TYPES) can access `.textFrame`;
+	 *  reading it on others (Table/Image/Chart/…) throws InvalidArgument at sync. */
 	type?: string;
 	left?: number;
 	top?: number;
@@ -105,9 +107,18 @@ function describePptError(op: string, err: unknown): string {
 	return `${op} failed${code}: ${message}${debug}`;
 }
 
-// Shape types whose `textFrame` throws (table) or is inaccessible (group) — skip
-// them so a deck with a table/SmartArt doesn't fail the whole read.
-const NON_TEXT_SHAPE_TYPES = new Set(["table", "group"]);
+// `Shape.type` is a PowerPoint.ShapeType value — PascalCase ("TextBox", "Table",
+// "Image", …), NOT camelCase. Reading `.textFrame` on a shape that can't hold text
+// (Table, Group, Image, Chart, Media, SmartArt, …) throws InvalidArgument at sync,
+// which would fail the whole read. So we ALLOWLIST the text-bearing types and only
+// touch `.textFrame` for those — anything else is treated as text-free (never
+// accessed), which is safe regardless of which non-text type it is.
+const TEXT_BEARING_SHAPE_TYPES = new Set(["TextBox", "Placeholder", "GeometricShape", "Callout", "Line"]);
+
+/** Whether a shape's (PascalCase) `Shape.type` can bear text via `textFrame`. */
+function isTextBearing(type: string | undefined): boolean {
+	return TEXT_BEARING_SHAPE_TYPES.has(type ?? "");
+}
 
 /** Read the text of every slide as an array of per-slide strings, robust to
  * non-text shapes (tables, groups, images) that would otherwise throw at sync. */
@@ -123,9 +134,9 @@ async function readAllSlideText(ppt: PowerPointLike): Promise<string[]> {
 		}
 		await ctx.sync();
 
-		// Only load text for text-bearing shapes; skip tables/groups.
+		// Only load text for text-bearing shapes; skip tables/images/charts/etc.
 		const textShapesPerSlide = slides.items.map(slide =>
-			slide.shapes.items.filter(shape => !NON_TEXT_SHAPE_TYPES.has(shape.type ?? "")),
+			slide.shapes.items.filter(shape => isTextBearing(shape.type)),
 		);
 		for (const shapes of textShapesPerSlide) {
 			for (const shape of shapes) {
@@ -193,16 +204,16 @@ async function readSlideShapes(ppt: PowerPointLike, slideIndex: number): Promise
 		await ctx.sync();
 
 		const shapes = slide.shapes.items;
-		// Only load text for text-bearing shapes; a table's textFrame throws at sync.
+		// Only load text for text-bearing shapes; a non-text shape's textFrame throws at sync.
 		for (const shape of shapes) {
-			if (!NON_TEXT_SHAPE_TYPES.has(shape.type ?? "")) {
+			if (isTextBearing(shape.type)) {
 				shape.textFrame?.load("hasText,textRange/text");
 			}
 		}
 		await ctx.sync();
 
 		return shapes.map(shape => {
-			const textual = !NON_TEXT_SHAPE_TYPES.has(shape.type ?? "") && shape.textFrame?.hasText;
+			const textual = isTextBearing(shape.type) && shape.textFrame?.hasText;
 			const text = textual ? (shape.textFrame?.textRange?.text ?? "") : "";
 			const detail: ShapeDetail = {
 				name: shape.name ?? "",
@@ -355,16 +366,27 @@ export function createPowerPointHostTools(ppt: PowerPointLike = getPowerPoint())
 				try {
 					await ppt.run(async ctx => {
 						const slide = ctx.presentation.slides.getItemAt(slideIndex);
-						slide.shapes.load("items/name");
+						slide.shapes.load("items/name,type");
 						await ctx.sync();
 						const shape = slide.shapes.items.find(s => s.name === shapeName);
 						if (!shape) {
 							throw new Error(`no shape named "${shapeName}" on slide ${slideIndex}`);
 						}
-						if (!shape.textFrame) {
+						// `.textFrame` is always a truthy proxy in real Office; a non-text shape
+						// only reveals itself by type. Gate on that so a Table/Image target gives
+						// a friendly error instead of a raw InvalidArgument at sync.
+						if (!isTextBearing(shape.type)) {
+							throw new Error(
+								`shape "${shapeName}" on slide ${slideIndex} (type ${shape.type ?? "unknown"}) can't hold text`,
+							);
+						}
+						// In real Office a text-bearing shape always has a textFrame proxy; this
+						// narrows the seam's optional type (and guards the mock).
+						const frame = shape.textFrame;
+						if (!frame) {
 							throw new Error(`shape "${shapeName}" on slide ${slideIndex} has no text frame`);
 						}
-						shape.textFrame.textRange.text = text;
+						frame.textRange.text = text;
 						await ctx.sync();
 					});
 				} catch (err) {

--- a/packages/office-pane/test/powerpoint-tools.test.ts
+++ b/packages/office-pane/test/powerpoint-tools.test.ts
@@ -42,7 +42,7 @@ function fakePpt(initial: string[][] = []): PowerPointLike & { slides: FakeSlide
 		masterName: "Office Theme",
 		shapes: texts.map((t, i) => ({
 			name: `Shape ${i + 1}`,
-			type: "textBox",
+			type: "TextBox",
 			left: i * 10,
 			top: i * 20,
 			width: 100,
@@ -60,7 +60,7 @@ function fakePpt(initial: string[][] = []): PowerPointLike & { slides: FakeSlide
 		addTextBox(text: string): FakeShape {
 			const shape: FakeShape = {
 				name: `Shape ${slide.shapes.length + 1}`,
-				type: "textBox",
+				type: "TextBox",
 				left: 0,
 				top: 0,
 				width: 100,
@@ -162,24 +162,34 @@ describe("powerpoint-tools", () => {
 		d.dispose();
 	});
 
-	it("read_slides skips table/group shapes instead of throwing on them", async () => {
-		// A slide with a table shape (textFrame would throw at sync) + a text shape.
+	it("read_slides skips non-text shapes (Table/Image, real PascalCase types) instead of throwing", async () => {
+		// A slide with a Table AND an Image (both throw on .textFrame in real Office)
+		// plus a text shape. Shape.type is PascalCase, as real PowerPoint returns.
 		const t = new MockTransport();
-		let loadedTextFrameOnTable = false;
+		let touchedNonTextFrame = false;
+		const throwingFrame = () => {
+			touchedNonTextFrame = true; // real API throws here — we must NOT touch it
+			throw new Error("InvalidArgument");
+		};
 		const withTable: PowerPointLike = {
 			run: async batch => {
 				const tableShape = {
-					type: "table",
+					type: "Table",
 					get textFrame() {
-						loadedTextFrameOnTable = true; // real API throws here — we must NOT touch it
-						throw new Error("InvalidArgument");
+						return throwingFrame();
+					},
+				};
+				const imageShape = {
+					type: "Image",
+					get textFrame() {
+						return throwingFrame();
 					},
 				};
 				const textShape = {
-					type: "textBox",
+					type: "TextBox",
 					textFrame: { hasText: true, textRange: { text: "Real content" }, load() {} },
 				};
-				const slide = { shapes: { items: [tableShape, textShape], load() {}, addTextBox() {} } };
+				const slide = { shapes: { items: [tableShape, imageShape, textShape], load() {}, addTextBox() {} } };
 				const ctx = {
 					presentation: {
 						slides: { items: [slide], load() {}, add() {}, getItemAt: () => slide },
@@ -199,7 +209,7 @@ describe("powerpoint-tools", () => {
 		const reply = callFrom(t);
 		expect(reply?.isError).toBeUndefined();
 		expect(firstText(reply)).toContain("Real content");
-		expect(loadedTextFrameOnTable).toBe(false); // table's textFrame was never accessed
+		expect(touchedNonTextFrame).toBe(false); // neither Table nor Image textFrame was accessed
 		d.dispose();
 	});
 
@@ -339,7 +349,7 @@ describe("powerpoint-tools", () => {
 		expect(reply?.isError).toBeUndefined();
 		const shapes = JSON.parse(firstText(reply) ?? "[]");
 		expect(shapes).toHaveLength(2);
-		expect(shapes[0]).toMatchObject({ name: "Shape 1", type: "textBox", text: "Only slide 1", left: 0, top: 0 });
+		expect(shapes[0]).toMatchObject({ name: "Shape 1", type: "TextBox", text: "Only slide 1", left: 0, top: 0 });
 		expect(shapes[1]).toMatchObject({ name: "Shape 2", text: "Second box", left: 10, top: 20 });
 		d.dispose();
 	});
@@ -351,7 +361,7 @@ describe("powerpoint-tools", () => {
 			run: async batch => {
 				const tableShape = {
 					name: "Table 1",
-					type: "table",
+					type: "Table",
 					left: 5,
 					top: 6,
 					width: 200,
@@ -363,7 +373,7 @@ describe("powerpoint-tools", () => {
 				};
 				const textShape = {
 					name: "Body 1",
-					type: "textBox",
+					type: "TextBox",
 					left: 1,
 					top: 2,
 					width: 3,
@@ -401,7 +411,7 @@ describe("powerpoint-tools", () => {
 		expect(reply?.isError).toBeUndefined();
 		const shapes = JSON.parse(firstText(reply) ?? "[]");
 		expect(shapes).toHaveLength(2);
-		expect(shapes[0]).toMatchObject({ name: "Table 1", type: "table" });
+		expect(shapes[0]).toMatchObject({ name: "Table 1", type: "Table" });
 		expect(shapes[0].text).toBeUndefined();
 		expect(shapes[1]).toMatchObject({ name: "Body 1", text: "Real content" });
 		expect(touchedTableTextFrame).toBe(false);
@@ -488,6 +498,49 @@ describe("powerpoint-tools", () => {
 		const reply = callFrom(t);
 		expect(reply?.isError).toBe(true);
 		expect(firstText(reply)).toContain("Nope");
+		d.dispose();
+	});
+
+	it("modify_shape_text gives a friendly error for a non-text shape (Table) — no raw InvalidArgument", async () => {
+		const t = new MockTransport();
+		let touchedTableTextFrame = false;
+		const withTable: PowerPointLike = {
+			run: async batch => {
+				const tableShape = {
+					name: "Table 1",
+					type: "Table",
+					get textFrame() {
+						touchedTableTextFrame = true;
+						throw new Error("InvalidArgument");
+					},
+				};
+				const slide = { shapes: { items: [tableShape], load() {}, addTextBox() {} } };
+				const ctx = {
+					presentation: {
+						slides: { items: [slide], load() {}, add() {}, getItemAt: () => slide },
+						getSelectedSlides: () => ({ getItemAt: () => slide }),
+					},
+					sync: async () => {},
+				};
+				return batch(ctx as unknown as PptContextLike);
+			},
+		};
+		const d = new HostToolDispatcher(t);
+		registerPowerPointTools(d, withTable);
+
+		t.emit({
+			type: "host_tool_call",
+			id: "mnt",
+			toolCallId: "tmnt",
+			toolName: "modify_shape_text",
+			arguments: { slideIndex: 0, shapeName: "Table 1", text: "x" },
+		});
+		await flush();
+
+		const reply = callFrom(t);
+		expect(reply?.isError).toBe(true);
+		expect(firstText(reply)).toContain("can't hold text");
+		expect(touchedTableTextFrame).toBe(false); // gated on type; never touched the throwing frame
 		d.dispose();
 	});
 


### PR DESCRIPTION
Closes #2265. From the cross-functional Office.js API audit — the highest-severity finding (crash).

## Problem

`PowerPoint.Shape.type` returns **PascalCase** `ShapeType` values (`"TextBox"`, `"Table"`, `"Image"`, `"GeometricShape"`, …) — PowerPoint is one of the few Office enums that aren't camelCase. The code filtered a **lowercase** denylist `{"table","group"}`, so in real PowerPoint the compare is **always false** → Table/Group shapes weren't skipped → the code read `shape.textFrame` on them → Office throws `InvalidArgument` at `sync()` → **`read_slides` / `read_slide_shapes` crashed on any deck containing a table or group.** The denylist was also incomplete — `.textFrame` throws for `Image`, `Chart`, `Media`, `SmartArt`, etc. The mock used lowercase types and always supplied a `textFrame`, so tests passed against a fiction (same class as Excel getTables).

## Fix

Replace the denylist with an **allowlist** of text-bearing PascalCase types — `TextBox`, `Placeholder`, `GeometricShape`, `Callout`, `Line` — via `isTextBearing()`, and only touch `.textFrame` for those. Robust to **all** non-text types, not just table/group. Applied in `read_slides`, `read_slide_shapes`, and `modify_shape_text` (a non-text target now yields a friendly "can't hold text" error instead of a raw `InvalidArgument`).

Mock corrected to real PascalCase types with **throwing** `textFrame` getters on `Table`/`Image`, so the tests would now catch the crash; added a `modify_shape_text` non-text-shape case.

## Verification

19 powerpoint-tools tests pass against the corrected shapes; `tsgo` + `biome` clean.

Completes the audit sweep: Excel getTables (#2260, merged) · Excel read_table/read_named_range (incoming) · Word tracked-change (#2264) · this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)