### PR TITLE
feat(office): surface server-tool activity and structured citations

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -397,6 +397,11 @@ async function streamAssistantResponse(
 			case "toolcall_start":
 			case "toolcall_delta":
 			case "toolcall_end":
+			// Provider-side tools (e.g. Anthropic web search) are progress signals only: they add
+			// no content block and there is nothing to dispatch, but they must reach subscribers so
+			// hosts can render live activity instead of a silent wait.
+			case "server_tool_start":
+			case "server_tool_end":
 				if (partialMessage) {
 					partialMessage = event.partial;
 					context.messages[context.messages.length - 1] = partialMessage;

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as tls from "node:tls";
 import Anthropic, { type ClientOptions as AnthropicSdkClientOptions } from "@anthropic-ai/sdk";
 import type {
+	CitationsDelta,
 	ContentBlockParam,
 	MessageCreateParamsStreaming,
 	MessageParam,
@@ -30,6 +31,7 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 	Usage,
+	WebCitation,
 } from "../types";
 import { isAnthropicOAuthToken, normalizeToolCallId, resolveCacheRetention } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
@@ -625,6 +627,24 @@ export function isProviderRetryableError(error: unknown): boolean {
 	);
 }
 
+/**
+ * Map an Anthropic `citations_delta` citation to a `WebCitation`.
+ *
+ * Only web-search citations are carried: the char/page/content-block locations belong to the
+ * document-citations API, which cites user-supplied documents rather than search results and has
+ * no source URL to render as a chip.
+ */
+function mapAnthropicWebCitation(citation: CitationsDelta["citation"]): WebCitation | undefined {
+	if (citation.type !== "web_search_result_location") return undefined;
+	return {
+		type: "web_search_result_location",
+		url: citation.url,
+		...(citation.title ? { title: citation.title } : {}),
+		...(citation.cited_text ? { citedText: citation.cited_text } : {}),
+		...(citation.encrypted_index ? { encryptedIndex: citation.encrypted_index } : {}),
+	};
+}
+
 function createEmptyUsage(premiumRequests?: number): Usage {
 	return {
 		input: 0,
@@ -733,6 +753,19 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				const anthropicRequest = client.messages.create({ ...params, stream: true }, { signal: requestSignal });
 				let streamedReplayUnsafeContent = false;
 
+				// SERVER-SIDE tools (Anthropic's built-in web search) are executed by the provider,
+				// so their blocks are deliberately NOT pushed into `output.content`: there is nothing
+				// for the agent loop to dispatch, and keeping their `encrypted_content` out of history
+				// avoids the byte-exact echo requirement that would 400 a follow-up turn. They are
+				// tracked here only long enough to report progress — keyed by the stream's block index
+				// (to accumulate the query) and by tool id (to name the matching result block).
+				// Declared inside the retry loop so a replayed attempt starts clean.
+				const serverToolUses = new Map<
+					number,
+					{ id: string; name: string; partialJson: string; inlineInput: unknown }
+				>();
+				const serverToolNames = new Map<string, string>();
+
 				try {
 					const { data: anthropicStream } = await anthropicRequest.withResponse();
 					const firstEventWatchdog = createFirstEventWatchdog(firstEventTimeoutMs, () =>
@@ -821,6 +854,30 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 									contentIndex: output.content.length - 1,
 									partial: output,
 								});
+							} else if (event.content_block.type === "server_tool_use") {
+								// Progress-only: remember the call so its query can be reported once the
+								// input JSON has finished streaming (see content_block_stop).
+								serverToolUses.set(event.index, {
+									id: event.content_block.id,
+									name: event.content_block.name,
+									partialJson: "",
+									// Nothing obliges the provider to stream the input as deltas — it may
+									// arrive whole right here. Kept as the fallback for the query.
+									inlineInput: event.content_block.input,
+								});
+								serverToolNames.set(event.content_block.id, event.content_block.name);
+							} else if (event.content_block.type === "web_search_tool_result") {
+								const toolId = event.content_block.tool_use_id;
+								const content = event.content_block.content;
+								stream.push({
+									type: "server_tool_end",
+									toolName: serverToolNames.get(toolId) ?? "web_search",
+									toolId,
+									...(Array.isArray(content)
+										? { resultCount: content.length }
+										: { errorCode: content.error_code }),
+									partial: output,
+								});
 							}
 						} else if (event.type === "content_block_delta") {
 							if (event.delta.type === "text_delta") {
@@ -848,17 +905,31 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 									});
 								}
 							} else if (event.delta.type === "input_json_delta") {
+								const serverToolUse = serverToolUses.get(event.index);
+								if (serverToolUse) {
+									// A server-side tool's input (the search query). Accumulated but not
+									// streamed as a toolcall_delta — there is no toolCall block to attach to.
+									serverToolUse.partialJson += event.delta.partial_json;
+								} else {
+									const index = blocks.findIndex(b => b.index === event.index);
+									const block = blocks[index];
+									if (block && block.type === "toolCall") {
+										block.partialJson += event.delta.partial_json;
+										block.arguments = parseStreamingJson(block.partialJson);
+										stream.push({
+											type: "toolcall_delta",
+											contentIndex: index,
+											delta: event.delta.partial_json,
+											partial: output,
+										});
+									}
+								}
+							} else if (event.delta.type === "citations_delta") {
 								const index = blocks.findIndex(b => b.index === event.index);
 								const block = blocks[index];
-								if (block && block.type === "toolCall") {
-									block.partialJson += event.delta.partial_json;
-									block.arguments = parseStreamingJson(block.partialJson);
-									stream.push({
-										type: "toolcall_delta",
-										contentIndex: index,
-										delta: event.delta.partial_json,
-										partial: output,
-									});
+								const citation = mapAnthropicWebCitation(event.delta.citation);
+								if (block && block.type === "text" && citation) {
+									block.citations = [...(block.citations ?? []), citation];
 								}
 							} else if (event.delta.type === "signature_delta") {
 								const index = blocks.findIndex(b => b.index === event.index);
@@ -869,6 +940,28 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 								}
 							}
 						} else if (event.type === "content_block_stop") {
+							const serverToolUse = serverToolUses.get(event.index);
+							if (serverToolUse) {
+								// The query has finished streaming, so the activity row can name what is
+								// being searched for. Reported here rather than at content_block_start
+								// because that is the first moment the query is known — and it still lands
+								// well before the provider's search completes.
+								serverToolUses.delete(event.index);
+								const streamed = parseStreamingJson(serverToolUse.partialJson) as
+									| { query?: unknown }
+									| undefined;
+								const inline = serverToolUse.inlineInput as { query?: unknown } | undefined;
+								const rawQuery = typeof streamed?.query === "string" ? streamed.query : inline?.query;
+								const query = typeof rawQuery === "string" && rawQuery.length > 0 ? rawQuery : undefined;
+								stream.push({
+									type: "server_tool_start",
+									toolName: serverToolUse.name,
+									toolId: serverToolUse.id,
+									...(query === undefined ? {} : { query }),
+									partial: output,
+								});
+								continue;
+							}
 							const index = blocks.findIndex(b => b.index === event.index);
 							const block = blocks[index];
 							if (block) {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -252,10 +252,33 @@ export interface TextSignatureV1 {
 	phase?: "commentary" | "final_answer";
 }
 
+/**
+ * A structured citation annotating a span of assistant text, produced by a provider's
+ * SERVER-SIDE search tool (Anthropic `citations_delta` → `web_search_result_location`).
+ *
+ * Carries the source title/url so hosts can render precise "Sources" chips instead of
+ * regex-scraping URLs out of the prose.
+ */
+export interface WebCitation {
+	type: "web_search_result_location";
+	url: string;
+	title?: string;
+	/** The span of source material the assistant drew on. */
+	citedText?: string;
+	/**
+	 * Opaque provider index for the cited result. Retained for fidelity only — it is never
+	 * re-sent, because echoing a provider's encrypted citation fields back on a later turn
+	 * must be byte-exact or the request is rejected.
+	 */
+	encryptedIndex?: string;
+}
+
 export interface TextContent {
 	type: "text";
 	text: string;
 	textSignature?: string; // e.g., for OpenAI responses, message metadata (legacy id string or TextSignatureV1 JSON)
+	/** Structured citations for this span, when the provider ran a server-side search. */
+	citations?: WebCitation[];
 }
 
 export interface ThinkingContent {
@@ -429,6 +452,32 @@ export type AssistantMessageEvent =
 	| { type: "toolcall_start"; contentIndex: number; partial: AssistantMessage }
 	| { type: "toolcall_delta"; contentIndex: number; delta: string; partial: AssistantMessage }
 	| { type: "toolcall_end"; contentIndex: number; toolCall: ToolCall; partial: AssistantMessage }
+	/**
+	 * A provider-SIDE tool (e.g. Anthropic's built-in web search) started running.
+	 *
+	 * Purely a progress signal so hosts can show a live activity row — the provider executes
+	 * these itself, so unlike `toolcall_*` there is nothing for the agent loop to dispatch and
+	 * no content block is added to the message.
+	 */
+	| {
+			type: "server_tool_start";
+			contentIndex?: undefined;
+			toolName: string;
+			toolId: string;
+			/** The search query, when the provider streamed one. */
+			query?: string;
+			partial: AssistantMessage;
+	  }
+	/** A provider-side tool finished: either it returned results, or it failed. */
+	| {
+			type: "server_tool_end";
+			contentIndex?: undefined;
+			toolName: string;
+			toolId: string;
+			resultCount?: number;
+			errorCode?: string;
+			partial: AssistantMessage;
+	  }
 	| {
 			type: "done";
 			contentIndex?: undefined;

--- a/packages/ai/test/anthropic-server-tools.test.ts
+++ b/packages/ai/test/anthropic-server-tools.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Anthropic SERVER-SIDE tool blocks (issue #2340).
+ *
+ * A web-search turn streams `server_tool_use` + `web_search_tool_result` content blocks and
+ * `citations_delta` deltas. The provider used to have no branch for any of them, so all three
+ * silently vanished: the Office pane showed a bare "Thinking…" for ~6s with no activity row,
+ * and Sources chips had to be regex-scraped out of the answer prose.
+ *
+ * The contract asserted here:
+ *  1. Server-tool use surfaces as transient `server_tool_start` / `server_tool_end` events
+ *     (with the search query and the result count) so hosts can render live activity.
+ *  2. Those blocks NEVER enter `AssistantMessage.content`. They are not executable and must not
+ *     look like a `toolCall` (the agent loop would try to run "web_search" and fail), and keeping
+ *     them out of history keeps `encrypted_content` / `encrypted_index` from being echoed back
+ *     malformed on a follow-up turn (Anthropic 400s on that).
+ *  3. `citations_delta` lands as STRUCTURED citations on the text block it annotates.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { Messages } from "@anthropic-ai/sdk/resources/messages/messages";
+import { streamAnthropic } from "../src/providers/anthropic";
+import type { AssistantMessageEvent, Context, Model } from "../src/types";
+
+const model: Model<"anthropic-messages"> = {
+	id: "claude-sonnet-4-5",
+	name: "Claude Sonnet 4.5",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+};
+
+const context: Context = {
+	messages: [{ role: "user", content: "latest F5 NGINX Plus release?", timestamp: Date.now() }],
+};
+
+type MockAnthropicEvent = Record<string, unknown>;
+
+function createMockRequest(events: MockAnthropicEvent[]) {
+	const response = new Response(null, { status: 200, headers: { "request-id": "req_mock" } });
+	return {
+		async withResponse() {
+			return {
+				data: {
+					async *[Symbol.asyncIterator]() {
+						for (const event of events) yield event;
+					},
+				},
+				response,
+				request_id: response.headers.get("request-id"),
+			};
+		},
+	};
+}
+
+const QUERY = "latest F5 NGINX Plus release";
+const ANSWER = "NGINX Plus R34 is the latest release.";
+const RESULT_A = {
+	type: "web_search_result",
+	url: "https://docs.nginx.com/nginx/releases/",
+	title: "NGINX Plus Releases",
+	encrypted_content: "ENCRYPTED_A",
+	page_age: "2 days ago",
+};
+const RESULT_B = {
+	type: "web_search_result",
+	url: "https://www.f5.com/products/nginx",
+	title: "F5 NGINX",
+	encrypted_content: "ENCRYPTED_B",
+	page_age: null,
+};
+
+function messageStart(): MockAnthropicEvent {
+	return {
+		type: "message_start",
+		message: {
+			id: "msg_websearch",
+			usage: { input_tokens: 20, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+		},
+	};
+}
+
+function messageEnd(): MockAnthropicEvent[] {
+	return [
+		{
+			type: "message_delta",
+			delta: { stop_reason: "end_turn" },
+			usage: { input_tokens: 20, output_tokens: 9, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+		},
+		{ type: "message_stop" },
+	];
+}
+
+/** A realistic successful web-search turn: search → results → cited answer. */
+function webSearchEvents(): MockAnthropicEvent[] {
+	return [
+		messageStart(),
+		{
+			type: "content_block_start",
+			index: 0,
+			content_block: { type: "server_tool_use", id: "srvtoolu_1", name: "web_search", input: {} },
+		},
+		{ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: '{"query":"' } },
+		{ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: `${QUERY}"}` } },
+		{ type: "content_block_stop", index: 0 },
+		{
+			type: "content_block_start",
+			index: 1,
+			content_block: {
+				type: "web_search_tool_result",
+				tool_use_id: "srvtoolu_1",
+				content: [RESULT_A, RESULT_B],
+			},
+		},
+		{ type: "content_block_stop", index: 1 },
+		{ type: "content_block_start", index: 2, content_block: { type: "text", text: "" } },
+		{ type: "content_block_delta", index: 2, delta: { type: "text_delta", text: ANSWER } },
+		{
+			type: "content_block_delta",
+			index: 2,
+			delta: {
+				type: "citations_delta",
+				citation: {
+					type: "web_search_result_location",
+					url: RESULT_A.url,
+					title: RESULT_A.title,
+					cited_text: "R34 is the latest",
+					encrypted_index: "IDX_A",
+				},
+			},
+		},
+		{ type: "content_block_stop", index: 2 },
+		...messageEnd(),
+	];
+}
+
+/** A web-search turn that Anthropic rejects (quota). */
+function webSearchErrorEvents(): MockAnthropicEvent[] {
+	return [
+		messageStart(),
+		{
+			type: "content_block_start",
+			index: 0,
+			content_block: { type: "server_tool_use", id: "srvtoolu_1", name: "web_search", input: {} },
+		},
+		{
+			type: "content_block_delta",
+			index: 0,
+			delta: { type: "input_json_delta", partial_json: `{"query":"${QUERY}"}` },
+		},
+		{ type: "content_block_stop", index: 0 },
+		{
+			type: "content_block_start",
+			index: 1,
+			content_block: {
+				type: "web_search_tool_result",
+				tool_use_id: "srvtoolu_1",
+				content: { type: "web_search_tool_result_error", error_code: "max_uses_exceeded" },
+			},
+		},
+		{ type: "content_block_stop", index: 1 },
+		...messageEnd(),
+	];
+}
+
+async function collect(events: MockAnthropicEvent[]) {
+	vi.spyOn(Messages.prototype, "create").mockImplementation(() => createMockRequest(events) as never);
+	const stream = streamAnthropic(model, context, { apiKey: "sk-ant-test" });
+	const seen: AssistantMessageEvent[] = [];
+	for await (const event of stream) seen.push(event);
+	return { events: seen, result: await stream.result() };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("anthropic server-side tool blocks (#2340)", () => {
+	it("emits server_tool_start carrying the search query", async () => {
+		const { events } = await collect(webSearchEvents());
+
+		const starts = events.filter(e => e.type === "server_tool_start");
+		expect(starts).toHaveLength(1);
+		expect(starts[0]).toMatchObject({ toolName: "web_search", toolId: "srvtoolu_1", query: QUERY });
+	});
+
+	it("emits server_tool_end carrying the result count", async () => {
+		const { events } = await collect(webSearchEvents());
+
+		const ends = events.filter(e => e.type === "server_tool_end");
+		expect(ends).toHaveLength(1);
+		expect(ends[0]).toMatchObject({ toolName: "web_search", toolId: "srvtoolu_1", resultCount: 2 });
+		expect((ends[0] as { errorCode?: string }).errorCode).toBeUndefined();
+	});
+
+	it("orders server_tool_start before server_tool_end before the answer text", async () => {
+		const { events } = await collect(webSearchEvents());
+		const order = events.map(e => e.type);
+
+		expect(order.indexOf("server_tool_start")).toBeGreaterThanOrEqual(0);
+		expect(order.indexOf("server_tool_start")).toBeLessThan(order.indexOf("server_tool_end"));
+		expect(order.indexOf("server_tool_end")).toBeLessThan(order.indexOf("text_delta"));
+	});
+
+	it("NEVER models server tools as an executable toolCall", async () => {
+		const { events, result } = await collect(webSearchEvents());
+
+		expect(events.some(e => e.type === "toolcall_start")).toBe(false);
+		expect(events.some(e => e.type === "toolcall_end")).toBe(false);
+		expect(result.content.some(block => block.type === "toolCall")).toBe(false);
+	});
+
+	it("keeps server-tool blocks OUT of message content (no encrypted_* echoed on follow-up)", async () => {
+		const { result } = await collect(webSearchEvents());
+
+		expect(result.content).toHaveLength(1);
+		expect(result.content[0].type).toBe("text");
+		expect(JSON.stringify(result.content)).not.toContain("ENCRYPTED_A");
+		expect(JSON.stringify(result.content)).not.toContain("ENCRYPTED_B");
+	});
+
+	it("attaches structured citations to the text block they annotate", async () => {
+		const { result } = await collect(webSearchEvents());
+
+		const text = result.content[0];
+		expect(text.type).toBe("text");
+		if (text.type !== "text") throw new Error("expected a text block");
+		expect(text.text).toBe(ANSWER);
+		expect(text.citations).toHaveLength(1);
+		expect(text.citations?.[0]).toEqual({
+			type: "web_search_result_location",
+			url: RESULT_A.url,
+			title: RESULT_A.title,
+			citedText: "R34 is the latest",
+			encryptedIndex: "IDX_A",
+		});
+	});
+
+	it("still streams the answer text normally around the server-tool blocks", async () => {
+		const { events, result } = await collect(webSearchEvents());
+
+		expect(events.filter(e => e.type === "text_start")).toHaveLength(1);
+		expect(events.filter(e => e.type === "text_end")).toHaveLength(1);
+		expect(events.filter(e => e.type === "done")).toHaveLength(1);
+		expect(result.stopReason).toBe("stop");
+	});
+
+	it("reports a server-tool failure via errorCode instead of a result count", async () => {
+		const { events } = await collect(webSearchErrorEvents());
+
+		const ends = events.filter(e => e.type === "server_tool_end");
+		expect(ends).toHaveLength(1);
+		expect(ends[0]).toMatchObject({ toolName: "web_search", errorCode: "max_uses_exceeded" });
+		expect((ends[0] as { resultCount?: number }).resultCount).toBeUndefined();
+	});
+
+	it("leaves a plain turn with no server tools completely unchanged", async () => {
+		const { events, result } = await collect([
+			messageStart(),
+			{ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+			{ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hello" } },
+			{ type: "content_block_stop", index: 0 },
+			...messageEnd(),
+		]);
+
+		expect(events.some(e => e.type === "server_tool_start" || e.type === "server_tool_end")).toBe(false);
+		expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+	});
+
+	it("reads the query from an INLINE input when it is not streamed as deltas", async () => {
+		// Nothing obliges a provider to stream a server tool's input incrementally — it may
+		// arrive whole on content_block_start. The activity row must still name the search.
+		const { events } = await collect([
+			messageStart(),
+			{
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "server_tool_use", id: "srvtoolu_1", name: "web_search", input: { query: QUERY } },
+			},
+			{ type: "content_block_stop", index: 0 },
+			...messageEnd(),
+		]);
+
+		const starts = events.filter(e => e.type === "server_tool_start");
+		expect(starts).toHaveLength(1);
+		expect(starts[0]).toMatchObject({ toolName: "web_search", query: QUERY });
+	});
+
+	it("still announces the search when no query is available at all", async () => {
+		const { events } = await collect([
+			messageStart(),
+			{
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "server_tool_use", id: "srvtoolu_1", name: "web_search", input: {} },
+			},
+			{ type: "content_block_stop", index: 0 },
+			...messageEnd(),
+		]);
+
+		const starts = events.filter(e => e.type === "server_tool_start");
+		expect(starts).toHaveLength(1);
+		expect(starts[0]).toMatchObject({ toolName: "web_search", toolId: "srvtoolu_1" });
+		expect((starts[0] as { query?: string }).query).toBeUndefined();
+	});
+});

--- a/packages/chat-ui/src/tools/activity-label.ts
+++ b/packages/chat-ui/src/tools/activity-label.ts
@@ -37,6 +37,10 @@ const LABELS: Readonly<Record<string, string>> = {
 	add_slide: "Adding slide",
 	add_text_box: "Adding text box",
 	modify_shape_text: "Editing shape text",
+	// Provider-side ("server") tools: the model's own built-ins, which the provider executes
+	// rather than the host. Named for what the user is waiting on (#2340).
+	web_search: "Searching the web",
+	web_fetch: "Fetching a page",
 };
 
 /** Title-case the first word of a de-snaked name: `take_screenshot` → `Take screenshot`. */

--- a/packages/chat-ui/test/tool-activity-label.test.ts
+++ b/packages/chat-ui/test/tool-activity-label.test.ts
@@ -45,4 +45,9 @@ describe("toolActivityLabel", () => {
 		expect(toolActivityLabel("")).toBe("Working");
 		expect(toolActivityLabel("   ")).toBe("Working");
 	});
+
+	test("names provider-side (server) tools for what the user is waiting on (#2340)", () => {
+		expect(toolActivityLabel("web_search")).toBe("Searching the web");
+		expect(toolActivityLabel("web_fetch")).toBe("Fetching a page");
+	});
 });

--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -275,6 +275,32 @@ export class ChatHandler {
 					chat.lastKeepaliveAt = nowMs;
 					this.#server.send({ type: "chat_keepalive", id: chat.id } satisfies ChatKeepalive);
 				}
+			} else if (ame.type === "server_tool_start") {
+				// PROVIDER-SIDE ACTIVITY (#2340): the provider runs web search itself, which takes
+				// seconds before any token streams. This notice is the only feedback in that window —
+				// without it the panel shows a bare "Thinking…" and looks hung. It doubles as a
+				// liveness signal, since the panel re-arms its first-token timer on a tool notice.
+				const label = serverToolLabels(ame.toolName);
+				this.#server.send({
+					type: "chat_tool_notice",
+					id: chat.id,
+					tool: ame.toolName,
+					ok: true,
+					detail: ame.query ? `${label.running}: ${ame.query}` : `${label.running}…`,
+				});
+			} else if (ame.type === "server_tool_end") {
+				const label = serverToolLabels(ame.toolName);
+				const failed = ame.errorCode !== undefined;
+				const count = ame.resultCount ?? 0;
+				this.#server.send({
+					type: "chat_tool_notice",
+					id: chat.id,
+					tool: ame.toolName,
+					ok: !failed,
+					detail: failed
+						? `${label.done} failed: ${ame.errorCode}`
+						: `${label.done}: ${count} result${count === 1 ? "" : "s"}`,
+				});
 			}
 		} else if (event.type === "message_end" && event.message.role === "assistant") {
 			const msg = event.message as AssistantMessage;
@@ -686,9 +712,39 @@ function trimTrailingMarkup(url: string): string {
 	return url.replace(/[*_~`,.;:!?'")\]}>]+$/, "");
 }
 
+/** Panel-facing labels for provider-side tools, used for the activity rows (#2340). */
+function serverToolLabels(toolName: string): { running: string; done: string } {
+	switch (toolName) {
+		case "web_search":
+			return { running: "Searching the web", done: "Web search" };
+		case "web_fetch":
+			return { running: "Fetching a page", done: "Page fetch" };
+		default:
+			return { running: `${toolName}: running`, done: toolName };
+	}
+}
+
 export function extractReferences(msg: AssistantMessage): ChatReference[] {
 	const refs: ChatReference[] = [];
 	const seen = new Set<string>();
+
+	// STRUCTURED CITATIONS FIRST (#2340): a provider-side search reports the real page title, so
+	// it beats the regex scrape below — which can only guess a title from the URL path, and finds
+	// nothing at all when the model cites a source without printing its URL in the prose. Done as
+	// its own pass so a citation in a later block still wins over a scrape in an earlier one.
+	for (const block of msg.content) {
+		if (block.type !== "text" || !block.citations) continue;
+		for (const citation of block.citations) {
+			const url = citation.url;
+			if (!url || seen.has(url)) continue;
+			seen.add(url);
+			refs.push({
+				kind: classifyReferenceKind(url),
+				title: citation.title?.trim() || titleFromUrl(url),
+				url,
+			});
+		}
+	}
 
 	for (const block of msg.content) {
 		if (block.type !== "text") continue;

--- a/packages/coding-agent/test/browser/chat-handler.server-tools.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.server-tools.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Issue #2340 — provider-side tool activity must reach the panel.
+ *
+ * On an Anthropic web-search turn the provider runs the search itself, which takes several
+ * seconds before ANY token streams. Those `server_tool_*` events used to stop dead in the
+ * provider, so the Office pane showed a bare "Thinking…" for ~6s with no indication a search
+ * was even happening (the symptom the operator reported as a hang).
+ *
+ * This drives the REAL chain — a stub model pushing `server_tool_start`/`server_tool_end` into
+ * a real agent loop, a real `AgentSession`, and a real `ChatHandler` — and asserts the events
+ * surface as `chat_tool_notice` frames on the wire (which the panel already renders as activity
+ * rows, and which also re-arm its first-token timer).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent } from "@f5-sales-demo/pi-agent-core";
+import { type AssistantMessage, getBundledModel } from "@f5-sales-demo/pi-ai";
+import { AssistantMessageEventStream } from "@f5-sales-demo/pi-ai/utils/event-stream";
+import { Snowflake } from "@f5-sales-demo/pi-utils";
+import { ChatHandler } from "@f5-sales-demo/xcsh/browser/chat-handler";
+import type { BridgeServer } from "@f5-sales-demo/xcsh/browser/extension-bridge";
+import { ModelRegistry } from "@f5-sales-demo/xcsh/config/model-registry";
+import { Settings } from "@f5-sales-demo/xcsh/config/settings";
+import { AgentSession } from "@f5-sales-demo/xcsh/session/agent-session";
+import { AuthStorage } from "@f5-sales-demo/xcsh/session/auth-storage";
+import { SessionManager } from "@f5-sales-demo/xcsh/session/session-manager";
+
+class FakeBridgeServer {
+	sent: Array<Record<string, unknown>> = [];
+	#onMessage: Array<(m: Record<string, unknown>) => void> = [];
+	#onDisconnected: Array<() => void> = [];
+
+	send(payload: unknown): void {
+		this.sent.push(payload as Record<string, unknown>);
+	}
+	onMessage(cb: (m: Record<string, unknown>) => void): void {
+		this.#onMessage.push(cb);
+	}
+	onDisconnected(cb: () => void): void {
+		this.#onDisconnected.push(cb);
+	}
+
+	emit(msg: Record<string, unknown>): void {
+		for (const cb of this.#onMessage) cb(msg);
+	}
+	ofType(type: string): Array<Record<string, unknown>> {
+		return this.sent.filter(frame => frame.type === type);
+	}
+	indexOf(type: string): number {
+		return this.sent.findIndex(frame => frame.type === type);
+	}
+}
+
+const QUERY = "latest F5 NGINX Plus release";
+const ANSWER = "NGINX Plus R34 is the latest release.";
+
+function baseAssistant(content: AssistantMessage["content"], stopReason: AssistantMessage["stopReason"]) {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: Date.now(),
+	} as AssistantMessage;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(5);
+	}
+	throw new Error("Timed out waiting for condition");
+}
+
+describe("#2340 — provider-side tool activity reaches the panel", () => {
+	let session: AgentSession;
+	let handler: ChatHandler;
+	let server: FakeBridgeServer;
+	let tempDir: string;
+	const authStorages: AuthStorage[] = [];
+
+	beforeEach(() => {
+		tempDir = path.join(os.tmpdir(), `pi-2340-server-tools-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		handler?.dispose();
+		if (session) await session.dispose();
+		for (const authStorage of authStorages.splice(0)) authStorage.close();
+		if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+	});
+
+	/**
+	 * @param outcome "results" → the search returns 2 hits; "error" → the provider rejects it.
+	 */
+	async function makeSession(outcome: "results" | "error"): Promise<AgentSession> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: "Test", tools: [] },
+			streamFn: () => {
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					const partial = baseAssistant([], "stop");
+					stream.push({ type: "start", partial });
+					stream.push({
+						type: "server_tool_start",
+						toolName: "web_search",
+						toolId: "srvtoolu_1",
+						query: QUERY,
+						partial,
+					});
+					stream.push({
+						type: "server_tool_end",
+						toolName: "web_search",
+						toolId: "srvtoolu_1",
+						...(outcome === "results" ? { resultCount: 2 } : { errorCode: "max_uses_exceeded" }),
+						partial,
+					});
+					stream.push({
+						type: "text_delta",
+						contentIndex: 0,
+						delta: ANSWER,
+						partial: baseAssistant([{ type: "text", text: ANSWER }], "stop"),
+					});
+					stream.push({
+						type: "done",
+						reason: "stop",
+						message: baseAssistant(
+							[
+								{
+									type: "text",
+									text: ANSWER,
+									citations: [
+										{
+											type: "web_search_result_location",
+											url: "https://docs.nginx.com/nginx/releases/",
+											title: "NGINX Plus Releases",
+											citedText: "R34 is the latest",
+										},
+									],
+								},
+							],
+							"stop",
+						),
+					});
+				});
+				return stream;
+			},
+		});
+
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+
+		return new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+	}
+
+	async function runTurn(outcome: "results" | "error"): Promise<void> {
+		session = await makeSession(outcome);
+		server = new FakeBridgeServer();
+		handler = new ChatHandler(server as unknown as BridgeServer, session);
+		handler.attach();
+		server.emit({
+			type: "chat_request",
+			id: "c-websearch-1",
+			text: QUERY,
+			context: null,
+			mode: "configuration",
+		});
+		await waitFor(() => server.ofType("chat_done").length === 1);
+	}
+
+	it("announces the search — with the query — as a tool notice", async () => {
+		await runTurn("results");
+
+		const notices = server.ofType("chat_tool_notice").filter(f => f.tool === "web_search");
+		expect(notices.length).toBeGreaterThanOrEqual(1);
+		expect(notices[0].ok).toBe(true);
+		expect(String(notices[0].detail)).toContain("Searching the web");
+		expect(String(notices[0].detail)).toContain(QUERY);
+	});
+
+	it("reports the result count when the search returns", async () => {
+		await runTurn("results");
+
+		const notices = server.ofType("chat_tool_notice").filter(f => f.tool === "web_search");
+		expect(notices).toHaveLength(2);
+		expect(notices[1].ok).toBe(true);
+		expect(String(notices[1].detail)).toContain("2 results");
+	});
+
+	it("shows the activity BEFORE the first answer token (the point of the fix)", async () => {
+		await runTurn("results");
+
+		const noticeIdx = server.indexOf("chat_tool_notice");
+		const deltaIdx = server.sent.findIndex(f => f.type === "chat_delta");
+		expect(noticeIdx).toBeGreaterThanOrEqual(0);
+		expect(deltaIdx).toBeGreaterThanOrEqual(0);
+		expect(noticeIdx).toBeLessThan(deltaIdx);
+	});
+
+	it("marks a failed search not-ok and names the error", async () => {
+		await runTurn("error");
+
+		const notices = server.ofType("chat_tool_notice").filter(f => f.tool === "web_search");
+		expect(notices).toHaveLength(2);
+		expect(notices[1].ok).toBe(false);
+		expect(String(notices[1].detail)).toContain("max_uses_exceeded");
+	});
+
+	it("still completes the turn exactly once, with no error", async () => {
+		await runTurn("results");
+
+		expect(server.ofType("chat_done")).toHaveLength(1);
+		expect(server.ofType("chat_error")).toHaveLength(0);
+	});
+
+	it("sends Sources from the structured citation, not a regex scrape of the prose", async () => {
+		await runTurn("results");
+
+		const done = server.ofType("chat_done")[0];
+		const references = done.references as Array<{ title: string; url: string }> | undefined;
+		expect(references).toBeDefined();
+		expect(references).toHaveLength(1);
+		// The prose contains no URL at all — a regex scrape would have found nothing.
+		expect(ANSWER).not.toContain("http");
+		expect(references?.[0].url).toBe("https://docs.nginx.com/nginx/releases/");
+		expect(references?.[0].title).toBe("NGINX Plus Releases");
+	});
+});

--- a/packages/coding-agent/test/browser/extract-references.test.ts
+++ b/packages/coding-agent/test/browser/extract-references.test.ts
@@ -5,7 +5,7 @@
  * See issue #2249.
  */
 import { describe, expect, test } from "bun:test";
-import type { AssistantMessage } from "@f5-sales-demo/pi-ai";
+import type { AssistantMessage, WebCitation } from "@f5-sales-demo/pi-ai";
 import { extractReferences } from "../../src/browser/chat-handler";
 
 /** Minimal AssistantMessage carrying a single text block. */
@@ -67,5 +67,55 @@ describe("extractReferences", () => {
 			assistantText("**https://docs.cloud.f5.com/waf** and again https://docs.cloud.f5.com/waf"),
 		);
 		expect(refs).toHaveLength(1);
+	});
+});
+
+/**
+ * Structured citations from a provider-side web search (#2340). Regex scraping can only find
+ * URLs the model happened to print, and can only guess a title from the URL path — the citations
+ * carry the real page title, so they must take precedence.
+ */
+describe("extractReferences — structured web-search citations", () => {
+	/** An AssistantMessage whose text block carries provider citations. */
+	function assistantCited(text: string, citations: WebCitation[]): AssistantMessage {
+		return { role: "assistant", content: [{ type: "text", text, citations }] } as unknown as AssistantMessage;
+	}
+
+	const CITATION: WebCitation = {
+		type: "web_search_result_location",
+		url: "https://docs.nginx.com/nginx/releases/",
+		title: "NGINX Plus Releases",
+		citedText: "R34 is the latest",
+	};
+
+	test("surfaces a citation even when the prose prints no URL at all", () => {
+		const refs = extractReferences(assistantCited("NGINX Plus R34 is the latest release.", [CITATION]));
+		expect(refs).toHaveLength(1);
+		expect(refs[0].url).toBe(CITATION.url);
+		expect(refs[0].title).toBe("NGINX Plus Releases");
+	});
+
+	test("citation title WINS over the title the regex would scrape from the URL", () => {
+		const refs = extractReferences(assistantCited(`See ${CITATION.url} for details.`, [CITATION]));
+		expect(refs).toHaveLength(1); // deduped, not doubled
+		expect(refs[0].title).toBe("NGINX Plus Releases"); // not "releases" from the path
+	});
+
+	test("falls back to a URL-derived title when the citation has none", () => {
+		const refs = extractReferences(
+			assistantCited("Answer.", [{ type: "web_search_result_location", url: "https://docs.cloud.f5.com/waf" }]),
+		);
+		expect(refs).toHaveLength(1);
+		expect(refs[0].title).toBe("waf");
+	});
+
+	test("dedupes repeated citations of the same URL", () => {
+		const refs = extractReferences(assistantCited("Answer.", [CITATION, { ...CITATION, citedText: "another span" }]));
+		expect(refs).toHaveLength(1);
+	});
+
+	test("still picks up prose URLs that were not cited", () => {
+		const refs = extractReferences(assistantCited(`Also https://docs.cloud.f5.com/lb helps.`, [CITATION]));
+		expect(refs.map(r => r.url)).toEqual([CITATION.url, "https://docs.cloud.f5.com/lb"]);
 	});
 });


### PR DESCRIPTION
Closes #2340

## Problem

Anthropic's server-side web search streams three kinds of data the provider had **no branch for**, so all of it was silently dropped:

- `server_tool_use` and `web_search_tool_result` matched no case in `content_block_start`
- `citations_delta` matched no case in `content_block_delta`

Two user-visible consequences in the Office pane:

1. **It looked hung.** The provider spends ~6s running the search before any token streams, and the pane showed only a bare `Thinking…` for that whole window — the symptom reported as a hang (measured: first delta 5.8–6.5s, `chat_done` 15–19s; nothing was actually stuck).
2. **Sources were guesswork.** Chips came from regex-scraping URLs out of the answer prose, so the precise `web_search_result_location` citations (real page title + cited span) were lost, and a source the model cited *without* printing its URL produced no chip at all.

## Change

| Package | Change |
|---|---|
| `ai` | Recognize the server-tool blocks; report them as transient `server_tool_start` / `server_tool_end` events carrying the query, result count, or error code. Map `citations_delta` → structured `WebCitation`s on the text block they annotate. |
| `agent` | Forward both events through the agent loop. |
| `coding-agent` | Map them to `chat_tool_notice`; prefer structured citations over the regex scrape in `extractReferences`. |
| `chat-ui` | Label provider-side tools for what the user is waiting on. |

No new wire frames and no new UI component — this reuses the existing `chat_tool_notice` activity rows and `references` chips, so the pane renders it as-is. The notice also **re-arms the panel's first-token timer**, so a slow search can no longer be mistaken for a dead worker.

## The two traps this deliberately avoids

- **Not executable.** Server-tool blocks are never added to `AssistantMessage.content`. Modelling one as a `toolCall` would make the agent loop try to run `web_search` and fail "Tool not found".
- **No 400 on the follow-up turn.** Anthropic requires `encrypted_content` / `encrypted_index` to be echoed back byte-for-byte if those blocks are kept in history. Keeping them out of history entirely (today's behavior) sidesteps that, and a test asserts the encrypted payloads never reach message content.

## Verification

TDD — tests written first and confirmed red, then green.

- `packages/ai/test/anthropic-server-tools.test.ts` (**11 new**): event emission + ordering (activity precedes the answer text), query from streamed deltas **and** from an inline `input`, no-query fallback, result count, `max_uses_exceeded` error path, structured citations, and the two invariants above.
- `packages/coding-agent/test/browser/chat-handler.server-tools.test.ts` (**6 new**): drives the real chain — stub model → real agent loop → real `AgentSession` → real `ChatHandler` — asserting the `chat_tool_notice` frames land on the wire before the first token, and that Sources come from the citation when the prose contains no URL at all.
- `extract-references.test.ts` (**5 new**): citation title wins over a scraped one, dedupe, URL-derived title fallback, uncited prose URLs still picked up.
- `tool-activity-label.test.ts` (**1 new**): the new labels.

Suites from the committed tree: `ai`+`agent` **642 pass / 0 fail**, `chat-ui` **143 + 78 / 0 fail**, `office-pane` **340 / 0 fail**, `coding-agent` **5788 / 0 fail**. `bun run check:ts` exit 0, biome clean.

Not covered: `packages/agent/src/proxy.ts` (the genai-proxy stream) does not serialize the new events. That path is a separate deployment that never emits them today, so adding speculative support would be untestable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)