### PR TITLE
fix(ai): omit empty tool arrays for vLLM

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 
 - Preserved native Gemini finish reasons in Google provider errors instead of reporting an unknown error ([#2874](https://github.com/f5-sales-demo/xcsh/issues/2874))
+- Omitted empty tool arrays from OpenAI-compatible chat-completions requests so vLLM accepts no-tool sessions ([#2942](https://github.com/f5-sales-demo/xcsh/issues/2942))
 
 <!-- markdownlint-disable MD024 -->
 <!-- textlint-disable terminology -->
@@ -432,7 +433,7 @@
 - Removed `UsageCache` and `UsageCacheEntry` interfaces—caching is now handled internally by AuthStorage
 - Removed `google-gemini-cli-usage` export; use new `gemini` usage provider instead
 - Removed `resetInMs` computation from all usage providers
-- Removed cache TTL constants and cache management from usage fetchers (claude, github-copilot, google-antigravity, kimi, openai-codex, zai)
+- Removed cache TTL constants and cache management from usage fetchers (`claude`, `github-copilot`, `google-antigravity`, `kimi`, `openai-codex`, `zai`)
 
 ### Fixed
 
@@ -1293,7 +1294,7 @@
 
 ### Changed
 
-- Updated @anthropic-ai/sdk to ^0.72.1
+- Updated `@anthropic-ai/sdk` to ^0.72.1
 - Updated @aws-sdk/client-bedrock-runtime to ^3.982.0
 - Updated @google/genai to ^1.39.0
 - Updated @smithy/node-http-handler to ^4.4.9

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -715,7 +715,7 @@ function buildParams(
 		params.service_tier = options.serviceTier;
 	}
 
-	if (context.tools) {
+	if (context.tools && context.tools.length > 0) {
 		const builtTools = convertTools(context.tools, compat, toolStrictModeOverride);
 		params.tools = builtTools.tools;
 		toolStrictMode = builtTools.toolStrictMode;

--- a/packages/ai/test/openai-tool-strict-mode.test.ts
+++ b/packages/ai/test/openai-tool-strict-mode.test.ts
@@ -94,6 +94,19 @@ describe("OpenAI tool strict mode", () => {
 		expect(payload.tools?.[0]?.function?.strict).toBeUndefined();
 	});
 
+	it("omits tools when the context has an empty tools array", async () => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+		};
+		const context: Context = { ...testContext, tools: [] };
+
+		const payload = (await captureCompletionsPayload(model, context)) as {
+			tools?: unknown[];
+		};
+		expect(payload.tools).toBeUndefined();
+	});
+
 	it("sends strict=true for openai-completions tool schemas on GitHub Copilot", async () => {
 		const model = getBundledModel("github-copilot", "gpt-4o") as Model<"openai-completions">;
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### Fixed
 
 - Made Office gateway configuration defer a blank model to xcsh's GPT-5.6 Sol default, preserve OpenAI-compatible URL paths, and ignore legacy Anthropic-era saved settings ([#2890](https://github.com/f5-sales-demo/xcsh/issues/2890))
+- Made no-tool local vLLM sessions omit empty tool payloads rejected by the OpenAI-compatible endpoint ([#2942](https://github.com/f5-sales-demo/xcsh/issues/2942))
 - Added a deterministic five-step MEDDPICC Office/Excel certification harness with live-model, plugin, filesystem, host-tool, workbook, and idempotency evidence ([#2890](https://github.com/f5-sales-demo/xcsh/issues/2890))
 - Rejected invalid lazy-command syntax before loading heavy command implementations while preserving command-specific launch-flag diagnostics ([#2874](https://github.com/f5-sales-demo/xcsh/issues/2874))
 - Added dependency-install verification and automatic repair so stale workspace links and release-bumped lock entries cannot silently load SDK versions older than manifests, and aligned development with Bun 1.3.14 ([#2874](https://github.com/f5-sales-demo/xcsh/issues/2874))


### PR DESCRIPTION
## Summary

Omit the OpenAI-compatible tools field when the active context contains an empty tool array. This allows keyless local vLLM requests to reach inference while preserving the existing tool-history compatibility path.

## Related Issue

Closes #2942

## Changes

- Guard tool conversion on a non-empty context tool array.
- Add a failing-first regression test that captures the outgoing completions payload.
- Document the fix in the AI and coding-agent changelogs.
- Format two historical changelog identifiers so whole-file terminology validation remains green.

## Verification evidence

- bun test packages/ai/test/openai-tool-strict-mode.test.ts: 11 passed, 0 failed.
- bun --cwd packages/ai test: 660 passed, 0 failed.
- bun --cwd packages/coding-agent test: 6,368 passed, 0 failed.
- bun run check:ts: all workspace formatting and type checks passed.
- bun run pii:gate: PII gate clean in head scope.
- git diff --check origin/main...HEAD: passed.
- Live local vLLM matrix: four fresh repetitions, 28/28 scenarios passed. Coverage includes no-tool conversation and arithmetic, exact typed arguments, a parallel two-read batch, sequential dependent calls, and a no-action safety prompt.
- GitHub CI watched to completion: all required checks passed, including full tests, native builds, installation methods, PII, Semgrep, Super-Linter, Zig verification, and AI review.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions