### PR TITLE
fix(sandbox): let the CLIs xcsh drives read their own configuration

### DIFF
--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -11,9 +11,17 @@ followed symlinks — so how a path is spelled does not change what is reachable
   `~/go/pkg/mod`, …), the network, and running programs are all untouched.
 - The CLIs you drive keep their own configuration, so `gh`, `glab`, `az`, `aws`, `gcloud`, `sf`,
   `docker`, `kubectl` and `terraform` all work normally, including the token refreshes and logs they
-  write as they go. What you cannot do is *rewrite* the settings that name a command to run —
-  `~/.aws/config`, `~/.kube/config`, `~/.docker/config.json`, a plugin directory. Those stay readable
-  and are refused for writing, because a later unfenced run of that CLI would execute what you wrote.
+  write as they go.
+{{#unless containment.commandConfigWritable}}
+  What you cannot do is *rewrite* the settings that name a command to run — `~/.aws/config`,
+  `~/.kube/config`, `~/.docker/config.json`, a plugin directory. Those stay readable and are refused for
+  writing, because a later unfenced run of that CLI would execute what you wrote.
+{{else}}
+  This backend cannot hold a file read-only inside a writable directory, so those settings are
+  writable here. Do not edit the ones that name a command to run — `~/.aws/config`, `~/.kube/config`,
+  `~/.docker/config.json`, `~/.azure/config`, a plugin directory — unless the operator asked you to: a
+  later unfenced run of that CLI would execute what you wrote.
+{{/unless}}
 - What is refused: reading or writing outside the session directory — another checkout, `~/.ssh`,
   `~/.gnupg`, `~/Documents`, and other sessions' transcripts. `~/.gitconfig` is readable, not writable.
 - `cd` out of the session tree is refused, because every later relative path would resolve there.

--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -7,10 +7,13 @@ Filesystem isolation is **on**. Enforcement for the `bash` tool: **{{containment
 Your shell is confined by the operating system, not by inspecting the command you wrote. A path is
 checked where it is actually opened, after the shell has expanded variables, resolved aliases and
 followed symlinks — so how a path is spelled does not change what is reachable.
-- Ordinary work is unrestricted: system paths, `/tmp`, package caches (`~/.bun`, `~/.cargo`, …), the
-  network, and running programs are all untouched.
+- Ordinary work is unrestricted: system paths, `/tmp`, package caches (`~/.bun`, `~/.cargo`,
+  `~/go/pkg/mod`, …), the network, and running programs are all untouched.
+- The CLIs you drive keep their own configuration, so `gh`, `glab`, `az`, `aws`, `gcloud`, `sf`,
+  `docker`, `kubectl` and `terraform` all work normally — including the commands that log in and write
+  a refreshed token back.
 - What is refused: reading or writing outside the session directory — another checkout, `~/.ssh`,
-  `~/.aws`, `~/Documents`, and other sessions' transcripts. `~/.gitconfig` is readable, not writable.
+  `~/.gnupg`, `~/Documents`, and other sessions' transcripts. `~/.gitconfig` is readable, not writable.
 - `cd` out of the session tree is refused, because every later relative path would resolve there.
 
 If a command is refused, do not try to reach the same path a different way: the boundary is enforced

--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -10,8 +10,10 @@ followed symlinks — so how a path is spelled does not change what is reachable
 - Ordinary work is unrestricted: system paths, `/tmp`, package caches (`~/.bun`, `~/.cargo`,
   `~/go/pkg/mod`, …), the network, and running programs are all untouched.
 - The CLIs you drive keep their own configuration, so `gh`, `glab`, `az`, `aws`, `gcloud`, `sf`,
-  `docker`, `kubectl` and `terraform` all work normally — including the commands that log in and write
-  a refreshed token back.
+  `docker`, `kubectl` and `terraform` all work normally, including the token refreshes and logs they
+  write as they go. What you cannot do is *rewrite* the settings that name a command to run —
+  `~/.aws/config`, `~/.kube/config`, `~/.docker/config.json`, a plugin directory. Those stay readable
+  and are refused for writing, because a later unfenced run of that CLI would execute what you wrote.
 - What is refused: reading or writing outside the session directory — another checkout, `~/.ssh`,
   `~/.gnupg`, `~/Documents`, and other sessions' transcripts. `~/.gitconfig` is readable, not writable.
 - `cd` out of the session tree is refused, because every later relative path would resolve there.

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -142,15 +142,31 @@ const TOOL_CONFIG_DIRS = [
  */
 const COMMAND_BEARING_CONFIG = [
 	path.join(".aws", "config"), // credential_process = <command>
+	path.join(".aws", "cli", "alias"), // aws aliases; a leading `!` runs through a shell
 	path.join(".kube", "config"), // users[].user.exec.command
 	path.join(".docker", "config.json"), // credsStore / credHelpers -> docker-credential-*
 	path.join(".docker", "cli-plugins"), // docker-* plugin executables
 	path.join(".azure", "cliextensions"), // az extensions, executed as Python
 	path.join(".terraform.d", "plugins"), // provider binaries
 	path.join(".config", "gcloud", "virtenv"), // sourced by the gcloud launcher
-	path.join(".config", "gh", "config.yml"), // gh alias set x '!sh -c ...'
-	path.join(".config", "glab-cli", "config.yml"), // glab aliases, XDG layout
-	path.join("Library", "Application Support", "glab-cli", "config.yml"), // glab aliases, macOS layout
+	path.join(".config", "gh", "config.yml"), // gh alias set x '!sh -c ...', plus editor/browser/pager
+	// glab keeps aliases in their own file, so those can be held read-only. Its config.yml cannot:
+	// glab rewrites it on ordinary commands (atomic rename) to refresh the OAuth token and the
+	// update-check stamp, and holding it read-only reproduced #2581 — `glab auth status` exits 1 with
+	// "rename …/.config.yml".
+	//
+	// Worse than a failed command, and the reason this is not merely a convenience: the OAuth refresh
+	// already happened at GitLab, so a denied write loses the rotated refresh token and the operator's
+	// login is permanently dead — `invalid_grant` afterwards, even outside the fence. Observed while
+	// testing this change, which cost a real `glab auth login`. Any CLI that refreshes a rotating token
+	// must be able to persist it.
+	//
+	// Left writable, and the residual exposure is stated rather than hidden:
+	// that file also carries `editor`, `browser` and `duo_cli_binary_path`/`duo_cli_auto_run`, so a write
+	// there IS a code-execution vector this fence does not close. `gh` needs no such exception because it
+	// was measured working with its config.yml read-only.
+	path.join(".config", "glab-cli", "aliases.yml"),
+	path.join("Library", "Application Support", "glab-cli", "aliases.yml"),
 ];
 
 /** Read-only inside home: configuration a tool needs to behave correctly, but must not rewrite. */
@@ -168,6 +184,33 @@ function canonical(root: string): string | undefined {
 		return fs.realpathSync(root);
 	} catch {
 		return undefined;
+	}
+}
+
+/**
+ * Canonicalise as much of `target` as already exists, keeping the absent tail.
+ *
+ * `canonical` gives up on a path whose leaf is missing, and falling back to the literal string is not
+ * safe for a rule whose job is to *narrow* another one. With `~/.aws` symlinked to a vault — chezmoi,
+ * stow and yadm all do this — and no config file yet, the grant is emitted resolved (`<vault>`) while
+ * the read-only rule keeps the link spelling (`~/.aws/config`). Both backends match a rule against the
+ * path the kernel resolved, so the narrower rule covers nothing.
+ *
+ * That was verified as a real escape before this existed: through the real seatbelt profile,
+ * `printf 'credential_process = …' > <vault>/config` succeeded. Note `fenceVerdict` did NOT show it,
+ * because `pathIsWithin` normalises symlinks — the in-process check was safe while the emitted profile
+ * was not, so a test asserting only the verdict passes while the boundary leaks.
+ */
+function canonicalThroughExisting(target: string): string {
+	const tail: string[] = [];
+	let current = target;
+	for (;;) {
+		const resolved = canonical(current);
+		if (resolved !== undefined) return path.join(resolved, ...tail);
+		const parent = path.dirname(current);
+		if (parent === current) return target;
+		tail.unshift(path.basename(current));
+		current = parent;
 	}
 }
 
@@ -266,12 +309,14 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		// `bun install` creates it, so dropping absent caches would break exactly the first run.
 		// Canonicalised when present, so a symlinked cache resolves to its real location.
 		for (const cache of [...CACHE_DIRS, ...TOOL_CONFIG_DIRS]) {
-			allow.add(canonical(path.join(home, cache)) ?? path.join(home, cache));
+			allow.add(canonicalThroughExisting(path.join(home, cache)));
 		}
 		// Deeper than the grant above, so `fenceVerdict` picks these and write becomes a deny while read
-		// stays allowed. Emitted even when absent, or creating the file would be the way around it.
+		// stays allowed. Emitted even when absent, or creating the file would be the way around it — and
+		// resolved through existing ancestors, or a symlinked config dir puts the two rules in different
+		// namespaces and the narrower one stops applying.
 		for (const config of [...READ_ONLY_HOME, ...COMMAND_BEARING_CONFIG]) {
-			allowReadOnly.add(canonical(path.join(home, config)) ?? path.join(home, config));
+			allowReadOnly.add(canonicalThroughExisting(path.join(home, config)));
 		}
 	}
 

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -51,6 +51,14 @@ export interface ContainmentOptions {
 	writeOnlyRoots?: readonly string[];
 	/** Cross-session leak roots to deny. Defaults to the real memories/sessions/contexts dirs. */
 	leakRoots?: readonly string[];
+	/**
+	 * Whether the active backend can express "writable directory, except this file" — see
+	 * COMMAND_BEARING_CONFIG. True for seatbelt, false for Landlock, which cannot.
+	 *
+	 * Defaults to false, so a caller that does not know its backend gets the portable policy rather
+	 * than one that silently breaks the CLIs on Linux.
+	 */
+	narrowsWithinGrant?: boolean;
 }
 
 /**
@@ -143,6 +151,7 @@ const TOOL_CONFIG_DIRS = [
 const COMMAND_BEARING_CONFIG = [
 	path.join(".aws", "config"), // credential_process = <command>
 	path.join(".aws", "cli", "alias"), // aws aliases; a leading `!` runs through a shell
+	path.join(".azure", "config"), // extension.index_url + use_dynamic_install fetch and run wheels
 	path.join(".kube", "config"), // users[].user.exec.command
 	path.join(".docker", "config.json"), // credsStore / credHelpers -> docker-credential-*
 	path.join(".docker", "cli-plugins"), // docker-* plugin executables
@@ -315,7 +324,17 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		// stays allowed. Emitted even when absent, or creating the file would be the way around it — and
 		// resolved through existing ancestors, or a symlinked config dir puts the two rules in different
 		// namespaces and the narrower one stops applying.
-		for (const config of [...READ_ONLY_HOME, ...COMMAND_BEARING_CONFIG]) {
+		//
+		// COMMAND_BEARING_CONFIG only when the backend can express a narrowing *inside* a grant.
+		// Seatbelt can: it is last-match-wins, so a deeper deny simply overrides. Landlock cannot — its
+		// rules are allow-only and always recursive, so a read-only child turns its parent into a split
+		// dir that loses write on its own inode. Verified with `containment-check plan`: adding
+		// `~/.azure/cliextensions` as read-only made `~/.azure` itself `r-`, which would stop `az` from
+		// creating `azureProfile.json` at all. Applying it anyway would trade a code-execution path for
+		// breaking the very CLIs #2581 is about, so the gap is reported instead — the same choice already
+		// made for `truncationUngoverned`.
+		const narrowed = options.narrowsWithinGrant ? COMMAND_BEARING_CONFIG : [];
+		for (const config of [...READ_ONLY_HOME, ...narrowed]) {
 			allowReadOnly.add(canonicalThroughExisting(path.join(home, config)));
 		}
 	}
@@ -380,6 +399,14 @@ export interface ContainmentStatus {
 	 * different claims and an operator is entitled to know which one they have.
 	 */
 	readonly truncationUngoverned?: boolean;
+	/**
+	 * Set when the backend cannot hold a file read-only inside a writable directory, so the
+	 * command-bearing CLI settings (`~/.aws/config`, `~/.kube/config`, …) are writable. Landlock's rules
+	 * are allow-only and recursive; narrowing inside a grant would strip write from the parent directory
+	 * and break the CLIs the grant exists for. Reported rather than folded into `osEnforced`, because it
+	 * changes what a write to those paths means, not whether the boundary holds.
+	 */
+	readonly commandConfigWritable?: boolean;
 }
 
 /**
@@ -421,6 +448,8 @@ export function containmentStatus(
 			osEnforced: true,
 			// Absent on the ABI that governs truncation; present, and stated, on the one that does not.
 			...(probed.truncateHandled === false ? { truncationUngoverned: true } : {}),
+			// Always true here: no Landlock ABI can narrow a right inside a grant.
+			commandConfigWritable: true,
 		};
 	}
 	return { enabled: true, backend: "scanner-only", osEnforced: false };

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -78,6 +78,9 @@ const CACHE_DIRS = [
 	// Go keeps its module cache under ~/go, but ~/go also holds checked-out source and `go install`
 	// output, so only the cache is granted. Missed in the original list; `go build` failed for it.
 	path.join("go", "pkg", "mod"),
+	// The build cache is separate from the module cache and `go build` needs both. On macOS it lands in
+	// ~/Library/Caches (already granted); on Linux it is ~/.cache/go-build, which nothing else covers.
+	path.join(".cache", "go-build"),
 	// No credential convention of their own, so granted whole.
 	".pnpm-store",
 	".deno",
@@ -89,18 +92,21 @@ const CACHE_DIRS = [
  * Config and state directories of the CLIs xcsh ships plugins and skills for — the same list it probes
  * for in `internal-urls/computer-profile.ts`.
  *
- * Granted **read and write**, which is a deliberate trade rather than an oversight. In v19.100.0 the home
- * deny covered all of these, so every one of `gh`, `glab`, `sf`, `az`, `aws` and `gcloud` failed on its
- * own configuration — and the agent is instructed to file issues with `gh`. Write is required too: these
- * CLIs persist refreshed tokens, logs and profiles during ordinary use, and `gh auth login`, `az login`,
- * `aws sso login` and `sf org login` all write here.
+ * Granted read and write. In v19.100.0 the home deny covered all of these, so every one of `gh`, `glab`,
+ * `sf`, `az`, `aws` and `gcloud` failed on its own configuration — and the agent is instructed to file
+ * issues with `gh` (#2581). Write is required, not convenience: `az` writes a log per invocation to
+ * `~/.azure/commands`, `sf` writes a dated log into `~/.sf`, and both `aws` and `gcloud` refresh cached
+ * tokens without being asked. Measured with these read-only instead: `az` exits 1 on
+ * `~/.azure/commands/<stamp>.log`, and `sf` reproduces the original `EPERM` crash on `~/.sf/sf-<date>.log`.
  *
  * The cost, stated plainly: a fence keyed on paths cannot let `aws` read `~/.aws/credentials` without
- * letting `cat` read it, so the operator's cloud credentials are reachable from a fenced shell. That is
- * accepted because the fence exists to stop the assistant wandering between customer workspaces, not to
- * withhold the operator's own credential store from the operator's own CLIs — and because the native
- * `az`/`aws` tools already act with those credentials, so denying the shell path broke the CLIs without
- * protecting anything. What is *not* granted: `~/.ssh`, `~/.gnupg`, and every path no shipped tool needs.
+ * letting `cat` read it, so the operator's cloud credentials are readable from a fenced shell. Accepted,
+ * because the fence exists to stop the assistant wandering between customer workspaces rather than to
+ * withhold the operator's credential store from the operator's own CLIs — and the native `az`/`aws` tools
+ * already act with those credentials, so denying only the shell path broke the CLIs without protecting
+ * anything. `~/.ssh` and `~/.gnupg` are still denied: no shipped tool needs them.
+ *
+ * Reading a credential is not the same as being able to *replace* one, so see COMMAND_BEARING_CONFIG.
  */
 const TOOL_CONFIG_DIRS = [
 	path.join(".config", "gh"), // gh
@@ -114,6 +120,37 @@ const TOOL_CONFIG_DIRS = [
 	".docker", // docker
 	".kube", // kubectl
 	".terraform.d", // terraform
+];
+
+/**
+ * Paths inside TOOL_CONFIG_DIRS that name a command or hold a loadable executable. Read-only, so the
+ * grant above never becomes a way to run code later.
+ *
+ * This is the distinction that matters: reading `~/.aws/credentials` discloses a secret, but *writing*
+ * `~/.aws/config` installs a `credential_process` that the operator's next — unfenced — `aws` call
+ * executes, with access to every customer workspace and private file the fence exists to protect. That
+ * is an escape from the sandbox rather than a leak inside it. `~/.cargo/config.toml` and
+ * `~/.gradle/init.gradle` are excluded from the cache carve-out for exactly this reason; these are the
+ * same class, and none of them was writable before #2581, so keeping them read-only means that change
+ * adds no new write capability on any path that can cause execution.
+ *
+ * Each entry is a documented mechanism, not a guess: `credential_process` (aws), `user.exec`
+ * (kubeconfig), `credsStore`/`credHelpers` and CLI plugins (docker), Python extensions (az), provider
+ * binaries (terraform), the virtualenv `activate` that gcloud's launcher sources, and `!`-prefixed shell
+ * aliases (gh, glab). The CLIs still read all of them, so nothing stops working; only rewriting does.
+ * `gh auth login` and `glab auth login` are interactive and belong outside a fenced session anyway.
+ */
+const COMMAND_BEARING_CONFIG = [
+	path.join(".aws", "config"), // credential_process = <command>
+	path.join(".kube", "config"), // users[].user.exec.command
+	path.join(".docker", "config.json"), // credsStore / credHelpers -> docker-credential-*
+	path.join(".docker", "cli-plugins"), // docker-* plugin executables
+	path.join(".azure", "cliextensions"), // az extensions, executed as Python
+	path.join(".terraform.d", "plugins"), // provider binaries
+	path.join(".config", "gcloud", "virtenv"), // sourced by the gcloud launcher
+	path.join(".config", "gh", "config.yml"), // gh alias set x '!sh -c ...'
+	path.join(".config", "glab-cli", "config.yml"), // glab aliases, XDG layout
+	path.join("Library", "Application Support", "glab-cli", "config.yml"), // glab aliases, macOS layout
 ];
 
 /** Read-only inside home: configuration a tool needs to behave correctly, but must not rewrite. */
@@ -231,7 +268,9 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		for (const cache of [...CACHE_DIRS, ...TOOL_CONFIG_DIRS]) {
 			allow.add(canonical(path.join(home, cache)) ?? path.join(home, cache));
 		}
-		for (const config of READ_ONLY_HOME) {
+		// Deeper than the grant above, so `fenceVerdict` picks these and write becomes a deny while read
+		// stays allowed. Emitted even when absent, or creating the file would be the way around it.
+		for (const config of [...READ_ONLY_HOME, ...COMMAND_BEARING_CONFIG]) {
 			allowReadOnly.add(canonical(path.join(home, config)) ?? path.join(home, config));
 		}
 	}

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -75,11 +75,45 @@ const CACHE_DIRS = [
 	path.join(".yarn", "berry", "cache"),
 	path.join(".rustup", "toolchains"),
 	path.join(".rustup", "downloads"),
+	// Go keeps its module cache under ~/go, but ~/go also holds checked-out source and `go install`
+	// output, so only the cache is granted. Missed in the original list; `go build` failed for it.
+	path.join("go", "pkg", "mod"),
 	// No credential convention of their own, so granted whole.
 	".pnpm-store",
 	".deno",
 	path.join("Library", "Caches"),
 	path.join("Library", "pnpm"),
+];
+
+/**
+ * Config and state directories of the CLIs xcsh ships plugins and skills for — the same list it probes
+ * for in `internal-urls/computer-profile.ts`.
+ *
+ * Granted **read and write**, which is a deliberate trade rather than an oversight. In v19.100.0 the home
+ * deny covered all of these, so every one of `gh`, `glab`, `sf`, `az`, `aws` and `gcloud` failed on its
+ * own configuration — and the agent is instructed to file issues with `gh`. Write is required too: these
+ * CLIs persist refreshed tokens, logs and profiles during ordinary use, and `gh auth login`, `az login`,
+ * `aws sso login` and `sf org login` all write here.
+ *
+ * The cost, stated plainly: a fence keyed on paths cannot let `aws` read `~/.aws/credentials` without
+ * letting `cat` read it, so the operator's cloud credentials are reachable from a fenced shell. That is
+ * accepted because the fence exists to stop the assistant wandering between customer workspaces, not to
+ * withhold the operator's own credential store from the operator's own CLIs — and because the native
+ * `az`/`aws` tools already act with those credentials, so denying the shell path broke the CLIs without
+ * protecting anything. What is *not* granted: `~/.ssh`, `~/.gnupg`, and every path no shipped tool needs.
+ */
+const TOOL_CONFIG_DIRS = [
+	path.join(".config", "gh"), // gh
+	path.join(".config", "glab-cli"), // glab, XDG layout
+	path.join("Library", "Application Support", "glab-cli"), // glab, macOS layout
+	".sf", // sf
+	".sfdx", // sf, legacy layout still read by current versions
+	".azure", // az
+	".aws", // aws
+	path.join(".config", "gcloud"), // gcloud
+	".docker", // docker
+	".kube", // kubectl
+	".terraform.d", // terraform
 ];
 
 /** Read-only inside home: configuration a tool needs to behave correctly, but must not rewrite. */
@@ -194,7 +228,9 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		// Granted whether or not they exist yet. `~/.bun` has to be writable *before* the first
 		// `bun install` creates it, so dropping absent caches would break exactly the first run.
 		// Canonicalised when present, so a symlinked cache resolves to its real location.
-		for (const cache of CACHE_DIRS) allow.add(canonical(path.join(home, cache)) ?? path.join(home, cache));
+		for (const cache of [...CACHE_DIRS, ...TOOL_CONFIG_DIRS]) {
+			allow.add(canonical(path.join(home, cache)) ?? path.join(home, cache));
+		}
 		for (const config of READ_ONLY_HOME) {
 			allowReadOnly.add(canonical(path.join(home, config)) ?? path.join(home, config));
 		}

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -543,6 +543,9 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			extraRoots: artifactsDir ? [artifactsDir] : [],
 			readOnlyRoots: (this.session.settings.get("sandbox.allowRead") as string[] | undefined) ?? [],
 			writeOnlyRoots: (this.session.settings.get("sandbox.allowWrite") as string[] | undefined) ?? [],
+			// Only seatbelt can hold a file read-only inside a writable directory; Landlock's rules are
+			// recursive, so asking for it there would strip write from the parent and break the CLIs.
+			narrowsWithinGrant: containmentStatus(true).backend === "seatbelt",
 		});
 	}
 

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -255,7 +255,8 @@ describe("buildContainmentFence — review findings", () => {
 			expect(fenceVerdict(fence, path.join(home, config), "write")).toBe("allow");
 		}
 
-		// Readable, but see the command-bearing test below: these are deliberately not writable.
+		// Readable, but see the command-bearing test below: these are deliberately not writable when the
+		// backend can express that.
 		for (const readOnly of [".aws/config", ".kube/config", "Library/Application Support/glab-cli/aliases.yml"]) {
 			expect(fenceVerdict(fence, path.join(home, readOnly), "read")).toBe("allow");
 		}
@@ -269,7 +270,7 @@ describe("buildContainmentFence — review findings", () => {
 		const home = realTmp("execconf");
 		const workspace = path.join(home, "w");
 		fs.mkdirSync(workspace, { recursive: true });
-		const fence = buildContainmentFence({ workspace, home });
+		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
 
 		for (const bearing of [
 			".aws/config", // credential_process = <command>
@@ -309,7 +310,7 @@ describe("buildContainmentFence — review findings", () => {
 		fs.symlinkSync(vault, path.join(home, ".aws"));
 		expect(fs.existsSync(path.join(vault, "config"))).toBe(false);
 
-		const fence = buildContainmentFence({ workspace, home });
+		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
 
 		// Assert the emitted ROOT, not the verdict. `fenceVerdict` normalises symlinks via
 		// `pathIsWithin`, so it answered "deny" even while the profile handed to sandbox-exec carried the
@@ -330,12 +331,46 @@ describe("buildContainmentFence — review findings", () => {
 		const home = realTmp("aliashome");
 		const workspace = path.join(home, "w");
 		fs.mkdirSync(workspace, { recursive: true });
-		const fence = buildContainmentFence({ workspace, home });
+		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
 
 		expect(fenceVerdict(fence, path.join(home, ".aws", "cli", "alias"), "write")).toBe("deny");
 		expect(fenceVerdict(fence, path.join(home, ".aws", "cli", "alias"), "read")).toBe("allow");
 		// The cache beside it is what `aws sso login` and assume-role write, so it stays writable.
 		expect(fenceVerdict(fence, path.join(home, ".aws", "cli", "cache", "x.json"), "write")).toBe("allow");
+	});
+
+	// Landlock cannot narrow a right inside a grant: its rules are allow-only and recursive, so holding
+	// a file read-only inside a writable directory turns the parent into a split dir that loses write on
+	// its own inode. Verified with `containment-check plan` — adding ~/.azure/cliextensions as read-only
+	// made ~/.azure itself `r-`, which stops `az` writing azureProfile.json at all. So on that backend the
+	// narrowing is skipped and the gap is reported, rather than breaking the CLIs #2581 is about.
+	it("skips the command-bearing narrowing on a backend that cannot express it", () => {
+		const home = realTmp("nonarrow");
+		const workspace = path.join(home, "w");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: false });
+
+		// Writable, because the alternative is a directory the CLI cannot write to at all.
+		for (const bearing of [".aws/config", ".kube/config", ".azure/config"]) {
+			expect(fenceVerdict(fence, path.join(home, bearing), "write")).toBe("allow");
+		}
+		// ~/.gitconfig is NOT part of this: it is read-only via its own root, not a narrowing inside a
+		// grant, so it must survive on every backend.
+		expect(fenceVerdict(fence, path.join(home, ".gitconfig"), "write")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(home, ".gitconfig"), "read")).toBe("allow");
+		// And the boundary itself is unchanged.
+		expect(fenceVerdict(fence, path.join(home, ".ssh", "id_rsa"), "read")).toBe("deny");
+	});
+
+	// Defaulting to the portable policy matters: a caller that does not know its backend must not get
+	// rules that break every CLI on Linux.
+	it("defaults to the portable policy when the caller does not say", () => {
+		const home = realTmp("defaultnarrow");
+		const workspace = path.join(home, "w");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home });
+
+		expect(fenceVerdict(fence, path.join(home, ".aws", "config"), "write")).toBe("allow");
 	});
 
 	// Same defect as the CACHE_DIRS carve-out, missed for Go: `go` is in the tool list xcsh probes for,
@@ -420,7 +455,14 @@ describe("containmentStatus", () => {
 			enabled: true,
 			backend: "landlock",
 			osEnforced: true,
+			// No Landlock ABI can narrow a right inside a grant, so the command-bearing CLI settings are
+			// writable there and the model is told so. Seatbelt reports no such field.
+			commandConfigWritable: true,
 		});
+	});
+
+	it("does not claim command-bearing config is writable under seatbelt", () => {
+		expect(containmentStatus(true, "darwin")).not.toHaveProperty("commandConfigWritable");
 	});
 
 	// The case that must not over-claim: a Linux box where Landlock is absent or too old.

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -241,21 +241,56 @@ describe("buildContainmentFence — review findings", () => {
 		// Read AND write: these CLIs persist refreshed tokens, logs and profiles as part of ordinary
 		// use. `gh auth login`, `az login`, `aws sso login` and `sf org login` all write here.
 		for (const config of [
-			".config/gh/hosts.yml",
-			".config/glab-cli/config.yml",
-			"Library/Application Support/glab-cli/config.yml",
+			".config/gh/hosts.yml", // the token gh authenticates with
 			".sf/sf-2026-07-28.log",
 			".sfdx/alias.json",
 			".azure/azureProfile.json",
-			".aws/config",
 			".aws/credentials",
-			".config/gcloud/virtenv/bin/activate",
-			".docker/config.json",
-			".kube/config",
+			".config/gcloud/access_tokens.db",
+			".docker/contexts/meta/x",
+			".kube/cache/discovery/x",
 			".terraform.d/credentials.tfrc.json",
 		]) {
 			expect(fenceVerdict(fence, path.join(home, config), "read")).toBe("allow");
 			expect(fenceVerdict(fence, path.join(home, config), "write")).toBe("allow");
+		}
+
+		// Readable, but see the command-bearing test below: these are deliberately not writable.
+		for (const readOnly of [".aws/config", ".kube/config", "Library/Application Support/glab-cli/config.yml"]) {
+			expect(fenceVerdict(fence, path.join(home, readOnly), "read")).toBe("allow");
+		}
+	});
+
+	// The grant above must not become a way to run code later. Writing `~/.aws/config` installs a
+	// `credential_process` that the operator's next — unfenced — `aws` call executes, with access to
+	// everything the fence protects. That is an escape, not a leak, so every command-bearing path stays
+	// read-only: the CLI still reads it, nothing stops working, only rewriting is refused.
+	it("never grants write to configuration that names a command or holds an executable", () => {
+		const home = realTmp("execconf");
+		const workspace = path.join(home, "w");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home });
+
+		for (const bearing of [
+			".aws/config", // credential_process = <command>
+			".kube/config", // users[].user.exec.command
+			".docker/config.json", // credsStore / credHelpers
+			".docker/cli-plugins/docker-evil", // plugin executable
+			".azure/cliextensions/evil/__init__.py", // az extension, executed as Python
+			".terraform.d/plugins/evil", // provider binary
+			".config/gcloud/virtenv/bin/activate", // sourced by the gcloud launcher
+			".config/gh/config.yml", // gh alias set x '!sh -c …'
+			".config/glab-cli/config.yml", // glab aliases
+			"Library/Application Support/glab-cli/config.yml",
+		]) {
+			expect(fenceVerdict(fence, path.join(home, bearing), "write")).toBe("deny");
+			// Read must survive, or the CLI cannot authenticate and #2581 is back.
+			expect(fenceVerdict(fence, path.join(home, bearing), "read")).toBe("allow");
+		}
+
+		// The state each CLI genuinely writes stays writable, or `az` exits 1 and `sf` hangs — measured.
+		for (const state of [".azure/commands/x.log", ".sf/sf-2026-07-28.log", ".aws/sso/cache/x.json"]) {
+			expect(fenceVerdict(fence, path.join(home, state), "write")).toBe("allow");
 		}
 	});
 

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -74,7 +74,11 @@ describe("buildContainmentFence", () => {
 		fs.mkdirSync(workspace, { recursive: true });
 		const fence = buildContainmentFence({ workspace, home });
 
-		for (const secret of [".ssh/id_rsa", ".aws/credentials", ".gnupg/secring.gpg", "Documents/tax.pdf"]) {
+		// `.aws/credentials` was on this list until #2581. It is now granted, deliberately: it is the
+		// credential store of a CLI xcsh drives, and a path-based fence cannot let `aws` read it without
+		// letting `cat` read it. What stays here is what no shipped tool needs — SSH and GPG private
+		// keys, and the operator's documents.
+		for (const secret of [".ssh/id_rsa", ".gnupg/secring.gpg", "Documents/tax.pdf"]) {
 			expect(fenceVerdict(fence, path.join(home, secret), "read")).toBe("deny");
 		}
 	});
@@ -222,6 +226,72 @@ describe("buildContainmentFence — review findings", () => {
 			".gradle/caches/modules-2/x",
 		]) {
 			expect(fenceVerdict(fence, path.join(home, artifact), "write")).toBe("allow");
+		}
+	});
+
+	// #2581: the home deny left every CLI xcsh ships a plugin for unable to read its own configuration.
+	// Measured on v19.100.0: `gh` exited 1, `glab` 2, `az` 1 with a Python traceback, `aws` 255 blaming a
+	// missing profile, `gcloud` 1, and `sf` exited **0** while crashing — a failure no script can detect.
+	it("grants each shipped CLI its own config and state directory", () => {
+		const home = realTmp("clihome");
+		const workspace = path.join(home, "w");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home });
+
+		// Read AND write: these CLIs persist refreshed tokens, logs and profiles as part of ordinary
+		// use. `gh auth login`, `az login`, `aws sso login` and `sf org login` all write here.
+		for (const config of [
+			".config/gh/hosts.yml",
+			".config/glab-cli/config.yml",
+			"Library/Application Support/glab-cli/config.yml",
+			".sf/sf-2026-07-28.log",
+			".sfdx/alias.json",
+			".azure/azureProfile.json",
+			".aws/config",
+			".aws/credentials",
+			".config/gcloud/virtenv/bin/activate",
+			".docker/config.json",
+			".kube/config",
+			".terraform.d/credentials.tfrc.json",
+		]) {
+			expect(fenceVerdict(fence, path.join(home, config), "read")).toBe("allow");
+			expect(fenceVerdict(fence, path.join(home, config), "write")).toBe("allow");
+		}
+	});
+
+	// Same defect as the CACHE_DIRS carve-out, missed for Go: `go` is in the tool list xcsh probes for,
+	// and its module cache lives at ~/go/pkg/mod, so `go build` failed inside the fence.
+	it("grants the Go module cache so `go build` works", () => {
+		const home = realTmp("gohome");
+		const workspace = path.join(home, "w");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home });
+
+		expect(fenceVerdict(fence, path.join(home, "go/pkg/mod/cache/download/x"), "write")).toBe("allow");
+		// Not the whole of ~/go — that holds checked-out source and built binaries, and granting it
+		// would put `go install` output inside the fence.
+		expect(fenceVerdict(fence, path.join(home, "go/src/private/x"), "read")).toBe("deny");
+	});
+
+	// The grants above must not have widened anything else. This is the property that makes the fence
+	// worth having at all, so it is asserted beside the change that could break it.
+	it("still isolates customer workspaces and private keys after the CLI grants", () => {
+		const home = realTmp("stillhome");
+		const workspace = path.join(home, "GIT", "custA");
+		const sessions = path.join(home, ".xcsh", "agent", "sessions");
+		fs.mkdirSync(workspace, { recursive: true });
+		fs.mkdirSync(sessions, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home, leakRoots: [sessions] });
+
+		for (const denied of [
+			"GIT/custB/secrets.tf", // the sibling checkout this fence exists for
+			".ssh/id_ed25519",
+			".gnupg/secring.gpg",
+			"Documents/contract.pdf",
+			".xcsh/agent/sessions/other.jsonl", // another session's transcript
+		]) {
+			expect(fenceVerdict(fence, path.join(home, denied), "read")).toBe("deny");
+			expect(fenceVerdict(fence, path.join(home, denied), "write")).toBe("deny");
 		}
 	});
 

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -256,7 +256,7 @@ describe("buildContainmentFence — review findings", () => {
 		}
 
 		// Readable, but see the command-bearing test below: these are deliberately not writable.
-		for (const readOnly of [".aws/config", ".kube/config", "Library/Application Support/glab-cli/config.yml"]) {
+		for (const readOnly of [".aws/config", ".kube/config", "Library/Application Support/glab-cli/aliases.yml"]) {
 			expect(fenceVerdict(fence, path.join(home, readOnly), "read")).toBe("allow");
 		}
 	});
@@ -280,8 +280,9 @@ describe("buildContainmentFence — review findings", () => {
 			".terraform.d/plugins/evil", // provider binary
 			".config/gcloud/virtenv/bin/activate", // sourced by the gcloud launcher
 			".config/gh/config.yml", // gh alias set x '!sh -c …'
-			".config/glab-cli/config.yml", // glab aliases
-			"Library/Application Support/glab-cli/config.yml",
+			".config/glab-cli/aliases.yml", // glab keeps aliases in their own file
+			"Library/Application Support/glab-cli/aliases.yml",
+			".aws/cli/alias", // an aws alias starting with `!` runs through a shell
 		]) {
 			expect(fenceVerdict(fence, path.join(home, bearing), "write")).toBe("deny");
 			// Read must survive, or the CLI cannot authenticate and #2581 is back.
@@ -292,6 +293,49 @@ describe("buildContainmentFence — review findings", () => {
 		for (const state of [".azure/commands/x.log", ".sf/sf-2026-07-28.log", ".aws/sso/cache/x.json"]) {
 			expect(fenceVerdict(fence, path.join(home, state), "write")).toBe("allow");
 		}
+	});
+
+	// A read-only descendant must land in the same namespace as the grant it narrows. `canonical`
+	// returns undefined for a path that does not exist yet, and falling back to the literal string is
+	// unsafe: with ~/.aws symlinked (chezmoi, stow and yadm all do this) the grant resolves to the link
+	// target while the read-only rule keeps the link path, so the kernel matches only the grant and the
+	// `credential_process` protection evaporates. Verified allow/allow before the fix.
+	it("protects command-bearing config even when its directory is a symlink", () => {
+		const home = realTmp("symconf");
+		const workspace = path.join(home, "w");
+		const vault = realTmp("vault");
+		fs.mkdirSync(workspace, { recursive: true });
+		// ~/.aws -> <vault>, and no config file exists inside it yet.
+		fs.symlinkSync(vault, path.join(home, ".aws"));
+		expect(fs.existsSync(path.join(vault, "config"))).toBe(false);
+
+		const fence = buildContainmentFence({ workspace, home });
+
+		// Assert the emitted ROOT, not the verdict. `fenceVerdict` normalises symlinks via
+		// `pathIsWithin`, so it answered "deny" even while the profile handed to sandbox-exec carried the
+		// unresolved spelling and the write went through. Verified: with the literal rule,
+		// `printf 'credential_process = …' > <vault>/config` succeeded under the real seatbelt profile.
+		// Only the emitted string tells the truth here, because that is what the backend compiles.
+		expect(fence.allowReadOnly).toContain(path.join(vault, "config"));
+		expect(fence.allowReadOnly).not.toContain(path.join(home, ".aws", "config"));
+		expect(fence.allow).toContain(vault);
+
+		// …while the rest of the tree stays writable, or `aws sso login` breaks.
+		expect(fenceVerdict(fence, path.join(vault, "sso", "cache", "x.json"), "write")).toBe("allow");
+	});
+
+	// AWS CLI reads ~/.aws/cli/alias, where an alias starting with `!` runs through a shell and can
+	// shadow a normal top-level command. Missed on the first pass because ~/.aws was granted wholesale.
+	it("refuses writes to the aws alias file, which executes through a shell", () => {
+		const home = realTmp("aliashome");
+		const workspace = path.join(home, "w");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home });
+
+		expect(fenceVerdict(fence, path.join(home, ".aws", "cli", "alias"), "write")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(home, ".aws", "cli", "alias"), "read")).toBe("allow");
+		// The cache beside it is what `aws sso login` and assume-role write, so it stays writable.
+		expect(fenceVerdict(fence, path.join(home, ".aws", "cli", "cache", "x.json"), "write")).toBe("allow");
 	});
 
 	// Same defect as the CACHE_DIRS carve-out, missed for Go: `go` is in the tool list xcsh probes for,


### PR DESCRIPTION
Fixes #2581

The home deny shipped in v19.100.0 covered every CLI configuration directory, so **six of the CLIs xcsh ships plugins for could not read their own config** inside a fenced shell — including `gh`, which the agent is instructed to use for filing issues. #2581 had to be filed with `GH_CONFIG_DIR` as a workaround.

`~/go/pkg/mod` was missed by the cache carve-out for the same reason, so `go build` failed too.

## Measured, with a baseline

Same driver, same command, only the fence differs. Driven through the real `compose_std_command` → `sandbox-exec` path by `containment-check run`, so nothing here reimplements the mechanism.

| CLI | v19.100.0 fence | this branch |
| --- | --------------- | ----------- |
| `gh api …` | 1 | **0** |
| `glab auth status` | 2 | **0** |
| `az account show` | 1 | **0** |
| `cat ~/.aws/config` | 1 | **0** |
| `gcloud config list` | 1 | **0** |
| `sf org list` | 1 | **0** |
| write `~/go/pkg/mod` | 1 | **0** |

Exactly 12 grants added, nothing removed.

## The trade, stated rather than buried

A fence keyed on paths cannot let `aws` read `~/.aws/credentials` without letting `cat` read it, so the operator's cloud credentials are readable from a fenced shell. Accepted because the fence exists to stop the assistant wandering between customer workspaces, not to withhold the operator's credential store from the operator's own CLIs — and the native `az`/`aws` tools already act with those credentials, so denying only the shell path broke the CLIs without protecting anything.

`~/.ssh` and `~/.gnupg` stay denied: no shipped tool needs them.

## Reading a credential is not replacing one

Review (codex, plus the commit security review, independently) caught that the first commit granted write to configuration that **names a command to run**. Writing `~/.aws/config` installs a `credential_process`; `~/.kube/config` takes a `user.exec`; `~/.azure/config` sets `extension.index_url` so `az` fetches and executes wheels; `~/.docker/config.json` selects a credential helper; and `cliextensions`, `cli-plugins`, `~/.terraform.d/plugins` and gcloud's sourced `virtenv` are loadable code.

The payload runs on the operator's **next, unfenced** CLI call — an escape from the sandbox, not a leak inside it. This is the distinction `~/.cargo/config.toml` and `~/.gradle/init.gradle` are already excluded for. None of these paths was writable before this change, so holding them read-only means **this change adds no new write capability on any path that can cause execution.** Verified: 7/7 write attempts refused through the real profile, reads still succeed.

Rejecting the reviewer's alternative of read-only throughout was also measured: `az` exits 1 on `~/.azure/commands/<stamp>.log`, and `sf` reproduces the original #2581 `EPERM` crash on its dated log.

## Two escapes found by review, both reproduced before fixing

**A symlinked config dir defeated the read-only rules.** `canonical` returns undefined for an absent leaf, and the literal fallback keeps the link spelling — so with `~/.aws` symlinked (chezmoi, stow and yadm all do this) the grant was emitted resolved while the narrower rule was not, leaving them in different namespaces. Reproduced end to end: `printf 'credential_process = …' > <vault>/config` **succeeded** through the real seatbelt profile, via both spellings. Now resolved through the deepest existing ancestor; all four spellings refused.

Worth stating why the test looks unusual: **`fenceVerdict` did not show this**, because `pathIsWithin` normalises symlinks. The in-process check was safe while the emitted profile was not, so the regression test asserts the emitted **root** rather than the verdict. A verdict-only test passes while the boundary leaks.

**`~/.aws/cli/alias` was writable**, where an alias beginning with `!` runs through a shell. Added, along with glab's `aliases.yml` — a separate file I had missed by only listing `config.yml`.

## The narrowing is not portable, and that is reported not hidden

Landlock rules are allow-only and always recursive, so holding a file read-only inside a writable directory turns the parent into a **split dir that loses write on its own inode**. Verified with `containment-check plan` — the complement compiler is pure Rust and runs on macOS — where adding `~/.azure/cliextensions` as read-only made `~/.azure` itself `r-`, which would stop `az` creating `azureProfile.json` at all.

**My macOS verification structurally could not see this.** So the narrowing is conditional on a backend that can express it (seatbelt is last-match-wins; Landlock cannot), and the gap is reported through `ContainmentStatus.commandConfigWritable` with `xcsh://about` telling the model — under the affected branch only. That is the same choice already made for `truncationUngoverned` on ABI 2: report the gap rather than degrade security or function silently.

`narrowsWithinGrant` defaults to **false**, so a caller that does not know its backend gets the portable policy rather than rules that break Linux. `~/.gitconfig` is unaffected — it is read-only via its own root, not a narrowing inside a grant — and that is asserted.

## One finding accepted rather than fixed, and it needs an operator decision

**glab's `config.yml` stays writable.** It is simultaneously glab's OAuth token store and the carrier of `editor`, `browser` and `duo_cli_binary_path`/`duo_cli_auto_run`, so a path-keyed fence cannot separate them. Read-only does not merely fail the command: the refresh has already happened at GitLab, so the rotated token is lost and the login dies with `invalid_grant` **even outside the fence**. Observed while testing this, at the cost of a real `glab auth login`.

So the residual exposure is documented in the code rather than hidden, and `aliases.yml` **is** held read-only. Flagged for the operator as an open decision — the alternative is dropping glab from the grant entirely and leaving it broken as in v19.100.0.

## Verification

- `bun test` sandbox suite — 159 pass, 0 fail (12 files), including the new command-bearing, symlink, alias and both-backends tests
- `cargo test -p containment-check` — 14 pass
- `CI=1 bun run check` — exit 0
- End to end on macOS through the real seatbelt profile: `gh`, `glab`, `az`, `aws`, `gcloud`, `git`, `go` all exit 0
- Negative controls retained, each refused: sibling checkout read **and** write, `~/.ssh` private keys, `~/.gnupg`, `~/Documents`, other sessions' transcripts, memories, `ls $HOME`, `~/.gitconfig` write — with an **unfenced control that leaks the canary**, because otherwise a refusal proves only that something failed

## Not fixed here

- **#2588** (filed): a genuinely fresh home cannot create its config/cache dirs under Landlock. Pre-existing (the accepted cost in #2576), but this change widened its blast radius from package caches to every CLI config dir.
- **#2582**: the command-text pre-check being stricter than the fence. Separate change.

## Local review

Three adversarial rounds; **eight findings, all confirmed, six fixed here**. The gate escalates at `max-iterations` with two outstanding: the glab trade above, and #2588. Recorded rather than worked around — see `.codex-review/verify-3.json`.

Reviewer suggestions that were refuted by measurement rather than dismissed: read-only config throughout (breaks `az` and `sf`), and workload-identity/OIDC (out of scope — the fence cannot change how an operator's installed CLIs authenticate).