### PR TITLE
fix(coding-agent): align governed Super-Linter contract

### DIFF
--- a/packages/coding-agent/test/scripts/super-linter-workflow.test.ts
+++ b/packages/coding-agent/test/scripts/super-linter-workflow.test.ts
@@ -10,11 +10,10 @@ function hasImmutableGovernedSuperLinter(source: string): boolean {
 }
 
 describe("Super-Linter workflow", () => {
-	it("pins the canonical governance workflow immutably for Rust 2024", async () => {
+	it("pins the canonical governance workflow immutably", async () => {
 		const source = await Bun.file(SUPER_LINTER_WORKFLOW).text();
 
 		expect(hasImmutableGovernedSuperLinter(source)).toBe(true);
-		expect(source).toContain('rust_edition: "2024"');
 	});
 
 	it("accepts pin rolls while rejecting mutable or noncanonical references", () => {


### PR DESCRIPTION
## Summary

Aligns the coding-agent governance test with the current downstream Super-Linter caller contract. The caller must pin the canonical docs-control reusable workflow by a full commit SHA; Rust edition policy is now owned by that reusable workflow and is no longer a downstream input.

This unblocks canonical caller synchronization without weakening the immutable pin and noncanonical-reference assertions.

## Related issue

Fixes #2929

## Verification

- `bun test packages/coding-agent/test/scripts/super-linter-workflow.test.ts`: 2 passed.
- `bun check`: passed.
- Installed dependency repair verified `@anthropic-ai/sdk` 0.115.0 and `@agentclientprotocol/sdk` 1.3.0 from the current lockfile.
- Full workspace test attempt: 6,354 passed, 559 skipped, 9 failed, 2 errors under concurrent local load; every non-manager failure passed in isolated reruns (52/52), and the triggering manager case passed alone. The remaining full-file manager flake reproduces independently on main and remains tracked in #2463 and #2561; no test was skipped or weakened here.
- Local Antigravity pre-push review of commit `7323d95b6c91c8ff1b91b54df1c10ec91469b161`: clean, including PII enforcement.

## Checklist

- [x] Linked to a detailed GitHub issue
- [x] Focused contract regression covered
- [x] No managed workflow edited downstream
- [x] Local checks and required pre-push review completed
