### PR TITLE
test(coding-agent): update plugin display name test for consolidated github plugin

### DIFF
--- a/packages/coding-agent/test/plugin-display-name.test.ts
+++ b/packages/coding-agent/test/plugin-display-name.test.ts
@@ -69,8 +69,8 @@ describe("normalizePluginDisplayName", () => {
 			expect(normalizePluginDisplayName("xcsh-meddpicc")).toBe("meddpicc");
 		});
 
-		it("handles xcsh-github-ops", () => {
-			expect(normalizePluginDisplayName("xcsh-github-ops")).toBe("github-ops");
+		it("handles xcsh-github", () => {
+			expect(normalizePluginDisplayName("xcsh-github")).toBe("github");
 		});
 	});
 });


### PR DESCRIPTION
## Summary
Updates plugin display name unit tests in `packages/coding-agent` to test the single poweruser `xcsh-github` plugin.

Closes #2962