### PR TITLE
fix(coding-agent): make sandbox check reliable in direct-home sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,6 +647,10 @@ jobs:
           XCSH_BUILD_BRANCH: main # compiled binaries have no .git at runtime; pin branch at build time
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: bun scripts/ci-release-build-binaries.ts --platform linux,win32
+      - name: Verify compiled Linux sandbox check in a direct-home live profile
+        env:
+          XCSH_TEST_SANDBOX_CHECK_BINARY: ${{ github.workspace }}/packages/coding-agent/binaries/xcsh-linux-x64
+        run: bun test packages/coding-agent/test/sandbox-check.test.ts
       - name: Stage native addons for release
         run: cp packages/natives/native/*.node packages/coding-agent/binaries/
       - name: Upload release binaries
@@ -978,6 +982,11 @@ jobs:
 
           echo "All checks passed for ${{ matrix.arch }}"
 
+      - name: Verify signed macOS sandbox check in a direct-home live profile
+        env:
+          XCSH_TEST_SANDBOX_CHECK_BINARY: ${{ github.workspace }}/packages/coding-agent/binaries/xcsh-darwin-${{ matrix.arch }}
+        run: bun test packages/coding-agent/test/sandbox-check.test.ts
+
       - name: Upload signed macOS binary
         uses: actions/upload-artifact@v7
         with:
@@ -1121,6 +1130,17 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 20
     steps:
+      - uses: actions/checkout@v6
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3"
+      - run: bun install --frozen-lockfile
+      - name: Download signed native addon for the live-profile harness
+        uses: actions/download-artifact@v8
+        with:
+          name: release-binaries-macos-arm64-signed
+          path: packages/natives/native
       - name: Install published xcsh formula and verify startup
         env:
           EXPECTED_VERSION: ${{ github.ref_name }}
@@ -1153,6 +1173,8 @@ jobs:
                 binary="$(brew --prefix f5-sales-demo/tap/xcsh)/bin/xcsh"
                 codesign --verify --deep --strict "$binary"
                 spctl --assess --verbose=4 --type install "$binary"
+                XCSH_TEST_SANDBOX_CHECK_BINARY="$binary" \
+                  bun test packages/coding-agent/test/sandbox-check.test.ts
                 echo "Homebrew install verification passed"
                 exit 0
               fi
@@ -1281,6 +1303,7 @@ jobs:
     needs: [publish-npm]
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
@@ -1338,6 +1361,12 @@ jobs:
           fi
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
+      - run: bun install --frozen-lockfile
+      - name: Download native addon for the live-profile harness
+        uses: actions/download-artifact@v8
+        with:
+          name: release-binaries-linux-win
+          path: packages/natives/native
       - name: Install xcsh via npm and verify native addon loads
         env:
           EXPECTED_VERSION: ${{ github.ref_name }}
@@ -1368,6 +1397,9 @@ jobs:
                 echo "Version match confirmed."
                 echo "Checking xcsh --help..."
                 xcsh --help >/dev/null
+                binary="$(command -v xcsh)"
+                XCSH_TEST_SANDBOX_CHECK_BINARY="$binary" \
+                  bun test packages/coding-agent/test/sandbox-check.test.ts
                 echo "npm install verification passed"
                 exit 0
               fi

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Made `xcsh sandbox check` work for sessions rooted directly under the operator home, distinguish harness errors from sandbox failures, and verify this topology against installed release artifacts ([#2807](https://github.com/f5-sales-demo/xcsh/issues/2807))
+
 ## [20.1.1] - 2026-08-01
 
 ### Fixed

--- a/packages/coding-agent/src/cli/sandbox-check.ts
+++ b/packages/coding-agent/src/cli/sandbox-check.ts
@@ -11,12 +11,12 @@ import { evaluateToolCall } from "../sandbox/enforce";
 import { SANDBOX_OPERATOR_HOME_ENV, SANDBOX_SESSION_ROOT_ENV } from "../sandbox/session-fence";
 import { BashTool, type ToolSession } from "../tools";
 
-export type SandboxCheckResultStatus = "PASS" | "FAIL" | "SKIP";
+export type SandboxCheckResultStatus = "PASS" | "FAIL" | "SKIP" | "ERROR";
 
 export interface SandboxCheckResult {
 	name: string;
 	status: SandboxCheckResultStatus;
-	/** Present on failures and skips; paths are generalized before they leave the process. */
+	/** Present on failures, errors, and skips; paths are generalized before they leave the process. */
 	detail?: string;
 }
 
@@ -27,6 +27,7 @@ export interface SandboxCheckReport {
 	summary: {
 		passed: number;
 		failed: number;
+		errors: number;
 		skipped: number;
 	};
 }
@@ -142,15 +143,19 @@ function renderReport(report: SandboxCheckReport, json: boolean, verbose: boolea
 
 	const enforcement = report.osEnforced ? "OS enforced" : "scanner only";
 	process.stdout.write(`Sandbox backend: ${report.backend} (${enforcement})\n\n`);
-	const width = Math.max(0, ...report.checks.map(check => check.name.length));
+	const nameWidth = Math.max(0, ...report.checks.map(check => check.name.length));
+	const statusWidth = Math.max(0, ...report.checks.map(check => check.status.length));
 	for (const check of report.checks) {
-		process.stdout.write(`${check.status.padEnd(4)}  ${check.name.padEnd(width)}\n`);
+		process.stdout.write(`${check.status.padEnd(statusWidth)}  ${check.name.padEnd(nameWidth)}\n`);
 		if (verbose && check.detail) process.stdout.write(`      ${check.detail}\n`);
 	}
 	process.stdout.write(
-		`\n${report.summary.passed} passed, ${report.summary.failed} failed, ${report.summary.skipped} skipped\n`,
+		`\n${report.summary.passed} passed, ${report.summary.failed} failed, ${report.summary.errors} errors, ${report.summary.skipped} skipped\n`,
 	);
-	if (!verbose && report.summary.failed > 0) {
+	if (report.checks.some(check => check.name === "conformance matrix setup" && check.status === "ERROR")) {
+		process.stdout.write("Conformance matrix did not run.\n");
+	}
+	if (!verbose && (report.summary.failed > 0 || report.summary.errors > 0)) {
 		process.stdout.write("Run `xcsh sandbox check --verbose` for failure details.\n");
 	}
 }
@@ -177,7 +182,7 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 		probe: () => boolean | ProbeOutcome | Promise<boolean | ProbeOutcome>,
 	): Promise<void> => {
 		if (abortController.signal.aborted) {
-			add(name, "FAIL", "probe aborted before execution; path=<probe>; errno=ABORTED");
+			add(name, "ERROR", "probe aborted before execution; path=<probe>; errno=ABORTED");
 			return;
 		}
 		try {
@@ -190,17 +195,22 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 			);
 		} catch (error) {
 			const outcome = exceptionOutcome("probe threw", "<probe>", error, redactions);
-			add(name, "FAIL", outcome.detail);
+			add(name, "ERROR", outcome.detail);
 		}
 	};
 
 	try {
-		const inheritedProfile = process.env[SANDBOX_SESSION_ROOT_ENV] !== undefined;
-		const workspaceInput = process.env[SANDBOX_SESSION_ROOT_ENV] ?? process.cwd();
-		const homeInput = process.env[SANDBOX_OPERATOR_HOME_ENV] ?? os.homedir();
+		const inheritedWorkspace = process.env[SANDBOX_SESSION_ROOT_ENV];
+		const inheritedHome = process.env[SANDBOX_OPERATOR_HOME_ENV];
+		const inheritedProfile = inheritedWorkspace !== undefined;
+		const workspaceInput = inheritedWorkspace ?? process.cwd();
+		const homeInput = inheritedHome ?? os.homedir();
 		redactions.push([workspaceInput, "<workspace>"], [homeInput, "<operator-home>"]);
-		const liveWorkspace = await fs.realpath(workspaceInput);
-		const liveHome = await fs.realpath(homeInput);
+		// BashTool owns and canonicalises inherited values before applying Seatbelt/Landlock. Re-running
+		// realpath here can require metadata access that the live profile deliberately withholds from the
+		// session parent — which is the operator home for a `~/<workspace>` layout (#2807).
+		const liveWorkspace = inheritedWorkspace ?? (await fs.realpath(workspaceInput));
+		const liveHome = inheritedHome ?? (await fs.realpath(homeInput));
 		redactions.push([liveWorkspace, "<workspace>"], [liveHome, "<operator-home>"]);
 
 		const fixtureBase = inheritedProfile ? liveWorkspace : await fs.realpath(os.tmpdir());
@@ -485,7 +495,7 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 		});
 	} catch (error) {
 		const outcome = exceptionOutcome("conformance matrix setup failed", "<probe>", error, redactions);
-		add("conformance matrix completed", "FAIL", outcome.detail);
+		add("conformance matrix setup", "ERROR", outcome.detail);
 	} finally {
 		process.off("SIGINT", interrupt);
 		process.off("SIGTERM", interrupt);
@@ -511,17 +521,17 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 			}
 		}
 
-		if (fixtureRoot === undefined || cleanupFailures.length > 0) {
+		if (cleanupFailures.length > 0) {
 			add(
 				"synthetic fixtures removed",
-				"FAIL",
+				"ERROR",
 				sanitizeDetail(
-					`fixture cleanup incomplete; path=<synthetic-fixtures>; errno=${
-						fixtureRoot === undefined ? "ENOENT" : "unknown"
-					}${cleanupFailures.length > 0 ? `; error=${cleanupFailures.join("; ")}` : ""}`,
+					`fixture cleanup incomplete; path=<synthetic-fixtures>; errno=unknown; error=${cleanupFailures.join("; ")}`,
 					redactions,
 				),
 			);
+		} else if (fixturePaths.length === 0) {
+			add("synthetic fixtures removed", "SKIP", "setup created no fixtures; path=<synthetic-fixtures>; errno=none");
 		} else {
 			add("synthetic fixtures removed", "PASS");
 		}
@@ -534,6 +544,7 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 		summary: {
 			passed: checks.filter(result => result.status === "PASS").length,
 			failed: checks.filter(result => result.status === "FAIL").length,
+			errors: checks.filter(result => result.status === "ERROR").length,
 			skipped: checks.filter(result => result.status === "SKIP").length,
 		},
 	};

--- a/packages/coding-agent/src/cli/sandbox-check.ts
+++ b/packages/coding-agent/src/cli/sandbox-check.ts
@@ -8,7 +8,11 @@ import { Settings } from "../config/settings";
 import { fenceForNative } from "../exec/bash-executor";
 import { buildContainmentFence, type ContainmentFence, containmentStatus } from "../sandbox/containment";
 import { evaluateToolCall } from "../sandbox/enforce";
-import { SANDBOX_OPERATOR_HOME_ENV, SANDBOX_SESSION_ROOT_ENV } from "../sandbox/session-fence";
+import {
+	SANDBOX_CHECK_NAMED_SIBLING_ENV,
+	SANDBOX_OPERATOR_HOME_ENV,
+	SANDBOX_SESSION_ROOT_ENV,
+} from "../sandbox/session-fence";
 import { BashTool, type ToolSession } from "../tools";
 
 export type SandboxCheckResultStatus = "PASS" | "FAIL" | "SKIP" | "ERROR";
@@ -202,6 +206,7 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 	try {
 		const inheritedWorkspace = process.env[SANDBOX_SESSION_ROOT_ENV];
 		const inheritedHome = process.env[SANDBOX_OPERATOR_HOME_ENV];
+		const inheritedSibling = process.env[SANDBOX_CHECK_NAMED_SIBLING_ENV];
 		const inheritedProfile = inheritedWorkspace !== undefined;
 		const workspaceInput = inheritedWorkspace ?? process.cwd();
 		const homeInput = inheritedHome ?? os.homedir();
@@ -212,6 +217,7 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 		const liveWorkspace = inheritedWorkspace ?? (await fs.realpath(workspaceInput));
 		const liveHome = inheritedHome ?? (await fs.realpath(homeInput));
 		redactions.push([liveWorkspace, "<workspace>"], [liveHome, "<operator-home>"]);
+		if (inheritedSibling !== undefined) redactions.push([inheritedSibling, "<session-parent>/<synthetic-sibling>"]);
 
 		const fixtureBase = inheritedProfile ? liveWorkspace : await fs.realpath(os.tmpdir());
 		fixtureRoot = await fs.mkdtemp(path.join(fixtureBase, ".xcsh-sandbox-check-policy-"));
@@ -319,17 +325,19 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 
 		await check("named sibling remains reachable", async () => {
 			const displayPath = "<session-parent>/<synthetic-sibling>";
-			let liveSibling: string;
-			try {
-				liveSibling = await fs.mkdtemp(path.join(path.dirname(liveWorkspace), ".xcsh-sandbox-check-sibling-"));
-				fixturePaths.push(liveSibling);
-				nonEnumerableCleanupDirs.add(liveSibling);
-				redactions.push([liveSibling, displayPath]);
-				const namedFile = path.join(liveSibling, "named.txt");
-				await Bun.write(namedFile, "sibling\n");
-				knownCleanupLeaves.push(namedFile);
-			} catch (error) {
-				return exceptionOutcome("create named sibling fixture", displayPath, error, redactions);
+			let liveSibling = inheritedSibling;
+			if (liveSibling === undefined) {
+				try {
+					liveSibling = await fs.mkdtemp(path.join(path.dirname(liveWorkspace), ".xcsh-sandbox-check-sibling-"));
+					fixturePaths.push(liveSibling);
+					nonEnumerableCleanupDirs.add(liveSibling);
+					redactions.push([liveSibling, displayPath]);
+					const namedFile = path.join(liveSibling, "named.txt");
+					await Bun.write(namedFile, "sibling\n");
+					knownCleanupLeaves.push(namedFile);
+				} catch (error) {
+					return exceptionOutcome("create named sibling fixture", displayPath, error, redactions);
+				}
 			}
 			const result = await shellProbe(
 				'test "$(cat named.txt)" = sibling',

--- a/packages/coding-agent/src/commands/sandbox.ts
+++ b/packages/coding-agent/src/commands/sandbox.ts
@@ -21,6 +21,6 @@ export default class Sandbox extends Command {
 	async run(): Promise<void> {
 		const { flags } = await this.parse(Sandbox);
 		const report = await runSandboxCheck({ json: flags.json, verbose: flags.verbose });
-		if (report.summary.failed > 0) process.exitCode = 1;
+		if (report.summary.failed > 0 || report.summary.errors > 0) process.exitCode = 1;
 	}
 }

--- a/packages/coding-agent/src/sandbox/session-fence.ts
+++ b/packages/coding-agent/src/sandbox/session-fence.ts
@@ -26,6 +26,7 @@ import { buildContainmentFence, type ContainmentFence } from "./containment";
  */
 export const SANDBOX_SESSION_ROOT_ENV = "XCSH_SANDBOX_SESSION_ROOT";
 export const SANDBOX_OPERATOR_HOME_ENV = "XCSH_SANDBOX_OPERATOR_HOME";
+export const SANDBOX_CHECK_NAMED_SIBLING_ENV = "XCSH_SANDBOX_CHECK_NAMED_SIBLING";
 
 /** The slice of `Settings` this needs — supplied explicitly so the caller names its own source. */
 export interface SettingsReader {

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
+import * as path from "node:path";
 import type {
 	AgentTool,
 	AgentToolContext,
@@ -18,7 +19,12 @@ import { truncateToVisualLines } from "../modes/components/visual-truncate";
 import type { Theme } from "../modes/theme/theme";
 import bashDescription from "../prompts/tools/bash.md" with { type: "text" };
 import { type ContainmentFence, containmentStatus, fenceVerdict } from "../sandbox/containment";
-import { resolveSessionFence, SANDBOX_OPERATOR_HOME_ENV, SANDBOX_SESSION_ROOT_ENV } from "../sandbox/session-fence";
+import {
+	resolveSessionFence,
+	SANDBOX_CHECK_NAMED_SIBLING_ENV,
+	SANDBOX_OPERATOR_HOME_ENV,
+	SANDBOX_SESSION_ROOT_ENV,
+} from "../sandbox/session-fence";
 import { SECRET_ENV_PATTERNS, type SecretObfuscator } from "../secrets";
 import { DEFAULT_MAX_BYTES, TailBuffer } from "../session/streaming-output";
 import { renderStatusLine } from "../tui";
@@ -187,6 +193,10 @@ async function canonicalizeSandboxContextPath(input: string): Promise<string> {
 		// working in that case; the diagnostic will report the path-specific failure if it is invoked.
 		return input;
 	}
+}
+
+function invokesSandboxCheck(command: string): boolean {
+	return /(?:xcsh(?:-[a-z0-9-]+)?|cli\.ts)["']?\s+["']?sandbox["']?\s+["']?check["']?(?:\s|$)/iu.test(command);
 }
 
 function escapeBashEnvValueForDisplay(value: string): string {
@@ -641,16 +651,19 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		// same boundary rather than two that merely agree today.
 		const containmentRoot = this.#containmentRoot();
 		const fence = this.#containmentFence(containmentRoot);
+		const sandboxCheckInvocation = fence !== undefined && invokesSandboxCheck(command);
 		// A nested `xcsh sandbox check` must exercise the grants of this exact live profile. Seatbelt and
 		// Landlock restrictions compose and cannot be relaxed by its subprocess, so the diagnostic needs
 		// the immutable session anchor even when this individual call uses `cwd` or starts with `cd`.
 		// Keep these values host-owned: tool-supplied env cannot replace them.
 		let env = requestedEnv;
+		let trustedSessionRoot = containmentRoot;
 		if (fence !== undefined) {
-			const [trustedSessionRoot, trustedOperatorHome] = await Promise.all([
+			const [canonicalSessionRoot, trustedOperatorHome] = await Promise.all([
 				canonicalizeSandboxContextPath(containmentRoot),
 				canonicalizeSandboxContextPath(os.homedir()),
 			]);
+			trustedSessionRoot = canonicalSessionRoot;
 			env = {
 				...requestedEnv,
 				[SANDBOX_SESSION_ROOT_ENV]: trustedSessionRoot,
@@ -699,6 +712,9 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		const obfuscator = this.session.obfuscator;
 		_sessionObfuscator = obfuscator; // Keep module-level ref fresh for renderer
 		const maskSecrets = obfuscator?.hasSecrets() ? (t: string) => obfuscator.obfuscate(t) : undefined;
+		if (asyncRequested && sandboxCheckInvocation) {
+			throw new ToolError("Sandbox check must run synchronously so its synthetic fixtures can be removed.");
+		}
 
 		if (asyncRequested) {
 			if (!this.session.asyncJobManager) {
@@ -719,7 +735,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			return this.#buildBackgroundStartResult(job.jobId, job.label, "", timeoutSec);
 		}
 
-		if (this.#autoBackgroundEnabled && !pty && this.session.asyncJobManager) {
+		if (this.#autoBackgroundEnabled && !pty && this.session.asyncJobManager && !sandboxCheckInvocation) {
 			const autoBackgroundWaitMs = this.#resolveAutoBackgroundWaitMs(timeoutMs);
 			const startBackgrounded = autoBackgroundWaitMs === 0;
 			const job = this.#startManagedBashJob({
@@ -777,41 +793,60 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		const osBackend = containmentStatus(fence !== undefined);
 		const ptyConfinable = !osBackend.osEnforced || osBackend.backend === "seatbelt";
 		const usePty = pty && ptyConfinable && $env.PI_NO_PTY !== "1" && ctx?.hasUI === true && ctx.ui !== undefined;
-		const result: BashResult | BashInteractiveResult = usePty
-			? await runInteractiveBashPty(ctx.ui!, {
-					command,
-					cwd: commandCwd,
-					timeoutMs,
-					signal,
-					env,
-					artifactPath,
-					artifactId,
-					maskSecrets,
-					// The same fence that decided `ptyConfinable`, so the gate and the enforcement can
-					// never be looking at different answers.
-					fence,
-				})
-			: await executeBash(command, {
-					cwd: commandCwd,
-					sessionKey: this.session.getSessionId?.() ?? undefined,
-					timeout: timeoutMs,
-					signal,
-					env,
-					artifactPath,
-					artifactId,
-					maskSecrets,
-					fence,
-					onChunk: chunk => {
-						tailBuffer.append(chunk);
-						if (onUpdate) {
-							const preview = maskSecrets ? maskSecrets(tailBuffer.text()) : tailBuffer.text();
-							onUpdate({
-								content: [{ type: "text", text: preview }],
-								details: {},
-							});
-						}
-					},
-				});
+		let sandboxCheckSibling: string | undefined;
+		if (sandboxCheckInvocation) {
+			// Landlock cannot add a newly-created child to an already-applied profile. Prepare the named
+			// sibling before the child is confined so the diagnostic measures reachability, not whether a
+			// nested sandbox can widen itself. The host owns both this path and its cleanup.
+			sandboxCheckSibling = await fs.promises.mkdtemp(
+				path.join(path.dirname(trustedSessionRoot), ".xcsh-sandbox-check-live-sibling-"),
+			);
+			await Bun.write(path.join(sandboxCheckSibling, "named.txt"), "sibling\n");
+			env = { ...env, [SANDBOX_CHECK_NAMED_SIBLING_ENV]: sandboxCheckSibling };
+		}
+
+		let result: BashResult | BashInteractiveResult;
+		try {
+			result = usePty
+				? await runInteractiveBashPty(ctx.ui!, {
+						command,
+						cwd: commandCwd,
+						timeoutMs,
+						signal,
+						env,
+						artifactPath,
+						artifactId,
+						maskSecrets,
+						// The same fence that decided `ptyConfinable`, so the gate and the enforcement can
+						// never be looking at different answers.
+						fence,
+					})
+				: await executeBash(command, {
+						cwd: commandCwd,
+						sessionKey: this.session.getSessionId?.() ?? undefined,
+						timeout: timeoutMs,
+						signal,
+						env,
+						artifactPath,
+						artifactId,
+						maskSecrets,
+						fence,
+						onChunk: chunk => {
+							tailBuffer.append(chunk);
+							if (onUpdate) {
+								const preview = maskSecrets ? maskSecrets(tailBuffer.text()) : tailBuffer.text();
+								onUpdate({
+									content: [{ type: "text", text: preview }],
+									details: {},
+								});
+							}
+						},
+					});
+		} finally {
+			if (sandboxCheckSibling !== undefined) {
+				await fs.promises.rm(sandboxCheckSibling, { recursive: true, force: true });
+			}
+		}
 		if (result.cancelled) {
 			if (signal?.aborted) {
 				throw new ToolAbortError(normalizeResultOutput(result) || "Command aborted");

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -178,6 +178,17 @@ function normalizeBashEnv(env: Record<string, string> | undefined): Record<strin
 	return normalized;
 }
 
+/** Canonical context resolved by the unfenced host before a child inherits the live profile. */
+async function canonicalizeSandboxContextPath(input: string): Promise<string> {
+	try {
+		return await fs.promises.realpath(input);
+	} catch {
+		// The fence builder already handles an unavailable home conservatively. Keep ordinary bash calls
+		// working in that case; the diagnostic will report the path-specific failure if it is invoked.
+		return input;
+	}
+}
+
 function escapeBashEnvValueForDisplay(value: string): string {
 	return value
 		.replaceAll("\\", "\\\\")
@@ -634,14 +645,18 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		// Landlock restrictions compose and cannot be relaxed by its subprocess, so the diagnostic needs
 		// the immutable session anchor even when this individual call uses `cwd` or starts with `cd`.
 		// Keep these values host-owned: tool-supplied env cannot replace them.
-		const env =
-			fence === undefined
-				? requestedEnv
-				: {
-						...requestedEnv,
-						[SANDBOX_SESSION_ROOT_ENV]: containmentRoot,
-						[SANDBOX_OPERATOR_HOME_ENV]: os.homedir(),
-					};
+		let env = requestedEnv;
+		if (fence !== undefined) {
+			const [trustedSessionRoot, trustedOperatorHome] = await Promise.all([
+				canonicalizeSandboxContextPath(containmentRoot),
+				canonicalizeSandboxContextPath(os.homedir()),
+			]);
+			env = {
+				...requestedEnv,
+				[SANDBOX_SESSION_ROOT_ENV]: trustedSessionRoot,
+				[SANDBOX_OPERATOR_HOME_ENV]: trustedOperatorHome,
+			};
+		}
 
 		const localOptions = {
 			getArtifactsDir: this.session.getArtifactsDir,

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -520,6 +520,43 @@ describe("CI verifies the published Homebrew formula end to end", () => {
 		expect(job).toContain('codesign --verify --deep --strict "$binary"');
 		expect(job).toContain('spctl --assess --verbose=4 --type install "$binary"');
 	});
+
+	it("runs the direct-home live-profile matrix against the installed binary", async () => {
+		const job = await loadVerifyHomebrewJob();
+		expect(job).toContain("release-binaries-macos-arm64-signed");
+		expect(job).toContain('XCSH_TEST_SANDBOX_CHECK_BINARY="$binary"');
+		expect(job).toContain("bun test packages/coding-agent/test/sandbox-check.test.ts");
+	});
+});
+
+describe("release artifacts run the sandbox matrix before and after publication", () => {
+	async function loadJob(name: string): Promise<string> {
+		const workflow = await fs.readFile(path.join(import.meta.dir, "../../../.github/workflows/ci.yml"), "utf8");
+		const match = workflow.match(new RegExp(`\\n {2}${name}:\\n[\\s\\S]*?(?=\\n {2}[a-z][a-z-]+:\\n|\\s*$)`));
+		expect(match).not.toBeNull();
+		return match?.[0] ?? "";
+	}
+
+	it("checks the compiled Linux and signed macOS executables", async () => {
+		const linux = await loadJob("build-release");
+		const macos = await loadJob("build-sign-macos");
+		expect(linux).toContain("packages/coding-agent/binaries/xcsh-linux-x64");
+		expect(linux).toContain("bun test packages/coding-agent/test/sandbox-check.test.ts");
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression
+		expect(macos).toContain("packages/coding-agent/binaries/xcsh-darwin-${{ matrix.arch }}");
+		expect(macos).toContain("bun test packages/coding-agent/test/sandbox-check.test.ts");
+		expect(macos.indexOf("Notarize macOS Binary")).toBeLessThan(
+			macos.indexOf("Verify signed macOS sandbox check in a direct-home live profile"),
+		);
+	});
+
+	it("checks the globally installed npm executable", async () => {
+		const job = await loadJob("verify-npm-install");
+		expect(job).toContain("release-binaries-linux-win");
+		expect(job).toContain('binary="$(command -v xcsh)"');
+		expect(job).toContain('XCSH_TEST_SANDBOX_CHECK_BINARY="$binary"');
+		expect(job).toContain("bun test packages/coding-agent/test/sandbox-check.test.ts");
+	});
 });
 
 describe("vim ex-command onUpdate throttle bypass (commit 8f5b630ac)", () => {

--- a/packages/coding-agent/test/sandbox-check.test.ts
+++ b/packages/coding-agent/test/sandbox-check.test.ts
@@ -2,43 +2,40 @@ import { expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { AgentToolResult } from "@f5-sales-demo/pi-agent-core";
 import { $ } from "bun";
 import type { SandboxCheckReport } from "../src/cli/sandbox-check";
 import { Settings } from "../src/config/settings";
 import { _resetShellSessionsForTest } from "../src/exec/bash-executor";
 import { SANDBOX_OPERATOR_HOME_ENV, SANDBOX_SESSION_ROOT_ENV } from "../src/sandbox/session-fence";
 import type { ToolSession } from "../src/tools";
-import { BashTool } from "../src/tools/bash";
+import { BashTool, type BashToolDetails } from "../src/tools/bash";
 
 const cli = path.resolve(import.meta.dir, "../src/cli.ts");
+const sandboxCheckExecutable = process.env.XCSH_TEST_SANDBOX_CHECK_BINARY;
 
-function assertHealthyReport(report: SandboxCheckReport): void {
-	expect(["seatbelt", "landlock", "scanner-only"]).toContain(report.backend);
-	expect(report.summary.failed).toBe(0);
-	expect(report.checks).toHaveLength(10);
-	expect(report.checks).toContainEqual({ name: "structured tools share the boundary", status: "PASS" });
-	expect(report.checks).toContainEqual({ name: "cwd resets across tool calls", status: "PASS" });
-	expect(report.checks).toContainEqual({ name: "synthetic fixtures removed", status: "PASS" });
-	if (report.osEnforced) {
-		expect(report.summary).toEqual({ passed: 10, failed: 0, skipped: 0 });
-		expect(report.checks).toContainEqual({ name: "account container cannot be enumerated", status: "PASS" });
-		expect(report.checks).toContainEqual({ name: "synthetic other account cannot be entered", status: "PASS" });
-	}
+function sandboxCheckCommand(...flags: string[]): string {
+	const argv = sandboxCheckExecutable === undefined ? [process.execPath, cli] : [sandboxCheckExecutable];
+	return [...argv, "sandbox", "check", ...flags].map(value => JSON.stringify(value)).join(" ");
 }
 
-it("runs the standalone installed-process matrix and verifies fixture cleanup", async () => {
-	const result = await $`bun ${cli} sandbox check --json`.quiet().nothrow();
-	const report = JSON.parse(result.stdout.toString()) as SandboxCheckReport;
+async function runSandboxCheckProcess(
+	flags: string[],
+	env: Record<string, string | undefined> = process.env,
+): Promise<$.ShellOutput> {
+	return await $`${{ raw: sandboxCheckCommand(...flags) }}`.env(env).quiet().nothrow();
+}
 
-	expect(result.exitCode).toBe(0);
-	assertHealthyReport(report);
-}, 30_000);
+function resultText(result: AgentToolResult<BashToolDetails>): string {
+	return result.content
+		.filter((part): part is { type: "text"; text: string } => part.type === "text")
+		.map(part => part.text)
+		.join("")
+		.trim();
+}
 
-it("reports a healthy matrix when invoked inside the live bash profile", async () => {
-	const container = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "sandbox-check-live-")));
-	const workspace = path.join(container, "workspace");
-	fs.mkdirSync(workspace);
-	const session = {
+function createSession(workspace: string): ToolSession {
+	return {
 		cwd: workspace,
 		hasUI: false,
 		hasEditTool: true,
@@ -50,22 +47,145 @@ it("reports a healthy matrix when invoked inside the live bash profile", async (
 		}),
 		getSessionId: () => "sandbox-check-nested-profile",
 	} as ToolSession;
-	const bash = new BashTool(session);
+}
 
+async function runInsideLiveProfile(workspace: string, attemptContextOverride = false): Promise<SandboxCheckReport> {
+	const bash = new BashTool(createSession(workspace));
+	const result = await bash.execute("sandbox-check-nested", {
+		command: sandboxCheckCommand("--json"),
+		cwd: fs.realpathSync(os.tmpdir()),
+		...(attemptContextOverride
+			? {
+					env: {
+						[SANDBOX_SESSION_ROOT_ENV]: path.join(workspace, "bogus-root"),
+						[SANDBOX_OPERATOR_HOME_ENV]: path.join(workspace, "bogus-home"),
+					},
+				}
+			: {}),
+	});
+	return JSON.parse(resultText(result)) as SandboxCheckReport;
+}
+
+function assertHealthyReport(report: SandboxCheckReport): void {
+	expect(["seatbelt", "landlock", "scanner-only"]).toContain(report.backend);
+	expect(report.summary.failed).toBe(0);
+	expect(report.summary.errors).toBe(0);
+	expect(report.checks).toHaveLength(10);
+	expect(report.checks).toContainEqual({ name: "structured tools share the boundary", status: "PASS" });
+	expect(report.checks).toContainEqual({ name: "cwd resets across tool calls", status: "PASS" });
+	expect(report.checks).toContainEqual({ name: "synthetic fixtures removed", status: "PASS" });
+	if (report.osEnforced) {
+		expect(report.summary).toEqual({ passed: 10, failed: 0, errors: 0, skipped: 0 });
+		expect(report.checks).toContainEqual({ name: "account container cannot be enumerated", status: "PASS" });
+		expect(report.checks).toContainEqual({ name: "synthetic other account cannot be entered", status: "PASS" });
+	}
+}
+
+it("runs the standalone installed-process matrix and verifies fixture cleanup", async () => {
+	const result = await runSandboxCheckProcess(["--json"]);
+	const report = JSON.parse(result.stdout.toString()) as SandboxCheckReport;
+
+	expect(result.exitCode).toBe(0);
+	assertHealthyReport(report);
+}, 30_000);
+
+it("reports a healthy matrix when invoked inside the live bash profile", async () => {
+	const container = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "sandbox-check-live-")));
+	const workspace = path.join(container, "workspace");
+	fs.mkdirSync(workspace);
 	try {
-		const result = await bash.execute("sandbox-check-nested", {
-			command: `${JSON.stringify(process.execPath)} ${JSON.stringify(cli)} sandbox check --json`,
-			cwd: fs.realpathSync(os.tmpdir()),
-		});
-		const output = result.content
-			.filter((part): part is { type: "text"; text: string } => part.type === "text")
-			.map(part => part.text)
-			.join("")
-			.trim();
-		const report = JSON.parse(output) as SandboxCheckReport;
-		assertHealthyReport(report);
+		assertHealthyReport(await runInsideLiveProfile(workspace));
 	} finally {
 		_resetShellSessionsForTest();
+		fs.rmSync(container, { recursive: true, force: true });
+	}
+}, 30_000);
+
+it("reports a healthy matrix for a live session rooted directly under operator home", async () => {
+	const home = fs.realpathSync(os.homedir());
+	const fixturePaths: string[] = [];
+	const createFixture = (prefix: string): string => {
+		const fixture = fs.realpathSync(fs.mkdtempSync(path.join(home, prefix)));
+		fixturePaths.push(fixture);
+		return fixture;
+	};
+
+	try {
+		const workspace = createFixture(".xcsh-sandbox-check-home-child-");
+		const sibling = createFixture(".xcsh-sandbox-check-named-sibling-");
+		const configFixture = createFixture(".xcsh-sandbox-check-config-");
+		fs.writeFileSync(path.join(sibling, "named.txt"), "sibling\n");
+		const bash = new BashTool(createSession(workspace));
+
+		// The context variables are host-owned; model-supplied replacements must not move the probes.
+		assertHealthyReport(await runInsideLiveProfile(workspace, true));
+
+		await bash.execute("sandbox-check-workspace-capability", {
+			command: "printf own > own.txt && printf '%s\\n' ./* > /dev/null && find . -type f > /dev/null",
+		});
+		expect(fs.readFileSync(path.join(workspace, "own.txt"), "utf8")).toBe("own");
+
+		const siblingRead = await bash.execute("sandbox-check-sibling-capability", {
+			command: 'test "$(cat named.txt)" = sibling',
+			cwd: sibling,
+		});
+		expect(resultText(siblingRead)).toBe("(no output)");
+
+		await bash.execute("sandbox-check-config-capability", {
+			command: "printf operator > config",
+			cwd: configFixture,
+		});
+		expect(fs.readFileSync(path.join(configFixture, "config"), "utf8")).toBe("operator");
+
+		let parentEnumerationDenied = false;
+		try {
+			await bash.execute("sandbox-check-parent-enumeration", {
+				command: `ls ${JSON.stringify(home)} > /dev/null`,
+			});
+		} catch {
+			parentEnumerationDenied = true;
+		}
+		expect(parentEnumerationDenied).toBe(true);
+	} finally {
+		_resetShellSessionsForTest();
+		for (const fixture of fixturePaths) {
+			fs.rmSync(fixture, { recursive: true, force: true });
+			expect(fs.existsSync(fixture)).toBe(false);
+		}
+	}
+}, 30_000);
+
+it("distinguishes setup errors from sandbox failures and skips empty cleanup", async () => {
+	const container = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "sandbox-check-setup-")));
+	const missingWorkspace = path.join(container, "missing-workspace");
+	const env = {
+		...process.env,
+		[SANDBOX_SESSION_ROOT_ENV]: missingWorkspace,
+		[SANDBOX_OPERATOR_HOME_ENV]: container,
+	};
+
+	try {
+		const jsonResult = await runSandboxCheckProcess(["--json"], env);
+		const report = JSON.parse(jsonResult.stdout.toString()) as SandboxCheckReport;
+
+		expect(jsonResult.exitCode).toBe(1);
+		expect(report.summary).toEqual({ passed: 0, failed: 0, errors: 1, skipped: 1 });
+		expect(report.checks[0]?.name).toBe("conformance matrix setup");
+		expect(report.checks[0]?.status).toBe("ERROR");
+		expect(report.checks[0]?.detail).not.toContain(missingWorkspace);
+		expect(report.checks[1]).toEqual({
+			name: "synthetic fixtures removed",
+			status: "SKIP",
+			detail: "setup created no fixtures; path=<synthetic-fixtures>; errno=none",
+		});
+
+		const humanResult = await runSandboxCheckProcess([], env);
+		const human = humanResult.stdout.toString();
+		expect(humanResult.exitCode).toBe(1);
+		expect(human).toContain("ERROR");
+		expect(human).toContain("0 passed, 0 failed, 1 errors, 1 skipped");
+		expect(human).toContain("Conformance matrix did not run.");
+	} finally {
 		fs.rmSync(container, { recursive: true, force: true });
 	}
 }, 30_000);
@@ -83,7 +203,7 @@ it("reports generalized assertion, path, and errno details for a failed probe", 
 	};
 
 	try {
-		const jsonResult = await $`bun ${cli} sandbox check --json`.env(env).quiet().nothrow();
+		const jsonResult = await runSandboxCheckProcess(["--json"], env);
 		const report = JSON.parse(jsonResult.stdout.toString()) as SandboxCheckReport;
 		const failure = report.checks.find(check => check.name === "operator home configuration is writable");
 
@@ -94,7 +214,7 @@ it("reports generalized assertion, path, and errno details for a failed probe", 
 		expect(failure?.detail).toContain("errno=ENOTDIR");
 		expect(failure?.detail).not.toContain(invalidHome);
 
-		const verboseResult = await $`bun ${cli} sandbox check --verbose`.env(env).quiet().nothrow();
+		const verboseResult = await runSandboxCheckProcess(["--verbose"], env);
 		const verbose = verboseResult.stdout.toString();
 		expect(verboseResult.exitCode).toBe(1);
 		expect(verbose).toContain("path=<operator-home>/<synthetic-fixture>");
@@ -103,4 +223,4 @@ it("reports generalized assertion, path, and errno details for a failed probe", 
 	} finally {
 		fs.rmSync(container, { recursive: true, force: true });
 	}
-}, 30_000);
+}, 60_000);

--- a/packages/coding-agent/test/sandbox-check.test.ts
+++ b/packages/coding-agent/test/sandbox-check.test.ts
@@ -7,7 +7,11 @@ import { $ } from "bun";
 import type { SandboxCheckReport } from "../src/cli/sandbox-check";
 import { Settings } from "../src/config/settings";
 import { _resetShellSessionsForTest } from "../src/exec/bash-executor";
-import { SANDBOX_OPERATOR_HOME_ENV, SANDBOX_SESSION_ROOT_ENV } from "../src/sandbox/session-fence";
+import {
+	SANDBOX_CHECK_NAMED_SIBLING_ENV,
+	SANDBOX_OPERATOR_HOME_ENV,
+	SANDBOX_SESSION_ROOT_ENV,
+} from "../src/sandbox/session-fence";
 import type { ToolSession } from "../src/tools";
 import { BashTool, type BashToolDetails } from "../src/tools/bash";
 
@@ -57,6 +61,7 @@ async function runInsideLiveProfile(workspace: string, attemptContextOverride = 
 		...(attemptContextOverride
 			? {
 					env: {
+						[SANDBOX_CHECK_NAMED_SIBLING_ENV]: path.join(workspace, "bogus-sibling"),
 						[SANDBOX_SESSION_ROOT_ENV]: path.join(workspace, "bogus-root"),
 						[SANDBOX_OPERATOR_HOME_ENV]: path.join(workspace, "bogus-home"),
 					},
@@ -104,6 +109,10 @@ it("reports a healthy matrix when invoked inside the live bash profile", async (
 it("reports a healthy matrix for a live session rooted directly under operator home", async () => {
 	const home = fs.realpathSync(os.homedir());
 	const fixturePaths: string[] = [];
+	const liveSiblingPrefix = ".xcsh-sandbox-check-live-sibling-";
+	const liveSiblingCount = (): number =>
+		fs.readdirSync(home).filter(entry => entry.startsWith(liveSiblingPrefix)).length;
+	const liveSiblingCountBefore = liveSiblingCount();
 	const createFixture = (prefix: string): string => {
 		const fixture = fs.realpathSync(fs.mkdtempSync(path.join(home, prefix)));
 		fixturePaths.push(fixture);
@@ -148,6 +157,7 @@ it("reports a healthy matrix for a live session rooted directly under operator h
 		expect(parentEnumerationDenied).toBe(true);
 	} finally {
 		_resetShellSessionsForTest();
+		expect(liveSiblingCount()).toBe(liveSiblingCountBefore);
 		for (const fixture of fixturePaths) {
 			fs.rmSync(fixture, { recursive: true, force: true });
 			expect(fs.existsSync(fixture)).toBe(false);


### PR DESCRIPTION
## Summary

- canonicalize trusted session and home anchors before applying the live BashTool profile
- report harness setup and cleanup faults as ERROR, with empty cleanup as SKIP
- exercise the direct-home topology against source, compiled Linux, signed macOS, npm, and Homebrew executables

Fixes #2807

## Verification

- bun test packages/coding-agent/test/sandbox-check.test.ts
- compiled darwin-arm64 executable through the same test harness
- 162 focused containment and bash executor tests
- cargo test -p containment-check
- bun check:ts
- staged PII gate