### PR TITLE
fix(chat-ui): derive useMenu's return type so preact/compat consumers compile

### DIFF
--- a/packages/chat-ui/src/components/useMenu.ts
+++ b/packages/chat-ui/src/components/useMenu.ts
@@ -13,20 +13,22 @@
  * on the trigger button. Framework-neutral (plain DOM APIs) so it works under
  * React and preact/compat alike.
  */
-import { type Dispatch, type RefObject, type SetStateAction, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-export interface UseMenuResult {
-	open: boolean;
-	setOpen: Dispatch<SetStateAction<boolean>>;
-	toggle: () => void;
-	// `RefObject<T | null>` — exactly what `useRef<T>(null)` returns, and what
-	// `<el ref={…}>` accepts. Nullable because it genuinely is: the ref holds null
-	// until the element mounts, and again after it unmounts.
-	menuRef: RefObject<HTMLDivElement | null>;
-	triggerRef: RefObject<HTMLButtonElement | null>;
-}
+/**
+ * What {@link useMenu} returns, DERIVED rather than hand-written.
+ *
+ * The ref types must be spelled by whichever runtime is compiling this source:
+ * React 19's `useRef<T>(null)` yields `RefObject<T | null>`, while preact/compat's
+ * yields its own `RefObject<T>` — and preact's JSX `ref` prop accepts only the
+ * latter. Naming either one explicitly typechecks in one host and breaks the
+ * other (a hand-written `RefObject<T | null>` broke the Chrome extension, which
+ * vendors this source and aliases react → preact/compat). Inference sidesteps the
+ * whole problem: each host derives the refs its own JSX already accepts.
+ */
+export type UseMenuResult = ReturnType<typeof useMenu>;
 
-export function useMenu(): UseMenuResult {
+export function useMenu() {
 	const [open, setOpen] = useState(false);
 	const menuRef = useRef<HTMLDivElement>(null);
 	const triggerRef = useRef<HTMLButtonElement>(null);


### PR DESCRIPTION
Closes #2403

Found while re-vendoring `chat-ui` into the Chrome extension — a break that CI structurally could not see.

## The problem

`useMenu` hand-wrote its ref types as `RefObject<T | null>`. That is exactly right for React 19. But this source is **vendored into the Chrome extension**, which aliases `react → preact/compat`, where:

- `useRef<T>(null)` yields preact's own `RefObject<T>` (`{ current: T | null }`)
- the JSX `ref` prop accepts `Ref<T> = RefObject<T> | RefCallback<T> | null`

`RefObject<T | null>` is not assignable to that, so every consumer which merely spreads `ref={menuRef}` failed to compile. A fresh vendor produced **10 `TS2322`s** across `AttachMenu`, `HeaderBar`, `ModeToggle`, `ModelSelector` and `SlashCommandMenu`.

This is fallout from #2398. Dropping the compat cast was right about the React 18/19 split — but that cast was *also* bridging the preact host, and since chrome vendors on its own schedule, nothing re-vendored afterwards and no CI job ever compiled the new source under preact. Worth noting as a class of gap, not a criticism of #2398: **the shared library has a consumer whose type-compatibility is only checked when someone syncs it.**

## The fix

Stop naming the ref types; let each host infer its own, and derive the public type instead of duplicating it:

```ts
export type UseMenuResult = ReturnType<typeof useMenu>;
export function useMenu() { … }
```

React 19 infers `RefObject<T | null>`, preact infers `RefObject<T>` — each precisely what that host's JSX already accepts. `UseMenuResult` stays exported from the barrel.

## This does NOT undo #2398

I re-ran that PR's own probe under `office-pane`'s `tsconfig.client.json`:

```ts
const el: HTMLDivElement = menuRef.current;
// error TS2322: Type 'HTMLDivElement | null' is not assignable to type 'HTMLDivElement'
```

Still errors. The ref remains honestly nullable — only the hand-written, host-specific spelling is gone.

## Verification

- Chrome extension typechecks against a freshly vendored copy: **0 errors (was 10)**
- chat-ui **162 + 78 pass**, office-pane **357 pass**, 0 fail
- biome + tsgo clean in both packages

The Chrome re-vendor PR depends on this landing first, since the vendored copy must byte-match this source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)