### PR TITLE
refactor(chat-ui): drop the now-obsolete React 18/19 ref compat cast in useMenu

### DIFF
--- a/packages/chat-ui/src/components/useMenu.ts
+++ b/packages/chat-ui/src/components/useMenu.ts
@@ -19,13 +19,11 @@ export interface UseMenuResult {
 	open: boolean;
 	setOpen: Dispatch<SetStateAction<boolean>>;
 	toggle: () => void;
-	// Plain `RefObject<T>` — the form BOTH React 18 and React 19 `<el ref={…}>`
-	// props accept from the components that spread these. The version split (React
-	// 19's `useRef<T>(null)` is `RefObject<T | null>`, React 18's is `RefObject<T>`)
-	// is absorbed by a normalizing cast at the single return site below, so the
-	// vendored source builds in the React-18 (office) and React-19 (VS Code) hosts.
-	menuRef: RefObject<HTMLDivElement>;
-	triggerRef: RefObject<HTMLButtonElement>;
+	// `RefObject<T | null>` — exactly what `useRef<T>(null)` returns, and what
+	// `<el ref={…}>` accepts. Nullable because it genuinely is: the ref holds null
+	// until the element mounts, and again after it unmounts.
+	menuRef: RefObject<HTMLDivElement | null>;
+	triggerRef: RefObject<HTMLButtonElement | null>;
 }
 
 export function useMenu(): UseMenuResult {
@@ -88,13 +86,11 @@ export function useMenu(): UseMenuResult {
 		return () => menu.removeEventListener("keydown", onKey);
 	}, [open]);
 
-	// Normalize the refs to `RefObject<T>` (see UseMenuResult): under React 19 the
-	// `useRef` result is `RefObject<T | null>`; this cast reconciles both versions.
 	return {
 		open,
 		setOpen,
 		toggle,
-		menuRef: menuRef as RefObject<HTMLDivElement>,
-		triggerRef: triggerRef as RefObject<HTMLButtonElement>,
+		menuRef,
+		triggerRef,
 	};
 }


### PR DESCRIPTION
Closes #2397. Finishes the React 19 migration from #2382.

## What

`useMenu.ts` cast its returned refs to bridge React 18 and 19. Its comment named the reason: *"so the vendored source builds in the **React-18 (office)** and React-19 (VS Code) hosts."*

Since #2382 there is no React-18 host — office-pane, chat-ui and stats are all on 19.2.8. The shim had nothing left to bridge, and CLAUDE.md is explicit that this repo carries no compatibility shims.

```diff
-	menuRef: RefObject<HTMLDivElement>;
-	triggerRef: RefObject<HTMLButtonElement>;
+	menuRef: RefObject<HTMLDivElement | null>;
+	triggerRef: RefObject<HTMLButtonElement | null>;
```
```diff
-		menuRef: menuRef as RefObject<HTMLDivElement>,
-		triggerRef: triggerRef as RefObject<HTMLButtonElement>,
+		menuRef,
+		triggerRef,
```

## Why it was worse than redundant

Under React 19 types `RefObject<T>.current` is `T` — **non-nullable** — while `useRef<T>(null)` returns `RefObject<T | null>`. Casting the latter to the former told the compiler `.current` can never be null. That is false: the ref holds null before mount and after unmount.

No live bug — all five consumers (`ModeToggle`, `ModelSelector`, `HeaderBar`, `AttachMenu`, `SlashCommandMenu`) only spread `ref={…}`. But the next person to write `menuRef.current.focus()` would have had the compiler agree with them.

## Verification — before/after, not assertion

Probe dereferencing `menuRef.current` into a non-nullable binding:

| | Result |
|---|---|
| **Before** (cast present) | compiles clean — the cast admits the null deref |
| **After** (cast removed) | `TS2322: Type 'HTMLDivElement \| null' is not assignable to type 'HTMLDivElement'` |

- `bun run ci:check:full` → **exit 0**
- chat-ui **162 + 78 pass, 0 fail**; office-pane **355 pass, 0 fail**; `menu-a11y.test.tsx` **2 pass**

### A correction worth surfacing

My first probe went in `chat-ui/src` and compiled clean — which I initially read as evidence. It was not. `packages/chat-ui/tsconfig.json` declares `include: ["scripts"]` and **excludes `src`**, so the file was in no program at all and the green result was vacuous. The real probe had to run under `packages/office-pane/tsconfig.client.json`, which is where chat-ui's source is actually typechecked (35 `chat-ui/src` files appear in that program).

That is recorded in #2397 as a finding in its own right: **chat-ui's own `check` script does not typecheck its `src`**. Coverage exists only transitively through office-pane, which also means chat-ui's type correctness depends on office-pane continuing to import every part of it. Not obviously wrong, but non-obvious and sharp-edged.

## Deliberately not done here

`chat-ui`'s `peerDependencies.react` remains `>=18`. Nothing in-repo is on React 18 any more, so the range claims support that is never built or tested — but narrowing it to `>=19` is a breaking change for external consumers of this vendored package, and that call belongs to someone who knows them. Structurally the new types remain React-18-compatible (under React 18, `RefObject<T>` is `{ readonly current: T | null }`, so `RefObject<T | null>` is the same type), though I could not verify that directly since React 18's types are no longer installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)