### PR TITLE
fix(coding-agent): isolate local account containers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Denied local account containers and other operators' homes while preserving full access to the current operator's home ([#2788](https://github.com/f5-sales-demo/xcsh/issues/2788))
+
 ## [20.0.4] - 2026-08-01
 
 ### Fixed

--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -15,9 +15,9 @@ followed symlinks — so how a path is spelled does not change what is reachable
 - Cross-tenant isolation removes the discovery step. The directory containing the session root cannot
   be enumerated, but a sibling path the operator names directly can still be read, written, or entered.
   An explicit read grant, including `--allow-path <dir>`, restores enumeration for that directory.
-- Cross-session stores and data roots remain denied. Another session's transcripts, memories, internal
-  contexts, and temporary working state are not reachable through tools, nor are unrelated data roots
-  and mounted data volumes.
+- Cross-session stores, other operators' accounts, and data roots remain denied. Another session's
+  transcripts, memories, internal contexts, and temporary working state are not reachable through
+  tools, nor are sibling local accounts, unrelated data roots, and mounted data volumes.
 
 The same boundary answers for every tool. `read`, `write`, `grep`, `find`, `python`, and `bash` consult
 the same rules, so changing tools or spelling a path differently does not widen the session.
@@ -51,7 +51,8 @@ spelling may not be caught.
 
 The intended rules are the same ones a confined session has: parent enumeration is refused while named
 operator access remains available, operator-owned home and configuration stay readable and writable,
-and cross-session stores and unrelated data roots stay denied. Ordinary work remains unrestricted.
+and cross-session stores, other operators' accounts, and unrelated data roots stay denied. Ordinary
+work remains unrestricted.
 
 Treat the boundary as a statement of intent rather than a guarantee, and do not go looking for paths
 outside the session directory on the assumption that something would stop you.

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -8,8 +8,8 @@
  *
  * So the fence is gentle. It leaves `/usr`, `/tmp`, package caches, the network and process execution
  * alone. Its cross-tenant courtesy removes the discovery step — enumerating the session root's parent —
- * while keeping named operator access. Explicit data-root and cross-session state denies remain where
- * the model has no legitimate reason to wander (#2554).
+ * while keeping named operator access. Other operators' accounts, explicit data roots and cross-session
+ * state remain denied where the model has no legitimate reason to wander (#2554).
  *
  * Produced declaratively rather than as an ordered rule list, because the two backends disagree about
  * order: seatbelt evaluates rules in sequence with the last match winning, while Landlock only grants
@@ -197,9 +197,8 @@ const OPERATIONAL_ROOT_NAMES = new Set([
  * unforeseen — `/data`, `/scratch`, a bespoke mount.
  */
 const DATA_ROOTS = [
-	// `/Users` and `/home` are deliberately absent: denying the home container denies this operator's own
-	// home with it, which is the whole of #2637. Other accounts are 0700, so the filesystem already refuses
-	// them; the fence is not here to re-implement file permissions.
+	"/Users", // Account containers are denied, then this operator's canonical home is allowed back at
+	"/home", // greater depth. That preserves #2637 without exposing another local account (#2788).
 	"/root", // Linux superuser home: not this operator's account
 	"/Volumes", // macOS mounts. Per-container, not per-child: /Volumes/Macintosh HD resolves to /,
 	"/mnt", // which `tooBroadToDeny` then rejects, and the kernel resolves such a path before any
@@ -481,6 +480,11 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 	}
 
 	if (home !== undefined) {
+		// The account container is a data root, but this operator's whole home belongs to them (#2637).
+		// A deeper full allow preserves their normal filesystem rights while leaving sibling accounts under
+		// the broader deny. Cross-session stores are denied again at still greater depth below.
+		allow.add(home);
+
 		// Granted whether or not they exist yet. `~/.bun` has to be writable *before* the first
 		// `bun install` creates it, so dropping absent caches would break exactly the first run.
 		// Canonicalised when present, so a symlinked cache resolves to its real location.
@@ -505,6 +509,7 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 	// prefix whether or not the path exists; Landlock cannot attach a rule to an absent inode, but its
 	// plan never grants a path `readdir` did not see either, so nothing is lost there.
 	const known = DATA_ROOTS.map(name => canonicalThroughExisting(path.join(fsRoot, path.basename(name))));
+	const accountRoots = new Set(["Users", "home"].map(name => canonicalThroughExisting(path.join(fsRoot, name))));
 	const found = dataRootEntries(fsRoot).map(entry => canonical(entry) ?? entry);
 	// Whole filesystem roots other than the workspace's own — the other Windows drives.
 	//
@@ -520,11 +525,11 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		// e.g. /Volumes/Macintosh HD -> /. Skipped for the whole-root list, per the note above.
 		if (!rootScoped.has(resolved) && tooBroadToDeny(resolved, fsRoot)) continue;
 		if (resolved === fsRoot) continue; // never the root the workspace lives on
-		// Never a directory that CONTAINS home, because denying it denies home (#2637). Removing `/Users`
-		// and `/home` from the static list was not enough: the root enumeration re-adds them, since
-		// `Users` is not an operational name. That is what still refused `~/git/STYLE_GUIDE.md` at the
-		// kernel while `fenceVerdict` said allow — the unit tests use synthetic roots and could not see it.
-		if (home !== undefined && pathIsWithin(resolved, home)) continue;
+		// A directory containing home is normally too broad to deny because it would revoke the operator's
+		// own files (#2637). Account containers are the deliberate exception: they are denied here and the
+		// canonical home allow above wins at greater depth, isolating sibling accounts without hobbling the
+		// operator (#2788).
+		if (home !== undefined && pathIsWithin(resolved, home) && !accountRoots.has(resolved)) continue;
 		// A deny beats an allow at EQUAL depth, so denying a root that IS the workspace or IS something
 		// the operator granted would not be redundant — it would silently revoke the grant. Deeper is
 		// fine and intended: an ancestor deny with the workspace allowed inside it is the normal shape.

--- a/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
+++ b/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
@@ -561,7 +561,7 @@ describe("renderAboutDoc containment section", () => {
 		expect(doc).toContain("readable and writable");
 		expect(doc).toContain("directory containing the session root cannot");
 		expect(doc).toContain("sibling path the operator names directly");
-		expect(doc).toContain("Cross-session stores and data roots remain denied");
+		expect(doc).toContain("Cross-session stores, other operators' accounts, and data roots remain denied");
 		// Ordinary work remains available and an operator can deliberately restore discovery.
 		expect(doc).toContain("--allow-path");
 	});

--- a/packages/coding-agent/test/sandbox-containment-conformance.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-conformance.test.ts
@@ -17,7 +17,10 @@ import { buildContainmentFence, type FenceAccess, fenceVerdict } from "../src/sa
  * than illustrative.
  */
 describe("containment fence: TypeScript and Rust agree", () => {
-	const home = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "xcsh-conf-home-")));
+	const fsRoot = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "xcsh-conf-root-")));
+	const accountRoot = path.join(fsRoot, "Users");
+	const home = path.join(accountRoot, "operator");
+	const otherHome = path.join(accountRoot, "other-account");
 	const workspace = path.join(home, "GIT", "custA");
 	const sibling = path.join(home, "GIT", "custB");
 	const leak = path.join(home, ".xcsh", "agent", "sessions");
@@ -25,14 +28,14 @@ describe("containment fence: TypeScript and Rust agree", () => {
 
 	// Removed after the file runs; both fixtures above leaked into the OS temp dir (#2633).
 	afterAll(() => {
-		for (const dir of [home, shared]) fs.rmSync(dir, { recursive: true, force: true });
+		for (const dir of [fsRoot, shared]) fs.rmSync(dir, { recursive: true, force: true });
 	});
-	for (const dir of [workspace, sibling, leak, path.join(home, ".ssh"), path.join(home, ".bun")]) {
+	for (const dir of [workspace, sibling, otherHome, leak, path.join(home, ".ssh"), path.join(home, ".bun")]) {
 		fs.mkdirSync(dir, { recursive: true });
 	}
 	fs.writeFileSync(path.join(home, ".gitconfig"), "[user]\n");
 
-	const fence = buildContainmentFence({ workspace, home, extraRoots: [shared], leakRoots: [leak] });
+	const fence = buildContainmentFence({ workspace, home, fsRoot, extraRoots: [shared], leakRoots: [leak] });
 	const wire = {
 		allow: [...fence.allow],
 		allowReadOnly: [...fence.allowReadOnly],
@@ -51,6 +54,10 @@ describe("containment fence: TypeScript and Rust agree", () => {
 		path.join(sibling, "secret.env"),
 		path.join(home, "Documents", "tax.pdf"),
 		home,
+		// another local account and its container
+		path.join(otherHome, "workspace", "notes.md"),
+		otherHome,
+		accountRoot,
 		// carve-outs
 		path.join(home, ".bun", "install", "cache", "pkg"),
 		path.join(home, ".cargo", "registry", "x"), // absent on purpose
@@ -98,6 +105,15 @@ describe("containment fence: TypeScript and Rust agree", () => {
 		expect(fencePermits(wire, parent, false, true)).toBe(false);
 		expect(fenceVerdict(fence, sibling, "read")).toBe("allow");
 		expect(fencePermits(wire, sibling, false, false)).toBe(true);
+	});
+
+	it("agrees that the operator's home is allowed inside a denied account container", () => {
+		expect(fenceVerdict(fence, accountRoot, "enumerate")).toBe("deny");
+		expect(fencePermits(wire, accountRoot, false, true)).toBe(false);
+		expect(fenceVerdict(fence, path.join(otherHome, "workspace"), "read")).toBe("deny");
+		expect(fencePermits(wire, path.join(otherHome, "workspace"), false, false)).toBe(false);
+		expect(fenceVerdict(fence, path.join(home, ".zshrc"), "write")).toBe("allow");
+		expect(fencePermits(wire, path.join(home, ".zshrc"), true, false)).toBe(true);
 	});
 
 	it("agrees that an absent fence restricts nothing", () => {

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -918,10 +918,22 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 
 		const fence = buildContainmentFence({ workspace, home, fsRoot });
 
-		// Another account is no longer denied (#2637): the container holding it also holds this operator's
-		// home, and denying it denied `~/git/STYLE_GUIDE.md`. A home directory is 0700, so the filesystem
-		// already refuses it — the fence does not re-implement file permissions.
-		expect(fenceVerdict(fence, path.join(fsRoot, "Users", "otheruser", "customerX"), "read")).toBe("allow");
+		// The account container is denied, with only this operator's canonical home allowed back at greater
+		// depth. This keeps all of the operator-rights fix from #2637 without exposing another local account.
+		const accountRoot = path.join(fsRoot, "Users");
+		const otherHome = path.join(accountRoot, "otheruser");
+		expect(fence.deny).toContain(accountRoot);
+		expect(fence.allow).toContain(home);
+		expect(fenceVerdict(fence, accountRoot, "enumerate")).toBe("deny");
+		for (const access of ["read", "write", "enumerate"] as const) {
+			expect(fenceVerdict(fence, path.join(otherHome, "workspace"), access)).toBe("deny");
+			expect(fenceVerdict(fence, path.join(home, ".config", "tool"), access)).toBe("allow");
+		}
+
+		// The operator can still override the courtesy with an explicit grant.
+		const granted = buildContainmentFence({ workspace, home, fsRoot, extraRoots: [otherHome] });
+		expect(fenceVerdict(granted, path.join(otherHome, "named-file"), "read")).toBe("allow");
+		expect(fenceVerdict(granted, path.join(otherHome, "named-file"), "write")).toBe("allow");
 
 		// The unrelated data roots, still denied — these were measured reachable before #2624.
 		for (const leak of [
@@ -1000,9 +1012,13 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 	it("denies the real home container on this machine and no operational root", () => {
 		const fence = buildContainmentFence({ workspace: fs.realpathSync(process.cwd()) });
 
-		// The home container is NOT denied since #2637 — denying it denies the operator's own home, which
-		// is what refused `~/git/STYLE_GUIDE.md` at the kernel while `fenceVerdict` said allow.
-		expect(fence.deny).not.toContain(process.platform === "darwin" ? "/Users" : "/home");
+		const accountRoot = path.join(
+			path.parse(fs.realpathSync(process.cwd())).root,
+			process.platform === "linux" ? "home" : "Users",
+		);
+		expect(fence.deny).toContain(accountRoot);
+		expect(fence.allow).toContain(fs.realpathSync(os.homedir()));
+		expect(fenceVerdict(fence, fs.realpathSync(os.homedir()), "write")).toBe("allow");
 		// Only what this platform actually has: `/private` is macOS-only, and `realpathSync` on an absent
 		// path throws — which failed the Linux runner while passing locally. The file already warns about
 		// exactly this trap two describes up, and I walked into it anyway.

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -214,14 +214,37 @@ describe("two-customer isolation, enforced in the shell", () => {
 	});
 });
 
-/**
- * Other operators' accounts are no longer fenced (#2637).
- *
- * #2624 denied `/Users` and `/home` wholesale and asserted here that listing them failed. That deny took
- * this operator's own home with it, which is what refused `~/git/STYLE_GUIDE.md`, so #2637 removed it. A
- * home directory is 0700 and the filesystem already refuses another account; the fence is not here to
- * re-implement file permissions, and this suite should not claim a protection it no longer provides.
- *
- * What replaced the assertion is the one below it: the customer container inside home, which is the
- * surface that actually matters and is asserted through the kernel above.
- */
+describe("local account isolation, enforced in the shell", () => {
+	it("denies another synthetic account while preserving the operator's home", async () => {
+		const fsRoot = path.join(tmp.absolute(), "account-fixture");
+		const accountRoot = path.join(fsRoot, "Users");
+		const operatorHome = path.join(accountRoot, "operator");
+		const otherHome = path.join(accountRoot, "other-account");
+		const workspace = path.join(operatorHome, "workspace");
+		fs.mkdirSync(workspace, { recursive: true });
+		fs.mkdirSync(otherHome, { recursive: true });
+		fs.writeFileSync(path.join(otherHome, "synthetic.txt"), "synthetic");
+
+		const fence = buildContainmentFence({ workspace, home: operatorHome, fsRoot });
+		const wire = {
+			allow: [...fence.allow],
+			allowReadOnly: [...fence.allowReadOnly],
+			allowWriteOnly: [...fence.allowWriteOnly],
+			deny: [...fence.deny],
+			denyEnumerate: [...fence.denyEnumerate],
+		};
+		const run = async (command: string) => {
+			const result = (await executeShell({ command, cwd: workspace, fence: wire }, () => {})) as {
+				exitCode?: number;
+			};
+			return result.exitCode ?? -1;
+		};
+
+		expect(await run(`printf operator > ${JSON.stringify(path.join(operatorHome, ".zshrc"))}`)).toBe(0);
+		expect(fs.readFileSync(path.join(operatorHome, ".zshrc"), "utf8")).toBe("operator");
+		if (containmentStatus(true).osEnforced) {
+			expect(await run(`ls ${JSON.stringify(accountRoot)} > /dev/null`)).not.toBe(0);
+			expect(await run(`cd ${JSON.stringify(otherHome)}`)).not.toBe(0);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- deny `/Users` and `/home` as account containers
- allow the current operator's canonical home back at greater depth
- preserve explicit grants, named workspace-sibling access, and deeper cross-session denies
- restore containment documentation for other operators' accounts

## Verification

- `bun test packages/coding-agent/test/sandbox-containment.test.ts packages/coding-agent/test/sandbox-containment-conformance.test.ts packages/coding-agent/test/sandbox-isolation.test.ts` (74 passed)
- `bun check:ts`
- `bun run pii:gate`
- live Seatbelt test uses synthetic account fixtures only

Fixes #2788