### PR TITLE
fix(test): make a waitForPort timeout explain itself instead of asserting null

### DIFF
--- a/packages/coding-agent/test/manager-wait-diagnostics.test.ts
+++ b/packages/coding-agent/test/manager-wait-diagnostics.test.ts
@@ -1,0 +1,70 @@
+/**
+ * What a `waitForPort` timeout is allowed to tell you (#2423).
+ *
+ * The manager integration test used to fail as a bare `expect(port).not.toBeNull()`,
+ * which says a port never appeared and nothing about why. #2418 read that silence as
+ * impatience and raised the budget 8s → 30s; the symptom then reappeared just past
+ * the raised budget, and there was still no way to tell "the spare was never spawned"
+ * from "adoption happened, late" from "adoption happened for a different session".
+ * Raising the number again would keep that ambiguity, so the timeout now has to
+ * explain itself. This is the pure part of that, so it is testable without waiting.
+ */
+import { describe, expect, test } from "bun:test";
+import { describeWaitFailure } from "./manager-wait-diagnostics";
+
+const PATTERN = /adopted spare pid \d+ on port (\d+) as tab-7 \(/;
+
+describe("describeWaitFailure", () => {
+	test("names the pattern and the exhausted budget", () => {
+		const msg = describeWaitFailure({ pattern: PATTERN, tries: 300, intervalMs: 100, stderr: "" });
+		expect(msg).toContain(String(PATTERN));
+		// The budget must appear as a duration, not only as a poll count — 300 tries
+		// means nothing to someone reading CI output for the first time.
+		expect(msg).toContain("300 tries");
+		expect(msg).toContain("30000ms");
+	});
+
+	test("an empty stderr is called out as the manager never logging at all", () => {
+		const msg = describeWaitFailure({ pattern: PATTERN, tries: 2, intervalMs: 100, stderr: "" });
+		expect(msg).toContain("captured no stderr");
+	});
+
+	test("reports that no spare was ever pre-warmed", () => {
+		const stderr = "[xcsh manager] listening on /tmp/x.sock\n[xcsh manager] pool target 0\n";
+		const msg = describeWaitFailure({ pattern: PATTERN, tries: 2, intervalMs: 100, stderr });
+		expect(msg).toContain("spares pre-warmed: 0");
+	});
+
+	test("counts pre-warmed spares, so 'never spawned' is distinguishable from 'never adopted'", () => {
+		const stderr = [
+			"[xcsh manager] pre-warmed spare → pid 11 on port 19222",
+			"[xcsh manager] pre-warmed spare → pid 12 on port 19223",
+		].join("\n");
+		const msg = describeWaitFailure({ pattern: PATTERN, tries: 2, intervalMs: 100, stderr });
+		expect(msg).toContain("spares pre-warmed: 2");
+		expect(msg).toContain("adoptions logged: 0");
+	});
+
+	test("an adoption for a DIFFERENT session is surfaced rather than looking like no adoption", () => {
+		// The wait is keyed to tab-7; an adoption as tab-999 never matches the pattern,
+		// and reading "adoptions logged: 0" would send the next person hunting the pool.
+		const stderr = "[xcsh manager] adopted spare pid 11 on port 19222 as tab-999 (handoff)";
+		const msg = describeWaitFailure({ pattern: PATTERN, tries: 2, intervalMs: 100, stderr });
+		expect(msg).toContain("adoptions logged: 1");
+		expect(msg).toContain("tab-999");
+	});
+
+	test("keeps the tail of stderr, which is where a late line would show", () => {
+		const lines = Array.from({ length: 60 }, (_, i) => `line-${i}`);
+		const msg = describeWaitFailure({
+			pattern: PATTERN,
+			tries: 2,
+			intervalMs: 100,
+			stderr: lines.join("\n"),
+		});
+		expect(msg).toContain("line-59");
+		// Bounded: a 60-line dump in a CI log buries the finding it is meant to expose.
+		expect(msg).not.toContain("line-0\n");
+		expect(msg).toContain("earlier lines omitted");
+	});
+});

--- a/packages/coding-agent/test/manager-wait-diagnostics.ts
+++ b/packages/coding-agent/test/manager-wait-diagnostics.ts
@@ -1,0 +1,74 @@
+/**
+ * Why a `waitForPort` poll ended empty (#2423).
+ *
+ * `manager.int.test.ts` waits for a "on port <N>" line in the manager's stderr. When
+ * that line never arrives the test used to fail as `expect(port).not.toBeNull()` — a
+ * bare "it was null", carrying none of the stderr the helper had just spent 30s
+ * reading. #2418 read that silence as impatience and raised the budget 8s → 30s. The
+ * symptom returned just past the raised budget, which is the point at which "wait
+ * longer" stops being a diagnosis: the same failure is also produced by a spare that
+ * was never spawned, and by an adoption that fired for a different session id.
+ *
+ * So the timeout explains itself instead. The census below is deliberately about
+ * DISTINGUISHING those cases, not about proving any one of them:
+ *
+ *   spares pre-warmed: 0   adoptions logged: 0  → the pool never filled
+ *   spares pre-warmed: 2   adoptions logged: 0  → spares exist, adoption never ran
+ *   spares pre-warmed: 2   adoptions logged: 1  → adoption ran, for another session
+ *                                                 (or later than the budget allowed)
+ *
+ * Kept as a pure function so it can be tested against synthetic stderr in
+ * milliseconds; asserting on it through the real helper would cost a 30s wait per
+ * case. Same reasoning as extracting any other diagnostic that a test cannot reach.
+ */
+
+/** The manager's pre-warm log: `[xcsh manager] pre-warmed spare → pid 11 on port 19222`. */
+const SPARE_SPAWNED = /pre-warmed spare →/g;
+/** The manager's adoption log: `... adopted spare pid 11 on port 19222 as tab-7 (...)`. */
+const SPARE_ADOPTED = /adopted spare pid \d+ on port \d+ as \S+/g;
+
+/** How many trailing stderr lines to quote. Enough to hold a late line, few enough to read. */
+const TAIL_LINES = 25;
+
+export interface WaitFailure {
+	/** The regex the helper was polling for. */
+	readonly pattern: RegExp;
+	/** Polls attempted before giving up. */
+	readonly tries: number;
+	/** Delay between polls, in ms. */
+	readonly intervalMs: number;
+	/** Everything captured from the manager's stderr so far. */
+	readonly stderr: string;
+}
+
+/**
+ * A failure message that says what was awaited, for how long, and what the manager
+ * actually reported — enough to classify the next occurrence without re-running it.
+ */
+export function describeWaitFailure({ pattern, tries, intervalMs, stderr }: WaitFailure): string {
+	const spares = stderr.match(SPARE_SPAWNED)?.length ?? 0;
+	const adoptions = stderr.match(SPARE_ADOPTED) ?? [];
+
+	const lines = [
+		`waitForPort never matched ${String(pattern)}`,
+		`  budget exhausted: ${tries} tries x ${intervalMs}ms = ${tries * intervalMs}ms`,
+		`  spares pre-warmed: ${spares}   adoptions logged: ${adoptions.length}`,
+	];
+
+	// Quote the adoption lines verbatim: an adoption for a different session id is
+	// invisible in the counts and is otherwise indistinguishable from no adoption.
+	for (const adoption of adoptions) lines.push(`  adopted: ${adoption.trim()}`);
+
+	if (stderr.trim() === "") {
+		lines.push("  the manager captured no stderr — it may not have started");
+		return lines.join("\n");
+	}
+
+	const all = stderr.split("\n");
+	const tail = all.slice(-TAIL_LINES);
+	if (all.length > tail.length) lines.push(`  ... ${all.length - tail.length} earlier lines omitted`);
+	lines.push("  manager stderr (tail):");
+	for (const line of tail) lines.push(`    ${line}`);
+
+	return lines.join("\n");
+}

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -16,6 +16,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { VERSION } from "@f5-sales-demo/pi-utils";
 import { PROBE_ORIGIN, probe } from "./helpers/bridge-probe";
+import { describeWaitFailure } from "./manager-wait-diagnostics";
 
 let mgr: import("bun").Subprocess | undefined;
 // A SECOND manager on the same socket (single-manager-invariant test). It is
@@ -243,14 +244,21 @@ function count(s: string, sub: string): number {
  * These are correctness waits, not latency assertions — the tests assert that a
  * log line eventually appears, never that it appears quickly. The enclosing tests
  * allow 60_000 ms, so 30s still fails well short of the test timeout on a real hang.
+ *
+ * On exhaustion this THROWS with a census of what the manager actually logged rather
+ * than returning null for `expect(port).not.toBeNull()` to report. A bare "it was
+ * null" is what made #2352 look like impatience and #2423 look like a repeat of it:
+ * the same symptom is produced by a spare that never spawned, an adoption that never
+ * ran, and an adoption that ran for another session id. See manager-wait-diagnostics.
  */
-async function waitForPort(getErr: () => string, re: RegExp, tries = 300): Promise<number | null> {
+async function waitForPort(getErr: () => string, re: RegExp, tries = 300): Promise<number> {
+	const intervalMs = 100;
 	for (let i = 0; i < tries; i++) {
 		const m = getErr().match(re);
 		if (m) return Number(m[1]);
-		await Bun.sleep(100);
+		await Bun.sleep(intervalMs);
 	}
-	return null;
+	throw new Error(describeWaitFailure({ pattern: re, tries, intervalMs, stderr: getErr() }));
 }
 
 /**
@@ -417,7 +425,6 @@ test("superseded shutdown LEAVES bound workers alive for re-adoption; manual rea
 	// probe (findTenant) that depends on context-activation timing under CI load —
 	// the exact source of the ~50% CI flake at this line.
 	const port = await waitForPort(getErr, /adopted spare pid \d+ on port (\d+) as tab-7 \(/);
-	expect(port).not.toBeNull();
 
 	// Handoff reason → the worker's bridge must SURVIVE the manager exit (the
 	// successor will re-adopt it), so its port keeps answering the handshake.
@@ -437,7 +444,7 @@ test("superseded shutdown LEAVES bound workers alive for re-adoption; manual rea
 	let survived = false;
 	for (let i = 0; i < 10; i++) {
 		try {
-			if ((await probe(port as number)).tenant === "acme") {
+			if ((await probe(port)).tenant === "acme") {
 				survived = true;
 				break;
 			}
@@ -449,7 +456,7 @@ test("superseded shutdown LEAVES bound workers alive for re-adoption; manual rea
 	expect(survived).toBe(true); // zero-downtime: the worker outlived its manager
 
 	// Clean it up (no successor in this test) — SIGTERM the surviving worker's port.
-	for (const pid of await pidsOnPort(port as number)) {
+	for (const pid of await pidsOnPort(port)) {
 		try {
 			process.kill(pid);
 		} catch {
@@ -736,9 +743,8 @@ test("cold spawn emits manager_provision + worker_boot spans with cold=true", as
 	const getErr = await startManagerWithPool("0"); // no spares -> cold spawn
 	await send({ type: "provision", sessionId: "tab-501", tenant: "acme|production" });
 	const port = await waitForPort(getErr, /provisioned tab-501 .* on port (\d+)/);
-	expect(port).not.toBeNull();
 
-	const spans = await collectSpans(port as number, 2, SPAN_COLLECT_TIMEOUT_MS);
+	const spans = await collectSpans(port, 2, SPAN_COLLECT_TIMEOUT_MS);
 	const byStage = Object.fromEntries(spans.map(s => [String(s.stage), s]));
 	expect(byStage.manager_provision).toBeDefined(); // NOTE: ~0ms by construction; assert presence, NOT a duration
 	expect(byStage.worker_boot).toBeDefined();
@@ -751,12 +757,11 @@ test("warm adopt emits worker_boot span with cold=false", async () => {
 	const getErr = await startManagerWithPool("1"); // one warm spare -> adopt
 	await send({ type: "provision", sessionId: "tab-777", tenant: "acme|production" });
 	const port = await waitForPort(getErr, /adopted spare pid \d+ on port (\d+) as tab-777/);
-	expect(port).not.toBeNull();
 
 	// The wait must cover activateTenantContext, which runs inside the bind closure
 	// AFTER the "adopted" log is printed — so the port is known well before the
 	// spans are flushed. See SPAN_COLLECT_TIMEOUT_MS.
-	const spans = await collectSpans(port as number, 2, SPAN_COLLECT_TIMEOUT_MS);
+	const spans = await collectSpans(port, 2, SPAN_COLLECT_TIMEOUT_MS);
 	const wb = spans.find(s => s.stage === "worker_boot");
 	expect(wb).toBeDefined();
 	expect(wb!.cold).toBe(false);


### PR DESCRIPTION
## Problem

`waitForPort` in `manager.int.test.ts` failed as a bare `expect(port).not.toBeNull()`, throwing away the 30s of manager stderr the helper had just finished reading.

That silence is what made #2352 look like impatience. #2418 raised the budget 8s → 30s on five observations clustered at ~8.8s — a reasonable read. Then the symptom returned **just past the raised budget** (#2423, failing at 31122ms). At that point "wait longer" stops being a diagnosis, because one assertion covers three different causes:

| stderr says | actual cause |
|---|---|
| `spares pre-warmed: 0   adoptions logged: 0` | the pool never filled |
| `spares pre-warmed: 2   adoptions logged: 0` | spares exist, adoption never ran |
| `spares pre-warmed: 2   adoptions logged: 1` | adoption ran — for another session, or later than the budget |

## Change

`waitForPort` now returns `number` and **throws a census** on exhaustion: what it awaited, the budget as a duration, the spare/adoption counts, each adoption line verbatim, and a bounded tail of stderr.

**Deliberately no budget change.** The issue's own suggestion was to capture *why* the wait ends empty rather than raise the number again, and raising it would preserve exactly the ambiguity above.

The message builder is a pure function in `test/manager-wait-diagnostics.ts` so it can be tested against synthetic stderr in **36ms**; asserting it through the real helper would cost a 30s wait per case. Six tests cover the three-way discrimination, including an adoption for a *different* session id — the case the counts alone would hide.

Because the helper now throws, the three `expect(port).not.toBeNull()` guards after it and their `port as number` casts are dead and removed. The four `findTenant` guards stay — that helper genuinely can return null.

## Verification

Forced the wait to miss against a **real** manager, which produced:

```
waitForPort never matched /adopted spare pid \d+ on port (\d+) as tab-NEVER/
  budget exhausted: 20 tries x 100ms = 2000ms
  spares pre-warmed: 2   adoptions logged: 1
  adopted: adopted spare pid 90735 on port 19222 as tab-777
  manager stderr (tail):
    [xcsh manager] pre-warmed spare → pid 90735 on port 19222
    [xcsh manager] pre-warmed spare → pid 90740 on port 19223
    [xcsh manager] adopted spare pid 90735 on port 19222 as tab-777 (acme|production)
```

That last line is the whole point: it says adoption *did* run, for `tab-777`, which the old failure could not distinguish from the pool never filling.

Also: 6/6 unit tests, the target `warm adopt` test passes, `bun run check` clean, local codex review 0 findings (gate `done: true`).

## What this does NOT claim

It does not fix the flake, and it does not assert #2418 was wrong.

Worth recording honestly: `manager.int.test.ts` is flaky in **full-file** runs on this machine independent of this change — clean `origin/main` failed **2 of 18** in a full-file run (`a second manager on the same socket…`, `a worker that dies out of band…`), while this branch failed **1**, and both passed in isolation. One of those failures was an `ESRCH` from `process.kill` racing a worker that had already exited — an inherent race in a test this PR does not touch.

That contention is consistent with the alternative explanation #2423 recorded, and it is precisely why this change adds diagnostics instead of claiming a root cause. The next real occurrence will now say which of the three causes it was.

Closes #2464

Refs #2423 — that issue stays OPEN. This PR does not fix the flake; it makes the next
occurrence classifiable. Closing #2423 would claim a fix that has not been demonstrated.