### PR TITLE
fix(release): set archive timestamps through filesystem API

### DIFF
--- a/packages/coding-agent/test/scripts/ci-workflow-contract.test.ts
+++ b/packages/coding-agent/test/scripts/ci-workflow-contract.test.ts
@@ -32,7 +32,7 @@ test("CI installs cross targets into the repository-selected Rust toolchain", as
 	}
 
 	expect(ciWorkflow.match(/uses: \.\/\.github\/actions\/setup-rust/g)).toHaveLength(3);
-	expect(ciWorkflow).toContain("target: ${{ matrix.target }}");
+	expect(ciWorkflow).toContain(`target: \${{ matrix.target }}`);
 	expect(codesignWorkflow.match(/uses: \.\/\.github\/actions\/setup-rust/g)).toHaveLength(1);
 	expect(setupAction).toContain("rustup toolchain install --profile minimal --no-self-update");
 	expect(setupAction).toContain('rustup target add "$RUST_TARGET"');

--- a/packages/coding-agent/test/scripts/homebrew-formula.test.ts
+++ b/packages/coding-agent/test/scripts/homebrew-formula.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { generateFormula } from "../../../../scripts/ci-release-homebrew";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { $ } from "bun";
+import { createArchives, generateFormula } from "../../../../scripts/ci-release-homebrew";
 
 /**
  * Guard for the brew `post_install` recycle hook (#upgrade-recycle).
@@ -32,5 +36,36 @@ describe("homebrew formula post_install recycle", () => {
 	it("still installs the binary for every arch and carries the version", () => {
 		expect(formula.match(/bin\.install "xcsh"/g)?.length).toBe(4); // 2 macOS + 2 linux
 		expect(formula).toContain('version "19.99.0"');
+	});
+});
+
+describe("homebrew release archives", () => {
+	it("creates reproducible zip bytes with the requested source timestamp", async () => {
+		const fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-homebrew-archive-test-"));
+		const epochSeconds = 1_700_000_000;
+		const archivePath = path.join(fixtureDir, "xcsh-darwin-arm64.zip");
+
+		try {
+			await Bun.write(path.join(fixtureDir, "xcsh-darwin-arm64"), "synthetic xcsh binary\n");
+			const options = {
+				binariesDir: fixtureDir,
+				dryRun: false,
+				sourceDateEpoch: String(epochSeconds),
+			};
+
+			await createArchives(options);
+			const firstArchive = await fs.readFile(archivePath);
+			await createArchives(options);
+			const secondArchive = await fs.readFile(archivePath);
+			expect(secondArchive).toEqual(firstArchive);
+
+			const extractDir = path.join(fixtureDir, "extracted");
+			await fs.mkdir(extractDir);
+			await $`unzip -q ${archivePath} -d ${extractDir}`.quiet();
+			const archivedBinary = await fs.stat(path.join(extractDir, "xcsh"));
+			expect(Math.floor(archivedBinary.mtimeMs / 1000)).toBe(epochSeconds);
+		} finally {
+			await fs.rm(fixtureDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/scripts/ci-release-homebrew.ts
+++ b/scripts/ci-release-homebrew.ts
@@ -28,6 +28,12 @@ const isDryRun = process.argv.includes("--dry-run");
 const packageOnly = process.argv.includes("--package-only");
 const updateTapOnly = process.argv.includes("--update-tap");
 
+export interface CreateArchivesOptions {
+	binariesDir?: string;
+	dryRun?: boolean;
+	sourceDateEpoch?: string;
+}
+
 function getVersion(): string {
 	const ref = process.env.GITHUB_REF_NAME || "";
 	if (ref.startsWith("v")) return ref.slice(1);
@@ -44,16 +50,27 @@ function getTag(): string {
 	return process.env.GITHUB_REF_NAME || `v${getVersion()}`;
 }
 
-async function createArchives(): Promise<void> {
-	console.log("Creating archives for Homebrew...");
-	const sourceDateEpoch = process.env.SOURCE_DATE_EPOCH;
-	if (!isDryRun && (!sourceDateEpoch || !/^\d+$/.test(sourceDateEpoch))) {
+function parseSourceDateEpoch(value: string | undefined): number {
+	if (!value || !/^\d+$/.test(value)) {
 		throw new Error("SOURCE_DATE_EPOCH is required for deterministic release archives");
 	}
+	const seconds = Number(value);
+	if (!Number.isSafeInteger(seconds)) {
+		throw new Error("SOURCE_DATE_EPOCH must be a safe integer");
+	}
+	return seconds;
+}
+
+export async function createArchives(options: CreateArchivesOptions = {}): Promise<void> {
+	console.log("Creating archives for Homebrew...");
+	const outputDir = options.binariesDir ?? binariesDir;
+	const dryRun = options.dryRun ?? isDryRun;
+	const sourceDateEpoch = options.sourceDateEpoch ?? process.env.SOURCE_DATE_EPOCH;
+	const epochSeconds = dryRun ? undefined : parseSourceDateEpoch(sourceDateEpoch);
 
 	for (const target of archiveTargets) {
-		const binaryPath = path.join(binariesDir, target.binary);
-		const archivePath = path.join(binariesDir, target.archive);
+		const binaryPath = path.join(outputDir, target.binary);
+		const archivePath = path.join(outputDir, target.archive);
 
 		try {
 			await fs.stat(binaryPath);
@@ -70,15 +87,16 @@ async function createArchives(): Promise<void> {
 			const stagedBinary = path.join(tmpDir, "xcsh");
 
 			if (target.format === "zip") {
-				if (isDryRun) {
+				if (dryRun) {
 					console.log(`  DRY RUN: zip -X -j ${archivePath} ${tmpDir}/xcsh`);
 				} else {
-					await $`touch -d ${`@${sourceDateEpoch}`} ${stagedBinary}`;
+					if (epochSeconds === undefined) throw new Error("SOURCE_DATE_EPOCH was not resolved");
+					await fs.utimes(stagedBinary, epochSeconds, epochSeconds);
 					await $`zip -X -j ${archivePath} ${stagedBinary}`;
 					console.log(`  Created ${target.archive}`);
 				}
 			} else {
-				if (isDryRun) {
+				if (dryRun) {
 					console.log(`  DRY RUN: deterministic tar + gzip -n ${archivePath}`);
 				} else {
 					await $`tar --sort=name --mtime=${`@${sourceDateEpoch}`} --owner=0 --group=0 --numeric-owner -cf - -C ${tmpDir} xcsh | gzip -n > ${archivePath}`;


### PR DESCRIPTION
## Summary

- replace unsupported Bun Shell touch flags with fs.utimes
- retain strict SOURCE_DATE_EPOCH validation
- verify identical archive bytes across repeated packaging
- verify the archived entry carries the requested source timestamp
- clear the workflow-contract lint warning discovered by the full check

## Verification

- focused archive and workflow contracts: 5 passed
- bun check:ts
- staged PII gate
- v20.2.1 release evidence: all build/sign jobs passed; publication failed only at the removed touch invocation

Fixes #2826