### PR TITLE
fix(release): invalidate stale release PRs immediately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,6 +442,28 @@ jobs:
       - name: Install method smoke tests
         run: bun run ci:test:install-methods
 
+  # Invalidate already-green release PRs immediately when their recorded base
+  # falls behind main. Release creation remains in auto-release after full CI.
+  invalidate-stale-release-prs:
+    if: github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore:')
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3"
+      - name: Close release PRs based on stale main
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: bun scripts/release.ts invalidate-stale
+
   auto-release:
     if: github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore:')
     needs: [check, native, test, install_methods]

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Invalidated stale release PRs immediately on new `main` pushes, before the full release-creation gate ([#2732](https://github.com/f5-sales-demo/xcsh/issues/2732))
 - Regenerated stale same-version release PRs when newer commits have merged into `main` ([#2727](https://github.com/f5-sales-demo/xcsh/issues/2727))
 
 ## [19.105.3] - 2026-07-31

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -417,6 +417,21 @@ describe("CI verify-npm-install uses version-pinned install with backoff (PR #93
 	});
 });
 
+describe("CI invalidates stale release PRs before the full test matrix", () => {
+	it("runs stale invalidation immediately while keeping release creation fully gated", async () => {
+		const workflow = await fs.readFile(path.join(import.meta.dir, "../../../.github/workflows/ci.yml"), "utf8");
+		const match = workflow.match(/\n {2}invalidate-stale-release-prs:\n[\s\S]*?(?=\n {2}auto-release:\n)/);
+		expect(match).not.toBeNull();
+		const job = match?.[0] ?? "";
+		expect(job).not.toContain("needs:");
+		expect(job).toContain("github.ref == 'refs/heads/main'");
+		expect(job).toContain("!startsWith(github.event.head_commit.message, 'chore:')");
+		expect(job).toContain("pull-requests: write");
+		expect(job).toContain("bun scripts/release.ts invalidate-stale");
+		expect(workflow).toContain("needs: [check, native, test, install_methods]");
+	});
+});
+
 describe("vim ex-command onUpdate throttle bypass (commit 8f5b630ac)", () => {
 	it("vim.ts onKbdStep forces update when engine.inputMode is command or search mode", async () => {
 		const src = await fs.readFile(path.join(import.meta.dir, "../src/tools/vim.ts"), "utf8");

--- a/packages/coding-agent/test/scripts/release-reconcile.test.ts
+++ b/packages/coding-agent/test/scripts/release-reconcile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { planReleaseReconcile } from "../../../../scripts/release";
+import { planReleaseReconcile, planStaleReleaseInvalidation } from "../../../../scripts/release";
 
 /**
  * Idempotent auto-release reconcile (#deterministic-ci).
@@ -84,5 +84,28 @@ describe("planReleaseReconcile", () => {
 				currentMainOid,
 			}),
 		).toEqual({ toCreate: null, toClose: ["19.63.0", "20.0.0"] });
+	});
+});
+
+describe("planStaleReleaseInvalidation", () => {
+	it("closes only release PRs created from an older main commit", () => {
+		expect(
+			planStaleReleaseInvalidation({
+				openReleasePRs: [
+					{ version: "19.105.4", baseRefOid: "main-before-fix" },
+					{ version: "19.105.5", baseRefOid: "main-current" },
+				],
+				currentMainOid: "main-current",
+			}),
+		).toEqual(["19.105.4"]);
+	});
+
+	it("is a no-op when every open release PR is based on current main", () => {
+		expect(
+			planStaleReleaseInvalidation({
+				openReleasePRs: [{ version: "19.105.5", baseRefOid: "main-current" }],
+				currentMainOid: "main-current",
+			}),
+		).toEqual([]);
 	});
 });

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -559,6 +559,15 @@ export function planReleaseReconcile(opts: {
 	return { toCreate, toClose };
 }
 
+/** Release PRs that can no longer represent current main and must be invalidated
+ * before their already-green checks allow auto-merge. */
+export function planStaleReleaseInvalidation(opts: {
+	openReleasePRs: OpenReleasePR[];
+	currentMainOid: string;
+}): string[] {
+	return opts.openReleasePRs.filter(pr => pr.baseRefOid !== opts.currentMainOid).map(pr => pr.version);
+}
+
 /** Current in-repo version from the canonical package.json (no leading v). */
 async function readInRepoVersion(): Promise<string> {
 	const pkg = await Bun.file("packages/coding-agent/package.json").json();
@@ -608,6 +617,17 @@ async function closeStaleReleasePR(version: string): Promise<void> {
 	const branch = `release/v${version}`;
 	console.log(`Superseding stale release PR ${branch}…`);
 	await $`gh pr close ${branch} --delete-branch --comment ${"Superseded by the canonical auto-release target (idempotent reconcile); these commits are covered by a newer release PR or an already-published tag."}`;
+}
+
+async function cmdInvalidateStaleReleasePRs(): Promise<void> {
+	console.log("\n=== Invalidate Stale Release PRs ===\n");
+	const [openReleasePRs, currentMainOid] = await Promise.all([listOpenReleasePRs(), readDefaultBranchOid()]);
+	const staleVersions = planStaleReleaseInvalidation({ openReleasePRs, currentMainOid });
+	if (staleVersions.length === 0) {
+		console.log("No stale release PRs found.");
+		return;
+	}
+	for (const version of staleVersions) await closeStaleReleasePR(version);
 }
 
 async function cmdAutoRelease(): Promise<void> {
@@ -674,12 +694,15 @@ if (import.meta.main) {
 		console.error("Usage:");
 		console.error("  bun scripts/release.ts <version>   Open a release PR that bumps to <version>");
 		console.error("  bun scripts/release.ts auto        Detect version from conventional commits + open release PR");
+		console.error("  bun scripts/release.ts invalidate-stale  Close release PRs not based on current main");
 		console.error("  bun scripts/release.ts watch       Watch CI for current commit");
 		process.exit(1);
 	}
 
 	if (arg === "watch") {
 		await cmdWatch();
+	} else if (arg === "invalidate-stale") {
+		await cmdInvalidateStaleReleasePRs();
 	} else if (arg === "auto") {
 		await cmdAutoRelease();
 	} else if (/^\d+\.\d+\.\d+/.test(arg)) {
@@ -689,6 +712,7 @@ if (import.meta.main) {
 		console.error("Usage:");
 		console.error("  bun scripts/release.ts <version>   Open a release PR that bumps to <version>");
 		console.error("  bun scripts/release.ts auto        Detect version from conventional commits + open release PR");
+		console.error("  bun scripts/release.ts invalidate-stale  Close release PRs not based on current main");
 		console.error("  bun scripts/release.ts watch       Watch CI for current commit");
 		process.exit(1);
 	}


### PR DESCRIPTION
Closes #2732

## Summary
- close release PRs whose recorded base OID is behind current `main`
- run invalidation immediately on non-chore `main` pushes without full-matrix dependencies
- keep replacement release creation behind the complete CI gate

## Verification
- focused release/workflow tests: 82 passed, 119 assertions
- `actionlint`
- `bun check:ts`
- `git diff --check`