### PR TITLE
fix(office-pane): read_table getDataBodyRange + read_named_range getRangeOrNullObject

### DIFF
--- a/packages/office-pane/src/office/excel-tools.ts
+++ b/packages/office-pane/src/office/excel-tools.ts
@@ -65,7 +65,10 @@ export interface ExcelTableColumnLike {
 /** An Excel Table — the subset the table tools touch. */
 export interface ExcelTableLike {
 	name: string;
-	getRange(): ExcelRangeLike;
+	/** The DATA BODY range (no header/totals). `getRange()` returns the entire
+	 * table incl. header + totals, so its row 0 duplicates the columns and a
+	 * totals row leaks in as junk data — read_table wants the body. */
+	getDataBodyRange(): ExcelRangeLike;
 	columns: ExcelNamedItemCollectionLike & { getItem(name: string): ExcelTableColumnLike };
 	/** Table sort surface. */
 	sort: { apply(fields: { key: number; ascending: boolean }[]): void };
@@ -87,7 +90,9 @@ export interface ExcelRequestContextLike {
 	workbook: {
 		worksheets: ExcelWorksheetCollectionLike;
 		/** Workbook-level named ranges: enumerable and resolvable by name. */
-		names: ExcelNamedItemCollectionLike & { getItem(name: string): { getRange(): ExcelRangeLike } };
+		names: ExcelNamedItemCollectionLike & {
+			getItem(name: string): { getRangeOrNullObject(): ExcelRangeLike & { isNullObject?: boolean } };
+		};
 		/** Workbook-level Excel Tables, resolvable by name. */
 		tables: { getItem(name: string): ExcelTableLike };
 	};
@@ -402,7 +407,7 @@ export function createExcelHostTools(excel: ExcelLike = getExcel()): HostToolReg
 				try {
 					data = await excel.run(async ctx => {
 						const table = ctx.workbook.tables.getItem(name);
-						const range = table.getRange();
+						const range = table.getDataBodyRange();
 						range.load("values,address");
 						table.columns.load("items/name");
 						await ctx.sync();
@@ -473,9 +478,17 @@ export function createExcelHostTools(excel: ExcelLike = getExcel()): HostToolReg
 				let data: { values: unknown[][]; address: string };
 				try {
 					data = await excel.run(async ctx => {
-						const range = ctx.workbook.names.getItem(name).getRange();
-						range.load("values,address");
+						// getRangeOrNullObject (not getRange) — getRange THROWS if the defined
+						// name isn't a cell range (a constant/formula). workbook.names also only
+						// resolves workbook-scoped names; a sheet-scoped name surfaces as ItemNotFound.
+						const range = ctx.workbook.names.getItem(name).getRangeOrNullObject();
+						range.load("values,address,isNullObject");
 						await ctx.sync();
+						if (range.isNullObject) {
+							throw new Error(
+								`named item "${name}" is not a cell range (it may be a constant or formula; only workbook-scoped ranges are supported)`,
+							);
+						}
 						return { values: range.values, address: range.address ?? "" };
 					});
 				} catch (err) {

--- a/packages/office-pane/test/excel-tools.test.ts
+++ b/packages/office-pane/test/excel-tools.test.ts
@@ -51,7 +51,7 @@ interface FakeExcelMeta {
 		}
 	>;
 	/** Workbook-level named ranges: name → { address, values }. */
-	namedRanges?: Record<string, { address: string; values: unknown[][] }>;
+	namedRanges?: Record<string, { address: string; values: unknown[][]; notRange?: boolean }>;
 	/** Workbook-level tables: name → { address, values, columns }. */
 	tables?: Record<string, { address: string; values: unknown[][]; columns?: string[] }>;
 }
@@ -150,7 +150,7 @@ function fakeExcel(
 				const cols = t.columns ?? [];
 				return {
 					name,
-					getRange: () => makeRange(t.address, { read: () => t.values }),
+					getDataBodyRange: () => makeRange(t.address, { read: () => t.values }),
 					columns: {
 						items: cols.map(c => ({ name: c })),
 						load(_props: string): void {},
@@ -187,7 +187,14 @@ function fakeExcel(
 						getItem: (name: string) => {
 							const nr = namedRanges[name];
 							if (!nr) throw new Error(`Named range "${name}" not found`);
-							return { getRange: () => makeRange(nr.address, { read: () => nr.values }) };
+							// getRangeOrNullObject: a non-range defined name resolves to a null object
+							// (isNullObject:true) rather than throwing — mirrors real Office.js.
+							return {
+								getRangeOrNullObject: () =>
+									Object.assign(makeRange(nr.address, { read: () => nr.values }), {
+										isNullObject: nr.notRange ?? false,
+									}),
+							};
 						},
 					},
 					tables: {
@@ -679,6 +686,18 @@ describe("read_named_range (Phase 1)", () => {
 	it("throws (dispatcher → isError) on a missing name", async () => {
 		const excel = fakeExcel();
 		expect(tool(excel, "read_named_range").handler({}, dummyCtx)).rejects.toThrow(/name/i);
+	});
+
+	it("reports a clear error when the defined name is NOT a cell range (getRangeOrNullObject → isNullObject)", async () => {
+		// A defined name pointing at a constant/formula resolves to a null object, not a range.
+		const excel = fakeExcel(
+			{},
+			{ Sheet1: {} },
+			{ namedRanges: { tax_rate: { address: "", values: [], notRange: true } } },
+		);
+		expect(tool(excel, "read_named_range").handler({ name: "tax_rate" }, dummyCtx)).rejects.toThrow(
+			/not a cell range/i,
+		);
 	});
 });
 


### PR DESCRIPTION
Closes #2268. From the cross-functional Office.js audit (the two remaining Excel findings).

1. **`read_table` → `getDataBodyRange()`** (silent-wrong) — `table.getRange()` returns the **entire** table (header + data + totals), so `values[0]` was always the header (dup of `columns`) and a totals row leaked in as junk. `getDataBodyRange()` returns the body only, matching the tool's contract.
2. **`read_named_range` → `getRangeOrNullObject()`** (conditional crash) — `NamedItem.getRange()` **throws** for a defined name that isn't a cell range (constant/formula). Now uses `getRangeOrNullObject()` + `isNullObject` guard with a clear message (and notes workbook-scoped-only resolution) — the same OrNullObject idiom `get_workbook_info` already uses.

Seams + mock corrected to the real API shapes (`getDataBodyRange`, `getRangeOrNullObject`, a non-range null-object case) so tests exercise reality, not fictions.

## Verification
32 excel-tools tests pass (incl. a new non-range-name error case); `tsgo` + `biome` clean.

## Sweep complete
This closes the systemic Office.js API-correctness audit: **Excel** getTables (#2260 ✅) + read_table/read_named_range (this) · **Word** TrackedChange author/type (#2264) · **PowerPoint** ShapeType allowlist (#2266). Every fix corrected the mock to match Office.js so the class can't silently recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)