### PR TITLE
test(coding-agent): assert stable governance pin contract

### DIFF
--- a/packages/coding-agent/test/scripts/super-linter-workflow.test.ts
+++ b/packages/coding-agent/test/scripts/super-linter-workflow.test.ts
@@ -2,14 +2,38 @@ import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
 
 const SUPER_LINTER_WORKFLOW = path.resolve(import.meta.dir, "../../../../.github/workflows/super-linter.yml");
+const IMMUTABLE_GOVERNED_SUPER_LINTER =
+	/^\s*uses: f5-sales-demo\/docs-control\/\.github\/workflows\/super-linter\.yml@[0-9a-f]{40}\s*$/m;
+
+function hasImmutableGovernedSuperLinter(source: string): boolean {
+	return IMMUTABLE_GOVERNED_SUPER_LINTER.test(source);
+}
 
 describe("Super-Linter workflow", () => {
-	it("pins the edition-aware governance workflow for Rust 2024", async () => {
+	it("pins the canonical governance workflow immutably for Rust 2024", async () => {
 		const source = await Bun.file(SUPER_LINTER_WORKFLOW).text();
 
-		expect(source).toContain(
-			"uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@a334c5f84fb36d486209be1e331b11c99d05830c",
-		);
+		expect(hasImmutableGovernedSuperLinter(source)).toBe(true);
 		expect(source).toContain('rust_edition: "2024"');
+	});
+
+	it("accepts pin rolls while rejecting mutable or noncanonical references", () => {
+		const fullSha = "0".repeat(40);
+		expect(
+			hasImmutableGovernedSuperLinter(
+				`uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@${fullSha}`,
+			),
+		).toBe(true);
+
+		const invalidCallers = [
+			"uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@main",
+			"uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@a334c5f",
+			`uses: example/docs-control/.github/workflows/super-linter.yml@${fullSha}`,
+			`uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yaml@${fullSha}`,
+		];
+
+		for (const caller of invalidCallers) {
+			expect(hasImmutableGovernedSuperLinter(caller)).toBe(false);
+		}
 	});
 });


### PR DESCRIPTION
## What

Replace the transient docs-control commit assertion with the stable governed caller contract: canonical repository and workflow path, immutable full 40-character lowercase SHA, and Rust 2024 input. Add negative coverage for floating, abbreviated, and noncanonical references.

## Why

Managed pin rolls are expected governance updates. Hard-coding the previous commit made legitimate propagation PR #2920 fail after docs-control advanced the immutable pin.

Closes #2921

## Testing

- `bun test --cwd packages/coding-agent test/scripts/super-linter-workflow.test.ts --max-concurrency 1`: 2 pass, 0 fail
- `bunx biome check packages/coding-agent/test/scripts/super-linter-workflow.test.ts`: clean
- `bun run check:ts`: clean
- `bun run pii:gate -- --scope staged`: clean
- `bash scripts/agy-pre-push-review.sh`: no findings; HEAD PII enforcement and repo hygiene clean
- Full coding-agent package run: 6,361 pass, 559 skip, 2 host-specific nested Landlock failures reproduced on unchanged main and tracked in #2924

- [x] Issue linked via `Closes #2921`
- [x] CHANGELOG not required for a test-contract correction