### PR TITLE
fix(coding-agent): skip eager todo when tool inactive

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `--no-tools` print requests forcing inactive `todo_write` through eager-todo enforcement ([#2711](https://github.com/f5-sales-demo/xcsh/issues/2711))
+
 ## [19.105.1] - 2026-07-31
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4391,7 +4391,7 @@ export class AgentSession {
 			return undefined;
 		}
 
-		if (!this.#toolRegistry.has("todo_write")) {
+		if (!this.agent.state.tools.some(tool => tool.name === "todo_write")) {
 			logger.warn("Eager todo enforcement skipped because todo_write is unavailable", {
 				activeToolNames: this.agent.state.tools.map(tool => tool.name),
 			});

--- a/packages/coding-agent/test/agent-session-eager-todo.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-todo.test.ts
@@ -221,6 +221,23 @@ describe("AgentSession eager todo enforcement", () => {
 		expect(session.formatSessionAsText()).not.toContain("<user-request>");
 	});
 
+	it("does not force todo_write when the tool is registered but inactive", async () => {
+		session.agent.setTools(session.agent.state.tools.filter(tool => tool.name !== "todo_write"));
+
+		await session.prompt("list all work trees");
+
+		expect(observedCalls).toEqual([
+			{
+				toolChoice: undefined,
+				toolNames: ["bash"],
+				messageRoles: ["user"],
+				messageTexts: ["list all work trees"],
+				lastMessageRole: "user",
+				lastMessageText: "list all work trees",
+			},
+		]);
+	});
+
 	it("initializes todos once, then continues within the same user turn", async () => {
 		scriptedResponses = [
 			createToolCallAssistantMessage("todo_write", {


### PR DESCRIPTION
## Summary

Skip eager-todo injection whenever `todo_write` is registered but absent from the agent's active tools. This keeps `--no-tools` requests internally consistent instead of forcing a tool the provider cannot call.

## Related issue

Closes #2711

## Changes

- Gate eager-todo enforcement on the active agent tool list.
- Add contract coverage for a registered-but-inactive `todo_write`.
- Document the fix in the coding-agent changelog.

## TDD evidence

- Red: the new test received `toolChoice: "todo_write"` plus the hidden eager-todo reminder while the request tool list contained only `bash`.
- Green: `bun test packages/coding-agent/test/agent-session-eager-todo.test.ts`
  - 6 pass, 0 fail, 21 assertions.
- `bun check:ts`
  - Exit 0; only the two pre-existing informational `useTemplate` suggestions in `xcsh-protocol.ts`.
- `git diff --check`
  - Exit 0.
- Real LiteLLM source UAT with tools, MCP, extensions, skills, and rules disabled returned exactly `NO TOOLS UAT OK`.

## Additional discovery

The setup-path `models.yml` permissions defect found during UAT is tracked separately in #2713 and will be fixed before this release work is considered complete.

## Checklist

- [x] Linked to a GitHub issue
- [x] Test written first and observed failing for the intended contract
- [x] Focused test and type checks pass
- [x] Verified through the real proxy
- [x] Changelog updated
- [x] CI watched to green
- [ ] Fix released, installed through Homebrew, and UAT repeated