### PR TITLE
feat(prompt): tell xcsh its working directory may be one customer's

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -196,6 +196,19 @@ Configs you didn't validate become incidents. Assumptions you didn't test fail u
 {{#list environment prefix="- " join="\n"}}{{label}}: {{value}}{{/list}}
 </workstation>
 
+<workspace-boundary>
+This session may be scoped to a single customer. The working directory is the whole of your
+context: what you need is inside it, and another customer's material is not yours to open here.
+- You **MUST NOT** range across the filesystem hunting for files, examples, or precedent.
+  Search within the working directory — never widen to its parent or to unrelated paths.
+- Subdirectories may themselves be separate customers. Reachable does not mean in scope: work in
+  the one the task names, state the crossing when the task genuinely spans more than one, and
+  **MUST NOT** merge two customers' material into one artifact.
+- Filesystem isolation is enforced, so a path outside the boundary is refused. That is the
+  boundary working, not a tool failure: say what you needed and why, and **MUST NOT** reach the
+  same path another way.
+</workspace-boundary>
+
 {{#if context}}
 ## F5 XC Platform Context
 

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -196,20 +196,7 @@ Configs you didn't validate become incidents. Assumptions you didn't test fail u
 {{#list environment prefix="- " join="\n"}}{{label}}: {{value}}{{/list}}
 </workstation>
 
-<workspace-boundary>
-This session may be scoped to a single customer. Treat the working directory as the scope of the
-work: what the task needs is inside it, and another customer's material is not yours to open here.
-- You **MUST NOT** range across the filesystem hunting for files, examples, or precedent. Search
-  within the working directory. Your own skills and plugins, and paths the operator granted
-  explicitly (`--allow-path`, `sandbox.allowRead`), are legitimate — and are not licence to browse
-  anywhere else.
-- Subdirectories may themselves be separate customers. Reachable does not mean in scope: work in
-  the one the task names, state the crossing when the task genuinely spans more than one, and
-  **MUST NOT** merge two customers' material into one artifact.
-- A sandbox confines this session's file access. When it is active, a path outside the boundary is
-  refused — that is the boundary working, not a tool failure. Say what you needed and why, and
-  **MUST NOT** reach the same path another way.
-</workspace-boundary>
+%%WORKSPACE_BOUNDARY%%
 
 {{#if context}}
 ## F5 XC Platform Context

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -197,16 +197,18 @@ Configs you didn't validate become incidents. Assumptions you didn't test fail u
 </workstation>
 
 <workspace-boundary>
-This session may be scoped to a single customer. The working directory is the whole of your
-context: what you need is inside it, and another customer's material is not yours to open here.
-- You **MUST NOT** range across the filesystem hunting for files, examples, or precedent.
-  Search within the working directory — never widen to its parent or to unrelated paths.
+This session may be scoped to a single customer. Treat the working directory as the scope of the
+work: what the task needs is inside it, and another customer's material is not yours to open here.
+- You **MUST NOT** range across the filesystem hunting for files, examples, or precedent. Search
+  within the working directory. Your own skills and plugins, and paths the operator granted
+  explicitly (`--allow-path`, `sandbox.allowRead`), are legitimate — and are not licence to browse
+  anywhere else.
 - Subdirectories may themselves be separate customers. Reachable does not mean in scope: work in
   the one the task names, state the crossing when the task genuinely spans more than one, and
   **MUST NOT** merge two customers' material into one artifact.
-- Filesystem isolation is enforced, so a path outside the boundary is refused. That is the
-  boundary working, not a tool failure: say what you needed and why, and **MUST NOT** reach the
-  same path another way.
+- A sandbox confines this session's file access. When it is active, a path outside the boundary is
+  refused — that is the boundary working, not a tool failure. Say what you needed and why, and
+  **MUST NOT** reach the same path another way.
 </workspace-boundary>
 
 {{#if context}}

--- a/packages/coding-agent/src/prompts/system/workspace-boundary.md
+++ b/packages/coding-agent/src/prompts/system/workspace-boundary.md
@@ -8,7 +8,8 @@ work: what the task needs is inside it, and another customer's material is not y
 - Subdirectories may themselves be separate customers. Reachable does not mean in scope: work in
   the one the task names, state the crossing when the task genuinely spans more than one, and
   **MUST NOT** merge two customers' material into one artifact.
-- A sandbox confines this session's file access. When it is active, a path outside the boundary is
-  refused — that is the boundary working, not a tool failure. Say what you needed and why, and
-  **MUST NOT** reach the same path another way.
+- A sandbox confines this session's file access, but its boundary is the working directory, not the
+  customer subdirectory: nothing refuses a sibling, so the rule above is yours to keep. When the
+  sandbox is active a path outside the working directory is refused — that is the boundary working,
+  not a tool failure. Say what you needed and why, and **MUST NOT** reach the same path another way.
 </workspace-boundary>

--- a/packages/coding-agent/src/prompts/system/workspace-boundary.md
+++ b/packages/coding-agent/src/prompts/system/workspace-boundary.md
@@ -1,0 +1,14 @@
+<workspace-boundary>
+This session may be scoped to a single customer. Treat the working directory as the scope of the
+work: what the task needs is inside it, and another customer's material is not yours to open here.
+- You **MUST NOT** range across the filesystem hunting for files, examples, or precedent. Search
+  within the working directory. Your own skills and plugins, and paths the operator granted
+  explicitly (`--allow-path`, `sandbox.allowRead`), are legitimate — and are not licence to browse
+  anywhere else.
+- Subdirectories may themselves be separate customers. Reachable does not mean in scope: work in
+  the one the task names, state the crossing when the task genuinely spans more than one, and
+  **MUST NOT** merge two customers' material into one artifact.
+- A sandbox confines this session's file access. When it is active, a path outside the boundary is
+  refused — that is the boundary working, not a tool failure. Say what you needed and why, and
+  **MUST NOT** reach the same path another way.
+</workspace-boundary>

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -26,9 +26,11 @@ import { listXcshPluginSummaries, type XcshPluginSummary } from "./discovery/hel
 import { isApplicableToContext, loadSkills, type Skill } from "./extensibility/skills";
 import customSystemPromptTemplate from "./prompts/system/custom-system-prompt.md" with { type: "text" };
 import systemPromptTemplate from "./prompts/system/system-prompt.md" with { type: "text" };
+import workspaceBoundaryTemplate from "./prompts/system/workspace-boundary.md" with { type: "text" };
 
 /** Sentinel in system-prompt.md replaced with the rendered deprecation guardrails. */
 const DEPRECATION_GUARDRAILS_MARKER = "%%DEPRECATION_GUARDRAILS%%";
+const WORKSPACE_BOUNDARY_MARKER = "%%WORKSPACE_BOUNDARY%%";
 
 let _buildMeta: { version: string; repoSlug: string } | null = null;
 
@@ -815,6 +817,14 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		knowledgeTopics: options.knowledgeTopics,
 	};
 	let rendered = prompt.render(resolvedCustomPrompt ? customSystemPromptTemplate : systemPromptTemplate, data);
+
+	// The workspace boundary is always-on for the same reason: a custom system prompt
+	// swaps in a template with no Workspace section, and the confidentiality guidance
+	// must not be what disappears when an operator customises their prompt.
+	const workspaceBoundary = workspaceBoundaryTemplate.trimEnd();
+	rendered = rendered.includes(WORKSPACE_BOUNDARY_MARKER)
+		? rendered.replace(WORKSPACE_BOUNDARY_MARKER, workspaceBoundary)
+		: `${rendered}\n\n${workspaceBoundary}`;
 
 	// Deprecation guardrails are always-on: replace the section marker in the default
 	// template, or append when the active template has none (e.g. a fully custom system

--- a/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
+++ b/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
@@ -1,0 +1,89 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { registerCodingAgentPromptHelpers } from "../src/config/prompt-templates";
+import { buildSystemPrompt } from "../src/system-prompt";
+
+const OPEN_TAG = "<workspace-boundary>";
+const CLOSE_TAG = "</workspace-boundary>";
+
+let rendered = "";
+
+beforeAll(async () => {
+	registerCodingAgentPromptHelpers();
+	rendered = await buildSystemPrompt({ tools: new Map() });
+});
+
+/** The block's own text, so assertions about it cannot be satisfied by the rest of the prompt. */
+function block(): string {
+	const open = rendered.indexOf(OPEN_TAG);
+	const close = rendered.indexOf(CLOSE_TAG);
+	if (open === -1 || close === -1) return "";
+	return rendered.slice(open, close + CLOSE_TAG.length);
+}
+
+/**
+ * The block with whitespace runs collapsed, for matching prose.
+ *
+ * The block is hard-wrapped, so a phrase can straddle a line break plus its indent
+ * ("reach the\n  same path another way"). Matching the raw text would make these
+ * assertions fail on a rewrap that changed nothing about the meaning.
+ */
+function flat(): string {
+	return block().replace(/\s+/g, " ");
+}
+
+function count(needle: string): number {
+	return rendered.split(needle).length - 1;
+}
+
+describe("system prompt workspace boundary", () => {
+	it("renders the block exactly once", () => {
+		expect(count(OPEN_TAG)).toBe(1);
+		expect(count(CLOSE_TAG)).toBe(1);
+	});
+
+	// The filesystem scope belongs beside the F5 XC tenant/namespace scope — the two
+	// things that bound a session — not appended wherever it happened to fit.
+	it("places the block inside the Workspace section", () => {
+		const workstation = rendered.indexOf("</workstation>");
+		const boundary = rendered.indexOf(OPEN_TAG);
+		const nextSection = rendered.indexOf("## Resource Manifest Format");
+		expect(workstation).toBeGreaterThan(-1);
+		expect(nextSection).toBeGreaterThan(-1);
+		expect(boundary).toBeGreaterThan(workstation);
+		expect(boundary).toBeLessThan(nextSection);
+	});
+
+	// A possibility, never an assertion: nothing in the prompt knows the directory's
+	// shape, because a customer boundary is not visible in the filesystem.
+	it("primes the single-customer case without asserting it", () => {
+		expect(flat()).toMatch(/may be scoped to a single customer/i);
+	});
+
+	it("prohibits ranging across the filesystem for context", () => {
+		expect(flat()).toContain("**MUST NOT** range across the filesystem");
+		expect(flat()).toMatch(/never widen to its parent/i);
+	});
+
+	// The sandbox link: enforcement is named so a refusal is legible as the boundary
+	// working, which is what stops the reach-for-another-spelling reflex.
+	it("names that filesystem isolation is enforced and refusals are not reroutable", () => {
+		expect(flat()).toMatch(/isolation is enforced/i);
+		expect(flat()).toMatch(/reach the same path another way/i);
+	});
+
+	// Guards the non-goal. Work that genuinely spans two subdirectories must stay
+	// possible; the requirement is that the crossing be deliberate and stated. This
+	// fails if a later edit quietly turns the block into a lockdown.
+	it("does not forbid cross-customer work outright", () => {
+		expect(flat()).not.toMatch(/MUST NOT (read|access|open|touch) (another|other|a different)/i);
+		expect(flat()).toMatch(/state the crossing/i);
+	});
+
+	// The non-empty guard is load-bearing: `block()` returns "" when the block is
+	// absent, and "" contains no "{{" — so without it this assertion passes vacuously
+	// on a prompt that never rendered the block at all.
+	it("leaves no unrendered template syntax in the block", () => {
+		expect(block()).not.toBe("");
+		expect(block()).not.toContain("{{");
+	});
+});

--- a/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
+++ b/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
@@ -84,9 +84,22 @@ describe("system prompt workspace boundary", () => {
 	// would give a deliberately-degraded session false assurance about isolation.
 	it("names the sandbox without asserting enforcement unconditionally", () => {
 		expect(flat()).toMatch(/sandbox confines this session/i);
-		expect(flat()).toMatch(/when it is active/i);
+		// The property is that the refusal is stated CONDITIONALLY on the sandbox being
+		// active; either phrasing of that condition satisfies it.
+		expect(flat()).toMatch(/when (it|the sandbox) is active/i);
 		expect(flat()).not.toMatch(/isolation is enforced/i);
 		expect(flat()).toMatch(/reach the same path another way/i);
+	});
+
+	// Codex round 3 called the block false assurance about the customer boundary. Refuted
+	// as stated -- "Reachable does not mean in scope" already tells the model the sandbox
+	// will not stop a sibling read. But the two boundaries sat in adjacent bullets and
+	// could be read as one, so the block now names which boundary the sandbox enforces.
+	// This is the awareness the change exists to create: crossing between sibling
+	// customers is refused by nothing, which is precisely why the rule is the model's.
+	it("distinguishes the sandbox boundary from the customer boundary", () => {
+		expect(flat()).toMatch(/boundary is the working directory, not the customer subdirectory/i);
+		expect(flat()).toMatch(/nothing refuses a sibling/i);
 	});
 
 	// Guards the non-goal. Work that genuinely spans two subdirectories must stay

--- a/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
+++ b/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
@@ -61,13 +61,30 @@ describe("system prompt workspace boundary", () => {
 
 	it("prohibits ranging across the filesystem for context", () => {
 		expect(flat()).toContain("**MUST NOT** range across the filesystem");
-		expect(flat()).toMatch(/never widen to its parent/i);
 	});
 
-	// The sandbox link: enforcement is named so a refusal is legible as the boundary
-	// working, which is what stops the reach-for-another-spelling reflex.
-	it("names that filesystem isolation is enforced and refusals are not reroutable", () => {
-		expect(flat()).toMatch(/isolation is enforced/i);
+	// `buildDefaultSandboxPolicy` allows reads OUTSIDE the CWD: user-level skills, the
+	// plugin dir, and any `--allow-path` / `sandbox.allowRead` grant. An absolute "never
+	// widen beyond the working directory" would forbid paths the operator deliberately
+	// granted, and would contradict the Procedure section's "if a skill matches the
+	// domain, you MUST read it before starting".
+	it("acknowledges explicit grants and the allowlisted read locations", () => {
+		expect(flat()).toMatch(/--allow-path/);
+		expect(flat()).toMatch(/skills and plugins/i);
+		expect(flat()).not.toMatch(/never widen to its parent/i);
+	});
+
+	// The sandbox link: naming the sandbox is what makes a refusal legible as the
+	// boundary working, which stops the reach-for-another-spelling reflex.
+	//
+	// But it MUST be conditional. `buildSystemPrompt` is handed no containment status,
+	// so the block cannot know whether isolation is on; under `--no-sandbox` or
+	// `sandbox.enabled: false` nothing is refused at all. Asserting enforcement as fact
+	// would give a deliberately-degraded session false assurance about isolation.
+	it("names the sandbox without asserting enforcement unconditionally", () => {
+		expect(flat()).toMatch(/sandbox confines this session/i);
+		expect(flat()).toMatch(/when it is active/i);
+		expect(flat()).not.toMatch(/isolation is enforced/i);
 		expect(flat()).toMatch(/reach the same path another way/i);
 	});
 

--- a/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
+++ b/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
@@ -39,6 +39,7 @@ describe("system prompt workspace boundary", () => {
 	it("renders the block exactly once", () => {
 		expect(count(OPEN_TAG)).toBe(1);
 		expect(count(CLOSE_TAG)).toBe(1);
+		expect(rendered).not.toContain("%%WORKSPACE_BOUNDARY%%");
 	});
 
 	// The filesystem scope belongs beside the F5 XC tenant/namespace scope — the two
@@ -94,6 +95,21 @@ describe("system prompt workspace boundary", () => {
 	it("does not forbid cross-customer work outright", () => {
 		expect(flat()).not.toMatch(/MUST NOT (read|access|open|touch) (another|other|a different)/i);
 		expect(flat()).toMatch(/state the crossing/i);
+	});
+
+	// A custom system prompt (--system-prompt, or an auto-discovered project/global
+	// SYSTEM.md) swaps in custom-system-prompt.md, which has no Workspace section. The
+	// confidentiality guidance MUST NOT be the thing that disappears when an operator
+	// customises their prompt. Same requirement the deprecation guardrails already meet,
+	// via the same replace-or-append marker.
+	it("survives a custom system prompt", async () => {
+		const custom = await buildSystemPrompt({
+			tools: new Map(),
+			customPrompt: "You are a custom operator prompt.",
+		});
+		expect(custom).toContain(OPEN_TAG);
+		expect(custom).toContain(CLOSE_TAG);
+		expect(custom).not.toContain("%%WORKSPACE_BOUNDARY%%");
 	});
 
 	// The non-empty guard is load-bearing: `block()` returns "" when the block is


### PR DESCRIPTION
Closes #2603

## What this does

Adds one static block to the always-loaded system prompt so xcsh is prepared for the case where its working directory is one customer's, and does not go hunting through the filesystem for context that was never in scope.

```
<workspace-boundary>
This session may be scoped to a single customer. Treat the working directory as the scope of the
work: what the task needs is inside it, and another customer's material is not yours to open here.
- You **MUST NOT** range across the filesystem hunting for files, examples, or precedent. Search
  within the working directory. Your own skills and plugins, and paths the operator granted
  explicitly (`--allow-path`, `sandbox.allowRead`), are legitimate — and are not licence to browse
  anywhere else.
- Subdirectories may themselves be separate customers. Reachable does not mean in scope: work in
  the one the task names, state the crossing when the task genuinely spans more than one, and
  **MUST NOT** merge two customers' material into one artifact.
- A sandbox confines this session's file access, but its boundary is the working directory, not the
  customer subdirectory: nothing refuses a sibling, so the rule above is yours to keep. When the
  sandbox is active a path outside the working directory is refused — that is the boundary working,
  not a tool failure. Say what you needed and why, and **MUST NOT** reach the same path another way.
</workspace-boundary>
```

**1196 characters, 2.53% of the rendered prompt.**

## Why the prompt, and not the sandbox

The enforcement is already right. `buildDefaultSandboxPolicy` (`sandbox/policy.ts:130`) confines reads and writes to the CWD subtree by default-deny and separately denies `~/.xcsh/memories`, `sessions`, and the shared tenant contexts. Nothing here changes it.

What was missing is awareness, and it was missing structurally: the guidance that exists — `prompts/internal-urls/containment.md` — renders only inside `xcsh://about`, and the prompt gates that URL with *"MUST NOT read unless the user asks about xcsh itself"*. During customer work xcsh was instructed not to read the one document describing its own boundary. The always-loaded prompt's entire filesystem content was `The current working directory is '{{cwd}}'`.

## What is deliberately not here

**No detection of "is this a multi-customer parent?"** A customer boundary is not visible in the filesystem — `~/customers/{acme,globex}` and `~/monorepo/{frontend,backend}` are structurally identical. Any heuristic either asserts a customer boundary in a monorepo or misses real customer folders. The block states the possibility rather than claiming to know the shape.

**Not a lockdown.** Cross-customer work stays permitted; the requirement is that a crossing be deliberate and stated. One test pins that so a later tightening edit cannot quietly turn this into a lockdown.

## Review history — three confirmed defects in my own work

`codex:verified-code-review` (`adversarial-review`), each finding checked against the code before acting on it. Gate: `done: true`, `findingsClear: true`, no escalation.

**Round 1 (high, confirmed).** The block asserted `Filesystem isolation is enforced, so a path outside the boundary is refused` and `never widen to its parent or to unrelated paths`. Both false. Verified by executing the policy:

```
user-level skill   -> ALLOWED | inside cwd? false
plugin dir         -> ALLOWED | inside cwd? false
--allow-path grant -> ALLOWED | inside cwd? false
sandbox disabled   -> /Users/other/private.txt -> ALLOWED — nothing is refused
```

So the absolute "never widen" forbade paths the operator deliberately granted and contradicted the Procedure section's *"if a skill matches the domain, you MUST read it"*; and under `--no-sandbox` the enforcement claim gave a degraded session false assurance. `buildSystemPrompt` is handed no containment status, so the block cannot know. Fixed by wording, not runtime plumbing. **Two of my original test assertions encoded this defect and were replaced.**

**Round 2 (high, confirmed).** The block lived only in `system-prompt.md`, and `buildSystemPrompt` renders `custom-system-prompt.md` whenever `customPrompt` is supplied — `--system-prompt`, or an auto-discovered `SYSTEM.md`. Verified:

```
default template -> block present: true
custom  template -> block present: false
```

Fixed by reusing the deprecation-guardrails replace-or-append marker rather than inventing a mechanism — those guardrails already survive this path, which is what identified the pattern.

**Round 3, finding 1 (high, REFUTED — then improved anyway).** Claimed the block gives false assurance that the sandbox enforces the customer boundary. It does not: the adjacent sentence says *"Reachable does not mean in scope"*, which is the opposite. The cited fact is true and is asserted as intended behaviour by a pre-existing passing test (`test/sandbox-isolation.test.ts:42`, *"a parent-folder session sees both customer subfolders (automatic)"*). Accepted as clarity only — the two boundaries sat in adjacent bullets, so the block now names which one the sandbox enforces.

**Round 3, finding 2 (medium, confirmed — out of scope, filed as #2610).** `sdk.ts:1697` returns `options.systemPrompt(defaultPrompt)` verbatim, so a function-form override drops both always-on blocks while the string form keeps them. Not patched here: changing what a function override returns alters a public SDK contract embedders use to take full control. This predates the PR — the deprecation guardrails have the same gap.

## Verification

- **TDD, and proven non-vacuous.** 7 assertions red before the block, green after. Then the block was removed from a full-file snapshot and all 7 failed again, restored with a `diff` byte-identity check. One assertion (`no unrendered {{`) *did* pass vacuously on an absent block — `""` contains no `{{` — and now guards non-empty first.
- **10 tests** in `test/system-prompt-workspace-boundary.test.ts`. Prose assertions match whitespace-normalized text so a rewrap cannot fail a property that still holds.
- **All 58 `system-prompt-*` tests pass. `bun run check` exits 0.**
- **UAT on the real rendered prompt, both paths.** Default: block present exactly once, between `</workstation>` and the resource-manifest section, marker substituted with no leak, F5 XC tenant block intact after it. Custom: appended alongside the deprecation guardrails.
- **Full package suite: 22 failures, all pre-existing.** Reproduced identically on unmodified `main` (`aa04beb39`, clean tree) — same count, same 10 files, verified by diffing the sorted failure sets. They are macOS-seatbelt shell-fence tests and Chrome/Puppeteer E2E tests; none touch the system prompt. One test (`bundled registration`) failed in the baseline at a 22s timeout and passed in this branch — a flake in the safe direction, confirmed passing in isolation on `main`.

## Note for the reviewer

The macOS shell-fence failures on `main` are worth someone's attention independently of this PR: `containmentStatus` reports `backend: seatbelt, osEnforced: true` on this host, yet three `sandbox-isolation` tests show `TOKEN=b` readable from a sibling directory. The test file's own comments explain it as the fence being allow-by-default for trees outside home, with the command-text scan as the layer that blocks it — and that scan's tests pass. Not investigated further here since it is pre-existing and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
