### PR TITLE
feat(office): sideload serves from the current folder; locate binary resources

### DIFF
--- a/packages/coding-agent/src/cli/office-cli.ts
+++ b/packages/coding-agent/src/cli/office-cli.ts
@@ -222,11 +222,25 @@ async function runSideload(app: OfficeApp): Promise<void> {
 	}
 }
 
+/**
+ * The two long-running halves of the command, injectable so the dispatch order can be
+ * tested without binding :8444 or shelling out to `office-addin-debugging`.
+ */
+export interface OfficeCommandDeps {
+	sideload: (app: OfficeApp) => Promise<void>;
+	serve: () => Promise<void>;
+}
+
+const defaultCommandDeps: OfficeCommandDeps = { sideload: runSideload, serve: runServe };
+
 /** Dispatch an `xcsh office <action>` invocation. */
-export async function runOfficeCommand(args: OfficeCommandArgs): Promise<void> {
+export async function runOfficeCommand(
+	args: OfficeCommandArgs,
+	deps: OfficeCommandDeps = defaultCommandDeps,
+): Promise<void> {
 	switch (args.action) {
 		case "serve":
-			await runServe();
+			await deps.serve();
 			return;
 		case "manifest": {
 			const text = await writeManifest(args.out);
@@ -238,7 +252,16 @@ export async function runOfficeCommand(args: OfficeCommandArgs): Promise<void> {
 			return;
 		}
 		case "sideload":
-			await runSideload(args.app ?? "excel");
+			// Register FIRST, then serve — serve blocks until a signal, so anything
+			// sequenced after it would never run.
+			//
+			// Registering alone used to be the whole command, which quietly left the
+			// operator half-configured: the pane's cwd (what its file tools and shell are
+			// confined to) comes from wherever `office serve` was launched, so a bare
+			// sideload produced a pane pointed at some unrelated folder, or at nothing.
+			// One command from the folder you care about now does both.
+			await deps.sideload(args.app ?? "excel");
+			await deps.serve();
 			return;
 		case "recycle":
 			console.log(await recycleOfficeServe());

--- a/packages/coding-agent/src/internal-urls/plugin-resolve.test.ts
+++ b/packages/coding-agent/src/internal-urls/plugin-resolve.test.ts
@@ -22,11 +22,16 @@ beforeAll(async () => {
 		path.join(root, ".xcsh-plugin", "resources.json"),
 		JSON.stringify({
 			schema: "schema/s.json",
+			template: "assets/t.xlsx",
 			engine: { runtime: "bun", entry: "engine/cli.ts", commands: ["validate"] },
 		}),
 	);
 	await fs.writeFile(path.join(root, "schema", "s.json"), `{"title":"x"}`);
 	await fs.writeFile(path.join(root, "engine", "cli.ts"), `console.log("hi")`);
+	// A binary resource: the first bytes of a real .xlsx (a zip container), including a
+	// NUL, so a UTF-8 read of it is lossy rather than merely ugly.
+	await fs.mkdir(path.join(root, "assets"), { recursive: true });
+	await fs.writeFile(path.join(root, "assets", "t.xlsx"), Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0xff, 0xfe]));
 	// Symlink inside the plugin root pointing outside it (for escape-via-symlink test).
 	await fs.symlink(os.tmpdir(), path.join(root, "escape"));
 	roots = [{ plugin: "demo", version: "9.9.9", path: root }];
@@ -82,5 +87,61 @@ describe("PluginResolver", () => {
 
 	test("rejects escape via a symlink inside the plugin root", async () => {
 		await expect(resolver().resolve(u("xcsh://plugin/demo/file/escape/x"))).rejects.toThrow(/traversal/i);
+	});
+});
+
+/**
+ * A plugin may declare a binary resource — the MEDDPICC plugin ships a 91 KB .xlsx
+ * template. Reading one as UTF-8 corrupts it, and no consumer wants 91 KB of mangled
+ * text in a prompt anyway. What a caller actually needs is where the file is, so it can
+ * be copied or opened with a tool that understands the format.
+ */
+describe("binary resources", () => {
+	const resolver = () => createPluginResolver(async () => roots);
+
+	test("a declared binary resource reports its location and size instead of its bytes", async () => {
+		const r = await resolver().resolve(u("xcsh://plugin/demo/template"));
+		expect(r.contentType).toBe("application/json");
+		const meta = JSON.parse(r.content) as { path: string; bytes: number; binary: boolean };
+		expect(meta.binary).toBe(true);
+		expect(meta.bytes).toBe(7);
+		expect(meta.path).toBe(path.join(root, "assets", "t.xlsx"));
+		expect(r.sourcePath).toBe(path.join(root, "assets", "t.xlsx"));
+	});
+
+	test("the raw bytes never appear in the content", async () => {
+		const r = await resolver().resolve(u("xcsh://plugin/demo/template"));
+		// A UTF-8 read of this file yields "PK\u0003\u0004\u0000\ufffd\ufffd".
+		expect(r.content).not.toContain("PK");
+		expect(r.content).not.toContain("\u0000");
+	});
+
+	test("the file/<relpath> route treats the same file as binary too", async () => {
+		const r = await resolver().resolve(u("xcsh://plugin/demo/file/assets/t.xlsx"));
+		const meta = JSON.parse(r.content) as { binary: boolean; bytes: number };
+		expect(meta.binary).toBe(true);
+		expect(meta.bytes).toBe(7);
+	});
+
+	test("text resources are unaffected — schema still returns its contents", async () => {
+		const r = await resolver().resolve(u("xcsh://plugin/demo/schema"));
+		expect(r.content).toContain(`"title"`);
+	});
+
+	test("a missing binary resource still throws rather than reporting a phantom file", async () => {
+		await fs.writeFile(
+			path.join(root, ".xcsh-plugin", "resources.json"),
+			JSON.stringify({ schema: "schema/s.json", template: "assets/gone.xlsx" }),
+		);
+		await expect(resolver().resolve(u("xcsh://plugin/demo/template"))).rejects.toThrow(/not found/i);
+		// Restore the manifest for any later test in this file.
+		await fs.writeFile(
+			path.join(root, ".xcsh-plugin", "resources.json"),
+			JSON.stringify({
+				schema: "schema/s.json",
+				template: "assets/t.xlsx",
+				engine: { runtime: "bun", entry: "engine/cli.ts", commands: ["validate"] },
+			}),
+		);
 	});
 });

--- a/packages/coding-agent/src/internal-urls/plugin-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/plugin-resolve.ts
@@ -12,6 +12,10 @@
  * - xcsh://plugin/<name>/schema         -> file at manifest key "schema"
  * - xcsh://plugin/<name>/engine         -> manifest engine block, entry resolved to abs path
  * - xcsh://plugin/<name>/file/<relpath> -> any root-relative file
+ *
+ * Text resources resolve to their CONTENTS. A declared binary resource (a .xlsx
+ * template, an image) resolves to its LOCATION — `{binary, path, bytes}` — because a
+ * UTF-8 read would corrupt it and its bytes are useless in a prompt regardless.
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -46,6 +50,42 @@ function contentTypeFor(filePath: string): InternalResource["contentType"] {
 	if (ext === ".json") return "application/json";
 	if (ext === ".md") return "text/markdown";
 	return "text/plain";
+}
+
+/**
+ * Extensions a plugin may legitimately declare that are NOT text.
+ *
+ * Reading one as UTF-8 corrupts it, and nobody wants 91 KB of mangled bytes in a prompt
+ * either — the MEDDPICC plugin's `meddpicc-template.xlsx` is exactly that size. What a
+ * caller needs is where the file is, so it can be copied, opened, or handed to a tool
+ * that understands the format; so a binary resource resolves to its location, not its
+ * contents. Deliberately a small allow-list of formats plugins actually ship rather than
+ * content sniffing, so the decision is inspectable.
+ */
+const BINARY_EXTENSIONS = new Set([
+	".xlsx",
+	".xls",
+	".xlsm",
+	".docx",
+	".doc",
+	".pptx",
+	".ppt",
+	".pdf",
+	".png",
+	".jpg",
+	".jpeg",
+	".gif",
+	".webp",
+	".zip",
+	".gz",
+	".tgz",
+	".woff",
+	".woff2",
+	".ico",
+]);
+
+function isBinaryResource(filePath: string): boolean {
+	return BINARY_EXTENSIONS.has(path.extname(filePath).toLowerCase());
 }
 
 /** realpath that tolerates a missing leaf by resolving the nearest existing ancestor. */
@@ -155,15 +195,7 @@ export class PluginResolver {
 			const relativePath = selector.slice(1).join("/");
 			if (!relativePath) throw new Error("xcsh://plugin/<name>/file/ requires a relative path");
 			const target = await safeJoin(root.path, relativePath);
-			const content = await this.#readFile(target);
-			return {
-				url: url.href,
-				content,
-				contentType: contentTypeFor(target),
-				size: Buffer.byteLength(content, "utf-8"),
-				sourcePath: target,
-				notes: [],
-			};
+			return await this.#resource(url, target);
 		}
 
 		// Named resource key from the manifest (e.g. "schema", "example").
@@ -174,6 +206,28 @@ export class PluginResolver {
 			throw new Error(`Unknown resource "${kind}" for plugin ${name}\nAvailable: ${keys.join(", ") || "none"}`);
 		}
 		const target = await safeJoin(root.path, value);
+		return await this.#resource(url, target);
+	}
+
+	/**
+	 * Resolve one on-disk file, as contents for text and as a locator for binary.
+	 * Shared by the `file/<relpath>` route and the named-key route so the two cannot
+	 * disagree about what a `.xlsx` is.
+	 */
+	async #resource(url: InternalUrl, target: string): Promise<InternalResource> {
+		if (isBinaryResource(target)) {
+			const file = Bun.file(target);
+			if (!(await file.exists())) throw new Error(`File not found: ${target}`);
+			const body = JSON.stringify({ binary: true, path: target, bytes: file.size });
+			return {
+				url: url.href,
+				content: body,
+				contentType: "application/json",
+				size: Buffer.byteLength(body, "utf-8"),
+				sourcePath: target,
+				notes: ["Binary resource: this is its location, not its bytes. Open or copy it with a tool."],
+			};
+		}
 		const content = await this.#readFile(target);
 		return {
 			url: url.href,

--- a/packages/coding-agent/src/internal-urls/terraform-index.generated.ts
+++ b/packages/coding-agent/src/internal-urls/terraform-index.generated.ts
@@ -149,6 +149,22 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			],
 		},
 		{
+			name: "Uncategorized",
+			slug: "uncategorized",
+			description: "Resources pending categorization",
+			resource_count: 8,
+			resources: [
+				"application_profiles",
+				"authorization_server",
+				"bot_infrastructure",
+				"domain",
+				"mitigated_domain",
+				"protected_application",
+				"protected_domain",
+				"registration_approval",
+			],
+		},
+		{
 			name: "DNS",
 			slug: "dns",
 			description: "DNS domains, zones, compliance checks, and DNS proxy configuration",
@@ -164,33 +180,11 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			],
 		},
 		{
-			name: "Uncategorized",
-			slug: "uncategorized",
-			description: "Resources pending categorization",
-			resource_count: 7,
-			resources: [
-				"application_profiles",
-				"authorization_server",
-				"bot_infrastructure",
-				"mitigated_domain",
-				"protected_application",
-				"protected_domain",
-				"registration_approval",
-			],
-		},
-		{
 			name: "API Security",
 			slug: "api-security",
 			description: "API definition, discovery, testing, and security controls for web APIs",
 			resource_count: 5,
 			resources: ["api_crawler", "api_definition", "api_discovery", "api_testing", "app_api_group"],
-		},
-		{
-			name: "Monitoring",
-			slug: "monitoring",
-			description: "Log receivers, alert policies, APM, and global logging configuration",
-			resource_count: 5,
-			resources: ["alert_receiver", "alert_template", "apm", "global_log_receiver", "log_receiver"],
 		},
 		{
 			name: "Applications",
@@ -212,6 +206,13 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			description: "TLS certificates, certificate chains, CRLs, and trusted CA lists",
 			resource_count: 4,
 			resources: ["certificate", "certificate_chain", "crl", "trusted_ca_list"],
+		},
+		{
+			name: "Monitoring",
+			slug: "monitoring",
+			description: "Log receivers, alert policies, alert templates, and global logging configuration",
+			resource_count: 4,
+			resources: ["alert_receiver", "alert_template", "global_log_receiver", "log_receiver"],
 		},
 		{
 			name: "VPN",
@@ -386,16 +387,6 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 			},
 			import_syntax: "terraform import xcsh_api_testing.example namespace/name",
 		},
-		apm: {
-			category: "monitoring",
-			description: "New APM as a service with configured parameters",
-			required: ["name", "namespace"],
-			minimal_config: 'resource "xcsh_apm" "example" {\n  name      = "example-apm"\n  namespace = "staging"\n}',
-			dependencies: {
-				requires: [],
-			},
-			import_syntax: "terraform import xcsh_apm.example namespace/name",
-		},
 		app_api_group: {
 			category: "api-security",
 			description: "App_api_group creates a new object in the storage backend for metadata.namespace",
@@ -531,7 +522,7 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		bgp_routing_policy: {
 			category: "security",
 			description:
-				"Bgp routing policy is a list of rules containing match criteria and action to be applied. these rules help contol routes which are imported or exported to bgp peers. configuration",
+				"Bgp routing policy is a list of rules containing match criteria and action to be applied. these rules help control routes which are imported or exported to bgp peers. configuration",
 			required: ["name", "namespace"],
 			minimal_config:
 				'resource "xcsh_bgp_routing_policy" "example" {\n  name      = "example-bgp-routing-policy"\n  namespace = "staging"\n}',
@@ -856,6 +847,17 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 				requires: [],
 			},
 			import_syntax: "terraform import xcsh_dns_zone.example namespace/name",
+		},
+		domain: {
+			category: "uncategorized",
+			description: "Allowed domain",
+			required: ["name", "namespace", "allowed_domain"],
+			minimal_config:
+				'resource "xcsh_domain" "example" {\n  name      = "example-domain"\n  namespace = "staging"\n\n  allowed_domain = "example-value"\n}',
+			dependencies: {
+				requires: [],
+			},
+			import_syntax: "terraform import xcsh_domain.example namespace/name",
 		},
 		endpoint: {
 			category: "load-balancing",
@@ -1636,9 +1638,9 @@ export const TERRAFORM_INDEX: TerraformIndex = {
 		udp_loadbalancer: {
 			category: "load-balancing",
 			description: "Load balancing UDP traffic across origin pools",
-			required: ["name", "namespace", "dns_volterra_managed", "enable_per_packet_load_balancing", "idle_timeout"],
+			required: ["name", "namespace", "dns_volterra_managed", "idle_timeout"],
 			minimal_config:
-				'resource "xcsh_udp_loadbalancer" "example" {\n  name      = "example-udp-loadbalancer"\n  namespace = "staging"\n\n  domains                          = ["example-value"]\n  dns_volterra_managed             = true\n  enable_per_packet_load_balancing = true\n  idle_timeout                     = 1\n}',
+				'resource "xcsh_udp_loadbalancer" "example" {\n  name      = "example-udp-loadbalancer"\n  namespace = "staging"\n\n  domains              = ["example-value"]\n  dns_volterra_managed = true\n  idle_timeout         = 1\n}',
 			dependencies: {
 				requires: ["namespace", "origin_pool"],
 			},

--- a/packages/coding-agent/test/office-cli.test.ts
+++ b/packages/coding-agent/test/office-cli.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { type OfficeServeDeps, officeWefDirs, removeStaleWefManifests, startOfficeServe } from "../src/cli/office-cli";
+import {
+	type OfficeServeDeps,
+	officeWefDirs,
+	removeStaleWefManifests,
+	runOfficeCommand,
+	startOfficeServe,
+} from "../src/cli/office-cli";
 
 /** A supersede seam that records it ran and reports nothing stale (no-op). */
 function noopSupersede() {
@@ -141,5 +147,78 @@ describe("office sideload idempotency (wef manifest cleanup)", () => {
 
 		removeStaleWefManifests(ID, home);
 		expect(fs.existsSync(other)).toBe(true);
+	});
+});
+
+/**
+ * `office sideload` used to REGISTER the add-in and exit. The pane's working folder —
+ * which is what its file tools and shell are confined to — comes from whatever
+ * `office serve` was launched from, so registering alone left the operator with a
+ * pane pointed at some other directory, or none at all. Sideloading now serves too,
+ * from the current folder, and blocks; `serve` remains available on its own.
+ */
+describe("office sideload starts the server from the current folder", () => {
+	function seams() {
+		const order: string[] = [];
+		let releaseServe = (): void => {};
+		const serveBlocked = new Promise<void>(resolve => {
+			releaseServe = resolve;
+		});
+		return {
+			order,
+			releaseServe,
+			deps: {
+				sideload: async (app: string) => {
+					order.push(`sideload:${app}`);
+				},
+				serve: async () => {
+					order.push("serve");
+					await serveBlocked;
+					order.push("serve:done");
+				},
+			},
+		};
+	}
+
+	test("registers the add-in FIRST, then serves", async () => {
+		// Order matters: serve blocks forever, so registering after it would never run.
+		const s = seams();
+		const run = runOfficeCommand({ action: "sideload", app: "excel" }, s.deps);
+		await Bun.sleep(5);
+		expect(s.order).toEqual(["sideload:excel", "serve"]);
+		s.releaseServe();
+		await run;
+		expect(s.order).toEqual(["sideload:excel", "serve", "serve:done"]);
+	});
+
+	test("blocks in serve rather than returning once the add-in is registered", async () => {
+		const s = seams();
+		let settled = false;
+		void runOfficeCommand({ action: "sideload", app: "word" }, s.deps).then(() => {
+			settled = true;
+		});
+		await Bun.sleep(20);
+		expect(settled).toBe(false);
+		s.releaseServe();
+		await Bun.sleep(5);
+		expect(settled).toBe(true);
+	});
+
+	test("defaults to excel when no app is given", async () => {
+		const s = seams();
+		const run = runOfficeCommand({ action: "sideload" }, s.deps);
+		await Bun.sleep(5);
+		expect(s.order[0]).toBe("sideload:excel");
+		s.releaseServe();
+		await run;
+	});
+
+	test("`serve` on its own still serves and does not sideload", async () => {
+		const s = seams();
+		const run = runOfficeCommand({ action: "serve" }, s.deps);
+		await Bun.sleep(5);
+		expect(s.order).toEqual(["serve"]);
+		s.releaseServe();
+		await run;
 	});
 });

--- a/packages/office-pane/UAT.md
+++ b/packages/office-pane/UAT.md
@@ -10,11 +10,15 @@ the pane, the host tools, or the chat engine.
 ## Setup
 
 1. Install the build under test (`brew upgrade xcsh`; confirm `xcsh --version`).
-2. Start the server from a small working directory:
-   `cd /tmp/xcsh-office-cwd && xcsh office serve` (leave it running).
-3. Sideload the add-in into the target app (`xcsh office sideload excel|word|powerpoint`, e.g. `xcsh office sideload word`)
-   and open the **xcsh** pane.
+2. From the working directory you want the pane scoped to, sideload and serve in one
+   command — it registers the add-in, then serves and blocks until Ctrl+C:
+   `cd /tmp/xcsh-office-cwd && xcsh office sideload excel|word|powerpoint`.
+   The directory matters: the sandbox confines the pane's file tools and its shell to it.
+3. Open the **xcsh** pane in the target app.
 4. Record the version and the pass/fail of each row.
+
+`xcsh office serve` still exists for a pane that is already registered (re-serving after a
+restart, or pointing an existing add-in at a different folder).
 
 Legend: **Fix** names the issue the row validates.
 
@@ -84,6 +88,24 @@ normal text shapes.
 | S2 | Run `xcsh office serve` from a large directory (for example the home directory) | It comes up quickly, with no "system prompt preparation timed out" warning. | #2246 |
 | S3 | `brew upgrade` while a server is running | The upgrade's post-install step recycles the running server. | #2241 |
 | S4 | Run `xcsh office recycle` with a server running, then with none | First stops the running server; second reports none is running. | #2241 |
+| S5 | `cd /tmp/xcsh-office-cwd && xcsh office sideload excel` | Registers the add-in AND starts serving from that directory, then blocks until Ctrl+C — one command, no separate `serve`. | #2485 |
+| S6 | In the pane, ask "what directory are you working in, and list its files" | The answer names the directory the sideload was launched from, not the home directory or a stale one. | #2485 |
+
+## Marketplace plugins (Excel)
+
+Requires an installed plugin that ships commands, skills and a schema. These rows use
+`meddpicc@f5-sales-demo-marketplace` (>= 2.2.0) and a folder holding a deal JSON —
+sideload from that folder.
+
+| # | Action / prompt | Expected | Fix |
+|---|---|---|---|
+| P1 | Open the composer's `/` menu | Lists the plugin's slash commands with their descriptions (`/meddpicc:qualify-deal`, `/meddpicc:deal-review`, …), not an empty menu and not a missing button. | #2480 |
+| P2 | Open `+` → Skills | Lists the plugin's skills (`meddpicc:coach`, `meddpicc:deal-review`, …). | #2473 |
+| P3 | Send `/meddpicc:meddpicc-status` | The assistant follows the COMMAND — reports schema readiness and inventories the deal files in the working directory. It must not answer *about* the literal string. | #2480 |
+| P4 | Send `/meddpicc:qualify-deal <account>` | The argument reaches the command (the reply is about that account, not `$ARGUMENTS`). | #2480 |
+| P5 | Ask "generate a meddpicc report" in plain English | Reaches the same place through the skill — no slash command needed. | #2473 |
+| P6 | During P4/P5, watch for a new worksheet | A sheet named after the deal is created and populated; the sheet you started on is not overwritten. Re-running overwrites that sheet rather than adding a duplicate tab. | #2476 |
+| P7 | Ask "show me the meddpicc schema" | The assistant reads it via `xcsh://plugin/meddpicc/schema` and does not claim plugin resources are unavailable. | #2476 |
 
 ## Coverage notes
 


### PR DESCRIPTION
Closes #2485

## 1. `sideload` left the pane half-configured

`xcsh office sideload excel` symlinked the manifest into Office's `wef` folder and exited.
It never started the server — that is `office serve`, a separate command.

That matters more than it sounds, because **the pane's working directory is what the
sandbox confines its file tools and shell to**, and it comes from wherever `office serve`
was launched. A bare sideload therefore produced either a pane that could not load
(nothing on :8444) or one pointed at whatever folder an earlier serve happened to use.
Working a deal means `cd`-ing to the deal folder — and the command that sounds like "set
this up" was the one that did not pin it.

Now: register, then serve from the current folder, and block. Registration goes first
because serve never returns. `serve` stays available on its own.

```
cd ~/MEDDPICC/CUSTOMER-C && xcsh office sideload excel
```

The two long-running halves are injectable, so the dispatch order is tested without
binding :8444 or shelling out to `office-addin-debugging` — including that it *blocks*
rather than returning once registered.

## 2. A binary plugin resource was read as UTF-8

Every declared resource went through `Bun.file(path).text()`, and `contentTypeFor` labelled
a `.xlsx` as `text/plain`. The MEDDPICC plugin declares a **91 KB** template. That read
corrupts it (invalid UTF-8 → U+FFFD), and 91 KB of mangled bytes would be useless to the
caller even intact. What a caller needs from a template is *where it is*.

A binary resource now resolves to `{binary, path, bytes}`, over both the `file/<relpath>`
and named-key routes, from **one shared helper** so the two cannot disagree about what a
`.xlsx` is. The extension list is explicit rather than content-sniffed, so the decision is
inspectable in review.

Verified against the actually-installed plugin:

```
xcsh://plugin/meddpicc/schema  → application/json | 22952 bytes | {"$schema": "https://json-schema.org/…
xcsh://plugin/meddpicc/file/…/meddpicc-template.xlsx
                               → application/json |   193 bytes | {"binary":true,"path":"/Users/…/meddpicc-template.xlsx","bytes":…
```

## Verification

- 9 new tests (4 dispatch-order, 5 binary-resource). **Mutation-checked**: forcing
  `isBinaryResource` to `false` fails three of them (confirmed).
- `packages/coding-agent`: 5863 pass / 1 fail — `AgentSession … should allow steer()`,
  which passes in isolation and is the parallel-load contention tracked in **#2423**, not
  this change. Reported rather than rounded to green.
- `bun run check:ts` clean end to end (root tools + every workspace package).
- Codex `verified-code-review` (`adversarial-review --base origin/main`): **0 findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)