### PR TITLE
fix(ai): normalize changelog terminology

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -433,7 +433,7 @@
 - Removed `UsageCache` and `UsageCacheEntry` interfaces—caching is now handled internally by AuthStorage
 - Removed `google-gemini-cli-usage` export; use new `gemini` usage provider instead
 - Removed `resetInMs` computation from all usage providers
-- Removed cache TTL constants and cache management from usage fetchers (claude, github-copilot, google-antigravity, kimi, openai-codex, zai)
+- Removed cache TTL constants and cache management from usage fetchers (claude, GitHub Copilot, google-antigravity, kimi, openai-codex, zai)
 
 ### Fixed
 
@@ -1294,7 +1294,7 @@
 
 ### Changed
 
-- Updated @anthropic-ai/sdk to ^0.72.1
+- Updated `@anthropic-ai/sdk` to ^0.72.1
 - Updated @aws-sdk/client-bedrock-runtime to ^3.982.0
 - Updated @google/genai to ^1.39.0
 - Updated @smithy/node-http-handler to ^4.4.9


### PR DESCRIPTION
Closes #3001

## Summary

- correct the two historical terminology violations exposed when PR #2998 touched the AI changelog
- preserve the provider-slug wording while using the required GitHub Copilot term
- mark the Anthropic package name as code so terminology lint does not rewrite an exact package identifier

## Verification

- bash scripts/lint-mdx-prose.sh --textlint-only packages/ai/CHANGELOG.md: pass
- git diff --check origin/main...HEAD: pass
- bash scripts/agy-pre-push-review.sh: PII clean and no critical/high findings