### PR TITLE
feat(office): "+" menu "Search the web" toggle — server-side web search [Phase 4]

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -193,6 +193,39 @@ export interface AgentOptions {
 
 export interface AgentPromptOptions {
 	toolChoice?: ToolChoice;
+	/**
+	 * Raw provider "server tool" specs to append to THIS turn's request `tools`
+	 * (e.g. Anthropic's `{type:"web_search_20250305", name:"web_search", max_uses:N}`).
+	 * Injected via the provider `onPayload` seam so it touches only this turn — every
+	 * other turn/session is unchanged. Empty/undefined ⇒ no-op.
+	 */
+	serverTools?: Record<string, unknown>[];
+}
+
+/**
+ * Compose the per-turn `onPayload` seam: run the base (extension) hook first, then
+ * append any per-turn server-tool specs to the request `tools`. Returns `undefined`
+ * (a true no-op — the provider skips the hook entirely) when there's neither a base
+ * hook nor server tools, so the default path is byte-identical to before.
+ */
+export function composeOnPayload(
+	base: SimpleStreamOptions["onPayload"] | undefined,
+	serverTools: Record<string, unknown>[] | undefined,
+): SimpleStreamOptions["onPayload"] | undefined {
+	const hasServerTools = Array.isArray(serverTools) && serverTools.length > 0;
+	if (!base && !hasServerTools) return undefined;
+	return async (payload, model) => {
+		let p = payload;
+		if (base) {
+			const replaced = await base(p, model);
+			if (replaced !== undefined) p = replaced;
+		}
+		if (hasServerTools && p && typeof p === "object") {
+			const params = p as { tools?: unknown[] };
+			params.tools = [...(params.tools ?? []), ...serverTools];
+		}
+		return p;
+	};
 }
 
 /** Buffered Cursor tool result with text position at time of call */
@@ -763,7 +796,9 @@ export class Agent {
 				preferWebsockets: this.#preferWebsockets,
 				convertToLlm: this.#convertToLlm,
 				transformContext: this.#transformContext,
-				onPayload: this.#onPayload,
+				// Per-turn: compose the extension hook with any server-tool injection for
+				// THIS prompt (e.g. Office "Search the web"). No-op when neither is present.
+				onPayload: composeOnPayload(this.#onPayload, options?.serverTools),
 				getApiKey: this.getApiKey,
 				getToolContext: this.#getToolContext,
 				syncContextBeforeModelCall: async context => {

--- a/packages/agent/test/compose-on-payload.test.ts
+++ b/packages/agent/test/compose-on-payload.test.ts
@@ -1,0 +1,44 @@
+/**
+ * `composeOnPayload` — the per-turn provider-payload seam that backs server-tool
+ * injection (e.g. the Office "Search the web" toggle). Must be a true no-op on the
+ * default path so the CLI and every other session are unaffected.
+ */
+import { describe, expect, it } from "bun:test";
+import { composeOnPayload } from "@f5-sales-demo/pi-agent-core";
+
+describe("composeOnPayload", () => {
+	it("returns undefined (no-op) when there's neither a base hook nor server tools", () => {
+		expect(composeOnPayload(undefined, undefined)).toBeUndefined();
+		expect(composeOnPayload(undefined, [])).toBeUndefined();
+	});
+
+	it("appends server tools to the request tools when provided", async () => {
+		const fn = composeOnPayload(undefined, [{ type: "web_search_20250305", name: "web_search", max_uses: 5 }]);
+		expect(fn).toBeDefined();
+		const out = (await fn?.({ tools: [{ name: "read" }] })) as { tools: unknown[] };
+		expect(out.tools).toEqual([{ name: "read" }, { type: "web_search_20250305", name: "web_search", max_uses: 5 }]);
+	});
+
+	it("initializes tools when the payload has none", async () => {
+		const fn = composeOnPayload(undefined, [{ type: "web_search_20250305", name: "web_search" }]);
+		const out = (await fn?.({})) as { tools: unknown[] };
+		expect(out.tools).toEqual([{ type: "web_search_20250305", name: "web_search" }]);
+	});
+
+	it("runs the base hook FIRST, then appends server tools to its result", async () => {
+		const base = (p: unknown) => ({ ...(p as object), baseRan: true, tools: [{ name: "fromBase" }] });
+		const fn = composeOnPayload(base, [{ type: "web_search_20250305", name: "web_search" }]);
+		const out = (await fn?.({ tools: [{ name: "orig" }] })) as { tools: unknown[]; baseRan: boolean };
+		expect(out.baseRan).toBe(true);
+		// The base replaced tools; server tools append to the base's result, not the original.
+		expect(out.tools).toEqual([{ name: "fromBase" }, { type: "web_search_20250305", name: "web_search" }]);
+	});
+
+	it("delegates to the base hook unchanged when there are no server tools", async () => {
+		const base = (p: unknown) => ({ ...(p as object), baseRan: true });
+		const fn = composeOnPayload(base, undefined);
+		const out = (await fn?.({ tools: [{ name: "read" }] })) as { tools: unknown[]; baseRan: boolean };
+		expect(out.baseRan).toBe(true);
+		expect(out.tools).toEqual([{ name: "read" }]); // untouched
+	});
+});

--- a/packages/chat-ui/src/components/AttachMenu.tsx
+++ b/packages/chat-ui/src/components/AttachMenu.tsx
@@ -25,21 +25,40 @@ export function AttachMenu({ categories, onSelect, disabled }: AttachMenuProps) 
 					{categories.length === 0 ? (
 						<div className="menu-header">No sources</div>
 					) : (
-						categories.map(cat => (
-							<button
-								key={cat.id}
-								type="button"
-								role="menuitem"
-								className="menu-item"
-								onClick={() => {
-									onSelect(cat.id);
-									setOpen(false);
-								}}
-							>
-								<span>{cat.label}</span>
-								{cat.description && <span className="menu-item-desc">{cat.description}</span>}
-							</button>
-						))
+						categories.map(cat =>
+							cat.toggle ? (
+								// A toggle category: a checkbox menu item that stays open on click so
+								// its on/off flip is visible (e.g. "Search the web").
+								<button
+									key={cat.id}
+									type="button"
+									role="menuitemcheckbox"
+									aria-checked={Boolean(cat.active)}
+									className={`menu-item${cat.active ? " selected" : ""}`}
+									onClick={() => onSelect(cat.id)}
+								>
+									<span>{cat.label}</span>
+									{cat.description && <span className="menu-item-desc">{cat.description}</span>}
+									<span className="menu-item-check" aria-hidden="true">
+										{cat.active ? "✓" : ""}
+									</span>
+								</button>
+							) : (
+								<button
+									key={cat.id}
+									type="button"
+									role="menuitem"
+									className="menu-item"
+									onClick={() => {
+										onSelect(cat.id);
+										setOpen(false);
+									}}
+								>
+									<span>{cat.label}</span>
+									{cat.description && <span className="menu-item-desc">{cat.description}</span>}
+								</button>
+							),
+						)
 					)}
 				</div>
 			)}

--- a/packages/chat-ui/src/types.ts
+++ b/packages/chat-ui/src/types.ts
@@ -78,6 +78,13 @@ export interface AttachCategory {
 	id: string;
 	label: string;
 	description?: string;
+	/**
+	 * Render this category as an on/off TOGGLE (a checkmark shows when `active`).
+	 * Picking a toggle fires `onSelect(id)` but does NOT close the menu, so the flip
+	 * is visible — used for the "Search the web" toggle.
+	 */
+	toggle?: boolean;
+	active?: boolean;
 }
 
 /**

--- a/packages/chat-ui/test/composer-attachments.test.tsx
+++ b/packages/chat-ui/test/composer-attachments.test.tsx
@@ -157,3 +157,17 @@ test("no Skills submenu when skills/onSkillSelect props are absent (office/chrom
 	fireEvent.click(screen.getByRole("menuitem", { name: "Skills" }));
 	expect(container.querySelector(".skills-menu")).toBeNull();
 });
+
+test("a toggle category shows a checkmark when active and keeps the menu OPEN on select", () => {
+	let picked = "";
+	const cats: AttachCategory[] = [{ id: "web_search", label: "Search the web", toggle: true, active: true }];
+	render(<AttachMenu categories={cats} onSelect={id => (picked = id)} />);
+	fireEvent.click(screen.getByRole("button", { name: /add context/i }));
+	// An active toggle is a checked menuitemcheckbox.
+	const item = screen.getByRole("menuitemcheckbox", { name: /search the web/i });
+	expect(item.getAttribute("aria-checked")).toBe("true");
+	fireEvent.click(item);
+	expect(picked).toBe("web_search");
+	// The menu stays open (so the flip is visible) — the item is still there.
+	expect(screen.getByRole("menuitemcheckbox", { name: /search the web/i })).toBeDefined();
+});

--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -186,10 +186,16 @@ export class ChatHandler {
 			data: img.data,
 			mimeType: img.mimeType,
 		}));
+		// "Search the web" toggle → add Anthropic's server-side web-search tool for this
+		// turn only. The gateway executes it and returns cited results; source URLs the
+		// model writes inline flow to the pane's Sources chips via extractReferences.
+		const serverTools = req.web_search
+			? [{ type: "web_search_20250305", name: "web_search", max_uses: 5 }]
+			: undefined;
 
 		try {
 			chat.promptAt = Date.now();
-			await this.#session.prompt(prompt, { expandPromptTemplates: false, synthetic: false, images });
+			await this.#session.prompt(prompt, { expandPromptTemplates: false, synthetic: false, images, serverTools });
 		} catch (err: unknown) {
 			const message = err instanceof Error ? err.message : "unknown error";
 			this.#sendTerminal(chat, { type: "chat_error", id, error: message, reason: classifyChatErrorReason(message) });

--- a/packages/coding-agent/src/browser/chat-protocol.ts
+++ b/packages/coding-agent/src/browser/chat-protocol.ts
@@ -89,6 +89,9 @@ export interface ChatRequest {
 	 *  grants them to the filesystem sandbox for the session and tells the model they
 	 *  are available to read on demand. */
 	contextPaths?: string[];
+	/** When true, the engine adds Anthropic's server-side web-search tool to this
+	 *  turn's request (the "Search the web" composer toggle). */
+	web_search?: boolean;
 }
 
 /** Client → engine: open a native OS file/folder picker on the machine running the

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -277,6 +277,12 @@ export interface PromptOptions {
 	attribution?: MessageAttribution;
 	/** Skip pre-send compaction checks for this prompt (internal use for maintenance flows). */
 	skipCompactionCheck?: boolean;
+	/**
+	 * Raw provider "server tool" specs to inject into THIS turn's request tools, e.g.
+	 * Anthropic's `{type:"web_search_20250305", name:"web_search", max_uses:N}`. Rides
+	 * the provider `onPayload` seam (per-turn, no client-side tool registration).
+	 */
+	serverTools?: Record<string, unknown>[];
 }
 
 /** Result from cycleModel() */
@@ -2632,7 +2638,7 @@ export class AgentSession {
 	async #promptWithMessage(
 		message: AgentMessage,
 		expandedText: string,
-		options?: Pick<PromptOptions, "toolChoice" | "images" | "skipCompactionCheck"> & {
+		options?: Pick<PromptOptions, "toolChoice" | "images" | "skipCompactionCheck" | "serverTools"> & {
 			prependMessages?: AgentMessage[];
 			skipPostPromptRecoveryWait?: boolean;
 		},
@@ -2753,7 +2759,10 @@ export class AgentSession {
 				return;
 			}
 
-			const agentPromptOptions = options?.toolChoice ? { toolChoice: options.toolChoice } : undefined;
+			const agentPromptOptions =
+				options?.toolChoice || options?.serverTools
+					? { toolChoice: options?.toolChoice, serverTools: options?.serverTools }
+					: undefined;
 			await logger.ttftAttr("ttft.agent-loop-total", () =>
 				this.#promptAgentWithIdleRetry(messages, agentPromptOptions),
 			);
@@ -5601,7 +5610,10 @@ export class AgentSession {
 		this.#resolveRetry();
 	}
 
-	async #promptAgentWithIdleRetry(messages: AgentMessage[], options?: { toolChoice?: ToolChoice }): Promise<void> {
+	async #promptAgentWithIdleRetry(
+		messages: AgentMessage[],
+		options?: { toolChoice?: ToolChoice; serverTools?: Record<string, unknown>[] },
+	): Promise<void> {
 		const deadline = Date.now() + 30_000;
 		for (;;) {
 			try {

--- a/packages/coding-agent/test/chat-handler-web-search.test.ts
+++ b/packages/coding-agent/test/chat-handler-web-search.test.ts
@@ -1,0 +1,61 @@
+/**
+ * "Search the web" toggle → `chat_request.web_search` → the handler adds Anthropic's
+ * server-side web_search tool to the turn via `PromptOptions.serverTools`. The gateway
+ * executes it server-side (verified live); this test asserts the wiring.
+ */
+import { expect, test } from "bun:test";
+import { ChatHandler } from "@f5-sales-demo/xcsh/browser/chat-handler";
+import type { BridgeServer } from "@f5-sales-demo/xcsh/browser/extension-bridge";
+import type { AgentSession } from "@f5-sales-demo/xcsh/session/agent-session";
+
+function harness() {
+	const sent: Record<string, unknown>[] = [];
+	let onMsg: (m: Record<string, unknown>) => void = () => {};
+	const promptCalls: Array<{ text: string; options?: Record<string, unknown> }> = [];
+	const server = {
+		send: (p: unknown) => sent.push(p as Record<string, unknown>),
+		onMessage: (cb: (m: Record<string, unknown>) => void) => {
+			onMsg = cb;
+		},
+		onDisconnected: () => {},
+	} as unknown as BridgeServer;
+	const session = {
+		isStreaming: false,
+		skills: [],
+		agent: { replaceMessages() {}, abort() {} },
+		subscribe: () => () => {},
+		prompt: async (text: string, options?: Record<string, unknown>) => {
+			promptCalls.push({ text, options });
+		},
+	} as unknown as AgentSession;
+	return { server, session, promptCalls, fire: (m: Record<string, unknown>) => onMsg(m) };
+}
+
+const flush = (ms = 15) => new Promise(r => setTimeout(r, ms));
+
+test("web_search:true adds the server-side web_search tool to session.prompt serverTools", async () => {
+	const h = harness();
+	new ChatHandler(h.server, h.session).attach();
+	h.fire({
+		type: "chat_request",
+		id: "c-1",
+		text: "latest F5 NGINX version?",
+		context: null,
+		mode: "educational",
+		web_search: true,
+	});
+	await flush();
+	expect(h.promptCalls).toHaveLength(1);
+	const serverTools = h.promptCalls[0].options?.serverTools as Array<Record<string, unknown>> | undefined;
+	expect(serverTools).toBeDefined();
+	expect(serverTools?.[0]).toMatchObject({ type: "web_search_20250305", name: "web_search" });
+});
+
+test("without web_search, no serverTools are attached (default turn is unchanged)", async () => {
+	const h = harness();
+	new ChatHandler(h.server, h.session).attach();
+	h.fire({ type: "chat_request", id: "c-1", text: "hi", context: null, mode: "educational" });
+	await flush();
+	expect(h.promptCalls).toHaveLength(1);
+	expect(h.promptCalls[0].options?.serverTools).toBeUndefined();
+});

--- a/packages/office-pane/src/panel/ChatPanel.tsx
+++ b/packages/office-pane/src/panel/ChatPanel.tsx
@@ -45,6 +45,8 @@ const FOLDER_CATEGORY: AttachCategory = {
 	description: "Pick a local folder as context",
 };
 const SKILLS_CATEGORY: AttachCategory = { id: "skills", label: "Skills", description: "Run a workspace skill" };
+/** A toggle category: enables Anthropic server-side web search for the next turns. */
+const WEB_SEARCH_CATEGORY = { id: "web_search", label: "Search the web", toggle: true } as const;
 
 /** Last path segment, for a compact chip label (handles trailing-slash-free paths). */
 function baseName(p: string): string {
@@ -153,19 +155,19 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 	// Photo/image attachments staged for the next send. The host owns this state and
 	// clears it in onSend (per the shared Composer's host-maps-its-own-state contract).
 	const [attachments, setAttachments] = useState<Attachment[]>([]);
+	// "Search the web" toggle — sticky across turns until the user flips it off.
+	const [webSearch, setWebSearch] = useState(false);
 
 	const messages = useMemo(() => turnsToMessages({ turns, status, reason, error }), [turns, status, reason, error]);
 	const streaming = status === "streaming";
 
-	// The "+" categories: photos + file/folder context always; Skills only when the
-	// engine reports skills.
-	const attachCategories = useMemo(
-		() =>
-			skills.length > 0
-				? [IMAGE_CATEGORY, FILE_CATEGORY, FOLDER_CATEGORY, SKILLS_CATEGORY]
-				: [IMAGE_CATEGORY, FILE_CATEGORY, FOLDER_CATEGORY],
-		[skills.length],
-	);
+	// The "+" categories: photos + file/folder context + the web-search toggle always;
+	// Skills only when the engine reports skills.
+	const attachCategories = useMemo(() => {
+		const search: AttachCategory = { ...WEB_SEARCH_CATEGORY, active: webSearch };
+		const base = [IMAGE_CATEGORY, FILE_CATEGORY, FOLDER_CATEGORY, search];
+		return skills.length > 0 ? [...base, SKILLS_CATEGORY] : base;
+	}, [skills.length, webSearch]);
 
 	// `+` category pick:
 	//  - "image" opens the hidden file input (photos → base64 vision blocks).
@@ -177,6 +179,10 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 		async (categoryId: string) => {
 			if (categoryId === "image") {
 				fileInputRef.current?.click();
+				return;
+			}
+			if (categoryId === "web_search") {
+				setWebSearch(v => !v); // flip the sticky toggle; the menu stays open to show it
 				return;
 			}
 			if (categoryId === "file" || categoryId === "folder") {
@@ -231,13 +237,14 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 			const contextPaths = attachments
 				.filter((a): a is Attachment & { path: string } => a.kind === "file" || a.kind === "folder")
 				.map(a => a.path);
-			const opts: { images?: ChatImageMsg[]; contextPaths?: string[] } = {};
+			const opts: { images?: ChatImageMsg[]; contextPaths?: string[]; webSearch?: boolean } = {};
 			if (images.length > 0) opts.images = images;
 			if (contextPaths.length > 0) opts.contextPaths = contextPaths;
+			if (webSearch) opts.webSearch = true;
 			send(text, Object.keys(opts).length > 0 ? opts : undefined);
 			setAttachments([]);
 		},
-		[attachments, send],
+		[attachments, webSearch, send],
 	);
 
 	// Auto-open the gateway config when a turn fails because the configured provider

--- a/packages/office-pane/src/panel/useChatSession.ts
+++ b/packages/office-pane/src/panel/useChatSession.ts
@@ -77,6 +77,8 @@ export interface SendOptions {
 	images?: ChatImageMsg[];
 	/** Absolute local paths (files/folders) attached as context for this turn. */
 	contextPaths?: string[];
+	/** Enable Anthropic server-side web search for this turn ("Search the web" toggle). */
+	webSearch?: boolean;
 }
 
 export interface ChatSessionResult {
@@ -224,6 +226,7 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 			const mode = opts?.mode ?? DEFAULT_INTERACTION_MODE;
 			const images = opts?.images;
 			const contextPaths = opts?.contextPaths;
+			const webSearch = opts?.webSearch;
 			counterRef.current += 1;
 			const id = `c-${counterRef.current}`;
 			lastUserTextRef.current = text;
@@ -247,6 +250,7 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 					// Only attach optional fields when present so a plain turn stays a clean frame.
 					...(images && images.length > 0 ? { images } : {}),
 					...(contextPaths && contextPaths.length > 0 ? { contextPaths } : {}),
+					...(webSearch ? { web_search: true } : {}),
 				});
 			} catch (err) {
 				// A closed/failed transport throws synchronously (e.g. "Cannot send in

--- a/packages/office-pane/test/ChatPanel.test.tsx
+++ b/packages/office-pane/test/ChatPanel.test.tsx
@@ -310,3 +310,24 @@ test("Add a folder: picks a path via the bridge, shows a chip, and sends context
 	expect(req.text).toBe("summarize this folder");
 	expect(req.contextPaths).toEqual(["/Users/me/ctx"]);
 });
+
+test("Search the web: toggling the + menu category rides chat_request.web_search", async () => {
+	const mock = new MockTransport();
+	const { container } = render(<ChatPanel transport={mock} />);
+	const scope = within(container);
+	await settle();
+
+	// Open the "+" menu and flip the web-search toggle on.
+	fireEvent.click(scope.getByRole("button", { name: /add context/i }));
+	fireEvent.click(scope.getByRole("menuitemcheckbox", { name: /search the web/i }));
+
+	// Type + send.
+	const editor = scope.getByRole("textbox", { name: /message input/i });
+	editor.textContent = "what shipped this week?";
+	fireEvent.input(editor);
+	fireEvent.click(scope.getByRole("button", { name: /send/i }));
+
+	const req = mock.sent.find((m): m is ChatRequestMsg => m.type === "chat_request");
+	if (!req) throw new Error("expected chat_request");
+	expect(req.web_search).toBe(true);
+});

--- a/packages/office-pane/test/useChatSession.test.tsx
+++ b/packages/office-pane/test/useChatSession.test.tsx
@@ -361,3 +361,17 @@ test("pickPath sends a pick_path frame and resolves with the path_picked reply",
 	expect(mock.sent.some(m => m.type === "pick_path" && (m as { mode?: string }).mode === "folder")).toBe(true);
 	expect(resolved.path).toBe("/Users/me/ctx");
 });
+
+test("send({webSearch}) sets web_search on the chat_request; omitted otherwise", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	await act(async () => {
+		result.current.send("news?", { webSearch: true });
+	});
+	await act(async () => {
+		result.current.send("plain");
+	});
+	const reqs = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request");
+	expect(reqs[0].web_search).toBe(true);
+	expect(reqs[1].web_search).toBeUndefined();
+});


### PR DESCRIPTION
## Summary

The final `+`-menu parity item: a **"Search the web"** toggle that uses Anthropic's server-side web search through the F5 gateway. Gateway-verified with a **live streaming + non-streaming probe** (SSE carries `server_tool_use` / `web_search_tool_result` / `citations_delta` with real F5 citations) — so this wires a real capability, not a stub.

## What changed

- **`packages/agent` (shared core)**: new `composeOnPayload(base, serverTools)` composes the existing extension `onPayload` hook with per-turn server-tool injection (appends the raw spec to `params.tools`). **Returns `undefined` — a true no-op — when neither is present**, so the CLI and every other session/turn are byte-identical. `AgentPromptOptions.serverTools` carries it per-turn.
- **`agent-session`**: `PromptOptions.serverTools` threaded through `#promptWithMessage` → `#promptAgentWithIdleRetry` → `agent.prompt` (mirrors the existing `toolChoice` plumbing).
- **`chat-handler`**: `chat_request.web_search` → `serverTools:[{type:"web_search_20250305",name:"web_search",max_uses:5}]`.
- **chat-ui**: `AttachCategory` gains `toggle`/`active`; `AttachMenu` renders a `menuitemcheckbox` (✓ when active) that keeps the menu open on click.
- **office-pane**: `ChatPanel` adds a sticky "Search the web" toggle → `useChatSession.send({webSearch})` → `chat_request.web_search`.

## Citations (v1)

The model writes source URLs inline in its answer (confirmed in the probe), so the existing `extractReferences` turns them into the pane's **Sources chips** for free. Capturing the *structured* `citations_delta` is a documented follow-up (needs new content-block plumbing in `packages/ai`; the current streaming handlers drop unknown block types).

## Blast radius / safety

The only shared-core touch is `composeOnPayload` at the `onPayload` seam, gated to a no-op on the default path. `packages/agent`'s full suite passes unchanged (regression proof). No client-side search tool is registered; nothing persists.

## Testing

- **TDD**: `composeOnPayload` (no-op / append / base-compose-first) in `packages/agent`; `chat-handler` `web_search`→`serverTools`; `AttachMenu` toggle (a11y `menuitemcheckbox` + stays-open); office `send({webSearch})` + `ChatPanel` toggle→`chat_request.web_search`.
- All four touched packages' `check` (biome + format-prompts + tsgo) green; `packages/agent` suite green; pane builds clean.
- **Live verification pending** (after release): `+` → Search the web (✓) → "what shipped in F5 NGINX this week?" → cited answer + Sources chips.

Closes #2323

🤖 Generated with [Claude Code](https://claude.com/claude-code)