### PR TITLE
test(framework): enhance regression protections for knowledge and prompt templates

### DIFF
--- a/packages/coding-agent/test/internal-urls/bundled-rules.test.ts
+++ b/packages/coding-agent/test/internal-urls/bundled-rules.test.ts
@@ -15,6 +15,28 @@ describe("bundled system rules", () => {
 		expect(names).toContain("epistemic-integrity");
 	});
 
+	it("contains an embedded rule definition for every rule:// referenced in prompt templates", async () => {
+		const promptsDir = path.resolve(__dirname, "../../src/prompts");
+		const systemPromptPath = path.join(promptsDir, "system/system-prompt.md");
+		const customPromptPath = path.join(promptsDir, "system/custom-system-prompt.md");
+
+		const systemPrompt = fs.readFileSync(systemPromptPath, "utf-8");
+		const customPrompt = fs.readFileSync(customPromptPath, "utf-8");
+
+		const ruleMatches = [
+			...systemPrompt.matchAll(/rule:\/\/([a-zA-Z0-9_-]+)/g),
+			...customPrompt.matchAll(/rule:\/\/([a-zA-Z0-9_-]+)/g),
+		];
+
+		const referencedRules = new Set(ruleMatches.map(m => m[1] as string));
+		const bundledNames = new Set(getBundledRules().map(r => r.name));
+
+		expect(referencedRules.size).toBeGreaterThan(0);
+		for (const ruleName of referencedRules) {
+			expect(bundledNames.has(ruleName)).toBe(true);
+		}
+	});
+
 	it("resolves llms-search without project or user rule discovery", async () => {
 		const router = new InternalUrlRouter();
 		router.register(new RuleProtocolHandler({ getRules: getBundledRules }));

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -257,6 +257,28 @@ describe("system Handlebars prompt templates", () => {
 		expect(ruleText).toContain("Web search re-entry");
 	});
 
+	test("system-prompt and custom-system-prompt conditionally render knowledgeTopics when present", async () => {
+		const sampleTopics = "Developer Tools: xcsh, xcsh GitHub Action; Product Features: WAF";
+
+		for (const fileName of ["system-prompt.md", "custom-system-prompt.md"]) {
+			const templatePath = path.join(systemPromptsDir, fileName);
+			const template = await Bun.file(templatePath).text();
+
+			const renderedWith = prompt.render(template, {
+				...baseRenderContext,
+				knowledgeTopics: sampleTopics,
+			});
+			expect(renderedWith).toContain("Available federated F5 XC documentation topics by category:");
+			expect(renderedWith).toContain(sampleTopics);
+
+			const renderedWithout = prompt.render(template, {
+				...baseRenderContext,
+				knowledgeTopics: undefined,
+			});
+			expect(renderedWithout).not.toContain("Available federated F5 XC documentation topics by category:");
+		}
+	});
+
 	test("system-prompt carries epistemic-integrity clause against sycophantic reversal", async () => {
 		const templatePath = path.join(systemPromptsDir, "system-prompt.md");
 		const template = await Bun.file(templatePath).text();

--- a/packages/coding-agent/test/tools/fetch-llms-candidates.test.ts
+++ b/packages/coding-agent/test/tools/fetch-llms-candidates.test.ts
@@ -47,6 +47,21 @@ describe("buildLlmEndpointCandidates", () => {
 		expect(candidates).toEqual([`${origin}/mcn/llms.txt`, `${origin}/mcn/llms.md`]);
 	});
 
+	it("prioritizes French locale index before root index for localized portal pages", () => {
+		const candidates = buildLlmEndpointCandidates(`${origin}/docs/fr/waf/overview/`);
+		expect(candidates[0]).toBe(`${origin}/docs/fr/waf/overview/llms.txt`);
+		expect(candidates).toContain(`${origin}/docs/fr/llms.txt`);
+		expect(candidates.indexOf(`${origin}/docs/fr/llms.txt`)).toBeLessThan(
+			candidates.indexOf(`${origin}/docs/llms.txt`),
+		);
+	});
+
+	it("returns deduplicated unique candidates for redundant paths", () => {
+		const candidates = buildLlmEndpointCandidates(`${origin}/docs/llms.txt`);
+		const unique = new Set(candidates);
+		expect(candidates.length).toBe(unique.size);
+	});
+
 	it("returns nothing for an unparseable URL", () => {
 		expect(buildLlmEndpointCandidates("not a url")).toEqual([]);
 	});

--- a/packages/coding-agent/test/xcsh-knowledge.test.ts
+++ b/packages/coding-agent/test/xcsh-knowledge.test.ts
@@ -167,6 +167,41 @@ describe("KnowledgeService", () => {
 		expect(service.getIndex()).toBeNull();
 	});
 
+	it("handles corrupt, future-versioned, or malformed cache files gracefully", () => {
+		const service = KnowledgeService.init(testDir);
+
+		// Future schema version
+		fs.writeFileSync(
+			service.cachePath,
+			JSON.stringify({
+				schemaVersion: 99,
+				title: "Future",
+				topics: [{ name: "t", url: "https://example.com/llms.txt" }],
+				fetchedAt: NOW.toISOString(),
+			}),
+		);
+		service.loadCache();
+		expect(service.getIndex()).toBeNull();
+
+		// Malformed JSON
+		fs.writeFileSync(service.cachePath, "{ malformed json: ");
+		service.loadCache();
+		expect(service.getIndex()).toBeNull();
+
+		// Non-array topics field
+		fs.writeFileSync(
+			service.cachePath,
+			JSON.stringify({
+				schemaVersion: 2,
+				title: "Index",
+				topics: "not-an-array",
+				fetchedAt: NOW.toISOString(),
+			}),
+		);
+		service.loadCache();
+		expect(service.getIndex()).toBeNull();
+	});
+
 	it("refreshes and exposes sorted topic names", async () => {
 		using _hook = hookFetch(() => new Response(CATEGORIZED_LLMS_TXT, { status: 200 }));
 		const service = KnowledgeService.init(testDir);


### PR DESCRIPTION
Closes #3048. Enhances regression protections for prompt template rules, corrupt cache safety, knowledgeTopics rendering, and locale candidate deduplication.