### PR TITLE
fix(release): verify published Homebrew installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # Never auto-cancel a tag run. The publishing chain (build-release ->
-  # create-release -> publish-npm / update-homebrew) lives in this workflow and
+  # create-release -> publish-npm / update-homebrew -> install verification) lives in this workflow and
   # inherits this group, so a cancel between publish-npm and update-homebrew
   # would leave the version on npm with Homebrew stale and no rollback. All six
   # jobs were cancelled on the v19.96.0 run; that escaped harm only because the
@@ -1090,6 +1090,61 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: bun scripts/ci-release-homebrew.ts --update-tap
+
+  # Install from the published tap so a successful formula push cannot mask a
+  # stale version, bad checksum, missing archive, or binary startup failure.
+  verify-homebrew-install:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [update-homebrew]
+    runs-on: macos-14
+    timeout-minutes: 20
+    steps:
+      - name: Install published xcsh formula and verify startup
+        env:
+          EXPECTED_VERSION: ${{ github.ref_name }}
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          set -euo pipefail
+
+          expected="${EXPECTED_VERSION#v}"
+          max_attempts=8
+          delay=10
+
+          brew uninstall --force f5-sales-demo/tap/xcsh 2>/dev/null || true
+          brew untap f5-sales-demo/tap 2>/dev/null || true
+
+          for attempt in $(seq 1 "$max_attempts"); do
+            echo "=== Homebrew install attempt $attempt/$max_attempts ==="
+
+            # Re-clone the tap on every attempt so a stale local formula cannot
+            # make a propagation retry install the previous release again.
+            brew untap f5-sales-demo/tap 2>/dev/null || true
+            brew tap f5-sales-demo/tap
+
+            if brew install f5-sales-demo/tap/xcsh; then
+              installed=$(xcsh --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+              echo "Installed version: ${installed:-unknown}; expected: $expected"
+
+              if [ "$installed" = "$expected" ]; then
+                xcsh --help >/dev/null
+                binary="$(brew --prefix f5-sales-demo/tap/xcsh)/bin/xcsh"
+                codesign --verify --deep --strict "$binary"
+                spctl --assess --verbose=4 --type install "$binary"
+                echo "Homebrew install verification passed"
+                exit 0
+              fi
+            fi
+
+            brew uninstall --force f5-sales-demo/tap/xcsh 2>/dev/null || true
+            if [ "$attempt" -eq "$max_attempts" ]; then
+              echo "::error::Homebrew install verification failed after $max_attempts attempts"
+              exit 1
+            fi
+
+            echo "Waiting ${delay}s for tap and release-asset propagation..."
+            sleep "$delay"
+            if [ "$delay" -lt 60 ]; then delay=$((delay * 2)); fi
+          done
 
   # Publish to npm
   publish-npm:

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -7,7 +7,8 @@ name: Tag on version bump
 # version and push the git tag `v<X.Y.Z>`. The tag push is not subject to
 # branch protection, so this step always succeeds and triggers the tag-gated
 # release chain (build-release / build-sign-macos / create-release /
-# publish-npm / update-homebrew / verify-npm-install) defined in ci.yml.
+# publish-npm / update-homebrew / verify-npm-install / verify-homebrew-install)
+# defined in ci.yml.
 #
 # Also supports workflow_dispatch for retroactive tagging: supply a
 # `commit_sha` whose subject matches the bump pattern, and this workflow will

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Added post-publication Homebrew install verification to the release workflow ([#2719](https://github.com/f5-sales-demo/xcsh/issues/2719))
 - Replaced the deprecated Node 20 Zig setup action with a checksum-pinned official installer ([#61](https://github.com/f5-sales-demo/xcsh/issues/61))
 - Invalidated stale release PRs immediately on new `main` pushes, before the full release-creation gate ([#2732](https://github.com/f5-sales-demo/xcsh/issues/2732))
 - Preserved GPT-5.6 Sol High reasoning and token-limit metadata through generated LiteLLM model discovery ([#2729](https://github.com/f5-sales-demo/xcsh/issues/2729))

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -454,6 +454,39 @@ describe("CI installs Zig without a deprecated JavaScript action", () => {
 	});
 });
 
+describe("CI verifies the published Homebrew formula end to end", () => {
+	async function loadVerifyHomebrewJob(): Promise<string> {
+		const workflow = await fs.readFile(path.join(import.meta.dir, "../../../.github/workflows/ci.yml"), "utf8");
+		const match = workflow.match(/\n {2}verify-homebrew-install:\n[\s\S]*?(?=\n {2}[a-z][a-z-]+:\n)/);
+		expect(match).not.toBeNull();
+		return match?.[0] ?? "";
+	}
+
+	it("runs on macOS only after the Homebrew tap update", async () => {
+		const job = await loadVerifyHomebrewJob();
+		expect(job).toContain("needs: [update-homebrew]");
+		expect(job).toContain("runs-on: macos-14");
+	});
+
+	it("installs from a clean tap state with bounded retries", async () => {
+		const job = await loadVerifyHomebrewJob();
+		expect(job).toContain("brew untap f5-sales-demo/tap");
+		expect(job).toContain("brew install f5-sales-demo/tap/xcsh");
+		expect(job).toContain("max_attempts=");
+	});
+
+	it("requires the published version and launches the installed CLI", async () => {
+		const job = await loadVerifyHomebrewJob();
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal string match against YAML content
+		expect(job).toContain("EXPECTED_VERSION: ${{ github.ref_name }}");
+		expect(job).toContain("installed=$(xcsh --version");
+		expect(job).toContain('if [ "$installed" = "$expected" ]');
+		expect(job).toContain("xcsh --help >/dev/null");
+		expect(job).toContain('codesign --verify --deep --strict "$binary"');
+		expect(job).toContain('spctl --assess --verbose=4 --type install "$binary"');
+	});
+});
+
 describe("vim ex-command onUpdate throttle bypass (commit 8f5b630ac)", () => {
 	it("vim.ts onKbdStep forces update when engine.inputMode is command or search mode", async () => {
 		const src = await fs.readFile(path.join(import.meta.dir, "../src/tools/vim.ts"), "utf8");


### PR DESCRIPTION
## Summary

Add a gated macOS install check after the release workflow publishes the Homebrew tap.

## Related Issue

Closes #2719

## Changes

- Add `verify-homebrew-install` after `update-homebrew` on tag runs.
- Re-clone the tap and retry installation with bounded backoff.
- Require the installed version to match the release tag.
- Launch the installed CLI and verify Developer ID signing and notarization through `codesign` and `spctl`.
- Add regression coverage for the release topology and install contract.

## Verification evidence

- Red: `bun test packages/coding-agent/test/regression-guard.test.ts` reported 73 passed and 3 failed because no Homebrew verification job existed.
- Green: `bun test packages/coding-agent/test/regression-guard.test.ts packages/coding-agent/test/workflow-action-pins.test.ts` reported 82 passed, 0 failed, and 124 assertions.
- `actionlint .github/workflows/ci.yml .github/workflows/tag-on-version-bump.yml` exited 0.
- `git diff --check` exited 0.
- The installed v19.105.1 binary passed the exact local signature commands: `codesign --verify --deep --strict` and `spctl --assess --verbose=4 --type install`, reporting `accepted` and `source=Notarized Developer ID`.
- CI run: pending.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions