### PR TITLE
fix(utils): canonicalize symlinked path prefix for non-existent targets (sandbox over-block)

### DIFF
--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { evaluateToolCall } from "@f5-sales-demo/xcsh/sandbox/enforce";
-import { SandboxPolicy } from "@f5-sales-demo/xcsh/sandbox/policy";
+import { buildDefaultSandboxPolicy, SandboxPolicy } from "@f5-sales-demo/xcsh/sandbox/policy";
 
 const CWD = "/work/custA";
 
@@ -145,5 +148,59 @@ describe("evaluateToolCall", () => {
 		expect(check("python", { code: "x=1", cwd: "/work/custB" }).block).toBe(true);
 		expect(check("python", { code: "open('notes.md')" }).block).toBe(false);
 		expect(check("python", { cells: [{ code: "open('../custB/x')" }] }).block).toBe(true);
+	});
+});
+
+describe("evaluateToolCall with a symlinked working directory (#2312)", () => {
+	const cleanups: Array<() => void> = [];
+	afterEach(() => {
+		while (cleanups.length) cleanups.pop()?.();
+	});
+
+	// A symlinked cwd (e.g. macOS /tmp -> /private/tmp) must not make the sandbox
+	// falsely block in-tree targets that don't yet exist on disk. Self-made symlink
+	// so the test reproduces on Linux CI too.
+	function symlinkedCwd(): string {
+		const base = fs.realpathSync(os.tmpdir());
+		const real = fs.mkdtempSync(path.join(base, "sbx-real-"));
+		const link = path.join(base, `sbx-link-${path.basename(real)}`);
+		fs.symlinkSync(real, link);
+		cleanups.push(() => {
+			try {
+				fs.unlinkSync(link);
+			} catch {}
+			try {
+				fs.rmSync(real, { recursive: true, force: true });
+			} catch {}
+		});
+		return link;
+	}
+
+	function checkAt(cwd: string, input: Record<string, unknown>) {
+		const policy = buildDefaultSandboxPolicy({ cwd, enabled: true, allowRead: [], allowWrite: [] });
+		return evaluateToolCall({ toolName: "read", input, cwd, policy });
+	}
+
+	it("allows in-tree reads/writes (including not-yet-existing targets) under a symlinked cwd", () => {
+		const cwd = symlinkedCwd();
+		expect(checkAt(cwd, { path: "notes.md" }).block).toBe(false);
+		expect(checkAt(cwd, { path: "new/dir/output.json" }).block).toBe(false);
+		// the original reported symptom: an internal-URL pseudo-path resolves under cwd and
+		// must not be treated as an out-of-tree filesystem escape.
+		expect(checkAt(cwd, { path: "xcsh://changes" }).block).toBe(false);
+		expect(
+			evaluateToolCall({
+				toolName: "write",
+				input: { path: "brand-new.ts" },
+				cwd,
+				policy: buildDefaultSandboxPolicy({ cwd, enabled: true, allowRead: [], allowWrite: [] }),
+			}).block,
+		).toBe(false);
+	});
+
+	it("still blocks genuinely out-of-tree paths from a symlinked cwd", () => {
+		const cwd = symlinkedCwd();
+		expect(checkAt(cwd, { path: "/etc/passwd" }).block).toBe(true);
+		expect(checkAt(cwd, { path: "../elsewhere/secret.json" }).block).toBe(true);
 	});
 });

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -52,7 +52,28 @@ export function resolveEquivalentPath(inputPath: string): string {
 	try {
 		return fs.realpathSync(resolvedPath);
 	} catch {
-		return resolvedPath;
+		// The full path does not exist on disk, so realpath can't resolve it. Canonicalize
+		// the deepest existing ancestor (resolving any symlinked prefix — e.g. macOS
+		// /tmp -> /private/tmp) and re-append the missing remainder, so comparisons stay
+		// symlink-consistent whether or not the leaf exists. Without this, a boundary root
+		// that exists gets canonicalized while a not-yet-created target under a symlinked
+		// cwd does not, and pathIsWithin() falsely reports it out-of-tree (issue #2312).
+		return canonicalizeExistingAncestor(resolvedPath);
+	}
+}
+
+/** realpath the deepest existing ancestor of an absolute path, re-appending the missing tail. */
+function canonicalizeExistingAncestor(resolvedPath: string): string {
+	let ancestor = resolvedPath;
+	while (true) {
+		const parent = path.dirname(ancestor);
+		if (parent === ancestor) return resolvedPath; // reached the root with nothing resolvable
+		try {
+			const realParent = fs.realpathSync(parent);
+			return path.join(realParent, path.relative(parent, resolvedPath));
+		} catch {
+			ancestor = parent;
+		}
 	}
 }
 

--- a/packages/utils/test/path-within-symlink.test.ts
+++ b/packages/utils/test/path-within-symlink.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathIsWithin, resolveEquivalentPath } from "../src/dirs";
+
+/**
+ * Regression: when the working directory is a symlink (e.g. macOS /tmp -> /private/tmp,
+ * or a symlinked project dir), the sandbox boundary falsely rejected any target that
+ * does not yet exist on disk. `pathIsWithin` canonicalized the boundary root (it exists)
+ * but not a non-existent candidate, so the symlinked prefix diverged. See issue #2312.
+ *
+ * Self-contained: builds its own symlink so it reproduces on Linux CI, not just macOS.
+ */
+describe("pathIsWithin with a symlinked root and non-existent leaves (#2312)", () => {
+	const cleanups: Array<() => void> = [];
+	afterEach(() => {
+		while (cleanups.length) cleanups.pop()?.();
+	});
+
+	function makeSymlinkedDir(): { real: string; link: string } {
+		const base = fs.realpathSync(os.tmpdir());
+		const real = fs.mkdtempSync(path.join(base, "sbx-real-"));
+		const link = path.join(base, `sbx-link-${path.basename(real)}`);
+		fs.symlinkSync(real, link);
+		cleanups.push(() => {
+			try {
+				fs.unlinkSync(link);
+			} catch {}
+			try {
+				fs.rmSync(real, { recursive: true, force: true });
+			} catch {}
+		});
+		return { real, link };
+	}
+
+	it("treats a not-yet-existing file under the symlinked cwd as within the boundary", () => {
+		const { link } = makeSymlinkedDir();
+		expect(pathIsWithin(link, path.join(link, "new-file.md"))).toBe(true);
+		expect(pathIsWithin(link, path.join(link, "sub", "deep", "missing.txt"))).toBe(true);
+	});
+
+	it("still rejects a sibling path outside the symlinked cwd (no over-broadening)", () => {
+		const { link, real } = makeSymlinkedDir();
+		expect(pathIsWithin(link, path.join(path.dirname(real), "other-cust", "secret.json"))).toBe(false);
+	});
+
+	it("resolveEquivalentPath canonicalizes the deepest existing ancestor of a missing path", () => {
+		const { link, real } = makeSymlinkedDir();
+		expect(resolveEquivalentPath(path.join(link, "missing.txt"))).toBe(
+			path.join(fs.realpathSync(real), "missing.txt"),
+		);
+		expect(resolveEquivalentPath(path.join(link, "a", "b", "c.txt"))).toBe(
+			path.join(fs.realpathSync(real), "a", "b", "c.txt"),
+		);
+	});
+});


### PR DESCRIPTION
## What

Fixes a filesystem-sandbox bug: when the session working directory is a **symlink** (e.g. macOS `/tmp` → `/private/tmp`, or a symlinked project dir), the sandbox falsely blocked in-tree targets that don't yet exist on disk — new files being written, and internal-URL pseudo-paths like `xcsh://changes` (which resolve to `/tmp/xcsh:/changes`).

`packages/utils/src/dirs.ts` `resolveEquivalentPath()` now canonicalizes the **deepest existing ancestor** of a non-existent path and re-appends the missing remainder, so `normalizePathForComparison`/`pathIsWithin` stay symlink-consistent whether or not the leaf exists. (Pattern mirrors `realpathAllowingMissing()` in `plugin-resolve.ts`.)

## Why

`resolveEquivalentPath` only `realpathSync`'d a path when the **full** path existed. So the boundary root (`/tmp`, exists → `/private/tmp`) got canonicalized but a non-existent candidate (`/tmp/newfile`) did not, and `path.relative("/private/tmp", "/tmp/newfile")` → `../../tmp/newfile` → "outside boundary". From a symlinked cwd, **every** non-existent target was blocked. Fails **closed** (over-restrictive) — a usability/correctness bug, not a security hole. Closes #2312.

Discovered while UAT-ing #2306 from `/tmp`: the "sandbox blocks `xcsh://changes`" symptom was this symlink bug, not internal-URL handling (which works correctly from a normal cwd).

## Testing

- **TDD**, red→green. `packages/utils/test/path-within-symlink.test.ts`: creates its **own** symlink (portable — runs on Linux CI, not `/tmp`-dependent) and asserts `pathIsWithin(link, link/missing)` is `true`, `resolveEquivalentPath` canonicalizes the existing ancestor, and a sibling stays out-of-tree.
- `sandbox-enforce.test.ts`: integration test — under a symlinked cwd, in-tree reads/writes (including not-yet-existing targets and `xcsh://changes`) are allowed, while `/etc/passwd` and `../elsewhere` remain blocked.
- Regression: sandbox-policy/isolation/guard + pi-utils dirs/context/shell-pwd suites — **58 pass / 0 fail**. `tsgo` (utils + coding-agent) clean; `biome` clean.

## Non-goals

- No internal-URL scheme exemption in the sandbox (the original mistaken hypothesis) — unnecessary; `read` already routes internal URLs to the in-memory router, and the symlink fix removes the false block at its root.
- No change to the sandbox policy model or deny-list.
