### PR TITLE
feat(coding-agent): add LiteLLM model selection after login

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added LiteLLM catalog metadata for GPT-5.6 Sol with verified High reasoning and token limits
+
 ## [15.0.0] - 2026-04-10
 
 ### Fixed

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -16541,6 +16541,30 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"gpt-5.6-sol": {
+			"id": "gpt-5.6-sol",
+			"name": "GPT-5.6 Sol",
+			"api": "openai-completions",
+			"provider": "litellm",
+			"baseUrl": "http://localhost:4000/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "high",
+				"maxLevel": "high"
+			}
+		},
 		"grok-4-1-fast-non-reasoning": {
 			"id": "grok-4-1-fast-non-reasoning",
 			"name": "Grok 4.1 Fast (Non-Reasoning)",

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -35,6 +35,25 @@ function createModel<TApi extends Api>(overrides: {
 }
 
 describe("model thinking metadata", () => {
+	it("bundles GPT-5.6 Sol for LiteLLM with verified high reasoning limits", () => {
+		const model = getBundledModel("litellm", "gpt-5.6-sol");
+
+		expect(model).toMatchObject({
+			id: "gpt-5.6-sol",
+			api: "openai-completions",
+			provider: "litellm",
+			reasoning: true,
+			contextWindow: 1050000,
+			maxTokens: 128000,
+			thinking: {
+				mode: "effort",
+				minLevel: Effort.High,
+				maxLevel: Effort.High,
+			},
+		});
+		expect(getSupportedEfforts(model)).toEqual([Effort.High]);
+	});
+
 	it("stores supported efforts for Codex mini in model metadata", () => {
 		const model = createModel({
 			id: "gpt-5.1-codex-mini",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a post-login LiteLLM model chooser for GPT-5.6 Sol and Claude Opus 5 with High reasoning; authenticated users can switch later with `/model`
+
+### Fixed
+
+- Restricted LiteLLM credential configuration files to owner-only permissions
+
 ## [19.51.5] - 2026-06-26
 
 ### Fixed

--- a/packages/coding-agent/src/config/auto-config.ts
+++ b/packages/coding-agent/src/config/auto-config.ts
@@ -15,7 +15,7 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { $env, logger, readProviderFromModelsYml } from "@f5-sales-demo/pi-utils";
+import { $env, isEnoent, logger, readProviderFromModelsYml } from "@f5-sales-demo/pi-utils";
 import { DEFAULT_MODEL_ROLE } from "./settings-schema";
 
 /** Current config schema version. Bump when the generated format changes. */
@@ -79,6 +79,17 @@ export function generateModelsYml(baseUrl: string, options?: GenerateModelsYmlOp
 
 	lines.push("");
 	return lines.join("\n");
+}
+
+/** Persist models.yml with owner-only permissions because it may contain a literal proxy credential. */
+export async function writeLiteLLMModelsYml(filePath: string, content: string): Promise<void> {
+	await fs.promises.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+	try {
+		await fs.promises.chmod(filePath, 0o600);
+	} catch (error) {
+		if (!isEnoent(error)) throw error;
+	}
+	await fs.promises.writeFile(filePath, content, { encoding: "utf-8", mode: 0o600 });
 }
 
 export interface LiteLLMConfig {

--- a/packages/coding-agent/src/modes/components/index.ts
+++ b/packages/coding-agent/src/modes/components/index.ts
@@ -15,6 +15,7 @@ export * from "./hook-input";
 export * from "./hook-message";
 export * from "./hook-selector";
 export * from "./keybinding-hints";
+export * from "./litellm-model-selector";
 export * from "./login-dialog";
 export * from "./model-selector";
 export * from "./oauth-selector";

--- a/packages/coding-agent/src/modes/components/litellm-model-selector.ts
+++ b/packages/coding-agent/src/modes/components/litellm-model-selector.ts
@@ -1,0 +1,40 @@
+import { Container, type SelectItem, SelectList, Spacer, Text } from "@f5-sales-demo/pi-tui";
+import type { LiteLLMLoginModelChoice } from "../controllers/login-model";
+import { getSelectListTheme } from "../theme/theme";
+import { DynamicBorder } from "./dynamic-border";
+
+export class LiteLLMModelSelectorComponent extends Container {
+	#selectList: SelectList;
+
+	constructor(
+		choices: readonly LiteLLMLoginModelChoice[],
+		onSelect: (choice: LiteLLMLoginModelChoice) => void,
+		onCancel: () => void,
+	) {
+		super();
+
+		const items: SelectItem[] = choices.map(choice => ({
+			value: `${choice.provider}/${choice.modelId}`,
+			label: choice.label,
+			description: choice.description,
+		}));
+
+		this.addChild(new DynamicBorder());
+		this.addChild(new Spacer(1));
+		this.addChild(new Text("Select your default model:", 1, 0));
+		this.addChild(new Spacer(1));
+		this.#selectList = new SelectList(items, items.length, getSelectListTheme());
+		this.#selectList.onSelect = item => {
+			const choice = choices.find(candidate => `${candidate.provider}/${candidate.modelId}` === item.value);
+			if (choice) onSelect(choice);
+		};
+		this.#selectList.onCancel = onCancel;
+		this.addChild(this.#selectList);
+		this.addChild(new Spacer(1));
+		this.addChild(new DynamicBorder());
+	}
+
+	getSelectList(): SelectList {
+		return this.#selectList;
+	}
+}

--- a/packages/coding-agent/src/modes/controllers/login-model.ts
+++ b/packages/coding-agent/src/modes/controllers/login-model.ts
@@ -1,4 +1,35 @@
+import { ThinkingLevel } from "@f5-sales-demo/pi-agent-core";
 import type { Model } from "@f5-sales-demo/pi-ai";
+
+export interface LiteLLMLoginModelChoice {
+	label: string;
+	description: string;
+	provider: "anthropic" | "litellm";
+	modelId: "claude-opus-5" | "gpt-5.6-sol";
+	thinkingLevel: ThinkingLevel;
+}
+
+export const LITELLM_LOGIN_MODEL_CHOICES: readonly LiteLLMLoginModelChoice[] = [
+	{
+		label: "GPT-5.6 Sol",
+		description: "OpenAI-compatible model with high reasoning",
+		provider: "litellm",
+		modelId: "gpt-5.6-sol",
+		thinkingLevel: ThinkingLevel.High,
+	},
+	{
+		label: "Claude Opus 5",
+		description: "Anthropic Messages model with high reasoning",
+		provider: "anthropic",
+		modelId: "claude-opus-5",
+		thinkingLevel: ThinkingLevel.High,
+	},
+];
+
+export function getAvailableLiteLLMLoginModelChoices(availableModelIds: readonly string[]): LiteLLMLoginModelChoice[] {
+	const available = new Set(availableModelIds);
+	return LITELLM_LOGIN_MODEL_CHOICES.filter(choice => available.has(choice.modelId));
+}
 
 /**
  * Minimal session surface needed to apply a model after a successful login.
@@ -6,27 +37,30 @@ import type { Model } from "@f5-sales-demo/pi-ai";
  * AgentSession type, and so it stays trivially unit-testable.
  */
 interface ModelApplicableSession {
-	model: Model | undefined;
 	modelRegistry: { getAll(): Model[] };
-	setModel(model: Model, role: "default", options?: { selector?: string }): Promise<void>;
+	setModel(model: Model, role: "default", options: { selector: string; thinkingLevel: ThinkingLevel }): Promise<void>;
+	setThinkingLevel(level: ThinkingLevel): void;
 }
 
 /**
- * After a successful `/login`, make the freshly-configured provider immediately
- * usable by setting it as the session's default model — but only when the session
- * has no model yet, so we never override a model the user already chose.
+ * After a successful `/login`, apply the model the user explicitly selected as
+ * the active and persisted default model, including its thinking level.
  *
- * Returns true when a model was applied. The login wizard auto-selects a model id
- * from the provider's /models list; resolving it here (post-registry-refresh) is
- * what lets the LLM readiness gate lift without a manual `/model` step.
+ * Returns true when the exact provider/model pair resolves after registry refresh.
  */
 export async function applyModelAfterLogin(
 	session: ModelApplicableSession,
-	selectedModelId: string | undefined,
+	choice: LiteLLMLoginModelChoice,
 ): Promise<boolean> {
-	if (session.model || !selectedModelId) return false;
-	const resolved = session.modelRegistry.getAll().find(m => m.id === selectedModelId);
+	const resolved = session.modelRegistry
+		.getAll()
+		.find(model => model.provider === choice.provider && model.id === choice.modelId);
 	if (!resolved) return false;
-	await session.setModel(resolved, "default", { selector: resolved.id });
+	const selector = `${choice.provider}/${choice.modelId}`;
+	await session.setModel(resolved, "default", {
+		selector,
+		thinkingLevel: choice.thinkingLevel,
+	});
+	session.setThinkingLevel(choice.thinkingLevel);
 	return true;
 }

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -13,6 +13,7 @@ import {
 	healConfigYmlModelRoles,
 	probeLiteLLMConnection,
 	readLiteLLMConfig,
+	writeLiteLLMModelsYml,
 } from "../../config/auto-config";
 import { getRoleInfo } from "../../config/model-registry";
 import { formatModelSelectorValue } from "../../config/model-resolver";
@@ -46,6 +47,7 @@ import { AssistantMessageComponent } from "../components/assistant-message";
 import { ExtensionDashboard } from "../components/extensions";
 import { GutterBlock } from "../components/gutter-block";
 import { HistorySearchComponent } from "../components/history-search";
+import { LiteLLMModelSelectorComponent } from "../components/litellm-model-selector";
 import { ModelSelectorComponent } from "../components/model-selector";
 import { OAuthSelectorComponent } from "../components/oauth-selector";
 import { PluginSelectorComponent } from "../components/plugin-selector";
@@ -58,7 +60,7 @@ import { ToolExecutionComponent } from "../components/tool-execution";
 import { TreeSelectorComponent } from "../components/tree-selector";
 import { UserMessageSelectorComponent } from "../components/user-message-selector";
 import type { SessionObserverRegistry } from "../session-observer-registry";
-import { applyModelAfterLogin } from "./login-model";
+import { applyModelAfterLogin, getAvailableLiteLLMLoginModelChoices, LITELLM_LOGIN_MODEL_CHOICES } from "./login-model";
 
 const CALLBACK_SERVER_PROVIDERS = new Set<OAuthProvider>([
 	"anthropic",
@@ -470,6 +472,69 @@ export class SelectorController {
 			);
 			return { component: selector, focus: selector };
 		});
+	}
+
+	async #showLiteLLMLoginModelSelector(availableModelIds: readonly string[]): Promise<boolean> {
+		const choices = getAvailableLiteLLMLoginModelChoices(availableModelIds);
+		const available = new Set(choices.map(choice => choice.modelId));
+		const unavailable = LITELLM_LOGIN_MODEL_CHOICES.filter(choice => !available.has(choice.modelId));
+
+		if (unavailable.length > 0) {
+			this.ctx.chatContainer.addChild(
+				new Text(
+					theme.fg(
+						"warning",
+						`Unavailable from this proxy: ${unavailable.map(choice => choice.label).join(", ")}`,
+					),
+					1,
+					0,
+				),
+			);
+		}
+
+		if (choices.length === 0) {
+			this.ctx.showError("LiteLLM login succeeded, but neither GPT-5.6 Sol nor Claude Opus 5 is available.");
+			return false;
+		}
+
+		const { promise, resolve } = Promise.withResolvers<boolean>();
+		let applying = false;
+		this.showSelector(done => {
+			const selector = new LiteLLMModelSelectorComponent(
+				choices,
+				choice => {
+					if (applying) return;
+					applying = true;
+					void (async () => {
+						try {
+							const applied = await applyModelAfterLogin(this.ctx.session, choice);
+							if (!applied) {
+								this.ctx.showError(`Model unavailable after refresh: ${choice.provider}/${choice.modelId}`);
+								applying = false;
+								return;
+							}
+							this.ctx.statusLine.invalidate();
+							this.ctx.updateEditorBorderColor();
+							done();
+							resolve(true);
+							this.ctx.ui.requestRender();
+						} catch (error) {
+							this.ctx.showError(error instanceof Error ? error.message : String(error));
+							applying = false;
+						}
+					})();
+				},
+				() => {
+					if (applying) return;
+					done();
+					resolve(false);
+					this.ctx.ui.requestRender();
+				},
+			);
+			return { component: selector, focus: selector.getSelectList() };
+		});
+
+		return promise;
 	}
 
 	async showPluginSelector(mode: "install" | "uninstall" = "install"): Promise<void> {
@@ -927,8 +992,7 @@ export class SelectorController {
 				apiBasePath: probe.apiBasePath,
 				apiKeyLiteral: result.apiKey,
 			});
-			fs.mkdirSync(path.dirname(modelsPath), { recursive: true });
-			fs.writeFileSync(modelsPath, yml);
+			await writeLiteLLMModelsYml(modelsPath, yml);
 
 			// Create/heal config.yml for model defaults
 			const configPath = path.join(path.dirname(modelsPath), "config.yml");
@@ -940,10 +1004,23 @@ export class SelectorController {
 			// Force online refresh so the registry re-probes the new proxy
 			// instead of serving stale data from the in-process SQLite cache.
 			await this.ctx.session.modelRegistry.refresh("online");
+			const modelSelected = await this.#showLiteLLMLoginModelSelector(probe.models);
 
 			this.ctx.chatContainer.addChild(new Spacer(1));
 			this.ctx.chatContainer.addChild(
 				new Text(theme.fg("success", `LiteLLM configuration saved to ${modelsPath}`), 1, 0),
+			);
+			this.ctx.chatContainer.addChild(
+				new Text(
+					theme.fg(
+						modelSelected ? "dim" : "warning",
+						modelSelected
+							? "Use /model to switch models without logging in again."
+							: "No model selected. Use /model to choose one without logging in again.",
+					),
+					1,
+					0,
+				),
 			);
 			this.ctx.ui.requestRender();
 		} catch (error: unknown) {
@@ -1143,29 +1220,17 @@ export class SelectorController {
 
 				// Auto-retry once on network errors
 				if (!probe.reachable && probe.error && !/\b(401|403|Unauthorized|Forbidden)\b/i.test(probe.error)) {
-					await new Promise(resolve => setTimeout(resolve, 1000));
+					await Bun.sleep(1000);
 					probe = await probeLiteLLMConnection(baseUrl, apiKey);
 				}
 
 				if (probe.reachable) {
-					// Auto-select best model
-					const preferenceOrder = ["claude-opus", "claude-sonnet", "claude", "gpt-4", "gpt"];
-					let selectedModel: string | undefined;
-					for (const pref of preferenceOrder) {
-						selectedModel = probe.models.find(m => m.toLowerCase().includes(pref));
-						if (selectedModel) break;
-					}
-					if (!selectedModel && probe.models.length > 0) {
-						selectedModel = probe.models[0];
-					}
-
 					// Save config
 					const yml = generateModelsYml(baseUrl, {
 						apiBasePath: probe.apiBasePath,
 						apiKeyLiteral: apiKey,
 					});
-					fs.mkdirSync(path.dirname(modelsPath), { recursive: true, mode: 0o700 });
-					fs.writeFileSync(modelsPath, yml, { mode: 0o600 });
+					await writeLiteLLMModelsYml(modelsPath, yml);
 
 					const configPath = path.join(path.dirname(modelsPath), "config.yml");
 					if (!fs.existsSync(configPath)) {
@@ -1174,10 +1239,13 @@ export class SelectorController {
 					healConfigYmlModelRoles(configPath);
 
 					await this.ctx.session.modelRegistry.refresh("online");
-					// Make the freshly-configured provider usable immediately so the LLM
-					// readiness gate lifts without requiring a manual /model selection.
-					await applyModelAfterLogin(this.ctx.session, selectedModel);
+					const modelSelected = await this.#showLiteLLMLoginModelSelector(probe.models);
 					await this.ctx.refreshWelcomeAfterLogin();
+					this.ctx.showStatus(
+						modelSelected
+							? "LiteLLM configured. Use /model to switch models without logging in again."
+							: "LiteLLM configured. Use /model to select a model.",
+					);
 					probeSuccess = true;
 				} else {
 					const errorMsg = probe.error ?? "connection failed";

--- a/packages/coding-agent/test/auto-config.test.ts
+++ b/packages/coding-agent/test/auto-config.test.ts
@@ -15,6 +15,7 @@ import {
 	tryAutoConfigLiteLLM,
 	validateModelsConfig,
 	warnIfConfigDrifted,
+	writeLiteLLMModelsYml,
 } from "../src/config/auto-config";
 
 // Isolated temp directory per test
@@ -136,6 +137,23 @@ describe("hasLiteLLMEnv()", () => {
 // =========================================================================
 
 describe("generateModelsYml()", () => {
+	test.skipIf(process.platform === "win32")(
+		"stores literal proxy credentials with owner-only permissions",
+		async () => {
+			fs.writeFileSync(modelsPath, "permissive", { mode: 0o644 });
+
+			await writeLiteLLMModelsYml(
+				modelsPath,
+				generateModelsYml("https://proxy.example.com", {
+					apiKeyLiteral: "sk-private-test-key",
+				}),
+			);
+
+			expect(fs.statSync(modelsPath).mode & 0o777).toBe(0o600);
+			expect(fs.readFileSync(modelsPath, "utf-8")).toContain('apiKey: "sk-private-test-key"');
+		},
+	);
+
 	test("generates valid YAML with anthropic and litellm providers", () => {
 		const yml = generateModelsYml("https://proxy.example.com");
 		expect(yml).toContain("providers:");

--- a/packages/coding-agent/test/login-model.test.ts
+++ b/packages/coding-agent/test/login-model.test.ts
@@ -1,45 +1,81 @@
 import { describe, expect, it, vi } from "bun:test";
-import { applyModelAfterLogin } from "@f5-sales-demo/xcsh/modes/controllers/login-model";
+import { ThinkingLevel } from "@f5-sales-demo/pi-agent-core";
+import {
+	applyModelAfterLogin,
+	getAvailableLiteLLMLoginModelChoices,
+	LITELLM_LOGIN_MODEL_CHOICES,
+} from "@f5-sales-demo/xcsh/modes/controllers/login-model";
 
 function makeSession(opts: { model?: { id: string; provider: string }; models: { id: string; provider: string }[] }) {
 	const setModel = vi.fn(async (_model: { id: string; provider: string }, _role: string, _opts?: unknown) => {});
+	const setThinkingLevel = vi.fn((_level: ThinkingLevel) => {});
 	const session = {
 		model: opts.model,
 		modelRegistry: { getAll: () => opts.models },
 		setModel,
+		setThinkingLevel,
 	};
-	return { session, setModel };
+	return { session, setModel, setThinkingLevel };
 }
 const M = (id: string, provider = "litellm") => ({ id, provider });
+const GPT_CHOICE = LITELLM_LOGIN_MODEL_CHOICES[0]!;
+const OPUS_CHOICE = LITELLM_LOGIN_MODEL_CHOICES[1]!;
 
 describe("applyModelAfterLogin", () => {
-	it("sets the session model when none is configured and the id resolves", async () => {
-		const { session, setModel } = makeSession({ model: undefined, models: [M("claude-opus-4")] });
-		const applied = await applyModelAfterLogin(session as never, "claude-opus-4");
+	it("persists the selected model and high thinking", async () => {
+		const { session, setModel, setThinkingLevel } = makeSession({
+			model: undefined,
+			models: [M("gpt-5.6-sol")],
+		});
+		const applied = await applyModelAfterLogin(session as never, GPT_CHOICE);
 		expect(applied).toBe(true);
 		expect(setModel).toHaveBeenCalledTimes(1);
-		expect(setModel.mock.calls[0][0]).toMatchObject({ id: "claude-opus-4" });
+		expect(setModel.mock.calls[0][0]).toMatchObject({ id: "gpt-5.6-sol", provider: "litellm" });
 		expect(setModel.mock.calls[0][1]).toBe("default");
+		expect(setModel.mock.calls[0][2]).toEqual({
+			selector: "litellm/gpt-5.6-sol",
+			thinkingLevel: ThinkingLevel.High,
+		});
+		expect(setThinkingLevel).toHaveBeenCalledWith(ThinkingLevel.High);
 	});
 
-	it("does not override an already-configured session model", async () => {
-		const { session, setModel } = makeSession({ model: M("existing"), models: [M("claude-opus-4")] });
-		const applied = await applyModelAfterLogin(session as never, "claude-opus-4");
+	it("applies an explicit post-login choice over the existing session model", async () => {
+		const { session, setModel } = makeSession({
+			model: M("existing"),
+			models: [M("claude-opus-5", "anthropic")],
+		});
+		const applied = await applyModelAfterLogin(session as never, OPUS_CHOICE);
+		expect(applied).toBe(true);
+		expect(setModel).toHaveBeenCalledWith(
+			M("claude-opus-5", "anthropic"),
+			"default",
+			expect.objectContaining({ selector: "anthropic/claude-opus-5" }),
+		);
+	});
+
+	it("requires the selected provider and model pair to resolve", async () => {
+		const { session, setModel } = makeSession({
+			model: undefined,
+			models: [M("claude-opus-5", "litellm")],
+		});
+		const applied = await applyModelAfterLogin(session as never, OPUS_CHOICE);
 		expect(applied).toBe(false);
 		expect(setModel).not.toHaveBeenCalled();
 	});
+});
 
-	it("returns false when the selected id is not in the registry", async () => {
-		const { session, setModel } = makeSession({ model: undefined, models: [M("other")] });
-		const applied = await applyModelAfterLogin(session as never, "claude-opus-4");
-		expect(applied).toBe(false);
-		expect(setModel).not.toHaveBeenCalled();
+describe("getAvailableLiteLLMLoginModelChoices", () => {
+	it("returns only curated models advertised by the authenticated catalog", () => {
+		const choices = getAvailableLiteLLMLoginModelChoices(["gpt-5.6-sol", "unrelated-model"]);
+		expect(choices).toEqual([GPT_CHOICE]);
 	});
 
-	it("returns false when there is no selected model id", async () => {
-		const { session, setModel } = makeSession({ model: undefined, models: [M("claude-opus-4")] });
-		const applied = await applyModelAfterLogin(session as never, undefined);
-		expect(applied).toBe(false);
-		expect(setModel).not.toHaveBeenCalled();
+	it("returns both curated choices in their stable display order", () => {
+		const choices = getAvailableLiteLLMLoginModelChoices(["claude-opus-5", "gpt-5.6-sol"]);
+		expect(choices).toEqual([GPT_CHOICE, OPUS_CHOICE]);
+	});
+
+	it("returns no choices when neither curated model is advertised", () => {
+		expect(getAvailableLiteLLMLoginModelChoices(["gpt-5.6-terra"])).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary

Add an explicit post-authentication LiteLLM model choice for GPT-5.6 Sol and Claude Opus 5, persist High thinking, and keep later model changes in `/model` without requiring another login.

## Related Issue

Closes #2681

## Changes

- Show only curated GPT-5.6 Sol and Claude Opus 5 choices advertised by the authenticated proxy catalog.
- Persist the selected provider/model as the active default with High thinking.
- Add verified GPT-5.6 Sol reasoning and token-limit metadata.
- Preserve the proxy session when model selection is cancelled and direct later changes to `/model`.
- Store literal LiteLLM proxy credentials with owner-only (`0600`) permissions.
- Update the `ai` and `coding-agent` changelogs.

## Verification evidence

- `bun test packages/coding-agent/test/login-model.test.ts packages/ai/test/model-thinking.test.ts packages/coding-agent/test/auto-config.test.ts`
  - 158 pass, 0 fail, 360 assertions.
- `bun check:ts`
  - Exit 0. The only output beyond successful checks is two pre-existing informational `useTemplate` suggestions in `xcsh-protocol.ts`.
- `git diff --check origin/main...HEAD`
  - Exit 0.
- Exercised the source CLI in an isolated `PI_CODING_AGENT_DIR` against the configured LiteLLM proxy:
  - `/login litellm` authenticated and reported 45 available models.
  - The post-login selector displayed GPT-5.6 Sol and Claude Opus 5.
  - Selecting GPT persisted `litellm/gpt-5.6-sol:high`.
  - Generated routes were the discovered OpenAI-compatible base for GPT and `/anthropic` for Opus.
  - `models.yml` was `0600` after the permissions regression fix.
  - `/model` switched the default to `anthropic/claude-opus-5:high` without another login.
- Minimal live endpoint probes also succeeded for GPT-5.6 Sol with High reasoning and Claude Opus 5 through their respective proxy routes.
- The pre-change full-suite baseline is not green in this worktree: it recorded 273 test-file load errors because the native addon was absent, plus environment-sensitive pre-existing failures. The native addon was subsequently built for the live CLI exercise. Focused changed-area suites are green as shown above; this PR does not claim a green full local suite.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [ ] Tests written first (TDD) and passing; the issue's acceptance criteria are met
  - The implementation preceded the request to enforce the repository TDD workflow, so strict red-before-green chronology cannot be claimed. The credential-permissions regression discovered during live UAT did follow a recorded red-green cycle.
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued) — [green workflow](https://github.com/f5-sales-demo/xcsh/actions/runs/30632612778)
- [x] Follows project conventions

