### PR TITLE
fix(ai): verify Antigravity enterprise tier binding

### DIFF
--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -1,7 +1,7 @@
 /**
  * Google Gemini CLI / Antigravity provider.
  * Shared implementation for both google-gemini-cli and google-antigravity providers.
- * Uses the Cloud Code Assist API endpoint to access Gemini and Claude models.
+ * Uses Cloud Code Assist plus explicit enterprise Vertex routes for supported Antigravity models.
  */
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { abortableSleep, readSseJson } from "@f5-sales-demo/pi-utils";
@@ -62,6 +62,9 @@ const DEFAULT_ENDPOINT = "https://cloudcode-pa.googleapis.com";
 const ANTIGRAVITY_DAILY_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
 const ANTIGRAVITY_SANDBOX_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
 const ANTIGRAVITY_ENDPOINT_FALLBACKS = [ANTIGRAVITY_DAILY_ENDPOINT, ANTIGRAVITY_SANDBOX_ENDPOINT] as const;
+const ANTIGRAVITY_VERTEX_MODELS: Readonly<Record<string, string>> = Object.freeze({
+	"gemini-3.1-pro-high-vertex": "gemini-3.1-pro-preview",
+});
 
 /**
  * Build a User-Agent string that identifies as Gemini CLI to unlock higher rate limits.
@@ -421,34 +424,36 @@ interface CloudCodeAssistRequest {
 	requestId?: string;
 }
 
-interface CloudCodeAssistResponseChunk {
-	response?: {
-		candidates?: Array<{
-			content?: {
-				role: string;
-				parts?: Array<{
-					text?: string;
-					thought?: boolean;
-					thoughtSignature?: string;
-					functionCall?: {
-						name: string;
-						args: Record<string, unknown>;
-						id?: string;
-					};
-				}>;
-			};
-			finishReason?: string;
-		}>;
-		usageMetadata?: {
-			promptTokenCount?: number;
-			candidatesTokenCount?: number;
-			thoughtsTokenCount?: number;
-			totalTokenCount?: number;
-			cachedContentTokenCount?: number;
+interface GeminiGenerateContentResponse {
+	candidates?: Array<{
+		content?: {
+			role: string;
+			parts?: Array<{
+				text?: string;
+				thought?: boolean;
+				thoughtSignature?: string;
+				functionCall?: {
+					name: string;
+					args: Record<string, unknown>;
+					id?: string;
+				};
+			}>;
 		};
-		modelVersion?: string;
-		responseId?: string;
+		finishReason?: string;
+	}>;
+	usageMetadata?: {
+		promptTokenCount?: number;
+		candidatesTokenCount?: number;
+		thoughtsTokenCount?: number;
+		totalTokenCount?: number;
+		cachedContentTokenCount?: number;
 	};
+	modelVersion?: string;
+	responseId?: string;
+}
+
+interface CloudCodeAssistResponseChunk extends GeminiGenerateContentResponse {
+	response?: GeminiGenerateContentResponse;
 	traceId?: string;
 }
 
@@ -492,11 +497,16 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 			const parsedCredentials = parseGeminiCliCredentials(apiKeyRaw);
 			const activeCredentials = await refreshGeminiCliCredentialsIfNeeded(parsedCredentials, isAntigravity);
 			const { accessToken, projectId } = activeCredentials;
+			const vertexModelId = isAntigravity ? ANTIGRAVITY_VERTEX_MODELS[model.id] : undefined;
+			const serviceName = vertexModelId ? "Vertex AI" : "Cloud Code Assist";
 
 			const baseUrl = model.baseUrl?.trim();
 			const endpoints = baseUrl ? [baseUrl] : isAntigravity ? ANTIGRAVITY_ENDPOINT_FALLBACKS : [DEFAULT_ENDPOINT];
 
-			let requestBody = buildRequest(model, context, projectId, options, isAntigravity);
+			const cloudCodeRequest = buildRequest(model, context, projectId, options, isAntigravity);
+			let requestBody: CloudCodeAssistRequest | CloudCodeAssistRequest["request"] = vertexModelId
+				? cloudCodeRequest.request
+				: cloudCodeRequest;
 			const replacementPayload = await options?.onPayload?.(requestBody, model);
 			if (replacementPayload !== undefined) {
 				requestBody = replacementPayload as typeof requestBody;
@@ -534,7 +544,9 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 
 				try {
 					const endpoint = endpoints[Math.min(attempt, endpoints.length - 1)];
-					requestUrl = `${endpoint}/v1internal:streamGenerateContent?alt=sse`;
+					requestUrl = vertexModelId
+						? `${endpoint}/v1/projects/${encodeURIComponent(projectId)}/locations/global/publishers/google/models/${encodeURIComponent(vertexModelId)}:streamGenerateContent?alt=sse`
+						: `${endpoint}/v1internal:streamGenerateContent?alt=sse`;
 					response = await fetch(requestUrl, {
 						method: "POST",
 						headers: requestHeaders,
@@ -552,7 +564,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 					if (response.status === 429) {
 						if (/quota|exhausted/i.test(errorText)) {
 							throw withHttpStatus(
-								new Error(`Cloud Code Assist API error (429): ${extractErrorMessage(errorText)}`),
+								new Error(`${serviceName} API error (429): ${extractErrorMessage(errorText)}`),
 								429,
 							);
 						}
@@ -590,7 +602,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 
 					// Not retryable or budget exceeded
 					throw withHttpStatus(
-						new Error(`Cloud Code Assist API error (${response.status}): ${extractErrorMessage(errorText)}`),
+						new Error(`${serviceName} API error (${response.status}): ${extractErrorMessage(errorText)}`),
 						response.status,
 					);
 				} catch (error) {
@@ -665,8 +677,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 					activeResponse.body!,
 					options?.signal,
 				)) {
-					const responseData = chunk.response;
-					if (!responseData) continue;
+					const responseData = chunk.response ?? chunk;
 
 					const candidate = responseData.candidates?.[0];
 					if (candidate?.content?.parts) {
@@ -878,7 +889,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 					if (!currentResponse.ok) {
 						const retryErrorText = await currentResponse.text();
 						throw withHttpStatus(
-							new Error(`Cloud Code Assist API error (${currentResponse.status}): ${retryErrorText}`),
+							new Error(`${serviceName} API error (${currentResponse.status}): ${retryErrorText}`),
 							currentResponse.status,
 						);
 					}
@@ -896,7 +907,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 			}
 
 			if (!receivedContent) {
-				throw new Error("Cloud Code Assist API returned an empty response");
+				throw new Error(`${serviceName} API returned an empty response`);
 			}
 
 			if (options?.signal?.aborted) {

--- a/packages/ai/src/utils/discovery/antigravity.ts
+++ b/packages/ai/src/utils/discovery/antigravity.ts
@@ -8,6 +8,13 @@ const DEFAULT_ANTIGRAVITY_DISCOVERY_ENDPOINTS = [
 	"https://daily-cloudcode-pa.sandbox.googleapis.com",
 ] as const;
 const FETCH_AVAILABLE_MODELS_PATH = "/v1internal:fetchAvailableModels";
+const ANTIGRAVITY_VERTEX_ENDPOINT = "https://aiplatform.googleapis.com";
+const ANTIGRAVITY_VERTEX_VARIANTS: Readonly<Record<string, { id: string; name: string }>> = Object.freeze({
+	"gemini-3.1-pro-high": {
+		id: "gemini-3.1-pro-high-vertex",
+		name: "Gemini 3.1 Pro High (Vertex, Antigravity)",
+	},
+});
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 const DEFAULT_MAX_TOKENS = 64_000;
@@ -222,12 +229,13 @@ export async function fetchAntigravityDiscoveryModels(
 			}
 
 			const supportsImages = model.supportsImages === true;
+			const vertexVariant = ANTIGRAVITY_VERTEX_VARIANTS[modelId];
 			models.push({
-				id: modelId,
-				name: model.displayName ? `${model.displayName} (Antigravity)` : modelId,
+				id: vertexVariant?.id ?? modelId,
+				name: vertexVariant?.name ?? (model.displayName ? `${model.displayName} (Antigravity)` : modelId),
 				api: "google-gemini-cli",
 				provider: "google-antigravity",
-				baseUrl: endpoint,
+				baseUrl: vertexVariant ? ANTIGRAVITY_VERTEX_ENDPOINT : endpoint,
 				reasoning: model.supportsThinking === true,
 				input: supportsImages ? ["text", "image"] : ["text"],
 				cost: {

--- a/packages/ai/src/utils/oauth/google-antigravity.ts
+++ b/packages/ai/src/utils/oauth/google-antigravity.ts
@@ -30,6 +30,7 @@ const AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const TOKEN_URL = "https://oauth2.googleapis.com/token";
 const CLOUD_CODE_ENDPOINT = "https://cloudcode-pa.googleapis.com";
 const TIER_LEGACY = "legacy-tier";
+const TIER_STANDARD = "standard-tier";
 const PROJECT_ONBOARD_MAX_ATTEMPTS = 5;
 const PROJECT_ONBOARD_INTERVAL_MS = 2000;
 const PROJECT_ID_PATTERN = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
@@ -248,6 +249,25 @@ async function onboardProjectWithRetries(
 	);
 }
 
+async function loadCodeAssist(
+	endpoint: string,
+	headers: Record<string, string>,
+	projectRequest: AntigravityProjectRequest,
+): Promise<LoadCodeAssistPayload> {
+	const response = await fetch(`${endpoint}/v1internal:loadCodeAssist`, {
+		method: "POST",
+		headers,
+		body: JSON.stringify(projectRequest),
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(`loadCodeAssist failed: ${response.status} ${response.statusText}: ${errorText}`);
+	}
+
+	return (await response.json()) as LoadCodeAssistPayload;
+}
+
 async function discoverProject(
 	accessToken: string,
 	configuredProjectId: string | undefined,
@@ -263,31 +283,42 @@ async function discoverProject(
 	onProgress?.("Checking for existing project...");
 	const endpoint = CLOUD_CODE_ENDPOINT;
 	try {
-		const loadResponse = await fetch(`${endpoint}/v1internal:loadCodeAssist`, {
-			method: "POST",
-			headers,
-			body: JSON.stringify(projectRequest),
-		});
-
-		if (!loadResponse.ok) {
-			const errorText = await loadResponse.text();
-			throw new Error(`loadCodeAssist failed: ${loadResponse.status} ${loadResponse.statusText}: ${errorText}`);
-		}
-
-		const loadPayload = (await loadResponse.json()) as LoadCodeAssistPayload;
+		const loadPayload = await loadCodeAssist(endpoint, headers, projectRequest);
 		const existingProject = readProjectId(loadPayload.cloudaicompanionProject);
-		if (existingProject) {
-			return configuredProjectId ?? existingProject;
+
+		if (!configuredProjectId) {
+			if (existingProject) {
+				return existingProject;
+			}
+
+			const tierId = getDefaultTierId(loadPayload.allowedTiers);
+			onProgress?.("Provisioning project...");
+			const onboardBody = {
+				tierId,
+				...projectRequest,
+			};
+			return await onboardProjectWithRetries(endpoint, headers, onboardBody, onProgress);
 		}
 
-		const tierId = getDefaultTierId(loadPayload.allowedTiers);
+		if (existingProject === configuredProjectId && loadPayload.currentTier?.id === TIER_STANDARD) {
+			return configuredProjectId;
+		}
+
+		const standardTierAvailable = loadPayload.allowedTiers?.some(tier => tier.id === TIER_STANDARD) ?? false;
+		if (!standardTierAvailable) {
+			throw new Error(`standard-tier is not available for configured project ${configuredProjectId}`);
+		}
+
 		onProgress?.("Provisioning project...");
 		const onboardBody = {
-			tierId,
+			tierId: TIER_STANDARD,
 			...projectRequest,
 		};
 		const provisionedProject = await onboardProjectWithRetries(endpoint, headers, onboardBody, onProgress);
-		return configuredProjectId ?? provisionedProject;
+		if (provisionedProject !== configuredProjectId) {
+			throw new Error(`onboardUser returned project ${provisionedProject} instead of ${configuredProjectId}`);
+		}
+		return configuredProjectId;
 	} catch (error) {
 		throw new Error(
 			`Could not discover or provision an Antigravity project. ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/ai/test/google-antigravity-auth.test.ts
+++ b/packages/ai/test/google-antigravity-auth.test.ts
@@ -123,10 +123,11 @@ describe("Google Antigravity auth alignment", () => {
 		});
 	});
 
-	it("prefers GOOGLE_CLOUD_PROJECT and retains it when discovery returns another project", async () => {
+	it("prefers GOOGLE_CLOUD_PROJECT when it already has a standard-tier binding", async () => {
 		await withProjectEnvironment("primary-enterprise-project", "fallback-enterprise-project", async () => {
 			const { projectId, requests } = await runLogin({
-				cloudaicompanionProject: { id: "generated-free-tier-project" },
+				cloudaicompanionProject: { id: "primary-enterprise-project" },
+				currentTier: { id: "standard-tier" },
 			});
 
 			expect(projectId).toBe("primary-enterprise-project");
@@ -148,7 +149,8 @@ describe("Google Antigravity auth alignment", () => {
 	it("uses GOOGLE_CLOUD_PROJECT_ID when the primary project variable is absent", async () => {
 		await withProjectEnvironment(undefined, "fallback-enterprise-project", async () => {
 			const { projectId, requests } = await runLogin({
-				cloudaicompanionProject: "generated-free-tier-project",
+				cloudaicompanionProject: "fallback-enterprise-project",
+				currentTier: { id: "standard-tier" },
 			});
 
 			expect(projectId).toBe("fallback-enterprise-project");
@@ -168,7 +170,10 @@ describe("Google Antigravity auth alignment", () => {
 	it("passes the Antigravity CLI enterprise project through discovery and returned credentials", async () => {
 		await withProjectEnvironment(undefined, undefined, async () => {
 			const { projectId, requests } = await runLogin(
-				{ cloudaicompanionProject: "generated-free-tier-project" },
+				{
+					cloudaicompanionProject: "metadata-enterprise-project",
+					currentTier: { id: "standard-tier" },
+				},
 				undefined,
 				{ readAntigravityProjectId: async () => "metadata-enterprise-project" },
 			);
@@ -189,15 +194,17 @@ describe("Google Antigravity auth alignment", () => {
 		});
 	});
 
-	it("includes the configured enterprise project when onboarding is required", async () => {
+	it("accepts successful enterprise onboarding when load metadata remains stale", async () => {
 		await withProjectEnvironment("primary-enterprise-project", undefined, async () => {
 			const { projectId, requests } = await runLogin(
 				{
-					allowedTiers: [{ id: "standard-tier", isDefault: true }],
+					cloudaicompanionProject: { id: "generated-free-tier-project" },
+					currentTier: { id: "free-tier" },
+					allowedTiers: [{ id: "free-tier", isDefault: true }, { id: "standard-tier" }],
 				},
 				{
 					done: true,
-					response: { cloudaicompanionProject: { id: "generated-free-tier-project" } },
+					response: { cloudaicompanionProject: { id: "primary-enterprise-project" } },
 				},
 			);
 
@@ -223,6 +230,53 @@ describe("Google Antigravity auth alignment", () => {
 							duetProject: "primary-enterprise-project",
 						},
 					},
+				},
+			]);
+		});
+	});
+
+	it("rejects a configured enterprise project when standard-tier is unavailable", async () => {
+		await withProjectEnvironment("primary-enterprise-project", undefined, async () => {
+			await expect(
+				runLogin({
+					cloudaicompanionProject: "generated-free-tier-project",
+					currentTier: { id: "free-tier" },
+					allowedTiers: [{ id: "free-tier", isDefault: true }],
+				}),
+			).rejects.toThrow("standard-tier is not available");
+		});
+	});
+
+	it("rejects onboarding that provisions a different project", async () => {
+		await withProjectEnvironment("primary-enterprise-project", undefined, async () => {
+			await expect(
+				runLogin(
+					{
+						currentTier: { id: "free-tier" },
+						allowedTiers: [{ id: "standard-tier" }],
+					},
+					{
+						done: true,
+						response: { cloudaicompanionProject: "wrong-project" },
+					},
+				),
+			).rejects.toThrow("onboardUser returned project wrong-project instead of primary-enterprise-project");
+		});
+	});
+
+	it("preserves an existing individual project when no enterprise project is configured", async () => {
+		await withProjectEnvironment(undefined, undefined, async () => {
+			const { projectId, requests } = await runLogin({
+				cloudaicompanionProject: "generated-free-tier-project",
+				currentTier: { id: "free-tier" },
+				allowedTiers: [{ id: "free-tier", isDefault: true }],
+			});
+
+			expect(projectId).toBe("generated-free-tier-project");
+			expect(requests).toEqual([
+				{
+					url: LOAD_CODE_ASSIST_URL,
+					body: { metadata: ANTIGRAVITY_LOAD_CODE_ASSIST_METADATA },
 				},
 			]);
 		});

--- a/packages/ai/test/google-antigravity-discovery.test.ts
+++ b/packages/ai/test/google-antigravity-discovery.test.ts
@@ -29,6 +29,11 @@ describe("Google Antigravity model discovery", () => {
 							supportsImages: true,
 							supportsThinking: true,
 						},
+						"gemini-3.1-pro-high": {
+							displayName: "Gemini 3.1 Pro High",
+							supportsImages: true,
+							supportsThinking: true,
+						},
 					},
 				}),
 			);
@@ -40,6 +45,7 @@ describe("Google Antigravity model discovery", () => {
 		expect(requestHeaders?.get("Authorization")).toBe("Bearer access-token");
 		expect(requestHeaders?.get("User-Agent")).toMatch(/^antigravity\/2\.4\.3 /);
 		expect(models?.map(model => model.id).sort()).toEqual([
+			"gemini-3.1-pro-high-vertex",
 			"gemini-3.6-flash-high",
 			"gemini-3.6-flash-low",
 			"gemini-3.6-flash-medium",
@@ -51,6 +57,13 @@ describe("Google Antigravity model discovery", () => {
 			input: ["text", "image"],
 			contextWindow: 1_048_576,
 			maxTokens: 65_536,
+		});
+		expect(models?.find(model => model.id === "gemini-3.1-pro-high-vertex")).toMatchObject({
+			id: "gemini-3.1-pro-high-vertex",
+			name: "Gemini 3.1 Pro High (Vertex, Antigravity)",
+			api: "google-gemini-cli",
+			provider: "google-antigravity",
+			baseUrl: "https://aiplatform.googleapis.com",
 		});
 	});
 });

--- a/packages/ai/test/google-antigravity-vertex.test.ts
+++ b/packages/ai/test/google-antigravity-vertex.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import { hookFetch } from "@f5-sales-demo/pi-utils";
+import { streamGoogleGeminiCli } from "../src/providers/google-gemini-cli";
+import type { Context, Model } from "../src/types";
+
+const model: Model<"google-gemini-cli"> = {
+	id: "gemini-3.1-pro-high-vertex",
+	name: "Gemini 3.1 Pro High (Vertex, Antigravity)",
+	api: "google-gemini-cli",
+	provider: "google-antigravity",
+	baseUrl: "https://aiplatform.googleapis.com",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1_048_576,
+	maxTokens: 65_536,
+};
+
+const context: Context = {
+	messages: [{ role: "user", content: "Reply with VERTEX_PRO_OK", timestamp: Date.now() }],
+};
+
+describe("Google Antigravity Vertex transport", () => {
+	it("routes the Pro High variant through Vertex with a direct Gemini request and response", async () => {
+		let requestUrl: string | undefined;
+		let requestHeaders: Headers | undefined;
+		let requestBody: Record<string, unknown> | undefined;
+		using _hook = hookFetch((input, init) => {
+			requestUrl = String(input);
+			requestHeaders = new Headers(init?.headers);
+			requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			const responseChunk = {
+				candidates: [
+					{
+						content: { role: "model", parts: [{ text: "VERTEX_PRO_OK" }] },
+						finishReason: "STOP",
+					},
+				],
+				usageMetadata: {
+					promptTokenCount: 4,
+					candidatesTokenCount: 3,
+					totalTokenCount: 7,
+				},
+			};
+			return new Response(`data: ${JSON.stringify(responseChunk)}\n\n`, {
+				headers: { "Content-Type": "text/event-stream" },
+			});
+		});
+
+		const result = await streamGoogleGeminiCli(model, context, {
+			apiKey: JSON.stringify({ token: "xcsh-access-token", projectId: "enterprise-project" }),
+			thinking: { enabled: true, level: "HIGH" },
+		}).result();
+
+		expect(requestUrl).toBe(
+			"https://aiplatform.googleapis.com/v1/projects/enterprise-project/locations/global/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse",
+		);
+		expect(requestHeaders?.get("Authorization")).toBe("Bearer xcsh-access-token");
+		expect(requestBody).not.toHaveProperty("project");
+		expect(requestBody).not.toHaveProperty("model");
+		expect(requestBody).not.toHaveProperty("request");
+		expect(requestBody).toMatchObject({
+			contents: [{ role: "user", parts: [{ text: "Reply with VERTEX_PRO_OK" }] }],
+			generationConfig: {
+				thinkingConfig: {
+					includeThoughts: true,
+					thinkingLevel: "HIGH",
+				},
+			},
+		});
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toContainEqual(expect.objectContaining({ type: "text", text: "VERTEX_PRO_OK" }));
+		expect(result.usage.totalTokens).toBe(7);
+	});
+});


### PR DESCRIPTION
## Summary

- Require an explicit enterprise project to be bound to standard-tier before accepting existing Antigravity metadata.
- Re-onboard stale or free-tier bindings and persist credentials only when onboarding returns the exact configured project.
- Discover and route Gemini 3.1 Pro High through enterprise Vertex AI while keeping Gemini 3.6 Flash High on Cloud Code Assist.
- Parse direct Vertex Gemini SSE responses and preserve the existing wrapped Cloud Code Assist path.

## Verification

- Focused AI package tests — 663 passed, 455 skipped, 0 failed
- Type checks and build — passed
- Live xcsh Gemini 3.6 Flash High prompt — passed
- Live xcsh Gemini 3.1 Pro High Vertex prompt — passed
- Matching agy Flash High and Pro High comparison prompts — passed
- Full workspace suite — 6,362 passed; only the same three saved Landlock baseline failures remained
- scripts/agy-pre-push-review.sh — passed on reviewed HEAD 288942c529e14feed0480ac6234c736820bd9af4
- Required GitHub CI — passed on reviewed HEAD 288942c529e14feed0480ac6234c736820bd9af4

Closes #2970
