### PR TITLE
fix(plugin): resolve a bare install name to the marketplace plugin, not npm

### DIFF
--- a/packages/coding-agent/src/cli/classify-install-target.ts
+++ b/packages/coding-agent/src/cli/classify-install-target.ts
@@ -2,11 +2,17 @@
  * Classify an install spec as a marketplace plugin reference or a plain npm package.
  *
  * Rules (applied in order):
+ *  0. `npm:<pkg>` prefix -> always npm (explicit escape hatch; the prefix is stripped).
  *  1. Starts with `@` (scoped npm) -> always npm.
  *  2. Contains `@` after the first character -> split on the LAST `@`.
  *     If the right-hand side is a known marketplace name, it's a marketplace ref.
  *     Otherwise it's an npm spec (e.g. `pkg@1.2.3`).
- *  3. No `@` -> npm.
+ *  3. Bare name (no `@`) -> look it up against the marketplace catalog index:
+ *       - exactly one marketplace publishes it -> marketplace ref;
+ *       - more than one -> ambiguous (caller errors and asks for `name@marketplace`);
+ *       - none (or no index supplied) -> npm.
+ *     This is what makes `xcsh plugin install azure` resolve to the marketplace
+ *     `azure` plugin rather than the public npm package of the same name.
  */
 // Common npm dist-tags that should never be interpreted as marketplace names
 const NPM_DIST_TAGS = new Set([
@@ -25,10 +31,19 @@ const NPM_DIST_TAGS = new Set([
 // Semver-like: starts with digit, or contains version range prefixes
 const LOOKS_LIKE_VERSION = /^[\d~^>=<]/;
 
+export type InstallTarget =
+	| { type: "marketplace"; name: string; marketplace: string }
+	| { type: "ambiguous"; name: string; marketplaces: string[] }
+	| { type: "npm"; spec: string };
+
 export function classifyInstallTarget(
 	spec: string,
 	knownMarketplaces: Set<string>,
-): { type: "marketplace"; name: string; marketplace: string } | { type: "npm"; spec: string } {
+	/** plugin name -> marketplaces whose catalog publishes a plugin with that name */
+	catalogIndex?: Map<string, string[]>,
+): InstallTarget {
+	// Rule 0: explicit npm escape hatch — force npm even if a marketplace shares the name.
+	if (spec.startsWith("npm:")) return { type: "npm", spec: spec.slice("npm:".length) };
 	// Rule 1: scoped npm package — @ at position 0 is never a marketplace separator.
 	if (spec.startsWith("@")) return { type: "npm", spec };
 	// Rule 2: @ somewhere after the first character.
@@ -45,6 +60,14 @@ export function classifyInstallTarget(
 		// Not a known marketplace — treat as npm version specifier.
 		return { type: "npm", spec };
 	}
-	// Rule 3: no @ at all.
+	// Rule 3: bare name — resolve against the marketplace catalog index before npm.
+	const sources = catalogIndex?.get(spec);
+	if (sources && sources.length === 1) {
+		return { type: "marketplace", name: spec, marketplace: sources[0] };
+	}
+	if (sources && sources.length > 1) {
+		return { type: "ambiguous", name: spec, marketplaces: sources };
+	}
+	// Rule 4: no marketplace publishes this name — plain npm package.
 	return { type: "npm", spec };
 }

--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -355,12 +355,39 @@ async function handleInstall(
 		process.exit(1);
 	}
 
-	// Build known marketplace set for classification
+	// Build classification inputs: known marketplace names, plus a catalog index
+	// (plugin name -> marketplaces that publish it) so a bare name resolves to the
+	// marketplace plugin instead of a same-named public npm package.
 	const mktMgr = await makeMarketplaceManager();
-	const knownMarketplaces = new Set((await mktMgr.listMarketplaces()).map(m => m.name));
+	const marketplaces = await mktMgr.listMarketplaces();
+	const knownMarketplaces = new Set(marketplaces.map(m => m.name));
+	const catalogIndex = new Map<string, string[]>();
+	for (const mp of marketplaces) {
+		let plugins: Awaited<ReturnType<typeof mktMgr.listAvailablePlugins>>;
+		try {
+			plugins = await mktMgr.listAvailablePlugins(mp.name);
+		} catch {
+			continue; // a broken/uncloned catalog must not block installs from others
+		}
+		for (const p of plugins) {
+			const sources = catalogIndex.get(p.name) ?? [];
+			if (!sources.includes(mp.name)) sources.push(mp.name);
+			catalogIndex.set(p.name, sources);
+		}
+	}
 
 	for (const spec of packages) {
-		const target = classifyInstallTarget(spec, knownMarketplaces);
+		const target = classifyInstallTarget(spec, knownMarketplaces, catalogIndex);
+
+		if (target.type === "ambiguous") {
+			console.error(
+				chalk.red(
+					`${theme.status.error} "${target.name}" is published by multiple marketplaces: ${target.marketplaces.join(", ")}.`,
+				),
+			);
+			console.error(chalk.dim(`Disambiguate with ${target.name}@<marketplace>.`));
+			process.exit(1);
+		}
 
 		if (target.type === "marketplace") {
 			try {

--- a/packages/coding-agent/test/marketplace/cli.test.ts
+++ b/packages/coding-agent/test/marketplace/cli.test.ts
@@ -49,4 +49,28 @@ describe("classifyInstallTarget", () => {
 		const result = classifyInstallTarget("some-pkg@my-marketplace", KNOWN);
 		expect(result).toEqual({ type: "marketplace", name: "some-pkg", marketplace: "my-marketplace" });
 	});
+
+	it("resolves a bare name to the marketplace that publishes it (catalog index)", () => {
+		const index = new Map<string, string[]>([["azure", ["f5-sales-demo-marketplace"]]]);
+		const result = classifyInstallTarget("azure", new Set(["f5-sales-demo-marketplace"]), index);
+		expect(result).toEqual({ type: "marketplace", name: "azure", marketplace: "f5-sales-demo-marketplace" });
+	});
+
+	it("reports ambiguity when a bare name is published by multiple marketplaces", () => {
+		const index = new Map<string, string[]>([["azure", ["mp-a", "mp-b"]]]);
+		const result = classifyInstallTarget("azure", new Set(["mp-a", "mp-b"]), index);
+		expect(result).toEqual({ type: "ambiguous", name: "azure", marketplaces: ["mp-a", "mp-b"] });
+	});
+
+	it("falls back to npm for a bare name absent from every catalog", () => {
+		const index = new Map<string, string[]>([["azure", ["f5-sales-demo-marketplace"]]]);
+		const result = classifyInstallTarget("cowsay", new Set(["f5-sales-demo-marketplace"]), index);
+		expect(result).toEqual({ type: "npm", spec: "cowsay" });
+	});
+
+	it("forces npm for an explicit npm: prefix even when a marketplace publishes the name", () => {
+		const index = new Map<string, string[]>([["azure", ["f5-sales-demo-marketplace"]]]);
+		const result = classifyInstallTarget("npm:azure", new Set(["f5-sales-demo-marketplace"]), index);
+		expect(result).toEqual({ type: "npm", spec: "azure" });
+	});
 });


### PR DESCRIPTION
## Summary

`xcsh plugin install azure` installed the **public npm package** `azure` (a deprecated Azure SDK meta-package) instead of the marketplace `azure` plugin. Root cause: `classifyInstallTarget` routed every bare name (no `@`) straight to npm, and `handleInstall` never consulted the configured marketplaces' catalog plugin names for a bare name.

- `classify-install-target.ts`: add a `catalogIndex` (plugin name → publishing marketplaces). A bare name resolves to a marketplace plugin when exactly one marketplace publishes it, is `ambiguous` when several do (caller errors, asks for `name@marketplace`), and falls back to npm only when none do. Added an explicit `npm:<pkg>` escape hatch to force npm.
- `plugin-cli.ts` `handleInstall`: build the catalog index from `listMarketplaces()` × `listAvailablePlugins()`, pass it to the classifier, and error clearly on ambiguity.

## Verification

- **TDD red → green** in `test/marketplace/cli.test.ts` (bare-name→marketplace, ambiguity, npm-fallback, `npm:` prefix): 12 pass.
- Marketplace suite: **285 pass / 0 fail**; `biome check` clean; `tsgo` typecheck clean.
- **Real CLI (from source):** `plugin install azure` now reports `azure@f5-sales-demo-marketplace ... already installed` (marketplace path) instead of npm-installing `azure`; no stray npm plugin added.

Closes #2274

🤖 Generated with [Claude Code](https://claude.com/claude-code)