### PR TITLE
fix(coding-agent): de-flake memories-runtime test (wait on full post-condition)

### DIFF
--- a/packages/coding-agent/test/memories-runtime.test.ts
+++ b/packages/coding-agent/test/memories-runtime.test.ts
@@ -211,6 +211,11 @@ describe("memories runtime", () => {
 		});
 
 		const memoryRoot = getMemoryRoot(fx.agentDir, fx.session.sessionManager.getCwd());
+		// The startup task is fire-and-forget and `refreshBaseSystemPrompt` runs AFTER
+		// phase2 finishes writing these files (memories/index.ts: runPhase1 → runPhase2 →
+		// refreshBaseSystemPrompt). Waiting only on the files and then asserting the
+		// refresh immediately is a race that flakes under CI load, so wait on the FULL
+		// post-condition — files AND the trailing calls — inside one waitFor.
 		await waitFor(async () => {
 			expect((await fs.readFile(path.join(memoryRoot, "MEMORY.md"), "utf8")).trim()).toBe(
 				"# Memory\n\nConsolidated body",
@@ -221,11 +226,9 @@ describe("memories runtime", () => {
 			expect(
 				(await fs.readFile(path.join(memoryRoot, "skills", "deploy-playbook", "SKILL.md"), "utf8")).trim(),
 			).toBe("# Deploy\nUse blue/green.");
+			expect(fx.session.refreshBaseSystemPrompt).toHaveBeenCalledTimes(1);
+			expect(ai.completeSimple).toHaveBeenCalledTimes(2);
 		});
-
-		expect(fx.session.refreshBaseSystemPrompt).toHaveBeenCalledTimes(1);
-		expect(ai.completeSimple).toHaveBeenCalled();
-		expect(ai.completeSimple).toHaveBeenCalledTimes(2);
 	});
 
 	test("phase2 sync prunes stale summaries and preserves raw memory ordering", async () => {


### PR DESCRIPTION
## Summary

`memories-runtime.test.ts` flaked in CI (`refreshBaseSystemPrompt` expected 1, got 0) and **blocked the v19.89.0 release PR** (#2327). It passes in isolation and passed on a green `main` run minutes earlier — a timing race, not a product defect.

## Root cause

`startMemoryStartupTask` is fire-and-forget, and in `memories/index.ts` (~205-207) the order is `runPhase1` → `runPhase2` (writes the files) → **`refreshBaseSystemPrompt`**. The test's `waitFor` waited only on the *files*, then asserted the refresh immediately — a genuine window that widens under CI load.

## Fix

Move the trailing assertions inside the existing `waitFor` so the test waits on the **complete** post-condition (files *and* the trailing calls). The file's other two `waitFor` blocks were already self-contained, so this is the only racy site.

This is the second flake of the same family as #2325 (under-specified waits / absolute-time budgets) — both were silently stalling the release pipeline.

## Testing

- Stable across 3 consecutive local runs (7/7 each).
- Still catches a real regression: if `refreshBaseSystemPrompt` is never called, the `waitFor` times out and the test fails.
- coding-agent `check` (biome + format-prompts + tsgo) green.

Closes #2330

🤖 Generated with [Claude Code](https://claude.com/claude-code)