### PR TITLE
fix(office): tell the pane agent there are no MCP/plugin tools (use bash for CLIs)

### DIFF
--- a/packages/coding-agent/src/browser/host-profiles.ts
+++ b/packages/coding-agent/src/browser/host-profiles.ts
@@ -94,6 +94,8 @@ SAFETY — NEVER DO THESE:
 const OFFICE_NATIVE_TOOLS_NOTE = `
 NATIVE TOOLS: Beyond the document host tools, you have xcsh's full local toolset — \`bash\` (run shell commands, including CLIs like \`az\`, \`gh\`, \`terraform\`, \`git\` when installed and authenticated), file tools (\`read\`/\`write\`/\`edit\`), and \`grep\` — plus any skills available in this workspace. Reach for them when the task genuinely needs them (pull live data with a CLI, read a local file the user points you at). Prefer the document host tools for document work. Your file tools and shell are confined to the folder xcsh was launched from.
 
+This pane runs NO MCP servers and NO plugin-provided tools — the tools listed above (plus the document host tools) are everything you have. Do not look for, read, or report on plugin/MCP manifests: to use a cloud or SCM CLI, invoke it directly with \`bash\` (e.g. \`az account show\`, \`gh repo view\`). The user sees your narration, so don't describe missing plugins as failures — just use the CLI.
+
 SKILLS: When a message begins with \`/<skill-name>\` naming one of your available skills, treat it as a request to USE that skill — read its instructions (open \`skill://<skill-name>\`, or its SKILL.md via \`read\`) and follow them, applying any text after the name as the skill's input.
 
 SAFETY:

--- a/packages/coding-agent/src/internal-urls/terraform-index.generated.ts
+++ b/packages/coding-agent/src/internal-urls/terraform-index.generated.ts
@@ -116,13 +116,14 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			name: "Sites",
 			slug: "sites",
 			description: "AWS/Azure/GCP VPC sites, SecureMesh, VoltStack, and site mesh groups",
-			resource_count: 11,
+			resource_count: 12,
 			resources: [
 				"aws_tgw_site",
 				"aws_vpc_site",
 				"azure_vnet_site",
 				"fleet",
 				"gcp_vpc_site",
+				"registration",
 				"securemesh_site",
 				"securemesh_site_v2",
 				"site",
@@ -166,7 +167,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			name: "Uncategorized",
 			slug: "uncategorized",
 			description: "Resources pending categorization",
-			resource_count: 6,
+			resource_count: 7,
 			resources: [
 				"application_profiles",
 				"authorization_server",
@@ -174,6 +175,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				"mitigated_domain",
 				"protected_application",
 				"protected_domain",
+				"registration_approval",
 			],
 		},
 		{
@@ -198,6 +200,13 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			resources: ["app_setting", "app_type", "discovery", "filter_set"],
 		},
 		{
+			name: "Authentication",
+			slug: "authentication",
+			description: "Authentication methods, cloud credentials, and secret management",
+			resource_count: 4,
+			resources: ["authentication", "cloud_credentials", "secret_management_access", "token"],
+		},
+		{
 			name: "Certificates",
 			slug: "certificates",
 			description: "TLS certificates, certificate chains, CRLs, and trusted CA lists",
@@ -210,13 +219,6 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "VPN and IPSec configuration",
 			resource_count: 4,
 			resources: ["ike1", "ike2", "ike_phase1_profile", "ike_phase2_profile"],
-		},
-		{
-			name: "Authentication",
-			slug: "authentication",
-			description: "Authentication methods, cloud credentials, and secret management",
-			resource_count: 3,
-			resources: ["authentication", "cloud_credentials", "secret_management_access"],
 		},
 		{
 			name: "BIG-IP Integration",
@@ -279,7 +281,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				"Advertise_policy object controls how and where a service represented by a given virtual_host object is advertised to consumers. configuration",
 			required: ["name", "namespace", "address", "protocol", "skip_xff_append"],
 			minimal_config:
-				'resource "xcsh_advertise_policy" "example" {\n  name      = "example-advertise-policy"\n  namespace = "staging"\n\n  address         = "example-value"\n  protocol        = "example-value"\n  skip_xff_append = true\n}',
+				'resource "xcsh_advertise_policy" "example" {\n  name      = "example-advertise-policy"\n  namespace = "staging"\n\n  address         = "example-value"\n  protocol        = "TCP"\n  skip_xff_append = true\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -860,7 +862,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "Endpoint will create the object in the storage backend for namespace metadata.namespace",
 			required: ["name", "namespace", "health_check_port", "port", "protocol"],
 			minimal_config:
-				'resource "xcsh_endpoint" "example" {\n  name      = "example-endpoint"\n  namespace = "staging"\n\n  health_check_port = 1\n  port              = 1\n  protocol          = "example-value"\n}',
+				'resource "xcsh_endpoint" "example" {\n  name      = "example-endpoint"\n  namespace = "staging"\n\n  health_check_port = 1\n  port              = 1\n  protocol          = "TCP"\n}',
 			dependencies: {
 				requires: [],
 			},
@@ -1415,6 +1417,28 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			},
 			import_syntax: "terraform import xcsh_rate_limiter_policy.example namespace/name",
 		},
+		registration: {
+			category: "sites",
+			description: "Vpm creates registration using this message, never used by users. configuration",
+			required: ["name", "namespace", "token"],
+			minimal_config:
+				'resource "xcsh_registration" "example" {\n  name      = "example-registration"\n  namespace = "staging"\n\n  token = "example-value"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_registration.example namespace/name",
+		},
+		registration_approval: {
+			category: "uncategorized",
+			description: "Request for admission approval. configuration",
+			required: ["name", "namespace"],
+			minimal_config:
+				'resource "xcsh_registration_approval" "example" {\n  name      = "example-registration-approval"\n  namespace = "staging"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_registration_approval.example namespace/name",
+		},
 		route: {
 			category: "load-balancing",
 			description:
@@ -1575,6 +1599,17 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				requires: [],
 			},
 			import_syntax: "terraform import xcsh_tenant_configuration.example namespace/name",
+		},
+		token: {
+			category: "authentication",
+			description:
+				"New token. Token object is used to manage site admission. User must generate token before provisioning and pass this token to site during it's registration",
+			required: ["name"],
+			minimal_config: 'resource "xcsh_token" "example" {\n  name      = "example-token"\n  namespace = "system"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_token.example namespace/name",
 		},
 		trusted_ca_list: {
 			category: "certificates",

--- a/packages/coding-agent/test/browser/host-profiles.test.ts
+++ b/packages/coding-agent/test/browser/host-profiles.test.ts
@@ -167,4 +167,19 @@ describe("host profiles", () => {
 		const excel: ClientHost = "excel";
 		expect(hostProfile(excel)).toBe(HOST_PROFILES.excel);
 	});
+	for (const host of ["excel", "powerpoint", "word"] as const) {
+		it(`${host} tells the agent it has native CLI tools and NO MCP/plugins`, () => {
+			const prompt = HOST_PROFILES[host].systemPrompt;
+			// Native tool-calling parity: the agent must know it can shell out.
+			expect(prompt).toContain("bash");
+			expect(prompt).toContain("az");
+			expect(prompt).toContain("gh");
+			// …and that its file tools are sandbox-confined to the launch dir.
+			expect(prompt).toContain("confined to the folder");
+			// No-MCP guidance: prevents a wasted turn hunting plugin manifests and the
+			// scary "plugin manifest failed to load" narration in a live demo.
+			expect(prompt).toContain("NO MCP servers");
+			expect(prompt).toMatch(/plugin\/MCP manifests|plugin manifests/);
+		});
+	}
 });


### PR DESCRIPTION
## Summary

During a live Excel demo the pane's agent narrated **"The plugin manifest failed to load…"** before correctly falling back to `az` via `bash`. That reads like a product error in front of a customer.

**xcsh emits no such string** (verified — it doesn't exist in the codebase). It was the *model* narrating a failed exploratory `read` while hunting for an Azure MCP plugin manifest.

## Root cause

The Office host profiles never state that the pane runs **no MCP servers and no plugin-provided tools** — which it genuinely doesn't (`headless-bridge.ts` creates the session with `enableMCP: false`, `disableExtensionDiscovery: true`). Lacking that context, the agent burns a turn looking for plugins and then reports their absence as a failure.

## Fix

Extend the shared Office `NATIVE TOOLS` note (interpolated into all three document profiles): the listed native tools + document host tools are everything; invoke cloud/SCM CLIs directly with `bash` (`az account show`, `gh repo view`); don't narrate missing plugins as failures.

## Testing

- `host-profiles.test.ts` now asserts each document profile carries the native-CLI guidance (`bash`/`az`/`gh`), the sandbox-confinement note, and the new no-MCP/no-plugin-manifest guidance.
- coding-agent `check` (biome + format-prompts + tsgo) green; `test/browser/` + chat-handler matrix: **356 pass / 0 fail**.
- Live verification (after release): asking for Azure data should go straight to `az` via bash — no plugin detour, no alarming narration.

Closes #2332

🤖 Generated with [Claude Code](https://claude.com/claude-code)