### PR TITLE
feat(office): write_cells — fill a formatted template in one batch

### DIFF
--- a/packages/coding-agent/src/browser/host-profiles.ts
+++ b/packages/coding-agent/src/browser/host-profiles.ts
@@ -124,6 +124,7 @@ TOOLS: Discover the workbook before you answer, then reach for the tool that mat
 - Use \`read_table\` for structured Excel Tables (it tracks the real extent), \`get_formulas\` to see the formulas behind cells, \`get_cell_metadata\` for cell types/number formats, and \`read_named_range\` to read a defined name.
 - Use \`sort_filter_table\` to sort or filter a Table by column.
 - Use \`read_range\`/\`write_range\` for arbitrary cell ranges (bare or sheet-qualified like Sheet2!A1:B10), and \`list_sheets\` when you only need the tab names.
+- Use \`write_cells\` to fill a formatted template: it takes many single \`{address, value}\` pairs and applies them in one batch, which is what merged cells need (only the top-left of a merge may be written, so a range write fails). Prefer it over a loop of \`write_range\` calls whenever you are placing more than a handful of individual values.
 - Use \`add_sheet\` to build a report on its own tab instead of overwriting the user's data. It is idempotent — an existing tab of that name is reused — so add first, then \`write_range\` block by block, and do not read the sheet back to confirm.
 ${OFFICE_NATIVE_TOOLS_NOTE}
 

--- a/packages/coding-agent/test/browser/host-profiles.test.ts
+++ b/packages/coding-agent/test/browser/host-profiles.test.ts
@@ -66,6 +66,9 @@ describe("host profiles", () => {
 		const t = HOST_PROFILES.excel.systemPrompt;
 		expect(t).toContain("add_sheet");
 		expect(t).toContain("idempotent");
+		// Filling a template is ~117 individual merged anchors; a loop of range writes is
+		// the wrong shape and the prompt has to say so.
+		expect(t).toContain("write_cells");
 	});
 
 	it("powerpoint prompt thinks in slides", () => {

--- a/packages/office-pane/src/office/excel-tools.ts
+++ b/packages/office-pane/src/office/excel-tools.ts
@@ -313,6 +313,73 @@ export function createExcelHostTools(excel: ExcelLike = getExcel()): HostToolReg
 		},
 		{
 			definition: {
+				name: "write_cells",
+				description:
+					"Write many INDIVIDUAL cells in one batch. Use this to fill a formatted template: each " +
+					"entry is one address and one value, so cells inside merged areas are written at their " +
+					"anchor, which a range write cannot do. Values are literal; strings that look like " +
+					"formulas are stored as text.",
+				parameters: {
+					type: "object",
+					properties: {
+						cells: {
+							type: "array",
+							description: "The cells to write, applied in one batch.",
+							items: {
+								type: "object",
+								properties: {
+									address: {
+										type: "string",
+										description: 'Single-cell A1 address, optionally sheet-qualified: "C4" or "Sheet2!C4".',
+									},
+									value: {
+										type: ["string", "number", "boolean"],
+										description:
+											"Literal value. Keep numbers numeric so the sheet's own formulas still compute.",
+									},
+								},
+								required: ["address", "value"],
+							},
+						},
+					},
+					required: ["cells"],
+				},
+			},
+			handler: async args => {
+				const cells = args.cells;
+				if (!Array.isArray(cells) || cells.length === 0) {
+					throw new Error('write_cells requires a non-empty "cells" array');
+				}
+				// Validate the WHOLE batch before touching the document. A half-applied fill
+				// leaves a report that looks complete and is not, with no way to tell which
+				// half landed.
+				const planned = cells.map((raw, i) => {
+					const cell = raw as { address?: unknown; value?: unknown };
+					if (typeof cell.address !== "string" || cell.address.trim() === "") {
+						throw new Error(`write_cells: entry ${i} has no address`);
+					}
+					if (cell.value === undefined || cell.value === null) {
+						throw new Error(`write_cells: entry ${i} (${cell.address}) has no value`);
+					}
+					const { sheet, range } = parseSheetAddress(cell.address);
+					return { sheet, range, value: sanitizeCellValue(cell.value) };
+				});
+
+				try {
+					await excel.run(async ctx => {
+						for (const p of planned) {
+							resolveWorksheet(ctx.workbook.worksheets, p.sheet).getRange(p.range).values = [[p.value]];
+						}
+						await ctx.sync();
+					});
+				} catch (err) {
+					throw new Error(describeExcelError("write_cells", `${planned.length} cell(s)`, err));
+				}
+				return textResult(`Wrote ${planned.length} cell(s).`, { cells: planned.length });
+			},
+		},
+		{
+			definition: {
 				name: "add_sheet",
 				description:
 					"Create a worksheet by name, or report that it already exists. Idempotent: safe to call " +

--- a/packages/office-pane/test/excel-tools.test.ts
+++ b/packages/office-pane/test/excel-tools.test.ts
@@ -256,6 +256,7 @@ describe("excel-tools", () => {
 		"read_range",
 		"read_table",
 		"sort_filter_table",
+		"write_cells",
 		"write_range",
 	];
 
@@ -907,6 +908,171 @@ describe("add_sheet", () => {
 		await flush();
 
 		expect(excel.sheetCells("Deal")["A1:B1"]).toEqual([["Account Name", "Visa, Inc."]]);
+		d.dispose();
+	});
+});
+
+/**
+ * `write_cells` — many single cells in ONE Excel.run.
+ *
+ * Filling the F5 MEDDPICC template means writing ~117 individual anchors. As
+ * `write_range` calls that is 117 round trips over the bridge, and the anchors cannot be
+ * batched into ranges because each sits inside a merged area where only the top-left may
+ * be written. So the batching has to happen tool-side.
+ */
+describe("write_cells", () => {
+	it("writes every cell in the batch", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		const excel = fakeExcel({}, { Sheet1: {} });
+		registerExcelTools(d, excel);
+
+		t.emit({
+			type: "host_tool_call",
+			id: "wc-1",
+			toolCallId: "tc-wc-1",
+			toolName: "write_cells",
+			arguments: {
+				cells: [
+					{ address: "C4", value: "Visa, Inc." },
+					{ address: "N7", value: 473687 },
+					{ address: "I5", value: 0.6 },
+				],
+			},
+		});
+		await flush();
+
+		expect(excel.cells.C4).toEqual([["Visa, Inc."]]);
+		expect(excel.cells.N7).toEqual([[473687]]);
+		expect(excel.cells.I5).toEqual([[0.6]]);
+		expect(firstText(callFrom(t))).toContain("3");
+		d.dispose();
+	});
+
+	it("honours a sheet-qualified address", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		const excel = fakeExcel({}, { Sheet1: {}, "MEDDPICC Deal Review Sheet": {} });
+		registerExcelTools(d, excel);
+
+		t.emit({
+			type: "host_tool_call",
+			id: "wc-2",
+			toolCallId: "tc-wc-2",
+			toolName: "write_cells",
+			arguments: { cells: [{ address: "'MEDDPICC Deal Review Sheet'!C4", value: "Visa" }] },
+		});
+		await flush();
+
+		expect(excel.sheetCells("MEDDPICC Deal Review Sheet").C4).toEqual([["Visa"]]);
+		d.dispose();
+	});
+
+	it("keeps numbers numeric — the template computes from them", async () => {
+		// The sheet's Factored Pipe is =N4*I5. A currency coerced to "$473,687" breaks it.
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		const excel = fakeExcel({}, { Sheet1: {} });
+		registerExcelTools(d, excel);
+
+		t.emit({
+			type: "host_tool_call",
+			id: "wc-3",
+			toolCallId: "tc-wc-3",
+			toolName: "write_cells",
+			arguments: { cells: [{ address: "N4", value: 1421060 }] },
+		});
+		await flush();
+
+		expect(typeof (excel.cells.N4 as unknown[][])[0][0]).toBe("number");
+		d.dispose();
+	});
+
+	it("neutralises a value Excel would execute as a formula", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		const excel = fakeExcel({}, { Sheet1: {} });
+		registerExcelTools(d, excel);
+
+		t.emit({
+			type: "host_tool_call",
+			id: "wc-4",
+			toolCallId: "tc-wc-4",
+			toolName: "write_cells",
+			arguments: { cells: [{ address: "C4", value: "=cmd|/c calc" }] },
+		});
+		await flush();
+
+		expect(String((excel.cells.C4 as unknown[][])[0][0]).startsWith("=")).toBe(false);
+		d.dispose();
+	});
+
+	it("rejects a malformed batch instead of writing half of it", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		const excel = fakeExcel({}, { Sheet1: {} });
+		registerExcelTools(d, excel);
+
+		t.emit({
+			type: "host_tool_call",
+			id: "wc-5",
+			toolCallId: "tc-wc-5",
+			toolName: "write_cells",
+			arguments: { cells: [{ address: "C4", value: "ok" }, { value: "no address" }] },
+		});
+		await flush();
+
+		expect(callFrom(t)?.isError).toBe(true);
+		// Validation happens before any write, so the good cell must not have landed.
+		expect(excel.cells.C4).toBeUndefined();
+		d.dispose();
+	});
+
+	it("rejects an empty batch rather than reporting a silent success", async () => {
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		registerExcelTools(d, fakeExcel({}, { Sheet1: {} }));
+
+		t.emit({
+			type: "host_tool_call",
+			id: "wc-6",
+			toolCallId: "tc-wc-6",
+			toolName: "write_cells",
+			arguments: { cells: [] },
+		});
+		await flush();
+
+		expect(callFrom(t)?.isError).toBe(true);
+		d.dispose();
+	});
+
+	it("a 117-cell batch is a SINGLE Excel.run", async () => {
+		// The whole reason this tool exists. One batch, one sync, one round trip.
+		const t = new MockTransport();
+		const d = new HostToolDispatcher(t);
+		const excel = fakeExcel({}, { Sheet1: {} });
+		let runs = 0;
+		const counting = {
+			...excel,
+			run: (b: Parameters<typeof excel.run>[0]) => {
+				runs++;
+				return excel.run(b);
+			},
+		};
+		registerExcelTools(d, counting as typeof excel);
+
+		const cells = Array.from({ length: 117 }, (_, i) => ({ address: `A${i + 1}`, value: i }));
+		t.emit({
+			type: "host_tool_call",
+			id: "wc-7",
+			toolCallId: "tc-wc-7",
+			toolName: "write_cells",
+			arguments: { cells },
+		});
+		await flush();
+
+		expect(runs).toBe(1);
+		expect(excel.cells.A117).toEqual([[116]]);
 		d.dispose();
 	});
 });


### PR DESCRIPTION
Closes #2501

## Why a new tool

Filling the F5 Deal Review Sheet template means writing ~117 **individual** cells. Neither
existing tool fits:

- `write_range` writes a rectangular grid to one address → 117 separate `host_tool_call`
  round trips over the bridge.
- Those anchors **cannot be coalesced into ranges**: nearly every one sits inside a merged
  area, and Office.js permits writing only the top-left cell of a merge. A range write
  spanning `C4:F4` fails where a 1×1 write to `C4` succeeds.

So the batching has to live in the tool, where a single `Excel.run` carries all of them.

## Behaviour worth reviewing

**The whole batch is validated before anything is written.** A half-applied fill leaves a
report that looks complete and is not, with nothing to indicate which half landed. One
malformed entry rejects the batch and the document is untouched — there is a test that a
good cell in a bad batch does *not* appear.

**Numbers stay numeric.** The template's Factored Pipe is `=N4*I5`; a currency coerced to
`"$473,687"` silently breaks the sheet's own arithmetic.

Reuses `parseSheetAddress`, `sanitizeCellValue` and `describeExcelError`, so
sheet-qualified addresses, formula-injection neutralising and actionable Office errors come
for free rather than being reimplemented.

## Verification

- 7 new tests. **Mutation-checked, both guards:**
  - giving each cell its own `Excel.run` fails *"a 117-cell batch is a SINGLE Excel.run"*
  - writing as we validate fails *"rejects a malformed batch instead of writing half of it"*
- `packages/office-pane`: 372 pass / 0 fail. `test/browser/` + `office-cli`: 374 pass / 0 fail.
- `bun run check:ts` clean across every workspace package.
- Codex `verified-code-review` (`adversarial-review --base origin/main`): **0 findings**.

**Full-workspace run: 6002 pass / 2 fail** — `AgentSession python cleanup` and
`ProfileCollector interface contract`. Both pass in isolation, neither is in code this PR
touches, and both are the parallel-load contention tracked in **#2423**. Reporting the
number rather than rounding it to green.

## Companion

marketplace **#863** teaches the MEDDPICC plugin to emit the cell plan this consumes
(`fill --plan`). That PR's `--out` path works today without this one; this one is what makes
the in-Excel path possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
