### PR TITLE
fix(office-pane): New chat aborts the in-flight server turn (wedge recovery)

### DIFF
--- a/packages/office-pane/src/panel/ChatPanel.tsx
+++ b/packages/office-pane/src/panel/ChatPanel.tsx
@@ -144,7 +144,9 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 
 	return (
 		<>
-			<Header onNewChat={newChat} canNewChat={ready && !streaming && turns.length > 0} />
+			{/* New chat stays available WHILE streaming — it aborts the in-flight turn
+			    (chat_stop) and resets, so a wedged turn is recoverable without a restart. */}
+			<Header onNewChat={newChat} canNewChat={ready && turns.length > 0} />
 			<Transcript messages={messages} streaming={streaming} onRetry={() => retry()} emptyState={emptyState} />
 			{/* No interaction-mode toggle: those modes are Chrome browser-automation
 			    only. The Office pane fixes the mode to `educational` (see useChatSession). */}

--- a/packages/office-pane/src/panel/useChatSession.ts
+++ b/packages/office-pane/src/panel/useChatSession.ts
@@ -239,6 +239,18 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 	}, [send]);
 
 	const newChat = useCallback(() => {
+		// Abort any in-flight turn on the SERVER first (chat_stop). Otherwise a turn
+		// that's still running (or wedged waiting on an unanswered host tool) keeps
+		// going after the reset, and the next send queues behind it forever — the
+		// "spins on Thinking… until a worker restart" trap. A closed transport throws
+		// on send; the reset below still clears the UI regardless.
+		if (activeTurnIdRef.current) {
+			try {
+				transport.stop(activeTurnIdRef.current);
+			} catch {
+				/* transport gone — nothing to abort; fall through to the local reset */
+			}
+		}
 		// Bump the conversation boundary so the NEXT send resets the engine's history,
 		// clear the transcript, and forget the last prompt (nothing to retry into the
 		// fresh chat). Ids stay monotonic (counterRef is not reset) to avoid collisions.
@@ -246,7 +258,7 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 		activeTurnIdRef.current = null;
 		lastUserTextRef.current = "";
 		setTurns([]);
-	}, []);
+	}, [transport]);
 
 	const lastAssistant = turns.findLast((t): t is AssistantTurn => t.kind === "assistant");
 

--- a/packages/office-pane/test/ChatPanel.test.tsx
+++ b/packages/office-pane/test/ChatPanel.test.tsx
@@ -29,7 +29,7 @@ test("New chat: disabled until there's a settled turn, then clears the transcrip
 	// No turns yet → disabled.
 	expect(newChatBtn().disabled).toBe(true);
 
-	// Send a turn and settle it (chat_done) → not streaming, one turn → enabled.
+	// Once there's a turn, New chat is enabled — including while it streams (recovery).
 	fireEvent.click(scope.getByRole("button", { name: /summarize/i }));
 	fireEvent.click(scope.getByRole("button", { name: /send/i }));
 	const req1 = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request")[0];
@@ -48,6 +48,28 @@ test("New chat: disabled until there's a settled turn, then clears the transcrip
 	fireEvent.click(scope.getByRole("button", { name: /send/i }));
 	const reqs = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request");
 	expect(reqs[reqs.length - 1].history_hint).not.toBe(req1.history_hint);
+});
+
+test("New chat is available WHILE streaming and aborts the in-flight turn (wedge recovery)", async () => {
+	const mock = new MockTransport();
+	const { container } = render(<ChatPanel transport={mock} />);
+	const scope = within(container);
+	await settle();
+	const newChatBtn = () => scope.getByRole("button", { name: /new chat/i }) as HTMLButtonElement;
+
+	fireEvent.click(scope.getByRole("button", { name: /summarize/i }));
+	fireEvent.click(scope.getByRole("button", { name: /send/i }));
+	const req = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request")[0];
+	if (!req) throw new Error("expected chat_request");
+
+	// Turn is streaming (no chat_done) — New chat must be usable as a recovery action.
+	expect(newChatBtn().disabled).toBe(false);
+
+	fireEvent.click(newChatBtn());
+	// It aborts the in-flight turn on the server (chat_stop) and clears the transcript.
+	const stops = mock.sent.filter(m => m.type === "chat_stop");
+	expect(stops.some(s => (s as { id: string }).id === req.id)).toBe(true);
+	await waitFor(() => expect(scope.queryByText("Summarize this document.")).toBeNull());
 });
 
 test("the empty state offers starter pills that PREFILL the composer without sending", async () => {

--- a/packages/office-pane/test/useChatSession.test.tsx
+++ b/packages/office-pane/test/useChatSession.test.tsx
@@ -170,6 +170,25 @@ test("each chat_request carries a history_hint; newChat bumps it (engine resets 
 	expect(req2.history_hint).not.toBe(req1.history_hint);
 });
 
+test("newChat aborts the in-flight turn (chat_stop) so a wedged turn can't survive the reset", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+
+	await act(async () => {
+		result.current.send("do a slow thing");
+	});
+	const req = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request")[0];
+	if (!req) throw new Error("expected chat_request");
+	// The turn is still streaming (no chat_done). newChat must abort it on the server.
+	await act(async () => {
+		result.current.newChat();
+	});
+	const stops = mock.sent.filter(m => m.type === "chat_stop");
+	expect(stops).toHaveLength(1);
+	expect((stops[0] as { id: string }).id).toBe(req.id);
+	expect(result.current.turns).toHaveLength(0);
+});
+
 test("within one conversation, successive turns reuse the SAME history_hint", async () => {
 	const mock = new MockTransport();
 	const { result } = renderHook(() => useChatSession(mock));


### PR DESCRIPTION
Closes #2281. From a live incident.

## Problem
A turn wedged (a `host_tool_call` the pane never answered — suspended WebView). The engine **queues** turns behind an active one, so every later prompt — even "list the sheets" — spun on "Thinking…" forever. **New chat cleared the UI but not the server turn**, so the zombie kept blocking the queue; only a manual worker restart recovered it. And the New-chat control was **disabled while streaming** — unavailable exactly when needed.

## Fix (client recovery path)
- `newChat()` sends `chat_stop` for the active turn before resetting — never strands a running/wedged server turn.
- New-chat is **enabled while streaming**, so it's a usable recovery action.

## Tests
`newChat` mid-stream emits `chat_stop` for the active turn id + clears turns; `ChatPanel` New-chat is enabled mid-stream and clicking it aborts + clears the transcript. office-pane 326 green; `tsgo` + `biome` clean; build 156.8KB/256KB.

## Note
This is the client recovery path. The root-cause complement — a `host_tool_call` timeout so a turn can't hang in the first place — is being specced separately (it touches the shared RPC bridge used by Chrome too, so it's spec-first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)