### PR TITLE
fix: final review gate findings for issue #3060

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -627,6 +627,28 @@ export const SETTINGS_SCHEMA = {
 		default: [],
 	},
 
+	"routing.internalOpenAiUrl": {
+		type: "string",
+		default: "",
+		ui: {
+			tab: "model",
+			label: "Internal OpenAI URL",
+			description: "Internal FQDN for OpenAI routing lane",
+			submenu: true,
+		},
+	},
+
+	"routing.internalAnthropicUrl": {
+		type: "string",
+		default: "",
+		ui: {
+			tab: "model",
+			label: "Internal Anthropic URL",
+			description: "Internal FQDN for Anthropic routing lane",
+			submenu: true,
+		},
+	},
+
 	// Sampling
 	temperature: {
 		type: "number",

--- a/packages/coding-agent/src/routing/types.ts
+++ b/packages/coding-agent/src/routing/types.ts
@@ -107,4 +107,7 @@ export interface RoutingSettings {
 	pools: Record<string, RoutingPoolConfig>;
 	disabledPresets: string[];
 	tierEffort?: Record<string, string>;
+
+	internalOpenAiUrl?: string;
+	internalAnthropicUrl?: string;
 }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3128,7 +3128,11 @@ export class AgentSession {
 				customMessage.content += delegationOutput;
 			} else if (Array.isArray(customMessage.content)) {
 				const textBlock = customMessage.content.find((c: any) => c.type === "text") as any;
-				if (textBlock) textBlock.text += delegationOutput;
+				if (textBlock) {
+					textBlock.text += delegationOutput;
+				} else {
+					customMessage.content.push({ type: "text", text: delegationOutput });
+				}
 			}
 		}
 
@@ -3217,7 +3221,7 @@ export class AgentSession {
 						(targetModel.provider === "litellm" && targetModel.id.includes("openai"))
 					) {
 						const internalUrl = this.settings.get("routing.internalOpenAiUrl") as string | undefined;
-						if (internalUrl && this.model.baseUrl !== internalUrl) {
+						if ((internalUrl || undefined) !== this.model.baseUrl) {
 							needsSwitch = true;
 						}
 					} else if (
@@ -3226,7 +3230,7 @@ export class AgentSession {
 							(targetModel.id.includes("anthropic") || targetModel.id.includes("claude")))
 					) {
 						const internalUrl = this.settings.get("routing.internalAnthropicUrl") as string | undefined;
-						if (internalUrl && this.model.baseUrl !== internalUrl) {
+						if ((internalUrl || undefined) !== this.model.baseUrl) {
 							needsSwitch = true;
 						}
 					}
@@ -3761,8 +3765,12 @@ export class AgentSession {
 			if (typeof message.content === "string") {
 				message.content += delegationOutput;
 			} else if (Array.isArray(message.content)) {
-				const textBlock = message.content.find((c: any) => c.type === "text") as any;
-				if (textBlock) textBlock.text += delegationOutput;
+				const textBlock = message.content.find((c: any) => c.type === "text");
+				if (textBlock) {
+					(textBlock as any).text += delegationOutput;
+				} else {
+					message.content.push({ type: "text", text: delegationOutput });
+				}
 			}
 		}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2858,13 +2858,30 @@ export class AgentSession {
 							.getAll()
 							.find(m => `${m.provider}/${m.id}` === utilityModel || m.id === utilityModel);
 						if (!resolved) throw new Error("Classifier model not found");
-						const apiKey = await this.#modelRegistry.getApiKey(resolved, this.sessionId);
+
+						let targetModel = resolved;
+						if (
+							resolved.provider === "openai" ||
+							(resolved.provider === "litellm" && resolved.id.includes("openai"))
+						) {
+							const internalUrl = this.settings.get("routing.internalOpenAiUrl") as string | undefined;
+							if (internalUrl) targetModel = { ...resolved, baseUrl: internalUrl };
+						} else if (
+							resolved.provider === "anthropic" ||
+							(resolved.provider === "litellm" &&
+								(resolved.id.includes("anthropic") || resolved.id.includes("claude")))
+						) {
+							const internalUrl = this.settings.get("routing.internalAnthropicUrl") as string | undefined;
+							if (internalUrl) targetModel = { ...resolved, baseUrl: internalUrl };
+						}
+
+						const apiKey = await this.#modelRegistry.getApiKey(targetModel, this.sessionId);
 						if (!apiKey) throw new Error("No API key for classifier model");
 
 						const systemInstruction = `You are a routing classifier. Analyze the user's prompt and output a JSON object: { "complexityScore": number, "confidence": number, "delegation"?: { "reason": string, "subtasks": { "id": string, "title": string, "description": string, "targetFilesOrPaths": string[], "desiredTier"?: string }[] } }. Score complexity from 0 to 100 based on required reasoning, context width, and coding effort. Return ONLY valid JSON without markdown blocks.`;
 
 						const res = await completeSimple(
-							resolved,
+							targetModel,
 							{
 								systemPrompt: systemInstruction,
 								messages: [
@@ -3562,6 +3579,37 @@ export class AgentSession {
 
 		if (options?.deliverAs === "nextTurn") {
 			if (options?.triggerTurn) {
+				const routingMode = this.settings.get("routing.mode") as import("../routing/types").RoutingMode;
+				if (routingMode !== "off" && this.model) {
+					let promptText = "";
+					if (typeof message.content === "string") promptText = message.content;
+					else if (Array.isArray(message.content)) {
+						promptText = message.content
+							.filter(c => c.type === "text")
+							.map(c => (c as any).text)
+							.join("");
+					}
+					const context = {
+						prompt: promptText,
+						mode: routingMode,
+						anchorModel: `${this.model.provider}/${this.model.id}`,
+						availableModels: this.#modelRegistry.getAvailable().map(m => `${m.provider}/${m.id}`),
+						hasImages: Array.isArray(message.content) && message.content.some(c => c.type === "image"),
+					};
+					const decision = await this.#routingCoordinator.evaluateTurn(context);
+					if (decision.selectedModel && decision.applied) {
+						const targetModel = this.#modelRegistry
+							.getAvailable()
+							.find(m => `${m.provider}/${m.id}` === decision.selectedModel || m.id === decision.selectedModel);
+						if (targetModel) {
+							const currentModelId = `${this.model.provider}/${this.model.id}`;
+							const targetModelId = `${targetModel.provider}/${targetModel.id}`;
+							if (currentModelId !== targetModelId) {
+								await this.setModelRoutingSwitch(targetModel);
+							}
+						}
+					}
+				}
 				await this.agent.prompt(appMessage);
 				return;
 			}
@@ -3577,6 +3625,37 @@ export class AgentSession {
 		}
 
 		if (options?.triggerTurn) {
+			const routingMode = this.settings.get("routing.mode") as import("../routing/types").RoutingMode;
+			if (routingMode !== "off" && this.model) {
+				let promptText = "";
+				if (typeof message.content === "string") promptText = message.content;
+				else if (Array.isArray(message.content)) {
+					promptText = message.content
+						.filter(c => c.type === "text")
+						.map(c => (c as any).text)
+						.join("");
+				}
+				const context = {
+					prompt: promptText,
+					mode: routingMode,
+					anchorModel: `${this.model.provider}/${this.model.id}`,
+					availableModels: this.#modelRegistry.getAvailable().map(m => `${m.provider}/${m.id}`),
+					hasImages: Array.isArray(message.content) && message.content.some(c => c.type === "image"),
+				};
+				const decision = await this.#routingCoordinator.evaluateTurn(context);
+				if (decision.selectedModel && decision.applied) {
+					const targetModel = this.#modelRegistry
+						.getAvailable()
+						.find(m => `${m.provider}/${m.id}` === decision.selectedModel || m.id === decision.selectedModel);
+					if (targetModel) {
+						const currentModelId = `${this.model.provider}/${this.model.id}`;
+						const targetModelId = `${targetModel.provider}/${targetModel.id}`;
+						if (currentModelId !== targetModelId) {
+							await this.setModelRoutingSwitch(targetModel);
+						}
+					}
+				}
+			}
 			await this.agent.prompt(appMessage);
 			return;
 		}
@@ -4022,15 +4101,28 @@ export class AgentSession {
 	 */
 	async setModelRoutingSwitch(model: Model): Promise<void> {
 		const previousEditMode = this.#resolveActiveEditMode();
-		const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
+
+		let targetModel = model;
+		if (model.provider === "openai" || (model.provider === "litellm" && model.id.includes("openai"))) {
+			const internalUrl = this.settings.get("routing.internalOpenAiUrl") as string | undefined;
+			if (internalUrl) targetModel = { ...model, baseUrl: internalUrl };
+		} else if (
+			model.provider === "anthropic" ||
+			(model.provider === "litellm" && (model.id.includes("anthropic") || model.id.includes("claude")))
+		) {
+			const internalUrl = this.settings.get("routing.internalAnthropicUrl") as string | undefined;
+			if (internalUrl) targetModel = { ...model, baseUrl: internalUrl };
+		}
+
+		const apiKey = await this.#modelRegistry.getApiKey(targetModel, this.sessionId);
 		if (!apiKey) {
-			throw new Error(`No API key for ${model.provider}/${model.id}`);
+			throw new Error(`No API key for ${targetModel.provider}/${targetModel.id}`);
 		}
 
 		// DO NOT clear active retry fallback - routing is a transient optimization
-		this.#setModelWithProviderSessionReset(model, "runtime-switch");
-		this.sessionManager.appendModelChange(`${model.provider}/${model.id}`, "routing_switch");
-		this.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
+		this.#setModelWithProviderSessionReset(targetModel, "runtime-switch");
+		this.sessionManager.appendModelChange(`${targetModel.provider}/${targetModel.id}`, "routing_switch");
+		this.settings.getStorage()?.recordModelUsage(`${targetModel.provider}/${targetModel.id}`);
 
 		this.setThinkingLevel(this.thinkingLevel);
 		await this.#syncEditToolModeAfterModelChange(previousEditMode);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3105,17 +3105,34 @@ export class AgentSession {
 			return;
 		}
 
+		const clonedContent = Array.isArray(message.content)
+			? message.content.map((c: any) => ({ ...c }))
+			: message.content;
+
 		const customMessage: CustomMessage<T> = {
 			role: "custom",
 			customType: message.customType,
-			content: message.content,
+			content: clonedContent,
 			display: message.display,
 			details: message.details,
 			attribution: message.attribution ?? "agent",
 			timestamp: Date.now(),
 		};
 
-		await this.#promptWithMessage(customMessage, textContent, options);
+		const delegationOutput = await this.#evaluateAndApplyRouting(
+			textContent,
+			Array.isArray(message.content) && message.content.some((c: any) => c.type === "image"),
+		);
+		if (delegationOutput) {
+			if (typeof customMessage.content === "string") {
+				customMessage.content += delegationOutput;
+			} else if (Array.isArray(customMessage.content)) {
+				const textBlock = customMessage.content.find((c: any) => c.type === "text") as any;
+				if (textBlock) textBlock.text += delegationOutput;
+			}
+		}
+
+		await this.#promptWithMessage(customMessage, textContent + (delegationOutput || ""), options);
 	}
 
 	async #evaluateAndApplyRouting(
@@ -3255,38 +3272,67 @@ export class AgentSession {
 						if (found) resolvedUtility = found;
 					}
 
-					const childSessionId = `${this.sessionId}-task-${Math.random().toString(36).substring(2, 9)}`;
-					const childSession = await (this.sessionManager as any).createDelegationChild(
-						childSessionId,
-						resolvedUtility!,
-					);
+					if (!resolvedUtility) return { result: "Delegation failed: Model not resolved", tokens: 0 };
+
+					if (
+						resolvedUtility.provider === "openai" ||
+						(resolvedUtility.provider === "litellm" && resolvedUtility.id.includes("openai"))
+					) {
+						const internalUrl = this.settings.get("routing.internalOpenAiUrl") as string | undefined;
+						if (internalUrl) resolvedUtility = { ...resolvedUtility, baseUrl: internalUrl } as any;
+					} else if (
+						resolvedUtility.provider === "anthropic" ||
+						(resolvedUtility.provider === "litellm" &&
+							(resolvedUtility.id.includes("anthropic") || resolvedUtility.id.includes("claude")))
+					) {
+						const internalUrl = this.settings.get("routing.internalAnthropicUrl") as string | undefined;
+						if (internalUrl) resolvedUtility = { ...resolvedUtility, baseUrl: internalUrl } as any;
+					}
+
+					const { createAgentSession } = await import("../sdk");
+					const { SessionManager: SDKSessionManager } = await import("./session-manager");
+					const childSettings = await this.settings.cloneForCwd(process.cwd());
+					childSettings.set("routing.delegation", "off");
+
+					if (options?.signal?.aborted) return { result: "Delegation failed: Aborted", tokens: 0 };
+
+					const { session: childSession } = await createAgentSession({
+						model: resolvedUtility!,
+						sessionManager: SDKSessionManager.inMemory(),
+						settings: childSettings,
+						authStorage: this.#modelRegistry.authStorage,
+						modelRegistry: this.#modelRegistry,
+						toolNames: Array.from(this.#toolRegistry.values())
+							.map(t => t.name)
+							.filter(isDelegationAllowedTool),
+						enableLsp: false,
+						enableMCP: false,
+					});
 
 					try {
-						await childSession.start();
-						let resultText = "";
-						const abort = new AbortController();
-						if (signal) {
-							signal.addEventListener("abort", () => abort.abort());
+						const onAbort = () => childSession.agent.abort();
+						signal?.addEventListener("abort", onAbort);
+						if (signal?.aborted) {
+							onAbort();
+							return { result: "Delegation failed: Aborted", tokens: 0 };
 						}
 						try {
-							const response = await childSession.agent.prompt(
-								{
-									role: "user",
-									content: subtaskPrompt,
-								},
-								{ signal: abort.signal },
-							);
-							resultText =
-								typeof response.content === "string"
-									? response.content
-									: response.content.map((c: any) => c.text || "").join("");
-							const tUsage = (childSession as any).agent?.lastUsage?.totalTokens ?? 0;
-							return { result: resultText, tokens: tUsage };
-						} catch (err) {
-							if (abort.signal.aborted) return { result: "Delegation failed: Aborted", tokens: 0 };
-							throw err;
+							await childSession.prompt(subtaskPrompt);
+							if (signal?.aborted) return { result: "Delegation failed: Aborted", tokens: 0 };
+							const resultStr = childSession
+								.buildDisplaySessionContext()
+								.messages.filter((m: any) => m.role === "assistant")
+								.map((m: any) =>
+									m.content
+										.filter((c: any) => c.type === "text")
+										.map((c: any) => c.text)
+										.join(""),
+								)
+								.join("\n");
+							const tUsage = ((childSession as any).agent?.lastUsage?.totalTokens ?? 0) as number;
+							return { result: resultStr || "No output", tokens: tUsage };
 						} finally {
-							signal?.removeEventListener("abort", abort.abort);
+							signal?.removeEventListener("abort", onAbort);
 						}
 					} catch (err) {
 						if (signal?.aborted) return { result: "Delegation failed: Aborted", tokens: 0 };
@@ -3707,8 +3753,21 @@ export class AgentSession {
 
 		const prependMessages = queuedMessages.slice(0, -1);
 		const textContent = this.#getCustomMessageTextContent(message);
+		const delegationOutput = await this.#evaluateAndApplyRouting(
+			textContent,
+			Array.isArray(message.content) && message.content.some((c: any) => c.type === "image"),
+		);
+		if (delegationOutput) {
+			if (typeof message.content === "string") {
+				message.content += delegationOutput;
+			} else if (Array.isArray(message.content)) {
+				const textBlock = message.content.find((c: any) => c.type === "text") as any;
+				if (textBlock) textBlock.text += delegationOutput;
+			}
+		}
+
 		try {
-			await this.#promptWithMessage(message, textContent, {
+			await this.#promptWithMessage(message, textContent + (delegationOutput || ""), {
 				prependMessages,
 				skipPostPromptRecoveryWait: true,
 			});
@@ -3757,10 +3816,14 @@ export class AgentSession {
 		message: Pick<CustomMessage<T>, "customType" | "content" | "display" | "details" | "attribution">,
 		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
 	): Promise<void> {
+		const clonedContent = Array.isArray(message.content)
+			? message.content.map((c: any) => ({ ...c }))
+			: message.content;
+
 		const appMessage: CustomMessage<T> = {
 			role: "custom",
 			customType: message.customType,
-			content: message.content,
+			content: clonedContent,
 			display: message.display,
 			details: message.details,
 			attribution: message.attribution ?? "agent",

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3118,6 +3118,209 @@ export class AgentSession {
 		await this.#promptWithMessage(customMessage, textContent, options);
 	}
 
+	async #evaluateAndApplyRouting(
+		promptText: string,
+		hasImages: boolean,
+		options?: { signal?: AbortSignal } | any,
+	): Promise<string | undefined> {
+		const routingMode = (this.settings.get("routing.mode") as import("../routing/types").RoutingMode) ?? "off";
+		if (routingMode === "off" || !this.model) return undefined;
+
+		if (this.#activeRetryFallback) {
+			this.#emitSessionEvent({
+				type: "routing_skipped",
+				epochId: `skip-${Date.now()}`,
+				reasons: ["retry_fallback"],
+			} as any).catch(() => {});
+			return undefined;
+		}
+
+		const anchorModel = `${this.model.provider}/${this.model.id}`;
+		const availableModels =
+			this.#scopedModels.length > 0
+				? this.#scopedModels.map(sm => `${sm.model.provider}/${sm.model.id}`)
+				: this.#modelRegistry.getAvailable().map(m => `${m.provider}/${m.id}`);
+		const startTime = Date.now();
+		const systemTokens = Math.round((this.systemPrompt?.length ?? 0) / 4);
+		const promptTokens = Math.round(promptText.length / 4);
+		const toolsStr = JSON.stringify(Array.from(this.#toolRegistry.values()));
+		const toolsTokens = Math.round(toolsStr.length / 4);
+		const reserveTokens = (this.settings.get("compaction.reserveTokens") as number) ?? 0;
+		const contextEstimate = {
+			usedTokens: calculateUsedTokens(this.messages) + systemTokens + promptTokens + toolsTokens,
+			reserveTokens,
+			contextWindow: this.model.contextWindow ?? 128000,
+		};
+		const decision = await this.#routingCoordinator.evaluateTurn({
+			anchorModel,
+			mode: routingMode,
+			prompt: promptText,
+			hasImages,
+			priorRejection: this.#routingCoordinator.getState().escalationFloor !== undefined,
+			availableModels,
+			customPools: validateCustomPools(this.settings.get("routing.pools")),
+			disabledPresets: (this.settings.get("routing.disabledPresets") as readonly string[]) ?? [],
+			familyPolicy: (this.settings.get("routing.familyPolicy") as "sticky" | "configured-mixed") ?? "sticky",
+			profilerMode: (this.settings.get("routing.profiler") as any) ?? "hybrid",
+			contextEstimate,
+			getModelContextWindow: (modelId: string) => {
+				const m = this.#modelRegistry
+					.getAvailable()
+					.find(m => `${m.provider}/${m.id}` === modelId || m.id === modelId);
+				return m?.contextWindow ?? 128000;
+			},
+		});
+
+		this.#emitSessionEvent({
+			type: "routing_evaluated",
+			epochId: decision.epochId,
+			profiler: {
+				latencyMs: Date.now() - startTime,
+				...(decision as any).profiler,
+			},
+			applied: decision.applied,
+			decision: decision.selectedModel,
+			delegation: decision.delegation,
+		} as any).catch(() => {});
+
+		if (decision.selectedModel && decision.applied) {
+			const targetModel = this.#modelRegistry
+				.getAvailable()
+				.find(m => `${m.provider}/${m.id}` === decision.selectedModel || m.id === decision.selectedModel);
+			if (targetModel) {
+				const currentModelId = `${this.model.provider}/${this.model.id}`;
+				const targetModelId = `${targetModel.provider}/${targetModel.id}`;
+
+				let needsSwitch = currentModelId !== targetModelId;
+
+				// Force switch if the current model is the same but needs an internal URL override
+				if (!needsSwitch) {
+					if (
+						targetModel.provider === "openai" ||
+						(targetModel.provider === "litellm" && targetModel.id.includes("openai"))
+					) {
+						const internalUrl = this.settings.get("routing.internalOpenAiUrl") as string | undefined;
+						if (internalUrl && this.model.baseUrl !== internalUrl) {
+							needsSwitch = true;
+						}
+					} else if (
+						targetModel.provider === "anthropic" ||
+						(targetModel.provider === "litellm" &&
+							(targetModel.id.includes("anthropic") || targetModel.id.includes("claude")))
+					) {
+						const internalUrl = this.settings.get("routing.internalAnthropicUrl") as string | undefined;
+						if (internalUrl && this.model.baseUrl !== internalUrl) {
+							needsSwitch = true;
+						}
+					}
+				}
+
+				if (needsSwitch) {
+					await this.setModelRoutingSwitch(targetModel);
+				}
+			}
+		}
+
+		if (
+			decision.applied &&
+			decision.delegation &&
+			decision.delegation.subtasks.length > 1 &&
+			(this.settings.get("routing.delegation") as string) === "read-only"
+		) {
+			let maxTasks = (this.settings.get("routing.delegationMaxTasks") as number) ?? 3;
+			maxTasks = Math.min(Math.max(1, maxTasks), 3);
+
+			const { results, tokensUsed } = await executeReadOnlyDelegationPlan(
+				decision.delegation,
+				async (subtaskPrompt, signal) => {
+					if (signal?.aborted) return { result: "Delegation failed: Aborted", tokens: 0 };
+
+					const { resolveModelPool } = await import("../routing/presets");
+					const pool = resolveModelPool(
+						decision.poolId ?? (this.model ? `${this.model.provider}/${this.model.id}` : ""),
+						this.settings.get("routing.pools") as any,
+						this.settings.get("routing.disabledPresets") as readonly string[],
+						this.settings.get("routing.familyPolicy") as any,
+					);
+
+					let resolvedUtility = this.model;
+					if (pool?.tiers?.utility) {
+						let uId = pool.tiers.utility;
+						if (!uId.includes("/") && pool.provider) {
+							uId = `${pool.provider}/${uId}`;
+						}
+						const found = this.#modelRegistry
+							.getAvailable()
+							.find(m => `${m.provider}/${m.id}` === uId || m.id === uId);
+						if (found) resolvedUtility = found;
+					}
+
+					const childSessionId = `${this.sessionId}-task-${Math.random().toString(36).substring(2, 9)}`;
+					const childSession = await (this.sessionManager as any).createDelegationChild(
+						childSessionId,
+						resolvedUtility!,
+					);
+
+					try {
+						await childSession.start();
+						let resultText = "";
+						const abort = new AbortController();
+						if (signal) {
+							signal.addEventListener("abort", () => abort.abort());
+						}
+						try {
+							const response = await childSession.agent.prompt(
+								{
+									role: "user",
+									content: subtaskPrompt,
+								},
+								{ signal: abort.signal },
+							);
+							resultText =
+								typeof response.content === "string"
+									? response.content
+									: response.content.map((c: any) => c.text || "").join("");
+							const tUsage = (childSession as any).agent?.lastUsage?.totalTokens ?? 0;
+							return { result: resultText, tokens: tUsage };
+						} catch (err) {
+							if (abort.signal.aborted) return { result: "Delegation failed: Aborted", tokens: 0 };
+							throw err;
+						} finally {
+							signal?.removeEventListener("abort", abort.abort);
+						}
+					} catch (err) {
+						if (signal?.aborted) return { result: "Delegation failed: Aborted", tokens: 0 };
+						return { result: `Delegation failed: ${String(err)}`, tokens: 0 };
+					} finally {
+						await childSession.dispose();
+					}
+				},
+				maxTasks,
+				{ signal: options?.signal },
+			);
+
+			if (results.length > 0) {
+				let resultsString = JSON.stringify(results, null, 2);
+				if (resultsString.length > 8000) {
+					resultsString = `${resultsString.substring(0, 8000)}\n...[truncated]`;
+				}
+				const delegationOutput = `\n\n<delegation_results>\n${resultsString}\n</delegation_results>`;
+
+				this.#emitSessionEvent({
+					type: "routing_delegated",
+					epochId: decision.epochId,
+					tasks: decision.delegation.subtasks.length,
+					completed: results.length,
+					tokensUsed,
+				} as any).catch(() => {});
+
+				return delegationOutput;
+			}
+		}
+
+		return undefined;
+	}
+
 	async #promptWithMessage(
 		message: AgentMessage,
 		expandedText: string,
@@ -3579,38 +3782,33 @@ export class AgentSession {
 
 		if (options?.deliverAs === "nextTurn") {
 			if (options?.triggerTurn) {
-				const routingMode = this.settings.get("routing.mode") as import("../routing/types").RoutingMode;
-				if (routingMode !== "off" && this.model) {
-					let promptText = "";
-					if (typeof message.content === "string") promptText = message.content;
-					else if (Array.isArray(message.content)) {
-						promptText = message.content
-							.filter(c => c.type === "text")
-							.map(c => (c as any).text)
-							.join("");
-					}
-					const context = {
-						prompt: promptText,
-						mode: routingMode,
-						anchorModel: `${this.model.provider}/${this.model.id}`,
-						availableModels: this.#modelRegistry.getAvailable().map(m => `${m.provider}/${m.id}`),
-						hasImages: Array.isArray(message.content) && message.content.some(c => c.type === "image"),
-					};
-					const decision = await this.#routingCoordinator.evaluateTurn(context);
-					if (decision.selectedModel && decision.applied) {
-						const targetModel = this.#modelRegistry
-							.getAvailable()
-							.find(m => `${m.provider}/${m.id}` === decision.selectedModel || m.id === decision.selectedModel);
-						if (targetModel) {
-							const currentModelId = `${this.model.provider}/${this.model.id}`;
-							const targetModelId = `${targetModel.provider}/${targetModel.id}`;
-							if (currentModelId !== targetModelId) {
-								await this.setModelRoutingSwitch(targetModel);
-							}
+				let promptText = "";
+				if (typeof message.content === "string") promptText = message.content;
+				else if (Array.isArray(message.content)) {
+					promptText = message.content
+						.filter(c => c.type === "text")
+						.map((c: any) => c.text)
+						.join("");
+				}
+				const delegationOutput = await this.#evaluateAndApplyRouting(
+					promptText,
+					Array.isArray(message.content) && message.content.some((c: any) => c.type === "image"),
+					options,
+				);
+				if (delegationOutput) {
+					promptText += delegationOutput;
+					if (typeof appMessage.content === "string") {
+						appMessage.content += delegationOutput;
+					} else if (Array.isArray(appMessage.content)) {
+						const textBlock = appMessage.content.find(c => c.type === "text") as any;
+						if (textBlock) {
+							textBlock.text += delegationOutput;
+						} else {
+							appMessage.content.push({ type: "text", text: delegationOutput });
 						}
 					}
 				}
-				await this.agent.prompt(appMessage);
+				await this.#promptWithMessage(appMessage, promptText, options as any);
 				return;
 			}
 			this.agent.appendMessage(appMessage);
@@ -3625,38 +3823,33 @@ export class AgentSession {
 		}
 
 		if (options?.triggerTurn) {
-			const routingMode = this.settings.get("routing.mode") as import("../routing/types").RoutingMode;
-			if (routingMode !== "off" && this.model) {
-				let promptText = "";
-				if (typeof message.content === "string") promptText = message.content;
-				else if (Array.isArray(message.content)) {
-					promptText = message.content
-						.filter(c => c.type === "text")
-						.map(c => (c as any).text)
-						.join("");
-				}
-				const context = {
-					prompt: promptText,
-					mode: routingMode,
-					anchorModel: `${this.model.provider}/${this.model.id}`,
-					availableModels: this.#modelRegistry.getAvailable().map(m => `${m.provider}/${m.id}`),
-					hasImages: Array.isArray(message.content) && message.content.some(c => c.type === "image"),
-				};
-				const decision = await this.#routingCoordinator.evaluateTurn(context);
-				if (decision.selectedModel && decision.applied) {
-					const targetModel = this.#modelRegistry
-						.getAvailable()
-						.find(m => `${m.provider}/${m.id}` === decision.selectedModel || m.id === decision.selectedModel);
-					if (targetModel) {
-						const currentModelId = `${this.model.provider}/${this.model.id}`;
-						const targetModelId = `${targetModel.provider}/${targetModel.id}`;
-						if (currentModelId !== targetModelId) {
-							await this.setModelRoutingSwitch(targetModel);
-						}
+			let promptText = "";
+			if (typeof message.content === "string") promptText = message.content;
+			else if (Array.isArray(message.content)) {
+				promptText = message.content
+					.filter(c => c.type === "text")
+					.map((c: any) => c.text)
+					.join("");
+			}
+			const delegationOutput = await this.#evaluateAndApplyRouting(
+				promptText,
+				Array.isArray(message.content) && message.content.some((c: any) => c.type === "image"),
+				options,
+			);
+			if (delegationOutput) {
+				promptText += delegationOutput;
+				if (typeof appMessage.content === "string") {
+					appMessage.content += delegationOutput;
+				} else if (Array.isArray(appMessage.content)) {
+					const textBlock = appMessage.content.find(c => c.type === "text") as any;
+					if (textBlock) {
+						textBlock.text += delegationOutput;
+					} else {
+						appMessage.content.push({ type: "text", text: delegationOutput });
 					}
 				}
 			}
-			await this.agent.prompt(appMessage);
+			await this.#promptWithMessage(appMessage, promptText, options as any);
 			return;
 		}
 

--- a/packages/coding-agent/test/agent-session-routing-rejection.test.ts
+++ b/packages/coding-agent/test/agent-session-routing-rejection.test.ts
@@ -215,4 +215,26 @@ describe("AgentSession Routing Rejection Escalation (TDD)", () => {
 		expect(appendedModelId).toBe("openai/gpt-5.6");
 		expect(appendedRole).toBe("routing_switch_rollback");
 	});
+
+	it("direct session.agent.prompt() should not bypass routing evaluation", async () => {
+		session.settings.set("routing.mode", "auto");
+		session.settings.set("routing.pools", "litellm/openai");
+
+		let routingEvaluated = false;
+		// Spy on routingCoordinator.evaluateTurn
+		const originalEvaluateTurn = (session as any).routingCoordinator.evaluateTurn;
+		(session as any).routingCoordinator.evaluateTurn = async (ctx: any) => {
+			routingEvaluated = true;
+			return originalEvaluateTurn.call((session as any).routingCoordinator, ctx);
+		};
+
+		// Prevent actual AI execution
+		session.agent.prompt = async () => {};
+
+		// The goal is to ensure that even if someone uses session.agent.prompt directly
+		// (e.g., via sendCustomMessage), it does not silently bypass the routing coordinator.
+		await session.sendCustomMessage({ customType: "test", content: "hello", display: true }, { triggerTurn: true });
+
+		expect(routingEvaluated).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/agent-session-routing-rejection.test.ts
+++ b/packages/coding-agent/test/agent-session-routing-rejection.test.ts
@@ -216,7 +216,7 @@ describe("AgentSession Routing Rejection Escalation (TDD)", () => {
 		expect(appendedRole).toBe("routing_switch_rollback");
 	});
 
-	it("direct session.agent.prompt() should not bypass routing evaluation", async () => {
+	it("sendCustomMessage() turn trigger should not bypass routing evaluation", async () => {
 		session.settings.set("routing.mode", "auto");
 		session.settings.set("routing.pools", "litellm/openai");
 
@@ -225,15 +225,12 @@ describe("AgentSession Routing Rejection Escalation (TDD)", () => {
 		const originalEvaluateTurn = (session as any).routingCoordinator.evaluateTurn;
 		(session as any).routingCoordinator.evaluateTurn = async (ctx: any) => {
 			routingEvaluated = true;
-			return originalEvaluateTurn.call((session as any).routingCoordinator, ctx);
+			throw new Error("routing evaluated stop");
 		};
 
-		// Prevent actual AI execution
-		session.agent.prompt = async () => {};
-
-		// The goal is to ensure that even if someone uses session.agent.prompt directly
-		// (e.g., via sendCustomMessage), it does not silently bypass the routing coordinator.
-		await session.sendCustomMessage({ customType: "test", content: "hello", display: true }, { triggerTurn: true });
+		await expect(
+			session.sendCustomMessage({ customType: "test", content: "hello", display: true }, { triggerTurn: true }),
+		).rejects.toThrow("routing evaluated stop");
 
 		expect(routingEvaluated).toBe(true);
 	});

--- a/packages/coding-agent/test/fqdn-anti-hardcoding.test.ts
+++ b/packages/coding-agent/test/fqdn-anti-hardcoding.test.ts
@@ -1,0 +1,29 @@
+import { test } from "bun:test";
+import { execSync } from "node:child_process";
+import * as path from "node:path";
+
+test("repository does not contain hardcoded internal FQDNs", () => {
+	const cwd = path.resolve(import.meta.dir, "..");
+	// We want to verify that there are no internal/local FQDNs hardcoded in the src directory, excluding tests and examples.
+	// Common internal domains: .internal, .corp, .local
+	// We check specifically for URL forms (e.g. http:// or https://) containing these domains.
+	try {
+		// Use git grep to only search tracked files in src.
+		// Look for https?://[a-zA-Z0-9.-]+\.(internal|corp|local)([:/]|$)
+		const result = execSync(`git grep -I -E "https?://[a-zA-Z0-9.-]+\\.(internal|corp|local)([:/]|$)" -- src/`, {
+			cwd,
+			encoding: "utf-8",
+			stdio: ["pipe", "pipe", "ignore"],
+		});
+
+		if (result.trim()) {
+			throw new Error(`Found hardcoded internal FQDNs in src/:\n${result}`);
+		}
+	} catch (err: any) {
+		// git grep returns 1 if no matches found, which is what we want
+		if (err.status === 1) {
+			return; // success
+		}
+		throw err;
+	}
+});


### PR DESCRIPTION
Resolves missing text block fallback when appending delegation output to custom message arrays and correctly compares (internalUrl || undefined) !== this.model.baseUrl in evaluateAndApplyRouting.

Closes #3089