### PR TITLE
feat(ci): ratchet gate over the managed PII scanner

### DIFF
--- a/.github/pii-baseline.json
+++ b/.github/pii-baseline.json
@@ -1,0 +1,374 @@
+{
+  "counts": {
+    ".github/workflows/deploy-office-pane.yml": {
+      "email": 1
+    },
+    ".xcsh/skills/gitlab/SKILL.md": {
+      "customer-identifier": 1
+    },
+    ".xcsh/skills/terraform-provider/SKILL.md": {
+      "customer-identifier": 3
+    },
+    "assets/ask.webp": {
+      "email": 1
+    },
+    "assets/perplexity.webp": {
+      "email": 1
+    },
+    "assets/python.webp": {
+      "email": 1
+    },
+    "assets/review.webp": {
+      "email": 3
+    },
+    "assets/slash.webp": {
+      "email": 1
+    },
+    "bun.lock": {
+      "email": 1
+    },
+    "crates/brush-core-vendored/src/sys/unix/landlock.rs": {
+      "home-path": 2
+    },
+    "crates/containment-check/tests/complement.rs": {
+      "home-path": 39
+    },
+    "crates/pi-natives/src/keys.rs": {
+      "home-path": 2
+    },
+    "docs/ar/runtime-tools/task-agent-discovery.md": {
+      "customer-identifier": 2
+    },
+    "docs/de/runtime-tools/task-agent-discovery.md": {
+      "customer-identifier": 2
+    },
+    "docs/en/mcp/mcp-config.md": {
+      "customer-identifier": 1
+    },
+    "docs/en/runtime-tools/task-agent-discovery.md": {
+      "customer-identifier": 2
+    },
+    "docs/es/runtime-tools/task-agent-discovery.md": {
+      "customer-identifier": 2
+    },
+    "docs/fr/runtime-tools/task-agent-discovery.md": {
+      "customer-identifier": 2
+    },
+    "docs/hi/runtime-tools/task-agent-discovery.md": {
+      "customer-identifier": 2
+    },
+    "docs/it/runtime-tools/task-agent-discovery.md": {
+      "customer-identifier": 2
+    },
+    "docs/ja/runtime-tools/task-agent-discovery.md": {
+      "customer-identifier": 2
+    },
+    "docs/ko/runtime-tools/task-agent-discovery.md": {
+      "customer-identifier": 2
+    },
+    "docs/pt-br/runtime-tools/task-agent-discovery.md": {
+      "customer-identifier": 2
+    },
+    "docs/th/runtime-tools/task-agent-discovery.md": {
+      "customer-identifier": 2
+    },
+    "docs/zh-cn/runtime-tools/task-agent-discovery.md": {
+      "customer-identifier": 2
+    },
+    "docs/zh-tw/runtime-tools/task-agent-discovery.md": {
+      "customer-identifier": 2
+    },
+    "package.json": {
+      "email": 1
+    },
+    "packages/ai/src/providers/cursor/gen/agent_pb.ts": {
+      "person-name": 1
+    },
+    "packages/ai/src/providers/cursor/proto/agent.proto": {
+      "person-name": 1
+    },
+    "packages/ai/src/providers/openai-codex/constants.ts": {
+      "customer-identifier": 1
+    },
+    "packages/ai/src/utils/oauth/kagi.ts": {
+      "email": 1
+    },
+    "packages/ai/test/google-gemini-cli-alignment.test.ts": {
+      "customer-identifier": 1
+    },
+    "packages/ai/test/kagi-login.test.ts": {
+      "email": 1
+    },
+    "packages/ai/test/zenmux-provider.test.ts": {
+      "person-name": 2
+    },
+    "packages/chat-ui/test/markdown/fidelity.test.ts": {
+      "email": 1
+    },
+    "packages/chat-ui/test/markdown/fixtures/autolink.golden.html": {
+      "email": 1
+    },
+    "packages/chat-ui/test/markdown/fixtures/autolink.md": {
+      "email": 1
+    },
+    "packages/chat-ui/test/markdown/fixtures/mixed-datasheet.golden.html": {
+      "email": 1
+    },
+    "packages/chat-ui/test/markdown/fixtures/mixed-datasheet.md": {
+      "email": 1
+    },
+    "packages/chat-ui/test/markdown/render.test.tsx": {
+      "email": 1
+    },
+    "packages/coding-agent/CHANGELOG.md": {
+      "home-path": 1
+    },
+    "packages/coding-agent/bench/extension-session.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/bench/ttft.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/src/commands/manager.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/src/discovery/agents-md.ts": {
+      "person-name": 1
+    },
+    "packages/coding-agent/src/discovery/agents.ts": {
+      "person-name": 1
+    },
+    "packages/coding-agent/src/discovery/claude-plugins.ts": {
+      "person-name": 1
+    },
+    "packages/coding-agent/src/discovery/claude.ts": {
+      "person-name": 1
+    },
+    "packages/coding-agent/src/discovery/cline.ts": {
+      "person-name": 1
+    },
+    "packages/coding-agent/src/discovery/codex.ts": {
+      "person-name": 1
+    },
+    "packages/coding-agent/src/discovery/cursor.ts": {
+      "person-name": 1
+    },
+    "packages/coding-agent/src/discovery/gemini.ts": {
+      "person-name": 1
+    },
+    "packages/coding-agent/src/discovery/github.ts": {
+      "person-name": 1
+    },
+    "packages/coding-agent/src/discovery/mcp-json.ts": {
+      "person-name": 1
+    },
+    "packages/coding-agent/src/discovery/opencode.ts": {
+      "person-name": 1
+    },
+    "packages/coding-agent/src/discovery/ssh.ts": {
+      "person-name": 1
+    },
+    "packages/coding-agent/src/discovery/vscode.ts": {
+      "person-name": 1
+    },
+    "packages/coding-agent/src/discovery/windsurf.ts": {
+      "person-name": 1
+    },
+    "packages/coding-agent/src/extensibility/skills.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/src/internal-urls/api-catalog-index.generated.ts": {
+      "email": 1
+    },
+    "packages/coding-agent/src/internal-urls/api-spec-index.generated.ts": {
+      "email": 1,
+      "person-name": 68
+    },
+    "packages/coding-agent/src/internal-urls/terraform-resolve.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/src/modes/components/agent-dashboard.ts": {
+      "customer-identifier": 3
+    },
+    "packages/coding-agent/src/modes/components/extensions/inspector-panel.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/src/modes/components/status-line/git-utils.ts": {
+      "email": 3
+    },
+    "packages/coding-agent/src/prompts/tools/read-chunk.md": {
+      "email": 1
+    },
+    "packages/coding-agent/src/prompts/tools/xcsh-api.md": {
+      "customer-identifier": 2
+    },
+    "packages/coding-agent/src/slash-commands/marketplace-install-parser.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/src/task/discovery.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/src/tools/xcsh-api.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/src/web/scrapers/dockerhub.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/test/browser/acquire-helpers.test.ts": {
+      "home-path": 9
+    },
+    "packages/coding-agent/test/core/python-kernel-env.test.ts": {
+      "home-path": 5
+    },
+    "packages/coding-agent/test/discovery/pi-config-dir.test.ts": {
+      "home-path": 1
+    },
+    "packages/coding-agent/test/env-secret-masking.test.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/test/fixtures/before-compaction.jsonl": {
+      "home-path": 598
+    },
+    "packages/coding-agent/test/fixtures/large-session.jsonl": {
+      "home-path": 23
+    },
+    "packages/coding-agent/test/git-url.test.ts": {
+      "email": 2
+    },
+    "packages/coding-agent/test/herdr-reporter.test.ts": {
+      "home-path": 1
+    },
+    "packages/coding-agent/test/internal-urls/build-info-factory.test.ts": {
+      "home-path": 3
+    },
+    "packages/coding-agent/test/internal-urls/profile-collectors.test.ts": {
+      "phone": 1
+    },
+    "packages/coding-agent/test/internal-urls/user-profile.test.ts": {
+      "email": 1,
+      "phone": 1
+    },
+    "packages/coding-agent/test/manager-core.test.ts": {
+      "customer-identifier": 6,
+      "home-path": 1
+    },
+    "packages/coding-agent/test/manager-wait-diagnostics.test.ts": {
+      "customer-identifier": 2
+    },
+    "packages/coding-agent/test/manager.int.test.ts": {
+      "customer-identifier": 18
+    },
+    "packages/coding-agent/test/marketplace/fetcher.test.ts": {
+      "email": 1
+    },
+    "packages/coding-agent/test/mcp-roots-list.test.ts": {
+      "home-path": 1
+    },
+    "packages/coding-agent/test/native-host.int.test.ts": {
+      "customer-identifier": 2
+    },
+    "packages/coding-agent/test/resource-management/manifest-parser.test.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/test/sdk-context-integration.test.ts": {
+      "customer-identifier": 3
+    },
+    "packages/coding-agent/test/services/context-env.test.ts": {
+      "customer-identifier": 3
+    },
+    "packages/coding-agent/test/session-manager/context-change.test.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/test/session-manager/file-operations.test.ts": {
+      "home-path": 2
+    },
+    "packages/coding-agent/test/session-manager/move-to.test.ts": {
+      "home-path": 2
+    },
+    "packages/coding-agent/test/skills.test.ts": {
+      "home-path": 2
+    },
+    "packages/coding-agent/test/status-line-git-utils.test.ts": {
+      "email": 9
+    },
+    "packages/coding-agent/test/system-prompt-templates.test.ts": {
+      "customer-identifier": 4
+    },
+    "packages/coding-agent/test/tools/web-search-kagi.test.ts": {
+      "email": 1
+    },
+    "packages/coding-agent/test/update-cli.test.ts": {
+      "home-path": 3
+    },
+    "packages/coding-agent/test/xcsh-api-client.test.ts": {
+      "customer-identifier": 4
+    },
+    "packages/coding-agent/test/xcsh-api-tool.test.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/test/xcsh-context-knowledge.test.ts": {
+      "home-path": 1
+    },
+    "packages/coding-agent/test/xcsh-context-service.test.ts": {
+      "email": 3
+    },
+    "packages/coding-agent/test/xcsh-env.test.ts": {
+      "customer-identifier": 1
+    },
+    "packages/coding-agent/test/xcsh-test-fixtures.ts": {
+      "home-path": 1
+    },
+    "packages/office-pane/assets/fonts/MesloLGS-NF-Bold-Italic.ttf": {
+      "email": 2
+    },
+    "packages/office-pane/assets/fonts/MesloLGS-NF-Bold.ttf": {
+      "email": 2
+    },
+    "packages/office-pane/assets/fonts/MesloLGS-NF-Italic.ttf": {
+      "email": 2
+    },
+    "packages/office-pane/assets/fonts/MesloLGS-NF-Regular.ttf": {
+      "email": 2
+    },
+    "packages/office-pane/test/bridge-discovery.test.ts": {
+      "customer-identifier": 7
+    },
+    "packages/resource-management/test/manifest-export.test.ts": {
+      "customer-identifier": 15
+    },
+    "packages/resource-management/test/manifest-parser.test.ts": {
+      "customer-identifier": 1
+    },
+    "packages/resource-management/test/minimal-export-matrix.test.ts": {
+      "customer-identifier": 5
+    },
+    "packages/tui/src/components/markdown.ts": {
+      "email": 1
+    },
+    "packages/typescript-edit-benchmark/fixtures.tar.gz": {
+      "email": 1
+    },
+    "packages/utils/test/mermaid-label-centering.test.ts": {
+      "email": 1
+    },
+    "plugin-discovery-matrix/fixtures/deal-self-describing.json": {
+      "customer-identifier": 1
+    },
+    "plugin-discovery-matrix/fixtures/deal-thin.json": {
+      "customer-identifier": 1
+    },
+    "plugin-discovery-matrix/fixtures/transcripts/invoked-abspath.jsonl": {
+      "home-path": 1
+    },
+    "plugin-discovery-matrix/fixtures/transcripts/real-invoked.jsonl": {
+      "email": 5
+    },
+    "scripts/ci-release-homebrew.ts": {
+      "email": 1
+    },
+    "uat-matrix/console-phrases.yaml": {
+      "customer-identifier": 2
+    }
+  },
+  "version": 1
+}

--- a/.github/workflows/pii-guard.yml
+++ b/.github/workflows/pii-guard.yml
@@ -1,0 +1,44 @@
+---
+# Ratchet gate over the managed PII scanner.
+#
+# CLAUDE.md requires that repositories, fixtures, generated output and commit messages carry no real
+# PII, and CONTRIBUTING.md documents a sweep procedure — but nothing ran that scanner automatically,
+# which is how a batch of real customer names, a work email and a personal tenant identifier reached
+# a public default branch.
+#
+# The repository still carries a backlog of findings, most of them false positives, so this job does
+# not demand zero. It pins the backlog in .github/pii-baseline.json and fails only when the count
+# grows. Fixing findings and lowering the baseline is the intended direction.
+name: pii-guard
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pii-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pii-guard:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The scanner reads tracked blobs from the object database, not the worktree, and the
+          # gate compares against a committed baseline. Neither needs history.
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify the gate's own behaviour before trusting its verdict
+        run: bash tests/test-pii-baseline-gate.sh
+
+      # The same entry point a developer runs as `bun run pii:gate`, so CI and local cannot drift.
+      # It distinguishes "findings grew" (fail) from "the scan could not run" (also fail, loudly)
+      # from "findings exist but did not grow" (pass).
+      - name: Scan tracked content and fail only if findings grew over the baseline
+        run: bash scripts/pii-gate.sh

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"check:rs": "bun scripts/run-rs-task.ts check:rs",
 		"lint": "bun run --parallel lint:ts lint:rs",
 		"lint:ts": "bun run lint:tools && bun run --workspaces --if-present lint",
+		"pii:gate": "bash scripts/pii-gate.sh",
 		"lint:tools": "biome lint . --no-errors-on-unmatched",
 		"lint:rs": "bun scripts/run-rs-task.ts lint:rs",
 		"fmt": "bun run --parallel fmt:ts fmt:rs",

--- a/scripts/pii-baseline-gate.py
+++ b/scripts/pii-baseline-gate.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Ratchet gate over `scripts/check-pii.sh --format json`.
+
+The repository carries a backlog of PII-shaped findings, so a gate that demands zero would block
+every pull request and would be turned off within a day. This gate instead pins the backlog and
+fails only when it **grows**: a new path, a new category in a known path, or more findings of a
+category than the baseline records.
+
+Counts are keyed by ``(path, category)`` rather than by line, because line numbers move whenever a
+file is edited and a line-keyed baseline would churn on unrelated changes.
+
+The baseline is data, not judgement: nothing here decides that a finding is acceptable. Lowering it
+is the point — pass ``--update`` after fixing findings so the new, lower count becomes the ceiling.
+
+Reads the scanner's JSON on stdin or from ``--findings``. Exit 0 means no growth, 1 means growth,
+2 means the gate could not run. Never prints a matched value; the scanner does not emit one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+BASELINE_VERSION = 1
+
+
+def load_findings(source: str | None) -> list[dict[str, Any]]:
+    """Read the scanner's JSON document from a path or stdin."""
+    raw = Path(source).read_text(encoding="utf-8") if source else sys.stdin.read()
+    if not raw.strip():
+        message = "no scanner output received (empty input)"
+        raise ValueError(message)
+    document = json.loads(raw)
+    findings = document.get("findings") if isinstance(document, dict) else document
+    if not isinstance(findings, list):
+        message = "scanner output has no findings array"
+        raise ValueError(message)
+    return findings
+
+
+def tally(findings: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
+    """Count findings per path and category."""
+    counts: dict[str, collections.Counter[str]] = collections.defaultdict(collections.Counter)
+    for finding in findings:
+        path = str(finding.get("path", ""))
+        category = str(finding.get("category", ""))
+        if path and category:
+            counts[path][category] += 1
+    return {path: dict(sorted(categories.items())) for path, categories in sorted(counts.items())}
+
+
+def annotate(finding: dict[str, Any]) -> str:
+    """Render one finding as a GitHub Actions error annotation."""
+    path = finding.get("path", "")
+    line = finding.get("line", 1)
+    category = finding.get("category", "unknown")
+    message = finding.get("message", "PII-shaped value")
+    return f"::error file={path},line={line}::[{category}] {message}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--findings", help="scanner JSON file; defaults to stdin")
+    parser.add_argument("--baseline", default=".github/pii-baseline.json")
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="rewrite the baseline from these findings instead of comparing",
+    )
+    args = parser.parse_args()
+
+    try:
+        findings = load_findings(args.findings)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"PII gate error: {error}", file=sys.stderr)
+        return 2
+
+    current = tally(findings)
+    baseline_path = Path(args.baseline)
+
+    if args.update:
+        document = {"version": BASELINE_VERSION, "counts": current}
+        baseline_path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        total = sum(sum(c.values()) for c in current.values())
+        print(f"PII gate: baseline written to {baseline_path} ({len(current)} path(s), {total} finding(s)).")
+        return 0
+
+    if not baseline_path.is_file():
+        print(f"PII gate error: baseline not found at {baseline_path}; run with --update", file=sys.stderr)
+        return 2
+    try:
+        baseline = json.loads(baseline_path.read_text(encoding="utf-8")).get("counts", {})
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"PII gate error: cannot read baseline: {error}", file=sys.stderr)
+        return 2
+
+    # Growth is what fails. Anything at or below the recorded ceiling passes.
+    grown: list[tuple[str, str, int, int]] = []
+    for path, categories in current.items():
+        allowed = baseline.get(path, {})
+        for category, count in categories.items():
+            ceiling = int(allowed.get(category, 0))
+            if count > ceiling:
+                grown.append((path, category, count, ceiling))
+
+    if grown:
+        offending = {(path, category) for path, category, _, _ in grown}
+        for finding in findings:
+            if (str(finding.get("path")), str(finding.get("category"))) in offending:
+                print(annotate(finding))
+        print("::error::PII findings increased over the recorded baseline.")
+        for path, category, count, ceiling in sorted(grown):
+            print(f"  {path} [{category}]: {count} > {ceiling}")
+        print("Fix the finding at its source. STYLE_GUIDE.md defines the synthetic replacements.")
+        print("If the increase is a scanner false positive, say so on the pull request and raise it")
+        print("with docs-control rather than raising the baseline to hide it.")
+        return 1
+
+    # Report improvements so the ceiling can be lowered deliberately.
+    improved = [
+        (path, category, int(counts.get(category, 0)), current.get(path, {}).get(category, 0))
+        for path, counts in baseline.items()
+        for category in counts
+        if current.get(path, {}).get(category, 0) < int(counts.get(category, 0))
+    ]
+    total = sum(sum(c.values()) for c in current.values())
+    print(f"PII gate: no growth over baseline ({total} finding(s) across {len(current)} path(s)).")
+    if improved:
+        removed = sum(was - now for _, _, was, now in improved)
+        print(f"::notice::{removed} finding(s) fixed since the baseline. Re-run with --update to lower it.")
+        for path, category, was, now in sorted(improved)[:20]:
+            print(f"  {path} [{category}]: {was} -> {now}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pii-gate.sh
+++ b/scripts/pii-gate.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Scan tracked content for PII-shaped values and fail only if findings grew over the baseline.
+#
+# CI and a local run execute this same script, so the two cannot drift. Scanner output goes to a
+# temporary file that is always removed: `.gitignore` is docs-control managed, so this must not
+# leave an untracked artifact behind for someone to commit by accident.
+#
+# Exit 0 = no growth, 1 = growth, 2 = the scan or the gate could not run.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "${REPO_ROOT}"
+
+SCOPE="head"
+BASELINE=".github/pii-baseline.json"
+UPDATE=""
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/pii-gate.sh [--scope staged|head|history] [--baseline PATH] [--update]
+
+  --scope staged   verify uncommitted work before a commit (the scanner's `head` scope reads
+                   `git ls-tree HEAD` and cannot see it)
+  --update         rewrite the baseline from the current findings, to lower it after a fix
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+  --scope)
+    [ "$#" -ge 2 ] || {
+      usage >&2
+      exit 2
+    }
+    SCOPE=$2
+    shift 2
+    ;;
+  --baseline)
+    [ "$#" -ge 2 ] || {
+      usage >&2
+      exit 2
+    }
+    BASELINE=$2
+    shift 2
+    ;;
+  --update)
+    UPDATE="--update"
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "PII gate error: unknown argument: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+  esac
+done
+
+FINDINGS=$(mktemp)
+trap 'rm -f "${FINDINGS}"' EXIT
+
+status=0
+bash scripts/check-pii.sh --scope "${SCOPE}" --mode enforce --format json >"${FINDINGS}" || status=$?
+if [ "${status}" -eq 2 ]; then
+  echo "PII gate error: the scanner could not run; treating as a failure, not as clean." >&2
+  exit 2
+fi
+
+python3 scripts/pii-baseline-gate.py --findings "${FINDINGS}" --baseline "${BASELINE}" ${UPDATE:+"${UPDATE}"}

--- a/tests/test-pii-baseline-gate.sh
+++ b/tests/test-pii-baseline-gate.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Behaviour tests for scripts/pii-baseline-gate.py.
+#
+# The gate's whole value is the direction of its asymmetry: growth fails, parity and improvement
+# pass. Each case below fixes one of those directions, plus the failure modes that would make the
+# gate silently useless (missing baseline, empty input, malformed JSON).
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+GATE="${REPO_ROOT}/scripts/pii-baseline-gate.py"
+WORK=$(mktemp -d)
+trap 'rm -rf "${WORK}"' EXIT
+
+PASS=0
+FAIL=0
+
+# run <expected-exit> <name> <findings-file> [extra args...]
+run() {
+  local expected=$1 name=$2 findings=$3
+  shift 3
+  local actual=0
+  python3 "${GATE}" --findings "${findings}" "$@" >"${WORK}/out.txt" 2>&1 || actual=$?
+  if [ "${actual}" = "${expected}" ]; then
+    PASS=$((PASS + 1))
+    echo "  ok    ${name} (exit ${actual})"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL  ${name}: expected exit ${expected}, got ${actual}"
+    sed 's/^/          /' "${WORK}/out.txt"
+  fi
+}
+
+finding() { # path category [line]
+  printf '{"category":"%s","line":%s,"message":"m","path":"%s","severity":"high"}' "$2" "${3:-1}" "$1"
+}
+
+cat >"${WORK}/two.json" <<EOF
+{"mode":"enforce","scope":"head","findings":[$(finding a.ts email 1),$(finding a.ts email 9)]}
+EOF
+cat >"${WORK}/three.json" <<EOF
+{"mode":"enforce","scope":"head","findings":[$(finding a.ts email 1),$(finding a.ts email 9),$(finding a.ts email 12)]}
+EOF
+cat >"${WORK}/one.json" <<EOF
+{"mode":"enforce","scope":"head","findings":[$(finding a.ts email 1)]}
+EOF
+cat >"${WORK}/newpath.json" <<EOF
+{"mode":"enforce","scope":"head","findings":[$(finding a.ts email 1),$(finding a.ts email 9),$(finding b.ts email 3)]}
+EOF
+cat >"${WORK}/newcat.json" <<EOF
+{"mode":"enforce","scope":"head","findings":[$(finding a.ts email 1),$(finding a.ts email 9),$(finding a.ts home-path 4)]}
+EOF
+cat >"${WORK}/moved.json" <<EOF
+{"mode":"enforce","scope":"head","findings":[$(finding a.ts email 400),$(finding a.ts email 900)]}
+EOF
+echo -n "" >"${WORK}/empty.json"
+echo "{not json" >"${WORK}/bad.json"
+
+echo "pii-baseline-gate:"
+
+# Baseline of two email findings in a.ts.
+python3 "${GATE}" --findings "${WORK}/two.json" --baseline "${WORK}/base.json" --update >/dev/null
+
+run 0 "same counts pass" "${WORK}/two.json" --baseline "${WORK}/base.json"
+run 0 "fewer findings pass, and are reported as an improvement" "${WORK}/one.json" --baseline "${WORK}/base.json"
+run 0 "same counts on different lines pass (baseline is not line-keyed)" "${WORK}/moved.json" --baseline "${WORK}/base.json"
+run 1 "more findings of a known category fail" "${WORK}/three.json" --baseline "${WORK}/base.json"
+run 1 "a finding in a new path fails" "${WORK}/newpath.json" --baseline "${WORK}/base.json"
+run 1 "a new category in a known path fails" "${WORK}/newcat.json" --baseline "${WORK}/base.json"
+run 2 "a missing baseline is an error, not a pass" "${WORK}/two.json" --baseline "${WORK}/absent.json"
+run 2 "empty scanner output is an error, not a pass" "${WORK}/empty.json" --baseline "${WORK}/base.json"
+run 2 "malformed scanner output is an error, not a pass" "${WORK}/bad.json" --baseline "${WORK}/base.json"
+
+# An improvement must be reported so the ceiling can be lowered deliberately.
+python3 "${GATE}" --findings "${WORK}/one.json" --baseline "${WORK}/base.json" >"${WORK}/imp.txt" 2>&1 || true
+if grep -q 'fixed since the baseline' "${WORK}/imp.txt"; then
+  PASS=$((PASS + 1))
+  echo "  ok    an improvement is reported, not silently accepted"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL  an improvement was not reported"
+fi
+
+# A failure must name the offending path so it is actionable.
+python3 "${GATE}" --findings "${WORK}/newpath.json" --baseline "${WORK}/base.json" >"${WORK}/f.txt" 2>&1 || true
+if grep -q 'b.ts' "${WORK}/f.txt" && grep -q '::error' "${WORK}/f.txt"; then
+  PASS=$((PASS + 1))
+  echo "  ok    a failure names the offending path and annotates it"
+else
+  FAIL=$((FAIL + 1))
+  echo "  FAIL  a failure did not name the offending path"
+fi
+
+echo "  ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ]


### PR DESCRIPTION
Closes #2691. Companion request in docs-control#902.

`CLAUDE.md` requires that repositories, fixtures, generated output and commit messages carry no real
PII, and `CONTRIBUTING.md` documents a sweep built on `scripts/check-pii.sh` — but **nothing ran that
scanner automatically**. Real customer names, a work email, a personal tenant identifier and a
colleague's staging hostname all reached a public default branch last night and were found only by
running it by hand (#2646, #2649, #2653, #2661, #2680). Nothing prevented a recurrence.

## Why a ratchet and not zero

The scanner reports **971 findings at HEAD**, most of them false positives on API schema values and
compressed binary data. A gate demanding zero fails on every pull request and gets switched off within
a day. This pins the backlog in `.github/pii-baseline.json` and fails only on **growth**: a new path, a
new category in a known path, or more findings of a category than the baseline records.

Improvements are reported so the ceiling is lowered deliberately with `--update`. The baseline is data,
not judgement — nothing in it declares a finding acceptable.

## Design decisions worth reviewing

- **Keyed by `(path, category)`, not by line.** Line numbers move on every edit; a line-keyed baseline
  would churn on unrelated changes. There is a test asserting the same findings on different lines pass.
- **"Could not run" fails loudly** rather than reading as clean. Scanner exit 2 is separated from exit 1.
- **One entry point.** `scripts/pii-gate.sh` serves CI and `bun run pii:gate`, so local and CI cannot
  diverge — the `Local vs CI` requirement in `CLAUDE.md`.
- **No artifact left behind.** Scanner output goes to a `mktemp` file removed on exit, because
  `.gitignore` is docs-control managed and an untracked `.pii-findings.json` invites an accidental commit.

## Verification — both directions

| Check | Result |
|---|---|
| Gate on the current tree | **exit 0** — "no growth over baseline (971 findings across 122 paths)" |
| Planted email + home path in a new file, `--scope staged` | **exit 1** — both findings annotated, path named, remediation stated |
| `tests/test-pii-baseline-gate.sh` | **11 pass, 0 fail** |
| `actionlint`, `zizmor` on the workflow | clean |
| `shellcheck -x` on both shell scripts | clean |

The failure case matters more than the passing one: a gate I have not watched fail is a gate I cannot
vouch for. The probe file was removed and the working tree verified clean afterwards.

## This does NOT yet block a merge — please read

Adding `pii-guard` to the required-status-check set means editing
`.github/workflows/enforce-repo-settings.yml`, and documenting it means editing `CONTRIBUTING.md`. Both
are docs-control managed, so until docs-control#902 lands, a red `pii-guard` is advisory.

That issue also asks for two scanner false positives to be fixed at the source rather than absorbed
into the baseline:

- `+1-555-0100` is flagged as non-fictional, but 555-0100–555-0199 is NANP-reserved for fiction.
- 5 `email` findings sit inside `.webp` files at byte offsets in compressed data; `strings` finds no
  address in any of them.

## Baseline composition, for context

122 paths, 971 findings: `home-path` 698, `customer-identifier` 127, `person-name` 86, `email` 58,
`phone` 2. The single largest entry is 598 findings in
`packages/coding-agent/test/fixtures/before-compaction.jsonl` — an upstream contributor's home path in
a compaction fixture, the one substantial genuine item still outstanding from #2659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)