### PR TITLE
fix(sandbox): resolve $HOME like ~, and refuse a redirect target we cannot resolve

### DIFF
--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -151,6 +151,21 @@ function deny(policy: SandboxPolicy, resolved: string, access: SandboxAccess): T
 	return { block: true, reason: policy.describe(resolved, access) };
 }
 
+/**
+ * `$HOME` and `${HOME}` are spellings of `~`, which `looksLikePath` already treats as a
+ * path (#2534). Three ways to name one file, only one of them checked, is an oversight
+ * rather than a policy: `cat ~/.ssh/id_rsa` was blocked while `cat $HOME/.ssh/id_rsa`
+ * was not. Rewriting to `~` here means detection AND resolution both see the real path,
+ * so the denial names the file rather than a literal dollar sign.
+ *
+ * `\b` keeps `$HOMEBREW_PREFIX` and friends out of it.
+ */
+const HOME_EXPANSION = /^\$(?:HOME\b|\{HOME\})/;
+
+function normalizeHomeExpansion(token: string): string {
+	return HOME_EXPANSION.test(token) ? token.replace(HOME_EXPANSION, "~") : token;
+}
+
 function looksLikePath(token: string): boolean {
 	return path.isAbsolute(token) || token.startsWith("~") || /(^|[/\\])\.\.([/\\]|$)/.test(token);
 }
@@ -224,7 +239,8 @@ const OPTION_VALUE_FORMS: readonly RegExp[] = [
  */
 function codePathOccurrences(command: string): PathOccurrence[] {
 	const found: PathOccurrence[] = [];
-	const add = (token: string, at: number, access?: SandboxAccess): void => {
+	const add = (raw: string, at: number, access?: SandboxAccess): void => {
+		const token = normalizeHomeExpansion(raw);
 		if (token.length > 0 && looksLikePath(token)) found.push({ token, at, access });
 	};
 	// Set when the previous token was nothing but a redirection operator, so this one is its operand.
@@ -306,11 +322,26 @@ function codePathCandidates(command: string): PathCandidate[] {
  * `-exec` run — is not blanked, so it is still scanned. When the command cannot be lexed
  * confidently, the floor stands alone.
  */
-function shellPathCandidates(command: string): PathCandidate[] {
+/**
+ * A redirect target the shell will certainly open, whose path cannot be resolved here —
+ * `printf x >"$TARGET"`. Unlike an operand, there is no reading under which this is data
+ * rather than a file, so it cannot be waved through (#2534).
+ */
+interface UnresolvableTarget {
+	text: string;
+	access: SandboxAccess;
+}
+
+interface ShellScan {
+	candidates: PathCandidate[];
+	unresolvable: UnresolvableTarget[];
+}
+
+function shellPathCandidates(command: string): ShellScan {
 	const lexed = lexShellCommand(command);
 	// Unbalanced quotes mean every word boundary is a guess: neither the blanking nor the write
 	// marking below can be trusted, so fall back to the floor, checked as reads.
-	if (lexed.unterminated) return codePathCandidates(command);
+	if (lexed.unterminated) return { candidates: codePathCandidates(command), unresolvable: [] };
 
 	const exemptSpans = lexed.commands.flatMap(simpleCommand => provenExemptWords(simpleCommand));
 	let scanned = command;
@@ -335,13 +366,19 @@ function shellPathCandidates(command: string): PathCandidate[] {
 	// Not gated on `looksLikePath`: that test is for the floor's *guesses* about which fragments of a
 	// command might be filenames. A redirect target is one the shell will certainly open, so a bare
 	// `out.txt` is checked too — it resolves under the cwd, which a read-only cwd does not license.
+	const unresolvable: UnresolvableTarget[] = [];
 	for (const word of lexed.words) {
 		if (word.redirect === undefined || word.redirect === "here-string") continue;
 		for (const access of word.redirect === "read-write" ? WRITE_AND_READ : [word.redirect]) {
-			candidates.push({ token: word.text, access });
+			// `literal` is false when the word carries `$VAR`, a substitution, a glob or a brace
+			// expansion, so `text` is not a stand-in for one filesystem reference. Resolving it
+			// anyway is what let `>"$TARGET"` through: it became the literal string `$TARGET`
+			// under the cwd, which the boundary happily allowed.
+			if (word.literal) candidates.push({ token: word.text, access });
+			else unresolvable.push({ text: word.text, access });
 		}
 	}
-	return candidates;
+	return { candidates, unresolvable };
 }
 
 /** Base directories a search input would actually search, split like the tools do. */
@@ -383,8 +420,25 @@ function evaluateCodeTool(check: ToolCallCheck, fields: string[], shell: boolean
 		// Only bash gets the shell-aware treatment. Python is not shell: lexing `open('/x')` as
 		// shell yields one non-absolute word and would lose the check entirely, and it has no
 		// redirects, so every candidate it produces is a read.
+		const scan: ShellScan = shell
+			? shellPathCandidates(command)
+			: { candidates: codePathCandidates(command), unresolvable: [] };
+		// Refused before any candidate is resolved: there is no path to check, and that is
+		// precisely the problem. The residual this does NOT cover is an expansion in an
+		// operand rather than a redirect target — `cat "$SECRET"` — which cannot be resolved
+		// at this layer at all. That is the Phase 2 OS-sandbox's job; do not read the text
+		// boundary as complete (#2534).
+		for (const target of scan.unresolvable) {
+			return {
+				block: true,
+				reason:
+					`sandbox: refusing to ${target.access} a redirect target this layer cannot resolve: ` +
+					`${target.text}. The shell will open it, but its path comes from an expansion, so the ` +
+					"boundary cannot be checked. Write to an explicit path, or use --allow-path.",
+			};
+		}
 		const seen = new Set<string>();
-		for (const { token, access } of shell ? shellPathCandidates(command) : codePathCandidates(command)) {
+		for (const { token, access } of scan.candidates) {
 			if (!seen.add(`${access}\0${token}`)) continue;
 			const resolved = resolveToCwd(token, base);
 			if (policy.isAllowed(resolved, access)) continue;

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -505,3 +505,55 @@ describe("option-attached paths (#2524)", () => {
 		expect(check("bash", { command: "git commit -m 'fix: a=b'" }).block).toBe(false);
 	});
 });
+
+describe("paths reaching the shell through an expansion (#2534)", () => {
+	/**
+	 * The boundary reads the command as text, so a path arriving via a parameter
+	 * expansion was never checked. Not all of that is fixable at this layer, and the
+	 * split matters:
+	 *
+	 *   - `$HOME`/`${HOME}` mean exactly what `~` means, which is already handled.
+	 *     Three spellings of one file, one of them blocked, is not a policy — it is
+	 *     an oversight.
+	 *   - A redirect target is unambiguously a file the shell opens, so a non-literal
+	 *     one cannot be defended as "might be data".
+	 *   - An arbitrary variable in an operand (`cat "$SECRET"`) is genuinely
+	 *     unresolvable here. Left open on purpose; see the note in enforce.ts.
+	 */
+	// Assembled rather than written literally: a shell `${HOME}` inside a TS string reads as
+	// a broken template placeholder to the linter, and suppressing that would hide the real
+	// rule everywhere else.
+	const BRACED_HOME = `$\u007bHOME\u007d`;
+
+	it("treats $HOME and its braced form as ~, which is already blocked", () => {
+		expect(check("bash", { command: "cat ~/.ssh/id_rsa" }).block).toBe(true); // the existing rule
+		expect(check("bash", { command: "cat $HOME/.ssh/id_rsa" }).block).toBe(true);
+		expect(check("bash", { command: `cat ${BRACED_HOME}/.ssh/id_rsa` }).block).toBe(true);
+		expect(check("bash", { command: 'cp secret "$HOME/exfil"' }).block).toBe(true);
+		// A different variable that merely starts with HOME must not be rewritten.
+		expect(check("bash", { command: "echo $HOMEBREW_PREFIX" }).block).toBe(false);
+	});
+
+	it("blocks a redirect target the shell will open but we cannot resolve", () => {
+		expect(check("bash", { command: 'printf x >"$TARGET"' }).block).toBe(true);
+		expect(check("bash", { command: "printf x > $TARGET" }).block).toBe(true);
+		expect(check("bash", { command: 'cat >"$OUT" <in.txt' }).block).toBe(true);
+		expect(check("bash", { command: "cat > $(mktemp)" }).block).toBe(true);
+	});
+
+	it("leaves ordinary redirects and globs working", () => {
+		expect(check("bash", { command: "echo x > out.txt" }).block).toBe(false);
+		expect(check("bash", { command: "echo x >> ./logs/run.log" }).block).toBe(false);
+		expect(check("bash", { command: "ls *.ts" }).block).toBe(false);
+		expect(check("bash", { command: "grep -rn TODO src/**/*.ts" }).block).toBe(false);
+		// A here-string operand is literal data, not a file the shell opens.
+		expect(check("bash", { command: "cat <<<$SECRET" }).block).toBe(false);
+	});
+
+	it("documents the residual: a variable in an operand is still not resolvable here", () => {
+		// Deliberately asserting the CURRENT behaviour, so that if a later change closes
+		// this the test fails loudly and the gap is re-evaluated rather than silently
+		// assumed. Phase 2 (OS-level sandbox) is what actually covers it.
+		expect(check("bash", { command: 'cat "$SECRET"' }).block).toBe(false);
+	});
+});


### PR DESCRIPTION
Fixes #2534

Two of the three escapes in the report, decided by research rather than by picking a design.
The third is left open deliberately.

## What the research found

**1. The lexer already detects this.** `ShellWord.literal` is documented as false when a word
carries `$VAR`, a substitution, a glob or a brace expansion, and it flags every example —
carrying the redirect direction with it:

```
NONLIT  cat "$SECRET"             -> ["$SECRET"]
NONLIT  printf x >"$TARGET"       -> ["$TARGET[write]"]
NONLIT  cat $(echo /work/custB/x) -> ["$(echo /work/custB/x)"]
literal cat /work/custB/secret
```

So this was never "a text scanner cannot see it". The signal existed; the sandbox did not
consume it. That made the problem much narrower than the issue implied.

**2. The assignment example was already fixed by #2541.** Verified, not assumed:

```
BLOCK  TARGET=/work/custB/y; printf x >"$TARGET"
BLOCK  TARGET=/work/custB/y
BLOCK  export TARGET=/work/custB/y
```

`TARGET=/work/custB/y` matches the `name=value` option-value form added there, so the path
is caught where it is written down, before expansion matters.

**3. `$HOME` trivially bypassed the existing `~` rule:**

```
BLOCK  cat ~/.ssh/id_rsa
ALLOW  cat $HOME/.ssh/id_rsa
ALLOW  cat ${HOME}/.ssh/id_rsa
```

Three spellings of one file, one blocked. An oversight, not a policy.

## What this changes

**`$HOME` / `${HOME}` → `~`**, rewritten where occurrences are recorded, so detection *and*
resolution both see the real path and the denial names the file rather than a dollar sign.
`\b` keeps `$HOMEBREW_PREFIX` out of it, with a test.

**A non-literal redirect target is refused outright.** It is the one position where there is
no reading under which the word is data rather than a file — the shell will open it.
Previously `>"$TARGET"` resolved to the literal string `$TARGET` under the cwd, which the
boundary allowed.

## What this deliberately does not fix

A variable in an **operand** — `cat "$SECRET"`. Genuinely unresolvable at this layer, and
refusing every command with a variable in an operand would break far more than it protects:
`ls *.ts` is non-literal too, so "fail closed on non-literal" is not available as a blanket
rule.

That is the Phase 2 OS-level sandbox's job. Rather than leave it implicit, there is a test
asserting the **current allow**, so if a later change closes it the gap is re-evaluated
instead of silently assumed, plus a note in `enforce.ts` saying the text boundary is not
complete. I would rather the limit be visible than have the boundary read as finished.

## Verification

Differential corpus, 30 commands, `origin/main` vs this branch — **exactly the six intended
escapes flip ALLOW → BLOCK, nothing else moves**:

```
cat $HOME/.ssh/id_rsa      cp secret "$HOME/exfil"     printf x >"$TARGET"
printf x > $TARGET         cat >"$OUT" <in.txt         cat > $(mktemp)
```

Untouched: `for f in *.ts; do echo $f; done`, `echo $HOMEBREW_PREFIX`, `cat <<<$SECRET`
(here-string operands are literal data), `echo x > out.txt`, `ls *.ts`,
`grep -rn TODO src/**/*.ts`, the #2470 sed/awk forms, and the documented residual.

- `bun run ci:check:full` — exit 0
- `sandbox-enforce.test.ts` — 42 pass
- Two full-suite failures were investigated and are **unrelated**: `ProfileCollector` fails
  identically on pristine main (30002 ms timeout), neither failing file references the
  sandbox, and both pass in isolation here.
