### PR TITLE
chore(deps): bump @anthropic-ai/sdk 0.78 → 0.115; drop the xhigh cast

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
         "pi-ai": "./src/cli.ts",
       },
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.78",
+        "@anthropic-ai/sdk": "^0.115",
         "@aws-sdk/client-bedrock-runtime": "^3",
         "@bufbuild/protobuf": "^2.11",
         "@f5-sales-demo/pi-utils": "workspace:*",
@@ -263,7 +263,7 @@
 
     "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.16.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.115.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
@@ -390,6 +390,16 @@
     "@f5-sales-demo/pi-ai": ["@f5-sales-demo/pi-ai@workspace:packages/ai"],
 
     "@f5-sales-demo/pi-natives": ["@f5-sales-demo/pi-natives@workspace:packages/natives"],
+
+    "@f5-sales-demo/pi-natives-darwin-arm64": ["@f5-sales-demo/pi-natives-darwin-arm64@19.90.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kT2645WIM7dBV0/EhCvD+cIvPmJqCAG6e7P8oM3vRZ/QnXJ/TMkzKI6RBdaPxidubMOTbMU99jJe7gXfVej4WQ=="],
+
+    "@f5-sales-demo/pi-natives-darwin-x64": ["@f5-sales-demo/pi-natives-darwin-x64@19.90.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-/ZhH0iCwKImkRQfe/JoSB8yUSygaf/ef2YIe776FYSR9BvPZW89CjuZMhCAmLBq6ZSN5D6sVXDLFZsCpI61lHQ=="],
+
+    "@f5-sales-demo/pi-natives-linux-arm64-gnu": ["@f5-sales-demo/pi-natives-linux-arm64-gnu@19.90.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-JHOA5jlOiFOu0RJkJBX1Pm2BKDrxX1xt8SETY9swkBNOGvtxWlc688B4Xu3yhKoRmBVGaEqXXw8HF5V1oPpCKA=="],
+
+    "@f5-sales-demo/pi-natives-linux-x64-gnu": ["@f5-sales-demo/pi-natives-linux-x64-gnu@19.90.0", "", { "os": "linux", "cpu": "x64" }, "sha512-EdoXpSVSOuNw5jTXFOKBtK23hlkXFpz2yjOw7bqDr1VqqofeeuoJwwftLjY24Q9WddSvJfmVZ4mY3FugXILOkQ=="],
+
+    "@f5-sales-demo/pi-natives-win32-x64-msvc": ["@f5-sales-demo/pi-natives-win32-x64-msvc@19.90.0", "", { "os": "win32", "cpu": "x64" }, "sha512-4pWA6hS4skSRr98Qe/9QHmGeOzmtdYtL8L5u5V7X9B9F0fp6KF87+f+aV3YbyWQacEQFtDgV1PGueL0GLbSFgQ=="],
 
     "@f5-sales-demo/pi-resource-management": ["@f5-sales-demo/pi-resource-management@workspace:packages/resource-management"],
 
@@ -634,6 +644,8 @@
     "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
+
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.1" } }, "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A=="],
 
@@ -948,6 +960,8 @@
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
+
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
 
@@ -1326,6 +1340,8 @@
     "stack-chain": ["stack-chain@1.3.7", "", {}, "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="],
 
     "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
+
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 
     "streamx": ["streamx@2.28.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw=="],
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -41,7 +41,7 @@
 		"generate-models": "bun scripts/generate-models.ts"
 	},
 	"dependencies": {
-		"@anthropic-ai/sdk": "^0.78",
+		"@anthropic-ai/sdk": "^0.115",
 		"@aws-sdk/client-bedrock-runtime": "^3",
 		"@bufbuild/protobuf": "^2.11",
 		"@google/genai": "^1.43",

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1426,16 +1426,10 @@ function buildParams(
 		const effort =
 			options.effort ?? (requestedEffort ? mapEffortToAnthropicAdaptiveEffort(model, requestedEffort) : undefined);
 
-		// The pinned @anthropic-ai/sdk (0.78) types `OutputConfig.effort` as
-		// 'low'|'medium'|'high'|'max' — it predates `xhigh`, which the live API
-		// accepts (verified: its 400 enumerates "'low', 'medium', 'high', 'xhigh'
-		// or 'max'"). Cast until the SDK pin is bumped; the wire value is valid.
-		const outputConfigEffort = effort as NonNullable<MessageCreateParamsStreaming["output_config"]>["effort"];
-
 		if (mode === "anthropic-adaptive") {
 			params.thinking = { type: "adaptive" };
 			if (effort) {
-				params.output_config = { effort: outputConfigEffort };
+				params.output_config = { effort };
 			}
 		} else {
 			params.thinking = {
@@ -1443,7 +1437,7 @@ function buildParams(
 				budget_tokens: options.thinkingBudgetTokens || 1024,
 			};
 			if (mode === "anthropic-budget-effort" && effort) {
-				params.output_config = { effort: outputConfigEffort };
+				params.output_config = { effort };
 			}
 		}
 		// Anthropic requires temperature=1 when thinking is enabled; override any


### PR DESCRIPTION
Step 1 of the dependency modernization program (#2347).

## Why

The pin was **~37 minors behind** (0.78.0 → 0.115.0) and its types predated `xhigh`, which forced a cast in #2346 to send a wire value the API accepts:

```ts
// old SDK 0.78
effort?: 'low' | 'medium' | 'high' | 'max' | null;   // no xhigh
// new SDK 0.115
effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | null;   // matches the API enum
```

The cast is **deleted** — root cause fixed, not worked around. `ci:check:full` passing without it is what proves the types now accept `xhigh` natively.

## The bump needed no other code changes

Only **4 files** import the SDK, all using stable core types (`Anthropic`, `ClientOptions`, `MessageCreateParamsStreaming`, `ContentBlockParam`, `MessageParam`). My concern in #2343 that this "touches every Anthropic call path" was overcautious — worth stating plainly since it changes the risk estimate for the rest of #2347.

Diff is 3 files: `bun.lock`, `packages/ai/package.json`, and the cast removal.

## Verified beyond typecheck

Compiling proves nothing about the wire, so all of this ran **live against the F5 gateway with the new SDK**:

| Check | Result |
|---|---|
| adaptive thinking + `effort=xhigh` | ✅ |
| `effort=max` | ✅ |
| streaming | ✅ `stop=end_turn` |
| `count_tokens` | ✅ |
| tool use | ✅ `stop=tool_use` |
| 1M-context beta header | ✅ |
| **prompt caching** | ✅ 11,703 tokens written, then read back |

`bun run ci:check:full` exit 0 · pi-ai **610/610** · lint clean.

## On the coding-agent suite — read this before trusting a red run

The full `coding-agent` suite fails **a different random subset every run**, all timeouts. I ran a **control on pristine `main` with the OLD SDK** and it fails too:

| Run | SDK | Result | Failures |
|---|---|---|---|
| A | 0.115 | 5777/0 | — |
| B | 0.115 | 5777/1 | `modelPattern` @ 5103ms |
| C | 0.115 | 5773/4 | 4× `createAgentSession` @ 5031–5497ms |
| **D (control)** | **0.78** | **5774/3** | manager/worker ×3 @ 9702–21608ms |

Disjoint sets, all at timeout boundaries, passing in isolation → **pre-existing contention, not this bump**. Filed as **#2352**, because it masks real regressions and shouldn't keep being written off as noise. It also means my "5777/5777" claim in #2346 was one lucky run, not a baseline.

Closes #2343
Refs #2347