### PR TITLE
fix(sandbox): preserve nested live-profile workspace writes

### DIFF
--- a/packages/coding-agent/src/cli/sandbox-check.ts
+++ b/packages/coding-agent/src/cli/sandbox-check.ts
@@ -221,7 +221,15 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 		redactions.push([liveWorkspace, "<workspace>"], [liveHome, "<operator-home>"]);
 		if (inheritedSibling !== undefined) redactions.push([inheritedSibling, "<session-parent>/<synthetic-sibling>"]);
 
-		const fixtureBase = inheritedProfile ? liveWorkspace : await fs.realpath(os.tmpdir());
+		// A home-rooted Landlock profile must split the home grant around protected session stores. The
+		// kernel can grant an existing named child but cannot grant future children of that split root
+		// without also reopening the protected stores. BashTool therefore prepares one host-owned child
+		// before confinement; keep all exact-home live fixtures beneath that already-granted directory.
+		const liveWritableRoot =
+			inheritedProfile && liveWorkspace === liveHome && inheritedSibling !== undefined
+				? inheritedSibling
+				: liveWorkspace;
+		const fixtureBase = inheritedProfile ? liveWritableRoot : await fs.realpath(os.tmpdir());
 		fixtureRoot = await fs.mkdtemp(path.join(fixtureBase, ".xcsh-sandbox-check-policy-"));
 		fixturePaths.push(fixtureRoot);
 		redactions.push([fixtureRoot, "<synthetic-root>"]);
@@ -356,7 +364,7 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 			const displayPath = "<workspace>/<synthetic-fixture>";
 			let liveFixture: string;
 			try {
-				liveFixture = await fs.mkdtemp(path.join(liveWorkspace, ".xcsh-sandbox-check-workspace-"));
+				liveFixture = await fs.mkdtemp(path.join(liveWritableRoot, ".xcsh-sandbox-check-workspace-"));
 				fixturePaths.push(liveFixture);
 				redactions.push([liveFixture, displayPath]);
 				await fs.mkdir(path.join(liveFixture, "nested"));

--- a/packages/coding-agent/src/cli/sandbox-check.ts
+++ b/packages/coding-agent/src/cli/sandbox-check.ts
@@ -12,6 +12,7 @@ import {
 	SANDBOX_CHECK_NAMED_SIBLING_ENV,
 	SANDBOX_OPERATOR_HOME_ENV,
 	SANDBOX_SESSION_ROOT_ENV,
+	sandboxCheckSiblingRoot,
 } from "../sandbox/session-fence";
 import type { ToolSession } from "../tools";
 import { BashTool } from "../tools/bash";
@@ -381,7 +382,9 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 			let liveSibling = inheritedSibling;
 			if (liveSibling === undefined) {
 				try {
-					liveSibling = await fs.mkdtemp(path.join(path.dirname(liveWorkspace), ".xcsh-sandbox-check-sibling-"));
+					liveSibling = await fs.mkdtemp(
+						path.join(sandboxCheckSiblingRoot(liveWorkspace, liveHome), ".xcsh-sandbox-check-sibling-"),
+					);
 					fixturePaths.push(liveSibling);
 					nonEnumerableCleanupDirs.add(liveSibling);
 					redactions.push([liveSibling, displayPath]);

--- a/packages/coding-agent/src/sandbox/session-fence.ts
+++ b/packages/coding-agent/src/sandbox/session-fence.ts
@@ -14,6 +14,7 @@
  * allow-by-default with targeted denies, so the effective boundary was their intersection and the
  * intersection refused ordinary work. One object means the pre-check and the kernel cannot disagree.
  */
+import * as path from "node:path";
 import { buildContainmentFence, type ContainmentFence } from "./containment";
 
 /**
@@ -27,6 +28,12 @@ import { buildContainmentFence, type ContainmentFence } from "./containment";
 export const SANDBOX_SESSION_ROOT_ENV = "XCSH_SANDBOX_SESSION_ROOT";
 export const SANDBOX_OPERATOR_HOME_ENV = "XCSH_SANDBOX_OPERATOR_HOME";
 export const SANDBOX_CHECK_NAMED_SIBLING_ENV = "XCSH_SANDBOX_CHECK_NAMED_SIBLING";
+
+/** Choose a writable root for the live named-path probe without escaping an operator-home session. */
+export function sandboxCheckSiblingRoot(workspace: string, operatorHome: string): string {
+	const parent = path.dirname(workspace);
+	return workspace === operatorHome || parent === workspace ? workspace : parent;
+}
 
 /** The slice of `Settings` this needs — supplied explicitly so the caller names its own source. */
 export interface SettingsReader {

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -24,6 +24,7 @@ import {
 	SANDBOX_CHECK_NAMED_SIBLING_ENV,
 	SANDBOX_OPERATOR_HOME_ENV,
 	SANDBOX_SESSION_ROOT_ENV,
+	sandboxCheckSiblingRoot,
 } from "../sandbox/session-fence";
 import { SECRET_ENV_PATTERNS, type SecretObfuscator } from "../secrets";
 import { DEFAULT_MAX_BYTES, TailBuffer } from "../session/streaming-output";
@@ -658,12 +659,14 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		// Keep these values host-owned: tool-supplied env cannot replace them.
 		let env = requestedEnv;
 		let trustedSessionRoot = containmentRoot;
+		let trustedOperatorHome = os.homedir();
 		if (fence !== undefined) {
-			const [canonicalSessionRoot, trustedOperatorHome] = await Promise.all([
+			const [canonicalSessionRoot, canonicalOperatorHome] = await Promise.all([
 				canonicalizeSandboxContextPath(containmentRoot),
-				canonicalizeSandboxContextPath(os.homedir()),
+				canonicalizeSandboxContextPath(trustedOperatorHome),
 			]);
 			trustedSessionRoot = canonicalSessionRoot;
+			trustedOperatorHome = canonicalOperatorHome;
 			env = {
 				...requestedEnv,
 				[SANDBOX_SESSION_ROOT_ENV]: trustedSessionRoot,
@@ -799,7 +802,10 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			// sibling before the child is confined so the diagnostic measures reachability, not whether a
 			// nested sandbox can widen itself. The host owns both this path and its cleanup.
 			sandboxCheckSibling = await fs.promises.mkdtemp(
-				path.join(path.dirname(trustedSessionRoot), ".xcsh-sandbox-check-live-sibling-"),
+				path.join(
+					sandboxCheckSiblingRoot(trustedSessionRoot, trustedOperatorHome),
+					".xcsh-sandbox-check-live-sibling-",
+				),
 			);
 			await Bun.write(path.join(sandboxCheckSibling, "named.txt"), "sibling\n");
 			env = { ...env, [SANDBOX_CHECK_NAMED_SIBLING_ENV]: sandboxCheckSibling };

--- a/packages/coding-agent/test/sandbox-check.test.ts
+++ b/packages/coding-agent/test/sandbox-check.test.ts
@@ -171,7 +171,22 @@ it("reports a healthy matrix when invoked inside the live bash profile", async (
 	}
 }, 30_000);
 
-it("reports a healthy matrix for a live session rooted directly under operator home", async () => {
+it("reports a healthy matrix for a live session rooted at operator home", async () => {
+	const home = fs.realpathSync(os.homedir());
+	const liveSiblingPrefix = ".xcsh-sandbox-check-live-sibling-";
+	const liveSiblingCount = (): number =>
+		fs.readdirSync(home).filter(entry => entry.startsWith(liveSiblingPrefix)).length;
+	const liveSiblingCountBefore = liveSiblingCount();
+
+	try {
+		assertHealthyReport(await runInsideLiveProfile(home));
+	} finally {
+		_resetShellSessionsForTest();
+		expect(liveSiblingCount()).toBe(liveSiblingCountBefore);
+	}
+}, 30_000);
+
+it("reports a healthy matrix for a live session rooted directly inside operator home", async () => {
 	const home = fs.realpathSync(os.homedir());
 	const fixturePaths: string[] = [];
 	const liveSiblingPrefix = ".xcsh-sandbox-check-live-sibling-";

--- a/packages/coding-agent/test/sandbox-check.test.ts
+++ b/packages/coding-agent/test/sandbox-check.test.ts
@@ -30,8 +30,9 @@ function sandboxCheckCommand(flags: string[] = [], prefixFlags: string[] = []): 
 async function runSandboxCheckProcess(
 	flags: string[],
 	env: Record<string, string | undefined> = process.env,
+	cwd = process.cwd(),
 ): Promise<$.ShellOutput> {
-	return await $`${{ raw: sandboxCheckCommand(flags) }}`.env(env).quiet().nothrow();
+	return await $`${{ raw: sandboxCheckCommand(flags) }}`.cwd(cwd).env(env).quiet().nothrow();
 }
 
 function resultText(result: AgentToolResult<BashToolDetails>): string {
@@ -99,6 +100,15 @@ function assertHealthyReport(report: SandboxCheckReport): void {
 
 it("runs the flag-free sandbox check named by launch-flag diagnostics and verifies fixture cleanup", async () => {
 	const result = await runSandboxCheckProcess(["--json"]);
+	const report = JSON.parse(result.stdout.toString()) as SandboxCheckReport;
+
+	expect(result.exitCode).toBe(0);
+	assertHealthyReport(report);
+}, 30_000);
+
+it("reports a healthy matrix when invoked from operator home", async () => {
+	const home = fs.realpathSync(os.homedir());
+	const result = await runSandboxCheckProcess(["--json"], process.env, home);
 	const report = JSON.parse(result.stdout.toString()) as SandboxCheckReport;
 
 	expect(result.exitCode).toBe(0);


### PR DESCRIPTION
Closes #2924

## Summary
- keep standalone sandbox fixtures writable when invoked from the operator home
- prepare nested live-profile fixtures inside a host-owned granted directory
- cover direct, nested repository, and exact-home Landlock diagnostics

## Verification
- 6,365 coding-agent tests passed; 559 skipped; 0 failed
- 197 sandbox tests and 15 Rust complement tests passed
- repository TypeScript checks and production build passed
- compiled Linux binary returned Landlock 11/11 directly and passed all 9 nested scenarios
- PII enforcement and Antigravity pre-push review passed with zero findings