### PR TITLE
fix(chat): chat_tool_notice ok-flag reads tool_execution_end.isError (not nonexistent .error)

### DIFF
--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -205,12 +205,16 @@ export class ChatHandler {
 			return;
 		}
 		if (event.type === "tool_execution_end" && "toolName" in event) {
+			// ToolExecutionEndEvent carries `isError` (NOT `error`) — checking the wrong
+			// field made this always ok:true, so errored tools rendered ✓ and "failed"
+			// never fired. Read the real field.
+			const failed = "isError" in event && Boolean(event.isError);
 			this.#server.send({
 				type: "chat_tool_notice",
 				id: chat.id,
 				tool: String(event.toolName),
-				ok: !("error" in event && event.error),
-				detail: `${event.toolName}: ${"error" in event && event.error ? "failed" : "done"}`,
+				ok: !failed,
+				detail: `${event.toolName}: ${failed ? "failed" : "done"}`,
 			});
 			return;
 		}

--- a/packages/coding-agent/test/browser/chat-handler.host-tools.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.host-tools.test.ts
@@ -187,3 +187,67 @@ describe("ChatHandler host-tool wiring (#2046 A3)", () => {
 		expect(session.refreshedTools).toBeNull();
 	});
 });
+
+/**
+ * chat_tool_notice `ok`/detail must reflect ToolExecutionEndEvent.isError. The
+ * mapper used to check `event.error` (a field that doesn't exist), so every tool
+ * — even a crash — reported ok:true / "done". #2273.
+ */
+describe("chat_tool_notice ok-flag reflects tool_execution_end.isError", () => {
+	class EmittingSession {
+		isStreaming = false;
+		agent = { abort(): void {}, replaceMessages(): void {} };
+		#cbs: Array<(e: unknown) => void> = [];
+		#isError: boolean;
+		constructor(isError: boolean) {
+			this.#isError = isError;
+		}
+		subscribe(cb: (e: unknown) => void): () => void {
+			this.#cbs.push(cb);
+			return () => {};
+		}
+		async prompt(): Promise<void> {
+			for (const cb of this.#cbs) {
+				cb({ type: "tool_execution_start", toolCallId: "t1", toolName: "get_workbook_info", args: {} });
+				cb({
+					type: "tool_execution_end",
+					toolCallId: "t1",
+					toolName: "get_workbook_info",
+					result: { content: [] },
+					isError: this.#isError,
+				});
+			}
+		}
+		async refreshRpcHostTools(): Promise<void> {}
+	}
+
+	async function endNotice(isError: boolean): Promise<Record<string, unknown> | undefined> {
+		const server = new FakeBridgeServer();
+		const session = new EmittingSession(isError);
+		const handler = new ChatHandler(server as unknown as BridgeServer, session as unknown as AgentSession);
+		handler.attach();
+		server.emit({ type: "chat_request", id: "c-1", text: "read the workbook", context: null, mode: "configuration" });
+		// Let the async chat_request → prompt() → notice sends settle.
+		for (let i = 0; i < 50 && server.ofType("chat_tool_notice").length < 2; i++) {
+			await new Promise(r => setTimeout(r, 0));
+		}
+		// The END notice is the one carrying done/failed (the start says "running…").
+		return server
+			.ofType("chat_tool_notice")
+			.find(n => n.tool === "get_workbook_info" && !String(n.detail).includes("running"));
+	}
+
+	it("errored tool → ok:false + 'failed'", async () => {
+		const end = await endNotice(true);
+		expect(end).toBeDefined();
+		expect(end?.ok).toBe(false);
+		expect(String(end?.detail)).toContain("failed");
+	});
+
+	it("successful tool → ok:true + 'done'", async () => {
+		const end = await endNotice(false);
+		expect(end).toBeDefined();
+		expect(end?.ok).toBe(true);
+		expect(String(end?.detail)).toContain("done");
+	});
+});


### PR DESCRIPTION
Closes #2273.

## Problem
An errored tool showed ✓ (not ✗) in the transcript's activity row.

## Root cause
`chat-handler.ts` mapped `tool_execution_end` → `chat_tool_notice` with `ok: !("error" in event && event.error)`. But `ToolExecutionEndEvent` carries **`isError`**, not `error` — so `"error" in event` was **always false**, `ok` was **always true**, and the "failed" detail branch was dead. Every tool (errored or not) reported success.

## Fix
Read the real field: `const failed = "isError" in event && Boolean(event.isError)` → `ok: !failed`, detail `failed ? "failed" : "done"`.

## Verification
New chat-handler test emits `tool_execution_end` with `isError` true and false and asserts the resulting `chat_tool_notice` `ok`/detail. 9 host-tools tests pass; `tsgo` + `biome` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)