### PR TITLE
fix(coding-agent): harden post-login model switching

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed exact `provider/model` searches in `/model` and restricted global agent configuration writes to owner-only permissions ([#2741](https://github.com/f5-sales-demo/xcsh/issues/2741))
+
 ## [19.105.6] - 2026-07-31
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/agent-config-file.ts
+++ b/packages/coding-agent/src/config/agent-config-file.ts
@@ -1,0 +1,34 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { isEnoent } from "@f5-sales-demo/pi-utils";
+
+const AGENT_CONFIG_DIR_MODE = 0o700;
+const AGENT_CONFIG_FILE_MODE = 0o600;
+
+export function hardenAgentConfigFileSync(filePath: string): void {
+	try {
+		fs.chmodSync(filePath, AGENT_CONFIG_FILE_MODE);
+	} catch (error) {
+		if (!isEnoent(error)) throw error;
+	}
+}
+
+export async function hardenAgentConfigFile(filePath: string): Promise<void> {
+	try {
+		await fs.promises.chmod(filePath, AGENT_CONFIG_FILE_MODE);
+	} catch (error) {
+		if (!isEnoent(error)) throw error;
+	}
+}
+
+export function writeAgentConfigFileSync(filePath: string, content: string): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: AGENT_CONFIG_DIR_MODE });
+	hardenAgentConfigFileSync(filePath);
+	fs.writeFileSync(filePath, content, { encoding: "utf-8", mode: AGENT_CONFIG_FILE_MODE });
+}
+
+export async function writeAgentConfigFile(filePath: string, content: string): Promise<void> {
+	await fs.promises.mkdir(path.dirname(filePath), { recursive: true, mode: AGENT_CONFIG_DIR_MODE });
+	await hardenAgentConfigFile(filePath);
+	await fs.promises.writeFile(filePath, content, { encoding: "utf-8", mode: AGENT_CONFIG_FILE_MODE });
+}

--- a/packages/coding-agent/src/config/auto-config.ts
+++ b/packages/coding-agent/src/config/auto-config.ts
@@ -16,6 +16,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { $env, isEnoent, logger, readProviderFromModelsYml } from "@f5-sales-demo/pi-utils";
+import { hardenAgentConfigFileSync, writeAgentConfigFileSync } from "./agent-config-file";
 import { DEFAULT_MODEL_ROLE } from "./settings-schema";
 
 /** Current config schema version. Bump when the generated format changes. */
@@ -189,6 +190,7 @@ const UNRESOLVABLE_DEFAULT_PROVIDER_PREFIXES = ["bench-instant/"];
  */
 export function healConfigYmlModelRoles(configPath: string): void {
 	try {
+		hardenAgentConfigFileSync(configPath);
 		const content = fs.readFileSync(configPath, "utf-8");
 		if (!content.includes("modelRoles:")) return; // binary default applies
 		const defaultLine = /^(\s*)default:\s*(\S+)\s*$/m;
@@ -197,7 +199,7 @@ export function healConfigYmlModelRoles(configPath: string): void {
 			const [, indent, value] = match;
 			if (UNRESOLVABLE_DEFAULT_PROVIDER_PREFIXES.some(prefix => value.startsWith(prefix))) {
 				const healed = content.replace(defaultLine, `${indent}default: ${DEFAULT_MODEL_ROLE_VALUE}`);
-				fs.writeFileSync(configPath, healed);
+				writeAgentConfigFileSync(configPath, healed);
 				logger.debug("Healed config.yml: replaced unresolvable default modelRole", {
 					configPath,
 					previous: value,
@@ -244,8 +246,7 @@ function backupModelsConfigIfExists(filePath: string): boolean {
 /** Safely write a file, creating parent directories. */
 function safeWrite(filePath: string, content: string): boolean {
 	try {
-		fs.mkdirSync(path.dirname(filePath), { recursive: true });
-		fs.writeFileSync(filePath, content, "utf-8");
+		writeAgentConfigFileSync(filePath, content);
 		return true;
 	} catch (err) {
 		logger.warn("Failed to write config file", { filePath, err });

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -35,6 +35,7 @@ import {
 } from "../modes/theme/theme";
 import { AgentStorage } from "../session/agent-storage";
 import { type EditMode, normalizeEditMode } from "../utils/edit-mode";
+import { hardenAgentConfigFile, writeAgentConfigFile } from "./agent-config-file";
 import { withFileLock } from "./file-lock";
 import {
 	type BashInterceptorRule,
@@ -421,6 +422,7 @@ export class Settings {
 
 			// Migrate from legacy formats if needed
 			await this.#migrateFromLegacy();
+			await hardenAgentConfigFile(this.#configPath!);
 
 			// Load global settings from config.yml
 			this.#global = await this.#loadYaml(this.#configPath!);
@@ -504,7 +506,7 @@ export class Settings {
 		// 3. Write merged settings
 		if (migrated && Object.keys(settings).length > 0) {
 			try {
-				await Bun.write(this.#configPath, YAML.stringify(settings, null, 2));
+				await writeAgentConfigFile(this.#configPath, YAML.stringify(settings, null, 2));
 				logger.debug("Settings: migrated to config.yml", { path: this.#configPath });
 			} catch {}
 		}
@@ -592,7 +594,7 @@ export class Settings {
 
 				// Update our global with any external changes we preserved
 				this.#global = current;
-				await Bun.write(configPath, YAML.stringify(this.#global, null, 2));
+				await writeAgentConfigFile(configPath, YAML.stringify(this.#global, null, 2));
 			});
 		} catch (error) {
 			logger.warn("Settings: save failed", { error: String(error) });

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -539,7 +539,11 @@ export class ModelSelectorComponent extends Container {
 				this.#sortCanonicalModels(fuzzyMatches);
 				this.#filteredCanonicalModels = fuzzyMatches;
 			} else {
-				const fuzzyMatches = fuzzyFilter(baseModels, query, ({ id, provider }) => `${id} ${provider}`);
+				const fuzzyMatches = fuzzyFilter(
+					baseModels,
+					query,
+					({ id, model, provider, selector }) => `${selector} ${id} ${provider} ${model.name}`,
+				);
 				this.#sortModels(fuzzyMatches);
 				this.#filteredModels = fuzzyMatches;
 			}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -7,6 +7,7 @@ import type { Component } from "@f5-sales-demo/pi-tui";
 import { Input, Loader, Spacer, Text } from "@f5-sales-demo/pi-tui";
 import { getAgentDbPath, getAgentDir, getConfigDirName, getProjectDir, t } from "@f5-sales-demo/pi-utils";
 import { invalidate as invalidateFsCache } from "../../capability/fs";
+import { writeAgentConfigFileSync } from "../../config/agent-config-file";
 import {
 	generateConfigYml,
 	generateModelsYml,
@@ -997,7 +998,7 @@ export class SelectorController {
 			// Create/heal config.yml for model defaults
 			const configPath = path.join(path.dirname(modelsPath), "config.yml");
 			if (!fs.existsSync(configPath)) {
-				fs.writeFileSync(configPath, generateConfigYml());
+				writeAgentConfigFileSync(configPath, generateConfigYml());
 			}
 			healConfigYmlModelRoles(configPath);
 
@@ -1234,7 +1235,7 @@ export class SelectorController {
 
 					const configPath = path.join(path.dirname(modelsPath), "config.yml");
 					if (!fs.existsSync(configPath)) {
-						fs.writeFileSync(configPath, generateConfigYml());
+						writeAgentConfigFileSync(configPath, generateConfigYml());
 					}
 					healConfigYmlModelRoles(configPath);
 

--- a/packages/coding-agent/test/auto-config.test.ts
+++ b/packages/coding-agent/test/auto-config.test.ts
@@ -221,6 +221,7 @@ describe("tryAutoConfigLiteLLM()", () => {
 		expect(content).toContain("https://proxy.example.com/anthropic");
 		if (process.platform !== "win32") {
 			expect(fs.statSync(modelsPath).mode & 0o777).toBe(0o600);
+			expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
 		}
 	});
 

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -125,4 +125,22 @@ describe("ModelSelector role badge thinking display", () => {
 		expect(menuRendered).toContain("Set as custom-fast");
 		expect(menuRendered).toContain("Set as SMOL (Quick)");
 	});
+
+	test("finds a model by its displayed provider/model selector", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+
+		const selector = createSelector(model, Settings.isolated());
+		await Bun.sleep(0);
+
+		for (const character of `${model.provider}/${model.id}`) {
+			selector.handleInput(character);
+		}
+
+		installTestTheme();
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain(`${model.provider}/${model.id}`);
+		expect(rendered).not.toContain("No matching models");
+	});
 });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -121,4 +121,16 @@ describe("Settings", () => {
 			expect(savedSettings.defaultThinkingLevel).toBe(Effort.High);
 		});
 	});
+
+	describe.skipIf(process.platform === "win32")("config file permissions", () => {
+		it("restores owner-only permissions when rewriting config.yml", async () => {
+			fs.writeFileSync(getConfigPath(), "modelRoles:\n  default: anthropic/claude-opus-5\n", { mode: 0o644 });
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			settings.set("defaultThinkingLevel", Effort.High);
+			await settings.flush();
+
+			expect(fs.statSync(getConfigPath()).mode & 0o777).toBe(0o600);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

- match `/model` searches against the displayed `provider/model` selector
- create, migrate, load, heal, and rewrite global agent `config.yml` with owner-only permissions
- cover login-created and settings-rewritten permissions plus exact selector search

Fixes #2741

## Verification

- TDD: 3 new contracts failed before implementation
- `bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts packages/coding-agent/test/settings-manager.test.ts packages/coding-agent/test/auto-config.test.ts` (137 passed)
- `bun check:ts`
- live tmux UAT against the LiteLLM proxy: exact `anthropic/claude-opus-5` search, in-session switch, High-thinking exact-marker inference
- verified `config.yml`, `models.yml`, and `models.yml.bak` are all `0600`
