### PR TITLE
fix(sandbox): check operand writes against the write boundary

### DIFF
--- a/packages/coding-agent/src/sandbox/command-operands.ts
+++ b/packages/coding-agent/src/sandbox/command-operands.ts
@@ -278,3 +278,195 @@ export function provenExemptWords(cmd: ShellSimpleCommand): ShellWord[] {
 
 	return exempt;
 }
+
+/** cp's flag-only options; shared so the mv/install entries stay readable. */
+const COPY_BOOLEAN_OPTIONS = [
+	"-a",
+	"--archive",
+	"-b",
+	"--backup",
+	"-d",
+	"-f",
+	"--force",
+	"-i",
+	"--interactive",
+	"-H",
+	"-l",
+	"--link",
+	"-L",
+	"--dereference",
+	"-n",
+	"--no-clobber",
+	"-P",
+	"--no-dereference",
+	"-p",
+	"-R",
+	"-r",
+	"--recursive",
+	"-s",
+	"--symbolic-link",
+	"-u",
+	"--update",
+	"-v",
+	"--verbose",
+	"-x",
+	"--one-file-system",
+] as const satisfies readonly string[];
+
+/**
+ * Which operands a command *writes*, so the boundary check picks the right direction.
+ *
+ * The read/write split in `enforce.ts` is derived from shell redirections. A write the invoked program
+ * performs on one of its own operands — `tee FILE`, `dd of=FILE`, `cp SRC DST`, `sort -o FILE` — had no
+ * such signal and defaulted to a read check. Under an `allowRead`-only grant that check passes, so the
+ * write lands on a path shared for reading only; confirmed at the decision layer, where all four returned
+ * `block: false` (GHSA-q4hg). The same misclassification refused those commands against a *write-only*
+ * grant, which is the mirror-image false refusal.
+ *
+ * Adding to this table is monotonic. Marking an operand as a write that is really a read costs a false
+ * refusal, which is the direction the surrounding code already errs in; missing one leaves today's
+ * behaviour untouched. So it is safe to extend, and deliberately incomplete rather than guessed at:
+ * `tar -f` is absent because whether it reads or writes depends on the mode letters, and getting that
+ * wrong in the permissive direction is the bug being fixed.
+ *
+ * Same suppression rule as `provenExemptWords`: an option this model cannot parse exactly shifts operand
+ * positions, so anything unrecognized abandons the command rather than guessing at a slot.
+ */
+interface WriteOperandSpec {
+	/** Options taking a separate value, so it is not mistaken for a positional operand. */
+	valueOptions: readonly string[];
+	/** Options that are flags only. */
+	booleanOptions: readonly string[];
+	/** `--output=F` style options whose value is the written path. */
+	outputOptions?: readonly string[];
+	/** `of=F` style prefixes whose value is the written path. */
+	outputPrefixes?: readonly string[];
+	/** Every positional operand is written (`tee a b c`). */
+	writesAllPositional?: boolean;
+	/** The final positional operand is written (`cp src dst`). */
+	writesLastPositional?: boolean;
+	/** With this option present the destination moves into it, so positional slots stop being writes. */
+	destinationOption?: string;
+}
+
+const WRITE_OPERAND_SPECS: Record<string, WriteOperandSpec> = {
+	// tee writes every file operand; it reads stdin, never the files.
+	tee: {
+		valueOptions: [],
+		booleanOptions: ["-a", "--append", "-i", "--ignore-interrupts", "-p"],
+		writesAllPositional: true,
+	},
+	// `of=` is the output file. `if=` stays a read, which is what the floor already gives it.
+	dd: { valueOptions: [], booleanOptions: [], outputPrefixes: ["of="] },
+	sort: {
+		valueOptions: ["-k", "-t", "-S", "-T", "--key", "--field-separator", "--buffer-size"],
+		booleanOptions: ["-b", "-d", "-f", "-g", "-i", "-M", "-h", "-n", "-R", "-r", "-u", "-V", "-z", "-c", "-s"],
+		outputOptions: ["-o", "--output"],
+	},
+	cp: {
+		valueOptions: ["-S", "--suffix", "-t", "--target-directory"],
+		booleanOptions: COPY_BOOLEAN_OPTIONS,
+		writesLastPositional: true,
+		destinationOption: "-t",
+	},
+	mv: {
+		valueOptions: ["-S", "--suffix", "-t", "--target-directory"],
+		booleanOptions: ["-f", "--force", "-i", "--interactive", "-n", "--no-clobber", "-v", "--verbose", "-u"],
+		writesLastPositional: true,
+		destinationOption: "-t",
+	},
+	install: {
+		valueOptions: ["-m", "--mode", "-o", "--owner", "-g", "--group", "-t", "--target-directory", "-S", "--suffix"],
+		booleanOptions: ["-b", "-c", "-C", "-d", "-D", "-p", "-s", "-v", "--verbose", "--backup"],
+		writesLastPositional: true,
+		destinationOption: "-t",
+	},
+	truncate: {
+		valueOptions: ["-s", "--size", "-r", "--reference"],
+		booleanOptions: ["-c", "--no-create", "-o", "--io-blocks"],
+		writesAllPositional: true,
+	},
+};
+
+/**
+ * Words of `cmd` the invoked command writes to.
+ *
+ * Empty whenever anything is uncertain — an unknown command, an unrecognized option, a non-literal word.
+ * A word returned here is checked against the write boundary instead of the read one.
+ */
+export function writtenOperandWords(cmd: ShellSimpleCommand): ShellWord[] {
+	if (cmd.name === undefined) return [];
+	const spec = WRITE_OPERAND_SPECS[cmd.name];
+	if (spec === undefined) return [];
+
+	const operandWords = cmd.words.slice(cmd.operandStart).filter(word => word.redirect === undefined);
+
+	// An unparsable option shifts every positional slot, so abandon rather than mark the wrong word.
+	for (const word of operandWords) {
+		const option = optionName(word.text);
+		if (option === undefined) continue;
+		if (isOutputOption(spec, option) || spec.valueOptions.includes(option)) continue;
+		if (!spec.booleanOptions.includes(option)) return [];
+	}
+
+	const written: ShellWord[] = [];
+	const positional: ShellWord[] = [];
+	let destinationMoved = false;
+
+	for (let index = 0; index < operandWords.length; index += 1) {
+		const word = operandWords[index];
+		const option = optionName(word.text);
+
+		if (option !== undefined) {
+			const attached = word.text.includes("=");
+			if (isOutputOption(spec, option)) {
+				// `--output=F` carries its value; `-o F` takes the next word.
+				const target = attached ? valueAfterEquals(word) : operandWords[index + 1];
+				if (!attached) index += 1;
+				if (target?.literal) written.push(target);
+				continue;
+			}
+			if (spec.valueOptions.includes(option)) {
+				if (option === spec.destinationOption) destinationMoved = true;
+				if (!attached) {
+					const target = operandWords[index + 1];
+					index += 1;
+					if (target?.literal) written.push(target);
+				} else if (word.literal) {
+					written.push(word);
+				}
+			}
+			continue;
+		}
+
+		// `of=PATH` and friends are positional in shape but name their own direction.
+		const prefix = spec.outputPrefixes?.find(candidate => word.text.startsWith(candidate));
+		if (prefix !== undefined) {
+			if (word.literal) written.push(word);
+			continue;
+		}
+
+		positional.push(word);
+	}
+
+	if (spec.writesAllPositional) {
+		written.push(...positional.filter(word => word.literal));
+	} else if (spec.writesLastPositional && !destinationMoved && positional.length >= 2) {
+		// Only with a source present. A lone operand is `cp x` — an error, not a write to model.
+		const destination = positional[positional.length - 1];
+		if (destination.literal) written.push(destination);
+	}
+
+	return written;
+}
+
+function isOutputOption(spec: WriteOperandSpec, option: string): boolean {
+	return spec.outputOptions?.includes(option) ?? false;
+}
+
+/** The value half of an `--option=value` word, as a span the caller can mark. */
+function valueAfterEquals(word: ShellWord): ShellWord | undefined {
+	const equals = word.text.indexOf("=");
+	if (equals === -1) return undefined;
+	return { ...word, text: word.text.slice(equals + 1) };
+}

--- a/packages/coding-agent/src/sandbox/command-operands.ts
+++ b/packages/coding-agent/src/sandbox/command-operands.ts
@@ -279,6 +279,57 @@ export function provenExemptWords(cmd: ShellSimpleCommand): ShellWord[] {
 	return exempt;
 }
 
+/** Flag-only options shared by the compressors. */
+const GZIP_BOOLEAN_OPTIONS = [
+	"-1",
+	"-2",
+	"-3",
+	"-4",
+	"-5",
+	"-6",
+	"-7",
+	"-8",
+	"-9",
+	"-c",
+	"--stdout",
+	"-d",
+	"--decompress",
+	"-f",
+	"--force",
+	"-k",
+	"--keep",
+	"-q",
+	"--quiet",
+	"-r",
+	"--recursive",
+	"-t",
+	"--test",
+	"-v",
+	"--verbose",
+] as const satisfies readonly string[];
+
+/** curl options that consume a separate value, so it is not mistaken for a path. */
+const CURL_VALUE_OPTIONS = [
+	"-H",
+	"--header",
+	"-X",
+	"--request",
+	"-d",
+	"--data",
+	"-u",
+	"--user",
+	"-A",
+	"--user-agent",
+	"--connect-timeout",
+	"--max-time",
+	"-m",
+	"--retry",
+	"-b",
+	"--cookie",
+	"-c",
+	"--cookie-jar",
+] as const satisfies readonly string[];
+
 /** cp's flag-only options; shared so the mv/install entries stay readable. */
 const COPY_BOOLEAN_OPTIONS = [
 	"-a",
@@ -347,6 +398,12 @@ interface WriteOperandSpec {
 	writesLastPositional?: boolean;
 	/** With this option present the destination moves into it, so positional slots stop being writes. */
 	destinationOption?: string;
+	/** Positional operands that are not paths at all — `chmod 644 f`, `chown me f`. */
+	skipLeadingPositional?: number;
+	/** Every positional is written once this option appears (`install -d a b c`). */
+	allPositionalOption?: string;
+	/** Sources are written too, because the command removes them (`mv`). */
+	writesSourcesToo?: boolean;
 }
 
 const WRITE_OPERAND_SPECS: Record<string, WriteOperandSpec> = {
@@ -369,10 +426,13 @@ const WRITE_OPERAND_SPECS: Record<string, WriteOperandSpec> = {
 		writesLastPositional: true,
 		destinationOption: "-t",
 	},
+	// `mv` also REMOVES its sources, so a source in a read-only root is a mutation of that root.
+	// Marking only the destination let `mv /shared/ctx/file .` delete from a read-allowed grant.
 	mv: {
 		valueOptions: ["-S", "--suffix", "-t", "--target-directory"],
 		booleanOptions: ["-f", "--force", "-i", "--interactive", "-n", "--no-clobber", "-v", "--verbose", "-u"],
 		writesLastPositional: true,
+		writesSourcesToo: true,
 		destinationOption: "-t",
 	},
 	install: {
@@ -380,6 +440,78 @@ const WRITE_OPERAND_SPECS: Record<string, WriteOperandSpec> = {
 		booleanOptions: ["-b", "-c", "-C", "-d", "-D", "-p", "-s", "-v", "--verbose", "--backup"],
 		writesLastPositional: true,
 		destinationOption: "-t",
+		// `install -d a b c` creates every operand as a directory rather than copying into the last.
+		allPositionalOption: "-d",
+	},
+	// Plain mutators: every path operand is written. Their absence was the largest hole in the table —
+	// `rm` and `touch` against a read-only root are the obvious cases, and both were classified as reads.
+	rm: {
+		valueOptions: [],
+		booleanOptions: ["-f", "--force", "-i", "-I", "-r", "-R", "--recursive", "-d", "--dir", "-v", "--verbose"],
+		writesAllPositional: true,
+	},
+	rmdir: { valueOptions: [], booleanOptions: ["-p", "--parents", "-v", "--verbose"], writesAllPositional: true },
+	touch: {
+		valueOptions: ["-d", "--date", "-r", "--reference", "-t"],
+		booleanOptions: ["-a", "-c", "--no-create", "-f", "-h", "--no-dereference", "-m"],
+		writesAllPositional: true,
+	},
+	mkdir: {
+		valueOptions: ["-m", "--mode"],
+		booleanOptions: ["-p", "--parents", "-v", "--verbose"],
+		writesAllPositional: true,
+	},
+	ln: {
+		valueOptions: ["-S", "--suffix", "-t", "--target-directory"],
+		booleanOptions: ["-b", "-f", "--force", "-i", "-L", "-n", "-P", "-r", "-s", "--symbolic", "-v"],
+		writesLastPositional: true,
+		destinationOption: "-t",
+	},
+	shred: {
+		valueOptions: ["-n", "--iterations", "-s", "--size"],
+		booleanOptions: ["-f", "--force", "-u", "--remove", "-v", "--verbose", "-x", "-z", "--zero"],
+		writesAllPositional: true,
+	},
+	unlink: { valueOptions: [], booleanOptions: [], writesAllPositional: true },
+	// The first positional is a mode or an owner, not a path.
+	chmod: {
+		valueOptions: ["--reference"],
+		booleanOptions: ["-c", "-f", "-v", "-R", "--recursive", "--silent", "--changes", "--verbose"],
+		writesAllPositional: true,
+		skipLeadingPositional: 1,
+	},
+	chown: {
+		valueOptions: ["--reference", "--from"],
+		booleanOptions: ["-c", "-f", "-v", "-R", "--recursive", "-h", "--no-dereference", "--silent", "--changes"],
+		writesAllPositional: true,
+		skipLeadingPositional: 1,
+	},
+	// In-place editors and compressors REPLACE the file they are given.
+	//
+	// `sed -i` has famously ambiguous arity — GNU takes an attached suffix, BSD a separate one — so
+	// which positional is the script cannot be settled. Every literal positional is therefore marked
+	// written, which over-marks the script operand. That is the safe direction: a false refusal, not a
+	// permitted write. The marking only applies when `-i` is present at all.
+	sed: {
+		valueOptions: ["-e", "--expression", "-f", "--file", "-l", "--line-length"],
+		booleanOptions: ["-n", "--quiet", "--silent", "-E", "-r", "--regexp-extended", "-s", "-u", "-z", "--debug"],
+		writesAllPositional: false,
+		allPositionalOption: "-i",
+	},
+	gzip: { valueOptions: ["-S", "--suffix"], booleanOptions: GZIP_BOOLEAN_OPTIONS, writesAllPositional: true },
+	gunzip: { valueOptions: ["-S", "--suffix"], booleanOptions: GZIP_BOOLEAN_OPTIONS, writesAllPositional: true },
+	bzip2: { valueOptions: [], booleanOptions: GZIP_BOOLEAN_OPTIONS, writesAllPositional: true },
+	xz: { valueOptions: ["-T", "--threads"], booleanOptions: GZIP_BOOLEAN_OPTIONS, writesAllPositional: true },
+	// Downloaders name their output explicitly; the URL operand is not a path.
+	curl: {
+		valueOptions: CURL_VALUE_OPTIONS,
+		booleanOptions: ["-L", "--location", "-s", "--silent", "-S", "--show-error", "-f", "--fail", "-k", "-I", "-v"],
+		outputOptions: ["-o", "--output"],
+	},
+	wget: {
+		valueOptions: ["--user-agent", "--header", "-P", "--directory-prefix", "-T", "--timeout"],
+		booleanOptions: ["-q", "--quiet", "-c", "--continue", "-N", "--no-verbose", "-nv"],
+		outputOptions: ["-O", "--output-document"],
 	},
 	truncate: {
 		valueOptions: ["-s", "--size", "-r", "--reference"],
@@ -402,20 +534,44 @@ export function writtenOperandWords(cmd: ShellSimpleCommand): ShellWord[] {
 	const operandWords = cmd.words.slice(cmd.operandStart).filter(word => word.redirect === undefined);
 
 	// An unparsable option shifts every positional slot, so abandon rather than mark the wrong word.
+	// Everything after `--` is a positional, however much it looks like an option — otherwise a file
+	// literally named `-t` makes `cp -- -t /drop/secret out/` read as a target-directory option and
+	// relabels a source as a write target.
+	let sawEndOfOptions = false;
 	for (const word of operandWords) {
+		if (word.text === "--") {
+			sawEndOfOptions = true;
+			continue;
+		}
+		if (sawEndOfOptions) continue;
 		const option = optionName(word.text);
 		if (option === undefined) continue;
 		if (isOutputOption(spec, option) || spec.valueOptions.includes(option)) continue;
-		if (!spec.booleanOptions.includes(option)) return [];
+		if (spec.booleanOptions.includes(option)) continue;
+		if (matchesAllPositionalOption(spec, option)) continue;
+		if (bundledBooleans(option, spec) !== undefined) continue;
+		return [];
 	}
 
 	const written: ShellWord[] = [];
 	const positional: ShellWord[] = [];
 	let destinationMoved = false;
+	let allPositionalWritten = spec.writesAllPositional ?? false;
+	let pastEndOfOptions = false;
 
 	for (let index = 0; index < operandWords.length; index += 1) {
 		const word = operandWords[index];
-		const option = optionName(word.text);
+		if (!pastEndOfOptions && word.text === "--") {
+			pastEndOfOptions = true;
+			continue;
+		}
+		const option = pastEndOfOptions ? undefined : optionName(word.text);
+
+		if (option !== undefined && matchesAllPositionalOption(spec, option)) {
+			// `install -d` stops copying and starts creating, so every operand becomes a written path.
+			allPositionalWritten = true;
+			continue;
+		}
 
 		if (option !== undefined) {
 			const attached = word.text.includes("=");
@@ -449,15 +605,44 @@ export function writtenOperandWords(cmd: ShellSimpleCommand): ShellWord[] {
 		positional.push(word);
 	}
 
-	if (spec.writesAllPositional) {
-		written.push(...positional.filter(word => word.literal));
-	} else if (spec.writesLastPositional && !destinationMoved && positional.length >= 2) {
+	const paths = positional.slice(spec.skipLeadingPositional ?? 0);
+	if (allPositionalWritten) {
+		written.push(...paths.filter(word => word.literal));
+	} else if (spec.writesSourcesToo && spec.writesLastPositional && !destinationMoved && paths.length >= 2) {
+		// Destination AND sources: `mv` removes what it moves.
+		written.push(...paths.filter(word => word.literal));
+	} else if (spec.writesLastPositional && !destinationMoved && paths.length >= 2) {
 		// Only with a source present. A lone operand is `cp x` — an error, not a write to model.
-		const destination = positional[positional.length - 1];
+		const destination = paths[paths.length - 1];
 		if (destination.literal) written.push(destination);
 	}
 
 	return written;
+}
+
+/**
+ * Split a bundled short option (`-ai`) into its letters when every one is a known boolean flag.
+ *
+ * Without this, `tee -ai /shared/ctx/x` hit the unrecognized-option path and abandoned the command —
+ * failing open to a read check on a write, which is the defect this module exists to fix.
+ */
+function bundledBooleans(option: string, spec: WriteOperandSpec): string[] | undefined {
+	if (!option.startsWith("-") || option.startsWith("--") || option.length <= 2) return undefined;
+	const letters = [...option.slice(1)].map(letter => `-${letter}`);
+	return letters.every(letter => spec.booleanOptions.includes(letter)) ? letters : undefined;
+}
+
+/**
+ * Whether an option turns every operand into a written path.
+ *
+ * Prefix-matched for the single-letter form, because GNU `sed` attaches the backup suffix to the flag:
+ * `-i.bak` is the same in-place edit as `-i`, and exact matching let that spelling through.
+ */
+function matchesAllPositionalOption(spec: WriteOperandSpec, option: string): boolean {
+	const target = spec.allPositionalOption;
+	if (target === undefined) return false;
+	if (option === target) return true;
+	return target.length === 2 && !target.startsWith("--") && option.startsWith(target);
 }
 
 function isOutputOption(spec: WriteOperandSpec, option: string): boolean {

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -44,7 +44,7 @@ import * as path from "node:path";
 import { pathIsWithin } from "@f5-sales-demo/pi-utils";
 import { expandPath, parseFindPattern, parseSearchPath, resolveToCwd, splitTopLevel } from "../tools/path-utils";
 import { lexShellCommand, type ShellSimpleCommand } from "../tools/shell-lex";
-import { provenExemptWords } from "./command-operands";
+import { provenExemptWords, writtenOperandWords } from "./command-operands";
 import type { SandboxAccess, SandboxPolicy } from "./policy";
 
 export interface ToolCallCheck {
@@ -585,7 +585,12 @@ function shellPathCandidates(command: string): ShellScan {
 	// `<>` opens for both, so it stays a read here and picks up its write below: a floor occurrence
 	// may carry only one access, and read is the one the floor would have used anyway.
 	const writeTargets = lexed.words.filter(word => word.redirect === "write");
-	const inWriteTarget = (at: number): boolean => writeTargets.some(word => at >= word.start && at < word.end);
+	// Plus the operands the invoked program writes itself — `tee FILE`, `dd of=FILE`, `cp SRC DST`.
+	// Those had no direction signal and defaulted to a read check, so a write into an allowRead-only
+	// root passed and a write into an allowWrite-only root was refused (GHSA-q4hg).
+	const writtenOperands = lexed.commands.flatMap(simpleCommand => writtenOperandWords(simpleCommand));
+	const inWriteTarget = (at: number): boolean =>
+		[...writeTargets, ...writtenOperands].some(word => at >= word.start && at < word.end);
 
 	// A floor occurrence takes the access its own operator gave it; failing that, the span of a
 	// lexed write target it sits inside; failing that, read.

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -794,3 +794,54 @@ describe("evaluateToolCall — the bash cwd parameter agrees with cd (#2582)", (
 		expect(decision.block).toBe(true);
 	});
 });
+
+/**
+ * GHSA-q4hg — a write reached through a command *operand* was checked against the READ boundary.
+ *
+ * The read/write split applies to shell redirections. `tee FILE`, `dd of=FILE`, `cp SRC DST` and
+ * `sort -o FILE` are writes the invoked program performs, and every one of them was classified as a read.
+ * Under an `allowRead`-only grant that check passes, so the write lands on a path the operator shared for
+ * reading only. Confirmed at the decision layer before this fix: all four returned `block: false`.
+ *
+ * It cuts the other way too. A write-only `allowWrite` grant refused `tee` into it, because a read check
+ * against a write-only root fails — a false refusal produced by the same misclassification.
+ *
+ * On a host with an OS backend the fence settles this below the text regardless. On Windows and Linux
+ * without Landlock this scan is the only boundary, which is where the bypass was live.
+ */
+describe("evaluateToolCall — operand writes are checked against the write boundary (GHSA-q4hg)", () => {
+	// `/shared/ctx` is read-allowed and NOT write-allowed; `/drop` is write-allowed and NOT read-allowed.
+	const bash = (command: string) => check("bash", { command });
+
+	it("refuses an operand write into a read-only root", () => {
+		for (const command of [
+			"echo x | tee /shared/ctx/planted.txt",
+			"echo x | tee -a /shared/ctx/planted.txt",
+			"cp notes.md /shared/ctx/planted.txt",
+			"dd of=/shared/ctx/planted.txt if=notes.md",
+			"sort -o /shared/ctx/planted.txt notes.md",
+		]) {
+			expect(bash(command).block).toBe(true);
+			expect(bash(command).reason).toContain("write boundary");
+		}
+	});
+
+	it("permits the same operand write into a write-only root", () => {
+		for (const command of ["echo x | tee /drop/out.log", "cp notes.md /drop/out.log", "dd of=/drop/out.log"]) {
+			expect(bash(command).block).toBe(false);
+		}
+	});
+
+	it("still reads the source operand as a read", () => {
+		// `cp` reads its source: a source in a write-only root must stay refused.
+		expect(bash("cp /drop/out.log notes.md").block).toBe(true);
+		// …and a source in a read-only root is fine.
+		expect(bash("cp /shared/ctx/in.txt notes.md").block).toBe(false);
+	});
+
+	it("leaves in-tree operand writes alone", () => {
+		for (const command of ["echo x | tee out.log", "cp a.txt b.txt", "sort -o sorted.txt in.txt"]) {
+			expect(bash(command).block).toBe(false);
+		}
+	});
+});

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -845,3 +845,98 @@ describe("evaluateToolCall — operand writes are checked against the write boun
 		}
 	});
 });
+
+/**
+ * Review of the operand-direction fix found four more ways a write reached a read-only root.
+ *
+ * The critical one is structural and is NOT fully closed here: the table is a denylist, so a mutating
+ * command it does not model still defaults to a read check. What is closed is the set that matters most —
+ * the plain mutators (`rm`, `touch`, `mkdir`, `chmod`, …), which were the largest hole — plus three
+ * defects in the model itself. The residual is tracked rather than implied away.
+ */
+describe("evaluateToolCall — operand writes, review round two (GHSA-q4hg)", () => {
+	const bash = (command: string) => check("bash", { command });
+
+	// `touch` and `rm` against a read-allowed root were classified as reads and permitted.
+	it("refuses the plain mutators against a read-only root", () => {
+		for (const command of [
+			"touch /shared/ctx/x",
+			"rm /shared/ctx/file",
+			"rm -rf /shared/ctx/dir",
+			"mkdir /shared/ctx/newdir",
+			"rmdir /shared/ctx/dir",
+			"ln -s /work/custA/a /shared/ctx/link",
+			"shred /shared/ctx/file",
+			"unlink /shared/ctx/file",
+		]) {
+			expect(bash(command).block).toBe(true);
+			expect(bash(command).reason).toContain("write boundary");
+		}
+	});
+
+	// `chmod 644 f` — the mode is a positional but not a path.
+	it("skips the leading non-path operand of chmod and chown", () => {
+		expect(bash("chmod 644 /shared/ctx/file").block).toBe(true);
+		expect(bash("chown me /shared/ctx/file").block).toBe(true);
+		// …and the mode itself is not mistaken for a path in the tree.
+		expect(bash("chmod 644 in-tree.txt").block).toBe(false);
+	});
+
+	// `mv` REMOVES its source, so a source in a read-only root is a mutation of that root.
+	it("treats an mv source as a write, because mv deletes it", () => {
+		expect(bash("mv /shared/ctx/file .").block).toBe(true);
+		expect(bash("mv /shared/ctx/file /shared/ctx/other").block).toBe(true);
+		// `cp` does not remove its source, so that stays a read.
+		expect(bash("cp /shared/ctx/file .").block).toBe(false);
+	});
+
+	// `install -d` creates directories rather than copying into the last operand.
+	it("treats every operand of install -d as written", () => {
+		expect(bash("install -d /shared/ctx/newdir").block).toBe(true);
+		expect(bash("install -d /shared/ctx/a /shared/ctx/b").block).toBe(true);
+	});
+
+	// A bundled short option used to hit the unrecognized-option path and abandon the command, which
+	// fails OPEN — the exact direction this module must never fail in.
+	it("understands bundled short flags", () => {
+		expect(bash("echo x | tee -ai /shared/ctx/x").block).toBe(true);
+		expect(bash("rm -rf /shared/ctx/dir").block).toBe(true);
+	});
+
+	// Everything after `--` is a positional, however much it looks like an option.
+	it("honours end-of-options", () => {
+		// Without this, `-t` parses as target-directory and relabels the next word as a write target.
+		expect(bash("cp -- -t /drop/secret out.txt").block).toBe(true);
+	});
+});
+
+/**
+ * In-place editors, compressors and downloaders — the mutators found by measuring the residual rather
+ * than by review. Each was permitted against a read-only root before being modelled.
+ */
+describe("evaluateToolCall — in-place and output-naming commands (GHSA-q4hg)", () => {
+	const bash = (command: string) => check("bash", { command });
+
+	it("treats an in-place sed as writing its file operands", () => {
+		expect(bash("sed -i 's/a/b/' /shared/ctx/file").block).toBe(true);
+		// GNU attaches the backup suffix to the flag; exact matching let this spelling through.
+		expect(bash("sed -i.bak 's/a/b/' /shared/ctx/file").block).toBe(true);
+	});
+
+	it("leaves a reading sed alone", () => {
+		// No -i, so nothing is written and the read-only grant is enough.
+		expect(bash("sed -n 's/a/b/p' /shared/ctx/file").block).toBe(false);
+		expect(bash("cat /shared/ctx/file").block).toBe(false);
+	});
+
+	it("treats compressors as replacing their input", () => {
+		for (const command of ["gzip /shared/ctx/file", "xz /shared/ctx/file", "bzip2 /shared/ctx/file"]) {
+			expect(bash(command).block).toBe(true);
+		}
+	});
+
+	it("treats a downloader's output option as a write", () => {
+		expect(bash("curl -o /shared/ctx/x https://example.com").block).toBe(true);
+		expect(bash("wget -O /shared/ctx/x https://example.com").block).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #2598

Addresses `GHSA-q4hg-3cmc-v9hw` — partially, and the PR is explicit about which part.

## The defect

The read/write split was derived from shell **redirections** only. A write the invoked program performs on its own operand had no direction signal and defaulted to a **read** check. Under an `allowRead`-only grant that check passes, so the write lands on a path the operator shared for reading only.

Confirmed at the decision layer — these returned `block: false`, not a refusal with the wrong wording:

```
*** ALLOW ***  echo x | tee /shared/ctx/planted.txt
*** ALLOW ***  echo x | tee -a /shared/ctx/planted.txt
*** ALLOW ***  cp notes.md /shared/ctx/planted.txt
*** ALLOW ***  dd of=/shared/ctx/planted.txt if=notes.md
REFUSE         printf x > /shared/ctx/planted.txt      <- redirect, classified correctly
```

`cp` was not among the vectors the advisory originally demonstrated. All five now refuse and name the **write** boundary.

The same misclassification refused those commands against a **write-only** grant — the mirror-image false refusal — so this fixes a bypass and a papercut together.

## What review then found, all confirmed

- **`mv` removes its source**, so a source in a read-only root is a mutation of that root. Marking only the destination let `mv /shared/ctx/file .` delete from a read-allowed grant.
- **Option parsing continued past `--`**, so a file literally named `-t` made `cp -- -t /drop/secret out/` read as a target-directory option and relabel a source as a write target.
- **`install -d`** creates directories rather than copying into the last operand.
- **A bundled short option** (`tee -ai`) hit the unrecognized-option path and abandoned the command — failing **open**, the one direction this module must never fail in.

## The largest hole, which review named critical

The plain mutators were simply absent: `touch`, `rm`, `rmdir`, `mkdir`, `ln`, `shred`, `unlink`, `chmod`, `chown` — all classified as reads against a read-only root. `chmod`/`chown` need their leading operand skipped, since a mode or owner is not a path.

## Found by measuring, not by review

After the review round I re-probed what still slipped through, which turned up in-place `sed` (including GNU's attached `-i.bak` spelling), the compressors, and `curl -o` / `wget -O`. `sed -i` arity is genuinely ambiguous between GNU and BSD, so every literal positional is marked written — over-marking the script operand, which is a false refusal rather than a permitted write.

## What this does NOT close

This is a denylist, so a mutating command it does not model still defaults to a read check. Measured still-open after everything above:

```
tar -xf a.tar -C /shared/ctx     # extract writes into -C; mode-letter dependent, deliberately unmodelled
git init /shared/ctx/repo
python3 -c "open('/shared/ctx/x','w')"
```

Each review round found more entries, which is evidence the enumeration cannot converge rather than evidence it needs one more pass. Closing the class means inverting it — model provably read-only commands and treat everything else as read+write, so an unmodeled command fails **closed**. That changes the failure direction for every unmodeled command and needs the false-refusal cost measured first, so it is **#2598** rather than more entries here.

## Why this is still worth shipping

Every addition is monotonic: a read marked as a write costs a false refusal, the direction this layer already errs in; a missed write leaves today's behaviour untouched. So this strictly reduces the exposed set without introducing a new way to be permissive.

`writtenOperandWords` mirrors the existing `provenExemptWords` — per-command, positional, and abandoning the command whenever an option cannot be parsed exactly, since an unrecognized option shifts every positional slot.

## Scope

On macOS (seatbelt) and Linux with Landlock the fence settles direction below the command text regardless. This matters on **Windows and Linux without Landlock**, where the scan is the only boundary — see #2579 for which hosts those are.

## Verification

- 119 sandbox tests pass, including 4 new suites covering every case above
- `CI=1 bun run check` — exit 0
- The advisory's own confirming probe re-run: 5/5 refuse, naming the write boundary
- Residual re-measured after each round rather than assumed

One pre-existing failure is unrelated and also fails on unmodified `main`: `bundled registration` times out at ~40s because the extension loader is slow on a machine with an installed plugin.