### PR TITLE
fix(ci): assert a release run exists for the tag, not that the push exited 0

### DIFF
--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -54,6 +54,13 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
 
+      # Needed only by the release-chain verification step below. The script it
+      # runs has no imports, so the bun binary alone is enough — no `bun install`.
+      - name: Set up bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3"
+
       - name: Resolve target commit SHA
         id: target
         env:
@@ -136,4 +143,19 @@ jobs:
             attempt=$((attempt + 1))
             delay=$((delay * 2))
           done
-          echo "Pushed tag ${TAG} -> ${SHA} — tag-gated release chain will now fire."
+          # Deliberately does NOT claim the release chain will fire — a push can
+          # exit 0 having emitted no event at all. The next step establishes that.
+          echo "Pushed tag ${TAG} -> ${SHA}."
+
+      # Runs whether or not the push was skipped, and that is the point. A push
+      # that half-fails (GitHub writes the ref, then errors) leaves the tag on
+      # origin with NO push event; the retry then reports `Everything up-to-date`,
+      # which is indistinguishable from success. Re-running this workflow cannot
+      # recover it either — the duplicate-tag guard above sees the tag and skips
+      # the push, so nothing ever emits an event again. Assert the post-condition
+      # that actually matters instead: a CI run exists for the tag. (#2487)
+      - name: Verify the release chain actually fired
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          TAG: ${{ steps.v.outputs.tag }}
+        run: bun scripts/ci-ensure-tag-release-run.ts "${TAG}"

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -56,8 +56,14 @@ jobs:
 
       # Needed only by the release-chain verification step below. The script it
       # runs has no imports, so the bun binary alone is enough — no `bun install`.
+      #
+      # Pinned to an immutable commit rather than the `v2` tag this repo uses
+      # elsewhere: this job holds RELEASE_TOKEN, so a third-party action that
+      # could be repointed at new code is a privileged place to accept that risk.
+      # The rest of the repo pins nothing (including `@nightly` and org workflows
+      # at `@main`) — that wider gap is its own problem, not one to solve here.
       - name: Set up bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3"
 

--- a/packages/coding-agent/test/scripts/ensure-tag-release-run.test.ts
+++ b/packages/coding-agent/test/scripts/ensure-tag-release-run.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { ensureTagReleaseRun } from "../../../../scripts/ci-ensure-tag-release-run";
+
+/**
+ * The tagging workflow's real post-condition (#2487).
+ *
+ * `git push origin <tag>` exiting 0 does NOT mean the release chain will fire.
+ * On 2026-07-27 v19.96.0 was tagged and never released: the first push attempt
+ * half-succeeded — GitHub wrote the ref, then failed with
+ * `fatal error in commit_refs` and reported `[remote rejected]` — so **no push
+ * event was emitted**. The retry five seconds later found the ref already there
+ * and printed `Everything up-to-date`, which the `until` loop read as success.
+ * The workflow exited 0 announcing a chain that never fired.
+ *
+ * Worse, the state is unrecoverable by re-running: the duplicate-tag guard sees
+ * the tag on origin and skips the push, so nothing ever emits an event again.
+ *
+ * So the post-condition to wait on is not "push exited 0" but "a CI run exists
+ * for refs/tags/<tag>" — and when it is missing, the chain must be dispatched
+ * explicitly rather than assumed. Same rule as #2364/#2463: wait on the thing
+ * you actually need, never on a proxy for it.
+ */
+
+type Call = string;
+
+function harness(runCounts: number[], opts: { dispatchThrows?: boolean; afterDispatch?: number[] } = {}) {
+	const calls: Call[] = [];
+	const before = [...runCounts];
+	const after = [...(opts.afterDispatch ?? [])];
+	let dispatched = false;
+	return {
+		calls,
+		deps: {
+			countRuns: async () => {
+				calls.push("count");
+				const queue = dispatched ? after : before;
+				return queue.length > 0 ? (queue.shift() as number) : 0;
+			},
+			dispatch: async () => {
+				calls.push("dispatch");
+				dispatched = true;
+				if (opts.dispatchThrows) throw new Error("dispatch refused");
+			},
+			sleep: async () => {
+				calls.push("sleep");
+			},
+			log: () => {},
+		},
+	};
+}
+
+const FAST = { pollAttempts: 3, pollDelayMs: 0, confirmAttempts: 2 };
+
+describe("ensureTagReleaseRun waits on 'a run exists', not on 'push exited 0' (#2487)", () => {
+	it("reports already-fired without dispatching when the run is already there", async () => {
+		const h = harness([1]);
+		const out = await ensureTagReleaseRun("v1.2.3", h.deps, FAST);
+		expect(out.status).toBe("already-fired");
+		expect(h.calls).not.toContain("dispatch");
+	});
+
+	it("tolerates event lag: polls until the run shows up, still without dispatching", async () => {
+		// GitHub can take a moment to register the run; absence on the first look
+		// is not yet evidence the event was dropped.
+		const h = harness([0, 0, 1]);
+		const out = await ensureTagReleaseRun("v1.2.3", h.deps, FAST);
+		expect(out.status).toBe("already-fired");
+		expect(h.calls).not.toContain("dispatch");
+	});
+
+	it("dispatches the chain when the push emitted no event at all", async () => {
+		// The v19.96.0 case: tag present, zero runs, forever.
+		const h = harness([0, 0, 0], { afterDispatch: [1] });
+		const out = await ensureTagReleaseRun("v19.96.0", h.deps, FAST);
+		expect(out.status).toBe("dispatched");
+		expect(h.calls.filter(c => c === "dispatch")).toHaveLength(1);
+	});
+
+	it("fails loudly when even the dispatch produces no run", async () => {
+		const h = harness([0, 0, 0], { afterDispatch: [0, 0] });
+		const out = await ensureTagReleaseRun("v19.96.0", h.deps, FAST);
+		expect(out.status).toBe("failed");
+	});
+
+	it("fails loudly when the dispatch itself is refused", async () => {
+		const h = harness([0, 0, 0], { dispatchThrows: true });
+		const out = await ensureTagReleaseRun("v19.96.0", h.deps, FAST);
+		expect(out.status).toBe("failed");
+		expect(out.detail).toContain("dispatch refused");
+	});
+
+	it("never dispatches twice", async () => {
+		const h = harness([0, 0, 0], { afterDispatch: [0, 0] });
+		await ensureTagReleaseRun("v19.96.0", h.deps, FAST);
+		expect(h.calls.filter(c => c === "dispatch")).toHaveLength(1);
+	});
+
+	it("reports how many polls it took, so a slow event is visible in the log", async () => {
+		const h = harness([0, 1]);
+		const out = await ensureTagReleaseRun("v1.2.3", h.deps, FAST);
+		expect(out.status).toBe("already-fired");
+		expect(out.polls).toBe(2);
+	});
+});
+
+describe("the tagging workflow is wired to the check (#2487)", () => {
+	const workflow = async () =>
+		await fs.readFile(path.join(import.meta.dir, "../../../../.github/workflows/tag-on-version-bump.yml"), "utf8");
+
+	it("invokes the verification script", async () => {
+		expect(await workflow()).toContain("bun scripts/ci-ensure-tag-release-run.ts");
+	});
+
+	it("runs the verification even when the duplicate-tag guard skipped the push", async () => {
+		// The unrecoverable state IS the skip path: tag on origin, no event, and a
+		// re-run skips the push and emits nothing. Gating the check on
+		// `skip != 'true'` would reintroduce exactly the trap it exists to catch.
+		const src = await workflow();
+		const step = src.slice(src.indexOf("Verify the release chain actually fired"));
+		expect(step).not.toContain("steps.guard.outputs.skip");
+	});
+
+	it("provides bun to the job, since the job is otherwise a bare checkout", async () => {
+		expect(await workflow()).toContain("oven-sh/setup-bun");
+	});
+
+	it("no longer claims the chain will fire merely because the push exited 0", async () => {
+		expect(await workflow()).not.toContain("tag-gated release chain will now fire");
+	});
+
+	it("passes the tag through env rather than interpolating it into the shell", async () => {
+		// Workflow-injection hygiene: the tag must reach the command as a quoted
+		// shell variable supplied via `env:`, never as a GitHub expression expanded
+		// directly into the run: body. Written as regexes so the assertion itself
+		// does not embed a literal `${...}` (which reads as a broken JS template).
+		const src = await workflow();
+		const step = src.slice(src.indexOf("Verify the release chain actually fired"));
+		expect(step).toMatch(/bun scripts\/ci-ensure-tag-release-run\.ts "\$\{TAG\}"/);
+		expect(step.slice(0, step.indexOf("run:"))).toMatch(/env:\s*\n\s*GH_TOKEN:/);
+		// No `${{ ... }}` inside the run: body.
+		expect(step.slice(step.indexOf("run:"))).not.toMatch(/\$\{\{/);
+	});
+});

--- a/scripts/ci-ensure-tag-release-run.ts
+++ b/scripts/ci-ensure-tag-release-run.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env bun
+
+/**
+ * Assert the tagging workflow's REAL post-condition: a CI run exists for the tag.
+ *
+ * `git push origin <tag>` exiting 0 does not mean the tag-gated release chain will
+ * fire. On 2026-07-27 v19.96.0 was tagged and never released (#2487): the first
+ * push attempt half-succeeded — GitHub wrote the ref, then failed with
+ * `fatal error in commit_refs` and reported `[remote rejected]` — so no push event
+ * was emitted. The retry five seconds later found the ref already present and
+ * printed `Everything up-to-date`, which the workflow's `until` loop read as
+ * success. It exited 0 announcing a chain that never fired, and npm/Homebrew sat
+ * on the previous version while every merge after it went unshipped.
+ *
+ * That state is also unrecoverable by re-running the tagging workflow: its
+ * duplicate-tag guard sees the tag already on origin, skips the push, and so emits
+ * nothing — forever. Only a manual dispatch or a later version bump escapes it.
+ *
+ * So this script waits on the post-condition instead of a proxy for it, and runs
+ * whether or not the push step was skipped. If no run appears it dispatches the
+ * chain explicitly; if that also fails it exits non-zero so the tag never sits
+ * silently unreleased again.
+ *
+ * Usage:
+ *   bun scripts/ci-ensure-tag-release-run.ts <tag>
+ *
+ * Requires `gh` authenticated (GH_TOKEN) with actions:read and actions:write.
+ */
+
+/** How the caller looks up how many CI runs exist for a tag ref. */
+export type CountRuns = (tag: string) => Promise<number>;
+/** How the caller triggers the tag-gated chain for a tag ref. */
+export type Dispatch = (tag: string) => Promise<void>;
+
+export interface EnsureDeps {
+	countRuns: CountRuns;
+	dispatch: Dispatch;
+	sleep: (ms: number) => Promise<void>;
+	log: (message: string) => void;
+}
+
+export interface EnsureOptions {
+	/** Polls before concluding the push emitted no event. */
+	pollAttempts?: number;
+	/** Delay between polls, ms. */
+	pollDelayMs?: number;
+	/** Polls after dispatching, before giving up. */
+	confirmAttempts?: number;
+}
+
+export interface EnsureOutcome {
+	status: "already-fired" | "dispatched" | "failed";
+	/** Total lookups performed — makes a slow event visible in the workflow log. */
+	polls: number;
+	detail?: string;
+}
+
+const DEFAULTS = { pollAttempts: 12, pollDelayMs: 10_000, confirmAttempts: 6 } as const;
+
+/**
+ * Ensure a CI run exists for `tag`, dispatching the chain if the push emitted no
+ * event. Pure with respect to I/O — every effect arrives through `deps`, so the
+ * decision logic is testable in milliseconds instead of against a live release.
+ */
+export async function ensureTagReleaseRun(
+	tag: string,
+	deps: EnsureDeps,
+	options: EnsureOptions = {},
+): Promise<EnsureOutcome> {
+	const { pollAttempts, pollDelayMs, confirmAttempts } = { ...DEFAULTS, ...options };
+	let polls = 0;
+
+	// A run can lag the push by a few seconds, so absence on the first look is not
+	// yet evidence the event was dropped.
+	for (let i = 0; i < pollAttempts; i++) {
+		polls++;
+		if ((await deps.countRuns(tag)) > 0) {
+			deps.log(`A CI run exists for ${tag} (after ${polls} check${polls === 1 ? "" : "s"}).`);
+			return { status: "already-fired", polls };
+		}
+		if (i < pollAttempts - 1) await deps.sleep(pollDelayMs);
+	}
+
+	deps.log(
+		`No CI run appeared for ${tag} after ${polls} checks — the tag exists but its push emitted no event. Dispatching the release chain explicitly.`,
+	);
+	try {
+		await deps.dispatch(tag);
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		return { status: "failed", polls, detail: `dispatch failed: ${detail}` };
+	}
+
+	for (let i = 0; i < confirmAttempts; i++) {
+		polls++;
+		if ((await deps.countRuns(tag)) > 0) {
+			deps.log(`Dispatched chain for ${tag} is running.`);
+			return { status: "dispatched", polls };
+		}
+		if (i < confirmAttempts - 1) await deps.sleep(pollDelayMs);
+	}
+
+	return {
+		status: "failed",
+		polls,
+		detail: `dispatched the chain for ${tag} but no run appeared`,
+	};
+}
+
+/** Count CI runs on `refs/tags/<tag>` via the GitHub CLI. */
+async function ghCountRuns(tag: string): Promise<number> {
+	const proc = Bun.spawn(
+		["gh", "run", "list", "--workflow=ci.yml", "--branch", tag, "--limit", "1", "--json", "databaseId"],
+		{ stdout: "pipe", stderr: "pipe" },
+	);
+	const out = await new Response(proc.stdout).text();
+	if ((await proc.exited) !== 0) return 0;
+	try {
+		return (JSON.parse(out) as unknown[]).length;
+	} catch {
+		return 0;
+	}
+}
+
+/** Dispatch ci.yml on `refs/tags/<tag>`. */
+async function ghDispatch(tag: string): Promise<void> {
+	const proc = Bun.spawn(["gh", "workflow", "run", "ci.yml", "--ref", tag], { stdout: "pipe", stderr: "pipe" });
+	const err = await new Response(proc.stderr).text();
+	if ((await proc.exited) !== 0) throw new Error(err.trim() || `gh workflow run failed for ${tag}`);
+}
+
+if (import.meta.main) {
+	const tag = process.argv[2];
+	if (!tag) {
+		console.error("::error::usage: bun scripts/ci-ensure-tag-release-run.ts <tag>");
+		process.exit(2);
+	}
+	const outcome = await ensureTagReleaseRun(tag, {
+		countRuns: ghCountRuns,
+		dispatch: ghDispatch,
+		sleep: (ms: number) => Bun.sleep(ms),
+		log: (message: string) => {
+			console.log(message);
+		},
+	});
+	if (outcome.status === "failed") {
+		console.error(
+			`::error::${tag} is tagged but no release run could be started (${outcome.detail}). The tag is on origin, so re-running the tagging workflow will NOT help — its duplicate-tag guard will skip the push. Dispatch ci.yml on ${tag} manually.`,
+		);
+		process.exit(1);
+	}
+}


### PR DESCRIPTION
Fixes #2487

## What went wrong

`v19.96.0` was tagged and never released. From the tagging run's log:

```
20:11:49  remote: fatal error in commit_refs
20:11:49   ! [remote rejected]     v19.96.0 -> v19.96.0 (failure)
20:11:49  Tag push attempt 1 failed; retrying in 5s…
20:11:54  Everything up-to-date
20:11:54  Pushed tag v19.96.0 -> 2735e0bc9 — tag-gated release chain will now fire.
```

The first push **half-succeeded**: GitHub wrote the ref, then errored and reported the push
as rejected — so no `push` event was emitted. Five seconds later the retry found the ref
already present and printed `Everything up-to-date`, which `until git push` read as success.
The workflow exited 0 announcing a chain that never fired. npm and Homebrew stayed on the
previous version and every merge after it went unshipped.

Two properties turn a transient GitHub error into a silent, permanent stall:

1. **`Everything up-to-date` is indistinguishable from real success** after a half-failed
   attempt, so nothing surfaced the problem — the job was green.
2. **Re-running cannot recover it.** The duplicate-tag guard sees the tag on origin, sets
   `skip=true`, and skips the push entirely, so no event is ever emitted again. The only
   escapes are a manual dispatch or a later version bump. v19.96.0 was rescued by the
   latter, by luck: v19.97.0 landed while I was diagnosing and shipped the same commits.

## The fix

Wait on the post-condition that actually matters — **a CI run exists for
`refs/tags/<tag>`** — instead of on `git push` exiting 0. Same rule as #2364 and #2463:
never wait on a proxy for the thing you need.

The new step polls for the run, dispatches `ci.yml` on the tag if none appears, and exits
non-zero if even that yields nothing — with an error saying plainly that re-running the
tagging workflow will not help and why.

**It runs whether or not the push was skipped, and that is the point.** The skip path *is*
the unrecoverable state. A test pins this specifically, and fails if anyone gates the check
on `skip` — verified by injecting the gate and watching it go red:

```
(fail) the tagging workflow is wired to the check (#2487) > runs the verification even when
       the duplicate-tag guard skipped the push
```

## Testing

The decision logic lives in `scripts/ci-ensure-tag-release-run.ts` with every effect
injected, so it is tested in milliseconds rather than against a live release. Twelve tests:

- run already present → no dispatch
- event lagging, then arriving → no dispatch (absence on the first look is not evidence)
- never arriving → dispatch, then confirm (the v19.96.0 case)
- dispatch produces nothing → `failed`
- dispatch itself refused → `failed`, with the reason surfaced
- never dispatches twice; reports poll count so a slow event is visible in the log
- plus five assertions pinning the workflow wiring

Following the existing convention: root `scripts/*.ts` invoked from workflows (`release.ts`,
`ci-release-homebrew.ts`, …) with unit tests under `packages/coding-agent/test/scripts/`.

## Notes

- The job was a bare `ubuntu-22.04` + `actions/checkout`, so **`bun` did not exist there**.
  Added `oven-sh/setup-bun`. The script has no imports, so the binary alone suffices — no
  `bun install`.
- The tag reaches the command as a quoted shell variable via `env:`, never interpolated
  into the `run:` body; a test asserts that, and that no `${{ }}` appears in the body.
  `steps.v.outputs.tag` is already regex-constrained to `v\d+\.\d+\.\d+` upstream.
- `scripts/` is outside biome's `files.includes` (as are all sibling CI scripts) but is
  typechecked via `tsconfig.tools.json`, which `ci:check:full` runs.
- The misleading `— tag-gated release chain will now fire` message is gone; the push step
  now states only what it knows.

### Gates

- `bun run ci:check:full` — exit 0
- 12/12 tests pass
- `biome check` — clean
