### PR TITLE
fix(ai): honor enterprise project during Antigravity OAuth

### DIFF
--- a/packages/ai/src/utils/oauth/google-antigravity.ts
+++ b/packages/ai/src/utils/oauth/google-antigravity.ts
@@ -2,6 +2,7 @@
  * Antigravity OAuth flow (Gemini 3, Claude, GPT-OSS via Google Cloud)
  * Uses different OAuth credentials than google-gemini-cli for access to additional models.
  */
+import { $env } from "@f5-sales-demo/pi-utils";
 import { getAntigravityAuthHeaders } from "../../providers/google-gemini-cli";
 import { OAuthCallbackFlow } from "./callback-server";
 import type { OAuthController, OAuthCredentials } from "./types";
@@ -48,6 +49,24 @@ export const ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA = Object.freeze({
 	pluginType: "GEMINI",
 });
 
+interface AntigravityProjectRequest {
+	cloudaicompanionProject?: string;
+	metadata: typeof ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA & { duetProject?: string };
+}
+
+function buildProjectRequest(configuredProjectId: string | undefined): AntigravityProjectRequest {
+	if (!configuredProjectId) {
+		return { metadata: ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA };
+	}
+	return {
+		cloudaicompanionProject: configuredProjectId,
+		metadata: {
+			...ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA,
+			duetProject: configuredProjectId,
+		},
+	};
+}
+
 function readProjectId(value: string | { id?: string } | undefined): string | undefined {
 	if (typeof value === "string" && value.length > 0) {
 		return value;
@@ -72,7 +91,7 @@ function getDefaultTierId(allowedTiers?: Array<{ id?: string; isDefault?: boolea
 async function onboardProjectWithRetries(
 	endpoint: string,
 	headers: Record<string, string>,
-	onboardBody: { tierId: string; metadata: typeof ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA },
+	onboardBody: { tierId: string } & AntigravityProjectRequest,
 	onProgress?: (message: string) => void,
 ): Promise<string> {
 	for (let attempt = 1; attempt <= PROJECT_ONBOARD_MAX_ATTEMPTS; attempt += 1) {
@@ -109,6 +128,8 @@ async function onboardProjectWithRetries(
 }
 
 async function discoverProject(accessToken: string, onProgress?: (message: string) => void): Promise<string> {
+	const configuredProjectId = $env.GOOGLE_CLOUD_PROJECT || $env.GOOGLE_CLOUD_PROJECT_ID;
+	const projectRequest = buildProjectRequest(configuredProjectId);
 	const headers = {
 		Authorization: `Bearer ${accessToken}`,
 		"Content-Type": "application/json",
@@ -121,9 +142,7 @@ async function discoverProject(accessToken: string, onProgress?: (message: strin
 		const loadResponse = await fetch(`${endpoint}/v1internal:loadCodeAssist`, {
 			method: "POST",
 			headers,
-			body: JSON.stringify({
-				metadata: ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA,
-			}),
+			body: JSON.stringify(projectRequest),
 		});
 
 		if (!loadResponse.ok) {
@@ -134,17 +153,17 @@ async function discoverProject(accessToken: string, onProgress?: (message: strin
 		const loadPayload = (await loadResponse.json()) as LoadCodeAssistPayload;
 		const existingProject = readProjectId(loadPayload.cloudaicompanionProject);
 		if (existingProject) {
-			return existingProject;
+			return configuredProjectId ?? existingProject;
 		}
 
 		const tierId = getDefaultTierId(loadPayload.allowedTiers);
 		onProgress?.("Provisioning project...");
 		const onboardBody = {
 			tierId,
-			metadata: ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA,
+			...projectRequest,
 		};
 		const provisionedProject = await onboardProjectWithRetries(endpoint, headers, onboardBody, onProgress);
-		return provisionedProject;
+		return configuredProjectId ?? provisionedProject;
 	} catch (error) {
 		throw new Error(
 			`Could not discover or provision an Antigravity project. ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/ai/test/google-antigravity-auth.test.ts
+++ b/packages/ai/test/google-antigravity-auth.test.ts
@@ -1,7 +1,79 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { getBundledModel } from "../src/models";
 import { getAntigravityAuthHeaders } from "../src/providers/google-gemini-cli";
-import { ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA } from "../src/utils/oauth/google-antigravity";
+import { ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA, loginAntigravity } from "../src/utils/oauth/google-antigravity";
+
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const USER_INFO_URL = "https://www.googleapis.com/oauth2/v1/userinfo?alt=json";
+const LOAD_CODE_ASSIST_URL = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist";
+const ONBOARD_USER_URL = "https://cloudcode-pa.googleapis.com/v1internal:onboardUser";
+const originalFetch = global.fetch;
+
+interface RecordedRequest {
+	url: string;
+	body: Record<string, unknown>;
+}
+
+function jsonResponse(payload: unknown): Response {
+	return new Response(JSON.stringify(payload), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+async function withProjectEnvironment(
+	primaryProject: string | undefined,
+	fallbackProject: string | undefined,
+	run: () => Promise<void>,
+): Promise<void> {
+	const originalPrimaryProject = Bun.env.GOOGLE_CLOUD_PROJECT;
+	const originalFallbackProject = Bun.env.GOOGLE_CLOUD_PROJECT_ID;
+	try {
+		if (primaryProject === undefined) delete Bun.env.GOOGLE_CLOUD_PROJECT;
+		else Bun.env.GOOGLE_CLOUD_PROJECT = primaryProject;
+		if (fallbackProject === undefined) delete Bun.env.GOOGLE_CLOUD_PROJECT_ID;
+		else Bun.env.GOOGLE_CLOUD_PROJECT_ID = fallbackProject;
+		await run();
+	} finally {
+		if (originalPrimaryProject === undefined) delete Bun.env.GOOGLE_CLOUD_PROJECT;
+		else Bun.env.GOOGLE_CLOUD_PROJECT = originalPrimaryProject;
+		if (originalFallbackProject === undefined) delete Bun.env.GOOGLE_CLOUD_PROJECT_ID;
+		else Bun.env.GOOGLE_CLOUD_PROJECT_ID = originalFallbackProject;
+	}
+}
+
+async function runLogin(
+	loadPayload: unknown,
+	onboardPayload?: unknown,
+): Promise<{ projectId: string | undefined; requests: RecordedRequest[] }> {
+	const requests: RecordedRequest[] = [];
+	global.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+		const url = input instanceof Request ? input.url : input.toString();
+		if (url === TOKEN_URL) {
+			return jsonResponse({ access_token: "access-token", refresh_token: "refresh-token", expires_in: 3600 });
+		}
+		if (url === USER_INFO_URL) {
+			return jsonResponse({ email: "developer@example.com" });
+		}
+		if (url === LOAD_CODE_ASSIST_URL || url === ONBOARD_USER_URL) {
+			const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			requests.push({ url, body });
+			if (url === LOAD_CODE_ASSIST_URL) return jsonResponse(loadPayload);
+			if (onboardPayload !== undefined) return jsonResponse(onboardPayload);
+		}
+		throw new Error(`Unexpected URL: ${url}`);
+	}) as unknown as typeof fetch;
+
+	const credentials = await loginAntigravity({
+		onManualCodeInput: async () => "authorization-code",
+	});
+	return { projectId: credentials.projectId, requests };
+}
+
+afterEach(() => {
+	global.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
 
 describe("Google Antigravity auth alignment", () => {
 	it("uses ANTIGRAVITY ideType in loadCodeAssist metadata payload", () => {
@@ -32,6 +104,116 @@ describe("Google Antigravity auth alignment", () => {
 				minLevel: "minimal",
 				maxLevel: "high",
 			},
+		});
+	});
+
+	it("prefers GOOGLE_CLOUD_PROJECT and retains it when discovery returns another project", async () => {
+		await withProjectEnvironment("primary-enterprise-project", "fallback-enterprise-project", async () => {
+			const { projectId, requests } = await runLogin({
+				cloudaicompanionProject: { id: "generated-free-tier-project" },
+			});
+
+			expect(projectId).toBe("primary-enterprise-project");
+			expect(requests).toEqual([
+				{
+					url: LOAD_CODE_ASSIST_URL,
+					body: {
+						cloudaicompanionProject: "primary-enterprise-project",
+						metadata: {
+							...ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA,
+							duetProject: "primary-enterprise-project",
+						},
+					},
+				},
+			]);
+		});
+	});
+
+	it("uses GOOGLE_CLOUD_PROJECT_ID when the primary project variable is absent", async () => {
+		await withProjectEnvironment(undefined, "fallback-enterprise-project", async () => {
+			const { projectId, requests } = await runLogin({
+				cloudaicompanionProject: "generated-free-tier-project",
+			});
+
+			expect(projectId).toBe("fallback-enterprise-project");
+			expect(requests[0]).toEqual({
+				url: LOAD_CODE_ASSIST_URL,
+				body: {
+					cloudaicompanionProject: "fallback-enterprise-project",
+					metadata: {
+						...ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA,
+						duetProject: "fallback-enterprise-project",
+					},
+				},
+			});
+		});
+	});
+
+	it("includes the configured enterprise project when onboarding is required", async () => {
+		await withProjectEnvironment("primary-enterprise-project", undefined, async () => {
+			const { projectId, requests } = await runLogin(
+				{
+					allowedTiers: [{ id: "standard-tier", isDefault: true }],
+				},
+				{
+					done: true,
+					response: { cloudaicompanionProject: { id: "generated-free-tier-project" } },
+				},
+			);
+
+			expect(projectId).toBe("primary-enterprise-project");
+			expect(requests).toEqual([
+				{
+					url: LOAD_CODE_ASSIST_URL,
+					body: {
+						cloudaicompanionProject: "primary-enterprise-project",
+						metadata: {
+							...ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA,
+							duetProject: "primary-enterprise-project",
+						},
+					},
+				},
+				{
+					url: ONBOARD_USER_URL,
+					body: {
+						tierId: "standard-tier",
+						cloudaicompanionProject: "primary-enterprise-project",
+						metadata: {
+							...ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA,
+							duetProject: "primary-enterprise-project",
+						},
+					},
+				},
+			]);
+		});
+	});
+
+	it("preserves automatic project onboarding when no project variable is configured", async () => {
+		await withProjectEnvironment(undefined, undefined, async () => {
+			const { projectId, requests } = await runLogin(
+				{
+					allowedTiers: [{ id: "free-tier", isDefault: true }],
+				},
+				{
+					done: true,
+					response: { cloudaicompanionProject: "generated-free-tier-project" },
+				},
+			);
+
+			expect(projectId).toBe("generated-free-tier-project");
+			expect(requests).toEqual([
+				{
+					url: LOAD_CODE_ASSIST_URL,
+					body: { metadata: ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA },
+				},
+				{
+					url: ONBOARD_USER_URL,
+					body: {
+						tierId: "free-tier",
+						metadata: ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA,
+					},
+				},
+			]);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Honor the established Google Cloud project overrides during Antigravity OAuth so enterprise users retain their entitled project instead of being bound to an automatically provisioned free-tier project.

## Related Issue

Closes #2906

## Changes

- Prefer GOOGLE_CLOUD_PROJECT, with GOOGLE_CLOUD_PROJECT_ID as fallback.
- Include the configured project in loadCodeAssist and onboarding payloads, including metadata.duetProject.
- Retain the configured enterprise project in saved credentials while preserving automatic discovery when no override is set.
- Add focused tests for precedence, fallback, onboarding, and no-override behavior.

## Verification evidence

- TDD red: focused suite had 4 passing tests and the 3 new enterprise cases failing before implementation.
- Focused green: 7 pass, 0 fail.
- AI package: 648 pass, 455 skip, 0 fail.
- Governed full suite: main workspace 6,359 pass, 559 skip, 0 fail; all workspace test commands exited 0.
- bun run check: exit 0.
- bun run build: exit 0.
- git diff --check: exit 0.
- Antigravity pre-push review: PII enforce clean; 0 blocking, 0 medium, 0 nit findings.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
