### PR TITLE
fix(ci): stop cancelling main runs, which was silently skipping releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,14 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never cancel a main run. auto-release lives in this workflow and waits on
+  # check/native/test/install_methods (~10 min); a push landing inside that window
+  # used to cancel the previous run's auto-release, so no release PR was opened and
+  # the commit was never released -- silently, since nothing goes red. Main runs now
+  # queue on this group and execute in order. Sequential runs cannot open competing
+  # release PRs: scripts/release.ts bails when the release branch already exists.
+  # PR branches keep cancelling, where superseding a stale run is what you want.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # Fast lint + type check (no Rust, no native build needed)


### PR DESCRIPTION
Closes #2497

One-line change (plus comment): `cancel-in-progress: true` -> `${{ github.ref != 'refs/heads/main' }}`.

## The bug

`auto-release` lives inside this workflow and waits on `check/native/test/install_methods` — roughly
ten minutes. With `cancel-in-progress: true` on a group keyed by ref, **any push to `main` inside
that window cancelled the previous run and its `auto-release` job.** No release PR was opened,
`tag-on-version-bump.yml` never fired, and the commit was never released.

Three consecutive `main` runs died this way today, each killed by the next merge:

```
cancelled  22:25  chore: bump version to v19.97.0 (#2492)
cancelled  22:29  test(office): automate the plugin-surface UAT
cancelled  22:34  refactor: drop the LEGACY_ORG compatibility path (#2491)
```

**Nothing went red.** The PR view shows `auto-release` as `SKIPPED`, which is *correct* — it is
gated on `github.ref == refs/heads/main`. I initially misread that SKIPPED as the explanation and
assumed the pipeline was healthy because a version-bump commit had landed. It was not: the
cancellation is only visible by inspecting the post-merge run. Worth knowing, because the same
misreading is easy for anyone else looking at a PR.

`v19.97.0` was tagged from the 22:25 bump commit, so it predates and does not contain #2491.

## Why this is safe

- **No competing release PRs.** Sequential `auto-release` runs bail — `scripts/release.ts:301-305`
  checks `git ls-remote --heads origin <branch>` and skips when the release branch already exists.
- **Tag jobs were never affected.** They run under `refs/tags/v*`, a distinct group per tag.
- **Precedent exists.** `tag-on-version-bump.yml` already sets `cancel-in-progress: false`; this
  brings `ci.yml` in line rather than inventing a policy.
- PR branches keep cancelling, which is where superseding a stale run actually saves time.

Trade-off, stated plainly: `main` runs now queue and execute in order instead of superseding, so a
burst of merges takes longer to drain. That is the cost of not dropping releases.

## Verification

- `actionlint` clean, `yamllint` clean.
- `zizmor` identical to baseline — 30 findings, 1 pre-existing low at `:1236` (`npm install -g`),
  unrelated to this change. Confirmed by stashing and re-running against `origin/main`.
- YAML parses with the expression intact (`cancel-in-progress` is a documented expression field).
- Codex `adversarial-review`: 0 findings — weak signal, recorded as such.

**This cannot be unit-tested**; the proof is empirical. After merge I will confirm that a `main` run
survives a subsequent `main` push, and that the backlog drains — this commit is itself a non-`chore:`
push to `main`, so its own `auto-release` should open a release PR covering the unreleased commits,
including #2491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)