### PR TITLE
fix: Issue #3060 incomplete rollback and TDD mock

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1354,6 +1354,7 @@ export class AgentSession {
 
 						const previousTier = this.#routingCoordinator.getState().currentTier;
 						const previousFloor = this.#routingCoordinator.getState().escalationFloor;
+						const previousModel = this.model;
 
 						try {
 							this.agent.abort();
@@ -1386,6 +1387,13 @@ export class AgentSession {
 								this.#routingCoordinator.getStateMachine().setEscalationFloor(previousFloor);
 							} else {
 								this.#routingCoordinator.getStateMachine().clearEscalationFloor();
+							}
+							if (previousModel) {
+								this.#setModelWithProviderSessionReset(previousModel, "runtime-switch");
+								this.sessionManager.appendModelChange(
+									`${previousModel.provider}/${previousModel.id}`,
+									"routing_switch_rollback",
+								);
 							}
 						} finally {
 							this.#scheduleAgentContinue({ delayMs: 10 });

--- a/packages/coding-agent/test/agent-session-routing-rejection.test.ts
+++ b/packages/coding-agent/test/agent-session-routing-rejection.test.ts
@@ -156,7 +156,11 @@ describe("AgentSession Routing Rejection Escalation (TDD)", () => {
 	});
 
 	it("should not immediately switch model if outcome is unsafe to continue", async () => {
-		modelRegistry.getAvailable = () => [{ provider: "openai", id: "gpt-5.4" }] as any;
+		modelRegistry.getAvailable = () =>
+			[
+				{ provider: "openai", id: "gpt-5.4" },
+				{ provider: "openai", id: "gpt-5.6-sol" },
+			] as any;
 
 		let switchCount = 0;
 		session.setModelRoutingSwitch = async () => {
@@ -174,5 +178,39 @@ describe("AgentSession Routing Rejection Escalation (TDD)", () => {
 		await session.waitForIdle();
 
 		expect(switchCount).toBe(0);
+	});
+
+	it("should restore model state if escalation swap fails", async () => {
+		modelRegistry.getAvailable = () => [{ provider: "openai", id: "gpt-5.4" }] as any;
+		session.setModelRoutingSwitch = async () => {
+			throw new Error("Simulated swap failure");
+		};
+
+		session.restoreRoutingState({ currentTier: "utility" });
+		Object.defineProperty(session, "model", {
+			get: () => ({ provider: "openai", id: "gpt-5.4-mini" }),
+			configurable: true,
+		});
+
+		let appendedModelId = "";
+		let appendedRole = "";
+		(session as any).sessionManager = {
+			appendModelChange: (modelId: string, role: string) => {
+				appendedModelId = modelId;
+				appendedRole = role;
+			},
+		} as any;
+
+		session.recordRoutingOutcome({
+			status: "rejected",
+			evidence: [{ kind: "test_failure", summary: "Failed" }],
+			safeToContinue: true,
+		});
+
+		await session.waitForIdle();
+
+		expect(session.model?.id).toBe("gpt-5.4-mini");
+		expect(appendedModelId).toBe("openai/gpt-5.4-mini");
+		expect(appendedRole).toBe("routing_switch_rollback");
 	});
 });


### PR DESCRIPTION
Closes #3060

This PR addresses the two remaining medium gaps:
- Fixes performEscalationModelSwap to properly capture and rollback the active model state when setModelRoutingSwitch() fails.
- Fixes the unsafe-outcome TDD test mock to use openai/gpt-5.6-sol so it properly reaches the safeToContinue guard.
- Adds an explicit TDD test for the rollback functionality.