### PR TITLE
fix(coding-agent): enforce launch flag scope

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Adopted browser bridge contract 2.0: Chrome chat requests now require explicit tab and session routing, terminal chat errors expose only a closed reason code, and Chrome clients can no longer configure provider credentials or send console login credentials through the bridge ([#2802](https://github.com/f5-sales-demo/xcsh/issues/2802))
 
+### Fixed
+
+- Made root launch flags reject ambiguous subcommand placement without entering agent startup, kept subcommand help correctly routed, and added installed conformance coverage that explicit grants restore parent enumeration ([#2817](https://github.com/f5-sales-demo/xcsh/issues/2817))
+
 ## [20.1.2] - 2026-08-01
 
 ### Fixed

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -5,6 +5,8 @@ import { APP_NAME, initI18n, MIN_BUN_VERSION, registerLocales, t, VERSION } from
  * lightweight CLI runner from pi-utils.
  */
 import { type CommandEntry, run } from "@f5-sales-demo/pi-utils/cli";
+import { FlagUsageError } from "./cli/flag-spec";
+import { findPrefixedCommand } from "./cli/root-command-routing";
 import { locales } from "./locales/index";
 
 registerLocales(locales);
@@ -89,11 +91,41 @@ function isSubcommand(first: string | undefined): boolean {
 	return commands.some(e => e.name === first || e.aliases?.includes(first));
 }
 
+function requestsHelp(args: readonly string[]): boolean {
+	for (const arg of args) {
+		if (arg === "--") return false;
+		if (arg === "--help" || arg === "-h") return true;
+	}
+	return false;
+}
+
 /** Run the CLI with the given argv (no `process.argv` prefix). */
 export function runCli(argv: string[]): Promise<void> {
 	// --help and --version are handled by run() directly, don't rewrite those.
 	// Everything else that isn't a known subcommand routes to "launch".
 	const first = argv[0];
+	const prefixedCommand = findPrefixedCommand(argv, token => isSubcommand(token));
+	if (
+		prefixedCommand !== undefined &&
+		!prefixedCommand.prefixFlags.some(flag => flag === "help" || flag === "version")
+	) {
+		if (requestsHelp(prefixedCommand.commandArgs)) {
+			return run({
+				bin: APP_NAME,
+				version: VERSION,
+				argv: [prefixedCommand.command, ...prefixedCommand.commandArgs],
+				commands,
+				help: showHelp,
+			});
+		}
+		const flags = [...new Set(prefixedCommand.prefixFlags)].map(flag => `--${flag}`).join(", ");
+		process.stderr.write(
+			`Error: launch ${prefixedCommand.prefixFlags.length === 1 ? "flag" : "flags"} ${flags} cannot precede the ` +
+				`\`${prefixedCommand.command}\` subcommand. Launch flags configure an agent session; subcommands must come first.\n`,
+		);
+		process.exitCode = 2;
+		return Promise.resolve();
+	}
 	const runArgv =
 		// Chrome launches the native-messaging host with the calling extension's
 		// origin (chrome-extension://…/) as the first arg. Route that to the
@@ -120,4 +152,10 @@ if (process.env.XCSH_SMOKE_TEST_SPECS === "1") {
 	process.exit(domainCount > 0 && categoryCount > 0 ? 0 : 1);
 }
 
-await runCli(process.argv.slice(2));
+try {
+	await runCli(process.argv.slice(2));
+} catch (error) {
+	if (!(error instanceof FlagUsageError)) throw error;
+	process.stderr.write(`Error: ${error.message}\n`);
+	process.exitCode = 2;
+}

--- a/packages/coding-agent/src/cli/root-command-routing.ts
+++ b/packages/coding-agent/src/cli/root-command-routing.ts
@@ -1,0 +1,72 @@
+import { flagNameForChar, flagSpec, type LaunchFlagName } from "./flag-spec";
+
+export interface PrefixedCommandRoute {
+	command: string;
+	commandArgs: string[];
+	prefixFlags: LaunchFlagName[];
+}
+
+function optionalValue(token: string | undefined): token is string {
+	return token !== undefined && !token.startsWith("-") && !token.startsWith("@");
+}
+
+/**
+ * Find a registered command after root launch flags without changing their scope.
+ *
+ * Root flags configure an agent launch. They are not global options for every command, so callers use
+ * this result to report the scope error instead of treating the command and its arguments as prompt
+ * text. `--` deliberately stops command discovery and keeps everything after it as launch content.
+ */
+export function findPrefixedCommand(
+	argv: readonly string[],
+	isCommand: (token: string) => boolean,
+): PrefixedCommandRoute | undefined {
+	const prefixFlags: LaunchFlagName[] = [];
+	let index = 0;
+	while (index < argv.length) {
+		const token = argv[index];
+		if (token === "--") return undefined;
+		if (!token.startsWith("-") || token === "-") {
+			if (prefixFlags.length === 0 || !isCommand(token)) return undefined;
+			return {
+				command: token,
+				commandArgs: argv.slice(index + 1),
+				prefixFlags,
+			};
+		}
+
+		const [longName, inlineValue] = token.startsWith("--") ? token.slice(2).split("=", 2) : [undefined, undefined];
+		const name = longName ?? flagNameForChar(token.slice(1));
+		const spec = name === undefined ? undefined : flagSpec(name);
+		if (name === undefined || spec === undefined) return undefined;
+		prefixFlags.push(name as LaunchFlagName);
+
+		// Keep invalid boolean `=value` forms on the launch parser's diagnostic path instead of
+		// replacing that syntax error with a subcommand-scope error.
+		if (spec.arity === "boolean") {
+			if (inlineValue !== undefined) return undefined;
+			index++;
+			continue;
+		}
+		if (inlineValue !== undefined) {
+			index++;
+			continue;
+		}
+		// Optional values and subcommands are otherwise ambiguous. A registered command wins; an
+		// operator who means the same token as a value can state that unambiguously with `=`.
+		if (spec.arity === "optional-value" && isCommand(argv[index + 1] ?? "")) {
+			return {
+				command: argv[index + 1],
+				commandArgs: argv.slice(index + 2),
+				prefixFlags,
+			};
+		}
+		if (spec.arity === "optional-value") {
+			index += optionalValue(argv[index + 1]) ? 2 : 1;
+			continue;
+		}
+		if (argv[index + 1] === undefined) return undefined;
+		index += 2;
+	}
+	return undefined;
+}

--- a/packages/coding-agent/src/cli/sandbox-check.ts
+++ b/packages/coding-agent/src/cli/sandbox-check.ts
@@ -2,11 +2,11 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { executeShell } from "@f5-sales-demo/pi-natives";
+import { executeShell, fencePermits } from "@f5-sales-demo/pi-natives";
 import { isEnoent } from "@f5-sales-demo/pi-utils";
 import { Settings } from "../config/settings";
 import { fenceForNative } from "../exec/bash-executor";
-import { buildContainmentFence, type ContainmentFence, containmentStatus } from "../sandbox/containment";
+import { buildContainmentFence, type ContainmentFence, containmentStatus, fenceVerdict } from "../sandbox/containment";
 import { evaluateToolCall } from "../sandbox/enforce";
 import {
 	SANDBOX_CHECK_NAMED_SIBLING_ENV,
@@ -364,6 +364,46 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 					redactions,
 				);
 			});
+			await check("explicit grant restores parent enumeration", async () => {
+				const grantedFence = buildContainmentFence({
+					workspace,
+					home: operatorHome,
+					fsRoot: fixtureRoot,
+					leakRoots: [sessionStore, memoryStore],
+					readOnlyRoots: [workspaces],
+					writeOnlyRoots: [workspaces],
+				});
+				const grantedNativeFence = fenceForNative(grantedFence);
+				if (
+					fenceVerdict(grantedFence, workspaces, "enumerate") !== "allow" ||
+					grantedNativeFence === undefined ||
+					!fencePermits(grantedNativeFence, workspaces, false, true)
+				) {
+					return {
+						passed: false,
+						detail:
+							"explicit grant was not accepted by both policy engines; path=<synthetic-session-parent>; errno=none",
+					};
+				}
+
+				// An inherited OS profile cannot be widened by a child. In that topology the live
+				// profile already grants this synthetic path through the workspace, so exercise the
+				// real operation there after both policy engines accepted the explicit grant. A
+				// standalone check applies the granted fence itself and covers the OS compiler too.
+				const result = await shellProbe(
+					`ls ${quote(workspaces)} > /dev/null`,
+					workspace,
+					inheritedProfile ? undefined : grantedFence,
+					abortController.signal,
+				);
+				return shellOutcome(
+					result,
+					true,
+					"explicit grant must restore synthetic session parent enumeration",
+					"<synthetic-session-parent>",
+					redactions,
+				);
+			});
 			await check("account container cannot be enumerated", async () => {
 				const result = await shellProbe(
 					`ls ${quote(accountRoot)} > /dev/null`,
@@ -422,6 +462,7 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 		} else {
 			for (const name of [
 				"session parent cannot be enumerated",
+				"explicit grant restores parent enumeration",
 				"account container cannot be enumerated",
 				"synthetic other account cannot be entered",
 				"cross-session stores cannot be read",

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -321,13 +321,11 @@ async function maybeAutoChdir(parsed: Args): Promise<void> {
 		return;
 	}
 
-	const normalizePath = (value: string) => {
-		const resolved = realpathSync(path.resolve(value));
-		return process.platform === "win32" ? resolved.toLowerCase() : resolved;
-	};
-
-	const cwd = normalizePath(getProjectDir());
-	const normalizedHome = normalizePath(home);
+	// A nested xcsh process may inherit a profile that permits named home access but withholds parent
+	// metadata. Comparison is advisory auto-chdir logic, so an unavailable realpath must fall back to
+	// the resolved spelling instead of crashing before command dispatch (#2817).
+	const cwd = normalizePathForComparison(getProjectDir());
+	const normalizedHome = normalizePathForComparison(home);
 	if (cwd !== normalizedHome) {
 		return;
 	}
@@ -356,7 +354,7 @@ async function maybeAutoChdir(parsed: Args): Promise<void> {
 
 	try {
 		const fallback = os.tmpdir();
-		if (fallback && normalizePath(fallback) !== cwd && (await isDirectory(fallback))) {
+		if (fallback && normalizePathForComparison(fallback) !== cwd && (await isDirectory(fallback))) {
 			setProjectDir(fallback);
 		}
 	} catch {

--- a/packages/coding-agent/test/root-command-routing.test.ts
+++ b/packages/coding-agent/test/root-command-routing.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { $ } from "bun";
+import { findPrefixedCommand } from "../src/cli/root-command-routing";
+
+const commands = new Set(["sandbox", "stats"]);
+const isCommand = (token: string): boolean => commands.has(token);
+const cli = path.resolve(import.meta.dir, "../src/cli.ts");
+
+describe("root launch flag scope", () => {
+	it("finds a subcommand after inline, repeated, and boolean launch flags", () => {
+		expect(
+			findPrefixedCommand(
+				["--allow-path=/tmp/a", "--allow-path", "/tmp/b", "--no-sandbox", "sandbox", "check"],
+				isCommand,
+			),
+		).toEqual({
+			command: "sandbox",
+			commandArgs: ["check"],
+			prefixFlags: ["allow-path", "allow-path", "no-sandbox"],
+		});
+	});
+
+	it("does not mistake a required flag value for a subcommand", () => {
+		expect(findPrefixedCommand(["--model", "sandbox", "check"], isCommand)).toBeUndefined();
+		expect(findPrefixedCommand(["--allow-path=sandbox", "check"], isCommand)).toBeUndefined();
+	});
+
+	it("leaves an invalid boolean value for the launch parser to reject", () => {
+		expect(findPrefixedCommand(["--no-sandbox=true", "sandbox", "check"], isCommand)).toBeUndefined();
+	});
+
+	it("reports invalid launch-flag syntax as usage without an exception trace", async () => {
+		const result = await $`${process.execPath} ${cli} --no-sandbox=true sandbox check`.quiet().nothrow();
+		const stderr = result.stderr.toString();
+		expect(result.exitCode).toBe(2);
+		expect(stderr).toContain("--no-sandbox is a boolean flag and does not take a value");
+		expect(stderr).not.toContain("Uncaught Exception");
+		expect(stderr).not.toContain("flag-spec.ts");
+	});
+
+	it("requires an equals sign when an optional flag value is also a subcommand name", () => {
+		expect(findPrefixedCommand(["--resume", "sandbox", "check"], isCommand)).toEqual({
+			command: "sandbox",
+			commandArgs: ["check"],
+			prefixFlags: ["resume"],
+		});
+		expect(findPrefixedCommand(["--resume=sandbox", "check"], isCommand)).toBeUndefined();
+	});
+
+	it("preserves everything after the prompt delimiter as launch content", () => {
+		expect(findPrefixedCommand(["--no-sandbox", "--", "sandbox", "check"], isCommand)).toBeUndefined();
+	});
+
+	it("does not rewrite an ordinary subcommand invocation", () => {
+		expect(findPrefixedCommand(["sandbox", "check"], isCommand)).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/sandbox-check.test.ts
+++ b/packages/coding-agent/test/sandbox-check.test.ts
@@ -18,16 +18,20 @@ import { BashTool, type BashToolDetails } from "../src/tools/bash";
 const cli = path.resolve(import.meta.dir, "../src/cli.ts");
 const sandboxCheckExecutable = process.env.XCSH_TEST_SANDBOX_CHECK_BINARY;
 
-function sandboxCheckCommand(...flags: string[]): string {
+function sandboxCommand(args: string[], prefixFlags: string[] = []): string {
 	const argv = sandboxCheckExecutable === undefined ? [process.execPath, cli] : [sandboxCheckExecutable];
-	return [...argv, "sandbox", "check", ...flags].map(value => JSON.stringify(value)).join(" ");
+	return [...argv, ...prefixFlags, "sandbox", ...args].map(value => JSON.stringify(value)).join(" ");
+}
+
+function sandboxCheckCommand(flags: string[] = [], prefixFlags: string[] = []): string {
+	return sandboxCommand(["check", ...flags], prefixFlags);
 }
 
 async function runSandboxCheckProcess(
 	flags: string[],
 	env: Record<string, string | undefined> = process.env,
 ): Promise<$.ShellOutput> {
-	return await $`${{ raw: sandboxCheckCommand(...flags) }}`.env(env).quiet().nothrow();
+	return await $`${{ raw: sandboxCheckCommand(flags) }}`.env(env).quiet().nothrow();
 }
 
 function resultText(result: AgentToolResult<BashToolDetails>): string {
@@ -53,10 +57,14 @@ function createSession(workspace: string): ToolSession {
 	} as ToolSession;
 }
 
-async function runInsideLiveProfile(workspace: string, attemptContextOverride = false): Promise<SandboxCheckReport> {
+async function runInsideLiveProfile(
+	workspace: string,
+	attemptContextOverride = false,
+	prefixFlags: string[] = [],
+): Promise<SandboxCheckReport> {
 	const bash = new BashTool(createSession(workspace));
 	const result = await bash.execute("sandbox-check-nested", {
-		command: sandboxCheckCommand("--json"),
+		command: sandboxCheckCommand(["--json"], prefixFlags),
 		cwd: fs.realpathSync(os.tmpdir()),
 		...(attemptContextOverride
 			? {
@@ -75,14 +83,15 @@ function assertHealthyReport(report: SandboxCheckReport): void {
 	expect(["seatbelt", "landlock", "scanner-only"]).toContain(report.backend);
 	expect(report.summary.failed).toBe(0);
 	expect(report.summary.errors).toBe(0);
-	expect(report.checks).toHaveLength(10);
+	expect(report.checks).toHaveLength(11);
 	expect(report.checks).toContainEqual({ name: "structured tools share the boundary", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "cwd resets across tool calls", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "synthetic fixtures removed", status: "PASS" });
 	if (report.osEnforced) {
-		expect(report.summary).toEqual({ passed: 10, failed: 0, errors: 0, skipped: 0 });
+		expect(report.summary).toEqual({ passed: 11, failed: 0, errors: 0, skipped: 0 });
 		expect(report.checks).toContainEqual({ name: "account container cannot be enumerated", status: "PASS" });
 		expect(report.checks).toContainEqual({ name: "synthetic other account cannot be entered", status: "PASS" });
+		expect(report.checks).toContainEqual({ name: "explicit grant restores parent enumeration", status: "PASS" });
 	}
 }
 
@@ -92,6 +101,45 @@ it("runs the standalone installed-process matrix and verifies fixture cleanup", 
 
 	expect(result.exitCode).toBe(0);
 	assertHealthyReport(report);
+}, 30_000);
+
+it("rejects launch flags before the installed sandbox subcommand without entering agent startup", async () => {
+	const home = fs.realpathSync(os.homedir());
+	const workspace = fs.realpathSync(fs.mkdtempSync(path.join(home, ".xcsh-sandbox-check-prefix-flags-")));
+	try {
+		for (const prefixFlags of [["--no-sandbox"], ["--allow-path", fs.realpathSync(os.tmpdir())]]) {
+			const bash = new BashTool(createSession(workspace));
+			let message = "";
+			try {
+				await bash.execute("sandbox-check-invalid-prefix", {
+					command: sandboxCheckCommand([], prefixFlags),
+				});
+			} catch (error) {
+				message = error instanceof Error ? error.message : String(error);
+			}
+			expect(message).toContain("launch flag");
+			expect(message).toContain("subcommands must come first");
+			expect(message).toContain("Command exited with code 2");
+			expect(message).not.toContain("Uncaught Exception");
+			expect(message).not.toContain("realpathSync");
+			expect(message).not.toContain(home);
+		}
+	} finally {
+		_resetShellSessionsForTest();
+		fs.rmSync(workspace, { recursive: true, force: true });
+		expect(fs.existsSync(workspace)).toBe(false);
+	}
+}, 30_000);
+
+it("renders sandbox help when sandbox launch flags precede the subcommand", async () => {
+	for (const prefixFlags of [["--no-sandbox"], ["--allow-path", fs.realpathSync(os.tmpdir())]]) {
+		const result = await $`${{ raw: sandboxCommand(["--help"], prefixFlags) }}`.quiet().nothrow();
+		const output = result.stdout.toString();
+		expect(result.exitCode).toBe(0);
+		expect(output).toContain("Verify the installed filesystem sandbox");
+		expect(output).toContain("sandbox [ACTION] [FLAGS]");
+		expect(output).not.toContain("COMMANDS");
+	}
 }, 30_000);
 
 it("reports a healthy matrix when invoked inside the live bash profile", async () => {


### PR DESCRIPTION
## Summary

- reject root launch flags placed before a registered subcommand with an explicit scope error
- route prefixed subcommand help correctly and preserve `--` prompt semantics
- make auto-chdir path comparison tolerant of inherited confinement
- extend `xcsh sandbox check` to verify explicit grants restore parent enumeration
- report malformed launch flags as usage errors without stack traces

## Verification

- `bun test packages/coding-agent/test/root-command-routing.test.ts packages/coding-agent/test/sandbox-check.test.ts`
- 243 argument, containment, enforcement, isolation, and shell integration tests
- `bun check:ts`
- `bun run pii:gate --scope staged`

Fixes #2817
