### PR TITLE
fix(bash): reset cwd between tool calls

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Reset model bash tool calls to the session working directory so a command-local `cd` cannot silently relocate later calls ([#2724](https://github.com/f5-sales-demo/xcsh/issues/2724))
+
 ## [20.0.3] - 2026-08-01
 
 ### Fixed

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -64,7 +64,7 @@ export interface BashResult {
 	outputLines: number;
 	outputBytes: number;
 	artifactId?: string;
-	/** Actual working directory after the command ran (persistent shell only). */
+	/** Actual working directory after the command ran; direct operator-shell callers may persist it. */
 	newCwd?: string;
 }
 

--- a/packages/coding-agent/src/internal-urls/fleet-resolve.ts
+++ b/packages/coding-agent/src/internal-urls/fleet-resolve.ts
@@ -149,13 +149,10 @@ export interface CwdEventSource {
 }
 
 /**
- * A getter for the working directory the *session* is in, not the one the process
- * started in.
+ * A getter for the working directory the *session* is rooted in, not the one the process started in.
  *
- * The bash tool keeps its own cwd and updates it on `cd`, emitting `cwd:changed`
- * (`tools/bash.ts`); `process.chdir` is never called for it. Classifying against
- * `process.cwd()` would therefore keep reporting the startup repository, so a
- * `content` grant could survive after moving into a `developer` repository.
+ * Model bash calls reset to this root, so a command-local `cd` must not emit this event. The event is
+ * reserved for an explicit session relocation; `process.chdir` is never used for either case.
  */
 export function createLiveCwdGetter(initialCwd: string, events?: CwdEventSource): () => string {
 	let current = initialCwd;

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -212,7 +212,7 @@ export class StatusLineComponent implements Component {
 		this.#invalidateGitCaches();
 	}
 
-	/** Update the displayed working directory (e.g. after a user !cd command). */
+	/** Update the displayed working directory after an operator command or explicit session move. */
 	setCwd(cwd: string): void {
 		this.#cwd = cwd;
 		this.#invalidateGitCaches();

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -2,6 +2,8 @@ Executes bash command in shell session for terminal operations like git, bun, ca
 
 <instruction>
 - You **MUST** use `cwd` parameter to set working directory instead of `cd dir && …`
+- Every call starts in the session working directory, or in `cwd` when provided. A `cd` affects only
+  that call and does not relocate later tool calls.
 - Always provide a `description` parameter: a short, human-readable summary of what the command does (e.g. "Install dependencies", "Run test suite"). This is displayed in compact mode and during execution.
 - Prefer `env: { NAME: "…" }` for multiline, quote-heavy, or untrusted values instead of inlining them into shell syntax; reference them from the command as `$NAME`
 - Quote variable expansions like `"$NAME"` to preserve exact content and avoid shell parsing bugs

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1170,8 +1170,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						},
 					}),
 				getPluginRoots: () => listXcshPluginRoots(os.homedir(), cwd).then(r => r.roots),
-				// Classification must follow the session's `cd`, not the process cwd, which
-				// never moves. The bash tool emits `cwd:changed` when it relocates.
+				// Classification follows explicit session relocation events, not command-local `cd` and not the
+				// process cwd. Model bash calls reset to this session root on every invocation (#2724).
 				fleetDeps: { cwd: createLiveCwdGetter(cwd, eventBus) },
 			}),
 		);

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -7,7 +7,7 @@ import type {
 } from "@f5-sales-demo/pi-agent-core";
 import type { Component } from "@f5-sales-demo/pi-tui";
 import { ImageProtocol, TERMINAL, Text } from "@f5-sales-demo/pi-tui";
-import { $env, getProjectDir, isEnoent, prompt, setShellPwd } from "@f5-sales-demo/pi-utils";
+import { $env, getProjectDir, isEnoent, prompt } from "@f5-sales-demo/pi-utils";
 import { Type } from "@sinclair/typebox";
 import { Settings } from "../config/settings";
 import { type BashResult, executeBash } from "../exec/bash-executor";
@@ -516,17 +516,13 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 	/**
 	 * Where this session's boundary is anchored.
 	 *
-	 * **Not the live cwd.** The fence used to be rebuilt from `session.cwd`, which line ~717 replaces
-	 * with whatever PWD the command ended in — so the model could move the boundary with a `cd`. Measured
-	 * on a workspace outside the home tree, which is the layout the sibling-checkout deny exists for:
-	 * with `/work/custA` as the workspace, `/work/custB/secret.env` was denied; `cd /usr` is permitted
-	 * (correctly — `/usr` is not sensitive), and the *next* fence was rooted at `/usr`, where the parent
-	 * deny of `/work` cannot be expressed because `dirname("/usr")` is `/` and denying the root is refused
-	 * as too broad. `/work/custB` then became readable **and** writable. Two tool calls, no exotic
-	 * spelling, and the tenant boundary was gone.
+	 * **Not a command's final PWD.** Every model tool call starts from `session.cwd` and a command-local
+	 * `cd` is discarded when that call ends (#2724). Before that reset existed, writing the final PWD
+	 * back into `session.cwd` also moved this fence: after `cd /usr`, the next boundary was rooted at
+	 * `/usr` and could no longer protect a workspace under `/work` (#2589).
 	 *
-	 * So the anchor is captured once per session and never follows the shell. It is keyed on the session
-	 * object rather than held on this instance because the tool is built by a factory
+	 * The anchor remains captured once per session as a defensive invariant and never follows the shell.
+	 * It is keyed on the session object rather than held on this instance because the tool is built by a factory
 	 * (`bash: s => new BashTool(s)`) and must not depend on how long an instance happens to live.
 	 *
 	 * An *operator* moving the project — startup, or the slash command that calls `setProjectDir` — does
@@ -546,8 +542,8 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			return this.session.cwd;
 		}
 		if (anchor.project !== project) {
-			// The operator moved the project. Re-anchor there rather than at `session.cwd`, which a
-			// model `cd` may have moved in the meantime.
+			// The operator moved the project. This is an explicit boundary relocation, unlike a model's
+			// command-local `cd`.
 			FENCE_ANCHORS.set(this.session, { root: project, project });
 			return project;
 		}
@@ -787,13 +783,6 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 						}
 					},
 				});
-		// Update working directory if the persistent shell changed it
-		if ("newCwd" in result && result.newCwd && result.newCwd !== this.session.cwd) {
-			this.session.cwd = result.newCwd;
-			setShellPwd(result.newCwd);
-			this.session.eventBus?.emit("cwd:changed", result.newCwd);
-		}
-
 		if (result.cancelled) {
 			if (signal?.aborted) {
 				throw new ToolAbortError(normalizeResultOutput(result) || "Command aborted");

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -58,6 +58,22 @@ describe("executeBash", () => {
 		expect(result.output.trim()).toBe(fs.realpathSync(tempDir));
 	});
 
+	it("preserves cwd for direct operator shell sessions", async () => {
+		const subdir = path.join(tempDir, "operator-cwd");
+		fs.mkdirSync(subdir);
+		const sessionKey = "operator-cwd-persistence";
+
+		const changed = await executeBash(`cd ${JSON.stringify(subdir)}`, {
+			cwd: tempDir,
+			timeout: 5000,
+			sessionKey,
+		});
+		expect(changed.newCwd).toBe(subdir);
+
+		const later = await executeBash("pwd", { timeout: 5000, sessionKey });
+		expect(later.output.trim()).toBe(subdir);
+	});
+
 	it("canonicalizes symlinked cwd before execution", async () => {
 		if (process.platform === "win32") {
 			return;

--- a/packages/coding-agent/test/internal-urls/fleet-resolve.test.ts
+++ b/packages/coding-agent/test/internal-urls/fleet-resolve.test.ts
@@ -121,11 +121,10 @@ describe("classifyRepo", () => {
 	});
 });
 
-describe("live working directory (#2429 review)", () => {
-	it("follows the session's cd instead of pinning the startup directory", () => {
-		// The bash tool tracks its own cwd and emits `cwd:changed`; process.cwd() never
-		// moves. Classifying against the startup directory would keep a content grant
-		// alive after cd'ing into a developer repository.
+describe("live session root (#2429 review)", () => {
+	it("follows an explicit session relocation instead of the process directory", () => {
+		// Model bash calls do not emit this event for command-local `cd`. An explicit session move may,
+		// while process.cwd() remains unchanged.
 		const handlers: Array<(next: unknown) => void> = [];
 		const events = {
 			on(_event: "cwd:changed", handler: (next: unknown) => void) {

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -233,9 +233,11 @@ describe("bash tool secret masking (PR #77)", () => {
 		expect(src).toContain("obfuscator");
 	});
 
-	it("bash.ts integrates setShellPwd for cwd tracking", async () => {
+	it("bash.ts does not persist a model command's final cwd", async () => {
 		const src = await fs.readFile(path.join(import.meta.dir, "../src/tools/bash.ts"), "utf8");
-		expect(src).toContain("setShellPwd");
+		expect(src).not.toContain("setShellPwd");
+		expect(src).not.toContain("session.cwd = result.newCwd");
+		expect(src).not.toContain('emit("cwd:changed", result.newCwd)');
 	});
 });
 
@@ -578,7 +580,7 @@ describe("Provider registration: env var fallback must not send literal name (PR
 
 // ─── Statusline CWD Tracking (#118, #120) ─────────────────────────────────
 
-describe("statusline tracks assistant cwd, not global shellPwd (PR #120 regression, #118)", () => {
+describe("statusline tracks the session root, not global shellPwd (PR #120 regression, #118)", () => {
 	it("status-line.ts owns a #cwd field initialized from session.cwd, not a stale global", async () => {
 		const src = await fs.readFile(path.join(import.meta.dir, "../src/modes/components/status-line.ts"), "utf8");
 		// The component must declare #cwd as a typed field (not inline-initialized from a global)

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -251,10 +251,9 @@ describe("evaluateToolCall", () => {
 	// look like a path, and the boundary never saw it at all (#2520). A single space was the only
 	// thing standing between a blocked read and an allowed one.
 	// A relative operand is never checked, because the floor assumes it resolves under the session
-	// directory. `cd` is what breaks that assumption: the bash tool runs one persistent in-process
-	// shell, so a directory change outlives the call that made it and every later relative path
-	// resolves somewhere else. Refusing a `cd` that cannot be proven to stay in-tree is what keeps
-	// the assumption true — see #2542, where `cd /` then `cat tmp/x` read a sibling's file.
+	// directory. A `cd` can break that assumption within the same call, even though the next call resets
+	// to the session root. Refusing a change that cannot be proven to stay in-tree keeps the unchecked
+	// relative operands safe — see #2542, where `cd /` then `cat tmp/x` read a sibling's file.
 	it("bash: cd into a denied directory is refused", () => {
 		// In-tree: allowed.
 		expect(check("bash", { command: "cd sub" }).block).toBe(false);

--- a/packages/coding-agent/test/sandbox-fence-anchor.int.test.ts
+++ b/packages/coding-agent/test/sandbox-fence-anchor.int.test.ts
@@ -2,16 +2,21 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { getSessionsDir, getShellPwd, setShellPwd } from "@f5-sales-demo/pi-utils";
 import { Settings } from "../src/config/settings";
+import { _resetShellSessionsForTest } from "../src/exec/bash-executor";
+import { evaluateToolCall } from "../src/sandbox/enforce";
+import { resolveSessionFence } from "../src/sandbox/session-fence";
 import type { ToolSession } from "../src/tools";
 import { BashTool } from "../src/tools/bash";
+import { EventBus } from "../src/utils/event-bus";
 
 /**
- * Can the model move the boundary it is inside?
+ * Every model bash call starts from the session root.
  *
- * The fence was rebuilt from `session.cwd` on every call, and the bash tool writes the command's
- * resulting PWD back into that field. So a `cd` the fence permits — and it does permit `cd /usr`, because
- * `/usr` is not sensitive and the fence is deliberately gentle — silently re-rooted the *next* fence.
+ * The shared executor intentionally keeps shell state for operator `!cmd` commands. The model tool used
+ * to copy that shell's final PWD into `session.cwd`, so a `cd` silently relocated every later tool call
+ * and made the interface's only working-directory signal false (#2724).
  *
  * That matters because the enumeration deny that prevents sibling discovery is derived from the
  * workspace's parent. Re-rooted at `/usr`, there is no parent to protect: `dirname("/usr")` is `/`, and
@@ -30,6 +35,8 @@ describe("the containment boundary cannot be relocated by the model", () => {
 	let custB: string;
 	let session: ToolSession;
 	let bash: BashTool;
+	let originalShellPwd: string;
+	let cwdEvents: string[];
 
 	beforeEach(() => {
 		work = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "anchor-work-")));
@@ -39,21 +46,34 @@ describe("the containment boundary cannot be relocated by the model", () => {
 		fs.mkdirSync(custB);
 		fs.writeFileSync(path.join(custB, "secret.env"), `${CANARY}\n`);
 		fs.writeFileSync(path.join(custA, "notes.md"), "mine\n");
+		originalShellPwd = getShellPwd();
+		setShellPwd(custA);
+		cwdEvents = [];
+		const eventBus = new EventBus();
+		eventBus.on("cwd:changed", next => {
+			if (typeof next === "string") cwdEvents.push(next);
+		});
 
 		session = {
 			cwd: custA,
 			hasUI: false,
+			eventBus,
 			getArtifactsDir: () => path.join(custA, ".artifacts"),
+			getSessionId: () => "cwd-reset-test",
 			settings: Settings.isolated({ "sandbox.enabled": true }),
 		} as unknown as ToolSession;
 		bash = new BashTool(session);
 	});
 
-	afterEach(() => fs.rmSync(work, { recursive: true, force: true }));
+	afterEach(() => {
+		setShellPwd(originalShellPwd);
+		_resetShellSessionsForTest();
+		fs.rmSync(work, { recursive: true, force: true });
+	});
 
-	async function run(command: string): Promise<string> {
+	async function run(command: string, cwd?: string): Promise<string> {
 		try {
-			const result = (await bash.execute(`call-${Math.random()}`, { command })) as {
+			const result = (await bash.execute(`call-${Math.random()}`, { command, cwd })) as {
 				content?: { type: string; text?: string }[];
 			};
 			return (result.content ?? [])
@@ -65,6 +85,44 @@ describe("the containment boundary cannot be relocated by the model", () => {
 			return error instanceof Error ? error.message : String(error);
 		}
 	}
+
+	it("discards a final cd before the next tool call", async () => {
+		expect(await run("cd /usr && pwd")).toContain("/usr");
+		expect(await run("pwd")).toContain(custA);
+		expect(session.cwd).toBe(custA);
+		expect(fs.realpathSync(getShellPwd())).toBe(custA);
+		expect(cwdEvents).toEqual([]);
+
+		const fence = resolveSessionFence(session.cwd, session.settings)!;
+		const diagnostic = evaluateToolCall({
+			toolName: "write",
+			input: { file_path: path.join(getSessionsDir(), "diagnostic.txt") },
+			cwd: session.cwd,
+			fence,
+		});
+		expect(diagnostic.block).toBe(true);
+		expect(diagnostic.reason).toContain(`working directory: ${custA}`);
+	});
+
+	it("keeps a cd within its call and resolves the next relative write at the session root", async () => {
+		const subdir = path.join(custA, "subdir");
+		fs.mkdirSync(subdir);
+
+		expect(await run("cd subdir && printf inside > local.txt && pwd")).toContain(subdir);
+		expect(fs.readFileSync(path.join(subdir, "local.txt"), "utf8")).toBe("inside");
+
+		expect(await run("printf root > next.txt && pwd")).toContain(custA);
+		expect(fs.readFileSync(path.join(custA, "next.txt"), "utf8")).toBe("root");
+		expect(fs.existsSync(path.join(subdir, "next.txt"))).toBe(false);
+	});
+
+	it("scopes the cwd parameter to one call", async () => {
+		const subdir = path.join(custA, "parameter-cwd");
+		fs.mkdirSync(subdir);
+
+		expect(await run("pwd", subdir)).toContain(subdir);
+		expect(await run("pwd")).toContain(custA);
+	});
 
 	it("keeps the original parent non-enumerable after a cd out of the tree", async () => {
 		// Control: the parent cannot be scanned before relocation. Both children exist, so an ordinary

--- a/packages/coding-agent/test/status-line-cwd-watch.test.ts
+++ b/packages/coding-agent/test/status-line-cwd-watch.test.ts
@@ -61,10 +61,9 @@ describe("StatusLineComponent.watchCwd", () => {
 	});
 
 	it("renders the cwd from the cwd:changed event payload, not getShellPwd()", () => {
-		// Regression for #118: the statusline must track the cwd carried by the
-		// cwd:changed event (the assistant's working directory), not the global
-		// shellPwd. The event payload and shellPwd can diverge when a user !cd
-		// command updates shellPwd but the assistant's cwd stays unchanged.
+		// Regression for #118: the statusline must track an explicit session relocation carried by the
+		// event, not the global shellPwd. The two can diverge because an operator `!cd` updates shellPwd
+		// while model tool calls remain rooted at the session directory (#2724).
 		//
 		// Use persistent, pid-scoped directories rather than mkdtempSync with
 		// cleanup. getTopBorder() kicks off fire-and-forget async IIFEs inside


### PR DESCRIPTION
## Summary

- keep every model bash invocation rooted at the session working directory unless that call supplies `cwd`
- stop copying a command final PWD into session state, global shell PWD, and `cwd:changed` events
- preserve persistent cwd behavior in the shared executor for operator `!cmd` sessions
- document the one-call cwd contract and update fleet/status commentary

## Verification

- `bun test packages/coding-agent/test/sandbox-fence-anchor.int.test.ts packages/coding-agent/test/regression-guard.test.ts packages/coding-agent/test/bash-executor.test.ts`
- focused fleet resolver and status-line cwd tests
- `bun check:ts`
- `bun run pii:gate -- --scope staged`

Fixes #2724