### PR TITLE
ci: pin third-party actions where a credential is in reach, and enforce it

### DIFF
--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Bun 1.3
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Bun 1.3
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: true
-      - uses: dtolnay/rust-toolchain@nightly # TODO: unpin once nightly codegen regression is fixed
+      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2 # nightly branch head # TODO: unpin once nightly codegen regression is fixed
         with:
           toolchain: nightly-2026-03-27
           components: ${{ matrix.rust_checks && 'clippy, rustfmt' || '' }}
@@ -140,12 +140,12 @@ jobs:
       - name: Ensure cross-compilation target is installed
         if: matrix.target
         run: rustup target add ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           key: ${{ matrix.target }}${{ matrix.variants }}
           cache-workspace-crates: true
       - name: Setup Bun 1.3
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:
@@ -198,7 +198,7 @@ jobs:
           fi
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: "0.15.2"
       - run: bun install --frozen-lockfile
@@ -236,7 +236,7 @@ jobs:
           fetch-depth: 0
           lfs: true
       - name: Setup Bun 1.3
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:
@@ -289,13 +289,13 @@ jobs:
           fi
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
-      - uses: dtolnay/rust-toolchain@nightly # TODO: unpin once nightly codegen regression is fixed
+      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2 # nightly branch head # TODO: unpin once nightly codegen regression is fixed
         with:
           toolchain: nightly-2026-03-27
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           cache-workspace-crates: true
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: "0.15.2"
       - name: Cache bun dependencies
@@ -303,7 +303,7 @@ jobs:
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
         with:
           tool: nextest
       - name: Install system deps
@@ -341,7 +341,7 @@ jobs:
         with:
           lfs: true
       - name: Setup Bun 1.3
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:
@@ -394,13 +394,13 @@ jobs:
           fi
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
-      - uses: dtolnay/rust-toolchain@nightly # TODO: unpin once nightly codegen regression is fixed
+      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2 # nightly branch head # TODO: unpin once nightly codegen regression is fixed
         with:
           toolchain: nightly-2026-03-27
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           cache-workspace-crates: true
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: "0.15.2"
       - name: Cache bun dependencies
@@ -431,7 +431,7 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
       - name: Setup Bun 1.3
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:
@@ -510,7 +510,7 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
           lfs: true
       - name: Setup Bun 1.3
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:
@@ -610,7 +610,7 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
           lfs: true
       - name: Setup Bun 1.3
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:
@@ -960,7 +960,7 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Setup Bun 1.3
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:
@@ -1063,7 +1063,7 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
           lfs: true
       - name: Setup Bun 1.3
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:
@@ -1164,7 +1164,7 @@ jobs:
         with:
           node-version: "24"
       - name: Setup Bun 1.3
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:

--- a/.github/workflows/console-catalog-drift.yml
+++ b/.github/workflows/console-catalog-drift.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Setup Bun 1.3
         if: steps.ver.outputs.checkable == 'true'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3"
 

--- a/.github/workflows/console-catalog-update.yml
+++ b/.github/workflows/console-catalog-update.yml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup Bun 1.3
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3"
 

--- a/packages/coding-agent/test/workflow-action-pins.test.ts
+++ b/packages/coding-agent/test/workflow-action-pins.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Third-party GitHub Actions in credential-bearing workflows must be pinned (#2498).
+ *
+ * A tag is a pointer. Whoever controls the upstream repo can move it to new code, and the
+ * next run picks that up with no diff on our side. That only matters where there is
+ * something to steal, and the exposure here is concentrated rather than diffuse: `ci.yml`
+ * alone holds 14 references to release secrets and owns the whole publish chain — npm, the
+ * Homebrew tap, GitHub releases, macOS signing.
+ *
+ * This test exists because the decision does not survive on its own. Before it, the only
+ * pinned action in the repo was the one pinned in #2496 — and #2508 added a fresh unpinned
+ * one straight afterwards. A policy recorded in an issue does not reach the next workflow;
+ * a failing test does.
+ *
+ * Scope is deliberately narrow, so it stays worth obeying:
+ *   - `actions/*` is exempt. First-party, GitHub-maintained major tags. Pinning them is
+ *     ceremony that costs a SHA bump per security fix and buys little.
+ *   - `f5-sales-demo/*` reusable workflows are exempt: same org, same trust boundary.
+ *   - Workflows with no credential are exempt. There is nothing to exfiltrate from
+ *     `semgrep.yml` or `test-codesign.yml`, and failing them would train people to
+ *     dismiss this.
+ */
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+const WORKFLOW_DIR = path.join(import.meta.dir, "../../../.github/workflows");
+
+/** Workflows that reference a publishing or write credential — the ones that matter. */
+const CREDENTIAL_BEARING = [
+	"ci.yml",
+	"api-spec-update.yml",
+	"console-catalog-drift.yml",
+	"console-catalog-update.yml",
+	"tag-on-version-bump.yml",
+];
+
+/** Owners whose refs are trusted mutable: GitHub itself, and this org's own workflows. */
+const EXEMPT_OWNER = /^(?:actions|f5-sales-demo)\//;
+
+const SHA_PINNED = /@[0-9a-f]{40}(?:\s|$)/;
+
+async function usesLines(file: string): Promise<string[]> {
+	const src = await fs.readFile(path.join(WORKFLOW_DIR, file), "utf8");
+	return [...src.matchAll(/^\s*-?\s*uses:\s*(\S+)/gm)].map(m => m[1]);
+}
+
+describe("third-party actions in credential-bearing workflows are pinned (#2498)", () => {
+	for (const file of CREDENTIAL_BEARING) {
+		it(`${file}: every third-party action is a 40-hex commit`, async () => {
+			const unpinned = (await usesLines(file))
+				.filter(ref => !ref.startsWith("./") && !EXEMPT_OWNER.test(ref))
+				.filter(ref => !SHA_PINNED.test(`${ref} `));
+			// Named so the failure says which action to pin, not merely that one exists.
+			expect(unpinned).toEqual([]);
+		});
+	}
+
+	it("the credential-bearing list still matches which workflows reference secrets", async () => {
+		// Guards the premise rather than the conclusion: if a workflow starts using a release
+		// secret, it joins the list above. Without this, the list silently goes stale and the
+		// pinning rule stops covering the thing it was written for.
+		const files = (await fs.readdir(WORKFLOW_DIR)).filter(f => f.endsWith(".yml"));
+		const withSecrets: string[] = [];
+		for (const file of files) {
+			const src = await fs.readFile(path.join(WORKFLOW_DIR, file), "utf8");
+			if (/secrets\.(?:RELEASE_TOKEN|NPM_TOKEN|GH_PAT|HOMEBREW\w*)/.test(src)) withSecrets.push(file);
+		}
+		expect(withSecrets.sort()).toEqual([...CREDENTIAL_BEARING].sort());
+	});
+});


### PR DESCRIPTION
Fixes #2498

Decided by measuring exposure, not by preference.

## The measurement

Every third-party `uses:`, mapped against whether its workflow references a release secret:

| workflow | secret refs | unpinned third-party actions |
| --- | --- | --- |
| **ci.yml** | **14** | 5 |
| api-spec-update.yml | 2 | 1 |
| console-catalog-drift.yml | 3 | 1 |
| console-catalog-update.yml | 3 | 1 |
| tag-on-version-bump.yml | 4 | *already pinned (#2496)* |
| semgrep / release-reconcile / test-codesign / code-review | 0 | nothing to steal |

**The exposure is concentrated, not diffuse.** `ci.yml` alone accounts for 14 of the
references and owns the whole publish chain — npm, the Homebrew tap, GitHub releases, macOS
signing. A repointed action there reaches the release path directly.

So "pin everything" was never the right frame. The right frame is *pin what runs next to a
publishing credential*, and that is a short, specific list.

## What is pinned, and what is not

Pinned to current releases (nothing downgraded): `Swatinem/rust-cache` v2.9.1,
`mlugg/setup-zig` v2.2.1, `oven-sh/setup-bun` v2.2.0, `taiki-e/install-action` v2.85.2,
`dtolnay/rust-toolchain` (nightly branch head).

Left mutable **on purpose**:

- `actions/*` — first-party, GitHub-maintained major tags. Pinning costs a SHA bump per
  security fix and buys little.
- `f5-sales-demo/*` reusable workflows — same org, same trust boundary.
- Credential-free workflows — failing `semgrep.yml` or `test-codesign.yml` would train
  people to dismiss this rule, and there is nothing there to exfiltrate.

## One detail that would have been a silent bug

`dtolnay/rust-toolchain@nightly` normally encodes the **toolchain** in the ref, so pinning it
to a SHA can change the compiler. Both call sites here already pass
`toolchain: nightly-2026-03-27` explicitly, so the ref was not selecting anything — checked
before touching it. Had the ref been the selector, this pin would have swapped the compiler
without saying so. (The `# TODO: unpin` comment there refers to the toolchain date, not the
action ref.)

## Enforcement, without which this does not hold

Worth being blunt: before today the only pinned action in the repo was the one I pinned in
#2496, and **#2508 added a fresh unpinned one immediately afterwards.** A decision recorded
in an issue does not reach the next workflow.

So there is a test asserting every third-party `uses:` in a credential-bearing workflow is a
40-hex commit, and it names the offender rather than just going red:

```
Received: ["mlugg/setup-zig@v2"]
```

Verified by unpinning one, watching it fail, then restoring.

A second test guards the **premise** rather than the conclusion: it recomputes which
workflows reference release secrets and asserts the list still matches. Without that, the
list silently goes stale and the rule stops covering what it was written for.

## Verification

- `bun run ci:check:full` — exit 0
- new tests — 6 pass, and confirmed failing when a pin is removed
- **this PR's own CI run exercises the pinned `ci.yml`**, which is the real check: if a pin
  were wrong for the `with:` inputs, it fails here rather than at release time
