### PR TITLE
feat(ci): reconcile tags against releases and npm on a schedule

### DIFF
--- a/.github/workflows/release-reconcile.yml
+++ b/.github/workflows/release-reconcile.yml
@@ -1,0 +1,53 @@
+---
+name: Release reconciliation
+
+# Assert the end state of the release chain, on a schedule.
+#
+# tag-on-version-bump.yml verifies that a CI run *exists* for a tag (#2487), but
+# a run that fired and was then cancelled still counts -- that is how v19.96.0
+# ended up tagged, unreleased and silent. A one-shot check at tag time also
+# cannot notice anything that dies afterwards, and a human can cancel a publish
+# between publish-npm and update-homebrew whatever the concurrency groups say.
+#
+# So this checks what actually matters, repeatedly: every tag has a GitHub
+# release, and every release reached npm. It fails closed -- an unreachable
+# registry is reported as a failure, never as a clean result.
+
+on:
+  schedule:
+    # 07:23 UTC. Deliberately off the hour: everyone schedules :00 and the
+    # runner queue is worst there.
+    - cron: "23 7 * * *"
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "How many of the newest tags to check"
+        required: false
+        default: "20"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-reconcile
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Tags are the input to this check; a shallow clone has none, and the
+          # script treats an empty tag list as unknown rather than clean.
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3"
+      - name: Reconcile tags against releases and npm
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LIMIT: ${{ inputs.limit || '20' }}
+        run: bun scripts/ci-reconcile-releases.ts --limit "${LIMIT}"

--- a/packages/coding-agent/test/scripts/reconcile-releases.test.ts
+++ b/packages/coding-agent/test/scripts/reconcile-releases.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+import { reconcileReleases } from "../../../../scripts/ci-reconcile-releases";
+
+/**
+ * The end-state check the release chain never had (#2505).
+ *
+ * #2496 asserts that a CI run exists for a tag, but `ghCountRuns` counts runs
+ * without filtering conclusion — a run that fired and was then cancelled still
+ * counts. That is exactly how v19.96.0 ended up tagged, unreleased, and silent.
+ *
+ * So this asserts the state that actually matters: for every tag there is a
+ * release, and for every release there is a published package. The partial case
+ * — released but not on npm — is the one a tag/release check alone calls clean
+ * and which no amount of concurrency tuning can rule out, because a human can
+ * always cancel a run between publish-npm and update-homebrew.
+ *
+ * Every unknown is a failure. An unreachable registry is not a clean result.
+ */
+
+const deps = (over: Partial<Parameters<typeof reconcileReleases>[0]> = {}) => ({
+	listTags: async () => ["v1.0.0"],
+	listReleases: async () => ["v1.0.0"],
+	listNpmVersions: async () => ["1.0.0"],
+	log: () => {},
+	...over,
+});
+
+describe("reconcileReleases", () => {
+	it("is clean when every tag has a release and a published package", async () => {
+		const r = await reconcileReleases(deps());
+		expect(r.status).toBe("clean");
+		expect(r.divergences).toHaveLength(0);
+	});
+
+	it("reports a tag that has no release", async () => {
+		const r = await reconcileReleases(deps({ listReleases: async () => [] }));
+		expect(r.status).toBe("diverged");
+		expect(r.divergences).toEqual([{ tag: "v1.0.0", missingRelease: true, missingNpm: false }]);
+	});
+
+	it("reports a release that never reached npm — the partial publish", async () => {
+		// create-release succeeded, publish-npm did not. A tag/release check alone
+		// calls this clean; it is the failure mode a cancelled chain actually leaves.
+		const r = await reconcileReleases(deps({ listNpmVersions: async () => [] }));
+		expect(r.status).toBe("diverged");
+		expect(r.divergences).toEqual([{ tag: "v1.0.0", missingRelease: false, missingNpm: true }]);
+	});
+
+	it("fails closed when the tag lookup throws", async () => {
+		const r = await reconcileReleases(
+			deps({
+				listTags: async () => {
+					throw new Error("network");
+				},
+			}),
+		);
+		expect(r.status).toBe("unknown");
+		expect(r.detail).toMatch(/network/);
+	});
+
+	it("fails closed when the npm lookup throws, rather than assuming published", async () => {
+		const r = await reconcileReleases(
+			deps({
+				listNpmVersions: async () => {
+					throw new Error("registry 503");
+				},
+			}),
+		);
+		expect(r.status).toBe("unknown");
+	});
+
+	it("treats an empty tag list as unknown, not clean", async () => {
+		// `git tag` returning nothing means the checkout is wrong, not that the
+		// project has no releases. Reading that as clean would silence the alarm
+		// permanently on a misconfigured runner.
+		const r = await reconcileReleases(deps({ listTags: async () => [] }));
+		expect(r.status).toBe("unknown");
+	});
+
+	it("does not fail on an allowlisted gap, but still surfaces it with its reason", async () => {
+		const logged: string[] = [];
+		const r = await reconcileReleases(
+			deps({ listReleases: async () => [], log: (m: string) => void logged.push(m) }),
+			{ allowlist: { "v1.0.0": "skipped version, see #2487" } },
+		);
+		expect(r.status).toBe("clean");
+		expect(r.divergences).toHaveLength(0);
+		expect(logged.join("\n")).toMatch(/v1\.0\.0.*skipped version, see #2487/);
+	});
+
+	it("reports every diverging tag, not just the first", async () => {
+		// All three are on npm, so only the missing release drives divergence —
+		// keeping this test about "reports all of them" and nothing else.
+		const r = await reconcileReleases(
+			deps({
+				listTags: async () => ["v1.0.0", "v1.1.0", "v1.2.0"],
+				listReleases: async () => ["v1.1.0"],
+				listNpmVersions: async () => ["1.0.0", "1.1.0", "1.2.0"],
+			}),
+		);
+		expect(r.divergences.map(d => d.tag)).toEqual(["v1.0.0", "v1.2.0"]);
+	});
+
+	it("tolerates a v-prefix mismatch between git tags and npm versions", async () => {
+		// git tags carry `v`, npm versions do not. A naive comparison reports every
+		// release as unpublished.
+		const r = await reconcileReleases(
+			deps({
+				listTags: async () => ["v2.3.4"],
+				listReleases: async () => ["v2.3.4"],
+				listNpmVersions: async () => ["2.3.4"],
+			}),
+		);
+		expect(r.status).toBe("clean");
+	});
+});

--- a/scripts/ci-reconcile-releases.ts
+++ b/scripts/ci-reconcile-releases.ts
@@ -1,0 +1,197 @@
+#!/usr/bin/env bun
+
+/**
+ * Reconcile git tags against what was actually published (#2505).
+ *
+ * #2496 waits for a CI run to exist for a tag, which is a real improvement over
+ * trusting `git push` to exit 0. But `ghCountRuns` counts runs without filtering
+ * conclusion, so a run that fired and was then cancelled still counts as success.
+ * That is precisely how v19.96.0 came to be tagged, unreleased, and silent.
+ *
+ * It is also a one-shot check at tag time. Anything that dies afterwards leaves
+ * no alarm at all, and a human can cancel a run between publish-npm and
+ * update-homebrew no matter how the concurrency groups are configured. So the
+ * only durable check is the end state, on a schedule: for every tag a release,
+ * and for every release a published package.
+ *
+ * Every uncertainty is a failure. An unreachable registry is not a clean bill of
+ * health -- same fail-closed rule as docs-control #806/#817. The alternative is a
+ * monitor that goes quiet exactly when the thing it monitors is broken.
+ *
+ * Usage:
+ *   bun scripts/ci-reconcile-releases.ts [--limit N]
+ *
+ * Requires `gh` authenticated with contents:read.
+ */
+
+/** How the caller enumerates git tags, newest first. */
+export type ListTags = () => Promise<string[]>;
+/** How the caller enumerates published GitHub releases. */
+export type ListReleases = () => Promise<string[]>;
+/** How the caller enumerates versions present on the npm registry. */
+export type ListNpmVersions = () => Promise<string[]>;
+
+export interface ReconcileDeps {
+	listTags: ListTags;
+	listReleases: ListReleases;
+	listNpmVersions: ListNpmVersions;
+	log: (message: string) => void;
+}
+
+export interface ReconcileOptions {
+	/**
+	 * Tags whose gap is deliberate, mapped to the reason. Entries are printed
+	 * rather than dropped: an allowlist nobody sees becomes a place to hide real
+	 * failures.
+	 */
+	allowlist?: Readonly<Record<string, string>>;
+}
+
+export interface Divergence {
+	readonly tag: string;
+	readonly missingRelease: boolean;
+	readonly missingNpm: boolean;
+}
+
+export interface ReconcileOutcome {
+	status: "clean" | "diverged" | "unknown";
+	divergences: Divergence[];
+	detail?: string;
+}
+
+/** Strip the leading `v` git tags carry and npm versions do not. */
+function toVersion(tag: string): string {
+	return tag.replace(/^v/, "");
+}
+
+/**
+ * Compare tags against releases and published packages. Pure with respect to
+ * I/O -- every effect arrives through `deps`, so the decision logic is testable
+ * in milliseconds rather than against a live release.
+ */
+export async function reconcileReleases(
+	deps: ReconcileDeps,
+	options: ReconcileOptions = {},
+): Promise<ReconcileOutcome> {
+	const allowlist = options.allowlist ?? {};
+
+	let tags: string[];
+	let releases: string[];
+	let npmVersions: string[];
+	try {
+		[tags, releases, npmVersions] = await Promise.all([
+			deps.listTags(),
+			deps.listReleases(),
+			deps.listNpmVersions(),
+		]);
+	} catch (error) {
+		// Fail closed. A lookup that errored tells us nothing about the release
+		// state, and reporting "clean" here would silence the alarm precisely when
+		// the infrastructure it depends on is degraded.
+		const detail = error instanceof Error ? error.message : String(error);
+		return { status: "unknown", divergences: [], detail: `lookup failed: ${detail}` };
+	}
+
+	if (tags.length === 0) {
+		// `git tag` returning nothing means a shallow or misconfigured checkout, not
+		// a project without releases. Treating it as clean would pass forever.
+		return { status: "unknown", divergences: [], detail: "no tags returned -- checkout is not usable" };
+	}
+
+	const released = new Set(releases);
+	const published = new Set(npmVersions.map(toVersion));
+
+	const divergences: Divergence[] = [];
+	for (const tag of tags) {
+		const missingRelease = !released.has(tag);
+		const missingNpm = !published.has(toVersion(tag));
+		if (!missingRelease && !missingNpm) continue;
+
+		const reason = allowlist[tag];
+		if (reason !== undefined) {
+			deps.log(`Known gap: ${tag} -- ${reason}`);
+			continue;
+		}
+		divergences.push({ tag, missingRelease, missingNpm });
+	}
+
+	return { status: divergences.length > 0 ? "diverged" : "clean", divergences };
+}
+
+/**
+ * Tags whose gap is deliberate or already tracked. Each entry must say why, and
+ * must be removable -- an entry that can never be deleted is a bug being
+ * annotated rather than fixed.
+ *
+ * Entries are printed on every run. That is the point: a silent allowlist
+ * becomes the place real failures go to hide.
+ */
+export const KNOWN_GAPS: Readonly<Record<string, string>> = {
+	// Tagged 2026-07-27, never released: the push half-succeeded and emitted no
+	// event (#2487), and the recovery dispatch was then cancelled. Nothing was
+	// published -- npm has no 19.96.0 -- so the state is consistent, just a
+	// skipped version. Whether to delete the tag is an open decision; this entry
+	// exists so the daily check stays meaningful instead of failing forever on a
+	// gap we already know about. Remove it when that decision lands.
+	"v19.96.0": "skipped version -- tagged, never published; see #2487",
+};
+
+async function sh(cmd: string[]): Promise<string> {
+	const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
+	const [out, err] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+	if ((await proc.exited) !== 0) throw new Error(err.trim() || `${cmd[0]} failed`);
+	return out;
+}
+
+if (import.meta.main) {
+	const limitArg = process.argv.indexOf("--limit");
+	const limit = limitArg === -1 ? 20 : Number(process.argv[limitArg + 1]);
+	if (!Number.isInteger(limit) || limit <= 0) {
+		console.error("::error::--limit must be a positive integer");
+		process.exit(2);
+	}
+
+	const outcome = await reconcileReleases(
+		{
+			// Newest N only. Older tags may predate the current publishing pipeline,
+			// and an alarm that always fires is an alarm nobody reads.
+			listTags: async () =>
+				(await sh(["git", "tag", "--sort=-v:refname"]))
+					.split("\n")
+					.map(t => t.trim())
+					.filter(Boolean)
+					.slice(0, limit),
+			listReleases: async () => {
+				const body = (await sh(["gh", "release", "list", "--limit", String(limit * 2), "--json", "tagName"])).trim();
+				if (!body) return [];
+				return (JSON.parse(body) as { tagName: string }[]).map(r => r.tagName);
+			},
+			listNpmVersions: async () => {
+				const body = await sh(["curl", "-sSf", "--max-time", "30", "https://registry.npmjs.org/@f5-sales-demo/xcsh"]);
+				return Object.keys((JSON.parse(body) as { versions?: Record<string, unknown> }).versions ?? {});
+			},
+			log: (message: string) => {
+				console.log(message);
+			},
+		},
+		{ allowlist: KNOWN_GAPS },
+	);
+
+	if (outcome.status === "unknown") {
+		console.error(`::error::release reconciliation could not complete (${outcome.detail}). Treating as a failure.`);
+		process.exit(1);
+	}
+	if (outcome.status === "diverged") {
+		for (const d of outcome.divergences) {
+			const missing = [d.missingRelease ? "no GitHub release" : "", d.missingNpm ? "not on npm" : ""]
+				.filter(Boolean)
+				.join(", ");
+			console.error(`::error::${d.tag}: ${missing}`);
+		}
+		console.error(
+			`::error::${outcome.divergences.length} tag(s) diverge from what was published. Re-running the tagging workflow will NOT help once a tag is on origin; dispatch ci.yml on the tag instead.`,
+		);
+		process.exit(1);
+	}
+	console.log("All checked tags have a GitHub release and a published package.");
+}


### PR DESCRIPTION
Closes #2505

The end-state check the release chain never had.

## Why #2496 is not enough

It waits for a CI run to exist for a tag — a real improvement over trusting `git push` to exit 0.
But `ghCountRuns` counts runs **without filtering conclusion**, so a run that fired and was then
cancelled still reads as success. That is exactly how `v19.96.0` came to be tagged, unreleased and
silent: a run existed, it was cancelled at 22:29:36, and the check was satisfied.

It is also one-shot at tag time. Anything dying afterwards leaves no alarm, and a human can cancel a
publish between `publish-npm` and `update-homebrew` whatever the concurrency groups say — #2504
removes one *automated* cancellation path, not that one.

## What it checks

Both halves, because only one of them is obvious:

- **tag with no GitHub release** — the visible case
- **release absent from npm** — the *partial publish*, which a tag/release comparison alone calls
  clean, and which is the shape a cancelled chain actually leaves behind

## Fails closed

A lookup that throws, or an empty tag list from a shallow checkout, returns `unknown` and exits
non-zero. Reporting clean there would silence the alarm precisely when the infrastructure it depends
on is degraded — the same rule as docs-control #806/#817. An unreachable registry is not a clean
bill of health.

## The strongest evidence

Run live against this repository **with an empty allowlist**, it independently reported:

```
::error::v19.96.0: no GitHub release, not on npm
exit=1
```

It found, unprompted, the bug that motivated it — including the npm half I had to check by hand.

`v19.96.0` is now a tracked entry in `KNOWN_GAPS` with its reason, so the daily run stays meaningful
instead of failing forever on a gap already known. **Verified narrow, not a blanket mute:** with it
tracked the run is clean, and injecting a second divergence still produced
`::error::v19.97.0: no GitHub release` and `exit=1`. Every allowlist entry prints on every run, so
the list cannot quietly become where failures hide. Remove the entry when #2487s tag is resolved.

## Verification

- 9 tests, dependency-injected, ~150ms — no live release needed.
- **All six mutants killed:** fail-open on lookup error (2 assertions), dropped empty-tag guard (1),
  ignored allowlist (1), broken v-prefix strip (4), stop-at-first-divergence (1), never-check-npm (1).
  I also caught that my own residue check was vacuous — `git diff` reports nothing for an untracked
  file — and re-verified by grepping for each mutation string.
- `actionlint`, `yamllint`, `zizmor` and `biome` clean; `check:types` clean.
- One test bug found and fixed while writing: the multi-divergence case was polluted by the default
  npm fixture, so it was asserting more than it claimed.

Schedule is `23 7 * * *` — deliberately off the hour, where the runner queue is worst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)