### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -20,4 +20,9 @@ jobs:
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]'
     uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@main
-    secrets: inherit
+    # Least privilege: pass ONLY the secret the reusable needs, not every
+    # repository secret (`secrets: inherit`). REPO_SYNC_TOKEN is the PAT that lets
+    # an auto-merge trigger downstream workflows; the reusable falls back to
+    # GITHUB_TOKEN when it is unset, so repos without the PAT still work.
+    secrets:
+      REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,5 +15,6 @@ permissions:
 jobs:
   call:
     if: github.actor == 'dependabot[bot]'
+    # No `secrets:` — least privilege. The reusable uses only the automatic
+    # GITHUB_TOKEN, so passing repository secrets would over-provision it.
     uses: f5-sales-demo/docs-control/.github/workflows/dependabot-auto-merge.yml@main
-    secrets: inherit

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -19,5 +19,7 @@ concurrency:
 
 jobs:
   check:
+    # No `secrets:` — least privilege. The reusable uses only the automatic
+    # GITHUB_TOKEN (always available to a called workflow), so passing repository
+    # secrets would hand over more than it needs.
     uses: f5-sales-demo/docs-control/.github/workflows/require-linked-issue.yml@main
-    secrets: inherit


### PR DESCRIPTION
Closes #2328

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/workflows/require-linked-issue.yml
- .github/workflows/dependabot-auto-merge.yml
- .github/workflows/auto-merge.yml