### PR TITLE
fix(ci): reconcile the Homebrew leg, including the artifacts it points at

### DIFF
--- a/packages/coding-agent/test/scripts/reconcile-releases.test.ts
+++ b/packages/coding-agent/test/scripts/reconcile-releases.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { reconcileReleases } from "../../../../scripts/ci-reconcile-releases";
+import { describeDivergence, reconcileReleases } from "../../../../scripts/ci-reconcile-releases";
 
 /**
  * The end-state check the release chain never had (#2505).
@@ -21,6 +21,7 @@ const deps = (over: Partial<Parameters<typeof reconcileReleases>[0]> = {}) => ({
 	listTags: async () => ["v1.0.0"],
 	listReleases: async () => ["v1.0.0"],
 	listNpmVersions: async () => ["1.0.0"],
+	listHomebrewVersion: async () => "1.0.0",
 	log: () => {},
 	...over,
 });
@@ -35,7 +36,9 @@ describe("reconcileReleases", () => {
 	it("reports a tag that has no release", async () => {
 		const r = await reconcileReleases(deps({ listReleases: async () => [] }));
 		expect(r.status).toBe("diverged");
-		expect(r.divergences).toEqual([{ tag: "v1.0.0", missingRelease: true, missingNpm: false }]);
+		expect(r.divergences).toEqual([
+			{ tag: "v1.0.0", missingRelease: true, missingNpm: false, missingHomebrew: false },
+		]);
 	});
 
 	it("reports a release that never reached npm — the partial publish", async () => {
@@ -43,7 +46,9 @@ describe("reconcileReleases", () => {
 		// calls this clean; it is the failure mode a cancelled chain actually leaves.
 		const r = await reconcileReleases(deps({ listNpmVersions: async () => [] }));
 		expect(r.status).toBe("diverged");
-		expect(r.divergences).toEqual([{ tag: "v1.0.0", missingRelease: false, missingNpm: true }]);
+		expect(r.divergences).toEqual([
+			{ tag: "v1.0.0", missingRelease: false, missingNpm: true, missingHomebrew: false },
+		]);
 	});
 
 	it("fails closed when the tag lookup throws", async () => {
@@ -96,9 +101,67 @@ describe("reconcileReleases", () => {
 				listTags: async () => ["v1.0.0", "v1.1.0", "v1.2.0"],
 				listReleases: async () => ["v1.1.0"],
 				listNpmVersions: async () => ["1.0.0", "1.1.0", "1.2.0"],
+				// v1.1.0 is the newest tag with a release, so it is what the tap is
+				// held against; keep them equal so this test stays about "reports all".
+				listHomebrewVersion: async () => "1.1.0",
 			}),
 		);
 		expect(r.divergences.map(d => d.tag)).toEqual(["v1.0.0", "v1.2.0"]);
+	});
+
+	// --- the Homebrew leg (#73) ------------------------------------------------
+	// publish-npm and update-homebrew are independent siblings, both
+	// needs: [create-release]. update-homebrew can fail or be cancelled while npm
+	// succeeds, which is the exact partial publish this whole check exists for --
+	// and the first version of it could not see that case at all.
+
+	it("reports a release that reached npm but not the Homebrew tap", async () => {
+		const r = await reconcileReleases(deps({ listHomebrewVersion: async () => "0.9.0" }));
+		expect(r.status).toBe("diverged");
+		expect(r.divergences).toEqual([
+			{ tag: "v1.0.0", missingRelease: false, missingNpm: false, missingHomebrew: true },
+		]);
+	});
+
+	it("fails closed when the Homebrew lookup throws, rather than assuming current", async () => {
+		const r = await reconcileReleases(
+			deps({
+				listHomebrewVersion: async () => {
+					throw new Error("tap unreachable");
+				},
+			}),
+		);
+		expect(r.status).toBe("unknown");
+	});
+
+	it("only holds the NEWEST tag against the tap, since a tap carries one version", async () => {
+		// npm retains every version; the tap has exactly one. Set-membership logic
+		// would mark every older tag as missing from Homebrew and alarm forever.
+		const r = await reconcileReleases(
+			deps({
+				listTags: async () => ["v1.2.0", "v1.1.0", "v1.0.0"],
+				listReleases: async () => ["v1.2.0", "v1.1.0", "v1.0.0"],
+				listNpmVersions: async () => ["1.2.0", "1.1.0", "1.0.0"],
+				listHomebrewVersion: async () => "1.2.0",
+			}),
+		);
+		expect(r.status).toBe("clean");
+	});
+
+	it("tolerates a v-prefix on the tap version", async () => {
+		const r = await reconcileReleases(deps({ listHomebrewVersion: async () => "v1.0.0" }));
+		expect(r.status).toBe("clean");
+	});
+
+	it("does not flag Homebrew on a tag that has no release yet", async () => {
+		// A tag mid-publish is already reported for the missing release; adding a
+		// Homebrew complaint to it is noise, not information.
+		const r = await reconcileReleases(
+			deps({ listReleases: async () => [], listHomebrewVersion: async () => "0.9.0" }),
+		);
+		expect(r.divergences).toEqual([
+			{ tag: "v1.0.0", missingRelease: true, missingNpm: false, missingHomebrew: false },
+		]);
 	});
 
 	it("tolerates a v-prefix mismatch between git tags and npm versions", async () => {
@@ -109,8 +172,38 @@ describe("reconcileReleases", () => {
 				listTags: async () => ["v2.3.4"],
 				listReleases: async () => ["v2.3.4"],
 				listNpmVersions: async () => ["2.3.4"],
+				listHomebrewVersion: async () => "2.3.4",
 			}),
 		);
 		expect(r.status).toBe("clean");
+	});
+
+	// --- operator-facing rendering ---------------------------------------------
+	// Caught by UAT, not by any of the above: the CLI printed "::error::v19.98.0: "
+	// with an empty reason, because the message builder knew about releases and npm
+	// but not the tap. An alarm that fires without saying why is barely an alarm.
+
+	it("names the Homebrew leg in the operator message", () => {
+		expect(
+			describeDivergence({ tag: "v1.0.0", missingRelease: false, missingNpm: false, missingHomebrew: true }),
+		).toBe("Homebrew tap is stale");
+	});
+
+	it("never renders an empty reason for any divergence it can produce", () => {
+		for (const missingRelease of [true, false]) {
+			for (const missingNpm of [true, false]) {
+				for (const missingHomebrew of [true, false]) {
+					if (!missingRelease && !missingNpm && !missingHomebrew) continue;
+					const text = describeDivergence({ tag: "v1.0.0", missingRelease, missingNpm, missingHomebrew });
+					expect(text).not.toBe("");
+				}
+			}
+		}
+	});
+
+	it("lists every failing leg, not just the first", () => {
+		expect(describeDivergence({ tag: "v1.0.0", missingRelease: true, missingNpm: true, missingHomebrew: true })).toBe(
+			"no GitHub release, not on npm, Homebrew tap is stale",
+		);
 	});
 });

--- a/packages/coding-agent/test/scripts/reconcile-releases.test.ts
+++ b/packages/coding-agent/test/scripts/reconcile-releases.test.ts
@@ -17,11 +17,20 @@ import { describeDivergence, reconcileReleases } from "../../../../scripts/ci-re
  * Every unknown is a failure. An unreachable registry is not a clean result.
  */
 
+const SHA = "a".repeat(64);
+
+/** A tap formula as ci-release-homebrew.ts generates it. */
+const formula = (version: string, sha: string = SHA) => `class Xcsh < Formula
+  version "${version}"
+  url "https://example.invalid/v${version}/xcsh-darwin-arm64.zip"
+  sha256 "${sha}"
+`;
+
 const deps = (over: Partial<Parameters<typeof reconcileReleases>[0]> = {}) => ({
 	listTags: async () => ["v1.0.0"],
 	listReleases: async () => ["v1.0.0"],
 	listNpmVersions: async () => ["1.0.0"],
-	listHomebrewVersion: async () => "1.0.0",
+	readHomebrewFormula: async () => formula("1.0.0"),
 	log: () => {},
 	...over,
 });
@@ -37,7 +46,7 @@ describe("reconcileReleases", () => {
 		const r = await reconcileReleases(deps({ listReleases: async () => [] }));
 		expect(r.status).toBe("diverged");
 		expect(r.divergences).toEqual([
-			{ tag: "v1.0.0", missingRelease: true, missingNpm: false, missingHomebrew: false },
+			{ tag: "v1.0.0", missingRelease: true, missingNpm: false, missingHomebrew: false, brokenHomebrew: false },
 		]);
 	});
 
@@ -47,7 +56,7 @@ describe("reconcileReleases", () => {
 		const r = await reconcileReleases(deps({ listNpmVersions: async () => [] }));
 		expect(r.status).toBe("diverged");
 		expect(r.divergences).toEqual([
-			{ tag: "v1.0.0", missingRelease: false, missingNpm: true, missingHomebrew: false },
+			{ tag: "v1.0.0", missingRelease: false, missingNpm: true, missingHomebrew: false, brokenHomebrew: false },
 		]);
 	});
 
@@ -103,7 +112,7 @@ describe("reconcileReleases", () => {
 				listNpmVersions: async () => ["1.0.0", "1.1.0", "1.2.0"],
 				// v1.1.0 is the newest tag with a release, so it is what the tap is
 				// held against; keep them equal so this test stays about "reports all".
-				listHomebrewVersion: async () => "1.1.0",
+				readHomebrewFormula: async () => formula("1.1.0"),
 			}),
 		);
 		expect(r.divergences.map(d => d.tag)).toEqual(["v1.0.0", "v1.2.0"]);
@@ -116,17 +125,17 @@ describe("reconcileReleases", () => {
 	// and the first version of it could not see that case at all.
 
 	it("reports a release that reached npm but not the Homebrew tap", async () => {
-		const r = await reconcileReleases(deps({ listHomebrewVersion: async () => "0.9.0" }));
+		const r = await reconcileReleases(deps({ readHomebrewFormula: async () => formula("0.9.0") }));
 		expect(r.status).toBe("diverged");
 		expect(r.divergences).toEqual([
-			{ tag: "v1.0.0", missingRelease: false, missingNpm: false, missingHomebrew: true },
+			{ tag: "v1.0.0", missingRelease: false, missingNpm: false, missingHomebrew: true, brokenHomebrew: false },
 		]);
 	});
 
 	it("fails closed when the Homebrew lookup throws, rather than assuming current", async () => {
 		const r = await reconcileReleases(
 			deps({
-				listHomebrewVersion: async () => {
+				readHomebrewFormula: async () => {
 					throw new Error("tap unreachable");
 				},
 			}),
@@ -142,14 +151,14 @@ describe("reconcileReleases", () => {
 				listTags: async () => ["v1.2.0", "v1.1.0", "v1.0.0"],
 				listReleases: async () => ["v1.2.0", "v1.1.0", "v1.0.0"],
 				listNpmVersions: async () => ["1.2.0", "1.1.0", "1.0.0"],
-				listHomebrewVersion: async () => "1.2.0",
+				readHomebrewFormula: async () => formula("1.2.0"),
 			}),
 		);
 		expect(r.status).toBe("clean");
 	});
 
 	it("tolerates a v-prefix on the tap version", async () => {
-		const r = await reconcileReleases(deps({ listHomebrewVersion: async () => "v1.0.0" }));
+		const r = await reconcileReleases(deps({ readHomebrewFormula: async () => formula("v1.0.0") }));
 		expect(r.status).toBe("clean");
 	});
 
@@ -157,10 +166,10 @@ describe("reconcileReleases", () => {
 		// A tag mid-publish is already reported for the missing release; adding a
 		// Homebrew complaint to it is noise, not information.
 		const r = await reconcileReleases(
-			deps({ listReleases: async () => [], listHomebrewVersion: async () => "0.9.0" }),
+			deps({ listReleases: async () => [], readHomebrewFormula: async () => formula("0.9.0") }),
 		);
 		expect(r.divergences).toEqual([
-			{ tag: "v1.0.0", missingRelease: true, missingNpm: false, missingHomebrew: false },
+			{ tag: "v1.0.0", missingRelease: true, missingNpm: false, missingHomebrew: false, brokenHomebrew: false },
 		]);
 	});
 
@@ -172,10 +181,44 @@ describe("reconcileReleases", () => {
 				listTags: async () => ["v2.3.4"],
 				listReleases: async () => ["v2.3.4"],
 				listNpmVersions: async () => ["2.3.4"],
-				listHomebrewVersion: async () => "2.3.4",
+				readHomebrewFormula: async () => formula("2.3.4"),
 			}),
 		);
 		expect(r.status).toBe("clean");
+	});
+
+	// --- formula health (#73, second Codex finding) -----------------------------
+	// ci-release-homebrew.ts:113 does `checksums.get(archive) || "MISSING_SHA256"`,
+	// so a formula can carry the correct version with a placeholder checksum. A
+	// version-only comparison calls that clean while `brew install` fails.
+
+	it("reports a formula whose checksum is the MISSING_SHA256 placeholder", async () => {
+		const r = await reconcileReleases(deps({ readHomebrewFormula: async () => formula("1.0.0", "MISSING_SHA256") }));
+		expect(r.status).toBe("diverged");
+		expect(r.divergences[0]?.brokenHomebrew).toBe(true);
+		expect(r.divergences[0]?.missingHomebrew).toBe(false);
+	});
+
+	it("reports a formula whose checksum is not a real digest", async () => {
+		const r = await reconcileReleases(deps({ readHomebrewFormula: async () => formula("1.0.0", "deadbeef") }));
+		expect(r.divergences[0]?.brokenHomebrew).toBe(true);
+	});
+
+	it("treats a formula with no version line as unknown, not clean", async () => {
+		const r = await reconcileReleases(deps({ readHomebrewFormula: async () => "class Xcsh < Formula\nend\n" }));
+		expect(r.status).toBe("unknown");
+	});
+
+	it("names a broken formula distinctly from a stale one", () => {
+		expect(
+			describeDivergence({
+				tag: "v1.0.0",
+				missingRelease: false,
+				missingNpm: false,
+				missingHomebrew: false,
+				brokenHomebrew: true,
+			}),
+		).toBe("Homebrew formula is broken");
 	});
 
 	// --- operator-facing rendering ---------------------------------------------
@@ -185,7 +228,13 @@ describe("reconcileReleases", () => {
 
 	it("names the Homebrew leg in the operator message", () => {
 		expect(
-			describeDivergence({ tag: "v1.0.0", missingRelease: false, missingNpm: false, missingHomebrew: true }),
+			describeDivergence({
+				tag: "v1.0.0",
+				missingRelease: false,
+				missingNpm: false,
+				missingHomebrew: true,
+				brokenHomebrew: false,
+			}),
 		).toBe("Homebrew tap is stale");
 	});
 
@@ -194,7 +243,13 @@ describe("reconcileReleases", () => {
 			for (const missingNpm of [true, false]) {
 				for (const missingHomebrew of [true, false]) {
 					if (!missingRelease && !missingNpm && !missingHomebrew) continue;
-					const text = describeDivergence({ tag: "v1.0.0", missingRelease, missingNpm, missingHomebrew });
+					const text = describeDivergence({
+						tag: "v1.0.0",
+						missingRelease,
+						missingNpm,
+						missingHomebrew,
+						brokenHomebrew: false,
+					});
 					expect(text).not.toBe("");
 				}
 			}
@@ -202,8 +257,14 @@ describe("reconcileReleases", () => {
 	});
 
 	it("lists every failing leg, not just the first", () => {
-		expect(describeDivergence({ tag: "v1.0.0", missingRelease: true, missingNpm: true, missingHomebrew: true })).toBe(
-			"no GitHub release, not on npm, Homebrew tap is stale",
-		);
+		expect(
+			describeDivergence({
+				tag: "v1.0.0",
+				missingRelease: true,
+				missingNpm: true,
+				missingHomebrew: true,
+				brokenHomebrew: false,
+			}),
+		).toBe("no GitHub release, not on npm, Homebrew tap is stale");
 	});
 });

--- a/packages/coding-agent/test/scripts/reconcile-releases.test.ts
+++ b/packages/coding-agent/test/scripts/reconcile-releases.test.ts
@@ -31,6 +31,7 @@ const deps = (over: Partial<Parameters<typeof reconcileReleases>[0]> = {}) => ({
 	listReleases: async () => ["v1.0.0"],
 	listNpmVersions: async () => ["1.0.0"],
 	readHomebrewFormula: async () => formula("1.0.0"),
+	listAssetDigests: async () => new Map([["xcsh-darwin-arm64.zip", SHA]]),
 	log: () => {},
 	...over,
 });
@@ -253,6 +254,40 @@ describe("reconcileReleases", () => {
 		expect(r.status).toBe("diverged");
 		expect(r.divergences[0]?.missingNpm).toBe(false); // excused by the allowlist
 		expect(r.divergences[0]?.missingHomebrew).toBe(true); // never excused
+	});
+
+	// --- artifact verification --------------------------------------------------
+	// ci.yml:1043 uploads with `--clobber`, so an archive can be replaced after the
+	// tap was written. The formula then keeps a valid-looking checksum and a
+	// correctly versioned URL while every `brew install` fails on a hash mismatch.
+	// GitHub exposes each asset's digest, so this costs one API call, not a download.
+
+	it("reports a formula whose checksum disagrees with the published asset", async () => {
+		const r = await reconcileReleases(
+			deps({ listAssetDigests: async () => new Map([["xcsh-darwin-arm64.zip", "b".repeat(64)]]) }),
+		);
+		expect(r.divergences[0]?.brokenHomebrew).toBe(true);
+	});
+
+	it("reports a formula referencing an asset the release does not have", async () => {
+		const r = await reconcileReleases(deps({ listAssetDigests: async () => new Map() }));
+		expect(r.divergences[0]?.brokenHomebrew).toBe(true);
+	});
+
+	it("is clean when every formula checksum matches its published asset", async () => {
+		const r = await reconcileReleases(deps());
+		expect(r.status).toBe("clean");
+	});
+
+	it("fails closed when the asset digest lookup throws", async () => {
+		const r = await reconcileReleases(
+			deps({
+				listAssetDigests: async () => {
+					throw new Error("assets unreachable");
+				},
+			}),
+		);
+		expect(r.status).toBe("unknown");
 	});
 
 	// --- operator-facing rendering ---------------------------------------------

--- a/packages/coding-agent/test/scripts/reconcile-releases.test.ts
+++ b/packages/coding-agent/test/scripts/reconcile-releases.test.ts
@@ -221,6 +221,40 @@ describe("reconcileReleases", () => {
 		).toBe("Homebrew formula is broken");
 	});
 
+	it("treats a formula with no checksums at all as broken", async () => {
+		// [].some() is false, so an empty digest list read as healthy.
+		const r = await reconcileReleases(
+			deps({ readHomebrewFormula: async () => 'class Xcsh < Formula\n  version "1.0.0"\nend\n' }),
+		);
+		expect(r.divergences[0]?.brokenHomebrew).toBe(true);
+	});
+
+	it("reports a formula whose download URLs point at a different version", async () => {
+		// version says 1.0.0, the archive it fetches is 0.9.0: installs the wrong
+		// binary while every checksum is syntactically valid.
+		const mismatched = `class Xcsh < Formula
+  version "1.0.0"
+  url "https://example.invalid/v0.9.0/xcsh-darwin-arm64.zip"
+  sha256 "${SHA}"
+`;
+		const r = await reconcileReleases(deps({ readHomebrewFormula: async () => mismatched }));
+		expect(r.divergences[0]?.brokenHomebrew).toBe(true);
+	});
+
+	it("does not let an allowlisted release gap excuse a tap failure on the same tag", async () => {
+		// The allowlist records deliberate history. The tap is always current, so a
+		// tap regression on an allowlisted tag must still alarm.
+		// v1.0.0 is released (so the tap is measurable against it) but deliberately
+		// absent from npm. The tap is then stale on top of that.
+		const r = await reconcileReleases(
+			deps({ listNpmVersions: async () => [], readHomebrewFormula: async () => formula("0.9.0") }),
+			{ allowlist: { "v1.0.0": "deliberately unpublished to npm" } },
+		);
+		expect(r.status).toBe("diverged");
+		expect(r.divergences[0]?.missingNpm).toBe(false); // excused by the allowlist
+		expect(r.divergences[0]?.missingHomebrew).toBe(true); // never excused
+	});
+
 	// --- operator-facing rendering ---------------------------------------------
 	// Caught by UAT, not by any of the above: the CLI printed "::error::v19.98.0: "
 	// with an empty reason, because the message builder knew about releases and npm

--- a/scripts/ci-reconcile-releases.ts
+++ b/scripts/ci-reconcile-releases.ts
@@ -30,14 +30,18 @@ export type ListTags = () => Promise<string[]>;
 export type ListReleases = () => Promise<string[]>;
 /** How the caller enumerates versions present on the npm registry. */
 export type ListNpmVersions = () => Promise<string[]>;
-/** How the caller reads the single version the Homebrew tap currently serves. */
-export type ListHomebrewVersion = () => Promise<string>;
+/**
+ * How the caller reads the tap's formula source. Raw text rather than a parsed
+ * version, so the parsing and the health checks live in the pure layer where
+ * they can be tested.
+ */
+export type ReadHomebrewFormula = () => Promise<string>;
 
 export interface ReconcileDeps {
 	listTags: ListTags;
 	listReleases: ListReleases;
 	listNpmVersions: ListNpmVersions;
-	listHomebrewVersion: ListHomebrewVersion;
+	readHomebrewFormula: ReadHomebrewFormula;
 	log: (message: string) => void;
 }
 
@@ -60,6 +64,13 @@ export interface Divergence {
 	 * needs: [create-release]), so it can die on its own and leave the tap behind.
 	 */
 	readonly missingHomebrew: boolean;
+	/**
+	 * The tap serves the right version but the formula cannot install:
+	 * ci-release-homebrew.ts falls back to the literal "MISSING_SHA256" when an
+	 * archive checksum is absent, so a formula can look current and still be
+	 * unusable. Version equality alone would call that clean.
+	 */
+	readonly brokenHomebrew: boolean;
 }
 
 export interface ReconcileOutcome {
@@ -80,6 +91,7 @@ export function describeDivergence(d: Divergence): string {
 		d.missingRelease ? "no GitHub release" : "",
 		d.missingNpm ? "not on npm" : "",
 		d.missingHomebrew ? "Homebrew tap is stale" : "",
+		d.brokenHomebrew ? "Homebrew formula is broken" : "",
 	]
 		.filter(Boolean)
 		.join(", ");
@@ -104,13 +116,13 @@ export async function reconcileReleases(
 	let tags: string[];
 	let releases: string[];
 	let npmVersions: string[];
-	let brewVersion: string;
+	let formula: string;
 	try {
-		[tags, releases, npmVersions, brewVersion] = await Promise.all([
+		[tags, releases, npmVersions, formula] = await Promise.all([
 			deps.listTags(),
 			deps.listReleases(),
 			deps.listNpmVersions(),
-			deps.listHomebrewVersion(),
+			deps.readHomebrewFormula(),
 		]);
 	} catch (error) {
 		// Fail closed. A lookup that errored tells us nothing about the release
@@ -119,6 +131,17 @@ export async function reconcileReleases(
 		const detail = error instanceof Error ? error.message : String(error);
 		return { status: "unknown", divergences: [], detail: `lookup failed: ${detail}` };
 	}
+
+	const brewVersion = formula.match(/^\s*version\s+"([^"]+)"/m)?.[1];
+	if (brewVersion === undefined) {
+		// Unparseable formula tells us nothing about the tap's state.
+		return { status: "unknown", divergences: [], detail: "no version line in the Homebrew formula" };
+	}
+	// Every checksum must be a real digest. The generator substitutes the literal
+	// "MISSING_SHA256" when an archive is absent, which still produces a formula
+	// carrying the current version.
+	const digests = [...formula.matchAll(/sha256\s+"([^"]*)"/g)].map(m => m[1] ?? "");
+	const brokenFormula = digests.some(d => !/^[a-f0-9]{64}$/.test(d));
 
 	if (tags.length === 0) {
 		// `git tag` returning nothing means a shallow or misconfigured checkout, not
@@ -138,15 +161,17 @@ export async function reconcileReleases(
 	for (const tag of tags) {
 		const missingRelease = !released.has(tag);
 		const missingNpm = !published.has(toVersion(tag));
-		const missingHomebrew = tag === newestReleased && toVersion(brewVersion) !== toVersion(tag);
-		if (!missingRelease && !missingNpm && !missingHomebrew) continue;
+		const isNewest = tag === newestReleased;
+		const missingHomebrew = isNewest && toVersion(brewVersion) !== toVersion(tag);
+		const brokenHomebrew = isNewest && !missingHomebrew && brokenFormula;
+		if (!missingRelease && !missingNpm && !missingHomebrew && !brokenHomebrew) continue;
 
 		const reason = allowlist[tag];
 		if (reason !== undefined) {
 			deps.log(`Known gap: ${tag} -- ${reason}`);
 			continue;
 		}
-		divergences.push({ tag, missingRelease, missingNpm, missingHomebrew });
+		divergences.push({ tag, missingRelease, missingNpm, missingHomebrew, brokenHomebrew });
 	}
 
 	return { status: divergences.length > 0 ? "diverged" : "clean", divergences };
@@ -196,13 +221,10 @@ if (import.meta.main) {
 				const body = await sh(["curl", "-sSf", "--max-time", "30", "https://registry.npmjs.org/@f5-sales-demo/xcsh"]);
 				return Object.keys((JSON.parse(body) as { versions?: Record<string, unknown> }).versions ?? {});
 			},
-			listHomebrewVersion: async () => {
+			readHomebrewFormula: async () => {
 				// Formulae live at the tap root, not under Formula/.
 				const rb = await sh(["gh", "api", "repos/f5-sales-demo/homebrew-tap/contents/xcsh.rb", "--jq", ".content"]);
-				const formula = Buffer.from(rb.trim(), "base64").toString("utf8");
-				const match = formula.match(/^\s*version\s+"([^"]+)"/m);
-				if (!match) throw new Error("could not read version from the Homebrew formula");
-				return match[1] as string;
+				return Buffer.from(rb.trim(), "base64").toString("utf8");
 			},
 			log: (message: string) => {
 				console.log(message);

--- a/scripts/ci-reconcile-releases.ts
+++ b/scripts/ci-reconcile-releases.ts
@@ -36,12 +36,19 @@ export type ListNpmVersions = () => Promise<string[]>;
  * they can be tested.
  */
 export type ReadHomebrewFormula = () => Promise<string>;
+/**
+ * How the caller maps a release's asset names to their published sha256. GitHub
+ * exposes a `digest` per asset, so verifying the tap against the real artifacts
+ * costs one API call rather than downloading every archive.
+ */
+export type ListAssetDigests = (tag: string) => Promise<Map<string, string>>;
 
 export interface ReconcileDeps {
 	listTags: ListTags;
 	listReleases: ListReleases;
 	listNpmVersions: ListNpmVersions;
 	readHomebrewFormula: ReadHomebrewFormula;
+	listAssetDigests: ListAssetDigests;
 	log: (message: string) => void;
 }
 
@@ -147,10 +154,28 @@ export async function reconcileReleases(
 	// downloaded, which is a different job from a cheap scheduled check.
 	const digests = [...formula.matchAll(/sha256\s+"([^"]*)"/g)].map(m => m[1] ?? "");
 	const urlVersions = [...formula.matchAll(/url\s+"[^"]*?\/v?([0-9]+\.[0-9]+\.[0-9]+)\//g)].map(m => m[1]);
+	// Pair each url with the sha256 that follows it, so a checksum can be checked
+	// against the artifact it actually names.
+	const pairs = [...formula.matchAll(/url\s+"([^"]+)"\s*\n\s*sha256\s+"([^"]*)"/g)].map(m => ({
+		asset: (m[1] ?? "").split("/").pop() ?? "",
+		sha: m[2] ?? "",
+	}));
+
+	let assetDigests: Map<string, string>;
+	try {
+		assetDigests = await deps.listAssetDigests(`v${toVersion(brewVersion)}`);
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		return { status: "unknown", divergences: [], detail: `asset digest lookup failed: ${detail}` };
+	}
+
 	const brokenFormula =
 		digests.length === 0 ||
 		digests.some(d => !/^[a-f0-9]{64}$/.test(d)) ||
-		urlVersions.some(v => v !== toVersion(brewVersion));
+		urlVersions.some(v => v !== toVersion(brewVersion)) ||
+		// --clobber means an archive can be replaced after the tap was written, so a
+		// syntactically valid checksum proves nothing on its own.
+		pairs.some(({ asset, sha }) => assetDigests.get(asset) !== sha);
 
 	if (tags.length === 0) {
 		// `git tag` returning nothing means a shallow or misconfigured checkout, not
@@ -235,6 +260,15 @@ if (import.meta.main) {
 			listNpmVersions: async () => {
 				const body = await sh(["curl", "-sSf", "--max-time", "30", "https://registry.npmjs.org/@f5-sales-demo/xcsh"]);
 				return Object.keys((JSON.parse(body) as { versions?: Record<string, unknown> }).versions ?? {});
+			},
+			listAssetDigests: async (tag: string) => {
+				const body = await sh(["gh", "api", `repos/f5-sales-demo/xcsh/releases/tags/${tag}`]);
+				const assets = (JSON.parse(body) as { assets?: { name: string; digest?: string }[] }).assets ?? [];
+				return new Map(
+					assets
+						.filter(a => typeof a.digest === "string")
+						.map(a => [a.name, (a.digest as string).replace(/^sha256:/, "")] as const),
+				);
 			},
 			readHomebrewFormula: async () => {
 				// Formulae live at the tap root, not under Formula/.

--- a/scripts/ci-reconcile-releases.ts
+++ b/scripts/ci-reconcile-releases.ts
@@ -30,11 +30,14 @@ export type ListTags = () => Promise<string[]>;
 export type ListReleases = () => Promise<string[]>;
 /** How the caller enumerates versions present on the npm registry. */
 export type ListNpmVersions = () => Promise<string[]>;
+/** How the caller reads the single version the Homebrew tap currently serves. */
+export type ListHomebrewVersion = () => Promise<string>;
 
 export interface ReconcileDeps {
 	listTags: ListTags;
 	listReleases: ListReleases;
 	listNpmVersions: ListNpmVersions;
+	listHomebrewVersion: ListHomebrewVersion;
 	log: (message: string) => void;
 }
 
@@ -51,12 +54,35 @@ export interface Divergence {
 	readonly tag: string;
 	readonly missingRelease: boolean;
 	readonly missingNpm: boolean;
+	/**
+	 * The tap serves one version, not a set, so this is only ever meaningful for
+	 * the newest released tag. update-homebrew is a sibling of publish-npm (both
+	 * needs: [create-release]), so it can die on its own and leave the tap behind.
+	 */
+	readonly missingHomebrew: boolean;
 }
 
 export interface ReconcileOutcome {
 	status: "clean" | "diverged" | "unknown";
 	divergences: Divergence[];
 	detail?: string;
+}
+
+/**
+ * Render the operator-facing reason a tag diverged. Exported and pure because
+ * UAT caught the CLI printing "::error::v19.98.0: " with an empty reason -- the
+ * inline builder knew about releases and npm but not the tap. An alarm that
+ * fires without saying why is barely an alarm, and this is the piece unit tests
+ * of the return value never touch.
+ */
+export function describeDivergence(d: Divergence): string {
+	return [
+		d.missingRelease ? "no GitHub release" : "",
+		d.missingNpm ? "not on npm" : "",
+		d.missingHomebrew ? "Homebrew tap is stale" : "",
+	]
+		.filter(Boolean)
+		.join(", ");
 }
 
 /** Strip the leading `v` git tags carry and npm versions do not. */
@@ -78,11 +104,13 @@ export async function reconcileReleases(
 	let tags: string[];
 	let releases: string[];
 	let npmVersions: string[];
+	let brewVersion: string;
 	try {
-		[tags, releases, npmVersions] = await Promise.all([
+		[tags, releases, npmVersions, brewVersion] = await Promise.all([
 			deps.listTags(),
 			deps.listReleases(),
 			deps.listNpmVersions(),
+			deps.listHomebrewVersion(),
 		]);
 	} catch (error) {
 		// Fail closed. A lookup that errored tells us nothing about the release
@@ -101,18 +129,24 @@ export async function reconcileReleases(
 	const released = new Set(releases);
 	const published = new Set(npmVersions.map(toVersion));
 
+	// The tap holds exactly one version, so only the newest tag that actually has
+	// a release can be compared against it. Treating it as a set would mark every
+	// older tag as missing from Homebrew and alarm permanently.
+	const newestReleased = tags.find(t => released.has(t));
+
 	const divergences: Divergence[] = [];
 	for (const tag of tags) {
 		const missingRelease = !released.has(tag);
 		const missingNpm = !published.has(toVersion(tag));
-		if (!missingRelease && !missingNpm) continue;
+		const missingHomebrew = tag === newestReleased && toVersion(brewVersion) !== toVersion(tag);
+		if (!missingRelease && !missingNpm && !missingHomebrew) continue;
 
 		const reason = allowlist[tag];
 		if (reason !== undefined) {
 			deps.log(`Known gap: ${tag} -- ${reason}`);
 			continue;
 		}
-		divergences.push({ tag, missingRelease, missingNpm });
+		divergences.push({ tag, missingRelease, missingNpm, missingHomebrew });
 	}
 
 	return { status: divergences.length > 0 ? "diverged" : "clean", divergences };
@@ -162,6 +196,14 @@ if (import.meta.main) {
 				const body = await sh(["curl", "-sSf", "--max-time", "30", "https://registry.npmjs.org/@f5-sales-demo/xcsh"]);
 				return Object.keys((JSON.parse(body) as { versions?: Record<string, unknown> }).versions ?? {});
 			},
+			listHomebrewVersion: async () => {
+				// Formulae live at the tap root, not under Formula/.
+				const rb = await sh(["gh", "api", "repos/f5-sales-demo/homebrew-tap/contents/xcsh.rb", "--jq", ".content"]);
+				const formula = Buffer.from(rb.trim(), "base64").toString("utf8");
+				const match = formula.match(/^\s*version\s+"([^"]+)"/m);
+				if (!match) throw new Error("could not read version from the Homebrew formula");
+				return match[1] as string;
+			},
 			log: (message: string) => {
 				console.log(message);
 			},
@@ -175,10 +217,7 @@ if (import.meta.main) {
 	}
 	if (outcome.status === "diverged") {
 		for (const d of outcome.divergences) {
-			const missing = [d.missingRelease ? "no GitHub release" : "", d.missingNpm ? "not on npm" : ""]
-				.filter(Boolean)
-				.join(", ");
-			console.error(`::error::${d.tag}: ${missing}`);
+			console.error(`::error::${d.tag}: ${describeDivergence(d)}`);
 		}
 		console.error(
 			`::error::${outcome.divergences.length} tag(s) diverge from what was published. Re-running the tagging workflow will NOT help once a tag is on origin; dispatch ci.yml on the tag instead.`,

--- a/scripts/ci-reconcile-releases.ts
+++ b/scripts/ci-reconcile-releases.ts
@@ -137,11 +137,20 @@ export async function reconcileReleases(
 		// Unparseable formula tells us nothing about the tap's state.
 		return { status: "unknown", divergences: [], detail: "no version line in the Homebrew formula" };
 	}
-	// Every checksum must be a real digest. The generator substitutes the literal
-	// "MISSING_SHA256" when an archive is absent, which still produces a formula
-	// carrying the current version.
+	// A formula can carry the right version and still not install. The generator
+	// substitutes the literal "MISSING_SHA256" when an archive is absent, an empty
+	// digest list is vacuously "all valid", and URLs are written independently of
+	// the version line so they can point at an older tag's assets.
+	//
+	// Limit worth stating: this checks the formula is internally coherent, not that
+	// each digest matches the artifact it names. Proving that needs the archives
+	// downloaded, which is a different job from a cheap scheduled check.
 	const digests = [...formula.matchAll(/sha256\s+"([^"]*)"/g)].map(m => m[1] ?? "");
-	const brokenFormula = digests.some(d => !/^[a-f0-9]{64}$/.test(d));
+	const urlVersions = [...formula.matchAll(/url\s+"[^"]*?\/v?([0-9]+\.[0-9]+\.[0-9]+)\//g)].map(m => m[1]);
+	const brokenFormula =
+		digests.length === 0 ||
+		digests.some(d => !/^[a-f0-9]{64}$/.test(d)) ||
+		urlVersions.some(v => v !== toVersion(brewVersion));
 
 	if (tags.length === 0) {
 		// `git tag` returning nothing means a shallow or misconfigured checkout, not
@@ -169,6 +178,12 @@ export async function reconcileReleases(
 		const reason = allowlist[tag];
 		if (reason !== undefined) {
 			deps.log(`Known gap: ${tag} -- ${reason}`);
+			// The allowlist records deliberate history, so it excuses a missing
+			// release or npm publish. It must never excuse the tap: the tap holds
+			// current state, and a regression there is new information regardless of
+			// what was once decided about this tag.
+			if (!missingHomebrew && !brokenHomebrew) continue;
+			divergences.push({ tag, missingRelease: false, missingNpm: false, missingHomebrew, brokenHomebrew });
 			continue;
 		}
 		divergences.push({ tag, missingRelease, missingNpm, missingHomebrew, brokenHomebrew });


### PR DESCRIPTION
Closes #2521

Four confirmed defects in the reconciliation merged in #2508. Each was verified against the code
before being acted on, and each has a failing-first test plus UAT against live data.

## 1. The Homebrew leg was missing entirely

`publish-npm` and `update-homebrew` are independent siblings (both `needs: [create-release]`), so
Homebrew can die while npm succeeds — and the check reported **clean**. That is the exact scenario
I cited as the motivation in #2504 and #2505. The monitor could not see the failure mode it was
built for.

The tap serves one version, not a set, so it is compared against the newest tag that has a release;
set-membership would flag every older tag forever.

## 2. Version equality is not installability

`ci-release-homebrew.ts:113` does `checksums.get(archive) || "MISSING_SHA256"`. Also, `[].some()`
is `false`, so a formula with **no** digests read as healthy, and URLs are emitted independently of
the version line so they can point at an older tag.

## 3. The allowlist muted the tap

An entry for a deliberate release or npm gap also silenced a later tap regression on the same tag.
The allowlist records deliberate history; the tap holds current state. It now excuses the release
and npm legs only.

## 4. Shape is not truth — and I was wrong about the cost

`ci.yml:1043` uploads with `--clobber`, so an archive can be replaced after the tap was written,
leaving a valid-looking checksum that no longer matches.

I had written "we cannot verify the artifact without downloading it" into the code as an accepted
limit. That was wrong. GitHub publishes a `digest` on every release asset — **one API call, not
~300MB**. The limit was in my research, not the platform.

## Verification

**28 tests, 13 mutants killed.** Live UAT with exit codes measured directly (not through a pipe,
which masked them on the first attempt):

| scenario | result |
|---|---|
| real formula vs real asset digests | clean, exit 0 |
| one digest → `MISSING_SHA256` | `Homebrew formula is broken`, exit 1 |
| version rolled back | `Homebrew tap is stale`, exit 1 |
| version line removed | unknown, exit 1 |
| published digest corrupted | `Homebrew formula is broken`, exit 1 |

Source verified byte-identical after every injection.

## Two process failures worth recording

**Every "0 findings" I reported today was a parsing bug of mine** — findings live under
`.result.findings`, and I read a top-level `.findings` that never exists. Five PRs claimed a clean
review nobody had read. All four defects above were found only after fixing it.

**My mutation harness corrupted the source and I shipped it.** It reverted `,` by replacing the
first occurrence in the file, which sat inside a different ternary, welding two branches together.
A test failed against the committed tree while my working tree was green, because I had not re-run
after committing. Mutation runs now restore from a full-file snapshot and end with a `diff` proving
byte-identity, and every commit is followed by a check that the committed tree still passes.

UAT also caught something no unit test could: the CLI printed `::error::v19.98.0: ` with an **empty
reason**. The formatter is now an exported pure function with a test asserting no reachable
combination renders empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)