### PR TITLE
fix(plugin): refresh marketplace catalogs on explicit upgrade

### DIFF
--- a/packages/coding-agent/src/cli/plugin-cli.ts
+++ b/packages/coding-agent/src/cli/plugin-cli.ts
@@ -311,10 +311,10 @@ async function handleUpgrade(args: string[], flags: PluginCommandArgs["flags"]):
 	try {
 		if (pluginId) {
 			if (flags.scope) {
-				const result = await manager.upgradePlugin(pluginId, flags.scope);
+				const result = await manager.upgradePlugin(pluginId, flags.scope, { refresh: true });
 				console.log(chalk.green(`Upgraded ${pluginId} (${flags.scope}) to ${result.version}`));
 			} else {
-				const entries = await manager.upgradePluginAcrossScopes(pluginId);
+				const entries = await manager.upgradePluginAcrossScopes(pluginId, { refresh: true });
 				for (const entry of entries) {
 					console.log(chalk.green(`Upgraded ${pluginId} (${entry.scope}) to ${entry.version}`));
 				}
@@ -327,7 +327,7 @@ async function handleUpgrade(args: string[], flags: PluginCommandArgs["flags"]):
 					),
 				);
 			}
-			const results = await manager.upgradeAllPlugins();
+			const results = await manager.upgradeAllPlugins({ refresh: true });
 			if (results.length === 0) {
 				console.log("All marketplace plugins are up to date.");
 			} else {

--- a/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/manager.ts
@@ -563,9 +563,13 @@ export class MarketplaceManager {
 	// Compare installed plugin versions against their catalog entries.
 	// Returns one entry per (pluginId, scope) pair where the catalog declares a newer version.
 	// Catalog entries without a version field are skipped.
-	async checkForUpdates(): Promise<
-		Array<{ pluginId: string; scope: "user" | "project" | "local"; from: string; to: string }>
-	> {
+	async checkForUpdates(opts?: {
+		refresh?: boolean;
+	}): Promise<Array<{ pluginId: string; scope: "user" | "project" | "local"; from: string; to: string }>> {
+		// Explicit upgrade flows pass refresh:true to re-fetch catalogs from source before
+		// comparing, so freshly-published versions are seen. Passive callers (startup notify,
+		// dashboard poll) omit it and rely on the 24h TTL (refreshStaleMarketplaces).
+		if (opts?.refresh) await this.updateAllMarketplaces();
 		const mktReg = await readMarketplacesRegistry(this.#opts.marketplacesRegistryPath);
 		const updates: Array<{ pluginId: string; scope: "user" | "project" | "local"; from: string; to: string }> = [];
 
@@ -620,7 +624,12 @@ export class MarketplaceManager {
 	}
 
 	// Re-install a specific plugin at the latest catalog version (force-overwrites).
-	async upgradePlugin(pluginId: string, scope?: "user" | "project" | "local"): Promise<InstalledPluginEntry> {
+	async upgradePlugin(
+		pluginId: string,
+		scope?: "user" | "project" | "local",
+		opts?: { refresh?: boolean },
+	): Promise<InstalledPluginEntry> {
+		if (opts?.refresh) await this.updateAllMarketplaces();
 		const parsed = parsePluginId(pluginId);
 		if (!parsed) {
 			throw new Error(`Invalid plugin ID: "${pluginId}". Expected "name@marketplace".`);
@@ -656,7 +665,8 @@ export class MarketplaceManager {
 
 	// Upgrade a plugin across all scopes where it is installed.
 	// Returns one entry per scope upgraded (0–2 entries).
-	async upgradePluginAcrossScopes(pluginId: string): Promise<InstalledPluginEntry[]> {
+	async upgradePluginAcrossScopes(pluginId: string, opts?: { refresh?: boolean }): Promise<InstalledPluginEntry[]> {
+		if (opts?.refresh) await this.updateAllMarketplaces();
 		const parsed = parsePluginId(pluginId);
 		if (!parsed) {
 			throw new Error(`Invalid plugin ID: "${pluginId}". Expected "name@marketplace".`);
@@ -688,10 +698,10 @@ export class MarketplaceManager {
 	// Upgrade every (pluginId, scope) pair that checkForUpdates reports as outdated.
 	// Only stale scopes are touched; a current user install is not re-installed when only
 	// the project scope is stale. Per-entry failures are skipped — partial success is returned.
-	async upgradeAllPlugins(): Promise<
-		Array<{ pluginId: string; scope: "user" | "project" | "local"; from: string; to: string }>
-	> {
-		const updates = await this.checkForUpdates();
+	async upgradeAllPlugins(opts?: {
+		refresh?: boolean;
+	}): Promise<Array<{ pluginId: string; scope: "user" | "project" | "local"; from: string; to: string }>> {
+		const updates = await this.checkForUpdates(opts);
 		const results: Array<{ pluginId: string; scope: "user" | "project" | "local"; from: string; to: string }> = [];
 		for (const update of updates) {
 			try {

--- a/packages/coding-agent/src/modes/components/plugins/plugin-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/plugins/plugin-dashboard.ts
@@ -353,7 +353,7 @@ export class PluginDashboard extends Container {
 		this.#rebuildAndRender();
 
 		try {
-			await this.#mgr.upgradePlugin(plugin.id, plugin.scope);
+			await this.#mgr.upgradePlugin(plugin.id, plugin.scope, { refresh: true });
 			this.#state.notice = t("plugins.dashboard.upgraded", { name: plugin.name });
 			await this.#reloadData();
 		} catch (error) {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1144,12 +1144,12 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 								runtime.ctx.showStatus(upArgs.error);
 								return;
 							}
-							const result = await mgr.upgradePlugin(upArgs.pluginId, upArgs.scope);
+							const result = await mgr.upgradePlugin(upArgs.pluginId, upArgs.scope, { refresh: true });
 							runtime.ctx.showStatus(
 								t("commands.plugin.upgraded", { pluginId: upArgs.pluginId, version: result.version }),
 							);
 						} else {
-							const results = await mgr.upgradeAllPlugins();
+							const results = await mgr.upgradeAllPlugins({ refresh: true });
 							if (results.length === 0) {
 								runtime.ctx.showStatus(t("commands.plugin.allUpToDate"));
 							} else {

--- a/packages/coding-agent/test/marketplace/manager.test.ts
+++ b/packages/coding-agent/test/marketplace/manager.test.ts
@@ -413,6 +413,35 @@ describe("MarketplaceManager", () => {
 			fs.writeFileSync(regPath, JSON.stringify(reg, null, 2));
 		}
 
+		it("upgradeAllPlugins({ refresh: true }) observes a freshly-published source version", async () => {
+			// Writable copy of the fixture so a new version can be "published" to the SOURCE
+			// (the cached catalog is what goes stale — bumpCatalogVersion patches the cache and
+			// therefore never exercises the stale-cache path this bug is about).
+			const sourceDir = path.join(ctx.tmpDir, "source-marketplace");
+			fs.cpSync(FIXTURE_DIR, sourceDir, { recursive: true });
+
+			await ctx.manager.addMarketplace(sourceDir); // caches catalog @ 1.0.0
+			await ctx.manager.installPlugin("hello-plugin", "test-marketplace"); // installed @ 1.0.0
+
+			// Publish 1.2.0 to the SOURCE only; the on-disk cached catalog still says 1.0.0.
+			const srcCatalog = path.join(sourceDir, ".xcsh-plugin", "marketplace.json");
+			const cat = JSON.parse(fs.readFileSync(srcCatalog, "utf-8")) as { plugins: Array<Record<string, unknown>> };
+			cat.plugins[0] = { ...cat.plugins[0], version: "1.2.0" };
+			fs.writeFileSync(srcCatalog, JSON.stringify(cat, null, 2));
+
+			// Control: without a refresh the stale cache hides the new version.
+			expect(await ctx.manager.upgradeAllPlugins()).toHaveLength(0);
+
+			// Clean-break behavior: an explicit refresh re-fetches the catalog and upgrades.
+			const results = await ctx.manager.upgradeAllPlugins({ refresh: true });
+			expect(results).toHaveLength(1);
+			expect(results[0]).toMatchObject({
+				pluginId: "hello-plugin@test-marketplace",
+				from: "1.0.0",
+				to: "1.2.0",
+			});
+		});
+
 		it("checkForUpdates returns outdated plugins", async () => {
 			await ctx.manager.addMarketplace(FIXTURE_DIR);
 			await ctx.manager.installPlugin("hello-plugin", "test-marketplace");


### PR DESCRIPTION
## Summary

`xcsh plugin upgrade` reported "All marketplace plugins are up to date" even after new versions were published, because it read the stale on-disk catalog cache and never re-fetched (the only auto-refresh is a 24h TTL the command didn't invoke; `--force` didn't bypass it either).

Add an opt-in `{ refresh: true }` to `checkForUpdates` / `upgradeAllPlugins` / `upgradePlugin` / `upgradePluginAcrossScopes` that calls `updateAllMarketplaces()` (re-fetch from source) before comparing. The **explicit** upgrade entry points pass `refresh: true`:
- `plugin upgrade` CLI (`plugin-cli.ts` `handleUpgrade`)
- `/plugin upgrade` slash-command (`builtin-registry.ts`)
- dashboard upgrade action (`plugin-dashboard.ts`)

**Passive** callers (startup notify, dashboard poll in `main.ts`/`state-manager.ts`) keep the 24h TTL, so this doesn't add a git-clone to every startup.

## Verification

- **TDD red → green** in `test/marketplace/manager.test.ts`: publishes a newer version to the marketplace **source** and asserts `upgradeAllPlugins({ refresh: true })` detects + applies it (with a control asserting the stale cache hides it without refresh).
- Marketplace suite: **0 fail**; `biome check` + `tsgo` typecheck clean.
- **Real CLI (from source):** `plugin upgrade` now reports `aws/azure/gcloud/github/gitlab 1.1.0 -> 1.2.0` and `salesforce 1.2.0 -> 1.3.0` (the freshly-published marketplace versions) instead of "All marketplace plugins are up to date".

Closes #2277

🤖 Generated with [Claude Code](https://claude.com/claude-code)