### PR TITLE
ci: align stable Rust formatting with Rust 2024 linting

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,9 @@ jobs:
   lint:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@7a9e56e38268119eb55947c09b4b0749e424f697
+    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@d75d315e83d9947b658f8e86b21654512fd437f6
+    with:
+      rust_edition: "2024"
     permissions:
       contents: read # checkout repository content in the reusable workflow
       packages: read # pull lint tooling from GitHub Packages

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@d75d315e83d9947b658f8e86b21654512fd437f6
+    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@a334c5f84fb36d486209be1e331b11c99d05830c
     with:
       rust_edition: "2024"
     permissions:

--- a/crates/brush-builtins-vendored/src/cd.rs
+++ b/crates/brush-builtins-vendored/src/cd.rs
@@ -81,7 +81,9 @@ impl builtins::Command for CdCommand {
 			target_dir = context.shell.absolute_path(target_dir).canonicalize()?;
 		}
 
-		context.shell.change_working_dir(&target_dir, &context.params)?;
+		context
+			.shell
+			.change_working_dir(&target_dir, &context.params)?;
 
 		// Bash compatibility
 		// https://www.gnu.org/software/bash/manual/bash.html#index-cd

--- a/crates/brush-core-vendored/src/commands.rs
+++ b/crates/brush-core-vendored/src/commands.rs
@@ -160,7 +160,11 @@ pub fn compose_std_command<S: AsRef<OsStr>>(
 	// it, so a fenced command cannot present a custom argv[0] (as a login shell's `-bash` would).
 	// Nothing in this agent's use depends on that, and the alternative is no confinement at all.
 	#[cfg(target_os = "macos")]
-	let sandboxed = context.params.containment.as_ref().map(|fence| fence.to_seatbelt_profile());
+	let sandboxed = context
+		.params
+		.containment
+		.as_ref()
+		.map(|fence| fence.to_seatbelt_profile());
 	#[cfg(target_os = "macos")]
 	let mut cmd = match sandboxed.as_deref() {
 		Some(profile) => {

--- a/crates/brush-core-vendored/src/containment.rs
+++ b/crates/brush-core-vendored/src/containment.rs
@@ -29,7 +29,7 @@ use std::path::{Component, Path, PathBuf};
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FileIdentity {
 	device: u64,
-	inode:  u64,
+	inode: u64,
 }
 
 impl FileIdentity {
@@ -39,7 +39,10 @@ impl FileIdentity {
 	/// to be created. The caller distinguishes the two, and must not read `None` as "unchanged".
 	#[must_use]
 	pub fn of_path(path: &Path) -> Option<Self> {
-		std::fs::metadata(path).ok().as_ref().map(Self::from_metadata)
+		std::fs::metadata(path)
+			.ok()
+			.as_ref()
+			.map(Self::from_metadata)
 	}
 
 	/// The identity of the object an open handle refers to.
@@ -66,7 +69,7 @@ impl FileIdentity {
 		use std::os::windows::fs::MetadataExt;
 		Self {
 			device: metadata.volume_serial_number().unwrap_or(0).into(),
-			inode:  metadata.file_index().unwrap_or(0),
+			inode: metadata.file_index().unwrap_or(0),
 		}
 	}
 }
@@ -130,7 +133,10 @@ pub struct ContainmentFence {
 
 /// How specific a matching root is. Deeper wins, so a nested rule beats the root it sits inside.
 fn depth(root: &Path) -> usize {
-	root.components().filter(|c| matches!(c, Component::Normal(_))).count()
+	root
+		.components()
+		.filter(|c| matches!(c, Component::Normal(_)))
+		.count()
 }
 
 /// The deepest root in `roots` that contains `candidate`, with its depth.
@@ -210,7 +216,8 @@ impl ContainmentFence {
 			return true;
 		}
 
-		if access == FenceAccess::Enumerate && self.deny_enumerate.iter().any(|root| root == resolved) {
+		if access == FenceAccess::Enumerate && self.deny_enumerate.iter().any(|root| root == resolved)
+		{
 			return false;
 		}
 
@@ -273,7 +280,7 @@ impl DirLister for RealFs {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct GrantRights {
 	/// Files in the subtree may be read.
-	pub read:  bool,
+	pub read: bool,
 	/// The subtree may be written.
 	pub write: bool,
 	/// Directories in the subtree may be enumerated.
@@ -337,7 +344,7 @@ impl Node {
 #[derive(Clone, Debug, Default)]
 pub struct GrantPlan {
 	/// Subtrees to grant, and in which directions.
-	pub grants:       Vec<(PathBuf, GrantRights)>,
+	pub grants: Vec<(PathBuf, GrantRights)>,
 	/// Directories that lost a right on their own inode because their children are not uniform.
 	///
 	/// A Landlock rule always covers a whole subtree, so a directory holding both granted and denied
@@ -345,7 +352,7 @@ pub struct GrantPlan {
 	/// loses that right: `ls` of it fails, and a file created directly in it afterwards is unreachable.
 	/// Reported rather than hidden, because the caller must refuse to claim OS enforcement when the
 	/// session's own workspace lands here.
-	pub split_dirs:   Vec<PathBuf>,
+	pub split_dirs: Vec<PathBuf>,
 	/// Directories that had to be enumerated but could not be, so nothing under them was granted.
 	pub unenumerable: Vec<PathBuf>,
 }
@@ -537,7 +544,8 @@ fn walk_for_access(
 /// command fail with "Operation not permitted" and no usable explanation. SBPL accepts `\n` in a
 /// string literal — verified — so the escape both parses and keeps the rule meaningful.
 fn escape_for_profile(path: &Path) -> String {
-	path.to_string_lossy()
+	path
+		.to_string_lossy()
 		.replace('\\', "\\\\")
 		.replace('"', "\\\"")
 		.replace('\n', "\\n")
@@ -608,7 +616,7 @@ impl ContainmentFence {
 				// denied — so a sibling's name is still not discoverable, only that the parent exists.
 				Rule::Metadata(root) => profile.push_str(&format!(
 					"(allow file-read-metadata (subpath \"{}\"))\n",
-					 escape_for_profile(root)
+					escape_for_profile(root)
 				)),
 				// A literal `file-read-data` denial prevents `readdir` on this directory but does not
 				// cover a named child. Traversal, metadata, and reads below a known child stay allowed.
@@ -634,5 +642,4 @@ impl ContainmentFence {
 		}
 		profile
 	}
-
 }

--- a/crates/brush-core-vendored/src/expansion.rs
+++ b/crates/brush-core-vendored/src/expansion.rs
@@ -645,7 +645,9 @@ impl<'a> WordExpander<'a> {
 			Some(fence) => pattern
 				.expand(
 					self.shell.working_dir(),
-					Some(&|path: &std::path::Path| fence.permits(path, crate::containment::FenceAccess::Read)),
+					Some(&|path: &std::path::Path| {
+						fence.permits(path, crate::containment::FenceAccess::Read)
+					}),
 					Some(&|path: &std::path::Path| {
 						fence.permits(path, crate::containment::FenceAccess::Enumerate)
 					}),

--- a/crates/brush-core-vendored/src/interp.rs
+++ b/crates/brush-core-vendored/src/interp.rs
@@ -1060,8 +1060,7 @@ impl ExecuteInPipeline for ast::SimpleCommand {
 		let mut assignments = vec![];
 		let mut args: Vec<CommandArg> = vec![];
 		let mut command_takes_assignments = false;
-		let status_change_count_before_expansion =
-			context.shell.last_exit_status_change_count();
+		let status_change_count_before_expansion = context.shell.last_exit_status_change_count();
 
 		for item in prefix_iter.chain(cmd_name_items.iter()).chain(suffix_iter) {
 			ensure_not_cancelled(&params)?;
@@ -1179,9 +1178,7 @@ impl ExecuteInPipeline for ast::SimpleCommand {
 
 			// Assignment-only commands succeed unless one of their expansions
 			// produced a status, such as the final command substitution.
-			if status_change_count_before_expansion
-				== context.shell.last_exit_status_change_count()
-			{
+			if status_change_count_before_expansion == context.shell.last_exit_status_change_count() {
 				context.shell.set_last_exit_status(0);
 			}
 
@@ -1504,7 +1501,12 @@ pub(crate) async fn setup_redirect(
 				.append(*append);
 
 			let stdout_file = shell
-				.open_file(&file_options, &expanded_file_path, params, crate::containment::FenceAccess::Write)
+				.open_file(
+					&file_options,
+					&expanded_file_path,
+					params,
+					crate::containment::FenceAccess::Write,
+				)
 				.map_err(|err| {
 					error::ErrorKind::RedirectionFailure(
 						expanded_file_path.to_string_lossy().to_string(),

--- a/crates/brush-core-vendored/src/shell.rs
+++ b/crates/brush-core-vendored/src/shell.rs
@@ -408,9 +408,12 @@ impl Shell {
 				let mut options = std::fs::File::options();
 				options.read(true);
 
-				if let Ok(history_file) =
-					shell.open_file(&options, history_path, &shell.default_exec_params(), crate::containment::FenceAccess::Read)
-				{
+				if let Ok(history_file) = shell.open_file(
+					&options,
+					history_path,
+					&shell.default_exec_params(),
+					crate::containment::FenceAccess::Read,
+				) {
 					shell.history = Some(history::History::import(history_file)?);
 				}
 			}
@@ -1439,7 +1442,9 @@ impl Shell {
 				));
 			}
 			let cleared = crate::containment::FileIdentity::of_path(&resolved);
-			let cleared_parent = resolved.parent().and_then(crate::containment::FileIdentity::of_path);
+			let cleared_parent = resolved
+				.parent()
+				.and_then(crate::containment::FileIdentity::of_path);
 			let opened = options.open(&resolved)?;
 			// Ask the kernel what was actually opened and check *that* against the fence. Re-walking
 			// the path cannot settle it: a swap landing before the pre-open stat makes the stat and the
@@ -1453,10 +1458,15 @@ impl Shell {
 				// created, so its directory had to be there and hold still. Weaker, and the reason the
 				// fd check is preferred wherever it exists.
 				None => match cleared {
-					Some(cleared) => crate::containment::FileIdentity::of_handle(&opened) != Some(cleared),
+					Some(cleared) => {
+						crate::containment::FileIdentity::of_handle(&opened) != Some(cleared)
+					},
 					None => {
 						cleared_parent.is_none()
-							|| resolved.parent().and_then(crate::containment::FileIdentity::of_path) != cleared_parent
+							|| resolved
+								.parent()
+								.and_then(crate::containment::FileIdentity::of_path)
+								!= cleared_parent
 					},
 				},
 			};
@@ -1504,9 +1514,11 @@ impl Shell {
 			// resolved path: checking `target_dir` and then storing `target_dir` lets a symlink change
 			// underneath between the two, leaving the shell standing somewhere it was never cleared for
 			// — and every later relative path would resolve from there.
-			let destination = crate::containment::canonicalize_for_fence(&self.absolute_path(target_dir.as_ref()));
+			let destination =
+				crate::containment::canonicalize_for_fence(&self.absolute_path(target_dir.as_ref()));
 			let readable = fence.permits_resolved(&destination, crate::containment::FenceAccess::Read);
-			let writable = fence.permits_resolved(&destination, crate::containment::FenceAccess::Write);
+			let writable =
+				fence.permits_resolved(&destination, crate::containment::FenceAccess::Write);
 			if !readable || !writable {
 				return Err(error::ErrorKind::OutsideBoundary(destination).into());
 			}

--- a/crates/brush-core-vendored/src/sys/unix/landlock.rs
+++ b/crates/brush-core-vendored/src/sys/unix/landlock.rs
@@ -94,7 +94,7 @@ struct RulesetAttr {
 #[repr(C, packed)]
 struct PathBeneathAttr {
 	allowed_access: u64,
-	parent_fd:      i32,
+	parent_fd: i32,
 }
 
 /// Why Landlock cannot be used on this machine.
@@ -271,7 +271,7 @@ fn components_are_link_free(path: &Path) -> Option<bool> {
 					// not something to attempt.
 					return Some(false);
 				}
-			}
+			},
 			// Absent from here down, which is the ordinary case for the tail being created.
 			Err(error) if error.kind() == io::ErrorKind::NotFound => return Some(true),
 			Err(_) => return None,

--- a/crates/containment-check/src/main.rs
+++ b/crates/containment-check/src/main.rs
@@ -23,25 +23,25 @@ use clap::{Parser, Subcommand};
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct FenceJson {
 	#[serde(default)]
-	allow:            Vec<PathBuf>,
+	allow: Vec<PathBuf>,
 	#[serde(default)]
-	allow_read_only:  Vec<PathBuf>,
+	allow_read_only: Vec<PathBuf>,
 	#[serde(default)]
 	allow_write_only: Vec<PathBuf>,
 	#[serde(default)]
-	deny:             Vec<PathBuf>,
+	deny: Vec<PathBuf>,
 	#[serde(default)]
-	deny_enumerate:   Vec<PathBuf>,
+	deny_enumerate: Vec<PathBuf>,
 }
 
 impl From<FenceJson> for ContainmentFence {
 	fn from(json: FenceJson) -> Self {
 		Self {
-			allow:            json.allow,
-			allow_read_only:  json.allow_read_only,
+			allow: json.allow,
+			allow_read_only: json.allow_read_only,
 			allow_write_only: json.allow_write_only,
-			deny:             json.deny,
-			deny_enumerate:   json.deny_enumerate,
+			deny: json.deny,
+			deny_enumerate: json.deny_enumerate,
 		}
 	}
 }
@@ -75,10 +75,10 @@ enum Command {
 	Run {
 		/// The fence, as JSON. Omit to run unfenced — the control case.
 		#[arg(long)]
-		fence:   Option<String>,
+		fence: Option<String>,
 		/// Working directory for the command.
 		#[arg(long)]
-		cwd:     Option<PathBuf>,
+		cwd: Option<PathBuf>,
 		/// The command line to run.
 		command: String,
 	},

--- a/crates/containment-check/tests/complement.rs
+++ b/crates/containment-check/tests/complement.rs
@@ -94,21 +94,21 @@ fn realistic() -> (FakeFs, ContainmentFence) {
 		"/home/alice/GIT/custA/.xcsh/sessions/other.jsonl",
 	]);
 	let fence = ContainmentFence {
-		allow:            vec![
+		allow: vec![
 			PathBuf::from("/home/alice/GIT/custA"),
 			PathBuf::from("/home/alice/.cargo/registry"),
 		],
-		allow_read_only:  vec![PathBuf::from("/home/alice/.gitconfig"), PathBuf::from("/opt/shared")],
+		allow_read_only: vec![PathBuf::from("/home/alice/.gitconfig"), PathBuf::from("/opt/shared")],
 		allow_write_only: vec![PathBuf::from("/drop")],
 		// `/home/alice/GIT` nested inside `/home/alice` exercises deny-inside-deny; the
 		// `.xcsh/sessions` root is a deny inside an allow inside a deny, which is the case
 		// seatbelt handles by rule order and Landlock cannot.
-		deny:             vec![
+		deny: vec![
 			PathBuf::from("/home/alice"),
 			PathBuf::from("/home/alice/GIT"),
 			PathBuf::from("/home/alice/GIT/custA/.xcsh/sessions"),
 		],
-		deny_enumerate:   Vec::new(),
+		deny_enumerate: Vec::new(),
 	};
 	(fs, fence)
 }

--- a/crates/pi-natives/build.rs
+++ b/crates/pi-natives/build.rs
@@ -26,15 +26,15 @@ const PROMOTION_FIELD_PRIORITY: &[&str] = &["definition", "declaration", "item",
 
 #[derive(Clone, Copy)]
 struct GrammarSpec {
-	language:       &'static str,
-	package:        &'static str,
+	language: &'static str,
+	package: &'static str,
 	node_types_rel: &'static str,
 }
 
 #[derive(Deserialize)]
 struct RawTypeRef {
 	#[serde(rename = "type")]
-	kind:  Option<String>,
+	kind: Option<String>,
 	named: bool,
 }
 
@@ -43,14 +43,14 @@ struct RawFieldSpec {
 	#[serde(default)]
 	multiple: bool,
 	#[serde(default)]
-	types:    Vec<RawTypeRef>,
+	types: Vec<RawTypeRef>,
 }
 
 #[derive(Deserialize)]
 struct RawNodeType {
 	#[serde(rename = "type")]
-	kind:     Option<String>,
-	fields:   Option<BTreeMap<String, RawFieldSpec>>,
+	kind: Option<String>,
+	fields: Option<BTreeMap<String, RawFieldSpec>>,
 	children: Option<RawFieldSpec>,
 	subtypes: Option<Vec<RawTypeRef>>,
 }
@@ -62,293 +62,281 @@ struct GeneratedSchema {
 
 #[derive(serde::Serialize)]
 struct GeneratedNodeTypeSchema {
-	identifier_fields:       Vec<String>,
-	body_fields:             Vec<String>,
-	promotion_fields:        Vec<String>,
-	container_child_kinds:   Vec<String>,
-	is_supertype:            bool,
+	identifier_fields: Vec<String>,
+	body_fields: Vec<String>,
+	promotion_fields: Vec<String>,
+	container_child_kinds: Vec<String>,
+	is_supertype: bool,
 	has_structural_children: bool,
 }
 
 const GRAMMARS: &[GrammarSpec] = &[
 	GrammarSpec {
-		language:       "astro",
-		package:        "tree-sitter-astro-next",
+		language: "astro",
+		package: "tree-sitter-astro-next",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "bash",
-		package:        "tree-sitter-bash",
+		language: "bash",
+		package: "tree-sitter-bash",
+		node_types_rel: "src/node-types.json",
+	},
+	GrammarSpec { language: "c", package: "tree-sitter-c", node_types_rel: "src/node-types.json" },
+	GrammarSpec {
+		language: "clojure",
+		package: "tree-sitter-clojure",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "c",
-		package:        "tree-sitter-c",
+		language: "cmake",
+		package: "tree-sitter-cmake",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "clojure",
-		package:        "tree-sitter-clojure",
+		language: "cpp",
+		package: "tree-sitter-cpp",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "cmake",
-		package:        "tree-sitter-cmake",
+		language: "csharp",
+		package: "tree-sitter-c-sharp",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "cpp",
-		package:        "tree-sitter-cpp",
+		language: "css",
+		package: "tree-sitter-css",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "csharp",
-		package:        "tree-sitter-c-sharp",
+		language: "diff",
+		package: "tree-sitter-diff",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "css",
-		package:        "tree-sitter-css",
+		language: "dockerfile",
+		package: "tree-sitter-dockerfile-updated",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "diff",
-		package:        "tree-sitter-diff",
+		language: "elixir",
+		package: "tree-sitter-elixir",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "dockerfile",
-		package:        "tree-sitter-dockerfile-updated",
+		language: "erlang",
+		package: "tree-sitter-erlang",
+		node_types_rel: "src/node-types.json",
+	},
+	GrammarSpec { language: "go", package: "tree-sitter-go", node_types_rel: "src/node-types.json" },
+	GrammarSpec {
+		language: "graphql",
+		package: "tree-sitter-graphql",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "elixir",
-		package:        "tree-sitter-elixir",
+		language: "handlebars",
+		package: "tree-sitter-glimmer",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "erlang",
-		package:        "tree-sitter-erlang",
+		language: "haskell",
+		package: "tree-sitter-haskell",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "go",
-		package:        "tree-sitter-go",
+		language: "hcl",
+		package: "tree-sitter-hcl",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "graphql",
-		package:        "tree-sitter-graphql",
+		language: "html",
+		package: "tree-sitter-html",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "handlebars",
-		package:        "tree-sitter-glimmer",
+		language: "ini",
+		package: "tree-sitter-ini",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "haskell",
-		package:        "tree-sitter-haskell",
+		language: "java",
+		package: "tree-sitter-java",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "hcl",
-		package:        "tree-sitter-hcl",
+		language: "javascript",
+		package: "tree-sitter-javascript",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "html",
-		package:        "tree-sitter-html",
+		language: "json",
+		package: "tree-sitter-json",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "ini",
-		package:        "tree-sitter-ini",
+		language: "toml",
+		package: "tree-sitter-toml-ng",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "java",
-		package:        "tree-sitter-java",
+		language: "just",
+		package: "tree-sitter-just",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "javascript",
-		package:        "tree-sitter-javascript",
+		language: "julia",
+		package: "tree-sitter-julia",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "json",
-		package:        "tree-sitter-json",
+		language: "kotlin",
+		package: "tree-sitter-kotlin-sg",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "toml",
-		package:        "tree-sitter-toml-ng",
+		language: "lua",
+		package: "tree-sitter-lua",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "just",
-		package:        "tree-sitter-just",
+		language: "make",
+		package: "tree-sitter-make",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "julia",
-		package:        "tree-sitter-julia",
-		node_types_rel: "src/node-types.json",
-	},
-	GrammarSpec {
-		language:       "kotlin",
-		package:        "tree-sitter-kotlin-sg",
-		node_types_rel: "src/node-types.json",
-	},
-	GrammarSpec {
-		language:       "lua",
-		package:        "tree-sitter-lua",
-		node_types_rel: "src/node-types.json",
-	},
-	GrammarSpec {
-		language:       "make",
-		package:        "tree-sitter-make",
-		node_types_rel: "src/node-types.json",
-	},
-	GrammarSpec {
-		language:       "markdown",
-		package:        "tree-sitter-md",
+		language: "markdown",
+		package: "tree-sitter-md",
 		node_types_rel: "tree-sitter-markdown/src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "nix",
-		package:        "tree-sitter-nix",
+		language: "nix",
+		package: "tree-sitter-nix",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "objc",
-		package:        "tree-sitter-objc",
+		language: "objc",
+		package: "tree-sitter-objc",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "odin",
-		package:        "tree-sitter-odin",
+		language: "odin",
+		package: "tree-sitter-odin",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "perl",
-		package:        "tree-sitter-perl-next",
+		language: "perl",
+		package: "tree-sitter-perl-next",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "php",
-		package:        "tree-sitter-php",
+		language: "php",
+		package: "tree-sitter-php",
 		node_types_rel: "php/src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "powershell",
-		package:        "tree-sitter-powershell",
+		language: "powershell",
+		package: "tree-sitter-powershell",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "protobuf",
-		package:        "tree-sitter-proto",
+		language: "protobuf",
+		package: "tree-sitter-proto",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "python",
-		package:        "tree-sitter-python",
+		language: "python",
+		package: "tree-sitter-python",
+		node_types_rel: "src/node-types.json",
+	},
+	GrammarSpec { language: "r", package: "tree-sitter-r", node_types_rel: "src/node-types.json" },
+	GrammarSpec {
+		language: "regex",
+		package: "tree-sitter-regex",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "r",
-		package:        "tree-sitter-r",
+		language: "ruby",
+		package: "tree-sitter-ruby",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "regex",
-		package:        "tree-sitter-regex",
+		language: "rust",
+		package: "tree-sitter-rust",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "ruby",
-		package:        "tree-sitter-ruby",
+		language: "scala",
+		package: "tree-sitter-scala",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "rust",
-		package:        "tree-sitter-rust",
+		language: "solidity",
+		package: "tree-sitter-solidity",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "scala",
-		package:        "tree-sitter-scala",
+		language: "sql",
+		package: "tree-sitter-sequel",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "solidity",
-		package:        "tree-sitter-solidity",
+		language: "starlark",
+		package: "tree-sitter-starlark",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "sql",
-		package:        "tree-sitter-sequel",
+		language: "svelte",
+		package: "tree-sitter-svelte-next",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "starlark",
-		package:        "tree-sitter-starlark",
+		language: "swift",
+		package: "tree-sitter-swift",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "svelte",
-		package:        "tree-sitter-svelte-next",
+		language: "toml",
+		package: "tree-sitter-toml-ng",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "swift",
-		package:        "tree-sitter-swift",
+		language: "tlaplus",
+		package: "tree-sitter-tlaplus",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "toml",
-		package:        "tree-sitter-toml-ng",
-		node_types_rel: "src/node-types.json",
-	},
-	GrammarSpec {
-		language:       "tlaplus",
-		package:        "tree-sitter-tlaplus",
-		node_types_rel: "src/node-types.json",
-	},
-	GrammarSpec {
-		language:       "tsx",
-		package:        "tree-sitter-typescript",
+		language: "tsx",
+		package: "tree-sitter-typescript",
 		node_types_rel: "tsx/src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "typescript",
-		package:        "tree-sitter-typescript",
+		language: "typescript",
+		package: "tree-sitter-typescript",
 		node_types_rel: "typescript/src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "verilog",
-		package:        "tree-sitter-verilog",
+		language: "verilog",
+		package: "tree-sitter-verilog",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "vue",
-		package:        "tree-sitter-vue-next",
+		language: "vue",
+		package: "tree-sitter-vue-next",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "xml",
-		package:        "tree-sitter-xml",
+		language: "xml",
+		package: "tree-sitter-xml",
 		node_types_rel: "xml/src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "yaml",
-		package:        "tree-sitter-yaml",
+		language: "yaml",
+		package: "tree-sitter-yaml",
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
-		language:       "zig",
-		package:        "tree-sitter-zig",
+		language: "zig",
+		package: "tree-sitter-zig",
 		node_types_rel: "src/node-types.json",
 	},
 ];
@@ -431,14 +419,17 @@ fn build_language_schema(raw_nodes: Vec<RawNodeType>) -> BTreeMap<String, Genera
 			continue;
 		}
 
-		out.insert(kind.clone(), GeneratedNodeTypeSchema {
-			identifier_fields,
-			body_fields,
-			promotion_fields,
-			container_child_kinds,
-			is_supertype,
-			has_structural_children,
-		});
+		out.insert(
+			kind.clone(),
+			GeneratedNodeTypeSchema {
+				identifier_fields,
+				body_fields,
+				promotion_fields,
+				container_child_kinds,
+				is_supertype,
+				has_structural_children,
+			},
+		);
 	}
 
 	out
@@ -526,7 +517,7 @@ fn collect_promotion_fields(
 
 #[derive(Clone, Copy, Default)]
 struct StructuralState {
-	is_structural:           bool,
+	is_structural: bool,
 	has_structural_children: bool,
 }
 
@@ -545,10 +536,10 @@ fn compute_structural_state(
 			let base_structural = is_supertype(raw)
 				|| raw.fields.as_ref().is_some_and(|fields| !fields.is_empty())
 				|| !named_child_type_kinds(raw).is_empty();
-			(kind.clone(), StructuralState {
-				is_structural:           base_structural,
-				has_structural_children: false,
-			})
+			(
+				kind.clone(),
+				StructuralState { is_structural: base_structural, has_structural_children: false },
+			)
 		})
 		.collect::<HashMap<_, _>>();
 

--- a/crates/pi-natives/src/appearance.rs
+++ b/crates/pi-natives/src/appearance.rs
@@ -59,10 +59,10 @@ mod platform {
 	/// Layout matches `CFRunLoopTimerContext` from CoreFoundation.
 	#[repr(C)]
 	struct TimerContext {
-		version:          CFIndex,
-		info:             *mut c_void,
-		retain:           *const c_void,
-		release:          *const c_void,
+		version: CFIndex,
+		info: *mut c_void,
+		retain: *const c_void,
+		release: *const c_void,
 		copy_description: *const c_void,
 	}
 
@@ -276,7 +276,7 @@ mod platform {
 	/// Internal state for a running observer.
 	pub struct ObserverInner {
 		run_loop: Arc<Mutex<Option<SendableRunLoop>>>,
-		thread:   Option<JoinHandle<()>>,
+		thread: Option<JoinHandle<()>>,
 	}
 
 	impl ObserverInner {
@@ -325,10 +325,10 @@ mod platform {
 					// 2. Polls `CFPreferencesCopyAppValue` every 2 s so we catch theme changes even
 					//    if the Mach-port notification does not fire on this thread.
 					let timer_ctx = TimerContext {
-						version:          0,
-						info:             ctx_ptr.cast::<c_void>(),
-						retain:           ptr::null(),
-						release:          ptr::null(),
+						version: 0,
+						info: ctx_ptr.cast::<c_void>(),
+						retain: ptr::null(),
+						release: ptr::null(),
 						copy_description: ptr::null(),
 					};
 					let timer = CFRunLoopTimerCreate(

--- a/crates/pi-natives/src/ast.rs
+++ b/crates/pi-natives/src/ast.rs
@@ -60,51 +60,51 @@ fn resolve_strictness(value: Option<AstMatchStrictness>) -> MatchStrictness {
 #[napi(object)]
 pub struct AstFindOptions<'env> {
 	/// ast-grep patterns to search for (OR across patterns).
-	pub patterns:     Option<Vec<String>>,
+	pub patterns: Option<Vec<String>>,
 	/// Language override; otherwise inferred from file extension per candidate.
-	pub lang:         Option<String>,
+	pub lang: Option<String>,
 	/// Single file or directory to scan (combined with `glob` when set).
-	pub path:         Option<String>,
+	pub path: Option<String>,
 	/// Optional glob filter relative to the search root.
-	pub glob:         Option<String>,
+	pub glob: Option<String>,
 	/// Rule selector for multi-rule ast-grep configurations.
-	pub selector:     Option<String>,
+	pub selector: Option<String>,
 	/// Pattern strictness; defaults to smart matching when omitted.
-	pub strictness:   Option<AstMatchStrictness>,
+	pub strictness: Option<AstMatchStrictness>,
 	/// Maximum matches to return after `offset` (default applies when omitted).
-	pub limit:        Option<u32>,
+	pub limit: Option<u32>,
 	/// Number of leading matches to skip before applying `limit`.
-	pub offset:       Option<u32>,
+	pub offset: Option<u32>,
 	/// When true, include meta-variable bindings per match.
 	pub include_meta: Option<bool>,
 	/// Reserved for contextual snippets; not used by the current native find
 	/// path.
-	pub context:      Option<u32>,
+	pub context: Option<u32>,
 	/// Optional cancellation handle (library-specific).
-	pub signal:       Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 	/// Wall-clock timeout for the worker task in milliseconds.
-	pub timeout_ms:   Option<u32>,
+	pub timeout_ms: Option<u32>,
 }
 
 /// One ast-grep match with source range and optional meta-variables.
 #[napi(object)]
 pub struct AstFindMatch {
 	/// Display path of the matching file.
-	pub path:           String,
+	pub path: String,
 	/// Matched source text.
-	pub text:           String,
+	pub text: String,
 	/// Start byte offset in the file (UTF-8 byte index).
-	pub byte_start:     u32,
+	pub byte_start: u32,
 	/// End byte offset in the file (exclusive UTF-8 byte index).
-	pub byte_end:       u32,
+	pub byte_end: u32,
 	/// 1-based start line.
-	pub start_line:     u32,
+	pub start_line: u32,
 	/// 1-based start column.
-	pub start_column:   u32,
+	pub start_column: u32,
 	/// 1-based end line.
-	pub end_line:       u32,
+	pub end_line: u32,
 	/// 1-based end column.
-	pub end_column:     u32,
+	pub end_column: u32,
 	/// Meta-variable name to captured text, when `includeMeta` was enabled.
 	pub meta_variables: Option<HashMap<String, String>>,
 }
@@ -113,17 +113,17 @@ pub struct AstFindMatch {
 #[napi(object)]
 pub struct AstFindResult {
 	/// Page of matches after sort, offset, and limit.
-	pub matches:            Vec<AstFindMatch>,
+	pub matches: Vec<AstFindMatch>,
 	/// Total matches found before paging (can exceed `matches.length`).
-	pub total_matches:      u32,
+	pub total_matches: u32,
 	/// Distinct files that contained at least one match.
 	pub files_with_matches: u32,
 	/// Files examined for the query.
-	pub files_searched:     u32,
+	pub files_searched: u32,
 	/// True when results were truncated by `limit`.
-	pub limit_reached:      bool,
+	pub limit_reached: bool,
 	/// Non-fatal parse or pattern errors collected during the run.
-	pub parse_errors:       Option<Vec<String>>,
+	pub parse_errors: Option<Vec<String>>,
 }
 
 /// Options for `astEdit`: rewrite rules, scan scope, safety limits, and
@@ -131,29 +131,29 @@ pub struct AstFindResult {
 #[napi(object)]
 pub struct AstReplaceOptions<'env> {
 	/// Map of pattern string to replacement template.
-	pub rewrites:            Option<HashMap<String, String>>,
+	pub rewrites: Option<HashMap<String, String>>,
 	/// Language override; otherwise inferred from discovered files.
-	pub lang:                Option<String>,
+	pub lang: Option<String>,
 	/// Single file or directory to rewrite.
-	pub path:                Option<String>,
+	pub path: Option<String>,
 	/// Optional glob filter within the search root.
-	pub glob:                Option<String>,
+	pub glob: Option<String>,
 	/// Rule selector for multi-rule configurations.
-	pub selector:            Option<String>,
+	pub selector: Option<String>,
 	/// Pattern strictness for rewrites.
-	pub strictness:          Option<AstMatchStrictness>,
+	pub strictness: Option<AstMatchStrictness>,
 	/// When true (default), compute changes without writing files.
-	pub dry_run:             Option<bool>,
+	pub dry_run: Option<bool>,
 	/// Cap on replacement applications across all files.
-	pub max_replacements:    Option<u32>,
+	pub max_replacements: Option<u32>,
 	/// Cap on distinct files that may be modified.
-	pub max_files:           Option<u32>,
+	pub max_files: Option<u32>,
 	/// Fail the operation when a file cannot be parsed for rewriting.
 	pub fail_on_parse_error: Option<bool>,
 	/// Optional cancellation handle.
-	pub signal:              Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 	/// Wall-clock timeout for the worker task in milliseconds.
-	pub timeout_ms:          Option<u32>,
+	pub timeout_ms: Option<u32>,
 }
 
 /// One textual replacement applied to a file (before/after slice and
@@ -161,33 +161,33 @@ pub struct AstReplaceOptions<'env> {
 #[napi(object)]
 pub struct AstReplaceChange {
 	/// File path for this change.
-	pub path:           String,
+	pub path: String,
 	/// Original matched text.
-	pub before:         String,
+	pub before: String,
 	/// Replacement text.
-	pub after:          String,
+	pub after: String,
 	/// Start byte offset of the replaced span.
-	pub byte_start:     u32,
+	pub byte_start: u32,
 	/// End byte offset of the replaced span (exclusive).
-	pub byte_end:       u32,
+	pub byte_end: u32,
 	/// Length of deleted text in bytes (may differ from `byteEnd - byteStart`
 	/// for edge cases).
 	pub deleted_length: u32,
 	/// 1-based start line of the match.
-	pub start_line:     u32,
+	pub start_line: u32,
 	/// 1-based start column.
-	pub start_column:   u32,
+	pub start_column: u32,
 	/// 1-based end line.
-	pub end_line:       u32,
+	pub end_line: u32,
 	/// 1-based end column.
-	pub end_column:     u32,
+	pub end_column: u32,
 }
 
 /// Per-file replacement count after an `astEdit` run.
 #[napi(object)]
 pub struct AstReplaceFileChange {
 	/// File that had replacements.
-	pub path:  String,
+	pub path: String,
 	/// Number of replacements in that file.
 	pub count: u32,
 }
@@ -196,31 +196,31 @@ pub struct AstReplaceFileChange {
 #[napi(object)]
 pub struct AstReplaceResult {
 	/// Individual replacement records (may be large).
-	pub changes:            Vec<AstReplaceChange>,
+	pub changes: Vec<AstReplaceChange>,
 	/// Replacement counts grouped by file.
-	pub file_changes:       Vec<AstReplaceFileChange>,
+	pub file_changes: Vec<AstReplaceFileChange>,
 	/// Total replacements applied or previewed.
 	pub total_replacements: u32,
 	/// Files that had at least one replacement.
-	pub files_touched:      u32,
+	pub files_touched: u32,
 	/// Files considered for rewriting.
-	pub files_searched:     u32,
+	pub files_searched: u32,
 	/// False when `dryRun` prevented writing.
-	pub applied:            bool,
+	pub applied: bool,
 	/// True when limits stopped further replacements.
-	pub limit_reached:      bool,
+	pub limit_reached: bool,
 	/// Parse or pattern errors when not failing the whole operation.
-	pub parse_errors:       Option<Vec<String>>,
+	pub parse_errors: Option<Vec<String>>,
 }
 
 struct FileCandidate {
 	absolute_path: PathBuf,
-	display_path:  String,
+	display_path: String,
 }
 
 struct PendingFileChange {
 	change: AstReplaceChange,
-	edit:   Edit<String>,
+	edit: Edit<String>,
 }
 
 fn to_u32(value: usize) -> u32 {
@@ -485,14 +485,14 @@ fn normalize_rewrite_map(
 	Ok(normalized)
 }
 struct CompiledFindPattern {
-	pattern:                String,
-	compiled_by_lang:       HashMap<String, Pattern>,
+	pattern: String,
+	compiled_by_lang: HashMap<String, Pattern>,
 	compile_errors_by_lang: HashMap<String, String>,
 }
 
 struct ResolvedCandidate {
-	candidate:      FileCandidate,
-	language:       Option<SupportLang>,
+	candidate: FileCandidate,
+	language: Option<SupportLang>,
 	language_error: Option<String>,
 }
 
@@ -776,14 +776,14 @@ pub fn ast_edit(options: AstReplaceOptions<'_>) -> task::Promise<AstReplaceResul
 		}
 		if compiled_rules.is_empty() {
 			return Ok(AstReplaceResult {
-				file_changes:       vec![],
+				file_changes: vec![],
 				total_replacements: 0,
-				files_touched:      0,
-				files_searched:     to_u32(candidates.len()),
-				applied:            !dry_run,
-				limit_reached:      false,
-				parse_errors:       (!parse_errors.is_empty()).then_some(parse_errors),
-				changes:            vec![],
+				files_touched: 0,
+				files_searched: to_u32(candidates.len()),
+				applied: !dry_run,
+				limit_reached: false,
+				parse_errors: (!parse_errors.is_empty()).then_some(parse_errors),
+				changes: vec![],
 			});
 		}
 
@@ -873,9 +873,9 @@ pub fn ast_edit(options: AstReplaceOptions<'_>) -> task::Promise<AstReplaceResul
 				let edits: Vec<Edit<String>> = file_changes
 					.iter()
 					.map(|entry| Edit {
-						position:       entry.edit.position,
+						position: entry.edit.position,
 						deleted_length: entry.edit.deleted_length,
-						inserted_text:  entry.edit.inserted_text.clone(),
+						inserted_text: entry.edit.inserted_text.clone(),
 					})
 					.collect();
 				let output = apply_edits(&source, &edits)?;

--- a/crates/pi-natives/src/chunk/ast_astro.rs
+++ b/crates/pi-natives/src/chunk/ast_astro.rs
@@ -14,15 +14,15 @@ pub struct AstroClassifier;
 impl LangClassifier for AstroClassifier {
 	fn tables(&self) -> &'static ClassifierTables {
 		static TABLES: ClassifierTables = ClassifierTables {
-			root:                 &[],
-			class:                &[],
-			function:             &[],
+			root: &[],
+			class: &[],
+			function: &[],
 			structural_overrides: StructuralOverrides {
-				extra_trivia:            &[],
-				preserved_trivia:        &[],
-				extra_root_wrappers:     &["document"],
+				extra_trivia: &[],
+				preserved_trivia: &[],
+				extra_root_wrappers: &["document"],
 				preserved_root_wrappers: &[],
-				absorbable_attrs:        &[],
+				absorbable_attrs: &[],
 			},
 		};
 		&TABLES

--- a/crates/pi-natives/src/chunk/ast_bash_make_diff.rs
+++ b/crates/pi-natives/src/chunk/ast_bash_make_diff.rs
@@ -81,7 +81,7 @@ impl ShellBuildClassifier {
 impl LangClassifier for ShellBuildClassifier {
 	fn tables(&self) -> &'static ClassifierTables {
 		static TABLES: ClassifierTables = ClassifierTables {
-			root:                 &[
+			root: &[
 				semantic_rule(
 					"conditional",
 					ChunkKind::If,
@@ -146,14 +146,14 @@ impl LangClassifier for ShellBuildClassifier {
 					RecurseMode::None,
 				),
 			],
-			class:                &[semantic_rule(
+			class: &[semantic_rule(
 				"hunk",
 				ChunkKind::Hunk,
 				RuleStyle::Positional,
 				NamingMode::None,
 				RecurseMode::None,
 			)],
-			function:             &[
+			function: &[
 				semantic_rule(
 					"if_statement",
 					ChunkKind::If,
@@ -205,11 +205,11 @@ impl LangClassifier for ShellBuildClassifier {
 				),
 			],
 			structural_overrides: StructuralOverrides {
-				extra_trivia:            &[],
-				preserved_trivia:        &[],
-				extra_root_wrappers:     &["makefile"],
+				extra_trivia: &[],
+				preserved_trivia: &[],
+				extra_root_wrappers: &["makefile"],
 				preserved_root_wrappers: &[],
-				absorbable_attrs:        &[],
+				absorbable_attrs: &[],
 			},
 		};
 		&TABLES

--- a/crates/pi-natives/src/chunk/ast_c_cpp_objc.rs
+++ b/crates/pi-natives/src/chunk/ast_c_cpp_objc.rs
@@ -155,9 +155,9 @@ const C_CPP_ROOT_RULES: &[super::classify::SemanticRule] = &[
 ];
 
 const C_CPP_TABLES: ClassifierTables = ClassifierTables {
-	root:                 C_CPP_ROOT_RULES,
-	class:                &[],
-	function:             &[],
+	root: C_CPP_ROOT_RULES,
+	class: &[],
+	function: &[],
 	structural_overrides: StructuralOverrides::EMPTY,
 };
 

--- a/crates/pi-natives/src/chunk/ast_clojure.rs
+++ b/crates/pi-natives/src/chunk/ast_clojure.rs
@@ -58,9 +58,9 @@ fn classify_form<'t>(node: Node<'t>, source: &str, at_root: bool) -> RawChunkCan
 impl LangClassifier for ClojureClassifier {
 	fn tables(&self) -> &'static ClassifierTables {
 		static TABLES: ClassifierTables = ClassifierTables {
-			root:                 &[],
-			class:                &[],
-			function:             &[],
+			root: &[],
+			class: &[],
+			function: &[],
 			structural_overrides: super::classify::StructuralOverrides::EMPTY,
 		};
 		&TABLES

--- a/crates/pi-natives/src/chunk/ast_cmake.rs
+++ b/crates/pi-natives/src/chunk/ast_cmake.rs
@@ -135,21 +135,21 @@ fn classify_if_child<'t>(node: Node<'t>, source: &str) -> Option<RawChunkCandida
 impl LangClassifier for CMakeClassifier {
 	fn tables(&self) -> &'static ClassifierTables {
 		static TABLES: ClassifierTables = ClassifierTables {
-			root:                 &[],
-			class:                &[],
-			function:             &[],
+			root: &[],
+			class: &[],
+			function: &[],
 			structural_overrides: StructuralOverrides {
-				extra_trivia:            &[
+				extra_trivia: &[
 					"endif_command",
 					"endforeach_command",
 					"endwhile_command",
 					"endfunction_command",
 					"endmacro_command",
 				],
-				preserved_trivia:        &[],
-				extra_root_wrappers:     &[],
+				preserved_trivia: &[],
+				extra_root_wrappers: &[],
 				preserved_root_wrappers: &[],
-				absorbable_attrs:        &[],
+				absorbable_attrs: &[],
 			},
 		};
 		&TABLES

--- a/crates/pi-natives/src/chunk/ast_csharp_java.rs
+++ b/crates/pi-natives/src/chunk/ast_csharp_java.rs
@@ -219,9 +219,9 @@ const CSHARP_JAVA_CLASS_RULES: &[super::classify::SemanticRule] = &[
 ];
 
 const CSHARP_JAVA_TABLES: ClassifierTables = ClassifierTables {
-	root:                 CSHARP_JAVA_ROOT_RULES,
-	class:                CSHARP_JAVA_CLASS_RULES,
-	function:             &[],
+	root: CSHARP_JAVA_ROOT_RULES,
+	class: CSHARP_JAVA_CLASS_RULES,
+	function: &[],
 	structural_overrides: StructuralOverrides::EMPTY,
 };
 

--- a/crates/pi-natives/src/chunk/ast_css.rs
+++ b/crates/pi-natives/src/chunk/ast_css.rs
@@ -31,15 +31,15 @@ const CSS_SHARED_RULES: &[super::classify::SemanticRule] = &[
 ];
 
 const CSS_TABLES: ClassifierTables = ClassifierTables {
-	root:                 CSS_SHARED_RULES,
-	class:                CSS_SHARED_RULES,
-	function:             &[],
+	root: CSS_SHARED_RULES,
+	class: CSS_SHARED_RULES,
+	function: &[],
 	structural_overrides: StructuralOverrides {
-		extra_trivia:            &[],
-		preserved_trivia:        &[],
-		extra_root_wrappers:     &["stylesheet"],
+		extra_trivia: &[],
+		preserved_trivia: &[],
+		extra_root_wrappers: &["stylesheet"],
 		preserved_root_wrappers: &[],
-		absorbable_attrs:        &[],
+		absorbable_attrs: &[],
 	},
 };
 

--- a/crates/pi-natives/src/chunk/ast_data_formats.rs
+++ b/crates/pi-natives/src/chunk/ast_data_formats.rs
@@ -14,9 +14,9 @@ use super::{
 pub struct DataFormatsClassifier;
 
 const DATA_FORMAT_STRUCTURAL_OVERRIDES: StructuralOverrides = StructuralOverrides {
-	extra_trivia:            &["bare_key", "quoted_key", "dotted_key"],
-	preserved_trivia:        &[],
-	extra_root_wrappers:     &[
+	extra_trivia: &["bare_key", "quoted_key", "dotted_key"],
+	preserved_trivia: &[],
+	extra_root_wrappers: &[
 		"array",
 		"block_mapping",
 		"block_node",
@@ -29,7 +29,7 @@ const DATA_FORMAT_STRUCTURAL_OVERRIDES: StructuralOverrides = StructuralOverride
 		"stream",
 	],
 	preserved_root_wrappers: &[],
-	absorbable_attrs:        &[],
+	absorbable_attrs: &[],
 };
 
 const DATA_FORMAT_ROOT_RULES: &[super::classify::SemanticRule] = &[
@@ -158,9 +158,9 @@ const DATA_FORMAT_CLASS_RULES: &[super::classify::SemanticRule] = &[
 ];
 
 const DATA_FORMAT_TABLES: ClassifierTables = ClassifierTables {
-	root:                 DATA_FORMAT_ROOT_RULES,
-	class:                DATA_FORMAT_CLASS_RULES,
-	function:             &[],
+	root: DATA_FORMAT_ROOT_RULES,
+	class: DATA_FORMAT_CLASS_RULES,
+	function: &[],
 	structural_overrides: DATA_FORMAT_STRUCTURAL_OVERRIDES,
 };
 

--- a/crates/pi-natives/src/chunk/ast_dockerfile.rs
+++ b/crates/pi-natives/src/chunk/ast_dockerfile.rs
@@ -96,9 +96,9 @@ const DOCKERFILE_FUNCTION_RULES: &[super::classify::SemanticRule] = &[
 ];
 
 const DOCKERFILE_TABLES: ClassifierTables = ClassifierTables {
-	root:                 DOCKERFILE_ROOT_RULES,
-	class:                &[],
-	function:             DOCKERFILE_FUNCTION_RULES,
+	root: DOCKERFILE_ROOT_RULES,
+	class: &[],
+	function: DOCKERFILE_FUNCTION_RULES,
 	structural_overrides: super::classify::StructuralOverrides::EMPTY,
 };
 

--- a/crates/pi-natives/src/chunk/ast_elixir.rs
+++ b/crates/pi-natives/src/chunk/ast_elixir.rs
@@ -134,15 +134,15 @@ fn call_name(node: Node<'_>, source: &str) -> Option<String> {
 impl LangClassifier for ElixirClassifier {
 	fn tables(&self) -> &'static ClassifierTables {
 		static TABLES: ClassifierTables = ClassifierTables {
-			root:                 &[],
-			class:                &[],
-			function:             &[],
+			root: &[],
+			class: &[],
+			function: &[],
 			structural_overrides: StructuralOverrides {
-				extra_trivia:            &["unary_operator"],
-				preserved_trivia:        &[],
-				extra_root_wrappers:     &[],
+				extra_trivia: &["unary_operator"],
+				preserved_trivia: &[],
+				extra_root_wrappers: &[],
 				preserved_root_wrappers: &[],
-				absorbable_attrs:        &[],
+				absorbable_attrs: &[],
 			},
 		};
 		&TABLES

--- a/crates/pi-natives/src/chunk/ast_erlang.rs
+++ b/crates/pi-natives/src/chunk/ast_erlang.rs
@@ -60,7 +60,7 @@ fn recurse_clause_body(node: Node<'_>) -> Option<RecurseSpec<'_>> {
 impl LangClassifier for ErlangClassifier {
 	fn tables(&self) -> &'static ClassifierTables {
 		static TABLES: ClassifierTables = ClassifierTables {
-			root:                 &[
+			root: &[
 				semantic_rule(
 					"export_attribute",
 					ChunkKind::Exports,
@@ -97,14 +97,14 @@ impl LangClassifier for ErlangClassifier {
 					RecurseMode::None,
 				),
 			],
-			class:                &[],
-			function:             &[],
+			class: &[],
+			function: &[],
 			structural_overrides: StructuralOverrides {
-				extra_trivia:            &[],
-				preserved_trivia:        &[],
-				extra_root_wrappers:     &[],
+				extra_trivia: &[],
+				preserved_trivia: &[],
+				extra_root_wrappers: &[],
 				preserved_root_wrappers: &[],
-				absorbable_attrs:        &["spec"],
+				absorbable_attrs: &["spec"],
 			},
 		};
 		&TABLES

--- a/crates/pi-natives/src/chunk/ast_go.rs
+++ b/crates/pi-natives/src/chunk/ast_go.rs
@@ -168,9 +168,9 @@ const FUNCTION_RULES: &[super::classify::SemanticRule] = &[
 ];
 
 const GO_TABLES: ClassifierTables = ClassifierTables {
-	root:                 ROOT_RULES,
-	class:                CLASS_RULES,
-	function:             FUNCTION_RULES,
+	root: ROOT_RULES,
+	class: CLASS_RULES,
+	function: FUNCTION_RULES,
 	structural_overrides: StructuralOverrides::EMPTY,
 };
 

--- a/crates/pi-natives/src/chunk/ast_graphql.rs
+++ b/crates/pi-natives/src/chunk/ast_graphql.rs
@@ -13,13 +13,13 @@ pub struct GraphqlClassifier;
 impl LangClassifier for GraphqlClassifier {
 	fn tables(&self) -> &'static ClassifierTables {
 		static TABLES: ClassifierTables = ClassifierTables {
-			root:                 &[],
-			class:                &[],
-			function:             &[],
+			root: &[],
+			class: &[],
+			function: &[],
 			structural_overrides: StructuralOverrides {
-				extra_trivia:            &["comma"],
-				preserved_trivia:        &[],
-				extra_root_wrappers:     &[
+				extra_trivia: &["comma"],
+				preserved_trivia: &[],
+				extra_root_wrappers: &[
 					"document",
 					"definition",
 					"type_system_definition",
@@ -27,7 +27,7 @@ impl LangClassifier for GraphqlClassifier {
 					"executable_definition",
 				],
 				preserved_root_wrappers: &[],
-				absorbable_attrs:        &[],
+				absorbable_attrs: &[],
 			},
 		};
 		&TABLES

--- a/crates/pi-natives/src/chunk/ast_haskell_scala.rs
+++ b/crates/pi-natives/src/chunk/ast_haskell_scala.rs
@@ -145,9 +145,9 @@ const HASKELL_SCALA_FUNCTION_RULES: &[super::classify::SemanticRule] = &[
 ];
 
 const HASKELL_SCALA_TABLES: ClassifierTables = ClassifierTables {
-	root:                 HASKELL_SCALA_ROOT_RULES,
-	class:                &[],
-	function:             HASKELL_SCALA_FUNCTION_RULES,
+	root: HASKELL_SCALA_ROOT_RULES,
+	class: &[],
+	function: HASKELL_SCALA_FUNCTION_RULES,
 	structural_overrides: super::classify::StructuralOverrides::EMPTY,
 };
 

--- a/crates/pi-natives/src/chunk/ast_html_xml.rs
+++ b/crates/pi-natives/src/chunk/ast_html_xml.rs
@@ -22,9 +22,9 @@ const HTML_XML_SHARED_RULES: &[super::classify::SemanticRule] = &[semantic_rule(
 )];
 
 const HTML_XML_TABLES: ClassifierTables = ClassifierTables {
-	root:                 HTML_XML_SHARED_RULES,
-	class:                HTML_XML_SHARED_RULES,
-	function:             &[],
+	root: HTML_XML_SHARED_RULES,
+	class: HTML_XML_SHARED_RULES,
+	function: &[],
 	structural_overrides: super::classify::StructuralOverrides::EMPTY,
 };
 

--- a/crates/pi-natives/src/chunk/ast_ini.rs
+++ b/crates/pi-natives/src/chunk/ast_ini.rs
@@ -18,9 +18,9 @@ pub struct IniClassifier;
 impl LangClassifier for IniClassifier {
 	fn tables(&self) -> &'static ClassifierTables {
 		static TABLES: ClassifierTables = ClassifierTables {
-			root:                 &[],
-			class:                &[],
-			function:             &[],
+			root: &[],
+			class: &[],
+			function: &[],
 			structural_overrides: super::classify::StructuralOverrides::EMPTY,
 		};
 		&TABLES

--- a/crates/pi-natives/src/chunk/ast_ipynb.rs
+++ b/crates/pi-natives/src/chunk/ast_ipynb.rs
@@ -61,14 +61,14 @@ fn format_marker(index: usize, cell_type: &str) -> String {
 /// is preserved verbatim for JSON round-tripping.
 #[derive(Clone)]
 pub struct NotebookCell {
-	pub cell_type:         String,
-	pub source:            String,
-	pub metadata:          Value,
-	pub outputs:           Option<Value>,
-	pub execution_count:   Option<Value>,
+	pub cell_type: String,
+	pub source: String,
+	pub metadata: Value,
+	pub outputs: Option<Value>,
+	pub execution_count: Option<Value>,
 	/// Additional fields on the cell object (`id`, `attachments`, …) so we
 	/// emit the same keys we consumed.
-	pub other:             Map<String, Value>,
+	pub other: Map<String, Value>,
 	/// Whether the original cell used `"source"` as a string (`true`) or an
 	/// array of lines (`false`). Preserved so round-trips stay byte-identical
 	/// when only metadata or unrelated cells change.
@@ -79,22 +79,22 @@ pub struct NotebookCell {
 #[derive(Clone)]
 pub struct NotebookContext {
 	/// Cells in document order.
-	pub cells:            Vec<NotebookCell>,
+	pub cells: Vec<NotebookCell>,
 	/// Top-level notebook fields other than `cells`, in original key order.
-	pub top_fields:       Map<String, Value>,
+	pub top_fields: Map<String, Value>,
 	/// Indent string detected from the original JSON (typically `" "`).
-	pub indent:           String,
+	pub indent: String,
 	/// Whether the original file ended with a trailing `\n`.
 	pub trailing_newline: bool,
 	/// Normalized kernel language used for code cells (e.g. `python`).
-	pub kernel_language:  String,
+	pub kernel_language: String,
 }
 
 /// Result of a notebook parse: the virtual source ready for chunking plus
 /// the context needed to rebuild the JSON later.
 pub struct NotebookParse {
 	pub virtual_source: String,
-	pub context:        NotebookContext,
+	pub context: NotebookContext,
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -294,15 +294,15 @@ pub fn build_virtual_source(ctx: &NotebookContext) -> String {
 /// `content_start_line_1based`,
 ///  `content_end_line_1based_inclusive_or_zero_if_empty`)
 struct CellRegion {
-	cell_num:         usize,
-	cell_type:        String,
-	marker_start:     usize, // byte offset of the `#` starting the marker line
-	content_start:    usize, // byte offset of the first byte of the cell body
-	content_end:      usize, // byte offset one past the last byte of the cell body
-	marker_line:      u32,   // 1-based line number of the marker
-	content_line:     u32,   // 1-based line number of the first body line (or marker_line + 1)
-	content_end_line: u32,   /* 1-based line number of the last body line (== content_line - 1
-	                          * for empty bodies) */
+	cell_num: usize,
+	cell_type: String,
+	marker_start: usize,  // byte offset of the `#` starting the marker line
+	content_start: usize, // byte offset of the first byte of the cell body
+	content_end: usize,   // byte offset one past the last byte of the cell body
+	marker_line: u32,     // 1-based line number of the marker
+	content_line: u32,    // 1-based line number of the first body line (or marker_line + 1)
+	content_end_line: u32, /* 1-based line number of the last body line (== content_line - 1
+	                       * for empty bodies) */
 }
 
 /// Scan a virtual source text for cell markers and return the list of
@@ -396,27 +396,27 @@ pub fn build_notebook_tree_from_virtual(
 	// Accumulated chunk nodes. Index 0 is reserved for the synthetic root.
 	let mut chunks: Vec<ChunkNode> = Vec::with_capacity(1 + regions.len() * 2);
 	chunks.push(ChunkNode {
-		path:                String::new(),
-		identifier:          None,
-		kind:                ChunkKind::Root,
-		leaf:                false,
-		virtual_content:     None,
-		parent_path:         None,
-		children:            Vec::new(),
-		signature:           None,
-		start_line:          u32::from(total_lines != 0),
-		end_line:            total_lines as u32,
-		line_count:          total_lines as u32,
-		start_byte:          0,
-		end_byte:            virtual_source.len() as u32,
+		path: String::new(),
+		identifier: None,
+		kind: ChunkKind::Root,
+		leaf: false,
+		virtual_content: None,
+		parent_path: None,
+		children: Vec::new(),
+		signature: None,
+		start_line: u32::from(total_lines != 0),
+		end_line: total_lines as u32,
+		line_count: total_lines as u32,
+		start_byte: 0,
+		end_byte: virtual_source.len() as u32,
 		checksum_start_byte: 0,
-		prologue_end_byte:   Some(0),
+		prologue_end_byte: Some(0),
 		epilogue_start_byte: Some(virtual_source.len() as u32),
-		checksum:            root_checksum.clone(),
-		error:               false,
-		indent:              0,
-		indent_char:         String::new(),
-		group:               false,
+		checksum: root_checksum.clone(),
+		error: false,
+		indent: 0,
+		indent_char: String::new(),
+		group: false,
 	});
 
 	let mut root_children: Vec<String> = Vec::with_capacity(regions.len());
@@ -460,33 +460,33 @@ pub fn build_notebook_tree_from_virtual(
 					.saturating_add(region.content_start as u32);
 				let line_shift = region.content_line.saturating_sub(1);
 				chunks.push(ChunkNode {
-					path:                translated_path.clone(),
-					identifier:          sub_chunk.identifier,
-					kind:                sub_chunk.kind,
-					leaf:                sub_chunk.leaf,
-					virtual_content:     sub_chunk.virtual_content,
-					parent_path:         translated_parent,
-					children:            translated_children,
-					signature:           sub_chunk.signature,
-					start_line:          sub_chunk.start_line.saturating_add(line_shift),
-					end_line:            sub_chunk.end_line.saturating_add(line_shift),
-					line_count:          sub_chunk.line_count,
-					start_byte:          shifted_start_byte,
-					end_byte:            shifted_end_byte,
+					path: translated_path.clone(),
+					identifier: sub_chunk.identifier,
+					kind: sub_chunk.kind,
+					leaf: sub_chunk.leaf,
+					virtual_content: sub_chunk.virtual_content,
+					parent_path: translated_parent,
+					children: translated_children,
+					signature: sub_chunk.signature,
+					start_line: sub_chunk.start_line.saturating_add(line_shift),
+					end_line: sub_chunk.end_line.saturating_add(line_shift),
+					line_count: sub_chunk.line_count,
+					start_byte: shifted_start_byte,
+					end_byte: shifted_end_byte,
 					checksum_start_byte: sub_chunk
 						.checksum_start_byte
 						.saturating_add(region.content_start as u32),
-					prologue_end_byte:   sub_chunk
+					prologue_end_byte: sub_chunk
 						.prologue_end_byte
 						.map(|b| b.saturating_add(region.content_start as u32)),
 					epilogue_start_byte: sub_chunk
 						.epilogue_start_byte
 						.map(|b| b.saturating_add(region.content_start as u32)),
-					checksum:            sub_chunk.checksum,
-					error:               sub_chunk.error,
-					indent:              sub_chunk.indent,
-					indent_char:         sub_chunk.indent_char,
-					group:               false,
+					checksum: sub_chunk.checksum,
+					error: sub_chunk.error,
+					indent: sub_chunk.indent,
+					indent_char: sub_chunk.indent_char,
+					group: false,
 				});
 			}
 			for sub_path in sub_tree.root_children {
@@ -509,27 +509,27 @@ pub fn build_notebook_tree_from_virtual(
 		let cell_end_line = region.marker_line + cell_line_count.saturating_sub(1);
 		let cell_leaf = cell_children_paths.is_empty();
 		chunks.push(ChunkNode {
-			path:                cell_path.clone(),
-			identifier:          Some(cell_path.clone()),
-			kind:                ChunkKind::Cell,
-			leaf:                cell_leaf,
-			virtual_content:     None,
-			parent_path:         Some(String::new()),
-			children:            cell_children_paths,
-			signature:           Some(format!("cell_{} ({})", region.cell_num, region.cell_type)),
-			start_line:          region.marker_line,
-			end_line:            cell_end_line,
-			line_count:          cell_line_count,
-			start_byte:          region.marker_start as u32,
-			end_byte:            region.content_end as u32,
+			path: cell_path.clone(),
+			identifier: Some(cell_path.clone()),
+			kind: ChunkKind::Cell,
+			leaf: cell_leaf,
+			virtual_content: None,
+			parent_path: Some(String::new()),
+			children: cell_children_paths,
+			signature: Some(format!("cell_{} ({})", region.cell_num, region.cell_type)),
+			start_line: region.marker_line,
+			end_line: cell_end_line,
+			line_count: cell_line_count,
+			start_byte: region.marker_start as u32,
+			end_byte: region.content_end as u32,
 			checksum_start_byte: region.content_start as u32,
-			prologue_end_byte:   Some(region.content_start as u32),
+			prologue_end_byte: Some(region.content_start as u32),
 			epilogue_start_byte: Some(region.content_end as u32),
-			checksum:            cell_checksum,
-			error:               false,
-			indent:              0,
-			indent_char:         String::new(),
-			group:               false,
+			checksum: cell_checksum,
+			error: false,
+			indent: 0,
+			indent_char: String::new(),
+			group: false,
 		});
 		root_children.push(cell_path);
 	}
@@ -629,18 +629,18 @@ pub fn notebook_to_json(
 				cell
 			},
 			None => NotebookCell {
-				cell_type:         region.cell_type.clone(),
-				source:            body.to_string(),
-				metadata:          Value::Object(Map::new()),
-				outputs:           match region.cell_type.as_str() {
+				cell_type: region.cell_type.clone(),
+				source: body.to_string(),
+				metadata: Value::Object(Map::new()),
+				outputs: match region.cell_type.as_str() {
 					"code" => Some(Value::Array(Vec::new())),
 					_ => None,
 				},
-				execution_count:   match region.cell_type.as_str() {
+				execution_count: match region.cell_type.as_str() {
 					"code" => Some(Value::Null),
 					_ => None,
 				},
-				other:             Map::new(),
+				other: Map::new(),
 				source_was_string: false,
 			},
 		};

--- a/crates/pi-natives/src/chunk/ast_js_ts.rs
+++ b/crates/pi-natives/src/chunk/ast_js_ts.rs
@@ -19,7 +19,7 @@ fn recurse_internal_module(node: Node<'_>) -> Option<RecurseSpec<'_>> {
 }
 
 static JSTS_TABLES: ClassifierTables = ClassifierTables {
-	root:                 &[
+	root: &[
 		semantic_rule(
 			"import_statement",
 			ChunkKind::Imports,
@@ -119,7 +119,7 @@ static JSTS_TABLES: ClassifierTables = ClassifierTables {
 			RecurseMode::None,
 		),
 	],
-	class:                &[
+	class: &[
 		semantic_rule(
 			"constructor",
 			ChunkKind::Constructor,
@@ -142,7 +142,7 @@ static JSTS_TABLES: ClassifierTables = ClassifierTables {
 			RecurseMode::None,
 		),
 	],
-	function:             &[],
+	function: &[],
 	structural_overrides: super::classify::StructuralOverrides::EMPTY,
 };
 
@@ -533,13 +533,18 @@ fn classify_export_statement<'t>(
 	let header = normalized_header(source, node.start_byte(), node.end_byte());
 	let is_default = header.starts_with("export default");
 
-	if let Some(candidate) =
-		promote_wrapper_candidate(&JsTsClassifier, context, node, source, WrapperTransform {
+	if let Some(candidate) = promote_wrapper_candidate(
+		&JsTsClassifier,
+		context,
+		node,
+		source,
+		WrapperTransform {
 			kind: is_default.then_some(ChunkKind::DefaultExport),
 			name_style: is_default.then_some(NameStyle::Named),
 			clear_identifier: is_default,
 			..WrapperTransform::default()
-		}) {
+		},
+	) {
 		return candidate;
 	}
 

--- a/crates/pi-natives/src/chunk/ast_just.rs
+++ b/crates/pi-natives/src/chunk/ast_just.rs
@@ -31,15 +31,15 @@ const JUST_FUNCTION_RULES: &[super::classify::SemanticRule] = &[
 ];
 
 const JUST_TABLES: ClassifierTables = ClassifierTables {
-	root:                 &[],
-	class:                &[],
-	function:             JUST_FUNCTION_RULES,
+	root: &[],
+	class: &[],
+	function: JUST_FUNCTION_RULES,
 	structural_overrides: StructuralOverrides {
-		extra_trivia:            &[],
-		preserved_trivia:        &[],
-		extra_root_wrappers:     &["source_file"],
+		extra_trivia: &[],
+		preserved_trivia: &[],
+		extra_root_wrappers: &["source_file"],
 		preserved_root_wrappers: &[],
-		absorbable_attrs:        &[],
+		absorbable_attrs: &[],
 	},
 };
 

--- a/crates/pi-natives/src/chunk/ast_markup.rs
+++ b/crates/pi-natives/src/chunk/ast_markup.rs
@@ -64,9 +64,9 @@ impl MarkupClassifier {
 impl LangClassifier for MarkupClassifier {
 	fn tables(&self) -> &'static ClassifierTables {
 		static TABLES: ClassifierTables = ClassifierTables {
-			root:                 &[],
-			class:                &[],
-			function:             &[],
+			root: &[],
+			class: &[],
+			function: &[],
 			structural_overrides: super::classify::StructuralOverrides::EMPTY,
 		};
 		&TABLES

--- a/crates/pi-natives/src/chunk/ast_misc.rs
+++ b/crates/pi-natives/src/chunk/ast_misc.rs
@@ -923,9 +923,9 @@ const MISC_FUNCTION_RULES: &[super::classify::SemanticRule] = &[
 ];
 
 const MISC_TABLES: ClassifierTables = ClassifierTables {
-	root:                 MISC_ROOT_RULES,
-	class:                MISC_CLASS_RULES,
-	function:             MISC_FUNCTION_RULES,
+	root: MISC_ROOT_RULES,
+	class: MISC_CLASS_RULES,
+	function: MISC_FUNCTION_RULES,
 	structural_overrides: StructuralOverrides::EMPTY,
 };
 
@@ -957,12 +957,12 @@ fn classify_root_override<'t>(node: Node<'t>, source: &str) -> Option<RawChunkCa
 	};
 	let module_recurse = || {
 		recurse_class(node).or_else(|| {
-			recurse_into(node, ChunkContext::ClassBody, &["body"], &[
-				"compound_statement",
-				"statement_block",
-				"declaration_list",
-				"block",
-			])
+			recurse_into(
+				node,
+				ChunkContext::ClassBody,
+				&["body"],
+				&["compound_statement", "statement_block", "declaration_list", "block"],
+			)
 		})
 	};
 	Some(match node.kind() {

--- a/crates/pi-natives/src/chunk/ast_nix_hcl.rs
+++ b/crates/pi-natives/src/chunk/ast_nix_hcl.rs
@@ -11,15 +11,15 @@ use super::{
 pub struct NixHclClassifier;
 
 const NIX_HCL_TABLES: ClassifierTables = ClassifierTables {
-	root:                 &[],
-	class:                &[],
-	function:             &[],
+	root: &[],
+	class: &[],
+	function: &[],
 	structural_overrides: StructuralOverrides {
-		extra_trivia:            &[],
-		preserved_trivia:        &[],
-		extra_root_wrappers:     &["body"],
+		extra_trivia: &[],
+		preserved_trivia: &[],
+		extra_root_wrappers: &["body"],
 		preserved_root_wrappers: &[],
-		absorbable_attrs:        &[],
+		absorbable_attrs: &[],
 	},
 };
 

--- a/crates/pi-natives/src/chunk/ast_ocaml.rs
+++ b/crates/pi-natives/src/chunk/ast_ocaml.rs
@@ -13,9 +13,9 @@ pub struct OcamlClassifier;
 impl LangClassifier for OcamlClassifier {
 	fn tables(&self) -> &'static ClassifierTables {
 		static TABLES: ClassifierTables = ClassifierTables {
-			root:                 &[],
-			class:                &[],
-			function:             &[],
+			root: &[],
+			class: &[],
+			function: &[],
 			structural_overrides: StructuralOverrides::EMPTY,
 		};
 		&TABLES
@@ -209,11 +209,12 @@ fn ocaml_class_type_recurse(node: Node<'_>) -> Option<RecurseSpec<'_>> {
 }
 
 fn ocaml_method_recurse(node: Node<'_>) -> Option<RecurseSpec<'_>> {
-	recurse_into(node, ChunkContext::FunctionBody, &["body"], &[
-		"function_expression",
-		"match_expression",
-		"let_expression",
-	])
+	recurse_into(
+		node,
+		ChunkContext::FunctionBody,
+		&["body"],
+		&["function_expression", "match_expression", "let_expression"],
+	)
 }
 
 fn ocaml_value_recurse(node: Node<'_>) -> Option<RecurseSpec<'_>> {

--- a/crates/pi-natives/src/chunk/ast_perl.rs
+++ b/crates/pi-natives/src/chunk/ast_perl.rs
@@ -45,15 +45,15 @@ const PERL_SHARED_RULES: &[super::classify::SemanticRule] = &[
 ];
 
 const PERL_TABLES: ClassifierTables = ClassifierTables {
-	root:                 PERL_SHARED_RULES,
-	class:                &[],
-	function:             PERL_SHARED_RULES,
+	root: PERL_SHARED_RULES,
+	class: &[],
+	function: PERL_SHARED_RULES,
 	structural_overrides: StructuralOverrides {
-		extra_trivia:            &[],
-		preserved_trivia:        &[],
-		extra_root_wrappers:     &["statement_list"],
+		extra_trivia: &[],
+		preserved_trivia: &[],
+		extra_root_wrappers: &["statement_list"],
 		preserved_root_wrappers: &[],
-		absorbable_attrs:        &[],
+		absorbable_attrs: &[],
 	},
 };
 

--- a/crates/pi-natives/src/chunk/ast_powershell.rs
+++ b/crates/pi-natives/src/chunk/ast_powershell.rs
@@ -14,7 +14,7 @@ use super::{
 pub struct PowershellClassifier;
 
 static POWERSHELL_TABLES: ClassifierTables = ClassifierTables {
-	root:                 &[
+	root: &[
 		semantic_rule(
 			"param_block",
 			ChunkKind::Parameters,
@@ -30,8 +30,8 @@ static POWERSHELL_TABLES: ClassifierTables = ClassifierTables {
 			RecurseMode::None,
 		),
 	],
-	class:                &[],
-	function:             &[
+	class: &[],
+	function: &[
 		semantic_rule(
 			"class_method_parameter_list",
 			ChunkKind::Parameters,
@@ -55,16 +55,11 @@ static POWERSHELL_TABLES: ClassifierTables = ClassifierTables {
 		),
 	],
 	structural_overrides: StructuralOverrides {
-		extra_trivia:            &[
-			"function_name",
-			"simple_name",
-			"type_literal",
-			"switch_condition",
-		],
-		preserved_trivia:        &[],
-		extra_root_wrappers:     &[],
+		extra_trivia: &["function_name", "simple_name", "type_literal", "switch_condition"],
+		preserved_trivia: &[],
+		extra_root_wrappers: &[],
 		preserved_root_wrappers: &[],
-		absorbable_attrs:        &[],
+		absorbable_attrs: &[],
 	},
 };
 
@@ -261,13 +256,11 @@ fn block_kind_for_parent(node: Node<'_>) -> ChunkKind {
 }
 
 fn powershell_name(node: Node<'_>, source: &str) -> Option<String> {
-	find_named_text(node, source, &[
-		"function_name",
-		"simple_name",
-		"member_name",
-		"type_identifier",
-		"variable",
-	])
+	find_named_text(
+		node,
+		source,
+		&["function_name", "simple_name", "member_name", "type_identifier", "variable"],
+	)
 	.and_then(|text| sanitize_identifier(text.trim_start_matches('$')))
 }
 

--- a/crates/pi-natives/src/chunk/ast_proto.rs
+++ b/crates/pi-natives/src/chunk/ast_proto.rs
@@ -57,9 +57,9 @@ const PROTO_CLASS_RULES: &[super::classify::SemanticRule] = &[semantic_rule(
 )];
 
 const PROTO_TABLES: ClassifierTables = ClassifierTables {
-	root:                 PROTO_ROOT_RULES,
-	class:                PROTO_CLASS_RULES,
-	function:             &[],
+	root: PROTO_ROOT_RULES,
+	class: PROTO_CLASS_RULES,
+	function: &[],
 	structural_overrides: super::classify::StructuralOverrides::EMPTY,
 };
 

--- a/crates/pi-natives/src/chunk/ast_python.rs
+++ b/crates/pi-natives/src/chunk/ast_python.rs
@@ -184,9 +184,9 @@ const FUNCTION_RULES: &[super::classify::SemanticRule] = &[
 ];
 
 const PYTHON_TABLES: ClassifierTables = ClassifierTables {
-	root:                 ROOT_RULES,
-	class:                CLASS_RULES,
-	function:             FUNCTION_RULES,
+	root: ROOT_RULES,
+	class: CLASS_RULES,
+	function: FUNCTION_RULES,
 	structural_overrides: super::classify::StructuralOverrides::EMPTY,
 };
 
@@ -203,10 +203,16 @@ impl LangClassifier for PythonClassifier {
 	) -> Option<RawChunkCandidate<'t>> {
 		match context {
 			ChunkContext::Root | ChunkContext::ClassBody if node.kind() == "decorated_definition" => {
-				promote_wrapper_candidate(self, context, node, source, WrapperTransform {
-					signature: WrapperSignature::Wrapper,
-					..WrapperTransform::default()
-				})
+				promote_wrapper_candidate(
+					self,
+					context,
+					node,
+					source,
+					WrapperTransform {
+						signature: WrapperSignature::Wrapper,
+						..WrapperTransform::default()
+					},
+				)
 				.or_else(|| Some(positional_candidate(node, ChunkKind::Block, source)))
 			},
 			ChunkContext::ClassBody if node.kind() == "function_definition" => {

--- a/crates/pi-natives/src/chunk/ast_r.rs
+++ b/crates/pi-natives/src/chunk/ast_r.rs
@@ -11,9 +11,9 @@ use super::{
 pub struct RClassifier;
 
 static R_TABLES: ClassifierTables = ClassifierTables {
-	root:                 &[],
-	class:                &[],
-	function:             &[],
+	root: &[],
+	class: &[],
+	function: &[],
 	structural_overrides: super::classify::StructuralOverrides::EMPTY,
 };
 
@@ -150,9 +150,12 @@ fn is_import_call(node: Node<'_>, source: &str) -> bool {
 }
 
 fn recurse_if(node: Node<'_>) -> Option<RecurseSpec<'_>> {
-	recurse_into(node, ChunkContext::FunctionBody, &["consequence", "alternative"], &[
-		"braced_expression",
-	])
+	recurse_into(
+		node,
+		ChunkContext::FunctionBody,
+		&["consequence", "alternative"],
+		&["braced_expression"],
+	)
 }
 
 fn recurse_loop(node: Node<'_>) -> Option<RecurseSpec<'_>> {

--- a/crates/pi-natives/src/chunk/ast_ruby_lua.rs
+++ b/crates/pi-natives/src/chunk/ast_ruby_lua.rs
@@ -198,15 +198,15 @@ const RUBY_LUA_FUNCTION_RULES: &[super::classify::SemanticRule] = &[
 ];
 
 const RUBY_LUA_TABLES: ClassifierTables = ClassifierTables {
-	root:                 RUBY_LUA_ROOT_RULES,
-	class:                RUBY_LUA_CLASS_RULES,
-	function:             RUBY_LUA_FUNCTION_RULES,
+	root: RUBY_LUA_ROOT_RULES,
+	class: RUBY_LUA_CLASS_RULES,
+	function: RUBY_LUA_FUNCTION_RULES,
 	structural_overrides: StructuralOverrides {
-		extra_trivia:            &[],
-		preserved_trivia:        &[],
-		extra_root_wrappers:     &[],
+		extra_trivia: &[],
+		preserved_trivia: &[],
+		extra_root_wrappers: &[],
 		preserved_root_wrappers: &["module"],
-		absorbable_attrs:        &[],
+		absorbable_attrs: &[],
 	},
 };
 

--- a/crates/pi-natives/src/chunk/ast_rust.rs
+++ b/crates/pi-natives/src/chunk/ast_rust.rs
@@ -225,9 +225,9 @@ const FUNCTION_RULES: &[super::classify::SemanticRule] = &[
 ];
 
 const RUST_TABLES: ClassifierTables = ClassifierTables {
-	root:                 ROOT_RULES,
-	class:                CLASS_RULES,
-	function:             FUNCTION_RULES,
+	root: ROOT_RULES,
+	class: CLASS_RULES,
+	function: FUNCTION_RULES,
 	structural_overrides: StructuralOverrides::EMPTY,
 };
 

--- a/crates/pi-natives/src/chunk/ast_sql.rs
+++ b/crates/pi-natives/src/chunk/ast_sql.rs
@@ -13,15 +13,15 @@ pub struct SqlClassifier;
 impl LangClassifier for SqlClassifier {
 	fn tables(&self) -> &'static ClassifierTables {
 		static TABLES: ClassifierTables = ClassifierTables {
-			root:                 &[],
-			class:                &[],
-			function:             &[],
+			root: &[],
+			class: &[],
+			function: &[],
 			structural_overrides: StructuralOverrides {
-				extra_trivia:            &["empty_statement", "dollar_quote", "keyword_from"],
-				preserved_trivia:        &[],
-				extra_root_wrappers:     &[],
+				extra_trivia: &["empty_statement", "dollar_quote", "keyword_from"],
+				preserved_trivia: &[],
+				extra_root_wrappers: &[],
 				preserved_root_wrappers: &[],
-				absorbable_attrs:        &[],
+				absorbable_attrs: &[],
 			},
 		};
 		&TABLES

--- a/crates/pi-natives/src/chunk/ast_svelte.rs
+++ b/crates/pi-natives/src/chunk/ast_svelte.rs
@@ -14,15 +14,15 @@ pub struct SvelteClassifier;
 impl LangClassifier for SvelteClassifier {
 	fn tables(&self) -> &'static ClassifierTables {
 		static TABLES: ClassifierTables = ClassifierTables {
-			root:                 &[],
-			class:                &[],
-			function:             &[],
+			root: &[],
+			class: &[],
+			function: &[],
 			structural_overrides: StructuralOverrides {
-				extra_trivia:            &[],
-				preserved_trivia:        &[],
-				extra_root_wrappers:     &["document"],
+				extra_trivia: &[],
+				preserved_trivia: &[],
+				extra_root_wrappers: &["document"],
 				preserved_root_wrappers: &[],
-				absorbable_attrs:        &[],
+				absorbable_attrs: &[],
 			},
 		};
 		&TABLES

--- a/crates/pi-natives/src/chunk/ast_tlaplus.rs
+++ b/crates/pi-natives/src/chunk/ast_tlaplus.rs
@@ -26,7 +26,7 @@ pub struct TlaplusClassifier;
 impl LangClassifier for TlaplusClassifier {
 	fn tables(&self) -> &'static ClassifierTables {
 		static TABLES: ClassifierTables = ClassifierTables {
-			root:                 &[
+			root: &[
 				semantic_rule(
 					"variable_declaration",
 					ChunkKind::Declarations,
@@ -49,14 +49,14 @@ impl LangClassifier for TlaplusClassifier {
 					RecurseMode::None,
 				),
 			],
-			class:                &[semantic_rule(
+			class: &[semantic_rule(
 				"pcal_var_decls",
 				ChunkKind::Declarations,
 				RuleStyle::Group,
 				NamingMode::None,
 				RecurseMode::None,
 			)],
-			function:             &[
+			function: &[
 				semantic_rule(
 					"pcal_if",
 					ChunkKind::If,
@@ -94,16 +94,11 @@ impl LangClassifier for TlaplusClassifier {
 				),
 			],
 			structural_overrides: StructuralOverrides {
-				extra_trivia:            &[
-					"header_line",
-					"double_line",
-					"extends",
-					"pcal_algorithm_start",
-				],
-				preserved_trivia:        &["block_comment"],
-				extra_root_wrappers:     &[],
+				extra_trivia: &["header_line", "double_line", "extends", "pcal_algorithm_start"],
+				preserved_trivia: &["block_comment"],
+				extra_root_wrappers: &[],
 				preserved_root_wrappers: &["module"],
-				absorbable_attrs:        &[],
+				absorbable_attrs: &[],
 			},
 		};
 		&TABLES
@@ -274,7 +269,7 @@ fn recurse_child<'tree>(
 #[derive(Clone, Copy)]
 struct TranslationRange {
 	start_line: u32,
-	end_line:   u32,
+	end_line: u32,
 }
 
 fn translation_ranges(source: &str) -> Vec<TranslationRange> {

--- a/crates/pi-natives/src/chunk/ast_vue.rs
+++ b/crates/pi-natives/src/chunk/ast_vue.rs
@@ -14,15 +14,15 @@ pub struct VueClassifier;
 impl LangClassifier for VueClassifier {
 	fn tables(&self) -> &'static ClassifierTables {
 		static TABLES: ClassifierTables = ClassifierTables {
-			root:                 &[],
-			class:                &[],
-			function:             &[],
+			root: &[],
+			class: &[],
+			function: &[],
 			structural_overrides: StructuralOverrides {
-				extra_trivia:            &[],
-				preserved_trivia:        &[],
-				extra_root_wrappers:     &["document"],
+				extra_trivia: &[],
+				preserved_trivia: &[],
+				extra_root_wrappers: &["document"],
 				preserved_root_wrappers: &[],
-				absorbable_attrs:        &[],
+				absorbable_attrs: &[],
 			},
 		};
 		&TABLES

--- a/crates/pi-natives/src/chunk/classify.rs
+++ b/crates/pi-natives/src/chunk/classify.rs
@@ -49,19 +49,19 @@ pub enum WrapperSignature {
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct WrapperTransform {
-	pub kind:             Option<ChunkKind>,
-	pub name_style:       Option<NameStyle>,
+	pub kind: Option<ChunkKind>,
+	pub name_style: Option<NameStyle>,
 	pub clear_identifier: bool,
-	pub signature:        WrapperSignature,
+	pub signature: WrapperSignature,
 }
 
 #[derive(Clone, Copy, Debug)]
 pub struct SemanticRule {
-	pub ts_kind:    &'static str,
+	pub ts_kind: &'static str,
 	pub chunk_kind: ChunkKind,
-	pub style:      RuleStyle,
-	pub naming:     NamingMode,
-	pub recurse:    RecurseMode,
+	pub style: RuleStyle,
+	pub naming: NamingMode,
+	pub recurse: RecurseMode,
 }
 
 pub const fn semantic_rule(
@@ -76,20 +76,20 @@ pub const fn semantic_rule(
 
 #[derive(Clone, Copy, Debug)]
 pub struct StructuralOverrides {
-	pub extra_trivia:            &'static [&'static str],
-	pub preserved_trivia:        &'static [&'static str],
-	pub extra_root_wrappers:     &'static [&'static str],
+	pub extra_trivia: &'static [&'static str],
+	pub preserved_trivia: &'static [&'static str],
+	pub extra_root_wrappers: &'static [&'static str],
 	pub preserved_root_wrappers: &'static [&'static str],
-	pub absorbable_attrs:        &'static [&'static str],
+	pub absorbable_attrs: &'static [&'static str],
 }
 
 impl StructuralOverrides {
 	pub const EMPTY: Self = Self {
-		extra_trivia:            &[],
-		preserved_trivia:        &[],
-		extra_root_wrappers:     &[],
+		extra_trivia: &[],
+		preserved_trivia: &[],
+		extra_root_wrappers: &[],
 		preserved_root_wrappers: &[],
-		absorbable_attrs:        &[],
+		absorbable_attrs: &[],
 	};
 
 	pub fn is_extra_trivia(&self, kind: &str) -> bool {
@@ -115,16 +115,16 @@ impl StructuralOverrides {
 
 #[derive(Clone, Copy, Debug)]
 pub struct ClassifierTables {
-	pub root:                 &'static [SemanticRule],
-	pub class:                &'static [SemanticRule],
-	pub function:             &'static [SemanticRule],
+	pub root: &'static [SemanticRule],
+	pub class: &'static [SemanticRule],
+	pub function: &'static [SemanticRule],
 	pub structural_overrides: StructuralOverrides,
 }
 
 pub const EMPTY_CLASSIFIER_TABLES: ClassifierTables = ClassifierTables {
-	root:                 &[],
-	class:                &[],
-	function:             &[],
+	root: &[],
+	class: &[],
+	function: &[],
 	structural_overrides: StructuralOverrides::EMPTY,
 };
 

--- a/crates/pi-natives/src/chunk/common.rs
+++ b/crates/pi-natives/src/chunk/common.rs
@@ -41,37 +41,37 @@ pub enum NameStyle {
 
 #[derive(Clone, Copy, Debug)]
 pub struct RecurseSpec<'tree> {
-	pub node:    Node<'tree>,
+	pub node: Node<'tree>,
 	pub context: ChunkContext,
 }
 
 #[derive(Clone, Copy, Debug)]
 pub struct InjectedChunkSpec<'tree> {
-	pub language:     SupportLang,
+	pub language: SupportLang,
 	pub content_node: Node<'tree>,
 }
 
 #[derive(Clone, Debug)]
 pub struct RawChunkCandidate<'tree> {
-	pub identifier:          Option<String>,
-	pub kind:                ChunkKind,
-	pub name_style:          NameStyle,
-	pub range_start_byte:    usize,
-	pub range_end_byte:      usize,
+	pub identifier: Option<String>,
+	pub kind: ChunkKind,
+	pub name_style: NameStyle,
+	pub range_start_byte: usize,
+	pub range_end_byte: usize,
 	/// Start byte for `chunk_checksum`; stays at the primary node's start while
 	/// `range_start_byte` may be extended backward to include leading
 	/// attributes/comments.
 	pub checksum_start_byte: usize,
-	pub range_start_line:    usize,
-	pub range_end_line:      usize,
-	pub signature:           Option<String>,
-	pub error:               bool,
-	pub groupable:           bool,
+	pub range_start_line: usize,
+	pub range_end_line: usize,
+	pub signature: Option<String>,
+	pub error: bool,
+	pub groupable: bool,
 	pub has_leading_comment: bool,
-	pub force_recurse:       bool,
-	pub region_node:         Option<Node<'tree>>,
-	pub injected:            Option<InjectedChunkSpec<'tree>>,
-	pub recurse:             Option<RecurseSpec<'tree>>,
+	pub force_recurse: bool,
+	pub region_node: Option<Node<'tree>>,
+	pub injected: Option<InjectedChunkSpec<'tree>>,
+	pub recurse: Option<RecurseSpec<'tree>>,
 }
 
 #[derive(Default)]

--- a/crates/pi-natives/src/chunk/conflict.rs
+++ b/crates/pi-natives/src/chunk/conflict.rs
@@ -11,39 +11,39 @@ use super::{
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ConflictRegion {
-	pub ours_start_line:   usize,
-	pub ours_end_line:     usize,
+	pub ours_start_line: usize,
+	pub ours_end_line: usize,
 	pub theirs_start_line: usize,
-	pub theirs_end_line:   usize,
+	pub theirs_end_line: usize,
 	pub marker_start_line: usize,
-	pub marker_end_line:   usize,
-	pub ours_content:      String,
-	pub theirs_content:    String,
-	pub base_content:      Option<String>,
-	pub base_label:        Option<String>,
-	pub ours_label:        String,
-	pub theirs_label:      String,
+	pub marker_end_line: usize,
+	pub ours_content: String,
+	pub theirs_content: String,
+	pub base_content: Option<String>,
+	pub base_label: Option<String>,
+	pub ours_label: String,
+	pub theirs_label: String,
 }
 
 #[derive(Clone, Debug)]
 pub struct CleanResult {
-	pub source:           String,
-	pub conflicts:        Vec<ConflictRegion>,
+	pub source: String,
+	pub conflicts: Vec<ConflictRegion>,
 	pub ours_byte_ranges: Vec<(usize, usize)>,
 }
 
 #[derive(Clone)]
 struct PendingConflict {
-	path:            Option<String>,
-	parent_path:     Option<String>,
+	path: Option<String>,
+	parent_path: Option<String>,
 	ours_start_byte: usize,
-	ours_end_byte:   usize,
-	ours_content:    String,
-	theirs_content:  String,
-	base_content:    Option<String>,
-	base_label:      Option<String>,
-	ours_label:      String,
-	theirs_label:    String,
+	ours_end_byte: usize,
+	ours_content: String,
+	theirs_content: String,
+	base_content: Option<String>,
+	base_label: Option<String>,
+	ours_label: String,
+	theirs_label: String,
 }
 
 pub fn has_conflict_markers(source: &str) -> bool {
@@ -137,8 +137,8 @@ pub fn detect_conflicts(source: &str) -> Vec<ConflictRegion> {
 pub fn accept_ours(source: &str, conflicts: &[ConflictRegion]) -> CleanResult {
 	if conflicts.is_empty() {
 		return CleanResult {
-			source:           source.to_owned(),
-			conflicts:        Vec::new(),
+			source: source.to_owned(),
+			conflicts: Vec::new(),
 			ours_byte_ranges: Vec::new(),
 		};
 	}
@@ -250,19 +250,19 @@ pub fn reinject_conflict_chunks(
 	let mut pending = conflict_meta
 		.iter()
 		.map(|(path, meta)| PendingConflict {
-			path:            Some(path.clone()),
-			parent_path:     conflict_parent_path(path),
+			path: Some(path.clone()),
+			parent_path: conflict_parent_path(path),
 			ours_start_byte: meta.ours_start_byte,
-			ours_end_byte:   meta.ours_end_byte,
-			ours_content:    source
+			ours_end_byte: meta.ours_end_byte,
+			ours_content: source
 				.get(meta.ours_start_byte..meta.ours_end_byte)
 				.unwrap_or_default()
 				.to_owned(),
-			theirs_content:  meta.theirs_content.clone(),
-			base_content:    meta.base_content.clone(),
-			base_label:      meta.base_label.clone(),
-			ours_label:      meta.ours_label.clone(),
-			theirs_label:    meta.theirs_label.clone(),
+			theirs_content: meta.theirs_content.clone(),
+			base_content: meta.base_content.clone(),
+			base_label: meta.base_label.clone(),
+			ours_label: meta.ours_label.clone(),
+			theirs_label: meta.theirs_label.clone(),
 		})
 		.collect::<Vec<_>>();
 	pending.sort_unstable_by_key(|conflict| conflict.ours_start_byte);
@@ -436,15 +436,18 @@ fn inject_pending_conflicts(
 			pending_conflict.ours_end_byte,
 		);
 
-		conflict_meta.insert(conflict_path, ConflictMeta {
-			theirs_content:  pending_conflict.theirs_content,
-			ours_label:      pending_conflict.ours_label,
-			theirs_label:    pending_conflict.theirs_label,
-			base_content:    pending_conflict.base_content,
-			base_label:      pending_conflict.base_label,
-			ours_start_byte: pending_conflict.ours_start_byte,
-			ours_end_byte:   pending_conflict.ours_end_byte,
-		});
+		conflict_meta.insert(
+			conflict_path,
+			ConflictMeta {
+				theirs_content: pending_conflict.theirs_content,
+				ours_label: pending_conflict.ours_label,
+				theirs_label: pending_conflict.theirs_label,
+				base_content: pending_conflict.base_content,
+				base_label: pending_conflict.base_label,
+				ours_start_byte: pending_conflict.ours_start_byte,
+				ours_end_byte: pending_conflict.ours_end_byte,
+			},
+		);
 	}
 
 	conflict_meta
@@ -670,15 +673,18 @@ fn a() {\n<<<<<<< HEAD\n\treturn foo();\n=======\n\treturn bar();\n>>>>>>> topic
 	fn reconstructs_conflict_markers_from_clean_source() {
 		let clean_source = "fn a() {\n\treturn foo();\n}\n";
 		let mut conflict_meta = HashMap::new();
-		conflict_meta.insert("fn_a.conflict_1".to_owned(), ConflictMeta {
-			theirs_content:  "\treturn bar();\n".to_owned(),
-			ours_label:      "HEAD".to_owned(),
-			theirs_label:    "topic".to_owned(),
-			base_content:    Some("\treturn baz();\n".to_owned()),
-			base_label:      Some("base".to_owned()),
-			ours_start_byte: 9,
-			ours_end_byte:   24,
-		});
+		conflict_meta.insert(
+			"fn_a.conflict_1".to_owned(),
+			ConflictMeta {
+				theirs_content: "\treturn bar();\n".to_owned(),
+				ours_label: "HEAD".to_owned(),
+				theirs_label: "topic".to_owned(),
+				base_content: Some("\treturn baz();\n".to_owned()),
+				base_label: Some("base".to_owned()),
+				ours_start_byte: 9,
+				ours_end_byte: 24,
+			},
+		);
 
 		let reconstructed = reconstruct_markers(clean_source, &conflict_meta);
 		assert_eq!(

--- a/crates/pi-natives/src/chunk/edit.rs
+++ b/crates/pi-natives/src/chunk/edit.rs
@@ -20,10 +20,10 @@ use crate::chunk::{
 
 #[derive(Clone)]
 struct ScheduledEditOperation {
-	operation:          EditOperation,
-	original_index:     usize,
+	operation: EditOperation,
+	original_index: usize,
 	requested_selector: Option<String>,
-	initial_chunk:      Option<ChunkNode>,
+	initial_chunk: Option<ChunkNode>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -37,7 +37,7 @@ enum InsertPosition {
 #[derive(Clone, Copy)]
 struct InsertSpacing {
 	blank_line_before: bool,
-	blank_line_after:  bool,
+	blank_line_after: bool,
 }
 
 #[derive(Clone)]
@@ -48,7 +48,7 @@ struct InsertionPoint {
 
 #[derive(Clone)]
 struct ResolvedEditTarget {
-	chunk:  ChunkNode,
+	chunk: ChunkNode,
 	region: Option<ChunkRegion>,
 }
 
@@ -1761,14 +1761,14 @@ fn compute_insert_spacing(
 			let spaced = markdown_block_spacing || children_want_blank_line_spacing(state, anchor);
 			InsertSpacing {
 				blank_line_before: false,
-				blank_line_after:  spaced && (!anchor.children.is_empty() || has_interior_content),
+				blank_line_after: spaced && (!anchor.children.is_empty() || has_interior_content),
 			}
 		},
 		InsertPosition::LastChild => {
 			let spaced = markdown_block_spacing || children_want_blank_line_spacing(state, anchor);
 			InsertSpacing {
 				blank_line_before: spaced && (!anchor.children.is_empty() || has_interior_content),
-				blank_line_after:  markdown_block_spacing && has_sibling_after(state, anchor),
+				blank_line_after: markdown_block_spacing && has_sibling_after(state, anchor),
 			}
 		},
 		InsertPosition::Before => {
@@ -1778,7 +1778,7 @@ fn compute_insert_spacing(
 				// When the op is `prepend` (container.prepend), omit the trailing
 				// blank line so the content stays adjacent to the chunk and gets
 				// absorbed as leading trivia on tree rebuild.
-				blank_line_after:  !is_prepend_or_append && spaced,
+				blank_line_after: !is_prepend_or_append && spaced,
 			}
 		},
 		InsertPosition::After => {
@@ -1787,7 +1787,7 @@ fn compute_insert_spacing(
 				// When the op is `append` (container.append), omit the leading
 				// blank line so the content stays adjacent to the chunk.
 				blank_line_before: !is_prepend_or_append && spaced,
-				blank_line_after:  has_sibling_after(state, anchor) && spaced,
+				blank_line_after: has_sibling_after(state, anchor) && spaced,
 			}
 		},
 	}
@@ -1908,10 +1908,10 @@ fn display_path_for_file(file_path: &str, cwd: &str) -> String {
 
 /// A parsed unified diff hunk.
 struct DiffHunk {
-	header:    String,
-	lines:     Vec<String>,
+	header: String,
+	lines: Vec<String>,
 	old_start: u32,
-	old_len:   u32,
+	old_len: u32,
 	new_start: u32,
 }
 
@@ -2088,7 +2088,7 @@ fn render_changed_hunks(
 			let anchor_label = deleted_chunk_anchor_label(deleted_chunk, style);
 			let mut lines = Vec::with_capacity(hunk.lines.len() + 2);
 			lines.push(crate::chunk::render::InlineHunkLine {
-				text:   style.render(
+				text: style.render(
 					&anchor_indent,
 					anchor_label.as_str(),
 					deleted_chunk.checksum.as_str(),
@@ -2096,14 +2096,14 @@ fn render_changed_hunks(
 				marker: Some('-'),
 			});
 			lines.push(crate::chunk::render::InlineHunkLine {
-				text:   format!("{diff_indent}{}", hunk.header),
+				text: format!("{diff_indent}{}", hunk.header),
 				marker: None,
 			});
 			for line in &hunk.lines {
 				let normalized =
 					render_hunk_line(line, normalize_indent, file_indent_char, file_indent_step);
 				lines.push(crate::chunk::render::InlineHunkLine {
-					text:   format!("{diff_indent}{normalized}"),
+					text: format!("{diff_indent}{normalized}"),
 					marker: None,
 				});
 			}
@@ -2129,14 +2129,14 @@ fn render_changed_hunks(
 		};
 		let mut lines = Vec::with_capacity(hunk.lines.len() + 1);
 		lines.push(crate::chunk::render::InlineHunkLine {
-			text:   format!("{indent}{}", hunk.header),
+			text: format!("{indent}{}", hunk.header),
 			marker: None,
 		});
 		for line in &hunk.lines {
 			let normalized =
 				render_hunk_line(line, normalize_indent, file_indent_char, file_indent_step);
 			lines.push(crate::chunk::render::InlineHunkLine {
-				text:   format!("{indent}{normalized}"),
+				text: format!("{indent}{normalized}"),
 				marker: None,
 			});
 		}
@@ -2291,19 +2291,22 @@ fn render_error_context(
 	} else {
 		PRESERVED_TAB_REPLACEMENT
 	};
-	let rendered = crate::chunk::render::render_state(state, &RenderParams {
-		chunk_path: Some(String::new()),
-		title: display_path.to_owned(),
-		language_tag: Some(state.language.clone()),
-		visible_range: None,
-		render_children_only: true,
-		omit_checksum: false,
-		anchor_style,
-		show_leaf_preview: true,
-		tab_replacement: Some(tab_replacement.to_owned()),
-		normalize_indent: Some(normalize_indent),
-		focused_paths,
-	});
+	let rendered = crate::chunk::render::render_state(
+		state,
+		&RenderParams {
+			chunk_path: Some(String::new()),
+			title: display_path.to_owned(),
+			language_tag: Some(state.language.clone()),
+			visible_range: None,
+			render_children_only: true,
+			omit_checksum: false,
+			anchor_style,
+			show_leaf_preview: true,
+			tab_replacement: Some(tab_replacement.to_owned()),
+			normalize_indent: Some(normalize_indent),
+			focused_paths,
+		},
+	);
 	format!("\n\nFresh content:\n{rendered}")
 }
 
@@ -2318,19 +2321,22 @@ fn render_unchanged_response(
 	} else {
 		PRESERVED_TAB_REPLACEMENT
 	};
-	crate::chunk::render::render_state(state, &RenderParams {
-		chunk_path: Some(String::new()),
-		title: display_path.to_owned(),
-		language_tag: Some(state.language.clone()),
-		visible_range: None,
-		render_children_only: true,
-		omit_checksum: false,
-		anchor_style,
-		focused_paths: None,
-		show_leaf_preview: true,
-		tab_replacement: Some(tab_replacement.to_owned()),
-		normalize_indent: Some(normalize_indent),
-	})
+	crate::chunk::render::render_state(
+		state,
+		&RenderParams {
+			chunk_path: Some(String::new()),
+			title: display_path.to_owned(),
+			language_tag: Some(state.language.clone()),
+			visible_range: None,
+			render_children_only: true,
+			omit_checksum: false,
+			anchor_style,
+			focused_paths: None,
+			show_leaf_preview: true,
+			tab_replacement: Some(tab_replacement.to_owned()),
+			normalize_indent: Some(normalize_indent),
+		},
+	)
 }
 
 #[cfg(test)]
@@ -2352,15 +2358,18 @@ mod tests {
 		file_path: &str,
 		operation: EditOperation,
 	) -> EditResult {
-		apply_edits(state, &EditParams {
-			operations:       vec![operation],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        file_path.to_owned(),
-			normalize_indent: None,
-		})
+		apply_edits(
+			state,
+			&EditParams {
+				operations: vec![operation],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: file_path.to_owned(),
+				normalize_indent: None,
+			},
+		)
 		.expect("edit should apply")
 	}
 
@@ -2370,22 +2379,25 @@ mod tests {
 		let state = state_for(source, "rust");
 		let chunk = state.inner().chunk("fn_main").expect("fn_main");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Put,
-				sel:     Some("fn_main".to_owned()),
-				crc:     Some(chunk.checksum.clone()),
-				region:  None,
-				content: Some("fn main() {\n        println!(\"new\");\n}".to_owned()),
-				find:    None,
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "test.rs".to_owned(),
-			normalize_indent: None,
-		})
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Put,
+					sel: Some("fn_main".to_owned()),
+					crc: Some(chunk.checksum.clone()),
+					region: None,
+					content: Some("fn main() {\n        println!(\"new\");\n}".to_owned()),
+					find: None,
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "test.rs".to_owned(),
+				normalize_indent: None,
+			},
+		)
 		.expect("edit should apply");
 
 		assert!(
@@ -2415,22 +2427,25 @@ mod tests {
 			.chunk("class_Foo.fn_increm")
 			.expect("fn_increm");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Put,
-				sel:     Some("class_Foo.fn_increm".to_owned()),
-				crc:     Some(chunk.checksum.clone()),
-				region:  Some(ChunkRegion::Body),
-				content: Some("this.value += 2;\n".to_owned()),
-				find:    None,
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "test.ts".to_owned(),
-			normalize_indent: None,
-		})
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Put,
+					sel: Some("class_Foo.fn_increm".to_owned()),
+					crc: Some(chunk.checksum.clone()),
+					region: Some(ChunkRegion::Body),
+					content: Some("this.value += 2;\n".to_owned()),
+					find: None,
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "test.ts".to_owned(),
+				normalize_indent: None,
+			},
+		)
 		.expect("edit should apply");
 
 		// The response text should contain diff hunks with tab-normalized
@@ -2461,14 +2476,18 @@ mod tests {
 		// The chunk range should include the #[napi] attribute.
 		assert_eq!(chunk.start_line, 1, "chunk should start at the attribute line");
 
-		let result = apply_single_edit(&state, "test.rs", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some("fn_close".to_owned()),
-			crc:     Some(chunk.checksum.clone()),
-			region:  None,
-			content: Some("/// doc\n#[napi]\nfn close() {\n    new();\n}".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.rs",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some("fn_close".to_owned()),
+				crc: Some(chunk.checksum.clone()),
+				region: None,
+				content: Some("/// doc\n#[napi]\nfn close() {\n    new();\n}".to_owned()),
+				find: None,
+			},
+		);
 
 		let occurrences = result.diff_after.matches("#[napi]").count();
 		assert_eq!(
@@ -2488,22 +2507,25 @@ mod tests {
 			.chunk("class_Worker.fn_run")
 			.expect("class_Worker.fn_run should exist");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Put,
-				sel:     Some("run".to_owned()),
-				crc:     Some(chunk.checksum.clone()),
-				region:  None,
-				content: Some("run(): void {\n\tconsole.log(\"resolved\");\n}".to_owned()),
-				find:    None,
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "test.ts".to_owned(),
-			normalize_indent: None,
-		})
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Put,
+					sel: Some("run".to_owned()),
+					crc: Some(chunk.checksum.clone()),
+					region: None,
+					content: Some("run(): void {\n\tconsole.log(\"resolved\");\n}".to_owned()),
+					find: None,
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "test.ts".to_owned(),
+				normalize_indent: None,
+			},
+		)
 		.expect("edit should resolve a unique fuzzy selector");
 
 		assert!(
@@ -2528,24 +2550,27 @@ mod tests {
 			.chunk("fn_fuzzyM")
 			.expect("fn_fuzzyM should exist");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Put,
-				sel:     Some("fuzzyM".to_owned()),
-				crc:     Some(chunk.checksum.clone()),
-				region:  None,
-				content: Some(
-					"function fuzzyMatch(): void {\n\tconsole.log(\"resolved\");\n}".to_owned(),
-				),
-				find:    None,
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "box.ts".to_owned(),
-			normalize_indent: None,
-		})
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Put,
+					sel: Some("fuzzyM".to_owned()),
+					crc: Some(chunk.checksum.clone()),
+					region: None,
+					content: Some(
+						"function fuzzyMatch(): void {\n\tconsole.log(\"resolved\");\n}".to_owned(),
+					),
+					find: None,
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "box.ts".to_owned(),
+				normalize_indent: None,
+			},
+		)
 		.expect("edit should resolve a prefixed bare selector");
 
 		assert!(result.diff_after.contains("console.log(\"resolved\");"), "{}", result.diff_after);
@@ -2563,22 +2588,27 @@ mod tests {
 			.chunk("fn_main")
 			.expect("fn_main should exist");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Put,
-				sel:     Some("box.ts".to_owned()),
-				crc:     Some(chunk.checksum.clone()),
-				region:  None,
-				content: Some("function main(): void {\n\tconsole.log(\"normalized\");\n}".to_owned()),
-				find:    None,
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "box.ts".to_owned(),
-			normalize_indent: None,
-		})
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Put,
+					sel: Some("box.ts".to_owned()),
+					crc: Some(chunk.checksum.clone()),
+					region: None,
+					content: Some(
+						"function main(): void {\n\tconsole.log(\"normalized\");\n}".to_owned(),
+					),
+					find: None,
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "box.ts".to_owned(),
+				normalize_indent: None,
+			},
+		)
 		.expect("edit should resolve file-prefixed checksum target");
 
 		assert!(result.diff_after.contains("console.log(\"normalized\");"), "{}", result.diff_after);
@@ -2591,22 +2621,25 @@ mod tests {
 		let chunk = state.inner().chunk("fn_main").expect("fn_main");
 
 		// L2 falls inside fn_main — should auto-resolve and apply the edit.
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Put,
-				sel:     Some(format!("L2#{}", chunk.checksum)),
-				crc:     None,
-				region:  None,
-				content: Some("function main(): void {\n\tconsole.log(\"new\");\n}".to_owned()),
-				find:    None,
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "box.ts".to_owned(),
-			normalize_indent: None,
-		});
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Put,
+					sel: Some(format!("L2#{}", chunk.checksum)),
+					crc: None,
+					region: None,
+					content: Some("function main(): void {\n\tconsole.log(\"new\");\n}".to_owned()),
+					find: None,
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "box.ts".to_owned(),
+				normalize_indent: None,
+			},
+		);
 
 		let result = result.expect("line-number selector should auto-resolve");
 		assert!(
@@ -2630,22 +2663,25 @@ mod tests {
 		let state = state_for(source, "typescript");
 
 		// L999 is way beyond the file — should fail.
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Put,
-				sel:     Some("L999".to_owned()),
-				crc:     None,
-				region:  None,
-				content: Some("// hello".to_owned()),
-				find:    None,
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "box.ts".to_owned(),
-			normalize_indent: None,
-		});
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Put,
+					sel: Some("L999".to_owned()),
+					crc: None,
+					region: None,
+					content: Some("// hello".to_owned()),
+					find: None,
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "box.ts".to_owned(),
+				normalize_indent: None,
+			},
+		);
 
 		assert!(result.is_err(), "line outside any chunk should fail");
 		let err = result.err().unwrap();
@@ -2661,22 +2697,25 @@ mod tests {
 			.chunk("sect_Top.sect_Buildi")
 			.expect("sect_Buildi");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Put,
-				sel:     Some("sect_Top.sect_Buildi".to_owned()),
-				crc:     Some(chunk.checksum.clone()),
-				region:  None,
-				content: Some("## Building\n\nNew content.\n".to_owned()),
-				find:    None,
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "test.md".to_owned(),
-			normalize_indent: None,
-		})
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Put,
+					sel: Some("sect_Top.sect_Buildi".to_owned()),
+					crc: Some(chunk.checksum.clone()),
+					region: None,
+					content: Some("## Building\n\nNew content.\n".to_owned()),
+					find: None,
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "test.md".to_owned(),
+				normalize_indent: None,
+			},
+		)
 		.expect("replace should succeed");
 
 		assert!(
@@ -2697,22 +2736,25 @@ mod tests {
 		let state = state_for(source, "rust");
 		let chunk = state.inner().chunk("fn_main").expect("fn_main");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Replace,
-				sel:     Some("fn_main".to_owned()),
-				crc:     Some(chunk.checksum.clone()),
-				region:  None,
-				content: Some("warn!(\"hello\")".to_owned()),
-				find:    Some("println!(\"hello\")".to_owned()),
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "test.rs".to_owned(),
-			normalize_indent: None,
-		})
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Replace,
+					sel: Some("fn_main".to_owned()),
+					crc: Some(chunk.checksum.clone()),
+					region: None,
+					content: Some("warn!(\"hello\")".to_owned()),
+					find: Some("println!(\"hello\")".to_owned()),
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "test.rs".to_owned(),
+				normalize_indent: None,
+			},
+		)
 		.expect("edit should apply");
 
 		assert!(
@@ -2733,22 +2775,25 @@ mod tests {
 		let state = state_for(source, "rust");
 		let chunk = state.inner().chunk("fn_main").expect("fn_main");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Replace,
-				sel:     Some("fn_main".to_owned()),
-				crc:     Some(chunk.checksum.clone()),
-				region:  None,
-				content: Some("replacement".to_owned()),
-				find:    Some("nonexistent text".to_owned()),
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "test.rs".to_owned(),
-			normalize_indent: None,
-		});
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Replace,
+					sel: Some("fn_main".to_owned()),
+					crc: Some(chunk.checksum.clone()),
+					region: None,
+					content: Some("replacement".to_owned()),
+					find: Some("nonexistent text".to_owned()),
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "test.rs".to_owned(),
+				normalize_indent: None,
+			},
+		);
 
 		assert!(result.is_err(), "expected error for not-found find text");
 		assert!(
@@ -2766,22 +2811,25 @@ mod tests {
 		let state = state_for(source, "rust");
 		let chunk = state.inner().chunk("fn_main").expect("fn_main");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Replace,
-				sel:     Some("fn_main".to_owned()),
-				crc:     Some(chunk.checksum.clone()),
-				region:  None,
-				content: Some("2".to_owned()),
-				find:    Some("= 1".to_owned()),
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "test.rs".to_owned(),
-			normalize_indent: None,
-		});
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Replace,
+					sel: Some("fn_main".to_owned()),
+					crc: Some(chunk.checksum.clone()),
+					region: None,
+					content: Some("2".to_owned()),
+					find: Some("= 1".to_owned()),
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "test.rs".to_owned(),
+				normalize_indent: None,
+			},
+		);
 
 		assert!(result.is_err(), "expected error for ambiguous find text");
 		let err = result.err().expect("err");
@@ -2795,22 +2843,25 @@ mod tests {
 		let state = state_for(source, "rust");
 		let chunk = state.inner().chunk("fn_main").expect("fn_main");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Replace,
-				sel:     Some("fn_main".to_owned()),
-				crc:     Some(chunk.checksum.clone()),
-				region:  None,
-				content: Some("replacement".to_owned()),
-				find:    Some(String::new()),
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "test.rs".to_owned(),
-			normalize_indent: None,
-		});
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Replace,
+					sel: Some("fn_main".to_owned()),
+					crc: Some(chunk.checksum.clone()),
+					region: None,
+					content: Some("replacement".to_owned()),
+					find: Some(String::new()),
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "test.rs".to_owned(),
+				normalize_indent: None,
+			},
+		);
 
 		assert!(result.is_err(), "expected error for empty find text");
 		assert!(result.err().expect("err").contains("cannot be empty"), "error should mention empty");
@@ -2824,22 +2875,25 @@ mod tests {
 		let state = state_for(source, "rust");
 		let chunk = state.inner().chunk("fn_main").expect("fn_main");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Replace,
-				sel:     Some("fn_main".to_owned()),
-				crc:     Some(chunk.checksum.clone()),
-				region:  None,
-				content: Some("goodbye".to_owned()),
-				find:    Some("hello".to_owned()),
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "test.rs".to_owned(),
-			normalize_indent: None,
-		});
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Replace,
+					sel: Some("fn_main".to_owned()),
+					crc: Some(chunk.checksum.clone()),
+					region: None,
+					content: Some("goodbye".to_owned()),
+					find: Some("hello".to_owned()),
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "test.rs".to_owned(),
+				normalize_indent: None,
+			},
+		);
 
 		assert!(result.is_err(), "find outside target chunk should fail");
 		assert!(
@@ -2856,22 +2910,25 @@ mod tests {
 		let state = state_for(source, "typescript");
 		let chunk = state.inner().chunk("var_c").expect("var_c");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Put,
-				sel:     Some("var_c".to_owned()),
-				crc:     Some(chunk.checksum.clone()),
-				region:  None,
-				content: Some("const c = 33;".to_owned()),
-				find:    None,
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     Some(ChunkAnchorStyle::Full),
-			cwd:              ".".to_owned(),
-			file_path:        "test.ts".to_owned(),
-			normalize_indent: None,
-		})
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Put,
+					sel: Some("var_c".to_owned()),
+					crc: Some(chunk.checksum.clone()),
+					region: None,
+					content: Some("const c = 33;".to_owned()),
+					find: None,
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: Some(ChunkAnchorStyle::Full),
+				cwd: ".".to_owned(),
+				file_path: "test.ts".to_owned(),
+				normalize_indent: None,
+			},
+		)
 		.expect("edit should apply");
 
 		// The focused edit view should show only the changed chunk chain, not
@@ -2924,24 +2981,27 @@ mod tests {
 		let state = parsed_state_for(source, "rust");
 		let alpha = state.inner().chunk("fn_alpha").expect("fn_alpha");
 
-		let Err(err) = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Put,
-				sel:     Some("fn_alpha".to_owned()),
-				crc:     Some(alpha.checksum.clone()),
-				region:  Some(ChunkRegion::Body),
-				// Intentionally broken: dangling `{` consumes subsequent
-				// top-level functions until tree-sitter gives up.
-				content: Some("let broken = { { {\n".to_owned()),
-				find:    None,
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     Some(ChunkAnchorStyle::Full),
-			cwd:              ".".to_owned(),
-			file_path:        "test.rs".to_owned(),
-			normalize_indent: None,
-		}) else {
+		let Err(err) = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Put,
+					sel: Some("fn_alpha".to_owned()),
+					crc: Some(alpha.checksum.clone()),
+					region: Some(ChunkRegion::Body),
+					// Intentionally broken: dangling `{` consumes subsequent
+					// top-level functions until tree-sitter gives up.
+					content: Some("let broken = { { {\n".to_owned()),
+					find: None,
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: Some(ChunkAnchorStyle::Full),
+				cwd: ".".to_owned(),
+				file_path: "test.rs".to_owned(),
+				normalize_indent: None,
+			},
+		) else {
 			panic!("edit should be rejected due to parse error");
 		};
 
@@ -2980,14 +3040,18 @@ mod tests {
 			.expect("stmts chunk should exist");
 		assert!(stmts.group, "stmts chunk should be marked as group");
 
-		let result = apply_single_edit(&state, "test.ts", EditOperation {
-			op:      ChunkEditOp::Append,
-			sel:     Some(stmts.path.clone()),
-			crc:     None,
-			region:  None,
-			content: Some("\nconsole.log(\"c\");".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.ts",
+			EditOperation {
+				op: ChunkEditOp::Append,
+				sel: Some(stmts.path.clone()),
+				crc: None,
+				region: None,
+				content: Some("\nconsole.log(\"c\");".to_owned()),
+				find: None,
+			},
+		);
 
 		assert!(
 			result.diff_after.contains("log(\"c\""),
@@ -3009,14 +3073,18 @@ mod tests {
 		let state = state_for(source, "typescript");
 		let chunk = state.inner().chunk("fn_main").expect("fn_main");
 
-		let result = apply_single_edit(&state, "test.ts", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("fn_main#{}~", chunk.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("\treturn next();\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.ts",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("fn_main#{}~", chunk.checksum)),
+				crc: None,
+				region: None,
+				content: Some("\treturn next();\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert_eq!(result.diff_after, "function main() {\n    return next();\n}\n");
 	}
@@ -3027,14 +3095,18 @@ mod tests {
 		let state = state_for(source, "rust");
 		let chunk = state.inner().chunk("fn_main").expect("fn_main");
 
-		let result = apply_single_edit(&state, "test.rs", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("fn_main#{}~", chunk.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("\tprintln!(\"new\");\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.rs",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("fn_main#{}~", chunk.checksum)),
+				crc: None,
+				region: None,
+				content: Some("\tprintln!(\"new\");\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert_eq!(result.diff_after, "fn main() {\n    println!(\"new\");\n}\n");
 	}
@@ -3045,14 +3117,18 @@ mod tests {
 		let state = state_for(source, "go");
 		let chunk = state.inner().chunk("fn_main").expect("fn_main");
 
-		let result = apply_single_edit(&state, "test.go", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("fn_main#{}~", chunk.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("\treturn\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.go",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("fn_main#{}~", chunk.checksum)),
+				crc: None,
+				region: None,
+				content: Some("\treturn\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert_eq!(result.diff_after, "func main() {\n    return\n}\n");
 	}
@@ -3063,14 +3139,18 @@ mod tests {
 		let state = state_for(source, "python");
 		let chunk = state.inner().chunk("fn_run").expect("fn_run");
 
-		let result = apply_single_edit(&state, "test.py", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("fn_run#{}~", chunk.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("\treturn 2\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.py",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("fn_run#{}~", chunk.checksum)),
+				crc: None,
+				region: None,
+				content: Some("\treturn 2\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert_eq!(result.diff_after, "def run():\n   return 2\n");
 	}
@@ -3080,14 +3160,18 @@ mod tests {
 		let source = "function alpha(): void {\n\twork();\n}\n";
 		let state = state_for(source, "typescript");
 
-		let result = apply_single_edit(&state, "test.ts", EditOperation {
-			op:      ChunkEditOp::After,
-			sel:     Some("fn_alpha".to_owned()),
-			crc:     None,
-			region:  None,
-			content: Some("function beta(): void {\n\twork();\n}\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.ts",
+			EditOperation {
+				op: ChunkEditOp::After,
+				sel: Some("fn_alpha".to_owned()),
+				crc: None,
+				region: None,
+				content: Some("function beta(): void {\n\twork();\n}\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert!(result.diff_after.contains("function alpha(): void"), "{}", result.diff_after);
 		assert!(result.diff_after.contains("function beta(): void"), "{}", result.diff_after);
@@ -3109,14 +3193,18 @@ mod tests {
 		              Start() {\n    work()\n}\n";
 
 		let body_state = state_for(source, "go");
-		let body_result = apply_single_edit(&body_state, "test.go", EditOperation {
-			op:      ChunkEditOp::Append,
-			sel:     Some("type_Server~".to_owned()),
-			crc:     None,
-			region:  None,
-			content: Some("\tPort int\n".to_owned()),
-			find:    None,
-		});
+		let body_result = apply_single_edit(
+			&body_state,
+			"test.go",
+			EditOperation {
+				op: ChunkEditOp::Append,
+				sel: Some("type_Server~".to_owned()),
+				crc: None,
+				region: None,
+				content: Some("\tPort int\n".to_owned()),
+				find: None,
+			},
+		);
 		assert!(
 			body_result
 				.diff_after
@@ -3131,14 +3219,18 @@ mod tests {
 		);
 
 		let container_state = state_for(source, "go");
-		let container_result = apply_single_edit(&container_state, "test.go", EditOperation {
-			op:      ChunkEditOp::Append,
-			sel:     Some("type_Server".to_owned()),
-			crc:     None,
-			region:  None,
-			content: Some("func (s *Server) Stop() {\n\twork()\n}\n".to_owned()),
-			find:    None,
-		});
+		let container_result = apply_single_edit(
+			&container_state,
+			"test.go",
+			EditOperation {
+				op: ChunkEditOp::Append,
+				sel: Some("type_Server".to_owned()),
+				crc: None,
+				region: None,
+				content: Some("func (s *Server) Stop() {\n\twork()\n}\n".to_owned()),
+				find: None,
+			},
+		);
 		assert!(
 			container_result
 				.diff_after
@@ -3171,14 +3263,18 @@ mod tests {
 		              *Server) Stop() {}\n";
 		let state = state_for(source, "go");
 
-		let result = apply_single_edit(&state, "test.go", EditOperation {
-			op:      ChunkEditOp::Append,
-			sel:     Some("type_Server".to_owned()),
-			crc:     None,
-			region:  None,
-			content: Some("func (s *Server) Restart() {}".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.go",
+			EditOperation {
+				op: ChunkEditOp::Append,
+				sel: Some("type_Server".to_owned()),
+				crc: None,
+				region: None,
+				content: Some("func (s *Server) Restart() {}".to_owned()),
+				find: None,
+			},
+		);
 
 		assert!(
 			result
@@ -3197,14 +3293,18 @@ mod tests {
 		              true\ntokio.workspace = true\ntracing.workspace = true\n";
 		let state = state_for(source, "toml");
 
-		let result = apply_single_edit(&state, "Cargo.toml", EditOperation {
-			op:      ChunkEditOp::After,
-			sel:     Some("table_depend.key_parkin".to_owned()),
-			crc:     None,
-			region:  None,
-			content: Some("rayon.workspace = true\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"Cargo.toml",
+			EditOperation {
+				op: ChunkEditOp::After,
+				sel: Some("table_depend.key_parkin".to_owned()),
+				crc: None,
+				region: None,
+				content: Some("rayon.workspace = true\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert!(
 			result.diff_after.contains(
@@ -3234,14 +3334,18 @@ mod tests {
 		let source = "const a = 1;\nconst b = 2;\nconst c = 3;\n";
 		let state = state_for(source, "typescript");
 
-		let result = apply_single_edit(&state, "test.ts", EditOperation {
-			op:      ChunkEditOp::After,
-			sel:     Some("var_b".to_owned()),
-			crc:     None,
-			region:  None,
-			content: Some("const bb = 22;\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.ts",
+			EditOperation {
+				op: ChunkEditOp::After,
+				sel: Some("var_b".to_owned()),
+				crc: None,
+				region: None,
+				content: Some("const bb = 22;\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert!(
 			result
@@ -3267,22 +3371,25 @@ mod tests {
 		let source = "class Foo {\n    bar() {\n        return 1;\n    }\n}\n";
 		let state = state_for(source, "typescript");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Put,
-				sel:     Some("class_Foo.fn_bar#ZZZZ".to_owned()),
-				crc:     None,
-				region:  None,
-				content: Some("baz() { return 2; }".to_owned()),
-				find:    None,
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     Some(ChunkAnchorStyle::Full),
-			cwd:              ".".to_owned(),
-			file_path:        "test.ts".to_owned(),
-			normalize_indent: None,
-		});
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Put,
+					sel: Some("class_Foo.fn_bar#ZZZZ".to_owned()),
+					crc: None,
+					region: None,
+					content: Some("baz() { return 2; }".to_owned()),
+					find: None,
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: Some(ChunkAnchorStyle::Full),
+				cwd: ".".to_owned(),
+				file_path: "test.ts".to_owned(),
+				normalize_indent: None,
+			},
+		);
 		let err = result.err().expect("should fail with stale CRC");
 
 		assert!(err.contains("Fresh content:"), "error should include fresh content: {err}");
@@ -3296,14 +3403,18 @@ mod tests {
 		let state = state_for(source, "rust");
 		let chunk = state.inner().chunk("fn_main").expect("fn_main");
 
-		let result = apply_single_edit(&state, "test.rs", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("fn_main#{}^", chunk.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("/// New doc.\nfn main() {".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.rs",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("fn_main#{}^", chunk.checksum)),
+				crc: None,
+				region: None,
+				content: Some("/// New doc.\nfn main() {".to_owned()),
+				find: None,
+			},
+		);
 
 		// The body should NOT be joined onto the prologue line.
 		assert!(
@@ -3332,14 +3443,18 @@ mod tests {
 		let source = "const a = 1;\n\nstruct Config {\n    host: String,\n}\n";
 		let state = state_for(source, "rust");
 
-		let result = apply_single_edit(&state, "test.rs", EditOperation {
-			op:      ChunkEditOp::Prepend,
-			sel:     Some("struct_Config".to_owned()),
-			crc:     None,
-			region:  None,
-			content: Some("// Config documentation\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.rs",
+			EditOperation {
+				op: ChunkEditOp::Prepend,
+				sel: Some("struct_Config".to_owned()),
+				crc: None,
+				region: None,
+				content: Some("// Config documentation\n".to_owned()),
+				find: None,
+			},
+		);
 
 		// The comment should exist in the output.
 		assert!(
@@ -3401,14 +3516,18 @@ mod tests {
 			.chunk("class_Server.fn_start")
 			.expect("fn_start");
 
-		let result = apply_single_edit(&state, "test.ts", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("class_Server.fn_start#{}~", chunk.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("\treturn 42;\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.ts",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("class_Server.fn_start#{}~", chunk.checksum)),
+				crc: None,
+				region: None,
+				content: Some("\treturn 42;\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert_eq!(
 			result.diff_after, "class Server {\n    start() {\n        return 42;\n    }\n}\n",
@@ -3426,14 +3545,18 @@ mod tests {
 			.chunk("class_Server.fn_start")
 			.expect("fn_start");
 
-		let result = apply_single_edit(&state, "test.ts", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("class_Server.fn_start#{}~", chunk.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("\treturn 42;\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.ts",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("class_Server.fn_start#{}~", chunk.checksum)),
+				crc: None,
+				region: None,
+				content: Some("\treturn 42;\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert_eq!(
 			result.diff_after, "class Server {\n  start() {\n    return 42;\n  }\n}\n",
@@ -3452,14 +3575,18 @@ mod tests {
 			.chunk("class_Server.fn_start")
 			.expect("fn_start");
 
-		let result = apply_single_edit(&state, "test.ts", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("class_Server.fn_start#{}~", chunk.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("\t\tif (x) {\n\t\t\ty();\n\t\t}\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.ts",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("class_Server.fn_start#{}~", chunk.checksum)),
+				crc: None,
+				region: None,
+				content: Some("\t\tif (x) {\n\t\t\ty();\n\t\t}\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert_eq!(
 			result.diff_after,
@@ -3475,14 +3602,18 @@ mod tests {
 		let source = "class Foo {\n    bar() {\n        return 1;\n    }\n}\n";
 		let state = state_for(source, "typescript");
 
-		let result = apply_single_edit(&state, "test.ts", EditOperation {
-			op:      ChunkEditOp::Append,
-			sel:     Some("class_Foo~".to_owned()),
-			crc:     None,
-			region:  None,
-			content: Some("baz() {\n\treturn 2;\n}\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.ts",
+			EditOperation {
+				op: ChunkEditOp::Append,
+				sel: Some("class_Foo~".to_owned()),
+				crc: None,
+				region: None,
+				content: Some("baz() {\n\treturn 2;\n}\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert!(
 			result.diff_after.contains("baz()"),
@@ -3506,14 +3637,18 @@ mod tests {
 		let source = "/** My enum. */\nenum Color {\n    Red,\n    Green,\n    Blue,\n}\n";
 		let state = state_for(source, "typescript");
 
-		let result = apply_single_edit(&state, "test.ts", EditOperation {
-			op:      ChunkEditOp::Prepend,
-			sel:     Some("enum_Color~".to_owned()),
-			crc:     None,
-			region:  None,
-			content: Some("White,\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.ts",
+			EditOperation {
+				op: ChunkEditOp::Prepend,
+				sel: Some("enum_Color~".to_owned()),
+				crc: None,
+				region: None,
+				content: Some("White,\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert!(
 			result.diff_after.contains("White"),
@@ -3545,14 +3680,18 @@ mod tests {
 			})
 			.expect("list chunk");
 
-		let result = apply_single_edit(&state, "test.md", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("{}#{}", list.path, list.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("- new 1\n- new 2\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.md",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("{}#{}", list.path, list.checksum)),
+				crc: None,
+				region: None,
+				content: Some("- new 1\n- new 2\n".to_owned()),
+				find: None,
+			},
+		);
 
 		// The blank line between the list and ## Next must be preserved.
 		assert!(
@@ -3571,14 +3710,18 @@ mod tests {
 			.chunk("sect_Title.sect_Alpha")
 			.expect("alpha section");
 
-		let result = apply_single_edit(&state, "test.md", EditOperation {
-			op:      ChunkEditOp::After,
-			sel:     Some(format!("{}#{}", section.path, section.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("## Inserted\n\ninserted body\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.md",
+			EditOperation {
+				op: ChunkEditOp::After,
+				sel: Some(format!("{}#{}", section.path, section.checksum)),
+				crc: None,
+				region: None,
+				content: Some("## Inserted\n\ninserted body\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert!(
 			result
@@ -3598,14 +3741,18 @@ mod tests {
 			.chunk("sect_Title.sect_Alpha")
 			.expect("alpha section");
 
-		let result = apply_single_edit(&state, "test.md", EditOperation {
-			op:      ChunkEditOp::Append,
-			sel:     Some(format!("{}#{}~", section.path, section.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("\nextra paragraph\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.md",
+			EditOperation {
+				op: ChunkEditOp::Append,
+				sel: Some(format!("{}#{}~", section.path, section.checksum)),
+				crc: None,
+				region: None,
+				content: Some("\nextra paragraph\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert!(
 			result
@@ -3644,14 +3791,18 @@ mod tests {
 		              start(self):\n        pass\n";
 		let state = state_for(source, "python");
 
-		let result = apply_single_edit(&state, "test.py", EditOperation {
-			op:      ChunkEditOp::Append,
-			sel:     Some("class_Server~".to_owned()),
-			crc:     None,
-			region:  None,
-			content: Some("def stop(self):\n\tpass\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.py",
+			EditOperation {
+				op: ChunkEditOp::Append,
+				sel: Some("class_Server~".to_owned()),
+				crc: None,
+				region: None,
+				content: Some("def stop(self):\n\tpass\n".to_owned()),
+				find: None,
+			},
+		);
 
 		// The appended method should be at 4-space indent (class member level),
 		// with its body at 8-space indent.
@@ -3676,22 +3827,25 @@ mod tests {
 
 		for region_suffix in ["~", "^"] {
 			let sel = format!("enum_LogLev.vrnt_Info#{}{}", chunk.checksum, region_suffix);
-			let result = apply_edits(&state, &EditParams {
-				operations:       vec![EditOperation {
-					op:      ChunkEditOp::Put,
-					sel:     Some(sel),
-					crc:     None,
-					region:  None,
-					content: Some("Error,".to_owned()),
-					find:    None,
-				}],
-				default_selector: None,
-				default_crc:      None,
-				anchor_style:     None,
-				cwd:              ".".to_owned(),
-				file_path:        "test.rs".to_owned(),
-				normalize_indent: None,
-			})
+			let result = apply_edits(
+				&state,
+				&EditParams {
+					operations: vec![EditOperation {
+						op: ChunkEditOp::Put,
+						sel: Some(sel),
+						crc: None,
+						region: None,
+						content: Some("Error,".to_owned()),
+						find: None,
+					}],
+					default_selector: None,
+					default_crc: None,
+					anchor_style: None,
+					cwd: ".".to_owned(),
+					file_path: "test.rs".to_owned(),
+					normalize_indent: None,
+				},
+			)
 			.expect("leaf region should fall back to full chunk");
 
 			assert!(
@@ -3742,16 +3896,21 @@ mod tests {
 			chunk.epilogue_start_byte,
 		);
 
-		let result = apply_single_edit(&state, "test.rs", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("impl_Server.fn_start#{}^", chunk.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some(
-				"    /// Initializes and starts the server.\n    pub fn start(&mut self) {".to_owned(),
-			),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.rs",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("impl_Server.fn_start#{}^", chunk.checksum)),
+				crc: None,
+				region: None,
+				content: Some(
+					"    /// Initializes and starts the server.\n    pub fn start(&mut self) {"
+						.to_owned(),
+				),
+				find: None,
+			},
+		);
 
 		let body_count = result.diff_after.matches("self.running = true;").count();
 		assert_eq!(
@@ -3801,14 +3960,18 @@ mod tests {
 			.expect("class_Server.fn_start should exist");
 		assert!(chunk.prologue_end_byte.is_some(), "fn_start should have prologue_end_byte");
 
-		let result = apply_single_edit(&state, "test.ts", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("class_Server.fn_start#{}^", chunk.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("    /** Initializes the server. */\n    start() {".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.ts",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("class_Server.fn_start#{}^", chunk.checksum)),
+				crc: None,
+				region: None,
+				content: Some("    /** Initializes the server. */\n    start() {".to_owned()),
+				find: None,
+			},
+		);
 
 		let body_count = result.diff_after.matches("this.running = true;").count();
 		assert_eq!(
@@ -3832,14 +3995,18 @@ mod tests {
 		let state = state_for(source, "python");
 		let chunk = state.inner().chunk("fn_main").expect("fn_main");
 
-		let result = apply_single_edit(&state, "test.py", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("fn_main#{}~", chunk.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("y = 2\nprint(y)\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.py",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("fn_main#{}~", chunk.checksum)),
+				crc: None,
+				region: None,
+				content: Some("y = 2\nprint(y)\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert!(
 			result.diff_after.contains("import os"),
@@ -3883,14 +4050,18 @@ mod tests {
 			.chunk("class_Server.fn_start")
 			.expect("fn_start");
 
-		let result = apply_single_edit(&state, "test.py", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("class_Server.fn_start#{}^", chunk.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("def begin(self) -> None:\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.py",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("class_Server.fn_start#{}^", chunk.checksum)),
+				crc: None,
+				region: None,
+				content: Some("def begin(self) -> None:\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert!(
 			result.diff_after.contains("def begin"),
@@ -3909,14 +4080,18 @@ mod tests {
 		let source = "def main():\n    x = 1\n    print(x)\n";
 		let state = state_for(source, "python");
 
-		let result = apply_single_edit(&state, "test.py", EditOperation {
-			op:      ChunkEditOp::Prepend,
-			sel:     Some("fn_main~".to_owned()),
-			crc:     None,
-			region:  None,
-			content: Some("y = 0\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.py",
+			EditOperation {
+				op: ChunkEditOp::Prepend,
+				sel: Some("fn_main~".to_owned()),
+				crc: None,
+				region: None,
+				content: Some("y = 0\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert!(
 			result.diff_after.contains("y = 0"),
@@ -3943,14 +4118,18 @@ mod tests {
 		let state = state_for(source, "python");
 		let chunk = state.inner().chunk("class_Server").expect("class_Server");
 
-		let result = apply_single_edit(&state, "test.py", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("class_Server#{}~", chunk.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some("def run(self):\n\tpass\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.py",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("class_Server#{}~", chunk.checksum)),
+				crc: None,
+				region: None,
+				content: Some("def run(self):\n\tpass\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert!(
 			result.diff_after.contains("class Server:"),
@@ -3992,14 +4171,18 @@ mod tests {
 		);
 
 		// Replace the function WITHOUT including #[test] in the content.
-		let result = apply_single_edit(&state, "test.rs", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some("mod_tests.fn_my_tes".to_owned()),
-			crc:     Some(chunk.checksum.clone()),
-			region:  None,
-			content: Some("fn my_test() {\n\tnew();\n}".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.rs",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some("mod_tests.fn_my_tes".to_owned()),
+				crc: Some(chunk.checksum.clone()),
+				region: None,
+				content: Some("fn my_test() {\n\tnew();\n}".to_owned()),
+				find: None,
+			},
+		);
 
 		// #[test] is dropped because the replacement didn't include it.
 		assert!(
@@ -4010,19 +4193,22 @@ mod tests {
 
 		// Verify the read output shows #[test] as part of the chunk's content
 		// so the LLM can see it needs to be included.
-		let read_output = crate::chunk::render::render_state(state.inner(), &RenderParams {
-			chunk_path:           Some(String::new()),
-			title:                "test.rs".to_owned(),
-			language_tag:         Some("rust".to_owned()),
-			visible_range:        None,
-			render_children_only: true,
-			omit_checksum:        true,
-			anchor_style:         Some(ChunkAnchorStyle::Full),
-			show_leaf_preview:    true,
-			tab_replacement:      Some("    ".to_owned()),
-			normalize_indent:     Some(true),
-			focused_paths:        None,
-		});
+		let read_output = crate::chunk::render::render_state(
+			state.inner(),
+			&RenderParams {
+				chunk_path: Some(String::new()),
+				title: "test.rs".to_owned(),
+				language_tag: Some("rust".to_owned()),
+				visible_range: None,
+				render_children_only: true,
+				omit_checksum: true,
+				anchor_style: Some(ChunkAnchorStyle::Full),
+				show_leaf_preview: true,
+				tab_replacement: Some("    ".to_owned()),
+				normalize_indent: Some(true),
+				focused_paths: None,
+			},
+		);
 		println!("=== READ OUTPUT ===\n{read_output}\n=== END ===");
 		assert!(
 			read_output.contains("#[test]"),
@@ -4051,32 +4237,35 @@ mod tests {
 			.expect("fn_test_b should exist");
 
 		// Batch replace: add #[test] to both functions.
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![
-				EditOperation {
-					op:      ChunkEditOp::Put,
-					sel:     Some("mod_tests.fn_test_a".to_owned()),
-					crc:     Some(chunk_a.checksum.clone()),
-					region:  None,
-					content: Some("#[test]\nfn test_alpha() {\n\tnew_alpha();\n}".to_owned()),
-					find:    None,
-				},
-				EditOperation {
-					op:      ChunkEditOp::Put,
-					sel:     Some("mod_tests.fn_test_b".to_owned()),
-					crc:     Some(chunk_b.checksum.clone()),
-					region:  None,
-					content: Some("#[test]\nfn test_beta() {\n\tnew_beta();\n}".to_owned()),
-					find:    None,
-				},
-			],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "test.rs".to_owned(),
-			normalize_indent: None,
-		})
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![
+					EditOperation {
+						op: ChunkEditOp::Put,
+						sel: Some("mod_tests.fn_test_a".to_owned()),
+						crc: Some(chunk_a.checksum.clone()),
+						region: None,
+						content: Some("#[test]\nfn test_alpha() {\n\tnew_alpha();\n}".to_owned()),
+						find: None,
+					},
+					EditOperation {
+						op: ChunkEditOp::Put,
+						sel: Some("mod_tests.fn_test_b".to_owned()),
+						crc: Some(chunk_b.checksum.clone()),
+						region: None,
+						content: Some("#[test]\nfn test_beta() {\n\tnew_beta();\n}".to_owned()),
+						find: None,
+					},
+				],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "test.rs".to_owned(),
+				normalize_indent: None,
+			},
+		)
 		.expect("edit should apply");
 
 		assert!(result.changed, "edit should be detected as a change");
@@ -4099,8 +4288,7 @@ mod tests {
 		// (sub-chunks like stmts, let bindings), the diff hunks should still
 		// appear in the response. Mirrors the real-world scenario where only
 		// #[test] is added and the function body stays identical.
-		let source =
-			"\
+		let source = "\
 #[cfg(test)]\nmod tests {\n\tuse super::*;\n\n\tfn test_alpha() {\n\t\tlet mut config = \
 			 base_config();\n\t\tconfig.enabled = Some(false);\n\t\tconfig.max_items = \
 			 Some(10);\n\n\t\tlet Err(error) = build_options(&config) else {\n\t\t\tpanic!(\"should \
@@ -4133,8 +4321,10 @@ mod tests {
 		);
 
 		// Replace both functions: only adding #[test], body is identical.
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![
 				EditOperation {
 					op:      ChunkEditOp::Put,
 					sel:     Some("mod_tests.fn_test_a".to_owned()),
@@ -4165,13 +4355,14 @@ mod tests {
 					find:    None,
 				},
 			],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "test.rs".to_owned(),
-			normalize_indent: None,
-		})
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "test.rs".to_owned(),
+				normalize_indent: None,
+			},
+		)
 		.expect("edit should apply");
 
 		assert!(result.changed, "edit should be detected as a change");
@@ -4209,14 +4400,14 @@ function foo() {\n<<<<<<< HEAD\n\treturn bar();\n=======\n\treturn baz();\n>>>>>
 			.clone();
 		let rendered = state
 			.render_read(crate::chunk::types::ReadRenderParams {
-				read_path:           String::new(),
-				display_path:        "test.ts".to_owned(),
-				language_tag:        Some("ts".to_owned()),
-				omit_checksum:       false,
-				anchor_style:        Some(ChunkAnchorStyle::Full),
+				read_path: String::new(),
+				display_path: "test.ts".to_owned(),
+				language_tag: Some("ts".to_owned()),
+				omit_checksum: false,
+				anchor_style: Some(ChunkAnchorStyle::Full),
 				absolute_line_range: None,
-				tab_replacement:     Some("    ".to_owned()),
-				normalize_indent:    Some(true),
+				tab_replacement: Some("    ".to_owned()),
+				normalize_indent: Some(true),
 			})
 			.expect("render should succeed");
 
@@ -4247,14 +4438,18 @@ function foo() {\n<<<<<<< HEAD\n\treturn bar();\n=======\n\treturn baz();\n>>>>>
 			.expect("ours chunk should exist")
 			.clone();
 
-		let result = apply_single_edit(&state, "test.ts", EditOperation {
-			op:      ChunkEditOp::Delete,
-			sel:     Some(ours.path.clone()),
-			crc:     Some(ours.checksum),
-			region:  None,
-			content: None,
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.ts",
+			EditOperation {
+				op: ChunkEditOp::Delete,
+				sel: Some(ours.path.clone()),
+				crc: Some(ours.checksum),
+				region: None,
+				content: None,
+				find: None,
+			},
+		);
 
 		assert!(!result.state.has_conflicts());
 		assert!(result.diff_before.contains("<<<<<<< HEAD"));
@@ -4274,14 +4469,18 @@ function foo() {\n<<<<<<< HEAD\n\treturn bar();\n=======\n\treturn baz();\n>>>>>
 			.expect("theirs chunk should exist")
 			.clone();
 
-		let result = apply_single_edit(&state, "test.ts", EditOperation {
-			op:      ChunkEditOp::Delete,
-			sel:     Some(theirs.path.clone()),
-			crc:     Some(theirs.checksum),
-			region:  None,
-			content: None,
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.ts",
+			EditOperation {
+				op: ChunkEditOp::Delete,
+				sel: Some(theirs.path.clone()),
+				crc: Some(theirs.checksum),
+				region: None,
+				content: None,
+				find: None,
+			},
+		);
 
 		assert!(!result.state.has_conflicts());
 		assert!(result.diff_after.contains("return bar();"));
@@ -4300,14 +4499,18 @@ function foo() {\n<<<<<<< HEAD\n\treturn bar();\n=======\n\treturn baz();\n>>>>>
 			.expect("conflict chunk should exist")
 			.clone();
 
-		let result = apply_single_edit(&state, "test.ts", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(conflict.path.clone()),
-			crc:     Some(conflict.checksum),
-			region:  None,
-			content: Some("\treturn qux();\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.ts",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(conflict.path.clone()),
+				crc: Some(conflict.checksum),
+				region: None,
+				content: Some("\treturn qux();\n".to_owned()),
+				find: None,
+			},
+		);
 
 		assert!(!result.state.has_conflicts());
 		assert!(result.diff_after.contains("return qux();"));
@@ -4336,32 +4539,35 @@ function foo() {\n<<<<<<< HEAD\n\treturn bar();\n=======\n\treturn baz();\n>>>>>
 			.expect("theirs child should exist")
 			.clone();
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![
-				EditOperation {
-					op:      ChunkEditOp::Put,
-					sel:     Some(ours.path.clone()),
-					crc:     Some(ours.checksum),
-					region:  None,
-					content: Some("\treturn bar(1);\n".to_owned()),
-					find:    None,
-				},
-				EditOperation {
-					op:      ChunkEditOp::Delete,
-					sel:     Some(theirs.path.clone()),
-					crc:     Some(theirs.checksum),
-					region:  None,
-					content: None,
-					find:    None,
-				},
-			],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "test.ts".to_owned(),
-			normalize_indent: None,
-		})
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![
+					EditOperation {
+						op: ChunkEditOp::Put,
+						sel: Some(ours.path.clone()),
+						crc: Some(ours.checksum),
+						region: None,
+						content: Some("\treturn bar(1);\n".to_owned()),
+						find: None,
+					},
+					EditOperation {
+						op: ChunkEditOp::Delete,
+						sel: Some(theirs.path.clone()),
+						crc: Some(theirs.checksum),
+						region: None,
+						content: None,
+						find: None,
+					},
+				],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "test.ts".to_owned(),
+				normalize_indent: None,
+			},
+		)
 		.expect("batch edit should apply");
 
 		assert!(!result.state.has_conflicts());
@@ -4429,17 +4635,21 @@ function foo() {\n<<<<<<< HEAD\n\treturn bar();\n=======\n\treturn baz();\n>>>>>
 			.chunk("impl_Server.fn_addres")
 			.expect("impl_Server.fn_addres should exist");
 
-		let result = apply_single_edit(&state, "test.rs", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(format!("impl_Server.fn_addres#{}^", chunk.checksum)),
-			crc:     None,
-			region:  None,
-			content: Some(
-				"/// Returns the server address.\n#[must_use]\npub fn address(&self) -> String {\n"
-					.to_owned(),
-			),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.rs",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(format!("impl_Server.fn_addres#{}^", chunk.checksum)),
+				crc: None,
+				region: None,
+				content: Some(
+					"/// Returns the server address.\n#[must_use]\npub fn address(&self) -> String {\n"
+						.to_owned(),
+				),
+				find: None,
+			},
+		);
 
 		assert!(
 			result
@@ -4479,14 +4689,18 @@ function foo() {\n<<<<<<< HEAD\n\treturn bar();\n=======\n\treturn baz();\n>>>>>
 			.chunk("sect_Title.chunk_2")
 			.expect("paragraph chunk should exist");
 
-		let result = apply_single_edit(&state, "test.md", EditOperation {
-			op:      ChunkEditOp::Append,
-			sel:     Some(para_chunk.path.clone()),
-			crc:     None,
-			region:  None,
-			content: Some("Appended line.\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.md",
+			EditOperation {
+				op: ChunkEditOp::Append,
+				sel: Some(para_chunk.path.clone()),
+				crc: None,
+				region: None,
+				content: Some("Appended line.\n".to_owned()),
+				find: None,
+			},
+		);
 
 		// The blank line before ## Next Section should be preserved
 		assert!(
@@ -4511,14 +4725,18 @@ function foo() {\n<<<<<<< HEAD\n\treturn bar();\n=======\n\treturn baz();\n>>>>>
 			.chunk("sect_Sectio.chunk_2")
 			.expect("table chunk should exist");
 
-		let result = apply_single_edit(&state, "test.md", EditOperation {
-			op:      ChunkEditOp::After,
-			sel:     Some(table_chunk.path.clone()),
-			crc:     None,
-			region:  None,
-			content: Some("Extra paragraph.\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.md",
+			EditOperation {
+				op: ChunkEditOp::After,
+				sel: Some(table_chunk.path.clone()),
+				crc: None,
+				region: None,
+				content: Some("Extra paragraph.\n".to_owned()),
+				find: None,
+			},
+		);
 
 		// Blank line before ## Next must be preserved
 		assert!(
@@ -4539,14 +4757,18 @@ function foo() {\n<<<<<<< HEAD\n\treturn bar();\n=======\n\treturn baz();\n>>>>>
 			.iter()
 			.find(|c| c.identifier.as_deref() == Some("is_running") || c.path.contains("is_run"))
 			.expect("is_running chunk");
-		let result = apply_single_edit(&state, "test.rs", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some(chunk.path.clone()),
-			crc:     Some(chunk.checksum.clone()),
-			region:  Some(ChunkRegion::Body),
-			content: Some("false\n".to_owned()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.rs",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some(chunk.path.clone()),
+				crc: Some(chunk.checksum.clone()),
+				region: Some(ChunkRegion::Body),
+				content: Some("false\n".to_owned()),
+				find: None,
+			},
+		);
 		// Body should be at 2 levels of indent (8 spaces), not 1 level (4 spaces)
 		let new_source = &result.diff_after;
 		assert!(
@@ -4560,14 +4782,18 @@ function foo() {\n<<<<<<< HEAD\n\treturn bar();\n=======\n\treturn baz();\n>>>>>
 		let source = "fn foo() {\n    old_body();\n}\n";
 		let state = state_for(source, "rust");
 		let chunk = state.inner().chunk("fn_foo").expect("fn_foo");
-		let result = apply_single_edit(&state, "test.rs", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some("fn_foo".to_owned()),
-			crc:     Some(chunk.checksum.clone()),
-			region:  Some(ChunkRegion::Body),
-			content: Some("new_body();".to_owned()), // No trailing newline
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.rs",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some("fn_foo".to_owned()),
+				crc: Some(chunk.checksum.clone()),
+				region: Some(ChunkRegion::Body),
+				content: Some("new_body();".to_owned()), // No trailing newline
+				find: None,
+			},
+		);
 		let new_source = &result.diff_after;
 		// Closing } should be on its own line, not merged
 		assert!(
@@ -4659,22 +4885,25 @@ function foo() {\n<<<<<<< HEAD\n\treturn bar();\n=======\n\treturn baz();\n>>>>>
 			.expect("if chunk should exist");
 		assert!(if_chunk.leaf, "if chunk should be leaf");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Put,
-				sel:     Some(format!("{}~", if_chunk.path)),
-				crc:     Some(if_chunk.checksum.clone()),
-				region:  None,
-				content: Some("if request.ok:\n    return \"forced\"\n".to_owned()),
-				find:    None,
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "test.py".to_owned(),
-			normalize_indent: None,
-		})
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Put,
+					sel: Some(format!("{}~", if_chunk.path)),
+					crc: Some(if_chunk.checksum.clone()),
+					region: None,
+					content: Some("if request.ok:\n    return \"forced\"\n".to_owned()),
+					find: None,
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "test.py".to_owned(),
+				normalize_indent: None,
+			},
+		)
 		.expect("leaf ~ should fall back to whole-chunk, not produce a parse error");
 
 		assert!(result.parse_valid, "edit should produce valid Python");
@@ -4704,22 +4933,25 @@ function foo() {\n<<<<<<< HEAD\n\treturn bar();\n=======\n\treturn baz();\n>>>>>
 			.find(|c| c.kind == ChunkKind::If)
 			.expect("if chunk should exist");
 
-		let result = apply_edits(&state, &EditParams {
-			operations:       vec![EditOperation {
-				op:      ChunkEditOp::Put,
-				sel:     Some(format!("{}~", if_chunk.path)),
-				crc:     Some(if_chunk.checksum.clone()),
-				region:  None,
-				content: Some("return \"forced\"\n".to_owned()),
-				find:    None,
-			}],
-			default_selector: None,
-			default_crc:      None,
-			anchor_style:     None,
-			cwd:              ".".to_owned(),
-			file_path:        "test.py".to_owned(),
-			normalize_indent: None,
-		})
+		let result = apply_edits(
+			&state,
+			&EditParams {
+				operations: vec![EditOperation {
+					op: ChunkEditOp::Put,
+					sel: Some(format!("{}~", if_chunk.path)),
+					crc: Some(if_chunk.checksum.clone()),
+					region: None,
+					content: Some("return \"forced\"\n".to_owned()),
+					find: None,
+				}],
+				default_selector: None,
+				default_crc: None,
+				anchor_style: None,
+				cwd: ".".to_owned(),
+				file_path: "test.py".to_owned(),
+				normalize_indent: None,
+			},
+		)
 		.expect("fallback body edit should preserve head and stay parse-valid");
 
 		assert!(result.parse_valid, "edit should remain parse-valid");
@@ -4745,14 +4977,18 @@ function foo() {\n<<<<<<< HEAD\n\treturn bar();\n=======\n\treturn baz();\n>>>>>
 		let source = "fn foo() {\n    println!(\"a\");\n}\n\nfn bar() {\n    println!(\"b\");\n}\n";
 		let state = state_for(source, "rust");
 		let foo = state.inner().chunk("fn_foo").expect("fn_foo");
-		let result = apply_single_edit(&state, "test.rs", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some("fn_foo".to_owned()),
-			crc:     Some(foo.checksum.clone()),
-			region:  None,
-			content: Some(String::new()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.rs",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some("fn_foo".to_owned()),
+				crc: Some(foo.checksum.clone()),
+				region: None,
+				content: Some(String::new()),
+				find: None,
+			},
+		);
 
 		assert!(result.changed, "deletion should be marked as changed");
 		// The response_text should include a diff showing removed lines,
@@ -4772,14 +5008,18 @@ function foo() {\n<<<<<<< HEAD\n\treturn bar();\n=======\n\treturn baz();\n>>>>>
 			.inner()
 			.chunk("enum_Level.vrnt_Debug")
 			.expect("vrnt_Debug");
-		let result = apply_single_edit(&state, "test.rs", EditOperation {
-			op:      ChunkEditOp::Put,
-			sel:     Some("enum_Level.vrnt_Debug".to_owned()),
-			crc:     Some(debug.checksum.clone()),
-			region:  None,
-			content: Some(String::new()),
-			find:    None,
-		});
+		let result = apply_single_edit(
+			&state,
+			"test.rs",
+			EditOperation {
+				op: ChunkEditOp::Put,
+				sel: Some("enum_Level.vrnt_Debug".to_owned()),
+				crc: Some(debug.checksum.clone()),
+				region: None,
+				content: Some(String::new()),
+				find: None,
+			},
+		);
 
 		assert!(result.changed, "deletion should be marked as changed");
 		// The response should show the removed variant in a diff hunk.

--- a/crates/pi-natives/src/chunk/indent.rs
+++ b/crates/pi-natives/src/chunk/indent.rs
@@ -547,15 +547,15 @@ mod tests {
 	#[test]
 	fn detect_file_indent_step_prefers_space_children() {
 		let tree = ChunkTree {
-			language:          "rust".to_owned(),
-			checksum:          "ABCD".to_owned(),
-			line_count:        1,
-			parse_errors:      0,
+			language: "rust".to_owned(),
+			checksum: "ABCD".to_owned(),
+			line_count: 1,
+			parse_errors: 0,
 			parse_error_lines: Vec::new(),
-			fallback:          false,
-			root_path:         String::new(),
-			root_children:     vec!["class_A".to_owned()],
-			chunks:            vec![
+			fallback: false,
+			root_path: String::new(),
+			root_children: vec!["class_A".to_owned()],
+			chunks: vec![
 				chunk("class_A", Some(""), &["fn_b"], 0, " "),
 				chunk("fn_b", Some("class_A"), &[], 2, " "),
 			],
@@ -568,15 +568,15 @@ mod tests {
 		// When the chunk tree has no parent->child pairs (all leaves),
 		// fall back to scanning source lines for the minimum indent width.
 		let tree = ChunkTree {
-			language:          "yaml".to_owned(),
-			checksum:          "ABCD".to_owned(),
-			line_count:        3,
-			parse_errors:      0,
+			language: "yaml".to_owned(),
+			checksum: "ABCD".to_owned(),
+			line_count: 3,
+			parse_errors: 0,
 			parse_error_lines: Vec::new(),
-			fallback:          false,
-			root_path:         String::new(),
-			root_children:     vec!["key_server".to_owned()],
-			chunks:            vec![chunk("key_server", Some(""), &[], 0, " ")],
+			fallback: false,
+			root_path: String::new(),
+			root_children: vec!["key_server".to_owned()],
+			chunks: vec![chunk("key_server", Some(""), &[], 0, " ")],
 		};
 		let source = "server:\n  host: localhost\n  port: 5432\n";
 		assert_eq!(detect_file_indent_step(source, &tree), 2);
@@ -585,15 +585,15 @@ mod tests {
 	#[test]
 	fn detect_file_indent_char_falls_back_to_source_lines() {
 		let tree = ChunkTree {
-			language:          "rust".to_owned(),
-			checksum:          "ABCD".to_owned(),
-			line_count:        3,
-			parse_errors:      0,
+			language: "rust".to_owned(),
+			checksum: "ABCD".to_owned(),
+			line_count: 3,
+			parse_errors: 0,
 			parse_error_lines: Vec::new(),
-			fallback:          false,
-			root_path:         String::new(),
-			root_children:     vec!["fn_main".to_owned()],
-			chunks:            vec![chunk("fn_main", Some(""), &[], 0, "")],
+			fallback: false,
+			root_path: String::new(),
+			root_children: vec!["fn_main".to_owned()],
+			chunks: vec![chunk("fn_main", Some(""), &[], 0, "")],
 		};
 
 		let source = "fn main() {\n    println!(\"hi\");\n}\n";
@@ -603,15 +603,15 @@ mod tests {
 	#[test]
 	fn detect_file_indent_char_defaults_to_spaces_without_signal() {
 		let tree = ChunkTree {
-			language:          "rust".to_owned(),
-			checksum:          "ABCD".to_owned(),
-			line_count:        0,
-			parse_errors:      0,
+			language: "rust".to_owned(),
+			checksum: "ABCD".to_owned(),
+			line_count: 0,
+			parse_errors: 0,
 			parse_error_lines: Vec::new(),
-			fallback:          false,
-			root_path:         String::new(),
-			root_children:     Vec::new(),
-			chunks:            Vec::new(),
+			fallback: false,
+			root_path: String::new(),
+			root_children: Vec::new(),
+			chunks: Vec::new(),
 		};
 
 		assert_eq!(detect_file_indent_char("", &tree), ' ');

--- a/crates/pi-natives/src/chunk/kind.rs
+++ b/crates/pi-natives/src/chunk/kind.rs
@@ -165,23 +165,23 @@ pub enum SummaryStyle {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ChunkTraits {
-	pub groupable:                bool,
-	pub packed:                   bool,
-	pub addressable_leaf:         bool,
+	pub groupable: bool,
+	pub packed: bool,
+	pub addressable_leaf: bool,
 	pub always_preserve_children: bool,
-	pub has_addressable_members:  bool,
-	pub summary:                  SummaryStyle,
-	pub container:                bool,
+	pub has_addressable_members: bool,
+	pub summary: SummaryStyle,
+	pub container: bool,
 }
 
 const DEFAULT_TRAITS: ChunkTraits = ChunkTraits {
-	groupable:                false,
-	packed:                   false,
-	addressable_leaf:         false,
+	groupable: false,
+	packed: false,
+	addressable_leaf: false,
 	always_preserve_children: false,
-	has_addressable_members:  false,
-	summary:                  SummaryStyle::Default,
-	container:                false,
+	has_addressable_members: false,
+	summary: SummaryStyle::Default,
+	container: false,
 };
 
 const GROUP_TRAITS: ChunkTraits = ChunkTraits { groupable: true, ..DEFAULT_TRAITS };

--- a/crates/pi-natives/src/chunk/mod.rs
+++ b/crates/pi-natives/src/chunk/mod.rs
@@ -131,29 +131,32 @@ pub(crate) fn build_chunk_tree(source: &str, language: &str) -> Result<ChunkTree
 
 	insert_preamble_chunk(source, &mut acc.chunks, &mut root_children);
 
-	acc.chunks.insert(0, ChunkNode {
-		path:                String::new(),
-		identifier:          None,
-		kind:                ChunkKind::Root,
-		leaf:                false,
-		virtual_content:     None,
-		parent_path:         None,
-		children:            root_children.clone(),
-		signature:           None,
-		start_line:          u32::from(total_lines != 0),
-		end_line:            total_lines as u32,
-		line_count:          total_lines as u32,
-		start_byte:          0,
-		end_byte:            source.len() as u32,
-		checksum_start_byte: 0,
-		prologue_end_byte:   Some(0),
-		epilogue_start_byte: Some(source.len() as u32),
-		checksum:            root_checksum.clone(),
-		error:               false,
-		indent:              0,
-		indent_char:         String::new(),
-		group:               false,
-	});
+	acc.chunks.insert(
+		0,
+		ChunkNode {
+			path: String::new(),
+			identifier: None,
+			kind: ChunkKind::Root,
+			leaf: false,
+			virtual_content: None,
+			parent_path: None,
+			children: root_children.clone(),
+			signature: None,
+			start_line: u32::from(total_lines != 0),
+			end_line: total_lines as u32,
+			line_count: total_lines as u32,
+			start_byte: 0,
+			end_byte: source.len() as u32,
+			checksum_start_byte: 0,
+			prologue_end_byte: Some(0),
+			epilogue_start_byte: Some(source.len() as u32),
+			checksum: root_checksum.clone(),
+			error: false,
+			indent: 0,
+			indent_char: String::new(),
+			group: false,
+		},
+	);
 
 	Ok(ChunkTree {
 		language: normalized_language,
@@ -212,27 +215,27 @@ fn build_blank_line_tree(
 	checksum: String,
 ) -> ChunkTree {
 	let mut chunks = vec![ChunkNode {
-		path:                String::new(),
-		identifier:          None,
-		kind:                ChunkKind::Root,
-		leaf:                false,
-		virtual_content:     None,
-		parent_path:         None,
-		children:            Vec::new(),
-		signature:           None,
-		start_line:          u32::from(total_lines != 0),
-		end_line:            total_lines as u32,
-		line_count:          total_lines as u32,
-		start_byte:          0,
-		end_byte:            source.len() as u32,
+		path: String::new(),
+		identifier: None,
+		kind: ChunkKind::Root,
+		leaf: false,
+		virtual_content: None,
+		parent_path: None,
+		children: Vec::new(),
+		signature: None,
+		start_line: u32::from(total_lines != 0),
+		end_line: total_lines as u32,
+		line_count: total_lines as u32,
+		start_byte: 0,
+		end_byte: source.len() as u32,
 		checksum_start_byte: 0,
-		prologue_end_byte:   Some(0),
+		prologue_end_byte: Some(0),
 		epilogue_start_byte: Some(source.len() as u32),
-		checksum:            checksum.clone(),
-		error:               false,
-		indent:              0,
-		indent_char:         String::new(),
-		group:               false,
+		checksum: checksum.clone(),
+		error: false,
+		indent: 0,
+		indent_char: String::new(),
+		group: false,
 	}];
 	let line_starts = line_start_offsets(source);
 	let mut root_children = Vec::new();
@@ -262,32 +265,32 @@ fn build_blank_line_tree(
 		let end_byte = line_end_offset(source, &line_starts, end_line);
 		root_children.push(name.clone());
 		chunks.push(ChunkNode {
-			path:                name.clone(),
-			identifier:          Some(name.clone()),
-			kind:                ChunkKind::Chunk,
-			leaf:                true,
-			virtual_content:     None,
-			parent_path:         Some(String::new()),
-			children:            Vec::new(),
-			signature:           None,
-			start_line:          (start_line + 1) as u32,
-			end_line:            (end_line + 1) as u32,
-			line_count:          (end_line - start_line + 1) as u32,
-			start_byte:          start_byte as u32,
-			end_byte:            end_byte as u32,
+			path: name.clone(),
+			identifier: Some(name.clone()),
+			kind: ChunkKind::Chunk,
+			leaf: true,
+			virtual_content: None,
+			parent_path: Some(String::new()),
+			children: Vec::new(),
+			signature: None,
+			start_line: (start_line + 1) as u32,
+			end_line: (end_line + 1) as u32,
+			line_count: (end_line - start_line + 1) as u32,
+			start_byte: start_byte as u32,
+			end_byte: end_byte as u32,
 			checksum_start_byte: start_byte as u32,
-			prologue_end_byte:   None,
+			prologue_end_byte: None,
 			epilogue_start_byte: None,
-			checksum:            chunk_checksum(
+			checksum: chunk_checksum(
 				source
 					.as_bytes()
 					.get(start_byte..end_byte)
 					.unwrap_or_default(),
 			),
-			error:               false,
-			indent:              0,
-			indent_char:         String::new(),
-			group:               false,
+			error: false,
+			indent: 0,
+			indent_char: String::new(),
+			group: false,
 		});
 		start_line = end_line + 1;
 	}
@@ -457,33 +460,33 @@ fn translate_injected_subtree(
 			.map(|child| format!("{parent_path}.{child}"))
 			.collect();
 		acc.chunks.push(ChunkNode {
-			path:                translated_path,
-			identifier:          sub_chunk.identifier,
-			kind:                sub_chunk.kind,
-			leaf:                sub_chunk.leaf,
-			virtual_content:     sub_chunk.virtual_content,
-			parent_path:         translated_parent,
-			children:            translated_children,
-			signature:           sub_chunk.signature,
-			start_line:          sub_chunk.start_line.saturating_add(content_line_shift),
-			end_line:            sub_chunk.end_line.saturating_add(content_line_shift),
-			line_count:          sub_chunk.line_count,
-			start_byte:          sub_chunk.start_byte.saturating_add(content_start as u32),
-			end_byte:            sub_chunk.end_byte.saturating_add(content_start as u32),
+			path: translated_path,
+			identifier: sub_chunk.identifier,
+			kind: sub_chunk.kind,
+			leaf: sub_chunk.leaf,
+			virtual_content: sub_chunk.virtual_content,
+			parent_path: translated_parent,
+			children: translated_children,
+			signature: sub_chunk.signature,
+			start_line: sub_chunk.start_line.saturating_add(content_line_shift),
+			end_line: sub_chunk.end_line.saturating_add(content_line_shift),
+			line_count: sub_chunk.line_count,
+			start_byte: sub_chunk.start_byte.saturating_add(content_start as u32),
+			end_byte: sub_chunk.end_byte.saturating_add(content_start as u32),
 			checksum_start_byte: sub_chunk
 				.checksum_start_byte
 				.saturating_add(content_start as u32),
-			prologue_end_byte:   sub_chunk
+			prologue_end_byte: sub_chunk
 				.prologue_end_byte
 				.map(|byte| byte.saturating_add(content_start as u32)),
 			epilogue_start_byte: sub_chunk
 				.epilogue_start_byte
 				.map(|byte| byte.saturating_add(content_start as u32)),
-			checksum:            sub_chunk.checksum,
-			error:               sub_chunk.error,
-			indent:              sub_chunk.indent,
-			indent_char:         sub_chunk.indent_char,
-			group:               sub_chunk.group,
+			checksum: sub_chunk.checksum,
+			error: sub_chunk.error,
+			indent: sub_chunk.indent,
+			indent_char: sub_chunk.indent_char,
+			group: sub_chunk.group,
 		});
 	}
 
@@ -2182,14 +2185,14 @@ impl Config {
 		for selector in selectors {
 			let result = state
 				.render_read(ReadRenderParams {
-					read_path:           selector.clone(),
-					display_path:        "sample.ts".to_string(),
-					language_tag:        Some("ts".to_string()),
-					omit_checksum:       false,
-					anchor_style:        Some(ChunkAnchorStyle::Full),
+					read_path: selector.clone(),
+					display_path: "sample.ts".to_string(),
+					language_tag: Some("ts".to_string()),
+					omit_checksum: false,
+					anchor_style: Some(ChunkAnchorStyle::Full),
 					absolute_line_range: None,
-					tab_replacement:     Some("    ".to_string()),
-					normalize_indent:    Some(true),
+					tab_replacement: Some("    ".to_string()),
+					normalize_indent: Some(true),
 				})
 				.unwrap_or_else(|err| panic!("selector {selector} should resolve: {err}"));
 			let resolved = result
@@ -2206,14 +2209,14 @@ impl Config {
 			.expect("state should parse");
 		let result = state
 			.render_read(ReadRenderParams {
-				read_path:           "sample.ts:?".to_string(),
-				display_path:        "sample.ts".to_string(),
-				language_tag:        Some("ts".to_string()),
-				omit_checksum:       false,
-				anchor_style:        Some(ChunkAnchorStyle::Full),
+				read_path: "sample.ts:?".to_string(),
+				display_path: "sample.ts".to_string(),
+				language_tag: Some("ts".to_string()),
+				omit_checksum: false,
+				anchor_style: Some(ChunkAnchorStyle::Full),
 				absolute_line_range: None,
-				tab_replacement:     Some("    ".to_string()),
-				normalize_indent:    Some(true),
+				tab_replacement: Some("    ".to_string()),
+				normalize_indent: Some(true),
 			})
 			.expect("listing should succeed");
 		assert!(result.text.contains("sample.ts chunks"), "{}", result.text);
@@ -2234,14 +2237,14 @@ impl Config {
 			.expect("state should parse");
 		let result = state
 			.render_read(ReadRenderParams {
-				read_path:           "sample.ts".to_string(),
-				display_path:        "sample.ts".to_string(),
-				language_tag:        Some("ts".to_string()),
-				omit_checksum:       false,
-				anchor_style:        Some(ChunkAnchorStyle::Full),
+				read_path: "sample.ts".to_string(),
+				display_path: "sample.ts".to_string(),
+				language_tag: Some("ts".to_string()),
+				omit_checksum: false,
+				anchor_style: Some(ChunkAnchorStyle::Full),
 				absolute_line_range: None,
-				tab_replacement:     Some("    ".to_string()),
-				normalize_indent:    Some(true),
+				tab_replacement: Some("    ".to_string()),
+				normalize_indent: Some(true),
 			})
 			.expect("root read should succeed");
 		assert!(result.text.contains("class_Worker.fn_run#"), "{}", result.text);
@@ -2261,14 +2264,14 @@ impl Config {
 		let state = ChunkState::parse(source, "typescript".to_string()).expect("state should parse");
 		let result = state
 			.render_read(ReadRenderParams {
-				read_path:           "sample.ts:fn_loadSk.try_2".to_string(),
-				display_path:        "sample.ts".to_string(),
-				language_tag:        Some("ts".to_string()),
-				omit_checksum:       false,
-				anchor_style:        Some(ChunkAnchorStyle::Full),
+				read_path: "sample.ts:fn_loadSk.try_2".to_string(),
+				display_path: "sample.ts".to_string(),
+				language_tag: Some("ts".to_string()),
+				omit_checksum: false,
+				anchor_style: Some(ChunkAnchorStyle::Full),
 				absolute_line_range: None,
-				tab_replacement:     Some("    ".to_string()),
-				normalize_indent:    Some(true),
+				tab_replacement: Some("    ".to_string()),
+				normalize_indent: Some(true),
 			})
 			.expect("render_read should succeed");
 
@@ -2288,14 +2291,14 @@ impl Config {
 			.expect("state should parse");
 		let result = state
 			.render_read(ReadRenderParams {
-				read_path:           "sample.ts:fn_run@unknown".to_string(),
-				display_path:        "sample.ts".to_string(),
-				language_tag:        Some("ts".to_string()),
-				omit_checksum:       false,
-				anchor_style:        Some(ChunkAnchorStyle::Full),
+				read_path: "sample.ts:fn_run@unknown".to_string(),
+				display_path: "sample.ts".to_string(),
+				language_tag: Some("ts".to_string()),
+				omit_checksum: false,
+				anchor_style: Some(ChunkAnchorStyle::Full),
 				absolute_line_range: None,
-				tab_replacement:     Some("    ".to_string()),
-				normalize_indent:    Some(true),
+				tab_replacement: Some("    ".to_string()),
+				normalize_indent: Some(true),
 			})
 			.expect("render_read should succeed");
 
@@ -2312,14 +2315,14 @@ impl Config {
 			.expect("state should parse");
 		let result = state
 			.render_read(ReadRenderParams {
-				read_path:           "sample.ts:fn_run~".to_string(),
-				display_path:        "sample.ts".to_string(),
-				language_tag:        Some("ts".to_string()),
-				omit_checksum:       false,
-				anchor_style:        Some(ChunkAnchorStyle::Full),
+				read_path: "sample.ts:fn_run~".to_string(),
+				display_path: "sample.ts".to_string(),
+				language_tag: Some("ts".to_string()),
+				omit_checksum: false,
+				anchor_style: Some(ChunkAnchorStyle::Full),
 				absolute_line_range: None,
-				tab_replacement:     Some("    ".to_string()),
-				normalize_indent:    Some(true),
+				tab_replacement: Some("    ".to_string()),
+				normalize_indent: Some(true),
 			})
 			.expect("render_read should succeed");
 
@@ -2349,14 +2352,14 @@ impl Config {
 			ChunkState::parse(source.to_string(), "python".to_string()).expect("state should parse");
 		let result = state
 			.render_read(ReadRenderParams {
-				read_path:           "test.py:class_Server.fn_addres^".to_string(),
-				display_path:        "test.py".to_string(),
-				language_tag:        Some("py".to_string()),
-				omit_checksum:       false,
-				anchor_style:        Some(ChunkAnchorStyle::Full),
+				read_path: "test.py:class_Server.fn_addres^".to_string(),
+				display_path: "test.py".to_string(),
+				language_tag: Some("py".to_string()),
+				omit_checksum: false,
+				anchor_style: Some(ChunkAnchorStyle::Full),
 				absolute_line_range: None,
-				tab_replacement:     Some("    ".to_string()),
-				normalize_indent:    Some(true),
+				tab_replacement: Some("    ".to_string()),
+				normalize_indent: Some(true),
 			})
 			.expect("render_read should succeed");
 
@@ -2867,8 +2870,7 @@ end
 	fn python_region_boundaries_correct_for_class() {
 		use super::{resolve::chunk_region_range, types::ChunkRegion};
 
-		let source =
-			"class Server:\n    def start(self) -> None:\n        self.running = True\n        \
+		let source = "class Server:\n    def start(self) -> None:\n        self.running = True\n        \
 			 print('ok')\n\n    def stop(self):\n        pass\n";
 		let tree = build_chunk_tree(source, "python").expect("tree should build");
 		let class_chunk = tree
@@ -2955,8 +2957,7 @@ end
 	fn python_class_body_replace_does_not_corrupt() {
 		use super::{resolve::chunk_region_range, types::ChunkRegion};
 
-		let source =
-			"class Server:\n    def __init__(self, host: str, port: int):\n        self.host = \
+		let source = "class Server:\n    def __init__(self, host: str, port: int):\n        self.host = \
 			 host\n        self.port = port\n\n    def start(self) -> None:\n        if \
 			 self.running:\n            raise RuntimeError(\"already running\")\n        \
 			 self.running = True\n        print(f\"Started on {self.host}:{self.port}\")\n\n    \
@@ -3096,14 +3097,14 @@ end
 		// Read only lines 3-7 — the function spans L1-L11, so it should be clipped.
 		let result = state
 			.render_read(ReadRenderParams {
-				read_path:           "test.ts:L3-L7".to_string(),
-				display_path:        "test.ts".to_string(),
-				language_tag:        Some("ts".to_string()),
-				omit_checksum:       true,
-				anchor_style:        Some(ChunkAnchorStyle::FullOmit),
+				read_path: "test.ts:L3-L7".to_string(),
+				display_path: "test.ts".to_string(),
+				language_tag: Some("ts".to_string()),
+				omit_checksum: true,
+				anchor_style: Some(ChunkAnchorStyle::FullOmit),
 				absolute_line_range: None,
-				tab_replacement:     Some("  ".to_string()),
-				normalize_indent:    Some(true),
+				tab_replacement: Some("  ".to_string()),
+				normalize_indent: Some(true),
 			})
 			.expect("render_read should succeed");
 
@@ -3146,14 +3147,14 @@ end
 
 		let result = state
 			.render_read(ReadRenderParams {
-				read_path:           "test.ts:L1-L2".to_string(),
-				display_path:        "test.ts".to_string(),
-				language_tag:        Some("ts".to_string()),
-				omit_checksum:       true,
-				anchor_style:        Some(ChunkAnchorStyle::FullOmit),
+				read_path: "test.ts:L1-L2".to_string(),
+				display_path: "test.ts".to_string(),
+				language_tag: Some("ts".to_string()),
+				omit_checksum: true,
+				anchor_style: Some(ChunkAnchorStyle::FullOmit),
 				absolute_line_range: None,
-				tab_replacement:     Some("  ".to_string()),
-				normalize_indent:    Some(true),
+				tab_replacement: Some("  ".to_string()),
+				normalize_indent: Some(true),
 			})
 			.expect("render_read should succeed");
 
@@ -3256,14 +3257,14 @@ end
 			ChunkState::parse(source.to_owned(), "markdown".to_owned()).expect("state should parse");
 		let result = state
 			.render_read(ReadRenderParams {
-				read_path:           "sample.md".to_owned(),
-				display_path:        "sample.md".to_owned(),
-				language_tag:        Some("md".to_owned()),
-				omit_checksum:       false,
-				anchor_style:        Some(ChunkAnchorStyle::Full),
+				read_path: "sample.md".to_owned(),
+				display_path: "sample.md".to_owned(),
+				language_tag: Some("md".to_owned()),
+				omit_checksum: false,
+				anchor_style: Some(ChunkAnchorStyle::Full),
 				absolute_line_range: None,
-				tab_replacement:     Some("    ".to_owned()),
-				normalize_indent:    Some(true),
+				tab_replacement: Some("    ".to_owned()),
+				normalize_indent: Some(true),
 			})
 			.expect("render_read should succeed");
 

--- a/crates/pi-natives/src/chunk/render.rs
+++ b/crates/pi-natives/src/chunk/render.rs
@@ -16,7 +16,7 @@ type ChunkLookup<'a> = HashMap<&'a str, &'a ChunkNode>;
 #[derive(Clone)]
 pub struct InlineHunkLine {
 	/// Fully indented line text ready to push as a meta line.
-	pub text:   String,
+	pub text: String,
 	/// Optional gutter marker (`*`, `-`, etc.) for the rendered meta line.
 	pub marker: Option<char>,
 }
@@ -220,10 +220,15 @@ fn render_state_impl(
 		let children =
 			visible_children_for_chunk(tree, chunk, &lookup, params.visible_range.as_ref(), focus_ref);
 		for (index, child) in children.iter().enumerate() {
-			emit_chunk_subtree(&mut ctx, child, 0, ChunkSubtreeOptions {
-				is_first_top_level:            index == 0,
-				between_top_level_definitions: true,
-			});
+			emit_chunk_subtree(
+				&mut ctx,
+				child,
+				0,
+				ChunkSubtreeOptions {
+					is_first_top_level: index == 0,
+					between_top_level_definitions: true,
+				},
+			);
 		}
 		emit_inline_hunks_for(&mut ctx, "");
 		return ctx.out;
@@ -233,18 +238,22 @@ fn render_state_impl(
 		if params.show_leaf_preview
 			&& intersect_visible_span(chunk, params.visible_range.as_ref()).is_some()
 		{
-			emit_chunk_subtree(&mut ctx, chunk, 0, ChunkSubtreeOptions {
-				is_first_top_level:            true,
-				between_top_level_definitions: false,
-			});
+			emit_chunk_subtree(
+				&mut ctx,
+				chunk,
+				0,
+				ChunkSubtreeOptions { is_first_top_level: true, between_top_level_definitions: false },
+			);
 		}
 		return ctx.out;
 	}
 
-	emit_chunk_subtree(&mut ctx, chunk, 0, ChunkSubtreeOptions {
-		is_first_top_level:            true,
-		between_top_level_definitions: false,
-	});
+	emit_chunk_subtree(
+		&mut ctx,
+		chunk,
+		0,
+		ChunkSubtreeOptions { is_first_top_level: true, between_top_level_definitions: false },
+	);
 	ctx.out
 }
 
@@ -429,13 +438,13 @@ fn chunk_head_body_lines(source: &str, chunk: &ChunkNode) -> (u32, u32) {
 #[derive(Clone, Copy)]
 struct VisibleSpan {
 	start: u32,
-	end:   u32,
+	end: u32,
 }
 
 #[derive(Clone, Copy)]
 struct LineSegment {
 	start: u32,
-	end:   u32,
+	end: u32,
 }
 
 fn intersect_visible_span(
@@ -545,7 +554,7 @@ fn build_leaf_entries(
 		};
 		LeafEntry::Line {
 			abs_line: line,
-			text:     source_lines
+			text: source_lines
 				.get(line.saturating_sub(1) as usize)
 				.map_or(String::new(), |text| {
 					normalize_rendered_line(text, normalize, tab_replacement)
@@ -841,27 +850,27 @@ fn compute_rendered_line_count(
 }
 
 struct RenderCtx<'a> {
-	out:                    String,
-	tree:                   &'a ChunkTree,
-	lookup:                 &'a ChunkLookup<'a>,
-	source:                 &'a str,
-	source_lines:           &'a [&'a str],
-	num_width:              usize,
-	visible_range:          Option<&'a VisibleLineRange>,
-	omit_checksum:          bool,
-	anchor_style:           ChunkAnchorStyle,
-	show_leaf_preview:      bool,
-	last_was_blank_meta:    bool,
+	out: String,
+	tree: &'a ChunkTree,
+	lookup: &'a ChunkLookup<'a>,
+	source: &'a str,
+	source_lines: &'a [&'a str],
+	num_width: usize,
+	visible_range: Option<&'a VisibleLineRange>,
+	omit_checksum: bool,
+	anchor_style: ChunkAnchorStyle,
+	show_leaf_preview: bool,
+	last_was_blank_meta: bool,
 	full_display_threshold: usize,
-	preview_head_lines:     usize,
-	preview_tail_lines:     usize,
-	tab_replacement:        &'a str,
-	normalize_indent:       Option<(char, usize)>,
-	fenced_lines:           HashSet<u32>,
-	focus:                  Option<HashMap<&'a str, ChunkFocusMode>>,
-	inline_hunks:           HashMap<String, Vec<InlineHunk>>,
-	compact_meta:           bool,
-	changed_anchor_paths:   HashSet<String>,
+	preview_head_lines: usize,
+	preview_tail_lines: usize,
+	tab_replacement: &'a str,
+	normalize_indent: Option<(char, usize)>,
+	fenced_lines: HashSet<u32>,
+	focus: Option<HashMap<&'a str, ChunkFocusMode>>,
+	inline_hunks: HashMap<String, Vec<InlineHunk>>,
+	compact_meta: bool,
+	changed_anchor_paths: HashSet<String>,
 }
 
 fn push_line(out: &mut String, line: String) {
@@ -1105,7 +1114,7 @@ fn emit_inline_hunks_for(ctx: &mut RenderCtx<'_>, chunk_path: &str) {
 }
 
 struct ChunkSubtreeOptions {
-	is_first_top_level:            bool,
+	is_first_top_level: bool,
 	between_top_level_definitions: bool,
 }
 
@@ -1197,10 +1206,12 @@ fn emit_chunk_subtree(
 					}
 				}
 			}
-			emit_chunk_subtree(ctx, child, depth + 1, ChunkSubtreeOptions {
-				is_first_top_level:            false,
-				between_top_level_definitions: false,
-			});
+			emit_chunk_subtree(
+				ctx,
+				child,
+				depth + 1,
+				ChunkSubtreeOptions { is_first_top_level: false, between_top_level_definitions: false },
+			);
 			cursor = cursor.max(child.end_line.saturating_add(1));
 		}
 		if cursor <= span.end && !is_container {
@@ -1213,10 +1224,15 @@ fn emit_chunk_subtree(
 		return;
 	}
 	for (index, child) in children.iter().enumerate() {
-		emit_chunk_subtree(ctx, child, depth + 1, ChunkSubtreeOptions {
-			is_first_top_level:            index == 0,
-			between_top_level_definitions: true,
-		});
+		emit_chunk_subtree(
+			ctx,
+			child,
+			depth + 1,
+			ChunkSubtreeOptions {
+				is_first_top_level: index == 0,
+				between_top_level_definitions: true,
+			},
+		);
 	}
 }
 

--- a/crates/pi-natives/src/chunk/resolve.rs
+++ b/crates/pi-natives/src/chunk/resolve.rs
@@ -9,7 +9,7 @@ const CHECKSUM_ALPHABET: &str = "ZPMQVRWSNKTXJBYH";
 
 pub struct ResolvedChunk<'a> {
 	pub chunk: &'a ChunkNode,
-	pub crc:   Option<String>,
+	pub crc: Option<String>,
 }
 
 fn parse_region_name(value: &str) -> Option<ChunkRegion> {
@@ -38,8 +38,8 @@ pub fn split_region_suffix(selector: &str) -> (&str, bool, Option<ChunkRegion>) 
 
 pub struct ParsedSelector {
 	pub selector: Option<String>,
-	pub crc:      Option<String>,
-	pub region:   Option<ChunkRegion>,
+	pub crc: Option<String>,
+	pub region: Option<ChunkRegion>,
 }
 
 pub fn split_selector_crc_and_region(
@@ -921,38 +921,48 @@ mod tests {
 	}
 
 	fn state_for_resolution() -> ChunkStateInner {
-		ChunkStateInner::new(String::new(), "typescript".to_owned(), ChunkTree {
-			language:          "typescript".to_owned(),
-			checksum:          "ROOT".to_owned(),
-			line_count:        1,
-			parse_errors:      0,
-			parse_error_lines: Vec::new(),
-			fallback:          false,
-			root_path:         String::new(),
-			root_children:     vec!["fn_handleTerraform".to_owned()],
-			chunks:            vec![
-				chunk("", "ROOT", None, vec!["fn_handleTerraform"]),
-				chunk("fn_handleTerraform", "HVJB", Some(""), vec!["fn_handleTerraform.try"]),
-				chunk("fn_handleTerraform.try", "RQPB", Some("fn_handleTerraform"), vec![
-					"fn_handleTerraform.try.if_2",
-				]),
-				chunk("fn_handleTerraform.try.if_2", "PKPV", Some("fn_handleTerraform.try"), vec![
-					"fn_handleTerraform.try.if_2.loop",
-				]),
-				chunk(
-					"fn_handleTerraform.try.if_2.loop",
-					"MZRS",
-					Some("fn_handleTerraform.try.if_2"),
-					vec!["fn_handleTerraform.try.if_2.loop.if_2"],
-				),
-				chunk(
-					"fn_handleTerraform.try.if_2.loop.if_2",
-					"QKJY",
-					Some("fn_handleTerraform.try.if_2.loop"),
-					vec![],
-				),
-			],
-		})
+		ChunkStateInner::new(
+			String::new(),
+			"typescript".to_owned(),
+			ChunkTree {
+				language: "typescript".to_owned(),
+				checksum: "ROOT".to_owned(),
+				line_count: 1,
+				parse_errors: 0,
+				parse_error_lines: Vec::new(),
+				fallback: false,
+				root_path: String::new(),
+				root_children: vec!["fn_handleTerraform".to_owned()],
+				chunks: vec![
+					chunk("", "ROOT", None, vec!["fn_handleTerraform"]),
+					chunk("fn_handleTerraform", "HVJB", Some(""), vec!["fn_handleTerraform.try"]),
+					chunk(
+						"fn_handleTerraform.try",
+						"RQPB",
+						Some("fn_handleTerraform"),
+						vec!["fn_handleTerraform.try.if_2"],
+					),
+					chunk(
+						"fn_handleTerraform.try.if_2",
+						"PKPV",
+						Some("fn_handleTerraform.try"),
+						vec!["fn_handleTerraform.try.if_2.loop"],
+					),
+					chunk(
+						"fn_handleTerraform.try.if_2.loop",
+						"MZRS",
+						Some("fn_handleTerraform.try.if_2"),
+						vec!["fn_handleTerraform.try.if_2.loop.if_2"],
+					),
+					chunk(
+						"fn_handleTerraform.try.if_2.loop.if_2",
+						"QKJY",
+						Some("fn_handleTerraform.try.if_2.loop"),
+						vec![],
+					),
+				],
+			},
+		)
 	}
 
 	#[test]
@@ -978,22 +988,31 @@ mod tests {
 
 	#[test]
 	fn resolves_stale_selector_by_same_parent_checksum() {
-		let state = ChunkStateInner::new(String::new(), "typescript".to_owned(), ChunkTree {
-			language:          "typescript".to_owned(),
-			checksum:          "ROOT".to_owned(),
-			line_count:        1,
-			parse_errors:      0,
-			parse_error_lines: Vec::new(),
-			fallback:          false,
-			root_path:         String::new(),
-			root_children:     vec!["fn_run".to_owned()],
-			chunks:            vec![
-				chunk("", "ROOT", None, vec!["fn_run"]),
-				chunk("fn_run", "CCCC", Some(""), vec!["fn_run.var_effect_1", "fn_run.var_effect_2"]),
-				chunk("fn_run.var_effect_1", "AAAA", Some("fn_run"), vec![]),
-				chunk("fn_run.var_effect_2", "BBBB", Some("fn_run"), vec![]),
-			],
-		});
+		let state = ChunkStateInner::new(
+			String::new(),
+			"typescript".to_owned(),
+			ChunkTree {
+				language: "typescript".to_owned(),
+				checksum: "ROOT".to_owned(),
+				line_count: 1,
+				parse_errors: 0,
+				parse_error_lines: Vec::new(),
+				fallback: false,
+				root_path: String::new(),
+				root_children: vec!["fn_run".to_owned()],
+				chunks: vec![
+					chunk("", "ROOT", None, vec!["fn_run"]),
+					chunk(
+						"fn_run",
+						"CCCC",
+						Some(""),
+						vec!["fn_run.var_effect_1", "fn_run.var_effect_2"],
+					),
+					chunk("fn_run.var_effect_1", "AAAA", Some("fn_run"), vec![]),
+					chunk("fn_run.var_effect_2", "BBBB", Some("fn_run"), vec![]),
+				],
+			},
+		);
 		let mut warnings = Vec::new();
 		let resolved =
 			resolve_chunk_with_crc(&state, Some("fn_run.var_effect"), Some("BBBB"), &mut warnings)
@@ -1008,22 +1027,26 @@ mod tests {
 
 	#[test]
 	fn stale_selector_prefers_best_leaf_name_when_crc_matches_multiple_siblings() {
-		let state = ChunkStateInner::new(String::new(), "typescript".to_owned(), ChunkTree {
-			language:          "typescript".to_owned(),
-			checksum:          "ROOT".to_owned(),
-			line_count:        1,
-			parse_errors:      0,
-			parse_error_lines: Vec::new(),
-			fallback:          false,
-			root_path:         String::new(),
-			root_children:     vec!["fn_run".to_owned()],
-			chunks:            vec![
-				chunk("", "ROOT", None, vec!["fn_run"]),
-				chunk("fn_run", "CCCC", Some(""), vec!["fn_run.var_other", "fn_run.var_effect_1"]),
-				chunk("fn_run.var_other", "BBBB", Some("fn_run"), vec![]),
-				chunk("fn_run.var_effect_1", "BBBB", Some("fn_run"), vec![]),
-			],
-		});
+		let state = ChunkStateInner::new(
+			String::new(),
+			"typescript".to_owned(),
+			ChunkTree {
+				language: "typescript".to_owned(),
+				checksum: "ROOT".to_owned(),
+				line_count: 1,
+				parse_errors: 0,
+				parse_error_lines: Vec::new(),
+				fallback: false,
+				root_path: String::new(),
+				root_children: vec!["fn_run".to_owned()],
+				chunks: vec![
+					chunk("", "ROOT", None, vec!["fn_run"]),
+					chunk("fn_run", "CCCC", Some(""), vec!["fn_run.var_other", "fn_run.var_effect_1"]),
+					chunk("fn_run.var_other", "BBBB", Some("fn_run"), vec![]),
+					chunk("fn_run.var_effect_1", "BBBB", Some("fn_run"), vec![]),
+				],
+			},
+		);
 		let mut warnings = Vec::new();
 		let resolved =
 			resolve_chunk_with_crc(&state, Some("fn_run.var_effect"), Some("BBBB"), &mut warnings)
@@ -1033,22 +1056,31 @@ mod tests {
 
 	#[test]
 	fn stale_selector_fails_closed_when_same_parent_crc_matches_are_ambiguous() {
-		let state = ChunkStateInner::new(String::new(), "typescript".to_owned(), ChunkTree {
-			language:          "typescript".to_owned(),
-			checksum:          "ROOT".to_owned(),
-			line_count:        1,
-			parse_errors:      0,
-			parse_error_lines: Vec::new(),
-			fallback:          false,
-			root_path:         String::new(),
-			root_children:     vec!["fn_run".to_owned()],
-			chunks:            vec![
-				chunk("", "ROOT", None, vec!["fn_run"]),
-				chunk("fn_run", "CCCC", Some(""), vec!["fn_run.var_effect_1", "fn_run.var_effect_2"]),
-				chunk("fn_run.var_effect_1", "BBBB", Some("fn_run"), vec![]),
-				chunk("fn_run.var_effect_2", "BBBB", Some("fn_run"), vec![]),
-			],
-		});
+		let state = ChunkStateInner::new(
+			String::new(),
+			"typescript".to_owned(),
+			ChunkTree {
+				language: "typescript".to_owned(),
+				checksum: "ROOT".to_owned(),
+				line_count: 1,
+				parse_errors: 0,
+				parse_error_lines: Vec::new(),
+				fallback: false,
+				root_path: String::new(),
+				root_children: vec!["fn_run".to_owned()],
+				chunks: vec![
+					chunk("", "ROOT", None, vec!["fn_run"]),
+					chunk(
+						"fn_run",
+						"CCCC",
+						Some(""),
+						vec!["fn_run.var_effect_1", "fn_run.var_effect_2"],
+					),
+					chunk("fn_run.var_effect_1", "BBBB", Some("fn_run"), vec![]),
+					chunk("fn_run.var_effect_2", "BBBB", Some("fn_run"), vec![]),
+				],
+			},
+		);
 		let mut warnings = Vec::new();
 		let Err(err) =
 			resolve_chunk_with_crc(&state, Some("fn_run.var_effect"), Some("BBBB"), &mut warnings)
@@ -1060,21 +1092,25 @@ mod tests {
 
 	#[test]
 	fn resolves_full_untruncated_identifier_paths() {
-		let state = ChunkStateInner::new(String::new(), "typescript".to_owned(), ChunkTree {
-			language:          "typescript".to_owned(),
-			checksum:          "ROOT".to_owned(),
-			line_count:        1,
-			parse_errors:      0,
-			parse_error_lines: Vec::new(),
-			fallback:          false,
-			root_path:         String::new(),
-			root_children:     vec!["class_Server".to_owned()],
-			chunks:            vec![
-				chunk("", "ROOT", None, vec!["class_Server"]),
-				chunk("class_Server", "CLSS", Some(""), vec!["class_Server.fn_handle"]),
-				chunk("class_Server.fn_handle", "ABCD", Some("class_Server"), vec![]),
-			],
-		});
+		let state = ChunkStateInner::new(
+			String::new(),
+			"typescript".to_owned(),
+			ChunkTree {
+				language: "typescript".to_owned(),
+				checksum: "ROOT".to_owned(),
+				line_count: 1,
+				parse_errors: 0,
+				parse_error_lines: Vec::new(),
+				fallback: false,
+				root_path: String::new(),
+				root_children: vec!["class_Server".to_owned()],
+				chunks: vec![
+					chunk("", "ROOT", None, vec!["class_Server"]),
+					chunk("class_Server", "CLSS", Some(""), vec!["class_Server.fn_handle"]),
+					chunk("class_Server.fn_handle", "ABCD", Some("class_Server"), vec![]),
+				],
+			},
+		);
 		let mut warnings = Vec::new();
 		let resolved = resolve_chunk_with_crc(
 			&state,

--- a/crates/pi-natives/src/chunk/schema.rs
+++ b/crates/pi-natives/src/chunk/schema.rs
@@ -9,11 +9,11 @@ struct GeneratedSchema {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct NodeTypeSchema {
-	pub identifier_fields:       Vec<String>,
-	pub body_fields:             Vec<String>,
-	pub promotion_fields:        Vec<String>,
-	pub container_child_kinds:   Vec<String>,
-	pub is_supertype:            bool,
+	pub identifier_fields: Vec<String>,
+	pub body_fields: Vec<String>,
+	pub promotion_fields: Vec<String>,
+	pub container_child_kinds: Vec<String>,
+	pub is_supertype: bool,
 	pub has_structural_children: bool,
 }
 

--- a/crates/pi-natives/src/chunk/state.rs
+++ b/crates/pi-natives/src/chunk/state.rs
@@ -35,26 +35,26 @@ static TLAPLUS_END_TRANSLATION_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ConflictMeta {
-	pub theirs_content:  String,
-	pub ours_label:      String,
-	pub theirs_label:    String,
-	pub base_content:    Option<String>,
-	pub base_label:      Option<String>,
+	pub theirs_content: String,
+	pub ours_label: String,
+	pub theirs_label: String,
+	pub base_content: Option<String>,
+	pub base_label: Option<String>,
 	pub ours_start_byte: usize,
-	pub ours_end_byte:   usize,
+	pub ours_end_byte: usize,
 }
 
 #[derive(Clone)]
 pub struct ChunkStateInner {
-	pub(crate) source:        String,
-	pub(crate) language:      String,
-	pub(crate) tree:          ChunkTree,
-	pub(crate) notebook:      Option<crate::chunk::ast_ipynb::SharedNotebookContext>,
+	pub(crate) source: String,
+	pub(crate) language: String,
+	pub(crate) tree: ChunkTree,
+	pub(crate) notebook: Option<crate::chunk::ast_ipynb::SharedNotebookContext>,
 	pub(crate) conflict_meta: HashMap<String, ConflictMeta>,
-	lookup:                   HashMap<String, usize>,
-	checksum_lookup:          HashMap<String, Vec<usize>>,
-	leaf_lookup:              HashMap<String, Vec<usize>>,
-	suffix_lookup:            HashMap<String, Vec<usize>>,
+	lookup: HashMap<String, usize>,
+	checksum_lookup: HashMap<String, Vec<usize>>,
+	leaf_lookup: HashMap<String, Vec<usize>>,
+	suffix_lookup: HashMap<String, Vec<usize>>,
 }
 
 impl ChunkStateInner {
@@ -371,9 +371,9 @@ impl ChunkState {
 				Ok(parsed) => parsed,
 				Err(err) => {
 					return Ok(ReadResult {
-						text:  format!("{}\n\n{}", params.display_path, err),
+						text: format!("{}\n\n{}", params.display_path, err),
 						chunk: Some(ChunkReadTarget {
-							status:   ChunkReadStatus::UnsupportedRegion,
+							status: ChunkReadStatus::UnsupportedRegion,
 							selector: params.read_path.clone(),
 						}),
 					});
@@ -382,7 +382,7 @@ impl ChunkState {
 		let visible_range = selector.as_deref().and_then(parse_visible_line_range);
 		let Some(root) = self.inner.root() else {
 			return Ok(ReadResult {
-				text:  format!("{}\n\n[Chunk tree root missing]", params.display_path),
+				text: format!("{}\n\n[Chunk tree root missing]", params.display_path),
 				chunk: None,
 			});
 		};
@@ -398,7 +398,7 @@ impl ChunkState {
 					)
 				};
 				return Ok(ReadResult {
-					text:  format!(
+					text: format!(
 						"Line {} is beyond end of file ({} lines total). {suggestion}",
 						visible_range.start_line,
 						self.inner.tree().line_count,
@@ -409,7 +409,7 @@ impl ChunkState {
 
 			let clamped_range = VisibleLineRange {
 				start_line: visible_range.start_line,
-				end_line:   visible_range.end_line.min(self.inner.tree().line_count),
+				end_line: visible_range.end_line.min(self.inner.tree().line_count),
 			};
 			let notice = format!(
 				"[Notice: chunk view scoped to requested lines L{}-L{}; clipped chunks keep head/tail \
@@ -417,35 +417,35 @@ impl ChunkState {
 				clamped_range.start_line, clamped_range.end_line
 			);
 			let text = self.render(RenderParams {
-				chunk_path:           Some(root.path.clone()),
-				title:                params.display_path.clone(),
-				language_tag:         params.language_tag.clone(),
-				visible_range:        Some(clamped_range),
+				chunk_path: Some(root.path.clone()),
+				title: params.display_path.clone(),
+				language_tag: params.language_tag.clone(),
+				visible_range: Some(clamped_range),
 				render_children_only: true,
-				omit_checksum:        params.omit_checksum,
-				anchor_style:         params.anchor_style,
-				show_leaf_preview:    true,
-				tab_replacement:      params.tab_replacement,
-				normalize_indent:     params.normalize_indent,
-				focused_paths:        None,
+				omit_checksum: params.omit_checksum,
+				anchor_style: params.anchor_style,
+				show_leaf_preview: true,
+				tab_replacement: params.tab_replacement,
+				normalize_indent: params.normalize_indent,
+				focused_paths: None,
 			});
 			return Ok(ReadResult { text: format!("{notice}\n\n{text}"), chunk: None });
 		}
 
 		if selector.as_deref().is_none_or(str::is_empty) && crc.is_none() && region.is_none() {
 			return Ok(ReadResult {
-				text:  self.render(RenderParams {
-					chunk_path:           Some(root.path.clone()),
-					title:                params.display_path.clone(),
-					language_tag:         params.language_tag.clone(),
-					visible_range:        None,
+				text: self.render(RenderParams {
+					chunk_path: Some(root.path.clone()),
+					title: params.display_path.clone(),
+					language_tag: params.language_tag.clone(),
+					visible_range: None,
 					render_children_only: true,
-					omit_checksum:        params.omit_checksum,
-					anchor_style:         params.anchor_style,
-					show_leaf_preview:    true,
-					tab_replacement:      params.tab_replacement,
-					normalize_indent:     params.normalize_indent,
-					focused_paths:        None,
+					omit_checksum: params.omit_checksum,
+					anchor_style: params.anchor_style,
+					show_leaf_preview: true,
+					tab_replacement: params.tab_replacement,
+					normalize_indent: params.normalize_indent,
+					focused_paths: None,
 				}),
 				chunk: None,
 			});
@@ -472,7 +472,7 @@ impl ChunkState {
 			Err(err) => {
 				let sel = selector.unwrap_or_default();
 				return Ok(ReadResult {
-					text:  format!("{}:{}\n\n{}", params.display_path, sel, err),
+					text: format!("{}:{}\n\n{}", params.display_path, sel, err),
 					chunk: Some(ChunkReadTarget { status: ChunkReadStatus::NotFound, selector: sel }),
 				});
 			},
@@ -507,14 +507,11 @@ impl ChunkState {
 					format!("L{req_start}-L{req_end}")
 				};
 				return Ok(ReadResult {
-					text:  format!(
+					text: format!(
 						"Requested range {requested} does not overlap {}:{} (lines {}-{}).",
 						params.display_path, chunk.path, chunk.start_line, chunk.end_line
 					),
-					chunk: Some(ChunkReadTarget {
-						status:   ChunkReadStatus::Ok,
-						selector: selector_ref,
-					}),
+					chunk: Some(ChunkReadTarget { status: ChunkReadStatus::Ok, selector: selector_ref }),
 				});
 			}
 		}
@@ -559,18 +556,18 @@ impl ChunkState {
 		}
 
 		Ok(ReadResult {
-			text:  self.render(RenderParams {
-				chunk_path:           Some(chunk.path.clone()),
-				title:                format!("{}:{}", params.display_path, chunk.path),
-				language_tag:         params.language_tag.clone(),
-				visible_range:        None,
+			text: self.render(RenderParams {
+				chunk_path: Some(chunk.path.clone()),
+				title: format!("{}:{}", params.display_path, chunk.path),
+				language_tag: params.language_tag.clone(),
+				visible_range: None,
 				render_children_only: false,
-				omit_checksum:        params.omit_checksum,
-				anchor_style:         params.anchor_style,
-				show_leaf_preview:    true,
-				tab_replacement:      params.tab_replacement,
-				normalize_indent:     params.normalize_indent,
-				focused_paths:        None,
+				omit_checksum: params.omit_checksum,
+				anchor_style: params.anchor_style,
+				show_leaf_preview: true,
+				tab_replacement: params.tab_replacement,
+				normalize_indent: params.normalize_indent,
+				focused_paths: None,
 			}),
 			chunk: Some(ChunkReadTarget { status: ChunkReadStatus::Ok, selector: selector_ref }),
 		})
@@ -605,8 +602,8 @@ impl ChunkState {
 #[derive(Clone)]
 struct ParsedChunkReadPath {
 	selector: Option<String>,
-	crc:      Option<String>,
-	region:   Option<ChunkRegion>,
+	crc: Option<String>,
+	region: Option<ChunkRegion>,
 }
 
 fn normalize_language(language: &str) -> String {
@@ -615,12 +612,12 @@ fn normalize_language(language: &str) -> String {
 
 fn chunk_info(chunk: &ChunkNode) -> ChunkInfo {
 	ChunkInfo {
-		path:       chunk.path.clone(),
+		path: chunk.path.clone(),
 		identifier: chunk.identifier.clone(),
-		checksum:   chunk.checksum.clone(),
+		checksum: chunk.checksum.clone(),
 		start_line: chunk.start_line,
-		end_line:   chunk.end_line,
-		leaf:       chunk.leaf,
+		end_line: chunk.end_line,
+		leaf: chunk.leaf,
 	}
 }
 

--- a/crates/pi-natives/src/chunk/types.rs
+++ b/crates/pi-natives/src/chunk/types.rs
@@ -6,21 +6,21 @@ use crate::chunk::{kind::ChunkKind, state::ChunkState};
 
 #[derive(Clone)]
 pub struct ChunkNode {
-	pub path:                String,
-	pub identifier:          Option<String>,
-	pub kind:                ChunkKind,
-	pub leaf:                bool,
+	pub path: String,
+	pub identifier: Option<String>,
+	pub kind: ChunkKind,
+	pub leaf: bool,
 	/// For virtual chunks (for example `theirs` branches in conflicts), content
 	/// that is rendered instead of slicing `source`.
-	pub virtual_content:     Option<String>,
-	pub parent_path:         Option<String>,
-	pub children:            Vec<String>,
-	pub signature:           Option<String>,
-	pub start_line:          u32,
-	pub end_line:            u32,
-	pub line_count:          u32,
-	pub start_byte:          u32,
-	pub end_byte:            u32,
+	pub virtual_content: Option<String>,
+	pub parent_path: Option<String>,
+	pub children: Vec<String>,
+	pub signature: Option<String>,
+	pub start_line: u32,
+	pub end_line: u32,
+	pub line_count: u32,
+	pub start_byte: u32,
+	pub end_byte: u32,
 	/// Start byte of the semantic declaration used for checksums. This can be
 	/// later than `start_byte` when the chunk absorbs attached leading trivia
 	/// such as doc comments or attributes.
@@ -28,35 +28,35 @@ pub struct ChunkNode {
 
 	/// End byte of the prologue region. `None` means the chunk does not expose
 	/// regions.
-	pub prologue_end_byte:   Option<u32>,
+	pub prologue_end_byte: Option<u32>,
 	/// Start byte of the epilogue region. `None` means the chunk does not expose
 	/// regions.
 	pub epilogue_start_byte: Option<u32>,
 
-	pub checksum:    String,
-	pub error:       bool,
-	pub indent:      u32,
+	pub checksum: String,
+	pub error: bool,
+	pub indent: u32,
 	pub indent_char: String,
 	/// True for group-candidate chunks (e.g. `stmts`, `imports`, `decls`) that
 	/// represent an ordered list of similar items. Append/prepend is valid on
 	/// these even when they are leaf nodes.
-	pub group:       bool,
+	pub group: bool,
 }
 
 #[derive(Clone)]
 pub struct ChunkTree {
-	pub language:          String,
-	pub checksum:          String,
-	pub line_count:        u32,
-	pub parse_errors:      u32,
+	pub language: String,
+	pub checksum: String,
+	pub line_count: u32,
+	pub parse_errors: u32,
 	/// 1-indexed line numbers of tree-sitter ERROR / MISSING nodes surfaced
 	/// during parsing. Used to focus error messages around failure locations
 	/// when an edit introduces a parse error far from the edit target.
 	pub parse_error_lines: Vec<u32>,
-	pub fallback:          bool,
-	pub root_path:         String,
-	pub root_children:     Vec<String>,
-	pub chunks:            Vec<ChunkNode>,
+	pub fallback: bool,
+	pub root_path: String,
+	pub root_children: Vec<String>,
+	pub chunks: Vec<ChunkNode>,
 }
 
 /// Summary of a single chunk node for tool output and navigation.
@@ -64,17 +64,17 @@ pub struct ChunkTree {
 #[napi(object)]
 pub struct ChunkInfo {
 	/// Chunk selector path within the tree.
-	pub path:       String,
+	pub path: String,
 	/// Bare chunk identifier (without kind prefix), if available.
 	pub identifier: Option<String>,
 	/// Stable checksum anchor for this chunk.
-	pub checksum:   String,
+	pub checksum: String,
 	/// 1-based start line in the source file (inclusive).
 	pub start_line: u32,
 	/// 1-based end line in the source file (inclusive).
-	pub end_line:   u32,
+	pub end_line: u32,
 	/// Whether this node is a leaf (no child chunks).
-	pub leaf:       bool,
+	pub leaf: bool,
 }
 
 /// Result of resolving a chunk read request against the tree.
@@ -156,7 +156,7 @@ impl ChunkEditOp {
 #[napi(object)]
 pub struct ChunkReadTarget {
 	/// Whether the selector matched.
-	pub status:   ChunkReadStatus,
+	pub status: ChunkReadStatus,
 	/// Sanitized selector string that was applied.
 	pub selector: String,
 }
@@ -169,7 +169,7 @@ pub struct VisibleLineRange {
 	/// First line to include.
 	pub start_line: u32,
 	/// Last line to include.
-	pub end_line:   u32,
+	pub end_line: u32,
 }
 
 /// How chunk anchors are formatted in rendered output (name and checksum
@@ -278,25 +278,25 @@ pub struct FocusedPath {
 #[napi(object)]
 pub struct RenderParams {
 	/// Path of the chunk to render; `None` uses the tree root.
-	pub chunk_path:           Option<String>,
+	pub chunk_path: Option<String>,
 	/// Title line shown above the tree (often the file path).
-	pub title:                String,
+	pub title: String,
 	/// Optional language label for the header block.
-	pub language_tag:         Option<String>,
+	pub language_tag: Option<String>,
 	/// Restrict output to an inclusive line range of the file.
-	pub visible_range:        Option<VisibleLineRange>,
+	pub visible_range: Option<VisibleLineRange>,
 	/// When true, list only direct children instead of a full subtree.
 	pub render_children_only: bool,
 	/// Hide checksums in anchors when true.
-	pub omit_checksum:        bool,
+	pub omit_checksum: bool,
 	/// Anchor formatting style for chunk headers.
-	pub anchor_style:         Option<ChunkAnchorStyle>,
+	pub anchor_style: Option<ChunkAnchorStyle>,
 	/// Include a one-line preview for leaf chunks.
-	pub show_leaf_preview:    bool,
+	pub show_leaf_preview: bool,
 	/// Replace tab characters in displayed previews (e.g. two spaces).
-	pub tab_replacement:      Option<String>,
+	pub tab_replacement: Option<String>,
 	/// When true, normalize displayed indentation to canonical tabs.
-	pub normalize_indent:     Option<bool>,
+	pub normalize_indent: Option<bool>,
 
 	/// When set, restrict rendering to these chunks with their specified focus
 	/// modes. Everything not in this list is skipped.
@@ -309,21 +309,21 @@ pub struct RenderParams {
 #[napi(object)]
 pub struct ReadRenderParams {
 	/// Read selector (`sel=...` path, line range, or empty for whole tree).
-	pub read_path:           String,
+	pub read_path: String,
 	/// Path shown in titles and error messages (often the file path).
-	pub display_path:        String,
+	pub display_path: String,
 	/// Optional language label for the rendered block.
-	pub language_tag:        Option<String>,
+	pub language_tag: Option<String>,
 	/// Hide checksums in rendered anchors.
-	pub omit_checksum:       bool,
+	pub omit_checksum: bool,
 	/// Anchor formatting style.
-	pub anchor_style:        Option<ChunkAnchorStyle>,
+	pub anchor_style: Option<ChunkAnchorStyle>,
 	/// Optional absolute file line range to intersect with the resolved chunk.
 	pub absolute_line_range: Option<VisibleLineRange>,
 	/// Replace tabs in embedded previews.
-	pub tab_replacement:     Option<String>,
+	pub tab_replacement: Option<String>,
 	/// When true, normalize displayed indentation to canonical tabs.
-	pub normalize_indent:    Option<bool>,
+	pub normalize_indent: Option<bool>,
 }
 
 /// Rendered chunk text plus optional resolution metadata for the read request.
@@ -331,7 +331,7 @@ pub struct ReadRenderParams {
 #[napi(object)]
 pub struct ReadResult {
 	/// Rendered UTF-8 text (chunk tree, notice, or error message).
-	pub text:  String,
+	pub text: String,
 	/// When a selector was used, whether it matched and which selector applied.
 	pub chunk: Option<ChunkReadTarget>,
 }
@@ -342,20 +342,20 @@ pub struct ReadResult {
 #[napi(object)]
 pub struct EditOperation {
 	/// Edit kind (replace, delete, insert relative to anchor).
-	pub op:      ChunkEditOp,
+	pub op: ChunkEditOp,
 	/// Chunk selector path; falls back to `EditParams.defaultSelector` when
 	/// omitted.
-	pub sel:     Option<String>,
+	pub sel: Option<String>,
 	/// Optional checksum anchor; falls back to `EditParams.defaultCrc` when
 	/// omitted.
-	pub crc:     Option<String>,
+	pub crc: Option<String>,
 	/// Region to target. When omitted, targets the full chunk.
-	pub region:  Option<ChunkRegion>,
+	pub region: Option<ChunkRegion>,
 	/// Replacement or inserted text (meaning depends on `op`).
 	pub content: Option<String>,
 	/// For `replace` op: literal substring to find inside the target chunk.
 	/// Must match exactly once.
-	pub find:    Option<String>,
+	pub find: Option<String>,
 }
 
 /// Arguments for applying a batch of chunk edits to a file.
@@ -363,20 +363,20 @@ pub struct EditOperation {
 #[napi(object)]
 pub struct EditParams {
 	/// Edits to apply in order.
-	pub operations:       Vec<EditOperation>,
+	pub operations: Vec<EditOperation>,
 	/// When true, normalize indentation for response rendering and inserted
 	/// content. When false, preserve literal tabs/spaces.
 	pub normalize_indent: Option<bool>,
 	/// Default chunk selector when an `EditOperation` omits `sel`.
 	pub default_selector: Option<String>,
 	/// Default checksum when an `EditOperation` omits `crc`.
-	pub default_crc:      Option<String>,
+	pub default_crc: Option<String>,
 	/// Anchor formatting for rendered response text.
-	pub anchor_style:     Option<ChunkAnchorStyle>,
+	pub anchor_style: Option<ChunkAnchorStyle>,
 	/// Working directory used to resolve `filePath` and display paths.
-	pub cwd:              String,
+	pub cwd: String,
 	/// Path to the source file to edit (often relative to `cwd`).
-	pub file_path:        String,
+	pub file_path: String,
 }
 
 /// Result of applying edits: new parse state plus before/after source and
@@ -385,19 +385,19 @@ pub struct EditParams {
 #[napi(object, object_from_js = false)]
 pub struct EditResult {
 	/// Chunk tree state after applying edits and re-parsing.
-	pub state:         ChunkState,
+	pub state: ChunkState,
 	/// Full file text before edits.
-	pub diff_before:   String,
+	pub diff_before: String,
 	/// Full file text after edits.
-	pub diff_after:    String,
+	pub diff_after: String,
 	/// Rendered summary for tooling (hunks, anchors), driven by `anchorStyle`.
 	pub response_text: String,
 	/// Whether the on-disk source changed.
-	pub changed:       bool,
+	pub changed: bool,
 	/// Whether the updated source re-parsed without fatal issues.
-	pub parse_valid:   bool,
+	pub parse_valid: bool,
 	/// Absolute or normalized paths that were written or touched.
 	pub touched_paths: Vec<String>,
 	/// Non-fatal issues (e.g. selector warnings) collected during apply.
-	pub warnings:      Vec<String>,
+	pub warnings: Vec<String>,
 }

--- a/crates/pi-natives/src/clipboard.rs
+++ b/crates/pi-natives/src/clipboard.rs
@@ -17,7 +17,7 @@ use crate::task;
 #[napi(object)]
 pub struct ClipboardImage {
 	/// PNG-encoded image bytes.
-	pub data:      Uint8Array,
+	pub data: Uint8Array,
 	/// MIME type for the encoded image payload.
 	pub mime_type: String,
 }
@@ -70,7 +70,7 @@ pub fn read_image_from_clipboard() -> task::Promise<Option<ClipboardImage>> {
 			Ok(image) => {
 				let bytes = encode_png(image)?;
 				Ok(Some(ClipboardImage {
-					data:      Uint8Array::from(bytes),
+					data: Uint8Array::from(bytes),
 					mime_type: "image/png".to_string(),
 				}))
 			},

--- a/crates/pi-natives/src/fd.rs
+++ b/crates/pi-natives/src/fd.rs
@@ -14,39 +14,39 @@ use crate::{fs_cache, task};
 #[napi(object)]
 pub struct FuzzyFindOptions<'env> {
 	/// Fuzzy query to match against file paths (case-insensitive).
-	pub query:       String,
+	pub query: String,
 	/// Directory to search.
-	pub path:        String,
+	pub path: String,
 	/// Include hidden files (default: false).
-	pub hidden:      Option<bool>,
+	pub hidden: Option<bool>,
 	/// Respect .gitignore (default: true).
-	pub gitignore:   Option<bool>,
+	pub gitignore: Option<bool>,
 	/// Enable shared filesystem scan cache (default: false).
-	pub cache:       Option<bool>,
+	pub cache: Option<bool>,
 	/// Maximum number of matches to return (default: 100).
 	pub max_results: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal:      Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 	/// Timeout in milliseconds for the operation.
-	pub timeout_ms:  Option<u32>,
+	pub timeout_ms: Option<u32>,
 }
 
 /// A single match in fuzzy find results.
 #[napi(object)]
 pub struct FuzzyFindMatch {
 	/// Relative path from the search root (uses `/` separators).
-	pub path:         String,
+	pub path: String,
 	/// Whether this entry is a directory.
 	pub is_directory: bool,
 	/// Match quality score (higher is better).
-	pub score:        u32,
+	pub score: u32,
 }
 
 /// Result of fuzzy file path search.
 #[napi(object)]
 pub struct FuzzyFindResult {
 	/// Matched entries (up to `maxResults`).
-	pub matches:       Vec<FuzzyFindMatch>,
+	pub matches: Vec<FuzzyFindMatch>,
 	/// Total number of matches found (may exceed `matches.len()`).
 	pub total_matches: u32,
 }
@@ -139,12 +139,12 @@ fn score_fuzzy_path(
 }
 
 struct FuzzyFindConfig {
-	query:       String,
-	path:        String,
-	hidden:      Option<bool>,
-	gitignore:   Option<bool>,
+	query: String,
+	path: String,
+	hidden: Option<bool>,
+	gitignore: Option<bool>,
 	max_results: Option<u32>,
-	cache:       Option<bool>,
+	cache: Option<bool>,
 }
 
 fn score_entries(

--- a/crates/pi-natives/src/fs_cache.rs
+++ b/crates/pi-natives/src/fs_cache.rs
@@ -33,9 +33,9 @@ use crate::{env_uint, task};
 #[napi]
 pub enum FileType {
 	/// Regular file.
-	File    = 1,
+	File = 1,
 	/// Directory.
-	Dir     = 2,
+	Dir = 2,
 	/// Symbolic link.
 	Symlink = 3,
 }
@@ -45,12 +45,12 @@ pub enum FileType {
 #[napi(object)]
 pub struct GlobMatch {
 	/// Relative path from the search root, using forward slashes.
-	pub path:      String,
+	pub path: String,
 	/// Resolved filesystem type for the match.
 	pub file_type: FileType,
 	/// Modification time in milliseconds since Unix epoch (from
 	/// `symlink_metadata`).
-	pub mtime:     Option<f64>,
+	pub mtime: Option<f64>,
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -84,23 +84,23 @@ pub fn max_cache_entries() -> usize {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct CacheKey {
-	root:              PathBuf,
-	include_hidden:    bool,
-	use_gitignore:     bool,
+	root: PathBuf,
+	include_hidden: bool,
+	use_gitignore: bool,
 	skip_node_modules: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ScanOptions {
-	pub include_hidden:    bool,
-	pub use_gitignore:     bool,
+	pub include_hidden: bool,
+	pub use_gitignore: bool,
 	pub skip_node_modules: bool,
 }
 
 #[derive(Clone)]
 struct CacheEntry {
 	created_at: Instant,
-	entries:    Vec<GlobMatch>,
+	entries: Vec<GlobMatch>,
 }
 
 static FS_CACHE: LazyLock<DashMap<CacheKey, CacheEntry>> = LazyLock::new(DashMap::new);
@@ -108,7 +108,7 @@ static FS_CACHE: LazyLock<DashMap<CacheKey, CacheEntry>> = LazyLock::new(DashMap
 /// Result of a cache-aware scan, including the age of the cached data.
 pub struct ScanResult {
 	/// Scanned filesystem entries.
-	pub entries:      Vec<GlobMatch>,
+	pub entries: Vec<GlobMatch>,
 	/// How old the cached data is in milliseconds (0 = freshly scanned).
 	pub cache_age_ms: u64,
 }
@@ -313,9 +313,9 @@ pub fn get_or_scan(
 	}
 
 	let key = CacheKey {
-		root:              root.to_path_buf(),
-		include_hidden:    options.include_hidden,
-		use_gitignore:     options.use_gitignore,
+		root: root.to_path_buf(),
+		include_hidden: options.include_hidden,
+		use_gitignore: options.use_gitignore,
 		skip_node_modules: options.skip_node_modules,
 	};
 
@@ -324,7 +324,7 @@ pub fn get_or_scan(
 		let age = now.duration_since(entry.created_at);
 		if age < Duration::from_millis(ttl) {
 			return Ok(ScanResult {
-				entries:      entry.entries.clone(),
+				entries: entry.entries.clone(),
 				cache_age_ms: age.as_millis() as u64,
 			});
 		}
@@ -350,9 +350,9 @@ pub fn force_rescan(
 	ct: &task::CancelToken,
 ) -> Result<Vec<GlobMatch>> {
 	let key = CacheKey {
-		root:              root.to_path_buf(),
-		include_hidden:    options.include_hidden,
-		use_gitignore:     options.use_gitignore,
+		root: root.to_path_buf(),
+		include_hidden: options.include_hidden,
+		use_gitignore: options.use_gitignore,
 		skip_node_modules: options.skip_node_modules,
 	};
 	FS_CACHE.remove(&key);
@@ -546,11 +546,7 @@ mod tests {
 		let ct = crate::task::CancelToken::default();
 		let entries = super::collect_entries(
 			root.path(),
-			super::ScanOptions {
-				include_hidden:    true,
-				use_gitignore:     false,
-				skip_node_modules: true,
-			},
+			super::ScanOptions { include_hidden: true, use_gitignore: false, skip_node_modules: true },
 			&ct,
 		)
 		.unwrap();
@@ -578,11 +574,7 @@ mod tests {
 		// With skip: should only get app.js
 		let entries = super::force_rescan(
 			root.path(),
-			super::ScanOptions {
-				include_hidden:    true,
-				use_gitignore:     false,
-				skip_node_modules: true,
-			},
+			super::ScanOptions { include_hidden: true, use_gitignore: false, skip_node_modules: true },
 			false,
 			&ct,
 		)
@@ -594,8 +586,8 @@ mod tests {
 		let entries = super::force_rescan(
 			root.path(),
 			super::ScanOptions {
-				include_hidden:    true,
-				use_gitignore:     false,
+				include_hidden: true,
+				use_gitignore: false,
 				skip_node_modules: false,
 			},
 			false,

--- a/crates/pi-natives/src/glob.rs
+++ b/crates/pi-natives/src/glob.rs
@@ -31,54 +31,54 @@ use crate::{fs_cache, glob_util, task};
 #[napi(object)]
 pub struct GlobOptions<'env> {
 	/// Glob pattern to match (e.g., "*.ts").
-	pub pattern:              String,
+	pub pattern: String,
 	/// Directory to search.
-	pub path:                 String,
+	pub path: String,
 	/// Filter by file type: "file", "dir", or "symlink". Symlinks are
 	/// matched for file/dir filters based on their target type.
-	pub file_type:            Option<FileType>,
+	pub file_type: Option<FileType>,
 	/// Match simple patterns recursively by default (`*.ts` -> recursive).
-	pub recursive:            Option<bool>,
+	pub recursive: Option<bool>,
 	/// Include hidden files (default: false).
-	pub hidden:               Option<bool>,
+	pub hidden: Option<bool>,
 	/// Maximum number of results to return.
-	pub max_results:          Option<u32>,
+	pub max_results: Option<u32>,
 	/// Respect .gitignore files (default: true).
-	pub gitignore:            Option<bool>,
+	pub gitignore: Option<bool>,
 	/// Enable shared filesystem scan cache (default: false).
-	pub cache:                Option<bool>,
+	pub cache: Option<bool>,
 	/// Sort results by mtime (most recent first) before applying limit.
-	pub sort_by_mtime:        Option<bool>,
+	pub sort_by_mtime: Option<bool>,
 	/// Include `node_modules` entries when the pattern does not explicitly
 	/// mention them.
 	pub include_node_modules: Option<bool>,
 	/// Abort signal for cancelling the operation.
-	pub signal:               Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 	/// Timeout in milliseconds for the operation.
-	pub timeout_ms:           Option<u32>,
+	pub timeout_ms: Option<u32>,
 }
 
 /// Result payload returned by a glob operation.
 #[napi(object)]
 pub struct GlobResult {
 	/// Matched filesystem entries.
-	pub matches:       Vec<GlobMatch>,
+	pub matches: Vec<GlobMatch>,
 	/// Number of returned matches (`matches.len()`), clamped to `u32::MAX`.
 	pub total_matches: u32,
 }
 
 /// Internal runtime config for a single glob execution.
 struct GlobConfig {
-	root:                  std::path::PathBuf,
-	pattern:               String,
-	recursive:             bool,
-	include_hidden:        bool,
-	file_type_filter:      Option<FileType>,
-	max_results:           usize,
-	use_gitignore:         bool,
+	root: std::path::PathBuf,
+	pattern: String,
+	recursive: bool,
+	include_hidden: bool,
+	file_type_filter: Option<FileType>,
+	max_results: usize,
+	use_gitignore: bool,
 	mentions_node_modules: bool,
-	sort_by_mtime:         bool,
-	use_cache:             bool,
+	sort_by_mtime: bool,
+	use_cache: bool,
 }
 
 fn resolve_symlink_target_type(root: &Path, relative_path: &str) -> Option<FileType> {

--- a/crates/pi-natives/src/grep.rs
+++ b/crates/pi-natives/src/grep.rs
@@ -59,66 +59,66 @@ enum OutputMode {
 #[napi(object)]
 pub struct SearchOptions {
 	/// Regex pattern to search for.
-	pub pattern:        String,
+	pub pattern: String,
 	/// Case-insensitive search.
-	pub ignore_case:    Option<bool>,
+	pub ignore_case: Option<bool>,
 	/// Enable multiline matching.
-	pub multiline:      Option<bool>,
+	pub multiline: Option<bool>,
 	/// Maximum number of matches to return.
-	pub max_count:      Option<u32>,
+	pub max_count: Option<u32>,
 	/// Skip first N matches.
-	pub offset:         Option<u32>,
+	pub offset: Option<u32>,
 	/// Lines of context before matches.
 	pub context_before: Option<u32>,
 	/// Lines of context after matches.
-	pub context_after:  Option<u32>,
+	pub context_after: Option<u32>,
 	/// Lines of context before/after matches (legacy).
-	pub context:        Option<u32>,
+	pub context: Option<u32>,
 	/// Truncate lines longer than this (characters).
-	pub max_columns:    Option<u32>,
+	pub max_columns: Option<u32>,
 	/// Output mode (content or count).
-	pub mode:           Option<GrepOutputMode>,
+	pub mode: Option<GrepOutputMode>,
 }
 
 /// Options for searching files on disk.
 #[napi(object)]
 pub struct GrepOptions<'env> {
 	/// Regex pattern to search for.
-	pub pattern:        String,
+	pub pattern: String,
 	/// Directory or file to search.
-	pub path:           String,
+	pub path: String,
 	/// Glob filter for filenames (e.g., "*.ts").
-	pub glob:           Option<String>,
+	pub glob: Option<String>,
 	/// Filter by file type (e.g., "js", "py", "rust").
-	pub r#type:         Option<String>,
+	pub r#type: Option<String>,
 	/// Case-insensitive search.
-	pub ignore_case:    Option<bool>,
+	pub ignore_case: Option<bool>,
 	/// Enable multiline matching.
-	pub multiline:      Option<bool>,
+	pub multiline: Option<bool>,
 	/// Include hidden files (default: true).
-	pub hidden:         Option<bool>,
+	pub hidden: Option<bool>,
 	/// Respect .gitignore files (default: true).
-	pub gitignore:      Option<bool>,
+	pub gitignore: Option<bool>,
 	/// Enable shared filesystem scan cache (default: false).
-	pub cache:          Option<bool>,
+	pub cache: Option<bool>,
 	/// Maximum number of matches to return.
-	pub max_count:      Option<u32>,
+	pub max_count: Option<u32>,
 	/// Skip first N matches.
-	pub offset:         Option<u32>,
+	pub offset: Option<u32>,
 	/// Lines of context before matches.
 	pub context_before: Option<u32>,
 	/// Lines of context after matches.
-	pub context_after:  Option<u32>,
+	pub context_after: Option<u32>,
 	/// Lines of context before/after matches (legacy).
-	pub context:        Option<u32>,
+	pub context: Option<u32>,
 	/// Truncate lines longer than this (characters).
-	pub max_columns:    Option<u32>,
+	pub max_columns: Option<u32>,
 	/// Output mode (content, filesWithMatches, or count).
-	pub mode:           Option<GrepOutputMode>,
+	pub mode: Option<GrepOutputMode>,
 	/// Abort signal for cancelling the operation.
-	pub signal:         Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 	/// Timeout in milliseconds for the operation.
-	pub timeout_ms:     Option<u32>,
+	pub timeout_ms: Option<u32>,
 }
 
 /// A context line (before or after a match).
@@ -128,35 +128,35 @@ pub struct ContextLine {
 	/// 1-indexed line number in the source file.
 	pub line_number: u32,
 	/// Raw line content (trimmed line ending).
-	pub line:        String,
+	pub line: String,
 }
 
 /// A single match in the content.
 #[napi(object)]
 pub struct Match {
 	/// 1-indexed line number.
-	pub line_number:    u32,
+	pub line_number: u32,
 	/// The matched line content.
-	pub line:           String,
+	pub line: String,
 	/// Context lines before the match.
 	pub context_before: Option<Vec<ContextLine>>,
 	/// Context lines after the match.
-	pub context_after:  Option<Vec<ContextLine>>,
+	pub context_after: Option<Vec<ContextLine>>,
 	/// Whether the line was truncated.
-	pub truncated:      Option<bool>,
+	pub truncated: Option<bool>,
 }
 
 /// Result of searching content.
 #[napi(object)]
 pub struct SearchResult {
 	/// All matches found.
-	pub matches:       Vec<Match>,
+	pub matches: Vec<Match>,
 	/// Total number of matches (may exceed `matches.len()` due to offset/limit).
-	pub match_count:   u32,
+	pub match_count: u32,
 	/// Whether the limit was reached.
 	pub limit_reached: bool,
 	/// Error message, if any.
-	pub error:         Option<String>,
+	pub error: Option<String>,
 }
 
 /// A single match in a grep result.
@@ -164,34 +164,34 @@ pub struct SearchResult {
 #[napi(object)]
 pub struct GrepMatch {
 	/// File path for the match (relative for directory searches).
-	pub path:           String,
+	pub path: String,
 	/// 1-indexed line number (0 for count-only entries).
-	pub line_number:    u32,
+	pub line_number: u32,
 	/// The matched line content (empty for count-only entries).
-	pub line:           String,
+	pub line: String,
 	/// Context lines before the match.
 	pub context_before: Option<Vec<ContextLine>>,
 	/// Context lines after the match.
-	pub context_after:  Option<Vec<ContextLine>>,
+	pub context_after: Option<Vec<ContextLine>>,
 	/// Whether the line was truncated.
-	pub truncated:      Option<bool>,
+	pub truncated: Option<bool>,
 	/// Per-file match count (count mode only).
-	pub match_count:    Option<u32>,
+	pub match_count: Option<u32>,
 }
 
 /// Result of searching files.
 #[napi(object)]
 pub struct GrepResult {
 	/// Matches or per-file counts, depending on output mode.
-	pub matches:            Vec<GrepMatch>,
+	pub matches: Vec<GrepMatch>,
 	/// Total matches across all files.
-	pub total_matches:      u32,
+	pub total_matches: u32,
 	/// Number of files with at least one match.
 	pub files_with_matches: u32,
 	/// Number of files searched.
-	pub files_searched:     u32,
+	pub files_searched: u32,
 	/// Whether the limit/offset stopped the search early.
-	pub limit_reached:      Option<bool>,
+	pub limit_reached: Option<bool>,
 }
 
 enum TypeFilter {
@@ -220,42 +220,42 @@ impl TypeFilter {
 // ---------------------------------------------------------------------------
 
 struct MatchCollector {
-	matches:         Vec<CollectedMatch>,
-	match_count:     u64,
+	matches: Vec<CollectedMatch>,
+	match_count: u64,
 	collected_count: u64,
-	max_count:       Option<u64>,
-	offset:          u64,
-	skipped:         u64,
-	limit_reached:   bool,
-	max_columns:     Option<usize>,
+	max_count: Option<u64>,
+	offset: u64,
+	skipped: u64,
+	limit_reached: bool,
+	max_columns: Option<usize>,
 	collect_matches: bool,
-	context_before:  SmallVec<[ContextLine; 8]>,
+	context_before: SmallVec<[ContextLine; 8]>,
 }
 
 struct CollectedMatch {
-	line_number:    u64,
-	line:           String,
+	line_number: u64,
+	line: String,
 	context_before: SmallVec<[ContextLine; 8]>,
-	context_after:  SmallVec<[ContextLine; 8]>,
-	truncated:      bool,
+	context_after: SmallVec<[ContextLine; 8]>,
+	truncated: bool,
 }
 
 struct SearchResultInternal {
-	matches:       Vec<CollectedMatch>,
-	match_count:   u64,
-	collected:     u64,
+	matches: Vec<CollectedMatch>,
+	match_count: u64,
+	collected: u64,
 	limit_reached: bool,
 }
 
 struct FileEntry {
-	path:          PathBuf,
+	path: PathBuf,
 	relative_path: String,
 }
 
 struct FileSearchResult {
 	relative_path: String,
-	matches:       Vec<CollectedMatch>,
-	match_count:   u64,
+	matches: Vec<CollectedMatch>,
+	match_count: u64,
 }
 
 enum FileBytes {
@@ -499,11 +499,11 @@ fn resolve_context(
 #[derive(Clone, Copy)]
 struct SearchParams {
 	context_before: u32,
-	context_after:  u32,
-	max_columns:    Option<u32>,
-	mode:           OutputMode,
-	max_count:      Option<u64>,
-	offset:         u64,
+	context_after: u32,
+	max_columns: Option<u32>,
+	mode: OutputMode,
+	max_count: Option<u64>,
+	offset: u64,
 }
 
 fn run_search(
@@ -539,9 +539,9 @@ fn run_search_reader<R: Read>(
 	);
 	searcher.search_reader(matcher, reader, &mut collector)?;
 	Ok(SearchResultInternal {
-		matches:       collector.matches,
-		match_count:   collector.match_count,
-		collected:     collector.collected_count,
+		matches: collector.matches,
+		match_count: collector.match_count,
+		collected: collector.collected_count,
 		limit_reached: collector.limit_reached,
 	})
 }
@@ -647,22 +647,22 @@ const fn empty_search_result(error: Option<String>) -> SearchResult {
 
 /// Internal configuration for grep, extracted from options.
 struct GrepConfig {
-	pattern:        String,
-	path:           String,
-	glob:           Option<String>,
-	type_filter:    Option<String>,
-	ignore_case:    Option<bool>,
-	multiline:      Option<bool>,
-	hidden:         Option<bool>,
-	gitignore:      Option<bool>,
-	cache:          Option<bool>,
-	max_count:      Option<u32>,
-	offset:         Option<u32>,
+	pattern: String,
+	path: String,
+	glob: Option<String>,
+	type_filter: Option<String>,
+	ignore_case: Option<bool>,
+	multiline: Option<bool>,
+	hidden: Option<bool>,
+	gitignore: Option<bool>,
+	cache: Option<bool>,
+	max_count: Option<u32>,
+	offset: Option<u32>,
 	context_before: Option<u32>,
-	context_after:  Option<u32>,
-	context:        Option<u32>,
-	max_columns:    Option<u32>,
-	mode:           Option<GrepOutputMode>,
+	context_after: Option<u32>,
+	context: Option<u32>,
+	max_columns: Option<u32>,
+	mode: Option<GrepOutputMode>,
 }
 
 fn collect_files(
@@ -937,22 +937,22 @@ mod tests {
 	#[cfg(unix)]
 	fn base_grep_config(path: &Path) -> GrepConfig {
 		GrepConfig {
-			pattern:        "needle".to_string(),
-			path:           path.to_string_lossy().into_owned(),
-			glob:           None,
-			type_filter:    None,
-			ignore_case:    None,
-			multiline:      None,
-			hidden:         None,
-			gitignore:      Some(false),
-			cache:          Some(false),
-			max_count:      None,
-			offset:         None,
+			pattern: "needle".to_string(),
+			path: path.to_string_lossy().into_owned(),
+			glob: None,
+			type_filter: None,
+			ignore_case: None,
+			multiline: None,
+			hidden: None,
+			gitignore: Some(false),
+			cache: Some(false),
+			max_count: None,
+			offset: None,
 			context_before: None,
-			context_after:  None,
-			context:        None,
-			max_columns:    None,
-			mode:           None,
+			context_after: None,
+			context: None,
+			max_columns: None,
+			mode: None,
 		}
 	}
 
@@ -1074,8 +1074,8 @@ fn run_parallel_search(
 				let search = run_search(matcher, bytes.as_slice(), file_params).ok()?;
 				Some(FileSearchResult {
 					relative_path: entry.relative_path.clone(),
-					matches:       search.matches,
-					match_count:   search.match_count,
+					matches: search.matches,
+					match_count: search.match_count,
 				})
 			},
 		)
@@ -1139,24 +1139,24 @@ fn run_sequential_search(
 			},
 			OutputMode::Count => {
 				matches.push(GrepMatch {
-					path:           entry.relative_path.clone(),
-					line_number:    0,
-					line:           String::new(),
+					path: entry.relative_path.clone(),
+					line_number: 0,
+					line: String::new(),
 					context_before: None,
-					context_after:  None,
-					truncated:      None,
-					match_count:    Some(crate::utils::clamp_u32(search.match_count)),
+					context_after: None,
+					truncated: None,
+					match_count: Some(crate::utils::clamp_u32(search.match_count)),
 				});
 			},
 			OutputMode::FilesWithMatches => {
 				matches.push(GrepMatch {
-					path:           entry.relative_path.clone(),
-					line_number:    0,
-					line:           String::new(),
+					path: entry.relative_path.clone(),
+					line_number: 0,
+					line: String::new(),
 					context_before: None,
-					context_after:  None,
-					truncated:      None,
-					match_count:    None,
+					context_after: None,
+					truncated: None,
+					match_count: None,
 				});
 			},
 		}
@@ -1195,10 +1195,10 @@ fn search_sync(content: &[u8], options: SearchOptions) -> SearchResult {
 	};
 
 	SearchResult {
-		matches:       result.matches.into_iter().map(to_public_match).collect(),
-		match_count:   crate::utils::clamp_u32(result.match_count),
+		matches: result.matches.into_iter().map(to_public_match).collect(),
+		match_count: crate::utils::clamp_u32(result.match_count),
 		limit_reached: result.limit_reached,
-		error:         None,
+		error: None,
 	}
 }
 
@@ -1242,11 +1242,11 @@ fn grep_sync(
 
 	if !metadata.is_file() && !metadata.is_dir() {
 		return Ok(GrepResult {
-			matches:            Vec::new(),
-			total_matches:      0,
+			matches: Vec::new(),
+			total_matches: 0,
 			files_with_matches: 0,
-			files_searched:     0,
-			limit_reached:      None,
+			files_searched: 0,
+			limit_reached: None,
 		});
 	}
 
@@ -1255,21 +1255,21 @@ fn grep_sync(
 			&& !matches_type_filter(&search_path, filter)
 		{
 			return Ok(GrepResult {
-				matches:            Vec::new(),
-				total_matches:      0,
+				matches: Vec::new(),
+				total_matches: 0,
 				files_with_matches: 0,
-				files_searched:     0,
-				limit_reached:      None,
+				files_searched: 0,
+				limit_reached: None,
 			});
 		}
 
 		let Ok(Some(bytes)) = read_file_bytes(&search_path) else {
 			return Ok(GrepResult {
-				matches:            Vec::new(),
-				total_matches:      0,
+				matches: Vec::new(),
+				total_matches: 0,
 				files_with_matches: 0,
-				files_searched:     0,
-				limit_reached:      None,
+				files_searched: 0,
+				limit_reached: None,
 			});
 		};
 
@@ -1278,11 +1278,11 @@ fn grep_sync(
 
 		if search.match_count == 0 {
 			return Ok(GrepResult {
-				matches:            Vec::new(),
-				total_matches:      0,
+				matches: Vec::new(),
+				total_matches: 0,
 				files_with_matches: 0,
-				files_searched:     1,
-				limit_reached:      None,
+				files_searched: 1,
+				limit_reached: None,
 			});
 		}
 
@@ -1296,24 +1296,24 @@ fn grep_sync(
 			},
 			OutputMode::Count => {
 				matches.push(GrepMatch {
-					path:           path_string,
-					line_number:    0,
-					line:           String::new(),
+					path: path_string,
+					line_number: 0,
+					line: String::new(),
 					context_before: None,
-					context_after:  None,
-					truncated:      None,
-					match_count:    Some(crate::utils::clamp_u32(search.match_count)),
+					context_after: None,
+					truncated: None,
+					match_count: Some(crate::utils::clamp_u32(search.match_count)),
 				});
 			},
 			OutputMode::FilesWithMatches => {
 				matches.push(GrepMatch {
-					path:           path_string,
-					line_number:    0,
-					line:           String::new(),
+					path: path_string,
+					line_number: 0,
+					line: String::new(),
 					context_before: None,
-					context_after:  None,
-					truncated:      None,
-					match_count:    None,
+					context_after: None,
+					truncated: None,
+					match_count: None,
 				});
 			},
 		}
@@ -1356,11 +1356,11 @@ fn grep_sync(
 	ct.heartbeat()?;
 	if entries.is_empty() {
 		return Ok(GrepResult {
-			matches:            Vec::new(),
-			total_matches:      0,
+			matches: Vec::new(),
+			total_matches: 0,
 			files_with_matches: 0,
-			files_searched:     0,
-			limit_reached:      None,
+			files_searched: 0,
+			limit_reached: None,
 		});
 	}
 
@@ -1391,13 +1391,13 @@ fn grep_sync(
 				},
 				OutputMode::Count => {
 					let grep_match = GrepMatch {
-						path:           result.relative_path.clone(),
-						line_number:    0,
-						line:           String::new(),
+						path: result.relative_path.clone(),
+						line_number: 0,
+						line: String::new(),
 						context_before: None,
-						context_after:  None,
-						truncated:      None,
-						match_count:    Some(crate::utils::clamp_u32(result.match_count)),
+						context_after: None,
+						truncated: None,
+						match_count: Some(crate::utils::clamp_u32(result.match_count)),
 					};
 					if let Some(callback) = on_match {
 						callback.call(Ok(grep_match.clone()), ThreadsafeFunctionCallMode::NonBlocking);
@@ -1406,13 +1406,13 @@ fn grep_sync(
 				},
 				OutputMode::FilesWithMatches => {
 					let grep_match = GrepMatch {
-						path:           result.relative_path.clone(),
-						line_number:    0,
-						line:           String::new(),
+						path: result.relative_path.clone(),
+						line_number: 0,
+						line: String::new(),
 						context_before: None,
-						context_after:  None,
-						truncated:      None,
-						match_count:    None,
+						context_after: None,
+						truncated: None,
+						match_count: None,
 					};
 					if let Some(callback) = on_match {
 						callback.call(Ok(grep_match.clone()), ThreadsafeFunctionCallMode::NonBlocking);

--- a/crates/pi-natives/src/highlight.rs
+++ b/crates/pi-natives/src/highlight.rs
@@ -28,66 +28,66 @@ struct ScopeMatchers {
 	comment: Scope,
 
 	// String (index 4)
-	string:                    Scope,
-	constant_character:        Scope,
+	string: Scope,
+	constant_character: Scope,
 	constant_character_escape: Scope,
-	meta_string:               Scope,
+	meta_string: Scope,
 
 	// Number (index 5)
 	constant_numeric: Scope,
 	constant_integer: Scope,
-	constant:         Scope,
+	constant: Scope,
 
 	// Keyword (index 1)
-	keyword:           Scope,
+	keyword: Scope,
 	constant_language: Scope,
 	variable_language: Scope,
-	entity_name_tag:   Scope,
-	storage_type:      Scope,
-	storage_modifier:  Scope,
+	entity_name_tag: Scope,
+	storage_type: Scope,
+	storage_modifier: Scope,
 
 	// Control flow keyword (index 11)
 	keyword_control: Scope,
 
 	// Function (index 2)
 	entity_name_function: Scope,
-	support_function:     Scope,
-	meta_function_call:   Scope,
-	variable_function:    Scope,
+	support_function: Scope,
+	meta_function_call: Scope,
+	variable_function: Scope,
 
 	// Type (index 6)
-	entity_name_type:      Scope,
-	support_type:          Scope,
-	support_class:         Scope,
-	entity_name_class:     Scope,
-	entity_name_struct:    Scope,
-	entity_name_enum:      Scope,
+	entity_name_type: Scope,
+	support_type: Scope,
+	support_class: Scope,
+	entity_name_class: Scope,
+	entity_name_struct: Scope,
+	entity_name_enum: Scope,
 	entity_name_interface: Scope,
-	entity_name_trait:     Scope,
+	entity_name_trait: Scope,
 
 	// Operator (index 7)
-	keyword_operator:     Scope,
+	keyword_operator: Scope,
 	punctuation_accessor: Scope,
 
 	// Punctuation (index 8)
 	punctuation: Scope,
 
 	// Variable (index 3)
-	variable:    Scope,
+	variable: Scope,
 	entity_name: Scope,
-	meta_path:   Scope,
+	meta_path: Scope,
 
 	// Diff (indices 9, 10)
-	markup_inserted:  Scope,
-	markup_deleted:   Scope,
+	markup_inserted: Scope,
+	markup_deleted: Scope,
 	meta_diff_header: Scope,
-	meta_diff_range:  Scope,
+	meta_diff_range: Scope,
 
 	// Property/attribute names → variable (index 3)
 	entity_other_attribute_name: Scope, /* HTML/XML/Astro attribute names
 	                                     * (entity.other.attribute-name.*) */
-	meta_structure_dict_key:     Scope, /* JSON / YAML dictionary keys
-	                                     * (meta.structure.dictionary.key.*) */
+	meta_structure_dict_key: Scope, /* JSON / YAML dictionary keys
+	                                 * (meta.structure.dictionary.key.*) */
 
 	// YAML mapping keys → variable (index 3); must precede generic entity.name.tag → keyword
 	entity_name_tag_yaml: Scope,
@@ -99,10 +99,10 @@ struct ScopeMatchers {
 	entity_name_section: Scope,
 
 	// Markdown rich text → appropriate semantic colors
-	markup_bold:   Scope, // bold text  → keyword (index 1)
+	markup_bold: Scope,   // bold text  → keyword (index 1)
 	markup_italic: Scope, // italic text → keyword (index 1)
-	markup_quote:  Scope, // blockquotes → comment (index 0)
-	markup_raw:    Scope, // inline code → string  (index 4)
+	markup_quote: Scope,  // blockquotes → comment (index 0)
+	markup_raw: Scope,    // inline code → string  (index 4)
 
 	// Ruby / Elixir / Crystal symbols → string (index 4); must precede generic constant → number
 	constant_other_symbol: Scope,
@@ -177,30 +177,30 @@ fn get_scope_matchers() -> &'static ScopeMatchers {
 #[napi(object)]
 pub struct HighlightColors {
 	/// ANSI color for comments.
-	pub comment:     String,
+	pub comment: String,
 	/// ANSI color for keywords.
-	pub keyword:     String,
+	pub keyword: String,
 	/// ANSI color for function names.
-	pub function:    String,
+	pub function: String,
 	/// ANSI color for variables and identifiers.
-	pub variable:    String,
+	pub variable: String,
 	/// ANSI color for string literals.
-	pub string:      String,
+	pub string: String,
 	/// ANSI color for numeric literals.
-	pub number:      String,
+	pub number: String,
 	/// ANSI color for type identifiers.
-	pub r#type:      String,
+	pub r#type: String,
 	/// ANSI color for operators.
-	pub operator:    String,
+	pub operator: String,
 	/// ANSI color for punctuation tokens.
 	pub punctuation: String,
 	/// ANSI color for control flow keywords (if, else, for, while, return,
 	/// import).
-	pub control:     Option<String>,
+	pub control: Option<String>,
 	/// ANSI color for diff inserted lines.
-	pub inserted:    Option<String>,
+	pub inserted: Option<String>,
 	/// ANSI color for diff deleted lines.
-	pub deleted:     Option<String>,
+	pub deleted: Option<String>,
 }
 
 /// Language alias mappings: (aliases, target syntax name).

--- a/crates/pi-natives/src/html.rs
+++ b/crates/pi-natives/src/html.rs
@@ -13,7 +13,7 @@ pub struct HtmlToMarkdownOptions {
 	/// Remove navigation elements, forms, headers, footers.
 	pub clean_content: Option<bool>,
 	/// Skip images during conversion.
-	pub skip_images:   Option<bool>,
+	pub skip_images: Option<bool>,
 }
 
 /// Convert HTML source to Markdown with optional preprocessing.
@@ -33,10 +33,10 @@ pub fn html_to_markdown(
 		let conversion_opts = ConversionOptions {
 			skip_images,
 			preprocessing: PreprocessingOptions {
-				enabled:           clean_content,
-				preset:            PreprocessingPreset::Aggressive,
+				enabled: clean_content,
+				preset: PreprocessingPreset::Aggressive,
 				remove_navigation: true,
-				remove_forms:      true,
+				remove_forms: true,
 			},
 			..Default::default()
 		};

--- a/crates/pi-natives/src/image.rs
+++ b/crates/pi-natives/src/image.rs
@@ -22,28 +22,28 @@ use crate::task;
 #[napi]
 pub enum ImageFormat {
 	/// PNG encoded bytes.
-	PNG  = 0,
+	PNG = 0,
 	/// JPEG encoded bytes.
 	JPEG = 1,
 	/// WebP encoded bytes.
 	WEBP = 2,
 	/// GIF encoded bytes.
-	GIF  = 3,
+	GIF = 3,
 }
 
 /// Sampling filter for resize operations.
 #[napi]
 pub enum SamplingFilter {
 	/// Nearest-neighbor sampling (fast, low quality).
-	Nearest    = 1,
+	Nearest = 1,
 	/// Triangle filter (linear interpolation).
-	Triangle   = 2,
+	Triangle = 2,
 	/// Catmull-Rom filter with sharper edges.
 	CatmullRom = 3,
 	/// Gaussian filter for smoother results.
-	Gaussian   = 4,
+	Gaussian = 4,
 	/// Lanczos3 filter for high-quality downscaling.
-	Lanczos3   = 5,
+	Lanczos3 = 5,
 }
 
 impl From<SamplingFilter> for FilterType {

--- a/crates/pi-natives/src/keys.rs
+++ b/crates/pi-natives/src/keys.rs
@@ -76,9 +76,9 @@ const MOD_NUM_LOCK: u32 = 128;
 #[napi]
 pub enum KeyEventType {
 	/// Key press event.
-	Press   = 1,
+	Press = 1,
 	/// Key repeat event.
-	Repeat  = 2,
+	Repeat = 2,
 	/// Key release event.
 	Release = 3,
 }
@@ -143,27 +143,27 @@ const fn keypad_operator_text_codepoint(codepoint: i32) -> Option<i32> {
 
 /// Parsed Kitty keyboard protocol sequence (subset we care about).
 struct ParsedKittySequence {
-	codepoint:       i32,
-	shifted_key:     Option<i32>,
+	codepoint: i32,
+	shifted_key: Option<i32>,
 	base_layout_key: Option<i32>,
-	text_codepoint:  Option<i32>,
-	modifier:        u32,
-	event_type:      Option<u32>,
+	text_codepoint: Option<i32>,
+	modifier: u32,
+	event_type: Option<u32>,
 }
 
 /// Parsed Kitty keyboard protocol sequence result for a Kitty input sequence.
 #[napi(object)]
 pub struct ParsedKittyResult {
 	/// Primary codepoint associated with the key.
-	pub codepoint:       i32,
+	pub codepoint: i32,
 	/// Optional shifted key codepoint from the sequence.
-	pub shifted_key:     Option<i32>,
+	pub shifted_key: Option<i32>,
 	/// Optional base layout key codepoint from the sequence.
 	pub base_layout_key: Option<i32>,
 	/// Modifier bitmask (shift/alt/ctrl), excluding lock bits.
-	pub modifier:        u32,
+	pub modifier: u32,
 	/// Optional event type (1 = press, 2 = repeat, 3 = release).
-	pub event_type:      Option<KeyEventType>,
+	pub event_type: Option<KeyEventType>,
 }
 
 /// Perfect hash map for legacy sequences - O(1) lookup
@@ -379,11 +379,11 @@ pub fn matches_key(data: String, key_id: String, kitty_protocol_active: bool) ->
 #[napi]
 pub fn parse_kitty_sequence(data: String) -> Option<ParsedKittyResult> {
 	parse_kitty_sequence_bytes(data.as_bytes()).map(|p| ParsedKittyResult {
-		codepoint:       p.codepoint,
-		shifted_key:     p.shifted_key,
+		codepoint: p.codepoint,
+		shifted_key: p.shifted_key,
 		base_layout_key: p.base_layout_key,
-		modifier:        p.modifier,
-		event_type:      optional_kitty_event_type(p.event_type),
+		modifier: p.modifier,
+		event_type: optional_kitty_event_type(p.event_type),
 	})
 }
 
@@ -392,7 +392,7 @@ pub fn parse_kitty_sequence(data: String) -> Option<ParsedKittyResult> {
 // =============================================================================
 
 struct ParsedKeyId<'a> {
-	key:      &'a str,
+	key: &'a str,
 	modifier: u32,
 }
 

--- a/crates/pi-natives/src/power.rs
+++ b/crates/pi-natives/src/power.rs
@@ -10,7 +10,7 @@ use napi_derive::napi;
 #[napi(object, js_name = "MacOSPowerAssertionOptions")]
 pub struct MacOSPowerAssertionOptions {
 	/// Human-readable reason shown in macOS power diagnostics.
-	pub reason:  Option<String>,
+	pub reason: Option<String>,
 	/// Keep the display awake in addition to preventing idle system sleep.
 	pub display: Option<bool>,
 }

--- a/crates/pi-natives/src/prof.rs
+++ b/crates/pi-natives/src/prof.rs
@@ -28,19 +28,19 @@ thread_local! {
 #[derive(Clone)]
 struct ProfileSample {
 	/// Stack of region names (from root to leaf).
-	stack:        SmallVec<[&'static str; 4]>,
+	stack: SmallVec<[&'static str; 4]>,
 	/// Duration in microseconds.
-	duration_us:  u64,
+	duration_us: u64,
 	/// Timestamp (microseconds since process start).
 	timestamp_us: u64,
 }
 
 /// Circular buffer for samples.
 struct CircularBuffer {
-	samples:   Vec<ProfileSample>,
-	capacity:  usize,
+	samples: Vec<ProfileSample>,
+	capacity: usize,
 	write_pos: usize,
-	count:     usize,
+	count: usize,
 }
 
 impl CircularBuffer {
@@ -71,7 +71,7 @@ impl CircularBuffer {
 /// RAII guard that records timing when dropped.
 pub struct ProfileGuard {
 	region: &'static str,
-	start:  Instant,
+	start: Instant,
 }
 
 impl ProfileGuard {
@@ -117,13 +117,13 @@ pub fn profile_region(region: &'static str) -> ProfileGuard {
 #[derive(Clone)]
 pub struct WorkProfile {
 	/// Folded stack format for flamegraph tools.
-	pub folded:       String,
+	pub folded: String,
 	/// Markdown summary of profiling results.
-	pub summary:      String,
+	pub summary: String,
 	/// SVG flamegraph (if generation succeeded).
-	pub svg:          Option<String>,
+	pub svg: Option<String>,
 	/// Total profiled duration in milliseconds.
-	pub total_ms:     f64,
+	pub total_ms: f64,
 	/// Number of samples collected.
 	pub sample_count: u32,
 }

--- a/crates/pi-natives/src/projfs_overlay.rs
+++ b/crates/pi-natives/src/projfs_overlay.rs
@@ -13,7 +13,7 @@ pub struct ProjfsOverlayProbeResult {
 	pub available: bool,
 	/// Human-readable reason when `available` is false (e.g. wrong OS or missing
 	/// DLL).
-	pub reason:    Option<String>,
+	pub reason: Option<String>,
 }
 
 /// Probe whether `ProjFS` overlay virtualization can be started on this system.
@@ -226,28 +226,28 @@ mod imp {
 	}
 
 	struct DirectoryEntry {
-		name_wide:  Vec<u16>,
+		name_wide: Vec<u16>,
 		basic_info: PRJ_FILE_BASIC_INFO,
 	}
 
 	#[derive(Default)]
 	struct DirectoryEnumeration {
-		entries:           Vec<DirectoryEntry>,
-		cursor:            usize,
+		entries: Vec<DirectoryEntry>,
+		cursor: usize,
 		search_expression: Option<Vec<u16>>,
 	}
 
 	struct ProviderContext {
-		lower_root:   PathBuf,
-		api:          Arc<ProjfsApi>,
+		lower_root: PathBuf,
+		api: Arc<ProjfsApi>,
 		enumerations: Mutex<BTreeMap<u128, DirectoryEnumeration>>,
 	}
 
 	struct ProjfsSession {
 		virtualization_context: PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
-		provider_context:       *mut ProviderContext,
-		callbacks:              Box<PRJ_CALLBACKS>,
-		api_handle:             Arc<ProjfsApi>,
+		provider_context: *mut ProviderContext,
+		callbacks: Box<PRJ_CALLBACKS>,
+		api_handle: Arc<ProjfsApi>,
 	}
 
 	// SAFETY: Session ownership is synchronized through `PROJFS_SESSIONS`; raw
@@ -312,8 +312,8 @@ mod imp {
 		}
 
 		let provider_context = Box::new(ProviderContext {
-			lower_root:   lower_root_path,
-			api:          api.clone(),
+			lower_root: lower_root_path,
+			api: api.clone(),
 			enumerations: Mutex::new(BTreeMap::new()),
 		});
 		let provider_context_ptr = Box::into_raw(provider_context);
@@ -423,11 +423,10 @@ mod imp {
 		};
 
 		let mut enumerations = context.enumerations.lock();
-		enumerations.insert(guid_to_u128(unsafe { &*enumeration_id }), DirectoryEnumeration {
-			entries,
-			cursor: 0,
-			search_expression: None,
-		});
+		enumerations.insert(
+			guid_to_u128(unsafe { &*enumeration_id }),
+			DirectoryEnumeration { entries, cursor: 0, search_expression: None },
+		);
 		0
 	}
 
@@ -667,7 +666,7 @@ mod imp {
 				continue;
 			}
 			entries.push(DirectoryEntry {
-				name_wide:  {
+				name_wide: {
 					name_wide.shrink_to_fit();
 					name_wide
 				},
@@ -686,12 +685,12 @@ mod imp {
 
 	fn to_basic_info(metadata: &fs::Metadata) -> PRJ_FILE_BASIC_INFO {
 		PRJ_FILE_BASIC_INFO {
-			IsDirectory:    metadata.is_dir(),
-			FileSize:       metadata.file_size() as i64,
-			CreationTime:   metadata.creation_time() as i64,
+			IsDirectory: metadata.is_dir(),
+			FileSize: metadata.file_size() as i64,
+			CreationTime: metadata.creation_time() as i64,
 			LastAccessTime: metadata.last_access_time() as i64,
-			LastWriteTime:  metadata.last_write_time() as i64,
-			ChangeTime:     metadata.last_write_time() as i64,
+			LastWriteTime: metadata.last_write_time() as i64,
+			ChangeTime: metadata.last_write_time() as i64,
 			FileAttributes: metadata.file_attributes(),
 		}
 	}

--- a/crates/pi-natives/src/ps.rs
+++ b/crates/pi-natives/src/ps.rs
@@ -133,16 +133,16 @@ mod platform {
 	#[repr(C)]
 	#[allow(non_snake_case, reason = "Windows PROCESSENTRY32W field names must match Win32 ABI")]
 	struct PROCESSENTRY32W {
-		dwSize:              u32,
-		cntUsage:            u32,
-		th32ProcessID:       u32,
-		th32DefaultHeapID:   usize,
-		th32ModuleID:        u32,
-		cntThreads:          u32,
+		dwSize: u32,
+		cntUsage: u32,
+		th32ProcessID: u32,
+		th32DefaultHeapID: usize,
+		th32ModuleID: u32,
+		cntThreads: u32,
 		th32ParentProcessID: u32,
-		pcPriClassBase:      i32,
-		dwFlags:             u32,
-		szExeFile:           [u16; 260],
+		pcPriClassBase: i32,
+		dwFlags: u32,
+		szExeFile: [u16; 260],
 	}
 
 	type Handle = *mut std::ffi::c_void;

--- a/crates/pi-natives/src/pty.rs
+++ b/crates/pi-natives/src/pty.rs
@@ -27,26 +27,26 @@ use crate::{shell::ContainmentFenceOptions, task};
 #[napi(object)]
 pub struct PtyStartOptions<'env> {
 	/// Command string to execute.
-	pub command:    String,
+	pub command: String,
 	/// Working directory for command execution.
-	pub cwd:        Option<String>,
+	pub cwd: Option<String>,
 	/// Environment variables for this command.
-	pub env:        Option<HashMap<String, String>>,
+	pub env: Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling.
 	pub timeout_ms: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal:     Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 	/// PTY column count.
-	pub cols:       Option<u16>,
+	pub cols: Option<u16>,
 	/// PTY row count.
-	pub rows:       Option<u16>,
+	pub rows: Option<u16>,
 	/// Filesystem boundary for this command; absent means unrestricted.
 	///
 	/// This path never runs brush-core — it spawns the system `sh`, so the
 	/// in-process checks that confine the non-PTY path do not apply here and
 	/// the OS is the only available enforcement. Without this the boundary was
 	/// opt-out by a tool parameter the model itself supplies.
-	pub fence:      Option<ContainmentFenceOptions>,
+	pub fence: Option<ContainmentFenceOptions>,
 }
 
 /// Result of a PTY command run.
@@ -62,11 +62,11 @@ pub struct PtyRunResult {
 
 #[derive(Clone)]
 struct PtyRunConfig {
-	command:          String,
-	cwd:              Option<String>,
-	env:              Option<HashMap<String, String>>,
-	cols:             u16,
-	rows:             u16,
+	command: String,
+	cwd: Option<String>,
+	env: Option<HashMap<String, String>>,
+	cols: u16,
+	rows: u16,
 	/// Compiled seatbelt profile, present only when a fence was supplied.
 	///
 	/// The profile is compiled here rather than carried as a fence because this
@@ -263,12 +263,7 @@ fn run_pty_sync(
 ) -> Result<PtyRunResult> {
 	let pty_system = native_pty_system();
 	let pair = pty_system
-		.openpty(PtySize {
-			rows:         config.rows,
-			cols:         config.cols,
-			pixel_width:  0,
-			pixel_height: 0,
-		})
+		.openpty(PtySize { rows: config.rows, cols: config.cols, pixel_width: 0, pixel_height: 0 })
 		.map_err(|err| Error::from_reason(format!("Failed to open PTY: {err}")))?;
 
 	// The fence, when present, has to be applied by the OS: this spawns the system

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -83,7 +83,7 @@ impl ShellAbortState {
 
 #[derive(Clone)]
 struct ShellConfig {
-	session_env:   Option<HashMap<String, String>>,
+	session_env: Option<HashMap<String, String>>,
 	snapshot_path: Option<String>,
 }
 
@@ -95,25 +95,25 @@ struct ShellConfig {
 #[napi(object)]
 pub struct ContainmentFenceOptions {
 	/// Roots the shell may read and write.
-	pub allow:            Vec<String>,
+	pub allow: Vec<String>,
 	/// Roots the shell may read but not write.
-	pub allow_read_only:  Vec<String>,
+	pub allow_read_only: Vec<String>,
 	/// Roots the shell may write but not read.
 	pub allow_write_only: Vec<String>,
 	/// Roots denied in both directions, winning over any allow they sit inside.
-	pub deny:             Vec<String>,
+	pub deny: Vec<String>,
 	/// Exact directories whose entries may not be enumerated.
-	pub deny_enumerate:   Vec<String>,
+	pub deny_enumerate: Vec<String>,
 }
 
 impl From<&ContainmentFenceOptions> for ContainmentFence {
 	fn from(options: &ContainmentFenceOptions) -> Self {
 		Self {
-			allow:            options.allow.iter().map(PathBuf::from).collect(),
-			allow_read_only:  options.allow_read_only.iter().map(PathBuf::from).collect(),
+			allow: options.allow.iter().map(PathBuf::from).collect(),
+			allow_read_only: options.allow_read_only.iter().map(PathBuf::from).collect(),
 			allow_write_only: options.allow_write_only.iter().map(PathBuf::from).collect(),
-			deny:             options.deny.iter().map(PathBuf::from).collect(),
-			deny_enumerate:   options.deny_enumerate.iter().map(PathBuf::from).collect(),
+			deny: options.deny.iter().map(PathBuf::from).collect(),
+			deny_enumerate: options.deny_enumerate.iter().map(PathBuf::from).collect(),
 		}
 	}
 }
@@ -142,11 +142,11 @@ pub fn fence_permits(
 #[napi(object)]
 pub struct ContainmentBackendInfo {
 	/// `"landlock"`, `"seatbelt"`, or `"scanner-only"` when the OS cannot help.
-	pub backend:          String,
+	pub backend: String,
 	/// Landlock ABI version, when that is the backend.
-	pub abi:              Option<u32>,
+	pub abi: Option<u32>,
 	/// Why there is no OS backend, when there is none.
-	pub reason:           Option<String>,
+	pub reason: Option<String>,
 	/// Whether truncation is governed. False on Landlock ABI 2, which is a real
 	/// if narrow gap.
 	pub truncate_handled: bool,
@@ -168,15 +168,15 @@ pub fn containment_backend() -> ContainmentBackendInfo {
 
 		match availability() {
 			Availability::Available(abi) => ContainmentBackendInfo {
-				backend:          "landlock".to_owned(),
-				abi:              Some(abi),
-				reason:           None,
+				backend: "landlock".to_owned(),
+				abi: Some(abi),
+				reason: None,
 				truncate_handled: truncate_handled(abi),
 			},
 			Availability::Unavailable(reason) => ContainmentBackendInfo {
-				backend:          "scanner-only".to_owned(),
-				abi:              None,
-				reason:           Some(reason.reason().to_owned()),
+				backend: "scanner-only".to_owned(),
+				abi: None,
+				reason: Some(reason.reason().to_owned()),
 				truncate_handled: false,
 			},
 		}
@@ -184,18 +184,18 @@ pub fn containment_backend() -> ContainmentBackendInfo {
 	#[cfg(target_os = "macos")]
 	{
 		ContainmentBackendInfo {
-			backend:          "seatbelt".to_owned(),
-			abi:              None,
-			reason:           None,
+			backend: "seatbelt".to_owned(),
+			abi: None,
+			reason: None,
 			truncate_handled: true,
 		}
 	}
 	#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 	{
 		ContainmentBackendInfo {
-			backend:          "scanner-only".to_owned(),
-			abi:              None,
-			reason:           Some("no OS containment backend exists for this platform".to_owned()),
+			backend: "scanner-only".to_owned(),
+			abi: None,
+			reason: Some("no OS containment backend exists for this platform".to_owned()),
 			truncate_handled: false,
 		}
 	}
@@ -205,7 +205,7 @@ pub fn containment_backend() -> ContainmentBackendInfo {
 #[napi(object)]
 pub struct ShellOptions {
 	/// Environment variables to apply once per session.
-	pub session_env:   Option<HashMap<String, String>>,
+	pub session_env: Option<HashMap<String, String>>,
 	/// Optional snapshot file to source on session creation.
 	pub snapshot_path: Option<String>,
 }
@@ -215,28 +215,28 @@ struct ShellRunConfig {
 	/// Command string to execute in the shell.
 	command: String,
 	/// Working directory for the command.
-	cwd:     Option<String>,
+	cwd: Option<String>,
 	/// Environment variables to apply for this command only.
-	env:     Option<HashMap<String, String>>,
+	env: Option<HashMap<String, String>>,
 	/// Which paths this command may reach. `None` is unrestricted.
-	fence:   Option<Arc<ContainmentFence>>,
+	fence: Option<Arc<ContainmentFence>>,
 }
 
 /// Options for running a shell command.
 #[napi(object)]
 pub struct ShellRunOptions<'env> {
 	/// Command string to execute in the shell.
-	pub command:    String,
+	pub command: String,
 	/// Working directory for the command.
-	pub cwd:        Option<String>,
+	pub cwd: Option<String>,
 	/// Environment variables to apply for this command only.
-	pub env:        Option<HashMap<String, String>>,
+	pub env: Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling the command.
 	pub timeout_ms: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal:     Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 	/// Which paths this command may reach. Absent means unrestricted.
-	pub fence:      Option<ContainmentFenceOptions>,
+	pub fence: Option<ContainmentFenceOptions>,
 }
 
 /// Result of running a shell command.
@@ -253,9 +253,9 @@ pub struct ShellRunResult {
 /// Persistent brush-core shell session.
 #[napi]
 pub struct Shell {
-	session:     Arc<TokioMutex<Option<ShellSessionCore>>>,
+	session: Arc<TokioMutex<Option<ShellSessionCore>>>,
 	abort_state: ShellAbortState,
-	config:      ShellConfig,
+	config: ShellConfig,
 }
 
 #[napi]
@@ -296,9 +296,9 @@ impl Shell {
 
 		let run_config = ShellRunConfig {
 			command: options.command,
-			cwd:     options.cwd,
-			env:     options.env,
-			fence:   options
+			cwd: options.cwd,
+			env: options.env,
+			fence: options
 				.fence
 				.as_ref()
 				.map(|f| Arc::new(ContainmentFence::from(f))),
@@ -385,21 +385,21 @@ async fn run_shell_session(
 #[napi(object)]
 pub struct ShellExecuteOptions<'env> {
 	/// Command string to execute in the shell.
-	pub command:       String,
+	pub command: String,
 	/// Working directory for the command.
-	pub cwd:           Option<String>,
+	pub cwd: Option<String>,
 	/// Environment variables to apply for this command only.
-	pub env:           Option<HashMap<String, String>>,
+	pub env: Option<HashMap<String, String>>,
 	/// Environment variables to apply once per session.
-	pub session_env:   Option<HashMap<String, String>>,
+	pub session_env: Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling the command.
-	pub timeout_ms:    Option<u32>,
+	pub timeout_ms: Option<u32>,
 	/// Optional snapshot file to source on session creation.
 	pub snapshot_path: Option<String>,
 	/// Abort signal for cancelling the operation.
-	pub signal:        Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 	/// Which paths this command may reach. Absent means unrestricted.
-	pub fence:         Option<ContainmentFenceOptions>,
+	pub fence: Option<ContainmentFenceOptions>,
 }
 
 /// Result of executing a shell command via brush-core.
@@ -429,9 +429,9 @@ pub fn execute_shell<'env>(
 		ShellConfig { session_env: options.session_env, snapshot_path: options.snapshot_path };
 	let run_config = ShellRunConfig {
 		command: options.command,
-		cwd:     options.cwd,
-		env:     options.env,
-		fence:   options
+		cwd: options.cwd,
+		env: options.env,
+		fence: options
 			.fence
 			.as_ref()
 			.map(|f| Arc::new(ContainmentFence::from(f))),
@@ -1157,7 +1157,7 @@ struct TimeoutCommand {
 	#[arg(required = true)]
 	duration: String,
 	#[arg(required = true, num_args = 1.., trailing_var_arg = true)]
-	command:  Vec<String>,
+	command: Vec<String>,
 }
 
 impl builtins::Command for TimeoutCommand {

--- a/crates/pi-natives/src/task.rs
+++ b/crates/pi-natives/src/task.rs
@@ -51,8 +51,8 @@ use crate::prof::profile_region;
 pub enum AbortReason {
 	Unknown = 1,
 	Timeout = 2,
-	Signal  = 3,
-	User    = 4,
+	Signal = 3,
+	User = 4,
 }
 
 impl TryFrom<u8> for AbortReason {
@@ -71,7 +71,7 @@ impl TryFrom<u8> for AbortReason {
 
 #[derive(Default)]
 struct Flag {
-	reason:   AtomicU8,
+	reason: AtomicU8,
 	notifier: Notify,
 }
 
@@ -107,7 +107,7 @@ impl Flag {
 #[derive(Clone, Default)]
 pub struct CancelToken {
 	deadline: Option<Instant>,
-	flag:     Option<Arc<Flag>>,
+	flag: Option<Arc<Flag>>,
 }
 
 impl From<()> for CancelToken {
@@ -244,9 +244,9 @@ pub struct Blocking<T>
 where
 	T: Send + 'static,
 {
-	tag:          &'static str,
+	tag: &'static str,
 	cancel_token: CancelToken,
-	work:         Option<Box<dyn FnOnce(CancelToken) -> Result<T> + Send>>,
+	work: Option<Box<dyn FnOnce(CancelToken) -> Result<T> + Send>>,
 }
 
 impl<T> Task for Blocking<T>

--- a/crates/pi-natives/src/text.rs
+++ b/crates/pi-natives/src/text.rs
@@ -32,9 +32,9 @@ pub enum Ellipsis {
 	/// Use a single Unicode ellipsis character ("…").
 	Unicode = 0,
 	/// Use three ASCII dots ("...").
-	Ascii   = 1,
+	Ascii = 1,
 	/// Omit ellipsis entirely.
-	Omit    = 2,
+	Omit = 2,
 }
 
 fn build_utf16_string(mut data: Vec<u16>) -> Utf16String {
@@ -54,7 +54,7 @@ fn build_utf16_string(mut data: Vec<u16>) -> Utf16String {
 #[napi(object)]
 pub struct SliceResult {
 	/// UTF-16 slice containing the selected text.
-	pub text:  Utf16String,
+	pub text: Utf16String,
 	/// Visible width of the slice in terminal cells.
 	pub width: u32,
 }
@@ -63,13 +63,13 @@ pub struct SliceResult {
 #[napi(object)]
 pub struct ExtractSegmentsResult {
 	/// UTF-16 content before the overlay region.
-	pub before:       Utf16String,
+	pub before: Utf16String,
 	/// Visible width of the `before` segment.
 	pub before_width: u32,
 	/// UTF-16 content after the overlay region.
-	pub after:        Utf16String,
+	pub after: Utf16String,
 	/// Visible width of the `after` segment.
-	pub after_width:  u32,
+	pub after_width: u32,
 }
 
 // ============================================================================
@@ -91,8 +91,8 @@ const COLOR_NONE: ColorVal = 0;
 #[derive(Clone, Copy, Default)]
 struct AnsiState {
 	attrs: u16,
-	fg:    ColorVal,
-	bg:    ColorVal,
+	fg: ColorVal,
+	bg: ColorVal,
 }
 
 impl AnsiState {
@@ -1256,10 +1256,10 @@ pub fn extract_segments(
 	);
 
 	Ok(ExtractSegmentsResult {
-		before:       build_utf16_string(before),
+		before: build_utf16_string(before),
 		before_width: crate::utils::clamp_u32(bw as u64),
-		after:        build_utf16_string(after),
-		after_width:  crate::utils::clamp_u32(aw as u64),
+		after: build_utf16_string(after),
+		after_width: crate::utils::clamp_u32(aw as u64),
 	})
 }
 

--- a/packages/coding-agent/test/scripts/super-linter-workflow.test.ts
+++ b/packages/coding-agent/test/scripts/super-linter-workflow.test.ts
@@ -8,7 +8,7 @@ describe("Super-Linter workflow", () => {
 		const source = await Bun.file(SUPER_LINTER_WORKFLOW).text();
 
 		expect(source).toContain(
-			"uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@d75d315e83d9947b658f8e86b21654512fd437f6",
+			"uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@a334c5f84fb36d486209be1e331b11c99d05830c",
 		);
 		expect(source).toContain('rust_edition: "2024"');
 	});

--- a/packages/coding-agent/test/scripts/super-linter-workflow.test.ts
+++ b/packages/coding-agent/test/scripts/super-linter-workflow.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+
+const SUPER_LINTER_WORKFLOW = path.resolve(import.meta.dir, "../../../../.github/workflows/super-linter.yml");
+
+describe("Super-Linter workflow", () => {
+	it("pins the edition-aware governance workflow for Rust 2024", async () => {
+		const source = await Bun.file(SUPER_LINTER_WORKFLOW).text();
+
+		expect(source).toContain(
+			"uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@d75d315e83d9947b658f8e86b21654512fd437f6",
+		);
+		expect(source).toContain('rust_edition: "2024"');
+	});
+});

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,19 +2,10 @@
 edition = "2024"
 style_edition = "2024"
 
-# Import Organization
-group_imports = "StdExternalCrate"
-imports_granularity = "Crate"
-imports_indent = "Block"
+# Import organization
 reorder_imports = true
 
-# Comments & Documentation
-comment_width = 80
-format_code_in_doc_comments = true
-normalize_doc_attributes = true
-wrap_comments = true
-
-# Width & Length
+# Width and length
 chain_width = 60
 max_width = 100
 single_line_if_else_max_width = 50
@@ -22,53 +13,23 @@ single_line_let_else_max_width = 50
 
 # Indentation
 hard_tabs = true
-indent_style = "Block"
 tab_spaces = 3
 
-# Spacing
-binop_separator = "Front"
-space_after_colon = true
-space_before_colon = false
-spaces_around_ranges = false
-
-# Trailing Delimiters
+# Trailing delimiters
 match_block_trailing_comma = true
-trailing_comma = "Vertical"
-trailing_semicolon = true
 
-# Formatting Behavior
-condense_wildcard_suffixes = true
+# Formatting behavior
 merge_derives = true
-overflow_delimited_expr = true
 remove_nested_parens = true
 use_field_init_shorthand = true
 use_small_heuristics = "Max"
 
-# Macros & Strings
-format_macro_bodies = true
-format_macro_matchers = true
-format_strings = true
-
-# Code Structure
-brace_style = "SameLineWhere"
+# Code structure
 fn_params_layout = "Tall"
-reorder_impl_items = true
-where_single_line = false
 
-# Match Expressions
-match_arm_blocks = true
+# Match expressions
 match_arm_leading_pipes = "Never"
-
-# Alignment
-enum_discrim_align_threshold = 20
-struct_field_align_threshold = 20
-
-# Blank Lines
-blank_lines_lower_bound = 0
-blank_lines_upper_bound = 1
 
 # Miscellaneous
 force_explicit_abi = true
-hex_literal_case = "Lower"
 newline_style = "Unix"
-ignore = ["crates/brush-core-vendored/**", "crates/brush-builtins-vendored/**"]


### PR DESCRIPTION
Closes #2917

Adopts stable rustfmt options, applies the resulting mechanical formatting, and pins the corrected shared Super-Linter workflow with rust_edition set to 2024. Includes a regression test for the caller contract.

Validation: full workspace suite, strict Clippy, Rust nextest, check, build, PII enforcement, and Antigravity review are green.