### PR TITLE
fix: use the Example pattern for organisation names in fixtures

### DIFF
--- a/.xcsh/skills/gitlab/SKILL.md
+++ b/.xcsh/skills/gitlab/SKILL.md
@@ -33,7 +33,7 @@ Only call `glab_setup(action: "check")` and `glab_setup(action: "status")` for d
 |-------------|-------------|
 | "show me bugs", "list open issues", "issues assigned to alice" | `glab_issue_list` |
 | "show issue #42", "view issue details", "what's in ticket 123" | `glab_issue_view` |
-| "find issues about Tempus", "search for login timeout", "bugs mentioning Safari" | `glab_search` |
+| "find issues about Example Corp", "search for login timeout", "bugs mentioning Safari" | `glab_search` |
 | "configure GitLab", "set up glab", "save project path" | `glab_setup(action: "save_project", project: "...")` |
 
 **Always try the search/list tool first.** If it fails with "not configured", show the setup message above and stop — do not call multiple tools trying to auto-configure.

--- a/packages/coding-agent/test/chat-handler-slash-commands.test.ts
+++ b/packages/coding-agent/test/chat-handler-slash-commands.test.ts
@@ -111,10 +111,10 @@ test("a /command chat_request is expanded into the command body", async () => {
 test("arguments after the command name are substituted into $ARGUMENTS", async () => {
 	const h = harness([QUALIFY]);
 	new ChatHandler(h.server, h.session).attach();
-	h.fire({ type: "chat_request", id: "c-2", text: "/meddpicc:qualify-deal Visa, Inc.", mode: "educational" });
+	h.fire({ type: "chat_request", id: "c-2", text: "/meddpicc:qualify-deal Example Corp", mode: "educational" });
 	await flush();
 
-	expect(h.prompts[0]).toContain('the deal "Visa, Inc."');
+	expect(h.prompts[0]).toContain('the deal "Example Corp"');
 	expect(h.prompts[0]).not.toContain("$ARGUMENTS");
 });
 
@@ -123,10 +123,10 @@ test("an unknown /name is left alone so the skill convention still applies", asy
 	// not by expansion. Rewriting or rejecting an unmatched name would break them.
 	const h = harness([QUALIFY]);
 	new ChatHandler(h.server, h.session).attach();
-	h.fire({ type: "chat_request", id: "c-3", text: "/meddpicc:deal-review Visa", mode: "educational" });
+	h.fire({ type: "chat_request", id: "c-3", text: "/meddpicc:deal-review Example Corp", mode: "educational" });
 	await flush();
 
-	expect(h.prompts[0]).toContain("/meddpicc:deal-review Visa");
+	expect(h.prompts[0]).toContain("/meddpicc:deal-review Example Corp");
 });
 
 test("ordinary prose is untouched", async () => {

--- a/packages/office-pane/test/excel-tools.test.ts
+++ b/packages/office-pane/test/excel-tools.test.ts
@@ -795,11 +795,11 @@ describe("add_sheet", () => {
 			id: "as-1",
 			toolCallId: "tc-as-1",
 			toolName: "add_sheet",
-			arguments: { name: "MEDDPICC — Visa, Inc." },
+			arguments: { name: "MEDDPICC — Example Corp" },
 		});
 		await flush();
 
-		expect(excel.sheetNames()).toContain("MEDDPICC — Visa, Inc.");
+		expect(excel.sheetNames()).toContain("MEDDPICC — Example Corp");
 		expect(firstText(callFrom(t))).toContain("Created");
 		d.dispose();
 	});
@@ -903,11 +903,11 @@ describe("add_sheet", () => {
 			id: "as-7",
 			toolCallId: "tc-as-7",
 			toolName: "write_range",
-			arguments: { address: "Deal!A1:B1", values: [["Account Name", "Visa, Inc."]] },
+			arguments: { address: "Deal!A1:B1", values: [["Account Name", "Example Corp"]] },
 		});
 		await flush();
 
-		expect(excel.sheetCells("Deal")["A1:B1"]).toEqual([["Account Name", "Visa, Inc."]]);
+		expect(excel.sheetCells("Deal")["A1:B1"]).toEqual([["Account Name", "Example Corp"]]);
 		d.dispose();
 	});
 });
@@ -934,7 +934,7 @@ describe("write_cells", () => {
 			toolName: "write_cells",
 			arguments: {
 				cells: [
-					{ address: "C4", value: "Visa, Inc." },
+					{ address: "C4", value: "Example Corp" },
 					{ address: "N7", value: 473687 },
 					{ address: "I5", value: 0.6 },
 				],
@@ -942,7 +942,7 @@ describe("write_cells", () => {
 		});
 		await flush();
 
-		expect(excel.cells.C4).toEqual([["Visa, Inc."]]);
+		expect(excel.cells.C4).toEqual([["Example Corp"]]);
 		expect(excel.cells.N7).toEqual([[473687]]);
 		expect(excel.cells.I5).toEqual([[0.6]]);
 		expect(firstText(callFrom(t))).toContain("3");
@@ -960,11 +960,11 @@ describe("write_cells", () => {
 			id: "wc-2",
 			toolCallId: "tc-wc-2",
 			toolName: "write_cells",
-			arguments: { cells: [{ address: "'MEDDPICC Deal Review Sheet'!C4", value: "Visa" }] },
+			arguments: { cells: [{ address: "'MEDDPICC Deal Review Sheet'!C4", value: "Example Corp" }] },
 		});
 		await flush();
 
-		expect(excel.sheetCells("MEDDPICC Deal Review Sheet").C4).toEqual([["Visa"]]);
+		expect(excel.sheetCells("MEDDPICC Deal Review Sheet").C4).toEqual([["Example Corp"]]);
 		d.dispose();
 	});
 


### PR DESCRIPTION
Closes #2648. Follow-up to #2644.

Two real organisation names were used as example data in this **public** repository:

| File | Occurrences | Context |
|---|---|---|
| `packages/office-pane/test/excel-tools.test.ts` | 8 | account name in MEDDPICC deal-review spreadsheet fixtures |
| `packages/coding-agent/test/chat-handler-slash-commands.test.ts` | 4 | argument to `/meddpicc:qualify-deal` and `/meddpicc:deal-review` |
| `.xcsh/skills/gitlab/SKILL.md` | 1 | a second organisation in an example search query |

Both correspond to directories in the operator's customer tree, and the surrounding context labels them
as accounts under sales qualification. Replaced with `Example Corp` per `STYLE_GUIDE.md`.

**Why #2644 missed these:** that scan was case-sensitive; these appear as `Visa, Inc.` and `Tempus`.

## Verification

- `CI=1 bun test` on both test files → **54 pass, 0 fail**, 110 `expect()` calls. Exit status read from a
  file, not a pipeline.
- A **case-insensitive**, word-bounded scan of all 3,476 tracked text files against every directory name
  in the operator's customer tree → **no match**.
- Separately, a scan of all 3,820 GitHub records (2,646 issue/PR bodies, 611 issue comments, 86 PR review
  comments, 477 release notes) → no match remaining.

`ACME` still appears 338 times across 51 files. `STYLE_GUIDE.md` bans it but it is not a real customer
name, so it is left as pre-existing debt to be renamed as surrounding content is touched.

## Not fixed here

The names remain in git history, in the commit message of `15e47a0f7`, and in the auto-generated source
archives for existing tags. A working-tree edit cannot reach those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)