### PR TITLE
feat: complete subscription model routing profiles

### DIFF
--- a/docs/plans/provider-agnostic-dynamic-model-routing.md
+++ b/docs/plans/provider-agnostic-dynamic-model-routing.md
@@ -4,13 +4,15 @@
 
 The production router is implemented at the `AgentSession` boundary. It supports explicit provider-qualified pools, utility/balanced/frontier tiers, off/shadow/auto modes, deterministic and hybrid classification, context eligibility, hysteresis, manual pins, escalation and rollback, read-only delegation, persistence, telemetry, and route commands.
 
-The authenticated routing-matrix harness has been redesigned under issue #3114. Its deterministic and mocked-network evidence is authoritative for code paths, but the project is not empirically complete until a clean exact-`origin/main` report proves all five required lanes through real authenticated inference.
+The authenticated routing-matrix harness was redesigned under issue #3114 and extended for subscription routing under issue #3129. The implementation now has provider-sticky Google Antigravity and OpenAI Codex profiles, entitlement-scoped inventory discovery through xcsh's existing OAuth storage, tier-specific reasoning effort, and response-body attribution for both transports. Its deterministic and mocked-network evidence is authoritative for code paths, but this iteration is not empirically complete until a clean exact-`origin/main` report proves the two subscription lanes through real authenticated inference.
 
 CI, unit tests, dry runs, bundled catalog entries, missing-credential BLOCKED results, and completion-auditor statements are not live acceptance evidence.
 
 ## Scope and non-goals
 
-The canonical profile requires direct OpenAI, direct Anthropic, LiteLLM OpenAI-family, LiteLLM Anthropic-family, and an explicitly configured Google Vertex pool. Four scenarios and three repetitions produce 60 measured rows; one warmup per lane produces five warmup rows.
+The legacy `canonical` benchmark profile retains direct OpenAI, direct Anthropic, LiteLLM OpenAI-family, LiteLLM Anthropic-family, and explicitly configured Google Vertex lanes. The `subscription` profile is the scope of issue #3129 and contains only Google Antigravity and OpenAI Codex. LiteLLM inference is explicitly out of scope for this iteration and must not be run as part of its UAT.
+
+The Google profile maps `smol` and `default` to `google-antigravity/gemini-3.6-flash-high:high`, and `slow` and `plan` to `google-antigravity/gemini-3.1-pro-high-vertex:high`. The Codex profile maps utility to Luna/low, balanced to Terra/medium, and frontier to Sol/high, with Sol/xhigh for a prior rejection or a complexity score of at least 90. Both profiles are provider-sticky and apply atomically only when every required model appears in fresh authenticated entitlement inventory.
 
 Other providers may opt in only through explicit capability and tier-pool configuration. Untiered providers remain on their selected model. Model names never imply tiers.
 
@@ -57,6 +59,8 @@ CLI profile
 | `litellm-openai` | OpenAI-compatible | OpenAI | `litellm/openai` | Its own authenticated LiteLLM endpoint | Lane-specific key/base URL, then xcsh LiteLLM resolver | Endpoint, request, client, raw response model; upstream provider may be unproven |
 | `litellm-anthropic` | Anthropic Messages-compatible | Anthropic | `litellm/anthropic` | Its own authenticated LiteLLM endpoint | Separate Anthropic-compatible base URL and LiteLLM credential | Endpoint, request, client, raw response model; upstream provider may be unproven |
 | `google-vertex` | Vertex | Google | `google-vertex/gemini` | Authenticated Model Garden publisher list | Real ADC access token and project/location | Endpoint, request, and client; the current SDK stream does not expose a response-reported model |
+| `google-antigravity` | Gemini CLI/Antigravity | Google | Flash for normal work, Pro for planning | Fresh authenticated Antigravity entitlement discovery | Existing xcsh OAuth credential resolver | Endpoint, requested alias, client, and response-reported Vertex model version; upstream infrastructure is not inferred |
+| `openai-codex` | ChatGPT Codex Responses | OpenAI | `openai-codex/gpt-5.6` | Fresh authenticated Codex entitlement discovery | Existing xcsh OAuth credential and account resolver | Endpoint, requested model, client, and response-body model; upstream infrastructure is not inferred |
 
 Lane identity is independent of provider name. This keeps direct Anthropic and Anthropic-over-LiteLLM distinct.
 
@@ -71,7 +75,9 @@ Four inventories remain distinct:
 3. Models returned by the lane's authenticated live endpoint.
 4. Eligible candidates: configured tiers intersected with that same lane's live inventory and runtime constraints.
 
-All three tiers must exist for every canonical lane. Candidate inventories are never combined across endpoints.
+All configured models must exist for every active lane. Google intentionally maps both utility and balanced tiers to the same Flash entitlement; this is one explicit relationship, not a fabricated third model. Candidate inventories are never combined across endpoints.
+
+Subscription discovery uses the existing `ModelRegistry` provider adapters. Only `status: ok`, `stale: false` entitlement responses satisfy live acceptance. Cached data, bundled models, partial model metadata, unsupported adapters, and failed refreshes remain BLOCKED or FAIL and cannot make a configured model eligible.
 
 Inventory states are `AVAILABLE`, `BLOCKED_AUTH`, `BLOCKED_NETWORK`, `BLOCKED_RATE_LIMIT`, `UNSUPPORTED_DISCOVERY`, `FAIL_SCHEMA`, `FAIL_EMPTY_INVENTORY`, and `FAIL_MISSING_TIERS`. Dry-run inventory is `SIMULATED`. No failed live state falls back to bundled success.
 
@@ -89,7 +95,7 @@ Statuses:
 - `SKIPPED_UNTIERED`: optional provider has no configured pool; illegal for canonical required lanes.
 - `SIMULATED`: dry-run row; never counted as PASS.
 
-Default counts are five warmups and 60 measured rows. `matrixComplete` requires exact counts and every live inventory, warmup, and measured row PASS. `authoritative` additionally requires non-dry execution, clean exact final HEAD, positive usage, declared response attribution, schema validation, recursive redaction, and secret-scan success.
+The canonical defaults remain five warmups and 60 measured rows. The subscription profile defaults to two warmups and 24 measured rows (two lanes × four scenarios × three repetitions). `matrixComplete` requires exact counts and every live inventory, warmup, and measured row PASS. `authoritative` additionally requires non-dry execution, clean exact final HEAD, positive usage, declared response attribution, schema validation, recursive redaction, and secret-scan success.
 
 Exit codes are 0 for successful requested-mode execution, 1 for behavior/schema/security failure, 2 for an environmentally BLOCKED or incomplete required matrix, and 64 for invalid CLI configuration. A successful dry run may exit 0 but remains non-complete and non-authoritative.
 
@@ -101,18 +107,18 @@ Every behavior is introduced with a failing focused test, minimal implementation
 
 Mocked HTTP coverage includes successful provider schemas, empty inventory, missing tiers, 401, 403, 404, 429, 500, malformed JSON, DNS/network failure, timeout/abort, ADC, OAuth/API-key headers, no bundled fallback, redaction, attribution gaps, warmup failures, and partial/all-BLOCKED contracts.
 
-Paid UAT is staged:
+Authenticated UAT is staged to isolate failures even when usage is not budget-constrained:
 
 1. Stage A: unit tests, mocked HTTP, type/lint checks, dry run, schema validation, and secret tests.
-2. Stage B: LiteLLM OpenAI utility with one warmup and one repetition; then balanced/frontier only after success.
-3. Stage C: both LiteLLM lanes, one warmup and one repetition per scenario.
-4. Stage D: final clean `origin/main`, all five lanes, five warmups, 60 measured rows, recursive scan.
+2. Stage B: Google Antigravity utility with one warmup and one repetition, followed by its frontier planning scenario.
+3. Stage C: OpenAI Codex utility, balanced, and frontier scenarios with one warmup and one repetition; confirm low/medium/high and a separate xhigh escalation test.
+4. Stage D: both subscription lanes on clean exact `origin/main`, two warmups, 24 measured rows, schema validation, and recursive scan.
 
-The complete paid matrix is never used as a debugging loop.
+The complete authenticated matrix is not used as a debugging loop. No LiteLLM lane is invoked in this iteration.
 
 ## Reporting, security, and rollout
 
-Schema-v2 reports record Git state, parameters, capability declarations, sanitized endpoint fingerprints, inventory reconciliation, first-class warmups and measurements, timestamps, durations, usage, attribution sources, counts, authority, and security state. Reports are written outside the repository with mode 0600.
+Schema-v3 reports record the selected benchmark profile, Git state, parameters, capability declarations, sanitized endpoint fingerprints, inventory reconciliation, first-class warmups and measurements, selected effort and reason, timestamps, durations, usage, attribution sources, counts, authority, and security state. Reports are written outside the repository with mode 0600.
 
 The writer recursively redacts resolved secrets, credential-shaped fields, authorization values, URL credentials, query tokens, and credential paths. It validates the final candidate against the checked-in schema, scans the exact bytes with Gitleaks, atomically publishes unchanged bytes, and writes a SHA-256 receipt. Scan failure publishes no report and exits 1.
 
@@ -183,42 +189,70 @@ Operational rollout remains off by default, then shadow, then per-lane automatic
   - Required artifact: command logs and dry-run report.
   - Completion claim: Stage A is green before any paid call is attempted.
   - Reviewer evidence: coding-agent 6,529 pass/559 skip/0 fail; AI package and focused suites pass; check and dry run exit zero.
-- [ ] RM-10 Stage B authenticated LiteLLM OpenAI smoke
-  - Implementation target: `litellm-openai`, one warmup, utility at one repetition, then balanced/frontier only after utility passes.
-  - Failing test: the first authenticated smoke must expose any endpoint, inventory, attribution, or inference defect.
-  - Verification command: `bun run bench:routing-matrix --lanes litellm-openai --scenarios utility-greeting --warmups 1 --repetitions 1`.
-  - Required artifact: clean, redacted smoke report outside the repository.
-  - Completion claim: live inventory, warmup, and utility measurement all PASS with valid usage and required attribution.
-  - Reviewer evidence: blocked on 2026-08-11 because neither LiteLLM endpoint nor credential is configured; no paid call was made.
-- [ ] RM-11 Stage C two-family LiteLLM matrix
-  - Implementation target: both LiteLLM lanes, all required scenarios, one warmup and one repetition.
-  - Failing test: cross-family pool/model selection, independent inventory, marker, or attribution mismatch fails its row.
-  - Verification command: `bun run bench:routing-matrix --lanes litellm-openai,litellm-anthropic --warmups 1 --repetitions 1`.
-  - Required artifact: redacted two-lane report and hash receipt.
-  - Completion claim: 2/2 warmups and 8/8 measured rows PASS with no FAIL/BLOCKED.
-  - Reviewer evidence: pending RM-10 and authorized credentials.
-- [ ] RM-12 Stage D authoritative five-lane matrix
-  - Implementation target: all canonical required lanes, one warmup, four scenarios, and three measured repetitions.
-  - Failing test: any missing inventory tier, warmup, row, usage, required attribution, or scan makes the run non-authoritative.
-  - Verification command: `bun run bench:routing-matrix` on clean current `origin/main`.
-  - Required artifact: redacted exact-head report with five warmups, 60 measurements, and hash receipt.
-  - Completion claim: `passedWarmups === 5`, `passedMeasured === 60`, `matrixComplete === true`, `authoritative === true`, exit 0.
-  - Reviewer evidence: pending RM-10/RM-11, all five authorized credentials, and merge to current main.
-- [ ] RM-13 final exact-head empirical review
-  - Implementation target: independently compare report SHA, Git SHA/cleanliness, schema, counts, evidence limitations, and recursive secret scan.
-  - Failing test: any mismatch between report claims and current main rejects completion.
-  - Verification command: schema validation, `sha256sum -c`, Gitleaks directory scan, and GitHub required-check review.
-  - Required artifact: reviewer acceptance linked to the exact authoritative report.
-  - Completion claim: project is empirically complete only after the reviewer accepts the clean exact-head authenticated evidence.
-  - Reviewer evidence: pending RM-12.
+- [x] SR-01 DRY subscription profile registry and role reuse
+  - Implementation target: one shared profile registry used by OAuth login, routing commands, and session application; reuse the common role-model resolver for slow/smol/commit selection.
+  - Failing test: atomic profile application, missing entitlement, canonical alias, and role-resolution cases.
+  - Verification command: `bun test test/subscription-routing-profiles.test.ts test/login-model.test.ts test/model-resolver.test.ts --max-concurrency 1`.
+  - Required artifact: focused test log and source diff showing no duplicated model-selection loop.
+  - Completion claim: Google and Codex role mappings have one source of truth and cannot partially apply.
+  - Reviewer evidence: focused subscription and login cases pass; final PR diff review remains required.
+- [x] SR-02 provider-sticky Codex tier and effort routing
+  - Implementation target: Luna/low, Terra/medium, Sol/high, and Sol/xhigh on rejection or complexity score ≥90.
+  - Failing test: normal balanced selection and independent frontier effort escalation.
+  - Verification command: `bun test test/routing-effort.test.ts test/routing-coordinator.test.ts test/agent-session-routing-rejection.test.ts --max-concurrency 1`.
+  - Required artifact: routing decision assertions for selected model, selected effort, and reason.
+  - Completion claim: model tier and reasoning effort are resolved independently without crossing providers.
+  - Reviewer evidence: focused coordinator and rejection tests pass.
+- [x] SR-03 Google planner/normal high-reasoning routing
+  - Implementation target: Flash High for `default`/`smol`, Pro High for `plan`/`slow`, including enterprise alias canonicalization.
+  - Failing test: login applies all four roles and preserves unrelated roles; stale inventory refuses application.
+  - Verification command: `bun test test/login-model.test.ts test/subscription-routing-profiles.test.ts --max-concurrency 1`.
+  - Required artifact: atomic role and active-model assertions.
+  - Completion claim: normal and planner paths both request high reasoning from fresh entitled models.
+  - Reviewer evidence: focused login/profile tests pass.
+- [x] SR-04 OAuth entitlement inventory and credential reuse
+  - Implementation target: reuse `AuthStorage` and `ModelRegistry` provider managers for Google Antigravity and OpenAI Codex; never inspect database rows or expose raw tokens.
+  - Failing test: fresh, stale, empty, missing-metadata, unavailable, and missing-credential entitlement states.
+  - Verification command: `bun test test/bench-routing-matrix.test.ts --max-concurrency 1`.
+  - Required artifact: sanitized inventory rows and mocked resolver evidence.
+  - Completion claim: only fresh provider-reported entitlement inventory constructs live candidates and runtime models.
+  - Reviewer evidence: focused entitlement and no-fallback tests pass.
+- [x] SR-05 subscription transport attribution and schema-v3 reporting
+  - Implementation target: capture Google model version and Codex response-body model/response ID; record requested effort and reason in schema-v3 reports.
+  - Failing test: actual content-block extraction, missing attribution, Google SSE attribution, and Codex SSE attribution.
+  - Verification command: `bun test test/google-gemini-cli-3x-thinking.test.ts test/openai-codex-stream.test.ts --max-concurrency 1` in `packages/ai`, plus the benchmark test.
+  - Required artifact: transport assertions and a schema-valid redacted dry-run report.
+  - Completion claim: request metadata is never manufactured as response evidence; known provider aliases are compared to their response-reported serving model.
+  - Reviewer evidence: focused transport tests pass; schema-v3 subscription dry-run and xhigh escalation dry-run reports passed validation and Gitleaks under `/tmp/routing-matrix-reports/`.
+- [ ] SR-06 deterministic Stage A and merged PR
+  - Implementation target: format, typecheck, focused suites, full workspace suite, both benchmark-profile dry runs, secret scan, review diff, and complete issue #3129 through CI and squash merge.
+  - Failing test: any source, test, schema, formatting, or CI failure keeps the task open.
+  - Verification command: repository-required checks, `bun run test`, and `bun run bench:routing-matrix --profile subscription --dry-run`.
+  - Required artifact: green command logs, dry-run receipt, merged linked PR, and clean Git state.
+  - Completion claim: all deterministic gates are green on the merged implementation.
+  - Reviewer evidence: `bun run check` and the full workspace test run pass (coding-agent: 6,541 pass, 559 skip, 0 fail); PR lifecycle remains pending.
+- [ ] SR-07 staged authenticated subscription smoke
+  - Implementation target: Google utility then frontier; Codex utility then balanced/frontier; one warmup and one repetition per requested scenario.
+  - Failing test: any entitlement, model, effort, marker, usage, stop, or attribution mismatch stops progression to the next stage.
+  - Verification command: `bun run bench:routing-matrix --profile subscription --lanes <lane> --scenarios <scenario> --warmups 1 --repetitions 1`.
+  - Required artifact: one redacted out-of-repository report and receipt per stage.
+  - Completion claim: both subscription transports prove their reviewed models through authenticated inference without invoking LiteLLM.
+  - Reviewer evidence: pending SR-06 and exact merged HEAD.
+- [ ] SR-08 authoritative two-lane matrix and exact-head review
+  - Implementation target: both subscription lanes, one warmup, four scenarios, three repetitions, clean exact `origin/main`, schema validation, recursive secret scan, and receipt verification.
+  - Failing test: any missing entitlement, warmup, row, usage, required response attribution, scan, Git, or count makes the result non-authoritative.
+  - Verification command: `bun run bench:routing-matrix --profile subscription` on clean current `origin/main`.
+  - Required artifact: redacted report with 2/2 warmups, 24/24 measurements, `matrixComplete: true`, `authoritative: true`, exit 0, and a matching SHA-256 receipt.
+  - Completion claim: the reviewer accepts the exact-head authenticated subscription matrix and its documented attribution limits.
+  - Reviewer evidence: pending SR-07.
 
-The unchecked items require configured authorized credentials and real inference. Until they pass, the project remains implemented but empirically incomplete.
+The legacy LiteLLM and five-lane canonical live matrices remain deferred, not silently accepted. They are outside issue #3129 and must not be run in this subscription-focused session. Until SR-06 through SR-08 pass, this iteration remains implemented but empirically incomplete.
 
 ## Risks and unresolved product decisions
 
-- Canonical availability risk: any configured tier absent from a live inventory blocks that entire required lane; changing the canonical tier is a reviewed product decision, not a harness fallback.
-- Attribution limitation: LiteLLM may not expose its true upstream provider and the current Vertex SDK stream does not report a serving model. Authority is therefore capability-relative and must retain these explicit omissions.
-- Credential topology: the two LiteLLM families require independently addressable inventory/inference configuration even if an installation chooses to share one key.
-- Vertex inventory compatibility: Model Garden permissions and regional availability may differ from inference permissions; authenticated UAT must confirm the chosen project/location.
-- Cost control: Stage D is prohibited as a debugging loop and remains gated on successful Stages B and C.
-- Final product decision: reviewers must explicitly accept capability-relative attribution, or require gateway/SDK changes that expose stronger upstream evidence before declaring RM-13 complete.
+- Entitlement risk: the reviewed GPT-5.6 and Gemini aliases are accepted only if the current authenticated account advertises them. Bundled catalog presence is insufficient.
+- Google alias risk: Antigravity request aliases can map to Vertex serving versions. The transport records both rather than demanding literal alias equality.
+- Attribution limitation: neither subscription gateway proves its internal upstream infrastructure. Authority is capability-relative to authenticated endpoint, request, client transport, and response-reported model.
+- Effort availability risk: the current Codex entitlement metadata caps supported effort at xhigh. A future max effort is not inferred or requested until entitlement and transport metadata advertise it.
+- Rollout decision: automatic Codex routing should move from shadow to per-profile auto after SR-08. Google normal/planner role routing may roll out independently; cross-provider fallback remains prohibited.
+- Legacy validation: LiteLLM and direct-provider canonical UAT still require a separate authorized iteration and must not be conflated with subscription acceptance.

--- a/docs/plans/provider-agnostic-dynamic-model-routing.md
+++ b/docs/plans/provider-agnostic-dynamic-model-routing.md
@@ -4,7 +4,11 @@
 
 The production router is implemented at the `AgentSession` boundary. It supports explicit provider-qualified pools, utility/balanced/frontier tiers, off/shadow/auto modes, deterministic and hybrid classification, context eligibility, hysteresis, manual pins, escalation and rollback, read-only delegation, persistence, telemetry, and route commands.
 
-The authenticated routing-matrix harness was redesigned under issue #3114 and extended for subscription routing under issue #3129. The implementation now has provider-sticky Google Antigravity and OpenAI Codex profiles, entitlement-scoped inventory discovery through xcsh's existing OAuth storage, tier-specific reasoning effort, and response-body attribution for both transports. Its deterministic and mocked-network evidence is authoritative for code paths, but this iteration is not empirically complete until a clean exact-`origin/main` report proves the two subscription lanes through real authenticated inference.
+The authenticated routing-matrix harness was redesigned under issue #3114 and extended for subscription routing under issue #3129.
+The implementation now has provider-sticky Google Antigravity and OpenAI Codex profiles, entitlement-scoped inventory discovery
+through xcsh's existing OAuth storage, tier-specific reasoning effort, and response-body attribution for both transports. Its
+deterministic and mocked-network evidence is authoritative for code paths, but this iteration is not empirically complete until
+a clean exact-`origin/main` report proves the two subscription lanes through real authenticated inference.
 
 CI, unit tests, dry runs, bundled catalog entries, missing-credential BLOCKED results, and completion-auditor statements are not live acceptance evidence.
 
@@ -12,7 +16,10 @@ CI, unit tests, dry runs, bundled catalog entries, missing-credential BLOCKED re
 
 The legacy `canonical` benchmark profile retains direct OpenAI, direct Anthropic, LiteLLM OpenAI-family, LiteLLM Anthropic-family, and explicitly configured Google Vertex lanes. The `subscription` profile is the scope of issue #3129 and contains only Google Antigravity and OpenAI Codex. LiteLLM inference is explicitly out of scope for this iteration and must not be run as part of its UAT.
 
-The Google profile maps `smol` and `default` to `google-antigravity/gemini-3.6-flash-high:high`, and `slow` and `plan` to `google-antigravity/gemini-3.1-pro-high-vertex:high`. The Codex profile maps utility to Luna/low, balanced to Terra/medium, and frontier to Sol/high, with Sol/xhigh for a prior rejection or a complexity score of at least 90. Both profiles are provider-sticky and apply atomically only when every required model appears in fresh authenticated entitlement inventory.
+The Google profile maps `smol` and `default` to `google-antigravity/gemini-3.6-flash-high:high`, and `slow` and `plan` to
+`google-antigravity/gemini-3.1-pro-high-vertex:high`. The Codex profile maps utility to Luna/low, balanced to Terra/medium,
+and frontier to Sol/high, with Sol/xhigh for a prior rejection or a complexity score of at least 90. Both profiles are
+provider-sticky and apply atomically only when every required model appears in fresh authenticated entitlement inventory.
 
 Other providers may opt in only through explicit capability and tier-pool configuration. Untiered providers remain on their selected model. Model names never imply tiers.
 
@@ -95,7 +102,10 @@ Statuses:
 - `SKIPPED_UNTIERED`: optional provider has no configured pool; illegal for canonical required lanes.
 - `SIMULATED`: dry-run row; never counted as PASS.
 
-The canonical defaults remain five warmups and 60 measured rows. The subscription profile defaults to two warmups and 24 measured rows (two lanes × four scenarios × three repetitions). `matrixComplete` requires exact counts and every live inventory, warmup, and measured row PASS. `authoritative` additionally requires non-dry execution, clean exact final HEAD, positive usage, declared response attribution, schema validation, recursive redaction, and secret-scan success.
+The canonical defaults remain five warmups and 60 measured rows. The subscription profile defaults to two warmups and
+24 measured rows (two lanes × four scenarios × three repetitions). `matrixComplete` requires exact counts and every live
+inventory, warmup, and measured row PASS. `authoritative` additionally requires non-dry execution, clean exact final HEAD,
+positive usage, declared response attribution, schema validation, recursive redaction, and secret-scan success.
 
 Exit codes are 0 for successful requested-mode execution, 1 for behavior/schema/security failure, 2 for an environmentally BLOCKED or incomplete required matrix, and 64 for invalid CLI configuration. A successful dry run may exit 0 but remains non-complete and non-authoritative.
 

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -69,6 +69,10 @@ const ANTIGRAVITY_VERTEX_MODELS: Readonly<Record<string, string>> = Object.freez
 	"gemini-3.1-pro-high-vertex": "gemini-3.1-pro-preview",
 });
 
+export function resolveAntigravityServingModelId(requestedModelId: string): string {
+	return ANTIGRAVITY_VERTEX_MODELS[requestedModelId] ?? requestedModelId;
+}
+
 /**
  * Build a User-Agent string that identifies as Gemini CLI to unlock higher rate limits.
  * Uses the same format as the official Gemini CLI (v0.35+):
@@ -477,6 +481,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 			api: "google-gemini-cli" as Api,
 			provider: model.provider,
 			model: model.id,
+			responseAttribution: { requestedModel: model.id },
 			usage: {
 				input: 0,
 				output: 0,
@@ -687,6 +692,14 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 					options?.signal,
 				)) {
 					const responseData = chunk.response ?? chunk;
+					if (responseData.modelVersion) {
+						output.responseAttribution = {
+							...(output.responseAttribution ?? { requestedModel: model.id }),
+							responseModel: responseData.modelVersion,
+							responseModelSource: "response-body",
+						};
+					}
+					if (responseData.responseId) output.responseId = responseData.responseId;
 
 					const candidate = responseData.candidates?.[0];
 					if (candidate?.content?.parts) {

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -385,6 +385,7 @@ function createAssistantOutput(model: Model<"openai-codex-responses">): Assistan
 		api: "openai-codex-responses" as Api,
 		provider: model.provider,
 		model: model.id,
+		responseAttribution: { requestedModel: model.id },
 		usage: createEmptyUsage(),
 		stopReason: "stop",
 		timestamp: Date.now(),
@@ -816,7 +817,8 @@ function handleCodexStreamEvent(args: {
 	}
 
 	if (eventType === "response.created") {
-		return handleResponseCreated(runtime, rawEvent);
+		handleResponseCreated(model, output, runtime, rawEvent);
+		return firstTokenTime;
 	}
 
 	if (eventType === "response.completed" || eventType === "response.done" || eventType === "response.incomplete") {
@@ -1011,13 +1013,27 @@ function handleOutputItemDone(
 	void model;
 }
 
-function handleResponseCreated(runtime: CodexStreamRuntime, rawEvent: Record<string, unknown>): number | undefined {
-	const response = (rawEvent as { response?: { id?: string } }).response;
+function handleResponseCreated(
+	model: Model<"openai-codex-responses">,
+	output: AssistantMessage,
+	runtime: CodexStreamRuntime,
+	rawEvent: Record<string, unknown>,
+): void {
+	const response = (rawEvent as { response?: { id?: string; model?: string } }).response;
+	if (typeof response?.id === "string" && response.id.length > 0) {
+		output.responseId = response.id;
+	}
+	if (typeof response?.model === "string" && response.model.length > 0) {
+		output.responseAttribution = {
+			...(output.responseAttribution ?? { requestedModel: model.id }),
+			responseModel: response.model,
+			responseModelSource: "response-body",
+		};
+	}
 	const state = runtime.websocketState;
 	if (runtime.transport === "websocket" && state && typeof response?.id === "string" && response.id.length > 0) {
 		state.lastResponseId = response.id;
 	}
-	return undefined;
 }
 
 function handleResponseCompleted(
@@ -1038,6 +1054,7 @@ function handleResponseCompleted(
 					input_tokens_details?: { cached_tokens?: number };
 				};
 				status?: string;
+				model?: string;
 			};
 		}
 	).response;
@@ -1055,6 +1072,13 @@ function handleResponseCompleted(
 	}
 	if (typeof response?.id === "string" && response.id.length > 0) {
 		output.responseId = response.id;
+	}
+	if (typeof response?.model === "string" && response.model.length > 0) {
+		output.responseAttribution = {
+			...(output.responseAttribution ?? { requestedModel: model.id }),
+			responseModel: response.model,
+			responseModelSource: "response-body",
+		};
 	}
 
 	const state = runtime.websocketState;

--- a/packages/ai/test/google-gemini-cli-3x-thinking.test.ts
+++ b/packages/ai/test/google-gemini-cli-3x-thinking.test.ts
@@ -145,4 +145,33 @@ describe("google-gemini-cli Gemini 3.x thinking mapping", () => {
 		expect(thinking?.thinkingLevel).toBeUndefined();
 		expect(thinking?.thinkingBudget).toBeDefined();
 	});
+
+	it("retains server-reported model and response identifiers as transport evidence", async () => {
+		using _hook = hookFetch(
+			() =>
+				new Response(
+					`data: ${JSON.stringify({
+						response: {
+							candidates: [{ content: { role: "model", parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+							usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 1, totalTokenCount: 3 },
+							modelVersion: "gemini-3.6-flash",
+							responseId: "response-123",
+						},
+					})}\n\n`,
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				),
+		);
+
+		const message = await streamSimple(createModel("gemini-3.6-flash-high", "google-antigravity"), context, {
+			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+			reasoning: Effort.High,
+		}).result();
+
+		expect(message.responseAttribution).toEqual({
+			requestedModel: "gemini-3.6-flash-high",
+			responseModel: "gemini-3.6-flash",
+			responseModelSource: "response-body",
+		});
+		expect(message.responseId).toBe("response-123");
+	});
 });

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -68,6 +68,7 @@ describe("openai-codex streaming", () => {
 			`data: ${JSON.stringify({
 				type: "response.completed",
 				response: {
+					model: "gpt-5.1-codex-2026-08-01",
 					status: "completed",
 					usage: {
 						input_tokens: 5,
@@ -142,6 +143,11 @@ describe("openai-codex streaming", () => {
 			if (event.type === "done") {
 				sawDone = true;
 				expect(event.message.content.find(c => c.type === "text")?.text).toBe("Hello");
+				expect(event.message.responseAttribution).toEqual({
+					requestedModel: "gpt-5.1-codex",
+					responseModel: "gpt-5.1-codex-2026-08-01",
+					responseModelSource: "response-body",
+				});
 			}
 		}
 

--- a/packages/coding-agent/scripts/bench-routing-matrix.ts
+++ b/packages/coding-agent/scripts/bench-routing-matrix.ts
@@ -10,9 +10,12 @@ import {
 	type TextContent,
 	type UserMessage,
 } from "@f5-sales-demo/pi-ai";
+import { resolveAntigravityServingModelId } from "@f5-sales-demo/pi-ai/providers/google-gemini-cli";
 import Ajv2020 from "ajv/dist/2020";
 import { GoogleAuth } from "google-auth-library";
+import { ModelRegistry, type ProviderDiscoveryState } from "../src/config/model-registry";
 import { RoutingCoordinator } from "../src/routing/coordinator";
+import { OPENAI_CODEX_ROUTING_POOL } from "../src/routing/subscription-profiles";
 import type { RoutingPoolConfig, RoutingTier } from "../src/routing/types";
 
 export type InventoryState =
@@ -35,15 +38,31 @@ export interface LaneCapability {
 	upstreamFamily: "openai" | "anthropic" | "google";
 	endpointKind: "direct" | "gateway";
 	poolId: string;
-	inferenceApiType: "openai-responses" | "anthropic-messages" | "google-vertex";
-	inventoryAdapterId: "openai-compatible" | "anthropic" | "vertex-model-garden";
+	inferenceApiType:
+		| "openai-responses"
+		| "openai-codex-responses"
+		| "anthropic-messages"
+		| "google-vertex"
+		| "google-gemini-cli";
+	inventoryAdapterId: "openai-compatible" | "anthropic" | "vertex-model-garden" | "oauth-entitlement";
 	credentialResolverId: string;
 	defaultBaseUrl?: string;
 	multimodal: boolean;
 	requireResponseModel: boolean;
 	canProveUpstreamProvider: boolean;
 	tiers: Record<RoutingTier, string>;
+	effortPolicy?: RoutingPoolConfig["effortPolicy"];
 }
+
+export type BenchmarkProfile = "canonical" | "subscription";
+export const CANONICAL_LANE_IDS = [
+	"openai",
+	"anthropic",
+	"litellm-openai",
+	"litellm-anthropic",
+	"google-vertex",
+] as const;
+export const SUBSCRIPTION_LANE_IDS = ["google-antigravity", "openai-codex"] as const;
 
 export const LANE_CAPABILITIES: Record<string, LaneCapability> = {
 	openai: {
@@ -132,9 +151,47 @@ export const LANE_CAPABILITIES: Record<string, LaneCapability> = {
 		canProveUpstreamProvider: true,
 		tiers: { utility: "gemini-2.5-flash-lite", balanced: "gemini-2.5-flash", frontier: "gemini-2.5-pro" },
 	},
+	"google-antigravity": {
+		id: "google-antigravity",
+		required: true,
+		clientProvider: "google-antigravity",
+		upstreamFamily: "google",
+		endpointKind: "gateway",
+		poolId: "google-antigravity/subscription",
+		inferenceApiType: "google-gemini-cli",
+		inventoryAdapterId: "oauth-entitlement",
+		credentialResolverId: "xcsh-auth-storage-google-antigravity",
+		multimodal: true,
+		requireResponseModel: true,
+		canProveUpstreamProvider: false,
+		// Flash handles normal operations; the planning/frontier tier uses Pro.
+		tiers: {
+			utility: "gemini-3.6-flash-high",
+			balanced: "gemini-3.6-flash-high",
+			frontier: "gemini-3.1-pro-high-vertex",
+		},
+		effortPolicy: { byTier: { utility: "high", balanced: "high", frontier: "high" } },
+	},
+	"openai-codex": {
+		id: "openai-codex",
+		required: true,
+		clientProvider: "openai-codex",
+		upstreamFamily: "openai",
+		endpointKind: "gateway",
+		poolId: OPENAI_CODEX_ROUTING_POOL.id,
+		inferenceApiType: "openai-codex-responses",
+		inventoryAdapterId: "oauth-entitlement",
+		credentialResolverId: "xcsh-auth-storage-openai-codex",
+		multimodal: true,
+		requireResponseModel: true,
+		canProveUpstreamProvider: false,
+		tiers: OPENAI_CODEX_ROUTING_POOL.tiers,
+		effortPolicy: OPENAI_CODEX_ROUTING_POOL.effortPolicy,
+	},
 };
 
 export interface BenchmarkArgs {
+	profile: BenchmarkProfile;
 	repetitions: number;
 	warmups: number;
 	lanes: string[];
@@ -152,7 +209,11 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): BenchmarkArgs
 	const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
 	const repetitions = Number(get("--repetitions") ?? process.env.ROUTING_MATRIX_REPETITIONS ?? "3");
 	const warmups = Number(get("--warmups") ?? process.env.ROUTING_MATRIX_WARMUPS ?? "1");
-	const timeoutMs = Number(get("--timeout-ms") ?? process.env.ROUTING_MATRIX_TIMEOUT_MS ?? "20000");
+	const profile = (get("--profile") ?? process.env.ROUTING_MATRIX_PROFILE ?? "canonical") as BenchmarkProfile;
+	if (profile !== "canonical" && profile !== "subscription") throw new Error(`Unknown profile: ${profile}`);
+	const timeoutMs = Number(
+		get("--timeout-ms") ?? process.env.ROUTING_MATRIX_TIMEOUT_MS ?? (profile === "subscription" ? "120000" : "20000"),
+	);
 	if (
 		!Number.isInteger(repetitions) ||
 		repetitions < 1 ||
@@ -163,7 +224,8 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): BenchmarkArgs
 	) {
 		throw new Error("Invalid benchmark counts or timeout");
 	}
-	const lanes = (get("--lanes") ?? process.env.ROUTING_MATRIX_LANES ?? Object.keys(LANE_CAPABILITIES).join(","))
+	const profileLanes = profile === "subscription" ? SUBSCRIPTION_LANE_IDS : CANONICAL_LANE_IDS;
+	const lanes = (get("--lanes") ?? process.env.ROUTING_MATRIX_LANES ?? profileLanes.join(","))
 		.split(",")
 		.map(value => value.trim().toLowerCase())
 		.filter(Boolean);
@@ -175,9 +237,10 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): BenchmarkArgs
 		.map(value => value.trim())
 		.filter(Boolean);
 	for (const scenario of scenarios) {
-		if (!BASE_SCENARIOS.some(item => item.id === scenario)) throw new Error(`Unknown scenario: ${scenario}`);
+		if (!ALL_SCENARIOS.some(item => item.id === scenario)) throw new Error(`Unknown scenario: ${scenario}`);
 	}
 	return {
+		profile,
 		repetitions,
 		warmups,
 		timeoutMs,
@@ -194,7 +257,7 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): BenchmarkArgs
 
 export interface LaneCredential {
 	apiKey?: string;
-	authMechanism?: "bearer" | "api-key" | "oauth-bearer" | "google-adc";
+	authMechanism?: "bearer" | "api-key" | "oauth-bearer" | "oauth-packed" | "google-adc";
 	baseUrl?: string;
 	inventoryBaseUrl?: string;
 	project?: string;
@@ -233,6 +296,8 @@ export async function resolveLaneCredentials(): Promise<Record<string, LaneCrede
 	const anthropicUsesOAuth = Boolean(process.env.ANTHROPIC_OAUTH_TOKEN || storage?.getOAuthCredential?.("anthropic"));
 	const litellmOpenai = await key("litellm", process.env.LITELLM_OPENAI_API_KEY ?? process.env.LITELLM_API_KEY);
 	const litellmAnthropic = await key("litellm", process.env.LITELLM_ANTHROPIC_API_KEY ?? process.env.LITELLM_API_KEY);
+	const googleAntigravity = await key("google-antigravity", process.env.GOOGLE_ANTIGRAVITY_OAUTH_TOKEN);
+	const openaiCodex = await key("openai-codex", process.env.OPENAI_CODEX_OAUTH_TOKEN);
 	const adcToken = await resolveAdcAccessToken();
 	storage?.close?.();
 	const location = process.env.GOOGLE_CLOUD_LOCATION ?? process.env.VERTEX_LOCATION ?? "us-central1";
@@ -267,6 +332,14 @@ export async function resolveLaneCredentials(): Promise<Record<string, LaneCrede
 			project: process.env.GOOGLE_CLOUD_PROJECT ?? process.env.VERTEX_PROJECT_ID,
 			location,
 			baseUrl: process.env.VERTEX_BASE_URL ?? `https://${location}-aiplatform.googleapis.com/v1beta1`,
+		},
+		"google-antigravity": {
+			apiKey: googleAntigravity,
+			authMechanism: googleAntigravity ? "oauth-packed" : undefined,
+		},
+		"openai-codex": {
+			apiKey: openaiCodex,
+			authMechanism: openaiCodex ? "oauth-packed" : undefined,
 		},
 	};
 }
@@ -429,12 +502,144 @@ export async function discoverLaneInventory(
 	return { ...base, state: "AVAILABLE", models, durationMs: performance.now() - started };
 }
 
+export interface OAuthEntitlementSnapshot {
+	state?: ProviderDiscoveryState;
+	models: Model<any>[];
+}
+
+export type OAuthEntitlementResolver = (provider: string) => Promise<OAuthEntitlementSnapshot>;
+
+async function resolveOAuthEntitlements(provider: string): Promise<OAuthEntitlementSnapshot> {
+	const { discoverAuthStorage } = await import("../src/sdk");
+	const storage = await discoverAuthStorage();
+	try {
+		const registry = new ModelRegistry(storage);
+		await registry.refreshProvider(provider, "online");
+		const state = registry.getProviderDiscoveryState(provider);
+		const entitled = new Set(state?.models ?? []);
+		return {
+			state,
+			models: registry.getAvailable().filter(model => model.provider === provider && entitled.has(model.id)),
+		};
+	} finally {
+		storage.close();
+	}
+}
+
+/**
+ * Discover subscription models through the provider's authenticated entitlement endpoint.
+ * Cached or bundled models are never accepted as live discovery evidence.
+ */
+export async function discoverOAuthEntitlementInventory(
+	capability: LaneCapability,
+	credential: LaneCredential,
+	resolver: OAuthEntitlementResolver = resolveOAuthEntitlements,
+): Promise<{ inventory: InventoryResult; models: Model<any>[] }> {
+	const started = performance.now();
+	const base: InventoryResult = {
+		laneId: capability.id,
+		state: "BLOCKED_AUTH",
+		models: [],
+		endpointId: createHash("sha256")
+			.update(`oauth-entitlement:${capability.clientProvider}`)
+			.digest("hex")
+			.slice(0, 16),
+		durationMs: 0,
+		missingTiers: [],
+		eligibleCandidates: [],
+	};
+	if (!credential.apiKey || credential.authMechanism !== "oauth-packed") {
+		return {
+			inventory: { ...base, durationMs: performance.now() - started, reasonCode: "missing_oauth_credentials" },
+			models: [],
+		};
+	}
+	let snapshot: OAuthEntitlementSnapshot;
+	try {
+		snapshot = await resolver(capability.clientProvider);
+	} catch {
+		return {
+			inventory: {
+				...base,
+				state: "BLOCKED_NETWORK",
+				durationMs: performance.now() - started,
+				reasonCode: "entitlement_discovery_error",
+			},
+			models: [],
+		};
+	}
+	const state = snapshot.state;
+	if (!state) {
+		return {
+			inventory: {
+				...base,
+				state: "UNSUPPORTED_DISCOVERY",
+				durationMs: performance.now() - started,
+				reasonCode: "missing_entitlement_adapter_state",
+			},
+			models: [],
+		};
+	}
+	if (state.status === "unauthenticated") {
+		return {
+			inventory: {
+				...base,
+				state: "BLOCKED_AUTH",
+				durationMs: performance.now() - started,
+				reasonCode: "entitlement_auth_failed",
+			},
+			models: [],
+		};
+	}
+	if (state.status !== "ok" || state.stale) {
+		return {
+			inventory: {
+				...base,
+				state: "BLOCKED_NETWORK",
+				durationMs: performance.now() - started,
+				reasonCode: state.stale ? "stale_entitlement_inventory" : "entitlement_discovery_unavailable",
+			},
+			models: [],
+		};
+	}
+	const modelsById = new Map(snapshot.models.map(model => [model.id, model]));
+	const models = [...new Set(state.models)].sort();
+	if (models.length === 0) {
+		return {
+			inventory: {
+				...base,
+				state: "FAIL_EMPTY_INVENTORY",
+				durationMs: performance.now() - started,
+				reasonCode: "empty_entitlement_inventory",
+			},
+			models: [],
+		};
+	}
+	const missingRecords = models.filter(model => !modelsById.has(model));
+	if (missingRecords.length > 0) {
+		return {
+			inventory: {
+				...base,
+				state: "FAIL_SCHEMA",
+				models,
+				durationMs: performance.now() - started,
+				reasonCode: "missing_entitlement_model_metadata",
+			},
+			models: [],
+		};
+	}
+	return {
+		inventory: { ...base, state: "AVAILABLE", models, durationMs: performance.now() - started },
+		models: models.map(model => modelsById.get(model)!),
+	};
+}
+
 export function reconcileLaneInventory(
 	capability: LaneCapability,
 	models: string[],
 ): Pick<InventoryResult, "state" | "missingTiers" | "eligibleCandidates"> {
 	const available = new Set(models.map(model => model.replace(/^models\//, "")));
-	const configured = [capability.tiers.utility, capability.tiers.balanced, capability.tiers.frontier];
+	const configured = [...new Set([capability.tiers.utility, capability.tiers.balanced, capability.tiers.frontier])];
 	const missingTiers = configured.filter(model => !available.has(model));
 	const eligibleCandidates = configured
 		.filter(model => available.has(model))
@@ -449,6 +654,7 @@ export interface ScenarioDefinition {
 	prompt: string;
 	responseMarker: string;
 	hasImages?: boolean;
+	priorRejection?: boolean;
 }
 
 export const BASE_SCENARIOS: ScenarioDefinition[] = [
@@ -483,6 +689,18 @@ export const BASE_SCENARIOS: ScenarioDefinition[] = [
 		hasImages: true,
 	},
 ];
+
+export const ESCALATION_SCENARIO: ScenarioDefinition = {
+	id: "rejection-escalation",
+	name: "Frontier rejection escalation",
+	expectedTier: "frontier",
+	prompt:
+		"Re-evaluate the rejected architecture and security migration deeply. Output RESPOND_ESCALATION_OK and nothing else.",
+	responseMarker: "RESPOND_ESCALATION_OK",
+	priorRejection: true,
+};
+
+export const ALL_SCENARIOS: ScenarioDefinition[] = [...BASE_SCENARIOS, ESCALATION_SCENARIO];
 
 export interface MatrixEntry {
 	lane: string;
@@ -530,6 +748,7 @@ export interface ClassifyMeasuredRunOptions {
 	effectiveTier?: RoutingTier;
 	expectedTier: RoutingTier;
 	requestedModel: string;
+	expectedResponseModel?: string;
 	responseModel?: string;
 	clientProvider?: string;
 	expectedClientProvider: string;
@@ -549,7 +768,11 @@ export function classifyMeasuredRun(options: ClassifyMeasuredRunOptions): { stat
 		return { status: "FAIL", reasonCode: "client_provider_mismatch" };
 	if (options.requireResponseModel && !options.responseModel)
 		return { status: "FAIL", reasonCode: "missing_response_model" };
-	if (options.responseModel && normalizeModelId(options.responseModel) !== normalizeModelId(options.requestedModel)) {
+	if (
+		options.responseModel &&
+		normalizeModelId(options.responseModel) !==
+			normalizeModelId(options.expectedResponseModel ?? options.requestedModel)
+	) {
 		return { status: "FAIL", reasonCode: "response_model_mismatch" };
 	}
 	if (options.stopReason !== "stop") return { status: "FAIL", reasonCode: "invalid_stop_reason" };
@@ -644,7 +867,16 @@ export function createMultimodalMessage(prompt: string): UserMessage {
 	return { role: "user", content: [text, image], timestamp: Date.now() };
 }
 
-function constructModel(capability: LaneCapability, modelId: string, baseUrl?: string): Model<any> {
+function constructModel(
+	capability: LaneCapability,
+	modelId: string,
+	baseUrl?: string,
+	discoveredModels: readonly Model<any>[] = [],
+): Model<any> {
+	const discovered = discoveredModels.find(
+		model => model.provider === capability.clientProvider && model.id === modelId,
+	);
+	if (discovered) return baseUrl ? { ...discovered, baseUrl } : discovered;
 	const bundled = getBundledModel(capability.clientProvider as any, modelId);
 	if (bundled) return baseUrl ? { ...bundled, baseUrl } : bundled;
 	return {
@@ -662,7 +894,12 @@ function constructModel(capability: LaneCapability, modelId: string, baseUrl?: s
 }
 
 function customPool(capability: LaneCapability): RoutingPoolConfig {
-	return { id: capability.poolId, provider: capability.clientProvider, tiers: capability.tiers };
+	return {
+		id: capability.poolId,
+		provider: capability.clientProvider,
+		tiers: capability.tiers,
+		effortPolicy: capability.effortPolicy,
+	};
 }
 
 interface ReportRow {
@@ -679,6 +916,8 @@ interface ReportRow {
 	scenarioId?: string;
 	repetition: number;
 	effectiveTier?: RoutingTier;
+	requestedEffort?: string;
+	effortReason?: string;
 	stopReason?: string;
 	usage?: { input: number; output: number; totalTokens: number };
 	startedAt: string;
@@ -698,6 +937,12 @@ function responseEvidence(response: any): {
 		upstreamProvider: attribution?.upstreamProvider,
 		upstreamProviderSource: attribution?.upstreamProviderSource,
 	};
+}
+
+function expectedResponseModel(capability: LaneCapability, requestedModel: string): string {
+	return capability.id === "google-antigravity"
+		? resolveAntigravityServingModelId(normalizeModelId(requestedModel))
+		: requestedModel;
 }
 
 function normalizedUsage(response: any): { input: number; output: number; totalTokens: number } {
@@ -749,6 +994,7 @@ async function run(): Promise<number> {
 	const credentials = await resolveLaneCredentials();
 	const inventory: InventoryResult[] = [];
 	const eligibleByLane = new Map<string, string[]>();
+	const discoveredModelsByLane = new Map<string, Model<any>[]>();
 	const secrets = Object.values(credentials).flatMap(item => (item.apiKey ? [item.apiKey] : []));
 	for (const laneId of args.lanes) {
 		const capability = LANE_CAPABILITIES[laneId];
@@ -767,12 +1013,19 @@ async function run(): Promise<number> {
 			eligibleByLane.set(laneId, reconciled.eligibleCandidates);
 			continue;
 		}
-		const discovered = await discoverLaneInventory(
-			capability,
-			credentials[laneId],
-			globalThis.fetch,
-			AbortSignal.timeout(args.timeoutMs),
-		);
+		const entitlement =
+			capability.inventoryAdapterId === "oauth-entitlement"
+				? await discoverOAuthEntitlementInventory(capability, credentials[laneId])
+				: undefined;
+		const discovered = entitlement
+			? entitlement.inventory
+			: await discoverLaneInventory(
+					capability,
+					credentials[laneId],
+					globalThis.fetch,
+					AbortSignal.timeout(args.timeoutMs),
+				);
+		if (entitlement?.models.length) discoveredModelsByLane.set(laneId, entitlement.models);
 		if (discovered.state === "AVAILABLE") {
 			const reconciled = reconcileLaneInventory(capability, discovered.models);
 			discovered.state = reconciled.state;
@@ -816,16 +1069,27 @@ async function run(): Promise<number> {
 			const requestedModel = capability.tiers.utility;
 			try {
 				const response = await completeSimple(
-					constructModel(capability, requestedModel, credentials[laneId].baseUrl),
+					constructModel(
+						capability,
+						requestedModel,
+						credentials[laneId].baseUrl,
+						discoveredModelsByLane.get(laneId),
+					),
 					{ systemPrompt: "Warmup", messages: [{ role: "user", content: "Reply OK", timestamp: Date.now() }] },
-					{ apiKey: credentials[laneId].apiKey, maxTokens: 8, signal: AbortSignal.timeout(args.timeoutMs) },
+					{
+						apiKey: credentials[laneId].apiKey,
+						maxTokens: 8,
+						reasoning: capability.effortPolicy?.byTier.utility as any,
+						signal: AbortSignal.timeout(args.timeoutMs),
+					},
 				);
 				const evidence = responseEvidence(response);
 				const usage = normalizedUsage(response);
 				const responseModelValid =
 					!capability.requireResponseModel ||
 					(evidence.responseModel !== undefined &&
-						normalizeModelId(evidence.responseModel) === normalizeModelId(requestedModel));
+						normalizeModelId(evidence.responseModel) ===
+							normalizeModelId(expectedResponseModel(capability, requestedModel)));
 				const clientProviderValid = response?.provider === capability.clientProvider;
 				const status: RunStatus =
 					response?.stopReason === "stop" && usage.totalTokens > 0 && responseModelValid && clientProviderValid
@@ -837,6 +1101,7 @@ async function run(): Promise<number> {
 					status,
 					reasonCode: status === "PASS" ? undefined : "warmup_behavioral_failure",
 					requestedModel,
+					requestedEffort: capability.effortPolicy?.byTier.utility,
 					clientProvider: response?.provider,
 					...evidence,
 					stopReason: response?.stopReason,
@@ -862,7 +1127,7 @@ async function run(): Promise<number> {
 		}
 	}
 
-	const selectedScenarios = BASE_SCENARIOS.filter(item => args.scenarios.includes(item.id));
+	const selectedScenarios = ALL_SCENARIOS.filter(item => args.scenarios.includes(item.id));
 	const measuredRows: ReportRow[] = [];
 	const coordinator = new RoutingCoordinator();
 	for (const entry of expandLaneScenarios(args.lanes, args.repetitions, selectedScenarios)) {
@@ -870,19 +1135,7 @@ async function run(): Promise<number> {
 		const discovered = inventory.find(item => item.laneId === entry.lane)!;
 		const startedAt = new Date().toISOString();
 		const started = performance.now();
-		if (args.dryRun) {
-			measuredRows.push({
-				lane: entry.lane,
-				kind: "measured",
-				status: "SIMULATED",
-				scenarioId: entry.scenario.id,
-				repetition: entry.repetition,
-				startedAt,
-				durationMs: 0,
-			});
-			continue;
-		}
-		if (discovered.state !== "AVAILABLE") {
+		if (!args.dryRun && discovered.state !== "AVAILABLE") {
 			measuredRows.push({
 				lane: entry.lane,
 				kind: "measured",
@@ -902,21 +1155,49 @@ async function run(): Promise<number> {
 			mode: "auto",
 			prompt: entry.scenario.prompt,
 			hasImages: entry.scenario.hasImages,
+			priorRejection: entry.scenario.priorRejection,
 			availableModels: eligibleByLane.get(entry.lane) ?? [],
 			customPools: { [capability.poolId]: pool },
 			profilerMode: "rules",
+			tierEffort: capability.effortPolicy?.byTier as Record<string, string> | undefined,
 			signal: AbortSignal.timeout(args.timeoutMs),
 		});
 		const requestedModel = decision.selectedModel ?? entry.anchorModel;
+		if (args.dryRun) {
+			measuredRows.push({
+				lane: entry.lane,
+				kind: "measured",
+				status: "SIMULATED",
+				requestedModel,
+				requestedEffort: decision.selectedEffort,
+				effortReason: decision.effortReason,
+				scenarioId: entry.scenario.id,
+				repetition: entry.repetition,
+				effectiveTier: decision.effectiveTier,
+				startedAt,
+				durationMs: performance.now() - started,
+			});
+			continue;
+		}
 		try {
 			const modelId = normalizeModelId(requestedModel);
 			const message = entry.scenario.hasImages
 				? createMultimodalMessage(entry.scenario.prompt)
 				: { role: "user" as const, content: entry.scenario.prompt, timestamp: Date.now() };
 			const response = await completeSimple(
-				constructModel(capability, modelId, credentials[entry.lane].baseUrl),
+				constructModel(
+					capability,
+					modelId,
+					credentials[entry.lane].baseUrl,
+					discoveredModelsByLane.get(entry.lane),
+				),
 				{ systemPrompt: "Follow the exact benchmark output contract.", messages: [message] },
-				{ apiKey: credentials[entry.lane].apiKey, maxTokens: 64, signal: AbortSignal.timeout(args.timeoutMs) },
+				{
+					apiKey: credentials[entry.lane].apiKey,
+					maxTokens: 64,
+					reasoning: decision.selectedEffort as any,
+					signal: AbortSignal.timeout(args.timeoutMs),
+				},
 			);
 			const evidence = responseEvidence(response);
 			const usage = normalizedUsage(response);
@@ -924,6 +1205,7 @@ async function run(): Promise<number> {
 				effectiveTier: decision.effectiveTier,
 				expectedTier: entry.scenario.expectedTier,
 				requestedModel,
+				expectedResponseModel: expectedResponseModel(capability, requestedModel),
 				responseModel: evidence.responseModel,
 				clientProvider: response?.provider,
 				expectedClientProvider: capability.clientProvider,
@@ -939,6 +1221,8 @@ async function run(): Promise<number> {
 				status: classification.status,
 				reasonCode: classification.reasonCode,
 				requestedModel,
+				requestedEffort: decision.selectedEffort,
+				effortReason: decision.effortReason,
 				clientProvider: response?.provider,
 				...evidence,
 				scenarioId: entry.scenario.id,
@@ -958,6 +1242,8 @@ async function run(): Promise<number> {
 				status: blocked ? "BLOCKED" : "FAIL",
 				reasonCode: blocked ? "inference_external_block" : "inference_behavioral_failure",
 				requestedModel,
+				requestedEffort: decision.selectedEffort,
+				effortReason: decision.effortReason,
 				scenarioId: entry.scenario.id,
 				repetition: entry.repetition,
 				effectiveTier: decision.effectiveTier,
@@ -982,7 +1268,7 @@ async function run(): Promise<number> {
 	});
 	const report = redactSecretStrings(
 		{
-			schemaVersion: 2,
+			schemaVersion: 3,
 			startedAt: warmupRows[0]?.startedAt ?? measuredRows[0]?.startedAt ?? new Date().toISOString(),
 			finishedAt: new Date().toISOString(),
 			git,

--- a/packages/coding-agent/scripts/routing-matrix-report.schema.json
+++ b/packages/coding-agent/scripts/routing-matrix-report.schema.json
@@ -4,7 +4,7 @@
 	"type": "object",
 	"required": ["schemaVersion", "git", "parameters", "inventory", "warmups", "measured", "summary", "security"],
 	"properties": {
-		"schemaVersion": { "const": 2 },
+		"schemaVersion": { "const": 3 },
 		"startedAt": { "type": "string" },
 		"finishedAt": { "type": "string" },
 		"git": {
@@ -18,12 +18,16 @@
 		},
 		"parameters": {
 			"type": "object",
-			"required": ["dryRun", "repetitions", "warmups", "lanes"],
+			"required": ["profile", "dryRun", "repetitions", "warmups", "lanes", "scenarios", "timeoutMs"],
 			"properties": {
+				"profile": { "enum": ["canonical", "subscription"] },
 				"dryRun": { "type": "boolean" },
 				"repetitions": { "type": "integer", "minimum": 1 },
 				"warmups": { "type": "integer", "minimum": 0 },
-				"lanes": { "type": "array", "items": { "type": "string" } }
+				"lanes": { "type": "array", "items": { "type": "string" } },
+				"scenarios": { "type": "array", "items": { "type": "string" } },
+				"timeoutMs": { "type": "integer", "minimum": 1 },
+				"reportDir": { "type": "string" }
 			}
 		},
 		"capabilities": { "type": "array" },

--- a/packages/coding-agent/src/commit/model-selection.ts
+++ b/packages/coding-agent/src/commit/model-selection.ts
@@ -2,13 +2,12 @@ import type { ThinkingLevel } from "@f5-sales-demo/pi-agent-core";
 import type { Api, Model } from "@f5-sales-demo/pi-ai";
 import { MODEL_ROLE_IDS } from "../config/model-registry";
 import {
+	findPriorityRoleModel,
 	type ModelLookupRegistry,
-	parseModelPattern,
 	resolveModelRoleValue,
 	resolveRoleSelection,
 } from "../config/model-resolver";
 import type { Settings } from "../config/settings";
-import MODEL_PRIO from "../priority.json" with { type: "json" };
 
 export interface ResolvedCommitModel {
 	model: Model<Api>;
@@ -54,10 +53,8 @@ export async function resolveSmolModel(
 		if (apiKey) return { model: resolvedSmol.model, apiKey, thinkingLevel: resolvedSmol.thinkingLevel };
 	}
 
-	const matchPreferences = { usageOrder: settings.getStorage()?.getModelUsageOrder() };
-	for (const pattern of MODEL_PRIO.smol) {
-		const candidate = parseModelPattern(pattern, available, matchPreferences, { modelRegistry }).model;
-		if (!candidate) continue;
+	const candidate = await findPriorityRoleModel(modelRegistry, "smol", undefined, false);
+	if (candidate) {
 		const apiKey = await modelRegistry.getApiKey(candidate);
 		if (apiKey) return { model: candidate, apiKey };
 	}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1470,10 +1470,27 @@ export class ModelRegistry {
 		try {
 			const manager = createModelManager({ ...options, cacheDbPath: this.#cacheDbPath });
 			const result = await manager.refresh(strategy);
-			return result.models.map(model =>
+			const models = result.models.map(model =>
 				model.provider === options.providerId ? model : { ...model, provider: options.providerId },
 			);
+			this.#providerDiscoveryStates.set(options.providerId, {
+				provider: options.providerId,
+				status: result.stale ? "cached" : "ok",
+				optional: false,
+				stale: result.stale,
+				fetchedAt: Date.now(),
+				models: models.map(model => model.id),
+			});
+			return models;
 		} catch (error) {
+			this.#providerDiscoveryStates.set(options.providerId, {
+				provider: options.providerId,
+				status: "unavailable",
+				optional: false,
+				stale: true,
+				models: [],
+				error: error instanceof Error ? error.message : String(error),
+			});
 			logger.warn("model discovery failed for provider", {
 				provider: options.providerId,
 				error: error instanceof Error ? error.message : String(error),

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1225,32 +1225,60 @@ export async function findSmolModel(
 	modelRegistry: ModelLookupRegistry,
 	savedModel?: string,
 ): Promise<Model<Api> | undefined> {
+	return findPriorityRoleModel(modelRegistry, "smol", savedModel);
+}
+
+export async function findPriorityRoleModel(
+	modelRegistry: ModelLookupRegistry,
+	role: "smol" | "slow",
+	savedModel?: string,
+	fallbackToFirst = true,
+): Promise<Model<Api> | undefined> {
+	return resolvePriorityRoleCandidates(modelRegistry, role, savedModel, fallbackToFirst)[0];
+}
+
+/** Shared ordered candidates for role consumers that need fallback retries. */
+export function resolvePriorityRoleCandidates(
+	modelRegistry: ModelLookupRegistry,
+	role: "smol" | "slow",
+	savedModel?: string,
+	includeAllFallbacks = true,
+): Model<Api>[] {
 	const availableModels = modelRegistry.getAvailable();
-	if (availableModels.length === 0) return undefined;
+	if (availableModels.length === 0) return [];
+	const candidates: Model<Api>[] = [];
+	const add = (model: Model<Api> | undefined): void => {
+		if (!model) return;
+		if (candidates.some(item => item.provider === model.provider && item.id === model.id)) return;
+		candidates.push(model);
+	};
 
 	// 1. Try saved model from settings
 	if (savedModel) {
 		const match = resolveModelFromString(savedModel, availableModels, undefined, modelRegistry);
-		if (match) return match;
+		add(match);
 	}
 
 	// 2. Try priority chain
-	for (const pattern of MODEL_PRIO.smol) {
+	for (const pattern of MODEL_PRIO[role]) {
 		// Try exact match with provider prefix
 		const providerMatch = availableModels.find(m => `${m.provider}/${m.id}`.toLowerCase() === pattern);
-		if (providerMatch) return providerMatch;
+		add(providerMatch);
 
 		// Try exact match first
 		const exactMatch = parseModelPattern(pattern, availableModels, undefined, { modelRegistry }).model;
-		if (exactMatch) return exactMatch;
+		add(exactMatch);
 
 		// Try fuzzy match (substring)
-		const fuzzyMatch = availableModels.find(m => m.id.toLowerCase().includes(pattern));
-		if (fuzzyMatch) return fuzzyMatch;
+		const fuzzyMatch = availableModels.find(m => m.id.toLowerCase().includes(pattern.toLowerCase()));
+		add(fuzzyMatch);
 	}
 
-	// 3. Fallback to first available (same as default)
-	return availableModels[0];
+	// 3. Optional full fallback order for retrying consumers.
+	if (includeAllFallbacks) {
+		for (const model of availableModels) add(model);
+	}
+	return candidates;
 }
 
 /**
@@ -1265,26 +1293,5 @@ export async function findSlowModel(
 	modelRegistry: ModelLookupRegistry,
 	savedModel?: string,
 ): Promise<Model<Api> | undefined> {
-	const availableModels = modelRegistry.getAvailable();
-	if (availableModels.length === 0) return undefined;
-
-	// 1. Try saved model from settings
-	if (savedModel) {
-		const match = resolveModelFromString(savedModel, availableModels, undefined, modelRegistry);
-		if (match) return match;
-	}
-
-	// 2. Try priority chain
-	for (const pattern of MODEL_PRIO.slow) {
-		// Try exact match first
-		const exactMatch = parseModelPattern(pattern, availableModels, undefined, { modelRegistry }).model;
-		if (exactMatch) return exactMatch;
-
-		// Try fuzzy match (substring)
-		const fuzzyMatch = availableModels.find(m => m.id.toLowerCase().includes(pattern.toLowerCase()));
-		if (fuzzyMatch) return fuzzyMatch;
-	}
-
-	// 3. Fallback to first available (same as default)
-	return availableModels[0];
+	return findPriorityRoleModel(modelRegistry, "slow", savedModel);
 }

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -544,6 +544,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"routing.profile": {
+		type: "enum",
+		values: ["none", "google-antigravity", "openai-codex"] as const,
+		default: "none",
+		ui: {
+			tab: "model",
+			label: "Routing Profile",
+			description: "Provider-sticky subscription routing profile",
+			submenu: true,
+		},
+	},
+
 	"routing.profiler": {
 		type: "enum",
 		values: ["rules", "hybrid"] as const,

--- a/packages/coding-agent/src/modes/controllers/login-model.ts
+++ b/packages/coding-agent/src/modes/controllers/login-model.ts
@@ -1,5 +1,6 @@
 import { ThinkingLevel } from "@f5-sales-demo/pi-agent-core";
 import { canonicalizeOAuthProviderId, type Model } from "@f5-sales-demo/pi-ai";
+import { applySubscriptionProfileRoles, type SubscriptionProfileId } from "../../routing/subscription-profiles";
 
 export interface LoginModelChoice {
 	label: string;
@@ -39,6 +40,14 @@ export const GOOGLE_ANTIGRAVITY_LOGIN_MODEL_CHOICE: LoginModelChoice = {
 	thinkingLevel: ThinkingLevel.High,
 };
 
+export const OPENAI_CODEX_LOGIN_MODEL_CHOICE: LoginModelChoice = {
+	label: "GPT-5.6 Terra",
+	description: "Balanced OpenAI Codex subscription model with medium reasoning",
+	provider: "openai-codex",
+	modelId: "gpt-5.6-terra",
+	thinkingLevel: ThinkingLevel.Medium,
+};
+
 export function getAvailableLiteLLMLoginModelChoices(availableModelIds: readonly string[]): LiteLLMLoginModelChoice[] {
 	const available = new Set(availableModelIds);
 	return LITELLM_LOGIN_MODEL_CHOICES.filter(choice => available.has(choice.modelId));
@@ -49,10 +58,23 @@ export function getAvailableLiteLLMLoginModelChoices(availableModelIds: readonly
  * Kept structural so the login flow can call it without pulling in the full
  * AgentSession type, and so it stays trivially unit-testable.
  */
-interface ModelApplicableSession {
+interface BaseModelApplicableSession {
 	modelRegistry: { getAll(): Model[] };
 	setModel(model: Model, role: "default", options: { selector: string; thinkingLevel: ThinkingLevel }): Promise<void>;
 	setThinkingLevel(level: ThinkingLevel): void;
+}
+
+interface ModelApplicableSession extends BaseModelApplicableSession {
+	modelRegistry: {
+		getAll(): Model[];
+		getProviderDiscoveryState?(provider: string): { status: string; stale: boolean } | undefined;
+	};
+	settings?: {
+		getModelRoles(): Readonly<Record<string, string | undefined>>;
+		get?(key: "routing.profile"): "none" | SubscriptionProfileId;
+		set(key: "modelRoles", value: Record<string, string>): void;
+		set(key: "routing.profile", value: "none" | SubscriptionProfileId): void;
+	};
 }
 
 /**
@@ -62,7 +84,7 @@ interface ModelApplicableSession {
  * Returns true when the exact provider/model pair resolves after registry refresh.
  */
 export async function applyModelAfterLogin(
-	session: ModelApplicableSession,
+	session: BaseModelApplicableSession,
 	choice: LoginModelChoice,
 ): Promise<boolean> {
 	const resolved = session.modelRegistry
@@ -88,7 +110,52 @@ export async function applyOAuthLoginModel(
 	session: ModelApplicableSession,
 	providerId: string,
 ): Promise<LoginModelChoice | undefined> {
-	if (canonicalizeOAuthProviderId(providerId) !== GOOGLE_ANTIGRAVITY_LOGIN_MODEL_CHOICE.provider) return undefined;
-	const applied = await applyModelAfterLogin(session, GOOGLE_ANTIGRAVITY_LOGIN_MODEL_CHOICE);
-	return applied ? GOOGLE_ANTIGRAVITY_LOGIN_MODEL_CHOICE : undefined;
+	const canonicalProvider = canonicalizeOAuthProviderId(providerId);
+	const choice =
+		canonicalProvider === GOOGLE_ANTIGRAVITY_LOGIN_MODEL_CHOICE.provider
+			? GOOGLE_ANTIGRAVITY_LOGIN_MODEL_CHOICE
+			: canonicalProvider === OPENAI_CODEX_LOGIN_MODEL_CHOICE.provider
+				? OPENAI_CODEX_LOGIN_MODEL_CHOICE
+				: undefined;
+	if (!choice) return undefined;
+	const discovery = session.modelRegistry.getProviderDiscoveryState?.(canonicalProvider);
+	if (session.modelRegistry.getProviderDiscoveryState && (discovery?.status !== "ok" || discovery.stale)) {
+		return undefined;
+	}
+
+	const settings = session.settings;
+	const previousProfile = settings?.get?.("routing.profile") ?? "none";
+	const previousRoles = settings
+		? Object.fromEntries(
+				Object.entries(settings.getModelRoles()).filter(
+					(entry): entry is [string, string] => entry[1] !== undefined,
+				),
+			)
+		: {};
+	if (settings) {
+		const available = session.modelRegistry.getAll().map(model => `${model.provider}/${model.id}`);
+		const profile = applySubscriptionProfileRoles(
+			canonicalProvider as SubscriptionProfileId,
+			previousRoles,
+			available,
+		);
+		if (!profile.applied) return undefined;
+		settings.set("modelRoles", profile.roles);
+		settings.set("routing.profile", canonicalProvider as SubscriptionProfileId);
+	}
+
+	try {
+		const applied = await applyModelAfterLogin(session, choice);
+		if (!applied && settings) {
+			settings.set("modelRoles", previousRoles);
+			settings.set("routing.profile", previousProfile);
+		}
+		return applied ? choice : undefined;
+	} catch (error) {
+		if (settings) {
+			settings.set("modelRoles", previousRoles);
+			settings.set("routing.profile", previousProfile);
+		}
+		throw error;
+	}
 }

--- a/packages/coding-agent/src/routing/commands.ts
+++ b/packages/coding-agent/src/routing/commands.ts
@@ -1,15 +1,18 @@
 import type { RoutingCoordinator } from "./coordinator";
+import { SUBSCRIPTION_ROUTING_PROFILES, type SubscriptionProfileId } from "./subscription-profiles";
 import type { RoutingMode } from "./types";
 
 export interface CommandContext {
 	coordinator: RoutingCoordinator;
 	currentModel: string;
 	mode: RoutingMode;
+	profile?: string;
 }
 
 export interface RouteCommandResult {
 	output: string;
 	newMode?: RoutingMode;
+	newProfile?: SubscriptionProfileId;
 }
 
 export async function handleRouteCommand(args: string[], ctx: CommandContext): Promise<RouteCommandResult> {
@@ -21,6 +24,7 @@ export async function handleRouteCommand(args: string[], ctx: CommandContext): P
 		case "status": {
 			const lines = [
 				`Routing Mode: ${ctx.mode}`,
+				`Routing Profile: ${ctx.profile ?? "none"}`,
 				`Active Model: ${ctx.currentModel}`,
 				`Active Tier: ${state.currentTier ?? "balanced"}`,
 				`Downshift Streak: ${state.downshiftStreak}`,
@@ -52,9 +56,19 @@ export async function handleRouteCommand(args: string[], ctx: CommandContext): P
 			};
 		}
 
+		case "profile": {
+			const profile = args[1] as SubscriptionProfileId | undefined;
+			if (!profile || !(profile in SUBSCRIPTION_ROUTING_PROFILES)) {
+				return {
+					output: `Usage: /route profile [${Object.keys(SUBSCRIPTION_ROUTING_PROFILES).join("|")}]`,
+				};
+			}
+			return { output: `Routing profile selected: ${profile}`, newProfile: profile };
+		}
+
 		default: {
 			return {
-				output: `Unknown /route subcommand '${subcommand}'. Usage: /route [status|off|shadow|auto]`,
+				output: `Unknown /route subcommand '${subcommand}'. Usage: /route [status|off|shadow|auto|profile]`,
 			};
 		}
 	}

--- a/packages/coding-agent/src/routing/coordinator.ts
+++ b/packages/coding-agent/src/routing/coordinator.ts
@@ -1,4 +1,5 @@
 import { classifyTaskHybrid } from "./classifier";
+import { resolveRoutingEffort } from "./effort";
 import { resolveModelPool } from "./presets";
 import { resolveTierModel } from "./resolver";
 import { type RoutingState, RoutingStateMachine } from "./state-machine";
@@ -24,6 +25,7 @@ export interface EvaluateTurnOptions {
 	profilerMode?: "rules" | "hybrid";
 	disabledPresets?: readonly string[];
 	familyPolicy?: "sticky" | "configured-mixed";
+	tierEffort?: Record<string, string>;
 
 	downshiftAfterTurns?: number;
 	getModelContextWindow?: (modelId: string) => number;
@@ -169,6 +171,13 @@ export class RoutingCoordinator {
 		}
 
 		const isShadow = options.mode === "shadow";
+		const effort = resolveRoutingEffort(
+			resolved.effectiveTier ?? effectiveTier,
+			taskProfile.complexityScore,
+			Boolean(options.priorRejection),
+			pool.effortPolicy,
+			options.tierEffort,
+		);
 		if (!isShadow) {
 			// Commit state machine transition only on successful non-degraded resolution
 			this.stateMachine.restoreState(targetSm.getState());
@@ -188,6 +197,8 @@ export class RoutingCoordinator {
 			desiredTier: taskProfile.desiredTier,
 			effectiveTier: resolved.effectiveTier,
 			selectedModel: resolved.selectedModel,
+			selectedEffort: effort.effort,
+			effortReason: effort.reason,
 			source: options.profilerMode === "rules" ? "rules" : "hybrid",
 			applied,
 			reasons,

--- a/packages/coding-agent/src/routing/effort.ts
+++ b/packages/coding-agent/src/routing/effort.ts
@@ -1,4 +1,4 @@
-import type { RoutingTier } from "./types";
+import type { RoutingEffort, RoutingEffortPolicy, RoutingEffortReason, RoutingTier } from "./types";
 
 const DEFAULT_EFFORT_MAP: Record<RoutingTier, string> = {
 	utility: "low",
@@ -11,4 +11,22 @@ export function mapTierToEffort(tier: RoutingTier, customMap?: Record<string, st
 		return customMap[tier];
 	}
 	return DEFAULT_EFFORT_MAP[tier] ?? "medium";
+}
+
+export function resolveRoutingEffort(
+	tier: RoutingTier,
+	complexityScore: number,
+	priorRejection: boolean,
+	policy?: RoutingEffortPolicy,
+	customMap?: Record<string, string>,
+): { effort: RoutingEffort; reason: RoutingEffortReason } {
+	const defaultEffort = (customMap?.[tier] ?? policy?.byTier[tier] ?? mapTierToEffort(tier)) as RoutingEffort;
+	const escalation = policy?.frontierEscalation;
+	if (tier === "frontier" && escalation) {
+		if (priorRejection) return { effort: escalation.effort, reason: "rejection_escalation" };
+		if (complexityScore >= escalation.minimumComplexityScore) {
+			return { effort: escalation.effort, reason: "complexity_escalation" };
+		}
+	}
+	return { effort: defaultEffort, reason: "tier_default" };
 }

--- a/packages/coding-agent/src/routing/index.ts
+++ b/packages/coding-agent/src/routing/index.ts
@@ -10,4 +10,5 @@ export * from "./presets";
 export * from "./profiler";
 export * from "./resolver";
 export * from "./state-machine";
+export * from "./subscription-profiles";
 export * from "./types";

--- a/packages/coding-agent/src/routing/presets.ts
+++ b/packages/coding-agent/src/routing/presets.ts
@@ -1,6 +1,8 @@
+import { OPENAI_CODEX_ROUTING_POOL } from "./subscription-profiles";
 import type { RoutingPoolConfig } from "./types";
 
 export const BUILTIN_ROUTING_PRESETS: Record<string, RoutingPoolConfig> = {
+	[OPENAI_CODEX_ROUTING_POOL.id]: OPENAI_CODEX_ROUTING_POOL,
 	"openai/gpt-5.6": {
 		id: "openai/gpt-5.6",
 		provider: "openai",

--- a/packages/coding-agent/src/routing/subscription-profiles.ts
+++ b/packages/coding-agent/src/routing/subscription-profiles.ts
@@ -1,0 +1,82 @@
+import type { RoutingPoolConfig } from "./types";
+
+export type SubscriptionProfileId = "google-antigravity" | "openai-codex";
+
+export interface SubscriptionRoutingProfile {
+	id: SubscriptionProfileId;
+	provider: string;
+	roles: Readonly<Record<"smol" | "default" | "slow" | "plan", string>>;
+	pool?: RoutingPoolConfig;
+}
+
+const OPENAI_CODEX_POOL: RoutingPoolConfig = {
+	id: "openai-codex/gpt-5.6",
+	provider: "openai-codex",
+	tiers: {
+		utility: "gpt-5.6-luna",
+		balanced: "gpt-5.6-terra",
+		frontier: "gpt-5.6-sol",
+	},
+	effortPolicy: {
+		byTier: { utility: "low", balanced: "medium", frontier: "high" },
+		frontierEscalation: { effort: "xhigh", minimumComplexityScore: 90 },
+	},
+};
+
+export const SUBSCRIPTION_ROUTING_PROFILES: Readonly<Record<SubscriptionProfileId, SubscriptionRoutingProfile>> = {
+	"google-antigravity": {
+		id: "google-antigravity",
+		provider: "google-antigravity",
+		roles: {
+			smol: "google-antigravity/gemini-3.6-flash-high:high",
+			default: "google-antigravity/gemini-3.6-flash-high:high",
+			slow: "google-antigravity/gemini-3.1-pro-high-vertex:high",
+			plan: "google-antigravity/gemini-3.1-pro-high-vertex:high",
+		},
+	},
+	"openai-codex": {
+		id: "openai-codex",
+		provider: "openai-codex",
+		roles: {
+			smol: "openai-codex/gpt-5.6-luna:low",
+			default: "openai-codex/gpt-5.6-terra:medium",
+			slow: "openai-codex/gpt-5.6-sol:high",
+			plan: "openai-codex/gpt-5.6-sol:high",
+		},
+		pool: OPENAI_CODEX_POOL,
+	},
+};
+
+function modelSelector(roleSelector: string): string {
+	const colon = roleSelector.lastIndexOf(":");
+	return colon > roleSelector.indexOf("/") ? roleSelector.slice(0, colon) : roleSelector;
+}
+
+export interface ApplySubscriptionProfileResult {
+	applied: boolean;
+	roles: Record<string, string>;
+	missingModels: string[];
+}
+
+/** Resolve a complete profile before mutating settings so partial entitlement can never partially apply. */
+export function applySubscriptionProfileRoles(
+	profileId: SubscriptionProfileId,
+	currentRoles: Readonly<Record<string, string>>,
+	availableModels: readonly string[],
+): ApplySubscriptionProfileResult {
+	const profile = SUBSCRIPTION_ROUTING_PROFILES[profileId];
+	const available = new Set(availableModels);
+	const missingModels = [
+		...new Set(
+			Object.values(profile.roles)
+				.map(modelSelector)
+				.filter(model => !available.has(model)),
+		),
+	];
+	if (missingModels.length > 0) {
+		return { applied: false, roles: { ...currentRoles }, missingModels };
+	}
+	return { applied: true, roles: { ...currentRoles, ...profile.roles }, missingModels: [] };
+}
+
+export const OPENAI_CODEX_ROUTING_POOL = OPENAI_CODEX_POOL;

--- a/packages/coding-agent/src/routing/types.ts
+++ b/packages/coding-agent/src/routing/types.ts
@@ -62,11 +62,23 @@ export interface RoutingPoolTiers {
 	frontier: string;
 }
 
+export type RoutingEffort = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+export type RoutingEffortReason = "tier_default" | "complexity_escalation" | "rejection_escalation";
+
+export interface RoutingEffortPolicy {
+	byTier: Partial<Record<RoutingTier, RoutingEffort>>;
+	frontierEscalation?: {
+		effort: RoutingEffort;
+		minimumComplexityScore: number;
+	};
+}
+
 export interface RoutingPoolConfig {
 	id: string;
 	provider?: string;
 	allowMixed?: boolean;
 	tiers: RoutingPoolTiers;
+	effortPolicy?: RoutingEffortPolicy;
 }
 
 export interface RoutingDecision {
@@ -77,6 +89,8 @@ export interface RoutingDecision {
 	desiredTier?: RoutingTier;
 	effectiveTier?: RoutingTier;
 	selectedModel?: string;
+	selectedEffort?: RoutingEffort;
+	effortReason?: RoutingEffortReason;
 	source?: RoutingDecisionSource;
 	applied: boolean;
 	reasons: RoutingReasonCode[];

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1260,6 +1260,7 @@ export class AgentSession {
 	 */
 	public getRoutingStatus(): {
 		mode: RoutingMode;
+		profile: string;
 		currentTier?: RoutingTier;
 		downshiftStreak: number;
 		manualPin?: string;
@@ -1269,6 +1270,7 @@ export class AgentSession {
 		const state = this.#routingCoordinator.getStateMachine().getState();
 		return {
 			mode,
+			profile: (this.settings.get("routing.profile") as string) ?? "none",
 			currentTier: state.currentTier,
 			downshiftStreak: state.downshiftStreak,
 			manualPin: state.manualPin,
@@ -1281,6 +1283,48 @@ export class AgentSession {
 	 */
 	public setRoutingMode(mode: RoutingMode): void {
 		this.settings.set("routing.mode", mode);
+	}
+
+	public async applyRoutingProfile(
+		profileId: import("../routing/subscription-profiles").SubscriptionProfileId,
+	): Promise<{ applied: boolean; missingModels: string[] }> {
+		const { applySubscriptionProfileRoles } = await import("../routing/subscription-profiles");
+		await this.#modelRegistry.refresh("online");
+		const discovery = this.#modelRegistry.getProviderDiscoveryState(profileId);
+		if (!discovery || discovery.stale || discovery.status !== "ok") {
+			return { applied: false, missingModels: [`${profileId}:authoritative-inventory`] };
+		}
+		const currentRoles = Object.fromEntries(
+			Object.entries(this.settings.getModelRoles()).filter(
+				(entry): entry is [string, string] => entry[1] !== undefined,
+			),
+		);
+		const resolved = applySubscriptionProfileRoles(
+			profileId,
+			currentRoles,
+			this.#modelRegistry.getAvailable().map(model => `${model.provider}/${model.id}`),
+		);
+		if (!resolved.applied) return { applied: false, missingModels: resolved.missingModels };
+
+		const previousProfile = this.settings.get("routing.profile");
+		const previousModel = this.model;
+		const previousThinking = this.thinkingLevel;
+		this.settings.set("modelRoles", resolved.roles);
+		this.settings.set("routing.profile", profileId);
+		const next = this.resolveRoleModelWithThinking("default");
+		try {
+			if (!next.model) throw new Error(`Default model for ${profileId} did not resolve`);
+			await this.setModelTemporary(next.model, next.thinkingLevel);
+			return { applied: true, missingModels: [] };
+		} catch (error) {
+			this.settings.set("modelRoles", { ...currentRoles });
+			this.settings.set("routing.profile", previousProfile);
+			if (previousModel) {
+				this.#setModelWithProviderSessionReset(previousModel, "runtime-switch");
+				this.setThinkingLevel(previousThinking);
+			}
+			throw error;
+		}
 	}
 
 	/**
@@ -1355,18 +1399,17 @@ export class AgentSession {
 						const previousTier = this.#routingCoordinator.getState().currentTier;
 						const previousFloor = this.#routingCoordinator.getState().escalationFloor;
 						const previousModel = this.model;
+						const previousThinkingLevel = this.thinkingLevel;
 
 						try {
-							await this.setModelRoutingSwitch(targetModel);
+							const effortMap = this.settings.get("routing.tierEffort") as Record<string, string> | undefined;
+							const { resolveRoutingEffort } = await import("../routing/effort");
+							const effort = resolveRoutingEffort(targetTier, 100, true, pool.effortPolicy, effortMap);
+							await this.setModelRoutingSwitch(targetModel, effort.effort as ThinkingLevel);
 							this.agent.abort();
 
 							this.#routingCoordinator.getStateMachine().setEscalationFloor(targetTier);
 							this.#routingCoordinator.restoreState({ currentTier: targetTier });
-							const effortMap = this.settings.get("routing.tierEffort") as Record<string, string> | undefined;
-							const { mapTierToEffort } = await import("../routing/effort");
-							const effort = mapTierToEffort(targetTier, effortMap);
-							this.setThinkingLevel(effort as any);
-
 							this.#emitSessionEvent(
 								sanitizeRoutingEvent({
 									type: "routing_escalated",
@@ -1376,6 +1419,8 @@ export class AgentSession {
 									effectiveTier: targetTier,
 									state: this.#routingCoordinator.getState(),
 									selectedModel: this.model ? `${this.model.provider}/${this.model.id}` : undefined,
+									selectedEffort: effort.effort,
+									effortReason: effort.reason,
 									escalated: true,
 								}),
 							).catch(() => {});
@@ -1389,6 +1434,7 @@ export class AgentSession {
 							}
 							if (previousModel) {
 								this.#setModelWithProviderSessionReset(previousModel, "runtime-switch");
+								this.setThinkingLevel(previousThinkingLevel);
 								this.sessionManager.appendModelChange(
 									`${previousModel.provider}/${previousModel.id}`,
 									"routing_switch_rollback",
@@ -2939,6 +2985,7 @@ export class AgentSession {
 			customPools: validateCustomPools(this.settings.get("routing.pools")),
 			disabledPresets: (this.settings.get("routing.disabledPresets") as readonly string[]) ?? [],
 			familyPolicy: (this.settings.get("routing.familyPolicy") as "sticky" | "configured-mixed") ?? "sticky",
+			tierEffort: this.settings.get("routing.tierEffort") as Record<string, string>,
 			profilerMode: (this.settings.get("routing.profiler") as any) ?? "hybrid",
 			contextEstimate,
 			signal: options?.signal,
@@ -2959,6 +3006,8 @@ export class AgentSession {
 			},
 			applied: decision.applied,
 			decision: decision.selectedModel,
+			selectedEffort: decision.selectedEffort,
+			effortReason: decision.effortReason,
 			delegation: decision.delegation,
 		} as any).catch(() => {});
 
@@ -2995,9 +3044,9 @@ export class AgentSession {
 					}
 				}
 
-				if (needsSwitch) {
-					await this.setModelRoutingSwitch(targetModel);
-				}
+				const selectedEffort = decision.selectedEffort as ThinkingLevel | undefined;
+				if (needsSwitch) await this.setModelRoutingSwitch(targetModel, selectedEffort);
+				else if (selectedEffort !== undefined) this.setThinkingLevel(selectedEffort);
 			}
 		}
 
@@ -4125,7 +4174,7 @@ export class AgentSession {
 	 * Temporarily set model from automated routing, preserving original manual model state.
 	 * Does NOT overwrite manual pin or retry fallback original selector.
 	 */
-	async setModelRoutingSwitch(model: Model): Promise<void> {
+	async setModelRoutingSwitch(model: Model, thinkingLevel?: ThinkingLevel): Promise<void> {
 		const previousEditMode = this.#resolveActiveEditMode();
 
 		let targetModel = model;
@@ -4153,7 +4202,7 @@ export class AgentSession {
 		this.sessionManager.appendModelChange(`${targetModel.provider}/${targetModel.id}`, "routing_switch");
 		this.settings.getStorage()?.recordModelUsage(`${targetModel.provider}/${targetModel.id}`);
 
-		this.setThinkingLevel(this.thinkingLevel);
+		this.setThinkingLevel(thinkingLevel ?? this.thinkingLevel);
 		await this.#syncEditToolModeAfterModelChange(previousEditMode);
 	}
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1587,6 +1587,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 			{ name: "off", description: "Disable dynamic model routing" },
 			{ name: "shadow", description: "Record dynamic model routing decisions speculatively without switching" },
 			{ name: "auto", description: "Enable dynamic model routing and clear manual model pins" },
+			{ name: "profile", description: "Select a provider-sticky subscription routing profile" },
 		],
 		handle: async (command, runtime) => {
 			runtime.ctx.editor.addToHistory(command.text);
@@ -1601,9 +1602,16 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 				coordinator: (runtime.ctx.session as any).routingCoordinator,
 				currentModel,
 				mode: status.mode,
+				profile: status.profile,
 			});
 			if (res.newMode) {
 				runtime.ctx.session.setRoutingMode(res.newMode);
+			}
+			if (res.newProfile) {
+				const applied = await runtime.ctx.session.applyRoutingProfile(res.newProfile);
+				if (!applied.applied) {
+					res.output = `Routing profile ${res.newProfile} unavailable: ${applied.missingModels.join(", ")}`;
+				}
 			}
 			(runtime.ctx.ui as any).notify?.(res.output, "info");
 		},

--- a/packages/coding-agent/src/utils/commit-message-generator.ts
+++ b/packages/coding-agent/src/utils/commit-message-generator.ts
@@ -7,9 +7,8 @@ import type { Api, Model } from "@f5-sales-demo/pi-ai";
 import { completeSimple } from "@f5-sales-demo/pi-ai";
 import { logger, prompt } from "@f5-sales-demo/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
-import { resolveModelRoleValue } from "../config/model-resolver";
+import { resolveModelRoleValue, resolvePriorityRoleCandidates } from "../config/model-resolver";
 import type { Settings } from "../config/settings";
-import MODEL_PRIO from "../priority.json" with { type: "json" };
 import commitSystemPrompt from "../prompts/system/commit-message-system.md" with { type: "text" };
 import { toReasoningEffort } from "../thinking";
 
@@ -56,13 +55,7 @@ function getSmolModelCandidates(
 	});
 	addCandidate(configuredSmol.model, configuredSmol.thinkingLevel);
 
-	for (const pattern of MODEL_PRIO.smol) {
-		const needle = pattern.toLowerCase();
-		addCandidate(availableModels.find(m => m.id.toLowerCase() === needle));
-		addCandidate(availableModels.find(m => m.id.toLowerCase().includes(needle)));
-	}
-
-	for (const model of availableModels) {
+	for (const model of resolvePriorityRoleCandidates(registry, "smol")) {
 		addCandidate(model);
 	}
 

--- a/packages/coding-agent/test/agent-session-routing-rejection.test.ts
+++ b/packages/coding-agent/test/agent-session-routing-rejection.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@f5-sales-demo/pi-agent-core";
+import { Effort } from "@f5-sales-demo/pi-ai";
 import { TempDir } from "@f5-sales-demo/pi-utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import { Settings } from "../src/config/settings";
@@ -315,15 +316,22 @@ describe("AgentSession Routing Rejection Escalation (TDD)", () => {
 		settings.set("routing.internalOpenAiUrl", "https://internal-openai.example.com");
 		modelRegistry.getApiKey = async () => "mock-key";
 
-		const litellmGptModel = { provider: "litellm", id: "gpt-5.6-luna", api: "openai-responses" } as any;
+		const litellmGptModel = {
+			provider: "litellm",
+			id: "gpt-5.6-luna",
+			api: "openai-responses",
+			reasoning: true,
+			thinking: { mode: "effort", minLevel: Effort.Low, maxLevel: Effort.XHigh },
+		} as any;
 
-		await session.setModelRoutingSwitch(litellmGptModel);
+		await session.setModelRoutingSwitch(litellmGptModel, "low" as any);
 
 		const activeModel = session.model;
 		expect(activeModel).toBeDefined();
 		expect(activeModel?.provider).toBe("litellm");
 		expect(activeModel?.id).toBe("gpt-5.6-luna");
 		expect(activeModel?.baseUrl).toBe("https://internal-openai.example.com");
+		expect(session.thinkingLevel).toBe(Effort.Low);
 	});
 
 	it("should calculate correct delegation tokens and pass AbortSignal", async () => {

--- a/packages/coding-agent/test/bench-routing-matrix.test.ts
+++ b/packages/coding-agent/test/bench-routing-matrix.test.ts
@@ -1,15 +1,20 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
 	BASE_SCENARIOS,
+	CANONICAL_LANE_IDS,
 	classifyMeasuredRun,
 	computeExitCode,
 	createMultimodalMessage,
 	discoverLaneInventory,
+	discoverOAuthEntitlementInventory,
+	ESCALATION_SCENARIO,
 	expandLaneScenarios,
 	extractResponseText,
 	LANE_CAPABILITIES,
+	parseArgs,
 	reconcileLaneInventory,
 	redactSecretStrings,
+	SUBSCRIPTION_LANE_IDS,
 	validateContractIntegrity,
 	validateRoutingMatrixReport,
 } from "../scripts/bench-routing-matrix";
@@ -32,24 +37,52 @@ function capturedRequest(input: string | URL | Request, init?: RequestInit): Req
 }
 
 describe("routing matrix capability and scenario contract", () => {
-	it("declares five distinct required lanes and transports", () => {
-		expect(Object.keys(LANE_CAPABILITIES)).toEqual([
+	it("declares the canonical and subscription lane profiles independently", () => {
+		expect(CANONICAL_LANE_IDS).toEqual([
 			"openai",
 			"anthropic",
 			"litellm-openai",
 			"litellm-anthropic",
 			"google-vertex",
 		]);
+		expect(SUBSCRIPTION_LANE_IDS).toEqual(["google-antigravity", "openai-codex"]);
 		expect(LANE_CAPABILITIES.anthropic.clientProvider).toBe("anthropic");
 		expect(LANE_CAPABILITIES["litellm-anthropic"].clientProvider).toBe("anthropic");
 		expect(LANE_CAPABILITIES.anthropic.endpointKind).toBe("direct");
 		expect(LANE_CAPABILITIES["litellm-anthropic"].endpointKind).toBe("gateway");
 		expect(Object.values(LANE_CAPABILITIES).every(lane => lane.required)).toBe(true);
+		expect(parseArgs(["--profile", "subscription", "--dry-run"]).lanes).toEqual([
+			"google-antigravity",
+			"openai-codex",
+		]);
 	});
 
 	it("expands the canonical contract to 60 measured rows", () => {
-		const rows = expandLaneScenarios(Object.keys(LANE_CAPABILITIES), 3);
+		const rows = expandLaneScenarios([...CANONICAL_LANE_IDS], 3);
 		expect(rows).toHaveLength(60);
+	});
+
+	it("maps subscription tiers to the reviewed models and reasoning levels", () => {
+		expect(LANE_CAPABILITIES["google-antigravity"]).toMatchObject({
+			tiers: {
+				utility: "gemini-3.6-flash-high",
+				balanced: "gemini-3.6-flash-high",
+				frontier: "gemini-3.1-pro-high-vertex",
+			},
+			effortPolicy: { byTier: { utility: "high", balanced: "high", frontier: "high" } },
+		});
+		expect(LANE_CAPABILITIES["openai-codex"]).toMatchObject({
+			tiers: { utility: "gpt-5.6-luna", balanced: "gpt-5.6-terra", frontier: "gpt-5.6-sol" },
+			effortPolicy: {
+				byTier: { utility: "low", balanced: "medium", frontier: "high" },
+				frontierEscalation: { effort: "xhigh", minimumComplexityScore: 90 },
+			},
+		});
+		expect(ESCALATION_SCENARIO).toMatchObject({ expectedTier: "frontier", priorRejection: true });
+		expect(
+			parseArgs(["--profile", "subscription", "--lanes", "openai-codex", "--scenarios", "rejection-escalation"])
+				.scenarios,
+		).toEqual(["rejection-escalation"]);
 	});
 
 	it("profiles every scenario to its declared tier", () => {
@@ -74,6 +107,84 @@ describe("routing matrix capability and scenario contract", () => {
 });
 
 describe("provider-specific authenticated inventory", () => {
+	it("accepts only fresh OAuth entitlement discovery and preserves runtime model metadata", async () => {
+		const model = {
+			id: "gpt-5.6-luna",
+			provider: "openai-codex",
+			api: "openai-codex-responses",
+		} as any;
+		const result = await discoverOAuthEntitlementInventory(
+			LANE_CAPABILITIES["openai-codex"],
+			{ apiKey: "packed-oauth", authMechanism: "oauth-packed" },
+			async provider => ({
+				state: {
+					provider,
+					status: "ok",
+					optional: false,
+					stale: false,
+					models: ["gpt-5.6-luna"],
+				},
+				models: [model],
+			}),
+		);
+		expect(result.inventory.state).toBe("AVAILABLE");
+		expect(result.inventory.models).toEqual(["gpt-5.6-luna"]);
+		expect(result.models).toEqual([model]);
+	});
+
+	it("rejects cached entitlement inventory instead of falling back to bundled models", async () => {
+		const result = await discoverOAuthEntitlementInventory(
+			LANE_CAPABILITIES["google-antigravity"],
+			{ apiKey: "packed-oauth", authMechanism: "oauth-packed" },
+			async provider => ({
+				state: {
+					provider,
+					status: "cached",
+					optional: false,
+					stale: true,
+					models: ["gemini-3.6-flash-high"],
+				},
+				models: [],
+			}),
+		);
+		expect(result.inventory.state).toBe("BLOCKED_NETWORK");
+		expect(result.inventory.models).toEqual([]);
+		expect(result.inventory.reasonCode).toBe("stale_entitlement_inventory");
+	});
+
+	it("fails closed for missing OAuth, adapter state, empty entitlement, and incomplete metadata", async () => {
+		const capability = LANE_CAPABILITIES["openai-codex"];
+		const missingCredential = await discoverOAuthEntitlementInventory(capability, {}, async () => {
+			throw new Error("resolver must not run");
+		});
+		const missingState = await discoverOAuthEntitlementInventory(
+			capability,
+			{ apiKey: "packed-oauth", authMechanism: "oauth-packed" },
+			async () => ({ models: [] }),
+		);
+		const empty = await discoverOAuthEntitlementInventory(
+			capability,
+			{ apiKey: "packed-oauth", authMechanism: "oauth-packed" },
+			async provider => ({
+				state: { provider, status: "ok", optional: false, stale: false, models: [] },
+				models: [],
+			}),
+		);
+		const incomplete = await discoverOAuthEntitlementInventory(
+			capability,
+			{ apiKey: "packed-oauth", authMechanism: "oauth-packed" },
+			async provider => ({
+				state: { provider, status: "ok", optional: false, stale: false, models: ["gpt-5.6-luna"] },
+				models: [],
+			}),
+		);
+
+		expect(missingCredential.inventory.state).toBe("BLOCKED_AUTH");
+		expect(missingState.inventory.state).toBe("UNSUPPORTED_DISCOVERY");
+		expect(empty.inventory.state).toBe("FAIL_EMPTY_INVENTORY");
+		expect(incomplete.inventory.state).toBe("FAIL_SCHEMA");
+	});
+
 	it("uses OpenAI bearer auth and parses data records", async () => {
 		let request: Request | undefined;
 		const result = await discoverLaneInventory(
@@ -306,9 +417,17 @@ describe("contract, schema, and recursive security", () => {
 		expect(validateRoutingMatrixReport({ schemaVersion: 1 }).valid).toBe(false);
 		expect(
 			validateRoutingMatrixReport({
-				schemaVersion: 2,
+				schemaVersion: 3,
 				git: { commit: "abc", clean: true, exactHead: true },
-				parameters: { dryRun: false, repetitions: 3, warmups: 1, lanes: Object.keys(LANE_CAPABILITIES) },
+				parameters: {
+					profile: "canonical",
+					dryRun: false,
+					repetitions: 3,
+					warmups: 1,
+					lanes: [...CANONICAL_LANE_IDS],
+					scenarios: BASE_SCENARIOS.map(item => item.id),
+					timeoutMs: 20_000,
+				},
 				inventory: [],
 				warmups: [],
 				measured: [],

--- a/packages/coding-agent/test/login-model.test.ts
+++ b/packages/coding-agent/test/login-model.test.ts
@@ -6,18 +6,35 @@ import {
 	GOOGLE_ANTIGRAVITY_LOGIN_MODEL_CHOICE,
 	getAvailableLiteLLMLoginModelChoices,
 	LITELLM_LOGIN_MODEL_CHOICES,
+	OPENAI_CODEX_LOGIN_MODEL_CHOICE,
 } from "../src/modes/controllers/login-model";
 
 function makeSession(opts: { model?: { id: string; provider: string }; models: { id: string; provider: string }[] }) {
 	const setModel = vi.fn(async (_model: { id: string; provider: string }, _role: string, _opts?: unknown) => {});
 	const setThinkingLevel = vi.fn((_level: ThinkingLevel) => {});
+	let modelRoles: Record<string, string> = { vision: "google/vision" };
+	let routingProfile: "none" | "google-antigravity" | "openai-codex" = "none";
 	const session = {
 		model: opts.model,
 		modelRegistry: { getAll: () => opts.models },
+		settings: {
+			getModelRoles: () => modelRoles,
+			get: () => routingProfile,
+			set: (key: string, value: any) => {
+				if (key === "modelRoles") modelRoles = value;
+				if (key === "routing.profile") routingProfile = value;
+			},
+		},
 		setModel,
 		setThinkingLevel,
 	};
-	return { session, setModel, setThinkingLevel };
+	return {
+		session,
+		setModel,
+		setThinkingLevel,
+		getModelRoles: () => modelRoles,
+		getRoutingProfile: () => routingProfile,
+	};
 }
 const M = (id: string, provider = "litellm") => ({ id, provider });
 const GPT_CHOICE = LITELLM_LOGIN_MODEL_CHOICES.find(choice => choice.modelId === "gpt-5.6-sol")!;
@@ -84,9 +101,12 @@ describe("getAvailableLiteLLMLoginModelChoices", () => {
 
 describe("applyOAuthLoginModel", () => {
 	it("persists Gemini 3.6 Flash High after Google Antigravity login", async () => {
-		const { session, setModel, setThinkingLevel } = makeSession({
+		const { session, setModel, setThinkingLevel, getModelRoles, getRoutingProfile } = makeSession({
 			model: M("gpt-5.6-sol"),
-			models: [M("gemini-3.6-flash-high", "google-antigravity")],
+			models: [
+				M("gemini-3.6-flash-high", "google-antigravity"),
+				M("gemini-3.1-pro-high-vertex", "google-antigravity"),
+			],
 		});
 
 		const applied = await applyOAuthLoginModel(session as never, "google-antigravity");
@@ -97,12 +117,21 @@ describe("applyOAuthLoginModel", () => {
 			thinkingLevel: ThinkingLevel.High,
 		});
 		expect(setThinkingLevel).toHaveBeenCalledWith(ThinkingLevel.High);
+		expect(getModelRoles()).toMatchObject({
+			default: "google-antigravity/gemini-3.6-flash-high:high",
+			plan: "google-antigravity/gemini-3.1-pro-high-vertex:high",
+			vision: "google/vision",
+		});
+		expect(getRoutingProfile()).toBe("google-antigravity");
 	});
 
 	it("applies the canonical Gemini profile after enterprise alias login", async () => {
 		const { session, setModel, setThinkingLevel } = makeSession({
 			model: M("gpt-5.6-sol"),
-			models: [M("gemini-3.6-flash-high", "google-antigravity")],
+			models: [
+				M("gemini-3.6-flash-high", "google-antigravity"),
+				M("gemini-3.1-pro-high-vertex", "google-antigravity"),
+			],
 		});
 
 		const applied = await applyOAuthLoginModel(session as never, "google-antigravity-enterprise");
@@ -128,6 +157,21 @@ describe("applyOAuthLoginModel", () => {
 		expect(setThinkingLevel).not.toHaveBeenCalled();
 	});
 
+	it("does not apply a subscription profile from stale entitlement discovery", async () => {
+		const { session, setModel } = makeSession({
+			models: [
+				M("gemini-3.6-flash-high", "google-antigravity"),
+				M("gemini-3.1-pro-high-vertex", "google-antigravity"),
+			],
+		});
+		(session.modelRegistry as any).getProviderDiscoveryState = () => ({ status: "cached", stale: true });
+
+		const result = await applyOAuthLoginModel(session as never, "google-antigravity");
+
+		expect(result).toBeUndefined();
+		expect(setModel).not.toHaveBeenCalled();
+	});
+
 	it("does not change models for OAuth providers without a preferred login model", async () => {
 		const { session, setModel } = makeSession({
 			model: M("gpt-5.6-sol"),
@@ -138,5 +182,31 @@ describe("applyOAuthLoginModel", () => {
 
 		expect(applied).toBeUndefined();
 		expect(setModel).not.toHaveBeenCalled();
+	});
+
+	it("applies the complete OpenAI Codex subscription profile", async () => {
+		const { session, setModel, getModelRoles, getRoutingProfile } = makeSession({
+			model: undefined,
+			models: [
+				M("gpt-5.6-luna", "openai-codex"),
+				M("gpt-5.6-terra", "openai-codex"),
+				M("gpt-5.6-sol", "openai-codex"),
+			],
+		});
+
+		const applied = await applyOAuthLoginModel(session as never, "openai-codex");
+
+		expect(applied).toEqual(OPENAI_CODEX_LOGIN_MODEL_CHOICE);
+		expect(setModel).toHaveBeenCalledWith(M("gpt-5.6-terra", "openai-codex"), "default", {
+			selector: "openai-codex/gpt-5.6-terra",
+			thinkingLevel: ThinkingLevel.Medium,
+		});
+		expect(getModelRoles()).toMatchObject({
+			smol: "openai-codex/gpt-5.6-luna:low",
+			default: "openai-codex/gpt-5.6-terra:medium",
+			slow: "openai-codex/gpt-5.6-sol:high",
+			plan: "openai-codex/gpt-5.6-sol:high",
+		});
+		expect(getRoutingProfile()).toBe("openai-codex");
 	});
 });

--- a/packages/coding-agent/test/routing-commands.test.ts
+++ b/packages/coding-agent/test/routing-commands.test.ts
@@ -53,4 +53,24 @@ describe("/route Commands (I09)", () => {
 		expect(coordinator.getStateMachine().getState().manualPin).toBeUndefined(); // Pin cleared!
 		expect(result.output).toContain("Routing mode set to auto");
 	});
+
+	it("selects only reviewed provider-sticky subscription profiles", async () => {
+		const coordinator = new RoutingCoordinator();
+		const selected = await handleRouteCommand(["profile", "openai-codex"], {
+			coordinator,
+			currentModel: "openai-codex/gpt-5.6-terra",
+			mode: "auto",
+			profile: "none",
+		});
+		expect(selected.newProfile).toBe("openai-codex");
+		expect(selected.output).toContain("openai-codex");
+
+		const invalid = await handleRouteCommand(["profile", "unknown"], {
+			coordinator,
+			currentModel: "openai-codex/gpt-5.6-terra",
+			mode: "auto",
+		});
+		expect(invalid.newProfile).toBeUndefined();
+		expect(invalid.output).toContain("Usage");
+	});
 });

--- a/packages/coding-agent/test/routing-coordinator.test.ts
+++ b/packages/coding-agent/test/routing-coordinator.test.ts
@@ -95,4 +95,28 @@ describe("Routing Coordinator (I01)", () => {
 		// The active state machine should remain untouched
 		expect(sm.getState().downshiftStreak).toBe(1);
 	});
+
+	it("selects the Codex tier effort and escalates frontier reasoning independently", async () => {
+		const availableCodex = ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"];
+		const normal = await new RoutingCoordinator().evaluateTurn({
+			anchorModel: "openai-codex/gpt-5.6-terra",
+			mode: "auto",
+			prompt: "Update this one configuration field",
+			availableModels: availableCodex,
+		});
+		expect(normal.selectedModel).toBe("openai-codex/gpt-5.6-terra");
+		expect(normal.selectedEffort).toBe("medium");
+		expect(normal.effortReason).toBe("tier_default");
+
+		const rejected = await new RoutingCoordinator().evaluateTurn({
+			anchorModel: "openai-codex/gpt-5.6-terra",
+			mode: "auto",
+			prompt: "Review the architecture migration and security design",
+			priorRejection: true,
+			availableModels: availableCodex,
+		});
+		expect(rejected.selectedModel).toBe("openai-codex/gpt-5.6-sol");
+		expect(rejected.selectedEffort).toBe("xhigh");
+		expect(rejected.effortReason).toBe("rejection_escalation");
+	});
 });

--- a/packages/coding-agent/test/routing-effort.test.ts
+++ b/packages/coding-agent/test/routing-effort.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mapTierToEffort } from "../src/routing/effort";
+import { mapTierToEffort, resolveRoutingEffort } from "../src/routing/effort";
 
 describe("Model Effort Compatibility (R07)", () => {
 	it("should map utility, balanced, frontier to low, medium, high by default", () => {
@@ -13,5 +13,26 @@ describe("Model Effort Compatibility (R07)", () => {
 		expect(mapTierToEffort("utility", custom)).toBe("minimal");
 		expect(mapTierToEffort("balanced", custom)).toBe("low");
 		expect(mapTierToEffort("frontier", custom)).toBe("max");
+	});
+
+	it("uses a pool policy for normal tier effort and xhigh frontier escalation", () => {
+		const policy = {
+			byTier: { utility: "low", balanced: "medium", frontier: "high" },
+			frontierEscalation: { effort: "xhigh", minimumComplexityScore: 90 },
+		} as const;
+
+		expect(resolveRoutingEffort("utility", 10, false, policy)).toEqual({ effort: "low", reason: "tier_default" });
+		expect(resolveRoutingEffort("frontier", 89, false, policy)).toEqual({
+			effort: "high",
+			reason: "tier_default",
+		});
+		expect(resolveRoutingEffort("frontier", 90, false, policy)).toEqual({
+			effort: "xhigh",
+			reason: "complexity_escalation",
+		});
+		expect(resolveRoutingEffort("frontier", 70, true, policy)).toEqual({
+			effort: "xhigh",
+			reason: "rejection_escalation",
+		});
 	});
 });

--- a/packages/coding-agent/test/routing-presets.test.ts
+++ b/packages/coding-agent/test/routing-presets.test.ts
@@ -11,6 +11,10 @@ describe("Routing Presets (R03)", () => {
 		expect(BUILTIN_ROUTING_PRESETS["anthropic/claude"]).toBeDefined();
 		expect(BUILTIN_ROUTING_PRESETS["litellm/openai"]).toBeDefined();
 		expect(BUILTIN_ROUTING_PRESETS["litellm/anthropic"]).toBeDefined();
+		expect(BUILTIN_ROUTING_PRESETS["openai-codex/gpt-5.6"]).toMatchObject({
+			provider: "openai-codex",
+			tiers: { utility: "gpt-5.6-luna", balanced: "gpt-5.6-terra", frontier: "gpt-5.6-sol" },
+		});
 	});
 
 	it("should validate all built-in preset models exist in the registry", async () => {
@@ -20,6 +24,8 @@ describe("Routing Presets (R03)", () => {
 		const available = registry.getAll().map(m => `${m.provider}/${m.id}`);
 
 		for (const pool of Object.values(BUILTIN_ROUTING_PRESETS)) {
+			// OAuth subscription models are entitlement-discovered and intentionally need not exist in the bundle.
+			if (pool.provider === "openai-codex") continue;
 			const p = pool.provider ? `${pool.provider}/` : "";
 			expect(available).toContain(`${p}${pool.tiers.utility}`);
 			expect(available).toContain(`${p}${pool.tiers.balanced}`);

--- a/packages/coding-agent/test/subscription-routing-profiles.test.ts
+++ b/packages/coding-agent/test/subscription-routing-profiles.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { applySubscriptionProfileRoles, SUBSCRIPTION_ROUTING_PROFILES } from "../src/routing/subscription-profiles";
+
+describe("subscription routing profiles", () => {
+	it("defines the reviewed Google Antigravity role profile", () => {
+		expect(SUBSCRIPTION_ROUTING_PROFILES["google-antigravity"]?.roles).toEqual({
+			smol: "google-antigravity/gemini-3.6-flash-high:high",
+			default: "google-antigravity/gemini-3.6-flash-high:high",
+			slow: "google-antigravity/gemini-3.1-pro-high-vertex:high",
+			plan: "google-antigravity/gemini-3.1-pro-high-vertex:high",
+		});
+	});
+
+	it("defines the reviewed OpenAI Codex role profile and tier pool", () => {
+		const profile = SUBSCRIPTION_ROUTING_PROFILES["openai-codex"];
+		expect(profile?.roles).toEqual({
+			smol: "openai-codex/gpt-5.6-luna:low",
+			default: "openai-codex/gpt-5.6-terra:medium",
+			slow: "openai-codex/gpt-5.6-sol:high",
+			plan: "openai-codex/gpt-5.6-sol:high",
+		});
+		expect(profile?.pool).toMatchObject({
+			id: "openai-codex/gpt-5.6",
+			provider: "openai-codex",
+			tiers: { utility: "gpt-5.6-luna", balanced: "gpt-5.6-terra", frontier: "gpt-5.6-sol" },
+		});
+	});
+
+	it("fails closed without changing roles when a required entitlement is absent", () => {
+		const current = { default: "anthropic/claude-sonnet-4-6:high", commit: "pi/smol" };
+		const result = applySubscriptionProfileRoles("google-antigravity", current, [
+			"google-antigravity/gemini-3.6-flash-high",
+		]);
+
+		expect(result.applied).toBe(false);
+		expect(result.roles).toEqual(current);
+		expect(result.missingModels).toEqual(["google-antigravity/gemini-3.1-pro-high-vertex"]);
+	});
+
+	it("atomically replaces only managed roles after every model is entitled", () => {
+		const result = applySubscriptionProfileRoles(
+			"openai-codex",
+			{ default: "old/default", vision: "google/vision", custom: "custom/model" },
+			["openai-codex/gpt-5.6-luna", "openai-codex/gpt-5.6-terra", "openai-codex/gpt-5.6-sol"],
+		);
+
+		expect(result.applied).toBe(true);
+		expect(result.missingModels).toEqual([]);
+		expect(result.roles).toMatchObject({
+			vision: "google/vision",
+			custom: "custom/model",
+			default: "openai-codex/gpt-5.6-terra:medium",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- add provider-sticky Google Antigravity and OpenAI Codex subscription profiles
- route Codex Luna/Terra/Sol with low/medium/high effort and xhigh escalation
- reuse xcsh OAuth entitlement discovery and shared role selection without reading credential rows directly
- add genuine Google/Codex response attribution and schema-v3 subscription benchmark evidence
- preserve the canonical five-lane benchmark while excluding LiteLLM from this iteration

## Verification

- `bun run check`
- `bun run test` (coding-agent: 6,541 pass, 559 skip, 0 fail)
- focused coding-agent routing/login/inventory tests (111 pass, then 35 pass after final harness additions)
- focused AI Google/Codex transport tests (30 pass)
- canonical dry run: 5 warmups / 60 measured simulated rows
- subscription dry run: 2 warmups / 24 measured simulated rows
- Codex rejection dry run selects `gpt-5.6-sol` with `xhigh`

Closes #3129