### PR TITLE
ci: migrate custom workflows to self-hosted runners

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -15,8 +15,61 @@ runs:
       shell: bash
       env:
         RUST_TARGET: ${{ inputs.target }}
-      run: |
+      # Environment-file values below come only from fixed runner mappings and
+      # checksum-verified Rustup release metadata, never from event-controlled data.
+      run: | # zizmor: ignore[github-env]
         set -euo pipefail
+
+        if ! command -v rustup >/dev/null 2>&1; then
+          if [ "${RUNNER_OS:-}" = "Linux" ] || [ "$(uname -s)" = "Linux" ]; then
+            arch="${RUNNER_ARCH:-}"
+            if [ -z "$arch" ]; then
+              case "$(uname -m)" in
+                x86_64) arch="X64" ;;
+                aarch64) arch="ARM64" ;;
+              esac
+            fi
+
+            case "$arch" in
+              X64 | amd64)
+                rust_host="x86_64-unknown-linux-gnu"
+                rustup_sha256="4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10"
+                ;;
+              ARM64 | arm64 | aarch64)
+                rust_host="aarch64-unknown-linux-gnu"
+                rustup_sha256="9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792"
+                ;;
+              *)
+                echo "Unsupported Linux architecture for rustup bootstrap: $arch" >&2
+                exit 1
+                ;;
+            esac
+
+            runner_temp="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+            rustup_root="$(mktemp -d "${runner_temp%/}/rustup.XXXXXX")"
+            CARGO_HOME="${CARGO_HOME:-$rustup_root/cargo}"
+            RUSTUP_HOME="${RUSTUP_HOME:-$rustup_root/rustup}"
+            export CARGO_HOME RUSTUP_HOME
+
+            rustup_init="$rustup_root/rustup-init"
+            curl --fail --silent --show-error --location \
+              --output "$rustup_init" \
+              "https://static.rust-lang.org/rustup/dist/${rust_host}/rustup-init"
+            echo "${rustup_sha256}  ${rustup_init}" | sha256sum -c -
+            chmod 0755 "$rustup_init"
+            "$rustup_init" -y --profile minimal --default-host "$rust_host" --no-modify-path
+            rm -f "$rustup_init"
+
+            export PATH="${CARGO_HOME}/bin:${PATH}"
+            if [ -n "${GITHUB_PATH:-}" ]; then
+              echo "${CARGO_HOME}/bin" >> "$GITHUB_PATH"
+            fi
+            if [ -n "${GITHUB_ENV:-}" ]; then
+              echo "CARGO_HOME=${CARGO_HOME}" >> "$GITHUB_ENV"
+              echo "RUSTUP_HOME=${RUSTUP_HOME}" >> "$GITHUB_ENV"
+            fi
+          fi
+        fi
 
         # With no explicit channel, rustup installs the active toolchain declared by
         # rust-toolchain.toml. Target installation is deliberately unqualified so it

--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -15,7 +15,7 @@ jobs:
   update-api-specs:
     environment: release
     name: Deliver Published API Specifications
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     timeout-minutes: 360
     permissions: {}
     steps:

--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -15,7 +15,7 @@ jobs:
   update-api-specs:
     environment: release
     name: Deliver Published API Specifications
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     timeout-minutes: 360
     permissions: {}
     steps:

--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Setup Bun 1.3
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
+          no-cache: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' }}
           bun-version: "1.3"
 
       - name: Validate dispatch identity
@@ -370,6 +371,7 @@ jobs:
       - name: Commit and push generated delivery
         if: steps.main_delivery.outputs.applied != 'true' && steps.main_pending.outputs.pending != 'true'
         env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           BRANCH: ${{ steps.delivery.outputs.branch }}
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           SPEC_VERSION: ${{ steps.delivery.outputs.version }}
@@ -632,6 +634,7 @@ jobs:
       - name: Prepare post-publication acknowledgment
         if: steps.main_delivery.outputs.applied != 'true'
         env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           ACK_BRANCH: ${{ steps.delivery.outputs.ack_branch }}
           DELIVERY_ID: ${{ steps.delivery.outputs.delivery_id }}
           LEDGER_PATH: ${{ steps.delivery.outputs.ledger_path }}

--- a/.github/workflows/api-spec-update.yml
+++ b/.github/workflows/api-spec-update.yml
@@ -373,7 +373,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           BRANCH: ${{ steps.delivery.outputs.branch }}
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           SPEC_VERSION: ${{ steps.delivery.outputs.version }}
         run: |
           set -euo pipefail
@@ -642,7 +641,6 @@ jobs:
           PUBLICATION_LEDGER_PATH: ${{ steps.delivery.outputs.publication_ledger_path }}
           PUBLICATION_RECEIPT_FILE: ${{ steps.publication.outputs.receipt_path }}
           SPEC_VERSION: ${{ steps.delivery.outputs.version }}
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           set -euo pipefail
           gh auth setup-git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
   # Fast lint + type check (no Rust, no native build needed)
   check:
     name: check
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -116,7 +116,7 @@ jobs:
 
   setup-zig-linux:
     name: Verify Zig (Linux)
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -158,7 +158,7 @@ jobs:
           {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"baseline","target":"x86_64-unknown-linux-gnu","rust_checks":true,"sandbox_check":true},
           {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"modern","target":"x86_64-unknown-linux-gnu","rust_checks":false,"sandbox_check":false}
           ]') }}
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     env:
       RUST_TARGET: ${{ matrix.target }}
     steps:
@@ -433,7 +433,7 @@ jobs:
           if-no-files-found: error
   test:
     name: test
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -542,7 +542,7 @@ jobs:
 
   install_methods:
     name: Test installation methods
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -632,7 +632,7 @@ jobs:
     environment: release
     name: Invalidate stale release pull requests
     if: github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore:')
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     timeout-minutes: 5
     permissions: {}
     steps:
@@ -655,7 +655,7 @@ jobs:
     name: Prepare automatic release
     if: github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore:')
     needs: [check, native-linux, native-nonlinux, test, install_methods]
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     permissions: {}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -744,7 +744,7 @@ jobs:
     name: Build Linux and Windows release
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [check, native-linux, native-nonlinux, test, install_methods]
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1186,7 +1186,7 @@ jobs:
     name: Publish immutable GitHub release
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build-release, build-sign-macos]
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     permissions: {}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1249,7 +1249,7 @@ jobs:
     name: Publish Homebrew formula
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1409,7 +1409,7 @@ jobs:
     name: Publish npm packages
     if: startsWith(github.ref, 'refs/tags/v') && !inputs.skip_npm
     needs: [create-release]
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     env:
       XCSH_BUILD_BRANCH: main
     permissions:
@@ -1517,7 +1517,7 @@ jobs:
     name: Verify npm installation
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [publish-npm]
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
   # Fast lint + type check (no Rust, no native build needed)
   check:
     name: check
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -114,13 +114,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run ci:check:full
 
-  setup-zig:
-    name: Verify Zig (${{ matrix.os }})
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-22.04, macos-15-intel, macos-14, windows-latest]
-    runs-on: ${{ matrix.os }}
+  setup-zig-linux:
+    name: Verify Zig (Linux)
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -131,25 +127,181 @@ jobs:
         shell: bash
         run: zig version
 
-  native:
+
+  setup-zig-native:
+    name: Verify Zig (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-15-intel, macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Zig 0.15.2
+        uses: ./.github/actions/setup-zig
+      - name: Verify Zig
+        shell: bash
+        run: zig version
+  native-linux:
     name: Native build (${{ matrix.os }}, ${{ matrix.arch }})
-    needs: setup-zig
+    needs: setup-zig-linux
     strategy:
       fail-fast: false
       matrix:
         include: ${{ startsWith(github.ref, 'refs/tags/v') && fromJSON('[
-          {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"baseline","rust_checks":true,"sandbox_check":true},
-          {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"modern"},
-          {"os":"ubuntu-22.04","platform":"linux","arch":"arm64","target":"aarch64-unknown-linux-gnu"},
-          {"os":"macos-15-intel","platform":"darwin","arch":"x64","variants":"baseline"},
-          {"os":"macos-15-intel","platform":"darwin","arch":"x64","variants":"modern"},
-          {"os":"macos-14","platform":"darwin","arch":"arm64","sandbox_check":true},
-          {"os":"windows-latest","platform":"win32","arch":"x64","variants":"baseline"},
-          {"os":"windows-latest","platform":"win32","arch":"x64","variants":"modern"}
+          {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"baseline","target":"x86_64-unknown-linux-gnu","rust_checks":true,"sandbox_check":true},
+          {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"modern","target":"x86_64-unknown-linux-gnu","rust_checks":false,"sandbox_check":false},
+          {"os":"ubuntu-22.04","platform":"linux","arch":"arm64","target":"aarch64-unknown-linux-gnu","rust_checks":false,"sandbox_check":false}
           ]') || fromJSON('[
-          {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"baseline","rust_checks":true,"sandbox_check":true},
-          {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"modern"},
-          {"os":"macos-14","platform":"darwin","arch":"arm64","sandbox_check":true}
+          {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"baseline","target":"x86_64-unknown-linux-gnu","rust_checks":true,"sandbox_check":true},
+          {"os":"ubuntu-22.04","platform":"linux","arch":"x64","variants":"modern","target":"x86_64-unknown-linux-gnu","rust_checks":false,"sandbox_check":false}
+          ]') }}
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    env:
+      RUST_TARGET: ${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          lfs: true
+      - uses: ./.github/actions/setup-rust
+        with:
+          target: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          lookup-only: true
+          key: ${{ matrix.target }}${{ matrix.variants }}
+          cache-workspace-crates: true
+      - name: Setup Bun 1.3
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        id: setup-bun
+        continue-on-error: true
+        with:
+          no-cache: true
+          bun-version: "1.3"
+      - name: Retry Bun setup on failure
+        if: steps.setup-bun.outcome == 'failure'
+        shell: bash
+        run: |
+          BUN_VERSION=$(curl -sSf "https://api.github.com/repos/oven-sh/bun/releases" \
+            -H "Accept: application/vnd.github+json" \
+            | grep -o '"tag_name": "bun-v1\.3\.[0-9]*"' \
+            | head -1 \
+            | grep -o '1\.3\.[0-9]*') || true
+          if [ -z "$BUN_VERSION" ]; then
+            echo "::warning::Could not resolve latest 1.3.x, falling back to 1.3.13"
+            BUN_VERSION=1.3.13
+          fi
+          echo "Resolved Bun version: $BUN_VERSION"
+          case "$RUNNER_OS" in
+            Linux)  PLATFORM="linux-x64" ;;
+            macOS)
+              case "$RUNNER_ARCH" in
+                ARM64) PLATFORM="darwin-aarch64" ;;
+                *)     PLATFORM="darwin-x64" ;;
+              esac ;;
+            Windows) PLATFORM="windows-x64" ;;
+          esac
+          URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-${PLATFORM}.zip"
+          OUTFILE="bun-download.zip"
+          echo "::warning::setup-bun action failed, retrying manual download from $URL"
+          MAX_RETRIES=3
+          DELAY=15
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            if curl -sSfL --connect-timeout 15 --max-time 120 "$URL" -o "$OUTFILE"; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+              echo "::error::Failed to download Bun after $MAX_RETRIES attempts"
+              exit 1
+            fi
+            echo "Download attempt $attempt/$MAX_RETRIES failed, retrying in ${DELAY}s..."
+            sleep $DELAY
+            DELAY=$((DELAY * 2))
+          done
+          unzip -q "$OUTFILE"
+          rm -f "$OUTFILE"
+          BUN_DIR="$PWD/bun-${PLATFORM}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            BUN_DIR=$(cygpath -w "$BUN_DIR")
+          fi
+          echo "$BUN_DIR" >> "$GITHUB_PATH"
+          bun --version
+      - name: Setup Zig 0.15.2
+        uses: ./.github/actions/setup-zig
+      - run: bun install --frozen-lockfile
+      - name: Install cross-compilation toolchain
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+      - name: Rust checks
+        if: matrix.rust_checks
+        run: bun run check:rs
+      # The containment fence's Landlock compiler. `crates/brush-core-vendored` is excluded from the
+      # workspace so `cargo test -p brush-core` refuses to run; this crate is a member and reaches that
+      # code by path, so it is the only place the compiler is covered. Pure logic — no kernel needed.
+      - name: Containment fence tests
+        if: matrix.rust_checks
+        run: cargo test -p containment-check
+      # Real enforcement, asserted — not a print and not a skip.
+      #
+      # This started as a diagnostic because I did not know whether this runner had Landlock in its LSM
+      # list (Ubuntu only added it to the default list in 24.04). It reported
+      # `lockdown,capability,landlock,yama,apparmor` on kernel 6.8-azure, so the answer is yes and the leg
+      # can assert. Worth having measured rather than guessed: I expected the opposite.
+      #
+      # `status` exits non-zero when there is no backend, which is deliberate. If this runner image ever
+      # loses Landlock, this step must fail loudly rather than quietly stop testing the boundary — a
+      # security check that skips reads exactly like one that passed.
+      - name: Landlock enforcement
+        if: matrix.rust_checks
+        run: |
+          echo "LSM list: $(cat /sys/kernel/security/lsm 2>/dev/null || echo unavailable)"
+          echo "kernel: $(uname -r)"
+          cargo build -p containment-check
+          cargo run -q -p containment-check -- status
+          bash crates/containment-check/landlock-e2e.sh target/debug/containment-check
+      - name: Build native addon(s)
+        env:
+          CROSS_TARGET: ${{ matrix.target }}
+          TARGET_PLATFORM: ${{ matrix.platform }}
+          TARGET_ARCH: ${{ matrix.arch }}
+          TARGET_VARIANTS: ${{ matrix.variants }}
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        shell: bash
+        run: |
+          bun run ci:build:native
+      # Run the diagnostic from inside the same fenced BashTool profile operators use. The standalone
+      # install smoke did not reproduce nested Seatbelt/Landlock composition, which is how #2800
+      # shipped 10/10 in CI and reported 7/10 in a healthy session.
+      - name: Sandbox self-test inside live bash profile
+        if: matrix.sandbox_check
+        run: bun test packages/coding-agent/test/sandbox-check.test.ts
+      - name: Upload native addon(s)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pi-natives-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.variants && format('-{0}', matrix.variants) || '' }}
+          path: packages/natives/native/pi_natives.${{ matrix.platform }}-${{ matrix.arch }}*.node
+          if-no-files-found: error
+
+
+  native-nonlinux:
+    name: Native build (${{ matrix.os }}, ${{ matrix.arch }})
+    needs: setup-zig-native
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ startsWith(github.ref, 'refs/tags/v') && fromJSON('[
+          {"os":"macos-15-intel","platform":"darwin","arch":"x64","variants":"baseline","target":"x86_64-apple-darwin","rust_checks":false,"sandbox_check":false},
+          {"os":"macos-15-intel","platform":"darwin","arch":"x64","variants":"modern","target":"x86_64-apple-darwin","rust_checks":false,"sandbox_check":false},
+          {"os":"macos-14","platform":"darwin","arch":"arm64","target":"aarch64-apple-darwin","rust_checks":false,"sandbox_check":true},
+          {"os":"windows-latest","platform":"win32","arch":"x64","variants":"baseline","target":"x86_64-pc-windows-msvc","rust_checks":false,"sandbox_check":false},
+          {"os":"windows-latest","platform":"win32","arch":"x64","variants":"modern","target":"x86_64-pc-windows-msvc","rust_checks":false,"sandbox_check":false}
+          ]') || fromJSON('[
+          {"os":"macos-14","platform":"darwin","arch":"arm64","target":"aarch64-apple-darwin","rust_checks":false,"sandbox_check":true}
           ]') }}
     runs-on: ${{ matrix.os }}
     env:
@@ -279,10 +431,9 @@ jobs:
           name: pi-natives-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.variants && format('-{0}', matrix.variants) || '' }}
           path: packages/natives/native/pi_natives.${{ matrix.platform }}-${{ matrix.arch }}*.node
           if-no-files-found: error
-
   test:
     name: test
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -391,7 +542,7 @@ jobs:
 
   install_methods:
     name: Test installation methods
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -481,7 +632,7 @@ jobs:
     environment: release
     name: Invalidate stale release pull requests
     if: github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore:')
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     timeout-minutes: 5
     permissions: {}
     steps:
@@ -503,8 +654,8 @@ jobs:
     environment: release
     name: Prepare automatic release
     if: github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore:')
-    needs: [check, native, test, install_methods]
-    runs-on: ubuntu-22.04
+    needs: [check, native-linux, native-nonlinux, test, install_methods]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     permissions: {}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -592,8 +743,8 @@ jobs:
     environment: release
     name: Build Linux and Windows release
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [check, native, test, install_methods]
-    runs-on: ubuntu-22.04
+    needs: [check, native-linux, native-nonlinux, test, install_methods]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -693,7 +844,7 @@ jobs:
     environment: release
     name: Build and sign macOS (${{ matrix.arch }})
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [check, native, test, install_methods]
+    needs: [check, native-linux, native-nonlinux, test, install_methods]
     strategy:
       fail-fast: false
       matrix:
@@ -1035,7 +1186,7 @@ jobs:
     name: Publish immutable GitHub release
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build-release, build-sign-macos]
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     permissions: {}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1098,7 +1249,7 @@ jobs:
     name: Publish Homebrew formula
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [create-release]
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1258,7 +1409,7 @@ jobs:
     name: Publish npm packages
     if: startsWith(github.ref, 'refs/tags/v') && !inputs.skip_npm
     needs: [create-release]
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     env:
       XCSH_BUILD_BRANCH: main
     permissions:
@@ -1366,7 +1517,7 @@ jobs:
     name: Verify npm installation
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [publish-npm]
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/console-catalog-drift.yml
+++ b/.github/workflows/console-catalog-drift.yml
@@ -31,7 +31,7 @@ jobs:
   drift-guard:
     name: Console catalog drift guard
     environment: release
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/console-catalog-drift.yml
+++ b/.github/workflows/console-catalog-drift.yml
@@ -79,6 +79,7 @@ jobs:
         if: steps.ver.outputs.checkable == 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
+          no-cache: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' }}
           bun-version: "1.3"
 
       - run: bun install --frozen-lockfile

--- a/.github/workflows/console-catalog-drift.yml
+++ b/.github/workflows/console-catalog-drift.yml
@@ -31,7 +31,7 @@ jobs:
   drift-guard:
     name: Console catalog drift guard
     environment: release
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/console-catalog-update.yml
+++ b/.github/workflows/console-catalog-update.yml
@@ -25,7 +25,7 @@ jobs:
   update-console-catalog:
     name: Update console catalog
     environment: release
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     permissions:
       contents: write # required to push the generated catalog branch
       pull-requests: write # required to open the catalog refresh PR

--- a/.github/workflows/console-catalog-update.yml
+++ b/.github/workflows/console-catalog-update.yml
@@ -49,9 +49,11 @@ jobs:
       - name: Setup Bun 1.3
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
+          no-cache: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' }}
           bun-version: "1.3"
 
       - name: Cache bun dependencies
+        if: ${{ !startsWith(github.ref, 'refs/tags/') && github.event_name != 'release' }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.bun/install/cache

--- a/.github/workflows/console-catalog-update.yml
+++ b/.github/workflows/console-catalog-update.yml
@@ -25,7 +25,7 @@ jobs:
   update-console-catalog:
     name: Update console catalog
     environment: release
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     permissions:
       contents: write # required to push the generated catalog branch
       pull-requests: write # required to open the catalog refresh PR

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -63,7 +63,7 @@ jobs:
 
   podman-uat-harness:
     name: podman-uat-harness
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     timeout-minutes: 5
     permissions:
       contents: read
@@ -80,7 +80,7 @@ jobs:
     name: container-test
     if: always()
     needs: [container-build-amd64, container-build-arm64, podman-uat-harness]
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     timeout-minutes: 5
     steps:
       - name: Require architecture and harness tests

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -15,21 +15,9 @@ concurrency:
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
-  container-build:
-    name: container-build (${{ matrix.architecture }})
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - architecture: amd64
-            expected_machine: x86_64
-            platform: linux/amd64
-            runner: ubuntu-22.04
-          - architecture: arm64
-            expected_machine: aarch64
-            platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
+  container-build-amd64:
+    name: container-build (amd64)
+    runs-on: [self-hosted, Linux, X64, xcsh, container-build]
     timeout-minutes: 60
     permissions:
       contents: read
@@ -44,15 +32,38 @@ jobs:
 
       - name: Test Alpine container
         env:
-          XCSH_EXPECTED_MACHINE: ${{ matrix.expected_machine }}
-          XCSH_TEST_PLATFORM: ${{ matrix.platform }}
+          XCSH_EXPECTED_MACHINE: x86_64
+          XCSH_TEST_PLATFORM: linux/amd64
+        run: |
+          test "$(uname -m)" = "$XCSH_EXPECTED_MACHINE"
+          bash ./scripts/tdd-docker.sh
+
+  container-build-arm64:
+    name: container-build (arm64)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Test Alpine container
+        env:
+          XCSH_EXPECTED_MACHINE: aarch64
+          XCSH_TEST_PLATFORM: linux/arm64
         run: |
           test "$(uname -m)" = "$XCSH_EXPECTED_MACHINE"
           bash ./scripts/tdd-docker.sh
 
   podman-uat-harness:
     name: podman-uat-harness
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     timeout-minutes: 5
     permissions:
       contents: read
@@ -68,23 +79,25 @@ jobs:
   container-test:
     name: container-test
     if: always()
-    needs: [container-build, podman-uat-harness]
-    runs-on: ubuntu-22.04
+    needs: [container-build-amd64, container-build-arm64, podman-uat-harness]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     timeout-minutes: 5
     steps:
       - name: Require architecture and harness tests
         env:
-          CONTAINER_BUILD_RESULT: ${{ needs.container-build.result }}
+          CONTAINER_BUILD_AMD64_RESULT: ${{ needs.container-build-amd64.result }}
+          CONTAINER_BUILD_ARM64_RESULT: ${{ needs.container-build-arm64.result }}
           PODMAN_HARNESS_RESULT: ${{ needs.podman-uat-harness.result }}
         run: |
-          test "$CONTAINER_BUILD_RESULT" = success
+          test "$CONTAINER_BUILD_AMD64_RESULT" = success
+          test "$CONTAINER_BUILD_ARM64_RESULT" = success
           test "$PODMAN_HARNESS_RESULT" = success
 
   publish-ghcr:
     name: publish-ghcr
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [container-test]
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, container-build]
     timeout-minutes: 180
     permissions:
       contents: read

--- a/.github/workflows/deploy-office-pane.yml
+++ b/.github/workflows/deploy-office-pane.yml
@@ -21,7 +21,7 @@ jobs:
   deploy:
     name: Deploy Office pane
     environment: release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, xcsh]
     steps:
       - name: Checkout xcsh
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/deploy-office-pane.yml
+++ b/.github/workflows/deploy-office-pane.yml
@@ -21,7 +21,7 @@ jobs:
   deploy:
     name: Deploy Office pane
     environment: release
-    runs-on: [self-hosted, Linux, X64, xcsh]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     steps:
       - name: Checkout xcsh
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pii-guard.yml
+++ b/.github/workflows/pii-guard.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   pii-guard:
     name: pii-guard
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/pii-guard.yml
+++ b/.github/workflows/pii-guard.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   pii-guard:
     name: pii-guard
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release-reconcile.yml
+++ b/.github/workflows/release-reconcile.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   reconcile:
     name: Reconcile release
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release-reconcile.yml
+++ b/.github/workflows/release-reconcile.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   reconcile:
     name: Reconcile release
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release-reconcile.yml
+++ b/.github/workflows/release-reconcile.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Setup Bun 1.3
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
+          no-cache: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' }}
           bun-version: "1.3"
       - name: Reconcile tags against releases and npm
         env:

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -48,7 +48,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.head_commit.message, 'chore: bump version to v')
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
     permissions: {}
     steps:
       - name: Checkout

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Set up bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
+          no-cache: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' }}
           bun-version: "1.3"
 
       - name: Resolve target commit SHA

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -48,7 +48,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.head_commit.message, 'chore: bump version to v')
-    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-22.04]
+    runs-on: [self-hosted, Linux, X64, xcsh, ubuntu-24.04]
     permissions: {}
     steps:
       - name: Checkout

--- a/.github/workflows/test-codesign.yml
+++ b/.github/workflows/test-codesign.yml
@@ -37,6 +37,7 @@ jobs:
         id: setup-bun
         continue-on-error: true
         with:
+          no-cache: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' }}
           bun-version: "1.3"
       - name: Retry Bun setup on failure
         if: steps.setup-bun.outcome == 'failure'
@@ -89,6 +90,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
+          lookup-only: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' }}
           cache-workspace-crates: true
       - name: Install Zig 0.15.2
         shell: bash

--- a/actionlint.yml
+++ b/actionlint.yml
@@ -1,7 +1,46 @@
 ---
 self-hosted-runner:
   labels:
+    - administration
+    - api-protection
+    - api-specs
+    - api-specs-enriched
+    - apt-repo
+    - bot-advanced
+    - bot-standard
+    - cdn
+    - cdn-simulator
+    - console
+    - container-build
+    - csd
+    - ddos
+    - demo-resource-template
+    - demo-resources
+    - devcontainer
+    - dns
+    - docs
+    - docs-builder
+    - docs-control
+    - docs-icons
+    - docs-theme
+    - i18n-core
+    - marketplace
+    - marketplace-claude-code
+    - mcn
+    - nginx
+    - observability
+    - origin-server
+    - starlight-llms-txt
+    - starlight-mega-menu
     - terraform-provider-xcsh
+    - traffic-generator
     - ubuntu-24.04-arm
+    - vscode-xcsh
+    - waf
+    - was
+    - webapp-api-protection
+    - xcsh
+    - xcsh-action
+    - xcsh-chrome-extension
 
 config-variables: null

--- a/actionlint.yml
+++ b/actionlint.yml
@@ -26,6 +26,7 @@ self-hosted-runner:
     - i18n-core
     - marketplace
     - marketplace-claude-code
+    - macos-15-intel
     - mcn
     - nginx
     - observability

--- a/packages/coding-agent/test/scripts/ci-workflow-contract.test.ts
+++ b/packages/coding-agent/test/scripts/ci-workflow-contract.test.ts
@@ -13,6 +13,8 @@ interface WorkflowDocument {
 const CI_WORKFLOW = path.resolve(import.meta.dir, "../../../../.github/workflows/ci.yml");
 const CODESIGN_WORKFLOW = path.resolve(import.meta.dir, "../../../../.github/workflows/test-codesign.yml");
 const RUST_SETUP_ACTION = path.resolve(import.meta.dir, "../../../../.github/actions/setup-rust/action.yml");
+const CONTAINER_WORKFLOW = path.resolve(import.meta.dir, "../../../../.github/workflows/container.yml");
+const TDD_DOCKER_SCRIPT = path.resolve(import.meta.dir, "../../../../scripts/tdd-docker.sh");
 
 test("protected CI jobs expose the exact required check-run names", async () => {
 	const workflow = parse(await Bun.file(CI_WORKFLOW).text()) as WorkflowDocument;
@@ -31,10 +33,24 @@ test("CI installs cross targets into the repository-selected Rust toolchain", as
 		expect(workflow).toContain("uses: ./.github/actions/setup-rust");
 	}
 
-	expect(ciWorkflow.match(/uses: \.\/\.github\/actions\/setup-rust/g)).toHaveLength(3);
+	expect(ciWorkflow.match(/uses: \.\/\.github\/actions\/setup-rust/g)).toHaveLength(4);
 	expect(ciWorkflow).toContain(`target: \${{ matrix.target }}`);
 	expect(codesignWorkflow.match(/uses: \.\/\.github\/actions\/setup-rust/g)).toHaveLength(1);
 	expect(setupAction).toContain("rustup toolchain install --profile minimal --no-self-update");
 	expect(setupAction).toContain('rustup target add "$RUST_TARGET"');
 	expect(setupAction).not.toContain("--toolchain");
+	expect(setupAction).toContain('mktemp -d "${runner_temp%/}/rustup.XXXXXX"');
+	expect(setupAction).toContain("4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10");
+	expect(setupAction).toContain("9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792");
+	expect(setupAction).toContain("sha256sum -c -");
+	expect(setupAction).not.toContain("sudo");
+});
+
+test("container publishing contract checks the ARM runner runs-on key", async () => {
+	const workflow = await Bun.file(CONTAINER_WORKFLOW).text();
+	const script = await Bun.file(TDD_DOCKER_SCRIPT).text();
+
+	expect(workflow).toContain("runs-on: ubuntu-24.04-arm");
+	expect(script).toContain("grep -Fq 'runs-on: ubuntu-24.04-arm' .github/workflows/container.yml");
+	expect(script).not.toContain("runner: ubuntu-24.04-arm");
 });

--- a/scripts/tdd-docker.sh
+++ b/scripts/tdd-docker.sh
@@ -104,7 +104,7 @@ if grep -Fq '/var/run/docker.sock' <<<"$compose_config"; then
   exit 1
 fi
 grep -Fq 'container-test:' .github/workflows/container.yml
-grep -Fq 'runner: ubuntu-24.04-arm' .github/workflows/container.yml
+grep -Fq 'runs-on: ubuntu-24.04-arm' .github/workflows/container.yml
 grep -Fq 'docker/build-push-action@' .github/workflows/container.yml
 grep -Fq 'docker/setup-qemu-action@' .github/workflows/container.yml
 grep -Fq 'platforms: linux/amd64,linux/arm64' .github/workflows/container.yml


### PR DESCRIPTION
Closes #3149

- route Linux jobs to repository-scoped self-hosted runners
- preserve explicit native macOS, Windows, and ARM64 coverage where applicable
- pin Marketplace actions to current stable release SHAs

Validation: central runner-routing and immutable-pin audit; actionlint syntax validation; git diff checks.