### PR TITLE
fix(release): accept staged native packages before publish

### DIFF
--- a/packages/coding-agent/test/scripts/dependency-install-state.test.ts
+++ b/packages/coding-agent/test/scripts/dependency-install-state.test.ts
@@ -117,11 +117,60 @@ describe("installed dependency state", () => {
 			await fs.rm(root, { recursive: true, force: true });
 		}
 	});
+
+	it("accepts only matching in-repo prepublication optional package versions", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-dependency-install-"));
+		const prepublicationLock: BunLockFile = {
+			workspaces: {
+				"packages/natives": {
+					optionalDependencies: {
+						"@f5-sales-demo/pi-natives-darwin-arm64": "20.3.0",
+						"@f5-sales-demo/pi-natives-darwin-x64": "20.3.0",
+						"@f5-sales-demo/pi-natives-linux-x64-gnu": "20.3.0",
+					},
+				},
+			},
+			packages: {},
+		};
+		try {
+			await writePackageVersion(root, "darwin-arm64", "@f5-sales-demo/pi-natives-darwin-arm64", "20.3.0");
+			await writePackageVersion(root, "darwin-x64", "@f5-sales-demo/pi-natives-darwin-x64", "20.3.0");
+			await writePackageVersion(root, "linux-x64-gnu", "@f5-sales-demo/pi-natives-linux-x64-gnu", "20.2.7");
+			await writeInstalledVersion(root, "packages/natives", "@f5-sales-demo/pi-natives-darwin-arm64", "20.3.0");
+			await writeInstalledVersion(root, "packages/natives", "@f5-sales-demo/pi-natives-darwin-x64", "20.2.7");
+
+			expect(await inspectDependencyInstall(root, prepublicationLock)).toEqual([
+				{
+					workspace: "packages/natives",
+					name: "@f5-sales-demo/pi-natives-darwin-x64",
+					requested: "20.3.0",
+					lockedVersions: [],
+					installedVersion: "20.2.7",
+				},
+				{
+					workspace: "packages/natives",
+					name: "@f5-sales-demo/pi-natives-linux-x64-gnu",
+					requested: "20.3.0",
+					lockedVersions: [],
+					installedVersion: undefined,
+				},
+			]);
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
 });
 
 async function writeInstalledVersion(root: string, workspace: string, name: string, version: string): Promise<void> {
 	await Bun.write(
 		path.join(root, workspace, "node_modules", ...name.split("/"), "package.json"),
 		JSON.stringify({ version }),
+	);
+}
+
+async function writePackageVersion(root: string, directory: string, name: string, version: string): Promise<void> {
+	await Bun.write(
+		path.join(root, "packages/natives/npm", directory, "package.json"),
+		JSON.stringify({ name, version }),
 	);
 }

--- a/scripts/check-installed-dependencies.ts
+++ b/scripts/check-installed-dependencies.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { $ } from "bun";
+import { $, Glob } from "bun";
 import * as path from "node:path";
 
 type LockWorkspace = {
@@ -25,6 +25,7 @@ export type DependencyInstallMismatch = {
 };
 
 const repoRoot = path.join(import.meta.dir, "..");
+const prepublicationPackageJsonGlob = new Glob("packages/natives/npm/*/package.json");
 
 if (import.meta.main) {
 	const repair = process.argv.includes("--repair");
@@ -86,6 +87,7 @@ export async function inspectDependencyInstall(
 	lock: BunLockFile,
 ): Promise<DependencyInstallMismatch[]> {
 	const lockedVersions = indexLockedVersions(lock.packages);
+	const prepublicationVersions = await indexPrepublicationPackageVersions(root);
 	const mismatches: DependencyInstallMismatch[] = [];
 
 	for (const [workspace, config] of Object.entries(lock.workspaces).sort(([left], [right]) =>
@@ -107,6 +109,21 @@ export async function inspectDependencyInstall(
 			);
 			const installedVersion = await readInstalledVersion(root, workspace, name);
 			if (!required && installedVersion === undefined && candidates.length > 0) continue;
+			// A release branch bumps these optional package manifests before publishing
+			// them, so a registry lock entry cannot exist yet. Accept only an optional
+			// dependency backed by a satisfying in-repo package version and either no
+			// installed link or that exact staged version; stale installed links and
+			// mismatched manifests must still fail this check.
+			const prepublicationVersion = prepublicationVersions.get(name);
+			if (
+				!required &&
+				candidates.length === 0 &&
+				prepublicationVersion !== undefined &&
+				Bun.semver.satisfies(prepublicationVersion, requested) &&
+				(installedVersion === undefined || installedVersion === prepublicationVersion)
+			) {
+				continue;
+			}
 			if (installedVersion === undefined || !candidates.includes(installedVersion)) {
 				mismatches.push({
 					workspace,
@@ -120,6 +137,20 @@ export async function inspectDependencyInstall(
 	}
 
 	return mismatches;
+}
+
+async function indexPrepublicationPackageVersions(root: string): Promise<Map<string, string>> {
+	const versions = new Map<string, string>();
+	for await (const manifestPath of prepublicationPackageJsonGlob.scan({ cwd: root, onlyFiles: true })) {
+		const manifest = (await Bun.file(path.join(root, manifestPath)).json()) as {
+			name?: unknown;
+			version?: unknown;
+		};
+		if (typeof manifest.name === "string" && typeof manifest.version === "string") {
+			versions.set(manifest.name, manifest.version);
+		}
+	}
+	return versions;
 }
 
 export function formatDependencyInstallMismatches(mismatches: DependencyInstallMismatch[]): string {


### PR DESCRIPTION
## Summary

Allow the dependency verifier to recognize the five in-repository platform-native package manifests during the pre-publication release window, when their bumped version cannot yet exist in npm or bun.lock.

Closes #2898

## Safety

- The bypass applies only to optional dependencies with no satisfying registry lock candidate.
- The staged manifest name/version must satisfy the requested version.
- An installed package must be absent or exactly match the staged manifest version.
- Stale installed links and mismatched staged manifests continue to fail.

## Verification

- Red/green regression reproduced the installed-matching-package false failure and then passed after the exact-version fix.
- bun run check:ts: pass.
- 130 release-script tests: pass.
- Exact overlay on release/v20.3.0: bun install --frozen-lockfile and bun run ensure:dependencies pass before package publication.
- Antigravity pre-push review: no findings; PII enforce clean.
- Verified-review: one high finding confirmed and fixed with red/green evidence; repeat review zero findings; deterministic gate done with no escalation.