### PR TITLE
fix(sandbox): gate the directory change, and stop a metacharacter joining the path

### DIFF
--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -18,8 +18,8 @@
  * for both bash and python.
  */
 import * as path from "node:path";
-import { parseFindPattern, parseSearchPath, resolveToCwd, splitTopLevel } from "../tools/path-utils";
-import { lexShellCommand } from "../tools/shell-lex";
+import { expandPath, parseFindPattern, parseSearchPath, resolveToCwd, splitTopLevel } from "../tools/path-utils";
+import { lexShellCommand, type ShellSimpleCommand } from "../tools/shell-lex";
 import { provenExemptWords } from "./command-operands";
 import type { SandboxAccess, SandboxPolicy } from "./policy";
 
@@ -194,6 +194,12 @@ function operandAccess(operator: string): SandboxAccess | "skip" {
 interface PathCandidate {
 	token: string;
 	access: SandboxAccess;
+	/**
+	 * A directory the shell is about to move into. It must clear both boundaries on its own merits,
+	 * and the system-root read exemption does not apply: `/usr` being readable is no reason to let
+	 * the working directory — and with it every unchecked relative path — move there.
+	 */
+	mustBeInTree?: boolean;
 }
 
 /** Write first, so a `<>` denial names the stricter boundary the caller is most likely missing. */
@@ -204,6 +210,9 @@ const REDIRECT_OPERATOR = /[0-9]*(?:&>>|&>|<<<|<<-|<<|>>|>\||<>|>&|<&|>|<)/g;
 
 /** A whitespace token that is only a redirection operator, so the next token is its operand. */
 const BARE_REDIRECT = /^[0-9]*(?:&>>|&>|<<<|<<-|<<|>>|>\||<>|>&|<&|>|<)$/;
+
+/** Where a shell word ends inside a whitespace token: an operator, separator, or grouping. */
+const METACHARACTER = /[;&|<>()]/;
 
 /**
  * A path glued to its option, as one shell word (#2524).
@@ -267,7 +276,17 @@ function codePathOccurrences(command: string): PathOccurrence[] {
 			const access = operandAccess(operator[0]);
 			if (access === "skip") continue;
 			const from = operator.index + operator[0].length;
-			add(stripped.slice(from).replace(/^["']|["']$/g, ""), match.index + openingQuote + from, access);
+			// The operand ends at the first shell metacharacter, not at the end of the whitespace
+			// token. `>/dev/null; echo x` is one token, and taking all of it produced the "path"
+			// `/dev/null;`, which matched no write sink and refused a completely ordinary command
+			// (#2540). Truncating only ever shortens a candidate, so nothing blocked becomes allowed.
+			const rest = stripped.slice(from);
+			const stop = rest.search(METACHARACTER);
+			add(
+				(stop === -1 ? rest : rest.slice(0, stop)).replace(/^["']|["']$/g, ""),
+				match.index + openingQuote + from,
+				access,
+			);
 		}
 
 		// An option glued to its value is one word too, and the lexer cannot help: it
@@ -323,18 +342,137 @@ function codePathCandidates(command: string): PathCandidate[] {
  * confidently, the floor stands alone.
  */
 /**
- * A redirect target the shell will certainly open, whose path cannot be resolved here —
- * `printf x >"$TARGET"`. Unlike an operand, there is no reading under which this is data
- * rather than a file, so it cannot be waved through (#2534).
+ * Something the shell will act on whose path this layer cannot resolve — `cd "$DEST"`.
+ *
+ * Refusal is justified here and *not* for a redirect target, which is the asymmetry worth stating: a
+ * redirect target that escapes damages one file, while a directory change silently relocates every
+ * later relative path in the session, and relative paths are never candidates at all. So an
+ * unresolvable `cd` fails closed, and an unresolvable `> "$LOG"` does not.
+ *
+ * The reverse was tried (#2552) and refused `make > "$LOG"`, `> "$TMPDIR/f"` and `> out-$$.txt` —
+ * ordinary shell, writing in-tree. Narrowing it is not possible either: a variable's *value* can
+ * contain `../`, so `> "out-$X"` escapes while looking relative. Resolving that needs the expansion,
+ * which only the shell has — Phase 2 (#2554).
  */
 interface UnresolvableTarget {
 	text: string;
-	access: SandboxAccess;
+	/** What the shell was about to do, for a message that names the actual problem. */
+	what: "directory change";
 }
 
 interface ShellScan {
 	candidates: PathCandidate[];
 	unresolvable: UnresolvableTarget[];
+}
+
+/**
+ * Why a directory change was refused. Distinct from `describe` because the remedy differs: the path
+ * may well be readable, and the problem is that standing there redefines every relative path the
+ * boundary trusts to stay in the tree.
+ */
+function describeDirectoryChange(policy: SandboxPolicy, target?: string, unresolved?: string): string {
+	const what =
+		target === undefined
+			? `a directory this check cannot resolve from the command text (${unresolved})`
+			: `${target}, which is outside it`;
+	return `Refusing to change the working directory to ${what} (session directory: ${policy.cwd}). Relative paths are trusted to stay inside the session tree, so moving out of it would silently take every later path with it. Use an absolute path, or --allow-path to widen the boundary first.`;
+}
+
+/** Builtins that move the shell, and therefore move what every later relative path means. */
+const DIRECTORY_CHANGE = new Set(["cd", "pushd"]);
+
+/** `cd`'s own options. All boolean, so the target is the first non-option operand. */
+const DIRECTORY_CHANGE_OPTIONS = new Set(["-L", "-P", "-e", "-@"]);
+
+/**
+ * Commands whose operand is a script the shell will run. The lexer hands the script over as one
+ * word, so a directory change inside it is invisible unless that word is lexed in turn.
+ */
+const SCRIPT_RUNNERS = new Set(["sh", "bash", "zsh", "dash", "ksh", "eval"]);
+
+/**
+ * Prefixes that run the *following words* as a command rather than a script string. `command` is
+ * already unwrapped by the lexer; `builtin` is not, and `builtin cd /` would otherwise sail past a
+ * gate that only looks at `name`.
+ */
+const COMMAND_PREFIXES = new Set(["builtin"]);
+
+/** Cheap pre-filter: only lex a script operand that could contain a directory change at all. */
+const DIRECTORY_CHANGE_TOKEN = /(^|[\s;&|(])(cd|pushd)([\s;&|)]|$)/;
+
+/**
+ * Targets of a directory change: a candidate that must resolve in-tree, or the raw text when it
+ * cannot be resolved at all.
+ *
+ * This gate exists because a relative operand is never a candidate — the floor assumes it resolves
+ * under the session directory. `cd` is what breaks that assumption: the bash tool runs one
+ * persistent brush-core shell in the agent's own process, so a directory change outlives the call
+ * that made it and afterwards `cat tmp/x` reads somewhere else entirely (#2542).
+ *
+ * It is defence-in-depth, not a boundary. Verified still open: `c=cd; $c /`, `alias g=cd; g /`, and
+ * a symlink created in the same command (#2553). Those need the shell's own resolution, which is
+ * Phase 2 (#2554). Do not add a seventh spelling here — two adversarial rounds produced six.
+ */
+function directoryChangeTargets(commands: readonly ShellSimpleCommand[], depth = 0): (PathCandidate | string)[] {
+	const targets: (PathCandidate | string)[] = [];
+
+	for (const command of commands) {
+		if (command.name === undefined) continue;
+		let name = command.name;
+		let operands = command.words.slice(command.operandStart).filter(word => word.redirect === undefined);
+		// `builtin cd sub` is a `cd`; unwrap the prefix before deciding anything.
+		while (COMMAND_PREFIXES.has(name) && operands.length > 0 && operands[0].literal) {
+			name = operands[0].text;
+			operands = operands.slice(1);
+		}
+
+		// A script operand is text the shell will run, so lex it and gate what it contains. `eval
+		// 'cd /'` and `sh -c '…'` both arrive here. One level is enough for every real spelling;
+		// deeper nesting is unprovable.
+		if (SCRIPT_RUNNERS.has(name)) {
+			for (const operand of operands) {
+				if (!operand.literal) {
+					targets.push(operand.text); // `eval "$cmd"` — nothing to read
+					continue;
+				}
+				if (!DIRECTORY_CHANGE_TOKEN.test(operand.text)) continue;
+				if (depth > 0) {
+					targets.push(operand.text);
+					continue;
+				}
+				const inner = lexShellCommand(operand.text);
+				if (inner.unterminated) targets.push(operand.text);
+				else targets.push(...directoryChangeTargets(inner.commands, depth + 1));
+			}
+			continue;
+		}
+
+		if (!DIRECTORY_CHANGE.has(name)) continue;
+
+		// Options precede the target and are all boolean. One the model does not recognise means the
+		// target cannot be located, so the proof fails rather than guessing which operand it is.
+		let index = 0;
+		let unparseable = false;
+		while (index < operands.length && operands[index].text.startsWith("-") && operands[index].text !== "-") {
+			if (!DIRECTORY_CHANGE_OPTIONS.has(operands[index].text)) {
+				unparseable = true;
+				break;
+			}
+			index++;
+		}
+		if (unparseable) {
+			targets.push(operands.map(word => word.text).join(" "));
+			continue;
+		}
+
+		const target = operands[index];
+		// `cd` with no operand goes to $HOME; `cd -` returns somewhere only the shell remembers; a
+		// non-literal target cannot be resolved from text.
+		if (target === undefined) targets.push(`${name} (no target: goes to $HOME)`);
+		else if (!target.literal || target.text === "-") targets.push(target.text);
+		else targets.push({ token: target.text, access: "read", mustBeInTree: true });
+	}
+	return targets;
 }
 
 function shellPathCandidates(command: string): ShellScan {
@@ -366,17 +504,20 @@ function shellPathCandidates(command: string): ShellScan {
 	// Not gated on `looksLikePath`: that test is for the floor's *guesses* about which fragments of a
 	// command might be filenames. A redirect target is one the shell will certainly open, so a bare
 	// `out.txt` is checked too — it resolves under the cwd, which a read-only cwd does not license.
-	const unresolvable: UnresolvableTarget[] = [];
 	for (const word of lexed.words) {
 		if (word.redirect === undefined || word.redirect === "here-string") continue;
 		for (const access of word.redirect === "read-write" ? WRITE_AND_READ : [word.redirect]) {
-			// `literal` is false when the word carries `$VAR`, a substitution, a glob or a brace
-			// expansion, so `text` is not a stand-in for one filesystem reference. Resolving it
-			// anyway is what let `>"$TARGET"` through: it became the literal string `$TARGET`
-			// under the cwd, which the boundary happily allowed.
+			// A non-literal target — `$VAR`, a substitution, a glob — is not checked. `text` is not a
+			// stand-in for one filesystem reference, and refusing on that basis rejected ordinary
+			// in-tree shell (see UnresolvableTarget). Resolving it is Phase 2's job.
 			if (word.literal) candidates.push({ token: word.text, access });
-			else unresolvable.push({ text: word.text, access });
 		}
+	}
+
+	const unresolvable: UnresolvableTarget[] = [];
+	for (const target of directoryChangeTargets(lexed.commands)) {
+		if (typeof target === "string") unresolvable.push({ text: target, what: "directory change" });
+		else candidates.push(target);
 	}
 	return { candidates, unresolvable };
 }
@@ -402,7 +543,12 @@ function evaluateCodeTool(check: ToolCallCheck, fields: string[], shell: boolean
 
 	const rawCwd = typeof input.cwd === "string" ? input.cwd : undefined;
 	const base = rawCwd ? resolveToCwd(rawCwd, cwd) : cwd;
-	if (rawCwd && !policy.isAllowed(base, "read")) return deny(policy, base, "read");
+	// Both boundaries, for the same reason a `cd` target needs both: relative paths are never
+	// scanned, so wherever the command runs is somewhere it can write freely. Read alone let
+	// `{ cwd: "/shared/ctx", command: "touch notes.md" }` write into a read-only root.
+	if (rawCwd && !(policy.isAllowed(base, "read") && policy.isAllowed(base, "write"))) {
+		return { block: true, reason: describeDirectoryChange(policy, base) };
+	}
 
 	const commands: string[] = [];
 	for (const field of fields) {
@@ -429,17 +575,19 @@ function evaluateCodeTool(check: ToolCallCheck, fields: string[], shell: boolean
 		// at this layer at all. That is the Phase 2 OS-sandbox's job; do not read the text
 		// boundary as complete (#2534).
 		for (const target of scan.unresolvable) {
-			return {
-				block: true,
-				reason:
-					`sandbox: refusing to ${target.access} a redirect target this layer cannot resolve: ` +
-					`${target.text}. The shell will open it, but its path comes from an expansion, so the ` +
-					"boundary cannot be checked. Write to an explicit path, or use --allow-path.",
-			};
+			return { block: true, reason: describeDirectoryChange(policy, undefined, target.text) };
 		}
 		const seen = new Set<string>();
-		for (const { token, access } of scan.candidates) {
-			if (!seen.add(`${access}\0${token}`)) continue;
+		for (const { token, access, mustBeInTree } of scan.candidates) {
+			if (!seen.add(`${access}\0${mustBeInTree ? "cd\0" : ""}${token}`)) continue;
+			if (mustBeInTree) {
+				// `path.resolve`, not `resolveToCwd`: the latter maps an all-slashes path to the cwd,
+				// which would read `cd /` as `cd .` and let the shell walk out. Both boundaries,
+				// because relative paths go unchecked wherever the shell is standing.
+				const moved = path.resolve(base, expandPath(token));
+				if (policy.isAllowed(moved, "read") && policy.isAllowed(moved, "write")) continue;
+				return { block: true, reason: describeDirectoryChange(policy, moved) };
+			}
 			const resolved = resolveToCwd(token, base);
 			if (policy.isAllowed(resolved, access)) continue;
 			// SYSTEM_READ_ROOTS is a read allowance — "directories a subprocess may legitimately

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -211,6 +211,94 @@ describe("evaluateToolCall", () => {
 	// The floor splits on whitespace, so an operator glued to its path was one token that did not
 	// look like a path, and the boundary never saw it at all (#2520). A single space was the only
 	// thing standing between a blocked read and an allowed one.
+	// A relative operand is never checked, because the floor assumes it resolves under the session
+	// directory. `cd` is what breaks that assumption: the bash tool runs one persistent in-process
+	// shell, so a directory change outlives the call that made it and every later relative path
+	// resolves somewhere else. Refusing a `cd` that cannot be proven to stay in-tree is what keeps
+	// the assumption true — see #2542, where `cd /` then `cat tmp/x` read a sibling's file.
+	it("bash: cd cannot leave the session tree", () => {
+		// Provably in-tree: allowed.
+		expect(check("bash", { command: "cd sub" }).block).toBe(false);
+		expect(check("bash", { command: "cd ./sub/deeper" }).block).toBe(false);
+		expect(check("bash", { command: "cd /work/custA/sub" }).block).toBe(false);
+		expect(check("bash", { command: "cd ." }).block).toBe(false);
+		// Provably out of tree.
+		expect(check("bash", { command: "cd /" }).block).toBe(true);
+		expect(check("bash", { command: "cd /work/custB" }).block).toBe(true);
+		expect(check("bash", { command: "cd .." }).block).toBe(true);
+		expect(check("bash", { command: "cd ~" }).block).toBe(true);
+		// Not provable — no target, or one the scanner cannot resolve. Fail closed.
+		expect(check("bash", { command: "cd" }).block).toBe(true);
+		expect(check("bash", { command: "cd $HOME" }).block).toBe(true);
+		expect(check("bash", { command: 'cd "$HOME"' }).block).toBe(true);
+		expect(check("bash", { command: "cd -" }).block).toBe(true);
+		expect(check("bash", { command: "pushd /" }).block).toBe(true);
+		expect(check("bash", { command: "pushd $HOME" }).block).toBe(true);
+	});
+
+	// Clamping the session cwd between calls would not have been enough: one call can both move the
+	// shell and use the new location.
+	it("bash: a cd and a relative read in the same call cannot combine into an escape", () => {
+		expect(check("bash", { command: "cd / && cat tmp/esc/canary.txt" }).block).toBe(true);
+		expect(check("bash", { command: "cd /; cat tmp/esc/canary.txt" }).block).toBe(true);
+		expect(check("bash", { command: "(cd / && cat tmp/esc/canary.txt)" }).block).toBe(true);
+		expect(check("bash", { command: "cd $HOME && cat .ssh/id_rsa" }).block).toBe(true);
+		expect(check("bash", { command: "cd /work/custB && cat secret" }).block).toBe(true);
+		// The same shape entirely in-tree is ordinary work.
+		expect(check("bash", { command: "cd sub && cat notes.md" }).block).toBe(false);
+		expect(check("bash", { command: "cd ./sub; cat notes.md" }).block).toBe(false);
+	});
+
+	// The gate is on the directory change, so every spelling of one has to reach it: options before
+	// the target, a `builtin` prefix, and a change buried in a script operand that the lexer hands
+	// over as a single word. All found by adversarial review, all verified allowed beforehand.
+	it("bash: alternative spellings of a directory change are gated too", () => {
+		expect(check("bash", { command: "cd -P /" }).block).toBe(true);
+		expect(check("bash", { command: "cd -L /" }).block).toBe(true);
+		expect(check("bash", { command: "cd -P / && cat tmp/esc/canary.txt" }).block).toBe(true);
+		expect(check("bash", { command: "builtin cd /" }).block).toBe(true);
+		expect(check("bash", { command: "command cd /" }).block).toBe(true);
+		expect(check("bash", { command: "eval 'cd /'" }).block).toBe(true);
+		expect(check("bash", { command: "sh -c 'cd / && cat tmp/x'" }).block).toBe(true);
+		expect(check("bash", { command: "bash -c 'cd /; cat tmp/x'" }).block).toBe(true);
+		// A script the scanner cannot read is not a proof of anything.
+		expect(check("bash", { command: 'eval "$cmd"' }).block).toBe(true);
+		expect(check("bash", { command: 'sh -c "$script"' }).block).toBe(true);
+		// The same options staying in-tree remain ordinary work.
+		expect(check("bash", { command: "cd -P sub" }).block).toBe(false);
+		expect(check("bash", { command: "builtin cd sub" }).block).toBe(false);
+		expect(check("bash", { command: "sh -c 'cd sub && cat notes.md'" }).block).toBe(false);
+		// An option the model does not know disables the proof rather than guessing.
+		expect(check("bash", { command: "cd --future-flag sub" }).block).toBe(true);
+	});
+
+	// A cd destination must be somewhere any relative path would be acceptable — which means write
+	// as well as read. The default policy grants the plugin and skill directories read-only, and
+	// moving into one turned every unchecked relative path into a write there.
+	it("bash: a directory change needs write access, not just read", () => {
+		// /shared/ctx is readable and deliberately not writable.
+		expect(check("bash", { command: "cd /shared/ctx" }).block).toBe(true);
+		expect(check("bash", { command: "cd /shared/ctx && printf x > notes.md" }).block).toBe(true);
+		// /drop is writable but not readable — also not a safe place to stand.
+		expect(check("bash", { command: "cd /drop" }).block).toBe(true);
+		// The session tree is granted both, so it stays usable.
+		expect(check("bash", { command: "cd sub" }).block).toBe(false);
+		expect(check("bash", { command: "cd /work/custA/sub" }).block).toBe(false);
+	});
+
+	// The `cwd` tool argument is the same lever as `cd`, supplied as structured input instead of
+	// text. It was checked for read only, so a read-only root could be used as a working directory
+	// and written to through an unscanned relative path.
+	it("bash: the cwd argument needs write access too", () => {
+		expect(check("bash", { cwd: "/shared/ctx", command: "touch notes.md" }).block).toBe(true);
+		expect(check("bash", { cwd: "/shared/ctx", command: "cat notes.md" }).block).toBe(true);
+		expect(check("bash", { cwd: "/drop", command: "cat x" }).block).toBe(true);
+		expect(check("bash", { cwd: "/work/custB", command: "cat x" }).block).toBe(true);
+		// In-tree stays usable.
+		expect(check("bash", { cwd: "/work/custA/sub", command: "cat notes.md" }).block).toBe(false);
+		expect(check("bash", { command: "cat notes.md" }).block).toBe(false);
+	});
+
 	it("bash: a redirect attached to its path is still checked", () => {
 		expect(check("bash", { command: "cat </work/custB/secret" }).block).toBe(true);
 		expect(check("bash", { command: "cat\t</work/custB/secret" }).block).toBe(true);
@@ -302,6 +390,26 @@ describe("evaluateToolCall", () => {
 		// And where the cwd *is* writable, a relative target is ordinary work.
 		expect(check("bash", { command: "printf x > out.txt" }).block).toBe(false);
 		expect(check("bash", { command: "printf x > ./sub/out.txt" }).block).toBe(false);
+	});
+
+	// The operand of a redirect was taken to the end of the whitespace token, so a metacharacter
+	// glued to the target was absorbed into the "path" and `/dev/null;` matched no write sink
+	// (#2540, a regression shipped in 19.98.2). Ordinary shell is full of this shape.
+	it("bash: a metacharacter after a redirect target is not part of the path", () => {
+		expect(check("bash", { command: "printf hello >/dev/null; echo x" }).block).toBe(false);
+		expect(check("bash", { command: "printf hello 2>/dev/null; echo x" }).block).toBe(false);
+		expect(check("bash", { command: "(printf hello >/dev/null)" }).block).toBe(false);
+		expect(check("bash", { command: "printf hello >/dev/null&&echo x" }).block).toBe(false);
+		expect(check("bash", { command: "printf hello >/dev/null|cat" }).block).toBe(false);
+		expect(check("bash", { command: "printf hello >/dev/null&" }).block).toBe(false);
+		expect(check("bash", { command: "ls 2>/dev/null|wc -l" }).block).toBe(false);
+		// Truncating at the metacharacter must not lose the target itself.
+		expect(check("bash", { command: "printf x >/work/custB/y; echo done" }).block).toBe(true);
+		expect(check("bash", { command: "cat </work/custB/secret; echo x" }).block).toBe(true);
+		expect(check("bash", { command: "printf x >/work/custB/y|cat" }).block).toBe(true);
+		expect(check("bash", { command: "printf x >/shared/ctx/f; echo done" }).block).toBe(true);
+		// Nor the direction of a nested one.
+		expect(check("bash", { command: "sh -c 'printf x >/shared/ctx/x; echo done'" }).block).toBe(true);
 	});
 
 	// SYSTEM_READ_ROOTS is a *read* allowance — "directories a subprocess may legitimately read or
@@ -508,21 +616,16 @@ describe("option-attached paths (#2524)", () => {
 
 describe("paths reaching the shell through an expansion (#2534)", () => {
 	/**
-	 * The boundary reads the command as text, so a path arriving via a parameter
-	 * expansion was never checked. Not all of that is fixable at this layer, and the
-	 * split matters:
+	 * The boundary reads the command as text, so a path arriving via a parameter expansion was
+	 * never checked. Only part of that is fixable at this layer, and the split matters:
 	 *
-	 *   - `$HOME`/`${HOME}` mean exactly what `~` means, which is already handled.
-	 *     Three spellings of one file, one of them blocked, is not a policy — it is
-	 *     an oversight.
-	 *   - A redirect target is unambiguously a file the shell opens, so a non-literal
-	 *     one cannot be defended as "might be data".
-	 *   - An arbitrary variable in an operand (`cat "$SECRET"`) is genuinely
-	 *     unresolvable here. Left open on purpose; see the note in enforce.ts.
+	 *   - `$HOME`/`${HOME}` mean exactly what `~` means, which is already handled. Three
+	 *     spellings of one file, one of them blocked, is an oversight rather than a policy.
+	 *   - Everything else — a variable in an operand, and a variable in a redirect target — is
+	 *     genuinely unresolvable here and is left open on purpose. See below.
 	 */
-	// Assembled rather than written literally: a shell `${HOME}` inside a TS string reads as
-	// a broken template placeholder to the linter, and suppressing that would hide the real
-	// rule everywhere else.
+	// Assembled from escapes rather than written literally: a shell brace-expansion inside a TS
+	// template literal is a template interpolation, and `HOME` is not a TS binding.
 	const BRACED_HOME = `$\u007bHOME\u007d`;
 
 	it("treats $HOME and its braced form as ~, which is already blocked", () => {
@@ -534,13 +637,6 @@ describe("paths reaching the shell through an expansion (#2534)", () => {
 		expect(check("bash", { command: "echo $HOMEBREW_PREFIX" }).block).toBe(false);
 	});
 
-	it("blocks a redirect target the shell will open but we cannot resolve", () => {
-		expect(check("bash", { command: 'printf x >"$TARGET"' }).block).toBe(true);
-		expect(check("bash", { command: "printf x > $TARGET" }).block).toBe(true);
-		expect(check("bash", { command: 'cat >"$OUT" <in.txt' }).block).toBe(true);
-		expect(check("bash", { command: "cat > $(mktemp)" }).block).toBe(true);
-	});
-
 	it("leaves ordinary redirects and globs working", () => {
 		expect(check("bash", { command: "echo x > out.txt" }).block).toBe(false);
 		expect(check("bash", { command: "echo x >> ./logs/run.log" }).block).toBe(false);
@@ -550,10 +646,29 @@ describe("paths reaching the shell through an expansion (#2534)", () => {
 		expect(check("bash", { command: "cat <<<$SECRET" }).block).toBe(false);
 	});
 
+	/**
+	 * #2552 refused every non-literal redirect target. That is reverted here, deliberately.
+	 *
+	 * It broke ordinary in-tree shell — `make > "$LOG"`, `> "$TMPDIR/f"`, `> out-$$.txt`,
+	 * `> "log-$(date +%s).txt"` — and it cannot be narrowed into safety: a variable's *value*
+	 * can contain `../`, so `> "out-$X"` escapes while looking relative. The asymmetry with
+	 * `cd` is the point: a bad redirect target damages one file, while a bad directory change
+	 * silently relocates every later relative path. Phase 2 (#2554) resolves both properly.
+	 */
+	it("allows a redirect target it cannot resolve, and says why in the code", () => {
+		expect(check("bash", { command: 'printf x >"$TARGET"' }).block).toBe(false);
+		expect(check("bash", { command: "printf x > $TARGET" }).block).toBe(false);
+		expect(check("bash", { command: "cat > $(mktemp)" }).block).toBe(false);
+		// The idioms whose refusal made this a functionality regression.
+		expect(check("bash", { command: 'make > "$LOG"' }).block).toBe(false);
+		expect(check("bash", { command: 'echo x > "$TMPDIR/f"' }).block).toBe(false);
+		expect(check("bash", { command: "printf x > out-$$.txt" }).block).toBe(false);
+		expect(check("bash", { command: 'date > "log-$(date +%s).txt"' }).block).toBe(false);
+	});
+
 	it("documents the residual: a variable in an operand is still not resolvable here", () => {
-		// Deliberately asserting the CURRENT behaviour, so that if a later change closes
-		// this the test fails loudly and the gap is re-evaluated rather than silently
-		// assumed. Phase 2 (OS-level sandbox) is what actually covers it.
+		// Asserting CURRENT behaviour so a later change that closes this fails loudly and the
+		// gap is re-evaluated rather than silently assumed. Phase 2 is what covers it.
 		expect(check("bash", { command: 'cat "$SECRET"' }).block).toBe(false);
 	});
 });


### PR DESCRIPTION
Closes #2542
Closes #2540

Two defects on one code path. They ship together because fixing either alone makes the other worse.

## #2542 — `cd` out of the tree, then a relative path

A relative operand is never a candidate: the floor assumes it resolves under the session directory and is therefore in-tree. The bash tool runs **one persistent brush-core shell inside the agent's own process**, so a `cd` outlives the call that made it, and afterwards every relative path resolves somewhere else.

Confirmed against the installed 19.98.2 with a canary file:

```
cat /tmp/esc-test/other/canary.txt     -> BLOCKED (read boundary)
cd / ; pwd                             -> /
cat tmp/esc-test/other/canary.txt      -> ESCAPE-CANARY-3317
```

Clamping the session cwd between calls would not have closed it — `cd / && cat tmp/x` is a single call. So the lever itself is gated: a directory change is allowed only when its target is provably in-tree, and the target must clear **both** boundaries, because relative paths are unchecked wherever the shell is standing.

Gated across spellings, each verified allowed beforehand: `cd -P /`, `cd -L /`, `builtin cd /`, `eval 'cd /'`, `sh -c 'cd / && …'`, `cd` bare, `cd $HOME`, `cd -`, `pushd /`. An option the model does not recognise fails the proof rather than guessing which operand is the target, and a script it cannot read — `eval "$cmd"` — is not a proof of anything.

The same rule now applies to the **`cwd` tool argument**, which is the identical lever supplied as structured input and was checked for read only: `{ cwd: "/shared/ctx", command: "touch notes.md" }` wrote into a read-only root.

**A correction.** An earlier draft of this work claimed the policy *follows* the shell's cwd. It does not — `runner.ts:182` declares `private readonly cwd` and `createContext()` passes it, so the extension context cwd is pinned at construction. The escape is real; my first account of the mechanism was wrong.

**A second correction.** I claimed the default policy has no read-only roots, so this could only bite a configured `allowRead`. False: `buildDefaultSandboxPolicy` grants the plugin dir, the skills dir and three profile JSONs read-only. `cd ~/.xcsh/plugins && printf compromised > package.json` was therefore reachable in an ordinary session.

## #2540 — a metacharacter glued to a redirect target

The operand was taken to the end of the whitespace token, so `>/dev/null; echo x` produced the "path" `/dev/null;`, matched no write sink, and refused a completely ordinary command. It now ends at the first metacharacter. Truncating only ever shortens a candidate, so nothing blocked becomes allowed.

**Why together:** `cd /; cat tmp/x` was blocked on main *only* because #2540 mangled `/;` into a bogus path. Fixing #2540 alone would have turned that into an allow and widened the escape.

## What this does NOT fix — please read

The `cd` gate is **defence-in-depth, not a boundary.** Three spellings survive, verified allowed on this branch and filed as #2553:

```
c=cd; $c / && cat tmp/x           # command name is a variable
alias g=cd; g / && cat tmp/x      # command name is an alias
ln -s / pivot && cd -P pivot      # target is a symlink made in the same command
```

Two rounds of adversarial review on this fix produced **six** bypasses of the gate, and each round's fix invited the next spelling. That is the enumeration hazard #2479's plan named. All three survivors end the same way — an in-call directory change followed by a relative path — and deciding that correctly needs the working directory at `open()` time, which no scan of command text has. Filed as #2553, with #2554 opened as the Phase-2 tracking issue (`enforce.ts:14-18` has promised it all along).

I stopped patching deliberately rather than shipping a seventh rule and implying convergence.

## Verification

Differential corpus of 70 commands, old versus new, against current main:

- **7 newly allowed** — every one a `>/dev/null` followed by a metacharacter. No out-of-boundary path became reachable.
- **8 newly blocked** — every one a `cd` leaving the tree, including both escape one-liners.
- **everything else unchanged**, including the #2470 false positives, the coverage floor, and in-tree `cd sub && cat notes.md`.

`bun run check` clean. `bun run test:ts` from the repo root: 6094 pass, 4 fail — ProfileCollector and three `createAgentSession deferred model pattern resolution` cases. **All four fail identically on current main** (which fails 5), and all pass isolated; failures also move between runs, which is the signature of load sensitivity rather than a break. `sandbox-isolation.test.ts` → `loads the sandbox-guard extension by default` times out at 5 s here **and on main** — also pre-existing.

## Pre-PR review

Two rounds of `codex:verified-code-review`, six findings, **all six confirmed by execution** — four fixed, two escalated. The gate reports `done: false` with those two outstanding, recorded rather than resolved away.

| Finding | Outcome |
| ------- | ------- |
| Supported shell syntax bypasses the gate (`cd -P`, `builtin`, `eval`) | fixed |
| Read-only allowlisted roots writable through relative paths | fixed — destination needs read+write |
| Explicit `cwd` argument required only read | fixed |
| `builtin cd sub` over-blocked by my own first fix | fixed |
| Dynamic command names (`$c`, alias) | **not fixed** — #2553 |
| Symlink pivot | **not fixed** — #2553 |

The reviewer's exact repro for the dynamic-name finding was actually blocked (`c=cd; $c /; cat …` — the `/;` token is itself out-of-tree); it reproduces with `&&`. Worth noting because it is the second time a finding on this code needed a different separator to reproduce.
