### PR TITLE
docs: reword identity-shaped source comments

### DIFF
--- a/packages/coding-agent/src/tools/xcsh-api.ts
+++ b/packages/coding-agent/src/tools/xcsh-api.ts
@@ -679,7 +679,7 @@ export class XcshApiTool implements AgentTool<typeof xcshApiSchema, XcshApiToolD
 			const resolved = isWildcard ? this.#loadListablePaths() : batchPaths;
 			if (resolved.length > 0) {
 				const batchNs = params.params?.namespace ?? this.#contextEnv.get("XCSH_NAMESPACE") ?? "";
-				// Wildcard namespace: batch ALL non-system namespaces in one tool call.
+				// A wildcard batches all non-system namespaces in one tool call.
 				// Reduces multi-namespace queries from N+1 batch calls to 1.
 				if (batchNs === "*") {
 					return this.#executeMultiNamespaceBatch(resolved, apiBase, apiToken, signal);

--- a/packages/office-pane/test/bridge-discovery.test.ts
+++ b/packages/office-pane/test/bridge-discovery.test.ts
@@ -154,7 +154,7 @@ describe("pickBridge()", () => {
 		const b = makeBridge({ port: 19223, tenant: "example-alpha", contextBound: true, lastSeen: 1 });
 		const c = makeBridge({ port: 19224, tenant: "example-beta", contextBound: true, lastSeen: 9999 });
 		const result = pickBridge([a, b, c], { tenant: "example-alpha" });
-		expect(result?.port).toBe(19223); // b: tenant=x + contextBound=true; c excluded
+		expect(result?.port).toBe(19223); // Candidate b matches the tenant and is context-bound; c is excluded.
 	});
 
 	it("(9) null tenant filter includes bridges with null tenant", () => {


### PR DESCRIPTION
Closes #2852

Rewords two source comments so they explain the same behavior without resembling serialized identity fields. Runtime behavior is unchanged.

Verification:
- `bun x biome check packages/coding-agent/src/tools/xcsh-api.ts packages/office-pane/test/bridge-discovery.test.ts`
- `bun --cwd=packages/office-pane test ./test/bridge-discovery.test.ts` (22 passed)