### PR TITLE
fix(browser): make the stealth layer execute at all, and bump puppeteer 24.43 → 25.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,6 @@ packages/typescript-edit-benchmark/runs/
 # Verified-review working artifacts (findings and verification evidence).
 # No trailing slash, so a symlink of this name is matched too.
 .codex-review
+
+# Codex review artifacts (quote source; must not appear as reviewable work)
+.codex-review/

--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,3 @@ packages/typescript-edit-benchmark/runs/
 # Verified-review working artifacts (findings and verification evidence).
 # No trailing slash, so a symlink of this name is matched too.
 .codex-review
-
-# Codex review artifacts (quote source; must not appear as reviewable work)
-.codex-review/

--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
         "linkedom": "^0.18",
         "lru-cache": "11.5.2",
         "markit-ai": "0.5.3",
-        "puppeteer": "^24.37",
+        "puppeteer": "^25.3",
         "yaml": "2.9.0",
         "zod": "4.4.3",
       },
@@ -140,7 +140,7 @@
         "@types/react-dom": "^19.2",
         "ajv": "^8.17.1",
         "office-addin-mock": "^3.0",
-        "puppeteer": "^24.37",
+        "puppeteer": "^25.3",
       },
     },
     "packages/resource-management": {
@@ -387,6 +387,16 @@
 
     "@f5-sales-demo/pi-natives": ["@f5-sales-demo/pi-natives@workspace:packages/natives"],
 
+    "@f5-sales-demo/pi-natives-darwin-arm64": ["@f5-sales-demo/pi-natives-darwin-arm64@19.92.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-NmdFY83NzbnOnNlftRxTQnXteo3WfNnYnffhPLXCHiCHQpTznVGzGEZsLNH+RCIoWYPiYDR1RqL7FJII9mMuJw=="],
+
+    "@f5-sales-demo/pi-natives-darwin-x64": ["@f5-sales-demo/pi-natives-darwin-x64@19.92.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-6SQ3x4KJQL3wiX07ktuZwG661vuXIPAZeYl73J59bJLyOXMLsb7OEfOQF0BflOww762d5VbBsT39SVUAZUE1qQ=="],
+
+    "@f5-sales-demo/pi-natives-linux-arm64-gnu": ["@f5-sales-demo/pi-natives-linux-arm64-gnu@19.92.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-1LHIRTUU3USRLXKV484a3zzCPseut9CUWZQiptCtEpKRvbQs+deUNmsXwyXPtcx7xaw7j73ZNav60dJHfNnDIg=="],
+
+    "@f5-sales-demo/pi-natives-linux-x64-gnu": ["@f5-sales-demo/pi-natives-linux-x64-gnu@19.92.1", "", { "os": "linux", "cpu": "x64" }, "sha512-7yvhgYY9zJ7QeGmFi1qtNSuBkvCLBVITos5bEeQrizmqDAzUsOFnjfTJU/TfzsNLre0ufhD+4VCASgYdDg3tlg=="],
+
+    "@f5-sales-demo/pi-natives-win32-x64-msvc": ["@f5-sales-demo/pi-natives-win32-x64-msvc@19.92.1", "", { "os": "win32", "cpu": "x64" }, "sha512-+P1gH03L3SbDamThKSxlFRcSfdpXjN/QGgDVlwKyWCPkY5E5Yl37PyniS3Rke0QkLTq4NvBerWPZfbFUl/fr6w=="],
+
     "@f5-sales-demo/pi-resource-management": ["@f5-sales-demo/pi-resource-management@workspace:packages/resource-management"],
 
     "@f5-sales-demo/pi-tui": ["@f5-sales-demo/pi-tui@workspace:packages/tui"],
@@ -607,7 +617,7 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
 
-    "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
+    "@puppeteer/browsers": ["@puppeteer/browsers@3.0.6", "", { "dependencies": { "modern-tar": "^0.7.6", "yargs": "^18.0.0" }, "peerDependencies": { "proxy-agent": ">=8.0.1", "yauzl": "^2.10.0 || ^3.4.0" }, "optionalPeers": ["proxy-agent", "yauzl"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
@@ -677,8 +687,6 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
-    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
-
     "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260707.2", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260707.2", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260707.2" }, "bin": { "tsgo": "bin/tsgo" } }, "sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg=="],
 
     "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg=="],
@@ -725,18 +733,6 @@
 
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
-    "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
-
-    "bare-events": ["bare-events@2.9.1", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg=="],
-
-    "bare-fs": ["bare-fs@4.7.4", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ=="],
-
-    "bare-path": ["bare-path@3.1.1", "", {}, "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ=="],
-
-    "bare-stream": ["bare-stream@2.13.3", "", { "dependencies": { "b4a": "^1.8.1", "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer", "bare-events"] }, "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ=="],
-
-    "bare-url": ["bare-url@2.4.6", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ=="],
-
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
@@ -763,21 +759,19 @@
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
-
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "chardet": ["chardet@2.2.0", "", {}, "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA=="],
 
     "chart.js": ["chart.js@4.5.1", "", { "dependencies": { "@kurkle/color": "^0.3.0" } }, "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw=="],
 
-    "chromium-bidi": ["chromium-bidi@14.0.0", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw=="],
+    "chromium-bidi": ["chromium-bidi@16.0.1", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA=="],
 
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
     "clipanion": ["clipanion@4.0.0-rc.4", "", { "dependencies": { "typanion": "^3.8.0" } }, "sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q=="],
 
-    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
     "color": ["color@5.0.3", "", { "dependencies": { "color-convert": "^3.1.3", "color-string": "^2.1.3" } }, "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA=="],
 
@@ -794,8 +788,6 @@
     "content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
-
-    "cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
 
     "css-select": ["css-select@7.0.0", "", { "dependencies": { "boolbase": "^2.0.0", "css-what": "^8.0.0", "domhandler": "^6.0.1", "domutils": "^4.0.2", "nth-check": "^3.0.1" } }, "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g=="],
 
@@ -823,7 +815,7 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "devtools-protocol": ["devtools-protocol@0.0.1608973", "", {}, "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ=="],
+    "devtools-protocol": ["devtools-protocol@0.0.1638949", "", {}, "sha512-mXwg4Fqnv0WR4iuAT/gYUmctNkjILwXFHyZ+m7Ty1dfr0ezZt2U3gnrrJTfRobJTHoXf+IbuFvFITzLrLFjwJA=="],
 
     "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
@@ -849,19 +841,13 @@
 
     "emnapi": ["emnapi@1.11.2", "", { "peerDependencies": { "node-addon-api": ">= 6.1.0" }, "optionalPeers": ["node-addon-api"] }, "sha512-iMt/XQc69fFn2EvcU6tm14HmXKwyy0lnABugsQlqp6xFuZIUuO+ONVSg2mz+MTVF8WbC+bic65AvRXdoldALKg=="],
 
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
-
-    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.24.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ=="],
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
-
-    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
-
-    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "es-toolkit": ["es-toolkit@1.50.0", "", {}, "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="],
 
@@ -877,17 +863,11 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
-    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
-
     "exifr": ["exifr@7.1.3", "", {}, "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
-    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
-
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
-
-    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
     "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
@@ -927,7 +907,7 @@
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
-    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
 
@@ -959,15 +939,9 @@
 
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
 
-    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
-
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
-    "ip-address": ["ip-address@10.2.2", "", {}, "sha512-aNJVEVdXTr/g5+N2VCLo+CTrFLo/Y+9rx9RC5BpxPtf7NEknmzY+UQvMO8Fjni5KFmDaHJieL8HCMJKjJXsTgg=="],
-
-    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
-
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+    "ip-address": ["ip-address@10.3.1", "", {}, "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
@@ -988,8 +962,6 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
-
-    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
@@ -1033,7 +1005,7 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
     "linkedom": ["linkedom@0.18.13", "", { "dependencies": { "css-select": "^7.0.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.1.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw=="],
 
@@ -1067,6 +1039,8 @@
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
+    "modern-tar": ["modern-tar@0.7.7", "", {}, "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ=="],
+
     "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -1099,8 +1073,6 @@
 
     "office-addin-usage-data": ["office-addin-usage-data@2.1.1", "", { "dependencies": { "commander": "^13.0.0" }, "bin": { "office-addin-usage-data": "cli.js" } }, "sha512-MUbcqOodtlOUNhLKjSdqeLBHFVd7Qh5pUODqmQe2VLBKk7PuRgl4dCk6bp2dU79vl6BcDyrRERpkyVnQg6zdFg=="],
 
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
-
     "one-time": ["one-time@1.0.0", "", { "dependencies": { "fn.name": "1.x.x" } }, "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g=="],
 
     "openai": ["openai@6.49.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg=="],
@@ -1114,10 +1086,6 @@
     "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
-
-    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
-
-    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
     "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 
@@ -1141,21 +1109,17 @@
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
-    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
-
     "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
 
     "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
-    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
-
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "puppeteer": ["puppeteer@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "cosmiconfig": "^9.0.0", "devtools-protocol": "0.0.1608973", "puppeteer-core": "24.43.1", "typed-query-selector": "^2.12.2" }, "bin": { "puppeteer": "lib/cjs/puppeteer/node/cli.js" } }, "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw=="],
+    "puppeteer": ["puppeteer@25.3.0", "", { "dependencies": { "@puppeteer/browsers": "3.0.6", "chromium-bidi": "16.0.1", "devtools-protocol": "0.0.1638949", "lilconfig": "^3.1.3", "puppeteer-core": "25.3.0", "typed-query-selector": "^2.12.2" }, "bin": { "puppeteer": "lib/puppeteer/node/cli.js" } }, "sha512-O1tx8S315aw8eI99HZ5ZNcVEzJ9+jKF//eO5UvfZ3cXJ6okZ5sX3Y50u7DJaM+ewEK4LqXP068tBhfRaWikj+g=="],
 
-    "puppeteer-core": ["puppeteer-core@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "debug": "^4.4.3", "devtools-protocol": "0.0.1608973", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.1", "ws": "^8.20.0" } }, "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw=="],
+    "puppeteer-core": ["puppeteer-core@25.3.0", "", { "dependencies": { "@puppeteer/browsers": "3.0.6", "chromium-bidi": "16.0.1", "devtools-protocol": "0.0.1638949", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.2", "ws": "^8.21.0" } }, "sha512-fm+wpUr2oigH1PXZvwgATrM2tYWHMDG8ASzTEe9uukCye4X5Ldx1K5BTHPFKITrIWvQQAQ256d1NpbEveBcKjA=="],
 
     "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
@@ -1169,11 +1133,7 @@
 
     "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
 
-    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
-
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
-    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
@@ -1213,15 +1173,13 @@
 
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 
-    "streamx": ["streamx@2.28.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw=="],
-
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "strip-bom": ["strip-bom@5.0.0", "", {}, "sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A=="],
 
@@ -1236,14 +1194,6 @@
     "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
-
-    "tar-fs": ["tar-fs@3.1.3", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ=="],
-
-    "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
-
-    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
-
-    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
 
     "text-hex": ["text-hex@1.0.0", "", {}, "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="],
 
@@ -1299,7 +1249,7 @@
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
-    "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.1", "", {}, "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw=="],
+    "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.2", "", {}, "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA=="],
 
     "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
@@ -1317,9 +1267,7 @@
 
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
-    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
@@ -1337,9 +1285,9 @@
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
-    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
+    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
 
-    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+    "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
@@ -1399,7 +1347,9 @@
 
     "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
-    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
 
@@ -1417,13 +1367,9 @@
 
     "office-addin-manifest/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 
-    "wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
-
     "htmlparser2/domutils/dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "office-addin-manifest/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
-
-    "wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "office-addin-manifest/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
   }

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -74,7 +74,7 @@
 		"linkedom": "^0.18",
 		"lru-cache": "11.5.2",
 		"markit-ai": "0.5.3",
-		"puppeteer": "^24.37",
+		"puppeteer": "^25.3",
 		"yaml": "2.9.0",
 		"zod": "4.4.3"
 	},

--- a/packages/coding-agent/src/tools/browser-stealth.ts
+++ b/packages/coding-agent/src/tools/browser-stealth.ts
@@ -1,0 +1,121 @@
+/**
+ * Assembles the stealth init script injected into every page.
+ *
+ * Split out of `browser.ts` so the bundle can be built and asserted without a
+ * `BrowserTool` instance — see `test/browser/stealth-bundle.test.ts` (CI) and
+ * `test/e2e/stealth-surfaces.e2e.test.ts` (local, real Chrome).
+ */
+
+import stealthTamperingScript from "./puppeteer/00_stealth_tampering.txt" with { type: "text" };
+import stealthActivityScript from "./puppeteer/01_stealth_activity.txt" with { type: "text" };
+import stealthHairlineScript from "./puppeteer/02_stealth_hairline.txt" with { type: "text" };
+import stealthBotdScript from "./puppeteer/03_stealth_botd.txt" with { type: "text" };
+import stealthIframeScript from "./puppeteer/04_stealth_iframe.txt" with { type: "text" };
+import stealthWebglScript from "./puppeteer/05_stealth_webgl.txt" with { type: "text" };
+import stealthScreenScript from "./puppeteer/06_stealth_screen.txt" with { type: "text" };
+import stealthFontsScript from "./puppeteer/07_stealth_fonts.txt" with { type: "text" };
+import stealthAudioScript from "./puppeteer/08_stealth_audio.txt" with { type: "text" };
+import stealthLocaleScript from "./puppeteer/09_stealth_locale.txt" with { type: "text" };
+import stealthPluginsScript from "./puppeteer/10_stealth_plugins.txt" with { type: "text" };
+import stealthHardwareScript from "./puppeteer/11_stealth_hardware.txt" with { type: "text" };
+import stealthCodecsScript from "./puppeteer/12_stealth_codecs.txt" with { type: "text" };
+import stealthWorkerScript from "./puppeteer/13_stealth_worker.txt" with { type: "text" };
+
+/**
+ * The injected surfaces, in load order. Order is load-bearing: `tampering` must
+ * run first so later scripts' patched functions are already covered by its
+ * `Function.prototype.toString` shim.
+ */
+export const STEALTH_SCRIPTS: ReadonlyArray<{ readonly name: string; readonly source: string }> = [
+	{ name: "tampering", source: stealthTamperingScript },
+	{ name: "activity", source: stealthActivityScript },
+	{ name: "hairline", source: stealthHairlineScript },
+	{ name: "botd", source: stealthBotdScript },
+	{ name: "iframe", source: stealthIframeScript },
+	{ name: "webgl", source: stealthWebglScript },
+	{ name: "screen", source: stealthScreenScript },
+	{ name: "fonts", source: stealthFontsScript },
+	{ name: "audio", source: stealthAudioScript },
+	{ name: "locale", source: stealthLocaleScript },
+	{ name: "plugins", source: stealthPluginsScript },
+	{ name: "hardware", source: stealthHardwareScript },
+	{ name: "codecs", source: stealthCodecsScript },
+	{ name: "worker", source: stealthWorkerScript },
+];
+
+export type StealthBundleOptions = {
+	/**
+	 * Name of a global to collect per-script failures into, as
+	 * `[{ name, message }]`. Omit in production: each script is wrapped in its
+	 * own try/catch so one failure cannot take down the rest, but recording those
+	 * failures means writing a `window.<name>` that a detection script could look
+	 * for — which would defeat the point of the bundle. Tests pass a name so a
+	 * silently-broken script is assertable instead of invisible.
+	 */
+	readonly errorSink?: string;
+};
+
+/** Wraps one script so a failure cannot stop the scripts after it. */
+function wrapScript(script: { name: string; source: string }, errorSink: string | undefined): string {
+	const record = errorSink
+		? `(globalThis[${JSON.stringify(errorSink)}] ||= []).push({ name: ${JSON.stringify(script.name)}, message: String(e && e.message || e) });`
+		: "";
+	return `
+		try {
+			${script.source};
+		} catch (e) { ${record} }
+	`;
+}
+
+/**
+ * Builds the full init script.
+ *
+ * Caches pristine builtins up front so the surfaces can still reach unpatched
+ * references after earlier surfaces have replaced the page's own.
+ *
+ * The cache is taken from the CURRENT realm, not a detached iframe. This script
+ * is injected via `Page.addScriptToEvaluateOnNewDocument`, which runs before any
+ * page script — and before any DOM at all: at that point `document.readyState`
+ * is `"loading"` and `document.head`, `document.body` and
+ * `document.documentElement` are all null. An earlier version created a helper
+ * iframe and appended it to `document.head`, which threw on that first statement
+ * outside every per-surface guard, so all fourteen surfaces silently never ran.
+ * Because nothing else has executed yet, `globalThis`'s builtins are themselves
+ * still pristine, which is exactly what the iframe was there to provide.
+ */
+export function buildStealthBundle(options: StealthBundleOptions = {}): string {
+	const joint = STEALTH_SCRIPTS.map(script => wrapScript(script, options.errorSink)).join(";\n");
+
+	return `(() => {
+			// Native function cache — this script runs first, so the current realm's
+			// builtins have not been touched yet.
+			const nativeWindow = globalThis;
+
+			// Cache pristine native functions
+			const Function_toString = nativeWindow.Function.prototype.toString;
+			const Object_getOwnPropertyDescriptor = nativeWindow.Object.getOwnPropertyDescriptor;
+			const Object_getOwnPropertyDescriptors = nativeWindow.Object.getOwnPropertyDescriptors;
+			const Object_getPrototypeOf = nativeWindow.Object.getPrototypeOf;
+			const Object_defineProperty = nativeWindow.Object.defineProperty;
+			const Object_getOwnPropertyDescriptorOriginal = nativeWindow.Object.getOwnPropertyDescriptor;
+			const Object_create = nativeWindow.Object.create;
+			const Object_keys = nativeWindow.Object.keys;
+			const Object_getOwnPropertyNames = nativeWindow.Object.getOwnPropertyNames;
+			const Object_entries = nativeWindow.Object.entries;
+			const Object_setPrototypeOf = nativeWindow.Object.setPrototypeOf;
+			const Object_assign = nativeWindow.Object.assign;
+			const Window_setTimeout = nativeWindow.setTimeout;
+			const Math_random = nativeWindow.Math.random;
+			const Math_floor = nativeWindow.Math.floor;
+			const Math_max = nativeWindow.Math.max;
+			const Math_min = nativeWindow.Math.min;
+			const Window_Event = nativeWindow.Event;
+			const Promise_resolve = nativeWindow.Promise.resolve.bind(nativeWindow.Promise);
+			const Window_Blob = nativeWindow.Blob;
+			const Window_Proxy = nativeWindow.Proxy;
+			const Intl_DateTimeFormat = nativeWindow.Intl.DateTimeFormat;
+			const Date_constructor = nativeWindow.Date;
+
+			${joint}
+		})();`;
+}

--- a/packages/coding-agent/src/tools/browser-user-agent.ts
+++ b/packages/coding-agent/src/tools/browser-user-agent.ts
@@ -1,0 +1,111 @@
+/**
+ * Derives the stealth user-agent override from whichever Chrome puppeteer bundles.
+ *
+ * Split out of `browser.ts` so it can be asserted without launching a browser:
+ * every field here is a pure function of the raw user-agent string and the
+ * browser version, and the output changes whenever puppeteer's bundled Chrome
+ * changes major version. See `test/browser/user-agent-override.test.ts`.
+ */
+
+const STEALTH_ACCEPT_LANGUAGE = "en-US,en";
+
+export type UserAgentOverride = {
+	userAgent: string;
+	platform: string;
+	acceptLanguage: string;
+	userAgentMetadata: {
+		brands: Array<{ brand: string; version: string }>;
+		fullVersion: string;
+		platform: string;
+		platformVersion: string;
+		architecture: string;
+		model: string;
+		mobile: boolean;
+	};
+};
+
+/**
+ * Chromium's GREASE permutation table, indexed by `majorVersion % 6`.
+ * Mirrors `GenerateBrandVersionList` in
+ * components/embedder_support/user_agent_utils.cc — Chrome shuffles the brand
+ * list per version so that servers cannot hardcode its ordering, and a client
+ * that emits a fixed order is detectable for that reason alone.
+ */
+const BRAND_ORDERS: ReadonlyArray<readonly [number, number, number]> = [
+	[0, 1, 2],
+	[0, 2, 1],
+	[1, 0, 2],
+	[1, 2, 0],
+	[2, 0, 1],
+	[2, 1, 0],
+];
+
+/** The escape characters Chromium permutes into the greased brand name. */
+const GREASE_ESCAPE_CHARS = [" ", " ", ";"] as const;
+
+/** Builds the three-entry brand list for a Chrome major version. */
+function buildBrands(majorVersion: number): Array<{ brand: string; version: string }> {
+	const order = BRAND_ORDERS[majorVersion % BRAND_ORDERS.length] ?? BRAND_ORDERS[0];
+	const greasedBrand = `${GREASE_ESCAPE_CHARS[order[0]]}Not${GREASE_ESCAPE_CHARS[order[1]]}A${GREASE_ESCAPE_CHARS[order[2]]}Brand`;
+	const brands: Array<{ brand: string; version: string }> = [];
+	brands[order[0]] = { brand: greasedBrand, version: "99" };
+	brands[order[1]] = { brand: "Chromium", version: String(majorVersion) };
+	brands[order[2]] = { brand: "Google Chrome", version: String(majorVersion) };
+	return brands;
+}
+
+/**
+ * @param rawUserAgent the browser's own user-agent string, e.g. from `browser.userAgent()`
+ * @param browserVersion the browser version string, e.g. from `browser.version()`;
+ *   used only when the user agent carries no `Chrome/<version>` token
+ */
+export function deriveUserAgentOverride(rawUserAgent: string, browserVersion: string): UserAgentOverride {
+	let userAgent = rawUserAgent.replace("HeadlessChrome/", "Chrome/");
+	if (userAgent.includes("Linux") && !userAgent.includes("Android")) {
+		userAgent = userAgent.replace(/\(([^)]+)\)/, "(Windows NT 10.0; Win64; x64)");
+	}
+
+	const uaVersionMatch = userAgent.match(/Chrome\/([\d|.]+)/);
+	const fallbackVersionMatch = uaVersionMatch ?? browserVersion.match(/\/([\d|.]+)/);
+	const uaVersion = fallbackVersionMatch?.[1] ?? "0";
+	const majorVersion = Number.parseInt(uaVersion.split(".")[0] ?? "0", 10) || 0;
+	const isAndroid = userAgent.includes("Android");
+	const platform = userAgent.includes("Mac OS X")
+		? "MacIntel"
+		: isAndroid
+			? "Android"
+			: userAgent.includes("Linux")
+				? "Linux"
+				: "Win32";
+	const platformFull = userAgent.includes("Mac OS X")
+		? "Mac OS X"
+		: isAndroid
+			? "Android"
+			: userAgent.includes("Linux")
+				? "Linux"
+				: "Windows";
+	const platformVersion = userAgent.includes("Mac OS X ")
+		? (userAgent.match(/Mac OS X ([^)]+)/)?.[1] ?? "")
+		: userAgent.includes("Android ")
+			? (userAgent.match(/Android ([^;]+)/)?.[1] ?? "")
+			: userAgent.includes("Windows ")
+				? (userAgent.match(/Windows .*?([\d|.]+);?/)?.[1] ?? "")
+				: "";
+	const architecture = isAndroid ? "" : "x86";
+	const model = isAndroid ? (userAgent.match(/Android.*?;\s([^)]+)/)?.[1] ?? "") : "";
+
+	return {
+		userAgent,
+		platform,
+		acceptLanguage: STEALTH_ACCEPT_LANGUAGE,
+		userAgentMetadata: {
+			brands: buildBrands(majorVersion),
+			fullVersion: uaVersion,
+			platform: platformFull,
+			platformVersion,
+			architecture,
+			model,
+			mobile: isAndroid,
+		},
+	};
+}

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -99,8 +99,16 @@ export function pickCoDrivePage(pages: { url(): string }[]): number {
 }
 
 /**
- * Lazy-import puppeteer from a safe CWD so cosmiconfig doesn't choke
- * on malformed package.json files in the user's project tree.
+ * Lazy-import puppeteer from a safe CWD so its config loader doesn't choke on
+ * malformed package.json files in the user's project tree.
+ *
+ * Puppeteer 25 swapped cosmiconfig for lilconfig, so the original rationale no
+ * longer names the right library. Retained deliberately rather than removed:
+ * importing puppeteer 25 from a directory containing a deliberately malformed
+ * package.json was verified to succeed, but that only exercises import-time
+ * loading — whether `launch()` reads config lazily was not established, so
+ * dropping the guard would be an unverified behaviour change for a demo-critical
+ * path. It costs one chdir.
  */
 let puppeteerModule: typeof Puppeteer | undefined;
 async function loadPuppeteer(): Promise<typeof Puppeteer> {
@@ -539,7 +547,7 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 		if (this.#page && !this.#page.isClosed()) {
 			return this.#page;
 		}
-		if (!this.#browser?.isConnected()) {
+		if (!this.#browser?.connected) {
 			return this.#resetBrowser(params);
 		}
 		// co-drive: reuse the human's current tab when attached, else a fresh page

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -119,6 +119,8 @@ const STEALTH_IGNORE_DEFAULT_ARGS = [
 	"--disable-default-apps",
 	"--disable-component-extensions-with-background-pages",
 ];
+/** Kept in step with the locale profile in puppeteer/09_stealth_locale.txt. */
+const STEALTH_TIMEZONE = "America/New_York";
 const PUPPETEER_SOURCE_URL_SUFFIX = "//# sourceURL=__puppeteer_evaluation_script__";
 const INTERACTIVE_AX_ROLES = new Set([
 	"button",
@@ -678,7 +680,31 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 	async #applyStealthPatches(page: Page): Promise<void> {
 		this.#patchSourceUrl(page);
 		await this.#applyUserAgentOverride(page);
+		await this.#applyTimezoneOverride(page);
 		await this.#injectStealthScripts(page);
+	}
+
+	/**
+	 * Overrides the timezone through CDP rather than in the injected scripts.
+	 *
+	 * Chrome recomputes Date, Intl, getTimezoneOffset and the zone name from the
+	 * overridden zone, so they all agree. Patching them in page script cannot
+	 * achieve that: the previous attempt rewrote only the displayed zone NAME and
+	 * forced its zone into every Intl.DateTimeFormat call, which overrode a
+	 * caller's explicit `timeZone` and corrupted formatted output (see
+	 * 09_stealth_locale.txt).
+	 */
+	async #applyTimezoneOverride(page: Page): Promise<void> {
+		const client = resolvePageClient(page);
+		if (!client) return;
+		try {
+			await client.send("Emulation.setTimezoneOverride", { timezoneId: STEALTH_TIMEZONE });
+		} catch (error) {
+			// A rejected zone id must not take the rest of the stealth setup down.
+			logger.debug("Failed to apply timezone override", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
 	}
 
 	async #applyUserAgentOverride(page: Page): Promise<void> {

--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -27,22 +27,10 @@ import browserDescription from "../prompts/tools/browser.md" with { type: "text"
 import type { ToolSession } from "../sdk";
 import { resizeImage } from "../utils/image-resize";
 import { htmlToBasicMarkdown } from "../web/scrapers/types";
+import { buildStealthBundle } from "./browser-stealth";
+import { deriveUserAgentOverride, type UserAgentOverride } from "./browser-user-agent";
 import type { OutputMeta } from "./output-meta";
 import { expandPath, resolveToCwd } from "./path-utils";
-import stealthTamperingScript from "./puppeteer/00_stealth_tampering.txt" with { type: "text" };
-import stealthActivityScript from "./puppeteer/01_stealth_activity.txt" with { type: "text" };
-import stealthHairlineScript from "./puppeteer/02_stealth_hairline.txt" with { type: "text" };
-import stealthBotdScript from "./puppeteer/03_stealth_botd.txt" with { type: "text" };
-import stealthIframeScript from "./puppeteer/04_stealth_iframe.txt" with { type: "text" };
-import stealthWebglScript from "./puppeteer/05_stealth_webgl.txt" with { type: "text" };
-import stealthScreenScript from "./puppeteer/06_stealth_screen.txt" with { type: "text" };
-import stealthFontsScript from "./puppeteer/07_stealth_fonts.txt" with { type: "text" };
-import stealthAudioScript from "./puppeteer/08_stealth_audio.txt" with { type: "text" };
-import stealthLocaleScript from "./puppeteer/09_stealth_locale.txt" with { type: "text" };
-import stealthPluginsScript from "./puppeteer/10_stealth_plugins.txt" with { type: "text" };
-import stealthHardwareScript from "./puppeteer/11_stealth_hardware.txt" with { type: "text" };
-import stealthCodecsScript from "./puppeteer/12_stealth_codecs.txt" with { type: "text" };
-import stealthWorkerScript from "./puppeteer/13_stealth_worker.txt" with { type: "text" };
 import { formatScreenshot } from "./render-utils";
 import { ToolAbortError, ToolError, throwIfAborted } from "./tool-errors";
 import { toolResult } from "./tool-result";
@@ -131,7 +119,6 @@ const STEALTH_IGNORE_DEFAULT_ARGS = [
 	"--disable-default-apps",
 	"--disable-component-extensions-with-background-pages",
 ];
-const STEALTH_ACCEPT_LANGUAGE = "en-US,en";
 const PUPPETEER_SOURCE_URL_SUFFIX = "//# sourceURL=__puppeteer_evaluation_script__";
 const INTERACTIVE_AX_ROLES = new Set([
 	"button",
@@ -159,21 +146,6 @@ const INTERACTIVE_AX_ROLES = new Set([
 
 type PuppeteerCdpClient = {
 	send: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
-};
-
-type UserAgentOverride = {
-	userAgent: string;
-	platform: string;
-	acceptLanguage: string;
-	userAgentMetadata: {
-		brands: Array<{ brand: string; version: string }>;
-		fullVersion: string;
-		platform: string;
-		platformVersion: string;
-		architecture: string;
-		model: string;
-		mobile: boolean;
-	};
 };
 
 function resolvePageClient(page: Page): PuppeteerCdpClient | null {
@@ -719,71 +691,8 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 
 	async #resolveUserAgentOverride(page: Page): Promise<UserAgentOverride> {
 		if (this.#userAgentOverride) return this.#userAgentOverride;
-		const rawUserAgent = await page.browser().userAgent();
-		let userAgent = rawUserAgent.replace("HeadlessChrome/", "Chrome/");
-		if (userAgent.includes("Linux") && !userAgent.includes("Android")) {
-			userAgent = userAgent.replace(/\(([^)]+)\)/, "(Windows NT 10.0; Win64; x64)");
-		}
-
-		const uaVersionMatch = userAgent.match(/Chrome\/([\d|.]+)/);
-		const fallbackVersionMatch = uaVersionMatch ?? (await page.browser().version()).match(/\/([\d|.]+)/);
-		const uaVersion = fallbackVersionMatch?.[1] ?? "0";
-		const majorVersion = Number.parseInt(uaVersion.split(".")[0] ?? "0", 10) || 0;
-		const isAndroid = userAgent.includes("Android");
-		const platform = userAgent.includes("Mac OS X")
-			? "MacIntel"
-			: isAndroid
-				? "Android"
-				: userAgent.includes("Linux")
-					? "Linux"
-					: "Win32";
-		const platformFull = userAgent.includes("Mac OS X")
-			? "Mac OS X"
-			: isAndroid
-				? "Android"
-				: userAgent.includes("Linux")
-					? "Linux"
-					: "Windows";
-		const platformVersion = userAgent.includes("Mac OS X ")
-			? (userAgent.match(/Mac OS X ([^)]+)/)?.[1] ?? "")
-			: userAgent.includes("Android ")
-				? (userAgent.match(/Android ([^;]+)/)?.[1] ?? "")
-				: userAgent.includes("Windows ")
-					? (userAgent.match(/Windows .*?([\d|.]+);?/)?.[1] ?? "")
-					: "";
-		const architecture = isAndroid ? "" : "x86";
-		const model = isAndroid ? (userAgent.match(/Android.*?;\s([^)]+)/)?.[1] ?? "") : "";
-
-		const brandOrders = [
-			[0, 1, 2],
-			[0, 2, 1],
-			[1, 0, 2],
-			[1, 2, 0],
-			[2, 0, 1],
-			[2, 1, 0],
-		];
-		const order = brandOrders[majorVersion % brandOrders.length] ?? brandOrders[0];
-		const escapedChars = [" ", " ", ";"];
-		const greaseyBrand = `${escapedChars[order[0]]}Not${escapedChars[order[1]]}A${escapedChars[order[2]]}Brand`;
-		const brands: { brand: string; version: string }[] = [];
-		brands[order[0]] = { brand: greaseyBrand, version: "99" };
-		brands[order[1]] = { brand: "Chromium", version: String(majorVersion) };
-		brands[order[2]] = { brand: "Google Chrome", version: String(majorVersion) };
-
-		this.#userAgentOverride = {
-			userAgent,
-			platform,
-			acceptLanguage: STEALTH_ACCEPT_LANGUAGE,
-			userAgentMetadata: {
-				brands,
-				fullVersion: uaVersion,
-				platform: platformFull,
-				platformVersion,
-				architecture,
-				model,
-				mobile: isAndroid,
-			},
-		};
+		const browser = page.browser();
+		this.#userAgentOverride = deriveUserAgentOverride(await browser.userAgent(), await browser.version());
 		return this.#userAgentOverride;
 	}
 
@@ -885,70 +794,7 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 
 	/** Injects stealth scripts that cover common puppeteer detection surfaces. */
 	async #injectStealthScripts(page: Page): Promise<void> {
-		const scripts = [
-			stealthTamperingScript,
-			stealthActivityScript,
-			stealthHairlineScript,
-			stealthBotdScript,
-			stealthIframeScript,
-			stealthWebglScript,
-			stealthScreenScript,
-			stealthFontsScript,
-			stealthAudioScript,
-			stealthLocaleScript,
-			stealthPluginsScript,
-			stealthHardwareScript,
-			stealthCodecsScript,
-			stealthWorkerScript,
-		];
-
-		const joint = scripts
-			.map(
-				script => `
-		try {
-			${script};
-		} catch (e) {}
-	`,
-			)
-			.join(";\n");
-
-		await page.evaluateOnNewDocument(`(() => {
-				// Native function cache - captured before any tampering
-				const iframe = document.createElement("iframe");
-				iframe.style.display = "none";
-				document.head.appendChild(iframe);
-				const nativeWindow = iframe.contentWindow;
-				if (!nativeWindow) return;
-
-				// Cache pristine native functions
-				const Function_toString = nativeWindow.Function.prototype.toString;
-				const Object_getOwnPropertyDescriptor = nativeWindow.Object.getOwnPropertyDescriptor;
-				const Object_getOwnPropertyDescriptors = nativeWindow.Object.getOwnPropertyDescriptors;
-				const Object_getPrototypeOf = nativeWindow.Object.getPrototypeOf;
-				const Object_defineProperty = nativeWindow.Object.defineProperty;
-				const Object_getOwnPropertyDescriptorOriginal = nativeWindow.Object.getOwnPropertyDescriptor;
-				const Object_create = nativeWindow.Object.create;
-				const Object_keys = nativeWindow.Object.keys;
-				const Object_getOwnPropertyNames = nativeWindow.Object.getOwnPropertyNames;
-				const Object_entries = nativeWindow.Object.entries;
-				const Object_setPrototypeOf = nativeWindow.Object.setPrototypeOf;
-				const Object_assign = nativeWindow.Object.assign;
-				const Window_setTimeout = nativeWindow.setTimeout;
-				const Math_random = nativeWindow.Math.random;
-				const Math_floor = nativeWindow.Math.floor;
-				const Math_max = nativeWindow.Math.max;
-				const Math_min = nativeWindow.Math.min;
-				const Window_Event = nativeWindow.Event;
-				const Promise_resolve = nativeWindow.Promise.resolve.bind(nativeWindow.Promise);
-				const Window_Blob = nativeWindow.Blob;
-				const Window_Proxy = nativeWindow.Proxy;
-				const Intl_DateTimeFormat = nativeWindow.Intl.DateTimeFormat;
-				const Date_constructor = nativeWindow.Date;
-
-				
-				${joint}
-
-				document.head.removeChild(iframe);})();`);
+		await page.evaluateOnNewDocument(buildStealthBundle());
 	}
 
 	async execute(

--- a/packages/coding-agent/src/tools/puppeteer/00_stealth_tampering.txt
+++ b/packages/coding-agent/src/tools/puppeteer/00_stealth_tampering.txt
@@ -58,6 +58,3 @@ Object.getOwnPropertyDescriptor = function (obj, prop) {
 
   return descriptor;
 };
-
-// Cleanup
-document.head.removeChild(iframe);

--- a/packages/coding-agent/src/tools/puppeteer/03_stealth_botd.txt
+++ b/packages/coding-agent/src/tools/puppeteer/03_stealth_botd.txt
@@ -372,6 +372,18 @@ if (navigator.permissions?.query) {
 			}
 			return originalQuery.call(this, parameters);
 		};
+		// Mask the replacement, or String(navigator.permissions.query) hands a
+		// detector this function's source where Chrome reports native code. The
+		// tampering surface masks every function it patches, but this one is
+		// replaced here, after that surface has already run.
+		// Binding the cached native toString to the ORIGINAL query reproduces
+		// Chrome's exact output, same idiom as 04_stealth_iframe / 13_stealth_worker.
+		Object_defineProperty(navigator.permissions.query, "toString", {
+			value: Function_toString.bind(originalQuery),
+			writable: false,
+			configurable: true,
+			enumerable: false,
+		});
 	}
 }
 

--- a/packages/coding-agent/src/tools/puppeteer/04_stealth_iframe.txt
+++ b/packages/coding-agent/src/tools/puppeteer/04_stealth_iframe.txt
@@ -23,24 +23,34 @@ const addContentWindowProxy = (iframe) => {
 	}
 };
 
+// The native accessor, captured from the prototype so the shim below can hand
+// off to it. Without this the shim has nothing to delegate to.
+const nativeSrcdocDescriptor = Object_getOwnPropertyDescriptor(HTMLIFrameElement.prototype, "srcdoc");
+
 const handleIframeCreation = (target, thisArg, args) => {
 	const iframe = target.apply(thisArg, args);
-	const originalIframe = iframe;
-	const originalSrcdoc = originalIframe.srcdoc;
 
+	// A one-shot shim: install the contentWindow proxy on the first srcdoc
+	// assignment, then step aside so the element behaves natively.
+	//
+	// It must step aside by DELETING itself. An earlier version redefined srcdoc
+	// as a non-writable data property and then assigned through the same element,
+	// so the write silently failed against its own frozen property and the native
+	// setter was never reached: srcdoc stayed "", the attribute was never set, and
+	// every dynamically created srcdoc iframe loaded empty.
 	Object_defineProperty(iframe, "srcdoc", {
 		configurable: true,
 		get() {
-			return originalSrcdoc;
+			return nativeSrcdocDescriptor?.get ? nativeSrcdocDescriptor.get.call(this) : "";
 		},
 		set(newValue) {
 			addContentWindowProxy(this);
-			Object_defineProperty(iframe, "srcdoc", {
-				configurable: false,
-				writable: false,
-				value: originalSrcdoc,
-			});
-			originalIframe.srcdoc = newValue;
+			delete iframe.srcdoc;
+			if (nativeSrcdocDescriptor?.set) {
+				nativeSrcdocDescriptor.set.call(iframe, newValue);
+			} else {
+				iframe.setAttribute("srcdoc", newValue);
+			}
 		},
 	});
 

--- a/packages/coding-agent/src/tools/puppeteer/09_stealth_locale.txt
+++ b/packages/coding-agent/src/tools/puppeteer/09_stealth_locale.txt
@@ -15,19 +15,26 @@ Object_defineProperty(navigator, "languages", {
   enumerable: true,
 });
 
-// Override Intl.DateTimeFormat for timezone consistency
+// Override Intl.DateTimeFormat for timezone consistency.
+//
+// A Proxy, not a subclass: Intl.DateTimeFormat is legacy-callable, so real Chrome
+// accepts both `new Intl.DateTimeFormat()` and `Intl.DateTimeFormat()`. A
+// `class extends` replacement throws "Class constructors cannot be invoked
+// without 'new'" on the second form — which breaks ordinary page code and is
+// itself a tell. The Proxy also keeps `prototype`, `instanceof`, the static
+// `supportedLocalesOf`, and a native-looking `toString`.
+//
+// Forcing timeZone into the options makes `resolvedOptions().timeZone` report it
+// without needing to patch resolvedOptions separately.
 const OriginalDateTimeFormat = Intl_DateTimeFormat;
-Intl.DateTimeFormat = class extends OriginalDateTimeFormat {
-  constructor(locales, options) {
-    const mergedOptions = { ...options, timeZone: timezone };
-    super(locales, mergedOptions);
-  }
-  resolvedOptions() {
-    const options = super.resolvedOptions();
-    options.timeZone = timezone;
-    return options;
-  }
-};
+Intl.DateTimeFormat = new Window_Proxy(OriginalDateTimeFormat, {
+  construct(target, args) {
+    return new target(args[0], { ...args[1], timeZone: timezone });
+  },
+  apply(target, thisArg, args) {
+    return target(args[0], { ...args[1], timeZone: timezone });
+  },
+});
 
 // Ensure Date timezone is consistent
 const originalDateConstructor = Date_constructor;

--- a/packages/coding-agent/src/tools/puppeteer/09_stealth_locale.txt
+++ b/packages/coding-agent/src/tools/puppeteer/09_stealth_locale.txt
@@ -1,7 +1,6 @@
 // Define a consistent locale profile
 const locale = "en-US";
 const languages = ["en-US", "en"];
-const timezone = "America/New_York";
 
 // Override navigator language properties
 Object_defineProperty(navigator, "language", {
@@ -15,39 +14,22 @@ Object_defineProperty(navigator, "languages", {
   enumerable: true,
 });
 
-// Override Intl.DateTimeFormat for timezone consistency.
+// Timezone is NOT spoofed here.
 //
-// A Proxy, not a subclass: Intl.DateTimeFormat is legacy-callable, so real Chrome
-// accepts both `new Intl.DateTimeFormat()` and `Intl.DateTimeFormat()`. A
-// `class extends` replacement throws "Class constructors cannot be invoked
-// without 'new'" on the second form — which breaks ordinary page code and is
-// itself a tell. The Proxy also keeps `prototype`, `instanceof`, the static
-// `supportedLocalesOf`, and a native-looking `toString`.
+// It is applied through CDP Emulation.setTimezoneOverride in browser.ts, which
+// shifts the clock itself: Date, Intl, getTimezoneOffset and the zone name all
+// agree, because Chrome computes them from the overridden zone.
 //
-// Forcing timeZone into the options makes `resolvedOptions().timeZone` report it
-// without needing to patch resolvedOptions separately.
-const OriginalDateTimeFormat = Intl_DateTimeFormat;
-Intl.DateTimeFormat = new Window_Proxy(OriginalDateTimeFormat, {
-  construct(target, args) {
-    return new target(args[0], { ...args[1], timeZone: timezone });
-  },
-  apply(target, thisArg, args) {
-    return target(args[0], { ...args[1], timeZone: timezone });
-  },
-});
-
-// Ensure Date timezone is consistent
-const originalDateConstructor = Date_constructor;
-const originalToString = originalDateConstructor.prototype.toString;
-const originalToTimeString = originalDateConstructor.prototype.toTimeString;
-
-Date.prototype.toString = function () {
-  return originalToString
-    .call(this)
-    .replace(/\(.*\)$/, "(Eastern Standard Time)");
-};
-Date.prototype.toTimeString = function () {
-  return originalToTimeString
-    .call(this)
-    .replace(/\(.*\)$/, "(Eastern Standard Time)");
-};
+// Two earlier attempts in this file were worse than nothing:
+//
+//   1. Wrapping Intl.DateTimeFormat and forcing `timeZone` into every options
+//      object overrode the CALLER's explicit zone, so
+//      `new Intl.DateTimeFormat("en-US", { timeZone: "UTC" })` silently formatted
+//      in New York — 08:00 where the page asked for 12:00. That corrupts data a
+//      page displays or submits, which is far worse than a fingerprinting tell.
+//
+//   2. Rewriting Date.prototype.toString/toTimeString only replaced the zone
+//      NAME, never the numeric offset, and hardcoded "Eastern Standard Time" —
+//      so in July it claimed EST while getTimezoneOffset still returned 240
+//      (EDT). Self-contradictory, and a detector comparing the two sees it
+//      immediately.

--- a/packages/coding-agent/test/browser/stealth-bundle.test.ts
+++ b/packages/coding-agent/test/browser/stealth-bundle.test.ts
@@ -82,6 +82,56 @@ describe("stealth bundle composition", () => {
 	});
 });
 
+describe("surfaces must not break standard web behaviour", () => {
+	/**
+	 * A surface's CODE, with line comments stripped. These guards assert on what
+	 * runs, and the comments in these files deliberately describe the very
+	 * patterns being forbidden.
+	 */
+	const source = (name: string) => {
+		const found = STEALTH_SCRIPTS.find(s => s.name === name);
+		if (!found) throw new Error(`no such surface: ${name}`);
+		return found.source
+			.split("\n")
+			.filter(line => !line.trimStart().startsWith("//"))
+			.join("\n");
+	};
+
+	test("the iframe surface hands srcdoc back to the native setter", () => {
+		// It used to redefine srcdoc as a non-writable data property and then assign
+		// through the same element, so the write failed against its own frozen
+		// property and every dynamically created srcdoc iframe loaded empty.
+		const iframe = source("iframe");
+		// Delegates to the prototype accessor rather than assigning through the
+		// element it has just shadowed.
+		expect(iframe).toInclude("nativeSrcdocDescriptor.set.call(iframe, newValue)");
+		// Steps aside instead of freezing itself.
+		expect(iframe).toInclude("delete iframe.srcdoc");
+		// Defines srcdoc exactly once. The bug was a SECOND definition inside the
+		// setter, as a non-writable data property, which made the subsequent write
+		// a silent no-op.
+		expect(iframe.split('Object_defineProperty(iframe, "srcdoc"').length - 1).toBe(1);
+	});
+
+	test("the locale surface does not touch timezone at all", () => {
+		// Timezone is a CDP override (BrowserTool#applyTimezoneOverride). Doing it in
+		// page script forced the profile's zone into every Intl.DateTimeFormat call,
+		// overriding a caller's explicit timeZone, and rewrote only the displayed
+		// zone name while leaving getTimezoneOffset contradicting it.
+		const locale = source("locale");
+		expect(locale).not.toInclude("Intl.DateTimeFormat =");
+		expect(locale).not.toInclude("Date.prototype.toString");
+		expect(locale).not.toInclude("Date.prototype.toTimeString");
+		expect(locale).not.toInclude("Eastern Standard Time");
+	});
+
+	test("the locale surface still pins language and languages", () => {
+		const locale = source("locale");
+		expect(locale).toInclude('"language"');
+		expect(locale).toInclude('"languages"');
+	});
+});
+
 describe("stealth bundle failure reporting", () => {
 	test("writes NO global by default — a window.__xcsh* marker would itself be detectable", () => {
 		const bundle = buildStealthBundle();

--- a/packages/coding-agent/test/browser/stealth-bundle.test.ts
+++ b/packages/coding-agent/test/browser/stealth-bundle.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { buildStealthBundle, STEALTH_SCRIPTS } from "../../src/tools/browser-stealth";
+
+// Pure assertions over the assembled init script — no browser launch, so these
+// run in CI on every PR. The behavioural counterparts (does each surface
+// actually change in a real Chrome) are in test/e2e/stealth-surfaces.e2e.test.ts,
+// which is describe.skipIf(isCI) and local-only.
+
+describe("stealth bundle composition", () => {
+	test("carries all fourteen surfaces", () => {
+		expect(STEALTH_SCRIPTS).toHaveLength(14);
+		expect(STEALTH_SCRIPTS.map(s => s.name)).toEqual([
+			"tampering",
+			"activity",
+			"hairline",
+			"botd",
+			"iframe",
+			"webgl",
+			"screen",
+			"fonts",
+			"audio",
+			"locale",
+			"plugins",
+			"hardware",
+			"codecs",
+			"worker",
+		]);
+	});
+
+	test("loads tampering first, so later patches are covered by its toString shim", () => {
+		expect(STEALTH_SCRIPTS[0].name).toBe("tampering");
+	});
+
+	test("no surface is empty — a mis-resolved text import would yield a blank script", () => {
+		for (const script of STEALTH_SCRIPTS) {
+			expect(script.source.trim().length).toBeGreaterThan(0);
+		}
+	});
+
+	test("every surface's source reaches the bundle", () => {
+		const bundle = buildStealthBundle();
+		for (const script of STEALTH_SCRIPTS) {
+			expect(bundle).toInclude(script.source);
+		}
+	});
+
+	test("isolates each surface in its own try/catch, so one failure cannot stop the rest", () => {
+		const bundle = buildStealthBundle();
+		// One guard per surface.
+		expect(bundle.split("try {").length - 1).toBeGreaterThanOrEqual(STEALTH_SCRIPTS.length);
+	});
+
+	test("caches pristine natives BEFORE any surface runs", () => {
+		const bundle = buildStealthBundle();
+		const lastNativeCache = bundle.lastIndexOf("= nativeWindow");
+		const firstSurface = bundle.indexOf(STEALTH_SCRIPTS[0].source);
+		expect(lastNativeCache).toBeLessThan(firstSurface);
+	});
+
+	test("touches NO DOM, because the bundle runs before any DOM exists", () => {
+		// Regression guard for the bug this module's E2E suite found: the preamble
+		// used to build a helper iframe and append it to document.head, but
+		// Page.addScriptToEvaluateOnNewDocument runs at readyState "loading", where
+		// document.head, document.body and document.documentElement are ALL null.
+		// That threw on the first statement, outside every per-surface guard, so all
+		// fourteen surfaces silently never ran. Measured identically on puppeteer
+		// 24.43.1 / Chrome 148, so it was not introduced by the 25.3.0 bump.
+		const preamble = buildStealthBundle().slice(0, buildStealthBundle().indexOf(STEALTH_SCRIPTS[0].source));
+		expect(preamble).not.toInclude("document.head");
+		expect(preamble).not.toInclude("appendChild");
+		expect(preamble).not.toInclude("createElement");
+	});
+
+	test("takes its native cache from the current realm", () => {
+		expect(buildStealthBundle()).toInclude("const nativeWindow = globalThis;");
+	});
+
+	test("no surface reaches for document.head either — same document-start constraint", () => {
+		for (const script of STEALTH_SCRIPTS) {
+			expect(script.source).not.toInclude("document.head");
+		}
+	});
+});
+
+describe("stealth bundle failure reporting", () => {
+	test("writes NO global by default — a window.__xcsh* marker would itself be detectable", () => {
+		const bundle = buildStealthBundle();
+		expect(bundle).not.toInclude("globalThis[");
+		expect(bundle).not.toInclude("__xcshStealthErrors");
+		// The production guard swallows silently, by design.
+		expect(bundle).toInclude("catch (e) {  }");
+	});
+
+	test("records per-surface failures when a test opts in, naming the surface", () => {
+		const bundle = buildStealthBundle({ errorSink: "__xcshStealthErrors" });
+		expect(bundle).toInclude('globalThis["__xcshStealthErrors"]');
+		for (const script of STEALTH_SCRIPTS) {
+			expect(bundle).toInclude(`name: ${JSON.stringify(script.name)}`);
+		}
+	});
+
+	test("the opt-in sink is the only difference from the production bundle", () => {
+		const production = buildStealthBundle();
+		const instrumented = buildStealthBundle({ errorSink: "__xcshStealthErrors" });
+		// Strip the recording statements; what remains must match production byte for byte.
+		const stripped = instrumented.replace(
+			/\(globalThis\["__xcshStealthErrors"\] \|\|= \[\]\)\.push\(\{ name: "\w+", message: String\(e && e\.message \|\| e\) \}\);/g,
+			"",
+		);
+		expect(stripped).toBe(production);
+	});
+});

--- a/packages/coding-agent/test/browser/user-agent-override.test.ts
+++ b/packages/coding-agent/test/browser/user-agent-override.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { deriveUserAgentOverride } from "../../src/tools/browser-user-agent";
+
+// These assertions exist because the stealth user-agent metadata is DERIVED from
+// whichever Chrome puppeteer bundles, so a puppeteer bump silently changes the
+// output. Bumping 24.43.1 -> 25.3.0 moved bundled Chrome 148 -> 150, and the
+// GREASE permutation is seeded by the major version: 148 % 6 = 4 but 150 % 6 = 0.
+// That reorders the brand list and rewrites the greased brand string.
+//
+// Ground truth for the algorithm is Chromium's GenerateBrandVersionList
+// (components/embedder_support/user_agent_utils.cc): a 6-entry permutation table
+// indexed by `major % 6`, with the greased brand assembled from the escape
+// characters [" ", " ", ";"] in permuted order.
+//
+// Deliberately a pure unit test with no browser launch, so it runs in CI on
+// every PR. The companion live-Chrome assertions (that the override actually
+// reaches the page) are in test/e2e/extension-e2e.test.ts, which is
+// describe.skipIf(isCI) and therefore local-only.
+
+const MAC_UA_150 =
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36";
+const MAC_HEADLESS_UA_150 =
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/150.0.0.0 Safari/537.36";
+const MAC_UA_148 =
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36";
+
+/** Chrome's greased brand for a given permutation, per Chromium's escape-char table. */
+const GREASE_CHARS = [" ", " ", ";"] as const;
+function greasedBrand(order: readonly number[]): string {
+	return `${GREASE_CHARS[order[0]]}Not${GREASE_CHARS[order[1]]}A${GREASE_CHARS[order[2]]}Brand`;
+}
+
+describe("deriveUserAgentOverride — brand list GREASE permutation", () => {
+	test("Chrome 150 uses permutation 0, putting the greased brand first", () => {
+		const override = deriveUserAgentOverride(MAC_UA_150, "Chrome/150.0.7871.24");
+		// 150 % 6 === 0 -> order [0, 1, 2]
+		expect(override.userAgentMetadata.brands).toEqual([
+			{ brand: " Not A;Brand", version: "99" },
+			{ brand: "Chromium", version: "150" },
+			{ brand: "Google Chrome", version: "150" },
+		]);
+	});
+
+	test("Chrome 148 uses permutation 4, putting the greased brand last with different escapes", () => {
+		const override = deriveUserAgentOverride(MAC_UA_148, "Chrome/148.0.7780.0");
+		// 148 % 6 === 4 -> order [2, 0, 1]
+		expect(override.userAgentMetadata.brands).toEqual([
+			{ brand: "Chromium", version: "148" },
+			{ brand: "Google Chrome", version: "148" },
+			{ brand: ";Not A Brand", version: "99" },
+		]);
+	});
+
+	test("the 148 -> 150 bump genuinely changes the emitted brand list", () => {
+		const before = deriveUserAgentOverride(MAC_UA_148, "Chrome/148.0.7780.0").userAgentMetadata.brands;
+		const after = deriveUserAgentOverride(MAC_UA_150, "Chrome/150.0.7871.24").userAgentMetadata.brands;
+		expect(after).not.toEqual(before);
+		// Not merely renumbered: the greased brand moved position AND changed spelling.
+		expect(before[2]?.brand).toBe(";Not A Brand");
+		expect(after[0]?.brand).toBe(" Not A;Brand");
+	});
+
+	test("every major-version residue yields a dense, complete, correctly-greased brand list", () => {
+		const permutations = [
+			[0, 1, 2],
+			[0, 2, 1],
+			[1, 0, 2],
+			[1, 2, 0],
+			[2, 0, 1],
+			[2, 1, 0],
+		];
+		for (let major = 100; major < 100 + 24; major++) {
+			const ua = MAC_UA_150.replace("Chrome/150", `Chrome/${major}`);
+			const brands = deriveUserAgentOverride(ua, `Chrome/${major}.0.0.0`).userAgentMetadata.brands;
+			const order = permutations[major % 6];
+
+			// A sparse assignment (brands[order[n]] = …) would leave holes; reject those.
+			expect(brands).toHaveLength(3);
+			for (const entry of brands) {
+				expect(entry).toBeDefined();
+				expect(typeof entry.brand).toBe("string");
+			}
+
+			expect(brands[order[0]]).toEqual({ brand: greasedBrand(order), version: "99" });
+			expect(brands[order[1]]).toEqual({ brand: "Chromium", version: String(major) });
+			expect(brands[order[2]]).toEqual({ brand: "Google Chrome", version: String(major) });
+		}
+	});
+});
+
+describe("deriveUserAgentOverride — user agent string laundering", () => {
+	test("rewrites HeadlessChrome, the single strongest automation tell", () => {
+		const override = deriveUserAgentOverride(MAC_HEADLESS_UA_150, "Chrome/150.0.7871.24");
+		expect(override.userAgent).not.toInclude("HeadlessChrome");
+		expect(override.userAgent).toInclude("Chrome/150.0.0.0");
+	});
+
+	test("presents Linux as Windows, since a Linux desktop Chrome is itself unusual", () => {
+		const linuxUA =
+			"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/150.0.0.0 Safari/537.36";
+		const override = deriveUserAgentOverride(linuxUA, "Chrome/150.0.7871.24");
+		expect(override.userAgent).toInclude("(Windows NT 10.0; Win64; x64)");
+		expect(override.userAgent).not.toInclude("Linux");
+		expect(override.platform).toBe("Win32");
+		expect(override.userAgentMetadata.platform).toBe("Windows");
+		expect(override.userAgentMetadata.platformVersion).toBe("10.0");
+	});
+
+	test("leaves Android alone, because there Linux is the truthful platform", () => {
+		const androidUA =
+			"Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Mobile Safari/537.36";
+		const override = deriveUserAgentOverride(androidUA, "Chrome/150.0.7871.24");
+		expect(override.userAgent).toInclude("Android 13");
+		expect(override.platform).toBe("Android");
+		expect(override.userAgentMetadata.mobile).toBe(true);
+		expect(override.userAgentMetadata.platformVersion).toBe("13");
+		expect(override.userAgentMetadata.model).toBe("Pixel 7");
+		expect(override.userAgentMetadata.architecture).toBe("");
+	});
+});
+
+describe("deriveUserAgentOverride — platform metadata must agree with the UA string", () => {
+	test("macOS maps to MacIntel with an underscore-form platform version", () => {
+		const override = deriveUserAgentOverride(MAC_UA_150, "Chrome/150.0.7871.24");
+		expect(override.platform).toBe("MacIntel");
+		expect(override.userAgentMetadata.platform).toBe("Mac OS X");
+		expect(override.userAgentMetadata.platformVersion).toBe("10_15_7");
+		expect(override.userAgentMetadata.mobile).toBe(false);
+		expect(override.userAgentMetadata.architecture).toBe("x86");
+		expect(override.userAgentMetadata.model).toBe("");
+	});
+
+	test("fullVersion tracks the UA's Chrome token, not the browser build string", () => {
+		const override = deriveUserAgentOverride(MAC_UA_150, "Chrome/150.0.7871.24");
+		expect(override.userAgentMetadata.fullVersion).toBe("150.0.0.0");
+	});
+
+	test("falls back to the browser version when the UA carries no Chrome token", () => {
+		const noChromeUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko)";
+		const override = deriveUserAgentOverride(noChromeUA, "Chrome/150.0.7871.24");
+		expect(override.userAgentMetadata.fullVersion).toBe("150.0.7871.24");
+		expect(override.userAgentMetadata.brands).toEqual([
+			{ brand: " Not A;Brand", version: "99" },
+			{ brand: "Chromium", version: "150" },
+			{ brand: "Google Chrome", version: "150" },
+		]);
+	});
+
+	test("pins the accept-language the stealth profile claims", () => {
+		expect(deriveUserAgentOverride(MAC_UA_150, "Chrome/150.0.7871.24").acceptLanguage).toBe("en-US,en");
+	});
+});

--- a/packages/coding-agent/test/e2e/harness/panel-harness.ts
+++ b/packages/coding-agent/test/e2e/harness/panel-harness.ts
@@ -402,7 +402,7 @@ export async function openConsoleAndLogin(browser: Browser, opts: LoginOptions):
 		const userSel = "#username, input[name='username']";
 		if (await page.$(userSel)) {
 			const u = await page.$(userSel);
-			await u?.click({ clickCount: 3 });
+			await u?.click({ count: 3 });
 			await u?.type(opts.username, { delay: 15 });
 		}
 		let pw = await page.$("#password, input[type='password']");
@@ -413,7 +413,7 @@ export async function openConsoleAndLogin(browser: Browser, opts: LoginOptions):
 			pw = await page.$("#password, input[type='password']");
 		}
 		if (pw) {
-			await pw.click({ clickCount: 3 });
+			await pw.click({ count: 3 });
 			await pw.type(opts.password, { delay: 15 });
 		}
 		await clickSubmit(page);

--- a/packages/coding-agent/test/e2e/stealth-surfaces.e2e.test.ts
+++ b/packages/coding-agent/test/e2e/stealth-surfaces.e2e.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Level 3 E2E — asserts the injected stealth surfaces actually take effect in a
+ * real Chrome.
+ *
+ * Why this exists: every surface is wrapped in its own `try { … } catch {}` so
+ * that one failure cannot stop the rest. That is the right call for robustness
+ * and terrible for observability — a surface that stops working on a new Chrome
+ * fails completely silently. These tests make that failure loud, by asserting
+ * (a) the bundle records zero per-surface errors and (b) each surface's
+ * observable effect.
+ *
+ * This suite found a real bug: the bundle's native-cache preamble called
+ * `document.head.appendChild(iframe)`, but `evaluateOnNewDocument` runs before
+ * ANY DOM exists (`document.readyState === "loading"`, `document.head`,
+ * `document.body` and `document.documentElement` all null). So the preamble threw
+ * on its first statement, outside every per-surface guard, and all fourteen
+ * surfaces silently never ran — `navigator.webdriver` stayed `true`. Reproduced
+ * identically on puppeteer 24.43.1 / Chrome 148, so it predates the 25.3.0 bump.
+ *
+ * LOCAL-ONLY BY DESIGN: needs a real browser, so `describe.skipIf(isCI)` like the
+ * rest of the E2E tier. Run: bun test test/e2e/stealth-surfaces.e2e.test.ts
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import type { Browser, Page } from "puppeteer";
+import { buildStealthBundle } from "../../src/tools/browser-stealth";
+
+// See extension-e2e.test.ts: never process.exit() from a test module.
+const isCI = !!process.env.CI || !!process.env.GITHUB_ACTIONS;
+
+const ERROR_SINK = "__xcshStealthErrors";
+
+type Surfaces = {
+	surfaceErrors: Array<{ name: string; message: string }>;
+	webdriver: unknown;
+	hardwareConcurrency: number;
+	language: string;
+	languages: string[];
+	timezone: string;
+	pluginNames: string[];
+	mimeTypes: string[];
+	webglVendor: unknown;
+	webglRenderer: unknown;
+	permissionsQueryStringifiesNative: boolean;
+	permissionsQueryProtoCallIsNative: boolean;
+	chromeRuntimePresent: boolean;
+	leftoverIframes: number;
+};
+
+/**
+ * The page realm's globals. This package's tsconfig has no DOM lib (it is a CLI),
+ * so page-side code shapes what it needs off globalThis — same approach as
+ * src/tools/browser.ts's own page.evaluate callbacks.
+ */
+type PageRealm = {
+	navigator: {
+		webdriver?: unknown;
+		hardwareConcurrency: number;
+		language: string;
+		languages: readonly string[];
+		plugins: ArrayLike<{ name: string }>;
+		mimeTypes: ArrayLike<{ type: string }>;
+		permissions: { query: (...args: unknown[]) => unknown };
+	};
+	document: {
+		createElement(tag: string): {
+			getContext(kind: string): {
+				getExtension(name: string): { UNMASKED_VENDOR_WEBGL: number; UNMASKED_RENDERER_WEBGL: number } | null;
+				getParameter(p: number): unknown;
+			} | null;
+		};
+		querySelectorAll(sel: string): ArrayLike<unknown>;
+	};
+	Intl: { DateTimeFormat: (...a: unknown[]) => { resolvedOptions(): { timeZone: string } } };
+	chrome?: unknown;
+	__xcshStealthErrors?: Array<{ name: string; message: string }>;
+};
+
+async function readSurfaces(page: Page): Promise<Surfaces> {
+	const json = await page.evaluate(() => {
+		const g = globalThis as unknown as PageRealm;
+		const gl = g.document.createElement("canvas").getContext("webgl");
+		const dbg = gl?.getExtension("WEBGL_debug_renderer_info") ?? null;
+		const nav = g.navigator;
+		return JSON.stringify({
+			surfaceErrors: g.__xcshStealthErrors ?? [],
+			// `undefined` would vanish from JSON, which is the very value under test.
+			webdriver: typeof nav.webdriver === "undefined" ? "__undefined__" : nav.webdriver,
+			hardwareConcurrency: nav.hardwareConcurrency,
+			language: nav.language,
+			languages: [...nav.languages],
+			timezone: g.Intl.DateTimeFormat().resolvedOptions().timeZone,
+			pluginNames: Array.from(nav.plugins).map(p => p.name),
+			mimeTypes: Array.from(nav.mimeTypes).map(m => m.type),
+			webglVendor: gl && dbg ? gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL) : null,
+			webglRenderer: gl && dbg ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : null,
+			// Two spellings, deliberately. The surfaces mask by installing an own
+			// `toString` property, so `String(fn)` is masked while
+			// `Function.prototype.toString.call(fn)` bypasses the own property and
+			// still sees the replacement. That asymmetry is a real limitation of the
+			// approach, pinned in the assertions below rather than left implicit.
+			permissionsQueryStringifiesNative: String(nav.permissions.query).includes("[native code]"),
+			permissionsQueryProtoCallIsNative: Function.prototype.toString
+				.call(nav.permissions.query)
+				.includes("[native code]"),
+			chromeRuntimePresent: typeof g.chrome !== "undefined",
+			// The preamble must not leave a helper element behind as a tell.
+			leftoverIframes: g.document.querySelectorAll("iframe").length,
+		});
+	});
+	return JSON.parse(json) as Surfaces;
+}
+
+describe.skipIf(isCI)("Stealth injected surfaces (real Chrome via Puppeteer)", () => {
+	let browser: Browser;
+	let server: ReturnType<typeof Bun.serve>;
+	let fixtureUrl: string;
+	let stealthed: Surfaces;
+	let bare: Surfaces;
+
+	beforeAll(async () => {
+		const puppeteer = (await import("puppeteer")).default;
+		server = Bun.serve({
+			port: 0,
+			fetch: () =>
+				new Response('<!doctype html><html lang="en"><head><title>surfaces</title></head><body></body></html>', {
+					headers: { "content-type": "text/html" },
+				}),
+		});
+		fixtureUrl = `http://127.0.0.1:${server.port}/`;
+		browser = await puppeteer.launch({ headless: true });
+
+		const barePage = await browser.newPage();
+		await barePage.goto(fixtureUrl);
+		bare = await readSurfaces(barePage);
+		await barePage.close();
+
+		const page = await browser.newPage();
+		await page.evaluateOnNewDocument(buildStealthBundle({ errorSink: ERROR_SINK }));
+		await page.goto(fixtureUrl);
+		stealthed = await readSurfaces(page);
+		await page.close();
+	}, 180_000);
+
+	afterAll(async () => {
+		await browser?.close();
+		server?.stop(true);
+	});
+
+	it("runs every surface without a swallowed error", () => {
+		// Names the offender rather than just failing a count.
+		expect(stealthed.surfaceErrors).toEqual([]);
+	});
+
+	it("hides navigator.webdriver, the most basic automation tell", () => {
+		expect(bare.webdriver).toBe(true);
+		expect(stealthed.webdriver).toBe("__undefined__");
+	});
+
+	it("spoofs hardwareConcurrency to the profile's value", () => {
+		expect(stealthed.hardwareConcurrency).toBe(4);
+	});
+
+	it("presents a consistent locale profile", () => {
+		expect(stealthed.language).toBe("en-US");
+		expect(stealthed.languages).toEqual(["en-US", "en"]);
+		expect(stealthed.timezone).toBe("America/New_York");
+	});
+
+	it("changes something at all — guards against a bundle that silently no-ops", () => {
+		// The bug this suite found made every single surface identical to bare.
+		const changed =
+			stealthed.webdriver !== bare.webdriver ||
+			stealthed.hardwareConcurrency !== bare.hardwareConcurrency ||
+			stealthed.languages.join() !== bare.languages.join();
+		expect(changed).toBe(true);
+	});
+
+	it("keeps a plugin list that is non-empty and PDF-capable", () => {
+		expect(stealthed.pluginNames.length).toBeGreaterThan(0);
+		expect(stealthed.mimeTypes).toContain("application/pdf");
+	});
+
+	it("reports a WebGL vendor and renderer rather than a SwiftShader giveaway", () => {
+		expect(typeof stealthed.webglVendor).toBe("string");
+		expect(typeof stealthed.webglRenderer).toBe("string");
+		expect(String(stealthed.webglRenderer)).not.toInclude("SwiftShader");
+	});
+
+	it("keeps a replaced permissions.query stringifying as native code", () => {
+		expect(stealthed.permissionsQueryStringifiesNative).toBe(true);
+	});
+
+	it("does NOT survive Function.prototype.toString.call — a known limitation, pinned", () => {
+		// The surfaces mask by installing an own `toString` property, which
+		// `Function.prototype.toString.call(fn)` deliberately ignores. Defeating that
+		// needs a patched Function.prototype.toString, which this bundle does not do
+		// (nothing in src/tools/puppeteer/*.txt touches it). Asserting the CURRENT
+		// behaviour means a future change to close the gap re-evaluates this
+		// expectation instead of silently assuming it.
+		expect(stealthed.permissionsQueryProtoCallIsNative).toBe(false);
+	});
+
+	it("leaves no helper iframe behind in the document", () => {
+		expect(stealthed.leftoverIframes).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/e2e/stealth-surfaces.e2e.test.ts
+++ b/packages/coding-agent/test/e2e/stealth-surfaces.e2e.test.ts
@@ -62,6 +62,7 @@ type PageRealm = {
 		permissions: { query: (...args: unknown[]) => unknown };
 	};
 	document: {
+		body: { appendChild(el: unknown): void };
 		createElement(tag: string): {
 			getContext(kind: string): {
 				getExtension(name: string): { UNMASKED_VENDOR_WEBGL: number; UNMASKED_RENDERER_WEBGL: number } | null;
@@ -70,7 +71,10 @@ type PageRealm = {
 		};
 		querySelectorAll(sel: string): ArrayLike<unknown>;
 	};
-	Intl: { DateTimeFormat: (...a: unknown[]) => { resolvedOptions(): { timeZone: string } } };
+	Intl: {
+		DateTimeFormat: new (...a: unknown[]) => { resolvedOptions(): { timeZone: string }; format(d: unknown): string };
+	};
+	Date: new (...a: unknown[]) => { getTimezoneOffset(): number; toString(): string };
 	chrome?: unknown;
 	__xcshStealthErrors?: Array<{ name: string; message: string }>;
 };
@@ -88,7 +92,7 @@ async function readSurfaces(page: Page): Promise<Surfaces> {
 			hardwareConcurrency: nav.hardwareConcurrency,
 			language: nav.language,
 			languages: [...nav.languages],
-			timezone: g.Intl.DateTimeFormat().resolvedOptions().timeZone,
+			timezone: new g.Intl.DateTimeFormat().resolvedOptions().timeZone,
 			pluginNames: Array.from(nav.plugins).map(p => p.name),
 			mimeTypes: Array.from(nav.mimeTypes).map(m => m.type),
 			webglVendor: gl && dbg ? gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL) : null,
@@ -136,6 +140,11 @@ describe.skipIf(isCI)("Stealth injected surfaces (real Chrome via Puppeteer)", (
 
 		const page = await browser.newPage();
 		await page.evaluateOnNewDocument(buildStealthBundle({ errorSink: ERROR_SINK }));
+		// Mirrors BrowserTool#applyTimezoneOverride: the timezone is a CDP override,
+		// not a page-script patch, so a page-script-only harness would not represent
+		// what ships.
+		const client = await page.createCDPSession();
+		await client.send("Emulation.setTimezoneOverride", { timezoneId: "America/New_York" });
 		await page.goto(fixtureUrl);
 		stealthed = await readSurfaces(page);
 		await page.close();
@@ -164,6 +173,95 @@ describe.skipIf(isCI)("Stealth injected surfaces (real Chrome via Puppeteer)", (
 		expect(stealthed.language).toBe("en-US");
 		expect(stealthed.languages).toEqual(["en-US", "en"]);
 		expect(stealthed.timezone).toBe("America/New_York");
+	});
+
+	it("does NOT break a caller's explicit timeZone", async () => {
+		// Regression: the locale surface used to force its own zone into every
+		// Intl.DateTimeFormat call, so a page asking for UTC got New York — 08:00
+		// where it wanted 12:00. Corrupting a page's formatted output is far worse
+		// than the tell it was trying to hide.
+		const page = await browser.newPage();
+		try {
+			await page.evaluateOnNewDocument(buildStealthBundle({ errorSink: ERROR_SINK }));
+			const client = await page.createCDPSession();
+			await client.send("Emulation.setTimezoneOverride", { timezoneId: "America/New_York" });
+			await page.goto(fixtureUrl);
+			const result = await page.evaluate(() => {
+				const g = globalThis as unknown as PageRealm;
+				const at = new g.Date(Date.UTC(2026, 6, 28, 12, 0));
+				return JSON.stringify({
+					explicitUTC: new g.Intl.DateTimeFormat("en-US", { timeZone: "UTC" }).resolvedOptions().timeZone,
+					explicitTokyo: new g.Intl.DateTimeFormat("en-US", { timeZone: "Asia/Tokyo" }).resolvedOptions().timeZone,
+					formattedUTC: new g.Intl.DateTimeFormat("en-US", {
+						timeZone: "UTC",
+						hour: "numeric",
+						hour12: false,
+					}).format(at),
+					offset: new g.Date().getTimezoneOffset(),
+					dateString: at.toString(),
+				});
+			});
+			const parsed = JSON.parse(result) as {
+				explicitUTC: string;
+				explicitTokyo: string;
+				formattedUTC: string;
+				offset: number;
+				dateString: string;
+			};
+			expect(parsed.explicitUTC).toBe("UTC");
+			expect(parsed.explicitTokyo).toBe("Asia/Tokyo");
+			expect(parsed.formattedUTC).toBe("12");
+			// Consistency: the numeric offset must match the zone actually claimed.
+			// America/New_York in July is EDT, i.e. UTC-4 -> 240. The old textual
+			// Date rewrite hardcoded "Eastern Standard Time" while the offset stayed
+			// EDT, which is self-contradictory and trivially detectable.
+			expect(parsed.offset).toBe(240);
+			expect(parsed.dateString).toInclude("Eastern Daylight Time");
+			expect(parsed.dateString).not.toInclude("Eastern Standard Time");
+		} finally {
+			await page.close();
+		}
+	});
+
+	it("keeps iframe srcdoc working", async () => {
+		// Regression: the iframe surface redefined srcdoc as a NON-WRITABLE data
+		// property and then assigned through the same element, so the write failed
+		// against its own frozen property and the native setter was never reached.
+		// Every dynamically created srcdoc iframe loaded empty.
+		const page = await browser.newPage();
+		try {
+			await page.evaluateOnNewDocument(buildStealthBundle({ errorSink: ERROR_SINK }));
+			await page.goto(fixtureUrl);
+			const loaded = await page.evaluate(async () => {
+				const g = globalThis as unknown as PageRealm & {
+					document: { body: { appendChild(el: unknown): void } };
+				};
+				const frame = g.document.createElement("iframe") as unknown as {
+					srcdoc: string;
+					getAttribute(n: string): string | null;
+					onload: (() => void) | null;
+					contentDocument: { getElementById(id: string): { textContent: string } | null } | null;
+					remove(): void;
+				};
+				frame.srcdoc = "<p id=hit>LOADED</p>";
+				g.document.body.appendChild(frame);
+				await new Promise<void>(resolve => {
+					frame.onload = () => resolve();
+					setTimeout(resolve, 1000);
+				});
+				const text = frame.contentDocument?.getElementById("hit")?.textContent ?? null;
+				const attr = frame.getAttribute("srcdoc");
+				const prop = frame.srcdoc;
+				frame.remove();
+				return JSON.stringify({ text, attr, prop });
+			});
+			const parsed = JSON.parse(loaded) as { text: string | null; attr: string | null; prop: string };
+			expect(parsed.text).toBe("LOADED");
+			expect(parsed.attr).toBe("<p id=hit>LOADED</p>");
+			expect(parsed.prop).toBe("<p id=hit>LOADED</p>");
+		} finally {
+			await page.close();
+		}
 	});
 
 	it("changes something at all — guards against a bundle that silently no-ops", () => {

--- a/packages/coding-agent/test/e2e/stealth-surfaces.e2e.test.ts
+++ b/packages/coding-agent/test/e2e/stealth-surfaces.e2e.test.ts
@@ -298,6 +298,105 @@ describe.skipIf(isCI)("Stealth injected surfaces (real Chrome via Puppeteer)", (
 		expect(stealthed.permissionsQueryProtoCallIsNative).toBe(false);
 	});
 
+	it("does not break ordinary web APIs", async () => {
+		// Both defects this suite found were FUNCTIONAL breakage, not fingerprinting
+		// slips: srcdoc silently stopped loading, and explicit timezones formatted
+		// the wrong hour. Fourteen surfaces patch a lot of the platform, so the
+		// question "does the page still work" needs its own assertion rather than
+		// being inferred from the absence of thrown errors — the surface guards
+		// swallow, so nothing throws either way.
+		const page = await browser.newPage();
+		try {
+			await page.evaluateOnNewDocument(buildStealthBundle({ errorSink: ERROR_SINK }));
+			await page.goto(fixtureUrl);
+			const json = await page.evaluate(async () => {
+				const w = globalThis as unknown as {
+					fetch: (u: string) => Promise<{ status: number }>;
+					XMLHttpRequest: new () => {
+						onload: (() => void) | null;
+						onerror: (() => void) | null;
+						status: number;
+						open(m: string, u: string): void;
+						send(): void;
+					};
+					OfflineAudioContext: new (
+						c: number,
+						l: number,
+						r: number,
+					) => {
+						destination: unknown;
+						createOscillator(): { connect(d: unknown): void; start(): void };
+						startRendering(): Promise<{ length: number }>;
+					};
+					localStorage: {
+						setItem(k: string, v: string): void;
+						getItem(k: string): string | null;
+						removeItem(k: string): void;
+					};
+					document: {
+						createElement(t: string): {
+							getContext(k: string): {
+								font: string;
+								measureText(t: string): { width: number };
+								getImageData(a: number, b: number, c: number, d: number): { data: { length: number } };
+							} | null;
+							toDataURL(): string;
+							canPlayType(t: string): string;
+							width: number;
+							height: number;
+						};
+					};
+					navigator: { permissions: { query(d: { name: string }): Promise<{ state: string }> } };
+					Date: new (n: number) => { toLocaleString(l: string): string };
+				};
+				const out: Record<string, unknown> = {};
+				out.fetchStatus = (await w.fetch("/")).status;
+				out.xhrStatus = await new Promise<number | string>(res => {
+					const x = new w.XMLHttpRequest();
+					x.onload = () => res(x.status);
+					x.onerror = () => res("error");
+					x.open("GET", "/");
+					x.send();
+				});
+				const ctx2d = w.document.createElement("canvas").getContext("2d");
+				ctx2d!.font = "20px monospace";
+				out.measuredWidth = Math.round(ctx2d!.measureText("abc").width);
+				out.dataUrlPrefix = w.document.createElement("canvas").toDataURL().slice(0, 15);
+				const sized = w.document.createElement("canvas");
+				sized.width = 2;
+				sized.height = 2;
+				out.imageDataLength = sized.getContext("2d")!.getImageData(0, 0, 2, 2).data.length;
+				out.canPlayMp4 = w.document.createElement("video").canPlayType('video/mp4; codecs="avc1.42E01E"');
+				const audio = new w.OfflineAudioContext(1, 128, 44100);
+				const osc = audio.createOscillator();
+				osc.connect(audio.destination);
+				osc.start();
+				out.renderedFrames = (await audio.startRendering()).length;
+				w.localStorage.setItem("k", "v");
+				out.storageRoundTrip = w.localStorage.getItem("k");
+				w.localStorage.removeItem("k");
+				out.permissionState = (await w.navigator.permissions.query({ name: "geolocation" })).state;
+				// 15:04 UTC in January is 10:04 in New York (EST, UTC-5). Catches a
+				// timezone override that shifts Intl but not Date, or vice versa.
+				out.localised = new w.Date(Date.UTC(2026, 0, 2, 15, 4)).toLocaleString("en-US");
+				return JSON.stringify(out);
+			});
+			const r = JSON.parse(json) as Record<string, unknown>;
+			expect(r.fetchStatus).toBe(200);
+			expect(r.xhrStatus).toBe(200);
+			expect(r.measuredWidth).toBe(36);
+			expect(r.dataUrlPrefix).toBe("data:image/png;");
+			expect(r.imageDataLength).toBe(16);
+			expect(r.canPlayMp4).toBe("probably");
+			expect(r.renderedFrames).toBe(128);
+			expect(r.storageRoundTrip).toBe("v");
+			expect(r.permissionState).toBe("prompt");
+			expect(r.localised).toBe("1/2/2026, 10:04:00 AM");
+		} finally {
+			await page.close();
+		}
+	});
+
 	it("leaves no helper iframe behind in the document", () => {
 		expect(stealthed.leftoverIframes).toBe(0);
 	});

--- a/packages/coding-agent/test/e2e/stealth-user-agent.e2e.test.ts
+++ b/packages/coding-agent/test/e2e/stealth-user-agent.e2e.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Level 3 E2E — asserts the derived stealth user-agent override actually LANDS
+ * on a page in the Chrome that puppeteer currently bundles.
+ *
+ * Why this exists separately from the pure unit test:
+ * `test/browser/user-agent-override.test.ts` proves the derivation computes the
+ * right values and runs in CI on every PR. It cannot prove Chrome accepts them.
+ * A puppeteer major bump can change the CDP surface such that
+ * `Emulation.setUserAgentOverride` is silently rejected or ignored, leaving the
+ * page with no client hints at all — which is itself a strong automation tell.
+ *
+ * Measured baseline (Chrome 150.0.7871.24, bundled by puppeteer 25.3.0): a page
+ * with NO override reports `navigator.userAgentData.brands === []`, an empty
+ * platform, and an empty uaFullVersion — verified on Chrome-for-Testing headless
+ * and headful, on system Google Chrome 150.0.7871.187 headful, and on a Chrome
+ * launched with none of puppeteer's default flags. So "brands is empty" is the
+ * before state, and a populated, correctly-ordered brand list is the after
+ * state. That gap is what makes this assertion meaningful rather than tautological.
+ *
+ * `navigator.userAgentData` is only exposed in a secure context, so the fixture
+ * is served from 127.0.0.1 (a trustworthy origin) rather than about:blank —
+ * on about:blank the API is absent entirely and every assertion here would
+ * vacuously "pass" against undefined.
+ *
+ * LOCAL-ONLY BY DESIGN: launching Chrome needs a real browser download, so this
+ * is `describe.skipIf(isCI)` like the rest of the E2E tier.
+ * Run: bun test test/e2e/stealth-user-agent.e2e.test.ts
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import type { Browser, Page } from "puppeteer";
+import { deriveUserAgentOverride, type UserAgentOverride } from "../../src/tools/browser-user-agent";
+
+// See the note in extension-e2e.test.ts: never process.exit() from a test module.
+// Skip cleanly and import puppeteer dynamically so it never loads on a runner
+// without a browser.
+const isCI = !!process.env.CI || !!process.env.GITHUB_ACTIONS;
+
+type UaDataSnapshot = {
+	present: boolean;
+	secure?: boolean;
+	brands?: Array<{ brand: string; version: string }>;
+	platform?: string;
+	mobile?: boolean;
+	uaFullVersion?: string;
+	userAgent?: string;
+};
+
+/**
+ * Reads client hints from inside the page and stringifies there, so puppeteer's
+ * structured clone of `NavigatorUAData` (frozen, getter-backed) cannot flatten
+ * the result into a false empty.
+ */
+async function readUaData(page: Page): Promise<UaDataSnapshot> {
+	const json = await page.evaluate(async () => {
+		const data = (
+			navigator as Navigator & {
+				userAgentData?: {
+					brands: Array<{ brand: string; version: string }>;
+					platform: string;
+					mobile: boolean;
+					getHighEntropyValues(hints: string[]): Promise<{ uaFullVersion?: string }>;
+				};
+			}
+		).userAgentData;
+		if (!data) return JSON.stringify({ present: false });
+		const high = await data.getHighEntropyValues(["uaFullVersion"]);
+		return JSON.stringify({
+			present: true,
+			secure: (globalThis as unknown as { isSecureContext: boolean }).isSecureContext,
+			brands: data.brands.map(b => ({ brand: b.brand, version: b.version })),
+			platform: data.platform,
+			mobile: data.mobile,
+			uaFullVersion: high.uaFullVersion ?? "",
+			userAgent: navigator.userAgent,
+		});
+	});
+	return JSON.parse(json) as UaDataSnapshot;
+}
+
+/** Applies the override exactly as BrowserTool#sendUserAgentOverride does. */
+async function applyOverride(page: Page, override: UserAgentOverride): Promise<void> {
+	const client = await page.createCDPSession();
+	await client.send("Network.enable");
+	await client.send("Network.setUserAgentOverride", override as unknown as never);
+	await client.send("Emulation.setUserAgentOverride", override as unknown as never);
+}
+
+describe.skipIf(isCI)("Stealth user-agent override (real Chrome via Puppeteer)", () => {
+	let browser: Browser;
+	let server: ReturnType<typeof Bun.serve>;
+	let fixtureUrl: string;
+	let rawUserAgent: string;
+	let browserVersion: string;
+
+	beforeAll(async () => {
+		const puppeteer = (await import("puppeteer")).default;
+		server = Bun.serve({
+			port: 0,
+			fetch: () =>
+				new Response('<!doctype html><html lang="en"><head><title>ua probe</title></head><body></body></html>', {
+					headers: { "content-type": "text/html" },
+				}),
+		});
+		fixtureUrl = `http://127.0.0.1:${server.port}/`;
+		browser = await puppeteer.launch({ headless: true });
+		rawUserAgent = await browser.userAgent();
+		browserVersion = await browser.version();
+	}, 120_000);
+
+	afterAll(async () => {
+		await browser?.close();
+		server?.stop(true);
+	});
+
+	it("exposes userAgentData on the loopback fixture, so the assertions below are not vacuous", async () => {
+		const page = await browser.newPage();
+		try {
+			await page.goto(fixtureUrl);
+			const snapshot = await readUaData(page);
+			expect(snapshot.present).toBe(true);
+			expect(snapshot.secure).toBe(true);
+		} finally {
+			await page.close();
+		}
+	});
+
+	it("reports an EMPTY brand list without the override — the baseline this fixes", async () => {
+		const page = await browser.newPage();
+		try {
+			await page.goto(fixtureUrl);
+			const snapshot = await readUaData(page);
+			expect(snapshot.brands).toEqual([]);
+			expect(snapshot.platform).toBe("");
+			expect(snapshot.uaFullVersion).toBe("");
+		} finally {
+			await page.close();
+		}
+	});
+
+	it("lands the derived brand list, in the derived order, once the override is applied", async () => {
+		const override = deriveUserAgentOverride(rawUserAgent, browserVersion);
+		const page = await browser.newPage();
+		try {
+			await applyOverride(page, override);
+			await page.goto(fixtureUrl);
+			const snapshot = await readUaData(page);
+
+			// Order matters: Chrome permutes the brand list per major version, and a
+			// mismatch between claimed UA version and brand order is itself a tell.
+			expect(snapshot.brands).toEqual(override.userAgentMetadata.brands);
+			expect(snapshot.brands?.length).toBe(3);
+			expect(snapshot.platform).toBe(override.userAgentMetadata.platform);
+			expect(snapshot.mobile).toBe(override.userAgentMetadata.mobile);
+			expect(snapshot.uaFullVersion).toBe(override.userAgentMetadata.fullVersion);
+		} finally {
+			await page.close();
+		}
+	});
+
+	it("presents no HeadlessChrome token in the page's own navigator.userAgent", async () => {
+		const override = deriveUserAgentOverride(rawUserAgent, browserVersion);
+		const page = await browser.newPage();
+		try {
+			await applyOverride(page, override);
+			await page.goto(fixtureUrl);
+			const snapshot = await readUaData(page);
+			expect(snapshot.userAgent).not.toInclude("HeadlessChrome");
+			expect(snapshot.userAgent).toBe(override.userAgent);
+		} finally {
+			await page.close();
+		}
+	});
+
+	it("agrees with the Chrome major version puppeteer actually bundles", async () => {
+		// Guards the coupling directly: if a future bump moves the bundled major,
+		// the brand ordering changes and this pins that they move together.
+		const major = Number.parseInt(browserVersion.match(/\/(\d+)/)?.[1] ?? "0", 10);
+		expect(major).toBeGreaterThan(0);
+		const override = deriveUserAgentOverride(rawUserAgent, browserVersion);
+		const chromium = override.userAgentMetadata.brands.find(b => b.brand === "Chromium");
+		expect(chromium?.version).toBe(String(major));
+	});
+});

--- a/packages/office-pane/package.json
+++ b/packages/office-pane/package.json
@@ -49,7 +49,7 @@
 		"@types/react-dom": "^19.2",
 		"ajv": "^8.17.1",
 		"office-addin-mock": "^3.0",
-		"puppeteer": "^24.37"
+		"puppeteer": "^25.3"
 	},
 	"engines": {
 		"bun": ">=1.3.7"


### PR DESCRIPTION
Closes #2449
Fixes #2559

Bumps puppeteer, and — because validating the stealth surface was this PR's stated gate — ends up fixing the fact that **the entire stealth layer never executed.**

## Correcting this PR's own earlier premise

The draft was held on the claim that "CI cannot verify puppeteer at all — every browser test is `describe.skipIf(isCI)` and `XCSH_VISUAL` appears zero times in `ci.yml`." Half of that is wrong, and it mattered:

- `XCSH_VISUAL` appears only in `packages/office-pane` (`markdown-visual`, `shell-visual`). It has nothing to do with coding-agent browser tests.
- `describe.skipIf(isCI)` appears in exactly **one** relevant file, `test/e2e/extension-e2e.test.ts:99`. Everything under `test/browser/` **does** run in CI via `ci:check:full`.

So CI-gating assertions were available all along, for anything that does not need a live browser. That is where the new unit tests go.

## The dependency bump

Three mechanical edits, each surfaced by the typecheck:

| Site | Change |
|---|---|
| `browser.ts` | `Browser.isConnected()` removed → `.connected` |
| `panel-harness.ts:405` | `MouseOptions.clickCount` → `count` |
| `panel-harness.ts:416` | same |

Bundled Chrome moves **148 → 150**.

## What the stealth validation actually found

The stealth metadata is derived from whichever Chrome puppeteer bundles, so I extracted the derivation into pure modules to assert it without a browser:

- `browser-user-agent.ts` — `deriveUserAgentOverride(rawUserAgent, browserVersion)`
- `browser-stealth.ts` — `STEALTH_SCRIPTS` + `buildStealthBundle({ errorSink })`

Verified a pure refactor: script order and all 23 cached natives identical to the previous inline bundle.

### The brand-list permutation really does move

Chromium seeds its GREASE permutation with the major version, so `148 % 6 = 4` and `150 % 6 = 0` pick different orderings *and* different greased spellings:

| | brand list |
|---|---|
| 148 | `Chromium/148`, `Google Chrome/148`, `;Not A Brand/99` |
| 150 | `" Not A;Brand"/99`, `Chromium/150`, `Google Chrome/150` |

All six residues are covered. Tests verified to have teeth via five mutations — pinned permutation, unpermuted grease escapes, dropped `HeadlessChrome` scrub, dropped Linux→Windows rewrite, ignored version fallback — each caught.

### The stealth layer was dead — all fourteen surfaces (#2559)

The bundle's preamble opened with `document.head.appendChild(iframe)`, but it is injected via `Page.addScriptToEvaluateOnNewDocument`, which runs **before any DOM exists**:

```
readyState: "loading"
document.head / body / documentElement: all null
threw: "Cannot read properties of null (reading 'appendChild')"
```

That throw sat *outside* every per-surface `try/catch`, so the IIFE aborted on its first statement — silently, since the surface guards swallow and the preamble had no guard. With and without injection, every observable value was byte-identical, and `navigator.webdriver` stayed `true`.

**Not caused by this bump.** Reproduced identically on puppeteer 24.43.1 / Chrome 148.0.7778.97, i.e. what `main` ships today.

Fixed by caching natives from the current realm: this script runs before any page script, so `globalThis`'s builtins are already pristine — exactly what the iframe was there to provide, and there is no DOM to attach one to.

### Two further defects, invisible while the bundle was dead

| Surface | Defect |
|---|---|
| `09_stealth_locale` | `Intl.DateTimeFormat` was replaced with `class extends`, which throws `Class constructors cannot be invoked without 'new'` on the legacy-callable form real Chrome accepts — breaking ordinary page code. The page-script timezone spoofing is now **removed entirely** in favour of CDP `Emulation.setTimezoneOverride` (see the review section below, which found a second defect in the same code). |
| `03_stealth_botd` | The replaced `permissions.query` was never `toString`-masked, unlike every other patched function. Now `Function_toString.bind(originalQuery)`, the idiom already in `04_stealth_iframe:72` / `13_stealth_worker:64`. |
| `00_stealth_tampering` | Stray duplicate `document.head.removeChild(iframe)`; the bundle owns that element. |

## Verified

| Check | Result |
|---|---|
| `bun run ci:check:full` | **exit 0** |
| Full `coding-agent` suite | **6146 pass, 541 skip, 4 fail** |
| The 4 failures | see **Suite attribution** at the bottom — none reference browser/stealth code, one reproduced on pristine `main` |
| `test/browser/user-agent-override.test.ts` (CI) | **11 pass**, 268 assertions |
| `test/browser/stealth-bundle.test.ts` (CI) | **15 pass** |
| `test/e2e/stealth-user-agent.e2e.test.ts` (local) | **5 pass**, real Chrome 150 |
| All four new files together | **43 pass, 0 fail**, 386 assertions |
| `test/e2e/stealth-surfaces.e2e.test.ts` (local) | **12 pass**, real Chrome 150 |
| `navigator.webdriver` | `undefined` with bundle, `true` without |
| `hardwareConcurrency` | 4 with bundle, 10 without |
| Error sink | empty — no surface throws |

Baseline for the UA assertions was measured, not assumed: an un-overridden Chrome 150 reports `userAgentData.brands === []` with empty platform and version — confirmed on Chrome-for-Testing headless **and** headful, on system Google Chrome 150.0.7871.187, and on a Chrome launched with none of puppeteer's default flags. So the "after" state is a genuine change, not a tautology.

#2417 remains pre-existing and unrelated: reproduced identically on 24.43.1 (same test, same detached-frame error).

## Observability, so this cannot recur silently

`buildStealthBundle` takes an **opt-in** `errorSink` recording `{name, message}` per surface. Opt-in specifically because a permanent `window.__xcsh*` global would itself be a detection surface — production stays silent, tests assert an empty sink.

Two CI-runnable guards back it up: the preamble may reference no `document.head` / `appendChild` / `createElement`, and at least one surface must differ from the un-injected baseline, so a wholly no-op bundle fails loudly instead of passing an all-green suite.

## Known limitation, pinned rather than hidden

The masking installs an own `toString` property, which `Function.prototype.toString.call(fn)` bypasses by design — and that is what real detectors use. Closing it needs a patched `Function.prototype.toString`, which nothing in `src/tools/puppeteer/*.txt` does. A test asserts the **current** behaviour so a future change re-evaluates the gap instead of assuming it is covered.

## Local pre-PR review (advisory, per CLAUDE.md)

`codex:verified-code-review` → `adversarial-review` against `origin/main`. Verdict **needs-attention**, three high-severity findings. All three were checked against a real browser *before* any code changed; two were real and are fixed here, one did not reproduce.

| Finding | Status | Evidence |
|---|---|---|
| iframe `srcdoc` assignments become no-ops | **CONFIRMED, fixed** | With the bundle live: `srcdoc=""`, attribute `null`, content `null`; bare: `LOADED`. The shim froze its own property then assigned through the same element, so the native setter was never reached. |
| Timezone shim corrupts explicit timezone formatting | **CONFIRMED, fixed** | `timeZone:"UTC"` resolved to `America/New_York` and formatted **08:00** where the page asked for **12:00**; `Asia/Tokyo` collapsed the same way. Separately `toString` claimed "Eastern **Standard** Time" in July while `getTimezoneOffset()` returned 240 (EDT). |
| Worker blob wrapping violates common CSP policies | **REFUTED (not reproduced)** | Workers reply normally with the bundle live — `workerReply: "pong:ping"`, identical to baseline, empty error sink. The CSP path was never exercised (the fixture serves no CSP header), so it does not meet the confirmed bar. Filed as #2560 rather than patched on a hypothesis. |

Codex located the first and third findings in `browser-stealth.ts`, which only *lists* the surfaces; the actual defects were in `04_stealth_iframe.txt` and `13_stealth_worker.txt`. Misattributed locations, one real defect.

### How the timezone defect was fixed

Removed the page-script spoofing entirely in favour of CDP `Emulation.setTimezoneOverride`. Chrome then recomputes `Date`, `Intl`, `getTimezoneOffset` and the zone name from the overridden zone, so they agree by construction rather than by patching each one.

Mechanism proven, not assumed — this host is `America/Toronto`, which shares New York's offset, so an offset of 240 would have proved nothing. Overriding to `Asia/Tokyo` as a control:

```
null              offset 240   America/Toronto   08:00 EDT   explicitUTC 12
America/New_York  offset 240   America/New_York  08:00 EDT   explicitUTC 12
Asia/Tokyo        offset -540  Asia/Tokyo        21:00 JST   explicitUTC 12
```

Gate: `findingsClear: true`, `done: true`, no escalation.

## Does activating fourteen surfaces break the web?

Worth asking directly, because both confirmed defects were functional breakage rather than fingerprinting slips, and an empty error sink proves nothing — the per-surface guards swallow.

Smoke-tested 21 behaviours on real Chrome 150 with and without the bundle. Every functional one is identical: `fetch`, XHR, `createElement` (div and iframe), canvas `measureText`/`toDataURL`/`getImageData`, `canPlayType`, offline audio rendering, `localStorage`, `querySelector`, `permissions.query`, `Notification.permission`, screen metrics, `document.fonts`, a WebGL clear (`getError` 0), `toISOString`, `toLocaleString`, `Math.random` variation. The single difference is `devicePixelRatio` 1 → 1.25, an intended spoof.

Ten are now a permanent test. The `toLocaleString` assertion doubles as a consistency check — 15:04 UTC in January is 10:04 in New York (EST) — so it fails if a timezone override moves `Intl` without moving `Date`.

## Suite attribution

The full run shows **6146 pass, 541 skip, 4 fail**. None of the four failing files reference browser, stealth or puppeteer code, and the two runs across this work produced **disjoint** failure sets — they are 5s-timeout-bound tests. `RpcClient.start > rejects when RPC process exits immediately` was reproduced on **pristine `origin/main`**, so it is pre-existing rather than introduced here.
