### PR TITLE
fix(coding-agent): secure all LiteLLM config writes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restricted LiteLLM `models.yml` setup, auto-fix, discovery-upgrade, and backup writes to owner-only permissions ([#2713](https://github.com/f5-sales-demo/xcsh/issues/2713))
+
 ## [19.105.1] - 2026-07-31
 
 ### Fixed

--- a/packages/coding-agent/src/config/auto-config.ts
+++ b/packages/coding-agent/src/config/auto-config.ts
@@ -20,6 +20,8 @@ import { DEFAULT_MODEL_ROLE } from "./settings-schema";
 
 /** Current config schema version. Bump when the generated format changes. */
 export const CURRENT_CONFIG_VERSION = 2;
+const LITELLM_CONFIG_DIR_MODE = 0o700;
+const LITELLM_MODELS_FILE_MODE = 0o600;
 
 // ---------------------------------------------------------------------------
 // Detection
@@ -83,13 +85,13 @@ export function generateModelsYml(baseUrl: string, options?: GenerateModelsYmlOp
 
 /** Persist models.yml with owner-only permissions because it may contain a literal proxy credential. */
 export async function writeLiteLLMModelsYml(filePath: string, content: string): Promise<void> {
-	await fs.promises.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+	await fs.promises.mkdir(path.dirname(filePath), { recursive: true, mode: LITELLM_CONFIG_DIR_MODE });
 	try {
-		await fs.promises.chmod(filePath, 0o600);
+		await fs.promises.chmod(filePath, LITELLM_MODELS_FILE_MODE);
 	} catch (error) {
 		if (!isEnoent(error)) throw error;
 	}
-	await fs.promises.writeFile(filePath, content, { encoding: "utf-8", mode: 0o600 });
+	await fs.promises.writeFile(filePath, content, { encoding: "utf-8", mode: LITELLM_MODELS_FILE_MODE });
 }
 
 export interface LiteLLMConfig {
@@ -217,15 +219,13 @@ export function readApiKeyLiteral(modelsPath: string): string | undefined {
 	return undefined;
 }
 
-/** Create a .bak backup of a file if it exists. Returns true if backed up. */
-function backupIfExists(filePath: string): boolean {
+/** Create an owner-only .bak backup of models.yml. Returns true if backed up. */
+function backupModelsConfigIfExists(filePath: string): boolean {
+	const backupPath = `${filePath}.bak`;
 	try {
-		if (fs.existsSync(filePath)) {
-			fs.copyFileSync(filePath, `${filePath}.bak`);
-			return true;
-		}
+		return safeWriteModelsConfig(backupPath, fs.readFileSync(filePath));
 	} catch (err) {
-		logger.warn("Failed to create backup", { filePath, err });
+		if (!isEnoent(err)) logger.warn("Failed to create backup", { filePath, err });
 	}
 	return false;
 }
@@ -238,6 +238,23 @@ function safeWrite(filePath: string, content: string): boolean {
 		return true;
 	} catch (err) {
 		logger.warn("Failed to write config file", { filePath, err });
+		return false;
+	}
+}
+
+/** Write models.yml content without ever exposing it through group/world-readable permissions. */
+function safeWriteModelsConfig(filePath: string, content: string | Uint8Array): boolean {
+	try {
+		fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: LITELLM_CONFIG_DIR_MODE });
+		try {
+			fs.chmodSync(filePath, LITELLM_MODELS_FILE_MODE);
+		} catch (err) {
+			if (!isEnoent(err)) throw err;
+		}
+		fs.writeFileSync(filePath, content, { encoding: "utf-8", mode: LITELLM_MODELS_FILE_MODE });
+		return true;
+	} catch (err) {
+		logger.warn("Failed to write LiteLLM models config", { filePath, err });
 		return false;
 	}
 }
@@ -367,7 +384,7 @@ export function tryAutoConfigLiteLLM(modelsPath: string): boolean {
 	const baseUrl = getLiteLLMBaseUrl();
 	if (!baseUrl) return false;
 
-	if (!safeWrite(modelsPath, generateModelsYml(baseUrl))) return false;
+	if (!safeWriteModelsConfig(modelsPath, generateModelsYml(baseUrl))) return false;
 	logger.debug("Auto-configured LiteLLM proxy", { modelsPath, baseUrl });
 
 	// Write config.yml if it doesn't exist, or heal it if it's missing modelRoles
@@ -501,10 +518,10 @@ export function autoFixModelsConfig(modelsPath: string): FixResult {
 
 	const existingLiteralKey = readApiKeyLiteral(modelsPath);
 
-	backupIfExists(modelsPath);
+	backupModelsConfigIfExists(modelsPath);
 
 	if (
-		!safeWrite(
+		!safeWriteModelsConfig(
 			modelsPath,
 			generateModelsYml(baseUrl, {
 				...(existingLiteralKey ? { apiKeyLiteral: existingLiteralKey } : {}),
@@ -688,12 +705,12 @@ export async function probeAndUpgradeLiteLLMConfig(
 
 	// Upgrade: backup and regenerate with correct base path, preserving literal keys
 	const existingLiteralKey = readApiKeyLiteral(modelsPath);
-	backupIfExists(modelsPath);
+	backupModelsConfigIfExists(modelsPath);
 	const newContent = generateModelsYml(baseUrl, {
 		apiBasePath: probe.apiBasePath,
 		...(existingLiteralKey ? { apiKeyLiteral: existingLiteralKey } : {}),
 	});
-	if (!safeWrite(modelsPath, newContent)) {
+	if (!safeWriteModelsConfig(modelsPath, newContent)) {
 		return false;
 	}
 

--- a/packages/coding-agent/test/auto-config.test.ts
+++ b/packages/coding-agent/test/auto-config.test.ts
@@ -219,6 +219,9 @@ describe("tryAutoConfigLiteLLM()", () => {
 
 		const content = fs.readFileSync(modelsPath, "utf-8");
 		expect(content).toContain("https://proxy.example.com/anthropic");
+		if (process.platform !== "win32") {
+			expect(fs.statSync(modelsPath).mode & 0o777).toBe(0o600);
+		}
 	});
 
 	test("returns false when env vars not set", () => {
@@ -1273,6 +1276,7 @@ describe("probeAndUpgradeLiteLLMConfig()", () => {
 			"",
 		].join("\n");
 		fs.writeFileSync(modelsPath, literalConfig);
+		fs.chmodSync(modelsPath, 0o644);
 		expect(literalConfig).toContain('apiKey: "sk-real-literal-key-789"');
 		expect(literalConfig).not.toContain("type: openai-compat");
 
@@ -1288,6 +1292,10 @@ describe("probeAndUpgradeLiteLLMConfig()", () => {
 		// Must preserve the literal key
 		expect(afterContent).toContain('apiKey: "sk-real-literal-key-789"');
 		expect(afterContent).toContain("type: openai-compat");
+		if (process.platform !== "win32") {
+			expect(fs.statSync(`${modelsPath}.bak`).mode & 0o777).toBe(0o600);
+			expect(fs.statSync(modelsPath).mode & 0o777).toBe(0o600);
+		}
 	});
 });
 
@@ -1338,12 +1346,17 @@ describe("autoFixModelsConfig() literal key preservation", () => {
 				apiKeyLiteral: "sk-preserved-key-456",
 			}),
 		);
+		fs.chmodSync(modelsPath, 0o644);
 
 		const result = autoFixModelsConfig(modelsPath);
 		expect(result.fixed).toBe(true);
 
 		const afterContent = fs.readFileSync(modelsPath, "utf-8");
 		expect(afterContent).toContain('apiKey: "sk-preserved-key-456"');
+		if (process.platform !== "win32") {
+			expect(fs.statSync(`${modelsPath}.bak`).mode & 0o777).toBe(0o600);
+			expect(fs.statSync(modelsPath).mode & 0o777).toBe(0o600);
+		}
 	});
 
 	test("keeps env var reference when no literal key exists", () => {


### PR DESCRIPTION
## Summary

Secure every LiteLLM models configuration write, including backups that can preserve literal credentials.

## Related Issue

Closes #2713

## Changes

- Create and normalize every `models.yml` through an owner-only write path.
- Create `.bak` files as `0600` immediately instead of copying permissive source modes.
- Cover fresh setup, auto-fix, discovery upgrades, and literal-key backups.
- Document the fix in the coding-agent changelog.

## Verification evidence

- Red: `bun test packages/coding-agent/test/auto-config.test.ts` reported 126 passed and 3 failed because the fresh setup and literal-key backup paths produced `0644`.
- Green: `bun test packages/coding-agent/test/auto-config.test.ts packages/coding-agent/test/setup-litellm.test.ts` reported 140 passed, 0 failed, and 323 assertions.
- `bun check:ts` exited 0.
- `git diff --check` exited 0.
- Source UAT exercised `xcsh setup litellm`, forced a permissive legacy config, reran setup, and reported `SOURCE PERMISSIONS UAT OK fresh=600 live=600 backup=600`.
- CI run: https://github.com/f5-sales-demo/xcsh/actions/runs/30647926352

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions