### PR TITLE
fix(search): deduplicate Anthropic allowed domains

### DIFF
--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -287,7 +287,7 @@ export async function searchAnthropic(params: AnthropicSearchParams): Promise<Se
 	const model = getModel();
 
 	const { cleanQuery, domains: siteDomains } = extractSiteOperators(params.query);
-	const allAllowedDomains = [...(params.allowed_domains ?? []), ...siteDomains];
+	const allAllowedDomains = Array.from(new Set([...(params.allowed_domains ?? []), ...siteDomains]));
 
 	const response = await callSearch(
 		auth,

--- a/packages/coding-agent/test/tools/web-search-anthropic.test.ts
+++ b/packages/coding-agent/test/tools/web-search-anthropic.test.ts
@@ -196,6 +196,19 @@ describe("searchAnthropic headers", () => {
 		expect(tools?.[0]?.allowed_domains).toEqual(["example.com", "docs.example.com"]);
 	});
 
+	it("deduplicates identical explicit allowed_domains and site: domain", async () => {
+		process.env.ANTHROPIC_SEARCH_API_KEY = "sk-ant-api-test";
+		using _hook = mockFetch(makeAnthropicResponse());
+
+		await searchAnthropic({
+			query: "site:example.com search terms",
+			allowed_domains: ["example.com", "other.com"],
+		});
+
+		const tools = capturedRequest?.body?.tools as any[];
+		expect(tools?.[0]?.allowed_domains).toEqual(["example.com", "other.com"]);
+	});
+
 	it("sends max_uses in tool definition when provided", async () => {
 		process.env.ANTHROPIC_SEARCH_API_KEY = "sk-ant-api-test";
 		using _hook = mockFetch(makeAnthropicResponse());


### PR DESCRIPTION
## Summary

Deduplicate Anthropic web-search `allowed_domains` before request emission so an explicit domain repeated by a `site:` operator is sent once.

## Related Issue

Closes #3159

## Changes

- Add a mocked-transport regression test for identical explicit and `site:` domains.
- Deduplicate the explicit-first/site-second combined list with case-sensitive, first-seen-order `Set` semantics.
- Leave blocked-domain behavior, public APIs, routing, and LiteLLM configuration unchanged.

## Verification evidence

- TDD red: focused mocked test failed with duplicate `example.com` (`0 pass`, `1 fail`).
- TDD green: focused mocked test passed (`1 pass`, `0 fail`).
- Anthropic web-search test file: `21 pass`, `0 fail`.
- Coding-agent package: `6546 pass`, `559 skip`, `0 fail` across 621 files.
- `bun run check:ts`: passed.
- No live provider or LiteLLM calls were made.

## Delivery evidence

- CI and squash auto-merge are being monitored through the persistent server-side Herdr workflow.

## Checklist

- [x] Linked to a detailed issue with `Closes #3159`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above

- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions
