### PR TITLE
chore: replace ACME placeholders repo-wide

### DIFF
--- a/docs/ar/runtime-tools/context-command.md
+++ b/docs/ar/runtime-tools/context-command.md
@@ -22,7 +22,7 @@ i18n:
 تحتاج إلى ثلاثة أشياء من وحدة تحكم F5 XC الخاصة بك: عنوان URL للمستأجر، ورمز API، واختيارياً مساحة أسماء.
 
 ```
-/context create production https://example.console.ves.volterra.io p12k3-your-api-token
+/context create production https://example-corp.console.ves.volterra.io p12k3-your-api-token
 ```
 
 ```
@@ -43,8 +43,8 @@ Context 'production' created. Use /context activate production to switch to it.
 
 ```
 ╭─ production ─────────────────────────────────────────────────╮
-│ XCSH_TENANT     example                                         │
-│ XCSH_API_URL    https://example.console.ves.volterra.io         │
+│ XCSH_TENANT     example-corp                                 │
+│ XCSH_API_URL    https://example-corp.console.ves.volterra.io │
 │ XCSH_API_TOKEN  ...oken                                      │
 │ Status          Connected (312ms)                            │
 ├─ Environment ────────────────────────────────────────────────┤
@@ -81,7 +81,7 @@ Context 'production' created. Use /context activate production to switch to it.
 ```
 
 ```
-  production           https://example.console.ves.volterra.io
+  production           https://example-corp.console.ves.volterra.io
 * staging              https://staging.console.ves.volterra.io
 ```
 
@@ -124,7 +124,7 @@ Context 'production' created. Use /context activate production to switch to it.
 يمكن أن تحمل السياقات متغيرات بيئة إضافية تُحقن في جلستك عند التفعيل. مفيدة للتكوينات الخاصة بكل مستأجر والتي ليست جزءاً من مجموعة بيانات الاعتماد.
 
 ```
-/context set CUSTOM_HEADER=x-example-trace
+/context set CUSTOM_HEADER=x-example-corp-trace
 /context set LOG_LEVEL=debug
 /context env list
 /context unset LOG_LEVEL
@@ -134,7 +134,7 @@ Context 'production' created. Use /context activate production to switch to it.
 
 ## الإكمال التلقائي بالتاب
 
-اكتب `/context ` واضغط Tab. تعرض القائمة المنسدلة:
+اكتب `/context` واضغط Tab. تعرض القائمة المنسدلة:
 
 1. **أسماء السياقات** -- مع تلميحات عنوان URL للمستأجر، حتى تتمكن من التمييز بين المستأجرين
 2. **`-`** -- يظهر عندما تكون قد بدّلت سابقاً، ويعرض السياق الذي ستنتقل إليه

--- a/docs/de/runtime-tools/context-command.md
+++ b/docs/de/runtime-tools/context-command.md
@@ -22,7 +22,7 @@ xcsh verbindet sich mit F5 Distributed Cloud über **Kontexte** -- benannte Anme
 Sie benötigen drei Dinge aus Ihrer F5 XC Konsole: die Tenant-URL, ein API-Token und optional einen Namespace.
 
 ```
-/context create production https://example.console.ves.volterra.io p12k3-your-api-token
+/context create production https://example-corp.console.ves.volterra.io p12k3-your-api-token
 ```
 
 ```
@@ -43,8 +43,8 @@ Oder verwenden Sie den geführten Assistenten, wenn Sie schrittweise Eingabeauff
 
 ```
 ╭─ production ─────────────────────────────────────────────────╮
-│ XCSH_TENANT     example                                         │
-│ XCSH_API_URL    https://example.console.ves.volterra.io         │
+│ XCSH_TENANT     example-corp                                 │
+│ XCSH_API_URL    https://example-corp.console.ves.volterra.io │
 │ XCSH_API_TOKEN  ...oken                                      │
 │ Status          Connected (312ms)                            │
 ├─ Environment ────────────────────────────────────────────────┤
@@ -81,7 +81,7 @@ Zweimaliges Aufrufen von `/context -` bringt Sie zurück zum Ausgangspunkt.
 ```
 
 ```
-  production           https://example.console.ves.volterra.io
+  production           https://example-corp.console.ves.volterra.io
 * staging              https://staging.console.ves.volterra.io
 ```
 
@@ -124,7 +124,7 @@ Tab-Vervollständigung bietet Namespace-Namen vom aktiven Tenant an.
 Kontexte können zusätzliche Umgebungsvariablen enthalten, die bei der Aktivierung in Ihre Sitzung injiziert werden. Nützlich für Tenant-spezifische Konfiguration, die nicht Teil des Anmeldedatensatzes ist.
 
 ```
-/context set CUSTOM_HEADER=x-example-trace
+/context set CUSTOM_HEADER=x-example-corp-trace
 /context set LOG_LEVEL=debug
 /context env list
 /context unset LOG_LEVEL
@@ -134,7 +134,7 @@ Aliase: `add` = `set`, `remove`/`clear` = `unset`.
 
 ## Tab-Vervollständigung
 
-Geben Sie `/context ` ein und drücken Sie Tab. Das Dropdown zeigt:
+Geben Sie `/context` ein und drücken Sie Tab. Das Dropdown zeigt:
 
 1. **Kontextnamen** -- mit Tenant-URL-Hinweisen, damit Sie Tenants unterscheiden können
 2. **`-`** -- erscheint, wenn Sie zuvor gewechselt haben, zeigt an, zu welchem Kontext Sie wechseln würden

--- a/docs/en/runtime-tools/context-command.md
+++ b/docs/en/runtime-tools/context-command.md
@@ -17,7 +17,7 @@ xcsh connects to F5 Distributed Cloud through **contexts** -- named credential s
 You need three things from your F5 XC console: the tenant URL, an API token, and optionally a namespace.
 
 ```
-/context create production https://example.console.ves.volterra.io p12k3-your-api-token
+/context create production https://example-corp.console.ves.volterra.io p12k3-your-api-token
 ```
 
 ```
@@ -38,8 +38,8 @@ Or use the guided wizard if you prefer step-by-step prompts:
 
 ```
 ╭─ production ─────────────────────────────────────────────────╮
-│ XCSH_TENANT     example                                         │
-│ XCSH_API_URL    https://example.console.ves.volterra.io         │
+│ XCSH_TENANT     example-corp                                 │
+│ XCSH_API_URL    https://example-corp.console.ves.volterra.io │
 │ XCSH_API_TOKEN  ...oken                                      │
 │ Status          Connected (312ms)                            │
 ├─ Environment ────────────────────────────────────────────────┤
@@ -76,7 +76,7 @@ Calling `/context -` twice returns you to where you started.
 ```
 
 ```
-  production           https://example.console.ves.volterra.io
+  production           https://example-corp.console.ves.volterra.io
 * staging              https://staging.console.ves.volterra.io
 ```
 
@@ -119,7 +119,7 @@ Tab completion offers namespace names from the active tenant.
 Contexts can carry extra environment variables that are injected into your session on activation. Useful for per-tenant configuration that isn't part of the credential set.
 
 ```
-/context set CUSTOM_HEADER=x-example-trace
+/context set CUSTOM_HEADER=x-example-corp-trace
 /context set LOG_LEVEL=debug
 /context env list
 /context unset LOG_LEVEL
@@ -129,7 +129,7 @@ Aliases: `add` = `set`, `remove`/`clear` = `unset`.
 
 ## Tab completion
 
-Type `/context ` and press Tab. The dropdown shows:
+Type `/context` and press Tab. The dropdown shows:
 
 1. **Context names** -- with tenant URL hints, so you can tell tenants apart
 2. **`-`** -- appears when you've switched before, shows which context you'd flip to

--- a/docs/es/runtime-tools/context-command.md
+++ b/docs/es/runtime-tools/context-command.md
@@ -22,7 +22,7 @@ xcsh se conecta a F5 Distributed Cloud a través de **contextos** -- conjuntos d
 Necesita tres elementos de su consola de F5 XC: la URL del tenant, un token de API y, opcionalmente, un namespace.
 
 ```
-/context create production https://example.console.ves.volterra.io p12k3-your-api-token
+/context create production https://example-corp.console.ves.volterra.io p12k3-your-api-token
 ```
 
 ```
@@ -43,8 +43,8 @@ O utilice el asistente guiado si prefiere indicaciones paso a paso:
 
 ```
 ╭─ production ─────────────────────────────────────────────────╮
-│ XCSH_TENANT     example                                         │
-│ XCSH_API_URL    https://example.console.ves.volterra.io         │
+│ XCSH_TENANT     example-corp                                 │
+│ XCSH_API_URL    https://example-corp.console.ves.volterra.io │
 │ XCSH_API_TOKEN  ...oken                                      │
 │ Status          Connected (312ms)                            │
 ├─ Environment ────────────────────────────────────────────────┤
@@ -81,7 +81,7 @@ Llamar a `/context -` dos veces le devuelve al punto de partida.
 ```
 
 ```
-  production           https://example.console.ves.volterra.io
+  production           https://example-corp.console.ves.volterra.io
 * staging              https://staging.console.ves.volterra.io
 ```
 
@@ -124,7 +124,7 @@ El autocompletado con Tab ofrece nombres de namespace del tenant activo.
 Los contextos pueden llevar variables de entorno adicionales que se inyectan en su sesión al activarse. Útil para configuraciones por tenant que no forman parte del conjunto de credenciales.
 
 ```
-/context set CUSTOM_HEADER=x-example-trace
+/context set CUSTOM_HEADER=x-example-corp-trace
 /context set LOG_LEVEL=debug
 /context env list
 /context unset LOG_LEVEL
@@ -134,7 +134,7 @@ Alias: `add` = `set`, `remove`/`clear` = `unset`.
 
 ## Autocompletado con Tab
 
-Escriba `/context ` y presione Tab. El menú desplegable muestra:
+Escriba `/context` y presione Tab. El menú desplegable muestra:
 
 1. **Nombres de contexto** -- con indicaciones de URL del tenant, para que pueda distinguir los tenants
 2. **`-`** -- aparece cuando ha cambiado anteriormente, muestra a qué contexto volvería

--- a/docs/fr/runtime-tools/context-command.md
+++ b/docs/fr/runtime-tools/context-command.md
@@ -22,7 +22,7 @@ xcsh se connecte à F5 Distributed Cloud via des **contextes** -- des jeux d'ide
 Vous avez besoin de trois éléments depuis votre console F5 XC : l'URL du tenant, un jeton API, et optionnellement un namespace.
 
 ```
-/context create production https://example.console.ves.volterra.io p12k3-your-api-token
+/context create production https://example-corp.console.ves.volterra.io p12k3-your-api-token
 ```
 
 ```
@@ -43,8 +43,8 @@ Ou utilisez l'assistant guidé si vous préférez des invites étape par étape 
 
 ```
 ╭─ production ─────────────────────────────────────────────────╮
-│ XCSH_TENANT     example                                         │
-│ XCSH_API_URL    https://example.console.ves.volterra.io         │
+│ XCSH_TENANT     example-corp                                 │
+│ XCSH_API_URL    https://example-corp.console.ves.volterra.io │
 │ XCSH_API_TOKEN  ...oken                                      │
 │ Status          Connected (312ms)                            │
 ├─ Environment ────────────────────────────────────────────────┤
@@ -81,7 +81,7 @@ Appeler `/context -` deux fois vous ramène à votre point de départ.
 ```
 
 ```
-  production           https://example.console.ves.volterra.io
+  production           https://example-corp.console.ves.volterra.io
 * staging              https://staging.console.ves.volterra.io
 ```
 
@@ -124,7 +124,7 @@ L'autocomplétion par tabulation propose les noms de namespace du tenant actif.
 Les contextes peuvent contenir des variables d'environnement supplémentaires qui sont injectées dans votre session lors de l'activation. Utile pour une configuration propre à chaque tenant qui ne fait pas partie du jeu d'identifiants.
 
 ```
-/context set CUSTOM_HEADER=x-example-trace
+/context set CUSTOM_HEADER=x-example-corp-trace
 /context set LOG_LEVEL=debug
 /context env list
 /context unset LOG_LEVEL
@@ -134,7 +134,7 @@ Alias : `add` = `set`, `remove`/`clear` = `unset`.
 
 ## Autocomplétion par tabulation
 
-Tapez `/context ` et appuyez sur Tab. Le menu déroulant affiche :
+Tapez `/context` et appuyez sur Tab. Le menu déroulant affiche :
 
 1. **Noms de contextes** -- avec des indications d'URL de tenant, pour distinguer les tenants
 2. **`-`** -- apparaît lorsque vous avez déjà basculé, indique vers quel contexte vous reviendriez

--- a/docs/hi/runtime-tools/context-command.md
+++ b/docs/hi/runtime-tools/context-command.md
@@ -22,7 +22,7 @@ xcsh **संदर्भों (contexts)** के माध्यम से F5
 आपको अपने F5 XC कंसोल से तीन चीज़ों की आवश्यकता है: टेनेंट URL, एक API टोकन, और वैकल्पिक रूप से एक नेमस्पेस।
 
 ```
-/context create production https://example.console.ves.volterra.io p12k3-your-api-token
+/context create production https://example-corp.console.ves.volterra.io p12k3-your-api-token
 ```
 
 ```
@@ -43,8 +43,8 @@ Context 'production' created. Use /context activate production to switch to it.
 
 ```
 ╭─ production ─────────────────────────────────────────────────╮
-│ XCSH_TENANT     example                                         │
-│ XCSH_API_URL    https://example.console.ves.volterra.io         │
+│ XCSH_TENANT     example-corp                                 │
+│ XCSH_API_URL    https://example-corp.console.ves.volterra.io │
 │ XCSH_API_TOKEN  ...oken                                      │
 │ Status          Connected (312ms)                            │
 ├─ Environment ────────────────────────────────────────────────┤
@@ -81,7 +81,7 @@ Context 'production' created. Use /context activate production to switch to it.
 ```
 
 ```
-  production           https://example.console.ves.volterra.io
+  production           https://example-corp.console.ves.volterra.io
 * staging              https://staging.console.ves.volterra.io
 ```
 
@@ -124,7 +124,7 @@ Context 'production' created. Use /context activate production to switch to it.
 संदर्भ अतिरिक्त एनवायरनमेंट वेरिएबल ले जा सकते हैं जो सक्रियण पर आपके सत्र में इंजेक्ट किए जाते हैं। प्रति-टेनेंट कॉन्फ़िगरेशन के लिए उपयोगी जो क्रेडेंशियल सेट का हिस्सा नहीं है।
 
 ```
-/context set CUSTOM_HEADER=x-example-trace
+/context set CUSTOM_HEADER=x-example-corp-trace
 /context set LOG_LEVEL=debug
 /context env list
 /context unset LOG_LEVEL
@@ -134,7 +134,7 @@ Context 'production' created. Use /context activate production to switch to it.
 
 ## टैब कंप्लीशन
 
-`/context ` टाइप करें और Tab दबाएं। ड्रॉपडाउन दिखाता है:
+`/context` टाइप करें और Tab दबाएं। ड्रॉपडाउन दिखाता है:
 
 1. **संदर्भ नाम** -- टेनेंट URL संकेतों के साथ, ताकि आप टेनेंट्स को अलग-अलग पहचान सकें
 2. **`-`** -- तब दिखाई देता है जब आपने पहले स्विच किया हो, दिखाता है कि आप किस संदर्भ पर पलटेंगे

--- a/docs/it/runtime-tools/context-command.md
+++ b/docs/it/runtime-tools/context-command.md
@@ -22,7 +22,7 @@ xcsh si connette a F5 Distributed Cloud tramite i **contesti** -- set di credenz
 Servono tre informazioni dalla console F5 XC: l'URL del tenant, un token API e opzionalmente un namespace.
 
 ```
-/context create production https://example.console.ves.volterra.io p12k3-your-api-token
+/context create production https://example-corp.console.ves.volterra.io p12k3-your-api-token
 ```
 
 ```
@@ -43,8 +43,8 @@ Oppure utilizzare la procedura guidata se si preferiscono i prompt passo-passo:
 
 ```
 ╭─ production ─────────────────────────────────────────────────╮
-│ XCSH_TENANT     example                                         │
-│ XCSH_API_URL    https://example.console.ves.volterra.io         │
+│ XCSH_TENANT     example-corp                                 │
+│ XCSH_API_URL    https://example-corp.console.ves.volterra.io │
 │ XCSH_API_TOKEN  ...oken                                      │
 │ Status          Connected (312ms)                            │
 ├─ Environment ────────────────────────────────────────────────┤
@@ -81,7 +81,7 @@ Eseguire `/context -` due volte riporta al punto di partenza.
 ```
 
 ```
-  production           https://example.console.ves.volterra.io
+  production           https://example-corp.console.ves.volterra.io
 * staging              https://staging.console.ves.volterra.io
 ```
 
@@ -124,7 +124,7 @@ Il completamento automatico con Tab suggerisce i nomi dei namespace dal tenant a
 I contesti possono contenere variabili d'ambiente aggiuntive che vengono iniettate nella sessione al momento dell'attivazione. Utile per configurazioni specifiche del tenant che non fanno parte del set di credenziali.
 
 ```
-/context set CUSTOM_HEADER=x-example-trace
+/context set CUSTOM_HEADER=x-example-corp-trace
 /context set LOG_LEVEL=debug
 /context env list
 /context unset LOG_LEVEL
@@ -134,7 +134,7 @@ Alias: `add` = `set`, `remove`/`clear` = `unset`.
 
 ## Completamento con Tab
 
-Digitare `/context ` e premere Tab. Il menu a discesa mostra:
+Digitare `/context` e premere Tab. Il menu a discesa mostra:
 
 1. **Nomi dei contesti** -- con indicazioni sull'URL del tenant, per distinguere i diversi tenant
 2. **`-`** -- appare quando si è già effettuato un cambio, mostra verso quale contesto si tornerebbe

--- a/docs/ja/runtime-tools/context-command.md
+++ b/docs/ja/runtime-tools/context-command.md
@@ -20,7 +20,7 @@ xcsh は **コンテキスト** を通じて F5 Distributed Cloud に接続し�
 F5 XC コンソールから次の3つの情報が必要です：テナント URL、API トークン、およびオプションでネームスペース。
 
 ```
-/context create production https://example.console.ves.volterra.io p12k3-your-api-token
+/context create production https://example-corp.console.ves.volterra.io p12k3-your-api-token
 ```
 
 ```
@@ -41,8 +41,8 @@ Context 'production' created. Use /context activate production to switch to it.
 
 ```
 ╭─ production ─────────────────────────────────────────────────╮
-│ XCSH_TENANT     example                                         │
-│ XCSH_API_URL    https://example.console.ves.volterra.io         │
+│ XCSH_TENANT     example-corp                                 │
+│ XCSH_API_URL    https://example-corp.console.ves.volterra.io │
 │ XCSH_API_TOKEN  ...oken                                      │
 │ Status          Connected (312ms)                            │
 ├─ Environment ────────────────────────────────────────────────┤
@@ -79,7 +79,7 @@ Context 'production' created. Use /context activate production to switch to it.
 ```
 
 ```
-  production           https://example.console.ves.volterra.io
+  production           https://example-corp.console.ves.volterra.io
 * staging              https://staging.console.ves.volterra.io
 ```
 
@@ -122,7 +122,7 @@ Context 'production' created. Use /context activate production to switch to it.
 コンテキストには追加の環境変数を設定でき、アクティブ化時にセッションに注入されます。認証情報セットには含まれないテナント固有の設定に便利です。
 
 ```
-/context set CUSTOM_HEADER=x-example-trace
+/context set CUSTOM_HEADER=x-example-corp-trace
 /context set LOG_LEVEL=debug
 /context env list
 /context unset LOG_LEVEL
@@ -132,7 +132,7 @@ Context 'production' created. Use /context activate production to switch to it.
 
 ## タブ補完
 
-`/context ` と入力して Tab キーを押します。ドロップダウンに以下が表示されます：
+`/context` と入力して Tab キーを押します。ドロップダウンに以下が表示されます：
 
 1. **コンテキスト名** -- テナント URL のヒント付きで、テナントを区別できます
 2. **`-`** -- 以前に切り替えたことがある場合に表示され、どのコンテキストに戻るかを示します

--- a/docs/ko/runtime-tools/context-command.md
+++ b/docs/ko/runtime-tools/context-command.md
@@ -20,7 +20,7 @@ xcsh는 **컨텍스트**를 통해 F5 Distributed Cloud에 연결합니다 -- �
 F5 XC 콘솔에서 세 가지가 필요합니다: 테넌트 URL, API 토큰, 그리고 선택적으로 네임스페이스입니다.
 
 ```
-/context create production https://example.console.ves.volterra.io p12k3-your-api-token
+/context create production https://example-corp.console.ves.volterra.io p12k3-your-api-token
 ```
 
 ```
@@ -41,8 +41,8 @@ Context 'production' created. Use /context activate production to switch to it.
 
 ```
 ╭─ production ─────────────────────────────────────────────────╮
-│ XCSH_TENANT     example                                         │
-│ XCSH_API_URL    https://example.console.ves.volterra.io         │
+│ XCSH_TENANT     example-corp                                 │
+│ XCSH_API_URL    https://example-corp.console.ves.volterra.io │
 │ XCSH_API_TOKEN  ...oken                                      │
 │ Status          Connected (312ms)                            │
 ├─ Environment ────────────────────────────────────────────────┤
@@ -79,7 +79,7 @@ Context 'production' created. Use /context activate production to switch to it.
 ```
 
 ```
-  production           https://example.console.ves.volterra.io
+  production           https://example-corp.console.ves.volterra.io
 * staging              https://staging.console.ves.volterra.io
 ```
 
@@ -122,7 +122,7 @@ Context 'production' created. Use /context activate production to switch to it.
 컨텍스트는 활성화 시 세션에 주입되는 추가 환경 변수를 포함할 수 있습니다. 자격 증명 세트에 포함되지 않는 테넌트별 구성에 유용합니다.
 
 ```
-/context set CUSTOM_HEADER=x-example-trace
+/context set CUSTOM_HEADER=x-example-corp-trace
 /context set LOG_LEVEL=debug
 /context env list
 /context unset LOG_LEVEL
@@ -132,7 +132,7 @@ Context 'production' created. Use /context activate production to switch to it.
 
 ## 탭 완성
 
-`/context `를 입력하고 Tab을 누르세요. 드롭다운에 다음이 표시됩니다:
+`/context`를 입력하고 Tab을 누르세요. 드롭다운에 다음이 표시됩니다:
 
 1. **컨텍스트 이름** -- 테넌트 URL 힌트가 포함되어 테넌트를 구분할 수 있습니다
 2. **`-`** -- 이전에 전환한 적이 있을 때 표시되며, 어떤 컨텍스트로 전환될지 보여줍니다

--- a/docs/pt-br/runtime-tools/context-command.md
+++ b/docs/pt-br/runtime-tools/context-command.md
@@ -22,7 +22,7 @@ O xcsh se conecta ao F5 Distributed Cloud por meio de **contextos** -- conjuntos
 Você precisa de três informações do seu console F5 XC: a URL do tenant, um token de API e, opcionalmente, um namespace.
 
 ```
-/context create production https://example.console.ves.volterra.io p12k3-your-api-token
+/context create production https://example-corp.console.ves.volterra.io p12k3-your-api-token
 ```
 
 ```
@@ -43,8 +43,8 @@ Ou use o assistente guiado se preferir prompts passo a passo:
 
 ```
 ╭─ production ─────────────────────────────────────────────────╮
-│ XCSH_TENANT     example                                         │
-│ XCSH_API_URL    https://example.console.ves.volterra.io         │
+│ XCSH_TENANT     example-corp                                 │
+│ XCSH_API_URL    https://example-corp.console.ves.volterra.io │
 │ XCSH_API_TOKEN  ...oken                                      │
 │ Status          Connected (312ms)                            │
 ├─ Environment ────────────────────────────────────────────────┤
@@ -81,7 +81,7 @@ Chamar `/context -` duas vezes retorna você ao ponto de partida.
 ```
 
 ```
-  production           https://example.console.ves.volterra.io
+  production           https://example-corp.console.ves.volterra.io
 * staging              https://staging.console.ves.volterra.io
 ```
 
@@ -124,7 +124,7 @@ O autocompletar com Tab oferece nomes de namespace do tenant ativo.
 Contextos podem carregar variáveis de ambiente extras que são injetadas na sua sessão ao serem ativados. Útil para configurações por tenant que não fazem parte do conjunto de credenciais.
 
 ```
-/context set CUSTOM_HEADER=x-example-trace
+/context set CUSTOM_HEADER=x-example-corp-trace
 /context set LOG_LEVEL=debug
 /context env list
 /context unset LOG_LEVEL
@@ -134,7 +134,7 @@ Aliases: `add` = `set`, `remove`/`clear` = `unset`.
 
 ## Autocompletar com Tab
 
-Digite `/context ` e pressione Tab. O menu suspenso mostra:
+Digite `/context` e pressione Tab. O menu suspenso mostra:
 
 1. **Nomes de contexto** -- com dicas de URL do tenant, para que você possa distinguir os tenants
 2. **`-`** -- aparece quando você já alternou antes, mostrando para qual contexto você voltaria

--- a/docs/th/runtime-tools/context-command.md
+++ b/docs/th/runtime-tools/context-command.md
@@ -22,7 +22,7 @@ xcsh เชื่อมต่อกับ F5 Distributed Cloud ผ่าน **co
 คุณต้องการข้อมูลสามอย่างจาก F5 XC คอนโซล ของคุณ: tenant URL, API token และ namespace (ไม่บังคับ)
 
 ```
-/context create production https://example.console.ves.volterra.io p12k3-your-api-token
+/context create production https://example-corp.console.ves.volterra.io p12k3-your-api-token
 ```
 
 ```
@@ -43,8 +43,8 @@ Context 'production' created. Use /context activate production to switch to it.
 
 ```
 ╭─ production ─────────────────────────────────────────────────╮
-│ XCSH_TENANT     example                                         │
-│ XCSH_API_URL    https://example.console.ves.volterra.io         │
+│ XCSH_TENANT     example-corp                                 │
+│ XCSH_API_URL    https://example-corp.console.ves.volterra.io │
 │ XCSH_API_TOKEN  ...oken                                      │
 │ Status          Connected (312ms)                            │
 ├─ Environment ────────────────────────────────────────────────┤
@@ -81,7 +81,7 @@ Context 'production' created. Use /context activate production to switch to it.
 ```
 
 ```
-  production           https://example.console.ves.volterra.io
+  production           https://example-corp.console.ves.volterra.io
 * staging              https://staging.console.ves.volterra.io
 ```
 
@@ -124,7 +124,7 @@ Tab completion จะแสดงชื่อ namespace จาก tenant ที�
 Contexts สามารถพกพา environment variables เพิ่มเติมที่จะถูกฉีดเข้าไปในเซสชันของคุณเมื่อเปิดใช้งาน มีประโยชน์สำหรับการกำหนดค่าต่อ tenant ที่ไม่ได้เป็นส่วนหนึ่งของชุดข้อมูลรับรอง
 
 ```
-/context set CUSTOM_HEADER=x-example-trace
+/context set CUSTOM_HEADER=x-example-corp-trace
 /context set LOG_LEVEL=debug
 /context env list
 /context unset LOG_LEVEL
@@ -134,7 +134,7 @@ Aliases: `add` = `set`, `remove`/`clear` = `unset`
 
 ## Tab Completion
 
-พิมพ์ `/context ` แล้วกด Tab dropdown จะแสดง:
+พิมพ์ `/context` แล้วกด Tab dropdown จะแสดง:
 
 1. **ชื่อ Context** -- พร้อม hints ของ tenant URL เพื่อให้คุณแยกแยะ tenants ได้
 2. **`-`** -- ปรากฏเมื่อคุณเคยสลับมาก่อน แสดง context ที่คุณจะสลับไป

--- a/docs/zh-cn/runtime-tools/context-command.md
+++ b/docs/zh-cn/runtime-tools/context-command.md
@@ -20,7 +20,7 @@ xcsh 通过**上下文**连接到 F5 Distributed Cloud -- 上下文是将租户 
 您需要从 F5 XC 控制台获取三项信息：租户 URL、API 令牌，以及可选的命名空间。
 
 ```
-/context create production https://example.console.ves.volterra.io p12k3-your-api-token
+/context create production https://example-corp.console.ves.volterra.io p12k3-your-api-token
 ```
 
 ```
@@ -41,8 +41,8 @@ Context 'production' created. Use /context activate production to switch to it.
 
 ```
 ╭─ production ─────────────────────────────────────────────────╮
-│ XCSH_TENANT     example                                         │
-│ XCSH_API_URL    https://example.console.ves.volterra.io         │
+│ XCSH_TENANT     example-corp                                 │
+│ XCSH_API_URL    https://example-corp.console.ves.volterra.io │
 │ XCSH_API_TOKEN  ...oken                                      │
 │ Status          Connected (312ms)                            │
 ├─ Environment ────────────────────────────────────────────────┤
@@ -79,7 +79,7 @@ Context 'production' created. Use /context activate production to switch to it.
 ```
 
 ```
-  production           https://example.console.ves.volterra.io
+  production           https://example-corp.console.ves.volterra.io
 * staging              https://staging.console.ves.volterra.io
 ```
 
@@ -122,7 +122,7 @@ Tab 补全会提供来自活跃租户的命名空间名称。
 上下文可以携带额外的环境变量，这些变量会在激活时注入您的会话中。适用于不属于凭据集但与特定租户相关的配置。
 
 ```
-/context set CUSTOM_HEADER=x-example-trace
+/context set CUSTOM_HEADER=x-example-corp-trace
 /context set LOG_LEVEL=debug
 /context env list
 /context unset LOG_LEVEL
@@ -132,7 +132,7 @@ Tab 补全会提供来自活跃租户的命名空间名称。
 
 ## Tab 补全
 
-输入 `/context ` 并按 Tab 键。下拉列表会显示：
+输入 `/context` 并按 Tab 键。下拉列表会显示：
 
 1. **上下文名称** -- 带有租户 URL 提示，便于区分不同租户
 2. **`-`** -- 在您之前切换过时出现，显示将要切换到的上下文

--- a/docs/zh-tw/runtime-tools/context-command.md
+++ b/docs/zh-tw/runtime-tools/context-command.md
@@ -20,7 +20,7 @@ xcsh 透過**環境上下文（contexts）**連線至 F5 Distributed Cloud——
 您需要從 F5 XC 控制台取得三項資訊：租戶 URL、API 令牌，以及選擇性的命名空間。
 
 ```
-/context create production https://example.console.ves.volterra.io p12k3-your-api-token
+/context create production https://example-corp.console.ves.volterra.io p12k3-your-api-token
 ```
 
 ```
@@ -41,8 +41,8 @@ Context 'production' created. Use /context activate production to switch to it.
 
 ```
 ╭─ production ─────────────────────────────────────────────────╮
-│ XCSH_TENANT     example                                         │
-│ XCSH_API_URL    https://example.console.ves.volterra.io         │
+│ XCSH_TENANT     example-corp                                 │
+│ XCSH_API_URL    https://example-corp.console.ves.volterra.io │
 │ XCSH_API_TOKEN  ...oken                                      │
 │ Status          Connected (312ms)                            │
 ├─ Environment ────────────────────────────────────────────────┤
@@ -79,7 +79,7 @@ Context 'production' created. Use /context activate production to switch to it.
 ```
 
 ```
-  production           https://example.console.ves.volterra.io
+  production           https://example-corp.console.ves.volterra.io
 * staging              https://staging.console.ves.volterra.io
 ```
 
@@ -122,7 +122,7 @@ Tab 自動補全會提供來自使用中租戶的命名空間名稱。
 環境上下文可以攜帶額外的環境變數，這些變數會在啟用時注入您的工作階段。這對於不屬於憑證集合一部分的租戶專屬設定非常有用。
 
 ```
-/context set CUSTOM_HEADER=x-example-trace
+/context set CUSTOM_HEADER=x-example-corp-trace
 /context set LOG_LEVEL=debug
 /context env list
 /context unset LOG_LEVEL
@@ -132,7 +132,7 @@ Tab 自動補全會提供來自使用中租戶的命名空間名稱。
 
 ## Tab 自動補全
 
-輸入 `/context ` 後按下 Tab 鍵。下拉選單會顯示：
+輸入 `/context` 後按下 Tab 鍵。下拉選單會顯示：
 
 1. **環境上下文名稱**——附帶租戶 URL 提示，讓您能區分不同租戶
 2. **`-`**——當您之前有切換過時出現，顯示您將切換至哪個環境上下文

--- a/packages/chat-ui/test/ReferenceChips.test.tsx
+++ b/packages/chat-ui/test/ReferenceChips.test.tsx
@@ -7,7 +7,7 @@ const doc: ChatReference = { kind: "doc", title: "WAF overview", url: "https://d
 const console: ChatReference = {
 	kind: "console",
 	title: "HTTP LB",
-	url: "https://example.console.ves.volterra.io/lb",
+	url: "https://example-corp.console.ves.volterra.io/lb",
 };
 
 test("renders a labelled Sources list with one chip per reference", () => {

--- a/packages/chat-ui/test/StatusBar.test.tsx
+++ b/packages/chat-ui/test/StatusBar.test.tsx
@@ -4,9 +4,9 @@ import { COLORS } from "../src";
 import { StatusBar } from "../src/components/StatusBar";
 
 test("renders the rounded context percentage and the session label", () => {
-	const { container } = render(<StatusBar contextPct={42.6} sessionLabel="example·prod" />);
+	const { container } = render(<StatusBar contextPct={42.6} sessionLabel="example-corp·prod" />);
 	expect(screen.getByText("43%")).toBeDefined();
-	expect(screen.getByText("example·prod")).toBeDefined();
+	expect(screen.getByText("example-corp·prod")).toBeDefined();
 	// The session segment is F5 red.
 	const session = container.querySelector(".seg-session") as HTMLElement;
 	expect(session.style.background).toContain(COLORS.f5Red);

--- a/packages/coding-agent/bench/extension-session.ts
+++ b/packages/coding-agent/bench/extension-session.ts
@@ -79,7 +79,7 @@ function spawnWorker(cmd: string[], port: number, extraEnv: Record<string, strin
 			...process.env,
 			XCSH_BROWSER_PROVIDER: "extension",
 			XCSH_SESSION_ID: "tab-bench",
-			XCSH_SESSION_TENANT: "example|staging",
+			XCSH_SESSION_TENANT: "example-corp|staging",
 			XCSH_BRIDGE_PORT: String(port),
 			// Isolate the tenant binding exactly as manager.ts does (undefined removes the var).
 			XCSH_API_URL: undefined,
@@ -204,7 +204,7 @@ async function measureAdoption(cmd: string[]): Promise<number> {
 		if (!(await waitBridgeReady(port, READY_DEADLINE_MS))) throw new Error("spare never became ready");
 		await sleep(ADOPT_SETTLE_MS); // ensure createAgentSession finished → fully warm
 		const t0 = Bun.nanoseconds();
-		(proc as { send(m: unknown): void }).send({ type: "bind", sessionId: "tab-bench", tenant: "example|staging" });
+		(proc as { send(m: unknown): void }).send({ type: "bind", sessionId: "tab-bench", tenant: "example-corp|staging" });
 		const timedOut = await Promise.race([bound.then(() => false), sleep(SESSION_DEADLINE_MS).then(() => true)]);
 		if (timedOut) throw new Error("bind never acked");
 		return (Bun.nanoseconds() - t0) / 1e6;

--- a/packages/coding-agent/bench/ttft.ts
+++ b/packages/coding-agent/bench/ttft.ts
@@ -73,7 +73,7 @@ async function sendProvision(sock: string): Promise<void> {
   const c = await Bun.connect({ unix: sock, socket: { data() {} } });
   // The manager's parseControlMsg requires a piped "tenant|env" string (isTenant);
   // a bare tenant is rejected and the provision silently dropped.
-  c.write(`${JSON.stringify({ type: "provision", sessionId: "tab-bench", tenant: "example|production" })}\n`);
+  c.write(`${JSON.stringify({ type: "provision", sessionId: "tab-bench", tenant: "example-corp|production" })}\n`);
   await sleep(50);
   c.end();
 }

--- a/packages/coding-agent/src/browser/chat-conformance.json
+++ b/packages/coding-agent/src/browser/chat-conformance.json
@@ -669,7 +669,7 @@
         "v": 1,
         "capturedAt": 1719000000000,
         "tabId": 7,
-        "url": "https://example.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
+        "url": "https://example-corp.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
         "path": "/web/namespaces/default/http_loadbalancers/lb1",
         "title": "lb1 — Distributed Cloud",
         "ax": {
@@ -707,7 +707,7 @@
           "v": 1,
           "capturedAt": 1719000000000,
           "tabId": 7,
-          "url": "https://example.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
+          "url": "https://example-corp.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
           "path": "/web/namespaces/default/http_loadbalancers/lb1",
           "title": "lb1 — Distributed Cloud",
           "ax": {
@@ -922,7 +922,7 @@
             "v": 1,
             "capturedAt": 1719000000000,
             "tabId": 7,
-            "url": "https://example.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
+            "url": "https://example-corp.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
             "path": "/web/namespaces/default/http_loadbalancers/lb1",
             "title": "lb1 — Distributed Cloud",
             "ax": {
@@ -967,7 +967,7 @@
             "v": 1,
             "capturedAt": 1719000000000,
             "tabId": 7,
-            "url": "https://example.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
+            "url": "https://example-corp.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
             "path": "/web/namespaces/default/http_loadbalancers/lb1",
             "title": "lb1 — Distributed Cloud",
             "ax": {
@@ -1027,7 +1027,7 @@
           "v": 2,
           "capturedAt": 1719000000000,
           "tabId": 7,
-          "url": "https://example.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
+          "url": "https://example-corp.console.ves.volterra.io/web/namespaces/default/http_loadbalancers/lb1",
           "path": "/web/namespaces/default/http_loadbalancers/lb1",
           "title": "lb1 — Distributed Cloud",
           "ax": {

--- a/packages/coding-agent/src/commands/manager.ts
+++ b/packages/coding-agent/src/commands/manager.ts
@@ -6,7 +6,7 @@
  * override `XCSH_MANAGER_SOCK`) for NDJSON control frames — one JSON object per
  * line — validated by the pure `manager-core` protocol:
  *
- *   {"type":"provision","sessionId":"tab-7","tenant":"example|staging"}
+ *   {"type":"provision","sessionId":"tab-7","tenant":"example-corp|staging"}
  *        → spawn a worker for that sessionId (idempotent). The registry is keyed
  *          on sessionId, so two tabs of the SAME tenant get two workers.
  *   {"type":"release","sessionId":"tab-7"}  → kill + forget that session's worker

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -773,7 +773,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	const filteredSkills = hasRead ? skills : [];
 
 	// contexts values match the tenant label derived from the API URL hostname (first DNS label).
-	// Example: https://example.console.ves.volterra.io → tenant "example" → contexts: ["example"]
+	// Example: https://example-corp.console.ves.volterra.io → tenant "example-corp" → contexts: ["example-corp"]
 	const contextName = context?.tenant;
 	const contextFilteredSkills = filteredSkills.filter(s => isApplicableToContext(s, contextName));
 

--- a/packages/coding-agent/test/context-add-wizard.test.ts
+++ b/packages/coding-agent/test/context-add-wizard.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@f5-sales-demo/xcsh/modes/components/context-add-wizard";
 
 const BASE_STATE = {
-	url: "https://example.console.ves.volterra.io",
+	url: "https://example-corp.console.ves.volterra.io",
 	token: "tok-abc-1234",
 	name: "prod",
 	namespace: "system",
@@ -16,11 +16,11 @@ const BASE_STATE = {
 
 describe("validateWizardUrl", () => {
 	it("accepts valid HTTPS URL", () => {
-		expect(validateWizardUrl("https://example.console.ves.volterra.io")).toBeNull();
+		expect(validateWizardUrl("https://example-corp.console.ves.volterra.io")).toBeNull();
 	});
 
 	it("rejects HTTP URL", () => {
-		expect(validateWizardUrl("http://example.console.ves.volterra.io")).not.toBeNull();
+		expect(validateWizardUrl("http://example-corp.console.ves.volterra.io")).not.toBeNull();
 	});
 
 	it("rejects non-URL string", () => {
@@ -41,7 +41,7 @@ describe("validateWizardUrl", () => {
 
 	it("accepts valid multi-label hostname", () => {
 		expect(validateWizardUrl("https://api.example.com")).toBeNull();
-		expect(validateWizardUrl("https://example.console.ves.volterra.io")).toBeNull();
+		expect(validateWizardUrl("https://example-corp.console.ves.volterra.io")).toBeNull();
 	});
 });
 
@@ -69,7 +69,7 @@ describe("buildWizardContext", () => {
 	it("builds the core fields and omits env when no credentials given", () => {
 		const ctx = buildWizardContext(BASE_STATE);
 		expect(ctx.name).toBe("prod");
-		expect(ctx.apiUrl).toBe("https://example.console.ves.volterra.io");
+		expect(ctx.apiUrl).toBe("https://example-corp.console.ves.volterra.io");
 		expect(ctx.apiToken).toBe("tok-abc-1234");
 		expect(ctx.defaultNamespace).toBe("system");
 		expect(ctx.env).toBeUndefined();
@@ -102,7 +102,7 @@ describe("buildWizardContext", () => {
 	});
 
 	it("preserves a password exactly (no trimming)", () => {
-		const ctx = buildWizardContext({ ...BASE_STATE, password: "  pad ded  " });
-		expect(ctx.env?.XCSH_CONSOLE_PASSWORD).toBe("  pad ded  ");
+		const ctx = buildWizardContext({ ...BASE_STATE, password: "  padded  " });
+		expect(ctx.env?.XCSH_CONSOLE_PASSWORD).toBe("  padded  ");
 	});
 });

--- a/packages/coding-agent/test/extension-session-contract.test.ts
+++ b/packages/coding-agent/test/extension-session-contract.test.ts
@@ -87,7 +87,7 @@ describe("extension session contract", () => {
 				XCSH_API_URL: process.env.XCSH_API_URL,
 			};
 			process.env.XCSH_SESSION_ID = "tab-7";
-			process.env.XCSH_SESSION_TENANT = "example|staging";
+			process.env.XCSH_SESSION_TENANT = "example-corp|staging";
 			delete process.env.XCSH_API_URL;
 		});
 		afterEach(() => {
@@ -102,7 +102,7 @@ describe("extension session contract", () => {
 		it("echoes XCSH_SESSION_ID as the tab-correlation sessionId and parses the tenant", () => {
 			const info = sessionInfoForWorker();
 			expect(info.sessionId).toBe("tab-7");
-			expect(info.tenant).toBe("example");
+			expect(info.tenant).toBe("example-corp");
 			expect(info.env).toBe("staging");
 			expect(info.apiUrl).toBeNull();
 			expect(info.contextBound).toBe(false);
@@ -121,10 +121,10 @@ describe("extension session contract", () => {
 		it("reports the bound identity after setWorkerIdentity (late-bind)", () => {
 			delete process.env.XCSH_SESSION_ID;
 			delete process.env.XCSH_SESSION_TENANT;
-			setWorkerIdentity("tab-7", "example|staging");
+			setWorkerIdentity("tab-7", "example-corp|staging");
 			const info = sessionInfoForWorker();
 			expect(info.sessionId).toBe("tab-7");
-			expect(info.tenant).toBe("example");
+			expect(info.tenant).toBe("example-corp");
 			expect(info.env).toBe("staging");
 		});
 	});
@@ -141,7 +141,7 @@ describe("extension session contract", () => {
 				XCSH_API_URL: process.env.XCSH_API_URL,
 			};
 			process.env.XCSH_SESSION_ID = "tab-7";
-			process.env.XCSH_SESSION_TENANT = "example|staging";
+			process.env.XCSH_SESSION_TENANT = "example-corp|staging";
 			delete process.env.XCSH_API_URL;
 			server = new BridgeServer();
 			// port 0 = OS-ephemeral; skipOriginCheck so a non-extension client may connect.
@@ -162,7 +162,7 @@ describe("extension session contract", () => {
 
 			expect(ack.type).toBe("hello_ack");
 			expect(ack.sessionId).toBe("tab-7");
-			expect(ack.tenant).toBe("example");
+			expect(ack.tenant).toBe("example-corp");
 			expect(ack.env).toBe("staging");
 			expect(ack.contextBound).toBe(false);
 			// The extension requires contract major 1 to bind + route (session-routing).

--- a/packages/coding-agent/test/helpers/bridge-probe.test.ts
+++ b/packages/coding-agent/test/helpers/bridge-probe.test.ts
@@ -9,7 +9,7 @@ import { probe } from "./bridge-probe";
  */
 describe("bridge probe() frame demultiplexing", () => {
 	it("returns hello_ack even when a telemetry span races ahead of it", async () => {
-		const ack = { type: "hello_ack", tenant: "example", env: "staging", sessionId: "tab-1" };
+		const ack = { type: "hello_ack", tenant: "example-corp", env: "staging", sessionId: "tab-1" };
 		const span = { type: "span", stage: "session_build", ms: 745, sid: "tab-1", cold: true };
 		const server = Bun.serve({
 			port: 0,
@@ -28,14 +28,14 @@ describe("bridge probe() frame demultiplexing", () => {
 		});
 		try {
 			const frame = await probe(server.port as number);
-			expect(frame).toMatchObject({ type: "hello_ack", tenant: "example", env: "staging" });
+			expect(frame).toMatchObject({ type: "hello_ack", tenant: "example-corp", env: "staging" });
 		} finally {
 			server.stop(true);
 		}
 	});
 
 	it("still returns hello_ack when it is the only frame", async () => {
-		const ack = { type: "hello_ack", tenant: "example", env: "prod", sessionId: "tab-2" };
+		const ack = { type: "hello_ack", tenant: "example-corp", env: "prod", sessionId: "tab-2" };
 		const server = Bun.serve({
 			port: 0,
 			fetch(req, srv) {
@@ -51,7 +51,7 @@ describe("bridge probe() frame demultiplexing", () => {
 		});
 		try {
 			const frame = await probe(server.port as number);
-			expect(frame).toMatchObject({ type: "hello_ack", tenant: "example", env: "prod" });
+			expect(frame).toMatchObject({ type: "hello_ack", tenant: "example-corp", env: "prod" });
 		} finally {
 			server.stop(true);
 		}

--- a/packages/coding-agent/test/internal-urls/user-profile-merge.test.ts
+++ b/packages/coding-agent/test/internal-urls/user-profile-merge.test.ts
@@ -86,9 +86,9 @@ describe("mergeProfile", () => {
 		});
 
 		it("does not overwrite existing worksFor", () => {
-			const target: UserProfile = { worksFor: { name: "Example" } };
+			const target: UserProfile = { worksFor: { name: "Example Corp" } };
 			mergeProfile(target, { worksFor: { name: "F5" } });
-			expect(target.worksFor?.name).toBe("Example");
+			expect(target.worksFor?.name).toBe("Example Corp");
 		});
 
 		it("sets birthPlace when target has none", () => {

--- a/packages/coding-agent/test/manager-core.test.ts
+++ b/packages/coding-agent/test/manager-core.test.ts
@@ -23,7 +23,7 @@ function reg(...recs: WorkerRec[]): Registry {
 }
 const W = (sessionId: string, port: number, lastSeen = 0): WorkerRec => ({
 	sessionId,
-	tenant: "example|production",
+	tenant: "example-corp|production",
 	port,
 	pid: 1,
 	lastSeen,
@@ -31,10 +31,10 @@ const W = (sessionId: string, port: number, lastSeen = 0): WorkerRec => ({
 
 describe("parseControlMsg", () => {
 	test("valid provision/release/status", () => {
-		expect(parseControlMsg({ type: "provision", sessionId: "tab-7", tenant: "example|staging" })).toEqual({
+		expect(parseControlMsg({ type: "provision", sessionId: "tab-7", tenant: "example-corp|staging" })).toEqual({
 			type: "provision",
 			sessionId: "tab-7",
-			tenant: "example|staging",
+			tenant: "example-corp|staging",
 		});
 		expect(parseControlMsg({ type: "release", sessionId: "tab-7" })).toEqual({ type: "release", sessionId: "tab-7" });
 		expect(parseControlMsg({ type: "status" })).toEqual({ type: "status" });
@@ -49,7 +49,7 @@ describe("parseControlMsg", () => {
 	});
 	test("rejects junk / missing fields / bad tenant", () => {
 		expect(parseControlMsg({ type: "provision", sessionId: "tab-7" })).toBeNull(); // no tenant
-		expect(parseControlMsg({ type: "provision", tenant: "example|staging" })).toBeNull(); // no sessionId
+		expect(parseControlMsg({ type: "provision", tenant: "example-corp|staging" })).toBeNull(); // no sessionId
 		expect(parseControlMsg({ type: "provision", sessionId: "tab-7", tenant: "no-pipe" })).toBeNull();
 		expect(parseControlMsg({ type: "release" })).toBeNull();
 		expect(parseControlMsg({ type: "nope", sessionId: "tab-7" })).toBeNull();
@@ -67,7 +67,7 @@ describe("parseControlMsg", () => {
 	});
 	test("rejects shutdown with an unknown/missing reason (fail closed)", () => {
 		expect(parseControlMsg({ type: "shutdown" })).toBeNull();
-		expect(parseControlMsg({ type: "shutdown", reason: "hax" })).toBeNull();
+		expect(parseControlMsg({ type: "shutdown", reason: "unknown" })).toBeNull();
 		expect(parseControlMsg({ type: "shutdown", reason: 3 })).toBeNull();
 	});
 });
@@ -224,7 +224,7 @@ describe("selectSpawnPort never probes a port it already handed out (#2463)", ()
 	function regWith(entries: Array<[string, number]>): Registry {
 		const reg: Registry = new Map();
 		for (const [sessionId, port] of entries) {
-			reg.set(sessionId, { sessionId, tenant: "example|staging", port, pid: 1000 + port, lastSeen: 0 });
+			reg.set(sessionId, { sessionId, tenant: "example-corp|staging", port, pid: 1000 + port, lastSeen: 0 });
 		}
 		return reg;
 	}

--- a/packages/coding-agent/test/manager-wait-diagnostics.test.ts
+++ b/packages/coding-agent/test/manager-wait-diagnostics.test.ts
@@ -76,15 +76,15 @@ describe("describePortScan (#2463 mode C)", () => {
 		// whether the second worker was absent, late, or answering another tenant.
 		const lines = describePortScan(
 			[
-				{ port: 19222, tenant: "example" },
+				{ port: 19222, tenant: "example-corp" },
 				{ port: 19223, tenant: "stale" },
 				{ port: 19224, error: "connect ECONNREFUSED 127.0.0.1:19224" },
 				{ port: 19225, error: "connect ECONNREFUSED 127.0.0.1:19225" },
 			],
-			"example",
+			"example-corp",
 		).join("\n");
 		expect(lines).toContain("19222");
-		expect(lines).toContain("example");
+		expect(lines).toContain("example-corp");
 		expect(lines).toContain("19223");
 		expect(lines).toContain("stale"); // a DIFFERENT tenant is the interesting case
 		expect(lines).toContain("ECONNREFUSED");
@@ -97,11 +97,11 @@ describe("describePortScan (#2463 mode C)", () => {
 				{ port: 19222, error: "ECONNREFUSED" },
 				{ port: 19223, error: "ECONNREFUSED" },
 			],
-			"example",
+			"example-corp",
 		).join("\n");
 		expect(allRefused).toContain("no port answered at all");
 
-		const wrongTenant = describePortScan([{ port: 19222, tenant: "other" }], "example").join("\n");
+		const wrongTenant = describePortScan([{ port: 19222, tenant: "other" }], "example-corp").join("\n");
 		expect(wrongTenant).not.toContain("no port answered at all");
 		expect(wrongTenant).toContain("matched 0 of 1");
 	});
@@ -113,7 +113,7 @@ describe("describePortScan reports who holds a silent port (#2463)", () => {
 	 * showed both workers provisioned on distinct ports and the FIRST one silent:
 	 *
 	 *     24800: no answer — ws error
-	 *     24801: tenant "example"
+	 *     24801: tenant "example-corp"
 	 *
 	 * and could go no further, because "no answer" covers two different defects. A dead
 	 * worker means something killed it; a live one that never answers means its bridge
@@ -125,10 +125,10 @@ describe("describePortScan reports who holds a silent port (#2463)", () => {
 		const lines = describePortScan(
 			[
 				{ port: 24800, error: "ws error", holders: [13389] },
-				{ port: 24801, tenant: "example" },
+				{ port: 24801, tenant: "example-corp" },
 				{ port: 24802, error: "ws error", holders: [] },
 			],
-			"example",
+			"example-corp",
 		).join("\n");
 		expect(lines).toContain("24800");
 		expect(lines).toContain("13389"); // alive but not answering — bridge/event-loop
@@ -136,21 +136,23 @@ describe("describePortScan reports who holds a silent port (#2463)", () => {
 	});
 
 	test("says so explicitly when a silent port has no holder — the worker is gone", () => {
-		const lines = describePortScan([{ port: 24800, error: "ECONNREFUSED", holders: [] }], "example").join("\n");
+		const lines = describePortScan([{ port: 24800, error: "ECONNREFUSED", holders: [] }], "example-corp").join("\n");
 		expect(lines).toContain("nothing holds it");
 		expect(lines).not.toContain("held by");
 	});
 
 	test("omits holder wording when the caller could not enumerate", () => {
 		// lsof absent, or the sweep failed: unknown must not read as "gone".
-		const lines = describePortScan([{ port: 24800, error: "ws error" }], "example").join("\n");
+		const lines = describePortScan([{ port: 24800, error: "ws error" }], "example-corp").join("\n");
 		expect(lines).not.toContain("nothing holds it");
 		expect(lines).not.toContain("held by");
 	});
 
 	test("an answering port needs no holder annotation", () => {
-		const lines = describePortScan([{ port: 24801, tenant: "example", holders: [13391] }], "example").join("\n");
-		expect(lines).toContain('tenant "example"');
+		const lines = describePortScan([{ port: 24801, tenant: "example-corp", holders: [13391] }], "example-corp").join(
+			"\n",
+		);
+		expect(lines).toContain('tenant "example-corp"');
 		expect(lines).not.toContain("13391"); // it answered; who holds it adds nothing
 	});
 });

--- a/packages/coding-agent/test/manager.int.test.ts
+++ b/packages/coding-agent/test/manager.int.test.ts
@@ -397,7 +397,7 @@ test("adopts a warm spare on provision, then replenishes the pool (XCSH_WORKER_P
 	// Pool fills at startup: exactly one spare is pre-warmed.
 	expect(await waitForStderr(getErr, "pre-warmed spare", 120)).toBe(true);
 
-	await send({ type: "provision", sessionId: "tab-7", tenant: "example|staging" });
+	await send({ type: "provision", sessionId: "tab-7", tenant: "example-corp|staging" });
 
 	// The provision ADOPTS the warm spare (IPC bind), not a cold-spawn.
 	expect(await waitForStderr(getErr, "adopted spare", 120)).toBe(true);
@@ -418,11 +418,11 @@ test("adopted spare's hello_ack advertises BOTH tenant AND env (#1872 contract)"
 	// filters any bridge missing tenant OR env and shows "No xcsh running".
 	const getErr = await startManagerWithPool("1");
 	expect(await waitForStderr(getErr, "pre-warmed spare", 120)).toBe(true);
-	await send({ type: "provision", sessionId: "tab-7", tenant: "example|staging" });
+	await send({ type: "provision", sessionId: "tab-7", tenant: "example-corp|staging" });
 	expect(await waitForStderr(getErr, "adopted spare", 120)).toBe(true);
-	const ack = await findFrame("example", "staging", 80);
+	const ack = await findFrame("example-corp", "staging", 80);
 	expect(ack).not.toBeNull();
-	expect(ack).toMatchObject({ tenant: "example", env: "staging" });
+	expect(ack).toMatchObject({ tenant: "example-corp", env: "staging" });
 	await send({ type: "release", sessionId: "tab-7" });
 }, 60_000);
 
@@ -468,7 +468,7 @@ test("graceful shutdown frame reaps spares, removes the socket + manager.json, e
 test("superseded shutdown LEAVES bound workers alive for re-adoption; manual reaps them (#1874 Task 6)", async () => {
 	const getErr = await startManagerWithPool("1");
 	expect(await waitForStderr(getErr, "pre-warmed spare", 120)).toBe(true);
-	await send({ type: "provision", sessionId: "tab-7", tenant: "example|staging" });
+	await send({ type: "provision", sessionId: "tab-7", tenant: "example-corp|staging" });
 	// Deterministic: wait for the manager's adopt log instead of a flaky WS bridge
 	// probe (findTenant) that depends on context-activation timing under CI load —
 	// the exact source of the ~50% CI flake at this line.
@@ -499,7 +499,7 @@ test("superseded shutdown LEAVES bound workers alive for re-adoption; manual rea
 		try {
 			const ack = await probe(port);
 			lastTenant = String(ack.tenant);
-			if (ack.tenant === "example") {
+			if (ack.tenant === "example-corp") {
 				survived = true;
 				break;
 			}
@@ -516,7 +516,7 @@ test("superseded shutdown LEAVES bound workers alive for re-adoption; manual rea
 		const holders = await pidsOnPort(port);
 		throw new Error(
 			[
-				`worker did not outlive its manager: no "example" ack on port ${port} within ${SURVIVAL_BUDGET_MS}ms`,
+				`worker did not outlive its manager: no "example-corp" ack on port ${port} within ${SURVIVAL_BUDGET_MS}ms`,
 				`  pids still holding the port: ${holders.length > 0 ? holders.join(", ") : "NONE (the worker is gone)"}`,
 				`  last ack tenant: ${lastTenant}`,
 				`  last probe error: ${lastProbeErr}`,
@@ -566,7 +566,7 @@ test("falls back to cold-spawn when the pool is disabled (XCSH_WORKER_POOL_SIZE=
 	await Bun.sleep(500);
 	expect(getErr()).not.toContain("pre-warmed spare");
 
-	await send({ type: "provision", sessionId: "tab-7", tenant: "example|staging" });
+	await send({ type: "provision", sessionId: "tab-7", tenant: "example-corp|staging" });
 
 	// With no spare to adopt, the provision cold-spawns (fallback path).
 	expect(await waitForStderr(getErr, "provisioned tab-7", 120)).toBe(true);
@@ -589,12 +589,12 @@ test("provision spawns a worker advertising the tenant; release reaps it", async
 	for (let i = 0; i < 60 && !fs.existsSync(sock); i++) await Bun.sleep(100);
 	expect(fs.existsSync(sock)).toBe(true);
 
-	await send({ type: "provision", sessionId: "tab-1", tenant: "example|staging" });
+	await send({ type: "provision", sessionId: "tab-1", tenant: "example-corp|staging" });
 
-	const port = await findTenant("example", 80);
+	const port = await findTenant("example-corp", 80);
 	expect(port).not.toBeNull();
 	// #1872: the cold-spawn frame must carry env too (not just tenant).
-	expect(await probe(port as number)).toMatchObject({ tenant: "example", env: "staging" });
+	expect(await probe(port as number)).toMatchObject({ tenant: "example-corp", env: "staging" });
 
 	// Release should reap the worker: the port stops answering the handshake.
 	await send({ type: "release", sessionId: "tab-1" });
@@ -616,11 +616,11 @@ test("provision spawns one worker PER sessionId (two same-tenant tabs → two wo
 
 	// Two tabs of the SAME tenant, keyed by distinct sessionIds. The manager keys
 	// its registry on sessionId, not tenant, so each tab gets its OWN worker on its
-	// own range port — even though both advertise the same tenant "example".
-	await send({ type: "provision", sessionId: "tab-101", tenant: "example|staging" });
-	await send({ type: "provision", sessionId: "tab-102", tenant: "example|staging" });
+	// own range port — even though both advertise the same tenant "example-corp".
+	await send({ type: "provision", sessionId: "tab-101", tenant: "example-corp|staging" });
+	await send({ type: "provision", sessionId: "tab-102", tenant: "example-corp|staging" });
 
-	// Both workers should come up on distinct range ports, both advertising "example".
+	// Both workers should come up on distinct range ports, both advertising "example-corp".
 	// Keep what each port LAST said instead of discarding it: a bare count cannot
 	// separate "the second worker never spawned" from "it spawned late" from "it
 	// answered under another tenant", and CI has reported this as `Received: 1`
@@ -633,7 +633,7 @@ test("provision spawns one worker PER sessionId (two same-tenant tabs → two wo
 				try {
 					const a = await probe(p);
 					lastSeen.set(p, { tenant: String(a.tenant) });
-					if (a.tenant === "example") ports.add(p);
+					if (a.tenant === "example-corp") ports.add(p);
 				} catch (e) {
 					lastSeen.set(p, { error: e instanceof Error ? e.message : String(e) });
 				}
@@ -650,14 +650,14 @@ test("provision spawns one worker PER sessionId (two same-tenant tabs → two wo
 		for (const p of RANGE) holdersByPort.set(p, await pidsOnPort(p));
 		throw new Error(
 			[
-				`expected 2 distinct range ports advertising "example", saw ${ports.size}`,
+				`expected 2 distinct range ports advertising "example-corp", saw ${ports.size}`,
 				...describePortScan(
 					RANGE.map(p => ({
 						port: p,
 						...(lastSeen.get(p) ?? { error: "never probed" }),
 						holders: holdersByPort.get(p),
 					})),
-					"example",
+					"example-corp",
 				),
 				...describeManagerCensus(getErr()),
 			].join("\n"),
@@ -839,7 +839,7 @@ test("a STALE control socket left by a crashed manager is reclaimed on next star
 
 test("cold spawn emits manager_provision + worker_boot spans with cold=true", async () => {
 	const getErr = await startManagerWithPool("0"); // no spares -> cold spawn
-	await send({ type: "provision", sessionId: "tab-501", tenant: "example|production" });
+	await send({ type: "provision", sessionId: "tab-501", tenant: "example-corp|production" });
 	const port = await waitForPort(getErr, /provisioned tab-501 .* on port (\d+)/);
 
 	// Wait for the STAGES asserted below, not for a span count (#2364).
@@ -869,7 +869,7 @@ test("warm adopt emits worker_boot span with cold=false", async () => {
 	// above already wait here; this one did not.
 	expect(await waitForStderr(getErr, "pre-warmed spare", 120)).toBe(true);
 
-	await send({ type: "provision", sessionId: "tab-777", tenant: "example|production" });
+	await send({ type: "provision", sessionId: "tab-777", tenant: "example-corp|production" });
 	const port = await waitForPort(getErr, /adopted spare pid \d+ on port (\d+) as tab-777/);
 
 	// The wait must cover activateTenantContext, which runs inside the bind closure
@@ -889,7 +889,7 @@ test("a manager on a STALE binary refuses the next provision (draining) and step
 	await startManager({ XCSH_FORCE_STALE: "1" });
 	// Spawning would ENOENT on the deleted binary → the provision is refused with the
 	// existing `draining` contract so the host retries the successor manager.
-	const reply = await request({ type: "provision", sessionId: "tab-1", tenant: "example|staging" });
+	const reply = await request({ type: "provision", sessionId: "tab-1", tenant: "example-corp|staging" });
 	expect(reply).toEqual({ type: "draining" });
 	// gracefulShutdown("updated") removes the socket + manager.json and exits.
 	let gone = false;
@@ -906,7 +906,7 @@ test("a manager on a STALE binary refuses the next provision (draining) and step
 test("a HEALTHY manager (present binary) never recycles — provisions normally, stays up", async () => {
 	await startManager(); // dev binary present → not stale
 	// A normal provision writes NO control reply (only draining does) → request times out → null.
-	const reply = await request({ type: "provision", sessionId: "tab-1", tenant: "example|staging" }, 1500);
+	const reply = await request({ type: "provision", sessionId: "tab-1", tenant: "example-corp|staging" }, 1500);
 	expect(reply).toBeNull(); // NOT draining — the manager served it
 	// Still alive: socket persists and the hello handshake still answers.
 	expect(fs.existsSync(sock)).toBe(true);

--- a/packages/coding-agent/test/native-host-launch.int.test.ts
+++ b/packages/coding-agent/test/native-host-launch.int.test.ts
@@ -118,7 +118,7 @@ test("Chrome-style launch of the installed wrapper reaches the relay and ensures
 	});
 
 	const stdin = host.stdin as import("bun").FileSink;
-	stdin.write(encodeNm({ type: "provision", tenantKey: "example|staging" }));
+	stdin.write(encodeNm({ type: "provision", tenantKey: "example-corp|staging" }));
 	stdin.flush();
 
 	let up = false;

--- a/packages/coding-agent/test/native-host.int.test.ts
+++ b/packages/coding-agent/test/native-host.int.test.ts
@@ -142,7 +142,7 @@ test("chrome-host ensures the manager and relays a provision frame", async () =>
 	});
 
 	const stdin = host.stdin as import("bun").FileSink;
-	stdin.write(encodeNm({ type: "provision", sessionId: "tab-1", tenant: "example|staging" }));
+	stdin.write(encodeNm({ type: "provision", sessionId: "tab-1", tenant: "example-corp|staging" }));
 	stdin.flush();
 
 	let up = false;
@@ -187,7 +187,7 @@ test("chrome-host supersedes an OLDER running manager and takes over (#1874)", a
 		stderr: "ignore",
 	});
 	const stdin = host.stdin as import("bun").FileSink;
-	stdin.write(encodeNm({ type: "provision", sessionId: "tab-1", tenant: "example|staging" }));
+	stdin.write(encodeNm({ type: "provision", sessionId: "tab-1", tenant: "example-corp|staging" }));
 	stdin.flush();
 
 	let superseded = false;

--- a/packages/coding-agent/test/profile-hint-and-checks.test.ts
+++ b/packages/coding-agent/test/profile-hint-and-checks.test.ts
@@ -50,13 +50,13 @@ describe("system-prompt userProfile hint", () => {
 			userProfile: {
 				name: "Ada Lovelace",
 				role: "Mathematician",
-				org: "Example",
+				org: "Example Corp",
 			},
 		});
 		expect(rendered).toContain("Primary Human");
 		expect(rendered).toContain("Ada Lovelace");
 		expect(rendered).toContain("Mathematician");
-		expect(rendered).toContain("Example");
+		expect(rendered).toContain("Example Corp");
 		expect(rendered).toContain("xcsh://user");
 	});
 
@@ -84,7 +84,7 @@ describe("system-prompt userProfile hint", () => {
 		const template = await Bun.file(systemPromptPath).text();
 		const rendered = prompt.render(template, {
 			...baseRenderContext,
-			userProfile: { name: "Ada Lovelace", role: "Mathematician", org: "Example" },
+			userProfile: { name: "Ada Lovelace", role: "Mathematician", org: "Example Corp" },
 		});
 		expect(rendered).toContain("MUST** read");
 		expect(rendered).toContain("PII");

--- a/packages/coding-agent/test/references-event.test.ts
+++ b/packages/coding-agent/test/references-event.test.ts
@@ -63,7 +63,9 @@ describe("referencesEventFor", () => {
 	});
 
 	test("classifies a tenant console deep link as console, not doc", () => {
-		const ev = referencesEventFor(messageEnd(cited("Open https://example.console.ves.volterra.io/lb to confirm.")));
+		const ev = referencesEventFor(
+			messageEnd(cited("Open https://example-corp.console.ves.volterra.io/lb to confirm.")),
+		);
 		expect(ev?.references[0].kind).toBe("console");
 	});
 });

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -413,7 +413,7 @@ describe("buildContainmentFence — adversarial review of #2624", () => {
 	it("denies other filesystem roots, as a second Windows drive would be", () => {
 		const home = realTmp("otherroots");
 		const workspace = path.join(home, "w");
-		const otherRoot = realTmp("driveD");
+		const otherRoot = realTmp("drive-d");
 		fs.mkdirSync(workspace, { recursive: true });
 		fs.mkdirSync(path.join(otherRoot, "customerB"), { recursive: true });
 
@@ -931,7 +931,7 @@ describe("buildContainmentFence — isolation does not depend on how deep the wo
 	it("denies a cousin tenant, not just an immediate sibling", () => {
 		const home = realTmp("cousinhome");
 		const container = realTmp("tenants");
-		const workspace = path.join(container, "example", "repo");
+		const workspace = path.join(container, "example-corp", "repo");
 		fs.mkdirSync(workspace, { recursive: true });
 		fs.mkdirSync(path.join(container, "globex", "repo"), { recursive: true });
 		const fence = buildContainmentFence({ workspace, home });
@@ -939,7 +939,7 @@ describe("buildContainmentFence — isolation does not depend on how deep the wo
 		// The case that exists for this fence, one level deeper than the original rule reached.
 		for (const access of ["read", "write"] as const) {
 			expect(fenceVerdict(fence, path.join(container, "globex", "repo", "secrets.tf"), access)).toBe("deny");
-			expect(fenceVerdict(fence, path.join(container, "example", "other-repo", "x"), access)).toBe("deny");
+			expect(fenceVerdict(fence, path.join(container, "example-corp", "other-repo", "x"), access)).toBe("deny");
 			expect(fenceVerdict(fence, path.join(container, "loose-file.txt"), access)).toBe("deny");
 		}
 		// …and the workspace itself still works, or the fence is useless.

--- a/packages/coding-agent/test/session-context-binding.test.ts
+++ b/packages/coding-agent/test/session-context-binding.test.ts
@@ -38,9 +38,9 @@ describe("resolveAutoBind — extension", () => {
 		expect(
 			resolveAutoBind({
 				kind: "extension",
-				availableContexts: ["example", "globex"],
+				availableContexts: ["example-corp", "globex"],
 				tenantKey: "globex|production",
-				contextTenantKeys: { example: "example|staging", globex: "globex|production" },
+				contextTenantKeys: { "example-corp": "example-corp|staging", globex: "globex|production" },
 			}),
 		).toEqual({ kind: "bind", contextName: "globex" });
 	});
@@ -48,14 +48,14 @@ describe("resolveAutoBind — extension", () => {
 		expect(
 			resolveAutoBind({
 				kind: "extension",
-				availableContexts: ["example"],
+				availableContexts: ["example-corp"],
 				tenantKey: "globex|production",
-				contextTenantKeys: { example: "example|staging" },
+				contextTenantKeys: { "example-corp": "example-corp|staging" },
 			}),
 		).toEqual({ kind: "needsSelection" });
 	});
 	test("no tenant key → none", () => {
-		expect(resolveAutoBind({ kind: "extension", availableContexts: ["example"], tenantKey: null })).toEqual({
+		expect(resolveAutoBind({ kind: "extension", availableContexts: ["example-corp"], tenantKey: null })).toEqual({
 			kind: "none",
 		});
 	});
@@ -119,16 +119,16 @@ describe("activateTenantContext", () => {
 	});
 
 	test("activates the context whose apiUrl matches the tenant key", async () => {
-		// Create a stored context for tenant "example" on production.
+		// Create a stored context for tenant "example-corp" on production.
 		await ContextService.instance.createContext({
-			name: "example-prod",
-			apiUrl: "https://example.console.ves.volterra.io/api",
+			name: "example-corp-prod",
+			apiUrl: "https://example-corp.console.ves.volterra.io/api",
 			apiToken: "t",
 			defaultNamespace: "system",
 		});
-		const activated = await activateTenantContext("example|production");
+		const activated = await activateTenantContext("example-corp|production");
 		expect(activated).toBe(true);
-		expect(ContextService.instance.getStatus().activeContextName).toBe("example-prod");
+		expect(ContextService.instance.getStatus().activeContextName).toBe("example-corp-prod");
 	});
 
 	test("returns false and leaves unbound when no context matches", async () => {

--- a/packages/coding-agent/test/xcsh-context-command.test.ts
+++ b/packages/coding-agent/test/xcsh-context-command.test.ts
@@ -257,7 +257,7 @@ describe("/context slash command handler", () => {
 	});
 
 	it("/context list shows env-only entry when XCSH_API_URL is set", async () => {
-		process.env.XCSH_API_URL = "https://example.console.ves.volterra.io";
+		process.env.XCSH_API_URL = "https://example-corp.console.ves.volterra.io";
 		process.env.XCSH_API_TOKEN = "FAKE-TOKEN";
 		const service = ContextService.init(xcshConfigDir);
 		await service.loadActive();
@@ -268,7 +268,7 @@ describe("/context slash command handler", () => {
 		expect(ctx.messages[0].type).toBe("status");
 		const plain = ctx.messages[0].text.replace(/\x1b\[[0-9;]*m/g, "");
 		expect(plain).toContain("contexts");
-		expect(plain).toContain("example");
+		expect(plain).toContain("example-corp");
 		expect(plain).toContain("via env vars");
 	});
 

--- a/packages/coding-agent/test/xcsh-context-display.test.ts
+++ b/packages/coding-agent/test/xcsh-context-display.test.ts
@@ -18,8 +18,8 @@ function status(overrides: Partial<ContextStatus> = {}): ContextStatus {
 
 describe("formatContextLabel", () => {
 	it("uses tenant and namespace when both are present", () => {
-		expect(formatContextLabel(status({ activeContextTenant: "example", activeContextNamespace: "prod" }))).toBe(
-			"example:prod",
+		expect(formatContextLabel(status({ activeContextTenant: "example-corp", activeContextNamespace: "prod" }))).toBe(
+			"example-corp:prod",
 		);
 	});
 
@@ -32,8 +32,8 @@ describe("formatContextLabel", () => {
 	});
 
 	it("prefers tenant over name when both are present", () => {
-		expect(formatContextLabel(status({ activeContextTenant: "example", activeContextName: "my-context" }))).toBe(
-			"example:default",
+		expect(formatContextLabel(status({ activeContextTenant: "example-corp", activeContextName: "my-context" }))).toBe(
+			"example-corp:default",
 		);
 	});
 
@@ -44,24 +44,24 @@ describe("formatContextLabel", () => {
 	it("appends warning icon when token is expiring", () => {
 		expect(
 			formatContextLabel(
-				status({ activeContextTenant: "example", activeContextNamespace: "prod", tokenHealth: "expiring" }),
+				status({ activeContextTenant: "example-corp", activeContextNamespace: "prod", tokenHealth: "expiring" }),
 			),
-		).toBe("example:prod ⚠");
+		).toBe("example-corp:prod ⚠");
 	});
 
 	it("appends warning icon when token is expired", () => {
 		expect(
 			formatContextLabel(
-				status({ activeContextTenant: "example", activeContextNamespace: "prod", tokenHealth: "expired" }),
+				status({ activeContextTenant: "example-corp", activeContextNamespace: "prod", tokenHealth: "expired" }),
 			),
-		).toBe("example:prod ⚠");
+		).toBe("example-corp:prod ⚠");
 	});
 
 	it("no suffix when token health is ok", () => {
 		expect(
 			formatContextLabel(
-				status({ activeContextTenant: "example", activeContextNamespace: "prod", tokenHealth: "ok" }),
+				status({ activeContextTenant: "example-corp", activeContextNamespace: "prod", tokenHealth: "ok" }),
 			),
-		).toBe("example:prod");
+		).toBe("example-corp:prod");
 	});
 });

--- a/packages/coding-agent/test/xcsh-env.test.ts
+++ b/packages/coding-agent/test/xcsh-env.test.ts
@@ -53,19 +53,19 @@ describe("xcsh-env", () => {
 		});
 
 		it("returns false when only XCSH_API_URL is set (URL alone is not an override)", () => {
-			process.env[XCSH_API_URL] = "https://example.console.ves.volterra.io";
+			process.env[XCSH_API_URL] = "https://example-corp.console.ves.volterra.io";
 			expect(hasEnvOverride()).toBe(false);
 		});
 	});
 
 	describe("sessionKeyFromUrl", () => {
 		it("keys staging and production of the same tenant distinctly", () => {
-			expect(sessionKeyFromUrl("https://example.staging.volterra.us/web/home")).toEqual({
-				tenant: "example",
+			expect(sessionKeyFromUrl("https://example-corp.staging.volterra.us/web/home")).toEqual({
+				tenant: "example-corp",
 				env: "staging",
 			});
-			expect(sessionKeyFromUrl("https://example.console.ves.volterra.io/web/x")).toEqual({
-				tenant: "example",
+			expect(sessionKeyFromUrl("https://example-corp.console.ves.volterra.io/web/x")).toEqual({
+				tenant: "example-corp",
 				env: "production",
 			});
 		});
@@ -84,20 +84,20 @@ describe("xcsh-env", () => {
 		// on every cell — a discovered worker's key must match the tab's key, or the
 		// panel gate shows "No xcsh running for this tenant". Change one, change both.
 		const GOLDEN: Array<[string | undefined, { tenant: string; env: "production" | "staging" } | null]> = [
-			["https://example.console.ves.volterra.io/web/x", { tenant: "example", env: "production" }],
-			["https://example.staging.volterra.us/web/home", { tenant: "example", env: "staging" }],
+			["https://example-corp.console.ves.volterra.io/web/x", { tenant: "example-corp", env: "production" }],
+			["https://example-corp.staging.volterra.us/web/home", { tenant: "example-corp", env: "staging" }],
 			["https://f5-amer-ent.console.ves.volterra.io/web/home?iss=x", { tenant: "f5-amer-ent", env: "production" }],
 			[
-				"https://login.ves.volterra.io/auth/realms/example-abc123/protocol/openid-connect/auth",
-				{ tenant: "example", env: "production" },
+				"https://login.ves.volterra.io/auth/realms/example-corp-abc123/protocol/openid-connect/auth",
+				{ tenant: "example-corp", env: "production" },
 			],
 			[
-				"https://login-staging.volterra.us/auth/realms/example-x/protocol/openid-connect/auth",
-				{ tenant: "example", env: "staging" },
+				"https://login-staging.volterra.us/auth/realms/example-corp-x/protocol/openid-connect/auth",
+				{ tenant: "example-corp", env: "staging" },
 			],
 			["https://console.ves.volterra.io/web/devportal/domain", null],
 			["https://login.ves.volterra.io/auth/realms/volterra/protocol/openid-connect/auth", null],
-			["https://example.ves.volterra.io", null],
+			["https://example-corp.ves.volterra.io", null],
 			["https://192.168.1.10/web/home", null],
 			["https://api.gateway.internal", null],
 			[undefined, null],
@@ -119,16 +119,16 @@ describe("xcsh-env", () => {
 			// apiUrl parses → apiUrl wins (the live/active context is authoritative)
 			[
 				"console apiUrl + tenantKey → apiUrl wins",
-				"https://example.console.ves.volterra.io",
-				"example|production",
-				"example",
+				"https://example-corp.console.ves.volterra.io",
+				"example-corp|production",
+				"example-corp",
 				"production",
 			],
 			[
 				"staging apiUrl → staging env",
-				"https://example.staging.volterra.us/web/home",
-				"example|production",
-				"example",
+				"https://example-corp.staging.volterra.us/web/home",
+				"example-corp|production",
+				"example-corp",
 				"staging",
 			],
 			[
@@ -141,33 +141,33 @@ describe("xcsh-env", () => {
 			// apiUrl present but UNPARSEABLE → fall back to tenantKey (the #1872 fix)
 			[
 				"non-console apiUrl + tenantKey → FALLBACK",
-				"https://example.ves.volterra.io",
-				"example|production",
-				"example",
+				"https://example-corp.ves.volterra.io",
+				"example-corp|production",
+				"example-corp",
 				"production",
 			],
 			[
 				"bare console host + tenantKey → FALLBACK",
 				"https://console.ves.volterra.io",
-				"example|production",
-				"example",
+				"example-corp|production",
+				"example-corp",
 				"production",
 			],
 			[
 				"unparseable apiUrl + staging tenantKey → FALLBACK",
 				"https://api.gateway.internal",
-				"example|staging",
-				"example",
+				"example-corp|staging",
+				"example-corp",
 				"staging",
 			],
 			// no apiUrl → tenantKey (contextless bound worker / adopted spare)
-			["no apiUrl + tenantKey", null, "example|production", "example", "production"],
+			["no apiUrl + tenantKey", null, "example-corp|production", "example-corp", "production"],
 			// nothing known → null (unbound spare / interactive no-context)
 			["no apiUrl + no tenantKey → null", null, null, null, null],
 			["unparseable apiUrl + no tenantKey → null", "https://api.gateway.internal", null, null, null],
 			["unparseable apiUrl + empty tenantKey → null", "https://api.gateway.internal", "", null, null],
 			// malformed tenantKey (missing env half) → tenant only, env null
-			["tenantKey without env half → tenant only", null, "example", "example", null],
+			["tenantKey without env half → tenant only", null, "example-corp", "example-corp", null],
 		];
 		it.each(M)("%s", (_label, apiUrl, tenantKey, tenant, env) => {
 			expect(deriveTenantEnv(apiUrl, tenantKey)).toEqual({ tenant, env });
@@ -176,11 +176,11 @@ describe("xcsh-env", () => {
 
 	describe("deriveTenantFromUrl", () => {
 		it("returns the first hostname label for a normal F5 XC URL", () => {
-			expect(deriveTenantFromUrl("https://example.console.ves.volterra.io")).toBe("example");
+			expect(deriveTenantFromUrl("https://example-corp.console.ves.volterra.io")).toBe("example-corp");
 		});
 
 		it("lowercases mixed-case labels", () => {
-			expect(deriveTenantFromUrl("https://Example-01.console.example.com")).toBe("example-01");
+			expect(deriveTenantFromUrl("https://Example-Corp-01.console.example.com")).toBe("example-corp-01");
 		});
 
 		it("returns a 63-character label as-is", () => {
@@ -194,15 +194,15 @@ describe("xcsh-env", () => {
 		});
 
 		it("returns null for labels containing underscores", () => {
-			expect(deriveTenantFromUrl("https://example_01.example.com")).toBeNull();
+			expect(deriveTenantFromUrl("https://example_corp_01.example.com")).toBeNull();
 		});
 
 		it("returns null for labels with a leading hyphen", () => {
-			expect(deriveTenantFromUrl("https://-example.example.com")).toBeNull();
+			expect(deriveTenantFromUrl("https://-example-corp.example.com")).toBeNull();
 		});
 
 		it("returns null for labels with a trailing hyphen", () => {
-			expect(deriveTenantFromUrl("https://example-.example.com")).toBeNull();
+			expect(deriveTenantFromUrl("https://example-corp-.example.com")).toBeNull();
 		});
 
 		it("returns null for dotless hostnames (including localhost)", () => {

--- a/packages/office-pane/test/adapt.test.ts
+++ b/packages/office-pane/test/adapt.test.ts
@@ -160,7 +160,7 @@ describe("turnsToMessages", () => {
 	test("a done assistant turn carries its cited references onto the row", () => {
 		const refs = [
 			{ kind: "doc" as const, title: "WAF docs", url: "https://docs.cloud.f5.com/waf" },
-			{ kind: "console" as const, title: "HTTP LB", url: "https://example.console.ves.volterra.io/lb" },
+			{ kind: "console" as const, title: "HTTP LB", url: "https://example-corp.console.ves.volterra.io/lb" },
 		];
 		const turns: Turn[] = [user("u-1", "how?"), assistant("c-1", "See the docs.", { references: refs })];
 		const msgs = turnsToMessages({ turns, status: "done" });

--- a/packages/office-pane/test/bridge-discovery.test.ts
+++ b/packages/office-pane/test/bridge-discovery.test.ts
@@ -117,14 +117,14 @@ describe("pickBridge()", () => {
 	});
 
 	it("(3) filters by tenant when opts.tenant is specified", () => {
-		const a = makeBridge({ port: 19222, tenant: "example" });
+		const a = makeBridge({ port: 19222, tenant: "example-corp" });
 		const b = makeBridge({ port: 19223, tenant: "other" });
-		const result = pickBridge([a, b], { tenant: "example" });
+		const result = pickBridge([a, b], { tenant: "example-corp" });
 		expect(result?.port).toBe(19222);
 	});
 
 	it("(4) returns undefined when tenant filter matches nothing", () => {
-		const a = makeBridge({ port: 19222, tenant: "example" });
+		const a = makeBridge({ port: 19222, tenant: "example-corp" });
 		expect(pickBridge([a], { tenant: "nobody" })).toBeUndefined();
 	});
 
@@ -167,8 +167,8 @@ describe("pickBridge()", () => {
 	// --- requireServeKind filter (issue #2201 port-collision correctness core) ---
 
 	it("(10) requireServeKind:'office' rejects a browser-kind bridge (even with matching tenant)", () => {
-		const browser = makeBridge({ port: 19342, serveKind: "browser", tenant: "example" });
-		expect(pickBridge([browser], { requireServeKind: "office", tenant: "example" })).toBeUndefined();
+		const browser = makeBridge({ port: 19342, serveKind: "browser", tenant: "example-corp" });
+		expect(pickBridge([browser], { requireServeKind: "office", tenant: "example-corp" })).toBeUndefined();
 	});
 
 	it("(11) requireServeKind:'office' rejects a serveKind:null bridge (stale/legacy → fail-safe)", () => {

--- a/plugin-discovery-matrix/fixtures/deal-self-describing.json
+++ b/plugin-discovery-matrix/fixtures/deal-self-describing.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
-    "dealId": "deal-example-dc-modernization-2026",
-    "accountName": "Example Corporation",
+    "dealId": "deal-example-corp-dc-modernization-2026",
+    "accountName": "Example Corp",
     "dealName": "DC Modernization Phase 2",
     "dealStatus": "Qualified",
     "closeDate": "2026-06-30",
@@ -225,8 +225,8 @@
     },
     "partner": {
       "name": "PartnerCo",
-      "whyAnything": "Example needs implementation support — their platform team is at capacity with the Kubernetes migration",
-      "whyThisPartner": "PartnerCo has 3 certified F5 engineers and prior Example relationship from the load balancer deployment",
+      "whyAnything": "Example Corp needs implementation support — their platform team is at capacity with the Kubernetes migration",
+      "whyThisPartner": "PartnerCo has 3 certified F5 engineers and prior Example Corp relationship from the load balancer deployment",
       "whyNow": "PartnerCo has a team available in June; if we wait, they're committed to another project through Q4"
     }
   },
@@ -273,7 +273,7 @@
     }
   ],
   "salesStrategy": {
-    "differentiatedValueProposition": "F5 is the only vendor that provides unified application and API security with native Kubernetes integration — eliminating the need to deploy separate tools for north-south and east-west API protection. This directly addresses Example's MTTR target by providing a single pane of glass for API discovery, threat detection, and incident response across all 3 data centers.",
+    "differentiatedValueProposition": "F5 is the only vendor that provides unified application and API security with native Kubernetes integration — eliminating the need to deploy separate tools for north-south and east-west API protection. This directly addresses Example Corp's MTTR target by providing a single pane of glass for API discovery, threat detection, and incident response across all 3 data centers.",
     "winStrategy": "Lead with the pain: $400K SLA penalties and board mandate create urgency. Differentiate on Kubernetes-native integration (Vendor A can't match this). Use the POC to prove MTTR improvement quantitatively. Get EB alignment on business case before architecture review board. Neutralize Vendor A's price advantage by quantifying the cost of deploying and managing a separate API discovery tool."
   },
   "closePlan": {

--- a/plugin-discovery-matrix/fixtures/deal-thin.json
+++ b/plugin-discovery-matrix/fixtures/deal-thin.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
-    "dealId": "deal-example-dc-modernization-2026",
-    "accountName": "Example Corporation",
+    "dealId": "deal-example-corp-dc-modernization-2026",
+    "accountName": "Example Corp",
     "dealName": "DC Modernization Phase 2",
     "dealStatus": "Qualified",
     "closeDate": "2026-06-30",
@@ -129,8 +129,8 @@
     },
     "partner": {
       "name": "PartnerCo",
-      "whyAnything": "Example needs implementation support — their platform team is at capacity with the Kubernetes migration",
-      "whyThisPartner": "PartnerCo has 3 certified F5 engineers and prior Example relationship from the load balancer deployment",
+      "whyAnything": "Example Corp needs implementation support — their platform team is at capacity with the Kubernetes migration",
+      "whyThisPartner": "PartnerCo has 3 certified F5 engineers and prior Example Corp relationship from the load balancer deployment",
       "whyNow": "PartnerCo has a team available in June; if we wait, they're committed to another project through Q4"
     }
   },
@@ -177,7 +177,7 @@
     }
   ],
   "salesStrategy": {
-    "differentiatedValueProposition": "F5 is the only vendor that provides unified application and API security with native Kubernetes integration — eliminating the need to deploy separate tools for north-south and east-west API protection. This directly addresses Example's MTTR target by providing a single pane of glass for API discovery, threat detection, and incident response across all 3 data centers.",
+    "differentiatedValueProposition": "F5 is the only vendor that provides unified application and API security with native Kubernetes integration — eliminating the need to deploy separate tools for north-south and east-west API protection. This directly addresses Example Corp's MTTR target by providing a single pane of glass for API discovery, threat detection, and incident response across all 3 data centers.",
     "winStrategy": "Lead with the pain: $400K SLA penalties and board mandate create urgency. Differentiate on Kubernetes-native integration (Vendor A can't match this). Use the POC to prove MTTR improvement quantitatively. Get EB alignment on business case before architecture review board. Neutralize Vendor A's price advantage by quantifying the cost of deploying and managing a separate API discovery tool."
   },
   "closePlan": {


### PR DESCRIPTION
## What

- replace fictitious ACME organizations, tenants, hosts, emails, headers, directories, and deal fixtures with approved Example-pattern values
- update all paired expectations, translated context documentation, benchmarks, and checked-in API snapshots
- retain the five genuine RFC 8555 references: four `_acme-challenge` records and one explicit ACME challenge fixture

## Why

ACME is an active certificate-management protocol name and is not an approved placeholder. Using it for fictitious tenants and organizations creates ambiguity and can point examples at real infrastructure.

Closes #2652

## Testing

- `bun run check:ts`
- 452 focused coding-agent tests
- 8 focused chat UI tests
- 40 focused Office pane tests
- `pre-commit run`
- `gitleaks git --staged --redact --no-banner`
- case-insensitive tracked-file inventory: five retained matches, all RFC 8555 challenge terminology