### PR TITLE
fix(ci): align cross targets with repository Rust toolchain

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,29 @@
+name: Setup Rust
+description: Install the repository-pinned Rust toolchain and an optional cross-compilation target
+
+inputs:
+  target:
+    description: Optional Rust compilation target to add to the active repository toolchain
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install repository Rust toolchain
+      shell: bash
+      env:
+        RUST_TARGET: ${{ inputs.target }}
+      run: |
+        set -euo pipefail
+
+        # With no explicit channel, rustup installs the active toolchain declared by
+        # rust-toolchain.toml. Target installation is deliberately unqualified so it
+        # cannot drift onto a different sysroot from the one Cargo uses.
+        rustup toolchain install --profile minimal --no-self-update
+        if [ -n "$RUST_TARGET" ]; then
+          rustup target add "$RUST_TARGET"
+        fi
+
+        rustup show active-toolchain
+        rustc --version --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,21 +153,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: true
-      - name: Install pinned Rust toolchain
-        shell: bash
-        env:
-          RUST_COMPONENTS: ${{ matrix.rust_checks && 'clippy,rustfmt' || '' }}
-        run: |
-          set -euo pipefail
-          rustup toolchain install nightly-2026-03-27 --profile minimal
-          rustup default nightly-2026-03-27
-          if [ -n "$RUST_COMPONENTS" ]; then
-            IFS=, read -ra components <<< "$RUST_COMPONENTS"
-            rustup component add --toolchain nightly-2026-03-27 "${components[@]}"
-          fi
-          if [ -n "$RUST_TARGET" ]; then
-            rustup target add --toolchain nightly-2026-03-27 "$RUST_TARGET"
-          fi
+      - uses: ./.github/actions/setup-rust
+        with:
+          target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           key: ${{ matrix.target }}${{ matrix.variants }}
@@ -347,12 +335,7 @@ jobs:
           fi
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
-      - name: Install pinned Rust toolchain
-        shell: bash
-        run: |
-          set -euo pipefail
-          rustup toolchain install nightly-2026-03-27 --profile minimal
-          rustup default nightly-2026-03-27
+      - uses: ./.github/actions/setup-rust
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           cache-workspace-crates: true
@@ -455,12 +438,7 @@ jobs:
           fi
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
-      - name: Install pinned Rust toolchain
-        shell: bash
-        run: |
-          set -euo pipefail
-          rustup toolchain install nightly-2026-03-27 --profile minimal
-          rustup default nightly-2026-03-27
+      - uses: ./.github/actions/setup-rust
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           cache-workspace-crates: true

--- a/.github/workflows/test-codesign.yml
+++ b/.github/workflows/test-codesign.yml
@@ -80,9 +80,7 @@ jobs:
           fi
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          toolchain: nightly-2026-03-27
+      - uses: ./.github/actions/setup-rust
       - uses: Swatinem/rust-cache@v2
         with:
           cache-workspace-crates: true

--- a/packages/coding-agent/test/scripts/ci-workflow-contract.test.ts
+++ b/packages/coding-agent/test/scripts/ci-workflow-contract.test.ts
@@ -11,10 +11,30 @@ interface WorkflowDocument {
 }
 
 const CI_WORKFLOW = path.resolve(import.meta.dir, "../../../../.github/workflows/ci.yml");
+const CODESIGN_WORKFLOW = path.resolve(import.meta.dir, "../../../../.github/workflows/test-codesign.yml");
+const RUST_SETUP_ACTION = path.resolve(import.meta.dir, "../../../../.github/actions/setup-rust/action.yml");
 
 test("protected CI jobs expose the exact required check-run names", async () => {
 	const workflow = parse(await Bun.file(CI_WORKFLOW).text()) as WorkflowDocument;
 
 	expect(workflow.jobs?.check?.name).toBe("check");
 	expect(workflow.jobs?.test?.name).toBe("test");
+});
+
+test("CI installs cross targets into the repository-selected Rust toolchain", async () => {
+	const ciWorkflow = await Bun.file(CI_WORKFLOW).text();
+	const codesignWorkflow = await Bun.file(CODESIGN_WORKFLOW).text();
+	const setupAction = await Bun.file(RUST_SETUP_ACTION).text();
+
+	for (const workflow of [ciWorkflow, codesignWorkflow]) {
+		expect(workflow).not.toMatch(/nightly-\d{4}-\d{2}-\d{2}/);
+		expect(workflow).toContain("uses: ./.github/actions/setup-rust");
+	}
+
+	expect(ciWorkflow.match(/uses: \.\/\.github\/actions\/setup-rust/g)).toHaveLength(3);
+	expect(ciWorkflow).toContain("target: ${{ matrix.target }}");
+	expect(codesignWorkflow.match(/uses: \.\/\.github\/actions\/setup-rust/g)).toHaveLength(1);
+	expect(setupAction).toContain("rustup toolchain install --profile minimal --no-self-update");
+	expect(setupAction).toContain('rustup target add "$RUST_TARGET"');
+	expect(setupAction).not.toContain("--toolchain");
 });


### PR DESCRIPTION
## Summary

- make rust-toolchain.toml the only dated Rust toolchain selection
- install matrix cross targets into the active repository-selected sysroot
- share that setup across CI and the codesign diagnostic
- add a workflow contract test that rejects duplicate dated toolchain pins

## Verification

- focused workflow contract: 2 passed
- bun check:ts
- actionlint
- staged PII gate
- local active-sysroot probe confirmed the cross-target libcore is installed under the Cargo-selected toolchain

Fixes #2823