### PR TITLE
refactor(system-prompt): use the shared withTimeout in readdirWithinBudget

### DIFF
--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -6,7 +6,16 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentTool } from "@f5-sales-demo/pi-agent-core";
-import { $env, getGpuCachePath, getProjectDir, hasFsCode, isEnoent, logger, prompt } from "@f5-sales-demo/pi-utils";
+import {
+	$env,
+	getGpuCachePath,
+	getProjectDir,
+	hasFsCode,
+	isEnoent,
+	logger,
+	prompt,
+	withTimeout,
+} from "@f5-sales-demo/pi-utils";
 import { $ } from "bun";
 import { contextFileCapability } from "./capability/context-file";
 import { systemPromptCapability } from "./capability/system-prompt";
@@ -155,19 +164,10 @@ interface WalkContext {
 async function readdirWithinBudget(dir: string, ctx: WalkContext): Promise<fs.Dirent[] | null> {
 	const remaining = ctx.deadline - Date.now();
 	if (remaining <= 0) return null;
-	let timer: ReturnType<typeof setTimeout> | undefined;
-	try {
-		return await Promise.race([
-			ctx.readdir(dir).catch(() => null),
-			new Promise<null>(resolve => {
-				timer = setTimeout(() => resolve(null), remaining);
-			}),
-		]);
-	} finally {
-		// Never leave the timer pending: it would hold the event loop open well past
-		// the walk (and past process exit for a long budget).
-		if (timer) clearTimeout(timer);
-	}
+	// `withTimeout` rejects on expiry and clears its own timer; here expiry is an
+	// ordinary outcome, so both it and a real read failure collapse to null — the
+	// caller treats either as "nothing here".
+	return await withTimeout(ctx.readdir(dir), remaining, `readdir exceeded the walk budget: ${dir}`).catch(() => null);
 }
 
 function normalizePath(value: string): string {


### PR DESCRIPTION
Closes #2406

The 🟡 DRY nit the reviewer raised on #2400.

`readdirWithinBudget` hand-rolled the "race a promise against a timeout, clear the timer on settle" pattern that pi-utils' tested `withTimeout` already provides, and which this package already uses in `mcp/client.ts`.

The reviewer left it to my discretion because the semantics differ: `withTimeout` models expiry as a **rejection**, whereas here expiry is an **ordinary outcome** reported as `null`. I adopted it anyway — that difference costs one `.catch(() => null)`, which the hand-rolled version already needed for read errors. So the helper collapses both failure modes into the same, already-required branch and removes twelve lines of bespoke concurrency code; timer cleanup moves inside the tested helper instead of a local `finally`.

```ts
// before: 12 lines of Promise.race + a finally that clears the timer
// after:
return await withTimeout(ctx.readdir(dir), remaining, `readdir exceeded the walk budget: ${dir}`).catch(() => null);
```

## Verification

Behaviour is unchanged, and I re-ran the mutation check rather than assuming: removing the timeout again still fails both blocking-`readdir` regression tests (4 pass / 2 fail), so the guard remains load-bearing after the refactor.

- coding-agent **5795 pass / 0 fail**
- biome + tsgo clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)