### PR TITLE
fix(test): wait for an evaluable service worker, not a present target

### DIFF
--- a/packages/coding-agent/test/e2e/extension-e2e.test.ts
+++ b/packages/coding-agent/test/e2e/extension-e2e.test.ts
@@ -138,12 +138,9 @@ describe.skipIf(isCI)("Extension E2E (real Chrome via Puppeteer)", () => {
 			args: [`--host-resolver-rules=MAP ${CONSOLE_HOST} 127.0.0.1:${fx.port}`, "--ignore-certificate-errors"],
 		});
 
-		// 3. Wait for the extension's service worker to start.
-		const swTarget = await browser.waitForTarget(
-			t => t.type() === "service_worker" && t.url().includes("service-worker"),
-			{ timeout: 20_000 },
-		);
-		worker = await swTarget.worker();
+		// 3. Wait for the extension's service worker to start — and to be evaluable,
+		//    not merely present. See acquireLiveWorker.
+		worker = await acquireLiveWorker(20_000);
 
 		// 4. Wait for the bridge connection (SW → native host → xcsh socket).
 		const deadline = Date.now() + 30_000;
@@ -172,6 +169,44 @@ describe.skipIf(isCI)("Extension E2E (real Chrome via Puppeteer)", () => {
 	}, 15_000);
 
 	// --- Helpers ---
+
+	/**
+	 * Acquire a service-worker handle that can actually be evaluated in.
+	 *
+	 * `browser.waitForTarget()` resolves IMMEDIATELY when a matching target
+	 * already exists — and after `worker.close()` the terminated service-worker
+	 * target lingers in the target list while detached. So waiting on target
+	 * presence hands back the dead handle, and the first `evaluate()` throws
+	 * "Execution context is not available in detached frame or worker" (#2417).
+	 *
+	 * Target presence is the wrong signal. The property we actually depend on is
+	 * a live execution context, so probe for exactly that: re-resolve the target
+	 * and attempt a trivial evaluate, retrying until one succeeds. This is a
+	 * correctness wait, not a latency tweak — a longer sleep cannot fix it,
+	 * because the stale handle never becomes usable no matter how long we wait.
+	 */
+	async function acquireLiveWorker(timeoutMs = 30_000): Promise<WebWorker> {
+		const deadline = Date.now() + timeoutMs;
+		let lastError: unknown;
+		while (Date.now() < deadline) {
+			try {
+				const target = await browser.waitForTarget(
+					t => t.type() === "service_worker" && t.url().includes("service-worker"),
+					{ timeout: Math.max(1_000, deadline - Date.now()) },
+				);
+				const candidate = await target.worker();
+				if (candidate) {
+					// The probe IS the readiness check: a detached worker throws here.
+					await candidate.evaluate(() => true);
+					return candidate;
+				}
+			} catch (error) {
+				lastError = error;
+			}
+			await sleep(250);
+		}
+		throw new Error(`no evaluable service worker within ${timeoutMs}ms; last error: ${String(lastError)}`);
+	}
 
 	// Pick a tab id to bind to. Prefer a real http(s) tab (the console the tools
 	// operate on); fall back to the last tab that exists.
@@ -349,11 +384,9 @@ describe.skipIf(isCI)("Extension E2E (real Chrome via Puppeteer)", () => {
 
 			// Re-acquire the worker handle FIRST — the old one is detached after
 			// close(), and ensureBound() calls worker.evaluate() to read the tab id.
-			const swTarget = await browser.waitForTarget(
-				t => t.type() === "service_worker" && t.url().includes("service-worker"),
-				{ timeout: 15_000 },
-			);
-			worker = await swTarget.worker();
+			// Must wait for an *evaluable* worker, not merely a present target: the
+			// terminated target lingers detached and would be returned instantly.
+			worker = await acquireLiveWorker();
 
 			// The reconnected port is a fresh socket with no tab correlation; re-assert
 			// the binding (as the session manager would) before pinging.


### PR DESCRIPTION
Closes #2417.

## Cause

`browser.waitForTarget()` resolves **immediately** when a matching target already exists. After `worker.close()` the terminated service-worker target lingers in the target list while detached — so the re-acquisition was handed the dead handle, and the first `evaluate()` threw:

```
Execution context is not available in detached frame or worker
"chrome-extension://…/service-worker.js"
  at currentTabId  (extension-e2e.test.ts:179)
  at ensureBound   (extension-e2e.test.ts:212)
```

The existing comment already said to re-acquire the handle first. The mechanism just never verified the worker it got back was alive — **target presence was the wrong signal**.

## Fix

`acquireLiveWorker()` polls until a service-worker target yields a handle that can actually be evaluated in. The probe **is** the readiness check, since a detached worker throws on `evaluate()`.

Applied to both the post-termination re-acquisition and the initial startup acquisition — the latter had the same latent race (target present before its context is ready) and duplicated the same `waitForTarget` block.

**This is a correctness fix, not a timing tweak.** The stale handle never becomes usable, so a longer wait on the old approach fails just as reliably, only later. That distinction is why the fix waits on a *signal* rather than a duration.

## Measured, because a handful of green runs would prove nothing

| | Result |
|---|---|
| Baseline — unmodified `main`, isolated | **1 fail / 5 runs** (~20%) |
| With the fix | **0 fail / 20 runs** |

At the baseline rate, 20 clean runs has probability 0.8²⁰ ≈ **1.2%**.

The run count is deliberate: at ~20% failure, *five* clean runs would be 33% likely by chance — worthless as evidence. This is the same trap that produced a wrong fix on #2352 earlier, where raising the wrong budget "worked" for one run.

`bun run ci:check:full` → exit 0. Diff is one file.

## Correcting my own claim on #2417

I wrote there that this "reproduces **reliably** — twice in a row — when the E2E file is run on its own." That was wrong: it was two failures in the puppeteer worktree, and on `main` the very next isolated run passed 16/16. I generalised from n=2. The real rate is ~1 in 5, which is exactly why the baseline had to be measured before claiming a fix.

## Still true, and the bigger issue

This file is `describe.skipIf(isCI)` and `XCSH_VISUAL` appears zero times in `ci.yml`, so **none of this runs in CI** — the measurements above are the only gate it has. Whether the Puppeteer E2E block should run somewhere (nightly, or a Chrome-enabled runner) remains open and is worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)