### PR TITLE
chore: bump version to v19.85.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "pi-natives"
-version = "19.85.3"
+version = "19.85.2"
 dependencies = [
  "arboard",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/brush-core-vendored", "crates/brush-builtins-vendored", "crat
 resolver = "3"
 
 [workspace.package]
-version = "19.85.3"
+version = "19.85.2"
 edition = "2024"
 license = "MIT"
 authors = ["Can Boluk"]

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/agent": {
       "name": "@f5-sales-demo/pi-agent-core",
-      "version": "19.85.3",
+      "version": "19.85.2",
       "dependencies": {
         "@f5-sales-demo/pi-ai": "workspace:*",
         "@f5-sales-demo/pi-utils": "workspace:*",
@@ -28,7 +28,7 @@
     },
     "packages/ai": {
       "name": "@f5-sales-demo/pi-ai",
-      "version": "19.85.3",
+      "version": "19.85.2",
       "bin": {
         "pi-ai": "./src/cli.ts",
       },
@@ -75,7 +75,7 @@
     },
     "packages/coding-agent": {
       "name": "@f5-sales-demo/xcsh",
-      "version": "19.85.3",
+      "version": "19.85.2",
       "bin": {
         "xcsh": "src/cli.ts",
       },
@@ -109,17 +109,17 @@
     },
     "packages/natives": {
       "name": "@f5-sales-demo/pi-natives",
-      "version": "19.85.3",
+      "version": "19.85.2",
       "devDependencies": {
         "@napi-rs/cli": "3.6.0",
         "@types/bun": "^1.3",
       },
       "optionalDependencies": {
-        "@f5-sales-demo/pi-natives-darwin-arm64": "19.85.3",
-        "@f5-sales-demo/pi-natives-darwin-x64": "19.85.3",
-        "@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.85.3",
-        "@f5-sales-demo/pi-natives-linux-x64-gnu": "19.85.3",
-        "@f5-sales-demo/pi-natives-win32-x64-msvc": "19.85.3",
+        "@f5-sales-demo/pi-natives-darwin-arm64": "19.85.2",
+        "@f5-sales-demo/pi-natives-darwin-x64": "19.85.2",
+        "@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.85.2",
+        "@f5-sales-demo/pi-natives-linux-x64-gnu": "19.85.2",
+        "@f5-sales-demo/pi-natives-win32-x64-msvc": "19.85.2",
       },
     },
     "packages/office-pane": {
@@ -147,7 +147,7 @@
     },
     "packages/resource-management": {
       "name": "@f5-sales-demo/pi-resource-management",
-      "version": "19.85.3",
+      "version": "19.85.2",
       "dependencies": {
         "yaml": "2.9.0",
       },
@@ -157,7 +157,7 @@
     },
     "packages/stats": {
       "name": "@f5-sales-demo/xcsh-stats",
-      "version": "19.85.3",
+      "version": "19.85.2",
       "bin": {
         "xcsh-stats": "./src/index.ts",
       },
@@ -182,7 +182,7 @@
     },
     "packages/swarm-extension": {
       "name": "@f5-sales-demo/swarm-extension",
-      "version": "19.85.3",
+      "version": "19.85.2",
       "bin": {
         "xcsh-swarm": "src/cli.ts",
       },
@@ -198,7 +198,7 @@
     },
     "packages/tui": {
       "name": "@f5-sales-demo/pi-tui",
-      "version": "19.85.3",
+      "version": "19.85.2",
       "dependencies": {
         "@f5-sales-demo/pi-natives": "workspace:*",
         "@f5-sales-demo/pi-utils": "workspace:*",
@@ -237,7 +237,7 @@
     },
     "packages/utils": {
       "name": "@f5-sales-demo/pi-utils",
-      "version": "19.85.3",
+      "version": "19.85.2",
       "dependencies": {
         "@f5-sales-demo/i18n-core": "^1.0.0",
         "beautiful-mermaid": "^1.1",
@@ -390,6 +390,16 @@
     "@f5-sales-demo/pi-ai": ["@f5-sales-demo/pi-ai@workspace:packages/ai"],
 
     "@f5-sales-demo/pi-natives": ["@f5-sales-demo/pi-natives@workspace:packages/natives"],
+
+    "@f5-sales-demo/pi-natives-darwin-arm64": ["@f5-sales-demo/pi-natives-darwin-arm64@19.85.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1ySJCRMm9ecAiwhgQqkugXC7Te6BiDG8jsnJ6IGprC+wd3jtXopk/P3xxZVoTbKwnMyh7Oms93U7qcjSWhxBAw=="],
+
+    "@f5-sales-demo/pi-natives-darwin-x64": ["@f5-sales-demo/pi-natives-darwin-x64@19.85.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-gGG4XMzqeK4OdEvLcSkbQlV+/0f29ZYg4wPyWBB9eLfsPEMkET99DoMbwpetgv7/oE/2QcwayIfGKCh4Y5++NQ=="],
+
+    "@f5-sales-demo/pi-natives-linux-arm64-gnu": ["@f5-sales-demo/pi-natives-linux-arm64-gnu@19.85.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-AGJW6mJGYQIIVGYi2mWYE7ZMMOItJkgECzLYwG3UfgXqpiltJfJ63VgVLYEhml5E6N2Dwugc/a7VibEj7RTwCw=="],
+
+    "@f5-sales-demo/pi-natives-linux-x64-gnu": ["@f5-sales-demo/pi-natives-linux-x64-gnu@19.85.2", "", { "os": "linux", "cpu": "x64" }, "sha512-pU4KTlzoiWXTcWTbv0x4ywc6/7RGNfjWM1z3R35n86ZTu3QI2UZ9pPN9LMJCwkejWxeOtBov6BAzrO/ohm3bBQ=="],
+
+    "@f5-sales-demo/pi-natives-win32-x64-msvc": ["@f5-sales-demo/pi-natives-win32-x64-msvc@19.85.2", "", { "os": "win32", "cpu": "x64" }, "sha512-EO4ExRkfkNhBtuMoBEBNsSm2IEoRFeThD2PvRASws/PX6IZZjTj34lZ+L69+G34h8YohUpiK8ImFkWbawNiz1g=="],
 
     "@f5-sales-demo/pi-resource-management": ["@f5-sales-demo/pi-resource-management@workspace:packages/resource-management"],
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-agent-core",
-	"version": "19.85.3",
+	"version": "19.85.2",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-ai",
-	"version": "19.85.3",
+	"version": "19.85.2",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/xcsh",
-	"version": "19.85.3",
+	"version": "19.85.2",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-arm64/package.json
+++ b/packages/natives/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-darwin-arm64",
-	"version": "19.85.3",
+	"version": "19.85.2",
 	"description": "Native addon for @f5-sales-demo/pi-natives (macOS arm64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-x64/package.json
+++ b/packages/natives/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-darwin-x64",
-	"version": "19.85.3",
+	"version": "19.85.2",
 	"description": "Native addon for @f5-sales-demo/pi-natives (macOS x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-arm64-gnu/package.json
+++ b/packages/natives/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-linux-arm64-gnu",
-	"version": "19.85.3",
+	"version": "19.85.2",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Linux arm64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-x64-gnu/package.json
+++ b/packages/natives/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-linux-x64-gnu",
-	"version": "19.85.3",
+	"version": "19.85.2",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Linux x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/win32-x64-msvc/package.json
+++ b/packages/natives/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-win32-x64-msvc",
-	"version": "19.85.3",
+	"version": "19.85.2",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Windows x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives",
-	"version": "19.85.3",
+	"version": "19.85.2",
 	"description": "Native Rust bindings for grep, clipboard, image processing, syntax highlighting, PTY, and shell operations via N-API",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",
@@ -56,11 +56,11 @@
 		}
 	},
 	"optionalDependencies": {
-		"@f5-sales-demo/pi-natives-linux-x64-gnu": "19.85.3",
-		"@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.85.3",
-		"@f5-sales-demo/pi-natives-darwin-x64": "19.85.3",
-		"@f5-sales-demo/pi-natives-darwin-arm64": "19.85.3",
-		"@f5-sales-demo/pi-natives-win32-x64-msvc": "19.85.3"
+		"@f5-sales-demo/pi-natives-linux-x64-gnu": "19.85.2",
+		"@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.85.2",
+		"@f5-sales-demo/pi-natives-darwin-x64": "19.85.2",
+		"@f5-sales-demo/pi-natives-darwin-arm64": "19.85.2",
+		"@f5-sales-demo/pi-natives-win32-x64-msvc": "19.85.2"
 	},
 	"files": [
 		"native",

--- a/packages/resource-management/package.json
+++ b/packages/resource-management/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-resource-management",
-	"version": "19.85.3",
+	"version": "19.85.2",
 	"description": "Shared resource management for F5 XC manifest parsing, validation, diff, and CRUD operations",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Robin Mordasiewicz",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/xcsh-stats",
-	"version": "19.85.3",
+	"version": "19.85.2",
 	"description": "Local observability dashboard for pi AI usage statistics",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/swarm-extension/package.json
+++ b/packages/swarm-extension/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/swarm-extension",
-	"version": "19.85.3",
+	"version": "19.85.2",
 	"description": "Swarm orchestration extension for xcsh",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Derek Rynd",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-tui",
-	"version": "19.85.3",
+	"version": "19.85.2",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-utils",
-	"version": "19.85.3",
+	"version": "19.85.2",
 	"description": "Shared utilities for pi packages",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",


### PR DESCRIPTION
Automated release PR generated by `scripts/release.ts`.

Bumps every public package and the Cargo workspace to `v19.85.2` and updates CHANGELOGs for the releasable commits since the last tag.

Once this PR squash-merges to `main`, `.github/workflows/tag-on-version-bump.yml` pushes the `v19.85.2` git tag, which triggers the downstream release chain (build → sign → publish).

### Releasable commits (9)

- fix(office-pane): New chat aborts the in-flight server turn (wedge recovery) (#2283)
- fix(plugin): refresh marketplace catalogs on explicit upgrade so fresh versions are seen (#2278)
- fix(plugin): resolve a bare install name to the marketplace plugin, not npm (#2276)
- fix(chat): chat_tool_notice ok-flag reads tool_execution_end.isError (not the nonexistent .error) (#2275)
- fix(chat-ui): stop assistant text overflowing the pane right margin (min-width:0 on grid content) (#2272)
- fix(office-pane): read_table uses getDataBodyRange; read_named_range uses getRangeOrNullObject (#2267)
- fix(office-pane): PowerPoint ShapeType is PascalCase — allowlist text-bearing shapes (read_slides crash) (#2266)
- fix(office-pane): Word TrackedChange.author (not authorName) + type "Added" (not "Inserted") (#2264)
- fix(office-pane): Worksheet.tables is a property, not getTables() (get_workbook_info live crash) (#2260)

See `docs-control`'s onboarding note "Release automation: release PR pattern" for the governance rationale.