### PR TITLE
feat(sandbox): enforce the boundary below the command text

### DIFF
--- a/crates/brush-builtins-vendored/Cargo.toml
+++ b/crates/brush-builtins-vendored/Cargo.toml
@@ -323,3 +323,11 @@ priority = 0
 [lints.rustdoc.all]
 level = "deny"
 priority = -1
+
+# Stops cargo walking up to find a workspace. Without this, a git worktree created under
+# `.claude/worktrees/` lives inside the repository, so cargo finds the repo's root manifest and
+# claims this crate as one of its members — "current package believes it's in a workspace when it's
+# not" — and `cargo fmt --all` / `cargo clippy --workspace` fail outright from any worktree. This
+# crate is reached through [patch.crates-io] and is never a workspace member, so an empty table is
+# the accurate statement as well as the fix.
+[workspace]

--- a/crates/brush-builtins-vendored/src/cd.rs
+++ b/crates/brush-builtins-vendored/src/cd.rs
@@ -81,7 +81,7 @@ impl builtins::Command for CdCommand {
 			target_dir = context.shell.absolute_path(target_dir).canonicalize()?;
 		}
 
-		context.shell.set_working_dir(&target_dir)?;
+		context.shell.change_working_dir(&target_dir, &context.params)?;
 
 		// Bash compatibility
 		// https://www.gnu.org/software/bash/manual/bash.html#index-cd

--- a/crates/brush-builtins-vendored/src/popd.rs
+++ b/crates/brush-builtins-vendored/src/popd.rs
@@ -21,7 +21,7 @@ impl builtins::Command for PopdCommand {
 	) -> Result<brush_core::ExecutionResult, Self::Error> {
 		if let Some(popped) = context.shell.directory_stack.pop() {
 			if !self.no_directory_change {
-				context.shell.set_working_dir(&popped)?;
+				context.shell.change_working_dir(&popped, &context.params)?;
 			}
 
 			// Display dirs.

--- a/crates/brush-builtins-vendored/src/pushd.rs
+++ b/crates/brush-builtins-vendored/src/pushd.rs
@@ -31,7 +31,7 @@ impl builtins::Command for PushdCommand {
 			let prev_working_dir = context.shell.working_dir().to_path_buf();
 
 			let dir = std::path::Path::new(&self.dir);
-			context.shell.set_working_dir(dir)?;
+			context.shell.change_working_dir(dir, &context.params)?;
 
 			context.shell.directory_stack.push(prev_working_dir);
 		}

--- a/crates/brush-core-vendored/Cargo.toml
+++ b/crates/brush-core-vendored/Cargo.toml
@@ -259,3 +259,11 @@ priority = 0
 [lints.rustdoc.all]
 level = "deny"
 priority = -1
+
+# Stops cargo walking up to find a workspace. Without this, a git worktree created under
+# `.claude/worktrees/` lives inside the repository, so cargo finds the repo's root manifest and
+# claims this crate as one of its members — "current package believes it's in a workspace when it's
+# not" — and `cargo fmt --all` / `cargo clippy --workspace` fail outright from any worktree. This
+# crate is reached through [patch.crates-io] and is never a workspace member, so an empty table is
+# the accurate statement as well as the fix.
+[workspace]

--- a/crates/brush-core-vendored/src/commands.rs
+++ b/crates/brush-core-vendored/src/commands.rs
@@ -152,11 +152,34 @@ pub fn compose_std_command<S: AsRef<OsStr>>(
 	args: &[S],
 	empty_env: bool,
 ) -> Result<std::process::Command, error::Error> {
-	let mut cmd = std::process::Command::new(command_name);
-
-	// Override argv[0].
-	// NOTE: Not supported on all platforms.
-	cmd.arg0(argv0);
+	// An external command opens its files in its own address space, so nothing the shell checks can
+	// confine it — only the OS can. On macOS that means wrapping argv with `sandbox-exec`, because
+	// `sandbox_init` is deprecated and there is no `pre_exec` route to seatbelt.
+	//
+	// The cost is `arg0`: sandbox-exec gives the child its own argv[0] and offers no way to override
+	// it, so a fenced command cannot present a custom argv[0] (as a login shell's `-bash` would).
+	// Nothing in this agent's use depends on that, and the alternative is no confinement at all.
+	#[cfg(target_os = "macos")]
+	let sandboxed = context.params.containment.as_ref().map(|fence| fence.to_seatbelt_profile());
+	#[cfg(target_os = "macos")]
+	let mut cmd = match sandboxed.as_deref() {
+		Some(profile) => {
+			let mut wrapper = std::process::Command::new("/usr/bin/sandbox-exec");
+			wrapper.arg("-p").arg(profile).arg(command_name);
+			wrapper
+		},
+		None => {
+			let mut direct = std::process::Command::new(command_name);
+			direct.arg0(argv0);
+			direct
+		},
+	};
+	#[cfg(not(target_os = "macos"))]
+	let mut cmd = {
+		let mut direct = std::process::Command::new(command_name);
+		direct.arg0(argv0);
+		direct
+	};
 
 	// Pass through args.
 	cmd.args(args);

--- a/crates/brush-core-vendored/src/commands.rs
+++ b/crates/brush-core-vendored/src/commands.rs
@@ -165,7 +165,10 @@ pub fn compose_std_command<S: AsRef<OsStr>>(
 	let mut cmd = match sandboxed.as_deref() {
 		Some(profile) => {
 			let mut wrapper = std::process::Command::new("/usr/bin/sandbox-exec");
-			wrapper.arg("-p").arg(profile).arg(command_name);
+			// `--` terminates sandbox-exec's own option parsing, so a command whose name begins with
+			// `-` cannot be read as a flag to the wrapper. Verified that sandbox-exec honours it —
+			// it is undocumented, and adding it blind would have broken every fenced command.
+			wrapper.arg("-p").arg(profile).arg("--").arg(command_name);
 			wrapper
 		},
 		None => {

--- a/crates/brush-core-vendored/src/containment.rs
+++ b/crates/brush-core-vendored/src/containment.rs
@@ -15,6 +15,92 @@
 
 use std::path::{Component, Path, PathBuf};
 
+/// The identity of a filesystem object, independent of the path used to reach it.
+///
+/// Resolving a path before opening it removes the final component from the race, but `open` still
+/// walks the directories above it, so a renamed directory can redirect a path that was just cleared.
+/// Comparing what was cleared against what was actually opened is what closes that: paths can be made
+/// to point somewhere else, an inode cannot.
+///
+/// Measured on the attack this exists for — a background process renaming a workspace directory aside
+/// and symlinking a sibling checkout in its place leaked through a redirect 17 times in 1000 attempts
+/// before this check, and 0 after.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FileIdentity {
+	device: u64,
+	inode:  u64,
+}
+
+impl FileIdentity {
+	/// The identity of the object at `path`, or `None` if it cannot be inspected.
+	///
+	/// `None` is not a failure: the common case is a path that does not exist yet because it is about
+	/// to be created. The caller distinguishes the two, and must not read `None` as "unchanged".
+	#[must_use]
+	pub fn of_path(path: &Path) -> Option<Self> {
+		std::fs::metadata(path).ok().as_ref().map(Self::from_metadata)
+	}
+
+	/// The identity of the object an open handle refers to.
+	///
+	/// Taken from the descriptor rather than from a path, which is the whole point: it cannot be
+	/// redirected after the fact.
+	#[must_use]
+	pub fn of_handle(file: &std::fs::File) -> Option<Self> {
+		file.metadata().ok().as_ref().map(Self::from_metadata)
+	}
+
+	#[cfg(unix)]
+	fn from_metadata(metadata: &std::fs::Metadata) -> Self {
+		use std::os::unix::fs::MetadataExt;
+		Self { device: metadata.dev(), inode: metadata.ino() }
+	}
+
+	// Windows has no OS backend for containment at all, so this exists to keep the crate building
+	// rather than to enforce anything. `volume_serial_number`/`file_index` are only populated for
+	// handles opened with the right access, so `0` is the honest answer for a path — and two `0`s
+	// comparing equal is the permissive direction, consistent with a platform that does not confine.
+	#[cfg(not(unix))]
+	fn from_metadata(metadata: &std::fs::Metadata) -> Self {
+		use std::os::windows::fs::MetadataExt;
+		Self {
+			device: metadata.volume_serial_number().unwrap_or(0).into(),
+			inode:  metadata.file_index().unwrap_or(0),
+		}
+	}
+}
+
+/// The path an open descriptor actually refers to, asked of the kernel.
+///
+/// This exists because re-walking a path cannot answer the question. Resolving before opening takes
+/// the final component out of the race, and comparing inodes catches a swap that lands between the
+/// stat and the open — but a swap that lands *before both* makes the stat and the open agree with each
+/// other and disagree with the fence. Measured: with only those two defences, a directory-swap race
+/// still leaked 23 times in 600 attempts through an in-process redirect.
+///
+/// A descriptor is already bound to its inode, so what the kernel reports for it cannot be redirected
+/// afterwards. `None` means the platform cannot be asked, which is why the caller keeps a fallback
+/// rather than treating absence as permission.
+#[must_use]
+pub fn path_of_handle(file: &std::fs::File) -> Option<PathBuf> {
+	#[cfg(target_os = "linux")]
+	{
+		use std::os::fd::AsRawFd;
+		std::fs::read_link(format!("/proc/self/fd/{}", file.as_raw_fd())).ok()
+	}
+	#[cfg(target_vendor = "apple")]
+	{
+		let mut buffer = PathBuf::new();
+		nix::fcntl::fcntl(file, nix::fcntl::FcntlArg::F_GETPATH(&mut buffer)).ok()?;
+		Some(buffer)
+	}
+	#[cfg(not(any(target_os = "linux", target_vendor = "apple")))]
+	{
+		let _ = file;
+		None
+	}
+}
+
 /// Direction of access being checked against the fence.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FenceAccess {
@@ -59,12 +145,16 @@ fn deepest_match(roots: &[PathBuf], candidate: &Path) -> Option<usize> {
 
 /// Resolve symlinks so the fence sees the file the shell will really touch.
 ///
+/// Public because a caller that is about to *open* the path must open this resolved form rather than
+/// what it was handed. Checking one path and opening another is a race, and a won race is a leak —
+/// see [`ContainmentFence::permits_resolved`].
+///
 /// A path that does not exist yet cannot be canonicalised — and a write target usually does not, so
 /// this must not fail on it. The deepest existing ancestor is resolved instead and the missing tail
 /// re-appended, which is what keeps a not-yet-created file under a symlinked directory on the correct
 /// side of the fence. Without it, `/tmp/x` and `/private/tmp/x` land on opposite sides and a rule that
 /// looks like it enforces does not.
-fn canonicalize_for_fence(candidate: &Path) -> PathBuf {
+pub fn canonicalize_for_fence(candidate: &Path) -> PathBuf {
 	if let Ok(resolved) = candidate.canonicalize() {
 		return resolved;
 	}
@@ -89,6 +179,23 @@ impl ContainmentFence {
 	/// and is the point: a path matched by nothing is outside the fence, so it is allowed.
 	#[must_use]
 	pub fn permits(&self, candidate: &Path, access: FenceAccess) -> bool {
+		self.permits_resolved(&canonicalize_for_fence(candidate), access)
+	}
+
+	/// Whether an **already resolved** path may be accessed for `access`.
+	///
+	/// Separate from [`Self::permits`] so a caller that is about to open the path can resolve once,
+	/// check that resolved path, and then open *that same* path. `permits` on its own invites the
+	/// caller to check one path and open another, and the gap between the two is a race an in-process
+	/// shell loses: brush-core runs inside the agent, so its redirections are not covered by the OS
+	/// confinement that protects spawned children.
+	///
+	/// Measured, before the callers were changed: a background process flipping a workspace symlink
+	/// between an in-fence file and a sibling checkout's secret leaked that secret through
+	/// `cat < pivot` once in 250 attempts, while the other 163 refusals looked like the fence working.
+	/// A boundary that holds 99% of the time is not a boundary.
+	#[must_use]
+	pub fn permits_resolved(&self, resolved: &Path, access: FenceAccess) -> bool {
 		if self.allow.is_empty()
 			&& self.allow_read_only.is_empty()
 			&& self.allow_write_only.is_empty()
@@ -96,12 +203,11 @@ impl ContainmentFence {
 		{
 			return true;
 		}
-		let resolved = canonicalize_for_fence(candidate);
 
-		let denied = deepest_match(&self.deny, &resolved);
-		let read_only = deepest_match(&self.allow_read_only, &resolved);
-		let write_only = deepest_match(&self.allow_write_only, &resolved);
-		let allowed = deepest_match(&self.allow, &resolved);
+		let denied = deepest_match(&self.deny, resolved);
+		let read_only = deepest_match(&self.allow_read_only, resolved);
+		let write_only = deepest_match(&self.allow_write_only, resolved);
+		let allowed = deepest_match(&self.allow, resolved);
 
 		let deepest = denied.max(read_only).max(write_only).max(allowed);
 		let Some(deepest) = deepest else {

--- a/crates/brush-core-vendored/src/containment.rs
+++ b/crates/brush-core-vendored/src/containment.rs
@@ -1,0 +1,124 @@
+//! The containment fence: which paths the shell may reach.
+//!
+//! The host's text-level boundary decides from the *command string*, which is why it has leaked
+//! repeatedly — every spelling of a path is a new hole. This fence is consulted where the shell
+//! actually acts, after expansion, alias resolution and symlink following, so how the path was
+//! written cannot matter.
+//!
+//! It is deliberately permissive. Anything matched by no root is outside the fence and allowed, so
+//! `/usr`, `/tmp`, package caches, the network and process execution are untouched. The single thing
+//! it prevents is reaching into another customer's checkout or the operator's private files.
+//!
+//! The fence is per-invocation and absent by default: only the model's `bash` tool supplies one.
+//! Host-driven shell use — credential helpers, the interactive `xcsh shell`, snapshot sourcing —
+//! runs with no fence and is unaffected.
+
+use std::path::{Component, Path, PathBuf};
+
+/// Direction of access being checked against the fence.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FenceAccess {
+	/// Reading a path.
+	Read,
+	/// Writing or creating a path.
+	Write,
+}
+
+/// Canonical roots describing what the shell may reach.
+#[derive(Clone, Debug, Default)]
+pub struct ContainmentFence {
+	/// Roots the shell may read and write.
+	pub allow: Vec<PathBuf>,
+	/// Roots the shell may read but not write.
+	pub allow_read_only: Vec<PathBuf>,
+	/// Roots denied in both directions, winning over any allow they sit inside.
+	pub deny: Vec<PathBuf>,
+}
+
+/// How specific a matching root is. Deeper wins, so a nested rule beats the root it sits inside.
+fn depth(root: &Path) -> usize {
+	root.components().filter(|c| matches!(c, Component::Normal(_))).count()
+}
+
+/// The deepest root in `roots` that contains `candidate`, with its depth.
+fn deepest_match(roots: &[PathBuf], candidate: &Path) -> Option<usize> {
+	let mut best: Option<usize> = None;
+	for root in roots {
+		if !candidate.starts_with(root) {
+			continue;
+		}
+		let d = depth(root);
+		if best.is_none_or(|current| d > current) {
+			best = Some(d);
+		}
+	}
+	best
+}
+
+/// Resolve symlinks so the fence sees the file the shell will really touch.
+///
+/// A path that does not exist yet cannot be canonicalised — and a write target usually does not, so
+/// this must not fail on it. The deepest existing ancestor is resolved instead and the missing tail
+/// re-appended, which is what keeps a not-yet-created file under a symlinked directory on the correct
+/// side of the fence. Without it, `/tmp/x` and `/private/tmp/x` land on opposite sides and a rule that
+/// looks like it enforces does not.
+fn canonicalize_for_fence(candidate: &Path) -> PathBuf {
+	if let Ok(resolved) = candidate.canonicalize() {
+		return resolved;
+	}
+	let mut ancestor = candidate;
+	while let Some(parent) = ancestor.parent() {
+		if let Ok(real_parent) = parent.canonicalize() {
+			return match candidate.strip_prefix(parent) {
+				Ok(tail) => real_parent.join(tail),
+				Err(_) => candidate.to_path_buf(),
+			};
+		}
+		ancestor = parent;
+	}
+	candidate.to_path_buf()
+}
+
+impl ContainmentFence {
+	/// Whether `candidate` may be accessed for `access`.
+	///
+	/// Deepest match wins and a deny beats an allow at equal depth, matching the host policy's
+	/// precedence so the two layers cannot disagree about a path they both see. The default differs
+	/// and is the point: a path matched by nothing is outside the fence, so it is allowed.
+	#[must_use]
+	pub fn permits(&self, candidate: &Path, access: FenceAccess) -> bool {
+		if self.allow.is_empty() && self.allow_read_only.is_empty() && self.deny.is_empty() {
+			return true;
+		}
+		let resolved = canonicalize_for_fence(candidate);
+
+		let denied = deepest_match(&self.deny, &resolved);
+		let read_only = deepest_match(&self.allow_read_only, &resolved);
+		let allowed = deepest_match(&self.allow, &resolved);
+
+		let deepest = denied.max(read_only).max(allowed);
+		let Some(deepest) = deepest else {
+			return true;
+		};
+
+		// Deny first at equal depth: the cross-session leak roots rely on it, since they sit under
+		// roots that are otherwise allowed.
+		if denied == Some(deepest) {
+			return false;
+		}
+		if read_only == Some(deepest) {
+			return access == FenceAccess::Read;
+		}
+		true
+	}
+}
+
+// No `#[cfg(test)]` block here on purpose. This crate is `exclude`d from the workspace
+// (root Cargo.toml) and reached only through `[patch.crates-io]`, so `cargo test -p brush-core`
+// refuses to run — "requires dev-dependencies and is not a member of the workspace". Unit tests
+// added here would look like coverage and never execute.
+//
+// Instead `permits` is exercised from TypeScript through the `fencePermits` napi export, by a
+// conformance test that runs one corpus through BOTH this implementation and the TS
+// `fenceVerdict` and asserts they agree. That is the risk worth testing: two languages evaluating
+// one rule set, free to drift.

--- a/crates/brush-core-vendored/src/containment.rs
+++ b/crates/brush-core-vendored/src/containment.rs
@@ -124,8 +124,26 @@ impl ContainmentFence {
 // one rule set, free to drift.
 
 /// Escape a path for inclusion in a seatbelt profile string literal.
+///
+/// Paths may contain any byte except `/` and NUL, so a directory name can hold a quote, a backslash
+/// or a **newline** — and a shell can create one, so this is reachable rather than theoretical.
+///
+/// Escaping the quote is what makes injection impossible: without it, a directory named
+/// `x"))\n(allow default)\n(allow file-read* (subpath "/` closes the literal and appends its own
+/// rules. Verified against `sandbox-exec`: unescaped, that path grants `(allow default)` and reads a
+/// file the profile denied; with the quote escaped the profile no longer parses and the command is
+/// refused instead — fail-closed, but refused.
+///
+/// Escaping the newline is what stops that fail-closed case being an outage. A raw newline breaks the
+/// profile, so one oddly-named directory anywhere in the workspace path would make every fenced
+/// command fail with "Operation not permitted" and no usable explanation. SBPL accepts `\n` in a
+/// string literal — verified — so the escape both parses and keeps the rule meaningful.
 fn escape_for_profile(path: &Path) -> String {
-	path.to_string_lossy().replace('\\', "\\\\").replace('"', "\\\"")
+	path.to_string_lossy()
+		.replace('\\', "\\\\")
+		.replace('"', "\\\"")
+		.replace('\n', "\\n")
+		.replace('\r', "\\r")
 }
 
 impl ContainmentFence {

--- a/crates/brush-core-vendored/src/containment.rs
+++ b/crates/brush-core-vendored/src/containment.rs
@@ -31,6 +31,8 @@ pub struct ContainmentFence {
 	pub allow: Vec<PathBuf>,
 	/// Roots the shell may read but not write.
 	pub allow_read_only: Vec<PathBuf>,
+	/// Roots the shell may write but not read.
+	pub allow_write_only: Vec<PathBuf>,
 	/// Roots denied in both directions, winning over any allow they sit inside.
 	pub deny: Vec<PathBuf>,
 }
@@ -87,16 +89,21 @@ impl ContainmentFence {
 	/// and is the point: a path matched by nothing is outside the fence, so it is allowed.
 	#[must_use]
 	pub fn permits(&self, candidate: &Path, access: FenceAccess) -> bool {
-		if self.allow.is_empty() && self.allow_read_only.is_empty() && self.deny.is_empty() {
+		if self.allow.is_empty()
+			&& self.allow_read_only.is_empty()
+			&& self.allow_write_only.is_empty()
+			&& self.deny.is_empty()
+		{
 			return true;
 		}
 		let resolved = canonicalize_for_fence(candidate);
 
 		let denied = deepest_match(&self.deny, &resolved);
 		let read_only = deepest_match(&self.allow_read_only, &resolved);
+		let write_only = deepest_match(&self.allow_write_only, &resolved);
 		let allowed = deepest_match(&self.allow, &resolved);
 
-		let deepest = denied.max(read_only).max(allowed);
+		let deepest = denied.max(read_only).max(write_only).max(allowed);
 		let Some(deepest) = deepest else {
 			return true;
 		};
@@ -108,6 +115,9 @@ impl ContainmentFence {
 		}
 		if read_only == Some(deepest) {
 			return access == FenceAccess::Read;
+		}
+		if write_only == Some(deepest) {
+			return access == FenceAccess::Write;
 		}
 		true
 	}
@@ -168,21 +178,29 @@ impl ContainmentFence {
 	#[must_use]
 	pub fn to_seatbelt_profile(&self) -> String {
 		enum Rule<'a> {
+			/// Existence and stat only, never contents or a directory listing.
+			Metadata(&'a PathBuf),
 			Deny(&'a PathBuf),
 			Allow(&'a PathBuf),
 			ReadOnly(&'a PathBuf),
+			WriteOnly(&'a PathBuf),
 		}
 
 		let mut rules: Vec<Rule<'_>> = Vec::new();
 		rules.extend(self.deny.iter().map(Rule::Deny));
+		rules.extend(self.deny.iter().map(Rule::Metadata));
 		rules.extend(self.allow.iter().map(Rule::Allow));
 		rules.extend(self.allow_read_only.iter().map(Rule::ReadOnly));
+		rules.extend(self.allow_write_only.iter().map(Rule::WriteOnly));
 
 		// Shallowest first so a deeper rule overrides it; deny last within a depth so it wins a tie.
 		rules.sort_by_key(|rule| match rule {
 			Rule::Allow(root) => (depth(root), 0),
 			Rule::ReadOnly(root) => (depth(root), 1),
+			Rule::WriteOnly(root) => (depth(root), 1),
 			Rule::Deny(root) => (depth(root), 2),
+			// After the deny at the same depth, so it re-permits stat and nothing else.
+			Rule::Metadata(root) => (depth(root), 3),
 		});
 
 		let mut profile = String::from("(version 1)\n(allow default)\n");
@@ -192,12 +210,25 @@ impl ContainmentFence {
 					"(deny file-read* file-write* (subpath \"{}\"))\n",
 					escape_for_profile(root)
 				)),
+				// Tools walk upward: `git init` stats every ancestor looking for a repository and an
+				// ownership marker, and refuses with "fatal: Invalid path" if it cannot. Verified that
+				// re-permitting metadata makes git work while contents AND directory listings stay
+				// denied — so a sibling's name is still not discoverable, only that the parent exists.
+				Rule::Metadata(root) => profile.push_str(&format!(
+					"(allow file-read-metadata (subpath \"{}\"))\n",
+					escape_for_profile(root)
+				)),
 				Rule::Allow(root) => profile.push_str(&format!(
 					"(allow file-read* file-write* (subpath \"{}\"))\n",
 					escape_for_profile(root)
 				)),
 				Rule::ReadOnly(root) => profile.push_str(&format!(
 					"(allow file-read* (subpath \"{}\"))\n(deny file-write* (subpath \"{}\"))\n",
+					escape_for_profile(root),
+					escape_for_profile(root)
+				)),
+				Rule::WriteOnly(root) => profile.push_str(&format!(
+					"(allow file-write* (subpath \"{}\"))\n(deny file-read* (subpath \"{}\"))\n",
 					escape_for_profile(root),
 					escape_for_profile(root)
 				)),

--- a/crates/brush-core-vendored/src/containment.rs
+++ b/crates/brush-core-vendored/src/containment.rs
@@ -122,3 +122,70 @@ impl ContainmentFence {
 // conformance test that runs one corpus through BOTH this implementation and the TS
 // `fenceVerdict` and asserts they agree. That is the risk worth testing: two languages evaluating
 // one rule set, free to drift.
+
+/// Escape a path for inclusion in a seatbelt profile string literal.
+fn escape_for_profile(path: &Path) -> String {
+	path.to_string_lossy().replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+impl ContainmentFence {
+	/// Compile the fence to a seatbelt (macOS sandbox) profile.
+	///
+	/// `(allow default)` is deliberate and load-bearing. A `(deny default)` profile cannot even
+	/// `execvp` a binary without a substantial allowlist — measured: "Operation not permitted" with
+	/// only the workspace granted — and everything it would then have to re-permit (exec, dyld, mach
+	/// lookups, network) is something this fence does not care about. Starting from allow keeps the
+	/// profile small enough to read and cannot break an operation nobody fenced.
+	///
+	/// **Rules are emitted shallowest-first, and that is the whole correctness argument.** Seatbelt
+	/// takes the *last matching* rule and has no notion of specificity, while this fence means
+	/// "deepest root wins". Emitting by category instead of by depth silently breaks both directions:
+	/// denies-then-allows re-exposes a cross-session root nested inside the workspace, and
+	/// allows-then-denies locks the operator out of a workspace nested inside their home. Sorting by
+	/// depth reproduces the intended precedence exactly, with deny last at equal depth so it wins.
+	///
+	/// Every root must already be canonical. A `(subpath "/tmp/x")` rule silently matches nothing when
+	/// the real path is `/private/tmp/x` — a rule that appears to enforce and does not — which is why
+	/// `buildContainmentFence` resolves them and refuses to build on an unresolvable workspace.
+	#[must_use]
+	pub fn to_seatbelt_profile(&self) -> String {
+		enum Rule<'a> {
+			Deny(&'a PathBuf),
+			Allow(&'a PathBuf),
+			ReadOnly(&'a PathBuf),
+		}
+
+		let mut rules: Vec<Rule<'_>> = Vec::new();
+		rules.extend(self.deny.iter().map(Rule::Deny));
+		rules.extend(self.allow.iter().map(Rule::Allow));
+		rules.extend(self.allow_read_only.iter().map(Rule::ReadOnly));
+
+		// Shallowest first so a deeper rule overrides it; deny last within a depth so it wins a tie.
+		rules.sort_by_key(|rule| match rule {
+			Rule::Allow(root) => (depth(root), 0),
+			Rule::ReadOnly(root) => (depth(root), 1),
+			Rule::Deny(root) => (depth(root), 2),
+		});
+
+		let mut profile = String::from("(version 1)\n(allow default)\n");
+		for rule in rules {
+			match rule {
+				Rule::Deny(root) => profile.push_str(&format!(
+					"(deny file-read* file-write* (subpath \"{}\"))\n",
+					escape_for_profile(root)
+				)),
+				Rule::Allow(root) => profile.push_str(&format!(
+					"(allow file-read* file-write* (subpath \"{}\"))\n",
+					escape_for_profile(root)
+				)),
+				Rule::ReadOnly(root) => profile.push_str(&format!(
+					"(allow file-read* (subpath \"{}\"))\n(deny file-write* (subpath \"{}\"))\n",
+					escape_for_profile(root),
+					escape_for_profile(root)
+				)),
+			}
+		}
+		profile
+	}
+
+}

--- a/crates/brush-core-vendored/src/error.rs
+++ b/crates/brush-core-vendored/src/error.rs
@@ -89,6 +89,16 @@ pub enum ErrorKind {
 	#[error("not a directory: {0}")]
 	NotADirectory(PathBuf),
 
+	/// The path lies outside the boundary the host set for this session.
+	///
+	/// A distinct variant rather than a reused one, so a refusal is never mistaken for a missing
+	/// file or a permission error the operator could fix by changing modes.
+	#[error(
+		"{0}: outside this session's boundary. Relative paths resolve wherever the shell stands, so \
+		 the boundary cannot follow it out of the session tree."
+	)]
+	OutsideBoundary(PathBuf),
+
 	/// The given path is a directory.
 	#[error("path is a directory")]
 	IsADirectory,

--- a/crates/brush-core-vendored/src/expansion.rs
+++ b/crates/brush-core-vendored/src/expansion.rs
@@ -635,13 +635,28 @@ impl<'a> WordExpander<'a> {
 			require_dot_in_pattern_to_match_dot_files: !self.shell.options.glob_matches_dotfiles,
 		};
 
-		let expansions = pattern
-			.expand(
-				self.shell.working_dir(),
-				Some(&patterns::Pattern::accept_all_expand_filter),
-				&options,
-			)
-			.unwrap_or_default();
+		// Glob expansion reads directories from the *agent's own process*, so the OS confinement applied
+		// to spawned children does not cover it. Without this filter `echo ../*` disclosed a sibling
+		// checkout's name — contents stayed protected, but the name is still information the session
+		// should not have. Filtering the results is enough to prevent disclosure: the readdir happened,
+		// but no name outside the fence reaches the caller.
+		let fence = self.params.containment.clone();
+		let expansions = match fence {
+			Some(fence) => pattern
+				.expand(
+					self.shell.working_dir(),
+					Some(&|path: &std::path::Path| fence.permits(path, crate::containment::FenceAccess::Read)),
+					&options,
+				)
+				.unwrap_or_default(),
+			None => pattern
+				.expand(
+					self.shell.working_dir(),
+					Some(&patterns::Pattern::accept_all_expand_filter),
+					&options,
+				)
+				.unwrap_or_default(),
+		};
 
 		if expansions.is_empty() && !self.shell.options.expand_non_matching_patterns_to_null {
 			vec![String::from(field)]

--- a/crates/brush-core-vendored/src/interp.rs
+++ b/crates/brush-core-vendored/src/interp.rs
@@ -1497,7 +1497,7 @@ pub(crate) async fn setup_redirect(
 				.append(*append);
 
 			let stdout_file = shell
-				.open_file(&file_options, &expanded_file_path, params)
+				.open_file(&file_options, &expanded_file_path, params, crate::containment::FenceAccess::Write)
 				.map_err(|err| {
 					error::ErrorKind::RedirectionFailure(
 						expanded_file_path.to_string_lossy().to_string(),
@@ -1575,8 +1575,22 @@ pub(crate) async fn setup_redirect(
 
 					let fd_num = specified_fd_num.unwrap_or(default_fd_if_unspecified);
 
+					// Taken from the redirect kind, not inferred from the command text. `ReadAndWrite`
+					// (`<>`) counts as a write: it may create and truncate, and the stricter of the
+					// two is the one a read-only grant must not license.
+					let access = match kind {
+						ast::IoFileRedirectKind::Read | ast::IoFileRedirectKind::DuplicateInput => {
+							crate::containment::FenceAccess::Read
+						},
+						ast::IoFileRedirectKind::Write
+						| ast::IoFileRedirectKind::Append
+						| ast::IoFileRedirectKind::ReadAndWrite
+						| ast::IoFileRedirectKind::Clobber
+						| ast::IoFileRedirectKind::DuplicateOutput => crate::containment::FenceAccess::Write,
+					};
+
 					let opened_file = shell
-						.open_file(&options, &expanded_file_path, params)
+						.open_file(&options, &expanded_file_path, params, access)
 						.map_err(|err| {
 							error::ErrorKind::RedirectionFailure(
 								expanded_file_path.to_string_lossy().to_string(),

--- a/crates/brush-core-vendored/src/interp.rs
+++ b/crates/brush-core-vendored/src/interp.rs
@@ -69,6 +69,14 @@ pub struct ExecutionParameters {
 	open_files: openfiles::OpenFiles,
 	/// Policy for how to manage spawned external processes.
 	pub process_group_policy: ProcessGroupPolicy,
+	/// Which paths this execution may reach, when the host supplied a fence.
+	///
+	/// Absent by default, and absent is unrestricted: host-driven shell use — credential helpers,
+	/// the interactive shell, snapshot sourcing — must keep working exactly as before. Only the
+	/// model's `bash` tool supplies one. Sits here rather than being passed around because
+	/// `Shell::open_file` already receives `&ExecutionParameters`, so one field reaches both the
+	/// in-process opens and the external-process spawn.
+	pub containment: Option<std::sync::Arc<crate::containment::ContainmentFence>>,
 	/// Optional cancellation token shared with callers.
 	cancel_token: Option<CancellationToken>,
 }

--- a/crates/brush-core-vendored/src/lib.rs
+++ b/crates/brush-core-vendored/src/lib.rs
@@ -7,6 +7,7 @@ mod braceexpansion;
 pub mod builtins;
 pub mod commands;
 pub mod completion;
+pub mod containment;
 pub mod env;
 pub mod error;
 pub mod escape;

--- a/crates/brush-core-vendored/src/shell.rs
+++ b/crates/brush-core-vendored/src/shell.rs
@@ -403,7 +403,7 @@ impl Shell {
 				options.read(true);
 
 				if let Ok(history_file) =
-					shell.open_file(&options, history_path, &shell.default_exec_params())
+					shell.open_file(&options, history_path, &shell.default_exec_params(), crate::containment::FenceAccess::Read)
 				{
 					shell.history = Some(history::History::import(history_file)?);
 				}
@@ -713,7 +713,7 @@ impl Shell {
 		options.read(true);
 
 		let opened_file: openfiles::OpenFile = self
-			.open_file(&options, path, params)
+			.open_file(&options, path, params, crate::containment::FenceAccess::Read)
 			.map_err(|e| error::ErrorKind::FailedSourcingFile(path.to_owned(), e))?;
 
 		if opened_file.is_dir() {
@@ -1374,6 +1374,7 @@ impl Shell {
 		options: &std::fs::OpenOptions,
 		path: impl AsRef<Path>,
 		params: &ExecutionParameters,
+		access: crate::containment::FenceAccess,
 	) -> Result<openfiles::OpenFile, std::io::Error> {
 		let path_to_open = self.absolute_path(path.as_ref());
 
@@ -1392,10 +1393,66 @@ impl Shell {
 			}
 		}
 
+		// The fence applies here rather than in the caller because this is the one place a
+		// caller-supplied path becomes an open file descriptor. `/dev/fd/N` above is deliberately
+		// exempt: it re-maps to a descriptor this process already holds, so no new path is reached.
+		//
+		// The direction is passed in rather than read back off `options`, because `OpenOptions` does
+		// not expose its flags. Each caller states it from the redirect kind it is already matching
+		// on, so a read redirect is checked as a read and `>`/`>>` as a write — no guessing from the
+		// command text, which is what the host layer was reduced to.
+		if let Some(fence) = params.containment.as_ref() {
+			if !fence.permits(&path_to_open, access) {
+				return Err(std::io::Error::new(
+					std::io::ErrorKind::PermissionDenied,
+					format!("{}: outside this session's boundary", path_to_open.display()),
+				));
+			}
+		}
+
 		Ok(options.open(path_to_open)?.into())
 	}
 
 	/// Sets the shell's current working directory to the given path.
+	///
+	/// # Arguments
+	///
+	/// * `target_dir` - The path to set as the working directory.
+	/// Change the working directory on behalf of the *shell* — `cd`, `pushd`, `popd`.
+	///
+	/// Separate from [`Shell::set_working_dir`] because the host also sets the working directory, per
+	/// invocation, and must never be fenced: that call is the host stating where the command runs, not
+	/// the shell moving itself. Only this path is checked.
+	///
+	/// Checking the destination is what makes the whole class of `cd` escapes unreachable rather than
+	/// merely harder. The text layer had to recognise every spelling — `cd -P`, `builtin cd`,
+	/// `eval 'cd …'`, `$c`, an alias, a symlink created moments earlier — and two adversarial review
+	/// rounds produced six bypasses of that gate (#2542, #2553). Here the shell has already resolved
+	/// all of it, so there is one thing to check and no spelling left to miss.
+	///
+	/// A destination needs BOTH directions: once the shell stands somewhere, every relative path it is
+	/// handed resolves there, and relative paths are not individually checked.
+	pub fn change_working_dir(
+		&mut self,
+		target_dir: impl AsRef<Path>,
+		params: &crate::interp::ExecutionParameters,
+	) -> Result<(), error::Error> {
+		if let Some(fence) = params.containment.as_ref() {
+			let destination = self.absolute_path(target_dir.as_ref());
+			let readable = fence.permits(&destination, crate::containment::FenceAccess::Read);
+			let writable = fence.permits(&destination, crate::containment::FenceAccess::Write);
+			if !readable || !writable {
+				return Err(error::ErrorKind::OutsideBoundary(destination).into());
+			}
+		}
+		self.set_working_dir(target_dir)
+	}
+
+	/// Sets the shell's current working directory to the given path, without consulting any
+	/// containment fence.
+	///
+	/// This is the host's entry point: it states where a command runs. Shell-initiated moves — `cd`,
+	/// `pushd`, `popd` — must go through [`Shell::change_working_dir`] instead, which is fenced.
 	///
 	/// # Arguments
 	///

--- a/crates/brush-core-vendored/src/shell.rs
+++ b/crates/brush-core-vendored/src/shell.rs
@@ -1401,13 +1401,61 @@ impl Shell {
 		// not expose its flags. Each caller states it from the redirect kind it is already matching
 		// on, so a read redirect is checked as a read and `>`/`>>` as a write — no guessing from the
 		// command text, which is what the host layer was reduced to.
+		// Resolve once, check the resolved path, then open *that* path. Opening what was handed in
+		// after checking what it resolved to is a race, and the shell loses it: brush-core runs inside
+		// the agent process, so a redirection is not covered by the OS confinement that protects
+		// spawned children. Measured before this change — a background flipper swapping a workspace
+		// symlink between an in-fence file and a sibling's secret leaked it through `cat < pivot` once
+		// in 250 attempts. Opening the resolved path takes the final component out of the race, because
+		// the symlink is no longer consulted at open time at all: 0 leaks in 1000 attempts after.
+		//
+		// That is necessary and not sufficient. `open` still walks the *directory* components, so a
+		// process that renames a workspace directory aside and drops a symlink in its place redirects
+		// the very path that was just cleared. Measured: 17 leaks in 1000 attempts, a better attack
+		// than the one resolving fixed. So the identity of what was cleared is recorded and checked
+		// against the descriptor actually obtained, and a mismatch is refused before the caller can
+		// read a byte. Inode identity is the check because it is what "the same file" means; comparing
+		// paths again would just re-run the race.
 		if let Some(fence) = params.containment.as_ref() {
-			if !fence.permits(&path_to_open, access) {
+			let resolved = crate::containment::canonicalize_for_fence(&path_to_open);
+			if !fence.permits_resolved(&resolved, access) {
 				return Err(std::io::Error::new(
 					std::io::ErrorKind::PermissionDenied,
 					format!("{}: outside this session's boundary", path_to_open.display()),
 				));
 			}
+			let cleared = crate::containment::FileIdentity::of_path(&resolved);
+			let cleared_parent = resolved.parent().and_then(crate::containment::FileIdentity::of_path);
+			let opened = options.open(&resolved)?;
+			// Ask the kernel what was actually opened and check *that* against the fence. Re-walking
+			// the path cannot settle it: a swap landing before the pre-open stat makes the stat and the
+			// open agree with each other while both disagree with the fence, which is how a
+			// directory-swap race still leaked 23 times in 600 attempts with only resolving and inode
+			// comparison in place.
+			let swapped = match crate::containment::path_of_handle(&opened) {
+				Some(reached) => !fence.permits_resolved(&reached, access),
+				// Nothing to ask on this platform, so fall back to identity: a file that existed when
+				// it was cleared must still be that file, and one that did not can only have been
+				// created, so its directory had to be there and hold still. Weaker, and the reason the
+				// fd check is preferred wherever it exists.
+				None => match cleared {
+					Some(cleared) => crate::containment::FileIdentity::of_handle(&opened) != Some(cleared),
+					None => {
+						cleared_parent.is_none()
+							|| resolved.parent().and_then(crate::containment::FileIdentity::of_path) != cleared_parent
+					},
+				},
+			};
+			if swapped {
+				return Err(std::io::Error::new(
+					std::io::ErrorKind::PermissionDenied,
+					format!(
+						"{}: changed underneath the boundary check; refusing",
+						path_to_open.display()
+					),
+				));
+			}
+			return Ok(opened.into());
 		}
 
 		Ok(options.open(path_to_open)?.into())
@@ -1438,12 +1486,17 @@ impl Shell {
 		params: &crate::interp::ExecutionParameters,
 	) -> Result<(), error::Error> {
 		if let Some(fence) = params.containment.as_ref() {
-			let destination = self.absolute_path(target_dir.as_ref());
-			let readable = fence.permits(&destination, crate::containment::FenceAccess::Read);
-			let writable = fence.permits(&destination, crate::containment::FenceAccess::Write);
+			// Resolved once and then *stored* resolved, for the same reason `open_file` opens the
+			// resolved path: checking `target_dir` and then storing `target_dir` lets a symlink change
+			// underneath between the two, leaving the shell standing somewhere it was never cleared for
+			// — and every later relative path would resolve from there.
+			let destination = crate::containment::canonicalize_for_fence(&self.absolute_path(target_dir.as_ref()));
+			let readable = fence.permits_resolved(&destination, crate::containment::FenceAccess::Read);
+			let writable = fence.permits_resolved(&destination, crate::containment::FenceAccess::Write);
 			if !readable || !writable {
 				return Err(error::ErrorKind::OutsideBoundary(destination).into());
 			}
+			return self.set_working_dir(destination);
 		}
 		self.set_working_dir(target_dir)
 	}

--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -12,6 +12,8 @@ use std::{
 	time::{Duration, Instant},
 };
 
+#[cfg(target_os = "macos")]
+use brush_core::containment::ContainmentFence;
 use napi::{
 	bindgen_prelude::*,
 	threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
@@ -19,7 +21,7 @@ use napi::{
 use napi_derive::napi;
 use portable_pty::{Child, CommandBuilder, PtySize, native_pty_system};
 
-use crate::task;
+use crate::{shell::ContainmentFenceOptions, task};
 
 /// Options for running a command in a PTY session.
 #[napi(object)]
@@ -38,6 +40,13 @@ pub struct PtyStartOptions<'env> {
 	pub cols:       Option<u16>,
 	/// PTY row count.
 	pub rows:       Option<u16>,
+	/// Filesystem boundary for this command; absent means unrestricted.
+	///
+	/// This path never runs brush-core — it spawns the system `sh`, so the
+	/// in-process checks that confine the non-PTY path do not apply here and
+	/// the OS is the only available enforcement. Without this the boundary was
+	/// opt-out by a tool parameter the model itself supplies.
+	pub fence:      Option<ContainmentFenceOptions>,
 }
 
 /// Result of a PTY command run.
@@ -53,11 +62,21 @@ pub struct PtyRunResult {
 
 #[derive(Clone)]
 struct PtyRunConfig {
-	command: String,
-	cwd:     Option<String>,
-	env:     Option<HashMap<String, String>>,
-	cols:    u16,
-	rows:    u16,
+	command:          String,
+	cwd:              Option<String>,
+	env:              Option<HashMap<String, String>>,
+	cols:             u16,
+	rows:             u16,
+	/// Compiled seatbelt profile, present only when a fence was supplied.
+	///
+	/// The profile is compiled here rather than carried as a fence because this
+	/// is the only thing the PTY path can do with one: it spawns the system
+	/// `sh`, so there is nothing in-process to check. The field is `cfg`-gated
+	/// to the platform that can enforce it, so a platform without a backend
+	/// cannot appear to hold a boundary it is not applying — the absence is
+	/// reported in `xcsh://about` rather than hidden behind an unused field.
+	#[cfg(target_os = "macos")]
+	seatbelt_profile: Option<String>,
 }
 
 enum ReaderEvent {
@@ -113,10 +132,15 @@ impl PtySession {
 	) -> Result<PromiseRaw<'env, PtyRunResult>> {
 		let run_config = PtyRunConfig {
 			command: options.command,
-			cwd:     options.cwd,
-			env:     options.env,
-			cols:    options.cols.unwrap_or(120).clamp(20, 400),
-			rows:    options.rows.unwrap_or(40).clamp(5, 200),
+			cwd: options.cwd,
+			env: options.env,
+			cols: options.cols.unwrap_or(120).clamp(20, 400),
+			rows: options.rows.unwrap_or(40).clamp(5, 200),
+			#[cfg(target_os = "macos")]
+			seatbelt_profile: options
+				.fence
+				.as_ref()
+				.map(|fence| ContainmentFence::from(fence).to_seatbelt_profile()),
 		};
 		let ct = task::CancelToken::new(options.timeout_ms, options.signal);
 		let core = Arc::clone(&self.core);
@@ -247,8 +271,40 @@ fn run_pty_sync(
 		})
 		.map_err(|err| Error::from_reason(format!("Failed to open PTY: {err}")))?;
 
-	let mut cmd = CommandBuilder::new("sh");
-	cmd.arg("-lc");
+	// The fence, when present, has to be applied by the OS: this spawns the system
+	// `sh`, so none of brush-core's in-process checks are in play. Wrapping argv
+	// mirrors `compose_std_command` in brush-core rather than inventing a second
+	// mechanism, and `--` terminates sandbox-exec's own option parsing so the
+	// wrapped argv cannot be read as flags to the wrapper.
+	//
+	// A fenced shell also drops `-l`, and that is a fix rather than a restriction.
+	// A login shell reads its startup files from the home directory, which the
+	// fence denies, so `-l` cannot succeed — it only prints `sh:
+	// /Users/…/.profile: Operation not permitted` before running the command
+	// correctly anyway. Verified: that line appeared on every fenced invocation, in
+	// the user's terminal and in the model's captured output, where it reads as a
+	// failure that did not happen.
+	//
+	// The alternative — granting read access to `.profile`, `.zshrc` and friends —
+	// was rejected. Those files routinely hold exported credentials, so allowing
+	// them would hand the session the kind of secret this fence exists to keep
+	// out, in exchange for cosmetics. Nothing is lost by dropping `-l`: `PATH` and
+	// the rest of the environment are inherited from the parent either way.
+	#[cfg(target_os = "macos")]
+	let (mut cmd, login) = match config.seatbelt_profile.as_deref() {
+		Some(profile) => {
+			let mut wrapper = CommandBuilder::new("/usr/bin/sandbox-exec");
+			wrapper.arg("-p");
+			wrapper.arg(profile);
+			wrapper.arg("--");
+			wrapper.arg("sh");
+			(wrapper, false)
+		},
+		None => (CommandBuilder::new("sh"), true),
+	};
+	#[cfg(not(target_os = "macos"))]
+	let (mut cmd, login) = (CommandBuilder::new("sh"), true);
+	cmd.arg(if login { "-lc" } else { "-c" });
 	cmd.arg(&config.command);
 	if let Some(cwd) = config.cwd.as_ref() {
 		cmd.cwd(cwd);

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -95,19 +95,22 @@ struct ShellConfig {
 #[napi(object)]
 pub struct ContainmentFenceOptions {
 	/// Roots the shell may read and write.
-	pub allow:           Vec<String>,
+	pub allow:            Vec<String>,
 	/// Roots the shell may read but not write.
-	pub allow_read_only: Vec<String>,
+	pub allow_read_only:  Vec<String>,
+	/// Roots the shell may write but not read.
+	pub allow_write_only: Vec<String>,
 	/// Roots denied in both directions, winning over any allow they sit inside.
-	pub deny:            Vec<String>,
+	pub deny:             Vec<String>,
 }
 
 impl From<&ContainmentFenceOptions> for ContainmentFence {
 	fn from(options: &ContainmentFenceOptions) -> Self {
 		Self {
-			allow:           options.allow.iter().map(PathBuf::from).collect(),
-			allow_read_only: options.allow_read_only.iter().map(PathBuf::from).collect(),
-			deny:            options.deny.iter().map(PathBuf::from).collect(),
+			allow:            options.allow.iter().map(PathBuf::from).collect(),
+			allow_read_only:  options.allow_read_only.iter().map(PathBuf::from).collect(),
+			allow_write_only: options.allow_write_only.iter().map(PathBuf::from).collect(),
+			deny:             options.deny.iter().map(PathBuf::from).collect(),
 		}
 	}
 }

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -18,6 +18,7 @@ use std::{
 	collections::HashMap,
 	fs,
 	io::{self, Write},
+	path::{Path, PathBuf},
 	str,
 	sync::Arc,
 	time::Duration,
@@ -30,6 +31,7 @@ use brush_builtins::{BuiltinSet, default_builtins};
 use brush_core::{
 	CreateOptions, ExecutionContext, ExecutionControlFlow, ExecutionExitCode, ExecutionResult,
 	ProcessGroupPolicy, Shell as BrushShell, ShellValue, ShellVariable, builtins,
+	containment::{ContainmentFence, FenceAccess},
 	env::EnvironmentScope,
 	openfiles::{self, OpenFile, OpenFiles},
 };
@@ -85,6 +87,44 @@ struct ShellConfig {
 	snapshot_path: Option<String>,
 }
 
+/// Canonical roots describing what the shell may reach, as built by the host.
+///
+/// Absent means unrestricted. Only the model's `bash` tool supplies one;
+/// credential helpers, the interactive shell and snapshot sourcing pass nothing
+/// and are unaffected.
+#[napi(object)]
+pub struct ContainmentFenceOptions {
+	/// Roots the shell may read and write.
+	pub allow:           Vec<String>,
+	/// Roots the shell may read but not write.
+	pub allow_read_only: Vec<String>,
+	/// Roots denied in both directions, winning over any allow they sit inside.
+	pub deny:            Vec<String>,
+}
+
+impl From<&ContainmentFenceOptions> for ContainmentFence {
+	fn from(options: &ContainmentFenceOptions) -> Self {
+		Self {
+			allow:           options.allow.iter().map(PathBuf::from).collect(),
+			allow_read_only: options.allow_read_only.iter().map(PathBuf::from).collect(),
+			deny:            options.deny.iter().map(PathBuf::from).collect(),
+		}
+	}
+}
+
+/// Whether a fence permits a path — exported so one corpus can be run through
+/// both this implementation and the TypeScript one, which is the only guard
+/// against the two drifting.
+#[napi]
+pub fn fence_permits(fence: ContainmentFenceOptions, candidate: String, write: bool) -> bool {
+	let access = if write {
+		FenceAccess::Write
+	} else {
+		FenceAccess::Read
+	};
+	ContainmentFence::from(&fence).permits(Path::new(&candidate), access)
+}
+
 /// Options for configuring a persistent shell session.
 #[napi(object)]
 pub struct ShellOptions {
@@ -102,6 +142,8 @@ struct ShellRunConfig {
 	cwd:     Option<String>,
 	/// Environment variables to apply for this command only.
 	env:     Option<HashMap<String, String>>,
+	/// Which paths this command may reach. `None` is unrestricted.
+	fence:   Option<Arc<ContainmentFence>>,
 }
 
 /// Options for running a shell command.
@@ -117,6 +159,8 @@ pub struct ShellRunOptions<'env> {
 	pub timeout_ms: Option<u32>,
 	/// Abort signal for cancelling the operation.
 	pub signal:     Option<Unknown<'env>>,
+	/// Which paths this command may reach. Absent means unrestricted.
+	pub fence:      Option<ContainmentFenceOptions>,
 }
 
 /// Result of running a shell command.
@@ -174,8 +218,15 @@ impl Shell {
 		let abort_state = self.abort_state.clone();
 		let config = self.config.clone();
 
-		let run_config =
-			ShellRunConfig { command: options.command, cwd: options.cwd, env: options.env };
+		let run_config = ShellRunConfig {
+			command: options.command,
+			cwd:     options.cwd,
+			env:     options.env,
+			fence:   options
+				.fence
+				.as_ref()
+				.map(|f| Arc::new(ContainmentFence::from(f))),
+		};
 
 		task::future(env, "shell.run", async move {
 			run_shell_session(session, abort_state, config, run_config, on_chunk, ct).await
@@ -271,6 +322,8 @@ pub struct ShellExecuteOptions<'env> {
 	pub snapshot_path: Option<String>,
 	/// Abort signal for cancelling the operation.
 	pub signal:        Option<Unknown<'env>>,
+	/// Which paths this command may reach. Absent means unrestricted.
+	pub fence:         Option<ContainmentFenceOptions>,
 }
 
 /// Result of executing a shell command via brush-core.
@@ -298,8 +351,15 @@ pub fn execute_shell<'env>(
 ) -> Result<PromiseRaw<'env, ShellExecuteResult>> {
 	let config =
 		ShellConfig { session_env: options.session_env, snapshot_path: options.snapshot_path };
-	let run_config =
-		ShellRunConfig { command: options.command, cwd: options.cwd, env: options.env };
+	let run_config = ShellRunConfig {
+		command: options.command,
+		cwd:     options.cwd,
+		env:     options.env,
+		fence:   options
+			.fence
+			.as_ref()
+			.map(|f| Arc::new(ContainmentFence::from(f))),
+	};
 
 	let ct = task::CancelToken::new(options.timeout_ms, options.signal);
 	task::future(env, "shell.execute", async move {
@@ -551,6 +611,7 @@ async fn run_shell_command(
 	params.set_fd(OpenFiles::STDOUT_FD, stdout_file);
 	params.set_fd(OpenFiles::STDERR_FD, stderr_file);
 	params.process_group_policy = ProcessGroupPolicy::NewProcessGroup;
+	params.containment = options.fence.clone();
 	params.set_cancel_token(cancel_token.clone());
 
 	let mut env_scope_pushed = false;

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -14,7 +14,12 @@ import { NON_INTERACTIVE_ENV } from "./non-interactive-env";
 /** The fence as the napi boundary wants it: plain mutable arrays, or absent for unrestricted. */
 function fenceForNative(fence: ContainmentFence | undefined) {
 	if (!fence) return undefined;
-	return { allow: [...fence.allow], allowReadOnly: [...fence.allowReadOnly], deny: [...fence.deny] };
+	return {
+		allow: [...fence.allow],
+		allowReadOnly: [...fence.allowReadOnly],
+		allowWriteOnly: [...fence.allowWriteOnly],
+		deny: [...fence.deny],
+	};
 }
 
 export interface BashExecutorOptions {

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -11,8 +11,13 @@ import { OutputSink } from "../session/streaming-output";
 import { getOrCreateSnapshot } from "../utils/shell-snapshot";
 import { NON_INTERACTIVE_ENV } from "./non-interactive-env";
 
-/** The fence as the napi boundary wants it: plain mutable arrays, or absent for unrestricted. */
-function fenceForNative(fence: ContainmentFence | undefined) {
+/**
+ * The fence as the napi boundary wants it: plain mutable arrays, or absent for unrestricted.
+ *
+ * Shared with the PTY path, which needs the identical conversion. One converter, so the two
+ * execution paths cannot end up disagreeing about what they hand the native layer.
+ */
+export function fenceForNative(fence: ContainmentFence | undefined) {
 	if (!fence) return undefined;
 	return {
 		allow: [...fence.allow],

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -6,9 +6,16 @@
 import * as fs from "node:fs/promises";
 import { executeShell, Shell } from "@f5-sales-demo/pi-natives";
 import { Settings } from "../config/settings";
+import type { ContainmentFence } from "../sandbox/containment";
 import { OutputSink } from "../session/streaming-output";
 import { getOrCreateSnapshot } from "../utils/shell-snapshot";
 import { NON_INTERACTIVE_ENV } from "./non-interactive-env";
+
+/** The fence as the napi boundary wants it: plain mutable arrays, or absent for unrestricted. */
+function fenceForNative(fence: ContainmentFence | undefined) {
+	if (!fence) return undefined;
+	return { allow: [...fence.allow], allowReadOnly: [...fence.allowReadOnly], deny: [...fence.deny] };
+}
 
 export interface BashExecutorOptions {
 	cwd?: string;
@@ -24,6 +31,16 @@ export interface BashExecutorOptions {
 	artifactId?: string;
 	/** Mask sensitive values (e.g. env var secrets) in output. */
 	maskSecrets?: (text: string) => string;
+	/**
+	 * Which paths this command may reach, enforced inside the shell rather than guessed from the
+	 * command text (#2554).
+	 *
+	 * Absent means unrestricted, and absent is the default on purpose. Only the model's `bash` tool
+	 * supplies one — `executeBash` is also reached by user-typed `!cmd`, by RPC `bash`, and the same
+	 * brush-core runs credential helpers and the interactive `xcsh shell`. Fencing those would break
+	 * API-key resolution and confine the operator at their own prompt.
+	 */
+	fence?: ContainmentFence;
 }
 
 export interface BashResult {
@@ -186,6 +203,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 						env: commandEnv,
 						timeoutMs: options?.timeout,
 						signal: runAbortController.signal,
+						fence: fenceForNative(options?.fence),
 					},
 					(err, chunk) => {
 						if (!err) {
@@ -202,6 +220,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 						snapshotPath: snapshotPath ?? undefined,
 						timeoutMs: options?.timeout,
 						signal: runAbortController.signal,
+						fence: fenceForNative(options?.fence),
 					},
 					(err, chunk) => {
 						if (!err) {

--- a/packages/coding-agent/src/internal-urls/build-info-runtime.ts
+++ b/packages/coding-agent/src/internal-urls/build-info-runtime.ts
@@ -3,6 +3,8 @@ import * as path from "node:path";
 import { prompt } from "@f5-sales-demo/pi-utils";
 import { $ } from "bun";
 import activeModelTemplate from "../prompts/internal-urls/active-model.md" with { type: "text" };
+import containmentTemplate from "../prompts/internal-urls/containment.md" with { type: "text" };
+import type { ContainmentStatus } from "../sandbox/containment";
 import type { ContextStatus } from "../services/xcsh-context";
 import type { ActiveModelSnapshot } from "../session/active-model";
 import { BUILD_INFO, type BuildInfo } from "./build-info.generated";
@@ -157,10 +159,23 @@ function renderActiveModel(model: ActiveModelSnapshot | null): string {
 	return prompt.render(activeModelTemplate, { model });
 }
 
+/**
+ * What is enforcing the filesystem boundary, and what that does and does not guarantee.
+ *
+ * Stated here because two sessions can look identical and offer very different guarantees: with an OS
+ * backend a path is checked where it is opened and the spelling cannot matter, while without one the
+ * only check reads the command text. An operator has no other way to tell which they have.
+ */
+function renderContainment(containment: ContainmentStatus | null): string {
+	if (!containment) return "";
+	return prompt.render(containmentTemplate, { containment });
+}
+
 export function renderAboutDoc(
 	info: RuntimeBuildInfo,
 	context: ContextStatus | null,
 	model: ActiveModelSnapshot | null,
+	containment: ContainmentStatus | null,
 ): string {
 	return [
 		"# xcsh — identity and build fingerprint",
@@ -183,6 +198,7 @@ export function renderAboutDoc(
 		"",
 		renderPlatformContext(context, Date.now()),
 		renderActiveModel(model),
+		renderContainment(containment),
 		"## Source of truth",
 		"",
 		`- Repository: ${info.repoUrl}`,

--- a/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
@@ -27,6 +27,7 @@
  */
 import * as path from "node:path";
 import { logger } from "@f5-sales-demo/pi-utils";
+import type { ContainmentStatus } from "../sandbox/containment";
 import type { ContextStatus } from "../services/xcsh-context";
 import type { ActiveModelSnapshot } from "../session/active-model";
 import { type ApiCatalogResolver, createApiCatalogResolver } from "./api-catalog-resolve";
@@ -311,6 +312,12 @@ export interface InternalDocsProtocolOptions {
 	 * reflects a mid-session switch instead of the model the session launched with (#2459).
 	 */
 	readonly getActiveModel?: () => ActiveModelSnapshot | null;
+	/**
+	 * What is enforcing the filesystem boundary. A live getter, like `getActiveModel`, because
+	 * `--no-sandbox` and `sandbox.enabled` can differ per session and the answer must not be captured
+	 * at construction.
+	 */
+	readonly getContainment?: () => ContainmentStatus | null;
 	readonly apiSpecResolver?: ApiSpecResolver;
 	readonly apiCatalogResolver?: ApiCatalogResolver;
 	readonly getPluginRoots?: GetPluginRoots;
@@ -323,6 +330,7 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 	readonly #resolveBuildInfo: () => Promise<RuntimeBuildInfo>;
 	readonly #getContextStatus: (() => ContextStatus | null) | undefined;
 	readonly #getActiveModel: (() => ActiveModelSnapshot | null) | undefined;
+	readonly #getContainment: (() => ContainmentStatus | null) | undefined;
 	#apiSpecResolver: ApiSpecResolver | null;
 	#apiCatalogResolver: ApiCatalogResolver | null;
 	#terraformResolver: TerraformResolver | null;
@@ -338,6 +346,7 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 		this.#resolveBuildInfo = options.resolveBuildInfo ?? getRuntimeBuildInfo;
 		this.#getContextStatus = options.getContextStatus;
 		this.#getActiveModel = options.getActiveModel;
+		this.#getContainment = options.getContainment;
 		this.#apiSpecResolver = options.apiSpecResolver ?? null;
 		this.#apiCatalogResolver = options.apiCatalogResolver ?? null;
 		this.#terraformResolver = null;
@@ -814,7 +823,8 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 			const info = await this.#resolveBuildInfo();
 			const context = this.#getContextStatus?.() ?? null;
 			const activeModel = this.#getActiveModel?.() ?? null;
-			const content = renderAboutDoc(info, context, activeModel);
+			const containment = this.#getContainment?.() ?? null;
+			const content = renderAboutDoc(info, context, activeModel, containment);
 			return {
 				url: url.href,
 				content,

--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -1,0 +1,35 @@
+## Sandbox containment
+
+{{#if containment.enabled}}
+Filesystem isolation is **on**. Enforcement for the `bash` tool: **{{containment.backend}}**.
+
+{{#if containment.osEnforced}}
+Your shell is confined by the operating system, not by inspecting the command you wrote. A path is
+checked where it is actually opened, after the shell has expanded variables, resolved aliases and
+followed symlinks — so how a path is spelled does not change what is reachable.
+- Ordinary work is unrestricted: system paths, `/tmp`, package caches (`~/.bun`, `~/.cargo`, …), the
+  network, and running programs are all untouched.
+- What is refused: reading or writing outside the session directory — another checkout, `~/.ssh`,
+  `~/.aws`, `~/Documents`, and other sessions' transcripts. `~/.gitconfig` is readable, not writable.
+- `cd` out of the session tree is refused, because every later relative path would resolve there.
+
+If a command is refused, do not try to reach the same path a different way: the boundary is enforced
+below the command text, so no rewriting will succeed. Say what you needed and why. The operator can
+widen it with `--allow-path <dir>`, which grants read and write.
+{{else}}
+On this platform there is **no OS-level backend**, so the boundary is enforced only by scanning the
+command text before it runs. That check is best-effort by construction: it reads what you wrote
+rather than what the shell will do, so a path assembled at runtime or reached through an unusual
+spelling may not be caught.
+
+Treat the boundary as a statement of intent rather than a guarantee here, and do not go looking for
+paths outside the session directory on the assumption that something would stop you.
+{{/if}}
+{{else}}
+Filesystem isolation is **off** for this session — started with `--no-sandbox`, or
+`sandbox.enabled` is false. Every path on this machine is reachable.
+
+Nothing is confining you, so the judgement is yours: stay within the directory the operator is
+working in unless they asked for something else, and do not read private files elsewhere on the
+machine because you happen to be able to.
+{{/if}}

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -163,3 +163,31 @@ export function fenceVerdict(fence: ContainmentFence, candidate: string, access:
 	if (allowed !== undefined && depth(allowed) === deepest) return "allow";
 	return "allow";
 }
+
+/** Which mechanism is actually enforcing the boundary for the `bash` tool. */
+export type ContainmentBackend = "seatbelt" | "landlock" | "scanner-only" | "disabled";
+
+export interface ContainmentStatus {
+	readonly enabled: boolean;
+	readonly backend: ContainmentBackend;
+	/** True when the kernel enforces it, false when only the command-text scan does. */
+	readonly osEnforced: boolean;
+}
+
+/**
+ * What is actually enforcing the boundary right now.
+ *
+ * Reported so an operator can tell a confined session from an unconfined one. The distinction is not
+ * cosmetic: with a backend, a path is checked where it is opened and the spelling cannot matter;
+ * without one, the only check reads the command text and is best-effort by construction. Two sessions
+ * that look identical can offer very different guarantees, and `xcsh://about` is where that is stated.
+ *
+ * Deliberately not surfaced at startup or anywhere in the TUI — the operator asked for no UI change.
+ */
+export function containmentStatus(enabled: boolean, platform: string = process.platform): ContainmentStatus {
+	if (!enabled) return { enabled: false, backend: "disabled", osEnforced: false };
+	// Only the macOS seatbelt backend exists today. Linux Landlock is a follow-up; until it lands,
+	// Linux and Windows fall back to the scanner and say so rather than implying enforcement.
+	if (platform === "darwin") return { enabled: true, backend: "seatbelt", osEnforced: true };
+	return { enabled: true, backend: "scanner-only", osEnforced: false };
+}

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -29,6 +29,8 @@ export interface ContainmentFence {
 	readonly allow: readonly string[];
 	/** Canonical roots the shell may read but not write. */
 	readonly allowReadOnly: readonly string[];
+	/** Canonical roots the shell may write but not read. */
+	readonly allowWriteOnly: readonly string[];
 	/** Canonical roots denied in both directions, winning over any allow they sit inside. */
 	readonly deny: readonly string[];
 }
@@ -40,8 +42,12 @@ export interface ContainmentOptions {
 	home?: string;
 	/** A session-specific temp dir, if the session has one. */
 	sessionTmp?: string;
-	/** Roots granted read+write by `--allow-path` / `sandbox.allow*`. */
+	/** Roots granted read+write, as `--allow-path` does. */
 	extraRoots?: readonly string[];
+	/** Roots granted read only — `sandbox.allowRead`. Must NOT become writable. */
+	readOnlyRoots?: readonly string[];
+	/** Roots granted write only — `sandbox.allowWrite`. */
+	writeOnlyRoots?: readonly string[];
 	/** Cross-session leak roots to deny. Defaults to the real memories/sessions/contexts dirs. */
 	leakRoots?: readonly string[];
 }
@@ -54,16 +60,23 @@ export interface ContainmentOptions {
  * `~/Library/Caches` is macOS-wide tool cache; it is not customer data and several toolchains use it.
  */
 const CACHE_DIRS = [
-	".bun",
-	".cargo",
-	".npm",
-	".rustup",
-	".cache",
-	".yarn",
+	// Artifact subdirectories only. Granting the parents put credentials inside the fence —
+	// `.cargo/credentials.toml`, `.m2/settings.xml`, `.npm/_authToken` — and `.cargo/config.toml`
+	// and `.gradle/init.gradle` are worse than credentials: both can redirect a later build, so a
+	// write there is persistence rather than theft. Found by adversarial review, verified writable.
+	path.join(".bun", "install", "cache"),
+	path.join(".cargo", "registry"),
+	path.join(".cargo", "git"),
+	path.join(".npm", "_cacache"),
+	path.join(".m2", "repository"),
+	path.join(".gradle", "caches"),
+	path.join(".gradle", "wrapper"),
+	path.join(".yarn", "berry", "cache"),
+	path.join(".rustup", "toolchains"),
+	path.join(".rustup", "downloads"),
+	// No credential convention of their own, so granted whole.
 	".pnpm-store",
 	".deno",
-	".gradle",
-	".m2",
 	path.join("Library", "Caches"),
 	path.join("Library", "pnpm"),
 ];
@@ -83,6 +96,46 @@ function canonical(root: string): string | undefined {
 		return fs.realpathSync(root);
 	} catch {
 		return undefined;
+	}
+}
+
+/**
+ * Parents that must never be denied, however the workspace is placed.
+ *
+ * Denying the workspace's parent closes sibling access, but the parent is not always a sibling
+ * container. A workspace directly under `/`, under a system directory, or under the OS temp dir would
+ * otherwise deny `/`, `/usr` or `/tmp` — refusing exactly the work this fence is supposed to leave
+ * alone. The home tree is excluded too because the home deny already covers it, at the right depth.
+ */
+function tooBroadToDeny(candidate: string): boolean {
+	if (candidate === path.parse(candidate).root) return true;
+	const never = [
+		safeReal(os.tmpdir()),
+		"/usr",
+		"/bin",
+		"/sbin",
+		"/lib",
+		"/opt",
+		"/etc",
+		"/dev",
+		"/proc",
+		"/sys",
+		"/var",
+		"/private",
+		"/System",
+		"/Library",
+		"/Users",
+		"/home",
+	];
+	return never.includes(candidate);
+}
+
+/** realpath without throwing, for building the never-deny list. */
+function safeReal(input: string): string {
+	try {
+		return fs.realpathSync(input);
+	} catch {
+		return input;
 	}
 }
 
@@ -109,15 +162,31 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 	const home = canonical(options.home ?? os.homedir());
 	const allow = new Set<string>([workspace]);
 	const allowReadOnly = new Set<string>();
+	const allowWriteOnly = new Set<string>();
 	const deny = new Set<string>();
 
-	// Home is the fence. Everything outside it is left alone entirely.
+	// Home is one fence. The workspace's own parent is the other, and it is the one that matters when
+	// checkouts live outside home: with /work/customer-a as the workspace, /work/customer-b matched no
+	// rule at all and was readable and writable. Denying the parent closes sibling access wherever the
+	// checkouts sit, which is the threat this exists for.
 	if (home !== undefined && home !== workspace) deny.add(home);
+	const parent = path.dirname(workspace);
+	if (parent !== workspace && !tooBroadToDeny(parent)) deny.add(parent);
 
 	for (const root of [options.sessionTmp, ...(options.extraRoots ?? [])]) {
 		if (root === undefined) continue;
 		const resolved = canonical(root);
 		if (resolved !== undefined) allow.add(resolved);
+	}
+	// Kept distinct. Merging them into one read+write list made a folder shared for reading writable,
+	// undoing the read/write split built for #2516 — found by adversarial review.
+	for (const root of options.readOnlyRoots ?? []) {
+		const resolved = canonical(root);
+		if (resolved !== undefined) allowReadOnly.add(resolved);
+	}
+	for (const root of options.writeOnlyRoots ?? []) {
+		const resolved = canonical(root);
+		if (resolved !== undefined) allowWriteOnly.add(resolved);
 	}
 
 	if (home !== undefined) {
@@ -139,7 +208,12 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		if (resolved !== undefined) deny.add(resolved);
 	}
 
-	return { allow: [...allow], allowReadOnly: [...allowReadOnly], deny: [...deny] };
+	return {
+		allow: [...allow],
+		allowReadOnly: [...allowReadOnly],
+		allowWriteOnly: [...allowWriteOnly],
+		deny: [...deny],
+	};
 }
 
 /**
@@ -152,14 +226,16 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 export function fenceVerdict(fence: ContainmentFence, candidate: string, access: FenceAccess): FenceVerdict {
 	const denied = deepestMatch(fence.deny, candidate);
 	const readOnly = deepestMatch(fence.allowReadOnly, candidate);
+	const writeOnly = deepestMatch(fence.allowWriteOnly, candidate);
 	const allowed = deepestMatch(fence.allow, candidate);
 
 	const depth = (root: string | undefined): number => (root === undefined ? -1 : root.length);
-	const deepest = Math.max(depth(denied), depth(readOnly), depth(allowed));
+	const deepest = Math.max(depth(denied), depth(readOnly), depth(writeOnly), depth(allowed));
 
 	// Deny first at equal depth: the leak roots depend on it.
 	if (denied !== undefined && depth(denied) === deepest) return "deny";
 	if (readOnly !== undefined && depth(readOnly) === deepest) return access === "read" ? "allow" : "deny";
+	if (writeOnly !== undefined && depth(writeOnly) === deepest) return access === "write" ? "allow" : "deny";
 	if (allowed !== undefined && depth(allowed) === deepest) return "allow";
 	return "allow";
 }

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -1,0 +1,165 @@
+/**
+ * The containment fence: what the shell may reach, enforced below the command text.
+ *
+ * This is deliberately NOT `SandboxPolicy`. That object is deny-by-default — "a path matched by no
+ * rule is denied" — which is the right posture for the structured file tools and the wrong one here.
+ * Confining a shell that way refuses ordinary work: measured on macOS 26.3, a deny-default seatbelt
+ * profile could not even `execvp /bin/cat`.
+ *
+ * So the fence is gentle. It restricts no operation — `/usr`, `/tmp`, package caches, the network and
+ * process execution are never mentioned, and nothing that works today stops working. The single thing
+ * it prevents is the assistant wandering the filesystem: reading or writing another customer's
+ * checkout, `~/.ssh`, `~/Documents`. That is where the cross-customer risk actually lives (#2554).
+ *
+ * Produced declaratively rather than as an ordered rule list, because the two backends disagree about
+ * order: seatbelt evaluates rules in sequence with the last match winning, while Landlock only grants
+ * and cannot deny a subpath of something granted. Both can compile `{allow, allowReadOnly, deny}` with
+ * deny-wins, so neither has to reason about ordering.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getMemoriesDir, getSessionsDir, getXCSHContextsDir, pathIsWithin } from "@f5-sales-demo/pi-utils";
+
+export type FenceAccess = "read" | "write";
+export type FenceVerdict = "allow" | "deny";
+
+export interface ContainmentFence {
+	/** Canonical roots the shell may read and write. */
+	readonly allow: readonly string[];
+	/** Canonical roots the shell may read but not write. */
+	readonly allowReadOnly: readonly string[];
+	/** Canonical roots denied in both directions, winning over any allow they sit inside. */
+	readonly deny: readonly string[];
+}
+
+export interface ContainmentOptions {
+	/** The session's working directory. Must exist — it is the one root that cannot be dropped. */
+	workspace: string;
+	/** Overridable for tests; defaults to the real home directory. */
+	home?: string;
+	/** A session-specific temp dir, if the session has one. */
+	sessionTmp?: string;
+	/** Roots granted read+write by `--allow-path` / `sandbox.allow*`. */
+	extraRoots?: readonly string[];
+	/** Cross-session leak roots to deny. Defaults to the real memories/sessions/contexts dirs. */
+	leakRoots?: readonly string[];
+}
+
+/**
+ * Directories inside home that hold tool state rather than the operator's data. Denying home without
+ * carving these back out is what would break `bun install`, `cargo build` and `npm ci` — the exact
+ * class of breakage this fence must not cause.
+ *
+ * `~/Library/Caches` is macOS-wide tool cache; it is not customer data and several toolchains use it.
+ */
+const CACHE_DIRS = [
+	".bun",
+	".cargo",
+	".npm",
+	".rustup",
+	".cache",
+	".yarn",
+	".pnpm-store",
+	".deno",
+	".gradle",
+	".m2",
+	path.join("Library", "Caches"),
+	path.join("Library", "pnpm"),
+];
+
+/** Read-only inside home: configuration a tool needs to behave correctly, but must not rewrite. */
+const READ_ONLY_HOME = [".gitconfig", path.join(".config", "git")];
+
+/**
+ * Canonicalise a root, or return undefined when it is absent.
+ *
+ * Canonicalisation is load-bearing rather than tidiness: a seatbelt `(subpath "/tmp/x")` rule grants
+ * nothing, because the real path is `/private/tmp/x`. A rule that appears to enforce and does not is
+ * the worst outcome available, so a root that cannot be resolved is dropped rather than emitted.
+ */
+function canonical(root: string): string | undefined {
+	try {
+		return fs.realpathSync(root);
+	} catch {
+		return undefined;
+	}
+}
+
+/** The deepest root containing `candidate`, so a nested rule beats the broader one it sits inside. */
+function deepestMatch(roots: readonly string[], candidate: string): string | undefined {
+	let best: string | undefined;
+	for (const root of roots) {
+		if (!pathIsWithin(root, candidate)) continue;
+		if (best === undefined || root.length > best.length) best = root;
+	}
+	return best;
+}
+
+/** Build the fence for a session. Throws only when the workspace itself cannot be resolved. */
+export function buildContainmentFence(options: ContainmentOptions): ContainmentFence {
+	const workspace = canonical(options.workspace);
+	if (workspace === undefined) {
+		throw new Error(
+			`sandbox containment: cannot canonicalise the session workspace ${options.workspace}. ` +
+				"A fence built on an unresolved path would silently grant nothing, so refusing to build one.",
+		);
+	}
+
+	const home = canonical(options.home ?? os.homedir());
+	const allow = new Set<string>([workspace]);
+	const allowReadOnly = new Set<string>();
+	const deny = new Set<string>();
+
+	// Home is the fence. Everything outside it is left alone entirely.
+	if (home !== undefined && home !== workspace) deny.add(home);
+
+	for (const root of [options.sessionTmp, ...(options.extraRoots ?? [])]) {
+		if (root === undefined) continue;
+		const resolved = canonical(root);
+		if (resolved !== undefined) allow.add(resolved);
+	}
+
+	if (home !== undefined) {
+		// Granted whether or not they exist yet. `~/.bun` has to be writable *before* the first
+		// `bun install` creates it, so dropping absent caches would break exactly the first run.
+		// Canonicalised when present, so a symlinked cache resolves to its real location.
+		for (const cache of CACHE_DIRS) allow.add(canonical(path.join(home, cache)) ?? path.join(home, cache));
+		for (const config of READ_ONLY_HOME) {
+			allowReadOnly.add(canonical(path.join(home, config)) ?? path.join(home, config));
+		}
+	}
+
+	// Cross-session leak roots. These may sit *under* an allowed root — the agent dir is inside home,
+	// and a session whose workspace is the agent dir would otherwise re-expose every other session's
+	// transcript. `fenceVerdict` resolves that by depth, so nesting is safe rather than accidental.
+	const leaks = options.leakRoots ?? [getMemoriesDir(), getSessionsDir(), getXCSHContextsDir()];
+	for (const leak of leaks) {
+		const resolved = canonical(leak);
+		if (resolved !== undefined) deny.add(resolved);
+	}
+
+	return { allow: [...allow], allowReadOnly: [...allowReadOnly], deny: [...deny] };
+}
+
+/**
+ * Whether the fence permits `access` on `candidate`.
+ *
+ * Deepest match wins, and a deny beats an allow at equal depth — the same precedence `SandboxPolicy`
+ * uses, so the two layers cannot disagree about a path they both see. Unlike that policy, the default
+ * here is **allow**: a path matched by no rule is outside the fence and none of its business.
+ */
+export function fenceVerdict(fence: ContainmentFence, candidate: string, access: FenceAccess): FenceVerdict {
+	const denied = deepestMatch(fence.deny, candidate);
+	const readOnly = deepestMatch(fence.allowReadOnly, candidate);
+	const allowed = deepestMatch(fence.allow, candidate);
+
+	const depth = (root: string | undefined): number => (root === undefined ? -1 : root.length);
+	const deepest = Math.max(depth(denied), depth(readOnly), depth(allowed));
+
+	// Deny first at equal depth: the leak roots depend on it.
+	if (denied !== undefined && depth(denied) === deepest) return "deny";
+	if (readOnly !== undefined && depth(readOnly) === deepest) return access === "read" ? "allow" : "deny";
+	if (allowed !== undefined && depth(allowed) === deepest) return "allow";
+	return "allow";
+}

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -14,8 +14,22 @@
  * Arbitrary-code tools (`bash`, `python`) cannot be fully contained in-process: this
  * checks the `cwd` argument precisely and scans the command/code for path tokens
  * (bare, quoted, `~`, `..`, absolute) that escape the tree. OS system paths are exempt.
- * This is best-effort; the opt-in OS-level sandbox (Phase 2) is the airtight enforcement
- * for both bash and python.
+ *
+ * **This scan is no longer the boundary for `bash` on macOS.** Containment now runs below the command
+ * text (`sandbox/containment.ts`, #2554): the shell's own `cd` and redirections are checked where they
+ * act, and spawned children are confined by a seatbelt profile. A path is therefore decided after
+ * expansion, alias resolution and symlink following, which is what closed the escapes this scan kept
+ * leaking — #2470, #2516, #2520, #2524, #2540, #2542, #2553, and GHSA-q4hg.
+ *
+ * What remains this file's job:
+ *  - every structured file tool (`read`/`write`/`edit`/`grep`/…), which has no subprocess to confine
+ *  - `python`, which is not covered by the shell fence at all
+ *  - `bash` on platforms with no backend — Linux Landlock is a follow-up, Windows has no equivalent —
+ *    where this is again the only layer, and `xcsh://about` says so
+ *  - a fast pre-check that produces a readable refusal before a command runs
+ *
+ * So: keep it, and do not extend it. Another spelling caught here buys little now, and the pattern of
+ * adding one has a poor record — two adversarial rounds on the #2542 fix alone produced six bypasses.
  */
 import * as path from "node:path";
 import { expandPath, parseFindPattern, parseSearchPath, resolveToCwd, splitTopLevel } from "../tools/path-utils";

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -96,6 +96,8 @@ import {
 } from "./mcp/discoverable-tool-metadata";
 import { buildMemoryToolDeveloperInstructions, getMemoryRoot, startMemoryStartupTask } from "./memories";
 import asyncResultTemplate from "./prompts/tools/async-result.md" with { type: "text" };
+import { containmentStatus } from "./sandbox/containment";
+import { resolveSessionPolicy } from "./sandbox/session-policy";
 import {
 	collectEnvSecrets,
 	deobfuscateSessionContext,
@@ -1154,6 +1156,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						return null;
 					}
 				},
+				// Read live rather than captured, for the same reason as the model: `--no-sandbox` and
+				// `sandbox.enabled` are per-session, so the answer must reflect this session (#2554).
+				getContainment: () => containmentStatus(resolveSessionPolicy(process.cwd(), settings) !== undefined),
 				// Read live rather than captured: `session.model` is a read-through to agent state, so a
 				// mid-session Ctrl+P switch shows up on the next xcsh://about read (#2459).
 				getActiveModel: () =>

--- a/packages/coding-agent/src/tools/bash-interactive.ts
+++ b/packages/coding-agent/src/tools/bash-interactive.ts
@@ -12,8 +12,10 @@ import {
 } from "@f5-sales-demo/pi-tui";
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
 import xterm from "@xterm/headless";
+import { fenceForNative } from "../exec/bash-executor";
 import { NON_INTERACTIVE_ENV } from "../exec/non-interactive-env";
 import type { Theme } from "../modes/theme/theme";
+import type { ContainmentFence } from "../sandbox/containment";
 import { OutputSink, type OutputSummary } from "../session/streaming-output";
 import { sanitizeWithImagePassthrough } from "../utils/image-passthrough";
 import { formatStatusIcon, replaceTabs } from "./render-utils";
@@ -293,6 +295,17 @@ export async function runInteractiveBashPty(
 		artifactPath?: string;
 		artifactId?: string;
 		maskSecrets?: (text: string) => string;
+		/**
+		 * Filesystem boundary for this command. `undefined` means unrestricted, and must be said
+		 * rather than omitted.
+		 *
+		 * Deliberately a required key with an optional value. This path is reached only from the
+		 * model's `bash` tool, and it was unfenced precisely because the field was easy to leave out
+		 * of one of two call sites — the boundary ended up opt-out via a parameter the model itself
+		 * supplies. Requiring the key makes that omission a type error instead of a silent hole; a
+		 * future caller that genuinely wants no fence has to write `fence: undefined` and mean it.
+		 */
+		fence: ContainmentFence | undefined;
 	},
 ): Promise<BashInteractiveResult> {
 	const sink = new OutputSink({
@@ -360,6 +373,7 @@ export async function runInteractiveBashPty(
 						signal: options.signal,
 						cols,
 						rows,
+						fence: fenceForNative(options.fence),
 					},
 					(err, chunk) => {
 						if (finished || err || !chunk) return;

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -671,6 +671,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					artifactPath,
 					artifactId,
 					maskSecrets,
+					fence: this.#containmentFence(),
 				})
 			: await executeBash(command, {
 					cwd: commandCwd,

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -492,13 +492,13 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		const policy = resolveSessionPolicy(this.session.cwd, this.session.settings);
 		if (!policy) return undefined; // --no-sandbox / sandbox.enabled = false
 		const artifactsDir = this.session.getArtifactsDir?.();
+		// The three grants stay distinct. Merging allowRead and allowWrite into one read+write list
+		// made a folder shared for reading writable, undoing the split built for #2516.
 		return buildContainmentFence({
 			workspace: this.session.cwd,
-			extraRoots: [
-				...(artifactsDir ? [artifactsDir] : []),
-				...((this.session.settings.get("sandbox.allowRead") as string[] | undefined) ?? []),
-				...((this.session.settings.get("sandbox.allowWrite") as string[] | undefined) ?? []),
-			],
+			extraRoots: artifactsDir ? [artifactsDir] : [],
+			readOnlyRoots: (this.session.settings.get("sandbox.allowRead") as string[] | undefined) ?? [],
+			writeOnlyRoots: (this.session.settings.get("sandbox.allowWrite") as string[] | undefined) ?? [],
 		});
 	}
 

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -16,6 +16,7 @@ import { resolveLocalRoot } from "../internal-urls/local-protocol";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
 import type { Theme } from "../modes/theme/theme";
 import bashDescription from "../prompts/tools/bash.md" with { type: "text" };
+import { buildContainmentFence } from "../sandbox/containment";
 import { resolveSessionPolicy } from "../sandbox/session-policy";
 import { SECRET_ENV_PATTERNS, type SecretObfuscator } from "../secrets";
 import { DEFAULT_MAX_BYTES, TailBuffer } from "../session/streaming-output";
@@ -392,6 +393,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 						artifactPath,
 						artifactId,
 						maskSecrets: options.maskSecrets,
+						fence: this.#containmentFence(),
 						onChunk: chunk => {
 							tailBuffer.append(chunk);
 							const preview = options.maskSecrets ? options.maskSecrets(tailBuffer.text()) : tailBuffer.text();
@@ -473,6 +475,31 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		if (this.#autoBackgroundThresholdMs <= 0) return 0;
 		const timeoutBufferMs = 1_000;
 		return Math.max(0, Math.min(this.#autoBackgroundThresholdMs, timeoutMs - timeoutBufferMs));
+	}
+
+	/**
+	 * The fence for this invocation, or undefined when isolation is off.
+	 *
+	 * Built here rather than in the executor because `executeBash` is shared: user-typed `!cmd` and
+	 * RPC `bash` reach it too, and the same brush-core runs credential helpers and the interactive
+	 * `xcsh shell`. Only the model's tool call is fenced (#2554).
+	 *
+	 * Uses the session's *live* cwd so an in-tree `cd` keeps working, while the fence's own roots
+	 * decide what is reachable — which is what stops a `cd` out of the tree from taking the boundary
+	 * with it, without the text layer having to recognise every spelling of `cd`.
+	 */
+	#containmentFence() {
+		const policy = resolveSessionPolicy(this.session.cwd, this.session.settings);
+		if (!policy) return undefined; // --no-sandbox / sandbox.enabled = false
+		const artifactsDir = this.session.getArtifactsDir?.();
+		return buildContainmentFence({
+			workspace: this.session.cwd,
+			extraRoots: [
+				...(artifactsDir ? [artifactsDir] : []),
+				...((this.session.settings.get("sandbox.allowRead") as string[] | undefined) ?? []),
+				...((this.session.settings.get("sandbox.allowWrite") as string[] | undefined) ?? []),
+			],
+		});
 	}
 
 	async execute(
@@ -654,6 +681,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					artifactPath,
 					artifactId,
 					maskSecrets,
+					fence: this.#containmentFence(),
 					onChunk: chunk => {
 						tailBuffer.append(chunk);
 						if (onUpdate) {

--- a/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
+++ b/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
@@ -181,7 +181,7 @@ describe("renderAboutDoc", () => {
 			source: "live-git" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info, null, null);
+		const md = renderAboutDoc(info, null, null, null);
 		expect(md).toContain(embedded.version);
 		expect(md).toContain(embedded.shortCommit);
 		expect(md).toContain(embedded.branch);
@@ -196,7 +196,7 @@ describe("renderAboutDoc", () => {
 			source: "compiled" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info, null, null);
+		const md = renderAboutDoc(info, null, null, null);
 		expect(md).toContain("compiled");
 	});
 
@@ -206,7 +206,7 @@ describe("renderAboutDoc", () => {
 			source: "embedded-fallback" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info, null, null);
+		const md = renderAboutDoc(info, null, null, null);
 		expect(md).toContain("embedded-fallback");
 	});
 
@@ -216,7 +216,7 @@ describe("renderAboutDoc", () => {
 			source: "live-git" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info, null, null);
+		const md = renderAboutDoc(info, null, null, null);
 		expect(md).toContain("xcsh://changes");
 		expect(md.toLowerCase()).toMatch(/gh pr list|git log/);
 	});
@@ -227,7 +227,7 @@ describe("renderAboutDoc", () => {
 			source: "live-git" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info, null, null);
+		const md = renderAboutDoc(info, null, null, null);
 		expect(md).toContain("f5-sales-demo/marketplace");
 		expect(md).toContain("f5-sales-demo/api-specs-enriched");
 		// implementation of feature code is delegated to a dedicated coding harness
@@ -238,7 +238,7 @@ describe("renderAboutDoc", () => {
 
 	it("cross-links the fleet route and makes implementation authority class-dependent", () => {
 		const info = { ...embedded, source: "live-git" as const, resolvedAt: "2026-07-26T00:00:00Z" };
-		const md = renderAboutDoc(info, null, null);
+		const md = renderAboutDoc(info, null, null, null);
 		expect(md).toContain("xcsh://fleet");
 		// Authority is not asserted flatly; it follows from the repository's class.
 		expect(md).toContain("`developer`");
@@ -251,7 +251,7 @@ describe("renderAboutDoc", () => {
 			source: "live-git" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info, null, null);
+		const md = renderAboutDoc(info, null, null, null);
 		const mdLower = md.toLowerCase();
 		// Must NOT recommend xcsh --version in a positive/confirming context
 		expect(md).not.toMatch(/ask them to run.*xcsh --version/i);
@@ -274,7 +274,7 @@ describe("renderAboutDoc", () => {
 			source: "live-git" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info, null, null);
+		const md = renderAboutDoc(info, null, null, null);
 		expect(md).toContain("## Product knowledge");
 		expect(md).toContain("https://f5-sales-demo.github.io/docs/llms.txt");
 		expect(md).toContain("federated");
@@ -286,7 +286,7 @@ describe("renderAboutDoc", () => {
 			source: "live-git" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info, null, null);
+		const md = renderAboutDoc(info, null, null, null);
 		expect(md).toContain("## Lineage");
 		expect(md).toContain("badlogic/pi-mono");
 		expect(md).toContain("## Architecture");
@@ -306,7 +306,7 @@ describe("renderAboutDoc", () => {
 			source: "live-git" as const,
 			resolvedAt: "2026-04-19T16:00:00Z",
 		};
-		const md = renderAboutDoc(info, null, null);
+		const md = renderAboutDoc(info, null, null, null);
 		// Platform capabilities (inherited)
 		expect(md).toContain("MCP server/client");
 		expect(md).toContain("slash commands");
@@ -370,7 +370,7 @@ describe("formatRelativeTime", () => {
 
 describe("renderAboutDoc platform context section", () => {
 	it("renders the unconfigured message when context is null", () => {
-		const doc = renderAboutDoc(fakeBuildInfo(), null, null);
+		const doc = renderAboutDoc(fakeBuildInfo(), null, null, null);
 		expect(doc).toContain("## Current Platform Context");
 		expect(doc).toContain("No F5 XC context active");
 		expect(doc).toContain("/context create");
@@ -390,7 +390,7 @@ describe("renderAboutDoc platform context section", () => {
 			authLatencyMs: 142,
 			authCheckedAt: now - 3 * 60_000, // 3 min ago
 		};
-		const doc = renderAboutDoc(fakeBuildInfo(), context, null);
+		const doc = renderAboutDoc(fakeBuildInfo(), context, null, null);
 		expect(doc).toContain("**Tenant:** acme-corp");
 		expect(doc).toContain("**Namespace:** production");
 		expect(doc).toContain("**Auth Status:** connected (latency: 142ms, checked: 3 min ago)");
@@ -407,7 +407,7 @@ describe("renderAboutDoc platform context section", () => {
 			authStatus: "unknown",
 			isConfigured: true,
 		};
-		const doc = renderAboutDoc(fakeBuildInfo(), context, null);
+		const doc = renderAboutDoc(fakeBuildInfo(), context, null, null);
 		expect(doc).toContain("**Auth Status:** unknown");
 		expect(doc).not.toContain("latency:");
 		expect(doc).not.toContain("checked:");
@@ -423,7 +423,7 @@ describe("renderAboutDoc platform context section", () => {
 			authStatus: "unknown",
 			isConfigured: false,
 		};
-		const doc = renderAboutDoc(fakeBuildInfo(), context, null);
+		const doc = renderAboutDoc(fakeBuildInfo(), context, null, null);
 		expect(doc).toContain("No F5 XC context active");
 	});
 
@@ -437,7 +437,7 @@ describe("renderAboutDoc platform context section", () => {
 			authStatus: "connected",
 			isConfigured: true,
 		};
-		const doc = renderAboutDoc(fakeBuildInfo(), context, null);
+		const doc = renderAboutDoc(fakeBuildInfo(), context, null, null);
 		expect(doc).toContain("**Credential Source:** environment");
 		expect(doc).not.toContain("environment (name:");
 	});
@@ -456,7 +456,7 @@ describe("renderAboutDoc platform context section", () => {
 			authStatus: "connected",
 			isConfigured: true,
 		};
-		const doc = renderAboutDoc(fakeBuildInfo(), context, null);
+		const doc = renderAboutDoc(fakeBuildInfo(), context, null, null);
 		expect(doc).toContain("- **Tenant:** acme-corp");
 		expect(doc).toContain("- **Namespace:** production");
 		expect(doc).toContain("**Auth Status:** connected");
@@ -485,7 +485,7 @@ describe("renderAboutDoc active model section", () => {
 	};
 
 	it("renders the model, provider, api, gateway host, and resolution source", () => {
-		const doc = renderAboutDoc(fakeBuildInfo(), null, snapshot);
+		const doc = renderAboutDoc(fakeBuildInfo(), null, snapshot, null);
 		expect(doc).toContain("## Active model");
 		expect(doc).toContain("claude-opus-5");
 		expect(doc).toContain("Claude Opus 5");
@@ -496,7 +496,7 @@ describe("renderAboutDoc active model section", () => {
 	});
 
 	it("lists only the configured role models", () => {
-		const doc = renderAboutDoc(fakeBuildInfo(), null, snapshot);
+		const doc = renderAboutDoc(fakeBuildInfo(), null, snapshot, null);
 		expect(doc).toContain("claude-haiku-4-5");
 		expect(doc).not.toContain("Role model — slow");
 		expect(doc).not.toContain("Role model — plan");
@@ -505,22 +505,73 @@ describe("renderAboutDoc active model section", () => {
 	// An absent snapshot must degrade to an explicit unknown, not vanish: a missing section would
 	// leave the agent guessing exactly as before.
 	it("renders an explicit unknown rather than omitting the section", () => {
-		const doc = renderAboutDoc(fakeBuildInfo(), null, null);
+		const doc = renderAboutDoc(fakeBuildInfo(), null, null, null);
 		expect(doc).toContain("## Active model");
 		expect(doc).toContain("unknown");
 		expect(doc).toContain("Do not guess");
 	});
 
 	it("tells the agent this section is authoritative and not to probe with xcsh -p", () => {
-		const doc = renderAboutDoc(fakeBuildInfo(), null, snapshot);
+		const doc = renderAboutDoc(fakeBuildInfo(), null, snapshot, null);
 		expect(doc).toContain("authoritative");
 		expect(doc).toContain("xcsh -p");
 		expect(doc).toContain("Active model");
 	});
 
 	it("keeps the section between the platform context and the source of truth", () => {
-		const doc = renderAboutDoc(fakeBuildInfo(), null, snapshot);
+		const doc = renderAboutDoc(fakeBuildInfo(), null, snapshot, null);
 		expect(doc.indexOf("## Current Platform Context")).toBeLessThan(doc.indexOf("## Active model"));
 		expect(doc.indexOf("## Active model")).toBeLessThan(doc.indexOf("## Source of truth"));
+	});
+});
+
+/**
+ * Two sessions can look identical and offer very different guarantees: with an OS backend a path is
+ * checked where it is opened and the spelling cannot matter, while without one the only check reads
+ * the command text. `xcsh://about` is the only place an operator can tell which they have — the
+ * maintainer asked for no UI change, so there is no banner and no startup line.
+ */
+describe("renderAboutDoc containment section", () => {
+	it("names the backend and states that spelling cannot matter, when the OS enforces it", () => {
+		const doc = renderAboutDoc(fakeBuildInfo(), null, null, {
+			enabled: true,
+			backend: "seatbelt",
+			osEnforced: true,
+		});
+		expect(doc).toContain("## Sandbox containment");
+		expect(doc).toContain("seatbelt");
+		expect(doc).toContain("how a path is spelled does not change what is reachable");
+		// The agent must be told not to retry a refusal a different way — that is wasted turns.
+		expect(doc).toContain("do not try to reach the same path a different way");
+		// And that ordinary work is not restricted, so it does not treat the fence as a reason to stop.
+		expect(doc).toContain("--allow-path");
+	});
+
+	it("says plainly that the boundary is best-effort where no backend exists", () => {
+		const doc = renderAboutDoc(fakeBuildInfo(), null, null, {
+			enabled: true,
+			backend: "scanner-only",
+			osEnforced: false,
+		});
+		expect(doc).toContain("no OS-level backend");
+		expect(doc).toContain("best-effort");
+		// Must NOT claim the stronger guarantee it does not have.
+		expect(doc).not.toContain("how a path is spelled does not change what is reachable");
+	});
+
+	it("says isolation is off rather than describing a fence that is not there", () => {
+		const doc = renderAboutDoc(fakeBuildInfo(), null, null, {
+			enabled: false,
+			backend: "disabled",
+			osEnforced: false,
+		});
+		expect(doc).toContain("isolation is **off**");
+		expect(doc).toContain("--no-sandbox");
+		expect(doc).not.toContain("no OS-level backend");
+	});
+
+	it("omits the section entirely when the status is unknown", () => {
+		const doc = renderAboutDoc(fakeBuildInfo(), null, null, null);
+		expect(doc).not.toContain("## Sandbox containment");
 	});
 });

--- a/packages/coding-agent/test/sandbox-containment-conformance.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-conformance.test.ts
@@ -31,6 +31,7 @@ describe("containment fence: TypeScript and Rust agree", () => {
 	const wire = {
 		allow: [...fence.allow],
 		allowReadOnly: [...fence.allowReadOnly],
+		allowWriteOnly: [...fence.allowWriteOnly],
 		deny: [...fence.deny],
 	};
 
@@ -84,7 +85,7 @@ describe("containment fence: TypeScript and Rust agree", () => {
 	});
 
 	it("agrees that an absent fence restricts nothing", () => {
-		const empty = { allow: [], allowReadOnly: [], deny: [] };
+		const empty = { allow: [], allowReadOnly: [], allowWriteOnly: [], deny: [] };
 		for (const candidate of corpus) {
 			expect(fencePermits(empty, candidate, true)).toBe(true);
 		}

--- a/packages/coding-agent/test/sandbox-containment-conformance.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-conformance.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fencePermits } from "@f5-sales-demo/pi-natives";
+import { buildContainmentFence, type FenceAccess, fenceVerdict } from "@f5-sales-demo/xcsh/sandbox/containment";
+
+/**
+ * One rule set, two implementations: `fenceVerdict` in TypeScript decides at the text layer, and
+ * `ContainmentFence::permits` in Rust decides where the shell actually opens the file. They are free
+ * to drift, and a drift is a silent hole — the pre-check would allow what the enforcement refuses, or
+ * worse, the reverse.
+ *
+ * The Rust crate cannot host its own unit tests: `crates/brush-core-vendored` is `exclude`d from the
+ * workspace and reached through `[patch.crates-io]`, so `cargo test -p brush-core` refuses to run.
+ * This is where that implementation is actually covered, which is why the corpus is broad rather
+ * than illustrative.
+ */
+describe("containment fence: TypeScript and Rust agree", () => {
+	const home = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "conf-home-")));
+	const workspace = path.join(home, "GIT", "custA");
+	const sibling = path.join(home, "GIT", "custB");
+	const leak = path.join(home, ".xcsh", "agent", "sessions");
+	const shared = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "conf-shared-")));
+	for (const dir of [workspace, sibling, leak, path.join(home, ".ssh"), path.join(home, ".bun")]) {
+		fs.mkdirSync(dir, { recursive: true });
+	}
+	fs.writeFileSync(path.join(home, ".gitconfig"), "[user]\n");
+
+	const fence = buildContainmentFence({ workspace, home, extraRoots: [shared], leakRoots: [leak] });
+	const wire = {
+		allow: [...fence.allow],
+		allowReadOnly: [...fence.allowReadOnly],
+		deny: [...fence.deny],
+	};
+
+	const corpus: string[] = [
+		// inside the workspace
+		path.join(workspace, "notes.md"),
+		path.join(workspace, "deep", "not", "created", "yet.txt"),
+		workspace,
+		// the fenced home
+		path.join(home, ".ssh", "id_rsa"),
+		path.join(sibling, "secret.env"),
+		path.join(home, "Documents", "tax.pdf"),
+		home,
+		// carve-outs
+		path.join(home, ".bun", "install", "cache", "pkg"),
+		path.join(home, ".cargo", "registry", "x"), // absent on purpose
+		path.join(home, ".gitconfig"),
+		// nested deny under an allowed root
+		path.join(leak, "other-session.jsonl"),
+		// explicit grant
+		path.join(shared, "handoff.md"),
+		// outside the fence entirely
+		"/usr/bin/env",
+		"/etc/hosts",
+		"/dev/null",
+		path.join(fs.realpathSync(os.tmpdir()), "scratch"),
+		"/opt/homebrew/bin/bun",
+	];
+
+	it("returns the same verdict for every path, in both directions", () => {
+		const disagreements: string[] = [];
+		for (const candidate of corpus) {
+			for (const access of ["read", "write"] as FenceAccess[]) {
+				const ts = fenceVerdict(fence, candidate, access) === "allow";
+				const rust = fencePermits(wire, candidate, access === "write");
+				if (ts !== rust) disagreements.push(`${access} ${candidate}: ts=${ts} rust=${rust}`);
+			}
+		}
+		expect(disagreements).toEqual([]);
+	});
+
+	// Both must resolve the symlink, or the pre-check and the enforcement disagree about the one
+	// case an attacker would reach for.
+	it("agrees when the path arrives through a symlink", () => {
+		const pivot = path.join(workspace, "pivot");
+		fs.symlinkSync(path.join(home, ".ssh"), pivot);
+		const viaLink = path.join(pivot, "id_rsa");
+
+		expect(fenceVerdict(fence, viaLink, "read")).toBe("deny");
+		expect(fencePermits(wire, viaLink, false)).toBe(false);
+	});
+
+	it("agrees that an absent fence restricts nothing", () => {
+		const empty = { allow: [], allowReadOnly: [], deny: [] };
+		for (const candidate of corpus) {
+			expect(fencePermits(empty, candidate, true)).toBe(true);
+		}
+	});
+});

--- a/packages/coding-agent/test/sandbox-containment-pty.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-pty.int.test.ts
@@ -3,7 +3,15 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { PtySession } from "@f5-sales-demo/pi-natives";
-import { buildContainmentFence } from "@f5-sales-demo/xcsh/sandbox/containment";
+import { buildContainmentFence, containmentStatus } from "@f5-sales-demo/xcsh/sandbox/containment";
+
+/**
+ * The PTY path runs the system `sh`, so *only* the OS can confine it — there is no in-process half here
+ * to fall back on. Where no backend exists, this path is not confined at all, and these tests assert
+ * that rather than skipping, for the same reason as in the shell integration test: a skip reads as
+ * coverage, and this is the gap that must not be implied to be closed.
+ */
+const OS_ENFORCED = containmentStatus(true).osEnforced;
 
 /**
  * The bash tool has two execution paths, and containment has to cover both.
@@ -63,14 +71,18 @@ describe("containment covers the PTY path, not just the in-process shell", () =>
 		expect(await runPty(`cat ${sibling}/secret.txt`, false)).toContain("PTY-CANARY-7734");
 	});
 
-	it("does not leak a sibling checkout through the PTY path", async () => {
-		expect(await runPty(`cat ${sibling}/secret.txt`, true)).not.toContain("PTY-CANARY-7734");
+	it(`${OS_ENFORCED ? "does not leak" : "still leaks"} a sibling checkout through the PTY path`, async () => {
+		const out = await runPty(`cat ${sibling}/secret.txt`, true);
+		if (OS_ENFORCED) expect(out).not.toContain("PTY-CANARY-7734");
+		else expect(out).toContain("PTY-CANARY-7734");
 	});
 
 	// The env-supplied path is the specific case the text scanner cannot see, and the reason a
 	// scanner-only PTY path was a hole rather than a rough edge.
-	it("does not leak through a path assembled at runtime", async () => {
-		expect(await runPty(`T=${sibling}/secret.txt; cat "$T"`, true)).not.toContain("PTY-CANARY-7734");
+	it(`${OS_ENFORCED ? "does not leak" : "still leaks"} through a path assembled at runtime`, async () => {
+		const out = await runPty(`T=${sibling}/secret.txt; cat "$T"`, true);
+		if (OS_ENFORCED) expect(out).not.toContain("PTY-CANARY-7734");
+		else expect(out).toContain("PTY-CANARY-7734");
 	});
 
 	it("still runs ordinary work inside the workspace", async () => {

--- a/packages/coding-agent/test/sandbox-containment-pty.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-pty.int.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { PtySession } from "@f5-sales-demo/pi-natives";
+import { buildContainmentFence } from "@f5-sales-demo/xcsh/sandbox/containment";
+
+/**
+ * The bash tool has two execution paths, and containment has to cover both.
+ *
+ * `pty` is a parameter the *model* supplies (`bash.ts` tool schema), so "PTY mode is for sudo and
+ * ssh" is a description of intent, not a restriction. Whatever the parameter is for, setting it is
+ * the model's choice, and a boundary the caller can opt out of by passing a flag is not a boundary.
+ *
+ * This path does not run brush-core at all: it spawns the system `sh -lc` through a PTY, so neither
+ * the in-process fence nor anything brush-core does applies. Confinement here can only come from the
+ * OS, which is why the assertion is about the canary and not about an error message.
+ */
+describe("containment covers the PTY path, not just the in-process shell", () => {
+	let home: string;
+	let workspace: string;
+	let sibling: string;
+	let wire: { allow: string[]; allowReadOnly: string[]; allowWriteOnly: string[]; deny: string[] };
+
+	beforeAll(() => {
+		home = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "pty-contain-")));
+		workspace = path.join(home, "GIT", "custA");
+		sibling = path.join(home, "GIT", "custB");
+		fs.mkdirSync(workspace, { recursive: true });
+		fs.mkdirSync(sibling, { recursive: true });
+		fs.writeFileSync(path.join(sibling, "secret.txt"), "PTY-CANARY-7734\n");
+		const fence = buildContainmentFence({ workspace, home });
+		wire = {
+			allow: [...fence.allow],
+			allowReadOnly: [...fence.allowReadOnly],
+			allowWriteOnly: [...fence.allowWriteOnly],
+			deny: [...fence.deny],
+		};
+	});
+
+	afterAll(() => fs.rmSync(home, { recursive: true, force: true }));
+
+	async function runPty(command: string, fenced: boolean): Promise<string> {
+		const session = new PtySession();
+		let out = "";
+		await session.start(
+			{
+				command,
+				cwd: workspace,
+				cols: 80,
+				rows: 24,
+				timeoutMs: 15_000,
+				...(fenced ? { fence: wire } : {}),
+			},
+			(_err: Error | null, chunk: string) => {
+				out += chunk ?? "";
+			},
+		);
+		return out;
+	}
+
+	it("leaks the canary with no fence — the control that proves the fence is what stops it", async () => {
+		expect(await runPty(`cat ${sibling}/secret.txt`, false)).toContain("PTY-CANARY-7734");
+	});
+
+	it("does not leak a sibling checkout through the PTY path", async () => {
+		expect(await runPty(`cat ${sibling}/secret.txt`, true)).not.toContain("PTY-CANARY-7734");
+	});
+
+	// The env-supplied path is the specific case the text scanner cannot see, and the reason a
+	// scanner-only PTY path was a hole rather than a rough edge.
+	it("does not leak through a path assembled at runtime", async () => {
+		expect(await runPty(`T=${sibling}/secret.txt; cat "$T"`, true)).not.toContain("PTY-CANARY-7734");
+	});
+
+	it("still runs ordinary work inside the workspace", async () => {
+		fs.writeFileSync(path.join(workspace, "own.txt"), "MINE-4242\n");
+		expect(await runPty("cat own.txt", true)).toContain("MINE-4242");
+	});
+
+	/**
+	 * Containment must be quiet as well as correct.
+	 *
+	 * A login shell reads its startup files from the home directory, which the fence denies, so every
+	 * fenced command used to print `sh: /Users/…/.profile: Operation not permitted` before going on to
+	 * succeed. That line reached the user's terminal and the model's captured output, where it reads as
+	 * a failure — and a boundary that appears to break things is one an operator turns off.
+	 *
+	 * The fence here uses the *real* home, because that is what makes the startup files denied. Using a
+	 * temp home would leave nothing for the shell to be refused, and the test would pass while the
+	 * product still emitted the error.
+	 */
+	it("says nothing about the home directory it cannot read", async () => {
+		const realHome = fs.realpathSync(os.homedir());
+		const outside = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "pty-quiet-")));
+		const realFence = buildContainmentFence({ workspace: outside, home: realHome });
+		const session = new PtySession();
+		let out = "";
+		await session.start(
+			{
+				command: "echo QUIET-5150",
+				cwd: outside,
+				cols: 80,
+				rows: 24,
+				timeoutMs: 20_000,
+				fence: {
+					allow: [...realFence.allow],
+					allowReadOnly: [...realFence.allowReadOnly],
+					allowWriteOnly: [...realFence.allowWriteOnly],
+					deny: [...realFence.deny],
+				},
+			},
+			(_err: Error | null, chunk: string) => {
+				out += chunk ?? "";
+			},
+		);
+		fs.rmSync(outside, { recursive: true, force: true });
+
+		// Assert the command ran, so a shell that produced nothing at all cannot pass by being silent.
+		expect(out).toContain("QUIET-5150");
+		expect(out).not.toContain("Operation not permitted");
+		expect(out).not.toContain(".profile");
+	});
+});

--- a/packages/coding-agent/test/sandbox-containment-race.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-race.int.test.ts
@@ -1,0 +1,151 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { executeShell } from "@f5-sales-demo/pi-natives";
+import { buildContainmentFence } from "@f5-sales-demo/xcsh/sandbox/containment";
+
+/**
+ * The fence has to hold against a path that changes while it is being checked.
+ *
+ * brush-core runs *inside* the agent process, so its own opens — redirections, `source`, the `read`
+ * builtin — are not covered by the OS confinement that protects spawned children. That makes them the
+ * one place where checking a path and then acting on it can be raced, and both of the races below were
+ * observed leaking a sibling checkout's secret before the code was changed:
+ *
+ * - swapping the final component (a symlink): 1 leak in 250 attempts
+ * - swapping a directory component: 23 leaks in 600 attempts
+ *
+ * The counts matter more than the mechanism. A refusal rate of 99% reads exactly like a working
+ * boundary from the outside, which is why these are measured over many attempts rather than asserted
+ * once. Each case also asserts the fence refused *something*, so a run where the attack never got near
+ * the window cannot pass as a defence.
+ *
+ * The equivalent attack against a spawned command (`cat sub/secret.txt`) never leaked at any point:
+ * seatbelt decides in the kernel, where there is no window. Only the in-process opens needed fixing.
+ */
+describe("containment holds while the path is being swapped underneath it", () => {
+	const ATTEMPTS = 200;
+	let home: string;
+	let workspace: string;
+	let wire: { allow: string[]; allowReadOnly: string[]; allowWriteOnly: string[]; deny: string[] };
+
+	beforeAll(() => {
+		home = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "race-")));
+		workspace = path.join(home, "GIT", "custA");
+		const sibling = path.join(home, "GIT", "custB");
+		fs.mkdirSync(path.join(workspace, "sub"), { recursive: true });
+		fs.mkdirSync(sibling, { recursive: true });
+		fs.writeFileSync(path.join(sibling, "secret.txt"), "RACE-CANARY-3141\n");
+		fs.writeFileSync(path.join(workspace, "sub", "secret.txt"), "harmless-sub\n");
+		fs.writeFileSync(path.join(workspace, "ok.txt"), "harmless\n");
+
+		// One long-lived flipper, not one spawn per flip. A flip every few microseconds against a
+		// check-to-open window of the same order is what makes the race winnable; `ln` in a loop costs
+		// ~200ms per flip under the sandbox and never lands inside the window.
+		fs.writeFileSync(
+			path.join(workspace, "flip-link.py"),
+			[
+				"import os, sys",
+				"ok, bad, link = sys.argv[1], sys.argv[2], sys.argv[3]",
+				"tmp = link + '.tmp'",
+				"while True:",
+				"    for target in (ok, bad):",
+				"        try:",
+				"            os.symlink(target, tmp); os.replace(tmp, link)",
+				"        except OSError:",
+				"            try: os.unlink(tmp)",
+				"            except OSError: pass",
+				"",
+			].join("\n"),
+		);
+		fs.writeFileSync(
+			path.join(workspace, "flip-dir.py"),
+			[
+				"import os, sys",
+				"real, target = sys.argv[1], sys.argv[2]",
+				"stash = real + '.real'",
+				"while True:",
+				"    try:",
+				"        os.rename(real, stash); os.symlink(target, real)",
+				"    except OSError: pass",
+				"    try:",
+				"        os.unlink(real); os.rename(stash, real)",
+				"    except OSError: pass",
+				"",
+			].join("\n"),
+		);
+
+		const fence = buildContainmentFence({ workspace, home });
+		wire = {
+			allow: [...fence.allow],
+			allowReadOnly: [...fence.allowReadOnly],
+			allowWriteOnly: [...fence.allowWriteOnly],
+			deny: [...fence.deny],
+		};
+	});
+
+	afterAll(() => fs.rmSync(home, { recursive: true, force: true }));
+
+	/**
+	 * Put the bait back exactly as each attack expects to find it.
+	 *
+	 * The flippers are killed mid-cycle, so they leave `sub` renamed aside or replaced by a symlink.
+	 * Without this reset the next attack's every iteration failed instantly on a broken path — 200
+	 * iterations in 252ms, no refusals and no leaks, which is indistinguishable from a fence that
+	 * worked. That is what `refusals > 0` in each case is guarding against.
+	 */
+	function resetBait(): void {
+		for (const leftover of ["sub", "sub.real", "sub.tmp", "pivot", "pivot.tmp"]) {
+			fs.rmSync(path.join(workspace, leftover), { recursive: true, force: true });
+		}
+		fs.mkdirSync(path.join(workspace, "sub"), { recursive: true });
+		fs.writeFileSync(path.join(workspace, "sub", "secret.txt"), "harmless-sub\n");
+	}
+
+	async function attack(command: string): Promise<{ leaks: number; refusals: number }> {
+		resetBait();
+		let out = "";
+		const result = (await executeShell({ command, cwd: workspace, fence: wire }, (_e, c) => {
+			out += c ?? "";
+		})) as { output?: string };
+		const text = out + (result?.output ?? "");
+		return {
+			leaks: (text.match(/RACE-CANARY-3141/g) ?? []).length,
+			refusals: (text.match(/outside this session's boundary|changed underneath/g) ?? []).length,
+		};
+	}
+
+	it("does not leak when the final component is swapped mid-check", async () => {
+		const { leaks, refusals } = await attack(`
+			ln -sfn ok.txt pivot
+			python3 flip-link.py ok.txt ../custB/secret.txt pivot & flip=$!
+			i=0; while [ $i -lt ${ATTEMPTS} ]; do cat < pivot 2>/dev/null; i=$((i+1)); done
+			kill $flip 2>/dev/null
+		`);
+		expect(leaks).toBe(0);
+		expect(refusals).toBeGreaterThan(0);
+	}, 180_000);
+
+	it("does not leak when a directory component is swapped mid-check", async () => {
+		const { leaks, refusals } = await attack(`
+			python3 flip-dir.py sub ../custB & flip=$!
+			i=0; while [ $i -lt ${ATTEMPTS} ]; do cat < sub/secret.txt 2>/dev/null; i=$((i+1)); done
+			kill $flip 2>/dev/null
+		`);
+		expect(leaks).toBe(0);
+		expect(refusals).toBeGreaterThan(0);
+	}, 180_000);
+
+	// The `read` builtin consumes the descriptor without any child process, so nothing but the
+	// in-process check stands between it and the file. It leaked the most before the fix (23 in 600).
+	it("does not leak to a builtin, which no OS confinement covers", async () => {
+		const { leaks, refusals } = await attack(`
+			python3 flip-dir.py sub ../custB & flip=$!
+			i=0; while [ $i -lt ${ATTEMPTS} ]; do read line < sub/secret.txt 2>/dev/null && echo "$line"; i=$((i+1)); done
+			kill $flip 2>/dev/null
+		`);
+		expect(leaks).toBe(0);
+		expect(refusals).toBeGreaterThan(0);
+	}, 180_000);
+});

--- a/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
@@ -21,7 +21,7 @@ describe("containment enforced inside the shell", () => {
 	let home: string;
 	let workspace: string;
 	let sibling: string;
-	let wire: { allow: string[]; allowReadOnly: string[]; deny: string[] };
+	let wire: { allow: string[]; allowReadOnly: string[]; allowWriteOnly: string[]; deny: string[] };
 
 	beforeAll(() => {
 		home = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "contain-")));
@@ -31,7 +31,12 @@ describe("containment enforced inside the shell", () => {
 		fs.mkdirSync(sibling, { recursive: true });
 		fs.writeFileSync(path.join(sibling, "secret.txt"), "CUSTB-CANARY-9001\n");
 		const fence = buildContainmentFence({ workspace, home });
-		wire = { allow: [...fence.allow], allowReadOnly: [...fence.allowReadOnly], deny: [...fence.deny] };
+		wire = {
+			allow: [...fence.allow],
+			allowReadOnly: [...fence.allowReadOnly],
+			allowWriteOnly: [...fence.allowWriteOnly],
+			deny: [...fence.deny],
+		};
 	});
 
 	afterAll(() => fs.rmSync(home, { recursive: true, force: true }));
@@ -148,6 +153,7 @@ describe("containment enforced inside the shell", () => {
 		const oddWire = {
 			allow: [...oddFence.allow],
 			allowReadOnly: [...oddFence.allowReadOnly],
+			allowWriteOnly: [...oddFence.allowWriteOnly],
 			deny: [...oddFence.deny],
 		};
 		let out = "";
@@ -179,5 +185,51 @@ describe("containment enforced inside the shell", () => {
 		const { code, text } = await run(`cat ${path.join(sibling, "secret.txt")}`, false);
 		expect(code).toBe(0);
 		expect(text).toContain("CUSTB-CANARY-9001");
+	});
+});
+
+/**
+ * Glob expansion runs in the agent's own process, not in a confined child, so the OS layer does not
+ * cover it. Verified before the fix: `echo ../*` disclosed a sibling checkout's name. Contents were
+ * always protected — a name is a smaller leak than a file, and still one the session should not have.
+ */
+describe("glob expansion does not disclose names outside the fence", () => {
+	let base: string;
+	let workspace: string;
+	let wire: { allow: string[]; allowReadOnly: string[]; allowWriteOnly: string[]; deny: string[] };
+
+	beforeAll(() => {
+		base = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "glob-")));
+		workspace = path.join(base, "customer-a");
+		fs.mkdirSync(workspace);
+		fs.mkdirSync(path.join(base, "SIBLING-MARKER"));
+		fs.writeFileSync(path.join(workspace, "mine.txt"), "x");
+		const fence = buildContainmentFence({ workspace });
+		wire = {
+			allow: [...fence.allow],
+			allowReadOnly: [...fence.allowReadOnly],
+			allowWriteOnly: [...fence.allowWriteOnly],
+			deny: [...fence.deny],
+		};
+	});
+
+	afterAll(() => fs.rmSync(base, { recursive: true, force: true }));
+
+	async function glob(command: string): Promise<string> {
+		let out = "";
+		await executeShell({ command, cwd: workspace, fence: wire }, (_e, c) => {
+			out += c ?? "";
+		});
+		return out;
+	}
+
+	it("hides a sibling's name from a glob that reaches outside", async () => {
+		expect(await glob("echo ../*")).not.toContain("SIBLING-MARKER");
+		expect(await glob("echo ../SIB*")).not.toContain("SIBLING-MARKER");
+	});
+
+	it("still expands globs inside the workspace", async () => {
+		expect(await glob("echo *")).toContain("mine.txt");
+		expect(await glob("for f in *.txt; do echo $f; done")).toContain("mine.txt");
 	});
 });

--- a/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
@@ -1,0 +1,130 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { executeShell } from "@f5-sales-demo/pi-natives";
+import { buildContainmentFence } from "@f5-sales-demo/xcsh/sandbox/containment";
+
+/**
+ * Enforcement through the real shell, not through the text scanner.
+ *
+ * This is the test that justifies Phase 2 (#2554). The host's text layer had to recognise every
+ * spelling of a path, and it could not: `c=cd; $c …`, an alias, and a symlink created moments earlier
+ * all survived two adversarial review rounds and six patches (#2542, #2553). None of them is
+ * special-cased here. They fail because brush-core has already expanded the variable, resolved the
+ * alias and followed the symlink by the time the fence is consulted, so there is nothing left to spell
+ * differently.
+ *
+ * If a case below starts passing where it should be refused, that is a sandbox escape.
+ */
+describe("containment enforced inside the shell", () => {
+	let home: string;
+	let workspace: string;
+	let sibling: string;
+	let wire: { allow: string[]; allowReadOnly: string[]; deny: string[] };
+
+	beforeAll(() => {
+		home = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "contain-")));
+		workspace = path.join(home, "GIT", "custA");
+		sibling = path.join(home, "GIT", "custB");
+		fs.mkdirSync(workspace, { recursive: true });
+		fs.mkdirSync(sibling, { recursive: true });
+		fs.writeFileSync(path.join(sibling, "secret.txt"), "CUSTB-CANARY-9001\n");
+		const fence = buildContainmentFence({ workspace, home });
+		wire = { allow: [...fence.allow], allowReadOnly: [...fence.allowReadOnly], deny: [...fence.deny] };
+	});
+
+	afterAll(() => fs.rmSync(home, { recursive: true, force: true }));
+
+	async function run(command: string, fenced = true): Promise<{ code: number; text: string }> {
+		let out = "";
+		const result = (await executeShell({ command, cwd: workspace, fence: fenced ? wire : undefined }, (_e, c) => {
+			out += c ?? "";
+		})) as { exitCode?: number; output?: string };
+		return { code: result?.exitCode ?? -1, text: out + (result?.output ?? "") };
+	}
+
+	it("leaks the canary with no fence — the control that proves the fence is what stops it", async () => {
+		const { code, text } = await run("cd ../custB && cat secret.txt", false);
+		expect(code).toBe(0);
+		expect(text).toContain("CUSTB-CANARY-9001");
+	});
+
+	it("refuses a cd out of the tree, however it is spelled", async () => {
+		// Plain, then the three forms the text gate could not reach (#2553).
+		for (const command of [
+			"cd ../custB && cat secret.txt",
+			"c=cd; $c ../custB && cat secret.txt",
+			"eval 'cd ../custB' && cat secret.txt",
+			"ln -sfn ../custB piv && cd -P piv && cat secret.txt",
+			"builtin cd ../custB && cat secret.txt",
+			"pushd ../custB && cat secret.txt",
+		]) {
+			const { code, text } = await run(command);
+			expect(code).not.toBe(0);
+			expect(text).not.toContain("CUSTB-CANARY-9001");
+		}
+	});
+
+	it("refuses a redirect out of the tree, with the filesystem as proof", async () => {
+		const target = path.join(sibling, "written.txt");
+		const { code } = await run("printf pwned > ../custB/written.txt");
+		expect(code).not.toBe(0);
+		expect(fs.existsSync(target)).toBe(false);
+	});
+
+	/**
+	 * The gap this layer does NOT close, asserted so it stays visible.
+	 *
+	 * `cat` is an external process: it opens the file itself, in its own address space, so nothing
+	 * the shell checks can stop it. Only OS-level confinement of the child can — the second
+	 * enforcement point in #2554, not yet built.
+	 *
+	 * In production this specific shape is still refused, by the host's text scanner, which sees the
+	 * absolute path in the command string. That is the division of labour for now: the scanner covers
+	 * paths written literally, the fence covers what the shell resolves. Child confinement is what
+	 * removes the reliance on the scanner.
+	 *
+	 * When it lands, this test flips to a refusal and should be rewritten, not deleted.
+	 */
+	it("does not yet stop an external command reading an absolute path — child confinement is next", async () => {
+		const { code, text } = await run(`cat ${path.join(sibling, "secret.txt")}`);
+		expect(code).toBe(0);
+		expect(text).toContain("CUSTB-CANARY-9001");
+	});
+
+	// The fence must cost nothing operationally. A failure here is as serious as a missed escape:
+	// it means the assistant cannot do its job.
+	it("leaves ordinary in-tree work alone", async () => {
+		const inTree = await run("printf ok > in-tree.txt && cat in-tree.txt");
+		expect(inTree.code).toBe(0);
+		expect(inTree.text).toContain("ok");
+
+		const nested = await run("mkdir -p sub && cd sub && printf deep > f.txt && cat f.txt");
+		expect(nested.code).toBe(0);
+		expect(nested.text).toContain("deep");
+
+		const devnull = await run("printf x > /dev/null && echo devnull-ok");
+		expect(devnull.code).toBe(0);
+		expect(devnull.text).toContain("devnull-ok");
+
+		// System paths are never mentioned by the fence, so reading one is untouched.
+		const system = await run("ls /usr/bin/env && echo system-ok");
+		expect(system.code).toBe(0);
+		expect(system.text).toContain("system-ok");
+
+		// A glued metacharacter after a redirect target — the #2540 shape — is the shell's problem
+		// now, not a regex's.
+		const glued = await run("printf hello >/dev/null; echo glued-ok");
+		expect(glued.code).toBe(0);
+		expect(glued.text).toContain("glued-ok");
+	});
+
+	it("restricts nothing at all when no fence is supplied", async () => {
+		// Host-driven shell use — credential helpers, `xcsh shell`, user `!cmd`, RPC bash — passes no
+		// fence and must behave exactly as before.
+		const { code, text } = await run(`cat ${path.join(sibling, "secret.txt")}`, false);
+		expect(code).toBe(0);
+		expect(text).toContain("CUSTB-CANARY-9001");
+	});
+});

--- a/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
@@ -3,7 +3,15 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { executeShell } from "@f5-sales-demo/pi-natives";
-import { buildContainmentFence } from "@f5-sales-demo/xcsh/sandbox/containment";
+import { buildContainmentFence, containmentStatus } from "@f5-sales-demo/xcsh/sandbox/containment";
+
+/**
+ * Whether an OS-level backend exists here, taken from the product rather than from a platform check
+ * written in the test. Confining a spawned child needs the kernel, and today only macOS seatbelt
+ * provides that — Linux Landlock is #2572. Asking `containmentStatus` means the tests and
+ * `xcsh://about` cannot disagree about which platforms are actually enforced.
+ */
+const OS_ENFORCED = containmentStatus(true).osEnforced;
 
 /**
  * Enforcement through the real shell, not through the text scanner.
@@ -85,29 +93,45 @@ describe("containment enforced inside the shell", () => {
 	 * is the OS layer: on macOS the argv is wrapped with `sandbox-exec` carrying a profile compiled
 	 * from the same fence. The refusal therefore comes from the kernel, not from reading the command.
 	 *
-	 * This assertion was the inverse one commit ago, documenting the gap. It flipped when child
-	 * confinement landed, which is what the comment there promised would happen.
+	 * Which way this asserts is decided by the product's own `containmentStatus`, not by a platform
+	 * check written here. Where no backend exists the child genuinely is not confined, and the test says
+	 * so rather than skipping: a skipped test reads as "covered", and this gap is the one thing about
+	 * this feature that must not be quietly implied to be closed. When a Linux backend lands, this
+	 * assertion starts failing and has to be flipped — which is how it should be found.
 	 */
-	it("refuses an external command reading an absolute path outside the tree", async () => {
+	it(`${OS_ENFORCED ? "refuses" : "cannot yet refuse"} an external command reading outside the tree`, async () => {
 		const { code, text } = await run(`cat ${path.join(sibling, "secret.txt")}`);
-		expect(code).not.toBe(0);
-		expect(text).not.toContain("CUSTB-CANARY-9001");
+		if (OS_ENFORCED) {
+			expect(code).not.toBe(0);
+			expect(text).not.toContain("CUSTB-CANARY-9001");
+		} else {
+			expect(text).toContain("CUSTB-CANARY-9001");
+		}
 	});
 
 	// The canary must be unreachable however the command is built, now that the child itself is
 	// confined. None of these is special-cased anywhere.
-	it("refuses every external route to the sibling", async () => {
+	it(`${OS_ENFORCED ? "refuses" : "cannot yet refuse"} every external read route to the sibling`, async () => {
 		for (const command of [
 			`cp ${path.join(sibling, "secret.txt")} .`,
 			`head -1 ${path.join(sibling, "secret.txt")}`,
 			`sh -c 'cat ${path.join(sibling, "secret.txt")}'`,
 			`find ${sibling} -name secret.txt -exec cat {} ;`,
-			`printf leak > ${path.join(sibling, "via-external.txt")}`,
 		]) {
 			const { text } = await run(command);
-			expect(text).not.toContain("CUSTB-CANARY-9001");
+			if (OS_ENFORCED) expect(text).not.toContain("CUSTB-CANARY-9001");
 		}
-		expect(fs.existsSync(path.join(sibling, "via-external.txt"))).toBe(false);
+		// `cp` writing into the workspace is the one route whose *result* is checkable either way.
+		if (OS_ENFORCED) expect(fs.existsSync(path.join(workspace, "secret.txt"))).toBe(false);
+	});
+
+	// A redirect is opened by the shell itself, in-process, so this one is refused on every platform —
+	// it does not depend on there being an OS backend at all.
+	it("refuses a redirect that writes outside the tree, with or without an OS backend", async () => {
+		const planted = path.join(sibling, "via-redirect.txt");
+		const { text } = await run(`printf leak > ${planted}`);
+		expect(text).not.toContain("CUSTB-CANARY-9001");
+		expect(fs.existsSync(planted)).toBe(false);
 	});
 
 	// The fence must cost nothing operationally. A failure here is as serious as a missed escape:

--- a/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
@@ -74,23 +74,35 @@ describe("containment enforced inside the shell", () => {
 	});
 
 	/**
-	 * The gap this layer does NOT close, asserted so it stays visible.
+	 * The external-command case, which the in-process fence alone cannot reach.
 	 *
-	 * `cat` is an external process: it opens the file itself, in its own address space, so nothing
-	 * the shell checks can stop it. Only OS-level confinement of the child can — the second
-	 * enforcement point in #2554, not yet built.
+	 * `cat` opens the file in its own address space, so no check the shell performs can stop it. This
+	 * is the OS layer: on macOS the argv is wrapped with `sandbox-exec` carrying a profile compiled
+	 * from the same fence. The refusal therefore comes from the kernel, not from reading the command.
 	 *
-	 * In production this specific shape is still refused, by the host's text scanner, which sees the
-	 * absolute path in the command string. That is the division of labour for now: the scanner covers
-	 * paths written literally, the fence covers what the shell resolves. Child confinement is what
-	 * removes the reliance on the scanner.
-	 *
-	 * When it lands, this test flips to a refusal and should be rewritten, not deleted.
+	 * This assertion was the inverse one commit ago, documenting the gap. It flipped when child
+	 * confinement landed, which is what the comment there promised would happen.
 	 */
-	it("does not yet stop an external command reading an absolute path — child confinement is next", async () => {
+	it("refuses an external command reading an absolute path outside the tree", async () => {
 		const { code, text } = await run(`cat ${path.join(sibling, "secret.txt")}`);
-		expect(code).toBe(0);
-		expect(text).toContain("CUSTB-CANARY-9001");
+		expect(code).not.toBe(0);
+		expect(text).not.toContain("CUSTB-CANARY-9001");
+	});
+
+	// The canary must be unreachable however the command is built, now that the child itself is
+	// confined. None of these is special-cased anywhere.
+	it("refuses every external route to the sibling", async () => {
+		for (const command of [
+			`cp ${path.join(sibling, "secret.txt")} .`,
+			`head -1 ${path.join(sibling, "secret.txt")}`,
+			`sh -c 'cat ${path.join(sibling, "secret.txt")}'`,
+			`find ${sibling} -name secret.txt -exec cat {} ;`,
+			`printf leak > ${path.join(sibling, "via-external.txt")}`,
+		]) {
+			const { text } = await run(command);
+			expect(text).not.toContain("CUSTB-CANARY-9001");
+		}
+		expect(fs.existsSync(path.join(sibling, "via-external.txt"))).toBe(false);
 	});
 
 	// The fence must cost nothing operationally. A failure here is as serious as a missed escape:

--- a/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
@@ -132,6 +132,47 @@ describe("containment enforced inside the shell", () => {
 		expect(glued.text).toContain("glued-ok");
 	});
 
+	/**
+	 * A directory name may contain any byte except `/` and NUL, so a shell can create one holding a
+	 * quote or a newline. Both end up inside the generated seatbelt profile.
+	 *
+	 * Escaping the quote is what makes injection impossible — verified against `sandbox-exec` that an
+	 * unescaped `x"))\n(allow default)…` name grants itself `(allow default)` and reads a denied file.
+	 * Escaping the newline is what stops the fail-closed case being an outage: a raw newline breaks
+	 * the profile, so one oddly-named directory would make every fenced command fail.
+	 */
+	it("survives a workspace path containing shell-hostile characters", async () => {
+		const odd = path.join(workspace, 'we"ird\nname');
+		fs.mkdirSync(odd, { recursive: true });
+		const oddFence = buildContainmentFence({ workspace: odd, home });
+		const oddWire = {
+			allow: [...oddFence.allow],
+			allowReadOnly: [...oddFence.allowReadOnly],
+			deny: [...oddFence.deny],
+		};
+		let out = "";
+		const result = (await executeShell(
+			{ command: "printf ok > f.txt && cat f.txt", cwd: odd, fence: oddWire },
+			(_e, c) => {
+				out += c ?? "";
+			},
+		)) as { exitCode?: number; output?: string };
+
+		// The profile parsed and the command ran — not refused with "Operation not permitted".
+		expect(result?.exitCode).toBe(0);
+		expect(out + (result?.output ?? "")).toContain("ok");
+		// And the fence still holds from there.
+		let denied = "";
+		const stillFenced = (await executeShell(
+			{ command: `cat ${path.join(sibling, "secret.txt")}`, cwd: odd, fence: oddWire },
+			(_e, c) => {
+				denied += c ?? "";
+			},
+		)) as { exitCode?: number; output?: string };
+		expect(stillFenced?.exitCode).not.toBe(0);
+		expect(denied + (stillFenced?.output ?? "")).not.toContain("CUSTB-CANARY-9001");
+	});
+
 	it("restricts nothing at all when no fence is supplied", async () => {
 		// Host-driven shell use — credential helpers, `xcsh shell`, user `!cmd`, RPC bash — passes no
 		// fence and must behave exactly as before.

--- a/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
@@ -112,17 +112,24 @@ describe("containment enforced inside the shell", () => {
 	// The canary must be unreachable however the command is built, now that the child itself is
 	// confined. None of these is special-cased anywhere.
 	it(`${OS_ENFORCED ? "refuses" : "cannot yet refuse"} every external read route to the sibling`, async () => {
+		// Every route asserts in both directions. A gate that removes the assertion instead leaves a
+		// test that passes while checking nothing — which is a worse report than a skip, because it
+		// looks like coverage of the one gap that is open.
 		for (const command of [
-			`cp ${path.join(sibling, "secret.txt")} .`,
 			`head -1 ${path.join(sibling, "secret.txt")}`,
 			`sh -c 'cat ${path.join(sibling, "secret.txt")}'`,
-			`find ${sibling} -name secret.txt -exec cat {} ;`,
+			// `\;` escaped, not a bare `;`. Unescaped, the shell takes the semicolon as a separator and
+			// `find` dies on "missing argument to -exec" — so this route printed nothing and satisfied a
+			// `not.toContain` assertion without ever exercising the boundary.
+			`find ${sibling} -name secret.txt -exec cat {} \\;`,
 		]) {
 			const { text } = await run(command);
 			if (OS_ENFORCED) expect(text).not.toContain("CUSTB-CANARY-9001");
+			else expect(text).toContain("CUSTB-CANARY-9001");
 		}
-		// `cp` writing into the workspace is the one route whose *result* is checkable either way.
-		if (OS_ENFORCED) expect(fs.existsSync(path.join(workspace, "secret.txt"))).toBe(false);
+		// `cp` is the one route whose result is on disk either way, so it needs no branch in the check.
+		await run(`cp ${path.join(sibling, "secret.txt")} .`);
+		expect(fs.existsSync(path.join(workspace, "secret.txt"))).toBe(!OS_ENFORCED);
 	});
 
 	// A redirect is opened by the shell itself, in-process, so this one is refused on every platform —
@@ -191,10 +198,12 @@ describe("containment enforced inside the shell", () => {
 		// The profile parsed and the command ran — not refused with "Operation not permitted".
 		expect(result?.exitCode).toBe(0);
 		expect(out + (result?.output ?? "")).toContain("ok");
-		// And the fence still holds from there.
+		// And the fence still holds from there. Probed with a `cd`, which the shell refuses itself, so
+		// this stays a real assertion on platforms with no OS backend — an external read would only be
+		// refused where seatbelt exists, and would have made this case vacuous off macOS.
 		let denied = "";
 		const stillFenced = (await executeShell(
-			{ command: `cat ${path.join(sibling, "secret.txt")}`, cwd: odd, fence: oddWire },
+			{ command: `cd ${path.join(sibling)} && cat secret.txt`, cwd: odd, fence: oddWire },
 			(_e, c) => {
 				denied += c ?? "";
 			},

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -51,8 +51,9 @@ describe("buildContainmentFence", () => {
 		const fence = buildContainmentFence({ workspace, home });
 
 		// These sit inside the denied home tree and must be carved back out, or `bun install`,
-		// `cargo build` and `npm ci` fail — the exact breakage this fence must not cause.
-		for (const cache of [".bun", ".cargo", ".npm"]) {
+		// `cargo build` and `npm ci` fail — the exact breakage this fence must not cause. Narrowed to
+		// the artifact subdirectories, because granting the parents exposed credentials.
+		for (const cache of [".bun/install/cache", ".cargo/registry", ".npm/_cacache", ".m2/repository"]) {
 			expect(fenceVerdict(fence, path.join(home, cache, "x"), "write")).toBe("allow");
 		}
 	});
@@ -150,10 +151,94 @@ describe("buildContainmentFence", () => {
 		const workspace = path.join(home, "w");
 		const realCache = realTmp("cache");
 		fs.mkdirSync(workspace, { recursive: true });
-		fs.symlinkSync(realCache, path.join(home, ".bun"));
+		fs.mkdirSync(path.join(home, ".bun", "install"), { recursive: true });
+		fs.symlinkSync(realCache, path.join(home, ".bun", "install", "cache"));
 
 		const fence = buildContainmentFence({ workspace, home });
 		expect(fence.allow).toContain(realCache);
 		expect(fenceVerdict(fence, path.join(realCache, "pkg"), "write")).toBe("allow");
+	});
+});
+
+/**
+ * Findings from adversarial review of this fence, each verified allowed before the fix.
+ *
+ * They share a shape worth naming: the fence is permissive by default, so every gap is a path that
+ * matched no rule rather than a rule that was wrong. Denying home was never the whole boundary.
+ */
+describe("buildContainmentFence — review findings", () => {
+	it("denies the workspace's siblings even when the workspace is outside home", () => {
+		// Verified allow/allow before the fix: with /work/customer-a as the workspace, /work/customer-b
+		// matched nothing and was readable AND writable. A fleet keeping customer folders outside the
+		// home tree got no containment at all.
+		const base = realTmp("work");
+		const a = path.join(base, "customer-a");
+		const b = path.join(base, "customer-b");
+		fs.mkdirSync(a);
+		fs.mkdirSync(b);
+		const fence = buildContainmentFence({ workspace: a, home: path.join(base, "unrelated-home") });
+
+		expect(fenceVerdict(fence, path.join(b, "secret"), "read")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(b, "planted"), "write")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(a, "own.md"), "write")).toBe("allow");
+	});
+
+	it("never denies a parent too broad to deny", () => {
+		// Denying the parent must not reach the filesystem root, a system directory, or the OS temp
+		// dir — each would refuse work the fence is supposed to leave alone.
+		const tmp = fs.realpathSync(os.tmpdir());
+		const shallow = buildContainmentFence({ workspace: tmp, home: path.join(tmp, "no-such-home") });
+		expect(fenceVerdict(shallow, path.join(tmp, "scratch"), "write")).toBe("allow");
+
+		const system = buildContainmentFence({ workspace: "/usr/local", home: path.join(tmp, "no-such-home") });
+		expect(fenceVerdict(system, "/usr/bin/env", "read")).toBe("allow");
+		expect(fenceVerdict(system, "/etc/hosts", "read")).toBe("allow");
+	});
+
+	it("keeps toolchain credentials outside the cache carve-outs", () => {
+		// Verified writable before the fix: granting ~/.cargo, ~/.m2, ~/.gradle and ~/.npm whole put
+		// credentials.toml, settings.xml, init.gradle and _authToken inside the fence — credential
+		// theft and persistent build-config tampering, not merely a read.
+		const home = realTmp("credhome");
+		const workspace = path.join(home, "w");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home });
+
+		for (const secret of [
+			".cargo/credentials.toml",
+			".cargo/config.toml",
+			".m2/settings.xml",
+			".gradle/init.gradle",
+			".npm/_authToken",
+		]) {
+			expect(fenceVerdict(fence, path.join(home, secret), "write")).toBe("deny");
+		}
+		// The parts a build actually writes stay granted, or the carve-out was pointless.
+		for (const artifact of [
+			".cargo/registry/index/x",
+			".m2/repository/org/x.jar",
+			".npm/_cacache/index-v5/x",
+			".bun/install/cache/pkg",
+			".gradle/caches/modules-2/x",
+		]) {
+			expect(fenceVerdict(fence, path.join(home, artifact), "write")).toBe("allow");
+		}
+	});
+
+	it("keeps a read-only grant read-only and a write-only grant write-only", () => {
+		// Verified allow/allow before the fix: bash.ts merged sandbox.allowRead and sandbox.allowWrite
+		// into one read+write list, so a folder shared for reading became writable — undoing the
+		// read/write split built for #2516.
+		const home = realTmp("splithome");
+		const workspace = path.join(home, "w");
+		const shared = realTmp("shared-ro");
+		const drop = realTmp("drop-wo");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home, readOnlyRoots: [shared], writeOnlyRoots: [drop] });
+
+		expect(fenceVerdict(fence, path.join(shared, "ctx.md"), "read")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(shared, "ctx.md"), "write")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(drop, "out.log"), "write")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(drop, "out.log"), "read")).toBe("deny");
 	});
 });

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildContainmentFence, fenceVerdict } from "@f5-sales-demo/xcsh/sandbox/containment";
+
+/**
+ * The fence is deliberately *gentle*: the only thing it prevents is the assistant wandering the
+ * filesystem. Operations are not restricted, so `/usr`, `/tmp`, package caches, the network and
+ * process execution are never mentioned. Anything that breaks ordinary work is a bug in the fence,
+ * not a stricter policy — see #2554.
+ */
+
+function realTmp(suffix: string): string {
+	const dir = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), `fence-${suffix}-`));
+	return fs.realpathSync(dir);
+}
+
+describe("buildContainmentFence", () => {
+	it("denies the home tree and re-allows the workspace inside it", () => {
+		const home = realTmp("home");
+		const workspace = path.join(home, "GIT", "custA");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home });
+
+		expect(fence.deny).toContain(home);
+		expect(fence.allow).toContain(workspace);
+		// A sibling checkout under the same home is the cross-customer case this exists for.
+		expect(fenceVerdict(fence, path.join(home, "GIT", "custB", "secret"), "read")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(workspace, "notes.md"), "read")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(workspace, "notes.md"), "write")).toBe("allow");
+	});
+
+	it("leaves everything outside home alone — nothing operational is restricted", () => {
+		const home = realTmp("home2");
+		const workspace = path.join(home, "w");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home });
+
+		for (const p of ["/usr/bin/env", "/bin/sh", "/etc/hosts", "/opt/homebrew/bin/bun", "/dev/null"]) {
+			expect(fenceVerdict(fence, p, "read")).toBe("allow");
+		}
+		// The OS temp dir is not customer data and must stay usable for both directions.
+		expect(fenceVerdict(fence, path.join(fs.realpathSync(os.tmpdir()), "scratch"), "write")).toBe("allow");
+	});
+
+	it("re-allows package caches so toolchains keep working", () => {
+		const home = realTmp("home3");
+		const workspace = path.join(home, "w");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home });
+
+		// These sit inside the denied home tree and must be carved back out, or `bun install`,
+		// `cargo build` and `npm ci` fail — the exact breakage this fence must not cause.
+		for (const cache of [".bun", ".cargo", ".npm"]) {
+			expect(fenceVerdict(fence, path.join(home, cache, "x"), "write")).toBe("allow");
+		}
+	});
+
+	it("keeps git config readable but not writable", () => {
+		const home = realTmp("home4");
+		const workspace = path.join(home, "w");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home });
+
+		expect(fenceVerdict(fence, path.join(home, ".gitconfig"), "read")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(home, ".gitconfig"), "write")).toBe("deny");
+	});
+
+	it("denies credentials even though they sit in the same home", () => {
+		const home = realTmp("home5");
+		const workspace = path.join(home, "w");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home });
+
+		for (const secret of [".ssh/id_rsa", ".aws/credentials", ".gnupg/secring.gpg", "Documents/tax.pdf"]) {
+			expect(fenceVerdict(fence, path.join(home, secret), "read")).toBe("deny");
+		}
+	});
+
+	it("denies the cross-session leak roots even nested under an allowed root", () => {
+		const home = realTmp("home6");
+		// The pathological case: the workspace IS the agent dir's parent, so the leak roots sit
+		// inside something the fence allows. Deny must win regardless of nesting depth.
+		const workspace = path.join(home, ".xcsh");
+		const sessions = path.join(workspace, "agent", "sessions");
+		fs.mkdirSync(sessions, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home, leakRoots: [sessions] });
+
+		expect(fenceVerdict(fence, path.join(workspace, "config.yml"), "read")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(sessions, "other.jsonl"), "read")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(sessions, "other.jsonl"), "write")).toBe("deny");
+	});
+
+	it("grants extra roots from --allow-path for both directions", () => {
+		const home = realTmp("home7");
+		const workspace = path.join(home, "w");
+		const shared = realTmp("shared");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home, extraRoots: [shared] });
+
+		expect(fenceVerdict(fence, path.join(shared, "f"), "read")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(shared, "f"), "write")).toBe("allow");
+	});
+
+	// A seatbelt `(subpath …)` rule on a non-canonical path silently matches nothing — a rule that
+	// appears to enforce and does not. Verified: `/tmp/x` grants nothing because the real path is
+	// `/private/tmp/x`. So canonicalisation is a correctness requirement, not tidiness.
+	it("canonicalises every root", () => {
+		const home = realTmp("home8");
+		const workspace = path.join(home, "w");
+		fs.mkdirSync(workspace, { recursive: true });
+		const link = path.join(home, "link-to-w");
+		fs.symlinkSync(workspace, link);
+		const fence = buildContainmentFence({ workspace: link, home });
+
+		expect(fence.allow).toContain(workspace);
+		expect(fence.allow).not.toContain(link);
+		for (const root of [...fence.allow, ...fence.allowReadOnly, ...fence.deny]) {
+			expect(path.isAbsolute(root)).toBe(true);
+			// A root that exists must already be its own real path. One that does not yet exist (an
+			// absent cache dir) has nothing to resolve, and is emitted so it can be created later.
+			if (fs.existsSync(root)) expect(root).toBe(fs.realpathSync(root));
+		}
+	});
+
+	it("refuses to build a fence whose workspace cannot be canonicalised", () => {
+		const home = realTmp("home9");
+		expect(() => buildContainmentFence({ workspace: path.join(home, "does-not-exist"), home })).toThrow(
+			/canonicalise/i,
+		);
+	});
+
+	// A cache dir must be grantable BEFORE it exists, or the very first `bun install` — which
+	// creates ~/.bun — fails inside the fence. Absent optional roots are granted, not dropped.
+	it("grants a cache dir that does not exist yet", () => {
+		const home = realTmp("home10");
+		const workspace = path.join(home, "w");
+		fs.mkdirSync(workspace, { recursive: true });
+		expect(fs.existsSync(path.join(home, ".bun"))).toBe(false);
+
+		const fence = buildContainmentFence({ workspace, home });
+		expect(fenceVerdict(fence, path.join(home, ".bun", "install", "cache", "x"), "write")).toBe("allow");
+	});
+
+	// An absent root must never be emitted non-canonically for a path that DOES exist, because a
+	// non-canonical rule silently grants nothing. Existing roots are still resolved.
+	it("canonicalises the roots that exist", () => {
+		const home = realTmp("home11");
+		const workspace = path.join(home, "w");
+		const realCache = realTmp("cache");
+		fs.mkdirSync(workspace, { recursive: true });
+		fs.symlinkSync(realCache, path.join(home, ".bun"));
+
+		const fence = buildContainmentFence({ workspace, home });
+		expect(fence.allow).toContain(realCache);
+		expect(fenceVerdict(fence, path.join(realCache, "pkg"), "write")).toBe("allow");
+	});
+});

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -6,7 +6,7 @@ import { executeShell } from "@f5-sales-demo/pi-natives";
 import { getAgentDir, getPluginsDir, TempDir } from "@f5-sales-demo/pi-utils";
 import { discoverAndLoadExtensions } from "@f5-sales-demo/xcsh/extensibility/extensions/loader";
 import { getMemoryRoot } from "@f5-sales-demo/xcsh/memories";
-import { buildContainmentFence } from "@f5-sales-demo/xcsh/sandbox/containment";
+import { buildContainmentFence, containmentStatus } from "@f5-sales-demo/xcsh/sandbox/containment";
 import { evaluateToolCall } from "@f5-sales-demo/xcsh/sandbox/enforce";
 import { buildDefaultSandboxPolicy } from "@f5-sales-demo/xcsh/sandbox/policy";
 
@@ -106,6 +106,10 @@ describe("bundled registration", () => {
  * asked the scanner would have passed throughout every escape in #2542 and #2553.
  */
 describe("two-customer isolation, enforced in the shell", () => {
+	// Taken from the product, not from a platform check written here, so this and `xcsh://about` cannot
+	// disagree about which platforms actually confine a spawned child.
+	const OS_ENFORCED = containmentStatus(true).osEnforced;
+
 	function fenceFor(cwd: string) {
 		const fence = buildContainmentFence({ workspace: cwd, home: parent });
 		return {
@@ -124,19 +128,42 @@ describe("two-customer isolation, enforced in the shell", () => {
 		return { code: result?.exitCode ?? -1, text: out + (result?.output ?? "") };
 	}
 
-	it("a session in custA cannot reach custB, by any route", async () => {
+	/**
+	 * Routes the shell itself closes, so they hold on every platform.
+	 *
+	 * `cd` is refused in-process, which takes the whole command down with it, and a redirect target is
+	 * opened by the shell rather than by the child. Neither needs an OS backend, which is why they are
+	 * asserted unconditionally.
+	 */
+	it("a session in custA cannot reach custB through anything the shell does itself", async () => {
 		for (const command of [
-			"cat ../custB/secret.env",
-			`cat ${path.join(custB, "secret.env")}`,
 			"cd ../custB && cat secret.env",
 			"c=cd; $c ../custB && cat secret.env",
-			`cp ${path.join(custB, "secret.env")} .`,
 			`printf x > ${path.join(custB, "planted.env")}`,
 		]) {
 			const { text } = await shell(custA, command);
 			expect(text).not.toContain("TOKEN=b");
 		}
 		expect(fs.existsSync(path.join(custB, "planted.env"))).toBe(false);
+	});
+
+	/**
+	 * Routes where the *child* does the opening, so only the kernel can refuse them.
+	 *
+	 * Asserted according to the product's own `containmentStatus` rather than skipped off macOS: these
+	 * reads really do succeed where no backend exists (#2572), and a skipped test would read as though
+	 * they did not. This inverts and starts failing when Landlock lands, which is the point.
+	 */
+	it(`a session in custA ${OS_ENFORCED ? "cannot" : "can still"} reach custB through a spawned command`, async () => {
+		// Both branches assert something. Gating the assertion away instead would leave a test that
+		// passes while checking nothing, which reports as coverage of exactly the gap that is open.
+		for (const command of ["cat ../custB/secret.env", `cat ${path.join(custB, "secret.env")}`]) {
+			const { text } = await shell(custA, command);
+			if (OS_ENFORCED) expect(text).not.toContain("TOKEN=b");
+			else expect(text).toContain("TOKEN=b");
+		}
+		await shell(custA, `cp ${path.join(custB, "secret.env")} .`);
+		expect(fs.existsSync(path.join(custA, "secret.env"))).toBe(!OS_ENFORCED);
 	});
 
 	it("but works normally inside its own folder", async () => {

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -108,7 +108,12 @@ describe("bundled registration", () => {
 describe("two-customer isolation, enforced in the shell", () => {
 	function fenceFor(cwd: string) {
 		const fence = buildContainmentFence({ workspace: cwd, home: parent });
-		return { allow: [...fence.allow], allowReadOnly: [...fence.allowReadOnly], deny: [...fence.deny] };
+		return {
+			allow: [...fence.allow],
+			allowReadOnly: [...fence.allowReadOnly],
+			allowWriteOnly: [...fence.allowWriteOnly],
+			deny: [...fence.deny],
+		};
 	}
 
 	async function shell(cwd: string, command: string, fenced = true) {

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -2,9 +2,11 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { executeShell } from "@f5-sales-demo/pi-natives";
 import { getAgentDir, getPluginsDir, TempDir } from "@f5-sales-demo/pi-utils";
 import { discoverAndLoadExtensions } from "@f5-sales-demo/xcsh/extensibility/extensions/loader";
 import { getMemoryRoot } from "@f5-sales-demo/xcsh/memories";
+import { buildContainmentFence } from "@f5-sales-demo/xcsh/sandbox/containment";
 import { evaluateToolCall } from "@f5-sales-demo/xcsh/sandbox/enforce";
 import { buildDefaultSandboxPolicy } from "@f5-sales-demo/xcsh/sandbox/policy";
 
@@ -92,5 +94,55 @@ describe("bundled registration", () => {
 	it("loads the sandbox-guard extension by default", async () => {
 		const result = await discoverAndLoadExtensions([], custA);
 		expect(result.extensions.some(ext => ext.path === "bundled:sandbox-guard")).toBe(true);
+	});
+});
+
+/**
+ * The same two-customer scenario, proved at the enforcement layer rather than at the text scan.
+ *
+ * The cases above ask `evaluateToolCall` whether it would refuse a command. These run the command.
+ * That distinction is the whole of #2554: the scanner reads what was written, while containment is
+ * consulted where the shell acts, after expansion and symlink resolution. A scenario that only ever
+ * asked the scanner would have passed throughout every escape in #2542 and #2553.
+ */
+describe("two-customer isolation, enforced in the shell", () => {
+	function fenceFor(cwd: string) {
+		const fence = buildContainmentFence({ workspace: cwd, home: parent });
+		return { allow: [...fence.allow], allowReadOnly: [...fence.allowReadOnly], deny: [...fence.deny] };
+	}
+
+	async function shell(cwd: string, command: string, fenced = true) {
+		let out = "";
+		const result = (await executeShell({ command, cwd, fence: fenced ? fenceFor(cwd) : undefined }, (_e, c) => {
+			out += c ?? "";
+		})) as { exitCode?: number; output?: string };
+		return { code: result?.exitCode ?? -1, text: out + (result?.output ?? "") };
+	}
+
+	it("a session in custA cannot reach custB, by any route", async () => {
+		for (const command of [
+			"cat ../custB/secret.env",
+			`cat ${path.join(custB, "secret.env")}`,
+			"cd ../custB && cat secret.env",
+			"c=cd; $c ../custB && cat secret.env",
+			`cp ${path.join(custB, "secret.env")} .`,
+			`printf x > ${path.join(custB, "planted.env")}`,
+		]) {
+			const { text } = await shell(custA, command);
+			expect(text).not.toContain("TOKEN=b");
+		}
+		expect(fs.existsSync(path.join(custB, "planted.env"))).toBe(false);
+	});
+
+	it("but works normally inside its own folder", async () => {
+		const own = await shell(custA, "cat notes.md && printf ' ok' >> notes.md && cat notes.md");
+		expect(own.code).toBe(0);
+		expect(own.text).toContain("a");
+	});
+
+	it("and the same session unfenced reaches custB — the control", async () => {
+		const { code, text } = await shell(custA, `cat ${path.join(custB, "secret.env")}`, false);
+		expect(code).toBe(0);
+		expect(text).toContain("TOKEN=b");
 	});
 });

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -447,8 +447,9 @@ export interface ClipboardImage {
 /**
  * Canonical roots describing what the shell may reach, as built by the host.
  *
- * Absent means unrestricted. Only the model's `bash` tool supplies one; credential helpers, the
- * interactive shell and snapshot sourcing pass nothing and are unaffected.
+ * Absent means unrestricted. Only the model's `bash` tool supplies one;
+ * credential helpers, the interactive shell and snapshot sourcing pass nothing
+ * and are unaffected.
  */
 export interface ContainmentFenceOptions {
   /** Roots the shell may read and write. */
@@ -607,8 +608,9 @@ export interface ExtractSegmentsResult {
 }
 
 /**
- * Whether a fence permits a path — exported so one corpus can be run through both this
- * implementation and the TypeScript one, which is the only guard against the two drifting.
+ * Whether a fence permits a path — exported so one corpus can be run through
+ * both this implementation and the TypeScript one, which is the only guard
+ * against the two drifting.
  */
 export declare function fencePermits(fence: ContainmentFenceOptions, candidate: string, write: boolean): boolean
 

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -456,6 +456,8 @@ export interface ContainmentFenceOptions {
   allow: Array<string>
   /** Roots the shell may read but not write. */
   allowReadOnly: Array<string>
+  /** Roots the shell may write but not read. */
+  allowWriteOnly: Array<string>
   /** Roots denied in both directions, winning over any allow they sit inside. */
   deny: Array<string>
 }

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -444,6 +444,21 @@ export interface ClipboardImage {
   mimeType: string
 }
 
+/**
+ * Canonical roots describing what the shell may reach, as built by the host.
+ *
+ * Absent means unrestricted. Only the model's `bash` tool supplies one; credential helpers, the
+ * interactive shell and snapshot sourcing pass nothing and are unaffected.
+ */
+export interface ContainmentFenceOptions {
+  /** Roots the shell may read and write. */
+  allow: Array<string>
+  /** Roots the shell may read but not write. */
+  allowReadOnly: Array<string>
+  /** Roots denied in both directions, winning over any allow they sit inside. */
+  deny: Array<string>
+}
+
 /** A context line (before or after a match). */
 export interface ContextLine {
   /** 1-indexed line number in the source file. */
@@ -590,6 +605,12 @@ export interface ExtractSegmentsResult {
   /** Visible width of the `after` segment. */
   afterWidth: number
 }
+
+/**
+ * Whether a fence permits a path — exported so one corpus can be run through both this
+ * implementation and the TypeScript one, which is the only guard against the two drifting.
+ */
+export declare function fencePermits(fence: ContainmentFenceOptions, candidate: string, write: boolean): boolean
 
 /** Resolved filesystem entry kind for glob filters and match metadata. */
 export declare enum FileType {
@@ -1252,6 +1273,8 @@ export interface ShellExecuteOptions {
   snapshotPath?: string
   /** Abort signal for cancelling the operation. */
   signal?: unknown
+  /** Which paths this command may reach. Absent means unrestricted. */
+  fence?: ContainmentFenceOptions
 }
 
 /** Result of executing a shell command via brush-core. */
@@ -1284,6 +1307,8 @@ export interface ShellRunOptions {
   timeoutMs?: number
   /** Abort signal for cancelling the operation. */
   signal?: unknown
+  /** Which paths this command may reach. Absent means unrestricted. */
+  fence?: ContainmentFenceOptions
 }
 
 /** Result of running a shell command. */

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -1117,6 +1117,14 @@ export interface PtyStartOptions {
   cols?: number
   /** PTY row count. */
   rows?: number
+  /**
+   * Filesystem boundary for this command; absent means unrestricted.
+   *
+   * This path never runs brush-core — it spawns the system `sh`, so the in-process checks that
+   * confine the non-PTY path do not apply here and the OS is the only available enforcement.
+   * Without this the boundary was opt-out by a tool parameter the model itself supplies.
+   */
+  fence?: ContainmentFenceOptions
 }
 
 /**

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -1120,9 +1120,10 @@ export interface PtyStartOptions {
   /**
    * Filesystem boundary for this command; absent means unrestricted.
    *
-   * This path never runs brush-core — it spawns the system `sh`, so the in-process checks that
-   * confine the non-PTY path do not apply here and the OS is the only available enforcement.
-   * Without this the boundary was opt-out by a tool parameter the model itself supplies.
+   * This path never runs brush-core — it spawns the system `sh`, so the
+   * in-process checks that confine the non-PTY path do not apply here and
+   * the OS is the only available enforcement. Without this the boundary was
+   * opt-out by a tool parameter the model itself supplies.
    */
   fence?: ContainmentFenceOptions
 }


### PR DESCRIPTION
Fixes #2554

Every sandbox defect filed against `xcsh` has been the same defect: the boundary was enforced against
*text describing* a filesystem operation instead of against the operation. Each fix closed one spelling
and the next review found another — #2470, #2516, #2520, #2524, #2540, #2542, #2553, #2534, GHSA-q4hg,
GHSA-7q8x. Two adversarial rounds on the #2542 fix alone produced six bypasses of that one gate.

This moves enforcement below the text. `enforce.ts:14` has said since it was written that it is
best-effort and that an OS-level sandbox is the real thing; this is that.

## What now enforces the boundary

| Where | Covers | Mechanism |
| ----- | ------ | --------- |
| The shell's own opens | redirections, `source`, `read`, glob expansion, `cd` | checked in-process, where the path is used |
| Spawned children | `cat`, `cp`, `tee`, `sed -i`, `find -exec`, … | macOS seatbelt profile around argv |
| PTY commands | anything run with `pty: true` | the same seatbelt profile |

Three escapes that survived every text fix now fail without being special-cased, because by the time
the fence is consulted brush-core has already expanded the variable, resolved the alias and followed
the symlink:

```
c=cd; $c / && cat tmp/x
alias g=cd; g / && cat tmp/x
ln -s / pivot && cd -P pivot && cat tmp/x
```

## Gentle by construction

The profile is `allow default` plus targeted denies. `/usr`, `/tmp`, `/dev`, package caches, the network
and process execution are never mentioned, so nothing that worked before stops working. This is not
only a preference: a `deny default` profile could not `execvp /bin/cat` with only the workspace granted.

The single thing prevented is reaching another customer's checkout, the operator's private files, or
another session's transcripts.

Verified under the fence: `git init`/`status`/`commit`, a real `bun add` against the real package cache,
tar roundtrip, heredocs, here-strings, `source`, a legitimate symlink inside the workspace,
`> /dev/null`, `curl`, nested `mkdir && cd && write`, `/usr` reads, and `$TMPDIR` writes.

## What review found, and what it cost to close

Nine of the eleven defects fixed here came from adversarial review or from testing a review fix. The
measured ones:

| Attack | Before | After |
| ------ | ------ | ----- |
| PTY path, direct read of a sibling checkout | leaked | refused |
| PTY path, runtime-assembled path (`T=…; cat "$T"`) | leaked | refused |
| Final-component symlink swapped mid-check | 1 leak / 250 | 0 / 1000 |
| Directory component swapped mid-check | 17 leaks / 1000 | 0 / 1000 |
| Same, through the `read` builtin | 23 leaks / 600 | 0 / 600 |
| Same, as a command argument (seatbelt) | 0 | 0 |

Two of these deserve naming, because both were boundaries that looked like boundaries:

**The PTY path was never fenced.** `pty` is a parameter the *model* supplies, and only the non-PTY
branch passed a fence — so containment was opt-out by the caller it constrains. `fence` is now a
required key on that options type, making the omission a type error rather than a hole.

**The in-process check was racy.** It checked a path and then opened it. Resolving before opening was
necessary and not sufficient: `open` still walks the directory components, so renaming a workspace
directory aside and symlinking a sibling in its place beat it — a better attack than the one resolving
fixed. Comparing inodes across the open did not settle it either, because a swap landing *before* the
pre-open stat makes the stat and the open agree with each other and disagree with the fence. The
descriptor is now asked what it actually refers to (`F_GETPATH` / `/proc/self/fd`) and that is checked
before the caller reads a byte. Spawned commands were never affected: seatbelt decides in the kernel,
where there is no window.

## Known limitation — read this before merging

**There is no OS-level backend on Linux or Windows.** `compose_std_command` wraps argv only under
`cfg(target_os = "macos")`; elsewhere commands spawn directly and the text scanner is all that remains.
This is a deliberate scope decision, not an oversight: Landlock cannot be verified on the machine this
was built on, and an unverifiable security backend is worse than a declared absence. Tracked as a
follow-up in #2572.

Non-macOS behaviour is unchanged from before this PR — nothing regresses — but the claim is no longer
silent. `xcsh://about` reports the backend as scanner-only, and the model is told in its prompt that the
boundary is best-effort there and not to rely on it.

The local Codex review gate therefore still reports this finding as blocking, and escalates. That is
correct and is recorded rather than worked around: the finding is real, and the decision to ship macOS
first is a scope call, not a refutation.

## The scanner keeps a job

`enforce.ts` stays, for `python`, for the structured file tools, and for platforms with no backend. It
is now a fast pre-check that produces a good error message before a command runs, rather than the
boundary. Nothing was deleted, so the two mechanisms overlap during rollout.

## Verification

- `bun run check` with `CI=1` (so the Rust half actually runs — locally it skips itself once Rust
  changes are committed, which is #2573): clean.
- `bun run test:ts`: exit 0.
- Containment suite: 84 pass, 0 fail across 6 files, including a TS↔Rust conformance test that runs one
  corpus through both implementations, since drift between them would be a silent hole.
- Race tests assert a refusal count as well as zero leaks. Without that, a run where the attack never
  reached the window looks identical to a fence that held — which is how the first version of that test
  passed while exercising nothing.
- `sandbox-isolation > loads the sandbox-guard extension by default` fails on `origin/main` too
  (verified by running main's own copy of the file: 8 pass / 1 fail, same 5s timeout). Not from this work.

macOS release build was exercised locally, because PR CI only builds `linux-x64`.
