### PR TITLE
fix(bash): preserve exit status in assignments

### DIFF
--- a/crates/brush-core-vendored/src/commands.rs
+++ b/crates/brush-core-vendored/src/commands.rs
@@ -621,7 +621,7 @@ pub(crate) async fn invoke_command_in_subshell_and_get_output(
 	let cmd_result = cmd_result.map_err(io::Error::other)??;
 
 	// Store the status.
-	*shell.last_exit_status_mut() = cmd_result.exit_code.into();
+	shell.set_last_exit_status(cmd_result.exit_code.into());
 
 	Ok(output_str)
 }

--- a/crates/brush-core-vendored/src/interp.rs
+++ b/crates/brush-core-vendored/src/interp.rs
@@ -258,7 +258,7 @@ impl Execute for ast::Program {
 			}
 		}
 
-		*shell.last_exit_status_mut() = result.exit_code.into();
+		shell.set_last_exit_status(result.exit_code.into());
 		Ok(result)
 	}
 }
@@ -295,7 +295,7 @@ impl Execute for ast::CompoundList {
 			}
 		}
 
-		*shell.last_exit_status_mut() = result.exit_code.into();
+		shell.set_last_exit_status(result.exit_code.into());
 		Ok(result)
 	}
 }
@@ -482,7 +482,7 @@ impl Execute for ast::Pipeline {
 		}
 
 		// Update statuses.
-		*shell.last_exit_status_mut() = result.exit_code.into();
+		shell.set_last_exit_status(result.exit_code.into());
 
 		// If requested, report timing.
 		if let Some(timed) = &self.timed {
@@ -600,12 +600,12 @@ async fn wait_for_pipeline_processes_and_update_status(
 		{
 			ExecutionWaitResult::Completed(current_result) => {
 				result = current_result;
-				*shell.last_exit_status_mut() = result.exit_code.into();
+				shell.set_last_exit_status(result.exit_code.into());
 				shell.last_pipeline_statuses.push(result.exit_code.into());
 			},
 			ExecutionWaitResult::Stopped(child) => {
 				result = ExecutionResult::stopped();
-				*shell.last_exit_status_mut() = result.exit_code.into();
+				shell.set_last_exit_status(result.exit_code.into());
 				shell.last_pipeline_statuses.push(result.exit_code.into());
 
 				stopped_children.push(jobs::JobTask::External(child));
@@ -783,7 +783,7 @@ impl Execute for ast::ForClauseCommand {
 			}
 		}
 
-		*shell.last_exit_status_mut() = result.exit_code.into();
+		shell.set_last_exit_status(result.exit_code.into());
 		Ok(result)
 	}
 }
@@ -851,7 +851,7 @@ impl Execute for ast::CaseClauseCommand {
 			}
 		}
 
-		*shell.last_exit_status_mut() = result.exit_code.into();
+		shell.set_last_exit_status(result.exit_code.into());
 
 		Ok(result)
 	}
@@ -900,7 +900,7 @@ impl Execute for ast::IfClauseCommand {
 		}
 
 		let result = ExecutionResult::success();
-		*shell.last_exit_status_mut() = result.exit_code.into();
+		shell.set_last_exit_status(result.exit_code.into());
 
 		Ok(result)
 	}
@@ -972,7 +972,7 @@ impl Execute for ast::ArithmeticCommand {
 			ExecutionResult::general_error()
 		};
 
-		*shell.last_exit_status_mut() = result.exit_code.into();
+		shell.set_last_exit_status(result.exit_code.into());
 
 		Ok(result)
 	}
@@ -1017,7 +1017,7 @@ impl Execute for ast::ArithmeticForClauseCommand {
 			}
 		}
 
-		*shell.last_exit_status_mut() = result.exit_code.into();
+		shell.set_last_exit_status(result.exit_code.into());
 		Ok(result)
 	}
 }
@@ -1032,7 +1032,7 @@ impl Execute for ast::FunctionDefinition {
 		shell.define_func(self.fname.value.clone(), self.clone());
 
 		let result = ExecutionResult::success();
-		*shell.last_exit_status_mut() = result.exit_code.into();
+		shell.set_last_exit_status(result.exit_code.into());
 
 		Ok(result)
 	}
@@ -1060,6 +1060,8 @@ impl ExecuteInPipeline for ast::SimpleCommand {
 		let mut assignments = vec![];
 		let mut args: Vec<CommandArg> = vec![];
 		let mut command_takes_assignments = false;
+		let status_change_count_before_expansion =
+			context.shell.last_exit_status_change_count();
 
 		for item in prefix_iter.chain(cmd_name_items.iter()).chain(suffix_iter) {
 			ensure_not_cancelled(&params)?;
@@ -1162,9 +1164,6 @@ impl ExecuteInPipeline for ast::SimpleCommand {
 				},
 			}
 		} else {
-			// Reset last status.
-			*context.shell.last_exit_status_mut() = 0;
-
 			// No command to run; assignments must be applied to this shell.
 			for assignment in assignments {
 				apply_assignment(
@@ -1176,6 +1175,14 @@ impl ExecuteInPipeline for ast::SimpleCommand {
 					EnvironmentScope::Global,
 				)
 				.await?;
+			}
+
+			// Assignment-only commands succeed unless one of their expansions
+			// produced a status, such as the final command substitution.
+			if status_change_count_before_expansion
+				== context.shell.last_exit_status_change_count()
+			{
+				context.shell.set_last_exit_status(0);
 			}
 
 			// Return the last exit status we have; in some cases, an expansion

--- a/crates/brush-core-vendored/src/shell.rs
+++ b/crates/brush-core-vendored/src/shell.rs
@@ -61,6 +61,10 @@ pub struct Shell {
 	/// The status of the last completed command.
 	last_exit_status: u8,
 
+	/// Tracks changes to `last_exit_status` so assignment-only commands can
+	/// distinguish status-producing expansions from ordinary assignments.
+	last_exit_status_change_count: usize,
+
 	/// The status of each of the commands in the last pipeline.
 	pub last_pipeline_statuses: Vec<u8>,
 
@@ -128,6 +132,7 @@ impl Clone for Shell {
 			jobs: jobs::JobManager::new(),
 			aliases: self.aliases.clone(),
 			last_exit_status: self.last_exit_status,
+			last_exit_status_change_count: self.last_exit_status_change_count,
 			last_pipeline_statuses: self.last_pipeline_statuses.clone(),
 			positional_parameters: self.positional_parameters.clone(),
 			shell_name: self.shell_name.clone(),
@@ -362,6 +367,7 @@ impl Shell {
 			jobs: jobs::JobManager::new(),
 			aliases: HashMap::default(),
 			last_exit_status: 0,
+			last_exit_status_change_count: 0,
 			last_pipeline_statuses: vec![0],
 			positional_parameters: vec![],
 			shell_name: options.shell_name,
@@ -437,6 +443,10 @@ impl Shell {
 		self.last_exit_status
 	}
 
+	pub(crate) const fn last_exit_status_change_count(&self) -> usize {
+		self.last_exit_status_change_count
+	}
+
 	/// Returns a reference to the current function call stack for the shell.
 	pub const fn function_call_stack(&self) -> &functions::CallStack {
 		&self.function_call_stack
@@ -447,9 +457,11 @@ impl Shell {
 		&self.script_call_stack
 	}
 
-	/// Returns a mutable reference to the last exit status.
-	pub const fn last_exit_status_mut(&mut self) -> &mut u8 {
-		&mut self.last_exit_status
+	/// Updates the last exit status and records that a command or expansion
+	/// produced a new status.
+	pub const fn set_last_exit_status(&mut self, status: u8) {
+		self.last_exit_status = status;
+		self.last_exit_status_change_count += 1;
 	}
 
 	/// Returns the key bindings helper for the shell.
@@ -965,12 +977,14 @@ impl Shell {
 		params.process_group_policy = ProcessGroupPolicy::SameProcessGroup;
 
 		let orig_last_exit_status = self.last_exit_status;
+		let orig_last_exit_status_change_count = self.last_exit_status_change_count;
 		self.traps.handler_depth += 1;
 
 		let result = self.run_string(handler, &params).await;
 
 		self.traps.handler_depth -= 1;
 		self.last_exit_status = orig_last_exit_status;
+		self.last_exit_status_change_count = orig_last_exit_status_change_count;
 
 		result
 	}
@@ -995,7 +1009,7 @@ impl Shell {
 			Err(err) => {
 				let _ = self.display_error(&mut params.stderr(self), &err).await;
 				let exit_code = ExecutionExitCode::from(&err);
-				*self.last_exit_status_mut() = exit_code.into();
+				self.set_last_exit_status(exit_code.into());
 				Ok(exit_code.into())
 			},
 		}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved command exit status while evaluating assignment-only shell commands so canonical captures such as `rc=$?` retain failures ([#2837](https://github.com/f5-sales-demo/xcsh/issues/2837))
+
 ## [20.2.3] - 2026-08-02
 
 ### Fixed

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -120,11 +120,9 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 	const CWD_SENTINEL_END = ":__XCSH_CWD_END__";
 	// Exit-code capture sentinel — the persistent shell's own exit code reflects
 	// the trailing printf (always 0), so the user command's actual exit status
-	// must be captured in-band. `$?` is referenced directly as a printf argument
-	// (see finalCommand below) because a variable-assignment capture like
-	// `_x=$?` resets `$?` to 0 in brush-core before the RHS is evaluated. Without
-	// this sentinel, subprocess failures like `false`, `ls /nonexistent`, or
-	// `(exit 3)` silently report success.
+	// must be captured in-band before another command replaces it. Without this
+	// sentinel, subprocess failures like `false`, `ls /nonexistent`, or `(exit 3)`
+	// silently report success.
 	const EXIT_SENTINEL_START = "__XCSH_EXIT__:";
 	const EXIT_SENTINEL_END = ":__XCSH_EXIT_END__";
 
@@ -167,12 +165,9 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 	}
 
 	// Append CWD + exit-code sentinels only for persistent shell sessions.
-	// `$?` must be referenced DIRECTLY in the printf arguments — using a
-	// variable assignment like `_x=$?` first resets `$?` to 0 in brush-core
-	// before the RHS is evaluated, defeating the capture. The persistent
-	// shell's winner.exitCode always reflects the printf's return (0), so
-	// the EXIT sentinel is the authoritative source for the user command's
-	// actual exit status.
+	// The persistent shell's winner.exitCode reflects the trailing printf's
+	// return (0), so the EXIT sentinel is the authoritative source for the user
+	// command's actual exit status.
 	const finalCommand = shellSession
 		? `${prefixedCommand}\nprintf '${CWD_SENTINEL_START}%s${CWD_SENTINEL_END}\\n${EXIT_SENTINEL_START}%s${EXIT_SENTINEL_END}\\n' "$PWD" "$?"`
 		: prefixedCommand;

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -53,6 +53,45 @@ describe("executeBash", () => {
 		}
 	});
 
+	it("preserves command status while evaluating assignment-only commands", async () => {
+		const result = await executeBash(
+			[
+				'false; printf "direct=%s\\n" "$?"',
+				'if false; then printf "if=wrong\\n"; else printf "if=correct\\n"; fi',
+				'false || printf "or=%s\\n" "$?"',
+				'true; zero=$?; printf "zero=%s\\n" "$zero"',
+				'false; one="$?"; printf "one=%s\\n" "$one"',
+				'(exit 3); three=$?; printf "three=%s\\n" "$three"',
+				'(exit 127); one_twenty_seven="$?"; printf "one-twenty-seven=%s\\n" "$one_twenty_seven"',
+				'true | false; pipeline_status=$?; printf "pipeline=%s\\n" "$pipeline_status"',
+				'capture_status() { (exit 9); function_status=$?; printf "function=%s\\n" "$function_status"; }; capture_status',
+				'for iteration in 1; do (exit 8); for_status=$?; printf "for=%s\\n" "$for_status"; done',
+				'iteration=0; while [ "$iteration" -lt 1 ]; do (exit 7); while_status=$?; printf "while=%s\\n" "$while_status"; iteration=$((iteration + 1)); done',
+				'false; first=$? second=$?; printf "multiple=%s,%s status=%s\\n" "$first" "$second" "$?"',
+				'substitution=$(exit 4) after_substitution=$?; printf "substitution=<%s>,%s status=%s\\n" "$substitution" "$after_substitution" "$?"',
+				"final_substitution=$(exit 37)",
+			].join("\n"),
+			{ cwd: tempDir, timeout: 5000 },
+		);
+
+		expect(result.output.trim().split("\n")).toEqual([
+			"direct=1",
+			"if=correct",
+			"or=1",
+			"zero=0",
+			"one=1",
+			"three=3",
+			"one-twenty-seven=127",
+			"pipeline=1",
+			"function=9",
+			"for=8",
+			"while=7",
+			"multiple=1,1 status=0",
+			"substitution=<>,4 status=4",
+		]);
+		expect(result.exitCode).toBe(37);
+	});
+
 	it("honors cwd", async () => {
 		const result = await executeBash("pwd", { cwd: tempDir, timeout: 5000 });
 		expect(result.output.trim()).toBe(fs.realpathSync(tempDir));


### PR DESCRIPTION
## Summary

- track exit-status changes in the vendored Brush shell instead of exposing untracked mutable status
- preserve the prior status while assignment values expand, then return zero only when no expansion produced a status
- cover direct expansion, quoted and unquoted capture, pipelines, subshells, functions, loops, multiple assignments, and command substitutions

## Root cause

Assignment-only commands set the shared last-exit-status field to zero before expanding their right-hand sides, so canonical captures such as `rc=$?` read that premature zero. The new status generation separates the input status from the assignment command result while preserving Bash command-substitution semantics.

This behavior has been present since Brush was vendored on 2026-02-01; it is not a 20.2.x regression.

## Verification

- `bun run build:native`
- `bun test packages/coding-agent/test/bash-executor.test.ts` (26 passed)
- `bun check`
- `bun run pii:gate`

Closes #2837