### PR TITLE
fix(security): harden workflows and unsafe input handling

### DIFF
--- a/.github/actions/setup-zig/action.yml
+++ b/.github/actions/setup-zig/action.yml
@@ -22,7 +22,9 @@ runs:
       shell: bash
       env:
         ZIG_VERSION: "0.15.2"
-      run: |
+      # Environment-file values below come only from fixed runner mappings and
+      # checksum-verified Zig release metadata, never from event-controlled data.
+      run: | # zizmor: ignore[github-env]
         set -euo pipefail
 
         case "$RUNNER_OS/$RUNNER_ARCH" in

--- a/.github/actions/setup-zig/action.yml
+++ b/.github/actions/setup-zig/action.yml
@@ -6,13 +6,13 @@ runs:
   using: composite
   steps:
     - name: Restore Zig release archive
-      uses: actions/cache@v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ runner.temp }}/zig-downloads
         key: setup-zig-archive-${{ runner.os }}-${{ runner.arch }}-0.15.2
 
     - name: Restore Zig build cache
-      uses: actions/cache@v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ github.workspace }}/.zig-cache
         key: setup-zig-cache-v3-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-0.15.2-${{ github.sha }}

--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -13,14 +13,16 @@ permissions: {}
 
 jobs:
   update-api-specs:
+    environment: release
     name: Deliver Published API Specifications
     runs-on: ubuntu-22.04
     timeout-minutes: 360
     permissions: {}
     steps:
       - name: Check out fresh main
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
           ref: main
@@ -301,7 +303,7 @@ jobs:
 
       - name: Cache bun dependencies
         if: steps.main_delivery.outputs.applied != 'true'
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
@@ -369,9 +371,11 @@ jobs:
         if: steps.main_delivery.outputs.applied != 'true' && steps.main_pending.outputs.pending != 'true'
         env:
           BRANCH: ${{ steps.delivery.outputs.branch }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           SPEC_VERSION: ${{ steps.delivery.outputs.version }}
         run: |
           set -euo pipefail
+          gh auth setup-git
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -f packages/coding-agent/src/internal-urls/api-spec-index.generated.ts
@@ -635,8 +639,10 @@ jobs:
           PUBLICATION_LEDGER_PATH: ${{ steps.delivery.outputs.publication_ledger_path }}
           PUBLICATION_RECEIPT_FILE: ${{ steps.publication.outputs.receipt_path }}
           SPEC_VERSION: ${{ steps.delivery.outputs.version }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           set -euo pipefail
+          gh auth setup-git
           git fetch --no-tags origin main
           if git ls-remote --exit-code --heads origin "$ACK_BRANCH" >/dev/null 2>&1; then
             git fetch --no-tags origin "$ACK_BRANCH:refs/remotes/origin/$ACK_BRANCH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,16 @@ jobs:
     name: check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Setup Bun 1.3
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:
+          no-cache: true
           bun-version: "1.3"
       - name: Retry Bun setup on failure
         if: steps.setup-bun.outcome == 'failure'
@@ -101,8 +103,9 @@ jobs:
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
+          lookup-only: true
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
       - run: bun install --frozen-lockfile
@@ -119,7 +122,9 @@ jobs:
         os: [ubuntu-22.04, macos-15-intel, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Setup Zig 0.15.2
         uses: ./.github/actions/setup-zig
       - name: Verify Zig
@@ -150,14 +155,16 @@ jobs:
     env:
       RUST_TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           lfs: true
       - uses: ./.github/actions/setup-rust
         with:
           target: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
+          lookup-only: true
           key: ${{ matrix.target }}${{ matrix.variants }}
           cache-workspace-crates: true
       - name: Setup Bun 1.3
@@ -165,6 +172,7 @@ jobs:
         id: setup-bun
         continue-on-error: true
         with:
+          no-cache: true
           bun-version: "1.3"
       - name: Retry Bun setup on failure
         if: steps.setup-bun.outcome == 'failure'
@@ -266,7 +274,7 @@ jobs:
         if: matrix.sandbox_check
         run: bun test packages/coding-agent/test/sandbox-check.test.ts
       - name: Upload native addon(s)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pi-natives-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.variants && format('-{0}', matrix.variants) || '' }}
           path: packages/natives/native/pi_natives.${{ matrix.platform }}-${{ matrix.arch }}*.node
@@ -277,8 +285,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
           lfs: true
       - name: Setup Bun 1.3
@@ -286,6 +295,7 @@ jobs:
         id: setup-bun
         continue-on-error: true
         with:
+          no-cache: true
           bun-version: "1.3"
       - name: Retry Bun setup on failure
         if: steps.setup-bun.outcome == 'failure'
@@ -336,14 +346,16 @@ jobs:
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
       - uses: ./.github/actions/setup-rust
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
+          lookup-only: true
           cache-workspace-crates: true
       - name: Setup Zig 0.15.2
         uses: ./.github/actions/setup-zig
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
+          lookup-only: true
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
       - uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
@@ -381,14 +393,16 @@ jobs:
     name: Test installation methods
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           lfs: true
       - name: Setup Bun 1.3
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:
+          no-cache: true
           bun-version: "1.3"
       - name: Retry Bun setup on failure
         if: steps.setup-bun.outcome == 'failure'
@@ -439,14 +453,16 @@ jobs:
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
       - uses: ./.github/actions/setup-rust
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
+          lookup-only: true
           cache-workspace-crates: true
       - name: Setup Zig 0.15.2
         uses: ./.github/actions/setup-zig
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
+          lookup-only: true
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
       - name: Install system deps
@@ -462,18 +478,21 @@ jobs:
   # Invalidate already-green release PRs immediately when their recorded base
   # falls behind main. Release creation remains in auto-release after full CI.
   invalidate-stale-release-prs:
+    environment: release
     name: Invalidate stale release pull requests
     if: github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore:')
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     permissions: {}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Setup Bun 1.3
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
+          no-cache: true
           bun-version: "1.3"
       - name: Close release PRs based on stale main
         env:
@@ -481,14 +500,16 @@ jobs:
         run: bun scripts/release.ts invalidate-stale
 
   auto-release:
+    environment: release
     name: Prepare automatic release
     if: github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore:')
     needs: [check, native, test, install_methods]
     runs-on: ubuntu-22.04
     permissions: {}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
       - name: Setup Bun 1.3
@@ -496,6 +517,7 @@ jobs:
         id: setup-bun
         continue-on-error: true
         with:
+          no-cache: true
           bun-version: "1.3"
       - name: Retry Bun setup on failure
         if: steps.setup-bun.outcome == 'failure'
@@ -546,8 +568,9 @@ jobs:
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
+          lookup-only: true
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
       - run: bun install --frozen-lockfile
@@ -562,13 +585,15 @@ jobs:
 
   # Build Linux + Windows binaries on Ubuntu
   build-release:
+    environment: release
     name: Build Linux and Windows release
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [check, native, test, install_methods]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           token: ${{ secrets.RELEASE_TOKEN }}
           lfs: true
       - name: Setup Bun 1.3
@@ -576,6 +601,7 @@ jobs:
         id: setup-bun
         continue-on-error: true
         with:
+          no-cache: true
           bun-version: "1.3"
       - name: Retry Bun setup on failure
         if: steps.setup-bun.outcome == 'failure'
@@ -626,13 +652,14 @@ jobs:
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
+          lookup-only: true
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
       - run: bun install --frozen-lockfile
       - name: Download native addons
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: pi-natives-*
           path: packages/natives/native
@@ -651,7 +678,7 @@ jobs:
       - name: Stage native addons for release
         run: cp packages/natives/native/*.node packages/coding-agent/binaries/
       - name: Upload release binaries
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-binaries-linux-win
           path: packages/coding-agent/binaries/*
@@ -659,6 +686,7 @@ jobs:
 
   # Build macOS binaries natively on matching architecture, then sign and notarize
   build-sign-macos:
+    environment: release
     name: Build and sign macOS (${{ matrix.arch }})
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [check, native, test, install_methods]
@@ -674,8 +702,9 @@ jobs:
     env:
       RELEASE_ARCH: ${{ matrix.arch }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           token: ${{ secrets.RELEASE_TOKEN }}
           lfs: true
       - name: Setup Bun 1.3
@@ -683,6 +712,7 @@ jobs:
         id: setup-bun
         continue-on-error: true
         with:
+          no-cache: true
           bun-version: "1.3"
       - name: Retry Bun setup on failure
         if: steps.setup-bun.outcome == 'failure'
@@ -733,8 +763,9 @@ jobs:
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
+          lookup-only: true
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('**/bun.lock') }}
       - name: Install dependencies
@@ -742,7 +773,7 @@ jobs:
         env:
           PUPPETEER_SKIP_DOWNLOAD: "true"
       - name: Download macOS native addons
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: pi-natives-darwin-${{ matrix.arch }}*
           path: packages/natives/native
@@ -988,7 +1019,7 @@ jobs:
         run: bun test packages/coding-agent/test/sandbox-check.test.ts
 
       - name: Upload signed macOS binary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-binaries-macos-${{ matrix.arch }}-signed
           path: packages/coding-agent/binaries/*
@@ -996,26 +1027,29 @@ jobs:
 
   # Collect all artifacts and create the GitHub Release
   create-release:
+    environment: release
     name: Publish immutable GitHub release
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build-release, build-sign-macos]
     runs-on: ubuntu-22.04
     permissions: {}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Setup Bun 1.3
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
+          no-cache: true
           bun-version: "1.3"
       - name: Download Linux/Windows binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-binaries-linux-win
           path: packages/coding-agent/binaries
       - name: Download signed macOS binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: release-binaries-macos-*-signed
           path: packages/coding-agent/binaries
@@ -1056,19 +1090,22 @@ jobs:
 
   # Package Homebrew archives from signed binaries and update the tap
   update-homebrew:
+    environment: release
     name: Publish Homebrew formula
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Setup Bun 1.3
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:
+          no-cache: true
           bun-version: "1.3"
       - name: Retry Bun setup on failure
         if: steps.setup-bun.outcome == 'failure'
@@ -1119,8 +1156,9 @@ jobs:
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
+          lookup-only: true
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
       - run: bun install --frozen-lockfile
@@ -1146,14 +1184,17 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Setup Bun 1.3
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
+          no-cache: true
           bun-version: "1.3"
       - run: bun install --frozen-lockfile
       - name: Download signed native addon for the live-profile harness
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-binaries-macos-arm64-signed
           path: packages/natives/native
@@ -1209,6 +1250,7 @@ jobs:
 
   # Publish to npm
   publish-npm:
+    environment: release
     name: Publish npm packages
     if: startsWith(github.ref, 'refs/tags/v') && !inputs.skip_npm
     needs: [create-release]
@@ -1218,8 +1260,9 @@ jobs:
     permissions:
       id-token: write # Required for npm trusted-publishing provenance.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           token: ${{ secrets.RELEASE_TOKEN }}
           lfs: true
       - name: Setup Bun 1.3
@@ -1227,6 +1270,7 @@ jobs:
         id: setup-bun
         continue-on-error: true
         with:
+          no-cache: true
           bun-version: "1.3"
       - name: Retry Bun setup on failure
         if: steps.setup-bun.outcome == 'failure'
@@ -1276,18 +1320,17 @@ jobs:
           fi
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
+      - name: Verify runner Node.js
+        run: node --version && npm --version
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
+          lookup-only: true
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
       - run: bun install --frozen-lockfile
       - name: Download native addon artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: pi-natives-*
           path: packages/natives/native
@@ -1321,15 +1364,17 @@ jobs:
     needs: [publish-npm]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          node-version: "24"
+          persist-credentials: false
+      - name: Verify runner Node.js
+        run: node --version && npm --version
       - name: Setup Bun 1.3
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:
+          no-cache: true
           bun-version: "1.3"
       - name: Retry Bun setup on failure
         if: steps.setup-bun.outcome == 'failure'
@@ -1384,61 +1429,11 @@ jobs:
       # live-profile verification harness below.
       - run: bun install --frozen-lockfile
       - name: Download native addon for the live-profile harness
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-binaries-linux-win
           path: packages/natives/native
       - name: Install xcsh via npm and verify native addon loads
         env:
           EXPECTED_VERSION: ${{ github.ref_name }}
-        # zizmor: ignore[adhoc-packages]
-        run: |
-          set -euo pipefail
-
-          # Strip leading 'v' from tag to get semver (v17.0.0 -> 17.0.0)
-          expected="${EXPECTED_VERSION#v}"
-          max_attempts=8
-          delay=10
-
-          echo "Expected version: $expected"
-
-          for attempt in $(seq 1 $max_attempts); do
-            echo ""
-            echo "=== Attempt $attempt/$max_attempts (backoff: ${delay}s) ==="
-
-            # Clear any previously installed version
-            npm uninstall -g @f5-sales-demo/xcsh 2>/dev/null || true
-            npm cache clean --force 2>/dev/null || true
-
-            # Install the specific version to avoid stale CDN cache
-            if npm install -g "@f5-sales-demo/xcsh@${expected}" 2>&1; then
-              installed=$(xcsh --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
-              echo "Installed version: $installed"
-
-              if [ "$installed" = "$expected" ]; then
-                echo "Version match confirmed."
-                echo "Checking xcsh --help..."
-                xcsh --help >/dev/null
-                binary="$(command -v xcsh)"
-                XCSH_TEST_SANDBOX_CHECK_BINARY="$binary" \
-                  bun test packages/coding-agent/test/sandbox-check.test.ts
-                echo "npm install verification passed"
-                exit 0
-              fi
-
-              echo "Version mismatch: got $installed, expected $expected"
-            else
-              echo "npm install failed (exit $?)"
-            fi
-
-            if [ "$attempt" -eq "$max_attempts" ]; then
-              echo "ERROR: verification failed after $max_attempts attempts"
-              echo "Last installed version: ${installed:-none}"
-              echo "Expected version: $expected"
-              exit 1
-            fi
-
-            echo "Waiting ${delay}s for npm registry propagation..."
-            sleep $delay
-            delay=$((delay * 2))
-          done
+        run: bash scripts/ci-verify-npm-install.sh

--- a/.github/workflows/console-catalog-drift.yml
+++ b/.github/workflows/console-catalog-drift.yml
@@ -18,6 +18,10 @@ on:
     paths:
       - "packages/coding-agent/src/internal-urls/console-catalog.generated.ts"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Read-only: the job reads the console repo through RELEASE_TOKEN and only diffs
 # locally, so GITHUB_TOKEN needs no write scope.
 permissions:
@@ -25,9 +29,13 @@ permissions:
 
 jobs:
   drift-guard:
+    name: Console catalog drift guard
+    environment: release
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Read the console version the committed catalog records
         id: ver
@@ -58,8 +66,9 @@ jobs:
 
       - name: Check out the console repo at the recorded version
         if: steps.ver.outputs.checkable == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: f5-sales-demo/console
           ref: ${{ steps.ver.outputs.ref }}
           path: console
@@ -80,6 +89,7 @@ jobs:
         working-directory: packages/coding-agent
         env:
           CONSOLE_CATALOG_DIR: ${{ github.workspace }}/console
+          WORKSPACE: ${{ github.workspace }}
           CONSOLE_CATALOG_VERSION: ${{ steps.ver.outputs.version }}
         run: |
           bun run generate-console-catalog
@@ -87,11 +97,11 @@ jobs:
           # format the regenerated file the same way before diffing (else formatting
           # noise reads as drift). Mirrors how the committed catalog is produced.
           bunx biome format --write src/internal-urls/console-catalog.generated.ts
-          if ! git -C "${{ github.workspace }}" diff --quiet -- \
+          if ! git -C "$WORKSPACE" diff --quiet -- \
               packages/coding-agent/src/internal-urls/console-catalog.generated.ts; then
             echo "::error::Committed console catalog does NOT match regenerating from console@${CONSOLE_CATALOG_VERSION}."
             echo "::error::Do not hand-edit generated files. Run: cd packages/coding-agent && bun run generate-console-catalog && bunx biome format --write src/internal-urls/console-catalog.generated.ts"
-            git -C "${{ github.workspace }}" --no-pager diff --stat -- packages/coding-agent/src/internal-urls/console-catalog.generated.ts
+            git -C "$WORKSPACE" --no-pager diff --stat -- packages/coding-agent/src/internal-urls/console-catalog.generated.ts
             exit 1
           fi
           echo "::notice::Console catalog is faithful to console@${CONSOLE_CATALOG_VERSION} — no drift."

--- a/.github/workflows/console-catalog-update.yml
+++ b/.github/workflows/console-catalog-update.yml
@@ -15,22 +15,32 @@ on:
     # catalog can never silently drift behind the console repo for long.
     - cron: "13 7 * * *"
 
+concurrency:
+  group: console-catalog-update
+  cancel-in-progress: false
+
+permissions: {}
+
 jobs:
   update-console-catalog:
+    name: Update console catalog
+    environment: release
     runs-on: ubuntu-22.04
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+      contents: write # required to push the generated catalog branch
+      pull-requests: write # required to open the catalog refresh PR
+      issues: write # required to create the PR's tracking issue
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
 
       - name: Check out the console repo (source of truth) at latest main
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: f5-sales-demo/console
           ref: main
           path: console
@@ -42,7 +52,7 @@ jobs:
           bun-version: "1.3"
 
       - name: Cache bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
@@ -57,10 +67,11 @@ jobs:
         working-directory: packages/coding-agent
         env:
           CONSOLE_CATALOG_DIR: ${{ github.workspace }}/console
+          WORKSPACE: ${{ github.workspace }}
         run: |
           # Full SHA (not --short): the drift guard feeds this to actions/checkout `ref:`,
           # which cannot resolve a short SHA (treats it as a branch/tag name).
-          CONSOLE_CATALOG_VERSION="$(git -C "${{ github.workspace }}/console" rev-parse HEAD)"
+          CONSOLE_CATALOG_VERSION="$(git -C "$WORKSPACE/console" rev-parse HEAD)"
           export CONSOLE_CATALOG_VERSION
           echo "::notice::Regenerating console catalog at console@${CONSOLE_CATALOG_VERSION}"
           bun run generate-console-catalog
@@ -95,6 +106,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           CATALOG_VERSION: ${{ steps.changes.outputs.catalog_version }}
         run: |
+          gh auth setup-git
           BRANCH="chore/console-catalog-${CATALOG_VERSION}"
           git checkout -b "$BRANCH"
           git add -f packages/coding-agent/src/internal-urls/console-catalog.generated.ts

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -88,7 +88,7 @@ jobs:
     timeout-minutes: 180
     permissions:
       contents: read
-      packages: write
+      packages: write # required to publish the release image to GHCR
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/deploy-office-pane.yml
+++ b/.github/workflows/deploy-office-pane.yml
@@ -10,18 +10,28 @@ on:
     types: [published]
   workflow_dispatch: # manual trigger for bootstrapping / re-deploy
 
+concurrency:
+  group: deploy-office-pane
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   deploy:
+    name: Deploy Office pane
+    environment: release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout xcsh
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/pii-guard.yml
+++ b/.github/workflows/pii-guard.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   pii-guard:
-    name: PII guard
+    name: pii-guard
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pii-guard.yml
+++ b/.github/workflows/pii-guard.yml
@@ -24,9 +24,10 @@ concurrency:
 
 jobs:
   pii-guard:
+    name: PII guard
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # The scanner reads tracked blobs from the object database, not the worktree. The default
           # head scope does not need history.

--- a/.github/workflows/release-reconcile.yml
+++ b/.github/workflows/release-reconcile.yml
@@ -34,16 +34,18 @@ concurrency:
 
 jobs:
   reconcile:
+    name: Reconcile release
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           # Tags are the input to this check; a shallow clone has none, and the
           # script treats an empty tag list as unknown rather than clean.
           fetch-depth: 0
           fetch-tags: true
       - name: Setup Bun 1.3
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3"
       - name: Reconcile tags against releases and npm

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -41,6 +41,7 @@ concurrency:
 
 jobs:
   tag:
+    environment: release
     name: Create immutable release tag
     # push path: only run when the head commit starts with the bump prefix.
     # workflow_dispatch path: always run (the extract step validates input).
@@ -51,8 +52,9 @@ jobs:
     permissions: {}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
 
@@ -144,6 +146,7 @@ jobs:
           SHA: ${{ steps.target.outputs.sha }}
         run: |
           set -euo pipefail
+          gh auth setup-git
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "${TAG}" "${SHA}"

--- a/.github/workflows/test-codesign.yml
+++ b/.github/workflows/test-codesign.yml
@@ -4,6 +4,10 @@ name: Test macOS Code Signing
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Read-only: this is a manual diagnostic that builds and signs locally and writes
 # nothing back to the repository.
 permissions:
@@ -11,6 +15,7 @@ permissions:
 
 jobs:
   test-codesign:
+    name: Test code signing
     strategy:
       fail-fast: false
       matrix:
@@ -23,11 +28,12 @@ jobs:
             label: "x64-native"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           lfs: true
       - name: Setup Bun 1.3
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         id: setup-bun
         continue-on-error: true
         with:
@@ -81,7 +87,7 @@ jobs:
           echo "$BUN_DIR" >> "$GITHUB_PATH"
           bun --version
       - uses: ./.github/actions/setup-rust
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-workspace-crates: true
       - name: Install Zig 0.15.2
@@ -122,12 +128,12 @@ jobs:
         id: test1
         continue-on-error: true
         run: |
-          echo "=== Test 1: bun build --compile --define PI_COMPILED=true --root . --external mupdf --target=bun-darwin-${{ matrix.arch }} ==="
+          echo "=== Test 1: bun build --compile --define PI_COMPILED=true --root . --external mupdf --target=bun-darwin-${TARGET_ARCH} ==="
           bun build --compile \
             --define PI_COMPILED=true \
             --root . \
             --external mupdf \
-            --target=bun-darwin-${{ matrix.arch }} \
+            --target="bun-darwin-${TARGET_ARCH}" \
             ./packages/coding-agent/src/cli.ts \
             --outfile /tmp/test1-xcsh
           echo "--- file ---"
@@ -150,7 +156,7 @@ jobs:
           bun build --compile \
             --define PI_COMPILED=true \
             --root . \
-            --target=bun-darwin-${{ matrix.arch }} \
+            --target="bun-darwin-${TARGET_ARCH}" \
             ./packages/coding-agent/src/cli.ts \
             --outfile /tmp/test2-xcsh 2>&1 || { echo "BUILD FAILED (expected if mupdf import fails)"; exit 0; }
           file /tmp/test2-xcsh
@@ -164,7 +170,7 @@ jobs:
         run: |
           echo "=== Test 3: minimal flags ==="
           bun build --compile \
-            --target=bun-darwin-${{ matrix.arch }} \
+            --target="bun-darwin-${TARGET_ARCH}" \
             ./packages/coding-agent/src/cli.ts \
             --outfile /tmp/test3-xcsh 2>&1 || { echo "BUILD FAILED"; exit 0; }
           file /tmp/test3-xcsh
@@ -195,7 +201,7 @@ jobs:
           echo "=== Test 5: simple binary (control test) ==="
           echo 'console.log("hello")' > /tmp/hello.ts
           bun build --compile \
-            --target=bun-darwin-${{ matrix.arch }} \
+            --target="bun-darwin-${TARGET_ARCH}" \
             /tmp/hello.ts \
             --outfile /tmp/test5-xcsh
           file /tmp/test5-xcsh
@@ -212,7 +218,7 @@ jobs:
             --define PI_COMPILED=true \
             --root . \
             --external mupdf \
-            --target=bun-darwin-${{ matrix.arch }} \
+            --target="bun-darwin-${TARGET_ARCH}" \
             ./packages/coding-agent/src/cli.ts \
             --outfile /tmp/test6-xcsh 2>&1 || { echo "BUILD FAILED"; exit 0; }
           echo "--- before strip ---"

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,6 +3,7 @@ telemetry = false
 [install]
 linker = "isolated"
 exact = true
+minimumReleaseAge = 604800
 saveTextLockfile = true
 
 [loader]

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -92,7 +92,7 @@ async function fetchProviderModelsFromCatalog(descriptor: CatalogProviderDescrip
 		console.log(`Fetched ${models.length} models from ${descriptor.catalogDiscovery.label} model manager`);
 		return models;
 	} catch (error) {
-		console.error(`Failed to fetch ${descriptor.catalogDiscovery.label} models:`, error);
+		console.error("Failed to fetch %s models:", descriptor.catalogDiscovery.label, error);
 		return [];
 	}
 }

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -355,6 +355,8 @@ function getValueAtPointer(root: unknown, pointer: string): unknown {
 function setValueAtPointer(root: unknown, pointer: string, value: unknown): unknown {
 	if (!pointer) return value;
 	const segments = decodeJsonPointer(pointer);
+	const unsafeSegments = new Set(["__proto__", "constructor", "prototype"]);
+	if (segments.some(segment => segment.length === 0 || unsafeSegments.has(segment))) return root;
 	let current: unknown = root;
 
 	// Navigate to the parent of the target location
@@ -363,25 +365,32 @@ function setValueAtPointer(root: unknown, pointer: string, value: unknown): unkn
 		if (current === null || current === undefined) return root;
 		if (Array.isArray(current)) {
 			const arrayIndex = Number(segment);
-			if (!Number.isInteger(arrayIndex)) return root;
+			if (!Number.isInteger(arrayIndex) || arrayIndex < 0 || arrayIndex >= current.length) return root;
 			current = current[arrayIndex];
 			continue;
 		}
 		if (typeof current !== "object") return root;
-		current = (current as Record<string, unknown>)[segment];
+		const record = current as Record<string, unknown>;
+		if (!Object.hasOwn(record, segment)) return root;
+		current = record[segment];
 	}
 
 	// Set the value at the final segment
 	const lastSegment = segments[segments.length - 1];
 	if (Array.isArray(current)) {
 		const arrayIndex = Number(lastSegment);
-		if (!Number.isInteger(arrayIndex)) return root;
-		current[arrayIndex] = value;
+		if (!Number.isInteger(arrayIndex) || arrayIndex < 0 || arrayIndex >= current.length) return root;
+		Reflect.set(current, arrayIndex, value);
 		return root;
 	}
 
 	if (typeof current !== "object" || current === null) return root;
-	(current as Record<string, unknown>)[lastSegment] = value;
+	Object.defineProperty(current, lastSegment, {
+		configurable: true,
+		enumerable: true,
+		value,
+		writable: true,
+	});
 	return root;
 }
 
@@ -559,7 +568,7 @@ function coerceArgsFromErrors(
 // Silent logger: MCP servers may declare non-standard format keywords (e.g. "uint")
 // which cause Ajv to emit console.warn() with strict:false — corrupting TUI output.
 const ajv = new Ajv({
-	allErrors: true,
+	allErrors: false,
 	strict: false,
 	logger: false,
 });

--- a/packages/ai/test/tool-argument-coercion.test.ts
+++ b/packages/ai/test/tool-argument-coercion.test.ts
@@ -587,6 +587,24 @@ describe("Tool argument coercion", () => {
 		expect(result.edits).toEqual([{ target: "fn_foo", op: "replace" }]);
 	});
 
+	it("does not coerce prototype-sensitive JSON Pointer paths", () => {
+		const schema = JSON.parse(
+			'{"type":"object","properties":{"__proto__":{"type":"number"}},"required":["__proto__"]}',
+		);
+		const tool: Tool = { name: "prototype-guard", description: "", parameters: schema };
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: "call-prototype-guard",
+			name: "prototype-guard",
+			arguments: JSON.parse('{"__proto__":"not-a-number"}'),
+		};
+
+		const result = validateToolArguments(tool, toolCall) as Record<string, unknown>;
+		expect(Object.hasOwn(result, "__proto__")).toBe(true);
+		expect(Reflect.get(result, "__proto__")).toBe("not-a-number");
+		expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+	});
+
 	it("does not heal deeply broken JSON strings", () => {
 		const tool: Tool = {
 			name: "heal-3",

--- a/packages/coding-agent/bunfig.toml
+++ b/packages/coding-agent/bunfig.toml
@@ -1,6 +1,7 @@
 [install]
 linker = "isolated"
 exact = true
+minimumReleaseAge = 604800
 saveTextLockfile = true
 
 [loader]

--- a/packages/coding-agent/scripts/auth-profile-rpc-uat.ts
+++ b/packages/coding-agent/scripts/auth-profile-rpc-uat.ts
@@ -179,6 +179,12 @@ function requireAssistantText(text: string | null, expected: RegExp, check: stri
 	if (!text || !expected.test(text)) throw new Error(`${check} response did not satisfy ${expected}`);
 }
 
+function requireAssistantIncludes(text: string | null, expected: string, check: string): void {
+	if (!text?.toLocaleLowerCase().includes(expected.toLocaleLowerCase())) {
+		throw new Error(`${check} response did not include the expected literal text`);
+	}
+}
+
 function requireSuccessfulTool(events: AgentEvent[], toolName: string, expectedText?: string): void {
 	const event = events.find(
 		(candidate): candidate is Extract<AgentEvent, { type: "tool_execution_end" }> =>
@@ -213,7 +219,7 @@ export async function runRpcProfileScenario(options: {
 			undefined,
 			180_000,
 		);
-		requireAssistantText(await client.getLastAssistantText(), new RegExp(nonce, "i"), "multi-turn seed");
+		requireAssistantIncludes(await client.getLastAssistantText(), nonce, "multi-turn seed");
 	});
 
 	await run("multi-turn recall", async () => {
@@ -222,7 +228,7 @@ export async function runRpcProfileScenario(options: {
 			undefined,
 			180_000,
 		);
-		requireAssistantText(await client.getLastAssistantText(), new RegExp(nonce, "i"), "multi-turn recall");
+		requireAssistantIncludes(await client.getLastAssistantText(), nonce, "multi-turn recall");
 	});
 
 	await run("host tool call", async () => {
@@ -232,7 +238,7 @@ export async function runRpcProfileScenario(options: {
 			180_000,
 		);
 		requireSuccessfulTool(events, "uat_echo", `echo:${nonce}`);
-		requireAssistantText(await client.getLastAssistantText(), new RegExp(`echo:${nonce}`, "i"), "host tool");
+		requireAssistantIncludes(await client.getLastAssistantText(), `echo:${nonce}`, "host tool");
 	});
 
 	await run("direct image input", async () => {

--- a/packages/coding-agent/scripts/capture-ax-fixture.ts
+++ b/packages/coding-agent/scripts/capture-ax-fixture.ts
@@ -73,7 +73,7 @@ try {
 	await Bun.write(HTML_OUT, formHtml);
 	console.log(`wrote ${HTML_OUT} (${formHtml.length} bytes)`);
 	const json = JSON.stringify(snap);
-	const roleCount = (role: string) => (json.match(new RegExp(`"role":"${role}"`, "g")) ?? []).length;
+	const roleCount = (role: string) => json.split(`"role":"${role}"`).length - 1;
 	console.log(`wrote ${OUT} (${json.length} bytes)`);
 	console.log(`url=${page.url().slice(0, 90)}`);
 	console.log(

--- a/packages/coding-agent/scripts/inspect-form.ts
+++ b/packages/coding-agent/scripts/inspect-form.ts
@@ -107,7 +107,7 @@ async function main() {
 		await Bun.sleep(2500);
 		const dump = await server.request("javascript_tool", { code: DUMP }, 15000);
 		const inputs = unwrapJs(dump.content) as Array<Record<string, unknown>>;
-		console.log(`\n=== ${resource}: ${inputs.length} visible inputs ===`);
+		console.log("\n=== %s: %d visible inputs ===", resource, inputs.length);
 		for (const i of inputs) {
 			console.log(
 				`  ${i.vis ? "VIS" : "hid"} <${i.tag}${i.type ? ` type=${i.type}` : ""}> @${JSON.stringify(i.xy)} ` +

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -75,16 +75,25 @@ export interface SettingsOptions {
 // Path Utilities
 // ═══════════════════════════════════════════════════════════════════════════
 
+const UNSAFE_PATH_SEGMENTS = new Set(["__proto__", "constructor", "prototype"]);
+
+function hasUnsafePathSegment(segments: string[]): boolean {
+	return segments.some(segment => segment.length === 0 || UNSAFE_PATH_SEGMENTS.has(segment));
+}
+
 /**
  * Get a nested value from an object by path segments.
  */
 function getByPath(obj: RawSettings, segments: string[]): unknown {
+	if (hasUnsafePathSegment(segments)) return undefined;
 	let current: unknown = obj;
 	for (const segment of segments) {
 		if (current === null || current === undefined || typeof current !== "object") {
 			return undefined;
 		}
-		current = (current as Record<string, unknown>)[segment];
+		const record = current as Record<string, unknown>;
+		if (!Object.hasOwn(record, segment)) return undefined;
+		current = record[segment];
 	}
 	return current;
 }
@@ -94,15 +103,25 @@ function getByPath(obj: RawSettings, segments: string[]): unknown {
  * Creates intermediate objects as needed.
  */
 function setByPath(obj: RawSettings, segments: string[], value: unknown): void {
+	if (hasUnsafePathSegment(segments)) throw new Error("Unsafe settings path");
 	let current = obj;
 	for (let i = 0; i < segments.length - 1; i++) {
 		const segment = segments[i];
-		if (!(segment in current) || typeof current[segment] !== "object" || current[segment] === null) {
-			current[segment] = {};
+		const existing = Object.hasOwn(current, segment) ? current[segment] : undefined;
+		if (typeof existing === "object" && existing !== null) {
+			current = existing as RawSettings;
+			continue;
 		}
-		current = current[segment] as RawSettings;
+		const child: RawSettings = {};
+		Object.defineProperty(current, segment, { configurable: true, enumerable: true, value: child, writable: true });
+		current = child;
 	}
-	current[segments[segments.length - 1]] = value;
+	Object.defineProperty(current, segments[segments.length - 1], {
+		configurable: true,
+		enumerable: true,
+		value,
+		writable: true,
+	});
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -247,13 +266,14 @@ export class Settings {
 	 */
 	clearOverride(path: SettingPath): void {
 		const segments = path.split(".");
+		if (hasUnsafePathSegment(segments)) throw new Error("Unsafe settings path");
 		let current = this.#overrides;
 		for (let i = 0; i < segments.length - 1; i++) {
 			const segment = segments[i];
-			if (!(segment in current)) return;
+			if (!Object.hasOwn(current, segment)) return;
 			current = current[segment] as RawSettings;
 		}
-		delete current[segments[segments.length - 1]];
+		Reflect.deleteProperty(current, segments[segments.length - 1]);
 		this.#rebuildMerged();
 	}
 

--- a/packages/coding-agent/src/sweep/spec-probe.ts
+++ b/packages/coding-agent/src/sweep/spec-probe.ts
@@ -58,16 +58,25 @@ const PROTO_POISON = new Set(["__proto__", "constructor", "prototype"]);
 
 export function setPath(root: Json, dotted: string, value: unknown): void {
 	const parts = dotted.split(".");
-	if (parts.some(k => PROTO_POISON.has(k))) return;
+	if (parts.some(k => k.length === 0 || PROTO_POISON.has(k))) return;
 	let cur: Json = root;
 	for (let i = 0; i < parts.length - 1; i++) {
 		const k = parts[i]!;
-		if (!Object.hasOwn(cur, k) || typeof cur[k] !== "object" || cur[k] === null) {
-			cur[k] = {};
+		const existing = Object.hasOwn(cur, k) ? cur[k] : undefined;
+		if (typeof existing === "object" && existing !== null) {
+			cur = existing as Json;
+			continue;
 		}
-		cur = cur[k] as Json;
+		const child: Json = {};
+		Object.defineProperty(cur, k, { configurable: true, enumerable: true, value: child, writable: true });
+		cur = child;
 	}
-	cur[parts[parts.length - 1]!] = value;
+	Object.defineProperty(cur, parts[parts.length - 1]!, {
+		configurable: true,
+		enumerable: true,
+		value,
+		writable: true,
+	});
 }
 
 export function getPath(root: Json, dotted: string): unknown {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -45,7 +45,7 @@ import {
 type SearchDb = unknown;
 
 const MCP_CALL_TIMEOUT_MS = 60_000;
-const ajv = new Ajv({ allErrors: true, strict: false, logger: false });
+const ajv = new Ajv({ allErrors: false, strict: false, logger: false });
 
 /** Agent event types to forward for progress tracking. */
 const agentEventTypes = new Set<AgentEvent["type"]>([

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -340,10 +340,13 @@ async function tryContentNegotiation(
  * Read a single HTML attribute from a tag string
  */
 function getHtmlAttribute(tag: string, attribute: string): string | null {
-	const pattern = new RegExp(`\\b${attribute}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'=<>]+))`, "i");
-	const match = tag.match(pattern);
-	if (!match) return null;
-	return (match[1] ?? match[2] ?? match[3] ?? "").trim();
+	const attributes = tag.matchAll(/\s([^\s"'<>/=]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>]+))/g);
+	for (const match of attributes) {
+		if (match[1]?.toLowerCase() === attribute.toLowerCase()) {
+			return (match[2] ?? match[3] ?? match[4] ?? "").trim();
+		}
+	}
+	return null;
 }
 
 /**

--- a/packages/coding-agent/src/tools/submit-result.ts
+++ b/packages/coding-agent/src/tools/submit-result.ts
@@ -24,7 +24,7 @@ export interface SubmitResultDetails {
 	error?: string;
 }
 
-const ajv = new Ajv({ allErrors: true, strict: false, logger: false });
+const ajv = new Ajv({ allErrors: false, strict: false, logger: false });
 
 function normalizeSchema(schema: unknown): { normalized?: unknown; error?: string } {
 	if (schema === undefined || schema === null) return {};

--- a/packages/coding-agent/src/web/scrapers/chocolatey.ts
+++ b/packages/coding-agent/src/web/scrapers/chocolatey.ts
@@ -27,10 +27,15 @@ interface NuGetODataResponse {
 }
 
 function extractXmlField(xml: string, fieldName: string): string | null {
-	const pattern = new RegExp(`<d:${fieldName}[^>]*>([\\s\\S]*?)</d:${fieldName}>`, "i");
-	const match = xml.match(pattern);
-	if (!match) return null;
-	return match[1].trim();
+	const lowerXml = xml.toLowerCase();
+	const qualifiedName = `d:${fieldName.toLowerCase()}`;
+	const openStart = lowerXml.indexOf(`<${qualifiedName}`);
+	if (openStart === -1) return null;
+	const valueStart = lowerXml.indexOf(">", openStart + qualifiedName.length + 1);
+	if (valueStart === -1) return null;
+	const valueEnd = lowerXml.indexOf(`</${qualifiedName}>`, valueStart + 1);
+	if (valueEnd === -1) return null;
+	return xml.slice(valueStart + 1, valueEnd).trim();
 }
 
 /**

--- a/packages/coding-agent/src/web/scrapers/hackage.ts
+++ b/packages/coding-agent/src/web/scrapers/hackage.ts
@@ -32,10 +32,9 @@ function compareVersions(a: string, b: string): number {
 }
 
 function extractCabalField(content: string, fieldName: string): string | undefined {
-	const pattern = new RegExp(`^${fieldName}:\\s*(.*)$`, "im");
-	const match = content.match(pattern);
-	if (!match) return undefined;
-	return match[1].trim();
+	const prefix = `${fieldName.toLowerCase()}:`;
+	const line = content.split("\n").find(candidate => candidate.toLowerCase().startsWith(prefix));
+	return line?.slice(prefix.length).trim();
 }
 
 function extractCabalDescription(content: string): string | undefined {

--- a/packages/coding-agent/src/web/search/providers/exa.ts
+++ b/packages/coding-agent/src/web/search/providers/exa.ts
@@ -55,10 +55,10 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 }
 
 function parseOptionalField(section: string, label: string): string | null | undefined {
-	const regex = new RegExp(`(?:^|\\n)${label}:\\s*([^\\n]*)`);
-	const match = section.match(regex);
-	if (!match) return undefined;
-	const value = match[1].trim();
+	const prefix = `${label}:`;
+	const line = section.split("\n").find(candidate => candidate.startsWith(prefix));
+	if (!line) return undefined;
+	const value = line.slice(prefix.length).trim();
 	return value.length > 0 ? value : null;
 }
 

--- a/packages/coding-agent/test/auth-profile-rpc-uat.test.ts
+++ b/packages/coding-agent/test/auth-profile-rpc-uat.test.ts
@@ -131,7 +131,7 @@ describe("authentication profile RPC UAT matrix", () => {
 	it("runs multi-turn recall, host tool, direct image, and inspect_image as one reusable scenario", async () => {
 		let lastText: string | null = null;
 		const prompts: Array<{ message: string; images?: ImageContent[] }> = [];
-		const nonce = "uat-litellm-gpt";
+		const nonce = "uat-[literal].*";
 		const client = {
 			async promptAndWait(message: string, images?: ImageContent[]): Promise<AgentEvent[]> {
 				prompts.push({ message, images });

--- a/packages/coding-agent/test/regression-guard.test.ts
+++ b/packages/coding-agent/test/regression-guard.test.ts
@@ -405,8 +405,8 @@ describe("LiteLLM openai-compat discovery schema (blocks xcsh startup for proxy 
 // ─── CI verify-npm-install backoff ────────────────────────────────────────
 
 describe("CI verify-npm-install uses version-pinned install with backoff (PR #93)", () => {
-	it("ci.yml pins specific version in verify-npm-install step", async () => {
-		const src = await fs.readFile(path.join(import.meta.dir, "../../../.github/workflows/ci.yml"), "utf8");
+	it("the verification script pins the release version instead of installing latest", async () => {
+		const src = await fs.readFile(path.join(import.meta.dir, "../../../scripts/ci-verify-npm-install.sh"), "utf8");
 		// Must install @f5-sales-demo/xcsh@<version> — specific version, not latest
 		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal string match against YAML content
 		expect(src).toContain('"@f5-sales-demo/xcsh@${expected}"');
@@ -478,7 +478,9 @@ describe("CI installs Zig without a deprecated JavaScript action", () => {
 		expect(installer).toContain("shasum -a 256 -c");
 		expect(installer).toContain('if [[ "$EXTENSION" == "zip" ]]');
 		expect(installer).toContain('unzip -q -o "$ARCHIVE"');
-		expect(installer.match(/uses: actions\/cache@v5/g)).toHaveLength(2);
+		expect(installer.match(/uses: actions\/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6\.1\.0/g)).toHaveLength(
+			2,
+		);
 		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression
 		expect(installer).toContain("setup-zig-archive-${{ runner.os }}-${{ runner.arch }}-0.15.2");
 		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression
@@ -554,10 +556,12 @@ describe("release artifacts run the sandbox matrix before and after publication"
 
 	it("checks the globally installed npm executable", async () => {
 		const job = await loadJob("verify-npm-install");
+		const script = await fs.readFile(path.join(import.meta.dir, "../../../scripts/ci-verify-npm-install.sh"), "utf8");
 		expect(job).toContain("release-binaries-linux-win");
-		expect(job).toContain('binary="$(command -v xcsh)"');
-		expect(job).toContain('XCSH_TEST_SANDBOX_CHECK_BINARY="$binary"');
-		expect(job).toContain("bun test packages/coding-agent/test/sandbox-check.test.ts");
+		expect(job).toContain("run: bash scripts/ci-verify-npm-install.sh");
+		expect(script).toContain("binary=$(command -v xcsh)");
+		expect(script).toContain('XCSH_TEST_SANDBOX_CHECK_BINARY="$binary"');
+		expect(script).toContain("bun test packages/coding-agent/test/sandbox-check.test.ts");
 	});
 });
 

--- a/packages/coding-agent/test/sandbox-guard.test.ts
+++ b/packages/coding-agent/test/sandbox-guard.test.ts
@@ -17,8 +17,12 @@ let CWD: string;
 let OTHER: string;
 /** Removed after the file runs; these leaked `guard-*` directories into the OS temp dir (#2633). */
 let container: string;
+let sessionsDirCreated = false;
 
-afterAll(() => fs.rmSync(container, { recursive: true, force: true }));
+afterAll(() => {
+	fs.rmSync(container, { recursive: true, force: true });
+	if (sessionsDirCreated) fs.rmdirSync(getSessionsDir());
+});
 
 beforeAll(() => {
 	container = fs.realpathSync(fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "xcsh-guard-")));
@@ -26,6 +30,12 @@ beforeAll(() => {
 	OTHER = path.join(container, "custB");
 	fs.mkdirSync(CWD);
 	fs.mkdirSync(OTHER);
+	// The read tool can enumerate only an existing directory; keep the fixture hermetic on clean CI homes.
+	const sessionsDir = getSessionsDir();
+	if (!fs.existsSync(sessionsDir)) {
+		fs.mkdirSync(sessionsDir, { recursive: true });
+		sessionsDirCreated = true;
+	}
 });
 
 interface ToolCallEvent {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -122,6 +122,18 @@ describe("Settings", () => {
 		});
 	});
 
+	it("rejects prototype-sensitive runtime override paths", async () => {
+		const settings = await Settings.init({ cwd: projectDir, agentDir, inMemory: true });
+		const runtimeSettings = settings as unknown as {
+			override(path: string, value: unknown): void;
+			clearOverride(path: string): void;
+		};
+
+		expect(() => runtimeSettings.override("__proto__.polluted", true)).toThrow("Unsafe settings path");
+		expect(() => runtimeSettings.clearOverride("constructor.prototype")).toThrow("Unsafe settings path");
+		expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+	});
+
 	describe.skipIf(process.platform === "win32")("config file permissions", () => {
 		it("restores owner-only permissions when rewriting config.yml", async () => {
 			fs.writeFileSync(getConfigPath(), "modelRoles:\n  default: anthropic/claude-opus-5\n", { mode: 0o644 });

--- a/packages/coding-agent/test/sweep/spec-probe.test.ts
+++ b/packages/coding-agent/test/sweep/spec-probe.test.ts
@@ -8,6 +8,8 @@ describe("setPath prototype-pollution guard", () => {
 		setPath(o, "constructor.prototype.polluted", "x");
 		expect(({} as any).polluted).toBeUndefined();
 		expect(Object.hasOwn(o, "__proto__")).toBe(false);
+		setPath(o, "safe..value", "x");
+		expect(Object.hasOwn(o, "safe")).toBe(false);
 	});
 	it("still sets normal nested paths", () => {
 		const o: Record<string, unknown> = {};

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -226,7 +226,7 @@ function loadNative() {
 			return bindings;
 		} catch (err) {
 			if (process.env.PI_DEV) {
-				console.error(`Error loading native addon from ${candidate}:`, err);
+				console.error("Error loading native addon from %s:", candidate, err);
 			}
 			const message = err instanceof Error ? err.message : String(err);
 			errors.push(`${candidate}: ${message}`);

--- a/scripts/ci-verify-npm-install.sh
+++ b/scripts/ci-verify-npm-install.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${EXPECTED_VERSION:?EXPECTED_VERSION is required}"
+
+# Strip the leading v from the release tag.
+expected="${EXPECTED_VERSION#v}"
+max_attempts=8
+delay=10
+
+echo "Expected version: $expected"
+
+for attempt in $(seq 1 "$max_attempts"); do
+  echo ""
+  echo "=== Attempt $attempt/$max_attempts (backoff: ${delay}s) ==="
+
+  npm uninstall -g @f5-sales-demo/xcsh 2>/dev/null || true
+  npm cache clean --force 2>/dev/null || true
+
+  if npm install -g "@f5-sales-demo/xcsh@${expected}" 2>&1; then
+    installed=$(xcsh --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+    echo "Installed version: $installed"
+
+    if [ "$installed" = "$expected" ]; then
+      echo "Version match confirmed."
+      echo "Checking xcsh --help..."
+      xcsh --help >/dev/null
+      binary=$(command -v xcsh)
+      XCSH_TEST_SANDBOX_CHECK_BINARY="$binary" \
+        bun test packages/coding-agent/test/sandbox-check.test.ts
+      echo "npm install verification passed"
+      exit 0
+    fi
+
+    echo "Version mismatch: got $installed, expected $expected"
+  else
+    echo "npm install failed (exit $?)"
+  fi
+
+  if [ "$attempt" -eq "$max_attempts" ]; then
+    echo "ERROR: verification failed after $max_attempts attempts"
+    echo "Last installed version: ${installed:-none}"
+    echo "Expected version: $expected"
+    exit 1
+  fi
+
+  echo "Waiting ${delay}s for npm registry propagation..."
+  sleep "$delay"
+  delay=$((delay * 2))
+done

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,6 +14,7 @@ REPO="f5-sales-demo/xcsh"
 PACKAGE="@f5-sales-demo/xcsh"
 INSTALL_DIR="${PI_INSTALL_DIR:-$HOME/.local/bin}"
 MIN_BUN_VERSION="1.3.7"
+BUN_INSTALL_VERSION="1.3.14"
 
 # Parse arguments
 MODE=""
@@ -122,14 +123,70 @@ has_git() {
 
 # Install bun
 install_bun() {
-  echo "Installing bun..."
-  if command -v bash >/dev/null 2>&1; then
-    curl -fsSL https://bun.sh/install | bash
+  echo "Installing bun ${BUN_INSTALL_VERSION}..."
+
+  for command_name in curl unzip; do
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+      echo "$command_name is required to install Bun"
+      exit 1
+    fi
+  done
+
+  case "$(uname -s)" in
+  Linux) bun_platform="linux" ;;
+  Darwin) bun_platform="darwin" ;;
+  *)
+    echo "Unsupported Bun installation platform: $(uname -s)"
+    exit 1
+    ;;
+  esac
+
+  case "$(uname -m)" in
+  x86_64 | amd64) bun_arch="x64" ;;
+  arm64 | aarch64) bun_arch="aarch64" ;;
+  *)
+    echo "Unsupported Bun installation architecture: $(uname -m)"
+    exit 1
+    ;;
+  esac
+
+  bun_asset="bun-${bun_platform}-${bun_arch}.zip"
+  case "$bun_asset" in
+  bun-darwin-aarch64.zip) bun_sha256="d8b96221828ad6f97ac7ac0ab7e95872341af763001e8803e8267652c2652620" ;;
+  bun-darwin-x64.zip) bun_sha256="4183df3374623e5bab315c547cfa0974533cd457d86b73b639f7a87974cd6633" ;;
+  bun-linux-aarch64.zip) bun_sha256="a27ffb63a8310375836e0d6f668ae17fa8d8d18b88c37c821c65331973a19a3b" ;;
+  bun-linux-x64.zip) bun_sha256="951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f" ;;
+  *)
+    echo "No checksum configured for ${bun_asset}"
+    exit 1
+    ;;
+  esac
+
+  bun_tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$bun_tmp_dir"' EXIT
+  bun_archive="$bun_tmp_dir/$bun_asset"
+  bun_url="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_INSTALL_VERSION}/${bun_asset}"
+  curl --proto '=https' --tlsv1.2 -fsSLo "$bun_archive" "$bun_url"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    bun_actual_sha256=$(sha256sum "$bun_archive" | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    bun_actual_sha256=$(shasum -a 256 "$bun_archive" | awk '{print $1}')
   else
-    echo "bash not found; attempting install with sh..."
-    curl -fsSL https://bun.sh/install | sh
+    echo "sha256sum or shasum is required to verify Bun"
+    exit 1
   fi
-  export BUN_INSTALL="$HOME/.bun"
+
+  if [ "$bun_actual_sha256" != "$bun_sha256" ]; then
+    echo "Bun archive checksum verification failed"
+    exit 1
+  fi
+
+  unzip -q "$bun_archive" -d "$bun_tmp_dir"
+  export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+  mkdir -p "$BUN_INSTALL/bin"
+  mv "$bun_tmp_dir/bun-${bun_platform}-${bun_arch}/bun" "$BUN_INSTALL/bin/bun"
+  chmod 0755 "$BUN_INSTALL/bin/bun"
   export PATH="$BUN_INSTALL/bin:$PATH"
   require_bun_version
 }

--- a/scripts/sync-versions.ts
+++ b/scripts/sync-versions.ts
@@ -37,7 +37,7 @@ for (const dir of packageDirs) {
 		versionMap[pkg.name] = pkg.version;
 	} catch (e) {
 		const error = e as Error;
-		console.error(`Failed to read ${pkgPath}:`, error.message);
+		console.error("Failed to read %s:", pkgPath, error.message);
 	}
 }
 


### PR DESCRIPTION
Resolves the repository security sweep by pinning actions to the latest stable release commits, disabling unsafe credential persistence and cache writes at untrusted boundaries, hardening prototype-sensitive paths and dynamic parsing, and replacing the remote Bun installer pipe with a versioned checksum-verified download.

Also tightens release secret boundaries and workflow validation findings discovered during the sweep. Managed IFS findings remain open for the final docs-control rollout.

Closes #3145