### PR TITLE
feat: verify spec and provider delivery chain

### DIFF
--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -5,115 +5,778 @@ on:
   repository_dispatch:
     types: [enriched-specs-updated]
 
+concurrency:
+  group: api-spec-update
+  cancel-in-progress: false
+
+permissions: {}
+
 jobs:
   update-api-specs:
+    name: Deliver Published API Specifications
     runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+    timeout-minutes: 360
+    permissions: {}
     steps:
-      - uses: actions/checkout@v6
+      - name: Check out fresh main
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
+          ref: main
 
       - name: Setup Bun 1.3
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3"
 
+      - name: Validate dispatch identity
+        id: delivery
+        run: bun scripts/api-spec-delivery.ts validate-event
+
+      - name: Verify exact published release
+        id: source_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: bun scripts/api-spec-delivery.ts verify-release
+
+      - name: Check durable delivery ledger on main
+        id: main_delivery
+        env:
+          DELIVERY_LEDGER_FILE: ${{ steps.delivery.outputs.ledger_path }}
+          DELIVERY_PUBLICATION_LEDGER_FILE: ${{ steps.delivery.outputs.publication_ledger_path }}
+        run: bun scripts/api-spec-delivery.ts check-ledger
+
+      - name: Check pending delivery on main
+        if: steps.main_delivery.outputs.applied != 'true'
+        id: main_pending
+        env:
+          DELIVERY_PENDING_FILE: ${{ steps.delivery.outputs.pending_path }}
+        run: bun scripts/api-spec-delivery.ts check-pending
+
+      - name: Prepare deterministic delivery branch
+        if: steps.main_delivery.outputs.applied != 'true' && steps.main_pending.outputs.pending != 'true'
+        id: branch
+        env:
+          BRANCH: ${{ steps.delivery.outputs.branch }}
+          PENDING_PATH: ${{ steps.delivery.outputs.pending_path }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch --no-tags origin "$BRANCH:refs/remotes/origin/$BRANCH"
+            BRANCH_PENDING="$RUNNER_TEMP/api-spec-delivery-pending.json"
+            git show "origin/$BRANCH:$PENDING_PATH" > "$BRANCH_PENDING" || {
+              echo "::error::Existing delivery branch has no pending identity marker"
+              exit 1
+            }
+            export DELIVERY_PENDING_FILE="$BRANCH_PENDING"
+            bun scripts/api-spec-delivery.ts verify-pending
+
+            ALLOWED_PATHS='^(packages/coding-agent/src/internal-urls/(api-spec-index|api-catalog-index|terraform-index)\.generated\.ts|packages/resource-management/src/defaults-metadata\.generated\.ts|tools/(spec-delivery-pending|spec-release)\.json)$'
+            UNEXPECTED_PATHS=$(git diff --name-only "origin/main...origin/$BRANCH" | grep -Ev "$ALLOWED_PATHS" || true)
+            if [ -n "$UNEXPECTED_PATHS" ]; then
+              echo "::error::Existing delivery branch contains unexpected paths"
+              printf '%s\n' "$UNEXPECTED_PATHS"
+              exit 1
+            fi
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+            echo "resumed=true" >> "$GITHUB_OUTPUT"
+          else
+            git checkout -B "$BRANCH" origin/main
+            echo "resumed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve exact published provider release
+        if: steps.main_delivery.outputs.applied != 'true'
+        id: provider_release
+        env:
+          EXPECTED_COMMIT: ${{ steps.delivery.outputs.target_commit }}
+          EXPECTED_DELIVERY_ID: ${{ steps.delivery.outputs.provider_delivery_id }}
+          EXPECTED_SPEC_TAG: ${{ steps.delivery.outputs.release_tag }}
+          EXPECTED_SPEC_VERSION: ${{ steps.delivery.outputs.version }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          SOURCE_PIN_FILE: ${{ steps.source_release.outputs.pin_path }}
+        run: |
+          set -euo pipefail
+          PROVIDER_REPOSITORY=f5-sales-demo/terraform-provider-xcsh
+          [[ "$EXPECTED_DELIVERY_ID" =~ ^[0-9a-f]{64}$ ]] || exit 1
+          [[ "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]] || exit 1
+          canonical_id() {
+            local version=$1 tag=$2 commit=$3 canonical
+            canonical=$(jq -cnS \
+              --arg commit "$commit" \
+              --arg event_type enriched-specs-updated \
+              --arg source f5-sales-demo/api-specs-enriched \
+              --arg tag "$tag" \
+              --arg target "$PROVIDER_REPOSITORY" \
+              --arg version "$version" \
+              '{commit:$commit,event_type:$event_type,source:$source,tag:$tag,target:$target,version:$version}')
+            printf '%s' "$canonical" | shasum -a 256 | awk '{print $1}'
+          }
+          for attempt in $(seq 1 120); do
+            PROVIDER_MAIN_SHA=$(gh api "repos/$PROVIDER_REPOSITORY/git/ref/heads/main" --jq '.object.sha' 2>/dev/null || true)
+            if [[ ! "$PROVIDER_MAIN_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              sleep 30
+              continue
+            fi
+            PROVIDER_LEDGER=$(gh api \
+              "repos/$PROVIDER_REPOSITORY/contents/tools/spec-deliveries.json?ref=$PROVIDER_MAIN_SHA" \
+              -H "Accept: application/vnd.github.raw+json" 2>/dev/null || true)
+            PROVIDER_EVIDENCE=$(gh api \
+              "repos/$PROVIDER_REPOSITORY/contents/tools/provider-publication-receipts.json?ref=$PROVIDER_MAIN_SHA" \
+              -H "Accept: application/vnd.github.raw+json" 2>/dev/null || true)
+            if [ -z "$PROVIDER_LEDGER" ] || [ -z "$PROVIDER_EVIDENCE" ]; then
+              sleep 30
+              continue
+            fi
+            printf '%s' "$PROVIDER_LEDGER" | jq -e '
+              type == "object" and (keys | sort) == ["deliveries", "version"] and
+              .version == 1 and (.deliveries | type == "object")
+            ' >/dev/null || { echo "::error::Provider delivery ledger is malformed"; exit 1; }
+            printf '%s' "$PROVIDER_EVIDENCE" | jq -e '
+              type == "object" and (keys | sort) == ["receipts", "version"] and
+              .version == 1 and (.receipts | type == "object")
+            ' >/dev/null || { echo "::error::Provider publication evidence ledger is malformed"; exit 1; }
+            [ "$(printf '%s' "$PROVIDER_LEDGER" | jq -cS '.deliveries | keys')" = \
+              "$(printf '%s' "$PROVIDER_EVIDENCE" | jq -cS '.receipts | keys')" ] || {
+              echo "::error::Provider common and detailed ledgers have different delivery keys"
+              exit 1
+            }
+            while IFS= read -r LEDGER_ENTRY; do
+              LEDGER_KEY=$(printf '%s' "$LEDGER_ENTRY" | jq -r '.key')
+              printf '%s' "$LEDGER_ENTRY" | jq -e '
+                (.value | type == "object") and
+                (.value | keys | sort) == ["release_tag", "target_commit", "version"] and
+                (.value.version | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) and
+                .value.release_tag == ("v" + .value.version) and
+                (.value.target_commit | test("^[0-9a-f]{40}$"))
+              ' >/dev/null || { echo "::error::Provider delivery ledger contains a malformed entry"; exit 1; }
+              CANONICAL_KEY=$(canonical_id \
+                "$(printf '%s' "$LEDGER_ENTRY" | jq -r '.value.version')" \
+                "$(printf '%s' "$LEDGER_ENTRY" | jq -r '.value.release_tag')" \
+                "$(printf '%s' "$LEDGER_ENTRY" | jq -r '.value.target_commit')")
+              [ "$LEDGER_KEY" = "$CANONICAL_KEY" ] || {
+                echo "::error::Provider delivery ledger contains a noncanonical key"
+                exit 1
+              }
+            done < <(printf '%s' "$PROVIDER_LEDGER" | jq -c '.deliveries | to_entries[]')
+            while IFS= read -r RECEIPT_ENTRY; do
+              RECEIPT_KEY=$(printf '%s' "$RECEIPT_ENTRY" | jq -r '.key')
+              COMMON_ENTRY=$(printf '%s' "$PROVIDER_LEDGER" | jq -c --arg id "$RECEIPT_KEY" '.deliveries[$id]')
+              printf '%s' "$RECEIPT_ENTRY" | jq -e --argjson common "$COMMON_ENTRY" '
+                (.value | type == "object") and
+                (.value | keys | sort) == ["delivery", "publication"] and
+                .value.delivery == $common and
+                (.value.publication | type == "object") and
+                (.value.publication | keys | sort) == ["assets", "commit", "spec_release_sha256", "tag", "version"] and
+                (.value.publication.commit | test("^[0-9a-f]{40}$")) and
+                (.value.publication.spec_release_sha256 | test("^[0-9a-f]{64}$")) and
+                .value.publication.tag == ("v" + .value.publication.version) and
+                (.value.publication.assets | keys | sort) == [
+                  ("mcp-data-" + .value.publication.version + ".tar.gz"),
+                  ("terraform-provider-xcsh_" + .value.publication.version + "_SHA256SUMS"),
+                  ("terraform-provider-xcsh_" + .value.publication.version + "_SHA256SUMS.sig"),
+                  ("terraform-provider-xcsh_" + .value.publication.version + "_darwin_amd64.zip"),
+                  ("terraform-provider-xcsh_" + .value.publication.version + "_darwin_arm64.zip"),
+                  ("terraform-provider-xcsh_" + .value.publication.version + "_freebsd_386.zip"),
+                  ("terraform-provider-xcsh_" + .value.publication.version + "_freebsd_amd64.zip"),
+                  ("terraform-provider-xcsh_" + .value.publication.version + "_linux_386.zip"),
+                  ("terraform-provider-xcsh_" + .value.publication.version + "_linux_amd64.zip"),
+                  ("terraform-provider-xcsh_" + .value.publication.version + "_linux_arm.zip"),
+                  ("terraform-provider-xcsh_" + .value.publication.version + "_linux_arm64.zip"),
+                  ("terraform-provider-xcsh_" + .value.publication.version + "_manifest.json"),
+                  ("terraform-provider-xcsh_" + .value.publication.version + "_windows_386.zip"),
+                  ("terraform-provider-xcsh_" + .value.publication.version + "_windows_amd64.zip")
+                ] and
+                ([.value.publication.assets[] | test("^[0-9a-f]{64}$")] | all)
+              ' >/dev/null || { echo "::error::Provider publication ledger contains malformed evidence"; exit 1; }
+            done < <(printf '%s' "$PROVIDER_EVIDENCE" | jq -c '.receipts | to_entries[]')
+
+            ENTRY=$(printf '%s' "$PROVIDER_LEDGER" | jq -c --arg id "$EXPECTED_DELIVERY_ID" '.deliveries[$id] // empty')
+            if [ -n "$ENTRY" ]; then
+              printf '%s' "$ENTRY" | jq -e --arg tag "$EXPECTED_SPEC_TAG" --arg commit "$EXPECTED_COMMIT" \
+                --arg version "$EXPECTED_SPEC_VERSION" \
+                '. == {release_tag:$tag,target_commit:$commit,version:$version}' >/dev/null || {
+                echo "::error::Provider ledger entry disagrees with the dispatched identity"
+                exit 1
+              }
+              DELIVERY_EVIDENCE=$(printf '%s' "$PROVIDER_EVIDENCE" | jq -c --arg id "$EXPECTED_DELIVERY_ID" '.receipts[$id]')
+              EVIDENCE=$(printf '%s' "$DELIVERY_EVIDENCE" | jq -c '.publication')
+                PROVIDER_TAG=$(printf '%s' "$EVIDENCE" | jq -r '.tag')
+                PROVIDER_COMMIT=$(printf '%s' "$EVIDENCE" | jq -r '.commit')
+                PROVIDER_TAG_COMMIT=$(gh api \
+                  "repos/$PROVIDER_REPOSITORY/commits/$PROVIDER_TAG" --jq '.sha')
+                [ "$PROVIDER_TAG_COMMIT" = "$PROVIDER_COMMIT" ] || {
+                  echo "::error::Provider tag no longer identifies its receipted commit"
+                  exit 1
+                }
+                PROVIDER_RELEASE=$(gh api \
+                  "repos/$PROVIDER_REPOSITORY/releases/tags/$PROVIDER_TAG")
+                printf '%s' "$PROVIDER_RELEASE" | jq -e --arg tag "$PROVIDER_TAG" '
+                  .tag_name == $tag and .draft == false and .prerelease == false and
+                  .immutable == true and (.assets | type == "array")
+                ' >/dev/null || {
+                  echo "::error::Provider release is absent or not final"
+                  exit 1
+                }
+                RECEIPTS=$(printf '%s' "$PROVIDER_RELEASE" | jq -r '.body // ""' \
+                  | sed -n 's/^<!-- provider-publication-receipt:\(.*\) -->$/\1/p')
+                [ "$(printf '%s\n' "$RECEIPTS" | awk 'NF { count++ } END { print count + 0 }')" -eq 1 ] || {
+                  echo "::error::Provider release does not contain exactly one publication receipt"
+                  exit 1
+                }
+                [ "$(printf '%s' "$RECEIPTS" | jq -cS .)" = "$(printf '%s' "$EVIDENCE" | jq -cS .)" ] || {
+                  echo "::error::Provider release receipt differs from durable publication evidence"
+                  exit 1
+                }
+                RELEASE_ASSETS=$(printf '%s' "$PROVIDER_RELEASE" | jq -r '.assets[].name' | sort)
+                EVIDENCE_ASSETS=$(printf '%s' "$EVIDENCE" | jq -r '.assets | keys[]' | sort)
+                [ "$RELEASE_ASSETS" = "$EVIDENCE_ASSETS" ] || {
+                  echo "::error::Provider release asset set differs from its publication evidence"
+                  exit 1
+                }
+                while IFS= read -r ASSET; do
+                  API_DIGEST=$(printf '%s' "$PROVIDER_RELEASE" | jq -er --arg name "$ASSET" '
+                    [.assets[] | select(.name == $name)] |
+                    if length == 1 then .[0].digest else empty end')
+                  RECEIPT_DIGEST=$(printf '%s' "$EVIDENCE" | jq -r --arg name "$ASSET" '.assets[$name]')
+                  [ "$API_DIGEST" = "sha256:$RECEIPT_DIGEST" ] || {
+                    echo "::error::Provider release bytes differ from publication evidence for $ASSET"
+                    exit 1
+                  }
+                done <<< "$RELEASE_ASSETS"
+                gh api \
+                  "repos/$PROVIDER_REPOSITORY/contents/tools/spec-release.json?ref=$PROVIDER_COMMIT" \
+                  -H "Accept: application/vnd.github.raw+json" \
+                  > "$RUNNER_TEMP/provider-spec-release.json"
+                PROVIDER_PIN_SHA=$(shasum -a 256 "$RUNNER_TEMP/provider-spec-release.json" | awk '{print $1}')
+                [ "$PROVIDER_PIN_SHA" = "$(printf '%s' "$EVIDENCE" | jq -r '.spec_release_sha256')" ] || {
+                  echo "::error::Provider release spec pin differs from publication evidence"
+                  exit 1
+                }
+                jq -e --arg tag "$EXPECTED_SPEC_TAG" --arg commit "$EXPECTED_COMMIT" \
+                  --arg version "$EXPECTED_SPEC_VERSION" '
+                  type == "object" and
+                  (keys | sort) == ["assets", "release_tag", "target_commit", "version"] and
+                  .release_tag == $tag and .target_commit == $commit and .version == $version and
+                  (.assets | keys | sort) == [
+                    "api-catalog.json", ("f5xc-api-specs-" + $tag + ".zip"),
+                    "index.json", "minimal-export-defaults.json", "openapi.json"
+                  ] and ([.assets[] | test("^[0-9a-f]{64}$")] | all)
+                ' "$RUNNER_TEMP/provider-spec-release.json" >/dev/null || {
+                  echo "::error::Provider release carries a malformed or mismatched spec pin"
+                  exit 1
+                }
+                [ "$(jq -cS . "$RUNNER_TEMP/provider-spec-release.json")" = "$(jq -cS . "$SOURCE_PIN_FILE")" ] || {
+                  echo "::error::Provider release consumed different spec bytes from this receiver"
+                  exit 1
+                }
+                SPEC_MARKER=$(gh api \
+                  "repos/$PROVIDER_REPOSITORY/contents/tools/spec-version.txt?ref=$PROVIDER_COMMIT" \
+                  -H "Accept: application/vnd.github.raw+json")
+                [ "${SPEC_MARKER//$'\n'/}" = "$EXPECTED_SPEC_TAG" ] || {
+                  echo "::error::Provider publication evidence names another spec release"
+                  exit 1
+                }
+                echo "::notice::Provider delivery is published in immutable release $PROVIDER_TAG"
+                echo "provider_commit=$PROVIDER_COMMIT" >> "$GITHUB_OUTPUT"
+                echo "provider_tag=$PROVIDER_TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+            fi
+
+            CONFLICT=$(printf '%s' "$PROVIDER_LEDGER" | jq -r --arg tag "$EXPECTED_SPEC_TAG" \
+              '[.deliveries | to_entries[] | select(.value.release_tag == $tag)][0].key // empty')
+            if [ -n "$CONFLICT" ]; then
+              echo "::error::Provider applied the spec tag under a different delivery identity"
+              exit 1
+            fi
+            if [ $((attempt % 10)) -eq 0 ]; then
+              echo "::notice::Still waiting for provider post-publication acknowledgment"
+            fi
+            sleep 30
+          done
+          echo "::error::Timed out waiting for the exact provider delivery to publish"
+          exit 1
+
       - name: Cache bun dependencies
+        if: steps.main_delivery.outputs.applied != 'true'
         uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
 
-      - run: bun install --frozen-lockfile
+      - name: Install dependencies
+        if: steps.main_delivery.outputs.applied != 'true'
+        run: bun install --frozen-lockfile
 
-      - name: Log dispatch payload
-        env:
-          PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
-          PAYLOAD_SOURCE: ${{ github.event.client_payload.trigger_source }}
-        run: |
-          echo "::notice::Received enriched-specs-updated dispatch"
-          echo "Upstream version: ${PAYLOAD_VERSION:-unknown}"
-          echo "Trigger source: ${PAYLOAD_SOURCE:-unknown}"
-
-      - name: Remove stale generated files so the script downloads fresh specs
+      - name: Remove stale generated files
+        if: steps.main_delivery.outputs.applied != 'true'
         run: |
           rm -f packages/coding-agent/src/internal-urls/api-spec-index.generated.ts
           rm -f packages/coding-agent/src/internal-urls/api-catalog-index.generated.ts
           rm -f packages/coding-agent/src/internal-urls/terraform-index.generated.ts
           rm -f packages/resource-management/src/defaults-metadata.generated.ts
 
-      - name: Regenerate API spec index from latest release
+      - name: Generate exact API spec and catalog indexes
+        if: steps.main_delivery.outputs.applied != 'true'
         working-directory: packages/coding-agent
+        env:
+          API_SPECS_TAG: ${{ steps.delivery.outputs.release_tag }}
+          API_SPECS_VERSION: ${{ steps.delivery.outputs.version }}
+          API_SPECS_BUNDLE_SHA256: ${{ steps.source_release.outputs.bundle_sha256 }}
+          API_SPECS_CATALOG_SHA256: ${{ steps.source_release.outputs.catalog_sha256 }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: bun run generate-api-spec-index
 
-      - name: Regenerate Terraform index from latest release
+      - name: Generate Terraform index
+        if: steps.main_delivery.outputs.applied != 'true'
         working-directory: packages/coding-agent
+        env:
+          API_SPECS_TAG: ${{ steps.delivery.outputs.release_tag }}
+          API_SPECS_VERSION: ${{ steps.delivery.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          TERRAFORM_PROVIDER_COMMIT: ${{ steps.provider_release.outputs.provider_commit }}
+          TERRAFORM_PROVIDER_TAG: ${{ steps.provider_release.outputs.provider_tag }}
         run: bun run generate-terraform-index
 
-      - name: Regenerate minimum-settings defaults table from latest release
+      - name: Generate exact minimum-settings defaults table
+        if: steps.main_delivery.outputs.applied != 'true'
         working-directory: packages/resource-management
+        env:
+          API_SPECS_TAG: ${{ steps.delivery.outputs.release_tag }}
+          API_SPECS_VERSION: ${{ steps.delivery.outputs.version }}
+          API_SPECS_DEFAULTS_SHA256: ${{ steps.source_release.outputs.defaults_sha256 }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: bun run generate-defaults
 
-      - name: Verify generated files exist
-        working-directory: packages/coding-agent
-        run: |
-          test -f src/internal-urls/api-spec-index.generated.ts
-          test -f src/internal-urls/api-catalog-index.generated.ts
-          test -f src/internal-urls/terraform-index.generated.ts
-          test -f ../resource-management/src/defaults-metadata.generated.ts
+      - name: Record exact generated delivery attestation
+        if: steps.main_delivery.outputs.applied != 'true' && steps.main_pending.outputs.pending != 'true'
+        env:
+          PROVIDER_COMMIT: ${{ steps.provider_release.outputs.provider_commit }}
+          PROVIDER_TAG: ${{ steps.provider_release.outputs.provider_tag }}
+          SOURCE_RELEASE_PIN_FILE: ${{ steps.source_release.outputs.pin_path }}
+        run: bun scripts/api-spec-delivery.ts record-pending
 
-      - name: Check for changes
-        id: changes
-        run: |
-          if git diff --quiet; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No changes detected — specs already up to date"
-          else
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            SPEC_VERSION=$(grep 'API_SPEC_VERSION' packages/coding-agent/src/internal-urls/api-spec-index.generated.ts | grep -o '"[^"]*"' | tr -d '"')
-            echo "spec_version=${SPEC_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "::notice::Specs updated to ${SPEC_VERSION}"
-          fi
+      - name: Verify exact regenerated delivery bytes
+        if: steps.main_delivery.outputs.applied != 'true'
+        env:
+          PROVIDER_COMMIT: ${{ steps.provider_release.outputs.provider_commit }}
+          PROVIDER_TAG: ${{ steps.provider_release.outputs.provider_tag }}
+        run: bun scripts/api-spec-delivery.ts verify-generated
 
-      - name: Configure git
-        if: steps.changes.outputs.has_changes == 'true'
+      - name: Commit and push generated delivery
+        if: steps.main_delivery.outputs.applied != 'true' && steps.main_pending.outputs.pending != 'true'
+        env:
+          BRANCH: ${{ steps.delivery.outputs.branch }}
+          SPEC_VERSION: ${{ steps.delivery.outputs.version }}
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Create issue and PR with updated specs
-        if: steps.changes.outputs.has_changes == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          SPEC_VERSION: ${{ steps.changes.outputs.spec_version }}
-        run: |
-          BRANCH="chore/api-specs-${SPEC_VERSION}"
-          git checkout -b "$BRANCH"
           git add -f packages/coding-agent/src/internal-urls/api-spec-index.generated.ts
           git add -f packages/coding-agent/src/internal-urls/api-catalog-index.generated.ts
+          git add -f packages/coding-agent/src/internal-urls/terraform-index.generated.ts
           git add -f packages/resource-management/src/defaults-metadata.generated.ts
-          # fix: (not chore:) so the embedded-spec/defaults refresh triggers an
-          # auto-release and publishes @f5-sales-demo/pi-resource-management with
-          # the fresh defaults table — otherwise consumers stay stale (auto-release
-          # in ci.yml skips chore:). The squash-merge commit uses this message.
-          git commit -m "fix(coding-agent): update embedded API specs to ${SPEC_VERSION}"
-          git push origin "$BRANCH"
-          ISSUE_URL=$(gh issue create \
-            --title "chore: update embedded API specs to ${SPEC_VERSION}" \
-            --body "Automated update triggered by upstream api-specs-enriched release to ${SPEC_VERSION}.")
-          ISSUE_NUM=$(echo "$ISSUE_URL" | grep -o '[0-9]*$')
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "fix(coding-agent): update embedded API specs to ${SPEC_VERSION}" \
-            --body "Automated update triggered by upstream api-specs-enriched release.
+          git add tools/spec-release.json
+          git add tools/spec-delivery-pending.json
+          if git diff --cached --quiet; then
+            echo "::notice::Resumed delivery already has the exact regenerated bytes"
+          else
+            git commit -m "fix(coding-agent): update embedded API specs to $SPEC_VERSION"
+            git push --set-upstream origin "$BRANCH"
+          fi
 
-          This PR updates the embedded API spec index and catalog to ${SPEC_VERSION}.
+      - name: Create or resume generated-artifact pull request
+        if: steps.main_delivery.outputs.applied != 'true'
+        id: generated_pr
+        env:
+          BRANCH: ${{ steps.delivery.outputs.branch }}
+          DELIVERY_ID: ${{ steps.delivery.outputs.delivery_id }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          SPEC_VERSION: ${{ steps.delivery.outputs.version }}
+        run: |
+          set -euo pipefail
+          PR_JSON=$(gh pr list --head "$BRANCH" --state all --limit 10 --json number,state)
+          PR_NUMBER=$(printf '%s' "$PR_JSON" | jq -r '.[0].number // empty')
+          PR_STATE=$(printf '%s' "$PR_JSON" | jq -r '.[0].state // empty')
 
-          Closes #${ISSUE_NUM}"
-          gh pr merge "$BRANCH" --squash --auto --delete-branch
+          if [ -n "$PR_NUMBER" ]; then
+            if [ "$PR_STATE" = "CLOSED" ]; then
+              gh pr reopen "$PR_NUMBER"
+              PR_STATE=OPEN
+            fi
+          else
+            DELIVERY_PREFIX=${DELIVERY_ID:0:12}
+            ISSUE_TITLE="chore: generate API spec delivery $DELIVERY_PREFIX"
+            ISSUE_JSON=$(gh issue list --state all --search "$ISSUE_TITLE in:title" --limit 100 --json number,state,title)
+            ISSUE_NUMBER=$(printf '%s' "$ISSUE_JSON" | jq -r --arg title "$ISSUE_TITLE" \
+              '[.[] | select(.title == $title)][0].number // empty')
+            ISSUE_STATE=$(printf '%s' "$ISSUE_JSON" | jq -r --arg title "$ISSUE_TITLE" \
+              '[.[] | select(.title == $title)][0].state // empty')
+            if [ -z "$ISSUE_NUMBER" ]; then
+              ISSUE_URL=$(gh issue create \
+                --title "$ISSUE_TITLE" \
+                --body "Track exact artifact generation for api-specs-enriched delivery $DELIVERY_PREFIX at v$SPEC_VERSION.")
+              ISSUE_NUMBER=${ISSUE_URL##*/}
+            elif [ "$ISSUE_STATE" = "CLOSED" ]; then
+              gh issue reopen "$ISSUE_NUMBER"
+            fi
+
+            PR_URL=$(gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "fix(coding-agent): update embedded API specs to $SPEC_VERSION" \
+              --body "Automated exact-tag generation from api-specs-enriched v$SPEC_VERSION.
+
+          This PR records a pending delivery marker. It does not acknowledge application; the durable ledger is updated only after the resulting xcsh release is published and verified.
+
+          Closes #$ISSUE_NUMBER")
+            PR_NUMBER=${PR_URL##*/}
+            PR_STATE=OPEN
+          fi
+
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || {
+            echo "::error::Could not resolve the generated-artifact PR number"
+            exit 1
+          }
+          if [ "$PR_STATE" != "MERGED" ]; then
+            gh pr merge "$PR_NUMBER" --squash --auto
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for generated artifacts to merge
+        if: steps.main_delivery.outputs.applied != 'true'
+        id: generated_merge
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          PR_NUMBER: ${{ steps.generated_pr.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || exit 1
+          for attempt in $(seq 1 240); do
+            PR_JSON=$(gh pr view "$PR_NUMBER" --json state,mergeCommit)
+            PR_STATE=$(printf '%s' "$PR_JSON" | jq -r '.state')
+            if [ "$PR_STATE" = "MERGED" ]; then
+              MERGE_SHA=$(printf '%s' "$PR_JSON" | jq -r '.mergeCommit.oid // empty')
+              [[ "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+                echo "::error::Merged delivery PR has no full merge commit SHA"
+                exit 1
+              }
+              echo "merge_sha=$MERGE_SHA" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$PR_STATE" = "CLOSED" ]; then
+              echo "::error::Generated-artifact PR closed without merging"
+              exit 1
+            fi
+            if [ $((attempt % 20)) -eq 0 ]; then
+              echo "::notice::Still waiting for generated-artifact PR $PR_NUMBER to merge"
+            fi
+            sleep 30
+          done
+          echo "::error::Timed out waiting for generated-artifact PR to merge"
+          exit 1
+
+      - name: Verify post-merge release publication
+        if: steps.main_delivery.outputs.applied != 'true'
+        id: publication
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          MERGE_SHA: ${{ steps.generated_merge.outputs.merge_sha }}
+          PENDING_PATH: ${{ steps.delivery.outputs.pending_path }}
+          PROVIDER_COMMIT: ${{ steps.provider_release.outputs.provider_commit }}
+          PROVIDER_TAG: ${{ steps.provider_release.outputs.provider_tag }}
+        run: |
+          set -euo pipefail
+          [[ "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]] || exit 1
+          for attempt in $(seq 1 240); do
+            while IFS= read -r TAG; do
+              [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+              TAG_REF=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" 2>/dev/null || true)
+              TAG_SHA=$(printf '%s' "$TAG_REF" | jq -r 'select(.object.type == "commit") | .object.sha // empty')
+              [[ "$TAG_SHA" =~ ^[0-9a-f]{40}$ ]] || continue
+              ANCESTRY=$(gh api "repos/$GITHUB_REPOSITORY/compare/$MERGE_SHA...$TAG_SHA" --jq '.status' 2>/dev/null || true)
+              if [ "$ANCESTRY" != "ahead" ] && [ "$ANCESTRY" != "identical" ]; then
+                continue
+              fi
+
+              RUN_JSON=$(gh run list --workflow ci.yml --event push --limit 100 \
+                --json conclusion,headBranch,headSha,status)
+              RUN_STATUS=$(printf '%s' "$RUN_JSON" | jq -r --arg tag "$TAG" --arg sha "$TAG_SHA" \
+                '[.[] | select(.headBranch == $tag and .headSha == $sha)][0].status // empty')
+              RUN_CONCLUSION=$(printf '%s' "$RUN_JSON" | jq -r --arg tag "$TAG" --arg sha "$TAG_SHA" \
+                '[.[] | select(.headBranch == $tag and .headSha == $sha)][0].conclusion // empty')
+              if [ "$RUN_STATUS" != "completed" ] || [ "$RUN_CONCLUSION" != "success" ]; then
+                continue
+              fi
+
+              VERSION=${TAG#v}
+              XCSH_NPM=$(npm view "@f5-sales-demo/xcsh@$VERSION" version gitHead dist.integrity --json 2>/dev/null || true)
+              DEFAULTS_NPM=$(npm view "@f5-sales-demo/pi-resource-management@$VERSION" version gitHead dist.integrity --json 2>/dev/null || true)
+              printf '%s' "$XCSH_NPM" | jq -e --arg version "$VERSION" --arg commit "$TAG_SHA" '
+                .version == $version and .gitHead == $commit and
+                (."dist.integrity" | test("^sha512-[A-Za-z0-9+/]+={0,2}$"))
+              ' >/dev/null || continue
+              printf '%s' "$DEFAULTS_NPM" | jq -e --arg version "$VERSION" --arg commit "$TAG_SHA" '
+                .version == $version and .gitHead == $commit and
+                (."dist.integrity" | test("^sha512-[A-Za-z0-9+/]+={0,2}$"))
+              ' >/dev/null || continue
+
+              RELEASE_JSON=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" 2>/dev/null || true)
+              printf '%s' "$RELEASE_JSON" | jq -e --arg tag "$TAG" '
+                .tag_name == $tag and .draft == false and .prerelease == false and .immutable == true and
+                (.assets | type == "array") and
+                ([.assets[] | .name] | sort) == [
+                  "pi_natives.darwin-arm64.node",
+                  "pi_natives.darwin-x64-baseline.node",
+                  "pi_natives.darwin-x64-modern.node",
+                  "pi_natives.linux-arm64.node",
+                  "pi_natives.linux-x64-baseline.node",
+                  "pi_natives.linux-x64-modern.node",
+                  "pi_natives.win32-x64-baseline.node",
+                  "pi_natives.win32-x64-modern.node",
+                  "xcsh-darwin-arm64",
+                  "xcsh-darwin-arm64.zip",
+                  "xcsh-darwin-x64",
+                  "xcsh-darwin-x64.zip",
+                  "xcsh-linux-arm64",
+                  "xcsh-linux-arm64.tar.gz",
+                  "xcsh-linux-x64",
+                  "xcsh-linux-x64.tar.gz",
+                  "xcsh-windows-x64.exe"
+                ] and
+                ([.assets[] | .digest | test("^sha256:[0-9a-f]{64}$")] | all)
+              ' >/dev/null || continue
+
+              CONTENT_MATCH=true
+              for FILE in \
+                packages/coding-agent/src/internal-urls/api-catalog-index.generated.ts \
+                packages/coding-agent/src/internal-urls/api-spec-index.generated.ts \
+                packages/coding-agent/src/internal-urls/terraform-index.generated.ts \
+                packages/resource-management/src/defaults-metadata.generated.ts \
+                tools/spec-delivery-pending.json \
+                tools/spec-release.json; do
+                MERGE_BLOB=$(gh api "repos/$GITHUB_REPOSITORY/contents/$FILE?ref=$MERGE_SHA" --jq '.sha' 2>/dev/null || true)
+                TAG_BLOB=$(gh api "repos/$GITHUB_REPOSITORY/contents/$FILE?ref=$TAG_SHA" --jq '.sha' 2>/dev/null || true)
+                if [[ ! "$MERGE_BLOB" =~ ^[0-9a-f]{40}$ ]] || [ "$MERGE_BLOB" != "$TAG_BLOB" ]; then
+                  CONTENT_MATCH=false
+                  break
+                fi
+              done
+              if [ "$CONTENT_MATCH" != true ]; then
+                continue
+              fi
+
+              TAG_PENDING="$RUNNER_TEMP/xcsh-release-pending.json"
+              TAG_PIN="$RUNNER_TEMP/xcsh-release-spec-pin.json"
+              gh api "repos/$GITHUB_REPOSITORY/contents/$PENDING_PATH?ref=$TAG_SHA" \
+                -H "Accept: application/vnd.github.raw+json" > "$TAG_PENDING"
+              gh api "repos/$GITHUB_REPOSITORY/contents/tools/spec-release.json?ref=$TAG_SHA" \
+                -H "Accept: application/vnd.github.raw+json" > "$TAG_PIN"
+              export DELIVERY_PENDING_FILE="$TAG_PENDING"
+              bun scripts/api-spec-delivery.ts verify-pending
+              [ "$(shasum -a 256 "$TAG_PIN" | awk '{print $1}')" = \
+                "$(jq -r '.spec_release_sha256' "$TAG_PENDING")" ] || continue
+              jq -e --arg commit "$PROVIDER_COMMIT" --arg tag "$PROVIDER_TAG" '
+                .provider == {commit:$commit,tag:$tag}
+              ' "$TAG_PENDING" >/dev/null || continue
+
+              PUBLICATION_RECEIPT="$RUNNER_TEMP/xcsh-publication-receipt.json"
+              jq -nS \
+                --arg commit "$TAG_SHA" \
+                --arg defaults_git_head "$(printf '%s' "$DEFAULTS_NPM" | jq -r '.gitHead')" \
+                --arg defaults_integrity "$(printf '%s' "$DEFAULTS_NPM" | jq -r '."dist.integrity"')" \
+                --arg provider_commit "$PROVIDER_COMMIT" \
+                --arg provider_tag "$PROVIDER_TAG" \
+                --arg spec_sha "$(jq -r '.spec_release_sha256' "$TAG_PENDING")" \
+                --arg tag "$TAG" \
+                --arg version "$VERSION" \
+                --arg xcsh_git_head "$(printf '%s' "$XCSH_NPM" | jq -r '.gitHead')" \
+                --arg xcsh_integrity "$(printf '%s' "$XCSH_NPM" | jq -r '."dist.integrity"')" \
+                --argjson assets "$(printf '%s' "$RELEASE_JSON" | jq -c \
+                  '.assets | map({key:.name,value:(.digest | sub("^sha256:"; ""))}) | from_entries')" \
+                --argjson generated "$(jq -c '.generated' "$TAG_PENDING")" '
+                {
+                  assets:$assets,
+                  commit:$commit,
+                  generated:$generated,
+                  npm:{
+                    "@f5-sales-demo/pi-resource-management":{git_head:$defaults_git_head,integrity:$defaults_integrity},
+                    "@f5-sales-demo/xcsh":{git_head:$xcsh_git_head,integrity:$xcsh_integrity}
+                  },
+                  provider:{commit:$provider_commit,tag:$provider_tag},
+                  spec_release_sha256:$spec_sha,
+                  tag:$tag,
+                  version:$version
+                }
+              ' > "$PUBLICATION_RECEIPT"
+              echo "::notice::Verified immutable $TAG release, exact source tree, assets, and npm artifacts"
+              echo "receipt_path=$PUBLICATION_RECEIPT" >> "$GITHUB_OUTPUT"
+              echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
+              exit 0
+            done < <(gh release list --limit 20 --json tagName --jq '.[].tagName')
+
+            if [ $((attempt % 10)) -eq 0 ]; then
+              echo "::notice::Still waiting for a successful published release containing $MERGE_SHA"
+            fi
+            sleep 30
+          done
+          echo "::error::No successfully published release containing the generated delivery appeared"
+          exit 1
+
+      - name: Prepare post-publication acknowledgment
+        if: steps.main_delivery.outputs.applied != 'true'
+        env:
+          ACK_BRANCH: ${{ steps.delivery.outputs.ack_branch }}
+          DELIVERY_ID: ${{ steps.delivery.outputs.delivery_id }}
+          LEDGER_PATH: ${{ steps.delivery.outputs.ledger_path }}
+          PENDING_PATH: ${{ steps.delivery.outputs.pending_path }}
+          PUBLICATION_LEDGER_PATH: ${{ steps.delivery.outputs.publication_ledger_path }}
+          PUBLICATION_RECEIPT_FILE: ${{ steps.publication.outputs.receipt_path }}
+          SPEC_VERSION: ${{ steps.delivery.outputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          if git ls-remote --exit-code --heads origin "$ACK_BRANCH" >/dev/null 2>&1; then
+            git fetch --no-tags origin "$ACK_BRANCH:refs/remotes/origin/$ACK_BRANCH"
+            ACK_LEDGER="$RUNNER_TEMP/api-spec-delivery-ack-ledger.json"
+            git show "origin/$ACK_BRANCH:$LEDGER_PATH" > "$ACK_LEDGER" || {
+              echo "::error::Existing acknowledgment branch has no delivery ledger"
+              exit 1
+            }
+            export DELIVERY_LEDGER_FILE="$ACK_LEDGER"
+            ACK_PUBLICATION_LEDGER="$RUNNER_TEMP/api-spec-delivery-ack-publication-ledger.json"
+            git show "origin/$ACK_BRANCH:$PUBLICATION_LEDGER_PATH" > "$ACK_PUBLICATION_LEDGER" || {
+              echo "::error::Existing acknowledgment branch has no publication evidence ledger"
+              exit 1
+            }
+            export DELIVERY_PUBLICATION_LEDGER_FILE="$ACK_PUBLICATION_LEDGER"
+            bun scripts/api-spec-delivery.ts verify-ledger
+            jq -e --arg id "$DELIVERY_ID" --slurpfile receipt "$PUBLICATION_RECEIPT_FILE" \
+              '.receipts[$id].publication == $receipt[0]' "$ACK_PUBLICATION_LEDGER" >/dev/null || {
+              echo "::error::Existing acknowledgment branch carries different publication evidence"
+              exit 1
+            }
+            if git cat-file -e "origin/$ACK_BRANCH:$PENDING_PATH" 2>/dev/null; then
+              echo "::error::Existing acknowledgment branch did not remove the pending marker"
+              exit 1
+            fi
+            ACK_ALLOWED='^tools/(spec-deliveries|spec-delivery-pending|xcsh-publication-receipts)\.json$'
+            ACK_UNEXPECTED=$(git diff --name-only "origin/main...origin/$ACK_BRANCH" | grep -Ev "$ACK_ALLOWED" || true)
+            if [ -n "$ACK_UNEXPECTED" ]; then
+              echo "::error::Existing acknowledgment branch contains unexpected paths"
+              printf '%s\n' "$ACK_UNEXPECTED"
+              exit 1
+            fi
+            git checkout -B "$ACK_BRANCH" "origin/$ACK_BRANCH"
+          else
+            git checkout -B "$ACK_BRANCH" origin/main
+            export DELIVERY_PENDING_FILE="$PENDING_PATH"
+            bun scripts/api-spec-delivery.ts verify-pending
+            bun scripts/api-spec-delivery.ts acknowledge
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add "$LEDGER_PATH"
+            git add "$PUBLICATION_LEDGER_PATH"
+            git add -u "$PENDING_PATH"
+            git diff --cached --quiet && {
+              echo "::error::Post-publication acknowledgment produced no change"
+              exit 1
+            }
+            git commit -m "chore: acknowledge published API specs $SPEC_VERSION"
+            git push --set-upstream origin "$ACK_BRANCH"
+          fi
+
+      - name: Create or resume acknowledgment pull request
+        if: steps.main_delivery.outputs.applied != 'true'
+        id: acknowledgment_pr
+        env:
+          ACK_BRANCH: ${{ steps.delivery.outputs.ack_branch }}
+          DELIVERY_ID: ${{ steps.delivery.outputs.delivery_id }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          RELEASE_TAG: ${{ steps.publication.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          PR_JSON=$(gh pr list --head "$ACK_BRANCH" --state all --limit 10 --json number,state)
+          PR_NUMBER=$(printf '%s' "$PR_JSON" | jq -r '.[0].number // empty')
+          PR_STATE=$(printf '%s' "$PR_JSON" | jq -r '.[0].state // empty')
+          if [ -n "$PR_NUMBER" ]; then
+            if [ "$PR_STATE" = "CLOSED" ]; then
+              gh pr reopen "$PR_NUMBER"
+              PR_STATE=OPEN
+            fi
+          else
+            DELIVERY_PREFIX=${DELIVERY_ID:0:12}
+            ISSUE_TITLE="chore: acknowledge published API spec delivery $DELIVERY_PREFIX"
+            ISSUE_JSON=$(gh issue list --state all --search "$ISSUE_TITLE in:title" --limit 100 --json number,state,title)
+            ISSUE_NUMBER=$(printf '%s' "$ISSUE_JSON" | jq -r --arg title "$ISSUE_TITLE" \
+              '[.[] | select(.title == $title)][0].number // empty')
+            ISSUE_STATE=$(printf '%s' "$ISSUE_JSON" | jq -r --arg title "$ISSUE_TITLE" \
+              '[.[] | select(.title == $title)][0].state // empty')
+            if [ -z "$ISSUE_NUMBER" ]; then
+              ISSUE_URL=$(gh issue create \
+                --title "$ISSUE_TITLE" \
+                --body "Record delivery $DELIVERY_PREFIX only after verified publication in $RELEASE_TAG.")
+              ISSUE_NUMBER=${ISSUE_URL##*/}
+            elif [ "$ISSUE_STATE" = "CLOSED" ]; then
+              gh issue reopen "$ISSUE_NUMBER"
+            fi
+
+            PR_URL=$(gh pr create \
+              --base main \
+              --head "$ACK_BRANCH" \
+              --title "chore: acknowledge published API spec delivery $DELIVERY_PREFIX" \
+              --body "The generated API spec delivery is present in verified published release $RELEASE_TAG.
+
+          This PR moves the exact delivery from the pending marker into the durable receiver ledger used by upstream completion polling.
+
+          Closes #$ISSUE_NUMBER")
+            PR_NUMBER=${PR_URL##*/}
+            PR_STATE=OPEN
+          fi
+
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || {
+            echo "::error::Could not resolve the acknowledgment PR number"
+            exit 1
+          }
+          if [ "$PR_STATE" != "MERGED" ]; then
+            gh pr merge "$PR_NUMBER" --squash --auto --delete-branch
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Verify acknowledgment reached main
+        if: steps.main_delivery.outputs.applied != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          LEDGER_PATH: ${{ steps.delivery.outputs.ledger_path }}
+          PUBLICATION_LEDGER_PATH: ${{ steps.delivery.outputs.publication_ledger_path }}
+          PR_NUMBER: ${{ steps.acknowledgment_pr.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || exit 1
+          for attempt in $(seq 1 240); do
+            PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
+            if [ "$PR_STATE" = "MERGED" ]; then
+              git fetch --no-tags origin main
+              MAIN_LEDGER="$RUNNER_TEMP/api-spec-delivery-main-ledger.json"
+              git show "origin/main:$LEDGER_PATH" > "$MAIN_LEDGER"
+              MAIN_PUBLICATION_LEDGER="$RUNNER_TEMP/api-spec-delivery-main-publication-ledger.json"
+              git show "origin/main:$PUBLICATION_LEDGER_PATH" > "$MAIN_PUBLICATION_LEDGER"
+              export DELIVERY_LEDGER_FILE="$MAIN_LEDGER"
+              export DELIVERY_PUBLICATION_LEDGER_FILE="$MAIN_PUBLICATION_LEDGER"
+              bun scripts/api-spec-delivery.ts verify-ledger
+              echo "::notice::Durable post-publication delivery acknowledgment is present on main"
+              exit 0
+            fi
+            if [ "$PR_STATE" = "CLOSED" ]; then
+              echo "::error::Acknowledgment PR closed without merging"
+              exit 1
+            fi
+            if [ $((attempt % 20)) -eq 0 ]; then
+              echo "::notice::Still waiting for acknowledgment PR $PR_NUMBER to merge"
+            fi
+            sleep 30
+          done
+          echo "::error::Timed out waiting for delivery acknowledgment to reach main"
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   # Fast lint + type check (no Rust, no native build needed)
   check:
-    name: Lint and type check
+    name: check
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
@@ -285,7 +285,7 @@ jobs:
           if-no-files-found: error
 
   test:
-    name: Test workspace
+    name: test
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ concurrency:
 jobs:
   # Fast lint + type check (no Rust, no native build needed)
   check:
+    name: Lint and type check
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
@@ -111,6 +112,7 @@ jobs:
         run: bun run ci:check:full
 
   setup-zig:
+    name: Verify Zig (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
@@ -125,6 +127,7 @@ jobs:
         run: zig version
 
   native:
+    name: Native build (${{ matrix.os }}, ${{ matrix.arch }})
     needs: setup-zig
     strategy:
       fail-fast: false
@@ -144,18 +147,27 @@ jobs:
           {"os":"macos-14","platform":"darwin","arch":"arm64","sandbox_check":true}
           ]') }}
     runs-on: ${{ matrix.os }}
+    env:
+      RUST_TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v6
         with:
           lfs: true
-      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2 # nightly branch head # TODO: unpin once nightly codegen regression is fixed
-        with:
-          toolchain: nightly-2026-03-27
-          components: ${{ matrix.rust_checks && 'clippy, rustfmt' || '' }}
-          targets: ${{ matrix.target }}
-      - name: Ensure cross-compilation target is installed
-        if: matrix.target
-        run: rustup target add ${{ matrix.target }}
+      - name: Install pinned Rust toolchain
+        shell: bash
+        env:
+          RUST_COMPONENTS: ${{ matrix.rust_checks && 'clippy,rustfmt' || '' }}
+        run: |
+          set -euo pipefail
+          rustup toolchain install nightly-2026-03-27 --profile minimal
+          rustup default nightly-2026-03-27
+          if [ -n "$RUST_COMPONENTS" ]; then
+            IFS=, read -ra components <<< "$RUST_COMPONENTS"
+            rustup component add --toolchain nightly-2026-03-27 "${components[@]}"
+          fi
+          if [ -n "$RUST_TARGET" ]; then
+            rustup target add --toolchain nightly-2026-03-27 "$RUST_TARGET"
+          fi
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           key: ${{ matrix.target }}${{ matrix.variants }}
@@ -273,6 +285,7 @@ jobs:
           if-no-files-found: error
 
   test:
+    name: Test workspace
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
@@ -334,9 +347,12 @@ jobs:
           fi
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
-      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2 # nightly branch head # TODO: unpin once nightly codegen regression is fixed
-        with:
-          toolchain: nightly-2026-03-27
+      - name: Install pinned Rust toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup toolchain install nightly-2026-03-27 --profile minimal
+          rustup default nightly-2026-03-27
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           cache-workspace-crates: true
@@ -379,6 +395,7 @@ jobs:
         run: bun run ci:test:smoke
 
   install_methods:
+    name: Test installation methods
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
@@ -438,9 +455,12 @@ jobs:
           fi
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
-      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2 # nightly branch head # TODO: unpin once nightly codegen regression is fixed
-        with:
-          toolchain: nightly-2026-03-27
+      - name: Install pinned Rust toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup toolchain install nightly-2026-03-27 --profile minimal
+          rustup default nightly-2026-03-27
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           cache-workspace-crates: true
@@ -464,12 +484,11 @@ jobs:
   # Invalidate already-green release PRs immediately when their recorded base
   # falls behind main. Release creation remains in auto-release after full CI.
   invalidate-stale-release-prs:
+    name: Invalidate stale release pull requests
     if: github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore:')
     runs-on: ubuntu-22.04
     timeout-minutes: 5
-    permissions:
-      contents: write
-      pull-requests: write
+    permissions: {}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -484,12 +503,11 @@ jobs:
         run: bun scripts/release.ts invalidate-stale
 
   auto-release:
+    name: Prepare automatic release
     if: github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore:')
     needs: [check, native, test, install_methods]
     runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-      pull-requests: write
+    permissions: {}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -566,6 +584,7 @@ jobs:
 
   # Build Linux + Windows binaries on Ubuntu
   build-release:
+    name: Build Linux and Windows release
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [check, native, test, install_methods]
     runs-on: ubuntu-22.04
@@ -662,6 +681,7 @@ jobs:
 
   # Build macOS binaries natively on matching architecture, then sign and notarize
   build-sign-macos:
+    name: Build and sign macOS (${{ matrix.arch }})
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [check, native, test, install_methods]
     strategy:
@@ -673,6 +693,8 @@ jobs:
           - os: macos-14
             arch: arm64
     runs-on: ${{ matrix.os }}
+    env:
+      RELEASE_ARCH: ${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -818,7 +840,7 @@ jobs:
           done
           # Notarize the addon(s). A bare .node cannot be stapled, so the load relies
           # on Gatekeeper's online notarization check (cdhash registered with Apple).
-          ZIP="$RUNNER_TEMP/natives-${{ matrix.arch }}.zip"
+          ZIP="$RUNNER_TEMP/natives-${RELEASE_ARCH}.zip"
           ditto -c -k packages/natives/native "$ZIP"
           xcrun notarytool submit "$ZIP" \
             --apple-id "$APPLE_ID" \
@@ -838,7 +860,7 @@ jobs:
         env:
           XCSH_BUILD_BRANCH: main # compiled binaries have no .git at runtime; pin branch at build time
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: bun scripts/ci-release-build-binaries.ts --platform darwin --arch ${{ matrix.arch }}
+        run: bun scripts/ci-release-build-binaries.ts --platform darwin --arch "$RELEASE_ARCH"
       - name: Stage macOS native addons for release
         run: cp packages/natives/native/*.node packages/coding-agent/binaries/
 
@@ -857,7 +879,7 @@ jobs:
           fi
           echo "Using signing identity: $SIGNING_IDENTITY"
 
-          BINARY_PATH="packages/coding-agent/binaries/xcsh-darwin-${{ matrix.arch }}"
+          BINARY_PATH="packages/coding-agent/binaries/xcsh-darwin-${RELEASE_ARCH}"
           if [ -f "$BINARY_PATH" ]; then
             echo "=== Binary diagnostics ==="
             file "$BINARY_PATH"
@@ -898,7 +920,7 @@ jobs:
             done
 
             codesign --verify --verbose "$BINARY_PATH" || {
-              echo "::error::Code signature verification failed for ${{ matrix.arch }}"
+              echo "::error::Code signature verification failed for ${RELEASE_ARCH}"
               exit 1
             }
 
@@ -917,7 +939,7 @@ jobs:
               exit 1
             fi
 
-            echo "${{ matrix.arch }} signed successfully"
+            echo "${RELEASE_ARCH} signed successfully"
           else
             echo "::error::Binary not found: $BINARY_PATH"
             exit 1
@@ -929,12 +951,12 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          BINARY_PATH="packages/coding-agent/binaries/xcsh-darwin-${{ matrix.arch }}"
-          ZIP_PATH="$RUNNER_TEMP/xcsh-darwin-${{ matrix.arch }}.zip"
+          BINARY_PATH="packages/coding-agent/binaries/xcsh-darwin-${RELEASE_ARCH}"
+          ZIP_PATH="$RUNNER_TEMP/xcsh-darwin-${RELEASE_ARCH}.zip"
 
           ditto -c -k --keepParent "$BINARY_PATH" "$ZIP_PATH"
 
-          echo "Submitting ${{ matrix.arch }} for notarization..."
+          echo "Submitting ${RELEASE_ARCH} for notarization..."
           echo "Xcode version: $(xcode-select -p)"
           xcrun notarytool --version 2>&1 || true
 
@@ -955,7 +977,7 @@ jobs:
             echo "$NOTARY_OUTPUT"
 
             if echo "$NOTARY_OUTPUT" | grep -q "status: Accepted"; then
-              echo "  Notarization accepted for ${{ matrix.arch }} on attempt $ATTEMPT"
+              echo "  Notarization accepted for ${RELEASE_ARCH} on attempt $ATTEMPT"
               NOTARIZE_OK=true
               break
             fi
@@ -969,7 +991,7 @@ jobs:
           done
 
           if [ "$NOTARIZE_OK" != "true" ]; then
-            echo "::error::Notarization failed for ${{ matrix.arch }} after $MAX_ATTEMPTS attempts"
+            echo "::error::Notarization failed for ${RELEASE_ARCH} after $MAX_ATTEMPTS attempts"
             exit 1
           fi
 
@@ -980,7 +1002,7 @@ jobs:
             echo "  Stapling not supported for bare Mach-O CLI tools (expected)"
           fi
 
-          echo "All checks passed for ${{ matrix.arch }}"
+          echo "All checks passed for ${RELEASE_ARCH}"
 
       - name: Verify signed macOS sandbox check in a direct-home live profile
         env:
@@ -996,15 +1018,19 @@ jobs:
 
   # Collect all artifacts and create the GitHub Release
   create-release:
+    name: Publish immutable GitHub release
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build-release, build-sign-macos]
     runs-on: ubuntu-22.04
-    permissions:
-      contents: write
+    permissions: {}
     steps:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3"
       - name: Download Linux/Windows binaries
         uses: actions/download-artifact@v8
         with:
@@ -1016,16 +1042,43 @@ jobs:
           pattern: release-binaries-macos-*-signed
           path: packages/coding-agent/binaries
           merge-multiple: true
+      - name: Build deterministic Homebrew archives twice
+        run: |
+          set -euo pipefail
+          SOURCE_DATE_EPOCH=$(git show -s --format=%ct "$GITHUB_SHA")
+          [[ "$SOURCE_DATE_EPOCH" =~ ^[0-9]+$ ]] || exit 1
+          export SOURCE_DATE_EPOCH
+          bun scripts/ci-release-homebrew.ts --package-only
+          sha256sum packages/coding-agent/binaries/*.zip packages/coding-agent/binaries/*.tar.gz \
+            | LC_ALL=C sort > "$RUNNER_TEMP/homebrew-archives-first.sha256"
+          bun scripts/ci-release-homebrew.ts --package-only
+          sha256sum packages/coding-agent/binaries/*.zip packages/coding-agent/binaries/*.tar.gz \
+            | LC_ALL=C sort > "$RUNNER_TEMP/homebrew-archives-second.sha256"
+          diff -u "$RUNNER_TEMP/homebrew-archives-first.sha256" \
+            "$RUNNER_TEMP/homebrew-archives-second.sha256"
       - name: List release binaries
         run: ls -la packages/coding-agent/binaries/
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
-        run: gh release create "$REF_NAME" packages/coding-agent/binaries/* --generate-notes
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/immutable-releases" \
+            | jq -e '.enabled == true' >/dev/null || {
+            echo "::error::Repository release immutability is not enabled"
+            exit 1
+          }
+          gh release create "$REF_NAME" packages/coding-agent/binaries/* --generate-notes
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${REF_NAME}" \
+            | jq -e '.draft == false and .prerelease == false and .immutable == true' >/dev/null || {
+            echo "::error::Created GitHub release is not final and immutable"
+            exit 1
+          }
 
   # Package Homebrew archives from signed binaries and update the tap
   update-homebrew:
+    name: Publish Homebrew formula
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
     runs-on: ubuntu-22.04
@@ -1093,30 +1146,14 @@ jobs:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
       - run: bun install --frozen-lockfile
-      - name: Download signed macOS binaries
-        uses: actions/download-artifact@v8
-        with:
-          pattern: release-binaries-macos-*-signed
-          path: packages/coding-agent/binaries
-          merge-multiple: true
-      - name: Download Linux binaries
-        uses: actions/download-artifact@v8
-        with:
-          name: release-binaries-linux-win
-          path: packages/coding-agent/binaries
-      - name: Package archives for Homebrew
-        run: bun scripts/ci-release-homebrew.ts --package-only
-      - name: Upload Homebrew archives to release
+      - name: Download immutable Homebrew archives from release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          for archive in packages/coding-agent/binaries/*.zip packages/coding-agent/binaries/*.tar.gz; do
-            if [ -f "$archive" ]; then
-              echo "Uploading $(basename "$archive") to release $TAG..."
-              gh release upload "$TAG" "$archive" --clobber
-            fi
-          done
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern 'xcsh-*.zip' \
+            --pattern 'xcsh-*.tar.gz' \
+            --dir packages/coding-agent/binaries
       - name: Update Homebrew tap
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
@@ -1125,6 +1162,7 @@ jobs:
   # Install from the published tap so a successful formula push cannot mask a
   # stale version, bad checksum, missing archive, or binary startup failure.
   verify-homebrew-install:
+    name: Verify Homebrew installation
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [update-homebrew]
     runs-on: macos-14
@@ -1193,13 +1231,14 @@ jobs:
 
   # Publish to npm
   publish-npm:
+    name: Publish npm packages
     if: startsWith(github.ref, 'refs/tags/v') && !inputs.skip_npm
     needs: [create-release]
     runs-on: ubuntu-22.04
     env:
       XCSH_BUILD_BRANCH: main
     permissions:
-      id-token: write
+      id-token: write # Required for npm trusted-publishing provenance.
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1299,6 +1338,7 @@ jobs:
 
   # Verify npm install works end-to-end after publishing
   verify-npm-install:
+    name: Verify npm installation
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [publish-npm]
     runs-on: ubuntu-22.04
@@ -1361,6 +1401,9 @@ jobs:
           fi
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
+      # The CLI under test is installed from the published registry artifact.
+      # Workspace dependencies and the downloaded addon support only the
+      # live-profile verification harness below.
       - run: bun install --frozen-lockfile
       - name: Download native addon for the live-profile harness
         uses: actions/download-artifact@v8
@@ -1370,6 +1413,7 @@ jobs:
       - name: Install xcsh via npm and verify native addon loads
         env:
           EXPECTED_VERSION: ${{ github.ref_name }}
+        # zizmor: ignore[adhoc-packages]
         run: |
           set -euo pipefail
 

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -33,8 +33,7 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: write
+permissions: {}
 
 concurrency:
   group: tag-on-version-bump
@@ -42,12 +41,14 @@ concurrency:
 
 jobs:
   tag:
+    name: Create immutable release tag
     # push path: only run when the head commit starts with the bump prefix.
     # workflow_dispatch path: always run (the extract step validates input).
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.head_commit.message, 'chore: bump version to v')
     runs-on: ubuntu-22.04
+    permissions: {}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -105,6 +106,19 @@ jobs:
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "Extracted tag: $tag (from $SHA)"
+
+      - name: Enable and require immutable releases before tagging
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh api --method PUT "repos/${REPOSITORY}/immutable-releases" -F enabled=true >/dev/null
+          gh api "repos/${REPOSITORY}/immutable-releases" \
+            | jq -e '.enabled == true' >/dev/null || {
+            echo "::error::Repository release immutability must be enabled before tagging"
+            exit 1
+          }
 
       - name: Guard against duplicate tag
         id: guard

--- a/packages/coding-agent/scripts/generate-api-spec-index.ts
+++ b/packages/coding-agent/scripts/generate-api-spec-index.ts
@@ -4,6 +4,11 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { $ } from "bun";
+import {
+	type ApiSpecReleaseIdentity,
+	releaseIdentityFromEnvironment,
+	validateArtifactVersion,
+} from "../../../scripts/api-spec-delivery";
 import { isLocalSpecsCurrent } from "./api-specs-version";
 import { sanitizeAcmePlaceholders, sanitizePublicIpv4Examples } from "./sanitize-generated-content";
 
@@ -97,6 +102,19 @@ interface RawIndex {
 const REPO = "f5-sales-demo/api-specs-enriched";
 const outputPath = path.resolve(import.meta.dir, "../src/internal-urls/api-spec-index.generated.ts");
 const catalogOutputPath = path.resolve(import.meta.dir, "../src/internal-urls/api-catalog-index.generated.ts");
+const releaseIdentity = releaseIdentityFromEnvironment(process.env);
+
+function requiredSha256(value: string | undefined, field: string): string {
+	if (!value || !/^[0-9a-f]{64}$/.test(value)) throw new Error(`${field} must be a lowercase SHA-256 digest`);
+	return value;
+}
+
+const expectedBundleSha256 = releaseIdentity
+	? requiredSha256(process.env.API_SPECS_BUNDLE_SHA256, "API_SPECS_BUNDLE_SHA256")
+	: undefined;
+const expectedCatalogSha256 = releaseIdentity
+	? requiredSha256(process.env.API_SPECS_CATALOG_SHA256, "API_SPECS_CATALOG_SHA256")
+	: undefined;
 
 /** Domains reserved for documentation by RFC 2606 / RFC 6761. */
 const RESERVED_EMAIL_DOMAINS = new Set(["example.com", "example.net", "example.org"]);
@@ -164,10 +182,10 @@ async function resolveLatestTag(): Promise<string> {
 	return data.tag_name;
 }
 
-async function downloadFromRelease(): Promise<string> {
+async function downloadFromRelease(exactTag?: string, expectedSha256?: string): Promise<string> {
 	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "api-specs-"));
 	downloadedTmpDir = tmpDir;
-	const tag = process.env.API_SPECS_TAG ?? (await resolveLatestTag());
+	const tag = exactTag ?? (await resolveLatestTag());
 	const zipName = `f5xc-api-specs-${tag}.zip`;
 	const downloadUrl = `https://github.com/${REPO}/releases/download/${tag}/${zipName}`;
 
@@ -179,6 +197,9 @@ async function downloadFromRelease(): Promise<string> {
 
 	const zipPath = path.join(tmpDir, zipName);
 	const buffer = Buffer.from(await response.arrayBuffer());
+	if (expectedSha256 && new Bun.CryptoHasher("sha256").update(buffer).digest("hex") !== expectedSha256) {
+		throw new Error(`Downloaded ${zipName} differs from its immutable publication receipt`);
+	}
 	fs.writeFileSync(zipPath, buffer);
 
 	const extractDir = path.join(tmpDir, "extracted");
@@ -210,7 +231,11 @@ function readLocalSpecsVersion(specsDir: string): string | undefined {
 	}
 }
 
-async function findSpecsDir(): Promise<string> {
+async function findSpecsDir(identity: ApiSpecReleaseIdentity | undefined): Promise<string> {
+	if (identity) {
+		return downloadFromRelease(identity.releaseTag, expectedBundleSha256);
+	}
+
 	const envDir = process.env.API_SPECS_DIR;
 	if (envDir && fs.existsSync(envDir)) {
 		// Explicit override — the caller is responsible for its freshness.
@@ -242,50 +267,64 @@ async function findSpecsDir(): Promise<string> {
 	return downloadFromRelease();
 }
 
-async function downloadCatalog(specsDir: string): Promise<Record<string, unknown> | null> {
+async function downloadJsonReleaseAsset(
+	tag: string,
+	assetName: string,
+	required: boolean,
+	expectedSha256?: string,
+): Promise<Record<string, unknown> | null> {
+	const url = `https://github.com/${REPO}/releases/download/${tag}/${assetName}`;
+	console.log(`Downloading ${assetName} from ${url}...`);
+	try {
+		const response = await fetchWithRetry(url, { redirect: "follow" });
+		if (!response.ok) {
+			if (required) {
+				throw new Error(`Required ${assetName} is absent from release ${tag}: HTTP ${response.status}`);
+			}
+			console.warn(`${assetName} not found (${response.status}), skipping generation`);
+			return null;
+		}
+		const bytes = new Uint8Array(await response.arrayBuffer());
+		if (expectedSha256 && new Bun.CryptoHasher("sha256").update(bytes).digest("hex") !== expectedSha256) {
+			throw new Error(`Downloaded ${assetName} differs from its immutable publication receipt`);
+		}
+		return JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>;
+	} catch (error) {
+		if (required) throw error;
+		console.warn(`Failed to download ${assetName}: ${error instanceof Error ? error.message : error}`);
+		return null;
+	}
+}
+
+async function downloadCatalog(
+	specsDir: string,
+	identity: ApiSpecReleaseIdentity | undefined,
+): Promise<Record<string, unknown> | null> {
+	if (identity) {
+		return downloadJsonReleaseAsset(identity.releaseTag, "api-catalog.json", true, expectedCatalogSha256);
+	}
+
 	const catalogPath = path.join(specsDir, "api-catalog.json");
 	if (fs.existsSync(catalogPath)) {
 		return JSON.parse(fs.readFileSync(catalogPath, "utf-8"));
 	}
 
-	const catalogTag = process.env.API_SPECS_TAG ?? (await resolveLatestTag());
-	const catalogUrl = `https://github.com/${REPO}/releases/download/${catalogTag}/api-catalog.json`;
-	console.log(`Downloading API catalog from ${catalogUrl}...`);
-	try {
-		const response = await fetchWithRetry(catalogUrl, { redirect: "follow" });
-		if (!response.ok) {
-			console.warn(`api-catalog.json not found (${response.status}), skipping catalog generation`);
-			return null;
-		}
-		const text = await response.text();
-		return JSON.parse(text);
-	} catch (err) {
-		console.warn(`Failed to download api-catalog.json: ${err instanceof Error ? err.message : err}`);
-		return null;
-	}
+	return downloadJsonReleaseAsset(await resolveLatestTag(), "api-catalog.json", false);
 }
 
-async function downloadValidation(specsDir: string): Promise<Record<string, unknown> | null> {
+async function downloadValidation(
+	specsDir: string,
+	identity: ApiSpecReleaseIdentity | undefined,
+): Promise<Record<string, unknown> | null> {
 	const validationPath = path.join(specsDir, "validation.json");
 	if (fs.existsSync(validationPath)) {
 		return JSON.parse(fs.readFileSync(validationPath, "utf-8"));
 	}
-
-	const validationTag = process.env.API_SPECS_TAG ?? (await resolveLatestTag());
-	const validationUrl = `https://github.com/${REPO}/releases/download/${validationTag}/validation.json`;
-	console.log(`Downloading validation.json from ${validationUrl}...`);
-	try {
-		const response = await fetchWithRetry(validationUrl, { redirect: "follow" });
-		if (!response.ok) {
-			console.warn(`validation.json not found (${response.status}), skipping validation data generation`);
-			return null;
-		}
-		const text = await response.text();
-		return JSON.parse(text);
-	} catch (err) {
-		console.warn(`Failed to download validation.json: ${err instanceof Error ? err.message : err}`);
-		return null;
+	if (identity) {
+		throw new Error(`Required validation.json is absent from the ${identity.releaseTag} spec bundle`);
 	}
+
+	return downloadJsonReleaseAsset(await resolveLatestTag(), "validation.json", false);
 }
 
 function serializeEnrichment(key: string, value: unknown): string | undefined {
@@ -295,12 +334,12 @@ function serializeEnrichment(key: string, value: unknown): string | undefined {
 
 let downloadedTmpDir: string | null = null;
 
-if (fs.existsSync(outputPath) && fs.existsSync(catalogOutputPath) && process.env.CI) {
+if (!releaseIdentity && fs.existsSync(outputPath) && fs.existsSync(catalogOutputPath) && process.env.CI) {
 	console.log("Generated spec files already exist in CI — skipping regeneration.");
 	process.exit(0);
 }
 
-const specsDir = await findSpecsDir();
+const specsDir = await findSpecsDir(releaseIdentity);
 console.log(`Reading specs from: ${specsDir}`);
 
 const indexPath = path.join(specsDir, "index.json");
@@ -310,9 +349,11 @@ if (!fs.existsSync(indexPath)) {
 }
 
 const rawIndex: RawIndex = JSON.parse(fs.readFileSync(indexPath, "utf-8"));
+if (releaseIdentity) validateArtifactVersion(rawIndex, releaseIdentity, "index.json");
 
-const catalog = await downloadCatalog(specsDir);
-const validation = await downloadValidation(specsDir);
+const catalog = await downloadCatalog(specsDir, releaseIdentity);
+if (releaseIdentity) validateArtifactVersion(catalog, releaseIdentity, "api-catalog.json");
+const validation = await downloadValidation(specsDir, releaseIdentity);
 
 const pathToCatalogCategories = new Map<string, string[]>();
 if (catalog) {

--- a/packages/coding-agent/scripts/generate-terraform-index.ts
+++ b/packages/coding-agent/scripts/generate-terraform-index.ts
@@ -16,26 +16,88 @@ const LOCAL_JSON_PATH = path.resolve(
 
 const GITHUB_RAW_URL =
 	"https://raw.githubusercontent.com/f5-sales-demo/terraform-provider-xcsh/main/docs/terraform-llms-index.json";
+const PROVIDER_REPOSITORY = "f5-sales-demo/terraform-provider-xcsh";
+const PROVIDER_TAG_PATTERN = /^v\d+\.\d+\.\d+$/;
 
-async function loadTerraformIndex(): Promise<unknown> {
-	const localFile = Bun.file(LOCAL_JSON_PATH);
-	if (await localFile.exists()) {
+type Fetcher = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+interface LoadedTerraformIndex {
+	data: unknown;
+	providerCommit?: string;
+	providerTag?: string;
+}
+
+interface FileError extends Error {
+	code: string;
+}
+
+function isEnoent(error: unknown): error is FileError {
+	return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+export function exactProviderIndexUrl(providerCommit: string): string {
+	if (!/^[0-9a-f]{40}$/.test(providerCommit)) {
+		throw new Error(`TERRAFORM_PROVIDER_COMMIT must be a full lowercase Git SHA, got ${providerCommit}`);
+	}
+	return `https://raw.githubusercontent.com/${PROVIDER_REPOSITORY}/${providerCommit}/docs/terraform-llms-index.json`;
+}
+
+function exactProviderIdentity(env: Record<string, string | undefined>): { commit: string; tag: string } | undefined {
+	const tag = env.TERRAFORM_PROVIDER_TAG;
+	const commit = env.TERRAFORM_PROVIDER_COMMIT;
+	if (tag === undefined && commit === undefined) return undefined;
+	if (tag === undefined || commit === undefined) {
+		throw new Error("TERRAFORM_PROVIDER_TAG and TERRAFORM_PROVIDER_COMMIT must be provided together");
+	}
+	if (!PROVIDER_TAG_PATTERN.test(tag)) {
+		throw new Error(`TERRAFORM_PROVIDER_TAG must be vMAJOR.MINOR.PATCH, got ${tag}`);
+	}
+	if (!/^[0-9a-f]{40}$/.test(commit)) {
+		throw new Error(`TERRAFORM_PROVIDER_COMMIT must be a full lowercase Git SHA, got ${commit}`);
+	}
+	return { commit, tag };
+}
+
+export async function loadTerraformIndex(
+	env: Record<string, string | undefined> = process.env,
+	fetcher: Fetcher = globalThis.fetch,
+): Promise<LoadedTerraformIndex> {
+	const exact = exactProviderIdentity(env);
+	if (exact) {
+		const exactUrl = exactProviderIndexUrl(exact.commit);
+		console.log(`Fetching Terraform index from provider release ${exact.tag} at ${exact.commit}`);
+		const headers: Record<string, string> = {};
+		const token = env.GITHUB_TOKEN ?? env.GH_TOKEN;
+		if (token) headers.Authorization = `token ${token}`;
+		const response = await fetcher(exactUrl, { headers });
+		if (!response.ok) {
+			throw new Error(
+				`Failed to fetch terraform-llms-index.json from provider release ${exact.tag} at ${exact.commit}: ${response.status} ${response.statusText}`,
+			);
+		}
+		return { data: await response.json(), providerCommit: exact.commit, providerTag: exact.tag };
+	}
+
+	try {
+		const data = await Bun.file(LOCAL_JSON_PATH).json();
 		console.log(`Reading from local checkout: ${LOCAL_JSON_PATH}`);
-		return localFile.json();
+		return { data };
+	} catch (error) {
+		if (!isEnoent(error)) throw error;
 	}
 
 	console.log(`Local not found, fetching from ${GITHUB_RAW_URL}`);
 	const headers: Record<string, string> = {};
-	const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+	const token = env.GITHUB_TOKEN ?? env.GH_TOKEN;
 	if (token) {
 		headers.Authorization = `token ${token}`;
 	}
 
-	const response = await fetch(GITHUB_RAW_URL, { headers });
+	const response = await fetcher(GITHUB_RAW_URL, { headers });
 	if (!response.ok) {
 		throw new Error(`Failed to fetch terraform-llms-index.json: ${response.status} ${response.statusText}`);
 	}
-	return response.json();
+	return { data: await response.json() };
 }
 
 // Backfill provider fields that older terraform-llms-index.json revisions lack, so the
@@ -62,20 +124,30 @@ function normalizeProvider(data: unknown): unknown {
 	return data;
 }
 
-function generateTypeScript(data: unknown): string {
+function generateTypeScript(
+	data: unknown,
+	providerTag: string | undefined,
+	providerCommit: string | undefined,
+): string {
 	const lines = [
 		"// AUTO-GENERATED — do not edit. Run `bun generate-terraform-index` to regenerate.",
+		providerTag && providerCommit ? `// Source: ${PROVIDER_REPOSITORY} ${providerTag} ${providerCommit}` : undefined,
 		"",
 		'import type { TerraformIndex } from "./terraform-types";',
 		"",
 		`export const TERRAFORM_INDEX: TerraformIndex = ${JSON.stringify(data, null, "\t")} as const;`,
 		"",
 	];
-	return lines.join("\n");
+	return lines.filter(line => line !== undefined).join("\n");
 }
 
-const data = normalizeProvider(await loadTerraformIndex());
-const output = generateTypeScript(data);
-await fs.writeFile(OUTPUT_FILE, output, "utf-8");
-await Bun.$`bunx biome format --write ${OUTPUT_FILE}`.quiet();
-console.log(`Generated ${OUTPUT_FILE}`);
+async function main(): Promise<void> {
+	const loaded = await loadTerraformIndex();
+	const data = normalizeProvider(loaded.data);
+	const output = generateTypeScript(data, loaded.providerTag, loaded.providerCommit);
+	await fs.writeFile(OUTPUT_FILE, output, "utf-8");
+	await Bun.$`bunx biome format --write ${OUTPUT_FILE}`.quiet();
+	console.log(`Generated ${OUTPUT_FILE}`);
+}
+
+if (import.meta.main) await main();

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -428,7 +428,9 @@ describe("CI invalidates stale release PRs before the full test matrix", () => {
 		expect(job).not.toContain("needs:");
 		expect(job).toContain("github.ref == 'refs/heads/main'");
 		expect(job).toContain("!startsWith(github.event.head_commit.message, 'chore:')");
-		expect(job).toContain("pull-requests: write");
+		// The job authenticates checkout and gh with RELEASE_TOKEN. Its generated
+		// GITHUB_TOKEN must retain no repository permissions.
+		expect(job).toContain("permissions: {}");
 		expect(job).toContain("bun scripts/release.ts invalidate-stale");
 		expect(workflow).toContain("needs: [check, native, test, install_methods]");
 	});

--- a/packages/coding-agent/test/scripts/api-spec-delivery.test.ts
+++ b/packages/coding-agent/test/scripts/api-spec-delivery.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	type ApiSpecDelivery,
+	acknowledgePublishedDelivery,
+	calculateDeliveryId,
+	calculateDeliveryIdForTarget,
+	DELIVERY_LEDGER_PATH,
+	DELIVERY_PENDING_PATH,
+	DELIVERY_PUBLICATION_LEDGER_PATH,
+	deliveryApplied,
+	deliveryBranch,
+	GENERATED_DELIVERY_PATHS,
+	parseDispatchEvent,
+	releaseIdentityFromEnvironment,
+	SPEC_RELEASE_PATH,
+	validateArtifactVersion,
+	verifyAcknowledgmentLedgers,
+	verifyGeneratedDelivery,
+	verifyReleasedTag,
+	writePendingDelivery,
+} from "../../../../scripts/api-spec-delivery";
+
+const VERSION = "2.1.208";
+const RELEASE_TAG = `v${VERSION}`;
+const TARGET_COMMIT = "a".repeat(40);
+const TRIGGER_SOURCE = "f5-sales-demo/api-specs-enriched";
+const PROVIDER_COMMIT = "b".repeat(40);
+const PROVIDER_TAG = "v9.8.7";
+
+const XCSH_RELEASE_ASSETS = [
+	"pi_natives.darwin-arm64.node",
+	"pi_natives.darwin-x64-baseline.node",
+	"pi_natives.darwin-x64-modern.node",
+	"pi_natives.linux-arm64.node",
+	"pi_natives.linux-x64-baseline.node",
+	"pi_natives.linux-x64-modern.node",
+	"pi_natives.win32-x64-baseline.node",
+	"pi_natives.win32-x64-modern.node",
+	"xcsh-darwin-arm64",
+	"xcsh-darwin-arm64.zip",
+	"xcsh-darwin-x64",
+	"xcsh-darwin-x64.zip",
+	"xcsh-linux-arm64",
+	"xcsh-linux-arm64.tar.gz",
+	"xcsh-linux-x64",
+	"xcsh-linux-x64.tar.gz",
+	"xcsh-windows-x64.exe",
+] as const;
+
+function specReleasePin(): Record<string, unknown> {
+	return {
+		assets: {
+			"api-catalog.json": "1".repeat(64),
+			[`f5xc-api-specs-${RELEASE_TAG}.zip`]: "2".repeat(64),
+			"index.json": "3".repeat(64),
+			"minimal-export-defaults.json": "4".repeat(64),
+			"openapi.json": "5".repeat(64),
+		},
+		release_tag: RELEASE_TAG,
+		target_commit: TARGET_COMMIT,
+		version: VERSION,
+	};
+}
+
+function publishedRelease(): Record<string, unknown> {
+	const pin = specReleasePin() as { assets: Record<string, string> };
+	const receipt = { assets: pin.assets, commit: TARGET_COMMIT, version: VERSION };
+	return {
+		assets: Object.entries(pin.assets).map(([name, digest]) => ({ digest: `sha256:${digest}`, name })),
+		body: `notes\n<!-- publication-receipt:${JSON.stringify(receipt)} -->\n`,
+		draft: false,
+		immutable: true,
+		prerelease: false,
+		tag_name: RELEASE_TAG,
+	};
+}
+
+function validDelivery(): ApiSpecDelivery {
+	const identity = {
+		releaseTag: RELEASE_TAG,
+		targetCommit: TARGET_COMMIT,
+		triggerSource: TRIGGER_SOURCE,
+		version: VERSION,
+	};
+	return { ...identity, deliveryId: calculateDeliveryId(identity) };
+}
+
+async function preparePendingDelivery(repoRoot: string): Promise<Record<string, unknown>> {
+	await Bun.write(path.join(repoRoot, DELIVERY_LEDGER_PATH), '{"deliveries":{},"version":1}\n');
+	await Bun.write(path.join(repoRoot, DELIVERY_PUBLICATION_LEDGER_PATH), '{"receipts":{},"version":1}\n');
+	for (const generatedPath of GENERATED_DELIVERY_PATHS) {
+		await Bun.write(path.join(repoRoot, generatedPath), `generated ${generatedPath}\n`);
+	}
+	const pinPath = path.join(repoRoot, "source-pin.json");
+	await Bun.write(pinPath, `${JSON.stringify(specReleasePin())}\n`);
+	await writePendingDelivery(repoRoot, validDelivery(), pinPath, PROVIDER_TAG, PROVIDER_COMMIT);
+	return Bun.file(path.join(repoRoot, DELIVERY_PENDING_PATH)).json();
+}
+
+function publicationEvidence(pending: Record<string, unknown>): Record<string, unknown> {
+	const commit = "c".repeat(40);
+	return {
+		assets: Object.fromEntries(
+			XCSH_RELEASE_ASSETS.map((name, index) => [name, (index + 1).toString(16).padStart(64, "0")]),
+		),
+		commit,
+		generated: pending.generated,
+		npm: {
+			"@f5-sales-demo/pi-resource-management": { git_head: commit, integrity: "sha512-QUJD" },
+			"@f5-sales-demo/xcsh": { git_head: commit, integrity: "sha512-REVG" },
+		},
+		provider: { commit: PROVIDER_COMMIT, tag: PROVIDER_TAG },
+		spec_release_sha256: pending.spec_release_sha256,
+		tag: "v3.2.1",
+		version: "3.2.1",
+	};
+}
+
+function dispatchEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	const delivery = validDelivery();
+	return {
+		action: "enriched-specs-updated",
+		client_payload: {
+			delivery_id: delivery.deliveryId,
+			release_tag: delivery.releaseTag,
+			target_commit: delivery.targetCommit,
+			trigger_source: delivery.triggerSource,
+			version: delivery.version,
+			...overrides,
+		},
+	};
+}
+
+describe("API spec delivery identity", () => {
+	it("accepts the canonical upstream payload and derives a delivery-specific branch", () => {
+		const delivery = parseDispatchEvent(dispatchEvent());
+
+		expect(delivery).toEqual(validDelivery());
+		expect(deliveryBranch(delivery)).toBe(`chore/api-specs-${RELEASE_TAG}-${delivery.deliveryId.slice(0, 12)}`);
+		expect(calculateDeliveryIdForTarget(delivery, "f5-sales-demo/terraform-provider-xcsh")).not.toBe(
+			delivery.deliveryId,
+		);
+	});
+
+	for (const field of ["delivery_id", "release_tag", "version"]) {
+		it(`rejects a dispatch without ${field}`, () => {
+			expect(() => parseDispatchEvent(dispatchEvent({ [field]: undefined }))).toThrow(field);
+		});
+	}
+
+	it("rejects tag/version disagreement and a forged delivery ID", () => {
+		expect(() => parseDispatchEvent(dispatchEvent({ release_tag: "v2.1.209" }))).toThrow("does not match version");
+		expect(() => parseDispatchEvent(dispatchEvent({ delivery_id: "0".repeat(64) }))).toThrow(
+			"does not match its payload identity",
+		);
+	});
+
+	it("requires API_SPECS_TAG and API_SPECS_VERSION together", () => {
+		expect(releaseIdentityFromEnvironment({})).toBeUndefined();
+		expect(() => releaseIdentityFromEnvironment({ API_SPECS_TAG: RELEASE_TAG })).toThrow("must be provided together");
+		expect(() => releaseIdentityFromEnvironment({ API_SPECS_VERSION: VERSION })).toThrow("must be provided together");
+		expect(releaseIdentityFromEnvironment({ API_SPECS_TAG: RELEASE_TAG, API_SPECS_VERSION: VERSION })).toEqual({
+			releaseTag: RELEASE_TAG,
+			version: VERSION,
+		});
+	});
+
+	it("rejects an artifact version that differs from the dispatch", () => {
+		const identity = { releaseTag: RELEASE_TAG, version: VERSION };
+		expect(() => validateArtifactVersion({ version: "2.1.207" }, identity, "index.json")).toThrow(
+			"index.json version 2.1.207 does not match dispatched version 2.1.208",
+		);
+	});
+});
+
+describe("durable API spec delivery ledger", () => {
+	it("keeps pending generation separate from atomic publication acknowledgment", async () => {
+		const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-spec-pending-"));
+		try {
+			const delivery = validDelivery();
+			const pending = await preparePendingDelivery(repoRoot);
+			expect(deliveryApplied(await Bun.file(path.join(repoRoot, DELIVERY_LEDGER_PATH)).json(), delivery)).toBe(
+				false,
+			);
+			expect(pending).toMatchObject({
+				delivery_id: delivery.deliveryId,
+				provider: { commit: PROVIDER_COMMIT, tag: PROVIDER_TAG },
+				release_tag: RELEASE_TAG,
+				target_commit: TARGET_COMMIT,
+				trigger_source: TRIGGER_SOURCE,
+				version: VERSION,
+			});
+			expect(Object.keys(pending.generated as Record<string, string>).sort()).toEqual(
+				[...GENERATED_DELIVERY_PATHS].sort(),
+			);
+			expect(pending.spec_release_sha256).toMatch(/^[0-9a-f]{64}$/);
+
+			const publicationPath = path.join(repoRoot, "publication.json");
+			const publication = publicationEvidence(pending);
+			publication.generated = Object.fromEntries(
+				Object.entries(publication.generated as Record<string, string>).reverse(),
+			);
+			await Bun.write(publicationPath, `${JSON.stringify(publication)}\n`);
+			await acknowledgePublishedDelivery(repoRoot, delivery, publicationPath);
+			expect(deliveryApplied(await Bun.file(path.join(repoRoot, DELIVERY_LEDGER_PATH)).json(), delivery)).toBe(true);
+			expect(await Bun.file(path.join(repoRoot, DELIVERY_PENDING_PATH)).exists()).toBe(false);
+			expect(
+				await verifyAcknowledgmentLedgers(
+					path.join(repoRoot, DELIVERY_LEDGER_PATH),
+					path.join(repoRoot, DELIVERY_PUBLICATION_LEDGER_PATH),
+					delivery,
+				),
+			).toBe(true);
+
+			const detailed = await Bun.file(path.join(repoRoot, DELIVERY_PUBLICATION_LEDGER_PATH)).json();
+			detailed.receipts[delivery.deliveryId].delivery = {
+				version: VERSION,
+				target_commit: TARGET_COMMIT,
+				release_tag: RELEASE_TAG,
+			};
+			await Bun.write(path.join(repoRoot, DELIVERY_PUBLICATION_LEDGER_PATH), `${JSON.stringify(detailed)}\n`);
+			expect(
+				await verifyAcknowledgmentLedgers(
+					path.join(repoRoot, DELIVERY_LEDGER_PATH),
+					path.join(repoRoot, DELIVERY_PUBLICATION_LEDGER_PATH),
+					delivery,
+				),
+			).toBe(true);
+		} finally {
+			await fs.rm(repoRoot, { force: true, recursive: true });
+		}
+	});
+
+	it("does not change either ledger when publication evidence is incomplete", async () => {
+		const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-spec-publication-"));
+		try {
+			const pending = await preparePendingDelivery(repoRoot);
+			const commonPath = path.join(repoRoot, DELIVERY_LEDGER_PATH);
+			const detailedPath = path.join(repoRoot, DELIVERY_PUBLICATION_LEDGER_PATH);
+			const pendingPath = path.join(repoRoot, DELIVERY_PENDING_PATH);
+			const before = await Promise.all([
+				Bun.file(commonPath).text(),
+				Bun.file(detailedPath).text(),
+				Bun.file(pendingPath).text(),
+			]);
+			const incomplete = publicationEvidence(pending);
+			delete (incomplete.assets as Record<string, string>)[XCSH_RELEASE_ASSETS[0]];
+			const publicationPath = path.join(repoRoot, "incomplete-publication.json");
+			await Bun.write(publicationPath, `${JSON.stringify(incomplete)}\n`);
+
+			await expect(acknowledgePublishedDelivery(repoRoot, validDelivery(), publicationPath)).rejects.toThrow(
+				"wrong asset set",
+			);
+			expect(
+				await Promise.all([
+					Bun.file(commonPath).text(),
+					Bun.file(detailedPath).text(),
+					Bun.file(pendingPath).text(),
+				]),
+			).toEqual(before);
+		} finally {
+			await fs.rm(repoRoot, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects malformed provider identity and arbitrary regenerated bytes", async () => {
+		const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-spec-attestation-"));
+		try {
+			await Bun.write(path.join(repoRoot, DELIVERY_LEDGER_PATH), '{"deliveries":{},"version":1}\n');
+			for (const generatedPath of GENERATED_DELIVERY_PATHS) {
+				await Bun.write(path.join(repoRoot, generatedPath), `generated ${generatedPath}\n`);
+			}
+			const pinPath = path.join(repoRoot, "source-pin.json");
+			await Bun.write(pinPath, `${JSON.stringify(specReleasePin())}\n`);
+			await expect(
+				writePendingDelivery(repoRoot, validDelivery(), pinPath, "latest", PROVIDER_COMMIT),
+			).rejects.toThrow("Provider tag must be");
+			await expect(
+				writePendingDelivery(repoRoot, validDelivery(), pinPath, PROVIDER_TAG, PROVIDER_COMMIT.toUpperCase()),
+			).rejects.toThrow("Provider commit must be");
+			expect(await Bun.file(path.join(repoRoot, SPEC_RELEASE_PATH)).exists()).toBe(false);
+
+			await writePendingDelivery(repoRoot, validDelivery(), pinPath, PROVIDER_TAG, PROVIDER_COMMIT);
+			await Bun.write(path.join(repoRoot, GENERATED_DELIVERY_PATHS[0]), "arbitrary resumed bytes\n");
+			await expect(
+				verifyGeneratedDelivery(repoRoot, validDelivery(), PROVIDER_TAG, PROVIDER_COMMIT),
+			).rejects.toThrow("differ from pending attestation");
+		} finally {
+			await fs.rm(repoRoot, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects a mismatched entry, noncanonical key, and duplicate tag under another canonical delivery", () => {
+		const delivery = validDelivery();
+		const mismatched = {
+			deliveries: {
+				[delivery.deliveryId]: {
+					release_tag: RELEASE_TAG,
+					target_commit: "b".repeat(40),
+					version: VERSION,
+				},
+			},
+			version: 1,
+		};
+		expect(() => deliveryApplied(mismatched, delivery)).toThrow("noncanonical delivery_id");
+
+		const forgedKey = {
+			deliveries: {
+				["0".repeat(64)]: {
+					release_tag: RELEASE_TAG,
+					target_commit: TARGET_COMMIT,
+					version: VERSION,
+				},
+			},
+			version: 1,
+		};
+		expect(() => deliveryApplied(forgedKey, delivery)).toThrow("noncanonical delivery_id");
+
+		const otherIdentity = {
+			releaseTag: RELEASE_TAG,
+			targetCommit: "b".repeat(40),
+			triggerSource: TRIGGER_SOURCE,
+			version: VERSION,
+		};
+		const duplicateTag = {
+			deliveries: {
+				[calculateDeliveryId(otherIdentity)]: {
+					release_tag: RELEASE_TAG,
+					target_commit: otherIdentity.targetCommit,
+					version: VERSION,
+				},
+			},
+			version: 1,
+		};
+		expect(() => deliveryApplied(duplicateTag, delivery)).toThrow("already applied under delivery");
+	});
+});
+
+describe("published release identity", () => {
+	it("requires the exact release tag to resolve to the dispatched target commit", async () => {
+		const requested: string[] = [];
+		const fetcher = async (input: string | URL | Request): Promise<Response> => {
+			const url = String(input);
+			requested.push(url);
+			if (url.includes("/releases/tags/")) return Response.json(publishedRelease());
+			return Response.json({ object: { sha: TARGET_COMMIT, type: "commit" } });
+		};
+
+		expect(await verifyReleasedTag(validDelivery(), undefined, fetcher)).toEqual({
+			assets: (specReleasePin() as { assets: Record<string, string> }).assets,
+			commit: TARGET_COMMIT,
+			version: VERSION,
+		});
+		expect(requested).toEqual([
+			`https://api.github.com/repos/${TRIGGER_SOURCE}/releases/tags/${RELEASE_TAG}`,
+			`https://api.github.com/repos/${TRIGGER_SOURCE}/git/ref/tags/${RELEASE_TAG}`,
+		]);
+	});
+
+	it("rejects a release tag that resolves to another commit", async () => {
+		const fetcher = async (input: string | URL | Request): Promise<Response> => {
+			if (String(input).includes("/releases/tags/")) return Response.json(publishedRelease());
+			return Response.json({ object: { sha: "b".repeat(40), type: "commit" } });
+		};
+
+		await expect(verifyReleasedTag(validDelivery(), undefined, fetcher)).rejects.toThrow(
+			"does not match dispatched target_commit",
+		);
+	});
+
+	it("rejects mutable releases and receipt/API byte disagreement", async () => {
+		const mutable = { ...publishedRelease(), immutable: false };
+		await expect(
+			verifyReleasedTag(validDelivery(), undefined, async input =>
+				Response.json(
+					String(input).includes("/releases/tags/") ? mutable : { object: { sha: TARGET_COMMIT, type: "commit" } },
+				),
+			),
+		).rejects.toThrow("not final and immutable");
+
+		const mismatched = publishedRelease();
+		(mismatched.assets as Array<Record<string, string>>)[0].digest = `sha256:${"f".repeat(64)}`;
+		await expect(
+			verifyReleasedTag(validDelivery(), undefined, async input =>
+				Response.json(
+					String(input).includes("/releases/tags/")
+						? mismatched
+						: { object: { sha: TARGET_COMMIT, type: "commit" } },
+				),
+			),
+		).rejects.toThrow("API digest differs");
+	});
+});

--- a/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
+++ b/packages/coding-agent/test/scripts/api-spec-update-workflow.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parse as parseYaml } from "yaml";
+import { calculateDeliveryIdForTarget } from "../../../../scripts/api-spec-delivery";
+
+interface WorkflowStep {
+	env?: Record<string, string>;
+	name?: string;
+	run?: string;
+}
+
+interface WorkflowDocument {
+	jobs: Record<string, { steps: WorkflowStep[] }>;
+}
+
+const repoRoot = path.resolve(import.meta.dir, "../../../..");
+const workflowPath = path.join(repoRoot, ".github/workflows/api-spec-update.yml");
+const generatorPath = path.join(repoRoot, "packages/coding-agent/scripts/generate-api-spec-index.ts");
+
+async function workflowSteps(): Promise<WorkflowStep[]> {
+	const document = parseYaml(await Bun.file(workflowPath).text()) as WorkflowDocument;
+	return document.jobs["update-api-specs"].steps;
+}
+
+function namedStep(steps: WorkflowStep[], name: string): WorkflowStep {
+	const step = steps.find(candidate => candidate.name === name);
+	if (!step) throw new Error(`Workflow step not found: ${name}`);
+	return step;
+}
+
+describe("API spec dispatch workflow contract", () => {
+	it("validates identity and the durable ledger before installing or generating", async () => {
+		const steps = await workflowSteps();
+		const names = steps.map(step => step.name ?? "");
+		const validateIndex = names.indexOf("Validate dispatch identity");
+		const releaseIndex = names.indexOf("Verify exact published release");
+		const ledgerIndex = names.indexOf("Check durable delivery ledger on main");
+		const providerIndex = names.indexOf("Resolve exact published provider release");
+		const installIndex = names.indexOf("Install dependencies");
+		const generateIndex = names.indexOf("Generate exact API spec and catalog indexes");
+
+		expect(validateIndex).toBeGreaterThan(-1);
+		expect(releaseIndex).toBeGreaterThan(validateIndex);
+		expect(ledgerIndex).toBeGreaterThan(releaseIndex);
+		expect(providerIndex).toBeGreaterThan(ledgerIndex);
+		expect(installIndex).toBeGreaterThan(providerIndex);
+		expect(generateIndex).toBeGreaterThan(installIndex);
+		expect(namedStep(steps, "Check durable delivery ledger on main").env?.DELIVERY_LEDGER_FILE).toContain(
+			"steps.delivery.outputs.ledger_path",
+		);
+		expect(namedStep(steps, "Check durable delivery ledger on main").env?.DELIVERY_PUBLICATION_LEDGER_FILE).toContain(
+			"steps.delivery.outputs.publication_ledger_path",
+		);
+	});
+
+	it("passes the validated exact tag and version to every API-spec consumer", async () => {
+		const steps = await workflowSteps();
+		for (const name of [
+			"Generate exact API spec and catalog indexes",
+			"Generate Terraform index",
+			"Generate exact minimum-settings defaults table",
+		]) {
+			const env = namedStep(steps, name).env;
+			expect(env?.API_SPECS_TAG).toContain("steps.delivery.outputs.release_tag");
+			expect(env?.API_SPECS_VERSION).toContain("steps.delivery.outputs.version");
+		}
+		expect(namedStep(steps, "Generate Terraform index").env?.TERRAFORM_PROVIDER_TAG).toContain(
+			"steps.provider_release.outputs.provider_tag",
+		);
+		expect(namedStep(steps, "Generate Terraform index").env?.TERRAFORM_PROVIDER_COMMIT).toContain(
+			"steps.provider_release.outputs.provider_commit",
+		);
+		expect(namedStep(steps, "Generate exact API spec and catalog indexes").env?.API_SPECS_BUNDLE_SHA256).toContain(
+			"steps.source_release.outputs.bundle_sha256",
+		);
+		expect(
+			namedStep(steps, "Generate exact minimum-settings defaults table").env?.API_SPECS_DEFAULTS_SHA256,
+		).toContain("steps.source_release.outputs.defaults_sha256");
+	});
+
+	it("waits for the provider's exact post-publication ledger before generating documentation", async () => {
+		const steps = await workflowSteps();
+		const provider = namedStep(steps, "Resolve exact published provider release").run ?? "";
+		expect(provider).toContain("f5-sales-demo/terraform-provider-xcsh");
+		expect(provider).toContain("git/ref/heads/main");
+		expect(provider).toContain("tools/spec-deliveries.json?ref=$PROVIDER_MAIN_SHA");
+		expect(provider).toContain("tools/provider-publication-receipts.json?ref=$PROVIDER_MAIN_SHA");
+		expect(provider).toContain("tools/spec-version.txt?ref=$PROVIDER_COMMIT");
+		expect(provider).toContain("Provider common and detailed ledgers have different delivery keys");
+		expect(provider).toContain("Provider delivery ledger contains a noncanonical key");
+		expect(provider).toContain("Provider release consumed different spec bytes from this receiver");
+		expect(provider).toContain("Provider release receipt differs from durable publication evidence");
+		expect(provider).toContain("Provider release bytes differ from publication evidence");
+		expect(provider).not.toContain("gh release list");
+		expect(namedStep(steps, "Verify exact regenerated delivery bytes").run).toContain("verify-generated");
+	});
+
+	it("records pending identity only after verification and resumes an existing branch and PR", async () => {
+		const steps = await workflowSteps();
+		const names = steps.map(step => step.name ?? "");
+		const generationIndex = names.indexOf("Generate exact minimum-settings defaults table");
+		const recordIndex = names.indexOf("Record exact generated delivery attestation");
+		const verifyIndex = names.indexOf("Verify exact regenerated delivery bytes");
+		const commitIndex = names.indexOf("Commit and push generated delivery");
+		expect(recordIndex).toBeGreaterThan(generationIndex);
+		expect(verifyIndex).toBeGreaterThan(recordIndex);
+		expect(commitIndex).toBeGreaterThan(verifyIndex);
+		expect(namedStep(steps, "Record exact generated delivery attestation").run).toContain("record-pending");
+
+		const branch = namedStep(steps, "Prepare deterministic delivery branch").run ?? "";
+		expect(branch).toContain("git ls-remote --exit-code --heads");
+		expect(branch).toContain("verify-pending");
+		expect(branch).toContain("Existing delivery branch contains unexpected paths");
+
+		const publish = namedStep(steps, "Create or resume generated-artifact pull request").run ?? "";
+		expect(publish).toContain('gh pr list --head "$BRANCH" --state all');
+		expect(publish).toContain('gh pr reopen "$PR_NUMBER"');
+		expect(publish).toContain('gh pr merge "$PR_NUMBER" --squash --auto');
+	});
+
+	it("acknowledges on main only after the generated release is published and measured", async () => {
+		const steps = await workflowSteps();
+		const names = steps.map(step => step.name ?? "");
+		const commitIndex = names.indexOf("Commit and push generated delivery");
+		const mergeIndex = names.indexOf("Wait for generated artifacts to merge");
+		const publicationIndex = names.indexOf("Verify post-merge release publication");
+		const acknowledgmentIndex = names.indexOf("Prepare post-publication acknowledgment");
+		const mainIndex = names.indexOf("Verify acknowledgment reached main");
+		expect(mergeIndex).toBeGreaterThan(commitIndex);
+		expect(publicationIndex).toBeGreaterThan(mergeIndex);
+		expect(acknowledgmentIndex).toBeGreaterThan(publicationIndex);
+		expect(mainIndex).toBeGreaterThan(acknowledgmentIndex);
+
+		const generatedCommit = namedStep(steps, "Commit and push generated delivery").run ?? "";
+		expect(generatedCommit).toContain("tools/spec-delivery-pending.json");
+		expect(generatedCommit).not.toContain("tools/spec-deliveries.json");
+
+		const publication = namedStep(steps, "Verify post-merge release publication").run ?? "";
+		expect(publication).toContain("gh run list --workflow ci.yml --event push");
+		expect(publication).toContain("@f5-sales-demo/xcsh@$VERSION");
+		expect(publication).toContain("@f5-sales-demo/pi-resource-management@$VERSION");
+		expect(publication).toContain(".gitHead == $commit");
+		expect(publication).toContain(".immutable == true");
+		expect(publication).toContain("MERGE_BLOB");
+		expect(publication).toContain("xcsh-publication-receipt.json");
+		expect(namedStep(steps, "Prepare post-publication acknowledgment").run).toContain(
+			"api-spec-delivery.ts acknowledge",
+		);
+		expect(namedStep(steps, "Prepare post-publication acknowledgment").run).toContain("xcsh-publication-receipts");
+		expect(namedStep(steps, "Verify acknowledgment reached main").run).toContain("verify-ledger");
+	});
+
+	it("never interpolates raw dispatch payload values into shell scripts", async () => {
+		for (const step of await workflowSteps()) {
+			expect(step.run ?? "").not.toContain("github.event.client_payload");
+		}
+	});
+});
+
+describe("provider publication evidence gate", () => {
+	it("resolves only the provider tag bound to the exact delivery and measured release bytes", async () => {
+		const fixture = await providerEvidenceFixture();
+		try {
+			const result = await runProviderEvidenceStep(fixture);
+			expect(result.exitCode).toBe(0);
+			expect(await Bun.file(fixture.output).text()).toContain(`provider_tag=${fixture.providerTag}`);
+		} finally {
+			await fs.rm(fixture.root, { force: true, recursive: true });
+		}
+	}, 60_000);
+
+	it("rejects durable evidence that does not match GitHub's release digest", async () => {
+		const fixture = await providerEvidenceFixture(true);
+		try {
+			const result = await runProviderEvidenceStep(fixture);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.output).toContain("Provider release bytes differ from publication evidence");
+		} finally {
+			await fs.rm(fixture.root, { force: true, recursive: true });
+		}
+	}, 60_000);
+
+	it("rejects noncanonical and mismatched provider ledgers", async () => {
+		const noncanonical = await providerEvidenceFixture();
+		try {
+			const ledger = await Bun.file(noncanonical.env.FIXTURE_LEDGER).json();
+			const detailed = await Bun.file(noncanonical.env.FIXTURE_DETAILED).json();
+			const canonicalId = Object.keys(ledger.deliveries)[0];
+			const forgedId = "0".repeat(64);
+			ledger.deliveries[forgedId] = ledger.deliveries[canonicalId];
+			detailed.receipts[forgedId] = detailed.receipts[canonicalId];
+			delete ledger.deliveries[canonicalId];
+			delete detailed.receipts[canonicalId];
+			await Bun.write(noncanonical.env.FIXTURE_LEDGER, `${JSON.stringify(ledger)}\n`);
+			await Bun.write(noncanonical.env.FIXTURE_DETAILED, `${JSON.stringify(detailed)}\n`);
+			const result = await runProviderEvidenceStep(noncanonical);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.output).toContain("Provider delivery ledger contains a noncanonical key");
+		} finally {
+			await fs.rm(noncanonical.root, { force: true, recursive: true });
+		}
+
+		const mismatched = await providerEvidenceFixture();
+		try {
+			const detailed = await Bun.file(mismatched.env.FIXTURE_DETAILED).json();
+			const deliveryId = Object.keys(detailed.receipts)[0];
+			detailed.receipts[deliveryId].delivery.target_commit = "d".repeat(40);
+			await Bun.write(mismatched.env.FIXTURE_DETAILED, `${JSON.stringify(detailed)}\n`);
+			const result = await runProviderEvidenceStep(mismatched);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.output).toContain("Provider publication ledger contains malformed evidence");
+		} finally {
+			await fs.rm(mismatched.root, { force: true, recursive: true });
+		}
+	}, 60_000);
+});
+
+describe("exact API spec generator contract", () => {
+	it("bypasses local sources and requires exact-version bundle, catalog, and validation data", async () => {
+		const source = await Bun.file(generatorPath).text();
+		const exactSource = source.indexOf(
+			"if (identity) {\n\t\treturn downloadFromRelease(identity.releaseTag, expectedBundleSha256);",
+		);
+		const localOverride = source.indexOf("const envDir = process.env.API_SPECS_DIR");
+		expect(exactSource).toBeGreaterThan(-1);
+		expect(localOverride).toBeGreaterThan(exactSource);
+		expect(source).toContain(
+			'downloadJsonReleaseAsset(identity.releaseTag, "api-catalog.json", true, expectedCatalogSha256)',
+		);
+		expect(source).toContain("differs from its immutable publication receipt");
+		expect(source).toContain("Required validation.json is absent from the");
+		expect(source).toContain("identity.releaseTag");
+		expect(source).toContain('validateArtifactVersion(rawIndex, releaseIdentity, "index.json")');
+		expect(source).toContain('validateArtifactVersion(catalog, releaseIdentity, "api-catalog.json")');
+	});
+});
+
+interface ProviderEvidenceFixture {
+	root: string;
+	bin: string;
+	output: string;
+	providerTag: string;
+	env: Record<string, string>;
+}
+
+async function providerEvidenceFixture(falseDigest = false): Promise<ProviderEvidenceFixture> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-provider-evidence-"));
+	const bin = path.join(root, "bin");
+	await fs.mkdir(bin);
+	const specVersion = "2.1.208";
+	const specTag = `v${specVersion}`;
+	const specCommit = "a".repeat(40);
+	const providerVersion = "9.8.7";
+	const providerTag = `v${providerVersion}`;
+	const providerCommit = "b".repeat(40);
+	const providerMainCommit = "c".repeat(40);
+	const providerDeliveryId = calculateDeliveryIdForTarget(
+		{
+			releaseTag: specTag,
+			targetCommit: specCommit,
+			triggerSource: "f5-sales-demo/api-specs-enriched",
+			version: specVersion,
+		},
+		"f5-sales-demo/terraform-provider-xcsh",
+	);
+	const pin = `${JSON.stringify({
+		assets: {
+			"api-catalog.json": "1".repeat(64),
+			[`f5xc-api-specs-${specTag}.zip`]: "2".repeat(64),
+			"index.json": "3".repeat(64),
+			"minimal-export-defaults.json": "4".repeat(64),
+			"openapi.json": "5".repeat(64),
+		},
+		release_tag: specTag,
+		target_commit: specCommit,
+		version: specVersion,
+	})}\n`;
+	const pinSha = new Bun.CryptoHasher("sha256").update(pin).digest("hex");
+	const assets = Object.fromEntries(
+		providerAssetNames(providerVersion).map((name, index) => [name, (index + 1).toString(16).padStart(64, "0")]),
+	);
+	const evidence = {
+		assets,
+		commit: providerCommit,
+		spec_release_sha256: pinSha,
+		tag: providerTag,
+		version: providerVersion,
+	};
+	const ledger = {
+		deliveries: {
+			[providerDeliveryId]: { release_tag: specTag, target_commit: specCommit, version: specVersion },
+		},
+		version: 1,
+	};
+	const detailed = {
+		receipts: {
+			[providerDeliveryId]: {
+				delivery: { release_tag: specTag, target_commit: specCommit, version: specVersion },
+				publication: evidence,
+			},
+		},
+		version: 1,
+	};
+	const release = {
+		assets: providerAssetNames(providerVersion).map(name => ({
+			digest: `sha256:${falseDigest && name.startsWith("mcp-data-") ? "0".repeat(64) : assets[name]}`,
+			name,
+		})),
+		body: `notes\n<!-- provider-publication-receipt:${JSON.stringify(evidence)} -->\n`,
+		draft: false,
+		immutable: true,
+		prerelease: false,
+		tag_name: providerTag,
+	};
+	await Bun.write(path.join(root, "ledger.json"), `${JSON.stringify(ledger)}\n`);
+	await Bun.write(path.join(root, "detailed.json"), `${JSON.stringify(detailed)}\n`);
+	await Bun.write(path.join(root, "release.json"), `${JSON.stringify(release)}\n`);
+	await Bun.write(path.join(root, "pin.json"), pin);
+	await Bun.write(
+		path.join(bin, "gh"),
+		`#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *git/ref/heads/main*) printf '%s\n' "$FIXTURE_MAIN_COMMIT" ;;
+  *contents/tools/spec-deliveries.json*) cat "$FIXTURE_LEDGER" ;;
+  *contents/tools/provider-publication-receipts.json*) cat "$FIXTURE_DETAILED" ;;
+  *commits/v9.8.7*) printf '%s\n' "$FIXTURE_PROVIDER_COMMIT" ;;
+  *releases/tags/v9.8.7*) cat "$FIXTURE_RELEASE" ;;
+  *contents/tools/spec-release.json*) cat "$FIXTURE_PIN" ;;
+  *contents/tools/spec-version.txt*) printf '%s\n' "$FIXTURE_SPEC_TAG" ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 9 ;;
+esac
+`,
+	);
+	await fs.chmod(path.join(bin, "gh"), 0o700);
+	return {
+		bin,
+		output: path.join(root, "github-output"),
+		providerTag,
+		root,
+		env: {
+			EXPECTED_COMMIT: specCommit,
+			EXPECTED_DELIVERY_ID: providerDeliveryId,
+			EXPECTED_SPEC_TAG: specTag,
+			EXPECTED_SPEC_VERSION: specVersion,
+			FIXTURE_DETAILED: path.join(root, "detailed.json"),
+			FIXTURE_LEDGER: path.join(root, "ledger.json"),
+			FIXTURE_MAIN_COMMIT: providerMainCommit,
+			FIXTURE_PIN: path.join(root, "pin.json"),
+			FIXTURE_PROVIDER_COMMIT: providerCommit,
+			FIXTURE_RELEASE: path.join(root, "release.json"),
+			FIXTURE_SPEC_TAG: specTag,
+			GH_TOKEN: "fixture",
+			GITHUB_OUTPUT: path.join(root, "github-output"),
+			RUNNER_TEMP: root,
+			SOURCE_PIN_FILE: path.join(root, "pin.json"),
+		},
+	};
+}
+
+async function runProviderEvidenceStep(
+	fixture: ProviderEvidenceFixture,
+): Promise<{ exitCode: number; output: string }> {
+	const provider = namedStep(await workflowSteps(), "Resolve exact published provider release").run ?? "";
+	const child = Bun.spawn(["bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", provider], {
+		cwd: fixture.root,
+		env: { ...process.env, ...fixture.env, PATH: `${fixture.bin}${path.delimiter}${process.env.PATH ?? ""}` },
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+	const [exitCode, stdout, stderr] = await Promise.all([
+		child.exited,
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+	]);
+	return { exitCode, output: `${stdout}${stderr}` };
+}
+
+function providerAssetNames(version: string): string[] {
+	return [
+		`terraform-provider-xcsh_${version}_darwin_amd64.zip`,
+		`terraform-provider-xcsh_${version}_darwin_arm64.zip`,
+		`terraform-provider-xcsh_${version}_freebsd_386.zip`,
+		`terraform-provider-xcsh_${version}_freebsd_amd64.zip`,
+		`terraform-provider-xcsh_${version}_linux_386.zip`,
+		`terraform-provider-xcsh_${version}_linux_amd64.zip`,
+		`terraform-provider-xcsh_${version}_linux_arm.zip`,
+		`terraform-provider-xcsh_${version}_linux_arm64.zip`,
+		`terraform-provider-xcsh_${version}_manifest.json`,
+		`terraform-provider-xcsh_${version}_SHA256SUMS`,
+		`terraform-provider-xcsh_${version}_SHA256SUMS.sig`,
+		`terraform-provider-xcsh_${version}_windows_386.zip`,
+		`terraform-provider-xcsh_${version}_windows_amd64.zip`,
+		`mcp-data-${version}.tar.gz`,
+	];
+}

--- a/packages/coding-agent/test/scripts/ci-workflow-contract.test.ts
+++ b/packages/coding-agent/test/scripts/ci-workflow-contract.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test";
+import * as path from "node:path";
+import { parse } from "yaml";
+
+interface WorkflowJob {
+	name?: unknown;
+}
+
+interface WorkflowDocument {
+	jobs?: Record<string, WorkflowJob>;
+}
+
+const CI_WORKFLOW = path.resolve(import.meta.dir, "../../../../.github/workflows/ci.yml");
+
+test("protected CI jobs expose the exact required check-run names", async () => {
+	const workflow = parse(await Bun.file(CI_WORKFLOW).text()) as WorkflowDocument;
+
+	expect(workflow.jobs?.check?.name).toBe("check");
+	expect(workflow.jobs?.test?.name).toBe("test");
+});

--- a/packages/coding-agent/test/scripts/terraform-index-delivery.test.ts
+++ b/packages/coding-agent/test/scripts/terraform-index-delivery.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { exactProviderIndexUrl, loadTerraformIndex } from "../../scripts/generate-terraform-index";
+
+const PROVIDER_TAG = "v3.73.0";
+const PROVIDER_COMMIT = "a".repeat(40);
+const EXACT_URL = `https://raw.githubusercontent.com/f5-sales-demo/terraform-provider-xcsh/${PROVIDER_COMMIT}/docs/terraform-llms-index.json`;
+
+describe("Terraform index exact provider delivery", () => {
+	it("bypasses mutable local/main sources for the immutable provider tag", async () => {
+		const requested: string[] = [];
+		const document = { provider: { source: "f5-sales-demo/xcsh" }, version: "0.1.0" };
+		const fetcher = async (input: string | URL | Request): Promise<Response> => {
+			requested.push(String(input));
+			return Response.json(document);
+		};
+
+		const loaded = await loadTerraformIndex(
+			{ TERRAFORM_PROVIDER_COMMIT: PROVIDER_COMMIT, TERRAFORM_PROVIDER_TAG: PROVIDER_TAG },
+			fetcher,
+		);
+
+		expect(requested).toEqual([EXACT_URL]);
+		expect(loaded).toEqual({ data: document, providerCommit: PROVIDER_COMMIT, providerTag: PROVIDER_TAG });
+	});
+
+	it("fails when the exact provider release has no Terraform index", async () => {
+		const fetcher = async (): Promise<Response> => new Response("not found", { status: 404 });
+
+		await expect(
+			loadTerraformIndex(
+				{ TERRAFORM_PROVIDER_COMMIT: PROVIDER_COMMIT, TERRAFORM_PROVIDER_TAG: PROVIDER_TAG },
+				fetcher,
+			),
+		).rejects.toThrow(
+			`Failed to fetch terraform-llms-index.json from provider release v3.73.0 at ${PROVIDER_COMMIT}: 404`,
+		);
+	});
+
+	it("rejects a mutable or malformed provider ref", async () => {
+		expect(() => exactProviderIndexUrl("main")).toThrow("full lowercase Git SHA");
+		expect(exactProviderIndexUrl(PROVIDER_COMMIT)).toBe(EXACT_URL);
+		await expect(loadTerraformIndex({ TERRAFORM_PROVIDER_TAG: PROVIDER_TAG })).rejects.toThrow(
+			"TERRAFORM_PROVIDER_TAG and TERRAFORM_PROVIDER_COMMIT must be provided together",
+		);
+	});
+});

--- a/packages/resource-management/scripts/generate-defaults.ts
+++ b/packages/resource-management/scripts/generate-defaults.ts
@@ -10,17 +10,19 @@
  * duplicated here.
  *
  * Source resolution (first hit wins):
- *   1. $API_SPECS_DEFAULTS_FILE         — explicit path to the artifact
- *   2. ../../../../api-specs-enriched/docs/specifications/api/minimal-export-defaults.json (local checkout)
- *   3. GitHub latest release asset       — minimal-export-defaults.json from $REPO
- *   4. none found                        — emit an empty table + warn (non-fatal)
+ *   1. Exact dispatched release          — when $API_SPECS_VERSION and $API_SPECS_TAG are both set
+ *   2. $API_SPECS_DEFAULTS_FILE          — explicit path to the artifact
+ *   3. ../../../../api-specs-enriched/docs/specifications/api/minimal-export-defaults.json (local checkout)
+ *   4. GitHub latest release asset       — minimal-export-defaults.json from $REPO
+ *   5. none found                        — emit an empty table + warn (non-fatal)
  *
- * The empty-table fallback is intentional: a kind with no entry exports
- * everything (today's behavior), so the build never breaks while
- * api-specs-enriched coverage is still being filled in.
+ * The empty-table fallback applies only to non-dispatch development: a kind
+ * with no entry exports everything (today's behavior). Exact dispatched
+ * releases must include a matching artifact and never use this fallback.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { type ApiSpecReleaseIdentity, releaseIdentityFromEnvironment } from "../../../scripts/api-spec-delivery";
 
 const REPO = "f5-sales-demo/api-specs-enriched";
 const ARTIFACT_NAME = "minimal-export-defaults.json";
@@ -41,14 +43,26 @@ interface DefaultsArtifact {
 	resources: Record<string, Partial<KindDefaultsMetadata>>;
 }
 
-async function fetchWithRetry(url: string, init?: RequestInit): Promise<Response> {
+type Fetcher = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+interface LoadedArtifact {
+	text: string;
+	source: string;
+}
+
+interface ParsedArtifact {
+	table: Record<string, KindDefaultsMetadata>;
+	version: string;
+}
+
+async function fetchWithRetry(url: string, init?: RequestInit, fetcher: Fetcher = globalThis.fetch): Promise<Response> {
 	let lastError: Error | null = null;
 	for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
 		if (attempt > 0) {
 			await Bun.sleep(INITIAL_BACKOFF_MS * 2 ** (attempt - 1));
 		}
 		try {
-			const response = await fetch(url, init);
+			const response = await fetcher(url, init);
 			if (response.status === 403 || response.status === 429) {
 				const retryAfter = response.headers.get("retry-after");
 				const waitMs = retryAfter ? Number.parseInt(retryAfter, 10) * 1000 : INITIAL_BACKOFF_MS * 2 ** attempt;
@@ -72,11 +86,15 @@ function githubHeaders(): Record<string, string> {
 	return headers;
 }
 
-async function resolveLatestTag(): Promise<string | undefined> {
+async function resolveLatestTag(fetcher: Fetcher): Promise<string | undefined> {
 	try {
-		const response = await fetchWithRetry(`https://api.github.com/repos/${REPO}/releases/latest`, {
-			headers: githubHeaders(),
-		});
+		const response = await fetchWithRetry(
+			`https://api.github.com/repos/${REPO}/releases/latest`,
+			{
+				headers: githubHeaders(),
+			},
+			fetcher,
+		);
 		if (!response.ok) return undefined;
 		const data = (await response.json()) as { tag_name?: string };
 		return data.tag_name;
@@ -85,9 +103,36 @@ async function resolveLatestTag(): Promise<string | undefined> {
 	}
 }
 
+function releaseArtifactUrl(releaseTag: string): string {
+	return `https://github.com/${REPO}/releases/download/${releaseTag}/${ARTIFACT_NAME}`;
+}
+
 /** Returns the raw artifact JSON text, or undefined if no source is available. */
-async function loadArtifactText(): Promise<{ text: string; source: string } | undefined> {
-	const envFile = process.env.API_SPECS_DEFAULTS_FILE;
+export async function loadArtifactText(
+	env: Record<string, string | undefined> = process.env,
+	fetcher: Fetcher = globalThis.fetch,
+): Promise<LoadedArtifact | undefined> {
+	const releaseIdentity = releaseIdentityFromEnvironment(env);
+	if (releaseIdentity) {
+		const expectedSha256 = env.API_SPECS_DEFAULTS_SHA256;
+		if (!expectedSha256 || !/^[0-9a-f]{64}$/.test(expectedSha256)) {
+			throw new Error("API_SPECS_DEFAULTS_SHA256 must be a lowercase SHA-256 digest");
+		}
+		const url = releaseArtifactUrl(releaseIdentity.releaseTag);
+		const response = await fetchWithRetry(url, { redirect: "follow" }, fetcher);
+		if (!response.ok) {
+			throw new Error(
+				`${ARTIFACT_NAME} is absent from dispatched release ${releaseIdentity.releaseTag} (${response.status})`,
+			);
+		}
+		const bytes = new Uint8Array(await response.arrayBuffer());
+		if (new Bun.CryptoHasher("sha256").update(bytes).digest("hex") !== expectedSha256) {
+			throw new Error(`${ARTIFACT_NAME} differs from its immutable publication receipt`);
+		}
+		return { text: new TextDecoder().decode(bytes), source: url };
+	}
+
+	const envFile = env.API_SPECS_DEFAULTS_FILE;
 	if (envFile && fs.existsSync(envFile)) {
 		return { text: fs.readFileSync(envFile, "utf8"), source: envFile };
 	}
@@ -100,10 +145,10 @@ async function loadArtifactText(): Promise<{ text: string; source: string } | un
 		return { text: fs.readFileSync(localCheckout, "utf8"), source: localCheckout };
 	}
 
-	const tag = process.env.API_SPECS_TAG ?? (await resolveLatestTag());
+	const tag = await resolveLatestTag(fetcher);
 	if (tag) {
-		const url = `https://github.com/${REPO}/releases/download/${tag}/${ARTIFACT_NAME}`;
-		const response = await fetchWithRetry(url, { redirect: "follow" });
+		const url = releaseArtifactUrl(tag);
+		const response = await fetchWithRetry(url, { redirect: "follow" }, fetcher);
 		if (response.ok) {
 			return { text: await response.text(), source: url };
 		}
@@ -122,6 +167,21 @@ function normalizeEntry(raw: Partial<KindDefaultsMetadata>): KindDefaultsMetadat
 	};
 }
 
+export function parseArtifact(loaded: LoadedArtifact, releaseIdentity?: ApiSpecReleaseIdentity): ParsedArtifact {
+	const artifact = JSON.parse(loaded.text) as DefaultsArtifact;
+	if (releaseIdentity && artifact.version !== releaseIdentity.version) {
+		throw new Error(
+			`${ARTIFACT_NAME} version ${String(artifact.version)} does not match dispatched version ${releaseIdentity.version}`,
+		);
+	}
+
+	const table: Record<string, KindDefaultsMetadata> = {};
+	for (const [kind, raw] of Object.entries(artifact.resources ?? {})) {
+		table[kind] = normalizeEntry(raw);
+	}
+	return { table, version: artifact.version ?? "unknown" };
+}
+
 function render(table: Record<string, KindDefaultsMetadata>, source: string | undefined, version: string): string {
 	const kinds = Object.keys(table).sort();
 	const body = JSON.stringify(Object.fromEntries(kinds.map(k => [k, table[k]])), null, "\t");
@@ -138,19 +198,18 @@ export const DEFAULTS_METADATA: Record<string, KindDefaultsMetadata> = ${body};
 }
 
 async function main(): Promise<void> {
-	const loaded = await loadArtifactText();
+	const releaseIdentity = releaseIdentityFromEnvironment(process.env);
+	const loaded = await loadArtifactText(process.env);
 
 	let table: Record<string, KindDefaultsMetadata> = {};
 	let version = "unknown";
 	let source: string | undefined;
 
 	if (loaded) {
-		const artifact = JSON.parse(loaded.text) as DefaultsArtifact;
-		version = artifact.version ?? "unknown";
+		const parsed = parseArtifact(loaded, releaseIdentity);
+		table = parsed.table;
+		version = parsed.version;
 		source = loaded.source;
-		for (const [kind, raw] of Object.entries(artifact.resources ?? {})) {
-			table[kind] = normalizeEntry(raw);
-		}
 		console.log(`Loaded ${Object.keys(table).length} kinds from ${loaded.source}`);
 	} else {
 		console.warn(`WARNING: no ${ARTIFACT_NAME} source found — writing an empty defaults table.`);
@@ -162,4 +221,4 @@ async function main(): Promise<void> {
 	console.log(`Wrote ${outputPath}`);
 }
 
-await main();
+if (import.meta.main) await main();

--- a/packages/resource-management/test/generate-defaults.test.ts
+++ b/packages/resource-management/test/generate-defaults.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import { loadArtifactText, parseArtifact } from "../scripts/generate-defaults";
+
+const RELEASE_TAG = "v2.1.208";
+const VERSION = "2.1.208";
+const EXACT_ARTIFACT_URL =
+	"https://github.com/f5-sales-demo/api-specs-enriched/releases/download/v2.1.208/minimal-export-defaults.json";
+
+describe("generate-defaults exact release delivery", () => {
+	it("downloads only the artifact attached to the dispatched release", async () => {
+		const requestedUrls: string[] = [];
+		const artifact = JSON.stringify({ resources: {}, version: VERSION });
+		const artifactSha256 = new Bun.CryptoHasher("sha256").update(artifact).digest("hex");
+		const fetcher = async (input: string | URL | Request): Promise<Response> => {
+			requestedUrls.push(String(input));
+			return new Response(artifact);
+		};
+
+		const loaded = await loadArtifactText(
+			{
+				API_SPECS_DEFAULTS_FILE: "/a/local/override/must/not/win.json",
+				API_SPECS_DEFAULTS_SHA256: artifactSha256,
+				API_SPECS_TAG: RELEASE_TAG,
+				API_SPECS_VERSION: VERSION,
+			},
+			fetcher,
+		);
+
+		expect(requestedUrls).toEqual([EXACT_ARTIFACT_URL]);
+		expect(loaded).toEqual({ source: EXACT_ARTIFACT_URL, text: artifact });
+	});
+
+	it("fails when the dispatched release has no defaults artifact", async () => {
+		const fetcher = async (): Promise<Response> => new Response("not found", { status: 404 });
+
+		await expect(
+			loadArtifactText(
+				{ API_SPECS_DEFAULTS_SHA256: "0".repeat(64), API_SPECS_TAG: RELEASE_TAG, API_SPECS_VERSION: VERSION },
+				fetcher,
+			),
+		).rejects.toThrow(`minimal-export-defaults.json is absent from dispatched release ${RELEASE_TAG} (404)`);
+	});
+
+	it("rejects downloaded defaults whose bytes differ from the publication receipt", async () => {
+		const fetcher = async (): Promise<Response> => Response.json({ resources: {}, version: VERSION });
+		await expect(
+			loadArtifactText(
+				{ API_SPECS_DEFAULTS_SHA256: "0".repeat(64), API_SPECS_TAG: RELEASE_TAG, API_SPECS_VERSION: VERSION },
+				fetcher,
+			),
+		).rejects.toThrow("differs from its immutable publication receipt");
+	});
+
+	it("rejects an artifact whose version differs from the dispatched version", () => {
+		expect(() =>
+			parseArtifact(
+				{
+					source: EXACT_ARTIFACT_URL,
+					text: JSON.stringify({ resources: {}, version: "2.1.207" }),
+				},
+				{ releaseTag: RELEASE_TAG, version: VERSION },
+			),
+		).toThrow("minimal-export-defaults.json version 2.1.207 does not match dispatched version 2.1.208");
+	});
+
+	it("requires a version field that exactly matches the dispatched version", () => {
+		expect(() =>
+			parseArtifact(
+				{ source: EXACT_ARTIFACT_URL, text: JSON.stringify({ resources: {} }) },
+				{ releaseTag: RELEASE_TAG, version: VERSION },
+			),
+		).toThrow("minimal-export-defaults.json version undefined does not match dispatched version 2.1.208");
+	});
+});

--- a/scripts/api-spec-delivery.ts
+++ b/scripts/api-spec-delivery.ts
@@ -1,0 +1,926 @@
+#!/usr/bin/env bun
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+const SOURCE_REPOSITORY = "f5-sales-demo/api-specs-enriched";
+const TARGET_REPOSITORY = "f5-sales-demo/xcsh";
+const PROVIDER_REPOSITORY = "f5-sales-demo/terraform-provider-xcsh";
+const EVENT_TYPE = "enriched-specs-updated";
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+const DELIVERY_ID_PATTERN = /^[0-9a-f]{64}$/;
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const LEDGER_VERSION = 1;
+
+export const DELIVERY_LEDGER_PATH = "tools/spec-deliveries.json";
+export const DELIVERY_PENDING_PATH = "tools/spec-delivery-pending.json";
+export const DELIVERY_PUBLICATION_LEDGER_PATH = "tools/xcsh-publication-receipts.json";
+export const SPEC_RELEASE_PATH = "tools/spec-release.json";
+
+export const GENERATED_DELIVERY_PATHS = [
+	"packages/coding-agent/src/internal-urls/api-catalog-index.generated.ts",
+	"packages/coding-agent/src/internal-urls/api-spec-index.generated.ts",
+	"packages/coding-agent/src/internal-urls/terraform-index.generated.ts",
+	"packages/resource-management/src/defaults-metadata.generated.ts",
+] as const;
+
+const XCSH_PACKAGES = ["@f5-sales-demo/pi-resource-management", "@f5-sales-demo/xcsh"] as const;
+
+const XCSH_RELEASE_ASSETS = [
+	"pi_natives.darwin-arm64.node",
+	"pi_natives.darwin-x64-baseline.node",
+	"pi_natives.darwin-x64-modern.node",
+	"pi_natives.linux-arm64.node",
+	"pi_natives.linux-x64-baseline.node",
+	"pi_natives.linux-x64-modern.node",
+	"pi_natives.win32-x64-baseline.node",
+	"pi_natives.win32-x64-modern.node",
+	"xcsh-darwin-arm64",
+	"xcsh-darwin-arm64.zip",
+	"xcsh-darwin-x64",
+	"xcsh-darwin-x64.zip",
+	"xcsh-linux-arm64",
+	"xcsh-linux-arm64.tar.gz",
+	"xcsh-linux-x64",
+	"xcsh-linux-x64.tar.gz",
+	"xcsh-windows-x64.exe",
+] as const;
+
+export interface ApiSpecReleaseIdentity {
+	version: string;
+	releaseTag: string;
+}
+
+export interface ApiSpecDelivery extends ApiSpecReleaseIdentity {
+	deliveryId: string;
+	targetCommit: string;
+	triggerSource: string;
+}
+
+export interface ApiSpecDeliveryLedgerEntry {
+	release_tag: string;
+	target_commit: string;
+	version: string;
+}
+
+export interface ApiSpecDeliveryLedger {
+	deliveries: Record<string, ApiSpecDeliveryLedgerEntry>;
+	version: 1;
+}
+
+interface ApiSpecPendingDelivery {
+	delivery_id: string;
+	generated: Record<string, string>;
+	provider: {
+		commit: string;
+		tag: string;
+	};
+	release_tag: string;
+	spec_release_sha256: string;
+	target_commit: string;
+	trigger_source: string;
+	version: string;
+}
+
+export interface ApiSpecReleasePin {
+	assets: Record<string, string>;
+	release_tag: string;
+	target_commit: string;
+	version: string;
+}
+
+export interface SourcePublicationReceipt {
+	assets: Record<string, string>;
+	commit: string;
+	version: string;
+}
+
+interface XcshNpmEvidence {
+	git_head: string;
+	integrity: string;
+}
+
+export interface XcshPublicationEvidence {
+	assets: Record<string, string>;
+	commit: string;
+	generated: Record<string, string>;
+	npm: Record<string, XcshNpmEvidence>;
+	provider: {
+		commit: string;
+		tag: string;
+	};
+	spec_release_sha256: string;
+	tag: string;
+	version: string;
+}
+
+interface XcshPublicationReceiptEntry {
+	delivery: ApiSpecDeliveryLedgerEntry;
+	publication: XcshPublicationEvidence;
+}
+
+interface XcshPublicationReceiptLedger {
+	receipts: Record<string, XcshPublicationReceiptEntry>;
+	version: 1;
+}
+
+type Fetcher = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+interface FileError extends Error {
+	code: string;
+}
+
+function isEnoent(error: unknown): error is FileError {
+	return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function requiredString(value: unknown, field: string): string {
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`Dispatch payload field ${field} is required`);
+	}
+	return value;
+}
+
+export function validateReleaseIdentity(version: string, releaseTag: string): ApiSpecReleaseIdentity {
+	if (!SEMVER_PATTERN.test(version)) {
+		throw new Error(`Dispatch version is not semantic: ${version}`);
+	}
+	if (releaseTag !== `v${version}`) {
+		throw new Error(`Dispatch release_tag ${releaseTag} does not match version ${version}`);
+	}
+	return { version, releaseTag };
+}
+
+export function releaseIdentityFromEnvironment(
+	env: Record<string, string | undefined>,
+): ApiSpecReleaseIdentity | undefined {
+	const version = env.API_SPECS_VERSION;
+	const releaseTag = env.API_SPECS_TAG;
+	if (version === undefined && releaseTag === undefined) return undefined;
+	if (version === undefined || releaseTag === undefined) {
+		throw new Error("API_SPECS_VERSION and API_SPECS_TAG must be provided together");
+	}
+	return validateReleaseIdentity(version, releaseTag);
+}
+
+export function validateArtifactVersion(
+	document: unknown,
+	identity: ApiSpecReleaseIdentity,
+	artifactName: string,
+): void {
+	if (!document || typeof document !== "object") {
+		throw new Error(`${artifactName} must be a JSON object`);
+	}
+	const version = (document as Record<string, unknown>).version;
+	if (version !== identity.version) {
+		throw new Error(`${artifactName} version ${String(version)} does not match dispatched version ${identity.version}`);
+	}
+}
+
+function expectedSpecAssetNames(releaseTag: string): string[] {
+	return [
+		"api-catalog.json",
+		`f5xc-api-specs-${releaseTag}.zip`,
+		"index.json",
+		"minimal-export-defaults.json",
+		"openapi.json",
+	].sort();
+}
+
+function validateDigestMap(document: unknown, expectedNames: readonly string[], field: string): Record<string, string> {
+	if (!document || typeof document !== "object" || Array.isArray(document)) {
+		throw new Error(`${field} must be an object`);
+	}
+	const digests = document as Record<string, unknown>;
+	if (JSON.stringify(sortedKeys(digests)) !== JSON.stringify([...expectedNames].sort())) {
+		throw new Error(`${field} has the wrong asset set`);
+	}
+	const validated: Record<string, string> = {};
+	for (const [name, value] of Object.entries(digests)) {
+		if (typeof value !== "string" || !SHA256_PATTERN.test(value)) {
+			throw new Error(`${field}.${name} must be a lowercase SHA-256 digest`);
+		}
+		validated[name] = value;
+	}
+	return validated;
+}
+
+export function parseSpecReleasePin(document: unknown, delivery?: ApiSpecDelivery): ApiSpecReleasePin {
+	if (!document || typeof document !== "object" || Array.isArray(document)) {
+		throw new Error("Spec release pin must be an object");
+	}
+	const pin = document as Record<string, unknown>;
+	if (JSON.stringify(sortedKeys(pin)) !== JSON.stringify(["assets", "release_tag", "target_commit", "version"])) {
+		throw new Error("Spec release pin has an invalid shape");
+	}
+	const version = requiredString(pin.version, "spec-release.version");
+	const releaseTag = requiredString(pin.release_tag, "spec-release.release_tag");
+	validateReleaseIdentity(version, releaseTag);
+	const targetCommit = requiredString(pin.target_commit, "spec-release.target_commit");
+	if (!COMMIT_PATTERN.test(targetCommit)) throw new Error("Spec release pin has an invalid target_commit");
+	if (delivery &&
+		(version !== delivery.version || releaseTag !== delivery.releaseTag || targetCommit !== delivery.targetCommit)) {
+		throw new Error("Spec release pin disagrees with the dispatched identity");
+	}
+	return {
+		assets: validateDigestMap(pin.assets, expectedSpecAssetNames(releaseTag), "spec-release.assets"),
+		release_tag: releaseTag,
+		target_commit: targetCommit,
+		version,
+	};
+}
+
+function sha256Bytes(bytes: Uint8Array | string): string {
+	return new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
+}
+
+async function sha256File(file: string): Promise<string> {
+	return sha256Bytes(await fs.readFile(file));
+}
+
+export function calculateDeliveryId(delivery: Omit<ApiSpecDelivery, "deliveryId">): string {
+	return calculateDeliveryIdForTarget(delivery, TARGET_REPOSITORY);
+}
+
+export function calculateDeliveryIdForTarget(
+	delivery: Omit<ApiSpecDelivery, "deliveryId">,
+	targetRepository: string,
+): string {
+	const canonical = JSON.stringify({
+		commit: delivery.targetCommit,
+		event_type: EVENT_TYPE,
+		source: delivery.triggerSource,
+		tag: delivery.releaseTag,
+		target: targetRepository,
+		version: delivery.version,
+	});
+	return new Bun.CryptoHasher("sha256").update(canonical).digest("hex");
+}
+
+export function parseDispatchEvent(document: unknown): ApiSpecDelivery {
+	if (!document || typeof document !== "object") throw new Error("Dispatch event must be an object");
+	const event = document as Record<string, unknown>;
+	if (event.action !== EVENT_TYPE) {
+		throw new Error(`Unexpected repository_dispatch action: ${String(event.action)}`);
+	}
+	const rawPayload = event.client_payload;
+	if (!rawPayload || typeof rawPayload !== "object") {
+		throw new Error("Dispatch event has no client_payload object");
+	}
+	const payload = rawPayload as Record<string, unknown>;
+	const version = requiredString(payload.version, "version");
+	const releaseTag = requiredString(payload.release_tag, "release_tag");
+	validateReleaseIdentity(version, releaseTag);
+	const triggerSource = requiredString(payload.trigger_source, "trigger_source");
+	if (triggerSource !== SOURCE_REPOSITORY) {
+		throw new Error(`Unexpected dispatch source: ${triggerSource}`);
+	}
+	const targetCommit = requiredString(payload.target_commit, "target_commit");
+	if (!COMMIT_PATTERN.test(targetCommit)) {
+		throw new Error("Dispatch target_commit must be a full lowercase Git SHA");
+	}
+	const deliveryId = requiredString(payload.delivery_id, "delivery_id");
+	if (!DELIVERY_ID_PATTERN.test(deliveryId)) {
+		throw new Error("Dispatch delivery_id must be a lowercase SHA-256 digest");
+	}
+	const delivery = { deliveryId, releaseTag, targetCommit, triggerSource, version };
+	const expectedId = calculateDeliveryId(delivery);
+	if (deliveryId !== expectedId) {
+		throw new Error(`Dispatch delivery_id does not match its payload identity`);
+	}
+	return delivery;
+}
+
+export function deliveryBranch(delivery: ApiSpecDelivery): string {
+	return `chore/api-specs-${delivery.releaseTag}-${delivery.deliveryId.slice(0, 12)}`;
+}
+
+function ledgerEntryFor(delivery: ApiSpecDelivery): ApiSpecDeliveryLedgerEntry {
+	return {
+		release_tag: delivery.releaseTag,
+		target_commit: delivery.targetCommit,
+		version: delivery.version,
+	};
+}
+
+async function pendingDeliveryFor(
+	repoRoot: string,
+	delivery: ApiSpecDelivery,
+	pin: ApiSpecReleasePin,
+	providerTag: string,
+	providerCommit: string,
+): Promise<ApiSpecPendingDelivery> {
+	if (!/^v\d+\.\d+\.\d+$/.test(providerTag)) throw new Error("Provider tag must be vMAJOR.MINOR.PATCH");
+	if (!COMMIT_PATTERN.test(providerCommit)) throw new Error("Provider commit must be a full lowercase Git SHA");
+	const generatedEntries = await Promise.all(
+		GENERATED_DELIVERY_PATHS.map(async file => [file, await sha256File(path.join(repoRoot, file))] as const),
+	);
+	return {
+		delivery_id: delivery.deliveryId,
+		generated: Object.fromEntries(generatedEntries),
+		provider: { commit: providerCommit, tag: providerTag },
+		release_tag: delivery.releaseTag,
+		spec_release_sha256: sha256Bytes(`${JSON.stringify(pin, null, "\t")}\n`),
+		target_commit: delivery.targetCommit,
+		trigger_source: delivery.triggerSource,
+		version: delivery.version,
+	};
+}
+
+export function verifyPendingDelivery(document: unknown, delivery: ApiSpecDelivery): ApiSpecPendingDelivery {
+	if (!document || typeof document !== "object" || Array.isArray(document)) {
+		throw new Error("Pending delivery marker must be an object");
+	}
+	const pending = document as Record<string, unknown>;
+	if (
+		JSON.stringify(sortedKeys(pending)) !==
+		JSON.stringify([
+			"delivery_id",
+			"generated",
+			"provider",
+			"release_tag",
+			"spec_release_sha256",
+			"target_commit",
+			"trigger_source",
+			"version",
+		])
+	) {
+		throw new Error("Pending delivery marker has an invalid shape");
+	}
+	const expected = {
+		delivery_id: delivery.deliveryId,
+		release_tag: delivery.releaseTag,
+		target_commit: delivery.targetCommit,
+		trigger_source: delivery.triggerSource,
+		version: delivery.version,
+	};
+	for (const [key, value] of Object.entries(expected)) {
+		if (pending[key] !== value) {
+			throw new Error(`Pending delivery marker disagrees with ${delivery.deliveryId}`);
+		}
+	}
+	const generated = validateDigestMap(pending.generated, GENERATED_DELIVERY_PATHS, "pending.generated");
+	if (!pending.provider || typeof pending.provider !== "object" || Array.isArray(pending.provider)) {
+		throw new Error("Pending provider identity must be an object");
+	}
+	const provider = pending.provider as Record<string, unknown>;
+	if (JSON.stringify(sortedKeys(provider)) !== JSON.stringify(["commit", "tag"])) {
+		throw new Error("Pending provider identity has an invalid shape");
+	}
+	const providerCommit = requiredString(provider.commit, "pending.provider.commit");
+	const providerTag = requiredString(provider.tag, "pending.provider.tag");
+	if (!COMMIT_PATTERN.test(providerCommit) || !/^v\d+\.\d+\.\d+$/.test(providerTag)) {
+		throw new Error("Pending provider identity is malformed");
+	}
+	const specReleaseSha256 = requiredString(pending.spec_release_sha256, "pending.spec_release_sha256");
+	if (!SHA256_PATTERN.test(specReleaseSha256)) throw new Error("Pending spec release digest is malformed");
+	return {
+		...expected,
+		generated,
+		provider: { commit: providerCommit, tag: providerTag },
+		spec_release_sha256: specReleaseSha256,
+	};
+}
+
+function sortedKeys(document: Record<string, unknown>): string[] {
+	return Object.keys(document).sort();
+}
+
+function digestMapsEqual(left: Record<string, string>, right: Record<string, string>): boolean {
+	const keys = Object.keys(left);
+	return keys.length === Object.keys(right).length && keys.every(key => left[key] === right[key]);
+}
+
+function ledgerEntriesEqual(left: ApiSpecDeliveryLedgerEntry, right: ApiSpecDeliveryLedgerEntry): boolean {
+	return (
+		left.release_tag === right.release_tag &&
+		left.target_commit === right.target_commit &&
+		left.version === right.version
+	);
+}
+
+function validateLedgerEntry(deliveryId: string, document: unknown): ApiSpecDeliveryLedgerEntry {
+	if (!DELIVERY_ID_PATTERN.test(deliveryId)) {
+		throw new Error(`Delivery ledger contains an invalid delivery_id: ${deliveryId}`);
+	}
+	if (!document || typeof document !== "object" || Array.isArray(document)) {
+		throw new Error(`Delivery ledger entry ${deliveryId} must be an object`);
+	}
+	const entry = document as Record<string, unknown>;
+	if (JSON.stringify(sortedKeys(entry)) !== JSON.stringify(["release_tag", "target_commit", "version"])) {
+		throw new Error(`Delivery ledger entry ${deliveryId} has an invalid shape`);
+	}
+	const version = requiredString(entry.version, `deliveries.${deliveryId}.version`);
+	const releaseTag = requiredString(entry.release_tag, `deliveries.${deliveryId}.release_tag`);
+	validateReleaseIdentity(version, releaseTag);
+	const targetCommit = requiredString(entry.target_commit, `deliveries.${deliveryId}.target_commit`);
+	if (!COMMIT_PATTERN.test(targetCommit)) {
+		throw new Error(`Delivery ledger entry ${deliveryId} has an invalid target_commit`);
+	}
+	const expectedId = calculateDeliveryIdForTarget(
+		{ releaseTag, targetCommit, triggerSource: SOURCE_REPOSITORY, version },
+		TARGET_REPOSITORY,
+	);
+	if (deliveryId !== expectedId) {
+		throw new Error(`Delivery ledger contains a noncanonical delivery_id: ${deliveryId}`);
+	}
+	return { release_tag: releaseTag, target_commit: targetCommit, version };
+}
+
+export function parseDeliveryLedger(document: unknown): ApiSpecDeliveryLedger {
+	if (!document || typeof document !== "object" || Array.isArray(document)) {
+		throw new Error("Delivery ledger must be an object");
+	}
+	const ledger = document as Record<string, unknown>;
+	if (JSON.stringify(sortedKeys(ledger)) !== JSON.stringify(["deliveries", "version"])) {
+		throw new Error("Delivery ledger has an invalid shape");
+	}
+	if (ledger.version !== LEDGER_VERSION) {
+		throw new Error(`Delivery ledger version must be ${LEDGER_VERSION}`);
+	}
+	if (!ledger.deliveries || typeof ledger.deliveries !== "object" || Array.isArray(ledger.deliveries)) {
+		throw new Error("Delivery ledger deliveries must be an object");
+	}
+	const deliveries: Record<string, ApiSpecDeliveryLedgerEntry> = {};
+	for (const [deliveryId, entry] of Object.entries(ledger.deliveries)) {
+		deliveries[deliveryId] = validateLedgerEntry(deliveryId, entry);
+	}
+	return { deliveries, version: LEDGER_VERSION };
+}
+
+export function deliveryApplied(document: unknown, delivery: ApiSpecDelivery): boolean {
+	const ledger = parseDeliveryLedger(document);
+	const existing = ledger.deliveries[delivery.deliveryId];
+	if (existing) {
+		if (!ledgerEntriesEqual(existing, ledgerEntryFor(delivery))) {
+			throw new Error(`Delivery ledger entry disagrees with ${delivery.deliveryId}`);
+		}
+		return true;
+	}
+	for (const [deliveryId, entry] of Object.entries(ledger.deliveries)) {
+		if (entry.release_tag === delivery.releaseTag) {
+			throw new Error(`Release ${delivery.releaseTag} was already applied under delivery ${deliveryId}`);
+		}
+	}
+	return false;
+}
+
+export async function readDeliveryLedger(ledgerFile: string): Promise<ApiSpecDeliveryLedger | undefined> {
+	try {
+		return parseDeliveryLedger(await Bun.file(ledgerFile).json());
+	} catch (error) {
+		if (isEnoent(error)) return undefined;
+		throw error;
+	}
+}
+
+export async function readPendingDelivery(pendingFile: string): Promise<unknown | undefined> {
+	try {
+		return await Bun.file(pendingFile).json();
+	} catch (error) {
+		if (isEnoent(error)) return undefined;
+		throw error;
+	}
+}
+
+export async function writePendingDelivery(
+	repoRoot: string,
+	delivery: ApiSpecDelivery,
+	sourcePinFile: string,
+	providerTag: string,
+	providerCommit: string,
+): Promise<string> {
+	const pin = parseSpecReleasePin(await Bun.file(sourcePinFile).json(), delivery);
+	const destination = path.join(repoRoot, DELIVERY_PENDING_PATH);
+	const existing = await readPendingDelivery(destination);
+	if (existing !== undefined) {
+		verifyPendingDelivery(existing, delivery);
+	}
+	const pending = await pendingDeliveryFor(repoRoot, delivery, pin, providerTag, providerCommit);
+	const canonicalPin = `${JSON.stringify(pin, null, "\t")}\n`;
+	await Bun.write(path.join(repoRoot, SPEC_RELEASE_PATH), canonicalPin);
+	await Bun.write(destination, `${JSON.stringify(pending, null, "\t")}\n`);
+	return DELIVERY_PENDING_PATH;
+}
+
+export async function verifyGeneratedDelivery(
+	repoRoot: string,
+	delivery: ApiSpecDelivery,
+	providerTag: string,
+	providerCommit: string,
+): Promise<void> {
+	const pending = await readPendingDelivery(path.join(repoRoot, DELIVERY_PENDING_PATH));
+	if (pending === undefined) throw new Error(`Pending delivery marker is absent: ${DELIVERY_PENDING_PATH}`);
+	const verified = verifyPendingDelivery(pending, delivery);
+	if (verified.provider.tag !== providerTag || verified.provider.commit !== providerCommit) {
+		throw new Error("Generated delivery provider identity differs from the receipted provider release");
+	}
+	const pinPath = path.join(repoRoot, SPEC_RELEASE_PATH);
+	const pin = parseSpecReleasePin(await Bun.file(pinPath).json(), delivery);
+	if ((await sha256File(pinPath)) !== verified.spec_release_sha256) {
+		throw new Error("Generated delivery spec release pin differs from its pending attestation");
+	}
+	for (const generatedPath of GENERATED_DELIVERY_PATHS) {
+		if ((await sha256File(path.join(repoRoot, generatedPath))) !== verified.generated[generatedPath]) {
+			throw new Error(`Generated delivery bytes differ from pending attestation: ${generatedPath}`);
+		}
+	}
+	void pin;
+}
+
+export async function clearPendingDelivery(repoRoot: string, delivery: ApiSpecDelivery): Promise<void> {
+	const destination = path.join(repoRoot, DELIVERY_PENDING_PATH);
+	const existing = await readPendingDelivery(destination);
+	if (existing === undefined) throw new Error(`Pending delivery marker is absent: ${DELIVERY_PENDING_PATH}`);
+	verifyPendingDelivery(existing, delivery);
+	await fs.unlink(destination);
+}
+
+function validatePublicationEvidence(document: unknown): XcshPublicationEvidence {
+	if (!document || typeof document !== "object" || Array.isArray(document)) {
+		throw new Error("xcsh publication evidence must be an object");
+	}
+	const evidence = document as Record<string, unknown>;
+	if (
+		JSON.stringify(sortedKeys(evidence)) !==
+		JSON.stringify(["assets", "commit", "generated", "npm", "provider", "spec_release_sha256", "tag", "version"])
+	) {
+		throw new Error("xcsh publication evidence has an invalid shape");
+	}
+	const version = requiredString(evidence.version, "publication.version");
+	const tag = requiredString(evidence.tag, "publication.tag");
+	validateReleaseIdentity(version, tag);
+	const commit = requiredString(evidence.commit, "publication.commit");
+	if (!COMMIT_PATTERN.test(commit)) throw new Error("xcsh publication evidence has an invalid commit");
+	const assets = validateDigestMap(evidence.assets, XCSH_RELEASE_ASSETS, "publication.assets");
+	const generated = validateDigestMap(evidence.generated, GENERATED_DELIVERY_PATHS, "publication.generated");
+	if (!evidence.provider || typeof evidence.provider !== "object" || Array.isArray(evidence.provider)) {
+		throw new Error("xcsh publication provider identity must be an object");
+	}
+	const rawProvider = evidence.provider as Record<string, unknown>;
+	if (JSON.stringify(sortedKeys(rawProvider)) !== JSON.stringify(["commit", "tag"])) {
+		throw new Error("xcsh publication provider identity has an invalid shape");
+	}
+	const providerCommit = requiredString(rawProvider.commit, "publication.provider.commit");
+	const providerTag = requiredString(rawProvider.tag, "publication.provider.tag");
+	if (!COMMIT_PATTERN.test(providerCommit) || !/^v\d+\.\d+\.\d+$/.test(providerTag)) {
+		throw new Error("xcsh publication provider identity is malformed");
+	}
+	const specReleaseSha256 = requiredString(evidence.spec_release_sha256, "publication.spec_release_sha256");
+	if (!SHA256_PATTERN.test(specReleaseSha256)) throw new Error("xcsh publication spec release digest is malformed");
+	if (!evidence.npm || typeof evidence.npm !== "object" || Array.isArray(evidence.npm)) {
+		throw new Error("xcsh publication npm evidence must be an object");
+	}
+	const rawNpm = evidence.npm as Record<string, unknown>;
+	if (JSON.stringify(sortedKeys(rawNpm)) !== JSON.stringify([...XCSH_PACKAGES].sort())) {
+		throw new Error("xcsh publication npm evidence has the wrong package set");
+	}
+	const npm: Record<string, XcshNpmEvidence> = {};
+	for (const packageName of XCSH_PACKAGES) {
+		const rawPackage = rawNpm[packageName];
+		if (!rawPackage || typeof rawPackage !== "object" || Array.isArray(rawPackage)) {
+			throw new Error(`xcsh publication npm evidence is malformed for ${packageName}`);
+		}
+		const packageEvidence = rawPackage as Record<string, unknown>;
+		if (JSON.stringify(sortedKeys(packageEvidence)) !== JSON.stringify(["git_head", "integrity"])) {
+			throw new Error(`xcsh publication npm evidence has an invalid shape for ${packageName}`);
+		}
+		const gitHead = requiredString(packageEvidence.git_head, `publication.npm.${packageName}.git_head`);
+		const integrity = requiredString(packageEvidence.integrity, `publication.npm.${packageName}.integrity`);
+		if (gitHead !== commit || !/^sha512-[A-Za-z0-9+/]+={0,2}$/.test(integrity)) {
+			throw new Error(`xcsh publication npm evidence is not bound to commit ${commit}`);
+		}
+		npm[packageName] = { git_head: gitHead, integrity };
+	}
+	return {
+		assets,
+		commit,
+		generated,
+		npm,
+		provider: { commit: providerCommit, tag: providerTag },
+		spec_release_sha256: specReleaseSha256,
+		tag,
+		version,
+	};
+}
+
+function parsePublicationLedger(
+	document: unknown,
+	common: ApiSpecDeliveryLedger,
+): XcshPublicationReceiptLedger {
+	if (!document || typeof document !== "object" || Array.isArray(document)) {
+		throw new Error("xcsh publication receipt ledger must be an object");
+	}
+	const ledger = document as Record<string, unknown>;
+	if (JSON.stringify(sortedKeys(ledger)) !== JSON.stringify(["receipts", "version"]) || ledger.version !== 1) {
+		throw new Error("xcsh publication receipt ledger has an invalid shape or version");
+	}
+	if (!ledger.receipts || typeof ledger.receipts !== "object" || Array.isArray(ledger.receipts)) {
+		throw new Error("xcsh publication receipts must be an object");
+	}
+	const receipts: Record<string, XcshPublicationReceiptEntry> = {};
+	for (const [deliveryId, rawEntry] of Object.entries(ledger.receipts)) {
+		if (!rawEntry || typeof rawEntry !== "object" || Array.isArray(rawEntry)) {
+			throw new Error(`xcsh publication receipt ${deliveryId} must be an object`);
+		}
+		const entry = rawEntry as Record<string, unknown>;
+		if (JSON.stringify(sortedKeys(entry)) !== JSON.stringify(["delivery", "publication"])) {
+			throw new Error(`xcsh publication receipt ${deliveryId} has an invalid shape`);
+		}
+		const commonEntry = common.deliveries[deliveryId];
+		const detailedEntry = validateLedgerEntry(deliveryId, entry.delivery);
+		if (!commonEntry || !ledgerEntriesEqual(detailedEntry, commonEntry)) {
+			throw new Error(`xcsh publication receipt ${deliveryId} differs from the common delivery ledger`);
+		}
+		receipts[deliveryId] = { delivery: commonEntry, publication: validatePublicationEvidence(entry.publication) };
+	}
+	if (JSON.stringify(sortedKeys(receipts)) !== JSON.stringify(sortedKeys(common.deliveries))) {
+		throw new Error("Common and xcsh publication receipt ledgers have different delivery keys");
+	}
+	return { receipts, version: 1 };
+}
+
+async function readPublicationLedger(
+	file: string,
+	common: ApiSpecDeliveryLedger,
+): Promise<XcshPublicationReceiptLedger> {
+	try {
+		return parsePublicationLedger(await Bun.file(file).json(), common);
+	} catch (error) {
+		if (isEnoent(error)) throw new Error(`xcsh publication receipt ledger is absent: ${file}`);
+		throw error;
+	}
+}
+
+export async function acknowledgePublishedDelivery(
+	repoRoot: string,
+	delivery: ApiSpecDelivery,
+	publicationFile: string,
+): Promise<void> {
+	const commonPath = path.join(repoRoot, DELIVERY_LEDGER_PATH);
+	const publicationPath = path.join(repoRoot, DELIVERY_PUBLICATION_LEDGER_PATH);
+	const common = await readDeliveryLedger(commonPath);
+	if (!common) throw new Error(`Delivery ledger is absent: ${DELIVERY_LEDGER_PATH}`);
+	const detailed = await readPublicationLedger(publicationPath, common);
+	if (deliveryApplied(common, delivery)) return;
+	const pendingDocument = await readPendingDelivery(path.join(repoRoot, DELIVERY_PENDING_PATH));
+	if (pendingDocument === undefined) throw new Error(`Pending delivery marker is absent: ${DELIVERY_PENDING_PATH}`);
+	const pending = verifyPendingDelivery(pendingDocument, delivery);
+	const publication = validatePublicationEvidence(await Bun.file(publicationFile).json());
+	if (
+		publication.provider.commit !== pending.provider.commit ||
+		publication.provider.tag !== pending.provider.tag ||
+		publication.spec_release_sha256 !== pending.spec_release_sha256 ||
+		!digestMapsEqual(publication.generated, pending.generated)
+	) {
+		throw new Error("xcsh publication evidence differs from the pending delivery attestation");
+	}
+	common.deliveries[delivery.deliveryId] = ledgerEntryFor(delivery);
+	detailed.receipts[delivery.deliveryId] = { delivery: ledgerEntryFor(delivery), publication };
+	const orderedCommon = Object.fromEntries(Object.entries(common.deliveries).sort(([left], [right]) => left.localeCompare(right)));
+	const orderedDetailed = Object.fromEntries(Object.entries(detailed.receipts).sort(([left], [right]) => left.localeCompare(right)));
+	await Bun.write(commonPath, `${JSON.stringify({ deliveries: orderedCommon, version: 1 }, null, "\t")}\n`);
+	await Bun.write(publicationPath, `${JSON.stringify({ receipts: orderedDetailed, version: 1 }, null, "\t")}\n`);
+	await clearPendingDelivery(repoRoot, delivery);
+}
+
+export async function verifyAcknowledgmentLedgers(
+	commonFile: string,
+	publicationFile: string,
+	delivery: ApiSpecDelivery,
+): Promise<boolean> {
+	const common = await readDeliveryLedger(commonFile);
+	if (!common) throw new Error(`Delivery ledger is absent: ${commonFile}`);
+	await readPublicationLedger(publicationFile, common);
+	return deliveryApplied(common, delivery);
+}
+
+async function githubDocument(url: string, token: string | undefined, fetcher: Fetcher): Promise<unknown> {
+	const headers: Record<string, string> = {
+		Accept: "application/vnd.github+json",
+		"X-GitHub-Api-Version": "2022-11-28",
+	};
+	if (token) headers.Authorization = `Bearer ${token}`;
+	const response = await fetcher(url, { headers });
+	if (!response.ok) {
+		throw new Error(`GitHub release identity request failed with HTTP ${response.status}`);
+	}
+	return response.json();
+}
+
+export async function verifyReleasedTag(
+	delivery: ApiSpecDelivery,
+	token: string | undefined,
+	fetcher: Fetcher = fetch,
+): Promise<SourcePublicationReceipt> {
+	const apiRoot = `https://api.github.com/repos/${SOURCE_REPOSITORY}`;
+	const release = (await githubDocument(`${apiRoot}/releases/tags/${delivery.releaseTag}`, token, fetcher)) as Record<
+		string,
+		unknown
+	>;
+	if (
+		release.tag_name !== delivery.releaseTag ||
+		release.draft !== false ||
+		release.prerelease !== false ||
+		release.immutable !== true
+	) {
+		throw new Error(`Release ${delivery.releaseTag} is not final and immutable`);
+	}
+	if (!Array.isArray(release.assets)) throw new Error("Published release assets must be an array");
+	const apiDigests: Record<string, string> = {};
+	for (const rawAsset of release.assets) {
+		if (!rawAsset || typeof rawAsset !== "object" || Array.isArray(rawAsset)) {
+			throw new Error("Published release contains a malformed asset");
+		}
+		const asset = rawAsset as Record<string, unknown>;
+		const name = requiredString(asset.name, "release asset name");
+		const digest = requiredString(asset.digest, `release asset ${name} digest`);
+		if (name in apiDigests || !digest.startsWith("sha256:") || !SHA256_PATTERN.test(digest.slice(7))) {
+			throw new Error(`Published release has no unique immutable SHA-256 digest for ${name}`);
+		}
+		apiDigests[name] = digest.slice(7);
+	}
+	validateDigestMap(apiDigests, expectedSpecAssetNames(delivery.releaseTag), "published release assets");
+
+	const body = typeof release.body === "string" ? release.body : "";
+	const receiptLines = body
+		.split("\n")
+		.filter(line => line.startsWith("<!-- publication-receipt:") && line.endsWith(" -->"));
+	if (receiptLines.length !== 1) throw new Error("Published release must contain exactly one publication receipt");
+	const rawReceipt = receiptLines[0].slice("<!-- publication-receipt:".length, -" -->".length);
+	let receiptDocument: unknown;
+	try {
+		receiptDocument = JSON.parse(rawReceipt);
+	} catch {
+		throw new Error("Published release receipt is not valid JSON");
+	}
+	if (!receiptDocument || typeof receiptDocument !== "object" || Array.isArray(receiptDocument)) {
+		throw new Error("Published release receipt must be an object");
+	}
+	const raw = receiptDocument as Record<string, unknown>;
+	if (JSON.stringify(sortedKeys(raw)) !== JSON.stringify(["assets", "commit", "version"])) {
+		throw new Error("Published release receipt has an invalid shape");
+	}
+	const commit = requiredString(raw.commit, "publication receipt commit");
+	const version = requiredString(raw.version, "publication receipt version");
+	const receipt: SourcePublicationReceipt = {
+		assets: validateDigestMap(raw.assets, expectedSpecAssetNames(delivery.releaseTag), "publication receipt assets"),
+		commit,
+		version,
+	};
+	if (commit !== delivery.targetCommit || version !== delivery.version) {
+		throw new Error("Published release receipt disagrees with the dispatched identity");
+	}
+	for (const [name, digest] of Object.entries(receipt.assets)) {
+		if (apiDigests[name] !== digest) {
+			throw new Error(`Published release API digest differs from its publication receipt for ${name}`);
+		}
+	}
+	let reference = (await githubDocument(
+		`${apiRoot}/git/ref/tags/${delivery.releaseTag}`,
+		token,
+		fetcher,
+	)) as Record<string, unknown>;
+	for (let depth = 0; depth < 5; depth++) {
+		const object = reference.object;
+		if (!object || typeof object !== "object") throw new Error("Published release tag has no Git object");
+		const gitObject = object as Record<string, unknown>;
+		const sha = requiredString(gitObject.sha, "release tag SHA");
+		const type = requiredString(gitObject.type, "release tag object type");
+		if (type === "commit") {
+			if (sha !== delivery.targetCommit) {
+				throw new Error(`Published release tag commit does not match dispatched target_commit`);
+			}
+			return receipt;
+		}
+		if (type !== "tag") throw new Error(`Published release tag points to unsupported Git object type ${type}`);
+		reference = (await githubDocument(`${apiRoot}/git/tags/${sha}`, token, fetcher)) as Record<string, unknown>;
+	}
+	throw new Error("Published release tag indirection exceeds the supported depth");
+}
+
+async function readEventFromEnvironment(): Promise<ApiSpecDelivery> {
+	const eventPath = requiredString(process.env.GITHUB_EVENT_PATH, "GITHUB_EVENT_PATH");
+	return parseDispatchEvent(await Bun.file(eventPath).json());
+}
+
+async function appendOutputs(delivery: ApiSpecDelivery): Promise<void> {
+	const outputPath = requiredString(process.env.GITHUB_OUTPUT, "GITHUB_OUTPUT");
+	const values = {
+		ack_branch: `chore/api-spec-delivery-ack-${delivery.deliveryId.slice(0, 12)}`,
+		branch: deliveryBranch(delivery),
+		delivery_id: delivery.deliveryId,
+		ledger_path: DELIVERY_LEDGER_PATH,
+		pending_path: DELIVERY_PENDING_PATH,
+		publication_ledger_path: DELIVERY_PUBLICATION_LEDGER_PATH,
+		provider_delivery_id: calculateDeliveryIdForTarget(delivery, PROVIDER_REPOSITORY),
+		release_tag: delivery.releaseTag,
+		target_commit: delivery.targetCommit,
+		version: delivery.version,
+	};
+	await fs.appendFile(
+		outputPath,
+		Object.entries(values)
+			.map(([key, value]) => `${key}=${value}\n`)
+			.join(""),
+	);
+}
+
+async function main(): Promise<void> {
+	const command = process.argv[2];
+	const delivery = await readEventFromEnvironment();
+	if (command === "validate-event") {
+		await appendOutputs(delivery);
+		return;
+	}
+	if (command === "verify-release") {
+		const receipt = await verifyReleasedTag(delivery, process.env.GITHUB_TOKEN);
+		const pin = parseSpecReleasePin(
+			{
+				assets: receipt.assets,
+				release_tag: delivery.releaseTag,
+				target_commit: receipt.commit,
+				version: receipt.version,
+			},
+			delivery,
+		);
+		const runnerTemp = requiredString(process.env.RUNNER_TEMP, "RUNNER_TEMP");
+		const pinPath = path.join(runnerTemp, "api-spec-release.json");
+		await Bun.write(pinPath, `${JSON.stringify(pin, null, "\t")}\n`);
+		const outputPath = requiredString(process.env.GITHUB_OUTPUT, "GITHUB_OUTPUT");
+		const bundleName = `f5xc-api-specs-${delivery.releaseTag}.zip`;
+		await fs.appendFile(
+			outputPath,
+			[
+				`bundle_sha256=${pin.assets[bundleName]}`,
+				`catalog_sha256=${pin.assets["api-catalog.json"]}`,
+				`defaults_sha256=${pin.assets["minimal-export-defaults.json"]}`,
+				`pin_path=${pinPath}`,
+			].join("\n") + "\n",
+		);
+		return;
+	}
+	if (command === "check-ledger" || command === "verify-ledger") {
+		const ledgerFile = requiredString(process.env.DELIVERY_LEDGER_FILE, "DELIVERY_LEDGER_FILE");
+		const publicationFile = requiredString(
+			process.env.DELIVERY_PUBLICATION_LEDGER_FILE,
+			"DELIVERY_PUBLICATION_LEDGER_FILE",
+		);
+		const applied = await verifyAcknowledgmentLedgers(ledgerFile, publicationFile, delivery);
+		if (command === "verify-ledger" && !applied) {
+			throw new Error(`Delivery ${delivery.deliveryId} is absent from the delivery ledger`);
+		}
+		if (command === "check-ledger") {
+			const outputPath = requiredString(process.env.GITHUB_OUTPUT, "GITHUB_OUTPUT");
+			await fs.appendFile(outputPath, `applied=${applied}\n`);
+		}
+		return;
+	}
+	if (command === "check-pending" || command === "verify-pending") {
+		const pendingFile = requiredString(process.env.DELIVERY_PENDING_FILE, "DELIVERY_PENDING_FILE");
+		const pending = await readPendingDelivery(pendingFile);
+		if (pending !== undefined) verifyPendingDelivery(pending, delivery);
+		if (command === "verify-pending" && pending === undefined) {
+			throw new Error(`Pending delivery marker is absent: ${pendingFile}`);
+		}
+		if (command === "check-pending") {
+			const outputPath = requiredString(process.env.GITHUB_OUTPUT, "GITHUB_OUTPUT");
+			await fs.appendFile(outputPath, `pending=${pending !== undefined}\n`);
+		}
+		return;
+	}
+	if (command === "record-pending") {
+		const repoRoot = requiredString(process.env.GITHUB_WORKSPACE, "GITHUB_WORKSPACE");
+		await writePendingDelivery(
+			repoRoot,
+			delivery,
+			requiredString(process.env.SOURCE_RELEASE_PIN_FILE, "SOURCE_RELEASE_PIN_FILE"),
+			requiredString(process.env.PROVIDER_TAG, "PROVIDER_TAG"),
+			requiredString(process.env.PROVIDER_COMMIT, "PROVIDER_COMMIT"),
+		);
+		return;
+	}
+	if (command === "verify-generated") {
+		const repoRoot = requiredString(process.env.GITHUB_WORKSPACE, "GITHUB_WORKSPACE");
+		await verifyGeneratedDelivery(
+			repoRoot,
+			delivery,
+			requiredString(process.env.PROVIDER_TAG, "PROVIDER_TAG"),
+			requiredString(process.env.PROVIDER_COMMIT, "PROVIDER_COMMIT"),
+		);
+		return;
+	}
+	if (command === "acknowledge") {
+		const repoRoot = requiredString(process.env.GITHUB_WORKSPACE, "GITHUB_WORKSPACE");
+		await acknowledgePublishedDelivery(
+			repoRoot,
+			delivery,
+			requiredString(process.env.PUBLICATION_RECEIPT_FILE, "PUBLICATION_RECEIPT_FILE"),
+		);
+		return;
+	}
+	throw new Error(`Unknown api-spec delivery command: ${String(command)}`);
+}
+
+if (import.meta.main) await main();

--- a/scripts/ci-release-homebrew.ts
+++ b/scripts/ci-release-homebrew.ts
@@ -46,6 +46,10 @@ function getTag(): string {
 
 async function createArchives(): Promise<void> {
 	console.log("Creating archives for Homebrew...");
+	const sourceDateEpoch = process.env.SOURCE_DATE_EPOCH;
+	if (!isDryRun && (!sourceDateEpoch || !/^\d+$/.test(sourceDateEpoch))) {
+		throw new Error("SOURCE_DATE_EPOCH is required for deterministic release archives");
+	}
 
 	for (const target of archiveTargets) {
 		const binaryPath = path.join(binariesDir, target.binary);
@@ -62,19 +66,22 @@ async function createArchives(): Promise<void> {
 		const tmpDir = await fs.mkdtemp(path.join(repoRoot, ".tmp-homebrew-"));
 		try {
 			await fs.copyFile(binaryPath, path.join(tmpDir, "xcsh"));
+			await fs.rm(archivePath, { force: true });
+			const stagedBinary = path.join(tmpDir, "xcsh");
 
 			if (target.format === "zip") {
 				if (isDryRun) {
-					console.log(`  DRY RUN: zip -j ${archivePath} ${tmpDir}/xcsh`);
+					console.log(`  DRY RUN: zip -X -j ${archivePath} ${tmpDir}/xcsh`);
 				} else {
-					await $`zip -j ${archivePath} ${path.join(tmpDir, "xcsh")}`;
+					await $`touch -d ${`@${sourceDateEpoch}`} ${stagedBinary}`;
+					await $`zip -X -j ${archivePath} ${stagedBinary}`;
 					console.log(`  Created ${target.archive}`);
 				}
 			} else {
 				if (isDryRun) {
-					console.log(`  DRY RUN: tar czf ${archivePath} -C ${tmpDir} xcsh`);
+					console.log(`  DRY RUN: deterministic tar + gzip -n ${archivePath}`);
 				} else {
-					await $`tar czf ${archivePath} -C ${tmpDir} xcsh`;
+					await $`tar --sort=name --mtime=${`@${sourceDateEpoch}`} --owner=0 --group=0 --numeric-owner -cf - -C ${tmpDir} xcsh | gzip -n > ${archivePath}`;
 					console.log(`  Created ${target.archive}`);
 				}
 			}

--- a/tools/spec-deliveries.json
+++ b/tools/spec-deliveries.json
@@ -1,0 +1,4 @@
+{
+	"deliveries": {},
+	"version": 1
+}

--- a/tools/xcsh-publication-receipts.json
+++ b/tools/xcsh-publication-receipts.json
@@ -1,0 +1,4 @@
+{
+	"receipts": {},
+	"version": 1
+}


### PR DESCRIPTION
## Summary
- verify immutable, receipted spec and provider releases from exact commits and asset bytes
- persist canonical append-only common and detailed delivery/publication ledgers atomically
- force resumed deliveries through full resolution and deterministic regeneration
- bind post-publication evidence to immutable GitHub and npm artifacts
- harden touched workflows without i18n or compatibility paths

## Verification
- type checks passed
- focused delivery suite: 32/32 passed
- Homebrew/reconcile suite: 38/38 passed
- actionlint and Zizmor pedantic passed with zero findings
- PII and diff gates passed

Closes #2808