### PR TITLE
fix(cli): report sandbox launch flag scope as usage

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Made sandbox launch-flag scope errors consistent in either argument position, report usage exit 2 without parser exceptions, and direct operators to the flag-free conformance check ([#2834](https://github.com/f5-sales-demo/xcsh/issues/2834))
+
 ## [20.2.1] - 2026-08-01
 
 ### Fixed

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -5,8 +5,7 @@ import { APP_NAME, initI18n, MIN_BUN_VERSION, registerLocales, t, VERSION } from
  * lightweight CLI runner from pi-utils.
  */
 import { type CommandEntry, run } from "@f5-sales-demo/pi-utils/cli";
-import { FlagUsageError } from "./cli/flag-spec";
-import { findPrefixedCommand } from "./cli/root-command-routing";
+import { findPrefixedCommand, launchFlagScopeMessage } from "./cli/root-command-routing";
 import { locales } from "./locales/index";
 
 registerLocales(locales);
@@ -118,10 +117,13 @@ export function runCli(argv: string[]): Promise<void> {
 				help: showHelp,
 			});
 		}
-		const flags = [...new Set(prefixedCommand.prefixFlags)].map(flag => `--${flag}`).join(", ");
 		process.stderr.write(
-			`Error: launch ${prefixedCommand.prefixFlags.length === 1 ? "flag" : "flags"} ${flags} cannot precede the ` +
-				`\`${prefixedCommand.command}\` subcommand. Launch flags configure an agent session; subcommands must come first.\n`,
+			`Error: ${launchFlagScopeMessage(
+				prefixedCommand.prefixFlags,
+				prefixedCommand.command,
+				prefixedCommand.commandArgs,
+				APP_NAME,
+			)}\n`,
 		);
 		process.exitCode = 2;
 		return Promise.resolve();
@@ -152,10 +154,4 @@ if (process.env.XCSH_SMOKE_TEST_SPECS === "1") {
 	process.exit(domainCount > 0 && categoryCount > 0 ? 0 : 1);
 }
 
-try {
-	await runCli(process.argv.slice(2));
-} catch (error) {
-	if (!(error instanceof FlagUsageError)) throw error;
-	process.stderr.write(`Error: ${error.message}\n`);
-	process.exitCode = 2;
-}
+await runCli(process.argv.slice(2));

--- a/packages/coding-agent/src/cli/flag-spec.ts
+++ b/packages/coding-agent/src/cli/flag-spec.ts
@@ -13,7 +13,7 @@
  * `cli/args.ts` can both depend on it without a cycle.
  */
 import { THINKING_EFFORTS } from "@f5-sales-demo/pi-ai";
-import { type FlagDescriptor, Flags } from "@f5-sales-demo/pi-utils/cli";
+import { CliUsageError, type FlagDescriptor, Flags } from "@f5-sales-demo/pi-utils/cli";
 
 export type FlagArity = "boolean" | "value" | "optional-value" | "repeatable-value";
 
@@ -157,8 +157,6 @@ export interface UnrecognizedFlag {
 	name: string;
 }
 
-export class FlagUsageError extends Error {}
-
 /**
  * Rewrite `--name=value` into `["--name", "value"]` for every flag that takes a value.
  *
@@ -197,7 +195,7 @@ export function normalizeFlagTokens(
 		const spec = flagSpec(name);
 		if (spec) {
 			if (!takesValue(spec)) {
-				throw new FlagUsageError(`--${name} is a boolean flag and does not take a value`);
+				throw new CliUsageError(`--${name} is a boolean flag and does not take a value`);
 			}
 			normalized.push(`--${name}`, value);
 			continue;
@@ -206,7 +204,7 @@ export function normalizeFlagTokens(
 		const extension = extensionFlags?.get(name);
 		if (extension) {
 			if (extension.type === "boolean") {
-				throw new FlagUsageError(`--${name} is a boolean flag and does not take a value`);
+				throw new CliUsageError(`--${name} is a boolean flag and does not take a value`);
 			}
 			normalized.push(`--${name}`, value);
 			continue;

--- a/packages/coding-agent/src/cli/root-command-routing.ts
+++ b/packages/coding-agent/src/cli/root-command-routing.ts
@@ -1,9 +1,71 @@
+import type { FlagDescriptor } from "@f5-sales-demo/pi-utils/cli";
 import { flagNameForChar, flagSpec, type LaunchFlagName } from "./flag-spec";
 
 export interface PrefixedCommandRoute {
 	command: string;
 	commandArgs: string[];
 	prefixFlags: LaunchFlagName[];
+}
+
+function uniqueFlags(flags: readonly LaunchFlagName[]): LaunchFlagName[] {
+	return [...new Set(flags)];
+}
+
+/**
+ * Find agent-launch flags in a registered command's argv while preserving that command's own flags.
+ *
+ * `--` ends option parsing. Long and short command flags both take precedence over identically named
+ * launch flags, so `sandbox check -v` remains the sandbox check's verbose mode.
+ */
+export function findCommandLaunchFlags(
+	argv: readonly string[],
+	commandFlags: Readonly<Record<string, FlagDescriptor>>,
+): LaunchFlagName[] {
+	const shortCommandFlags = new Set(
+		Object.values(commandFlags)
+			.map(descriptor => descriptor.char)
+			.filter((char): char is string => char !== undefined),
+	);
+	const found: LaunchFlagName[] = [];
+
+	for (const token of argv) {
+		if (token === "--") break;
+		if (token.startsWith("--")) {
+			const name = token.slice(2).split("=", 1)[0];
+			if (commandFlags[name] !== undefined) continue;
+			if (flagSpec(name) !== undefined) found.push(name as LaunchFlagName);
+			continue;
+		}
+		if (!token.startsWith("-") || token === "-") continue;
+		const char = token.slice(1);
+		if (shortCommandFlags.has(char)) continue;
+		const name = flagNameForChar(char);
+		if (name !== undefined) found.push(name);
+	}
+
+	return uniqueFlags(found);
+}
+
+/** Render the single scope diagnostic used for launch flags on either side of a subcommand. */
+export function launchFlagScopeMessage(
+	flags: readonly LaunchFlagName[],
+	command: string,
+	commandArgs: readonly string[],
+	bin: string,
+): string {
+	const unique = uniqueFlags(flags);
+	const names = unique.map(flag => `--${flag}`).join(", ");
+	const singular = unique.length === 1;
+	if (command === "sandbox" && commandArgs[0] === "check") {
+		return (
+			`Launch ${singular ? "flag" : "flags"} ${names} ${singular ? "applies" : "apply"} to an agent session, not to \`sandbox check\`. ` +
+			`Run \`${bin} sandbox check\` without launch flags; its \`explicit grant restores parent enumeration\` probe verifies grant behavior.`
+		);
+	}
+	return (
+		`Launch ${singular ? "flag" : "flags"} ${names} ${singular ? "applies" : "apply"} to an agent session, not to the ` +
+		`\`${command}\` subcommand. Start an agent session with launch flags before its prompt.`
+	);
 }
 
 function optionalValue(token: string | undefined): token is string {

--- a/packages/coding-agent/src/commands/sandbox.ts
+++ b/packages/coding-agent/src/commands/sandbox.ts
@@ -1,5 +1,7 @@
 /** Run installed-binary sandbox diagnostics. */
-import { Args, Command, Flags } from "@f5-sales-demo/pi-utils/cli";
+import { APP_NAME } from "@f5-sales-demo/pi-utils";
+import { Args, CliUsageError, Command, Flags } from "@f5-sales-demo/pi-utils/cli";
+import { findCommandLaunchFlags, launchFlagScopeMessage } from "../cli/root-command-routing";
 import { runSandboxCheck } from "../cli/sandbox-check";
 
 export default class Sandbox extends Command {
@@ -19,6 +21,10 @@ export default class Sandbox extends Command {
 	};
 
 	async run(): Promise<void> {
+		const launchFlags = findCommandLaunchFlags(this.argv, Sandbox.flags);
+		if (launchFlags.length > 0) {
+			throw new CliUsageError(launchFlagScopeMessage(launchFlags, "sandbox", this.argv, APP_NAME));
+		}
 		const { flags } = await this.parse(Sandbox);
 		const report = await runSandboxCheck({ json: flags.json, verbose: flags.verbose });
 		if (report.summary.failed > 0 || report.summary.errors > 0) process.exitCode = 1;

--- a/packages/coding-agent/test/root-command-routing.test.ts
+++ b/packages/coding-agent/test/root-command-routing.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
+import { Flags } from "@f5-sales-demo/pi-utils/cli";
 import { $ } from "bun";
-import { findPrefixedCommand } from "../src/cli/root-command-routing";
+import { findCommandLaunchFlags, findPrefixedCommand } from "../src/cli/root-command-routing";
 
 const commands = new Set(["sandbox", "stats"]);
 const isCommand = (token: string): boolean => commands.has(token);
@@ -54,5 +55,27 @@ describe("root launch flag scope", () => {
 
 	it("does not rewrite an ordinary subcommand invocation", () => {
 		expect(findPrefixedCommand(["sandbox", "check"], isCommand)).toBeUndefined();
+	});
+
+	it("finds launch-only flags after a command without taking over command-local flags", () => {
+		const sandboxFlags = {
+			json: Flags.boolean({ description: "Output JSON" }),
+			verbose: Flags.boolean({ char: "v", description: "Show failure details" }),
+		};
+		expect(
+			findCommandLaunchFlags(
+				["check", "--json", "-v", "--allow-path=/tmp", "--no-sandbox", "--", "--model", "ignored"],
+				sandboxFlags,
+			),
+		).toEqual(["allow-path", "no-sandbox"]);
+	});
+
+	it("reports subcommand parser failures as usage without an exception trace", async () => {
+		const result = await $`${process.execPath} ${cli} sandbox check --not-a-sandbox-flag`.quiet().nothrow();
+		const stderr = result.stderr.toString();
+		expect(result.exitCode).toBe(2);
+		expect(stderr).toContain("Unknown option '--not-a-sandbox-flag'");
+		expect(stderr).not.toContain("Uncaught Exception");
+		expect(stderr).not.toContain("node:util");
 	});
 });

--- a/packages/coding-agent/test/sandbox-check.test.ts
+++ b/packages/coding-agent/test/sandbox-check.test.ts
@@ -95,7 +95,7 @@ function assertHealthyReport(report: SandboxCheckReport): void {
 	}
 }
 
-it("runs the standalone installed-process matrix and verifies fixture cleanup", async () => {
+it("runs the flag-free sandbox check named by launch-flag diagnostics and verifies fixture cleanup", async () => {
 	const result = await runSandboxCheckProcess(["--json"]);
 	const report = JSON.parse(result.stdout.toString()) as SandboxCheckReport;
 
@@ -103,26 +103,31 @@ it("runs the standalone installed-process matrix and verifies fixture cleanup", 
 	assertHealthyReport(report);
 }, 30_000);
 
-it("rejects launch flags before the installed sandbox subcommand without entering agent startup", async () => {
+it("rejects launch flags on either side of the installed sandbox subcommand with one scope diagnostic", async () => {
 	const home = fs.realpathSync(os.homedir());
 	const workspace = fs.realpathSync(fs.mkdtempSync(path.join(home, ".xcsh-sandbox-check-prefix-flags-")));
 	try {
-		for (const prefixFlags of [["--no-sandbox"], ["--allow-path", fs.realpathSync(os.tmpdir())]]) {
-			const bash = new BashTool(createSession(workspace));
-			let message = "";
-			try {
-				await bash.execute("sandbox-check-invalid-prefix", {
-					command: sandboxCheckCommand([], prefixFlags),
-				});
-			} catch (error) {
-				message = error instanceof Error ? error.message : String(error);
+		for (const launchFlags of [["--no-sandbox"], ["--allow-path", fs.realpathSync(os.tmpdir())]]) {
+			const commands = [sandboxCheckCommand([], launchFlags), sandboxCheckCommand(launchFlags)];
+			const messages: string[] = [];
+			for (const command of commands) {
+				const bash = new BashTool(createSession(workspace));
+				let message = "";
+				try {
+					await bash.execute("sandbox-check-invalid-scope", { command });
+				} catch (error) {
+					message = error instanceof Error ? error.message : String(error);
+				}
+				messages.push(message);
+				expect(message).toContain("applies to an agent session, not to `sandbox check`");
+				expect(message).toContain("Run `xcsh sandbox check` without launch flags");
+				expect(message).toContain("explicit grant restores parent enumeration");
+				expect(message).toContain("Command exited with code 2");
+				expect(message).not.toContain("Uncaught Exception");
+				expect(message).not.toContain("realpathSync");
+				expect(message).not.toContain(home);
 			}
-			expect(message).toContain("launch flag");
-			expect(message).toContain("subcommands must come first");
-			expect(message).toContain("Command exited with code 2");
-			expect(message).not.toContain("Uncaught Exception");
-			expect(message).not.toContain("realpathSync");
-			expect(message).not.toContain(home);
+			expect(messages[0]).toBe(messages[1]);
 		}
 	} finally {
 		_resetShellSessionsForTest();

--- a/packages/utils/src/cli.ts
+++ b/packages/utils/src/cli.ts
@@ -98,6 +98,9 @@ export interface ParseOutput<
 	argv: string[];
 }
 
+/** Invalid command-line syntax that callers should report as a usage error. */
+export class CliUsageError extends Error {}
+
 // ---------------------------------------------------------------------------
 // Command base class
 // ---------------------------------------------------------------------------
@@ -173,12 +176,19 @@ export abstract class Command {
 
 		// strict=false when command declares args (positionals must pass through)
 		// or when the command itself opts out
-		const { values: rawValues, positionals } = nodeParseArgs({
-			args: this.argv,
-			options,
-			allowPositionals: true,
-			strict,
-		});
+		const { values: rawValues, positionals } = (() => {
+			try {
+				return nodeParseArgs({
+					args: this.argv,
+					options,
+					allowPositionals: true,
+					strict,
+				});
+			} catch (error) {
+				if (error instanceof TypeError) throw new CliUsageError(error.message);
+				throw error;
+			}
+		})();
 
 		// Convert raw values to proper types and validate
 		const flags: Record<string, unknown> = {};
@@ -190,7 +200,7 @@ export abstract class Command {
 				} else {
 					const n = Number.parseInt(raw as string, 10);
 					if (Number.isNaN(n)) {
-						throw new Error(`Expected integer for --${name}, got "${raw}"`);
+						throw new CliUsageError(`Expected integer for --${name}, got "${raw}"`);
 					}
 					flags[name] = n;
 				}
@@ -203,14 +213,16 @@ export abstract class Command {
 				// Validate options constraint
 				if (val !== undefined && desc.options && !Array.isArray(val)) {
 					if (!desc.options.includes(val as string)) {
-						throw new Error(`Expected --${name} to be one of: ${[...desc.options].join(", ")}; got "${val}"`);
+						throw new CliUsageError(
+							`Expected --${name} to be one of: ${[...desc.options].join(", ")}; got "${val}"`,
+						);
 					}
 				}
 				flags[name] = val;
 			}
 			// Validate required
 			if (desc.required && flags[name] === undefined) {
-				throw new Error(`Missing required flag: --${name}`);
+				throw new CliUsageError(`Missing required flag: --${name}`);
 			}
 		}
 
@@ -229,13 +241,15 @@ export abstract class Command {
 			}
 			// Validate required
 			if (desc.required && args[argName] === undefined) {
-				throw new Error(`Missing required argument: ${argName}`);
+				throw new CliUsageError(`Missing required argument: ${argName}`);
 			}
 			// Validate options constraint
 			const argVal = args[argName];
 			if (argVal !== undefined && desc.options && typeof argVal === "string") {
 				if (!desc.options.includes(argVal)) {
-					throw new Error(`Expected ${argName} to be one of: ${[...desc.options].join(", ")}; got "${argVal}"`);
+					throw new CliUsageError(
+						`Expected ${argName} to be one of: ${[...desc.options].join(", ")}; got "${argVal}"`,
+					);
 				}
 			}
 		}
@@ -418,7 +432,13 @@ export async function run(opts: RunOptions): Promise<void> {
 	const Cmd = await entry.load();
 	const config: CliConfig = { bin, version, commands: new Map([[entry.name, Cmd]]) };
 	const instance = new Cmd(commandArgv, config);
-	await instance.run();
+	try {
+		await instance.run();
+	} catch (error) {
+		if (!(error instanceof CliUsageError)) throw error;
+		process.stderr.write(`Error: ${error.message}\n`);
+		process.exitCode = 2;
+	}
 }
 
 /** Resolve all command loaders for help/alias display. */


### PR DESCRIPTION
## Summary

- classify subcommand parser failures as usage errors with exit status 2
- reject agent launch flags on either side of sandbox check with one scope diagnostic
- direct operators to the flag-free check and its explicit-grant conformance probe

## Verification

- bun test packages/coding-agent/test/root-command-routing.test.ts
- bun test packages/coding-agent/test/sandbox-check.test.ts
- bun check:ts
- bun run pii:gate

Fixes #2834
