### PR TITLE
fix(sandbox): align operator home rights

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Made operator-owned home files, CLI configuration, shell profiles, SSH state, plugins, skills, and settings consistently writable while preserving cross-session and data-root isolation ([#2720](https://github.com/f5-sales-demo/xcsh/issues/2720))
 - Prevented sandbox sessions from enumerating the session root's parent while preserving named operator access and explicit read-grant overrides ([#2725](https://github.com/f5-sales-demo/xcsh/issues/2725))
 
 ## [19.105.7] - 2026-07-31

--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -7,51 +7,40 @@ Filesystem isolation is **on**. Enforcement for the `bash` tool: **{{containment
 Your shell is confined by the operating system, not by inspecting the command you wrote. A path is
 checked where it is actually opened, after the shell has expanded variables, resolved aliases and
 followed symlinks — so how a path is spelled does not change what is reachable.
-- Ordinary work is unrestricted: system paths, `/tmp`, package caches (`~/.bun`, `~/.cargo`,
-  `~/go/pkg/mod`, …), the network, and running programs are all untouched.
-- The CLIs you drive keep their own configuration, so `gh`, `glab`, `az`, `aws`, `gcloud`, `sf`,
-  `docker`, `kubectl` and `terraform` all work normally, including the token refreshes and logs they
-  write as they go.
-{{#unless containment.commandConfigWritable}}
-  What you cannot do is *rewrite* the settings that name a command to run — `~/.aws/config`,
-  `~/.kube/config`, `~/.docker/config.json`, a plugin directory. Those stay readable and are refused for
-  writing, because a later unfenced run of that CLI would execute what you wrote.
-{{else}}
-  This backend cannot hold a file read-only inside a writable directory, so those settings are
-  writable here. Do not edit the ones that name a command to run — `~/.aws/config`, `~/.kube/config`,
-  `~/.docker/config.json`, `~/.azure/config`, a plugin directory — unless the operator asked you to: a
-  later unfenced run of that CLI would execute what you wrote.
-{{/unless}}
-- What is refused is a short list of *places*, not kinds of operation: another customer's folder, the
-  rest of the home directory (`~/.ssh`, `~/.gnupg`, `~/Documents`), other operators' accounts, other
-  mounted volumes, and other sessions' transcripts. `~/.gitconfig` is readable, not writable.
-- `cd` follows the same boundary as everything else: moving somewhere reachable is fine, and `cd` into
-  a denied directory is refused. Where you stand does not widen anything — the boundary is fixed for
-  the session, so it never follows the shell.
+- Ordinary work is unrestricted: system paths, `/tmp`, package caches, the network, and running
+  programs are all untouched.
+- The operator's home and configuration belong to the operator. Shell profiles, SSH and GPG state,
+  Git and cloud CLI configuration, xcsh settings, plugins, and skills are readable and writable with
+  the operator's normal filesystem rights.
+- Cross-tenant isolation removes the discovery step. The directory containing the session root cannot
+  be enumerated, but a sibling path the operator names directly can still be read, written, or entered.
+  An explicit read grant, including `--allow-path <dir>`, restores enumeration for that directory.
+- Cross-session stores and data roots remain denied. Another session's transcripts, memories, internal
+  contexts, and temporary working state are not reachable through tools, nor are unrelated data roots
+  and mounted data volumes.
 
-The same boundary answers for every tool. `read`, `write`, `grep`, `find` and `python` are checked
-against exactly the rules above, so a path is reachable or not regardless of which tool you use to ask.
-If one refuses something, another will not succeed at it, and it is not worth trying.
+The same boundary answers for every tool. `read`, `write`, `grep`, `find`, `python`, and `bash` consult
+the same rules, so changing tools or spelling a path differently does not widen the session.
 
-If a command is refused, do not try to reach the same path a different way. Say what you needed and why.
-The operator can widen it with `--allow-path <dir>`, which grants read and write.
+If parent enumeration is refused, use a known path or ask the operator for an explicit read grant. If
+a cross-session or data-root path is refused, do not try to reach it another way. Say what you needed
+and why.
 
-That is an instruction, not a claim that rewriting is impossible: the boundary is a set of paths, so a
-path it does not name is reachable whether or not reaching for it is sensible. The rule of thumb is that
-if a file belongs to someone other than the operator you are working with, it is not yours to read.
+This sandbox is a courtesy for session-context isolation, not a privilege boundary against xcsh or the
+operator. The rule of thumb is that if a file belongs to someone other than the operator you are
+working with, it is not yours to read.
 
 {{#if containment.landlock}}
 Three things behave differently under this backend, and none of them is a bug to work around:
-- `ls /` and `ls` of the directory holding the session tree fail. A kernel rule covers a whole subtree,
-  so a directory with both reachable and unreachable children cannot be listed at all. Listing a
-  specific directory you can reach works normally.
+- `ls /` can fail because a kernel rule cannot expose a directory that mixes reachable and denied data
+  roots. Listing a specific reachable directory works normally.
 - `sudo` and other setuid programs do not work, because confining a process requires giving up the
   ability to gain privileges.
 - Interactive terminal programs (`top`, `less`, an interactive `ssh`) run without a real terminal here,
   so prefer their non-interactive forms — `ps`, `cat`, `ssh -T`, or a piped command.
 {{#if containment.truncationUngoverned}}
-- This kernel is too old to govern truncation, so a file outside the boundary can still be emptied even
-  though it cannot be read or written. Never truncate a path outside the session directory.
+- This kernel is too old to govern truncation, so a denied file can still be emptied even though it
+  cannot be read or written. Never truncate a path outside the session directory.
 {{/if}}
 {{/if}}
 {{else}}
@@ -60,12 +49,12 @@ scanning the command text before it runs. That check is best-effort by construct
 wrote rather than what the shell will do, so a path assembled at runtime or reached through an unusual
 spelling may not be caught.
 
-The rules are the same ones a confined session has — another customer's folder, the rest of home, other
-operators' accounts, other volumes, other sessions' transcripts — and ordinary work is equally
-unrestricted here. What differs is only how reliably the boundary is applied to a spawned program.
+The intended rules are the same ones a confined session has: parent enumeration is refused while named
+operator access remains available, operator-owned home and configuration stay readable and writable,
+and cross-session stores and unrelated data roots stay denied. Ordinary work remains unrestricted.
 
-Treat it as a statement of intent rather than a guarantee, and do not go looking for paths outside the
-session directory on the assumption that something would stop you.
+Treat the boundary as a statement of intent rather than a guarantee, and do not go looking for paths
+outside the session directory on the assumption that something would stop you.
 {{/if}}
 {{else}}
 Filesystem isolation is **off** for this session — started with `--no-sandbox`, or

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -21,10 +21,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as natives from "@f5-sales-demo/pi-natives";
 import {
-	getAgentDir,
-	getConfigRootDir,
 	getMemoriesDir,
-	getPluginsDir,
 	getSessionsDir,
 	getXCSHContextsDir,
 	normalizePathForComparison,
@@ -72,14 +69,6 @@ export interface ContainmentOptions {
 	 * letters. Overridable for tests, which cannot mount a second volume.
 	 */
 	otherRoots?: readonly string[];
-	/**
-	 * Whether the active backend can express "writable directory, except this file" — see
-	 * COMMAND_BEARING_CONFIG. True for seatbelt, false for Landlock, which cannot.
-	 *
-	 * Defaults to false, so a caller that does not know its backend gets the portable policy rather
-	 * than one that silently breaks the CLIs on Linux.
-	 */
-	narrowsWithinGrant?: boolean;
 	/**
 	 * The filesystem root whose immediate entries are classified as operational or data — see
 	 * DATA_ROOTS. Overridable for tests; defaults to the real root.
@@ -141,9 +130,8 @@ const CACHE_DIRS = [
  * because the fence exists to stop the assistant wandering between customer workspaces rather than to
  * withhold the operator's credential store from the operator's own CLIs — and the native `az`/`aws` tools
  * already act with those credentials, so denying only the shell path broke the CLIs without protecting
- * anything. `~/.ssh` and `~/.gnupg` are still denied: no shipped tool needs them.
- *
- * Reading a credential is not the same as being able to *replace* one, so see COMMAND_BEARING_CONFIG.
+ * anything. The same operator-rights rule applies to all other files in home, including SSH and GPG
+ * state: this fence isolates session context; it does not withhold the operator's own files.
  */
 const TOOL_CONFIG_DIRS = [
 	path.join(".config", "gh"), // gh
@@ -158,63 +146,6 @@ const TOOL_CONFIG_DIRS = [
 	".kube", // kubectl
 	".terraform.d", // terraform
 ];
-
-/**
- * Paths inside TOOL_CONFIG_DIRS that name a command or hold a loadable executable. Read-only, so the
- * grant above never becomes a way to run code later.
- *
- * This is the distinction that matters: reading `~/.aws/credentials` discloses a secret, but *writing*
- * `~/.aws/config` installs a `credential_process` that the operator's next — unfenced — `aws` call
- * executes, with access to every customer workspace and private file the fence exists to protect. That
- * is an escape from the sandbox rather than a leak inside it. `~/.cargo/config.toml` and
- * `~/.gradle/init.gradle` are excluded from the cache carve-out for exactly this reason; these are the
- * same class, and none of them was writable before #2581, so keeping them read-only means that change
- * adds no new write capability on any path that can cause execution.
- *
- * Each entry is a documented mechanism, not a guess: `credential_process` (aws), `user.exec`
- * (kubeconfig), `credsStore`/`credHelpers` and CLI plugins (docker), Python extensions (az), provider
- * binaries (terraform), the virtualenv `activate` that gcloud's launcher sources, and `!`-prefixed shell
- * aliases (gh, glab). The CLIs still read all of them, so nothing stops working; only rewriting does.
- * `gh auth login` and `glab auth login` are interactive and belong outside a fenced session anyway.
- */
-const COMMAND_BEARING_CONFIG = [
-	path.join(".aws", "config"), // credential_process = <command>
-	path.join(".aws", "cli", "alias"), // aws aliases; a leading `!` runs through a shell
-	path.join(".azure", "config"), // extension.index_url + use_dynamic_install fetch and run wheels
-	path.join(".kube", "config"), // users[].user.exec.command
-	path.join(".docker", "config.json"), // credsStore / credHelpers -> docker-credential-*
-	path.join(".docker", "cli-plugins"), // docker-* plugin executables
-	path.join(".azure", "cliextensions"), // az extensions, executed as Python
-	path.join(".terraform.d", "plugins"), // provider binaries
-	path.join(".config", "gcloud", "virtenv"), // sourced by the gcloud launcher
-	path.join(".config", "gh", "config.yml"), // gh alias set x '!sh -c ...', plus editor/browser/pager
-	// glab keeps aliases in their own file, so those can be held read-only. Its config.yml cannot:
-	// glab rewrites it on ordinary commands (atomic rename) to refresh the OAuth token and the
-	// update-check stamp, and holding it read-only reproduced #2581 — `glab auth status` exits 1 with
-	// "rename …/.config.yml".
-	//
-	// Worse than a failed command, and the reason this is not merely a convenience: the OAuth refresh
-	// already happened at GitLab, so a denied write loses the rotated refresh token and the operator's
-	// login is permanently dead — `invalid_grant` afterwards, even outside the fence. Observed while
-	// testing this change, which cost a real `glab auth login`. Any CLI that refreshes a rotating token
-	// must be able to persist it.
-	//
-	// Left writable, and the residual exposure is stated rather than hidden:
-	// that file also carries `editor`, `browser` and `duo_cli_binary_path`/`duo_cli_auto_run`, so a write
-	// there IS a code-execution vector this fence does not close. `gh` needs no such exception because it
-	// was measured working with its config.yml read-only.
-	path.join(".config", "glab-cli", "aliases.yml"),
-	path.join("Library", "Application Support", "glab-cli", "aliases.yml"),
-	// Build configuration that redirects a later build. Protected by *omission* while home was denied —
-	// the cache carve-outs grant `.cargo/registry` rather than `.cargo` — so #2637 had to name them. A
-	// write here is persistence, not theft: the operator's next build runs what it says. Reads are fine.
-	path.join(".cargo", "config.toml"),
-	path.join(".gradle", "init.gradle"),
-	path.join(".gradle", "init.d"),
-];
-
-/** Read-only inside home: configuration a tool needs to behave correctly, but must not rewrite. */
-const READ_ONLY_HOME = [".gitconfig", path.join(".config", "git")];
 
 /**
  * Names of top-level directories that hold tools rather than data.
@@ -258,14 +189,6 @@ const OPERATIONAL_ROOT_NAMES = new Set([
 ]);
 
 /**
- * The operator's settings, read by the agent to configure the current session.
- *
- * Read-only, and named individually rather than by their directory: the config root also holds the
- * cross-session leak dirs, which stay denied at greater depth.
- */
-const AGENT_PROFILE_FILES = [path.join(getConfigRootDir(), "settings.json")];
-
-/**
  * Top-level directories that hold data on some machine even when this one has none of them.
  *
  * Denied by name whether or not the root enumeration sees them, because that enumeration is one
@@ -304,16 +227,9 @@ function canonical(root: string): string | undefined {
 /**
  * Canonicalise as much of `target` as already exists, keeping the absent tail.
  *
- * `canonical` gives up on a path whose leaf is missing, and falling back to the literal string is not
- * safe for a rule whose job is to *narrow* another one. With `~/.aws` symlinked to a vault — chezmoi,
- * stow and yadm all do this — and no config file yet, the grant is emitted resolved (`<vault>`) while
- * the read-only rule keeps the link spelling (`~/.aws/config`). Both backends match a rule against the
- * path the kernel resolved, so the narrower rule covers nothing.
- *
- * That was verified as a real escape before this existed: through the real seatbelt profile,
- * `printf 'credential_process = …' > <vault>/config` succeeded. Note `fenceVerdict` did NOT show it,
- * because `pathIsWithin` normalises symlinks — the in-process check was safe while the emitted profile
- * was not, so a test asserting only the verdict passes while the boundary leaks.
+ * `canonical` gives up on a path whose leaf is missing. Grants and leak roots must still be emitted
+ * before their leaf exists, and they must share the namespace the kernel sees when an existing parent
+ * is a symlink. Resolve the existing prefix and retain only the absent tail.
  */
 function canonicalThroughExisting(target: string): string {
 	const tail: string[] = [];
@@ -414,9 +330,8 @@ function dataRootEntries(fsRoot: string): string[] {
  * refusal it was meant to lift keeps recommending it.
  *
  *  - `~` is expanded. Passed straight to `realpathSync` it names a path that does not exist, so
- *    `sandbox.allowRead: ["~/shared"]` was discarded — and since `~` sits inside the denied home tree,
- *    the grant did not merely fail to widen, it left the path refused. The policy this replaced expanded
- *    it, so this was a regression rather than an old gap.
+ *    `sandbox.allowRead: ["~/shared"]` was discarded and could not restore parent enumeration. The
+ *    policy this replaced expanded it, so this was a regression rather than an old gap.
  *  - An absent target is kept, resolved through the ancestors that do exist, so `--allow-path
  *    <new-output-dir>` can authorize creating it. Harmless while an unnamed path defaulted to allow;
  *    once unknown top-level roots are denied, dropping the grant turns the flag into a refusal.
@@ -572,32 +487,6 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		for (const cache of [...CACHE_DIRS, ...TOOL_CONFIG_DIRS]) {
 			allow.add(canonicalThroughExisting(path.join(home, cache)));
 		}
-		// Deeper than the grant above, so `fenceVerdict` picks these and write becomes a deny while read
-		// stays allowed. Emitted even when absent, or creating the file would be the way around it — and
-		// resolved through existing ancestors, or a symlinked config dir puts the two rules in different
-		// namespaces and the narrower one stops applying.
-		//
-		// COMMAND_BEARING_CONFIG only when the backend can express a narrowing *inside* a grant.
-		// Seatbelt can: it is last-match-wins, so a deeper deny simply overrides. Landlock cannot — its
-		// rules are allow-only and always recursive, so a read-only child turns its parent into a split
-		// dir that loses write on its own inode. Verified with `containment-check plan`: adding
-		// `~/.azure/cliextensions` as read-only made `~/.azure` itself `r-`, which would stop `az` from
-		// creating `azureProfile.json` at all. Applying it anyway would trade a code-execution path for
-		// breaking the very CLIs #2581 is about, so the gap is reported instead — the same choice already
-		// made for `truncationUngoverned`.
-		const narrowed = options.narrowsWithinGrant ? COMMAND_BEARING_CONFIG : [];
-		for (const config of [...READ_ONLY_HOME, ...narrowed]) {
-			allowReadOnly.add(canonicalThroughExisting(path.join(home, config)));
-		}
-	}
-
-	// The agent's own inputs, which sit inside the denied home tree. The file tools allow-listed these
-	// while the fence did not, so `bash` could not read a plugin that `read` could — one of the
-	// asymmetries #2624 removes now that both consult this fence. Read-only: they are inputs, and a
-	// write changes what a later session loads. Emitted through existing ancestors so the skills
-	// directory, which is created on first use, is covered before it exists rather than after.
-	for (const own of [getPluginsDir(), path.join(getAgentDir(), "skills"), ...AGENT_PROFILE_FILES]) {
-		allowReadOnly.add(canonicalThroughExisting(own));
 	}
 
 	// Top-level directories that hold somebody's files. Without these the fence covered only home and
@@ -648,10 +537,8 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 	// and a session whose workspace is the agent dir would otherwise re-expose every other session's
 	// transcript. `fenceVerdict` resolves that by depth, so nesting is safe rather than accidental.
 	//
-	// Emitted even when absent, for the reason COMMAND_BEARING_CONFIG is: a rule that appears only once
-	// the directory does is one nobody can rely on, and creating it would otherwise be the way around
-	// it. Today the home deny covers all three anyway, so this matters only where the agent dir has
-	// been relocated outside home — but "only matters in that case" is how the last few holes were built.
+	// Emitted even when absent: a rule that appears only once the directory does is one nobody can rely
+	// on, and creating it would otherwise be the way around it. This also covers relocated agent state.
 	const leaks = options.leakRoots ?? [
 		getMemoriesDir(),
 		getSessionsDir(),
@@ -722,14 +609,6 @@ export interface ContainmentStatus {
 	 * different claims and an operator is entitled to know which one they have.
 	 */
 	readonly truncationUngoverned?: boolean;
-	/**
-	 * Set when the backend cannot hold a file read-only inside a writable directory, so the
-	 * command-bearing CLI settings (`~/.aws/config`, `~/.kube/config`, …) are writable. Landlock's rules
-	 * are allow-only and recursive; narrowing inside a grant would strip write from the parent directory
-	 * and break the CLIs the grant exists for. Reported rather than folded into `osEnforced`, because it
-	 * changes what a write to those paths means, not whether the boundary holds.
-	 */
-	readonly commandConfigWritable?: boolean;
 }
 
 /**
@@ -771,8 +650,6 @@ export function containmentStatus(
 			osEnforced: true,
 			// Absent on the ABI that governs truncation; present, and stated, on the one that does not.
 			...(probed.truncateHandled === false ? { truncationUngoverned: true } : {}),
-			// Always true here: no Landlock ABI can narrow a right inside a grant.
-			commandConfigWritable: true,
 		};
 	}
 	return { enabled: true, backend: "scanner-only", osEnforced: false };

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -156,11 +156,9 @@ function deny(cwd: string, resolved: string, access: SandboxAccess): ToolCallDec
 }
 
 /**
- * `$HOME` and `${HOME}` are spellings of `~`, which `looksLikePath` already treats as a
- * path (#2534). Three ways to name one file, only one of them checked, is an oversight
- * rather than a policy: `cat ~/.ssh/id_rsa` was blocked while `cat $HOME/.ssh/id_rsa`
- * was not. Rewriting to `~` here means detection AND resolution both see the real path,
- * so the denial names the file rather than a literal dollar sign.
+ * `$HOME` and `${HOME}` are spellings of `~`, which `looksLikePath` already treats as a path (#2534).
+ * Rewriting to `~` means detection and resolution answer consistently whether the resulting home path
+ * is allowed or denied by an explicit rule.
  *
  * `\b` keeps `$HOMEBREW_PREFIX` and friends out of it.
  */

--- a/packages/coding-agent/src/sandbox/session-fence.ts
+++ b/packages/coding-agent/src/sandbox/session-fence.ts
@@ -14,7 +14,7 @@
  * allow-by-default with targeted denies, so the effective boundary was their intersection and the
  * intersection refused ordinary work. One object means the pre-check and the kernel cannot disagree.
  */
-import { buildContainmentFence, type ContainmentFence, containmentStatus } from "./containment";
+import { buildContainmentFence, type ContainmentFence } from "./containment";
 
 /** The slice of `Settings` this needs — supplied explicitly so the caller names its own source. */
 export interface SettingsReader {
@@ -64,16 +64,12 @@ export function resolveSessionFence(
 
 	const allowRead = readSetting<string[]>(settings, "sandbox.allowRead", []);
 	const allowWrite = readSetting<string[]>(settings, "sandbox.allowWrite", []);
-	// Only seatbelt can hold a file read-only inside a writable directory; Landlock's rules are
-	// recursive, so asking for it there would strip write from the parent and break the CLIs (#2581).
-	const narrowsWithinGrant = containmentStatus(true).backend === "seatbelt";
 	const signature = [
 		workspace,
 		JSON.stringify(allowRead),
 		JSON.stringify(allowWrite),
 		extras.sessionTmp ?? "",
 		JSON.stringify(extras.extraRoots ?? []),
-		String(narrowsWithinGrant),
 	].join(" ");
 
 	const cached = cache.get(signature);
@@ -88,7 +84,6 @@ export function resolveSessionFence(
 		extraRoots: extras.extraRoots,
 		readOnlyRoots: allowRead,
 		writeOnlyRoots: allowWrite,
-		narrowsWithinGrant,
 	});
 	if (cache.size >= CACHE_LIMIT) {
 		const oldest = cache.keys().next();

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -564,8 +564,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 	#containmentFence() {
 		const artifactsDir = this.session.getArtifactsDir?.();
 		// One resolver, shared with `sandbox-guard` and the internal-URL check, so the pre-check and the
-		// kernel cannot be looking at different boundaries (#2624). It reads the allow-lists and picks
-		// `narrowsWithinGrant` from the active backend itself.
+		// kernel cannot be looking at different boundaries (#2624).
 		return resolveSessionFence(this.#containmentRoot(), this.session.settings, {
 			extraRoots: artifactsDir ? [artifactsDir] : [],
 		});

--- a/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
+++ b/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
@@ -556,9 +556,13 @@ describe("renderAboutDoc containment section", () => {
 		expect(doc).toContain("## Sandbox containment");
 		expect(doc).toContain("seatbelt");
 		expect(doc).toContain("how a path is spelled does not change what is reachable");
-		// The agent must be told not to retry a refusal a different way — that is wasted turns.
-		expect(doc).toContain("do not try to reach the same path a different way");
-		// And that ordinary work is not restricted, so it does not treat the fence as a reason to stop.
+		// The contract distinguishes operator rights from session-context isolation.
+		expect(doc).toContain("home and configuration belong to the operator");
+		expect(doc).toContain("readable and writable");
+		expect(doc).toContain("directory containing the session root cannot");
+		expect(doc).toContain("sibling path the operator names directly");
+		expect(doc).toContain("Cross-session stores and data roots remain denied");
+		// Ordinary work remains available and an operator can deliberately restore discovery.
 		expect(doc).toContain("--allow-path");
 	});
 

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getAgentDir, getPluginsDir } from "@f5-sales-demo/pi-utils";
+import { getAgentDir, getConfigRootDir, getPluginsDir } from "@f5-sales-demo/pi-utils";
 import { buildContainmentFence, containmentStatus, fenceVerdict } from "@f5-sales-demo/xcsh/sandbox/containment";
 
 /**
@@ -95,25 +95,35 @@ describe("buildContainmentFence", () => {
 		fs.mkdirSync(workspace, { recursive: true });
 		const fence = buildContainmentFence({ workspace, home });
 
-		// These sit inside the denied home tree and must be carved back out, or `bun install`,
-		// `cargo build` and `npm ci` fail — the exact breakage this fence must not cause. Narrowed to
-		// the artifact subdirectories, because granting the parents exposed credentials.
+		// Keep these explicit grants stable for toolchain compatibility. Home is otherwise available under
+		// the operator-rights policy, so the grants must not introduce a narrower write rule.
 		for (const cache of [".bun/install/cache", ".cargo/registry", ".npm/_cacache", ".m2/repository"]) {
 			expect(fenceVerdict(fence, path.join(home, cache, "x"), "write")).toBe("allow");
 		}
 	});
 
-	it("keeps git config readable but not writable", () => {
+	it("keeps operator-owned home and configuration writable", () => {
 		const home = realTmp("home4");
 		const workspace = path.join(home, "w");
 		fs.mkdirSync(workspace, { recursive: true });
 		const fence = buildContainmentFence({ workspace, home });
 
-		expect(fenceVerdict(fence, path.join(home, ".gitconfig"), "read")).toBe("allow");
-		expect(fenceVerdict(fence, path.join(home, ".gitconfig"), "write")).toBe("deny");
+		for (const own of [
+			".gitconfig",
+			".aws/config",
+			".zshrc",
+			".zprofile",
+			".ssh/config",
+			".xcsh/settings.json",
+			".xcsh/plugins/example/plugin.json",
+			".xcsh/skills/example/SKILL.md",
+		]) {
+			expect(fenceVerdict(fence, path.join(home, own), "read")).toBe("allow");
+			expect(fenceVerdict(fence, path.join(home, own), "write")).toBe("allow");
+		}
 	});
 
-	it("denies credentials even though they sit in the same home", () => {
+	it("keeps the operator's private files under their normal filesystem rights", () => {
 		const home = realTmp("home5");
 		const workspace = path.join(home, "w");
 		fs.mkdirSync(workspace, { recursive: true });
@@ -308,18 +318,6 @@ describe("buildContainmentFence — the operator's home is theirs (#2637)", () =
 		// The cross-SESSION surfaces are still closed, because those are the agent's own state rather
 		// than the operator's layout.
 		expect(fenceVerdict(fence, path.join(sessions, "x.jsonl"), "read")).toBe("deny");
-	});
-
-	// A write that installs something a later unfenced run executes is a different concern from context
-	// isolation, so #2637 does not relax it.
-	it("still refuses writes to command-bearing CLI config", () => {
-		const { home, workspace } = customerSession("cmdconfig");
-		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
-
-		for (const vector of [path.join(".aws", "config"), path.join(".cargo", "config.toml")]) {
-			expect(fenceVerdict(fence, path.join(home, vector), "write")).toBe("deny");
-			expect(fenceVerdict(fence, path.join(home, vector), "read")).toBe("allow");
-		}
 	});
 });
 
@@ -598,28 +596,22 @@ describe("buildContainmentFence — review findings", () => {
 		expect(fenceVerdict(system, "/etc/hosts", "read")).toBe("allow");
 	});
 
-	it("keeps toolchain credentials outside the cache carve-outs", () => {
-		// Verified writable before the fix: granting ~/.cargo, ~/.m2, ~/.gradle and ~/.npm whole put
-		// credentials.toml, settings.xml, init.gradle and _authToken inside the fence — credential
-		// theft and persistent build-config tampering, not merely a read.
+	it("keeps operator-owned toolchain configuration writable while preserving cache access", () => {
 		const home = realTmp("credhome");
 		const workspace = path.join(home, "w");
 		fs.mkdirSync(workspace, { recursive: true });
 		const fence = buildContainmentFence({ workspace, home });
 
-		// Since #2637 home is the operator's own, so the credential files here read and write like anything
-		// else of theirs. What must stay refused is a write that redirects a later build — persistence
-		// rather than theft — which needed naming in COMMAND_BEARING_CONFIG once the cache carve-outs
-		// stopped shielding it by omission.
-		const narrowing = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
-		for (const buildVector of [".cargo/config.toml", ".gradle/init.gradle"]) {
-			expect(fenceVerdict(narrowing, path.join(home, buildVector), "write")).toBe("deny");
-			expect(fenceVerdict(narrowing, path.join(home, buildVector), "read")).toBe("allow");
-		}
-		for (const own of [".cargo/credentials.toml", ".m2/settings.xml", ".npm/_authToken"]) {
+		for (const own of [
+			".cargo/config.toml",
+			".cargo/credentials.toml",
+			".gradle/init.gradle",
+			".m2/settings.xml",
+			".npm/_authToken",
+		]) {
 			expect(fenceVerdict(fence, path.join(home, own), "read")).toBe("allow");
+			expect(fenceVerdict(fence, path.join(home, own), "write")).toBe("allow");
 		}
-		// The parts a build actually writes stay granted, or the carve-out was pointless.
 		for (const artifact of [
 			".cargo/registry/index/x",
 			".m2/repository/org/x.jar",
@@ -657,24 +649,9 @@ describe("buildContainmentFence — review findings", () => {
 			expect(fenceVerdict(fence, path.join(home, config), "write")).toBe("allow");
 		}
 
-		// Readable, but see the command-bearing test below: these are deliberately not writable when the
-		// backend can express that.
-		for (const readOnly of [".aws/config", ".kube/config", "Library/Application Support/glab-cli/aliases.yml"]) {
-			expect(fenceVerdict(fence, path.join(home, readOnly), "read")).toBe("allow");
-		}
-	});
-
-	// The grant above must not become a way to run code later. Writing `~/.aws/config` installs a
-	// `credential_process` that the operator's next — unfenced — `aws` call executes, with access to
-	// everything the fence protects. That is an escape, not a leak, so every command-bearing path stays
-	// read-only: the CLI still reads it, nothing stops working, only rewriting is refused.
-	it("never grants write to configuration that names a command or holds an executable", () => {
-		const home = realTmp("execconf");
-		const workspace = path.join(home, "w");
-		fs.mkdirSync(workspace, { recursive: true });
-		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
-
-		for (const bearing of [
+		// These paths can name commands, but that does not turn this courtesy into a privilege boundary
+		// against the operator. Shell profiles and SSH configuration are writable for the same reason.
+		for (const config of [
 			".aws/config", // credential_process = <command>
 			".kube/config", // users[].user.exec.command
 			".docker/config.json", // credsStore / credHelpers
@@ -687,93 +664,9 @@ describe("buildContainmentFence — review findings", () => {
 			"Library/Application Support/glab-cli/aliases.yml",
 			".aws/cli/alias", // an aws alias starting with `!` runs through a shell
 		]) {
-			expect(fenceVerdict(fence, path.join(home, bearing), "write")).toBe("deny");
-			// Read must survive, or the CLI cannot authenticate and #2581 is back.
-			expect(fenceVerdict(fence, path.join(home, bearing), "read")).toBe("allow");
+			expect(fenceVerdict(fence, path.join(home, config), "read")).toBe("allow");
+			expect(fenceVerdict(fence, path.join(home, config), "write")).toBe("allow");
 		}
-
-		// The state each CLI genuinely writes stays writable, or `az` exits 1 and `sf` hangs — measured.
-		for (const state of [".azure/commands/x.log", ".sf/sf-2026-07-28.log", ".aws/sso/cache/x.json"]) {
-			expect(fenceVerdict(fence, path.join(home, state), "write")).toBe("allow");
-		}
-	});
-
-	// A read-only descendant must land in the same namespace as the grant it narrows. `canonical`
-	// returns undefined for a path that does not exist yet, and falling back to the literal string is
-	// unsafe: with ~/.aws symlinked (chezmoi, stow and yadm all do this) the grant resolves to the link
-	// target while the read-only rule keeps the link path, so the kernel matches only the grant and the
-	// `credential_process` protection evaporates. Verified allow/allow before the fix.
-	it("protects command-bearing config even when its directory is a symlink", () => {
-		const home = realTmp("symconf");
-		const workspace = path.join(home, "w");
-		const vault = realTmp("vault");
-		fs.mkdirSync(workspace, { recursive: true });
-		// ~/.aws -> <vault>, and no config file exists inside it yet.
-		fs.symlinkSync(vault, path.join(home, ".aws"));
-		expect(fs.existsSync(path.join(vault, "config"))).toBe(false);
-
-		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
-
-		// Assert the emitted ROOT, not the verdict. `fenceVerdict` normalises symlinks via
-		// `pathIsWithin`, so it answered "deny" even while the profile handed to sandbox-exec carried the
-		// unresolved spelling and the write went through. Verified: with the literal rule,
-		// `printf 'credential_process = …' > <vault>/config` succeeded under the real seatbelt profile.
-		// Only the emitted string tells the truth here, because that is what the backend compiles.
-		expect(fence.allowReadOnly).toContain(path.join(vault, "config"));
-		expect(fence.allowReadOnly).not.toContain(path.join(home, ".aws", "config"));
-		expect(fence.allow).toContain(vault);
-
-		// …while the rest of the tree stays writable, or `aws sso login` breaks.
-		expect(fenceVerdict(fence, path.join(vault, "sso", "cache", "x.json"), "write")).toBe("allow");
-	});
-
-	// AWS CLI reads ~/.aws/cli/alias, where an alias starting with `!` runs through a shell and can
-	// shadow a normal top-level command. Missed on the first pass because ~/.aws was granted wholesale.
-	it("refuses writes to the aws alias file, which executes through a shell", () => {
-		const home = realTmp("aliashome");
-		const workspace = path.join(home, "w");
-		fs.mkdirSync(workspace, { recursive: true });
-		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: true });
-
-		expect(fenceVerdict(fence, path.join(home, ".aws", "cli", "alias"), "write")).toBe("deny");
-		expect(fenceVerdict(fence, path.join(home, ".aws", "cli", "alias"), "read")).toBe("allow");
-		// The cache beside it is what `aws sso login` and assume-role write, so it stays writable.
-		expect(fenceVerdict(fence, path.join(home, ".aws", "cli", "cache", "x.json"), "write")).toBe("allow");
-	});
-
-	// Landlock cannot narrow a right inside a grant: its rules are allow-only and recursive, so holding
-	// a file read-only inside a writable directory turns the parent into a split dir that loses write on
-	// its own inode. Verified with `containment-check plan` — adding ~/.azure/cliextensions as read-only
-	// made ~/.azure itself `r-`, which stops `az` writing azureProfile.json at all. So on that backend the
-	// narrowing is skipped and the gap is reported, rather than breaking the CLIs #2581 is about.
-	it("skips the command-bearing narrowing on a backend that cannot express it", () => {
-		const home = realTmp("nonarrow");
-		const workspace = path.join(home, "w");
-		fs.mkdirSync(workspace, { recursive: true });
-		const fence = buildContainmentFence({ workspace, home, narrowsWithinGrant: false });
-
-		// Writable, because the alternative is a directory the CLI cannot write to at all.
-		for (const bearing of [".aws/config", ".kube/config", ".azure/config"]) {
-			expect(fenceVerdict(fence, path.join(home, bearing), "write")).toBe("allow");
-		}
-		// ~/.gitconfig is NOT part of this: it is read-only via its own root, not a narrowing inside a
-		// grant, so it must survive on every backend.
-		expect(fenceVerdict(fence, path.join(home, ".gitconfig"), "write")).toBe("deny");
-		expect(fenceVerdict(fence, path.join(home, ".gitconfig"), "read")).toBe("allow");
-		// And the boundary still applies where it should: the workspace's container, not the operator's own
-		// dotfiles, which #2637 stopped denying.
-		expect(fenceVerdict(fence, path.join(home, ".ssh", "id_rsa"), "read")).toBe("allow");
-	});
-
-	// Defaulting to the portable policy matters: a caller that does not know its backend must not get
-	// rules that break every CLI on Linux.
-	it("defaults to the portable policy when the caller does not say", () => {
-		const home = realTmp("defaultnarrow");
-		const workspace = path.join(home, "w");
-		fs.mkdirSync(workspace, { recursive: true });
-		const fence = buildContainmentFence({ workspace, home });
-
-		expect(fenceVerdict(fence, path.join(home, ".aws", "config"), "write")).toBe("allow");
 	});
 
 	// Same defect as the CACHE_DIRS carve-out, missed for Go: `go` is in the tool list xcsh probes for,
@@ -858,14 +751,7 @@ describe("containmentStatus", () => {
 			enabled: true,
 			backend: "landlock",
 			osEnforced: true,
-			// No Landlock ABI can narrow a right inside a grant, so the command-bearing CLI settings are
-			// writable there and the model is told so. Seatbelt reports no such field.
-			commandConfigWritable: true,
 		});
-	});
-
-	it("does not claim command-bearing config is writable under seatbelt", () => {
-		expect(containmentStatus(true, "darwin")).not.toHaveProperty("commandConfigWritable");
 	});
 
 	// The case that must not over-claim: a Linux box where Landlock is absent or too old.
@@ -1129,17 +1015,18 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 		expect(fenceVerdict(fence, path.join(fs.realpathSync("/tmp"), "scratch.txt"), "write")).toBe("allow");
 	});
 
-	// The agent's own plugins and user skills sit under `~/.xcsh`, inside the home deny. The file tools
-	// allow-listed them and the fence did not, so `bash` could not read a plugin the `read` tool could —
-	// the asymmetry #2624 removes. Emitted whether or not they exist yet: the skills dir is created on
-	// first use, and a rule that appears only after the directory does is a rule nobody can rely on.
-	it("grants the agent's own plugins and user skills, which sit under denied home", () => {
+	// Agent configuration belongs to the operator just like shell and CLI configuration. Keeping these
+	// read-only would still be a privilege boundary even though they happen to be xcsh inputs.
+	it("keeps the agent's plugins, user skills, and settings writable", () => {
 		const fence = buildContainmentFence({ workspace: fs.realpathSync(process.cwd()) });
 
-		for (const own of [getPluginsDir(), path.join(getAgentDir(), "skills")]) {
-			expect(fenceVerdict(fence, path.join(own, "probe", "manifest.json"), "read")).toBe("allow");
-			// Read-only: these are inputs, and a write there changes what a later session loads.
-			expect(fenceVerdict(fence, path.join(own, "probe", "manifest.json"), "write")).toBe("deny");
+		for (const own of [
+			path.join(getPluginsDir(), "probe", "manifest.json"),
+			path.join(getAgentDir(), "skills", "probe", "SKILL.md"),
+			path.join(getConfigRootDir(), "settings.json"),
+		]) {
+			expect(fenceVerdict(fence, own, "read")).toBe("allow");
+			expect(fenceVerdict(fence, own, "write")).toBe("allow");
 		}
 	});
 

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -13,8 +13,8 @@ const CWD = "/work/custA";
  *
  * `ContainmentFence` is a plain record of canonical roots, so these tests need no filesystem — which is
  * what keeps them a unit test of `evaluateToolCall` rather than of `buildContainmentFence`. The shape
- * mirrors a real session: the workspace read+write, a couple of one-directional grants, and the
- * workspace's container denied so a neighbouring tenant is unreachable.
+ * exercises the workspace, one-directional grants, and a protected data root. Parent enumeration and
+ * named sibling access are covered with a real built fence below.
  *
  * Note what is deliberately absent: any rule about `/etc`, `/usr`, `/tmp` or an unrelated `/elsewhere`.
  * The fence is allow-by-default, so those are reachable, and that is the loosening #2624 is — a
@@ -23,16 +23,9 @@ const CWD = "/work/custA";
 function makeFence(): ContainmentFence {
 	return {
 		allow: [CWD],
-		allowReadOnly: [
-			"/opt/xcsh/plugins", // plugin cache
-			"/shared/ctx", // shared context: readable, deliberately not writable
-			path.join(os.homedir(), ".gitconfig"), // needed by git, must not be rewritten
-		],
+		allowReadOnly: ["/shared/ctx"], // shared context: readable, deliberately not writable
 		allowWriteOnly: ["/drop"], // write-only drop box, deliberately not readable
-		deny: [
-			"/work", // the container: every other tenant under it is unreachable
-			os.homedir(), // ~/.ssh, ~/Documents, another checkout — the real fence denies all of home
-		],
+		deny: ["/work"], // stands in for a data root or cross-session store
 		denyEnumerate: [],
 	};
 }
@@ -72,9 +65,9 @@ describe("evaluateToolCall", () => {
 		expect(check("edit", { file_path: "/work/custB/hosts" }).block).toBe(true);
 	});
 
-	it("treats plugin cache as readable (meddpicc engine) but not writable", () => {
+	it("keeps operator-owned plugin state readable and writable", () => {
 		expect(check("read", { file_path: "/opt/xcsh/plugins/meddpicc/cli.ts" }).block).toBe(false);
-		expect(check("write", { file_path: "/opt/xcsh/plugins/x" }).block).toBe(true);
+		expect(check("write", { file_path: "/opt/xcsh/plugins/x" }).block).toBe(false);
 	});
 
 	it("search tools: absent path defaults to cwd (allowed); explicit out-of-tree blocked", () => {
@@ -131,7 +124,7 @@ describe("evaluateToolCall", () => {
 
 	it("bash: blocks absolute-path escapes, exempts OS system paths", () => {
 		expect(check("bash", { command: "cat /work/custB/secrets.env" }).block).toBe(true);
-		expect(check("bash", { command: "cat ~/.ssh/id_rsa" }).block).toBe(true);
+		expect(check("bash", { command: "cat ~/.ssh/id_rsa" }).block).toBe(false);
 		expect(check("bash", { command: "cat /etc/os-release" }).block).toBe(false);
 		expect(check("bash", { command: "/usr/bin/env node app.js" }).block).toBe(false);
 	});
@@ -271,7 +264,7 @@ describe("evaluateToolCall", () => {
 		// Into something the fence denies: refused, which is the case that matters.
 		expect(check("bash", { command: "cd /work/custB" }).block).toBe(true);
 		expect(check("bash", { command: "cd .." }).block).toBe(true);
-		expect(check("bash", { command: "cd ~" }).block).toBe(true);
+		expect(check("bash", { command: "cd ~" }).block).toBe(false);
 		// `cd /` is allowed now (#2624). Standing at `/` widens nothing: the boundary is fixed for the
 		// session and no longer follows the shell (#2589), so a later relative path is still decided
 		// against the same rules — `cd / && cat Users/other/x` is refused by the fence at the open.
@@ -281,11 +274,10 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "cd" }).block).toBe(false);
 		expect(check("bash", { command: "cd -" }).block).toBe(false);
 		expect(check("bash", { command: "pushd /" }).block).toBe(false);
-		// `$HOME` is still caught, but by the floor rather than the `cd` gate: it rewrites the token to
-		// `~`, which resolves into the denied home tree.
-		expect(check("bash", { command: "cd $HOME" }).block).toBe(true);
-		expect(check("bash", { command: 'cd "$HOME"' }).block).toBe(true);
-		expect(check("bash", { command: "pushd $HOME" }).block).toBe(true);
+		// Home is operator-owned and remains available through every spelling.
+		expect(check("bash", { command: "cd $HOME" }).block).toBe(false);
+		expect(check("bash", { command: 'cd "$HOME"' }).block).toBe(false);
+		expect(check("bash", { command: "pushd $HOME" }).block).toBe(false);
 	});
 
 	// Clamping the session cwd between calls would not have been enough: one call can both move the
@@ -294,7 +286,7 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "cd .. && cat custB/secret" }).block).toBe(true);
 		expect(check("bash", { command: "cd ..; cat custB/secret" }).block).toBe(true);
 		expect(check("bash", { command: "(cd /work/custB && cat secret)" }).block).toBe(true);
-		expect(check("bash", { command: "cd $HOME && cat .ssh/id_rsa" }).block).toBe(true);
+		expect(check("bash", { command: "cd $HOME && cat .ssh/id_rsa" }).block).toBe(false);
 		expect(check("bash", { command: "cd /work/custB && cat secret" }).block).toBe(true);
 		// `cd /` is the case that changed: it is permitted, and the relative read after it lands in a
 		// temp path the fence allows anyway. What must still fail is reaching a *denied* tree from there,
@@ -334,8 +326,7 @@ describe("evaluateToolCall", () => {
 	});
 
 	// A cd destination must be somewhere any relative path would be acceptable — which means write
-	// as well as read. The default policy grants the plugin and skill directories read-only, and
-	// moving into one turned every unchecked relative path into a write there.
+	// as well as read. An explicit read-only grant cannot become writable through relative paths.
 	it("bash: a directory change needs write access, not just read", () => {
 		// /shared/ctx is readable and deliberately not writable.
 		expect(check("bash", { command: "cd /shared/ctx" }).block).toBe(true);
@@ -694,8 +685,8 @@ describe("paths reaching the shell through an expansion (#2534)", () => {
 	 * The boundary reads the command as text, so a path arriving via a parameter expansion was
 	 * never checked. Only part of that is fixable at this layer, and the split matters:
 	 *
-	 *   - `$HOME`/`${HOME}` mean exactly what `~` means, which is already handled. Three
-	 *     spellings of one file, one of them blocked, is an oversight rather than a policy.
+	 *   - `$HOME`/`${HOME}` mean exactly what `~` means, which is already handled. All three spellings
+	 *     must preserve the operator's normal home access.
 	 *   - Everything else — a variable in an operand, and a variable in a redirect target — is
 	 *     genuinely unresolvable here and is left open on purpose. See below.
 	 */
@@ -703,11 +694,11 @@ describe("paths reaching the shell through an expansion (#2534)", () => {
 	// template literal is a template interpolation, and `HOME` is not a TS binding.
 	const BRACED_HOME = `$\u007bHOME\u007d`;
 
-	it("treats $HOME and its braced form as ~, which is already blocked", () => {
-		expect(check("bash", { command: "cat ~/.ssh/id_rsa" }).block).toBe(true); // the existing rule
-		expect(check("bash", { command: "cat $HOME/.ssh/id_rsa" }).block).toBe(true);
-		expect(check("bash", { command: `cat ${BRACED_HOME}/.ssh/id_rsa` }).block).toBe(true);
-		expect(check("bash", { command: 'cp secret "$HOME/exfil"' }).block).toBe(true);
+	it("treats $HOME and its braced form as the operator-owned home", () => {
+		expect(check("bash", { command: "cat ~/.ssh/id_rsa" }).block).toBe(false);
+		expect(check("bash", { command: "cat $HOME/.ssh/id_rsa" }).block).toBe(false);
+		expect(check("bash", { command: `cat ${BRACED_HOME}/.ssh/id_rsa` }).block).toBe(false);
+		expect(check("bash", { command: 'cp secret "$HOME/exfil"' }).block).toBe(false);
 		// A different variable that merely starts with HOME must not be rewritten.
 		expect(check("bash", { command: "echo $HOMEBREW_PREFIX" }).block).toBe(false);
 	});
@@ -809,15 +800,13 @@ describe("evaluateToolCall — the reported false refusals (#2624)", () => {
 		const gitconfig = path.join(os.homedir(), ".gitconfig");
 		expect(check("bash", { command: `cat ${gitconfig}` }).block).toBe(false);
 		expect(check("read", { file_path: gitconfig }).block).toBe(false);
-		// Read-only in the fence, so the write direction is refused on both — the split still holds.
-		expect(check("bash", { command: `printf x > ${gitconfig}` }).block).toBe(true);
-		expect(check("write", { file_path: gitconfig }).block).toBe(true);
+		expect(check("bash", { command: `printf x > ${gitconfig}` }).block).toBe(false);
+		expect(check("write", { file_path: gitconfig }).block).toBe(false);
 	});
 
 	// What the change must NOT do. The fence still denies these, so the pre-check still refuses them.
 	it("keeps refusing the paths the fence denies", () => {
 		expect(check("bash", { command: "cat /work/custB/secret.env" }).block).toBe(true);
-		expect(check("bash", { command: "cat ~/.ssh/id_rsa" }).block).toBe(true);
 		expect(check("read", { file_path: "/work/custB/secret.env" }).block).toBe(true);
 		expect(check("python", { code: 'open("/work/custB/secret.env").read()' }).block).toBe(true);
 		expect(check("grep", { pattern: "TOKEN", path: "/work/custB" }).block).toBe(true);
@@ -835,7 +824,6 @@ describe("evaluateToolCall — the bash cwd parameter agrees with cd (#2624)", (
 
 	it("still refuses a cwd the fence denies", () => {
 		expect(check("bash", { command: "ls", cwd: "/work/custB" }).block).toBe(true);
-		expect(check("bash", { command: "ls", cwd: os.homedir() }).block).toBe(true);
 	});
 
 	// A read-only root is not somewhere a command may stand: every relative path it then writes would

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { executeShell } from "@f5-sales-demo/pi-natives";
-import { getAgentDir, getPluginsDir, TempDir } from "@f5-sales-demo/pi-utils";
+import { getAgentDir, getConfigRootDir, getPluginsDir, TempDir } from "@f5-sales-demo/pi-utils";
 import { discoverAndLoadExtensions } from "@f5-sales-demo/xcsh/extensibility/extensions/loader";
 import { getMemoryRoot } from "@f5-sales-demo/xcsh/memories";
 import { buildContainmentFence, containmentStatus } from "@f5-sales-demo/xcsh/sandbox/containment";
@@ -40,6 +40,12 @@ function reads(cwd: string, filePath: string): boolean {
 	return evaluateToolCall({ toolName: "read", input: { file_path: filePath }, cwd, fence }).block;
 }
 
+/** Whether the `write` tool would be refused. */
+function writes(cwd: string, filePath: string): boolean {
+	const fence = resolveSessionFence(cwd, { get: () => undefined })!;
+	return evaluateToolCall({ toolName: "write", input: { file_path: filePath }, cwd, fence }).block;
+}
+
 describe("two-customer isolation", () => {
 	it("a session in custA cannot enumerate the parent but can use a named custB path", () => {
 		expect(reads(custA, parent)).toBe(true);
@@ -72,18 +78,30 @@ describe("two-customer isolation", () => {
 });
 
 describe("functionality preservation under the sandbox", () => {
-	it("keeps the plugin cache readable (e.g. the meddpicc engine)", () => {
-		expect(reads(custA, path.join(getPluginsDir(), "cache", "plugins", "meddpicc", "engine", "cli.ts"))).toBe(false);
+	it("keeps operator-owned plugins writable (e.g. the meddpicc engine)", () => {
+		const plugin = path.join(getPluginsDir(), "cache", "plugins", "meddpicc", "engine", "cli.ts");
+		expect(reads(custA, plugin)).toBe(false);
+		expect(writes(custA, plugin)).toBe(false);
 	});
 
-	it("keeps user-level skills readable", () => {
-		expect(reads(custA, path.join(getAgentDir(), "skills", "account-planning", "SKILL.md"))).toBe(false);
+	it("keeps user-level skills and settings writable", () => {
+		for (const own of [
+			path.join(getAgentDir(), "skills", "account-planning", "SKILL.md"),
+			path.join(getConfigRootDir(), "settings.json"),
+		]) {
+			expect(reads(custA, own)).toBe(false);
+			expect(writes(custA, own)).toBe(false);
+		}
 	});
 
 	// #2637: the operator's own dotfiles are theirs. What stays blocked is another customer's folder and
 	// another session's state, asserted above and below.
-	it("no longer blocks the operator's own home dotfiles", () => {
-		expect(reads(custA, path.join(os.homedir(), ".ssh", "id_rsa"))).toBe(false);
+	it("keeps the operator's own home and configuration writable", () => {
+		for (const own of [".gitconfig", ".aws/config", ".zshrc", ".zprofile", ".ssh/config"]) {
+			const target = path.join(os.homedir(), own);
+			expect(reads(custA, target)).toBe(false);
+			expect(writes(custA, target)).toBe(false);
+		}
 	});
 });
 
@@ -159,6 +177,22 @@ describe("two-customer isolation, enforced in the shell", () => {
 		expect(fs.readFileSync(path.join(custB, "planted.env"), "utf8")).toBe("x");
 		await shell(custA, `cp ${path.join(custB, "secret.env")} .`);
 		expect(fs.existsSync(path.join(custA, "secret.env"))).toBe(true);
+	});
+
+	it("allows operator-owned configuration writes through the OS fence", async () => {
+		const targets = [
+			path.join(home, ".gitconfig"),
+			path.join(home, ".aws", "config"),
+			path.join(home, ".zshrc"),
+			path.join(home, ".ssh", "config"),
+			path.join(home, ".xcsh", "plugins", "example", "plugin.json"),
+		];
+		for (const target of targets) {
+			fs.mkdirSync(path.dirname(target), { recursive: true });
+			const result = await shell(custA, `printf operator > ${JSON.stringify(target)}`);
+			expect(result.code).toBe(0);
+			expect(fs.readFileSync(target, "utf8")).toBe("operator");
+		}
 	});
 
 	it(`a spawned parent listing ${OS_ENFORCED ? "is" : "is not"} OS-confined`, async () => {


### PR DESCRIPTION
## Summary

- remove special write denials for operator-owned home and CLI configuration
- keep explicit read-only grants, cross-session state denies, data-root isolation, and parent-enumeration isolation
- update `xcsh://about` to describe the courtesy boundary that is actually enforced
- cover shell profiles, SSH state, plugins, skills, settings, and command-bearing configuration through the tool gate and OS fence

This is stacked on #2747 because the parent-enumeration behavior defines the documentation in this change.

## Verification

- focused containment, enforcement, session-fence, isolation, conformance, and rendered-document tests
- `bun check:ts`
- `bun check:rs`
- `bun run pii:gate -- --scope staged`

Fixes #2720