### PR TITLE
fix(office): settle a mid-stream chat when banking it into history

### DIFF
--- a/packages/office-pane/src/panel/useChatSession.ts
+++ b/packages/office-pane/src/panel/useChatSession.ts
@@ -91,6 +91,30 @@ export interface ChatHistoryEntry {
 /** Longest history-menu title before ellipsis (a 320px pane is narrow). */
 const HISTORY_TITLE_MAX = 48;
 
+/**
+ * Freeze a conversation on its way into {@link ChatHistoryEntry}.
+ *
+ * `newChat` is deliberately usable mid-stream (it is the wedge-recovery path) and
+ * `transport.stop()` only sends `chat_stop` — it does not settle the local turn. The
+ * terminal frame then arrives AFTER the bank and maps over the live turns, so it can
+ * never reach the snapshot (turns are immutable). Left alone, the archive would read
+ * back as permanently "streaming": a read-only past chat stuck on "Thinking…".
+ *
+ * A turn with text settles to `done`, matching what pressing Stop produces — and
+ * NOT to `error`, which `turnsToMessages` renders as the error message ALONE,
+ * discarding the very text the archive exists to preserve. A turn stopped before its
+ * first token has no answer to keep, so it says so rather than leaving an empty row.
+ */
+function settleForArchive(turns: Turn[]): Turn[] {
+	return turns.map(turn => {
+		if (turn.kind !== "assistant" || turn.state.status !== "streaming") return turn;
+		const settled: TurnState = turn.state.text
+			? { ...turn.state, status: "done" }
+			: { ...turn.state, status: "error", error: "Stopped before a response arrived." };
+		return { kind: "assistant", state: settled, activities: settleActivities(turn.activities) };
+	});
+}
+
 function historyTitle(turns: Turn[]): string {
 	const first = turns.find((t): t is UserTurn => t.kind === "user");
 	const text = first?.text.trim().replace(/\s+/g, " ") ?? "";
@@ -394,7 +418,8 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 			const entry: ChatHistoryEntry = {
 				id: `conv-${historyHintRef.current}`,
 				title: historyTitle(outgoing),
-				turns: outgoing,
+				// Settle first: the chat_stop above lands too late to reach this snapshot.
+				turns: settleForArchive(outgoing),
 			};
 			setHistory(prev => [entry, ...prev]);
 		}

--- a/packages/office-pane/test/useChatSession.test.tsx
+++ b/packages/office-pane/test/useChatSession.test.tsx
@@ -545,3 +545,69 @@ test("newChat while viewing history exits the archive and banks the LIVE convers
 	// "chat two" (the live one) was archived — not the snapshot being viewed.
 	expect(result.current.history.map(h => h.title)).toEqual(["chat two", "chat one"]);
 });
+
+test("a chat banked MID-STREAM reads back settled, keeping the text that had arrived", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	await waitFor(() => expect(result.current.provisioning).toBe("ready"));
+
+	await act(async () => {
+		result.current.send("a question mid-flight");
+	});
+	const req = mock.sent.find((m): m is ChatRequestMsg => m.type === "chat_request");
+	if (!req) throw new Error("expected chat_request");
+	await act(async () => {
+		mock.emit({ type: "chat_delta", id: req.id, seq: 0, delta: "a partial answer" });
+		mock.emit({ type: "chat_tool_notice", id: req.id, tool: "read_range", phase: "start" } as never);
+	});
+	expect(result.current.status).toBe("streaming");
+
+	// New chat while streaming is the wedge-recovery path: it chat_stops the turn and
+	// banks the conversation. The terminal frame lands after the bank and can never
+	// reach the (immutable) snapshot, so newChat must settle it on the way in.
+	await act(async () => {
+		result.current.newChat();
+	});
+	await act(async () => {
+		mock.emit({ type: "chat_done", id: req.id });
+	});
+
+	await act(async () => {
+		result.current.viewHistory(result.current.history[0].id);
+	});
+
+	// Never a perpetual "Thinking…" in a read-only archive.
+	expect(result.current.status).not.toBe("streaming");
+	// The text the user actually saw is preserved (mirrors pressing Stop, which
+	// settles to done with whatever arrived — an error state would DISCARD it).
+	const assistant = result.current.turns.find(t => t.kind === "assistant");
+	if (!assistant || assistant.kind !== "assistant") throw new Error("expected an archived assistant turn");
+	expect(assistant.state.status).toBe("done");
+	expect(assistant.state.text).toBe("a partial answer");
+	// And no tool row is left spinning.
+	expect(assistant.activities.some(a => a.running)).toBe(false);
+});
+
+test("a chat banked before the first token reads back as a terminal message, not an empty bubble", async () => {
+	const mock = new MockTransport();
+	const { result } = renderHook(() => useChatSession(mock));
+	await waitFor(() => expect(result.current.provisioning).toBe("ready"));
+
+	await act(async () => {
+		result.current.send("stopped before any answer");
+	});
+	await act(async () => {
+		result.current.newChat();
+	});
+	await act(async () => {
+		result.current.viewHistory(result.current.history[0].id);
+	});
+
+	expect(result.current.status).not.toBe("streaming");
+	const assistant = result.current.turns.find(t => t.kind === "assistant");
+	if (!assistant || assistant.kind !== "assistant") throw new Error("expected an archived assistant turn");
+	// Nothing arrived, so there is no partial answer to preserve: say it was stopped
+	// rather than render an empty assistant row.
+	expect(assistant.state.status).toBe("error");
+	expect(assistant.state.error).toMatch(/stopped/i);
+});


### PR DESCRIPTION
Closes #2394 — the 🟠 Medium finding the automated reviewer raised on #2392 (non-blocking, so #2392 merged; this is the follow-up).

## The bug

A chat banked **while a turn was streaming** read back frozen on "Thinking…" forever.

`newChat` is deliberately usable mid-stream — it's the wedge-recovery path — but `transport.stop()` only sends `chat_stop`; it does not settle the local turn. The terminal frame then arrives *after* the bank and maps over the **live** turns, so it can never reach the snapshot (turn objects are immutable). Read-back derives `status` from the visible turns, so the archive showed a streaming caret that could never resolve.

Contained (composer disabled while viewing, live conversation unaffected) but it's exactly the wrong signal for a mode whose whole point is honest read-back — and the path is newly reachable: before #2392 a new-chat-while-streaming turn was discarded, not preserved.

**Reproduced before fixing:** send → `chat_delta` → `newChat()` → late `chat_done` → `viewHistory(…)` ⇒ `status === "streaming"`.

## The fix, and one deliberate departure from the suggested direction

`settleForArchive` settles any still-streaming turn on the way into history. The reviewer suggested settling to `"done"`/`"error"`; which one matters more than it looks:

- **With text → `done`, keeping the text.** Deliberately **not** `error`: `turnsToMessages` (`adapt.ts:101-102`) renders an errored assistant turn as the error message **alone**, discarding the accumulated text — it would delete the very content the archive exists to preserve. `done` with partial text is also precisely what pressing **Stop** produces on the live path, so the archive matches what the user would otherwise have seen.
- **Without text → `error`** with a plain "Stopped before a response arrived", rather than an empty assistant bubble.
- Tool rows go through the existing `settleActivities`, so none is left spinning.

The live conversation, `chat_stop` behaviour and the `history_hint` reset are untouched.

## Verification

- Two regression tests, **both mutation-checked** — each fails when the settle is removed and passes with it
- office-pane **356 pass**, chat-ui **162 + 78 pass**, 0 fail
- `XCSH_VISUAL=1` Puppeteer **4 pass / 66 assertions**
- `bun run check` (biome + tsgo) clean in both packages; bundle **161.3KB / 256KB** gz

🤖 Generated with [Claude Code](https://claude.com/claude-code)