### PR TITLE
fix(coding-agent): separate update command boundaries

### DIFF
--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -23,10 +23,10 @@ interface ReleaseInfo {
 
 /**
  * Parse update subcommand arguments.
- * Returns undefined if not an update command.
+ * Returns undefined if not a self-update command.
  */
 export function parseUpdateArgs(args: string[]): { force: boolean; check: boolean } | undefined {
-	if (args.length === 0 || args[0] !== "update") {
+	if (args.length === 0 || args[0] !== "self-update") {
 		return undefined;
 	}
 

--- a/packages/coding-agent/test/resource-cli.test.ts
+++ b/packages/coding-agent/test/resource-cli.test.ts
@@ -21,6 +21,41 @@ describe("resource CLI automation contract", () => {
 		expect(report).toMatchObject({ success: true, operation: "validate" });
 	}, 40_000);
 
+	test("routes manifest update through the public CLI without starting an agent", () => {
+		const result = Bun.spawnSync(
+			[
+				"bun",
+				"src/cli.ts",
+				"update",
+				"-f",
+				"test/fixtures/resource-manifest.yaml",
+				"--dry-run",
+				"client",
+				"-o",
+				"json",
+			],
+			{
+				cwd: import.meta.dir.replace(/\/test$/, ""),
+				env: { ...process.env, XCSH_API_URL: "", XCSH_API_TOKEN: "", XCSH_NAMESPACE: "" },
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+		expect(result.exitCode).toBe(2);
+		const report = JSON.parse(result.stdout.toString()) as {
+			success: boolean;
+			operation: string;
+			counts: Record<string, number>;
+			results: Array<{ error?: { kind?: string; message?: string } }>;
+		};
+		expect(report).toMatchObject({
+			success: false,
+			operation: "update",
+			counts: { total: 1, succeeded: 0, failed: 1, error: 1 },
+			results: [{ error: { kind: "validation", message: "API credentials are required for this operation." } }],
+		});
+	}, 40_000);
+
 	test("maps validation failures to usage exit code 2", () => {
 		expect(
 			exitCodeForResourceReport({

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -1,8 +1,51 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { _resolveUpdateMethodForTest } from "../src/cli/update-cli";
+import { renderCommandHelp } from "@f5-sales-demo/pi-utils/cli";
+import { _resolveUpdateMethodForTest, parseUpdateArgs } from "../src/cli/update-cli";
+import SelfUpdate from "../src/commands/self-update";
+import Update from "../src/commands/update";
+
+describe("update command boundary", () => {
+	it("recognizes only self-update as the executable updater", () => {
+		expect(parseUpdateArgs(["self-update", "--check"])).toEqual({ force: false, check: true });
+		expect(parseUpdateArgs(["self-update", "--force"])).toEqual({ force: true, check: false });
+	});
+
+	it("never interprets manifest update flags as executable updater flags", () => {
+		expect(parseUpdateArgs(["update", "-f", "manifest.yaml"])).toBeUndefined();
+	});
+
+	it("exposes distinct public CLI contracts for update and self-update", () => {
+		const write = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+		try {
+			renderCommandHelp("xcsh", "update", Update);
+			const manifestUpdate = write.mock.calls.map(([chunk]) => String(chunk)).join("");
+			write.mockClear();
+			renderCommandHelp("xcsh", "self-update", SelfUpdate);
+			const executableUpdate = write.mock.calls.map(([chunk]) => String(chunk)).join("");
+
+			expect(manifestUpdate).toContain("Update existing resources from manifests");
+			expect(manifestUpdate).toContain("--filename=<value>");
+			expect(executableUpdate).toContain("Check for and install xcsh executable updates");
+			expect(executableUpdate).toContain("--check");
+		} finally {
+			write.mockRestore();
+		}
+	});
+
+	it("directs both English update notices to self-update", () => {
+		const mainSource = fs.readFileSync(new URL("../src/main.ts", import.meta.url), "utf8");
+		const messages = JSON.parse(
+			fs.readFileSync(new URL("../src/locales/en.json", import.meta.url), "utf8"),
+		) as Record<string, string>;
+
+		expect(mainSource).toContain("run: xcsh self-update");
+		expect(mainSource).not.toContain("run: xcsh update`");
+		expect(messages["welcome.updateHint"]).toBe("run: xcsh self-update");
+	});
+});
 
 describe("update-cli install target detection", () => {
 	// --- Existing tests (bun and binary) ---


### PR DESCRIPTION
## Summary

Lock the public boundary between deterministic manifest `xcsh update` and executable `xcsh self-update`. The updater helper now recognizes only `self-update`, while public regression coverage proves manifest update routes through the non-agent resource path and both commands retain distinct help contracts.

## Related Issue

Closes #2973

## Changes

- Restrict `parseUpdateArgs` to `self-update` so `update -f manifest.yaml` can never be interpreted as executable-updater flags.
- Add direct updater parsing and distinct production help-rendering regression tests.
- Add a public CLI test proving `update -f ... --dry-run client` returns a deterministic aggregate resource report without agent startup or LLM credentials.
- Assert English update notices direct users to `xcsh self-update`.
- Render command help in-process in the test to avoid heavyweight child-process timeout flakes while exercising the production command classes and help renderer.

## Verification evidence

- TDD red phase: 3 expected failures, including the helper collision where `update -f` was parsed as executable updater input.
- `bun test --cwd packages/coding-agent test/update-cli.test.ts test/resource-cli.test.ts --max-concurrency 2`: 18 passed, 0 failed; 29 assertions. The help-contract body completes in about 1 ms without child processes.
- `bun run check:ts`: all workspace Biome, prompt-format, and TypeScript checks passed on the final v20.4.2/AI-provider base.
- Earlier clean full bounded run: coding-agent 6,373 passed, 559 skipped, 0 failed; all workspaces exited 0.
- Final-base `bun run test`: all newly landed AI-provider tests passed (663 passed, 455 skipped, 0 failed), and all other workspaces passed. Under unrelated host CPU starvation, three untouched 5-second coding-agent tests timed out; rerunning exactly the affected files at concurrency 1 produced 192 passed, 0 failed, including those tests at 31 ms, 582 ms, and 402 ms.
- `bash scripts/agy-pre-push-review.sh`: PII enforcement clean; valid two-pass review passed with no critical or high finding after one malformed-output attempt correctly failed closed.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
