### PR TITLE
fix(sandbox): use neutral placeholders in fixtures and comments

### DIFF
--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -543,7 +543,7 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 	// ~30 carve-outs to make ordinary tooling work again — every one of them evidence the posture was wrong.
 	//
 	// What the walk still covers is the part that matters: every level between the workspace and home. With
-	// the workspace at `~/MEDDPICC/EQUIFAX`, `~/MEDDPICC` is denied so the `ACME` sibling is unreachable,
+	// the workspace at `~/MEDDPICC/CUSTOMER-A`, `~/MEDDPICC` is denied so the `CUSTOMER-B` sibling is unreachable,
 	// and with `<container>/<tenant>/repo` every level up to home is denied, so the v19.100.1 cross-tenant
 	// regression does not return.
 	//
@@ -620,7 +620,7 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 	}
 
 	// Top-level directories that hold somebody's files. Without these the fence covered only home and
-	// the workspace's ancestors, so with the workspace at `~/MEDDPICC/EQUIFAX` another operator's
+	// the workspace's ancestors, so with the workspace at `~/MEDDPICC/CUSTOMER-A` another operator's
 	// account, an external volume and `/data/globex` were all readable AND writable — measured. The
 	// command-text scan was refusing them on the way in, which is exactly why that scan could not
 	// simply be stood down (#2624).

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -213,7 +213,7 @@ describe("buildContainmentFence", () => {
 /**
  * The operator's home is theirs (#2637).
  *
- * Reported: `Read ~/git/STYLE_GUIDE.md` refused with the workspace at `~/MEDDPICC/EQUIFAX`. The refusal was
+ * Reported: `Read ~/git/STYLE_GUIDE.md` refused with the workspace at `~/MEDDPICC/CUSTOMER-A`. The refusal was
  * correct for the rule and the model declined to work around it, so the work simply stopped and the
  * operator was told the boundary was working as intended.
  *
@@ -222,12 +222,12 @@ describe("buildContainmentFence", () => {
  * them. It is not a prison, and it does not re-implement file permissions.
  */
 describe("buildContainmentFence — the operator's home is theirs (#2637)", () => {
-	/** `<home>/MEDDPICC/EQUIFAX`, the shape the report came from. */
+	/** `<home>/MEDDPICC/CUSTOMER-A`, the shape the report came from. */
 	function customerSession(suffix: string) {
 		const home = realTmp(suffix);
 		const container = path.join(home, "MEDDPICC");
-		const workspace = path.join(container, "EQUIFAX");
-		const sibling = path.join(container, "ACME");
+		const workspace = path.join(container, "CUSTOMER-A");
+		const sibling = path.join(container, "CUSTOMER-B");
 		const elsewhere = path.join(home, "git");
 		for (const dir of [workspace, sibling, elsewhere]) fs.mkdirSync(dir, { recursive: true });
 		return { home, container, workspace, sibling, elsewhere };
@@ -256,14 +256,14 @@ describe("buildContainmentFence — the operator's home is theirs (#2637)", () =
 	it("still refuses other tenants when the workspace is nested deeper", () => {
 		const home = realTmp("nested");
 		const container = path.join(home, "MEDDPICC");
-		const workspace = path.join(container, "EQUIFAX", "repo");
-		const otherTenant = path.join(container, "ACME", "repo");
+		const workspace = path.join(container, "CUSTOMER-A", "repo");
+		const otherTenant = path.join(container, "CUSTOMER-B", "repo");
 		for (const dir of [workspace, otherTenant]) fs.mkdirSync(dir, { recursive: true });
 
 		const fence = buildContainmentFence({ workspace, home });
 
 		expect(fenceVerdict(fence, path.join(otherTenant, "secret.env"), "read")).toBe("deny");
-		expect(fenceVerdict(fence, path.join(container, "EQUIFAX", "sibling-of-repo"), "read")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(container, "CUSTOMER-A", "sibling-of-repo"), "read")).toBe("deny");
 		expect(fenceVerdict(fence, path.join(workspace, "mine.md"), "write")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(home, "git", "STYLE_GUIDE.md"), "read")).toBe("allow");
 	});
@@ -1004,7 +1004,7 @@ describe("buildContainmentFence — the ancestor walk never denies a temp root",
  *
  * The home deny and the ancestor walk together cover the realistic case — customer checkouts under
  * `~`. They cover nothing under an unrelated root: measured with the workspace at
- * `~/MEDDPICC/EQUIFAX`, the fence allowed `/Users/<otheruser>/…`, `/Volumes/Backup/…`, `/data/globex`
+ * `~/MEDDPICC/CUSTOMER-A`, the fence allowed `/Users/<otheruser>/…`, `/Volumes/Backup/…`, `/data/globex`
  * and `/srv/tenantZ`, read and write. The command-text scan was refusing those on the way in, so the
  * composite looked right while the fence alone did not — and that scan is what #2624 stops using as a
  * boundary, so this has to hold on its own now.
@@ -1024,7 +1024,7 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 	it("denies unrelated data roots while leaving every operational root alone", () => {
 		const fsRoot = syntheticRoot("fsdata", ["usr", "bin", "etc", "opt", "var", "Users", "data", "srv", "Volumes"]);
 		const home = path.join(fsRoot, "Users", "me");
-		const workspace = path.join(home, "MEDDPICC", "EQUIFAX");
+		const workspace = path.join(home, "MEDDPICC", "CUSTOMER-A");
 		fs.mkdirSync(workspace, { recursive: true });
 		fs.mkdirSync(path.join(fsRoot, "Users", "otheruser"), { recursive: true });
 		fs.mkdirSync(path.join(fsRoot, "data", "globex"), { recursive: true });


### PR DESCRIPTION
Closes #2644.

A real organisation's name was used as a test fixture directory literal and in sandbox code comments, in
a **public** repository. `STYLE_GUIDE.md` allows documentation-reserved example values only and bans
`ACME` by name; both appeared on the same lines.

Replaced with `CUSTOMER-A` / `CUSTOMER-B` in:

- `packages/coding-agent/src/sandbox/containment.ts` — 2 comment lines
- `packages/coding-agent/test/sandbox-containment.test.ts` — 7 lines, including the fixture literal

Mechanical: comment text plus a literal that is both constructed and asserted inside the same test.

## Verification

- `CI=1 bun test packages/coding-agent/test/sandbox-containment.test.ts` → **58 pass, 0 fail**, 369
  `expect()` calls — same count as before the rename. Exit status read from a file, not a pipeline.
- `git grep -nw` for the organisation name returns nothing in the tracked tree.
- No `ACME` remains in either file. Pre-existing `ACME` references elsewhere in docs/translations are
  untouched — `STYLE_GUIDE.md` says to rename those as the surrounding content is touched.
- A scan of every tracked file against all 21 directory names under the operator's customer tree finds
  no other match. (One apparent hit was random bytes inside `assets/review.webp`.)

## Not fixed by this PR

The name also exists in this repo's **git history** and in the release artifacts built from it, which an
edit to the working tree cannot reach. Tracked with the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)