### PR TITLE
fix(models): stop sending effort 'xhigh' to models that reject it

### DIFF
--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -68,6 +68,18 @@ const ANTHROPIC_ADAPTIVE_EFFORTS: readonly Effort[] = [
 	Effort.XHigh,
 	Effort.Max,
 ];
+/**
+ * Anthropic Messages API versions MEASURED to accept the full adaptive enum
+ * (`xhigh` and `max`) with no fallback chain to be capped against.
+ *
+ * Probed 2026-07-30 against the live gateway with a bogus control value, which
+ * was rejected everywhere — so the accepts mean something (#2630).
+ *
+ * Adding a version here without a probe is the defect this set exists to
+ * prevent: an unprobed model must fail closed to DEFAULT_REASONING_EFFORTS.
+ */
+const ANTHROPIC_EXTENDED_EFFORT_VERSIONS: ReadonlySet<string> = new Set(["5.0"]);
+
 const GEMINI_3_PRO_EFFORTS: readonly Effort[] = [Effort.Low, Effort.High];
 const GEMINI_3_FLASH_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High];
 const GPT_5_2_PLUS_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh];
@@ -449,15 +461,42 @@ function inferAnthropicSupportedEfforts<TApi extends Api>(
 		(model.api === "anthropic-messages" || model.api === "bedrock-converse-stream") &&
 		semverGte(parsedModel.version, "4.6")
 	) {
-		// Opus 4.6+ and Sonnet 5+ accept the extended range. Sonnet 4.6 tops out at
-		// `high` — the reason this can't key on version alone (#2341).
+		// Only 5.x accepts the extended range. Probed against the live gateway on
+		// 2026-07-30 with a bogus control value (rejected everywhere, so the accepts
+		// mean something) — #2630:
+		//
+		//   model              low med high xhigh max   fallbacks
+		//   claude-opus-5       Y   Y    Y     Y    Y   (none)
+		//   claude-sonnet-5     Y   Y    Y     Y    Y   (none)
+		//   claude-opus-4-8     Y   Y    Y     Y    Y   opus-4-6, opus-4-5
+		//   claude-opus-4-6     Y   Y    Y     .    Y   opus-4-5, sonnet-4-6
+		//   claude-sonnet-4-6   Y   Y    Y     .    Y   (none)
+		//   claude-opus-4-5     Y   Y    Y     .    .   (none)
+		//
+		// The ceiling is what a model group AND its fallbacks accept, because the
+		// gateway re-sends an identical body on fallback instead of re-mapping per
+		// target — in #2630 both fallbacks 400'd on the same `xhigh`.
+		// `claude-opus-4-5` accepts neither `xhigh` nor `max` and sits in both 4.x
+		// chains, so 4.6 and 4.8 cap at `high` even though 4.8 accepts `xhigh`
+		// alone. 5.x has no fallback chain, so it keeps its full range.
+		//
+		// #2346 keyed this on `kind === "opus" || version >= 5.0` after probing only
+		// opus-5 and sonnet-5, which handed `xhigh` to every opus >= 4.6 and made
+		// resumed sessions pinned to opus-4-6 fail with a 400.
 		const extended = parsedModel.kind === "opus" || semverGte(parsedModel.version, "5.0");
 		if (!extended) return DEFAULT_REASONING_EFFORTS;
-		// `max` is only claimed for the first-party Messages API, where the enum was
-		// verified against the live gateway. Bedrock's effort support is not verified
-		// here, so it keeps the pre-existing `xhigh` ceiling rather than being widened
-		// on an assumption.
-		return model.api === "anthropic-messages" ? ANTHROPIC_ADAPTIVE_EFFORTS : DEFAULT_REASONING_EFFORTS_WITH_XHIGH;
+		// Bedrock was NOT probed, so it keeps its pre-existing `xhigh` ceiling.
+		// Narrowing it here would repeat #2346's mistake in the opposite direction —
+		// changing a whole family's capability without measuring it.
+		if (model.api === "bedrock-converse-stream") return DEFAULT_REASONING_EFFORTS_WITH_XHIGH;
+		// Messages API: opt in per MEASURED version, never by an open-ended
+		// comparison. `semverGte(version, "5.0")` would hand the extended enum to
+		// every future Claude the moment it lands in the catalog — the same
+		// open-ended grant that caused this bug. Unprobed versions fail closed to
+		// the conservative range; add one here only with a probe to back it.
+		return ANTHROPIC_EXTENDED_EFFORT_VERSIONS.has(`${parsedModel.version.major}.${parsedModel.version.minor}`)
+			? ANTHROPIC_ADAPTIVE_EFFORTS
+			: DEFAULT_REASONING_EFFORTS;
 	}
 	return inferFallbackEfforts(model);
 }

--- a/packages/ai/test/effort-ladder.test.ts
+++ b/packages/ai/test/effort-ladder.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import {
+	clampThinkingLevelForModel,
 	Effort,
 	getBundledModel,
+	getSupportedEfforts,
 	type Model,
 	mapEffortToAnthropicAdaptiveEffort,
 	mapEffortToGoogleThinkingLevel,
@@ -73,6 +75,81 @@ describe("catalog effort ranges", () => {
 
 	it("keeps sonnet-4-6 below xhigh (it does not support that level) — #2341", () => {
 		expect(anthropic("claude-sonnet-4-6").thinking?.maxLevel).toBe(Effort.High);
+	});
+});
+
+/**
+ * #2630. #2346 widened the ladder to emit `xhigh` for every `opus >= 4.6`, but
+ * probed only opus-5 and sonnet-5. Resuming a session pinned to
+ * `claude-opus-4-6` then sent an effort that model rejects:
+ *
+ *   This model does not support effort level 'xhigh'.
+ *   Supported levels: high, low, max, medium.
+ *
+ * Probed against the live gateway on 2026-07-30, with a bogus control value
+ * (`ludicrous`) rejected everywhere so the accepts are meaningful:
+ *
+ *   model              low med high xhigh max   fallbacks
+ *   claude-opus-5       Y   Y    Y     Y    Y   (none)
+ *   claude-sonnet-5     Y   Y    Y     Y    Y   (none)
+ *   claude-opus-4-8     Y   Y    Y     Y    Y   opus-4-6, opus-4-5
+ *   claude-opus-4-6     Y   Y    Y     .    Y   opus-4-5, sonnet-4-6
+ *   claude-sonnet-4-6   Y   Y    Y     .    Y   (none)
+ *   claude-opus-4-5     Y   Y    Y     .    .   (none)
+ *
+ * The ceiling is capped to what a model group AND its fallbacks accept, because
+ * the gateway re-sends an identical body on fallback rather than re-mapping per
+ * target — in the original report both fallbacks 400'd on the same `xhigh`.
+ * `claude-opus-4-5` accepts neither `xhigh` nor `max` and sits in both chains,
+ * so opus-4-6 and opus-4-8 cap at `high` even though opus-4-8 accepts `xhigh`
+ * on its own.
+ */
+describe("effort ceilings are capped to the model group AND its fallbacks — #2630", () => {
+	for (const id of ["claude-opus-4-6", "claude-opus-4-8"]) {
+		it(`${id} never emits xhigh on the wire`, () => {
+			const model = anthropic(id);
+			expect(getSupportedEfforts(model)).not.toContain(Effort.XHigh);
+			for (const effort of THINKING_EFFORTS) {
+				const wire = mapEffortToAnthropicAdaptiveEffort(
+					model,
+					clampThinkingLevelForModel(model, effort) ?? Effort.Low,
+				);
+				expect(wire).not.toBe("xhigh");
+			}
+		});
+
+		it(`${id} degrades a requested xhigh to high instead of throwing`, () => {
+			// This is the path the reported failure took: the session persisted an
+			// effort, and `requireSupportedEffort` throws while the resolver's clamp
+			// (coding-agent thinking.ts / model-resolver.ts) is what must absorb it.
+			expect(clampThinkingLevelForModel(anthropic(id), Effort.XHigh)).toBe(Effort.High);
+		});
+	}
+
+	it("leaves opus-5 and sonnet-5 at their full measured ceiling", () => {
+		// Both have no fallback chain, so the conservative cap costs them nothing.
+		for (const id of ["claude-opus-5", "claude-sonnet-5"]) {
+			const model = anthropic(id);
+			expect(getSupportedEfforts(model)).toContain(Effort.XHigh);
+			expect(getSupportedEfforts(model)).toContain(Effort.Max);
+		}
+	});
+
+	it("emits no effort outside what the probe recorded as accepted", () => {
+		// Guard: a newly added adaptive model cannot inherit an unverified ceiling.
+		const ACCEPTED: Record<string, readonly string[]> = {
+			"claude-opus-5": ["low", "medium", "high", "xhigh", "max"],
+			"claude-sonnet-5": ["low", "medium", "high", "xhigh", "max"],
+			"claude-opus-4-8": ["low", "medium", "high"],
+			"claude-opus-4-6": ["low", "medium", "high"],
+			"claude-sonnet-4-6": ["low", "medium", "high"],
+		};
+		for (const [id, accepted] of Object.entries(ACCEPTED)) {
+			const model = anthropic(id);
+			for (const effort of getSupportedEfforts(model)) {
+				expect(accepted).toContain(mapEffortToAnthropicAdaptiveEffort(model, effort));
+			}
+		}
 	});
 });
 

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -4,6 +4,7 @@ import {
 	clampThinkingLevelForModel,
 	Effort,
 	enrichModelThinking,
+	getSupportedEfforts,
 	linkSparkPromotionTargets,
 	mapEffortToAnthropicAdaptiveEffort,
 	mapEffortToGoogleThinkingLevel,
@@ -105,16 +106,54 @@ describe("model thinking metadata", () => {
 		expect(opus46.thinking).toEqual({
 			mode: "anthropic-adaptive",
 			minLevel: Effort.Minimal,
-			maxLevel: Effort.Max,
+			// `high`, not `max` — opus 4.6 on the Messages API rejects `xhigh`, and its
+			// fallback chain (opus-4-5) rejects `max` too, so the ceiling is `high`.
+			// Measured 2026-07-30; this previously claimed `max` on an unprobed
+			// assumption and produced 400s on resumed sessions (#2630).
+			maxLevel: Effort.High,
 		});
 		expect(sonnet46.thinking).toEqual({
 			mode: "anthropic-adaptive",
 			minLevel: Effort.Minimal,
 			maxLevel: Effort.High,
 		});
-		expect(mapEffortToAnthropicAdaptiveEffort(opus46, Effort.XHigh)).toBe("xhigh");
-		expect(mapEffortToAnthropicAdaptiveEffort(opus46, Effort.Max)).toBe("max");
+		// opus 4.6 now refuses xhigh/max for the same reason sonnet 4.6 always has:
+		// the Messages API rejects `xhigh` on both, and opus 4.6's fallback chain
+		// rejects `max`. Asserting the old `"xhigh"`/`"max"` here is what let #2630
+		// ship — the mapping was pinned to an unprobed assumption.
+		expect(() => mapEffortToAnthropicAdaptiveEffort(opus46, Effort.XHigh)).toThrow(/not supported/);
+		expect(() => mapEffortToAnthropicAdaptiveEffort(opus46, Effort.Max)).toThrow(/not supported/);
 		expect(() => mapEffortToAnthropicAdaptiveEffort(sonnet46, Effort.XHigh)).toThrow(/not supported/);
+		// The user-facing path clamps rather than throwing; see effort-ladder.test.ts.
+		expect(mapEffortToAnthropicAdaptiveEffort(opus46, Effort.High)).toBe("high");
+	});
+});
+
+/**
+ * #2630 follow-up. The first fix keyed the extended enum on
+ * `semverGte(version, "5.0")`, which grants `xhigh`/`max` to every FUTURE Claude
+ * version the moment it appears in the catalog — the same open-ended grant that
+ * caused #2630 in the first place (#2346 keyed on `kind === "opus"`).
+ *
+ * Capability must be opt-in per measured version, so an unprobed model fails
+ * closed to the conservative range instead of inheriting an unverified ceiling.
+ */
+describe("unprobed Claude versions fail closed — #2630", () => {
+	for (const id of ["claude-opus-6", "claude-sonnet-6", "claude-opus-5.1"]) {
+		it(`${id} does not inherit xhigh or max before it is probed`, () => {
+			const model = createModel({ id, api: "anthropic-messages", provider: "anthropic" });
+			const levels = getSupportedEfforts(model);
+			expect(levels).not.toContain(Effort.XHigh);
+			expect(levels).not.toContain(Effort.Max);
+		});
+	}
+
+	it("still grants the measured 5.0 models their full range", () => {
+		for (const id of ["claude-opus-5", "claude-sonnet-5"]) {
+			const levels = getSupportedEfforts(createModel({ id, api: "anthropic-messages", provider: "anthropic" }));
+			expect(levels).toContain(Effort.XHigh);
+			expect(levels).toContain(Effort.Max);
+		}
 	});
 });
 


### PR DESCRIPTION
Fixes #2630

Resuming a session with `xcsh -c` 400'd because xcsh offered `xhigh` to a model that rejects it. The captured request shows xcsh as the sender — `output_config: {"effort":"xhigh"}` with `model: claude-opus-4-6`. Not a local-config problem: the reporter's `settings.json` declares no model or effort keys.

## Cause

#2346 widened the ladder for `kind === "opus" || version >= 5.0` after probing **only** opus-5 and sonnet-5, handing `xhigh` to every opus ≥ 4.6. Sessions persist their model, so `-c` pins the old one.

## Measured, not assumed

Probed the live gateway with a bogus control value (`ludicrous`), rejected everywhere — so the accepts mean something:

| model | low | med | high | xhigh | max | fallbacks |
|---|:--:|:--:|:--:|:--:|:--:|---|
| claude-opus-5 | Y | Y | Y | **Y** | Y | (none) |
| claude-sonnet-5 | Y | Y | Y | **Y** | Y | (none) |
| claude-opus-4-8 | Y | Y | Y | **Y** | Y | opus-4-6, opus-4-5 |
| claude-opus-4-6 | Y | Y | Y | **·** | Y | opus-4-5, sonnet-4-6 |
| claude-sonnet-4-6 | Y | Y | Y | **·** | Y | (none) |
| claude-opus-4-5 | Y | Y | Y | **·** | **·** | (none) |

Two results contradicted the plan I started from: **opus-4-8 does accept `xhigh`**, and **opus-4-5 accepts neither `xhigh` nor `max`**. Since opus-4-5 sits in both 4.x fallback chains and the gateway re-sends an identical body on fallback rather than re-mapping per target, the conservative ceiling for 4.6 **and** 4.8 is `high`.

That also made the plan's non-contiguous effort set unnecessary — the cap collapses both to plain `high`, which the existing `DEFAULT_REASONING_EFFORTS` already expresses. No new constant for that, no `models.json` change.

5.x has no fallback chain, so the conservative cap costs the default model nothing.

## Deliberately not done

- **Bedrock keeps its existing `xhigh` ceiling.** It was not probed. Narrowing a family without measuring it is #2346's mistake in reverse.
- **`models.json` untouched.** Its stale `maxLevel: "xhigh"` cannot reach the wire — nothing reads `thinking.maxLevel` except `expandEffortRange`, which *is* the intersect path, so `getSupportedEfforts` caps it. Confirmed by probe: 4.6 emits only `low/medium/high` despite that entry.

## The follow-up the review caught

My first fix keyed on `semverGte(version, "5.0")`, which would grant `xhigh`/`max` to **every future Claude** the moment it appeared in the catalog — the same defect class, merely deferred. A `codex:verified-code-review` flagged it (high); a synthesized `claude-opus-6` confirmed it, red.

Capability is now opt-in per measured version via `ANTHROPIC_EXTENDED_EFFORT_VERSIONS`, so an unprobed model fails closed.

The review's second finding (regenerate `models.json`) was **refuted** — see the intersect argument above.

## Verified

| Check | Result |
|---|---|
| `bun run ci:check:full` | **exit 0** |
| `packages/ai` suite | **631 pass, 0 fail** |
| Live gateway, every emitted effort | opus-5/sonnet-5 `{low,medium,high,xhigh,max}` all accepted; 4.x `{low,medium,high}` all accepted |
| `coding-agent` full suite, run alone | **6255 pass / 24 fail** vs **6258 / 21** on pristine main |

The three branch-only failures are known-flaky families, each checked rather than waved off: `RpcClient.start` reproduces on pristine main; the manager STALE-binary test is the #2561 leaked-manager family; and the one whose name mentions "thinking override" is a 5000 ms **timeout** that passes 4/4 in isolation, three runs in a row.

Worth noting for anyone reading the numbers: the same suite showed **47** unique failures when I first ran it concurrently with the `ai` suite and the gateway probes (1033 s vs 418 s). Running it alone dropped that to 23. This suite is contention-sensitive; compare against a solo control before attributing.

## Also updated

Two pre-existing assertions encoded the bug — opus 4.6 mapping `XHigh → "xhigh"` and `maxLevel: Max`. Those expectations are what let it ship, so they now assert the measured behaviour.