### PR TITLE
fix(coding-agent): stop sandbox source-text path scanning

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Prevalidated manifest batches before mutation, preserved strict create and update semantics, rejected unsupported server dry-run, and returned automation-grade exit codes for resource operations ([#2930](https://github.com/f5-sales-demo/xcsh/issues/2930))
+- Prevented sandbox false refusals from path-like Bash and Python source text while limiting account and data containers to discovery protection and preserving xcsh-private runtime isolation ([#2931](https://github.com/f5-sales-demo/xcsh/issues/2931))
 
 ## [20.3.0] - 2026-08-04
 

--- a/packages/coding-agent/src/cli/sandbox-check.ts
+++ b/packages/coding-agent/src/cli/sandbox-check.ts
@@ -301,6 +301,56 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 					};
 		});
 
+		// Use a recursive synthetic deny here. The production account root is discovery-only, so testing
+		// against that fence alone would pass even if arbitrary source scanning were accidentally restored.
+		const sourceTextFence: ContainmentFence = {
+			...fence,
+			deny: [...fence.deny, accountRoot],
+		};
+		const pathLikePattern = `${accountRoot}${path.sep}|alpha`;
+		await check("Bash grep pattern remains data (#2931)", () => {
+			const bashResult = evaluateToolCall({
+				toolName: "bash",
+				input: { command: `grep -nE ${JSON.stringify(pathLikePattern)} own.txt` },
+				cwd: workspace,
+				fence: sourceTextFence,
+			});
+			const grepResult = evaluateToolCall({
+				toolName: "grep",
+				input: { pattern: pathLikePattern, path: workspace },
+				cwd: workspace,
+				fence: sourceTextFence,
+			});
+			return !bashResult.block && !grepResult.block
+				? { passed: true }
+				: {
+						passed: false,
+						detail:
+							"Bash and structured grep disagreed on path-like pattern data; path=<synthetic-root>; errno=none",
+					};
+		});
+		await check("Bash Python heredoc remains data (#2931)", () => {
+			const command = [
+				"python3 - <<'PY'",
+				`patterns = {"home path": ${JSON.stringify(`${accountRoot}${path.sep}`)}}`,
+				'print("  scanned for:", list(patterns.values()))',
+				"PY",
+			].join("\n");
+			const result = evaluateToolCall({
+				toolName: "bash",
+				input: { command },
+				cwd: workspace,
+				fence: sourceTextFence,
+			});
+			return !result.block
+				? { passed: true }
+				: {
+						passed: false,
+						detail:
+							"Bash pre-check interpreted Python heredoc source as a path; path=<synthetic-root>; errno=none",
+					};
+		});
+
 		await check("workspace read, write, glob, and recursion", async () => {
 			const displayPath = "<workspace>/<synthetic-fixture>";
 			let liveFixture: string;

--- a/packages/coding-agent/src/cli/sandbox-check.ts
+++ b/packages/coding-agent/src/cli/sandbox-check.ts
@@ -257,14 +257,7 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 		await check("structured tools share the boundary", () => {
 			const blocked = [
 				evaluateToolCall({ toolName: "read", input: { file_path: workspaces }, cwd: workspace, fence }),
-				evaluateToolCall({
-					toolName: "write",
-					input: { file_path: path.join(otherHome, "new.txt") },
-					cwd: workspace,
-					fence,
-				}),
 				evaluateToolCall({ toolName: "find", input: { pattern: `${accountRoot}/**/*` }, cwd: workspace, fence }),
-				evaluateToolCall({ toolName: "grep", input: { path: otherHome }, cwd: workspace, fence }),
 				evaluateToolCall({
 					toolName: "read",
 					input: { file_path: path.join(otherSession, "state.jsonl") },
@@ -277,20 +270,29 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 					cwd: workspace,
 					fence,
 				}),
+			];
+			const allowed = [
+				evaluateToolCall({
+					toolName: "write",
+					input: { file_path: path.join(otherHome, "new.txt") },
+					cwd: workspace,
+					fence,
+				}),
+				evaluateToolCall({ toolName: "grep", input: { path: otherHome }, cwd: workspace, fence }),
 				evaluateToolCall({
 					toolName: "python",
 					input: { code: `import os; os.listdir(${JSON.stringify(accountRoot)})` },
 					cwd: workspace,
 					fence,
 				}),
+				evaluateToolCall({
+					toolName: "write",
+					input: { file_path: path.join(configDir, "config") },
+					cwd: workspace,
+					fence,
+				}),
 			];
-			const ownConfig = evaluateToolCall({
-				toolName: "write",
-				input: { file_path: path.join(configDir, "config") },
-				cwd: workspace,
-				fence,
-			});
-			const passed = blocked.every(result => result.block) && !ownConfig.block;
+			const passed = blocked.every(result => result.block) && allowed.every(result => !result.block);
 			return passed
 				? { passed: true }
 				: {
@@ -420,12 +422,12 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 					redactions,
 				);
 			});
-			await check("synthetic other account cannot be entered", async () => {
+			await check("named other account remains reachable", async () => {
 				const result = await shellProbe(`cd ${quote(otherHome)}`, workspace, fence, abortController.signal);
 				return shellOutcome(
 					result,
-					false,
-					"synthetic other account traversal must be refused",
+					true,
+					"named synthetic account traversal must remain available",
 					"<synthetic-other-account>",
 					redactions,
 				);
@@ -465,7 +467,7 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 				"session parent cannot be enumerated",
 				"explicit grant restores parent enumeration",
 				"account container cannot be enumerated",
-				"synthetic other account cannot be entered",
+				"named other account remains reachable",
 				"cross-session stores cannot be read",
 			]) {
 				add(name, "SKIP", "OS enforcement backend unavailable; path=<probe>; errno=unsupported");

--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -13,19 +13,20 @@ followed symlinks — so how a path is spelled does not change what is reachable
 - The operator's home and configuration belong to the operator. Shell profiles, SSH and GPG state,
   Git and cloud CLI configuration, xcsh settings, plugins, and skills are readable and writable with
   the operator's normal filesystem rights.
-- Cross-tenant isolation removes the discovery step. The directory containing the session root cannot
-  be enumerated, but a sibling path the operator names directly can still be read, written, or entered.
-  An explicit read grant, including `--allow-path <dir>`, restores enumeration for that directory.
-- Cross-session stores, other operators' accounts, and data roots remain denied. Another session's
-  transcripts, memories, internal contexts, and temporary working state are not reachable through
-  tools, nor are sibling local accounts, unrelated data roots, and mounted data volumes.
+- Cross-tenant isolation removes the discovery step. The session container, local-account containers,
+  data roots, and mounted-data containers cannot be enumerated, but a descendant path the operator
+  names directly can still be read, written, or entered. An explicit read grant restores enumeration.
+- Xcsh-private cross-session stores remain denied recursively. Another session's transcripts, memories,
+  internal contexts, credentials, and temporary working state are not reachable unless the operator
+  explicitly grants the relevant root.
 
-The same boundary answers for every tool. `read`, `write`, `grep`, `find`, `python`, and `bash` consult
-the same rules, so changing tools or spelling a path differently does not widen the session.
+Structured filesystem tools and the `bash` runtime consult the same fence. Bash command text is not
+scanned for path-looking strings; the operating system decides when a process actually opens a path.
+The persistent `python` kernel cannot carry a per-session runtime fence, so only an explicit Python
+`cwd` is checked. Python source and cell text are not scanned.
 
 If parent enumeration is refused, use a known path or ask the operator for an explicit read grant. If
-a cross-session or data-root path is refused, do not try to reach it another way. Say what you needed
-and why.
+an xcsh-private cross-session path is refused, say what you needed and why.
 
 This sandbox is a courtesy for session-context isolation, not a privilege boundary against xcsh or the
 operator. The rule of thumb is that if a file belongs to someone other than the operator you are
@@ -47,14 +48,12 @@ Three things behave differently under this backend, and none of them is a bug to
 {{/if}}
 {{else}}
 On this platform there is **no OS-level backend**, so for `bash` the boundary is enforced only by
-scanning the command text before it runs. That check is best-effort by construction: it reads what you
-wrote rather than what the shell will do, so a path assembled at runtime or reached through an unusual
-spelling may not be caught.
+precise pre-checks for an explicit `cwd`, literal redirections, known write operands, and literal
+directory changes. Command and source text are never scanned for path-looking strings.
 
-The intended rules are the same ones a confined session has: parent enumeration is refused while named
-operator access remains available, operator-owned home and configuration stay readable and writable,
-and cross-session stores, other operators' accounts, and unrelated data roots stay denied. Ordinary
-work remains unrestricted.
+Without a runtime backend, Bash child-process reads cannot enforce protected-container enumeration or
+xcsh-private-root denial. Structured tools still enforce those rules, and ordinary work remains
+unrestricted. The persistent `python` kernel is likewise unfenced beyond its explicit `cwd` check.
 
 Treat the boundary as a statement of intent rather than a guarantee, and do not go looking for paths
 outside the session directory on the assumption that something would stop you.

--- a/packages/coding-agent/src/sandbox/command-operands.ts
+++ b/packages/coding-agent/src/sandbox/command-operands.ts
@@ -124,8 +124,8 @@ interface WriteOperandSpec {
 	writesAllPositional?: boolean;
 	/** The final positional operand is written (`cp src dst`). */
 	writesLastPositional?: boolean;
-	/** With this option present the destination moves into it, so positional slots stop being writes. */
-	destinationOption?: string;
+	/** Options that move the destination into their value, so positional slots stop being writes. */
+	destinationOptions?: readonly string[];
 	/** Positional operands that are not paths at all — `chmod 644 f`, `chown me f`. */
 	skipLeadingPositional?: number;
 	/** Every positional is written once this option appears (`install -d a b c`). */
@@ -152,7 +152,7 @@ const WRITE_OPERAND_SPECS: Record<string, WriteOperandSpec> = {
 		valueOptions: ["-S", "--suffix", "-t", "--target-directory"],
 		booleanOptions: COPY_BOOLEAN_OPTIONS,
 		writesLastPositional: true,
-		destinationOption: "-t",
+		destinationOptions: ["-t", "--target-directory"],
 	},
 	// `mv` also REMOVES its sources, so a source in a read-only root is a mutation of that root.
 	// Marking only the destination let `mv /shared/ctx/file .` delete from a read-allowed grant.
@@ -161,13 +161,13 @@ const WRITE_OPERAND_SPECS: Record<string, WriteOperandSpec> = {
 		booleanOptions: ["-f", "--force", "-i", "--interactive", "-n", "--no-clobber", "-v", "--verbose", "-u"],
 		writesLastPositional: true,
 		writesSourcesToo: true,
-		destinationOption: "-t",
+		destinationOptions: ["-t", "--target-directory"],
 	},
 	install: {
 		valueOptions: ["-m", "--mode", "-o", "--owner", "-g", "--group", "-t", "--target-directory", "-S", "--suffix"],
 		booleanOptions: ["-b", "-c", "-C", "-d", "-D", "-p", "-s", "-v", "--verbose", "--backup"],
 		writesLastPositional: true,
-		destinationOption: "-t",
+		destinationOptions: ["-t", "--target-directory"],
 		// `install -d a b c` creates every operand as a directory rather than copying into the last.
 		allPositionalOption: "-d",
 	},
@@ -193,7 +193,7 @@ const WRITE_OPERAND_SPECS: Record<string, WriteOperandSpec> = {
 		valueOptions: ["-S", "--suffix", "-t", "--target-directory"],
 		booleanOptions: ["-b", "-f", "--force", "-i", "-L", "-n", "-P", "-r", "-s", "--symbolic", "-v"],
 		writesLastPositional: true,
-		destinationOption: "-t",
+		destinationOptions: ["-t", "--target-directory"],
 	},
 	shred: {
 		valueOptions: ["-n", "--iterations", "-s", "--size"],
@@ -266,7 +266,8 @@ export function writtenOperandWords(cmd: ShellSimpleCommand): ShellWord[] {
 	// literally named `-t` makes `cp -- -t /drop/secret out/` read as a target-directory option and
 	// relabels a source as a write target.
 	let sawEndOfOptions = false;
-	for (const word of operandWords) {
+	for (let index = 0; index < operandWords.length; index += 1) {
+		const word = operandWords[index];
 		if (word.text === "--") {
 			sawEndOfOptions = true;
 			continue;
@@ -274,7 +275,10 @@ export function writtenOperandWords(cmd: ShellSimpleCommand): ShellWord[] {
 		if (sawEndOfOptions) continue;
 		const option = optionName(word.text);
 		if (option === undefined) continue;
-		if (isOutputOption(spec, option) || spec.valueOptions.includes(option)) continue;
+		if (isOutputOption(spec, option) || spec.valueOptions.includes(option)) {
+			if (!word.text.includes("=")) index += 1;
+			continue;
+		}
 		if (spec.booleanOptions.includes(option)) continue;
 		if (matchesAllPositionalOption(spec, option)) continue;
 		if (bundledBooleans(option, spec) !== undefined) continue;
@@ -311,13 +315,11 @@ export function writtenOperandWords(cmd: ShellSimpleCommand): ShellWord[] {
 				continue;
 			}
 			if (spec.valueOptions.includes(option)) {
-				if (option === spec.destinationOption) destinationMoved = true;
-				if (!attached) {
-					const target = operandWords[index + 1];
-					index += 1;
+				const target = attached ? valueAfterEquals(word) : operandWords[index + 1];
+				if (!attached) index += 1;
+				if (spec.destinationOptions?.includes(option)) {
+					destinationMoved = true;
 					if (target?.literal) written.push(target);
-				} else if (word.literal) {
-					written.push(word);
 				}
 			}
 			continue;

--- a/packages/coding-agent/src/sandbox/command-operands.ts
+++ b/packages/coding-agent/src/sandbox/command-operands.ts
@@ -1,282 +1,10 @@
-/**
- * Which words of a command are provably *not* filesystem references.
- *
- * The read-boundary scan in `enforce.ts` finds path-like tokens by scanning raw command text. That
- * is indiscriminate on purpose, and it is what makes the scan hard to fool — it sees inside quoted
- * scripts, heredoc bodies and nested commands by accident. It also produces the false positives in
- * issue #2470: `sed -n '/a/p'` is refused because `/a/p` is absolute-looking, even though sed never
- * opens it.
- *
- * So this module does not replace that scan. It identifies the narrow set of words a command
- * demonstrably treats as a script or a pattern rather than a filename; `enforce.ts` blanks those
- * spans and re-runs the scan over what is left. The scan remains the floor.
- *
- * Note the exemption is *positional*. An earlier version subtracted token strings, which lost track
- * of which occurrence a token came from: exempting the quoted operand of
- * `echo '/elsewhere/x' && cat /elsewhere/x` also cleared the identical token belonging to `cat`.
- *
- * The invariant to preserve: an exemption must never let a command read a file it would not
- * otherwise open. Concretely, that means every one of these must stay unexempted, because each one
- * really does open the path inside it — `test/sandbox-enforce.test.ts` pins all of them:
- *
- *     sh -c 'cat /work/custB/x'          the shell runs the string
- *     bash <<'EOF' … EOF                 the heredoc body is a script
- *     find . -exec sh -c '…' \;          -exec consumes a whole command run
- *     sed -n 'r /work/custB/x'           sed's `r` reads a file
- *     sed 's|x|cat /work/custB/x|e'      sed's `e` flag executes the replacement
- *     awk 'BEGIN { getline x < "…" }'    awk's getline reads a file
- *
- * When a dialect construct cannot be ruled out, do not exempt. A missed construct is a sandbox
- * escape; a falsely-detected one is only a false positive the current code already produces.
- */
 import type { ShellSimpleCommand, ShellWord } from "../tools/shell-lex";
-
-interface OperandSpec {
-	/** Count of leading non-option operands that are scripts or patterns rather than files. */
-	readonly exemptLeading: number;
-	/** Options that relocate the script, so no leading operand is exemptible. */
-	readonly suppressedBy: readonly string[];
-	/** Options taking no argument. Anything not listed here or in `valueOptions` disables exemption. */
-	readonly booleanOptions: readonly string[];
-	/** Options whose following word is a value, not an operand. */
-	readonly valueOptions: readonly string[];
-	/** Set when every operand is text the command never interprets as a path. */
-	readonly exemptAll?: true;
-	/** Dialect whose file-access constructs must be absent for the exemption to hold. */
-	readonly dialect?: "sed" | "awk";
-}
-
-const SED: OperandSpec = {
-	exemptLeading: 1,
-	suppressedBy: ["-e", "--expression", "-f", "--file"],
-	booleanOptions: [
-		"-n",
-		"--quiet",
-		"--silent",
-		"-s",
-		"--separate",
-		"-u",
-		"--unbuffered",
-		"-z",
-		"--null-data",
-		"-E",
-		"-r",
-		"--regexp-extended",
-		"--posix",
-		"--debug",
-		"--sandbox",
-	],
-	// -i and -l are deliberately absent: GNU sed attaches -i's suffix and gives -l an argument,
-	// while BSD sed gives -i an argument and treats -l as a flag. Their arity is unknowable here,
-	// so they land in the unrecognized bucket and disable exemption.
-	valueOptions: [],
-	dialect: "sed",
-};
-
-const AWK: OperandSpec = {
-	exemptLeading: 1,
-	suppressedBy: ["-f", "--file", "--source"],
-	booleanOptions: ["--posix", "--traditional", "--re-interval", "-c"],
-	valueOptions: ["-v", "--assign", "-F", "--field-separator"],
-	dialect: "awk",
-};
-
-const GREP: OperandSpec = {
-	exemptLeading: 1,
-	suppressedBy: ["-e", "--regexp", "-f", "--file"],
-	booleanOptions: [
-		"-r",
-		"-R",
-		"--recursive",
-		"-i",
-		"--ignore-case",
-		"-v",
-		"--invert-match",
-		"-n",
-		"--line-number",
-		"-H",
-		"--with-filename",
-		"-h",
-		"--no-filename",
-		"-c",
-		"--count",
-		"-l",
-		"--files-with-matches",
-		"-L",
-		"--files-without-match",
-		"-w",
-		"--word-regexp",
-		"-x",
-		"--line-regexp",
-		"-F",
-		"--fixed-strings",
-		"-E",
-		"--extended-regexp",
-		"-P",
-		"--perl-regexp",
-		"-o",
-		"--only-matching",
-		"-q",
-		"--quiet",
-		"-a",
-		"--text",
-		"-s",
-		"--no-messages",
-		"-z",
-		"--null-data",
-		"-b",
-		"--byte-offset",
-		"--color",
-		"--colour",
-	],
-	valueOptions: [
-		"-m",
-		"--max-count",
-		"-A",
-		"--after-context",
-		"-B",
-		"--before-context",
-		"-C",
-		"--context",
-		"--include",
-		"--exclude",
-		"--exclude-dir",
-	],
-};
-
-const EMITTER: OperandSpec = {
-	exemptLeading: 0,
-	suppressedBy: [],
-	booleanOptions: ["-n", "-e", "-E"],
-	valueOptions: [],
-	exemptAll: true,
-};
-
-/**
- * Per-command operand models.
- *
- * `find` and `rg` are deliberately absent. `find -exec` consumes an entire command run, and `rg` has
- * options that execute a program per input (`--pre`, `--hostname-bin`) — in both cases an operand
- * that looks like a pattern can be a path the command runs, so the cost of drawing the boundary
- * wrong is a bypass rather than a false positive. #2470 reports false positives for neither, so
- * there is nothing to buy. `grep`/`egrep`/`fgrep` stay: their option surface is POSIX-stable and
- * contains nothing that executes.
- */
-const SPECS: Record<string, OperandSpec> = {
-	sed: SED,
-	gsed: SED,
-	awk: AWK,
-	gawk: AWK,
-	mawk: AWK,
-	nawk: AWK,
-	grep: GREP,
-	egrep: GREP,
-	fgrep: GREP,
-	echo: EMITTER,
-	printf: EMITTER,
-};
-
-/** A sed address: a line number, `$`, a `/regex/`, or nothing at all. */
-const SED_ADDRESS = String.raw`(?:\/(?:\\.|[^\/\\])*\/|[0-9]+|\$)?`;
-
-/**
- * sed commands that read a file (`r`, `R`), write one (`w`, `W`), or execute a shell command (`e`),
- * in command position after an optional address range. Anchoring on the address is what keeps
- * `s/red/blue/` exempt while catching `/foo/r file`.
- */
-const SED_FILE_ACCESS = new RegExp(
-	String.raw`(?:^|[;{}\n])\s*${SED_ADDRESS}(?:,${SED_ADDRESS})?\s*!?\s*[rRwWe](?:\s|$)`,
-);
-
-/**
- * A substitution flag that writes a file (`w`) or executes the replacement as a shell command (`e`),
- * as in `s/a/b/w file` or `s|x|cat /elsewhere/secret|e`. The `e` flag makes the script arbitrary
- * code, so a script carrying it is never inert text.
- */
-const SED_SUBSTITUTE_EXECUTES = /s(.)(?:\\.|(?!\1)[^\\])*\1(?:\\.|(?!\1)[^\\])*\1[a-zA-Z0-9]*[we]/;
-
-/** awk constructs that read, write, or execute rather than just matching and printing. */
-const AWK_FILE_ACCESS = [
-	/\bgetline\b/,
-	/\bsystem\s*\(/,
-	/\bclose\s*\(/,
-	/\bfflush\s*\(/,
-	/\|/, // a pipe to or from a command
-	/\b(?:print|printf)\b[^;}\n]*>/,
-];
-
-function hasFileAccessConstruct(dialect: "sed" | "awk" | undefined, script: string): boolean {
-	if (dialect === "sed") return SED_FILE_ACCESS.test(script) || SED_SUBSTITUTE_EXECUTES.test(script);
-	if (dialect === "awk") return AWK_FILE_ACCESS.some(pattern => pattern.test(script));
-	return false;
-}
 
 /** The option name of a word, ignoring any `=value` suffix; undefined when it is not an option. */
 function optionName(text: string): string | undefined {
 	if (!text.startsWith("-") || text === "-" || text === "--") return undefined;
 	const equals = text.indexOf("=");
 	return equals === -1 ? text : text.slice(0, equals);
-}
-
-/**
- * Words of `cmd` whose contents the invoked command provably never opens as a path.
- *
- * Returns an empty array whenever anything is uncertain: an unknown command, a suppressing option, a
- * word that is unquoted or carries an expansion, a redirect target, or a script containing a
- * file-access construct.
- */
-export function provenExemptWords(cmd: ShellSimpleCommand): ShellWord[] {
-	if (cmd.name === undefined) return [];
-	const spec = SPECS[cmd.name];
-	if (spec === undefined) return [];
-
-	const operandWords = cmd.words.slice(cmd.operandStart);
-
-	// Which operand holds the script depends entirely on how the options parsed, so an option the
-	// model cannot parse exactly makes the whole command unmodellable. Two ways that bites:
-	// a suppressing option carrying an attached argument (`-e's/a/b/'`) would go unrecognized and
-	// let a real file operand slide into the script slot, and an option of unknown arity (`sed -i`)
-	// would shift every operand by one. Both end in exempting a path the command really opens, so
-	// anything unrecognized disables exemption for this command.
-	for (const word of operandWords) {
-		if (word.redirect !== undefined) continue;
-		const option = optionName(word.text);
-		if (option === undefined) continue;
-		if (spec.suppressedBy.includes(option)) return [];
-		if (!spec.booleanOptions.includes(option) && !spec.valueOptions.includes(option)) return [];
-	}
-
-	const exempt: ShellWord[] = [];
-	let leadingSeen = 0;
-
-	for (let i = 0; i < operandWords.length; i++) {
-		const word = operandWords[i];
-
-		// A redirect target is a real file the shell opens, whatever the command does with its args.
-		if (word.redirect !== undefined) continue;
-
-		const option = optionName(word.text);
-		if (option !== undefined) {
-			// An option's value is consumed here so it is never mistaken for the first operand.
-			if (!word.text.includes("=") && spec.valueOptions.includes(option)) i++;
-			continue;
-		}
-
-		if (!spec.exemptAll) {
-			if (leadingSeen >= spec.exemptLeading) continue;
-			leadingSeen++;
-		}
-
-		// Quoting is the author's own signal that the word is data. An unquoted or expansion-bearing
-		// word is not provably anything, so it stays on the floor.
-		if (word.quote !== "single" && word.quote !== "double") continue;
-		if (!word.literal) continue;
-		if (hasFileAccessConstruct(spec.dialect, word.text)) continue;
-
-		exempt.push(word);
-	}
-
-	return exempt;
 }
 
 /** Flag-only options shared by the compressors. */
@@ -380,8 +108,8 @@ const COPY_BOOLEAN_OPTIONS = [
  * `tar -f` is absent because whether it reads or writes depends on the mode letters, and getting that
  * wrong in the permissive direction is the bug being fixed.
  *
- * Same suppression rule as `provenExemptWords`: an option this model cannot parse exactly shifts operand
- * positions, so anything unrecognized abandons the command rather than guessing at a slot.
+ * An option this model cannot parse exactly shifts operand positions, so anything unrecognized
+ * abandons the command rather than guessing at a slot.
  */
 interface WriteOperandSpec {
 	/** Options taking a separate value, so it is not mistaken for a positional operand. */
@@ -413,7 +141,7 @@ const WRITE_OPERAND_SPECS: Record<string, WriteOperandSpec> = {
 		booleanOptions: ["-a", "--append", "-i", "--ignore-interrupts", "-p"],
 		writesAllPositional: true,
 	},
-	// `of=` is the output file. `if=` stays a read, which is what the floor already gives it.
+	// `of=` is the output file. `if=` is deliberately not interpreted by the pre-check.
 	dd: { valueOptions: [], booleanOptions: [], outputPrefixes: ["of="] },
 	sort: {
 		valueOptions: ["-k", "-t", "-S", "-T", "--key", "--field-separator", "--buffer-size"],
@@ -598,7 +326,7 @@ export function writtenOperandWords(cmd: ShellSimpleCommand): ShellWord[] {
 		// `of=PATH` and friends are positional in shape but name their own direction.
 		const prefix = spec.outputPrefixes?.find(candidate => word.text.startsWith(candidate));
 		if (prefix !== undefined) {
-			if (word.literal) written.push(word);
+			if (word.literal) written.push({ ...word, text: word.text.slice(prefix.length) });
 			continue;
 		}
 

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -7,9 +7,9 @@
  * profile could not even `execvp /bin/cat`.
  *
  * So the fence is gentle. It leaves `/usr`, `/tmp`, package caches, the network and process execution
- * alone. Its cross-tenant courtesy removes the discovery step — enumerating the session root's parent —
- * while keeping named operator access. Other operators' accounts, explicit data roots and cross-session
- * state remain denied where the model has no legitimate reason to wander (#2554).
+ * alone. Its cross-tenant courtesy removes discovery by enumerating session, account, and data
+ * containers while keeping named operator access. Xcsh-private cross-session state remains denied
+ * recursively unless the operator grants it explicitly (#2931).
  *
  * Produced declaratively rather than as an ordered rule list, because the two backends disagree about
  * order: seatbelt evaluates rules in sequence with the last match winning, while Landlock only grants
@@ -257,10 +257,8 @@ function canonicalThroughExisting(target: string): string {
  * otherwise deny `/`, `/usr` or `/tmp` — refusing exactly the work this fence is supposed to leave
  * alone.
  *
- * `/Users` and `/home` were here too, and deliberately are no longer: those hold other operators'
- * accounts, so denying them is the point rather than the accident (#2624). The workspace, the caches
- * and the tool config dirs all match at greater depth, and home is denied anyway, so nothing inside
- * the current account changes.
+ * `/Users` and `/home` are deliberately absent: their exact listings are protected separately while
+ * named account paths remain available (#2931).
  */
 function tooBroadToDeny(candidate: string, fsRoot: string): boolean {
 	if (candidate === path.parse(candidate).root) return true;
@@ -348,14 +346,12 @@ function resolveGrants(roots: readonly string[] | undefined, home: string): Set<
  * Filesystem roots other than the one the workspace is on.
  *
  * On POSIX there is one root and this is empty. On Windows every drive letter is its own root, so a
- * workspace on `C:` left `D:\customerB` and any mapped share matching no rule at all — and Windows has
- * no kernel backend, so the command-text scan is the entire boundary there. While that scan was
- * deny-by-default it refused those paths incidentally; making it agree with the fence (#2624) removed
- * the cover and exposed the gap. Found by adversarial review.
+ * workspace on `C:` otherwise leaves the `D:\` account/data container discoverable. Windows has no
+ * kernel backend, so this exact-enumeration rule is enforced for structured tools but cannot confine a
+ * Bash child process.
  *
  * **Unverified on Windows.** The probe below cannot run on the platforms this fleet uses, so what is
- * tested is the denying, not the discovery — see the test, which injects the list. A drive holding a
- * toolchain is opened again with `--allow-path`, which grants at greater depth.
+ * tested is the exact-enumeration protection, not discovery — see the test, which injects the list.
  *
  * UNC paths (`\\server\share`) have no enumerable root and are not covered.
  */
@@ -446,10 +442,12 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 	// Through `resolveGrants` like the allow-lists, so a session temp dir or artifacts dir that does not
 	// exist yet is still granted rather than silently dropped.
 	const tildeHome = canonical(options.homeForTilde ?? options.home ?? os.homedir()) ?? os.homedir();
-	for (const root of resolveGrants(
-		[options.sessionTmp, ...(options.extraRoots ?? [])].filter((r): r is string => r !== undefined),
+	const sessionTmpResolved = resolveGrants(
+		options.sessionTmp === undefined ? undefined : [options.sessionTmp],
 		tildeHome,
-	)) {
+	);
+	const extraResolved = resolveGrants(options.extraRoots, tildeHome);
+	for (const root of [...sessionTmpResolved, ...extraResolved]) {
 		allow.add(root);
 	}
 	// Kept distinct. Merging them into one read+write list made a folder shared for reading writable,
@@ -474,15 +472,17 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 	// posture is intentionally not enough: it keeps named access working, while this one exact directory
 	// still cannot be scanned. `--allow-path` appears in both settings lists, so it reaches this branch via
 	// `readOnlyResolved`; a write-only grant does not imply permission to learn directory entries.
-	const parentExplicitlyReadable = [...readOnlyResolved].some(root => pathIsWithin(root, parentToProtect));
+	const parentExplicitlyReadable = [...extraResolved, ...readOnlyResolved].some(root =>
+		pathIsWithin(root, parentToProtect),
+	);
 	if (!tooBroadToDeny(parentToProtect, fsRoot) && !parentExplicitlyReadable) {
 		denyEnumerate.add(parentToProtect);
 	}
 
 	if (home !== undefined) {
 		// The account container is a data root, but this operator's whole home belongs to them (#2637).
-		// A deeper full allow preserves their normal filesystem rights while leaving sibling accounts under
-		// the broader deny. Cross-session stores are denied again at still greater depth below.
+		// A deeper full allow preserves their normal filesystem rights. The account container loses only
+		// enumeration, and cross-session stores are denied again at still greater depth below.
 		allow.add(home);
 
 		// Granted whether or not they exist yet. `~/.bun` has to be writable *before* the first
@@ -493,21 +493,17 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		}
 	}
 
-	// Top-level directories that hold somebody's files. Without these the fence covered only home and
-	// the workspace's ancestors, so with the workspace at `~/MEDDPICC/CUSTOMER-A` another operator's
-	// account, an external volume and `/data/globex` were all readable AND writable — measured. The
-	// command-text scan was refusing them on the way in, which is exactly why that scan could not
-	// simply be stood down (#2624).
+	// Top-level directories that hold somebody's files lose only their own directory listing. Named
+	// descendants remain available with the operator's normal filesystem rights: this fence removes
+	// casual discovery, not professional access to a path the operator already knows (#2931).
 	//
 	// Two sources, and the static one is not redundant: enumeration is a single `readdir` that can
 	// fail, and coverage that evaporates with it would be worse than no claim at all. So the known data
-	// roots are denied by name, and enumeration adds whatever this machine has that the list does not
-	// foresee.
+	// roots are protected by name, and enumeration adds whatever this machine has that the list does
+	// not foresee.
 	//
 	// The known roots are resolved through their existing ancestors rather than dropped when absent, so
-	// a `/data` created *after* the session starts is already denied. Seatbelt matches a `(subpath …)`
-	// prefix whether or not the path exists; Landlock cannot attach a rule to an absent inode, but its
-	// plan never grants a path `readdir` did not see either, so nothing is lost there.
+	// a `/data` created *after* the session starts already has its exact listing protected.
 	const known = DATA_ROOTS.map(name => canonicalThroughExisting(path.join(fsRoot, path.basename(name))));
 	const accountRoots = new Set(["Users", "home"].map(name => canonicalThroughExisting(path.join(fsRoot, name))));
 	const found = dataRootEntries(fsRoot).map(entry => canonical(entry) ?? entry);
@@ -525,17 +521,15 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		// e.g. /Volumes/Macintosh HD -> /. Skipped for the whole-root list, per the note above.
 		if (!rootScoped.has(resolved) && tooBroadToDeny(resolved, fsRoot)) continue;
 		if (resolved === fsRoot) continue; // never the root the workspace lives on
-		// A directory containing home is normally too broad to deny because it would revoke the operator's
-		// own files (#2637). Account containers are the deliberate exception: they are denied here and the
-		// canonical home allow above wins at greater depth, isolating sibling accounts without hobbling the
-		// operator (#2788).
+		// A directory containing home is normally too broad to protect because it would hide unrelated
+		// operational entries. Account containers are the deliberate exception: their listing is the
+		// discovery surface, while every named account remains reachable (#2788, #2931).
 		if (home !== undefined && pathIsWithin(resolved, home) && !accountRoots.has(resolved)) continue;
-		// A deny beats an allow at EQUAL depth, so denying a root that IS the workspace or IS something
-		// the operator granted would not be redundant — it would silently revoke the grant. Deeper is
-		// fine and intended: an ancestor deny with the workspace allowed inside it is the normal shape.
+		// The session workspace and explicit read/full grants retain enumeration. A write-only grant does
+		// not imply permission to learn directory entries.
 		if (resolved === workspace) continue;
-		if (allow.has(resolved) || allowReadOnly.has(resolved) || allowWriteOnly.has(resolved)) continue;
-		deny.add(resolved);
+		if ([...extraResolved, ...readOnlyResolved].some(root => pathIsWithin(root, resolved))) continue;
+		denyEnumerate.add(resolved);
 	}
 
 	// Cross-session leak roots. These may sit *under* an allowed root — the agent dir is inside home,
@@ -550,8 +544,13 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		getXCSHContextsDir(),
 		...sharedTempLeakRoots(),
 	];
+	const explicitGrants = [...extraResolved, ...readOnlyResolved, ...writeOnlyResolved];
 	for (const leak of leaks) {
-		deny.add(canonicalThroughExisting(leak));
+		const resolved = canonicalThroughExisting(leak);
+		// A grant at or above a private root is an explicit operator override. Directional grants stay
+		// directional because their allowReadOnly/allowWriteOnly rule remains the deepest matching rule.
+		if (explicitGrants.some(root => pathIsWithin(root, resolved))) continue;
+		deny.add(resolved);
 	}
 
 	return {
@@ -601,7 +600,7 @@ export type ContainmentBackend = "seatbelt" | "landlock" | "scanner-only" | "dis
 export interface ContainmentStatus {
 	readonly enabled: boolean;
 	readonly backend: ContainmentBackend;
-	/** True when the kernel enforces it, false when only the command-text scan does. */
+	/** True when the kernel enforces it, false when only precise tool-call pre-checks run. */
 	readonly osEnforced: boolean;
 	/**
 	 * Set when the backend enforces reads and writes but cannot govern truncation.
@@ -621,8 +620,8 @@ export interface ContainmentStatus {
  *
  * Reported so an operator can tell a confined session from an unconfined one. The distinction is not
  * cosmetic: with a backend, a path is checked where it is opened and the spelling cannot matter;
- * without one, the only check reads the command text and is best-effort by construction. Two sessions
- * that look identical can offer very different guarantees, and `xcsh://about` is where that is stated.
+ * without one, only explicit tool-call effects can be checked before execution. Two sessions that look
+ * identical can offer very different guarantees, and `xcsh://about` is where that is stated.
  *
  * Deliberately not surfaced at startup or anywhere in the TUI — the operator asked for no UI change.
  */

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -11,45 +11,18 @@
  * base directory. We split the same way and check EVERY token's base, so a
  * multi-path input cannot smuggle a sibling directory past the gate.
  *
- * Arbitrary-code tools (`bash`, `python`) cannot be fully contained in-process: this
- * checks the `cwd` argument precisely and scans the command/code for path tokens
- * (bare, quoted, `~`, `..`, absolute) that escape the tree. OS system paths are exempt.
- *
- * **This scan is no longer the boundary for `bash` on macOS.** Containment now runs below the command
- * text (`sandbox/containment.ts`, #2554): the shell's own `cd` and redirections are checked where they
- * act, and spawned children are confined by a seatbelt profile. A path is therefore decided after
- * expansion, alias resolution and symlink following, which is what closed the escapes this scan kept
- * leaking — #2470, #2516, #2520, #2524, #2540, #2542, #2553, and GHSA-q4hg.
- *
- * What remains this file's job:
- *  - every structured file tool (`read`/`write`/`edit`/`grep`/…), which has no subprocess to confine
- *  - `python`, whose kernel is a shared, lock-protected gateway reused across sessions, so it can never
- *    carry a per-session fence and this is the only thing deciding for it
- *  - `bash` on a platform with no backend, where this is again the only layer and `xcsh://about` says so
- *  - a fast pre-check that produces a readable refusal before a command runs
- *
- * So: keep it, and do not extend it. Another spelling caught here buys little now, and the pattern of
- * adding one has a poor record — two adversarial rounds on the #2542 fix alone produced six bypasses.
- *
- * **One policy, asked at two places (#2624.)** This used to consult `SandboxPolicy`, which was
- * deny-by-default and confined to the cwd, while the fence below it is allow-by-default with targeted
- * denies. Running both made the effective boundary their intersection, and the intersection refused
- * ordinary work: `grep -oE '<title>[^<]*</title>'` was rejected because the floor reads the fragment
- * `/title` out of the closing tag and a deny-by-default policy has to refuse an unrecognised absolute
- * path. So were `</h1>`, `</td>`, `--pretty=format:'%h </%an>'`, `cd "$DEST"`, `read /etc/hosts` and a
- * `/tmp` write — none of which has anything to do with reaching another customer's files.
- *
- * The floor is unchanged, because the floor was never the problem. It guesses which fragments of a
- * command might be paths, and under allow-by-default a wrong guess matches no rule and costs nothing.
- * Deny-by-default is what turned each wrong guess into a refusal, so the posture went rather than the
- * guessing — which also means this file no longer needs to know about system roots, temp directories or
- * which backend is running. The fence answers all of that, and it is the same answer the kernel gives.
+ * Arbitrary-code tools are intentionally different. Their source text is data, not a reliable account
+ * of what the program will open, and scanning it caused false refusals such as #2931. `bash` therefore
+ * pre-checks only filesystem effects the shell lexer proves: an explicit `cwd`, literal redirections,
+ * known write operands, and literal directory changes. The OS backend remains the boundary for spawned
+ * processes. The shared `python` kernel cannot carry a per-session OS fence, so only its explicit `cwd`
+ * is checked; source and cell text are never scanned.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { expandPath, parseFindPattern, parseSearchPath, resolveToCwd, splitTopLevel } from "../tools/path-utils";
 import { lexShellCommand, type ShellSimpleCommand } from "../tools/shell-lex";
-import { provenExemptWords, writtenOperandWords } from "./command-operands";
+import { writtenOperandWords } from "./command-operands";
 import { type ContainmentFence, type FenceAccess, fenceVerdict } from "./containment";
 
 /** The two access directions, named as the fence names them. */
@@ -123,12 +96,6 @@ const SEARCH_TOOLS: Record<string, SearchSpec> = {
 	ast_edit: { key: "path", base: token => parseSearchPath(token).basePath, access: "write" },
 };
 
-/** Arbitrary-code tools whose command/code strings are scanned best-effort. */
-const CODE_FIELDS: Record<string, string[]> = {
-	bash: ["command"],
-	python: ["code"],
-};
-
 function firstString(input: Record<string, unknown>, keys: string[]): string | undefined {
 	for (const key of keys) {
 		const value = input[key];
@@ -155,43 +122,6 @@ function deny(cwd: string, resolved: string, access: SandboxAccess): ToolCallDec
 	};
 }
 
-/**
- * `$HOME` and `${HOME}` are spellings of `~`, which `looksLikePath` already treats as a path (#2534).
- * Rewriting to `~` means detection and resolution answer consistently whether the resulting home path
- * is allowed or denied by an explicit rule.
- *
- * `\b` keeps `$HOMEBREW_PREFIX` and friends out of it.
- */
-const HOME_EXPANSION = /^\$(?:HOME\b|\{HOME\})/;
-
-function normalizeHomeExpansion(token: string): string {
-	return HOME_EXPANSION.test(token) ? token.replace(HOME_EXPANSION, "~") : token;
-}
-
-function looksLikePath(token: string): boolean {
-	return path.isAbsolute(token) || token.startsWith("~") || /(^|[/\\])\.\.([/\\]|$)/.test(token);
-}
-
-/** A path-like token found by the floor, with where it was found. */
-interface PathOccurrence {
-	token: string;
-	/** Offset of the token's first character — past any opening quote — in the scanned string. */
-	at: number;
-	/** Set when a redirection operator in the raw text says what the shell will do with it. */
-	access?: SandboxAccess;
-}
-
-/**
- * What a redirection operator does to the operand that follows it. `skip` is a here-string or a
- * heredoc delimiter: that operand is literal data the shell never opens — verified against bash,
- * where `cat <<</tmp/f` prints the string `/tmp/f` rather than the contents of that file.
- */
-function operandAccess(operator: string): SandboxAccess | "skip" {
-	if (operator.includes("<<")) return "skip";
-	// `<>` opens for both; the write side is the one a read-only grant must not license.
-	return operator.includes(">") ? "write" : "read";
-}
-
 /** A path to check, and the boundary to check it against. */
 interface PathCandidate {
 	token: string;
@@ -207,142 +137,6 @@ interface PathCandidate {
 /** Write first, so a `<>` denial names the stricter boundary the caller is most likely missing. */
 const WRITE_AND_READ = ["write", "read"] as const satisfies readonly SandboxAccess[];
 
-/** A redirection operator, with its optional file-descriptor prefix. Longest forms first. */
-const REDIRECT_OPERATOR = /[0-9]*(?:&>>|&>|<<<|<<-|<<|>>|>\||<>|>&|<&|>|<)/g;
-
-/** A whitespace token that is only a redirection operator, so the next token is its operand. */
-const BARE_REDIRECT = /^[0-9]*(?:&>>|&>|<<<|<<-|<<|>>|>\||<>|>&|<&|>|<)$/;
-
-/** Where a shell word ends inside a whitespace token: an operator, separator, or grouping. */
-const METACHARACTER = /[;&|<>()]/;
-
-/**
- * A path glued to its option, as one shell word (#2524).
- *
- * `path.isAbsolute("if=/work/custB/secret")` is false, so the floor's whole-token test
- * never saw these — a single space was the difference between the blocked form and the
- * allowed one.
- *
- * Only the option's VALUE is captured, never an arbitrary `/`-containing substring. That
- * distinction is what keeps #2470 shut: scanning any slash-bearing fragment would read
- * `sed -n '/a/p'` as a path again, which is the false positive #2479 exists to remove.
- * The captured value still has to satisfy `looksLikePath`, so `--output=./out` stays
- * allowed while `--output=/work/custB/x` does not.
- *
- * The short-option form additionally requires its value to begin with `/` or `~`. Without
- * that, `-la` and friends would be read as an option carrying a relative path.
- */
-const OPTION_VALUE_FORMS: readonly RegExp[] = [
-	/^-{1,2}[A-Za-z0-9][^=]*=(.+)$/, // --output=/p, -o=/p
-	/^[A-Za-z_][A-Za-z0-9_]*=(.+)$/, // if=/p, of=/p (operand style)
-	/^-[A-Za-z0-9]+([/~].*)$/, // -o/p, -C/p (no separator)
-];
-
-/**
- * Path-like tokens in a command/code string: bare (whitespace-split) and quoted.
- *
- * Indiscriminate by design, and that is the point: because it never asks what a command *means*, it
- * also catches paths hidden inside quoted scripts, heredoc bodies, `-exec` runs and substitutions.
- * This is the coverage floor for both bash and python. Do not narrow it.
- *
- * Offsets come along so a caller can tell one occurrence of a token from another. Nothing else about
- * what this finds has changed: the two passes and `looksLikePath` are the floor.
- */
-function codePathOccurrences(command: string): PathOccurrence[] {
-	const found: PathOccurrence[] = [];
-	const add = (raw: string, at: number, access?: SandboxAccess): void => {
-		const token = normalizeHomeExpansion(raw);
-		if (token.length > 0 && looksLikePath(token)) found.push({ token, at, access });
-	};
-	// Set when the previous token was nothing but a redirection operator, so this one is its operand.
-	let carried: SandboxAccess | "skip" | undefined;
-	for (const match of command.matchAll(/\S+/g)) {
-		const raw = match[0];
-		const operand = carried;
-		carried = undefined;
-
-		if (BARE_REDIRECT.test(raw)) {
-			carried = operandAccess(raw);
-			continue;
-		}
-
-		const stripped = raw.replace(/^["']|["']$/g, "");
-		const openingQuote = raw.length !== stripped.length && (raw[0] === '"' || raw[0] === "'") ? 1 : 0;
-		if (operand !== "skip") add(stripped, match.index + openingQuote, operand);
-		// An operator glued to its operand is one whitespace token, and `>/work/x` is not absolute.
-		// The lexer resolves this for words it can see, but not for text inside a quoted script or a
-		// heredoc body — where the floor is the only thing looking — so scan past the operator here
-		// too, anywhere it appears in the token: `echo a>/work/x` is one token as well. The operator
-		// is also the only thing that says which boundary a nested redirect crosses.
-		for (const operator of stripped.matchAll(REDIRECT_OPERATOR)) {
-			const access = operandAccess(operator[0]);
-			if (access === "skip") continue;
-			const from = operator.index + operator[0].length;
-			// The operand ends at the first shell metacharacter, not at the end of the whitespace
-			// token. `>/dev/null; echo x` is one token, and taking all of it produced the "path"
-			// `/dev/null;`, which matched no write sink and refused a completely ordinary command
-			// (#2540). Truncating only ever shortens a candidate, so nothing blocked becomes allowed.
-			const rest = stripped.slice(from);
-			const stop = rest.search(METACHARACTER);
-			add(
-				(stop === -1 ? rest : rest.slice(0, stop)).replace(/^["']|["']$/g, ""),
-				match.index + openingQuote + from,
-				access,
-			);
-		}
-
-		// An option glued to its value is one word too, and the lexer cannot help: it
-		// correctly reports `if=/work/custB/secret` as a single word, because that is what
-		// it is. Which options introduce a filename is command-specific knowledge the floor
-		// deliberately does not have, so scan the value and let `looksLikePath` decide.
-		//
-		// Skipped after a here-string or heredoc delimiter for the same reason the whole
-		// token is: that operand is literal data the shell never opens, so `cat <<<if=/tmp/f`
-		// prints the text rather than reading the file.
-		if (operand !== "skip") {
-			for (const form of OPTION_VALUE_FORMS) {
-				const optionValue = stripped.match(form);
-				if (!optionValue?.[1]) continue;
-				const from = stripped.length - optionValue[1].length;
-				add(optionValue[1].replace(/^["']|["']$/g, ""), match.index + openingQuote + from, operand);
-				break; // the forms overlap; the first that matches has already captured the value
-			}
-		}
-	}
-	for (const match of command.matchAll(/["']([^"']+)["']/g)) add(match[1], match.index + 1);
-	return found;
-}
-
-/** The floor as plain read candidates — what a non-shell language gets. */
-function codePathCandidates(command: string): PathCandidate[] {
-	return codePathOccurrences(command).map(({ token }) => ({ token, access: "read" as const }));
-}
-
-/**
- * Path candidates of a *bash* command. Three things happen here, and only the first narrows:
- *
- * 1. **Exempt words are blanked.** Words the invoked command provably treats as a script or pattern
- *    rather than a filename stop being scanned (issue #2470: `sed -n '/a/p'` was refused because
- *    `/a/p` looks absolute, though sed never opens it). Implemented by blanking the exempt spans and
- *    re-running the floor over what remains, rather than by subtracting a set of token strings. Set
- *    subtraction loses which *occurrence* a token came from, so `echo '/elsewhere/x' && cat
- *    /elsewhere/x` would exempt the echo operand and thereby clear the identical token belonging to
- *    `cat`. Blanking is positional and cannot leak that way.
- *
- * 2. **A word the shell opens for writing is checked against the write boundary** (issue #2516).
- *    Every candidate used to be checked as a read, so a path granted read access but not write was
- *    writable through `>`. Marking is by span, for the same occurrence-identity reason as blanking:
- *    in `cat /shared/x && printf y > /shared/x` only the second occurrence is the write.
- *
- * 3. **Redirect targets are added as candidates** (issue #2520). The floor splits on whitespace, so
- *    an operator glued to its path — `cat </work/custB/secret` — was one token that did not look
- *    like a path and was never checked at all. The lexer parses those correctly, so its redirect
- *    targets go in on top of the floor. This only ever adds candidates.
- *
- * The floor's reach is unchanged: text the lexer never turns into a word — a heredoc body, an
- * `-exec` run — is not blanked, so it is still scanned. When the command cannot be lexed
- * confidently, the floor stands alone.
- */
 /**
  * A `cd` whose target this layer cannot resolve — `cd "$DEST"`, `cd $(git rev-parse …)`, `cd -` — is
  * **not** refused (#2624).
@@ -395,8 +189,8 @@ const DIRECTORY_CHANGE_TOKEN = /(^|[\s;&|(])(cd|pushd)([\s;&|)]|$)/;
 /**
  * Literal targets of a directory change, as candidates that must resolve in-tree.
  *
- * This gate exists because a relative operand is never a candidate — the floor assumes it resolves
- * under the session directory. `cd` is what breaks that assumption: the bash tool runs one
+ * This gate exists because ordinary relative operands are runtime decisions. `cd` changes where
+ * those operands resolve: the bash tool runs one
  * persistent brush-core shell in the agent's own process, so a directory change outlives the call
  * that made it and afterwards `cat tmp/x` reads somewhere else entirely (#2542).
  *
@@ -459,38 +253,14 @@ function directoryChangeTargets(commands: readonly ShellSimpleCommand[], depth =
 
 function shellPathCandidates(command: string): ShellScan {
 	const lexed = lexShellCommand(command);
-	// Unbalanced quotes mean every word boundary is a guess: neither the blanking nor the write
-	// marking below can be trusted, so fall back to the floor, checked as reads.
-	if (lexed.unterminated) return { candidates: codePathCandidates(command) };
+	// An unfinished command has no filesystem effect, and treating partial words as paths is exactly
+	// the source-text guessing this layer avoids.
+	if (lexed.unterminated) return { candidates: [] };
 
-	const exemptSpans = lexed.commands.flatMap(simpleCommand => provenExemptWords(simpleCommand));
-	let scanned = command;
-	// Replace each exempt word with equivalent-length whitespace, so surrounding offsets and word
-	// boundaries are preserved and only that word's own text stops being scanned.
-	for (const word of exemptSpans) {
-		scanned = scanned.slice(0, word.start) + " ".repeat(word.end - word.start) + scanned.slice(word.end);
-	}
+	const candidates: PathCandidate[] = [];
 
-	// `<>` opens for both, so it stays a read here and picks up its write below: a floor occurrence
-	// may carry only one access, and read is the one the floor would have used anyway.
-	const writeTargets = lexed.words.filter(word => word.redirect === "write");
-	// Plus the operands the invoked program writes itself — `tee FILE`, `dd of=FILE`, `cp SRC DST`.
-	// Those had no direction signal and defaulted to a read check, so a write into an allowRead-only
-	// root passed and a write into an allowWrite-only root was refused (GHSA-q4hg).
-	const writtenOperands = lexed.commands.flatMap(simpleCommand => writtenOperandWords(simpleCommand));
-	const inWriteTarget = (at: number): boolean =>
-		[...writeTargets, ...writtenOperands].some(word => at >= word.start && at < word.end);
-
-	// A floor occurrence takes the access its own operator gave it; failing that, the span of a
-	// lexed write target it sits inside; failing that, read.
-	const candidates: PathCandidate[] = codePathOccurrences(scanned).map(({ token, at, access }) => ({
-		token,
-		access: access ?? (inWriteTarget(at) ? "write" : "read"),
-	}));
-
-	// Not gated on `looksLikePath`: that test is for the floor's *guesses* about which fragments of a
-	// command might be filenames. A redirect target is one the shell will certainly open, so a bare
-	// `out.txt` is checked too — it resolves under the cwd, which a read-only cwd does not license.
+	// A redirect target is one the shell will certainly open, so a bare `out.txt` is checked too — it
+	// resolves under the cwd, which a read-only cwd does not license.
 	for (const word of lexed.words) {
 		if (word.redirect === undefined || word.redirect === "here-string") continue;
 		for (const access of word.redirect === "read-write" ? WRITE_AND_READ : [word.redirect]) {
@@ -499,6 +269,13 @@ function shellPathCandidates(command: string): ShellScan {
 			// in-tree shell (#2552). The shell resolves it below the text instead.
 			if (word.literal) candidates.push({ token: word.text, access });
 		}
+	}
+
+	// Known program operands that are written — `tee FILE`, `dd of=FILE`, `cp SRC DST` — are as
+	// explicit as redirects. Ordinary read operands are deliberately absent: only the process that
+	// opens them can decide whether path-looking argument text is a filename, a pattern, or data.
+	for (const word of lexed.commands.flatMap(simpleCommand => writtenOperandWords(simpleCommand))) {
+		if (word.literal) candidates.push({ token: word.text, access: "write" });
 	}
 
 	candidates.push(...directoryChangeTargets(lexed.commands));
@@ -521,7 +298,7 @@ function searchBases(raw: string, base: (token: string) => string): string[] {
 	return [...tokens];
 }
 
-function evaluateCodeTool(check: ToolCallCheck, fields: string[], shell: boolean): ToolCallDecision {
+function evaluateCodeTool(check: ToolCallCheck, shell: boolean): ToolCallDecision {
 	const { input, cwd } = check;
 
 	const rawCwd = typeof input.cwd === "string" ? input.cwd : undefined;
@@ -533,38 +310,26 @@ function evaluateCodeTool(check: ToolCallCheck, fields: string[], shell: boolean
 		return { block: true, reason: describeDirectoryChange(cwd, base) };
 	}
 
-	const commands: string[] = [];
-	for (const field of fields) {
-		if (typeof input[field] === "string") commands.push(input[field] as string);
-	}
-	// python also accepts a `cells` array of { code }.
-	if (Array.isArray(input.cells)) {
-		for (const cell of input.cells) {
-			const code = (cell as { code?: unknown })?.code;
-			if (typeof code === "string") commands.push(code);
-		}
-	}
+	// Python's persistent shared kernel has no per-session OS fence. Scanning source cannot fix that:
+	// path-like strings may be inert data while computed paths never appear in source at all. Keep the
+	// explicit cwd contract and otherwise let Python run without a heuristic pre-check (#2931).
+	if (!shell || typeof input.command !== "string") return ALLOW;
 
-	for (const command of commands) {
-		// Only bash gets the shell-aware treatment. Python is not shell: lexing `open('/x')` as
-		// shell yields one non-absolute word and would lose the check entirely, and it has no
-		// redirects, so every candidate it produces is a read.
-		const scan: ShellScan = shell ? shellPathCandidates(command) : { candidates: codePathCandidates(command) };
-		const seen = new Set<string>();
-		for (const { token, access, mustBeInTree } of scan.candidates) {
-			if (!seen.add(`${access}\0${mustBeInTree ? "cd\0" : ""}${token}`)) continue;
-			if (mustBeInTree) {
-				// `path.resolve`, not `resolveToCwd`: the latter maps an all-slashes path to the cwd,
-				// which would read `cd /` as `cd .` and let the shell walk out. Both directions,
-				// because relative paths go unchecked wherever the shell is standing.
-				const moved = path.resolve(base, expandPath(token));
-				if (permits(check, moved, "read") && permits(check, moved, "write")) continue;
-				return { block: true, reason: describeDirectoryChange(cwd, moved) };
-			}
-			const resolved = resolveToCwd(token, base);
-			if (permits(check, resolved, access)) continue;
-			return deny(cwd, resolved, access);
+	const scan = shellPathCandidates(input.command);
+	const seen = new Set<string>();
+	for (const { token, access, mustBeInTree } of scan.candidates) {
+		if (!seen.add(`${access}\0${mustBeInTree ? "cd\0" : ""}${token}`)) continue;
+		if (mustBeInTree) {
+			// `path.resolve`, not `resolveToCwd`: the latter maps an all-slashes path to the cwd,
+			// which would read `cd /` as `cd .` and let the shell walk out. Both directions,
+			// because relative paths go unchecked wherever the shell is standing.
+			const moved = path.resolve(base, expandPath(token));
+			if (permits(check, moved, "read") && permits(check, moved, "write")) continue;
+			return { block: true, reason: describeDirectoryChange(cwd, moved) };
 		}
+		const resolved = resolveToCwd(token, base);
+		if (permits(check, resolved, access)) continue;
+		return deny(cwd, resolved, access);
 	}
 
 	return ALLOW;
@@ -695,8 +460,8 @@ function evaluateReadTool(check: ToolCallCheck): ToolCallDecision {
 export function evaluateToolCall(check: ToolCallCheck): ToolCallDecision {
 	const { toolName, input, cwd } = check;
 
-	const codeFields = CODE_FIELDS[toolName];
-	if (codeFields) return evaluateCodeTool(check, codeFields, toolName === "bash");
+	if (toolName === "bash") return evaluateCodeTool(check, true);
+	if (toolName === "python") return evaluateCodeTool(check, false);
 
 	if (toolName === "edit") return evaluateEdit(check);
 	if (toolName === "read") return evaluateReadTool(check);

--- a/packages/coding-agent/src/tools/shell-lex.ts
+++ b/packages/coding-agent/src/tools/shell-lex.ts
@@ -1,23 +1,21 @@
 /**
  * Shell-aware tokenizer for bash command strings.
  *
- * Two subsystems used to scan raw command text with regexes and got argument *data* wrong in
- * opposite directions: internal-URL expansion rewrote `xcsh://` tokens sitting inside quoted
- * strings (#2468), and the sandbox read-boundary check reported `sed` regex addresses as
- * filesystem paths (#2470). Both need to know where a shell *word* starts and ends.
+ * Raw command-text regexes get argument *data* wrong. Internal-URL expansion rewrote `xcsh://`
+ * tokens sitting inside quoted strings (#2468), while sandbox enforcement needs to identify only
+ * explicit redirections, write operands, and directory changes. Both need to know where a shell
+ * *word* starts and ends.
  *
  * This module answers only that question. It deliberately does NOT decide anything:
  *
  * - #2468 uses `text` plus `start`/`end` to tell "this whole word is the URL" from "the URL is
  *   mentioned inside this word", and to splice a replacement over the exact source span.
- * - #2470 uses `name` and `operandStart` to *locate* a script operand it may exempt, and to
- *   report a real word instead of a fragment like `` /a/p'; ``. The sandbox's safety still rests
- *   on its own coverage floor, never on this lexer being complete — see
- *   `sandbox/command-operands.ts`.
+ * - Sandbox enforcement uses `name`, `operandStart`, and redirect metadata only for filesystem
+ *   effects whose meaning is known without interpreting arbitrary argument text.
  *
  * Scope: enough POSIX shell to describe the commands an agent actually writes. Heredoc bodies are
- * consumed as data and never re-lexed, which is shell-correct but means a `bash <<EOF` body is
- * invisible here; that is exactly why the sandbox keeps a floor rather than trusting these words.
+ * consumed as data and never re-lexed, which is shell-correct: source and heredoc text are left to
+ * the runtime fence rather than scanned for path-looking strings.
  */
 
 /** How a word was quoted. `mixed` when built from differently-quoted segments, as in `a"b"'c'`. */

--- a/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
+++ b/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
@@ -542,8 +542,8 @@ describe("renderAboutDoc active model section", () => {
 
 /**
  * Two sessions can look identical and offer very different guarantees: with an OS backend a path is
- * checked where it is opened and the spelling cannot matter, while without one the only check reads
- * the command text. `xcsh://about` is the only place an operator can tell which they have — the
+ * checked where it is opened and the spelling cannot matter, while without one arbitrary child-process
+ * reads cannot be confined. `xcsh://about` is the only place an operator can tell which they have — the
  * maintainer asked for no UI change, so there is no banner and no startup line.
  */
 describe("renderAboutDoc containment section", () => {
@@ -559,21 +559,22 @@ describe("renderAboutDoc containment section", () => {
 		// The contract distinguishes operator rights from session-context isolation.
 		expect(doc).toContain("home and configuration belong to the operator");
 		expect(doc).toContain("readable and writable");
-		expect(doc).toContain("directory containing the session root cannot");
-		expect(doc).toContain("sibling path the operator names directly");
-		expect(doc).toContain("Cross-session stores, other operators' accounts, and data roots remain denied");
+		expect(doc).toContain("session container, local-account containers");
+		expect(doc).toContain("descendant path the operator");
+		expect(doc).toContain("Xcsh-private cross-session stores remain denied recursively");
 		// Ordinary work remains available and an operator can deliberately restore discovery.
-		expect(doc).toContain("--allow-path");
+		expect(doc).toContain("An explicit read grant restores enumeration");
 	});
 
-	it("says plainly that the boundary is best-effort where no backend exists", () => {
+	it("says plainly that the boundary is intent rather than a guarantee where no backend exists", () => {
 		const doc = renderAboutDoc(fakeBuildInfo(), null, null, {
 			enabled: true,
 			backend: "scanner-only",
 			osEnforced: false,
 		});
 		expect(doc).toContain("no OS-level backend");
-		expect(doc).toContain("best-effort");
+		expect(doc).toContain("statement of intent rather than a guarantee");
+		expect(doc).toContain("Command and source text are never scanned");
 		// Must NOT claim the stronger guarantee it does not have.
 		expect(doc).not.toContain("how a path is spelled does not change what is reachable");
 	});

--- a/packages/coding-agent/test/sandbox-check.test.ts
+++ b/packages/coding-agent/test/sandbox-check.test.ts
@@ -90,7 +90,7 @@ function assertHealthyReport(report: SandboxCheckReport): void {
 	if (report.osEnforced) {
 		expect(report.summary).toEqual({ passed: 11, failed: 0, errors: 0, skipped: 0 });
 		expect(report.checks).toContainEqual({ name: "account container cannot be enumerated", status: "PASS" });
-		expect(report.checks).toContainEqual({ name: "synthetic other account cannot be entered", status: "PASS" });
+		expect(report.checks).toContainEqual({ name: "named other account remains reachable", status: "PASS" });
 		expect(report.checks).toContainEqual({ name: "explicit grant restores parent enumeration", status: "PASS" });
 	}
 }

--- a/packages/coding-agent/test/sandbox-check.test.ts
+++ b/packages/coding-agent/test/sandbox-check.test.ts
@@ -83,12 +83,14 @@ function assertHealthyReport(report: SandboxCheckReport): void {
 	expect(["seatbelt", "landlock", "scanner-only"]).toContain(report.backend);
 	expect(report.summary.failed).toBe(0);
 	expect(report.summary.errors).toBe(0);
-	expect(report.checks).toHaveLength(11);
+	expect(report.checks).toHaveLength(13);
 	expect(report.checks).toContainEqual({ name: "structured tools share the boundary", status: "PASS" });
+	expect(report.checks).toContainEqual({ name: "Bash grep pattern remains data (#2931)", status: "PASS" });
+	expect(report.checks).toContainEqual({ name: "Bash Python heredoc remains data (#2931)", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "cwd resets across tool calls", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "synthetic fixtures removed", status: "PASS" });
 	if (report.osEnforced) {
-		expect(report.summary).toEqual({ passed: 11, failed: 0, errors: 0, skipped: 0 });
+		expect(report.summary).toEqual({ passed: 13, failed: 0, errors: 0, skipped: 0 });
 		expect(report.checks).toContainEqual({ name: "account container cannot be enumerated", status: "PASS" });
 		expect(report.checks).toContainEqual({ name: "named other account remains reachable", status: "PASS" });
 		expect(report.checks).toContainEqual({ name: "explicit grant restores parent enumeration", status: "PASS" });

--- a/packages/coding-agent/test/sandbox-command-operands.test.ts
+++ b/packages/coding-agent/test/sandbox-command-operands.test.ts
@@ -1,111 +1,27 @@
 import { describe, expect, it } from "bun:test";
-import { provenExemptWords } from "../src/sandbox/command-operands";
+import { writtenOperandWords } from "../src/sandbox/command-operands";
 import { lexShellCommand } from "../src/tools/shell-lex";
 
-/** The literal text of every word the exemption rules can prove is not a filesystem reference. */
-function exempt(command: string): string[] {
-	return lexShellCommand(command).commands.flatMap(cmd => provenExemptWords(cmd).map(w => w.text));
+function written(command: string): string[] {
+	return lexShellCommand(command).commands.flatMap(cmd => writtenOperandWords(cmd).map(word => word.text));
 }
 
-describe("provenExemptWords — script and pattern operands", () => {
-	it("exempts a sed script operand", () => {
-		expect(exempt(`sed -n '/a/p'`)).toEqual(["/a/p"]);
-		expect(exempt(`sed -n '/^COMMANDS/,$p' notes.md`)).toEqual(["/^COMMANDS/,$p"]);
-		expect(exempt(`sed 's/^a/X/' notes.md`)).toEqual(["s/^a/X/"]);
+describe("writtenOperandWords", () => {
+	it("identifies explicit output operands", () => {
+		expect(written("tee a.log b.log")).toEqual(["a.log", "b.log"]);
+		expect(written("dd if=input.img of=/drop/output.img")).toEqual(["/drop/output.img"]);
+		expect(written("sort -o sorted.txt input.txt")).toEqual(["sorted.txt"]);
+		expect(written("curl --output=result.json https://example.com")).toEqual(["result.json"]);
 	});
 
-	it("exempts an awk program operand", () => {
-		expect(exempt(`awk '/^a/ {print "hit:" $0}'`)).toEqual([`/^a/ {print "hit:" $0}`]);
-		expect(exempt(`gawk '{print $1}' notes.md`)).toEqual(["{print $1}"]);
+	it("distinguishes destinations from read-only source operands", () => {
+		expect(written("cp source.txt destination.txt")).toEqual(["destination.txt"]);
+		expect(written("cp -t destination source-a source-b")).toEqual(["destination"]);
+		expect(written("mv source.txt destination.txt")).toEqual(["source.txt", "destination.txt"]);
 	});
 
-	it("exempts a grep pattern operand but not its file operands", () => {
-		expect(exempt(`grep '/work/custB/x' .`)).toEqual(["/work/custB/x"]);
-		// The file operand that follows the pattern is never exempt.
-		expect(exempt(`grep 'TODO' '/work/custB/x'`)).toEqual(["TODO"]);
-	});
-
-	it("exempts every operand of a pure emitter", () => {
-		expect(exempt(`echo '/a/p'`)).toEqual(["/a/p"]);
-		expect(exempt(`printf '%s\\n' '/a/b'`)).toEqual(["%s\\n", "/a/b"]);
-	});
-
-	it("exempts nothing for a command with no entry", () => {
-		expect(exempt("cat /work/custB/secrets.env")).toEqual([]);
-		expect(exempt("sh -c 'cat /work/custB/x'")).toEqual([]);
-		expect(exempt("find . -exec sh -c 'cat /work/custB/x' \\;")).toEqual([]);
-		expect(exempt("bash <<'EOF'\ncat /work/custB/x\nEOF")).toEqual([]);
-	});
-});
-
-describe("provenExemptWords — file-access constructs defeat the exemption", () => {
-	it("refuses to exempt a sed script that reads or writes a file", () => {
-		expect(exempt(`sed -n 'r /work/custB/x' notes.md`)).toEqual([]);
-		expect(exempt(`sed -n '/foo/r /work/custB/x' notes.md`)).toEqual([]);
-		expect(exempt(`sed '1,3w /work/custB/x' notes.md`)).toEqual([]);
-		expect(exempt(`sed 's/a/b/w /work/custB/x' notes.md`)).toEqual([]);
-		expect(exempt(`sed '1e cat /work/custB/x' notes.md`)).toEqual([]);
-	});
-
-	it("still exempts a sed substitution whose regex merely contains r, w or e", () => {
-		expect(exempt(`sed 's/red/blue/' notes.md`)).toEqual(["s/red/blue/"]);
-		expect(exempt(`sed 's/write/read/g' notes.md`)).toEqual(["s/write/read/g"]);
-	});
-
-	it("refuses to exempt an awk program that reads, writes, or executes", () => {
-		expect(exempt(`awk 'BEGIN { getline x < "/work/custB/x" }'`)).toEqual([]);
-		expect(exempt(`awk '{print > "/work/custB/x"}'`)).toEqual([]);
-		expect(exempt(`awk '{print $0 >> "/work/custB/x"}'`)).toEqual([]);
-		expect(exempt(`awk 'BEGIN { system("cat /work/custB/x") }'`)).toEqual([]);
-		expect(exempt(`awk 'BEGIN { close("/work/custB/x") }'`)).toEqual([]);
-		expect(exempt(`awk 'BEGIN { "cat /work/custB/x" | getline }'`)).toEqual([]);
-	});
-});
-
-describe("provenExemptWords — preconditions", () => {
-	it("never exempts a redirect target, even for a command whose operands are all exempt", () => {
-		// The quoted operand is exempt; the redirect target beside it is not.
-		expect(exempt(`echo '/a/b' > '/work/custB/y'`)).toEqual(["/a/b"]);
-		expect(exempt(`printf '%s' '/a/b' >> '/work/custB/y'`)).toEqual(["%s", "/a/b"]);
-	});
-
-	it("never exempts an unquoted operand", () => {
-		expect(exempt("sed -n /a/p")).toEqual([]);
-		expect(exempt("echo /work/custB/x")).toEqual([]);
-	});
-
-	it("never exempts a word carrying an expansion or glob", () => {
-		expect(exempt(`echo "$HOME/x"`)).toEqual([]);
-		expect(exempt(`sed -n "/$PATTERN/p"`)).toEqual([]);
-		expect(exempt(`echo "$(cat /work/custB/x)"`)).toEqual([]);
-	});
-
-	it("does not exempt a leading operand when the script came from an option", () => {
-		// With -e the first operand is a FILE, not the script.
-		expect(exempt(`sed -e 's/a/b/' /work/custB/x`)).toEqual([]);
-		expect(exempt(`sed -f prog.sed /work/custB/x`)).toEqual([]);
-		expect(exempt(`awk -f prog.awk /work/custB/x`)).toEqual([]);
-		expect(exempt(`grep -e TODO /work/custB/x`)).toEqual([]);
-		expect(exempt(`grep -f pats.txt /work/custB/x`)).toEqual([]);
-	});
-
-	it("skips over an option's value when locating the first operand", () => {
-		// -F is a value option, so ':' is not the program; '{print $1}' is.
-		expect(exempt(`awk -F : '{print $1}' notes.md`)).toEqual(["{print $1}"]);
-		expect(exempt(`grep -m 3 '/a/b' .`)).toEqual(["/a/b"]);
-	});
-
-	it("exempts only the first script operand, never subsequent file operands", () => {
-		expect(exempt(`sed -n '/a/p' '/work/custB/x'`)).toEqual(["/a/p"]);
-		expect(exempt(`awk '{print}' '/work/custB/x'`)).toEqual(["{print}"]);
-	});
-
-	it("resolves the command through a wrapper", () => {
-		expect(exempt(`sudo sed -n '/a/p'`)).toEqual(["/a/p"]);
-		expect(exempt(`/usr/bin/env awk '{print}'`)).toEqual(["{print}"]);
-	});
-
-	it("exempts per simple command across a pipeline", () => {
-		expect(exempt(`cat /work/custB/x | sed -n '/a/p'`)).toEqual(["/a/p"]);
+	it("abandons positional inference when an option is unknown", () => {
+		expect(written("cp --future-option source.txt destination.txt")).toEqual([]);
+		expect(written("tee --future-option output.txt")).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/sandbox-command-operands.test.ts
+++ b/packages/coding-agent/test/sandbox-command-operands.test.ts
@@ -17,7 +17,15 @@ describe("writtenOperandWords", () => {
 	it("distinguishes destinations from read-only source operands", () => {
 		expect(written("cp source.txt destination.txt")).toEqual(["destination.txt"]);
 		expect(written("cp -t destination source-a source-b")).toEqual(["destination"]);
+		expect(written("cp --target-directory=destination source-a source-b")).toEqual(["destination"]);
 		expect(written("mv source.txt destination.txt")).toEqual(["source.txt", "destination.txt"]);
+	});
+
+	it("does not misclassify non-path option values as destinations", () => {
+		expect(written("install -m 0755 -o root source.txt destination.txt")).toEqual(["destination.txt"]);
+		expect(written("cp -S .backup source.txt destination.txt")).toEqual(["destination.txt"]);
+		expect(written("cp -S -backup source.txt destination.txt")).toEqual(["destination.txt"]);
+		expect(written("sort -k 2 -S 1M -o output.txt input.txt")).toEqual(["output.txt"]);
 	});
 
 	it("abandons positional inference when an option is unknown", () => {

--- a/packages/coding-agent/test/sandbox-containment-conformance.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-conformance.test.ts
@@ -107,11 +107,11 @@ describe("containment fence: TypeScript and Rust agree", () => {
 		expect(fencePermits(wire, sibling, false, false)).toBe(true);
 	});
 
-	it("agrees that the operator's home is allowed inside a denied account container", () => {
+	it("agrees that account enumeration is denied while named accounts remain reachable", () => {
 		expect(fenceVerdict(fence, accountRoot, "enumerate")).toBe("deny");
 		expect(fencePermits(wire, accountRoot, false, true)).toBe(false);
-		expect(fenceVerdict(fence, path.join(otherHome, "workspace"), "read")).toBe("deny");
-		expect(fencePermits(wire, path.join(otherHome, "workspace"), false, false)).toBe(false);
+		expect(fenceVerdict(fence, path.join(otherHome, "workspace"), "read")).toBe("allow");
+		expect(fencePermits(wire, path.join(otherHome, "workspace"), false, false)).toBe(true);
 		expect(fenceVerdict(fence, path.join(home, ".zshrc"), "write")).toBe("allow");
 		expect(fencePermits(wire, path.join(home, ".zshrc"), true, false)).toBe(true);
 	});

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -156,6 +156,34 @@ describe("buildContainmentFence", () => {
 		expect(fenceVerdict(fence, path.join(sessions, "other.jsonl"), "write")).toBe("deny");
 	});
 
+	it("lets explicit grants override private roots without widening their direction", () => {
+		const home = realTmp("private-grants");
+		const workspace = path.join(home, "w");
+		const privateParent = path.join(home, ".xcsh", "agent");
+		const sessions = path.join(privateParent, "sessions");
+		const candidate = path.join(sessions, "other.jsonl");
+		fs.mkdirSync(workspace, { recursive: true });
+		fs.mkdirSync(sessions, { recursive: true });
+
+		const defaultFence = buildContainmentFence({ workspace, home, leakRoots: [sessions] });
+		const full = buildContainmentFence({ workspace, home, leakRoots: [sessions], extraRoots: [privateParent] });
+		const readOnly = buildContainmentFence({ workspace, home, leakRoots: [sessions], readOnlyRoots: [sessions] });
+		const writeOnly = buildContainmentFence({
+			workspace,
+			home,
+			leakRoots: [sessions],
+			writeOnlyRoots: [privateParent],
+		});
+
+		expect(fenceVerdict(defaultFence, candidate, "read")).toBe("deny");
+		expect(fenceVerdict(full, candidate, "read")).toBe("allow");
+		expect(fenceVerdict(full, candidate, "write")).toBe("allow");
+		expect(fenceVerdict(readOnly, candidate, "read")).toBe("allow");
+		expect(fenceVerdict(readOnly, candidate, "write")).toBe("deny");
+		expect(fenceVerdict(writeOnly, candidate, "read")).toBe("deny");
+		expect(fenceVerdict(writeOnly, candidate, "write")).toBe("allow");
+	});
+
 	it("grants extra roots from --allow-path for both directions", () => {
 		const home = realTmp("home7");
 		const workspace = path.join(home, "w");
@@ -414,17 +442,8 @@ describe("buildContainmentFence — adversarial review of #2624", () => {
 		expect(fenceVerdict(fence, path.join(shared, "ref.csv"), "write")).toBe("deny");
 	});
 
-	/**
-	 * A workspace's filesystem root is the only one enumerated, so on Windows a second drive matched no
-	 * rule and was allowed — and Windows has no kernel backend, so the text scan is the whole boundary
-	 * there. Deny-by-default used to refuse `D:\customerB`; allow-by-default does not.
-	 *
-	 * The list is injectable because the enumeration it replaces cannot run here: probing `A:`–`Z:` needs
-	 * a Windows host. This asserts the part that decides — that a named sibling root is denied and the
-	 * workspace's own is not — and the enumeration itself is stated as unverified rather than implied to
-	 * be tested.
-	 */
-	it("denies other filesystem roots, as a second Windows drive would be", () => {
+	/** The injectable list exercises the second-drive shape that cannot be discovered on this host. */
+	it("protects enumeration of other filesystem roots while allowing named paths", () => {
 		const home = realTmp("otherroots");
 		const workspace = path.join(home, "w");
 		const otherRoot = realTmp("drive-d");
@@ -433,10 +452,10 @@ describe("buildContainmentFence — adversarial review of #2624", () => {
 
 		const fence = buildContainmentFence({ workspace, home, otherRoots: [otherRoot] });
 
-		expect(fence.deny).toContain(otherRoot);
-		expect(fenceVerdict(fence, path.join(otherRoot, "customerB", "secret.tf"), "read")).toBe("deny");
-		expect(fenceVerdict(fence, path.join(otherRoot, "customerB", "secret.tf"), "write")).toBe("deny");
-		// The workspace's own tree is untouched, or the deny was simply too broad.
+		expect(fence.denyEnumerate).toContain(otherRoot);
+		expect(fenceVerdict(fence, otherRoot, "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(otherRoot, "customerB", "secret.tf"), "read")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(otherRoot, "customerB", "secret.tf"), "write")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(workspace, "notes.md"), "write")).toBe("allow");
 	});
 
@@ -451,7 +470,7 @@ describe("buildContainmentFence — adversarial review of #2624", () => {
 	 * `/` is the only value on this platform that reproduces the shape. Nonsense as a real configuration —
 	 * which is the point: this asserts the list is not silently filtered, not that anyone should pass it.
 	 */
-	it("does not let the never-deny-a-root rule filter the other-roots list", () => {
+	it("does not let the broad-root guard filter the other-roots list", () => {
 		const container = realTmp("rootfilter");
 		const workspace = path.join(container, "w");
 		fs.mkdirSync(workspace, { recursive: true });
@@ -468,7 +487,7 @@ describe("buildContainmentFence — adversarial review of #2624", () => {
 			otherRoots: [otherRoot],
 		});
 
-		expect(fence.deny).toContain(otherRoot);
+		expect(fence.denyEnumerate).toContain(otherRoot);
 	});
 
 	// …but the root the workspace actually lives on is never denied, however it arrives.
@@ -485,12 +504,11 @@ describe("buildContainmentFence — adversarial review of #2624", () => {
 		});
 
 		expect(fence.deny).not.toContain(container);
+		expect(fence.denyEnumerate).not.toContain(container);
 		expect(fenceVerdict(fence, path.join(workspace, "notes.md"), "write")).toBe("allow");
 	});
 
-	// …and the operator can still open one deliberately, which is the escape hatch for a toolchain that
-	// lives on another drive.
-	it("lets a granted root override an other-root deny", () => {
+	it("keeps a named granted tree usable under a protected other root", () => {
 		const home = realTmp("otherrootsgrant");
 		const workspace = path.join(home, "w");
 		const otherRoot = realTmp("driveE");
@@ -501,12 +519,11 @@ describe("buildContainmentFence — adversarial review of #2624", () => {
 		const fence = buildContainmentFence({ workspace, home, otherRoots: [otherRoot], extraRoots: [tools] });
 
 		expect(fenceVerdict(fence, path.join(tools, "bin", "cc"), "read")).toBe("allow");
-		expect(fenceVerdict(fence, path.join(otherRoot, "customerB", "x"), "read")).toBe("deny");
+		expect(fenceVerdict(fence, otherRoot, "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(otherRoot, "customerB", "x"), "read")).toBe("allow");
 	});
 
-	// `--allow-path <dir>` for a directory that does not exist yet was dropped, so the grant could not
-	// authorize creating it. Harmless while an unnamed path defaulted to allow; now that unknown top-level
-	// roots are denied, the drop turns the flag into a refusal.
+	// `--allow-path <dir>` for a directory that does not exist yet must retain its directional contract.
 	it("honours a granted root that does not exist yet", () => {
 		const home = realTmp("absentgrant");
 		const workspace = path.join(home, "w");
@@ -885,20 +902,7 @@ describe("buildContainmentFence — the ancestor walk never denies a temp root",
 	});
 });
 
-/**
- * Data roots that are neither the workspace nor operational (#2624).
- *
- * The home deny and the ancestor walk together cover the realistic case — customer checkouts under
- * `~`. They cover nothing under an unrelated root: measured with the workspace at
- * `~/MEDDPICC/CUSTOMER-A`, the fence allowed `/Users/<otheruser>/…`, `/Volumes/Backup/…`, `/data/globex`
- * and `/srv/tenantZ`, read and write. The command-text scan was refusing those on the way in, so the
- * composite looked right while the fence alone did not — and that scan is what #2624 stops using as a
- * boundary, so this has to hold on its own now.
- *
- * The rule is one readdir of the filesystem root: an entry whose name is not operational holds data
- * rather than tools, and is denied. Nothing operational is touched, which is the property that
- * separates this from a deny-by-default profile.
- */
+/** Data containers lose casual discovery without restricting explicitly named paths (#2931). */
 describe("buildContainmentFence — data roots outside the workspace", () => {
 	/** A synthetic filesystem root, so an assertion never depends on what this machine mounts. */
 	function syntheticRoot(suffix: string, entries: readonly string[]): string {
@@ -907,7 +911,7 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 		return root;
 	}
 
-	it("denies unrelated data roots while leaving every operational root alone", () => {
+	it("protects container enumeration while leaving named and operational paths alone", () => {
 		const fsRoot = syntheticRoot("fsdata", ["usr", "bin", "etc", "opt", "var", "Users", "data", "srv", "Volumes"]);
 		const home = path.join(fsRoot, "Users", "me");
 		const workspace = path.join(home, "MEDDPICC", "CUSTOMER-A");
@@ -918,15 +922,15 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 
 		const fence = buildContainmentFence({ workspace, home, fsRoot });
 
-		// The account container is denied, with only this operator's canonical home allowed back at greater
-		// depth. This keeps all of the operator-rights fix from #2637 without exposing another local account.
+		// The account container cannot be listed, but a named account remains under normal OS authority.
 		const accountRoot = path.join(fsRoot, "Users");
 		const otherHome = path.join(accountRoot, "otheruser");
-		expect(fence.deny).toContain(accountRoot);
+		expect(fence.deny).not.toContain(accountRoot);
+		expect(fence.denyEnumerate).toContain(accountRoot);
 		expect(fence.allow).toContain(home);
 		expect(fenceVerdict(fence, accountRoot, "enumerate")).toBe("deny");
 		for (const access of ["read", "write", "enumerate"] as const) {
-			expect(fenceVerdict(fence, path.join(otherHome, "workspace"), access)).toBe("deny");
+			expect(fenceVerdict(fence, path.join(otherHome, "workspace"), access)).toBe("allow");
 			expect(fenceVerdict(fence, path.join(home, ".config", "tool"), access)).toBe("allow");
 		}
 
@@ -935,29 +939,25 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 		expect(fenceVerdict(granted, path.join(otherHome, "named-file"), "read")).toBe("allow");
 		expect(fenceVerdict(granted, path.join(otherHome, "named-file"), "write")).toBe("allow");
 
-		// The unrelated data roots, still denied — these were measured reachable before #2624.
-		for (const leak of [
-			path.join("data", "globex", "secrets.tf"),
-			path.join("srv", "tenantZ", "notes.md"),
-			path.join("Volumes", "Backup", "customerY"),
-		]) {
-			const candidate = path.join(fsRoot, leak);
-			expect(fenceVerdict(fence, candidate, "read")).toBe("deny");
-			expect(fenceVerdict(fence, candidate, "write")).toBe("deny");
+		for (const root of ["data", "srv", "Volumes"].map(name => path.join(fsRoot, name))) {
+			expect(fence.denyEnumerate).toContain(root);
+			expect(fenceVerdict(fence, root, "enumerate")).toBe("deny");
+		}
+		for (const named of ["data/globex/secrets.tf", "srv/tenantZ/notes.md", "Volumes/Backup/customerY"]) {
+			const candidate = path.join(fsRoot, named);
+			expect(fenceVerdict(fence, candidate, "read")).toBe("allow");
+			expect(fenceVerdict(fence, candidate, "write")).toBe("allow");
 		}
 
 		// …and nothing a tool needs. This fence restricts no operation; that is what makes it gentle.
 		for (const operational of ["usr/bin/env", "bin/sh", "etc/hosts", "opt/homebrew/bin/bun", "var/log/x"]) {
 			expect(fenceVerdict(fence, path.join(fsRoot, operational), "read")).toBe("allow");
 		}
-		// The workspace still wins inside its denied ancestors.
+		// The workspace remains fully usable inside a protected container.
 		expect(fenceVerdict(fence, path.join(workspace, "notes.md"), "write")).toBe("allow");
 	});
 
-	// Enumeration only sees what exists when the fence is built, so a known data root that does not
-	// exist yet has to be denied by name — otherwise `mkdir /data` mid-session would open it. Seatbelt
-	// matches a `(subpath …)` prefix whether or not the path is there, so the rule costs nothing.
-	it("denies a known data root that does not exist yet", () => {
+	it("protects a known data container that does not exist yet", () => {
 		const fsRoot = syntheticRoot("fsabsent", ["usr", "Users"]);
 		const home = path.join(fsRoot, "Users", "me");
 		const workspace = path.join(home, "w");
@@ -966,8 +966,9 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 
 		const fence = buildContainmentFence({ workspace, home, fsRoot });
 
-		expect(fence.deny).toContain(path.join(fsRoot, "srv"));
-		expect(fenceVerdict(fence, path.join(fsRoot, "srv", "tenantZ", "x"), "read")).toBe("deny");
+		expect(fence.denyEnumerate).toContain(path.join(fsRoot, "srv"));
+		expect(fenceVerdict(fence, path.join(fsRoot, "srv"), "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(fsRoot, "srv", "tenantZ", "x"), "read")).toBe("allow");
 	});
 
 	// A deny beats an allow at EQUAL depth, so denying a root that is itself the workspace would not
@@ -979,6 +980,7 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 		const fence = buildContainmentFence({ workspace, home: path.join(fsRoot, "Users", "me"), fsRoot });
 
 		expect(fence.deny).not.toContain(workspace);
+		expect(fence.denyEnumerate).not.toContain(workspace);
 		expect(fenceVerdict(fence, path.join(workspace, "src", "main.ts"), "read")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(workspace, "src", "main.ts"), "write")).toBe("allow");
 	});
@@ -1003,20 +1005,25 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 		expect(fenceVerdict(fence, path.join(fsRoot, "shared", "x"), "write")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(fsRoot, "readonly", "x"), "read")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(fsRoot, "readonly", "x"), "write")).toBe("deny");
-		// An ungranted data root beside them is still denied, or the carve-out proved nothing.
-		expect(fenceVerdict(fence, path.join(fsRoot, "data", "x"), "read")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(fsRoot, "shared"), "enumerate")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(fsRoot, "readonly"), "enumerate")).toBe("allow");
+		// An ungranted data container beside them still cannot be enumerated.
+		expect(fenceVerdict(fence, path.join(fsRoot, "data"), "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(fsRoot, "data", "x"), "read")).toBe("allow");
 	});
 
 	// The synthetic root proves the rule; this proves it is wired to the real filesystem, which is the
 	// part that actually ships. Asserted on the emitted roots, because that is what the backend compiles.
-	it("denies the real home container on this machine and no operational root", () => {
+	it("protects the real home container on this machine and no operational root", () => {
 		const fence = buildContainmentFence({ workspace: fs.realpathSync(process.cwd()) });
 
 		const accountRoot = path.join(
 			path.parse(fs.realpathSync(process.cwd())).root,
 			process.platform === "linux" ? "home" : "Users",
 		);
-		expect(fence.deny).toContain(accountRoot);
+		expect(fence.deny).not.toContain(accountRoot);
+		expect(fence.denyEnumerate).toContain(accountRoot);
+		expect(fenceVerdict(fence, accountRoot, "enumerate")).toBe("deny");
 		expect(fence.allow).toContain(fs.realpathSync(os.homedir()));
 		expect(fenceVerdict(fence, fs.realpathSync(os.homedir()), "write")).toBe("allow");
 		// Only what this platform actually has: `/private` is macOS-only, and `realpathSync` on an absent

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -116,108 +116,24 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "ls" }).block).toBe(false);
 	});
 
-	it("bash: best-effort blocks ../ traversal escaping the tree (Phase 1)", () => {
-		expect(check("bash", { command: "cat ../custB/secrets.env" }).block).toBe(true);
-		expect(check("bash", { command: "cat ./sub/../notes.md" }).block).toBe(false); // stays in-tree
-		expect(check("bash", { command: "grep -r TODO ." }).block).toBe(false);
-	});
-
-	it("bash: blocks absolute-path escapes, exempts OS system paths", () => {
-		expect(check("bash", { command: "cat /work/custB/secrets.env" }).block).toBe(true);
-		expect(check("bash", { command: "cat ~/.ssh/id_rsa" }).block).toBe(false);
-		expect(check("bash", { command: "cat /etc/os-release" }).block).toBe(false);
-		expect(check("bash", { command: "/usr/bin/env node app.js" }).block).toBe(false);
-	});
-
-	// The false positives reported in #2470: a regex address or a program body is not a path, so
-	// standard text processing must run. Each of these is refused today.
-	it("bash: exempts script and pattern operands of sed/awk/grep and echo (#2470)", () => {
-		expect(check("bash", { command: "sed -n '/a/p'" }).block).toBe(false);
-		expect(check("bash", { command: "sed -n '/^COMMANDS/,$p' notes.md" }).block).toBe(false);
-		expect(check("bash", { command: "awk '/^a/ {print \"hit:\" $0}'" }).block).toBe(false);
-		expect(check("bash", { command: "echo '/a/p'" }).block).toBe(false);
-		// The exemption is scoped to the script operand; a file operand beside it still counts.
-		expect(check("bash", { command: "sed -n '/a/p' /work/custB/x" }).block).toBe(true);
-	});
-
-	// #2470 also asks for this: a reported "path" containing a quote or a statement separator is
-	// proof the extraction was wrong, so no diagnostic may ever contain one.
-	it("bash: a boundary diagnostic never contains shell punctuation", () => {
-		const blocked = [
-			"cat /work/custB/secrets.env",
-			"sed -n 'r /work/custB/x' notes.md",
-			"sh -c 'cat /work/custB/x'",
-			"cat $(echo /work/custB/x)",
+	it("does not interpret Bash argument text as a path (#2931)", () => {
+		const usersDenied = { ...makeFence(), deny: ["/Users"] };
+		const commands = [
+			'grep -nE "/Users/|alpha" notes.txt',
+			"custom-tool /Users/customer/file",
+			"cat /Users/customer/file",
+			"python <<'PY'\nvalue = \"/Users/\"\nPY",
 		];
-		for (const command of blocked) {
-			const decision = check("bash", { command });
-			expect(decision.block).toBe(true);
-			// Pull out just the path the message names, not the surrounding prose.
-			const reported = /\): (.*)\. Use --allow-path/.exec(decision.reason ?? "")?.[1];
-			expect(reported).toBeDefined();
-			for (const punctuation of ["'", '"', ";", "|"]) {
-				expect(reported).not.toContain(punctuation);
-			}
+		for (const command of commands) {
+			expect(check("bash", { command }, usersDenied).block).toBe(false);
 		}
 	});
 
-	// The read-boundary scan's coverage FLOOR. Every command below reads a path out of argument
-	// *content* rather than from a plain operand, so a scanner that only inspects real argv words
-	// would miss it. The scan is documented as best-effort, but "best-effort" must not mean
-	// "regresses": exemptions may only ever SUBTRACT from what this floor already catches
-	// (see sandbox/command-operands.ts). Treat a failure here as a sandbox escape, not a test nit.
-	it("bash: coverage floor — paths embedded in argument content stay blocked", () => {
-		// A quoted script is one argv word; the path lives inside it.
-		expect(check("bash", { command: "sh -c 'cat /work/custB/x'" }).block).toBe(true);
-		expect(check("bash", { command: 'bash -c "cat /work/custB/x"' }).block).toBe(true);
-		// A heredoc body is data to the shell, but bash executes it as a script.
-		expect(check("bash", { command: "bash <<'EOF'\ncat /work/custB/x\nEOF" }).block).toBe(true);
-		// -exec consumes a whole command run, so the nested shell never appears as the command name.
-		expect(check("bash", { command: "find . -exec sh -c 'cat /work/custB/x' \\;" }).block).toBe(true);
-		// sed/awk read files through their own dialects, not through operands.
-		expect(check("bash", { command: "sed -n 'r /work/custB/x' notes.md" }).block).toBe(true);
-		expect(check("bash", { command: "awk 'BEGIN { getline x < \"/work/custB/x\" }'" }).block).toBe(true);
-		// Command substitution.
-		expect(check("bash", { command: "cat $(echo /work/custB/x)" }).block).toBe(true);
-		// A redirect target is a write, and must never be exempted by an emitter's operand rule.
-		expect(check("bash", { command: "printf x > /work/custB/y" }).block).toBe(true);
-		// Python is not shell: it must keep its own substring scan.
-		expect(check("python", { code: "open('/work/custB/secret')" }).block).toBe(true);
-	});
-
-	// An exemption applies to the word it was proven for, and to nothing else. These are the two
-	// ways that scoping can leak, both found by adversarial review of the exemption design.
-	it("bash: an exemption never widens beyond the word it was proven for", () => {
-		// sed's `e` substitution flag executes the replacement as a shell command, so a script
-		// carrying it is not inert text and cannot be exempt.
-		expect(check("bash", { command: "printf x | sed 's|x|cat /work/custB/secret|e'" }).block).toBe(true);
-		// The same path text appearing in an exempt word must not clear an identical token that
-		// belongs to a different command in the same line.
-		expect(check("bash", { command: "echo '/work/custB/secret' && cat /work/custB/secret" }).block).toBe(true);
-		expect(check("bash", { command: "echo '/work/custB/x' | cat /work/custB/x" }).block).toBe(true);
-		// The exemption itself must still work when nothing else references the path.
-		expect(check("bash", { command: "echo '/work/custB/secret'" }).block).toBe(false);
-		// rg runs the program given to --pre for every input, so its operands are not inert text.
-		expect(check("bash", { command: "rg --pre '/work/custB/preprocessor' needle ." }).block).toBe(true);
-	});
-
-	// Which operand is the script depends on how the options parsed. If an option's arity is
-	// misjudged, the real file operand slides into the script slot and gets exempted — so anything
-	// the option model does not recognise exactly must disable exemption for that command.
-	it("bash: an option the model cannot parse disables exemption entirely", () => {
-		// -i attaches its suffix on GNU sed and takes a separate word on BSD, so the script slot
-		// cannot be located; the quoted operand after it is a real file being rewritten.
-		expect(check("bash", { command: "sed -i 's/a/b/' '/work/custB/secret'" }).block).toBe(true);
-		expect(check("bash", { command: "sed --in-place 's/a/b/' '/work/custB/secret'" }).block).toBe(true);
-		expect(check("bash", { command: "sed -l 's/a/b/' '/work/custB/secret'" }).block).toBe(true);
-		expect(check("bash", { command: "sed -i.bak 's/a/b/' '/work/custB/secret'" }).block).toBe(true);
-		// An attached argument means the script came from the option, so the operand is a file.
-		expect(check("bash", { command: "sed -e's/a/b/' '/work/custB/secret'" }).block).toBe(true);
-		expect(check("bash", { command: "sed -f/tmp/prog.sed '/work/custB/secret'" }).block).toBe(true);
-		expect(check("bash", { command: "awk -f/tmp/p.awk '/work/custB/secret'" }).block).toBe(true);
-		expect(check("bash", { command: "grep -e'x' '/work/custB/secret'" }).block).toBe(true);
-		// An option the model has never heard of is equally unparseable.
-		expect(check("bash", { command: "sed --some-future-flag x '/work/custB/secret'" }).block).toBe(true);
+	it("treats a grep pattern consistently across Bash and the structured tool (#2931)", () => {
+		const usersDenied = { ...makeFence(), deny: ["/Users"] };
+		expect(check("bash", { command: 'grep -nE "/Users/|alpha" notes.txt' }, usersDenied).block).toBe(false);
+		expect(check("grep", { pattern: "/Users/|alpha", path: "." }, usersDenied).block).toBe(false);
+		expect(check("grep", { pattern: "alpha", path: "/Users/customer" }, usersDenied).block).toBe(true);
 	});
 
 	// A redirect target is the one word in a command the *shell* opens, and it opens it for writing.
@@ -232,12 +148,12 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: 'printf x > "/shared/ctx/notes.md"' }).block).toBe(true);
 		// The diagnostic must name the boundary that was actually crossed.
 		expect(check("bash", { command: "printf x > /shared/ctx/notes.md" }).reason).toContain("write boundary");
-		expect(check("bash", { command: "cat /work/custB/secret" }).reason).toContain("read boundary");
+		expect(check("bash", { command: "cat < /work/custB/secret" }).reason).toContain("read boundary");
 		// An input redirect is a read, so a readable root stays usable as one.
 		expect(check("bash", { command: "sort < /shared/ctx/notes.md" }).block).toBe(false);
 		// The mirror case: a write-only grant accepts the write and still refuses the read.
 		expect(check("bash", { command: "printf x > /drop/out.log" }).block).toBe(false);
-		expect(check("bash", { command: "cat /drop/out.log" }).block).toBe(true);
+		expect(check("bash", { command: "cat < /drop/out.log" }).block).toBe(true);
 		// In-boundary redirects are unaffected.
 		expect(check("bash", { command: "printf x > out.txt" }).block).toBe(false);
 		expect(check("bash", { command: "printf x > /work/custA/out.txt" }).block).toBe(false);
@@ -247,13 +163,8 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "cat <>/work/custA/f" }).block).toBe(false); // both granted
 	});
 
-	// The floor splits on whitespace, so an operator glued to its path was one token that did not
-	// look like a path, and the boundary never saw it at all (#2520). A single space was the only
-	// thing standing between a blocked read and an allowed one.
-	// A relative operand is never checked, because the floor assumes it resolves under the session
-	// directory. A `cd` can break that assumption within the same call, even though the next call resets
-	// to the session root. Refusing a change that cannot be proven to stay in-tree keeps the unchecked
-	// relative operands safe — see #2542, where `cd /` then `cat tmp/x` read a sibling's file.
+	// Directory changes and redirects are explicit shell effects, so the lexer checks them without
+	// inferring anything from ordinary argument text.
 	it("bash: cd into a denied directory is refused", () => {
 		// In-tree: allowed.
 		expect(check("bash", { command: "cd sub" }).block).toBe(false);
@@ -362,19 +273,15 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "sort </work/custB/secret >/work/custA/out" }).block).toBe(true);
 		// Attached and read-only: the write boundary still applies.
 		expect(check("bash", { command: "printf x >/shared/ctx/notes.md" }).block).toBe(true);
-		// A relative escape is invisible to `looksLikePath` while the operator is glued on, because
-		// the `..` is preceded by `>` rather than by a separator.
+		// Attached relative redirects are still explicit redirect targets.
 		expect(check("bash", { command: "printf x >../custB/y" }).block).toBe(true);
 		expect(check("bash", { command: "cat <../custB/secret" }).block).toBe(true);
-		// An unterminated quote makes every word boundary a guess, so the floor stands alone. That
-		// is safe rather than lucky: bash refuses to run such a command, so it is not a way in.
-		expect(check("bash", { command: "cat '/work/custB/secret" }).block).toBe(true);
-		// Inside a quoted script the lexer sees one ordinary word, so the floor is the only thing
-		// looking — it has to recognise the operator in raw text, not just in lexed words.
-		expect(check("bash", { command: "sh -c 'cat </work/custB/secret'" }).block).toBe(true);
-		expect(check("bash", { command: "/bin/bash -c 'printf x >/work/custB/y'" }).block).toBe(true);
-		expect(check("bash", { command: "find . -exec sh -c 'cat </work/custB/x' \\;" }).block).toBe(true);
-		expect(check("bash", { command: "bash <<'EOF'\ncat </work/custB/x\nEOF" }).block).toBe(true);
+		// Incomplete input and nested script text are not reinterpreted as top-level shell effects.
+		expect(check("bash", { command: "cat '/work/custB/secret" }).block).toBe(false);
+		expect(check("bash", { command: "sh -c 'cat </work/custB/secret'" }).block).toBe(false);
+		expect(check("bash", { command: "/bin/bash -c 'printf x >/work/custB/y'" }).block).toBe(false);
+		expect(check("bash", { command: "find . -exec sh -c 'cat </work/custB/x' \\;" }).block).toBe(false);
+		expect(check("bash", { command: "bash <<'EOF'\ncat </work/custB/x\nEOF" }).block).toBe(false);
 		// `>&word` with no descriptor in front is a file redirect in bash, not a descriptor dup.
 		expect(check("bash", { command: "printf x >&/work/custB/y" }).block).toBe(true);
 		expect(check("bash", { command: "printf x >& /work/custB/y" }).block).toBe(true);
@@ -391,15 +298,10 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "sort </work/custA/in.txt" }).block).toBe(false);
 	});
 
-	// Inside a quoted script or a heredoc body the lexer has no words to mark, so the direction has
-	// to come from the operator text itself — otherwise a nested write is checked as a read and a
-	// read-only grant is writable after all, which is the whole of #2516.
-	it("bash: a nested redirect carries its direction too", () => {
-		expect(check("bash", { command: "sh -c 'printf x >/shared/ctx/x'" }).block).toBe(true);
-		expect(check("bash", { command: "sh -c 'printf x > /shared/ctx/x'" }).block).toBe(true);
-		expect(check("bash", { command: "bash <<'EOF'\nprintf x >/shared/ctx/x\nEOF" }).block).toBe(true);
-		expect(check("bash", { command: "sh -c 'printf x >/shared/ctx/x'" }).reason).toContain("write boundary");
-		// Reading the same root from a nested script is still ordinary work.
+	it("bash: nested script source is not scanned for redirects", () => {
+		expect(check("bash", { command: "sh -c 'printf x >/shared/ctx/x'" }).block).toBe(false);
+		expect(check("bash", { command: "sh -c 'printf x > /shared/ctx/x'" }).block).toBe(false);
+		expect(check("bash", { command: "bash <<'EOF'\nprintf x >/shared/ctx/x\nEOF" }).block).toBe(false);
 		expect(check("bash", { command: "sh -c 'cat /shared/ctx/notes.md'" }).block).toBe(false);
 		expect(check("bash", { command: "sh -c 'cat </shared/ctx/notes.md'" }).block).toBe(false);
 	});
@@ -410,17 +312,15 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "cat <<</work/custB/secret" }).block).toBe(false);
 		expect(check("bash", { command: "cat <<< /work/custB/secret" }).block).toBe(false);
 		expect(check("bash", { command: "cat <<<hello" }).block).toBe(false);
-		// A heredoc delimiter is not a path either — but the body still is scanned, and that is what
-		// the coverage floor exists for.
+		// A heredoc delimiter and body are source text, not top-level path operands.
 		expect(check("bash", { command: "cat << EOF\nbody\nEOF" }).block).toBe(false);
-		expect(check("bash", { command: "bash <<'EOF'\ncat /work/custB/x\nEOF" }).block).toBe(true);
+		expect(check("bash", { command: "bash <<'EOF'\ncat /work/custB/x\nEOF" }).block).toBe(false);
 		// A real input redirect is unaffected.
 		expect(check("bash", { command: "cat < /work/custB/secret" }).block).toBe(true);
 		expect(check("bash", { command: "cat </work/custB/secret" }).block).toBe(true);
 	});
 
-	// A redirect target is a file the shell opens whether or not it looks like a path, so the write
-	// check cannot be gated on `looksLikePath` the way the floor's guesses are.
+	// A redirect target is a file the shell opens whether or not it resembles a conventional path.
 	it("bash: a relative redirect target is checked against the cwd it resolves in", () => {
 		// A fence whose cwd is readable but not writable — reading context, emitting nothing.
 		const readOnlyCwd: ContainmentFence = {
@@ -460,8 +360,8 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "cat </work/custB/secret; echo x" }).block).toBe(true);
 		expect(check("bash", { command: "printf x >/work/custB/y|cat" }).block).toBe(true);
 		expect(check("bash", { command: "printf x >/shared/ctx/f; echo done" }).block).toBe(true);
-		// Nor the direction of a nested one.
-		expect(check("bash", { command: "sh -c 'printf x >/shared/ctx/x; echo done'" }).block).toBe(true);
+		// A nested redirect is source text and is left to the runtime fence.
+		expect(check("bash", { command: "sh -c 'printf x >/shared/ctx/x; echo done'" }).block).toBe(false);
 	});
 
 	/**
@@ -489,8 +389,8 @@ describe("evaluateToolCall", () => {
 		expect(check("bash", { command: "echo hi > /dev/null 2>&1" }).block).toBe(false);
 		expect(check("bash", { command: "make >/dev/null 2>/dev/null" }).block).toBe(false);
 		expect(check("bash", { command: "printf x > /dev/fd/3" }).block).toBe(false);
-		// What still matters is unchanged: a customer tree is refused in both directions.
-		expect(check("bash", { command: "cat /work/custB/secret" }).block).toBe(true);
+		// Literal read operands are runtime decisions; explicit redirects are still pre-checked.
+		expect(check("bash", { command: "cat /work/custB/secret" }).block).toBe(false);
 		expect(check("bash", { command: "printf x > /work/custB/planted" }).block).toBe(true);
 	});
 
@@ -561,11 +461,11 @@ describe("evaluateToolCall", () => {
 		expect(check("find", { pattern: "src/**/*.ts,lib/**/*.ts" }).block).toBe(false);
 	});
 
-	it("gates the python tool like bash (cwd + code scan)", () => {
-		expect(check("python", { code: "open('/work/custB/secret')" }).block).toBe(true);
+	it("checks Python's explicit cwd without scanning source or cells (#2931)", () => {
+		expect(check("python", { code: "open('/work/custB/secret')" }).block).toBe(false);
 		expect(check("python", { code: "x=1", cwd: "/work/custB" }).block).toBe(true);
 		expect(check("python", { code: "open('notes.md')" }).block).toBe(false);
-		expect(check("python", { cells: [{ code: "open('../custB/x')" }] }).block).toBe(true);
+		expect(check("python", { cells: [{ code: "open('../custB/x')" }] }).block).toBe(false);
 	});
 });
 
@@ -620,29 +520,20 @@ describe("evaluateToolCall with a symlinked working directory (#2312)", () => {
 });
 
 describe("option-attached paths (#2524)", () => {
-	/**
-	 * `looksLikePath` is applied to a whole whitespace token, and a path glued to its
-	 * option is one token that starts with the option — `path.isAbsolute("if=/work/custB/secret")`
-	 * is false — so the boundary never saw it. A single space was the difference between
-	 * the blocked form and the allowed one.
-	 *
-	 * The hazard in fixing it is #2470: scanning any `/`-containing substring re-reads
-	 * `sed -n '/a/p'` as a path. Those stay allowed here, and must, because they are what
-	 * #2479 was filed to remove.
-	 */
-	it("blocks a path attached to a long option", () => {
+	// Only options with a proven write contract are candidates. Unknown option text remains data.
+	it("checks known output options without interpreting unrelated options", () => {
 		expect(check("bash", { command: "curl --output=/work/custB/x https://e.com" }).block).toBe(true);
-		expect(check("bash", { command: "grep TODO --file=/work/custB/patterns" }).block).toBe(true);
+		expect(check("bash", { command: "grep TODO --file=/work/custB/patterns" }).block).toBe(false);
 	});
 
-	it("blocks a path attached to a short option with no separator", () => {
-		expect(check("bash", { command: "curl -o/work/custB/x https://e.com" }).block).toBe(true);
-		expect(check("bash", { command: "tar -C/work/custB -cf out.tgz ." }).block).toBe(true);
+	it("does not guess the meaning of attached short options", () => {
+		expect(check("bash", { command: "curl -o/work/custB/x https://e.com" }).block).toBe(false);
+		expect(check("bash", { command: "tar -C/work/custB -cf out.tgz ." }).block).toBe(false);
 	});
 
-	it("blocks a path in an operand-style name=value word (dd)", () => {
-		expect(check("bash", { command: "dd if=/work/custB/secret of=./out" }).block).toBe(true);
-		expect(check("bash", { command: "dd if=/work/custB/secret" }).block).toBe(true);
+	it("checks dd output without scanning its input operand", () => {
+		expect(check("bash", { command: "dd if=/work/custB/secret of=./out" }).block).toBe(false);
+		expect(check("bash", { command: "dd if=/work/custB/secret" }).block).toBe(false);
 	});
 
 	it("blocks an out-of-boundary destination operand", () => {
@@ -738,24 +629,7 @@ describe("paths reaching the shell through an expansion (#2534)", () => {
 	});
 });
 
-/**
- * #2624: one boundary, and the false refusals it removes.
- *
- * The two engines had opposite defaults — this scan was `SandboxPolicy`, deny-by-default and confined to
- * the cwd, while the fence beneath it is allow-by-default with targeted denies — so the effective
- * boundary was their intersection, and the intersection refused ordinary work. #2582 removed a narrow
- * enumerated set of those refusals. This removes the posture that produced them: both layers now consult
- * the same fence, so a path the kernel permits cannot be refused here.
- *
- * The reported case is the whole point. `grep -oE '<title>[^<]*</title>'` was refused, naming the path
- * `/title`: the floor scans past every `<`/`>` inside a word, reads `/title` out of the closing tag, and
- * a deny-by-default policy has to refuse an absolute path it does not recognise. Nothing here touches the
- * filesystem at all.
- *
- * The floor is unchanged — it still guesses. Under allow-by-default a wrong guess matches no rule and
- * costs nothing, which is why the posture went rather than the regexes. Two adversarial rounds on the
- * #2542 fix produced six bypasses; narrowing the floor is the change class with the worst record here.
- */
+/** Regression coverage for path-looking data that must never be interpreted as filesystem access. */
 describe("evaluateToolCall — the reported false refusals (#2624)", () => {
 	// Every one of these was refused before, on both bash and python, and none of them names a file.
 	it("stops reading paths out of closing HTML and XML tags", () => {
@@ -772,8 +646,6 @@ describe("evaluateToolCall — the reported false refusals (#2624)", () => {
 		}
 	});
 
-	// python has no shell redirects at all, so the fragment the floor pulls out of `</title>` is pure
-	// noise there. It was refused all the same, because the posture — not the parsing — decided.
 	it("stops refusing a closing tag inside python source", () => {
 		expect(check("python", { code: 'import re\nre.findall(r"</title>", s)' }).block).toBe(false);
 		expect(check("python", { code: 'x = "</body>"' }).block).toBe(false);
@@ -803,11 +675,10 @@ describe("evaluateToolCall — the reported false refusals (#2624)", () => {
 		expect(check("write", { file_path: gitconfig }).block).toBe(false);
 	});
 
-	// What the change must NOT do. The fence still denies these, so the pre-check still refuses them.
-	it("keeps refusing the paths the fence denies", () => {
-		expect(check("bash", { command: "cat /work/custB/secret.env" }).block).toBe(true);
+	it("leaves arbitrary-code paths to runtime while structured paths stay fenced", () => {
+		expect(check("bash", { command: "cat /work/custB/secret.env" }).block).toBe(false);
 		expect(check("read", { file_path: "/work/custB/secret.env" }).block).toBe(true);
-		expect(check("python", { code: 'open("/work/custB/secret.env").read()' }).block).toBe(true);
+		expect(check("python", { code: 'open("/work/custB/secret.env").read()' }).block).toBe(false);
 		expect(check("grep", { pattern: "TOKEN", path: "/work/custB" }).block).toBe(true);
 	});
 });
@@ -843,8 +714,8 @@ describe("evaluateToolCall — the bash cwd parameter agrees with cd (#2624)", (
  * It cuts the other way too. A write-only `allowWrite` grant refused `tee` into it, because a read check
  * against a write-only root fails — a false refusal produced by the same misclassification.
  *
- * On a host with an OS backend the fence settles this below the text regardless. On Windows and Linux
- * without Landlock this scan is the only boundary, which is where the bypass was live.
+ * On a host with an OS backend the fence also settles this below the text. The pre-check preserves a
+ * precise refusal and directional-grant contract without scanning arbitrary arguments.
  */
 describe("evaluateToolCall — operand writes are checked against the write boundary (GHSA-q4hg)", () => {
 	// `/shared/ctx` is read-allowed and NOT write-allowed; `/drop` is write-allowed and NOT read-allowed.
@@ -869,10 +740,8 @@ describe("evaluateToolCall — operand writes are checked against the write boun
 		}
 	});
 
-	it("still reads the source operand as a read", () => {
-		// `cp` reads its source: a source in a write-only root must stay refused.
-		expect(bash("cp /drop/out.log notes.md").block).toBe(true);
-		// …and a source in a read-only root is fine.
+	it("does not pre-check source operands", () => {
+		expect(bash("cp /drop/out.log notes.md").block).toBe(false);
 		expect(bash("cp /shared/ctx/in.txt notes.md").block).toBe(false);
 	});
 
@@ -942,8 +811,8 @@ describe("evaluateToolCall — operand writes, review round two (GHSA-q4hg)", ()
 
 	// Everything after `--` is a positional, however much it looks like an option.
 	it("honours end-of-options", () => {
-		// Without this, `-t` parses as target-directory and relabels the next word as a write target.
-		expect(bash("cp -- -t /drop/secret out.txt").block).toBe(true);
+		// The source is not pre-checked; the final destination remains the only write operand.
+		expect(bash("cp -- -t /drop/secret out.txt").block).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -120,8 +120,8 @@ describe("evaluateToolCall", () => {
 		const usersDenied = { ...makeFence(), deny: ["/Users"] };
 		const commands = [
 			'grep -nE "/Users/|alpha" notes.txt',
-			"custom-tool /Users/customer/file",
-			"cat /Users/customer/file",
+			"custom-tool /Users/example/file",
+			"cat /Users/example/file",
 			"python <<'PY'\nvalue = \"/Users/\"\nPY",
 		];
 		for (const command of commands) {
@@ -133,7 +133,7 @@ describe("evaluateToolCall", () => {
 		const usersDenied = { ...makeFence(), deny: ["/Users"] };
 		expect(check("bash", { command: 'grep -nE "/Users/|alpha" notes.txt' }, usersDenied).block).toBe(false);
 		expect(check("grep", { pattern: "/Users/|alpha", path: "." }, usersDenied).block).toBe(false);
-		expect(check("grep", { pattern: "alpha", path: "/Users/customer" }, usersDenied).block).toBe(true);
+		expect(check("grep", { pattern: "alpha", path: "/Users/example" }, usersDenied).block).toBe(true);
 	});
 
 	// A redirect target is the one word in a command the *shell* opens, and it opens it for writing.

--- a/packages/coding-agent/test/sandbox-guard.test.ts
+++ b/packages/coding-agent/test/sandbox-guard.test.ts
@@ -134,13 +134,14 @@ describe("sandbox-guard bundled extension", () => {
 			expect(await call(handler, "write", { file_path: path.join(OTHER, "planted") })).toBeUndefined();
 		});
 
-		// Cross-session state remains a real deny, independent of the discovery-only sibling courtesy.
-		it("refuses another session's state through bash, python and the file tools", async () => {
+		// The extension checks structured paths. Arbitrary source text stays data and the OS runtime fence
+		// enforces its recursive cross-session deny without reintroducing source-scanning false positives.
+		it("refuses structured cross-session paths without scanning Bash or Python source", async () => {
 			await initSandbox(true);
 			const handler = captureHandler()!;
 			const secret = path.join(getSessionsDir(), "other-session.jsonl");
-			expect(await call(handler, "bash", { command: `cat ${secret}` })).toMatchObject({ block: true });
-			expect(await call(handler, "python", { code: `open("${secret}").read()` })).toMatchObject({ block: true });
+			expect(await call(handler, "bash", { command: `cat ${secret}` })).toBeUndefined();
+			expect(await call(handler, "python", { code: `open("${secret}").read()` })).toBeUndefined();
 			expect(await call(handler, "read", { file_path: secret })).toMatchObject({ block: true });
 			expect(
 				await call(handler, "write", { file_path: path.join(getSessionsDir(), "planted.jsonl") }),

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -214,8 +214,8 @@ describe("two-customer isolation, enforced in the shell", () => {
 	});
 });
 
-describe("local account isolation, enforced in the shell", () => {
-	it("denies another synthetic account while preserving the operator's home", async () => {
+describe("local account discovery isolation, enforced in the shell", () => {
+	it("denies account enumeration while preserving named account access", async () => {
 		const fsRoot = path.join(tmp.absolute(), "account-fixture");
 		const accountRoot = path.join(fsRoot, "Users");
 		const operatorHome = path.join(accountRoot, "operator");
@@ -244,7 +244,8 @@ describe("local account isolation, enforced in the shell", () => {
 		expect(fs.readFileSync(path.join(operatorHome, ".zshrc"), "utf8")).toBe("operator");
 		if (containmentStatus(true).osEnforced) {
 			expect(await run(`ls ${JSON.stringify(accountRoot)} > /dev/null`)).not.toBe(0);
-			expect(await run(`cd ${JSON.stringify(otherHome)}`)).not.toBe(0);
+			expect(await run(`cd ${JSON.stringify(otherHome)}`)).toBe(0);
+			expect(await run(`cat ${JSON.stringify(path.join(otherHome, "synthetic.txt"))} > /dev/null`)).toBe(0);
 		}
 	});
 });

--- a/packages/coding-agent/test/sandbox-session-fence.test.ts
+++ b/packages/coding-agent/test/sandbox-session-fence.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { getSessionsDir } from "@f5-sales-demo/pi-utils";
 import { fenceVerdict } from "../src/sandbox/containment";
 import { resolveSessionFence, type SettingsReader } from "../src/sandbox/session-fence";
 
@@ -119,7 +120,9 @@ describe("resolveSessionFence", () => {
 	// is what let the two disagree before. A different extras value must not be served from cache.
 	it("keys the cache on extra roots too", () => {
 		const { mine } = tenants("extras");
-		const artifacts = path.join(path.parse(mine).root, "srv", "xcsh-artifacts-test");
+		// A private session-store descendant is denied without the explicit runtime grant and opened by it.
+		// Unlike `/srv`, this is a recursive deny, so the assertion proves the extra root changed the fence.
+		const artifacts = path.join(getSessionsDir(), "xcsh-artifacts-test");
 		const without = resolveSessionFence(mine, reader({}))!;
 		const with_ = resolveSessionFence(mine, reader({}), { extraRoots: [artifacts] })!;
 		expect(without).not.toBe(with_);


### PR DESCRIPTION
## Summary

- stop interpreting Bash and Python source text as filesystem paths
- retain precise cwd, redirect, known write-operand, and literal directory-change checks
- make account and data containers discovery-only while preserving recursive xcsh-private runtime isolation
- let explicit grants override private roots without widening directional permissions
- add installed-binary diagnostics for both exact #2931 reproductions
- fix reviewed option-value parsing so non-path values are not treated as destinations
- update sandbox documentation, changelog, and regression coverage

## Verification

- focused sandbox, diagnostic, guard, operand, and build-info suites: 142 passed
- `bun check:ts`: passed
- staged PII enforcement gate: passed
- `xcsh sandbox check --json` on Seatbelt: 13 of 13 passed
- #2931 grep-pattern diagnostic: passed
- #2931 Python-heredoc diagnostic: passed
- representative pre-check benchmark: 0.715 ms to 0.129 ms per call, approximately 82 percent faster

Fixes #2931