### PR TITLE
fix(ai): resolve Antigravity enterprise project

### DIFF
--- a/packages/ai/src/utils/oauth/google-antigravity.ts
+++ b/packages/ai/src/utils/oauth/google-antigravity.ts
@@ -2,6 +2,9 @@
  * Antigravity OAuth flow (Gemini 3, Claude, GPT-OSS via Google Cloud)
  * Uses different OAuth credentials than google-gemini-cli for access to additional models.
  */
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { $env } from "@f5-sales-demo/pi-utils";
 import { getAntigravityAuthHeaders } from "../../providers/google-gemini-cli";
 import { OAuthCallbackFlow } from "./callback-server";
@@ -29,6 +32,8 @@ const CLOUD_CODE_ENDPOINT = "https://cloudcode-pa.googleapis.com";
 const TIER_LEGACY = "legacy-tier";
 const PROJECT_ONBOARD_MAX_ATTEMPTS = 5;
 const PROJECT_ONBOARD_INTERVAL_MS = 2000;
+const PROJECT_ID_PATTERN = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
+const ANTIGRAVITY_CLI_TOKEN_PATH = join(homedir(), ".gemini", "antigravity-cli", "antigravity-oauth-token");
 
 interface LoadCodeAssistPayload {
 	cloudaicompanionProject?: string | { id?: string };
@@ -52,6 +57,119 @@ export const ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA = Object.freeze({
 interface AntigravityProjectRequest {
 	cloudaicompanionProject?: string;
 	metadata: typeof ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA & { duetProject?: string };
+}
+
+interface ProjectEnvironment {
+	GOOGLE_CLOUD_PROJECT?: string;
+	GOOGLE_CLOUD_PROJECT_ID?: string;
+}
+
+interface GcloudProjectCommandResult {
+	exitCode: number;
+	stdout: string;
+}
+
+type GcloudProjectCommand = () => Promise<GcloudProjectCommandResult>;
+
+export interface AntigravityProjectSources {
+	environment?: ProjectEnvironment;
+	readAntigravityProjectId?: () => Promise<string | undefined>;
+	readGcloudProjectId?: () => Promise<string | undefined>;
+}
+
+export interface AntigravityLoginOptions {
+	projectSources?: AntigravityProjectSources;
+}
+
+function normalizeProjectId(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const projectId = value.trim();
+	return PROJECT_ID_PATTERN.test(projectId) ? projectId : undefined;
+}
+
+export async function readAntigravityCliProjectId(
+	metadataPath = ANTIGRAVITY_CLI_TOKEN_PATH,
+): Promise<string | undefined> {
+	try {
+		const metadata = JSON.parse(await readFile(metadataPath, "utf8")) as unknown;
+		if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return undefined;
+		return normalizeProjectId((metadata as { project_id?: unknown }).project_id);
+	} catch {
+		return undefined;
+	}
+}
+
+async function runGcloudProjectCommand(): Promise<GcloudProjectCommandResult> {
+	const subprocess = Bun.spawn(["gcloud", "config", "get-value", "project"], {
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "ignore",
+	});
+	const [stdout, exitCode] = await Promise.all([new Response(subprocess.stdout).text(), subprocess.exited]);
+	return { exitCode, stdout };
+}
+
+export async function readGcloudProjectId(
+	runCommand: GcloudProjectCommand = runGcloudProjectCommand,
+): Promise<string | undefined> {
+	try {
+		const result = await runCommand();
+		if (result.exitCode !== 0) return undefined;
+		return normalizeProjectId(result.stdout);
+	} catch {
+		return undefined;
+	}
+}
+
+async function readExternalProjectId(source: () => Promise<string | undefined>): Promise<string | undefined> {
+	try {
+		return normalizeProjectId(await source());
+	} catch {
+		return undefined;
+	}
+}
+
+export async function resolveAntigravityProjectId(
+	ctrl: OAuthController,
+	sources: AntigravityProjectSources = {},
+): Promise<string | undefined> {
+	const environment = sources.environment ?? {
+		GOOGLE_CLOUD_PROJECT: $env.GOOGLE_CLOUD_PROJECT,
+		GOOGLE_CLOUD_PROJECT_ID: $env.GOOGLE_CLOUD_PROJECT_ID,
+	};
+	const environmentProjectId =
+		normalizeProjectId(environment.GOOGLE_CLOUD_PROJECT) ?? normalizeProjectId(environment.GOOGLE_CLOUD_PROJECT_ID);
+	if (environmentProjectId) {
+		ctrl.onProgress?.("Using the Google Cloud project configured by the environment...");
+		return environmentProjectId;
+	}
+
+	const antigravityProjectId = await readExternalProjectId(
+		sources.readAntigravityProjectId ?? readAntigravityCliProjectId,
+	);
+	if (antigravityProjectId) {
+		ctrl.onProgress?.("Using the Google Cloud project configured by Antigravity CLI...");
+		return antigravityProjectId;
+	}
+
+	const gcloudProjectId = await readExternalProjectId(sources.readGcloudProjectId ?? readGcloudProjectId);
+	if (gcloudProjectId) {
+		ctrl.onProgress?.("Using the Google Cloud project configured by gcloud...");
+		return gcloudProjectId;
+	}
+
+	if (!ctrl.onPrompt) return undefined;
+	const input = await ctrl.onPrompt({
+		message: "Google Cloud project ID (leave blank to use individual-tier discovery):",
+		placeholder: "my-enterprise-project",
+		allowEmpty: true,
+	});
+	if (!input.trim()) return undefined;
+	const promptedProjectId = normalizeProjectId(input);
+	if (!promptedProjectId) {
+		throw new Error("Invalid Google Cloud project ID. Use 6-30 lowercase letters, digits, or hyphens.");
+	}
+	return promptedProjectId;
 }
 
 function buildProjectRequest(configuredProjectId: string | undefined): AntigravityProjectRequest {
@@ -127,8 +245,11 @@ async function onboardProjectWithRetries(
 	);
 }
 
-async function discoverProject(accessToken: string, onProgress?: (message: string) => void): Promise<string> {
-	const configuredProjectId = $env.GOOGLE_CLOUD_PROJECT || $env.GOOGLE_CLOUD_PROJECT_ID;
+async function discoverProject(
+	accessToken: string,
+	configuredProjectId: string | undefined,
+	onProgress?: (message: string) => void,
+): Promise<string> {
 	const projectRequest = buildProjectRequest(configuredProjectId);
 	const headers = {
 		Authorization: `Bearer ${accessToken}`,
@@ -188,8 +309,11 @@ async function getUserEmail(accessToken: string): Promise<string | undefined> {
 }
 
 class AntigravityOAuthFlow extends OAuthCallbackFlow {
-	constructor(ctrl: OAuthController) {
+	#configuredProjectId: string | undefined;
+
+	constructor(ctrl: OAuthController, configuredProjectId: string | undefined) {
 		super(ctrl, CALLBACK_PORT, CALLBACK_PATH);
+		this.#configuredProjectId = configuredProjectId;
 	}
 
 	async generateAuthUrl(state: string, redirectUri: string): Promise<{ url: string; instructions?: string }> {
@@ -239,7 +363,7 @@ class AntigravityOAuthFlow extends OAuthCallbackFlow {
 
 		this.ctrl.onProgress?.("Getting user info...");
 		const email = await getUserEmail(tokenData.access_token);
-		const projectId = await discoverProject(tokenData.access_token, this.ctrl.onProgress);
+		const projectId = await discoverProject(tokenData.access_token, this.#configuredProjectId, this.ctrl.onProgress);
 
 		return {
 			refresh: tokenData.refresh_token,
@@ -254,8 +378,12 @@ class AntigravityOAuthFlow extends OAuthCallbackFlow {
 /**
  * Login with Antigravity OAuth
  */
-export async function loginAntigravity(ctrl: OAuthController): Promise<OAuthCredentials> {
-	const flow = new AntigravityOAuthFlow(ctrl);
+export async function loginAntigravity(
+	ctrl: OAuthController,
+	options: AntigravityLoginOptions = {},
+): Promise<OAuthCredentials> {
+	const configuredProjectId = await resolveAntigravityProjectId(ctrl, options.projectSources);
+	const flow = new AntigravityOAuthFlow(ctrl, configuredProjectId);
 	return flow.login();
 }
 

--- a/packages/ai/src/utils/oauth/google-antigravity.ts
+++ b/packages/ai/src/utils/oauth/google-antigravity.ts
@@ -33,6 +33,7 @@ const TIER_LEGACY = "legacy-tier";
 const PROJECT_ONBOARD_MAX_ATTEMPTS = 5;
 const PROJECT_ONBOARD_INTERVAL_MS = 2000;
 const PROJECT_ID_PATTERN = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
+const PROJECT_NUMBER_PATTERN = /^\d{12}$/;
 const ANTIGRAVITY_CLI_TOKEN_PATH = join(homedir(), ".gemini", "antigravity-cli", "antigravity-oauth-token");
 
 interface LoadCodeAssistPayload {
@@ -84,7 +85,7 @@ export interface AntigravityLoginOptions {
 function normalizeProjectId(value: unknown): string | undefined {
 	if (typeof value !== "string") return undefined;
 	const projectId = value.trim();
-	return PROJECT_ID_PATTERN.test(projectId) ? projectId : undefined;
+	return PROJECT_ID_PATTERN.test(projectId) || PROJECT_NUMBER_PATTERN.test(projectId) ? projectId : undefined;
 }
 
 export async function readAntigravityCliProjectId(
@@ -167,7 +168,9 @@ export async function resolveAntigravityProjectId(
 	if (!input.trim()) return undefined;
 	const promptedProjectId = normalizeProjectId(input);
 	if (!promptedProjectId) {
-		throw new Error("Invalid Google Cloud project ID. Use 6-30 lowercase letters, digits, or hyphens.");
+		throw new Error(
+			"Invalid Google Cloud project. Use a 6-30 character lowercase project ID or a 12-digit project number.",
+		);
 	}
 	return promptedProjectId;
 }

--- a/packages/ai/test/google-antigravity-auth.test.ts
+++ b/packages/ai/test/google-antigravity-auth.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { getBundledModel } from "../src/models";
 import { getAntigravityAuthHeaders } from "../src/providers/google-gemini-cli";
-import { ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA, loginAntigravity } from "../src/utils/oauth/google-antigravity";
+import {
+	ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA,
+	type AntigravityProjectSources,
+	loginAntigravity,
+} from "../src/utils/oauth/google-antigravity";
 
 const TOKEN_URL = "https://oauth2.googleapis.com/token";
 const USER_INFO_URL = "https://www.googleapis.com/oauth2/v1/userinfo?alt=json";
@@ -13,6 +17,9 @@ interface RecordedRequest {
 	url: string;
 	body: Record<string, unknown>;
 }
+
+const NO_EXTERNAL_PROJECT_SOURCES: Pick<AntigravityProjectSources, "readAntigravityProjectId" | "readGcloudProjectId"> =
+	{ readAntigravityProjectId: async () => undefined, readGcloudProjectId: async () => undefined };
 
 function jsonResponse(payload: unknown): Response {
 	return new Response(JSON.stringify(payload), {
@@ -45,6 +52,7 @@ async function withProjectEnvironment(
 async function runLogin(
 	loadPayload: unknown,
 	onboardPayload?: unknown,
+	projectSources: AntigravityProjectSources = {},
 ): Promise<{ projectId: string | undefined; requests: RecordedRequest[] }> {
 	const requests: RecordedRequest[] = [];
 	global.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
@@ -64,9 +72,17 @@ async function runLogin(
 		throw new Error(`Unexpected URL: ${url}`);
 	}) as unknown as typeof fetch;
 
-	const credentials = await loginAntigravity({
-		onManualCodeInput: async () => "authorization-code",
-	});
+	const credentials = await loginAntigravity(
+		{
+			onManualCodeInput: async () => "authorization-code",
+		},
+		{
+			projectSources: {
+				...NO_EXTERNAL_PROJECT_SOURCES,
+				...projectSources,
+			},
+		},
+	);
 	return { projectId: credentials.projectId, requests };
 }
 
@@ -146,6 +162,30 @@ describe("Google Antigravity auth alignment", () => {
 					},
 				},
 			});
+		});
+	});
+
+	it("passes the Antigravity CLI enterprise project through discovery and returned credentials", async () => {
+		await withProjectEnvironment(undefined, undefined, async () => {
+			const { projectId, requests } = await runLogin(
+				{ cloudaicompanionProject: "generated-free-tier-project" },
+				undefined,
+				{ readAntigravityProjectId: async () => "metadata-enterprise-project" },
+			);
+
+			expect(projectId).toBe("metadata-enterprise-project");
+			expect(requests).toEqual([
+				{
+					url: LOAD_CODE_ASSIST_URL,
+					body: {
+						cloudaicompanionProject: "metadata-enterprise-project",
+						metadata: {
+							...ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA,
+							duetProject: "metadata-enterprise-project",
+						},
+					},
+				},
+			]);
 		});
 	});
 

--- a/packages/ai/test/google-antigravity-project.test.ts
+++ b/packages/ai/test/google-antigravity-project.test.ts
@@ -134,16 +134,16 @@ describe("Antigravity project sources", () => {
 				metadataPath,
 				JSON.stringify({
 					auth_method: "oauth",
-					project_id: "metadata-enterprise-project",
+					project_id: "123456789012",
 					region: "",
 					token: "credential-sentinel-must-not-leak",
 				}),
 				{ mode: 0o600 },
 			);
 
-			expect(await readAntigravityCliProjectId(metadataPath)).toBe("metadata-enterprise-project");
+			expect(await readAntigravityCliProjectId(metadataPath)).toBe("123456789012");
 
-			await fs.writeFile(metadataPath, '{"project_id": "invalid", "token": "credential-sentinel');
+			await fs.writeFile(metadataPath, '{"project_id": "123456789012", "token": "credential-sentinel');
 			expect(await readAntigravityCliProjectId(metadataPath)).toBeUndefined();
 		} finally {
 			await fs.rm(tempDirectory, { recursive: true, force: true });

--- a/packages/ai/test/google-antigravity-project.test.ts
+++ b/packages/ai/test/google-antigravity-project.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	type AntigravityProjectSources,
+	readAntigravityCliProjectId,
+	readGcloudProjectId,
+	resolveAntigravityProjectId,
+} from "../src/utils/oauth/google-antigravity";
+
+const NO_PROJECT_SOURCES: AntigravityProjectSources = {
+	environment: {},
+	readAntigravityProjectId: async () => undefined,
+	readGcloudProjectId: async () => undefined,
+};
+
+describe("Antigravity enterprise project resolution", () => {
+	it("prefers GOOGLE_CLOUD_PROJECT before every external source", async () => {
+		const readAntigravityProjectId = vi.fn(async () => "metadata-enterprise-project");
+		const readGcloudProjectId = vi.fn(async () => "gcloud-enterprise-project");
+		const onPrompt = vi.fn(async () => "interactive-enterprise-project");
+
+		const projectId = await resolveAntigravityProjectId(
+			{ onPrompt },
+			{
+				environment: {
+					GOOGLE_CLOUD_PROJECT: "primary-enterprise-project",
+					GOOGLE_CLOUD_PROJECT_ID: "fallback-enterprise-project",
+				},
+				readAntigravityProjectId,
+				readGcloudProjectId,
+			},
+		);
+
+		expect(projectId).toBe("primary-enterprise-project");
+		expect(readAntigravityProjectId).not.toHaveBeenCalled();
+		expect(readGcloudProjectId).not.toHaveBeenCalled();
+		expect(onPrompt).not.toHaveBeenCalled();
+	});
+
+	it("uses GOOGLE_CLOUD_PROJECT_ID when the primary variable is absent", async () => {
+		const projectId = await resolveAntigravityProjectId(
+			{},
+			{
+				...NO_PROJECT_SOURCES,
+				environment: { GOOGLE_CLOUD_PROJECT_ID: "fallback-enterprise-project" },
+			},
+		);
+
+		expect(projectId).toBe("fallback-enterprise-project");
+	});
+
+	it("prefers Antigravity CLI metadata before gcloud configuration", async () => {
+		const readGcloudProjectId = vi.fn(async () => "gcloud-enterprise-project");
+		const projectId = await resolveAntigravityProjectId(
+			{},
+			{
+				...NO_PROJECT_SOURCES,
+				readAntigravityProjectId: async () => "metadata-enterprise-project",
+				readGcloudProjectId,
+			},
+		);
+
+		expect(projectId).toBe("metadata-enterprise-project");
+		expect(readGcloudProjectId).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the configured gcloud project", async () => {
+		const projectId = await resolveAntigravityProjectId(
+			{},
+			{
+				...NO_PROJECT_SOURCES,
+				readGcloudProjectId: async () => "gcloud-enterprise-project",
+			},
+		);
+
+		expect(projectId).toBe("gcloud-enterprise-project");
+	});
+
+	it("prompts interactively only after configured sources are exhausted", async () => {
+		const onPrompt = vi.fn(async () => "interactive-enterprise-project");
+		const projectId = await resolveAntigravityProjectId({ onPrompt }, NO_PROJECT_SOURCES);
+
+		expect(projectId).toBe("interactive-enterprise-project");
+		expect(onPrompt).toHaveBeenCalledWith(
+			expect.objectContaining({
+				allowEmpty: true,
+				message: expect.stringContaining("Google Cloud project ID"),
+			}),
+		);
+	});
+
+	it("treats an explicit blank prompt as individual-tier discovery", async () => {
+		const projectId = await resolveAntigravityProjectId({ onPrompt: async () => "   " }, NO_PROJECT_SOURCES);
+
+		expect(projectId).toBeUndefined();
+	});
+
+	it("keeps noninteractive no-project login on individual-tier discovery", async () => {
+		expect(await resolveAntigravityProjectId({}, NO_PROJECT_SOURCES)).toBeUndefined();
+	});
+
+	it("does not expose external-source errors while falling through", async () => {
+		const credentialSentinel = "credential-sentinel-must-not-leak";
+		const progress: string[] = [];
+		const projectId = await resolveAntigravityProjectId(
+			{
+				onProgress: message => progress.push(message),
+				onPrompt: async () => "",
+			},
+			{
+				environment: {},
+				readAntigravityProjectId: async () => {
+					throw new Error(credentialSentinel);
+				},
+				readGcloudProjectId: async () => {
+					throw new Error(credentialSentinel);
+				},
+			},
+		);
+
+		expect(projectId).toBeUndefined();
+		expect(progress.join("\n")).not.toContain(credentialSentinel);
+	});
+});
+
+describe("Antigravity project sources", () => {
+	it("reads only a valid project_id from Antigravity CLI metadata", async () => {
+		const tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "pi-antigravity-project-"));
+		const metadataPath = path.join(tempDirectory, "antigravity-oauth-token");
+		try {
+			await fs.writeFile(
+				metadataPath,
+				JSON.stringify({
+					auth_method: "oauth",
+					project_id: "metadata-enterprise-project",
+					region: "",
+					token: "credential-sentinel-must-not-leak",
+				}),
+				{ mode: 0o600 },
+			);
+
+			expect(await readAntigravityCliProjectId(metadataPath)).toBe("metadata-enterprise-project");
+
+			await fs.writeFile(metadataPath, '{"project_id": "invalid", "token": "credential-sentinel');
+			expect(await readAntigravityCliProjectId(metadataPath)).toBeUndefined();
+		} finally {
+			await fs.rm(tempDirectory, { recursive: true, force: true });
+		}
+	});
+
+	it("normalizes successful gcloud output and rejects unset or failed output", async () => {
+		expect(await readGcloudProjectId(async () => ({ exitCode: 0, stdout: "gcloud-enterprise-project\n" }))).toBe(
+			"gcloud-enterprise-project",
+		);
+		expect(await readGcloudProjectId(async () => ({ exitCode: 0, stdout: "(unset)\n" }))).toBeUndefined();
+		expect(
+			await readGcloudProjectId(async () => ({ exitCode: 1, stdout: "credential-sentinel-must-not-leak" })),
+		).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Resolve the enterprise Google Cloud project before Antigravity OAuth discovery so authenticated corporate users do not silently bind xcsh to an exhausted individual-tier project.

## Related Issue

Closes #2926

## Changes

- Resolve project precedence from GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_PROJECT_ID, Antigravity CLI metadata, gcloud, then an explicit interactive choice.
- Read only project_id from Antigravity metadata and suppress external-source errors so credential contents cannot leak.
- Accept both validated Google Cloud project IDs and twelve-digit project numbers.
- Carry the selected project through loadCodeAssist, onboarding, and persisted credentials while retaining deliberate individual-tier fallback.
- Preserve google-antigravity/gemini-3.6-flash-high as the post-login default.

## Verification evidence

- Initial focused TDD test failed because Antigravity CLI metadata was ignored; the completed touched suites pass: 18 pass, 0 fail.
- AI package suite: 659 pass, 455 skip, 0 fail.
- Bounded root comparison: 8,284 pass, 1,076 skip, 282 known DOM-runner failures across 9,642 tests, improving on the 283-failure baseline with no regression.
- bun run check:ts: passed across all TypeScript workspaces.
- bun run build: production build passed, including the Linux native addon.
- bun run pii:gate: clean (head scope).
- bash scripts/agy-pre-push-review.sh: clean for origin/main...aaa9d0bea; no blocking, medium, or nit findings.
- Live Ubuntu source verification: OAuth persisted project f5-gcs-2505-dgtl-gemini-prod, selected google-antigravity/gemini-3.6-flash-high, and returned a model response without the individual-quota 429.
- PR CI: https://github.com/f5-sales-demo/xcsh/actions/runs/30942073865 completed green, including the full test, install, Zig, and native-build jobs.

## Checklist

- [x] Linked to a GitHub issue (required - CI blocks merge without it)
- [x] Feature-complete and verified - not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change - evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions
