### PR TITLE
office-pane UI polish: scrolling brand, HeaderBar icon row, session history, /skill pills

### DIFF
--- a/packages/chat-ui/src/components/EmptyState.tsx
+++ b/packages/chat-ui/src/components/EmptyState.tsx
@@ -17,9 +17,21 @@ export interface EmptyStateProps {
 	 * persistent header already carries the brand (avoids a duplicate F5 logo).
 	 */
 	logo?: ReactNode | false;
+	/**
+	 * Lay the pills out as a vertical list instead of a wrapping centred row — the
+	 * Claude-for-Office shape for slash-command starters, where each pill is a
+	 * command rather than a short phrase. Opt-in, so other surfaces are unchanged.
+	 */
+	stacked?: boolean;
 }
 
-export function EmptyState({ pills, onPick, heading = "Get started with these skills:", logo }: EmptyStateProps) {
+export function EmptyState({
+	pills,
+	onPick,
+	heading = "Get started with these skills:",
+	logo,
+	stacked = false,
+}: EmptyStateProps) {
 	// `undefined` → default logo; `false` → no logo; any node → that node.
 	const logoNode = logo === undefined ? <F5Logo variant="ascii" /> : logo;
 	return (
@@ -28,7 +40,7 @@ export function EmptyState({ pills, onPick, heading = "Get started with these sk
 			{pills.length > 0 && (
 				<>
 					<div className="empty-heading">{heading}</div>
-					<div className="pills">
+					<div className={stacked ? "pills pills-stacked" : "pills"}>
 						{pills.map(p => (
 							<button key={p.id} type="button" className="pill" title={p.hint} onClick={() => onPick(p.id)}>
 								{p.label}

--- a/packages/chat-ui/src/components/GatewayGate.tsx
+++ b/packages/chat-ui/src/components/GatewayGate.tsx
@@ -3,16 +3,20 @@
  * headless: no Transport / store / ChatPanel imports (those stay per-host). The
  * host owns the persisted config (passes it in as `config`, persists via
  * `onSaveConfig`); this gate decides whether to show the {@link GatewayConfigForm}
- * or the host-rendered chat (`children(config, api)`), plus a Settings affordance
- * to reconfigure. `api.reconfigure()` lets the child reopen the (prefilled) form
- * itself — e.g. a configure-error banner's recovery action — without routing
- * through the generic Settings button.
+ * or the host-rendered chat (`children(config, api)`).
+ *
+ * It renders NO chrome of its own: `api.reconfigure()` reopens the (prefilled)
+ * form, and the host decides where that lives — the Office pane puts it in the
+ * header's "⋯" menu, and a configure-error banner uses it as its recovery action.
+ * (This gate used to render its own floating "Settings" button; that stacked a
+ * second right-aligned row above the host's header, which in an Office task pane
+ * collided with Office's native ⓘ button.)
  *
  * Two modes:
  *  - **config-required** (default): a missing config forces the form first (the
  *    gateway is mandatory before chat).
  *  - **chat-first** (`optional`): a missing config renders the chat anyway, with
- *    config demoted to the optional Settings affordance. For a single-engine host
+ *    config demoted to the host's optional Settings affordance. For a single-engine host
  *    (xcsh) whose agent already has provider credentials, so the pane should not
  *    gate on a redundant login; `children` may then be called with `config: null`.
  *
@@ -90,12 +94,5 @@ export function GatewayGate<T>({
 		);
 	}
 
-	return (
-		<>
-			<button type="button" className="gateway-settings-btn" onClick={reconfigure}>
-				Settings
-			</button>
-			{children(config, { reconfigure })}
-		</>
-	);
+	return <>{children(config, { reconfigure })}</>;
 }

--- a/packages/chat-ui/src/components/HeaderBar.tsx
+++ b/packages/chat-ui/src/components/HeaderBar.tsx
@@ -1,15 +1,25 @@
 /**
- * The top header bar (NEW), giving Claude-for-Office structural parity in our
- * terminal aesthetic. Right-aligned icon-button controls, in order:
- *   history (≡, dropdown of past chats) · new-chat (✎, action) · more (⋯, dropdown)
- * Callbacks + menu items are props — headless. Menu buttons use terminal glyphs.
+ * The top header bar, giving Claude-for-Office structural parity in our terminal
+ * aesthetic. Right-aligned icon-button controls, in order:
+ *   history (clock, dropdown of past chats) · new-chat (⊕, action) · more (⋮, dropdown)
+ * Callbacks + menu items are props — headless.
+ *
+ * This row is PINNED (a sibling of the scrollport, not inside it). The brand block
+ * scrolls instead — it is passed to `Transcript.brand`.
+ *
+ * Each control labels itself via `aria-label` + `data-tip`, never `title`: the CSS
+ * tooltip is driven by `data-tip`, and keeping `title` too would stack a second
+ * native tooltip on top of it.
  */
-import type { MenuItem } from "../types";
+import type { MenuItem, ReactNode } from "../types";
+import { HistoryIcon, MoreIcon, NewChatIcon } from "./icons";
 import { useMenu } from "./useMenu";
 
 export interface HeaderBarProps {
 	title?: string;
 	onNewChat: () => void;
+	/** Gate the new-chat action (e.g. nothing to reset yet). Default: enabled. */
+	canNewChat?: boolean;
 	historyItems?: MenuItem[];
 	onHistorySelect?: (id: string) => void;
 	moreItems?: MenuItem[];
@@ -17,13 +27,13 @@ export interface HeaderBarProps {
 }
 
 function MenuButton({
-	glyph,
-	title,
+	icon,
+	label,
 	items,
 	onSelect,
 }: {
-	glyph: string;
-	title: string;
+	icon: ReactNode;
+	label: string;
 	items: MenuItem[];
 	onSelect?: (id: string) => void;
 }) {
@@ -35,13 +45,13 @@ function MenuButton({
 				ref={triggerRef}
 				type="button"
 				className="header-btn"
-				title={title}
-				aria-label={title}
+				data-tip={label}
+				aria-label={label}
 				aria-haspopup="menu"
 				aria-expanded={open}
 				onClick={toggle}
 			>
-				{glyph}
+				{icon}
 			</button>
 			{open && (
 				<div className="menu menu-down menu-right" role="menu" ref={menuRef}>
@@ -73,6 +83,7 @@ function MenuButton({
 export function HeaderBar({
 	title,
 	onNewChat,
+	canNewChat = true,
 	historyItems,
 	onHistorySelect,
 	moreItems,
@@ -82,11 +93,22 @@ export function HeaderBar({
 		<div className="header">
 			{title && <span className="header-title">{title}</span>}
 			<span className="header-spacer" />
-			{historyItems && <MenuButton glyph="≡" title="Chat history" items={historyItems} onSelect={onHistorySelect} />}
-			<button type="button" className="header-btn" title="New chat" aria-label="New chat" onClick={onNewChat}>
-				✎
+			{historyItems && (
+				<MenuButton icon={<HistoryIcon />} label="Chat history" items={historyItems} onSelect={onHistorySelect} />
+			)}
+			<button
+				type="button"
+				className="header-btn"
+				data-tip="New chat"
+				aria-label="New chat"
+				disabled={!canNewChat}
+				onClick={onNewChat}
+			>
+				<NewChatIcon />
 			</button>
-			{moreItems && <MenuButton glyph="⋯" title="More options" items={moreItems} onSelect={onMoreSelect} />}
+			{moreItems && (
+				<MenuButton icon={<MoreIcon />} label="More options" items={moreItems} onSelect={onMoreSelect} />
+			)}
 		</div>
 	);
 }

--- a/packages/chat-ui/src/components/HeaderBar.tsx
+++ b/packages/chat-ui/src/components/HeaderBar.tsx
@@ -22,6 +22,9 @@ export interface HeaderBarProps {
 	canNewChat?: boolean;
 	historyItems?: MenuItem[];
 	onHistorySelect?: (id: string) => void;
+	/** Caption above the history entries — e.g. "This session", so a host whose
+	 *  history does not survive a reload cannot be mistaken for one that does. */
+	historyHeader?: string;
 	moreItems?: MenuItem[];
 	onMoreSelect?: (id: string) => void;
 }
@@ -29,11 +32,13 @@ export interface HeaderBarProps {
 function MenuButton({
 	icon,
 	label,
+	header,
 	items,
 	onSelect,
 }: {
 	icon: ReactNode;
 	label: string;
+	header?: string;
 	items: MenuItem[];
 	onSelect?: (id: string) => void;
 }) {
@@ -55,6 +60,7 @@ function MenuButton({
 			</button>
 			{open && (
 				<div className="menu menu-down menu-right" role="menu" ref={menuRef}>
+					{header && <div className="menu-header">{header}</div>}
 					{items.length === 0 ? (
 						<div className="menu-header">Empty</div>
 					) : (
@@ -86,6 +92,7 @@ export function HeaderBar({
 	canNewChat = true,
 	historyItems,
 	onHistorySelect,
+	historyHeader,
 	moreItems,
 	onMoreSelect,
 }: HeaderBarProps) {
@@ -94,7 +101,13 @@ export function HeaderBar({
 			{title && <span className="header-title">{title}</span>}
 			<span className="header-spacer" />
 			{historyItems && (
-				<MenuButton icon={<HistoryIcon />} label="Chat history" items={historyItems} onSelect={onHistorySelect} />
+				<MenuButton
+					icon={<HistoryIcon />}
+					label="Chat history"
+					header={historyHeader}
+					items={historyItems}
+					onSelect={onHistorySelect}
+				/>
 			)}
 			<button
 				type="button"

--- a/packages/chat-ui/src/components/Transcript.tsx
+++ b/packages/chat-ui/src/components/Transcript.tsx
@@ -21,6 +21,17 @@ export interface TranscriptProps {
 	 */
 	thinkingLabel?: string;
 	onRetry?: (text: string) => void;
+	/**
+	 * Rendered as the FIRST child INSIDE the scrollport, in both the empty and the
+	 * populated state — so a host brand block (logo + wordmark) is visible on open
+	 * and then scrolls away with the conversation (Claude-for-Office behaviour).
+	 *
+	 * It must live inside `.messages` rather than in {@link emptyState}: the empty
+	 * state unmounts on the first send, so brand-via-emptyState would VANISH
+	 * instead of scrolling. Static content, so being inside the `aria-live` log is
+	 * harmless (initial content is not announced and it never mutates).
+	 */
+	brand?: ReactNode;
 	/** Rendered in place of the rows when there are no messages. */
 	emptyState?: ReactNode;
 	/** Accessible label for the transcript live region (default "Conversation"). */
@@ -32,6 +43,7 @@ export function Transcript({
 	streaming,
 	thinkingLabel,
 	onRetry,
+	brand,
 	emptyState,
 	label = "Conversation",
 }: TranscriptProps) {
@@ -59,14 +71,17 @@ export function Transcript({
 		setShowFab(false);
 	}, []);
 
-	// After each render, follow the tail only if the user was already at the bottom.
-	useLayoutEffect(() => {
-		const el = scrollRef.current;
-		if (el && userAtBottom.current) el.scrollTop = el.scrollHeight;
-	});
-
 	const lastId = messages.length > 0 ? messages[messages.length - 1].id : null;
 	const empty = messages.length === 0;
+
+	// After each render, follow the tail only if the user was already at the bottom.
+	// NOT while empty: `userAtBottom` starts true and this effect has no dep array, so
+	// an empty transcript would be pinned to the bottom on first paint — scrolling the
+	// `brand` block out of view before the user ever sees it.
+	useLayoutEffect(() => {
+		const el = scrollRef.current;
+		if (el && userAtBottom.current && !empty) el.scrollTop = el.scrollHeight;
+	});
 
 	return (
 		<>
@@ -78,6 +93,7 @@ export function Transcript({
 				aria-live="polite"
 				aria-label={label}
 			>
+				{brand}
 				{empty && emptyState
 					? emptyState
 					: messages.map(m => renderMessage(m, lastId, streaming, onRetry, thinkingLabel))}

--- a/packages/chat-ui/src/components/icons.tsx
+++ b/packages/chat-ui/src/components/icons.tsx
@@ -1,7 +1,12 @@
 /**
- * The shared composer glyph icons (unified from the Chrome + VS Code seeds so
- * every surface reads as one product): an up-arrow send, a rounded-square stop,
- * and a plus for attach.
+ * The shared glyph icons (unified from the Chrome + VS Code seeds so every
+ * surface reads as one product): the composer's up-arrow send, rounded-square
+ * stop and attach plus, plus the header-bar controls.
+ *
+ * Header icons are SVG rather than the text glyphs they replaced (≡ ✎ ⋯): an
+ * Office task-pane WebView has no say over font fallback, so a glyph can render
+ * as tofu or shift the row's metrics. They are `aria-hidden` — the accessible
+ * name lives on the button's `aria-label`.
  */
 export function SendIcon() {
 	return (
@@ -23,6 +28,37 @@ export function PlusIcon() {
 	return (
 		<svg viewBox="0 0 20 20" width="16" height="16" fill="currentColor" aria-hidden="true">
 			<path d="M10 5a.75.75 0 01.75.75V9.25h3.5a.75.75 0 010 1.5h-3.5v3.5a.75.75 0 01-1.5 0v-3.5h-3.5a.75.75 0 010-1.5h3.5V5.75A.75.75 0 0110 5z" />
+		</svg>
+	);
+}
+
+/** Header: past chats — a clock face, the conventional "history" mark. */
+export function HistoryIcon() {
+	return (
+		<svg viewBox="0 0 20 20" width="16" height="16" fill="currentColor" aria-hidden="true">
+			<path d="M10 3a7 7 0 100 14 7 7 0 000-14zm0 1.5a5.5 5.5 0 110 11 5.5 5.5 0 010-11z" />
+			<path d="M9.25 6a.75.75 0 011.5 0v3.94l2.4 1.39a.75.75 0 01-.75 1.3l-2.78-1.6a.75.75 0 01-.37-.65V6z" />
+		</svg>
+	);
+}
+
+/** Header: start a new chat — a plus in a circle. */
+export function NewChatIcon() {
+	return (
+		<svg viewBox="0 0 20 20" width="16" height="16" fill="currentColor" aria-hidden="true">
+			<path d="M10 3a7 7 0 100 14 7 7 0 000-14zm0 1.5a5.5 5.5 0 110 11 5.5 5.5 0 010-11z" />
+			<path d="M10 6.5a.75.75 0 01.75.75v2h2a.75.75 0 010 1.5h-2v2a.75.75 0 01-1.5 0v-2h-2a.75.75 0 010-1.5h2v-2A.75.75 0 0110 6.5z" />
+		</svg>
+	);
+}
+
+/** Header: overflow menu — a vertical ellipsis. */
+export function MoreIcon() {
+	return (
+		<svg viewBox="0 0 20 20" width="16" height="16" fill="currentColor" aria-hidden="true">
+			<circle cx="10" cy="5" r="1.4" />
+			<circle cx="10" cy="10" r="1.4" />
+			<circle cx="10" cy="15" r="1.4" />
 		</svg>
 	);
 }

--- a/packages/chat-ui/src/components/icons.tsx
+++ b/packages/chat-ui/src/components/icons.tsx
@@ -32,11 +32,15 @@ export function PlusIcon() {
 	);
 }
 
+/** The 1.5px-stroke circle outline both circular header marks are drawn inside, so
+ *  the clock and new-chat glyphs stay the same weight and diameter as each other. */
+const CIRCLE_OUTLINE = "M10 3a7 7 0 100 14 7 7 0 000-14zm0 1.5a5.5 5.5 0 110 11 5.5 5.5 0 010-11z";
+
 /** Header: past chats — a clock face, the conventional "history" mark. */
 export function HistoryIcon() {
 	return (
 		<svg viewBox="0 0 20 20" width="16" height="16" fill="currentColor" aria-hidden="true">
-			<path d="M10 3a7 7 0 100 14 7 7 0 000-14zm0 1.5a5.5 5.5 0 110 11 5.5 5.5 0 010-11z" />
+			<path d={CIRCLE_OUTLINE} />
 			<path d="M9.25 6a.75.75 0 011.5 0v3.94l2.4 1.39a.75.75 0 01-.75 1.3l-2.78-1.6a.75.75 0 01-.37-.65V6z" />
 		</svg>
 	);
@@ -46,7 +50,7 @@ export function HistoryIcon() {
 export function NewChatIcon() {
 	return (
 		<svg viewBox="0 0 20 20" width="16" height="16" fill="currentColor" aria-hidden="true">
-			<path d="M10 3a7 7 0 100 14 7 7 0 000-14zm0 1.5a5.5 5.5 0 110 11 5.5 5.5 0 010-11z" />
+			<path d={CIRCLE_OUTLINE} />
 			<path d="M10 6.5a.75.75 0 01.75.75v2h2a.75.75 0 010 1.5h-2v2a.75.75 0 01-1.5 0v-2h-2a.75.75 0 010-1.5h2v-2A.75.75 0 0110 6.5z" />
 		</svg>
 	);

--- a/packages/chat-ui/src/index.ts
+++ b/packages/chat-ui/src/index.ts
@@ -29,7 +29,7 @@ export { GatewayConfigForm, type GatewayConfigFormProps } from "./components/Gat
 export { GatewayGate, type GatewayGateChildApi, type GatewayGateProps } from "./components/GatewayGate";
 // ── Shell (header / empty state / context chip / activation overlay) ───────
 export { HeaderBar, type HeaderBarProps } from "./components/HeaderBar";
-export { PlusIcon, SendIcon, StopIcon } from "./components/icons";
+export { HistoryIcon, MoreIcon, NewChatIcon, PlusIcon, SendIcon, StopIcon } from "./components/icons";
 export { MarkdownRenderer, type MarkdownRendererProps } from "./components/MarkdownRenderer";
 export { ModelSelector, type ModelSelectorProps } from "./components/ModelSelector";
 export { ModeToggle, type ModeToggleProps } from "./components/ModeToggle";

--- a/packages/chat-ui/src/theme/panel.css.ts
+++ b/packages/chat-ui/src/theme/panel.css.ts
@@ -172,7 +172,11 @@ code { background:var(--code-bg); padding:1px 5px; border-radius:4px; overflow-w
 .ascii-red { color: var(--f5-red); }
 .ascii-white { color: var(--bright-white); }
 .ascii-shadow { color: var(--f5-dark-red); }
-.f5-mark { display:block; width:auto; height:auto; }
+/* No width/height here: the PNG is 128px square and F5Logo sets width/height
+   attributes from its size prop. Those are presentational hints, so ANY author
+   rule beats them — a width:auto/height:auto here silently pinned every mark to the
+   intrinsic 128px and made the size prop dead (a 20px mark rendered 128px tall). */
+.f5-mark { display:block; }
 
 /* ── Scroll-to-bottom FAB ───────────────────────────────────────────────── */
 .scroll-to-bottom { position:absolute; right:16px; bottom:96px; z-index:6; width:32px; height:32px; border-radius:50%;

--- a/packages/chat-ui/src/theme/panel.css.ts
+++ b/packages/chat-ui/src/theme/panel.css.ts
@@ -24,18 +24,28 @@ body { background: var(--charcoal); color: var(--bright-white);
 .xcsh-panel { height:100%; display:flex; flex-direction:column; position:relative; overflow:hidden; }
 
 /* ── Header bar ─────────────────────────────────────────────────────────── */
-.header { display:flex; align-items:center; gap:6px; padding:6px 10px; border-bottom:1px solid var(--subtle-gray); }
+/* A compact PINNED control row. Deliberately has NO bottom border: the brand block
+   lives inside the scrollport (see .brand-block) and scrolls away, so a divider here
+   would cut the pane in half instead of reading as continuous with the transcript. */
+.header { display:flex; align-items:center; gap:6px; padding:6px 10px; }
 .header-title { color: var(--bright-white); font-size:12px; letter-spacing:.04em; }
-.header-new-chat { margin-left:auto; background:transparent; color: var(--cool-gray); border:1px solid var(--subtle-gray);
-  border-radius:6px; padding:2px 10px; font:inherit; font-size:11px; cursor:pointer; }
-.header-new-chat:hover:not(:disabled) { color: var(--bright-white); border-color: var(--chrome-accent); }
-.header-new-chat:disabled { opacity:.4; cursor:default; }
 .header-spacer { flex:1; }
 .header-btn { position:relative; display:flex; align-items:center; justify-content:center; width:28px; height:28px;
   background:none; border:1px solid transparent; color: var(--cool-gray); border-radius:6px; cursor:pointer;
   font:inherit; font-size:15px; line-height:1; }
 .header-btn:hover { color: var(--bright-white); border-color: var(--subtle-gray); }
+.header-btn:disabled { opacity:.4; cursor:default; }
+.header-btn:disabled:hover { color: var(--cool-gray); border-color:transparent; }
 .header-menuwrap { position:relative; }
+/* Hover/focus tooltip driven by the data-tip attribute (NOT the title attribute, or
+   the browser's own tooltip would double up on ours); the accessible name stays on
+   aria-label. Anchored right so a tip can never overflow a narrow 320px task pane. */
+.header-btn[data-tip]::after { content: attr(data-tip); position:absolute; top:calc(100% + 6px); right:0; z-index:30;
+  padding:3px 7px; border-radius:5px; background: var(--code-bg); color: var(--bright-white);
+  border:1px solid var(--subtle-gray); font-size:11px; line-height:1.4; white-space:nowrap; opacity:0;
+  pointer-events:none; transition:opacity .12s ease .35s; }
+.header-btn[data-tip]:hover::after, .header-btn[data-tip]:focus-visible::after { opacity:1; }
+@media (prefers-reduced-motion: reduce) { .header-btn[data-tip]::after { transition:none; } }
 
 /* ── Shared popup menu (header / mode / model dropdowns) ────────────────── */
 .menu { position:absolute; z-index:20; min-width:180px; background: var(--deep-charcoal);
@@ -140,8 +150,18 @@ code { background:var(--code-bg); padding:1px 5px; border-radius:4px; overflow-w
 /* ── Empty state (skill pills) ──────────────────────────────────────────── */
 .empty-state { flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:14px; padding:24px; }
 .empty-logo { color: var(--f5-red); }
+/* The host brand (logo + wordmark), rendered as the FIRST child inside .messages so
+   it scrolls away with the conversation (Claude-for-Office). Top-anchored + flex:none
+   on purpose — it must NOT centre or stretch like .empty-state (flex:1), which would
+   push it into the middle of the pane and fight the centred skills block below it. */
+.brand-block { flex:none; display:flex; align-items:center; gap:10px; padding:4px 2px 10px; }
+.brand-title { color: var(--bright-white); font-size:13px; letter-spacing:.04em; }
 .empty-heading { color: var(--bright-white); font-size:13px; letter-spacing:.02em; }
 .pills { display:flex; flex-wrap:wrap; gap:8px; justify-content:center; max-width:340px; }
+/* Claude's empty state stacks its slash-command pills vertically. Opt-in so the
+   wrapped row layout stays the default for other surfaces (chrome/vscode). */
+.pills.pills-stacked { flex-direction:column; flex-wrap:nowrap; align-items:stretch; width:100%; max-width:340px; }
+.pills.pills-stacked .pill { text-align:left; border-radius:8px; padding:6px 12px; }
 .pill { background: var(--deep-charcoal); border:1px solid var(--subtle-gray); color: var(--bright-white);
   border-radius:14px; padding:4px 12px; cursor:pointer; font:inherit; font-size:12px; }
 .pill:hover { border-color: var(--f5-red); }
@@ -230,8 +250,6 @@ code { background:var(--code-bg); padding:1px 5px; border-radius:4px; overflow-w
   padding:6px 14px; cursor:pointer; font:inherit; }
 .gateway-actions .gateway-cancel { background:none; color: var(--cool-gray); border:1px solid var(--subtle-gray);
   border-radius:6px; padding:6px 14px; cursor:pointer; font:inherit; }
-.gateway-settings-btn { align-self:flex-end; margin:6px 12px 0; background:none; color: var(--cool-gray);
-  border:1px solid var(--subtle-gray); border-radius:6px; padding:2px 10px; cursor:pointer; font:inherit; font-size:12px; }
 /* Config-error recovery view (a rejected provider configure — #2134). */
 /* ── Onboarding screen (first-run, no bridge) ─────────────────────────── */
 .onboarding { display:flex; flex-direction:column; align-items:center; gap:12px; padding:24px 16px; text-align:center; }
@@ -326,6 +344,10 @@ code { background:var(--code-bg); padding:1px 5px; border-radius:4px; overflow-w
    code stays monospace for the exact Claude prose-vs-code contrast. */
 .xcsh-doc { font-family: var(--font-sans); }
 .xcsh-doc .messages { padding: var(--gutter-doc); }
+/* Office HOST reserve (a separate class from .xcsh-doc, which only means "sans
+   document typography"): Office draws its own info button over the pane's
+   top-right corner, so keep our icon row clear of it. */
+.xcsh-host-office .header { padding-right:36px; }
 .xcsh-doc .content .body,
 .xcsh-doc .markdown-root { font-family: var(--font-sans); font-size: var(--text-base); line-height: var(--leading-relaxed);
   max-width: min(var(--measure), var(--measure-px)); }

--- a/packages/chat-ui/test/EmptyState.test.tsx
+++ b/packages/chat-ui/test/EmptyState.test.tsx
@@ -34,3 +34,13 @@ test("renders NO logo (and no empty wrapper) when logo={false}", () => {
 	// Pills + heading still render.
 	expect(screen.getByText("Get started with these skills:")).toBeDefined();
 });
+
+test("stacked lays the pills out as a vertical list; the default stays a wrapping row", () => {
+	const { container, rerender } = render(<EmptyState pills={PILLS} onPick={() => {}} stacked />);
+	const pills = container.querySelector(".pills");
+	expect(pills?.classList.contains("pills-stacked")).toBe(true);
+
+	// Other surfaces are untouched: the modifier is opt-in.
+	rerender(<EmptyState pills={PILLS} onPick={() => {}} />);
+	expect(container.querySelector(".pills")?.classList.contains("pills-stacked")).toBe(false);
+});

--- a/packages/chat-ui/test/GatewayGate.test.tsx
+++ b/packages/chat-ui/test/GatewayGate.test.tsx
@@ -14,6 +14,22 @@ function validate(d: GatewayConfigDraft): GatewayValidateResult<Cfg> {
 	return { ok: true, config: { baseUrl: d.baseUrl, token: d.token } };
 }
 
+/**
+ * The gate renders NO Settings affordance of its own — the host places it (the
+ * office pane puts it in the header's "⋯" menu) and drives it through
+ * `api.reconfigure`. These harness children stand in for that host chrome.
+ */
+function chatWithSettings(baseUrl: string | undefined, reconfigure: () => void) {
+	return (
+		<div>
+			chat over {baseUrl}
+			<button type="button" onClick={reconfigure}>
+				Settings
+			</button>
+		</div>
+	);
+}
+
 test("shows the config form when unconfigured, then the chat after a save", () => {
 	let stored: Cfg | null = null;
 
@@ -45,11 +61,25 @@ test("shows the config form when unconfigured, then the chat after a save", () =
 	expect(screen.getByText("chat over https://gw/anthropic")).toBeDefined();
 });
 
-test("the Settings button reopens the config form over an existing config", () => {
+test("the gate renders no Settings chrome of its own — the host owns that affordance", () => {
+	const cfg: Cfg = { baseUrl: "https://gw/anthropic", token: "t" };
+	const { container } = render(
+		<GatewayGate<Cfg> config={cfg} validate={validate} onSaveConfig={() => {}}>
+			{c => <div>chat over {c?.baseUrl}</div>}
+		</GatewayGate>,
+	);
+	// A floating button here stacked a second right-aligned row above the host's own
+	// header — in the Office pane it collided with Office's native ⓘ button.
+	expect(container.querySelector(".gateway-settings-btn")).toBeNull();
+	expect(screen.queryByRole("button", { name: /settings/i })).toBeNull();
+	expect(screen.getByText(/chat over/)).toBeDefined();
+});
+
+test("a host Settings affordance reopens the config form over an existing config", () => {
 	const cfg: Cfg = { baseUrl: "https://gw/anthropic", token: "t" };
 	render(
 		<GatewayGate<Cfg> config={cfg} validate={validate} onSaveConfig={() => {}}>
-			{c => <div>chat over {c?.baseUrl}</div>}
+			{(c, { reconfigure }) => chatWithSettings(c?.baseUrl, reconfigure)}
 		</GatewayGate>,
 	);
 	expect(screen.getByText(/chat over/)).toBeDefined();
@@ -64,7 +94,7 @@ test("configToDraft prefills the form from the current config when reopened via 
 	const cfg: Cfg = { baseUrl: "https://gw/anthropic", token: "t" };
 	render(
 		<GatewayGate<Cfg> config={cfg} validate={validate} onSaveConfig={() => {}} configToDraft={c => c}>
-			{c => <div>chat over {c?.baseUrl}</div>}
+			{(c, { reconfigure }) => chatWithSettings(c?.baseUrl, reconfigure)}
 		</GatewayGate>,
 	);
 	fireEvent.click(screen.getByRole("button", { name: /settings/i }));
@@ -75,7 +105,7 @@ test("without configToDraft the reopened form is blank (falls back to initial)",
 	const cfg: Cfg = { baseUrl: "https://gw/anthropic", token: "t" };
 	render(
 		<GatewayGate<Cfg> config={cfg} validate={validate} onSaveConfig={() => {}}>
-			{c => <div>chat over {c?.baseUrl}</div>}
+			{(c, { reconfigure }) => chatWithSettings(c?.baseUrl, reconfigure)}
 		</GatewayGate>,
 	);
 	fireEvent.click(screen.getByRole("button", { name: /settings/i }));
@@ -111,14 +141,19 @@ test("optional (chat-first): with NO config, renders the chat (config null) — 
 	// Chat-first: no forced form; children rendered with a null config.
 	expect(screen.getByText("chat cfg=null")).toBeDefined();
 	expect(screen.queryByRole("button", { name: /save|connect/i })).toBeNull();
-	// Config is still reachable via Settings.
-	expect(screen.getByRole("button", { name: /settings/i })).toBeDefined();
 });
 
 test("optional (chat-first): Settings opens the form and Cancel returns to chat even with no config", () => {
 	render(
 		<GatewayGate<Cfg> config={null} validate={validate} onSaveConfig={() => {}} optional>
-			{() => <div>the chat</div>}
+			{(_c, { reconfigure }) => (
+				<div>
+					the chat
+					<button type="button" onClick={reconfigure}>
+						Settings
+					</button>
+				</div>
+			)}
 		</GatewayGate>,
 	);
 	fireEvent.click(screen.getByRole("button", { name: /settings/i }));

--- a/packages/chat-ui/test/HeaderBar.test.tsx
+++ b/packages/chat-ui/test/HeaderBar.test.tsx
@@ -41,3 +41,59 @@ test("menus are not rendered when their item lists are omitted", () => {
 	expect(screen.queryByRole("button", { name: /chat history/i })).toBeNull();
 	expect(screen.queryByRole("button", { name: /more options/i })).toBeNull();
 });
+
+test("new chat is disabled when canNewChat is false, and enabled by default", () => {
+	let created = 0;
+	const { rerender } = render(<HeaderBar onNewChat={() => (created += 1)} canNewChat={false} />);
+	const btn = () => screen.getByRole("button", { name: /new chat/i }) as HTMLButtonElement;
+	expect(btn().disabled).toBe(true);
+	fireEvent.click(btn());
+	expect(created).toBe(0);
+
+	// Omitted → enabled (the other surfaces pass no gate).
+	rerender(<HeaderBar onNewChat={() => (created += 1)} />);
+	expect(btn().disabled).toBe(false);
+	fireEvent.click(btn());
+	expect(created).toBe(1);
+});
+
+test("every control carries a data-tip tooltip matching its accessible name, and NO title", () => {
+	const { container } = render(
+		<HeaderBar onNewChat={() => {}} historyItems={HISTORY} moreItems={MORE} />,
+	);
+	const buttons = Array.from(container.querySelectorAll<HTMLElement>(".header-btn"));
+	expect(buttons).toHaveLength(3);
+	for (const btn of buttons) {
+		const label = btn.getAttribute("aria-label");
+		expect(label).toBeTruthy();
+		// Our CSS tooltip is driven by data-tip. `title` must be ABSENT or the browser
+		// renders a second, native tooltip on top of ours.
+		expect(btn.getAttribute("data-tip")).toBe(label);
+		expect(btn.getAttribute("title")).toBeNull();
+	}
+});
+
+test("the controls are SVG icons (not text glyphs), hidden from the a11y tree", () => {
+	const { container } = render(
+		<HeaderBar onNewChat={() => {}} historyItems={HISTORY} moreItems={MORE} />,
+	);
+	const buttons = Array.from(container.querySelectorAll<HTMLElement>(".header-btn"));
+	for (const btn of buttons) {
+		const svg = btn.querySelector("svg");
+		expect(svg).not.toBeNull();
+		// The accessible name comes from aria-label; the glyph must not be announced.
+		expect(svg?.getAttribute("aria-hidden")).toBe("true");
+		// No leftover text glyph beside the icon.
+		expect(btn.textContent?.trim()).toBe("");
+	}
+});
+
+test("the controls read left-to-right: history, new chat, more", () => {
+	const { container } = render(
+		<HeaderBar onNewChat={() => {}} historyItems={HISTORY} moreItems={MORE} />,
+	);
+	const labels = Array.from(container.querySelectorAll<HTMLElement>(".header-btn")).map(b =>
+		b.getAttribute("aria-label"),
+	);
+	expect(labels).toEqual(["Chat history", "New chat", "More options"]);
+});

--- a/packages/chat-ui/test/HeaderBar.test.tsx
+++ b/packages/chat-ui/test/HeaderBar.test.tsx
@@ -42,6 +42,17 @@ test("menus are not rendered when their item lists are omitted", () => {
 	expect(screen.queryByRole("button", { name: /more options/i })).toBeNull();
 });
 
+test("the history menu can caption its scope (session-only history must not look durable)", () => {
+	render(<HeaderBar onNewChat={() => {}} historyItems={HISTORY} historyHeader="This session" />);
+	act(() => {
+		fireEvent.click(screen.getByRole("button", { name: /chat history/i }));
+	});
+	expect(screen.getByText("This session")).toBeDefined();
+	// A caption, not a selectable entry.
+	expect(screen.queryByRole("menuitem", { name: /this session/i })).toBeNull();
+	expect(screen.getByRole("menuitem", { name: /load balancer walkthrough/i })).toBeDefined();
+});
+
 test("new chat is disabled when canNewChat is false, and enabled by default", () => {
 	let created = 0;
 	const { rerender } = render(<HeaderBar onNewChat={() => (created += 1)} canNewChat={false} />);

--- a/packages/chat-ui/test/Transcript.test.tsx
+++ b/packages/chat-ui/test/Transcript.test.tsx
@@ -172,3 +172,49 @@ test("without thinkingLabel the row is the plain Thinking… indicator", () => {
 	expect(within(container).getByText(/Thinking…/)).toBeDefined();
 	expect(container.textContent).not.toContain("with web search");
 });
+
+// ── Claude-parity: the brand block lives INSIDE the scrollport ───────────────
+// Claude for Office scrolls its brand away with the transcript. Routing it through
+// `emptyState` would make it VANISH on first send (EmptyState unmounts) instead of
+// scrolling, so it must be a leading child of `.messages` in BOTH states.
+
+test("brand renders inside the .messages scrollport when the transcript is empty", () => {
+	const { container } = render(
+		<Transcript messages={[]} streaming={false} brand={<div className="brand-block">xcsh</div>} />,
+	);
+	const scrollport = container.querySelector(".messages");
+	const brand = container.querySelector(".brand-block");
+	expect(brand).not.toBeNull();
+	expect(scrollport?.contains(brand as Node)).toBe(true);
+});
+
+test("brand is the FIRST child of .messages and precedes the rows once messages exist", () => {
+	const messages: ChatMessage[] = [msg({ id: "1", role: "user", text: "hello there" })];
+	const { container } = render(
+		<Transcript messages={messages} streaming={false} brand={<div className="brand-block">xcsh</div>} />,
+	);
+	const scrollport = container.querySelector(".messages") as HTMLElement;
+	expect(scrollport.firstElementChild?.className).toContain("brand-block");
+	// Still renders the row (brand does not replace content).
+	expect(screen.getByText("hello there")).toBeDefined();
+});
+
+test("without brand nothing extra is rendered (other surfaces unaffected)", () => {
+	const { container } = render(<Transcript messages={[]} streaming={false} />);
+	expect(container.querySelector(".brand-block")).toBeNull();
+});
+
+test("an EMPTY transcript is not auto-pinned to the bottom (the brand stays visible)", () => {
+	// The auto-pin useLayoutEffect has no dep array and userAtBottom starts true, so
+	// without an `empty` guard it pins on first paint and scrolls the brand out of view.
+	const { container } = render(
+		<Transcript messages={[]} streaming={false} brand={<div className="brand-block">xcsh</div>} />,
+	);
+	const list = container.querySelector(".messages") as HTMLElement;
+	Object.defineProperty(list, "scrollHeight", { configurable: true, value: 1000 });
+	Object.defineProperty(list, "clientHeight", { configurable: true, value: 300 });
+	list.scrollTop = 0;
+	// Force another render pass; the effect must NOT pin while empty.
+	fireEvent.scroll(list);
+	expect(list.scrollTop).toBe(0);
+});

--- a/packages/chat-ui/test/Transcript.test.tsx
+++ b/packages/chat-ui/test/Transcript.test.tsx
@@ -204,17 +204,43 @@ test("without brand nothing extra is rendered (other surfaces unaffected)", () =
 	expect(container.querySelector(".brand-block")).toBeNull();
 });
 
+/**
+ * Give every div a non-zero `scrollHeight` for the duration of `body`.
+ *
+ * happy-dom has no layout engine, so `scrollHeight` is 0 and `scrollTop =
+ * scrollHeight` is a no-op — an auto-pin assertion would pass whether or not the
+ * component pins, which is worse than no test. Stubbing it on the PROTOTYPE (before
+ * render, since the effect runs during the first commit) makes a pin observable.
+ */
+function withFakeScrollHeight(value: number, body: () => void): void {
+	const proto = HTMLDivElement.prototype as unknown as object;
+	const original = Object.getOwnPropertyDescriptor(proto, "scrollHeight");
+	Object.defineProperty(proto, "scrollHeight", { configurable: true, get: () => value });
+	try {
+		body();
+	} finally {
+		if (original) Object.defineProperty(proto, "scrollHeight", original);
+		else Reflect.deleteProperty(proto, "scrollHeight");
+	}
+}
+
 test("an EMPTY transcript is not auto-pinned to the bottom (the brand stays visible)", () => {
 	// The auto-pin useLayoutEffect has no dep array and userAtBottom starts true, so
 	// without an `empty` guard it pins on first paint and scrolls the brand out of view.
-	const { container } = render(
-		<Transcript messages={[]} streaming={false} brand={<div className="brand-block">xcsh</div>} />,
-	);
-	const list = container.querySelector(".messages") as HTMLElement;
-	Object.defineProperty(list, "scrollHeight", { configurable: true, value: 1000 });
-	Object.defineProperty(list, "clientHeight", { configurable: true, value: 300 });
-	list.scrollTop = 0;
-	// Force another render pass; the effect must NOT pin while empty.
-	fireEvent.scroll(list);
-	expect(list.scrollTop).toBe(0);
+	withFakeScrollHeight(1000, () => {
+		const { container } = render(
+			<Transcript messages={[]} streaming={false} brand={<div className="brand-block">xcsh</div>} />,
+		);
+		expect((container.querySelector(".messages") as HTMLElement).scrollTop).toBe(0);
+	});
+});
+
+test("a POPULATED transcript still auto-pins to the tail (the guard didn't disable following)", () => {
+	withFakeScrollHeight(1000, () => {
+		const messages: ChatMessage[] = [msg({ id: "1", role: "assistant", text: "streamed answer" })];
+		const { container } = render(
+			<Transcript messages={messages} streaming={true} brand={<div className="brand-block">xcsh</div>} />,
+		);
+		expect((container.querySelector(".messages") as HTMLElement).scrollTop).toBe(1000);
+	});
 });

--- a/packages/chat-ui/test/panel-css.test.ts
+++ b/packages/chat-ui/test/panel-css.test.ts
@@ -60,6 +60,17 @@ describe(".xcsh-doc document surface", () => {
 });
 
 describe("Claude-parity shell chrome", () => {
+	test("the F5 mark honours its size prop (no width/height override)", () => {
+		// F5Logo emits width/height ATTRIBUTES from `size`. Those are presentational
+		// hints that any author rule outranks, so a width/height declaration in
+		// `.f5-mark` makes `size` dead and pins every mark to the PNG's intrinsic
+		// 128px — which is what turned a 20px brand mark into a 140px band.
+		const rule = /\.f5-mark\s*\{([^}]*)\}/.exec(PANEL_CSS)?.[1] ?? "";
+		expect(rule).toContain("display:block");
+		expect(rule).not.toMatch(/\bwidth\s*:/);
+		expect(rule).not.toMatch(/\bheight\s*:/);
+	});
+
 	test("the brand block is a top-anchored layer (not the centered empty state)", () => {
 		expect(PANEL_CSS).toContain(".brand-block");
 		// Must NOT centre like .empty-state — it sits at the top of the scrollport.

--- a/packages/chat-ui/test/panel-css.test.ts
+++ b/packages/chat-ui/test/panel-css.test.ts
@@ -58,3 +58,37 @@ describe(".xcsh-doc document surface", () => {
 		expect(PANEL_CSS).toMatch(/\.xcsh-doc[^{]*(code|pre)[^{]*\{[^}]*var\(--font-mono\)/);
 	});
 });
+
+describe("Claude-parity shell chrome", () => {
+	test("the brand block is a top-anchored layer (not the centered empty state)", () => {
+		expect(PANEL_CSS).toContain(".brand-block");
+		// Must NOT centre like .empty-state — it sits at the top of the scrollport.
+		expect(PANEL_CSS).not.toMatch(/\.brand-block\s*\{[^}]*justify-content:\s*center/);
+	});
+
+	test("the pinned control row has no divider (Claude has no rule under the brand)", () => {
+		expect(PANEL_CSS).not.toMatch(/^\.header\s*\{[^}]*border-bottom/m);
+	});
+
+	test("the Office host reserves right padding so the row clears Office's own i button", () => {
+		expect(PANEL_CSS).toMatch(/\.xcsh-host-office\s+\.header\s*\{[^}]*padding-right/);
+	});
+
+	test("icon buttons carry a CSS tooltip driven by data-tip, hidden by default", () => {
+		expect(PANEL_CSS).toMatch(/\.header-btn\[data-tip\]::after\s*\{[^}]*content:\s*attr\(data-tip\)/);
+		expect(PANEL_CSS).toMatch(/\.header-btn\[data-tip\]::after\s*\{[^}]*opacity:\s*0/);
+		expect(PANEL_CSS).toMatch(/\.header-btn\[data-tip\]:hover::after/);
+		expect(PANEL_CSS).toMatch(/\.header-btn\[data-tip\]:focus-visible::after/);
+		// Respect reduced-motion (no fade/delay for users who ask for less motion).
+		expect(PANEL_CSS).toMatch(/prefers-reduced-motion/);
+	});
+
+	test("stacked pills read as Claude's vertical slash-command list", () => {
+		expect(PANEL_CSS).toMatch(/\.pills\.pills-stacked\s*\{[^}]*flex-direction:\s*column/);
+	});
+
+	test("the retired bespoke office header + floating settings button are gone", () => {
+		expect(PANEL_CSS).not.toContain(".header-new-chat");
+		expect(PANEL_CSS).not.toContain(".gateway-settings-btn");
+	});
+});

--- a/packages/office-pane/.gitignore
+++ b/packages/office-pane/.gitignore
@@ -1,0 +1,4 @@
+# Advisory contact-sheet PNGs written by the XCSH_VISUAL-gated Puppeteer tests
+# (markdown-visual / shell-visual). Regenerated on every run; the computed-style
+# assertions are the oracle, not these images, so they are never committed.
+test/__visual__/

--- a/packages/office-pane/src/office/host-adapter.ts
+++ b/packages/office-pane/src/office/host-adapter.ts
@@ -81,9 +81,15 @@ export interface MountGateOptions {
  * typography (Claude-for-Office parity) — the terminal chrome (red frame, glyph
  * gutter, powerline, code) is unchanged; only the prose read switches to sans.
  * This class is Office-only; Chrome/VS Code/CLI never set it.
+ *
+ * `.xcsh-host-office` is a separate marker for host-specific layout — currently
+ * reserving right-side header room so our control row clears the ⓘ button Office
+ * itself draws over the top-right of every task pane. It is deliberately NOT
+ * folded into `.xcsh-doc`: that one means "sans document typography", and a
+ * future non-Office surface could want one without the other.
  */
 export function mountGate(container: Element, opts: MountGateOptions): Root {
-	container.classList.add("xcsh-panel", "xcsh-doc");
+	container.classList.add("xcsh-panel", "xcsh-doc", "xcsh-host-office");
 	const root = createRoot(container);
 	root.render(createElement(GatewayGate, opts));
 	return root;

--- a/packages/office-pane/src/panel/ChatPanel.tsx
+++ b/packages/office-pane/src/panel/ChatPanel.tsx
@@ -19,8 +19,10 @@ import {
 	type ComposerHandle,
 	EmptyState,
 	F5Logo,
+	HeaderBar,
 	type ImageAttachment,
 	isImageAttachment,
+	type MenuItem,
 	type SkillPill,
 	Transcript,
 } from "@f5-sales-demo/xcsh-chat-ui";
@@ -118,25 +120,14 @@ const STARTERS: readonly (SkillPill & { text: string })[] = [
 	{ id: "summarize", label: "Summarize", hint: "Prefill a prompt", text: "Summarize this document." },
 ];
 
-/** The F5-branded terminal header, shared by the chat and config-error views.
- *  When `onNewChat` is supplied, a "New chat" affordance resets the conversation. */
-function Header({ onNewChat, canNewChat }: { onNewChat?: () => void; canNewChat?: boolean } = {}) {
+/** The F5 brand block. Rendered INSIDE the transcript scrollport (via
+ *  `Transcript.brand`) so it scrolls away with the conversation instead of sitting
+ *  in a pinned band — the pinned row is the {@link HeaderBar} control row. */
+function Brand() {
 	return (
-		<div className="header">
+		<div className="brand-block">
 			<F5Logo variant="mark" size={20} />
-			<span className="header-title">xcsh</span>
-			{onNewChat ? (
-				<button
-					type="button"
-					className="header-new-chat"
-					onClick={onNewChat}
-					disabled={!canNewChat}
-					title="Start a new chat"
-					aria-label="New chat"
-				>
-					New chat
-				</button>
-			) : null}
+			<span className="brand-title">xcsh</span>
 		</div>
 	);
 }
@@ -205,6 +196,21 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 		[pickPath],
 	);
 
+	// The header's "⋯" menu. It carries gateway Settings, which used to be a floating
+	// button the shared GatewayGate rendered — that stacked a second right-aligned row
+	// that collided with Office's native ⓘ. Omitted entirely (rather than rendered
+	// inert) when the host wired no reconfigure action, so the menu is never empty.
+	const moreItems = useMemo<MenuItem[] | undefined>(
+		() => (onReconfigure ? [{ id: "settings", label: "Settings" }] : undefined),
+		[onReconfigure],
+	);
+	const handleMoreSelect = useCallback(
+		(id: string) => {
+			if (id === "settings") onReconfigure?.();
+		},
+		[onReconfigure],
+	);
+
 	// Picking a skill prefills the composer with `/name ` (Claude idiom) for the user
 	// to add input and send; the engine treats a leading `/skill` as a skill invocation.
 	const handleSkillSelect = useCallback((name: string) => {
@@ -262,13 +268,35 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 		}
 	}, [providerRejected, onProviderConfigError]);
 
+	// Chat is gated until provisioning resolves so a turn can't race `configure_ack`.
+	const ready = provisioning === "ready";
+
+	// The pinned control row, rendered in EVERY branch. The error and onboarding
+	// branches need it too: it now carries the only route to gateway config (the
+	// shared GatewayGate no longer renders a floating Settings button), and those
+	// are exactly the states where the user needs to fix the gateway. They pass a
+	// `title` because they don't render the transcript, whose scrolling brand block
+	// otherwise carries the wordmark.
+	//
+	// New chat stays available WHILE streaming — it aborts the in-flight turn
+	// (chat_stop) and resets, so a wedged turn is recoverable without a restart.
+	const controlRow = (title?: string) => (
+		<HeaderBar
+			title={title}
+			onNewChat={newChat}
+			canNewChat={ready && turns.length > 0}
+			moreItems={moreItems}
+			onMoreSelect={handleMoreSelect}
+		/>
+	);
+
 	// A rejected provider `configure` is a non-silent, recoverable state: show the
 	// reason and a Reconfigure action instead of a chat that would silently talk to
 	// xcsh's baked-in default provider. #2134.
 	if (provisioning === "error") {
 		return (
 			<>
-				<Header />
+				{controlRow("xcsh")}
 				<div className="gateway-config-error" role="alert">
 					<p className="gateway-config-error-title">Couldn't configure the gateway.</p>
 					<p className="gateway-config-error-detail">
@@ -289,7 +317,7 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 	if (firstRunBridgeFailure) {
 		return (
 			<>
-				<Header />
+				{controlRow("xcsh")}
 				<main className="onboarding">
 					<F5Logo variant="mark" size={64} />
 					<h2 className="onboarding-title">Install xcsh to get started</h2>
@@ -317,23 +345,18 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 		);
 	}
 
-	// Chat is gated until provisioning resolves so a turn can't race `configure_ack`.
-	const ready = provisioning === "ready";
-
 	const emptyState = (
 		<EmptyState
 			pills={STARTERS.map(({ id, label, hint }) => ({ id, label, hint }))}
 			onPick={id => composerRef.current?.setText(STARTERS.find(s => s.id === id)?.text ?? "")}
-			// The persistent Header already shows the F5 brand — don't duplicate it here.
+			// The scrolling brand block already shows the F5 mark — don't duplicate it.
 			logo={false}
 		/>
 	);
 
 	return (
 		<>
-			{/* New chat stays available WHILE streaming — it aborts the in-flight turn
-			    (chat_stop) and resets, so a wedged turn is recoverable without a restart. */}
-			<Header onNewChat={newChat} canNewChat={ready && turns.length > 0} />
+			{controlRow()}
 			<Transcript
 				messages={messages}
 				streaming={streaming}
@@ -341,6 +364,7 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 				// say so rather than showing a bare "Thinking…" that reads as a hang.
 				thinkingLabel={webSearch ? "with web search" : undefined}
 				onRetry={() => retry()}
+				brand={<Brand />}
 				emptyState={emptyState}
 			/>
 			{/* Hidden file input backing the "+" → "Add files or photos" category —

--- a/packages/office-pane/src/panel/ChatPanel.tsx
+++ b/packages/office-pane/src/panel/ChatPanel.tsx
@@ -138,9 +138,29 @@ const PROVISIONING_PLACEHOLDER: Record<string, string> = {
 	configuring: "Configuring gateway…",
 };
 
+/** Sentinel history-menu id for "leave the archive, back to the live chat". Cannot
+ *  collide with a real entry id (those are the engine's `conv-N` boundaries). */
+const LIVE_CHAT_ITEM = "__current__";
+
 export function ChatPanel({ transport, provision, onConnected, onReconfigure, onProviderConfigError }: ChatPanelProps) {
-	const { turns, send, stop, retry, newChat, status, reason, error, provisioning, provisionError, skills, pickPath } =
-		useChatSession(transport, { provision, onConnected });
+	const {
+		turns,
+		send,
+		stop,
+		retry,
+		newChat,
+		history,
+		viewingId,
+		viewHistory,
+		exitHistory,
+		status,
+		reason,
+		error,
+		provisioning,
+		provisionError,
+		skills,
+		pickPath,
+	} = useChatSession(transport, { provision, onConnected });
 	const composerRef = useRef<ComposerHandle>(null);
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	// Photo/image attachments staged for the next send. The host owns this state and
@@ -194,6 +214,28 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 			}
 		},
 		[pickPath],
+	);
+
+	// The header's clock menu: this session's banked chats, newest first, plus a way
+	// back to the live one while reading an archive. Omitted entirely when there is
+	// nothing to show, so the control never appears as a dead button on first run.
+	const historyItems = useMemo<MenuItem[] | undefined>(() => {
+		if (history.length === 0) return undefined;
+		const banked: MenuItem[] = history.map(h => ({
+			id: h.id,
+			label: h.title,
+			// The one already on screen isn't a destination.
+			disabled: h.id === viewingId,
+		}));
+		return viewingId ? [{ id: LIVE_CHAT_ITEM, label: "Current chat" }, ...banked] : banked;
+	}, [history, viewingId]);
+
+	const handleHistorySelect = useCallback(
+		(id: string) => {
+			if (id === LIVE_CHAT_ITEM) exitHistory();
+			else viewHistory(id);
+		},
+		[exitHistory, viewHistory],
 	);
 
 	// The header's "⋯" menu. It carries gateway Settings, which used to be a floating
@@ -256,8 +298,9 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 
 	// Auto-open the gateway config when a turn fails because the configured provider
 	// rejected us (provider-4xx = bad/absent gateway token). Fire once per episode;
-	// a subsequent retry (status leaves 'error') re-arms it.
-	const providerRejected = status === "error" && reason === "provider-4xx";
+	// a subsequent retry (status leaves 'error') re-arms it. Never while reading an
+	// archive: that failure is history, and popping the form over it is a false alarm.
+	const providerRejected = !viewingId && status === "error" && reason === "provider-4xx";
 	const promptedRef = useRef(false);
 	useEffect(() => {
 		if (providerRejected && !promptedRef.current) {
@@ -285,6 +328,10 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 			title={title}
 			onNewChat={newChat}
 			canNewChat={ready && turns.length > 0}
+			historyItems={historyItems}
+			onHistorySelect={handleHistorySelect}
+			// Say the quiet part out loud: these chats live only in this pane session.
+			historyHeader="This session"
 			moreItems={moreItems}
 			onMoreSelect={handleMoreSelect}
 		/>
@@ -354,6 +401,17 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 		/>
 	);
 
+	// Reading a banked chat is read-only (the engine no longer holds its context, so a
+	// reply would answer without it). The session refuses such a send outright; the
+	// composer says so rather than looking broken, and no error row offers a Retry
+	// that could only fire into a different conversation.
+	const viewing = viewingId !== null;
+	const composerPlaceholder = viewing
+		? "Reading a past chat — reopen the current chat to reply"
+		: ready
+			? undefined
+			: PROVISIONING_PLACEHOLDER[provisioning];
+
 	return (
 		<>
 			{controlRow()}
@@ -363,7 +421,7 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 				// A server-side web search adds several seconds before the first token;
 				// say so rather than showing a bare "Thinking…" that reads as a hang.
 				thinkingLabel={webSearch ? "with web search" : undefined}
-				onRetry={() => retry()}
+				onRetry={viewing ? undefined : () => retry()}
 				brand={<Brand />}
 				emptyState={emptyState}
 			/>
@@ -384,8 +442,8 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 			<Composer
 				ref={composerRef}
 				streaming={streaming}
-				disabled={!ready}
-				placeholder={ready ? undefined : PROVISIONING_PLACEHOLDER[provisioning]}
+				disabled={!ready || viewing}
+				placeholder={composerPlaceholder}
 				onSend={handleSend}
 				onStop={stop}
 				attachCategories={attachCategories}

--- a/packages/office-pane/src/panel/ChatPanel.tsx
+++ b/packages/office-pane/src/panel/ChatPanel.tsx
@@ -392,14 +392,27 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 		);
 	}
 
-	const emptyState = (
-		<EmptyState
-			pills={STARTERS.map(({ id, label, hint }) => ({ id, label, hint }))}
-			onPick={id => composerRef.current?.setText(STARTERS.find(s => s.id === id)?.text ?? "")}
-			// The scrolling brand block already shows the F5 mark — don't duplicate it.
-			logo={false}
-		/>
-	);
+	// Starters: prefer the engine's real skills as a vertical /slash list (Claude's
+	// shape, and every pill is a genuine invocation — the engine treats a leading
+	// `/skill` as one). Falls back to the prose starters until the skills reply lands,
+	// or for good if no skills are loaded, so the empty state is never bare.
+	const emptyState =
+		skills.length > 0 ? (
+			<EmptyState
+				heading="Get started with a skill:"
+				pills={skills.map(s => ({ id: s.name, label: `/${s.name}`, hint: s.description }))}
+				onPick={handleSkillSelect}
+				stacked
+				logo={false}
+			/>
+		) : (
+			<EmptyState
+				pills={STARTERS.map(({ id, label, hint }) => ({ id, label, hint }))}
+				onPick={id => composerRef.current?.setText(STARTERS.find(s => s.id === id)?.text ?? "")}
+				// The scrolling brand block already shows the F5 mark — don't duplicate it.
+				logo={false}
+			/>
+		);
 
 	// Reading a banked chat is read-only (the engine no longer holds its context, so a
 	// reply would answer without it). The session refuses such a send outright; the

--- a/packages/office-pane/src/panel/useChatSession.ts
+++ b/packages/office-pane/src/panel/useChatSession.ts
@@ -70,6 +70,34 @@ export interface AssistantTurn {
 
 export type Turn = UserTurn | AssistantTurn;
 
+/**
+ * A conversation banked by {@link ChatSessionResult.newChat}, for READ-BACK only.
+ *
+ * `newChat` bumps the `history_hint` that tells the bridge to reset the engine's
+ * message array, so by the time a chat is in here the engine has already forgotten
+ * it. Reopening one shows the transcript; it does NOT resume the conversation
+ * (see {@link ChatSessionResult.viewHistory}).
+ *
+ * In-memory and session-scoped: closing or reloading the pane loses these. `Turn`
+ * is plain JSON-serializable data, so a durable store could drop in unchanged.
+ */
+export interface ChatHistoryEntry {
+	id: string;
+	/** Derived from the first user turn, for the history menu. */
+	title: string;
+	turns: Turn[];
+}
+
+/** Longest history-menu title before ellipsis (a 320px pane is narrow). */
+const HISTORY_TITLE_MAX = 48;
+
+function historyTitle(turns: Turn[]): string {
+	const first = turns.find((t): t is UserTurn => t.kind === "user");
+	const text = first?.text.trim().replace(/\s+/g, " ") ?? "";
+	if (!text) return "Untitled chat"; // an images-only opening turn has no text
+	return text.length > HISTORY_TITLE_MAX ? `${text.slice(0, HISTORY_TITLE_MAX - 1)}…` : text;
+}
+
 /** Optional per-send extras. `mode` overrides the fixed Office mode (retry only);
  *  `images` are photo/image attachments sent as vision blocks. */
 export interface SendOptions {
@@ -82,14 +110,30 @@ export interface SendOptions {
 }
 
 export interface ChatSessionResult {
+	/** The transcript to render: the live conversation, or — while
+	 *  {@link viewingId} is set — the archived one being read back. */
 	turns: Turn[];
 	send(text: string, opts?: SendOptions): void;
 	stop(): void;
 	retry(): void;
-	/** Start a fresh conversation: clear the transcript and reset the engine's
-	 *  history (the next turn carries a new `history_hint`, which the bridge maps
-	 *  to `replaceMessages([])`). */
+	/** Start a fresh conversation: bank the outgoing one in {@link history}, clear
+	 *  the transcript and reset the engine's history (the next turn carries a new
+	 *  `history_hint`, which the bridge maps to `replaceMessages([])`). Also leaves
+	 *  history-viewing mode. */
 	newChat(): void;
+	/** Conversations banked by {@link newChat} this session, newest first. */
+	history: ChatHistoryEntry[];
+	/** The archived conversation currently being read back, or null for the live one. */
+	viewingId: string | null;
+	/**
+	 * Read back an archived conversation. READ-ONLY: the engine's context was reset
+	 * when this chat was banked, so {@link send} refuses while viewing rather than
+	 * answering a follow-up without the conversation on screen. The live chat is
+	 * untouched — {@link exitHistory} returns to it.
+	 */
+	viewHistory(id: string): void;
+	/** Return to the live conversation. */
+	exitHistory(): void;
 	status: "idle" | "streaming" | "done" | "error";
 	/** Populated when status is 'error'; mirrors TurnState.reason for turn errors
 	 *  and is set to 'bridge-disconnected' for transport.connect() failures. */
@@ -116,7 +160,18 @@ export interface ChatSessionResult {
 // ---------------------------------------------------------------------------
 
 export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): ChatSessionResult {
+	// The LIVE conversation. Streaming frames only ever land here, so reading an
+	// archive never interferes with a turn in flight.
 	const [turns, setTurns] = useState<Turn[]>([]);
+	const [history, setHistory] = useState<ChatHistoryEntry[]>([]);
+	const [viewingId, setViewingId] = useState<string | null>(null);
+	// Mirrors `viewingId` for send()'s refusal guard, so the guard can't be defeated
+	// by a handler captured in an earlier render. Written only via setViewing.
+	const viewingIdRef = useRef<string | null>(null);
+	// Mirrors the live turns so newChat() can bank them without taking `turns` as a
+	// dependency (keeping its identity stable) or side-effecting in a state updater.
+	const turnsRef = useRef<Turn[]>(turns);
+	turnsRef.current = turns;
 	// Holds a connect() rejection; reset whenever transport changes.
 	const [connectErr, setConnectErr] = useState<{ reason: ChatErrorReason; message: string } | null>(null);
 	const [provisioning, setProvisioning] = useState<Provisioning>("connecting");
@@ -221,8 +276,18 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 		};
 	}, [transport]);
 
+	const setViewing = useCallback((id: string | null) => {
+		viewingIdRef.current = id;
+		setViewingId(id);
+	}, []);
+
 	const send = useCallback(
 		(text: string, opts?: SendOptions) => {
+			// Reading back an archived chat is READ-ONLY. The engine's message array was
+			// reset when that chat was banked, so a follow-up here would be answered
+			// WITHOUT the conversation the user is looking at. Refuse in the hook, not
+			// just by disabling the composer, so no UI path can produce that answer.
+			if (viewingIdRef.current) return;
 			const mode = opts?.mode ?? DEFAULT_INTERACTION_MODE;
 			const images = opts?.images;
 			const contextPaths = opts?.contextPaths;
@@ -320,6 +385,20 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 				/* transport gone — nothing to abort; fall through to the local reset */
 			}
 		}
+		// Bank the outgoing conversation for read-back before clearing it. Keyed by the
+		// history_hint it ran under — the same value the engine is about to forget.
+		// Nothing to bank for an empty transcript (no blank entries), and it is always
+		// the LIVE turns, never an archive being viewed.
+		const outgoing = turnsRef.current;
+		if (outgoing.length > 0) {
+			const entry: ChatHistoryEntry = {
+				id: `conv-${historyHintRef.current}`,
+				title: historyTitle(outgoing),
+				turns: outgoing,
+			};
+			setHistory(prev => [entry, ...prev]);
+		}
+		setViewing(null);
 		// Bump the conversation boundary so the NEXT send resets the engine's history,
 		// clear the transcript, and forget the last prompt (nothing to retry into the
 		// fresh chat). Ids stay monotonic (counterRef is not reset) to avoid collisions.
@@ -328,9 +407,28 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 		lastUserTextRef.current = "";
 		lastUserImagesRef.current = undefined;
 		setTurns([]);
-	}, [transport]);
+	}, [transport, setViewing]);
 
-	const lastAssistant = turns.findLast((t): t is AssistantTurn => t.kind === "assistant");
+	const viewHistory = useCallback(
+		(id: string) => {
+			setViewing(id);
+		},
+		[setViewing],
+	);
+
+	const exitHistory = useCallback(() => {
+		setViewing(null);
+	}, [setViewing]);
+
+	// What the transcript shows: the archive being read back, else the live chat. A
+	// missing id can't happen (entries are never removed) but falls back to live
+	// rather than blanking the pane.
+	const viewedTurns = viewingId ? history.find(h => h.id === viewingId)?.turns : undefined;
+	const visibleTurns = viewedTurns ?? turns;
+
+	// Status describes what is ON SCREEN, so an archived (settled) chat never shows a
+	// streaming caret for a turn still running in the live conversation behind it.
+	const lastAssistant = visibleTurns.findLast((t): t is AssistantTurn => t.kind === "assistant");
 
 	// connect() failures take precedence; fall back to the last assistant turn's status.
 	// Design note: we expose `reason` directly on ChatSessionResult (same field name/type
@@ -351,5 +449,22 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 		status = "idle";
 	}
 
-	return { turns, send, stop, retry, newChat, status, reason, error, provisioning, provisionError, skills, pickPath };
+	return {
+		turns: visibleTurns,
+		send,
+		stop,
+		retry,
+		newChat,
+		history,
+		viewingId,
+		viewHistory,
+		exitHistory,
+		status,
+		reason,
+		error,
+		provisioning,
+		provisionError,
+		skills,
+		pickPath,
+	};
 }

--- a/packages/office-pane/test/ChatPanel.test.tsx
+++ b/packages/office-pane/test/ChatPanel.test.tsx
@@ -109,6 +109,58 @@ test("New chat is available WHILE streaming and aborts the in-flight turn (wedge
 	await waitFor(() => expect(scope.queryByText("Summarize this document.")).toBeNull());
 });
 
+test("chat history: banked on New chat, listed under the clock, and read back READ-ONLY", async () => {
+	const mock = new MockTransport();
+	const { container } = render(<ChatPanel transport={mock} />);
+	const scope = within(container);
+	await settle();
+
+	// Nothing banked yet → no history control at all (never a dead button).
+	expect(scope.queryByRole("button", { name: /chat history/i })).toBeNull();
+
+	// One completed exchange, then New chat banks it.
+	fireEvent.click(scope.getByRole("button", { name: /summarize/i }));
+	fireEvent.click(scope.getByRole("button", { name: /send/i }));
+	const req = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request")[0];
+	if (!req) throw new Error("expected chat_request");
+	await act(async () => {
+		mock.emit({ type: "chat_done", id: req.id });
+	});
+	fireEvent.click(scope.getByRole("button", { name: /new chat/i }));
+	await waitFor(() => expect(scope.queryByText("Summarize this document.")).toBeNull());
+
+	// The clock now exists and lists the banked chat under a session-scope caption —
+	// this history does NOT survive a reload, and must not look like it does.
+	await act(async () => {
+		fireEvent.click(scope.getByRole("button", { name: /chat history/i }));
+	});
+	expect(scope.getByText(/this session/i)).toBeDefined();
+	await act(async () => {
+		fireEvent.click(scope.getByRole("menuitem", { name: /summarize this document/i }));
+	});
+
+	// The archived transcript is shown…
+	await waitFor(() => expect(scope.getByText("Summarize this document.")).toBeDefined());
+	// …read-only. The engine reset its history when this chat was banked, so a reply
+	// here would answer without the conversation on screen: the composer is inert AND
+	// the session refuses the send.
+	const editor = scope.getByRole("textbox", { name: /message input/i });
+	expect(editor.getAttribute("contenteditable")).toBe("false");
+	const sentBefore = mock.sent.filter(m => m.type === "chat_request").length;
+	fireEvent.keyDown(editor, { key: "Enter" });
+	expect(mock.sent.filter(m => m.type === "chat_request")).toHaveLength(sentBefore);
+
+	// And there is a way back to the live conversation.
+	await act(async () => {
+		fireEvent.click(scope.getByRole("button", { name: /chat history/i }));
+	});
+	await act(async () => {
+		fireEvent.click(scope.getByRole("menuitem", { name: /current chat/i }));
+	});
+	await waitFor(() => expect(scope.queryByText("Summarize this document.")).toBeNull());
+	expect(scope.getByRole("textbox", { name: /message input/i }).getAttribute("contenteditable")).toBe("true");
+});
+
 test("the empty state offers starter pills that PREFILL the composer without sending", async () => {
 	const mock = new MockTransport();
 	const { container } = render(<ChatPanel transport={mock} />);

--- a/packages/office-pane/test/ChatPanel.test.tsx
+++ b/packages/office-pane/test/ChatPanel.test.tsx
@@ -10,13 +10,50 @@ async function settle(): Promise<void> {
 	});
 }
 
-test("renders the terminal shell: header, transcript live region, and composer", () => {
+test("renders the terminal shell: pinned control row, transcript live region, and composer", () => {
 	const { container } = render(<ChatPanel transport={new MockTransport()} />);
 	const scope = within(container);
-	expect(scope.getByRole("log", { name: /conversation/i })).toBeDefined();
+	const log = scope.getByRole("log", { name: /conversation/i });
+	expect(log).toBeDefined();
 	expect(scope.getByRole("textbox", { name: /message input/i })).toBeDefined();
-	// F5-branded header title.
-	expect(scope.getByText("xcsh")).toBeDefined();
+
+	// The F5 brand block lives INSIDE the scrollport so it scrolls away with the
+	// conversation (Claude parity) instead of sitting in a pinned band.
+	const brand = container.querySelector(".brand-block");
+	expect(brand).not.toBeNull();
+	expect(log.contains(brand)).toBe(true);
+	expect(within(brand as HTMLElement).getByText("xcsh")).toBeDefined();
+	// Exactly one wordmark: the header must not duplicate the brand here (#2178).
+	expect(scope.getAllByText("xcsh")).toHaveLength(1);
+
+	// The control row is PINNED — a sibling of the scrollport, not inside it.
+	const header = container.querySelector(".header");
+	expect(header).not.toBeNull();
+	expect(log.contains(header)).toBe(false);
+
+	// The retired chrome is gone: no text "New chat" button, no floating Settings.
+	expect(container.querySelector(".header-new-chat")).toBeNull();
+	expect(container.querySelector(".gateway-settings-btn")).toBeNull();
+});
+
+test("the ⋯ menu carries Settings, wired to the host's reconfigure action", async () => {
+	let reconfigured = 0;
+	const { container } = render(<ChatPanel transport={new MockTransport()} onReconfigure={() => (reconfigured += 1)} />);
+	const scope = within(container);
+	await settle();
+
+	await act(async () => {
+		fireEvent.click(scope.getByRole("button", { name: /more options/i }));
+	});
+	fireEvent.click(scope.getByRole("menuitem", { name: /settings/i }));
+	expect(reconfigured).toBe(1);
+});
+
+test("no ⋯ menu when the host wired no reconfigure action (never an empty menu)", async () => {
+	const { container } = render(<ChatPanel transport={new MockTransport()} />);
+	const scope = within(container);
+	await settle();
+	expect(scope.queryByRole("button", { name: /more options/i })).toBeNull();
 });
 
 test("New chat: disabled until there's a settled turn, then clears the transcript and resets history_hint", async () => {
@@ -146,6 +183,55 @@ test("a rejected provision renders a NON-SILENT config error with a Reconfigure 
 
 	// Chat is NOT presented while unconfigured.
 	expect(scope.queryByRole("textbox", { name: /message input/i })).toBeNull();
+});
+
+test("Settings stays reachable from the config-error view (the only route with a bad gateway)", async () => {
+	let reconfigured = 0;
+	const { container } = render(
+		<ChatPanel
+			transport={new MockTransport()}
+			provision={() => Promise.reject(new Error("configure_error: token expired"))}
+			onReconfigure={() => (reconfigured += 1)}
+		/>,
+	);
+	const scope = within(container);
+	await waitFor(() => scope.getByRole("alert"));
+
+	// No transcript in this branch, so the header carries the wordmark instead of the
+	// (unrendered) scrolling brand block — the pane never loses its identity.
+	expect(container.querySelector(".header-title")?.textContent).toBe("xcsh");
+
+	// The control row renders in this branch too — otherwise removing the floating
+	// Settings button would leave gateway config unreachable here.
+	await act(async () => {
+		fireEvent.click(scope.getByRole("button", { name: /more options/i }));
+	});
+	fireEvent.click(scope.getByRole("menuitem", { name: /settings/i }));
+	expect(reconfigured).toBe(1);
+	// Nothing to reset yet, so new-chat is present but inert.
+	expect((scope.getByRole("button", { name: /new chat/i }) as HTMLButtonElement).disabled).toBe(true);
+});
+
+test("Settings stays reachable from the first-run onboarding view (no bridge at all)", async () => {
+	const noBridge: Transport = {
+		state: "idle",
+		connect: () => Promise.reject(new Error("ECONNREFUSED")),
+		send: () => {},
+		onMessage: () => () => {},
+		stop: () => {},
+		dispose: () => {},
+	};
+	let reconfigured = 0;
+	const { container } = render(<ChatPanel transport={noBridge} onReconfigure={() => (reconfigured += 1)} />);
+	const scope = within(container);
+	await settle();
+	expect(scope.getByText(/install xcsh/i)).toBeDefined();
+
+	await act(async () => {
+		fireEvent.click(scope.getByRole("button", { name: /more options/i }));
+	});
+	fireEvent.click(scope.getByRole("menuitem", { name: /settings/i }));
+	expect(reconfigured).toBe(1);
 });
 
 test("auto-opens the gateway config when a turn fails with provider-4xx (bad gateway token)", async () => {

--- a/packages/office-pane/test/ChatPanel.test.tsx
+++ b/packages/office-pane/test/ChatPanel.test.tsx
@@ -181,6 +181,39 @@ test("the empty state offers starter pills that PREFILL the composer without sen
 	expect(container.querySelector(".empty-logo")).toBeNull();
 });
 
+test("once the engine reports skills, the empty state offers them as stacked /slash pills", async () => {
+	const mock = new MockTransport();
+	const { container } = render(<ChatPanel transport={mock} />);
+	const scope = within(container);
+	await settle();
+
+	// Before the skills reply: the host-agnostic prose starters.
+	expect(scope.getByRole("button", { name: /summarize/i })).toBeDefined();
+
+	await act(async () => {
+		mock.emit({
+			type: "skills",
+			skills: [
+				{ name: "competitive", description: "F5 XC battlecards" },
+				{ name: "roi-calculator", description: "ROI / TCO" },
+			],
+		} as never);
+	});
+
+	// Real engine skills replace the prose starters — a leading /skill IS an
+	// invocation, so unlike a hardcoded starter these always work.
+	const pill = await waitFor(() => scope.getByRole("button", { name: "/competitive" }));
+	expect(scope.getByRole("button", { name: "/roi-calculator" })).toBeDefined();
+	expect(scope.queryByRole("button", { name: /^Summarize$/ })).toBeNull();
+	// Stacked vertically (Claude's slash-command list), not a wrapping row.
+	expect(container.querySelector(".pills")?.classList.contains("pills-stacked")).toBe(true);
+
+	// Picking one PREFILLS the composer for the user to add input — it does not send.
+	fireEvent.click(pill);
+	expect(scope.getByRole("textbox", { name: /message input/i }).textContent).toBe("/competitive ");
+	expect(mock.sent.filter(m => m.type === "chat_request")).toHaveLength(0);
+});
+
 test("no Chrome-automation mode toggle; chats send the fixed 'educational' mode", async () => {
 	const mock = new MockTransport();
 	const { container } = render(<ChatPanel transport={mock} />);

--- a/packages/office-pane/test/GatewayGate.test.tsx
+++ b/packages/office-pane/test/GatewayGate.test.tsx
@@ -4,7 +4,8 @@
  * The office wrapper owns the office concerns (persist via GatewayConfigStore,
  * build/tear-down the transport, validate via core's normalizeGatewayConfig) over
  * the shared headless `@f5-sales-demo/xcsh-chat-ui` gate, which owns the
- * config-vs-chat decision, the form, and the Settings affordance.
+ * config-vs-chat decision and the form. The Settings affordance itself is the
+ * pane's — it lives in the header's "⋯" menu and drives `api.reconfigure`.
  *
  * CHAT-FIRST (#2171): the pane runs the shared gate in `optional` mode — an
  * unconfigured pane opens straight into chat over xcsh's existing provider, with
@@ -35,6 +36,20 @@ async function settle(): Promise<void> {
 	});
 }
 
+/**
+ * Open the gateway form the way a user does: the header's "⋯" menu → Settings.
+ * (There is no floating Settings button — in an Office task pane it collided with
+ * Office's own ⓘ, so the affordance moved into the pane's control row.)
+ */
+async function openSettings(): Promise<void> {
+	await act(async () => {
+		fireEvent.click(screen.getByRole("button", { name: /more options/i }));
+	});
+	await act(async () => {
+		fireEvent.click(screen.getByRole("menuitem", { name: /settings/i }));
+	});
+}
+
 test("chat-first: with NO stored config, opens the chat directly (not the form), built with a null config", () => {
 	const store = new MemoryGatewayConfigStore();
 	const built: (GatewayConfig | null)[] = [];
@@ -52,8 +67,9 @@ test("chat-first: with NO stored config, opens the chat directly (not the form),
 	expect(screen.queryByLabelText(/gateway url/i)).toBeNull();
 	// Transport built with a null config — chat runs over xcsh's existing provider.
 	expect(built).toEqual([null]);
-	// Config is still reachable via Settings.
-	expect(screen.getByRole("button", { name: /settings/i })).toBeDefined();
+	// Config is still reachable — through the header's "⋯" menu, not a floating button.
+	expect(screen.queryByRole("button", { name: /^settings$/i })).toBeNull();
+	expect(screen.getByRole("button", { name: /more options/i })).toBeDefined();
 });
 
 test("saving a config via Settings persists it and rebuilds the transport from it", async () => {
@@ -70,9 +86,7 @@ test("saving a config via Settings persists it and rebuilds the transport from i
 	);
 
 	// Chat-first opens on chat → open Settings to reach the form.
-	await act(async () => {
-		fireEvent.click(screen.getByRole("button", { name: /settings/i }));
-	});
+	await openSettings();
 	fill(/gateway url/i, "https://gw.example/anthropic");
 	fill(/token/i, "sk-1");
 	await act(async () => {
@@ -135,9 +149,7 @@ test("the Settings affordance reopens the form prefilled, and Cancel returns to 
 	store.save(CONFIG);
 	render(<GatewayGate store={store} buildTransport={() => ({ transport: new MockTransport() })} />);
 
-	await act(async () => {
-		fireEvent.click(screen.getByRole("button", { name: /settings/i }));
-	});
+	await openSettings();
 	// Form is shown, prefilled with the stored base URL.
 	expect((screen.getByLabelText(/gateway url/i) as HTMLInputElement).value).toBe("https://gw.example/anthropic");
 
@@ -166,9 +178,7 @@ test("reconfiguring via Settings disposes the superseded transport (no socket le
 	expect(built[0].state).not.toBe("closed");
 
 	// Settings → change the gateway → Save a NEW config.
-	await act(async () => {
-		fireEvent.click(screen.getByRole("button", { name: /settings/i }));
-	});
+	await openSettings();
 	fill(/gateway url/i, "https://gw2.example/anthropic");
 	fill(/token/i, "t2");
 	await act(async () => {
@@ -243,9 +253,7 @@ test("an invalid config surfaces the validator error and stays on the form", asy
 	render(<GatewayGate store={store} buildTransport={() => ({ transport: new MockTransport() })} />);
 
 	// Chat-first → open Settings to reach the form.
-	await act(async () => {
-		fireEvent.click(screen.getByRole("button", { name: /settings/i }));
-	});
+	await openSettings();
 	fill(/gateway url/i, "http://insecure.example/anthropic");
 	fill(/token/i, "sk-1");
 	await act(async () => {

--- a/packages/office-pane/test/host-adapter.test.ts
+++ b/packages/office-pane/test/host-adapter.test.ts
@@ -103,12 +103,18 @@ test("mountGate with no stored config renders the chat (chat-first) and marks th
 	);
 
 	expect(container.classList.contains("xcsh-panel")).toBe(true);
+	// Document typography, plus the Office-host marker that reserves header room for
+	// Office's own ⓘ button. Distinct classes: `.xcsh-doc` means "sans document
+	// typography", NOT "running in an Office task pane".
+	expect(container.classList.contains("xcsh-doc")).toBe(true);
+	expect(container.classList.contains("xcsh-host-office")).toBe(true);
 	const scope = within(container);
 	// Chat-first: an unconfigured pane opens on chat, NOT a forced gateway form.
 	expect(scope.getByRole("textbox", { name: /message input/i })).toBeDefined();
 	expect(scope.queryByLabelText(/gateway url/i)).toBeNull();
-	// The gateway form is still reachable via Settings.
-	expect(scope.getByRole("button", { name: /settings/i })).toBeDefined();
+	// The gateway form is reachable through the header's "⋯" menu (there is no
+	// floating Settings button — it collided with Office's native ⓘ).
+	expect(scope.getByRole("button", { name: /more options/i })).toBeDefined();
 });
 
 test("mountGate with a stored config renders the chat over the built transport", async () => {

--- a/packages/office-pane/test/shell-visual.test.ts
+++ b/packages/office-pane/test/shell-visual.test.ts
@@ -1,0 +1,279 @@
+/**
+ * LAYER 4 — visual / computed-layout eval for the pane SHELL (Puppeteer, real Chromium).
+ *
+ * Sibling of `markdown-visual.test.ts` (which covers document typography); this one
+ * covers the Claude-for-Office shell chrome that unit tests can't judge, because
+ * jsdom/happy-dom have no layout engine: what is PINNED vs what SCROLLS, whether the
+ * control row clears Office's own button, whether stacked pills really stack, and
+ * whether the CSS tooltip actually becomes visible on hover.
+ *
+ * GATED behind `XCSH_VISUAL=1` and skipped in the default `bun run test`. Run it on a
+ * Chrome-equipped runner:  `XCSH_VISUAL=1 bun test ./test/shell-visual.test.ts`.
+ *
+ * It server-renders the REAL shipped components (`HeaderBar`, `Transcript`,
+ * `EmptyState`) composed exactly as `ChatPanel` composes them, into the REAL shared
+ * stylesheet (`cssVars()` + `PANEL_CSS`) with the same root classes `mountGate` sets.
+ * Deviation (same one markdown-visual documents): it does not boot
+ * `dist/taskpane.js`, which would need the Office.js runtime and a live bridge — but
+ * the markup and CSS are the shipped ones, so the computed layout is production's.
+ *
+ * SCOPE LIMIT, stated so these assertions aren't over-read: static markup runs no
+ * effects, so this layer cannot exercise Transcript's auto-pin `useLayoutEffect`. It
+ * verifies the LAYOUT consequences (what moves when the scrollport scrolls, what the
+ * brand's resting position is). That the effect itself skips an empty transcript is
+ * covered by `chat-ui/test/Transcript.test.tsx`, which renders on the client and
+ * stubs `scrollHeight` so a stray pin is observable.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+	type ChatMessage,
+	cssVars,
+	EmptyState,
+	F5Logo,
+	HeaderBar,
+	PANEL_CSS,
+	Transcript,
+} from "@f5-sales-demo/xcsh-chat-ui";
+import type { Browser } from "puppeteer";
+import { createElement as h } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const RUN = process.env.XCSH_VISUAL === "1";
+const PKG = dirname(import.meta.dir);
+const OUT_DIR = join(PKG, "test", "__visual__");
+/** Narrowest real task pane, and a roomier one. */
+const WIDTHS = [320, 480] as const;
+/** Office draws its own ⓘ over the pane's top-right; our row must not sit under it. */
+const MIN_RIGHT_RESERVE = 28;
+
+/** Enough turns to overflow the scrollport, so "does the brand scroll?" is decidable. */
+function longConversation(): ChatMessage[] {
+	const out: ChatMessage[] = [];
+	for (let i = 0; i < 12; i++) {
+		out.push({ id: `u${i}`, role: "user", text: `Question ${i} about the quarterly figures` });
+		out.push({
+			id: `a${i}`,
+			role: "assistant",
+			text: `Answer ${i}. ${"Sales rose across every region this quarter. ".repeat(3)}`,
+		});
+	}
+	return out;
+}
+
+const SKILL_PILLS = [
+	{ id: "competitive", label: "/competitive", hint: "F5 XC battlecards" },
+	{ id: "roi-calculator", label: "/roi-calculator", hint: "ROI / TCO" },
+	{ id: "waap-full-stack-demo", label: "/waap-full-stack-demo", hint: "Build a WAAP demo" },
+];
+
+/** The shipped shell: same root classes as `mountGate`, same components as ChatPanel. */
+function harnessHtml(messages: ChatMessage[]): string {
+	const brand = h(
+		"div",
+		{ className: "brand-block" },
+		h(F5Logo, { variant: "mark", size: 20 }),
+		h("span", { className: "brand-title" }, "xcsh"),
+	);
+	const shell = h(
+		"div",
+		{ className: "xcsh-panel xcsh-doc xcsh-host-office" },
+		h(HeaderBar, {
+			onNewChat: () => {},
+			historyItems: [{ id: "conv-1", label: "An earlier chat" }],
+			historyHeader: "This session",
+			moreItems: [{ id: "settings", label: "Settings" }],
+		}),
+		h(Transcript, {
+			messages,
+			streaming: false,
+			brand,
+			emptyState: h(EmptyState, { pills: SKILL_PILLS, onPick: () => {}, stacked: true, logo: false }),
+		}),
+	);
+	return `<!doctype html><html><head><meta charset="utf-8">
+<style>${cssVars()}</style>
+<style>${PANEL_CSS}</style>
+<style>html,body{margin:0;height:100%} .xcsh-panel{height:100%}</style>
+</head><body>${renderToStaticMarkup(shell)}</body></html>`;
+}
+
+describe.skipIf(!RUN)("Layer 4 — computed-layout shell parity", () => {
+	test("the brand scrolls with the transcript while the control row stays pinned", async () => {
+		mkdirSync(OUT_DIR, { recursive: true });
+		const puppeteer = (await import("puppeteer")).default;
+		const browser: Browser = await puppeteer.launch({
+			headless: true,
+			args: ["--no-sandbox", "--force-device-scale-factor=1"],
+		});
+		try {
+			for (const width of WIDTHS) {
+				const page = await browser.newPage();
+				await page.setViewport({ width, height: 640, deviceScaleFactor: 1 });
+				await page.setContent(harnessHtml(longConversation()), { waitUntil: "load" });
+
+				const probe = await page.evaluate(() => {
+					const messages = document.querySelector(".messages") as HTMLElement;
+					const header = document.querySelector(".header") as HTMLElement;
+					const brand = document.querySelector(".brand-block") as HTMLElement;
+					const before = {
+						header: header.getBoundingClientRect().top,
+						brand: brand.getBoundingClientRect().top,
+					};
+					messages.scrollTop = 99_999;
+					return {
+						brandInScrollport: messages.contains(brand),
+						headerInScrollport: messages.contains(header),
+						overflows: messages.scrollHeight > messages.clientHeight,
+						before,
+						after: {
+							header: header.getBoundingClientRect().top,
+							brand: brand.getBoundingClientRect().top,
+						},
+						scrollportTop: messages.getBoundingClientRect().top,
+					};
+				});
+
+				await page.screenshot({ path: join(OUT_DIR, `shell-scrolled-${width}.png`) as `${string}.png` });
+				await page.close();
+
+				// The premise of the test: there is something to scroll.
+				expect(probe.overflows).toBe(true);
+				// Structure: brand inside the scrollport, control row outside it.
+				expect(probe.brandInScrollport).toBe(true);
+				expect(probe.headerInScrollport).toBe(false);
+				// The control row does not move…
+				expect(probe.after.header).toBeCloseTo(probe.before.header, 0);
+				// …while the brand scrolls up and out of the scrollport entirely.
+				expect(probe.after.brand).toBeLessThan(probe.before.brand - 50);
+				expect(probe.after.brand).toBeLessThan(probe.scrollportTop);
+			}
+		} finally {
+			await browser.close();
+		}
+	}, 60_000);
+
+	test("on an empty pane the brand is visible above the starters, not scrolled past", async () => {
+		const puppeteer = (await import("puppeteer")).default;
+		const browser: Browser = await puppeteer.launch({
+			headless: true,
+			args: ["--no-sandbox", "--force-device-scale-factor=1"],
+		});
+		try {
+			const page = await browser.newPage();
+			await page.setViewport({ width: 320, height: 640, deviceScaleFactor: 1 });
+			await page.setContent(harnessHtml([]), { waitUntil: "load" });
+
+			const probe = await page.evaluate(() => {
+				const messages = document.querySelector(".messages") as HTMLElement;
+				const brand = messages.querySelector(".brand-block") as HTMLElement;
+				const mark = brand.querySelector(".f5-mark") as HTMLElement;
+				const markRect = mark.getBoundingClientRect();
+				const pills = Array.from(messages.querySelectorAll<HTMLElement>(".pill")).map(p => {
+					const r = p.getBoundingClientRect();
+					return { left: Math.round(r.left), top: Math.round(r.top), width: Math.round(r.width) };
+				});
+				const b = brand.getBoundingClientRect();
+				const m = messages.getBoundingClientRect();
+				return {
+					scrollTop: messages.scrollTop,
+					brandTop: b.top,
+					brandHeight: Math.round(b.height),
+					markSize: { w: Math.round(markRect.width), h: Math.round(markRect.height) },
+					brandVisible: b.top >= m.top && b.bottom <= m.bottom,
+					firstPillTop: pills[0]?.top ?? 0,
+					pills,
+					pillsStacked: (messages.querySelector(".pills") as HTMLElement).classList.contains("pills-stacked"),
+				};
+			});
+
+			await page.screenshot({ path: join(OUT_DIR, "shell-empty-320.png") });
+			await page.close();
+
+			// At rest (scrollTop 0 — no effects run here, see SCOPE LIMIT above) the brand
+			// is fully inside the visible scrollport, so the pane opens showing the brand
+			// rather than needing a scroll-up to find it.
+			expect(probe.scrollTop).toBe(0);
+			expect(probe.brandVisible).toBe(true);
+			// The mark renders at the requested 20px, not the PNG's intrinsic 128px, so the
+			// brand is a compact line rather than a band dominating a 320px pane.
+			expect(probe.markSize).toEqual({ w: 20, h: 20 });
+			expect(probe.brandHeight).toBeLessThan(48);
+			// Brand sits above the starters.
+			expect(probe.brandTop).toBeLessThan(probe.firstPillTop);
+			// Starters really stack: one column (shared left edge, increasing top).
+			expect(probe.pillsStacked).toBe(true);
+			expect(probe.pills).toHaveLength(SKILL_PILLS.length);
+			const lefts = new Set(probe.pills.map(p => p.left));
+			expect(lefts.size).toBe(1);
+			for (let i = 1; i < probe.pills.length; i++) {
+				expect(probe.pills[i].top).toBeGreaterThan(probe.pills[i - 1].top);
+			}
+			// Full-width rows, not shrink-wrapped chips.
+			const widths = new Set(probe.pills.map(p => p.width));
+			expect(widths.size).toBe(1);
+		} finally {
+			await browser.close();
+		}
+	}, 60_000);
+
+	test("the control row clears Office's own top-right button, and tooltips appear on hover", async () => {
+		const puppeteer = (await import("puppeteer")).default;
+		const browser: Browser = await puppeteer.launch({
+			headless: true,
+			args: ["--no-sandbox", "--force-device-scale-factor=1"],
+		});
+		try {
+			const page = await browser.newPage();
+			await page.setViewport({ width: 320, height: 640, deviceScaleFactor: 1 });
+			await page.setContent(harnessHtml([]), { waitUntil: "load" });
+
+			const reserve = await page.evaluate(() => {
+				const panel = document.querySelector(".xcsh-panel") as HTMLElement;
+				const header = document.querySelector(".header") as HTMLElement;
+				const buttons = Array.from(header.querySelectorAll<HTMLElement>(".header-btn"));
+				const last = buttons[buttons.length - 1];
+				return {
+					count: buttons.length,
+					paddingRight: Number.parseFloat(getComputedStyle(header).paddingRight),
+					gap: panel.getBoundingClientRect().right - last.getBoundingClientRect().right,
+					tipOpacity: getComputedStyle(last, "::after").opacity,
+					tipContent: getComputedStyle(last, "::after").content,
+				};
+			});
+
+			// All three controls, and the rightmost one keeps clear of the pane edge.
+			expect(reserve.count).toBe(3);
+			expect(reserve.paddingRight).toBeGreaterThanOrEqual(MIN_RIGHT_RESERVE);
+			expect(reserve.gap).toBeGreaterThanOrEqual(MIN_RIGHT_RESERVE);
+			// The tooltip exists, carries the button's label, and starts hidden.
+			expect(reserve.tipContent).toContain("More options");
+			expect(Number.parseFloat(reserve.tipOpacity)).toBe(0);
+
+			// Hover → it becomes visible (allowing for the transition's ~350ms delay).
+			await page.hover(".header-menuwrap:last-of-type .header-btn");
+			await new Promise(r => setTimeout(r, 900));
+			const hovered = await page.evaluate(() => {
+				const buttons = Array.from(document.querySelectorAll<HTMLElement>(".header-btn"));
+				const last = buttons[buttons.length - 1];
+				const after = getComputedStyle(last, "::after");
+				const panel = (document.querySelector(".xcsh-panel") as HTMLElement).getBoundingClientRect();
+				const tipWidth = Number.parseFloat(after.width);
+				return {
+					opacity: Number.parseFloat(after.opacity),
+					// right:0 anchors the tip to the button's right edge; on a 320px pane it
+					// must not overflow the left side either.
+					fitsPane: tipWidth <= panel.width,
+				};
+			});
+			await page.screenshot({ path: join(OUT_DIR, "shell-tooltip-320.png") });
+			await page.close();
+
+			expect(hovered.opacity).toBe(1);
+			expect(hovered.fitsPane).toBe(true);
+		} finally {
+			await browser.close();
+		}
+	}, 60_000);
+});

--- a/packages/office-pane/test/useChatSession.test.tsx
+++ b/packages/office-pane/test/useChatSession.test.tsx
@@ -375,3 +375,173 @@ test("send({webSearch}) sets web_search on the chat_request; omitted otherwise",
 	expect(reqs[0].web_search).toBe(true);
 	expect(reqs[1].web_search).toBeUndefined();
 });
+
+// ---------------------------------------------------------------------------
+// Session-local chat history (read-back only)
+// ---------------------------------------------------------------------------
+
+/** Send `text` and settle the turn so it looks like a completed exchange. */
+async function completeTurn(mock: MockTransport, send: (t: string) => void, text: string): Promise<void> {
+	await act(async () => {
+		send(text);
+	});
+	const reqs = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request");
+	const req = reqs[reqs.length - 1];
+	if (!req) throw new Error("expected chat_request");
+	await act(async () => {
+		mock.emit({ type: "chat_delta", id: req.id, seq: 0, delta: "ok" });
+		mock.emit({ type: "chat_done", id: req.id });
+	});
+}
+
+test("history starts empty and nothing is being viewed", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	await waitFor(() => expect(result.current.provisioning).toBe("ready"));
+	expect(result.current.history).toEqual([]);
+	expect(result.current.viewingId).toBeNull();
+});
+
+test("newChat archives the outgoing conversation, titled from its first user turn", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	await waitFor(() => expect(result.current.provisioning).toBe("ready"));
+
+	await completeTurn(mock, result.current.send, "explain this pivot table");
+	await act(async () => {
+		result.current.send("and the second question");
+	});
+
+	await act(async () => {
+		result.current.newChat();
+	});
+
+	// The live transcript is clear and the conversation moved into history intact.
+	expect(result.current.turns).toEqual([]);
+	expect(result.current.history).toHaveLength(1);
+	expect(result.current.history[0].title).toBe("explain this pivot table");
+	expect(result.current.history[0].turns.filter(t => t.kind === "user")).toHaveLength(2);
+});
+
+test("newChat on an empty transcript archives nothing (no blank history entries)", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	await waitFor(() => expect(result.current.provisioning).toBe("ready"));
+
+	await act(async () => {
+		result.current.newChat();
+		result.current.newChat();
+	});
+	expect(result.current.history).toEqual([]);
+});
+
+test("a long first prompt is truncated into the history title", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	await waitFor(() => expect(result.current.provisioning).toBe("ready"));
+
+	const long = `summarize ${"the quarterly revenue figures ".repeat(6)}`;
+	await completeTurn(mock, result.current.send, long);
+	await act(async () => {
+		result.current.newChat();
+	});
+
+	const title = result.current.history[0].title;
+	expect(title.length).toBeLessThanOrEqual(48);
+	expect(title.endsWith("…")).toBe(true);
+	expect(long.startsWith(title.slice(0, -1))).toBe(true);
+});
+
+test("newest chats come first in history", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	await waitFor(() => expect(result.current.provisioning).toBe("ready"));
+
+	await completeTurn(mock, result.current.send, "first chat");
+	await act(async () => {
+		result.current.newChat();
+	});
+	await completeTurn(mock, result.current.send, "second chat");
+	await act(async () => {
+		result.current.newChat();
+	});
+
+	expect(result.current.history.map(h => h.title)).toEqual(["second chat", "first chat"]);
+});
+
+test("viewHistory shows the archived turns; exitHistory restores the live ones", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	await waitFor(() => expect(result.current.provisioning).toBe("ready"));
+
+	await completeTurn(mock, result.current.send, "the archived question");
+	await act(async () => {
+		result.current.newChat();
+	});
+	await completeTurn(mock, result.current.send, "the live question");
+
+	const archivedId = result.current.history[0].id;
+	await act(async () => {
+		result.current.viewHistory(archivedId);
+	});
+	expect(result.current.viewingId).toBe(archivedId);
+	expect(result.current.turns.some(t => t.kind === "user" && t.text === "the archived question")).toBe(true);
+	expect(result.current.turns.some(t => t.kind === "user" && t.text === "the live question")).toBe(false);
+
+	// Exiting restores the live conversation — reading an archive never destroys it.
+	await act(async () => {
+		result.current.exitHistory();
+	});
+	expect(result.current.viewingId).toBeNull();
+	expect(result.current.turns.some(t => t.kind === "user" && t.text === "the live question")).toBe(true);
+});
+
+test("send() HARD-REFUSES while viewing history (the engine no longer holds that context)", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	await waitFor(() => expect(result.current.provisioning).toBe("ready"));
+
+	await completeTurn(mock, result.current.send, "archived");
+	await act(async () => {
+		result.current.newChat();
+	});
+	const archivedId = result.current.history[0].id;
+	await act(async () => {
+		result.current.viewHistory(archivedId);
+	});
+
+	const before = mock.sent.filter(m => m.type === "chat_request").length;
+	await act(async () => {
+		result.current.send("a follow-up in the restored chat");
+		result.current.retry();
+	});
+
+	// Nothing was sent and no optimistic turn was appended: answering here would
+	// silently reply WITHOUT the conversation the user is reading.
+	expect(mock.sent.filter(m => m.type === "chat_request")).toHaveLength(before);
+	expect(result.current.turns.some(t => t.kind === "user" && t.text.includes("follow-up"))).toBe(false);
+});
+
+test("newChat while viewing history exits the archive and banks the LIVE conversation", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	await waitFor(() => expect(result.current.provisioning).toBe("ready"));
+
+	await completeTurn(mock, result.current.send, "chat one");
+	await act(async () => {
+		result.current.newChat();
+	});
+	await completeTurn(mock, result.current.send, "chat two");
+	await act(async () => {
+		result.current.viewHistory(result.current.history[0].id);
+	});
+
+	await act(async () => {
+		result.current.newChat();
+	});
+
+	expect(result.current.viewingId).toBeNull();
+	expect(result.current.turns).toEqual([]);
+	// "chat two" (the live one) was archived — not the snapshot being viewed.
+	expect(result.current.history.map(h => h.title)).toEqual(["chat two", "chat one"]);
+});


### PR DESCRIPTION
Closes #2378

An A/B against the Claude for Office pane exposed shell/chrome polish gaps — the pane worked, but didn't yet *feel* shipped. This closes all five, plus a latent brand-sizing bug the new visual layer caught.

## What changed

| Gap | Before | After |
|---|---|---|
| **Brand pinned** | F5 logo + "xcsh" in a fixed band that never scrolled | Brand lives inside the scrollport (`Transcript.brand`) and scrolls away with the conversation |
| **Two right-aligned rows + a collision** | Text "New chat" button, plus a floating "Settings" button the shared gate rendered on its own row — directly under the ⓘ Office draws over every pane | One compact pinned icon row (clock / ⊕ / ⋮) with hover tooltips; Settings folded into `⋯`; header reserves room for Office's ⓘ |
| **No way back to a past chat** | New chat silently discarded the conversation | Session-local history behind the clock, **read-back only** (see below) |
| **Prose starters, wrapping** | Three hardcoded phrases in a wrapping row | The engine's **real skills** as vertical `/slash` pills that prefill the composer |
| **Oversized F5 mark** (found by the new visual test) | `.f5-mark` set `width:auto/height:auto`, which outranks the `width`/`height` attributes — so every mark rendered at the PNG's intrinsic 128px and `size={20}` produced a 140px brand band | Override dropped; the mark honours `size`, guarded by a CSS test and a computed-size assertion |

## The honesty constraint on history

`newChat` already bumps the `history_hint` that the bridge maps to `replaceMessages([])`, so a chat in history is one **the engine has already forgotten**. Answering a follow-up "in" a reopened chat would silently reply *without* the conversation on screen. So:

- `send()` **hard-refuses** while viewing — guarded by a ref, so a handler captured in an earlier render can't slip past it — rather than the composer merely looking disabled.
- The menu is captioned **"This session"**; nothing implies it survives a reload.
- No Retry on archived error rows, and no `provider-4xx` auto-open while viewing — both would act on a different conversation than the one being read.
- Live turns and the viewed snapshot are separate state, so reading an archive can't disturb a turn in flight, and exiting restores it intact.

True resume is possible (`AgentSession.replaceMessages` exists) but needs a new `replace_history` frame — a contract bump, deliberately out of scope.

## Two tests that could not fail

Worth calling out, because it changes what the earlier "verified" claim was worth: happy-dom has no layout engine, so `scrollHeight` is `0` and `scrollTop = scrollHeight` is a no-op. The Task-1 auto-pin guard test **passed with the guard removed**. Both auto-pin tests are rewritten to stub `scrollHeight` on the prototype before render (the effect runs during the first commit), and each now fails under the mutation that breaks its behaviour — as do both new F5-mark guards.

## Verification

- `bun run test` — chat-ui **162 + 78 pass**, office-pane **354 pass**, 0 fail
- `bun run check` (biome + tsgo) clean in both packages
- `XCSH_VISUAL=1` Puppeteer: **4 pass / 66 assertions**. New `shell-visual.test.ts` server-renders the real shipped components into the real stylesheet and asserts what unit tests can't judge: brand inside the scrollport / header outside it; scrolling moves the brand out of view while the header's top stays put; pills share a left edge with increasing tops and uniform width; the rightmost control keeps ≥28px clear of the pane edge; the `data-tip` tooltip goes opacity 0 → 1 on hover without overflowing a 320px pane; the mark computes to 20px
- `bun run build` — browser-safe, **161.2KB / 256KB** gz budget
- Mutation-checked every new guard (auto-pin ×2, F5-mark ×2) — each fails when its behaviour is broken

Contact-sheet PNGs are written to `test/__visual__/` and gitignored (the computed-style assertions are the oracle, not the images).

## Notes for reviewers

- **`GatewayGate` no longer renders Settings.** It's headless now — it hands `api.reconfigure` to children and the host places the affordance. The office pane is its only consumer, so no compat flag. The control row is rendered in the **config-error and onboarding branches too**: with the floating button gone that's the only route to gateway config, and those are exactly the states where the user needs it.
- **Other surfaces unaffected.** Every new prop is optional with the previous behaviour as its default (`brand`, `canNewChat`, `historyHeader`, `stacked`). The composer `/` menu was deliberately not touched, so the "office has no slash/tools composer UI" guard still passes unchanged.
- **Vendored copies are now behind.** chat-ui source changed, so the chrome / VS Code vendored copies want a re-vendor in a follow-up (separate repos; `verifySync` catches it there). Only the office pane uses `variant="mark"` in this repo, but the `.f5-mark` fix will change rendered size anywhere else that passes `size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)