### PR TITLE
feat(office): add_sheet host tool; let the pane read plugin resources

### DIFF
--- a/packages/coding-agent/src/browser/host-profiles.ts
+++ b/packages/coding-agent/src/browser/host-profiles.ts
@@ -94,9 +94,11 @@ SAFETY — NEVER DO THESE:
 const OFFICE_NATIVE_TOOLS_NOTE = `
 NATIVE TOOLS: Beyond the document host tools, you have xcsh's full local toolset — \`bash\` (run shell commands, including CLIs like \`az\`, \`gh\`, \`terraform\`, \`git\` when installed and authenticated), file tools (\`read\`/\`write\`/\`edit\`), and \`grep\` — plus any skills available in this workspace. Reach for them when the task genuinely needs them (pull live data with a CLI, read a local file the user points you at). Prefer the document host tools for document work. Your file tools and shell are confined to the folder xcsh was launched from.
 
-This pane runs NO MCP servers and NO plugin-provided tools — the tools listed above (plus the document host tools) are everything you have. Do not look for, read, or report on plugin/MCP manifests: to use a cloud or SCM CLI, invoke it directly with \`bash\` (e.g. \`az account show\`, \`gh repo view\`). The user sees your narration, so don't describe missing plugins as failures — just use the CLI.
+This pane runs NO MCP servers and exposes NO plugin-provided TOOLS — the tools listed above (plus the document host tools) are everything you can call. To use a cloud or SCM CLI, invoke it directly with \`bash\` (e.g. \`az account show\`, \`gh repo view\`) rather than hunting for an MCP server that would provide it. The user sees your narration, so don't describe a missing MCP tool as a failure — just use the CLI.
 
-SKILLS: When a message begins with \`/<skill-name>\` naming one of your available skills, treat it as a request to USE that skill — read its instructions (open \`skill://<skill-name>\`, or its SKILL.md via \`read\`) and follow them, applying any text after the name as the skill's input.
+Plugin RESOURCES are a different thing and they ARE available to you: an installed plugin's skills, slash commands, schemas, templates and engines. Read them through \`xcsh://plugin/<name>\` (summary), \`xcsh://plugin/<name>/<key>\` (a declared resource such as \`schema\`), or \`xcsh://plugin/<name>/file/<path>\` (any file in the plugin), and run a plugin's engine with \`bash\` (e.g. \`bun xcsh://plugin/<name>/file/engine/cli.ts <command>\`). When a plugin declares a deterministic engine, use it — never recompute by hand what the engine computes.
+
+SKILLS AND SLASH COMMANDS: A message beginning \`/<name>\` names either a slash command (already expanded for you before it arrived — just follow the instructions you were given) or one of your available skills. For a skill, treat it as a request to USE it — read its instructions (open \`skill://<skill-name>\`, or its SKILL.md via \`read\`) and follow them, applying any text after the name as the skill's input. Names from a plugin are prefixed with the plugin, e.g. \`/meddpicc:deal-review\`.
 
 SAFETY:
 - NEVER kill, stop, inspect, or manage the xcsh \`office serve\` process, its bridge ports, or any xcsh process — that bridge IS you; ending it ends the session.
@@ -122,6 +124,7 @@ TOOLS: Discover the workbook before you answer, then reach for the tool that mat
 - Use \`read_table\` for structured Excel Tables (it tracks the real extent), \`get_formulas\` to see the formulas behind cells, \`get_cell_metadata\` for cell types/number formats, and \`read_named_range\` to read a defined name.
 - Use \`sort_filter_table\` to sort or filter a Table by column.
 - Use \`read_range\`/\`write_range\` for arbitrary cell ranges (bare or sheet-qualified like Sheet2!A1:B10), and \`list_sheets\` when you only need the tab names.
+- Use \`add_sheet\` to build a report on its own tab instead of overwriting the user's data. It is idempotent — an existing tab of that name is reused — so add first, then \`write_range\` block by block, and do not read the sheet back to confirm.
 ${OFFICE_NATIVE_TOOLS_NOTE}
 
 BEHAVIOR:

--- a/packages/coding-agent/test/browser/host-profiles.test.ts
+++ b/packages/coding-agent/test/browser/host-profiles.test.ts
@@ -60,6 +60,14 @@ describe("host profiles", () => {
 		}
 	});
 
+	it("excel prompt tells the agent to build reports on their own tab", () => {
+		// Without this the model writes a report over whatever sheet happens to be
+		// active, destroying the user's data to produce it.
+		const t = HOST_PROFILES.excel.systemPrompt;
+		expect(t).toContain("add_sheet");
+		expect(t).toContain("idempotent");
+	});
+
 	it("powerpoint prompt thinks in slides", () => {
 		const t = HOST_PROFILES.powerpoint.systemPrompt;
 		expect(t).toContain("presentation");
@@ -176,10 +184,21 @@ describe("host profiles", () => {
 			expect(prompt).toContain("gh");
 			// …and that its file tools are sandbox-confined to the launch dir.
 			expect(prompt).toContain("confined to the folder");
-			// No-MCP guidance: prevents a wasted turn hunting plugin manifests and the
+			// No-MCP guidance: prevents a wasted turn hunting for an MCP server and the
 			// scary "plugin manifest failed to load" narration in a live demo.
 			expect(prompt).toContain("NO MCP servers");
-			expect(prompt).toMatch(/plugin\/MCP manifests|plugin manifests/);
+			expect(prompt).toContain("NO plugin-provided TOOLS");
+		});
+
+		it(`${host} permits plugin RESOURCES even though plugin TOOLS are absent`, () => {
+			// The earlier wording ("do not look for, read, or report on plugin/MCP
+			// manifests") over-reached: it forbade the very thing an installed plugin
+			// exists to provide. A pane told that cannot read a plugin's schema, run its
+			// engine, or follow its slash command.
+			const prompt = HOST_PROFILES[host].systemPrompt;
+			expect(prompt).toContain("xcsh://plugin/");
+			expect(prompt).toMatch(/Plugin RESOURCES .*ARE available/);
+			expect(prompt).not.toMatch(/[Dd]o not look for, read, or report on plugin/);
 		});
 	}
 });

--- a/packages/office-pane/src/office/excel-tools.ts
+++ b/packages/office-pane/src/office/excel-tools.ts
@@ -79,6 +79,10 @@ export interface ExcelWorksheetCollectionLike {
 	getActiveWorksheet(): ExcelWorksheetLike;
 	/** Look up a worksheet by its tab name (for cross-sheet reads like `Sheet2!A1:B3`). */
 	getItem(name: string): ExcelWorksheetLike;
+	/** Presence probe: resolves to `{ isNullObject: true }` instead of throwing. */
+	getItemOrNullObject(name: string): { isNullObject?: boolean; load(properties: string): void };
+	/** Create a worksheet. Throws `ItemAlreadyExists` on a duplicate tab name. */
+	add(name: string): ExcelWorksheetLike;
 	/** After `load("items")` + `sync()`, the array of all worksheets. */
 	items: ExcelWorksheetLike[];
 	/** Queue a property (e.g. `"items"`) to load on the next `sync()`. */
@@ -117,6 +121,10 @@ export function parseSheetAddress(input: string): { sheet: string | null; range:
 }
 
 /** Resolve a worksheet from the collection: by name if specified, else the active one. */
+/** Excel's own worksheet-name rules, enforced before Office.js can reject them opaquely. */
+const SHEET_NAME_MAX_LENGTH = 31;
+const SHEET_NAME_ILLEGAL_CHARS = /[:\\/?*[\]]/g;
+
 function resolveWorksheet(worksheets: ExcelWorksheetCollectionLike, sheetName: string | null): ExcelWorksheetLike {
 	return sheetName ? worksheets.getItem(sheetName) : worksheets.getActiveWorksheet();
 }
@@ -301,6 +309,58 @@ export function createExcelHostTools(excel: ExcelLike = getExcel()): HostToolReg
 					throw new Error(describeExcelError("write_range", raw, err));
 				}
 				return textResult(`Wrote ${values.length} row(s) to ${raw}.`, { address: raw });
+			},
+		},
+		{
+			definition: {
+				name: "add_sheet",
+				description:
+					"Create a worksheet by name, or report that it already exists. Idempotent: safe to call " +
+					"before writing, and safe to repeat — a re-run overwrites the sheet's cells rather than " +
+					"adding a duplicate tab. Use it to build a report sheet, then fill it with write_range.",
+				parameters: {
+					type: "object",
+					properties: {
+						name: {
+							type: "string",
+							description:
+								"Tab name. Max 31 characters; may not contain : \\ / ? * [ ] or be blank (Excel's rules).",
+						},
+					},
+					required: ["name"],
+				},
+			},
+			handler: async args => {
+				const name = typeof args.name === "string" ? args.name.trim() : "";
+				// Validate here rather than letting Office.js reject it: its InvalidArgument
+				// carries no hint about WHICH rule was broken, and the caller is an LLM that
+				// has to decide what to try next.
+				if (name === "") throw new Error("add_sheet requires a non-empty sheet name");
+				if (name.length > SHEET_NAME_MAX_LENGTH) {
+					throw new Error(
+						`Sheet name is ${name.length} characters; Excel allows at most ${SHEET_NAME_MAX_LENGTH}: "${name}"`,
+					);
+				}
+				const illegal = [...new Set(name.match(SHEET_NAME_ILLEGAL_CHARS) ?? [])];
+				if (illegal.length > 0) {
+					throw new Error(`Sheet name may not contain ${illegal.join(" ")} — Excel rejects it: "${name}"`);
+				}
+
+				try {
+					return await excel.run(async ctx => {
+						const existing = ctx.workbook.worksheets.getItemOrNullObject(name);
+						existing.load("isNullObject");
+						await ctx.sync();
+						if (existing.isNullObject === false) {
+							return textResult(`Sheet "${name}" already exists — writing into it.`, { name, created: false });
+						}
+						ctx.workbook.worksheets.add(name);
+						await ctx.sync();
+						return textResult(`Created sheet "${name}".`, { name, created: true });
+					});
+				} catch (err) {
+					throw new Error(describeExcelError("add_sheet", name, err));
+				}
 			},
 		},
 		{

--- a/packages/office-pane/test/excel-tools.test.ts
+++ b/packages/office-pane/test/excel-tools.test.ts
@@ -74,7 +74,14 @@ function fakeExcel(
 	seed: Record<string, unknown[][]> = {},
 	sheets?: Record<string, Record<string, unknown[][]>>,
 	meta: FakeExcelMeta = {},
-): ExcelLike & { cells: Record<string, unknown[][]>; ops: FakeExcelOps } {
+): ExcelLike & {
+	cells: Record<string, unknown[][]>;
+	ops: FakeExcelOps;
+	/** Tab names currently in the fake workbook, in creation order. */
+	sheetNames(): string[];
+	/** The address→values store for one sheet (asserting cross-sheet writes). */
+	sheetCells(name: string): Record<string, unknown[][]>;
+} {
 	// Backward compat: if `sheets` isn't provided, wrap seed as the sole "Sheet1".
 	const sheetStore: Record<string, Record<string, unknown[][]>> = sheets ?? { Sheet1: { ...seed } };
 	const sheetNames = Object.keys(sheetStore);
@@ -114,6 +121,8 @@ function fakeExcel(
 	return {
 		cells,
 		ops,
+		sheetNames: () => Object.keys(sheetStore),
+		sheetCells: (name: string) => sheetStore[name] ?? {},
 		run: async <T>(batch: (ctx: never) => Promise<T>): Promise<T> => {
 			const makeSheet = (name: string) => {
 				const store = sheetStore[name];
@@ -176,6 +185,19 @@ function fakeExcel(
 					worksheets: {
 						getActiveWorksheet: () => makeSheet(activeName),
 						getItem: (name: string) => makeSheet(name),
+						// Office.js resolves a missing sheet to a null object rather than
+						// throwing, but only after the `isNullObject` load is synced.
+						getItemOrNullObject: (name: string) => ({
+							isNullObject: !(name in sheetStore),
+							load(_props: string): void {
+								/* isNullObject is already resolved above */
+							},
+						}),
+						add: (name: string) => {
+							if (name in sheetStore) throw new Error(`ItemAlreadyExists: ${name}`);
+							sheetStore[name] = {};
+							return makeSheet(name);
+						},
 						items: sheetNames.map(n => makeSheet(n)),
 						load(_props: string): void {
 							/* items already populated */
@@ -225,6 +247,7 @@ function flush(): Promise<void> {
 
 describe("excel-tools", () => {
 	const ALL_TOOL_NAMES = [
+		"add_sheet",
 		"get_cell_metadata",
 		"get_formulas",
 		"get_workbook_info",
@@ -353,17 +376,9 @@ describe("excel-tools", () => {
 
 		onConnected(); // simulates ChatPanel's post-connect hook
 		const frame = t.sent.find(m => m.type === "set_host_tools") as SetHostToolsMsg | undefined;
-		expect(frame?.tools.map(x => x.name).sort()).toEqual([
-			"get_cell_metadata",
-			"get_formulas",
-			"get_workbook_info",
-			"list_sheets",
-			"read_named_range",
-			"read_range",
-			"read_table",
-			"sort_filter_table",
-			"write_range",
-		]);
+		// ALL_TOOL_NAMES, not a second copy of it: this list was duplicated here and went
+		// stale the moment a tool was added.
+		expect(frame?.tools.map(x => x.name).sort()).toEqual(ALL_TOOL_NAMES);
 
 		// A host_tool_call is serviced end-to-end.
 		t.emit({
@@ -764,5 +779,134 @@ describe("parseSheetAddress", () => {
 	});
 	it("handles dotted/numeric sheet names", () => {
 		expect(parseSheetAddress("Data.2024!A1:Z100")).toEqual({ sheet: "Data.2024", range: "A1:Z100" });
+	});
+});
+
+describe("add_sheet", () => {
+	it("creates a worksheet that does not exist yet", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		const excel = fakeExcel({}, { Sheet1: {} });
+		registerExcelTools(d, excel);
+
+		t.emit({
+			type: "host_tool_call",
+			id: "as-1",
+			toolCallId: "tc-as-1",
+			toolName: "add_sheet",
+			arguments: { name: "MEDDPICC — Visa, Inc." },
+		});
+		await flush();
+
+		expect(excel.sheetNames()).toContain("MEDDPICC — Visa, Inc.");
+		expect(firstText(callFrom(t))).toContain("Created");
+		d.dispose();
+	});
+
+	it("is idempotent — re-rendering a deal reuses the sheet instead of adding a second one", async () => {
+		// Office.js `worksheets.add` throws ItemAlreadyExists on a duplicate name, which
+		// would abort a re-render halfway. A second call must be a no-op, so the caller
+		// can always add-then-write.
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		const excel = fakeExcel({}, { Sheet1: {}, Report: {} });
+		registerExcelTools(d, excel);
+
+		t.emit({
+			type: "host_tool_call",
+			id: "as-2",
+			toolCallId: "tc-as-2",
+			toolName: "add_sheet",
+			arguments: { name: "Report" },
+		});
+		await flush();
+
+		expect(excel.sheetNames().filter(n => n === "Report")).toHaveLength(1);
+		expect(firstText(callFrom(t))).toContain("already exists");
+		d.dispose();
+	});
+
+	it("rejects a name Excel cannot accept rather than letting Office.js fail opaquely", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerExcelTools(d, fakeExcel({}, { Sheet1: {} }));
+
+		t.emit({
+			type: "host_tool_call",
+			id: "as-3",
+			toolCallId: "tc-as-3",
+			toolName: "add_sheet",
+			arguments: { name: "a/b:c" },
+		});
+		await flush();
+
+		const reply = callFrom(t);
+		expect(reply?.isError).toBe(true);
+		expect(firstText(reply)).toContain(":");
+		d.dispose();
+	});
+
+	it("rejects an over-long name (Excel's 31-character limit)", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerExcelTools(d, fakeExcel({}, { Sheet1: {} }));
+
+		t.emit({
+			type: "host_tool_call",
+			id: "as-4",
+			toolCallId: "tc-as-4",
+			toolName: "add_sheet",
+			arguments: { name: "x".repeat(32) },
+		});
+		await flush();
+
+		expect(callFrom(t)?.isError).toBe(true);
+		d.dispose();
+	});
+
+	it("rejects an empty name", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerExcelTools(d, fakeExcel({}, { Sheet1: {} }));
+
+		t.emit({
+			type: "host_tool_call",
+			id: "as-5",
+			toolCallId: "tc-as-5",
+			toolName: "add_sheet",
+			arguments: { name: "   " },
+		});
+		await flush();
+
+		expect(callFrom(t)?.isError).toBe(true);
+		d.dispose();
+	});
+
+	it("a newly added sheet is immediately writable by write_range", async () => {
+		// The whole point: `add_sheet` then `write_range` per block, with no read-back.
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		const excel = fakeExcel({}, { Sheet1: {} });
+		registerExcelTools(d, excel);
+
+		t.emit({
+			type: "host_tool_call",
+			id: "as-6",
+			toolCallId: "tc-as-6",
+			toolName: "add_sheet",
+			arguments: { name: "Deal" },
+		});
+		await flush();
+		t.emit({
+			type: "host_tool_call",
+			id: "as-7",
+			toolCallId: "tc-as-7",
+			toolName: "write_range",
+			arguments: { address: "Deal!A1:B1", values: [["Account Name", "Visa, Inc."]] },
+		});
+		await flush();
+
+		expect(excel.sheetCells("Deal")["A1:B1"]).toEqual([["Account Name", "Visa, Inc."]]);
+		d.dispose();
 	});
 });


### PR DESCRIPTION
Closes #2476

## 1. `add_sheet`

The Excel host tools could read and write cells but never create a sheet, and
`write_range` resolves a sheet-qualified address through `worksheets.getItem`, which
throws on an unknown name. An agent asked for a report therefore had exactly one option:
overwrite the active sheet. In a workbook of deal data that destroys the user's data to
produce the report.

`add_sheet` is **idempotent** — an existing tab is reused rather than erroring, so
add-then-write is always safe and re-rendering overwrites instead of piling up
`Report (2)` tabs. Name validation happens before Office.js sees it (31 characters, no
`: \ / ? * [ ]`, non-blank), because Office.js answers a bad name with an
`InvalidArgument` that never says which rule was broken — and the caller deciding what to
try next is a model.

## 2. The prompt forbade using plugins at all

`OFFICE_NATIVE_TOOLS_NOTE` said:

> This pane runs NO MCP servers and NO plugin-provided tools … **Do not look for, read,
> or report on plugin/MCP manifests**

The intent was right — stop the model burning a turn hunting for an MCP server that will
never exist — but the wording banned the category. An installed plugin's schema,
template, engine and slash commands are all reached through `xcsh://plugin/<name>/…`, so
a pane given that instruction must decline to read the MEDDPICC schema it was installed
to use.

Now scoped to executable **TOOLS**, with plugin **RESOURCES** described as available
(`xcsh://plugin/<name>`, `…/<key>`, `…/file/<path>`, and running a declared engine via
`bash`), plus the plugin-prefixed `/<plugin>:<name>` form the old text never mentioned.

## Test hygiene found on the way

- `wireExcelHostTools` asserted against its **own copy** of the tool-name list, which
  went stale the moment a tool was added — three failures from one addition. It now uses
  `ALL_TOOL_NAMES`.
- The prompt test asserted only that the new wording is *present*. A wording change that
  left the old over-broad sentence in place would still have passed, so it now asserts
  the old sentence is **gone**.

## Verification

- 6 new `add_sheet` tests + 2 prompt tests. **Mutation-checked**: removing the
  idempotency check fails the idempotency test (confirmed).
- `packages/office-pane`: 363 pass / 0 fail. `packages/coding-agent`: 5855 pass / 0 fail.
- `bun run check:ts` and `bun run check`: clean.
- Codex `verified-code-review` (`adversarial-review --base origin/main`): **0 findings**.

**Honest note on the full-workspace run.** Running all packages concurrently, one test
fails per run and it is a *different* test each time — 6 `manager.int` timeouts in one
run, `AgentSession … should allow steer()` in the next. Each passes in isolation and both
packages are green run on their own, so this is the parallel-load contention tracked in
**#2423**, not this change. I am not claiming a clean full-workspace run, because I did
not get one.

(Also: `bun test packages/coding-agent/test/manager.int.test.ts` from the workspace root
fails 18/18 — that suite spawns `bun src/cli.ts` with `cwd: process.cwd()`, so it only
works when run from the package directory. My own mis-measurement, recorded here so the
next person does not read it as a regression.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)