### PR TITLE
feat(office): list and expand plugin slash commands in the pane

### DIFF
--- a/packages/coding-agent/src/browser/capabilities.generated.ts
+++ b/packages/coding-agent/src/browser/capabilities.generated.ts
@@ -26,7 +26,7 @@ export interface ExtensionCapabilities {
 
 export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 	"version": "0.1.0",
-	"contractVersion": "1.11.0",
+	"contractVersion": "1.12.0",
 	"multiPortDiscovery": true,
 	"protocol": "tool_request/result",
 	"tools": [
@@ -858,7 +858,11 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 				"host_tool_cancel",
 				"configure",
 				"configure_ack",
-				"configure_error"
+				"configure_error",
+				"list_skills",
+				"skills",
+				"list_commands",
+				"commands"
 			],
 			"description": "User ↔ xcsh chat over the bridge. The extension side panel sends chat_request (with mode and page-context snapshot); xcsh streams chat_delta tokens then a terminal chat_done (with reference links) or chat_error. Chat ids are prefixed \"c-\". Tool calls during a turn use the normal tool_request flow. chat_stop halts a streaming response. chat_tool_notice is emitted by the EXTENSION (the service worker) to the panel as a best-effort UI signal when a tool runs during a turn — it is NOT sent by xcsh; xcsh must not produce it to avoid double-rendering in the panel.",
 			"promptHints": {
@@ -878,6 +882,6 @@ export const EXTENSION_CAPABILITIES: ExtensionCapabilities = {
 	}
 };
 
-export const EXTENSION_CONTRACT_VERSION = "1.11.0";
+export const EXTENSION_CONTRACT_VERSION = "1.12.0";
 
 export const EXTENSION_TOOL_NAMES: readonly string[] = ["ping","capabilities","reload","debug_exec","detach","set_bridge_port","navigate","login","scroll_to","resize_window","tabs_list","tabs_create","tabs_close","click","click_element","click_xy","type_text","form_input","key_press","select_option","label_select","file_upload","read_ax","get_page_text","query_dom","find","wait_for","assert_text","screenshot","read_console","read_network","diag_suspension","diag_bridges","diag_activation","diag_ttft","capture_login_flow","wait_for_api_response","get_page_context","javascript_tool","browser_batch","set_explain_mode","annotate"];

--- a/packages/coding-agent/src/browser/capabilities.json
+++ b/packages/coding-agent/src/browser/capabilities.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "contractVersion": "1.11.0",
+  "contractVersion": "1.12.0",
   "multiPortDiscovery": true,
   "protocol": "tool_request/result",
   "tools": [
@@ -751,7 +751,11 @@
         "host_tool_cancel",
         "configure",
         "configure_ack",
-        "configure_error"
+        "configure_error",
+        "list_skills",
+        "skills",
+        "list_commands",
+        "commands"
       ],
       "description": "User ↔ xcsh chat over the bridge. The extension side panel sends chat_request (with mode and page-context snapshot); xcsh streams chat_delta tokens then a terminal chat_done (with reference links) or chat_error. Chat ids are prefixed \"c-\". Tool calls during a turn use the normal tool_request flow. chat_stop halts a streaming response. chat_tool_notice is emitted by the EXTENSION (the service worker) to the panel as a best-effort UI signal when a tool runs during a turn — it is NOT sent by xcsh; xcsh must not produce it to avoid double-rendering in the panel.",
       "promptHints": {

--- a/packages/coding-agent/src/browser/chat-conformance.json
+++ b/packages/coding-agent/src/browser/chat-conformance.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": "1.11.0",
+  "contractVersion": "1.12.0",
   "schemas": {
     "chat_request": {
       "type": "object",
@@ -599,6 +599,68 @@
           "type": "boolean"
         }
       }
+    },
+    "list_skills": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "const": "list_skills",
+          "type": "string"
+        }
+      }
+    },
+    "skills": {
+      "type": "object",
+      "required": ["type", "skills"],
+      "properties": {
+        "type": {
+          "const": "skills",
+          "type": "string"
+        },
+        "skills": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "description"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "description": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "list_commands": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "const": "list_commands",
+          "type": "string"
+        }
+      }
+    },
+    "commands": {
+      "type": "object",
+      "required": ["type", "commands"],
+      "properties": {
+        "type": {
+          "const": "commands",
+          "type": "string"
+        },
+        "commands": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "description"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "description": { "type": "string" }
+            }
+          }
+        }
+      }
     }
   },
   "examples": {
@@ -814,6 +876,38 @@
         "type": "host_tool_cancel",
         "id": "7295551234567891",
         "targetId": "7295551234567890"
+      },
+      "list_skills": {
+        "type": "list_skills"
+      },
+      "skills": {
+        "type": "skills",
+        "skills": [
+          {
+            "name": "meddpicc:deal-review",
+            "description": "Facilitate a structured weekly MEDDPICC deal review"
+          }
+        ]
+      },
+      "skills_empty": {
+        "type": "skills",
+        "skills": []
+      },
+      "list_commands": {
+        "type": "list_commands"
+      },
+      "commands": {
+        "type": "commands",
+        "commands": [
+          {
+            "name": "meddpicc:qualify-deal",
+            "description": "Score and qualify a deal using the MEDDPICC framework"
+          }
+        ]
+      },
+      "commands_empty": {
+        "type": "commands",
+        "commands": []
       }
     },
     "invalid": [
@@ -1013,6 +1107,51 @@
         "value": {
           "type": "configure",
           "token": ""
+        }
+      },
+      {
+        "schema": "commands",
+        "why": "commands must be an array, not a name-keyed map",
+        "value": {
+          "type": "commands",
+          "commands": {
+            "meddpicc:qualify-deal": "Score and qualify a deal"
+          }
+        }
+      },
+      {
+        "schema": "commands",
+        "why": "an entry with no description has nothing to render in the menu",
+        "value": {
+          "type": "commands",
+          "commands": [
+            {
+              "name": "meddpicc:qualify-deal"
+            }
+          ]
+        }
+      },
+      {
+        "schema": "commands",
+        "why": "an entry with an empty name cannot be sent back as a prompt",
+        "value": {
+          "type": "commands",
+          "commands": [
+            {
+              "name": "",
+              "description": "Score and qualify a deal"
+            }
+          ]
+        }
+      },
+      {
+        "schema": "skills",
+        "why": "skills must be an array, not a name-keyed map",
+        "value": {
+          "type": "skills",
+          "skills": {
+            "meddpicc:coach": "MEDDPICC coaching"
+          }
         }
       }
     ]

--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -4,6 +4,7 @@ import type { AssistantMessage, ImageContent } from "@f5-sales-demo/pi-ai";
 import { settings } from "../config/settings";
 import { DEFAULT_MODEL_ROLE } from "../config/settings-schema";
 import { toSkillSummaries } from "../extensibility/skills";
+import { expandSlashCommand, toSlashCommandSummaries } from "../extensibility/slash-commands";
 import {
 	isRpcHostToolResult,
 	isRpcHostToolUpdate,
@@ -28,6 +29,7 @@ import {
 	isChatRequest,
 	isChatStop,
 	isConfigure,
+	isListCommands,
 	isListSkills,
 	isSetHostTools,
 	type PageContextSnapshot,
@@ -35,6 +37,7 @@ import {
 	type SetHostToolsAck,
 	type SetHostToolsError,
 	type SkillsList,
+	type SlashCommandsList,
 } from "./chat-protocol";
 import { CONSOLE_ROUTES } from "./console-routes.generated";
 import type { BridgeServer } from "./extension-bridge";
@@ -110,6 +113,9 @@ export class ChatHandler {
 			// Skills enumeration (#2311): the pane asks for the loaded skills to populate
 			// the composer's Skills submenu.
 			else if (isListSkills(msg)) this.#handleListSkills();
+			// Slash-command enumeration: the pane asks for the session's file-based
+			// commands to populate the composer's `/` menu.
+			else if (isListCommands(msg)) this.#handleListCommands();
 			else if (isRpcHostToolResult(msg)) this.#hostToolBridge.handleResult(msg as unknown as HostToolResult);
 			else if (isRpcHostToolUpdate(msg)) this.#hostToolBridge.handleUpdate(msg as unknown as HostToolUpdate);
 		});
@@ -179,7 +185,14 @@ export class ChatHandler {
 		// model's read/grep/bash calls pass the gate. Session-scoped, in-memory, deduped.
 		const contextPaths = Array.isArray(req.contextPaths) ? sanitizeContextPaths(req.contextPaths) : [];
 		if (contextPaths.length > 0) grantSandboxPaths(contextPaths);
-		const prompt = composeChatPrompt(req.text, req.context, req.mode, this.#server.clientHost, contextPaths);
+		// Expand a file-based slash command HERE, on the user's raw text, before it is
+		// composed. Two reasons it cannot live in `AgentSession.prompt` for this surface:
+		// we call `prompt` with `expandPromptTemplates: false`, and `composeChatPrompt`
+		// appends the user's text last, so by then the string no longer starts with `/`.
+		// A `/name` that matches nothing is returned unchanged, which is what keeps the
+		// skill convention (same spelling, handled by the system prompt) working.
+		const text = expandSlashCommand(req.text, [...this.#session.slashCommands]);
+		const prompt = composeChatPrompt(text, req.context, req.mode, this.#server.clientHost, contextPaths);
 		// Photo/image attachments ride as base64 vision blocks (the model is
 		// vision-capable); text attachments are already folded into req.text upstream.
 		const images: ImageContent[] | undefined = req.images?.map(img => ({
@@ -431,6 +444,16 @@ export class ChatHandler {
 	#handleListSkills(): void {
 		// Shared projection: one place decides what crosses to a client (never paths).
 		this.#server.send({ type: "skills", skills: toSkillSummaries(this.#session.skills) } satisfies SkillsList);
+	}
+
+	/** Reply to `list_commands` with the session's file-based slash commands (name +
+	 *  description) so the pane can populate the composer's `/` menu. Pure read — the
+	 *  commands are already discovered; the template bodies never cross the wire. */
+	#handleListCommands(): void {
+		this.#server.send({
+			type: "commands",
+			commands: toSlashCommandSummaries(this.#session.slashCommands),
+		} satisfies SlashCommandsList);
 	}
 
 	#sendTerminal(chat: ActiveChat, frame: ChatDone | ChatError): void {

--- a/packages/coding-agent/src/browser/chat-protocol.ts
+++ b/packages/coding-agent/src/browser/chat-protocol.ts
@@ -129,6 +129,30 @@ export interface SkillsList {
 	skills: SkillInfo[];
 }
 
+/** Client → engine: enumerate the session's file-based slash commands for the
+ *  composer's `/` menu. Sent once after the pane connects, beside `list_skills`. */
+export interface ListCommands {
+	type: "list_commands";
+}
+
+/**
+ * One slash command surfaced to the pane's `/` menu.
+ *
+ * Deliberately NOT the command's `content`: that body is a prompt template which can run
+ * to hundreds of lines, and the menu needs a label. It also keeps the plugin author's
+ * instructions off the wire, where nothing reads them.
+ */
+export interface SlashCommandInfo {
+	name: string;
+	description: string;
+}
+
+/** Engine → client: the session's live slash commands, in load order. */
+export interface SlashCommandsList {
+	type: "commands";
+	commands: SlashCommandInfo[];
+}
+
 export interface ChatStop {
 	type: "chat_stop";
 	id: string;
@@ -310,6 +334,10 @@ export function isChatStop(msg: Record<string, unknown>): boolean {
 
 export function isListSkills(msg: Record<string, unknown>): boolean {
 	return msg.type === "list_skills";
+}
+
+export function isListCommands(msg: Record<string, unknown>): boolean {
+	return msg.type === "list_commands";
 }
 
 export function isPickPath(msg: Record<string, unknown>): boolean {

--- a/packages/coding-agent/src/extensibility/slash-commands.ts
+++ b/packages/coding-agent/src/extensibility/slash-commands.ts
@@ -147,6 +147,26 @@ export interface FileSlashCommand {
 	_source?: { providerName: string; level: "user" | "project" | "native" };
 }
 
+/** A slash command as a CLIENT sees it: enough to render a menu entry, nothing more. */
+export interface SlashCommandSummary {
+	name: string;
+	description: string;
+}
+
+/**
+ * Project loaded slash commands onto the client-facing summary.
+ *
+ * `FileSlashCommand` also carries `content` — the prompt template, which can run to
+ * hundreds of lines — plus `source` and `_source`, the operator's on-disk layout. A UI
+ * surface needs only the name and description to populate its `/` menu, so this is the
+ * one place that decides what crosses the boundary. Shared by every transport (the
+ * `list_commands` bridge frame and the `list_commands` RPC command) so they can't drift
+ * into leaking different amounts. Mirrors `toSkillSummaries` in `./skills`.
+ */
+export function toSlashCommandSummaries(commands: readonly FileSlashCommand[]): SlashCommandSummary[] {
+	return commands.map(c => ({ name: c.name, description: c.description }));
+}
+
 const EMBEDDED_SLASH_COMMANDS = EMBEDDED_COMMAND_TEMPLATES;
 
 function parseCommandTemplate(

--- a/packages/coding-agent/src/internal-urls/terraform-index.generated.ts
+++ b/packages/coding-agent/src/internal-urls/terraform-index.generated.ts
@@ -149,6 +149,22 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			],
 		},
 		{
+			name: "Uncategorized",
+			slug: "uncategorized",
+			description: "Resources pending categorization",
+			resource_count: 8,
+			resources: [
+				"application_profiles",
+				"authorization_server",
+				"bot_infrastructure",
+				"domain",
+				"mitigated_domain",
+				"protected_application",
+				"protected_domain",
+				"registration_approval",
+			],
+		},
+		{
 			name: "DNS",
 			slug: "dns",
 			description: "DNS domains, zones, compliance checks, and DNS proxy configuration",
@@ -164,33 +180,11 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			],
 		},
 		{
-			name: "Uncategorized",
-			slug: "uncategorized",
-			description: "Resources pending categorization",
-			resource_count: 7,
-			resources: [
-				"application_profiles",
-				"authorization_server",
-				"bot_infrastructure",
-				"mitigated_domain",
-				"protected_application",
-				"protected_domain",
-				"registration_approval",
-			],
-		},
-		{
 			name: "API Security",
 			slug: "api-security",
 			description: "API definition, discovery, testing, and security controls for web APIs",
 			resource_count: 5,
 			resources: ["api_crawler", "api_definition", "api_discovery", "api_testing", "app_api_group"],
-		},
-		{
-			name: "Monitoring",
-			slug: "monitoring",
-			description: "Log receivers, alert policies, APM, and global logging configuration",
-			resource_count: 5,
-			resources: ["alert_receiver", "alert_template", "apm", "global_log_receiver", "log_receiver"],
 		},
 		{
 			name: "Applications",
@@ -212,6 +206,13 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "TLS certificates, certificate chains, CRLs, and trusted CA lists",
 			resource_count: 4,
 			resources: ["certificate", "certificate_chain", "crl", "trusted_ca_list"],
+		},
+		{
+			name: "Monitoring",
+			slug: "monitoring",
+			description: "Log receivers, alert policies, alert templates, and global logging configuration",
+			resource_count: 4,
+			resources: ["alert_receiver", "alert_template", "global_log_receiver", "log_receiver"],
 		},
 		{
 			name: "VPN",
@@ -386,16 +387,6 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			},
 			import_syntax: "terraform import xcsh_api_testing.example namespace/name",
 		},
-		apm: {
-			category: "monitoring",
-			description: "New APM as a service with configured parameters",
-			required: ["name", "namespace"],
-			minimal_config: 'resource "xcsh_apm" "example" {\n  name      = "example-apm"\n  namespace = "staging"\n}',
-			dependencies: {
-				requires: [],
-			},
-			import_syntax: "terraform import xcsh_apm.example namespace/name",
-		},
 		app_api_group: {
 			category: "api-security",
 			description: "App_api_group creates a new object in the storage backend for metadata.namespace",
@@ -531,7 +522,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		bgp_routing_policy: {
 			category: "security",
 			description:
-				"Bgp routing policy is a list of rules containing match criteria and action to be applied. these rules help contol routes which are imported or exported to bgp peers. configuration",
+				"Bgp routing policy is a list of rules containing match criteria and action to be applied. these rules help control routes which are imported or exported to bgp peers. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
 				'resource "xcsh_bgp_routing_policy" "example" {\n  name      = "example-bgp-routing-policy"\n  namespace = "staging"\n}',
@@ -856,6 +847,17 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				requires: [],
 			},
 			import_syntax: "terraform import xcsh_dns_zone.example namespace/name",
+		},
+		domain: {
+			category: "uncategorized",
+			description: "Allowed domain",
+			required: ["name", "namespace", "allowed_domain"],
+			minimal_config:
+				'resource "xcsh_domain" "example" {\n  name      = "example-domain"\n  namespace = "staging"\n\n  allowed_domain = "example-value"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_domain.example namespace/name",
 		},
 		endpoint: {
 			category: "load-balancing",
@@ -1636,9 +1638,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		udp_loadbalancer: {
 			category: "load-balancing",
 			description: "Load balancing UDP traffic across origin pools",
-			required: ["name", "namespace", "dns_volterra_managed", "enable_per_packet_load_balancing", "idle_timeout"],
+			required: ["name", "namespace", "dns_volterra_managed", "idle_timeout"],
 			minimal_config:
-				'resource "xcsh_udp_loadbalancer" "example" {\n  name      = "example-udp-loadbalancer"\n  namespace = "staging"\n\n  domains                          = ["example-value"]\n  dns_volterra_managed             = true\n  enable_per_packet_load_balancing = true\n  idle_timeout                     = 1\n}',
+				'resource "xcsh_udp_loadbalancer" "example" {\n  name      = "example-udp-loadbalancer"\n  namespace = "staging"\n\n  domains              = ["example-value"]\n  dns_volterra_managed = true\n  idle_timeout         = 1\n}',
 			dependencies: {
 				requires: ["namespace", "origin_pool"],
 			},

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -399,6 +399,16 @@ export class RpcClient {
 	}
 
 	/**
+	 * List the session's file-based slash commands (name + description) so a host can
+	 * populate a `/` menu. Enumeration only — sending `/name …` as a prompt is what
+	 * invokes one, and the engine substitutes the arguments into the template.
+	 */
+	async listCommands(): Promise<{ commands: Array<{ name: string; description: string }> }> {
+		const response = await this.#send({ type: "list_commands" });
+		return this.#getData(response);
+	}
+
+	/**
 	 * Set thinking level.
 	 */
 	async setThinkingLevel(level: ThinkingLevel): Promise<void> {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -17,6 +17,7 @@ import type {
 	ExtensionWidgetOptions,
 } from "../../extensibility/extensions";
 import { toSkillSummaries } from "../../extensibility/skills";
+import { toSlashCommandSummaries } from "../../extensibility/slash-commands";
 import {
 	isRpcHostToolResult,
 	isRpcHostToolUpdate,
@@ -648,6 +649,13 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 				// prompt. Mirrors the `list_skills` bridge frame the Office pane uses, via
 				// the same shared projection so neither transport can leak on-disk paths.
 				return success(id, "list_skills", { skills: toSkillSummaries(session.skills) });
+			}
+
+			case "list_commands": {
+				// Enumeration only: `session.prompt` already expands a `/name` it recognises.
+				// Mirrors the `list_commands` bridge frame the Office pane uses, via the same
+				// shared projection so neither transport ships the template bodies.
+				return success(id, "list_commands", { commands: toSlashCommandSummaries(session.slashCommands) });
 			}
 
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -8,6 +8,7 @@ import type { AgentMessage, ThinkingLevel } from "@f5-sales-demo/pi-agent-core";
 import type { Effort, ImageContent, Model } from "@f5-sales-demo/pi-ai";
 import type { BashResult } from "../../exec/bash-executor";
 import type { SkillSummary } from "../../extensibility/skills";
+import type { SlashCommandSummary } from "../../extensibility/slash-commands";
 // The host-tool wire types are transport-neutral and live in the shared host-tool
 // core so both the stdio RPC driver and the WS chat bridge use one vocabulary.
 import type {
@@ -50,6 +51,7 @@ export type RpcCommand =
 	| { id?: string; type: "set_host_tools"; tools: RpcHostToolDefinition[] }
 	| { id?: string; type: "get_integrations" }
 	| { id?: string; type: "list_skills" }
+	| { id?: string; type: "list_commands" }
 
 	// Model
 	| { id?: string; type: "set_model"; provider: string; modelId: string }
@@ -140,6 +142,13 @@ export type RpcResponse =
 			command: "list_skills";
 			success: true;
 			data: { skills: SkillSummary[] };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "list_commands";
+			success: true;
+			data: { commands: SlashCommandSummary[] };
 	  }
 	| {
 			id?: string;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3222,6 +3222,15 @@ export class AgentSession {
 		return this.#skillWarnings;
 	}
 
+	/**
+	 * File-based slash commands discovered for this session (`commands/*.md` from every
+	 * enabled provider, plugin ones prefixed `<plugin>:<name>`). Read-only: `prompt()`
+	 * expands them internally, and clients that render a `/` menu need to enumerate them.
+	 */
+	get slashCommands(): readonly FileSlashCommand[] {
+		return this.#slashCommands;
+	}
+
 	getTodoPhases(): TodoPhase[] {
 		return this.#cloneTodoPhases(this.#todoPhases);
 	}

--- a/packages/coding-agent/test/browser/chat-handler.configure.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.configure.test.ts
@@ -68,6 +68,9 @@ class FakeModelRegistry {
 class FakeAgentSession {
 	setModelCalls: Array<{ provider: string; id: string }> = [];
 	isStreaming = false;
+	// Read by the handler to expand a `/name` before composing; the `as unknown as
+	// AgentSession` cast means tsc cannot flag its absence.
+	readonly slashCommands = [];
 	modelRegistry = new FakeModelRegistry();
 	// Current default model (used when `configure` omits `model`).
 	model = { provider: "anthropic", id: "claude-opus-4-8" };

--- a/packages/coding-agent/test/browser/chat-handler.host-tools.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.host-tools.test.ts
@@ -43,6 +43,9 @@ class FakeBridgeServer {
 class FakeAgentSession {
 	refreshedTools: AgentTool[] | null = null;
 	isStreaming = false;
+	// Read by the handler to expand a `/name` before composing; the `as unknown as
+	// AgentSession` cast means tsc cannot flag its absence.
+	readonly slashCommands = [];
 	agent = {
 		abort(): void {},
 		replaceMessages(): void {},
@@ -196,6 +199,8 @@ describe("ChatHandler host-tool wiring (#2046 A3)", () => {
 describe("chat_tool_notice ok-flag reflects tool_execution_end.isError", () => {
 	class EmittingSession {
 		isStreaming = false;
+		// Read by the handler to expand a `/name` before composing the prompt.
+		readonly slashCommands = [];
 		agent = { abort(): void {}, replaceMessages(): void {} };
 		#cbs: Array<(e: unknown) => void> = [];
 		#isError: boolean;

--- a/packages/coding-agent/test/chat-handler-images.test.ts
+++ b/packages/coding-agent/test/chat-handler-images.test.ts
@@ -30,6 +30,9 @@ function harness() {
 	} as unknown as BridgeServer;
 	const session = {
 		isStreaming: false,
+		// The handler reads this to expand a `/name` before composing the prompt; a fake
+		// that omits it is lying about AgentSession's shape (the cast hides it from tsc).
+		slashCommands: [],
 		agent: { replaceMessages() {}, abort() {} },
 		subscribe: (_cb: (e: AgentSessionEvent) => void) => () => {},
 		prompt: async (text: string, options?: Record<string, unknown>) => {

--- a/packages/coding-agent/test/chat-handler-list-skills.test.ts
+++ b/packages/coding-agent/test/chat-handler-list-skills.test.ts
@@ -31,6 +31,7 @@ function harness(skills: Array<{ name: string; description: string }> = []) {
 			baseDir: "/skills",
 			source: "native:project",
 		})),
+		slashCommands: [],
 		agent: { replaceMessages() {}, abort() {} },
 		subscribe: () => () => {},
 		prompt: async () => {},

--- a/packages/coding-agent/test/chat-handler-matrix.test.ts
+++ b/packages/coding-agent/test/chat-handler-matrix.test.ts
@@ -29,6 +29,9 @@ function harness(opts: { promptMs?: number; promptRejects?: string } = {}) {
 	} as unknown as BridgeServer;
 	const session = {
 		isStreaming: false,
+		// The handler reads this to expand a `/name` before composing the prompt; a fake
+		// that omits it is lying about AgentSession's shape (the cast hides it from tsc).
+		slashCommands: [],
 		agent: {
 			replaceMessages() {},
 			abort() {
@@ -82,6 +85,9 @@ function multiTurnHarness(behaviors: Array<(emit: (e: AgentSessionEvent) => void
 
 	const session = {
 		isStreaming: false,
+		// The handler reads this to expand a `/name` before composing the prompt; a fake
+		// that omits it is lying about AgentSession's shape (the cast hides it from tsc).
+		slashCommands: [],
 		agent: { replaceMessages() {}, abort() {} },
 		subscribe: (cb: (e: AgentSessionEvent) => void) => {
 			subscriber = cb;

--- a/packages/coding-agent/test/chat-handler-reason.test.ts
+++ b/packages/coding-agent/test/chat-handler-reason.test.ts
@@ -20,6 +20,9 @@ function makeFakes(opts: { isStreaming?: boolean; promptRejects?: string } = {})
 	} as unknown as BridgeServer;
 	const session = {
 		isStreaming: opts.isStreaming ?? false,
+		// The handler reads this to expand a `/name` before composing the prompt; a fake
+		// that omits it is lying about AgentSession's shape (the cast hides it from tsc).
+		slashCommands: [],
 		agent: { replaceMessages() {}, abort() {} },
 		subscribe: (_cb: (e: AgentSessionEvent) => void) => () => {},
 		prompt: async () => {

--- a/packages/coding-agent/test/chat-handler-slash-commands.test.ts
+++ b/packages/coding-agent/test/chat-handler-slash-commands.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Plugin slash commands over the Office bridge: enumeration (`list_commands`) and
+ * expansion (a `/name` chat_request becomes the command's body before it is composed).
+ *
+ * The engine already discovers these — `discoverSlashCommands` returns every
+ * `commands/*.md` from an installed plugin, prefixed with the plugin name — and the TUI
+ * expands them inside `AgentSession.prompt`. The pane got neither: no frame advertised
+ * them, and `chat-handler` calls `prompt` with `expandPromptTemplates: false`, which
+ * skips the expansion branch entirely. Even with that flag on it would not have worked,
+ * because `composeChatPrompt` appends the user's text LAST, so the string reaching
+ * `prompt` no longer starts with `/`.
+ *
+ * Expansion therefore belongs here, on `req.text`, before composition.
+ */
+import { expect, test } from "bun:test";
+import { ChatHandler } from "@f5-sales-demo/xcsh/browser/chat-handler";
+import { isListCommands } from "@f5-sales-demo/xcsh/browser/chat-protocol";
+import type { BridgeServer } from "@f5-sales-demo/xcsh/browser/extension-bridge";
+import type { FileSlashCommand } from "@f5-sales-demo/xcsh/extensibility/slash-commands";
+import type { AgentSession } from "@f5-sales-demo/xcsh/session/agent-session";
+
+const QUALIFY: FileSlashCommand = {
+	name: "meddpicc:qualify-deal",
+	description: "Score and qualify a deal using the MEDDPICC framework",
+	content: 'Invoke the `meddpicc:deal-qualification` skill for the deal "$ARGUMENTS".',
+	source: "via xcsh Marketplace User",
+};
+
+const STATUS: FileSlashCommand = {
+	name: "meddpicc:meddpicc-status",
+	description: "Check MEDDPICC framework readiness and deal data availability",
+	content: "Report MEDDPICC framework readiness and per-deal status.",
+	source: "via xcsh Marketplace User",
+};
+
+function harness(slashCommands: FileSlashCommand[] = []) {
+	const sent: Record<string, unknown>[] = [];
+	const prompts: string[] = [];
+	let onMsg: (m: Record<string, unknown>) => void = () => {};
+	const server = {
+		send: (p: unknown) => sent.push(p as Record<string, unknown>),
+		onMessage: (cb: (m: Record<string, unknown>) => void) => {
+			onMsg = cb;
+		},
+		onDisconnected: () => {},
+		clientHost: "excel",
+	} as unknown as BridgeServer;
+	const session = {
+		isStreaming: false,
+		skills: [],
+		slashCommands,
+		agent: { replaceMessages() {}, abort() {} },
+		subscribe: () => () => {},
+		prompt: async (text: string) => {
+			prompts.push(text);
+		},
+	} as unknown as AgentSession;
+	return { sent, prompts, server, session, fire: (m: Record<string, unknown>) => onMsg(m) };
+}
+
+const flush = (ms = 10) => new Promise(r => setTimeout(r, ms));
+
+test("isListCommands guard", () => {
+	expect(isListCommands({ type: "list_commands" })).toBe(true);
+	expect(isListCommands({ type: "list_skills" })).toBe(false);
+	expect(isListCommands({})).toBe(false);
+});
+
+test("list_commands replies projecting name + description, never the command body", async () => {
+	// The body is a prompt template that can run to hundreds of lines; a menu needs a
+	// label. Shipping `content` would also put the plugin author's instructions on the
+	// wire for no reason.
+	const h = harness([QUALIFY, STATUS]);
+	new ChatHandler(h.server, h.session).attach();
+	h.fire({ type: "list_commands" });
+	await flush();
+
+	const reply = h.sent.find(m => m.type === "commands");
+	expect(reply).toBeDefined();
+	expect(reply?.commands).toEqual([
+		{ name: "meddpicc:qualify-deal", description: "Score and qualify a deal using the MEDDPICC framework" },
+		{
+			name: "meddpicc:meddpicc-status",
+			description: "Check MEDDPICC framework readiness and deal data availability",
+		},
+	]);
+	expect(JSON.stringify(reply)).not.toContain("deal-qualification` skill");
+});
+
+test("list_commands with none loaded replies with an empty list", async () => {
+	const h = harness([]);
+	new ChatHandler(h.server, h.session).attach();
+	h.fire({ type: "list_commands" });
+	await flush();
+	expect(h.sent.find(m => m.type === "commands")?.commands).toEqual([]);
+});
+
+test("a /command chat_request is expanded into the command body", async () => {
+	const h = harness([QUALIFY, STATUS]);
+	new ChatHandler(h.server, h.session).attach();
+	h.fire({ type: "chat_request", id: "c-1", text: "/meddpicc:meddpicc-status", mode: "educational" });
+	await flush();
+
+	expect(h.prompts).toHaveLength(1);
+	expect(h.prompts[0]).toContain("Report MEDDPICC framework readiness");
+	// The raw command name must not survive — if it did, the model would be answering
+	// "/meddpicc:meddpicc-status" as prose instead of following the command.
+	expect(h.prompts[0]).not.toContain("/meddpicc:meddpicc-status");
+});
+
+test("arguments after the command name are substituted into $ARGUMENTS", async () => {
+	const h = harness([QUALIFY]);
+	new ChatHandler(h.server, h.session).attach();
+	h.fire({ type: "chat_request", id: "c-2", text: "/meddpicc:qualify-deal Visa, Inc.", mode: "educational" });
+	await flush();
+
+	expect(h.prompts[0]).toContain('the deal "Visa, Inc."');
+	expect(h.prompts[0]).not.toContain("$ARGUMENTS");
+});
+
+test("an unknown /name is left alone so the skill convention still applies", async () => {
+	// Skills are invoked by the same `/name` spelling but handled by the system prompt,
+	// not by expansion. Rewriting or rejecting an unmatched name would break them.
+	const h = harness([QUALIFY]);
+	new ChatHandler(h.server, h.session).attach();
+	h.fire({ type: "chat_request", id: "c-3", text: "/meddpicc:deal-review Visa", mode: "educational" });
+	await flush();
+
+	expect(h.prompts[0]).toContain("/meddpicc:deal-review Visa");
+});
+
+test("ordinary prose is untouched", async () => {
+	const h = harness([QUALIFY]);
+	new ChatHandler(h.server, h.session).attach();
+	h.fire({ type: "chat_request", id: "c-4", text: "generate a meddpicc report", mode: "educational" });
+	await flush();
+
+	expect(h.prompts[0]).toContain("generate a meddpicc report");
+});
+
+test("a mid-text slash is not a command", async () => {
+	const h = harness([QUALIFY]);
+	new ChatHandler(h.server, h.session).attach();
+	h.fire({ type: "chat_request", id: "c-5", text: "run /meddpicc:qualify-deal for me", mode: "educational" });
+	await flush();
+
+	expect(h.prompts[0]).toContain("run /meddpicc:qualify-deal for me");
+	expect(h.prompts[0]).not.toContain("Invoke the `meddpicc:deal-qualification`");
+});
+
+test("the expanded body still rides inside the host prompt, not instead of it", async () => {
+	// composeChatPrompt wraps the text with the Excel/Word/PowerPoint self-awareness
+	// directive. Expanding must not bypass that — the command body replaces the user's
+	// text, not the whole prompt.
+	const h = harness([STATUS]);
+	new ChatHandler(h.server, h.session).attach();
+	h.fire({ type: "chat_request", id: "c-6", text: "/meddpicc:meddpicc-status", mode: "educational" });
+	await flush();
+
+	expect(h.prompts[0]).toContain("<system-directive>");
+	expect(h.prompts[0]).toContain("Report MEDDPICC framework readiness");
+});

--- a/packages/coding-agent/test/chat-handler-ttft.test.ts
+++ b/packages/coding-agent/test/chat-handler-ttft.test.ts
@@ -16,6 +16,9 @@ function makeFakes(deltas: string[] = ["Hi"]) {
 	} as unknown as BridgeServer;
 	const session = {
 		isStreaming: false,
+		// The handler reads this to expand a `/name` before composing the prompt; a fake
+		// that omits it is lying about AgentSession's shape (the cast hides it from tsc).
+		slashCommands: [],
 		agent: { replaceMessages() {}, abort() {} },
 		subscribe: (cb: (e: AgentSessionEvent) => void) => {
 			listener = cb;

--- a/packages/coding-agent/test/chat-handler-web-search.test.ts
+++ b/packages/coding-agent/test/chat-handler-web-search.test.ts
@@ -22,6 +22,7 @@ function harness() {
 	const session = {
 		isStreaming: false,
 		skills: [],
+		slashCommands: [],
 		agent: { replaceMessages() {}, abort() {} },
 		subscribe: () => () => {},
 		prompt: async (text: string, options?: Record<string, unknown>) => {

--- a/packages/office-pane/src/core/index.ts
+++ b/packages/office-pane/src/core/index.ts
@@ -33,12 +33,15 @@ export type {
 	HostToolResultMsg,
 	HostToolUpdateMsg,
 	InteractionMode,
+	ListCommandsMsg,
 	ListSkillsMsg,
 	PathPickedMsg,
 	PickPathMsg,
 	SetHostToolsMsg,
 	SkillInfo,
 	SkillsListMsg,
+	SlashCommandInfo,
+	SlashCommandsListMsg,
 	TurnState,
 } from "./protocol";
 export {
@@ -54,6 +57,7 @@ export {
 	isConfigureError,
 	isPathPicked,
 	isSkillsList,
+	isSlashCommandsList,
 	reduceChatTurn,
 } from "./protocol";
 // Transport surface

--- a/packages/office-pane/src/core/protocol/index.ts
+++ b/packages/office-pane/src/core/protocol/index.ts
@@ -23,6 +23,7 @@ export type {
 	HostToolResultMsg,
 	HostToolUpdate,
 	HostToolUpdateMsg,
+	ListCommandsMsg,
 	ListSkillsMsg,
 	PathPickedMsg,
 	PickPathMsg,
@@ -30,6 +31,8 @@ export type {
 	SetHostToolsMsg,
 	SkillInfo,
 	SkillsListMsg,
+	SlashCommandInfo,
+	SlashCommandsListMsg,
 } from "./messages";
 export {
 	isChatDelta,
@@ -43,6 +46,7 @@ export {
 	isHostToolCancel,
 	isPathPicked,
 	isSkillsList,
+	isSlashCommandsList,
 } from "./messages";
 export type { ChatErrorReason, InteractionMode } from "./reasons";
 export { CHAT_ERROR_REASONS, INTERACTION_MODES } from "./reasons";

--- a/packages/office-pane/src/core/protocol/messages.ts
+++ b/packages/office-pane/src/core/protocol/messages.ts
@@ -117,6 +117,7 @@ export type ChatInboundMsg =
 	| ConfigureAck
 	| ConfigureError
 	| SkillsList
+	| SlashCommandsList
 	| PathPicked;
 
 // ---------------------------------------------------------------------------

--- a/packages/office-pane/src/core/protocol/messages.ts
+++ b/packages/office-pane/src/core/protocol/messages.ts
@@ -36,12 +36,15 @@ import type {
 	HostToolDefinition,
 	HostToolResult,
 	HostToolUpdate,
+	ListCommands,
 	ListSkills,
 	PathPicked,
 	PickPath,
 	SetHostTools,
 	SkillInfo,
 	SkillsList,
+	SlashCommandInfo,
+	SlashCommandsList,
 } from "@f5-sales-demo/xcsh/browser/chat-protocol";
 
 // --- Native wire types, re-exported under office-pane's local names. ---
@@ -68,6 +71,7 @@ export type {
 	HostToolResult as HostToolResultMsg,
 	HostToolUpdate,
 	HostToolUpdate as HostToolUpdateMsg,
+	ListCommands as ListCommandsMsg,
 	ListSkills as ListSkillsMsg,
 	PathPicked as PathPickedMsg,
 	PickPath as PickPathMsg,
@@ -75,6 +79,8 @@ export type {
 	SetHostTools as SetHostToolsMsg,
 	SkillInfo,
 	SkillsList as SkillsListMsg,
+	SlashCommandInfo,
+	SlashCommandsList as SlashCommandsListMsg,
 };
 
 // ---------------------------------------------------------------------------
@@ -166,6 +172,11 @@ export function isConfigureError(msg: unknown): msg is ConfigureError {
 /** Inbound guard: xcsh replied to `list_skills` with the loaded skills. */
 export function isSkillsList(msg: unknown): msg is SkillsList {
 	return isObj(msg) && msg.type === "skills" && Array.isArray(msg.skills);
+}
+
+/** Inbound guard: xcsh replied to `list_commands` with the loaded slash commands. */
+export function isSlashCommandsList(msg: unknown): msg is SlashCommandsList {
+	return isObj(msg) && msg.type === "commands" && Array.isArray(msg.commands);
 }
 
 /** Inbound guard: xcsh replied to `pick_path` with the picker result. */

--- a/packages/office-pane/src/core/transport/index.ts
+++ b/packages/office-pane/src/core/transport/index.ts
@@ -10,6 +10,7 @@ import type {
 	ConfigureMsg,
 	HostToolResultMsg,
 	HostToolUpdateMsg,
+	ListCommandsMsg,
 	ListSkillsMsg,
 	PickPathMsg,
 	SetHostToolsMsg,
@@ -29,6 +30,7 @@ export type ChatOutbound =
 	| HostToolUpdateMsg
 	| ConfigureMsg
 	| ListSkillsMsg
+	| ListCommandsMsg
 	| PickPathMsg;
 
 /**

--- a/packages/office-pane/src/panel/ChatPanel.tsx
+++ b/packages/office-pane/src/panel/ChatPanel.tsx
@@ -168,6 +168,7 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 		provisioning,
 		provisionError,
 		skills,
+		slashCommands,
 		pickPath,
 	} = useChatSession(transport, { provision, onConnected });
 	const composerRef = useRef<ComposerHandle>(null);
@@ -269,6 +270,19 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 	const handleSkillSelect = useCallback((name: string) => {
 		composerRef.current?.setText(`/${name} `);
 	}, []);
+
+	/** Prefill rather than send: a command usually takes arguments (a deal or account
+	 *  name), and the engine substitutes them into the template's `$ARGUMENTS`. */
+	const handleSlashSelect = useCallback((command: string) => {
+		composerRef.current?.setText(`${command} `);
+	}, []);
+
+	/** The chat-ui menu wants `{command, label, description}`; the wire carries
+	 *  `{name, description}`. The leading slash belongs to the UI, not the engine. */
+	const slashMenuItems = useMemo(
+		() => slashCommands.map(c => ({ command: `/${c.name}`, label: c.name, description: c.description })),
+		[slashCommands],
+	);
 
 	const handleFiles = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
 		const files = Array.from(e.target.files ?? []);
@@ -475,6 +489,8 @@ export function ChatPanel({ transport, provision, onConnected, onReconfigure, on
 				onRemoveAttachment={handleRemoveAttachment}
 				skills={skills}
 				onSkillSelect={handleSkillSelect}
+				slashCommands={slashMenuItems}
+				onSlashSelect={handleSlashSelect}
 			/>
 		</>
 	);

--- a/packages/office-pane/src/panel/useChatSession.ts
+++ b/packages/office-pane/src/panel/useChatSession.ts
@@ -14,9 +14,11 @@ import {
 	initTurn,
 	isPathPicked,
 	isSkillsList,
+	isSlashCommandsList,
 	type PathPickedMsg,
 	reduceChatTurn,
 	type SkillInfo,
+	type SlashCommandInfo,
 	type Transport,
 	type TurnState,
 } from "../core";
@@ -173,6 +175,10 @@ export interface ChatSessionResult {
 	/** The engine's loaded skills, requested on connect — powers the composer's
 	 *  Skills submenu. Empty until the `skills` reply arrives (or if none load). */
 	skills: SkillInfo[];
+	/** The engine's file-based slash commands, requested on connect — powers the
+	 *  composer's `/` menu. Includes an installed plugin's commands, prefixed
+	 *  `<plugin>:<name>`. Empty until the `commands` reply arrives. */
+	slashCommands: SlashCommandInfo[];
 	/** Open a native OS file/folder picker on the bridge machine and resolve the
 	 *  chosen path (or a canceled/unsupported result). Backs the "Add a file/folder"
 	 *  composer categories. */
@@ -201,6 +207,7 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 	const [provisioning, setProvisioning] = useState<Provisioning>("connecting");
 	const [provisionError, setProvisionError] = useState<string | undefined>(undefined);
 	const [skills, setSkills] = useState<SkillInfo[]>([]);
+	const [slashCommands, setSlashCommands] = useState<SlashCommandInfo[]>([]);
 	// Resolver for an in-flight pickPath() — settled by the next `path_picked` frame.
 	const pendingPickRef = useRef<((r: PathPickedMsg) => void) | null>(null);
 	const counterRef = useRef(0);
@@ -247,6 +254,8 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 				// submenu. Best-effort: a failure just leaves the submenu empty.
 				try {
 					transport.send({ type: "list_skills" });
+					// …and for its slash commands, which populate the composer's `/` menu.
+					transport.send({ type: "list_commands" });
 				} catch {
 					/* transport already gone — skip; the submenu stays empty */
 				}
@@ -277,6 +286,9 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 			} else if (isSkillsList(msg)) {
 				// The engine's loaded skills — cache them for the composer's Skills submenu.
 				setSkills(msg.skills);
+			} else if (isSlashCommandsList(msg)) {
+				// The engine's slash commands — cache them for the composer's `/` menu.
+				setSlashCommands(msg.commands);
 			} else if (isPathPicked(msg)) {
 				// Settle the in-flight pickPath() with the picker result.
 				pendingPickRef.current?.(msg);
@@ -490,6 +502,7 @@ export function useChatSession(transport: Transport, hooks?: ChatSessionHooks): 
 		provisioning,
 		provisionError,
 		skills,
+		slashCommands,
 		pickPath,
 	};
 }


### PR DESCRIPTION
Closes #2480

## What was broken

The engine already discovers every `commands/*.md` an installed plugin ships. The pane
could use none of them.

**Nothing advertised them.** `chat-protocol.ts` had `list_skills`/`skills` and no command
equivalent, so `ChatPanel` never passed `slashCommands` to `Composer` and the
`SlashCommandMenu` the shared chat-ui *already ships* never rendered — the `/` button
simply did not appear.

**Typing one did nothing.** `chat-handler` calls `session.prompt(...)` with
`expandPromptTemplates: false`, which skips the expansion branch. Even with that flag on
it would still fail: `composeChatPrompt` appends the user's text **last**, so by the time
`prompt` sees the string it no longer starts with `/`. `/meddpicc:qualify-deal CUSTOMER-C`
reached the model as literal prose, and the model answered *about* the string.

## Verified against the real plugin

From `~/MEDDPICC/CUSTOMER-C`, driving the same discovery path a session uses:

```
MENU (what list_commands sends):
  /meddpicc:build-map        — Build a buyer-approved Mutual Action Plan tied to MEDDPICC
  /meddpicc:champion-test    — Test whether your contact is a true MEDDPICC champion
  /meddpicc:deal-review      — Facilitate a structured weekly MEDDPICC deal review
  /meddpicc:meddpicc-status  — Check MEDDPICC framework readiness and deal data availability
  /meddpicc:qualify-deal     — Score and qualify a deal using the MEDDPICC framework…
  /meddpicc:update-deal      — Ingest meeting notes, emails, transcripts, OSINT reports…

EXPANSION of /meddpicc:meddpicc-status →
  Report MEDDPICC framework readiness and per-deal status. The
  deterministic status (ordering, completion, scores) comes from the
  plugin engine — never count files or compute scores by hand.

unknown /name passthrough: "/not-a-command x"
```

## Design notes

**Expansion lives in the handler, on `req.text`, before composition** — the only point
where the text still starts with `/`. It reuses the existing `expandSlashCommand` rather
than growing a second expander.

**An unmatched `/name` passes through untouched.** Skills are invoked by the same spelling
but handled by the system prompt, so rewriting or rejecting an unknown name would break
them. There is a test for exactly this.

**`toSlashCommandSummaries` sits beside `toSkillSummaries`** for the reason that one
exists: bridge and RPC project through a single function, so they cannot drift into
shipping different amounts. Command bodies never cross the wire — they are prompt
templates that can run to hundreds of lines, and a menu needs a label.

**VS Code gets the matching `list_commands` RPC command**, so its webview does not fall
another release behind the pane.

## Contract

Bumped to **1.12.0**. While adding the new frames I found the contract never recorded the
enumeration frames at all — `list_skills`/`skills` were missing from both the `messages`
list and `chat-conformance.json`. All four are now registered, with schemas and golden
valid/invalid examples (empty list, name-keyed map instead of array, entry without a
description, entry with an empty name).

## Test-fake hygiene

Nine chat-handler fakes omitted `slashCommands` and passed only because nothing read it —
the `as unknown as AgentSession` cast hides the gap from tsc. Adding one read surfaced 31
failures at once. They now declare the field.

## Verification

- 9 new tests. **Mutation-checked**: reverting the expansion to `req.text` fails three of
  them (confirmed) — enumeration, argument substitution, and the host-prompt wrapper.
- `packages/coding-agent`: 5868 pass / 0 fail. `packages/office-pane`: 365 pass / 0 fail
  (conformance drift guard included).
- `bun run check:types` clean; biome clean on all 21 changed files.
- Codex `verified-code-review` (`adversarial-review --base origin/main`): **0 findings**.

## Unrelated breakage found, not fixed here

`bun run check:tools` is **red on `main`**: `internal-urls/xcsh-protocol.ts:654,657` fail
biome's `useTemplate`, introduced by #2447. CI runs `check:rs` but never `check:tools`, so
nothing caught it. Confirmed pre-existing by stashing this branch and re-running. Out of
scope here — filing separately rather than smuggling a drive-by fix into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)