### PR TITLE
fix(sandbox): check a redirect target against the boundary it actually crosses

### DIFF
--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -160,6 +160,19 @@ interface PathOccurrence {
 	token: string;
 	/** Offset of the token's first character — past any opening quote — in the scanned string. */
 	at: number;
+	/** Set when a redirection operator in the raw text says what the shell will do with it. */
+	access?: SandboxAccess;
+}
+
+/**
+ * What a redirection operator does to the operand that follows it. `skip` is a here-string or a
+ * heredoc delimiter: that operand is literal data the shell never opens — verified against bash,
+ * where `cat <<</tmp/f` prints the string `/tmp/f` rather than the contents of that file.
+ */
+function operandAccess(operator: string): SandboxAccess | "skip" {
+	if (operator.includes("<<")) return "skip";
+	// `<>` opens for both; the write side is the one a read-only grant must not license.
+	return operator.includes(">") ? "write" : "read";
 }
 
 /** A path to check, and the boundary to check it against. */
@@ -174,6 +187,9 @@ const WRITE_AND_READ = ["write", "read"] as const satisfies readonly SandboxAcce
 /** A redirection operator, with its optional file-descriptor prefix. Longest forms first. */
 const REDIRECT_OPERATOR = /[0-9]*(?:&>>|&>|<<<|<<-|<<|>>|>\||<>|>&|<&|>|<)/g;
 
+/** A whitespace token that is only a redirection operator, so the next token is its operand. */
+const BARE_REDIRECT = /^[0-9]*(?:&>>|&>|<<<|<<-|<<|>>|>\||<>|>&|<&|>|<)$/;
+
 /**
  * Path-like tokens in a command/code string: bare (whitespace-split) and quoted.
  *
@@ -186,21 +202,34 @@ const REDIRECT_OPERATOR = /[0-9]*(?:&>>|&>|<<<|<<-|<<|>>|>\||<>|>&|<&|>|<)/g;
  */
 function codePathOccurrences(command: string): PathOccurrence[] {
 	const found: PathOccurrence[] = [];
-	const add = (token: string, at: number): void => {
-		if (token.length > 0 && looksLikePath(token)) found.push({ token, at });
+	const add = (token: string, at: number, access?: SandboxAccess): void => {
+		if (token.length > 0 && looksLikePath(token)) found.push({ token, at, access });
 	};
+	// Set when the previous token was nothing but a redirection operator, so this one is its operand.
+	let carried: SandboxAccess | "skip" | undefined;
 	for (const match of command.matchAll(/\S+/g)) {
 		const raw = match[0];
+		const operand = carried;
+		carried = undefined;
+
+		if (BARE_REDIRECT.test(raw)) {
+			carried = operandAccess(raw);
+			continue;
+		}
+
 		const stripped = raw.replace(/^["']|["']$/g, "");
 		const openingQuote = raw.length !== stripped.length && (raw[0] === '"' || raw[0] === "'") ? 1 : 0;
-		add(stripped, match.index + openingQuote);
-		// An operator glued to its path is one whitespace token, and `>/work/x` is not absolute. The
-		// lexer resolves this for words it can see, but not for text inside a quoted script or a
+		if (operand !== "skip") add(stripped, match.index + openingQuote, operand);
+		// An operator glued to its operand is one whitespace token, and `>/work/x` is not absolute.
+		// The lexer resolves this for words it can see, but not for text inside a quoted script or a
 		// heredoc body — where the floor is the only thing looking — so scan past the operator here
-		// too, anywhere it appears in the token: `echo a>/work/x` is one token as well.
+		// too, anywhere it appears in the token: `echo a>/work/x` is one token as well. The operator
+		// is also the only thing that says which boundary a nested redirect crosses.
 		for (const operator of stripped.matchAll(REDIRECT_OPERATOR)) {
+			const access = operandAccess(operator[0]);
+			if (access === "skip") continue;
 			const from = operator.index + operator[0].length;
-			add(stripped.slice(from).replace(/^["']|["']$/g, ""), match.index + openingQuote + from);
+			add(stripped.slice(from).replace(/^["']|["']$/g, ""), match.index + openingQuote + from, access);
 		}
 	}
 	for (const match of command.matchAll(/["']([^"']+)["']/g)) add(match[1], match.index + 1);
@@ -256,16 +285,18 @@ function shellPathCandidates(command: string): PathCandidate[] {
 	const writeTargets = lexed.words.filter(word => word.redirect === "write");
 	const inWriteTarget = (at: number): boolean => writeTargets.some(word => at >= word.start && at < word.end);
 
-	const candidates: PathCandidate[] = codePathOccurrences(scanned).map(({ token, at }) => ({
+	// A floor occurrence takes the access its own operator gave it; failing that, the span of a
+	// lexed write target it sits inside; failing that, read.
+	const candidates: PathCandidate[] = codePathOccurrences(scanned).map(({ token, at, access }) => ({
 		token,
-		access: inWriteTarget(at) ? "write" : "read",
+		access: access ?? (inWriteTarget(at) ? "write" : "read"),
 	}));
 
 	// Not gated on `looksLikePath`: that test is for the floor's *guesses* about which fragments of a
 	// command might be filenames. A redirect target is one the shell will certainly open, so a bare
 	// `out.txt` is checked too — it resolves under the cwd, which a read-only cwd does not license.
 	for (const word of lexed.words) {
-		if (word.redirect === undefined) continue;
+		if (word.redirect === undefined || word.redirect === "here-string") continue;
 		for (const access of word.redirect === "read-write" ? WRITE_AND_READ : [word.redirect]) {
 			candidates.push({ token: word.text, access });
 		}

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -116,6 +116,29 @@ function isSystemPath(resolved: string): boolean {
 	return SYSTEM_READ_ROOTS.some(root => resolved === root || resolved.startsWith(`${root}${path.sep}`));
 }
 
+/**
+ * Character devices that discard output or route it back to the caller's own descriptors. Writing
+ * to one stores nothing and reaches no file, so it cannot carry data across the boundary — and
+ * `> /dev/null` is too common to refuse.
+ *
+ * An exact list, not a `/dev` prefix: `/dev` also holds raw block devices like `/dev/disk0`, where
+ * a write is both an escape and a catastrophe.
+ */
+const SYSTEM_WRITE_SINKS = new Set([
+	"/dev/null",
+	"/dev/zero",
+	"/dev/full",
+	"/dev/tty",
+	"/dev/stdin",
+	"/dev/stdout",
+	"/dev/stderr",
+]);
+
+function isSystemWriteSink(resolved: string): boolean {
+	// /dev/fd/N is an already-open descriptor of this process, not a path it can newly reach.
+	return SYSTEM_WRITE_SINKS.has(resolved) || resolved.startsWith("/dev/fd/");
+}
+
 function firstString(input: Record<string, unknown>, keys: string[]): string | undefined {
 	for (const key of keys) {
 		const value = input[key];
@@ -132,52 +155,108 @@ function looksLikePath(token: string): boolean {
 	return path.isAbsolute(token) || token.startsWith("~") || /(^|[/\\])\.\.([/\\]|$)/.test(token);
 }
 
+/** A path-like token found by the floor, with where it was found. */
+interface PathOccurrence {
+	token: string;
+	/** Offset of the token's first character — past any opening quote — in the scanned string. */
+	at: number;
+}
+
+/** A path to check, and the boundary to check it against. */
+interface PathCandidate {
+	token: string;
+	access: SandboxAccess;
+}
+
+/** Write first, so a `<>` denial names the stricter boundary the caller is most likely missing. */
+const WRITE_AND_READ = ["write", "read"] as const satisfies readonly SandboxAccess[];
+
 /**
  * Path-like tokens in a command/code string: bare (whitespace-split) and quoted.
  *
  * Indiscriminate by design, and that is the point: because it never asks what a command *means*, it
  * also catches paths hidden inside quoted scripts, heredoc bodies, `-exec` runs and substitutions.
  * This is the coverage floor for both bash and python. Do not narrow it.
+ *
+ * Offsets come along so a caller can tell one occurrence of a token from another. Nothing else about
+ * what this finds has changed: the two passes and `looksLikePath` are the floor.
  */
-function codePathTokens(command: string): string[] {
-	const tokens = new Set<string>();
-	for (const raw of command.split(/\s+/)) tokens.add(raw.replace(/^["']|["']$/g, ""));
-	for (const match of command.matchAll(/["']([^"']+)["']/g)) tokens.add(match[1]);
-	return [...tokens].filter(token => token.length > 0 && looksLikePath(token));
+function codePathOccurrences(command: string): PathOccurrence[] {
+	const found: PathOccurrence[] = [];
+	const add = (token: string, at: number): void => {
+		if (token.length > 0 && looksLikePath(token)) found.push({ token, at });
+	};
+	for (const match of command.matchAll(/\S+/g)) {
+		const raw = match[0];
+		const stripped = raw.replace(/^["']|["']$/g, "");
+		const openingQuote = raw.length !== stripped.length && (raw[0] === '"' || raw[0] === "'") ? 1 : 0;
+		add(stripped, match.index + openingQuote);
+	}
+	for (const match of command.matchAll(/["']([^"']+)["']/g)) add(match[1], match.index + 1);
+	return found;
+}
+
+/** The floor as plain read candidates — what a non-shell language gets. */
+function codePathCandidates(command: string): PathCandidate[] {
+	return codePathOccurrences(command).map(({ token }) => ({ token, access: "read" as const }));
 }
 
 /**
- * Path-like tokens of a *bash* command, ignoring words the invoked command provably treats as a
- * script or pattern rather than a filename (issue #2470: `sed -n '/a/p'` was refused because `/a/p`
- * looks absolute, though sed never opens it).
+ * Path candidates of a *bash* command. Three things happen here, and only the first narrows:
  *
- * Implemented by blanking the exempt spans and re-running the floor over what remains, rather than
- * by subtracting a set of token strings. Set subtraction loses which *occurrence* a token came from,
- * so `echo '/elsewhere/x' && cat /elsewhere/x` would exempt the echo operand and thereby clear the
- * identical token belonging to `cat`. Blanking is positional and cannot leak that way.
+ * 1. **Exempt words are blanked.** Words the invoked command provably treats as a script or pattern
+ *    rather than a filename stop being scanned (issue #2470: `sed -n '/a/p'` was refused because
+ *    `/a/p` looks absolute, though sed never opens it). Implemented by blanking the exempt spans and
+ *    re-running the floor over what remains, rather than by subtracting a set of token strings. Set
+ *    subtraction loses which *occurrence* a token came from, so `echo '/elsewhere/x' && cat
+ *    /elsewhere/x` would exempt the echo operand and thereby clear the identical token belonging to
+ *    `cat`. Blanking is positional and cannot leak that way.
  *
- * It also keeps the floor's reach: text the lexer never turns into a word — a heredoc body, an
+ * 2. **A word the shell opens for writing is checked against the write boundary** (issue #2516).
+ *    Every candidate used to be checked as a read, so a path granted read access but not write was
+ *    writable through `>`. Marking is by span, for the same occurrence-identity reason as blanking:
+ *    in `cat /shared/x && printf y > /shared/x` only the second occurrence is the write.
+ *
+ * 3. **Redirect targets are added as candidates** (issue #2520). The floor splits on whitespace, so
+ *    an operator glued to its path — `cat </work/custB/secret` — was one token that did not look
+ *    like a path and was never checked at all. The lexer parses those correctly, so its redirect
+ *    targets go in on top of the floor. This only ever adds candidates.
+ *
+ * The floor's reach is unchanged: text the lexer never turns into a word — a heredoc body, an
  * `-exec` run — is not blanked, so it is still scanned. When the command cannot be lexed
- * confidently, nothing is blanked at all.
+ * confidently, the floor stands alone.
  */
-function shellPathTokens(command: string): string[] {
-	const floor = codePathTokens(command);
-	if (floor.length === 0) return floor;
-
+function shellPathCandidates(command: string): PathCandidate[] {
 	const lexed = lexShellCommand(command);
-	// Unbalanced quotes mean the word boundaries are guesses; keep the whole floor.
-	if (lexed.unterminated) return floor;
+	// Unbalanced quotes mean every word boundary is a guess: neither the blanking nor the write
+	// marking below can be trusted, so fall back to the floor, checked as reads.
+	if (lexed.unterminated) return codePathCandidates(command);
 
 	const exemptSpans = lexed.commands.flatMap(simpleCommand => provenExemptWords(simpleCommand));
-	if (exemptSpans.length === 0) return floor;
-
+	let scanned = command;
 	// Replace each exempt word with equivalent-length whitespace, so surrounding offsets and word
 	// boundaries are preserved and only that word's own text stops being scanned.
-	let masked = command;
 	for (const word of exemptSpans) {
-		masked = masked.slice(0, word.start) + " ".repeat(word.end - word.start) + masked.slice(word.end);
+		scanned = scanned.slice(0, word.start) + " ".repeat(word.end - word.start) + scanned.slice(word.end);
 	}
-	return codePathTokens(masked);
+
+	// `<>` opens for both, so it stays a read here and picks up its write below: a floor occurrence
+	// may carry only one access, and read is the one the floor would have used anyway.
+	const writeTargets = lexed.words.filter(word => word.redirect === "write");
+	const inWriteTarget = (at: number): boolean => writeTargets.some(word => at >= word.start && at < word.end);
+
+	const candidates: PathCandidate[] = codePathOccurrences(scanned).map(({ token, at }) => ({
+		token,
+		access: inWriteTarget(at) ? "write" : "read",
+	}));
+
+	for (const word of lexed.words) {
+		if (word.redirect === undefined || !looksLikePath(word.text)) continue;
+		for (const access of word.redirect === "read-write" ? WRITE_AND_READ : [word.redirect]) {
+			candidates.push({ token: word.text, access });
+		}
+	}
+	return candidates;
 }
 
 /** Base directories a search input would actually search, split like the tools do. */
@@ -216,13 +295,19 @@ function evaluateCodeTool(check: ToolCallCheck, fields: string[], shell: boolean
 	}
 
 	for (const command of commands) {
-		// Only bash gets the shell-aware subtraction. Python is not shell: lexing `open('/x')` as
-		// shell yields one non-absolute word and would lose the check entirely.
-		for (const token of shell ? shellPathTokens(command) : codePathTokens(command)) {
+		// Only bash gets the shell-aware treatment. Python is not shell: lexing `open('/x')` as
+		// shell yields one non-absolute word and would lose the check entirely, and it has no
+		// redirects, so every candidate it produces is a read.
+		const seen = new Set<string>();
+		for (const { token, access } of shell ? shellPathCandidates(command) : codePathCandidates(command)) {
+			if (!seen.add(`${access}\0${token}`)) continue;
 			const resolved = resolveToCwd(token, base);
-			if (!policy.isAllowed(resolved, "read") && !isSystemPath(resolved)) {
-				return deny(policy, resolved, "read");
-			}
+			if (policy.isAllowed(resolved, access)) continue;
+			// SYSTEM_READ_ROOTS is a read allowance — "directories a subprocess may legitimately
+			// read or traverse". It never licenses writing into /etc, /usr or /opt; only the
+			// discard-and-echo devices are writable.
+			if (access === "read" ? isSystemPath(resolved) : isSystemWriteSink(resolved)) continue;
+			return deny(policy, resolved, access);
 		}
 	}
 

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -171,6 +171,9 @@ interface PathCandidate {
 /** Write first, so a `<>` denial names the stricter boundary the caller is most likely missing. */
 const WRITE_AND_READ = ["write", "read"] as const satisfies readonly SandboxAccess[];
 
+/** A redirection operator, with its optional file-descriptor prefix. Longest forms first. */
+const REDIRECT_OPERATOR = /[0-9]*(?:&>>|&>|<<<|<<-|<<|>>|>\||<>|>&|<&|>|<)/g;
+
 /**
  * Path-like tokens in a command/code string: bare (whitespace-split) and quoted.
  *
@@ -191,6 +194,14 @@ function codePathOccurrences(command: string): PathOccurrence[] {
 		const stripped = raw.replace(/^["']|["']$/g, "");
 		const openingQuote = raw.length !== stripped.length && (raw[0] === '"' || raw[0] === "'") ? 1 : 0;
 		add(stripped, match.index + openingQuote);
+		// An operator glued to its path is one whitespace token, and `>/work/x` is not absolute. The
+		// lexer resolves this for words it can see, but not for text inside a quoted script or a
+		// heredoc body — where the floor is the only thing looking — so scan past the operator here
+		// too, anywhere it appears in the token: `echo a>/work/x` is one token as well.
+		for (const operator of stripped.matchAll(REDIRECT_OPERATOR)) {
+			const from = operator.index + operator[0].length;
+			add(stripped.slice(from).replace(/^["']|["']$/g, ""), match.index + openingQuote + from);
+		}
 	}
 	for (const match of command.matchAll(/["']([^"']+)["']/g)) add(match[1], match.index + 1);
 	return found;
@@ -250,8 +261,11 @@ function shellPathCandidates(command: string): PathCandidate[] {
 		access: inWriteTarget(at) ? "write" : "read",
 	}));
 
+	// Not gated on `looksLikePath`: that test is for the floor's *guesses* about which fragments of a
+	// command might be filenames. A redirect target is one the shell will certainly open, so a bare
+	// `out.txt` is checked too — it resolves under the cwd, which a read-only cwd does not license.
 	for (const word of lexed.words) {
-		if (word.redirect === undefined || !looksLikePath(word.text)) continue;
+		if (word.redirect === undefined) continue;
 		for (const access of word.redirect === "read-write" ? WRITE_AND_READ : [word.redirect]) {
 			candidates.push({ token: word.text, access });
 		}

--- a/packages/coding-agent/src/tools/shell-lex.ts
+++ b/packages/coding-agent/src/tools/shell-lex.ts
@@ -298,10 +298,17 @@ function readRedirect(lexer: Lexer, end: number): RedirectToken | undefined {
 		lexer.pos = cursor + 2;
 		return { kind: "file", direction: "read-write" };
 	}
+	// `>&` and `<&` duplicate a descriptor only when a descriptor follows: `2>&1`, `3>&-`. With a
+	// filename after it — `printf x >&out.txt` — bash opens the file instead, sending both stdout
+	// and stderr to it, so the target has to be checked like any other write.
 	if (src.startsWith(">&", cursor) || src.startsWith("<&", cursor)) {
-		lexer.pos = cursor + 2;
-		while (lexer.pos < end && (isDigit(src[lexer.pos]) || src[lexer.pos] === "-")) lexer.pos++;
-		return { kind: "fd-dup" };
+		const write = src[cursor] === ">";
+		let scan = cursor + 2;
+		while (scan < end && isDigit(src[scan])) scan++;
+		if (src[scan] === "-") scan++;
+		const duplicated = scan > cursor + 2 && (scan >= end || isWordBreak(src[scan]));
+		lexer.pos = duplicated ? scan : cursor + 2;
+		return duplicated ? { kind: "fd-dup" } : { kind: "file", direction: write ? "write" : "read" };
 	}
 	if (src.startsWith(">>", cursor)) {
 		lexer.pos = cursor + 2;
@@ -319,6 +326,11 @@ function readRedirect(lexer: Lexer, end: number): RedirectToken | undefined {
 	}
 	lexer.pos = cursor + 1;
 	return { kind: "file", direction: "read" };
+}
+
+/** True where a word ends: whitespace, or the start of an operator or grouping. */
+function isWordBreak(ch: string | undefined): boolean {
+	return ch === undefined || /[\s;&|<>()]/.test(ch);
 }
 
 function isDigit(ch: string | undefined): boolean {

--- a/packages/coding-agent/src/tools/shell-lex.ts
+++ b/packages/coding-agent/src/tools/shell-lex.ts
@@ -23,6 +23,9 @@
 /** How a word was quoted. `mixed` when built from differently-quoted segments, as in `a"b"'c'`. */
 export type QuoteKind = "none" | "single" | "double" | "ansi-c" | "mixed";
 
+/** What the shell will do with a redirect target. `<>` opens the file for both. */
+export type RedirectDirection = "read" | "write" | "read-write";
+
 export interface ShellWord {
 	/** Literal text after quote removal and backslash processing. */
 	text: string;
@@ -37,8 +40,11 @@ export interface ShellWord {
 	 * must not treat a non-literal word as a resolvable path or a whole-word URL.
 	 */
 	literal: boolean;
-	/** Set when this word is the target of a redirection, with the direction of that redirect. */
-	redirect: "read" | "write" | undefined;
+	/**
+	 * Set when this word is the target of a redirection, with the direction of that redirect.
+	 * `read-write` is `<>`, which opens the one file for both.
+	 */
+	redirect: RedirectDirection | undefined;
 }
 
 export type ShellOperator = "|" | "||" | "&&" | ";" | "&" | "\n";
@@ -245,7 +251,7 @@ function readOperator(lexer: Lexer): ShellOperator | undefined {
 }
 
 type RedirectToken =
-	| { kind: "file"; direction: "read" | "write" }
+	| { kind: "file"; direction: RedirectDirection }
 	| { kind: "fd-dup" }
 	| { kind: "heredoc"; stripTabs: boolean };
 
@@ -287,12 +293,23 @@ function readRedirect(lexer: Lexer, end: number): RedirectToken | undefined {
 		lexer.pos = cursor + 2;
 		return { kind: "heredoc", stripTabs: false };
 	}
+	// `<>` opens one file for reading and writing; reported as `<` alone the write would be invisible.
+	if (src.startsWith("<>", cursor)) {
+		lexer.pos = cursor + 2;
+		return { kind: "file", direction: "read-write" };
+	}
 	if (src.startsWith(">&", cursor) || src.startsWith("<&", cursor)) {
 		lexer.pos = cursor + 2;
 		while (lexer.pos < end && (isDigit(src[lexer.pos]) || src[lexer.pos] === "-")) lexer.pos++;
 		return { kind: "fd-dup" };
 	}
 	if (src.startsWith(">>", cursor)) {
+		lexer.pos = cursor + 2;
+		return { kind: "file", direction: "write" };
+	}
+	// `>|` overrides noclobber. Without this the `|` reads as a pipe and the filename after it
+	// becomes the next command's name, so the write target is lost.
+	if (src.startsWith(">|", cursor)) {
 		lexer.pos = cursor + 2;
 		return { kind: "file", direction: "write" };
 	}

--- a/packages/coding-agent/src/tools/shell-lex.ts
+++ b/packages/coding-agent/src/tools/shell-lex.ts
@@ -23,8 +23,11 @@
 /** How a word was quoted. `mixed` when built from differently-quoted segments, as in `a"b"'c'`. */
 export type QuoteKind = "none" | "single" | "double" | "ansi-c" | "mixed";
 
-/** What the shell will do with a redirect target. `<>` opens the file for both. */
-export type RedirectDirection = "read" | "write" | "read-write";
+/**
+ * What the shell will do with a redirect operand. `<>` opens the file for both. `here-string` is
+ * `<<<`, whose operand is literal text supplied on stdin — the shell never opens it as a path.
+ */
+export type RedirectDirection = "read" | "write" | "read-write" | "here-string";
 
 export interface ShellWord {
 	/** Literal text after quote removal and backslash processing. */
@@ -280,10 +283,10 @@ function readRedirect(lexer: Lexer, end: number): RedirectToken | undefined {
 		return { kind: "file", direction: "write" };
 	}
 	if (src.startsWith("<<<", cursor)) {
-		// A here-string supplies literal text, not a filename, but treating it as a redirect target
-		// keeps it out of the exemptible-operand set.
+		// A here-string supplies literal text, not a filename. It stays a redirect target so it is
+		// still kept out of the exemptible-operand set, but its direction says it is never opened.
 		lexer.pos = cursor + 3;
-		return { kind: "file", direction: "read" };
+		return { kind: "file", direction: "here-string" };
 	}
 	if (src.startsWith("<<-", cursor)) {
 		lexer.pos = cursor + 3;

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -14,8 +14,12 @@ function makePolicy(enabled = true): SandboxPolicy {
 		read: [
 			{ root: CWD, allow: true },
 			{ root: "/opt/xcsh/plugins", allow: true }, // stand-in for plugin cache
+			{ root: "/shared/ctx", allow: true }, // shared context: readable, deliberately not writable
 		],
-		write: [{ root: CWD, allow: true }],
+		write: [
+			{ root: CWD, allow: true },
+			{ root: "/drop", allow: true }, // write-only drop box: writable, deliberately not readable
+		],
 	});
 }
 
@@ -175,6 +179,88 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "grep -e'x' '/work/custB/secret'" }).block).toBe(true);
 		// An option the model has never heard of is equally unparseable.
 		expect(check("bash", { command: "sed --some-future-flag x '/work/custB/secret'" }).block).toBe(true);
+	});
+
+	// A redirect target is the one word in a command the *shell* opens, and it opens it for writing.
+	// Checking it against the read boundary let a read-only grant be written through (#2516).
+	it("bash: a redirect target is checked against the write boundary", () => {
+		// /shared/ctx is readable but not writable.
+		expect(check("bash", { command: "cat /shared/ctx/notes.md" }).block).toBe(false);
+		expect(check("bash", { command: "grep -n TODO /shared/ctx/notes.md" }).block).toBe(false);
+		expect(check("bash", { command: "printf x > /shared/ctx/notes.md" }).block).toBe(true);
+		expect(check("bash", { command: "printf x >> /shared/ctx/notes.md" }).block).toBe(true);
+		expect(check("bash", { command: "printf x 2> /shared/ctx/err.log" }).block).toBe(true);
+		expect(check("bash", { command: 'printf x > "/shared/ctx/notes.md"' }).block).toBe(true);
+		// The diagnostic must name the boundary that was actually crossed.
+		expect(check("bash", { command: "printf x > /shared/ctx/notes.md" }).reason).toContain("write boundary");
+		expect(check("bash", { command: "cat /work/custB/secret" }).reason).toContain("read boundary");
+		// An input redirect is a read, so a readable root stays usable as one.
+		expect(check("bash", { command: "sort < /shared/ctx/notes.md" }).block).toBe(false);
+		// The mirror case: a write-only grant accepts the write and still refuses the read.
+		expect(check("bash", { command: "printf x > /drop/out.log" }).block).toBe(false);
+		expect(check("bash", { command: "cat /drop/out.log" }).block).toBe(true);
+		// In-boundary redirects are unaffected.
+		expect(check("bash", { command: "printf x > out.txt" }).block).toBe(false);
+		expect(check("bash", { command: "printf x > /work/custA/out.txt" }).block).toBe(false);
+		// `<>` opens for both, so it has to clear both boundaries — neither grant alone is enough.
+		expect(check("bash", { command: "cat <>/drop/f" }).block).toBe(true); // writable, not readable
+		expect(check("bash", { command: "cat <>/shared/ctx/notes.md" }).block).toBe(true); // the reverse
+		expect(check("bash", { command: "cat <>/work/custA/f" }).block).toBe(false); // both granted
+	});
+
+	// The floor splits on whitespace, so an operator glued to its path was one token that did not
+	// look like a path, and the boundary never saw it at all (#2520). A single space was the only
+	// thing standing between a blocked read and an allowed one.
+	it("bash: a redirect attached to its path is still checked", () => {
+		expect(check("bash", { command: "cat </work/custB/secret" }).block).toBe(true);
+		expect(check("bash", { command: "cat\t</work/custB/secret" }).block).toBe(true);
+		expect(check("bash", { command: "cat <<</work/custB/secret" }).block).toBe(true);
+		expect(check("bash", { command: "printf x >/work/custB/y" }).block).toBe(true);
+		expect(check("bash", { command: "printf x >>/work/custB/y" }).block).toBe(true);
+		expect(check("bash", { command: "printf x 2>/work/custB/y" }).block).toBe(true);
+		expect(check("bash", { command: "printf x &>/work/custB/y" }).block).toBe(true);
+		expect(check("bash", { command: "printf x >|/work/custB/y" }).block).toBe(true);
+		// Read a sibling's file and land it inside the session tree, where an ordinary read reaches it.
+		expect(check("bash", { command: "sort </work/custB/secret >/work/custA/out" }).block).toBe(true);
+		// Attached and read-only: the write boundary still applies.
+		expect(check("bash", { command: "printf x >/shared/ctx/notes.md" }).block).toBe(true);
+		// A relative escape is invisible to `looksLikePath` while the operator is glued on, because
+		// the `..` is preceded by `>` rather than by a separator.
+		expect(check("bash", { command: "printf x >../custB/y" }).block).toBe(true);
+		expect(check("bash", { command: "cat <../custB/secret" }).block).toBe(true);
+		// An unterminated quote makes every word boundary a guess, so the floor stands alone. That
+		// is safe rather than lucky: bash refuses to run such a command, so it is not a way in.
+		expect(check("bash", { command: "cat '/work/custB/secret" }).block).toBe(true);
+		// The spaced and quoted forms were already blocked and stay blocked.
+		expect(check("bash", { command: "cat < /work/custB/secret" }).block).toBe(true);
+		expect(check("bash", { command: "cat <'/work/custB/secret'" }).block).toBe(true);
+		// An attached in-boundary redirect is ordinary work and must keep running.
+		expect(check("bash", { command: "printf x >out.txt" }).block).toBe(false);
+		expect(check("bash", { command: "printf x >/work/custA/out.txt" }).block).toBe(false);
+		expect(check("bash", { command: "sort </work/custA/in.txt" }).block).toBe(false);
+	});
+
+	// SYSTEM_READ_ROOTS is a *read* allowance — "directories a subprocess may legitimately read or
+	// traverse". Applying it to a redirect target licensed writes into /etc, /usr and /opt.
+	it("bash: the system-root read exemption does not license a write", () => {
+		expect(check("bash", { command: "cat /etc/hosts" }).block).toBe(false);
+		expect(check("bash", { command: "/usr/bin/python3 -c 'print(1)'" }).block).toBe(false);
+		expect(check("bash", { command: "printf x > /etc/hosts" }).block).toBe(true);
+		expect(check("bash", { command: "printf x >> /etc/profile" }).block).toBe(true);
+		expect(check("bash", { command: "printf x >/opt/homebrew/bin/xcsh" }).block).toBe(true);
+		expect(check("bash", { command: "printf x > /usr/local/lib/evil.so" }).block).toBe(true);
+		// The discard-and-echo devices stay writable: `> /dev/null` is in a large share of ordinary
+		// commands, and a write to one reaches no file.
+		expect(check("bash", { command: "printf x > /dev/null" }).block).toBe(false);
+		expect(check("bash", { command: "echo hi > /dev/null 2>&1" }).block).toBe(false);
+		expect(check("bash", { command: "make >/dev/null 2>/dev/null" }).block).toBe(false);
+		expect(check("bash", { command: "printf x > /dev/stderr" }).block).toBe(false);
+		expect(check("bash", { command: "printf x > /dev/fd/3" }).block).toBe(false);
+		// A raw block device is in /dev too, and a write there is an escape, not a discard.
+		expect(check("bash", { command: "printf x > /dev/disk0" }).block).toBe(true);
+		expect(check("bash", { command: "printf x >/dev/rdisk0" }).block).toBe(true);
+		// Note the limit of this: `dd of=/dev/rdisk0` is an *operand*, not a redirect, and the
+		// floor cannot see a path attached to an option. That is #2524, not this change.
 	});
 
 	it("gates the other filesystem tools (image/lsp/puppeteer/catalog/debug)", () => {

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -231,6 +231,19 @@ describe("evaluateToolCall", () => {
 		// An unterminated quote makes every word boundary a guess, so the floor stands alone. That
 		// is safe rather than lucky: bash refuses to run such a command, so it is not a way in.
 		expect(check("bash", { command: "cat '/work/custB/secret" }).block).toBe(true);
+		// Inside a quoted script the lexer sees one ordinary word, so the floor is the only thing
+		// looking — it has to recognise the operator in raw text, not just in lexed words.
+		expect(check("bash", { command: "sh -c 'cat </work/custB/secret'" }).block).toBe(true);
+		expect(check("bash", { command: "/bin/bash -c 'printf x >/work/custB/y'" }).block).toBe(true);
+		expect(check("bash", { command: "find . -exec sh -c 'cat </work/custB/x' \\;" }).block).toBe(true);
+		expect(check("bash", { command: "bash <<'EOF'\ncat </work/custB/x\nEOF" }).block).toBe(true);
+		// `>&word` with no descriptor in front is a file redirect in bash, not a descriptor dup.
+		expect(check("bash", { command: "printf x >&/work/custB/y" }).block).toBe(true);
+		expect(check("bash", { command: "printf x >& /work/custB/y" }).block).toBe(true);
+		// Real descriptor duplication has no filename and must stay allowed.
+		expect(check("bash", { command: "printf x 2>&1" }).block).toBe(false);
+		expect(check("bash", { command: "make >build.log 2>&1" }).block).toBe(false);
+		expect(check("bash", { command: "printf x >&2" }).block).toBe(false);
 		// The spaced and quoted forms were already blocked and stay blocked.
 		expect(check("bash", { command: "cat < /work/custB/secret" }).block).toBe(true);
 		expect(check("bash", { command: "cat <'/work/custB/secret'" }).block).toBe(true);
@@ -238,6 +251,30 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "printf x >out.txt" }).block).toBe(false);
 		expect(check("bash", { command: "printf x >/work/custA/out.txt" }).block).toBe(false);
 		expect(check("bash", { command: "sort </work/custA/in.txt" }).block).toBe(false);
+	});
+
+	// A redirect target is a file the shell opens whether or not it looks like a path, so the write
+	// check cannot be gated on `looksLikePath` the way the floor's guesses are.
+	it("bash: a relative redirect target is checked against the cwd it resolves in", () => {
+		// A policy whose cwd is readable but not writable — reading context, emitting nothing.
+		const readOnlyCwd = new SandboxPolicy({
+			enabled: true,
+			cwd: "/shared/ctx",
+			read: [{ root: "/shared/ctx", allow: true }],
+			write: [],
+		});
+		const inRoCwd = (command: string) =>
+			evaluateToolCall({ toolName: "bash", input: { command }, cwd: "/shared/ctx", policy: readOnlyCwd });
+		expect(inRoCwd("cat notes.md").block).toBe(false);
+		expect(inRoCwd("printf x > out.txt").block).toBe(true);
+		expect(inRoCwd("printf x >out.txt").block).toBe(true);
+		expect(inRoCwd("printf x > ./sub/out.txt").block).toBe(true);
+		expect(inRoCwd("printf x > /shared/ctx/out.txt").block).toBe(true);
+		// Discarding output writes no file, so it stays allowed even here.
+		expect(inRoCwd("make > /dev/null 2>&1").block).toBe(false);
+		// And where the cwd *is* writable, a relative target is ordinary work.
+		expect(check("bash", { command: "printf x > out.txt" }).block).toBe(false);
+		expect(check("bash", { command: "printf x > ./sub/out.txt" }).block).toBe(false);
 	});
 
 	// SYSTEM_READ_ROOTS is a *read* allowance — "directories a subprocess may legitimately read or

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -214,7 +214,6 @@ describe("evaluateToolCall", () => {
 	it("bash: a redirect attached to its path is still checked", () => {
 		expect(check("bash", { command: "cat </work/custB/secret" }).block).toBe(true);
 		expect(check("bash", { command: "cat\t</work/custB/secret" }).block).toBe(true);
-		expect(check("bash", { command: "cat <<</work/custB/secret" }).block).toBe(true);
 		expect(check("bash", { command: "printf x >/work/custB/y" }).block).toBe(true);
 		expect(check("bash", { command: "printf x >>/work/custB/y" }).block).toBe(true);
 		expect(check("bash", { command: "printf x 2>/work/custB/y" }).block).toBe(true);
@@ -251,6 +250,34 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "printf x >out.txt" }).block).toBe(false);
 		expect(check("bash", { command: "printf x >/work/custA/out.txt" }).block).toBe(false);
 		expect(check("bash", { command: "sort </work/custA/in.txt" }).block).toBe(false);
+	});
+
+	// Inside a quoted script or a heredoc body the lexer has no words to mark, so the direction has
+	// to come from the operator text itself — otherwise a nested write is checked as a read and a
+	// read-only grant is writable after all, which is the whole of #2516.
+	it("bash: a nested redirect carries its direction too", () => {
+		expect(check("bash", { command: "sh -c 'printf x >/shared/ctx/x'" }).block).toBe(true);
+		expect(check("bash", { command: "sh -c 'printf x > /shared/ctx/x'" }).block).toBe(true);
+		expect(check("bash", { command: "bash <<'EOF'\nprintf x >/shared/ctx/x\nEOF" }).block).toBe(true);
+		expect(check("bash", { command: "sh -c 'printf x >/shared/ctx/x'" }).reason).toContain("write boundary");
+		// Reading the same root from a nested script is still ordinary work.
+		expect(check("bash", { command: "sh -c 'cat /shared/ctx/notes.md'" }).block).toBe(false);
+		expect(check("bash", { command: "sh -c 'cat </shared/ctx/notes.md'" }).block).toBe(false);
+	});
+
+	// A here-string supplies literal text on stdin; the shell never opens it. Verified against real
+	// bash: `cat <<</tmp/f` prints the string "/tmp/f", not the contents of that file.
+	it("bash: a here-string operand is data, not a path", () => {
+		expect(check("bash", { command: "cat <<</work/custB/secret" }).block).toBe(false);
+		expect(check("bash", { command: "cat <<< /work/custB/secret" }).block).toBe(false);
+		expect(check("bash", { command: "cat <<<hello" }).block).toBe(false);
+		// A heredoc delimiter is not a path either — but the body still is scanned, and that is what
+		// the coverage floor exists for.
+		expect(check("bash", { command: "cat << EOF\nbody\nEOF" }).block).toBe(false);
+		expect(check("bash", { command: "bash <<'EOF'\ncat /work/custB/x\nEOF" }).block).toBe(true);
+		// A real input redirect is unaffected.
+		expect(check("bash", { command: "cat < /work/custB/secret" }).block).toBe(true);
+		expect(check("bash", { command: "cat </work/custB/secret" }).block).toBe(true);
 	});
 
 	// A redirect target is a file the shell opens whether or not it looks like a path, so the write

--- a/packages/coding-agent/test/tools/shell-lex.test.ts
+++ b/packages/coding-agent/test/tools/shell-lex.test.ts
@@ -108,6 +108,20 @@ describe("lexShellCommand operators and redirection", () => {
 		expect(lexShellCommand("printf x >|out.txt").commands).toHaveLength(1);
 	});
 
+	// `>&word` duplicates a descriptor only when `word` is a descriptor. Otherwise bash opens it as
+	// a file — verified against real bash: `printf hello >&/tmp/f` writes "hello" to /tmp/f.
+	it("distinguishes >&file from descriptor duplication", () => {
+		for (const command of ["printf x >&out.txt", "printf x >& out.txt"]) {
+			const lexed = lexShellCommand(command);
+			expect(lexed.words.at(-1)?.text).toBe("out.txt");
+			expect(lexed.words.at(-1)?.redirect).toBe("write");
+		}
+		// A descriptor target is a dup, and produces no filename word at all.
+		for (const command of ["printf x 2>&1", "printf x >&2", "cat <&0", "exec 3>&-"]) {
+			expect(lexShellCommand(command).words.some(word => word.redirect !== undefined)).toBe(false);
+		}
+	});
+
 	// `<>` opens one file for both reading and writing. Reported as either direction alone it would
 	// tell a caller half the truth about what the shell is about to do with that path.
 	it("reports <> as a read-write target", () => {

--- a/packages/coding-agent/test/tools/shell-lex.test.ts
+++ b/packages/coding-agent/test/tools/shell-lex.test.ts
@@ -89,6 +89,36 @@ describe("lexShellCommand operators and redirection", () => {
 		expect(lexShellCommand("cat in.txt").words.at(-1)?.redirect).toBeUndefined();
 	});
 
+	// The operator does not need a space before its target, and `>|` overrides noclobber. Read as a
+	// pipe instead, `>|out.txt` would make `out.txt` the next command's name and lose the target.
+	it("records a redirect target attached to its operator, including >|", () => {
+		for (const [command, direction] of [
+			["printf x >out.txt", "write"],
+			["printf x >>out.txt", "write"],
+			["printf x >|out.txt", "write"],
+			["printf x 2>out.txt", "write"],
+			["printf x &>out.txt", "write"],
+			["cat <in.txt", "read"],
+		] as const) {
+			const lexed = lexShellCommand(command);
+			expect(lexed.words.at(-1)?.text).toBe(direction === "write" ? "out.txt" : "in.txt");
+			expect(lexed.words.at(-1)?.redirect).toBe(direction);
+		}
+		// `>|` is one operator, so it must not leave a pipe behind that splits the command.
+		expect(lexShellCommand("printf x >|out.txt").commands).toHaveLength(1);
+	});
+
+	// `<>` opens one file for both reading and writing. Reported as either direction alone it would
+	// tell a caller half the truth about what the shell is about to do with that path.
+	it("reports <> as a read-write target", () => {
+		for (const command of ["cat <>rw.txt", "cat <> rw.txt", "cat 3<>rw.txt"]) {
+			const lexed = lexShellCommand(command);
+			expect(lexed.words.at(-1)?.text).toBe("rw.txt");
+			expect(lexed.words.at(-1)?.redirect).toBe("read-write");
+			expect(lexed.commands).toHaveLength(1);
+		}
+	});
+
 	it("keeps a redirect target in its own simple command", () => {
 		const result = lexShellCommand("printf x > out.txt");
 		expect(result.commands).toHaveLength(1);


### PR DESCRIPTION
Closes #2516
Closes #2520

The code-tool scan asked `isAllowed(resolved, "read")` for every path-like token in a bash command, and the coverage floor never saw a path glued to its operator. Both were reproduced against a real `SandboxPolicy` before anything was changed.

## What was wrong

**A read-only grant was writable** (#2516). `sandbox.allowRead: ["/shared/ctx"]` with no write grant:

```
ALLOW  cat    /shared/ctx/notes.md      correct
ALLOW  printf x >  /shared/ctx/notes.md should be blocked
ALLOW  printf x >> /shared/ctx/notes.md should be blocked
```

`--allow-path` grants read and write together, so the common path never showed this. It bites where the two are deliberately split — `sandbox.allowRead` on its own, or the Office pane sharing a user-picked context folder.

**A redirect glued to its path was invisible** (#2520). One space was the whole difference:

```
ALLOW  cat </work/custB/secret
BLOCK  cat < /work/custB/secret
ALLOW  sort </work/custB/secret >/work/custA/out
```

The last line reads another customer's file and lands it inside the session tree, where an ordinary `read` reaches it. `codePathTokens` splits on whitespace, and `path.isAbsolute("</work/custB/secret")` is false, so the path was never a candidate. The quoted forms blocked only incidentally, because the second pass matches `["']([^"']+)["']` regardless of what precedes it.

## The fix

Direction comes from the redirection operator, and the operator is read from two places so neither has to be complete on its own:

- **The lexer**, for words it can see: targets are added as candidates on top of the floor, with their direction. This only ever adds candidates.
- **The raw text**, for everything else: a quoted script, a heredoc body, an `-exec` run. This is what makes the direction survive into `sh -c 'printf x >/shared/ctx/x'`, where there is no top-level word to mark.

Floor occurrences carry offsets so a write mark lands on the right *occurrence* — in `cat /shared/x && printf y > /shared/x` only the second is a write. That is the same reason exempt words are blanked positionally rather than subtracted as strings.

Four lexer bugs surfaced on the way, each fixed at the source with a test:

| Form | Was | Now |
| ---- | --- | --- |
| `>\|out` | `\|` read as a pipe, so the filename became the next command's name | write target |
| `<>f` | write only | `read-write`; must clear both boundaries |
| `>&f` | every `>&` was descriptor duplication | file write unless digits or `-` follow — confirmed against real bash, where `printf hello >&/tmp/f` writes the file |
| `<<<x` | file read | `here-string`; the shell never opens it, so it is not a path |

Two further corrections to the boundary itself:

- `SYSTEM_READ_ROOTS` is a **read** allowance — "directories a subprocess may legitimately read or traverse". It no longer licenses `printf x > /etc/hosts`. The discard-and-echo devices stay writable by exact name (`/dev/null`, `/dev/fd/*`, …), not by a `/dev` prefix, because `/dev` also holds raw block devices.
- A lexed redirect target is no longer gated on `looksLikePath`. That test is for the floor's *guesses*; a redirect target is one the shell will certainly open, so a bare `out.txt` is checked too — it resolves under the cwd, which a read-only cwd does not license.

## Verification

A 72-command differential corpus was run against the old and new checks. **Exactly one command changed from blocked to allowed:**

```
printf x > /drop/out.log     # /drop is in sandbox.allowWrite
```

That is the point of the change: a write to a root the operator explicitly granted for writing. 15 changed from allowed to blocked, all escapes. The other 56 are unchanged, including every #2470 false positive and the whole coverage floor.

Probed for new false positives and found none: `>&2`, `2>&1`, `make >build.log 2>&1`, `awk '$1 > 5 {print}'`, `sed -n '/a/p'`, `grep -rn 'x -> y' src/`, `echo 'a > b'`, `cmp <(sort a) <(sort b)`, `> /dev/null`.

- `bun run check` clean.
- `bun run test:ts` from the repo root: 6058 pass, 1 fail — `steer() while streaming`, a pre-existing load flake that passes 10/10 isolated, now filed as #2535.

## Pre-PR review

Two rounds of `codex:verified-code-review`, six findings, **all six confirmed by execution** — four fixed here, two filed. Three of the four were defects in this branch's own first draft, including one false positive it introduced.

| Finding | Outcome |
| ------- | ------- |
| Attached redirects inside executed script strings bypass enforcement | fixed — floor now scans past the operator |
| `>&file` misclassified as descriptor duplication | fixed — verified against real bash |
| Relative redirect targets skipped in a read-only cwd | fixed — gate removed |
| Nested redirects still use the read boundary | fixed — direction from the operator text |
| Here-strings treated as file reads | fixed — a false positive this branch added |
| Expanded redirect targets bypass enforcement | **not fixed**, filed as #2534 |

The last one is real but not redirect-specific: `cat "$SECRET"` behaves identically on `main`, because the scan has no model of parameter expansion. Refusing every non-literal word would reject `$HOME`, `$PWD` and loop variables, so it needs a design decision rather than a patch here. The local gate therefore reports `done: false` with that finding outstanding — recorded rather than resolved away.

## Also found and filed, not fixed here

- **#2524** — a path attached to an option (`dd if=/work/custB/secret`, `curl --output=/path`, `-o/path`) bypasses the floor the same way #2520 did, but the fix is different and pulls against #2470's false positives.
- **#2532** — `manager.int` workers do not survive whole-monorepo load. A different mechanism from #2495; reproduced on `main`.

## Deliberate behaviour changes

1. A path in `sandbox.allowWrite` but not `allowRead` is now writable through a redirect. Previously blocked, because everything was checked as a read.
2. Writes into `SYSTEM_READ_ROOTS` are now blocked. `/dev/null` and friends are not.
3. `cat <<< /some/path` is now allowed. The shell passes the literal text; blocking it was a false positive, pre-existing for the spaced form.
