### PR TITLE
fix(coding-agent): align sandbox discovery messaging

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -8,6 +8,7 @@ import { parseEffort } from "../thinking";
 import {
 	flagNameForChar,
 	flagSpec,
+	LAUNCH_FLAGS,
 	type LaunchFlagName,
 	normalizeFlagTokens,
 	takesValue,
@@ -19,9 +20,9 @@ export type Mode = "text" | "json" | "rpc" | "acp";
 export interface Args {
 	cwd?: string;
 	allowHome?: boolean;
-	/** Disable the session filesystem sandbox (widen to unrestricted access). */
+	/** Disable the session filesystem discovery guard; OS-user permissions are unchanged. */
 	noSandbox?: boolean;
-	/** Extra directories the session may read AND write, beyond its CWD subtree (repeatable). */
+	/** Extra directories whose entries the session may discover (repeatable). */
 	allowPath?: string[];
 	provider?: string;
 	context?: string;
@@ -375,8 +376,8 @@ ${chalk.bold("Available Tools (default-enabled unless noted):")}
   ask           - Ask user questions (interactive mode only)
 
 ${chalk.bold("Sandbox Options:")}
-  --no-sandbox               Disable session filesystem isolation (allow access outside the CWD)
-  --allow-path <path>        Grant read+write access to an extra directory (repeatable)
+  --no-sandbox               ${LAUNCH_FLAGS["no-sandbox"].description}
+  --allow-path <path>        ${LAUNCH_FLAGS["allow-path"].description}
 
 ${chalk.bold("Plugin Options:")}
   --plugin-dir <path>        Load plugin from directory (repeatable)

--- a/packages/coding-agent/src/cli/flag-spec.ts
+++ b/packages/coding-agent/src/cli/flag-spec.ts
@@ -53,11 +53,11 @@ export const LAUNCH_FLAGS = defineFlags({
 	"allow-home": { arity: "boolean", description: "Allow starting in ~ without auto-switching to a temp dir" },
 	"no-sandbox": {
 		arity: "boolean",
-		description: "Disable session filesystem isolation (allow access outside the CWD)",
+		description: "Disable the session filesystem discovery guard",
 	},
 	"allow-path": {
 		arity: "repeatable-value",
-		description: "Grant read+write access to an extra directory (repeatable)",
+		description: "Allow directory discovery at an additional path (repeatable)",
 	},
 	mode: {
 		arity: "value",

--- a/packages/coding-agent/src/prompts/system/workspace-boundary.md
+++ b/packages/coding-agent/src/prompts/system/workspace-boundary.md
@@ -1,4 +1,15 @@
 <workspace-boundary>
+You run with the same filesystem rights as the human who launched xcsh. Those are the launching
+account's ordinary rights; this sandbox does not grant root or administrator privileges.
+
+The session sandbox is a discovery guard, not a privilege boundary. It may refuse a directory
+listing while a directly named path keeps the operator's ordinary operating-system rights. When a
+tool reports an `enumerate boundary`, read that as "names cannot be discovered here," not "this path
+is inaccessible."
+- When the task supplies an exact path, you **MUST** use it directly.
+- When a directory listing is required, you **MUST** ask for the exact path or an explicit discovery
+  grant. You **MUST NOT** disable the guard merely to browse.
+
 Separate tenants may sit side by side — as subdirectories of the working directory, and anywhere
 else you can reach when filesystem isolation is off. Reaching something is not the same as it being
 in scope; keeping tenants apart is your judgment.

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -110,10 +110,20 @@ function permits(check: ToolCallCheck, resolved: string, access: SandboxAccess):
 }
 
 /**
- * The refusal the model sees. Wording preserved from the policy this replaced, because the bash prompt
- * and the skill-URL boundary both tell the model to expect it.
+ * The refusal the model sees. Read/write wording stays compatible with the directional policy this
+ * replaced; enumeration gets the discovery-specific recovery that matches the ordinary session fence.
  */
 function deny(cwd: string, resolved: string, access: SandboxAccess): ToolCallDecision {
+	if (access === "enumerate") {
+		return {
+			block: true,
+			reason:
+				`Directory discovery is outside this session's enumerate boundary (working directory: ${cwd}): ${resolved}. ` +
+				"This refusal is about listing names, not general filesystem access. Use the exact path the task names directly. " +
+				"If the directory must be listed, use --allow-path or the sandbox.allow* settings to grant discovery, " +
+				"or --no-sandbox to disable the discovery guard.",
+		};
+	}
 	return {
 		block: true,
 		reason:

--- a/packages/coding-agent/test/cli/flag-spec.test.ts
+++ b/packages/coding-agent/test/cli/flag-spec.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { type Mode, parseArgs } from "../../src/cli/args";
+import { getExtraHelpText, type Mode, parseArgs } from "../../src/cli/args";
 import { buildCliFlags, flagSpec, LAUNCH_FLAGS, normalizeFlagTokens, takesValue } from "../../src/cli/flag-spec";
 import Index from "../../src/commands/launch";
 
@@ -39,6 +39,18 @@ describe("help and parser cannot drift", () => {
 			if (spec.arity !== "repeatable-value" || "hidden" in spec) continue;
 			expect(flags[name].multiple, `--${name} should be multiple`).toBe(true);
 		}
+	});
+
+	test("sandbox help describes discovery rather than CWD access grants", () => {
+		const noSandbox = LAUNCH_FLAGS["no-sandbox"].description;
+		const allowPath = LAUNCH_FLAGS["allow-path"].description;
+		const extraHelp = getExtraHelpText();
+
+		expect(noSandbox).toMatch(/discovery guard/i);
+		expect(allowPath).toMatch(/directory discovery/i);
+		expect(extraHelp).toContain(noSandbox);
+		expect(extraHelp).toContain(allowPath);
+		expect(`${noSandbox}\n${allowPath}\n${extraHelp}`).not.toMatch(/access outside the CWD|read\+write access/i);
 	});
 
 	test("hidden flags are parsed but not advertised", () => {

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -95,7 +95,11 @@ describe("evaluateToolCall", () => {
 			const evaluate = (toolName: string, input: Record<string, unknown>) =>
 				evaluateToolCall({ toolName, input, cwd: workspace, fence });
 
-			expect(evaluate("read", { file_path: parent }).block).toBe(true);
+			const directoryRead = evaluate("read", { file_path: parent });
+			expect(directoryRead.block).toBe(true);
+			expect(directoryRead.reason).toContain("enumerate boundary");
+			expect(directoryRead.reason).toMatch(/listing names, not general filesystem access/i);
+			expect(directoryRead.reason).toMatch(/exact path.*task names directly/i);
 			expect(evaluate("read", { file_path: path.join(workspace, "parent-link") }).block).toBe(true);
 			expect(evaluate("read", { file_path: namedFile }).block).toBe(false);
 			expect(evaluate("grep", { pattern: "context", path: parent }).block).toBe(true);

--- a/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
+++ b/packages/coding-agent/test/system-prompt-workspace-boundary.test.ts
@@ -59,6 +59,19 @@ describe("system prompt workspace boundary", () => {
 		expect(boundary).toBeLessThan(nextSection);
 	});
 
+	it("states the operator-rights model without implying privilege escalation", () => {
+		expect(flat()).toMatch(/same filesystem rights as the human who launched xcsh/i);
+		expect(flat()).toMatch(/does not grant root or administrator privileges/i);
+	});
+
+	it("explains that the sandbox guards discovery rather than known-path access", () => {
+		expect(flat()).toMatch(/discovery guard, not a privilege boundary/i);
+		expect(flat()).toMatch(/enumerate boundary.*names cannot be discovered/i);
+		expect(flat()).toMatch(/directly named path.*ordinary operating-system rights/i);
+		expect(flat()).toMatch(/task supplies an exact path.*MUST\*{0,2} use it directly/i);
+		expect(flat()).toMatch(/directory listing is required.*explicit discovery grant/i);
+	});
+
 	// The one thing the fence cannot do. Where the working directory holds several
 	// tenants, they are all inside the allowed subtree, so separating them is
 	// judgment and nothing else.
@@ -115,6 +128,9 @@ describe("system prompt workspace boundary", () => {
 	it("does not prohibit reading paths the fence allows", () => {
 		expect(flat()).not.toMatch(/range across the filesystem/i);
 		expect(flat()).not.toMatch(/never widen/i);
+		expect(flat()).not.toMatch(
+			/access (?:is|stays) (?:limited|confined|restricted) to the (?:cwd|working directory)/i,
+		);
 	});
 
 	// A custom system prompt (--system-prompt, or an auto-discovered project/global


### PR DESCRIPTION
## Summary

Align sandbox messaging with the actual operator-rights model: xcsh has the launching human account normal filesystem rights, while the session sandbox acts as a discovery guard rather than a privilege boundary.

This is a behavior-preserving wording change. It does not alter containment, sandbox backends, settings, protected paths, or filesystem permissions.

## Related Issue

Closes #3009

## Changes

- Explain the OS-user rights and discovery-guard model once in the workspace boundary prompt.
- Make enumerate-boundary refusals distinguish blocked directory listing from directly named path access.
- Align launch-flag descriptions and supplemental CLI help without claiming CWD confinement or new read/write grants.
- Add regression coverage for the prompt, refusal, and shared CLI wording.

## Verification evidence

- TDD red phase: 4 expected failures before implementation.
- Focused sandbox and CLI tests: 99 pass, 0 fail.
- `bun run check:ts`: passed.
- `bun test --cwd packages/coding-agent --max-concurrency 2`: 6,388 pass, 559 skip, 0 fail across 6,947 tests.
- `bun run test`: passed; all TypeScript packages green, Rust correctly skipped because no Rust-affecting files changed.
- `git diff --check`: passed.
- `bash scripts/agy-pre-push-review.sh`: Antigravity gate passed with no critical or high findings.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions