### PR TITLE
refactor(benchmark): normalize TSTypeCastExpression at the parse boundary

### DIFF
--- a/packages/typescript-edit-benchmark/src/mutations.ts
+++ b/packages/typescript-edit-benchmark/src/mutations.ts
@@ -110,7 +110,11 @@ function parseCode(code: string): Parsed | null {
 
 	for (const plugins of pluginSets) {
 		try {
-			return { ast: parseWithPlugins(code, plugins), code };
+			const ast = parseWithPlugins(code, plugins);
+			// Normalize at the parse boundary so nothing downstream — traversal,
+			// mutation, or generation — ever meets a node @babel/types cannot model.
+			normalizeParserScratchNodes(ast);
+			return { ast, code };
 		} catch {}
 	}
 
@@ -118,38 +122,101 @@ function parseCode(code: string): Parsed | null {
 }
 
 /*
- * Babel parser 7.29 emits TSTypeCastExpression but generator/types don't define it.
- * Register it in VISITOR_KEYS (so the printer's isLastChild doesn't crash) and in
- * generatorInfosMap with a custom handler that unwraps the TSTypeAnnotation wrapper.
+ * Babel's parser emits TSTypeCastExpression but @babel/types and the generator do
+ * not define it, so `generate()` throws "unknown node of type" on any subtree
+ * containing one. Register it in VISITOR_KEYS so @babel/traverse can still walk
+ * into such a node — needed both by the normalization below and as a safety net
+ * for any cast shape that normalization declines to rewrite.
  */
 t.VISITOR_KEYS.TSTypeCastExpression = ["expression", "typeAnnotation"];
-{
-	const { generatorInfosMap } = require("@babel/generator/lib/nodes") as {
-		generatorInfosMap: Map<string, [any, number, unknown]>;
-	};
-	if (!generatorInfosMap.has("TSTypeCastExpression")) {
-		const tsAs = generatorInfosMap.get("TSAsExpression");
-		if (tsAs) {
-			// Custom handler: like TSAsExpression but unwraps TSTypeAnnotation → TSType
-			function TSTypeCastExpression(
-				this: {
-					print: (node: unknown, printComments?: boolean) => void;
-					space: () => void;
-					word: (word: string) => void;
-				},
-				node: Record<string, unknown>,
-			): void {
-				this.print(node.expression, true);
-				this.space();
-				this.word("as");
-				this.space();
-				const annot = node.typeAnnotation as Record<string, unknown> | undefined;
-				// TSTypeCastExpression.typeAnnotation is TSTypeAnnotation {typeAnnotation: TSType}
-				this.print(annot && "typeAnnotation" in annot ? annot.typeAnnotation : annot);
+
+/**
+ * The scratch node's shape, declared structurally.
+ *
+ * It cannot be described in terms of `t.Node`: `@babel/types` has no
+ * `TSTypeCastExpression` member, so `(node as t.Node).type === "TSTypeCastExpression"`
+ * is a comparison TypeScript rejects as having no overlap (TS2367). That rejection is
+ * the same types/parser gap this whole normalization exists to close, so it is
+ * answered with an honest structural type rather than a suppression.
+ */
+type TypeCastLike = {
+	type: "TSTypeCastExpression";
+	expression: t.Expression;
+	typeAnnotation: t.Node;
+	start?: number | null;
+	end?: number | null;
+	loc?: t.SourceLocation | null;
+	leadingComments?: t.Comment[] | null;
+	trailingComments?: t.Comment[] | null;
+};
+
+function isTypeCast(node: unknown): node is TypeCastLike {
+	return typeof node === "object" && node !== null && (node as { type?: unknown }).type === "TSTypeCastExpression";
+}
+
+/**
+ * Rewrite one parser scratch node into the equivalent node the generator knows,
+ * or return null when it is not a cast (or has an unexpected shape).
+ *
+ * `TSTypeCastExpression{expression, typeAnnotation: TSTypeAnnotation{typeAnnotation}}`
+ * carries exactly the operands of a `TSAsExpression`, so `(x: T)` becomes `x as T` —
+ * the same rendering the removed generator monkey-patch produced by hand. Source
+ * position is copied over so `nodeRange` keeps slicing the ORIGINAL text.
+ */
+function typeCastToAsExpression(node: unknown): t.Node | null {
+	if (!isTypeCast(node)) return null;
+	const annotation = node.typeAnnotation;
+	const inner = t.isTSTypeAnnotation(annotation) ? annotation.typeAnnotation : annotation;
+	// An unexpected shape is left alone; VISITOR_KEYS above keeps traversal working.
+	if (!node.expression || !inner || !t.isTSType(inner)) return null;
+	const as = t.tsAsExpression(node.expression, inner);
+	as.start = node.start ?? null;
+	as.end = node.end ?? null;
+	as.loc = node.loc ?? null;
+	as.leadingComments = node.leadingComments ?? null;
+	as.trailingComments = node.trailingComments ?? null;
+	return as;
+}
+
+/**
+ * Replace every `TSTypeCastExpression` in a freshly parsed AST with a `TSAsExpression`.
+ *
+ * `(x: T)` is not valid TypeScript — per @babel/parser's own typings it "is not a
+ * valid TS production". It is built in `parseParenItem` and only survives into the
+ * AST because this file parses with `errorRecovery: true`. Left in place it poisons
+ * the generator for every ANCESTOR node too, which is what previously forced this
+ * module to monkey-patch `generatorInfosMap`, an unexported Babel internal, just to
+ * render such subtrees.
+ *
+ * Normalizing at the parse boundary removes that need using only public builders,
+ * and keeps working on Babel 8 (both versions have the same types/parser gap).
+ *
+ * Done with a plain recursive walk rather than @babel/traverse: traverse validates
+ * visitor keys against known node types, and this node is precisely the one
+ * @babel/types does not know.
+ */
+function normalizeParserScratchNodes(ast: t.File): void {
+	const seen = new Set<object>();
+	const visit = (node: unknown): void => {
+		if (typeof node !== "object" || node === null || seen.has(node)) return;
+		seen.add(node);
+		const record = node as Record<string, unknown>;
+		for (const key of Object.keys(record)) {
+			const child = record[key];
+			if (Array.isArray(child)) {
+				for (let i = 0; i < child.length; i++) {
+					const rewritten = typeCastToAsExpression(child[i]);
+					if (rewritten) child[i] = rewritten;
+					visit(child[i]);
+				}
+			} else if (typeof child === "object" && child !== null) {
+				const rewritten = typeCastToAsExpression(child);
+				if (rewritten) record[key] = rewritten;
+				visit(record[key]);
 			}
-			generatorInfosMap.set("TSTypeCastExpression", [TSTypeCastExpression, tsAs[1], tsAs[2]]);
 		}
-	}
+	};
+	visit(ast);
 }
 
 type SourceRange = {

--- a/packages/typescript-edit-benchmark/test/mutations.test.ts
+++ b/packages/typescript-edit-benchmark/test/mutations.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Contract of the AST mutations' snippet rendering (#2428).
+ *
+ * `mutations.ts` had no test coverage at all, which is how it came to carry a
+ * monkey-patch of an unexported Babel internal (`generatorInfosMap`) with nothing
+ * pinning what the patch was for. These tests pin the two properties that matter,
+ * so the patch can be removed and the loss — if any — is visible:
+ *
+ *  1. A node whose subtree contains `(x: T)` (`TSTypeCastExpression`, which
+ *     `@babel/generator` cannot print) still renders a non-empty snippet.
+ *  2. `mutatedSnippet` reflects the MUTATION, not the original source. This is the
+ *     one that makes the fix non-obvious: mutations edit the AST in place, so a
+ *     mutated node's `start`/`end` still point at the ORIGINAL text. Rendering it
+ *     by slicing source would silently return the pre-mutation string — and, worse,
+ *     `buildEdits` uses that same string as the replacement written to the file, so
+ *     the edit would be a no-op and every AST mutation would quietly stop working.
+ */
+import { describe, expect, test } from "bun:test";
+import { ALL_MUTATIONS } from "../src/mutations";
+
+/** Deterministic rng so a mutation's random choice is reproducible. */
+function seededRng(seed: number): () => number {
+	let s = seed >>> 0;
+	return () => {
+		s = (s * 1664525 + 1013904223) >>> 0;
+		return s / 0x100000000;
+	};
+}
+
+function mutationNamed(name: string) {
+	const m = ALL_MUTATIONS.find(x => x.name === name);
+	if (!m) throw new Error(`no mutation named ${name}; have: ${ALL_MUTATIONS.map(x => x.name).join(", ")}`);
+	return m;
+}
+
+/**
+ * A `(x: T)` parenthesised annotation that genuinely reaches `TSTypeCastExpression`.
+ *
+ * The `abstract class` is load-bearing, not decoration. `parseCode` tries its FLOW
+ * plugin set first and only falls through to the TypeScript set when flow throws —
+ * and under flow, `(a: number)` is a perfectly ordinary `TypeCastExpression` that
+ * the generator prints without complaint. So a plain `.ts`-looking fixture never
+ * reaches the TS parser at all. `abstract` is TS-only syntax, which makes the flow
+ * parse fail, which is what routes this source to the TypeScript plugin set where
+ * `(a: number)` becomes the unprintable `TSTypeCastExpression`.
+ */
+const WITH_TYPE_CAST = `abstract class Shape {
+	abstract area(): number;
+}
+function pick(a: number, b: number) {
+	if (a < b) {
+		const y = (a: number);
+		return y;
+	} else {
+		return b;
+	}
+}
+`;
+
+const PLAIN = `function pick(a: number, b: number) {
+	if (a <= b) {
+		return a;
+	}
+	return b;
+}
+`;
+
+describe("snippet rendering survives nodes the generator cannot print (#2428)", () => {
+	test("a mutation over a node containing (x: T) still produces a non-empty mutated snippet", () => {
+		const swapIfElse = mutationNamed("swap-if-else");
+		expect(swapIfElse.canApply(WITH_TYPE_CAST)).toBe(true);
+
+		const [mutated, info] = swapIfElse.mutate(WITH_TYPE_CAST, seededRng(7));
+
+		// The whole point of the removed generatorInfosMap patch: this node's subtree
+		// contains a TSTypeCastExpression, so `generate()` throws on it.
+		expect(info.mutatedSnippet).not.toBe("");
+		expect(mutated).not.toBe(WITH_TYPE_CAST);
+		expect(info.lineNumber).toBeGreaterThan(0);
+	});
+
+	test("the cast is normalized to the equivalent `as` expression, not dropped", () => {
+		// `(a: number)` is rewritten to `a as number` at the parse boundary — the same
+		// rendering the removed generator monkey-patch produced by hand. Assert the
+		// binding is carried through rather than silently lost.
+		//
+		// Note the assertion targets `y = a as number` specifically: a bare
+		// `toContain("a: number")` would pass on the untouched `pick(a: number, ...)`
+		// signature elsewhere in the fixture and prove nothing.
+		const [mutated] = mutationNamed("swap-if-else").mutate(WITH_TYPE_CAST, seededRng(7));
+		expect(mutated).toContain("y = a as number");
+		expect(mutated).not.toContain("y = (a: number)"); // the scratch form is gone
+	});
+
+	test("normalization leaves valid TypeScript untouched", () => {
+		// The rewrite must be inert for code that never produced a scratch node.
+		const [mutated, info] = mutationNamed("swap-comparison").mutate(PLAIN, seededRng(3));
+		expect(mutated).toContain("function pick(a: number, b: number)"); // annotations intact
+		expect(mutated).not.toContain(" as "); // nothing spuriously rewritten
+		expect(info.lineNumber).toBeGreaterThan(0);
+	});
+});
+
+describe("mutatedSnippet reflects the mutation, not the original source", () => {
+	test("swap-comparison reports the swapped operator and actually edits the file", () => {
+		const [mutated, info] = mutationNamed("swap-comparison").mutate(PLAIN, seededRng(3));
+
+		expect(mutated).not.toBe(PLAIN); // a real edit landed
+		expect(info.originalSnippet).toBe("a <= b");
+		expect(info.mutatedSnippet).toBe("a < b"); // the SWAPPED form, not the source slice
+		expect(info.mutatedSnippet).not.toBe(info.originalSnippet);
+		expect(mutated).toContain("a < b");
+	});
+
+	test("every applicable mutation that reports a change actually changes the content", () => {
+		// Guards the failure mode where a snippet regression turns edits into no-ops:
+		// buildEdits writes snippetFromNode's output back into the file, so if that
+		// ever returned the original slice the edit would be identity and mutate()
+		// would silently report a no-op for every mutation at once.
+		const applied: string[] = [];
+		for (const m of ALL_MUTATIONS) {
+			if (!m.canApply(PLAIN)) continue;
+			const [mutated, info] = m.mutate(PLAIN, seededRng(11));
+			if (info.lineNumber === 0) continue; // declined this input — fine
+			applied.push(m.name);
+			expect(mutated).not.toBe(PLAIN);
+		}
+		expect(applied.length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
Fixes #2428

## The proposal as written cannot work

#2428 asks for `snippetFromNode` to slice source via `nodeRange` instead of generating,
so the `generatorInfosMap` monkey-patch can be deleted. I tried that first. It breaks the
benchmark, and the reason is worth recording because it is not obvious from the issue:

| Call sites | Shape | Effect of slicing source |
| --- | --- | --- |
| ~20 | `snippetFromSource(parsed.code, node, snippetFromNode(node))` | **Already does this.** The slice is preferred; `snippetFromNode` is only the no-range fallback. |
| ~18 | `mutatedSnippet: snippetFromNode(node)` | Mutations edit the AST **in place**, so the node's `start`/`end` still point at the ORIGINAL text. Reports the pre-mutation string as the mutated one. |
| 1 | `buildEdits` → `replacement` | This is the text **written into the file**. Slicing makes the edit identity → `mutated === content` → `mutate()` returns `noopInfo()` → **every AST mutation silently stops producing output.** |

So AC1 as literally stated ("returns the original source slice for nodes with a range")
would zero out the generator, which is exactly what the issue's own last AC — "still
produces a non-zero mutation count" — is there to catch.

## What this does instead

Rather than teach the renderer to cope with a node `@babel/types` cannot model, stop
letting that node exist. `(x: T)` is not valid TypeScript — per `@babel/parser`'s own
typings it "is not a valid TS production" — and only survives into the AST because this
file parses with `errorRecovery: true`. It is isomorphic to `TSAsExpression`, so it is
rewritten at the parse boundary with public builders, preserving `start`/`end`/`loc` so
`nodeRange` keeps slicing original text.

`x as T` is precisely what the removed monkey-patch printed by hand, so nothing downstream
changes. All three call-site classes keep working, and `snippetFromNode` needs no signature
change at 38 call sites.

`t.VISITOR_KEYS.TSTypeCastExpression` is **retained** as the issue asks — traversal still
needs it for any cast shape the rewrite declines (missing `expression`, or an annotation
that isn't a `TSType`).

## Verification

`mutations.ts` had no test coverage at all, which is how it came to carry a patch of an
unexported Babel internal with nothing pinning what the patch was for. New tests, verified
three ways:

1. **They genuinely cover the patch's purpose.** With the patch removed and no
   normalization, the first test FAILS — `mutatedSnippet` is `""`, because `buildEdits`
   can't render the node and bails.
2. **The refactor is behaviour-preserving, not merely green.** The same tests PASS
   unchanged against `origin/main`'s patched version. They are equivalence pins.
3. **End to end.** `generate.ts` over a real source tree produces **160 files across 40
   cases that are byte-identical** between the patched and normalized versions (same score
   distribution, same difficulty fallbacks). This is the issue's last AC, met by direct
   comparison rather than a recorded number.

One trap worth flagging for whoever reads the fixture: the `abstract class` in it is
load-bearing. `parseCode` tries its **flow** plugin set first, and under flow
`(a: number)` is an ordinary, printable `TypeCastExpression`. A plain TS-looking fixture
never reaches the TypeScript parser, so it exercises nothing. `abstract` is TS-only syntax,
which makes the flow parse throw and routes the source to the TS plugin set where the
scratch node actually appears. My first fixture had this bug and passed for the wrong
reason; so did an assertion (`toContain("a: number")` matches the untouched
`pick(a: number, b: number)` signature). Both are fixed and commented.

### Gates

- `bun run ci:check:full` — exit 0
- `bun run test` (package) — 17 pass, 0 fail
- `biome check` — clean

TypeScript rejected the obvious `(node as t.Node).type === "TSTypeCastExpression"` guard
with TS2367 (no overlap) — the same types/parser gap this change closes. Answered with a
structural `TypeCastLike` type, not a suppression.
