### PR TITLE
test(sandbox): stop leaking temp fixtures, and namespace them

### DIFF
--- a/packages/coding-agent/test/sandbox-containment-conformance.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-conformance.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -17,11 +17,16 @@ import { buildContainmentFence, type FenceAccess, fenceVerdict } from "@f5-sales
  * than illustrative.
  */
 describe("containment fence: TypeScript and Rust agree", () => {
-	const home = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "conf-home-")));
+	const home = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "xcsh-conf-home-")));
 	const workspace = path.join(home, "GIT", "custA");
 	const sibling = path.join(home, "GIT", "custB");
 	const leak = path.join(home, ".xcsh", "agent", "sessions");
-	const shared = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "conf-shared-")));
+	const shared = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "xcsh-conf-shared-")));
+
+	// Removed after the file runs; both fixtures above leaked into the OS temp dir (#2633).
+	afterAll(() => {
+		for (const dir of [home, shared]) fs.rmSync(dir, { recursive: true, force: true });
+	});
 	for (const dir of [workspace, sibling, leak, path.join(home, ".ssh"), path.join(home, ".bun")]) {
 		fs.mkdirSync(dir, { recursive: true });
 	}

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, spyOn } from "bun:test";
+import { afterAll, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -12,9 +12,33 @@ import { buildContainmentFence, containmentStatus, fenceVerdict } from "@f5-sale
  * not a stricter policy — see #2554.
  */
 
+/**
+ * Fixture directories, removed after the file runs (#2633).
+ *
+ * These leaked for a long time: 2,714 `fence-*` directories were sitting in the OS temp dir, from 52 call
+ * sites here with no cleanup. That is not merely untidy — it is what made `readdirSync(os.tmpdir())`
+ * expensive enough (15.4ms) to cause a real latency regression in #2624, and it buries anyone reading that
+ * directory to debug a temp-path problem.
+ *
+ * The `xcsh-` prefix is deliberate. The previous prefixes were generic — `fence-`, `sf-`, `conf-` — and a
+ * bulk cleanup of `sf-*` would also match the Salesforce CLI's own `sf-telemetry` directory. Fixtures
+ * should be identifiable as ours from the name alone, so removing them can never take somebody else's
+ * state with them.
+ *
+ * Cleanup lives in `afterAll`, not at the end of each test: a `rmSync` in the body is skipped when an
+ * assertion throws, which is exactly when the file is being re-run repeatedly and littering fastest.
+ */
+const fixtures: string[] = [];
+
+afterAll(() => {
+	for (const dir of fixtures) fs.rmSync(dir, { recursive: true, force: true });
+	fixtures.length = 0;
+});
+
 function realTmp(suffix: string): string {
-	const dir = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), `fence-${suffix}-`));
-	return fs.realpathSync(dir);
+	const dir = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), `xcsh-fence-${suffix}-`)));
+	fixtures.push(dir);
+	return dir;
 }
 
 describe("buildContainmentFence", () => {

--- a/packages/coding-agent/test/sandbox-guard.test.ts
+++ b/packages/coding-agent/test/sandbox-guard.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -14,9 +14,13 @@ import sandboxGuard from "@f5-sales-demo/xcsh/extensibility/extensions/bundled/s
  */
 let CWD: string;
 let OTHER: string;
+/** Removed after the file runs; these leaked `guard-*` directories into the OS temp dir (#2633). */
+let container: string;
+
+afterAll(() => fs.rmSync(container, { recursive: true, force: true }));
 
 beforeAll(() => {
-	const container = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "guard-")));
+	container = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "xcsh-guard-")));
 	CWD = path.join(container, "custA");
 	OTHER = path.join(container, "custB");
 	fs.mkdirSync(CWD);

--- a/packages/coding-agent/test/sandbox-session-fence.test.ts
+++ b/packages/coding-agent/test/sandbox-session-fence.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -11,8 +11,19 @@ import { resolveSessionFence, type SettingsReader } from "@f5-sales-demo/xcsh/sa
  * would rather throw. The synthetic `/work/custA` these tests used to pass around only worked because
  * the policy they replaced never touched the filesystem.
  */
+/** Fixture containers, removed after the file runs — these leaked 78 `sf-*` directories (#2633). */
+const fixtures: string[] = [];
+
+afterAll(() => {
+	for (const dir of fixtures) fs.rmSync(dir, { recursive: true, force: true });
+	fixtures.length = 0;
+});
+
 function tenants(suffix: string): { mine: string; theirs: string; shared: string } {
-	const container = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), `sf-${suffix}-`)));
+	const container = fs.realpathSync(
+		fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), `xcsh-sessfence-${suffix}-`)),
+	);
+	fixtures.push(container);
 	const mine = path.join(container, "custA");
 	const theirs = path.join(container, "custB");
 	// Beside the tenants, so the ancestor walk denies it by default and an allow-list has something to


### PR DESCRIPTION
Closes #2633

## Problem

The sandbox tests created temp directories with `mkdtempSync` and never removed them. Measured on a
development workstation:

```
os.tmpdir() total              18,456 entries
  fence-*     (realTmp)         2,714    52 call sites, no cleanup
  xcsh-sbx-*                      118
  conf-home-* / conf-shared-*      94    no cleanup at all
  sf-*        (session-fence)      78    no cleanup at all
  guard-*                           6
```

3,208 removed by hand, dating back to at least Jul 28.

## Why it mattered, concretely

#2624 briefly enumerated `os.tmpdir()` to find per-session task directories. That cost **15.4 ms of a
25–42 ms fence build** — paid on a session's first `bash` call — and pushed a trivial `echo` past the 50 ms
auto-background threshold, failing `tools.test.ts`. The enumeration was the bug and is gone, but the
directory was that large *because of these tests*, and anything else touching the OS temp dir pays the
same tax: `mkdtemp` and `readdir` both slow as it grows, and a developer debugging a temp-path problem
wades through thousands of fixtures.

Deleting the litter without fixing the source only delays it.

## Change

`afterAll` cleanup for the four leaking files — `sandbox-containment`, `-session-fence`, `-guard`,
`-conformance`. Cleanup goes in the hook rather than at the end of each test body, because a trailing
`rmSync` is **skipped when an assertion throws** — precisely when a file is being re-run repeatedly and
littering fastest.

Fixture prefixes are now `xcsh-`. The old ones were generic, and clearing `sf-*` also matches the
Salesforce CLI's own `sf-telemetry` directory — which I hit while clearing the backlog by hand. A fixture
should be identifiable as ours from its name alone, so removing one can never take somebody else's state
with it.

## Verification

- 73 tests across the four files pass.
- OS temp dir entry count **unchanged across a run** (delta 0), with no `xcsh-`-prefixed fixtures
  surviving afterwards.

The issue's suggested "count entries before and after" acceptance test is deliberately **not** added as a
test: other processes write to the OS temp dir concurrently, so it would flake. The measurement was done
by hand; the durable protection is the hooks themselves.

## Noted while doing this, not fixed here

`sandbox-containment-conformance.test.ts` cannot load against a locally-built native addon:
`bun --cwd=packages/natives run build` produces 54 exports without `fencePermits`, while the released
artifact in `~/.xcsh/natives/<version>/` has 56 including it. So the TS↔Rust fence agreement test — by its
own comment "the only guard against the two drifting" — passes in CI but errors locally unless a released
addon happens to be cached. Worth its own issue; it is an environment/build-parity problem, not a defect
in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
