### PR TITLE
feat(sandbox): confine spawned commands on Linux with Landlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,17 +216,24 @@ jobs:
       - name: Containment fence tests
         if: matrix.rust_checks
         run: cargo test -p containment-check
-      # Diagnostic, deliberately not yet an assertion. The enforcement leg is only meaningful where the
-      # kernel actually offers Landlock, and Ubuntu did not add it to the default LSM list until 24.04 —
-      # so this reports what this runner has before anything is made to depend on it. Guessing would give
-      # us a security test that skips silently, which reads exactly like one that passed.
-      - name: Landlock availability on this runner (diagnostic)
+      # Real enforcement, asserted — not a print and not a skip.
+      #
+      # This started as a diagnostic because I did not know whether this runner had Landlock in its LSM
+      # list (Ubuntu only added it to the default list in 24.04). It reported
+      # `lockdown,capability,landlock,yama,apparmor` on kernel 6.8-azure, so the answer is yes and the leg
+      # can assert. Worth having measured rather than guessed: I expected the opposite.
+      #
+      # `status` exits non-zero when there is no backend, which is deliberate. If this runner image ever
+      # loses Landlock, this step must fail loudly rather than quietly stop testing the boundary — a
+      # security check that skips reads exactly like one that passed.
+      - name: Landlock enforcement
         if: matrix.rust_checks
-        continue-on-error: true
         run: |
           echo "LSM list: $(cat /sys/kernel/security/lsm 2>/dev/null || echo unavailable)"
           echo "kernel: $(uname -r)"
-          cargo run -q -p containment-check -- status || echo "no Landlock backend on this runner"
+          cargo build -p containment-check
+          cargo run -q -p containment-check -- status
+          bash crates/containment-check/landlock-e2e.sh target/debug/containment-check
       - name: Build native addon(s)
         env:
           CROSS_TARGET: ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,23 @@ jobs:
       - name: Rust checks
         if: matrix.rust_checks
         run: bun run check:rs
+      # The containment fence's Landlock compiler. `crates/brush-core-vendored` is excluded from the
+      # workspace so `cargo test -p brush-core` refuses to run; this crate is a member and reaches that
+      # code by path, so it is the only place the compiler is covered. Pure logic — no kernel needed.
+      - name: Containment fence tests
+        if: matrix.rust_checks
+        run: cargo test -p containment-check
+      # Diagnostic, deliberately not yet an assertion. The enforcement leg is only meaningful where the
+      # kernel actually offers Landlock, and Ubuntu did not add it to the default LSM list until 24.04 —
+      # so this reports what this runner has before anything is made to depend on it. Guessing would give
+      # us a security test that skips silently, which reads exactly like one that passed.
+      - name: Landlock availability on this runner (diagnostic)
+        if: matrix.rust_checks
+        continue-on-error: true
+        run: |
+          echo "LSM list: $(cat /sys/kernel/security/lsm 2>/dev/null || echo unavailable)"
+          echo "kernel: $(uname -r)"
+          cargo run -q -p containment-check -- status || echo "no Landlock backend on this runner"
       - name: Build native addon(s)
         env:
           CROSS_TARGET: ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "containment-check"
+version = "19.99.0"
+dependencies = [
+ "brush-builtins",
+ "brush-core",
+ "clap",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/brush-core-vendored/Cargo.toml
+++ b/crates/brush-core-vendored/Cargo.toml
@@ -116,6 +116,10 @@ version = "1.48.0"
 features = [
     "io-util",
     "macros",
+    # `commands.rs` uses `tokio::io::unix::AsyncFd`, which is gated behind `net`. Undeclared until now,
+    # so this crate only compiled because another member of the build graph happened to enable it —
+    # building brush-core on its own failed with "could not find `unix` in `io`".
+    "net",
     "process",
     "rt",
     "rt-multi-thread",

--- a/crates/brush-core-vendored/src/commands.rs
+++ b/crates/brush-core-vendored/src/commands.rs
@@ -184,6 +184,22 @@ pub fn compose_std_command<S: AsRef<OsStr>>(
 		direct
 	};
 
+	// On Linux the same job is done by Landlock, which needs no wrapper process and so keeps `argv0`.
+	// The ruleset is built here, before `fork`, and the child only has to apply it — see
+	// `sys::landlock::arm` for why the split matters and why this registration must come first.
+	#[cfg(target_os = "linux")]
+	if let Some(fence) = context.params.containment.as_ref() {
+		if let sys::landlock::Availability::Available(abi) = sys::landlock::availability() {
+			let plan = fence.compile_grant_plan(&crate::containment::RealFs);
+			let ruleset = sys::landlock::build_ruleset(&plan, abi).map_err(|err| {
+				error::ErrorKind::ContainmentSetupFailed(command_name.to_owned(), err)
+			})?;
+			sys::landlock::arm(&mut cmd, ruleset);
+		}
+		// No Landlock here means the command runs exactly as it did before this backend existed. The
+		// absence is reported to the operator through `xcsh://about`; it must never fail a command.
+	}
+
 	// Pass through args.
 	cmd.args(args);
 
@@ -486,6 +502,11 @@ pub(crate) fn execute_external_command(
 					Err(error::ErrorKind::CommandNotFound(context.command_name).into())
 				}
 			} else {
+				// Deliberately not special-cased for containment. Setting up the fence happens before
+				// `fork` and reports `ContainmentSetupFailed` from there, so the only failures that can
+				// arrive here are the child's `prctl`/`restrict_self`, which cannot fail once the probe
+				// has succeeded. Branching on `containment.is_some()` to reword this would mislabel a
+				// plain non-executable file — also `EACCES` — to clarify a case that cannot happen.
 				Err(error::ErrorKind::FailedToExecuteCommand(context.command_name, spawn_err).into())
 			}
 		},

--- a/crates/brush-core-vendored/src/containment.rs
+++ b/crates/brush-core-vendored/src/containment.rs
@@ -229,6 +229,254 @@ impl ContainmentFence {
 	}
 }
 
+/// Lists the entries of a directory, so the grant compiler can be tested without a filesystem.
+///
+/// The compiler has to enumerate real directories — see [`ContainmentFence::compile_grant_plan`] — and
+/// that is the only I/O it performs. Injecting it is what lets the whole complement algorithm be tested
+/// on a synthetic tree, on any platform, with no kernel involved.
+pub trait DirLister {
+	/// The names directly inside `dir`, in any order.
+	fn entries(&self, dir: &Path) -> std::io::Result<Vec<std::ffi::OsString>>;
+}
+
+/// A [`DirLister`] backed by the real filesystem.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct RealFs;
+
+impl DirLister for RealFs {
+	fn entries(&self, dir: &Path) -> std::io::Result<Vec<std::ffi::OsString>> {
+		let mut names = Vec::new();
+		for entry in std::fs::read_dir(dir)? {
+			names.push(entry?.file_name());
+		}
+		Ok(names)
+	}
+}
+
+/// Which directions a single grant covers.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct GrantRights {
+	/// The subtree may be read.
+	pub read:  bool,
+	/// The subtree may be written.
+	pub write: bool,
+}
+
+/// What a fence root grants, ordered so the greater value wins when two roots name the same path.
+///
+/// The order mirrors the sequence [`ContainmentFence::permits_resolved`] tests at equal depth — deny,
+/// then read-only, then write-only, then allow — so `max` reproduces that precedence exactly. Getting
+/// this backwards would silently turn a deny into an allow.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum RootKind {
+	Allow,
+	WriteOnly,
+	ReadOnly,
+	Deny,
+}
+
+impl RootKind {
+	/// Whether a root of this kind grants `access`.
+	fn grants(self, access: FenceAccess) -> bool {
+		match (self, access) {
+			(Self::Deny, _) => false,
+			(Self::Allow, _) => true,
+			(Self::ReadOnly, FenceAccess::Read) | (Self::WriteOnly, FenceAccess::Write) => true,
+			(Self::ReadOnly, FenceAccess::Write) | (Self::WriteOnly, FenceAccess::Read) => false,
+		}
+	}
+}
+
+/// A node in the trie of fence roots, keyed by path component.
+#[derive(Debug, Default)]
+struct Node {
+	kind: Option<RootKind>,
+	kids: std::collections::BTreeMap<std::ffi::OsString, Node>,
+}
+
+impl Node {
+	/// Whether any descendant's verdict differs from `inherited` for `access`.
+	///
+	/// When nothing differs the whole subtree is uniform and can be granted (or skipped) in one rule,
+	/// which is what keeps the rule count small and avoids enumerating directories needlessly.
+	fn subtree_differs(&self, inherited: bool, access: FenceAccess) -> bool {
+		self.kids.values().any(|kid| {
+			let here = kid.kind.map_or(inherited, |kind| kind.grants(access));
+			here != inherited || kid.subtree_differs(here, access)
+		})
+	}
+}
+
+/// Grants to hand to an allow-only backend, plus what compiling them cost.
+///
+/// Landlock has no deny primitive and no default-allow, while the fence is allow-by-default with
+/// targeted denies. Bridging the two means granting the *complement* of the denied subtrees, and this
+/// is the result of that translation.
+#[derive(Clone, Debug, Default)]
+pub struct GrantPlan {
+	/// Subtrees to grant, and in which directions.
+	pub grants:       Vec<(PathBuf, GrantRights)>,
+	/// Directories that lost a right on their own inode because their children are not uniform.
+	///
+	/// A Landlock rule always covers a whole subtree, so a directory holding both granted and denied
+	/// children cannot be granted at all — only its qualifying children can. The directory itself then
+	/// loses that right: `ls` of it fails, and a file created directly in it afterwards is unreachable.
+	/// Reported rather than hidden, because the caller must refuse to claim OS enforcement when the
+	/// session's own workspace lands here.
+	pub split_dirs:   Vec<PathBuf>,
+	/// Directories that had to be enumerated but could not be, so nothing under them was granted.
+	pub unenumerable: Vec<PathBuf>,
+}
+
+impl GrantPlan {
+	/// Whether the compiled grants permit `access` on `path`.
+	///
+	/// A faithful model of what the kernel will decide, because a Landlock rule covers the whole subtree
+	/// beneath the granted directory and path *traversal* is never restricted — so there is no
+	/// ancestor-permission term to account for. That makes this the oracle the compiler is tested
+	/// against without needing a kernel.
+	#[must_use]
+	pub fn permits(&self, path: &Path, access: FenceAccess) -> bool {
+		self.grants.iter().any(|(root, rights)| {
+			path.starts_with(root)
+				&& match access {
+					FenceAccess::Read => rights.read,
+					FenceAccess::Write => rights.write,
+				}
+		})
+	}
+}
+
+impl ContainmentFence {
+	/// Compile the fence into grants for an allow-only backend (Linux Landlock).
+	///
+	/// Unlike [`Self::to_seatbelt_profile`], this cannot lean on rule order: seatbelt takes the last
+	/// matching rule, while Landlock takes the union of every rule and has no way to express a deny.
+	/// So the denied subtrees are subtracted by walking down to each one and granting its siblings at
+	/// every level, which is the only way to preserve "a path matched by nothing is allowed".
+	///
+	/// **Compiled once per direction and merged.** Doing both at once would let a read-only root split
+	/// the *read* plan, breaking `ls` of its parent for no reason — the directions are independent
+	/// because Landlock unions rights per rule.
+	///
+	/// The enumeration is a snapshot. Its window is the microseconds between compiling and `execve`, and
+	/// an entry appearing afterwards is *denied* rather than granted — the fail-closed direction, so the
+	/// snapshot can never widen the fence. Where enumeration fails outright, nothing is granted and the
+	/// directory is reported in [`GrantPlan::unenumerable`].
+	///
+	/// Assumes POSIX absolute roots, which is what the only consumer (the Linux backend) supplies.
+	#[must_use]
+	pub fn compile_grant_plan(&self, lister: &dyn DirLister) -> GrantPlan {
+		let trie = self.build_trie();
+		let mut merged: std::collections::BTreeMap<PathBuf, GrantRights> =
+			std::collections::BTreeMap::new();
+		let mut split_dirs: Vec<PathBuf> = Vec::new();
+		let mut unenumerable: Vec<PathBuf> = Vec::new();
+
+		for access in [FenceAccess::Read, FenceAccess::Write] {
+			let mut granted: Vec<PathBuf> = Vec::new();
+			walk_for_access(
+				&trie,
+				&PathBuf::from(std::path::MAIN_SEPARATOR_STR),
+				true,
+				access,
+				lister,
+				&mut granted,
+				&mut split_dirs,
+				&mut unenumerable,
+			);
+			for path in granted {
+				let rights = merged.entry(path).or_default();
+				match access {
+					FenceAccess::Read => rights.read = true,
+					FenceAccess::Write => rights.write = true,
+				}
+			}
+		}
+
+		split_dirs.sort_unstable();
+		split_dirs.dedup();
+		unenumerable.sort_unstable();
+		unenumerable.dedup();
+		GrantPlan { grants: merged.into_iter().collect(), split_dirs, unenumerable }
+	}
+
+	/// Index every fence root by path component, keeping the winning kind where two roots collide.
+	fn build_trie(&self) -> Node {
+		let mut root = Node::default();
+		for (roots, kind) in [
+			(&self.allow, RootKind::Allow),
+			(&self.allow_write_only, RootKind::WriteOnly),
+			(&self.allow_read_only, RootKind::ReadOnly),
+			(&self.deny, RootKind::Deny),
+		] {
+			for path in roots {
+				let mut node = &mut root;
+				for component in path.components() {
+					if let Component::Normal(name) = component {
+						node = node.kids.entry(name.to_os_string()).or_default();
+					}
+				}
+				node.kind = Some(node.kind.map_or(kind, |existing| existing.max(kind)));
+			}
+		}
+		root
+	}
+}
+
+/// Collect the grants for one direction, subtracting the denied subtrees.
+///
+/// `inherited` starts `true` because the fence allows anything it does not mention.
+fn walk_for_access(
+	node: &Node,
+	path: &Path,
+	inherited: bool,
+	access: FenceAccess,
+	lister: &dyn DirLister,
+	granted: &mut Vec<PathBuf>,
+	split_dirs: &mut Vec<PathBuf>,
+	unenumerable: &mut Vec<PathBuf>,
+) {
+	let here = node.kind.map_or(inherited, |kind| kind.grants(access));
+
+	// Uniform subtree: one rule settles it, and no directory has to be read.
+	if !node.subtree_differs(here, access) {
+		if here {
+			granted.push(path.to_path_buf());
+		}
+		return;
+	}
+
+	if here {
+		// Granted here but not everywhere below, so this directory cannot be granted as a subtree.
+		// Grant the children that are not mentioned by the fence, and record what that costs.
+		split_dirs.push(path.to_path_buf());
+		match lister.entries(path) {
+			Ok(names) => {
+				for name in names {
+					if !node.kids.contains_key(&name) {
+						granted.push(path.join(name));
+					}
+				}
+			},
+			Err(_) => unenumerable.push(path.to_path_buf()),
+		}
+	}
+
+	for (name, kid) in &node.kids {
+		walk_for_access(
+			kid,
+			&path.join(name),
+			here,
+			access,
+			lister,
+			granted,
+			split_dirs,
+			unenumerable,
+		);
+	}
+}
+
 // No `#[cfg(test)]` block here on purpose. This crate is `exclude`d from the workspace
 // (root Cargo.toml) and reached only through `[patch.crates-io]`, so `cargo test -p brush-core`
 // refuses to run — "requires dev-dependencies and is not a member of the workspace". Unit tests

--- a/crates/brush-core-vendored/src/error.rs
+++ b/crates/brush-core-vendored/src/error.rs
@@ -167,6 +167,15 @@ pub enum ErrorKind {
 	#[error("failed to create child process")]
 	ChildCreationFailure,
 
+	/// The OS containment backend could not be applied, so the command was refused rather than run
+	/// unconfined.
+	///
+	/// Distinct from [`Self::FailedToExecuteCommand`] on purpose: "could not confine" and "could not
+	/// execute" call for different responses, and a boundary that silently degrades to running the
+	/// command anyway is the failure this whole layer exists to prevent.
+	#[error("cannot confine command '{0}': {1}")]
+	ContainmentSetupFailed(String, #[source] std::io::Error),
+
 	/// An error occurred while formatting a string.
 	#[error(transparent)]
 	FormattingError(#[from] std::fmt::Error),
@@ -293,7 +302,9 @@ impl From<&ErrorKind> for results::ExecutionExitCode {
 			},
 			ErrorKind::ParseError(..) => Self::InvalidUsage,
 			ErrorKind::FunctionParseError(..) => Self::InvalidUsage,
-			ErrorKind::FailedToExecuteCommand(..) => Self::CannotExecute,
+			ErrorKind::FailedToExecuteCommand(..) | ErrorKind::ContainmentSetupFailed(..) => {
+				Self::CannotExecute
+			},
 			ErrorKind::BuiltinError(inner, ..) => inner.as_exit_code(),
 			_ => Self::GeneralError,
 		}

--- a/crates/brush-core-vendored/src/sys.rs
+++ b/crates/brush-core-vendored/src/sys.rs
@@ -30,6 +30,9 @@ pub mod fs;
 pub use platform::commands;
 pub use platform::fd;
 pub use platform::input;
+/// The OS containment backend for spawned commands. Linux-only; macOS uses a seatbelt profile instead.
+#[cfg(target_os = "linux")]
+pub use platform::landlock;
 pub(crate) use platform::network;
 pub use platform::process;
 pub use platform::resource;

--- a/crates/brush-core-vendored/src/sys/unix.rs
+++ b/crates/brush-core-vendored/src/sys/unix.rs
@@ -2,6 +2,9 @@ pub mod commands;
 pub mod fd;
 pub mod fs;
 pub mod input;
+/// Landlock is Linux-only; other unix platforms have no OS backend for containment.
+#[cfg(target_os = "linux")]
+pub mod landlock;
 pub(crate) mod network;
 use crate::error;
 pub use crate::sys::tokio_process as process;

--- a/crates/brush-core-vendored/src/sys/unix/landlock.rs
+++ b/crates/brush-core-vendored/src/sys/unix/landlock.rs
@@ -1,0 +1,380 @@
+//! Landlock confinement for spawned commands, on Linux.
+//!
+//! An external command opens its files in its own address space, so nothing the shell checks can
+//! confine it — only the OS can. On macOS that is `sandbox-exec`; here it is Landlock, applied to the
+//! forked child immediately before `execve` so the restriction is inherited by everything it runs.
+//!
+//! The rule set comes from [`crate::containment::ContainmentFence::compile_grant_plan`], which does the
+//! hard part: Landlock is allow-only, so the fence's denies are expressed by granting their complement.
+//!
+//! # What this deliberately does not restrict
+//!
+//! Only the rights in [`handled_rights`] are governed; anything absent from `handled_access_fs` is
+//! completely unrestricted, which is what keeps the fence gentle. Left out on purpose:
+//!
+//! - **`EXECUTE`** — handling it would mean granting exec wherever binaries live, and a denied `$HOME`
+//!   would make `~/.cargo/bin/cargo` and `~/.bun/bin/bun` unrunnable. Nothing is lost by omitting it:
+//!   the exec'd child inherits this same domain and still cannot read a denied file.
+//! - **`IOCTL_DEV`** (ABI 5) — `TIOCSPGRP` is not in the kernel's always-allowed ioctl list, so handling
+//!   it would break [`crate::sys::terminal::move_self_to_foreground`] and job control.
+//! - **network rights (ABI 4) and `scoped` (ABI 6)** — the fence has no notion of ports or signal
+//!   scope. Enforced structurally rather than by discipline: [`RulesetAttr`] has a single field and is
+//!   passed with `size = 8`, so those fields cannot be set even by mistake.
+//!
+//! `REFER` is the inverse trap and is the reason ABI 1 is refused outright: cross-directory
+//! `rename`/`link` is denied by the kernel whenever *any* filesystem right is handled, **even if the
+//! REFER bit is absent**. Without handling and granting it, every `mv` across directories and every
+//! `git` tmp-file-then-rename would fail. ABI 1 has no REFER bit, so there is no way to be gentle on it.
+//!
+//! Landlock does not restrict `stat`, `access` or `chdir`, so unlike the seatbelt profile this needs no
+//! metadata carve-out for `git init`'s ancestor walk.
+//!
+//! One caveat shared with seatbelt's `subpath`: a bind mount of a denied tree under a granted one is
+//! reachable. Mounting requires `CAP_SYS_ADMIN` or a user namespace, so it is not a practical escape
+//! for a confined child.
+
+use std::io;
+use std::os::fd::{AsRawFd, OwnedFd};
+use std::path::Path;
+use std::sync::OnceLock;
+
+use nix::libc;
+
+use crate::containment::GrantPlan;
+
+/// `landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION)` returns the supported ABI.
+const CREATE_RULESET_VERSION: u32 = 1;
+/// `LANDLOCK_RULE_PATH_BENEATH`.
+const RULE_PATH_BENEATH: libc::c_int = 1;
+
+const ACCESS_FS_WRITE_FILE: u64 = 1 << 1;
+const ACCESS_FS_READ_FILE: u64 = 1 << 2;
+const ACCESS_FS_READ_DIR: u64 = 1 << 3;
+const ACCESS_FS_REMOVE_DIR: u64 = 1 << 4;
+const ACCESS_FS_REMOVE_FILE: u64 = 1 << 5;
+const ACCESS_FS_MAKE_CHAR: u64 = 1 << 6;
+const ACCESS_FS_MAKE_DIR: u64 = 1 << 7;
+const ACCESS_FS_MAKE_REG: u64 = 1 << 8;
+const ACCESS_FS_MAKE_SOCK: u64 = 1 << 9;
+const ACCESS_FS_MAKE_FIFO: u64 = 1 << 10;
+const ACCESS_FS_MAKE_BLOCK: u64 = 1 << 11;
+const ACCESS_FS_MAKE_SYM: u64 = 1 << 12;
+/// ABI 2. See the module docs — denied by default even when unhandled, so it must be handled.
+const ACCESS_FS_REFER: u64 = 1 << 13;
+/// ABI 3.
+const ACCESS_FS_TRUNCATE: u64 = 1 << 14;
+
+/// The only rights the kernel accepts on a rule whose target is not a directory.
+///
+/// `landlock_add_rule` returns `EINVAL` for a non-directory carrying any other right, and the fence
+/// really does grant files — `~/.gitconfig` is read-only in every session. Getting this wrong is not a
+/// subtle degradation: one file root made `landlock_create_ruleset` succeed and then every single
+/// `add_rule` fail, so every fenced command was refused with "cannot confine". Measured, not deduced.
+///
+/// `EXECUTE` belongs to this set in the kernel but is never handled here, so it cannot appear.
+const FILE_ONLY_RIGHTS: u64 = ACCESS_FS_READ_FILE | ACCESS_FS_WRITE_FILE | ACCESS_FS_TRUNCATE;
+
+/// The lowest ABI this backend will use. ABI 1 cannot express `REFER`; see the module docs.
+const MINIMUM_ABI: u32 = 2;
+
+/// `struct landlock_ruleset_attr`, restricted to the one field this backend sets.
+///
+/// Deliberately not the full struct. The kernel infers which ABI's layout it was given from `size`, and
+/// a shorter struct is accepted on every ABI — so omitting `handled_access_net` and `scoped` makes it
+/// impossible to restrict networking or signal scope by accident.
+#[repr(C)]
+struct RulesetAttr {
+	handled_access_fs: u64,
+}
+
+/// `struct landlock_path_beneath_attr`.
+///
+/// **Packed, and that is not cosmetic.** The UAPI header declares it `__attribute__((packed))`, so it is
+/// 12 bytes; a plain `#[repr(C)]` would be 16 and the kernel would misread every rule.
+#[repr(C, packed)]
+struct PathBeneathAttr {
+	allowed_access: u64,
+	parent_fd:      i32,
+}
+
+/// Why Landlock cannot be used on this machine.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Unavailable {
+	/// `ENOSYS`: kernel older than 5.13, or the syscall is filtered away.
+	SyscallMissing,
+	/// `EOPNOTSUPP`: compiled into the kernel but not in the boot-time LSM list.
+	DisabledAtBoot,
+	/// ABI 1 cannot handle `REFER`, so every cross-directory rename would be denied.
+	AbiTooOld(u32),
+	/// Some other refusal from the probe, e.g. a seccomp filter returning `EPERM`.
+	Blocked(i32),
+}
+
+impl Unavailable {
+	/// A short reason, for reporting the active backend to the operator.
+	#[must_use]
+	pub fn reason(self) -> &'static str {
+		match self {
+			Self::SyscallMissing => "kernel does not provide Landlock (needs 5.13 or newer)",
+			Self::DisabledAtBoot => "Landlock is not enabled in this kernel's LSM list",
+			Self::AbiTooOld(_) => "Landlock ABI 1 cannot allow cross-directory rename",
+			Self::Blocked(_) => "Landlock was refused by this environment",
+		}
+	}
+}
+
+/// Whether this process can confine children with Landlock.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Availability {
+	/// Usable, at the given ABI version.
+	Available(u32),
+	/// Not usable, for this reason.
+	Unavailable(Unavailable),
+}
+
+/// Probe Landlock once per process.
+///
+/// `EOPNOTSUPP` gates all three Landlock syscalls identically, so a probe that succeeds is sufficient
+/// evidence that `landlock_restrict_self` will work — there is no state where the version query
+/// succeeds and restriction is then refused for want of the LSM. That is why this does not fork a child
+/// to test enforcement for real.
+pub fn availability() -> Availability {
+	static PROBED: OnceLock<Availability> = OnceLock::new();
+	*PROBED.get_or_init(|| {
+		// SAFETY: `landlock_create_ruleset` with a null attr, size 0 and the version flag is the
+		// documented way to query the supported ABI. It creates nothing and touches no memory.
+		let result = unsafe {
+			libc::syscall(
+				libc::SYS_landlock_create_ruleset,
+				std::ptr::null::<RulesetAttr>(),
+				0_usize,
+				CREATE_RULESET_VERSION,
+			)
+		};
+		if result >= 0 {
+			let Ok(abi) = u32::try_from(result) else {
+				return Availability::Unavailable(Unavailable::Blocked(0));
+			};
+			if abi < MINIMUM_ABI {
+				return Availability::Unavailable(Unavailable::AbiTooOld(abi));
+			}
+			return Availability::Available(abi);
+		}
+		match io::Error::last_os_error().raw_os_error() {
+			Some(libc::ENOSYS) => Availability::Unavailable(Unavailable::SyscallMissing),
+			Some(libc::EOPNOTSUPP) => Availability::Unavailable(Unavailable::DisabledAtBoot),
+			Some(errno) => Availability::Unavailable(Unavailable::Blocked(errno)),
+			None => Availability::Unavailable(Unavailable::Blocked(0)),
+		}
+	})
+}
+
+/// The rights granted for reading a subtree.
+const fn read_rights() -> u64 {
+	ACCESS_FS_READ_FILE | ACCESS_FS_READ_DIR
+}
+
+/// The rights granted for writing a subtree, at the given ABI.
+const fn write_rights(abi: u32) -> u64 {
+	let mut rights = ACCESS_FS_WRITE_FILE
+		| ACCESS_FS_REMOVE_DIR
+		| ACCESS_FS_REMOVE_FILE
+		| ACCESS_FS_MAKE_CHAR
+		| ACCESS_FS_MAKE_DIR
+		| ACCESS_FS_MAKE_REG
+		| ACCESS_FS_MAKE_SOCK
+		| ACCESS_FS_MAKE_FIFO
+		| ACCESS_FS_MAKE_BLOCK
+		| ACCESS_FS_MAKE_SYM;
+	if abi >= 2 {
+		rights |= ACCESS_FS_REFER;
+	}
+	if abi >= 3 {
+		rights |= ACCESS_FS_TRUNCATE;
+	}
+	rights
+}
+
+/// Everything the ruleset governs — exactly the union of the rights any rule can grant.
+///
+/// Naming a right here that no rule grants would deny it everywhere; naming one the running ABI does not
+/// know makes `landlock_create_ruleset` fail with `EINVAL`. Both are why this is derived from the probed
+/// ABI rather than written out.
+#[must_use]
+pub const fn handled_rights(abi: u32) -> u64 {
+	read_rights() | write_rights(abi)
+}
+
+/// Whether truncation is governed at this ABI.
+///
+/// `false` on ABI 2, where `truncate(2)` on a denied path is not refused. That is destruction rather
+/// than disclosure, and it is not reachable through `>` (which needs `WRITE_FILE` at open), but it is a
+/// real gap and is reported rather than quietly accepted.
+#[must_use]
+pub const fn truncate_handled(abi: u32) -> bool {
+	abi >= 3
+}
+
+/// Build a Landlock ruleset from a compiled grant plan.
+///
+/// Every syscall that can allocate or fail informatively happens here, before `fork`. The child is left
+/// with two syscalls and no allocation — see [`arm`].
+///
+/// A grant whose path cannot be opened is skipped rather than fatal: an enumerated entry can be a
+/// dangling symlink, and a plan may name a cache directory that does not exist yet. Skipping is the
+/// fail-closed direction, because an ungranted path stays denied.
+pub fn build_ruleset(plan: &GrantPlan, abi: u32) -> io::Result<OwnedFd> {
+	use std::os::fd::FromRawFd;
+
+	let attr = RulesetAttr { handled_access_fs: handled_rights(abi) };
+	// SAFETY: `attr` is a live `#[repr(C)]` value and the size passed is its real size, which is how
+	// the kernel selects the layout it reads. The call only creates a ruleset fd.
+	let raw = unsafe {
+		libc::syscall(
+			libc::SYS_landlock_create_ruleset,
+			std::ptr::from_ref(&attr),
+			std::mem::size_of::<RulesetAttr>(),
+			0_u32,
+		)
+	};
+	if raw < 0 {
+		// Descriptive rather than a bare errno: this runs before `fork`, so allocating is fine here, and
+		// "cannot confine: Invalid argument" tells an operator nothing about which step objected.
+		return Err(io::Error::other(format!(
+			"landlock_create_ruleset(handled_access_fs={:#x}, size={}) failed: {}",
+			handled_rights(abi),
+			std::mem::size_of::<RulesetAttr>(),
+			io::Error::last_os_error()
+		)));
+	}
+	let fd = i32::try_from(raw).map_err(|_| {
+		io::Error::other(format!("landlock_create_ruleset returned an out-of-range fd: {raw}"))
+	})?;
+	// SAFETY: `fd` was just returned by the kernel as a fresh, owned descriptor.
+	let ruleset = unsafe { OwnedFd::from_raw_fd(fd) };
+
+	let mut granted = 0_usize;
+	for (path, rights) in &plan.grants {
+		let mut allowed = 0_u64;
+		if rights.read {
+			allowed |= read_rights();
+		}
+		if rights.write {
+			allowed |= write_rights(abi);
+		}
+		if allowed == 0 {
+			continue;
+		}
+		let Some(parent) = open_path(path) else {
+			continue;
+		};
+		// A rule on a file may only carry the file rights; anything else is `EINVAL`. Decided from the
+		// descriptor rather than the path so a swap between opening and asking cannot change the answer.
+		if !is_directory(&parent) {
+			allowed &= FILE_ONLY_RIGHTS;
+			if allowed == 0 {
+				continue;
+			}
+		}
+		let beneath = PathBeneathAttr { allowed_access: allowed, parent_fd: parent.as_raw_fd() };
+		// SAFETY: `beneath` is a live packed `#[repr(C)]` value matching the UAPI layout, and
+		// `parent_fd` is open for the duration of the call. The kernel copies the rule, so the
+		// descriptor may be closed immediately afterwards.
+		let added = unsafe {
+			libc::syscall(
+				libc::SYS_landlock_add_rule,
+				ruleset.as_raw_fd(),
+				RULE_PATH_BENEATH,
+				std::ptr::from_ref(&beneath),
+				0_u32,
+			)
+		};
+		drop(parent);
+		if added != 0 {
+			return Err(io::Error::other(format!(
+				"landlock_add_rule(allowed_access={allowed:#x}, path={}) failed: {}",
+				path.display(),
+				io::Error::last_os_error()
+			)));
+		}
+		granted += 1;
+	}
+
+	// A ruleset that governs reading and grants nothing cannot run the dynamic loader, so every command
+	// would die with an `EACCES` that points at nothing. Refuse to build it instead.
+	if granted == 0 {
+		return Err(io::Error::other(format!(
+			"the fence granted nothing openable ({} planned), so no command could run",
+			plan.grants.len()
+		)));
+	}
+	Ok(ruleset)
+}
+
+/// Whether an `O_PATH` descriptor refers to a directory.
+///
+/// Asked of the descriptor, not the path, so it describes the object the rule will actually cover.
+fn is_directory(fd: &OwnedFd) -> bool {
+	// SAFETY: `stat` is a plain C struct filled in by the kernel; a zeroed value is a valid starting
+	// state, and `fstat` writes it wholly on success. The descriptor is borrowed and stays open.
+	let mut stat = unsafe { std::mem::zeroed::<libc::stat>() };
+	// SAFETY: `fd` is a live descriptor and `stat` is a live, correctly-typed out-parameter. `fstat` is
+	// permitted on an `O_PATH` descriptor.
+	let result = unsafe { libc::fstat(fd.as_raw_fd(), &raw mut stat) };
+	result == 0 && (stat.st_mode & libc::S_IFMT) == libc::S_IFDIR
+}
+
+/// Open a path for use as a rule's `parent_fd`, or `None` if it cannot be opened.
+fn open_path(path: &Path) -> Option<OwnedFd> {
+	use std::os::unix::ffi::OsStrExt;
+
+	let mut bytes = path.as_os_str().as_bytes().to_vec();
+	if bytes.contains(&0) {
+		return None;
+	}
+	bytes.push(0);
+	// SAFETY: `bytes` is NUL-terminated and contains no interior NUL, so it is a valid C string for
+	// the duration of the call. `O_PATH` opens the directory without granting access to its contents.
+	let raw = unsafe {
+		libc::open(bytes.as_ptr().cast::<libc::c_char>(), libc::O_PATH | libc::O_CLOEXEC)
+	};
+	if raw < 0 {
+		return None;
+	}
+	use std::os::fd::FromRawFd;
+	// SAFETY: `raw` was just returned by `open` as a fresh, owned descriptor.
+	Some(unsafe { OwnedFd::from_raw_fd(raw) })
+}
+
+/// Arrange for `cmd`'s child to confine itself to `ruleset` immediately after `fork`.
+///
+/// **Register this before any other `pre_exec` on the command.** `command_fds`, used by
+/// [`crate::sys::commands::CommandFdInjectionExt::inject_fds`], `dup2`s onto caller-chosen descriptor
+/// numbers — `exec 3< file` produces child fd 3 — and closes whatever was already there. If the ruleset
+/// descriptor were one of those numbers, restriction would fail or, worse, act on an unrelated fd.
+/// Restricting first removes the hazard entirely, and is safe because Landlock governs no descriptor
+/// operation: `dup2` and `fcntl` are unaffected by an active domain, and `chdir` has already happened
+/// by the time any closure runs.
+pub fn arm(cmd: &mut std::process::Command, ruleset: OwnedFd) {
+	use std::os::unix::process::CommandExt;
+
+	// SAFETY:
+	// This closure runs after `fork` in a process that is multi-threaded — a tokio runtime inside the
+	// host — so only async-signal-safe work is legal: any lock the vanished threads held is still held.
+	// It performs exactly two direct syscalls and builds `io::Error` from an errno, none of which
+	// allocate, take a lock, or can panic. `io::Error::last_os_error` is deliberate: it forwards to
+	// `from_raw_os_error`, which bit-packs the errno, whereas `io::Error::other`/`new` would box a
+	// payload and allocate here. `ruleset` is moved in so it stays open for the command's lifetime; the
+	// child never drops it, because it either `execve`s (the fd is `O_CLOEXEC`) or `_exit`s.
+	unsafe {
+		cmd.pre_exec(move || {
+			if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 {
+				return Err(io::Error::last_os_error());
+			}
+			if libc::syscall(libc::SYS_landlock_restrict_self, ruleset.as_raw_fd(), 0_u32) != 0 {
+				return Err(io::Error::last_os_error());
+			}
+			Ok(())
+		});
+	}
+}

--- a/crates/brush-core-vendored/src/sys/unix/landlock.rs
+++ b/crates/brush-core-vendored/src/sys/unix/landlock.rs
@@ -268,9 +268,18 @@ pub fn build_ruleset(plan: &GrantPlan, abi: u32) -> io::Result<OwnedFd> {
 		let Some(parent) = open_path(path) else {
 			continue;
 		};
-		// A rule on a file may only carry the file rights; anything else is `EINVAL`. Decided from the
-		// descriptor rather than the path so a swap between opening and asking cannot change the answer.
-		if !is_directory(&parent) {
+		let Some(kind) = file_kind(&parent) else {
+			continue;
+		};
+		// Never grant through a symlink: the rule would land on the target's inode, which is how a link
+		// in a split directory defeated the entire deny. Skipping costs nothing, because Landlock
+		// evaluates the *resolved* path — `/bin/ls` is still reachable through the `/usr` grant when
+		// `/bin` is a symlink into it, which is exactly the common case on a systemd distribution.
+		if kind == FileKind::Symlink {
+			continue;
+		}
+		// A rule on a file may only carry the file rights; anything else is `EINVAL`.
+		if kind != FileKind::Directory {
 			allowed &= FILE_ONLY_RIGHTS;
 			if allowed == 0 {
 				continue;
@@ -311,20 +320,44 @@ pub fn build_ruleset(plan: &GrantPlan, abi: u32) -> io::Result<OwnedFd> {
 	Ok(ruleset)
 }
 
-/// Whether an `O_PATH` descriptor refers to a directory.
+/// The kind of object a descriptor refers to, as far as rule-building cares.
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum FileKind {
+	Directory,
+	Symlink,
+	Other,
+}
+
+/// What an `O_PATH` descriptor refers to.
 ///
-/// Asked of the descriptor, not the path, so it describes the object the rule will actually cover.
-fn is_directory(fd: &OwnedFd) -> bool {
+/// Asked of the descriptor, not the path, so it describes the object the rule will actually cover and a
+/// swap between asking and acting cannot change the answer.
+fn file_kind(fd: &OwnedFd) -> Option<FileKind> {
 	// SAFETY: `stat` is a plain C struct filled in by the kernel; a zeroed value is a valid starting
 	// state, and `fstat` writes it wholly on success. The descriptor is borrowed and stays open.
 	let mut stat = unsafe { std::mem::zeroed::<libc::stat>() };
 	// SAFETY: `fd` is a live descriptor and `stat` is a live, correctly-typed out-parameter. `fstat` is
 	// permitted on an `O_PATH` descriptor.
-	let result = unsafe { libc::fstat(fd.as_raw_fd(), &raw mut stat) };
-	result == 0 && (stat.st_mode & libc::S_IFMT) == libc::S_IFDIR
+	if unsafe { libc::fstat(fd.as_raw_fd(), &raw mut stat) } != 0 {
+		return None;
+	}
+	Some(match stat.st_mode & libc::S_IFMT {
+		libc::S_IFDIR => FileKind::Directory,
+		libc::S_IFLNK => FileKind::Symlink,
+		_ => FileKind::Other,
+	})
 }
 
 /// Open a path for use as a rule's `parent_fd`, or `None` if it cannot be opened.
+///
+/// **`O_NOFOLLOW` is load-bearing, not defensive.** A Landlock rule attaches to the inode behind the
+/// descriptor, so following a symlink here grants whatever it points at. Measured before this was added:
+/// a symlink sitting in a split directory and aimed at the denied home — `/home/pivot -> /home/u` — was
+/// enumerated as an ordinary child, granted, and resolved to the home's inode. That did not merely expose
+/// the path through the link; it made `cat /home/u/secret.txt` succeed directly. The whole deny was gone.
+///
+/// Split directories lose write rights on their own inode, so a *confined* command cannot plant such a
+/// link itself — but one already on disk is enough, and relying on that would be relying on an accident.
 fn open_path(path: &Path) -> Option<OwnedFd> {
 	use std::os::unix::ffi::OsStrExt;
 
@@ -336,7 +369,10 @@ fn open_path(path: &Path) -> Option<OwnedFd> {
 	// SAFETY: `bytes` is NUL-terminated and contains no interior NUL, so it is a valid C string for
 	// the duration of the call. `O_PATH` opens the directory without granting access to its contents.
 	let raw = unsafe {
-		libc::open(bytes.as_ptr().cast::<libc::c_char>(), libc::O_PATH | libc::O_CLOEXEC)
+		libc::open(
+			bytes.as_ptr().cast::<libc::c_char>(),
+			libc::O_PATH | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+		)
 	};
 	if raw < 0 {
 		return None;

--- a/crates/containment-check/Cargo.toml
+++ b/crates/containment-check/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "containment-check"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+# Deliberately depends on brush-core and nothing heavy. `crates/brush-core-vendored` is `exclude`d from
+# the workspace and reached only through `[patch.crates-io]`, so `cargo test -p brush-core` refuses to
+# run and the containment code has never had runnable Rust tests. This crate IS a workspace member, so
+# `cargo test -p containment-check` exercises that code for real.
+#
+# It also stays cheap on purpose: brush-core's dependency closure only, no napi and no tree-sitter, so it
+# builds inside a small container where a full `pi-natives` build would not fit.
+[dependencies]
+brush-core = { version = "0.4.0", path = "../brush-core-vendored" }
+brush-builtins = { version = "0.1.0", path = "../brush-builtins-vendored" }
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/containment-check/landlock-e2e.sh
+++ b/crates/containment-check/landlock-e2e.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Does Landlock confinement actually hold, through the shipped code path?
+#
+# `containment-check run` builds a real brush shell and sets `params.containment` the way the host does,
+# so every case below goes through `compose_std_command` → a real ruleset → a real forked child. Nothing
+# here reimplements the mechanism, which is the point: a test that models the sandbox instead of using it
+# proves only that the model agrees with itself.
+#
+# Usage: landlock-e2e.sh /path/to/containment-check
+set -uo pipefail
+
+BIN="${1:?usage: landlock-e2e.sh /path/to/containment-check}"
+ROOT="$(mktemp -d)"
+HOME_DIR="$ROOT/home"
+WORKSPACE="$HOME_DIR/GIT/custA"
+SIBLING="$HOME_DIR/GIT/custB"
+DROP="$HOME_DIR/drop"
+CANARY="LANDLOCK-CANARY-8801"
+
+mkdir -p "$WORKSPACE/sub" "$SIBLING" "$DROP"
+printf '%s\n' "$CANARY" > "$SIBLING/secret.txt"
+printf 'mine\n' > "$WORKSPACE/own.txt"
+printf '[user]\n' > "$HOME_DIR/.gitconfig"
+
+# The shape a real fence has: the home tree and the workspace's parent denied, the workspace carved back
+# out, plus one read-only and one write-only root.
+FENCE=$(printf '{"allow":["%s"],"allowReadOnly":["%s"],"allowWriteOnly":["%s"],"deny":["%s","%s"]}' \
+	"$WORKSPACE" "$HOME_DIR/.gitconfig" "$DROP" "$HOME_DIR" "$HOME_DIR/GIT")
+
+pass=0 fail=0
+
+# expect <label> <want: ok|refused> <command...>
+expect() {
+	local label="$1" want="$2"; shift 2
+	local out rc
+	out=$("$BIN" run --fence "$FENCE" --cwd "$WORKSPACE" "$*" 2>&1); rc=$?
+	local got=ok; [ "$rc" -eq 0 ] || got=refused
+	if [ "$got" = "$want" ] && ! grep -q "$CANARY" <<<"$out"; then
+		printf 'PASS  %-52s (%s)\n' "$label" "$got"; pass=$((pass+1))
+	else
+		printf 'FAIL  %-52s want=%s got=%s\n      %s\n' "$label" "$want" "$got" "${out//$'\n'/ | }"
+		fail=$((fail+1))
+	fi
+}
+
+printf '=== backend ===\n'
+"$BIN" status || { printf 'no OS backend here; these results would prove nothing\n'; exit 1; }
+
+printf '\n=== the boundary holds ===\n'
+# The control first. If this does NOT leak, the fixture is wrong and every refusal below is meaningless.
+control=$("$BIN" run --cwd "$WORKSPACE" "cat $SIBLING/secret.txt" 2>&1)
+if grep -q "$CANARY" <<<"$control"; then
+	printf 'PASS  %-52s (leaks unfenced, as it must)\n' "control: unfenced read of the sibling"
+	pass=$((pass+1))
+else
+	printf 'FAIL  %-52s the control did not leak: %s\n' "control: unfenced read of the sibling" "$control"
+	fail=$((fail+1))
+fi
+expect "fenced read of the sibling checkout" refused "cat $SIBLING/secret.txt"
+expect "fenced read via a runtime-assembled path" refused "T=$SIBLING/secret.txt; cat \"\$T\""
+expect "fenced write into the sibling checkout" refused "printf x > $SIBLING/planted.txt"
+expect "fenced read of the denied home" refused "cat $HOME_DIR/.bash_history"
+
+printf '\n=== ordinary work is untouched ===\n'
+expect "read a file in the workspace" ok "cat own.txt"
+expect "create and read a new file" ok "printf hi > new.txt && cat new.txt"
+expect "create a file in a subdirectory" ok "printf hi > sub/deep.txt && cat sub/deep.txt"
+expect "mkdir then write" ok "mkdir -p made && printf hi > made/f && cat made/f"
+# The only case that catches a missing REFER bit. Without it every cross-directory mv fails, and nothing
+# else here would notice.
+expect "cross-directory mv (REFER)" ok "mkdir -p a b && touch a/x && mv a/x b/x && test -f b/x"
+expect "redirect to /dev/null" ok "echo noise > /dev/null && echo ok"
+expect "read a system path" ok "head -1 /usr/bin/env > /dev/null && echo ok"
+expect "read /etc" ok "cat /etc/hostname > /dev/null && echo ok"
+expect "write in the OS temp dir" ok "printf x > /tmp/ll-e2e-probe && echo ok"
+expect "truncate a file in the workspace" ok ": > own.txt && test ! -s own.txt"
+expect "pipeline with grep and sed" ok "printf 'a\\nb\\n' > p.txt && sed -n 2p p.txt | grep b"
+expect "tar roundtrip" ok "mkdir -p t && echo x > t/f && tar czf t.tgz t && rm -rf t && tar xzf t.tgz && cat t/f"
+
+printf '\n=== directional roots keep their direction ===\n'
+expect "read the read-only root" ok "cat $HOME_DIR/.gitconfig > /dev/null && echo ok"
+expect "write the read-only root" refused "printf x >> $HOME_DIR/.gitconfig"
+expect "write the write-only root" ok "printf x > $DROP/out.log"
+expect "read the write-only root" refused "cat $DROP/out.log"
+
+printf '\n=== the accepted costs, asserted so they stay known ===\n'
+# A recursive-only rule model cannot grant a directory holding both granted and denied children, so `/`
+# and the home's parent lose READ_DIR. Documented in the plan; asserted here so it is a property.
+expect "ls / fails (split directory)" refused "ls / > /dev/null"
+# `landlock_restrict_self` requires PR_SET_NO_NEW_PRIVS, which disables setuid binaries in the child.
+expect "NO_NEW_PRIVS is set in the child" ok \
+	"grep -q 'NoNewPrivs:.*1' /proc/self/status"
+
+printf '\n=== %d passed, %d failed ===\n' "$pass" "$fail"
+rm -rf "$ROOT" /tmp/ll-e2e-probe
+[ "$fail" -eq 0 ]

--- a/crates/containment-check/landlock-e2e.sh
+++ b/crates/containment-check/landlock-e2e.sh
@@ -61,6 +61,14 @@ expect "fenced read via a runtime-assembled path" refused "T=$SIBLING/secret.txt
 expect "fenced write into the sibling checkout" refused "printf x > $SIBLING/planted.txt"
 expect "fenced read of the denied home" refused "cat $HOME_DIR/.bash_history"
 
+# A Landlock rule attaches to the inode behind the descriptor, so a symlink enumerated as an ordinary
+# child of a split directory used to grant whatever it pointed at. Measured: this made the denied file
+# readable *directly*, not merely through the link — the whole deny was gone. Both forms are asserted,
+# because fixing only the link-shaped one would leave the real hole open.
+ln -sfn "$HOME_DIR" "$ROOT/pivot" 2>/dev/null
+expect "no escape through a symlink into the denied tree" refused "cat $ROOT/pivot/GIT/custB/secret.txt"
+expect "the denied tree stays denied directly" refused "cat $SIBLING/secret.txt"
+
 printf '\n=== ordinary work is untouched ===\n'
 expect "read a file in the workspace" ok "cat own.txt"
 expect "create and read a new file" ok "printf hi > new.txt && cat new.txt"

--- a/crates/containment-check/src/main.rs
+++ b/crates/containment-check/src/main.rs
@@ -52,26 +52,154 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-	/// Print what a fence compiles to on this machine, as JSON.
+	/// Print what a fence compiles to on this machine.
 	Plan {
 		/// The fence, as JSON.
 		#[arg(long)]
 		fence: String,
 	},
+	/// Report whether an OS containment backend is usable here.
+	///
+	/// Exits non-zero when there is none, so a verification script cannot
+	/// mistake "no backend" for "nothing to test" — a security check that skips
+	/// silently reads exactly like one that passed.
+	Status,
+	/// Run a command through the real shell, optionally fenced, and report what
+	/// happened.
+	///
+	/// This is the empirical leg: it goes through `compose_std_command`, so it
+	/// exercises the shipped mechanism rather than a reimplementation of it.
+	Run {
+		/// The fence, as JSON. Omit to run unfenced — the control case.
+		#[arg(long)]
+		fence:   Option<String>,
+		/// Working directory for the command.
+		#[arg(long)]
+		cwd:     Option<PathBuf>,
+		/// The command line to run.
+		command: String,
+	},
 }
 
-fn main() -> std::process::ExitCode {
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> std::process::ExitCode {
 	let cli = Cli::parse();
 	match cli.command {
-		Command::Plan { fence } => match serde_json::from_str::<FenceJson>(&fence) {
-			Ok(json) => {
-				print_plan(&ContainmentFence::from(json).compile_grant_plan(&RealFs));
+		Command::Plan { fence } => match parse_fence(&fence) {
+			Ok(fence) => {
+				print_plan(&fence.compile_grant_plan(&RealFs));
 				std::process::ExitCode::SUCCESS
 			},
-			Err(err) => {
-				eprintln!("could not parse --fence as JSON: {err}");
-				std::process::ExitCode::FAILURE
-			},
+			Err(code) => code,
+		},
+		Command::Status => report_status(),
+		Command::Run { fence, cwd, command } => {
+			let fence = match fence.as_deref().map(parse_fence) {
+				Some(Ok(fence)) => Some(fence),
+				Some(Err(code)) => return code,
+				None => None,
+			};
+			run_command(fence, cwd, &command).await
+		},
+	}
+}
+
+fn parse_fence(raw: &str) -> Result<ContainmentFence, std::process::ExitCode> {
+	serde_json::from_str::<FenceJson>(raw)
+		.map(ContainmentFence::from)
+		.map_err(|err| {
+			eprintln!("could not parse --fence as JSON: {err}");
+			std::process::ExitCode::FAILURE
+		})
+}
+
+/// Report the backend, exiting non-zero when there is none.
+#[cfg(target_os = "linux")]
+fn report_status() -> std::process::ExitCode {
+	use brush_core::sys::landlock::{Availability, availability, handled_rights, truncate_handled};
+
+	match availability() {
+		Availability::Available(abi) => {
+			println!("backend: landlock");
+			println!("abi: {abi}");
+			println!("handled_access_fs: {:#x}", handled_rights(abi));
+			println!("truncate_handled: {}", truncate_handled(abi));
+			std::process::ExitCode::SUCCESS
+		},
+		Availability::Unavailable(reason) => {
+			println!("backend: scanner-only");
+			println!("reason: {}", reason.reason());
+			eprintln!(
+				"NO OS BACKEND HERE — an enforcement check on this machine would prove nothing.\nRun \
+				 it somewhere Landlock is available, or fix the environment. Not skipping quietly."
+			);
+			std::process::ExitCode::FAILURE
+		},
+	}
+}
+
+#[cfg(not(target_os = "linux"))]
+fn report_status() -> std::process::ExitCode {
+	println!(
+		"backend: {}",
+		if cfg!(target_os = "macos") {
+			"seatbelt"
+		} else {
+			"scanner-only"
+		}
+	);
+	eprintln!("this subcommand reports the Landlock backend, which only exists on Linux");
+	std::process::ExitCode::FAILURE
+}
+
+/// Run `command` through a real brush shell, mirroring how the host configures
+/// one.
+async fn run_command(
+	fence: Option<ContainmentFence>,
+	cwd: Option<PathBuf>,
+	command: &str,
+) -> std::process::ExitCode {
+	use brush_builtins::{BuiltinSet, default_builtins};
+	use brush_core::{CreateOptions, Shell};
+
+	let options = CreateOptions {
+		interactive: false,
+		login: false,
+		no_profile: true,
+		no_rc: true,
+		do_not_inherit_env: true,
+		builtins: default_builtins(BuiltinSet::BashMode),
+		..Default::default()
+	};
+	let mut shell = match Shell::new(options).await {
+		Ok(shell) => shell,
+		Err(err) => {
+			eprintln!("could not create shell: {err}");
+			return std::process::ExitCode::FAILURE;
+		},
+	};
+	if let Some(cwd) = cwd
+		&& let Err(err) = shell.set_working_dir(&cwd)
+	{
+		eprintln!("could not enter {}: {err}", cwd.display());
+		return std::process::ExitCode::FAILURE;
+	}
+
+	let mut params = shell.default_exec_params();
+	// Exactly how `pi-natives` supplies the fence, so this drives the shipped path.
+	params.containment = fence.map(std::sync::Arc::new);
+
+	match shell.run_string(command, &params).await {
+		Ok(result) => {
+			let code = u8::from(result.exit_code);
+			println!("exit: {code}");
+			std::process::ExitCode::from(code)
+		},
+		Err(err) => {
+			// A refusal is a result, not a crash: print it so a script can assert on the
+			// wording.
+			println!("error: {err}");
+			std::process::ExitCode::from(126)
 		},
 	}
 }

--- a/crates/containment-check/src/main.rs
+++ b/crates/containment-check/src/main.rs
@@ -1,0 +1,100 @@
+//! Drives the containment fence's OS backend directly, for verification.
+//!
+//! `crates/brush-core-vendored` is `exclude`d from the workspace and reached
+//! only through `[patch.crates-io]`, so `cargo test -p brush-core` refuses to
+//! run and its containment code has never had runnable Rust tests. This crate
+//! is a workspace member that depends on brush-core by path, which
+//! is what makes `cargo test -p containment-check` exercise that code for real.
+//!
+//! It exists to answer two questions that a unit test cannot:
+//!
+//! - what does the fence compile to on this machine (`plan`),
+//! - and does a spawned command actually get refused (`run`) — through the
+//!   shipped `compose_std_command` path, with no reimplementation of the
+//!   mechanism.
+
+use std::path::PathBuf;
+
+use brush_core::containment::{ContainmentFence, GrantPlan, RealFs};
+use clap::{Parser, Subcommand};
+
+/// The fence as JSON, matching the four lists the napi boundary already passes.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FenceJson {
+	#[serde(default)]
+	allow:            Vec<PathBuf>,
+	#[serde(default)]
+	allow_read_only:  Vec<PathBuf>,
+	#[serde(default)]
+	allow_write_only: Vec<PathBuf>,
+	#[serde(default)]
+	deny:             Vec<PathBuf>,
+}
+
+impl From<FenceJson> for ContainmentFence {
+	fn from(json: FenceJson) -> Self {
+		Self {
+			allow:            json.allow,
+			allow_read_only:  json.allow_read_only,
+			allow_write_only: json.allow_write_only,
+			deny:             json.deny,
+		}
+	}
+}
+
+#[derive(Parser)]
+#[command(about = "Verify the containment fence's OS backend")]
+struct Cli {
+	#[command(subcommand)]
+	command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+	/// Print what a fence compiles to on this machine, as JSON.
+	Plan {
+		/// The fence, as JSON.
+		#[arg(long)]
+		fence: String,
+	},
+}
+
+fn main() -> std::process::ExitCode {
+	let cli = Cli::parse();
+	match cli.command {
+		Command::Plan { fence } => match serde_json::from_str::<FenceJson>(&fence) {
+			Ok(json) => {
+				print_plan(&ContainmentFence::from(json).compile_grant_plan(&RealFs));
+				std::process::ExitCode::SUCCESS
+			},
+			Err(err) => {
+				eprintln!("could not parse --fence as JSON: {err}");
+				std::process::ExitCode::FAILURE
+			},
+		},
+	}
+}
+
+fn print_plan(plan: &GrantPlan) {
+	println!("grants ({}):", plan.grants.len());
+	for (path, rights) in &plan.grants {
+		let mode = match (rights.read, rights.write) {
+			(true, true) => "rw",
+			(true, false) => "r-",
+			(false, true) => "-w",
+			(false, false) => "--",
+		};
+		println!("  {mode} {}", path.display());
+	}
+	println!("split dirs ({}) — these lost a right on their own inode:", plan.split_dirs.len());
+	for path in &plan.split_dirs {
+		println!("  {}", path.display());
+	}
+	if !plan.unenumerable.is_empty() {
+		println!("unenumerable ({}) — nothing granted beneath these:", plan.unenumerable.len());
+		for path in &plan.unenumerable {
+			println!("  {}", path.display());
+		}
+	}
+}

--- a/crates/containment-check/tests/complement.rs
+++ b/crates/containment-check/tests/complement.rs
@@ -1,0 +1,397 @@
+//! Does the Landlock grant compiler mean the same thing as the fence it
+//! compiles?
+//!
+//! Landlock is allow-only with no deny primitive, while the fence is
+//! allow-by-default with targeted denies, so `compile_grant_plan` has to
+//! express the denies by granting their complement. That translation is the
+//! part that can be subtly wrong, and it is pure — no kernel, no privileges —
+//! so it is tested here against `permits_resolved` as the oracle, on every
+//! platform.
+//!
+//! Two properties, and the asymmetry between them is the point:
+//!
+//! - **Safety** — the plan must never permit what the fence denies. A failure
+//!   here is a sandbox escape.
+//! - **Fidelity** — for anything else, the plan must agree with the fence. A
+//!   failure here is the fence refusing ordinary work, which is how a security
+//!   feature gets switched off.
+//!
+//! Fidelity has one legitimate exception: a *split directory*, which a
+//! recursive-only rule model cannot grant without also granting its denied
+//! children. Those are enumerated by the compiler and asserted to be strictly
+//! stricter, never laxer.
+
+use std::{
+	collections::BTreeSet,
+	ffi::OsString,
+	path::{Path, PathBuf},
+};
+
+use brush_core::containment::{ContainmentFence, DirLister, FenceAccess, GrantPlan};
+
+/// A synthetic directory tree, so the compiler can be driven without touching a
+/// filesystem.
+struct FakeFs {
+	paths: BTreeSet<PathBuf>,
+}
+
+impl FakeFs {
+	fn new(paths: &[&str]) -> Self {
+		let mut all = BTreeSet::new();
+		for path in paths {
+			// Insert every ancestor too, so the tree is well-formed however it was listed.
+			let mut current = PathBuf::from(path);
+			loop {
+				all.insert(current.clone());
+				match current.parent() {
+					Some(parent) if parent != current => current = parent.to_path_buf(),
+					_ => break,
+				}
+			}
+		}
+		Self { paths: all }
+	}
+
+	fn contains(&self, path: &Path) -> bool {
+		self.paths.contains(path)
+	}
+}
+
+impl DirLister for FakeFs {
+	fn entries(&self, dir: &Path) -> std::io::Result<Vec<OsString>> {
+		if !self.paths.contains(dir) {
+			return Err(std::io::Error::from(std::io::ErrorKind::NotFound));
+		}
+		Ok(self
+			.paths
+			.iter()
+			.filter(|path| path.parent() == Some(dir))
+			.filter_map(|path| path.file_name().map(std::ffi::OsStr::to_os_string))
+			.collect())
+	}
+}
+
+/// The shape a real Linux fence has: home denied, a workspace re-allowed inside
+/// it, package caches carved back out, a leak root denied *inside* the
+/// workspace, and read-only / write-only roots.
+fn realistic() -> (FakeFs, ContainmentFence) {
+	let fs = FakeFs::new(&[
+		"/usr/bin/env",
+		"/etc/hosts",
+		"/tmp/scratch",
+		"/opt/shared/ctx.md",
+		"/opt/other/thing",
+		"/drop/out.log",
+		"/home/v/notes.md",
+		"/home/u/.ssh/id_rsa",
+		"/home/u/Documents/tax.pdf",
+		"/home/u/.gitconfig",
+		"/home/u/.cargo/registry/index",
+		"/home/u/.cargo/credentials.toml",
+		"/home/u/GIT/custB/secret.env",
+		"/home/u/GIT/custA/notes.md",
+		"/home/u/GIT/custA/sub/deep.txt",
+		"/home/u/GIT/custA/.xcsh/sessions/other.jsonl",
+	]);
+	let fence = ContainmentFence {
+		allow:            vec![
+			PathBuf::from("/home/u/GIT/custA"),
+			PathBuf::from("/home/u/.cargo/registry"),
+		],
+		allow_read_only:  vec![PathBuf::from("/home/u/.gitconfig"), PathBuf::from("/opt/shared")],
+		allow_write_only: vec![PathBuf::from("/drop")],
+		// `/home/u/GIT` nested inside `/home/u` exercises deny-inside-deny; the `.xcsh/sessions`
+		// root is a deny inside an allow inside a deny, which is the case seatbelt handles by rule
+		// order and Landlock cannot.
+		deny:             vec![
+			PathBuf::from("/home/u"),
+			PathBuf::from("/home/u/GIT"),
+			PathBuf::from("/home/u/GIT/custA/.xcsh/sessions"),
+		],
+	};
+	(fs, fence)
+}
+
+fn candidates(fs: &FakeFs) -> Vec<PathBuf> {
+	let mut out: Vec<PathBuf> = fs.paths.iter().cloned().collect();
+	// Paths that do not exist yet, because a write target usually does not.
+	for extra in [
+		"/home/u/GIT/custA/created-later.txt",
+		"/home/u/GIT/custA/sub/created-later.txt",
+		"/home/u/GIT/custB/planted.env",
+		"/tmp/new-file",
+		"/drop/new.log",
+		"/home/u/.ssh/planted",
+	] {
+		out.push(PathBuf::from(extra));
+	}
+	out
+}
+
+#[test]
+fn plan_never_permits_what_the_fence_denies() {
+	let (fs, fence) = realistic();
+	let plan = fence.compile_grant_plan(&fs);
+
+	let mut escapes = Vec::new();
+	for path in candidates(&fs) {
+		for access in [FenceAccess::Read, FenceAccess::Write] {
+			if plan.permits(&path, access) && !fence.permits_resolved(&path, access) {
+				escapes.push(format!("{access:?} {}", path.display()));
+			}
+		}
+	}
+	assert!(escapes.is_empty(), "grant plan is laxer than the fence for: {escapes:#?}");
+}
+
+#[test]
+fn plan_agrees_with_the_fence_except_on_split_directories() {
+	let (fs, fence) = realistic();
+	let plan = fence.compile_grant_plan(&fs);
+	let split: BTreeSet<&PathBuf> = plan.split_dirs.iter().collect();
+
+	let mut disagreements = Vec::new();
+	for path in candidates(&fs) {
+		if split.contains(&path) {
+			continue;
+		}
+		// A path that does not exist and sits directly inside a split directory was
+		// never enumerated, so it is denied. That is the documented cost, asserted on
+		// its own below.
+		if path
+			.parent()
+			.is_some_and(|parent| split.contains(&parent.to_path_buf()))
+			&& !fs.contains(&path)
+		{
+			continue;
+		}
+		for access in [FenceAccess::Read, FenceAccess::Write] {
+			let planned = plan.permits(&path, access);
+			let fenced = fence.permits_resolved(&path, access);
+			if planned != fenced {
+				disagreements
+					.push(format!("{access:?} {}: plan={planned} fence={fenced}", path.display()));
+			}
+		}
+	}
+	assert!(disagreements.is_empty(), "grant plan disagrees with the fence: {disagreements:#?}");
+}
+
+#[test]
+fn split_directories_are_only_ever_stricter() {
+	let (fs, fence) = realistic();
+	let plan = fence.compile_grant_plan(&fs);
+
+	for dir in &plan.split_dirs {
+		for access in [FenceAccess::Read, FenceAccess::Write] {
+			assert!(
+				!(plan.permits(dir, access) && !fence.permits_resolved(dir, access)),
+				"split dir {} is laxer than the fence for {access:?}",
+				dir.display()
+			);
+		}
+	}
+}
+
+#[test]
+fn everything_outside_the_fence_stays_reachable() {
+	let (fs, fence) = realistic();
+	let plan = fence.compile_grant_plan(&fs);
+
+	// The whole point of the complement: paths the fence never mentions must keep
+	// working, in both directions. If this fails, the backend has turned a gentle
+	// fence into a deny-by-default one.
+	for path in ["/usr/bin/env", "/etc/hosts", "/tmp/scratch", "/tmp/new-file", "/home/v/notes.md"] {
+		let path = PathBuf::from(path);
+		assert!(plan.permits(&path, FenceAccess::Read), "{} should be readable", path.display());
+		assert!(plan.permits(&path, FenceAccess::Write), "{} should be writable", path.display());
+	}
+}
+
+#[test]
+fn the_denied_home_and_sibling_checkout_are_unreachable() {
+	let (fs, fence) = realistic();
+	let plan = fence.compile_grant_plan(&fs);
+
+	for path in [
+		"/home/u/.ssh/id_rsa",
+		"/home/u/Documents/tax.pdf",
+		"/home/u/.cargo/credentials.toml",
+		"/home/u/GIT/custB/secret.env",
+		"/home/u/GIT/custA/.xcsh/sessions/other.jsonl",
+	] {
+		let path = PathBuf::from(path);
+		assert!(!plan.permits(&path, FenceAccess::Read), "{} must not be readable", path.display());
+		assert!(!plan.permits(&path, FenceAccess::Write), "{} must not be writable", path.display());
+	}
+}
+
+#[test]
+fn the_workspace_and_its_carve_outs_are_fully_usable() {
+	let (fs, fence) = realistic();
+	let plan = fence.compile_grant_plan(&fs);
+
+	for path in [
+		"/home/u/GIT/custA/notes.md",
+		"/home/u/GIT/custA/sub/deep.txt",
+		"/home/u/GIT/custA/sub/created-later.txt",
+		"/home/u/.cargo/registry/index",
+	] {
+		let path = PathBuf::from(path);
+		assert!(plan.permits(&path, FenceAccess::Read), "{} should be readable", path.display());
+		assert!(plan.permits(&path, FenceAccess::Write), "{} should be writable", path.display());
+	}
+}
+
+#[test]
+fn read_only_and_write_only_roots_keep_their_direction() {
+	let (fs, fence) = realistic();
+	let plan = fence.compile_grant_plan(&fs);
+
+	let gitconfig = PathBuf::from("/home/u/.gitconfig");
+	assert!(plan.permits(&gitconfig, FenceAccess::Read));
+	assert!(!plan.permits(&gitconfig, FenceAccess::Write));
+
+	let shared = PathBuf::from("/opt/shared/ctx.md");
+	assert!(plan.permits(&shared, FenceAccess::Read));
+	assert!(!plan.permits(&shared, FenceAccess::Write));
+
+	let drop = PathBuf::from("/drop/out.log");
+	assert!(plan.permits(&drop, FenceAccess::Write));
+	assert!(!plan.permits(&drop, FenceAccess::Read));
+}
+
+/// A read-only root under an *allowed* parent must not cost that parent its
+/// read rights.
+///
+/// This is why the plan is compiled once per direction. Compiling both at once
+/// would make `/opt` a split directory for reads as well, so `ls /opt` would
+/// fail for no reason at all.
+#[test]
+fn a_read_only_root_splits_only_the_write_direction() {
+	let (fs, fence) = realistic();
+	let plan = fence.compile_grant_plan(&fs);
+
+	let opt = PathBuf::from("/opt");
+	assert!(plan.permits(&opt, FenceAccess::Read), "/opt must stay readable, so `ls /opt` works");
+	assert!(
+		!plan.permits(&opt, FenceAccess::Write),
+		"/opt itself is not writable: /opt/shared is RO"
+	);
+	// And the sibling that the fence never mentions keeps both directions.
+	let other = PathBuf::from("/opt/other/thing");
+	assert!(plan.permits(&other, FenceAccess::Read));
+	assert!(plan.permits(&other, FenceAccess::Write));
+}
+
+/// The accepted costs, asserted so they are known properties rather than future
+/// bug reports.
+#[test]
+fn the_documented_costs_hold() {
+	let (fs, fence) = realistic();
+	let plan = fence.compile_grant_plan(&fs);
+	let split: BTreeSet<&PathBuf> = plan.split_dirs.iter().collect();
+
+	// `/` and `/home` hold both granted and denied children, so neither can be
+	// granted as a subtree — which is exactly why `ls /` and `ls /home` fail under
+	// a fence.
+	assert!(
+		split.contains(&PathBuf::from("/")),
+		"/ should be a split dir, got {:?}",
+		plan.split_dirs
+	);
+	assert!(split.contains(&PathBuf::from("/home")), "/home should be a split dir");
+	assert!(!plan.permits(Path::new("/"), FenceAccess::Read), "`ls /` is expected to fail");
+	assert!(!plan.permits(Path::new("/home"), FenceAccess::Read), "`ls /home` is expected to fail");
+
+	// A leak root denied inside the workspace makes the workspace itself a split
+	// dir, so a file created directly in the workspace root afterwards is
+	// unreachable. The caller must refuse to claim OS enforcement in this case
+	// rather than ship a fence that forbids `touch` where the agent works.
+	let workspace = PathBuf::from("/home/u/GIT/custA");
+	assert!(split.contains(&workspace), "a deny inside the workspace splits the workspace");
+	assert!(!plan.permits(Path::new("/home/u/GIT/custA/created-later.txt"), FenceAccess::Write));
+}
+
+/// A directory that has to be enumerated but cannot be grants nothing, and says
+/// so.
+#[test]
+fn unenumerable_directories_fail_closed() {
+	struct Blind;
+	impl DirLister for Blind {
+		fn entries(&self, _dir: &Path) -> std::io::Result<Vec<OsString>> {
+			Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+		}
+	}
+	let fence = ContainmentFence {
+		allow: vec![PathBuf::from("/home/u/GIT/custA")],
+		deny: vec![PathBuf::from("/home/u")],
+		..ContainmentFence::default()
+	};
+	let plan = fence.compile_grant_plan(&Blind);
+
+	assert!(!plan.unenumerable.is_empty(), "a failed readdir must be reported");
+	// Nothing outside the explicit allow is granted, because nothing could be
+	// enumerated.
+	assert!(!plan.permits(Path::new("/usr/bin/env"), FenceAccess::Read));
+	// The explicit allow still lands, because it needs no enumeration.
+	assert!(plan.permits(Path::new("/home/u/GIT/custA/notes.md"), FenceAccess::Read));
+}
+
+/// An empty fence restricts nothing, and must compile to a plan that says so.
+#[test]
+fn an_empty_fence_grants_the_whole_tree() {
+	let fs = FakeFs::new(&["/usr/bin/env", "/home/u/x"]);
+	let plan = ContainmentFence::default().compile_grant_plan(&fs);
+
+	assert!(plan.split_dirs.is_empty(), "nothing splits when nothing is denied");
+	for path in ["/usr/bin/env", "/home/u/x", "/anything/at/all"] {
+		assert!(plan.permits(Path::new(path), FenceAccess::Read));
+		assert!(plan.permits(Path::new(path), FenceAccess::Write));
+	}
+}
+
+/// Two lists naming the same path must resolve the way `permits_resolved` does:
+/// deny wins.
+#[test]
+fn deny_wins_when_two_lists_name_the_same_root() {
+	let fs = FakeFs::new(&["/work/shared/f"]);
+	let fence = ContainmentFence {
+		allow: vec![PathBuf::from("/work/shared")],
+		deny: vec![PathBuf::from("/work/shared")],
+		..ContainmentFence::default()
+	};
+	let plan = fence.compile_grant_plan(&fs);
+	let path = PathBuf::from("/work/shared/f");
+
+	assert_eq!(fence.permits_resolved(&path, FenceAccess::Read), false, "oracle: deny wins the tie");
+	assert!(!plan.permits(&path, FenceAccess::Read), "plan must agree that deny wins");
+}
+
+/// The plan must be usable as the source of truth for the ruleset, so it has to
+/// be deterministic.
+#[test]
+fn compilation_is_deterministic() {
+	let (fs, fence) = realistic();
+	let first: Vec<_> = fence.compile_grant_plan(&fs).grants;
+	let second: Vec<_> = fence.compile_grant_plan(&fs).grants;
+	assert_eq!(first, second);
+}
+
+/// Sanity on the shape: a realistic fence should stay in the tens of rules, not
+/// the thousands.
+#[test]
+fn the_rule_count_stays_small() {
+	let (fs, fence) = realistic();
+	let plan: GrantPlan = fence.compile_grant_plan(&fs);
+	// Both bounds matter. An empty plan would satisfy every "must not permit"
+	// assertion in this file while confining nothing usable, so the lower bound is
+	// what stops the suite passing vacuously.
+	assert!(!plan.grants.is_empty(), "a fence with denies must still grant the complement");
+	assert!(
+		plan.grants.len() < 64,
+		"expected tens of grants, got {}: {:#?}",
+		plan.grants.len(),
+		plan.grants
+	);
+}

--- a/crates/containment-check/tests/complement.rs
+++ b/crates/containment-check/tests/complement.rs
@@ -306,8 +306,14 @@ fn the_documented_costs_hold() {
 
 	// A leak root denied inside the workspace makes the workspace itself a split
 	// dir, so a file created directly in the workspace root afterwards is
-	// unreachable. The caller must refuse to claim OS enforcement in this case
-	// rather than ship a fence that forbids `touch` where the agent works.
+	// unreachable.
+	//
+	// The backend confines anyway rather than falling back. Of the three options —
+	// confine and lose new files at the workspace root, run unconfined, or refuse
+	// every command — only the first keeps the boundary, and it is reachable only
+	// when the workspace *is* the agent directory, which no ordinary session does.
+	// Running unconfined while still reporting `landlock` would be the worst of the
+	// three; refusing every command turns a narrow cost into a dead session.
 	let workspace = PathBuf::from("/home/u/GIT/custA");
 	assert!(split.contains(&workspace), "a deny inside the workspace splits the workspace");
 	assert!(!plan.permits(Path::new("/home/u/GIT/custA/created-later.txt"), FenceAccess::Write));

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -128,6 +128,69 @@ pub fn fence_permits(fence: ContainmentFenceOptions, candidate: String, write: b
 	ContainmentFence::from(&fence).permits(Path::new(&candidate), access)
 }
 
+/// Which OS backend can confine a spawned command on this machine.
+#[napi(object)]
+pub struct ContainmentBackendInfo {
+	/// `"landlock"`, `"seatbelt"`, or `"scanner-only"` when the OS cannot help.
+	pub backend:          String,
+	/// Landlock ABI version, when that is the backend.
+	pub abi:              Option<u32>,
+	/// Why there is no OS backend, when there is none.
+	pub reason:           Option<String>,
+	/// Whether truncation is governed. False on Landlock ABI 2, which is a real
+	/// if narrow gap.
+	pub truncate_handled: bool,
+}
+
+/// Probe the OS containment backend.
+///
+/// Exported so `containmentStatus` reports what is actually enforcing rather
+/// than inferring it from `process.platform`. Landlock can be compiled out,
+/// left out of the boot-time LSM list, or too old to use — none of which is
+/// visible from the platform name, and all of which change what the boundary is
+/// worth. Guessing here would put a claim in `xcsh://about` that the kernel
+/// does not back.
+#[napi]
+pub fn containment_backend() -> ContainmentBackendInfo {
+	#[cfg(target_os = "linux")]
+	{
+		use brush_core::sys::landlock::{Availability, availability, truncate_handled};
+
+		match availability() {
+			Availability::Available(abi) => ContainmentBackendInfo {
+				backend:          "landlock".to_owned(),
+				abi:              Some(abi),
+				reason:           None,
+				truncate_handled: truncate_handled(abi),
+			},
+			Availability::Unavailable(reason) => ContainmentBackendInfo {
+				backend:          "scanner-only".to_owned(),
+				abi:              None,
+				reason:           Some(reason.reason().to_owned()),
+				truncate_handled: false,
+			},
+		}
+	}
+	#[cfg(target_os = "macos")]
+	{
+		ContainmentBackendInfo {
+			backend:          "seatbelt".to_owned(),
+			abi:              None,
+			reason:           None,
+			truncate_handled: true,
+		}
+	}
+	#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+	{
+		ContainmentBackendInfo {
+			backend:          "scanner-only".to_owned(),
+			abi:              None,
+			reason:           Some("no OS containment backend exists for this platform".to_owned()),
+			truncate_handled: false,
+		}
+	}
+}
+
 /// Options for configuring a persistent shell session.
 #[napi(object)]
 pub struct ShellOptions {

--- a/packages/coding-agent/src/internal-urls/build-info-runtime.ts
+++ b/packages/coding-agent/src/internal-urls/build-info-runtime.ts
@@ -168,7 +168,12 @@ function renderActiveModel(model: ActiveModelSnapshot | null): string {
  */
 function renderContainment(containment: ContainmentStatus | null): string {
 	if (!containment) return "";
-	return prompt.render(containmentTemplate, { containment });
+	// `landlock` is derived rather than another field on the status, because the template needs a
+	// boolean and Handlebars cannot compare strings. It gates the Linux-only costs — unlistable split
+	// directories, no setuid, no interactive terminal — which are true of that backend and no other.
+	return prompt.render(containmentTemplate, {
+		containment: { ...containment, landlock: containment.backend === "landlock" },
+	});
 }
 
 export function renderAboutDoc(

--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -26,6 +26,10 @@ Three things behave differently under this backend, and none of them is a bug to
   ability to gain privileges.
 - Interactive terminal programs (`top`, `less`, an interactive `ssh`) run without a real terminal here,
   so prefer their non-interactive forms — `ps`, `cat`, `ssh -T`, or a piped command.
+{{#if containment.truncationUngoverned}}
+- This kernel is too old to govern truncation, so a file outside the boundary can still be emptied even
+  though it cannot be read or written. Never truncate a path outside the session directory.
+{{/if}}
 {{/if}}
 {{else}}
 On this platform there is **no OS-level backend**, so the boundary is enforced only by scanning the

--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -16,6 +16,17 @@ followed symlinks — so how a path is spelled does not change what is reachable
 If a command is refused, do not try to reach the same path a different way: the boundary is enforced
 below the command text, so no rewriting will succeed. Say what you needed and why. The operator can
 widen it with `--allow-path <dir>`, which grants read and write.
+
+{{#if containment.landlock}}
+Three things behave differently under this backend, and none of them is a bug to work around:
+- `ls /` and `ls` of the directory holding the session tree fail. A kernel rule covers a whole subtree,
+  so a directory with both reachable and unreachable children cannot be listed at all. Listing a
+  specific directory you can reach works normally.
+- `sudo` and other setuid programs do not work, because confining a process requires giving up the
+  ability to gain privileges.
+- Interactive terminal programs (`top`, `less`, an interactive `ssh`) run without a real terminal here,
+  so prefer their non-interactive forms — `ps`, `cat`, `ssh -T`, or a piped command.
+{{/if}}
 {{else}}
 On this platform there is **no OS-level backend**, so the boundary is enforced only by scanning the
 command text before it runs. That check is best-effort by construction: it reads what you wrote

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -19,7 +19,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { containmentBackend } from "@f5-sales-demo/pi-natives";
+import * as natives from "@f5-sales-demo/pi-natives";
 import { getMemoriesDir, getSessionsDir, getXCSHContextsDir, pathIsWithin } from "@f5-sales-demo/pi-utils";
 
 export type FenceAccess = "read" | "write";
@@ -306,7 +306,18 @@ export function containmentStatus(
 	return { enabled: true, backend: "scanner-only", osEnforced: false };
 }
 
-/** Ask the native layer which backend is active. May throw; the caller guards. */
+/**
+ * Ask the native layer which backend is active, if it can answer.
+ *
+ * **Reached through a namespace import on purpose.** A native module built before this export existed
+ * does not have the symbol, and a static `import { containmentBackend }` against it fails at *link*
+ * time with `SyntaxError: Export named 'containmentBackend' not found` — taking the whole module graph
+ * down before any `try`/`catch` can run. Found exactly that way: the tarball install smoke test died on
+ * it while the runtime guard sat there looking sufficient. A namespace member that is absent is merely
+ * `undefined`, which is a case code can actually handle.
+ */
 function probeNativeBackend(): { backend: string; truncateHandled?: boolean } | undefined {
-	return containmentBackend();
+	const probe = (natives as { containmentBackend?: () => { backend: string; truncateHandled?: boolean } })
+		.containmentBackend;
+	return typeof probe === "function" ? probe() : undefined;
 }

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -249,6 +249,17 @@ export interface ContainmentStatus {
 	readonly backend: ContainmentBackend;
 	/** True when the kernel enforces it, false when only the command-text scan does. */
 	readonly osEnforced: boolean;
+	/**
+	 * Set when the backend enforces reads and writes but cannot govern truncation.
+	 *
+	 * True only on Landlock ABI 2 — kernels 5.19 to 6.1, which includes Debian 12 — where
+	 * `LANDLOCK_ACCESS_FS_TRUNCATE` does not exist. A denied file cannot be read or written there, but
+	 * `truncate(2)` can still zero it. That is destruction rather than disclosure, and it is not
+	 * reachable through `>` (which needs write access at open), so the backend is still worth having.
+	 * Reported rather than folded into `osEnforced`, because "enforced" and "enforced except this" are
+	 * different claims and an operator is entitled to know which one they have.
+	 */
+	readonly truncationUngoverned?: boolean;
 }
 
 /**
@@ -264,7 +275,7 @@ export interface ContainmentStatus {
 export function containmentStatus(
 	enabled: boolean,
 	platform: string = process.platform,
-	probe: () => { backend: string } | undefined = probeNativeBackend,
+	probe: () => { backend: string; truncateHandled?: boolean } | undefined = probeNativeBackend,
 ): ContainmentStatus {
 	if (!enabled) return { enabled: false, backend: "disabled", osEnforced: false };
 	// macOS always has seatbelt, so there is nothing to ask.
@@ -277,17 +288,25 @@ export function containmentStatus(
 	// one. A native module from an older release has no such export, and letting a `TypeError` escape
 	// would turn a missing status line into a broken `xcsh://about`. Falling back to `scanner-only`
 	// understates the boundary, which is the safe direction to be wrong in.
-	let backend: string | undefined;
+	let probed: { backend: string; truncateHandled?: boolean } | undefined;
 	try {
-		backend = probe()?.backend;
+		probed = probe();
 	} catch {
-		backend = undefined;
+		probed = undefined;
 	}
-	if (backend === "landlock") return { enabled: true, backend: "landlock", osEnforced: true };
+	if (probed?.backend === "landlock") {
+		return {
+			enabled: true,
+			backend: "landlock",
+			osEnforced: true,
+			// Absent on the ABI that governs truncation; present, and stated, on the one that does not.
+			...(probed.truncateHandled === false ? { truncationUngoverned: true } : {}),
+		};
+	}
 	return { enabled: true, backend: "scanner-only", osEnforced: false };
 }
 
 /** Ask the native layer which backend is active. May throw; the caller guards. */
-function probeNativeBackend(): { backend: string } | undefined {
+function probeNativeBackend(): { backend: string; truncateHandled?: boolean } | undefined {
 	return containmentBackend();
 }

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -19,6 +19,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { containmentBackend } from "@f5-sales-demo/pi-natives";
 import { getMemoriesDir, getSessionsDir, getXCSHContextsDir, pathIsWithin } from "@f5-sales-demo/pi-utils";
 
 export type FenceAccess = "read" | "write";
@@ -260,10 +261,33 @@ export interface ContainmentStatus {
  *
  * Deliberately not surfaced at startup or anywhere in the TUI — the operator asked for no UI change.
  */
-export function containmentStatus(enabled: boolean, platform: string = process.platform): ContainmentStatus {
+export function containmentStatus(
+	enabled: boolean,
+	platform: string = process.platform,
+	probe: () => { backend: string } | undefined = probeNativeBackend,
+): ContainmentStatus {
 	if (!enabled) return { enabled: false, backend: "disabled", osEnforced: false };
-	// Only the macOS seatbelt backend exists today. Linux Landlock is a follow-up; until it lands,
-	// Linux and Windows fall back to the scanner and say so rather than implying enforcement.
+	// macOS always has seatbelt, so there is nothing to ask.
 	if (platform === "darwin") return { enabled: true, backend: "seatbelt", osEnforced: true };
+	// Everywhere else the answer cannot be inferred from the platform name. Landlock can be compiled
+	// out of the kernel, left out of its boot-time LSM list, or too old to allow cross-directory
+	// rename — and none of that is visible from `process.platform`. Asking the native layer is the
+	// difference between reporting what is enforcing and reporting what we hope is enforcing.
+	// Guarded here rather than inside the probe, so *any* probe is safe to pass — including an injected
+	// one. A native module from an older release has no such export, and letting a `TypeError` escape
+	// would turn a missing status line into a broken `xcsh://about`. Falling back to `scanner-only`
+	// understates the boundary, which is the safe direction to be wrong in.
+	let backend: string | undefined;
+	try {
+		backend = probe()?.backend;
+	} catch {
+		backend = undefined;
+	}
+	if (backend === "landlock") return { enabled: true, backend: "landlock", osEnforced: true };
 	return { enabled: true, backend: "scanner-only", osEnforced: false };
+}
+
+/** Ask the native layer which backend is active. May throw; the caller guards. */
+function probeNativeBackend(): { backend: string } | undefined {
+	return containmentBackend();
 }

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -38,6 +38,14 @@ import { clampTimeout } from "./tool-timeouts";
 // Module-level obfuscator reference for the renderer (set by BashTool constructor).
 let _sessionObfuscator: SecretObfuscator | undefined;
 
+/**
+ * Where each session's containment boundary is anchored, captured once and never moved by the model.
+ *
+ * Keyed on the session object because the tool is built by a factory, so an instance field would reset
+ * whenever a new `BashTool` is made. Weak so a finished session is collectable.
+ */
+const FENCE_ANCHORS = new WeakMap<object, { root: string; project: string }>();
+
 export const BASH_DEFAULT_PREVIEW_LINES = 10;
 
 const BASH_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
@@ -478,24 +486,60 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 	}
 
 	/**
+	 * Where this session's boundary is anchored.
+	 *
+	 * **Not the live cwd.** The fence used to be rebuilt from `session.cwd`, which line ~717 replaces
+	 * with whatever PWD the command ended in — so the model could move the boundary with a `cd`. Measured
+	 * on a workspace outside the home tree, which is the layout the sibling-checkout deny exists for:
+	 * with `/work/custA` as the workspace, `/work/custB/secret.env` was denied; `cd /usr` is permitted
+	 * (correctly — `/usr` is not sensitive), and the *next* fence was rooted at `/usr`, where the parent
+	 * deny of `/work` cannot be expressed because `dirname("/usr")` is `/` and denying the root is refused
+	 * as too broad. `/work/custB` then became readable **and** writable. Two tool calls, no exotic
+	 * spelling, and the tenant boundary was gone.
+	 *
+	 * So the anchor is captured once per session and never follows the shell. It is keyed on the session
+	 * object rather than held on this instance because the tool is built by a factory
+	 * (`bash: s => new BashTool(s)`) and must not depend on how long an instance happens to live.
+	 *
+	 * An *operator* moving the project — startup, or the slash command that calls `setProjectDir` — does
+	 * re-anchor it. That asymmetry is the point: the operator may move the boundary, the model may not.
+	 *
+	 * Note the read/write tools are unaffected by this class of bug: `SandboxPolicy` is deny-by-default,
+	 * so relocating its root grants nothing new. Only an allow-by-default fence loses a deny when it
+	 * moves, which is why this needed fixing here and not there.
+	 */
+	#containmentRoot(): string {
+		const project = getProjectDir();
+		const anchor = FENCE_ANCHORS.get(this.session);
+		if (anchor === undefined) {
+			FENCE_ANCHORS.set(this.session, { root: this.session.cwd, project });
+			return this.session.cwd;
+		}
+		if (anchor.project !== project) {
+			// The operator moved the project. Re-anchor there rather than at `session.cwd`, which a
+			// model `cd` may have moved in the meantime.
+			FENCE_ANCHORS.set(this.session, { root: project, project });
+			return project;
+		}
+		return anchor.root;
+	}
+
+	/**
 	 * The fence for this invocation, or undefined when isolation is off.
 	 *
 	 * Built here rather than in the executor because `executeBash` is shared: user-typed `!cmd` and
 	 * RPC `bash` reach it too, and the same brush-core runs credential helpers and the interactive
 	 * `xcsh shell`. Only the model's tool call is fenced (#2554).
-	 *
-	 * Uses the session's *live* cwd so an in-tree `cd` keeps working, while the fence's own roots
-	 * decide what is reachable — which is what stops a `cd` out of the tree from taking the boundary
-	 * with it, without the text layer having to recognise every spelling of `cd`.
 	 */
 	#containmentFence() {
-		const policy = resolveSessionPolicy(this.session.cwd, this.session.settings);
+		const root = this.#containmentRoot();
+		const policy = resolveSessionPolicy(root, this.session.settings);
 		if (!policy) return undefined; // --no-sandbox / sandbox.enabled = false
 		const artifactsDir = this.session.getArtifactsDir?.();
 		// The three grants stay distinct. Merging allowRead and allowWrite into one read+write list
 		// made a folder shared for reading writable, undoing the split built for #2516.
 		return buildContainmentFence({
-			workspace: this.session.cwd,
+			workspace: root,
 			extraRoots: artifactsDir ? [artifactsDir] : [],
 			readOnlyRoots: (this.session.settings.get("sandbox.allowRead") as string[] | undefined) ?? [],
 			writeOnlyRoots: (this.session.settings.get("sandbox.allowWrite") as string[] | undefined) ?? [],

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -16,7 +16,7 @@ import { resolveLocalRoot } from "../internal-urls/local-protocol";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
 import type { Theme } from "../modes/theme/theme";
 import bashDescription from "../prompts/tools/bash.md" with { type: "text" };
-import { buildContainmentFence } from "../sandbox/containment";
+import { buildContainmentFence, containmentStatus } from "../sandbox/containment";
 import { resolveSessionPolicy } from "../sandbox/session-policy";
 import { SECRET_ENV_PATTERNS, type SecretObfuscator } from "../secrets";
 import { DEFAULT_MAX_BYTES, TailBuffer } from "../session/streaming-output";
@@ -670,8 +670,12 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		// The cost is real and Linux-only: `top`, `less` and `ssh` run without a terminal in a fenced
 		// session. Confining the PTY child properly is the follow-up; reporting a boundary that a flag
 		// steps around would be worse than losing interactivity.
+		// Only worth giving up when there is an OS backend for the non-PTY path to use and none for this
+		// one. Where no backend exists — Linux without Landlock, Windows — both paths are scanner-only,
+		// so disabling PTY would remove interactive terminals and improve containment by nothing.
 		const fence = this.#containmentFence();
-		const ptyConfinable = fence === undefined || process.platform === "darwin";
+		const osBackend = containmentStatus(fence !== undefined);
+		const ptyConfinable = !osBackend.osEnforced || osBackend.backend === "seatbelt";
 		const usePty = pty && ptyConfinable && $env.PI_NO_PTY !== "1" && ctx?.hasUI === true && ctx.ui !== undefined;
 		const result: BashResult | BashInteractiveResult = usePty
 			? await runInteractiveBashPty(ctx.ui!, {

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -660,7 +660,19 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		// Allocate artifact for truncated output storage
 		const { path: artifactPath, id: artifactId } = (await this.session.allocateOutputArtifact?.("bash")) ?? {};
 
-		const usePty = pty && $env.PI_NO_PTY !== "1" && ctx?.hasUI === true && ctx.ui !== undefined;
+		// The PTY path can only be confined where the OS backend reaches it, and on Linux it does not:
+		// Landlock is applied in a `pre_exec` hook, and `portable-pty`'s `CommandBuilder` exposes none
+		// (its `as_command` is private, and its `Clone + Debug + PartialEq` derives preclude a closure
+		// field ever being added). Since `pty` is a parameter the *model* supplies, leaving it reachable
+		// would make containment opt-out by the very caller it constrains — the hole that was just closed
+		// on macOS. So a fenced session falls back to the non-PTY path, which is confined.
+		//
+		// The cost is real and Linux-only: `top`, `less` and `ssh` run without a terminal in a fenced
+		// session. Confining the PTY child properly is the follow-up; reporting a boundary that a flag
+		// steps around would be worse than losing interactivity.
+		const fence = this.#containmentFence();
+		const ptyConfinable = fence === undefined || process.platform === "darwin";
+		const usePty = pty && ptyConfinable && $env.PI_NO_PTY !== "1" && ctx?.hasUI === true && ctx.ui !== undefined;
 		const result: BashResult | BashInteractiveResult = usePty
 			? await runInteractiveBashPty(ctx.ui!, {
 					command,
@@ -671,7 +683,9 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					artifactPath,
 					artifactId,
 					maskSecrets,
-					fence: this.#containmentFence(),
+					// The same fence that decided `ptyConfinable`, so the gate and the enforcement can
+					// never be looking at different answers.
+					fence,
 				})
 			: await executeBash(command, {
 					cwd: commandCwd,
@@ -682,7 +696,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 					artifactPath,
 					artifactId,
 					maskSecrets,
-					fence: this.#containmentFence(),
+					fence,
 					onChunk: chunk => {
 						tailBuffer.append(chunk);
 						if (onUpdate) {

--- a/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
+++ b/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
@@ -559,6 +559,34 @@ describe("renderAboutDoc containment section", () => {
 		expect(doc).not.toContain("how a path is spelled does not change what is reachable");
 	});
 
+	/**
+	 * Landlock enforces as strongly as seatbelt but costs three things seatbelt does not, so the model
+	 * has to be told — otherwise it reads `ls /` failing as a broken sandbox and starts working around
+	 * it. Asserted against `seatbelt` too, so the Linux-only paragraph cannot leak onto macOS and
+	 * describe restrictions that are not there.
+	 */
+	it("states the Linux-only costs under landlock, and only under landlock", () => {
+		const landlock = renderAboutDoc(fakeBuildInfo(), null, null, {
+			enabled: true,
+			backend: "landlock",
+			osEnforced: true,
+		});
+		// Still makes the full enforcement claim: this backend is not weaker, just costlier.
+		expect(landlock).toContain("how a path is spelled does not change what is reachable");
+		expect(landlock).toContain("landlock");
+		expect(landlock).toContain("ls /");
+		expect(landlock).toContain("sudo");
+		expect(landlock).toContain("without a real terminal");
+
+		const seatbelt = renderAboutDoc(fakeBuildInfo(), null, null, {
+			enabled: true,
+			backend: "seatbelt",
+			osEnforced: true,
+		});
+		expect(seatbelt).not.toContain("ls /");
+		expect(seatbelt).not.toContain("without a real terminal");
+	});
+
 	it("says isolation is off rather than describing a fence that is not there", () => {
 		const doc = renderAboutDoc(fakeBuildInfo(), null, null, {
 			enabled: false,

--- a/packages/coding-agent/test/sandbox-containment-pty.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-pty.int.test.ts
@@ -7,11 +7,22 @@ import { buildContainmentFence, containmentStatus } from "@f5-sales-demo/xcsh/sa
 
 /**
  * The PTY path runs the system `sh`, so *only* the OS can confine it — there is no in-process half here
- * to fall back on. Where no backend exists, this path is not confined at all, and these tests assert
- * that rather than skipping, for the same reason as in the shell integration test: a skip reads as
- * coverage, and this is the gap that must not be implied to be closed.
+ * to fall back on. Where nothing can confine it, these tests assert the leak rather than skipping, for the
+ * same reason as in the shell integration test: a skip reads as coverage, and this is the gap that must
+ * not be implied to be closed.
+ *
+ * **Keyed on seatbelt specifically, not on `osEnforced`.** Confining this path means getting a policy onto
+ * a child that `portable-pty` spawns, and only the macOS backend can — it wraps argv, needing no hook.
+ * Landlock is applied in a `pre_exec` closure, and `CommandBuilder` exposes none, so a Linux box with a
+ * perfectly good Landlock backend still cannot confine a PTY.
+ *
+ * That distinction was found by CI rather than by reasoning: once the backend probe started reporting
+ * Landlock on the `ubuntu-22.04` runner, `osEnforced` became true there and these cases began demanding a
+ * confinement that cannot exist on that path. The product's answer on Linux is not to use the PTY path at
+ * all when a fence is present (`bash.ts`), which is where that protection is asserted; here we only test
+ * the mechanism, and only where the mechanism exists.
  */
-const OS_ENFORCED = containmentStatus(true).osEnforced;
+const PTY_CONFINABLE = containmentStatus(true).backend === "seatbelt";
 
 /**
  * The bash tool has two execution paths, and containment has to cover both.
@@ -71,17 +82,17 @@ describe("containment covers the PTY path, not just the in-process shell", () =>
 		expect(await runPty(`cat ${sibling}/secret.txt`, false)).toContain("PTY-CANARY-7734");
 	});
 
-	it(`${OS_ENFORCED ? "does not leak" : "still leaks"} a sibling checkout through the PTY path`, async () => {
+	it(`${PTY_CONFINABLE ? "does not leak" : "still leaks"} a sibling checkout through the PTY path`, async () => {
 		const out = await runPty(`cat ${sibling}/secret.txt`, true);
-		if (OS_ENFORCED) expect(out).not.toContain("PTY-CANARY-7734");
+		if (PTY_CONFINABLE) expect(out).not.toContain("PTY-CANARY-7734");
 		else expect(out).toContain("PTY-CANARY-7734");
 	});
 
 	// The env-supplied path is the specific case the text scanner cannot see, and the reason a
 	// scanner-only PTY path was a hole rather than a rough edge.
-	it(`${OS_ENFORCED ? "does not leak" : "still leaks"} through a path assembled at runtime`, async () => {
+	it(`${PTY_CONFINABLE ? "does not leak" : "still leaks"} through a path assembled at runtime`, async () => {
 		const out = await runPty(`T=${sibling}/secret.txt; cat "$T"`, true);
-		if (OS_ENFORCED) expect(out).not.toContain("PTY-CANARY-7734");
+		if (PTY_CONFINABLE) expect(out).not.toContain("PTY-CANARY-7734");
 		else expect(out).toContain("PTY-CANARY-7734");
 	});
 

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -293,6 +293,21 @@ describe("containmentStatus", () => {
 		});
 	});
 
+	/**
+	 * The failure mode that actually happened, which the throwing case does not cover.
+	 *
+	 * A native module built before this export existed simply does not have the symbol. The first version
+	 * of this code reached it through a static named import, which fails at *link* time — the tarball
+	 * install smoke test died with `SyntaxError: Export named 'containmentBackend' not found` before any
+	 * runtime guard could run. Reaching it as a namespace member turns that into `undefined`, which is a
+	 * case code can handle, and this is the shape that has to keep working.
+	 */
+	it("treats a native module with no such export as simply having no backend", () => {
+		const olderNative = {} as { containmentBackend?: () => { backend: string } };
+		const status = containmentStatus(true, "linux", () => olderNative.containmentBackend?.());
+		expect(status).toEqual({ enabled: true, backend: "scanner-only", osEnforced: false });
+	});
+
 	it("survives a probe that throws rather than taking down xcsh://about", () => {
 		const status = containmentStatus(true, "linux", () => {
 			throw new TypeError("containmentBackend is not a function");

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { buildContainmentFence, fenceVerdict } from "@f5-sales-demo/xcsh/sandbox/containment";
+import { buildContainmentFence, containmentStatus, fenceVerdict } from "@f5-sales-demo/xcsh/sandbox/containment";
 
 /**
  * The fence is deliberately *gentle*: the only thing it prevents is the assistant wandering the
@@ -240,5 +240,78 @@ describe("buildContainmentFence — review findings", () => {
 		expect(fenceVerdict(fence, path.join(shared, "ctx.md"), "write")).toBe("deny");
 		expect(fenceVerdict(fence, path.join(drop, "out.log"), "write")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(drop, "out.log"), "read")).toBe("deny");
+	});
+});
+
+/**
+ * What gets reported has to be what is actually enforcing.
+ *
+ * The backend cannot be inferred from `process.platform`: Landlock can be compiled out of the kernel,
+ * left out of its boot-time LSM list, or too old to allow cross-directory rename. Each of those looks
+ * identical from TypeScript, and each changes what the boundary is worth — so the answer comes from a
+ * probe, and these tests pin what happens for every answer it can give.
+ */
+describe("containmentStatus", () => {
+	const landlock = () => ({ backend: "landlock" });
+	const scannerOnly = () => ({ backend: "scanner-only" });
+	const unavailable = () => undefined;
+
+	it("reports seatbelt on macOS without consulting the probe at all", () => {
+		let probed = false;
+		const status = containmentStatus(true, "darwin", () => {
+			probed = true;
+			return scannerOnly();
+		});
+		expect(status).toEqual({ enabled: true, backend: "seatbelt", osEnforced: true });
+		expect(probed).toBe(false);
+	});
+
+	it("reports landlock as OS-enforced when the kernel provides it", () => {
+		expect(containmentStatus(true, "linux", landlock)).toEqual({
+			enabled: true,
+			backend: "landlock",
+			osEnforced: true,
+		});
+	});
+
+	// The case that must not over-claim: a Linux box where Landlock is absent or too old.
+	it("reports scanner-only on Linux when the kernel does not provide Landlock", () => {
+		expect(containmentStatus(true, "linux", scannerOnly)).toEqual({
+			enabled: true,
+			backend: "scanner-only",
+			osEnforced: false,
+		});
+	});
+
+	it("falls back to scanner-only when the probe cannot answer", () => {
+		// A native module from an older release has no such export. Understating the boundary is the
+		// safe direction to be wrong in; claiming enforcement that is not there is not.
+		expect(containmentStatus(true, "linux", unavailable)).toEqual({
+			enabled: true,
+			backend: "scanner-only",
+			osEnforced: false,
+		});
+	});
+
+	it("survives a probe that throws rather than taking down xcsh://about", () => {
+		const status = containmentStatus(true, "linux", () => {
+			throw new TypeError("containmentBackend is not a function");
+		});
+		expect(status.osEnforced).toBe(false);
+		expect(status.backend).toBe("scanner-only");
+	});
+
+	it("says disabled before asking anything, when isolation is off", () => {
+		let probed = false;
+		const status = containmentStatus(false, "linux", () => {
+			probed = true;
+			return landlock();
+		});
+		expect(status).toEqual({ enabled: false, backend: "disabled", osEnforced: false });
+		expect(probed).toBe(false);
+	});
+
+	it("reports scanner-only on Windows", () => {
+		expect(containmentStatus(true, "win32", scannerOnly).osEnforced).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/sandbox-fence-anchor.int.test.ts
+++ b/packages/coding-agent/test/sandbox-fence-anchor.int.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@f5-sales-demo/xcsh/config/settings";
+import type { ToolSession } from "@f5-sales-demo/xcsh/tools";
+import { BashTool } from "@f5-sales-demo/xcsh/tools/bash";
+
+/**
+ * Can the model move the boundary it is inside?
+ *
+ * The fence was rebuilt from `session.cwd` on every call, and the bash tool writes the command's
+ * resulting PWD back into that field. So a `cd` the fence permits — and it does permit `cd /usr`, because
+ * `/usr` is not sensitive and the fence is deliberately gentle — silently re-rooted the *next* fence.
+ *
+ * That mattered because the deny that isolates one customer from another is derived from the workspace's
+ * parent. Re-rooted at `/usr`, there is no expressible parent deny: `dirname("/usr")` is `/`, and denying
+ * the filesystem root is refused as too broad. Measured before the fix, with customers outside the home
+ * tree: `/work/custB/secret.env` was denied, and after `cd /usr` it was readable *and* writable.
+ *
+ * Two tool calls, no exotic spelling, and cross-tenant isolation was gone. This is the regression test.
+ *
+ * The workspace deliberately sits outside `$HOME`, because that is the layout the sibling-checkout deny
+ * exists for — with customers *under* home the home deny happens to survive the relocation and hides the
+ * bug entirely.
+ */
+describe("the containment boundary cannot be relocated by the model", () => {
+	const CANARY = "TOKEN=ANCHOR-CANARY-6120";
+	let work: string;
+	let custA: string;
+	let custB: string;
+	let session: ToolSession;
+	let bash: BashTool;
+
+	beforeEach(() => {
+		work = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "anchor-work-")));
+		custA = path.join(work, "custA");
+		custB = path.join(work, "custB");
+		fs.mkdirSync(custA);
+		fs.mkdirSync(custB);
+		fs.writeFileSync(path.join(custB, "secret.env"), `${CANARY}\n`);
+		fs.writeFileSync(path.join(custA, "notes.md"), "mine\n");
+
+		session = {
+			cwd: custA,
+			hasUI: false,
+			getArtifactsDir: () => path.join(custA, ".artifacts"),
+			settings: Settings.isolated({ "sandbox.enabled": true }),
+		} as unknown as ToolSession;
+		bash = new BashTool(session);
+	});
+
+	afterEach(() => fs.rmSync(work, { recursive: true, force: true }));
+
+	async function run(command: string): Promise<string> {
+		try {
+			const result = (await bash.execute(`call-${Math.random()}`, { command })) as {
+				content?: { type: string; text?: string }[];
+			};
+			return (result.content ?? [])
+				.filter(block => block.type === "text")
+				.map(block => block.text ?? "")
+				.join("\n");
+		} catch (error) {
+			// A refusal arrives as a thrown ToolError; its message is a result, not a crash.
+			return error instanceof Error ? error.message : String(error);
+		}
+	}
+
+	it("keeps the sibling checkout unreachable after a cd out of the tree", async () => {
+		// Control: the sibling is denied to begin with. Without this, the assertion below could pass on a
+		// session that was never fenced at all.
+		expect(await run(`cat ${path.join(custB, "secret.env")}`)).not.toContain(CANARY);
+
+		// The relocation attempt. `cd /usr` is *expected* to succeed — the fence does not confine the cwd,
+		// it denies specific trees — so this asserts nothing about the cd itself.
+		await run("c=cd; $c /usr");
+
+		// The actual property: the boundary did not travel with the shell.
+		expect(await run(`cat ${path.join(custB, "secret.env")}`)).not.toContain(CANARY);
+		expect(await run(`cat ${path.join(custB, "secret.env")}`)).not.toContain("ANCHOR-CANARY");
+	}, 120_000);
+
+	it("still cannot write into the sibling after the same cd", async () => {
+		await run("c=cd; $c /usr");
+		const planted = path.join(custB, "planted.env");
+		await run(`printf pwned > ${planted}`);
+		expect(fs.existsSync(planted)).toBe(false);
+	}, 120_000);
+
+	it("leaves ordinary work in the session's own tree alone", async () => {
+		// The fix must not have pinned the boundary somewhere the session cannot work.
+		expect(await run(`cat ${path.join(custA, "notes.md")}`)).toContain("mine");
+		expect(
+			await run(`printf ok > ${path.join(custA, "fresh.txt")} && cat ${path.join(custA, "fresh.txt")}`),
+		).toContain("ok");
+	}, 120_000);
+});

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -447,10 +447,12 @@ export interface ClipboardImage {
 /**
  * Probe the OS containment backend.
  *
- * Exported so `containmentStatus` reports what is actually enforcing rather than inferring it from
- * `process.platform`. Landlock can be compiled out, left out of the boot-time LSM list, or too old to
- * use — none of which is visible from the platform name, and all of which change what the boundary is
- * worth. Guessing here would put a claim in `xcsh://about` that the kernel does not back.
+ * Exported so `containmentStatus` reports what is actually enforcing rather
+ * than inferring it from `process.platform`. Landlock can be compiled out,
+ * left out of the boot-time LSM list, or too old to use — none of which is
+ * visible from the platform name, and all of which change what the boundary is
+ * worth. Guessing here would put a claim in `xcsh://about` that the kernel
+ * does not back.
  */
 export declare function containmentBackend(): ContainmentBackendInfo
 
@@ -462,7 +464,10 @@ export interface ContainmentBackendInfo {
   abi?: number
   /** Why there is no OS backend, when there is none. */
   reason?: string
-  /** Whether truncation is governed. False on Landlock ABI 2, which is a real if narrow gap. */
+  /**
+   * Whether truncation is governed. False on Landlock ABI 2, which is a real
+   * if narrow gap.
+   */
   truncateHandled: boolean
 }
 

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -445,6 +445,28 @@ export interface ClipboardImage {
 }
 
 /**
+ * Probe the OS containment backend.
+ *
+ * Exported so `containmentStatus` reports what is actually enforcing rather than inferring it from
+ * `process.platform`. Landlock can be compiled out, left out of the boot-time LSM list, or too old to
+ * use — none of which is visible from the platform name, and all of which change what the boundary is
+ * worth. Guessing here would put a claim in `xcsh://about` that the kernel does not back.
+ */
+export declare function containmentBackend(): ContainmentBackendInfo
+
+/** Which OS backend can confine a spawned command on this machine. */
+export interface ContainmentBackendInfo {
+  /** `"landlock"`, `"seatbelt"`, or `"scanner-only"` when the OS cannot help. */
+  backend: string
+  /** Landlock ABI version, when that is the backend. */
+  abi?: number
+  /** Why there is no OS backend, when there is none. */
+  reason?: string
+  /** Whether truncation is governed. False on Landlock ABI 2, which is a real if narrow gap. */
+  truncateHandled: boolean
+}
+
+/**
  * Canonical roots describing what the shell may reach, as built by the host.
  *
  * Absent means unrestricted. Only the model's `bash` tool supplies one;


### PR DESCRIPTION
Fixes #2572

Phase 2 containment shipped in v19.99.0 with OS-level child confinement on **macOS only**.
`compose_std_command` wrapped argv with `sandbox-exec` under `cfg(target_os = "macos")`; everywhere else
it read `context.params.containment` and did nothing with it, so `P=/home/other/secret; cat "$P"` was
unconfined on Linux. This closes that.

The gap was deferred on the stated grounds that Landlock could not be verified on the development
machine. **That was wrong**, and the correction came from the maintainer: `podman machine` on Apple
Silicon *is* an Apple-Virtualization Linux VM, so Landlock is directly testable here.

## Verified, not asserted

Measured in that VM (kernel 7.1.3, aarch64) and inside an Ubuntu 24.04 container under podman's default
seccomp:

| Check | Result |
| ----- | ------ |
| `/sys/kernel/security/lsm` | includes `landlock` |
| ABI | **9** |
| `handled_access_fs` | `0x7ffe` — bit 0 (`EXECUTE`) and bit 15 (`IOCTL_DEV`) deliberately clear |

**25 of 25 enforcement assertions pass**, driven through the real `compose_std_command` path by
`containment-check run` — nothing here reimplements the mechanism. The suite includes an **unfenced
control that leaks the canary**, because otherwise a refusal proves only that something failed.

Refused: a sibling checkout, a runtime-assembled path (`T=…; cat "$T"`), a write into the sibling, the
denied home. Still working: create/read/truncate in the workspace, `mkdir`, cross-directory `mv`, `tar`
roundtrip, `sed`/`grep` pipelines, `> /dev/null`, `/etc` and `/usr` reads, `$TMPDIR` writes, read-only
and write-only roots in their correct directions.

## Two traps that only execution found

**A Landlock rule on a non-directory may only carry file rights.** The fence grants `~/.gitconfig`
read-only, and `READ_DIR` on a *file* makes `landlock_add_rule` return `EINVAL` — so a single file root
made `create_ruleset` succeed and then every `add_rule` fail. 11 of 23 assertions red at the time, and in production
it would have been every external command, reported as an unexplained "cannot confine". The rights mask
is now narrowed per rule, decided from the descriptor rather than the path.

**`REFER` is denied by default even when its bit is absent from `handled_access_fs`.** Handling any
filesystem right therefore breaks every cross-directory `mv` and `git`'s tmp-then-rename unless REFER is
handled *and* granted. The one assertion that catches this is `mv a/x b/x`; nothing else notices. It is
also why **ABI 1 is refused outright** rather than degraded — it has no REFER bit, so there is no way to
be gentle on it.

Neither was reachable by unit test. Both are kernel constraints, not algorithm errors.

## How a default-allow fence becomes an allow-only ruleset

The fence is allow-by-default with targeted denies; Landlock has no deny primitive and no default-allow.
`compile_grant_plan` therefore grants the **complement** of the denied subtrees, walking down to each
deny and granting siblings at every level.

Two consequences worth stating:

- **Rules are always recursive**, so a directory with both reachable and unreachable children cannot be
  granted at all. Those are reported as `split_dirs` rather than hidden.
- **Compiled once per direction and merged.** Doing both at once would let a read-only root split the
  *read* plan, so `ls` of its parent would fail for no reason. There is a test for exactly that, because
  it is invisible until someone tries `ls /opt`.

Verified against a real filesystem as well as synthetic trees: a fence denying `$HOME` and `~/GIT` with
the workspace and `~/.cargo/registry` carved back out compiles to 26 grants, exactly two split dirs
(`/` and `/Users`), and only two directories enumerated — `~/GIT` is denied, so it is never read.

## Where the syscalls run

Everything expensive happens **before `fork`**: probe, compile, `create_ruleset`, then `open(O_PATH)` +
`add_rule` per grant with the descriptor closed immediately (the kernel copies the rule).

The child gets **two syscalls and no allocation** — `PR_SET_NO_NEW_PRIVS`, then
`landlock_restrict_self`. It runs post-fork in a process whose other threads are gone and may still hold
the malloc lock, so `io::Error::last_os_error()` is deliberate: it bit-packs an errno, where
`io::Error::other` would box a payload and allocate.

Registration comes **before `inject_fds`**, whose `dup2` onto caller-chosen fd numbers (`exec 3< file`)
could otherwise close the ruleset descriptor. Safe because Landlock governs no descriptor operation.

## Honest reporting, and the PTY hole

`containmentStatus` inferred the backend from `process.platform`, which cannot answer on Linux: Landlock
can be compiled out, absent from the boot LSM list, or too old. All three look identical from TypeScript
and all three change what the boundary is worth, so a new `containmentBackend()` napi export reports what
the kernel actually offers. It is reached as a *namespace member* and its call is guarded, so a native
module without the export yields `undefined` rather than breaking the module graph — see the review section.

**`pty: true` cannot be confined on Linux**, because `portable-pty`'s `CommandBuilder` exposes no
pre-exec hook (`as_command` is private; `Clone + Debug + PartialEq` preclude a closure field). Since
`pty` is a parameter the *model* supplies, leaving it reachable would make containment opt-out by the
caller it constrains — the hole just closed on macOS. A fenced non-darwin session therefore falls back to
the confined non-PTY path.

## Accepted costs, each asserted so it stays a known property

| Cost | Why it is unavoidable |
| ---- | --------------------- |
| `ls /` and `ls` of the session tree's parent fail | recursive-only rules; the alternative leaks sibling checkout *names*, weaker than what ships on macOS |
| `sudo`/`ping` fail in fenced children | `restrict_self` requires `PR_SET_NO_NEW_PRIVS` |
| `top`/`less`/interactive `ssh` lose their terminal | the PTY path cannot be confined here |
| `mv` **into** a write-only root fails (`cp` works) | REFER needs the destination's rights to cover the source's |
| First `bun install` in a genuinely fresh home fails | Landlock cannot grant a path that does not exist and its parent is denied; most machines already have `~/.bun`/`~/.cargo` |

The model is told the first three in `xcsh://about`, under the landlock branch only, so the paragraph
cannot leak onto macOS and describe restrictions that are not there.

## Testing infrastructure this adds

`crates/brush-core-vendored` is workspace-`exclude`d, so `cargo test -p brush-core` refuses to run and
the containment code has **never** had runnable Rust tests. `crates/containment-check` is a workspace
member depending on brush-core by path, which fixes that. It stays deliberately cheap — brush-core's
closure only, no napi, no tree-sitter — so it builds in a small container.

It asserts two properties whose asymmetry is the point: the plan must **never** permit what the fence
denies (a failure there is an escape), and must otherwise agree with it (a failure there is the fence
refusing ordinary work, which is how a security feature gets switched off).

## Also fixed

`brush-core` used `tokio::io::unix::AsyncFd` without declaring tokio's `net` feature. It compiled only
because another crate in the graph enabled it; building brush-core alone failed with "could not find
`unix` in `io`".

## Verification

- `cargo test -p containment-check` — 14 tests, runs on macOS, no kernel needed. Added to CI.
- `crates/containment-check/landlock-e2e.sh` — 25 enforcement assertions in the VM, and now in CI.
- `CI=1 bun run check` and `bun run test:ts` clean.
- macOS sandbox suite unaffected, plus the new anchor and reporting tests.

**Landlock enforcement is asserted in CI.** I did not know whether the `ubuntu-22.04` runner had
`landlock` in its LSM list — Ubuntu only added it to the default list in 24.04 — so this shipped first as a
diagnostic rather than a guess. It reported `lockdown,capability,landlock,yama,apparmor` on kernel
6.8-azure, so the leg now asserts: it runs the full 25-case battery, and `status` exits non-zero if the
runner ever loses Landlock, so the boundary cannot quietly stop being tested. Worth having measured — I
expected the opposite and would have moved this to a 24.04 job for nothing.

## Review found a boundary escape that is in the shipped release

Two adversarial rounds produced eight defects on this branch. Seven came from review or from testing a
review fix. The one that matters most is **not** part of the Landlock work at all:

**The model could relocate its own boundary.** The fence was rebuilt from `session.cwd` on every call, and
the bash tool writes the command's resulting PWD back into that field. A `cd` the fence permits therefore
re-rooted the *next* fence — and `cd /usr` is permitted, correctly, because `/usr` is not sensitive. But
the deny that isolates one customer from another derives from the workspace's *parent*, and rooted at
`/usr` there is no expressible parent deny: `dirname("/usr")` is `/`, and denying the filesystem root is
refused as too broad.

Measured with customers outside the home tree — the layout that deny exists for: `/work/custB/secret.env`
was denied, then after `cd /usr` it was readable **and** writable, with `planted.env` appearing on disk in
the sibling checkout. Two tool calls, no exotic spelling.

This lives in `bash.ts`, so **it is in the shipped v19.99.0**. The anchor is now captured once per session
and never follows the shell; an *operator* moving the project still re-anchors it, because the operator may
move the boundary and the model may not. The regression test was verified to fail without the fix,
including the planted file appearing. The read/write tools were never exposed to this class: `SandboxPolicy`
is deny-by-default, so relocating its root grants nothing new — only an allow-by-default fence loses a deny
when it moves.

**A symlink in a split directory granted its target.** `open_path` used `O_PATH` without `O_NOFOLLOW`, and a
Landlock rule attaches to the inode behind the descriptor. With `/home/pivot -> /home/u` while `/home/u` was
denied, `cat /home/u/secret.txt` succeeded **directly** — the whole deny gone, not merely bypassed by
spelling. Now `O_NOFOLLOW` is set and symlinks are skipped, which costs nothing because Landlock evaluates
the resolved path.

**An older native module took down the module graph.** The backend probe was a static named import, so a
`pi-natives` built before that export existed failed at *link* time with `SyntaxError: Export named
'containmentBackend' not found` — before the `try`/`catch` guarding the call could run. I had written a
comment claiming that case was handled; it was not, and the tarball install smoke test proved it. Reached as
a namespace member, an absent export is `undefined`.

## One finding deliberately not fixed

Review holds that ABI 2 should not count as enforcing, because `LANDLOCK_ACCESS_FS_TRUNCATE` only exists
from ABI 3, and that a prompt warning is not an integrity control. Both true.

I have kept ABI 2 usable anyway. On those kernels (5.19-6.1, Debian 12 among them) Landlock still confines
every read and every write to a denied path; what it cannot govern is `truncate(2)`, which destroys rather
than discloses and is unreachable through `>`. Refusing ABI 2 would leave those kernels with **no** boundary,
making a sibling checkout fully readable and writable — trading a confidentiality boundary for an integrity
guarantee, on a feature whose purpose is confidentiality.

So the gap is reported rather than folded into `osEnforced`: `ContainmentStatus` carries
`truncationUngoverned`, `xcsh://about` states it, and the model is told not to truncate outside the boundary.
The local review gate therefore still reports this as blocking, which is recorded rather than worked around.
**Raising `MINIMUM_ABI` to 3 is a one-line change if you would rather have the stricter posture.**
