### PR TITLE
fix: use governed namespace placeholder in UAT corpus

### DIFF
--- a/research/benchmarks/uat-matrix/corpora/console.yaml
+++ b/research/benchmarks/uat-matrix/corpora/console.yaml
@@ -15,7 +15,7 @@
 #   verify:
 #     api_path        : underscore/plural API path for the GET check
 #     resource_name   : object name to GET
-#     namespace       : API scope (demo)
+#     namespace       : demo-app
 #     expect_http_create / expect_http_delete : 200 / 404
 #     ui_readback     : text the workflow asserts in the list (UI confirmation)
 #   nested            : ordered child resources (created BEFORE the parent); each


### PR DESCRIPTION
Closes #2749. Follow-up to #2744. Replaces the UAT corpus namespace comment with the exact governed synthetic placeholder so the tracked-content PII ratchet passes without raising its baseline.