### PR TITLE
test(manager.int): size the adopted-worker survival budget against measurement

### DIFF
--- a/packages/coding-agent/test/helpers/manager-waits.ts
+++ b/packages/coding-agent/test/helpers/manager-waits.ts
@@ -120,3 +120,28 @@ export async function requireSpans(
 		].join("\n"),
 	);
 }
+
+/**
+ * How long a just-adopted worker gets to answer the extension handshake (#2463).
+ *
+ * A pre-warmed spare adopted into a session runs `activateTenantContext` inside its
+ * bind closure before it serves the handshake, so it holds its port while briefly
+ * unresponsive. Measured over six consecutive adoptions: 1056, 1082, 1199, 1268,
+ * 1455, 1458 ms.
+ *
+ * The previous budget was 10 x 250ms = 2500ms — the TYPICAL case already consumed
+ * 50-60% of it, which is why the survival assertion failed roughly one run in twenty
+ * with the worker demonstrably alive and still holding its port.
+ *
+ * Sized as an order of magnitude over the observed worst case, in line with this
+ * file's other correctness waits (18-30s) and well under the 60s test timeout so an
+ * exhausted budget still prints its diagnostic instead of dying by timeout.
+ *
+ * This is NOT #2418 repeated. There a budget was raised for a log line that never
+ * arrived, so no number could have helped. Here the ack is measured to arrive; the
+ * budget was simply under the load-induced spread. The diagnostic keeps the two
+ * distinguishable — a worker that genuinely died reports no pids holding the port.
+ */
+export const SURVIVAL_BUDGET_MS = 15_000;
+/** Interval between survival probes; the budget above divides by this. */
+export const SURVIVAL_PROBE_INTERVAL_MS = 250;

--- a/packages/coding-agent/test/manager-waits.test.ts
+++ b/packages/coding-agent/test/manager-waits.test.ts
@@ -10,7 +10,7 @@
  * percent of the time.
  */
 import { describe, expect, test } from "bun:test";
-import { collectSpans, missingStages, requireSpans } from "./helpers/manager-waits";
+import { collectSpans, missingStages, requireSpans, SURVIVAL_BUDGET_MS } from "./helpers/manager-waits";
 
 /**
  * A stand-in for a worker's span flush: on first client connect, emit `frames`
@@ -130,5 +130,31 @@ describe("a wait that ends empty explains why (#2423)", () => {
 		} finally {
 			stop();
 		}
+	});
+});
+
+describe("the adopted-worker survival budget is sized against measurement (#2463 mode D)", () => {
+	test("allows an order of magnitude over the observed ack latency", () => {
+		// Measured on this file, six consecutive adoptions: 1056, 1082, 1199, 1268,
+		// 1455, 1458 ms — a just-adopted spare runs activateTenantContext inside its
+		// bind closure before it serves the handshake.
+		//
+		// The budget was 10 x 250ms = 2500ms, i.e. the TYPICAL case already consumed
+		// 50-60% of it. That is why the test failed ~1 run in 20 with the worker
+		// demonstrably alive and still holding its port.
+		//
+		// This is not #2418 repeated. There, a budget was raised for a log line that
+		// never arrived, so no number could have worked. Here the ack is measured to
+		// arrive, and the budget was simply below the load-induced spread. The
+		// diagnostic still distinguishes the two: a worker that genuinely died
+		// reports `pids still holding the port: NONE`.
+		const OBSERVED_WORST_MS = 1458;
+		expect(SURVIVAL_BUDGET_MS).toBeGreaterThanOrEqual(OBSERVED_WORST_MS * 10);
+	});
+
+	test("stays below the enclosing test timeout, so exhaustion reports instead of timing out", () => {
+		// A budget at or above the test timeout means the diagnostic can never print —
+		// the same trap #2510 hit when the reap budget equalled the hook timeout.
+		expect(SURVIVAL_BUDGET_MS).toBeLessThan(60_000);
 	});
 });

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -16,7 +16,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { VERSION } from "@f5-sales-demo/pi-utils";
 import { probe } from "./helpers/bridge-probe";
-import { requireSpans } from "./helpers/manager-waits";
+import { requireSpans, SURVIVAL_BUDGET_MS, SURVIVAL_PROBE_INTERVAL_MS } from "./helpers/manager-waits";
 import {
 	type PortReaperDeps,
 	parseLsofPids,
@@ -488,11 +488,14 @@ test("superseded shutdown LEAVES bound workers alive for re-adoption; manual rea
 	expect(socketGone).toBe(true); // manager exited
 	expect(getErr()).toContain("leaving 1 worker(s) for re-adoption");
 	// Poll for survival: the worker's WS bridge should outlive the manager (zero-
-	// downtime re-adoption). Retry a few times under CI load.
+	// downtime re-adoption). A just-adopted spare is briefly unresponsive while it
+	// activates its tenant context, so the budget is sized against measurement —
+	// see SURVIVAL_BUDGET_MS.
 	let survived = false;
 	let lastProbeErr = "(never attempted)";
 	let lastTenant = "(no ack)";
-	for (let i = 0; i < 10; i++) {
+	const survivalAttempts = Math.ceil(SURVIVAL_BUDGET_MS / SURVIVAL_PROBE_INTERVAL_MS);
+	for (let i = 0; i < survivalAttempts; i++) {
 		try {
 			const ack = await probe(port);
 			lastTenant = String(ack.tenant);
@@ -503,7 +506,7 @@ test("superseded shutdown LEAVES bound workers alive for re-adoption; manual rea
 		} catch (e) {
 			lastProbeErr = e instanceof Error ? e.message : String(e);
 		}
-		await Bun.sleep(250);
+		await Bun.sleep(SURVIVAL_PROBE_INTERVAL_MS);
 	}
 	// Say WHY the wait ended empty rather than asserting a bare boolean: "the worker
 	// is gone" (nothing holding the port, connection refused) and "the worker is
@@ -513,7 +516,7 @@ test("superseded shutdown LEAVES bound workers alive for re-adoption; manual rea
 		const holders = await pidsOnPort(port);
 		throw new Error(
 			[
-				`worker did not outlive its manager: no "acme" ack on port ${port} within 10 x 250ms`,
+				`worker did not outlive its manager: no "acme" ack on port ${port} within ${SURVIVAL_BUDGET_MS}ms`,
 				`  pids still holding the port: ${holders.length > 0 ? holders.join(", ") : "NONE (the worker is gone)"}`,
 				`  last ack tenant: ${lastTenant}`,
 				`  last probe error: ${lastProbeErr}`,


### PR DESCRIPTION
Fixes #2538
Refs #2463

The last surviving mode of the manager.int flake. The #2527 diagnostics classified it on
their first occurrence — and it turned out the assertion had been reporting the **opposite**
of what happened.

## What the diagnostic showed

```
worker did not outlive its manager: no "acme" ack on port 24400 within 10 x 250ms
  pids still holding the port: 81728
  last ack tenant: (no ack)
  last probe error: ws error
  adopted: adopted spare pid 81728 on port 24400 as tab-7
```

**The worker did not die.** It is alive and still holding its port — the assertion's premise
is satisfied. It simply had not answered the handshake yet. The old bare
`expect(survived).toBe(true)` reported that as a failure to survive.

## The measurement

A just-adopted spare runs `activateTenantContext` inside its bind closure before serving the
handshake. Six consecutive adoptions, timed:

```
1056ms  1082ms  1199ms  1268ms  1455ms  1458ms     mean ~1250ms, worst 1458ms
```

Against a budget of 10 × 250ms = **2500ms**. The *typical* case consumed 50–60% of the whole
budget, so any load spike crossed it — matching the observed ~1-in-20 rate. Every sibling
correctness wait in this file allows 18–30s; 2.5s was the outlier.

## This is not #2418 repeated

I have been sharply critical of budget raises throughout this file's history, including my
own #2418, so the distinction has to be explicit:

| | #2418 | here |
| --- | --- | --- |
| awaited event | log line that **never arrived** | ack **measured to arrive** at ~1.25s |
| could any number work? | no | yes — the budget sat just above the mean |
| outcome of raising | failure moved later, cause untouched | rate removed |

Same-shaped change, opposite justification. The difference is a measurement of the event
actually occurring.

The #2527 diagnostic keeps the two separable permanently: a worker that genuinely dies
reports `pids still holding the port: NONE`, and the budget is emphatically not the answer
then.

## Verification

Same machine, same command, back to back:

| | failing runs |
| --- | --- |
| before | **1/20** (this mode) |
| after | **0/20** |

`0/20` cannot prove zero — a residual 5% would still show 0/20 about a third of the time —
but it rules out the observed rate.

- `bun run ci:check:full` — exit 0
- `manager.int.test.ts` — 18/18
- wait-semantics unit tests — 7/7, including two new ones pinning that the budget is an
  order of magnitude over the measured worst case and stays below the 60s test timeout
  (a budget equal to its own timeout is the trap #2510 hit)

## Adjacent, deliberately out of scope

A just-adopted worker is unresponsive to the extension for over a second. That is real
behaviour, not a test artefact. Whether it is acceptable for the zero-downtime re-adoption
story is a product judgement, recorded on #2538 rather than acted on here.
