### PR TITLE
feat(office-pane): onboarding screen when bridge is unreachable (AppSource first-run)

### DIFF
--- a/packages/chat-ui/src/theme/panel.css.ts
+++ b/packages/chat-ui/src/theme/panel.css.ts
@@ -233,6 +233,13 @@ code { background:var(--code-bg); padding:1px 5px; border-radius:4px; overflow-w
 .gateway-settings-btn { align-self:flex-end; margin:6px 12px 0; background:none; color: var(--cool-gray);
   border:1px solid var(--subtle-gray); border-radius:6px; padding:2px 10px; cursor:pointer; font:inherit; font-size:12px; }
 /* Config-error recovery view (a rejected provider configure — #2134). */
+/* ── Onboarding screen (first-run, no bridge) ─────────────────────────── */
+.onboarding { display:flex; flex-direction:column; align-items:center; gap:12px; padding:24px 16px; text-align:center; }
+.onboarding-title { color: var(--bright-white); font-size:16px; margin:4px 0 0; }
+.onboarding-steps { color: var(--cool-gray); font-size:13px; text-align:left; margin:8px 0; padding-left:20px; }
+.onboarding-steps li { margin:6px 0; }
+.onboarding-steps code { background: var(--code-bg); padding:2px 6px; border-radius:4px; font-size:12px; }
+
 .gateway-config-error { display:flex; flex-direction:column; align-items:flex-start; gap:8px; margin:16px 12px;
   padding:12px 14px; background: var(--deep-charcoal); border:1px solid var(--alert-red); border-radius:8px; }
 .gateway-config-error-title { color: var(--alert-red); font-weight:600; margin:0; }

--- a/packages/office-pane/src/panel/ChatPanel.tsx
+++ b/packages/office-pane/src/panel/ChatPanel.tsx
@@ -281,6 +281,41 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 		);
 	}
 
+	// First-run with no bridge: the pane loaded (cloud-hosted for AppSource) but
+	// can't reach the local xcsh serve. Show a dedicated onboarding screen instead
+	// of a confusing "Connection to the assistant was lost." error.
+	const firstRunBridgeFailure = status === "error" && reason === "bridge-disconnected" && turns.length === 0;
+	if (firstRunBridgeFailure) {
+		return (
+			<>
+				<Header />
+				<main className="onboarding">
+					<F5Logo variant="mark" size={64} />
+					<h2 className="onboarding-title">Install xcsh to get started</h2>
+					<ol className="onboarding-steps">
+						<li>
+							Install: <code>brew install f5-sales-demo/tap/xcsh</code>
+						</li>
+						<li>
+							Start the Office bridge: <code>xcsh office serve</code>
+						</li>
+						<li>Click Retry below to connect.</li>
+					</ol>
+					<button
+						type="button"
+						className="msg-retry"
+						onClick={() => {
+							// Reload the pane to re-trigger the transport connect.
+							window.location.reload();
+						}}
+					>
+						Retry
+					</button>
+				</main>
+			</>
+		);
+	}
+
 	// Chat is gated until provisioning resolves so a turn can't race `configure_ack`.
 	const ready = provisioning === "ready";
 

--- a/packages/office-pane/test/ChatPanel.test.tsx
+++ b/packages/office-pane/test/ChatPanel.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { type ChatRequestMsg, MockTransport } from "../src/core";
+import { type ChatRequestMsg, MockTransport, type Transport } from "../src/core";
 import { ChatPanel } from "../src/panel";
 
 /** Flush the connect→provision→ready microtask chain. */
@@ -330,4 +330,26 @@ test("Search the web: toggling the + menu category rides chat_request.web_search
 	const req = mock.sent.find((m): m is ChatRequestMsg => m.type === "chat_request");
 	if (!req) throw new Error("expected chat_request");
 	expect(req.web_search).toBe(true);
+});
+
+test("first-run with no bridge shows an onboarding screen (not a broken error state)", async () => {
+	// A transport whose connect() always rejects = no bridge running.
+	const noBridge: Transport = {
+		state: "idle",
+		connect: () => Promise.reject(new Error("ECONNREFUSED")),
+		send: () => {},
+		onMessage: () => () => {},
+		stop: () => {},
+		dispose: () => {},
+	};
+	const { container } = render(<ChatPanel transport={noBridge} />);
+	const scope = within(container);
+	await settle();
+
+	// The onboarding screen shows install instructions — not the generic "Connection to the assistant was lost."
+	expect(scope.getByText(/install xcsh/i)).toBeDefined();
+	expect(scope.getByText(/xcsh office serve/i)).toBeDefined();
+	expect(scope.getByRole("button", { name: /retry/i })).toBeDefined();
+	// The generic error message should NOT appear on first-run.
+	expect(scope.queryByText(/connection to the assistant was lost/i)).toBeNull();
 });


### PR DESCRIPTION
Closes #2294. Phase 1.3 of the AppSource publishing plan.

## Problem
An AppSource reviewer (or a user who hasn't installed xcsh yet) opening the cloud-hosted pane sees "Connection to the assistant was lost." — a broken error state with no guidance.

## Fix
First-run bridge failure (`status=error`, `reason=bridge-disconnected`, `turns=0`) now renders a **dedicated onboarding screen**: F5 logo, install instructions (`brew install f5-sales-demo/tap/xcsh`), "run `xcsh office serve`" step, and a Retry button that reloads the pane. Mid-session bridge drops (turns > 0) keep the existing behavior.

## Verification
327 office-pane tests green (incl. new first-run-no-bridge test); `tsgo` + `biome` clean; build 157.2KB/256KB. The onboarding screen renders when the transport's `connect()` rejects (no bridge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)