### PR TITLE
fix(ci): replace deprecated Node 20 Zig setup

### DIFF
--- a/.github/actions/setup-zig/action.yml
+++ b/.github/actions/setup-zig/action.yml
@@ -1,0 +1,49 @@
+name: Setup Zig
+description: Install the repository-pinned Zig toolchain from the official release archive
+
+runs:
+  using: composite
+  steps:
+    - name: Restore Zig release archive
+      uses: actions/cache@v5
+      with:
+        path: ${{ runner.temp }}/zig-0.15.2.tar.xz
+        key: setup-zig-tarball-zig-x86_64-linux-0.15.2.tar.xz
+
+    - name: Restore Zig build cache
+      uses: actions/cache@v5
+      with:
+        path: ${{ github.workspace }}/.zig-cache
+        key: setup-zig-cache-v2-${{ github.job }}-zig-x86_64-linux-0.15.2-${{ github.sha }}
+        restore-keys: setup-zig-cache-v2-${{ github.job }}-zig-x86_64-linux-0.15.2-
+
+    - name: Install Zig 0.15.2
+      shell: bash
+      env:
+        ZIG_VERSION: "0.15.2"
+        ZIG_SHA256: 02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239
+      run: |
+        set -euo pipefail
+
+        if [[ "$RUNNER_OS" != "Linux" || "$RUNNER_ARCH" != "X64" ]]; then
+          echo "::error::The pinned Zig installer supports only Linux X64 runners"
+          exit 1
+        fi
+
+        ARCHIVE="$RUNNER_TEMP/zig-${ZIG_VERSION}.tar.xz"
+        ZIG_DIR="$RUNNER_TEMP/zig-${ZIG_VERSION}"
+        ZIG_URL="https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz"
+
+        if [[ ! -f "$ARCHIVE" ]] || ! printf '%s  %s\n' "$ZIG_SHA256" "$ARCHIVE" | sha256sum --check --status; then
+          curl --silent --show-error --fail --location \
+            --retry 3 --retry-all-errors --connect-timeout 15 --max-time 180 \
+            --output "$ARCHIVE" "$ZIG_URL"
+        fi
+        printf '%s  %s\n' "$ZIG_SHA256" "$ARCHIVE" | sha256sum --check
+
+        mkdir -p "$ZIG_DIR"
+        tar --extract --xz --file "$ARCHIVE" --directory "$ZIG_DIR" --strip-components=1
+        echo "$ZIG_DIR" >> "$GITHUB_PATH"
+        printf 'ZIG_GLOBAL_CACHE_DIR=%s/.zig-cache\nZIG_LOCAL_CACHE_DIR=%s/.zig-cache\n' \
+          "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+        "$ZIG_DIR/zig" version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,9 +198,8 @@ jobs:
           fi
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
-        with:
-          version: "0.15.2"
+      - name: Setup Zig 0.15.2
+        uses: ./.github/actions/setup-zig
       - run: bun install --frozen-lockfile
       - name: Install cross-compilation toolchain
         if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -319,9 +318,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           cache-workspace-crates: true
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
-        with:
-          version: "0.15.2"
+      - name: Setup Zig 0.15.2
+        uses: ./.github/actions/setup-zig
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:
@@ -424,9 +422,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           cache-workspace-crates: true
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
-        with:
-          version: "0.15.2"
+      - name: Setup Zig 0.15.2
+        uses: ./.github/actions/setup-zig
       - name: Cache bun dependencies
         uses: actions/cache@v5
         with:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Replaced the deprecated Node 20 Zig setup action with a checksum-pinned official installer ([#61](https://github.com/f5-sales-demo/xcsh/issues/61))
 - Invalidated stale release PRs immediately on new `main` pushes, before the full release-creation gate ([#2732](https://github.com/f5-sales-demo/xcsh/issues/2732))
 - Regenerated stale same-version release PRs when newer commits have merged into `main` ([#2727](https://github.com/f5-sales-demo/xcsh/issues/2727))
 

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -432,6 +432,28 @@ describe("CI invalidates stale release PRs before the full test matrix", () => {
 	});
 });
 
+describe("CI installs Zig without a deprecated JavaScript action", () => {
+	it("uses a checksum-pinned composite installer in every Zig-dependent job", async () => {
+		const root = path.join(import.meta.dir, "../../..");
+		const workflow = await fs.readFile(path.join(root, ".github/workflows/ci.yml"), "utf8");
+		const installer = await fs.readFile(path.join(root, ".github/actions/setup-zig/action.yml"), "utf8");
+
+		expect(workflow).not.toContain("mlugg/setup-zig");
+		expect(workflow.match(/uses: \.\/\.github\/actions\/setup-zig/g)).toHaveLength(3);
+		expect(installer).toContain("using: composite");
+		expect(installer).toContain('ZIG_VERSION: "0.15.2"');
+		expect(installer).toMatch(/zig-x86_64-linux-\$\{ZIG_VERSION\}\.tar\.xz/);
+		expect(installer).toContain("02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239");
+		expect(installer).toContain("sha256sum --check");
+		expect(installer.match(/uses: actions\/cache@v5/g)).toHaveLength(2);
+		expect(installer).toContain("setup-zig-tarball-zig-x86_64-linux-0.15.2.tar.xz");
+		expect(installer).toContain("ZIG_GLOBAL_CACHE_DIR");
+		expect(installer).toContain("ZIG_LOCAL_CACHE_DIR");
+		expect(installer).toContain('>> "$GITHUB_PATH"');
+		expect(installer).toContain('"$ZIG_DIR/zig" version');
+	});
+});
+
 describe("vim ex-command onUpdate throttle bypass (commit 8f5b630ac)", () => {
 	it("vim.ts onKbdStep forces update when engine.inputMode is command or search mode", async () => {
 		const src = await fs.readFile(path.join(import.meta.dir, "../src/tools/vim.ts"), "utf8");


### PR DESCRIPTION
Closes #61

## Summary
- replace the latest `mlugg/setup-zig` action, which still declares Node 20, with a local composite installer
- pin Zig 0.15.2 to its official archive and SHA-256 digest
- preserve release-archive and per-job Zig build caches
- fail closed on unsupported runner platforms or checksum mismatch

## TDD and verification
- red: regression guard failed because the composite installer did not exist
- green: 75 regression tests, 124 assertions
- `bun check:ts`
- `actionlint .github/workflows/ci.yml`
- parsed composite action metadata with `Bun.YAML`
- `git diff --check`