### PR TITLE
fix(office): ship React's production build, not the development build

### DIFF
--- a/packages/coding-agent/src/internal-urls/api-catalog-index.generated.ts
+++ b/packages/coding-agent/src/internal-urls/api-catalog-index.generated.ts
@@ -3,7 +3,7 @@
 import type { ApiCatalogCategory, ApiCatalogCategorySummary, ApiCatalogIndex } from "./api-catalog-types";
 
 export const API_CATALOG_INDEX: ApiCatalogIndex = {
-	version: "2.1.189",
+	version: "2.1.190",
 	displayName: "F5 Distributed Cloud",
 	service: "f5xc",
 	categoryCount: 867,

--- a/packages/office-pane/build.ts
+++ b/packages/office-pane/build.ts
@@ -152,6 +152,12 @@ export async function build(): Promise<void> {
 		minify: true,
 		sourcemap: "none",
 		naming: "[dir]/[name].[ext]",
+		// React (and much of the ecosystem) branches on this at runtime. Without
+		// the substitution the DEVELOPMENT build is what gets bundled and served
+		// through AppSource: prop-validation and warning machinery customers can
+		// never act on, and a third of the gzipped payload. `build.test.ts`
+		// asserts the emitted artifact really is the production build.
+		define: { "process.env.NODE_ENV": JSON.stringify("production") },
 	});
 
 	if (!result.success) {

--- a/packages/office-pane/test/build.test.ts
+++ b/packages/office-pane/test/build.test.ts
@@ -98,4 +98,35 @@ describe("build.ts", () => {
 		const js = readFileSync(join(DIST, "taskpane.js"), "utf8");
 		expect(js).not.toMatch(/["']node:[a-z][a-z0-9/._-]*["']/i);
 	});
+
+	// Guards the NODE_ENV define. Without it `process.env.NODE_ENV` is never
+	// substituted, React keeps its development branch, and the AppSource-served
+	// pane ships dev-only warning machinery -- a third of the gzipped bundle.
+	// Asserted on the real artifact rather than on build.ts's source so the
+	// guard survives a refactor of how the define is supplied.
+	test("ships React's PRODUCTION build, not the development build", () => {
+		const js = readFileSync(join(DIST, "taskpane.js"), "utf8");
+		// Assert on booleans, not on `js` itself: a failed .toContain against a
+		// ~500 KB minified bundle dumps the whole thing into the test output.
+		const has = (needle: string) => js.includes(needle);
+
+		// Dev-only machinery must be absent.
+		for (const devMarker of [
+			"_debugSource",
+			"unstable_isNewReconciler",
+			"Each child in a list should have a unique",
+		]) {
+			expect(has(devMarker), `dev-build marker "${devMarker}" present — is the NODE_ENV define missing?`).toBe(
+				false,
+			);
+		}
+
+		// And the production error path must be present. Checking only for the
+		// absence of dev markers would also pass if React were dropped entirely,
+		// so this is the positive half of the assertion.
+		expect(has("Minified React error"), "production React error path absent — not a production build").toBe(true);
+
+		// Nothing should still be branching on an unsubstituted NODE_ENV.
+		expect(has("process.env.NODE_ENV"), "unsubstituted process.env.NODE_ENV remains in the bundle").toBe(false);
+	});
 });

--- a/packages/stats/build.ts
+++ b/packages/stats/build.ts
@@ -54,6 +54,11 @@ const result = await Bun.build({
 	outdir: "./dist/client",
 	minify: true,
 	naming: "[dir]/[name].[ext]",
+	// Without this, React's DEVELOPMENT build is bundled -- the dashboard is
+	// served locally rather than distributed, so this is payload hygiene rather
+	// than a customer-facing concern, but there is no reason to ship the dev
+	// build's warning machinery to a built artifact either way.
+	define: { "process.env.NODE_ENV": JSON.stringify("production") },
 });
 
 if (!result.success) {


### PR DESCRIPTION
Closes #2373.

## What

`packages/office-pane/build.ts` passed no `define` to `Bun.build`, so `process.env.NODE_ENV` was never substituted. React branches on it at runtime, so the **development** build is what got bundled — and `dist/taskpane.js` is the artifact `deploy-office-pane.yml` copies straight to the Pages repo AppSource serves.

One line each in `office-pane/build.ts` and `stats/build.ts`, plus a regression guard.

## Measured on the real artifacts

| Bundle | Before | After | Saving |
|---|---|---|---|
| `office-pane/dist/taskpane.js` | 175.2 KB gz | **116.7 KB gz** | −58.4 KB (**−33.3%**) |
| `stats/dist/client/index.js` | 189.6 KB gz | **131.2 KB gz** | −58.4 KB |

office-pane now sits at 116.7 KB against the 256 KB budget in `build.ts`, down from 68%.

A third of what customers downloaded was dev-only prop-validation and warning machinery they can never act on. The development build is also slower per render by design, which matters most in the path this pane exercises hardest — the rAF-coalesced streaming markdown renderer.

### Marker flip (office-pane)

Confirms the production build is genuinely selected, not the dev build merely stripped:

| Marker | Before | After |
|---|---|---|
| `_debugSource` | 5 | **0** |
| `unstable_isNewReconciler` | 1 | **0** |
| `"Each child in a list should have a unique"` | 3 | **0** |
| `process.env.NODE_ENV` | 0 (unsubstituted) | **0** (substituted) |
| `"Minified React error"` | 0 | **1** |

## Regression guard, written failing first

New test in `build.test.ts`, asserting on the **emitted artifact** rather than on `build.ts`'s source, so it survives a refactor of how the define is supplied. It checks both halves — dev markers absent **and** the production error path present — because absence alone would also pass if React were dropped from the bundle entirely.

Verified RED before the fix (`dev-build marker "Each child in a list should have a unique" present — is the NODE_ENV define missing?`) and GREEN after.

Assertions compare booleans rather than the bundle string: a failed `.toContain` against ~500 KB of minified JS dumps the entire bundle into the test output, which I hit on the first RED run and fixed.

## `packages/stats` audited and fixed too

Same omission. Different rationale, recorded in-line: that dashboard is **served locally rather than distributed**, so it is payload hygiene, not customer impact. Its marker profile differed — no `_debugSource`, because of a different JSX transform — but it carried the same dev warning text and gained the same production error path.

## No information disclosure

Checked explicitly, since a dev bundle can embed source paths: **zero** `/Users/` occurrences in the shipped artifact. `_debugSource` was a bare minified property assignment, not a path. So this was waste, not a leak — which is why it was filed as a follow-up rather than treated as urgent.

## Verification

- `bun run ci:check:full` → **exit 0**
- office-pane suite → **341 pass, 1 skip, 0 fail** (includes the new guard, and `build.test.ts` spawns the real build)
- Sizes and markers above measured directly on the emitted bundles

## ⚠️ Needs a sideload — this is a behavioural change

**Not purely a size optimisation.** React 19 surfaces uncaught render errors differently between the development and production builds, so a mount failure can present differently after this change. `src/taskpane.tsx` has no automated test and CI has no browser, so the runtime mount path is unverified here.

This is deliberately paired with the sideload already owed for React 19 (shipped in v19.91.0) — **one session validates both**. In Excel, PowerPoint and Word (`manifest.json` declares `workbook`, `presentation`, `document`):

1. **Pane mounts at all.** A production-build mount failure can present as a *silently blank pane* rather than a thrown error — open the WebView DevTools rather than assuming it is still loading.
2. **Theme injection** — red terminal frame, powerline status bar, MesloLGS NF glyphs.
3. **First-run gate** — clear `localStorage`, reopen; must land chat-first with a `role="textbox"` input, and Settings must still reach the gateway form.
4. **The `forwardRef` + `useImperativeHandle` seam** — trigger a skill pill or slash command that *prefills* rather than sends; text should land, editor focus, caret at end. Highest-value probe for React 19.
5. **Focus-on-turn-end** — send a turn, let it finish, focus should return without a scroll jump.
6. **Streaming markdown** — a table, a fenced code block, a list; watch for a blank flash on first delta or a dropped final frame.
7. **Menus** — model selector / mode toggle / header: arrow-key roving focus, Home/End, Escape closes and returns focus to the trigger.
8. **Unmount** — close and reopen repeatedly; no duplicated `role="textbox"` should accumulate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)