### PR TITLE
test(coding-agent): use Bun sleep in staging CRUD

### DIFF
--- a/packages/coding-agent/test/e2e/staging-crud.test.ts
+++ b/packages/coding-agent/test/e2e/staging-crud.test.ts
@@ -75,7 +75,7 @@ describe.skipIf(!canRun)("staging CRUD matrix (real F5 XC API)", () => {
 	});
 
 	it("VERIFY-GONE: the resource is no longer retrievable (404)", async () => {
-		await new Promise(r => setTimeout(r, 2000)); // eventual consistency
+		await Bun.sleep(2000); // eventual consistency
 		const { status } = await api("GET", `${hcPath}/${RESOURCE}`);
 		expect(status).toBe(404);
 	});


### PR DESCRIPTION
## Summary

Replace the staging CRUD test callback-based deletion wait with the Bun-native sleep API.

## Related Issue

Closes #2769

## Changes

- Preserve the two-second eventual-consistency delay.
- Remove the Promise and setTimeout wrapper.
- Use await Bun.sleep(2000).

## Verification evidence

- Red: the source contract failed while staging CRUD still used the callback timer anti-pattern.
- Green: the same contract printed staging CRUD timer contract valid.
- With all XCSH_STAGING variables removed, the focused test completed with 0 failures and 6 expected skips.
- bun check passed with Biome, prompt formatting, and all workspace type checks green.
- Managed staged PII enforcement and audit exited 0.
- Staged and one-commit gitleaks scans found no leaks.
- GitHub CI run 30683872550 completed successfully: check, full workspace tests, CLI smoke, install-method smoke, and native builds all passed.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Test-first red/green contract completed; issue acceptance criteria are met
- [x] Verified locally by exercising the focused test path
- [x] CI watched to green (not just queued)
- [x] Follows project conventions
