### PR TITLE
chore(ci): drop the v19.96.0 known-gap entry now the tag is deleted

### DIFF
--- a/scripts/ci-reconcile-releases.ts
+++ b/scripts/ci-reconcile-releases.ts
@@ -126,15 +126,7 @@ export async function reconcileReleases(
  * Entries are printed on every run. That is the point: a silent allowlist
  * becomes the place real failures go to hide.
  */
-export const KNOWN_GAPS: Readonly<Record<string, string>> = {
-	// Tagged 2026-07-27, never released: the push half-succeeded and emitted no
-	// event (#2487), and the recovery dispatch was then cancelled. Nothing was
-	// published -- npm has no 19.96.0 -- so the state is consistent, just a
-	// skipped version. Whether to delete the tag is an open decision; this entry
-	// exists so the daily check stays meaningful instead of failing forever on a
-	// gap we already know about. Remove it when that decision lands.
-	"v19.96.0": "skipped version -- tagged, never published; see #2487",
-};
+export const KNOWN_GAPS: Readonly<Record<string, string>> = {};
 
 async function sh(cmd: string[]): Promise<string> {
 	const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });


### PR DESCRIPTION
Closes #2511

The `KNOWN_GAPS` entry existed so the daily reconciliation stayed meaningful while the orphaned
`v19.96.0` tag existed. **The tag has now been deleted from origin**, so the entry matches nothing —
dead configuration in the one place the monitor permits an exception, which is exactly where dead
entries do the most harm.

`KNOWN_GAPS` is now empty, which is the healthiest state for it.

## Why deleting the tag was safe

Verified immediately before doing it:

- commit `2735e0bc9` is on `main`, so the tag held **no unique history**
- **no GitHub release** (`release not found`)
- **not on npm** (`19.96.0` absent; `dist-tags.latest` is `19.97.1`)
- no CHANGELOG entry; the only textual references are incident comments in `ci.yml`,
  `release-reconcile.yml` and the #2496 tests, which remain accurate as history

Reversible if ever needed:

```
git tag v19.96.0 2735e0bc9b41e7a4b21151b3eb37d83605952a71 && git push origin v19.96.0
```

## Verification

- 9 tests pass. The allowlist test uses its own fixture, so it does not depend on the real
  constant — confirmed by the entry removal not touching it.
- Live run against the repository with an empty allowlist: `All checked tags have a GitHub release
  and a published package.`, exit 0.
- Codex `adversarial-review`: 0 findings.

The comment stating that entries must carry a reason and be removable stays. This change is that
rule being honoured, not an exception to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)