### PR TITLE
fix(test): root-cause the manager.int flake — 35% to 0% over 20 runs

### DIFF
--- a/packages/coding-agent/test/helpers/manager-waits.ts
+++ b/packages/coding-agent/test/helpers/manager-waits.ts
@@ -1,0 +1,122 @@
+/**
+ * The manager integration test's SPAN wait (#2364).
+ *
+ * Extracted from `manager.int.test.ts` so its semantics can be tested directly
+ * (`manager-waits.test.ts`) instead of only through a 60s integration test that
+ * reproduces its own defects a few percent of the time.
+ *
+ * The rule it exists to enforce: **wait on the post-condition, never on a proxy
+ * for it** — the same rule behind #2326 and #2331. `collectSpans` waits for the
+ * span STAGES the caller asserts on. It used to wait for a COUNT of spans of any
+ * stage, so a run in which unrelated spans arrived first returned "successfully"
+ * with the wrong set. No budget can fix that, because the wait was never watching
+ * for the thing it was supposed to produce.
+ *
+ * The port wait's counterpart lives in `../manager-wait-diagnostics.ts`; this
+ * module reuses its manager census rather than growing a second one.
+ */
+import { describeManagerCensus } from "../manager-wait-diagnostics";
+import { PROBE_ORIGIN } from "./bridge-probe";
+
+/** A `span` frame flushed by a worker to its first client. */
+export type SpanFrame = Record<string, unknown>;
+
+/** Which of `required` never arrived in `collected`. */
+export function missingStages(collected: readonly SpanFrame[], required: readonly string[]): string[] {
+	return required.filter(stage => !collected.some(s => s.stage === stage));
+}
+
+/**
+ * Connect ONE persistent client (extension Origin) as the worker's first client and
+ * collect `span` frames flushed on connect, returning once every stage in
+ * `required` has arrived. Retries the CONNECT until the (freshly cold-spawned)
+ * worker has bound its port — a refused attempt never opens, so it does not
+ * consume the on-connect flush; only a successful open becomes the first client.
+ * onmessage is attached synchronously so an immediate flush is not missed.
+ *
+ * On a spent budget it returns whatever arrived, so the caller can report which
+ * stages were missing; `requireSpans` does that for you.
+ */
+export async function collectSpans(port: number, required: readonly string[], timeoutMs: number): Promise<SpanFrame[]> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const result = await new Promise<SpanFrame[] | null>(resolve => {
+			const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+				headers: { Origin: PROBE_ORIGIN },
+			} as unknown as string[]);
+			const collected: SpanFrame[] = [];
+			let opened = false;
+			const timer = setTimeout(
+				() => {
+					try {
+						ws.close();
+					} catch {}
+					resolve(opened ? collected : null);
+				},
+				Math.max(0, deadline - Date.now()),
+			);
+			ws.onopen = () => {
+				opened = true;
+				ws.send(JSON.stringify({ type: "hello" }));
+			};
+			ws.onmessage = ev => {
+				const m = JSON.parse(String(ev.data)) as SpanFrame;
+				if (m.type !== "span") return;
+				collected.push(m);
+				// Wait on the post-condition — every stage the caller asserts on —
+				// never on a count of spans of any stage (#2364).
+				if (missingStages(collected, required).length > 0) return;
+				clearTimeout(timer);
+				try {
+					ws.close();
+				} catch {}
+				resolve(collected);
+			};
+			ws.onerror = () => {
+				clearTimeout(timer);
+				try {
+					ws.close();
+				} catch {}
+				// If we had already opened (and thus consumed the worker's first-client
+				// flush), return whatever we collected rather than retrying a second
+				// client that would receive nothing; only a never-opened attempt retries.
+				resolve(opened ? collected : null);
+			};
+			ws.onclose = () => {
+				if (!opened) {
+					clearTimeout(timer);
+					resolve(null);
+				}
+			};
+		});
+		if (result !== null) return result; // opened (first client); return whatever was collected
+		await Bun.sleep(150); // worker not listening yet — retry the connect (no client was established)
+	}
+	return [];
+}
+
+/**
+ * `collectSpans`, but missing stages throw naming exactly what never arrived
+ * instead of an opaque `expect(undefined).toBeDefined()` downstream (#2364).
+ * Same principle as `waitForPort` throwing a census instead of returning null.
+ */
+export async function requireSpans(
+	port: number,
+	required: readonly string[],
+	timeoutMs: number,
+	getErr: () => string,
+): Promise<SpanFrame[]> {
+	const started = Date.now();
+	const spans = await collectSpans(port, required, timeoutMs);
+	const missing = missingStages(spans, required);
+	if (missing.length === 0) return spans;
+	const arrived = spans.map(s => String(s.stage));
+	throw new Error(
+		[
+			`span stage(s) [${required.join(", ")}] never arrived on port ${port} within ${Date.now() - started}ms`,
+			`  missing: ${missing.join(", ")}`,
+			`  arrived: ${arrived.length > 0 ? arrived.join(", ") : "(no spans at all)"} (${spans.length} span${spans.length === 1 ? "" : "s"})`,
+			...describeManagerCensus(getErr()),
+		].join("\n"),
+	);
+}

--- a/packages/coding-agent/test/manager-wait-diagnostics.ts
+++ b/packages/coding-agent/test/manager-wait-diagnostics.ts
@@ -42,18 +42,19 @@ export interface WaitFailure {
 }
 
 /**
- * A failure message that says what was awaited, for how long, and what the manager
- * actually reported — enough to classify the next occurrence without re-running it.
+ * What the manager actually reported, as message lines.
+ *
+ * Split out from {@link describeWaitFailure} because the port wait is not the only
+ * wait in this file that can end empty and need the same census: the span wait
+ * (`requireSpans`, see helpers/manager-waits.ts) and the worker-survival poll both
+ * fail for reasons the manager's own log explains. Each caller supplies its own
+ * heading and appends this; there is one census implementation, not three.
  */
-export function describeWaitFailure({ pattern, tries, intervalMs, stderr }: WaitFailure): string {
+export function describeManagerCensus(stderr: string): string[] {
 	const spares = stderr.match(SPARE_SPAWNED)?.length ?? 0;
 	const adoptions = stderr.match(SPARE_ADOPTED) ?? [];
 
-	const lines = [
-		`waitForPort never matched ${String(pattern)}`,
-		`  budget exhausted: ${tries} tries x ${intervalMs}ms = ${tries * intervalMs}ms`,
-		`  spares pre-warmed: ${spares}   adoptions logged: ${adoptions.length}`,
-	];
+	const lines = [`  spares pre-warmed: ${spares}   adoptions logged: ${adoptions.length}`];
 
 	// Quote the adoption lines verbatim: an adoption for a different session id is
 	// invisible in the counts and is otherwise indistinguishable from no adoption.
@@ -61,7 +62,7 @@ export function describeWaitFailure({ pattern, tries, intervalMs, stderr }: Wait
 
 	if (stderr.trim() === "") {
 		lines.push("  the manager captured no stderr — it may not have started");
-		return lines.join("\n");
+		return lines;
 	}
 
 	const all = stderr.split("\n");
@@ -70,5 +71,17 @@ export function describeWaitFailure({ pattern, tries, intervalMs, stderr }: Wait
 	lines.push("  manager stderr (tail):");
 	for (const line of tail) lines.push(`    ${line}`);
 
-	return lines.join("\n");
+	return lines;
+}
+
+/**
+ * A failure message that says what was awaited, for how long, and what the manager
+ * actually reported — enough to classify the next occurrence without re-running it.
+ */
+export function describeWaitFailure({ pattern, tries, intervalMs, stderr }: WaitFailure): string {
+	return [
+		`waitForPort never matched ${String(pattern)}`,
+		`  budget exhausted: ${tries} tries x ${intervalMs}ms = ${tries * intervalMs}ms`,
+		...describeManagerCensus(stderr),
+	].join("\n");
 }

--- a/packages/coding-agent/test/manager-waits.test.ts
+++ b/packages/coding-agent/test/manager-waits.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Semantics of the manager integration test's waits (#2364, #2423).
+ *
+ * `manager.int.test.ts` asserts on a SPECIFIC span stage but used to wait on a
+ * COUNT of spans of any stage, so a run in which unrelated spans arrived first
+ * returned "successfully" with the wrong set and failed on an opaque
+ * `expect(undefined).toBeDefined()`. That is a property of the wait helper, not
+ * of the manager, so it is pinned here — deterministically, in milliseconds —
+ * rather than only through a 60s integration test that reproduces it a few
+ * percent of the time.
+ */
+import { describe, expect, test } from "bun:test";
+import { collectSpans, missingStages, requireSpans } from "./helpers/manager-waits";
+
+/**
+ * A stand-in for a worker's span flush: on first client connect, emit `frames`
+ * in order, each after its own delay. Mirrors the real flush shape
+ * (`{ type: "span", stage, ... }`) without needing a manager or a worker.
+ */
+function startSpanServer(frames: Array<{ stage: string; afterMs: number; extra?: object }>): {
+	port: number;
+	stop: () => void;
+} {
+	const server = Bun.serve({
+		port: 0,
+		fetch(req, srv) {
+			if (srv.upgrade(req)) return undefined;
+			return new Response("expected a websocket upgrade", { status: 426 });
+		},
+		websocket: {
+			open(ws) {
+				for (const f of frames) {
+					setTimeout(() => {
+						try {
+							ws.send(JSON.stringify({ type: "span", stage: f.stage, ...f.extra }));
+						} catch {
+							/* client already closed — the wait it was feeding is over */
+						}
+					}, f.afterMs);
+				}
+			},
+			message() {
+				/* the client's `hello` needs no reply for a span flush */
+			},
+		},
+	});
+	return { port: server.port as number, stop: () => server.stop(true) };
+}
+
+describe("collectSpans waits on stages, not on a count (#2364)", () => {
+	test("returns only once EVERY required stage has arrived, even when unrelated spans arrive first", async () => {
+		// Two unrelated spans land immediately; the awaited stage lands later. A
+		// count-based wait (want = 2) returns after the first two and never sees it.
+		const { port, stop } = startSpanServer([
+			{ stage: "manager_provision", afterMs: 0 },
+			{ stage: "tenant_activate", afterMs: 0 },
+			{ stage: "worker_boot", afterMs: 250, extra: { cold: false, sid: "tab-777" } },
+		]);
+		try {
+			const spans = await collectSpans(port, ["worker_boot"], 10_000);
+			const wb = spans.find(s => s.stage === "worker_boot");
+			expect(wb).toBeDefined();
+			expect(wb?.sid).toBe("tab-777");
+		} finally {
+			stop();
+		}
+	});
+
+	test("waits for ALL required stages when more than one is asserted on", async () => {
+		const { port, stop } = startSpanServer([
+			{ stage: "noise_a", afterMs: 0 },
+			{ stage: "noise_b", afterMs: 0 },
+			{ stage: "manager_provision", afterMs: 120 },
+			{ stage: "worker_boot", afterMs: 260, extra: { cold: true, sid: "tab-501" } },
+		]);
+		try {
+			const spans = await collectSpans(port, ["manager_provision", "worker_boot"], 10_000);
+			const stages = spans.map(s => s.stage);
+			expect(stages).toContain("manager_provision");
+			expect(stages).toContain("worker_boot");
+		} finally {
+			stop();
+		}
+	});
+
+	test("returns promptly once the required stages are in, without burning the whole budget", async () => {
+		const { port, stop } = startSpanServer([{ stage: "worker_boot", afterMs: 50 }]);
+		try {
+			const started = Date.now();
+			const spans = await collectSpans(port, ["worker_boot"], 10_000);
+			const elapsed = Date.now() - started;
+			expect(spans.map(s => s.stage)).toContain("worker_boot");
+			expect(elapsed).toBeLessThan(5_000); // not "waited out the deadline"
+		} finally {
+			stop();
+		}
+	});
+
+	test("missingStages names exactly the stages that never arrived", () => {
+		const collected = [{ stage: "manager_provision" }, { stage: "noise" }];
+		expect(missingStages(collected, ["manager_provision"])).toEqual([]);
+		expect(missingStages(collected, ["manager_provision", "worker_boot"])).toEqual(["worker_boot"]);
+		expect(missingStages([], ["worker_boot"])).toEqual(["worker_boot"]);
+	});
+});
+
+describe("a wait that ends empty explains why (#2423)", () => {
+	test("requireSpans names the missing stages, what did arrive, and the manager's progress", async () => {
+		// The awaited stage never arrives; two unrelated ones do.
+		const { port, stop } = startSpanServer([
+			{ stage: "manager_provision", afterMs: 0 },
+			{ stage: "tenant_activate", afterMs: 0 },
+		]);
+		// Real manager format — the census regexes key off the arrow (manager.ts:277).
+		const stderr =
+			"[xcsh manager] pre-warmed spare → pid 4242 on port 19222\n" +
+			"[xcsh manager] pre-warmed spare → pid 4243 on port 19223\n";
+		try {
+			const err = await requireSpans(port, ["worker_boot"], 1_000, () => stderr).then(
+				() => null,
+				(e: Error) => e,
+			);
+			expect(err).toBeInstanceOf(Error);
+			const msg = String(err?.message);
+			expect(msg).toContain("missing: worker_boot");
+			expect(msg).toContain("manager_provision"); // what DID arrive
+			expect(msg).toContain("spares pre-warmed: 2"); // a spare WAS spawned...
+			expect(msg).toContain("adoptions logged: 0"); // ...but was never adopted
+			expect(msg).toContain("pid 4243"); // stderr tail is quoted
+		} finally {
+			stop();
+		}
+	});
+});

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -15,8 +15,9 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { VERSION } from "@f5-sales-demo/pi-utils";
-import { PROBE_ORIGIN, probe } from "./helpers/bridge-probe";
-import { describeWaitFailure } from "./manager-wait-diagnostics";
+import { probe } from "./helpers/bridge-probe";
+import { requireSpans } from "./helpers/manager-waits";
+import { describeManagerCensus, describeWaitFailure } from "./manager-wait-diagnostics";
 
 let mgr: import("bun").Subprocess | undefined;
 // A SECOND manager on the same socket (single-manager-invariant test). It is
@@ -55,6 +56,34 @@ afterEach(async () => {
 				/* already gone */
 			}
 		}
+	}
+	// A kill is not a release. SIGTERM'd bound workers SELF-DRAIN (see killPid in
+	// manager.ts), so without waiting here the next test starts while a worker from
+	// this one still owns a RANGE port — and RANGE is only 4 ports wide. Measured
+	// consequences on origin/main: the cold-spawn span test received
+	// `worker_boot{cold:false, sid:"tab-solo"}`, i.e. the buffered spans of a
+	// leftover worker from an ENTIRELY DIFFERENT test, and the two-tab test found
+	// zero workers because the range was still occupied (#2463). Wait for the ports
+	// to come back, escalating to SIGKILL for anything that will not drain — no test
+	// here asserts on a graceful drain that outlives its own body, so teardown has
+	// no reason to be patient. The SIGTERM above gets one 100ms grace period; a 2s
+	// grace instead cost ~30s per run of this file.
+	for (let i = 0; i < 50; i++) {
+		const held: number[] = [];
+		for (const p of RANGE) if ((await pidsOnPort(p)).length > 0) held.push(p);
+		if (held.length === 0) break;
+		if (i >= 1) {
+			for (const p of held) {
+				for (const pid of await pidsOnPort(p)) {
+					try {
+						process.kill(pid, "SIGKILL");
+					} catch {
+						/* already gone */
+					}
+				}
+			}
+		}
+		await Bun.sleep(100);
 	}
 	if (sock) {
 		try {
@@ -262,86 +291,19 @@ async function waitForPort(getErr: () => string, re: RegExp, tries = 300): Promi
 }
 
 /**
- * Budget for `collectSpans` to observe the spans it is waiting for.
+ * Budget for `requireSpans` to observe the stages it is waiting for.
  *
- * Raised from 8_000 ms defensively, NOT because it was the observed cause — the
- * #2352 flake was `waitForPort`'s 8s poll (see its docs). Both budgets happened
- * to be 8s, which is what made the wrong one look guilty: raising this alone left
- * the failure time unchanged at ~8.84s, which is how the real cause was found.
+ * A correctness wait, not a latency assertion: the tests assert a span eventually
+ * arrives with the right shape, never that it arrives quickly. The spans are
+ * flushed only after `activateTenantContext` completes inside the bind closure,
+ * which runs AFTER the "adopted spare" line is logged, so the gap this must cover
+ * is not bounded by anything the test controls. The enclosing tests allow
+ * 60_000 ms, so this still fails short of the test timeout on a real hang.
  *
- * It is raised anyway because it is the same defect class and would be the next
- * to bite. The spans are flushed only after `activateTenantContext` completes
- * inside the bind closure, which runs AFTER the "adopted spare" line is logged,
- * so the gap this must cover is not bounded by anything the test controls.
- *
- * Like the other waits here this is a correctness wait, not a latency assertion:
- * the tests assert a span eventually arrives with the right shape, never that it
- * arrives quickly. The enclosing tests allow 60_000 ms.
+ * Sizing this budget is NOT what makes the span waits reliable — waiting on the
+ * required STAGES rather than on a span count is (#2364, see helpers/manager-waits.ts).
  */
 const SPAN_COLLECT_TIMEOUT_MS = 30_000;
-
-/** Connect ONE persistent client (extension Origin) as the worker's first client and
- *  collect `span` frames flushed on connect. Retries the CONNECT until the (freshly
- *  cold-spawned) worker has bound its port — a refused attempt never opens, so it does
- *  not consume the on-connect flush; only a successful open becomes the first client.
- *  onmessage is attached synchronously so an immediate flush is not missed. */
-async function collectSpans(port: number, want: number, timeoutMs: number): Promise<Array<Record<string, unknown>>> {
-	const deadline = Date.now() + timeoutMs;
-	while (Date.now() < deadline) {
-		const result = await new Promise<Array<Record<string, unknown>> | null>(resolve => {
-			const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
-				headers: { Origin: PROBE_ORIGIN },
-			} as unknown as string[]);
-			const collected: Array<Record<string, unknown>> = [];
-			let opened = false;
-			const timer = setTimeout(
-				() => {
-					try {
-						ws.close();
-					} catch {}
-					resolve(opened ? collected : null);
-				},
-				Math.max(0, deadline - Date.now()),
-			);
-			ws.onopen = () => {
-				opened = true;
-				ws.send(JSON.stringify({ type: "hello" }));
-			};
-			ws.onmessage = ev => {
-				const m = JSON.parse(String(ev.data)) as Record<string, unknown>;
-				if (m.type === "span") {
-					collected.push(m);
-					if (collected.length >= want) {
-						clearTimeout(timer);
-						try {
-							ws.close();
-						} catch {}
-						resolve(collected);
-					}
-				}
-			};
-			ws.onerror = () => {
-				clearTimeout(timer);
-				try {
-					ws.close();
-				} catch {}
-				// If we had already opened (and thus consumed the worker's first-client
-				// flush), return whatever we collected rather than retrying a second
-				// client that would receive nothing; only a never-opened attempt retries.
-				resolve(opened ? collected : null);
-			};
-			ws.onclose = () => {
-				if (!opened) {
-					clearTimeout(timer);
-					resolve(null);
-				}
-			};
-		});
-		if (result !== null) return result; // opened (first client); return whatever was collected
-		await Bun.sleep(150); // worker not listening yet — retry the connect (no client was established)
-	}
-	return [];
-}
 
 test("adopts a warm spare on provision, then replenishes the pool (XCSH_WORKER_POOL_SIZE=1)", async () => {
 	const getErr = await startManagerWithPool("1");
@@ -442,18 +404,37 @@ test("superseded shutdown LEAVES bound workers alive for re-adoption; manual rea
 	// Poll for survival: the worker's WS bridge should outlive the manager (zero-
 	// downtime re-adoption). Retry a few times under CI load.
 	let survived = false;
+	let lastProbeErr = "(never attempted)";
+	let lastTenant = "(no ack)";
 	for (let i = 0; i < 10; i++) {
 		try {
-			if ((await probe(port)).tenant === "acme") {
+			const ack = await probe(port);
+			lastTenant = String(ack.tenant);
+			if (ack.tenant === "acme") {
 				survived = true;
 				break;
 			}
-		} catch {
-			/* worker bridge momentarily busy */
+		} catch (e) {
+			lastProbeErr = e instanceof Error ? e.message : String(e);
 		}
 		await Bun.sleep(250);
 	}
-	expect(survived).toBe(true); // zero-downtime: the worker outlived its manager
+	// Say WHY the wait ended empty rather than asserting a bare boolean: "the worker
+	// is gone" (nothing holding the port, connection refused) and "the worker is
+	// alive but did not ack in time" are different defects, and `toBe(true)` cannot
+	// tell them apart — the same silence that made #2352 look like impatience.
+	if (!survived) {
+		const holders = await pidsOnPort(port);
+		throw new Error(
+			[
+				`worker did not outlive its manager: no "acme" ack on port ${port} within 10 x 250ms`,
+				`  pids still holding the port: ${holders.length > 0 ? holders.join(", ") : "NONE (the worker is gone)"}`,
+				`  last ack tenant: ${lastTenant}`,
+				`  last probe error: ${lastProbeErr}`,
+				...describeManagerCensus(getErr()),
+			].join("\n"),
+		);
+	}
 
 	// Clean it up (no successor in this test) — SIGTERM the surviving worker's port.
 	for (const pid of await pidsOnPort(port)) {
@@ -744,7 +725,8 @@ test("cold spawn emits manager_provision + worker_boot spans with cold=true", as
 	await send({ type: "provision", sessionId: "tab-501", tenant: "acme|production" });
 	const port = await waitForPort(getErr, /provisioned tab-501 .* on port (\d+)/);
 
-	const spans = await collectSpans(port, 2, SPAN_COLLECT_TIMEOUT_MS);
+	// Wait for the STAGES asserted below, not for a span count (#2364).
+	const spans = await requireSpans(port, ["manager_provision", "worker_boot"], SPAN_COLLECT_TIMEOUT_MS, getErr);
 	const byStage = Object.fromEntries(spans.map(s => [String(s.stage), s]));
 	expect(byStage.manager_provision).toBeDefined(); // NOTE: ~0ms by construction; assert presence, NOT a duration
 	expect(byStage.worker_boot).toBeDefined();
@@ -755,13 +737,28 @@ test("cold spawn emits manager_provision + worker_boot spans with cold=true", as
 
 test("warm adopt emits worker_boot span with cold=false", async () => {
 	const getErr = await startManagerWithPool("1"); // one warm spare -> adopt
+
+	// Establish the PRECONDITION before provisioning: the spare must actually be in
+	// the pool. `adoptSpare` does `pool.shift()` and, on an empty pool, the caller
+	// falls back to `spawnWorker` — a cold spawn that logs "provisioned tab-777"
+	// and NEVER logs "adopted spare … as tab-777". A provision racing the pool fill
+	// therefore waits out the port budget in full, whatever that budget is: the
+	// awaited line is not late, it does not exist in that run. That is the #2352 /
+	// #2423 flake — failures at 8831-8889ms against an 8s budget and at
+	// 31040-31588ms against the raised 30s one, i.e. always ~startup + the whole
+	// budget, which is the signature of a line that never arrives rather than of
+	// impatience. `pool.push` precedes the log (manager.ts), so this line arriving
+	// means the spare is already in the pool. The three sibling adoption tests
+	// above already wait here; this one did not.
+	expect(await waitForStderr(getErr, "pre-warmed spare", 120)).toBe(true);
+
 	await send({ type: "provision", sessionId: "tab-777", tenant: "acme|production" });
 	const port = await waitForPort(getErr, /adopted spare pid \d+ on port (\d+) as tab-777/);
 
 	// The wait must cover activateTenantContext, which runs inside the bind closure
 	// AFTER the "adopted" log is printed — so the port is known well before the
 	// spans are flushed. See SPAN_COLLECT_TIMEOUT_MS.
-	const spans = await collectSpans(port, 2, SPAN_COLLECT_TIMEOUT_MS);
+	const spans = await requireSpans(port, ["worker_boot"], SPAN_COLLECT_TIMEOUT_MS, getErr);
 	const wb = spans.find(s => s.stage === "worker_boot");
 	expect(wb).toBeDefined();
 	expect(wb!.cold).toBe(false);


### PR DESCRIPTION
Fixes #2364
Fixes #2463
Refs #2423

## What was actually wrong

I measured before changing anything: **20 sequential runs of `test/manager.int.test.ts`
alone on `origin/main` @ `95ee4dfa4` failed 7 times — 35% — across three distinct modes.**
Neither open issue described the dominant one, and the mode #2364 described caused none of
the observed failures.

| Mode | Test | Actual assertion | Runs | n |
| ---- | ---- | ---------------- | ---- | - |
| A | warm adopt emits worker_boot span | `expect(port).not.toBeNull()` @ ~31s | 3, 12, 13, 17 | 4 |
| B | cold spawn emits … spans cold=true | `worker_boot.cold`→`false`, `sid`→`"tab-solo"` | 7, 9 | 2 |
| C | one worker PER sessionId | `ports.size`→`0` | 8 | 1 |

### Mode A — the pool-fill race. This is what #2423 was reporting.

`startManagerWithPool` waits only for the socket file to exist, **not** for the pool to
fill. `adoptSpare` does `pool.shift()` and, on an empty pool, `manager.ts:471` falls back to
`spawnWorker` — which logs `provisioned tab-777` and **never** logs
`adopted spare … as tab-777`. When the provision beats the pre-warm, the awaited line does
not exist in that run, so the wait burns its budget in full whatever the budget is.

That is exactly the "fixed deadline" signature #2418 read as impatience: 8831–8889 ms
against an 8 s budget, then 31040–31588 ms against the raised 30 s one — always
≈ startup + the whole budget. #2423 called this correctly ("raising the budget moves the
failure later without removing it").

The three sibling adoption tests in this file already wait for `pre-warmed spare` before
provisioning. This one did not. Now it does — establishing the precondition, not enlarging
the wait. `pool.push` precedes that log line (`manager.ts:271` vs `:277`), so observing it
guarantees the spare is in the pool; the fix is correct by construction, not just
empirically.

### Mode B/C — leaked workers (#2463)

`afterEach` killed by pid but never waited for the ports to be released, and SIGTERM'd bound
workers self-drain. With `RANGE` only four ports wide, one straggler changes what the next
test sees: run 9 received `worker_boot{sid: "tab-solo"}` — a session belonging to an
entirely different test — and run 8 found zero workers because the range was still occupied.
`afterEach` now waits for the post-condition, escalating to SIGKILL after a 100 ms grace (a
2 s grace cost ~30 s per run of this file, so patience here is not free and buys nothing —
no test asserts on a graceful drain that outlives its own body).

### #2364 — real, latent, and not the cause of any observed failure

`collectSpans(port, want, ms)` resolved on a **count** of spans of any stage while both call
sites asserted a **specific** stage. That is a genuine defect and it is fixed here — but it
did not produce any of the 7 baseline failures, so this PR does not claim it as the flake.
Rather than leave that unproven, it is now pinned deterministically: a fake span server that
emits two unrelated stages before `worker_boot` makes the old count-based helper return the
wrong set in **7 ms**, reproducing #2364's exact CI symptom (`Received: undefined`) without
a manager, a worker, or a 60 s timeout.

## Relationship to #2462

#2462 landed while this branch was in validation and independently built the same #2423
diagnostics layer. Rather than ship a second one, this PR **defers to it**:

- My `requirePort` / `describeManagerProgress` are deleted. Upstream's throwing `waitForPort`
  and `describeWaitFailure` do that job, and do it better — quoting adoption lines verbatim
  catches "adopted for a *different* session id", which my marker counts would have hidden.
- `describeManagerCensus` is extracted from `describeWaitFailure` so the span wait and the
  worker-survival poll reuse it instead of growing their own. `describeWaitFailure` now
  composes heading + census; its output is byte-identical and **all six of its tests pass
  unchanged**.

This PR therefore adds only what #2462 deliberately did not attempt — it says so itself:
*"this change adds diagnostics rather than claiming a root cause."* This is the root cause.

## Changes

- **New `test/helpers/manager-waits.ts`** — the span wait, extracted so its semantics are
  testable directly. `collectSpans` waits on required **stages**; `requireSpans` throws
  naming the missing stages, the stages that did arrive, and the manager census.
- **New `test/manager-waits.test.ts`** — 5 sub-second tests over the wait semantics and the
  failure-message contract.
- **`test/manager-wait-diagnostics.ts`** — extract `describeManagerCensus` (no output change).
- **`test/manager.int.test.ts`** — waits for `pre-warmed spare` before the warm-adopt
  provision; `afterEach` waits for RANGE ports to be released; span call sites moved to
  `requireSpans`; the worker-survival poll now reports the pids still holding the port, the
  last ack tenant and the last probe error instead of a bare `expect(survived).toBe(true)`.

No production code changed. No test skipped, weakened, or `.only`/`.skip`-ed.

## Verification

Baseline and validation were run identically — same machine, same command, sequential, one
in a pristine `origin/main` worktree and one on this branch — so the rates are comparable.

| | Baseline (`origin/main` @ `95ee4dfa4`) | This branch (rebased on `4a40d9757`) |
| --- | --- | --- |
| Mode A | 4 | **0** |
| Mode B | 2 | **0** |
| Mode C | 1 | **0** |
| **Total** | **7/20 — 35%** | **0/20** |

P(20 clean runs | rate still 35%) ≈ 1.3e-4. What 20 runs cannot do is prove the rate is
*zero*: a residual ~10% would still show 0/20 about 12% of the time. The claim is that the
three measured modes are gone, not that the file is now provably perfect.

### One caveat, stated plainly

An earlier iteration of this branch — identical except that `afterEach` waited 2 s before
escalating to SIGKILL — failed 2/20 on a **fourth** mode absent from the baseline:
`expect(survived).toBe(true)` in *superseded shutdown LEAVES bound workers alive*. It has not
recurred in 40 subsequent runs. `0/20` vs `2/20` is not statistically distinguishable
(Fisher p ≈ 0.24), so I am neither claiming it was pre-existing nor that I fixed it. It
appeared with the *more patient* cleanup and vanished with the decisive one, which is
consistent with it being another leaked-worker effect (#2463) — a hypothesis, not a result.

What this PR does about it is refuse to leave it un-instrumented: that assertion was a bare
boolean whose retry loop swallowed every probe error, so it could not distinguish "the
worker died" from "the worker is alive but did not ack in 2.5 s". Raising its budget would
have repeated the #2418 mistake.

### Gates

- `bun run ci:check:full` — exit 0
- `bun run test` (full `coding-agent` suite) — 5844 pass, 0 fail, 6385 tests
- `biome check` — clean
