### PR TITLE
fix(models): let the effort ladder express the API's xhigh; add Effort.Max

### DIFF
--- a/packages/agent/src/thinking.ts
+++ b/packages/agent/src/thinking.ts
@@ -13,6 +13,7 @@ export const ThinkingLevel = {
 	Medium: Effort.Medium,
 	High: Effort.High,
 	XHigh: Effort.XHigh,
+	Max: Effort.Max,
 } as const;
 
 export type ThinkingLevel = (typeof ThinkingLevel)[keyof typeof ThinkingLevel];

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -1,21 +1,51 @@
 import { resolveOpenAICompat } from "./providers/openai-completions-compat";
 import type { Api, Model as ApiModel, ThinkingConfig } from "./types";
 
-/** User-facing thinking levels, ordered least to most intensive. */
+/**
+ * User-facing thinking levels, ordered least to most intensive.
+ *
+ * `Minimal` is xcsh-only — no provider accepts it on the wire (Anthropic rejects
+ * it with `output_config.effort: Input should be 'low', 'medium', 'high', 'xhigh'
+ * or 'max'`), so every mapper must translate it down.
+ */
 export const enum Effort {
 	Minimal = "minimal",
 	Low = "low",
 	Medium = "medium",
 	High = "high",
 	XHigh = "xhigh",
+	Max = "max",
 }
 
+/**
+ * Anthropic's `output_config.effort` enum, verbatim. Authority is the API's own
+ * validation error: `Input should be 'low', 'medium', 'high', 'xhigh' or 'max'`.
+ * Deliberately excludes xcsh's `minimal`, which the API rejects.
+ */
+export type AnthropicAdaptiveEffort = "low" | "medium" | "high" | "xhigh" | "max";
+
+/** Effort levels for providers whose wire enum stops at `xhigh` (no `max`). */
+export type EffortThroughXHigh = "minimal" | "low" | "medium" | "high" | "xhigh";
+
+/**
+ * Clamp an effort to a provider whose wire enum has no `max` (OpenAI-compat
+ * reasoning_effort, GitLab Duo, Kimi, Synthetic, …). `requireSupportedEffort`
+ * already keeps `Max` out of those providers at runtime — because their
+ * supported-effort lists exclude it — but the wire types can't prove that, and
+ * clamping is the safe direction if a caller bypasses the range check.
+ */
+export function clampEffortThroughXHigh(effort: Effort): EffortThroughXHigh {
+	return effort === Effort.Max ? Effort.XHigh : effort;
+}
+
+/** Order is load-bearing: `indexOf` drives expandEffortRange/requireSupportedEffort. */
 export const THINKING_EFFORTS: readonly Effort[] = [
 	Effort.Minimal,
 	Effort.Low,
 	Effort.Medium,
 	Effort.High,
 	Effort.XHigh,
+	Effort.Max,
 ];
 
 const DEFAULT_REASONING_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High];
@@ -25,6 +55,18 @@ const DEFAULT_REASONING_EFFORTS_WITH_XHIGH: readonly Effort[] = [
 	Effort.Medium,
 	Effort.High,
 	Effort.XHigh,
+];
+/**
+ * Anthropic 4.6+/5-era range. These models accept the full API enum, including
+ * `xhigh` (Anthropic's recommended setting for coding/agentic work) and `max`.
+ */
+const ANTHROPIC_ADAPTIVE_EFFORTS: readonly Effort[] = [
+	Effort.Minimal,
+	Effort.Low,
+	Effort.Medium,
+	Effort.High,
+	Effort.XHigh,
+	Effort.Max,
 ];
 const GEMINI_3_PRO_EFFORTS: readonly Effort[] = [Effort.Low, Effort.High];
 const GEMINI_3_FLASH_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High];
@@ -250,15 +292,22 @@ export function mapEffortToGoogleThinkingLevel<TApi extends Api>(
 			return "MEDIUM";
 		case Effort.High:
 		case Effort.XHigh:
+		case Effort.Max:
 			return "HIGH";
 	}
 }
 
-/** Maps a normalized thinking effort to Anthropic adaptive effort values. */
+/**
+ * Maps a normalized thinking effort to Anthropic adaptive effort values.
+ *
+ * The API enum is `low | medium | high | xhigh | max` (per its own validation
+ * error). `Minimal` has no wire equivalent and is translated down to `low` —
+ * sending `"minimal"` is a 400.
+ */
 export function mapEffortToAnthropicAdaptiveEffort<TApi extends Api>(
 	model: ApiModel<TApi>,
 	effort: Effort,
-): "low" | "medium" | "high" | "max" {
+): AnthropicAdaptiveEffort {
 	switch (requireSupportedEffort(model, effort)) {
 		case Effort.Minimal:
 		case Effort.Low:
@@ -268,6 +317,8 @@ export function mapEffortToAnthropicAdaptiveEffort<TApi extends Api>(
 		case Effort.High:
 			return "high";
 		case Effort.XHigh:
+			return "xhigh";
+		case Effort.Max:
 			return "max";
 	}
 }
@@ -398,7 +449,15 @@ function inferAnthropicSupportedEfforts<TApi extends Api>(
 		(model.api === "anthropic-messages" || model.api === "bedrock-converse-stream") &&
 		semverGte(parsedModel.version, "4.6")
 	) {
-		return parsedModel.kind === "opus" ? DEFAULT_REASONING_EFFORTS_WITH_XHIGH : DEFAULT_REASONING_EFFORTS;
+		// Opus 4.6+ and Sonnet 5+ accept the extended range. Sonnet 4.6 tops out at
+		// `high` — the reason this can't key on version alone (#2341).
+		const extended = parsedModel.kind === "opus" || semverGte(parsedModel.version, "5.0");
+		if (!extended) return DEFAULT_REASONING_EFFORTS;
+		// `max` is only claimed for the first-party Messages API, where the enum was
+		// verified against the live gateway. Bedrock's effort support is not verified
+		// here, so it keeps the pre-existing `xhigh` ceiling rather than being widened
+		// on an assumption.
+		return model.api === "anthropic-messages" ? ANTHROPIC_ADAPTIVE_EFFORTS : DEFAULT_REASONING_EFFORTS_WITH_XHIGH;
 	}
 	return inferFallbackEfforts(model);
 }

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -2647,7 +2647,7 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max"
 			}
 		},
 		"claude-sonnet-4-0": {
@@ -2800,7 +2800,7 @@
 			"thinking": {
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "max"
 			}
 		}
 	},

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -659,6 +659,7 @@ function buildAdditionalModelRequestFields(
 		medium: 8192,
 		high: 16384,
 		xhigh: 32768,
+		max: 65536,
 	};
 	const budget = options.thinkingBudgets?.[level] ?? defaultBudgets[level];
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -8,7 +8,7 @@ import type {
 	MessageParam,
 } from "@anthropic-ai/sdk/resources/messages";
 import { $env, abortableSleep, isEnoent } from "@f5-sales-demo/pi-utils";
-import { mapEffortToAnthropicAdaptiveEffort } from "../model-thinking";
+import { type AnthropicAdaptiveEffort, mapEffortToAnthropicAdaptiveEffort } from "../model-thinking";
 import { calculateCost } from "../models";
 import { getEnvApiKey, OUTPUT_FALLBACK_BUFFER } from "../stream";
 import type {
@@ -355,7 +355,11 @@ function convertContentBlocks(content: (TextContent | ImageContent)[]):
 	return blocks;
 }
 
-export type AnthropicEffort = "low" | "medium" | "high" | "max";
+/**
+ * Anthropic's `output_config.effort` enum. Single source of truth lives in
+ * model-thinking so the mapper and this raw-passthrough path cannot drift.
+ */
+export type AnthropicEffort = AnthropicAdaptiveEffort;
 
 export interface AnthropicOptions extends StreamOptions {
 	/**
@@ -1422,10 +1426,16 @@ function buildParams(
 		const effort =
 			options.effort ?? (requestedEffort ? mapEffortToAnthropicAdaptiveEffort(model, requestedEffort) : undefined);
 
+		// The pinned @anthropic-ai/sdk (0.78) types `OutputConfig.effort` as
+		// 'low'|'medium'|'high'|'max' — it predates `xhigh`, which the live API
+		// accepts (verified: its 400 enumerates "'low', 'medium', 'high', 'xhigh'
+		// or 'max'"). Cast until the SDK pin is bumped; the wire value is valid.
+		const outputConfigEffort = effort as NonNullable<MessageCreateParamsStreaming["output_config"]>["effort"];
+
 		if (mode === "anthropic-adaptive") {
 			params.thinking = { type: "adaptive" };
 			if (effort) {
-				params.output_config = { effort };
+				params.output_config = { effort: outputConfigEffort };
 			}
 		} else {
 			params.thinking = {
@@ -1433,7 +1443,7 @@ function buildParams(
 				budget_tokens: options.thinkingBudgetTokens || 1024,
 			};
 			if (mode === "anthropic-budget-effort" && effort) {
-				params.output_config = { effort };
+				params.output_config = { effort: outputConfigEffort };
 			}
 		}
 		// Anthropic requires temperature=1 when thinking is enabled; override any

--- a/packages/ai/src/providers/gitlab-duo.ts
+++ b/packages/ai/src/providers/gitlab-duo.ts
@@ -1,3 +1,4 @@
+import { clampEffortThroughXHigh } from "../model-thinking";
 import { ANTHROPIC_THINKING, mapAnthropicToolChoice } from "../stream";
 import type { Api, Context, Model, SimpleStreamOptions } from "../types";
 import { AssistantMessageEventStream } from "../utils/event-stream";
@@ -301,6 +302,7 @@ export function streamGitLabDuo(
 								thinkingBudgetTokens: reasoningEffort
 									? (options.thinkingBudgets?.[reasoningEffort] ?? ANTHROPIC_THINKING[reasoningEffort])
 									: undefined,
+								// Anthropic path — takes the full ladder, no clamp.
 								reasoning: reasoningEffort,
 								toolChoice: mapAnthropicToolChoice(options.toolChoice),
 							},
@@ -331,7 +333,7 @@ export function streamGitLabDuo(
 									sessionId: options.sessionId,
 									providerSessionState: options.providerSessionState,
 									onPayload: options.onPayload,
-									reasoning: reasoningEffort,
+									reasoning: reasoningEffort && clampEffortThroughXHigh(reasoningEffort),
 									toolChoice: options.toolChoice,
 								} satisfies OpenAIResponsesOptions,
 							)
@@ -360,7 +362,7 @@ export function streamGitLabDuo(
 									sessionId: options.sessionId,
 									providerSessionState: options.providerSessionState,
 									onPayload: options.onPayload,
-									reasoning: reasoningEffort,
+									reasoning: reasoningEffort && clampEffortThroughXHigh(reasoningEffort),
 									toolChoice: options.toolChoice,
 								} satisfies OpenAICompletionsOptions,
 							);

--- a/packages/ai/src/providers/kimi.ts
+++ b/packages/ai/src/providers/kimi.ts
@@ -1,3 +1,4 @@
+import { clampEffortThroughXHigh } from "../model-thinking";
 /**
  * Kimi Code provider - wraps OpenAI or Anthropic API based on format setting.
  *
@@ -104,7 +105,7 @@ export function streamKimi(
 					headers: mergedHeaders,
 					sessionId: options?.sessionId,
 					onPayload: options?.onPayload,
-					reasoning: reasoningEffort,
+					reasoning: reasoningEffort && clampEffortThroughXHigh(reasoningEffort),
 				});
 
 				for await (const event of innerStream) {

--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -1,5 +1,5 @@
 import type { Effort } from "../../model-thinking";
-import { requireSupportedEffort } from "../../model-thinking";
+import { clampEffortThroughXHigh, requireSupportedEffort } from "../../model-thinking";
 import type { Api, Model } from "../../types";
 
 export interface ReasoningConfig {
@@ -53,8 +53,12 @@ export interface RequestBody {
 
 function getReasoningConfig(model: Model<Api>, options: CodexRequestOptions): ReasoningConfig {
 	return {
+		// Codex's reasoning effort has no `max`; clamp so the ladder's top level
+		// degrades to `xhigh` instead of emitting a value Codex would reject.
 		effort:
-			options.reasoningEffort === "none" ? "none" : requireSupportedEffort(model, options.reasoningEffort as Effort),
+			options.reasoningEffort === "none"
+				? "none"
+				: clampEffortThroughXHigh(requireSupportedEffort(model, options.reasoningEffort as Effort)),
 		summary: options.reasoningSummary ?? "detailed",
 	};
 }

--- a/packages/ai/src/providers/synthetic.ts
+++ b/packages/ai/src/providers/synthetic.ts
@@ -1,3 +1,4 @@
+import { clampEffortThroughXHigh } from "../model-thinking";
 /**
  * Synthetic provider - wraps OpenAI or Anthropic API based on format setting.
  *
@@ -107,7 +108,7 @@ export function streamSynthetic(
 					headers: mergedHeaders,
 					sessionId: options?.sessionId,
 					onPayload: options?.onPayload,
-					reasoning: reasoningEffort,
+					reasoning: reasoningEffort && clampEffortThroughXHigh(reasoningEffort),
 				});
 
 				for await (const event of innerStream) {

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -5,6 +5,8 @@ import { $env, $pickenv } from "@f5-sales-demo/pi-utils";
 import { getCustomApi } from "./api-registry";
 import type { Effort } from "./model-thinking";
 import {
+	clampEffortThroughXHigh,
+	type EffortThroughXHigh,
 	mapEffortToAnthropicAdaptiveEffort,
 	mapEffortToGoogleThinkingLevel,
 	requireSupportedEffort,
@@ -317,6 +319,7 @@ export const ANTHROPIC_THINKING: Record<Effort, number> = {
 	medium: 8192,
 	high: 16384,
 	xhigh: 32768,
+	max: 65536,
 };
 
 const GOOGLE_THINKING: Record<Effort, number> = {
@@ -325,6 +328,8 @@ const GOOGLE_THINKING: Record<Effort, number> = {
 	medium: 8192,
 	high: 16384,
 	xhigh: 24575,
+	// Google caps the thinking budget here; `max` cannot exceed it.
+	max: 24575,
 };
 
 const BEDROCK_CLAUDE_THINKING: Record<Effort, number> = {
@@ -333,6 +338,8 @@ const BEDROCK_CLAUDE_THINKING: Record<Effort, number> = {
 	medium: 8192,
 	high: 16384,
 	xhigh: 16384,
+	// Bedrock Claude caps the thinking budget here; `max` cannot exceed it.
+	max: 16384,
 };
 
 function resolveBedrockThinkingBudget(
@@ -394,10 +401,12 @@ function mapOpenAiToolChoice(choice?: ToolChoice): OpenAICompletionsOptions["too
 function resolveOpenAiReasoningEffort<TApi extends Api>(
 	model: Model<TApi>,
 	options?: SimpleStreamOptions,
-): Effort | undefined {
+): EffortThroughXHigh | undefined {
 	const reasoning = options?.reasoning;
 	if (!reasoning || !model.reasoning) return undefined;
-	return requireSupportedEffort(model, reasoning);
+	// OpenAI-compat `reasoning_effort` has no `max`; clamp rather than emit a
+	// value the provider would reject.
+	return clampEffortThroughXHigh(requireSupportedEffort(model, reasoning));
 }
 
 const castApi = <TApi extends Api>(api: OptionsForApi<TApi>): OptionsForApi<Api> => api as OptionsForApi<Api>;

--- a/packages/ai/test/effort-ladder.test.ts
+++ b/packages/ai/test/effort-ladder.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+import {
+	Effort,
+	getBundledModel,
+	type Model,
+	mapEffortToAnthropicAdaptiveEffort,
+	mapEffortToGoogleThinkingLevel,
+	THINKING_EFFORTS,
+} from "@f5-sales-demo/pi-ai";
+
+/**
+ * Regression for #2342: xcsh could not express the Anthropic API's `xhigh`
+ * effort — `Effort.XHigh` mapped to the wire value `"max"`, so the ladder
+ * jumped `high` → `max` and skipped the level Anthropic documents as the best
+ * setting for coding/agentic work.
+ *
+ * The API's own validation error is the authority on the enum:
+ *   output_config.effort: Input should be 'low', 'medium', 'high', 'xhigh' or 'max'
+ * Note `minimal` is NOT in it — it is an xcsh-internal level that must always
+ * be translated down before reaching the wire.
+ */
+const API_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
+
+const anthropic = (id: string) => getBundledModel("anthropic", id) as Model<"anthropic-messages">;
+
+describe("Effort ladder", () => {
+	it("is ordered least→most intensive and ends at max", () => {
+		expect(THINKING_EFFORTS).toEqual([
+			Effort.Minimal,
+			Effort.Low,
+			Effort.Medium,
+			Effort.High,
+			Effort.XHigh,
+			Effort.Max,
+		]);
+	});
+});
+
+describe("mapEffortToAnthropicAdaptiveEffort", () => {
+	const model = anthropic("claude-opus-5");
+
+	it("maps XHigh to the API's xhigh (not max)", () => {
+		expect(mapEffortToAnthropicAdaptiveEffort(model, Effort.XHigh)).toBe("xhigh");
+	});
+
+	it("maps Max to the API's max", () => {
+		expect(mapEffortToAnthropicAdaptiveEffort(model, Effort.Max)).toBe("max");
+	});
+
+	it("translates the xcsh-only Minimal level down to low (minimal would 400)", () => {
+		expect(mapEffortToAnthropicAdaptiveEffort(model, Effort.Minimal)).toBe("low");
+	});
+
+	it("only ever emits values in the API's enum", () => {
+		for (const effort of THINKING_EFFORTS) {
+			const wire = mapEffortToAnthropicAdaptiveEffort(model, effort);
+			expect(API_EFFORTS).toContain(wire);
+			expect(wire).not.toBe("minimal");
+		}
+	});
+});
+
+describe("catalog effort ranges", () => {
+	for (const id of ["claude-opus-5", "claude-sonnet-5"]) {
+		it(`${id} reaches max and can express xhigh`, () => {
+			const model = anthropic(id);
+			expect(model.thinking?.maxLevel).toBe(Effort.Max);
+			// The whole point of #2342: xhigh must be reachable, not skipped.
+			expect(mapEffortToAnthropicAdaptiveEffort(model, Effort.XHigh)).toBe("xhigh");
+			expect(mapEffortToAnthropicAdaptiveEffort(model, Effort.Max)).toBe("max");
+		});
+	}
+
+	it("keeps sonnet-4-6 below xhigh (it does not support that level) — #2341", () => {
+		expect(anthropic("claude-sonnet-4-6").thinking?.maxLevel).toBe(Effort.High);
+	});
+});
+
+describe("other providers are unaffected", () => {
+	it("Gemini wire values are unchanged", () => {
+		const gemini = getBundledModel("google", "gemini-3-pro-preview");
+		expect(mapEffortToGoogleThinkingLevel(gemini, Effort.Low)).toBe("LOW");
+		expect(mapEffortToGoogleThinkingLevel(gemini, Effort.High)).toBe("HIGH");
+	});
+});

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -105,14 +105,15 @@ describe("model thinking metadata", () => {
 		expect(opus46.thinking).toEqual({
 			mode: "anthropic-adaptive",
 			minLevel: Effort.Minimal,
-			maxLevel: Effort.XHigh,
+			maxLevel: Effort.Max,
 		});
 		expect(sonnet46.thinking).toEqual({
 			mode: "anthropic-adaptive",
 			minLevel: Effort.Minimal,
 			maxLevel: Effort.High,
 		});
-		expect(mapEffortToAnthropicAdaptiveEffort(opus46, Effort.XHigh)).toBe("max");
+		expect(mapEffortToAnthropicAdaptiveEffort(opus46, Effort.XHigh)).toBe("xhigh");
+		expect(mapEffortToAnthropicAdaptiveEffort(opus46, Effort.Max)).toBe("max");
 		expect(() => mapEffortToAnthropicAdaptiveEffort(sonnet46, Effort.XHigh)).toThrow(/not supported/);
 	});
 });
@@ -234,6 +235,7 @@ describe("generated model policies", () => {
 		expect(models[1]?.thinking).toEqual({
 			mode: "anthropic-adaptive",
 			minLevel: Effort.Minimal,
+			// Bedrock keeps the xhigh ceiling — `max` is claimed only where verified.
 			maxLevel: Effort.XHigh,
 		});
 		expect(models[1]?.cost.cacheRead).toBe(0.5);

--- a/packages/ai/test/opus-5-1m-default.test.ts
+++ b/packages/ai/test/opus-5-1m-default.test.ts
@@ -38,11 +38,11 @@ describe.each([
 		expect(getBundledModel("anthropic", id).betas).toContain(CONTEXT_1M_BETA);
 	});
 
-	it("advertises adaptive thinking up to xhigh", () => {
+	it("advertises adaptive thinking up to max (the top of the API enum)", () => {
 		expect(getBundledModel("anthropic", id).thinking).toMatchObject({
 			mode: "anthropic-adaptive",
 			minLevel: "minimal",
-			maxLevel: "xhigh",
+			maxLevel: "max",
 		});
 	});
 

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -32,7 +32,12 @@ const THINKING_LEVEL_METADATA: Record<ThinkingLevel, ThinkingLevelMetadata> = {
 	[ThinkingLevel.XHigh]: {
 		value: ThinkingLevel.XHigh,
 		label: "xhigh",
-		description: "Maximum reasoning (~32k tokens)",
+		description: "Very deep reasoning (~32k tokens)",
+	},
+	[ThinkingLevel.Max]: {
+		value: ThinkingLevel.Max,
+		label: "max",
+		description: "Maximum reasoning (~64k tokens)",
 	},
 };
 


### PR DESCRIPTION
## Problem

xcsh **could not send Anthropic's `xhigh` effort** — the level Anthropic documents as the best setting for coding/agentic work and the default in Claude Code. `mapEffortToAnthropicAdaptiveEffort` returned `"low"|"medium"|"high"|"max"` and mapped `Effort.XHigh → "max"`, so xcsh's `xhigh` was a **label that transmitted `max`** and the ladder jumped `high → max`.

## Verified, not inferred

The API's own validation error is the authority:

```
output_config.effort: Input should be 'low', 'medium', 'high', 'xhigh' or 'max'
```

Probed every candidate against `claude-opus-5` / `claude-sonnet-5` **with a bogus control value** (rejected — so the accepts are meaningful, unlike beta headers which this gateway does *not* validate). `minimal` is **rejected**: it's an xcsh-internal level that must always be translated down.

Resulting wire mapping:

```
claude-opus-5      cap=max   minimal→low  low→low  medium→medium  high→high  xhigh→xhigh  max→max
claude-sonnet-5    cap=max   minimal→low  low→low  medium→medium  high→high  xhigh→xhigh  max→max
claude-sonnet-4-6  cap=high  minimal→low  low→low  medium→medium  high→high  xhigh→(unsupported)  max→(unsupported)
```

## Changes

- **`Effort`**: add `Max = "max"`, appended to `THINKING_EFFORTS` (order is load-bearing for `expandEffortRange`/`requireSupportedEffort`).
- **Anthropic mapper**: `XHigh → "xhigh"`, `Max → "max"`; `Minimal`/`Low → "low"`.
- **New `AnthropicAdaptiveEffort`** is the single source of truth; `AnthropicEffort` aliases it so the mapper and the raw passthrough can't drift.
- **`clampEffortThroughXHigh()`** for providers whose wire enum has no `max` (OpenAI-compat, GitLab Duo, Kimi, Synthetic, Codex).
- **`max` budget entries** for the `Record<Effort, number>` maps; Google and Bedrock Claude keep their documented ceilings.
- **`ThinkingLevel`** (pi-agent-core) + coding-agent UI metadata gain the level.
- **Closes #2341**: `inferAnthropicSupportedEfforts` no longer hardcodes `xhigh` to opus — Sonnet 5+ gets the extended range, Sonnet 4.6 keeps its `high` cap.
- **Catalog**: `claude-opus-5` / `claude-sonnet-5` reach `max`.

## Two deliberate judgment calls

1. **Bedrock is NOT widened.** The enum was verified against the Anthropic gateway only; I have no Bedrock access. `max` is claimed for `anthropic-messages`, and Bedrock keeps its existing `xhigh` ceiling rather than being widened on an assumption.
2. **The SDK cast is a symptom, not the fix.** `@anthropic-ai/sdk` is pinned at `^0.78` (latest **0.115.0**) and types `output_config.effort` without `xhigh`, so the assignment needs a cast. Root cause is the stale pin — tracked in **#2343**; a 37-minor bump touches every Anthropic call path and doesn't belong here.

## Blast radius (larger than first scoped)

Adding a member to a shared enum surfaced **every** consumer with a hardcoded 5-value union — 14 files across 3 packages, including a parallel `ThinkingLevel` ladder. All compiler-driven. Two over-broad edits of mine were caught by tests and reverted: a GitLab-Duo *Anthropic* path that legitimately takes the full ladder, and a **GPT-5.2** assertion whose `xhigh` cap is correct (OpenAI has no `max`).

## Verification

- `bun run ci:check:full` → **exit 0** (canonical gate)
- pi-ai **610/610** · pi-agent-core **30/30** · office-pane **338/338** · coding-agent **5777/5777**
- TDD: tests written first, confirmed red (`XHigh` returned `"max"`; `Effort.Max` didn't exist)
- New `effort-ladder.test.ts` asserts every level maps into the API enum and that **no** mapping ever emits `"minimal"`

Closes #2342
Closes #2341