### PR TITLE
fix(release): update immutable-release API call

### DIFF
--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -113,7 +113,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          gh api --method PUT "repos/${REPOSITORY}/immutable-releases" -F enabled=true >/dev/null
+          gh api --method PUT "repos/${REPOSITORY}/immutable-releases" >/dev/null
           gh api "repos/${REPOSITORY}/immutable-releases" \
             | jq -e '.enabled == true' >/dev/null || {
             echo "::error::Repository release immutability must be enabled before tagging"


### PR DESCRIPTION
## Summary

- enable immutable releases with the current bodyless `PUT` contract
- retain the read-after-write assertion before tag creation

## Verification

- bodyless `PUT /repos/f5-sales-demo/xcsh/immutable-releases` succeeded
- follow-up `GET` reports `enabled: true`
- `bun run pii:gate --scope staged`

Fixes #2821
