### PR TITLE
feat(rpc): emit citation events so an RPC host can show Sources chips

### DIFF
--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -10,6 +10,7 @@ import {
 	normalizeHostToolDefinitions,
 	RpcHostToolBridge,
 } from "../host-tools";
+import { extractReferences } from "../references";
 import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
 import {
 	type ChatDelta,
@@ -17,7 +18,6 @@ import {
 	type ChatError,
 	type ChatErrorReason,
 	type ChatKeepalive,
-	type ChatReference,
 	type ChatRequest,
 	type Configure,
 	type ConfigureAck,
@@ -680,39 +680,6 @@ function composeBrowserPageContext(parts: string[], context: PageContextSnapshot
 	parts.push("---");
 }
 
-export function classifyReferenceKind(url: string): "doc" | "console" {
-	try {
-		const parsed = new URL(url);
-		if (/\.console\.ves\.volterra\.io$/.test(parsed.hostname)) return "console";
-		if (parsed.hostname === "docs.cloud.f5.com" || parsed.pathname.startsWith("/docs")) return "doc";
-	} catch {
-		/* malformed URL — default to doc */
-	}
-	return "doc";
-}
-
-function titleFromUrl(url: string): string {
-	try {
-		const parsed = new URL(url);
-		const segments = parsed.pathname.split("/").filter(Boolean);
-		return segments.length > 0 ? segments[segments.length - 1] : parsed.hostname;
-	} catch {
-		return url;
-	}
-}
-
-/**
- * Trailing characters a bare-URL match may greedily swallow at a markdown/prose
- * boundary — markdown emphasis + code (`*_~` and backtick) and sentence/wrap
- * punctuation. A real URL effectively never ends in these, so trimming them yields
- * the intended link (e.g. `**https://…/llms.txt**` or a code-wrapped
- * `` `https://…/llms.txt` `` → `https://…/llms.txt`). The markdown-link branch is
- * bounded by its closing `)` and needs no trimming.
- */
-function trimTrailingMarkup(url: string): string {
-	return url.replace(/[*_~`,.;:!?'")\]}>]+$/, "");
-}
-
 /** Panel-facing labels for provider-side tools, used for the activity rows (#2340). */
 function serverToolLabels(toolName: string): { running: string; done: string } {
 	switch (toolName) {
@@ -723,48 +690,4 @@ function serverToolLabels(toolName: string): { running: string; done: string } {
 		default:
 			return { running: `${toolName}: running`, done: toolName };
 	}
-}
-
-export function extractReferences(msg: AssistantMessage): ChatReference[] {
-	const refs: ChatReference[] = [];
-	const seen = new Set<string>();
-
-	// STRUCTURED CITATIONS FIRST (#2340): a provider-side search reports the real page title, so
-	// it beats the regex scrape below — which can only guess a title from the URL path, and finds
-	// nothing at all when the model cites a source without printing its URL in the prose. Done as
-	// its own pass so a citation in a later block still wins over a scrape in an earlier one.
-	for (const block of msg.content) {
-		if (block.type !== "text" || !block.citations) continue;
-		for (const citation of block.citations) {
-			const url = citation.url;
-			if (!url || seen.has(url)) continue;
-			seen.add(url);
-			refs.push({
-				kind: classifyReferenceKind(url),
-				title: citation.title?.trim() || titleFromUrl(url),
-				url,
-			});
-		}
-	}
-
-	for (const block of msg.content) {
-		if (block.type !== "text") continue;
-
-		const mdLinkRegex = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
-		for (let match = mdLinkRegex.exec(block.text); match !== null; match = mdLinkRegex.exec(block.text)) {
-			const [, title, url] = match;
-			if (seen.has(url)) continue;
-			seen.add(url);
-			refs.push({ kind: classifyReferenceKind(url), title, url });
-		}
-
-		const bareUrlRegex = /(?<!\()(https?:\/\/[^\s)>\]]+)/g;
-		for (let match = bareUrlRegex.exec(block.text); match !== null; match = bareUrlRegex.exec(block.text)) {
-			const url = trimTrailingMarkup(match[1]);
-			if (seen.has(url)) continue;
-			seen.add(url);
-			refs.push({ kind: classifyReferenceKind(url), title: titleFromUrl(url), url });
-		}
-	}
-	return refs;
 }

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -24,6 +24,7 @@ import {
 	RpcHostToolBridge,
 } from "../../host-tools";
 import { type Theme, theme } from "../../modes/theme/theme";
+import { referencesEventFor } from "../../references";
 import type { AgentSession } from "../../session/agent-session";
 import { mapContextStatus, runWelcomeChecks } from "../components/welcome-checks";
 import type {
@@ -497,6 +498,11 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 	// Output all agent events as JSON
 	session.subscribe(event => {
 		output(event);
+		// Citations for the host's Sources chips, mirroring `chat_done.references` on
+		// the WS bridge. The turn-boundary rule (an intermediate tool-use step also
+		// emits message_end) lives in the shared, tested `referencesEventFor` (#2420).
+		const refs = referencesEventFor(event);
+		if (refs) output(refs);
 	});
 
 	// Handle a single command

--- a/packages/coding-agent/src/references.ts
+++ b/packages/coding-agent/src/references.ts
@@ -1,0 +1,116 @@
+/**
+ * Citation extraction — the "Sources" chips a surface shows under an answer.
+ *
+ * Neutral module ON PURPOSE. This used to live in `browser/chat-handler.ts`, whose
+ * 14 imports would have dragged the whole browser chat stack into the RPC path when
+ * `rpc-mode` needed the same extraction (#2420). One extractor, and one rule for
+ * "which assistant message ends a turn", shared by every transport — a client
+ * reimplementing either would drift (see the #2249 trailing-markup regression).
+ */
+import type { AssistantMessage } from "@f5-sales-demo/pi-ai";
+import type { ChatReference } from "./browser/chat-protocol";
+
+export function classifyReferenceKind(url: string): "doc" | "console" {
+	try {
+		const parsed = new URL(url);
+		if (/\.console\.ves\.volterra\.io$/.test(parsed.hostname)) return "console";
+		if (parsed.hostname === "docs.cloud.f5.com" || parsed.pathname.startsWith("/docs")) return "doc";
+	} catch {
+		/* malformed URL — default to doc */
+	}
+	return "doc";
+}
+function titleFromUrl(url: string): string {
+	try {
+		const parsed = new URL(url);
+		const segments = parsed.pathname.split("/").filter(Boolean);
+		return segments.length > 0 ? segments[segments.length - 1] : parsed.hostname;
+	} catch {
+		return url;
+	}
+}
+/**
+ * Trailing characters a bare-URL match may greedily swallow at a markdown/prose
+ * boundary — markdown emphasis + code (`*_~` and backtick) and sentence/wrap
+ * punctuation. A real URL effectively never ends in these, so trimming them yields
+ * the intended link (e.g. `**https://…/llms.txt**` or a code-wrapped
+ * `` `https://…/llms.txt` `` → `https://…/llms.txt`). The markdown-link branch is
+ * bounded by its closing `)` and needs no trimming.
+ */
+function trimTrailingMarkup(url: string): string {
+	return url.replace(/[*_~`,.;:!?'")\]}>]+$/, "");
+}
+export function extractReferences(msg: AssistantMessage): ChatReference[] {
+	const refs: ChatReference[] = [];
+	const seen = new Set<string>();
+
+	// STRUCTURED CITATIONS FIRST (#2340): a provider-side search reports the real page title, so
+	// it beats the regex scrape below — which can only guess a title from the URL path, and finds
+	// nothing at all when the model cites a source without printing its URL in the prose. Done as
+	// its own pass so a citation in a later block still wins over a scrape in an earlier one.
+	for (const block of msg.content) {
+		if (block.type !== "text" || !block.citations) continue;
+		for (const citation of block.citations) {
+			const url = citation.url;
+			if (!url || seen.has(url)) continue;
+			seen.add(url);
+			refs.push({
+				kind: classifyReferenceKind(url),
+				title: citation.title?.trim() || titleFromUrl(url),
+				url,
+			});
+		}
+	}
+
+	for (const block of msg.content) {
+		if (block.type !== "text") continue;
+
+		const mdLinkRegex = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+		for (let match = mdLinkRegex.exec(block.text); match !== null; match = mdLinkRegex.exec(block.text)) {
+			const [, title, url] = match;
+			if (seen.has(url)) continue;
+			seen.add(url);
+			refs.push({ kind: classifyReferenceKind(url), title, url });
+		}
+
+		const bareUrlRegex = /(?<!\()(https?:\/\/[^\s)>\]]+)/g;
+		for (let match = bareUrlRegex.exec(block.text); match !== null; match = bareUrlRegex.exec(block.text)) {
+			const url = trimTrailingMarkup(match[1]);
+			if (seen.has(url)) continue;
+			seen.add(url);
+			refs.push({ kind: classifyReferenceKind(url), title: titleFromUrl(url), url });
+		}
+	}
+	return refs;
+}
+
+/** The RPC stream's citation event, mirroring `chat_done.references` on the bridge. */
+export interface RpcReferencesEvent {
+	type: "references";
+	references: ChatReference[];
+}
+
+/**
+ * Decide whether an agent event should produce a citation event, and build it.
+ *
+ * Pure so the TURN-BOUNDARY rule is testable: an intermediate tool-use step also
+ * emits `message_end`, and treating that as terminal is the trap
+ * `chat-handler.ts` documents at length — it would publish the citations of a
+ * half-finished answer (and, on the bridge, end the turn early). Returns null for
+ * anything that is not a settled assistant message, and for a turn that cited
+ * nothing, so callers emit only real content.
+ *
+ * Typed by what it CONSUMES (a tagged event that may carry a message) rather than by
+ * one event union: the bridge and the RPC session stream different unions
+ * (`AgentEvent` vs `AgentSessionEvent`) and both must be able to call this.
+ */
+export function referencesEventFor(event: { type: string; message?: unknown }): RpcReferencesEvent | null {
+	if (event.type !== "message_end") return null;
+	const message = (event as { message?: { role?: string } }).message;
+	if (message?.role !== "assistant") return null;
+	const assistant = message as AssistantMessage;
+	// Intermediate tool-use step — the turn continues after the tool round-trip.
+	if (assistant.stopReason === "toolUse" || assistant.content.some(part => part.type === "toolCall")) return null;
+	const references = extractReferences(assistant);
+	return references.length > 0 ? { type: "references", references } : null;
+}

--- a/packages/coding-agent/test/browser/chat-handler.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import {
-	classifyReferenceKind,
 	composeChatPrompt,
 	KEEPALIVE_INTERVAL_MS,
 	shouldSendKeepalive,
 } from "@f5-sales-demo/xcsh/browser/chat-handler";
 import type { PageContextSnapshot } from "@f5-sales-demo/xcsh/browser/chat-protocol";
+import { classifyReferenceKind } from "@f5-sales-demo/xcsh/references";
 
 describe("composeChatPrompt", () => {
 	it("includes mode instruction and user text", () => {

--- a/packages/coding-agent/test/browser/extract-references.test.ts
+++ b/packages/coding-agent/test/browser/extract-references.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import type { AssistantMessage, WebCitation } from "@f5-sales-demo/pi-ai";
-import { extractReferences } from "../../src/browser/chat-handler";
+import { extractReferences } from "../../src/references";
 
 /** Minimal AssistantMessage carrying a single text block. */
 function assistantText(text: string): AssistantMessage {

--- a/packages/coding-agent/test/references-event.test.ts
+++ b/packages/coding-agent/test/references-event.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The turn-boundary rule for citation events (#2420).
+ *
+ * An INTERMEDIATE tool-use step also emits `message_end`, so "assistant message
+ * ended" is not the same as "turn ended". Treating the former as terminal is the
+ * trap `browser/chat-handler.ts` documents at length — it would publish the
+ * citations of a half-finished answer. This lives in a pure function precisely so
+ * the rule is testable; `runRpcMode` can't be imported by a test.
+ */
+import { describe, expect, test } from "bun:test";
+import type { AgentEvent } from "@f5-sales-demo/pi-agent-core";
+import { referencesEventFor } from "@f5-sales-demo/xcsh/references";
+
+function messageEnd(message: unknown): AgentEvent {
+	return { type: "message_end", message } as unknown as AgentEvent;
+}
+const cited = (text: string, extra: Record<string, unknown> = {}): unknown => ({
+	role: "assistant",
+	content: [{ type: "text", text }],
+	...extra,
+});
+
+describe("referencesEventFor", () => {
+	test("a settled assistant turn with cited sources yields a references event", () => {
+		const ev = referencesEventFor(messageEnd(cited("See [HTTP LB](https://docs.cloud.f5.com/lb) for details.")));
+		expect(ev).toEqual({
+			type: "references",
+			references: [{ kind: "doc", title: "HTTP LB", url: "https://docs.cloud.f5.com/lb" }],
+		});
+	});
+
+	test("an INTERMEDIATE tool-use step yields nothing (stopReason)", () => {
+		// The turn continues after the tool round-trip; its citations are not final.
+		expect(
+			referencesEventFor(
+				messageEnd(cited("Checking [docs](https://docs.cloud.f5.com/x)", { stopReason: "toolUse" })),
+			),
+		).toBeNull();
+	});
+
+	test("an INTERMEDIATE tool-use step yields nothing (toolCall block)", () => {
+		expect(
+			referencesEventFor(
+				messageEnd({
+					role: "assistant",
+					content: [
+						{ type: "text", text: "Reading [docs](https://docs.cloud.f5.com/y)" },
+						{ type: "toolCall", id: "t1", name: "read" },
+					],
+				}),
+			),
+		).toBeNull();
+	});
+
+	test("a turn that cited nothing yields nothing (no empty event on the stream)", () => {
+		expect(referencesEventFor(messageEnd(cited("No sources needed.")))).toBeNull();
+	});
+
+	test("non-assistant and non-message_end events yield nothing", () => {
+		expect(referencesEventFor(messageEnd({ role: "user", content: [] }))).toBeNull();
+		expect(referencesEventFor({ type: "turn_end" } as unknown as AgentEvent)).toBeNull();
+		expect(referencesEventFor(messageEnd(undefined))).toBeNull();
+	});
+
+	test("classifies a tenant console deep link as console, not doc", () => {
+		const ev = referencesEventFor(messageEnd(cited("Open https://acme.console.ves.volterra.io/lb to confirm.")));
+		expect(ev?.references[0].kind).toBe("console");
+	});
+});


### PR DESCRIPTION
Closes #2420

The Office pane and Chrome side panel both render "Sources" chips. The bridge supplies them by attaching `extractReferences(msg)` to `chat_done`. **An RPC host could not get them at all** — `rpc-mode` streams raw agent events, so the assistant message does arrive inside `message_end`, but deciding *which* message ends a turn, and scraping citations plus markdown/bare URLs out of its content blocks, is xcsh's job rather than a client's.

Without this, the VS Code extension would reimplement `extractReferences`, `classifyReferenceKind`, `titleFromUrl` and the #2249 trailing-markup trimming **in another repo**, and have to keep them in step.

## Why the extractor moved

It could not simply be imported from `browser/chat-handler.ts`: that module has **14 imports**, so importing it from `rpc-mode` would drag the entire browser chat stack into the RPC path. The cluster moves to a neutral `src/references.ts`.

No re-export shim — the two existing test files repoint to the new home, per the no-compat-shims standard. The WS path is otherwise untouched and its 30 reference tests still pass from there.

## The part that needed a test seam

`referencesEventFor(event)` is pure and owns the **turn-boundary rule**: an intermediate tool-use step *also* emits `message_end`, and treating that as terminal is the trap `chat-handler.ts:318` documents at length — it would publish the citations of a half-finished answer. Pure precisely so that rule is testable, since `runRpcMode` cannot be imported by a test.

It is typed by what it **consumes** (`{ type: string; message?: unknown }`) rather than by one event union, because the bridge and the RPC session stream *different* unions (`AgentEvent` vs `AgentSessionEvent`) and both must be able to call it.

## Verification

- coding-agent **6344 tests, 0 fail** on a clean run; biome + tsgo clean.
- The turn-boundary guard is **mutation-checked**: deleting it turns both intermediate-step tests red.
- Six cases cover terminal-with-citations, both intermediate shapes (`stopReason` and a `toolCall` block), cited-nothing, non-assistant/non-`message_end`, and console-vs-doc classification.

## One unrelated flake, filed not swallowed

While gating this I hit `manager.int`'s **"warm adopt emits worker_boot span"** failing at **31122 ms** — i.e. just past the *raised* 30s budget from #2418, the same shape as the old ~8.8s failures against the old 8s budget. Filed as **#2423** with the caveat that it is n=1 on a loaded machine, so I am not asserting #2418's diagnosis was wrong — only that the symptom survived it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)