### PR TITLE
fix(system-prompt): make the XCSH.md walk's deadline preempt a blocking readdir

### DIFF
--- a/packages/chat-ui/scripts/sync-vendor.ts
+++ b/packages/chat-ui/scripts/sync-vendor.ts
@@ -164,7 +164,9 @@ export function verifySync(targetDir: string, srcDir: string = SRC_DIR): VerifyR
 function defaultSiblingTargets(): string[] {
 	const root = path.resolve(PKG_DIR, "..", "..", ".."); // .../f5-sales-demo
 	return [
-		path.join(root, "vscode-xcsh", "webview", "src", "vendor", "chat-ui"),
+		// vscode-xcsh vendors to `vendored/`, NOT `vendor/`: its .gitignore ignores
+		// `vendor/`, so writing there would silently update a copy git never sees.
+		path.join(root, "vscode-xcsh", "webview", "src", "vendored", "chat-ui"),
 		path.join(root, "xcsh-chrome-extension", "src", "vendor", "chat-ui"),
 	].filter(d => fs.existsSync(path.dirname(path.dirname(d))));
 }

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -125,11 +125,49 @@ export interface AgentsMdSearch {
 	files: string[];
 }
 
-/** Mutable traversal budget shared across the recursive walk. */
-interface WalkBudget {
+/** Reads one directory. Injectable so tests can simulate a readdir that never settles. */
+type ReaddirFn = (dir: string) => Promise<fs.Dirent[]>;
+
+/** Mutable traversal budget + the reader, shared across the recursive walk. */
+interface WalkContext {
 	readonly maxDirs: number;
 	readonly deadline: number;
+	readonly readdir: ReaddirFn;
 	dirsVisited: number;
+}
+
+/**
+ * Read one directory, giving up when the walk's deadline passes.
+ *
+ * The budget checks between directories are NOT enough on their own: a `readdir`
+ * that never settles — a TCC-protected or cloud-synced directory such as
+ * ~/Documents on a managed Mac — would park the walk forever at zero CPU, hanging
+ * `createAgentSession` and with it the Office pane's `set_host_tools` (#2399). The
+ * deadline has to be enforced HERE, around the syscall itself.
+ *
+ * Returns null when the directory could not be read in time (or at all); the
+ * caller treats that as "nothing here" and moves on.
+ *
+ * The abandoned read keeps a thread-pool slot until the OS releases it. That is
+ * bounded by the number of pathological directories and is strictly better than
+ * never returning.
+ */
+async function readdirWithinBudget(dir: string, ctx: WalkContext): Promise<fs.Dirent[] | null> {
+	const remaining = ctx.deadline - Date.now();
+	if (remaining <= 0) return null;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			ctx.readdir(dir).catch(() => null),
+			new Promise<null>(resolve => {
+				timer = setTimeout(() => resolve(null), remaining);
+			}),
+		]);
+	} finally {
+		// Never leave the timer pending: it would hold the event loop open well past
+		// the walk (and past process exit for a long budget).
+		if (timer) clearTimeout(timer);
+	}
 }
 
 function normalizePath(value: string): string {
@@ -148,7 +186,7 @@ async function collectAgentsMdFiles(
 	limit: number,
 	maxDepth: number,
 	discovered: Set<string>,
-	budget: WalkBudget,
+	budget: WalkContext,
 ): Promise<void> {
 	// Stop on any bound: depth, enough matches, the directory-visit budget, or the
 	// wall-clock deadline. The last two keep a match-poor tree (e.g. $HOME) bounded.
@@ -165,12 +203,9 @@ async function collectAgentsMdFiles(
 	// sibling sees the updated count before it yields, making the cap effectively hard.
 	budget.dirsVisited++;
 
-	let entries: fs.Dirent[];
-	try {
-		entries = await fs.promises.readdir(dir, { withFileTypes: true });
-	} catch {
-		return;
-	}
+	// Deadline-guarded: a directory that never answers must not park the whole walk.
+	const entries = await readdirWithinBudget(dir, budget);
+	if (!entries) return;
 
 	if (depth >= AGENTS_MD_MIN_DEPTH) {
 		const hasAgentsMd = entries.some(entry => entry.isFile() && entry.name === "XCSH.md");
@@ -208,12 +243,18 @@ export interface DiscoverAgentsMdOptions {
 	maxDepth?: number;
 	maxDirs?: number;
 	budgetMs?: number;
+	/** Directory reader; defaults to `fs.promises.readdir`. A test seam for
+	 *  simulating a filesystem that never answers. */
+	readdir?: ReaddirFn;
 }
 
 /**
  * Walk `root` (bounded by depth, match-limit, directory budget, and a wall-clock
  * deadline) collecting nested `XCSH.md` paths. Returns the sorted matches plus the
  * number of directories visited (for observability/tests). Never throws.
+ *
+ * The deadline is PREEMPTIVE: it bounds each `readdir` as well as the walk as a
+ * whole, so a directory that never answers cannot stall startup (#2399).
  */
 export async function discoverAgentsMdFiles(
 	root: string,
@@ -221,17 +262,18 @@ export async function discoverAgentsMdFiles(
 ): Promise<{ files: string[]; dirsVisited: number }> {
 	const limit = opts.limit ?? AGENTS_MD_LIMIT;
 	const maxDepth = opts.maxDepth ?? AGENTS_MD_MAX_DEPTH;
-	const budget: WalkBudget = {
+	const ctx: WalkContext = {
 		maxDirs: opts.maxDirs ?? AGENTS_MD_MAX_DIRS,
 		deadline: Date.now() + (opts.budgetMs ?? AGENTS_MD_WALK_BUDGET_MS),
+		readdir: opts.readdir ?? ((dir: string) => fs.promises.readdir(dir, { withFileTypes: true })),
 		dirsVisited: 0,
 	};
 	try {
 		const discovered = new Set<string>();
-		await collectAgentsMdFiles(root, root, 0, limit, maxDepth, discovered, budget);
-		return { files: Array.from(discovered).sort().slice(0, limit), dirsVisited: budget.dirsVisited };
+		await collectAgentsMdFiles(root, root, 0, limit, maxDepth, discovered, ctx);
+		return { files: Array.from(discovered).sort().slice(0, limit), dirsVisited: ctx.dirsVisited };
 	} catch {
-		return { files: [], dirsVisited: budget.dirsVisited };
+		return { files: [], dirsVisited: ctx.dirsVisited };
 	}
 }
 

--- a/packages/coding-agent/test/discovery/agents-md-walk.test.ts
+++ b/packages/coding-agent/test/discovery/agents-md-walk.test.ts
@@ -60,6 +60,70 @@ describe("discoverAgentsMdFiles (bounded walk)", () => {
 	});
 });
 
+/**
+ * The budget must be PREEMPTIVE, not merely cooperative. Checking the deadline
+ * between directories is not enough: a `readdir` that never settles — a
+ * TCC-protected or cloud-synced directory such as ~/Documents on a managed Mac —
+ * parks the walk forever at zero CPU, which hung `createAgentSession` (and so the
+ * Office pane's `set_host_tools`) whenever xcsh was served from $HOME. See #2399.
+ */
+describe("discoverAgentsMdFiles (a blocking readdir cannot stall the walk)", () => {
+	let tempDir = "";
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-block-"));
+	});
+	afterEach(() => {
+		if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	/**
+	 * Real readdir, except `blockedDir` returns a promise that never settles.
+	 * `calls` proves the injected seam was actually USED — without it, an ignored
+	 * option would silently fall back to the (fast, real) readdir and the timing
+	 * assertions below would pass while testing nothing.
+	 */
+	function readdirBlockingOn(blockedDir: string) {
+		const calls: string[] = [];
+		const readdir = (dir: string): Promise<fs.Dirent[]> => {
+			calls.push(dir);
+			return path.resolve(dir) === path.resolve(blockedDir)
+				? new Promise<fs.Dirent[]>(() => {}) // never settles, like ~/Documents
+				: fs.promises.readdir(dir, { withFileTypes: true });
+		};
+		return { readdir, calls };
+	}
+
+	it("returns within budget when a directory's readdir never settles", async () => {
+		const blocked = path.join(tempDir, "blocked");
+		const ok = path.join(tempDir, "service");
+		fs.mkdirSync(blocked, { recursive: true });
+		fs.mkdirSync(ok, { recursive: true });
+		fs.writeFileSync(path.join(ok, "XCSH.md"), "# rules");
+		const { readdir, calls } = readdirBlockingOn(blocked);
+
+		const started = Date.now();
+		const { files } = await discoverAgentsMdFiles(tempDir, { budgetMs: 300, readdir });
+		const elapsed = Date.now() - started;
+
+		// The walk really went through the injected readdir (and reached the bad dir).
+		expect(calls.map(c => path.resolve(c))).toContain(path.resolve(blocked));
+		// Bounded: without preemption this never returns at all.
+		expect(elapsed).toBeLessThan(5000);
+		// …and the healthy sibling is still discovered, so one bad directory does not
+		// cost us the rest of the tree.
+		expect(files).toContain("service/XCSH.md");
+	});
+
+	it("returns within budget even when the ROOT readdir never settles", async () => {
+		const { readdir, calls } = readdirBlockingOn(tempDir);
+		const started = Date.now();
+		const { files } = await discoverAgentsMdFiles(tempDir, { budgetMs: 300, readdir });
+		expect(calls).toHaveLength(1);
+		expect(Date.now() - started).toBeLessThan(5000);
+		expect(files).toEqual([]);
+	});
+});
+
 describe("buildSystemPrompt hoists agentsMdSearch (no re-walk)", () => {
 	let tempDir = "";
 	beforeAll(() => {


### PR DESCRIPTION
Closes #2399

Serving the Office pane from `$HOME` hung the pane on **"Connecting to xcsh…" forever**. Until now this was only ever worked around ("run `xcsh office serve` from a small cwd"). This is the root-cause fix.

## What was actually wrong

`discoverAgentsMdFiles` enforced its `maxDirs` / `deadline` budget **only between directories**. Once inside `await fs.promises.readdir(dir)`, nothing could preempt it — so a single `readdir` that never settles parked the whole walk **forever, at zero CPU**. On a managed Mac, `~/Documents` and `~/Downloads` are exactly that (TCC-protected and/or cloud-synced).

`createAgentSession` awaits that walk (`sdk.ts:978`), and `startHeadlessChatBridge` binds the bridge **before** creating the session — so the socket happily answered `hello` while the session never came into existence and `set_host_tools` was never acked. The startup banner never printed either.

## Measured, so the fix targets the real cause

| Experiment | Result |
|---|---|
| `set_host_tools` from `/tmp/xcsh-office-cwd` | **ack in 34 ms** |
| `set_host_tools` from `$HOME` | **never** (60 s+) |
| `createAgentSession({cwd: $HOME})` | **never resolved** (`/tmp`: 235 ms) |
| …**without** `sandbox-guard` | still hung ⇒ **not the sandbox** |
| …on a huge **non-home** tree (all of `GIT/f5-sales-demo`) | **942 ms, fine** ⇒ **not tree size** |
| `discoverAgentsMdFiles($HOME)` alone | **never returned** (budget is 1500 ms) |
| `readdir` per `$HOME` child | **`~/Documents`, `~/Downloads` block >8 s** |
| `sample` of the hung process | idle in `kevent64`, **0.1 % CPU** |

The zero-CPU idle stack is the tell: a blocked syscall, not a slow scan. **#2245 bounded this walk for SIZE — size was never the problem.**

## The fix

`readdirWithinBudget` races each read against the remaining deadline and treats a timeout as "nothing here", so one unresponsive directory costs that directory rather than the process. The timer is always cleared so it can't hold the event loop open.

An abandoned read still holds a Bun thread-pool slot until the OS releases it — bounded by the number of pathological directories, and strictly better than never returning. Noted in the code.

**Two things deliberately left out:**
- Making `office serve` auto-chdir out of `$HOME` (as the CLI's `maybeAutoChdir` does). That would silently relocate where the user's file tools operate; the walk is the root cause and fixing it there helps every caller.
- A redundant outer race around the whole walk. I wrote one, then removed it: the per-readdir guard alone satisfies the contract, so the outer race was unreachable code that no test could justify. I verified this by mutation — with both guards in, removing *either* one individually left every test green.

## Verification

- **The original repro is cured:** `createAgentSession` with `cwd=$HOME` goes from *never resolving* to **1182 ms**.
- Two regression tests inject a never-settling `readdir` (one mid-tree, one at the root) through a new injectable `readdir` option. Both **assert the seam was actually used** — my first draft passed while testing nothing, because an unknown option is silently ignored and the real, fast `readdir` ran instead. Both **fail without the fix** (mutation-checked).
- coding-agent **5795 pass / 0 fail**; biome + tsgo clean in both touched packages.

## Drive-by

`sync-vendor.ts`'s `defaultSiblingTargets()` pointed at `vscode-xcsh/webview/src/vendor/chat-ui`, but that repo vendors to `vendored/` and its `.gitignore:65` ignores `vendor/` — a default-target run silently wrote to a copy git never sees. Needed for the vendor-sync work that follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)