### PR TITLE
fix(office): restore the brand mark's size and stop hiding/greying the controls

### DIFF
--- a/packages/office-pane/src/panel/ChatPanel.tsx
+++ b/packages/office-pane/src/panel/ChatPanel.tsx
@@ -120,13 +120,22 @@ const STARTERS: readonly (SkillPill & { text: string })[] = [
 	{ id: "summarize", label: "Summarize", hint: "Prefill a prompt", text: "Summarize this document." },
 ];
 
+/**
+ * Brand-mark size. Until #2414 `.f5-mark` declared `width/height:auto`, which
+ * outranks the width/height attributes F5Logo emits from `size` — so every mark
+ * rendered at the PNG's intrinsic 128px and this prop was dead. That 128px is the
+ * appearance that shipped and was signed off, so it is now stated deliberately
+ * rather than inherited by accident.
+ */
+const BRAND_MARK_SIZE = 128;
+
 /** The F5 brand block. Rendered INSIDE the transcript scrollport (via
  *  `Transcript.brand`) so it scrolls away with the conversation instead of sitting
  *  in a pinned band — the pinned row is the {@link HeaderBar} control row. */
 function Brand() {
 	return (
 		<div className="brand-block">
-			<F5Logo variant="mark" size={20} />
+			<F5Logo variant="mark" size={BRAND_MARK_SIZE} />
 			<span className="brand-title">xcsh</span>
 		</div>
 	);
@@ -219,8 +228,10 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 	// The header's clock menu: this session's banked chats, newest first, plus a way
 	// back to the live one while reading an archive. Omitted entirely when there is
 	// nothing to show, so the control never appears as a dead button on first run.
-	const historyItems = useMemo<MenuItem[] | undefined>(() => {
-		if (history.length === 0) return undefined;
+	// ALWAYS rendered, even with nothing banked: the menu then reads "This session ·
+	// Empty", which is honest, whereas a control that materialises later reads as
+	// broken (#2415 — the reference pane always shows it).
+	const historyItems = useMemo<MenuItem[]>(() => {
 		const banked: MenuItem[] = history.map(h => ({
 			id: h.id,
 			label: h.title,
@@ -327,7 +338,6 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 		<HeaderBar
 			title={title}
 			onNewChat={newChat}
-			canNewChat={ready && turns.length > 0}
 			historyItems={historyItems}
 			onHistorySelect={handleHistorySelect}
 			// Say the quiet part out loud: these chats live only in this pane session.

--- a/packages/office-pane/test/ChatPanel.test.tsx
+++ b/packages/office-pane/test/ChatPanel.test.tsx
@@ -56,17 +56,19 @@ test("no ⋯ menu when the host wired no reconfigure action (never an empty menu
 	expect(scope.queryByRole("button", { name: /more options/i })).toBeNull();
 });
 
-test("New chat: disabled until there's a settled turn, then clears the transcript and resets history_hint", async () => {
+test("New chat is actionable from the start, clears the transcript and resets history_hint", async () => {
 	const mock = new MockTransport();
 	const { container } = render(<ChatPanel transport={mock} />);
 	const scope = within(container);
 	await settle();
 
 	const newChatBtn = () => scope.getByRole("button", { name: /new chat/i }) as HTMLButtonElement;
-	// No turns yet → disabled.
-	expect(newChatBtn().disabled).toBe(true);
+	// Actionable on the pane the user first sees — a greyed control reads as broken, and
+	// resetting an already-empty chat is a harmless no-op (#2415). It is also the way
+	// back to the live chat while reading an archive, which has nothing to do with how
+	// many turns the VISIBLE transcript has.
+	expect(newChatBtn().disabled).toBe(false);
 
-	// Once there's a turn, New chat is enabled — including while it streams (recovery).
 	fireEvent.click(scope.getByRole("button", { name: /summarize/i }));
 	fireEvent.click(scope.getByRole("button", { name: /send/i }));
 	const req1 = mock.sent.filter((m): m is ChatRequestMsg => m.type === "chat_request")[0];
@@ -74,8 +76,6 @@ test("New chat: disabled until there's a settled turn, then clears the transcrip
 	await act(async () => {
 		mock.emit({ type: "chat_done", id: req1.id });
 	});
-	await waitFor(() => expect(newChatBtn().disabled).toBe(false));
-
 	// Click New chat → transcript clears (the user prompt row is gone).
 	fireEvent.click(newChatBtn());
 	await waitFor(() => expect(scope.queryByText("Summarize this document.")).toBeNull());
@@ -115,8 +115,16 @@ test("chat history: banked on New chat, listed under the clock, and read back RE
 	const scope = within(container);
 	await settle();
 
-	// Nothing banked yet → no history control at all (never a dead button).
-	expect(scope.queryByRole("button", { name: /chat history/i })).toBeNull();
+	// The history control is always present (the reference pane's behaviour): opening it
+	// on a fresh session must SAY it is empty rather than the button not existing.
+	await act(async () => {
+		fireEvent.click(scope.getByRole("button", { name: /chat history/i }));
+	});
+	expect(scope.getByText(/this session/i)).toBeDefined();
+	expect(scope.getByText(/^Empty$/)).toBeDefined();
+	await act(async () => {
+		fireEvent.keyDown(document, { key: "Escape" });
+	});
 
 	// One completed exchange, then New chat banks it.
 	fireEvent.click(scope.getByRole("button", { name: /summarize/i }));
@@ -293,8 +301,9 @@ test("Settings stays reachable from the config-error view (the only route with a
 	});
 	fireEvent.click(scope.getByRole("menuitem", { name: /settings/i }));
 	expect(reconfigured).toBe(1);
-	// Nothing to reset yet, so new-chat is present but inert.
-	expect((scope.getByRole("button", { name: /new chat/i }) as HTMLButtonElement).disabled).toBe(true);
+	// The control row is fully live here too (nothing to reset is a no-op, not a reason
+	// to grey it out).
+	expect((scope.getByRole("button", { name: /new chat/i }) as HTMLButtonElement).disabled).toBe(false);
 });
 
 test("Settings stays reachable from the first-run onboarding view (no bridge at all)", async () => {

--- a/packages/office-pane/test/shell-visual.test.ts
+++ b/packages/office-pane/test/shell-visual.test.ts
@@ -47,6 +47,11 @@ const OUT_DIR = join(PKG, "test", "__visual__");
 const WIDTHS = [320, 480] as const;
 /** Office draws its own ⓘ over the pane's top-right; our row must not sit under it. */
 const MIN_RIGHT_RESERVE = 28;
+/** Mark size the harness renders. Asserted as "whatever we asked for" rather than a
+ *  literal, so this keeps guarding `.f5-mark` against regaining a width/height
+ *  override (which once forced every mark to the PNG's intrinsic 128px and made the
+ *  `size` prop dead — #2414) WITHOUT pinning a design choice into a test. */
+const BRAND_MARK_SIZE = 128;
 
 /** Enough turns to overflow the scrollport, so "does the brand scroll?" is decidable. */
 function longConversation(): ChatMessage[] {
@@ -73,7 +78,7 @@ function harnessHtml(messages: ChatMessage[]): string {
 	const brand = h(
 		"div",
 		{ className: "brand-block" },
-		h(F5Logo, { variant: "mark", size: 20 }),
+		h(F5Logo, { variant: "mark", size: BRAND_MARK_SIZE }),
 		h("span", { className: "brand-title" }, "xcsh"),
 	);
 	const shell = h(
@@ -196,10 +201,9 @@ describe.skipIf(!RUN)("Layer 4 — computed-layout shell parity", () => {
 			// rather than needing a scroll-up to find it.
 			expect(probe.scrollTop).toBe(0);
 			expect(probe.brandVisible).toBe(true);
-			// The mark renders at the requested 20px, not the PNG's intrinsic 128px, so the
-			// brand is a compact line rather than a band dominating a 320px pane.
-			expect(probe.markSize).toEqual({ w: 20, h: 20 });
-			expect(probe.brandHeight).toBeLessThan(48);
+			// The mark honours the size it was GIVEN (see BRAND_MARK_SIZE): the guard is
+			// "the prop is respected", not "the logo is N px".
+			expect(probe.markSize).toEqual({ w: BRAND_MARK_SIZE, h: BRAND_MARK_SIZE });
 			// Brand sits above the starters.
 			expect(probe.brandTop).toBeLessThan(probe.firstPillTop);
 			// Starters really stack: one column (shared left edge, increasing top).


### PR DESCRIPTION
Closes #2414
Closes #2415

Three visual regressions caught in the live Excel pane. All three were **my** choices rather than the reference pane's behaviour.

## 1. Brand mark far too small (#2414)

`.f5-mark` used to declare `width/height:auto`, which outranks the `width`/`height` attributes `F5Logo` emits from its `size` prop — so every mark rendered at the PNG's **intrinsic 128px** and `size` was dead code. #2392 removed that override, which was correct in itself, but it silently swapped the shipped appearance for the `size={20}` the call site had been passing all along.

**Nobody ever chose 20px.** The 128px that shipped and was signed off is the real baseline, so it's now stated deliberately as `BRAND_MARK_SIZE` instead of inherited by accident.

## 2. History clock hidden until something was banked (#2415)

I'd reasoned a clock opening an empty menu "lies about capability". That was backwards — a control that *materialises later* reads as broken, and `MenuButton` already renders an honest **"This session · Empty"**. The reference pane always shows it.

## 3. New chat greyed out on an empty transcript (#2415)

Gated on `ready && turns.length > 0`, so the pane the user first sees had a dead control. Resetting an empty chat is a harmless no-op — and gating on the **visible** transcript was actively wrong, since New chat is the way back to the live chat while reading an archive.

## Test changes, stated plainly

Three `ChatPanel` assertions encoded deviations 2 and 3, so they changed along with the behaviour. Coverage is *kept* for the parts that still matter: that the empty history menu is honest, and that New chat still exits history view.

The visual guard is now **size-agnostic** — it asserts the mark renders at whatever size the harness passed, so it still fails if `.f5-mark` regains a width/height override (the #2414 root cause) without pinning a design choice into a test.

## One thing to flag

At a **320px** pane the 128px mark is ~40% of the width; the captured contact sheet in `test/__visual__/` shows it. The operator's pane is considerably wider, and they told me this size reads well there, so I've restored theirs rather than substitute my judgement a second time. `BRAND_MARK_SIZE` is a single number if it wants tuning.

## Verification

| Gate | Result |
|---|---|
| office-pane `bun run test` | **357 pass / 0 fail** |
| chat-ui `bun run test` | **162 + 78 pass / 0 fail** |
| `XCSH_VISUAL=1` suite | **4 pass / 65 assertions** |
| biome + tsgo | clean |
| `bun run build` | 119.9 KB / 256 KB gz |

🤖 Generated with [Claude Code](https://claude.com/claude-code)