### PR TITLE
fix(sandbox): check the value of an option-attached path, closing a read bypass

### DIFF
--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -191,6 +191,28 @@ const REDIRECT_OPERATOR = /[0-9]*(?:&>>|&>|<<<|<<-|<<|>>|>\||<>|>&|<&|>|<)/g;
 const BARE_REDIRECT = /^[0-9]*(?:&>>|&>|<<<|<<-|<<|>>|>\||<>|>&|<&|>|<)$/;
 
 /**
+ * A path glued to its option, as one shell word (#2524).
+ *
+ * `path.isAbsolute("if=/work/custB/secret")` is false, so the floor's whole-token test
+ * never saw these — a single space was the difference between the blocked form and the
+ * allowed one.
+ *
+ * Only the option's VALUE is captured, never an arbitrary `/`-containing substring. That
+ * distinction is what keeps #2470 shut: scanning any slash-bearing fragment would read
+ * `sed -n '/a/p'` as a path again, which is the false positive #2479 exists to remove.
+ * The captured value still has to satisfy `looksLikePath`, so `--output=./out` stays
+ * allowed while `--output=/work/custB/x` does not.
+ *
+ * The short-option form additionally requires its value to begin with `/` or `~`. Without
+ * that, `-la` and friends would be read as an option carrying a relative path.
+ */
+const OPTION_VALUE_FORMS: readonly RegExp[] = [
+	/^-{1,2}[A-Za-z0-9][^=]*=(.+)$/, // --output=/p, -o=/p
+	/^[A-Za-z_][A-Za-z0-9_]*=(.+)$/, // if=/p, of=/p (operand style)
+	/^-[A-Za-z0-9]+([/~].*)$/, // -o/p, -C/p (no separator)
+];
+
+/**
  * Path-like tokens in a command/code string: bare (whitespace-split) and quoted.
  *
  * Indiscriminate by design, and that is the point: because it never asks what a command *means*, it
@@ -230,6 +252,24 @@ function codePathOccurrences(command: string): PathOccurrence[] {
 			if (access === "skip") continue;
 			const from = operator.index + operator[0].length;
 			add(stripped.slice(from).replace(/^["']|["']$/g, ""), match.index + openingQuote + from, access);
+		}
+
+		// An option glued to its value is one word too, and the lexer cannot help: it
+		// correctly reports `if=/work/custB/secret` as a single word, because that is what
+		// it is. Which options introduce a filename is command-specific knowledge the floor
+		// deliberately does not have, so scan the value and let `looksLikePath` decide.
+		//
+		// Skipped after a here-string or heredoc delimiter for the same reason the whole
+		// token is: that operand is literal data the shell never opens, so `cat <<<if=/tmp/f`
+		// prints the text rather than reading the file.
+		if (operand !== "skip") {
+			for (const form of OPTION_VALUE_FORMS) {
+				const optionValue = stripped.match(form);
+				if (!optionValue?.[1]) continue;
+				const from = stripped.length - optionValue[1].length;
+				add(optionValue[1].replace(/^["']|["']$/g, ""), match.index + openingQuote + from, operand);
+				break; // the forms overlap; the first that matches has already captured the value
+			}
 		}
 	}
 	for (const match of command.matchAll(/["']([^"']+)["']/g)) add(match[1], match.index + 1);

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -445,3 +445,63 @@ describe("evaluateToolCall with a symlinked working directory (#2312)", () => {
 		expect(checkAt(cwd, { path: "../elsewhere/secret.json" }).block).toBe(true);
 	});
 });
+
+describe("option-attached paths (#2524)", () => {
+	/**
+	 * `looksLikePath` is applied to a whole whitespace token, and a path glued to its
+	 * option is one token that starts with the option — `path.isAbsolute("if=/work/custB/secret")`
+	 * is false — so the boundary never saw it. A single space was the difference between
+	 * the blocked form and the allowed one.
+	 *
+	 * The hazard in fixing it is #2470: scanning any `/`-containing substring re-reads
+	 * `sed -n '/a/p'` as a path. Those stay allowed here, and must, because they are what
+	 * #2479 was filed to remove.
+	 */
+	it("blocks a path attached to a long option", () => {
+		expect(check("bash", { command: "curl --output=/work/custB/x https://e.com" }).block).toBe(true);
+		expect(check("bash", { command: "grep TODO --file=/work/custB/patterns" }).block).toBe(true);
+	});
+
+	it("blocks a path attached to a short option with no separator", () => {
+		expect(check("bash", { command: "curl -o/work/custB/x https://e.com" }).block).toBe(true);
+		expect(check("bash", { command: "tar -C/work/custB -cf out.tgz ." }).block).toBe(true);
+	});
+
+	it("blocks a path in an operand-style name=value word (dd)", () => {
+		expect(check("bash", { command: "dd if=/work/custB/secret of=./out" }).block).toBe(true);
+		expect(check("bash", { command: "dd if=/work/custB/secret" }).block).toBe(true);
+	});
+
+	it("blocks an out-of-boundary destination operand", () => {
+		// Deliberately not asserting WHICH boundary: knowing that `of=` is a write and `if=`
+		// a read needs a per-command option table, which is the enumeration hazard #2479
+		// warned against. Out-of-tree is out-of-tree either way, and that is what is fixed
+		// here. A read-granted-but-not-write path attached to `of=` remains uncovered.
+		expect(check("bash", { command: "dd if=./in of=/work/custB/out" }).block).toBe(true);
+	});
+
+	it("keeps #2470's false positives allowed — a regex address is not a path", () => {
+		expect(check("bash", { command: "sed -n '/a/p'" }).block).toBe(false);
+		expect(check("bash", { command: "sed -n '/^COMMANDS/,$p' notes.md" }).block).toBe(false);
+		expect(check("bash", { command: "awk '/^a/ {print}'" }).block).toBe(false);
+		expect(check("bash", { command: "echo '/a/p'" }).block).toBe(false);
+	});
+
+	it("still allows an in-boundary option value", () => {
+		expect(check("bash", { command: "curl --output=./out.html https://e.com" }).block).toBe(false);
+		expect(check("bash", { command: "dd if=./in of=./out" }).block).toBe(false);
+		expect(check("bash", { command: "tar -C. -cf out.tgz ." }).block).toBe(false);
+	});
+
+	it("leaves a here-string operand literal — the shell never opens it", () => {
+		// `cat <<</tmp/f` prints the string rather than reading the file, so an
+		// option-shaped here-string operand must not be scanned either.
+		expect(check("bash", { command: "cat <<<if=/work/custB/secret" }).block).toBe(false);
+	});
+
+	it("does not mistake a bare option or an equals sign in data for a path", () => {
+		expect(check("bash", { command: "ls -la" }).block).toBe(false);
+		expect(check("bash", { command: "echo a=b" }).block).toBe(false);
+		expect(check("bash", { command: "git commit -m 'fix: a=b'" }).block).toBe(false);
+	});
+});


### PR DESCRIPTION
Fixes #2524

A sandbox read bypass: **a path glued to its option escaped the boundary entirely.**

```
dd if=/work/custB/secret of=./out      → allowed
curl -o/work/custB/x https://e.com     → allowed
tar -C/work/custB -cf out.tgz .        → allowed
cat /work/custB/secret                 → blocked
```

The first line reads another customer's file into the session tree, where an ordinary `read`
call then reaches it. `looksLikePath` is applied to a whole whitespace token, and
`path.isAbsolute("if=/work/custB/secret")` is `false` — so a single space was the difference
between the blocked form and the allowed one.

## The hard part is not spotting it

Scanning any `/`-containing substring would read `sed -n '/a/p'` as a path again — the
false positive #2479 exists to remove. So this captures **only the option's value**, via
three explicit forms, and the value still has to satisfy the same `looksLikePath` gate:

| form | example |
| --- | --- |
| `--flag=value` | `curl --output=/p` |
| `name=value` | `dd if=/p` |
| `-o value` glued | `tar -C/p` |

The glued short-option form requires its value to begin with `/` or `~`; without that,
`ls -la` reads as an option carrying a relative path. Nothing else about the coverage floor
changes.

## Differential corpus, not just new tests

43 commands evaluated against `origin/main` and against this branch. **Exactly the six
escapes flip ALLOW → BLOCK; nothing else moves.**

Two results worth calling out, because they show this is a boundary check rather than a
blanket ban on absolute option values:

```
ALLOW   cc -I/opt/xcsh/plugins -o app main.c     (readable root)
ALLOW   tar -C/shared/ctx -cf out.tgz .          (readable root)
```

And the #2470 false positives are untouched — `sed -n '/a/p'`, `sed -n '/^COMMANDS/,$p'`,
`awk -F/ '{print $2}'`, `jq '.a/.b'`, `grep -E '^/usr/(bin|lib)'` — as are ordinary option
forms like `node --max-old-space-size=4096`, `ssh -o StrictHostKeyChecking=no`,
`cc -I./include`.

## A real case the typechecker caught

`operand` can be `"skip"` — a here-string or heredoc delimiter, whose operand the shell
never opens (`cat <<</tmp/f` prints the text). I had passed it through. That is a genuine
semantic case, not a typing nuisance, so it is guarded and has its own test rather than a
cast.

## Deliberately not covered

Which boundary an option implies. Knowing `of=` is a write and `if=` a read needs a
per-command option table — the enumeration hazard #2479 warned against — so these are
checked as reads. A path granted read but not write, attached to `of=`, remains uncovered;
that limit is stated in the test rather than papered over.

## Verification

- `bun run ci:check:full` — exit 0
- full `coding-agent` suite — 6093 pass, 0 fail
- `sandbox-enforce.test.ts` — 38 pass, including the #2470 fence and the coverage floor
- differential corpus above
