### PR TITLE
Catch up with MEDDPICC's retired template and renamed fields

### DIFF
--- a/packages/coding-agent/src/internal-urls/plugin-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/plugin-resolve.ts
@@ -55,12 +55,12 @@ function contentTypeFor(filePath: string): InternalResource["contentType"] {
 /**
  * Extensions a plugin may legitimately declare that are NOT text.
  *
- * Reading one as UTF-8 corrupts it, and nobody wants 91 KB of mangled bytes in a prompt
- * either — the MEDDPICC plugin's `meddpicc-template.xlsx` is exactly that size. What a
- * caller needs is where the file is, so it can be copied, opened, or handed to a tool
- * that understands the format; so a binary resource resolves to its location, not its
- * contents. Deliberately a small allow-list of formats plugins actually ship rather than
- * content sniffing, so the decision is inspectable.
+ * Reading one as UTF-8 corrupts it, and nobody wants tens of kilobytes of mangled bytes in a
+ * prompt either — a spreadsheet or a slide deck runs to that easily. What a caller needs is
+ * where the file is, so it can be copied, opened, or handed to a tool that understands the
+ * format; so a binary resource resolves to its location, not its contents. Deliberately a
+ * small allow-list of formats plugins actually ship rather than content sniffing, so the
+ * decision is inspectable.
  */
 const BINARY_EXTENSIONS = new Set([
 	".xlsx",

--- a/plugin-discovery-matrix/fixtures/deal-self-describing.json
+++ b/plugin-discovery-matrix/fixtures/deal-self-describing.json
@@ -9,7 +9,7 @@
     "winProbability": 0.5,
     "forecastStage": "Best Case",
     "revenue": {
-      "pAndIplusAcvx": 150000,
+      "subscription": 150000,
       "hardware": 0,
       "software": 85000,
       "acv": 85000
@@ -50,7 +50,10 @@
   "qualification": {
     "metrics": {
       "definition": "Quantified business outcomes the client expects — cost reduction, risk reduction, revenue impact, productivity gains, time-to-value",
-      "questions": ["What goals is the client trying to accomplish?", "What KPIs are they using to measure the goals?"],
+      "questions": [
+        "What goals is the client trying to accomplish?",
+        "What KPIs are they using to measure the goals?"
+      ],
       "responses": [
         "Reduce MTTR from 4 hours to 30 minutes and achieve 99.99% uptime for customer-facing APIs across 3 data centers",
         "Tracking MTTR, uptime SLA compliance rate, incident count per month, and API error rate (target <0.1%)"
@@ -68,7 +71,10 @@
     },
     "economicBuyer": {
       "definition": "The individual with final budget authority and political power to fund the purchase",
-      "questions": ["Who makes the buying decision?", "How are we engaged with them to address their priorities?"],
+      "questions": [
+        "Who makes the buying decision?",
+        "How are we engaged with them to address their priorities?"
+      ],
       "responses": [
         "Sarah Chen, SVP Infrastructure — confirmed budget authority for all platform security investments up to $500K",
         "Direct meeting held 2026-04-20. She is focused on reducing security incidents before Q3 board review. Follow-up scheduled May 15."
@@ -132,7 +138,10 @@
         "What are the legal steps required to conclude on the transaction?",
         "What administrative steps need to be completed to allow an order to flow?"
       ],
-      "responses": ["", ""],
+      "responses": [
+        "",
+        ""
+      ],
       "score": 0,
       "scoreDefinition": {
         "0": "Unknown — No procurement discovery done",
@@ -167,7 +176,10 @@
     },
     "champion": {
       "definition": "A powerful internal advocate who sells for you when you're not in the room",
-      "questions": ["Who will benefit most from this transaction?", "Can they influence the buying process?"],
+      "questions": [
+        "Who will benefit most from this transaction?",
+        "Can they influence the buying process?"
+      ],
       "responses": [
         "Mike Torres, Director of Platform Engineering — he owns the API gateway team and will be directly measured on MTTR improvement",
         "Yes — he reports to the CTO, introduced us to the EB, and is running the POC internally. Shared competitor pricing last week."
@@ -206,9 +218,9 @@
     }
   },
   "threeWhys": {
-    "f5": {
+    "us": {
       "whyAnything": "3 API security incidents in Q1 cost $400K in SLA penalties; board mandated a fix by Q3; regulatory audit in September requires documented controls",
-      "whyF5": "Only vendor with unified app + API security that integrates natively with their Kubernetes platform; deepest API discovery and threat detection",
+      "whyUs": "Only vendor with unified app + API security that integrates natively with their Kubernetes platform; deepest API discovery and threat detection",
       "whyNow": "Board mandate deadline is Q3 2026; regulatory audit in September; every month of delay is another month of exposure to SLA penalties"
     },
     "partner": {
@@ -226,8 +238,8 @@
       "mustSayYes": true,
       "canSayNo": true,
       "whatTheyNeedToBelieve": "F5 will reduce security incidents by 60% within 6 months and the TCO stays under $100K/yr",
-      "viewOfF5": "Positive",
-      "f5Owner": "Jane Smith"
+      "sentiment": "Positive",
+      "relationshipOwner": "Jane Smith"
     },
     {
       "name": "David Park",
@@ -236,8 +248,8 @@
       "mustSayYes": true,
       "canSayNo": true,
       "whatTheyNeedToBelieve": "F5 integrates with existing Kubernetes platform without migration risk and passes architecture review",
-      "viewOfF5": "Positive",
-      "f5Owner": "Bob Johnson"
+      "sentiment": "Positive",
+      "relationshipOwner": "Bob Johnson"
     },
     {
       "name": "Mike Torres",
@@ -246,8 +258,8 @@
       "mustSayYes": false,
       "canSayNo": false,
       "whatTheyNeedToBelieve": "F5 makes his team more productive and helps him hit the MTTR target that gets him headcount",
-      "viewOfF5": "Positive",
-      "f5Owner": "Jane Smith"
+      "sentiment": "Positive",
+      "relationshipOwner": "Jane Smith"
     },
     {
       "name": "Lisa Wang",
@@ -256,8 +268,8 @@
       "mustSayYes": false,
       "canSayNo": true,
       "whatTheyNeedToBelieve": "F5 meets SOC2 and regulatory requirements without creating new compliance gaps",
-      "viewOfF5": "Neutral",
-      "f5Owner": "Bob Johnson"
+      "sentiment": "Neutral",
+      "relationshipOwner": "Bob Johnson"
     }
   ],
   "salesStrategy": {
@@ -314,14 +326,39 @@
     ]
   },
   "team": {
-    "f5": [
-      { "name": "Jane Smith", "role": "Account Executive", "dateRequiredFrom": "2026-03-01", "assignedToDeal": true },
-      { "name": "Bob Johnson", "role": "Solutions Engineer", "dateRequiredFrom": "2026-04-01", "assignedToDeal": true },
-      { "name": "Amy Chen", "role": "CSM", "dateRequiredFrom": "2026-06-15", "assignedToDeal": false }
+    "internal": [
+      {
+        "name": "Jane Smith",
+        "role": "Account Executive",
+        "dateRequiredFrom": "2026-03-01",
+        "assignedToDeal": true
+      },
+      {
+        "name": "Bob Johnson",
+        "role": "Solutions Engineer",
+        "dateRequiredFrom": "2026-04-01",
+        "assignedToDeal": true
+      },
+      {
+        "name": "Amy Chen",
+        "role": "CSM",
+        "dateRequiredFrom": "2026-06-15",
+        "assignedToDeal": false
+      }
     ],
     "partner": [
-      { "name": "Tom Rivera", "role": "Lead Engineer", "dateRequiredFrom": "2026-06-01", "assignedToDeal": true },
-      { "name": "Priya Patel", "role": "Project Manager", "dateRequiredFrom": "2026-06-01", "assignedToDeal": false }
+      {
+        "name": "Tom Rivera",
+        "role": "Lead Engineer",
+        "dateRequiredFrom": "2026-06-01",
+        "assignedToDeal": true
+      },
+      {
+        "name": "Priya Patel",
+        "role": "Project Manager",
+        "dateRequiredFrom": "2026-06-01",
+        "assignedToDeal": false
+      }
     ]
   },
   "scoring": {

--- a/plugin-discovery-matrix/fixtures/deal-thin.json
+++ b/plugin-discovery-matrix/fixtures/deal-thin.json
@@ -9,7 +9,7 @@
     "winProbability": 0.5,
     "forecastStage": "Best Case",
     "revenue": {
-      "pAndIplusAcvx": 150000,
+      "subscription": 150000,
       "hardware": 0,
       "software": 85000,
       "acv": 85000
@@ -122,9 +122,9 @@
     }
   },
   "threeWhys": {
-    "f5": {
+    "us": {
       "whyAnything": "3 API security incidents in Q1 cost $400K in SLA penalties; board mandated a fix by Q3; regulatory audit in September requires documented controls",
-      "whyF5": "Only vendor with unified app + API security that integrates natively with their Kubernetes platform; deepest API discovery and threat detection",
+      "whyUs": "Only vendor with unified app + API security that integrates natively with their Kubernetes platform; deepest API discovery and threat detection",
       "whyNow": "Board mandate deadline is Q3 2026; regulatory audit in September; every month of delay is another month of exposure to SLA penalties"
     },
     "partner": {
@@ -142,8 +142,8 @@
       "mustSayYes": true,
       "canSayNo": true,
       "whatTheyNeedToBelieve": "F5 will reduce security incidents by 60% within 6 months and the TCO stays under $100K/yr",
-      "viewOfF5": "Positive",
-      "f5Owner": "Jane Smith"
+      "sentiment": "Positive",
+      "relationshipOwner": "Jane Smith"
     },
     {
       "name": "David Park",
@@ -152,8 +152,8 @@
       "mustSayYes": true,
       "canSayNo": true,
       "whatTheyNeedToBelieve": "F5 integrates with existing Kubernetes platform without migration risk and passes architecture review",
-      "viewOfF5": "Positive",
-      "f5Owner": "Bob Johnson"
+      "sentiment": "Positive",
+      "relationshipOwner": "Bob Johnson"
     },
     {
       "name": "Mike Torres",
@@ -162,8 +162,8 @@
       "mustSayYes": false,
       "canSayNo": false,
       "whatTheyNeedToBelieve": "F5 makes his team more productive and helps him hit the MTTR target that gets him headcount",
-      "viewOfF5": "Positive",
-      "f5Owner": "Jane Smith"
+      "sentiment": "Positive",
+      "relationshipOwner": "Jane Smith"
     },
     {
       "name": "Lisa Wang",
@@ -172,8 +172,8 @@
       "mustSayYes": false,
       "canSayNo": true,
       "whatTheyNeedToBelieve": "F5 meets SOC2 and regulatory requirements without creating new compliance gaps",
-      "viewOfF5": "Neutral",
-      "f5Owner": "Bob Johnson"
+      "sentiment": "Neutral",
+      "relationshipOwner": "Bob Johnson"
     }
   ],
   "salesStrategy": {
@@ -230,7 +230,7 @@
     ]
   },
   "team": {
-    "f5": [
+    "internal": [
       {
         "name": "Jane Smith",
         "role": "Account Executive",


### PR DESCRIPTION
Closes #2568. Three loose ends left by MEDDPICC retiring its template
(f5-sales-demo/marketplace#894) and renaming its schema fields
(f5-sales-demo/marketplace#896).

**The stale comment.** `plugin-resolve.ts` explained the binary-extension allow-list by citing
`meddpicc-template.xlsx` and its exact size. That file no longer exists, so the comment asserted
something untrue about it — worse than no comment, because the next reader trusts it. The reasoning
and the allow-list are unchanged; only the example is now generic.

**The fixtures.** Both `plugin-discovery-matrix` deal fixtures used the retired field names. They are
migrated with the engine's own `migrate --apply` rather than hand-edited — 12 renames each, no
conflicts — and both validate against the current schema afterwards.

Nothing here was broken: the matrix is referenced by no workflow and no package script, so it is a
manual harness. But the engine now *refuses* a deal using the old names rather than silently ignoring
their values, so anyone running it by hand would have hit a non-zero exit.

**`write_cells` stays.** It shipped in #2501 specifically to fill the F5 Deal Review Sheet, and that
workflow is gone — but the tool carries no MEDDPICC coupling. It batches individual cell writes with
whole-batch validation, merged-cell awareness and formula-injection neutralising, and its own
description already speaks of "a formatted template" generically. Retiring it would remove a
capability anyone filling a formatted workbook by hand can still use, for no gain beyond tidiness. Its
*rationale* was tied to a workflow that no longer exists; the tool is not.

## Verification

- Both fixtures parse, validate against the current schema (`validate` exits 0), and carry the new
  names — `sentiment`, `relationshipOwner`, `whyUs`, `subscription`, `team.internal`.
- No file in this repository references `viewOfF5`, `f5Owner`, `whyF5` or `pAndIplusAcvx` any more.
- The changed TypeScript is comment-only and passes `biome format`.
