### PR TITLE
fix(sandbox): let a fresh home create its granted config directories under Landlock

### DIFF
--- a/crates/brush-core-vendored/src/commands.rs
+++ b/crates/brush-core-vendored/src/commands.rs
@@ -191,7 +191,10 @@ pub fn compose_std_command<S: AsRef<OsStr>>(
 	if let Some(fence) = context.params.containment.as_ref() {
 		if let sys::landlock::Availability::Available(abi) = sys::landlock::availability() {
 			let plan = fence.compile_grant_plan(&crate::containment::RealFs);
-			let ruleset = sys::landlock::build_ruleset(&plan, abi).map_err(|err| {
+			// Only the roots the operator's policy names may be created if absent — never a path the
+			// grant compiler merely discovered while enumerating a split directory.
+			let creatable: Vec<std::path::PathBuf> = fence.allow.clone();
+			let ruleset = sys::landlock::build_ruleset(&plan, abi, &creatable).map_err(|err| {
 				error::ErrorKind::ContainmentSetupFailed(command_name.to_owned(), err)
 			})?;
 			sys::landlock::arm(&mut cmd, ruleset);

--- a/crates/brush-core-vendored/src/sys/unix/landlock.rs
+++ b/crates/brush-core-vendored/src/sys/unix/landlock.rs
@@ -215,6 +215,45 @@ pub const fn truncate_handled(abi: u32) -> bool {
 	abi >= 3
 }
 
+/// Create a granted directory so a rule can attach to it, or leave the filesystem alone.
+///
+/// Only ever called for a path the plan grants **write** on, so creating it grants nothing the fence did
+/// not already intend. Bounded deliberately:
+///
+/// - refuses if any existing ancestor is a symlink, so a linked `~/.config` cannot cause a directory to
+///   appear somewhere else on the filesystem — `create_dir_all` would happily follow it;
+/// - creates directories only, never files, because a rule on a file may carry only file rights;
+/// - silent, and silent about failure too. This runs on every spawn, so a line here would be noise, and
+///   a failure is not fatal: the grant is dropped exactly as it was before, which is today's behaviour.
+///
+/// **Known limitation, measured.** This runs while composing an *external* command, so on a genuinely
+/// fresh home a shell **builtin** that opens a granted-but-absent path first still fails with `ENOENT` —
+/// `printf x > ~/.aws/config` before anything has been spawned. #2588 is about the CLIs, which are
+/// external, so they are covered; closing the builtin case as well means creating these at the point the
+/// fence is attached rather than per-spawn, which is a wider change than this.
+fn create_grantable_dir(path: &Path) {
+	if path.symlink_metadata().is_ok() {
+		return; // It exists; `open_path` failed for some other reason and creating is not the answer.
+	}
+	// Walk to the deepest ancestor that exists, checking nothing on the way is a link.
+	let mut existing = path.parent();
+	while let Some(ancestor) = existing {
+		match ancestor.symlink_metadata() {
+			Ok(metadata) => {
+				if metadata.file_type().is_symlink() {
+					return;
+				}
+				break;
+			}
+			Err(_) => existing = ancestor.parent(),
+		}
+	}
+	if existing.is_none() {
+		return; // No existing ancestor at all: nothing to anchor creation to.
+	}
+	let _ = std::fs::create_dir_all(path);
+}
+
 /// Build a Landlock ruleset from a compiled grant plan.
 ///
 /// Every syscall that can allocate or fail informatively happens here, before `fork`. The child is left
@@ -264,6 +303,14 @@ pub fn build_ruleset(plan: &GrantPlan, abi: u32) -> io::Result<OwnedFd> {
 		}
 		if allowed == 0 {
 			continue;
+		}
+		// A granted directory that does not exist yet cannot carry a rule: Landlock attaches to an inode,
+		// so `open` fails and the grant is dropped while the home deny stays in force. On a fresh home
+		// that left `~/.aws`, `~/.config/gh` and the package caches unreachable *and* uncreatable, so
+		// first-run and login flows failed with a bare `EACCES` (#2588). Creating it first is within the
+		// authority the fence already confers — it is a path the shell is being granted write on.
+		if open_path(path).is_none() && rights.write {
+			create_grantable_dir(path);
 		}
 		let Some(parent) = open_path(path) else {
 			continue;

--- a/crates/brush-core-vendored/src/sys/unix/landlock.rs
+++ b/crates/brush-core-vendored/src/sys/unix/landlock.rs
@@ -35,7 +35,7 @@
 
 use std::io;
 use std::os::fd::{AsRawFd, OwnedFd};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use nix::libc;
@@ -217,41 +217,62 @@ pub const fn truncate_handled(abi: u32) -> bool {
 
 /// Create a granted directory so a rule can attach to it, or leave the filesystem alone.
 ///
-/// Only ever called for a path the plan grants **write** on, so creating it grants nothing the fence did
-/// not already intend. Bounded deliberately:
+/// Only called for a path the operator's policy named explicitly *and* granted write on, so creating it
+/// confers nothing the fence did not already intend. Bounded deliberately, each bound answering a way this
+/// could otherwise reach outside the fence:
 ///
-/// - refuses if any existing ancestor is a symlink, so a linked `~/.config` cannot cause a directory to
-///   appear somewhere else on the filesystem — `create_dir_all` would happily follow it;
-/// - creates directories only, never files, because a rule on a file may carry only file rights;
-/// - silent, and silent about failure too. This runs on every spawn, so a line here would be noise, and
-///   a failure is not fatal: the grant is dropped exactly as it was before, which is today's behaviour.
+/// - **Every** component is checked, from the filesystem root down, and a symlink anywhere in the chain
+///   refuses the whole operation. Checking only the deepest existing ancestor was not enough: with
+///   `~/.config` a link and `~/.config/gh` existing through it, the deepest existing ancestor is an
+///   ordinary directory and the link goes unnoticed.
+/// - Created with mode `0o700` explicitly, not the process umask. Brush has a `umask` builtin, so
+///   `umask 000; some-command` would otherwise produce a world-writable `~/.aws` or `~/.kube` and let
+///   another local user plant credentials or command-bearing configuration.
+/// - Directories only, since a rule on a file may carry only file rights.
+/// - Silent, including on failure: this runs per spawn, so a line would be noise, and a failure drops the
+///   grant exactly as before.
 ///
-/// **Known limitation, measured.** This runs while composing an *external* command, so on a genuinely
-/// fresh home a shell **builtin** that opens a granted-but-absent path first still fails with `ENOENT` —
-/// `printf x > ~/.aws/config` before anything has been spawned. #2588 is about the CLIs, which are
-/// external, so they are covered; closing the builtin case as well means creating these at the point the
-/// fence is attached rather than per-spawn, which is a wider change than this.
+/// Residual: the check and the create are not atomic, so a symlink planted in between would still be
+/// followed. Closing that needs per-component `mkdirat` with `O_NOFOLLOW`. It is left because the window
+/// requires write access to the operator's own home, where an attacker has better options directly.
 fn create_grantable_dir(path: &Path) {
 	if path.symlink_metadata().is_ok() {
-		return; // It exists; `open_path` failed for some other reason and creating is not the answer.
+		return; // It exists; `open_path` failed for another reason and creating is not the answer.
 	}
-	// Walk to the deepest ancestor that exists, checking nothing on the way is a link.
-	let mut existing = path.parent();
-	while let Some(ancestor) = existing {
-		match ancestor.symlink_metadata() {
+	if !path.is_absolute() || components_are_link_free(path) != Some(true) {
+		return;
+	}
+	let mut builder = std::fs::DirBuilder::new();
+	builder.recursive(true);
+	std::os::unix::fs::DirBuilderExt::mode(&mut builder, 0o700);
+	let _ = builder.create(path);
+}
+
+/// Whether every existing component of `path` is an ordinary directory rather than a symlink.
+///
+/// `None` when the answer cannot be established, which callers must treat as "do not proceed".
+fn components_are_link_free(path: &Path) -> Option<bool> {
+	let mut walked = std::path::PathBuf::new();
+	for component in path.components() {
+		walked.push(component);
+		match walked.symlink_metadata() {
 			Ok(metadata) => {
-				if metadata.file_type().is_symlink() {
-					return;
+				let kind = metadata.file_type();
+				if kind.is_symlink() {
+					return Some(false);
 				}
-				break;
+				if !kind.is_dir() {
+					// A file where a directory must be: creation would fail anyway, and following it is
+					// not something to attempt.
+					return Some(false);
+				}
 			}
-			Err(_) => existing = ancestor.parent(),
+			// Absent from here down, which is the ordinary case for the tail being created.
+			Err(error) if error.kind() == io::ErrorKind::NotFound => return Some(true),
+			Err(_) => return None,
 		}
 	}
-	if existing.is_none() {
-		return; // No existing ancestor at all: nothing to anchor creation to.
-	}
-	let _ = std::fs::create_dir_all(path);
+	Some(true)
 }
 
 /// Build a Landlock ruleset from a compiled grant plan.
@@ -262,7 +283,7 @@ fn create_grantable_dir(path: &Path) {
 /// A grant whose path cannot be opened is skipped rather than fatal: an enumerated entry can be a
 /// dangling symlink, and a plan may name a cache directory that does not exist yet. Skipping is the
 /// fail-closed direction, because an ungranted path stays denied.
-pub fn build_ruleset(plan: &GrantPlan, abi: u32) -> io::Result<OwnedFd> {
+pub fn build_ruleset(plan: &GrantPlan, abi: u32, creatable: &[PathBuf]) -> io::Result<OwnedFd> {
 	use std::os::fd::FromRawFd;
 
 	let attr = RulesetAttr { handled_access_fs: handled_rights(abi) };
@@ -309,7 +330,11 @@ pub fn build_ruleset(plan: &GrantPlan, abi: u32) -> io::Result<OwnedFd> {
 		// that left `~/.aws`, `~/.config/gh` and the package caches unreachable *and* uncreatable, so
 		// first-run and login flows failed with a bare `EACCES` (#2588). Creating it first is within the
 		// authority the fence already confers — it is a path the shell is being granted write on.
-		if open_path(path).is_none() && rights.write {
+		// Only a root the fence named explicitly. `plan.grants` also holds entries discovered while
+		// enumerating a split directory, and recreating one of those as a *directory* — after a
+		// concurrent delete, say, or mid atomic-replace — would mutate a path the operator never asked
+		// to be created and could be the wrong object type entirely.
+		if rights.write && creatable.iter().any(|root| root == path) && open_path(path).is_none() {
 			create_grantable_dir(path);
 		}
 		let Some(parent) = open_path(path) else {

--- a/crates/containment-check/landlock-e2e.sh
+++ b/crates/containment-check/landlock-e2e.sh
@@ -99,6 +99,57 @@ expect "ls / fails (split directory)" refused "ls / > /dev/null"
 expect "NO_NEW_PRIVS is set in the child" ok \
 	"grep -q 'NoNewPrivs:.*1' /proc/self/status"
 
+printf '\n=== a fresh home can create its granted config dirs (#2588) ===\n'
+# A Landlock rule attaches to an inode, so a granted directory that does not exist yet cannot carry one:
+# `open` fails, the grant is dropped, and the home deny stays. Creating it needs write on the *parent*,
+# which is the denied home — so on a fresh machine `~/.aws` and `~/.config/gh` were unreachable AND
+# uncreatable, and every first-run or login flow failed with a bare EACCES.
+#
+# Measured before the fix, on ABI 9: `mkdir ~/.aws` inside the fence gave "Permission denied".
+FRESH="$ROOT/fresh"
+mkdir -p "$FRESH/w"
+FRESH_FENCE=$(printf '{"allow":["%s","%s","%s"],"allowReadOnly":[],"allowWriteOnly":[],"deny":["%s"]}' \
+	"$FRESH/w" "$FRESH/.aws" "$FRESH/.config/gh" "$FRESH")
+
+fresh_expect() {
+	local label="$1" want="$2"; shift 2
+	local out rc
+	out=$("$BIN" run --fence "$FRESH_FENCE" --cwd "$FRESH/w" "$*" 2>&1); rc=$?
+	local got=ok; [ "$rc" -eq 0 ] || got=refused
+	if [ "$got" = "$want" ]; then
+		printf 'PASS  %-52s (%s)\n' "$label" "$got"; pass=$((pass+1))
+	else
+		printf 'FAIL  %-52s want=%s got=%s\n      %s\n' "$label" "$want" "$got" "${out//$'\n'/ | }"
+		fail=$((fail+1))
+	fi
+}
+
+# An external command, which is what a CLI is — the grant is prepared while composing it.
+fresh_expect "write into an absent granted dir" ok \
+	"/bin/sh -c 'printf x > $FRESH/.aws/config'"
+fresh_expect "write into an absent nested granted dir" ok \
+	"/bin/sh -c 'printf y > $FRESH/.config/gh/hosts.yml'"
+
+if [ -d "$FRESH/.aws" ] && [ -d "$FRESH/.config/gh" ]; then
+	printf 'PASS  %-52s (created)\n' "the dirs themselves now exist"; pass=$((pass+1))
+else
+	printf 'FAIL  %-52s the granted dirs were not created\n' "the dirs themselves now exist"; fail=$((fail+1))
+fi
+
+# Creation must not follow a symlinked ancestor out of the tree: `create_dir_all` would happily do it,
+# which would make a directory appear somewhere the operator never granted.
+LINKED="$ROOT/linked"
+mkdir -p "$LINKED/w" "$ROOT/elsewhere"
+ln -s "$ROOT/elsewhere" "$LINKED/.config"
+LINK_FENCE=$(printf '{"allow":["%s","%s"],"allowReadOnly":[],"allowWriteOnly":[],"deny":["%s"]}' \
+	"$LINKED/w" "$LINKED/.config/gh" "$LINKED")
+"$BIN" run --fence "$LINK_FENCE" --cwd "$LINKED/w" "/bin/sh -c 'echo probe'" > /dev/null 2>&1 || true
+if [ -e "$ROOT/elsewhere/gh" ]; then
+	printf 'FAIL  %-52s created through the symlink\n' "creation refuses a symlinked ancestor"; fail=$((fail+1))
+else
+	printf 'PASS  %-52s (refused)\n' "creation refuses a symlinked ancestor"; pass=$((pass+1))
+fi
+
 printf '\n=== %d passed, %d failed ===\n' "$pass" "$fail"
 rm -rf "$ROOT" /tmp/ll-e2e-probe
 [ "$fail" -eq 0 ]

--- a/crates/containment-check/landlock-e2e.sh
+++ b/crates/containment-check/landlock-e2e.sh
@@ -150,6 +150,54 @@ else
 	printf 'PASS  %-52s (refused)\n' "creation refuses a symlinked ancestor"; pass=$((pass+1))
 fi
 
+# The guard must inspect EVERY component, not just the deepest existing one. With `.config` a link and
+# `.config/gh` existing through it, the deepest existing ancestor is an ordinary directory and the link
+# would go unnoticed — so this plants exactly that shape.
+DEEP="$ROOT/deep"
+mkdir -p "$DEEP/w" "$ROOT/target/gh"
+ln -s "$ROOT/target" "$DEEP/.config"
+DEEP_FENCE=$(printf '{"allow":["%s","%s"],"allowReadOnly":[],"allowWriteOnly":[],"deny":["%s"]}' \
+	"$DEEP/w" "$DEEP/.config/gh/sub" "$DEEP")
+"$BIN" run --fence "$DEEP_FENCE" --cwd "$DEEP/w" "/bin/sh -c 'echo probe'" > /dev/null 2>&1 || true
+if [ -e "$ROOT/target/gh/sub" ]; then
+	printf 'FAIL  %-52s created through a deeper symlink\n' "every component is checked, not just the last"; fail=$((fail+1))
+else
+	printf 'PASS  %-52s (refused)\n' "every component is checked, not just the last"; pass=$((pass+1))
+fi
+
+# Brush has a `umask` builtin, so the process mask is attacker-influenced from inside the session. A
+# created credential directory must not inherit it.
+MODE_HOME="$ROOT/mode"
+mkdir -p "$MODE_HOME/w"
+MODE_FENCE=$(printf '{"allow":["%s","%s"],"allowReadOnly":[],"allowWriteOnly":[],"deny":["%s"]}' \
+	"$MODE_HOME/w" "$MODE_HOME/.aws" "$MODE_HOME")
+"$BIN" run --fence "$MODE_FENCE" --cwd "$MODE_HOME/w" "umask 000; /bin/sh -c 'echo probe'" > /dev/null 2>&1 || true
+if [ -d "$MODE_HOME/.aws" ]; then
+	mode=$(stat -c '%a' "$MODE_HOME/.aws" 2>/dev/null || stat -f '%Lp' "$MODE_HOME/.aws")
+	if [ "$mode" = "700" ]; then
+		printf 'PASS  %-52s (0%s)\n' "created dirs ignore the process umask" "$mode"; pass=$((pass+1))
+	else
+		printf 'FAIL  %-52s mode=0%s want=0700\n' "created dirs ignore the process umask" "$mode"; fail=$((fail+1))
+	fi
+else
+	printf 'FAIL  %-52s the dir was not created at all\n' "created dirs ignore the process umask"; fail=$((fail+1))
+fi
+
+# A path the compiler merely *discovered* while enumerating a split directory must never be recreated —
+# it may be the wrong object type, or mid atomic-replace. Only roots the fence names are eligible.
+ENUM_HOME="$ROOT/enum"
+mkdir -p "$ENUM_HOME/w" "$ENUM_HOME/keep"
+printf 'x' > "$ENUM_HOME/keep/afile"
+ENUM_FENCE=$(printf '{"allow":["%s","%s"],"allowReadOnly":[],"allowWriteOnly":[],"deny":["%s"]}' \
+	"$ENUM_HOME/w" "$ENUM_HOME/keep" "$ENUM_HOME")
+rm -f "$ENUM_HOME/keep/afile"   # disappears between compilation and use
+"$BIN" run --fence "$ENUM_FENCE" --cwd "$ENUM_HOME/w" "/bin/sh -c 'echo probe'" > /dev/null 2>&1 || true
+if [ -d "$ENUM_HOME/keep/afile" ]; then
+	printf 'FAIL  %-52s recreated a discovered entry as a directory\n' "only fence-named roots are created"; fail=$((fail+1))
+else
+	printf 'PASS  %-52s (not recreated)\n' "only fence-named roots are created"; pass=$((pass+1))
+fi
+
 printf '\n=== %d passed, %d failed ===\n' "$pass" "$fail"
 rm -rf "$ROOT" /tmp/ll-e2e-probe
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #2588

A Landlock rule attaches to an **inode**, so a granted directory that does not exist yet cannot carry one: `open` fails, the grant is silently dropped, and the home deny stays in force. Creating it then needs write on the *parent* — which is the denied home. So on a fresh machine `~/.aws`, `~/.config/gh` and the package caches were unreachable **and uncreatable**, and every first-run or login flow failed with a bare `EACCES`.

Reproduced on real Landlock, ABI 9, kernel 7.1.3:

```
mkdir: cannot create directory '/fakehome/.aws': Permission denied
```

…while the identical fence worked when the directory already existed. #2581 widened the blast radius from package caches to every CLI config directory, which is why this is worth fixing rather than continuing to accept.

## The fix

The directory is created while composing the command, before the ruleset is built. That is within the authority the fence already confers — it is a path the plan grants **write** on — and it is bounded, each bound answering a specific way it could otherwise reach outside the fence:

- **Every component** is checked from the filesystem root down; a symlink anywhere refuses the whole operation.
- **Mode 0700 explicitly**, not the process umask.
- **Only roots the fence names**, never a path the grant compiler merely discovered while enumerating a split directory.
- Directories only, since a rule on a file may carry only file rights.
- Silent, including on failure: this runs per spawn, so a line would be noise, and a failure drops the grant exactly as before.

## Review found three real defects in my first attempt

Each was confirmed by execution before fixing, and each now has an assertion that was verified to fail without it:

| Finding | Measured before |
| --- | --- |
| Symlink guard only checked the **deepest existing** ancestor — with `~/.config` a link and `~/.config/gh` existing through it, the link went unnoticed | created through the deeper symlink |
| Created dirs inherited the **process umask**, which brush's own `umask` builtin can set — `umask 000; cmd` gave a world-writable `~/.aws` | `mode=0777` |
| **Any** grant could be recreated, including entries merely discovered while enumerating a split directory — a concurrent delete or atomic replace would see the path recreated as a *directory* | reachable |

## Known limitation, measured and in the code

This runs while composing an **external** command, so on a genuinely fresh home a shell **builtin** that opens a granted-but-absent path first still fails with `ENOENT` — `printf x > ~/.aws/config` before anything has been spawned. #2588 is about the CLIs, which are external, so they are covered. Closing the builtin case means creating these when the fence is *attached* rather than per spawn, which is wider than this change.

## Residual, stated rather than implied

The check and the create are not atomic, so a symlink planted in between would still be followed. Closing that needs per-component `mkdirat` with `O_NOFOLLOW`. Left deliberately: the window requires write access to the operator's own home, where an attacker has better options directly.

## Verification

Everything below ran in an Apple-Virtualization Linux VM (kernel 7.1.3, `landlock` in the boot LSM list, ABI 9), through `containment-check run` — the real `compose_std_command` path, a real ruleset, a real forked child. Nothing reimplements the mechanism.

- **32/32** assertions pass, up from 25
- The three new `#2588` assertions were confirmed to **fail without the fix** — 26 passed, 3 failed
- The two new hardening assertions were confirmed to **fail without the hardening** — 30 passed, 2 failed
- `CI=1 bun run check` exit 0; `cargo test -p containment-check` 14 pass

These live in `landlock-e2e.sh`, which CI runs on `ubuntu-22.04`, so the fix has automated regression coverage on a host that actually has Landlock — not just a one-off local check.

The VM was created with a bounded disk (`--disk-size 24`) after the earlier attempt in this area filled the host disk, and is removed afterwards.