### PR TITLE
fix(coding-agent): harden inference routing

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 
 - Preserved native Gemini finish reasons in Google provider errors instead of reporting an unknown error ([#2874](https://github.com/f5-sales-demo/xcsh/issues/2874))
+- Resolved Vertex AI projects directly from the active gcloud configuration before invoking gcloud, so Gemini authentication remains usable when the local gcloud Python launcher is broken ([#2996](https://github.com/f5-sales-demo/xcsh/issues/2996))
 
 <!-- markdownlint-disable MD024 -->
 <!-- textlint-disable terminology -->

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { $env, $which, isEnoent } from "@f5-sales-demo/pi-utils";
@@ -46,6 +47,7 @@ export interface GoogleVertexOptions extends StreamOptions {
 
 export interface GoogleVertexProjectRuntime {
 	readAdcProject(): Promise<string | undefined>;
+	readLocalConfigProject?(): Promise<string | undefined>;
 	findGcloud(): string | null;
 	readConfiguredProject(gcloud: string): Promise<string | undefined>;
 }
@@ -359,6 +361,7 @@ function resolveApiKey(options?: GoogleVertexOptions): string | undefined {
 
 const defaultProjectRuntime: GoogleVertexProjectRuntime = {
 	readAdcProject,
+	readLocalConfigProject: readConfiguredGcloudProject,
 	findGcloud: () => $which("gcloud"),
 	readConfiguredProject: async gcloud => {
 		const result = await $`${gcloud} config get-value project`.quiet().nothrow();
@@ -370,6 +373,50 @@ const defaultProjectRuntime: GoogleVertexProjectRuntime = {
 	},
 };
 
+function parseGcloudCoreProject(content: string): string | undefined {
+	let inCoreSection = false;
+	for (const rawLine of content.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (!line || line.startsWith("#") || line.startsWith(";")) continue;
+		const section = line.match(/^\[([^\]]+)]$/);
+		if (section) {
+			inCoreSection = section[1].trim() === "core";
+			continue;
+		}
+		if (!inCoreSection) continue;
+		const property = line.match(/^project\s*=\s*(.+)$/);
+		if (!property) continue;
+		const project = property[1].trim();
+		return project && project !== "(unset)" ? project : undefined;
+	}
+	return undefined;
+}
+
+/** Read the active gcloud project's INI file without requiring gcloud's Python launcher. */
+export async function readConfiguredGcloudProject(
+	configDirectory: string = $env.CLOUDSDK_CONFIG || path.join(os.homedir(), ".config", "gcloud"),
+): Promise<string | undefined> {
+	let configurationName = $env.CLOUDSDK_ACTIVE_CONFIG_NAME?.trim();
+	if (!configurationName) {
+		try {
+			configurationName = (await fs.readFile(path.join(configDirectory, "active_config"), "utf8")).trim();
+		} catch {
+			configurationName = "default";
+		}
+	}
+	if (!/^[A-Za-z0-9_-]+$/.test(configurationName)) return undefined;
+
+	try {
+		const content = await fs.readFile(
+			path.join(configDirectory, "configurations", `config_${configurationName}`),
+			"utf8",
+		);
+		return parseGcloudCoreProject(content);
+	} catch {
+		return undefined;
+	}
+}
+
 export async function resolveGoogleVertexProject(
 	options?: GoogleVertexOptions,
 	runtime: GoogleVertexProjectRuntime = defaultProjectRuntime,
@@ -379,6 +426,9 @@ export async function resolveGoogleVertexProject(
 
 	const adcProject = await runtime.readAdcProject();
 	if (adcProject) return adcProject;
+
+	const localConfigProject = await runtime.readLocalConfigProject?.();
+	if (localConfigProject) return localConfigProject;
 
 	const gcloud = runtime.findGcloud();
 	if (gcloud) {

--- a/packages/ai/test/google-vertex-config.test.ts
+++ b/packages/ai/test/google-vertex-config.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import {
 	type GoogleVertexProjectRuntime,
 	googleVertexRequestUrl,
+	readConfiguredGcloudProject,
 	resolveGoogleVertexLocation,
 	resolveGoogleVertexProject,
 } from "../src/providers/google-vertex";
@@ -62,6 +63,40 @@ describe("Google Vertex runtime configuration", () => {
 
 			expect(await resolveGoogleVertexProject(undefined, runtime)).toBe("gcloud-project");
 			expect(requestedExecutables).toEqual(["/test/bin/gcloud"]);
+		});
+	});
+
+	it("reads the active project directly from the gcloud configuration", async () => {
+		const configDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-gcloud-config-"));
+		try {
+			await fs.mkdir(path.join(configDirectory, "configurations"), { recursive: true });
+			await Bun.write(path.join(configDirectory, "active_config"), "enterprise\n");
+			await Bun.write(
+				path.join(configDirectory, "configurations", "config_enterprise"),
+				"[core]\naccount = user@example.com\nproject = enterprise-vertex-project\n[compute]\nregion = us-east1\n",
+			);
+
+			expect(await readConfiguredGcloudProject(configDirectory)).toBe("enterprise-vertex-project");
+		} finally {
+			await fs.rm(configDirectory, { recursive: true, force: true });
+		}
+	});
+
+	it("uses the local gcloud configuration before invoking the gcloud executable", async () => {
+		await withoutProjectEnvironment(async () => {
+			let executableLookupCalled = false;
+			const runtime: GoogleVertexProjectRuntime = {
+				readAdcProject: async () => undefined,
+				readLocalConfigProject: async () => "local-config-project",
+				findGcloud: () => {
+					executableLookupCalled = true;
+					return "/test/bin/gcloud";
+				},
+				readConfiguredProject: async () => "cli-project",
+			};
+
+			expect(await resolveGoogleVertexProject(undefined, runtime)).toBe("local-config-project");
+			expect(executableLookupCalled).toBe(false);
 		});
 	});
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - Prevalidated manifest batches before mutation, preserved strict create and update semantics, rejected unsupported server dry-run, and returned automation-grade exit codes for resource operations ([#2930](https://github.com/f5-sales-demo/xcsh/issues/2930))
 - Prevented sandbox false refusals from path-like Bash and Python source text while limiting account and data containers to discovery protection and preserving xcsh-private runtime isolation ([#2931](https://github.com/f5-sales-demo/xcsh/issues/2931))
+- Validated matching chat-completion POST routes during LiteLLM discovery so Open WebUI model-management endpoints cannot be mistaken for inference endpoints ([#2996](https://github.com/f5-sales-demo/xcsh/issues/2996))
+- Returned non-zero status from headless text and JSON sessions when the model turn fails or is aborted, while disposing each session exactly once ([#2996](https://github.com/f5-sales-demo/xcsh/issues/2996))
 
 ## [20.3.0] - 2026-08-04
 

--- a/packages/coding-agent/src/config/auto-config.ts
+++ b/packages/coding-agent/src/config/auto-config.ts
@@ -312,14 +312,25 @@ export interface ProbeResult {
 	apiBasePath?: string;
 }
 
-/** Candidate paths to probe for the models endpoint (tried in order). */
-const MODELS_ENDPOINT_PATHS = ["/v1/models", "/api/v1/models"];
+/** Candidate OpenAI-compatible API base paths, tried in order. */
+const API_BASE_PATHS = ["/v1", "/api", "/api/v1"];
+
+/**
+ * A route probe deliberately omits the required model and messages. OpenAI-compatible
+ * servers reject that payload before inference with 400 or 422. A 2xx response is also
+ * accepted for permissive proxies; 404/405 and server/auth failures reject the route.
+ */
+function acceptsChatCompletionPost(status: number): boolean {
+	return (status >= 200 && status < 300) || status === 400 || status === 422;
+}
 
 /**
  * Probe a LiteLLM proxy to validate connectivity and discover available models.
  *
- * Tries multiple endpoint paths in order (/v1/models, then /api/v1/models) to
- * handle deployments where a frontend like Open WebUI intercepts /v1/*.
+ * A models GET alone is not enough: Open WebUI also exposes management endpoints such
+ * as /api/v1/models that do not share an inference route. Each candidate must return an
+ * OpenAI-shaped model catalog and accept POST at the matching /chat/completions path.
+ * The POST carries an empty JSON object, so validation happens before model inference.
  *
  * Returns the list of model IDs on success, or an error on failure.
  * Uses a 3-second timeout per endpoint to avoid blocking startup.
@@ -333,11 +344,11 @@ export async function probeLiteLLMConnection(
 	const normalizedUrl = baseUrl.replace(/\/+$/, "");
 	let lastError = "";
 
-	for (const endpointPath of MODELS_ENDPOINT_PATHS) {
-		const url = `${normalizedUrl}${endpointPath}`;
+	for (const apiBasePath of API_BASE_PATHS) {
+		const modelsUrl = `${normalizedUrl}${apiBasePath}/models`;
 		let response: Response;
 		try {
-			response = await fetchImpl(url, {
+			response = await fetchImpl(modelsUrl, {
 				method: "GET",
 				headers: {
 					Accept: "application/json",
@@ -351,7 +362,7 @@ export async function probeLiteLLMConnection(
 		}
 
 		if (!response.ok) {
-			lastError = `HTTP ${response.status} ${response.statusText} from ${url}`;
+			lastError = `HTTP ${response.status} ${response.statusText} from ${modelsUrl}`;
 			continue;
 		}
 
@@ -359,7 +370,7 @@ export async function probeLiteLLMConnection(
 		try {
 			payload = await response.json();
 		} catch {
-			lastError = `Non-JSON response from ${url}`;
+			lastError = `Non-JSON response from ${modelsUrl}`;
 			continue;
 		}
 
@@ -378,13 +389,35 @@ export async function probeLiteLLMConnection(
 			}
 		}
 
-		if (models.length > 0) {
-			// Derive the API base path from the endpoint that worked
-			const apiBasePath = endpointPath.replace(/\/models$/, "");
-			return { reachable: true, models, apiBasePath };
+		if (models.length === 0) {
+			lastError = `No models in response from ${modelsUrl}`;
+			continue;
 		}
 
-		lastError = `No models in response from ${url}`;
+		const chatUrl = `${normalizedUrl}${apiBasePath}/chat/completions`;
+		let chatResponse: Response;
+		try {
+			chatResponse = await fetchImpl(chatUrl, {
+				method: "POST",
+				headers: {
+					Accept: "application/json",
+					Authorization: `Bearer ${apiKey}`,
+					"Content-Type": "application/json",
+				},
+				body: "{}",
+				signal: options?.signal ?? AbortSignal.timeout(3000),
+			});
+		} catch (err) {
+			lastError = err instanceof Error ? err.message : String(err);
+			continue;
+		}
+		await chatResponse.body?.cancel();
+		if (!acceptsChatCompletionPost(chatResponse.status)) {
+			lastError = `HTTP ${chatResponse.status} ${chatResponse.statusText} from ${chatUrl}`;
+			continue;
+		}
+
+		return { reachable: true, models, apiBasePath };
 	}
 
 	return { reachable: false, models: [], error: lastError };

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1083,7 +1083,7 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 		// Non-interactive (--print, piped, --mode json): force temperature=0 for
 		// deterministic HCL generation. Interactive mode keeps its configured value.
 		session.agent.temperature = 0;
-		await runPrintMode(session, {
+		const exitCode = await runPrintMode(session, {
 			mode,
 			messages: parsedArgs.messages,
 			initialMessage,
@@ -1091,7 +1091,7 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 		});
 		await session.dispose();
 		stopThemeWatcher();
-		await postmortem.quit(0);
+		await postmortem.quit(exitCode);
 	}
 }
 

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -68,7 +68,7 @@ export function buildJsonAgentEventLine(event: AgentSessionEvent): string | unde
 	return `${JSON.stringify(publicEvent)}\n`;
 }
 
-export async function runPrintMode(session: AgentSession, options: PrintModeOptions): Promise<void> {
+export async function runPrintMode(session: AgentSession, options: PrintModeOptions): Promise<0 | 1> {
 	const { mode, messages = [], initialMessage, initialImages } = options;
 
 	// Emit session header for JSON mode.
@@ -200,21 +200,16 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 		await session.prompt(message);
 	}
 
-	// In text mode, output final response
-	if (mode === "text") {
-		const state = session.state;
-		const lastMessage = state.messages[state.messages.length - 1];
+	const state = session.state;
+	const lastMessage = state.messages[state.messages.length - 1];
+	const assistantMsg = lastMessage?.role === "assistant" ? (lastMessage as AssistantMessage) : undefined;
+	const failed = assistantMsg?.stopReason === "error" || assistantMsg?.stopReason === "aborted";
 
-		if (lastMessage?.role === "assistant") {
-			const assistantMsg = lastMessage as AssistantMessage;
-
-			// Check for error/aborted
-			if (assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") {
-				process.stderr.write(`${assistantMsg.errorMessage || `Request ${assistantMsg.stopReason}`}\n`);
-				process.exit(1);
-			}
-
-			// Output text content
+	// In text mode, output final response or the terminal model error.
+	if (mode === "text" && assistantMsg) {
+		if (failed) {
+			process.stderr.write(`${assistantMsg.errorMessage || `Request ${assistantMsg.stopReason}`}\n`);
+		} else {
 			for (const content of assistantMsg.content) {
 				if (content.type === "text") {
 					process.stdout.write(`${content.text}\n`);
@@ -232,5 +227,5 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 	});
 	await promise;
 
-	await session.dispose();
+	return failed ? 1 : 0;
 }

--- a/packages/coding-agent/test/auto-config.test.ts
+++ b/packages/coding-agent/test/auto-config.test.ts
@@ -1078,8 +1078,13 @@ describe("config schema versioning", () => {
 
 describe("probeLiteLLMConnection()", () => {
 	test("returns model list on successful probe at /v1/models", async () => {
-		const mockFetch = async (_url: string, init?: RequestInit) => {
+		const calls: Array<{ body: RequestInit["body"]; method: string; url: string }> = [];
+		const mockFetch = async (url: string, init?: RequestInit) => {
 			expect(init?.headers).toHaveProperty("Authorization", "Bearer sk-test123");
+			calls.push({ body: init?.body, method: init?.method ?? "GET", url });
+			if (init?.method === "POST") {
+				return new Response(JSON.stringify({ detail: "model is required" }), { status: 422 });
+			}
 			return new Response(
 				JSON.stringify({
 					data: [
@@ -1098,14 +1103,24 @@ describe("probeLiteLLMConnection()", () => {
 		expect(result.models).toContain("gpt-5.4");
 		expect(result.apiBasePath).toBe("/v1");
 		expect(result.error).toBeUndefined();
+		expect(calls).toEqual([
+			{ body: undefined, method: "GET", url: "https://proxy.example.com/v1/models" },
+			{ body: "{}", method: "POST", url: "https://proxy.example.com/v1/chat/completions" },
+		]);
 	});
 
-	test("falls back to /api/v1/models when /v1/models returns HTML", async () => {
-		const mockFetch = async (url: string) => {
-			if (url.includes("/api/v1/models")) {
+	test("selects the Open WebUI /api route only after its chat endpoint accepts POST", async () => {
+		const calls: Array<{ method: string; url: string }> = [];
+		const mockFetch = async (url: string, init?: RequestInit) => {
+			const method = init?.method ?? "GET";
+			calls.push({ method, url });
+			if (url.endsWith("/api/models") && method === "GET") {
 				return new Response(JSON.stringify({ data: [{ id: "claude-sonnet-4-6" }] }), { status: 200 });
 			}
-			// Open WebUI returns HTML for /v1/models
+			if (url.endsWith("/api/chat/completions") && method === "POST") {
+				return new Response(JSON.stringify({ detail: "model is required" }), { status: 422 });
+			}
+			// The web frontend returns HTML for /v1/*.
 			return new Response("<!doctype html><html>...</html>", { status: 200 });
 		};
 		const result = await probeLiteLLMConnection("https://proxy.example.com", "sk-test123", {
@@ -1113,7 +1128,46 @@ describe("probeLiteLLMConnection()", () => {
 		});
 		expect(result.reachable).toBe(true);
 		expect(result.models).toContain("claude-sonnet-4-6");
-		expect(result.apiBasePath).toBe("/api/v1");
+		expect(result.apiBasePath).toBe("/api");
+		expect(calls).toContainEqual({ method: "POST", url: "https://proxy.example.com/api/chat/completions" });
+	});
+
+	test("rejects a models-only /api/v1 management route whose chat endpoint returns 405", async () => {
+		const mockFetch = async (url: string, init?: RequestInit) => {
+			const method = init?.method ?? "GET";
+			if (url.endsWith("/api/v1/models") && method === "GET") {
+				return new Response(JSON.stringify({ data: [{ id: "managed-model-record" }] }), { status: 200 });
+			}
+			if (url.endsWith("/api/v1/chat/completions") && method === "POST") {
+				return new Response(JSON.stringify({ detail: "Method Not Allowed" }), { status: 405 });
+			}
+			return new Response("Not Found", { status: 404 });
+		};
+		const result = await probeLiteLLMConnection("https://proxy.example.com", "sk-test123", {
+			fetch: mockFetch as unknown as typeof globalThis.fetch,
+		});
+		expect(result.reachable).toBe(false);
+		expect(result.models).toHaveLength(0);
+		expect(result.error).toContain("405");
+	});
+
+	test("retains a matching /api/v1 route when both model listing and chat POST are supported", async () => {
+		const mockFetch = async (url: string, init?: RequestInit) => {
+			const method = init?.method ?? "GET";
+			if (url.endsWith("/api/v1/models") && method === "GET") {
+				return new Response(JSON.stringify({ data: [{ id: "private-model" }] }), { status: 200 });
+			}
+			if (url.endsWith("/api/v1/chat/completions") && method === "POST") {
+				return new Response(JSON.stringify({ detail: "messages are required" }), { status: 400 });
+			}
+			return new Response("Not Found", { status: 404 });
+		};
+
+		const result = await probeLiteLLMConnection("https://proxy.example.com", "sk-test123", {
+			fetch: mockFetch as unknown as typeof globalThis.fetch,
+		});
+
+		expect(result).toEqual({ reachable: true, models: ["private-model"], apiBasePath: "/api/v1" });
 	});
 
 	test("returns unreachable when all endpoints fail", async () => {
@@ -1150,7 +1204,7 @@ describe("probeLiteLLMConnection()", () => {
 
 	test("tries fallback when first endpoint returns empty data array", async () => {
 		const mockFetch = async (url: string) => {
-			if (url.includes("/api/v1/models")) {
+			if (url.includes("/api/models")) {
 				return new Response(JSON.stringify({ data: [{ id: "gpt-5.4" }] }), { status: 200 });
 			}
 			return new Response(JSON.stringify({ data: [] }), { status: 200 });
@@ -1160,12 +1214,12 @@ describe("probeLiteLLMConnection()", () => {
 		});
 		expect(result.reachable).toBe(true);
 		expect(result.models).toContain("gpt-5.4");
-		expect(result.apiBasePath).toBe("/api/v1");
+		expect(result.apiBasePath).toBe("/api");
 	});
 
 	test("handles malformed JSON response by trying fallback", async () => {
 		const mockFetch = async (url: string) => {
-			if (url.includes("/api/v1/models")) {
+			if (url.includes("/api/models")) {
 				return new Response(JSON.stringify({ data: [{ id: "claude-sonnet-4-6" }] }), { status: 200 });
 			}
 			return new Response("not json", { status: 200 });
@@ -1174,7 +1228,7 @@ describe("probeLiteLLMConnection()", () => {
 			fetch: mockFetch as unknown as typeof globalThis.fetch,
 		});
 		expect(result.reachable).toBe(true);
-		expect(result.apiBasePath).toBe("/api/v1");
+		expect(result.apiBasePath).toBe("/api");
 	});
 });
 
@@ -1247,7 +1301,7 @@ describe("probeAndUpgradeLiteLLMConfig()", () => {
 		expect(fs.existsSync(`${modelsPath}.bak`)).toBe(true);
 	});
 
-	test("fixes wrong base path when probe discovers /api/v1 works", async () => {
+	test("fixes wrong base path when probe discovers /api works", async () => {
 		setEnv("https://proxy.example.com", "sk-abc123");
 		fs.mkdirSync(path.dirname(modelsPath), { recursive: true });
 
@@ -1255,7 +1309,7 @@ describe("probeAndUpgradeLiteLLMConfig()", () => {
 		fs.writeFileSync(modelsPath, generateModelsYml("https://proxy.example.com"));
 
 		const mockFetch = async (url: string) => {
-			if (url.includes("/api/v1/models")) {
+			if (url.includes("/api/models")) {
 				return new Response(JSON.stringify({ data: [{ id: "claude-sonnet-4-6" }] }), { status: 200 });
 			}
 			// Open WebUI intercepts /v1/models — returns HTML
@@ -1268,7 +1322,7 @@ describe("probeAndUpgradeLiteLLMConfig()", () => {
 		expect(upgraded).toBe(true);
 
 		const afterContent = fs.readFileSync(modelsPath, "utf-8");
-		expect(afterContent).toContain('baseUrl: "https://proxy.example.com/api/v1"');
+		expect(afterContent).toContain('baseUrl: "https://proxy.example.com/api"');
 	});
 
 	test("no-ops when discovery is already configured with correct base path", async () => {

--- a/packages/coding-agent/test/modes/print-mode-result.test.ts
+++ b/packages/coding-agent/test/modes/print-mode-result.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { AssistantMessage } from "@f5-sales-demo/pi-ai";
+import { runPrintMode } from "../../src/modes/print-mode";
+import type { AgentSession } from "../../src/session/agent-session";
+
+function assistantMessage(stopReason: "stop" | "error" | "aborted"): AssistantMessage {
+	return {
+		role: "assistant",
+		content: stopReason === "stop" ? [{ type: "text", text: "ok" }] : [],
+		api: "openai-completions",
+		provider: "litellm",
+		model: "gpt-5.6-sol",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: Date.now(),
+		...(stopReason !== "stop" ? { errorMessage: "405 Method Not Allowed" } : {}),
+	};
+}
+
+function fakeSession(message: AssistantMessage): { session: AgentSession; dispose: ReturnType<typeof mock> } {
+	const dispose = mock(async () => {});
+	const session = {
+		sessionManager: { getHeader: () => null },
+		model: undefined,
+		thinkingLevel: undefined,
+		extensionRunner: undefined,
+		subscribe: () => () => {},
+		state: { messages: [message] },
+		dispose,
+	} as unknown as AgentSession;
+	return { session, dispose };
+}
+
+describe("print mode result", () => {
+	it("returns failure for a JSON model error and leaves lifecycle disposal to main", async () => {
+		const { session, dispose } = fakeSession(assistantMessage("error"));
+
+		const result = await runPrintMode(session, { mode: "json" });
+
+		expect(result).toBe(1);
+		expect(dispose).not.toHaveBeenCalled();
+	});
+
+	it("returns failure and reports the provider error in text mode", async () => {
+		const { session, dispose } = fakeSession(assistantMessage("error"));
+		const originalWrite = process.stderr.write;
+		let stderr = "";
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			stderr += chunk.toString();
+			return true;
+		}) as typeof process.stderr.write;
+
+		try {
+			const result = await runPrintMode(session, { mode: "text" });
+
+			expect(result).toBe(1);
+			expect(stderr).toBe("405 Method Not Allowed\n");
+			expect(dispose).not.toHaveBeenCalled();
+		} finally {
+			process.stderr.write = originalWrite;
+		}
+	});
+
+	it("returns failure when the model turn is aborted", async () => {
+		const { session } = fakeSession(assistantMessage("aborted"));
+
+		expect(await runPrintMode(session, { mode: "json" })).toBe(1);
+	});
+
+	it("returns success for a completed JSON response", async () => {
+		const { session, dispose } = fakeSession(assistantMessage("stop"));
+
+		const result = await runPrintMode(session, { mode: "json" });
+
+		expect(result).toBe(0);
+		expect(dispose).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Closes #2996

## Summary

- validate a matching POST chat-completions endpoint before accepting a LiteLLM discovery route
- prefer the working Open WebUI /api inference family and reject management-only /api/v1 routes
- return exit 1 from headless text/JSON sessions on model errors or aborts, with single-owner session disposal
- read the active gcloud project configuration before invoking a broken gcloud Python launcher

## Verification

- bun test packages/coding-agent/test/auto-config.test.ts packages/coding-agent/test/modes/print-mode-result.test.ts packages/ai/test/google-vertex-config.test.ts --max-concurrency 2: 142 pass, 0 fail
- bun run check:ts: pass
- packages/ai: 669 pass, 0 fail
- packages/coding-agent: 6,385 pass, 0 fail
- bun run test: all workspaces pass, zero failures
- bun run build in packages/coding-agent: pass
- exact built-artifact UAT: all six cells pass (default and explicit GPT-5.6 Sol high, Gemini 3.6 Flash high, Claude Opus 5 high, one read tool call/result, forced 405 exits 1 with stopReason=error)
- bash scripts/agy-pre-push-review.sh: PII clean; independent Antigravity gate passed with no critical/high findings