### PR TITLE
docs(office-pane): fix UAT sideload syntax (positional app, not --app flag)

### DIFF
--- a/packages/office-pane/UAT.md
+++ b/packages/office-pane/UAT.md
@@ -12,7 +12,7 @@ the pane, the host tools, or the chat engine.
 1. Install the build under test (`brew upgrade xcsh`; confirm `xcsh --version`).
 2. Start the server from a small working directory:
    `cd /tmp/xcsh-office-cwd && xcsh office serve` (leave it running).
-3. Sideload the add-in into the target app (`xcsh office sideload --app excel|word|powerpoint`)
+3. Sideload the add-in into the target app (`xcsh office sideload excel|word|powerpoint`, e.g. `xcsh office sideload word`)
    and open the **xcsh** pane.
 4. Record the version and the pass/fail of each row.
 


### PR DESCRIPTION
Closes #2287. `office`'s `app` is a positional argument, so `xcsh office sideload --app word` errors `Unknown option '--app'`. Corrected `UAT.md` to `xcsh office sideload word` (positional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)