### PR TITLE
fix(coding-agent): prevent parent workspace enumeration

### DIFF
--- a/crates/brush-core-vendored/src/completion.rs
+++ b/crates/brush-core-vendored/src/completion.rs
@@ -267,6 +267,7 @@ impl Spec {
 			let expansions = pattern.expand(
 				shell.working_dir(),
 				Some(&patterns::Pattern::accept_all_expand_filter),
+				Some(&patterns::Pattern::accept_all_expand_filter),
 				&patterns::FilenameExpansionOptions::default(),
 			)?;
 
@@ -1086,6 +1087,7 @@ async fn get_file_completions(
 		.expand(
 			shell.working_dir(),
 			Some(&path_filter),
+			Some(&patterns::Pattern::accept_all_expand_filter),
 			&patterns::FilenameExpansionOptions::default(),
 		)
 		.unwrap_or_default()

--- a/crates/brush-core-vendored/src/containment.rs
+++ b/crates/brush-core-vendored/src/containment.rs
@@ -6,8 +6,9 @@
 //! written cannot matter.
 //!
 //! It is deliberately permissive. Anything matched by no root is outside the fence and allowed, so
-//! `/usr`, `/tmp`, package caches, the network and process execution are untouched. The single thing
-//! it prevents is reaching into another customer's checkout or the operator's private files.
+//! `/usr`, `/tmp`, package caches, the network and process execution are untouched. Cross-tenant
+//! isolation removes accidental parent enumeration while preserving named operator access; explicit
+//! data-root and cross-session state denies remain recursive.
 //!
 //! The fence is per-invocation and absent by default: only the model's `bash` tool supplies one.
 //! Host-driven shell use — credential helpers, the interactive `xcsh shell`, snapshot sourcing —
@@ -108,6 +109,8 @@ pub enum FenceAccess {
 	Read,
 	/// Writing or creating a path.
 	Write,
+	/// Reading the entries of one directory.
+	Enumerate,
 }
 
 /// Canonical roots describing what the shell may reach.
@@ -121,6 +124,8 @@ pub struct ContainmentFence {
 	pub allow_write_only: Vec<PathBuf>,
 	/// Roots denied in both directions, winning over any allow they sit inside.
 	pub deny: Vec<PathBuf>,
+	/// Exact directories whose entries may not be enumerated. Descendants remain reachable by name.
+	pub deny_enumerate: Vec<PathBuf>,
 }
 
 /// How specific a matching root is. Deeper wins, so a nested rule beats the root it sits inside.
@@ -200,9 +205,20 @@ impl ContainmentFence {
 			&& self.allow_read_only.is_empty()
 			&& self.allow_write_only.is_empty()
 			&& self.deny.is_empty()
+			&& self.deny_enumerate.is_empty()
 		{
 			return true;
 		}
+
+		if access == FenceAccess::Enumerate && self.deny_enumerate.iter().any(|root| root == resolved) {
+			return false;
+		}
+
+		let ordinary_access = if access == FenceAccess::Enumerate {
+			FenceAccess::Read
+		} else {
+			access
+		};
 
 		let denied = deepest_match(&self.deny, resolved);
 		let read_only = deepest_match(&self.allow_read_only, resolved);
@@ -220,10 +236,10 @@ impl ContainmentFence {
 			return false;
 		}
 		if read_only == Some(deepest) {
-			return access == FenceAccess::Read;
+			return ordinary_access == FenceAccess::Read;
 		}
 		if write_only == Some(deepest) {
-			return access == FenceAccess::Write;
+			return ordinary_access == FenceAccess::Write;
 		}
 		true
 	}
@@ -256,10 +272,12 @@ impl DirLister for RealFs {
 /// Which directions a single grant covers.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct GrantRights {
-	/// The subtree may be read.
+	/// Files in the subtree may be read.
 	pub read:  bool,
 	/// The subtree may be written.
 	pub write: bool,
+	/// Directories in the subtree may be enumerated.
+	pub enumerate: bool,
 }
 
 /// What a fence root grants, ordered so the greater value wins when two roots name the same path.
@@ -281,8 +299,10 @@ impl RootKind {
 		match (self, access) {
 			(Self::Deny, _) => false,
 			(Self::Allow, _) => true,
-			(Self::ReadOnly, FenceAccess::Read) | (Self::WriteOnly, FenceAccess::Write) => true,
-			(Self::ReadOnly, FenceAccess::Write) | (Self::WriteOnly, FenceAccess::Read) => false,
+			(Self::ReadOnly, FenceAccess::Read | FenceAccess::Enumerate)
+			| (Self::WriteOnly, FenceAccess::Write) => true,
+			(Self::ReadOnly, FenceAccess::Write)
+			| (Self::WriteOnly, FenceAccess::Read | FenceAccess::Enumerate) => false,
 		}
 	}
 }
@@ -291,6 +311,7 @@ impl RootKind {
 #[derive(Debug, Default)]
 struct Node {
 	kind: Option<RootKind>,
+	deny_enumerate: bool,
 	kids: std::collections::BTreeMap<std::ffi::OsString, Node>,
 }
 
@@ -301,8 +322,9 @@ impl Node {
 	/// which is what keeps the rule count small and avoids enumerating directories needlessly.
 	fn subtree_differs(&self, inherited: bool, access: FenceAccess) -> bool {
 		self.kids.values().any(|kid| {
-			let here = kid.kind.map_or(inherited, |kind| kind.grants(access));
-			here != inherited || kid.subtree_differs(here, access)
+			let recursive = kid.kind.map_or(inherited, |kind| kind.grants(access));
+			let here = recursive && !(access == FenceAccess::Enumerate && kid.deny_enumerate);
+			here != inherited || kid.subtree_differs(recursive, access)
 		})
 	}
 }
@@ -342,6 +364,7 @@ impl GrantPlan {
 				&& match access {
 					FenceAccess::Read => rights.read,
 					FenceAccess::Write => rights.write,
+					FenceAccess::Enumerate => rights.enumerate,
 				}
 		})
 	}
@@ -355,7 +378,7 @@ impl ContainmentFence {
 	/// So the denied subtrees are subtracted by walking down to each one and granting its siblings at
 	/// every level, which is the only way to preserve "a path matched by nothing is allowed".
 	///
-	/// **Compiled once per direction and merged.** Doing both at once would let a read-only root split
+	/// **Compiled once per direction and merged.** Combining directions would let a read-only root split
 	/// the *read* plan, breaking `ls` of its parent for no reason — the directions are independent
 	/// because Landlock unions rights per rule.
 	///
@@ -373,7 +396,7 @@ impl ContainmentFence {
 		let mut split_dirs: Vec<PathBuf> = Vec::new();
 		let mut unenumerable: Vec<PathBuf> = Vec::new();
 
-		for access in [FenceAccess::Read, FenceAccess::Write] {
+		for access in [FenceAccess::Read, FenceAccess::Write, FenceAccess::Enumerate] {
 			let mut granted: Vec<PathBuf> = Vec::new();
 			walk_for_access(
 				&trie,
@@ -390,6 +413,7 @@ impl ContainmentFence {
 				match access {
 					FenceAccess::Read => rights.read = true,
 					FenceAccess::Write => rights.write = true,
+					FenceAccess::Enumerate => rights.enumerate = true,
 				}
 			}
 		}
@@ -420,6 +444,15 @@ impl ContainmentFence {
 				node.kind = Some(node.kind.map_or(kind, |existing| existing.max(kind)));
 			}
 		}
+		for path in &self.deny_enumerate {
+			let mut node = &mut root;
+			for component in path.components() {
+				if let Component::Normal(name) = component {
+					node = node.kids.entry(name.to_os_string()).or_default();
+				}
+			}
+			node.deny_enumerate = true;
+		}
 		root
 	}
 }
@@ -437,17 +470,18 @@ fn walk_for_access(
 	split_dirs: &mut Vec<PathBuf>,
 	unenumerable: &mut Vec<PathBuf>,
 ) {
-	let here = node.kind.map_or(inherited, |kind| kind.grants(access));
+	let recursive = node.kind.map_or(inherited, |kind| kind.grants(access));
+	let here = recursive && !(access == FenceAccess::Enumerate && node.deny_enumerate);
 
 	// Uniform subtree: one rule settles it, and no directory has to be read.
-	if !node.subtree_differs(here, access) {
+	if here == recursive && !node.subtree_differs(recursive, access) {
 		if here {
 			granted.push(path.to_path_buf());
 		}
 		return;
 	}
 
-	if here {
+	if recursive {
 		// Granted here but not everywhere below, so this directory cannot be granted as a subtree.
 		// Grant the children that are not mentioned by the fence, and record what that costs.
 		split_dirs.push(path.to_path_buf());
@@ -467,7 +501,7 @@ fn walk_for_access(
 		walk_for_access(
 			kid,
 			&path.join(name),
-			here,
+			recursive,
 			access,
 			lister,
 			granted,
@@ -535,6 +569,7 @@ impl ContainmentFence {
 			/// Existence and stat only, never contents or a directory listing.
 			Metadata(&'a PathBuf),
 			Deny(&'a PathBuf),
+			DenyEnumerate(&'a PathBuf),
 			Allow(&'a PathBuf),
 			ReadOnly(&'a PathBuf),
 			WriteOnly(&'a PathBuf),
@@ -543,6 +578,7 @@ impl ContainmentFence {
 		let mut rules: Vec<Rule<'_>> = Vec::new();
 		rules.extend(self.deny.iter().map(Rule::Deny));
 		rules.extend(self.deny.iter().map(Rule::Metadata));
+		rules.extend(self.deny_enumerate.iter().map(Rule::DenyEnumerate));
 		rules.extend(self.allow.iter().map(Rule::Allow));
 		rules.extend(self.allow_read_only.iter().map(Rule::ReadOnly));
 		rules.extend(self.allow_write_only.iter().map(Rule::WriteOnly));
@@ -555,6 +591,8 @@ impl ContainmentFence {
 			Rule::Deny(root) => (depth(root), 2),
 			// After the deny at the same depth, so it re-permits stat and nothing else.
 			Rule::Metadata(root) => (depth(root), 3),
+			// Exact enumeration denies win over a recursive allow at the same depth.
+			Rule::DenyEnumerate(root) => (depth(root), 4),
 		});
 
 		let mut profile = String::from("(version 1)\n(allow default)\n");
@@ -570,6 +608,12 @@ impl ContainmentFence {
 				// denied — so a sibling's name is still not discoverable, only that the parent exists.
 				Rule::Metadata(root) => profile.push_str(&format!(
 					"(allow file-read-metadata (subpath \"{}\"))\n",
+					 escape_for_profile(root)
+				)),
+				// A literal `file-read-data` denial prevents `readdir` on this directory but does not
+				// cover a named child. Traversal, metadata, and reads below a known child stay allowed.
+				Rule::DenyEnumerate(root) => profile.push_str(&format!(
+					"(deny file-read-data (literal \"{}\"))\n",
 					escape_for_profile(root)
 				)),
 				Rule::Allow(root) => profile.push_str(&format!(

--- a/crates/brush-core-vendored/src/expansion.rs
+++ b/crates/brush-core-vendored/src/expansion.rs
@@ -646,12 +646,16 @@ impl<'a> WordExpander<'a> {
 				.expand(
 					self.shell.working_dir(),
 					Some(&|path: &std::path::Path| fence.permits(path, crate::containment::FenceAccess::Read)),
+					Some(&|path: &std::path::Path| {
+						fence.permits(path, crate::containment::FenceAccess::Enumerate)
+					}),
 					&options,
 				)
 				.unwrap_or_default(),
 			None => pattern
 				.expand(
 					self.shell.working_dir(),
+					Some(&patterns::Pattern::accept_all_expand_filter),
 					Some(&patterns::Pattern::accept_all_expand_filter),
 					&options,
 				)

--- a/crates/brush-core-vendored/src/patterns.rs
+++ b/crates/brush-core-vendored/src/patterns.rs
@@ -126,16 +126,19 @@ impl Pattern {
 	///
 	/// * `working_dir` - The current working directory, used for relative paths.
 	/// * `path_filter` - Optionally provides a function that filters paths after expansion.
+	/// * `enumerate_filter` - Optionally decides whether a directory may be read during expansion.
 
 	#[allow(clippy::unwrap_in_result)]
-	pub(crate) fn expand<PF>(
+	pub(crate) fn expand<PF, EF>(
 		&self,
 		working_dir: &Path,
 		path_filter: Option<&PF>,
+		enumerate_filter: Option<&EF>,
 		options: &FilenameExpansionOptions,
 	) -> Result<Vec<String>, error::Error>
 	where
 		PF: Fn(&Path) -> bool,
+		EF: Fn(&Path) -> bool,
 	{
 		// If the pattern is completely empty, then short-circuit the function; there's
 		// no reason to proceed onward when we know there's no expansions.
@@ -225,6 +228,9 @@ impl Pattern {
 
 			let current_paths = std::mem::take(&mut paths_so_far);
 			for current_path in current_paths {
+				if enumerate_filter.is_some_and(|filter| !filter(&current_path)) {
+					continue;
+				}
 				let subpattern = Self::from(&component)
 					.set_extended_globbing(self.enable_extended_globbing)
 					.set_case_insensitive(self.case_insensitive);

--- a/crates/brush-core-vendored/src/sys/unix/landlock.rs
+++ b/crates/brush-core-vendored/src/sys/unix/landlock.rs
@@ -169,9 +169,14 @@ pub fn availability() -> Availability {
 	})
 }
 
-/// The rights granted for reading a subtree.
-const fn read_rights() -> u64 {
-	ACCESS_FS_READ_FILE | ACCESS_FS_READ_DIR
+/// The right granted for reading file contents in a subtree.
+const fn read_file_rights() -> u64 {
+	ACCESS_FS_READ_FILE
+}
+
+/// The right granted for reading directory entries in a subtree.
+const fn enumerate_rights() -> u64 {
+	ACCESS_FS_READ_DIR
 }
 
 /// The rights granted for writing a subtree, at the given ABI.
@@ -202,7 +207,7 @@ const fn write_rights(abi: u32) -> u64 {
 /// ABI rather than written out.
 #[must_use]
 pub const fn handled_rights(abi: u32) -> u64 {
-	read_rights() | write_rights(abi)
+	read_file_rights() | enumerate_rights() | write_rights(abi)
 }
 
 /// Whether truncation is governed at this ABI.
@@ -317,7 +322,10 @@ pub fn build_ruleset(plan: &GrantPlan, abi: u32, creatable: &[PathBuf]) -> io::R
 	for (path, rights) in &plan.grants {
 		let mut allowed = 0_u64;
 		if rights.read {
-			allowed |= read_rights();
+			allowed |= read_file_rights();
+		}
+		if rights.enumerate {
+			allowed |= enumerate_rights();
 		}
 		if rights.write {
 			allowed |= write_rights(abi);

--- a/crates/containment-check/landlock-e2e.sh
+++ b/crates/containment-check/landlock-e2e.sh
@@ -85,6 +85,16 @@ expect "truncate a file in the workspace" ok ": > own.txt && test ! -s own.txt"
 expect "pipeline with grep and sed" ok "printf 'a\\nb\\n' > p.txt && sed -n 2p p.txt | grep b"
 expect "tar roundtrip" ok "mkdir -p t && echo x > t/f && tar czf t.tgz t && rm -rf t && tar xzf t.tgz && cat t/f"
 
+printf '\n=== exact parent enumeration courtesy ===\n'
+BASE_FENCE="$FENCE"
+FENCE=$(printf '{"allow":["%s"],"allowReadOnly":[],"allowWriteOnly":[],"deny":[],"denyEnumerate":["%s"]}' \
+	"$WORKSPACE" "$HOME_DIR/GIT")
+expect "listing the protected parent" refused "ls $HOME_DIR/GIT > /dev/null"
+expect "read a named sibling file" ok "cat $SIBLING/secret.txt > /dev/null && echo named-ok"
+expect "write a named sibling file" ok "printf named > $SIBLING/named.txt && test -f $SIBLING/named.txt"
+expect "list below a named sibling" ok "ls $SIBLING > /dev/null && echo child-ok"
+FENCE="$BASE_FENCE"
+
 printf '\n=== directional roots keep their direction ===\n'
 expect "read the read-only root" ok "cat $HOME_DIR/.gitconfig > /dev/null && echo ok"
 expect "write the read-only root" refused "printf x >> $HOME_DIR/.gitconfig"

--- a/crates/containment-check/src/main.rs
+++ b/crates/containment-check/src/main.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 use brush_core::containment::{ContainmentFence, GrantPlan, RealFs};
 use clap::{Parser, Subcommand};
 
-/// The fence as JSON, matching the four lists the napi boundary already passes.
+/// The fence as JSON, matching the lists the napi boundary already passes.
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct FenceJson {
@@ -30,6 +30,8 @@ struct FenceJson {
 	allow_write_only: Vec<PathBuf>,
 	#[serde(default)]
 	deny:             Vec<PathBuf>,
+	#[serde(default)]
+	deny_enumerate:   Vec<PathBuf>,
 }
 
 impl From<FenceJson> for ContainmentFence {
@@ -39,6 +41,7 @@ impl From<FenceJson> for ContainmentFence {
 			allow_read_only:  json.allow_read_only,
 			allow_write_only: json.allow_write_only,
 			deny:             json.deny,
+			deny_enumerate:   json.deny_enumerate,
 		}
 	}
 }

--- a/crates/containment-check/tests/complement.rs
+++ b/crates/containment-check/tests/complement.rs
@@ -108,6 +108,7 @@ fn realistic() -> (FakeFs, ContainmentFence) {
 			PathBuf::from("/home/alice/GIT"),
 			PathBuf::from("/home/alice/GIT/custA/.xcsh/sessions"),
 		],
+		deny_enumerate:   Vec::new(),
 	};
 	(fs, fence)
 }
@@ -135,7 +136,7 @@ fn plan_never_permits_what_the_fence_denies() {
 
 	let mut escapes = Vec::new();
 	for path in candidates(&fs) {
-		for access in [FenceAccess::Read, FenceAccess::Write] {
+		for access in [FenceAccess::Read, FenceAccess::Write, FenceAccess::Enumerate] {
 			if plan.permits(&path, access) && !fence.permits_resolved(&path, access) {
 				escapes.push(format!("{access:?} {}", path.display()));
 			}
@@ -165,7 +166,7 @@ fn plan_agrees_with_the_fence_except_on_split_directories() {
 		{
 			continue;
 		}
-		for access in [FenceAccess::Read, FenceAccess::Write] {
+		for access in [FenceAccess::Read, FenceAccess::Write, FenceAccess::Enumerate] {
 			let planned = plan.permits(&path, access);
 			let fenced = fence.permits_resolved(&path, access);
 			if planned != fenced {
@@ -183,7 +184,7 @@ fn split_directories_are_only_ever_stricter() {
 	let plan = fence.compile_grant_plan(&fs);
 
 	for dir in &plan.split_dirs {
-		for access in [FenceAccess::Read, FenceAccess::Write] {
+		for access in [FenceAccess::Read, FenceAccess::Write, FenceAccess::Enumerate] {
 			assert!(
 				!(plan.permits(dir, access) && !fence.permits_resolved(dir, access)),
 				"split dir {} is laxer than the fence for {access:?}",
@@ -356,7 +357,29 @@ fn an_empty_fence_grants_the_whole_tree() {
 	for path in ["/usr/bin/env", "/home/alice/x", "/anything/at/all"] {
 		assert!(plan.permits(Path::new(path), FenceAccess::Read));
 		assert!(plan.permits(Path::new(path), FenceAccess::Write));
+		assert!(plan.permits(Path::new(path), FenceAccess::Enumerate));
 	}
+}
+
+#[test]
+fn an_exact_enumeration_deny_keeps_named_descendants_reachable() {
+	let fs = FakeFs::new(&[
+		"/home/alice/customers/example-a/notes.md",
+		"/home/alice/customers/example-b/context.md",
+	]);
+	let parent = PathBuf::from("/home/alice/customers");
+	let sibling = PathBuf::from("/home/alice/customers/example-b/context.md");
+	let sibling_dir = PathBuf::from("/home/alice/customers/example-b");
+	let fence =
+		ContainmentFence { deny_enumerate: vec![parent.clone()], ..ContainmentFence::default() };
+	let plan = fence.compile_grant_plan(&fs);
+
+	assert!(!fence.permits_resolved(&parent, FenceAccess::Enumerate));
+	assert!(!plan.permits(&parent, FenceAccess::Enumerate));
+	assert!(fence.permits_resolved(&sibling, FenceAccess::Read));
+	assert!(plan.permits(&sibling, FenceAccess::Read));
+	assert!(fence.permits_resolved(&sibling_dir, FenceAccess::Enumerate));
+	assert!(plan.permits(&sibling_dir, FenceAccess::Enumerate));
 }
 
 /// Two lists naming the same path must resolve the way `permits_resolved` does:

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -102,6 +102,8 @@ pub struct ContainmentFenceOptions {
 	pub allow_write_only: Vec<String>,
 	/// Roots denied in both directions, winning over any allow they sit inside.
 	pub deny:             Vec<String>,
+	/// Exact directories whose entries may not be enumerated.
+	pub deny_enumerate:   Vec<String>,
 }
 
 impl From<&ContainmentFenceOptions> for ContainmentFence {
@@ -111,6 +113,7 @@ impl From<&ContainmentFenceOptions> for ContainmentFence {
 			allow_read_only:  options.allow_read_only.iter().map(PathBuf::from).collect(),
 			allow_write_only: options.allow_write_only.iter().map(PathBuf::from).collect(),
 			deny:             options.deny.iter().map(PathBuf::from).collect(),
+			deny_enumerate:   options.deny_enumerate.iter().map(PathBuf::from).collect(),
 		}
 	}
 }
@@ -119,8 +122,15 @@ impl From<&ContainmentFenceOptions> for ContainmentFence {
 /// both this implementation and the TypeScript one, which is the only guard
 /// against the two drifting.
 #[napi]
-pub fn fence_permits(fence: ContainmentFenceOptions, candidate: String, write: bool) -> bool {
-	let access = if write {
+pub fn fence_permits(
+	fence: ContainmentFenceOptions,
+	candidate: String,
+	write: bool,
+	enumerate: Option<bool>,
+) -> bool {
+	let access = if enumerate == Some(true) {
+		FenceAccess::Enumerate
+	} else if write {
 		FenceAccess::Write
 	} else {
 		FenceAccess::Read

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Made operator-owned home files, CLI configuration, shell profiles, SSH state, plugins, skills, and settings consistently writable while preserving cross-session and data-root isolation ([#2720](https://github.com/f5-sales-demo/xcsh/issues/2720))
 - Prevented sandbox sessions from enumerating the session root's parent while preserving named operator access and explicit read-grant overrides ([#2725](https://github.com/f5-sales-demo/xcsh/issues/2725))
 
 ## [20.0.0] - 2026-08-01

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevented sandbox sessions from enumerating the session root's parent while preserving named operator access and explicit read-grant overrides ([#2725](https://github.com/f5-sales-demo/xcsh/issues/2725))
+
 ## [20.0.0] - 2026-08-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -24,6 +24,7 @@ export function fenceForNative(fence: ContainmentFence | undefined) {
 		allowReadOnly: [...fence.allowReadOnly],
 		allowWriteOnly: [...fence.allowWriteOnly],
 		deny: [...fence.deny],
+		denyEnumerate: [...fence.denyEnumerate],
 	};
 }
 

--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -7,51 +7,40 @@ Filesystem isolation is **on**. Enforcement for the `bash` tool: **{{containment
 Your shell is confined by the operating system, not by inspecting the command you wrote. A path is
 checked where it is actually opened, after the shell has expanded variables, resolved aliases and
 followed symlinks — so how a path is spelled does not change what is reachable.
-- Ordinary work is unrestricted: system paths, `/tmp`, package caches (`~/.bun`, `~/.cargo`,
-  `~/go/pkg/mod`, …), the network, and running programs are all untouched.
-- The CLIs you drive keep their own configuration, so `gh`, `glab`, `az`, `aws`, `gcloud`, `sf`,
-  `docker`, `kubectl` and `terraform` all work normally, including the token refreshes and logs they
-  write as they go.
-{{#unless containment.commandConfigWritable}}
-  What you cannot do is *rewrite* the settings that name a command to run — `~/.aws/config`,
-  `~/.kube/config`, `~/.docker/config.json`, a plugin directory. Those stay readable and are refused for
-  writing, because a later unfenced run of that CLI would execute what you wrote.
-{{else}}
-  This backend cannot hold a file read-only inside a writable directory, so those settings are
-  writable here. Do not edit the ones that name a command to run — `~/.aws/config`, `~/.kube/config`,
-  `~/.docker/config.json`, `~/.azure/config`, a plugin directory — unless the operator asked you to: a
-  later unfenced run of that CLI would execute what you wrote.
-{{/unless}}
-- What is refused is a short list of *places*, not kinds of operation: another customer's folder, the
-  rest of the home directory (`~/.ssh`, `~/.gnupg`, `~/Documents`), other operators' accounts, other
-  mounted volumes, and other sessions' transcripts. `~/.gitconfig` is readable, not writable.
-- `cd` follows the same boundary as everything else: moving somewhere reachable is fine, and `cd` into
-  a denied directory is refused. Where you stand does not widen anything — the boundary is fixed for
-  the session, so it never follows the shell.
+- Ordinary work is unrestricted: system paths, `/tmp`, package caches, the network, and running
+  programs are all untouched.
+- The operator's home and configuration belong to the operator. Shell profiles, SSH and GPG state,
+  Git and cloud CLI configuration, xcsh settings, plugins, and skills are readable and writable with
+  the operator's normal filesystem rights.
+- Cross-tenant isolation removes the discovery step. The directory containing the session root cannot
+  be enumerated, but a sibling path the operator names directly can still be read, written, or entered.
+  An explicit read grant, including `--allow-path <dir>`, restores enumeration for that directory.
+- Cross-session stores and data roots remain denied. Another session's transcripts, memories, internal
+  contexts, and temporary working state are not reachable through tools, nor are unrelated data roots
+  and mounted data volumes.
 
-The same boundary answers for every tool. `read`, `write`, `grep`, `find` and `python` are checked
-against exactly the rules above, so a path is reachable or not regardless of which tool you use to ask.
-If one refuses something, another will not succeed at it, and it is not worth trying.
+The same boundary answers for every tool. `read`, `write`, `grep`, `find`, `python`, and `bash` consult
+the same rules, so changing tools or spelling a path differently does not widen the session.
 
-If a command is refused, do not try to reach the same path a different way. Say what you needed and why.
-The operator can widen it with `--allow-path <dir>`, which grants read and write.
+If parent enumeration is refused, use a known path or ask the operator for an explicit read grant. If
+a cross-session or data-root path is refused, do not try to reach it another way. Say what you needed
+and why.
 
-That is an instruction, not a claim that rewriting is impossible: the boundary is a set of paths, so a
-path it does not name is reachable whether or not reaching for it is sensible. The rule of thumb is that
-if a file belongs to someone other than the operator you are working with, it is not yours to read.
+This sandbox is a courtesy for session-context isolation, not a privilege boundary against xcsh or the
+operator. The rule of thumb is that if a file belongs to someone other than the operator you are
+working with, it is not yours to read.
 
 {{#if containment.landlock}}
 Three things behave differently under this backend, and none of them is a bug to work around:
-- `ls /` and `ls` of the directory holding the session tree fail. A kernel rule covers a whole subtree,
-  so a directory with both reachable and unreachable children cannot be listed at all. Listing a
-  specific directory you can reach works normally.
+- `ls /` can fail because a kernel rule cannot expose a directory that mixes reachable and denied data
+  roots. Listing a specific reachable directory works normally.
 - `sudo` and other setuid programs do not work, because confining a process requires giving up the
   ability to gain privileges.
 - Interactive terminal programs (`top`, `less`, an interactive `ssh`) run without a real terminal here,
   so prefer their non-interactive forms — `ps`, `cat`, `ssh -T`, or a piped command.
 {{#if containment.truncationUngoverned}}
-- This kernel is too old to govern truncation, so a file outside the boundary can still be emptied even
-  though it cannot be read or written. Never truncate a path outside the session directory.
+- This kernel is too old to govern truncation, so a denied file can still be emptied even though it
+  cannot be read or written. Never truncate a path outside the session directory.
 {{/if}}
 {{/if}}
 {{else}}
@@ -60,12 +49,12 @@ scanning the command text before it runs. That check is best-effort by construct
 wrote rather than what the shell will do, so a path assembled at runtime or reached through an unusual
 spelling may not be caught.
 
-The rules are the same ones a confined session has — another customer's folder, the rest of home, other
-operators' accounts, other volumes, other sessions' transcripts — and ordinary work is equally
-unrestricted here. What differs is only how reliably the boundary is applied to a spawned program.
+The intended rules are the same ones a confined session has: parent enumeration is refused while named
+operator access remains available, operator-owned home and configuration stay readable and writable,
+and cross-session stores and unrelated data roots stay denied. Ordinary work remains unrestricted.
 
-Treat it as a statement of intent rather than a guarantee, and do not go looking for paths outside the
-session directory on the assumption that something would stop you.
+Treat the boundary as a statement of intent rather than a guarantee, and do not go looking for paths
+outside the session directory on the assumption that something would stop you.
 {{/if}}
 {{else}}
 Filesystem isolation is **off** for this session — started with `--no-sandbox`, or

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -21,10 +21,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as natives from "@f5-sales-demo/pi-natives";
 import {
-	getAgentDir,
-	getConfigRootDir,
 	getMemoriesDir,
-	getPluginsDir,
 	getSessionsDir,
 	getXCSHContextsDir,
 	normalizePathForComparison,
@@ -72,14 +69,6 @@ export interface ContainmentOptions {
 	 * letters. Overridable for tests, which cannot mount a second volume.
 	 */
 	otherRoots?: readonly string[];
-	/**
-	 * Whether the active backend can express "writable directory, except this file" — see
-	 * COMMAND_BEARING_CONFIG. True for seatbelt, false for Landlock, which cannot.
-	 *
-	 * Defaults to false, so a caller that does not know its backend gets the portable policy rather
-	 * than one that silently breaks the CLIs on Linux.
-	 */
-	narrowsWithinGrant?: boolean;
 	/**
 	 * The filesystem root whose immediate entries are classified as operational or data — see
 	 * DATA_ROOTS. Overridable for tests; defaults to the real root.
@@ -141,9 +130,8 @@ const CACHE_DIRS = [
  * because the fence exists to stop the assistant wandering between customer workspaces rather than to
  * withhold the operator's credential store from the operator's own CLIs — and the native `az`/`aws` tools
  * already act with those credentials, so denying only the shell path broke the CLIs without protecting
- * anything. `~/.ssh` and `~/.gnupg` are still denied: no shipped tool needs them.
- *
- * Reading a credential is not the same as being able to *replace* one, so see COMMAND_BEARING_CONFIG.
+ * anything. The same operator-rights rule applies to all other files in home, including SSH and GPG
+ * state: this fence isolates session context; it does not withhold the operator's own files.
  */
 const TOOL_CONFIG_DIRS = [
 	path.join(".config", "gh"), // gh
@@ -158,63 +146,6 @@ const TOOL_CONFIG_DIRS = [
 	".kube", // kubectl
 	".terraform.d", // terraform
 ];
-
-/**
- * Paths inside TOOL_CONFIG_DIRS that name a command or hold a loadable executable. Read-only, so the
- * grant above never becomes a way to run code later.
- *
- * This is the distinction that matters: reading `~/.aws/credentials` discloses a secret, but *writing*
- * `~/.aws/config` installs a `credential_process` that the operator's next — unfenced — `aws` call
- * executes, with access to every customer workspace and private file the fence exists to protect. That
- * is an escape from the sandbox rather than a leak inside it. `~/.cargo/config.toml` and
- * `~/.gradle/init.gradle` are excluded from the cache carve-out for exactly this reason; these are the
- * same class, and none of them was writable before #2581, so keeping them read-only means that change
- * adds no new write capability on any path that can cause execution.
- *
- * Each entry is a documented mechanism, not a guess: `credential_process` (aws), `user.exec`
- * (kubeconfig), `credsStore`/`credHelpers` and CLI plugins (docker), Python extensions (az), provider
- * binaries (terraform), the virtualenv `activate` that gcloud's launcher sources, and `!`-prefixed shell
- * aliases (gh, glab). The CLIs still read all of them, so nothing stops working; only rewriting does.
- * `gh auth login` and `glab auth login` are interactive and belong outside a fenced session anyway.
- */
-const COMMAND_BEARING_CONFIG = [
-	path.join(".aws", "config"), // credential_process = <command>
-	path.join(".aws", "cli", "alias"), // aws aliases; a leading `!` runs through a shell
-	path.join(".azure", "config"), // extension.index_url + use_dynamic_install fetch and run wheels
-	path.join(".kube", "config"), // users[].user.exec.command
-	path.join(".docker", "config.json"), // credsStore / credHelpers -> docker-credential-*
-	path.join(".docker", "cli-plugins"), // docker-* plugin executables
-	path.join(".azure", "cliextensions"), // az extensions, executed as Python
-	path.join(".terraform.d", "plugins"), // provider binaries
-	path.join(".config", "gcloud", "virtenv"), // sourced by the gcloud launcher
-	path.join(".config", "gh", "config.yml"), // gh alias set x '!sh -c ...', plus editor/browser/pager
-	// glab keeps aliases in their own file, so those can be held read-only. Its config.yml cannot:
-	// glab rewrites it on ordinary commands (atomic rename) to refresh the OAuth token and the
-	// update-check stamp, and holding it read-only reproduced #2581 — `glab auth status` exits 1 with
-	// "rename …/.config.yml".
-	//
-	// Worse than a failed command, and the reason this is not merely a convenience: the OAuth refresh
-	// already happened at GitLab, so a denied write loses the rotated refresh token and the operator's
-	// login is permanently dead — `invalid_grant` afterwards, even outside the fence. Observed while
-	// testing this change, which cost a real `glab auth login`. Any CLI that refreshes a rotating token
-	// must be able to persist it.
-	//
-	// Left writable, and the residual exposure is stated rather than hidden:
-	// that file also carries `editor`, `browser` and `duo_cli_binary_path`/`duo_cli_auto_run`, so a write
-	// there IS a code-execution vector this fence does not close. `gh` needs no such exception because it
-	// was measured working with its config.yml read-only.
-	path.join(".config", "glab-cli", "aliases.yml"),
-	path.join("Library", "Application Support", "glab-cli", "aliases.yml"),
-	// Build configuration that redirects a later build. Protected by *omission* while home was denied —
-	// the cache carve-outs grant `.cargo/registry` rather than `.cargo` — so #2637 had to name them. A
-	// write here is persistence, not theft: the operator's next build runs what it says. Reads are fine.
-	path.join(".cargo", "config.toml"),
-	path.join(".gradle", "init.gradle"),
-	path.join(".gradle", "init.d"),
-];
-
-/** Read-only inside home: configuration a tool needs to behave correctly, but must not rewrite. */
-const READ_ONLY_HOME = [".gitconfig", path.join(".config", "git")];
 
 /**
  * Names of top-level directories that hold tools rather than data.
@@ -258,14 +189,6 @@ const OPERATIONAL_ROOT_NAMES = new Set([
 ]);
 
 /**
- * The operator's settings, read by the agent to configure the current session.
- *
- * Read-only, and named individually rather than by their directory: the config root also holds the
- * cross-session leak dirs, which stay denied at greater depth.
- */
-const AGENT_PROFILE_FILES = [path.join(getConfigRootDir(), "settings.json")];
-
-/**
  * Top-level directories that hold data on some machine even when this one has none of them.
  *
  * Denied by name whether or not the root enumeration sees them, because that enumeration is one
@@ -304,16 +227,9 @@ function canonical(root: string): string | undefined {
 /**
  * Canonicalise as much of `target` as already exists, keeping the absent tail.
  *
- * `canonical` gives up on a path whose leaf is missing, and falling back to the literal string is not
- * safe for a rule whose job is to *narrow* another one. With `~/.aws` symlinked to a vault — chezmoi,
- * stow and yadm all do this — and no config file yet, the grant is emitted resolved (`<vault>`) while
- * the read-only rule keeps the link spelling (`~/.aws/config`). Both backends match a rule against the
- * path the kernel resolved, so the narrower rule covers nothing.
- *
- * That was verified as a real escape before this existed: through the real seatbelt profile,
- * `printf 'credential_process = …' > <vault>/config` succeeded. Note `fenceVerdict` did NOT show it,
- * because `pathIsWithin` normalises symlinks — the in-process check was safe while the emitted profile
- * was not, so a test asserting only the verdict passes while the boundary leaks.
+ * `canonical` gives up on a path whose leaf is missing. Grants and leak roots must still be emitted
+ * before their leaf exists, and they must share the namespace the kernel sees when an existing parent
+ * is a symlink. Resolve the existing prefix and retain only the absent tail.
  */
 function canonicalThroughExisting(target: string): string {
 	const tail: string[] = [];
@@ -414,9 +330,8 @@ function dataRootEntries(fsRoot: string): string[] {
  * refusal it was meant to lift keeps recommending it.
  *
  *  - `~` is expanded. Passed straight to `realpathSync` it names a path that does not exist, so
- *    `sandbox.allowRead: ["~/shared"]` was discarded — and since `~` sits inside the denied home tree,
- *    the grant did not merely fail to widen, it left the path refused. The policy this replaced expanded
- *    it, so this was a regression rather than an old gap.
+ *    `sandbox.allowRead: ["~/shared"]` was discarded and could not restore parent enumeration. The
+ *    policy this replaced expanded it, so this was a regression rather than an old gap.
  *  - An absent target is kept, resolved through the ancestors that do exist, so `--allow-path
  *    <new-output-dir>` can authorize creating it. Harmless while an unnamed path defaulted to allow;
  *    once unknown top-level roots are denied, dropping the grant turns the flag into a refusal.
@@ -572,32 +487,6 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		for (const cache of [...CACHE_DIRS, ...TOOL_CONFIG_DIRS]) {
 			allow.add(canonicalThroughExisting(path.join(home, cache)));
 		}
-		// Deeper than the grant above, so `fenceVerdict` picks these and write becomes a deny while read
-		// stays allowed. Emitted even when absent, or creating the file would be the way around it — and
-		// resolved through existing ancestors, or a symlinked config dir puts the two rules in different
-		// namespaces and the narrower one stops applying.
-		//
-		// COMMAND_BEARING_CONFIG only when the backend can express a narrowing *inside* a grant.
-		// Seatbelt can: it is last-match-wins, so a deeper deny simply overrides. Landlock cannot — its
-		// rules are allow-only and always recursive, so a read-only child turns its parent into a split
-		// dir that loses write on its own inode. Verified with `containment-check plan`: adding
-		// `~/.azure/cliextensions` as read-only made `~/.azure` itself `r-`, which would stop `az` from
-		// creating `azureProfile.json` at all. Applying it anyway would trade a code-execution path for
-		// breaking the very CLIs #2581 is about, so the gap is reported instead — the same choice already
-		// made for `truncationUngoverned`.
-		const narrowed = options.narrowsWithinGrant ? COMMAND_BEARING_CONFIG : [];
-		for (const config of [...READ_ONLY_HOME, ...narrowed]) {
-			allowReadOnly.add(canonicalThroughExisting(path.join(home, config)));
-		}
-	}
-
-	// The agent's own inputs, which sit inside the denied home tree. The file tools allow-listed these
-	// while the fence did not, so `bash` could not read a plugin that `read` could — one of the
-	// asymmetries #2624 removes now that both consult this fence. Read-only: they are inputs, and a
-	// write changes what a later session loads. Emitted through existing ancestors so the skills
-	// directory, which is created on first use, is covered before it exists rather than after.
-	for (const own of [getPluginsDir(), path.join(getAgentDir(), "skills"), ...AGENT_PROFILE_FILES]) {
-		allowReadOnly.add(canonicalThroughExisting(own));
 	}
 
 	// Top-level directories that hold somebody's files. Without these the fence covered only home and
@@ -648,10 +537,8 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 	// and a session whose workspace is the agent dir would otherwise re-expose every other session's
 	// transcript. `fenceVerdict` resolves that by depth, so nesting is safe rather than accidental.
 	//
-	// Emitted even when absent, for the reason COMMAND_BEARING_CONFIG is: a rule that appears only once
-	// the directory does is one nobody can rely on, and creating it would otherwise be the way around
-	// it. Today the home deny covers all three anyway, so this matters only where the agent dir has
-	// been relocated outside home — but "only matters in that case" is how the last few holes were built.
+	// Emitted even when absent: a rule that appears only once the directory does is one nobody can rely
+	// on, and creating it would otherwise be the way around it. This also covers relocated agent state.
 	const leaks = options.leakRoots ?? [
 		getMemoriesDir(),
 		getSessionsDir(),
@@ -722,14 +609,6 @@ export interface ContainmentStatus {
 	 * different claims and an operator is entitled to know which one they have.
 	 */
 	readonly truncationUngoverned?: boolean;
-	/**
-	 * Set when the backend cannot hold a file read-only inside a writable directory, so the
-	 * command-bearing CLI settings (`~/.aws/config`, `~/.kube/config`, …) are writable. Landlock's rules
-	 * are allow-only and recursive; narrowing inside a grant would strip write from the parent directory
-	 * and break the CLIs the grant exists for. Reported rather than folded into `osEnforced`, because it
-	 * changes what a write to those paths means, not whether the boundary holds.
-	 */
-	readonly commandConfigWritable?: boolean;
 }
 
 /**
@@ -771,8 +650,6 @@ export function containmentStatus(
 			osEnforced: true,
 			// Absent on the ABI that governs truncation; present, and stated, on the one that does not.
 			...(probed.truncateHandled === false ? { truncationUngoverned: true } : {}),
-			// Always true here: no Landlock ABI can narrow a right inside a grant.
-			commandConfigWritable: true,
 		};
 	}
 	return { enabled: true, backend: "scanner-only", osEnforced: false };

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -6,10 +6,10 @@
  * Confining a shell that way refuses ordinary work: measured on macOS 26.3, a deny-default seatbelt
  * profile could not even `execvp /bin/cat`.
  *
- * So the fence is gentle. It restricts no operation — `/usr`, `/tmp`, package caches, the network and
- * process execution are never mentioned, and nothing that works today stops working. The single thing
- * it prevents is the assistant wandering the filesystem: reading or writing another customer's
- * checkout, `~/.ssh`, `~/Documents`. That is where the cross-customer risk actually lives (#2554).
+ * So the fence is gentle. It leaves `/usr`, `/tmp`, package caches, the network and process execution
+ * alone. Its cross-tenant courtesy removes the discovery step — enumerating the session root's parent —
+ * while keeping named operator access. Explicit data-root and cross-session state denies remain where
+ * the model has no legitimate reason to wander (#2554).
  *
  * Produced declaratively rather than as an ordered rule list, because the two backends disagree about
  * order: seatbelt evaluates rules in sequence with the last match winning, while Landlock only grants
@@ -27,10 +27,11 @@ import {
 	getPluginsDir,
 	getSessionsDir,
 	getXCSHContextsDir,
+	normalizePathForComparison,
 	pathIsWithin,
 } from "@f5-sales-demo/pi-utils";
 
-export type FenceAccess = "read" | "write";
+export type FenceAccess = "read" | "write" | "enumerate";
 export type FenceVerdict = "allow" | "deny";
 
 export interface ContainmentFence {
@@ -42,6 +43,8 @@ export interface ContainmentFence {
 	readonly allowWriteOnly: readonly string[];
 	/** Canonical roots denied in both directions, winning over any allow they sit inside. */
 	readonly deny: readonly string[];
+	/** Canonical directories whose own entries may not be enumerated. Descendants remain reachable by name. */
+	readonly denyEnumerate: readonly string[];
 }
 
 export interface ContainmentOptions {
@@ -516,43 +519,15 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 	const allowReadOnly = new Set<string>();
 	const allowWriteOnly = new Set<string>();
 	const deny = new Set<string>();
+	const denyEnumerate = new Set<string>();
 
-	// Home is one fence. The workspace's ancestors are the other, and they are what matters when
-	// checkouts live outside home: with /work/customer-a as the workspace, /work/customer-b matched no
-	// rule at all and was readable and writable.
-	//
-	// Every ancestor, not just the immediate parent. One level only works when the parent happens to be
-	// the container the tenants sit in; with `<container>/<tenant>/repo` the immediate parent IS the
-	// tenant, so every OTHER tenant matched nothing and the fence allowed it, read and write. That went
-	// unnoticed because the command-text scan is deny-by-default and refused those paths on the way in —
-	// the composite looked right while the fence alone did not. Removing that scan for OS-confined shells
-	// (#2582) is what exposed it, so the two changes ship together.
-	//
-	// Denying an ancestor costs nothing above it: the walk stops before anything `tooBroadToDeny`
-	// rejects, so `/`, `/usr`, `/tmp` and `$TMPDIR` are never denied and operational paths stay
-	// reachable. And it costs nothing below: the workspace is allowed at greater depth, and
-	// `fenceVerdict` takes the deepest match.
-	// Home is never denied, and the walk stops there (#2637).
-	//
-	// This is a professional courtesy, not a prison: an effort to stop *inadvertent* filesystem wandering
-	// between customers, for an operator with senior technical skills and the same rights on this machine
-	// as the agent acting for them. Denying home outright refused `~/git/STYLE_GUIDE.md` and then needed
-	// ~30 carve-outs to make ordinary tooling work again — every one of them evidence the posture was wrong.
-	//
-	// What the walk still covers is the part that matters: every level between the workspace and home. With
-	// the workspace at `~/MEDDPICC/CUSTOMER-A`, `~/MEDDPICC` is denied so the `CUSTOMER-B` sibling is unreachable,
-	// and with `<container>/<tenant>/repo` every level up to home is denied, so the v19.100.1 cross-tenant
-	// regression does not return.
-	//
-	// A session whose folder IS home, or a direct child of it, therefore fences nothing above itself. That
-	// is deliberate: if the operator chooses to work in home, that is their filesystem to lay out.
-	for (let ancestor = path.dirname(workspace); ; ancestor = path.dirname(ancestor)) {
-		if (ancestor === home) break; // the operator's own account is theirs
-		if (tooBroadToDeny(ancestor, fsRoot)) break;
-		deny.add(ancestor);
-		const next = path.dirname(ancestor);
-		if (next === ancestor) break; // reached a filesystem root that `tooBroadToDeny` did not name
-	}
+	// The fence is a professional courtesy, not a privilege boundary. Refusing an entire parent tree
+	// withheld paths the operator is entitled to use and recreated the whole-home failure from #2637.
+	// What matters for cross-tenant context isolation is the discovery step: without a directory listing,
+	// a session cannot casually scan the container and learn which sibling workspaces exist. The exact
+	// parent therefore loses enumeration only; traversal and named reads/writes remain ordinary filesystem
+	// operations. Operational parents such as `/usr` and the system temp directory are left alone.
+	const parentToProtect = path.dirname(workspace);
 
 	// Through `resolveGrants` like the allow-lists, so a session temp dir or artifacts dir that does not
 	// exist yet is still granted rather than silently dropped.
@@ -579,6 +554,15 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 	}
 	for (const root of writeOnlyResolved) {
 		if (!readOnlyResolved.has(root)) allowWriteOnly.add(root);
+	}
+
+	// An explicit read grant is the operator overriding this courtesy. The default allow-by-default
+	// posture is intentionally not enough: it keeps named access working, while this one exact directory
+	// still cannot be scanned. `--allow-path` appears in both settings lists, so it reaches this branch via
+	// `readOnlyResolved`; a write-only grant does not imply permission to learn directory entries.
+	const parentExplicitlyReadable = [...readOnlyResolved].some(root => pathIsWithin(root, parentToProtect));
+	if (!tooBroadToDeny(parentToProtect, fsRoot) && !parentExplicitlyReadable) {
+		denyEnumerate.add(parentToProtect);
 	}
 
 	if (home !== undefined) {
@@ -683,6 +667,7 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		allowReadOnly: [...allowReadOnly],
 		allowWriteOnly: [...allowWriteOnly],
 		deny: [...deny],
+		denyEnumerate: [...denyEnumerate],
 	};
 }
 
@@ -694,18 +679,26 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
  * here is **allow**: a path matched by no rule is outside the fence and none of its business.
  */
 export function fenceVerdict(fence: ContainmentFence, candidate: string, access: FenceAccess): FenceVerdict {
+	if (access === "enumerate") {
+		const normalizedCandidate = normalizePathForComparison(candidate);
+		if (fence.denyEnumerate.some(root => normalizePathForComparison(root) === normalizedCandidate)) {
+			return "deny";
+		}
+	}
+
 	const denied = deepestMatch(fence.deny, candidate);
 	const readOnly = deepestMatch(fence.allowReadOnly, candidate);
 	const writeOnly = deepestMatch(fence.allowWriteOnly, candidate);
 	const allowed = deepestMatch(fence.allow, candidate);
+	const ordinaryAccess = access === "enumerate" ? "read" : access;
 
 	const depth = (root: string | undefined): number => (root === undefined ? -1 : root.length);
 	const deepest = Math.max(depth(denied), depth(readOnly), depth(writeOnly), depth(allowed));
 
 	// Deny first at equal depth: the leak roots depend on it.
 	if (denied !== undefined && depth(denied) === deepest) return "deny";
-	if (readOnly !== undefined && depth(readOnly) === deepest) return access === "read" ? "allow" : "deny";
-	if (writeOnly !== undefined && depth(writeOnly) === deepest) return access === "write" ? "allow" : "deny";
+	if (readOnly !== undefined && depth(readOnly) === deepest) return ordinaryAccess === "read" ? "allow" : "deny";
+	if (writeOnly !== undefined && depth(writeOnly) === deepest) return ordinaryAccess === "write" ? "allow" : "deny";
 	if (allowed !== undefined && depth(allowed) === deepest) return "allow";
 	return "allow";
 }

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -156,11 +156,9 @@ function deny(cwd: string, resolved: string, access: SandboxAccess): ToolCallDec
 }
 
 /**
- * `$HOME` and `${HOME}` are spellings of `~`, which `looksLikePath` already treats as a
- * path (#2534). Three ways to name one file, only one of them checked, is an oversight
- * rather than a policy: `cat ~/.ssh/id_rsa` was blocked while `cat $HOME/.ssh/id_rsa`
- * was not. Rewriting to `~` here means detection AND resolution both see the real path,
- * so the denial names the file rather than a literal dollar sign.
+ * `$HOME` and `${HOME}` are spellings of `~`, which `looksLikePath` already treats as a path (#2534).
+ * Rewriting to `~` means detection and resolution answer consistently whether the resulting home path
+ * is allowed or denied by an explicit rule.
  *
  * `\b` keeps `$HOMEBREW_PREFIX` and friends out of it.
  */

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -45,6 +45,7 @@
  * guessing — which also means this file no longer needs to know about system roots, temp directories or
  * which backend is running. The fence answers all of that, and it is the same answer the kernel gives.
  */
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { expandPath, parseFindPattern, parseSearchPath, resolveToCwd, splitTopLevel } from "../tools/path-utils";
 import { lexShellCommand, type ShellSimpleCommand } from "../tools/shell-lex";
@@ -668,6 +669,23 @@ function evaluateSearchTool(check: ToolCallCheck, spec: SearchSpec): ToolCallDec
 	for (const basePath of searchBases(raw, spec.base)) {
 		const resolved = resolveToCwd(basePath, cwd);
 		if (!permits(check, resolved, spec.access)) return deny(cwd, resolved, spec.access);
+		if (!permits(check, resolved, "enumerate")) return deny(cwd, resolved, "enumerate");
+	}
+	return ALLOW;
+}
+
+/** `read` lists a directory when its path resolves to one; named file reads do not enumerate it. */
+function evaluateReadTool(check: ToolCallCheck): ToolCallDecision {
+	const raw = firstString(check.input, ["file_path", "path"]);
+	if (!raw) return ALLOW;
+	const resolved = resolveToCwd(raw, check.cwd);
+	if (!permits(check, resolved, "read")) return deny(check.cwd, resolved, "read");
+	try {
+		if (fs.statSync(resolved).isDirectory() && !permits(check, resolved, "enumerate")) {
+			return deny(check.cwd, resolved, "enumerate");
+		}
+	} catch {
+		// The tool owns its normal not-found/error contract; the fence has already decided the read path.
 	}
 	return ALLOW;
 }
@@ -683,6 +701,7 @@ export function evaluateToolCall(check: ToolCallCheck): ToolCallDecision {
 	if (codeFields) return evaluateCodeTool(check, codeFields, toolName === "bash");
 
 	if (toolName === "edit") return evaluateEdit(check);
+	if (toolName === "read") return evaluateReadTool(check);
 	if (toolName === "generate_image") return evaluateGenerateImage(check);
 	if (toolName === "puppeteer") return evaluatePuppeteer(check);
 

--- a/packages/coding-agent/src/sandbox/session-fence.ts
+++ b/packages/coding-agent/src/sandbox/session-fence.ts
@@ -14,7 +14,7 @@
  * allow-by-default with targeted denies, so the effective boundary was their intersection and the
  * intersection refused ordinary work. One object means the pre-check and the kernel cannot disagree.
  */
-import { buildContainmentFence, type ContainmentFence, containmentStatus } from "./containment";
+import { buildContainmentFence, type ContainmentFence } from "./containment";
 
 /** The slice of `Settings` this needs — supplied explicitly so the caller names its own source. */
 export interface SettingsReader {
@@ -64,16 +64,12 @@ export function resolveSessionFence(
 
 	const allowRead = readSetting<string[]>(settings, "sandbox.allowRead", []);
 	const allowWrite = readSetting<string[]>(settings, "sandbox.allowWrite", []);
-	// Only seatbelt can hold a file read-only inside a writable directory; Landlock's rules are
-	// recursive, so asking for it there would strip write from the parent and break the CLIs (#2581).
-	const narrowsWithinGrant = containmentStatus(true).backend === "seatbelt";
 	const signature = [
 		workspace,
 		JSON.stringify(allowRead),
 		JSON.stringify(allowWrite),
 		extras.sessionTmp ?? "",
 		JSON.stringify(extras.extraRoots ?? []),
-		String(narrowsWithinGrant),
 	].join(" ");
 
 	const cached = cache.get(signature);
@@ -88,7 +84,6 @@ export function resolveSessionFence(
 		extraRoots: extras.extraRoots,
 		readOnlyRoots: allowRead,
 		writeOnlyRoots: allowWrite,
-		narrowsWithinGrant,
 	});
 	if (cache.size >= CACHE_LIMIT) {
 		const oldest = cache.keys().next();

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -564,8 +564,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 	#containmentFence() {
 		const artifactsDir = this.session.getArtifactsDir?.();
 		// One resolver, shared with `sandbox-guard` and the internal-URL check, so the pre-check and the
-		// kernel cannot be looking at different boundaries (#2624). It reads the allow-lists and picks
-		// `narrowsWithinGrant` from the active backend itself.
+		// kernel cannot be looking at different boundaries (#2624).
 		return resolveSessionFence(this.#containmentRoot(), this.session.settings, {
 			extraRoots: artifactsDir ? [artifactsDir] : [],
 		});

--- a/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
+++ b/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
@@ -556,9 +556,13 @@ describe("renderAboutDoc containment section", () => {
 		expect(doc).toContain("## Sandbox containment");
 		expect(doc).toContain("seatbelt");
 		expect(doc).toContain("how a path is spelled does not change what is reachable");
-		// The agent must be told not to retry a refusal a different way — that is wasted turns.
-		expect(doc).toContain("do not try to reach the same path a different way");
-		// And that ordinary work is not restricted, so it does not treat the fence as a reason to stop.
+		// The contract distinguishes operator rights from session-context isolation.
+		expect(doc).toContain("home and configuration belong to the operator");
+		expect(doc).toContain("readable and writable");
+		expect(doc).toContain("directory containing the session root cannot");
+		expect(doc).toContain("sibling path the operator names directly");
+		expect(doc).toContain("Cross-session stores and data roots remain denied");
+		// Ordinary work remains available and an operator can deliberately restore discovery.
 		expect(doc).toContain("--allow-path");
 	});
 

--- a/packages/coding-agent/test/sandbox-containment-conformance.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-conformance.test.ts
@@ -38,6 +38,7 @@ describe("containment fence: TypeScript and Rust agree", () => {
 		allowReadOnly: [...fence.allowReadOnly],
 		allowWriteOnly: [...fence.allowWriteOnly],
 		deny: [...fence.deny],
+		denyEnumerate: [...fence.denyEnumerate],
 	};
 
 	const corpus: string[] = [
@@ -69,9 +70,9 @@ describe("containment fence: TypeScript and Rust agree", () => {
 	it("returns the same verdict for every path, in both directions", () => {
 		const disagreements: string[] = [];
 		for (const candidate of corpus) {
-			for (const access of ["read", "write"] as FenceAccess[]) {
+			for (const access of ["read", "write", "enumerate"] as FenceAccess[]) {
 				const ts = fenceVerdict(fence, candidate, access) === "allow";
-				const rust = fencePermits(wire, candidate, access === "write");
+				const rust = fencePermits(wire, candidate, access === "write", access === "enumerate");
 				if (ts !== rust) disagreements.push(`${access} ${candidate}: ts=${ts} rust=${rust}`);
 			}
 		}
@@ -81,18 +82,26 @@ describe("containment fence: TypeScript and Rust agree", () => {
 	// Both must resolve the symlink, or the pre-check and the enforcement disagree about the one
 	// case an attacker would reach for.
 	it("agrees when the path arrives through a symlink", () => {
-		// Points at the sibling checkout, not `~/.ssh`: #2637 stopped denying the operator's own dotfiles,
-		// so using one as the "denied" target made TS and Rust agree on `allow` and proved nothing.
+		// Points at the cross-session leak root. Named sibling paths are deliberately reachable now; the
+		// courtesy prevents discovering them by enumerating the shared parent.
 		const pivot = path.join(workspace, "pivot");
-		fs.symlinkSync(sibling, pivot);
+		fs.symlinkSync(leak, pivot);
 		const viaLink = path.join(pivot, "secrets.tf");
 
 		expect(fenceVerdict(fence, viaLink, "read")).toBe("deny");
-		expect(fencePermits(wire, viaLink, false)).toBe(false);
+		expect(fencePermits(wire, viaLink, false, false)).toBe(false);
+	});
+
+	it("agrees that only the shared parent loses enumeration", () => {
+		const parent = path.dirname(workspace);
+		expect(fenceVerdict(fence, parent, "enumerate")).toBe("deny");
+		expect(fencePermits(wire, parent, false, true)).toBe(false);
+		expect(fenceVerdict(fence, sibling, "read")).toBe("allow");
+		expect(fencePermits(wire, sibling, false, false)).toBe(true);
 	});
 
 	it("agrees that an absent fence restricts nothing", () => {
-		const empty = { allow: [], allowReadOnly: [], allowWriteOnly: [], deny: [] };
+		const empty = { allow: [], allowReadOnly: [], allowWriteOnly: [], deny: [], denyEnumerate: [] };
 		for (const candidate of corpus) {
 			expect(fencePermits(empty, candidate, true)).toBe(true);
 		}

--- a/packages/coding-agent/test/sandbox-containment-pty.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-pty.int.test.ts
@@ -39,7 +39,13 @@ describe("containment covers the PTY path, not just the in-process shell", () =>
 	let home: string;
 	let workspace: string;
 	let sibling: string;
-	let wire: { allow: string[]; allowReadOnly: string[]; allowWriteOnly: string[]; deny: string[] };
+	let wire: {
+		allow: string[];
+		allowReadOnly: string[];
+		allowWriteOnly: string[];
+		deny: string[];
+		denyEnumerate: string[];
+	};
 
 	beforeAll(() => {
 		home = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "pty-contain-")));
@@ -48,12 +54,13 @@ describe("containment covers the PTY path, not just the in-process shell", () =>
 		fs.mkdirSync(workspace, { recursive: true });
 		fs.mkdirSync(sibling, { recursive: true });
 		fs.writeFileSync(path.join(sibling, "secret.txt"), "PTY-CANARY-7734\n");
-		const fence = buildContainmentFence({ workspace, home });
+		const fence = buildContainmentFence({ workspace, home, leakRoots: [sibling] });
 		wire = {
 			allow: [...fence.allow],
 			allowReadOnly: [...fence.allowReadOnly],
 			allowWriteOnly: [...fence.allowWriteOnly],
 			deny: [...fence.deny],
+			denyEnumerate: [...fence.denyEnumerate],
 		};
 	});
 
@@ -131,6 +138,7 @@ describe("containment covers the PTY path, not just the in-process shell", () =>
 					allowReadOnly: [...realFence.allowReadOnly],
 					allowWriteOnly: [...realFence.allowWriteOnly],
 					deny: [...realFence.deny],
+					denyEnumerate: [...realFence.denyEnumerate],
 				},
 			},
 			(_err: Error | null, chunk: string) => {

--- a/packages/coding-agent/test/sandbox-containment-race.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-race.int.test.ts
@@ -28,7 +28,13 @@ describe("containment holds while the path is being swapped underneath it", () =
 	const ATTEMPTS = 200;
 	let home: string;
 	let workspace: string;
-	let wire: { allow: string[]; allowReadOnly: string[]; allowWriteOnly: string[]; deny: string[] };
+	let wire: {
+		allow: string[];
+		allowReadOnly: string[];
+		allowWriteOnly: string[];
+		deny: string[];
+		denyEnumerate: string[];
+	};
 
 	beforeAll(() => {
 		home = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "race-")));
@@ -76,12 +82,15 @@ describe("containment holds while the path is being swapped underneath it", () =
 			].join("\n"),
 		);
 
-		const fence = buildContainmentFence({ workspace, home });
+		// The race contract still needs a recursively denied target. Production sibling paths are named
+		// access now, so classify this synthetic target as a cross-session leak root for the test.
+		const fence = buildContainmentFence({ workspace, home, leakRoots: [sibling] });
 		wire = {
 			allow: [...fence.allow],
 			allowReadOnly: [...fence.allowReadOnly],
 			allowWriteOnly: [...fence.allowWriteOnly],
 			deny: [...fence.deny],
+			denyEnumerate: [...fence.denyEnumerate],
 		};
 	});
 

--- a/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
@@ -29,7 +29,13 @@ describe("containment enforced inside the shell", () => {
 	let home: string;
 	let workspace: string;
 	let sibling: string;
-	let wire: { allow: string[]; allowReadOnly: string[]; allowWriteOnly: string[]; deny: string[] };
+	let wire: {
+		allow: string[];
+		allowReadOnly: string[];
+		allowWriteOnly: string[];
+		deny: string[];
+		denyEnumerate: string[];
+	};
 
 	beforeAll(() => {
 		home = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "contain-")));
@@ -38,12 +44,15 @@ describe("containment enforced inside the shell", () => {
 		fs.mkdirSync(workspace, { recursive: true });
 		fs.mkdirSync(sibling, { recursive: true });
 		fs.writeFileSync(path.join(sibling, "secret.txt"), "CUSTB-CANARY-9001\n");
-		const fence = buildContainmentFence({ workspace, home });
+		// Keep a recursive deny in this suite so it continues exercising read/write enforcement. The
+		// production sibling policy is enumeration-only and is covered in the glob and isolation suites.
+		const fence = buildContainmentFence({ workspace, home, leakRoots: [sibling] });
 		wire = {
 			allow: [...fence.allow],
 			allowReadOnly: [...fence.allowReadOnly],
 			allowWriteOnly: [...fence.allowWriteOnly],
 			deny: [...fence.deny],
+			denyEnumerate: [...fence.denyEnumerate],
 		};
 	});
 
@@ -180,12 +189,13 @@ describe("containment enforced inside the shell", () => {
 	it("survives a workspace path containing shell-hostile characters", async () => {
 		const odd = path.join(workspace, 'we"ird\nname');
 		fs.mkdirSync(odd, { recursive: true });
-		const oddFence = buildContainmentFence({ workspace: odd, home });
+		const oddFence = buildContainmentFence({ workspace: odd, home, leakRoots: [sibling] });
 		const oddWire = {
 			allow: [...oddFence.allow],
 			allowReadOnly: [...oddFence.allowReadOnly],
 			allowWriteOnly: [...oddFence.allowWriteOnly],
 			deny: [...oddFence.deny],
+			denyEnumerate: [...oddFence.denyEnumerate],
 		};
 		let out = "";
 		const result = (await executeShell(
@@ -229,7 +239,13 @@ describe("containment enforced inside the shell", () => {
 describe("glob expansion does not disclose names outside the fence", () => {
 	let base: string;
 	let workspace: string;
-	let wire: { allow: string[]; allowReadOnly: string[]; allowWriteOnly: string[]; deny: string[] };
+	let wire: {
+		allow: string[];
+		allowReadOnly: string[];
+		allowWriteOnly: string[];
+		deny: string[];
+		denyEnumerate: string[];
+	};
 
 	beforeAll(() => {
 		base = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "glob-")));
@@ -243,6 +259,7 @@ describe("glob expansion does not disclose names outside the fence", () => {
 			allowReadOnly: [...fence.allowReadOnly],
 			allowWriteOnly: [...fence.allowWriteOnly],
 			deny: [...fence.deny],
+			denyEnumerate: [...fence.denyEnumerate],
 		};
 	});
 

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -42,21 +42,23 @@ function realTmp(suffix: string): string {
 }
 
 describe("buildContainmentFence", () => {
-	it("denies the home tree and re-allows the workspace inside it", () => {
+	it("denies parent enumeration while preserving named access", () => {
 		const home = realTmp("home");
 		const workspace = path.join(home, "GIT", "custA");
 		fs.mkdirSync(workspace, { recursive: true });
 		const fence = buildContainmentFence({ workspace, home });
 
-		// Home is not denied (#2637). What is denied is the container the checkouts sit in, which is what
-		// makes the sibling unreachable — the same protection, one level narrower.
+		// Home and the shared container remain usable by name (#2637). Only the scanning step is refused.
 		expect(fence.deny).not.toContain(home);
-		expect(fence.deny).toContain(path.join(home, "GIT"));
+		expect(fence.deny).not.toContain(path.join(home, "GIT"));
+		expect(fence.denyEnumerate).toContain(path.join(home, "GIT"));
 		expect(fence.allow).toContain(workspace);
-		// A sibling checkout under the same home is the cross-customer case this exists for.
-		expect(fenceVerdict(fence, path.join(home, "GIT", "custB", "secret"), "read")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(home, "GIT"), "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(home, "GIT", "custB", "secret"), "read")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(home, "GIT", "custB", "secret"), "write")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(workspace, "notes.md"), "read")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(workspace, "notes.md"), "write")).toBe("allow");
+		expect(fenceVerdict(fence, workspace, "enumerate")).toBe("allow");
 	});
 
 	it("leaves everything outside home alone — nothing operational is restricted", () => {
@@ -70,6 +72,21 @@ describe("buildContainmentFence", () => {
 		}
 		// The OS temp dir is not customer data and must stay usable for both directions.
 		expect(fenceVerdict(fence, path.join(fs.realpathSync(os.tmpdir()), "scratch"), "write")).toBe("allow");
+	});
+
+	it("lets an explicit read grant restore parent enumeration", () => {
+		const home = realTmp("enumeration-override");
+		const parent = path.join(home, "customers");
+		const workspace = path.join(parent, "example-a");
+		fs.mkdirSync(workspace, { recursive: true });
+
+		const defaultFence = buildContainmentFence({ workspace, home });
+		const readGranted = buildContainmentFence({ workspace, home, readOnlyRoots: [parent] });
+		const writeGranted = buildContainmentFence({ workspace, home, writeOnlyRoots: [parent] });
+
+		expect(fenceVerdict(defaultFence, parent, "enumerate")).toBe("deny");
+		expect(fenceVerdict(readGranted, parent, "enumerate")).toBe("allow");
+		expect(fenceVerdict(writeGranted, parent, "enumerate")).toBe("deny");
 	});
 
 	it("re-allows package caches so toolchains keep working", () => {
@@ -153,7 +170,7 @@ describe("buildContainmentFence", () => {
 
 		expect(fence.allow).toContain(workspace);
 		expect(fence.allow).not.toContain(link);
-		for (const root of [...fence.allow, ...fence.allowReadOnly, ...fence.deny]) {
+		for (const root of [...fence.allow, ...fence.allowReadOnly, ...fence.deny, ...fence.denyEnumerate]) {
 			expect(path.isAbsolute(root)).toBe(true);
 			// A root that exists must already be its own real path. One that does not yet exist (an
 			// absent cache dir) has nothing to resolve, and is emitted so it can be created later.
@@ -241,19 +258,18 @@ describe("buildContainmentFence — the operator's home is theirs (#2637)", () =
 		expect(fence.deny).not.toContain(home);
 	});
 
-	it("still refuses the session folder's sibling and its container", () => {
+	it("refuses scanning the session folder's parent without refusing a named sibling", () => {
 		const { home, container, workspace, sibling } = customerSession("sibling");
 		const fence = buildContainmentFence({ workspace, home });
 
-		expect(fenceVerdict(fence, path.join(sibling, "notes.md"), "read")).toBe("deny");
-		expect(fenceVerdict(fence, path.join(sibling, "notes.md"), "write")).toBe("deny");
-		expect(fence.deny).toContain(container);
+		expect(fenceVerdict(fence, container, "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(sibling, "notes.md"), "read")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(sibling, "notes.md"), "write")).toBe("allow");
+		expect(fence.denyEnumerate).toContain(container);
 		expect(fenceVerdict(fence, path.join(workspace, "mine.md"), "write")).toBe("allow");
 	});
 
-	// The v19.100.1 regression: with `<container>/<tenant>/repo`, denying only the immediate parent left
-	// every OTHER tenant reachable. Stopping the walk at home must not bring that back.
-	it("still refuses other tenants when the workspace is nested deeper", () => {
+	it("keeps the enumeration deny exact when the workspace is nested deeper", () => {
 		const home = realTmp("nested");
 		const container = path.join(home, "MEDDPICC");
 		const workspace = path.join(container, "CUSTOMER-A", "repo");
@@ -262,19 +278,18 @@ describe("buildContainmentFence — the operator's home is theirs (#2637)", () =
 
 		const fence = buildContainmentFence({ workspace, home });
 
-		expect(fenceVerdict(fence, path.join(otherTenant, "secret.env"), "read")).toBe("deny");
-		expect(fenceVerdict(fence, path.join(container, "CUSTOMER-A", "sibling-of-repo"), "read")).toBe("deny");
+		expect(fenceVerdict(fence, path.dirname(workspace), "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(otherTenant, "secret.env"), "read")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(container, "CUSTOMER-A", "sibling-of-repo"), "read")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(workspace, "mine.md"), "write")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(home, "git", "STYLE_GUIDE.md"), "read")).toBe("allow");
 	});
 
 	/**
-	 * A session whose folder IS home, or a direct child of it, fences nothing above itself.
+	 * A session whose folder is a direct child of home protects the home listing, not home contents.
 	 *
-	 * Asserted rather than left to be discovered, because it is the deliberate consequence of not denying
-	 * home: the siblings live in home, so there is no arrangement of rules that reads all of home and
-	 * refuses a sibling inside it. If the operator chooses to work there, that is their filesystem to lay
-	 * out — and a test that pretended otherwise would be claiming a protection that does not exist.
+	 * The sibling remains reachable by name because the operator's home is theirs. What the session cannot
+	 * do accidentally is list home and discover which sibling names exist.
 	 */
 	it("does not fence home when the session folder sits directly in it", () => {
 		const home = realTmp("inhome");
@@ -288,6 +303,7 @@ describe("buildContainmentFence — the operator's home is theirs (#2637)", () =
 		const fence = buildContainmentFence({ workspace, home, leakRoots: [sessions] });
 
 		expect(fence.deny).not.toContain(home);
+		expect(fenceVerdict(fence, home, "enumerate")).toBe("deny");
 		expect(fenceVerdict(fence, path.join(sibling, "notes.md"), "read")).toBe("allow");
 		// The cross-SESSION surfaces are still closed, because those are the agent's own state rather
 		// than the operator's layout.
@@ -556,10 +572,7 @@ describe("buildContainmentFence — review findings", () => {
 		expect(fenceVerdict(fence, path.join(writable, "x"), "read")).toBe("deny");
 	});
 
-	it("denies the workspace's siblings even when the workspace is outside home", () => {
-		// Verified allow/allow before the fix: with /work/customer-a as the workspace, /work/customer-b
-		// matched nothing and was readable AND writable. A fleet keeping customer folders outside the
-		// home tree got no containment at all.
+	it("denies sibling discovery even when the workspace is outside home", () => {
 		const base = realTmp("work");
 		const a = path.join(base, "customer-a");
 		const b = path.join(base, "customer-b");
@@ -567,8 +580,9 @@ describe("buildContainmentFence — review findings", () => {
 		fs.mkdirSync(b);
 		const fence = buildContainmentFence({ workspace: a, home: path.join(base, "unrelated-home") });
 
-		expect(fenceVerdict(fence, path.join(b, "secret"), "read")).toBe("deny");
-		expect(fenceVerdict(fence, path.join(b, "planted"), "write")).toBe("deny");
+		expect(fenceVerdict(fence, base, "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(b, "secret"), "read")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(b, "planted"), "write")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(a, "own.md"), "write")).toBe("allow");
 	});
 
@@ -778,7 +792,7 @@ describe("buildContainmentFence — review findings", () => {
 
 	// The grants above must not have widened anything else. This is the property that makes the fence
 	// worth having at all, so it is asserted beside the change that could break it.
-	it("still isolates customer workspaces and private keys after the CLI grants", () => {
+	it("keeps discovery and cross-session isolation after the CLI grants", () => {
 		const home = realTmp("stillhome");
 		const workspace = path.join(home, "GIT", "custA");
 		const sessions = path.join(home, ".xcsh", "agent", "sessions");
@@ -786,15 +800,11 @@ describe("buildContainmentFence — review findings", () => {
 		fs.mkdirSync(sessions, { recursive: true });
 		const fence = buildContainmentFence({ workspace, home, leakRoots: [sessions] });
 
-		// The two things left inside home since #2637, and the only two this fence is for: another
-		// customer's checkout, and another session's transcript. Both are inadvertent-wandering surfaces.
-		for (const denied of [
-			"GIT/custB/secrets.tf", // the sibling checkout this fence exists for
-			".xcsh/agent/sessions/other.jsonl", // another session's transcript
-		]) {
-			expect(fenceVerdict(fence, path.join(home, denied), "read")).toBe("deny");
-			expect(fenceVerdict(fence, path.join(home, denied), "write")).toBe("deny");
-		}
+		expect(fenceVerdict(fence, path.join(home, "GIT"), "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(home, "GIT/custB/secrets.tf"), "read")).toBe("allow");
+		const otherSession = path.join(home, ".xcsh/agent/sessions/other.jsonl");
+		expect(fenceVerdict(fence, otherSession, "read")).toBe("deny");
+		expect(fenceVerdict(fence, otherSession, "write")).toBe("deny");
 		// The operator's own private files are not withheld from them. Asserted rather than left implicit,
 		// so anyone auditing what this fence protects sees the choice.
 		for (const own of [".ssh/id_ed25519", ".gnupg/secring.gpg", "Documents/contract.pdf"]) {
@@ -915,20 +925,8 @@ describe("containmentStatus", () => {
 	});
 });
 
-/**
- * The parent deny was one level deep, and that is not where tenants necessarily sit.
- *
- * `buildContainmentFence` denied home and the workspace's *immediate* parent. With a layout of
- * `<container>/<tenant>/repo` the immediate parent is the tenant, so every OTHER tenant matched no rule
- * and the fence allowed it — read and write. That went unnoticed because the command-text scan is
- * deny-by-default and refused those paths on the way in, so the composite looked correct while the fence
- * alone was not. Removing that scan for OS-confined shells (#2582) is what exposed it.
- *
- * Found by adversarial review of #2582, reproduced here before fixing: `<container>/globex/repo/secrets.tf`
- * was `read=allow write=allow`.
- */
-describe("buildContainmentFence — isolation does not depend on how deep the workspace sits", () => {
-	it("denies a cousin tenant, not just an immediate sibling", () => {
+describe("buildContainmentFence — enumeration isolation is exact", () => {
+	it("does not turn the courtesy into a named-path restriction", () => {
 		const home = realTmp("cousinhome");
 		const container = realTmp("tenants");
 		const workspace = path.join(container, "example-corp", "repo");
@@ -936,11 +934,12 @@ describe("buildContainmentFence — isolation does not depend on how deep the wo
 		fs.mkdirSync(path.join(container, "globex", "repo"), { recursive: true });
 		const fence = buildContainmentFence({ workspace, home });
 
-		// The case that exists for this fence, one level deeper than the original rule reached.
+		expect(fenceVerdict(fence, path.dirname(workspace), "enumerate")).toBe("deny");
+		// Known paths stay under the operator's normal authority.
 		for (const access of ["read", "write"] as const) {
-			expect(fenceVerdict(fence, path.join(container, "globex", "repo", "secrets.tf"), access)).toBe("deny");
-			expect(fenceVerdict(fence, path.join(container, "example-corp", "other-repo", "x"), access)).toBe("deny");
-			expect(fenceVerdict(fence, path.join(container, "loose-file.txt"), access)).toBe("deny");
+			expect(fenceVerdict(fence, path.join(container, "globex", "repo", "secrets.tf"), access)).toBe("allow");
+			expect(fenceVerdict(fence, path.join(container, "example-corp", "other-repo", "x"), access)).toBe("allow");
+			expect(fenceVerdict(fence, path.join(container, "loose-file.txt"), access)).toBe("allow");
 		}
 		// …and the workspace itself still works, or the fence is useless.
 		expect(fenceVerdict(fence, path.join(workspace, "notes.md"), "read")).toBe("allow");
@@ -990,8 +989,9 @@ describe("buildContainmentFence — the ancestor walk never denies a temp root",
 				expect(root).not.toBe(realTmpRoot);
 			}
 			expect(fenceVerdict(fence, path.join(realTmpRoot, "other-session.txt"), "read")).toBe("allow");
-			// The workspace's own container is still denied, which is the point of the walk.
-			expect(fenceVerdict(fence, path.join(realContainer, "sibling", "x"), "read")).toBe("deny");
+			// The workspace's own container cannot be scanned, but a named child is still reachable.
+			expect(fenceVerdict(fence, realContainer, "enumerate")).toBe("deny");
+			expect(fenceVerdict(fence, path.join(realContainer, "sibling", "x"), "read")).toBe("allow");
 			expect(fenceVerdict(fence, path.join(fs.realpathSync(workspace), "mine.txt"), "write")).toBe("allow");
 		} finally {
 			fs.rmSync(container, { recursive: true, force: true });

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getAgentDir, getPluginsDir } from "@f5-sales-demo/pi-utils";
+import { getAgentDir, getConfigRootDir, getPluginsDir } from "@f5-sales-demo/pi-utils";
 import { buildContainmentFence, containmentStatus, fenceVerdict } from "../src/sandbox/containment";
 
 /**
@@ -95,25 +95,35 @@ describe("buildContainmentFence", () => {
 		fs.mkdirSync(workspace, { recursive: true });
 		const fence = buildContainmentFence({ workspace, home });
 
-		// These sit inside the denied home tree and must be carved back out, or `bun install`,
-		// `cargo build` and `npm ci` fail — the exact breakage this fence must not cause. Narrowed to
-		// the artifact subdirectories, because granting the parents exposed credentials.
+		// Keep these explicit grants stable for toolchain compatibility. Home is otherwise available under
+		// the operator-rights policy, so the grants must not introduce a narrower write rule.
 		for (const cache of [".bun/install/cache", ".cargo/registry", ".npm/_cacache", ".m2/repository"]) {
 			expect(fenceVerdict(fence, path.join(home, cache, "x"), "write")).toBe("allow");
 		}
 	});
 
-	it("keeps git config readable but not writable", () => {
+	it("keeps operator-owned home and configuration writable", () => {
 		const home = realTmp("home4");
 		const workspace = path.join(home, "w");
 		fs.mkdirSync(workspace, { recursive: true });
 		const fence = buildContainmentFence({ workspace, home });
 
-		expect(fenceVerdict(fence, path.join(home, ".gitconfig"), "read")).toBe("allow");
-		expect(fenceVerdict(fence, path.join(home, ".gitconfig"), "write")).toBe("deny");
+		for (const own of [
+			".gitconfig",
+			".aws/config",
+			".zshrc",
+			".zprofile",
+			".ssh/config",
+			".xcsh/settings.json",
+			".xcsh/plugins/example/plugin.json",
+			".xcsh/skills/example/SKILL.md",
+		]) {
+			expect(fenceVerdict(fence, path.join(home, own), "read")).toBe("allow");
+			expect(fenceVerdict(fence, path.join(home, own), "write")).toBe("allow");
+		}
 	});
 
-	it("denies credentials even though they sit in the same home", () => {
+	it("keeps the operator's private files under their normal filesystem rights", () => {
 		const home = realTmp("home5");
 		const workspace = path.join(home, "w");
 		fs.mkdirSync(workspace, { recursive: true });
@@ -308,18 +318,6 @@ describe("buildContainmentFence — the operator's home is theirs (#2637)", () =
 		// The cross-SESSION surfaces are still closed, because those are the agent's own state rather
 		// than the operator's layout.
 		expect(fenceVerdict(fence, path.join(sessions, "x.jsonl"), "read")).toBe("deny");
-	});
-
-	// A write that installs something a later unfenced run executes is a different concern from context
-	// isolation, so #2637 does not relax it.
-	it("still refuses writes to command-bearing CLI config", () => {
-		const { home, workspace } = customerSession("cmdconfig");
-		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
-
-		for (const vector of [path.join(".aws", "config"), path.join(".cargo", "config.toml")]) {
-			expect(fenceVerdict(fence, path.join(home, vector), "write")).toBe("deny");
-			expect(fenceVerdict(fence, path.join(home, vector), "read")).toBe("allow");
-		}
 	});
 });
 
@@ -598,28 +596,22 @@ describe("buildContainmentFence — review findings", () => {
 		expect(fenceVerdict(system, "/etc/hosts", "read")).toBe("allow");
 	});
 
-	it("keeps toolchain credentials outside the cache carve-outs", () => {
-		// Verified writable before the fix: granting ~/.cargo, ~/.m2, ~/.gradle and ~/.npm whole put
-		// credentials.toml, settings.xml, init.gradle and _authToken inside the fence — credential
-		// theft and persistent build-config tampering, not merely a read.
+	it("keeps operator-owned toolchain configuration writable while preserving cache access", () => {
 		const home = realTmp("credhome");
 		const workspace = path.join(home, "w");
 		fs.mkdirSync(workspace, { recursive: true });
 		const fence = buildContainmentFence({ workspace, home });
 
-		// Since #2637 home is the operator's own, so the credential files here read and write like anything
-		// else of theirs. What must stay refused is a write that redirects a later build — persistence
-		// rather than theft — which needed naming in COMMAND_BEARING_CONFIG once the cache carve-outs
-		// stopped shielding it by omission.
-		const narrowing = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
-		for (const buildVector of [".cargo/config.toml", ".gradle/init.gradle"]) {
-			expect(fenceVerdict(narrowing, path.join(home, buildVector), "write")).toBe("deny");
-			expect(fenceVerdict(narrowing, path.join(home, buildVector), "read")).toBe("allow");
-		}
-		for (const own of [".cargo/credentials.toml", ".m2/settings.xml", ".npm/_authToken"]) {
+		for (const own of [
+			".cargo/config.toml",
+			".cargo/credentials.toml",
+			".gradle/init.gradle",
+			".m2/settings.xml",
+			".npm/_authToken",
+		]) {
 			expect(fenceVerdict(fence, path.join(home, own), "read")).toBe("allow");
+			expect(fenceVerdict(fence, path.join(home, own), "write")).toBe("allow");
 		}
-		// The parts a build actually writes stay granted, or the carve-out was pointless.
 		for (const artifact of [
 			".cargo/registry/index/x",
 			".m2/repository/org/x.jar",
@@ -657,24 +649,9 @@ describe("buildContainmentFence — review findings", () => {
 			expect(fenceVerdict(fence, path.join(home, config), "write")).toBe("allow");
 		}
 
-		// Readable, but see the command-bearing test below: these are deliberately not writable when the
-		// backend can express that.
-		for (const readOnly of [".aws/config", ".kube/config", "Library/Application Support/glab-cli/aliases.yml"]) {
-			expect(fenceVerdict(fence, path.join(home, readOnly), "read")).toBe("allow");
-		}
-	});
-
-	// The grant above must not become a way to run code later. Writing `~/.aws/config` installs a
-	// `credential_process` that the operator's next — unfenced — `aws` call executes, with access to
-	// everything the fence protects. That is an escape, not a leak, so every command-bearing path stays
-	// read-only: the CLI still reads it, nothing stops working, only rewriting is refused.
-	it("never grants write to configuration that names a command or holds an executable", () => {
-		const home = realTmp("execconf");
-		const workspace = path.join(home, "w");
-		fs.mkdirSync(workspace, { recursive: true });
-		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
-
-		for (const bearing of [
+		// These paths can name commands, but that does not turn this courtesy into a privilege boundary
+		// against the operator. Shell profiles and SSH configuration are writable for the same reason.
+		for (const config of [
 			".aws/config", // credential_process = <command>
 			".kube/config", // users[].user.exec.command
 			".docker/config.json", // credsStore / credHelpers
@@ -687,93 +664,9 @@ describe("buildContainmentFence — review findings", () => {
 			"Library/Application Support/glab-cli/aliases.yml",
 			".aws/cli/alias", // an aws alias starting with `!` runs through a shell
 		]) {
-			expect(fenceVerdict(fence, path.join(home, bearing), "write")).toBe("deny");
-			// Read must survive, or the CLI cannot authenticate and #2581 is back.
-			expect(fenceVerdict(fence, path.join(home, bearing), "read")).toBe("allow");
+			expect(fenceVerdict(fence, path.join(home, config), "read")).toBe("allow");
+			expect(fenceVerdict(fence, path.join(home, config), "write")).toBe("allow");
 		}
-
-		// The state each CLI genuinely writes stays writable, or `az` exits 1 and `sf` hangs — measured.
-		for (const state of [".azure/commands/x.log", ".sf/sf-2026-07-28.log", ".aws/sso/cache/x.json"]) {
-			expect(fenceVerdict(fence, path.join(home, state), "write")).toBe("allow");
-		}
-	});
-
-	// A read-only descendant must land in the same namespace as the grant it narrows. `canonical`
-	// returns undefined for a path that does not exist yet, and falling back to the literal string is
-	// unsafe: with ~/.aws symlinked (chezmoi, stow and yadm all do this) the grant resolves to the link
-	// target while the read-only rule keeps the link path, so the kernel matches only the grant and the
-	// `credential_process` protection evaporates. Verified allow/allow before the fix.
-	it("protects command-bearing config even when its directory is a symlink", () => {
-		const home = realTmp("symconf");
-		const workspace = path.join(home, "w");
-		const vault = realTmp("vault");
-		fs.mkdirSync(workspace, { recursive: true });
-		// ~/.aws -> <vault>, and no config file exists inside it yet.
-		fs.symlinkSync(vault, path.join(home, ".aws"));
-		expect(fs.existsSync(path.join(vault, "config"))).toBe(false);
-
-		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
-
-		// Assert the emitted ROOT, not the verdict. `fenceVerdict` normalises symlinks via
-		// `pathIsWithin`, so it answered "deny" even while the profile handed to sandbox-exec carried the
-		// unresolved spelling and the write went through. Verified: with the literal rule,
-		// `printf 'credential_process = …' > <vault>/config` succeeded under the real seatbelt profile.
-		// Only the emitted string tells the truth here, because that is what the backend compiles.
-		expect(fence.allowReadOnly).toContain(path.join(vault, "config"));
-		expect(fence.allowReadOnly).not.toContain(path.join(home, ".aws", "config"));
-		expect(fence.allow).toContain(vault);
-
-		// …while the rest of the tree stays writable, or `aws sso login` breaks.
-		expect(fenceVerdict(fence, path.join(vault, "sso", "cache", "x.json"), "write")).toBe("allow");
-	});
-
-	// AWS CLI reads ~/.aws/cli/alias, where an alias starting with `!` runs through a shell and can
-	// shadow a normal top-level command. Missed on the first pass because ~/.aws was granted wholesale.
-	it("refuses writes to the aws alias file, which executes through a shell", () => {
-		const home = realTmp("aliashome");
-		const workspace = path.join(home, "w");
-		fs.mkdirSync(workspace, { recursive: true });
-		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
-
-		expect(fenceVerdict(fence, path.join(home, ".aws", "cli", "alias"), "write")).toBe("deny");
-		expect(fenceVerdict(fence, path.join(home, ".aws", "cli", "alias"), "read")).toBe("allow");
-		// The cache beside it is what `aws sso login` and assume-role write, so it stays writable.
-		expect(fenceVerdict(fence, path.join(home, ".aws", "cli", "cache", "x.json"), "write")).toBe("allow");
-	});
-
-	// Landlock cannot narrow a right inside a grant: its rules are allow-only and recursive, so holding
-	// a file read-only inside a writable directory turns the parent into a split dir that loses write on
-	// its own inode. Verified with `containment-check plan` — adding ~/.azure/cliextensions as read-only
-	// made ~/.azure itself `r-`, which stops `az` writing azureProfile.json at all. So on that backend the
-	// narrowing is skipped and the gap is reported, rather than breaking the CLIs #2581 is about.
-	it("skips the command-bearing narrowing on a backend that cannot express it", () => {
-		const home = realTmp("nonarrow");
-		const workspace = path.join(home, "w");
-		fs.mkdirSync(workspace, { recursive: true });
-		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: false });
-
-		// Writable, because the alternative is a directory the CLI cannot write to at all.
-		for (const bearing of [".aws/config", ".kube/config", ".azure/config"]) {
-			expect(fenceVerdict(fence, path.join(home, bearing), "write")).toBe("allow");
-		}
-		// ~/.gitconfig is NOT part of this: it is read-only via its own root, not a narrowing inside a
-		// grant, so it must survive on every backend.
-		expect(fenceVerdict(fence, path.join(home, ".gitconfig"), "write")).toBe("deny");
-		expect(fenceVerdict(fence, path.join(home, ".gitconfig"), "read")).toBe("allow");
-		// And the boundary still applies where it should: the workspace's container, not the operator's own
-		// dotfiles, which #2637 stopped denying.
-		expect(fenceVerdict(fence, path.join(home, ".ssh", "id_rsa"), "read")).toBe("allow");
-	});
-
-	// Defaulting to the portable policy matters: a caller that does not know its backend must not get
-	// rules that break every CLI on Linux.
-	it("defaults to the portable policy when the caller does not say", () => {
-		const home = realTmp("defaultnarrow");
-		const workspace = path.join(home, "w");
-		fs.mkdirSync(workspace, { recursive: true });
-		const fence = buildContainmentFence({ workspace, home });
-
-		expect(fenceVerdict(fence, path.join(home, ".aws", "config"), "write")).toBe("allow");
 	});
 
 	// Same defect as the CACHE_DIRS carve-out, missed for Go: `go` is in the tool list xcsh probes for,
@@ -858,14 +751,7 @@ describe("containmentStatus", () => {
 			enabled: true,
 			backend: "landlock",
 			osEnforced: true,
-			// No Landlock ABI can narrow a right inside a grant, so the command-bearing CLI settings are
-			// writable there and the model is told so. Seatbelt reports no such field.
-			commandConfigWritable: true,
 		});
-	});
-
-	it("does not claim command-bearing config is writable under seatbelt", () => {
-		expect(containmentStatus(true, "darwin")).not.toHaveProperty("commandConfigWritable");
 	});
 
 	// The case that must not over-claim: a Linux box where Landlock is absent or too old.
@@ -1129,17 +1015,18 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 		expect(fenceVerdict(fence, path.join(fs.realpathSync("/tmp"), "scratch.txt"), "write")).toBe("allow");
 	});
 
-	// The agent's own plugins and user skills sit under `~/.xcsh`, inside the home deny. The file tools
-	// allow-listed them and the fence did not, so `bash` could not read a plugin the `read` tool could —
-	// the asymmetry #2624 removes. Emitted whether or not they exist yet: the skills dir is created on
-	// first use, and a rule that appears only after the directory does is a rule nobody can rely on.
-	it("grants the agent's own plugins and user skills, which sit under denied home", () => {
+	// Agent configuration belongs to the operator just like shell and CLI configuration. Keeping these
+	// read-only would still be a privilege boundary even though they happen to be xcsh inputs.
+	it("keeps the agent's plugins, user skills, and settings writable", () => {
 		const fence = buildContainmentFence({ workspace: fs.realpathSync(process.cwd()) });
 
-		for (const own of [getPluginsDir(), path.join(getAgentDir(), "skills")]) {
-			expect(fenceVerdict(fence, path.join(own, "probe", "manifest.json"), "read")).toBe("allow");
-			// Read-only: these are inputs, and a write there changes what a later session loads.
-			expect(fenceVerdict(fence, path.join(own, "probe", "manifest.json"), "write")).toBe("deny");
+		for (const own of [
+			path.join(getPluginsDir(), "probe", "manifest.json"),
+			path.join(getAgentDir(), "skills", "probe", "SKILL.md"),
+			path.join(getConfigRootDir(), "settings.json"),
+		]) {
+			expect(fenceVerdict(fence, own, "read")).toBe("allow");
+			expect(fenceVerdict(fence, own, "write")).toBe("allow");
 		}
 	});
 

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { ContainmentFence } from "../src/sandbox/containment";
+import { buildContainmentFence, type ContainmentFence } from "../src/sandbox/containment";
 import { evaluateToolCall } from "../src/sandbox/enforce";
 import { resolveSessionFence } from "../src/sandbox/session-fence";
 
@@ -33,6 +33,7 @@ function makeFence(): ContainmentFence {
 			"/work", // the container: every other tenant under it is unreachable
 			os.homedir(), // ~/.ssh, ~/Documents, another checkout — the real fence denies all of home
 		],
+		denyEnumerate: [],
 	};
 }
 
@@ -83,6 +84,30 @@ describe("evaluateToolCall", () => {
 		// of the asymmetries #2624 removes — a fenced `bash` could already `grep /etc`.
 		expect(check("ast_grep", { path: "/etc" }).block).toBe(false);
 		expect(check("ast_grep", { path: "/work/custB" }).block).toBe(true);
+	});
+
+	it("blocks parent enumeration without blocking a named sibling file", () => {
+		const parent = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "xcsh-enumerate-")));
+		const workspace = path.join(parent, "example-a");
+		const sibling = path.join(parent, "example-b");
+		fs.mkdirSync(workspace);
+		fs.mkdirSync(sibling);
+		fs.symlinkSync("..", path.join(workspace, "parent-link"));
+		const namedFile = path.join(sibling, "context.md");
+		fs.writeFileSync(namedFile, "context");
+		try {
+			const fence = buildContainmentFence({ workspace, home: parent });
+			const evaluate = (toolName: string, input: Record<string, unknown>) =>
+				evaluateToolCall({ toolName, input, cwd: workspace, fence });
+
+			expect(evaluate("read", { file_path: parent }).block).toBe(true);
+			expect(evaluate("read", { file_path: path.join(workspace, "parent-link") }).block).toBe(true);
+			expect(evaluate("read", { file_path: namedFile }).block).toBe(false);
+			expect(evaluate("grep", { pattern: "context", path: parent }).block).toBe(true);
+			expect(evaluate("ast_edit", { path: parent }).block).toBe(true);
+		} finally {
+			fs.rmSync(parent, { recursive: true, force: true });
+		}
 	});
 
 	it("find: pattern base escaping the tree is blocked; in-tree glob allowed", () => {
@@ -413,6 +438,7 @@ describe("evaluateToolCall", () => {
 			allowReadOnly: ["/shared/ctx"],
 			allowWriteOnly: [],
 			deny: [],
+			denyEnumerate: [],
 		};
 		const inRoCwd = (command: string) =>
 			evaluateToolCall({ toolName: "bash", input: { command }, cwd: "/shared/ctx", fence: readOnlyCwd });
@@ -521,7 +547,13 @@ describe("evaluateToolCall", () => {
 	// undefined and `sandbox-guard` returns before evaluating. The equivalent here is a fence with no
 	// rules at all, which allows everything by construction.
 	it("allows everything under a fence with no rules", () => {
-		const open: ContainmentFence = { allow: [], allowReadOnly: [], allowWriteOnly: [], deny: [] };
+		const open: ContainmentFence = {
+			allow: [],
+			allowReadOnly: [],
+			allowWriteOnly: [],
+			deny: [],
+			denyEnumerate: [],
+		};
 		expect(check("read", { file_path: "/etc/passwd" }, open).block).toBe(false);
 		expect(check("bash", { command: "cat ../custB/x" }, open).block).toBe(false);
 	});
@@ -588,13 +620,12 @@ describe("evaluateToolCall with a symlinked working directory (#2312)", () => {
 		expect(checkAt(cwd, { path: "brand-new.ts" }, "write").block).toBe(false);
 	});
 
-	it("still blocks genuinely out-of-tree paths from a symlinked cwd", () => {
+	it("still blocks parent enumeration from a symlinked cwd", () => {
 		const cwd = symlinkedCwd();
-		// A sibling of the symlinked cwd: the ancestor walk denies the container they share. `/etc/passwd`
-		// used to serve here and cannot any more — it is permitted now (#2624), and a customer tree is the
-		// thing this test is actually about.
-		expect(checkAt(cwd, { path: "../elsewhere/secret.json" }).block).toBe(true);
-		// `~/.ssh` used to serve here; #2637 stopped denying it. The sibling above is the case that matters.
+		const parent = path.dirname(fs.realpathSync(cwd));
+		expect(checkAt(cwd, { path: parent }).block).toBe(true);
+		// The deny is exact and does not revoke operator authority over a named child.
+		expect(checkAt(cwd, { path: "../elsewhere/secret.json" }).block).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -13,8 +13,8 @@ const CWD = "/work/custA";
  *
  * `ContainmentFence` is a plain record of canonical roots, so these tests need no filesystem — which is
  * what keeps them a unit test of `evaluateToolCall` rather than of `buildContainmentFence`. The shape
- * mirrors a real session: the workspace read+write, a couple of one-directional grants, and the
- * workspace's container denied so a neighbouring tenant is unreachable.
+ * exercises the workspace, one-directional grants, and a protected data root. Parent enumeration and
+ * named sibling access are covered with a real built fence below.
  *
  * Note what is deliberately absent: any rule about `/etc`, `/usr`, `/tmp` or an unrelated `/elsewhere`.
  * The fence is allow-by-default, so those are reachable, and that is the loosening #2624 is — a
@@ -23,16 +23,9 @@ const CWD = "/work/custA";
 function makeFence(): ContainmentFence {
 	return {
 		allow: [CWD],
-		allowReadOnly: [
-			"/opt/xcsh/plugins", // plugin cache
-			"/shared/ctx", // shared context: readable, deliberately not writable
-			path.join(os.homedir(), ".gitconfig"), // needed by git, must not be rewritten
-		],
+		allowReadOnly: ["/shared/ctx"], // shared context: readable, deliberately not writable
 		allowWriteOnly: ["/drop"], // write-only drop box, deliberately not readable
-		deny: [
-			"/work", // the container: every other tenant under it is unreachable
-			os.homedir(), // ~/.ssh, ~/Documents, another checkout — the real fence denies all of home
-		],
+		deny: ["/work"], // stands in for a data root or cross-session store
 		denyEnumerate: [],
 	};
 }
@@ -72,9 +65,9 @@ describe("evaluateToolCall", () => {
 		expect(check("edit", { file_path: "/work/custB/hosts" }).block).toBe(true);
 	});
 
-	it("treats plugin cache as readable (meddpicc engine) but not writable", () => {
+	it("keeps operator-owned plugin state readable and writable", () => {
 		expect(check("read", { file_path: "/opt/xcsh/plugins/meddpicc/cli.ts" }).block).toBe(false);
-		expect(check("write", { file_path: "/opt/xcsh/plugins/x" }).block).toBe(true);
+		expect(check("write", { file_path: "/opt/xcsh/plugins/x" }).block).toBe(false);
 	});
 
 	it("search tools: absent path defaults to cwd (allowed); explicit out-of-tree blocked", () => {
@@ -131,7 +124,7 @@ describe("evaluateToolCall", () => {
 
 	it("bash: blocks absolute-path escapes, exempts OS system paths", () => {
 		expect(check("bash", { command: "cat /work/custB/secrets.env" }).block).toBe(true);
-		expect(check("bash", { command: "cat ~/.ssh/id_rsa" }).block).toBe(true);
+		expect(check("bash", { command: "cat ~/.ssh/id_rsa" }).block).toBe(false);
 		expect(check("bash", { command: "cat /etc/os-release" }).block).toBe(false);
 		expect(check("bash", { command: "/usr/bin/env node app.js" }).block).toBe(false);
 	});
@@ -271,7 +264,7 @@ describe("evaluateToolCall", () => {
 		// Into something the fence denies: refused, which is the case that matters.
 		expect(check("bash", { command: "cd /work/custB" }).block).toBe(true);
 		expect(check("bash", { command: "cd .." }).block).toBe(true);
-		expect(check("bash", { command: "cd ~" }).block).toBe(true);
+		expect(check("bash", { command: "cd ~" }).block).toBe(false);
 		// `cd /` is allowed now (#2624). Standing at `/` widens nothing: the boundary is fixed for the
 		// session and no longer follows the shell (#2589), so a later relative path is still decided
 		// against the same rules — `cd / && cat Users/other/x` is refused by the fence at the open.
@@ -281,11 +274,10 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "cd" }).block).toBe(false);
 		expect(check("bash", { command: "cd -" }).block).toBe(false);
 		expect(check("bash", { command: "pushd /" }).block).toBe(false);
-		// `$HOME` is still caught, but by the floor rather than the `cd` gate: it rewrites the token to
-		// `~`, which resolves into the denied home tree.
-		expect(check("bash", { command: "cd $HOME" }).block).toBe(true);
-		expect(check("bash", { command: 'cd "$HOME"' }).block).toBe(true);
-		expect(check("bash", { command: "pushd $HOME" }).block).toBe(true);
+		// Home is operator-owned and remains available through every spelling.
+		expect(check("bash", { command: "cd $HOME" }).block).toBe(false);
+		expect(check("bash", { command: 'cd "$HOME"' }).block).toBe(false);
+		expect(check("bash", { command: "pushd $HOME" }).block).toBe(false);
 	});
 
 	// Clamping the session cwd between calls would not have been enough: one call can both move the
@@ -294,7 +286,7 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "cd .. && cat custB/secret" }).block).toBe(true);
 		expect(check("bash", { command: "cd ..; cat custB/secret" }).block).toBe(true);
 		expect(check("bash", { command: "(cd /work/custB && cat secret)" }).block).toBe(true);
-		expect(check("bash", { command: "cd $HOME && cat .ssh/id_rsa" }).block).toBe(true);
+		expect(check("bash", { command: "cd $HOME && cat .ssh/id_rsa" }).block).toBe(false);
 		expect(check("bash", { command: "cd /work/custB && cat secret" }).block).toBe(true);
 		// `cd /` is the case that changed: it is permitted, and the relative read after it lands in a
 		// temp path the fence allows anyway. What must still fail is reaching a *denied* tree from there,
@@ -334,8 +326,7 @@ describe("evaluateToolCall", () => {
 	});
 
 	// A cd destination must be somewhere any relative path would be acceptable — which means write
-	// as well as read. The default policy grants the plugin and skill directories read-only, and
-	// moving into one turned every unchecked relative path into a write there.
+	// as well as read. An explicit read-only grant cannot become writable through relative paths.
 	it("bash: a directory change needs write access, not just read", () => {
 		// /shared/ctx is readable and deliberately not writable.
 		expect(check("bash", { command: "cd /shared/ctx" }).block).toBe(true);
@@ -694,8 +685,8 @@ describe("paths reaching the shell through an expansion (#2534)", () => {
 	 * The boundary reads the command as text, so a path arriving via a parameter expansion was
 	 * never checked. Only part of that is fixable at this layer, and the split matters:
 	 *
-	 *   - `$HOME`/`${HOME}` mean exactly what `~` means, which is already handled. Three
-	 *     spellings of one file, one of them blocked, is an oversight rather than a policy.
+	 *   - `$HOME`/`${HOME}` mean exactly what `~` means, which is already handled. All three spellings
+	 *     must preserve the operator's normal home access.
 	 *   - Everything else — a variable in an operand, and a variable in a redirect target — is
 	 *     genuinely unresolvable here and is left open on purpose. See below.
 	 */
@@ -703,11 +694,11 @@ describe("paths reaching the shell through an expansion (#2534)", () => {
 	// template literal is a template interpolation, and `HOME` is not a TS binding.
 	const BRACED_HOME = `$\u007bHOME\u007d`;
 
-	it("treats $HOME and its braced form as ~, which is already blocked", () => {
-		expect(check("bash", { command: "cat ~/.ssh/id_rsa" }).block).toBe(true); // the existing rule
-		expect(check("bash", { command: "cat $HOME/.ssh/id_rsa" }).block).toBe(true);
-		expect(check("bash", { command: `cat ${BRACED_HOME}/.ssh/id_rsa` }).block).toBe(true);
-		expect(check("bash", { command: 'cp secret "$HOME/exfil"' }).block).toBe(true);
+	it("treats $HOME and its braced form as the operator-owned home", () => {
+		expect(check("bash", { command: "cat ~/.ssh/id_rsa" }).block).toBe(false);
+		expect(check("bash", { command: "cat $HOME/.ssh/id_rsa" }).block).toBe(false);
+		expect(check("bash", { command: `cat ${BRACED_HOME}/.ssh/id_rsa` }).block).toBe(false);
+		expect(check("bash", { command: 'cp secret "$HOME/exfil"' }).block).toBe(false);
 		// A different variable that merely starts with HOME must not be rewritten.
 		expect(check("bash", { command: "echo $HOMEBREW_PREFIX" }).block).toBe(false);
 	});
@@ -809,15 +800,13 @@ describe("evaluateToolCall — the reported false refusals (#2624)", () => {
 		const gitconfig = path.join(os.homedir(), ".gitconfig");
 		expect(check("bash", { command: `cat ${gitconfig}` }).block).toBe(false);
 		expect(check("read", { file_path: gitconfig }).block).toBe(false);
-		// Read-only in the fence, so the write direction is refused on both — the split still holds.
-		expect(check("bash", { command: `printf x > ${gitconfig}` }).block).toBe(true);
-		expect(check("write", { file_path: gitconfig }).block).toBe(true);
+		expect(check("bash", { command: `printf x > ${gitconfig}` }).block).toBe(false);
+		expect(check("write", { file_path: gitconfig }).block).toBe(false);
 	});
 
 	// What the change must NOT do. The fence still denies these, so the pre-check still refuses them.
 	it("keeps refusing the paths the fence denies", () => {
 		expect(check("bash", { command: "cat /work/custB/secret.env" }).block).toBe(true);
-		expect(check("bash", { command: "cat ~/.ssh/id_rsa" }).block).toBe(true);
 		expect(check("read", { file_path: "/work/custB/secret.env" }).block).toBe(true);
 		expect(check("python", { code: 'open("/work/custB/secret.env").read()' }).block).toBe(true);
 		expect(check("grep", { pattern: "TOKEN", path: "/work/custB" }).block).toBe(true);
@@ -835,7 +824,6 @@ describe("evaluateToolCall — the bash cwd parameter agrees with cd (#2624)", (
 
 	it("still refuses a cwd the fence denies", () => {
 		expect(check("bash", { command: "ls", cwd: "/work/custB" }).block).toBe(true);
-		expect(check("bash", { command: "ls", cwd: os.homedir() }).block).toBe(true);
 	});
 
 	// A read-only root is not somewhere a command may stand: every relative path it then writes would

--- a/packages/coding-agent/test/sandbox-fence-anchor.int.test.ts
+++ b/packages/coding-agent/test/sandbox-fence-anchor.int.test.ts
@@ -13,16 +13,15 @@ import { BashTool } from "../src/tools/bash";
  * resulting PWD back into that field. So a `cd` the fence permits — and it does permit `cd /usr`, because
  * `/usr` is not sensitive and the fence is deliberately gentle — silently re-rooted the *next* fence.
  *
- * That mattered because the deny that isolates one customer from another is derived from the workspace's
- * parent. Re-rooted at `/usr`, there is no expressible parent deny: `dirname("/usr")` is `/`, and denying
- * the filesystem root is refused as too broad. Measured before the fix, with customers outside the home
- * tree: `/work/custB/secret.env` was denied, and after `cd /usr` it was readable *and* writable.
+ * That matters because the enumeration deny that prevents sibling discovery is derived from the
+ * workspace's parent. Re-rooted at `/usr`, there is no parent to protect: `dirname("/usr")` is `/`, and
+ * refusing root enumeration is too broad. The boundary is a courtesy rather than a privilege boundary,
+ * so named sibling reads and writes deliberately remain available; what must not move is the one parent
+ * directory the session cannot scan.
  *
- * Two tool calls, no exotic spelling, and cross-tenant isolation was gone. This is the regression test.
+ * A directory change must not erase that discovery boundary. This is the regression test.
  *
- * The workspace deliberately sits outside `$HOME`, because that is the layout the sibling-checkout deny
- * exists for — with customers *under* home the home deny happens to survive the relocation and hides the
- * bug entirely.
+ * The workspace deliberately sits outside `$HOME`, matching the sibling-checkout layout this rule covers.
  */
 describe("the containment boundary cannot be relocated by the model", () => {
 	const CANARY = "TOKEN=ANCHOR-CANARY-6120";
@@ -67,25 +66,29 @@ describe("the containment boundary cannot be relocated by the model", () => {
 		}
 	}
 
-	it("keeps the sibling checkout unreachable after a cd out of the tree", async () => {
-		// Control: the sibling is denied to begin with. Without this, the assertion below could pass on a
-		// session that was never fenced at all.
-		expect(await run(`cat ${path.join(custB, "secret.env")}`)).not.toContain(CANARY);
+	it("keeps the original parent non-enumerable after a cd out of the tree", async () => {
+		// Control: the parent cannot be scanned before relocation. Both children exist, so an ordinary
+		// listing would necessarily disclose these synthetic workspace names.
+		const before = await run(`ls ${work}`);
+		expect(before).not.toContain("custA");
+		expect(before).not.toContain("custB");
 
 		// The relocation attempt. `cd /usr` is *expected* to succeed — the fence does not confine the cwd,
 		// it denies specific trees — so this asserts nothing about the cd itself.
 		await run("c=cd; $c /usr");
 
 		// The actual property: the boundary did not travel with the shell.
-		expect(await run(`cat ${path.join(custB, "secret.env")}`)).not.toContain(CANARY);
-		expect(await run(`cat ${path.join(custB, "secret.env")}`)).not.toContain("ANCHOR-CANARY");
+		const after = await run(`ls ${work}`);
+		expect(after).not.toContain("custA");
+		expect(after).not.toContain("custB");
 	}, 120_000);
 
-	it("still cannot write into the sibling after the same cd", async () => {
+	it("preserves named sibling reads and writes after the same cd", async () => {
 		await run("c=cd; $c /usr");
+		expect(await run(`cat ${path.join(custB, "secret.env")}`)).toContain(CANARY);
 		const planted = path.join(custB, "planted.env");
 		await run(`printf pwned > ${planted}`);
-		expect(fs.existsSync(planted)).toBe(false);
+		expect(fs.readFileSync(planted, "utf8")).toBe("pwned");
 	}, 120_000);
 
 	it("leaves ordinary work in the session's own tree alone", async () => {

--- a/packages/coding-agent/test/sandbox-guard.test.ts
+++ b/packages/coding-agent/test/sandbox-guard.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { getSessionsDir } from "@f5-sales-demo/pi-utils";
 import { _resetSettingsForTest, Settings, settings } from "../src/config/settings";
 import sandboxGuard from "../src/extensibility/extensions/bundled/sandbox-guard";
 
@@ -63,10 +64,10 @@ describe("sandbox-guard bundled extension", () => {
 		expect(typeof captureHandler()).toBe("function");
 	});
 
-	it("blocks an out-of-tree read when enabled", async () => {
+	it("blocks enumeration of the session root's parent when enabled", async () => {
 		await initSandbox(true);
 		const handler = captureHandler()!;
-		expect(await call(handler, "read", { file_path: path.join(OTHER, "secret") })).toMatchObject({ block: true });
+		expect(await call(handler, "read", { file_path: container })).toMatchObject({ block: true });
 	});
 
 	it("allows an in-tree read when enabled", async () => {
@@ -81,19 +82,18 @@ describe("sandbox-guard bundled extension", () => {
 		expect(await call(handler, "read", { file_path: path.join(OTHER, "secret") })).toBeUndefined();
 	});
 
-	it("honors a MID-SESSION allowRead grant (settings.override busts the fence cache)", async () => {
+	it("honors a MID-SESSION parent-enumeration grant (settings.override busts the fence cache)", async () => {
 		await initSandbox(true);
 		const handler = captureHandler()!;
-		const secret = path.join(OTHER, "secret");
-		// First call caches the fence; the path is out-of-tree → blocked.
-		expect(await call(handler, "read", { file_path: secret })).toMatchObject({ block: true });
-		// The user grants custB at runtime (e.g. the Office pane picks a context folder). A cwd-only
-		// cache would keep blocking; the allow-list-keyed cache rebuilds.
-		settings.override("sandbox.allowRead", [OTHER]);
-		expect(await call(handler, "read", { file_path: secret })).toBeUndefined();
+		// First call caches the fence; the parent cannot be enumerated.
+		expect(await call(handler, "read", { file_path: container })).toMatchObject({ block: true });
+		// The user grants the parent at runtime. A cwd-only cache would keep blocking; the
+		// allow-list-keyed cache rebuilds and restores enumeration.
+		settings.override("sandbox.allowRead", [container]);
+		expect(await call(handler, "read", { file_path: container })).toBeUndefined();
 		// Revoking it re-blocks (cache tracks the current allow-list, not a one-way widen).
 		settings.override("sandbox.allowRead", []);
-		expect(await call(handler, "read", { file_path: secret })).toMatchObject({ block: true });
+		expect(await call(handler, "read", { file_path: container })).toMatchObject({ block: true });
 	});
 
 	/**
@@ -124,17 +124,27 @@ describe("sandbox-guard bundled extension", () => {
 			expect(await call(handler, "write", { file_path: "/tmp/xcsh-guard-probe.txt" })).toBeUndefined();
 		});
 
-		// And the coverage that must not move: a neighbouring tenant, through every interface.
-		it("refuses the neighbouring tenant through bash, python and the file tools", async () => {
+		it("preserves named sibling reads and writes through every interface", async () => {
 			await initSandbox(true);
 			const handler = captureHandler()!;
 			const secret = path.join(OTHER, "secret");
+			expect(await call(handler, "bash", { command: `cat ${secret}` })).toBeUndefined();
+			expect(await call(handler, "python", { code: `open("${secret}").read()` })).toBeUndefined();
+			expect(await call(handler, "read", { file_path: secret })).toBeUndefined();
+			expect(await call(handler, "write", { file_path: path.join(OTHER, "planted") })).toBeUndefined();
+		});
+
+		// Cross-session state remains a real deny, independent of the discovery-only sibling courtesy.
+		it("refuses another session's state through bash, python and the file tools", async () => {
+			await initSandbox(true);
+			const handler = captureHandler()!;
+			const secret = path.join(getSessionsDir(), "other-session.jsonl");
 			expect(await call(handler, "bash", { command: `cat ${secret}` })).toMatchObject({ block: true });
 			expect(await call(handler, "python", { code: `open("${secret}").read()` })).toMatchObject({ block: true });
 			expect(await call(handler, "read", { file_path: secret })).toMatchObject({ block: true });
-			expect(await call(handler, "write", { file_path: path.join(OTHER, "planted") })).toMatchObject({
-				block: true,
-			});
+			expect(
+				await call(handler, "write", { file_path: path.join(getSessionsDir(), "planted.jsonl") }),
+			).toMatchObject({ block: true });
 		});
 	});
 });

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -41,8 +41,9 @@ function reads(cwd: string, filePath: string): boolean {
 }
 
 describe("two-customer isolation", () => {
-	it("a session in custA cannot read custB, but can read its own files", () => {
-		expect(reads(custA, path.join(custB, "secret.env"))).toBe(true);
+	it("a session in custA cannot enumerate the parent but can use a named custB path", () => {
+		expect(reads(custA, parent)).toBe(true);
+		expect(reads(custA, path.join(custB, "secret.env"))).toBe(false);
 		expect(reads(custA, path.join(custA, "notes.md"))).toBe(false);
 	});
 
@@ -51,19 +52,22 @@ describe("two-customer isolation", () => {
 		expect(reads(parent, path.join(custB, "secret.env"))).toBe(false);
 	});
 
-	// The pre-check and the kernel now consult one fence (#2624), so this asserts they agree rather than
-	// that one is stricter. The `shellOsConfined` flag it used to pass is gone with the second policy —
-	// there is no longer a version of this question whose answer depends on which backend is running.
-	it("blocks Bash reads of custB from custA", () => {
+	it("keeps Bash named access under the operator's authority", () => {
 		const fence = resolveSessionFence(custA, { get: () => undefined })!;
 		const scan = (command: string) => evaluateToolCall({ toolName: "bash", input: { command }, cwd: custA, fence });
 
 		for (const command of ["cat ../custB/secret.env", `cat ${path.join(custB, "secret.env")}`]) {
-			expect(scan(command).block).toBe(true);
+			expect(scan(command).block).toBe(false);
 		}
-		// …and the same fence permits the session's own tree, or the assertion above would hold for a
-		// fence that refused everything.
 		expect(scan("cat notes.md").block).toBe(false);
+	});
+
+	it("blocks structured recursive discovery from the shared parent", () => {
+		const fence = resolveSessionFence(custA, { get: () => undefined })!;
+		for (const toolName of ["find", "grep", "ast_grep", "ast_edit"]) {
+			const input = toolName === "find" ? { pattern: `${parent}/**/*` } : { path: parent };
+			expect(evaluateToolCall({ toolName, input, cwd: custA, fence }).block).toBe(true);
+		}
 	});
 });
 
@@ -123,6 +127,7 @@ describe("two-customer isolation, enforced in the shell", () => {
 			allowReadOnly: [...fence.allowReadOnly],
 			allowWriteOnly: [...fence.allowWriteOnly],
 			deny: [...fence.deny],
+			denyEnumerate: [...fence.denyEnumerate],
 		};
 	}
 
@@ -135,41 +140,31 @@ describe("two-customer isolation, enforced in the shell", () => {
 	}
 
 	/**
-	 * Routes the shell itself closes, so they hold on every platform.
-	 *
-	 * `cd` is refused in-process, which takes the whole command down with it, and a redirect target is
-	 * opened by the shell rather than by the child. Neither needs an OS backend, which is why they are
-	 * asserted unconditionally.
+	 * Brush expands globs in the agent process, before an OS sandbox can help. The enumeration check must
+	 * therefore happen before `read_dir`, on every platform.
 	 */
-	it("a session in custA cannot reach custB through anything the shell does itself", async () => {
-		for (const command of [
-			"cd ../custB && cat secret.env",
-			"c=cd; $c ../custB && cat secret.env",
-			`printf x > ${path.join(custB, "planted.env")}`,
-		]) {
-			const { text } = await shell(custA, command);
-			expect(text).not.toContain("TOKEN=b");
-		}
-		expect(fs.existsSync(path.join(custB, "planted.env"))).toBe(false);
+	it("a parent glob does not reveal sibling names", async () => {
+		const { text } = await shell(custA, "printf '%s\\n' ../*");
+		expect(text).not.toContain("custB");
 	});
 
-	/**
-	 * Routes where the *child* does the opening, so only the kernel can refuse them.
-	 *
-	 * Asserted according to the product's own `containmentStatus` rather than skipped off macOS: these
-	 * reads really do succeed where no backend exists (#2572), and a skipped test would read as though
-	 * they did not. This inverts and starts failing when Landlock lands, which is the point.
-	 */
-	it(`a session in custA ${OS_ENFORCED ? "cannot" : "can still"} reach custB through a spawned command`, async () => {
-		// Both branches assert something. Gating the assertion away instead would leave a test that
-		// passes while checking nothing, which reports as coverage of exactly the gap that is open.
+	it("named sibling reads, traversal, and writes remain available", async () => {
 		for (const command of ["cat ../custB/secret.env", `cat ${path.join(custB, "secret.env")}`]) {
 			const { text } = await shell(custA, command);
-			if (OS_ENFORCED) expect(text).not.toContain("TOKEN=b");
-			else expect(text).toContain("TOKEN=b");
+			expect(text).toContain("TOKEN=b");
 		}
+		const moved = await shell(custA, "cd ../custB && cat secret.env");
+		expect(moved.text).toContain("TOKEN=b");
+		await shell(custA, `printf x > ${path.join(custB, "planted.env")}`);
+		expect(fs.readFileSync(path.join(custB, "planted.env"), "utf8")).toBe("x");
 		await shell(custA, `cp ${path.join(custB, "secret.env")} .`);
-		expect(fs.existsSync(path.join(custA, "secret.env"))).toBe(!OS_ENFORCED);
+		expect(fs.existsSync(path.join(custA, "secret.env"))).toBe(true);
+	});
+
+	it(`a spawned parent listing ${OS_ENFORCED ? "is" : "is not"} OS-confined`, async () => {
+		const { text } = await shell(custA, "ls ..");
+		if (OS_ENFORCED) expect(text).not.toContain("custB");
+		else expect(text).toContain("custB");
 	});
 
 	it("but works normally inside its own folder", async () => {

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { executeShell } from "@f5-sales-demo/pi-natives";
-import { getAgentDir, getPluginsDir, TempDir } from "@f5-sales-demo/pi-utils";
+import { getAgentDir, getConfigRootDir, getPluginsDir, TempDir } from "@f5-sales-demo/pi-utils";
 import { discoverAndLoadExtensions } from "../src/extensibility/extensions/loader";
 import { getMemoryRoot } from "../src/memories";
 import { buildContainmentFence, containmentStatus } from "../src/sandbox/containment";
@@ -40,6 +40,12 @@ function reads(cwd: string, filePath: string): boolean {
 	return evaluateToolCall({ toolName: "read", input: { file_path: filePath }, cwd, fence }).block;
 }
 
+/** Whether the `write` tool would be refused. */
+function writes(cwd: string, filePath: string): boolean {
+	const fence = resolveSessionFence(cwd, { get: () => undefined })!;
+	return evaluateToolCall({ toolName: "write", input: { file_path: filePath }, cwd, fence }).block;
+}
+
 describe("two-customer isolation", () => {
 	it("a session in custA cannot enumerate the parent but can use a named custB path", () => {
 		expect(reads(custA, parent)).toBe(true);
@@ -72,18 +78,30 @@ describe("two-customer isolation", () => {
 });
 
 describe("functionality preservation under the sandbox", () => {
-	it("keeps the plugin cache readable (e.g. the meddpicc engine)", () => {
-		expect(reads(custA, path.join(getPluginsDir(), "cache", "plugins", "meddpicc", "engine", "cli.ts"))).toBe(false);
+	it("keeps operator-owned plugins writable (e.g. the meddpicc engine)", () => {
+		const plugin = path.join(getPluginsDir(), "cache", "plugins", "meddpicc", "engine", "cli.ts");
+		expect(reads(custA, plugin)).toBe(false);
+		expect(writes(custA, plugin)).toBe(false);
 	});
 
-	it("keeps user-level skills readable", () => {
-		expect(reads(custA, path.join(getAgentDir(), "skills", "account-planning", "SKILL.md"))).toBe(false);
+	it("keeps user-level skills and settings writable", () => {
+		for (const own of [
+			path.join(getAgentDir(), "skills", "account-planning", "SKILL.md"),
+			path.join(getConfigRootDir(), "settings.json"),
+		]) {
+			expect(reads(custA, own)).toBe(false);
+			expect(writes(custA, own)).toBe(false);
+		}
 	});
 
 	// #2637: the operator's own dotfiles are theirs. What stays blocked is another customer's folder and
 	// another session's state, asserted above and below.
-	it("no longer blocks the operator's own home dotfiles", () => {
-		expect(reads(custA, path.join(os.homedir(), ".ssh", "id_rsa"))).toBe(false);
+	it("keeps the operator's own home and configuration writable", () => {
+		for (const own of [".gitconfig", ".aws/config", ".zshrc", ".zprofile", ".ssh/config"]) {
+			const target = path.join(os.homedir(), own);
+			expect(reads(custA, target)).toBe(false);
+			expect(writes(custA, target)).toBe(false);
+		}
 	});
 });
 
@@ -159,6 +177,22 @@ describe("two-customer isolation, enforced in the shell", () => {
 		expect(fs.readFileSync(path.join(custB, "planted.env"), "utf8")).toBe("x");
 		await shell(custA, `cp ${path.join(custB, "secret.env")} .`);
 		expect(fs.existsSync(path.join(custA, "secret.env"))).toBe(true);
+	});
+
+	it("allows operator-owned configuration writes through the OS fence", async () => {
+		const targets = [
+			path.join(home, ".gitconfig"),
+			path.join(home, ".aws", "config"),
+			path.join(home, ".zshrc"),
+			path.join(home, ".ssh", "config"),
+			path.join(home, ".xcsh", "plugins", "example", "plugin.json"),
+		];
+		for (const target of targets) {
+			fs.mkdirSync(path.dirname(target), { recursive: true });
+			const result = await shell(custA, `printf operator > ${JSON.stringify(target)}`);
+			expect(result.code).toBe(0);
+			expect(fs.readFileSync(target, "utf8")).toBe("operator");
+		}
 	});
 
 	it(`a spawned parent listing ${OS_ENFORCED ? "is" : "is not"} OS-confined`, async () => {

--- a/packages/coding-agent/test/sandbox-session-fence.test.ts
+++ b/packages/coding-agent/test/sandbox-session-fence.test.ts
@@ -52,19 +52,21 @@ describe("resolveSessionFence", () => {
 		expect(resolveSessionFence(mine, reader({ "sandbox.enabled": false }))).toBeUndefined();
 	});
 
-	it("fails closed when the setting cannot be read", () => {
+	it("keeps parent discovery closed when the setting cannot be read", () => {
 		const { mine, theirs } = tenants("throw");
 		const fence = resolveSessionFence(mine, throwingReader);
 		expect(fence).toBeDefined();
-		expect(fenceVerdict(fence!, path.join(theirs, "x"), "read")).toBe("deny");
+		expect(fenceVerdict(fence!, path.dirname(mine), "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence!, path.join(theirs, "x"), "read")).toBe("allow");
 	});
 
-	it("denies the neighbouring tenant while the workspace works", () => {
+	it("denies neighbour discovery while named paths and the workspace work", () => {
 		const { mine, theirs } = tenants("basic");
 		const fence = resolveSessionFence(mine, reader({}))!;
 		expect(fenceVerdict(fence, path.join(mine, "notes.md"), "read")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(mine, "out.ts"), "write")).toBe("allow");
-		expect(fenceVerdict(fence, path.join(theirs, "notes.md"), "read")).toBe("deny");
+		expect(fenceVerdict(fence, path.dirname(mine), "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(theirs, "notes.md"), "read")).toBe("allow");
 	});
 
 	// Allow-by-default is the posture now, so a path under no rule at all is reachable. That is the
@@ -89,12 +91,12 @@ describe("resolveSessionFence", () => {
 	// isolated Settings instance. A cwd-keyed cache would hand one session the other's boundary.
 	it("distinguishes same-cwd sessions whose settings differ", () => {
 		const { mine, shared } = tenants("samecwd");
-		const permissive = resolveSessionFence(mine, reader({ "sandbox.allowRead": [shared] }))!;
-		const strict = resolveSessionFence(mine, reader({}))!;
+		const readOnly = resolveSessionFence(mine, reader({ "sandbox.allowRead": [shared] }))!;
+		const ordinary = resolveSessionFence(mine, reader({}))!;
 
-		expect(fenceVerdict(permissive, path.join(shared, "file.md"), "read")).toBe("allow");
-		expect(fenceVerdict(strict, path.join(shared, "file.md"), "read")).toBe("deny");
-		expect(permissive).not.toBe(strict);
+		expect(fenceVerdict(readOnly, path.join(shared, "file.md"), "write")).toBe("deny");
+		expect(fenceVerdict(ordinary, path.join(shared, "file.md"), "write")).toBe("allow");
+		expect(readOnly).not.toBe(ordinary);
 	});
 
 	it("reuses the fence for an identical configuration", () => {
@@ -105,17 +107,19 @@ describe("resolveSessionFence", () => {
 	});
 
 	it("rebuilds when an allow-list is widened mid-session", () => {
-		const { mine, shared } = tenants("widen");
+		const { mine } = tenants("widen");
+		const parent = path.dirname(mine);
 		const before = resolveSessionFence(mine, reader({}))!;
-		const after = resolveSessionFence(mine, reader({ "sandbox.allowRead": [shared] }))!;
-		expect(fenceVerdict(before, path.join(shared, "x"), "read")).toBe("deny");
-		expect(fenceVerdict(after, path.join(shared, "x"), "read")).toBe("allow");
+		const after = resolveSessionFence(mine, reader({ "sandbox.allowRead": [parent] }))!;
+		expect(fenceVerdict(before, parent, "enumerate")).toBe("deny");
+		expect(fenceVerdict(after, parent, "enumerate")).toBe("allow");
 	});
 
 	// The bash tool passes its artifacts dir here rather than building a second fence of its own, which
 	// is what let the two disagree before. A different extras value must not be served from cache.
 	it("keys the cache on extra roots too", () => {
-		const { mine, shared: artifacts } = tenants("extras");
+		const { mine } = tenants("extras");
+		const artifacts = path.join(path.parse(mine).root, "srv", "xcsh-artifacts-test");
 		const without = resolveSessionFence(mine, reader({}))!;
 		const with_ = resolveSessionFence(mine, reader({}), { extraRoots: [artifacts] })!;
 		expect(without).not.toBe(with_);

--- a/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
+++ b/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
@@ -146,9 +146,8 @@ describe("system prompt workspace boundary", () => {
  *
  * This block has twice asserted a mechanism fact that reality contradicted: an
  * unconditional "isolation is enforced" (false under `--no-sandbox`, caught in review),
- * and "nothing refuses a sibling" (true when written, falsified a day later when #2624 /
- * #2637 unified the fence and started denying the workspace's parent). Prose cannot be
- * trusted to stay true about code it does not import.
+ * and "nothing refuses a sibling" (too broad once the workspace parent stopped being
+ * enumerable). Prose cannot be trusted to stay true about code it does not import.
  *
  * So the claim is measured rather than reviewed. If the deny logic changes again, this
  * fails and names the sentence that went stale, instead of shipping a confident
@@ -187,13 +186,13 @@ describe("workspace boundary claims match the real fence", () => {
 		expect(refuses(parent, path.join(tenantB, "secret.env"))).toBe(false);
 	});
 
-	// And the converse the block must NOT claim. From inside one customer the fence
-	// denies the parent, so a sibling read IS refused — the generalisation this block
-	// used to make ("nothing refuses a sibling") is false and must not come back.
-	it("does not let the block generalise to siblings the fence refuses", () => {
-		const siblingRefused = refuses(tenantA, path.join(tenantB, "secret.env"));
-		expect(siblingRefused).toBe(true);
-		expect(flat()).not.toMatch(/nothing refuses a sibling/i);
-		expect(flat()).not.toMatch(/boundary is the working directory, not the customer subdirectory/i);
+	// From inside one tenant the courtesy boundary removes discovery, not operator authority. The
+	// parent cannot be listed, but a sibling file named by the task remains reachable. The prompt must
+	// therefore keep tenant separation in judgment instead of claiming the filesystem makes it happen.
+	it("matches the discovery-only boundary around sibling workspaces", () => {
+		expect(refuses(tenantA, parent)).toBe(true);
+		expect(refuses(tenantA, path.join(tenantB, "secret.env"))).toBe(false);
+		expect(flat()).toMatch(/keeping tenants apart is your judgment/i);
+		expect(flat()).not.toMatch(/filesystem (?:refuses|prevents|blocks) (?:a )?sibling/i);
 	});
 });

--- a/packages/coding-agent/test/tools/bash-skill-urls.test.ts
+++ b/packages/coding-agent/test/tools/bash-skill-urls.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -290,12 +290,15 @@ describe("expandInternalUrls — resolution failures", () => {
 // paths the read tool refuses. Tested against the REAL default policy: a permissive stub would hide
 // the production failure this check exists to prevent.
 describe("expandInternalUrls — session read boundary", () => {
-	// Nested in a container, not placed directly in the temp root: the fence must never deny the temp
-	// root, so a workspace put straight into it has no denied parent and the "outside the boundary" case
-	// below would be reachable for reasons unrelated to this check.
+	// Nested in a container so the real policy has a concrete parent on which to apply its enumeration
+	// courtesy. The refused path cases below use the policy's explicit cross-session roots.
 	const container = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-boundary-")));
 	const cwd = path.join(container, "session");
 	fs.mkdirSync(cwd, { recursive: true });
+	const cleanup = [container];
+	afterAll(() => {
+		for (const target of cleanup) fs.rmSync(target, { recursive: true, force: true });
+	});
 	// The production adapter, so this exercises what bash actually hands the expander (#2624).
 	const policy = readBoundaryFor(resolveSessionFence(cwd, { get: () => undefined }), cwd);
 
@@ -307,8 +310,8 @@ describe("expandInternalUrls — session read boundary", () => {
 		).resolves.toBe(`cat ${shellEscape(inside)}`);
 	});
 
-	it("refuses a path outside the boundary, naming the scheme and the boundary", async () => {
-		const outside = path.join(container, "xcsh-elsewhere", "secret.md");
+	it("refuses a cross-session path, naming the scheme and the boundary", async () => {
+		const outside = path.join(getMemoriesDir(), "other-session", "secret.md");
 		const router = createInternalRouter({ "artifact://2": { sourcePath: outside } });
 		const attempt = expandInternalUrls("cat artifact://2", {
 			skills: [],
@@ -319,12 +322,11 @@ describe("expandInternalUrls — session read boundary", () => {
 		await expect(attempt).rejects.toThrow("outside this session's read boundary");
 	});
 
-	// The default policy deny-lists the whole sessions directory, and a session's own artifact root
+	// The default policy deny-lists cross-session stores, and a session's own artifact root
 	// lives under it — so artifact:// and local:// would break without this carve-out.
 	it("allows a path under a session-owned root even when the policy denies its parent", async () => {
-		const ownedRoot = path.join(cwd, "..", "xcsh-owned-root");
-		fs.mkdirSync(ownedRoot, { recursive: true });
-		const owned = path.join(fs.realpathSync(ownedRoot), "12.bash.log");
+		const ownedRoot = path.join(getMemoriesDir(), `owned-${path.basename(container)}`);
+		const owned = path.join(ownedRoot, "12.bash.log");
 		const router = createInternalRouter({ "artifact://12": { sourcePath: owned } });
 
 		// Without the carve-out this is outside the boundary.
@@ -337,7 +339,7 @@ describe("expandInternalUrls — session read boundary", () => {
 				skills: [],
 				internalRouter: router,
 				readBoundary: policy,
-				sessionOwnedRoots: () => [fs.realpathSync(ownedRoot)],
+				sessionOwnedRoots: () => [ownedRoot],
 			}),
 		).resolves.toBe(`cat ${shellEscape(owned)}`);
 	});
@@ -345,10 +347,13 @@ describe("expandInternalUrls — session read boundary", () => {
 	// Containment is canonicalized, so a symlink planted under an owned root cannot smuggle a path
 	// back out of the boundary.
 	it("refuses a symlink under an owned root that points outside it", async () => {
-		// Both inside `container`, whose sibling-of-the-workspace status is what the fence denies. Placed
-		// in the temp root instead they would match no rule at all and be allowed by default.
-		const ownedRoot = fs.realpathSync(fs.mkdtempSync(path.join(container, "xcsh-owned-")));
-		const target = fs.realpathSync(fs.mkdtempSync(path.join(container, "xcsh-target-")));
+		// Both sit under the shared cross-session temp root, which the default fence denies. The owned
+		// subtree is carved back out, but a symlink cannot carry that authority into its sibling.
+		const sharedRoot = path.join(fs.realpathSync(os.tmpdir()), "xcsh-local");
+		fs.mkdirSync(sharedRoot, { recursive: true });
+		const ownedRoot = fs.realpathSync(fs.mkdtempSync(path.join(sharedRoot, "xcsh-owned-")));
+		const target = fs.realpathSync(fs.mkdtempSync(path.join(sharedRoot, "xcsh-target-")));
+		cleanup.push(ownedRoot, target);
 		const link = path.join(ownedRoot, "escape");
 		fs.symlinkSync(target, link);
 
@@ -374,8 +379,7 @@ describe("expandInternalUrls — session read boundary", () => {
 	});
 
 	it("does not create parent directories for a refused local:// URL", async () => {
-		const outsideArtifacts = path.join(container, "xcsh-refused-local");
-		fs.rmSync(outsideArtifacts, { recursive: true, force: true });
+		const outsideArtifacts = path.join(getMemoriesDir(), `refused-${path.basename(container)}`);
 		const localOptions = {
 			getArtifactsDir: () => outsideArtifacts,
 			getSessionId: () => "session-1",
@@ -391,6 +395,6 @@ describe("expandInternalUrls — session read boundary", () => {
 		).rejects.toThrow("outside this session's read boundary");
 
 		// The directory must not have been created before the refusal.
-		expect(fs.existsSync(path.join(outsideArtifacts, "handoffs"))).toBe(false);
+		expect(fs.existsSync(path.join(outsideArtifacts, "local", "handoffs"))).toBe(false);
 	});
 });

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -487,6 +487,8 @@ export interface ContainmentFenceOptions {
   allowWriteOnly: Array<string>
   /** Roots denied in both directions, winning over any allow they sit inside. */
   deny: Array<string>
+  /** Exact directories whose entries may not be enumerated. */
+  denyEnumerate: Array<string>
 }
 
 /** A context line (before or after a match). */
@@ -641,7 +643,7 @@ export interface ExtractSegmentsResult {
  * both this implementation and the TypeScript one, which is the only guard
  * against the two drifting.
  */
-export declare function fencePermits(fence: ContainmentFenceOptions, candidate: string, write: boolean): boolean
+export declare function fencePermits(fence: ContainmentFenceOptions, candidate: string, write: boolean, enumerate?: boolean | undefined | null): boolean
 
 /** Resolved filesystem entry kind for glob filters and match metadata. */
 export declare enum FileType {


### PR DESCRIPTION
## Summary
- add an exact directory-enumeration access direction across the TypeScript, native, Seatbelt, and Landlock fences
- refuse listing the session root parent while preserving traversal and named operator reads and writes
- make explicit read grants restore listing and gate Brush globs plus structured recursive tools before enumeration

## Verification
- `bun check:ts`
- `bun check:rs`
- focused sandbox unit, native conformance, shell, PTY, and race tests
- `cargo test -p containment-check --test complement`
- staged PII gate: zero findings

Fixes #2725