### PR TITLE
test(manager.int): report who holds a silent port, so "dead" and "not serving" separate

### DIFF
--- a/packages/coding-agent/test/manager-wait-diagnostics.test.ts
+++ b/packages/coding-agent/test/manager-wait-diagnostics.test.ts
@@ -106,3 +106,51 @@ describe("describePortScan (#2463 mode C)", () => {
 		expect(wrongTenant).toContain("matched 0 of 1");
 	});
 });
+
+describe("describePortScan reports who holds a silent port (#2463)", () => {
+	/**
+	 * Mode C recurred on main with #2533 present (run 30328598436, 21160ms). The scan
+	 * showed both workers provisioned on distinct ports and the FIRST one silent:
+	 *
+	 *     24800: no answer — ws error
+	 *     24801: tenant "acme"
+	 *
+	 * and could go no further, because "no answer" covers two different defects. A dead
+	 * worker means something killed it; a live one that never answers means its bridge
+	 * failed to come up or its event loop is stalled. The survival diagnostic already
+	 * reports holder pids for exactly this reason (#2539); the scan did not, so a third
+	 * occurrence was spent without resolving it.
+	 */
+	test("a silent port with a live holder is distinguished from a vacant one", () => {
+		const lines = describePortScan(
+			[
+				{ port: 24800, error: "ws error", holders: [13389] },
+				{ port: 24801, tenant: "acme" },
+				{ port: 24802, error: "ws error", holders: [] },
+			],
+			"acme",
+		).join("\n");
+		expect(lines).toContain("24800");
+		expect(lines).toContain("13389"); // alive but not answering — bridge/event-loop
+		expect(lines).toContain("nothing holds it"); // 24802 is genuinely vacant
+	});
+
+	test("says so explicitly when a silent port has no holder — the worker is gone", () => {
+		const lines = describePortScan([{ port: 24800, error: "ECONNREFUSED", holders: [] }], "acme").join("\n");
+		expect(lines).toContain("nothing holds it");
+		expect(lines).not.toContain("held by");
+	});
+
+	test("omits holder wording when the caller could not enumerate", () => {
+		// lsof absent, or the sweep failed: unknown must not read as "gone".
+		const lines = describePortScan([{ port: 24800, error: "ws error" }], "acme").join("\n");
+		expect(lines).not.toContain("nothing holds it");
+		expect(lines).not.toContain("held by");
+	});
+
+	test("an answering port needs no holder annotation", () => {
+		const lines = describePortScan([{ port: 24801, tenant: "acme", holders: [13391] }], "acme").join("\n");
+		expect(lines).toContain('tenant "acme"');
+		expect(lines).not.toContain("13391"); // it answered; who holds it adds nothing
+	});
+});

--- a/packages/coding-agent/test/manager-wait-diagnostics.ts
+++ b/packages/coding-agent/test/manager-wait-diagnostics.ts
@@ -93,6 +93,12 @@ export interface PortProbe {
 	readonly tenant?: string;
 	/** Why it did not answer, when it did not. */
 	readonly error?: string;
+	/**
+	 * PIDs holding the port, when the caller could enumerate them. Omit when it could
+	 * not — `undefined` means unknown, `[]` means genuinely nobody, and conflating the
+	 * two would report a live worker as gone.
+	 */
+	readonly holders?: readonly number[];
 }
 
 /**
@@ -111,9 +117,22 @@ export function describePortScan(results: readonly PortProbe[], wantedTenant: st
 	const answered = results.filter(r => r.tenant !== undefined).length;
 	const lines = [`  port scan — matched ${matched} of ${results.length} for tenant "${wantedTenant}":`];
 	for (const r of results) {
-		lines.push(
-			`    ${r.port}: ${r.tenant !== undefined ? `tenant "${r.tenant}"` : `no answer — ${r.error ?? "unknown"}`}`,
-		);
+		if (r.tenant !== undefined) {
+			lines.push(`    ${r.port}: tenant "${r.tenant}"`);
+			continue;
+		}
+		// "No answer" spans two different defects, and the difference is the whole
+		// question: a port nobody holds means the worker is gone (something killed it),
+		// while a port held by a live pid means it is up but not serving — a bridge that
+		// failed to start, or a stalled event loop. Mode C spent three occurrences
+		// unresolved for want of this line.
+		const holders =
+			r.holders === undefined
+				? "" // could not enumerate; unknown must not read as "gone"
+				: r.holders.length > 0
+					? ` — held by pid ${r.holders.join(", ")}, so it is up but not serving`
+					: " — nothing holds it, so the worker is gone";
+		lines.push(`    ${r.port}: no answer — ${r.error ?? "unknown"}${holders}`);
 	}
 	if (answered === 0) {
 		lines.push("  no port answered at all — nothing is listening on the range");

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -642,11 +642,21 @@ test("provision spawns one worker PER sessionId (two same-tenant tabs → two wo
 		}
 	})();
 	if (ports.size !== 2) {
+		// Who holds a silent port is the datum that separates "the worker died" from
+		// "it is up but not serving" — the ambiguity that left three Mode C occurrences
+		// unresolved (#2463). Enumerated only on the failure path, so the happy path
+		// pays nothing.
+		const holdersByPort = new Map<number, number[]>();
+		for (const p of RANGE) holdersByPort.set(p, await pidsOnPort(p));
 		throw new Error(
 			[
 				`expected 2 distinct range ports advertising "acme", saw ${ports.size}`,
 				...describePortScan(
-					RANGE.map(p => ({ port: p, ...(lastSeen.get(p) ?? { error: "never probed" }) })),
+					RANGE.map(p => ({
+						port: p,
+						...(lastSeen.get(p) ?? { error: "never probed" }),
+						holders: holdersByPort.get(p),
+					})),
 					"acme",
 				),
 				...describeManagerCensus(getErr()),


### PR DESCRIPTION
Closes #2545
Refs #2463

Closes a gap in my own instrumentation that cost a third unresolved occurrence.

## What happened

Mode C recurred on main **with #2533 present** (run 30328598436, 21160 ms — verified by
`git merge-base --is-ancestor bd4359864 040e76faf`). The scan reported:

```
port scan — matched 1 of 4 for tenant "acme":
  24800: no answer — ws error
  24801: tenant "acme"
provisioned tab-101 → pid 13389 on port 24800
provisioned tab-102 → pid 13391 on port 24801
```

That established real things and ruled several out:

- **Both** workers were provisioned, on **distinct** ports — not a collision, not registry
  dedupe, not range exhaustion.
- It is the **first** tab going silent, not the second — the opposite of the natural reading
  of `Received: 1`.

But it stopped there, because **"no answer" spans two different defects**:

| holder | meaning | where to look |
| --- | --- | --- |
| nobody | the worker is gone | something killed it |
| a live pid | up but not serving | bridge startup, or a stalled event loop |

Those need opposite investigations, and the scan couldn't tell them apart.

## The inconsistency

I added exactly this datum to the *survival* diagnostic in #2539 — `pids still holding the
port` — and did not carry it across to the port scan. Same file, same question, same
session. That is why a third occurrence went unresolved.

## Design note

`holders` is deliberately three-valued:

- `undefined` — the caller could not enumerate (lsof absent, sweep failed)
- `[]` — genuinely nobody
- non-empty — held

Collapsing the first two would report a live worker as gone, which is precisely the error
this exists to prevent. Enumeration runs only on the failure path, so the happy path pays
nothing.

## Verification

Forced the failure against a real manager and read the output rather than assuming the
formatter was wired:

```
20800: no answer — ws error — nothing holds it, so the worker is gone
```

Correct for that run — the poll was shortened, so the workers had not bound yet.

The four formatter branches are unit-tested deterministically. `pidsOnPort` returning live
pids in this exact context is already evidenced by the Mode D occurrence that printed
`pids still holding the port: 81728`, so it is not re-proven here.

- `bun run ci:check:full` — exit 0
- `manager.int.test.ts` — 18/18
- diagnostics unit tests — 12/12

No wait, budget or timing changed. Diagnostics only.

## On #2463

Staying open. I claimed in #2533 that the port-probe fix "explains the two `Received: 1`
occurrences"; a third has now happened with that fix in place, so the explanation is at
best incomplete. Correction recorded on the issue. The next occurrence will say which of
the two defects above it is.
