### PR TITLE
test(manager.int): say WHY the two-tab probe fell short, and capture every manager's stderr

### DIFF
--- a/packages/coding-agent/test/manager-wait-diagnostics.test.ts
+++ b/packages/coding-agent/test/manager-wait-diagnostics.test.ts
@@ -10,7 +10,7 @@
  * explain itself. This is the pure part of that, so it is testable without waiting.
  */
 import { describe, expect, test } from "bun:test";
-import { describeWaitFailure } from "./manager-wait-diagnostics";
+import { describePortScan, describeWaitFailure } from "./manager-wait-diagnostics";
 
 const PATTERN = /adopted spare pid \d+ on port (\d+) as tab-7 \(/;
 
@@ -66,5 +66,43 @@ describe("describeWaitFailure", () => {
 		// Bounded: a 60-line dump in a CI log buries the finding it is meant to expose.
 		expect(msg).not.toContain("line-0\n");
 		expect(msg).toContain("earlier lines omitted");
+	});
+});
+
+describe("describePortScan (#2463 mode C)", () => {
+	test("names which ports answered and with what tenant, so a wrong tenant is not silence", () => {
+		// The failure this exists for: the two-tab test asserted a bare `ports.size`
+		// while swallowing every probe error, so `Received: 1` said nothing about
+		// whether the second worker was absent, late, or answering another tenant.
+		const lines = describePortScan(
+			[
+				{ port: 19222, tenant: "acme" },
+				{ port: 19223, tenant: "stale" },
+				{ port: 19224, error: "connect ECONNREFUSED 127.0.0.1:19224" },
+				{ port: 19225, error: "connect ECONNREFUSED 127.0.0.1:19225" },
+			],
+			"acme",
+		).join("\n");
+		expect(lines).toContain("19222");
+		expect(lines).toContain("acme");
+		expect(lines).toContain("19223");
+		expect(lines).toContain("stale"); // a DIFFERENT tenant is the interesting case
+		expect(lines).toContain("ECONNREFUSED");
+		expect(lines).toContain("matched 1 of 4"); // how many satisfied the wanted tenant
+	});
+
+	test("distinguishes 'nothing listening anywhere' from 'listening but wrong tenant'", () => {
+		const allRefused = describePortScan(
+			[
+				{ port: 19222, error: "ECONNREFUSED" },
+				{ port: 19223, error: "ECONNREFUSED" },
+			],
+			"acme",
+		).join("\n");
+		expect(allRefused).toContain("no port answered at all");
+
+		const wrongTenant = describePortScan([{ port: 19222, tenant: "other" }], "acme").join("\n");
+		expect(wrongTenant).not.toContain("no port answered at all");
+		expect(wrongTenant).toContain("matched 0 of 1");
 	});
 });

--- a/packages/coding-agent/test/manager-wait-diagnostics.ts
+++ b/packages/coding-agent/test/manager-wait-diagnostics.ts
@@ -85,3 +85,38 @@ export function describeWaitFailure({ pattern, tries, intervalMs, stderr }: Wait
 		...describeManagerCensus(stderr),
 	].join("\n");
 }
+
+/** One port's outcome from a range scan: it answered with a tenant, or it did not. */
+export interface PortProbe {
+	readonly port: number;
+	/** The tenant the bridge advertised, when it answered. */
+	readonly tenant?: string;
+	/** Why it did not answer, when it did not. */
+	readonly error?: string;
+}
+
+/**
+ * Render a range scan for a wanted tenant (#2463, mode C).
+ *
+ * The two-tab test asserted a bare `ports.size` while its poll swallowed every
+ * probe error, so a CI failure read `Expected: 2, Received: 1` and said nothing
+ * about WHY: a worker that never spawned, one that spawned late, and one
+ * answering under a different tenant are three different defects that the count
+ * alone cannot separate. Listing each port with what it actually said — and
+ * calling out the case where nothing answered at all — makes the next occurrence
+ * classifiable from the log.
+ */
+export function describePortScan(results: readonly PortProbe[], wantedTenant: string): string[] {
+	const matched = results.filter(r => r.tenant === wantedTenant).length;
+	const answered = results.filter(r => r.tenant !== undefined).length;
+	const lines = [`  port scan — matched ${matched} of ${results.length} for tenant "${wantedTenant}":`];
+	for (const r of results) {
+		lines.push(
+			`    ${r.port}: ${r.tenant !== undefined ? `tenant "${r.tenant}"` : `no answer — ${r.error ?? "unknown"}`}`,
+		);
+	}
+	if (answered === 0) {
+		lines.push("  no port answered at all — nothing is listening on the range");
+	}
+	return lines;
+}

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -27,7 +27,7 @@ import {
 	SWEEP_TIMEOUT_MS,
 	TEARDOWN_HOOK_TIMEOUT_MS,
 } from "./helpers/port-reaper";
-import { describeManagerCensus, describeWaitFailure } from "./manager-wait-diagnostics";
+import { describeManagerCensus, describePortScan, describeWaitFailure } from "./manager-wait-diagnostics";
 
 let mgr: import("bun").Subprocess | undefined;
 // A SECOND manager on the same socket (single-manager-invariant test). It is
@@ -203,18 +203,50 @@ async function request(msg: unknown, timeoutMs = 2000): Promise<Record<string, u
 }
 
 /** Spawn a fresh manager on a temp socket and wait for it to bind. */
-async function startManager(extraEnv: Record<string, string> = {}): Promise<void> {
+/**
+ * Spawn a manager on a temp socket, wait for it to bind, and capture its stderr
+ * live. Returns a reader for that stderr.
+ *
+ * stderr is captured for EVERY manager, not only the pool tests, because it is
+ * the sole input to `describeManagerCensus`. Without it a failing test can say
+ * that something did not happen but never what the manager did instead — which
+ * is how the two-tab assertion below came to report `Received: 1` and nothing
+ * more (#2463).
+ */
+async function spawnManager(poolSize: string, extraEnv: Record<string, string> = {}): Promise<() => string> {
 	sock = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-mgr-")), "manager.sock");
-	mgr = Bun.spawn(["bun", "src/cli.ts", "manager"], {
+	const proc = Bun.spawn(["bun", "src/cli.ts", "manager"], {
 		cwd: process.cwd(),
-		// Cold-spawn tests below assert on the 4-port RANGE; disable the pre-warm pool
-		// so spares don't occupy those ports. Pool behavior is covered by its own tests.
-		env: { ...process.env, ...BRIDGE_ENV, XCSH_MANAGER_SOCK: sock, XCSH_WORKER_POOL_SIZE: "0", ...extraEnv },
+		env: { ...process.env, ...BRIDGE_ENV, XCSH_MANAGER_SOCK: sock, XCSH_WORKER_POOL_SIZE: poolSize, ...extraEnv },
 		stdout: "ignore",
-		stderr: "ignore",
+		stderr: "pipe",
 	});
+	mgr = proc;
+	let err = "";
+	void (async () => {
+		const reader = (proc.stderr as ReadableStream<Uint8Array>).getReader();
+		const dec = new TextDecoder();
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				err += dec.decode(value, { stream: true });
+			}
+		} catch {
+			/* stream torn down when the manager is killed */
+		}
+	})();
 	for (let i = 0; i < 60 && !fs.existsSync(sock); i++) await Bun.sleep(100);
 	expect(fs.existsSync(sock)).toBe(true);
+	return () => err;
+}
+
+/**
+ * A manager with NO pre-warm pool. Cold-spawn tests below assert on the 4-port
+ * RANGE, so spares must not occupy those ports; pool behaviour has its own tests.
+ */
+async function startManager(extraEnv: Record<string, string> = {}): Promise<() => string> {
+	return await spawnManager("0", extraEnv);
 }
 
 /**
@@ -282,31 +314,7 @@ async function findFrame(tenant: string, env: string, tries: number): Promise<Re
  *   "provisioned"       → a provision cold-spawned (fallback path)
  */
 async function startManagerWithPool(poolSize: string): Promise<() => string> {
-	sock = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-mgr-")), "manager.sock");
-	const proc = Bun.spawn(["bun", "src/cli.ts", "manager"], {
-		cwd: process.cwd(),
-		env: { ...process.env, ...BRIDGE_ENV, XCSH_MANAGER_SOCK: sock, XCSH_WORKER_POOL_SIZE: poolSize },
-		stdout: "ignore",
-		stderr: "pipe",
-	});
-	mgr = proc;
-	let err = "";
-	void (async () => {
-		const reader = (proc.stderr as ReadableStream<Uint8Array>).getReader();
-		const dec = new TextDecoder();
-		try {
-			while (true) {
-				const { done, value } = await reader.read();
-				if (done) break;
-				err += dec.decode(value, { stream: true });
-			}
-		} catch {
-			/* stream torn down when the manager is killed */
-		}
-	})();
-	for (let i = 0; i < 60 && !fs.existsSync(sock); i++) await Bun.sleep(100);
-	expect(fs.existsSync(sock)).toBe(true);
-	return () => err;
+	return await spawnManager(poolSize);
 }
 
 /** Poll captured stderr until `sub` appears, or the try budget is spent. */
@@ -601,7 +609,7 @@ test("provision spawns a worker advertising the tenant; release reaps it", async
 }, 60_000);
 
 test("provision spawns one worker PER sessionId (two same-tenant tabs → two workers)", async () => {
-	await startManager();
+	const getErr = await startManager();
 
 	// Two tabs of the SAME tenant, keyed by distinct sessionIds. The manager keys
 	// its registry on sessionId, not tenant, so each tab gets its OWN worker on its
@@ -610,21 +618,38 @@ test("provision spawns one worker PER sessionId (two same-tenant tabs → two wo
 	await send({ type: "provision", sessionId: "tab-102", tenant: "acme|staging" });
 
 	// Both workers should come up on distinct range ports, both advertising "acme".
+	// Keep what each port LAST said instead of discarding it: a bare count cannot
+	// separate "the second worker never spawned" from "it spawned late" from "it
+	// answered under another tenant", and CI has reported this as `Received: 1`
+	// with nothing else to go on (#2463).
 	const ports = new Set<number>();
+	const lastSeen = new Map<number, { tenant?: string; error?: string }>();
 	await (async () => {
 		for (let i = 0; i < 80 && ports.size < 2; i++) {
 			for (const p of RANGE) {
 				try {
 					const a = await probe(p);
+					lastSeen.set(p, { tenant: String(a.tenant) });
 					if (a.tenant === "acme") ports.add(p);
-				} catch {
-					/* worker not up yet on this port */
+				} catch (e) {
+					lastSeen.set(p, { error: e instanceof Error ? e.message : String(e) });
 				}
 			}
 			await Bun.sleep(250);
 		}
 	})();
-	expect(ports.size).toBe(2);
+	if (ports.size !== 2) {
+		throw new Error(
+			[
+				`expected 2 distinct range ports advertising "acme", saw ${ports.size}`,
+				...describePortScan(
+					RANGE.map(p => ({ port: p, ...(lastSeen.get(p) ?? { error: "never probed" }) })),
+					"acme",
+				),
+				...describeManagerCensus(getErr()),
+			].join("\n"),
+		);
+	}
 
 	await send({ type: "release", sessionId: "tab-101" });
 	await send({ type: "release", sessionId: "tab-102" });


### PR DESCRIPTION
Closes #2528
Refs #2463

Complements #2510, which removed the environmental causes of this file's flakiness. This
removes the remaining blindness: the one assertion left that could fail without saying why.

## The gap

`expect(ports.size).toBe(2)` in *provision spawns one worker PER sessionId* polls `probe()`
across the range and **catches every error, discarding it**. CI reported it as:

```
expect(received).toBe(expected)
Expected: 2
Received: 1
```

That single number cannot separate three different defects:

- the second worker never spawned,
- it spawned but too late for the poll,
- it answered under a *different* tenant.

Each needs a different fix, and the count hides which one happened. It was the last bare
assertion of this kind in the file — #2466 replaced the others.

## What it reports now

The poll keeps what each port last said. On shortfall it throws a scan plus the manager
census. Forced against a real manager to confirm the wiring, rather than assumed:

```
expected 2 distinct range ports advertising "acme", saw 0
  port scan — matched 0 of 4 for tenant "acme":
    27000: no answer — ws error
    27001: no answer — ws error
    27002: no answer — ws error
    27003: no answer — ws error
  no port answered at all — nothing is listening on the range
  spares pre-warmed: 0   adoptions logged: 0
  manager stderr (tail):
    [xcsh manager] control socket listening at /var/.../manager.sock
```

In a real occurrence the manager's own `provisioned tab-101 → port N` lines appear in that
tail, which is what distinguishes "the manager never provisioned it" from "it did, and the
worker never listened".

## A DRY fix that fell out of it

The census reads manager stderr — but `startManager` set `stderr: "ignore"`, so **nine
tests had no census available at all**. It also duplicated `startManagerWithPool` almost
line for line. Both now delegate to one `spawnManager`, so there is a single stderr-capture
implementation and every one of those nine tests can report what the manager actually did.

`describePortScan` is a pure function beside the existing diagnostics, tested directly —
including the case that matters most, distinguishing "nothing answered anywhere" from
"answered under a different tenant".

## Known limitation

The probe error surfaces as the thin `ws error` from `bridge-probe`. It establishes *that* a
port did not answer, and the manager's log supplies the rest, so this is sufficient to
classify — but a richer error would be better. Deliberately not widening this change.

## Verification

- `bun run ci:check:full` — exit 0
- `manager.int.test.ts` — 18/18, 51.3s (down from ~80s on the pre-#2510 base)
- diagnostics unit tests — 8/8
- failure output confirmed by forcing the shortfall, then restoring and re-running clean

**No flake-rate claim.** I attempted a local main-vs-branch comparison and found it
unmeasurable on this machine: concurrent sessions from a second clone were running this
same file, and leaked managers — one alive 3h22m — were competing for the shared port
window. #2510's per-process `PORT_BASE` and ownership check address exactly that. CI is the
trustworthy signal here, and this change is diagnostics only: it alters no wait, no budget
and no timing.
