### PR TITLE
chore: bump version to v20.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "containment-check"
-version = "20.2.7"
+version = "20.3.0"
 dependencies = [
  "brush-builtins",
  "brush-core",
@@ -2144,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "pi-natives"
-version = "20.2.7"
+version = "20.3.0"
 dependencies = [
  "arboard",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/brush-core-vendored", "crates/brush-builtins-vendored", "crat
 resolver = "3"
 
 [workspace.package]
-version = "20.2.7"
+version = "20.3.0"
 edition = "2024"
 license = "MIT"
 authors = ["Can Boluk"]

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/agent": {
       "name": "@f5-sales-demo/pi-agent-core",
-      "version": "20.2.7",
+      "version": "20.3.0",
       "dependencies": {
         "@f5-sales-demo/pi-ai": "workspace:*",
         "@f5-sales-demo/pi-utils": "workspace:*",
@@ -28,7 +28,7 @@
     },
     "packages/ai": {
       "name": "@f5-sales-demo/pi-ai",
-      "version": "20.2.7",
+      "version": "20.3.0",
       "bin": {
         "pi-ai": "./src/cli.ts",
       },
@@ -74,7 +74,7 @@
     },
     "packages/coding-agent": {
       "name": "@f5-sales-demo/xcsh",
-      "version": "20.2.7",
+      "version": "20.3.0",
       "bin": {
         "xcsh": "src/cli.ts",
       },
@@ -107,17 +107,17 @@
     },
     "packages/natives": {
       "name": "@f5-sales-demo/pi-natives",
-      "version": "20.2.7",
+      "version": "20.3.0",
       "devDependencies": {
         "@napi-rs/cli": "3.7.4",
         "@types/bun": "^1.3",
       },
       "optionalDependencies": {
-        "@f5-sales-demo/pi-natives-darwin-arm64": "20.2.7",
-        "@f5-sales-demo/pi-natives-darwin-x64": "20.2.7",
-        "@f5-sales-demo/pi-natives-linux-arm64-gnu": "20.2.7",
-        "@f5-sales-demo/pi-natives-linux-x64-gnu": "20.2.7",
-        "@f5-sales-demo/pi-natives-win32-x64-msvc": "20.2.7",
+        "@f5-sales-demo/pi-natives-darwin-arm64": "20.3.0",
+        "@f5-sales-demo/pi-natives-darwin-x64": "20.3.0",
+        "@f5-sales-demo/pi-natives-linux-arm64-gnu": "20.3.0",
+        "@f5-sales-demo/pi-natives-linux-x64-gnu": "20.3.0",
+        "@f5-sales-demo/pi-natives-win32-x64-msvc": "20.3.0",
       },
     },
     "packages/office-pane": {
@@ -144,7 +144,7 @@
     },
     "packages/resource-management": {
       "name": "@f5-sales-demo/pi-resource-management",
-      "version": "20.2.7",
+      "version": "20.3.0",
       "dependencies": {
         "yaml": "2.9.0",
       },
@@ -154,7 +154,7 @@
     },
     "packages/stats": {
       "name": "@f5-sales-demo/xcsh-stats",
-      "version": "20.2.7",
+      "version": "20.3.0",
       "bin": {
         "xcsh-stats": "./src/index.ts",
       },
@@ -179,7 +179,7 @@
     },
     "packages/tui": {
       "name": "@f5-sales-demo/pi-tui",
-      "version": "20.2.7",
+      "version": "20.3.0",
       "dependencies": {
         "@f5-sales-demo/pi-natives": "workspace:*",
         "@f5-sales-demo/pi-utils": "workspace:*",
@@ -218,7 +218,7 @@
     },
     "packages/utils": {
       "name": "@f5-sales-demo/pi-utils",
-      "version": "20.2.7",
+      "version": "20.3.0",
       "dependencies": {
         "@f5-sales-demo/i18n-core": "^1.0.0",
         "beautiful-mermaid": "^1.1",
@@ -370,16 +370,6 @@
     "@f5-sales-demo/pi-ai": ["@f5-sales-demo/pi-ai@workspace:packages/ai"],
 
     "@f5-sales-demo/pi-natives": ["@f5-sales-demo/pi-natives@workspace:packages/natives"],
-
-    "@f5-sales-demo/pi-natives-darwin-arm64": ["@f5-sales-demo/pi-natives-darwin-arm64@20.2.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Seer7fVqZNqW0anY699AZarYGk1859vIDtNQy30pILP5OQg6OjqlzyrED/rfou1bKc/XU1AfLsyIeUL0aba0qA=="],
-
-    "@f5-sales-demo/pi-natives-darwin-x64": ["@f5-sales-demo/pi-natives-darwin-x64@20.2.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-I7ZIQzI9+xAwwSWMsmJzplS1lBGHK5JLrNLe2bPa9QfYrWlQxdlSd+/5hSDGMCJ/ZjyUNCNCQBEL3lpE7VLlqQ=="],
-
-    "@f5-sales-demo/pi-natives-linux-arm64-gnu": ["@f5-sales-demo/pi-natives-linux-arm64-gnu@20.2.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-Dd4LY0SKPjKF5Q4YHHuluD+uNnNYQPsKPclBVyvXBKNXEwBNl/FMBeIDT77HFLw7IX8eGAfOrzT/HxtMcXzCyQ=="],
-
-    "@f5-sales-demo/pi-natives-linux-x64-gnu": ["@f5-sales-demo/pi-natives-linux-x64-gnu@20.2.7", "", { "os": "linux", "cpu": "x64" }, "sha512-exMr3/fAsV5yG/x7pMO5Yy94ytBTBQYyIxSWbQDlnrltDCzyg5udQ5XV/MC3ECPRFKpr1m+yyqux9BF+8EzVgw=="],
-
-    "@f5-sales-demo/pi-natives-win32-x64-msvc": ["@f5-sales-demo/pi-natives-win32-x64-msvc@20.2.7", "", { "os": "win32", "cpu": "x64" }, "sha512-A8/Bru4PnnlwofwuSpbyy7mIRXC6XkjFvzEH2oFwLs/dcEG6k38+H6IQEzC/Q2PN6gRrmSNgtLXEk3KGj6fDVw=="],
 
     "@f5-sales-demo/pi-resource-management": ["@f5-sales-demo/pi-resource-management@workspace:packages/resource-management"],
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 
-## [Unreleased]
+## [20.3.0] - 2026-08-04
 
 ### Fixed
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-agent-core",
-	"version": "20.2.7",
+	"version": "20.3.0",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 
-## [Unreleased]
+## [20.3.0] - 2026-08-04
 
 ### Changed
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-ai",
-	"version": "20.2.7",
+	"version": "20.3.0",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 
-## [Unreleased]
+## [20.3.0] - 2026-08-04
 
 ### Added
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/xcsh",
-	"version": "20.2.7",
+	"version": "20.3.0",
 	"description": "Coding agent CLI with read, bash, edit, write tools and session management",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 
-## [Unreleased]
+## [20.3.0] - 2026-08-04
 
 ### Fixed
 

--- a/packages/natives/npm/darwin-arm64/package.json
+++ b/packages/natives/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-darwin-arm64",
-	"version": "20.2.7",
+	"version": "20.3.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (macOS arm64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/darwin-x64/package.json
+++ b/packages/natives/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-darwin-x64",
-	"version": "20.2.7",
+	"version": "20.3.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (macOS x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-arm64-gnu/package.json
+++ b/packages/natives/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-linux-arm64-gnu",
-	"version": "20.2.7",
+	"version": "20.3.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Linux arm64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/linux-x64-gnu/package.json
+++ b/packages/natives/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-linux-x64-gnu",
-	"version": "20.2.7",
+	"version": "20.3.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Linux x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/npm/win32-x64-msvc/package.json
+++ b/packages/natives/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives-win32-x64-msvc",
-	"version": "20.2.7",
+	"version": "20.3.0",
 	"description": "Native addon for @f5-sales-demo/pi-natives (Windows x64)",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@f5-sales-demo/pi-natives",
-	"version": "20.2.7",
+	"version": "20.3.0",
 	"description": "Native Rust bindings for grep, clipboard, image processing, syntax highlighting, PTY, and shell operations via N-API",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",
@@ -56,11 +56,11 @@
 		}
 	},
 	"optionalDependencies": {
-		"@f5-sales-demo/pi-natives-linux-x64-gnu": "20.2.7",
-		"@f5-sales-demo/pi-natives-linux-arm64-gnu": "20.2.7",
-		"@f5-sales-demo/pi-natives-darwin-x64": "20.2.7",
-		"@f5-sales-demo/pi-natives-darwin-arm64": "20.2.7",
-		"@f5-sales-demo/pi-natives-win32-x64-msvc": "20.2.7"
+		"@f5-sales-demo/pi-natives-linux-x64-gnu": "20.3.0",
+		"@f5-sales-demo/pi-natives-linux-arm64-gnu": "20.3.0",
+		"@f5-sales-demo/pi-natives-darwin-x64": "20.3.0",
+		"@f5-sales-demo/pi-natives-darwin-arm64": "20.3.0",
+		"@f5-sales-demo/pi-natives-win32-x64-msvc": "20.3.0"
 	},
 	"files": [
 		"native",

--- a/packages/resource-management/package.json
+++ b/packages/resource-management/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-resource-management",
-	"version": "20.2.7",
+	"version": "20.3.0",
 	"description": "Shared resource management for F5 XC manifest parsing, validation, diff, and CRUD operations",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Robin Mordasiewicz",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/xcsh-stats",
-	"version": "20.2.7",
+	"version": "20.3.0",
 	"description": "Local observability dashboard for pi AI usage statistics",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 
-## [Unreleased]
+## [20.3.0] - 2026-08-04
 
 <!-- textlint-disable terminology -->
 

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-tui",
-	"version": "20.2.7",
+	"version": "20.3.0",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Changelog
 
-## [Unreleased]
+## [20.3.0] - 2026-08-04
 
 ### Added
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@f5-sales-demo/pi-utils",
-	"version": "20.2.7",
+	"version": "20.3.0",
 	"description": "Shared utilities for pi packages",
 	"homepage": "https://github.com/f5-sales-demo/xcsh",
 	"author": "Can Boluk",


### PR DESCRIPTION
Automated release PR generated by `scripts/release.ts`.

Bumps every public package and the Cargo workspace to `v20.3.0` and updates CHANGELOGs for the releasable commits since the last tag.

Once this PR squash-merges to `main`, `.github/workflows/tag-on-version-bump.yml` pushes the `v20.3.0` git tag, which triggers the downstream release chain (build → sign → publish).

### Releasable commits (1)

- feat(ai): add Gemini Vertex benchmark matrix (#2875)

See `docs-control`'s onboarding note "Release automation: release PR pattern" for the governance rationale.