### PR TITLE
fix(ai): omit unsupported GPT-5.6 temperature

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GPT-5.6 Sol requests to omit the unsupported temperature parameter ([#2698](https://github.com/f5-sales-demo/xcsh/issues/2698))
+
 ## [19.104.0] - 2026-07-31
 
 ### Added

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -16563,6 +16563,9 @@
 				"mode": "effort",
 				"minLevel": "high",
 				"maxLevel": "high"
+			},
+			"compat": {
+				"supportsTemperature": false
 			}
 		},
 		"grok-4-1-fast-non-reasoning": {

--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -87,6 +87,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 
 	return {
 		supportsStore: !isNonStandard,
+		supportsTemperature: model.id.toLowerCase() !== "gpt-5.6-sol",
 		supportsDeveloperRole: !isNonStandard,
 		supportsReasoningEffort: !isGrok && !isZai,
 		reasoningEffortMap,
@@ -133,6 +134,7 @@ export function resolveOpenAICompat(
 
 	return {
 		supportsStore: model.compat.supportsStore ?? detected.supportsStore,
+		supportsTemperature: model.compat.supportsTemperature ?? detected.supportsTemperature,
 		supportsDeveloperRole: model.compat.supportsDeveloperRole ?? detected.supportsDeveloperRole,
 		supportsReasoningEffort: model.compat.supportsReasoningEffort ?? detected.supportsReasoningEffort,
 		reasoningEffortMap: model.compat.reasoningEffortMap ?? detected.reasoningEffortMap,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -693,7 +693,7 @@ function buildParams(
 		}
 	}
 
-	if (options?.temperature !== undefined) {
+	if (options?.temperature !== undefined && compat.supportsTemperature) {
 		params.temperature = options.temperature;
 	}
 	if (options?.topP !== undefined) {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -498,6 +498,8 @@ export type AssistantMessageEvent =
 export interface OpenAICompat {
 	/** Whether the provider supports the `store` field. Default: auto-detected from URL. */
 	supportsStore?: boolean;
+	/** Whether the model accepts an explicit `temperature` parameter. Default: true. */
+	supportsTemperature?: boolean;
 	/** Whether the provider supports the `developer` role (vs `system`). Default: auto-detected from URL. */
 	supportsDeveloperRole?: boolean;
 	/** Whether the provider supports `reasoning_effort`. Default: auto-detected from URL. */

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -68,6 +68,7 @@ describe("openai-completions compatibility", () => {
 		};
 		const compat = {
 			supportsStore: true,
+			supportsTemperature: true,
 			supportsDeveloperRole: true,
 			supportsReasoningEffort: true,
 			reasoningEffortMap: {},
@@ -235,6 +236,45 @@ describe("openai-completions compatibility", () => {
 				controller: "mlx",
 			}),
 		);
+	});
+
+	it("omits unsupported temperature from discovered GPT-5.6 Sol requests", async () => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("litellm", "gpt-5.6-sol"),
+			api: "openai-completions",
+			compat: undefined,
+		};
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			temperature: 0,
+			signal: createAbortedSignal(),
+			onPayload: payload => resolve(payload),
+		});
+
+		const payload = toObject(await promise);
+		expect(payload).not.toBeNull();
+		if (!payload) throw new Error("request payload missing");
+		expect(Reflect.has(payload, "temperature")).toBe(false);
+	});
+
+	it("preserves explicit temperature for models that support it", async () => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+		};
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			temperature: 0.25,
+			signal: createAbortedSignal(),
+			onPayload: payload => resolve(payload),
+		});
+
+		const payload = toObject(await promise);
+		expect(payload).not.toBeNull();
+		if (!payload) throw new Error("request payload missing");
+		expect(Reflect.get(payload, "temperature")).toBe(0.25);
 	});
 
 	it("preserves the streamed reasoning field name for follow-up requests", async () => {

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -21,6 +21,7 @@ const emptyUsage: Usage = {
 
 const compat: Required<OpenAICompat> = {
 	supportsStore: true,
+	supportsTemperature: true,
 	supportsDeveloperRole: true,
 	supportsReasoningEffort: true,
 	reasoningEffortMap: {},

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GPT-5.6 Sol inference through LiteLLM when deterministic print mode requests an unsupported temperature ([#2698](https://github.com/f5-sales-demo/xcsh/issues/2698))
+
 ## [19.104.0] - 2026-07-31
 
 ### Added

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -140,6 +140,7 @@ const ReasoningEffortMapSchema = Type.Object({
 
 const OpenAICompatSchema = Type.Object({
 	supportsStore: Type.Optional(Type.Boolean()),
+	supportsTemperature: Type.Optional(Type.Boolean()),
 	supportsDeveloperRole: Type.Optional(Type.Boolean()),
 	supportsReasoningEffort: Type.Optional(Type.Boolean()),
 	reasoningEffortMap: Type.Optional(ReasoningEffortMapSchema),


### PR DESCRIPTION
## Summary

Omit the unsupported `temperature` request field for GPT-5.6 Sol while preserving explicit temperature values for compatible OpenAI-completions models. This fixes real inference from deterministic print mode through the LiteLLM proxy.

## Related issue

Closes #2698

## Changes

- Add an OpenAI compatibility capability for explicit temperature support.
- Mark GPT-5.6 Sol as not accepting explicit temperature, including dynamically discovered instances that do not retain bundled compatibility metadata.
- Preserve current request behavior for compatible models.
- Add regression coverage and update affected changelogs.

## Verification evidence

- Red: the new discovered-model payload test failed with `Expected: false, Received: true` because `temperature` was emitted.
- Green: `bun test packages/ai/test/openai-completions-tool-result-images.test.ts packages/ai/test/model-thinking.test.ts packages/ai/test/openai-completions-compat.test.ts`
  - 41 pass, 0 fail, 127 assertions.
- `bun check:ts`
  - Exit 0; only the two pre-existing informational `useTemplate` suggestions in `xcsh-protocol.ts`.
- `git diff --check`
  - Exit 0.
- Live source UAT through the configured VPN LiteLLM proxy:
  - GPT-5.6 Sol with High thinking returned exactly `GPT UAT OK`.
  - Claude Opus 5 through `/anthropic` returned exactly `OPUS UAT OK`.
- The published `v19.104.0` Homebrew binary reproduced the original GPT failure before this patch.

## Checklist

- [x] Linked to a GitHub issue
- [x] Tests written first and observed failing before implementation
- [x] Focused tests and type checks pass
- [x] Verified against the real proxy path
- [x] Changelogs updated
- [x] CI watched to green ([workflow 30639488668](https://github.com/f5-sales-demo/xcsh/actions/runs/30639488668))
- [x] Patch release v19.105.1 published and installed via Homebrew ([workflow 30643701974](https://github.com/f5-sales-demo/xcsh/actions/runs/30643701974))
- [x] Installed-binary end-to-end UAT passes


- Installed Homebrew v19.105.1 UAT:
  - GPT-5.6 Sol with High thinking returned exactly `GPT UAT OK`.
  - Switched models without reauthentication; Claude Opus 5 with High thinking returned exactly `OPUS UAT OK`.
  - A separate `--no-tools` eager-todo inconsistency discovered by an extra constrained probe is tracked in #2711.
