### PR TITLE
fix(build): stop check, test and build regenerating committed files

### DIFF
--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -31,7 +31,7 @@
 		"xcsh": "src/cli.ts"
 	},
 	"scripts": {
-		"build": "bun run generate-build-info && test -f src/internal-urls/api-spec-index.generated.ts && bun --cwd=../stats scripts/generate-client-bundle.ts --generate && bun --cwd=../office-pane scripts/generate-client-bundle.ts --generate && bun --cwd=../natives run embed:native && bun build --compile --define PI_COMPILED=true --external mupdf --root ../.. ./src/cli.ts --outfile dist/xcsh && bun --cwd=../natives run embed:native --reset && bun --cwd=../stats scripts/generate-client-bundle.ts --reset && bun --cwd=../office-pane scripts/generate-client-bundle.ts --reset",
+		"build": "bun run generate-build-info && bun run generate-extension-capabilities && test -f src/internal-urls/api-spec-index.generated.ts && bun --cwd=../stats scripts/generate-client-bundle.ts --generate && bun --cwd=../office-pane scripts/generate-client-bundle.ts --generate && bun --cwd=../natives run embed:native && bun build --compile --define PI_COMPILED=true --external mupdf --root ../.. ./src/cli.ts --outfile dist/xcsh && bun --cwd=../natives run embed:native --reset && bun --cwd=../stats scripts/generate-client-bundle.ts --reset && bun --cwd=../office-pane scripts/generate-client-bundle.ts --reset",
 		"check": "biome check . && bun run format-prompts -- --check && bun run check:types",
 		"check:types": "bun run generate-build-info && tsgo -p tsconfig.json --noEmit",
 		"lint": "biome lint .",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -31,12 +31,12 @@
 		"xcsh": "src/cli.ts"
 	},
 	"scripts": {
-		"build": "bun run generate-build-info && bun run generate-extension-capabilities && bun run generate-api-spec-index && bun run generate-branding-index && bun run generate-sitecli-index && bun run generate-terraform-index && bun run generate-console-catalog && bun run generate-console-field-metadata && test -f src/internal-urls/api-spec-index.generated.ts && bun --cwd=../stats scripts/generate-client-bundle.ts --generate && bun --cwd=../office-pane scripts/generate-client-bundle.ts --generate && bun --cwd=../natives run embed:native && bun build --compile --define PI_COMPILED=true --external mupdf --root ../.. ./src/cli.ts --outfile dist/xcsh && bun --cwd=../natives run embed:native --reset && bun --cwd=../stats scripts/generate-client-bundle.ts --reset && bun --cwd=../office-pane scripts/generate-client-bundle.ts --reset",
+		"build": "bun run generate-build-info && test -f src/internal-urls/api-spec-index.generated.ts && bun --cwd=../stats scripts/generate-client-bundle.ts --generate && bun --cwd=../office-pane scripts/generate-client-bundle.ts --generate && bun --cwd=../natives run embed:native && bun build --compile --define PI_COMPILED=true --external mupdf --root ../.. ./src/cli.ts --outfile dist/xcsh && bun --cwd=../natives run embed:native --reset && bun --cwd=../stats scripts/generate-client-bundle.ts --reset && bun --cwd=../office-pane scripts/generate-client-bundle.ts --reset",
 		"check": "biome check . && bun run format-prompts -- --check && bun run check:types",
-		"check:types": "bun run generate-build-info && bun run generate-extension-capabilities && bun run generate-api-spec-index && bun run generate-branding-index && bun run generate-sitecli-index && bun run generate-terraform-index && tsgo -p tsconfig.json --noEmit",
+		"check:types": "bun run generate-build-info && tsgo -p tsconfig.json --noEmit",
 		"lint": "biome lint .",
 		"check:bundle": "bun scripts/check-bundle.ts",
-		"test": "bun run generate-build-info && bun run generate-extension-capabilities && bun run generate-api-spec-index && bun run generate-console-catalog && bun run generate-console-field-metadata && bun scripts/bun-test-guarded.ts --max-concurrency 4",
+		"test": "bun run generate-build-info && bun scripts/bun-test-guarded.ts --max-concurrency 4",
 		"fix": "biome check --write --unsafe . && bun run format-prompts && bun run generate-docs-index && bun run generate-api-spec-index && bun run generate-build-info",
 		"fmt": "biome format --write . && bun run format-prompts",
 		"format-prompts": "bun scripts/format-prompts.ts",


### PR DESCRIPTION
Closes #2601

A **type check** depended on the network, on six other repositories' upstream state, on how stale the developer's sibling checkouts were, and on which directory the checkout physically sat in.

`check:types`, `test` and `build` each ran a set of data generators before doing their actual job. Every one of those writes a **committed** file, and every one derives its content from something that moves — a sibling resolved as `../../../../<repo>`, a `raw.githubusercontent.com` fetch, or both.

The sibling path is the sharp edge: from a worktree it lands inside `.claude/worktrees/`, so the same command silently takes a different input.

## Two measured instances

**#2578** — a sibling `xcsh-chrome-extension` checkout at contractVersion 1.8.0 overwrote the committed 1.12.0 and deleted a feature block, on every check/test/build. Fixed at the generator with a guard; this removes the trigger.

**`sitecli-index`, with the staleness pointing the other way** — the local `mcn` checkout is **27 commits behind** and reports `site: ar-bgp-eastus01`; upstream reports `mcn-ce-ha-eastus01`. Run from the main checkout the generator read the stale local sibling and reproduced the stale committed value, so nothing looked wrong. Run from a worktree the sibling path missed, it fell back to the network, and produced the fresher upstream value — which then read as unexplained drift in `git status` and got reverted.

**Whether `check` "fixed" or "broke" a committed file depended on which directory you were in.** That is the defect, and it violates the repo's own standard that the same run yields the same result.

#2457 already recorded the downstream symptom: these generators opening a PR per run.

## Why removing them is safe and costs no coverage

All seven outputs are **committed**, and dedicated workflows already own deliberate refresh — `api-spec-update.yml`, `console-catalog-update.yml`, `console-catalog-drift.yml`. That is the right place for it: these files encode data captured from other systems and deserve review. `build` already asserted `test -f …api-spec-index.generated.ts`, so the committed file was expected to be present all along.

`generate-build-info` stays everywhere. It is the one **gitignored** output and must be produced locally, because it embeds the git sha, branch and dirty state.

## One thing review caught, and it was right

`XCSH_EXTENSION_CAPABILITIES` is read only by `generate-extension-capabilities`, so removing that generator from `build` would have made a deliberate co-build silently compile the committed contract instead of the selected manifest — new tools missing, removed tools still exposed, only a runtime handshake warning to show for it.

So it is restored to **`build` only**. `build` produces the artifact, so deriving the contract there is the point; `check:types` and `test` do not, which is where the non-determinism actually hurt. The accidental path stays closed by #2578's guard, which refuses a sibling that goes backwards or drops tools or features.

## Verification

- `CI=1 bun run check` — exit 0 and **git status clean**, from the main checkout **and** from a worktree. Previously the worktree run rewrote `sitecli-index.generated.ts`.
- The two runs now produce identical results, which was the whole point.
- Full `coding-agent` suite: **6212 pass**, no generated-file failures, tree clean afterwards. The 26 failures are pre-existing and environmental — Chrome/worker/manager tests that need an installed Chrome and a built binary, unchanged by this.
- `generate-build-info` still reports the right sha, branch and dirty state.
- `build`'s generator run yields contract 1.12.0 with no drift; with `XCSH_EXTENSION_CAPABILITIES` set it logs "set explicitly" and adopts the selected manifest.

## Correction to the record

I previously described the `sitecli-index` diff as drift and reverted it several times across this work. It was not drift — it was the generator picking up a legitimate upstream change that the committed file is behind on. Nothing wrong was committed either way, but the committed value in this repo **is** stale relative to `mcn`, and refreshing it is now a deliberate act through the existing workflow rather than a side effect of whoever last ran `check` from the right directory.