### PR TITLE
fix(coding-agent): clear API spec lint findings

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed Biome findings from generated Site CLI transport descriptions ([#2715](https://github.com/f5-sales-demo/xcsh/issues/2715))
+
 ## [19.105.1] - 2026-07-31
 
 ### Fixed

--- a/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/xcsh-protocol.ts
@@ -668,10 +668,10 @@ export class InternalDocsProtocolHandler implements ProtocolHandler {
 						...(entry.example ? [`- example argument: \`${entry.example}\``] : []),
 						"",
 						entry.transport === "global-get"
-							? "GLOBAL scope: GET .../vpm/debug/global/" + subpath + " — NOT reachable via exec-user."
+							? `GLOBAL scope: GET .../vpm/debug/global/${subpath} — NOT reachable via exec-user.`
 							: entry.transport === "exec"
 								? "Exec tier: privileged and mutating. Do not run speculatively."
-								: 'POST .../vpm/debug/{node}/exec-user with {"command":["' + subpath + '", ...]}.',
+								: `POST .../vpm/debug/{node}/exec-user with {"command":["${subpath}", ...]}.`,
 					].join("\n")
 				: `Unknown Site CLI command: ${subpath}\n\nRead xcsh://sitecli for the full list (build ${build}).`;
 		}


### PR DESCRIPTION
## Summary

Clear the two Biome findings introduced by the API-spec sync without changing rendered content.

## Related Issue

Closes #2715

## Changes

- Replace both Site CLI transport string concatenations with template literals.
- Preserve the rendered internal-document content.
- Document the cleanup in the coding-agent changelog.

## Verification evidence

- Red: `bun check:ts` reported two `lint/style/useTemplate` findings.
- Green: `bun check:ts` reported `Checked 1933 files` and `Checked 1418 files` with no Biome findings; all workspace type checks passed.
- `git diff --check` exited 0.
- CI run: https://github.com/f5-sales-demo/xcsh/actions/runs/30648116719

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the static check acceptance criteria are met
- [x] Verified locally by running the release-blocking check — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions