### PR TITLE
fix(ci): never auto-cancel a tag run, to protect the publishing chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,20 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never auto-cancel a tag run. The publishing chain (build-release ->
+  # create-release -> publish-npm / update-homebrew) lives in this workflow and
+  # inherits this group, so a cancel between publish-npm and update-homebrew
+  # would leave the version on npm with Homebrew stale and no rollback. All six
+  # jobs were cancelled on the v19.96.0 run; that escaped harm only because the
+  # cancel arrived before publish-npm did any work.
+  #
+  # refs/tags/vX.Y.Z is unique per tag, so an ordinary push cannot supersede it --
+  # the realistic collision is ci-ensure-tag-release-run.ts dispatching the chain
+  # after ~120s of polling, racing a run that only just became visible.
+  #
+  # main and PR branches keep cancelling: those collisions are frequent but cost
+  # only latency, and a superseded auto-release is picked up by the next run.
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
   # Fast lint + type check (no Rust, no native build needed)


### PR DESCRIPTION
Closes #2502

```yaml
cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
```

## Why

The publishing chain lives in `ci.yml` and inherits its concurrency group. Verified: **none** of
`build-release`, `build-sign-macos`, `create-release`, `publish-npm`, `update-homebrew`,
`verify-npm-install` declares job-level concurrency — and that would not help, since a
workflow-level cancel takes the whole run.

The chain is sequential (`create-release` → `publish-npm`, `create-release` → `update-homebrew`).
A cancel between them leaves the version **on npm with Homebrew stale, with no rollback**.

Not hypothetical: all six jobs were cancelled on the `v19.96.0` run at 22:29:36. It escaped harm
only because the cancel arrived before `publish-npm` did any work — npm confirms no 19.96.0 exists
and `dist-tags.latest` is 19.97.0. Consistent by luck, not design.

The realistic collision is self-inflicted rather than a push: `refs/tags/vX.Y.Z` is unique per tag,
but `ci-ensure-tag-release-run.ts` (merged in #2496) polls ~120s and then dispatches the chain — a
run that only becomes visible at 2:01 would be cancelled by that dispatch. Two automated systems
racing.

## This reverses my own earlier PR

**#2500 is closed, not rebased — it protected the wrong ref.** I had the risk profile inverted:

| ref | collision frequency | consequence | recovers? |
|---|---|---|---|
| `main` | frequent | latency only | **yes** — next run sweeps up, as #2499 did for 4 commits |
| tags | rare | partial publish | **no** |

#2500 disabled cancellation on the frequent, low-consequence, self-healing case and left the rare,
unrecoverable one exposed — and paid for it by giving up fast supersession on `main`. This costs
nothing: `main` and PR branches keep cancelling.

Issue #2497 is closed too; its premise ("commits were never released") was disproven by #2499.

## Rejected alternatives

- **Extracting the release chain into its own workflow.** The tag jobs
  `needs: [check, native, test, install_methods]`, so extraction means duplicating ~10 minutes of
  gates per tag or dropping validation at tag time. Large refactor, same outcome as one line.
- **Job-level concurrency.** Does not survive a workflow-level cancel.

Manual cancellation defeats any concurrency design — that is answered by reconciliation and
recoverable re-dispatch, which is tracked separately.

## Verification

- `actionlint` clean, `yamllint` clean.
- Expression checked against all three ref shapes: `refs/tags/v19.97.1` → no cancel;
  `refs/heads/main` → cancel; `refs/pull/2502/merge` → cancel.
- `zizmor` identical to baseline (30 findings, 1 pre-existing low at `:1236`), confirmed by stashing
  and re-running against `origin/main`.
- Codex `adversarial-review`: 0 findings — weak signal, recorded as such.

**Empirical proof is deferred by nature**: this only demonstrates itself on the next tag that races
a dispatch. The reconciliation job tracked separately is what would catch it if this is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)