### PR TITLE
fix(coding-agent): preserve operator workflows in Linux sandbox

### DIFF
--- a/crates/brush-core-vendored/src/commands.rs
+++ b/crates/brush-core-vendored/src/commands.rs
@@ -192,7 +192,12 @@ pub fn compose_std_command<S: AsRef<OsStr>>(
 	// The ruleset is built here, before `fork`, and the child only has to apply it — see
 	// `sys::landlock::arm` for why the split matters and why this registration must come first.
 	#[cfg(target_os = "linux")]
-	if let Some(fence) = context.params.containment.as_ref() {
+	if let Some(fence) = context
+		.params
+		.containment
+		.as_ref()
+		.filter(|fence| fence.requires_landlock())
+	{
 		if let sys::landlock::Availability::Available(abi) = sys::landlock::availability() {
 			let plan = fence.compile_grant_plan(&crate::containment::RealFs);
 			// Only the roots the operator's policy names may be created if absent — never a path the

--- a/crates/brush-core-vendored/src/containment.rs
+++ b/crates/brush-core-vendored/src/containment.rs
@@ -185,6 +185,17 @@ pub fn canonicalize_for_fence(candidate: &Path) -> PathBuf {
 }
 
 impl ContainmentFence {
+	/// Whether this fence needs Linux Landlock rather than the in-process shell checks alone.
+	///
+	/// Landlock cannot express an exact directory-enumeration deny without also removing READ_DIR from
+	/// every ancestor. The production discovery-only fence therefore stays in-process on Linux: arming
+	/// Landlock for it broke `ls ~`, `ls /tmp`, `ls /`, PTYs, and setuid tools while buying no faithful
+	/// enforcement. Recursive and directional low-level policies still need the kernel backend.
+	#[must_use]
+	pub fn requires_landlock(&self) -> bool {
+		!self.deny.is_empty() || !self.allow_read_only.is_empty() || !self.allow_write_only.is_empty()
+	}
+
 	/// Whether `candidate` may be accessed for `access`.
 	///
 	/// Deepest match wins and a deny beats an allow at equal depth, matching the host policy's

--- a/crates/brush-core-vendored/src/containment.rs
+++ b/crates/brush-core-vendored/src/containment.rs
@@ -7,8 +7,10 @@
 //!
 //! It is deliberately permissive. Anything matched by no root is outside the fence and allowed, so
 //! `/usr`, `/tmp`, package caches, the network and process execution are untouched. Cross-tenant
-//! isolation removes accidental parent enumeration while preserving named operator access; explicit
-//! data-root and cross-session state denies remain recursive.
+//! isolation removes accidental parent enumeration while preserving named operator access. Recursive
+//! denies remain available for explicit policies, but the production session fence does not use one
+//! beneath an operator-writable parent: Landlock cannot subtract that child without preventing direct
+//! creation in its parent.
 //!
 //! The fence is per-invocation and absent by default: only the model's `bash` tool supplies one.
 //! Host-driven shell use — credential helpers, the interactive `xcsh shell`, snapshot sourcing —

--- a/crates/containment-check/landlock-e2e.sh
+++ b/crates/containment-check/landlock-e2e.sh
@@ -92,14 +92,22 @@ expect "truncate a file in the workspace" ok ": > own.txt && test ! -s own.txt"
 expect "pipeline with grep and sed" ok "printf 'a\\nb\\n' > p.txt && sed -n 2p p.txt | grep b"
 expect "tar roundtrip" ok "mkdir -p t && echo x > t/f && tar czf t.tgz t && rm -rf t && tar xzf t.tgz && cat t/f"
 
-printf '\n=== exact parent enumeration courtesy ===\n'
+printf '\n=== discovery-only courtesy stays out of Landlock ===\n'
 BASE_FENCE="$FENCE"
 FENCE=$(printf '{"allow":["%s"],"allowReadOnly":[],"allowWriteOnly":[],"deny":[],"denyEnumerate":["%s"]}' \
   "$WORKSPACE" "$HOME_DIR/GIT")
-expect "listing the protected parent" refused "ls $HOME_DIR/GIT > /dev/null"
+# Landlock cannot hide this one listing without also breaking every ancestor listing. Production keeps
+# this courtesy in the structured-tool/brush checks, so an external child retains normal operator rights
+# and, critically, does not inherit no_new_privs.
+expect "external listing keeps operator rights" ok "ls $HOME_DIR/GIT > /dev/null"
 expect "read a named sibling file" ok "cat $SIBLING/secret.txt > /dev/null && echo named-ok"
 expect "write a named sibling file" ok "printf named > $SIBLING/named.txt && test -f $SIBLING/named.txt"
 expect "list below a named sibling" ok "ls $SIBLING > /dev/null && echo child-ok"
+expect "operator home remains enumerable" ok "ls $HOME_DIR > /dev/null"
+expect "system temp remains enumerable" ok "ls /tmp > /dev/null"
+expect "filesystem root remains enumerable" ok "ls / > /dev/null"
+expect "discovery-only child keeps privilege capability" ok \
+  "grep -q 'NoNewPrivs:.*0' /proc/self/status"
 FENCE="$BASE_FENCE"
 
 printf '\n=== directional roots keep their direction ===\n'

--- a/crates/containment-check/tests/complement.rs
+++ b/crates/containment-check/tests/complement.rs
@@ -417,6 +417,28 @@ fn production_enumeration_isolation_preserves_direct_parent_creation() {
 	);
 }
 
+#[test]
+fn discovery_only_fences_do_not_require_landlock() {
+	let discovery_only = ContainmentFence {
+		allow: vec![PathBuf::from("/home/alice")],
+		deny_enumerate: vec![PathBuf::from("/home/alice/customers")],
+		..ContainmentFence::default()
+	};
+	assert!(!discovery_only.requires_landlock());
+
+	let recursive = ContainmentFence {
+		deny: vec![PathBuf::from("/home/alice/customers")],
+		..ContainmentFence::default()
+	};
+	assert!(recursive.requires_landlock());
+
+	let directional = ContainmentFence {
+		allow_read_only: vec![PathBuf::from("/shared")],
+		..ContainmentFence::default()
+	};
+	assert!(directional.requires_landlock());
+}
+
 /// Two lists naming the same path must resolve the way `permits_resolved` does:
 /// deny wins.
 #[test]

--- a/crates/containment-check/tests/complement.rs
+++ b/crates/containment-check/tests/complement.rs
@@ -382,6 +382,41 @@ fn an_exact_enumeration_deny_keeps_named_descendants_reachable() {
 	assert!(plan.permits(&sibling_dir, FenceAccess::Enumerate));
 }
 
+#[test]
+fn production_enumeration_isolation_preserves_direct_parent_creation() {
+	let fs = FakeFs::new(&[
+		"/tmp/existing",
+		"/tmp/xcsh-local/other-session/state.json",
+		"/tmp/xcsh-tasks/other-task/artifact",
+		"/home/alice/existing",
+		"/home/alice/.xcsh/agent/sessions/other.jsonl",
+	]);
+	let fence = ContainmentFence {
+		allow: vec![PathBuf::from("/home/alice")],
+		deny_enumerate: vec![
+			PathBuf::from("/tmp/xcsh-local"),
+			PathBuf::from("/tmp/xcsh-tasks"),
+			PathBuf::from("/home/alice/.xcsh/agent/sessions"),
+		],
+		..ContainmentFence::default()
+	};
+	let plan = fence.compile_grant_plan(&fs);
+
+	for direct_child in ["/tmp/terraform-provider-new", "/home/alice/new-config"] {
+		assert!(
+			plan.permits(Path::new(direct_child), FenceAccess::Write),
+			"{} must remain directly creatable",
+			direct_child
+		);
+	}
+	for private_root in ["/tmp/xcsh-local", "/tmp/xcsh-tasks", "/home/alice/.xcsh/agent/sessions"] {
+		assert!(!plan.permits(Path::new(private_root), FenceAccess::Enumerate));
+	}
+	assert!(
+		plan.permits(Path::new("/home/alice/.xcsh/agent/sessions/other.jsonl"), FenceAccess::Read)
+	);
+}
+
 /// Two lists naming the same path must resolve the way `permits_resolved` does:
 /// deny wins.
 #[test]

--- a/packages/coding-agent/src/cli/sandbox-check.ts
+++ b/packages/coding-agent/src/cli/sandbox-check.ts
@@ -168,7 +168,7 @@ function renderReport(report: SandboxCheckReport, json: boolean, verbose: boolea
 
 /** Run the conformance matrix and report only after every synthetic fixture has been removed. */
 export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promise<SandboxCheckReport> {
-	const backend = containmentStatus(true);
+	let backend = containmentStatus(true);
 	const checks: SandboxCheckResult[] = [];
 	const fixturePaths: string[] = [];
 	const knownCleanupLeaves: string[] = [];
@@ -265,6 +265,7 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 			leakRoots: [sessionStore, memoryStore],
 		});
 		const liveFence = buildContainmentFence({ workspace: liveWorkspace, home: liveHome });
+		backend = containmentStatus(true, process.platform, undefined, liveFence);
 
 		await check("structured tools share the boundary", () => {
 			const blocked = [
@@ -412,6 +413,55 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 			);
 		});
 
+		await check("system temp remains enumerable", async () => {
+			const result = await shellProbe(
+				`ls ${quote(liveSystemTmp)} > /dev/null`,
+				liveWorkspace,
+				inheritedProfile ? undefined : liveFence,
+				abortController.signal,
+			);
+			return shellOutcome(
+				result,
+				true,
+				"live profile must preserve normal system-temp enumeration",
+				"<system-temp>",
+				redactions,
+			);
+		});
+
+		await check("operator home remains enumerable", async () => {
+			const result = await shellProbe(
+				`ls ${quote(liveHome)} > /dev/null`,
+				liveWorkspace,
+				inheritedProfile ? undefined : liveFence,
+				abortController.signal,
+			);
+			return shellOutcome(
+				result,
+				true,
+				"live profile must preserve normal operator-home enumeration",
+				"<operator-home>",
+				redactions,
+			);
+		});
+
+		await check("filesystem root remains enumerable", async () => {
+			const filesystemRoot = path.parse(liveWorkspace).root;
+			const result = await shellProbe(
+				`ls ${quote(filesystemRoot)} > /dev/null`,
+				liveWorkspace,
+				inheritedProfile ? undefined : liveFence,
+				abortController.signal,
+			);
+			return shellOutcome(
+				result,
+				true,
+				"live profile must preserve normal filesystem-root enumeration",
+				"<filesystem-root>",
+				redactions,
+			);
+		});
+
 		await check("named sibling remains reachable", async () => {
 			const displayPath = "<session-parent>/<synthetic-sibling>";
 			let liveSibling = inheritedSibling;
@@ -440,8 +490,9 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 		});
 
 		if (backend.osEnforced) {
-			await check("session parent cannot be enumerated", async () => {
+			await check("session parent discovery respects operator home", async () => {
 				const probeParent = inheritedProfile ? liveSessionParent : workspaces;
+				const parentIsOperatorHome = probeParent === liveHome;
 				const result = await shellProbe(
 					`ls ${quote(probeParent)} > /dev/null`,
 					workspace,
@@ -450,8 +501,10 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 				);
 				return shellOutcome(
 					result,
-					false,
-					"synthetic session parent enumeration must be refused",
+					parentIsOperatorHome,
+					parentIsOperatorHome
+						? "operator home must remain enumerable when it is the session parent"
+						: "synthetic session parent enumeration must be refused",
 					"<synthetic-session-parent>",
 					redactions,
 				);
@@ -583,7 +636,7 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 			});
 		} else {
 			for (const name of [
-				"session parent cannot be enumerated",
+				"session parent discovery respects operator home",
 				"explicit grant restores parent enumeration",
 				"account container cannot be enumerated",
 				"named other account remains reachable",

--- a/packages/coding-agent/src/cli/sandbox-check.ts
+++ b/packages/coding-agent/src/cli/sandbox-check.ts
@@ -218,18 +218,20 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 		// session parent — which is the operator home for a `~/<workspace>` layout (#2807).
 		const liveWorkspace = inheritedWorkspace ?? (await fs.realpath(workspaceInput));
 		const liveHome = inheritedHome ?? (await fs.realpath(homeInput));
-		redactions.push([liveWorkspace, "<workspace>"], [liveHome, "<operator-home>"]);
+		const liveSystemTmp = await fs.realpath(os.tmpdir());
+		const liveSessionParent = path.dirname(liveWorkspace);
+		const liveAccountRoot = path.dirname(liveHome);
+		redactions.push(
+			[liveWorkspace, "<workspace>"],
+			[liveHome, "<operator-home>"],
+			[liveSystemTmp, "<system-temp>"],
+			[liveSessionParent, "<session-parent>"],
+			[liveAccountRoot, "<account-container>"],
+		);
 		if (inheritedSibling !== undefined) redactions.push([inheritedSibling, "<session-parent>/<synthetic-sibling>"]);
 
-		// A home-rooted Landlock profile must split the home grant around protected session stores. The
-		// kernel can grant an existing named child but cannot grant future children of that split root
-		// without also reopening the protected stores. BashTool therefore prepares one host-owned child
-		// before confinement; keep all exact-home live fixtures beneath that already-granted directory.
-		const liveWritableRoot =
-			inheritedProfile && liveWorkspace === liveHome && inheritedSibling !== undefined
-				? inheritedSibling
-				: liveWorkspace;
-		const fixtureBase = inheritedProfile ? liveWritableRoot : await fs.realpath(os.tmpdir());
+		const liveWritableRoot = liveWorkspace;
+		const fixtureBase = inheritedProfile ? liveWritableRoot : liveSystemTmp;
 		fixtureRoot = await fs.mkdtemp(path.join(fixtureBase, ".xcsh-sandbox-check-policy-"));
 		fixturePaths.push(fixtureRoot);
 		redactions.push([fixtureRoot, "<synthetic-root>"]);
@@ -262,23 +264,14 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 			fsRoot: fixtureRoot,
 			leakRoots: [sessionStore, memoryStore],
 		});
+		const liveFence = buildContainmentFence({ workspace: liveWorkspace, home: liveHome });
 
 		await check("structured tools share the boundary", () => {
 			const blocked = [
 				evaluateToolCall({ toolName: "read", input: { file_path: workspaces }, cwd: workspace, fence }),
 				evaluateToolCall({ toolName: "find", input: { pattern: `${accountRoot}/**/*` }, cwd: workspace, fence }),
-				evaluateToolCall({
-					toolName: "read",
-					input: { file_path: path.join(otherSession, "state.jsonl") },
-					cwd: workspace,
-					fence,
-				}),
-				evaluateToolCall({
-					toolName: "read",
-					input: { file_path: path.join(otherMemory, "MEMORY.md") },
-					cwd: workspace,
-					fence,
-				}),
+				evaluateToolCall({ toolName: "read", input: { file_path: sessionStore }, cwd: workspace, fence }),
+				evaluateToolCall({ toolName: "find", input: { pattern: `${memoryStore}/**/*` }, cwd: workspace, fence }),
 			];
 			const allowed = [
 				evaluateToolCall({
@@ -297,6 +290,18 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 				evaluateToolCall({
 					toolName: "write",
 					input: { file_path: path.join(configDir, "config") },
+					cwd: workspace,
+					fence,
+				}),
+				evaluateToolCall({
+					toolName: "read",
+					input: { file_path: path.join(otherSession, "state.jsonl") },
+					cwd: workspace,
+					fence,
+				}),
+				evaluateToolCall({
+					toolName: "read",
+					input: { file_path: path.join(otherMemory, "MEMORY.md") },
 					cwd: workspace,
 					fence,
 				}),
@@ -385,6 +390,28 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 			);
 		});
 
+		await check("system temp supports direct file creation", async () => {
+			const displayPath = "<system-temp>/<synthetic-fixture>";
+			const template = path.join(liveSystemTmp, ".xcsh-sandbox-check-tmp-XXXXXX");
+			const command =
+				`probe=$(mktemp ${quote(template)}) || exit $?; ` +
+				`trap 'rm -f "$probe"' EXIT; printf temporary > "$probe" && ` +
+				`test "$(cat "$probe")" = temporary && rm "$probe"`;
+			const result = await shellProbe(
+				command,
+				liveWorkspace,
+				inheritedProfile ? undefined : liveFence,
+				abortController.signal,
+			);
+			return shellOutcome(
+				result,
+				true,
+				"live profile must allow direct system-temp creation and removal",
+				displayPath,
+				redactions,
+			);
+		});
+
 		await check("named sibling remains reachable", async () => {
 			const displayPath = "<session-parent>/<synthetic-sibling>";
 			let liveSibling = inheritedSibling;
@@ -414,10 +441,11 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 
 		if (backend.osEnforced) {
 			await check("session parent cannot be enumerated", async () => {
+				const probeParent = inheritedProfile ? liveSessionParent : workspaces;
 				const result = await shellProbe(
-					`ls ${quote(workspaces)} > /dev/null`,
+					`ls ${quote(probeParent)} > /dev/null`,
 					workspace,
-					fence,
+					inheritedProfile ? undefined : fence,
 					abortController.signal,
 				);
 				return shellOutcome(
@@ -469,10 +497,11 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 				);
 			});
 			await check("account container cannot be enumerated", async () => {
+				const probeAccountRoot = inheritedProfile ? liveAccountRoot : accountRoot;
 				const result = await shellProbe(
-					`ls ${quote(accountRoot)} > /dev/null`,
+					`ls ${quote(probeAccountRoot)} > /dev/null`,
 					workspace,
-					fence,
+					inheritedProfile ? undefined : fence,
 					abortController.signal,
 				);
 				return shellOutcome(
@@ -493,33 +522,62 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 					redactions,
 				);
 			});
-			await check("cross-session stores cannot be read", async () => {
-				const sessionRead = await shellProbe(
-					`cat ${quote(path.join(otherSession, "state.jsonl"))} > /dev/null`,
+			await check("cross-session stores hide listings and keep named access", async () => {
+				let probeStore = sessionStore;
+				let knownPaths = [path.join(otherSession, "state.jsonl"), path.join(otherMemory, "MEMORY.md")];
+				let probeFence: ContainmentFence | undefined = fence;
+				if (inheritedProfile) {
+					const livePrivateContainer = path.join(liveSystemTmp, "xcsh-local");
+					try {
+						await fs.mkdir(livePrivateContainer, { recursive: true });
+						const livePrivateFixture = await fs.mkdtemp(
+							path.join(livePrivateContainer, ".xcsh-sandbox-check-private-"),
+						);
+						fixturePaths.push(livePrivateFixture);
+						redactions.push(
+							[livePrivateContainer, "<live-private-container>"],
+							[livePrivateFixture, "<live-private-container>/<synthetic-session>"],
+						);
+						const knownState = path.join(livePrivateFixture, "state.jsonl");
+						await Bun.write(knownState, "synthetic\n");
+						probeStore = livePrivateContainer;
+						knownPaths = [knownState];
+						probeFence = undefined;
+					} catch (error) {
+						return exceptionOutcome(
+							"create a known path in the live private temp container",
+							"<live-private-container>/<synthetic-session>",
+							error,
+							redactions,
+						);
+					}
+				}
+				const sessionListing = await shellProbe(
+					`ls ${quote(probeStore)} > /dev/null`,
 					workspace,
-					fence,
+					probeFence,
 					abortController.signal,
 				);
 				const sessionOutcome = shellOutcome(
-					sessionRead,
+					sessionListing,
 					false,
-					"synthetic other session read must be refused",
-					"<synthetic-session-store>/<synthetic-session>",
+					"synthetic session-store listing must be refused",
+					"<synthetic-session-store>",
 					redactions,
 				);
 				if (!sessionOutcome.passed) return sessionOutcome;
 
-				const memoryRead = await shellProbe(
-					`cat ${quote(path.join(otherMemory, "MEMORY.md"))} > /dev/null`,
+				const namedReads = await shellProbe(
+					`cat ${knownPaths.map(quote).join(" ")} > /dev/null`,
 					workspace,
-					fence,
+					probeFence,
 					abortController.signal,
 				);
 				return shellOutcome(
-					memoryRead,
-					false,
-					"synthetic other memory read must be refused",
-					"<synthetic-memory-store>/<synthetic-memory>",
+					namedReads,
+					true,
+					"known synthetic cross-session paths must keep operator access",
+					"<synthetic-session-store>/<known-path>",
 					redactions,
 				);
 			});
@@ -529,38 +587,29 @@ export async function runSandboxCheck(options: SandboxCheckOptions = {}): Promis
 				"explicit grant restores parent enumeration",
 				"account container cannot be enumerated",
 				"named other account remains reachable",
-				"cross-session stores cannot be read",
+				"cross-session stores hide listings and keep named access",
 			]) {
 				add(name, "SKIP", "OS enforcement backend unavailable; path=<probe>; errno=unsupported");
 			}
 		}
 
-		await check("operator home configuration is writable", async () => {
+		await check("operator home supports direct file creation", async () => {
 			const displayPath = "<operator-home>/<synthetic-fixture>";
-			let liveConfig: string;
-			try {
-				// Landlock cannot grant creation on a split directory without also granting every
-				// denied descendant. The live fence therefore grants operator-owned CLI config roots
-				// explicitly; use one of those when another Landlock profile is already inherited.
-				// Standalone and Seatbelt checks retain the direct-home probe.
-				const configBase =
-					inheritedProfile && backend.backend === "landlock" ? path.join(liveHome, ".config", "gh") : liveHome;
-				liveConfig = await fs.mkdtemp(path.join(configBase, ".xcsh-sandbox-check-home-"));
-				fixturePaths.push(liveConfig);
-				redactions.push([liveConfig, displayPath]);
-			} catch (error) {
-				return exceptionOutcome("create operator-home fixture", displayPath, error, redactions);
-			}
+			const template = path.join(liveHome, ".xcsh-sandbox-check-home-XXXXXX");
+			const command =
+				`probe=$(mktemp ${quote(template)}) || exit $?; ` +
+				`trap 'rm -f "$probe"' EXIT; printf operator > "$probe" && ` +
+				`test "$(cat "$probe")" = operator && rm "$probe"`;
 			const result = await shellProbe(
-				'printf operator > config && test "$(cat config)" = operator',
-				liveConfig,
-				undefined,
+				command,
+				liveWorkspace,
+				inheritedProfile ? undefined : liveFence,
 				abortController.signal,
 			);
 			return shellOutcome(
 				result,
 				true,
-				"live profile must allow operator-home configuration writes",
+				"live profile must allow direct operator-home creation and removal",
 				displayPath,
 				redactions,
 			);

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1810,22 +1810,19 @@ export const SETTINGS_SCHEMA = {
 		ui: { tab: "providers", label: "Hide Secrets", description: "Obfuscate secrets before sending to AI providers" },
 	},
 
-	// Session filesystem isolation. Confines the file tools (read/write/edit/find/grep)
-	// and the Bash working directory to the session's CWD subtree plus a curated global
-	// allowlist, so concurrent sessions in different customer folders cannot read or
-	// write each other's files, secrets, or memory. See src/sandbox/.
+	// Session filesystem isolation is a discovery courtesy, not a user-rights policy. It hides selected
+	// cross-session container listings while named paths retain the operator's normal access.
 	"sandbox.enabled": {
 		type: "boolean",
 		default: true,
 		ui: {
 			tab: "sandbox",
 			label: "Filesystem isolation",
-			description: "Confine file tools to the working directory subtree (blocks cross-session access)",
+			description: "Hide cross-session container listings without restricting named operator access",
 		},
 	},
-	// Extra roots (beyond the CWD subtree) the session may read/write. Config/CLI only —
-	// e.g. `--allow-path <dir>` maps into both. The hardcoded cross-session leak-denies
-	// (other sessions' memories/sessions and the shared tenant contexts) always win.
+	// Historical names retained for compatibility. Either list now restores discovery and leaves the
+	// operator's ordinary read/write rights unchanged; `--allow-path <dir>` maps into both.
 	"sandbox.allowRead": { type: "array", default: [] as string[] },
 	"sandbox.allowWrite": { type: "array", default: [] as string[] },
 

--- a/packages/coding-agent/src/extensibility/extensions/bundled/sandbox-guard.ts
+++ b/packages/coding-agent/src/extensibility/extensions/bundled/sandbox-guard.ts
@@ -6,15 +6,13 @@ import { resolveSessionFence } from "../../../sandbox/session-fence";
 /**
  * Session filesystem sandbox (bundled, default-on).
  *
- * Confines the model-invoked file tools (read/write/edit/find/grep) and the Bash
- * working directory to the session's CWD subtree plus a curated global allowlist, so
- * concurrent sessions in different customer folders cannot read or write each other's
- * files, secrets, or memory. Enforcement is a `tool_call` gate: the extension wrapper
+ * Removes casual cross-session discovery from model-invoked filesystem tools while preserving the
+ * operator's normal rights on every named path. Enforcement is a `tool_call` gate: the extension wrapper
  * blocks the tool when this returns `{ block: true }`, and fails safe (a thrown handler
  * also blocks).
  *
  * The boundary is derived from `ctx.cwd` (always the live session's directory) plus the
- * `sandbox.*` settings. Controlled by `sandbox.enabled` (default true); widened per run
+ * `sandbox.*` settings. Controlled by `sandbox.enabled` (default true); discovery is widened per run
  * with `--allow-path` / `--no-sandbox` or the `sandbox.allow*` settings.
  */
 export default function sandboxGuard(pi: ExtensionAPI): void {

--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -47,7 +47,15 @@ Three things behave differently under this backend, and none is a bug to work ar
 {{/if}}
 {{/if}}
 {{else}}
-On this platform there is **no OS-level backend**, so for `bash` the boundary is enforced only by
+{{#if containment.discoveryOnly}}
+This Linux session deliberately does **not** arm Landlock for its discovery-only profile. Landlock
+cannot hide one nested directory listing without also breaking ordinary ancestor listings such as
+`ls ~`, `ls /tmp`, and `ls /`; arming it also disables PTYs and setuid tools such as `sudo`. Those
+costs would turn a cross-context courtesy into a user-rights control.
+
+{{else}}
+This session is **not using an OS-level backend**, so for `bash` the boundary is enforced only by
+{{/if}}
 precise pre-checks for an explicit `cwd`, literal redirections, known write operands, and literal
 directory changes. Command and source text are never scanned for path-looking strings.
 

--- a/packages/coding-agent/src/prompts/internal-urls/containment.md
+++ b/packages/coding-agent/src/prompts/internal-urls/containment.md
@@ -16,9 +16,9 @@ followed symlinks — so how a path is spelled does not change what is reachable
 - Cross-tenant isolation removes the discovery step. The session container, local-account containers,
   data roots, and mounted-data containers cannot be enumerated, but a descendant path the operator
   names directly can still be read, written, or entered. An explicit read grant restores enumeration.
-- Xcsh-private cross-session stores remain denied recursively. Another session's transcripts, memories,
-  internal contexts, credentials, and temporary working state are not reachable unless the operator
-  explicitly grants the relevant root.
+- Xcsh-private cross-session stores follow the same discovery boundary: their container cannot be
+  enumerated, while a descendant path the operator names directly keeps the operator's normal rights.
+  This preserves `/tmp`, home, credentials, package managers, and ordinary tooling without workarounds.
 
 Structured filesystem tools and the `bash` runtime consult the same fence. Bash command text is not
 scanned for path-looking strings; the operating system decides when a process actually opens a path.
@@ -33,10 +33,10 @@ operator. The rule of thumb is that if a file belongs to someone other than the 
 working with, it is not yours to read.
 
 {{#if containment.landlock}}
-Three things behave differently under this backend, and none of them is a bug to work around:
+Three things behave differently under this backend, and none is a bug to work around:
 
-- `ls /` can fail because a kernel rule cannot expose a directory that mixes reachable and denied data
-  roots. Listing a specific reachable directory works normally.
+- `ls /` can fail because a kernel rule cannot expose a directory whose descendants have different
+  enumeration rights. Listing a specific reachable directory works normally.
 - `sudo` and other setuid programs do not work, because confining a process requires giving up the
   ability to gain privileges.
 - Interactive terminal programs (`top`, `less`, an interactive `ssh`) run without a real terminal here,

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -476,7 +476,10 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 	const parentExplicitlyReadable = [...extraResolved, ...readOnlyResolved].some(root =>
 		pathIsWithin(root, parentToProtect),
 	);
-	if (!tooBroadToDeny(parentToProtect, fsRoot) && !parentExplicitlyReadable) {
+	// Home itself is an operator workspace, not a customer-container boundary. Hiding its listing when a
+	// project is a direct child made ordinary shell navigation fail even on Seatbelt. Deeper project
+	// containers are still protected, but the operator always retains a normal `ls ~` experience.
+	if (parentToProtect !== home && !tooBroadToDeny(parentToProtect, fsRoot) && !parentExplicitlyReadable) {
 		denyEnumerate.add(parentToProtect);
 	}
 
@@ -605,6 +608,8 @@ export interface ContainmentStatus {
 	readonly backend: ContainmentBackend;
 	/** True when the kernel enforces it, false when only precise tool-call pre-checks run. */
 	readonly osEnforced: boolean;
+	/** Linux discovery-only profiles stay scanner-only so Landlock cannot remove ordinary ancestor listings. */
+	readonly discoveryOnly?: true;
 	/**
 	 * Set when the backend enforces reads and writes but cannot govern truncation.
 	 *
@@ -628,14 +633,34 @@ export interface ContainmentStatus {
  *
  * Deliberately not surfaced at startup or anywhere in the TUI — the operator asked for no UI change.
  */
+/**
+ * Whether Linux needs to arm Landlock for this fence.
+ *
+ * Exact enumeration denies are the production session courtesy, but Landlock cannot express one without
+ * also removing READ_DIR from every ancestor. Arming it made `ls ~`, `ls /tmp`, and `ls /` fail and also
+ * set `no_new_privs`, disabling sudo. Keep those checks in brush and the structured-tool gate. Recursive
+ * or directional low-level policies still require the kernel backend and retain their stricter contract.
+ */
+export function requiresLandlock(fence: ContainmentFence): boolean {
+	return fence.deny.length > 0 || fence.allowReadOnly.length > 0 || fence.allowWriteOnly.length > 0;
+}
+
 export function containmentStatus(
 	enabled: boolean,
 	platform: string = process.platform,
 	probe: () => { backend: string; truncateHandled?: boolean } | undefined = probeNativeBackend,
+	fence?: ContainmentFence,
 ): ContainmentStatus {
 	if (!enabled) return { enabled: false, backend: "disabled", osEnforced: false };
 	// macOS always has seatbelt, so there is nothing to ask.
 	if (platform === "darwin") return { enabled: true, backend: "seatbelt", osEnforced: true };
+	// Landlock is subtree-based. Applying it to an exact-listing-only courtesy removes normal access to
+	// ancestor listings and sets no_new_privs even though it cannot faithfully enforce the intended rule.
+	// Do not even probe in this common path: avoiding the syscall is part of keeping the sandbox off the
+	// command's latency path.
+	if (platform === "linux" && fence !== undefined && !requiresLandlock(fence)) {
+		return { enabled: true, backend: "scanner-only", osEnforced: false, discoveryOnly: true };
+	}
 	// Everywhere else the answer cannot be inferred from the platform name. Landlock can be compiled
 	// out of the kernel, left out of its boot-time LSM list, or too old to allow cross-directory
 	// rename — and none of that is visible from `process.platform`. Asking the native layer is the

--- a/packages/coding-agent/src/sandbox/containment.ts
+++ b/packages/coding-agent/src/sandbox/containment.ts
@@ -7,9 +7,8 @@
  * profile could not even `execvp /bin/cat`.
  *
  * So the fence is gentle. It leaves `/usr`, `/tmp`, package caches, the network and process execution
- * alone. Its cross-tenant courtesy removes discovery by enumerating session, account, and data
- * containers while keeping named operator access. Xcsh-private cross-session state remains denied
- * recursively unless the operator grants it explicitly (#2931).
+ * alone. Its cross-tenant courtesy removes discovery by enumerating session, account, data, and
+ * xcsh-private containers while keeping named operator access (#2931, #2952).
  *
  * Produced declaratively rather than as an ordered rule list, because the two backends disagree about
  * order: seatbelt evaluates rules in sequence with the last match winning, while Landlock only grants
@@ -375,12 +374,14 @@ function otherFilesystemRoots(fsRoot: string): string[] {
  *
  * `local://` content lands at `<tmp>/xcsh-local/<sessionId>` (`internal-urls/local-protocol.ts`) and a
  * task's artifacts at `<tmp>/xcsh-tasks/<id>` (`task/index.ts`) whenever no session artifacts dir is
- * configured. Those are the same class as `~/.xcsh/agent/sessions` — one session reading another's
- * working notes — so they belong in the leak roots rather than being covered incidentally.
+ * configured. Those are the same class as `~/.xcsh/agent/sessions` — another session's working notes —
+ * so their parent listings belong in the leak roots rather than being covered incidentally.
  *
  * Nothing else in the temp dir is touched: `xcsh://about` promises `/tmp` is reachable, and refusing it
- * wholesale is the false refusal #2582 removed. The session's OWN local root is granted back through
- * `extraRoots` at greater depth, so `local://` keeps working.
+ * wholesale is the false refusal #2582 removed. These roots lose enumeration only. A recursive deny
+ * beneath `/tmp` makes Landlock split that writable parent, which prevents ordinary programs from
+ * creating a direct child there (#2952). Named access therefore keeps the operator's normal rights,
+ * while the session's own local root remains discoverable through its known path.
  *
  * **Two fixed parents, deliberately never enumerated.** The first version listed the temp dir looking for
  * `xcsh-task-*` siblings, which cost 15ms of a 25-42ms fence build on a 17k-entry temp directory — per
@@ -532,25 +533,27 @@ export function buildContainmentFence(options: ContainmentOptions): ContainmentF
 		denyEnumerate.add(resolved);
 	}
 
-	// Cross-session leak roots. These may sit *under* an allowed root — the agent dir is inside home,
-	// and a session whose workspace is the agent dir would otherwise re-expose every other session's
-	// transcript. `fenceVerdict` resolves that by depth, so nesting is safe rather than accidental.
+	// Cross-session leak roots lose their exact directory listing, just like sibling workspace and
+	// account containers. Named descendants keep the operator's normal filesystem rights. This is
+	// deliberate rather than a weaker approximation: Landlock is allow-only, so recursively denying a
+	// child of `/tmp` or home prevents creating any new direct child in that parent (#2952). A professional
+	// tool must not require TMPDIR workarounds or a pre-created home subdirectory merely to run.
 	//
-	// Emitted even when absent: a rule that appears only once the directory does is one nobody can rely
-	// on, and creating it would otherwise be the way around it. This also covers relocated agent state.
+	// Emitted even when absent: a root created after the session starts must already have its listing
+	// protected. This also covers relocated agent state without enumerating home or the OS temp dir.
 	const leaks = options.leakRoots ?? [
 		getMemoriesDir(),
 		getSessionsDir(),
 		getXCSHContextsDir(),
 		...sharedTempLeakRoots(),
 	];
-	const explicitGrants = [...extraResolved, ...readOnlyResolved, ...writeOnlyResolved];
+	const explicitlyReadable = [...extraResolved, ...readOnlyResolved];
 	for (const leak of leaks) {
 		const resolved = canonicalThroughExisting(leak);
-		// A grant at or above a private root is an explicit operator override. Directional grants stay
-		// directional because their allowReadOnly/allowWriteOnly rule remains the deepest matching rule.
-		if (explicitGrants.some(root => pathIsWithin(root, resolved))) continue;
-		deny.add(resolved);
+		// A full or read grant at or above a private root explicitly restores its listing. A write-only
+		// grant does not imply permission to discover entries, so it leaves this exact protection intact.
+		if (explicitlyReadable.some(root => pathIsWithin(root, resolved))) continue;
+		denyEnumerate.add(resolved);
 	}
 
 	return {

--- a/packages/coding-agent/src/sandbox/session-fence.ts
+++ b/packages/coding-agent/src/sandbox/session-fence.ts
@@ -67,7 +67,7 @@ export interface SessionFenceExtras {
  * The session's fence for `workspace`, or undefined when sandboxing is off.
  *
  * Cached on the full effective configuration — the workspace plus the resolved enable flag, both
- * allow-lists and any extra roots — not on the workspace alone. Keying on the allow-lists is what lets
+ * discovery-grant lists and any extra roots — not on the workspace alone. Keying on the lists is what lets
  * a mid-session `settings.override("sandbox.allowRead", …)` take effect, as when the Office pane grants
  * a user-picked folder; a workspace-only key would keep serving the stale fence and block the path that
  * was just granted. The key only ever triggers more rebuilds, never fewer restrictions.
@@ -94,15 +94,15 @@ export function resolveSessionFence(
 	const cached = cache.get(signature);
 	if (cached) return cached;
 
-	// The three grants stay distinct. Merging allowRead and allowWrite into one read+write list made a
-	// folder shared for reading writable, undoing the split built for #2516. A root in *both* lists is
-	// the deliberate exception the fence itself handles, because that is what `--allow-path` produces.
+	// Session settings restore discovery; they do not reduce the operator's normal rights. The fence is a
+	// cross-context courtesy, not a read-only/write-only privilege boundary. Treat either historical
+	// allow-list as a full named-path grant so an old `sandbox.allowRead` entry cannot make a professional
+	// tool fail when it writes credentials, state, or build output there. The low-level fence keeps
+	// directional roots for specialized callers and tests, but ordinary xcsh sessions never emit them.
 	const fence = buildContainmentFence({
 		workspace,
 		sessionTmp: extras.sessionTmp,
-		extraRoots: extras.extraRoots,
-		readOnlyRoots: allowRead,
-		writeOnlyRoots: allowWrite,
+		extraRoots: [...(extras.extraRoots ?? []), ...allowRead, ...allowWrite],
 	});
 	if (cache.size >= CACHE_LIMIT) {
 		const oldest = cache.keys().next();

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1167,7 +1167,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				},
 				// Read live rather than captured, for the same reason as the model: `--no-sandbox` and
 				// `sandbox.enabled` are per-session, so the answer must reflect this session (#2554).
-				getContainment: () => containmentStatus(resolveSessionFence(process.cwd(), settings) !== undefined),
+				getContainment: () => {
+					const fence = resolveSessionFence(process.cwd(), settings);
+					return containmentStatus(fence !== undefined, process.platform, undefined, fence);
+				},
 				// Read live rather than captured: `session.model` is a read-through to agent state, so a
 				// mid-session Ctrl+P switch shows up on the next xcsh://about read (#2459).
 				getActiveModel: () =>

--- a/packages/coding-agent/src/tools/bash-skill-urls.ts
+++ b/packages/coding-agent/src/tools/bash-skill-urls.ts
@@ -172,10 +172,10 @@ function shellEscape(p: string): string {
 /**
  * Refuse a resolved path the session is not allowed to read.
  *
- * Without this the expander and the sandbox disagreed: bash was handed paths under `~/.xcsh` that
- * the same session's `read` tool refuses. The carve-out for session-owned roots is what keeps
- * `artifact://`, `agent://` and `local://` working, since the default policy deny-lists the whole
- * sessions directory and a session's own artifact root lives inside it.
+ * Without this the expander and the sandbox can disagree when an operator configures an explicit
+ * directional or recursive boundary. Session-owned roots are still carved out so `artifact://`,
+ * `agent://` and `local://` keep working under those opt-in policies. The default production fence
+ * preserves named operator access and therefore reaches this check only for enumeration attempts.
  */
 function enforceReadBoundary(scheme: SupportedInternalScheme, resolved: string, options: InternalUrlExpansionOptions) {
 	const boundary = options.readBoundary;

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -793,7 +793,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		// Only worth giving up when there is an OS backend for the non-PTY path to use and none for this
 		// one. Where no backend exists — Linux without Landlock, Windows — both paths are scanner-only,
 		// so disabling PTY would remove interactive terminals and improve containment by nothing.
-		const osBackend = containmentStatus(fence !== undefined);
+		const osBackend = containmentStatus(fence !== undefined, process.platform, undefined, fence);
 		const ptyConfinable = !osBackend.osEnforced || osBackend.backend === "seatbelt";
 		const usePty = pty && ptyConfinable && $env.PI_NO_PTY !== "1" && ctx?.hasUI === true && ctx.ui !== undefined;
 		let sandboxCheckSibling: string | undefined;

--- a/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
+++ b/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
@@ -561,7 +561,7 @@ describe("renderAboutDoc containment section", () => {
 		expect(doc).toContain("readable and writable");
 		expect(doc).toContain("session container, local-account containers");
 		expect(doc).toContain("descendant path the operator");
-		expect(doc).toContain("Xcsh-private cross-session stores remain denied recursively");
+		expect(doc).toContain("Xcsh-private cross-session stores follow the same discovery boundary");
 		// Ordinary work remains available and an operator can deliberately restore discovery.
 		expect(doc).toContain("An explicit read grant restores enumeration");
 	});

--- a/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
+++ b/packages/coding-agent/test/internal-urls/build-info-runtime.test.ts
@@ -572,11 +572,24 @@ describe("renderAboutDoc containment section", () => {
 			backend: "scanner-only",
 			osEnforced: false,
 		});
-		expect(doc).toContain("no OS-level backend");
+		expect(doc).toContain("not using an OS-level backend");
 		expect(doc).toContain("statement of intent rather than a guarantee");
 		expect(doc).toContain("Command and source text are never scanned");
 		// Must NOT claim the stronger guarantee it does not have.
 		expect(doc).not.toContain("how a path is spelled does not change what is reachable");
+	});
+
+	it("explains why a Linux discovery-only session preserves operator capabilities", () => {
+		const doc = renderAboutDoc(fakeBuildInfo(), null, null, {
+			enabled: true,
+			backend: "scanner-only",
+			osEnforced: false,
+			discoveryOnly: true,
+		});
+		expect(doc).toContain("does **not** arm Landlock");
+		expect(doc).toContain("`ls ~`, `ls /tmp`, and `ls /`");
+		expect(doc).toContain("PTYs and setuid tools such as `sudo`");
+		expect(doc).toContain("user-rights control");
 	});
 
 	/**

--- a/packages/coding-agent/test/sandbox-check.test.ts
+++ b/packages/coding-agent/test/sandbox-check.test.ts
@@ -84,14 +84,16 @@ function assertHealthyReport(report: SandboxCheckReport): void {
 	expect(["seatbelt", "landlock", "scanner-only"]).toContain(report.backend);
 	expect(report.summary.failed).toBe(0);
 	expect(report.summary.errors).toBe(0);
-	expect(report.checks).toHaveLength(13);
+	expect(report.checks).toHaveLength(14);
 	expect(report.checks).toContainEqual({ name: "structured tools share the boundary", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "Bash grep pattern remains data (#2931)", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "Bash Python heredoc remains data (#2931)", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "cwd resets across tool calls", status: "PASS" });
+	expect(report.checks).toContainEqual({ name: "system temp supports direct file creation", status: "PASS" });
+	expect(report.checks).toContainEqual({ name: "operator home supports direct file creation", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "synthetic fixtures removed", status: "PASS" });
 	if (report.osEnforced) {
-		expect(report.summary).toEqual({ passed: 13, failed: 0, errors: 0, skipped: 0 });
+		expect(report.summary).toEqual({ passed: 14, failed: 0, errors: 0, skipped: 0 });
 		expect(report.checks).toContainEqual({ name: "account container cannot be enumerated", status: "PASS" });
 		expect(report.checks).toContainEqual({ name: "named other account remains reachable", status: "PASS" });
 		expect(report.checks).toContainEqual({ name: "explicit grant restores parent enumeration", status: "PASS" });
@@ -295,11 +297,11 @@ it("reports generalized assertion, path, and errno details for a failed probe", 
 	try {
 		const jsonResult = await runSandboxCheckProcess(["--json"], env);
 		const report = JSON.parse(jsonResult.stdout.toString()) as SandboxCheckReport;
-		const failure = report.checks.find(check => check.name === "operator home configuration is writable");
+		const failure = report.checks.find(check => check.name === "operator home supports direct file creation");
 
 		expect(jsonResult.exitCode).toBe(1);
 		expect(failure?.status).toBe("FAIL");
-		expect(failure?.detail).toContain("create operator-home fixture");
+		expect(failure?.detail).toContain("direct operator-home creation");
 		expect(failure?.detail).toContain("path=<operator-home>/<synthetic-fixture>");
 		expect(failure?.detail).toContain("errno=ENOTDIR");
 		expect(failure?.detail).not.toContain(invalidHome);

--- a/packages/coding-agent/test/sandbox-check.test.ts
+++ b/packages/coding-agent/test/sandbox-check.test.ts
@@ -84,16 +84,19 @@ function assertHealthyReport(report: SandboxCheckReport): void {
 	expect(["seatbelt", "landlock", "scanner-only"]).toContain(report.backend);
 	expect(report.summary.failed).toBe(0);
 	expect(report.summary.errors).toBe(0);
-	expect(report.checks).toHaveLength(14);
+	expect(report.checks).toHaveLength(17);
 	expect(report.checks).toContainEqual({ name: "structured tools share the boundary", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "Bash grep pattern remains data (#2931)", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "Bash Python heredoc remains data (#2931)", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "cwd resets across tool calls", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "system temp supports direct file creation", status: "PASS" });
+	expect(report.checks).toContainEqual({ name: "system temp remains enumerable", status: "PASS" });
+	expect(report.checks).toContainEqual({ name: "operator home remains enumerable", status: "PASS" });
+	expect(report.checks).toContainEqual({ name: "filesystem root remains enumerable", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "operator home supports direct file creation", status: "PASS" });
 	expect(report.checks).toContainEqual({ name: "synthetic fixtures removed", status: "PASS" });
 	if (report.osEnforced) {
-		expect(report.summary).toEqual({ passed: 14, failed: 0, errors: 0, skipped: 0 });
+		expect(report.summary).toEqual({ passed: 17, failed: 0, errors: 0, skipped: 0 });
 		expect(report.checks).toContainEqual({ name: "account container cannot be enumerated", status: "PASS" });
 		expect(report.checks).toContainEqual({ name: "named other account remains reachable", status: "PASS" });
 		expect(report.checks).toContainEqual({ name: "explicit grant restores parent enumeration", status: "PASS" });
@@ -209,7 +212,8 @@ it("reports a healthy matrix for a live session rooted directly inside operator 
 		const bash = new BashTool(createSession(workspace));
 
 		// The context variables are host-owned; model-supplied replacements must not move the probes.
-		assertHealthyReport(await runInsideLiveProfile(workspace, true));
+		const liveReport = await runInsideLiveProfile(workspace, true);
+		assertHealthyReport(liveReport);
 
 		await bash.execute("sandbox-check-workspace-capability", {
 			command: "printf own > own.txt && printf '%s\\n' ./* > /dev/null && find . -type f > /dev/null",
@@ -236,7 +240,7 @@ it("reports a healthy matrix for a live session rooted directly inside operator 
 		} catch {
 			parentEnumerationDenied = true;
 		}
-		expect(parentEnumerationDenied).toBe(true);
+		expect(parentEnumerationDenied).toBe(false);
 	} finally {
 		_resetShellSessionsForTest();
 		expect(liveSiblingCount()).toBe(liveSiblingCountBefore);

--- a/packages/coding-agent/test/sandbox-containment-conformance.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-conformance.test.ts
@@ -62,7 +62,7 @@ describe("containment fence: TypeScript and Rust agree", () => {
 		path.join(home, ".bun", "install", "cache", "pkg"),
 		path.join(home, ".cargo", "registry", "x"), // absent on purpose
 		path.join(home, ".gitconfig"),
-		// nested deny under an allowed root
+		// nested discovery boundary under an allowed root
 		path.join(leak, "other-session.jsonl"),
 		// explicit grant
 		path.join(shared, "handoff.md"),
@@ -89,14 +89,14 @@ describe("containment fence: TypeScript and Rust agree", () => {
 	// Both must resolve the symlink, or the pre-check and the enforcement disagree about the one
 	// case an attacker would reach for.
 	it("agrees when the path arrives through a symlink", () => {
-		// Points at the cross-session leak root. Named sibling paths are deliberately reachable now; the
-		// courtesy prevents discovering them by enumerating the shared parent.
+		// Points at the cross-session leak root. Known paths remain deliberately reachable; the courtesy
+		// prevents discovering them by enumerating the private container.
 		const pivot = path.join(workspace, "pivot");
 		fs.symlinkSync(leak, pivot);
 		const viaLink = path.join(pivot, "secrets.tf");
 
-		expect(fenceVerdict(fence, viaLink, "read")).toBe("deny");
-		expect(fencePermits(wire, viaLink, false, false)).toBe(false);
+		expect(fenceVerdict(fence, viaLink, "read")).toBe("allow");
+		expect(fencePermits(wire, viaLink, false, false)).toBe(true);
 	});
 
 	it("agrees that only the shared parent loses enumeration", () => {

--- a/packages/coding-agent/test/sandbox-containment-pty.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-pty.int.test.ts
@@ -54,12 +54,14 @@ describe("containment covers the PTY path, not just the in-process shell", () =>
 		fs.mkdirSync(workspace, { recursive: true });
 		fs.mkdirSync(sibling, { recursive: true });
 		fs.writeFileSync(path.join(sibling, "secret.txt"), "PTY-CANARY-7734\n");
-		const fence = buildContainmentFence({ workspace, home, leakRoots: [sibling] });
+		// PTY confinement still needs an explicit recursive-deny fixture even though the production
+		// session policy preserves named access outside hidden container listings.
+		const fence = buildContainmentFence({ workspace, home });
 		wire = {
 			allow: [...fence.allow],
 			allowReadOnly: [...fence.allowReadOnly],
 			allowWriteOnly: [...fence.allowWriteOnly],
-			deny: [...fence.deny],
+			deny: [...fence.deny, sibling],
 			denyEnumerate: [...fence.denyEnumerate],
 		};
 	});

--- a/packages/coding-agent/test/sandbox-containment-race.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-race.int.test.ts
@@ -82,14 +82,14 @@ describe("containment holds while the path is being swapped underneath it", () =
 			].join("\n"),
 		);
 
-		// The race contract still needs a recursively denied target. Production sibling paths are named
-		// access now, so classify this synthetic target as a cross-session leak root for the test.
-		const fence = buildContainmentFence({ workspace, home, leakRoots: [sibling] });
+		// The race contract still needs a recursively denied target. Production sibling and private-store
+		// paths preserve named access now, so append a synthetic deny to the wire contract explicitly.
+		const fence = buildContainmentFence({ workspace, home });
 		wire = {
 			allow: [...fence.allow],
 			allowReadOnly: [...fence.allowReadOnly],
 			allowWriteOnly: [...fence.allowWriteOnly],
-			deny: [...fence.deny],
+			deny: [...fence.deny, sibling],
 			denyEnumerate: [...fence.denyEnumerate],
 		};
 	});

--- a/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
+++ b/packages/coding-agent/test/sandbox-containment-shell.int.test.ts
@@ -46,12 +46,12 @@ describe("containment enforced inside the shell", () => {
 		fs.writeFileSync(path.join(sibling, "secret.txt"), "CUSTB-CANARY-9001\n");
 		// Keep a recursive deny in this suite so it continues exercising read/write enforcement. The
 		// production sibling policy is enumeration-only and is covered in the glob and isolation suites.
-		const fence = buildContainmentFence({ workspace, home, leakRoots: [sibling] });
+		const fence = buildContainmentFence({ workspace, home });
 		wire = {
 			allow: [...fence.allow],
 			allowReadOnly: [...fence.allowReadOnly],
 			allowWriteOnly: [...fence.allowWriteOnly],
-			deny: [...fence.deny],
+			deny: [...fence.deny, sibling],
 			denyEnumerate: [...fence.denyEnumerate],
 		};
 	});
@@ -189,12 +189,12 @@ describe("containment enforced inside the shell", () => {
 	it("survives a workspace path containing shell-hostile characters", async () => {
 		const odd = path.join(workspace, 'we"ird\nname');
 		fs.mkdirSync(odd, { recursive: true });
-		const oddFence = buildContainmentFence({ workspace: odd, home, leakRoots: [sibling] });
+		const oddFence = buildContainmentFence({ workspace: odd, home });
 		const oddWire = {
 			allow: [...oddFence.allow],
 			allowReadOnly: [...oddFence.allowReadOnly],
 			allowWriteOnly: [...oddFence.allowWriteOnly],
-			deny: [...oddFence.deny],
+			deny: [...oddFence.deny, sibling],
 			denyEnumerate: [...oddFence.denyEnumerate],
 		};
 		let out = "";

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -345,12 +345,7 @@ describe("buildContainmentFence — the operator's home is theirs (#2637)", () =
 		expect(fenceVerdict(fence, path.join(home, "git", "STYLE_GUIDE.md"), "read")).toBe("allow");
 	});
 
-	/**
-	 * A session whose folder is a direct child of home protects the home listing, not home contents.
-	 *
-	 * The sibling remains reachable by name because the operator's home is theirs. What the session cannot
-	 * do accidentally is list home and discover which sibling names exist.
-	 */
+	/** A session whose folder is a direct child of home must not change normal home navigation. */
 	it("does not fence home when the session folder sits directly in it", () => {
 		const home = realTmp("inhome");
 		const workspace = path.join(home, "custA");
@@ -363,7 +358,7 @@ describe("buildContainmentFence — the operator's home is theirs (#2637)", () =
 		const fence = buildContainmentFence({ workspace, home, leakRoots: [sessions] });
 
 		expect(fence.deny).not.toContain(home);
-		expect(fenceVerdict(fence, home, "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, home, "enumerate")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(sibling, "notes.md"), "read")).toBe("allow");
 		// Xcsh-private state follows the same operator-rights rule: its listing is hidden, while a path
 		// the operator names directly remains available.
@@ -795,6 +790,27 @@ describe("containmentStatus", () => {
 			backend: "landlock",
 			osEnforced: true,
 		});
+	});
+
+	it("does not arm Landlock for a discovery-only fence that would remove ancestor listings", () => {
+		const home = realTmp("status-discovery-home");
+		const workspace = path.join(home, "workspaces", "customer-a");
+		fs.mkdirSync(workspace, { recursive: true });
+		const fence = buildContainmentFence({ workspace, home });
+		let probed = false;
+
+		expect(
+			containmentStatus(
+				true,
+				"linux",
+				() => {
+					probed = true;
+					return landlock();
+				},
+				fence,
+			),
+		).toEqual({ enabled: true, backend: "scanner-only", osEnforced: false, discoveryOnly: true });
+		expect(probed).toBe(false);
 	});
 
 	// The case that must not over-claim: a Linux box where Landlock is absent or too old.

--- a/packages/coding-agent/test/sandbox-containment.test.ts
+++ b/packages/coding-agent/test/sandbox-containment.test.ts
@@ -142,18 +142,36 @@ describe("buildContainmentFence", () => {
 		}
 	});
 
-	it("denies the cross-session leak roots even nested under an allowed root", () => {
+	it("hides cross-session root listings even when nested under an allowed root", () => {
 		const home = realTmp("home6");
 		// The pathological case: the workspace IS the agent dir's parent, so the leak roots sit
-		// inside something the fence allows. Deny must win regardless of nesting depth.
+		// inside something the fence allows. The exact enumeration deny must still win.
 		const workspace = path.join(home, ".xcsh");
 		const sessions = path.join(workspace, "agent", "sessions");
 		fs.mkdirSync(sessions, { recursive: true });
 		const fence = buildContainmentFence({ workspace, home, leakRoots: [sessions] });
 
 		expect(fenceVerdict(fence, path.join(workspace, "config.yml"), "read")).toBe("allow");
-		expect(fenceVerdict(fence, path.join(sessions, "other.jsonl"), "read")).toBe("deny");
-		expect(fenceVerdict(fence, path.join(sessions, "other.jsonl"), "write")).toBe("deny");
+		expect(fenceVerdict(fence, sessions, "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(sessions, "other.jsonl"), "read")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(sessions, "other.jsonl"), "write")).toBe("allow");
+	});
+
+	it("isolates cross-session roots without splitting their writable parent", () => {
+		const home = realTmp("operator-rights");
+		const workspace = path.join(home, "work");
+		const sessions = path.join(home, ".xcsh", "agent", "sessions");
+		fs.mkdirSync(workspace, { recursive: true });
+		fs.mkdirSync(sessions, { recursive: true });
+
+		const fence = buildContainmentFence({ workspace, home, leakRoots: [sessions] });
+
+		expect(fence.deny).not.toContain(sessions);
+		expect(fence.denyEnumerate).toContain(sessions);
+		expect(fenceVerdict(fence, sessions, "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(sessions, "known-session.jsonl"), "read")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(home, "created-directly"), "write")).toBe("allow");
+		expect(fenceVerdict(fence, path.join(fs.realpathSync(os.tmpdir()), "created-directly"), "write")).toBe("allow");
 	});
 
 	it("lets explicit grants override private roots without widening their direction", () => {
@@ -175,13 +193,17 @@ describe("buildContainmentFence", () => {
 			writeOnlyRoots: [privateParent],
 		});
 
-		expect(fenceVerdict(defaultFence, candidate, "read")).toBe("deny");
+		expect(fenceVerdict(defaultFence, sessions, "enumerate")).toBe("deny");
+		expect(fenceVerdict(defaultFence, candidate, "read")).toBe("allow");
+		expect(fenceVerdict(defaultFence, candidate, "write")).toBe("allow");
 		expect(fenceVerdict(full, candidate, "read")).toBe("allow");
 		expect(fenceVerdict(full, candidate, "write")).toBe("allow");
+		expect(fenceVerdict(full, sessions, "enumerate")).toBe("allow");
 		expect(fenceVerdict(readOnly, candidate, "read")).toBe("allow");
 		expect(fenceVerdict(readOnly, candidate, "write")).toBe("deny");
 		expect(fenceVerdict(writeOnly, candidate, "read")).toBe("deny");
 		expect(fenceVerdict(writeOnly, candidate, "write")).toBe("allow");
+		expect(fenceVerdict(writeOnly, sessions, "enumerate")).toBe("deny");
 	});
 
 	it("grants extra roots from --allow-path for both directions", () => {
@@ -343,9 +365,10 @@ describe("buildContainmentFence — the operator's home is theirs (#2637)", () =
 		expect(fence.deny).not.toContain(home);
 		expect(fenceVerdict(fence, home, "enumerate")).toBe("deny");
 		expect(fenceVerdict(fence, path.join(sibling, "notes.md"), "read")).toBe("allow");
-		// The cross-SESSION surfaces are still closed, because those are the agent's own state rather
-		// than the operator's layout.
-		expect(fenceVerdict(fence, path.join(sessions, "x.jsonl"), "read")).toBe("deny");
+		// Xcsh-private state follows the same operator-rights rule: its listing is hidden, while a path
+		// the operator names directly remains available.
+		expect(fenceVerdict(fence, sessions, "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(sessions, "x.jsonl"), "read")).toBe("allow");
 	});
 });
 
@@ -353,8 +376,8 @@ describe("buildContainmentFence — adversarial review of #2624", () => {
 	// The shared temp root holds per-session state: `local://` content at `<tmp>/xcsh-local/<sessionId>`
 	// (local-protocol.ts:118) and task artifacts at `<tmp>/xcsh-tasks/<id>` (task/index.ts). Both are
 	// exactly the cross-session channel the leak roots exist to close, and classifying `tmp` as
-	// operational made every session's copy readable and writable by every other session.
-	it("denies other sessions' local roots under the shared temp dir", () => {
+	// operational made every session's copy discoverable by every other session.
+	it("hides other sessions' local roots without splitting the shared temp dir", () => {
 		const home = realTmp("leaktmp");
 		const workspace = path.join(home, "w");
 		fs.mkdirSync(workspace, { recursive: true });
@@ -363,10 +386,11 @@ describe("buildContainmentFence — adversarial review of #2624", () => {
 		const fence = buildContainmentFence({ workspace, home });
 
 		const otherLocal = path.join(sharedTmp, "xcsh-local", "other-session", "handoff.json");
-		expect(fenceVerdict(fence, otherLocal, "read")).toBe("deny");
-		expect(fenceVerdict(fence, otherLocal, "write")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(sharedTmp, "xcsh-local"), "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, otherLocal, "read")).toBe("allow");
+		expect(fenceVerdict(fence, otherLocal, "write")).toBe("allow");
 		// Ordinary scratch beside it stays reachable — `xcsh://about` promises `/tmp`, and the refusal of
-		// it was one of the false refusals #2582 removed. Only the agent's own per-session trees are shut.
+		// it was one of the false refusals #2582 removed. Only the private-container listings are shut.
 		expect(fenceVerdict(fence, path.join(sharedTmp, "scratch.txt"), "write")).toBe("allow");
 	});
 
@@ -407,9 +431,8 @@ describe("buildContainmentFence — adversarial review of #2624", () => {
 		expect(scanned).toEqual([home]);
 	});
 
-	// …and the session's own local root must stay reachable, or `local://` breaks for everyone. Granted
-	// through `extraRoots`, at greater depth than the deny.
-	it("keeps the session's own local root reachable inside that deny", () => {
+	// …and the session's own known local root must stay reachable, or `local://` breaks for everyone.
+	it("keeps the session's own local root reachable inside the hidden container", () => {
 		const home = realTmp("ownlocal");
 		const workspace = path.join(home, "w");
 		fs.mkdirSync(workspace, { recursive: true });
@@ -420,9 +443,11 @@ describe("buildContainmentFence — adversarial review of #2624", () => {
 
 		expect(fenceVerdict(fence, path.join(mine, "handoff.json"), "read")).toBe("allow");
 		expect(fenceVerdict(fence, path.join(mine, "handoff.json"), "write")).toBe("allow");
-		// A different session's, under the same parent, is still refused.
+		// A different session is not discoverable by listing the shared parent, but a path the operator
+		// already knows keeps ordinary named access.
 		const theirs = path.join(fs.realpathSync(os.tmpdir()), "xcsh-local", "their-session", "x");
-		expect(fenceVerdict(fence, theirs, "read")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(fs.realpathSync(os.tmpdir()), "xcsh-local"), "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, theirs, "read")).toBe("allow");
 	});
 
 	// `sandbox.allowRead: ["~/shared"]` was passed straight to `realpathSync`, which does not expand `~`,
@@ -713,8 +738,9 @@ describe("buildContainmentFence — review findings", () => {
 		expect(fenceVerdict(fence, path.join(home, "GIT"), "enumerate")).toBe("deny");
 		expect(fenceVerdict(fence, path.join(home, "GIT/custB/secrets.tf"), "read")).toBe("allow");
 		const otherSession = path.join(home, ".xcsh/agent/sessions/other.jsonl");
-		expect(fenceVerdict(fence, otherSession, "read")).toBe("deny");
-		expect(fenceVerdict(fence, otherSession, "write")).toBe("deny");
+		expect(fenceVerdict(fence, sessions, "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, otherSession, "read")).toBe("allow");
+		expect(fenceVerdict(fence, otherSession, "write")).toBe("allow");
 		// The operator's own private files are not withheld from them. Asserted rather than left implicit,
 		// so anyone auditing what this fence protects sees the choice.
 		for (const own of [".ssh/id_ed25519", ".gnupg/secring.gpg", "Documents/contract.pdf"]) {
@@ -1053,12 +1079,12 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 		}
 	});
 
-	// A leak root inside the granted plugins tree must still win, and it must win while ABSENT — the
+	// A leak root inside the granted plugins tree must still hide its listing while ABSENT — the
 	// case that used to fall through, because `canonical` drops a path that does not exist yet and the
 	// home deny was quietly covering for it. Passed explicitly rather than read from the environment:
 	// the ambient dirs depend on whether an earlier test relocated the agent dir, which is not a
 	// property this test is about.
-	it("denies a cross-session leak root nested inside a grant, even before it exists", () => {
+	it("hides a cross-session leak root nested inside a grant, even before it exists", () => {
 		const home = realTmp("leaknest");
 		const workspace = path.join(home, "w");
 		const plugins = path.join(home, ".xcsh", "plugins");
@@ -1069,7 +1095,9 @@ describe("buildContainmentFence — data roots outside the workspace", () => {
 
 		const fence = buildContainmentFence({ workspace, home, leakRoots: [leak] });
 
-		expect(fence.deny).toContain(leak);
-		expect(fenceVerdict(fence, path.join(leak, "other-session.json"), "read")).toBe("deny");
+		expect(fence.deny).not.toContain(leak);
+		expect(fence.denyEnumerate).toContain(leak);
+		expect(fenceVerdict(fence, leak, "enumerate")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(leak, "other-session.json"), "read")).toBe("allow");
 	});
 });

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -80,16 +80,18 @@ describe("evaluateToolCall", () => {
 	});
 
 	it("blocks parent enumeration without blocking a named sibling file", () => {
-		const parent = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "xcsh-enumerate-")));
+		const home = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "xcsh-enumerate-")));
+		const parent = path.join(home, "customers");
 		const workspace = path.join(parent, "example-a");
 		const sibling = path.join(parent, "example-b");
+		fs.mkdirSync(parent);
 		fs.mkdirSync(workspace);
 		fs.mkdirSync(sibling);
 		fs.symlinkSync("..", path.join(workspace, "parent-link"));
 		const namedFile = path.join(sibling, "context.md");
 		fs.writeFileSync(namedFile, "context");
 		try {
-			const fence = buildContainmentFence({ workspace, home: parent });
+			const fence = buildContainmentFence({ workspace, home });
 			const evaluate = (toolName: string, input: Record<string, unknown>) =>
 				evaluateToolCall({ toolName, input, cwd: workspace, fence });
 
@@ -99,7 +101,7 @@ describe("evaluateToolCall", () => {
 			expect(evaluate("grep", { pattern: "context", path: parent }).block).toBe(true);
 			expect(evaluate("ast_edit", { path: parent }).block).toBe(true);
 		} finally {
-			fs.rmSync(parent, { recursive: true, force: true });
+			fs.rmSync(home, { recursive: true, force: true });
 		}
 	});
 

--- a/packages/coding-agent/test/sandbox-fence-anchor.int.test.ts
+++ b/packages/coding-agent/test/sandbox-fence-anchor.int.test.ts
@@ -125,9 +125,9 @@ describe("the containment boundary cannot be relocated by the model", () => {
 	});
 
 	it("keeps the original parent non-enumerable after a cd out of the tree", async () => {
-		// Control: the parent cannot be scanned before relocation. Both children exist, so an ordinary
-		// listing would necessarily disclose these synthetic workspace names.
-		const before = await run(`ls ${work}`);
+		// Brush expands the glob in-process, where the exact enumeration fence applies on every platform.
+		// External Linux commands deliberately keep the operator's ordinary listing rights (#2952).
+		const before = await run(`printf '%s\\n' ${work}/*`);
 		expect(before).not.toContain("custA");
 		expect(before).not.toContain("custB");
 
@@ -136,7 +136,7 @@ describe("the containment boundary cannot be relocated by the model", () => {
 		await run("c=cd; $c /usr");
 
 		// The actual property: the boundary did not travel with the shell.
-		const after = await run(`ls ${work}`);
+		const after = await run(`printf '%s\\n' ${work}/*`);
 		expect(after).not.toContain("custA");
 		expect(after).not.toContain("custB");
 	}, 120_000);

--- a/packages/coding-agent/test/sandbox-fence-anchor.int.test.ts
+++ b/packages/coding-agent/test/sandbox-fence-anchor.int.test.ts
@@ -95,8 +95,8 @@ describe("the containment boundary cannot be relocated by the model", () => {
 
 		const fence = resolveSessionFence(session.cwd, session.settings)!;
 		const diagnostic = evaluateToolCall({
-			toolName: "write",
-			input: { file_path: path.join(getSessionsDir(), "diagnostic.txt") },
+			toolName: "read",
+			input: { file_path: getSessionsDir() },
 			cwd: session.cwd,
 			fence,
 		});

--- a/packages/coding-agent/test/sandbox-fence-anchor.int.test.ts
+++ b/packages/coding-agent/test/sandbox-fence-anchor.int.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getSessionsDir, getShellPwd, setShellPwd } from "@f5-sales-demo/pi-utils";
+import { getShellPwd, setShellPwd } from "@f5-sales-demo/pi-utils";
 import { Settings } from "../src/config/settings";
 import { _resetShellSessionsForTest } from "../src/exec/bash-executor";
 import { evaluateToolCall } from "../src/sandbox/enforce";
@@ -96,7 +96,7 @@ describe("the containment boundary cannot be relocated by the model", () => {
 		const fence = resolveSessionFence(session.cwd, session.settings)!;
 		const diagnostic = evaluateToolCall({
 			toolName: "read",
-			input: { file_path: getSessionsDir() },
+			input: { file_path: work },
 			cwd: session.cwd,
 			fence,
 		});

--- a/packages/coding-agent/test/sandbox-guard.test.ts
+++ b/packages/coding-agent/test/sandbox-guard.test.ts
@@ -134,18 +134,19 @@ describe("sandbox-guard bundled extension", () => {
 			expect(await call(handler, "write", { file_path: path.join(OTHER, "planted") })).toBeUndefined();
 		});
 
-		// The extension checks structured paths. Arbitrary source text stays data and the OS runtime fence
-		// enforces its recursive cross-session deny without reintroducing source-scanning false positives.
-		it("refuses structured cross-session paths without scanning Bash or Python source", async () => {
+		// The extension checks structured enumeration while arbitrary source text and named paths retain
+		// operator access. This keeps every interface on the same discovery-only boundary.
+		it("hides cross-session listings without scanning source or blocking named paths", async () => {
 			await initSandbox(true);
 			const handler = captureHandler()!;
 			const secret = path.join(getSessionsDir(), "other-session.jsonl");
 			expect(await call(handler, "bash", { command: `cat ${secret}` })).toBeUndefined();
 			expect(await call(handler, "python", { code: `open("${secret}").read()` })).toBeUndefined();
-			expect(await call(handler, "read", { file_path: secret })).toMatchObject({ block: true });
+			expect(await call(handler, "read", { file_path: getSessionsDir() })).toMatchObject({ block: true });
+			expect(await call(handler, "read", { file_path: secret })).toBeUndefined();
 			expect(
 				await call(handler, "write", { file_path: path.join(getSessionsDir(), "planted.jsonl") }),
-			).toMatchObject({ block: true });
+			).toBeUndefined();
 		});
 	});
 });

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -3,7 +3,14 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { executeShell } from "@f5-sales-demo/pi-natives";
-import { getAgentDir, getConfigRootDir, getMemoriesDir, getPluginsDir, TempDir } from "@f5-sales-demo/pi-utils";
+import {
+	getAgentDir,
+	getConfigRootDir,
+	getMemoriesDir,
+	getPluginsDir,
+	setAgentDir,
+	TempDir,
+} from "@f5-sales-demo/pi-utils";
 import { discoverAndLoadExtensions } from "../src/extensibility/extensions/loader";
 import { getMemoryRoot } from "../src/memories";
 import { buildContainmentFence, containmentStatus } from "../src/sandbox/containment";
@@ -15,6 +22,8 @@ let home: string;
 let parent: string;
 let custA: string;
 let custB: string;
+let originalAgentDir: string;
+let originalAgentDirOverride: string | undefined;
 
 beforeAll(() => {
 	tmp = TempDir.createSync("xcsh-sbx-iso-");
@@ -30,9 +39,18 @@ beforeAll(() => {
 	fs.mkdirSync(custB, { recursive: true });
 	fs.writeFileSync(path.join(custA, "notes.md"), "a");
 	fs.writeFileSync(path.join(custB, "secret.env"), "TOKEN=b");
+	originalAgentDir = getAgentDir();
+	originalAgentDirOverride = process.env.PI_CODING_AGENT_DIR;
+	setAgentDir(path.join(home, ".xcsh", "agent"));
+	fs.mkdirSync(getMemoriesDir(), { recursive: true });
 });
 
-afterAll(() => tmp.removeSync());
+afterAll(() => {
+	setAgentDir(originalAgentDir);
+	if (originalAgentDirOverride === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = originalAgentDirOverride;
+	tmp.removeSync();
+});
 
 /** Whether the `read` tool would be refused — the same fence the shell is confined by (#2624). */
 function reads(cwd: string, filePath: string): boolean {
@@ -133,12 +151,12 @@ describe("bundled registration", () => {
  * asked the scanner would have passed throughout every escape in #2542 and #2553.
  */
 describe("two-customer isolation, enforced in the shell", () => {
-	// Taken from the product, not from a platform check written here, so this and `xcsh://about` cannot
-	// disagree about which platforms actually confine a spawned child.
-	const OS_ENFORCED = containmentStatus(true).osEnforced;
+	function productFenceFor(cwd: string) {
+		return buildContainmentFence({ workspace: cwd, home });
+	}
 
 	function fenceFor(cwd: string) {
-		const fence = buildContainmentFence({ workspace: cwd, home });
+		const fence = productFenceFor(cwd);
 		return {
 			allow: [...fence.allow],
 			allowReadOnly: [...fence.allowReadOnly],
@@ -194,9 +212,10 @@ describe("two-customer isolation, enforced in the shell", () => {
 		}
 	});
 
-	it(`a spawned parent listing ${OS_ENFORCED ? "is" : "is not"} OS-confined`, async () => {
+	it("reports a spawned parent listing according to the actual fence backend", async () => {
+		const osEnforced = containmentStatus(true, process.platform, undefined, productFenceFor(custA)).osEnforced;
 		const { text } = await shell(custA, "ls ..");
-		if (OS_ENFORCED) expect(text).not.toContain("custB");
+		if (osEnforced) expect(text).not.toContain("custB");
 		else expect(text).toContain("custB");
 	});
 
@@ -214,7 +233,7 @@ describe("two-customer isolation, enforced in the shell", () => {
 });
 
 describe("local account discovery isolation, enforced in the shell", () => {
-	it("denies account enumeration while preserving named account access", async () => {
+	it("aligns account enumeration with the actual fence backend and preserves named access", async () => {
 		const fsRoot = path.join(tmp.absolute(), "account-fixture");
 		const accountRoot = path.join(fsRoot, "Users");
 		const operatorHome = path.join(accountRoot, "operator");
@@ -241,10 +260,10 @@ describe("local account discovery isolation, enforced in the shell", () => {
 
 		expect(await run(`printf operator > ${JSON.stringify(path.join(operatorHome, ".zshrc"))}`)).toBe(0);
 		expect(fs.readFileSync(path.join(operatorHome, ".zshrc"), "utf8")).toBe("operator");
-		if (containmentStatus(true).osEnforced) {
-			expect(await run(`ls ${JSON.stringify(accountRoot)} > /dev/null`)).not.toBe(0);
-			expect(await run(`cd ${JSON.stringify(otherHome)}`)).toBe(0);
-			expect(await run(`cat ${JSON.stringify(path.join(otherHome, "synthetic.txt"))} > /dev/null`)).toBe(0);
-		}
+		const osEnforced = containmentStatus(true, process.platform, undefined, fence).osEnforced;
+		const accountListing = await run(`ls ${JSON.stringify(accountRoot)} > /dev/null`);
+		expect(accountListing === 0).toBe(!osEnforced);
+		expect(await run(`cd ${JSON.stringify(otherHome)}`)).toBe(0);
+		expect(await run(`cat ${JSON.stringify(path.join(otherHome, "synthetic.txt"))} > /dev/null`)).toBe(0);
 	});
 });

--- a/packages/coding-agent/test/sandbox-isolation.test.ts
+++ b/packages/coding-agent/test/sandbox-isolation.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { executeShell } from "@f5-sales-demo/pi-natives";
-import { getAgentDir, getConfigRootDir, getPluginsDir, TempDir } from "@f5-sales-demo/pi-utils";
+import { getAgentDir, getConfigRootDir, getMemoriesDir, getPluginsDir, TempDir } from "@f5-sales-demo/pi-utils";
 import { discoverAndLoadExtensions } from "../src/extensibility/extensions/loader";
 import { getMemoryRoot } from "../src/memories";
 import { buildContainmentFence, containmentStatus } from "../src/sandbox/containment";
@@ -110,11 +110,10 @@ describe("memory isolation (belt-and-suspenders)", () => {
 		expect(getMemoryRoot(getAgentDir(), custA)).not.toBe(getMemoryRoot(getAgentDir(), custB));
 	});
 
-	it("does not expose any session's raw memory store to the file tools", () => {
-		// The memory pipeline is an internal subsystem that bypasses the file-tool
-		// boundary; the model-invoked tools cannot read the raw store for any cwd.
-		expect(reads(custA, path.join(getMemoryRoot(getAgentDir(), custB), "MEMORY.md"))).toBe(true);
-		expect(reads(custA, path.join(getMemoryRoot(getAgentDir(), custA), "MEMORY.md"))).toBe(true);
+	it("hides the memory-store listing while preserving named operator access", () => {
+		expect(reads(custA, getMemoriesDir())).toBe(true);
+		expect(reads(custA, path.join(getMemoryRoot(getAgentDir(), custB), "MEMORY.md"))).toBe(false);
+		expect(reads(custA, path.join(getMemoryRoot(getAgentDir(), custA), "MEMORY.md"))).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/sandbox-session-fence.test.ts
+++ b/packages/coding-agent/test/sandbox-session-fence.test.ts
@@ -81,23 +81,23 @@ describe("resolveSessionFence", () => {
 		}
 	});
 
-	it("honours the allow-lists", () => {
+	it("treats the allow-lists as discovery grants, not operator-rights restrictions", () => {
 		const { mine, shared } = tenants("lists");
 		const fence = resolveSessionFence(mine, reader({ "sandbox.allowRead": [shared] }))!;
 		expect(fenceVerdict(fence, path.join(shared, "file.md"), "read")).toBe("allow");
-		expect(fenceVerdict(fence, path.join(shared, "file.md"), "write")).toBe("deny");
+		expect(fenceVerdict(fence, path.join(shared, "file.md"), "write")).toBe("allow");
 	});
 
 	// Two sessions can share a cwd and differ in sandbox settings — createAgentSession accepts an
 	// isolated Settings instance. A cwd-keyed cache would hand one session the other's boundary.
 	it("distinguishes same-cwd sessions whose settings differ", () => {
 		const { mine, shared } = tenants("samecwd");
-		const readOnly = resolveSessionFence(mine, reader({ "sandbox.allowRead": [shared] }))!;
+		const readGranted = resolveSessionFence(mine, reader({ "sandbox.allowRead": [shared] }))!;
 		const ordinary = resolveSessionFence(mine, reader({}))!;
 
-		expect(fenceVerdict(readOnly, path.join(shared, "file.md"), "write")).toBe("deny");
+		expect(fenceVerdict(readGranted, path.join(shared, "file.md"), "write")).toBe("allow");
 		expect(fenceVerdict(ordinary, path.join(shared, "file.md"), "write")).toBe("allow");
-		expect(readOnly).not.toBe(ordinary);
+		expect(readGranted).not.toBe(ordinary);
 	});
 
 	it("reuses the fence for an identical configuration", () => {

--- a/packages/coding-agent/test/sandbox-session-fence.test.ts
+++ b/packages/coding-agent/test/sandbox-session-fence.test.ts
@@ -120,13 +120,15 @@ describe("resolveSessionFence", () => {
 	// is what let the two disagree before. A different extras value must not be served from cache.
 	it("keys the cache on extra roots too", () => {
 		const { mine } = tenants("extras");
-		// A private session-store descendant is denied without the explicit runtime grant and opened by it.
-		// Unlike `/srv`, this is a recursive deny, so the assertion proves the extra root changed the fence.
+		// Named private-store descendants already retain operator access. The runtime grant still belongs in
+		// the cache key because it records the session-owned artifact root explicitly.
 		const artifacts = path.join(getSessionsDir(), "xcsh-artifacts-test");
 		const without = resolveSessionFence(mine, reader({}))!;
 		const with_ = resolveSessionFence(mine, reader({}), { extraRoots: [artifacts] })!;
 		expect(without).not.toBe(with_);
-		expect(fenceVerdict(without, path.join(artifacts, "out.txt"), "write")).toBe("deny");
+		expect(without.allow).not.toContain(artifacts);
+		expect(with_.allow).toContain(artifacts);
+		expect(fenceVerdict(without, path.join(artifacts, "out.txt"), "write")).toBe("allow");
 		expect(fenceVerdict(with_, path.join(artifacts, "out.txt"), "write")).toBe("allow");
 	});
 });

--- a/packages/coding-agent/test/tools/bash-skill-urls.test.ts
+++ b/packages/coding-agent/test/tools/bash-skill-urls.test.ts
@@ -287,11 +287,11 @@ describe("expandInternalUrls — resolution failures", () => {
 });
 
 // #2468 item 6: the expander and the sandbox disagreed about what was reachable, so bash was handed
-// paths the read tool refuses. Tested against the REAL default policy: a permissive stub would hide
-// the production failure this check exists to prevent.
+// paths the read tool refuses. Tested against the real default policy so URL expansion and file tools
+// continue to agree as the production boundary evolves.
 describe("expandInternalUrls — session read boundary", () => {
 	// Nested in a container so the real policy has a concrete parent on which to apply its enumeration
-	// courtesy. The refused path cases below use the policy's explicit cross-session roots.
+	// courtesy. Named cross-session paths retain the operator's normal rights.
 	const container = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "xcsh-boundary-")));
 	const cwd = path.join(container, "session");
 	fs.mkdirSync(cwd, { recursive: true });
@@ -310,29 +310,22 @@ describe("expandInternalUrls — session read boundary", () => {
 		).resolves.toBe(`cat ${shellEscape(inside)}`);
 	});
 
-	it("refuses a cross-session path, naming the scheme and the boundary", async () => {
+	it("allows a named cross-session path under the operator-rights policy", async () => {
 		const outside = path.join(getMemoriesDir(), "other-session", "secret.md");
 		const router = createInternalRouter({ "artifact://2": { sourcePath: outside } });
-		const attempt = expandInternalUrls("cat artifact://2", {
-			skills: [],
-			internalRouter: router,
-			readBoundary: policy,
-		});
-		await expect(attempt).rejects.toThrow("artifact://");
-		await expect(attempt).rejects.toThrow("outside this session's read boundary");
+		await expect(
+			expandInternalUrls("cat artifact://2", { skills: [], internalRouter: router, readBoundary: policy }),
+		).resolves.toBe(`cat ${shellEscape(outside)}`);
 	});
 
-	// The default policy deny-lists cross-session stores, and a session's own artifact root
-	// lives under it — so artifact:// and local:// would break without this carve-out.
-	it("allows a path under a session-owned root even when the policy denies its parent", async () => {
+	it("keeps a session-owned root explicit even though named access is already allowed", async () => {
 		const ownedRoot = path.join(getMemoriesDir(), `owned-${path.basename(container)}`);
 		const owned = path.join(ownedRoot, "12.bash.log");
 		const router = createInternalRouter({ "artifact://12": { sourcePath: owned } });
 
-		// Without the carve-out this is outside the boundary.
 		await expect(
 			expandInternalUrls("cat artifact://12", { skills: [], internalRouter: router, readBoundary: policy }),
-		).rejects.toThrow("outside this session's read boundary");
+		).resolves.toBe(`cat ${shellEscape(owned)}`);
 
 		await expect(
 			expandInternalUrls("cat artifact://12", {
@@ -344,11 +337,9 @@ describe("expandInternalUrls — session read boundary", () => {
 		).resolves.toBe(`cat ${shellEscape(owned)}`);
 	});
 
-	// Containment is canonicalized, so a symlink planted under an owned root cannot smuggle a path
-	// back out of the boundary.
-	it("refuses a symlink under an owned root that points outside it", async () => {
-		// Both sit under the shared cross-session temp root, which the default fence denies. The owned
-		// subtree is carved back out, but a symlink cannot carry that authority into its sibling.
+	it("preserves named access through a symlink into another private-store path", async () => {
+		// Both sit under the shared cross-session temp root. Its listing is hidden, but a target the
+		// operator names explicitly remains reachable.
 		const sharedRoot = path.join(fs.realpathSync(os.tmpdir()), "xcsh-local");
 		fs.mkdirSync(sharedRoot, { recursive: true });
 		const ownedRoot = fs.realpathSync(fs.mkdtempSync(path.join(sharedRoot, "xcsh-owned-")));
@@ -365,26 +356,30 @@ describe("expandInternalUrls — session read boundary", () => {
 				readBoundary: policy,
 				sessionOwnedRoots: () => [ownedRoot],
 			}),
-		).rejects.toThrow("outside this session's read boundary");
+		).resolves.toBe(`cat ${shellEscape(path.join(link, "secret.md"))}`);
 	});
 
-	// The concrete #2468 item-6 case: memory:// resolved under ~/.xcsh, which the same session's
-	// sandbox refuses to read. Refusing at expansion time is what makes the two agree.
-	it("refuses memory:// because the default policy deny-lists the memories directory", async () => {
+	it("allows a named memory:// path with the operator's normal rights", async () => {
 		const memoryPath = path.join(getMemoriesDir(), "--work--", "memory_summary.md");
 		const router = createInternalRouter({ "memory://root": { sourcePath: memoryPath } });
 		await expect(
 			expandInternalUrls("cat memory://root", { skills: [], internalRouter: router, readBoundary: policy }),
-		).rejects.toThrow("outside this session's read boundary");
+		).resolves.toBe(`cat ${shellEscape(memoryPath)}`);
 	});
 
-	it("does not create parent directories for a refused local:// URL", async () => {
-		const outsideArtifacts = path.join(getMemoriesDir(), `refused-${path.basename(container)}`);
+	it("creates parent directories for a named local:// path", async () => {
+		const outsideArtifacts = path.join(
+			fs.realpathSync(os.tmpdir()),
+			"xcsh-local",
+			`allowed-${path.basename(container)}`,
+		);
+		cleanup.push(outsideArtifacts);
 		const localOptions = {
 			getArtifactsDir: () => outsideArtifacts,
 			getSessionId: () => "session-1",
 		};
 
+		const expected = resolveLocalUrlToPath("local://handoffs/new.json", localOptions);
 		await expect(
 			expandInternalUrls("cp x local://handoffs/new.json", {
 				skills: [],
@@ -392,9 +387,8 @@ describe("expandInternalUrls — session read boundary", () => {
 				ensureLocalParentDirs: true,
 				readBoundary: policy,
 			}),
-		).rejects.toThrow("outside this session's read boundary");
+		).resolves.toBe(`cp x ${shellEscape(expected)}`);
 
-		// The directory must not have been created before the refusal.
-		expect(fs.existsSync(path.join(outsideArtifacts, "local", "handoffs"))).toBe(false);
+		expect(fs.existsSync(path.join(outsideArtifacts, "local", "handoffs"))).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

Keep xcsh's sandbox focused on cross-context discovery isolation without reducing a professional operator's normal machine capabilities.

Linux discovery-only sessions now stay on the zero-probe scanner/brush path instead of arming Landlock. This preserves direct `/tmp` and home writes, ancestor listings, PTYs, credentials, and `sudo` (`NoNewPrivs: 0`). macOS Seatbelt retains OS-enforced exact-listing isolation, while specialized recursive/directional fences continue to exercise Landlock.

## Related Issue

Closes #2952

## Changes

- preserve direct file creation and listings under `/tmp`, the operator home, and `/`
- treat historical session allow lists as discovery grants rather than user-rights controls
- retain structured-tool and brush expansion isolation for sibling/session discovery
- arm Landlock only for low-level recursive or directional fences it can represent faithfully
- expand the installed diagnostic from 14 to 17 probes and report Linux discovery-only mode as `scanner-only`
- keep Linux PTY and `sudo` paths available for normal discovery-only sessions
- make Linux tests derive enforcement expectations from the actual fence

The issue originally expected the installed diagnostic to remain OS-enforced. Live Ubuntu verification showed that Landlock cannot hide one nested listing without removing ancestor listings and setting `no_new_privs`; retaining that backend would violate the operator-rights requirement. The PR therefore makes the unavoidable backend reduction explicit and retains Landlock coverage for the stricter low-level profiles.

## Verification evidence

- `bun run check:ts` — exit 0
- `bun run check:rs` — exit 0
- `cargo test -p containment-check --test complement` — 17 passed, 0 failed
- focused Ubuntu sandbox suite — 277 passed, 0 failed, 1,262 expectations
- `bash crates/containment-check/landlock-e2e.sh target/debug/containment-check` — 47 passed, 0 failed
- full Ubuntu suite under Bun 1.3.14 — xcsh 6,368 passed / 559 skipped / 0 failed; Rust 248/248; every other workspace exited 0
- release-style native build — Linux x64 baseline and modern addons built; symbols verified
- release-style compiled binary — `xcsh/20.4.1`; native, API-spec, and Office-pane smoke tests passed
- compiled `xcsh sandbox check --verbose` — 12 passed, 5 expected scanner-only skips, 0 failed, 0 errors (17 probes total)
- production-fence capability probe — `backend=scanner-only`, `NoNewPrivs=0`, `SUDO_OK`, `PTY_STDIN_OK`, `PTY_STDOUT_OK`, `PTY_SUDO_OK`
- fresh Terraform fixture with `TMPDIR=<unset>` — `terraform init -backend=false`, `validate`, and `plan` exited 0
- mandatory `bash scripts/agy-pre-push-review.sh` — clean, no findings; PII enforcement clean

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met with the documented Linux backend correction
- [x] Verified locally and on the authorized Ubuntu server by exercising the compiled change
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
