### PR TITLE
feat(media): add durable rich media core and playback

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -433,6 +433,24 @@ export const SETTINGS_SCHEMA = {
 		ui: { tab: "appearance", label: "Block Images", description: "Prevent images from being sent to LLM providers" },
 	},
 
+	"media.autoplay": {
+		type: "boolean",
+		default: true,
+		ui: { tab: "appearance", label: "Autoplay Media", description: "Play rich media once when it becomes visible" },
+	},
+
+	"media.reducedMotion": {
+		type: "boolean",
+		default: false,
+		ui: { tab: "appearance", label: "Reduced Motion", description: "Disable automatic rich-media playback" },
+	},
+
+	"media.fpsCap": {
+		type: "number",
+		default: 12,
+		ui: { tab: "appearance", label: "Media FPS Cap", description: "Maximum rich-media playback frame rate" },
+	},
+
 	"images.pasteDir": {
 		type: "string",
 		default: ".",

--- a/packages/coding-agent/src/media/ffmpeg.ts
+++ b/packages/coding-agent/src/media/ffmpeg.ts
@@ -1,0 +1,395 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export interface ProbedMedia {
+	width?: number;
+	height?: number;
+	durationMs?: number;
+}
+
+export interface DecodedRasterFrame {
+	data: Buffer;
+	durationMs: number;
+}
+
+export interface DecodeRasterFramesOptions {
+	ffmpegPath?: string;
+	fpsCap?: number;
+	maxFrames?: number;
+	maxOutputBytes?: number;
+	timeoutMs?: number;
+	signal?: AbortSignal;
+	webpmuxPath?: string;
+	animDumpPath?: string;
+}
+
+async function runWithInput(
+	command: string[],
+	input: Buffer,
+	timeoutMs: number,
+	maxOutputBytes: number,
+	signal?: AbortSignal,
+): Promise<Buffer> {
+	const child = Bun.spawn(command, { stdin: "pipe", stdout: "pipe", stderr: "pipe" });
+	let timedOut = false;
+	let aborted = false;
+	const onAbort = () => {
+		aborted = true;
+		child.kill();
+	};
+	signal?.addEventListener("abort", onAbort, { once: true });
+	if (signal?.aborted) onAbort();
+	const timer = setTimeout(() => {
+		timedOut = true;
+		child.kill();
+	}, timeoutMs);
+	const stderrPromise = new Response(child.stderr).text();
+	const chunks: Buffer[] = [];
+	let bytes = 0;
+	try {
+		child.stdin.write(input);
+		child.stdin.end();
+		const reader = child.stdout.getReader();
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			const chunk = Buffer.from(value);
+			bytes += chunk.byteLength;
+			if (bytes > maxOutputBytes) {
+				child.kill();
+				throw new Error("decoded media output exceeded its bound");
+			}
+			chunks.push(chunk);
+		}
+		const exitCode = await child.exited;
+		const stderr = await stderrPromise;
+		if (aborted) throw signal?.reason ?? new Error("media decoder aborted");
+		if (timedOut) throw new Error("media decoder timed out");
+		if (exitCode !== 0) throw new Error(stderr.trim() || `${command[0]} exited with code ${exitCode}`);
+		return Buffer.concat(chunks, bytes);
+	} finally {
+		clearTimeout(timer);
+		signal?.removeEventListener("abort", onAbort);
+	}
+}
+
+async function runWithoutInput(
+	command: string[],
+	timeoutMs: number,
+	maxOutputBytes: number,
+	signal?: AbortSignal,
+): Promise<Buffer> {
+	const child = Bun.spawn(command, { stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+	let timedOut = false;
+	let aborted = false;
+	const onAbort = () => {
+		aborted = true;
+		child.kill();
+	};
+	signal?.addEventListener("abort", onAbort, { once: true });
+	if (signal?.aborted) onAbort();
+	const timer = setTimeout(() => {
+		timedOut = true;
+		child.kill();
+	}, timeoutMs);
+	const stderrPromise = new Response(child.stderr).text();
+	const chunks: Buffer[] = [];
+	let bytes = 0;
+	try {
+		const reader = child.stdout.getReader();
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			const chunk = Buffer.from(value);
+			bytes += chunk.byteLength;
+			if (bytes > maxOutputBytes) {
+				child.kill();
+				throw new Error("media helper output exceeded its bound");
+			}
+			chunks.push(chunk);
+		}
+		const exitCode = await child.exited;
+		const stderr = await stderrPromise;
+		if (aborted) throw signal?.reason ?? new Error("media helper aborted");
+		if (timedOut) throw new Error("media helper timed out");
+		if (exitCode !== 0) throw new Error(stderr.trim() || `${command[0]} exited with code ${exitCode}`);
+		return Buffer.concat(chunks, bytes);
+	} finally {
+		clearTimeout(timer);
+		signal?.removeEventListener("abort", onAbort);
+	}
+}
+
+function isAnimatedWebp(input: Buffer): boolean {
+	return (
+		input.length >= 16 &&
+		input.subarray(0, 4).toString("ascii") === "RIFF" &&
+		input.subarray(8, 12).toString("ascii") === "WEBP" &&
+		input.includes(Buffer.from("ANIM"))
+	);
+}
+
+async function decodeAnimatedWebpFallback(
+	input: Buffer,
+	options: {
+		ffmpegPath: string;
+		webpmuxPath: string;
+		animDumpPath: string;
+		maxFrames: number;
+		maxOutputBytes: number;
+		timeoutMs: number;
+		fpsCap: number;
+		signal?: AbortSignal;
+	},
+): Promise<DecodedRasterFrame[] | null> {
+	const directory = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-webp-"));
+	try {
+		const sourcePath = path.join(directory, "input.webp");
+		const framesPath = path.join(directory, "frames");
+		await fs.mkdir(framesPath);
+		await fs.writeFile(sourcePath, input);
+		const info = (
+			await runWithoutInput(
+				[options.webpmuxPath, "-info", sourcePath],
+				options.timeoutMs,
+				1024 * 1024,
+				options.signal,
+			)
+		).toString("utf8");
+		const canvas = /Canvas size:\s*(\d+)\s*x\s*(\d+)/u.exec(info);
+		const count = /Number of frames:\s*(\d+)/u.exec(info);
+		const width = Number(canvas?.[1]);
+		const height = Number(canvas?.[2]);
+		const frameCount = Number(count?.[1]);
+		if (
+			!Number.isInteger(width) ||
+			!Number.isInteger(height) ||
+			!Number.isInteger(frameCount) ||
+			width <= 0 ||
+			height <= 0 ||
+			frameCount <= 0 ||
+			frameCount > options.maxFrames ||
+			width * height * 4 * frameCount > options.maxOutputBytes
+		) {
+			return null;
+		}
+		const nativeDurations = info
+			.split("\n")
+			.map(line => /^\s*\d+:\s+\d+\s+\d+\s+\S+\s+\d+\s+\d+\s+(\d+)/u.exec(line))
+			.filter((match): match is RegExpExecArray => match !== null)
+			.map(match => Number(match[1]));
+		await runWithoutInput(
+			[options.animDumpPath, "-folder", framesPath, "-prefix", "frame_", "-pam", sourcePath],
+			options.timeoutMs,
+			1024 * 1024,
+			options.signal,
+		);
+		const framePaths = (await fs.readdir(framesPath))
+			.filter(name => /^frame_\d+\.pam$/u.test(name))
+			.sort()
+			.slice(0, options.maxFrames);
+		if (framePaths.length !== frameCount) return null;
+		const frames: DecodedRasterFrame[] = [];
+		let outputBytes = 0;
+		const minimumDuration = Math.ceil(1000 / options.fpsCap);
+		for (const [index, name] of framePaths.entries()) {
+			const pam = await fs.readFile(path.join(framesPath, name));
+			const remaining = options.maxOutputBytes - outputBytes;
+			if (remaining <= 0) return null;
+			const png = await runWithInput(
+				[
+					options.ffmpegPath,
+					"-v",
+					"error",
+					"-nostdin",
+					"-f",
+					"image2pipe",
+					"-vcodec",
+					"pam",
+					"-i",
+					"pipe:0",
+					"-frames:v",
+					"1",
+					"-f",
+					"image2pipe",
+					"-vcodec",
+					"png",
+					"pipe:1",
+				],
+				pam,
+				options.timeoutMs,
+				remaining,
+				options.signal,
+			);
+			outputBytes += png.byteLength;
+			frames.push({ data: png, durationMs: Math.max(minimumDuration, nativeDurations[index] ?? minimumDuration) });
+		}
+		return frames;
+	} catch {
+		return null;
+	} finally {
+		await fs.rm(directory, { recursive: true, force: true });
+	}
+}
+
+function splitPngStream(output: Buffer, maxFrames: number): Buffer[] {
+	const signature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	const frames: Buffer[] = [];
+	let offset = 0;
+	while (offset < output.length) {
+		if (!output.subarray(offset, offset + signature.length).equals(signature)) {
+			throw new Error("FFmpeg emitted an invalid PNG stream");
+		}
+		const start = offset;
+		offset += signature.length;
+		let complete = false;
+		while (offset + 12 <= output.length) {
+			const length = output.readUInt32BE(offset);
+			const chunkEnd = offset + 12 + length;
+			if (chunkEnd > output.length) throw new Error("FFmpeg emitted a truncated PNG frame");
+			const type = output.subarray(offset + 4, offset + 8).toString("ascii");
+			offset = chunkEnd;
+			if (type === "IEND") {
+				frames.push(output.subarray(start, offset));
+				if (frames.length > maxFrames) throw new Error("decoded media exceeded its frame bound");
+				complete = true;
+				break;
+			}
+		}
+		if (!complete) throw new Error("FFmpeg emitted an incomplete PNG frame");
+	}
+	return frames;
+}
+
+export async function probeMedia(
+	input: Buffer,
+	ffprobePath = "ffprobe",
+	timeoutMs = 10_000,
+	signal?: AbortSignal,
+): Promise<ProbedMedia | null> {
+	try {
+		const output = await runWithInput(
+			[
+				ffprobePath,
+				"-v",
+				"error",
+				"-select_streams",
+				"v:0",
+				"-show_entries",
+				"stream=width,height:format=duration",
+				"-of",
+				"json",
+				"-i",
+				"pipe:0",
+			],
+			input,
+			timeoutMs,
+			1024 * 1024,
+			signal,
+		);
+		const parsed = JSON.parse(output.toString("utf8")) as {
+			streams?: Array<{ width?: number; height?: number }>;
+			format?: { duration?: string };
+		};
+		const stream = parsed.streams?.[0];
+		const durationSeconds = Number(parsed.format?.duration);
+		return {
+			width: stream?.width,
+			height: stream?.height,
+			durationMs:
+				Number.isFinite(durationSeconds) && durationSeconds > 0 ? Math.round(durationSeconds * 1000) : undefined,
+		};
+	} catch {
+		return null;
+	}
+}
+
+export async function decodePoster(
+	input: Buffer,
+	ffmpegPath = "ffmpeg",
+	timeoutMs = 15_000,
+	signal?: AbortSignal,
+): Promise<Buffer | null> {
+	try {
+		return await runWithInput(
+			[
+				ffmpegPath,
+				"-v",
+				"error",
+				"-nostdin",
+				"-i",
+				"pipe:0",
+				"-an",
+				"-frames:v",
+				"1",
+				"-vf",
+				"scale='min(1920,iw)':-2",
+				"-f",
+				"image2pipe",
+				"-vcodec",
+				"png",
+				"pipe:1",
+			],
+			input,
+			timeoutMs,
+			25 * 1024 * 1024,
+			signal,
+		);
+	} catch {
+		return null;
+	}
+}
+
+export async function decodeRasterFrames(
+	input: Buffer,
+	options: DecodeRasterFramesOptions = {},
+): Promise<DecodedRasterFrame[] | null> {
+	const ffmpegPath = options.ffmpegPath ?? "ffmpeg";
+	const fpsCap = Math.max(1, Math.min(60, Math.floor(options.fpsCap ?? 12)));
+	const maxFrames = Math.max(1, Math.floor(options.maxFrames ?? 720));
+	const maxOutputBytes = Math.max(1, Math.floor(options.maxOutputBytes ?? 100 * 1024 * 1024));
+	const timeoutMs = Math.max(1, Math.floor(options.timeoutMs ?? 30_000));
+	try {
+		const output = await runWithInput(
+			[
+				ffmpegPath,
+				"-v",
+				"error",
+				"-nostdin",
+				"-i",
+				"pipe:0",
+				"-an",
+				"-vf",
+				`fps=${fpsCap},scale='min(1920,iw)':-2`,
+				"-frames:v",
+				String(maxFrames),
+				"-f",
+				"image2pipe",
+				"-vcodec",
+				"png",
+				"pipe:1",
+			],
+			input,
+			timeoutMs,
+			maxOutputBytes,
+			options.signal,
+		);
+		const durationMs = Math.ceil(1000 / fpsCap);
+		const frames = splitPngStream(output, maxFrames);
+		if (frames.length === 0) return null;
+		return frames.map(data => ({ data, durationMs }));
+	} catch {
+		if (!isAnimatedWebp(input)) return null;
+		return await decodeAnimatedWebpFallback(input, {
+			ffmpegPath,
+			webpmuxPath: options.webpmuxPath ?? "webpmux",
+			animDumpPath: options.animDumpPath ?? "anim_dump",
+			maxFrames,
+			maxOutputBytes,
+			timeoutMs,
+			fpsCap,
+			signal: options.signal,
+		});
+	}
+}

--- a/packages/coding-agent/src/media/ffmpeg.ts
+++ b/packages/coding-agent/src/media/ffmpeg.ts
@@ -187,7 +187,11 @@ async function decodeAnimatedWebpFallback(
 		);
 		const framePaths = (await fs.readdir(framesPath))
 			.filter(name => /^frame_\d+\.pam$/u.test(name))
-			.sort()
+			.sort(
+				(left, right) =>
+					Number(left.slice("frame_".length, -".pam".length)) -
+					Number(right.slice("frame_".length, -".pam".length)),
+			)
 			.slice(0, options.maxFrames);
 		if (framePaths.length !== frameCount) return null;
 		const frames: DecodedRasterFrame[] = [];

--- a/packages/coding-agent/src/media/ingest.ts
+++ b/packages/coding-agent/src/media/ingest.ts
@@ -1,0 +1,269 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { InternalUrlRouter } from "../internal-urls";
+import type { BlobStore } from "../session/blob-store";
+import { decodePoster, decodeRasterFrames, probeMedia } from "./ffmpeg";
+import { DEFAULT_MEDIA_MAX_BYTES, downloadMediaUrl } from "./network";
+import { sniffMedia } from "./sniff";
+import {
+	createMediaId,
+	type MediaAssetRefV1,
+	type MediaDescriptorV1,
+	type MediaFrameV1,
+	sanitizeMediaProvenance,
+	validateMediaDescriptorV1,
+} from "./types";
+
+export interface MediaInputFrame {
+	text?: string;
+	source?: string;
+	durationMs: number;
+}
+
+export interface DisplayMediaInput {
+	source?: string;
+	frames?: MediaInputFrame[];
+	caption?: string;
+	alt?: string;
+	autoplay?: boolean;
+	loop?: boolean;
+	fpsCap?: number;
+}
+
+export interface IngestedMedia {
+	descriptor: MediaDescriptorV1;
+	posterData?: string;
+	posterMimeType?: string;
+}
+
+export interface MediaIngestorOptions {
+	cwd: string;
+	blobStore: BlobStore;
+	internalRouter?: InternalUrlRouter;
+	maxBytes?: number;
+	ffmpegPath?: string;
+	ffprobePath?: string;
+	resolveArtifact?: (source: string) => Promise<string | null>;
+	downloadMedia?: typeof downloadMediaUrl;
+}
+
+export class MediaIngestError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "MediaIngestError";
+	}
+}
+
+interface LoadedSource {
+	data: Buffer;
+	provenanceSource: string;
+	contentType?: string;
+}
+
+function asAsset(ref: string, mimeType: string, bytes: number): MediaAssetRefV1 {
+	return { ref, mimeType, bytes };
+}
+
+function playback(input: DisplayMediaInput): MediaDescriptorV1["playback"] {
+	return {
+		autoplay: input.autoplay ?? true,
+		loop: input.loop ?? false,
+		muted: true,
+		fpsCap: Math.max(1, Math.min(60, Math.floor(input.fpsCap ?? 12))),
+	};
+}
+
+export class MediaIngestor {
+	readonly #options: Required<Pick<MediaIngestorOptions, "cwd" | "blobStore" | "maxBytes">> &
+		Omit<MediaIngestorOptions, "cwd" | "blobStore" | "maxBytes">;
+
+	constructor(options: MediaIngestorOptions) {
+		this.#options = { ...options, maxBytes: options.maxBytes ?? DEFAULT_MEDIA_MAX_BYTES };
+	}
+
+	async #readFile(resolvedPath: string): Promise<Buffer> {
+		const stat = await fs.stat(resolvedPath);
+		if (!stat.isFile()) throw new MediaIngestError("media source must be a regular file");
+		if (stat.size > this.#options.maxBytes) {
+			throw new MediaIngestError(`media source exceeds ${this.#options.maxBytes} byte limit`);
+		}
+		const data = await fs.readFile(resolvedPath);
+		if (data.byteLength > this.#options.maxBytes) {
+			throw new MediaIngestError(`media source exceeds ${this.#options.maxBytes} byte limit`);
+		}
+		return data;
+	}
+
+	async #loadSource(source: string, signal?: AbortSignal): Promise<LoadedSource> {
+		signal?.throwIfAborted();
+		if (source.startsWith("https://")) {
+			try {
+				const result = await (this.#options.downloadMedia ?? downloadMediaUrl)(source, {
+					maxBytes: this.#options.maxBytes,
+					signal,
+				});
+				return { data: result.data, contentType: result.contentType, provenanceSource: result.finalUrl };
+			} catch (error) {
+				throw new MediaIngestError(error instanceof Error ? error.message : String(error));
+			}
+		}
+		if (source.startsWith("artifact://")) {
+			if (this.#options.internalRouter) {
+				const resource = await this.#options.internalRouter.resolve(source);
+				const data = resource.sourcePath
+					? await this.#readFile(resource.sourcePath)
+					: Buffer.from(resource.content, "utf8");
+				return { data, contentType: resource.contentType, provenanceSource: source };
+			}
+			const artifactPath = await this.#options.resolveArtifact?.(source);
+			if (!artifactPath) throw new MediaIngestError("artifact media is unavailable in this session");
+			return { data: await this.#readFile(artifactPath), provenanceSource: source };
+		}
+		const resolvedPath = path.isAbsolute(source) ? path.normalize(source) : path.resolve(this.#options.cwd, source);
+		return { data: await this.#readFile(resolvedPath), provenanceSource: resolvedPath };
+	}
+
+	async #put(data: Buffer, mimeType: string): Promise<MediaAssetRefV1> {
+		const stored = await this.#options.blobStore.put(data);
+		return asAsset(stored.ref, mimeType, data.byteLength);
+	}
+
+	async #ingestTimeline(input: DisplayMediaInput, signal?: AbortSignal): Promise<IngestedMedia> {
+		const frames = input.frames ?? [];
+		if (frames.length === 0) throw new MediaIngestError("display_media requires a source or at least one frame");
+		if (frames.length > 720) throw new MediaIngestError("media timelines are limited to 720 frames");
+		const hasText = frames.some(frame => frame.text !== undefined);
+		const hasRaster = frames.some(frame => frame.source !== undefined);
+		if (hasText === hasRaster) throw new MediaIngestError("timeline frames must be all text or all raster sources");
+		const timeline: MediaFrameV1[] = [];
+		let posterData: string | undefined;
+		let posterMimeType: string | undefined;
+		let rasterBytes = 0;
+		if (hasText) {
+			for (const frame of frames) {
+				signal?.throwIfAborted();
+				if (typeof frame.text !== "string" || !Number.isInteger(frame.durationMs) || frame.durationMs <= 0) {
+					throw new MediaIngestError("text timeline frames require text and a positive integer durationMs");
+				}
+				timeline.push({ text: frame.text, durationMs: frame.durationMs });
+			}
+		} else {
+			for (const frame of frames) {
+				signal?.throwIfAborted();
+				if (!frame.source || !Number.isInteger(frame.durationMs) || frame.durationMs <= 0) {
+					throw new MediaIngestError("raster timeline frames require source and a positive integer durationMs");
+				}
+				const loaded = await this.#loadSource(frame.source, signal);
+				rasterBytes += loaded.data.byteLength;
+				if (rasterBytes > this.#options.maxBytes) {
+					throw new MediaIngestError(`raster timeline aggregate exceeds ${this.#options.maxBytes} byte limit`);
+				}
+				const sniffed = sniffMedia(loaded.data);
+				if (sniffed?.kind !== "image") throw new MediaIngestError("raster timeline frames must be static images");
+				const asset = await this.#put(loaded.data, sniffed.mimeType);
+				timeline.push({ asset, durationMs: frame.durationMs });
+				posterData ??= loaded.data.toString("base64");
+				posterMimeType ??= sniffed.mimeType;
+			}
+		}
+		const canonical = Buffer.from(JSON.stringify(timeline), "utf8");
+		if (canonical.byteLength > this.#options.maxBytes) {
+			throw new MediaIngestError(`media timeline descriptor exceeds ${this.#options.maxBytes} byte limit`);
+		}
+		const hash = new Bun.CryptoHasher("sha256").update(canonical).digest("hex");
+		signal?.throwIfAborted();
+		const descriptor = validateMediaDescriptorV1({
+			version: 1,
+			id: createMediaId(hash),
+			kind: hasText ? "text-timeline" : "raster-timeline",
+			durationMs: timeline.reduce((total, frame) => total + frame.durationMs, 0),
+			caption: input.caption,
+			alt: input.alt,
+			timeline,
+			...(!hasText && "asset" in timeline[0]! ? { poster: timeline[0]!.asset } : {}),
+			provenance: { sourceType: "timeline", source: `timeline:${hash.slice(0, 24)}` },
+			playback: playback(input),
+		});
+		return { descriptor, posterData, posterMimeType };
+	}
+
+	async ingest(input: DisplayMediaInput, signal?: AbortSignal): Promise<IngestedMedia> {
+		signal?.throwIfAborted();
+		if (!input.source) return this.#ingestTimeline(input, signal);
+		if (input.frames) throw new MediaIngestError("display_media accepts either source or frames, not both");
+		const loaded = await this.#loadSource(input.source, signal);
+		signal?.throwIfAborted();
+		const sniffed = sniffMedia(loaded.data);
+		if (!sniffed) throw new MediaIngestError("unsupported or corrupt media content");
+		if (
+			loaded.contentType &&
+			loaded.contentType !== "application/octet-stream" &&
+			loaded.contentType !== sniffed.mimeType
+		) {
+			throw new MediaIngestError(
+				`media MIME mismatch: server sent ${loaded.contentType}, content is ${sniffed.mimeType}`,
+			);
+		}
+		const original = await this.#put(loaded.data, sniffed.mimeType);
+		let poster = sniffed.kind === "image" ? original : undefined;
+		let posterData = sniffed.kind === "image" ? loaded.data.toString("base64") : undefined;
+		let posterMimeType = sniffed.kind === "image" ? sniffed.mimeType : undefined;
+		let degradation: string | undefined;
+		let width = sniffed.width;
+		let height = sniffed.height;
+		let durationMs: number | undefined;
+		let timeline: MediaFrameV1[] | undefined;
+		if (sniffed.kind !== "image") {
+			const [probe, decodedFrames] = await Promise.all([
+				probeMedia(loaded.data, this.#options.ffprobePath, 10_000, signal),
+				decodeRasterFrames(loaded.data, {
+					ffmpegPath: this.#options.ffmpegPath,
+					fpsCap: playback(input).fpsCap,
+					maxOutputBytes: this.#options.maxBytes,
+					signal,
+				}),
+			]);
+			signal?.throwIfAborted();
+			width ??= probe?.width;
+			height ??= probe?.height;
+			durationMs = probe?.durationMs;
+			if (decodedFrames?.length) {
+				timeline = [];
+				for (const frame of decodedFrames) {
+					timeline.push({ asset: await this.#put(frame.data, "image/png"), durationMs: frame.durationMs });
+				}
+				const first = decodedFrames[0]!;
+				poster = "asset" in timeline[0]! ? timeline[0]!.asset : undefined;
+				posterData = first.data.toString("base64");
+				posterMimeType = "image/png";
+				durationMs ??= timeline.reduce((total, frame) => total + frame.durationMs, 0);
+			} else {
+				const decodedPoster = await decodePoster(loaded.data, this.#options.ffmpegPath, 15_000, signal);
+				if (decodedPoster) {
+					poster = await this.#put(decodedPoster, "image/png");
+					posterData = decodedPoster.toString("base64");
+					posterMimeType = "image/png";
+				}
+				degradation =
+					"FFmpeg 6+ is unavailable or could not decode bounded animation frames; showing a static poster.";
+			}
+		}
+		const descriptor = validateMediaDescriptorV1({
+			version: 1,
+			id: createMediaId(original.ref.slice("blob:sha256:".length)),
+			kind: sniffed.kind,
+			width,
+			height,
+			durationMs,
+			caption: input.caption,
+			alt: input.alt,
+			original,
+			poster,
+			timeline,
+			provenance: sanitizeMediaProvenance(loaded.provenanceSource),
+			playback: playback(input),
+			degradation,
+		});
+		return { descriptor, posterData, posterMimeType };
+	}
+}

--- a/packages/coding-agent/src/media/markdown-resolver.ts
+++ b/packages/coding-agent/src/media/markdown-resolver.ts
@@ -1,0 +1,81 @@
+import * as path from "node:path";
+import type { MarkdownMediaOptions, ResolvedMarkdownMedia } from "@f5-sales-demo/pi-tui";
+import type { SessionEntry, SessionManager } from "../session/session-manager";
+import { type DisplayMediaInput, MediaIngestor } from "./ingest";
+import type { MediaDescriptorV1, MediaMessage } from "./types";
+import { sanitizeMediaProvenance } from "./types";
+
+function provenanceKey(source: string, cwd: string): string {
+	if (source.startsWith("https://") || source.startsWith("artifact://")) {
+		return sanitizeMediaProvenance(source).source;
+	}
+	const resolved = path.isAbsolute(source) ? path.normalize(source) : path.resolve(cwd, source);
+	return sanitizeMediaProvenance(resolved).source;
+}
+
+function findPersistedDescriptor(entries: SessionEntry[], source: string, cwd: string): MediaDescriptorV1 | undefined {
+	const key = provenanceKey(source, cwd);
+	for (let index = entries.length - 1; index >= 0; index--) {
+		const entry = entries[index];
+		if (
+			entry?.type === "message" &&
+			entry.message.role === "media" &&
+			entry.message.media.provenance.source === key
+		) {
+			return entry.message.media;
+		}
+	}
+	return undefined;
+}
+
+async function resolveDescriptorAsset(
+	manager: SessionManager,
+	descriptor: MediaDescriptorV1,
+	alt: string,
+): Promise<ResolvedMarkdownMedia | null> {
+	const first = descriptor.timeline?.[0];
+	const asset =
+		descriptor.poster ??
+		(descriptor.kind === "image" ? descriptor.original : undefined) ??
+		(first && "asset" in first ? first.asset : undefined);
+	if (!asset) return null;
+	const hash = asset.ref.startsWith("blob:sha256:") ? asset.ref.slice("blob:sha256:".length) : "";
+	const data = hash ? await manager.getBlobStore().get(hash) : null;
+	if (!data) return null;
+	return {
+		id: descriptor.id,
+		data: data.toString("base64"),
+		mimeType: asset.mimeType,
+		filename: alt || descriptor.alt,
+	};
+}
+
+export function createMarkdownMediaOptions(manager: SessionManager, onInvalidate: () => void): MarkdownMediaOptions {
+	return {
+		onInvalidate,
+		resolve: async request => {
+			const persisted = findPersistedDescriptor(manager.getEntries(), request.source, manager.getCwd());
+			if (persisted) {
+				const restored = await resolveDescriptorAsset(manager, persisted, request.alt);
+				if (restored) return restored;
+			}
+			const ingestor = new MediaIngestor({
+				cwd: manager.getCwd(),
+				blobStore: manager.getBlobStore(),
+				resolveArtifact: async source => {
+					const id = new URL(source).hostname;
+					return await manager.getArtifactPath(id);
+				},
+			});
+			const ingested = await ingestor.ingest({
+				source: request.source,
+				alt: request.alt,
+			} satisfies DisplayMediaInput);
+			const message: MediaMessage = { role: "media", media: ingested.descriptor, timestamp: Date.now() };
+			manager.appendMessage(message);
+			const resolved = await resolveDescriptorAsset(manager, ingested.descriptor, request.alt);
+			if (!resolved) throw new Error(ingested.descriptor.degradation ?? "media has no displayable poster");
+			return resolved;
+		},
+	};
+}

--- a/packages/coding-agent/src/media/network.ts
+++ b/packages/coding-agent/src/media/network.ts
@@ -1,0 +1,208 @@
+import * as dns from "node:dns/promises";
+import type { IncomingHttpHeaders } from "node:http";
+import * as https from "node:https";
+import * as net from "node:net";
+
+export const DEFAULT_MEDIA_MAX_BYTES = 100 * 1024 * 1024;
+export const DEFAULT_MEDIA_CONNECT_TIMEOUT_MS = 10_000;
+export const DEFAULT_MEDIA_TOTAL_TIMEOUT_MS = 60_000;
+export const DEFAULT_MEDIA_MAX_REDIRECTS = 5;
+
+export interface DownloadedMedia {
+	data: Buffer;
+	contentType?: string;
+	finalUrl: string;
+}
+
+export interface MediaRequestOptions {
+	maxBytes: number;
+	connectTimeoutMs: number;
+	totalTimeoutMs: number;
+	maxRedirects: number;
+}
+
+export type MediaLookup = (hostname: string) => Promise<Array<{ address: string; family: number }>>;
+export type MediaRequest = (
+	url: URL,
+	address: string,
+	options: MediaRequestOptions,
+	totalSignal: AbortSignal,
+) => Promise<{ status: number; headers: IncomingHttpHeaders; data: Buffer }>;
+
+export interface MediaDownloadOptions {
+	maxBytes?: number;
+	connectTimeoutMs?: number;
+	totalTimeoutMs?: number;
+	maxRedirects?: number;
+	lookup?: MediaLookup;
+	request?: MediaRequest;
+	signal?: AbortSignal;
+}
+
+function parseIpv4(address: string): number[] | null {
+	const parts = address.split(".");
+	if (parts.length !== 4) return null;
+	const values = parts.map(part => Number(part));
+	return values.every(value => Number.isInteger(value) && value >= 0 && value <= 255) ? values : null;
+}
+
+async function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+	if (signal.aborted) throw signal.reason;
+	return await new Promise<T>((resolve, reject) => {
+		const onAbort = () => {
+			cleanup();
+			reject(signal.reason);
+		};
+		const cleanup = () => signal.removeEventListener("abort", onAbort);
+		signal.addEventListener("abort", onAbort, { once: true });
+		promise.then(
+			value => {
+				cleanup();
+				resolve(value);
+			},
+			error => {
+				cleanup();
+				reject(error);
+			},
+		);
+	});
+}
+
+export function isProhibitedMediaAddress(address: string): boolean {
+	let normalized = address.toLowerCase().split("%", 1)[0] ?? address.toLowerCase();
+	if (normalized.startsWith("::ffff:")) normalized = normalized.slice(7);
+	const v4 = parseIpv4(normalized);
+	if (v4) {
+		const [a, b] = v4;
+		if (a === 0 || a === 127) return true;
+		if (a === 169 && b === 254) return true;
+		if (a >= 224) return true;
+		return false;
+	}
+	if (net.isIP(normalized) !== 6) return true;
+	if (normalized === "::" || normalized === "::1") return true;
+	if (/^fe[89ab][0-9a-f]:/u.test(normalized)) return true;
+	if (normalized.startsWith("ff")) return true;
+	return false;
+}
+
+function validateMediaUrl(input: string): URL {
+	const url = new URL(input);
+	if (url.protocol !== "https:") throw new Error("remote media must use HTTPS");
+	if (url.username || url.password) throw new Error("remote media URLs must not contain credentials");
+	return url;
+}
+
+async function requestPinned(
+	url: URL,
+	address: string,
+	options: MediaRequestOptions,
+	totalSignal: AbortSignal,
+): Promise<{ status: number; headers: IncomingHttpHeaders; data: Buffer }> {
+	return await new Promise((resolve, reject) => {
+		const request = https.request({
+			protocol: "https:",
+			hostname: address,
+			port: url.port ? Number(url.port) : 443,
+			path: `${url.pathname}${url.search}`,
+			method: "GET",
+			servername: url.hostname,
+			rejectUnauthorized: true,
+			headers: {
+				Host: url.port ? `${url.hostname}:${url.port}` : url.hostname,
+				Accept: "image/*,video/mp4;q=0.9,application/octet-stream;q=0.1",
+				"User-Agent": "xcsh-media/1",
+			},
+			signal: totalSignal,
+		});
+		const connectTimer = setTimeout(
+			() => request.destroy(new Error("media connection timed out")),
+			options.connectTimeoutMs,
+		);
+		request.once("socket", socket => {
+			socket.once("secureConnect", () => clearTimeout(connectTimer));
+		});
+		request.once("error", error => {
+			clearTimeout(connectTimer);
+			reject(error);
+		});
+		request.once("response", response => {
+			clearTimeout(connectTimer);
+			const status = response.statusCode ?? 0;
+			const chunks: Buffer[] = [];
+			let bytes = 0;
+			const declaredBytes = Number(response.headers["content-length"]);
+			if (Number.isFinite(declaredBytes) && declaredBytes > options.maxBytes) {
+				response.destroy(new Error(`remote media exceeds ${options.maxBytes} byte limit`));
+				return;
+			}
+			response.on("data", chunkValue => {
+				const chunk = Buffer.from(chunkValue);
+				bytes += chunk.byteLength;
+				if (bytes > options.maxBytes) {
+					response.destroy(new Error(`remote media exceeds ${options.maxBytes} byte limit`));
+					return;
+				}
+				chunks.push(chunk);
+			});
+			response.once("error", reject);
+			response.once("aborted", () => reject(new Error("remote media response was truncated")));
+			response.once("end", () => {
+				if (Number.isFinite(declaredBytes) && declaredBytes >= 0 && bytes !== declaredBytes) {
+					reject(new Error("remote media response was truncated"));
+					return;
+				}
+				resolve({ status, headers: response.headers, data: Buffer.concat(chunks) });
+			});
+		});
+		request.end();
+	});
+}
+
+export async function downloadMediaUrl(input: string, options: MediaDownloadOptions = {}): Promise<DownloadedMedia> {
+	const resolved = {
+		maxBytes: options.maxBytes ?? DEFAULT_MEDIA_MAX_BYTES,
+		connectTimeoutMs: options.connectTimeoutMs ?? DEFAULT_MEDIA_CONNECT_TIMEOUT_MS,
+		totalTimeoutMs: options.totalTimeoutMs ?? DEFAULT_MEDIA_TOTAL_TIMEOUT_MS,
+		maxRedirects: options.maxRedirects ?? DEFAULT_MEDIA_MAX_REDIRECTS,
+	};
+	const lookup: MediaLookup =
+		options.lookup ?? (async hostname => await dns.lookup(hostname, { all: true, verbatim: true }));
+	const request = options.request ?? requestPinned;
+	const controller = new AbortController();
+	const onExternalAbort = () => controller.abort(options.signal?.reason ?? new Error("media download aborted"));
+	options.signal?.addEventListener("abort", onExternalAbort, { once: true });
+	if (options.signal?.aborted) onExternalAbort();
+	const totalTimer = setTimeout(
+		() => controller.abort(new Error("media download timed out")),
+		resolved.totalTimeoutMs,
+	);
+	try {
+		let url = validateMediaUrl(input);
+		for (let redirect = 0; redirect <= resolved.maxRedirects; redirect++) {
+			const addresses = await abortable(lookup(url.hostname), controller.signal);
+			if (addresses.length === 0) throw new Error("remote media host has no addresses");
+			if (addresses.some(item => isProhibitedMediaAddress(item.address))) {
+				throw new Error("remote media host resolves to a prohibited address");
+			}
+			const response = await request(url, addresses[0]!.address, resolved, controller.signal);
+			if (response.status >= 300 && response.status < 400) {
+				const location = response.headers.location;
+				if (!location) throw new Error("media redirect is missing a Location header");
+				if (redirect === resolved.maxRedirects) throw new Error("media redirect limit exceeded");
+				url = validateMediaUrl(new URL(location, url).toString());
+				continue;
+			}
+			if (response.status < 200 || response.status >= 300) {
+				throw new Error(`media download failed with HTTP ${response.status}`);
+			}
+			const header = response.headers["content-type"];
+			const contentType = Array.isArray(header) ? header[0] : header?.split(";", 1)[0]?.trim().toLowerCase();
+			return { data: response.data, contentType, finalUrl: url.toString() };
+		}
+		throw new Error("media redirect limit exceeded");
+	} finally {
+		clearTimeout(totalTimer);
+		options.signal?.removeEventListener("abort", onExternalAbort);
+	}
+}

--- a/packages/coding-agent/src/media/sniff.ts
+++ b/packages/coding-agent/src/media/sniff.ts
@@ -1,0 +1,73 @@
+import type { MediaKind } from "./types";
+
+export interface SniffedMedia {
+	mimeType: "image/png" | "image/jpeg" | "image/gif" | "image/webp" | "video/mp4";
+	kind: Extract<MediaKind, "image" | "video" | "animation">;
+	width?: number;
+	height?: number;
+}
+
+function jpegDimensions(buffer: Buffer): { width: number; height: number } | undefined {
+	let offset = 2;
+	while (offset + 9 < buffer.length) {
+		if (buffer[offset] !== 0xff) {
+			offset++;
+			continue;
+		}
+		const marker = buffer[offset + 1] ?? 0;
+		if (marker >= 0xc0 && marker <= 0xc3) {
+			return { height: buffer.readUInt16BE(offset + 5), width: buffer.readUInt16BE(offset + 7) };
+		}
+		if (offset + 3 >= buffer.length) return undefined;
+		const length = buffer.readUInt16BE(offset + 2);
+		if (length < 2) return undefined;
+		offset += length + 2;
+	}
+	return undefined;
+}
+
+export function sniffMedia(buffer: Buffer): SniffedMedia | null {
+	if (
+		buffer.length >= 24 &&
+		buffer[0] === 0x89 &&
+		buffer.subarray(1, 8).equals(Buffer.from([0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+	) {
+		return {
+			mimeType: "image/png",
+			kind: "image",
+			width: buffer.readUInt32BE(16),
+			height: buffer.readUInt32BE(20),
+		};
+	}
+	if (buffer.length >= 4 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+		return { mimeType: "image/jpeg", kind: "image", ...jpegDimensions(buffer) };
+	}
+	if (buffer.length >= 10 && ["GIF87a", "GIF89a"].includes(buffer.subarray(0, 6).toString("ascii"))) {
+		return {
+			mimeType: "image/gif",
+			kind: "animation",
+			width: buffer.readUInt16LE(6),
+			height: buffer.readUInt16LE(8),
+		};
+	}
+	if (
+		buffer.length >= 16 &&
+		buffer.subarray(0, 4).toString("ascii") === "RIFF" &&
+		buffer.subarray(8, 12).toString("ascii") === "WEBP"
+	) {
+		const chunk = buffer.subarray(12, 16).toString("ascii");
+		let width: number | undefined;
+		let height: number | undefined;
+		let animated = buffer.includes(Buffer.from("ANIM"));
+		if (chunk === "VP8X" && buffer.length >= 30) {
+			animated ||= ((buffer[20] ?? 0) & 0x02) !== 0;
+			width = 1 + (buffer[24] ?? 0) + ((buffer[25] ?? 0) << 8) + ((buffer[26] ?? 0) << 16);
+			height = 1 + (buffer[27] ?? 0) + ((buffer[28] ?? 0) << 8) + ((buffer[29] ?? 0) << 16);
+		}
+		return { mimeType: "image/webp", kind: animated ? "animation" : "image", width, height };
+	}
+	if (buffer.length >= 12 && buffer.subarray(4, 8).toString("ascii") === "ftyp") {
+		return { mimeType: "video/mp4", kind: "video" };
+	}
+	return null;
+}

--- a/packages/coding-agent/src/media/types.ts
+++ b/packages/coding-agent/src/media/types.ts
@@ -1,0 +1,137 @@
+export type MediaKind = "image" | "video" | "animation" | "raster-timeline" | "text-timeline";
+
+export interface MediaAssetRefV1 {
+	ref: string;
+	mimeType: string;
+	bytes: number;
+}
+
+export interface MediaTextFrameV1 {
+	text: string;
+	durationMs: number;
+}
+
+export interface MediaRasterFrameV1 {
+	asset: MediaAssetRefV1;
+	durationMs: number;
+}
+
+export type MediaFrameV1 = MediaTextFrameV1 | MediaRasterFrameV1;
+
+export interface MediaProvenanceV1 {
+	sourceType: "path" | "artifact" | "url" | "timeline" | "tool";
+	source: string;
+}
+
+export interface MediaPlaybackV1 {
+	autoplay: boolean;
+	loop: boolean;
+	muted: true;
+	fpsCap: number;
+}
+
+export interface MediaDescriptorV1 {
+	version: 1;
+	id: string;
+	kind: MediaKind;
+	width?: number;
+	height?: number;
+	durationMs?: number;
+	caption?: string;
+	alt?: string;
+	original?: MediaAssetRefV1;
+	poster?: MediaAssetRefV1;
+	timeline?: MediaFrameV1[];
+	provenance: MediaProvenanceV1;
+	playback: MediaPlaybackV1;
+	degradation?: string;
+}
+
+export interface MediaMessage {
+	role: "media";
+	media: MediaDescriptorV1;
+	timestamp: number;
+}
+
+const BLOB_REF_RE = /^blob:sha256:[a-f0-9]{64}$/u;
+const MEDIA_ID_RE = /^media_[a-f0-9]{24}$/u;
+const MIME_RE = /^(?:image\/(?:png|jpeg|gif|webp)|video\/mp4|text\/plain)$/u;
+
+function assertPositiveInteger(value: unknown, field: string): asserts value is number {
+	if (!Number.isInteger(value) || Number(value) <= 0) {
+		throw new Error(`${field} must be a positive integer`);
+	}
+}
+
+function validateAsset(value: unknown, field: string): asserts value is MediaAssetRefV1 {
+	if (!value || typeof value !== "object") throw new Error(`${field} must be an asset reference`);
+	const asset = value as Partial<MediaAssetRefV1>;
+	if (typeof asset.ref !== "string" || !BLOB_REF_RE.test(asset.ref)) {
+		throw new Error(`${field}.ref must be a SHA-256 blob reference`);
+	}
+	if (typeof asset.mimeType !== "string" || !MIME_RE.test(asset.mimeType)) {
+		throw new Error(`${field}.mimeType is unsupported`);
+	}
+	assertPositiveInteger(asset.bytes, `${field}.bytes`);
+}
+
+export function createMediaId(sha256: string): string {
+	if (!/^[a-f0-9]{64}$/u.test(sha256)) throw new Error("media hash must be 64 lowercase hexadecimal characters");
+	return `media_${sha256.slice(0, 24)}`;
+}
+
+export function sanitizeMediaProvenance(source: string): MediaProvenanceV1 {
+	if (source.startsWith("https://")) {
+		const url = new URL(source);
+		url.username = "";
+		url.password = "";
+		url.search = "";
+		url.hash = "";
+		return { sourceType: "url", source: url.toString() };
+	}
+	if (source.startsWith("artifact://")) {
+		return { sourceType: "artifact", source: source.split(/[?#]/u, 1)[0] ?? source };
+	}
+	return { sourceType: "path", source: source.replace(/[\u0000-\u001f\u007f]/gu, "") };
+}
+
+export function validateMediaDescriptorV1(value: unknown): MediaDescriptorV1 {
+	if (!value || typeof value !== "object") throw new Error("media descriptor must be an object");
+	const descriptor = value as Partial<MediaDescriptorV1>;
+	if (descriptor.version !== 1) throw new Error("unsupported media descriptor version");
+	if (typeof descriptor.id !== "string" || !MEDIA_ID_RE.test(descriptor.id)) throw new Error("invalid media id");
+	if (!["image", "video", "animation", "raster-timeline", "text-timeline"].includes(String(descriptor.kind))) {
+		throw new Error("invalid media kind");
+	}
+	if (!descriptor.original && !descriptor.poster && !descriptor.timeline) {
+		throw new Error("media descriptor requires an original, poster, or timeline");
+	}
+	if (descriptor.original) validateAsset(descriptor.original, "original");
+	if (descriptor.poster) validateAsset(descriptor.poster, "poster");
+	if (descriptor.width !== undefined) assertPositiveInteger(descriptor.width, "width");
+	if (descriptor.height !== undefined) assertPositiveInteger(descriptor.height, "height");
+	if (descriptor.durationMs !== undefined) assertPositiveInteger(descriptor.durationMs, "durationMs");
+	if (!descriptor.provenance || typeof descriptor.provenance.source !== "string") {
+		throw new Error("media provenance is required");
+	}
+	if (descriptor.playback?.muted !== true) throw new Error("media playback must be muted");
+	if (typeof descriptor.playback.autoplay !== "boolean" || typeof descriptor.playback.loop !== "boolean") {
+		throw new Error("media playback flags are required");
+	}
+	if (
+		!Number.isFinite(descriptor.playback.fpsCap) ||
+		descriptor.playback.fpsCap < 1 ||
+		descriptor.playback.fpsCap > 60
+	) {
+		throw new Error("fpsCap must be between 1 and 60");
+	}
+	if (descriptor.timeline) {
+		if (descriptor.timeline.length === 0) throw new Error("timeline must contain at least one frame");
+		for (const [index, frame] of descriptor.timeline.entries()) {
+			assertPositiveInteger(frame.durationMs, `timeline[${index}].durationMs`);
+			if ("asset" in frame) validateAsset(frame.asset, `timeline[${index}].asset`);
+			else if (typeof frame.text !== "string") throw new Error(`timeline[${index}].text must be a string`);
+		}
+	}
+	return descriptor as MediaDescriptorV1;
+}

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -1,5 +1,14 @@
 import type { AssistantMessage, ImageContent, Usage } from "@f5-sales-demo/pi-ai";
-import { Container, Image, ImageProtocol, Markdown, Spacer, TERMINAL, Text } from "@f5-sales-demo/pi-tui";
+import {
+	Container,
+	Image,
+	ImageProtocol,
+	Markdown,
+	type MarkdownMediaOptions,
+	Spacer,
+	TERMINAL,
+	Text,
+} from "@f5-sales-demo/pi-tui";
 import { formatNumber, logger } from "@f5-sales-demo/pi-utils";
 import { settings } from "../../config/settings";
 import { hasPendingMermaid, mermaidThemeSignature, prerenderMermaid } from "../../modes/theme/mermaid-cache";
@@ -19,6 +28,7 @@ export class AssistantMessageComponent extends Container {
 	constructor(
 		message?: AssistantMessage,
 		private hideThinkingBlock = false,
+		private readonly markdownMediaOptions?: MarkdownMediaOptions,
 	) {
 		super();
 
@@ -141,7 +151,9 @@ export class AssistantMessageComponent extends Container {
 			if (content.type === "text" && content.text.trim()) {
 				// Assistant text messages with no background - trim the text
 				// Set paddingY=0 to avoid extra spacing before tool executions
-				this.#contentContainer.addChild(new Markdown(content.text.trim(), 0, 0, getMarkdownTheme()));
+				this.#contentContainer.addChild(
+					new Markdown(content.text.trim(), 0, 0, getMarkdownTheme(), undefined, 2, this.markdownMediaOptions),
+				);
 			} else if (content.type === "thinking" && content.thinking.trim()) {
 				// Add spacing only when another visible assistant content block follows.
 				// This avoids a superfluous blank line before separately-rendered tool execution blocks.

--- a/packages/coding-agent/src/modes/components/gutter-block.ts
+++ b/packages/coding-agent/src/modes/components/gutter-block.ts
@@ -151,6 +151,11 @@ export class GutterBlock<T extends Component> implements Component {
 		this.#stopSpinner();
 	}
 
+	unmount(): void {
+		this.dispose();
+		this.#child.unmount?.();
+	}
+
 	#buildGutterPrefix(): string {
 		if (this.#state === "done") {
 			const colorFn = this.#doneColorFnForOutcome();

--- a/packages/coding-agent/src/modes/components/media-message.ts
+++ b/packages/coding-agent/src/modes/components/media-message.ts
@@ -1,0 +1,272 @@
+import type { TUI } from "@f5-sales-demo/pi-tui";
+import {
+	Container,
+	deleteKittyImage,
+	Image,
+	ImageProtocol,
+	MediaPlaybackScheduler,
+	type MediaPlaybackState,
+	stableKittyImageId,
+	TERMINAL,
+	Text,
+} from "@f5-sales-demo/pi-tui";
+import type { MediaMessage, MediaRasterFrameV1 } from "../../media/types";
+import { type BlobStore, parseBlobRef } from "../../session/blob-store";
+import { resolveImageOptions } from "../../tools/render-utils";
+import { theme } from "../theme/theme";
+
+export interface MediaRenderOptions {
+	autoplay: boolean;
+	reducedMotion: boolean;
+	fpsCap: number;
+}
+
+export type MediaPlaybackAction = "play" | "pause" | "stop";
+
+export interface MediaPlaybackControlResult {
+	id: string;
+	state: MediaPlaybackState;
+}
+
+type LoadedFrame = { text: string; durationMs: number } | { data: string; mimeType: string; durationMs: number };
+
+const activeMediaComponents: MediaMessageComponent[] = [];
+
+export function controlMediaPlayback(
+	action: MediaPlaybackAction,
+	target: "latest" | string = "latest",
+): MediaPlaybackControlResult | null {
+	const component =
+		target === "latest"
+			? activeMediaComponents.at(-1)
+			: activeMediaComponents.findLast(candidate => candidate.mediaId === target);
+	if (!component) return null;
+	component.control(action);
+	return { id: component.mediaId, state: component.playbackState };
+}
+
+export class MediaMessageComponent extends Container {
+	readonly #imageId: number;
+	readonly #viewportObserver: { marker: string; dispose: () => void };
+	readonly #options: MediaRenderOptions;
+	#frames: LoadedFrame[] = [];
+	#scheduler?: MediaPlaybackScheduler;
+	#timer?: ReturnType<typeof setTimeout>;
+	#visible = false;
+	#disposed = false;
+	#extraDegradation?: string;
+
+	constructor(
+		private readonly message: MediaMessage,
+		private readonly blobStore: BlobStore,
+		private readonly ui: TUI,
+		options: Partial<MediaRenderOptions> = {},
+	) {
+		super();
+		this.#imageId = stableKittyImageId(message.media.id);
+		this.#options = {
+			autoplay: options.autoplay ?? true,
+			reducedMotion: options.reducedMotion ?? false,
+			fpsCap: Math.max(1, Math.min(60, Math.floor(options.fpsCap ?? message.media.playback.fpsCap))),
+		};
+		this.#viewportObserver = ui.registerViewportObserver(visible => this.#setVisible(visible));
+		activeMediaComponents.push(this);
+		this.addChild(new Text(theme.fg("dim", `Loading media ${message.media.id}…`), 0, 0));
+		void this.#load();
+	}
+
+	get mediaId(): string {
+		return this.message.media.id;
+	}
+
+	get playbackState(): MediaPlaybackState {
+		return this.#scheduler?.state ?? "stopped";
+	}
+
+	override render(width: number): string[] {
+		const lines = super.render(width);
+		if (lines.length === 0) return [this.#viewportObserver.marker];
+		return lines.map(line => this.#viewportObserver.marker + line);
+	}
+
+	control(action: MediaPlaybackAction): void {
+		if (!this.#scheduler || this.#disposed) return;
+		switch (action) {
+			case "play":
+				this.#scheduler.play(Date.now());
+				this.#scheduleTick();
+				break;
+			case "pause":
+				this.#scheduler.pause();
+				this.#clearTimer();
+				break;
+			case "stop":
+				this.#scheduler.stop();
+				this.#clearTimer();
+				this.#showFrame(0);
+				break;
+		}
+		this.ui.requestRender();
+	}
+
+	async #loadAsset(frame: MediaRasterFrameV1): Promise<LoadedFrame | null> {
+		const hash = parseBlobRef(frame.asset.ref);
+		const data = hash ? await this.blobStore.get(hash) : null;
+		if (!data) return null;
+		return { data: data.toString("base64"), mimeType: frame.asset.mimeType, durationMs: frame.durationMs };
+	}
+
+	async #load(): Promise<void> {
+		try {
+			const { media } = this.message;
+			const timeline = media.timeline;
+			if (timeline?.length) {
+				const isRaster = "asset" in timeline[0]!;
+				const supportsMotion = !isRaster || TERMINAL.imageProtocol === ImageProtocol.Kitty;
+				if (supportsMotion) {
+					const loaded = await Promise.all(
+						timeline.map(frame =>
+							"asset" in frame
+								? this.#loadAsset(frame)
+								: Promise.resolve<LoadedFrame>({ text: frame.text, durationMs: frame.durationMs }),
+						),
+					);
+					if (loaded.some(frame => frame === null)) {
+						throw new Error("one or more timeline assets are unavailable");
+					}
+					this.#frames = loaded as LoadedFrame[];
+				} else {
+					this.#extraDegradation = "Motion playback requires a Kitty graphics terminal; showing a static poster.";
+				}
+			}
+
+			if (this.#frames.length === 0) {
+				const firstFrame = media.timeline?.[0];
+				const asset =
+					media.poster ??
+					(media.kind === "image" ? media.original : undefined) ??
+					(firstFrame && "asset" in firstFrame ? firstFrame.asset : undefined);
+				if (asset) {
+					const hash = parseBlobRef(asset.ref);
+					const data = hash ? await this.blobStore.get(hash) : null;
+					if (data) {
+						this.#frames = [{ data: data.toString("base64"), mimeType: asset.mimeType, durationMs: 1000 }];
+					}
+				} else if (firstFrame && "text" in firstFrame) {
+					this.#frames = [{ text: firstFrame.text, durationMs: firstFrame.durationMs }];
+				}
+			}
+
+			if (this.#disposed) return;
+			if (this.#frames.length === 0) throw new Error("media asset is unavailable");
+			if ((timeline?.length ?? 0) > 1 && this.#frames.length > 1) {
+				this.#scheduler = new MediaPlaybackScheduler(
+					this.#frames.map(frame => frame.durationMs),
+					{
+						autoplay: media.playback.autoplay && this.#options.autoplay,
+						loop: media.playback.loop,
+						fpsCap: Math.min(media.playback.fpsCap, this.#options.fpsCap),
+						reducedMotion: this.#options.reducedMotion,
+					},
+				);
+				this.#scheduler.setVisible(this.#visible, Date.now());
+			}
+			this.#showFrame(0);
+			this.#scheduleTick();
+		} catch (error) {
+			if (this.#disposed) return;
+			this.clear();
+			this.addChild(
+				new Text(
+					theme.fg(
+						"warning",
+						`Media asset unavailable: ${this.message.media.id} (${
+							error instanceof Error ? error.message : String(error)
+						})`,
+					),
+					0,
+					0,
+				),
+			);
+			this.ui.requestRender();
+		}
+	}
+
+	#showFrame(index: number): void {
+		const frame = this.#frames[index];
+		if (!frame || this.#disposed) return;
+		this.clear();
+		if ("text" in frame) {
+			this.addChild(new Text(frame.text, 0, 0));
+		} else {
+			this.addChild(
+				new Image(
+					frame.data,
+					frame.mimeType,
+					{ fallbackColor: text => theme.fg("toolOutput", text) },
+					{
+						...resolveImageOptions(),
+						filename: this.message.media.alt,
+						imageId: this.#imageId,
+					},
+				),
+			);
+		}
+		if (this.message.media.caption) {
+			this.addChild(new Text(theme.fg("muted", this.message.media.caption), 0, 0));
+		}
+		if (this.message.media.degradation) {
+			this.addChild(new Text(theme.fg("warning", this.message.media.degradation), 0, 0));
+		}
+		if (this.#extraDegradation) {
+			this.addChild(new Text(theme.fg("warning", this.#extraDegradation), 0, 0));
+		}
+		this.ui.requestRender();
+	}
+
+	#setVisible(visible: boolean): void {
+		this.#visible = visible;
+		if (!this.#scheduler || this.#disposed) return;
+		this.#scheduler.setVisible(visible, Date.now());
+		if (visible) this.#scheduleTick();
+		else this.#clearTimer();
+	}
+
+	#scheduleTick(): void {
+		this.#clearTimer();
+		if (!this.#visible || this.#scheduler?.state !== "playing" || this.#disposed) return;
+		const delay = Math.ceil(1000 / Math.min(this.message.media.playback.fpsCap, this.#options.fpsCap));
+		this.#timer = setTimeout(() => {
+			this.#timer = undefined;
+			if (!this.#scheduler || this.#disposed) return;
+			const previous = this.#scheduler.frameIndex;
+			const current = this.#scheduler.tick(Date.now());
+			if (current !== previous) this.#showFrame(current);
+			this.#scheduleTick();
+		}, delay);
+	}
+
+	#clearTimer(): void {
+		if (this.#timer) {
+			clearTimeout(this.#timer);
+			this.#timer = undefined;
+		}
+	}
+
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		this.#clearTimer();
+		this.#scheduler?.dispose();
+		this.#viewportObserver.dispose();
+		const index = activeMediaComponents.indexOf(this);
+		if (index >= 0) activeMediaComponents.splice(index, 1);
+		if (TERMINAL.imageProtocol === ImageProtocol.Kitty) {
+			this.ui.terminal.write(deleteKittyImage(this.#imageId));
+		}
+	}
+
+	unmount(): void {
+		this.dispose();
+	}
+}

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -22,6 +22,7 @@ import { BashExecutionComponent } from "../../modes/components/bash-execution";
 import { BorderedLoader } from "../../modes/components/bordered-loader";
 import { DynamicBorder } from "../../modes/components/dynamic-border";
 import { createToolGutter } from "../../modes/components/gutter-block";
+import { controlMediaPlayback, type MediaPlaybackAction } from "../../modes/components/media-message";
 import { PythonExecutionComponent } from "../../modes/components/python-execution";
 import { getMarkdownTheme, getSymbolTheme, theme } from "../../modes/theme/theme";
 import type { InteractiveModeContext } from "../../modes/types";
@@ -237,6 +238,22 @@ export class CommandController {
 				);
 			}
 		}
+	}
+
+	handleMediaCommand(text: string): void {
+		const [, action, target = "latest", ...extra] = text.trim().split(/\s+/u);
+		if (!["play", "pause", "stop"].includes(action ?? "") || extra.length > 0) {
+			this.ctx.showError("Usage: /media play|pause|stop <latest|media-id>");
+			return;
+		}
+		const result = controlMediaPlayback(action as MediaPlaybackAction, target);
+		if (!result) {
+			this.ctx.showError(
+				target === "latest" ? "No media is available in this transcript." : `Media not found: ${target}`,
+			);
+			return;
+		}
+		this.ctx.showStatus(`Media ${result.id}: ${result.state}`);
 	}
 
 	handleCopyCommand(sub?: string) {

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -2,6 +2,7 @@ import { INTENT_FIELD } from "@f5-sales-demo/pi-agent-core";
 import type { AssistantMessage, ImageContent } from "@f5-sales-demo/pi-ai";
 import { Loader, Spacer, TERMINAL } from "@f5-sales-demo/pi-tui";
 import { settings } from "../../config/settings";
+import { createMarkdownMediaOptions } from "../../media/markdown-resolver";
 import { AssistantMessageComponent } from "../../modes/components/assistant-message";
 import {
 	createStreamingAssistantGutter,
@@ -192,7 +193,11 @@ export class EventController {
 				} else if (event.message.role === "assistant") {
 					this.#lastThinkingCount = 0;
 					this.#resetReadGroup();
-					this.ctx.streamingComponent = new AssistantMessageComponent(undefined, this.ctx.hideThinkingBlock);
+					this.ctx.streamingComponent = new AssistantMessageComponent(
+						undefined,
+						this.ctx.hideThinkingBlock,
+						createMarkdownMediaOptions(this.ctx.sessionManager, () => this.ctx.ui.requestRender()),
+					);
 					this.ctx.streamingMessage = event.message;
 					this.ctx.streamingAssistantGutter = createStreamingAssistantGutter(
 						this.ctx.ui,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1215,6 +1215,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#commandController.handleCopyCommand(sub);
 	}
 
+	handleMediaCommand(text: string): void {
+		this.#commandController.handleMediaCommand(text);
+	}
+
 	handleSessionCommand(): Promise<void> {
 		return this.#commandController.handleSessionCommand();
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -173,6 +173,7 @@ export interface InteractiveModeContext {
 	handleExportCommand(text: string): Promise<void>;
 	handleShareCommand(): Promise<void>;
 	handleCopyCommand(sub?: string): void;
+	handleMediaCommand(text: string): void;
 	handleSessionCommand(): Promise<void>;
 	handleJobsCommand(): Promise<void>;
 	handleUsageCommand(reports?: UsageReport[] | null): Promise<void>;

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@f5-sales-demo/pi-agent-core";
 import type { AssistantMessage, ImageContent, Message } from "@f5-sales-demo/pi-ai";
 import { Spacer, Text, TruncatedText } from "@f5-sales-demo/pi-tui";
 import { settings } from "../../config/settings";
+import { createMarkdownMediaOptions } from "../../media/markdown-resolver";
 import { AssistantMessageComponent } from "../../modes/components/assistant-message";
 import { BashExecutionComponent } from "../../modes/components/bash-execution";
 import { BranchSummaryMessageComponent } from "../../modes/components/branch-summary-message";
@@ -13,6 +14,7 @@ import {
 	createToolGutter,
 	GutterBlock,
 } from "../../modes/components/gutter-block";
+import { MediaMessageComponent } from "../../modes/components/media-message";
 import { PythonExecutionComponent } from "../../modes/components/python-execution";
 import { ReadToolGroupComponent } from "../../modes/components/read-tool-group";
 import { SkillMessageComponent } from "../../modes/components/skill-message";
@@ -195,8 +197,21 @@ export class UiHelpers {
 				break;
 			}
 			case "assistant": {
-				const assistantComponent = new AssistantMessageComponent(message, this.ctx.hideThinkingBlock);
+				const assistantComponent = new AssistantMessageComponent(
+					message,
+					this.ctx.hideThinkingBlock,
+					createMarkdownMediaOptions(this.ctx.sessionManager, () => this.ctx.ui.requestRender()),
+				);
 				this.ctx.chatContainer.addChild(createTextGutter(this.ctx.ui, assistantComponent));
+				break;
+			}
+			case "media": {
+				const component = new MediaMessageComponent(message, this.ctx.sessionManager.getBlobStore(), this.ctx.ui, {
+					autoplay: this.ctx.session.settings.get("media.autoplay"),
+					reducedMotion: this.ctx.session.settings.get("media.reducedMotion"),
+					fpsCap: this.ctx.session.settings.get("media.fpsCap"),
+				});
+				this.ctx.chatContainer.addChild(createTextGutter(this.ctx.ui, component));
 				break;
 			}
 			case "toolResult": {

--- a/packages/coding-agent/src/prompts/tools/display-media.md
+++ b/packages/coding-agent/src/prompts/tools/display-media.md
@@ -1,0 +1,8 @@
+Display rich media in the transcript.
+
+Pass exactly one of:
+
+- `source`: a local path, `artifact://` source, session/tool artifact, or HTTPS URL.
+- `frames`: ordered text frames or raster-frame sources with per-frame `durationMs`.
+
+Playback is always muted. Autoplay defaults to once, looping is opt-in, and playback is capped at 12 FPS unless a lower or higher cap (up to 60) is requested. Unsupported terminals and missing FFmpeg receive a static poster or text fallback.

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -436,6 +436,24 @@ function evaluatePuppeteer(check: ToolCallCheck): ToolCallDecision {
 	return ALLOW;
 }
 
+function evaluateDisplayMedia(check: ToolCallCheck): ToolCallDecision {
+	const sources: string[] = [];
+	if (typeof check.input.source === "string") sources.push(check.input.source);
+	if (Array.isArray(check.input.frames)) {
+		for (const frame of check.input.frames) {
+			if (frame && typeof frame === "object" && "source" in frame && typeof frame.source === "string") {
+				sources.push(frame.source);
+			}
+		}
+	}
+	for (const source of sources) {
+		if (source.startsWith("https://") || source.startsWith("artifact://")) continue;
+		const resolved = resolveToCwd(source, check.cwd);
+		if (!permits(check, resolved, "read")) return deny(check.cwd, resolved, "read");
+	}
+	return ALLOW;
+}
+
 function evaluateSearchTool(check: ToolCallCheck, spec: SearchSpec): ToolCallDecision {
 	const { input, cwd } = check;
 	const raw = typeof input[spec.key] === "string" ? (input[spec.key] as string) : "";
@@ -477,6 +495,7 @@ export function evaluateToolCall(check: ToolCallCheck): ToolCallDecision {
 	if (toolName === "read") return evaluateReadTool(check);
 	if (toolName === "generate_image") return evaluateGenerateImage(check);
 	if (toolName === "puppeteer") return evaluatePuppeteer(check);
+	if (toolName === "display_media") return evaluateDisplayMedia(check);
 
 	const searchSpec = SEARCH_TOOLS[toolName];
 	if (searchSpec) return evaluateSearchTool(check, searchSpec);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1082,6 +1082,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			requireSubmitResultTool: options.requireSubmitResultTool,
 			taskDepth: options.taskDepth ?? 0,
 			getSessionFile: () => sessionManager.getSessionFile() ?? null,
+			mediaBlobStore: sessionManager.getBlobStore(),
+			appendMediaMessage: message => {
+				agent.appendMessage(message);
+				sessionManager.appendMessage(message);
+			},
 			getPythonKernelOwnerId: () => pythonKernelOwnerId,
 			assertPythonExecutionAllowed: () => session?.assertPythonExecutionAllowed(),
 			trackPythonExecution: (execution, abortController) =>

--- a/packages/coding-agent/src/session/blob-store.ts
+++ b/packages/coding-agent/src/session/blob-store.ts
@@ -35,6 +35,7 @@ export class BlobStore {
 			},
 		};
 
+		await fs.mkdir(this.dir, { recursive: true });
 		await Bun.write(blobPath, data);
 		return result;
 	}

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -16,6 +16,7 @@ import type {
 	ToolResultMessage,
 } from "@f5-sales-demo/pi-ai";
 import { logger, prompt } from "@f5-sales-demo/pi-utils";
+import type { MediaMessage } from "../media/types";
 import branchSummaryContextPrompt from "../prompts/compaction/branch-summary-context.md" with { type: "text" };
 import compactionSummaryContextPrompt from "../prompts/compaction/compaction-summary-context.md" with { type: "text" };
 import type { OutputMeta } from "../tools/output-meta";
@@ -148,6 +149,7 @@ declare module "@f5-sales-demo/pi-agent-core" {
 		branchSummary: BranchSummaryMessage;
 		compactionSummary: CompactionSummaryMessage;
 		fileMention: FileMentionMessage;
+		media: MediaMessage;
 	}
 }
 
@@ -461,6 +463,8 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 	const converted = messages
 		.map((m): Message | undefined => {
 			switch (m.role) {
+				case "media":
+					return undefined;
 				case "bashExecution":
 					if (m.excludeFromContext) {
 						return undefined;

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -26,6 +26,7 @@ import {
 	Snowflake,
 	toError,
 } from "@f5-sales-demo/pi-utils";
+import type { MediaMessage } from "../media/types";
 import { ArtifactManager } from "./artifacts";
 import {
 	type BlobPutResult,
@@ -1472,6 +1473,11 @@ export class SessionManager {
 		return this.#blobStore.put(data);
 	}
 
+	/** Returns the session's content-addressed blob store for media services. */
+	getBlobStore(): BlobStore {
+		return this.#blobStore;
+	}
+
 	captureState(): SessionManagerStateSnapshot {
 		return {
 			sessionId: this.#sessionId,
@@ -2115,7 +2121,8 @@ export class SessionManager {
 			| HookMessage
 			| BashExecutionMessage
 			| PythonExecutionMessage
-			| FileMentionMessage,
+			| FileMentionMessage
+			| MediaMessage,
 	): string {
 		const entry: SessionMessageEntry = {
 			type: "message",

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -782,6 +782,20 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 		},
 	},
 	{
+		name: "media",
+		description: "Control rich-media playback",
+		subcommands: [
+			{ name: "play", description: "Play media", usage: "<latest|id>" },
+			{ name: "pause", description: "Pause media", usage: "<latest|id>" },
+			{ name: "stop", description: "Stop and reset media", usage: "<latest|id>" },
+		],
+		allowArgs: true,
+		handle: (command, runtime) => {
+			runtime.ctx.editor.setText("");
+			runtime.ctx.handleMediaCommand(command.text);
+		},
+	},
+	{
 		name: "new",
 		description: t("commands.new.description"),
 		handle: async (_command, runtime) => {

--- a/packages/coding-agent/src/tools/display-image.ts
+++ b/packages/coding-agent/src/tools/display-image.ts
@@ -1,23 +1,15 @@
+import * as path from "node:path";
 import type {
 	AgentTool,
 	AgentToolContext,
 	AgentToolResult,
 	AgentToolUpdateCallback,
 } from "@f5-sales-demo/pi-agent-core";
-import type { ImageContent, TextContent } from "@f5-sales-demo/pi-ai";
-import { TERMINAL } from "@f5-sales-demo/pi-tui/terminal-capabilities";
 import { prompt } from "@f5-sales-demo/pi-utils";
 import { type Static, Type } from "@sinclair/typebox";
 import displayImageDescription from "../prompts/tools/display-image.md" with { type: "text" };
-import {
-	ImageInputTooLargeError,
-	type LoadedImageInput,
-	loadImageInput,
-	MAX_IMAGE_INPUT_BYTES,
-} from "../utils/image-loading";
-import { openImageExternal } from "../utils/image-viewer";
+import { DisplayMediaTool } from "./display-media";
 import type { ToolSession } from "./index";
-import { ToolError } from "./tool-errors";
 
 const displayImageSchema = Type.Object(
 	{
@@ -35,72 +27,40 @@ export interface DisplayImageToolDetails {
 	displayMethod: "inline" | "external";
 }
 
+/** Compatibility wrapper for callers that still use the legacy display_image contract. */
 export class DisplayImageTool implements AgentTool<typeof displayImageSchema, DisplayImageToolDetails> {
 	readonly name = "display_image";
 	readonly label = "DisplayImage";
-	readonly description: string;
+	readonly description = prompt.render(displayImageDescription);
 	readonly parameters = displayImageSchema;
 	readonly strict = true;
 
-	constructor(private readonly session: ToolSession) {
-		this.description = prompt.render(displayImageDescription);
-	}
+	constructor(private readonly session: ToolSession) {}
 
 	async execute(
-		_toolCallId: string,
+		toolCallId: string,
 		params: DisplayImageParams,
-		_signal?: AbortSignal,
+		signal?: AbortSignal,
 		_onUpdate?: AgentToolUpdateCallback<DisplayImageToolDetails>,
-		_context?: AgentToolContext,
+		context?: AgentToolContext,
 	): Promise<AgentToolResult<DisplayImageToolDetails>> {
-		if (this.session.settings.get("images.blockImages")) {
-			throw new ToolError("Image display is disabled by settings (images.blockImages=true).");
-		}
-
-		let imageInput: LoadedImageInput | null;
-		try {
-			imageInput = await loadImageInput({
-				path: params.path,
-				cwd: this.session.cwd,
-				autoResize: this.session.settings.get("images.autoResize"),
-				maxBytes: MAX_IMAGE_INPUT_BYTES,
-			});
-		} catch (error) {
-			if (error instanceof ImageInputTooLargeError) {
-				throw new ToolError(error.message);
-			}
-			throw error;
-		}
-
-		if (!imageInput) {
-			throw new ToolError("display_image only supports PNG, JPEG, GIF, and WEBP files detected by file content.");
-		}
-
-		const content: (TextContent | ImageContent)[] = [];
-		let displayMethod: "inline" | "external";
-
-		if (TERMINAL.imageProtocol) {
-			content.push({ type: "image", data: imageInput.data, mimeType: imageInput.mimeType });
-			displayMethod = "inline";
-		} else {
-			const opened = await openImageExternal(imageInput.resolvedPath);
-			const msg = opened
-				? `Opened ${imageInput.resolvedPath} in system image viewer.`
-				: `Could not open ${imageInput.resolvedPath} — no inline image protocol and external viewer failed.`;
-			content.push({ type: "text", text: msg });
-			displayMethod = "external";
-		}
-
-		if (params.caption) {
-			content.push({ type: "text", text: params.caption });
-		}
-
+		const result = await new DisplayMediaTool(this.session).execute(
+			toolCallId,
+			{ source: params.path, caption: params.caption },
+			signal,
+			undefined,
+			context,
+		);
+		const descriptor = result.details?.descriptor;
+		if (!descriptor?.original) throw new Error("display_media did not return an original image asset");
 		return {
-			content,
+			content: result.content,
 			details: {
-				imagePath: imageInput.resolvedPath,
-				mimeType: imageInput.mimeType,
-				displayMethod,
+				imagePath: path.isAbsolute(params.path)
+					? path.normalize(params.path)
+					: path.resolve(this.session.cwd, params.path),
+				mimeType: descriptor.original.mimeType,
+				displayMethod: "inline",
 			},
 		};
 	}

--- a/packages/coding-agent/src/tools/display-media-renderer.ts
+++ b/packages/coding-agent/src/tools/display-media-renderer.ts
@@ -1,0 +1,96 @@
+import type { Component } from "@f5-sales-demo/pi-tui";
+import { Text } from "@f5-sales-demo/pi-tui";
+import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import type { MediaDescriptorV1 } from "../media/types";
+import type { Theme } from "../modes/theme/theme";
+import { CachedOutputBlock, F5_TOOL_BORDER_COLOR, renderStatusLine } from "../tui";
+import { addSection, formatErrorMessage, shortenPath } from "./render-utils";
+
+interface DisplayMediaRenderArgs {
+	source?: string;
+	frames?: unknown[];
+	caption?: string;
+}
+
+interface DisplayMediaRendererResult {
+	content: Array<{ type: string; text?: string }>;
+	details?: { descriptor: MediaDescriptorV1; displayMethod: "inline" | "poster" | "text" };
+	isError?: boolean;
+}
+
+function description(args: DisplayMediaRenderArgs): string {
+	if (args.source) return shortenPath(args.source);
+	if (args.frames) return `${args.frames.length} timeline frame${args.frames.length === 1 ? "" : "s"}`;
+	return "media";
+}
+
+export const displayMediaToolRenderer = {
+	renderCall(args: DisplayMediaRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
+		return new Text(
+			renderStatusLine(
+				{
+					icon: "pending",
+					title: "Display Media",
+					description: uiTheme.fg("muted", description(args)),
+				},
+				uiTheme,
+			),
+			0,
+			0,
+		);
+	},
+
+	renderResult(
+		result: DisplayMediaRendererResult,
+		options: RenderResultOptions,
+		uiTheme: Theme,
+		args?: DisplayMediaRenderArgs,
+	): Component {
+		if (result.isError && !result.details) {
+			const errorText = result.content?.find(content => content.type === "text")?.text;
+			return new Text(formatErrorMessage(errorText, uiTheme), 0, 0);
+		}
+		const descriptor = result.details?.descriptor;
+		const sections: Array<{ label?: string; lines: string[] }> = [];
+		for (const block of result.content?.filter(content => content.type === "text") ?? []) {
+			if (block.text) addSection(sections, "", [uiTheme.fg("toolOutput", `  ${block.text}`)], uiTheme);
+		}
+		const meta = descriptor
+			? [
+					uiTheme.fg("dim", descriptor.kind),
+					uiTheme.fg("dim", descriptor.id),
+					uiTheme.fg("dim", result.details?.displayMethod ?? "text"),
+				]
+			: undefined;
+		const header = renderStatusLine(
+			{
+				title: "Display Media",
+				titleColor: "contentAccent",
+				description: description(args ?? {}),
+				meta,
+			},
+			uiTheme,
+		);
+		const outputBlock = new CachedOutputBlock();
+		return {
+			render(width: number): string[] {
+				return outputBlock.render(
+					{
+						header,
+						state: options.isPartial ? "pending" : result.isError ? "error" : "success",
+						sections,
+						width,
+						borderColor: F5_TOOL_BORDER_COLOR,
+					},
+					uiTheme,
+				);
+			},
+			invalidate(): void {
+				outputBlock.invalidate();
+			},
+		};
+	},
+
+	mergeCallAndResult: true,
+	inline: true,
+};

--- a/packages/coding-agent/src/tools/display-media.ts
+++ b/packages/coding-agent/src/tools/display-media.ts
@@ -1,0 +1,103 @@
+import type {
+	AgentTool,
+	AgentToolContext,
+	AgentToolResult,
+	AgentToolUpdateCallback,
+} from "@f5-sales-demo/pi-agent-core";
+import type { ImageContent, TextContent } from "@f5-sales-demo/pi-ai";
+import { getBlobsDir, prompt } from "@f5-sales-demo/pi-utils";
+import { type Static, Type } from "@sinclair/typebox";
+import { type DisplayMediaInput, type IngestedMedia, MediaIngestError, MediaIngestor } from "../media/ingest";
+import type { MediaDescriptorV1, MediaMessage } from "../media/types";
+import displayMediaDescription from "../prompts/tools/display-media.md" with { type: "text" };
+import { BlobStore } from "../session/blob-store";
+import type { ToolSession } from "./index";
+import { ToolError } from "./tool-errors";
+
+const mediaFrameSchema = Type.Object(
+	{
+		text: Type.Optional(Type.String()),
+		source: Type.Optional(Type.String()),
+		durationMs: Type.Integer({ minimum: 1 }),
+	},
+	{ additionalProperties: false },
+);
+
+const displayMediaSchema = Type.Object(
+	{
+		source: Type.Optional(
+			Type.String({
+				description: "Local path, artifact:// URL, session/tool artifact, or HTTPS URL",
+			}),
+		),
+		frames: Type.Optional(Type.Array(mediaFrameSchema, { minItems: 1 })),
+		caption: Type.Optional(Type.String()),
+		alt: Type.Optional(Type.String()),
+		autoplay: Type.Optional(Type.Boolean({ default: true })),
+		loop: Type.Optional(Type.Boolean({ default: false })),
+		fpsCap: Type.Optional(Type.Integer({ minimum: 1, maximum: 60, default: 12 })),
+	},
+	{ additionalProperties: false },
+);
+
+export type DisplayMediaParams = Static<typeof displayMediaSchema>;
+
+export interface DisplayMediaToolDetails {
+	descriptor: MediaDescriptorV1;
+	displayMethod: "inline" | "poster" | "text";
+}
+
+export class DisplayMediaTool implements AgentTool<typeof displayMediaSchema, DisplayMediaToolDetails> {
+	readonly name = "display_media";
+	readonly label = "DisplayMedia";
+	readonly description = prompt.render(displayMediaDescription);
+	readonly parameters = displayMediaSchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {}
+
+	async execute(
+		_toolCallId: string,
+		params: DisplayMediaParams,
+		signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<DisplayMediaToolDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<DisplayMediaToolDetails>> {
+		if ((params.source ? 1 : 0) + (params.frames ? 1 : 0) !== 1) {
+			throw new ToolError("display_media accepts either source or frames, but not both.");
+		}
+		if (this.session.settings.get("images.blockImages")) {
+			throw new ToolError("Media display is disabled by settings (images.blockImages=true).");
+		}
+		const ingestor = new MediaIngestor({
+			cwd: this.session.cwd,
+			blobStore: this.session.mediaBlobStore ?? new BlobStore(getBlobsDir()),
+			internalRouter: this.session.internalRouter,
+		});
+		let ingested: IngestedMedia;
+		try {
+			ingested = await ingestor.ingest(params as DisplayMediaInput, signal);
+		} catch (error) {
+			if (error instanceof MediaIngestError) throw new ToolError(error.message);
+			throw error;
+		}
+
+		const message: MediaMessage = { role: "media", media: ingested.descriptor, timestamp: Date.now() };
+		this.session.appendMediaMessage?.(message);
+
+		const content: Array<TextContent | ImageContent> = [];
+		let displayMethod: DisplayMediaToolDetails["displayMethod"] = "text";
+		if (ingested.posterData && ingested.posterMimeType) {
+			content.push({ type: "image", data: ingested.posterData, mimeType: ingested.posterMimeType });
+			displayMethod = ingested.descriptor.kind === "image" ? "inline" : "poster";
+		}
+		if (params.caption) content.push({ type: "text", text: params.caption });
+		if (ingested.descriptor.degradation) content.push({ type: "text", text: ingested.descriptor.degradation });
+		if (content.length === 0) {
+			content.push({ type: "text", text: `Media ready: ${ingested.descriptor.id}` });
+		}
+		return { content, details: { descriptor: ingested.descriptor, displayMethod } };
+	}
+}
+
+export { displayMediaToolRenderer } from "./display-media-renderer";

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -29,6 +29,7 @@ import { CatalogWorkflowRunnerTool } from "./catalog-workflow-runner";
 import { type CheckpointState, CheckpointTool, RewindTool } from "./checkpoint";
 import { DebugTool } from "./debug";
 import { DisplayImageTool } from "./display-image";
+import { DisplayMediaTool } from "./display-media";
 import { ExitPlanModeTool } from "./exit-plan-mode";
 import { FindTool } from "./find";
 import { GetPageContextTool } from "./get-page-context";
@@ -71,6 +72,7 @@ export * from "./catalog-workflow-runner";
 export * from "./checkpoint";
 export * from "./debug";
 export * from "./display-image";
+export * from "./display-media";
 export * from "./exit-plan-mode";
 export * from "./find";
 export * from "./gemini-image";
@@ -166,6 +168,10 @@ export interface ToolSession {
 	asyncJobManager?: AsyncJobManager;
 	/** Settings instance for passing to subagents */
 	settings: Settings;
+	/** Blob store used for durable media descriptors. */
+	mediaBlobStore?: import("../session/blob-store").BlobStore;
+	/** Persist a media message outside model context. */
+	appendMediaMessage?: (message: import("../media/types").MediaMessage) => void;
 	/** Plan mode state (if active) */
 	getPlanModeState?: () => PlanModeState | undefined;
 	/** Get compact conversation context for subagents (excludes tool results, system prompts) */
@@ -222,6 +228,7 @@ export const BUILTIN_TOOLS: Record<string, ToolFactory> = {
 	lsp: LspTool.createIf,
 	notebook: s => new NotebookTool(s),
 	read: s => new ReadTool(s),
+	display_media: s => new DisplayMediaTool(s),
 	display_image: s => new DisplayImageTool(s),
 	inspect_image: s => new InspectImageTool(s),
 	browser: s => new BrowserTool(s),

--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -19,6 +19,7 @@ import { browserRenderer } from "./browser-renderer";
 import { calculatorToolRenderer } from "./calculator";
 import { debugToolRenderer } from "./debug";
 import { displayImageToolRenderer } from "./display-image-renderer";
+import { displayMediaToolRenderer } from "./display-media-renderer";
 import { findToolRenderer } from "./find";
 import { grepToolRenderer } from "./grep";
 import { inspectImageToolRenderer } from "./inspect-image-renderer";
@@ -59,6 +60,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
 	grep: grepToolRenderer as ToolRenderer,
 	lsp: lspToolRenderer as ToolRenderer,
 	notebook: notebookToolRenderer as ToolRenderer,
+	display_media: displayMediaToolRenderer as ToolRenderer,
 	display_image: displayImageToolRenderer as ToolRenderer,
 	inspect_image: inspectImageToolRenderer as ToolRenderer,
 	read: readToolRenderer as ToolRenderer,

--- a/packages/coding-agent/test/display-media.test.ts
+++ b/packages/coding-agent/test/display-media.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "../src/config/settings";
+import type { MediaMessage } from "../src/media/types";
+import { BlobStore } from "../src/session/blob-store";
+import type { ToolSession } from "../src/tools";
+import { DisplayImageTool } from "../src/tools/display-image";
+import { DisplayMediaTool } from "../src/tools/display-media";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+test("display_media ingests a source, returns a poster, and persists a media message", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-display-media-"));
+	roots.push(root);
+	const png = Buffer.alloc(24);
+	png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	png.writeUInt32BE(4, 16);
+	png.writeUInt32BE(5, 20);
+	await Bun.write(path.join(root, "poster.dat"), png);
+	const messages: MediaMessage[] = [];
+	const session = {
+		cwd: root,
+		hasUI: true,
+		settings: Settings.isolated({}),
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		mediaBlobStore: new BlobStore(path.join(root, "blobs")),
+		appendMediaMessage: message => messages.push(message),
+	} as ToolSession;
+	const tool = new DisplayMediaTool(session);
+	const result = await tool.execute("call", { source: "poster.dat", caption: "Demo" });
+
+	expect(tool.name).toBe("display_media");
+	expect(result.details?.descriptor.kind).toBe("image");
+	expect(result.content).toContainEqual({ type: "image", data: png.toString("base64"), mimeType: "image/png" });
+	expect(result.content).toContainEqual({ type: "text", text: "Demo" });
+	expect(messages).toHaveLength(1);
+	expect(messages[0]!.media.id).toBe(result.details!.descriptor.id);
+});
+
+describe("display_media validation", () => {
+	test("rejects source and frames together", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-display-media-"));
+		roots.push(root);
+		const session = {
+			cwd: root,
+			hasUI: false,
+			settings: Settings.isolated({}),
+			getSessionFile: () => null,
+			getSessionSpawns: () => null,
+			mediaBlobStore: new BlobStore(path.join(root, "blobs")),
+		} as ToolSession;
+		const tool = new DisplayMediaTool(session);
+		await expect(tool.execute("call", { source: "x.png", frames: [{ text: "x", durationMs: 100 }] })).rejects.toThrow(
+			"either source or frames",
+		);
+	});
+});
+
+test("display_image delegates ingestion to the durable media core", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-display-image-"));
+	roots.push(root);
+	const png = Buffer.alloc(24);
+	png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	png.writeUInt32BE(3, 16);
+	png.writeUInt32BE(2, 20);
+	await Bun.write(path.join(root, "compat.bin"), png);
+	const messages: MediaMessage[] = [];
+	const session = {
+		cwd: root,
+		hasUI: true,
+		settings: Settings.isolated({}),
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		mediaBlobStore: new BlobStore(path.join(root, "blobs")),
+		appendMediaMessage: message => messages.push(message),
+	} as ToolSession;
+
+	const result = await new DisplayImageTool(session).execute("call", {
+		path: "compat.bin",
+		caption: "Compatibility",
+	});
+
+	expect(messages).toHaveLength(1);
+	expect(messages[0]!.media.kind).toBe("image");
+	expect(result.content).toContainEqual({ type: "image", data: png.toString("base64"), mimeType: "image/png" });
+	expect(result.content).toContainEqual({ type: "text", text: "Compatibility" });
+});

--- a/packages/coding-agent/test/markdown-media-resolver.test.ts
+++ b/packages/coding-agent/test/markdown-media-resolver.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createMarkdownMediaOptions } from "../src/media/markdown-resolver";
+import { createMediaId, type MediaMessage, validateMediaDescriptorV1 } from "../src/media/types";
+import { BlobStore } from "../src/session/blob-store";
+import type { SessionManager } from "../src/session/session-manager";
+
+const roots: string[] = [];
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+test("Markdown media recovers a persisted descriptor without reading its original source", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-markdown-media-"));
+	roots.push(root);
+	const store = new BlobStore(path.join(root, "blobs"));
+	const png = Buffer.alloc(24);
+	png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	png.writeUInt32BE(8, 16);
+	png.writeUInt32BE(9, 20);
+	const stored = await store.put(png);
+	const media: MediaMessage = {
+		role: "media",
+		media: validateMediaDescriptorV1({
+			version: 1,
+			id: createMediaId(stored.hash),
+			kind: "image",
+			width: 8,
+			height: 9,
+			original: { ref: stored.ref, mimeType: "image/png", bytes: png.byteLength },
+			poster: { ref: stored.ref, mimeType: "image/png", bytes: png.byteLength },
+			provenance: { sourceType: "path", source: path.join(root, "deleted.png") },
+			playback: { autoplay: true, loop: false, muted: true, fpsCap: 12 },
+		}),
+		timestamp: 1,
+	};
+	let appended = 0;
+	const manager = {
+		getEntries: () => [
+			{ type: "message", id: "1", parentId: null, timestamp: new Date(1).toISOString(), message: media },
+		],
+		getBlobStore: () => store,
+		getCwd: () => root,
+		getArtifactPath: async () => null,
+		appendMessage: () => {
+			appended++;
+			return "2";
+		},
+	} as unknown as SessionManager;
+	const options = createMarkdownMediaOptions(manager, () => {});
+
+	const resolved = await options.resolve({ source: path.join(root, "deleted.png"), alt: "restored" });
+	expect(resolved.data).toBe(png.toString("base64"));
+	expect(resolved.filename).toBe("restored");
+	expect(appended).toBe(0);
+});

--- a/packages/coding-agent/test/media-ffmpeg.test.ts
+++ b/packages/coding-agent/test/media-ffmpeg.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { decodeRasterFrames } from "../src/media/ffmpeg";
 
 const ffmpeg = Bun.which("ffmpeg");
@@ -91,4 +94,79 @@ describe.skipIf(!ffmpeg)("decodeRasterFrames", () => {
 
 test("missing FFmpeg degrades without throwing", async () => {
 	expect(await decodeRasterFrames(Buffer.from("anything"), { ffmpegPath: "/missing/ffmpeg" })).toBeNull();
+});
+
+test("orders double-digit animated WebP fallback frames numerically", async () => {
+	const directory = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-webp-order-test-"));
+	try {
+		const ffmpegPath = path.join(directory, "ffmpeg");
+		const webpmuxPath = path.join(directory, "webpmux");
+		const animDumpPath = path.join(directory, "anim_dump");
+		await fs.writeFile(
+			ffmpegPath,
+			`#!/usr/bin/env bash
+set -euo pipefail
+if [[ " $* " == *" -vcodec pam "* ]]; then
+	cat
+	exit 0
+fi
+cat >/dev/null
+exit 1
+`,
+			{ mode: 0o755 },
+		);
+		await fs.writeFile(
+			webpmuxPath,
+			`#!/usr/bin/env bash
+cat <<'EOF'
+Canvas size: 1 x 1
+Number of frames: 12
+  1: 1 1 no 0 0 101
+  2: 1 1 no 0 0 102
+  3: 1 1 no 0 0 103
+  4: 1 1 no 0 0 104
+  5: 1 1 no 0 0 105
+  6: 1 1 no 0 0 106
+  7: 1 1 no 0 0 107
+  8: 1 1 no 0 0 108
+  9: 1 1 no 0 0 109
+  10: 1 1 no 0 0 110
+  11: 1 1 no 0 0 111
+  12: 1 1 no 0 0 112
+EOF
+`,
+			{ mode: 0o755 },
+		);
+		await fs.writeFile(
+			animDumpPath,
+			`#!/usr/bin/env bash
+set -euo pipefail
+folder=""
+while (( $# )); do
+	case "$1" in
+		-folder) folder="$2"; shift 2 ;;
+		*) shift ;;
+	esac
+done
+for i in {0..11}; do
+	printf '%s' "$i" >"$folder/frame_$i.pam"
+done
+`,
+			{ mode: 0o755 },
+		);
+
+		const decoded = await decodeRasterFrames(Buffer.from("RIFF0000WEBPANIM"), {
+			ffmpegPath,
+			webpmuxPath,
+			animDumpPath,
+			fpsCap: 60,
+			maxFrames: 12,
+		});
+
+		expect(decoded?.map(frame => frame.data.toString("utf8"))).toEqual(
+			Array.from({ length: 12 }, (_, index) => String(index)),
+		);
+	} finally {
+		await fs.rm(directory, { recursive: true, force: true });
+	}
 });

--- a/packages/coding-agent/test/media-ffmpeg.test.ts
+++ b/packages/coding-agent/test/media-ffmpeg.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { decodeRasterFrames } from "../src/media/ffmpeg";
+
+const ffmpeg = Bun.which("ffmpeg");
+
+function generateVideo(): Buffer {
+	if (!ffmpeg) throw new Error("ffmpeg unavailable");
+	const result = Bun.spawnSync([
+		ffmpeg,
+		"-v",
+		"error",
+		"-f",
+		"lavfi",
+		"-i",
+		"testsrc=size=24x16:rate=6:duration=0.5",
+		"-an",
+		"-c:v",
+		"libx264",
+		"-pix_fmt",
+		"yuv420p",
+		"-movflags",
+		"frag_keyframe+empty_moov",
+		"-f",
+		"mp4",
+		"pipe:1",
+	]);
+	if (result.exitCode !== 0) throw new Error(result.stderr.toString());
+	return Buffer.from(result.stdout);
+}
+
+function generateAnimation(format: "gif" | "webp"): Buffer {
+	if (!ffmpeg) throw new Error("ffmpeg unavailable");
+	const codec = format === "webp" ? ["-c:v", "libwebp_anim", "-loop", "0"] : [];
+	const result = Bun.spawnSync([
+		ffmpeg,
+		"-v",
+		"error",
+		"-f",
+		"lavfi",
+		"-i",
+		"testsrc=size=24x16:rate=6:duration=0.5",
+		"-an",
+		...codec,
+		"-f",
+		format,
+		"pipe:1",
+	]);
+	if (result.exitCode !== 0) throw new Error(result.stderr.toString());
+	return Buffer.from(result.stdout);
+}
+
+describe.skipIf(!ffmpeg)("decodeRasterFrames", () => {
+	test("streams bounded silent PNG frames at the requested FPS cap", async () => {
+		const decoded = await decodeRasterFrames(generateVideo(), {
+			ffmpegPath: ffmpeg!,
+			fpsCap: 4,
+			maxFrames: 10,
+			maxOutputBytes: 2 * 1024 * 1024,
+		});
+
+		expect(decoded).not.toBeNull();
+		expect(decoded!.length).toBeGreaterThan(1);
+		expect(decoded!.length).toBeLessThanOrEqual(10);
+		for (const frame of decoded!) {
+			expect(frame.data.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 13, 10, 26, 10]));
+			expect(frame.durationMs).toBeGreaterThanOrEqual(250);
+		}
+	});
+
+	test("decodes animated GIF and WebP through the same silent frame pipeline", async () => {
+		for (const format of ["gif", "webp"] as const) {
+			const decoded = await decodeRasterFrames(generateAnimation(format), {
+				ffmpegPath: ffmpeg!,
+				fpsCap: 6,
+				maxFrames: 10,
+			});
+			expect(decoded?.length).toBeGreaterThan(1);
+		}
+	});
+
+	test("rejects corrupt media and output that exceeds the streaming bound", async () => {
+		expect(await decodeRasterFrames(Buffer.from("not-media"), { ffmpegPath: ffmpeg! })).toBeNull();
+		expect(
+			await decodeRasterFrames(generateVideo(), {
+				ffmpegPath: ffmpeg!,
+				maxOutputBytes: 32,
+			}),
+		).toBeNull();
+	});
+});
+
+test("missing FFmpeg degrades without throwing", async () => {
+	expect(await decodeRasterFrames(Buffer.from("anything"), { ffmpegPath: "/missing/ffmpeg" })).toBeNull();
+});

--- a/packages/coding-agent/test/media-ingest.test.ts
+++ b/packages/coding-agent/test/media-ingest.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { MediaIngestError, MediaIngestor } from "../src/media/ingest";
+import { isProhibitedMediaAddress } from "../src/media/network";
+import { BlobStore, parseBlobRef } from "../src/session/blob-store";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+async function fixture(): Promise<{ root: string; store: BlobStore }> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-media-"));
+	roots.push(root);
+	return { root, store: new BlobStore(path.join(root, "blobs")) };
+}
+
+function png(width = 2, height = 3): Buffer {
+	const value = Buffer.alloc(24);
+	value.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	value.writeUInt32BE(width, 16);
+	value.writeUInt32BE(height, 20);
+	return value;
+}
+
+describe("MediaIngestor", () => {
+	test("sniffs, content-addresses, and deduplicates local media", async () => {
+		const { root, store } = await fixture();
+		await Bun.write(path.join(root, "not-an-image.bin"), png());
+		const ingestor = new MediaIngestor({ cwd: root, blobStore: store });
+
+		const first = await ingestor.ingest({ source: "not-an-image.bin", alt: "tiny image" });
+		const second = await ingestor.ingest({ source: "not-an-image.bin" });
+
+		expect(first.descriptor.kind).toBe("image");
+		expect(first.descriptor.width).toBe(2);
+		expect(first.descriptor.height).toBe(3);
+		expect(first.descriptor.original?.ref).toBe(second.descriptor.original?.ref);
+		expect(first.descriptor.poster?.ref).toBe(first.descriptor.original?.ref);
+		expect(first.posterData).toBe(png().toString("base64"));
+		const hash = parseBlobRef(first.descriptor.original?.ref ?? "");
+		expect(hash && (await store.has(hash))).toBe(true);
+	});
+
+	test("enforces the configured byte limit before ingestion", async () => {
+		const { root, store } = await fixture();
+		await Bun.write(path.join(root, "oversized.png"), Buffer.concat([png(), Buffer.alloc(20)]));
+		const ingestor = new MediaIngestor({ cwd: root, blobStore: store, maxBytes: 32 });
+		await expect(ingestor.ingest({ source: "oversized.png" })).rejects.toBeInstanceOf(MediaIngestError);
+	});
+
+	test("bounds raster timelines by aggregate bytes", async () => {
+		const { root, store } = await fixture();
+		await Bun.write(path.join(root, "one.png"), png());
+		await Bun.write(path.join(root, "two.png"), png());
+		const ingestor = new MediaIngestor({ cwd: root, blobStore: store, maxBytes: 32 });
+		await expect(
+			ingestor.ingest({
+				frames: [
+					{ source: "one.png", durationMs: 100 },
+					{ source: "two.png", durationMs: 100 },
+				],
+			}),
+		).rejects.toThrow("aggregate");
+	});
+
+	test("creates ordered text timelines with bounded playback defaults", async () => {
+		const { root, store } = await fixture();
+		const ingestor = new MediaIngestor({ cwd: root, blobStore: store });
+		const result = await ingestor.ingest({
+			frames: [
+				{ text: "one", durationMs: 40 },
+				{ text: "two", durationMs: 60 },
+			],
+			loop: true,
+			fpsCap: 120,
+		});
+		expect(result.descriptor.kind).toBe("text-timeline");
+		expect(result.descriptor.durationMs).toBe(100);
+		expect(result.descriptor.timeline).toHaveLength(2);
+		expect(result.descriptor.playback).toEqual({ autoplay: true, loop: true, muted: true, fpsCap: 60 });
+	});
+});
+
+describe("remote media address policy", () => {
+	test("permits public, RFC1918, and IPv6 ULA addresses", () => {
+		for (const address of ["8.8.8.8", "10.1.2.3", "172.16.1.2", "192.168.1.2", "fc00::1", "fd12::1"]) {
+			expect(isProhibitedMediaAddress(address)).toBe(false);
+		}
+	});
+
+	test("rejects loopback, link-local, metadata, multicast, and unspecified addresses", () => {
+		for (const address of [
+			"0.0.0.0",
+			"127.0.0.1",
+			"169.254.169.254",
+			"224.0.0.1",
+			"::",
+			"::1",
+			"fe80::1",
+			"ff02::1",
+		]) {
+			expect(isProhibitedMediaAddress(address)).toBe(true);
+		}
+	});
+});
+
+const ffmpeg = Bun.which("ffmpeg");
+
+function generatedMp4(): Buffer {
+	if (!ffmpeg) throw new Error("ffmpeg unavailable");
+	const result = Bun.spawnSync([
+		ffmpeg,
+		"-v",
+		"error",
+		"-f",
+		"lavfi",
+		"-i",
+		"testsrc=size=24x16:rate=6:duration=0.5",
+		"-an",
+		"-c:v",
+		"libx264",
+		"-pix_fmt",
+		"yuv420p",
+		"-movflags",
+		"frag_keyframe+empty_moov",
+		"-f",
+		"mp4",
+		"pipe:1",
+	]);
+	if (result.exitCode !== 0) throw new Error(result.stderr.toString());
+	return Buffer.from(result.stdout);
+}
+
+describe.skipIf(!ffmpeg)("FFmpeg media ingestion", () => {
+	test("stores bounded decoded video frames as a canonical raster timeline", async () => {
+		const { root, store } = await fixture();
+		await Bun.write(path.join(root, "clip.bin"), generatedMp4());
+		const result = await new MediaIngestor({
+			cwd: root,
+			blobStore: store,
+			ffmpegPath: ffmpeg!,
+			ffprobePath: Bun.which("ffprobe") ?? "ffprobe",
+		}).ingest({ source: "clip.bin", fpsCap: 4 });
+
+		expect(result.descriptor.kind).toBe("video");
+		expect(result.descriptor.timeline?.length).toBeGreaterThan(1);
+		expect(result.descriptor.playback.fpsCap).toBe(4);
+		expect(result.descriptor.poster?.ref).toBe(
+			result.descriptor.timeline?.[0] && "asset" in result.descriptor.timeline[0]
+				? result.descriptor.timeline[0].asset.ref
+				: undefined,
+		);
+		for (const frame of result.descriptor.timeline ?? []) {
+			expect("asset" in frame).toBe(true);
+			if ("asset" in frame) {
+				const hash = parseBlobRef(frame.asset.ref);
+				expect(hash && (await store.has(hash))).toBe(true);
+			}
+		}
+	});
+
+	test("keeps the original and records a static degradation when FFmpeg is missing", async () => {
+		const { root, store } = await fixture();
+		await Bun.write(path.join(root, "clip.mp4"), generatedMp4());
+		const result = await new MediaIngestor({
+			cwd: root,
+			blobStore: store,
+			ffmpegPath: "/missing/ffmpeg",
+			ffprobePath: "/missing/ffprobe",
+		}).ingest({ source: "clip.mp4" });
+
+		expect(result.descriptor.original).toBeDefined();
+		expect(result.descriptor.timeline).toBeUndefined();
+		expect(result.descriptor.degradation).toContain("FFmpeg 6+");
+	});
+});
+
+test("rejects an HTTPS response whose declared MIME disagrees with sniffed content", async () => {
+	const { root, store } = await fixture();
+	const ingestor = new MediaIngestor({
+		cwd: root,
+		blobStore: store,
+		downloadMedia: async source => ({
+			data: png(),
+			contentType: "video/mp4",
+			finalUrl: source,
+		}),
+	});
+	await expect(ingestor.ingest({ source: "https://media.example/chart.png?token=secret" })).rejects.toThrow(
+		"MIME mismatch",
+	);
+});

--- a/packages/coding-agent/test/media-message-component.test.ts
+++ b/packages/coding-agent/test/media-message-component.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Container, TUI } from "@f5-sales-demo/pi-tui";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+import type { MediaMessage } from "../src/media/types";
+import { controlMediaPlayback, MediaMessageComponent } from "../src/modes/components/media-message";
+import { initTheme } from "../src/modes/theme/theme";
+import { BlobStore } from "../src/session/blob-store";
+
+let root: string | undefined;
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+afterEach(async () => {
+	if (root) await fs.rm(root, { recursive: true, force: true });
+	root = undefined;
+});
+
+describe("MediaMessageComponent playback", () => {
+	test("reduced motion stays static until manual play and unmount removes controls", async () => {
+		root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-media-component-"));
+		const terminal = new VirtualTerminal(40, 5);
+		const tui = new TUI(terminal);
+		const message: MediaMessage = {
+			role: "media",
+			timestamp: Date.now(),
+			media: {
+				version: 1,
+				id: "media_0123456789abcdef01234567",
+				kind: "text-timeline",
+				durationMs: 40,
+				timeline: [
+					{ text: "frame-one", durationMs: 20 },
+					{ text: "frame-two", durationMs: 20 },
+				],
+				provenance: { sourceType: "timeline", source: "timeline:test" },
+				playback: { autoplay: true, loop: false, muted: true, fpsCap: 60 },
+			},
+		};
+		const component = new MediaMessageComponent(message, new BlobStore(path.join(root, "blobs")), tui, {
+			autoplay: true,
+			reducedMotion: true,
+			fpsCap: 60,
+		});
+		const container = new Container();
+		container.addChild(component);
+		tui.addChild(container);
+		tui.start();
+		await Bun.sleep(0);
+		await terminal.flush();
+		expect(component.render(40).join("\n")).toContain("frame-one");
+		await Bun.sleep(30);
+		expect(component.render(40).join("\n")).toContain("frame-one");
+
+		expect(controlMediaPlayback("play", "latest")?.state).toBe("playing");
+		await Bun.sleep(45);
+		expect(component.render(40).join("\n")).toContain("frame-two");
+		expect(controlMediaPlayback("stop", message.media.id)?.state).toBe("stopped");
+		expect(component.render(40).join("\n")).toContain("frame-one");
+
+		container.clear();
+		expect(controlMediaPlayback("play", message.media.id)).toBeNull();
+		tui.stop();
+	});
+});

--- a/packages/coding-agent/test/media-network.test.ts
+++ b/packages/coding-agent/test/media-network.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { downloadMediaUrl } from "../src/media/network";
+
+type Reply = {
+	status: number;
+	headers: Record<string, string>;
+	data: Buffer;
+};
+
+describe("downloadMediaUrl redirect security", () => {
+	test("revalidates DNS and pins the selected address on every HTTPS redirect", async () => {
+		const lookups: string[] = [];
+		const requests: Array<{ host: string; address: string }> = [];
+		const replies: Reply[] = [
+			{ status: 302, headers: { location: "https://cdn.example/final.png" }, data: Buffer.alloc(0) },
+			{ status: 200, headers: { "content-type": "image/png" }, data: Buffer.from("png") },
+		];
+		const result = await downloadMediaUrl("https://origin.example/start", {
+			lookup: async host => {
+				lookups.push(host);
+				return [{ address: host === "origin.example" ? "203.0.113.10" : "203.0.113.11", family: 4 }];
+			},
+			request: async (url, address) => {
+				requests.push({ host: url.hostname, address });
+				return replies.shift()!;
+			},
+		});
+
+		expect(lookups).toEqual(["origin.example", "cdn.example"]);
+		expect(requests).toEqual([
+			{ host: "origin.example", address: "203.0.113.10" },
+			{ host: "cdn.example", address: "203.0.113.11" },
+		]);
+		expect(result.finalUrl).toBe("https://cdn.example/final.png");
+	});
+
+	test("rejects credentials, non-HTTPS redirects, DNS rebinding, TLS errors, and total timeout", async () => {
+		await expect(downloadMediaUrl("https://user:secret@example.test/a")).rejects.toThrow("credentials");
+		await expect(
+			downloadMediaUrl("https://example.test/a", {
+				lookup: async () => [{ address: "203.0.113.10", family: 4 }],
+				request: async () => ({
+					status: 302,
+					headers: { location: "http://example.test/plain" },
+					data: Buffer.alloc(0),
+				}),
+			}),
+		).rejects.toThrow("HTTPS");
+
+		let lookupCount = 0;
+		await expect(
+			downloadMediaUrl("https://example.test/a", {
+				lookup: async () => [{ address: ++lookupCount === 1 ? "203.0.113.10" : "127.0.0.1", family: 4 }],
+				request: async () => ({
+					status: 302,
+					headers: { location: "https://example.test/b" },
+					data: Buffer.alloc(0),
+				}),
+			}),
+		).rejects.toThrow("prohibited");
+
+		await expect(
+			downloadMediaUrl("https://example.test/a", {
+				lookup: async () => [{ address: "203.0.113.10", family: 4 }],
+				request: async () => {
+					throw new Error("certificate verify failed");
+				},
+			}),
+		).rejects.toThrow("certificate verify failed");
+
+		await expect(
+			downloadMediaUrl("https://example.test/a", {
+				totalTimeoutMs: 5,
+				lookup: async () => await new Promise(() => {}),
+				request: async () => {
+					throw new Error("request must not run after a DNS timeout");
+				},
+			}),
+		).rejects.toThrow("timed out");
+
+		await expect(
+			downloadMediaUrl("https://example.test/a", {
+				totalTimeoutMs: 5,
+				lookup: async () => [{ address: "203.0.113.10", family: 4 }],
+				request: async (_url, _address, _options, signal) =>
+					await new Promise((_resolve, reject) => {
+						signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+					}),
+			}),
+		).rejects.toThrow("timed out");
+	});
+});

--- a/packages/coding-agent/test/media-schema.test.ts
+++ b/packages/coding-agent/test/media-schema.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	createMediaId,
+	type MediaMessage,
+	sanitizeMediaProvenance,
+	validateMediaDescriptorV1,
+} from "../src/media/types";
+import { convertToLlm } from "../src/session/messages";
+import { SessionManager } from "../src/session/session-manager";
+
+describe("MediaDescriptorV1", () => {
+	test("validates a muted content-addressed image descriptor", () => {
+		const descriptor = validateMediaDescriptorV1({
+			version: 1,
+			id: createMediaId("a".repeat(64)),
+			kind: "image",
+			width: 640,
+			height: 480,
+			alt: "chart",
+			original: { ref: `blob:sha256:${"a".repeat(64)}`, mimeType: "image/png", bytes: 24 },
+			provenance: { sourceType: "path", source: "/tmp/chart.png" },
+			playback: { autoplay: true, loop: false, muted: true, fpsCap: 12 },
+		});
+
+		expect(descriptor.id).toBe(`media_${"a".repeat(24)}`);
+		expect(descriptor.playback.muted).toBe(true);
+	});
+
+	test("rejects non-content-addressed assets and unmuted playback", () => {
+		expect(() =>
+			validateMediaDescriptorV1({
+				version: 1,
+				id: "media_bad",
+				kind: "video",
+				original: { ref: "/tmp/video.mp4", mimeType: "video/mp4", bytes: 10 },
+				provenance: { sourceType: "path", source: "/tmp/video.mp4" },
+				playback: { autoplay: true, loop: false, muted: false, fpsCap: 12 },
+			}),
+		).toThrow();
+	});
+
+	test("sanitizes URL credentials, query strings, and fragments", () => {
+		expect(sanitizeMediaProvenance("https://user:pass@example.com/a.png?token=secret#frag")).toEqual({
+			sourceType: "url",
+			source: "https://example.com/a.png",
+		});
+	});
+});
+
+test("media messages are omitted from LLM conversion", () => {
+	const message: MediaMessage = {
+		role: "media",
+		media: validateMediaDescriptorV1({
+			version: 1,
+			id: createMediaId("b".repeat(64)),
+			kind: "image",
+			original: { ref: `blob:sha256:${"b".repeat(64)}`, mimeType: "image/png", bytes: 24 },
+			provenance: { sourceType: "path", source: "/tmp/b.png" },
+			playback: { autoplay: false, loop: false, muted: true, fpsCap: 12 },
+		}),
+		timestamp: 1,
+	};
+
+	expect(convertToLlm([message])).toEqual([]);
+});
+
+test("media messages and blobs survive a real session reopen", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-media-session-"));
+	try {
+		const manager = SessionManager.create(root, root);
+		const blob = await manager.putBlob(Buffer.from("durable-media"));
+		const message: MediaMessage = {
+			role: "media",
+			timestamp: 42,
+			media: validateMediaDescriptorV1({
+				version: 1,
+				id: createMediaId(blob.hash),
+				kind: "image",
+				original: { ref: blob.ref, mimeType: "image/png", bytes: 13 },
+				provenance: { sourceType: "tool", source: "display_media" },
+				playback: { autoplay: true, loop: false, muted: true, fpsCap: 12 },
+			}),
+		};
+		manager.appendMessage(message);
+		await manager.ensureOnDisk();
+		await manager.flush();
+		const reopened = await SessionManager.open(manager.getSessionFile()!);
+		const restored = reopened.getBranch().find(entry => entry.type === "message" && entry.message.role === "media");
+		expect(restored && restored.type === "message" ? restored.message : undefined).toEqual(message);
+		expect(await reopened.getBlobStore().get(blob.hash)).toEqual(Buffer.from("durable-media"));
+		expect(convertToLlm([message])).toEqual([]);
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});

--- a/packages/coding-agent/test/media-sniff.test.ts
+++ b/packages/coding-agent/test/media-sniff.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { sniffMedia } from "../src/media/sniff";
+
+describe("sniffMedia", () => {
+	test("recognizes PNG and MP4 by content instead of extension", () => {
+		const png = Buffer.alloc(24);
+		png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+		png.writeUInt32BE(320, 16);
+		png.writeUInt32BE(200, 20);
+		expect(sniffMedia(png)).toEqual({ mimeType: "image/png", kind: "image", width: 320, height: 200 });
+
+		const mp4 = Buffer.from([0, 0, 0, 24, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d]);
+		expect(sniffMedia(mp4)).toMatchObject({ mimeType: "video/mp4", kind: "video" });
+	});
+
+	test("recognizes GIF and animated WebP", () => {
+		const gif = Buffer.alloc(10);
+		gif.write("GIF89a", 0, "ascii");
+		gif.writeUInt16LE(40, 6);
+		gif.writeUInt16LE(30, 8);
+		expect(sniffMedia(gif)).toEqual({ mimeType: "image/gif", kind: "animation", width: 40, height: 30 });
+
+		const webp = Buffer.alloc(30);
+		webp.write("RIFF", 0, "ascii");
+		webp.write("WEBP", 8, "ascii");
+		webp.write("VP8X", 12, "ascii");
+		webp[20] = 0x02;
+		webp[24] = 19;
+		webp[27] = 9;
+		expect(sniffMedia(webp)).toEqual({ mimeType: "image/webp", kind: "animation", width: 20, height: 10 });
+	});
+
+	test("rejects unknown input", () => {
+		expect(sniffMedia(Buffer.from("not media"))).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -852,3 +852,28 @@ describe("evaluateToolCall — in-place and output-naming commands (GHSA-q4hg)",
 		expect(bash("wget -O /shared/ctx/x https://example.com").block).toBe(true);
 	});
 });
+
+describe("display_media sandbox paths", () => {
+	it("checks every local raster-frame source while ignoring text frames and remote sources", () => {
+		expect(check("display_media", { source: "images/local.png" }).block).toBe(false);
+		expect(check("display_media", { source: "/work/custB/private.png" }).block).toBe(true);
+		expect(check("display_media", { source: "https://media.example/image.png" }).block).toBe(false);
+		expect(check("display_media", { source: "artifact://tool/output.png" }).block).toBe(false);
+		expect(
+			check("display_media", {
+				frames: [
+					{ source: "frames/one.png", durationMs: 100 },
+					{ source: "/work/custB/private.png", durationMs: 100 },
+				],
+			}).block,
+		).toBe(true);
+		expect(
+			check("display_media", {
+				frames: [
+					{ text: "one", durationMs: 100 },
+					{ text: "two", durationMs: 100 },
+				],
+			}).block,
+		).toBe(false);
+	});
+});

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -15,6 +15,7 @@ export interface ImageOptions {
 	maxWidthCells?: number;
 	maxHeightCells?: number;
 	filename?: string;
+	imageId?: number;
 }
 
 export class Image implements Component {
@@ -60,6 +61,7 @@ export class Image implements Component {
 			const result = renderImage(this.#base64Data, this.#dimensions, {
 				maxWidthCells: maxWidth,
 				maxHeightCells: this.#options.maxHeightCells,
+				imageId: this.#options.imageId,
 			});
 
 			if (result) {

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1,6 +1,6 @@
 import { marked, type Token, type Tokens } from "marked";
 import type { SymbolTheme } from "../symbols";
-import { TERMINAL } from "../terminal-capabilities";
+import { getImageDimensions, imageFallback, renderImage, stableKittyImageId, TERMINAL } from "../terminal-capabilities";
 import type { Component } from "../tui";
 import {
 	applyBackgroundToLine,
@@ -16,6 +16,21 @@ import {
  * Default text styling for markdown content.
  * Applied to all text unless overridden by markdown formatting.
  */
+export interface ResolvedMarkdownMedia {
+	id: string;
+	data: string;
+	mimeType: string;
+	filename?: string;
+}
+
+export type MarkdownMediaResolver = (request: { source: string; alt: string }) => Promise<ResolvedMarkdownMedia>;
+
+export interface MarkdownMediaOptions {
+	resolve: MarkdownMediaResolver;
+	onInvalidate?: () => void;
+}
+
+/** Default text styling for markdown content. */
 export interface DefaultTextStyle {
 	/** Foreground color function */
 	color?: (text: string) => string;
@@ -74,6 +89,16 @@ type ListToken = Token & { items: Array<{ tokens?: Token[] }>; ordered: boolean;
 type TableCellToken = { tokens?: Token[] };
 type TableToken = Token & { header: TableCellToken[]; rows: TableCellToken[][]; raw?: string };
 
+function isImageToken(token: Token): token is Tokens.Image {
+	return (
+		token.type === "image" &&
+		"href" in token &&
+		typeof token.href === "string" &&
+		"text" in token &&
+		typeof token.text === "string"
+	);
+}
+
 function formatHyperlink(text: string, target: string): string {
 	if (!TERMINAL.hyperlinks || !target) {
 		return text;
@@ -96,6 +121,11 @@ export class Markdown implements Component {
 	#defaultStylePrefix?: string;
 	/** Number of spaces used to indent code block content. */
 	#codeBlockIndent: number;
+	#mediaOptions?: MarkdownMediaOptions;
+	#mediaCache = new Map<
+		string,
+		{ status: "pending" } | { status: "loaded"; media: ResolvedMarkdownMedia } | { status: "error"; message: string }
+	>();
 
 	// Cache for rendered output
 	#cachedText?: string;
@@ -109,6 +139,7 @@ export class Markdown implements Component {
 		theme: MarkdownTheme,
 		defaultTextStyle?: DefaultTextStyle,
 		codeBlockIndent: number = 2,
+		mediaOptions?: MarkdownMediaOptions,
 	) {
 		this.#text = text;
 		this.#paddingX = paddingX;
@@ -116,6 +147,7 @@ export class Markdown implements Component {
 		this.#theme = theme;
 		this.#defaultTextStyle = defaultTextStyle;
 		this.#codeBlockIndent = Math.max(0, Math.floor(codeBlockIndent));
+		this.#mediaOptions = mediaOptions;
 	}
 
 	setText(text: string): void {
@@ -326,8 +358,12 @@ export class Markdown implements Component {
 			}
 
 			case "paragraph": {
-				const paragraphText = this.#renderInlineTokens(token.tokens || [], styleContext);
-				lines.push(paragraphText);
+				const paragraphTokens = token.tokens || [];
+				if (this.#mediaOptions && paragraphTokens.some(child => child.type === "image")) {
+					lines.push(...this.#renderParagraphWithMedia(paragraphTokens, width, styleContext));
+				} else {
+					lines.push(this.#renderInlineTokens(paragraphTokens, styleContext));
+				}
 				// Don't add spacing if next token is space or list
 				if (nextTokenType && nextTokenType !== "list" && nextTokenType !== "space") {
 					lines.push("");
@@ -474,6 +510,75 @@ export class Markdown implements Component {
 		}
 
 		return lines;
+	}
+
+	#renderParagraphWithMedia(tokens: Token[], width: number, styleContext?: InlineStyleContext): string[] {
+		const lines: string[] = [];
+		let inline: Token[] = [];
+		const flushInline = (): void => {
+			if (inline.length === 0) return;
+			const rendered = this.#renderInlineTokens(inline, styleContext);
+			lines.push(...rendered.split("\n"));
+			inline = [];
+		};
+		for (const token of tokens) {
+			if (!isImageToken(token)) {
+				inline.push(token);
+				continue;
+			}
+			flushInline();
+			lines.push(...this.#renderMarkdownMedia(token, width));
+		}
+		flushInline();
+		return lines;
+	}
+
+	#renderMarkdownMedia(token: Tokens.Image, width: number): string[] {
+		const source = token.href;
+		let state = this.#mediaCache.get(source);
+		if (!state) {
+			state = { status: "pending" };
+			this.#mediaCache.set(source, state);
+			void this.#mediaOptions
+				?.resolve({ source, alt: token.text })
+				.then(media => {
+					this.#mediaCache.set(source, { status: "loaded", media });
+				})
+				.catch(error => {
+					this.#mediaCache.set(source, {
+						status: "error",
+						message: error instanceof Error ? error.message : String(error),
+					});
+				})
+				.finally(() => {
+					this.invalidate();
+					this.#mediaOptions?.onInvalidate?.();
+				});
+		}
+		if (state.status === "pending") {
+			return [this.#theme.link(`[Loading media: ${token.text || source}]`)];
+		}
+		if (state.status === "error") {
+			return [this.#theme.linkUrl(`[Media unavailable: ${state.message}]`)];
+		}
+		const dimensions = getImageDimensions(state.media.data, state.media.mimeType) ?? undefined;
+		if (dimensions && TERMINAL.imageProtocol) {
+			const rendered = renderImage(state.media.data, dimensions, {
+				maxWidthCells: Math.max(1, width),
+				imageId: stableKittyImageId(state.media.id),
+			});
+			if (rendered) {
+				const result = Array.from({ length: Math.max(0, rendered.rows - 1) }, () => "");
+				const moveUp = rendered.rows > 1 ? `\x1b[${rendered.rows - 1}A` : "";
+				result.push(moveUp + rendered.sequence);
+				return result;
+			}
+		}
+		return [
+			this.#theme.linkUrl(
+				imageFallback(state.media.mimeType, dimensions, state.media.filename ?? token.text ?? undefined),
+			),
+		];
 	}
 
 	#renderInlineTokens(tokens: Token[], styleContext?: InlineStyleContext): string {

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -49,6 +49,8 @@ export {
 export * from "./keybindings";
 // Kitty keyboard protocol helpers
 export * from "./keys";
+// Media playback state machine
+export * from "./media-playback";
 // Mermaid diagram support
 // Input buffering for batch splitting
 export * from "./stdin-buffer";

--- a/packages/tui/src/media-playback.ts
+++ b/packages/tui/src/media-playback.ts
@@ -1,0 +1,100 @@
+export type MediaPlaybackState = "stopped" | "playing" | "paused";
+
+export interface MediaPlaybackOptions {
+	autoplay: boolean;
+	loop: boolean;
+	fpsCap: number;
+	reducedMotion: boolean;
+}
+
+export class MediaPlaybackScheduler {
+	readonly #durations: number[];
+	readonly #options: MediaPlaybackOptions;
+	#state: MediaPlaybackState = "stopped";
+	#frameIndex = 0;
+	#lastTick = 0;
+	#visible = false;
+	#autoplayConsumed = false;
+	#resumeWhenVisible = false;
+
+	constructor(frameDurationsMs: number[], options: MediaPlaybackOptions) {
+		if (frameDurationsMs.length === 0) throw new Error("media playback requires at least one frame");
+		if (!Number.isFinite(options.fpsCap) || options.fpsCap < 1) throw new Error("fpsCap must be positive");
+		const minimumDuration = 1000 / Math.min(60, options.fpsCap);
+		this.#durations = frameDurationsMs.map(duration => Math.max(minimumDuration, duration));
+		this.#options = options;
+	}
+
+	get state(): MediaPlaybackState {
+		return this.#state;
+	}
+
+	get frameIndex(): number {
+		return this.#frameIndex;
+	}
+
+	setVisible(visible: boolean, now: number): void {
+		if (visible === this.#visible) return;
+		this.#visible = visible;
+		if (!visible && this.#state === "playing") {
+			this.#resumeWhenVisible = true;
+			this.pause();
+			return;
+		}
+		if (!visible) return;
+		if (this.#resumeWhenVisible) {
+			this.#resumeWhenVisible = false;
+			this.play(now);
+			return;
+		}
+		if (this.#options.autoplay && !this.#options.reducedMotion && !this.#autoplayConsumed) {
+			this.#autoplayConsumed = true;
+			this.play(now);
+		}
+	}
+
+	play(now: number): void {
+		if (this.#frameIndex >= this.#durations.length) this.#frameIndex = 0;
+		this.#lastTick = now;
+		this.#state = "playing";
+	}
+
+	pause(): void {
+		if (this.#state === "playing") this.#state = "paused";
+	}
+
+	stop(): void {
+		this.#state = "stopped";
+		this.#frameIndex = 0;
+		this.#resumeWhenVisible = false;
+		this.#autoplayConsumed = true;
+	}
+
+	tick(now: number): number {
+		if (this.#state !== "playing") return this.#frameIndex;
+		let elapsed = Math.max(0, now - this.#lastTick);
+		while (elapsed >= (this.#durations[this.#frameIndex] ?? Number.POSITIVE_INFINITY)) {
+			const duration = this.#durations[this.#frameIndex] ?? Number.POSITIVE_INFINITY;
+			elapsed -= duration;
+			if (this.#frameIndex + 1 < this.#durations.length) {
+				this.#frameIndex++;
+				this.#lastTick = now - elapsed;
+				continue;
+			}
+			if (this.#options.loop) {
+				this.#frameIndex = 0;
+				this.#lastTick = now - elapsed;
+				continue;
+			}
+			this.#state = "stopped";
+			this.#frameIndex = this.#durations.length - 1;
+			break;
+		}
+		return this.#frameIndex;
+	}
+
+	dispose(): void {
+		this.#state = "stopped";
+		this.#resumeWhenVisible = false;
+	}
+}

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -218,6 +218,7 @@ export interface ImageRenderOptions {
 	maxWidthCells?: number;
 	maxHeightCells?: number;
 	preserveAspectRatio?: boolean;
+	imageId?: number;
 }
 
 // Default cell dimensions - updated by TUI when terminal responds to query
@@ -229,6 +230,21 @@ export function getCellDimensions(): CellDimensions {
 
 export function setCellDimensions(dims: CellDimensions): void {
 	cellDimensions = dims;
+}
+
+/** Derive a deterministic Kitty image/placement id from a durable media id. */
+export function stableKittyImageId(mediaId: string): number {
+	let hash = 0x811c9dc5;
+	for (let index = 0; index < mediaId.length; index++) {
+		hash ^= mediaId.charCodeAt(index);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return ((hash >>> 0) % 2_147_483_646) + 1;
+}
+
+/** Delete a Kitty image and all placements that use its stable id. */
+export function deleteKittyImage(imageId: number): string {
+	return `\x1b_Ga=d,d=I,i=${imageId},q=2;\x1b\\`;
 }
 
 export function encodeKitty(
@@ -497,6 +513,7 @@ export function renderImage(
 		const sequence = encodeKitty(base64Data, {
 			columns: fit.columns,
 			rows: fit.rows,
+			imageId: options.imageId,
 		});
 		return { sequence, rows: fit.rows };
 	}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -41,6 +41,9 @@ export interface Component {
 	 * Called when theme changes or when component needs to re-render from scratch.
 	 */
 	invalidate(): void;
+
+	/** Release timers, subprocesses, and terminal placements when removed from a container. */
+	unmount?(): void;
 }
 
 /**
@@ -183,10 +186,12 @@ export class Container implements Component {
 		const index = this.children.indexOf(component);
 		if (index !== -1) {
 			this.children.splice(index, 1);
+			component.unmount?.();
 		}
 	}
 
 	clear(): void {
+		for (const child of this.children) child.unmount?.();
 		this.children = [];
 	}
 
@@ -239,6 +244,8 @@ export class TUI extends Container {
 	#maxLinesRendered = 0; // High-water line count used for clear-on-shrink policy
 	#fullRedrawCount = 0;
 	#stopped = false;
+	#viewportObservers = new Map<number, { callback: (visible: boolean) => void; visible: boolean }>();
+	#nextViewportObserverId = 1;
 
 	// Overlay stack for modal components rendered on top of base content
 	overlayStack: {
@@ -258,6 +265,43 @@ export class TUI extends Container {
 
 	get fullRedraws(): number {
 		return this.#fullRedrawCount;
+	}
+
+	registerViewportObserver(callback: (visible: boolean) => void): { marker: string; dispose: () => void } {
+		const id = this.#nextViewportObserverId++;
+		this.#viewportObservers.set(id, { callback, visible: false });
+		return {
+			marker: `\x1b_pi:v=${id}\x07`,
+			dispose: () => {
+				const observer = this.#viewportObservers.get(id);
+				if (observer?.visible) observer.callback(false);
+				this.#viewportObservers.delete(id);
+			},
+		};
+	}
+
+	#updateViewportObservers(lines: string[], height: number): void {
+		if (this.#viewportObservers.size === 0) return;
+		const visibleIds = new Set<number>();
+		const viewportTop = Math.max(0, lines.length - height);
+		const marker = /\x1b_pi:v=(\d+)\x07/gu;
+		for (let index = 0; index < lines.length; index++) {
+			lines[index] = lines[index].replace(marker, (_sequence, rawId: string) => {
+				const id = Number(rawId);
+				if (index >= viewportTop && this.#viewportObservers.has(id)) visibleIds.add(id);
+				return "";
+			});
+		}
+		for (const [id, observer] of this.#viewportObservers) {
+			const visible = visibleIds.has(id);
+			if (visible === observer.visible) continue;
+			observer.visible = visible;
+			try {
+				observer.callback(visible);
+			} catch {
+				// Viewport observers must not break terminal rendering.
+			}
+		}
 	}
 
 	getShowHardwareCursor(): boolean {
@@ -1022,6 +1066,7 @@ export class TUI extends Container {
 
 		// Render all components to get new lines
 		let newLines = this.render(width);
+		this.#updateViewportObservers(newLines, height);
 
 		// Clamp any oversized lines before dirty-checking so the truncated form
 		// matches what we store in #previousLines, preventing perpetual repaints.

--- a/packages/tui/test/markdown-media.test.ts
+++ b/packages/tui/test/markdown-media.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+import { Markdown, type MarkdownMediaResolver } from "../src/components/markdown";
+import { defaultMarkdownTheme } from "./test-themes";
+
+function png(width = 3, height = 2): string {
+	const value = Buffer.alloc(24);
+	value.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	value.writeUInt32BE(width, 16);
+	value.writeUInt32BE(height, 20);
+	return value.toString("base64");
+}
+
+test("Markdown resolves image nodes asynchronously and preserves their position", async () => {
+	let resolveRefresh: (() => void) | undefined;
+	const refreshed = new Promise<void>(resolve => {
+		resolveRefresh = resolve;
+	});
+	const calls: string[] = [];
+	const resolver: MarkdownMediaResolver = async request => {
+		calls.push(request.source);
+		await Promise.resolve();
+		return { id: "media_aaaaaaaaaaaaaaaaaaaaaaaa", data: png(), mimeType: "image/png", filename: request.alt };
+	};
+	const markdown = new Markdown(
+		"before\n\n![diagram](artifact://7)\n\nafter",
+		0,
+		0,
+		defaultMarkdownTheme,
+		undefined,
+		2,
+		{ resolve: resolver, onInvalidate: () => resolveRefresh?.() },
+	);
+
+	expect(markdown.render(80).join("\n")).toContain("Loading media: diagram");
+	await refreshed;
+	const rendered = markdown.render(80).join("\n");
+	expect(rendered.indexOf("before")).toBeLessThan(rendered.indexOf("[Image: diagram [image/png] 3x2]"));
+	expect(rendered.indexOf("[Image: diagram [image/png] 3x2]")).toBeLessThan(rendered.indexOf("after"));
+	expect(calls).toEqual(["artifact://7"]);
+	expect(markdown.render(80).join("\n")).toContain("[Image: diagram [image/png] 3x2]");
+	expect(calls).toHaveLength(1);
+});
+
+test("Markdown reports resolver failures without retrying each render", async () => {
+	let refresh: (() => void) | undefined;
+	const refreshed = new Promise<void>(resolve => {
+		refresh = resolve;
+	});
+	let calls = 0;
+	const markdown = new Markdown("![bad](https://example.com/bad)", 0, 0, defaultMarkdownTheme, undefined, 2, {
+		resolve: async () => {
+			calls++;
+			throw new Error("MIME mismatch");
+		},
+		onInvalidate: () => refresh?.(),
+	});
+	markdown.render(80);
+	await refreshed;
+	expect(markdown.render(80).join("\n")).toContain("Media unavailable: MIME mismatch");
+	markdown.render(80);
+	expect(calls).toBe(1);
+});

--- a/packages/tui/test/media-playback.test.ts
+++ b/packages/tui/test/media-playback.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { MediaPlaybackScheduler } from "../src/media-playback";
+import { encodeKitty, stableKittyImageId } from "../src/terminal-capabilities";
+
+describe("MediaPlaybackScheduler", () => {
+	test("autoplays once when visible, pauses off-screen, and resumes", () => {
+		const scheduler = new MediaPlaybackScheduler([50, 50, 50], {
+			autoplay: true,
+			loop: false,
+			fpsCap: 12,
+			reducedMotion: false,
+		});
+
+		expect(scheduler.state).toBe("stopped");
+		scheduler.setVisible(true, 0);
+		expect(scheduler.state).toBe("playing");
+		expect(scheduler.tick(84)).toBe(1);
+		scheduler.setVisible(false, 90);
+		expect(scheduler.state).toBe("paused");
+		scheduler.setVisible(true, 200);
+		expect(scheduler.state).toBe("playing");
+		expect(scheduler.tick(285)).toBe(2);
+		expect(scheduler.tick(370)).toBe(2);
+		expect(scheduler.state).toBe("stopped");
+
+		scheduler.setVisible(false, 400);
+		scheduler.setVisible(true, 500);
+		expect(scheduler.state).toBe("stopped");
+	});
+
+	test("reduced motion disables autoplay and fps cap enforces a minimum frame duration", () => {
+		const scheduler = new MediaPlaybackScheduler([1, 1], {
+			autoplay: true,
+			loop: true,
+			fpsCap: 10,
+			reducedMotion: true,
+		});
+		scheduler.setVisible(true, 0);
+		expect(scheduler.state).toBe("stopped");
+		scheduler.play(0);
+		expect(scheduler.tick(99)).toBe(0);
+		expect(scheduler.tick(100)).toBe(1);
+	});
+});
+
+test("Kitty media uses a stable positive image ID and transmit/replace action", () => {
+	const first = stableKittyImageId("media_abc");
+	const second = stableKittyImageId("media_abc");
+	expect(first).toBe(second);
+	expect(first).toBeGreaterThan(0);
+	expect(encodeKitty("YWJj", { imageId: first })).toContain(`a=T,f=100,q=2,i=${first}`);
+});

--- a/packages/tui/test/viewport-observer.test.ts
+++ b/packages/tui/test/viewport-observer.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { type Component, Container, TUI } from "../src/tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+class Lines implements Component {
+	constructor(private readonly lines: string[]) {}
+	render(): string[] {
+		return this.lines;
+	}
+	invalidate(): void {}
+}
+
+describe("TUI viewport observers", () => {
+	test("reports marked media lines entering and leaving the visible viewport", async () => {
+		const terminal = new VirtualTerminal(40, 2);
+		const tui = new TUI(terminal);
+		const states: boolean[] = [];
+		const observer = tui.registerViewportObserver(visible => states.push(visible));
+		tui.addChild(new Lines(["above", `${observer.marker}media`]));
+		tui.start();
+		await Bun.sleep(0);
+		await terminal.flush();
+		expect(states.at(-1)).toBe(true);
+
+		tui.addChild(new Lines(["below-1", "below-2", "below-3"]));
+		tui.requestRender();
+		await Bun.sleep(0);
+		await terminal.flush();
+		expect(states.at(-1)).toBe(false);
+		observer.dispose();
+		tui.stop();
+	});
+
+	test("unmounts child resources when containers clear", () => {
+		const container = new Container();
+		let unmounted = false;
+		container.addChild({
+			render: () => [],
+			invalidate: () => {},
+			unmount: () => {
+				unmounted = true;
+			},
+		});
+		container.clear();
+		expect(unmounted).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- add durable `MediaDescriptorV1` and media messages backed by the SHA-256 blob store
- add secure local, artifact, HTTPS, text-frame, and raster-frame ingestion plus `display_media`
- add bounded silent FFmpeg/WebP decoding, async Markdown recovery, and Kitty/TUI playback controls
- preserve numeric frame order in the animated WebP demux fallback

## Validation

- 34 focused media and TUI tests pass
- full workspace TypeScript/Biome checks pass
- full coding-agent suite: 6,547 pass, 559 skip, 7 inherited sandbox/backend environment failures
- Ghostty-through-Herdr Kitty acceptance verified stable image ID, changing frame fingerprints, and intact transcript
- two independent Direct Remote AGY reports approve with zero findings

Closes #3183
