### PR TITLE
fix(prompt): trim the workspace boundary to what the fence cannot do

### DIFF
--- a/packages/coding-agent/src/prompts/system/workspace-boundary.md
+++ b/packages/coding-agent/src/prompts/system/workspace-boundary.md
@@ -1,6 +1,7 @@
 <workspace-boundary>
-Subdirectories of the working directory may be separate customers. When they are, every one of them
-is reachable and nothing will refuse a crossing — keeping them apart is your judgment.
+Separate tenants may sit side by side — as subdirectories of the working directory, and anywhere
+else you can reach when filesystem isolation is off. Reaching something is not the same as it being
+in scope; keeping tenants apart is your judgment.
 - Work in the one the task names, and say so when the task genuinely spans more than one.
-- You **MUST NOT** merge two customers' material into one artifact.
+- You **MUST NOT** merge two tenants' material into one artifact.
 </workspace-boundary>

--- a/packages/coding-agent/src/prompts/system/workspace-boundary.md
+++ b/packages/coding-agent/src/prompts/system/workspace-boundary.md
@@ -3,5 +3,6 @@ Separate tenants may sit side by side — as subdirectories of the working direc
 else you can reach when filesystem isolation is off. Reaching something is not the same as it being
 in scope; keeping tenants apart is your judgment.
 - Work in the one the task names, and say so when the task genuinely spans more than one.
-- You **MUST NOT** merge two tenants' material into one artifact.
+- You **MUST NOT** open another tenant's material for context, examples, or precedent when the task
+  did not ask for it, and **MUST NOT** merge two tenants' material into one artifact.
 </workspace-boundary>

--- a/packages/coding-agent/src/prompts/system/workspace-boundary.md
+++ b/packages/coding-agent/src/prompts/system/workspace-boundary.md
@@ -1,15 +1,6 @@
 <workspace-boundary>
-This session may be scoped to a single customer. Treat the working directory as the scope of the
-work: what the task needs is inside it, and another customer's material is not yours to open here.
-- You **MUST NOT** range across the filesystem hunting for files, examples, or precedent. Search
-  within the working directory. Your own skills and plugins, and paths the operator granted
-  explicitly (`--allow-path`, `sandbox.allowRead`), are legitimate — and are not licence to browse
-  anywhere else.
-- Subdirectories may themselves be separate customers. Reachable does not mean in scope: work in
-  the one the task names, state the crossing when the task genuinely spans more than one, and
-  **MUST NOT** merge two customers' material into one artifact.
-- A sandbox confines this session's file access, but its boundary is the working directory, not the
-  customer subdirectory: nothing refuses a sibling, so the rule above is yours to keep. When the
-  sandbox is active a path outside the working directory is refused — that is the boundary working,
-  not a tool failure. Say what you needed and why, and **MUST NOT** reach the same path another way.
+Subdirectories of the working directory may be separate customers. When they are, every one of them
+is reachable and nothing will refuse a crossing — keeping them apart is your judgment.
+- Work in the one the task names, and say so when the task genuinely spans more than one.
+- You **MUST NOT** merge two customers' material into one artifact.
 </workspace-boundary>

--- a/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
+++ b/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
@@ -1,5 +1,10 @@
-import { beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { TempDir } from "@f5-sales-demo/pi-utils";
 import { registerCodingAgentPromptHelpers } from "../src/config/prompt-templates";
+import { evaluateToolCall } from "../src/sandbox/enforce";
+import { resolveSessionFence } from "../src/sandbox/session-fence";
 import { buildSystemPrompt } from "../src/system-prompt";
 
 const OPEN_TAG = "<workspace-boundary>";
@@ -23,9 +28,9 @@ function block(): string {
 /**
  * The block with whitespace runs collapsed, for matching prose.
  *
- * The block is hard-wrapped, so a phrase can straddle a line break plus its indent
- * ("reach the\n  same path another way"). Matching the raw text would make these
- * assertions fail on a rewrap that changed nothing about the meaning.
+ * The block is hard-wrapped, so a phrase can straddle a line break plus its indent.
+ * Matching the raw text would make these assertions fail on a rewrap that changed
+ * nothing about the meaning.
  */
 function flat(): string {
 	return block().replace(/\s+/g, " ");
@@ -54,52 +59,12 @@ describe("system prompt workspace boundary", () => {
 		expect(boundary).toBeLessThan(nextSection);
 	});
 
-	// A possibility, never an assertion: nothing in the prompt knows the directory's
-	// shape, because a customer boundary is not visible in the filesystem.
-	it("primes the single-customer case without asserting it", () => {
-		expect(flat()).toMatch(/may be scoped to a single customer/i);
-	});
-
-	it("prohibits ranging across the filesystem for context", () => {
-		expect(flat()).toContain("**MUST NOT** range across the filesystem");
-	});
-
-	// The session fence allows reads OUTSIDE the CWD: user-level skills, the
-	// plugin dir, and any `--allow-path` / `sandbox.allowRead` grant. An absolute "never
-	// widen beyond the working directory" would forbid paths the operator deliberately
-	// granted, and would contradict the Procedure section's "if a skill matches the
-	// domain, you MUST read it before starting".
-	it("acknowledges explicit grants and the allowlisted read locations", () => {
-		expect(flat()).toMatch(/--allow-path/);
-		expect(flat()).toMatch(/skills and plugins/i);
-		expect(flat()).not.toMatch(/never widen to its parent/i);
-	});
-
-	// The sandbox link: naming the sandbox is what makes a refusal legible as the
-	// boundary working, which stops the reach-for-another-spelling reflex.
-	//
-	// But it MUST be conditional. `buildSystemPrompt` is handed no containment status,
-	// so the block cannot know whether isolation is on; under `--no-sandbox` or
-	// `sandbox.enabled: false` nothing is refused at all. Asserting enforcement as fact
-	// would give a deliberately-degraded session false assurance about isolation.
-	it("names the sandbox without asserting enforcement unconditionally", () => {
-		expect(flat()).toMatch(/sandbox confines this session/i);
-		// The property is that the refusal is stated CONDITIONALLY on the sandbox being
-		// active; either phrasing of that condition satisfies it.
-		expect(flat()).toMatch(/when (it|the sandbox) is active/i);
-		expect(flat()).not.toMatch(/isolation is enforced/i);
-		expect(flat()).toMatch(/reach the same path another way/i);
-	});
-
-	// Codex round 3 called the block false assurance about the customer boundary. Refuted
-	// as stated -- "Reachable does not mean in scope" already tells the model the sandbox
-	// will not stop a sibling read. But the two boundaries sat in adjacent bullets and
-	// could be read as one, so the block now names which boundary the sandbox enforces.
-	// This is the awareness the change exists to create: crossing between sibling
-	// customers is refused by nothing, which is precisely why the rule is the model's.
-	it("distinguishes the sandbox boundary from the customer boundary", () => {
-		expect(flat()).toMatch(/boundary is the working directory, not the customer subdirectory/i);
-		expect(flat()).toMatch(/nothing refuses a sibling/i);
+	// The one thing the fence cannot do. Where the working directory holds several
+	// customers, they are all inside the allowed subtree, so separating them is
+	// judgment and nothing else.
+	it("covers the case the fence leaves open", () => {
+		expect(flat()).toMatch(/subdirectories of the working directory may be separate customers/i);
+		expect(flat()).toMatch(/your judgment/i);
 	});
 
 	// Guards the non-goal. Work that genuinely spans two subdirectories must stay
@@ -107,7 +72,17 @@ describe("system prompt workspace boundary", () => {
 	// fails if a later edit quietly turns the block into a lockdown.
 	it("does not forbid cross-customer work outright", () => {
 		expect(flat()).not.toMatch(/MUST NOT (read|access|open|touch) (another|other|a different)/i);
-		expect(flat()).toMatch(/state the crossing/i);
+		expect(flat()).toMatch(/say so when the task genuinely spans more than one/i);
+		expect(flat()).toMatch(/MUST NOT\*{0,2} merge two customers/i);
+	});
+
+	// #2643. The block must not re-impose at the prompt layer what the fence
+	// deliberately stopped enforcing: `containment.ts` records that a deny-by-default
+	// boundary "refuses ordinary work", and the wider filesystem is open on purpose.
+	// A blanket prohibition on looking anywhere is the restriction that was removed.
+	it("does not prohibit reading paths the fence allows", () => {
+		expect(flat()).not.toMatch(/range across the filesystem/i);
+		expect(flat()).not.toMatch(/never widen/i);
 	});
 
 	// A custom system prompt (--system-prompt, or an auto-discovered project/global
@@ -131,5 +106,62 @@ describe("system prompt workspace boundary", () => {
 	it("leaves no unrendered template syntax in the block", () => {
 		expect(block()).not.toBe("");
 		expect(block()).not.toContain("{{");
+	});
+});
+
+/**
+ * Binds the prompt's description of reachability to what the fence actually does.
+ *
+ * This block has twice asserted a mechanism fact that reality contradicted: an
+ * unconditional "isolation is enforced" (false under `--no-sandbox`, caught in review),
+ * and "nothing refuses a sibling" (true when written, falsified a day later when #2624 /
+ * #2637 unified the fence and started denying the workspace's parent). Prose cannot be
+ * trusted to stay true about code it does not import.
+ *
+ * So the claim is measured rather than reviewed. If the deny logic changes again, this
+ * fails and names the sentence that went stale, instead of shipping a confident
+ * falsehood in every session's prompt.
+ */
+describe("workspace boundary claims match the real fence", () => {
+	let tmp: TempDir;
+	let parent: string;
+	let custA: string;
+	let custB: string;
+
+	beforeAll(() => {
+		tmp = TempDir.createSync("xcsh-boundary-claim-");
+		parent = path.join(tmp.absolute(), "customers");
+		custA = path.join(parent, "custA");
+		custB = path.join(parent, "custB");
+		fs.mkdirSync(custA, { recursive: true });
+		fs.mkdirSync(custB, { recursive: true });
+		fs.writeFileSync(path.join(custA, "notes.md"), "a");
+		fs.writeFileSync(path.join(custB, "secret.env"), "TOKEN=b");
+	});
+
+	afterAll(() => tmp.removeSync());
+
+	/** Whether the `read` tool would be refused from `cwd`, through the real session fence. */
+	function refuses(cwd: string, filePath: string): boolean {
+		const fence = resolveSessionFence(cwd, { get: () => undefined });
+		if (!fence) throw new Error("expected a fence: sandboxing should default to on");
+		return evaluateToolCall({ toolName: "read", input: { file_path: filePath }, cwd, fence }).block;
+	}
+
+	// What the block claims: from a working directory holding several customers, every
+	// one of them is reachable and no crossing is refused.
+	it("is right that a crossing between children of the working directory is not refused", () => {
+		expect(refuses(parent, path.join(custA, "notes.md"))).toBe(false);
+		expect(refuses(parent, path.join(custB, "secret.env"))).toBe(false);
+	});
+
+	// And the converse the block must NOT claim. From inside one customer the fence
+	// denies the parent, so a sibling read IS refused — the generalisation this block
+	// used to make ("nothing refuses a sibling") is false and must not come back.
+	it("does not let the block generalise to siblings the fence refuses", () => {
+		const siblingRefused = refuses(custA, path.join(custB, "secret.env"));
+		expect(siblingRefused).toBe(true);
+		expect(flat()).not.toMatch(/nothing refuses a sibling/i);
+		expect(flat()).not.toMatch(/boundary is the working directory, not the customer subdirectory/i);
 	});
 });

--- a/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
+++ b/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
@@ -60,11 +60,29 @@ describe("system prompt workspace boundary", () => {
 	});
 
 	// The one thing the fence cannot do. Where the working directory holds several
-	// customers, they are all inside the allowed subtree, so separating them is
+	// tenants, they are all inside the allowed subtree, so separating them is
 	// judgment and nothing else.
+	//
+	// "tenant" is deliberate: it is the agnostic term for one bounded scope of work,
+	// and it matches the F5 XC tenant named in the Platform Context block directly
+	// below. "customer" would be narrower than the category this actually covers.
 	it("covers the case the fence leaves open", () => {
-		expect(flat()).toMatch(/subdirectories of the working directory may be separate customers/i);
+		expect(flat()).toMatch(/subdirectories of the working directory/i);
 		expect(flat()).toMatch(/your judgment/i);
+	});
+
+	// #2643 review, confirmed. `resolveSessionFence` returns undefined outright when
+	// `sandbox.enabled` is false, so under `--no-sandbox` nothing is refused anywhere.
+	// Scoping this block to subdirectories of the working directory would leave those
+	// sessions with no always-loaded statement about tenant scope at all — the text
+	// that covers it (containment.md) sits behind the `xcsh://` gate, which the prompt
+	// tells the model not to read unless asked about xcsh itself.
+	//
+	// Stated as judgment, never as a prohibition on reading: the point is that reaching
+	// something is not the same as it being in scope, not that paths are off limits.
+	it("covers sessions where filesystem isolation is off", () => {
+		expect(flat()).toMatch(/isolation is off/i);
+		expect(flat()).toMatch(/not the same as it being in scope/i);
 	});
 
 	// Guards the non-goal. Work that genuinely spans two subdirectories must stay
@@ -73,7 +91,7 @@ describe("system prompt workspace boundary", () => {
 	it("does not forbid cross-customer work outright", () => {
 		expect(flat()).not.toMatch(/MUST NOT (read|access|open|touch) (another|other|a different)/i);
 		expect(flat()).toMatch(/say so when the task genuinely spans more than one/i);
-		expect(flat()).toMatch(/MUST NOT\*{0,2} merge two customers/i);
+		expect(flat()).toMatch(/MUST NOT\*{0,2} merge two tenants/i);
 	});
 
 	// #2643. The block must not re-impose at the prompt layer what the fence
@@ -125,18 +143,18 @@ describe("system prompt workspace boundary", () => {
 describe("workspace boundary claims match the real fence", () => {
 	let tmp: TempDir;
 	let parent: string;
-	let custA: string;
-	let custB: string;
+	let tenantA: string;
+	let tenantB: string;
 
 	beforeAll(() => {
 		tmp = TempDir.createSync("xcsh-boundary-claim-");
 		parent = path.join(tmp.absolute(), "customers");
-		custA = path.join(parent, "custA");
-		custB = path.join(parent, "custB");
-		fs.mkdirSync(custA, { recursive: true });
-		fs.mkdirSync(custB, { recursive: true });
-		fs.writeFileSync(path.join(custA, "notes.md"), "a");
-		fs.writeFileSync(path.join(custB, "secret.env"), "TOKEN=b");
+		tenantA = path.join(parent, "tenantA");
+		tenantB = path.join(parent, "tenantB");
+		fs.mkdirSync(tenantA, { recursive: true });
+		fs.mkdirSync(tenantB, { recursive: true });
+		fs.writeFileSync(path.join(tenantA, "notes.md"), "a");
+		fs.writeFileSync(path.join(tenantB, "secret.env"), "TOKEN=b");
 	});
 
 	afterAll(() => tmp.removeSync());
@@ -148,18 +166,18 @@ describe("workspace boundary claims match the real fence", () => {
 		return evaluateToolCall({ toolName: "read", input: { file_path: filePath }, cwd, fence }).block;
 	}
 
-	// What the block claims: from a working directory holding several customers, every
+	// What the block claims: from a working directory holding several tenants, every
 	// one of them is reachable and no crossing is refused.
 	it("is right that a crossing between children of the working directory is not refused", () => {
-		expect(refuses(parent, path.join(custA, "notes.md"))).toBe(false);
-		expect(refuses(parent, path.join(custB, "secret.env"))).toBe(false);
+		expect(refuses(parent, path.join(tenantA, "notes.md"))).toBe(false);
+		expect(refuses(parent, path.join(tenantB, "secret.env"))).toBe(false);
 	});
 
 	// And the converse the block must NOT claim. From inside one customer the fence
 	// denies the parent, so a sibling read IS refused — the generalisation this block
 	// used to make ("nothing refuses a sibling") is false and must not come back.
 	it("does not let the block generalise to siblings the fence refuses", () => {
-		const siblingRefused = refuses(custA, path.join(custB, "secret.env"));
+		const siblingRefused = refuses(tenantA, path.join(tenantB, "secret.env"));
 		expect(siblingRefused).toBe(true);
 		expect(flat()).not.toMatch(/nothing refuses a sibling/i);
 		expect(flat()).not.toMatch(/boundary is the working directory, not the customer subdirectory/i);

--- a/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
+++ b/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
@@ -85,13 +85,27 @@ describe("system prompt workspace boundary", () => {
 		expect(flat()).toMatch(/not the same as it being in scope/i);
 	});
 
-	// Guards the non-goal. Work that genuinely spans two subdirectories must stay
-	// possible; the requirement is that the crossing be deliberate and stated. This
-	// fails if a later edit quietly turns the block into a lockdown.
-	it("does not forbid cross-customer work outright", () => {
-		expect(flat()).not.toMatch(/MUST NOT (read|access|open|touch) (another|other|a different)/i);
+	// #2643 review round 2, confirmed. "Work in the one the task names" is guidance,
+	// not a rule, so the only MUST NOT covered merging — leaving an agent free to read
+	// a neighbouring tenant's secrets for "precedent" without breaking anything
+	// explicit. That accidental context loading is the whole reason this block exists.
+	//
+	// The rule is scoped to TENANTS and conditioned on the task, which is what keeps it
+	// a useful control rather than a filesystem-wide prohibition: it says nothing about
+	// the paths the fence deliberately leaves open.
+	it("forbids opening another tenant only when the task did not ask", () => {
+		expect(flat()).toMatch(/MUST NOT\*{0,2} open another tenant/i);
+		expect(flat()).toMatch(/the task did not ask/i);
+	});
+
+	// Guards the non-goal. Work that genuinely spans two tenants must stay possible;
+	// the requirement is that the crossing be deliberate and stated. A MUST NOT about
+	// opening another tenant is acceptable ONLY while that permission survives beside
+	// it, so this guards the permission rather than pattern-matching the prohibition.
+	it("does not forbid cross-tenant work outright", () => {
 		expect(flat()).toMatch(/say so when the task genuinely spans more than one/i);
 		expect(flat()).toMatch(/MUST NOT\*{0,2} merge two tenants/i);
+		expect(flat()).not.toMatch(/MUST NOT\*{0,2} (work|operate|act) across/i);
 	});
 
 	// #2643. The block must not re-impose at the prompt layer what the fence


### PR DESCRIPTION
Closes #2643

## What happened

The fence unification (#2624 / #2628 / #2637) landed the day after #2611 and invalidated both halves of the `<workspace-boundary>` block.

**It stated the opposite of the truth.** The block said *"nothing refuses a sibling"*. The fence now denies the workspace's parent. Measured against the current `resolveSessionFence`, from `tenants/tenantA`:

```
own file                  -> allowed
sibling tenantB/secret    -> REFUSED
parent tenants/           -> REFUSED
/usr/share/dict/words     -> allowed
```

**It re-imposed what the fence deliberately dropped.** *"You MUST NOT range across the filesystem hunting for files, examples, or precedent"* forbade paths the fence leaves open on purpose. `containment.ts` records why the old model went: a deny-by-default boundary *"refuses ordinary work"*. xcsh's users are network engineers who need a capable coworker, not a supervised one.

## The block now

```
<workspace-boundary>
Separate tenants may sit side by side — as subdirectories of the working directory, and anywhere
else you can reach when filesystem isolation is off. Reaching something is not the same as it being
in scope; keeping tenants apart is your judgment.
- Work in the one the task names, and say so when the task genuinely spans more than one.
- You **MUST NOT** open another tenant's material for context, examples, or precedent when the task
  did not ask for it, and **MUST NOT** merge two tenants' material into one artifact.
</workspace-boundary>
```

**565 characters, down from 1196** — 1.21% of the rendered prompt, was 2.53%. No claim about the sandbox that the fence can contradict, and no prohibition on any path the fence allows.

**Terminology: customer → tenant.** Tenant is the agnostic term for one bounded scope of work, and it matches the F5 XC tenant named in the Platform Context block that renders immediately below this one.

## The drift guard

This block has now asserted a mechanism fact that reality contradicted **twice** — an unconditional *"isolation is enforced"* (false under `--no-sandbox`, caught in review) and *"nothing refuses a sibling"* (falsified a day after merge). Prose cannot be trusted to stay true about code it does not import.

So the claim is measured. The new test builds a **real fence** over a two-tenant tree and asserts the prompt matches both what it permits and what it refuses:

- from the parent CWD, a cross-child read is permitted — the claim the block makes;
- from inside one tenant, a sibling read **is** refused — so the block must not generalise to "nothing refuses a sibling", asserted as a negative match.

Mutation-checked: re-introducing the stale sentence fails the guard, and the file was restored from a byte-identical snapshot.

## Review — two confirmed, one refuted

`codex:verified-code-review` (`adversarial-review`). Gate: `done: true`, `findingsClear: true`, no escalation.

**Round 1 (high, confirmed).** Scoping the block to subdirectories left `--no-sandbox` sessions with no always-loaded statement about scope at all — `resolveSessionFence` returns `undefined` outright when `sandbox.enabled` is false (`session-fence.ts:63`), and the only text covering that case is `containment.md`, behind the `xcsh://` gate. Closed by widening the subject rather than re-adding a prohibition.

**Round 2 (high, confirmed).** The only `MUST NOT` covered *merging*, so reading a neighbouring tenant's secrets for "precedent" violated nothing explicit — the accidental context loading this block exists to prevent. The trim had cut too far. Fixed with a rule scoped to tenants and conditioned on the task. The lockdown guard was refined too: it pattern-matched `/MUST NOT (read|access|open|touch) (another|other)/`, which would have failed a correctly-scoped rule as readily as a blanket one, so it now guards the surviving permission instead.

**Round 3 (high, REFUTED).** Claimed non-tenant credentials are now in prompt-authorized scope because `~/.ssh/id_rsa` stays readable. **The fact is right; the conclusion is not.** That is a deliberate decision, not a gap — `sandbox-isolation.test.ts:81` is titled *"no longer blocks the operator's own home dotfiles"* with the comment *"#2637: the operator's own dotfiles are theirs"*, and `containment.ts:92` denies only *"directories inside home that hold tool state rather than the operator's data"*. Forbidding it in the prompt would re-impose the exact control the fence dropped, on the operator's own machine and own key. It is also outside this block's scope — an operator's `~/.ssh` is neither tenant's material — and transcript exposure already has its own mechanism, the `secretsEnabled` `<redacted-content>` block at `system-prompt.md:769`.

## Verification

- TDD throughout: 4 red → green on the trim, 1 red → green on round 1, 1 red → green on round 2.
- 11 tests in `system-prompt-workspace-boundary.test.ts`; all 59 `system-prompt-*` tests pass; `bun run check` exits 0.
- Block still renders once in the Workspace section and still survives a custom system prompt (the #2628 marker path).

## Not addressed here

**#2621** — three `sandbox-isolation` shell tests remain red on `main` on macOS (`backend: seatbelt, osEnforced: true`, yet a sibling read succeeds), and no CI job runs them: the `test` job is `ubuntu-22.04` only and the containment steps are gated on `rust_checks`, set on one ubuntu matrix entry. Confirmed still failing after this refactor. Separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
