### PR TITLE
fix(manager): never probe a port already handed out — the probe could kill its own worker

### DIFF
--- a/packages/coding-agent/src/commands/manager-core.ts
+++ b/packages/coding-agent/src/commands/manager-core.ts
@@ -104,13 +104,6 @@ export function needsProvision(reg: Registry, sessionId: string): boolean {
 	return !reg.has(sessionId);
 }
 
-/** Lowest free port in the range not already held by a worker. */
-export function pickPort(reg: Registry, range: number[]): number | null {
-	const used = new Set([...reg.values()].map(w => w.port));
-	for (const p of range) if (!used.has(p)) return p;
-	return null;
-}
-
 /** sessionIds whose worker has been idle longer than idleMs. */
 export function staleKeys(reg: Registry, now: number, idleMs: number): string[] {
 	const out: string[] = [];
@@ -169,4 +162,36 @@ export function sparesToSpawn(
 	const want = Math.max(0, target - currentSpares);
 	const freeSlots = Math.max(0, totalPorts - activeWorkers - currentSpares);
 	return Math.min(want, freeSlots);
+}
+
+/**
+ * Choose a port to spawn on, probing ONLY ports that are not already spoken for.
+ *
+ * `isFree` is not a read — every implementation of it binds the port to find out,
+ * then releases it. Probing a port that has already been handed to a worker which
+ * is still starting up can therefore win that bind, and a worker whose forced
+ * `XCSH_BRIDGE_PORT` is occupied throws and exits rather than retrying
+ * ("XCSH_BRIDGE_PORT N is already in use", extension-bridge.ts). `proc.exited`
+ * then drops its registry entry, so the session ends up with no worker at all.
+ *
+ * That is the two-tab flake (#2463): provisioning a second tab swept the whole
+ * range, including the first tab's port, and could kill the first tab's worker
+ * mid-bind — leaving exactly one port advertising the tenant.
+ *
+ * `reserved` covers ports promised but not yet in the registry (pre-warmed spares
+ * live there until adopted). Probing is lazy: it stops at the first free port, so
+ * this binds no more ports than it has to.
+ */
+export function selectSpawnPort(
+	reg: Registry,
+	range: readonly number[],
+	reserved: readonly number[],
+	isFree: (port: number) => boolean,
+): number | null {
+	const taken = new Set<number>([...reg.values()].map(w => w.port).concat(reserved));
+	for (const port of range) {
+		if (taken.has(port)) continue; // ours already — never probe it
+		if (isFree(port)) return port;
+	}
+	return null;
 }

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -33,8 +33,8 @@ import {
 	binaryIsStale,
 	needsProvision,
 	parseControlMsg,
-	pickPort,
 	type Registry,
+	selectSpawnPort,
 	sparesToSpawn,
 	staleKeys,
 	touchLastSeen,
@@ -46,12 +46,16 @@ const IDLE_MS = 20 * 60_000;
 const SWEEP_MS = 60_000;
 
 /**
- * Whether a loopback TCP port is bindable RIGHT NOW. `pickPort` only dedupes
- * against the manager's own registry; a range port can still be held by another
- * app, a stale worker, or a second manager. We pre-filter the range with this so
- * a spawned worker (which binds its forced `XCSH_BRIDGE_PORT` strictly) never
- * lands on an occupied port and dies. Bun.listen binds and throws synchronously,
- * so this stays sync — keeping provision idempotency race-free.
+ * Whether a loopback TCP port is bindable RIGHT NOW. A range port can be held by
+ * another app, a stale worker, or a second manager, and a spawned worker binds its
+ * forced `XCSH_BRIDGE_PORT` strictly — it throws and exits rather than falling back
+ * — so an occupied port must be ruled out before we hand it over.
+ *
+ * NOTE this is a BINDING probe, not a read: it takes the port and releases it. Only
+ * `selectSpawnPort` may call it, and only for ports we have not already handed out;
+ * probing one of our own in-flight workers can win the bind and kill it (#2463).
+ * Bun.listen binds and throws synchronously, so this stays sync — keeping provision
+ * idempotency race-free.
  */
 function isPortFree(port: number): boolean {
 	try {
@@ -241,10 +245,12 @@ export default class Manager extends Command {
 		const pool: SpareRec[] = [];
 
 		const spawnSpare = (): void => {
-			const usedPorts = new Set<number>([...reg.values()].map(w => w.port).concat(pool.map(s => s.port)));
-			const port = pickPort(
+			// Same rule as spawnWorker: assigned and reserved ports are never probed.
+			const port = selectSpawnPort(
 				reg,
-				range.filter(p => !usedPorts.has(p) && isPortFree(p)),
+				range,
+				pool.map(s => s.port),
+				isPortFree,
 			);
 			if (port === null) return; // range full — do not pre-warm
 			const proc = Bun.spawn([process.execPath, ...workerArgv()], {
@@ -388,8 +394,15 @@ export default class Manager extends Command {
 		};
 
 		const spawnWorker = (msg: { sessionId: string; tenant: string }, managerProvisionMs: number): void => {
-			// Registry-dedupe (pickPort) over only the ports free at the OS level.
-			const port = pickPort(reg, range.filter(isPortFree));
+			// Never probe a port we have already handed out: isPortFree BINDS to find
+			// out, so sweeping the whole range could win the bind from a worker that is
+			// still starting up and kill it (#2463). Spares are reserved the same way.
+			const port = selectSpawnPort(
+				reg,
+				range,
+				pool.map(s => s.port),
+				isPortFree,
+			);
 			if (port === null) {
 				console.error(`[xcsh manager] port range exhausted; cannot provision ${msg.sessionId}`);
 				return;

--- a/packages/coding-agent/test/manager-core.test.ts
+++ b/packages/coding-agent/test/manager-core.test.ts
@@ -7,8 +7,8 @@ import {
 	needsProvision,
 	parseControlMsg,
 	parseManagerState,
-	pickPort,
 	type Registry,
+	selectSpawnPort,
 	serializeManagerState,
 	shouldSupersede,
 	staleKeys,
@@ -122,14 +122,6 @@ describe("needsProvision (idempotent per sessionId)", () => {
 		expect(needsProvision(r, "tab-8")).toBe(true); // same tenant, different tab → still needs its own worker
 	});
 });
-describe("pickPort", () => {
-	test("lowest free port", () => {
-		expect(pickPort(reg(W("tab-7", 19222)), [19222, 19223, 19224])).toBe(19223);
-	});
-	test("null when exhausted", () => {
-		expect(pickPort(reg(W("a", 19222), W("b", 19223)), [19222, 19223])).toBeNull();
-	});
-});
 describe("staleKeys", () => {
 	test("returns sids idle beyond ttl", () => {
 		const now = 100_000;
@@ -209,5 +201,79 @@ describe("sparesToSpawn", () => {
 	it("is never negative and treats target 0 as disabled", () => {
 		expect(sparesToSpawn(0, 0, 0, 20)).toBe(0);
 		expect(sparesToSpawn(2, 5, 0, 20)).toBe(0);
+	});
+});
+
+describe("selectSpawnPort never probes a port it already handed out (#2463)", () => {
+	/**
+	 * `isPortFree` is not a read — it BINDS the port and closes it again. Probing a
+	 * port that a just-spawned worker is still starting up to bind can therefore win
+	 * that bind, and a worker whose forced XCSH_BRIDGE_PORT is occupied throws and
+	 * exits (extension-bridge.ts: "XCSH_BRIDGE_PORT N is already in use"). Its
+	 * registry entry is then dropped by proc.exited, leaving the session with no
+	 * worker at all.
+	 *
+	 * That is the two-tab failure: provision tab-101, then 50ms later provision
+	 * tab-102, whose port probe sweeps the whole range including tab-101's port and
+	 * kills tab-101's worker mid-bind. Exactly one port ends up advertising the
+	 * tenant — the `Received: 1` seen twice on CI, at 20972ms and 21036ms.
+	 *
+	 * spawnSpare already filtered assigned ports out before probing; spawnWorker did
+	 * not. The rule belongs in one place, so neither can drift again.
+	 */
+	function regWith(entries: Array<[string, number]>): Registry {
+		const reg: Registry = new Map();
+		for (const [sessionId, port] of entries) {
+			reg.set(sessionId, { sessionId, tenant: "acme|staging", port, pid: 1000 + port, lastSeen: 0 });
+		}
+		return reg;
+	}
+
+	it("does not probe a port assigned to a live registry entry", () => {
+		const probed: number[] = [];
+		const reg = regWith([["tab-101", 19222]]);
+		const port = selectSpawnPort(reg, [19222, 19223, 19224], [], p => {
+			probed.push(p);
+			return true;
+		});
+		// The assigned port must never be bound by the probe, even transiently.
+		expect(probed).not.toContain(19222);
+		expect(port).toBe(19223);
+	});
+
+	it("does not probe a port reserved by a pending spare", () => {
+		const probed: number[] = [];
+		const port = selectSpawnPort(new Map(), [19222, 19223], [19222], p => {
+			probed.push(p);
+			return true;
+		});
+		expect(probed).not.toContain(19222);
+		expect(port).toBe(19223);
+	});
+
+	it("still probes unassigned ports, since another app or a stale worker may hold them", () => {
+		const probed: number[] = [];
+		const reg = regWith([["tab-101", 19222]]);
+		const port = selectSpawnPort(reg, [19222, 19223, 19224], [], p => {
+			probed.push(p);
+			return p !== 19223; // 19223 occupied by something outside our registry
+		});
+		expect(probed).toEqual([19223, 19224]);
+		expect(port).toBe(19224);
+	});
+
+	it("returns null when every candidate is assigned or occupied", () => {
+		const reg = regWith([["tab-101", 19222]]);
+		expect(selectSpawnPort(reg, [19222, 19223], [], () => false)).toBeNull();
+	});
+
+	it("stops probing once it has a port, so it binds no more ports than necessary", () => {
+		const probed: number[] = [];
+		const port = selectSpawnPort(new Map(), [19222, 19223, 19224], [], p => {
+			probed.push(p);
+			return true;
+		});
+		expect(port).toBe(19222);
+		expect(probed).toEqual([19222]); // lazy: 19223/19224 never bound
 	});
 });


### PR DESCRIPTION
Fixes #2531
Refs #2463

**Provisioning a tab could kill another tab's worker.** This is a production defect, found
while root-causing the two-tab flake — the test was reporting a real bug, not a test bug.

## Mechanism

`isPortFree` is not a read. It **binds** the port and releases it. `spawnWorker` probed with
it across the whole range:

```ts
const port = pickPort(reg, range.filter(isPortFree));
```

`.filter()` is eager, so **every provision bound and released all twenty ports** — including
ones already assigned to workers that were still starting up. A spawned worker binds its
forced `XCSH_BRIDGE_PORT` strictly and, on failure, throws and exits rather than falling
back (`extension-bridge.ts:578`). `proc.exited` then drops its registry entry.

So the probe could win the bind from its own in-flight worker, leaving that session with no
worker while the manager reported the provision as successful.

`spawnSpare` **already guarded this**. `spawnWorker` did not:

```ts
// spawnSpare — correct
range.filter(p => !usedPorts.has(p) && isPortFree(p))
// spawnWorker — probes ports it already owns
range.filter(isPortFree)
```

That asymmetry produced the `Received: 1` seen twice on CI: #2484 at 20972 ms and #2517 at
21036 ms — the poll running to completion (80 × 250 ms), agreeing to within 64 ms.

## Proof, not just mechanism

The natural window is microseconds wide. **48 back-to-back provisions did not reproduce it
(0/8)** — so mechanism alone was not grounds to claim a fix.

Holding the probe 50 ms, applied identically to both builds, same machine and load:

| build | rounds short of 6 workers |
| --- | --- |
| unfixed | **6/6** |
| this fix | **0/6** |

On the unfixed runs the manager logged 5–6 provisions while only 3–4 workers stayed
listening — workers dying *after* provisioning, which is the predicted signature rather than
a generic failure. The amplification was then reverted and both trees confirmed clean.

## The fix

One rule in one place: `selectSpawnPort` skips assigned and reserved ports **before**
probing, and stops at the first free port, so it binds no more ports than it must. Both
spawn paths use it, so they cannot drift apart again. `pickPort` is superseded and removed
rather than left as a second way to do the same thing.

Five unit tests pin the property directly:

- an assigned port is never passed to the probe
- a port reserved by a pending spare is never probed
- unassigned ports **are** still probed (another app or a stale worker can hold them)
- null when everything is assigned or occupied
- probing stops at the first free port

## Impact beyond the test suite

Real users hit this: opening a second tab shortly after a first can silently kill the first
tab's worker. The window is small, which is why it surfaced as a rare CI flake rather than
an obvious bug.

## Verification

- `bun run ci:check:full` — exit 0
- full `coding-agent` suite — 6074 pass, 0 fail
- `manager.int.test.ts` — 18/18
- `manager-core` unit tests — 29/29
- amplified experiment above, reverted afterwards
