### PR TITLE
docs(sandbox): state the Landlock kernel baseline

### DIFF
--- a/docs/en/runtime-tools/bash-tool-runtime.md
+++ b/docs/en/runtime-tools/bash-tool-runtime.md
@@ -255,6 +255,53 @@ This component is wired by `CommandController.handleBashCommand()` and fed from 
 | Interactive bang command (`!`) | `AgentSession.executeBash` + `BashExecutionComponent` | No (uses executor directly)                                          | Dedicated bash execution component                                       | Controller catches exceptions and shows UI error |
 | RPC `bash` command             | `rpc-mode` -> `session.executeBash`                   | No                                                                   | Returns `BashResult` directly                                            | Consumer handles returned fields                 |
 
+## Filesystem containment: what enforces it, and where
+
+The bash tool's filesystem boundary is enforced below the command text — the shell's own `cd` and
+redirections are checked where they act, and spawned children are confined by the operating system. Which
+OS mechanism does that depends on the host, and on one host family there is **no OS mechanism at all**.
+
+`xcsh://about` reports the active backend for the machine you are on. This table is for planning a fleet
+before you get there.
+
+| Host | Kernel | Landlock ABI | Backend | Boundary |
+| ---- | ------ | ------------ | ------- | -------- |
+| macOS | — | — | `seatbelt` | OS-enforced |
+| RHEL 9 and derivatives | 5.14 | 1 | `scanner-only` | **command-text scan only** |
+| Ubuntu 22.04, stock GA kernel | 5.15 | 1 | `scanner-only` | **command-text scan only** |
+| Debian 12 | 6.1 | 2 | `landlock` | OS-enforced; `truncate(2)` ungoverned |
+| Ubuntu 22.04 HWE, Ubuntu 24.04 | 6.8 | 4 | `landlock` | OS-enforced |
+| Fedora current | 6.1x–7.x | 6–9 | `landlock` | OS-enforced |
+
+ABI numbers are anchored on two measured hosts: kernel 6.8.0-azure reports ABI 4, kernel 7.1.3 reports
+ABI 9. The rest follow the kernel-to-ABI mapping.
+
+### Why ABI 1 gets no OS boundary
+
+`LANDLOCK_ACCESS_FS_REFER` does not exist before ABI 2, and the kernel denies cross-directory `rename` and
+`link` whenever a ruleset handles *any* filesystem right. On ABI 1 there is therefore no way to permit
+`mv a/x b/x`, and no way for `git` to do its write-tmp-then-rename. Confining on ABI 1 would break ordinary
+work, which this boundary's design forbids, so it is refused rather than degraded.
+
+That is a deliberate trade and not a bug to work around: the alternative is a boundary that breaks `git`.
+
+### What scanner-only means in practice
+
+The command-text scan is still there and still refuses out-of-tree paths, but it reads what was *written*
+rather than what the shell will *do*. A path assembled at runtime — `P=/other/customer/secrets; cat "$P"`
+— is not caught. Treat it as a statement of intent, not a guarantee.
+
+**If sessions on an ABI 1 host handle more than one customer's data, that is a materially weaker posture
+than the macOS default**, and the remedy is operational rather than a code change: run a newer kernel
+(Ubuntu 22.04 HWE is the smallest step), or run those sessions in a container on a newer host.
+
+### Debian 12 / ABI 2
+
+Landlock confines every read and every write, but `LANDLOCK_ACCESS_FS_TRUNCATE` only exists from ABI 3, so
+`truncate(2)` on a path outside the boundary is not governed. It destroys rather than discloses, and is
+unreachable through `>`. `containmentStatus` reports this as `truncationUngoverned` and `xcsh://about`
+states it, so the session knows.
+
 ## Operational caveats
 
 - Interceptor only blocks commands when suggested tool is currently available in context.


### PR DESCRIPTION
Closes #2579

OS-level filesystem enforcement for the `bash` tool needs Landlock **ABI 2** (kernel 5.19+). RHEL 9 and stock Ubuntu 22.04 ship 5.14/5.15 — ABI 1 — so those hosts get **scanner-only** and no OS boundary at all.

Until now that fact lived in a Rust constant (`MINIMUM_ABI`) and a runtime status string, so the only way to find it was to run `xcsh://about` on the host. That is a fine runtime answer and a poor planning one.

| Host | Kernel | ABI | Backend |
| ---- | ------ | --- | ------- |
| macOS | — | — | `seatbelt` |
| RHEL 9 and derivatives | 5.14 | 1 | **`scanner-only`** |
| Ubuntu 22.04 stock GA | 5.15 | 1 | **`scanner-only`** |
| Debian 12 | 6.1 | 2 | `landlock`, `truncate(2)` ungoverned |
| Ubuntu 22.04 HWE / 24.04 | 6.8 | 4 | `landlock` |
| Fedora current | 6.1x–7.x | 6–9 | `landlock` |

## Checked, not recalled

Every claim verified against the source: `MINIMUM_ABI = 2`, `truncate_handled(abi) = abi >= 3`, `ACCESS_FS_REFER` added at ABI 2, `ACCESS_FS_TRUNCATE` at ABI 3. The kernel-to-ABI mapping is anchored on two measured hosts — 6.8.0-azure reports ABI 4, 7.1.3 reports ABI 9.

It also states the two things an operator would otherwise learn the hard way:

- **Why ABI 1 is refused rather than degraded.** No `REFER` bit means no cross-directory `mv` and no `git` write-tmp-then-rename, so confining there would break ordinary work. That is a deliberate trade, not a gap to patch.
- **What to do about it.** For a multi-customer RHEL 9 host the remedy is operational — a newer kernel (Ubuntu 22.04 HWE is the smallest step) or a container on a newer host — not a code change.

## Two things this PR does not do

**It needs the translation step before it can merge.** Editing `docs/en` leaves the **13 locale copies stale** (`sourceHash`), and the `audit / Translation freshness` check is required. Generation is deliberately local-only and needs `docs-translate` plus `ANTHROPIC_API_KEY`, neither available on the machine this was written on — so `docs-translate --staged` has to be run against this branch. I expect that check to be red until then, and that is the known state rather than a surprise.

**It does not answer the policy question.** Whether scanner-only is acceptable for RHEL 9 fleet hosts handling more than one customer's data is a decision, not a documentation gap. The linked-issue gate requires a closing keyword, so rather than bury that decision inside a closed docs ticket it is split out as **#2597**, which also carries a possible code follow-up: whether a *read-only* Landlock domain is usable on ABI 1, since REFER is a write-side concern. Unverified, and worth measuring before promising.

## Verification

- `markdownlint-cli2` — 0 issues
- textlint could not resolve its terminology rule locally; left to the CI `Lint Code Base` gate
- Source claims cross-checked against `crates/brush-core-vendored/src/sys/unix/landlock.rs` and `packages/coding-agent/src/sandbox/containment.ts`