### PR TITLE
chore(deps): PR A — six independent majors, batched (genai 2, ACP 1.3, marked 18, diff 9, lucide-react 1, lint-staged 17)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -2,7 +2,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"correctness": {
 				"noUnusedImports": "error",
 				"noVoidTypeReturn": "off"

--- a/bun.lock
+++ b/bun.lock
@@ -80,7 +80,7 @@
         "xcsh": "src/cli.ts",
       },
       "dependencies": {
-        "@agentclientprotocol/sdk": "0.16.1",
+        "@agentclientprotocol/sdk": "1.3.0",
         "@f5-sales-demo/pi-agent-core": "workspace:*",
         "@f5-sales-demo/pi-ai": "workspace:*",
         "@f5-sales-demo/pi-natives": "workspace:*",
@@ -261,7 +261,7 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 
-    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.16.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.3.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.115.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
       "version": "0.1.0",
       "dependencies": {
         "dompurify": "^3",
-        "marked": "^17",
+        "marked": "^18",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.10.6",
@@ -202,7 +202,7 @@
       "dependencies": {
         "@f5-sales-demo/pi-natives": "workspace:*",
         "@f5-sales-demo/pi-utils": "workspace:*",
-        "marked": "^17.0",
+        "marked": "^18.0",
       },
       "devDependencies": {
         "@xterm/headless": "^6.0",
@@ -1133,7 +1133,7 @@
 
     "mammoth": ["mammoth@1.12.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.6", "argparse": "~1.0.3", "base64-js": "^1.5.1", "bluebird": "~3.4.0", "dingbat-to-unicode": "^1.0.1", "jszip": "^3.7.1", "lop": "^0.4.2", "path-is-absolute": "^1.0.0", "underscore": "^1.13.1", "xmlbuilder": "^10.0.0" }, "bin": { "mammoth": "bin/mammoth" } }, "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w=="],
 
-    "marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
+    "marked": ["marked@18.0.7", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA=="],
 
     "markit-ai": ["markit-ai@0.5.3", "", { "dependencies": { "chalk": "^5.6.2", "commander": "^14.0.3", "exifr": "^7.1.3", "fast-xml-parser": "^5.5.9", "jszip": "^3.10.1", "mammoth": "^1.9.0", "mupdf": "^1.27.0", "music-metadata": "^11.12.3", "rss-parser": "^3.13.0", "turndown": "^7.2.0", "turndown-plugin-gfm": "^1.0.2" }, "bin": { "markit": "dist/main.js" } }, "sha512-h4nhn6a/SNXEdc3kLVtL37TspxjUNCNL0OM7LRWxd389ZByI/B7bjNNgxFdVAT0O+H7ZekSwLdVe/lws1l2AZQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
         "@aws-sdk/client-bedrock-runtime": "^3",
         "@bufbuild/protobuf": "^2.11",
         "@f5-sales-demo/pi-utils": "workspace:*",
-        "@google/genai": "^1.43",
+        "@google/genai": "^2.13",
         "@sinclair/typebox": "^0.34",
         "@smithy/node-http-handler": "^4.4",
         "ajv": "^8.20",
@@ -407,7 +407,7 @@
 
     "@f5-sales-demo/xcsh-stats": ["@f5-sales-demo/xcsh-stats@workspace:packages/stats"],
 
-    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
+    "@google/genai": ["@google/genai@2.13.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-GM7C8Kaomvjz05x5JEO6+l3d/pciL9LxAG9dUjJLD7nTPZ9X0Cfsf2Z7eET6UjgWyUmxXCHtYnQoQ77F9+ZIOQ=="],
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.11.1" } }, "sha512-1C0wwHiyMlEdsbrJqff5ORE2PwaXBOam5rMqkZVOReAezd5nt6Tl/WGg28UAo75Ziuwchs0KaF8lvnn2oAtvJA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -371,7 +371,7 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
-    "@f5-sales-demo/i18n-core": ["@f5-sales-demo/i18n-core@1.0.28", "", {}, "sha512-6hSqtT/Khp++/OuS0OtDaFadrb/KIgmgjSt7QUAsjjBs8JPgxi9mvLE2dACQ3lIAk/4zdzFPlfobIZjPiVUiGQ=="],
+    "@f5-sales-demo/i18n-core": ["@f5-sales-demo/i18n-core@1.0.29", "", {}, "sha512-telSznQZEK+vdvGFKEBJ/YWX7eEAWGxrKtA0TuQX1dU7oIWSoqVGJ2C0GB1pKjxR3Br80pHaZ/9kJYEzUGfOOA=="],
 
     "@f5-sales-demo/pi-agent-core": ["@f5-sales-demo/pi-agent-core@workspace:packages/agent"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -93,7 +93,7 @@
         "@xterm/headless": "^6.0",
         "ajv": "^8.20",
         "chalk": "^5.6",
-        "diff": "^8.0",
+        "diff": "^9.0",
         "fflate": "0.8.3",
         "handlebars": "^4.7",
         "linkedom": "^0.18",
@@ -225,7 +225,7 @@
         "@f5-sales-demo/pi-tui": "workspace:*",
         "@f5-sales-demo/pi-utils": "workspace:*",
         "@f5-sales-demo/xcsh": "workspace:*",
-        "diff": "^8.0",
+        "diff": "^9.0",
         "prettier": "^3.8",
         "regexp-tree": "^0.1",
       },
@@ -861,7 +861,7 @@
 
     "diagnostic-channel-publishers": ["diagnostic-channel-publishers@0.4.4", "", { "peerDependencies": { "diagnostic-channel": "*" } }, "sha512-l126t01d2ZS9EreskvEtZPrcgstuvH3rbKy82oUhUrVmBaGx4hO9wECdl3cvZbKDYjMF3QJDB5z5dL9yWAjvZQ=="],
 
-    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "dingbat-to-unicode": ["dingbat-to-unicode@1.0.1", "", {}, "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@bufbuild/protoc-gen-es": "^2.11",
         "@types/bun": "^1.3",
         "@typescript/native-preview": "^7.0.0-dev.20260302.1",
-        "lint-staged": "^16.3",
+        "lint-staged": "^17.2",
         "prettier": "^3.8",
         "yaml": "2.9.0",
       },
@@ -717,11 +717,9 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
-
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
 
@@ -790,10 +788,6 @@
     "chart.js": ["chart.js@4.5.1", "", { "dependencies": { "@kurkle/color": "^0.3.0" } }, "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw=="],
 
     "chromium-bidi": ["chromium-bidi@14.0.0", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw=="],
-
-    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
-
-    "cli-truncate": ["cli-truncate@5.2.0", "", { "dependencies": { "slice-ansi": "^8.0.0", "string-width": "^8.2.0" } }, "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw=="],
 
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
@@ -889,7 +883,7 @@
 
     "emnapi": ["emnapi@1.11.2", "", { "peerDependencies": { "node-addon-api": ">= 6.1.0" }, "optionalPeers": ["node-addon-api"] }, "sha512-iMt/XQc69fFn2EvcU6tm14HmXKwyy0lnABugsQlqp6xFuZIUuO+ONVSg2mz+MTVF8WbC+bic65AvRXdoldALKg=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
 
@@ -900,8 +894,6 @@
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
-
-    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
@@ -926,8 +918,6 @@
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
-
-    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
 
@@ -983,8 +973,6 @@
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
-    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
-
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
@@ -1039,7 +1027,7 @@
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
@@ -1109,11 +1097,7 @@
 
     "linkedom": ["linkedom@0.18.13", "", { "dependencies": { "css-select": "^7.0.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.1.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw=="],
 
-    "lint-staged": ["lint-staged@16.4.0", "", { "dependencies": { "commander": "^14.0.3", "listr2": "^9.0.5", "picomatch": "^4.0.3", "string-argv": "^0.3.2", "tinyexec": "^1.0.4", "yaml": "^2.8.2" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw=="],
-
-    "listr2": ["listr2@9.0.5", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
-
-    "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
+    "lint-staged": ["lint-staged@17.2.0", "", { "dependencies": { "picomatch": "^4.0.5", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-FchGnFe4i4B1C/a35SPU9bNGPEHSC1+1iV0plLjzBmKVe9klZrlRfSgK6Cw4VeHyqOXbJUXP0vON61uRftNQ0A=="],
 
     "logform": ["logform@2.7.0", "", { "dependencies": { "@colors/colors": "1.6.0", "@types/triple-beam": "^1.3.2", "fecha": "^4.2.0", "ms": "^2.1.1", "safe-stable-stringify": "^2.3.1", "triple-beam": "^1.3.0" } }, "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ=="],
 
@@ -1144,8 +1128,6 @@
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
-    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
@@ -1190,8 +1172,6 @@
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "one-time": ["one-time@1.0.0", "", { "dependencies": { "fn.name": "1.x.x" } }, "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g=="],
-
-    "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "openai": ["openai@6.49.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg=="],
 
@@ -1273,11 +1253,7 @@
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
-    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
-
     "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
-
-    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
@@ -1303,8 +1279,6 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
-
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
     "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
@@ -1327,11 +1301,11 @@
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
-    "string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
@@ -1429,7 +1403,7 @@
 
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
-    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -1487,12 +1461,6 @@
 
     "chromium-bidi/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
     "cls-hooked/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
     "diagnostic-channel/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
@@ -1519,8 +1487,6 @@
 
     "jwa/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
-    "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
-
     "mammoth/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
@@ -1533,23 +1499,17 @@
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
-    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "rss-parser/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
-    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
     "util/inherits": ["inherits@2.0.3", "", {}, "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="],
 
-    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
-
-    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@f5-sales-demo/xcsh-stats/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -1561,12 +1521,6 @@
 
     "@napi-rs/tar-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
-    "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
     "htmlparser2/domutils/dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
     "jszip/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
@@ -1577,19 +1531,13 @@
 
     "office-addin-manifest/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 
-    "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "cliui/wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+    "wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "htmlparser2/domutils/dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "office-addin-manifest/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 
-    "cliui/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+    "wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "office-addin-manifest/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
   }

--- a/bun.lock
+++ b/bun.lock
@@ -167,7 +167,7 @@
         "@tailwindcss/node": "^4.2",
         "chart.js": "^4.5",
         "date-fns": "~4.4.0",
-        "lucide-react": "^0.576",
+        "lucide-react": "^1.26",
         "react": "^19.2",
         "react-chartjs-2": "^5.3",
         "react-dom": "^19.2",
@@ -1125,7 +1125,7 @@
 
     "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
-    "lucide-react": ["lucide-react@0.576.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug=="],
+    "lucide-react": ["lucide-react@1.26.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-raglYVR2+VkMfJL158krjVmE+rV5ST2lzA/KQm1FRSjMHT4MnWaegHxoVEpmc2So3nOEhp9oGejJwAPX8MoAjg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"@bufbuild/protoc-gen-es": "^2.11",
 		"@types/bun": "^1.3",
 		"@typescript/native-preview": "^7.0.0-dev.20260302.1",
-		"lint-staged": "^16.3",
+		"lint-staged": "^17.2",
 		"prettier": "^3.8",
 		"yaml": "2.9.0"
 	},

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -44,7 +44,7 @@
 		"@anthropic-ai/sdk": "^0.115",
 		"@aws-sdk/client-bedrock-runtime": "^3",
 		"@bufbuild/protobuf": "^2.11",
-		"@google/genai": "^1.43",
+		"@google/genai": "^2.13",
 		"@f5-sales-demo/pi-utils": "workspace:*",
 		"@sinclair/typebox": "^0.34",
 		"@smithy/node-http-handler": "^4.4",

--- a/packages/chat-ui/package.json
+++ b/packages/chat-ui/package.json
@@ -38,7 +38,7 @@
 	},
 	"dependencies": {
 		"dompurify": "^3",
-		"marked": "^17"
+		"marked": "^18"
 	},
 	"peerDependencies": {
 		"react": ">=18"

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -54,7 +54,7 @@
 		"check-workflow-field-coverage": "bun scripts/check-workflow-field-coverage.ts"
 	},
 	"dependencies": {
-		"@agentclientprotocol/sdk": "0.16.1",
+		"@agentclientprotocol/sdk": "1.3.0",
 		"@mozilla/readability": "^0.6",
 		"@f5-sales-demo/xcsh-stats": "workspace:*",
 		"@f5-sales-demo/pi-agent-core": "workspace:*",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -67,7 +67,7 @@
 		"@xterm/headless": "^6.0",
 		"ajv": "^8.20",
 		"chalk": "^5.6",
-		"diff": "^8.0",
+		"diff": "^9.0",
 		"fflate": "0.8.3",
 		"handlebars": "^4.7",
 		"linkedom": "^0.18",

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -25,14 +25,11 @@ import {
 	type ResumeSessionResponse,
 	type SessionConfigOption,
 	type SessionInfo,
-	type SessionModelState,
 	type SessionModeState,
 	type SessionNotification,
 	type SessionUpdate,
 	type SetSessionConfigOptionRequest,
 	type SetSessionConfigOptionResponse,
-	type SetSessionModelRequest,
-	type SetSessionModelResponse,
 	type SetSessionModeRequest,
 	type SetSessionModeResponse,
 	type Usage,
@@ -201,7 +198,6 @@ export class AcpAgent implements Agent {
 		const response: NewSessionResponse = {
 			sessionId: record.session.sessionId,
 			configOptions: this.#buildConfigOptions(record.session),
-			models: this.#buildModelState(record.session),
 			modes: this.#buildModeState(),
 		};
 		this.#scheduleBootstrapUpdates(record.session.sessionId);
@@ -214,7 +210,6 @@ export class AcpAgent implements Agent {
 		await this.#replaySessionHistory(record);
 		const response: LoadSessionResponse = {
 			configOptions: this.#buildConfigOptions(record.session),
-			models: this.#buildModelState(record.session),
 			modes: this.#buildModeState(),
 		};
 		this.#scheduleBootstrapUpdates(record.session.sessionId);
@@ -238,12 +233,11 @@ export class AcpAgent implements Agent {
 		};
 	}
 
-	async unstable_resumeSession(params: ResumeSessionRequest): Promise<ResumeSessionResponse> {
+	async resumeSession(params: ResumeSessionRequest): Promise<ResumeSessionResponse> {
 		this.#assertAbsoluteCwd(params.cwd);
 		const record = await this.#resumeManagedSession(params.sessionId, params.cwd, params.mcpServers ?? []);
 		const response: ResumeSessionResponse = {
 			configOptions: this.#buildConfigOptions(record.session),
-			models: this.#buildModelState(record.session),
 			modes: this.#buildModeState(),
 		};
 		this.#scheduleBootstrapUpdates(record.session.sessionId);
@@ -256,14 +250,13 @@ export class AcpAgent implements Agent {
 		const response: ForkSessionResponse = {
 			sessionId: record.session.sessionId,
 			configOptions: this.#buildConfigOptions(record.session),
-			models: this.#buildModelState(record.session),
 			modes: this.#buildModeState(),
 		};
 		this.#scheduleBootstrapUpdates(record.session.sessionId);
 		return response;
 	}
 
-	async unstable_closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {
+	async closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {
 		const record = this.#sessions.get(params.sessionId);
 		if (!record) {
 			return {};
@@ -317,19 +310,6 @@ export class AcpAgent implements Agent {
 		return { configOptions };
 	}
 
-	async unstable_setSessionModel(params: SetSessionModelRequest): Promise<SetSessionModelResponse> {
-		const record = this.#getSessionRecord(params.sessionId);
-		await this.#setModelById(record.session, params.modelId);
-		await this.#connection.sessionUpdate({
-			sessionId: record.session.sessionId,
-			update: {
-				sessionUpdate: "config_option_update",
-				configOptions: this.#buildConfigOptions(record.session),
-			},
-		});
-		return {};
-	}
-
 	async prompt(params: PromptRequest): Promise<PromptResponse> {
 		const record = this.#getSessionRecord(params.sessionId);
 		if (record.promptTurn && !record.promptTurn.settled) {
@@ -339,7 +319,7 @@ export class AcpAgent implements Agent {
 		const converted = this.#convertPromptBlocks(params.prompt);
 		const pendingPrompt = Promise.withResolvers<PromptResponse>();
 		record.promptTurn = {
-			userMessageId: params.messageId ?? crypto.randomUUID(),
+			userMessageId: crypto.randomUUID(),
 			cancelRequested: false,
 			settled: false,
 			usageBaseline: this.#cloneUsageStatistics(record.session.sessionManager.getUsageStatistics()),
@@ -371,7 +351,6 @@ export class AcpAgent implements Agent {
 			this.#finishPrompt(record, {
 				stopReason: "cancelled",
 				usage: this.#buildTurnUsage(promptTurn.usageBaseline, record.session.sessionManager.getUsageStatistics()),
-				userMessageId: promptTurn.userMessageId,
 			});
 		} catch (error: unknown) {
 			this.#finishPrompt(record, undefined, error);
@@ -563,7 +542,6 @@ export class AcpAgent implements Agent {
 			this.#finishPrompt(record, {
 				stopReason: promptTurn.cancelRequested ? "cancelled" : "end_turn",
 				usage: this.#buildTurnUsage(promptTurn.usageBaseline, record.session.sessionManager.getUsageStatistics()),
-				userMessageId: promptTurn.userMessageId,
 			});
 		}
 	}
@@ -672,28 +650,6 @@ export class AcpAgent implements Agent {
 			options: this.#buildThinkingOptions(session),
 		});
 		return configOptions;
-	}
-
-	#buildModelState(session: AgentSession): SessionModelState | undefined {
-		const models = session.getAvailableModels();
-		if (models.length === 0) {
-			return undefined;
-		}
-
-		const availableModels = models.map(model => ({
-			modelId: this.#toModelId(model),
-			name: model.name,
-			description: `${model.provider}/${model.id}`,
-		}));
-		const currentModelId = session.model ? this.#toModelId(session.model) : availableModels[0]?.modelId;
-		if (!currentModelId) {
-			return undefined;
-		}
-
-		return {
-			availableModels,
-			currentModelId,
-		};
 	}
 
 	#buildThinkingOptions(session: AgentSession): Array<{ value: string; name: string; description?: string }> {
@@ -1264,6 +1220,15 @@ export class AcpAgent implements Agent {
 				headers: this.#toNameValueMap(server.headers),
 			};
 		}
+		// ACP 1.x added an `acp` transport, whose descriptor carries a serverId
+		// instead of a url/headers pair. We never opt into it -- `initialize`
+		// advertises only `mcpCapabilities.http` and `.sse` -- so reject it
+		// explicitly rather than letting it fall through to the sse branch.
+		if (server.type === "acp") {
+			throw new Error(
+				`Unsupported MCP transport "acp" for server "${server.name}": xcsh advertises only http and sse`,
+			);
+		}
 		return {
 			type: "sse",
 			url: server.url,
@@ -1301,7 +1266,6 @@ export class AcpAgent implements Agent {
 		this.#finishPrompt(record, {
 			stopReason: "cancelled",
 			usage: this.#buildTurnUsage(promptTurn.usageBaseline, record.session.sessionManager.getUsageStatistics()),
-			userMessageId: promptTurn.userMessageId,
 		});
 	}
 

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -2,7 +2,8 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AgentSideConnection, PromptRequest, SessionNotification } from "@agentclientprotocol/sdk";
+import type { PromptRequest, SessionNotification } from "@agentclientprotocol/sdk";
+import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk";
 import type { Model } from "@f5-sales-demo/pi-ai";
 import { getConfigRootDir, setAgentDir } from "@f5-sales-demo/pi-utils";
 import { AcpAgent } from "../src/modes/acp/acp-agent";
@@ -289,13 +290,20 @@ describe("ACP agent", () => {
 		const first = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
 		const second = await harness.agent.newSession({ cwd: harness.cwdB, mcpServers: [] });
 
-		expect(first.models?.availableModels.map(model => model.modelId)).toEqual(
+		// ACP 1.x removed SessionModelState and the session/set_model method; model
+		// choice is now advertised and changed through the `model` config option.
+		const modelOption = first.configOptions?.find(option => option.category === "model");
+		expect(modelOption?.type).toBe("select");
+		// 1.x also widened select options to `Option[] | Group[]`; we emit flat options.
+		const modelChoices = modelOption?.type === "select" ? modelOption.options : [];
+		expect(modelChoices.flatMap(choice => ("value" in choice ? [choice.value] : []))).toEqual(
 			TEST_MODELS.map(model => `${model.provider}/${model.id}`),
 		);
 
-		await harness.agent.unstable_setSessionModel({
+		await harness.agent.setSessionConfigOption({
 			sessionId: first.sessionId,
-			modelId: `${TEST_MODELS[1]!.provider}/${TEST_MODELS[1]!.id}`,
+			configId: "model",
+			value: `${TEST_MODELS[1]!.provider}/${TEST_MODELS[1]!.id}`,
 		});
 		await harness.agent.setSessionConfigOption({
 			sessionId: first.sessionId,
@@ -323,7 +331,7 @@ describe("ACP agent", () => {
 		expect(forked.sessionId).not.toBe(first.sessionId);
 		expect(forkedMessages.some(message => message.role === "user" && message.content === "fork me")).toBe(true);
 
-		await harness.agent.unstable_closeSession({ sessionId: forked.sessionId });
+		await harness.agent.closeSession({ sessionId: forked.sessionId });
 		await expect(harness.agent.setSessionMode({ sessionId: forked.sessionId, modeId: "default" })).rejects.toThrow(
 			"Unsupported ACP session",
 		);
@@ -365,14 +373,16 @@ describe("ACP agent", () => {
 		const live = await harness.agent.newSession({ cwd: harness.cwdB, mcpServers: [] });
 		const response = await harness.agent.prompt({
 			sessionId: live.sessionId,
-			messageId: "05b17a6f-b310-4be7-b767-6b4f3a84eb63",
 			prompt: [{ type: "text", text: "ping" }],
 		} as PromptRequest);
 
 		const liveChunks = harness.updates.filter(
 			update => update.sessionId === live.sessionId && update.update.sessionUpdate === "agent_message_chunk",
 		);
-		expect(response.userMessageId).toBe("05b17a6f-b310-4be7-b767-6b4f3a84eb63");
+		// ACP 1.x removed PromptRequest.messageId and PromptResponse.userMessageId,
+		// so the turn ID is agent-generated and no longer echoed. ContentChunk
+		// .messageId survives, so assert the invariant that still matters: every
+		// chunk in the turn carries one and the same generated ID.
 		expect(response.usage).toEqual({
 			inputTokens: 10,
 			outputTokens: 5,
@@ -385,8 +395,144 @@ describe("ACP agent", () => {
 				update => typeof getChunkMessageId(update) === "string" && getChunkMessageId(update)!.length > 0,
 			),
 		).toBe(true);
+		expect(new Set(liveChunks.map(update => getChunkMessageId(update))).size).toBe(1);
 
 		harness.abortController.abort();
 		await Bun.sleep(0);
+	});
+});
+
+/**
+ * The tests above invoke `AcpAgent` members directly on the class. That cannot
+ * catch a whole class of breakage: the SDK dispatches JSON-RPC by looking up
+ * *specific* member names, and most session-lifecycle members are declared
+ * **optional** on `Agent`. If one is renamed upstream, our class still
+ * typechecks and its direct-call tests still pass, while the wire method
+ * quietly starts returning "method not found" — even though `initialize` keeps
+ * advertising the capability.
+ *
+ * These tests speak real newline-delimited JSON-RPC over a real
+ * `AgentSideConnection`, so an advertised-but-undispatchable capability fails.
+ */
+const METHOD_NOT_FOUND = -32601;
+/** Our agent routes methods outside AGENT_METHODS to `extMethod`, which we do not implement. */
+const INTERNAL_ERROR = -32603;
+
+interface JsonRpcResponse {
+	id: number;
+	result?: unknown;
+	error?: { code: number; message: string };
+}
+
+async function* readNdJsonLines(readable: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+	const reader = readable.getReader();
+	const decoder = new TextDecoder();
+	let buffered = "";
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) {
+			return;
+		}
+		buffered += decoder.decode(value, { stream: true });
+		let newline = buffered.indexOf("\n");
+		while (newline !== -1) {
+			const line = buffered.slice(0, newline).trim();
+			buffered = buffered.slice(newline + 1);
+			if (line) {
+				yield line;
+			}
+			newline = buffered.indexOf("\n");
+		}
+	}
+}
+
+async function createWireHarness(): Promise<{
+	request: (method: string, params: unknown) => Promise<JsonRpcResponse>;
+	cwd: string;
+}> {
+	const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "xcsh-acp-wire-"));
+	cleanupRoots.push(root);
+	const agentDir = path.join(root, "agent");
+	const cwd = path.join(root, "cwd");
+	await fs.promises.mkdir(agentDir, { recursive: true });
+	await fs.promises.mkdir(cwd, { recursive: true });
+	setAgentDir(agentDir);
+
+	const clientToAgent = new TransformStream<Uint8Array, Uint8Array>();
+	const agentToClient = new TransformStream<Uint8Array, Uint8Array>();
+	// `ndJsonStream(output, input)`: first arg is what the agent WRITES to, second
+	// is what it READS from — matching runAcpMode's wiring.
+	const transport = ndJsonStream(agentToClient.writable, clientToAgent.readable);
+	const initial = new FakeAgentSession(cwd);
+	new AgentSideConnection(
+		conn =>
+			new AcpAgent(conn, initial as unknown as AgentSession, async next => {
+				return new FakeAgentSession(next) as unknown as AgentSession;
+			}),
+		transport,
+	);
+
+	const writer = clientToAgent.writable.getWriter();
+	const lines = readNdJsonLines(agentToClient.readable);
+	let nextId = 1;
+
+	return {
+		cwd,
+		request: async (method, params) => {
+			const id = nextId++;
+			await writer.write(new TextEncoder().encode(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`));
+			for (;;) {
+				const next = await lines.next();
+				if (next.done) {
+					throw new Error(`connection closed before a response to ${method}`);
+				}
+				const message = JSON.parse(next.value) as Partial<JsonRpcResponse>;
+				// Skip notifications (no `id`) and responses to earlier requests.
+				if (message.id === id) {
+					return message as JsonRpcResponse;
+				}
+			}
+		},
+	};
+}
+
+describe("ACP dispatch over a real AgentSideConnection", () => {
+	it("dispatches every session capability advertised by initialize", async () => {
+		const wire = await createWireHarness();
+
+		const init = await wire.request("initialize", { protocolVersion: 1, clientCapabilities: {} });
+		expect(init.error).toBeUndefined();
+		const advertised = (init.result as { agentCapabilities?: { sessionCapabilities?: Record<string, unknown> } })
+			.agentCapabilities?.sessionCapabilities;
+		// Guard the premise: if we stop advertising these, this test is moot.
+		expect(Object.keys(advertised ?? {}).sort()).toEqual(["close", "fork", "list", "resume"]);
+
+		const created = await wire.request("session/new", { cwd: wire.cwd, mcpServers: [] });
+		expect(created.error).toBeUndefined();
+		const sessionId = (created.result as { sessionId: string }).sessionId;
+
+		// A capability we advertise but cannot dispatch is exactly what a
+		// renamed-but-optional `Agent` member produces.
+		const calls: Array<[string, unknown]> = [
+			["session/list", {}],
+			["session/resume", { sessionId, cwd: wire.cwd, mcpServers: [] }],
+			["session/fork", { sessionId, cwd: wire.cwd, mcpServers: [] }],
+			["session/close", { sessionId }],
+		];
+		for (const [method, params] of calls) {
+			const response = await wire.request(method, params);
+			expect(response.error?.code, `${method} must be dispatchable`).not.toBe(METHOD_NOT_FOUND);
+		}
+	});
+
+	it("does not silently succeed for a method outside AGENT_METHODS (control)", async () => {
+		const wire = await createWireHarness();
+		await wire.request("initialize", { protocolVersion: 1, clientCapabilities: {} });
+
+		const response = await wire.request("session/definitely_not_a_method", {});
+		// Unknown methods fall through to `extMethod`, which we do not implement,
+		// so this proves the wire is live and errors rather than no-ops.
+		expect(response.error?.code).toBe(INTERNAL_ERROR);
+		expect(response.result).toBeUndefined();
 	});
 });

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -42,7 +42,7 @@
 		"@tailwindcss/node": "^4.2",
 		"chart.js": "^4.5",
 		"date-fns": "~4.4.0",
-		"lucide-react": "^0.576",
+		"lucide-react": "^1.26",
 		"react": "^19.2",
 		"react-chartjs-2": "^5.3",
 		"react-dom": "^19.2"

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -39,7 +39,7 @@
 	"dependencies": {
 		"@f5-sales-demo/pi-natives": "workspace:*",
 		"@f5-sales-demo/pi-utils": "workspace:*",
-		"marked": "^17.0"
+		"marked": "^18.0"
 	},
 	"devDependencies": {
 		"chalk": "^5.6",

--- a/packages/typescript-edit-benchmark/package.json
+++ b/packages/typescript-edit-benchmark/package.json
@@ -33,7 +33,7 @@
 		"@f5-sales-demo/pi-agent-core": "workspace:*",
 		"@f5-sales-demo/xcsh": "workspace:*",
 		"@f5-sales-demo/pi-utils": "workspace:*",
-		"diff": "^8.0",
+		"diff": "^9.0",
 		"prettier": "^3.8",
 		"regexp-tree": "^0.1",
 		"@f5-sales-demo/pi-ai": "workspace:*",


### PR DESCRIPTION
Closes #2369. Closes #2357. Batch of #2347.

Eight commits, **one per dependency**, so any CI failure is bisectable locally without another ~20-minute round trip.

## Why batched

Every dependency PR touches `bun.lock` and so cannot overlap. Shipping these one at a time meant six sequential CI runs for changes that touch disjoint subsystems. Batched here on request.

Two majors were **removed from this batch** after research:

- **`puppeteer` 25.3** → its own PR, held. Bundled Chrome jumps 148 → 150, which can silently regress the 14 stealth scripts in `tools/browser.ts`, and the UA greased-brand permutation is derived from `majorVersion % 6`. **CI cannot verify any of it** — every browser test is `describe.skipIf(isCI)` and `XCSH_VISUAL` appears zero times in `ci.yml`. Since green CI auto-merges here, that must not ride along.
- **`@babel/*` 8** → #2363, blocked. `require("@babel/generator/lib/nodes")` is gone (subpath absent *and* the `exports` map blocks it) with no documented replacement, and the `TSTypeCastExpression` gap it patches still exists in 8.

## Contents

| Commit | Bump | Source edits |
|---|---|---|
| `54890f3` | `diff` 8.0.4 → 9.0.0 | none |
| `e6ccf43` | `marked` 17.0.6 → 18.0.7 | none |
| `3ac0e6c` | `lucide-react` 0.576.0 → 1.26.0 | none |
| `fd22cee` | `lint-staged` 16.4.0 → 17.2.0 | none |
| `fd50997` | `@google/genai` 1.52.0 → 2.13.0 | none |
| `f5c291b` | `biome.json` `recommended` → `preset` | config |
| `d70f007` | `@agentclientprotocol/sdk` 0.16.1 → 1.3.0 | **yes** |
| `2c8a42c` | `@f5-sales-demo/i18n-core` → 1.0.29 | none |

Six of eight are lockfile/range-only. Full reasoning is in each commit message.

## The one that mattered: an ACP break green CI could not catch

`unstable_resumeSession` → `resumeSession` and `unstable_closeSession` → `closeSession` (stabilised upstream in 0.20.0). These are **optional** members on `Agent`, so our class kept typechecking under the old names — while 1.3's dispatcher registers handlers via `if (implementation.resumeSession)`. `session/resume` and `session/close` would have returned method-not-found at runtime while `initialize` kept advertising `sessionCapabilities.resume`/`close`.

**Zero type errors. Zero pre-existing test failures.** The existing tests could not detect it because they invoke members directly on the class through a hand-faked `AgentSideConnection`, bypassing the dispatcher.

Caught with a new test, **written failing first**, that speaks real newline-delimited JSON-RPC over a real `AgentSideConnection` + `ndJsonStream` pair and asserts every capability `initialize` advertises is actually dispatchable:

- Before the rename → fails, `session/resume must be dispatchable`, `-32601`
- After → passes
- **Mutation-verified**: restoring `unstable_resumeSession` fails it again

It also has a control asserting an unknown method still errors, so the assertion can't pass vacuously.

The other four ACP changes were compile errors and therefore self-announcing: `session/set_model` + `SessionModelState` removed (model choice already flows through `setSessionConfigOption` category `model`), `models` dropped from four session responses, `PromptRequest.messageId`/`PromptResponse.userMessageId` removed, and `McpServer` gaining an `acp` variant that broke `#toMcpConfig`'s narrowing — rejected explicitly rather than falling through to `sse`, since we advertise only `http` and `sse`.

## Verification

- `bun run ci:check:full` → **exit 0**
- `bun install --frozen-lockfile` → **exit 0**
- `bun outdated --filter '*'` now reports **only** `puppeteer`, `@babel/*`, and the React 19 cluster — i.e. exactly the deferred work

| Workspace | Result |
|---|---|
| coding-agent | **5790 pass, 541 skip, 0 fail** (6331 tests / 547 files) |
| pi-ai | 621 pass, 0 fail |
| pi-tui | 474 pass, 0 fail |
| office-pane | 340 pass, 0 fail |
| chat-ui | 143 + 78 pass, 0 fail |
| pi-utils | 201 pass, 0 fail |
| resource-management | 141 pass, 0 fail |
| pi-agent-core | 30 pass, 0 fail |
| typescript-edit-benchmark | 12 pass, 0 fail |

Each suite was run via **its own package script** — three of them (`chat-ui`, `pi-tui`, `office-pane`) require DOM/preload flags that a bare `bun test` skips, which produces false failures.

Per #2352 the coding-agent suite is non-deterministic, so the clean run above is corroboration rather than proof; the load-bearing evidence is the targeted runs plus the mutation test.

### Non-obvious verifications

- **biome `preset` migration proven behaviourally, not asserted.** A temporary probe violating six recommended rules across two groups produced a byte-identical diagnostic set before and after (`noDuplicateObjectKeys`, `noDoubleEquals`, `noDebugger`, `noAsyncPromiseExecutor`, `noUnusedVariables`, `noUnsafeOptionalChaining`). Probe deleted; zero `DEPRECATED` diagnostics remain.
- **`lint-staged` 17 exercised live**, since it has no test coverage and never runs in CI. A real partially-staged commit confirmed biome's `--write` landed in the commit, the unstaged hunk survived, and `git stash list` was empty afterwards — the last one matters because this repo shares a stash stack across worktrees. Pinned `^17.2`, not `^17.0`: 17.0.x regressed staging, fixed in 17.0.6.
- **`marked` 18 goldens did not drift.** `fidelity.test.ts` includes a `gen-md-goldens --check` drift guard, so that is a positive signal, not merely an absent one. No golden was regenerated. `tsgo` also accepts marked's TS-6-emitted declarations.
- **`@google/genai` enum shapes confirmed at runtime**, not just by typecheck: `FinishReason` still has exactly 17 members matching the 17 cases in `mapStopReason`, whose `never` exhaustiveness guard would fail to compile on any add *or* remove — so the green typecheck is load-bearing here.

## Known verification limit, stated plainly

**`@google/genai` has no real test coverage.** `google.ts` and `google-vertex.ts` are the only files that construct a `GoogleGenAI` client, and no test references `streamGoogle`/`streamGoogleVertex` — the existing Google tests exercise the hand-rolled HTTP path in `google-gemini-cli.ts`, which never touches the SDK client. Client construction and the streaming loop are covered by the typecheck and the enum checks above, not by tests. A live gateway smoke test remains the only real signal for those paths.

Similarly, `packages/stats` has zero tests, so `lucide-react` rests on the typecheck plus a dashboard build smoke (both green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)