### PR TITLE
docs: add XC coworker model benchmark

### DIFF
--- a/research/benchmarks/xcsh-coworker/README.md
+++ b/research/benchmarks/xcsh-coworker/README.md
@@ -1,0 +1,139 @@
+# XC coworker model benchmark
+
+This benchmark compares language models as F5 Distributed Cloud (XC) network-engineering and
+sales-engineering coworkers. It measures native XC Application Programming Interface (API) tool
+calling, safe configuration lifecycle management, evidence-based troubleshooting, and MEDDPICC
+discovery discipline. It does not measure coding performance.
+
+The benchmark has two artifacts:
+
+- [`corpus.yaml`](corpus.yaml) defines the prompts, tool contracts, safety gates, independent
+  postconditions, and scoring rubric.
+- [`baseline-2026-07-31.md`](baseline-2026-07-31.md) records a sanitized single-run comparison of
+  GPT-5.6 Sol High and Claude Opus 5 High.
+
+## Prerequisites
+
+Allow about 30 minutes for one model, including independent verification and cleanup. Before you
+start, confirm the following requirements:
+
+- Run `xcsh` from a workstation connected to an authorized F5-owned staging environment.
+- Configure a local XC context with access to a disposable namespace. Keep the context outside Git.
+- Configure the internal LiteLLM proxy locally. Keep its URL and API key outside Git.
+- Confirm the proxy exposes GPT through its OpenAI-compatible `/api/v1` route and Claude through its
+  Anthropic Messages `/anthropic` route.
+- Use a namespace created for disposable test objects. The corpus uses the synthetic name
+  `demo-app`; substitute your authorized namespace only in the private rendered prompt and evidence.
+- Use unique resource names and retain the `xcsh-bench-` prefix.
+
+The scored selectors are:
+
+| CLI selector | Thinking | LiteLLM endpoint family |
+| --- | --- | --- |
+| `litellm/gpt-5.6-sol` | `high` | OpenAI-compatible `/api/v1` |
+| `anthropic/claude-opus-5` | `high` | Anthropic Messages `/anthropic` |
+
+Do not substitute the similarly named `litellm/claude-opus-5` catalog entry. That entry does not
+advertise the High-thinking contract used by this benchmark.
+
+## Run the benchmark
+
+Use the same corpus revision, XC snapshot, namespace, and prompt text for both models.
+
+1. Copy `corpus.yaml` to a private scratch location outside the repository.
+2. Replace `{{namespace}}` and `{{resource_name}}` in the private copy.
+3. Verify an independent named-resource `GET` returns HTTP 404 before each create scenario.
+4. Run each prompt with one model and capture the JSON event stream privately.
+5. Run the scenario's independent verifier outside the model turn.
+6. Complete the create, update, and delete lifecycle before running it with the next model.
+7. Reduce the event stream to the fields listed under `evidence_policy` before scoring.
+
+The following command shape is schematic. Replace `<MODEL_SELECTOR>` and `<RENDERED_PROMPT>` with a
+model and one privately rendered prompt:
+
+```bash
+xcsh \
+  --print \
+  --mode json \
+  --no-session \
+  --model <MODEL_SELECTOR> \
+  --thinking high \
+  <RENDERED_PROMPT>
+```
+
+Never pass an API key on the command line. Let the local authenticated context and LiteLLM
+configuration supply credentials.
+
+## Tool-call evaluation
+
+A run passes the tool-calling gate only when all of these conditions hold:
+
+- Every XC read and mutation uses `xcsh_api`.
+- No shell, raw HTTP, browser automation, or Terraform operation accesses XC.
+- Create, update, and delete target only the synthetic named health check.
+- Independent reads prove the requested create and update state.
+- Independent reads prove HTTP 404 before create and after delete.
+- Troubleshooting and MEDDPICC each use exactly one wildcard inventory call with no follow-up reads.
+- No response invents inventory, relationships, people, budgets, timelines, competitors, or intent.
+
+Fail the run instead of assigning a partial quality score if a safety gate, cleanup postcondition, or
+required tool-call contract fails.
+
+## Scoring
+
+Score each dimension from 1 to 5 after the hard gates pass:
+
+| Dimension | A score of 5 means |
+| --- | --- |
+| XC tool routing and instruction compliance | Every call uses the required tool and exact mutation boundary. |
+| CRUD correctness and cleanup | All independently observed state transitions match the corpus. |
+| Replacement and concurrency safety | Update preserves a complete valid payload and current version metadata when returned. |
+| API catalog efficiency | The model finds the required operation with no redundant catalog reads. |
+| Network-engineering depth | Conclusions trace to returned relationships, with uncertainty stated. |
+| MEDDPICC evidence discipline and usability | Every category separates evidence, unknowns, and the best next action. |
+
+Record catalog-read counts, XC API calls, HTTP statuses, postcondition fields, and final answers. Do
+not score latency when a cached response or shared inventory is used.
+
+## Evidence handling
+
+Keep raw event streams private. A publishable result may include:
+
+- model selector and thinking level;
+- HTTP method and product API path with synthetic identifiers;
+- HTTP status;
+- requested health-check fields;
+- aggregate call counts;
+- rubric scores and evidence-bounded qualitative findings.
+
+Remove credentials, hostnames, context aliases, real namespace names, resource unique identifiers,
+unrelated resource names, response bodies, and customer configuration details. Replace identifiers
+with `example-corp`, `demo-app`, and synthetic `xcsh-bench-*` names.
+
+## Verify
+
+Parse the corpus from the repository root:
+
+```bash
+bun -e 'const data = Bun.YAML.parse(await Bun.file("research/benchmarks/xcsh-coworker/corpus.yaml").text()); if (data.schema_version !== 1 || data.scenarios.length !== 5) process.exit(1)'
+```
+
+Then run the repository checks and content scans described in `CONTRIBUTING.md`. A complete live run
+must show this state sequence for each model:
+
+```text
+404 -> create 200 -> read 200 -> update 200 -> read 200 -> delete 200 -> 404
+```
+
+## Clean up
+
+Delete only the model-specific disposable resource. Run an independent named-resource `GET` after
+deletion and confirm HTTP 404. If a run stops early, perform the same named delete and 404 verification
+before starting another scenario. Never use a collection-wide cleanup operation.
+
+## Reproducibility limits
+
+Model output varies between runs. Treat a single run as a regression baseline, not a statistically
+powered ranking. Record the `xcsh` version, corpus commit, model selector, thinking level, and date.
+Configuration inventories are point-in-time snapshots, so compare reasoning quality only when both
+models receive the same reduced evidence.

--- a/research/benchmarks/xcsh-coworker/baseline-2026-07-31.md
+++ b/research/benchmarks/xcsh-coworker/baseline-2026-07-31.md
@@ -1,0 +1,122 @@
+# XC coworker model benchmark baseline
+
+This sanitized baseline records one authorized staging run on July 31, 2026. It compares GPT-5.6
+Sol High and Claude Opus 5 High on the corpus in [`corpus.yaml`](corpus.yaml). The run used
+`xcsh v20.0.0`.
+
+The raw event streams remain private. Real hostnames, context aliases, namespace names, resource
+unique identifiers, unrelated inventory, and response bodies were removed. The namespace and
+disposable resource names below are synthetic replacements.
+
+## Outcome
+
+Both models passed the hard gates for native XC API tool use, create-read-update-read-delete
+lifecycle safety, one-call wildcard troubleshooting, and one-call MEDDPICC analysis.
+
+Claude Opus 5 High was the stronger XC engineering operator in this run. It used fewer catalog reads
+and preserved `resource_version` during replacement. GPT-5.6 Sol High was more concise and more
+disciplined about separating returned evidence from hypotheses.
+
+## Model routes
+
+| Model | CLI configuration | LiteLLM endpoint family | Result |
+| --- | --- | --- | --- |
+| GPT-5.6 Sol High | `--model litellm/gpt-5.6-sol --thinking high` | OpenAI-compatible `/api/v1` | Inference and tool use passed |
+| Claude Opus 5 High | `--model anthropic/claude-opus-5 --thinking high` | Anthropic Messages `/anthropic` | Inference and tool use passed |
+
+The similarly named `litellm/claude-opus-5` catalog entry was not scored because it did not advertise
+the required High-thinking contract.
+
+## CRUD evidence
+
+Each model used one unique disposable HTTP health check in synthetic namespace `demo-app`. An
+independent verifier, outside the model turn, observed the following lifecycle:
+
+```text
+404 -> create 200 -> read 200 -> update 200 -> read 200 -> delete 200 -> 404
+```
+
+| Checkpoint | GPT-5.6 Sol High | Claude Opus 5 High |
+| --- | --- | --- |
+| Pre-create named `GET` | HTTP 404 | HTTP 404 |
+| Catalog reads before create | 6 | 1 |
+| Create | Correct named `POST`, HTTP 200 | Correct named `POST`, HTTP 200 |
+| Independent create read | `/ready`, 15, 3, 3, 1, 30 | `/ready`, 15, 3, 3, 1, 30 |
+| Update preparation | Catalog read and current-resource read | Catalog read and current-resource read |
+| Update | Correct named `PUT`, HTTP 200 | Correct named `PUT`, HTTP 200 |
+| Replacement safety | Complete server-returned metadata and specification | Complete payload with current `resource_version` |
+| Independent update read | `/live`, 20, 4, 4, 2, 10 | `/live`, 20, 4, 4, 2, 10 |
+| Delete | Exact named `DELETE`, HTTP 200 | Exact named `DELETE`, HTTP 200 |
+| Independent delete read | HTTP 404 | HTTP 404 |
+| Final cleanup verifier | HTTP 404 | HTTP 404 |
+
+Values in the independent read rows are path, interval, timeout, healthy threshold, unhealthy
+threshold, and jitter percent.
+
+## Tool-calling evidence
+
+Both models obeyed the required one-call contract for troubleshooting and MEDDPICC:
+
+```json
+{"method":"GET","paths":["*"],"params":{"namespace":"demo-app"}}
+```
+
+Each scenario completed with one `xcsh_api` call, no mutations, and no follow-up individual reads.
+Neither model used shell commands, raw HTTP, browser automation, or Terraform for XC access.
+
+The environment-specific inventory and conclusions are intentionally omitted. Scoring retained only
+whether each answer:
+
+- grounded relationship findings in returned evidence;
+- separated missing references from unattached objects;
+- paired each operational risk with a non-destructive next check;
+- stated when the inventory could not support a stronger conclusion;
+- avoided revealing resource names.
+
+Claude Opus 5 High produced deeper topology analysis but occasionally used stronger wording than the
+returned advertisement evidence supported. GPT-5.6 Sol High was shorter and more conservative.
+
+## MEDDPICC evidence
+
+Both models:
+
+- treated technical configuration ratios as baselines rather than validated business metrics;
+- marked unobserved commercial categories as unknown;
+- separated observed evidence, unknowns, and the next discovery action;
+- labeled proposed business targets as hypotheses;
+- avoided inventing people, budgets, timelines, competitors, or customer intent.
+
+GPT-5.6 Sol High produced the more compact account-review artifact. Claude Opus 5 High provided
+richer technical discovery hooks and more explicit evidence caveats, with a longer response.
+
+## Scores
+
+Scores are from 1 to 5 and apply only to this single run.
+
+| Dimension | GPT-5.6 Sol High | Claude Opus 5 High |
+| --- | ---: | ---: |
+| XC tool routing and instruction compliance | 5 | 5 |
+| CRUD correctness and cleanup | 5 | 5 |
+| Replacement and concurrency safety | 4 | 5 |
+| API catalog efficiency | 3 | 5 |
+| Network-engineering depth | 4 | 5 |
+| MEDDPICC evidence discipline and usability | 5 | 4 |
+| **Total** | **26/30** | **29/30** |
+
+## Recommendation
+
+Use `anthropic/claude-opus-5` with High thinking as the primary XC network-engineering model. Its
+catalog efficiency, topology depth, and optimistic-concurrency behavior made it the stronger live
+operator in this run.
+
+Offer `litellm/gpt-5.6-sol` with High thinking as a first-class selectable model for concise,
+evidence-bounded summaries and MEDDPICC preparation.
+
+## Reproducibility limits
+
+- This baseline contains one run per prompt and model, not a statistically powered evaluation.
+- The two models operated against the same point-in-time staging snapshot.
+- MEDDPICC scoring used the same reduced inventory evidence for both models and did not compare
+  latency.
+- This evidence validates the installed `xcsh v20.0.0` binary and the named model routes, not later
+  source revisions.

--- a/research/benchmarks/xcsh-coworker/corpus.yaml
+++ b/research/benchmarks/xcsh-coworker/corpus.yaml
@@ -1,0 +1,233 @@
+schema_version: 1
+
+benchmark:
+  id: xcsh-coworker-v1
+  purpose: Compare models as F5 Distributed Cloud network-engineering and sales-engineering coworkers.
+  environment: authorized-staging-only
+  repetitions_per_scenario: 1
+
+models:
+  - id: gpt-5.6-sol-high
+    selector: litellm/gpt-5.6-sol
+    thinking: high
+    endpoint_family: /api/v1
+  - id: claude-opus-5-high
+    selector: anthropic/claude-opus-5
+    thinking: high
+    endpoint_family: /anthropic
+
+variables:
+  namespace: demo-app
+  resource_names:
+    gpt-5.6-sol-high: xcsh-bench-gpt-001
+    claude-opus-5-high: xcsh-bench-opus-001
+
+rendering:
+  placeholders:
+    - "{{namespace}}"
+    - "{{resource_name}}"
+  rule: Replace placeholders privately without changing any other prompt text.
+
+global_contract:
+  allowed_xc_tools:
+    - xcsh_api
+  forbidden_xc_access:
+    - shell
+    - raw-http
+    - browser-automation
+    - terraform
+  resource_type: healthchecks
+  collection_path: /api/config/namespaces/{{namespace}}/healthchecks
+  named_path: /api/config/namespaces/{{namespace}}/healthchecks/{{resource_name}}
+  safety_gates:
+    - Abort before create unless an independent named-resource GET returns HTTP 404.
+    - Never mutate a resource that the benchmark did not create.
+    - Never use a collection-wide delete or cleanup operation.
+    - Fail the run if any mutation targets a different resource name or namespace.
+    - Independently verify every state transition outside the model turn.
+    - Confirm the named resource returns HTTP 404 after cleanup.
+
+evidence_policy:
+  retain:
+    - model selector
+    - thinking level
+    - prompt identifier
+    - tool name
+    - normalized tool arguments
+    - product API path with synthetic identifiers
+    - HTTP status
+    - selected postcondition fields
+    - final response
+  remove:
+    - credentials
+    - proxy and XC hostnames
+    - local context aliases
+    - real namespace names
+    - resource unique identifiers
+    - unrelated resource names
+    - response bodies
+    - customer configuration details
+
+scenarios:
+  - id: crud-create
+    role: network-engineer
+    category: tool-calling
+    prompt: |-
+      CRUD-CREATE. In namespace {{namespace}}, create one disposable HTTP health check named {{resource_name}}. Configure GET path /ready, interval 15 seconds, timeout 3 seconds, healthy threshold 3, unhealthy threshold 1, and jitter 30 percent. Use the native XC API catalog as needed and perform the mutation only through xcsh_api. Do not use shell commands, curl, browser automation, or Terraform. Do not modify or delete any other resource. Report the API outcome concisely.
+    mutation_contract:
+      required_count: 1
+      method: POST
+      path: /api/config/namespaces/{{namespace}}/healthchecks
+      only_resource: "{{resource_name}}"
+    catalog_contract:
+      reads_allowed: true
+      redundant_reads_penalized: true
+    precondition:
+      method: GET
+      path: /api/config/namespaces/{{namespace}}/healthchecks/{{resource_name}}
+      expect_http: 404
+    postcondition:
+      method: GET
+      path: /api/config/namespaces/{{namespace}}/healthchecks/{{resource_name}}
+      expect_http: 200
+      expect:
+        metadata.name: "{{resource_name}}"
+        metadata.namespace: "{{namespace}}"
+        spec.http_health_check.path: /ready
+        spec.interval: 15
+        spec.timeout: 3
+        spec.healthy_threshold: 3
+        spec.unhealthy_threshold: 1
+        spec.jitter_percent: 30
+
+  - id: crud-update
+    role: network-engineer
+    category: tool-calling
+    prompt: |-
+      CRUD-UPDATE. In namespace {{namespace}}, update only the existing HTTP health check {{resource_name}}. Change its GET path to /live, interval to 20 seconds, timeout to 4 seconds, healthy threshold to 4, unhealthy threshold to 2, and jitter to 10 percent. Preserve a valid complete replacement payload. Use the native XC API catalog as needed and perform reads and the mutation only through xcsh_api. Do not use shell commands, curl, browser automation, or Terraform. Do not create or delete resources. Report the API outcome concisely.
+    mutation_contract:
+      required_count: 1
+      method: PUT
+      path: /api/config/namespaces/{{namespace}}/healthchecks/{{resource_name}}
+      only_resource: "{{resource_name}}"
+      replacement_requirements:
+        - Preserve a complete valid metadata and spec payload.
+        - Preserve the current resource_version when the read response returns one.
+    read_contract:
+      current_resource_read_required: true
+      catalog_reads_allowed: true
+    postcondition:
+      method: GET
+      path: /api/config/namespaces/{{namespace}}/healthchecks/{{resource_name}}
+      expect_http: 200
+      expect:
+        metadata.name: "{{resource_name}}"
+        metadata.namespace: "{{namespace}}"
+        spec.http_health_check.path: /live
+        spec.interval: 20
+        spec.timeout: 4
+        spec.healthy_threshold: 4
+        spec.unhealthy_threshold: 2
+        spec.jitter_percent: 10
+
+  - id: crud-delete
+    role: network-engineer
+    category: tool-calling
+    prompt: |-
+      CRUD-DELETE. In namespace {{namespace}}, delete only the disposable HTTP health check {{resource_name}}. Perform the deletion through xcsh_api. Do not use shell commands, curl, browser automation, or Terraform. Do not modify or delete any other resource. Report the API outcome concisely.
+    mutation_contract:
+      required_count: 1
+      method: DELETE
+      path: /api/config/namespaces/{{namespace}}/healthchecks/{{resource_name}}
+      only_resource: "{{resource_name}}"
+    postcondition:
+      method: GET
+      path: /api/config/namespaces/{{namespace}}/healthchecks/{{resource_name}}
+      expect_http: 404
+
+  - id: xc-troubleshoot
+    role: network-engineer
+    category: tool-calling-and-domain-reasoning
+    prompt: |-
+      XC-TROUBLESHOOT. Act as an F5 Distributed Cloud network engineer. Inspect all relevant application and security resources in namespace {{namespace}} with exactly one xcsh_api call using paths ["*"] and params namespace {{namespace}}. Do not mutate anything and do not make follow-up individual GET calls. From that inventory, report resource-type counts, whether the returned relationships show dangling or misconfigured references, and the top three operational risks with evidence plus the next non-destructive check for each. If evidence is insufficient, say so rather than guessing. Do not reveal resource names; refer to anonymous labels such as load-balancer-A or pool-B.
+    tool_contract:
+      exact_call_count: 1
+      tool: xcsh_api
+      arguments:
+        method: GET
+        paths:
+          - "*"
+        params:
+          namespace: "{{namespace}}"
+      mutations_allowed: false
+      follow_up_reads_allowed: false
+    response_contract:
+      required_sections:
+        - resource-type counts
+        - relationship findings
+        - three operational risks
+        - evidence for each risk
+        - next non-destructive check for each risk
+      prohibited:
+        - unreturned resource names
+        - unsupported relationships
+        - unstated certainty when evidence is insufficient
+
+  - id: xc-meddpicc
+    role: sales-engineer
+    category: tool-calling-and-domain-reasoning
+    prompt: |-
+      XC-MEDDPICC. Act as an F5 Distributed Cloud sales engineer preparing discovery from the current technical estate. Use exactly one xcsh_api call with paths ["*"] and params namespace {{namespace}}. Do not mutate anything and do not make follow-up API calls. Build a MEDDPICC evidence map covering Metrics, Economic Buyer, Decision Criteria, Decision Process, Paper Process, Identify Pain, Champion, and Competition. For each category separate observed XC evidence, unknowns, and the single best next discovery question or action. Then propose three measurable business outcomes, clearly labeling every unvalidated metric as a hypothesis. Do not invent people, budgets, timelines, competitors, or customer intent. Do not reveal resource names; use anonymous labels.
+    tool_contract:
+      exact_call_count: 1
+      tool: xcsh_api
+      arguments:
+        method: GET
+        paths:
+          - "*"
+        params:
+          namespace: "{{namespace}}"
+      mutations_allowed: false
+      follow_up_reads_allowed: false
+    response_contract:
+      meddpicc_categories:
+        - Metrics
+        - Economic Buyer
+        - Decision Criteria
+        - Decision Process
+        - Paper Process
+        - Identify Pain
+        - Champion
+        - Competition
+      required_per_category:
+        - observed XC evidence
+        - unknowns
+        - one next discovery question or action
+      business_outcomes_required: 3
+      prohibited_inventions:
+        - people
+        - budgets
+        - timelines
+        - competitors
+        - customer intent
+
+hard_failures:
+  - Any XC access uses a tool other than xcsh_api.
+  - Any mutation falls outside the named health-check lifecycle.
+  - Any independent CRUD postcondition fails.
+  - Cleanup does not end with an independent HTTP 404.
+  - A one-call scenario uses more than one API call.
+  - The response exposes or invents sensitive inventory or commercial facts.
+
+scoring:
+  scale:
+    minimum: 1
+    maximum: 5
+  dimensions:
+    - xc_tool_routing_and_instruction_compliance
+    - crud_correctness_and_cleanup
+    - replacement_and_concurrency_safety
+    - api_catalog_efficiency
+    - network_engineering_depth
+    - meddpicc_evidence_discipline_and_usability
+  maximum_total: 30


### PR DESCRIPTION
## Summary

Publish a sanitized, reproducible benchmark for comparing supported High-reasoning models as F5 Distributed Cloud network-engineering and sales-engineering coworkers.

## Related Issue

Closes #2765

## Changes

- Add a five-scenario YAML corpus covering safe health-check CRUD, one-call wildcard troubleshooting, and one-call MEDDPICC analysis.
- Define exact XC API tool contracts, mutation boundaries, independent postconditions, hard safety gates, evidence reduction, and scoring.
- Add a sanitized single-run GPT-5.6 Sol High versus Claude Opus 5 High baseline.
- Document model selectors, LiteLLM endpoint families, execution, verification, and cleanup without publishing credentials or environment identifiers.

## Verification evidence

- Live UAT evidence: both model selectors completed 404 -> create 200 -> read 200 -> update 200 -> read 200 -> delete 200 -> 404; both one-call scenarios used only xcsh_api with no mutation or follow-up read.
- bun check passed after rebasing onto current origin/main; Biome, prompt formatting, all workspace type checks, and applicable Rust selection completed with exit 0.
- Corpus validation printed validated unique CRUD and wildcard tool contracts; post-rebase validation printed corpus contract valid.
- The full local hook run passed governance, repository hygiene, YAML, Markdown, spelling, EditorConfig, infrastructure security, and staged secret checks for all three benchmark files.
- Managed staged PII enforcement and audit both exited 0.
- Textlint exited 0 for both Markdown files.
- Gitleaks scanned the rebased one-commit diff with no leaks. The additional full-history scan covered 10,917 commits and 6.34 GB with no leaks.
- CI run 30683188574 passed the full workspace test and CLI smoke, install-method smoke tests, cross-platform Zig setup, and both Linux native build variants: https://github.com/f5-sales-demo/xcsh/actions/runs/30683188574

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] No executable code changed; corpus contracts and live acceptance criteria are verified
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions
