### PR TITLE
feat(rpc): add a list_skills command and share the client-facing projection

### DIFF
--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import type { AssistantMessage, ImageContent } from "@f5-sales-demo/pi-ai";
 import { settings } from "../config/settings";
 import { DEFAULT_MODEL_ROLE } from "../config/settings-schema";
+import { toSkillSummaries } from "../extensibility/skills";
 import {
 	isRpcHostToolResult,
 	isRpcHostToolUpdate,
@@ -428,8 +429,8 @@ export class ChatHandler {
 	 *  already loaded on the session; the model actions them via the read tool + the
 	 *  system prompt (Phase 2A enabled `read`), so this is enumeration only. */
 	#handleListSkills(): void {
-		const skills = this.#session.skills.map(s => ({ name: s.name, description: s.description }));
-		this.#server.send({ type: "skills", skills } satisfies SkillsList);
+		// Shared projection: one place decides what crosses to a client (never paths).
+		this.#server.send({ type: "skills", skills: toSkillSummaries(this.#session.skills) } satisfies SkillsList);
 	}
 
 	#sendTerminal(chat: ActiveChat, frame: ChatDone | ChatError): void {

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -19,6 +19,26 @@ export interface Skill {
 	_source?: SourceMeta;
 }
 
+/** A skill as a CLIENT sees it: enough to render a menu entry, nothing more. */
+export interface SkillSummary {
+	name: string;
+	description: string;
+}
+
+/**
+ * Project loaded skills onto the client-facing summary.
+ *
+ * `Skill` also carries `filePath`, `baseDir`, `source` and `_source` — the
+ * operator's on-disk layout. A UI surface (Office pane, Chrome side panel, VS Code
+ * webview) needs only the name and description to populate a menu, so this is the
+ * one place that decides what crosses the boundary. Shared by every transport
+ * (the `list_skills` bridge frame and the `list_skills` RPC command) so they can't
+ * drift into leaking different amounts.
+ */
+export function toSkillSummaries(skills: readonly Skill[]): SkillSummary[] {
+	return skills.map(s => ({ name: s.name, description: s.description }));
+}
+
 export interface SkillWarning {
 	skillPath: string;
 	message: string;

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -390,6 +390,15 @@ export class RpcClient {
 	}
 
 	/**
+	 * List the session's loaded skills (name + description) so a host can populate a
+	 * skills menu. Enumeration only — invoking one is just a prompt beginning `/name`.
+	 */
+	async listSkills(): Promise<{ skills: Array<{ name: string; description: string }> }> {
+		const response = await this.#send({ type: "list_skills" });
+		return this.#getData(response);
+	}
+
+	/**
 	 * Set thinking level.
 	 */
 	async setThinkingLevel(level: ThinkingLevel): Promise<void> {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -16,6 +16,7 @@ import type {
 	ExtensionUIDialogOptions,
 	ExtensionWidgetOptions,
 } from "../../extensibility/extensions";
+import { toSkillSummaries } from "../../extensibility/skills";
 import {
 	isRpcHostToolResult,
 	isRpcHostToolUpdate,
@@ -634,6 +635,13 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 					model: welcomeResult.model,
 					services,
 				});
+			}
+
+			case "list_skills": {
+				// Enumeration only: skills already work through the read tool + system
+				// prompt. Mirrors the `list_skills` bridge frame the Office pane uses, via
+				// the same shared projection so neither transport can leak on-disk paths.
+				return success(id, "list_skills", { skills: toSkillSummaries(session.skills) });
 			}
 
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -7,6 +7,7 @@
 import type { AgentMessage, ThinkingLevel } from "@f5-sales-demo/pi-agent-core";
 import type { Effort, ImageContent, Model } from "@f5-sales-demo/pi-ai";
 import type { BashResult } from "../../exec/bash-executor";
+import type { SkillSummary } from "../../extensibility/skills";
 // The host-tool wire types are transport-neutral and live in the shared host-tool
 // core so both the stdio RPC driver and the WS chat bridge use one vocabulary.
 import type {
@@ -48,6 +49,7 @@ export type RpcCommand =
 	| { id?: string; type: "set_todos"; phases: TodoPhase[] }
 	| { id?: string; type: "set_host_tools"; tools: RpcHostToolDefinition[] }
 	| { id?: string; type: "get_integrations" }
+	| { id?: string; type: "list_skills" }
 
 	// Model
 	| { id?: string; type: "set_model"; provider: string; modelId: string }
@@ -132,6 +134,13 @@ export type RpcResponse =
 	| { id?: string; type: "response"; command: "get_state"; success: true; data: RpcSessionState }
 	| { id?: string; type: "response"; command: "set_todos"; success: true; data: { todoPhases: TodoPhase[] } }
 	| { id?: string; type: "response"; command: "set_host_tools"; success: true; data: { toolNames: string[] } }
+	| {
+			id?: string;
+			type: "response";
+			command: "list_skills";
+			success: true;
+			data: { skills: SkillSummary[] };
+	  }
 	| {
 			id?: string;
 			type: "response";

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { type Skill as CapabilitySkill, skillCapability } from "@f5-sales-demo/xcsh/capability/skill";
 import { getCapability } from "@f5-sales-demo/xcsh/discovery";
-import { loadSkills, loadSkillsFromDir, type Skill } from "@f5-sales-demo/xcsh/extensibility/skills";
+import { loadSkills, loadSkillsFromDir, type Skill, toSkillSummaries } from "@f5-sales-demo/xcsh/extensibility/skills";
 
 const fixturesDir = path.resolve(import.meta.dirname, "fixtures/skills");
 const collisionFixturesDir = path.resolve(import.meta.dirname, "fixtures/skills-collision");
@@ -440,5 +440,30 @@ description: Skill loaded from a tilde-expanded custom directory.
 			expect(collisionWarnings).toHaveLength(1);
 			expect(collisionWarnings[0].message).toContain("name collision");
 		});
+	});
+});
+
+describe("toSkillSummaries", () => {
+	const skill = (name: string, description: string): Skill => ({
+		name,
+		description,
+		filePath: `/Users/someone/private/skills/${name}/SKILL.md`,
+		baseDir: "/Users/someone/private/skills",
+		source: "native:project",
+		_source: { kind: "project" } as never,
+	});
+
+	it("projects ONLY name + description — never the on-disk paths", () => {
+		const out = toSkillSummaries([skill("competitive", "F5 XC battlecards")]);
+		// Exact match: `Skill` also carries filePath / baseDir / source / _source, and a
+		// client (Office pane, Chrome side panel, VS Code webview) must never receive
+		// the operator's directory layout just to populate a menu.
+		expect(out).toEqual([{ name: "competitive", description: "F5 XC battlecards" }]);
+		expect(JSON.stringify(out)).not.toContain("private");
+	});
+
+	it("preserves load order and handles an empty list", () => {
+		expect(toSkillSummaries([skill("a", "first"), skill("b", "second")]).map(s => s.name)).toEqual(["a", "b"]);
+		expect(toSkillSummaries([])).toEqual([]);
 	});
 });


### PR DESCRIPTION
Closes #2407 — the engine half of giving the VS Code webview a skills menu.

## Why

The Office pane populates its Skills submenu with the `list_skills` **bridge frame**, and the Chrome extension can use the same frame (same WebSocket bridge). **VS Code cannot** — it drives xcsh over the **RPC bridge** (spawned child process), and `rpc-mode.ts` exposed no skills command at all. So that webview had no way to enumerate them.

Adds `list_skills` to the `RpcCommand` / `RpcResponse` unions, the dispatch case, and `RpcClient.listSkills()`. Enumeration only, matching the bridge frame's semantics: invoking a skill is just a prompt beginning `/name`.

## The part that isn't just plumbing

The WS handler inlined its own projection:

```ts
session.skills.map(s => ({ name: s.name, description: s.description }))
```

`Skill` also carries `filePath`, `baseDir`, `source` and `_source` — the operator's on-disk layout. Copying that `.map(...)` into `rpc-mode` would leave **two independent places deciding what crosses to a client**, each free to drift into leaking different amounts. A menu needs a name and a description; it does not need the user's directory structure.

Both transports now go through one `toSkillSummaries` in `extensibility/skills.ts`, which is where that decision belongs.

## Verification

- The projection is guarded by a test asserting **only** `name` + `description` survive, plus that the serialized output contains no path fragment. **Mutation-checked**: adding `filePath` back turns it red.
- The existing bridge tests (`test/chat-handler-list-skills.test.ts`) pass unchanged, so the WS contract is untouched.
- coding-agent **5797 pass / 0 fail**; biome + tsgo clean.

The VS Code side (webview protocol + `ComposerHost` wiring) follows in that repo, and Chrome's own skills menu uses the bridge frame rather than this command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)