### PR TITLE
feat(office): "+" menu Skills submenu (enumerate + invoke skills) [Phase 2]

### DIFF
--- a/packages/chat-ui/src/components/Composer.tsx
+++ b/packages/chat-ui/src/components/Composer.tsx
@@ -24,11 +24,12 @@ import {
 	useState,
 } from "react";
 import { type Attachment, serializeAttachments } from "../attachments/model";
-import type { AttachCategory, InteractionMode, ModelOption, SlashCommand, ToolItem } from "../types";
+import type { AttachCategory, InteractionMode, ModelOption, SkillMenuItem, SlashCommand, ToolItem } from "../types";
 import { AttachMenu } from "./AttachMenu";
 import { PlusIcon, SendIcon, StopIcon } from "./icons";
 import { ModelSelector } from "./ModelSelector";
 import { ModeToggle } from "./ModeToggle";
+import { SkillsMenu } from "./SkillsMenu";
 import { SlashCommandMenu } from "./SlashCommandMenu";
 import { StatusBar } from "./StatusBar";
 import { ToolsPickerMenu } from "./ToolsPickerMenu";
@@ -79,6 +80,14 @@ export interface ComposerProps {
 	 */
 	tools?: ToolItem[];
 	onToolsConfirm?: (names: string[]) => void;
+	/**
+	 * Skills submenu. When `skills` + `onSkillSelect` are provided AND
+	 * `attachCategories` includes an id `"skills"`, picking that category opens a
+	 * single-select popup of the engine's loaded skills; picking one fires
+	 * `onSkillSelect(name)` (the host prefills `/name`).
+	 */
+	skills?: SkillMenuItem[];
+	onSkillSelect?: (name: string) => void;
 	/** Slash-command menu — a "/" button (rendered only when both are provided). */
 	slashCommands?: SlashCommand[];
 	onSlashSelect?: (command: string) => void;
@@ -135,6 +144,8 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 		onRemoveAttachment,
 		tools,
 		onToolsConfirm,
+		skills,
+		onSkillSelect,
 		slashCommands,
 		onSlashSelect,
 		thinkingLevels,
@@ -148,20 +159,27 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 	const editorRef = useRef<HTMLDivElement>(null);
 	const [text, setText] = useState("");
 	const [showToolsPicker, setShowToolsPicker] = useState(false);
+	const [showSkillsPicker, setShowSkillsPicker] = useState(false);
 	const hasAttachments = (attachments?.length ?? 0) > 0;
 	const canPickTools = tools != null && onToolsConfirm != null;
+	const canPickSkills = skills != null && onSkillSelect != null;
 
 	// AttachMenu category pick: the "tools" category opens the multi-select picker
-	// (when tools are provided); every other category round-trips to the host.
+	// and "skills" opens the single-select Skills submenu (when the host provides
+	// them); every other category round-trips to the host.
 	const handleCategory = useCallback(
 		(id: string) => {
 			if (id === "tools" && canPickTools) {
 				setShowToolsPicker(true);
 				return;
 			}
+			if (id === "skills" && canPickSkills) {
+				setShowSkillsPicker(true);
+				return;
+			}
 			onRequestAttachment?.(id);
 		},
-		[canPickTools, onRequestAttachment],
+		[canPickTools, canPickSkills, onRequestAttachment],
 	);
 
 	const submit = useCallback(() => {
@@ -266,6 +284,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 								onConfirm={onToolsConfirm}
 								onClose={() => setShowToolsPicker(false)}
 							/>
+						</div>
+					)}
+					{showSkillsPicker && skills && onSkillSelect && (
+						<div style={{ position: "absolute", bottom: "100%", left: 0, marginBottom: 4, zIndex: 10 }}>
+							<SkillsMenu skills={skills} onSelect={onSkillSelect} onClose={() => setShowSkillsPicker(false)} />
 						</div>
 					)}
 					{attachCategories ? (

--- a/packages/chat-ui/src/components/SkillsMenu.tsx
+++ b/packages/chat-ui/src/components/SkillsMenu.tsx
@@ -1,0 +1,40 @@
+/**
+ * Single-select popover for the composer's "skills" attach category — the Skills
+ * submenu (Claude-for-Office parity). Lists the host-provided {@link SkillMenuItem}s
+ * (the engine's loaded skills); picking one fires `onSelect(name)` and closes.
+ * Rendered by the {@link Composer} when the `skills` category is picked (controlled
+ * open state, mirroring {@link ToolsPickerMenu}); `onClose` dismisses.
+ */
+import type { SkillMenuItem } from "../types";
+
+export interface SkillsMenuProps {
+	skills: SkillMenuItem[];
+	onSelect: (name: string) => void;
+	onClose: () => void;
+}
+
+export function SkillsMenu({ skills, onSelect, onClose }: SkillsMenuProps) {
+	return (
+		<div className="menu menu-up menu-left skills-menu" role="menu">
+			{skills.length === 0 ? (
+				<div className="menu-header">No skills available</div>
+			) : (
+				skills.map(skill => (
+					<button
+						key={skill.name}
+						type="button"
+						role="menuitem"
+						className="menu-item"
+						onClick={() => {
+							onSelect(skill.name);
+							onClose();
+						}}
+					>
+						<span className="menu-item-command">/{skill.name}</span>
+						{skill.description && <span className="menu-item-desc">{skill.description}</span>}
+					</button>
+				))
+			)}
+		</div>
+	);
+}

--- a/packages/chat-ui/src/index.ts
+++ b/packages/chat-ui/src/index.ts
@@ -48,6 +48,7 @@ export {
 	type UserMessageProps,
 } from "./components/messages";
 export { ReferenceChips, type ReferenceChipsProps } from "./components/ReferenceChips";
+export { SkillsMenu, type SkillsMenuProps } from "./components/SkillsMenu";
 export { SlashCommandMenu, type SlashCommandMenuProps } from "./components/SlashCommandMenu";
 export { StatusBar, type StatusBarProps } from "./components/StatusBar";
 export { ThinkingBlock, type ThinkingBlockProps } from "./components/ThinkingBlock";
@@ -93,6 +94,7 @@ export type {
 	MenuItem,
 	ModelOption,
 	ReactNode,
+	SkillMenuItem,
 	SkillPill,
 	SlashCommand,
 	ToolItem,

--- a/packages/chat-ui/src/types.ts
+++ b/packages/chat-ui/src/types.ts
@@ -102,6 +102,16 @@ export interface ToolItem {
 	description?: string;
 }
 
+/**
+ * A skill shown in the composer's Skills submenu (opened by the `skills` attach
+ * category). The host feeds the list (from the engine's loaded skills); picking
+ * one reports its `name` so the host can invoke it (e.g. prefill `/name`).
+ */
+export interface SkillMenuItem {
+	name: string;
+	description?: string;
+}
+
 /** A rich assistant content block (text / tool_use / thinking). */
 export type ContentBlock =
 	| { type: "text"; text: string }

--- a/packages/chat-ui/test/SkillsMenu.test.tsx
+++ b/packages/chat-ui/test/SkillsMenu.test.tsx
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { SkillsMenu } from "../src/components/SkillsMenu";
+import type { SkillMenuItem } from "../src/types";
+
+const SKILLS: SkillMenuItem[] = [
+	{ name: "competitive", description: "F5 XC battlecards" },
+	{ name: "roi-calculator", description: "ROI / TCO" },
+];
+
+test("lists each skill as /name with its description", () => {
+	const { container } = render(<SkillsMenu skills={SKILLS} onSelect={() => {}} onClose={() => {}} />);
+	const scope = within(container);
+	expect(scope.getByText("/competitive")).toBeDefined();
+	expect(scope.getByText("F5 XC battlecards")).toBeDefined();
+	expect(scope.getByText("/roi-calculator")).toBeDefined();
+});
+
+test("picking a skill fires onSelect(name) and closes", () => {
+	let picked = "";
+	let closed = false;
+	render(<SkillsMenu skills={SKILLS} onSelect={n => (picked = n)} onClose={() => (closed = true)} />);
+	fireEvent.click(screen.getByRole("menuitem", { name: /competitive/i }));
+	expect(picked).toBe("competitive");
+	expect(closed).toBe(true);
+});
+
+test("shows an empty-safe header when there are no skills", () => {
+	const { container } = render(<SkillsMenu skills={[]} onSelect={() => {}} onClose={() => {}} />);
+	expect(within(container).getByText(/no skills available/i)).toBeDefined();
+});

--- a/packages/chat-ui/test/composer-attachments.test.tsx
+++ b/packages/chat-ui/test/composer-attachments.test.tsx
@@ -120,3 +120,40 @@ test("no attachment UI at all when no attach props are given (office/chrome unaf
 	expect(scope.queryByRole("button", { name: /^attach$/i })).toBeNull();
 	expect(container.querySelector(".attachment-chips")).toBeNull();
 });
+
+test("the 'skills' attach category opens the single-select Skills submenu; picking prefills via onSkillSelect", () => {
+	let picked = "";
+	render(
+		<Composer
+			streaming={false}
+			onSend={() => {}}
+			onStop={() => {}}
+			attachCategories={[{ id: "skills", label: "Skills" }]}
+			onRequestAttachment={() => {}}
+			skills={[{ name: "competitive", description: "F5 XC battlecards" }]}
+			onSkillSelect={n => (picked = n)}
+		/>,
+	);
+	// Open the "+" menu and pick the Skills category.
+	fireEvent.click(screen.getByRole("button", { name: /add context/i }));
+	fireEvent.click(screen.getByRole("menuitem", { name: "Skills" }));
+	// The Skills submenu is now open; pick a skill.
+	fireEvent.click(screen.getByRole("menuitem", { name: /competitive/i }));
+	expect(picked).toBe("competitive");
+});
+
+test("no Skills submenu when skills/onSkillSelect props are absent (office/chrome unaffected)", () => {
+	const { container } = render(
+		<Composer
+			streaming={false}
+			onSend={() => {}}
+			onStop={() => {}}
+			attachCategories={[{ id: "skills", label: "Skills" }]}
+			onRequestAttachment={() => {}}
+		/>,
+	);
+	// Picking the category round-trips to the host instead of opening a submenu.
+	fireEvent.click(screen.getByRole("button", { name: /add context/i }));
+	fireEvent.click(screen.getByRole("menuitem", { name: "Skills" }));
+	expect(container.querySelector(".skills-menu")).toBeNull();
+});

--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -24,11 +24,13 @@ import {
 	isChatRequest,
 	isChatStop,
 	isConfigure,
+	isListSkills,
 	isSetHostTools,
 	type PageContextSnapshot,
 	type SetHostTools,
 	type SetHostToolsAck,
 	type SetHostToolsError,
+	type SkillsList,
 } from "./chat-protocol";
 import { CONSOLE_ROUTES } from "./console-routes.generated";
 import type { BridgeServer } from "./extension-bridge";
@@ -101,6 +103,9 @@ export class ChatHandler {
 			// Provider configuration channel (#2095): swap the LLM provider/model in
 			// session memory at runtime (never persisted), then ack or nack.
 			else if (isConfigure(msg)) this.#handleConfigure(msg as unknown as Configure);
+			// Skills enumeration (#2311): the pane asks for the loaded skills to populate
+			// the composer's Skills submenu.
+			else if (isListSkills(msg)) this.#handleListSkills();
 			else if (isRpcHostToolResult(msg)) this.#hostToolBridge.handleResult(msg as unknown as HostToolResult);
 			else if (isRpcHostToolUpdate(msg)) this.#hostToolBridge.handleUpdate(msg as unknown as HostToolUpdate);
 		});
@@ -375,6 +380,15 @@ export class ChatHandler {
 		const chat = this.#activeChats.get(stop.id);
 		if (!chat) return;
 		this.#session.agent.abort();
+	}
+
+	/** Reply to `list_skills` with the session's live skills (name + description) so
+	 *  the pane can populate the composer's Skills submenu. Pure read — skills are
+	 *  already loaded on the session; the model actions them via the read tool + the
+	 *  system prompt (Phase 2A enabled `read`), so this is enumeration only. */
+	#handleListSkills(): void {
+		const skills = this.#session.skills.map(s => ({ name: s.name, description: s.description }));
+		this.#server.send({ type: "skills", skills } satisfies SkillsList);
 	}
 
 	#sendTerminal(chat: ActiveChat, frame: ChatDone | ChatError): void {

--- a/packages/coding-agent/src/browser/chat-protocol.ts
+++ b/packages/coding-agent/src/browser/chat-protocol.ts
@@ -87,6 +87,24 @@ export interface ChatRequest {
 	images?: ChatImage[];
 }
 
+/** Client → engine: enumerate the session's loaded skills for the composer's
+ *  Skills submenu. Sent once after the pane connects. */
+export interface ListSkills {
+	type: "list_skills";
+}
+
+/** One skill surfaced to the pane's Skills submenu (name + human description). */
+export interface SkillInfo {
+	name: string;
+	description: string;
+}
+
+/** Engine → client: the session's live skills, in load order. */
+export interface SkillsList {
+	type: "skills";
+	skills: SkillInfo[];
+}
+
 export interface ChatStop {
 	type: "chat_stop";
 	id: string;
@@ -264,6 +282,10 @@ export function isChatRequest(msg: Record<string, unknown>): boolean {
 
 export function isChatStop(msg: Record<string, unknown>): boolean {
 	return msg.type === "chat_stop" && hasChatIdPrefix(msg.id);
+}
+
+export function isListSkills(msg: Record<string, unknown>): boolean {
+	return msg.type === "list_skills";
 }
 
 export function isSetHostTools(msg: Record<string, unknown>): boolean {

--- a/packages/coding-agent/src/browser/host-profiles.ts
+++ b/packages/coding-agent/src/browser/host-profiles.ts
@@ -94,6 +94,8 @@ SAFETY — NEVER DO THESE:
 const OFFICE_NATIVE_TOOLS_NOTE = `
 NATIVE TOOLS: Beyond the document host tools, you have xcsh's full local toolset — \`bash\` (run shell commands, including CLIs like \`az\`, \`gh\`, \`terraform\`, \`git\` when installed and authenticated), file tools (\`read\`/\`write\`/\`edit\`), and \`grep\` — plus any skills available in this workspace. Reach for them when the task genuinely needs them (pull live data with a CLI, read a local file the user points you at). Prefer the document host tools for document work. Your file tools and shell are confined to the folder xcsh was launched from.
 
+SKILLS: When a message begins with \`/<skill-name>\` naming one of your available skills, treat it as a request to USE that skill — read its instructions (open \`skill://<skill-name>\`, or its SKILL.md via \`read\`) and follow them, applying any text after the name as the skill's input.
+
 SAFETY:
 - NEVER kill, stop, inspect, or manage the xcsh \`office serve\` process, its bridge ports, or any xcsh process — that bridge IS you; ending it ends the session.
 - NEVER run \`lsof\`/\`fuser\`/\`kill\`/\`pkill\` against the bridge ports or use the shell to manage xcsh itself.`;

--- a/packages/coding-agent/test/chat-handler-list-skills.test.ts
+++ b/packages/coding-agent/test/chat-handler-list-skills.test.ts
@@ -1,0 +1,73 @@
+/**
+ * `list_skills` over the Office bridge → the composer `+` → Skills submenu.
+ *
+ * The handler answers with the session's LIVE skills (name + description) so the
+ * pane can populate the submenu. Skills already work end-to-end via the enabled
+ * `read` tool + system prompt (Phase 2A); this frame is enumeration only.
+ */
+import { expect, test } from "bun:test";
+import { ChatHandler } from "@f5-sales-demo/xcsh/browser/chat-handler";
+import { isListSkills } from "@f5-sales-demo/xcsh/browser/chat-protocol";
+import type { BridgeServer } from "@f5-sales-demo/xcsh/browser/extension-bridge";
+import type { AgentSession } from "@f5-sales-demo/xcsh/session/agent-session";
+
+function harness(skills: Array<{ name: string; description: string }> = []) {
+	const sent: Record<string, unknown>[] = [];
+	let onMsg: (m: Record<string, unknown>) => void = () => {};
+	const server = {
+		send: (p: unknown) => sent.push(p as Record<string, unknown>),
+		onMessage: (cb: (m: Record<string, unknown>) => void) => {
+			onMsg = cb;
+		},
+		onDisconnected: () => {},
+	} as unknown as BridgeServer;
+	const session = {
+		isStreaming: false,
+		// Skills carry more fields in reality (filePath/baseDir/source); the handler
+		// projects only name + description onto the wire.
+		skills: skills.map(s => ({
+			...s,
+			filePath: `/skills/${s.name}/SKILL.md`,
+			baseDir: "/skills",
+			source: "native:project",
+		})),
+		agent: { replaceMessages() {}, abort() {} },
+		subscribe: () => () => {},
+		prompt: async () => {},
+	} as unknown as AgentSession;
+	return { sent, server, session, fire: (m: Record<string, unknown>) => onMsg(m) };
+}
+
+const flush = (ms = 10) => new Promise(r => setTimeout(r, ms));
+
+test("isListSkills guard", () => {
+	expect(isListSkills({ type: "list_skills" })).toBe(true);
+	expect(isListSkills({ type: "chat_request" })).toBe(false);
+	expect(isListSkills({})).toBe(false);
+});
+
+test("list_skills replies with a skills frame projecting name + description from session.skills", async () => {
+	const h = harness([
+		{ name: "competitive", description: "F5 XC competitive battlecards" },
+		{ name: "roi-calculator", description: "ROI / TCO business case" },
+	]);
+	new ChatHandler(h.server, h.session).attach();
+	h.fire({ type: "list_skills" });
+	await flush();
+	const reply = h.sent.find(m => m.type === "skills");
+	expect(reply).toBeDefined();
+	expect(reply?.skills).toEqual([
+		{ name: "competitive", description: "F5 XC competitive battlecards" },
+		{ name: "roi-calculator", description: "ROI / TCO business case" },
+	]);
+});
+
+test("list_skills with no loaded skills replies with an empty list (menu shows empty-safe)", async () => {
+	const h = harness([]);
+	new ChatHandler(h.server, h.session).attach();
+	h.fire({ type: "list_skills" });
+	await flush();
+	const reply = h.sent.find(m => m.type === "skills");
+	expect(reply).toBeDefined();
+	expect(reply?.skills).toEqual([]);
+});

--- a/packages/office-pane/src/core/index.ts
+++ b/packages/office-pane/src/core/index.ts
@@ -33,7 +33,10 @@ export type {
 	HostToolResultMsg,
 	HostToolUpdateMsg,
 	InteractionMode,
+	ListSkillsMsg,
 	SetHostToolsMsg,
+	SkillInfo,
+	SkillsListMsg,
 	TurnState,
 } from "./protocol";
 export {
@@ -47,6 +50,7 @@ export {
 	isChatToolNotice,
 	isConfigureAck,
 	isConfigureError,
+	isSkillsList,
 	reduceChatTurn,
 } from "./protocol";
 // Transport surface

--- a/packages/office-pane/src/core/protocol/index.ts
+++ b/packages/office-pane/src/core/protocol/index.ts
@@ -23,8 +23,11 @@ export type {
 	HostToolResultMsg,
 	HostToolUpdate,
 	HostToolUpdateMsg,
+	ListSkillsMsg,
 	SetHostTools,
 	SetHostToolsMsg,
+	SkillInfo,
+	SkillsListMsg,
 } from "./messages";
 export {
 	isChatDelta,
@@ -36,6 +39,7 @@ export {
 	isConfigureError,
 	isHostToolCall,
 	isHostToolCancel,
+	isSkillsList,
 } from "./messages";
 export type { ChatErrorReason, InteractionMode } from "./reasons";
 export { CHAT_ERROR_REASONS, INTERACTION_MODES } from "./reasons";

--- a/packages/office-pane/src/core/protocol/messages.ts
+++ b/packages/office-pane/src/core/protocol/messages.ts
@@ -36,7 +36,10 @@ import type {
 	HostToolDefinition,
 	HostToolResult,
 	HostToolUpdate,
+	ListSkills,
 	SetHostTools,
+	SkillInfo,
+	SkillsList,
 } from "@f5-sales-demo/xcsh/browser/chat-protocol";
 
 // --- Native wire types, re-exported under office-pane's local names. ---
@@ -63,8 +66,11 @@ export type {
 	HostToolResult as HostToolResultMsg,
 	HostToolUpdate,
 	HostToolUpdate as HostToolUpdateMsg,
+	ListSkills as ListSkillsMsg,
 	SetHostTools,
 	SetHostTools as SetHostToolsMsg,
+	SkillInfo,
+	SkillsList as SkillsListMsg,
 };
 
 // ---------------------------------------------------------------------------
@@ -99,7 +105,8 @@ export type ChatInboundMsg =
 	| HostToolCall
 	| HostToolCancel
 	| ConfigureAck
-	| ConfigureError;
+	| ConfigureError
+	| SkillsList;
 
 // ---------------------------------------------------------------------------
 // Type guards (client direction — no native equivalent)
@@ -149,4 +156,9 @@ export function isConfigureAck(msg: unknown): msg is ConfigureAck {
 /** Inbound guard: xcsh rejected a provider configure. */
 export function isConfigureError(msg: unknown): msg is ConfigureError {
 	return isObj(msg) && msg.type === "configure_error" && typeof msg.error === "string";
+}
+
+/** Inbound guard: xcsh replied to `list_skills` with the loaded skills. */
+export function isSkillsList(msg: unknown): msg is SkillsList {
+	return isObj(msg) && msg.type === "skills" && Array.isArray(msg.skills);
 }

--- a/packages/office-pane/src/core/transport/index.ts
+++ b/packages/office-pane/src/core/transport/index.ts
@@ -10,6 +10,7 @@ import type {
 	ConfigureMsg,
 	HostToolResultMsg,
 	HostToolUpdateMsg,
+	ListSkillsMsg,
 	SetHostToolsMsg,
 } from "../protocol";
 
@@ -25,7 +26,8 @@ export type ChatOutbound =
 	| SetHostToolsMsg
 	| HostToolResultMsg
 	| HostToolUpdateMsg
-	| ConfigureMsg;
+	| ConfigureMsg
+	| ListSkillsMsg;
 
 /**
  * Messages the worker sends to the panel (inbound to the panel). Includes the

--- a/packages/office-pane/src/panel/ChatPanel.tsx
+++ b/packages/office-pane/src/panel/ChatPanel.tsx
@@ -30,10 +30,14 @@ import type { ChatImageMsg, Transport } from "../core";
 import { turnsToMessages } from "./adapt";
 import { useChatSession } from "./useChatSession";
 
-/** The composer `+` menu categories. Today: photos/images (Add files or photos). */
-const ATTACH_CATEGORIES: readonly AttachCategory[] = [
-	{ id: "image", label: "Add files or photos", description: "Attach a photo or image" },
-];
+/** The composer `+` menu photo category (always present). A "Skills" category is
+ *  appended at runtime only when the engine reports loaded skills. */
+const IMAGE_CATEGORY: AttachCategory = {
+	id: "image",
+	label: "Add files or photos",
+	description: "Attach a photo or image",
+};
+const SKILLS_CATEGORY: AttachCategory = { id: "skills", label: "Skills", description: "Run a workspace skill" };
 
 /** Image types the vision model accepts (Anthropic: png/jpeg/gif/webp). */
 const IMAGE_ACCEPT = "image/png,image/jpeg,image/gif,image/webp";
@@ -129,10 +133,8 @@ const PROVISIONING_PLACEHOLDER: Record<string, string> = {
 };
 
 export function ChatPanel({ transport, provision, onConnected, onReconfigure, onProviderConfigError }: ChatPanelProps) {
-	const { turns, send, stop, retry, newChat, status, reason, error, provisioning, provisionError } = useChatSession(
-		transport,
-		{ provision, onConnected },
-	);
+	const { turns, send, stop, retry, newChat, status, reason, error, provisioning, provisionError, skills } =
+		useChatSession(transport, { provision, onConnected });
 	const composerRef = useRef<ComposerHandle>(null);
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	// Photo/image attachments staged for the next send. The host owns this state and
@@ -142,10 +144,23 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 	const messages = useMemo(() => turnsToMessages({ turns, status, reason, error }), [turns, status, reason, error]);
 	const streaming = status === "streaming";
 
+	// The "+" categories: photos always; Skills only when the engine reports skills.
+	const attachCategories = useMemo(
+		() => (skills.length > 0 ? [IMAGE_CATEGORY, SKILLS_CATEGORY] : [IMAGE_CATEGORY]),
+		[skills.length],
+	);
+
 	// `+` category pick: "image" opens the hidden file input; the browser file picker
-	// is the only way to attach a local file from an Office task-pane WebView.
+	// is the only way to attach a local file from an Office task-pane WebView. ("skills"
+	// is handled inside the Composer, which opens the Skills submenu.)
 	const handleRequestAttachment = useCallback((categoryId: string) => {
 		if (categoryId === "image") fileInputRef.current?.click();
+	}, []);
+
+	// Picking a skill prefills the composer with `/name ` (Claude idiom) for the user
+	// to add input and send; the engine treats a leading `/skill` as a skill invocation.
+	const handleSkillSelect = useCallback((name: string) => {
+		composerRef.current?.setText(`/${name} `);
 	}, []);
 
 	const handleFiles = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -250,10 +265,12 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 				placeholder={ready ? undefined : PROVISIONING_PLACEHOLDER[provisioning]}
 				onSend={handleSend}
 				onStop={stop}
-				attachCategories={[...ATTACH_CATEGORIES]}
+				attachCategories={attachCategories}
 				attachments={attachments}
 				onRequestAttachment={handleRequestAttachment}
 				onRemoveAttachment={handleRemoveAttachment}
+				skills={skills}
+				onSkillSelect={handleSkillSelect}
 			/>
 		</>
 	);

--- a/packages/office-pane/src/panel/useChatSession.ts
+++ b/packages/office-pane/src/panel/useChatSession.ts
@@ -12,7 +12,9 @@ import {
 	type ChatImageMsg,
 	type InteractionMode,
 	initTurn,
+	isSkillsList,
 	reduceChatTurn,
+	type SkillInfo,
 	type Transport,
 	type TurnState,
 } from "../core";
@@ -94,6 +96,9 @@ export interface ChatSessionResult {
 	/** Set when provisioning is 'error' (a rejected provider `configure`); the
 	 *  panel renders it as a non-silent, recoverable error rather than proceeding. */
 	provisionError?: string;
+	/** The engine's loaded skills, requested on connect — powers the composer's
+	 *  Skills submenu. Empty until the `skills` reply arrives (or if none load). */
+	skills: SkillInfo[];
 }
 
 // ---------------------------------------------------------------------------
@@ -106,6 +111,7 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 	const [connectErr, setConnectErr] = useState<{ reason: ChatErrorReason; message: string } | null>(null);
 	const [provisioning, setProvisioning] = useState<Provisioning>("connecting");
 	const [provisionError, setProvisionError] = useState<string | undefined>(undefined);
+	const [skills, setSkills] = useState<SkillInfo[]>([]);
 	const counterRef = useRef(0);
 	const activeTurnIdRef = useRef<string | null>(null);
 	const lastUserTextRef = useRef<string>("");
@@ -146,6 +152,13 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 				// Provisioned → enable chat, then advertise host tools (needs an open socket).
 				setProvisioning("ready");
 				hooksRef.current?.onConnected?.();
+				// Ask the engine for its loaded skills to populate the composer's Skills
+				// submenu. Best-effort: a failure just leaves the submenu empty.
+				try {
+					transport.send({ type: "list_skills" });
+				} catch {
+					/* transport already gone — skip; the submenu stays empty */
+				}
 			})
 			.catch((err: unknown) => {
 				console.error("[useChatSession] transport.connect() failed:", err);
@@ -170,6 +183,9 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 						return turn;
 					}),
 				);
+			} else if (isSkillsList(msg)) {
+				// The engine's loaded skills — cache them for the composer's Skills submenu.
+				setSkills(msg.skills);
 			} else if (msg.type === "chat_tool_notice") {
 				// Live tool activity: fold the notice into its turn's activity list so
 				// the transcript shows "Reading data…" while xcsh works (Claude parity).
@@ -298,5 +314,5 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 		status = "idle";
 	}
 
-	return { turns, send, stop, retry, newChat, status, reason, error, provisioning, provisionError };
+	return { turns, send, stop, retry, newChat, status, reason, error, provisioning, provisionError, skills };
 }

--- a/packages/office-pane/test/ChatPanel.test.tsx
+++ b/packages/office-pane/test/ChatPanel.test.tsx
@@ -239,3 +239,43 @@ test("a photo can be sent with no typed text (images-only turn)", async () => {
 	expect(req.text).toBe("");
 	expect(req.images?.[0]?.mimeType).toBe("image/jpeg");
 });
+
+test("the + menu gains a Skills submenu once the engine reports skills; picking prefills /name", async () => {
+	const mock = new MockTransport();
+	const { container } = render(<ChatPanel transport={mock} />);
+	const scope = within(container);
+	await settle();
+
+	// The pane requested skills on connect; the engine replies with two.
+	await act(async () => {
+		mock.emit({
+			type: "skills",
+			skills: [
+				{ name: "competitive", description: "F5 XC battlecards" },
+				{ name: "roi-calculator", description: "ROI / TCO" },
+			],
+		} as never);
+	});
+
+	// Open the "+" menu → the Skills category is now present.
+	fireEvent.click(scope.getByRole("button", { name: /add context/i }));
+	fireEvent.click(scope.getByRole("menuitem", { name: /^Skills/ }));
+	// The Skills submenu lists the skills; pick one.
+	fireEvent.click(scope.getByRole("menuitem", { name: /competitive/i }));
+
+	// The composer is prefilled with the slash-invocation (NOT sent).
+	const editor = scope.getByRole("textbox", { name: /message input/i });
+	expect(editor.textContent).toBe("/competitive ");
+	expect(mock.sent.filter(m => m.type === "chat_request")).toHaveLength(0);
+});
+
+test("no Skills category when the engine reports no skills", async () => {
+	const mock = new MockTransport();
+	const { container } = render(<ChatPanel transport={mock} />);
+	const scope = within(container);
+	await settle();
+	// No skills reply (or an empty one) → only the photos category in the + menu.
+	fireEvent.click(scope.getByRole("button", { name: /add context/i }));
+	expect(scope.queryByRole("menuitem", { name: /^Skills/ })).toBeNull();
+	expect(scope.getByRole("menuitem", { name: /add files or photos/i })).toBeDefined();
+});

--- a/packages/office-pane/test/useChatSession.test.tsx
+++ b/packages/office-pane/test/useChatSession.test.tsx
@@ -328,3 +328,20 @@ test("send with images places them on the chat_request; a text-only send omits t
 	// A text-only turn stays a clean frame — no empty images array.
 	expect(reqs[1].images).toBeUndefined();
 });
+
+test("requests list_skills on connect and exposes the skills reply", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	// Let connect → provision (none) → ready run, which sends list_skills.
+	await act(async () => {
+		await new Promise(r => setTimeout(r, 0));
+	});
+	expect(mock.sent.some(m => m.type === "list_skills")).toBe(true);
+	expect(result.current.skills).toEqual([]);
+
+	// The engine replies with its loaded skills → they surface on the hook.
+	await act(async () => {
+		mock.emit({ type: "skills", skills: [{ name: "competitive", description: "battlecards" }] } as never);
+	});
+	expect(result.current.skills).toEqual([{ name: "competitive", description: "battlecards" }]);
+});


### PR DESCRIPTION
## Summary

Adds the Claude-for-Office-style **Skills submenu** to the composer `+` menu. Because Phase 2A (#2314) enabled the `read` tool, skills already work end-to-end via the normal system-prompt + `read` mechanism — so this PR is the **discovery UX** plus a thin enumeration frame, not a bespoke dispatch path.

## What changed

- **coding-agent**: `list_skills` / `skills` wire frames + `SkillInfo` (`chat-protocol.ts`), `isListSkills` guard, and `ChatHandler.#handleListSkills` replying with the session's **live** `skills` (name + description) — a pure read. `host-profiles.ts` gains a SKILLS note so a message beginning with `/<skill>` reliably means "use that skill (read its SKILL.md and follow it)".
- **chat-ui**: net-new `SkillsMenu` (single-select popover; reuses `.menu` CSS + the controlled-open pattern of `ToolsPickerMenu`). `Composer` gains optional `skills` + `onSkillSelect`, opened from a `"skills"` attach category. Fully additive — Chrome/VS Code render nothing without the props (parity tests included).
- **office-pane**: the frames flow through the transport unions + an `isSkillsList` guard; `useChatSession` sends `list_skills` on connect and exposes `skills`; `ChatPanel` appends a "Skills" category **only when the engine reports skills**, and picking one prefills the composer with `/name ` (Claude idiom).

For this repo, the pane will list its real project skills (account-planning, competitive, meeting-prep, roi-calculator, validation-plan, …) whenever `office serve` runs inside the repo.

## Testing

- **TDD** across all three packages: `SkillsMenu.test.tsx`, Composer skills-submenu + parity (`composer-attachments.test.tsx`), `chat-handler-list-skills.test.ts` (enumeration from `session.skills`, empty-safe), `useChatSession` (requests on connect + exposes), `ChatPanel` (category appears with skills + prefill `/name`; absent when none).
- All three package `check` (biome + format-prompts + tsgo) green; office-pane bundle builds at 158.1 KB gzip.
- **Live verification pending** (after release): `+` → Skills → pick e.g. `competitive` → composer prefills `/competitive ` → send → the engine reads the skill and follows it.

Closes #2311

🤖 Generated with [Claude Code](https://claude.com/claude-code)