### PR TITLE
feat(coding-agent): state which repositories xcsh authors in

### DIFF
--- a/packages/coding-agent/src/internal-urls/fleet-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/fleet-resolve.ts
@@ -210,6 +210,127 @@ export function classifyRepo(classes: RepoClasses | null, repo: RepoIdentity | n
 	return { className: className || CLASS_UNCLASSIFIED, declared, trustedOrg, definition };
 }
 
+/** The fleet split by what may be done in each repository, rather than by class name. */
+export interface AuthorityPartition {
+	/** Repositories xcsh authors in directly. */
+	readonly authored: readonly string[];
+	/** Repositories whose implementation belongs to a coding harness. */
+	readonly delegated: readonly string[];
+	/** Repositories that change only through the governed path. */
+	readonly governed: readonly string[];
+	/** Declared repositories whose class carries an authority this build does not know. */
+	readonly unknown: readonly string[];
+	/** Distinct `delegate_to` targets across the delegating classes. */
+	readonly delegateTargets: readonly string[];
+}
+
+/**
+ * Group every *declared* repository by the authority its class carries.
+ *
+ * Classes are the manifest's vocabulary; authority is what actually decides how xcsh
+ * contributes, and it is the only thing that answers "is this one mine?". Grouping by it
+ * keeps that answer correct if docs-control ever adds a fourth class — a new authoring
+ * class lands in `authored` without a change here.
+ *
+ * Only declared repositories appear. An unlisted one is UNCLASSIFIED and must never be
+ * presented as authorable, which is the same fail-closed stance `classifyRepo` takes.
+ */
+export function partitionByAuthority(classes: RepoClasses): AuthorityPartition {
+	const authored: string[] = [];
+	const delegated: string[] = [];
+	const governed: string[] = [];
+	const unknown: string[] = [];
+	const delegateTargets = new Set<string>();
+
+	for (const [repo, className] of Object.entries(classes.repos)) {
+		// An assignment naming an undefined class has no authority to read, so it falls
+		// through to `unknown` — never to `authored`.
+		const definition = classes.classes[className];
+		switch (definition?.authority) {
+			case AUTHORITY_AUTHOR:
+				authored.push(repo);
+				break;
+			case AUTHORITY_DELEGATE:
+				delegated.push(repo);
+				if (definition.delegateTo) delegateTargets.add(definition.delegateTo);
+				break;
+			case AUTHORITY_GOVERNED:
+				governed.push(repo);
+				break;
+			default:
+				unknown.push(repo);
+				break;
+		}
+	}
+
+	return {
+		authored: authored.sort(),
+		delegated: delegated.sort(),
+		governed: governed.sort(),
+		unknown: unknown.sort(),
+		delegateTargets: [...delegateTargets].sort(),
+	};
+}
+
+/** Repository names as inline code, or an explicit marker when the group is empty. */
+function renderRepoList(repos: readonly string[]): string {
+	return repos.length > 0 ? repos.map(r => `\`${r}\``).join(" ") : "_none_";
+}
+
+/**
+ * The roster, stated plainly: which repositories xcsh authors in, which belong to a
+ * coding harness, and which move only through the governed path.
+ *
+ * `renderFleet` below already lists every class in manifest detail, but reading it means
+ * mapping class → authority → "is this mine?" for each entry. That question comes up on
+ * its own ("which repositories do I manage?"), so answer it once, by name, and let it be
+ * read rather than inferred.
+ */
+function renderTerritory(classes: RepoClasses): string[] {
+	const { authored, delegated, governed, unknown, delegateTargets } = partitionByAuthority(classes);
+	const handOff =
+		delegateTargets.length > 0 ? delegateTargets.map(t => `\`${t}\``).join(", ") : "a dedicated coding harness";
+
+	const lines = [
+		"## Your territory",
+		"",
+		`**You author in these ${authored.length} repositories** — every one whose class carries`,
+		`\`authority: ${AUTHORITY_AUTHOR}\`. Documentation, Terraform plans, network diagrams, howtos and`,
+		"demo scripts are yours to write here, through the governed path:",
+		"",
+		renderRepoList(authored),
+		"",
+		`**${delegated.length} repositories are delegated** to ${handOff}. Your deliverable there is a`,
+		"verified issue plus the specification, review and documentation around it — never an",
+		"implementation:",
+		"",
+		renderRepoList(delegated),
+		"",
+		`**${governed.length} repositories change through the governed path only** — fleet plumbing whose`,
+		"changes propagate everywhere:",
+		"",
+		renderRepoList(governed),
+		"",
+	];
+
+	if (unknown.length > 0) {
+		lines.push(
+			`**${unknown.length} repositories carry an authority this build does not recognize.** Treat them`,
+			"as `delegate`, the restrictive case, and ask docs-control to fix the manifest:",
+			"",
+			renderRepoList(unknown),
+			"",
+		);
+	}
+
+	lines.push(
+		"This roster is read from the manifest, never inferred from what a repository contains. A",
+		"repository missing from it is UNCLASSIFIED and is never authored, whatever it holds.",
+		"",
+	);
+	return lines;
+}
+
 /** The behaviour each authority implies, stated so the agent does not have to infer it. */
 function authorityGuidance(authority: string): string[] {
 	switch (authority) {
@@ -309,16 +430,7 @@ function renderFleet(classes: RepoClasses): string[] {
 		const def = classes.classes[className];
 		lines.push(`### ${className} (${repos.length}) — authority: ${def?.authority ?? "unknown"}`);
 		if (def?.description) lines.push("", def.description);
-		lines.push(
-			"",
-			repos.length > 0
-				? repos
-						.sort()
-						.map(r => `\`${r}\``)
-						.join(" ")
-				: "_none_",
-			"",
-		);
+		lines.push("", renderRepoList(repos.sort()), "");
 	}
 
 	lines.push(
@@ -392,6 +504,7 @@ export function renderFleetDoc(
 		"# Fleet — repository classes and your authority here",
 		"",
 		...renderCurrentRepo(slug, verdict, classes),
+		...renderTerritory(classes),
 		...renderFleet(classes),
 		...renderProvenance(origin, classes),
 		...FOOTER,

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -44,7 +44,9 @@ Terraform, howtos, demo and traffic-generation scripts — through the governed 
 classified **developer** your deliverable is a rigorously-verified issue plus the specification,
 review and documentation around it, and the implementation is delegated to a development
 environment (Claude Code / Codex). In one classified **scaffolding**, changes go through the
-governed path only. An unclassified repository is treated as **developer**.
+governed path only. An unclassified repository is treated as **developer**. That document also
+names, one by one, every repository in each group — so "which repositories do I manage?" is a
+question you read the answer to, never one you estimate.
 
 You are also a **work in progress** under active development — you improve by verified
 contribution, never by claiming. See `<self-awareness>`.
@@ -313,7 +315,7 @@ Most tools resolve custom protocol URLs to internal resources (not web URLs):
 - `local://<TITLE>.md` — Finalized plan artifact created after `exit_plan_mode` approval
 - `jobs://<job-id>` — Specific job status and result
 - `mcp://<resource-uri>` — MCP resource from a connected server; matched against exact resource URIs first, then RFC 6570 URI templates advertised by connected servers
-- `xcsh://fleet` — The class of the repository you are working in and what you may author there. **MUST** read before creating, updating, or deleting content in any repository of this organization — this is about the *current repository*, not about xcsh, so the gate on the other `xcsh://` documents does not apply.
+- `xcsh://fleet` — The class of the repository you are working in and what you may author there, plus the full roster: every repository in the fleet listed by name under the authority that governs it. **MUST** read before creating, updating, or deleting content in any repository of this organization, and whenever you are asked which repositories you author in or manage — this is about the *current repository* and its fleet, not about xcsh, so the gate on the other `xcsh://` documents does not apply.
 - `xcsh://..` — Internal xcsh documentation. **MUST NOT** read unless the user asks about xcsh itself.
   - `xcsh://about` — Identity, version, build fingerprint, architecture, self-improvement. **MUST** read for any question about xcsh before exploring `~/.xcsh/`.
     This document contains the authoritative repository URL, issues URL, and source location.
@@ -349,7 +351,8 @@ from the contents**. Before you create, update, or delete content in any reposit
 organization, read `xcsh://fleet` and act on its verdict:
 - **content** → author directly. You do not need permission to write documentation, Terraform,
   howtos, diagrams or demo scripts here; you do need the governed path — linked issue → branch →
-  pull request → CI → auto-merge, never a commit to `main`.
+  pull request → CI → auto-merge, never a commit to `main`. `xcsh://fleet` lists every content
+  repository by name under "Your territory"; that list is the answer to what you author in.
 - **developer** → do not implement feature code. File a CONTRIBUTING-compliant issue (reproduce
   first, no unverified claims) and delegate the implementation to a dedicated coding harness.
   Specifying, reviewing and documenting remain yours.

--- a/packages/coding-agent/test/internal-urls/fleet-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/fleet-resolve.test.ts
@@ -6,6 +6,7 @@ import {
 	createFleetResolver,
 	createLiveCwdGetter,
 	parseRepoClasses,
+	partitionByAuthority,
 	repoNameFromOrigin,
 	TRUSTED_ORGS,
 } from "@f5-sales-demo/xcsh/internal-urls/fleet-resolve";
@@ -322,5 +323,143 @@ describe("xcsh://fleet document", () => {
 		expect(received.join(" ")).toContain("docs-control");
 		expect(res.content).toContain("## Fleet");
 		expect(res.content).toContain("mcn");
+	});
+});
+
+describe("partitionByAuthority", () => {
+	const SOURCE_REPO = "f5-sales-demo/docs-control";
+
+	/** Build a RepoClasses from a repo_classes literal, the way the manifest ships it. */
+	function classesOf(repoClasses: unknown) {
+		const parsed = parseRepoClasses(JSON.stringify({ source_repo: SOURCE_REPO, repo_classes: repoClasses }));
+		if (!parsed) throw new Error("fixture did not parse");
+		return parsed;
+	}
+
+	it("groups declared repos by the authority their class carries", () => {
+		const parsed = parseRepoClasses(GOVERNANCE);
+		if (!parsed) throw new Error("fixture did not parse");
+		const part = partitionByAuthority(parsed);
+		expect(part.authored).toEqual(["mcn", "waf"]);
+		expect(part.delegated).toEqual(["api-specs", "xcsh"]);
+		expect(part.governed).toEqual(["docs-control"]);
+		expect(part.unknown).toEqual([]);
+	});
+
+	it("reports the delegate targets the manifest declares, deduped", () => {
+		const part = partitionByAuthority(
+			classesOf({
+				_default: "developer",
+				classes: {
+					developer: { authority: "delegate", delegate_to: "claude-code|codex" },
+					tooling: { authority: "delegate", delegate_to: "claude-code|codex" },
+				},
+				repos: { xcsh: "developer", console: "tooling" },
+			}),
+		);
+		expect(part.delegateTargets).toEqual(["claude-code|codex"]);
+	});
+
+	it("never lists a repo whose class carries an unrecognized authority as authored", () => {
+		const part = partitionByAuthority(
+			classesOf({
+				_default: "developer",
+				classes: { odd: { authority: "curator" }, content: { authority: "author" } },
+				repos: { weird: "odd", mcn: "content" },
+			}),
+		);
+		expect(part.unknown).toEqual(["weird"]);
+		expect(part.authored).toEqual(["mcn"]);
+	});
+
+	it("never lists a repo assigned to an undefined class as authored", () => {
+		// A typo in `repos` must withhold authority, not inherit it from somewhere.
+		const part = partitionByAuthority(
+			classesOf({
+				_default: "developer",
+				classes: { content: { authority: "author" } },
+				repos: { mcn: "content", oops: "contnet" },
+			}),
+		);
+		expect(part.authored).toEqual(["mcn"]);
+		expect(part.unknown).toEqual(["oops"]);
+	});
+
+	it("picks up a new authoring class without needing a code change", () => {
+		// Grouping by authority rather than class name is what makes this hold.
+		const part = partitionByAuthority(
+			classesOf({
+				_default: "developer",
+				classes: { collateral: { authority: "author" } },
+				repos: { "account-plans": "collateral" },
+			}),
+		);
+		expect(part.authored).toEqual(["account-plans"]);
+	});
+
+	it("handles a manifest that assigns no repositories at all", () => {
+		const part = partitionByAuthority(
+			classesOf({ _default: "developer", classes: { content: { authority: "author" } }, repos: {} }),
+		);
+		expect(part.authored).toEqual([]);
+		expect(part.delegated).toEqual([]);
+		expect(part.governed).toEqual([]);
+		expect(part.unknown).toEqual([]);
+	});
+});
+
+describe("xcsh://fleet territory roster", () => {
+	/** The territory section: everything between its heading and the class listing. */
+	function territoryOf(doc: string): string {
+		const start = doc.indexOf("## Your territory");
+		expect(start).toBeGreaterThan(-1);
+		return doc.slice(start, doc.indexOf("## Fleet"));
+	}
+
+	it("names the repositories xcsh authors in, so the answer is read not inferred", async () => {
+		const territory = territoryOf(await render("https://github.com/f5-sales-demo/mcn.git", GOVERNANCE));
+		expect(territory).toContain("`mcn`");
+		expect(territory).toContain("`waf`");
+		expect(territory).toMatch(/2 repositories/);
+	});
+
+	it("separates the delegated repos and names who they go to", async () => {
+		const territory = territoryOf(await render("https://github.com/f5-sales-demo/mcn.git", GOVERNANCE));
+		expect(territory).toContain("`xcsh`");
+		expect(territory).toContain("`api-specs`");
+		expect(territory).toContain("claude-code|codex");
+		expect(territory).toMatch(/verified issue/i);
+	});
+
+	it("states the roster is manifest-declared, not inferred from repo contents", async () => {
+		const territory = territoryOf(await render("https://github.com/f5-sales-demo/mcn.git", GOVERNANCE));
+		expect(territory).toMatch(/read from the manifest/i);
+		expect(territory).toContain("UNCLASSIFIED");
+	});
+
+	it("shows the same roster from a developer repo — it describes the fleet, not the cwd", async () => {
+		const fromContent = territoryOf(await render("https://github.com/f5-sales-demo/mcn.git", GOVERNANCE));
+		const fromDeveloper = territoryOf(await render("https://github.com/f5-sales-demo/xcsh.git", GOVERNANCE));
+		expect(fromDeveloper).toBe(fromContent);
+	});
+
+	it("appears after the current-repo verdict and before the class listing", async () => {
+		const doc = await render("https://github.com/f5-sales-demo/mcn.git", GOVERNANCE);
+		expect(doc.indexOf("## This repository")).toBeLessThan(doc.indexOf("## Your territory"));
+		expect(doc.indexOf("## Your territory")).toBeLessThan(doc.indexOf("## Fleet"));
+	});
+
+	it("renders an empty authoring group explicitly rather than silently", async () => {
+		const noContent = JSON.stringify({
+			source_repo: "f5-sales-demo/docs-control",
+			repo_classes: {
+				_default: "developer",
+				classes: { developer: { authority: "delegate", delegate_to: "claude-code|codex" } },
+				repos: { xcsh: "developer" },
+			},
+		});
+		const territory = territoryOf(await render("https://github.com/f5-sales-demo/xcsh.git", noContent));
+		expect(territory).toContain("_none_");
+		expect(territory).toMatch(/0 repositories/);
 	});
 });


### PR DESCRIPTION
Closes #2586

`xcsh://fleet` gains a **Your territory** section: the roster, by name, of what xcsh authors, what it delegates and to whom, and what moves only through the governed path. Derived from the `authority` that `repo_classes` already declares — no new manifest field, `governance.json` untouched.

### Rendered against the real manifest, offline

```
## Your territory

**You author in these 19 repositories** — every one whose class carries
`authority: author`. Documentation, Terraform plans, network diagrams, howtos and
demo scripts are yours to write here, through the governed path:

`administration` `api-protection` `bot-advanced` `bot-standard` `cdn` `cdn-simulator`
`csd` `ddos` `demo-resources` `dns` `docs` `mcn` `nginx` `observability` `origin-server`
`traffic-generator` `waf` `was` `webapp-api-protection`

**15 repositories are delegated** to `claude-code|codex`. Your deliverable there is a
verified issue plus the specification, review and documentation around it — never an
implementation:

`api-specs` `api-specs-enriched` `console` `docs-builder` `docs-icons` `docs-theme`
`i18n-core` `marketplace` `marketplace-claude-code` `starlight-llms-txt`
`starlight-mega-menu` `terraform-provider-xcsh` `vscode-xcsh` `xcsh` `xcsh-chrome-extension`

**5 repositories change through the governed path only** — fleet plumbing whose
changes propagate everywhere:

`apt-repo` `code-review` `demo-resource-template` `devcontainer` `docs-control`

This roster is read from the manifest, never inferred from what a repository contains. A
repository missing from it is UNCLASSIFIED and is never authored, whatever it holds.
```

### Design notes

- **Grouped by authority, not class name.** Authority is what decides how xcsh contributes; a fourth authoring class added by docs-control lands in `authored` with no code change here. There is a test for exactly that.
- **Fail-closed throughout.** Only *declared* repositories appear. A repo assigned to an undefined class, or to a class whose authority this build does not recognize, falls to `unknown` and renders as "treat as `delegate`" — never dropped, never listed as authored.
- **`delegate_to` is read, not hardcoded.**
- **Fleet-wide, not cwd-dependent.** Identical from a `content` and a `developer` checkout, while the current-repo verdict still differs correctly.
- **Resolution order unchanged**: local synced `governance.json` first, `gh` against docs-control only as fallback. Verified with `gh` forced to fail.
- `renderFleet`'s inline list-building is now shared with the new section via `renderRepoList` rather than duplicated.

Three wording edits in `system-prompt.md` so the assistant treats "which repos do I manage?" as a lookup rather than an estimate.

### Verification

```
$ bun test ./packages/coding-agent/test/internal-urls/fleet-resolve.test.ts
 42 pass, 0 fail, 102 expect() calls          # 12 new
$ bunx biome check <changed files>            # clean
$ bunx tsc --noEmit                           # 0 errors in the changed files
```

**Pre-existing failure, unrelated:** 20 tests in `test/internal-urls/xcsh-protocol-console.test.ts` fail with `Cannot find module '@f5-sales-demo/pi-utils'`. Confirmed identical with this branch's changes stashed — 20 fail before, 20 fail after. This PR takes the directory from 130 → 142 passing with no new failures.

Paired with f5-sales-demo/.github#9 (the same classification, scoping `clone-all-repos.sh`) and f5-sales-demo/docs-control#853 (recording the consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)