### PR TITLE
fix(sandbox): stop the command-text scan refusing what the fence permits

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/bundled/sandbox-guard.ts
+++ b/packages/coding-agent/src/extensibility/extensions/bundled/sandbox-guard.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@f5-sales-demo/xcsh";
 import { settings } from "../../../config/settings";
+import { containmentStatus } from "../../../sandbox/containment";
 import { evaluateToolCall } from "../../../sandbox/enforce";
 import { resolveSessionPolicy } from "../../../sandbox/session-policy";
 
@@ -30,6 +31,11 @@ export default function sandboxGuard(pi: ExtensionAPI): void {
 			input: event.input as Record<string, unknown>,
 			cwd: ctx.cwd,
 			policy,
+			// Asked per call rather than cached at load: the answer comes from a probe of the running
+			// kernel, and a session can be created before the native module has been reached. The probe
+			// itself memoises, so this costs nothing after the first call. When an OS backend confines the
+			// shell, the command-text scan stops deciding for `bash` — see the #2582 note in enforce.ts.
+			shellOsConfined: containmentStatus(true).osEnforced,
 		});
 		return decision.block ? { block: true, reason: decision.reason } : undefined;
 	});

--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -24,7 +24,9 @@ followed symlinks — so how a path is spelled does not change what is reachable
 {{/unless}}
 - What is refused: reading or writing outside the session directory — another checkout, `~/.ssh`,
   `~/.gnupg`, `~/Documents`, and other sessions' transcripts. `~/.gitconfig` is readable, not writable.
-- `cd` out of the session tree is refused, because every later relative path would resolve there.
+- `cd` follows the same boundary as everything else: moving somewhere reachable is fine, and `cd` into
+  a place you could not read is refused. Where you stand does not widen anything — the boundary is
+  fixed for the session, so it never follows the shell.
 
 If a command is refused, do not try to reach the same path a different way: the boundary is enforced
 below the command text, so no rewriting will succeed. Say what you needed and why. The operator can

--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -28,9 +28,13 @@ followed symlinks — so how a path is spelled does not change what is reachable
   a place you could not read is refused. Where you stand does not widen anything — the boundary is
   fixed for the session, so it never follows the shell.
 
-If a command is refused, do not try to reach the same path a different way: the boundary is enforced
-below the command text, so no rewriting will succeed. Say what you needed and why. The operator can
-widen it with `--allow-path <dir>`, which grants read and write.
+If a command is refused, do not try to reach the same path a different way. Say what you needed and why.
+The operator can widen it with `--allow-path <dir>`, which grants read and write.
+
+That is an instruction, not a claim that rewriting is impossible. Two layers decide: the OS confinement
+above, and a scan of the command text before it runs. The scan reads what you wrote, so a path assembled
+at runtime can get past it — and reaching for that spelling after a refusal is precisely the behaviour
+being asked for here, whether or not it would work.
 
 {{#if containment.landlock}}
 Three things behave differently under this backend, and none of them is a bug to work around:

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -289,13 +289,28 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 	const allowWriteOnly = new Set<string>();
 	const deny = new Set<string>();
 
-	// Home is one fence. The workspace's own parent is the other, and it is the one that matters when
+	// Home is one fence. The workspace's ancestors are the other, and they are what matters when
 	// checkouts live outside home: with /work/customer-a as the workspace, /work/customer-b matched no
-	// rule at all and was readable and writable. Denying the parent closes sibling access wherever the
-	// checkouts sit, which is the threat this exists for.
+	// rule at all and was readable and writable.
+	//
+	// Every ancestor, not just the immediate parent. One level only works when the parent happens to be
+	// the container the tenants sit in; with `<container>/<tenant>/repo` the immediate parent IS the
+	// tenant, so every OTHER tenant matched nothing and the fence allowed it, read and write. That went
+	// unnoticed because the command-text scan is deny-by-default and refused those paths on the way in —
+	// the composite looked right while the fence alone did not. Removing that scan for OS-confined shells
+	// (#2582) is what exposed it, so the two changes ship together.
+	//
+	// Denying an ancestor costs nothing above it: the walk stops before anything `tooBroadToDeny`
+	// rejects, so `/`, `/usr`, `/tmp` and `$TMPDIR` are never denied and operational paths stay
+	// reachable. And it costs nothing below: the workspace is allowed at greater depth, and
+	// `fenceVerdict` takes the deepest match.
 	if (home !== undefined && home !== workspace) deny.add(home);
-	const parent = path.dirname(workspace);
-	if (parent !== workspace && !tooBroadToDeny(parent)) deny.add(parent);
+	for (let ancestor = path.dirname(workspace); ; ancestor = path.dirname(ancestor)) {
+		if (tooBroadToDeny(ancestor)) break;
+		deny.add(ancestor);
+		const next = path.dirname(ancestor);
+		if (next === ancestor) break; // reached a filesystem root that `tooBroadToDeny` did not name
+	}
 
 	for (const root of [options.sessionTmp, ...(options.extraRoots ?? [])]) {
 		if (root === undefined) continue;

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -235,6 +235,11 @@ function tooBroadToDeny(candidate: string): boolean {
 	if (candidate === path.parse(candidate).root) return true;
 	const never = [
 		safeReal(os.tmpdir()),
+		// Both spellings: `/tmp` resolves to `/private/tmp` on macOS, and the ancestor walk works on
+		// resolved paths. Without the resolved form, a workspace at `/tmp/<x>/repo` denied `/private/tmp`
+		// — every other temp path with it — which contradicts the `/tmp` guarantee in `xcsh://about`.
+		"/tmp",
+		safeReal("/tmp"),
 		"/usr",
 		"/bin",
 		"/sbin",

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -42,6 +42,14 @@ export interface ToolCallCheck {
 	input: Record<string, unknown>;
 	cwd: string;
 	policy: SandboxPolicy;
+	/**
+	 * Whether an OS backend is confining the `bash` tool's shell — seatbelt or Landlock.
+	 *
+	 * When it is, this file stops deciding for `bash`: see the #2582 note on `evaluateToolCall`.
+	 * Absent means "not known", which keeps the scan deciding, because understating the backend leaves
+	 * a refusal in place while overstating it removes the only boundary there is.
+	 */
+	shellOsConfined?: boolean;
 }
 
 export interface ToolCallDecision {
@@ -723,6 +731,24 @@ function evaluateSearchTool(check: ToolCallCheck, spec: SearchSpec): ToolCallDec
 export function evaluateToolCall(check: ToolCallCheck): ToolCallDecision {
 	const { toolName, input, cwd, policy } = check;
 	if (!policy.enabled) return ALLOW;
+
+	// #2582: where the OS confines the shell, this scan stops deciding for `bash`.
+	//
+	// The two engines have opposite defaults. This one is `SandboxPolicy` — deny-by-default, confined to
+	// the cwd. The fence is allow-by-default with targeted denies, because a deny-default profile could
+	// not even `execvp /bin/cat`. Running both made the composite their *intersection*, so the scan
+	// refused operations the fence permits and `xcsh://about` promises: a `/tmp` write, a `~/.gitconfig`
+	// read, a `/tmp` that only appeared inside a Python string.
+	//
+	// Between the two, the scan is the one that cannot be right. It reads the text of a command instead
+	// of the operation, which is the defect every sandbox issue filed against xcsh has been. It also made
+	// the guidance false — the model is told "no rewriting will succeed", yet `~/.gitconfig` was refused
+	// literally and readable through `$HOME`, which teaches it to abandon permitted work.
+	//
+	// It is deliberately *not* narrowed, because the floor is load-bearing elsewhere: `python` is covered
+	// by no fence on any platform, and on a platform with no backend this is the whole boundary. Only the
+	// decision for `bash`, on a host where something below the text is already deciding, goes away.
+	if (toolName === "bash" && check.shellOsConfined) return ALLOW;
 
 	const codeFields = CODE_FIELDS[toolName];
 	if (codeFields) return evaluateCodeTool(check, codeFields, toolName === "bash");

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -641,7 +641,10 @@ function evaluateCodeTool(check: ToolCallCheck, fields: string[], shell: boolean
 	// Both boundaries, for the same reason a `cd` target needs both: relative paths are never
 	// scanned, so wherever the command runs is somewhere it can write freely. Read alone let
 	// `{ cwd: "/shared/ctx", command: "touch notes.md" }` write into a read-only root.
-	if (rawCwd && !(policy.isAllowed(base, "read") && policy.isAllowed(base, "write"))) {
+	// `cwd: "/tmp"` has to answer the same as `cd /tmp`, or the false refusal simply moves to the other
+	// interface — and `cwd` is the one the bash prompt tells the model to prefer over `cd`.
+	const fencePermitsBase = fenced && fenceAlsoPermits(base, "read") && fenceAlsoPermits(base, "write");
+	if (rawCwd && !fencePermitsBase && !(policy.isAllowed(base, "read") && policy.isAllowed(base, "write"))) {
 		return { block: true, reason: describeDirectoryChange(policy, base) };
 	}
 

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -30,8 +30,18 @@
  *
  * So: keep it, and do not extend it. Another spelling caught here buys little now, and the pattern of
  * adding one has a poor record — two adversarial rounds on the #2542 fix alone produced six bypasses.
+ *
+ * **It is still a real layer, though, not a legacy one (#2582.)** It was tempting to conclude that the
+ * fence sits below this and therefore this can only produce false positives. That is wrong: the fence is
+ * allow-by-default and denies only home plus the workspace's ancestors, so it does not cover a second
+ * customer tree under an unrelated root, and `policy.ts` withholds the shared OS temp dir from the file
+ * tools on purpose. Deleting this would hand both away. What #2582 actually fixed is narrower — the
+ * *false refusals*, where this layer refused what the fence grants; see `fenceAlsoPermits`.
  */
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
+import { pathIsWithin } from "@f5-sales-demo/pi-utils";
 import { expandPath, parseFindPattern, parseSearchPath, resolveToCwd, splitTopLevel } from "../tools/path-utils";
 import { lexShellCommand, type ShellSimpleCommand } from "../tools/shell-lex";
 import { provenExemptWords } from "./command-operands";
@@ -45,9 +55,11 @@ export interface ToolCallCheck {
 	/**
 	 * Whether an OS backend is confining the `bash` tool's shell — seatbelt or Landlock.
 	 *
-	 * When it is, this file stops deciding for `bash`: see the #2582 note on `evaluateToolCall`.
-	 * Absent means "not known", which keeps the scan deciding, because understating the backend leaves
-	 * a refusal in place while overstating it removes the only boundary there is.
+	 * It does not stand this scan down. It only stops the scan refusing the operational paths the fence
+	 * grants, so the composite is no longer stricter than either engine — see `fenceAlsoPermits`.
+	 *
+	 * Absent means "not known", which keeps every refusal in place: understating the backend costs a
+	 * false refusal, while overstating it would relax the only boundary a scanner-only host has.
 	 */
 	shellOsConfined?: boolean;
 }
@@ -159,6 +171,65 @@ const SYSTEM_WRITE_SINKS = new Set([
 function isSystemWriteSink(resolved: string): boolean {
 	// /dev/fd/N is an already-open descriptor of this process, not a path it can newly reach.
 	return SYSTEM_WRITE_SINKS.has(resolved) || resolved.startsWith("/dev/fd/");
+}
+
+/**
+ * Paths the containment fence permits, which this scan must therefore stop refusing (#2582).
+ *
+ * The two engines have opposite defaults: this one is `SandboxPolicy`, deny-by-default and confined to
+ * the cwd, while the fence is allow-by-default with targeted denies. Running both made the composite
+ * their intersection, so the scan refused work the fence permits and `xcsh://about` promises — a `/tmp`
+ * write, a `~/.gitconfig` read, `cd /tmp`. That falsified the model's own instructions and taught it to
+ * abandon operations that were allowed.
+ *
+ * Only the *false refusals* go away. The scan keeps deciding, because it is not merely a slower copy of
+ * the fence: the fence denies home and the workspace's ancestors and allows everything else, so it does
+ * NOT cover a second customer tree under an unrelated root (`/data/globex`), and `policy.ts` deliberately
+ * withholds the shared OS temp dir from the *file* tools to stop one session reading another's scratch.
+ * Deleting this layer would hand both of those away. Adversarial review caught that; #2582's premise that
+ * the scan "cannot add security" is wrong.
+ *
+ * So this is a narrow, enumerated set — the operational paths the fence grants — and it applies to the
+ * shell only, gated on a backend actually being there. `python` is covered by no fence on any platform,
+ * and on a host with no backend this scan is the whole boundary, so neither is widened.
+ */
+function fenceAlsoPermits(resolved: string, access: SandboxAccess): boolean {
+	// The fence never mentions the temp directories, so they are reachable below the text whatever this
+	// says. Refusing them here only produced a diagnostic that contradicted the documentation.
+	if (tempRoots().some(root => pathIsWithin(root, resolved))) return true;
+	// Granted read-only by the fence (`READ_ONLY_HOME`): a tool needs it to behave correctly, and it must
+	// not be rewritten. The write direction stays refused, which matches the fence exactly.
+	if (access === "read") {
+		const home = os.homedir();
+		return [path.join(home, ".gitconfig"), path.join(home, ".config", "git")].some(root =>
+			pathIsWithin(root, resolved),
+		);
+	}
+	return false;
+}
+
+/**
+ * The temp directories, resolved once.
+ *
+ * Both spellings are needed, and conflating them is the bug this comment exists to prevent: on macOS
+ * `os.tmpdir()` is the *per-user* `/var/folders/…/T`, which is not `/tmp` at all. `xcsh://about` promises
+ * `/tmp` specifically, so covering only `os.tmpdir()` left the exact case #2582 reported still refused.
+ * Real paths as well as nominal ones, because `/tmp` is a symlink to `/private/tmp` and a resolved
+ * candidate carries the latter.
+ */
+let cachedTempRoots: string[] | undefined;
+function tempRoots(): string[] {
+	if (cachedTempRoots === undefined) {
+		const resolve = (input: string): string => {
+			try {
+				return fs.realpathSync(input);
+			} catch {
+				return input;
+			}
+		};
+		cachedTempRoots = [...new Set(["/tmp", resolve("/tmp"), os.tmpdir(), resolve(os.tmpdir())])];
+	}
+	return cachedTempRoots;
 }
 
 function firstString(input: Record<string, unknown>, keys: string[]): string | undefined {
@@ -562,6 +633,8 @@ function searchBases(raw: string, base: (token: string) => string): string[] {
 
 function evaluateCodeTool(check: ToolCallCheck, fields: string[], shell: boolean): ToolCallDecision {
 	const { input, cwd, policy } = check;
+	// The fence's allowances apply to the shell only, and only where a backend is actually enforcing.
+	const fenced = shell && check.shellOsConfined === true;
 
 	const rawCwd = typeof input.cwd === "string" ? input.cwd : undefined;
 	const base = rawCwd ? resolveToCwd(rawCwd, cwd) : cwd;
@@ -608,6 +681,9 @@ function evaluateCodeTool(check: ToolCallCheck, fields: string[], shell: boolean
 				// because relative paths go unchecked wherever the shell is standing.
 				const moved = path.resolve(base, expandPath(token));
 				if (policy.isAllowed(moved, "read") && policy.isAllowed(moved, "write")) continue;
+				// `cd /tmp` was refused while the fence permits standing there, and the boundary no
+				// longer follows the shell (#2589), so where it stands widens nothing.
+				if (fenced && fenceAlsoPermits(moved, "read") && fenceAlsoPermits(moved, "write")) continue;
 				return { block: true, reason: describeDirectoryChange(policy, moved) };
 			}
 			const resolved = resolveToCwd(token, base);
@@ -616,6 +692,9 @@ function evaluateCodeTool(check: ToolCallCheck, fields: string[], shell: boolean
 			// read or traverse". It never licenses writing into /etc, /usr or /opt; only the
 			// discard-and-echo devices are writable.
 			if (access === "read" ? isSystemPath(resolved) : isSystemWriteSink(resolved)) continue;
+			// Anything the fence grants outright: refusing it here contradicted the documentation and
+			// bought nothing, since the fence permits it below the text either way.
+			if (fenced && fenceAlsoPermits(resolved, access)) continue;
 			return deny(policy, resolved, access);
 		}
 	}
@@ -731,24 +810,6 @@ function evaluateSearchTool(check: ToolCallCheck, spec: SearchSpec): ToolCallDec
 export function evaluateToolCall(check: ToolCallCheck): ToolCallDecision {
 	const { toolName, input, cwd, policy } = check;
 	if (!policy.enabled) return ALLOW;
-
-	// #2582: where the OS confines the shell, this scan stops deciding for `bash`.
-	//
-	// The two engines have opposite defaults. This one is `SandboxPolicy` — deny-by-default, confined to
-	// the cwd. The fence is allow-by-default with targeted denies, because a deny-default profile could
-	// not even `execvp /bin/cat`. Running both made the composite their *intersection*, so the scan
-	// refused operations the fence permits and `xcsh://about` promises: a `/tmp` write, a `~/.gitconfig`
-	// read, a `/tmp` that only appeared inside a Python string.
-	//
-	// Between the two, the scan is the one that cannot be right. It reads the text of a command instead
-	// of the operation, which is the defect every sandbox issue filed against xcsh has been. It also made
-	// the guidance false — the model is told "no rewriting will succeed", yet `~/.gitconfig` was refused
-	// literally and readable through `$HOME`, which teaches it to abandon permitted work.
-	//
-	// It is deliberately *not* narrowed, because the floor is load-bearing elsewhere: `python` is covered
-	// by no fence on any platform, and on a platform with no backend this is the whole boundary. Only the
-	// decision for `bash`, on a host where something below the text is already deciding, goes away.
-	if (toolName === "bash" && check.shellOsConfined) return ALLOW;
 
 	const codeFields = CODE_FIELDS[toolName];
 	if (codeFields) return evaluateCodeTool(check, codeFields, toolName === "bash");

--- a/packages/coding-agent/src/sandbox/policy.ts
+++ b/packages/coding-agent/src/sandbox/policy.ts
@@ -113,11 +113,19 @@ export interface DefaultSandboxOptions {
  * contexts are explicitly denied, so even a broad user-configured allow cannot re-expose
  * another customer's memory, session, or credentials.
  *
- * Note: the OS temp dir is deliberately NOT allowlisted. It is shared across all
+ * Note: the OS temp dir is deliberately NOT allowlisted here. It is shared across all
  * sessions, so allowing it would let one customer's session read another's scratch
  * files. The agent should work in temp directories under its CWD; internal tool temp
  * usage bypasses this boundary (it is not a model-invoked path). A specific session
  * temp dir can still be granted via `tmpDir`.
+ *
+ * That still holds for every tool this policy governs directly. It does NOT hold for
+ * `bash` on a host with an OS backend: the containment fence never mentions the temp
+ * directories, so they are reachable below the command text regardless, and refusing
+ * them in the text scan produced only a diagnostic that contradicted `xcsh://about`
+ * (#2582). The protection was spelling-deep in any case — `T=/tmp/other; cat "$T"`
+ * never went through this check. Treat shared temp as readable by a fenced shell, and
+ * put anything that must not cross sessions under the session directory or `tmpDir`.
  */
 export function buildDefaultSandboxPolicy(opts: DefaultSandboxOptions): SandboxPolicy {
 	const cwd = path.resolve(opts.cwd);

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -574,3 +574,27 @@ describe("buildContainmentFence — isolation does not depend on how deep the wo
 		}
 	});
 });
+
+// Review of the ancestor walk: with the workspace under /tmp, canonicalisation gives /private/tmp/…,
+// and `tooBroadToDeny` named `/private` and `os.tmpdir()` but not the resolved `/tmp` — so the walk
+// denied /private/tmp and took every other temp path with it, against the guarantee in xcsh://about.
+describe("buildContainmentFence — the ancestor walk never denies a temp root", () => {
+	it("leaves /tmp usable when the workspace itself lives under it", () => {
+		const home = realTmp("tmphome");
+		const workspace = `/tmp/fence-tmp-probe-${process.pid}/repo`;
+		fs.mkdirSync(workspace, { recursive: true });
+		try {
+			const fence = buildContainmentFence({ workspace, home });
+			for (const root of fence.deny) {
+				expect(root).not.toBe("/tmp");
+				expect(root).not.toBe(fs.realpathSync("/tmp"));
+			}
+			expect(fenceVerdict(fence, "/private/tmp/other-session.txt", "read")).toBe("allow");
+			// The workspace's own container is still denied, which is the point of the walk.
+			expect(fenceVerdict(fence, `/private/tmp/fence-tmp-probe-${process.pid}/sibling/x`, "read")).toBe("deny");
+			expect(fenceVerdict(fence, path.join(fs.realpathSync(workspace), "mine.txt"), "write")).toBe("allow");
+		} finally {
+			fs.rmSync(`/tmp/fence-tmp-probe-${process.pid}`, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -521,3 +521,56 @@ describe("containmentStatus", () => {
 		expect(containmentStatus(true, "win32", scannerOnly).osEnforced).toBe(false);
 	});
 });
+
+/**
+ * The parent deny was one level deep, and that is not where tenants necessarily sit.
+ *
+ * `buildContainmentFence` denied home and the workspace's *immediate* parent. With a layout of
+ * `<container>/<tenant>/repo` the immediate parent is the tenant, so every OTHER tenant matched no rule
+ * and the fence allowed it — read and write. That went unnoticed because the command-text scan is
+ * deny-by-default and refused those paths on the way in, so the composite looked correct while the fence
+ * alone was not. Removing that scan for OS-confined shells (#2582) is what exposed it.
+ *
+ * Found by adversarial review of #2582, reproduced here before fixing: `<container>/globex/repo/secrets.tf`
+ * was `read=allow write=allow`.
+ */
+describe("buildContainmentFence — isolation does not depend on how deep the workspace sits", () => {
+	it("denies a cousin tenant, not just an immediate sibling", () => {
+		const home = realTmp("cousinhome");
+		const container = realTmp("tenants");
+		const workspace = path.join(container, "acme", "repo");
+		fs.mkdirSync(workspace, { recursive: true });
+		fs.mkdirSync(path.join(container, "globex", "repo"), { recursive: true });
+		const fence = buildContainmentFence({ workspace, home });
+
+		// The case that exists for this fence, one level deeper than the original rule reached.
+		for (const access of ["read", "write"] as const) {
+			expect(fenceVerdict(fence, path.join(container, "globex", "repo", "secrets.tf"), access)).toBe("deny");
+			expect(fenceVerdict(fence, path.join(container, "acme", "other-repo", "x"), access)).toBe("deny");
+			expect(fenceVerdict(fence, path.join(container, "loose-file.txt"), access)).toBe("deny");
+		}
+		// …and the workspace itself still works, or the fence is useless.
+		expect(fenceVerdict(fence, path.join(workspace, "notes.md"), "read")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(workspace, "notes.md"), "write")).toBe("allow");
+	});
+
+	it("still refuses to deny a root too broad to deny", () => {
+		const home = realTmp("broadhome");
+		// Directly under the OS temp dir: walking up must stop rather than deny $TMPDIR or /.
+		const workspace = path.join(fs.realpathSync(os.tmpdir()), `fence-broad-${process.pid}`);
+		fs.mkdirSync(workspace, { recursive: true });
+		try {
+			const fence = buildContainmentFence({ workspace, home });
+			for (const root of fence.deny) {
+				expect(root).not.toBe("/");
+				expect(root).not.toBe(fs.realpathSync(os.tmpdir()));
+			}
+			// Operational paths stay reachable however far up the walk went.
+			for (const p of ["/usr/bin/env", "/etc/hosts", "/bin/sh"]) {
+				expect(fenceVerdict(fence, p, "read")).toBe("allow");
+			}
+		} finally {
+			fs.rmSync(workspace, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -581,20 +581,27 @@ describe("buildContainmentFence — isolation does not depend on how deep the wo
 describe("buildContainmentFence — the ancestor walk never denies a temp root", () => {
 	it("leaves /tmp usable when the workspace itself lives under it", () => {
 		const home = realTmp("tmphome");
-		const workspace = `/tmp/fence-tmp-probe-${process.pid}/repo`;
+		const container = `/tmp/fence-tmp-probe-${process.pid}`;
+		const workspace = path.join(container, "repo");
 		fs.mkdirSync(workspace, { recursive: true });
 		try {
+			// Resolved, never hardcoded: `/tmp` really is `/private/tmp` on macOS and really is `/tmp` on
+			// Linux, and the fence works in resolved paths. Writing the macOS spelling in made this pass
+			// locally and fail on the Linux runner, where it asserted against a path that exists nowhere.
+			const realTmpRoot = fs.realpathSync("/tmp");
+			const realContainer = fs.realpathSync(container);
+
 			const fence = buildContainmentFence({ workspace, home });
 			for (const root of fence.deny) {
 				expect(root).not.toBe("/tmp");
-				expect(root).not.toBe(fs.realpathSync("/tmp"));
+				expect(root).not.toBe(realTmpRoot);
 			}
-			expect(fenceVerdict(fence, "/private/tmp/other-session.txt", "read")).toBe("allow");
+			expect(fenceVerdict(fence, path.join(realTmpRoot, "other-session.txt"), "read")).toBe("allow");
 			// The workspace's own container is still denied, which is the point of the walk.
-			expect(fenceVerdict(fence, `/private/tmp/fence-tmp-probe-${process.pid}/sibling/x`, "read")).toBe("deny");
+			expect(fenceVerdict(fence, path.join(realContainer, "sibling", "x"), "read")).toBe("deny");
 			expect(fenceVerdict(fence, path.join(fs.realpathSync(workspace), "mine.txt"), "write")).toBe("allow");
 		} finally {
-			fs.rmSync(`/tmp/fence-tmp-probe-${process.pid}`, { recursive: true, force: true });
+			fs.rmSync(container, { recursive: true, force: true });
 		}
 	});
 });

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -752,3 +752,45 @@ describe("evaluateToolCall — bash false refusals under an OS fence (#2582)", (
 		expect(check("bash", { command: `printf x > ${path.join(tmp, "probe.txt")}` }).block).toBe(true);
 	});
 });
+
+// Review: the fenced allowance was applied only to paths parsed out of the command text, so the
+// documented `cwd` parameter — which the bash prompt tells the model to prefer over `cd` — still
+// refused a temp path. The false refusal simply moved to the other interface.
+describe("evaluateToolCall — the bash cwd parameter agrees with cd (#2582)", () => {
+	const tmp = fs.realpathSync(os.tmpdir());
+
+	it("accepts a cwd the fence permits", () => {
+		const decision = evaluateToolCall({
+			toolName: "bash",
+			input: { command: "pwd", cwd: tmp },
+			cwd: CWD,
+			policy: makePolicy(),
+			shellOsConfined: true,
+		});
+		expect(decision.block).toBe(false);
+	});
+
+	it("still refuses a cwd nothing permits", () => {
+		for (const dir of ["/work/custB", "/data/globex"]) {
+			const decision = evaluateToolCall({
+				toolName: "bash",
+				input: { command: "pwd", cwd: dir },
+				cwd: CWD,
+				policy: makePolicy(),
+				shellOsConfined: true,
+			});
+			expect(decision.block).toBe(true);
+		}
+	});
+
+	it("keeps refusing a temp cwd where no backend is enforcing", () => {
+		const decision = evaluateToolCall({
+			toolName: "bash",
+			input: { command: "pwd", cwd: tmp },
+			cwd: CWD,
+			policy: makePolicy(),
+			shellOsConfined: false,
+		});
+		expect(decision.block).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -674,44 +674,55 @@ describe("paths reaching the shell through an expansion (#2534)", () => {
 });
 
 /**
- * #2582: two policy engines with opposite defaults.
+ * #2582: two policy engines with opposite defaults, and the composite was stricter than either.
  *
  * This scan is `SandboxPolicy` — deny-by-default, confined to the cwd. The containment fence is
- * allow-by-default with targeted denies. The shipped composite was the *intersection*, so the scan
- * refused what the fence permits and what `xcsh://about` promises: a `/tmp` write, a `~/.gitconfig`
- * read. The stricter engine is the one that cannot be right, because it reasons about the text of a
- * command rather than about the operation.
+ * allow-by-default with targeted denies. Running both made the effective policy their intersection, so
+ * the scan refused work the fence permits and `xcsh://about` promises: a `/tmp` write, a `~/.gitconfig`
+ * read, `cd /tmp`.
  *
- * So where an OS backend confines the shell, the scan stops deciding for `bash`. It is NOT narrowed —
- * the floor is the only boundary on a platform with no backend, and `python` is never covered by the
- * shell fence at all.
+ * Only those false refusals go away. The scan keeps deciding, because it is NOT a slower copy of the
+ * fence — adversarial review showed the fence allows a second customer tree under an unrelated root, and
+ * `policy.ts` withholds the shared temp dir from the file tools deliberately. Standing this layer down
+ * would have handed both away, so #2582's premise that it "cannot add security" is refuted.
  */
-describe("evaluateToolCall — bash under an OS-confined shell (#2582)", () => {
-	const confined = (input: Record<string, unknown>) =>
+describe("evaluateToolCall — bash false refusals under an OS fence (#2582)", () => {
+	const fenced = (input: Record<string, unknown>) =>
 		evaluateToolCall({ toolName: "bash", input, cwd: CWD, policy: makePolicy(), shellOsConfined: true });
-	const scanned = (input: Record<string, unknown>) =>
+	const unfenced = (input: Record<string, unknown>) =>
 		evaluateToolCall({ toolName: "bash", input, cwd: CWD, policy: makePolicy(), shellOsConfined: false });
+	const tmp = fs.realpathSync(os.tmpdir());
 
-	// Each of these was measured refused on v19.100.0 while the fence permitted it.
-	it("stops refusing what the fence permits", () => {
-		for (const command of [
-			"printf x > /tmp/probe.txt", // fence: /tmp is never mentioned, so untouched
-			"cat /Users/someone/.gitconfig | wc -l", // fence: readable, not writable
-			"cd /tmp", // fence: permitted, and the anchor no longer follows the shell
-			"python3 -c \"print('/tmp is only a string here')\"", // refused on a path inside program source
-			"cat /work/custB/secret.json", // the fence refuses this one — below the text, not here
-		]) {
-			expect(confined({ command }).block).toBe(false);
+	// Each was measured refused on v19.100.0 while the fence permitted it.
+	it("stops refusing the operational paths the fence grants", () => {
+		expect(fenced({ command: `printf x > ${path.join(tmp, "probe.txt")}` }).block).toBe(false);
+		expect(fenced({ command: `cat ${path.join(tmp, "probe.txt")}` }).block).toBe(false);
+		expect(fenced({ command: `cd ${tmp}` }).block).toBe(false);
+		expect(fenced({ command: `cat ${path.join(os.homedir(), ".gitconfig")} | wc -l` }).block).toBe(false);
+	});
+
+	// The fence grants ~/.gitconfig READ only, and so does this. Diverging in the other direction would
+	// be worse than the bug: a permitted-looking write that the fence then refuses.
+	it("keeps the read-only home config read-only", () => {
+		expect(fenced({ command: `echo x >> ${path.join(os.homedir(), ".gitconfig")}` }).block).toBe(true);
+	});
+
+	// The protection the fence does NOT provide, and the reason this layer stays.
+	it("still refuses a tree the fence would allow", () => {
+		for (const command of ["cat /work/custB/secret.json", "cat /data/globex/secrets.tf"]) {
+			expect(fenced({ command }).block).toBe(true);
+			expect(unfenced({ command }).block).toBe(true);
 		}
 	});
 
-	it("still decides for bash when nothing else is enforcing", () => {
-		expect(scanned({ command: "printf x > /tmp/probe.txt" }).block).toBe(true);
-		expect(scanned({ command: "cat /work/custB/secret.json" }).block).toBe(true);
+	// Nothing changes where no backend is enforcing: there the scan is the whole boundary.
+	it("changes nothing on a host with no OS backend", () => {
+		expect(unfenced({ command: `printf x > ${path.join(tmp, "probe.txt")}` }).block).toBe(true);
+		expect(unfenced({ command: `cd ${tmp}` }).block).toBe(true);
 	});
 
-	// The scan is the ONLY boundary for python: no fence covers it, on any platform.
-	it("keeps deciding for python even when the shell is confined", () => {
+	// python is covered by no fence on any platform, so it must never get the allowance.
+	it("never widens python", () => {
 		const python = (code: string) =>
 			evaluateToolCall({
 				toolName: "python",
@@ -720,24 +731,24 @@ describe("evaluateToolCall — bash under an OS-confined shell (#2582)", () => {
 				policy: makePolicy(),
 				shellOsConfined: true,
 			});
-		expect(python("open('/work/custB/secret.json').read()").block).toBe(true);
+		expect(python(`open('${path.join(tmp, "probe.txt")}','w')`).block).toBe(true);
 		expect(python("open('notes.md').read()").block).toBe(false);
 	});
 
-	// Structured file tools have no subprocess to confine, so they are unaffected by the shell's backend.
-	it("leaves the structured file tools deny-by-default", () => {
-		const read = evaluateToolCall({
-			toolName: "read",
-			input: { file_path: "/work/custB/secret.json" },
+	// Nor the structured file tools, which have no subprocess to confine.
+	it("never widens the structured file tools", () => {
+		const write = evaluateToolCall({
+			toolName: "write",
+			input: { file_path: path.join(tmp, "probe.txt") },
 			cwd: CWD,
 			policy: makePolicy(),
 			shellOsConfined: true,
 		});
-		expect(read.block).toBe(true);
+		expect(write.block).toBe(true);
 	});
 
-	// Absent means "do not know", and the safe reading of that is to keep deciding.
-	it("keeps deciding when the caller does not say whether the shell is confined", () => {
-		expect(check("bash", { command: "printf x > /tmp/probe.txt" }).block).toBe(true);
+	// Absent must mean "keep deciding": a caller that cannot answer must not relax the boundary.
+	it("keeps refusing when the caller does not say", () => {
+		expect(check("bash", { command: `printf x > ${path.join(tmp, "probe.txt")}` }).block).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -672,3 +672,72 @@ describe("paths reaching the shell through an expansion (#2534)", () => {
 		expect(check("bash", { command: 'cat "$SECRET"' }).block).toBe(false);
 	});
 });
+
+/**
+ * #2582: two policy engines with opposite defaults.
+ *
+ * This scan is `SandboxPolicy` — deny-by-default, confined to the cwd. The containment fence is
+ * allow-by-default with targeted denies. The shipped composite was the *intersection*, so the scan
+ * refused what the fence permits and what `xcsh://about` promises: a `/tmp` write, a `~/.gitconfig`
+ * read. The stricter engine is the one that cannot be right, because it reasons about the text of a
+ * command rather than about the operation.
+ *
+ * So where an OS backend confines the shell, the scan stops deciding for `bash`. It is NOT narrowed —
+ * the floor is the only boundary on a platform with no backend, and `python` is never covered by the
+ * shell fence at all.
+ */
+describe("evaluateToolCall — bash under an OS-confined shell (#2582)", () => {
+	const confined = (input: Record<string, unknown>) =>
+		evaluateToolCall({ toolName: "bash", input, cwd: CWD, policy: makePolicy(), shellOsConfined: true });
+	const scanned = (input: Record<string, unknown>) =>
+		evaluateToolCall({ toolName: "bash", input, cwd: CWD, policy: makePolicy(), shellOsConfined: false });
+
+	// Each of these was measured refused on v19.100.0 while the fence permitted it.
+	it("stops refusing what the fence permits", () => {
+		for (const command of [
+			"printf x > /tmp/probe.txt", // fence: /tmp is never mentioned, so untouched
+			"cat /Users/someone/.gitconfig | wc -l", // fence: readable, not writable
+			"cd /tmp", // fence: permitted, and the anchor no longer follows the shell
+			"python3 -c \"print('/tmp is only a string here')\"", // refused on a path inside program source
+			"cat /work/custB/secret.json", // the fence refuses this one — below the text, not here
+		]) {
+			expect(confined({ command }).block).toBe(false);
+		}
+	});
+
+	it("still decides for bash when nothing else is enforcing", () => {
+		expect(scanned({ command: "printf x > /tmp/probe.txt" }).block).toBe(true);
+		expect(scanned({ command: "cat /work/custB/secret.json" }).block).toBe(true);
+	});
+
+	// The scan is the ONLY boundary for python: no fence covers it, on any platform.
+	it("keeps deciding for python even when the shell is confined", () => {
+		const python = (code: string) =>
+			evaluateToolCall({
+				toolName: "python",
+				input: { code },
+				cwd: CWD,
+				policy: makePolicy(),
+				shellOsConfined: true,
+			});
+		expect(python("open('/work/custB/secret.json').read()").block).toBe(true);
+		expect(python("open('notes.md').read()").block).toBe(false);
+	});
+
+	// Structured file tools have no subprocess to confine, so they are unaffected by the shell's backend.
+	it("leaves the structured file tools deny-by-default", () => {
+		const read = evaluateToolCall({
+			toolName: "read",
+			input: { file_path: "/work/custB/secret.json" },
+			cwd: CWD,
+			policy: makePolicy(),
+			shellOsConfined: true,
+		});
+		expect(read.block).toBe(true);
+	});
+
+	// Absent means "do not know", and the safe reading of that is to keep deciding.
+	it("keeps deciding when the caller does not say whether the shell is confined", () => {
+		expect(check("bash", { command: "printf x > /tmp/probe.txt" }).block).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/sandbox-guard.test.ts
+++ b/packages/coding-agent/test/sandbox-guard.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { _resetSettingsForTest, Settings, settings } from "@f5-sales-demo/xcsh/config/settings";
 import sandboxGuard from "@f5-sales-demo/xcsh/extensibility/extensions/bundled/sandbox-guard";
+import { containmentStatus } from "@f5-sales-demo/xcsh/sandbox/containment";
 
 const CWD = "/work/custA";
 
@@ -70,5 +71,43 @@ describe("sandbox-guard bundled extension", () => {
 		// Revoking it re-blocks (cache tracks the current allow-list, not a one-way widen).
 		settings.override("sandbox.allowRead", []);
 		expect(await call(handler, "read", { file_path: "/work/custB/secret" })).toMatchObject({ block: true });
+	});
+	/**
+	 * #2582, at the layer that actually shipped the divergence.
+	 *
+	 * The guard is what refused a `/tmp` write and a `~/.gitconfig` read on v19.100.0 — operations the
+	 * fence permits and `xcsh://about` promises. It now asks whether an OS backend is confining the
+	 * shell, and stands aside for `bash` when one is. Keyed off the product's own
+	 * `containmentStatus(true).osEnforced` rather than a platform check written here, so this test and
+	 * the shipped behaviour cannot drift apart.
+	 */
+	describe("bash and the OS fence (#2582)", () => {
+		const osEnforced = containmentStatus(true).osEnforced;
+
+		it(`${osEnforced ? "defers to the fence" : "is the boundary"} for a bash command naming a reachable path`, async () => {
+			await initSandbox(true);
+			const handler = captureHandler()!;
+			// The fence permits both of these; the scan refused both.
+			for (const command of ["printf x > /tmp/xcsh-guard-probe.txt", "cat /etc/hosts"]) {
+				const decision = await call(handler, "bash", { command });
+				if (osEnforced) expect(decision).toBeUndefined();
+				else expect(decision).toMatchObject({ block: true });
+			}
+		});
+
+		it("never stands aside for python, which no fence covers", async () => {
+			await initSandbox(true);
+			const handler = captureHandler()!;
+			expect(await call(handler, "python", { code: "open('/work/custB/secret').read()" })).toMatchObject({
+				block: true,
+			});
+		});
+
+		it("never stands aside for the structured file tools", async () => {
+			await initSandbox(true);
+			const handler = captureHandler()!;
+			expect(await call(handler, "read", { file_path: "/work/custB/secret" })).toMatchObject({ block: true });
+			expect(await call(handler, "write", { file_path: "/work/custB/planted" })).toMatchObject({ block: true });
+		});
 	});
 });

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -44,20 +44,18 @@ describe("two-customer isolation", () => {
 		expect(reads(parent, path.join(custB, "secret.env"))).toBe(false);
 	});
 
-	// Which LAYER refuses depends on the host, so say so rather than asserting one and implying both.
-	// With no OS backend this scan is the whole boundary and must refuse. With one, it deliberately
-	// stands aside (#2582) and the refusal is the fence's job — proven by execution in
-	// `sandbox-containment-shell.int.test.ts`, not here.
-	it("blocks Bash reads of custB from custA when the scan is the only boundary", () => {
+	// The scan keeps deciding for bash even where the OS fence is enforcing, because the fence is
+	// allow-by-default: it denies home and the workspace's ancestors, so a customer tree under an
+	// unrelated root matches nothing and the fence permits it. That is exactly what this layer covers,
+	// and #2582 narrowed only its false refusals rather than standing it down.
+	it("blocks Bash reads of custB from custA, fence or no fence", () => {
 		const policy = buildDefaultSandboxPolicy({ cwd: custA });
 		const scan = (command: string, shellOsConfined: boolean) =>
 			evaluateToolCall({ toolName: "bash", input: { command }, cwd: custA, policy, shellOsConfined });
 
 		for (const command of ["cat ../custB/secret.env", `cat ${path.join(custB, "secret.env")}`]) {
 			expect(scan(command, false).block).toBe(true);
-			// Not a weakening: below the text, the fence refuses the same read after expansion, aliases
-			// and symlinks — which is what closed the escapes this scan kept leaking.
-			expect(scan(command, true).block).toBe(false);
+			expect(scan(command, true).block).toBe(true);
 		}
 	});
 });

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -44,22 +44,21 @@ describe("two-customer isolation", () => {
 		expect(reads(parent, path.join(custB, "secret.env"))).toBe(false);
 	});
 
-	it("blocks Bash reads of custB from custA (relative and absolute)", () => {
+	// Which LAYER refuses depends on the host, so say so rather than asserting one and implying both.
+	// With no OS backend this scan is the whole boundary and must refuse. With one, it deliberately
+	// stands aside (#2582) and the refusal is the fence's job — proven by execution in
+	// `sandbox-containment-shell.int.test.ts`, not here.
+	it("blocks Bash reads of custB from custA when the scan is the only boundary", () => {
 		const policy = buildDefaultSandboxPolicy({ cwd: custA });
-		const relative = evaluateToolCall({
-			toolName: "bash",
-			input: { command: "cat ../custB/secret.env" },
-			cwd: custA,
-			policy,
-		});
-		const absolute = evaluateToolCall({
-			toolName: "bash",
-			input: { command: `cat ${path.join(custB, "secret.env")}` },
-			cwd: custA,
-			policy,
-		});
-		expect(relative.block).toBe(true);
-		expect(absolute.block).toBe(true);
+		const scan = (command: string, shellOsConfined: boolean) =>
+			evaluateToolCall({ toolName: "bash", input: { command }, cwd: custA, policy, shellOsConfined });
+
+		for (const command of ["cat ../custB/secret.env", `cat ${path.join(custB, "secret.env")}`]) {
+			expect(scan(command, false).block).toBe(true);
+			// Not a weakening: below the text, the fence refuses the same read after expansion, aliases
+			// and symlinks — which is what closed the escapes this scan kept leaking.
+			expect(scan(command, true).block).toBe(false);
+		}
 	});
 });
 


### PR DESCRIPTION
Fixes #2582

Two policy engines with opposite defaults were both deciding for `bash`, so the effective policy was their **intersection** — and the stricter half is the one that reasons about text rather than about the operation.

The scan is `SandboxPolicy`: deny-by-default, confined to the cwd. The fence is allow-by-default with targeted denies, because a deny-default seatbelt profile could not even `execvp /bin/cat`. Every case #2582 reports reproduced exactly, verbatim including the mangled paths:

| Operation | v19.100.1 | Fence | Now |
| --- | --- | --- | --- |
| `printf x > /tmp/f` | refused | allows | **allowed** |
| write `$TMPDIR/f` | refused | allows | **allowed** |
| `cat ~/.gitconfig` | refused | allows | **allowed** |
| `cd /tmp` | refused | allows | **allowed** |
| `cwd: "/tmp"` | refused | allows | **allowed** |
| `echo x >> ~/.gitconfig` | refused | denies write | refused ✓ |
| `cat /data/globex/secrets.tf` | refused | **allows** | refused ✓ |
| `cat ~/.ssh/id_ed25519` | refused | denies | refused ✓ |

## #2582's premise is wrong, and review is what showed it

The issue argues the scan "cannot add security, since the fence sits below it, so it can only add false positives", and recommends deleting it. I implemented that first. **It is not true.**

The fence denies home and the workspace's ancestors and allows everything else, so it does **not** cover a second customer tree under an unrelated root. Measured with the workspace at `/work/acme`: `/data/globex/secrets.tf` is `read=allow write=allow` under the fence alone. `policy.ts` also withholds the shared temp dir from the file tools deliberately. Standing the scan down handed both away.

So the scan keeps deciding. Only the **false refusals** go: `fenceAlsoPermits` tolerates exactly the operational paths the fence grants — the temp directories, and `~/.gitconfig`/`~/.config/git` for reading only — for the shell only, and only where a backend is actually enforcing. `python` is covered by no fence on any platform, the structured file tools have no subprocess to confine, and a host with no backend behaves exactly as before. `shellOsConfined` absent still means "keep refusing", because understating the backend costs a false refusal while overstating it would relax the only boundary a scanner-only host has.

The floor is **not** narrowed. That was the other tempting move, and `enforce.ts` already warns against it: one earlier fix in that area produced six bypasses across two review rounds.

## A real hole in shipped v19.100.1, found on the way

The fence denied home and the workspace's **immediate** parent. That is only the tenant container when the workspace sits exactly one level inside it. With a `<container>/<tenant>/repo` layout the immediate parent **is** the tenant, so every *other* tenant matched no rule and the fence allowed it — read **and** write.

It went unnoticed because the scan is deny-by-default and refused those paths on the way in, so the composite looked correct while the fence alone was not. Removing the scan is exactly what exposed it, which is why both changes ship together.

Every ancestor is now denied, stopping before anything `tooBroadToDeny` rejects. Verified through the real seatbelt profile with the chain walking `<container>/acme → <container>/tenants → <container>`: cousin read, cousin write, container listing and `../../` traversal all refused; in-tree writes and `/usr` reads fine; **unfenced control leaks the canary**.

## Three more from review, each reproduced before fixing

- **The ancestor walk could deny `/tmp` itself.** With a workspace under `/tmp`, canonicalisation gives `/private/tmp/<x>/repo`, and `tooBroadToDeny` named `/private` and `os.tmpdir()` but not the resolved `/tmp` — so the walk denied `/private/tmp` and took every other temp path with it. Measured: `/private/tmp/other-session.txt` went to `read=deny`.
- **The `cwd` parameter still refused a permitted temp path**, so `cd /tmp` passed while `cwd: "/tmp"` did not — and `cwd` is the interface the bash prompt tells the model to prefer. The false refusal had simply moved.
- **`os.tmpdir()` is not `/tmp`** on macOS — it is the per-user `/var/folders/…/T`. My first attempt covered only that, leaving the exact case #2582 reported still refused. Both spellings, nominal and resolved, are now covered.

## Documentation that was false

`xcsh://about` told the model *"the boundary is enforced below the command text, so no rewriting will succeed."* With a text layer still able to refuse, that is untrue — and telling the model a falsehood about its own boundary is what taught it to abandon permitted work, which is the actual harm in #2582. The instruction stays; the claim is replaced by what is true of the two layers.

The `cd` line is corrected too: it promised `cd` out of the session tree is always refused, which is no longer how it behaves.

`policy.ts` stated the shared temp dir must stay excluded so one session cannot read another's scratch. That still holds for every tool it governs directly, but not for a fenced `bash`. Rather than leave two opposing statements in the codebase, that comment now says which case it covers and what the residual is.

## The accepted trade, stated plainly

**Shared temp is readable and writable by a fenced shell.** Review flags this and it is real. It is not a net loss: the fence never mentions temp, so a fenced shell reaches it below the text regardless, and the scan's protection there was spelling-deep — `T=/tmp/other; cat "$T"` never went through this check at all. Refusing it produced only a diagnostic that contradicted the documentation.

Anything that must not cross sessions belongs under the session directory or a granted `tmpDir`, and that is now written down where the decision lives.

## Verification

- Sandbox suite — 162 pass, 0 fail, including new tests for the cousin tenant, the `/tmp` deny, the `cwd` agreement, and both `shellOsConfined` branches
- `cargo test -p containment-check` — 14 pass; `CI=1 bun run check` — exit 0
- End to end through the **real guard**: the whole table above
- End to end through the **real seatbelt profile** for the ancestor fix, with an unfenced control that leaks

Tests assert which **layer** refuses rather than implying both do, and the guard test keys off the product's own `containmentStatus` so it cannot drift from shipped behaviour.

## Not fixed here

- **GHSA-q4hg** — now **confirmed** rather than "strong evidence": with an `allowRead`-only root, `tee`, `tee -a`, `cp` and `dd of=` are all *permitted* writes, not merely misreported, and `cp` was not previously among the demonstrated vectors. This change closes it on fenced hosts (the fence refuses writes to `allowReadOnly` roots however the operand is spelled) and it survives on scanner-only ones. Advisory updated with the evidence. Fixing it means teaching the scan per-command operand direction — the change class with the worst record here — so it needs its own PR.
- **#2588** — a fresh home cannot create its config dirs under Landlock.
- The python-string false positive (`/tmp',`) remains: it needs the tokenizer, and a conservative false refusal is the safe direction while that layer is load-bearing.

## Local review

Three adversarial rounds, **five findings, all confirmed, four fixed**. The gate escalates at `max-iterations` with the shared-temp trade outstanding, recorded rather than worked around — see `.codex-review/verify-3.json`. The first round refuted the approach I had already committed, which is the run's most useful result.