### PR TITLE
fix(coding-agent): preserve LiteLLM GPT High metadata

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Invalidated stale release PRs immediately on new `main` pushes, before the full release-creation gate ([#2732](https://github.com/f5-sales-demo/xcsh/issues/2732))
+- Preserved GPT-5.6 Sol High reasoning and token-limit metadata through generated LiteLLM model discovery ([#2729](https://github.com/f5-sales-demo/xcsh/issues/2729))
 - Regenerated stale same-version release PRs when newer commits have merged into `main` ([#2727](https://github.com/f5-sales-demo/xcsh/issues/2727))
 
 ## [19.105.3] - 2026-07-31

--- a/packages/coding-agent/src/config/auto-config.ts
+++ b/packages/coding-agent/src/config/auto-config.ts
@@ -19,7 +19,7 @@ import { $env, isEnoent, logger, readProviderFromModelsYml } from "@f5-sales-dem
 import { DEFAULT_MODEL_ROLE } from "./settings-schema";
 
 /** Current config schema version. Bump when the generated format changes. */
-export const CURRENT_CONFIG_VERSION = 2;
+export const CURRENT_CONFIG_VERSION = 3;
 const LITELLM_CONFIG_DIR_MODE = 0o700;
 const LITELLM_MODELS_FILE_MODE = 0o600;
 
@@ -77,6 +77,17 @@ export function generateModelsYml(baseUrl: string, options?: GenerateModelsYmlOp
 		"    api: openai-completions",
 		"    discovery:",
 		"      type: openai-compat",
+		"    modelOverrides:",
+		"      gpt-5.6-sol:",
+		"        reasoning: true",
+		"        thinking:",
+		"          mode: effort",
+		"          minLevel: high",
+		"          maxLevel: high",
+		"        contextWindow: 1050000",
+		"        maxTokens: 128000",
+		"        compat:",
+		"          supportsTemperature: false",
 	];
 
 	lines.push("");

--- a/packages/coding-agent/test/auto-config.test.ts
+++ b/packages/coding-agent/test/auto-config.test.ts
@@ -962,6 +962,42 @@ describe("config schema versioning", () => {
 		expect(fs.existsSync(`${modelsPath}.bak`)).toBe(true);
 	});
 
+	test.skipIf(process.platform === "win32")(
+		"startupHealthCheck upgrades version 2 metadata with owner-only live and backup files",
+		() => {
+			setEnv("https://proxy.example.com", "sk-abc123");
+			fs.writeFileSync(
+				modelsPath,
+				[
+					"configVersion: 2",
+					"providers:",
+					"  anthropic:",
+					'    baseUrl: "https://proxy.example.com/anthropic"',
+					"    apiKey: LITELLM_API_KEY",
+					"  litellm:",
+					'    baseUrl: "https://proxy.example.com/v1"',
+					"    apiKey: LITELLM_API_KEY",
+					"    api: openai-completions",
+					"    discovery:",
+					"      type: openai-compat",
+				].join("\n"),
+				{ mode: 0o644 },
+			);
+
+			const repaired = startupHealthCheck("ok", modelsPath, {
+				anthropic: { baseUrl: "https://proxy.example.com/anthropic" },
+			});
+
+			expect(repaired).toBe(true);
+			const content = fs.readFileSync(modelsPath, "utf-8");
+			expect(content).toContain(`configVersion: ${CURRENT_CONFIG_VERSION}`);
+			expect(content).toContain("gpt-5.6-sol:");
+			expect(content).toContain("minLevel: high");
+			expect(fs.statSync(modelsPath).mode & 0o777).toBe(0o600);
+			expect(fs.statSync(`${modelsPath}.bak`).mode & 0o777).toBe(0o600);
+		},
+	);
+
 	test("startupHealthCheck does not regenerate when configVersion is current", () => {
 		setEnv("https://proxy.example.com", "sk-abc123");
 		fs.mkdirSync(path.dirname(modelsPath), { recursive: true });

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Effort, type Model, type OpenAICompat, type ThinkingConfig, writeModelCache } from "@f5-sales-demo/pi-ai";
 import { hookFetch, Snowflake } from "@f5-sales-demo/pi-utils";
+import { generateModelsYml } from "@f5-sales-demo/xcsh/config/auto-config";
 import {
 	kNoAuth,
 	MODEL_ROLES,
@@ -1802,6 +1803,45 @@ describe("ModelRegistry", () => {
 	});
 
 	describe("openai-compat discovery (LiteLLM proxy)", () => {
+		test("generated config preserves GPT-5.6 Sol High reasoning metadata after discovery", async () => {
+			const previousBaseUrl = Bun.env.LITELLM_BASE_URL;
+			const previousApiKey = Bun.env.LITELLM_API_KEY;
+			try {
+				Bun.env.LITELLM_BASE_URL = "https://proxy.example.com";
+				Bun.env.LITELLM_API_KEY = "test-key";
+				const generatedModelsPath = path.join(tempDir, "generated-models.yml");
+				fs.writeFileSync(
+					generatedModelsPath,
+					generateModelsYml("https://proxy.example.com", {
+						apiBasePath: "/api/v1",
+						apiKeyLiteral: "test-key",
+					}),
+				);
+				using _hook = mockOpenAiCompatibleModels("https://proxy.example.com/api/v1/models", [
+					"gpt-5.6-sol",
+					"unrelated-model",
+				]);
+
+				const registry = new ModelRegistry(authStorage, generatedModelsPath);
+				await registry.refreshProvider("litellm", "online");
+
+				const model = registry.find("litellm", "gpt-5.6-sol");
+				expect(model).toMatchObject({
+					reasoning: true,
+					thinking: { mode: "effort", minLevel: Effort.High, maxLevel: Effort.High },
+					contextWindow: 1_050_000,
+					maxTokens: 128_000,
+					compat: { supportsTemperature: false },
+				});
+				expect(registry.find("litellm", "unrelated-model")?.reasoning).toBe(false);
+			} finally {
+				if (previousBaseUrl === undefined) delete Bun.env.LITELLM_BASE_URL;
+				else Bun.env.LITELLM_BASE_URL = previousBaseUrl;
+				if (previousApiKey === undefined) delete Bun.env.LITELLM_API_KEY;
+				else Bun.env.LITELLM_API_KEY = previousApiKey;
+			}
+		});
+
 		test("config with discovery.type openai-compat loads without schema error", () => {
 			writeRawModelsJson({
 				litellm: {


### PR DESCRIPTION
## Summary

Ensure generated LiteLLM discovery preserves the High reasoning contract for GPT-5.6 Sol and migrates existing prerelease configs.

## Related Issue

Closes #2729

## Changes

- Add a generated `modelOverrides` entry for the advertised `gpt-5.6-sol` model with High-only reasoning, curated token limits, and temperature compatibility.
- Bump the generated config schema to v3 so existing v2 configs are backed up and repaired.
- Verify live and backup migration files remain owner-only.
- Restore the post-v19.105.3 #2715 changelog entry to `[Unreleased]`.

## Verification evidence

- Red: the isolated generated-config discovery test resolved GPT as `reasoning: false`, 128K context, 8.2K max output, and no compatibility metadata.
- Red: the v2 migration test returned `repaired: false` and did not create a secured backup.
- Green: `bun test packages/coding-agent/test/model-registry.test.ts packages/coding-agent/test/auto-config.test.ts` passed 215/215 with 1,084 assertions.
- `bun check:ts` passed with zero Biome findings and all workspace type checks successful.
- `git diff --check origin/main` exited 0.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing
- [x] Verified locally with focused integration/migration tests and workspace checks
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
