### PR TITLE
fix(test): assert the worker actually started, not just that two failures did not occur

### DIFF
--- a/packages/coding-agent/test/e2e/stealth-workers.e2e.test.ts
+++ b/packages/coding-agent/test/e2e/stealth-workers.e2e.test.ts
@@ -142,27 +142,47 @@ describe.skipIf(isCI)("Workers under the stealth bundle (real Chrome via Puppete
 		}
 	}
 
-	it("starts a worker created from a relative URL", async () => {
-		const result = await runWorker({});
-		// The removed surface failed here with
-		// "Failed to execute 'importScripts' ... The URL '/w.js' is invalid."
+	/**
+	 * Asserts the worker actually STARTED and replied.
+	 *
+	 * Every test goes through this rather than picking its own subset of negative
+	 * checks. The CSP test used to assert only `workerError === undefined` and
+	 * `worker !== "TIMEOUT"`, which both hold when `new Worker()` throws
+	 * synchronously — the harness then sets `constructorThrew` and leaves the other
+	 * two fields undefined. So the test passed with no worker at all, which is the
+	 * exact outcome it exists to catch (#2565).
+	 *
+	 * The negative assertions are kept alongside the positive one because they name
+	 * the specific historical failure modes, which makes a regression's cause
+	 * readable straight from the failure output.
+	 */
+	function expectWorkerStarted(result: WorkerOutcome): { ua: string; brands: string[] | null } {
 		expect(result.constructorThrew).toBeUndefined();
 		expect(result.workerError).toBeUndefined();
 		expect(result.worker).not.toBe("TIMEOUT");
+		expect(result.worker).toBeDefined();
+		const worker = result.worker as { ua: string; brands: string[] | null };
+		// A reply that carries no user agent is not a started worker either.
+		expect(typeof worker.ua).toBe("string");
+		expect(worker.ua).toInclude("Chrome/");
+		return worker;
+	}
+
+	it("starts a worker created from a relative URL", async () => {
+		// The removed surface failed here with
+		// "Failed to execute 'importScripts' ... The URL '/w.js' is invalid."
+		expectWorkerStarted(await runWorker({}));
 	}, 60_000);
 
 	it("starts a worker under a CSP that allows only same-origin workers", async () => {
 		// `worker-src 'self'` is an ordinary policy and does NOT permit blob:. The
 		// refusal arrived asynchronously, so the constructor's fallback never caught it.
-		const result = await runWorker({ csp: "worker-src 'self'; default-src 'self' 'unsafe-inline'" });
-		expect(result.workerError).toBeUndefined();
-		expect(result.worker).not.toBe("TIMEOUT");
+		expectWorkerStarted(await runWorker({ csp: "worker-src 'self'; default-src 'self' 'unsafe-inline'" }));
 	}, 60_000);
 
 	it("gives the worker the same spoofed identity as the page, via CDP rather than injection", async () => {
 		const result = await runWorker({ withUaOverride: true });
-		expect(result.worker).not.toBe("TIMEOUT");
-		const worker = result.worker as { ua: string; brands: string[] | null };
+		const worker = expectWorkerStarted(result);
 
 		// No HeadlessChrome leak in the worker realm...
 		expect(worker.ua).not.toInclude("HeadlessChrome");


### PR DESCRIPTION
Fixes #2565

The worker CSP regression test added in #2563 could pass with no worker having started — the exact outcome it exists to detect.

## The defect

```ts
expect(result.workerError).toBeUndefined();
expect(result.worker).not.toBe("TIMEOUT");
```

When `new Worker()` throws **synchronously**, the harness records `constructorThrew` and leaves `worker` and `workerError` undefined. Both assertions then hold against `undefined`. The relative-URL test in the same file did check `constructorThrew`; the CSP test picked the weaker subset.

## Confirmed by amplification, before changing anything

Forcing a synchronous construction failure at the harness's `new Worker` call left the CSP test **green** while the other two correctly failed:

```
before   1 pass, 2 fail    <- the survivor was the CSP test
after    0 pass, 3 fail
```

## The fix

One `expectWorkerStarted` helper, used by all three tests, asserting a **positive** outcome: the worker replied and its payload carries a plausible user agent. The negative assertions are kept alongside it, because they name the specific historical failure modes and make a regression's cause readable straight from the failure output.

Sharing one helper is the point — it removes the possibility of a future test picking the weak subset by accident.

## Verified

| Scenario | Result |
|---|---|
| Unmodified | **3 pass, 0 fail** |
| Amplified synchronous constructor throw | **0 pass, 3 fail** |
| Amplified async error event (worker script fails at load) | **0 pass, 3 fail** |
| `bun run ci:check:full` | **exit 0** |

Both failure modes now fail every test, which is what #2565's acceptance criteria asked for.

## How this was found

By running `codex:verified-code-review` **retrospectively** against the already-merged #2563 — I had skipped it before pushing that branch, which is where CLAUDE.md asks for it. Running it late still caught a real defect, in the very test that was supposed to be the guard.

This branch was reviewed before pushing, as it should be. Verdict: `approve` — *"HEAD matches origin/main; the sole uncommitted test change closes the worker-start vacuity without introducing a defensible material risk."*