### PR TITLE
fix(release): configure git auth for automatic releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,6 +578,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Configure scoped GitHub Git credentials
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: gh auth setup-git
       - name: Auto-detect version and release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Closes #3156

Preserves credential-free checkout and configures the existing scoped release token as a GitHub CLI Git credential helper immediately before the automatic release command.

Validation:
- `git diff --check`
- `actionlint -ignore 'label "macos-15-intel" is unknown' .github/workflows/ci.yml` (the ignored labels are existing governed configuration pending sync)\n- `bun run check`