### PR TITLE
fix(coding-agent): make herdr accept xcsh session refs so panes resume

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/bundled/herdr-reporter.ts
+++ b/packages/coding-agent/src/extensibility/extensions/bundled/herdr-reporter.ts
@@ -29,6 +29,24 @@ import type { ExtensionAPI, ExtensionContext } from "@f5-sales-demo/xcsh";
  * The extension is completely inert unless it is running inside a herdr pane
  * (detected via `HERDR_PANE_ID`), so it has zero effect for users who do not run
  * xcsh under herdr.
+ *
+ * Sequencing contract with herdr — do not regress. herdr keeps one monotonic
+ * `seq` per *source*, shared across every method, and silently discards any frame
+ * whose `seq` is not greater than the last it accepted for `herdr:xcsh`. Two
+ * consequences drive the design below, and both previously cost panes their
+ * resume reference:
+ *
+ *   1. `seq` is seeded from the wall clock, not 0, so a restarted xcsh always
+ *      outranks its predecessor in the same pane. With a per-process counter from
+ *      0, every frame from the second xcsh in a pane looks stale and is dropped.
+ *   2. Frames go out one at a time through `enqueue`. They used to be
+ *      fire-and-forget on independent sockets, so ordering was left to chance.
+ *   3. The state frame is always sent *before* the session frame. herdr discards a
+ *      `pane.report_agent_session` for a pane whose agent it does not yet own, so
+ *      the state frame has to establish `herdr:xcsh` as the pane's agent first.
+ *      Verified against a live herdr: session-then-state (even with a correctly
+ *      ascending `seq`) leaves `agent_session` null, while state-then-session
+ *      records it.
  */
 
 const HERDR_AGENT_LABEL = "xcsh";
@@ -42,26 +60,43 @@ const SOCKET_TIMEOUT_MS = 2000;
 
 /**
  * Write one newline-delimited JSON-RPC request to herdr's unix socket and close.
- * Fire-and-forget: the response is ignored and every failure path is reported
- * via `onError` without throwing, so a dead socket never disturbs the agent.
+ * The response is ignored and every failure path is reported via `onError`
+ * without throwing, so a dead socket never disturbs the agent.
+ *
+ * Resolves once the frame has been flushed (or the attempt failed or timed out),
+ * which is what lets callers order frames relative to one another.
  */
 function sendToHerdrSocket(
 	socketPath: string,
 	method: string,
 	params: Record<string, unknown>,
 	onError: (err: unknown) => void,
-): void {
-	const conn = connect({ path: socketPath });
-	// Never let a report keep xcsh's event loop alive.
-	conn.unref();
-	conn.once("error", err => {
-		onError(err);
-		conn.destroy();
+): Promise<void> {
+	return new Promise<void>(resolve => {
+		let settled = false;
+		const settle = (): void => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			resolve();
+		};
+		const conn = connect({ path: socketPath });
+		// Never let a report keep xcsh's event loop alive.
+		conn.unref();
+		conn.once("error", err => {
+			onError(err);
+			conn.destroy();
+			settle();
+		});
+		conn.once("connect", () => {
+			conn.end(`${JSON.stringify({ id: "xcsh:herdr-reporter", method, params })}\n`, settle);
+		});
+		conn.setTimeout(SOCKET_TIMEOUT_MS, () => {
+			conn.destroy();
+			settle();
+		});
 	});
-	conn.once("connect", () => {
-		conn.end(`${JSON.stringify({ id: "xcsh:herdr-reporter", method, params })}\n`);
-	});
-	conn.setTimeout(SOCKET_TIMEOUT_MS, () => conn.destroy());
 }
 
 /** Translate a JSON-RPC report/release into `herdr` CLI arguments (fallback). */
@@ -90,10 +125,19 @@ export default function herdrReporter(pi: ExtensionAPI): void {
 		return;
 	}
 
-	let seq = 0;
+	// Seeded from the wall clock at microsecond scale rather than 0 so a new xcsh
+	// process in a pane always starts above whatever the previous process reached.
+	// Matches the pi/omp reporters and stays well inside Number.MAX_SAFE_INTEGER.
+	let seq = Date.now() * 1000;
 	// Tracks whether an interactive prompt is currently awaiting the user, so an
 	// agent_end that fires while a prompt is open is reported as blocked, not idle.
 	let promptOpen = false;
+	// Last session ref already delivered, so repeated lifecycle events do not
+	// re-send an unchanged ref every turn.
+	let lastSessionRefKey: string | undefined;
+	// Serializes frames: herdr compares `seq` across all methods for this source,
+	// so frames must reach it in the order they were generated.
+	let queue: Promise<void> = Promise.resolve();
 
 	pi.setLabel(HERDR_AGENT_LABEL);
 
@@ -103,17 +147,27 @@ export default function herdrReporter(pi: ExtensionAPI): void {
 		});
 	};
 
-	const send = (method: string, params: Record<string, unknown>): void => {
-		const socketPath = process.env.HERDR_SOCKET_PATH;
-		if (socketPath) {
-			sendToHerdrSocket(socketPath, method, params, onError);
-			return;
-		}
-		// Fallback for the rare case herdr did not inject a socket path.
-		pi.exec("herdr", toCliArgs(method, params)).catch(onError);
+	/** Chain a frame onto the tail of the send queue. Never rejects. */
+	const enqueue = (task: () => Promise<void>): Promise<void> => {
+		queue = queue.then(task, task).catch(onError);
+		return queue;
 	};
 
-	const report = (state: "idle" | "working" | "blocked"): void => {
+	const send = (method: string, params: Record<string, unknown>): Promise<void> => {
+		const socketPath = process.env.HERDR_SOCKET_PATH;
+		if (socketPath) {
+			return enqueue(() => sendToHerdrSocket(socketPath, method, params, onError));
+		}
+		// Fallback for the rare case herdr did not inject a socket path.
+		return enqueue(() =>
+			pi
+				.exec("herdr", toCliArgs(method, params))
+				.then(() => undefined)
+				.catch(onError),
+		);
+	};
+
+	const report = (state: "idle" | "working" | "blocked"): Promise<void> =>
 		send(REPORT_METHOD, {
 			pane_id: paneId,
 			source: HERDR_SOURCE,
@@ -121,7 +175,6 @@ export default function herdrReporter(pi: ExtensionAPI): void {
 			state,
 			seq: seq++,
 		});
-	};
 
 	// Report the current session's identity so herdr can resume this pane
 	// (`xcsh --resume=<session>`) after a server restart. This is sent only over
@@ -129,10 +182,16 @@ export default function herdrReporter(pi: ExtensionAPI): void {
 	// reports via the CLI fallback). Prefer the absolute session file path, which
 	// herdr resumes directly; fall back to the session id for non-persisted
 	// sessions (e.g. print/RPC mode, where getSessionFile() is undefined).
-	const reportSession = (ctx: ExtensionContext): void => {
+	//
+	// Called from every lifecycle handler because xcsh creates the session file
+	// lazily: getSessionFile() can still be undefined at session_start and even at
+	// agent_start, and a ref missed there would otherwise be lost until the next
+	// turn — long enough for a restart to lose the pane. Unchanged refs are
+	// suppressed, so the extra call sites cost nothing on the wire.
+	const reportSession = (ctx: ExtensionContext): Promise<void> => {
 		const socketPath = process.env.HERDR_SOCKET_PATH;
 		if (!socketPath) {
-			return;
+			return Promise.resolve();
 		}
 		let sessionRef: Record<string, unknown> | undefined;
 		try {
@@ -147,58 +206,63 @@ export default function herdrReporter(pi: ExtensionAPI): void {
 			}
 		} catch (err) {
 			onError(err);
-			return;
+			return Promise.resolve();
 		}
 		if (!sessionRef) {
-			return;
+			return Promise.resolve();
 		}
-		sendToHerdrSocket(
-			socketPath,
-			SESSION_METHOD,
-			{
-				pane_id: paneId,
-				source: HERDR_SOURCE,
-				agent: HERDR_AGENT_LABEL,
-				seq: seq++,
-				...sessionRef,
-			},
-			onError,
-		);
+		const refKey = JSON.stringify(sessionRef);
+		if (refKey === lastSessionRefKey) {
+			return Promise.resolve();
+		}
+		lastSessionRefKey = refKey;
+		const frame = {
+			pane_id: paneId,
+			source: HERDR_SOURCE,
+			agent: HERDR_AGENT_LABEL,
+			seq: seq++,
+			...sessionRef,
+		};
+		return enqueue(() => sendToHerdrSocket(socketPath, SESSION_METHOD, frame, onError));
 	};
 
 	// Announce presence and session identity as soon as the session is initialized.
-	pi.on("session_start", (_event, ctx) => {
-		reportSession(ctx);
-		report("idle");
+	pi.on("session_start", async (_event, ctx) => {
+		await report("idle");
+		await reportSession(ctx);
 	});
 
 	// Busy while the agent loop is streaming a response. Re-report session identity
 	// in case the active session file changed (e.g. after /new, /resume, or /fork).
-	pi.on("agent_start", (_event, ctx) => {
-		reportSession(ctx);
-		report("working");
+	pi.on("agent_start", async (_event, ctx) => {
+		await report("working");
+		await reportSession(ctx);
 	});
 
 	// Back to idle when the loop ends — unless we are waiting on a user prompt.
-	pi.on("agent_end", () => {
-		report(promptOpen ? "blocked" : "idle");
+	// This is also the first point where a lazily-created session file is certain
+	// to exist, so it is the backstop for capturing the resume ref.
+	pi.on("agent_end", async (_event, ctx) => {
+		await report(promptOpen ? "blocked" : "idle");
+		await reportSession(ctx);
 	});
 
 	// An interactive prompt (permission gate, ask tool, confirm/input) is
 	// awaiting the user: that is herdr's "needs attention" (blocked) state.
 	pi.on("user_prompt_start", () => {
 		promptOpen = true;
-		report("blocked");
+		void report("blocked");
 	});
 
-	pi.on("user_prompt_end", (_event, ctx) => {
+	pi.on("user_prompt_end", async (_event, ctx) => {
 		promptOpen = false;
-		report(ctx.isIdle() ? "idle" : "working");
+		await report(ctx.isIdle() ? "idle" : "working");
+		await reportSession(ctx);
 	});
 
 	// Relinquish pane authority so herdr stops showing xcsh once we exit.
 	pi.on("session_shutdown", () => {
-		send(RELEASE_METHOD, {
+		void send(RELEASE_METHOD, {
 			pane_id: paneId,
 			source: HERDR_SOURCE,
 			agent: HERDR_AGENT_LABEL,

--- a/packages/coding-agent/test/herdr-reporter.test.ts
+++ b/packages/coding-agent/test/herdr-reporter.test.ts
@@ -111,6 +111,9 @@ const reportMsg = (state: string, seq: number) => ({
 	params: { pane_id: "w1:p1", source: "herdr:xcsh", agent: "xcsh", state, seq },
 });
 
+/** seq is seeded from the wall clock, so assert offsets from the first frame. */
+const baseSeq = (herdr: FakeHerdr): number => herdr.received[0]?.params.seq as number;
+
 describe("herdr-reporter extension", () => {
 	const originalPaneId = process.env.HERDR_PANE_ID;
 	const originalSocket = process.env.HERDR_SOCKET_PATH;
@@ -148,9 +151,10 @@ describe("herdr-reporter extension", () => {
 			await handlers.get("agent_end")?.({ messages: [] }, idleCtx);
 
 			await waitFor(() => herdr.received.length >= 3);
-			expect(herdr.received[0]).toEqual(reportMsg("idle", 0));
-			expect(herdr.received[1]).toEqual(reportMsg("working", 1));
-			expect(herdr.received[2]).toEqual(reportMsg("idle", 2));
+			const base = baseSeq(herdr);
+			expect(herdr.received[0]).toEqual(reportMsg("idle", base));
+			expect(herdr.received[1]).toEqual(reportMsg("working", base + 1));
+			expect(herdr.received[2]).toEqual(reportMsg("idle", base + 2));
 			// Socket transport must not shell out to the CLI.
 			expect(execCalls).toEqual([]);
 		} finally {
@@ -172,9 +176,10 @@ describe("herdr-reporter extension", () => {
 			await handlers.get("user_prompt_end")?.({ kind: "select" }, busyCtx);
 
 			await waitFor(() => herdr.received.length >= 3);
-			expect(herdr.received[0]).toEqual(reportMsg("blocked", 0));
-			expect(herdr.received[1]).toEqual(reportMsg("blocked", 1));
-			expect(herdr.received[2]).toEqual(reportMsg("working", 2));
+			const base = baseSeq(herdr);
+			expect(herdr.received[0]).toEqual(reportMsg("blocked", base));
+			expect(herdr.received[1]).toEqual(reportMsg("blocked", base + 1));
+			expect(herdr.received[2]).toEqual(reportMsg("working", base + 2));
 		} finally {
 			await herdr.close();
 		}
@@ -194,7 +199,7 @@ describe("herdr-reporter extension", () => {
 			expect(herdr.received[0]).toEqual({
 				id: "xcsh:herdr-reporter",
 				method: "pane.release_agent",
-				params: { pane_id: "w1:p1", source: "herdr:xcsh", agent: "xcsh", seq: 0 },
+				params: { pane_id: "w1:p1", source: "herdr:xcsh", agent: "xcsh", seq: baseSeq(herdr) },
 			});
 		} finally {
 			await herdr.close();
@@ -209,7 +214,11 @@ describe("herdr-reporter extension", () => {
 		herdrReporter(pi);
 		await handlers.get("agent_start")?.({}, idleCtx);
 		await handlers.get("session_shutdown")?.({}, idleCtx);
+		await waitFor(() => execCalls.length >= 2);
 
+		const cliSeq = (call: { args: string[] }): number => Number(call.args[call.args.indexOf("--seq") + 1]);
+		const base = cliSeq(execCalls[0]!);
+		expect(base).toBeGreaterThan(0);
 		expect(execCalls[0]).toEqual({
 			command: "herdr",
 			args: [
@@ -223,12 +232,22 @@ describe("herdr-reporter extension", () => {
 				"--state",
 				"working",
 				"--seq",
-				"0",
+				String(base),
 			],
 		});
 		expect(execCalls[1]).toEqual({
 			command: "herdr",
-			args: ["pane", "release-agent", "w1:p1", "--source", "herdr:xcsh", "--agent", "xcsh", "--seq", "1"],
+			args: [
+				"pane",
+				"release-agent",
+				"w1:p1",
+				"--source",
+				"herdr:xcsh",
+				"--agent",
+				"xcsh",
+				"--seq",
+				String(base + 1),
+			],
 		});
 	});
 
@@ -294,6 +313,83 @@ describe("herdr-reporter extension", () => {
 
 			await waitFor(() => herdr.received.some(m => m.method === "pane.report_agent"));
 			expect(herdr.received.some(m => m.method === "pane.report_agent_session")).toBe(false);
+		} finally {
+			await herdr.close();
+		}
+	});
+
+	it("seeds seq from a clock so a restarted xcsh process outranks the previous one", async () => {
+		// herdr keys hook_report_sequences by source and rejects seq <= last_seq. A
+		// per-process counter starting at 0 means a restarted xcsh can never
+		// out-rank its predecessor in the same pane, so every one of its reports is
+		// silently dropped. pi/omp seed from Date.now() * 1000 for this reason.
+		const herdr = await startFakeHerdr();
+		try {
+			process.env.HERDR_PANE_ID = "w1:p1";
+			process.env.HERDR_SOCKET_PATH = herdr.socketPath;
+			const lowerBound = Date.now() * 1000;
+			const { pi, handlers } = makeMockPi();
+
+			herdrReporter(pi);
+			await handlers.get("session_start")?.({}, idleCtx);
+			await waitFor(() => herdr.received.length >= 1);
+			const upperBound = Date.now() * 1000 + 1_000_000;
+
+			const firstSeq = herdr.received[0]?.params.seq as number;
+			expect(firstSeq).toBeGreaterThanOrEqual(lowerBound);
+			expect(firstSeq).toBeLessThanOrEqual(upperBound);
+		} finally {
+			await herdr.close();
+		}
+	});
+
+	it("delivers the state frame before the session frame, with an ascending seq", async () => {
+		// herdr drops a session frame for a pane whose agent it does not yet own, so
+		// the state frame must establish herdr:xcsh first. Verified against a live
+		// herdr: session-then-state leaves agent_session null even when seq ascends.
+		const herdr = await startFakeHerdr();
+		try {
+			process.env.HERDR_PANE_ID = "w1:p1";
+			process.env.HERDR_SOCKET_PATH = herdr.socketPath;
+			const { pi, handlers } = makeMockPi();
+
+			herdrReporter(pi);
+			await handlers.get("session_start")?.({}, sessionCtx("/tmp/x/session.jsonl"));
+
+			await waitFor(() => herdr.received.length >= 2);
+			expect(herdr.received[0]?.method).toBe("pane.report_agent");
+			expect(herdr.received[1]?.method).toBe("pane.report_agent_session");
+			expect(herdr.received[1]?.params.seq as number).toBeGreaterThan(herdr.received[0]?.params.seq as number);
+		} finally {
+			await herdr.close();
+		}
+	});
+
+	it("reports the session ref once the session file appears later", async () => {
+		// xcsh creates the session .jsonl lazily, so getSessionFile() can still be
+		// undefined at session_start and at agent_start. The ref must be picked up
+		// on a later lifecycle event instead of being lost until the next turn.
+		const herdr = await startFakeHerdr();
+		try {
+			process.env.HERDR_PANE_ID = "w1:p1";
+			process.env.HERDR_SOCKET_PATH = herdr.socketPath;
+			const { pi, handlers } = makeMockPi();
+
+			let file: string | undefined;
+			const lazyCtx = {
+				isIdle: () => true,
+				sessionManager: { getSessionFile: () => file, getSessionId: () => "" },
+			} as unknown as ExtensionContext;
+
+			herdrReporter(pi);
+			await handlers.get("session_start")?.({}, lazyCtx);
+			await handlers.get("agent_start")?.({}, lazyCtx);
+			file = "/tmp/x/late-session.jsonl";
+			await handlers.get("agent_end")?.({ messages: [] }, lazyCtx);
+
+			await waitFor(() => herdr.received.some(r => r.method === "pane.report_agent_session"));
+			const session = herdr.received.find(r => r.method === "pane.report_agent_session");
+			expect(session?.params.agent_session_path).toBe("/tmp/x/late-session.jsonl");
 		} finally {
 			await herdr.close();
 		}


### PR DESCRIPTION
## What

Fixes the bundled `herdr-reporter` so herdr actually records an xcsh pane's session reference, which
is what lets it resume the pane with `xcsh --resume=<session>` after a restart.

Three interacting defects, all in
`packages/coding-agent/src/extensibility/extensions/bundled/herdr-reporter.ts`:

1. **`seq` started at 0 in every process.** herdr keeps one monotonic `seq` per *source*, shared
   across every method, and drops any frame whose `seq` is not greater than the last it accepted for
   `herdr:xcsh`. A restarted xcsh could therefore never out-rank its predecessor in the same pane.
   Now seeded from `Date.now() * 1000`, matching the pi and omp reporters.
2. **Frames raced.** `sendToHerdrSocket` was fire-and-forget on independent, unawaited sockets, so
   delivery order was luck. Frames now go out one at a time through a queue that resolves on write
   flush.
3. **The session frame went out before the state frame.** herdr discards a
   `pane.report_agent_session` for a pane whose agent it does not yet own, so the state frame has to
   establish `herdr:xcsh` first. Order reversed.

Plus: xcsh creates its session `.jsonl` lazily, so `getSessionFile()` can still be `undefined` at
both `session_start` and `agent_start`. The ref is now also reported on `agent_end` and
`user_prompt_end`, with unchanged refs suppressed so nothing extra hits the wire.

## Why

xcsh panes under herdr never resumed — herdr restored them as plain shells and made no attempt to
run `xcsh --resume`, silently losing in-flight work. Observed on a real session: 7 xcsh panes, zero
with an `agent_session` recorded, while every `claude` pane in the same session had one.

State reporting was working the whole time (`screen_detection_skipped: true`, idle/working/blocked
tracked correctly), which is why this looked like "resume is broken" rather than "the integration
isn't connected".

No herdr-side change is required, so this works against stock upstream herdr rather than depending
on a fork.

Closes #2388

## Testing

**TDD** — the 4 new/updated assertions fail against the current reporter and pass with the fix:

```
$ git stash push <reporter>   # original reporter, new tests
(fail) seeds seq from a clock so a restarted xcsh process outranks the previous one
(fail) delivers the state frame before the session frame, with an ascending seq
(fail) reports the session ref once the session file appears later
(fail) falls back to the herdr CLI when HERDR_SOCKET_PATH is unset
 9 pass, 4 fail

$ git stash pop               # with the fix
 13 pass, 0 fail
```

**Regression** — all 10 extensibility suites green (89 tests, 0 fail):
`bench-instant-extension`, `extension-bridge-tools`, `extension-loading-contract`,
`extension-session-contract`, `extensions-discovery`, `extensions-runner`, `herdr-reporter`,
`loader-bundled-extensions`, `plugin-extensions-discovery`, `rpc-mode-extension-ui`.

`bun run check:types` exits 0. `biome check` clean on both changed files.

**End-to-end against a live herdr** (`herdr 0.7.5`, `xcsh 19.90.1`), driving the patched reporter
module directly at the real herdr socket with a throwaway pane:

| Scenario | `herdr agent get <pane>` |
|---|---|
| unpatched xcsh, 3 fresh panes (incl. one `--resume`) | `agent_session: null` |
| patched reporter, first process | `agent_session: {kind: path, source: herdr:xcsh, value: …}` |
| patched reporter, simulated second process | ref **updated** — restart no longer rejected |

The ordering requirement in (3) was found this way: session-then-state with a correctly ascending
`seq` still left `agent_session` null, so a seq-only fix would have looked right and changed nothing.

**Not covered:** this exercises the reporter module against a real herdr, not a built-and-installed
xcsh binary. Confirming a real pane survives a reboot needs a released build.

---

- [x] `biome check` passes on changed files; `check:types` exits 0
- [x] `bun test` — extensibility suites show no new failures vs baseline (89 pass)
- [ ] CHANGELOG updated (n/a — no CHANGELOG file; releases derive from conventional commits)
- [x] Issue linked via `Closes #2388`
