### PR TITLE
fix(office): make office sideload idempotent — pre-clean stale wef manifest links

### DIFF
--- a/packages/coding-agent/src/cli/office-cli.ts
+++ b/packages/coding-agent/src/cli/office-cli.ts
@@ -8,6 +8,8 @@
  * mirroring `stats-cli.ts` / `chrome-cli.ts`.
  */
 import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { LOCALIP_HOST } from "../browser/bridge-cert";
 import { type HeadlessChatBridge, startHeadlessChatBridge } from "../browser/headless-bridge";
@@ -133,7 +135,49 @@ async function runServe(): Promise<void> {
 	});
 }
 
-/** Run the Office sideload against the embedded bundle (best-effort). */
+/** The macOS Office desktop containers whose `wef` folder holds sideloaded manifests. */
+const OFFICE_WEF_CONTAINERS = ["com.microsoft.Excel", "com.microsoft.Powerpoint", "com.microsoft.Word"];
+
+/** The `wef` sideload directories for the desktop Office apps under `homeDir`. */
+export function officeWefDirs(homeDir: string): string[] {
+	return OFFICE_WEF_CONTAINERS.map(c => path.join(homeDir, "Library", "Containers", c, "Data", "Documents", "wef"));
+}
+
+/**
+ * `office-addin-debugging` symlinks the add-in manifest into each Office container's
+ * `wef` folder as `<manifestId>.manifest.json` and fails `EEXIST` if a link from a
+ * prior sideload is already there — so a repeat sideload errors even though the
+ * add-in registered fine. Remove any stale copy for our id so `office sideload` is
+ * idempotent. Best-effort per dir (a missing file or container is a no-op). Returns
+ * the paths actually removed.
+ */
+export function removeStaleWefManifests(manifestId: string, homeDir: string = os.homedir()): string[] {
+	const removed: string[] = [];
+	for (const dir of officeWefDirs(homeDir)) {
+		const p = path.join(dir, `${manifestId}.manifest.json`);
+		try {
+			if (fs.existsSync(p)) {
+				fs.rmSync(p);
+				removed.push(p);
+			}
+		} catch {
+			/* best-effort: a permission error or race here must not block the sideload */
+		}
+	}
+	return removed;
+}
+
+/** The add-in manifest id from the bundled manifest.json (the `wef` link's basename). */
+function manifestIdFrom(manifestText: string): string | undefined {
+	try {
+		const id = (JSON.parse(manifestText) as { id?: unknown }).id;
+		return typeof id === "string" && id.length > 0 ? id : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Run the Office sideload against the embedded bundle (idempotent + best-effort). */
 async function runSideload(app: OfficeApp): Promise<void> {
 	// Point office-addin-debugging at the extracted bundle dir, which has
 	// manifest.json AND its referenced `assets/` icons colocated. A bare temp
@@ -141,6 +185,21 @@ async function runSideload(app: OfficeApp): Promise<void> {
 	// step: `File to zip ".../assets/color.png" does not exist`.
 	const dir = await getOfficePaneDir();
 	const manifestPath = path.join(dir, "manifest.json");
+
+	// Idempotency: office-addin-debugging fails EEXIST if a prior sideload left a
+	// `<id>.manifest.json` link in a container's wef folder. Clear stale copies first.
+	const manifestId = manifestIdFrom(
+		await Bun.file(manifestPath)
+			.text()
+			.catch(() => ""),
+	);
+	if (manifestId) {
+		const removed = removeStaleWefManifests(manifestId);
+		if (removed.length > 0) {
+			console.log(`Cleared ${removed.length} stale sideload manifest link(s) from a previous sideload.`);
+		}
+	}
+
 	console.log(`Sideloading ${manifestPath} into ${app} (requires the office-addin-debugging / atk tool on PATH)...`);
 
 	const result = spawnSync("office-addin-debugging", ["start", manifestPath, "desktop", "--app", app], {

--- a/packages/coding-agent/test/office-cli.test.ts
+++ b/packages/coding-agent/test/office-cli.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, test } from "bun:test";
-import { type OfficeServeDeps, startOfficeServe } from "../src/cli/office-cli";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type OfficeServeDeps, officeWefDirs, removeStaleWefManifests, startOfficeServe } from "../src/cli/office-cli";
 
 /** A supersede seam that records it ran and reports nothing stale (no-op). */
 function noopSupersede() {
@@ -91,5 +94,52 @@ describe("startOfficeServe", () => {
 
 		await expect(startOfficeServe(deps)).rejects.toThrow(/isn't an xcsh office serve/);
 		expect(paneStarted).toBe(false);
+	});
+});
+
+describe("office sideload idempotency (wef manifest cleanup)", () => {
+	const ID = "6d3b8a41-2f5c-4e7a-9b0d-1c2e3f4a5b6c";
+	let home = "";
+	beforeEach(() => {
+		home = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-wef-"));
+	});
+	afterEach(() => {
+		if (home) fs.rmSync(home, { recursive: true, force: true });
+	});
+
+	test("officeWefDirs covers Excel/PowerPoint/Word wef folders under the home container store", () => {
+		const dirs = officeWefDirs(home);
+		expect(dirs).toHaveLength(3);
+		expect(dirs.some(d => d.includes("com.microsoft.Excel"))).toBe(true);
+		expect(dirs.some(d => d.includes("com.microsoft.Powerpoint"))).toBe(true);
+		expect(dirs.some(d => d.includes("com.microsoft.Word"))).toBe(true);
+		expect(dirs.every(d => d.endsWith(path.join("Data", "Documents", "wef")))).toBe(true);
+	});
+
+	test("removes a stale <id>.manifest.json from a container's wef and reports it", () => {
+		const wef = officeWefDirs(home).find(d => d.includes("com.microsoft.Powerpoint"));
+		if (!wef) throw new Error("no powerpoint wef dir");
+		fs.mkdirSync(wef, { recursive: true });
+		const stale = path.join(wef, `${ID}.manifest.json`);
+		fs.writeFileSync(stale, "{}");
+
+		const removed = removeStaleWefManifests(ID, home);
+		expect(removed).toContain(stale);
+		expect(fs.existsSync(stale)).toBe(false);
+	});
+
+	test("no-op (no throw, nothing removed) when the link and container dirs are absent", () => {
+		expect(removeStaleWefManifests(ID, home)).toEqual([]);
+	});
+
+	test("leaves a DIFFERENT add-in's manifest link untouched", () => {
+		const wef = officeWefDirs(home).find(d => d.includes("com.microsoft.Word"));
+		if (!wef) throw new Error("no word wef dir");
+		fs.mkdirSync(wef, { recursive: true });
+		const other = path.join(wef, "aaaaaaaa-0000-0000-0000-000000000000.manifest.json");
+		fs.writeFileSync(other, "{}");
+
+		removeStaleWefManifests(ID, home);
+		expect(fs.existsSync(other)).toBe(true);
 	});
 });


### PR DESCRIPTION
Closes #2289. From a live failure.

## Problem
Re-running `xcsh office sideload <app>` errors:
```
Error: EEXIST … -> '…/com.microsoft.Excel/Data/Documents/wef/6d3b8a41-….manifest.json'
```
`office-addin-debugging` symlinks the manifest into each Office container's `wef` folder as `<manifestId>.manifest.json` and won't overwrite a link left by a prior sideload — so a second sideload errors even though the add-in registered.

## Fix
`runSideload` reads the bundled manifest's `id` and removes any stale `<id>.manifest.json` from the Excel/PowerPoint/Word container `wef` dirs before delegating — idempotent sideloads.

New exported, unit-tested helpers: `officeWefDirs(homeDir)` and `removeStaleWefManifests(id, homeDir)`.

## Tests
Against a temp home dir: removes our id's link (+ reports it), no-op when the link/container is absent, leaves a *different* add-in's link untouched, and `officeWefDirs` covers all three apps. 7 office-cli tests pass; `tsgo` + `biome` clean. (The `office-addin-debugging` spawn itself needs real Office, so it stays a thin uncovered seam — the cleanup is the tested part.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)