### PR TITLE
chore: bump version to v19.102.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "containment-check"
-version = "19.102.5"
+version = "19.102.6"
 dependencies = [
  "brush-builtins",
  "brush-core",
@@ -2144,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "pi-natives"
-version = "19.102.5"
+version = "19.102.6"
 dependencies = [
  "arboard",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/brush-core-vendored", "crates/brush-builtins-vendored", "crat
 resolver = "3"
 
 [workspace.package]
-version = "19.102.5"
+version = "19.102.6"
 edition = "2024"
 license = "MIT"
 authors = ["Can Boluk"]

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/agent": {
       "name": "@f5-sales-demo/pi-agent-core",
-      "version": "19.102.5",
+      "version": "19.102.6",
       "dependencies": {
         "@f5-sales-demo/pi-ai": "workspace:*",
         "@f5-sales-demo/pi-utils": "workspace:*",
@@ -28,7 +28,7 @@
     },
     "packages/ai": {
       "name": "@f5-sales-demo/pi-ai",
-      "version": "19.102.5",
+      "version": "19.102.6",
       "bin": {
         "pi-ai": "./src/cli.ts",
       },
@@ -74,7 +74,7 @@
     },
     "packages/coding-agent": {
       "name": "@f5-sales-demo/xcsh",
-      "version": "19.102.5",
+      "version": "19.102.6",
       "bin": {
         "xcsh": "src/cli.ts",
       },
@@ -108,17 +108,17 @@
     },
     "packages/natives": {
       "name": "@f5-sales-demo/pi-natives",
-      "version": "19.102.5",
+      "version": "19.102.6",
       "devDependencies": {
         "@napi-rs/cli": "3.7.4",
         "@types/bun": "^1.3",
       },
       "optionalDependencies": {
-        "@f5-sales-demo/pi-natives-darwin-arm64": "19.102.5",
-        "@f5-sales-demo/pi-natives-darwin-x64": "19.102.5",
-        "@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.102.5",
-        "@f5-sales-demo/pi-natives-linux-x64-gnu": "19.102.5",
-        "@f5-sales-demo/pi-natives-win32-x64-msvc": "19.102.5",
+        "@f5-sales-demo/pi-natives-darwin-arm64": "19.102.6",
+        "@f5-sales-demo/pi-natives-darwin-x64": "19.102.6",
+        "@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.102.6",
+        "@f5-sales-demo/pi-natives-linux-x64-gnu": "19.102.6",
+        "@f5-sales-demo/pi-natives-win32-x64-msvc": "19.102.6",
       },
     },
     "packages/office-pane": {
@@ -145,7 +145,7 @@
     },
     "packages/resource-management": {
       "name": "@f5-sales-demo/pi-resource-management",
-      "version": "19.102.5",
+      "version": "19.102.6",
       "dependencies": {
         "yaml": "2.9.0",
       },
@@ -155,7 +155,7 @@
     },
     "packages/stats": {
       "name": "@f5-sales-demo/xcsh-stats",
-      "version": "19.102.5",
+      "version": "19.102.6",
       "bin": {
         "xcsh-stats": "./src/index.ts",
       },
@@ -180,7 +180,7 @@
     },
     "packages/swarm-extension": {
       "name": "@f5-sales-demo/swarm-extension",
-      "version": "19.102.5",
+      "version": "19.102.6",
       "bin": {
         "xcsh-swarm": "src/cli.ts",
       },
@@ -196,7 +196,7 @@
     },
     "packages/tui": {
       "name": "@f5-sales-demo/pi-tui",
-      "version": "19.102.5",
+      "version": "19.102.6",
       "dependencies": {
         "@f5-sales-demo/pi-natives": "workspace:*",
         "@f5-sales-demo/pi-utils": "workspace:*",
@@ -235,7 +235,7 @@
     },
     "packages/utils": {
       "name": "@f5-sales-demo/pi-utils",
-      "version": "19.102.5",
+      "version": "19.102.6",
       "dependencies": {
         "@f5-sales-demo/i18n-core": "^1.0.0",
         "beautiful-mermaid": "^1.1",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-agent-core",
-	"version": "19.102.5",
+	"version": "19.102.6",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-ai",
-	"version": "19.102.5",
+	"version": "19.102.6",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/xcsh",
-	"version": "19.102.5",
+	"version": "19.102.6",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-arm64/package.json
+++ b/packages/natives/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-darwin-arm64",
-	"version": "19.102.5",
+	"version": "19.102.6",
 	"description": "Native addon for @f5-sales-demo/pi-natives (macOS arm64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-x64/package.json
+++ b/packages/natives/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-darwin-x64",
-	"version": "19.102.5",
+	"version": "19.102.6",
 	"description": "Native addon for @f5-sales-demo/pi-natives (macOS x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-arm64-gnu/package.json
+++ b/packages/natives/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-linux-arm64-gnu",
-	"version": "19.102.5",
+	"version": "19.102.6",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Linux arm64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-x64-gnu/package.json
+++ b/packages/natives/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-linux-x64-gnu",
-	"version": "19.102.5",
+	"version": "19.102.6",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Linux x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/win32-x64-msvc/package.json
+++ b/packages/natives/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-win32-x64-msvc",
-	"version": "19.102.5",
+	"version": "19.102.6",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Windows x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives",
-	"version": "19.102.5",
+	"version": "19.102.6",
 	"description": "Native Rust bindings for grep, clipboard, image processing, syntax highlighting, PTY, and shell operations via N-API",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",
@@ -56,11 +56,11 @@
 		}
 	},
 	"optionalDependencies": {
-		"@f5-sales-demo/pi-natives-linux-x64-gnu": "19.102.5",
-		"@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.102.5",
-		"@f5-sales-demo/pi-natives-darwin-x64": "19.102.5",
-		"@f5-sales-demo/pi-natives-darwin-arm64": "19.102.5",
-		"@f5-sales-demo/pi-natives-win32-x64-msvc": "19.102.5"
+		"@f5-sales-demo/pi-natives-linux-x64-gnu": "19.102.6",
+		"@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.102.6",
+		"@f5-sales-demo/pi-natives-darwin-x64": "19.102.6",
+		"@f5-sales-demo/pi-natives-darwin-arm64": "19.102.6",
+		"@f5-sales-demo/pi-natives-win32-x64-msvc": "19.102.6"
 	},
 	"files": [
 		"native",

--- a/packages/resource-management/package.json
+++ b/packages/resource-management/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-resource-management",
-	"version": "19.102.5",
+	"version": "19.102.6",
 	"description": "Shared resource management for F5 XC manifest parsing, validation, diff, and CRUD operations",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Robin Mordasiewicz",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/xcsh-stats",
-	"version": "19.102.5",
+	"version": "19.102.6",
 	"description": "Local observability dashboard for pi AI usage statistics",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/swarm-extension/package.json
+++ b/packages/swarm-extension/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/swarm-extension",
-	"version": "19.102.5",
+	"version": "19.102.6",
 	"description": "Swarm orchestration extension for xcsh",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Derek Rynd",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-tui",
-	"version": "19.102.5",
+	"version": "19.102.6",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-utils",
-	"version": "19.102.5",
+	"version": "19.102.6",
 	"description": "Shared utilities for pi packages",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",


### PR DESCRIPTION
Automated release PR generated by `scripts/release.ts`.

Bumps every public package and the Cargo workspace to `v19.102.6` and updates CHANGELOGs for the releasable commits since the last tag.

Once this PR squash-merges to `main`, `.github/workflows/tag-on-version-bump.yml` pushes the `v19.102.6` git tag, which triggers the downstream release chain (build → sign → publish).

### Releasable commits (2)

- fix(sandbox): use neutral placeholders in fixtures and comments (#2644) (#2646)
- fix(prompt): trim the workspace boundary to what the fence cannot do (#2645)

See `docs-control`'s onboarding note "Release automation: release PR pattern" for the governance rationale.