### PR TITLE
fix(host-tools): idle timeout on host_tool_call — an unanswered tool can no longer hang the turn

### DIFF
--- a/packages/coding-agent/src/host-tools/host-tools.ts
+++ b/packages/coding-agent/src/host-tools/host-tools.ts
@@ -82,13 +82,25 @@ class RpcHostToolAdapter<TParams extends TSchema = TSchema, TTheme extends Theme
 	}
 }
 
+/**
+ * How long a host tool may go with NO response — neither a `host_tool_result` nor a
+ * `host_tool_update` — before we give up on it. An unanswered call (e.g. an Office
+ * task-pane whose WebView the host suspended when it lost focus) would otherwise hang
+ * the agent turn forever, and since turns are queued behind the active one, every
+ * later turn wedges too. This is IDLE time, reset by each streamed update, so a
+ * legitimately slow-but-progressing tool is never cut off — only true silence trips it.
+ */
+export const HOST_TOOL_IDLE_TIMEOUT_MS = 60_000;
+
 export class RpcHostToolBridge {
 	#output: RpcHostToolOutput;
 	#definitions = new Map<string, RpcHostToolDefinition>();
 	#pendingCalls = new Map<string, PendingHostToolCall>();
+	#idleTimeoutMs: number;
 
-	constructor(output: RpcHostToolOutput) {
+	constructor(output: RpcHostToolOutput, opts?: { idleTimeoutMs?: number }) {
 		this.#output = output;
+		this.#idleTimeoutMs = opts?.idleTimeoutMs ?? HOST_TOOL_IDLE_TIMEOUT_MS;
 	}
 
 	getToolNames(): string[] {
@@ -141,7 +153,23 @@ export class RpcHostToolBridge {
 		const { promise, resolve, reject } = Promise.withResolvers<AgentToolResult<unknown>>();
 		let settled = false;
 
+		// ---- idle timer (reset by updates; fires → cancel + reject) ----
+		let idleTimer: ReturnType<typeof setTimeout> | undefined;
+		const clearIdle = (): void => {
+			if (idleTimer !== undefined) {
+				clearTimeout(idleTimer);
+				idleTimer = undefined;
+			}
+		};
+		const armIdle = (): void => {
+			clearIdle();
+			idleTimer = setTimeout(onIdleTimeout, this.#idleTimeoutMs);
+			// Don't keep the process alive just for this backstop.
+			if (typeof idleTimer === "object" && "unref" in idleTimer) idleTimer.unref();
+		};
+
 		const cleanup = () => {
+			clearIdle();
 			signal?.removeEventListener("abort", onAbort);
 			this.#pendingCalls.delete(id);
 		};
@@ -158,6 +186,23 @@ export class RpcHostToolBridge {
 			reject(new Error(`Host tool "${definition.name}" was aborted`));
 		};
 
+		const onIdleTimeout = () => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			this.#output({
+				type: "host_tool_cancel",
+				id: Snowflake.next() as string,
+				targetId: id,
+			});
+			reject(
+				new Error(
+					`Host tool "${definition.name}" did not respond within ${this.#idleTimeoutMs / 1000}s ` +
+						"(the host may be unresponsive — a suspended Office WebView loses its connection)",
+				),
+			);
+		};
+
 		signal?.addEventListener("abort", onAbort, { once: true });
 		this.#pendingCalls.set(id, {
 			resolve: result => {
@@ -172,7 +217,11 @@ export class RpcHostToolBridge {
 				cleanup();
 				reject(error);
 			},
-			onUpdate,
+			onUpdate: partial => {
+				// A streamed update proves the host is alive — reset the idle clock.
+				armIdle();
+				onUpdate?.(partial);
+			},
 		});
 
 		this.#output({
@@ -182,6 +231,9 @@ export class RpcHostToolBridge {
 			toolName: definition.name,
 			arguments: args,
 		});
+
+		// Start the idle clock AFTER sending the call.
+		armIdle();
 
 		return promise;
 	}

--- a/packages/coding-agent/test/rpc-host-tools.test.ts
+++ b/packages/coding-agent/test/rpc-host-tools.test.ts
@@ -234,3 +234,69 @@ function handle(frame) {
 		}
 	});
 });
+
+describe("RpcHostToolBridge idle timeout (#2284)", () => {
+	const DEF = {
+		name: "test_tool",
+		label: "Test",
+		description: "A test tool",
+		parameters: { type: "object", properties: {}, additionalProperties: false },
+	};
+
+	it("rejects + sends host_tool_cancel when the host goes silent past the idle window", async () => {
+		const frames: Array<RpcHostToolCallRequest | RpcHostToolCancelRequest> = [];
+		const bridge = new RpcHostToolBridge(frame => frames.push(frame), { idleTimeoutMs: 50 });
+		const [tool] = bridge.setTools([DEF]);
+
+		const execution = tool.execute("t1", {});
+		// No result ever arrives → the idle timer fires.
+		await expect(execution).rejects.toThrow(/did not respond within/);
+		expect(frames.some(f => f.type === "host_tool_cancel")).toBe(true);
+	});
+
+	it("an update resets the idle clock — a slow but progressing tool completes without timeout", async () => {
+		const frames: Array<RpcHostToolCallRequest | RpcHostToolCancelRequest> = [];
+		const bridge = new RpcHostToolBridge(frame => frames.push(frame), { idleTimeoutMs: 300 });
+		const [tool] = bridge.setTools([DEF]);
+
+		const execution = tool.execute("t1", {}, undefined, () => {});
+		const req = frames.find((f): f is RpcHostToolCallRequest => f.type === "host_tool_call")!;
+
+		// At ~100ms send an update (resets the 300ms idle → new deadline ~400ms).
+		await new Promise(r => setTimeout(r, 100));
+		bridge.handleUpdate({
+			type: "host_tool_update",
+			id: req.id,
+			partialResult: { content: [{ type: "text", text: "progress" }] },
+		});
+
+		// At ~200ms (well within the 300ms idle window from the update) send the result.
+		await new Promise(r => setTimeout(r, 100));
+		bridge.handleResult({
+			type: "host_tool_result",
+			id: req.id,
+			result: { content: [{ type: "text", text: "done" }] },
+		});
+
+		await expect(execution).resolves.toEqual({ content: [{ type: "text", text: "done" }] });
+		expect(frames.some(f => f.type === "host_tool_cancel")).toBe(false);
+	});
+
+	it("a fast result settles before the idle timer — no cancellation or timeout", async () => {
+		const frames: Array<RpcHostToolCallRequest | RpcHostToolCancelRequest> = [];
+		const bridge = new RpcHostToolBridge(frame => frames.push(frame), { idleTimeoutMs: 50 });
+		const [tool] = bridge.setTools([DEF]);
+
+		const execution = tool.execute("t1", {});
+		const req = frames.find((f): f is RpcHostToolCallRequest => f.type === "host_tool_call")!;
+
+		bridge.handleResult({
+			type: "host_tool_result",
+			id: req.id,
+			result: { content: [{ type: "text", text: "fast" }] },
+		});
+
+		await expect(execution).resolves.toEqual({ content: [{ type: "text", text: "fast" }] });
+		expect(frames.some(f => f.type === "host_tool_cancel")).toBe(false);
+	});
+});


### PR DESCRIPTION
Closes #2284.

## Problem (live, 3× incidents)
The Office pane's WebView suspended when Excel lost focus, stranding a `host_tool_call` with no `host_tool_result`. The engine awaited indefinitely → the turn wedged → every later turn queued behind it → "Thinking…" forever. Only a manual worker restart recovered it.

## Fix
`RpcHostToolBridge.requestExecution` arms an **idle timer** when sending `host_tool_call`. If **no** `host_tool_result` (nor `host_tool_update`) arrives within **`HOST_TOOL_IDLE_TIMEOUT_MS` (60s)**, it sends `host_tool_cancel` and rejects the tool with a clear error → the agent loop continues, the turn ends gracefully, the queue unblocks. **`host_tool_update`** (streaming partial results) **resets** the timer, so a slow-but-progressing tool is never cut off — only true silence trips it.

## Cross-surface note
`RpcHostToolBridge` is shared by the Office bridge, Chrome extension, and stdio RPC. The 60s idle window is conservative for all three (Chrome tools complete in seconds; Office.js reads are fast; the hang case is total silence from a suspended/dead client). The timeout is an injectable constructor option (`idleTimeoutMs`) + a named export (`HOST_TOOL_IDLE_TIMEOUT_MS`) for discoverability and testing.

## Tests
- Unanswered tool → rejects with "did not respond" + `host_tool_cancel` sent.
- Update resets the idle → slow tool completes without timeout.
- Fast result → no timeout, no cancellation.

6 host-tool tests pass; `tsgo` + `biome` clean.

Complements #2281 (client-side New-chat aborts the turn): #2281 is the manual recovery; this is the automatic backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)