### PR TITLE
fix(coding-agent): ship generated API indexes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Made operator-owned home files, CLI configuration, shell profiles, SSH state, plugins, skills, and settings consistently writable while preserving cross-session and data-root isolation ([#2720](https://github.com/f5-sales-demo/xcsh/issues/2720))
 - Prevented sandbox sessions from enumerating the session root's parent while preserving named operator access and explicit read-grant overrides ([#2725](https://github.com/f5-sales-demo/xcsh/issues/2725))
+- Included the generated API-spec indexes in npm artifacts and exercised them in tarball install smoke tests ([#2760](https://github.com/f5-sales-demo/xcsh/issues/2760))
 
 ## [20.0.0] - 2026-08-01
 

--- a/packages/coding-agent/src/internal-urls/.gitignore
+++ b/packages/coding-agent/src/internal-urls/.gitignore
@@ -1,2 +1,0 @@
-api-catalog-index.generated.ts
-api-spec-index.generated.ts

--- a/scripts/install-tests/run-ci.sh
+++ b/scripts/install-tests/run-ci.sh
@@ -17,6 +17,7 @@ smoke_cli() {
 	"$omp_bin" --version
 	"$omp_bin" --help >/dev/null
 	"$omp_bin" stats --summary >/dev/null
+	XCSH_SMOKE_TEST_SPECS=1 "$omp_bin" >/dev/null
 }
 
 find_tarball() {


### PR DESCRIPTION
## Summary

- stop excluding the generated API-spec and catalog indexes from npm tarballs
- exercise the API-spec contract through binary, source, and tarball install smoke tests
- document the packaging fix

## Verification

- red: `bun run ci:test:install-methods` failed from the tarball install because the generated spec module was absent
- green: `bun run ci:test:install-methods` passed after the packaging fix
- `bun check`
- `bash tests/test-pii-gate.sh` (10 passed)
- `bash scripts/pii-gate.sh --scope staged`

Fixes #2760