### PR TITLE
fix(ai): route Antigravity high-tier models through Vertex

### DIFF
--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -61,8 +61,11 @@ export interface GoogleGeminiCliOptions extends StreamOptions {
 const DEFAULT_ENDPOINT = "https://cloudcode-pa.googleapis.com";
 const ANTIGRAVITY_DAILY_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
 const ANTIGRAVITY_SANDBOX_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
+const ANTIGRAVITY_VERTEX_ENDPOINT = "https://aiplatform.googleapis.com";
 const ANTIGRAVITY_ENDPOINT_FALLBACKS = [ANTIGRAVITY_DAILY_ENDPOINT, ANTIGRAVITY_SANDBOX_ENDPOINT] as const;
 const ANTIGRAVITY_VERTEX_MODELS: Readonly<Record<string, string>> = Object.freeze({
+	"gemini-3.6-flash-high": "gemini-3.6-flash",
+	"gemini-3.1-pro-high": "gemini-3.1-pro-preview",
 	"gemini-3.1-pro-high-vertex": "gemini-3.1-pro-preview",
 });
 
@@ -501,7 +504,13 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 			const serviceName = vertexModelId ? "Vertex AI" : "Cloud Code Assist";
 
 			const baseUrl = model.baseUrl?.trim();
-			const endpoints = baseUrl ? [baseUrl] : isAntigravity ? ANTIGRAVITY_ENDPOINT_FALLBACKS : [DEFAULT_ENDPOINT];
+			const endpoints = vertexModelId
+				? [ANTIGRAVITY_VERTEX_ENDPOINT]
+				: baseUrl
+					? [baseUrl]
+					: isAntigravity
+						? ANTIGRAVITY_ENDPOINT_FALLBACKS
+						: [DEFAULT_ENDPOINT];
 
 			const cloudCodeRequest = buildRequest(model, context, projectId, options, isAntigravity);
 			let requestBody: CloudCodeAssistRequest | CloudCodeAssistRequest["request"] = vertexModelId

--- a/packages/ai/test/google-antigravity-vertex.test.ts
+++ b/packages/ai/test/google-antigravity-vertex.test.ts
@@ -3,28 +3,31 @@ import { hookFetch } from "@f5-sales-demo/pi-utils";
 import { streamGoogleGeminiCli } from "../src/providers/google-gemini-cli";
 import type { Context, Model } from "../src/types";
 
-const model: Model<"google-gemini-cli"> = {
-	id: "gemini-3.1-pro-high-vertex",
-	name: "Gemini 3.1 Pro High (Vertex, Antigravity)",
-	api: "google-gemini-cli",
-	provider: "google-antigravity",
-	baseUrl: "https://aiplatform.googleapis.com",
-	reasoning: true,
-	input: ["text", "image"],
-	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-	contextWindow: 1_048_576,
-	maxTokens: 65_536,
-};
-
 const context: Context = {
-	messages: [{ role: "user", content: "Reply with VERTEX_PRO_OK", timestamp: Date.now() }],
+	messages: [{ role: "user", content: "Reply with VERTEX_OK", timestamp: Date.now() }],
 };
 
 describe("Google Antigravity Vertex transport", () => {
-	it("routes the Pro High variant through Vertex with a direct Gemini request and response", async () => {
+	it.each([
+		["gemini-3.6-flash-high", "gemini-3.6-flash"],
+		["gemini-3.1-pro-high", "gemini-3.1-pro-preview"],
+		["gemini-3.1-pro-high-vertex", "gemini-3.1-pro-preview"],
+	] as const)("routes %s through the enterprise Vertex endpoint as %s", async (modelId, vertexModelId) => {
 		let requestUrl: string | undefined;
 		let requestHeaders: Headers | undefined;
 		let requestBody: Record<string, unknown> | undefined;
+		const model: Model<"google-gemini-cli"> = {
+			id: modelId,
+			name: modelId,
+			api: "google-gemini-cli",
+			provider: "google-antigravity",
+			baseUrl: "https://daily-cloudcode-pa.googleapis.com",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1_048_576,
+			maxTokens: 65_536,
+		};
 		using _hook = hookFetch((input, init) => {
 			requestUrl = String(input);
 			requestHeaders = new Headers(init?.headers);
@@ -32,7 +35,7 @@ describe("Google Antigravity Vertex transport", () => {
 			const responseChunk = {
 				candidates: [
 					{
-						content: { role: "model", parts: [{ text: "VERTEX_PRO_OK" }] },
+						content: { role: "model", parts: [{ text: "VERTEX_OK" }] },
 						finishReason: "STOP",
 					},
 				],
@@ -53,14 +56,14 @@ describe("Google Antigravity Vertex transport", () => {
 		}).result();
 
 		expect(requestUrl).toBe(
-			"https://aiplatform.googleapis.com/v1/projects/enterprise-project/locations/global/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse",
+			`https://aiplatform.googleapis.com/v1/projects/enterprise-project/locations/global/publishers/google/models/${vertexModelId}:streamGenerateContent?alt=sse`,
 		);
 		expect(requestHeaders?.get("Authorization")).toBe("Bearer xcsh-access-token");
 		expect(requestBody).not.toHaveProperty("project");
 		expect(requestBody).not.toHaveProperty("model");
 		expect(requestBody).not.toHaveProperty("request");
 		expect(requestBody).toMatchObject({
-			contents: [{ role: "user", parts: [{ text: "Reply with VERTEX_PRO_OK" }] }],
+			contents: [{ role: "user", parts: [{ text: "Reply with VERTEX_OK" }] }],
 			generationConfig: {
 				thinkingConfig: {
 					includeThoughts: true,
@@ -69,7 +72,7 @@ describe("Google Antigravity Vertex transport", () => {
 			},
 		});
 		expect(result.stopReason).toBe("stop");
-		expect(result.content).toContainEqual(expect.objectContaining({ type: "text", text: "VERTEX_PRO_OK" }));
+		expect(result.content).toContainEqual(expect.objectContaining({ type: "text", text: "VERTEX_OK" }));
 		expect(result.usage.totalTokens).toBe(7);
 	});
 });

--- a/packages/ai/test/google-gemini-cli-3x-thinking.test.ts
+++ b/packages/ai/test/google-gemini-cli-3x-thinking.test.ts
@@ -12,6 +12,9 @@ interface GeminiCliThinkingConfig {
 }
 
 interface CapturedRequestBody {
+	generationConfig?: {
+		thinkingConfig?: GeminiCliThinkingConfig;
+	};
 	request?: {
 		generationConfig?: {
 			thinkingConfig?: GeminiCliThinkingConfig;
@@ -44,7 +47,7 @@ const context: Context = {
 function extractThinking(bodyText: string | undefined): GeminiCliThinkingConfig | undefined {
 	if (!bodyText) return undefined;
 	const parsed = JSON.parse(bodyText) as CapturedRequestBody;
-	return parsed.request?.generationConfig?.thinkingConfig;
+	return parsed.generationConfig?.thinkingConfig ?? parsed.request?.generationConfig?.thinkingConfig;
 }
 
 describe("google-gemini-cli Gemini 3.x thinking mapping", () => {


### PR DESCRIPTION
## Summary

Route the public Antigravity Gemini 3.6 Flash High and Gemini 3.1 Pro High IDs through the enterprise Vertex endpoint, while preserving the Pro Vertex alias.

## Related Issue

Closes #2988

## Changes

- Map `gemini-3.6-flash-high` to Vertex `gemini-3.6-flash`.
- Map public and alias Pro High IDs to Vertex `gemini-3.1-pro-preview`.
- Force direct Vertex routes onto `aiplatform.googleapis.com`, ignoring cached Cloud Code base URLs.
- Cover endpoint, enterprise project path, direct payload shape, thinking config, and response parsing.

## Verification evidence

- TDD red: Flash High expected `aiplatform.googleapis.com` but received `daily-cloudcode-pa.googleapis.com/v1internal`.
- Focused Antigravity suite: 21 passed, 0 failed.
- Full AI package: 665 passed, 455 skipped, 0 failed.
- `bun run check:ts`: passed across all TypeScript workspaces.
- `bun run test`: passed; coding-agent 6,373 passed / 559 skipped / 0 failed, all other workspaces green.
- Live source CLI: `XCSH_SOURCE_FLASH_HIGH_OK`, `XCSH_SOURCE_PUBLIC_PRO_HIGH_OK`, and `XCSH_SOURCE_PRO_ALIAS_OK`.
- `agy` comparison: Flash High and Pro High succeeded through matching Vertex model endpoints and the same enterprise project.
- Exact-HEAD Antigravity review: PII clean; no critical or high finding remains.
- Green CI run: https://github.com/f5-sales-demo/xcsh/actions/runs/30986311439

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions
