### PR TITLE
docs(office-pane): UAT acceptance checklist (per-surface prompts + expected results)

### DIFF
--- a/packages/office-pane/UAT.md
+++ b/packages/office-pane/UAT.md
@@ -1,0 +1,96 @@
+# Office pane — UAT acceptance checklist
+
+Manual acceptance tests for the xcsh Office task pane. The Office.js host tools and
+the pane UI run inside the real host app (Excel, Word, PowerPoint); there is no
+headless Office runtime, so these cannot be exercised by CI. CI and the unit tests
+verify each tool's API *shape* against a faithful mock — this checklist verifies the
+real behavior in the app. Re-run the relevant section after any release that touches
+the pane, the host tools, or the chat engine.
+
+## Setup
+
+1. Install the build under test (`brew upgrade xcsh`; confirm `xcsh --version`).
+2. Start the server from a small working directory:
+   `cd /tmp/xcsh-office-cwd && xcsh office serve` (leave it running).
+3. Sideload the add-in into the target app (`xcsh office sideload --app excel|word|powerpoint`)
+   and open the **xcsh** pane.
+4. Record the version and the pass/fail of each row.
+
+Legend: **Fix** names the issue the row validates.
+
+## Excel
+
+Fixture: a workbook with several sheets, at least one named Table, one named range
+that points at a cell range, one defined name that points at a constant or formula,
+and one empty sheet.
+
+| # | Action / prompt | Expected | Fix |
+|---|---|---|---|
+| E1 | "summarize the structure of this workbook" | Activity shows "Reading workbook structure ✓"; the answer lists sheets, Tables, and named ranges. No "get_workbook_info errored / falling back" message. | #2260 |
+| E2 | "read the `<TableName>` table" | Returns the Table's **data rows only** — the first returned row is real data, not the column headers (headers are returned separately as column names); no totals row leaks in. | #2267 |
+| E3 | "read the named range `<rangeName>`" (a real cell range) | Returns the range's values and address. | Excel tools |
+| E4 | Define a name as a constant (for example `taxRate` = `=0.2`), then "read the named range `taxRate`" | A clear message that the name is not a cell range — not a crash or an empty result. | #2267 |
+| E5 | Select the empty sheet, then "summarize this sheet" | No `ItemNotFound` crash from the structure read. | #2231 |
+| E6 | "read `Sheet2!A1:C3`" | Cross-sheet values returned. | Excel tools |
+| E7 | "show the formulas in `A1:B5`" | Formulas (not just values) returned. | Excel tools |
+| E8 | "sort the `<TableName>` table by `<column>` descending" | The Table re-sorts in the sheet. | Excel tools |
+| E9 | "what is the number format and type of `A1`" | Cell metadata returned. | Excel tools |
+| E10 | "list the sheets" | All sheet tab names returned. | Excel tools |
+| E11 | "write `hello` into `Z1`" | The cell updates in the sheet. | Excel tools |
+
+## Word
+
+Fixture: a document with at least one comment and one tracked change (an insertion),
+several styled paragraphs, and a text selection.
+
+| # | Action / prompt | Expected | Fix |
+|---|---|---|---|
+| W1 | "read the tracked changes" | Each revision shows its text, an author (populated, not blank), and a type of `Added` / `Deleted` / `Formatted` — never `Inserted`. | #2264 |
+| W2 | "read the comments" | Each comment's text and author. | Word tools |
+| W3 | "outline the document structure" | Section count, heading outline, word count, and whether comments / tracked changes exist. | Word tools |
+| W4 | "read the paragraphs with their styles" | Paragraph text with style names (Heading 1, Normal, …). | Word tools |
+| W5 | Select some text, then "read my selection" | The selected text is returned. | Word tools |
+| W6 | "insert a paragraph 'Summary' at the end" | The paragraph is added. | Word tools |
+
+## PowerPoint
+
+Fixture: a deck where at least one slide contains a **table or an image** alongside
+normal text shapes.
+
+| # | Action / prompt | Expected | Fix |
+|---|---|---|---|
+| P1 | "read all the slides" | Text from text-bearing shapes is returned; the deck with a table / image does **not** crash ("read_slides errored"). | #2266 |
+| P2 | "read the shapes on slide 1" | Every shape is listed with its name, type, and geometry; text-bearing shapes include their text; the table / image is listed without text and without error. | #2266 |
+| P3 | "set the text of the table shape to 'x'" | A friendly "can't hold text" message — not a raw `InvalidArgument`. | #2266 |
+| P4 | "read the layout of slide 1" | Layout and master names returned. | PowerPoint tools |
+| P5 | "add a slide" then "add a text box saying 'Agenda'" | A slide and a text box are added. | PowerPoint tools |
+| P6 | "set the text of the title shape to 'Q3 Review'" | The title text updates. | PowerPoint tools |
+
+## Pane UI (any surface)
+
+| # | Action | Expected | Fix |
+|---|---|---|---|
+| U1 | Ask a question whose answer contains a long code block or a long URL | Text wraps within the pane; nothing is clipped at the right margin. | #2272 |
+| U2 | Trigger a tool that fails (for example, on a deck with a table, try P3's edit) | The activity row shows a ✗ and "failed" — not a ✓. | #2275 |
+| U3 | Watch a reply as it streams | A blinking caret follows the streaming text; it stops when the answer settles. | #2244 |
+| U4 | Ask something that cites F5 documentation or console links | A "Sources" chip row appears beneath the answer; each chip is a clean clickable link (no trailing `*` or backtick). | #2237 / #2250 / #2257 |
+| U5 | After a few turns, click "New chat" | The transcript clears; the next answer shows no memory of the prior conversation. | #2244 |
+
+## Server reliability
+
+| # | Action | Expected | Fix |
+|---|---|---|---|
+| S1 | With a server already running, run `xcsh office serve` again | The new one reports it superseded the previous server and binds; no "port 8444 in use" error. | #2241 |
+| S2 | Run `xcsh office serve` from a large directory (for example the home directory) | It comes up quickly, with no "system prompt preparation timed out" warning. | #2246 |
+| S3 | `brew upgrade` while a server is running | The upgrade's post-install step recycles the running server. | #2241 |
+| S4 | Run `xcsh office recycle` with a server running, then with none | First stops the running server; second reports none is running. | #2241 |
+
+## Coverage notes
+
+- Excel `get_workbook_info` (E1), the pane tool-activity rows, the New-chat control,
+  markdown rendering, `history_hint` reset, cited-source cleanliness, and server
+  supersede / recycle / large-directory start have been verified in the live app or
+  against the running binary.
+- The remaining Excel tools (E2–E11), and **all** Word and PowerPoint rows, are
+  verified by unit tests against faithful mocks but have not yet been exercised in the
+  live app — run those sections in Excel, Word, and PowerPoint respectively.


### PR DESCRIPTION
Closes #2279.

Adds `packages/office-pane/UAT.md` — a repeatable manual acceptance checklist for the Office pane, since the Office.js tools + pane UI can't be exercised headless (no headless Office runtime; CI/mocks verify API *shape* only).

Per-surface tables (Excel / Word / PowerPoint / pane-UI / server-reliability). Each row = action/prompt → expected result → the fix+issue it validates, plus the document fixtures each section needs (a workbook with a Table + named range + empty sheet; a Word doc with a comment + tracked change; a deck with a table/image + text shapes).

Also documents **honest coverage** — what's been verified live vs. unit-only:
- Live-verified: `get_workbook_info`, tool-activity rows, New-chat, markdown, `history_hint` reset, source-link cleanliness, serve supersede/recycle/large-dir start.
- Unit-only (need a live run in-app): the rest of the Excel tools, and **all** Word + PowerPoint rows.

This is the acceptance harness to run after each release; it's the answer to "did you E2E test everything" — it makes the remaining live checks explicit and repeatable rather than ad hoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)