### PR TITLE
fix(coding-agent): validate governed workflow contract

### DIFF
--- a/packages/coding-agent/test/scripts/super-linter-workflow.test.ts
+++ b/packages/coding-agent/test/scripts/super-linter-workflow.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
 
 const SUPER_LINTER_WORKFLOW = path.resolve(import.meta.dir, "../../../../.github/workflows/super-linter.yml");
+const GOVERNED_SUPER_LINTER_CALLER =
+	/^\s+uses: f5-sales-demo\/docs-control\/\.github\/workflows\/super-linter\.yml@[0-9a-f]{40}$/m;
 
 describe("Super-Linter workflow", () => {
 	it("pins the edition-aware governance workflow for Rust 2024", async () => {
 		const source = await Bun.file(SUPER_LINTER_WORKFLOW).text();
 
-		expect(source).toContain(
-			"uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@a334c5f84fb36d486209be1e331b11c99d05830c",
-		);
+		expect(source).toMatch(GOVERNED_SUPER_LINTER_CALLER);
 		expect(source).toContain('rust_edition: "2024"');
 	});
 });


### PR DESCRIPTION
## Summary

- validate the exact governed Super-Linter workflow path
- require an immutable full 40-hex commit revision without hardcoding one fleet rollout SHA
- preserve the Rust 2024 contract assertion

Closes #2922

## Verification

- `bun test packages/coding-agent/test/scripts/super-linter-workflow.test.ts` — 1 passed
- `bun check` — passed
- installed dependency verification — Anthropic SDK 0.115.0 and ACP SDK 1.3.0
- `bash scripts/agy-pre-push-review.sh` — passed with no findings; PII enforce scan clean