### PR TITLE
fix(sandbox): the operator's home is theirs

### DIFF
--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -203,6 +203,12 @@ const COMMAND_BEARING_CONFIG = [
 	// was measured working with its config.yml read-only.
 	path.join(".config", "glab-cli", "aliases.yml"),
 	path.join("Library", "Application Support", "glab-cli", "aliases.yml"),
+	// Build configuration that redirects a later build. Protected by *omission* while home was denied —
+	// the cache carve-outs grant `.cargo/registry` rather than `.cargo` — so #2637 had to name them. A
+	// write here is persistence, not theft: the operator's next build runs what it says. Reads are fine.
+	path.join(".cargo", "config.toml"),
+	path.join(".gradle", "init.gradle"),
+	path.join(".gradle", "init.d"),
 ];
 
 /** Read-only inside home: configuration a tool needs to behave correctly, but must not rewrite. */
@@ -268,9 +274,10 @@ const AGENT_PROFILE_FILES = ["user-profile.json", "computer-profile.json", "sett
  * unforeseen — `/data`, `/scratch`, a bespoke mount.
  */
 const DATA_ROOTS = [
-	"/Users", // macOS home container: other operators' accounts, /Users/Shared
-	"/home", // Linux home container
-	"/root", // Linux superuser home
+	// `/Users` and `/home` are deliberately absent: denying the home container denies this operator's own
+	// home with it, which is the whole of #2637. Other accounts are 0700, so the filesystem already refuses
+	// them; the fence is not here to re-implement file permissions.
+	"/root", // Linux superuser home: not this operator's account
 	"/Volumes", // macOS mounts. Per-container, not per-child: /Volumes/Macintosh HD resolves to /,
 	"/mnt", // which `tooBroadToDeny` then rejects, and the kernel resolves such a path before any
 	"/media", // rule matches it — so denying the container cannot deny the boot volume.
@@ -528,8 +535,22 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 	// rejects, so `/`, `/usr`, `/tmp` and `$TMPDIR` are never denied and operational paths stay
 	// reachable. And it costs nothing below: the workspace is allowed at greater depth, and
 	// `fenceVerdict` takes the deepest match.
-	if (home !== undefined && home !== workspace) deny.add(home);
+	// Home is never denied, and the walk stops there (#2637).
+	//
+	// This is a professional courtesy, not a prison: an effort to stop *inadvertent* filesystem wandering
+	// between customers, for an operator with senior technical skills and the same rights on this machine
+	// as the agent acting for them. Denying home outright refused `~/git/STYLE_GUIDE.md` and then needed
+	// ~30 carve-outs to make ordinary tooling work again — every one of them evidence the posture was wrong.
+	//
+	// What the walk still covers is the part that matters: every level between the workspace and home. With
+	// the workspace at `~/MEDDPICC/EQUIFAX`, `~/MEDDPICC` is denied so the `ACME` sibling is unreachable,
+	// and with `<container>/<tenant>/repo` every level up to home is denied, so the v19.100.1 cross-tenant
+	// regression does not return.
+	//
+	// A session whose folder IS home, or a direct child of it, therefore fences nothing above itself. That
+	// is deliberate: if the operator chooses to work in home, that is their filesystem to lay out.
 	for (let ancestor = path.dirname(workspace); ; ancestor = path.dirname(ancestor)) {
+		if (ancestor === home) break; // the operator's own account is theirs
 		if (tooBroadToDeny(ancestor, fsRoot)) break;
 		deny.add(ancestor);
 		const next = path.dirname(ancestor);
@@ -629,6 +650,11 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		// e.g. /Volumes/Macintosh HD -> /. Skipped for the whole-root list, per the note above.
 		if (!rootScoped.has(resolved) && tooBroadToDeny(resolved, fsRoot)) continue;
 		if (resolved === fsRoot) continue; // never the root the workspace lives on
+		// Never a directory that CONTAINS home, because denying it denies home (#2637). Removing `/Users`
+		// and `/home` from the static list was not enough: the root enumeration re-adds them, since
+		// `Users` is not an operational name. That is what still refused `~/git/STYLE_GUIDE.md` at the
+		// kernel while `fenceVerdict` said allow — the unit tests use synthetic roots and could not see it.
+		if (home !== undefined && pathIsWithin(resolved, home)) continue;
 		// A deny beats an allow at EQUAL depth, so denying a root that IS the workspace or IS something
 		// the operator granted would not be redundant — it would silently revoke the grant. Deeper is
 		// fine and intended: an ancestor deny with the workspace allowed inside it is the normal shape.

--- a/packages/coding-agent/test/sandbox-containment-conformance.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-conformance.test.ts
@@ -81,9 +81,11 @@ describe("containment fence: TypeScript and Rust agree", () => {
 	// Both must resolve the symlink, or the pre-check and the enforcement disagree about the one
 	// case an attacker would reach for.
 	it("agrees when the path arrives through a symlink", () => {
+		// Points at the sibling checkout, not `~/.ssh`: #2637 stopped denying the operator's own dotfiles,
+		// so using one as the "denied" target made TS and Rust agree on `allow` and proved nothing.
 		const pivot = path.join(workspace, "pivot");
-		fs.symlinkSync(path.join(home, ".ssh"), pivot);
-		const viaLink = path.join(pivot, "id_rsa");
+		fs.symlinkSync(sibling, pivot);
+		const viaLink = path.join(pivot, "secrets.tf");
 
 		expect(fenceVerdict(fence, viaLink, "read")).toBe("deny");
 		expect(fencePermits(wire, viaLink, false)).toBe(false);

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -48,7 +48,10 @@ describe("buildContainmentFence", () => {
 		fs.mkdirSync(workspace, { recursive: true });
 		const fence = buildContainmentFence({ workspace, home });
 
-		expect(fence.deny).toContain(home);
+		// Home is not denied (#2637). What is denied is the container the checkouts sit in, which is what
+		// makes the sibling unreachable — the same protection, one level narrower.
+		expect(fence.deny).not.toContain(home);
+		expect(fence.deny).toContain(path.join(home, "GIT"));
 		expect(fence.allow).toContain(workspace);
 		// A sibling checkout under the same home is the cross-customer case this exists for.
 		expect(fenceVerdict(fence, path.join(home, "GIT", "custB", "secret"), "read")).toBe("deny");
@@ -99,12 +102,16 @@ describe("buildContainmentFence", () => {
 		fs.mkdirSync(workspace, { recursive: true });
 		const fence = buildContainmentFence({ workspace, home });
 
-		// `.aws/credentials` was on this list until #2581. It is now granted, deliberately: it is the
-		// credential store of a CLI xcsh drives, and a path-based fence cannot let `aws` read it without
-		// letting `cat` read it. What stays here is what no shipped tool needs — SSH and GPG private
-		// keys, and the operator's documents.
-		for (const secret of [".ssh/id_rsa", ".gnupg/secring.gpg", "Documents/tax.pdf"]) {
-			expect(fenceVerdict(fence, path.join(home, secret), "read")).toBe("deny");
+		// This asserted the opposite until #2637, and the reversal is deliberate. `.aws/credentials` stopped
+		// being denied in #2581 because a path-based fence cannot let `aws` read it without letting `cat`
+		// read it. #2637 finished the thought: the fence is a courtesy against inadvertent wandering
+		// between customers, not a privilege boundary against the operator, whose own machine this is.
+		//
+		// The exfiltration-via-prompt-injection risk was raised in review and is real, but it is not new —
+		// the cloud credential store has been readable since #2581, so closing SSH alone would be theatre.
+		// Recorded on #2637; the operator's call, and they made it.
+		for (const own of [".ssh/id_rsa", ".gnupg/secring.gpg", "Documents/tax.pdf"]) {
+			expect(fenceVerdict(fence, path.join(home, own), "read")).toBe("allow");
 		}
 	});
 
@@ -203,6 +210,103 @@ describe("buildContainmentFence", () => {
  * for each gap. Removing that posture is what exposed them, which is the risk this whole change carries
  * and the reason the review was worth running.
  */
+/**
+ * The operator's home is theirs (#2637).
+ *
+ * Reported: `Read ~/git/STYLE_GUIDE.md` refused with the workspace at `~/MEDDPICC/EQUIFAX`. The refusal was
+ * correct for the rule and the model declined to work around it, so the work simply stopped and the
+ * operator was told the boundary was working as intended.
+ *
+ * This fence is a professional courtesy — an effort to stop *inadvertent* wandering between customers —
+ * for an operator with senior technical skills and the same rights on this machine as the agent acting for
+ * them. It is not a prison, and it does not re-implement file permissions.
+ */
+describe("buildContainmentFence — the operator's home is theirs (#2637)", () => {
+	/** `<home>/MEDDPICC/EQUIFAX`, the shape the report came from. */
+	function customerSession(suffix: string) {
+		const home = realTmp(suffix);
+		const container = path.join(home, "MEDDPICC");
+		const workspace = path.join(container, "EQUIFAX");
+		const sibling = path.join(container, "ACME");
+		const elsewhere = path.join(home, "git");
+		for (const dir of [workspace, sibling, elsewhere]) fs.mkdirSync(dir, { recursive: true });
+		return { home, container, workspace, sibling, elsewhere };
+	}
+
+	it("reads a file elsewhere in the operator's home", () => {
+		const { home, workspace, elsewhere } = customerSession("ownhome");
+		const fence = buildContainmentFence({ workspace, home });
+
+		expect(fenceVerdict(fence, path.join(elsewhere, "STYLE_GUIDE.md"), "read")).toBe("allow");
+		expect(fence.deny).not.toContain(home);
+	});
+
+	it("still refuses the session folder's sibling and its container", () => {
+		const { home, container, workspace, sibling } = customerSession("sibling");
+		const fence = buildContainmentFence({ workspace, home });
+
+		expect(fenceVerdict(fence, path.join(sibling, "notes.md"), "read")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(sibling, "notes.md"), "write")).toBe("deny");
+		expect(fence.deny).toContain(container);
+		expect(fenceVerdict(fence, path.join(workspace, "mine.md"), "write")).toBe("allow");
+	});
+
+	// The v19.100.1 regression: with `<container>/<tenant>/repo`, denying only the immediate parent left
+	// every OTHER tenant reachable. Stopping the walk at home must not bring that back.
+	it("still refuses other tenants when the workspace is nested deeper", () => {
+		const home = realTmp("nested");
+		const container = path.join(home, "MEDDPICC");
+		const workspace = path.join(container, "EQUIFAX", "repo");
+		const otherTenant = path.join(container, "ACME", "repo");
+		for (const dir of [workspace, otherTenant]) fs.mkdirSync(dir, { recursive: true });
+
+		const fence = buildContainmentFence({ workspace, home });
+
+		expect(fenceVerdict(fence, path.join(otherTenant, "secret.env"), "read")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(container, "EQUIFAX", "sibling-of-repo"), "read")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(workspace, "mine.md"), "write")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(home, "git", "STYLE_GUIDE.md"), "read")).toBe("allow");
+	});
+
+	/**
+	 * A session whose folder IS home, or a direct child of it, fences nothing above itself.
+	 *
+	 * Asserted rather than left to be discovered, because it is the deliberate consequence of not denying
+	 * home: the siblings live in home, so there is no arrangement of rules that reads all of home and
+	 * refuses a sibling inside it. If the operator chooses to work there, that is their filesystem to lay
+	 * out — and a test that pretended otherwise would be claiming a protection that does not exist.
+	 */
+	it("does not fence home when the session folder sits directly in it", () => {
+		const home = realTmp("inhome");
+		const workspace = path.join(home, "custA");
+		const sibling = path.join(home, "custB");
+		for (const dir of [workspace, sibling]) fs.mkdirSync(dir, { recursive: true });
+
+		// Leak roots passed explicitly: the defaults point at the *real* agent directories, which a temp
+		// home knows nothing about, so relying on them here would assert nothing.
+		const sessions = path.join(home, ".xcsh", "agent", "sessions");
+		const fence = buildContainmentFence({ workspace, home, leakRoots: [sessions] });
+
+		expect(fence.deny).not.toContain(home);
+		expect(fenceVerdict(fence, path.join(sibling, "notes.md"), "read")).toBe("allow");
+		// The cross-SESSION surfaces are still closed, because those are the agent's own state rather
+		// than the operator's layout.
+		expect(fenceVerdict(fence, path.join(sessions, "x.jsonl"), "read")).toBe("deny");
+	});
+
+	// A write that installs something a later unfenced run executes is a different concern from context
+	// isolation, so #2637 does not relax it.
+	it("still refuses writes to command-bearing CLI config", () => {
+		const { home, workspace } = customerSession("cmdconfig");
+		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
+
+		for (const vector of [path.join(".aws", "config"), path.join(".cargo", "config.toml")]) {
+			expect(fenceVerdict(fence, path.join(home, vector), "write")).toBe("deny");
+			expect(fenceVerdict(fence, path.join(home, vector), "read")).toBe("allow");
+		}
+	});
+});
+
 describe("buildContainmentFence — adversarial review of #2624", () => {
 	// The shared temp root holds per-session state: `local://` content at `<tmp>/xcsh-local/<sessionId>`
 	// (local-protocol.ts:118) and task artifacts at `<tmp>/xcsh-tasks/<id>` (task/index.ts). Both are
@@ -340,14 +444,17 @@ describe("buildContainmentFence — adversarial review of #2624", () => {
 
 		// `fsRoot` is the container, so `/` is a filesystem root that is NOT this workspace's — the exact
 		// shape a second Windows drive has, and the only way to produce it on this platform.
+		// The injected root must not contain home, or the #2637 guard correctly skips it. A sibling temp
+		// root is the honest stand-in for "a second Windows drive".
+		const otherRoot = realTmp("rootfilter-other");
 		const fence = buildContainmentFence({
 			workspace,
-			home: realTmp("rootfilter-home"),
+			home: path.join(container, "home"),
 			fsRoot: container,
-			otherRoots: ["/"],
+			otherRoots: [otherRoot],
 		});
 
-		expect(fence.deny).toContain("/");
+		expect(fence.deny).toContain(otherRoot);
 	});
 
 	// …but the root the workspace actually lives on is never denied, however it arrives.
@@ -486,14 +593,17 @@ describe("buildContainmentFence — review findings", () => {
 		fs.mkdirSync(workspace, { recursive: true });
 		const fence = buildContainmentFence({ workspace, home });
 
-		for (const secret of [
-			".cargo/credentials.toml",
-			".cargo/config.toml",
-			".m2/settings.xml",
-			".gradle/init.gradle",
-			".npm/_authToken",
-		]) {
-			expect(fenceVerdict(fence, path.join(home, secret), "write")).toBe("deny");
+		// Since #2637 home is the operator's own, so the credential files here read and write like anything
+		// else of theirs. What must stay refused is a write that redirects a later build — persistence
+		// rather than theft — which needed naming in COMMAND_BEARING_CONFIG once the cache carve-outs
+		// stopped shielding it by omission.
+		const narrowing = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
+		for (const buildVector of [".cargo/config.toml", ".gradle/init.gradle"]) {
+			expect(fenceVerdict(narrowing, path.join(home, buildVector), "write")).toBe("deny");
+			expect(fenceVerdict(narrowing, path.join(home, buildVector), "read")).toBe("allow");
+		}
+		for (const own of [".cargo/credentials.toml", ".m2/settings.xml", ".npm/_authToken"]) {
+			expect(fenceVerdict(fence, path.join(home, own), "read")).toBe("allow");
 		}
 		// The parts a build actually writes stay granted, or the carve-out was pointless.
 		for (const artifact of [
@@ -636,8 +746,9 @@ describe("buildContainmentFence — review findings", () => {
 		// grant, so it must survive on every backend.
 		expect(fenceVerdict(fence, path.join(home, ".gitconfig"), "write")).toBe("deny");
 		expect(fenceVerdict(fence, path.join(home, ".gitconfig"), "read")).toBe("allow");
-		// And the boundary itself is unchanged.
-		expect(fenceVerdict(fence, path.join(home, ".ssh", "id_rsa"), "read")).toBe("deny");
+		// And the boundary still applies where it should: the workspace's container, not the operator's own
+		// dotfiles, which #2637 stopped denying.
+		expect(fenceVerdict(fence, path.join(home, ".ssh", "id_rsa"), "read")).toBe("allow");
 	});
 
 	// Defaulting to the portable policy matters: a caller that does not know its backend must not get
@@ -660,9 +771,9 @@ describe("buildContainmentFence — review findings", () => {
 		const fence = buildContainmentFence({ workspace, home });
 
 		expect(fenceVerdict(fence, path.join(home, "go/pkg/mod/cache/download/x"), "write")).toBe("allow");
-		// Not the whole of ~/go — that holds checked-out source and built binaries, and granting it
-		// would put `go install` output inside the fence.
-		expect(fenceVerdict(fence, path.join(home, "go/src/private/x"), "read")).toBe("deny");
+		// `~/go/src` was denied only as a side effect of the whole-home deny. It is the operator's own
+		// checked-out source, so #2637 leaves it alone.
+		expect(fenceVerdict(fence, path.join(home, "go/src/private/x"), "read")).toBe("allow");
 	});
 
 	// The grants above must not have widened anything else. This is the property that makes the fence
@@ -675,15 +786,19 @@ describe("buildContainmentFence — review findings", () => {
 		fs.mkdirSync(sessions, { recursive: true });
 		const fence = buildContainmentFence({ workspace, home, leakRoots: [sessions] });
 
+		// The two things left inside home since #2637, and the only two this fence is for: another
+		// customer's checkout, and another session's transcript. Both are inadvertent-wandering surfaces.
 		for (const denied of [
 			"GIT/custB/secrets.tf", // the sibling checkout this fence exists for
-			".ssh/id_ed25519",
-			".gnupg/secring.gpg",
-			"Documents/contract.pdf",
 			".xcsh/agent/sessions/other.jsonl", // another session's transcript
 		]) {
 			expect(fenceVerdict(fence, path.join(home, denied), "read")).toBe("deny");
 			expect(fenceVerdict(fence, path.join(home, denied), "write")).toBe("deny");
+		}
+		// The operator's own private files are not withheld from them. Asserted rather than left implicit,
+		// so anyone auditing what this fence protects sees the choice.
+		for (const own of [".ssh/id_ed25519", ".gnupg/secring.gpg", "Documents/contract.pdf"]) {
+			expect(fenceVerdict(fence, path.join(home, own), "read")).toBe("allow");
 		}
 	});
 
@@ -917,9 +1032,13 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 
 		const fence = buildContainmentFence({ workspace, home, fsRoot });
 
-		// The four cases measured as reachable before this existed.
+		// Another account is no longer denied (#2637): the container holding it also holds this operator's
+		// home, and denying it denied `~/git/STYLE_GUIDE.md`. A home directory is 0700, so the filesystem
+		// already refuses it — the fence does not re-implement file permissions.
+		expect(fenceVerdict(fence, path.join(fsRoot, "Users", "otheruser", "customerX"), "read")).toBe("allow");
+
+		// The unrelated data roots, still denied — these were measured reachable before #2624.
 		for (const leak of [
-			path.join("Users", "otheruser", "customerX"),
 			path.join("data", "globex", "secrets.tf"),
 			path.join("srv", "tenantZ", "notes.md"),
 			path.join("Volumes", "Backup", "customerY"),
@@ -995,8 +1114,9 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 	it("denies the real home container on this machine and no operational root", () => {
 		const fence = buildContainmentFence({ workspace: fs.realpathSync(process.cwd()) });
 
-		// Other users live here, and nothing operational does.
-		expect(fence.deny).toContain(process.platform === "darwin" ? "/Users" : "/home");
+		// The home container is NOT denied since #2637 — denying it denies the operator's own home, which
+		// is what refused `~/git/STYLE_GUIDE.md` at the kernel while `fenceVerdict` said allow.
+		expect(fence.deny).not.toContain(process.platform === "darwin" ? "/Users" : "/home");
 		// Only what this platform actually has: `/private` is macOS-only, and `realpathSync` on an absent
 		// path throws — which failed the Linux runner while passing locally. The file already warns about
 		// exactly this trap two describes up, and I walked into it anyway.

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -594,7 +594,7 @@ describe("evaluateToolCall with a symlinked working directory (#2312)", () => {
 		// used to serve here and cannot any more — it is permitted now (#2624), and a customer tree is the
 		// thing this test is actually about.
 		expect(checkAt(cwd, { path: "../elsewhere/secret.json" }).block).toBe(true);
-		expect(checkAt(cwd, { path: path.join(os.homedir(), ".ssh", "id_rsa") }).block).toBe(true);
+		// `~/.ssh` used to serve here; #2637 stopped denying it. The sibling above is the case that matters.
 	});
 });
 

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -11,13 +11,19 @@ import { evaluateToolCall } from "@f5-sales-demo/xcsh/sandbox/enforce";
 import { resolveSessionFence } from "@f5-sales-demo/xcsh/sandbox/session-fence";
 
 let tmp: TempDir;
+let home: string;
 let parent: string;
 let custA: string;
 let custB: string;
 
 beforeAll(() => {
 	tmp = TempDir.createSync("xcsh-sbx-iso-");
-	parent = tmp.absolute();
+	// The customers live in a container *inside* home, which is the layout the fleet uses
+	// (`~/MEDDPICC/<customer>`). They used to sit directly in `home`, and #2637 deliberately leaves that
+	// case open — the siblings are in home, so nothing can read all of home and refuse them. Keeping the
+	// old shape here would have asserted a protection that no longer exists.
+	home = path.join(tmp.absolute(), "home");
+	parent = path.join(home, "customers");
 	custA = path.join(parent, "custA");
 	custB = path.join(parent, "custB");
 	fs.mkdirSync(custA, { recursive: true });
@@ -70,8 +76,10 @@ describe("functionality preservation under the sandbox", () => {
 		expect(reads(custA, path.join(getAgentDir(), "skills", "account-planning", "SKILL.md"))).toBe(false);
 	});
 
-	it("still blocks unrelated home dotfiles (e.g. ~/.ssh)", () => {
-		expect(reads(custA, path.join(os.homedir(), ".ssh", "id_rsa"))).toBe(true);
+	// #2637: the operator's own dotfiles are theirs. What stays blocked is another customer's folder and
+	// another session's state, asserted above and below.
+	it("no longer blocks the operator's own home dotfiles", () => {
+		expect(reads(custA, path.join(os.homedir(), ".ssh", "id_rsa"))).toBe(false);
 	});
 });
 
@@ -109,7 +117,7 @@ describe("two-customer isolation, enforced in the shell", () => {
 	const OS_ENFORCED = containmentStatus(true).osEnforced;
 
 	function fenceFor(cwd: string) {
-		const fence = buildContainmentFence({ workspace: cwd, home: parent });
+		const fence = buildContainmentFence({ workspace: cwd, home });
 		return {
 			allow: [...fence.allow],
 			allowReadOnly: [...fence.allowReadOnly],
@@ -178,68 +186,13 @@ describe("two-customer isolation, enforced in the shell", () => {
 });
 
 /**
- * The container other operators' accounts live in, enforced by the kernel (#2624).
+ * Other operators' accounts are no longer fenced (#2637).
  *
- * The scenario above puts both tenants under one container, which the ancestor walk already covered.
- * This asserts the rule that was genuinely missing: a top-level root holding somebody else's files is
- * denied. Measured reachable before — `/Users/<otheruser>`, `/Volumes/<other>`, `/data/globex` all
- * matched no rule and defaulted to allow, read and write.
+ * #2624 denied `/Users` and `/home` wholesale and asserted here that listing them failed. That deny took
+ * this operator's own home with it, which is what refused `~/git/STYLE_GUIDE.md`, so #2637 removed it. A
+ * home directory is 0700 and the filesystem already refuses another account; the fence is not here to
+ * re-implement file permissions, and this suite should not claim a protection it no longer provides.
  *
- * Deliberately run against the REAL filesystem root with the real home, because a synthetic root
- * cannot show this. Under a temp-directory root the ancestor walk denies that whole container anyway,
- * so the test passes with or without the rule and proves nothing — measured, before rewriting it this
- * way. `ls` of the home container needs no write access and no planted file, which is what makes a
- * real-filesystem assertion possible here.
+ * What replaced the assertion is the one below it: the customer container inside home, which is the
+ * surface that actually matters and is asserted through the kernel above.
  */
-describe("the container other operators' accounts live in", () => {
-	const OS_ENFORCED = containmentStatus(true).osEnforced;
-	// Both exist on their platform, both list successfully when unfenced, and neither holds anything a
-	// toolchain needs — so a refusal here is the rule working rather than an accident of permissions.
-	const HOME_CONTAINER = process.platform === "darwin" ? "/Users" : "/home";
-
-	async function shell(command: string, fenced = true) {
-		// The session's own checkout: a real directory under the real home, so the fence is shaped
-		// exactly as it is in production rather than by an injected root.
-		const workspace = fs.realpathSync(process.cwd());
-		const fence = buildContainmentFence({ workspace });
-		let out = "";
-		const result = (await executeShell(
-			{
-				command,
-				cwd: workspace,
-				fence: fenced
-					? {
-							allow: [...fence.allow],
-							allowReadOnly: [...fence.allowReadOnly],
-							allowWriteOnly: [...fence.allowWriteOnly],
-							deny: [...fence.deny],
-						}
-					: undefined,
-			},
-			(_e, c) => {
-				out += c ?? "";
-			},
-		)) as { exitCode?: number; output?: string };
-		return { code: result?.exitCode ?? -1, text: out + (result?.output ?? "") };
-	}
-
-	it(`${OS_ENFORCED ? "cannot" : "can still"} be listed from a fenced shell`, async () => {
-		const { code } = await shell(`/bin/ls ${HOME_CONTAINER}`);
-		if (OS_ENFORCED) expect(code).not.toBe(0);
-		else expect(code).toBe(0);
-	});
-
-	it("while the operational roots and the session's own tree still work", async () => {
-		// If the profile denied something a process needs to start, every assertion above would pass for
-		// the wrong reason. This is the positive control that says commands still run at all.
-		const sys = await shell("/bin/cat /etc/hosts > /dev/null && /bin/ls /usr/bin > /dev/null && echo sysok");
-		expect(sys.text).toContain("sysok");
-		const own = await shell("/bin/ls package.json");
-		expect(own.code).toBe(0);
-	});
-
-	it("but the same listing unfenced succeeds — the control", async () => {
-		const { code } = await shell(`/bin/ls ${HOME_CONTAINER}`, false);
-		expect(code).toBe(0);
-	});
-});


### PR DESCRIPTION
Reported: `Read ~/git/STYLE_GUIDE.md` refused with the workspace at `~/MEDDPICC/CUSTOMER-A`. The refusal was
correct for the rule and the model declined to work around it, so the work stopped and the operator was
told the boundary was working as intended.

The fence denied the whole home directory and then carved ~30 exceptions back out to make ordinary tooling
work — every carve-out evidence that the posture was wrong. This is a professional courtesy against
*inadvertent* wandering between customers, for an operator with senior technical skills and the same rights
on this machine as the agent acting for them. It is not a privilege boundary against the operator and does
not re-implement file permissions.

Home is never denied and the ancestor walk stops there. `/Users` and `/home` container denies are gone —
and, the part that actually mattered, nothing that *contains* home is denied. Removing the static entries
was not enough: the root enumeration re-adds `/Users`, because `Users` is not an operational name. That is
what still refused the reported path at the kernel while `fenceVerdict` said allow, invisible to unit tests
because they use synthetic roots.

What remains fenced is only inadvertent-wandering surface: every level between the workspace and home (so
`~/MEDDPICC` is denied and the `ACME` sibling is unreachable, and `<container>/<tenant>/repo` keeps the
v19.100.1 fix), other sessions' state, other volumes and unrelated data roots, and *writes* to CLI config
that names a command to run. `~/.cargo/config.toml` and `~/.gradle/init.gradle` needed naming there: they
were protected by omission while home was denied, since the cache carve-outs grant `.cargo/registry`.

A session folder in home, or a direct child of it, fences nothing above itself — asserted as intended, not
left to be discovered. The siblings live in home, so nothing can read all of home and refuse them; if the
operator works there, that is their filesystem to lay out.

Not included, deliberately: an unconditional `~/.ssh` / `~/.gnupg` deny. Automated review flagged the
prompt-injection-to-exfiltration risk, it was surfaced to the operator, and they reaffirmed. It would also
be theatre while `~/.aws/credentials` has been readable since #2581 for the same structural reason.
Recorded on #2637.

Verified at the kernel with a freshly built addon: the reported read ALLOWED, `~/.ssh` allowed, the sibling
and its container refused, workspace writes working. 177 sandbox tests pass.

Six pre-existing tests asserted the old posture and were repointed rather than deleted, including the
TS/Rust conformance test, which used `~/.ssh` as its "denied" target and so would have agreed on `allow`
and proved nothing.

Note for anyone reading earlier measurements in #2638: they were taken against a two-day-old addon that
`.worktreeinclude` copies into a new worktree, so its `ls`-leak evidence is unreliable and needs redoing.

Closes #2637

🤖 Generated with [Claude Code](https://claude.com/claude-code)
