### PR TITLE
fix(release): refresh stale same-version release PR

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Regenerated stale same-version release PRs when newer commits have merged into `main` ([#2727](https://github.com/f5-sales-demo/xcsh/issues/2727))
+
 ## [19.105.3] - 2026-07-31
 
 ### Fixed

--- a/packages/coding-agent/test/scripts/release-reconcile.test.ts
+++ b/packages/coding-agent/test/scripts/release-reconcile.test.ts
@@ -13,30 +13,64 @@ import { planReleaseReconcile } from "../../../../scripts/release";
  * the same (open PRs, target) always yields the same plan, so re-running converges.
  */
 describe("planReleaseReconcile", () => {
+	const currentMainOid = "main-current";
+	const openReleasePR = (version: string, baseRefOid = currentMainOid) => ({ version, baseRefOid });
+
 	it("closes stale phantom release PRs, keeps/creates only the canonical target", () => {
 		// The exact bug: v19.63.0 stranded after v19.62.1 shipped the same commits.
-		expect(planReleaseReconcile({ openReleaseVersions: ["19.63.0"], target: "19.62.2" })).toEqual({
+		expect(
+			planReleaseReconcile({
+				openReleasePRs: [openReleasePR("19.63.0")],
+				target: "19.62.2",
+				currentMainOid,
+			}),
+		).toEqual({
 			toCreate: "19.62.2",
 			toClose: ["19.63.0"],
 		});
 	});
 
 	it("creates the target when no release PR is open", () => {
-		expect(planReleaseReconcile({ openReleaseVersions: [], target: "19.62.2" })).toEqual({
+		expect(planReleaseReconcile({ openReleasePRs: [], target: "19.62.2", currentMainOid })).toEqual({
 			toCreate: "19.62.2",
 			toClose: [],
 		});
 	});
 
-	it("is idempotent: the target already open → nothing to create or close", () => {
-		expect(planReleaseReconcile({ openReleaseVersions: ["19.62.2"], target: "19.62.2" })).toEqual({
+	it("is idempotent when the target PR was created from current main", () => {
+		expect(
+			planReleaseReconcile({
+				openReleasePRs: [openReleasePR("19.62.2")],
+				target: "19.62.2",
+				currentMainOid,
+			}),
+		).toEqual({
 			toCreate: null,
 			toClose: [],
 		});
 	});
 
+	it("closes and recreates a same-target PR created from stale main", () => {
+		expect(
+			planReleaseReconcile({
+				openReleasePRs: [openReleasePR("19.62.2", "main-before-new-fix")],
+				target: "19.62.2",
+				currentMainOid,
+			}),
+		).toEqual({
+			toCreate: "19.62.2",
+			toClose: ["19.62.2"],
+		});
+	});
+
 	it("no releasable commits (target null) → closes ALL open release PRs (phantoms), creates nothing", () => {
-		expect(planReleaseReconcile({ openReleaseVersions: ["19.63.0", "19.62.2"], target: null })).toEqual({
+		expect(
+			planReleaseReconcile({
+				openReleasePRs: [openReleasePR("19.63.0"), openReleasePR("19.62.2")],
+				target: null,
+				currentMainOid,
+			}),
+		).toEqual({
 			toCreate: null,
 			toClose: ["19.63.0", "19.62.2"],
 		});
@@ -44,7 +78,11 @@ describe("planReleaseReconcile", () => {
 
 	it("closes multiple stale versions while keeping the canonical one open", () => {
 		expect(
-			planReleaseReconcile({ openReleaseVersions: ["19.62.2", "19.63.0", "20.0.0"], target: "19.62.2" }),
+			planReleaseReconcile({
+				openReleasePRs: [openReleasePR("19.62.2"), openReleasePR("19.63.0"), openReleasePR("20.0.0")],
+				target: "19.62.2",
+				currentMainOid,
+			}),
 		).toEqual({ toCreate: null, toClose: ["19.63.0", "20.0.0"] });
 	});
 });

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -529,19 +529,33 @@ export function classifyReleaseAction(opts: {
 	return opts.tagExists ? "already-released" : "bumped-untagged";
 }
 
+export type OpenReleasePR = {
+	version: string;
+	baseRefOid: string;
+};
+
 /** Idempotent reconcile plan for the set of open `release/vX.Y.Z` PRs. There must be
  * exactly ONE canonical next version (or none): any open release PR whose version
- * isn't `target` is a stale/superseded phantom (e.g. a v19.63.0 stranded after a
- * v19.62.1 shipped the same commit range) and must be closed; the target is created
- * only when it isn't already open. Pure + deterministic — running it repeatedly on
- * the same (open PRs, target) always yields the same plan, so `auto-release`
- * converges instead of accumulating conflicting release branches. */
-export function planReleaseReconcile(opts: { openReleaseVersions: string[]; target: string | null }): {
+ * isn't `target`, or whose recorded base no longer matches the default branch, is a
+ * stale/superseded phantom and must be closed. The target is created only when a
+ * current target PR isn't already open. Pure + deterministic — running it repeatedly
+ * on the same inputs always yields the same plan, so `auto-release` converges instead
+ * of retaining a release generated before newer commits merged. */
+export function planReleaseReconcile(opts: {
+	openReleasePRs: OpenReleasePR[];
+	target: string | null;
+	currentMainOid: string;
+}): {
 	toCreate: string | null;
 	toClose: string[];
 } {
-	const toClose = opts.openReleaseVersions.filter(v => v !== opts.target);
-	const toCreate = opts.target && !opts.openReleaseVersions.includes(opts.target) ? opts.target : null;
+	const currentTargetOpen = opts.openReleasePRs.some(
+		pr => pr.version === opts.target && pr.baseRefOid === opts.currentMainOid,
+	);
+	const toClose = opts.openReleasePRs
+		.filter(pr => pr.version !== opts.target || pr.baseRefOid !== opts.currentMainOid)
+		.map(pr => pr.version);
+	const toCreate = opts.target && !currentTargetOpen ? opts.target : null;
 	return { toCreate, toClose };
 }
 
@@ -572,29 +586,28 @@ function bumpedUntaggedGuidance(version: string): string {
 	].join("\n");
 }
 
-/** Versions of the currently-open `release/vX.Y.Z` PRs (best-effort; [] on error). */
-async function listOpenReleaseVersions(): Promise<string[]> {
-	try {
-		const out = await $`gh pr list --state open --limit 50 --json headRefName`.text();
-		const prs = JSON.parse(out) as { headRefName: string }[];
-		return prs
-			.map(p => p.headRefName)
-			.filter(b => /^release\/v\d+\.\d+\.\d+$/.test(b))
-			.map(b => b.replace(/^release\/v/, ""));
-	} catch {
-		return [];
-	}
+/** Currently-open `release/vX.Y.Z` PRs and their recorded base commits. */
+async function listOpenReleasePRs(): Promise<OpenReleasePR[]> {
+	const out = await $`gh pr list --state open --limit 50 --json headRefName,baseRefOid`.text();
+	const prs = JSON.parse(out) as { headRefName: string; baseRefOid: string }[];
+	return prs
+		.filter(pr => /^release\/v\d+\.\d+\.\d+$/.test(pr.headRefName))
+		.map(pr => ({ version: pr.headRefName.replace(/^release\/v/, ""), baseRefOid: pr.baseRefOid }));
 }
 
-/** Close a stale/superseded release PR and delete its branch (best-effort, non-fatal). */
+/** Current default-branch commit queried from GitHub, independent of local checkout state. */
+async function readDefaultBranchOid(): Promise<string> {
+	const endpoint = "repos/{owner}/{repo}/commits/HEAD";
+	const oid = (await $`gh api ${endpoint} --jq .sha`.text()).trim();
+	if (!oid) throw new Error("GitHub returned an empty default-branch commit OID");
+	return oid;
+}
+
+/** Close a stale/superseded release PR and delete its branch before replacement. */
 async function closeStaleReleasePR(version: string): Promise<void> {
 	const branch = `release/v${version}`;
 	console.log(`Superseding stale release PR ${branch}…`);
-	try {
-		await $`gh pr close ${branch} --delete-branch --comment ${"Superseded by the canonical auto-release target (idempotent reconcile); these commits are covered by a newer release PR or an already-published tag."}`;
-	} catch (e) {
-		console.warn(`  (could not close ${branch}: ${e}) — non-fatal`);
-	}
+	await $`gh pr close ${branch} --delete-branch --comment ${"Superseded by the canonical auto-release target (idempotent reconcile); these commits are covered by a newer release PR or an already-published tag."}`;
 }
 
 async function cmdAutoRelease(): Promise<void> {
@@ -607,8 +620,8 @@ async function cmdAutoRelease(): Promise<void> {
 	// closing any stale/phantom release PRs a prior run left behind. Deterministic —
 	// re-running with the same repo state yields the same open-release-PR set, so a
 	// stranded conflicting release branch is cleaned programmatically, not by hand.
-	const openVersions = await listOpenReleaseVersions();
-	const plan = planReleaseReconcile({ openReleaseVersions: openVersions, target });
+	const [openReleasePRs, currentMainOid] = await Promise.all([listOpenReleasePRs(), readDefaultBranchOid()]);
+	const plan = planReleaseReconcile({ openReleasePRs, target, currentMainOid });
 	for (const v of plan.toClose) await closeStaleReleasePR(v);
 
 	if (!result) {


### PR DESCRIPTION
## Summary

Regenerate a same-version release PR when newer commits have merged into the default branch.

## Related Issue

Closes #2727

## Changes

- Query open release PR base OIDs and the current default-branch OID from GitHub.
- Retain the canonical target only when its recorded base is current.
- Close stale targets before recreating them, and fail the release job if reconciliation cannot complete.
- Document the release fix in the coding-agent changelog.

## Verification evidence

- Red: `bun test packages/coding-agent/test/scripts/release-reconcile.test.ts` failed 0/6 against the version-only planner.
- Green: the same focused suite passed 6/6, including stale same-target close-and-recreate behavior.
- `bun check:ts` passed with 0 Biome findings and all workspace type checks successful.
- `git diff --check` exited 0.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing
- [x] Verified locally with focused tests, workspace TypeScript/Biome checks, and diff validation
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
