### PR TITLE
chore(governance): bootstrap exact managed callers

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -1,6 +1,7 @@
 ---
 name: Enforce Repository Settings
 
+#checkov:skip=CKV_GHA_7:Exact source receipts are validated before any governed read or mutation.
 on:
   schedule:
     - cron: '0 */6 * * *'
@@ -253,7 +254,7 @@ jobs:
   enforce-settings:
     needs: resolve-source
     if: needs.resolve-source.outputs.ready == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@1534ac5010121685f8deed2af7cdab3452f800b0
+    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@ee62a350312f35a8ddd80e316193535f12fb9152
     with:
       source_sha: ${{ needs.resolve-source.outputs.source_sha }}
     secrets:
@@ -262,7 +263,7 @@ jobs:
   sync-files:
     needs: resolve-source
     if: needs.resolve-source.outputs.ready == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@1534ac5010121685f8deed2af7cdab3452f800b0
+    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@ee62a350312f35a8ddd80e316193535f12fb9152
     with:
       source_sha: ${{ needs.resolve-source.outputs.source_sha }}
       downstream_sha: ${{ github.sha }}

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -1,6 +1,7 @@
 ---
 name: Require Linked Issue
 
+#checkov:skip=CKV_GHA_7:Targeted inputs are exact PR receipts validated before a status is written.
 on:
   schedule:
     - cron: '*/5 * * * *'


### PR DESCRIPTION
Installs the exact applicable managed callers before fleet enforcement resumes. The sync/ branch uses the governed automation exemption from linked-issue enforcement.