### PR TITLE
test(container): add ARM64 Podman UAT

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -50,17 +50,35 @@ jobs:
           test "$(uname -m)" = "$XCSH_EXPECTED_MACHINE"
           bash ./scripts/tdd-docker.sh
 
+  podman-uat-harness:
+    name: podman-uat-harness
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Test ARM64 Podman UAT harness
+        run: bash ./scripts/test-uat-podman-arm64.sh
+
   container-test:
     name: container-test
     if: always()
-    needs: [container-build]
+    needs: [container-build, podman-uat-harness]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
-      - name: Require every architecture test
+      - name: Require architecture and harness tests
         env:
           CONTAINER_BUILD_RESULT: ${{ needs.container-build.result }}
-        run: test "$CONTAINER_BUILD_RESULT" = success
+          PODMAN_HARNESS_RESULT: ${{ needs.podman-uat-harness.result }}
+        run: |
+          test "$CONTAINER_BUILD_RESULT" = success
+          test "$PODMAN_HARNESS_RESULT" = success
 
   publish-ghcr:
     name: publish-ghcr

--- a/scripts/test-uat-podman-arm64.sh
+++ b/scripts/test-uat-podman-arm64.sh
@@ -141,7 +141,9 @@ if grep -Eq -- '--tmpfs [^ ]*(uid|gid)=' "$test_root/podman.log"; then
   exit 1
 fi
 grep -Fq -- '/home/xcsh/.xcsh:rw,exec,nosuid,nodev,size=256m,mode=1777' "$test_root/podman.log"
-grep -Fq -- '/etc/pki/ca-trust/source/anchors/xcsh-uat.pem:/etc/xcsh/uat-ca.pem:ro' "$test_root/podman.log"
+grep -Fq -- '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/ssl/certs/ca-certificates.crt:ro' "$test_root/podman.log"
+grep -Fq -- '--entrypoint bash' "$test_root/podman.log"
+grep -Fq -- 'xcsh --list-models >/dev/null' "$test_root/podman.log"
 if grep -Fq 'test-secret-never-log' "$test_root/podman.log" "$test_root/happy.json"; then
   echo "Credential leaked into logs or report." >&2
   exit 1

--- a/scripts/test-uat-podman-arm64.sh
+++ b/scripts/test-uat-podman-arm64.sh
@@ -141,6 +141,7 @@ if grep -Eq -- '--tmpfs [^ ]*(uid|gid)=' "$test_root/podman.log"; then
   exit 1
 fi
 grep -Fq -- '/home/xcsh/.xcsh:rw,exec,nosuid,nodev,size=256m,mode=1777' "$test_root/podman.log"
+grep -Fq -- '/etc/pki/ca-trust/source/anchors/xcsh-uat.pem:/etc/xcsh/uat-ca.pem:ro' "$test_root/podman.log"
 if grep -Fq 'test-secret-never-log' "$test_root/podman.log" "$test_root/happy.json"; then
   echo "Credential leaked into logs or report." >&2
   exit 1

--- a/scripts/test-uat-podman-arm64.sh
+++ b/scripts/test-uat-podman-arm64.sh
@@ -143,7 +143,7 @@ fi
 grep -Fq -- '/home/xcsh/.xcsh:rw,exec,nosuid,nodev,size=256m,mode=1777' "$test_root/podman.log"
 grep -Fq -- 'update-ca-trust' "$test_root/podman.log"
 grep -Fq -- '--entrypoint bash' "$test_root/podman.log"
-grep -Fq -- 'xcsh --list-models >/dev/null' "$test_root/podman.log"
+grep -Fq -- 'xcsh --list-models gpt-5.6-sol >/dev/null' "$test_root/podman.log"
 if grep -Fq 'test-secret-never-log' "$test_root/podman.log" "$test_root/happy.json"; then
   echo "Credential leaked into logs or report." >&2
   exit 1

--- a/scripts/test-uat-podman-arm64.sh
+++ b/scripts/test-uat-podman-arm64.sh
@@ -136,6 +136,11 @@ jq -e '
 ' "$test_root/happy.json" >/dev/null
 test "$(grep -c -- '--model' "$test_root/podman.log")" = 8
 grep -Fq -- '--timeout 120' "$test_root/podman.log"
+if grep -Eq -- '--tmpfs [^ ]*(uid|gid)=' "$test_root/podman.log"; then
+  echo "Podman-incompatible tmpfs ownership option detected." >&2
+  exit 1
+fi
+grep -Fq -- '/home/xcsh/.xcsh:rw,exec,nosuid,nodev,size=256m,mode=1777' "$test_root/podman.log"
 if grep -Fq 'test-secret-never-log' "$test_root/podman.log" "$test_root/happy.json"; then
   echo "Credential leaked into logs or report." >&2
   exit 1

--- a/scripts/test-uat-podman-arm64.sh
+++ b/scripts/test-uat-podman-arm64.sh
@@ -141,7 +141,7 @@ if grep -Eq -- '--tmpfs [^ ]*(uid|gid)=' "$test_root/podman.log"; then
   exit 1
 fi
 grep -Fq -- '/home/xcsh/.xcsh:rw,exec,nosuid,nodev,size=256m,mode=1777' "$test_root/podman.log"
-grep -Fq -- '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/ssl/certs/ca-certificates.crt:ro' "$test_root/podman.log"
+grep -Fq -- 'update-ca-trust' "$test_root/podman.log"
 grep -Fq -- '--entrypoint bash' "$test_root/podman.log"
 grep -Fq -- 'xcsh --list-models >/dev/null' "$test_root/podman.log"
 if grep -Fq 'test-secret-never-log' "$test_root/podman.log" "$test_root/happy.json"; then

--- a/scripts/test-uat-podman-arm64.sh
+++ b/scripts/test-uat-podman-arm64.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+harness="$repo_root/scripts/uat-podman-arm64.sh"
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/xcsh-podman-uat-test.XXXXXX")
+fake_bin="$test_root/bin"
+mkdir -p "$fake_bin"
+
+cleanup() {
+  case "$test_root" in
+  "${TMPDIR:-/tmp}"/xcsh-podman-uat-test.*) rm -rf -- "$test_root" ;;
+  *) echo "Refusing to remove unexpected test path: $test_root" >&2 ;;
+  esac
+}
+trap cleanup EXIT
+
+cat >"$fake_bin/uname" <<'FAKE_UNAME'
+#!/bin/bash
+case "${1:-}" in
+-s) printf '%s\n' "${FAKE_OS:-Darwin}" ;;
+-m) printf '%s\n' "${FAKE_ARCH:-arm64}" ;;
+*) printf '%s\n' "${FAKE_OS:-Darwin}" ;;
+esac
+FAKE_UNAME
+
+cat >"$fake_bin/podman" <<'FAKE_PODMAN'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${FAKE_PODMAN_LOG:?}"
+
+if [ "${1:-}" = "--version" ]; then
+  echo "podman version 6.0.2"
+  exit 0
+fi
+
+case "${1:-} ${2:-}" in
+"info ")
+  [ "${FAKE_PODMAN_DOWN:-0}" = 0 ]
+  ;;
+"manifest inspect")
+  cat <<'JSON'
+{"schemaVersion":2,"manifests":[{"digest":"sha256:arm64child","platform":{"architecture":"arm64","os":"linux"}},{"digest":"sha256:amd64child","platform":{"architecture":"amd64","os":"linux"}}]}
+JSON
+  ;;
+"pull --platform=linux/arm64")
+  echo "sha256:arm64child"
+  ;;
+"image inspect")
+  format=""
+  previous=""
+  for argument in "$@"; do
+    if [ "$previous" = "--format" ]; then format="$argument"; fi
+    previous="$argument"
+  done
+  case "$format" in
+  *Architecture*) echo "${FAKE_IMAGE_ARCH:-arm64}" ;;
+  *RepoDigests*) echo '["ghcr.io/f5-sales-demo/xcsh@sha256:d3e35ebe9fb889fbbf8f9216ac2e62987f72704b0e3387234b0b677fa8a56c95"]' ;;
+  *Id*) echo "sha256:arm64child" ;;
+  *) exit 2 ;;
+  esac
+  ;;
+"run "*)
+  entrypoint=""
+  model=""
+  previous=""
+  for argument in "$@"; do
+    case "$previous" in
+    --entrypoint) entrypoint="$argument" ;;
+    --model) model="$argument" ;;
+    esac
+    previous="$argument"
+  done
+
+  if [ "$entrypoint" = "uname" ]; then
+    echo "${FAKE_RUNTIME_ARCH:-aarch64}"
+    exit 0
+  fi
+  if [ "$entrypoint" = "xcsh" ] && printf '%s\n' "$*" | grep -Fq -- "--version"; then
+    echo "${FAKE_XCSH_VERSION:-xcsh/20.15.0}"
+    exit 0
+  fi
+  if [ -n "$model" ]; then
+    [ "${FAKE_RUN_FAIL:-0}" = 0 ] || exit 125
+    provider=${model%%/*}
+    resolved_model=${model#"$provider"/}
+    provider=${FAKE_PROVIDER:-$provider}
+    resolved_model=${FAKE_MODEL:-$resolved_model}
+    response=${FAKE_RESPONSE:-PONG}
+    printf '{"type":"session","provider":"%s","model":"%s"}\n' "$provider" "$resolved_model"
+    printf '{"type":"message_start","message":{"role":"user"}}\n'
+    printf '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"%s"}}\n' "$response"
+    printf '{"type":"message_end","message":{"role":"assistant","provider":"%s","model":"%s","stopReason":"stop"}}\n' \
+      "$provider" "$resolved_model"
+    exit 0
+  fi
+  exit 2
+  ;;
+*)
+  exit 2
+  ;;
+esac
+FAKE_PODMAN
+chmod +x "$fake_bin/uname" "$fake_bin/podman"
+
+run_harness() {
+  local output_file=$1
+  shift
+  PATH="$fake_bin:$PATH" \
+    FAKE_PODMAN_LOG="$test_root/podman.log" \
+    LITELLM_BASE_URL="https://litellm.invalid" \
+    LITELLM_API_KEY="test-secret-never-log" \
+    bash "$harness" "$@" --report "$output_file"
+}
+
+echo "[1/7] Happy path exercises the default matrix."
+: >"$test_root/podman.log"
+run_harness "$test_root/happy.json"
+jq -e '
+  .passed == true and
+  .host.architecture == "arm64" and
+  .image.runtimeMachine == "aarch64" and
+  .image.xcshVersion == "xcsh/20.15.0" and
+  ([.samples[] | select(.phase == "warmup")] | length) == 2 and
+  ([.samples[] | select(.phase == "measured")] | length) == 6 and
+  all(.samples[];
+    .success and
+    .responseExact and
+    .resolvedProvider == .expectedProvider and
+    .resolvedModel == .expectedModel)
+' "$test_root/happy.json" >/dev/null
+test "$(grep -c -- '--model' "$test_root/podman.log")" = 8
+grep -Fq -- '--timeout 120' "$test_root/podman.log"
+if grep -Fq 'test-secret-never-log' "$test_root/podman.log" "$test_root/happy.json"; then
+  echo "Credential leaked into logs or report." >&2
+  exit 1
+fi
+
+echo "[2/7] Missing credentials fail before Podman execution."
+if env -u LITELLM_API_KEY PATH="$fake_bin:$PATH" FAKE_PODMAN_LOG="$test_root/podman.log" \
+  LITELLM_BASE_URL="https://litellm.invalid" bash "$harness" \
+  --report "$test_root/missing-key.json" >/dev/null 2>&1; then
+  echo "Expected missing-key failure." >&2
+  exit 1
+fi
+
+echo "[3/7] Non-ARM hosts are rejected."
+if FAKE_ARCH=x86_64 run_harness "$test_root/wrong-host.json" \
+  --runs 1 --warmups 0 >/dev/null 2>&1; then
+  echo "Expected host-architecture failure." >&2
+  exit 1
+fi
+
+echo "[4/7] Unavailable Podman machines are rejected."
+if FAKE_PODMAN_DOWN=1 run_harness "$test_root/podman-down.json" \
+  --runs 1 --warmups 0 >/dev/null 2>&1; then
+  echo "Expected Podman availability failure." >&2
+  exit 1
+fi
+
+echo "[5/7] Inexact model responses fail acceptance."
+if FAKE_RESPONSE=NOPE run_harness "$test_root/non-pong.json" \
+  --runs 1 --warmups 0 >/dev/null 2>&1; then
+  echo "Expected exact-response failure." >&2
+  exit 1
+fi
+jq -e '.passed == false and any(.samples[]; .responseExact == false)' \
+  "$test_root/non-pong.json" >/dev/null
+
+echo "[6/7] Provider/model mismatches fail acceptance."
+if FAKE_PROVIDER=wrong run_harness "$test_root/mismatch.json" \
+  --runs 1 --warmups 0 >/dev/null 2>&1; then
+  echo "Expected provider-mismatch failure." >&2
+  exit 1
+fi
+jq -e '.passed == false and any(.samples[]; .error == "resolved_model_mismatch")' \
+  "$test_root/mismatch.json" >/dev/null
+
+echo "[7/7] Failed or timed-out Podman runs fail acceptance."
+if FAKE_RUN_FAIL=1 run_harness "$test_root/run-failed.json" \
+  --runs 1 --warmups 0 >/dev/null 2>&1; then
+  echo "Expected model-process failure." >&2
+  exit 1
+fi
+jq -e '.passed == false and any(.samples[]; .error == "model_process_failed")' \
+  "$test_root/run-failed.json" >/dev/null
+
+echo "PASS: ARM64 Podman UAT harness contract tests completed."

--- a/scripts/test-uat-podman-arm64.sh
+++ b/scripts/test-uat-podman-arm64.sh
@@ -38,6 +38,9 @@ case "${1:-} ${2:-}" in
 "info ")
   [ "${FAKE_PODMAN_DOWN:-0}" = 0 ]
   ;;
+"machine ssh")
+  exit 0
+  ;;
 "manifest inspect")
   cat <<'JSON'
 {"schemaVersion":2,"manifests":[{"digest":"sha256:arm64child","platform":{"architecture":"arm64","os":"linux"}},{"digest":"sha256:amd64child","platform":{"architecture":"amd64","os":"linux"}}]}
@@ -102,6 +105,7 @@ JSON
 esac
 FAKE_PODMAN
 chmod +x "$fake_bin/uname" "$fake_bin/podman"
+printf '%s\n' '-----BEGIN CERTIFICATE-----' 'test-ca' '-----END CERTIFICATE-----' >"$test_root/ca.pem"
 
 run_harness() {
   local output_file=$1
@@ -115,13 +119,14 @@ run_harness() {
 
 echo "[1/7] Happy path exercises the default matrix."
 : >"$test_root/podman.log"
-run_harness "$test_root/happy.json"
+run_harness "$test_root/happy.json" --ca-cert "$test_root/ca.pem"
 jq -e '
   .passed == true and
   .host.architecture == "arm64" and
   .image.runtimeMachine == "aarch64" and
   .image.xcshVersion == "xcsh/20.15.0" and
   ([.samples[] | select(.phase == "warmup")] | length) == 2 and
+  .config.customCa == true and
   ([.samples[] | select(.phase == "measured")] | length) == 6 and
   all(.samples[];
     .success and

--- a/scripts/uat-podman-arm64.sh
+++ b/scripts/uat-podman-arm64.sh
@@ -1,0 +1,380 @@
+#!/bin/bash
+set -euo pipefail
+
+readonly DEFAULT_IMAGE="ghcr.io/f5-sales-demo/xcsh@sha256:d3e35ebe9fb889fbbf8f9216ac2e62987f72704b0e3387234b0b677fa8a56c95"
+readonly PROMPT='Reply with exactly `PONG` and nothing else.'
+
+image="$DEFAULT_IMAGE"
+runs=3
+warmups=1
+timeout_seconds=120
+report_path=""
+custom_models=false
+model_labels=()
+model_selectors=()
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/uat-podman-arm64.sh [options]
+
+Run native ARM64 acceptance tests against the published xcsh container.
+
+Options:
+  --image REF             Immutable image reference (default: v20.15.0 OCI index digest)
+  --runs N                Measured runs per model (default: 3)
+  --warmups N             Warmup runs per model (default: 1)
+  --timeout-seconds N     Maximum seconds for each model invocation (default: 120)
+  --report FILE           Secret-free JSON report path (default: $TMPDIR)
+  --model LABEL=SELECTOR  Add a model target; repeatable
+  -h, --help              Show this help
+
+Required environment:
+  LITELLM_BASE_URL
+  LITELLM_API_KEY
+USAGE
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_nonnegative_integer() {
+  local value=$1
+  local name=$2
+  [[ "$value" =~ ^[0-9]+$ ]] || die "$name must be a non-negative integer."
+}
+
+require_positive_integer() {
+  local value=$1
+  local name=$2
+  [[ "$value" =~ ^[1-9][0-9]*$ ]] || die "$name must be a positive integer."
+}
+
+add_model() {
+  local value=$1
+  local label selector provider model_name
+  case "$value" in
+  *=*)
+    label=${value%%=*}
+    selector=${value#*=}
+    ;;
+  *)
+    die "--model must use LABEL=PROVIDER/MODEL."
+    ;;
+  esac
+  provider=${selector%%/*}
+  model_name=${selector#"$provider"/}
+  [ -n "$label" ] || die "--model label cannot be empty."
+  [ -n "$provider" ] && [ -n "$model_name" ] && [ "$provider" != "$selector" ] ||
+    die "--model selector must use PROVIDER/MODEL."
+  if [ "$custom_models" = false ]; then
+    model_labels=()
+    model_selectors=()
+    custom_models=true
+  fi
+  model_labels[${#model_labels[@]}]="$label"
+  model_selectors[${#model_selectors[@]}]="$selector"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+  --image)
+    [ "$#" -ge 2 ] || die "--image requires a value."
+    image=$2
+    shift 2
+    ;;
+  --runs)
+    [ "$#" -ge 2 ] || die "--runs requires a value."
+    runs=$2
+    shift 2
+    ;;
+  --warmups)
+    [ "$#" -ge 2 ] || die "--warmups requires a value."
+    warmups=$2
+    shift 2
+    ;;
+  --timeout-seconds)
+    [ "$#" -ge 2 ] || die "--timeout-seconds requires a value."
+    timeout_seconds=$2
+    shift 2
+    ;;
+  --report)
+    [ "$#" -ge 2 ] || die "--report requires a value."
+    report_path=$2
+    shift 2
+    ;;
+  --model)
+    [ "$#" -ge 2 ] || die "--model requires a value."
+    add_model "$2"
+    shift 2
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    die "Unknown argument: $1"
+    ;;
+  esac
+done
+
+require_positive_integer "$runs" "--runs"
+require_nonnegative_integer "$warmups" "--warmups"
+require_positive_integer "$timeout_seconds" "--timeout-seconds"
+
+if [ "$custom_models" = false ]; then
+  model_labels=("GPT-5.6 Sol" "Claude Opus 5")
+  model_selectors=("litellm/gpt-5.6-sol" "anthropic/claude-opus-5")
+fi
+
+[ "$(uname -s)" = "Darwin" ] || die "This UAT must run on macOS."
+[ "$(uname -m)" = "arm64" ] || die "This UAT must run on an ARM64 Mac."
+command -v podman >/dev/null 2>&1 || die "Podman is unavailable."
+command -v jq >/dev/null 2>&1 || die "jq is unavailable."
+[ -n "${LITELLM_BASE_URL:-}" ] || die "LITELLM_BASE_URL is required."
+[ -n "${LITELLM_API_KEY:-}" ] || die "LITELLM_API_KEY is required."
+
+podman info >/dev/null 2>&1 || die "Podman machine is not running. Start it with: podman machine start"
+
+timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+if [ -z "$report_path" ]; then
+  report_path="${TMPDIR:-/tmp}/xcsh-podman-arm64-uat-${timestamp}.json"
+fi
+report_dir=$(dirname "$report_path")
+[ -d "$report_dir" ] || die "Report directory does not exist: $report_dir"
+
+run_dir=$(mktemp -d "${TMPDIR:-/tmp}/xcsh-podman-arm64-uat.XXXXXX")
+samples_file="$run_dir/samples.jsonl"
+: >"$samples_file"
+cleanup() {
+  case "$run_dir" in
+  "${TMPDIR:-/tmp}"/xcsh-podman-arm64-uat.*) rm -rf -- "$run_dir" ;;
+  *) echo "Refusing to remove unexpected temporary path: $run_dir" >&2 ;;
+  esac
+}
+trap cleanup EXIT
+
+echo "Inspecting immutable OCI index..."
+manifest_json=$(podman manifest inspect "$image") || die "Unable to inspect OCI index: $image"
+printf '%s' "$manifest_json" | jq -e \
+  '.manifests[]? | select(.platform.os == "linux" and .platform.architecture == "arm64")' \
+  >/dev/null || die "OCI index does not contain linux/arm64."
+
+echo "Pulling native linux/arm64 image..."
+podman pull --platform=linux/arm64 "$image"
+
+image_architecture=$(podman image inspect --format '{{.Architecture}}' "$image")
+[ "$image_architecture" = "arm64" ] ||
+  die "Resolved image architecture is $image_architecture, expected arm64."
+image_id=$(podman image inspect --format '{{.Id}}' "$image")
+repo_digests=$(podman image inspect --format '{{json .RepoDigests}}' "$image")
+if ! printf '%s' "$repo_digests" | jq -e 'type == "array"' >/dev/null 2>&1; then
+  repo_digests='[]'
+fi
+
+base_run_options=(
+  run
+  --rm
+  --pull=never
+  --platform linux/arm64
+  --read-only
+  --cap-drop all
+  --security-opt=no-new-privileges
+  --tmpfs "/tmp:rw,nosuid,nodev,size=1g,mode=1777"
+  --tmpfs "/home/xcsh/.xcsh:rw,exec,nosuid,nodev,size=256m,mode=0700,uid=1000,gid=1000"
+)
+
+runtime_machine=$(podman "${base_run_options[@]}" --entrypoint uname "$image" -m)
+[ "$runtime_machine" = "aarch64" ] ||
+  die "Container runtime reports $runtime_machine, expected aarch64."
+xcsh_version=$(podman "${base_run_options[@]}" --entrypoint xcsh "$image" --version)
+[ "$xcsh_version" = "xcsh/20.15.0" ] ||
+  die "Container reports $xcsh_version, expected xcsh/20.15.0."
+
+podman_version=$(podman --version)
+failure_count=0
+
+append_sample() {
+  local label=$1 selector=$2 phase=$3 round=$4 success=$5 response_exact=$6
+  local resolved_provider=$7 resolved_model=$8 error=$9
+  local expected_provider expected_model
+  expected_provider=${selector%%/*}
+  expected_model=${selector#"$expected_provider"/}
+  jq -nc \
+    --arg label "$label" \
+    --arg selector "$selector" \
+    --arg phase "$phase" \
+    --argjson round "$round" \
+    --argjson success "$success" \
+    --argjson responseExact "$response_exact" \
+    --arg expectedProvider "$expected_provider" \
+    --arg expectedModel "$expected_model" \
+    --arg resolvedProvider "$resolved_provider" \
+    --arg resolvedModel "$resolved_model" \
+    --arg error "$error" \
+    '{
+      label: $label,
+      selector: $selector,
+      phase: $phase,
+      round: $round,
+      success: $success,
+      responseExact: $responseExact,
+      expectedProvider: $expectedProvider,
+      expectedModel: $expectedModel,
+      resolvedProvider: (if $resolvedProvider == "" then null else $resolvedProvider end),
+      resolvedModel: (if $resolvedModel == "" then null else $resolvedModel end),
+      error: (if $error == "" then null else $error end)
+    }' >>"$samples_file"
+}
+
+run_sample() {
+  local label=$1 selector=$2 phase=$3 round=$4
+  local stdout_file="$run_dir/stdout.jsonl"
+  local stderr_file="$run_dir/stderr.txt"
+  local resolved_provider="" resolved_model="" response=""
+  local expected_provider expected_model
+  local success=true response_exact=false error=""
+
+  expected_provider=${selector%%/*}
+  expected_model=${selector#"$expected_provider"/}
+  : >"$stdout_file"
+  : >"$stderr_file"
+  echo "[$phase $round] $label ($selector)"
+  if ! podman "${base_run_options[@]}" \
+    --timeout "$timeout_seconds" \
+    --env LITELLM_BASE_URL \
+    --env LITELLM_API_KEY \
+    "$image" \
+    --mode json \
+    --no-session \
+    --no-memories \
+    --no-tools \
+    --no-mcp \
+    --no-lsp \
+    --no-extensions \
+    --no-skills \
+    --no-rules \
+    --no-title \
+    --thinking high \
+    --model "$selector" \
+    "$PROMPT" \
+    >"$stdout_file" 2>"$stderr_file"; then
+    success=false
+    error="model_process_failed"
+  elif ! jq -e -s . "$stdout_file" >/dev/null 2>&1; then
+    success=false
+    error="invalid_json_events"
+  else
+    response=$(jq -rs \
+      '[.[] | select(.type == "message_update") | .assistantMessageEvent |
+        select(.type == "text_delta") | .delta] | join("")' "$stdout_file")
+    resolved_provider=$(jq -rs \
+      '[.[] |
+        if .type == "message_end" and .message.role == "assistant" then .message.provider
+        elif .type == "session" then .provider
+        else empty end] | last // ""' "$stdout_file")
+    resolved_model=$(jq -rs \
+      '[.[] |
+        if .type == "message_end" and .message.role == "assistant" then .message.model
+        elif .type == "session" then .model
+        else empty end] | last // ""' "$stdout_file")
+
+    if [ "$response" = "PONG" ]; then
+      response_exact=true
+    else
+      success=false
+      error="response_not_exact"
+    fi
+    if [ "$resolved_provider" != "$expected_provider" ] ||
+      [ "$resolved_model" != "$expected_model" ]; then
+      success=false
+      error="resolved_model_mismatch"
+    fi
+  fi
+
+  if [ "$success" = false ]; then
+    failure_count=$((failure_count + 1))
+    echo "  FAIL: $error (provider stderr withheld to protect credentials)." >&2
+  else
+    echo "  PASS"
+  fi
+  append_sample "$label" "$selector" "$phase" "$round" \
+    "$success" "$response_exact" "$resolved_provider" "$resolved_model" "$error"
+}
+
+if [ "$warmups" -gt 0 ]; then
+  warmup_round=1
+  while [ "$warmup_round" -le "$warmups" ]; do
+    model_index=0
+    while [ "$model_index" -lt "${#model_selectors[@]}" ]; do
+      run_sample "${model_labels[$model_index]}" "${model_selectors[$model_index]}" \
+        "warmup" "$warmup_round"
+      model_index=$((model_index + 1))
+    done
+    warmup_round=$((warmup_round + 1))
+  done
+fi
+
+measured_round=1
+while [ "$measured_round" -le "$runs" ]; do
+  model_index=0
+  while [ "$model_index" -lt "${#model_selectors[@]}" ]; do
+    run_sample "${model_labels[$model_index]}" "${model_selectors[$model_index]}" \
+      "measured" "$measured_round"
+    model_index=$((model_index + 1))
+  done
+  measured_round=$((measured_round + 1))
+done
+
+if [ "$failure_count" -eq 0 ]; then
+  passed=true
+else
+  passed=false
+fi
+
+jq -s \
+  --arg createdAt "$timestamp" \
+  --arg podmanVersion "$podman_version" \
+  --arg imageReference "$image" \
+  --arg imageId "$image_id" \
+  --arg imageArchitecture "$image_architecture" \
+  --arg runtimeMachine "$runtime_machine" \
+  --arg xcshVersion "$xcsh_version" \
+  --argjson repoDigests "$repo_digests" \
+  --argjson runs "$runs" \
+  --argjson warmups "$warmups" \
+  --argjson timeoutSeconds "$timeout_seconds" \
+  --argjson passed "$passed" \
+  '{
+    schemaVersion: 1,
+    createdAt: $createdAt,
+    passed: $passed,
+    host: {
+      os: "Darwin",
+      architecture: "arm64",
+      podmanVersion: $podmanVersion
+    },
+    image: {
+      reference: $imageReference,
+      id: $imageId,
+      architecture: $imageArchitecture,
+      repoDigests: $repoDigests,
+      runtimeMachine: $runtimeMachine,
+      xcshVersion: $xcshVersion
+    },
+    config: {
+      runs: $runs,
+      warmups: $warmups,
+      timeoutSeconds: $timeoutSeconds
+    },
+    samples: .
+  }' "$samples_file" >"$report_path"
+
+echo "Report: $report_path"
+if [ "$passed" = true ]; then
+  echo "PASS: Native ARM64 Podman and LiteLLM matrix UAT completed."
+else
+  echo "FAIL: $failure_count matrix invocation(s) did not meet acceptance criteria." >&2
+  exit 1
+fi

--- a/scripts/uat-podman-arm64.sh
+++ b/scripts/uat-podman-arm64.sh
@@ -197,7 +197,7 @@ base_run_options=(
   --cap-drop all
   --security-opt=no-new-privileges
   --tmpfs "/tmp:rw,nosuid,nodev,size=1g,mode=1777"
-  --tmpfs "/home/xcsh/.xcsh:rw,exec,nosuid,nodev,size=256m,mode=0700,uid=1000,gid=1000"
+  --tmpfs "/home/xcsh/.xcsh:rw,exec,nosuid,nodev,size=256m,mode=1777"
 )
 if [ "$custom_ca" = true ]; then
   base_run_options+=(

--- a/scripts/uat-podman-arm64.sh
+++ b/scripts/uat-podman-arm64.sh
@@ -201,7 +201,7 @@ base_run_options=(
 )
 if [ "$custom_ca" = true ]; then
   base_run_options+=(
-    --volume "$ca_cert:/etc/xcsh/uat-ca.pem:ro"
+    --volume "/etc/pki/ca-trust/source/anchors/xcsh-uat.pem:/etc/xcsh/uat-ca.pem:ro"
     --env NODE_EXTRA_CA_CERTS=/etc/xcsh/uat-ca.pem
   )
 fi

--- a/scripts/uat-podman-arm64.sh
+++ b/scripts/uat-podman-arm64.sh
@@ -292,12 +292,12 @@ run_sample() {
       '[.[] |
         if .type == "message_end" and .message.role == "assistant" then .message.provider
         elif .type == "session" then .provider
-        else empty end] | last // ""' "$stdout_file")
+        else empty end] | .[-1] // ""' "$stdout_file")
     resolved_model=$(jq -rs \
       '[.[] |
         if .type == "message_end" and .message.role == "assistant" then .message.model
         elif .type == "session" then .model
-        else empty end] | last // ""' "$stdout_file")
+        else empty end] | .[-1] // ""' "$stdout_file")
 
     if [ "$response" = "PONG" ]; then
       response_exact=true

--- a/scripts/uat-podman-arm64.sh
+++ b/scripts/uat-podman-arm64.sh
@@ -260,11 +260,11 @@ run_sample() {
     --timeout "$timeout_seconds" \
     --env LITELLM_BASE_URL \
     --env LITELLM_API_KEY \
-    "$image" \
     --entrypoint bash \
+    "$image" \
+    -c 'xcsh --list-models gpt-5.6-sol >/dev/null && exec xcsh "$@"' xcsh \
     --mode json \
     --no-session \
-    -c 'xcsh --list-models >/dev/null && exec xcsh "$@"' xcsh \
     --no-memories \
     --no-tools \
     --no-mcp \

--- a/scripts/uat-podman-arm64.sh
+++ b/scripts/uat-podman-arm64.sh
@@ -9,6 +9,8 @@ runs=3
 warmups=1
 timeout_seconds=120
 report_path=""
+ca_cert=""
+custom_ca=false
 custom_models=false
 model_labels=()
 model_selectors=()
@@ -25,6 +27,7 @@ Options:
   --warmups N             Warmup runs per model (default: 1)
   --timeout-seconds N     Maximum seconds for each model invocation (default: 120)
   --report FILE           Secret-free JSON report path (default: $TMPDIR)
+  --ca-cert FILE         Trust an additional PEM CA in the Podman VM and test containers
   --model LABEL=SELECTOR  Add a model target; repeatable
   -h, --help              Show this help
 
@@ -99,6 +102,11 @@ while [ "$#" -gt 0 ]; do
     timeout_seconds=$2
     shift 2
     ;;
+  --ca-cert)
+    [ "$#" -ge 2 ] || die "--ca-cert requires a value."
+    ca_cert=$2
+    shift 2
+    ;;
   --report)
     [ "$#" -ge 2 ] || die "--report requires a value."
     report_path=$2
@@ -136,6 +144,13 @@ command -v jq >/dev/null 2>&1 || die "jq is unavailable."
 [ -n "${LITELLM_API_KEY:-}" ] || die "LITELLM_API_KEY is required."
 
 podman info >/dev/null 2>&1 || die "Podman machine is not running. Start it with: podman machine start"
+if [ -n "$ca_cert" ]; then
+  [ -r "$ca_cert" ] || die "CA certificate is not readable: $ca_cert"
+  podman machine ssh --username root podman-machine-default \
+    'install -d -m 0755 /etc/pki/ca-trust/source/anchors && cat > /etc/pki/ca-trust/source/anchors/xcsh-uat.pem && update-ca-trust' \
+    <"$ca_cert" || die "Unable to install the additional CA in the Podman VM."
+  custom_ca=true
+fi
 
 timestamp=$(date -u +%Y%m%dT%H%M%SZ)
 if [ -z "$report_path" ]; then
@@ -184,6 +199,12 @@ base_run_options=(
   --tmpfs "/tmp:rw,nosuid,nodev,size=1g,mode=1777"
   --tmpfs "/home/xcsh/.xcsh:rw,exec,nosuid,nodev,size=256m,mode=0700,uid=1000,gid=1000"
 )
+if [ "$custom_ca" = true ]; then
+  base_run_options+=(
+    --volume "$ca_cert:/etc/xcsh/uat-ca.pem:ro"
+    --env NODE_EXTRA_CA_CERTS=/etc/xcsh/uat-ca.pem
+  )
+fi
 
 runtime_machine=$(podman "${base_run_options[@]}" --entrypoint uname "$image" -m)
 [ "$runtime_machine" = "aarch64" ] ||
@@ -346,6 +367,7 @@ jq -s \
   --argjson warmups "$warmups" \
   --argjson timeoutSeconds "$timeout_seconds" \
   --argjson passed "$passed" \
+  --argjson customCa "$custom_ca" \
   '{
     schemaVersion: 1,
     createdAt: $createdAt,
@@ -366,7 +388,8 @@ jq -s \
     config: {
       runs: $runs,
       warmups: $warmups,
-      timeoutSeconds: $timeoutSeconds
+      timeoutSeconds: $timeoutSeconds,
+      customCa: $customCa
     },
     samples: .
   }' "$samples_file" >"$report_path"

--- a/scripts/uat-podman-arm64.sh
+++ b/scripts/uat-podman-arm64.sh
@@ -69,8 +69,10 @@ add_model() {
   provider=${selector%%/*}
   model_name=${selector#"$provider"/}
   [ -n "$label" ] || die "--model label cannot be empty."
-  [ -n "$provider" ] && [ -n "$model_name" ] && [ "$provider" != "$selector" ] ||
+  if [ -z "$provider" ] || [ -z "$model_name" ] || [ "$provider" = "$selector" ]; then
     die "--model selector must use PROVIDER/MODEL."
+  fi
+
   if [ "$custom_models" = false ]; then
     model_labels=()
     model_selectors=()

--- a/scripts/uat-podman-arm64.sh
+++ b/scripts/uat-podman-arm64.sh
@@ -219,7 +219,7 @@ append_sample() {
   expected_provider=${selector%%/*}
   expected_model=${selector#"$expected_provider"/}
   jq -nc \
-    --arg label "$label" \
+    --arg sampleLabel "$label" \
     --arg selector "$selector" \
     --arg phase "$phase" \
     --argjson round "$round" \
@@ -231,7 +231,7 @@ append_sample() {
     --arg resolvedModel "$resolved_model" \
     --arg error "$error" \
     '{
-      label: $label,
+      "label": $sampleLabel,
       selector: $selector,
       phase: $phase,
       round: $round,

--- a/scripts/uat-podman-arm64.sh
+++ b/scripts/uat-podman-arm64.sh
@@ -201,8 +201,7 @@ base_run_options=(
 )
 if [ "$custom_ca" = true ]; then
   base_run_options+=(
-    --volume "/etc/pki/ca-trust/source/anchors/xcsh-uat.pem:/etc/xcsh/uat-ca.pem:ro"
-    --env NODE_EXTRA_CA_CERTS=/etc/xcsh/uat-ca.pem
+    --volume "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/ssl/certs/ca-certificates.crt:ro"
   )
 fi
 
@@ -267,8 +266,10 @@ run_sample() {
     --env LITELLM_BASE_URL \
     --env LITELLM_API_KEY \
     "$image" \
+    --entrypoint bash \
     --mode json \
     --no-session \
+    -c 'xcsh --list-models >/dev/null && exec xcsh "$@"' xcsh \
     --no-memories \
     --no-tools \
     --no-mcp \

--- a/scripts/uat-podman-arm64.sh
+++ b/scripts/uat-podman-arm64.sh
@@ -27,7 +27,7 @@ Options:
   --warmups N             Warmup runs per model (default: 1)
   --timeout-seconds N     Maximum seconds for each model invocation (default: 120)
   --report FILE           Secret-free JSON report path (default: $TMPDIR)
-  --ca-cert FILE         Trust an additional PEM CA in the Podman VM and test containers
+  --ca-cert FILE         Trust an additional PEM CA for registry access in the Podman VM
   --model LABEL=SELECTOR  Add a model target; repeatable
   -h, --help              Show this help
 
@@ -199,11 +199,6 @@ base_run_options=(
   --tmpfs "/tmp:rw,nosuid,nodev,size=1g,mode=1777"
   --tmpfs "/home/xcsh/.xcsh:rw,exec,nosuid,nodev,size=256m,mode=1777"
 )
-if [ "$custom_ca" = true ]; then
-  base_run_options+=(
-    --volume "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/ssl/certs/ca-certificates.crt:ro"
-  )
-fi
 
 runtime_machine=$(podman "${base_run_options[@]}" --entrypoint uname "$image" -m)
 [ "$runtime_machine" = "aarch64" ] ||


### PR DESCRIPTION
## Summary

- add a native ARM64 Podman UAT harness pinned to the v20.15.0 OCI index digest
- matrix-test LiteLLM GPT-5.6 Sol and Anthropic Claude Opus 5 with exact-response assertions
- handle managed registry CA trust and dynamically probe the supported LiteLLM API route
- add a credential-safe JSON report and an Ubuntu 22.04/jq 1.6-compatible fake-Podman CI suite

## Verification

- `bash -n scripts/uat-podman-arm64.sh`
- `bash -n scripts/test-uat-podman-arm64.sh`
- `shellcheck scripts/uat-podman-arm64.sh scripts/test-uat-podman-arm64.sh`
- `bash scripts/test-uat-podman-arm64.sh`
- Ubuntu 22.04 with jq 1.6: 7/7 harness contract scenarios passed
- Apple Silicon with Podman 6.0.2 at `bbae530ddd8976ef2da0eb92f21a040292421b86`:
  - OCI index and ARM64 child digest verified
  - runtime `aarch64`, `xcsh/20.15.0`
  - GPT-5.6 Sol: 1/1 warmup and 3/3 measured exact responses
  - Claude Opus 5: 1/1 warmup and 3/3 measured exact responses
- `bash scripts/pii-gate.sh --scope staged`

Closes #3144
