### PR TITLE
fix(ci): support Zig setup on all release runners

### DIFF
--- a/.github/actions/setup-zig/action.yml
+++ b/.github/actions/setup-zig/action.yml
@@ -7,43 +7,83 @@ runs:
     - name: Restore Zig release archive
       uses: actions/cache@v5
       with:
-        path: ${{ runner.temp }}/zig-0.15.2.tar.xz
-        key: setup-zig-tarball-zig-x86_64-linux-0.15.2.tar.xz
+        path: ${{ runner.temp }}/zig-downloads
+        key: setup-zig-archive-${{ runner.os }}-${{ runner.arch }}-0.15.2
 
     - name: Restore Zig build cache
       uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/.zig-cache
-        key: setup-zig-cache-v2-${{ github.job }}-zig-x86_64-linux-0.15.2-${{ github.sha }}
-        restore-keys: setup-zig-cache-v2-${{ github.job }}-zig-x86_64-linux-0.15.2-
+        key: setup-zig-cache-v3-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-0.15.2-${{ github.sha }}
+        restore-keys: setup-zig-cache-v3-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-0.15.2-
 
     - name: Install Zig 0.15.2
       shell: bash
       env:
         ZIG_VERSION: "0.15.2"
-        ZIG_SHA256: 02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239
       run: |
         set -euo pipefail
 
-        if [[ "$RUNNER_OS" != "Linux" || "$RUNNER_ARCH" != "X64" ]]; then
-          echo "::error::The pinned Zig installer supports only Linux X64 runners"
-          exit 1
+        case "$RUNNER_OS/$RUNNER_ARCH" in
+          Linux/X64)
+            PLATFORM="x86_64-linux"
+            EXTENSION="tar.xz"
+            ZIG_SHA256="02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239"
+            ;;
+          macOS/X64)
+            PLATFORM="x86_64-macos"
+            EXTENSION="tar.xz"
+            ZIG_SHA256="375b6909fc1495d16fc2c7db9538f707456bfc3373b14ee83fdd3e22b3d43f7f"
+            ;;
+          macOS/ARM64)
+            PLATFORM="aarch64-macos"
+            EXTENSION="tar.xz"
+            ZIG_SHA256="3cc2bab367e185cdfb27501c4b30b1b0653c28d9f73df8dc91488e66ece5fa6b"
+            ;;
+          Windows/X64)
+            PLATFORM="x86_64-windows"
+            EXTENSION="zip"
+            ZIG_SHA256="3a0ed1e8799a2f8ce2a6e6290a9ff22e6906f8227865911fb7ddedc3cc14cb0c"
+            ;;
+          *)
+            echo "::error::Unsupported Zig runner: $RUNNER_OS/$RUNNER_ARCH"
+            exit 1
+            ;;
+        esac
+
+        RUNNER_TEMP_PATH="$RUNNER_TEMP"
+        WORKSPACE_PATH="$GITHUB_WORKSPACE"
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          RUNNER_TEMP_PATH=$(cygpath -u "$RUNNER_TEMP")
+          WORKSPACE_PATH=$(cygpath -u "$GITHUB_WORKSPACE")
         fi
 
-        ARCHIVE="$RUNNER_TEMP/zig-${ZIG_VERSION}.tar.xz"
-        ZIG_DIR="$RUNNER_TEMP/zig-${ZIG_VERSION}"
-        ZIG_URL="https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz"
+        ARCHIVE_DIR="$RUNNER_TEMP_PATH/zig-downloads"
+        ARCHIVE="$ARCHIVE_DIR/zig-${PLATFORM}-${ZIG_VERSION}.${EXTENSION}"
+        ZIG_DIR="$RUNNER_TEMP_PATH/zig-${ZIG_VERSION}"
+        ZIG_URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${PLATFORM}-${ZIG_VERSION}.${EXTENSION}"
+        mkdir -p "$ARCHIVE_DIR"
 
-        if [[ ! -f "$ARCHIVE" ]] || ! printf '%s  %s\n' "$ZIG_SHA256" "$ARCHIVE" | sha256sum --check --status; then
+        if [[ ! -f "$ARCHIVE" ]] || ! printf '%s  %s\n' "$ZIG_SHA256" "$ARCHIVE" | shasum -a 256 --check --status; then
           curl --silent --show-error --fail --location \
             --retry 3 --retry-all-errors --connect-timeout 15 --max-time 180 \
             --output "$ARCHIVE" "$ZIG_URL"
         fi
-        printf '%s  %s\n' "$ZIG_SHA256" "$ARCHIVE" | sha256sum --check
+        printf '%s  %s\n' "$ZIG_SHA256" "$ARCHIVE" | shasum -a 256 --check
 
         mkdir -p "$ZIG_DIR"
-        tar --extract --xz --file "$ARCHIVE" --directory "$ZIG_DIR" --strip-components=1
-        echo "$ZIG_DIR" >> "$GITHUB_PATH"
-        printf 'ZIG_GLOBAL_CACHE_DIR=%s/.zig-cache\nZIG_LOCAL_CACHE_DIR=%s/.zig-cache\n' \
-          "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
-        "$ZIG_DIR/zig" version
+        tar --extract --file "$ARCHIVE" --directory "$ZIG_DIR" --strip-components=1
+
+        ZIG_PATH="$ZIG_DIR"
+        ZIG_BINARY="$ZIG_DIR/zig"
+        ZIG_CACHE_DIR="$WORKSPACE_PATH/.zig-cache"
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          ZIG_PATH=$(cygpath -w "$ZIG_DIR")
+          ZIG_BINARY="$ZIG_DIR/zig.exe"
+          ZIG_CACHE_DIR=$(cygpath -w "$ZIG_CACHE_DIR")
+        fi
+
+        echo "$ZIG_PATH" >> "$GITHUB_PATH"
+        printf 'ZIG_GLOBAL_CACHE_DIR=%s\nZIG_LOCAL_CACHE_DIR=%s\n' \
+          "$ZIG_CACHE_DIR" "$ZIG_CACHE_DIR" >> "$GITHUB_ENV"
+        "$ZIG_BINARY" version

--- a/.github/actions/setup-zig/action.yml
+++ b/.github/actions/setup-zig/action.yml
@@ -64,12 +64,20 @@ runs:
         ZIG_URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${PLATFORM}-${ZIG_VERSION}.${EXTENSION}"
         mkdir -p "$ARCHIVE_DIR"
 
-        if [[ ! -f "$ARCHIVE" ]] || ! printf '%s  %s\n' "$ZIG_SHA256" "$ARCHIVE" | shasum -a 256 --check --status; then
+        verify_archive() {
+          if command -v sha256sum >/dev/null 2>&1; then
+            printf '%s  %s\n' "$ZIG_SHA256" "$ARCHIVE" | sha256sum --check "$@"
+          else
+            printf '%s  %s\n' "$ZIG_SHA256" "$ARCHIVE" | shasum -a 256 --check "$@"
+          fi
+        }
+
+        if [[ ! -f "$ARCHIVE" ]] || ! verify_archive --status; then
           curl --silent --show-error --fail --location \
             --retry 3 --retry-all-errors --connect-timeout 15 --max-time 180 \
             --output "$ARCHIVE" "$ZIG_URL"
         fi
-        printf '%s  %s\n' "$ZIG_SHA256" "$ARCHIVE" | shasum -a 256 --check
+        verify_archive
 
         mkdir -p "$ZIG_DIR"
         tar --extract --file "$ARCHIVE" --directory "$ZIG_DIR" --strip-components=1

--- a/.github/actions/setup-zig/action.yml
+++ b/.github/actions/setup-zig/action.yml
@@ -60,27 +60,31 @@ runs:
 
         ARCHIVE_DIR="$RUNNER_TEMP_PATH/zig-downloads"
         ARCHIVE="$ARCHIVE_DIR/zig-${PLATFORM}-${ZIG_VERSION}.${EXTENSION}"
-        ZIG_DIR="$RUNNER_TEMP_PATH/zig-${ZIG_VERSION}"
+        ZIG_DIR="$RUNNER_TEMP_PATH/zig-${PLATFORM}-${ZIG_VERSION}"
         ZIG_URL="https://ziglang.org/download/${ZIG_VERSION}/zig-${PLATFORM}-${ZIG_VERSION}.${EXTENSION}"
         mkdir -p "$ARCHIVE_DIR"
 
         verify_archive() {
-          if command -v sha256sum >/dev/null 2>&1; then
-            printf '%s  %s\n' "$ZIG_SHA256" "$ARCHIVE" | sha256sum --check "$@"
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            printf '%s  %s\n' "$ZIG_SHA256" "$ARCHIVE" | shasum -a 256 -c
           else
-            printf '%s  %s\n' "$ZIG_SHA256" "$ARCHIVE" | shasum -a 256 --check "$@"
+            printf '%s  %s\n' "$ZIG_SHA256" "$ARCHIVE" | sha256sum -c
           fi
         }
 
-        if [[ ! -f "$ARCHIVE" ]] || ! verify_archive --status; then
+        if [[ ! -f "$ARCHIVE" ]] || ! verify_archive >/dev/null 2>&1; then
           curl --silent --show-error --fail --location \
             --retry 3 --retry-all-errors --connect-timeout 15 --max-time 180 \
             --output "$ARCHIVE" "$ZIG_URL"
         fi
         verify_archive
 
-        mkdir -p "$ZIG_DIR"
-        tar --extract --file "$ARCHIVE" --directory "$ZIG_DIR" --strip-components=1
+        if [[ "$EXTENSION" == "zip" ]]; then
+          unzip -q -o "$ARCHIVE" -d "$RUNNER_TEMP_PATH"
+        else
+          mkdir -p "$ZIG_DIR"
+          tar --extract --file "$ARCHIVE" --directory "$ZIG_DIR" --strip-components=1
+        fi
 
         ZIG_PATH="$ZIG_DIR"
         ZIG_BINARY="$ZIG_DIR/zig"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,22 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run ci:check:full
 
+  setup-zig:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-15-intel, macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Zig 0.15.2
+        uses: ./.github/actions/setup-zig
+      - name: Verify Zig
+        shell: bash
+        run: zig version
+
   native:
+    needs: setup-zig
     strategy:
       fail-fast: false
       matrix:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the checksum-pinned Zig installer on macOS and Windows native release runners ([#61](https://github.com/f5-sales-demo/xcsh/issues/61))
+
 ## [19.105.5] - 2026-07-31
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the checksum-pinned Zig installer on macOS and Windows native release runners ([#61](https://github.com/f5-sales-demo/xcsh/issues/61))
+- Fixed the checksum-pinned Zig installer on macOS and Windows native release runners and added cross-platform pre-merge validation ([#61](https://github.com/f5-sales-demo/xcsh/issues/61))
 
 ## [19.105.5] - 2026-07-31
 

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -469,6 +469,8 @@ describe("CI installs Zig without a deprecated JavaScript action", () => {
 			expect(installer).toContain(checksum);
 		}
 		expect(installer).toContain('case "$RUNNER_OS/$RUNNER_ARCH" in');
+		expect(installer).toContain("command -v sha256sum");
+		expect(installer).toContain("sha256sum --check");
 		expect(installer).toContain("shasum -a 256 --check");
 		expect(installer.match(/uses: actions\/cache@v5/g)).toHaveLength(2);
 		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -469,9 +469,11 @@ describe("CI installs Zig without a deprecated JavaScript action", () => {
 			expect(installer).toContain(checksum);
 		}
 		expect(installer).toContain('case "$RUNNER_OS/$RUNNER_ARCH" in');
-		expect(installer).toContain("command -v sha256sum");
-		expect(installer).toContain("sha256sum --check");
-		expect(installer).toContain("shasum -a 256 --check");
+		expect(installer).toContain('if [[ "$RUNNER_OS" == "macOS" ]]');
+		expect(installer).toContain("sha256sum -c");
+		expect(installer).toContain("shasum -a 256 -c");
+		expect(installer).toContain('if [[ "$EXTENSION" == "zip" ]]');
+		expect(installer).toContain('unzip -q -o "$ARCHIVE"');
 		expect(installer.match(/uses: actions\/cache@v5/g)).toHaveLength(2);
 		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression
 		expect(installer).toContain("setup-zig-archive-${{ runner.os }}-${{ runner.arch }}-0.15.2");

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -433,7 +433,7 @@ describe("CI invalidates stale release PRs before the full test matrix", () => {
 });
 
 describe("CI installs Zig without a deprecated JavaScript action", () => {
-	it("uses a checksum-pinned composite installer in every Zig-dependent job", async () => {
+	it("uses a checksum-pinned composite installer for every native release runner", async () => {
 		const root = path.join(import.meta.dir, "../../..");
 		const workflow = await fs.readFile(path.join(root, ".github/workflows/ci.yml"), "utf8");
 		const installer = await fs.readFile(path.join(root, ".github/actions/setup-zig/action.yml"), "utf8");
@@ -442,15 +442,30 @@ describe("CI installs Zig without a deprecated JavaScript action", () => {
 		expect(workflow.match(/uses: \.\/\.github\/actions\/setup-zig/g)).toHaveLength(3);
 		expect(installer).toContain("using: composite");
 		expect(installer).toContain('ZIG_VERSION: "0.15.2"');
-		expect(installer).toMatch(/zig-x86_64-linux-\$\{ZIG_VERSION\}\.tar\.xz/);
-		expect(installer).toContain("02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239");
-		expect(installer).toContain("sha256sum --check");
+		const releases = [
+			["Linux/X64", "x86_64-linux", "tar.xz", "02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239"],
+			["macOS/X64", "x86_64-macos", "tar.xz", "375b6909fc1495d16fc2c7db9538f707456bfc3373b14ee83fdd3e22b3d43f7f"],
+			["macOS/ARM64", "aarch64-macos", "tar.xz", "3cc2bab367e185cdfb27501c4b30b1b0653c28d9f73df8dc91488e66ece5fa6b"],
+			["Windows/X64", "x86_64-windows", "zip", "3a0ed1e8799a2f8ce2a6e6290a9ff22e6906f8227865911fb7ddedc3cc14cb0c"],
+		] as const;
+		for (const [runner, platform, extension, checksum] of releases) {
+			expect(installer).toContain(`${runner})`);
+			expect(installer).toContain(`PLATFORM="${platform}"`);
+			expect(installer).toContain(`EXTENSION="${extension}"`);
+			expect(installer).toContain(checksum);
+		}
+		expect(installer).toContain('case "$RUNNER_OS/$RUNNER_ARCH" in');
+		expect(installer).toContain("shasum -a 256 --check");
 		expect(installer.match(/uses: actions\/cache@v5/g)).toHaveLength(2);
-		expect(installer).toContain("setup-zig-tarball-zig-x86_64-linux-0.15.2.tar.xz");
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression
+		expect(installer).toContain("setup-zig-archive-${{ runner.os }}-${{ runner.arch }}-0.15.2");
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression
+		expect(installer).toContain("setup-zig-cache-v3-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}");
 		expect(installer).toContain("ZIG_GLOBAL_CACHE_DIR");
 		expect(installer).toContain("ZIG_LOCAL_CACHE_DIR");
+		expect(installer).toContain('cygpath -w "$ZIG_DIR"');
 		expect(installer).toContain('>> "$GITHUB_PATH"');
-		expect(installer).toContain('"$ZIG_DIR/zig" version');
+		expect(installer).toContain('"$ZIG_BINARY" version');
 	});
 });
 

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -433,13 +433,27 @@ describe("CI invalidates stale release PRs before the full test matrix", () => {
 });
 
 describe("CI installs Zig without a deprecated JavaScript action", () => {
+	it("executes the Zig installer on every release runner before native builds", async () => {
+		const workflow = await fs.readFile(path.join(import.meta.dir, "../../../.github/workflows/ci.yml"), "utf8");
+		const smokeJob = workflow.match(/\n {2}setup-zig:\n[\s\S]*?(?=\n {2}native:\n)/)?.[0] ?? "";
+		const nativeJob = workflow.match(/\n {2}native:\n[\s\S]*?(?=\n {2}test:\n)/)?.[0] ?? "";
+
+		expect(smokeJob).toContain("ubuntu-22.04");
+		expect(smokeJob).toContain("macos-15-intel");
+		expect(smokeJob).toContain("macos-14");
+		expect(smokeJob).toContain("windows-latest");
+		expect(smokeJob).toContain("uses: ./.github/actions/setup-zig");
+		expect(smokeJob).toContain("run: zig version");
+		expect(nativeJob).toContain("needs: setup-zig");
+	});
+
 	it("uses a checksum-pinned composite installer for every native release runner", async () => {
 		const root = path.join(import.meta.dir, "../../..");
 		const workflow = await fs.readFile(path.join(root, ".github/workflows/ci.yml"), "utf8");
 		const installer = await fs.readFile(path.join(root, ".github/actions/setup-zig/action.yml"), "utf8");
 
 		expect(workflow).not.toContain("mlugg/setup-zig");
-		expect(workflow.match(/uses: \.\/\.github\/actions\/setup-zig/g)).toHaveLength(3);
+		expect(workflow.match(/uses: \.\/\.github\/actions\/setup-zig/g)).toHaveLength(4);
 		expect(installer).toContain("using: composite");
 		expect(installer).toContain('ZIG_VERSION: "0.15.2"');
 		const releases = [


### PR DESCRIPTION
## Summary
- map every tagged native runner to its official Zig 0.15.2 archive and SHA-256 checksum
- use cross-platform checksum verification, extraction, cache keys, and Windows path normalization
- add regression coverage for Linux X64, macOS X64/ARM64, and Windows X64

Fixes #61

## Verification
- red/green focused regression test
- `bun test packages/coding-agent/test/regression-guard.test.ts` (78 pass)
- `bun check:ts`
- local macOS ARM64 composite-action rehearsal (`zig version` = 0.15.2)