### PR TITLE
feat(herdr): bind conversations to owned terminal workspaces

### DIFF
--- a/docs/en/configuration/herdr.md
+++ b/docs/en/configuration/herdr.md
@@ -1,0 +1,22 @@
+---
+title: Herdr terminals
+description: Run xcsh conversations with isolated, conversation-owned support terminals.
+---
+
+# Herdr terminals
+
+xcsh can bind one conversation to one Herdr workspace and expose named support terminals as tabs. The recommended full rich-media stack is Ghostty with Kitty graphics, Herdr with `experimental.kitty_graphics=true`, and FFmpeg 6 or newer. Other terminals remain usable and receive static media fallbacks.
+
+Launch a conversation-owned workspace from outside Herdr:
+
+```bash
+xcsh herdr --session my-organization --label project-task -- --model openai/gpt-5
+```
+
+The launcher creates the workspace, writes a mode-`0600` `HerdrBindingV1` under the user state directory, starts xcsh in the root pane, and attaches to the named Herdr session. Plain `xcsh` remains fully supported; terminal-management operations report unavailable without both a launcher-issued owner binding and `HERDR_SOCKET_PATH`.
+
+Inside the conversation, humans use `/terminal` and the model uses `herdr_terminal`. Both surfaces provide `list`, `create`, `run`, `send`, `read`, `wait`, `status`, `focus`, and `close` actions. Creation is always non-focusing. Focus is an explicit action. A busy terminal rejects the first close and requires a second close with `force: true` (or `/terminal close NAME --force`).
+
+Ownership is enforced by a random `xcsh_owner` metadata token on the workspace and each managed pane. xcsh lists, reads, sends to, focuses, and closes only panes carrying the current binding token. Tabs from other conversations or users are not exposed. Session creation, resume, switching, branching, and tree navigation keep the workspace and tabs while refreshing the stored xcsh session reference.
+
+The socket client uses Herdr protocol 18 over newline-delimited JSON on `HERDR_SOCKET_PATH`. Each request reconnects independently, validates the `ping` protocol version, caps responses at 4 MiB, and uses bounded timeouts so a Herdr restart cannot wedge the chat process.

--- a/docs/en/configuration/herdr.md
+++ b/docs/en/configuration/herdr.md
@@ -3,8 +3,6 @@ title: Herdr terminals
 description: Run xcsh conversations with isolated, conversation-owned support terminals.
 ---
 
-# Herdr terminals
-
 xcsh can bind one conversation to one Herdr workspace and expose named support terminals as tabs. The recommended full rich-media stack is Ghostty with Kitty graphics, Herdr with `experimental.kitty_graphics=true`, and FFmpeg 6 or newer. Other terminals remain usable and receive static media fallbacks.
 
 Launch a conversation-owned workspace from outside Herdr:

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -63,6 +63,7 @@ const commands: CommandEntry[] = [
 	{ name: "chrome", load: () => import("./commands/chrome").then(m => m.default) },
 	{ name: "chrome-host", load: () => import("./commands/native-host").then(m => m.default) },
 	{ name: "grep", load: () => import("./commands/grep").then(m => m.default) },
+	{ name: "herdr", load: () => import("./commands/herdr").then(m => m.default) },
 	{ name: "grievances", load: () => import("./commands/grievances").then(m => m.default) },
 	{ name: "read", load: () => import("./commands/read").then(m => m.default) },
 	{

--- a/packages/coding-agent/src/commands/herdr.ts
+++ b/packages/coding-agent/src/commands/herdr.ts
@@ -1,0 +1,122 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Args, Command, Flags } from "@f5-sales-demo/pi-utils/cli";
+import type { HerdrBindingV1 } from "../herdr/controller";
+
+interface CommandResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+}
+
+async function execute(command: string[], inherit = false): Promise<CommandResult> {
+	const child = Bun.spawn({
+		cmd: command,
+		stdin: inherit ? "inherit" : "ignore",
+		stdout: inherit ? "inherit" : "pipe",
+		stderr: inherit ? "inherit" : "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		inherit ? Promise.resolve("") : new Response(child.stdout).text(),
+		inherit ? Promise.resolve("") : new Response(child.stderr).text(),
+		child.exited,
+	]);
+	if (exitCode !== 0) throw new Error(stderr.trim() || `${command[0]} exited with ${exitCode}`);
+	return { stdout, stderr, exitCode };
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function buildXcshCommand(executable: string, args: string[]): string {
+	return [executable, ...args].map(shellQuote).join(" ");
+}
+
+export default class Herdr extends Command {
+	static description = "Launch xcsh in a conversation-owned Herdr workspace";
+	static strict = false;
+	static flags = {
+		session: Flags.string({ required: true, description: "Herdr named session" }),
+		label: Flags.string({ description: "Workspace label" }),
+	};
+	static args = {
+		xcshArgs: Args.string({ required: false, multiple: true, description: "Arguments passed to xcsh after --" }),
+	};
+
+	async run(): Promise<void> {
+		if (process.env.HERDR_ENV === "1") throw new Error("xcsh herdr must be launched outside an existing Herdr pane");
+		const { flags, args } = await this.parse(Herdr);
+		const session = flags.session;
+		if (!session) throw new Error("--session is required");
+		const ownerToken = randomUUID();
+		const stateRoot = process.env.XDG_STATE_HOME ?? path.join(os.homedir(), ".local", "state");
+		const bindingDir = path.join(stateRoot, "xcsh", "herdr");
+		await fs.mkdir(bindingDir, { recursive: true, mode: 0o700 });
+		const bindingPath = path.join(bindingDir, `${session}-${ownerToken}.json`);
+		const label = flags.label ?? `xcsh-${new Date().toISOString().replace(/[-:.]/g, "").slice(0, 15).toLowerCase()}`;
+		const created = await execute([
+			"herdr",
+			"--session",
+			session,
+			"workspace",
+			"create",
+			"--cwd",
+			process.cwd(),
+			"--label",
+			label,
+			"--env",
+			`XCSH_HERDR_OWNER=${ownerToken}`,
+			"--env",
+			`XCSH_HERDR_BINDING_PATH=${bindingPath}`,
+			"--focus",
+		]);
+		const response = JSON.parse(created.stdout) as {
+			result?: { workspace?: { workspace_id?: string }; root_pane?: { pane_id?: string } };
+		};
+		const workspaceId = response.result?.workspace?.workspace_id;
+		const rootPaneId = response.result?.root_pane?.pane_id;
+		if (!workspaceId || !rootPaneId) throw new Error("Herdr returned an invalid workspace creation response");
+		const binding: HerdrBindingV1 = {
+			version: 1,
+			sessionName: session,
+			workspaceId,
+			rootPaneId,
+			ownerToken,
+			terminals: [],
+		};
+		await fs.writeFile(bindingPath, `${JSON.stringify(binding, null, 2)}\n`, { mode: 0o600 });
+		await execute([
+			"herdr",
+			"--session",
+			session,
+			"workspace",
+			"report-metadata",
+			workspaceId,
+			"--source",
+			"xcsh:terminal",
+			"--token",
+			`xcsh_owner=${ownerToken}`,
+		]);
+		await execute([
+			"herdr",
+			"--session",
+			session,
+			"pane",
+			"report-metadata",
+			rootPaneId,
+			"--source",
+			"xcsh:terminal",
+			"--token",
+			`xcsh_owner=${ownerToken}`,
+		]);
+		const forwarded = Array.isArray(args.xcshArgs) ? args.xcshArgs : [];
+		const xcshCommand = buildXcshCommand(process.env.XCSH_BIN ?? "xcsh", forwarded);
+		await execute(["herdr", "--session", session, "pane", "run", rootPaneId, xcshCommand]);
+		await execute(["herdr", "session", "attach", session], true);
+	}
+}
+
+export { buildXcshCommand, shellQuote };

--- a/packages/coding-agent/src/extensibility/extensions/bundled/herdr-terminal.ts
+++ b/packages/coding-agent/src/extensibility/extensions/bundled/herdr-terminal.ts
@@ -16,6 +16,17 @@ interface TerminalParams {
 	force?: boolean;
 }
 
+export function createRetryingLazy<T>(factory: () => Promise<T>): () => Promise<T> {
+	let pending: Promise<T> | undefined;
+	return () => {
+		pending ??= factory().catch(error => {
+			pending = undefined;
+			throw error;
+		});
+		return pending;
+	};
+}
+
 function sessionRef(ctx: ExtensionContext): string | undefined {
 	return ctx.sessionManager.getSessionFile?.() ?? ctx.sessionManager.getSessionId?.();
 }
@@ -49,8 +60,7 @@ async function dispatch(controller: HerdrController, params: TerminalParams): Pr
 
 export default function herdrTerminal(pi: ExtensionAPI): void {
 	const { Type } = pi.typebox;
-	let controllerPromise: Promise<HerdrController> | undefined;
-	const controller = (): Promise<HerdrController> => (controllerPromise ??= HerdrController.connect());
+	const controller = createRetryingLazy(() => HerdrController.connect());
 
 	pi.registerTool({
 		name: "herdr_terminal",

--- a/packages/coding-agent/src/extensibility/extensions/bundled/herdr-terminal.ts
+++ b/packages/coding-agent/src/extensibility/extensions/bundled/herdr-terminal.ts
@@ -1,0 +1,125 @@
+import type { ExtensionAPI, ExtensionContext } from "@f5-sales-demo/xcsh";
+import { HerdrController } from "../../../herdr/controller";
+
+type Action = "list" | "create" | "run" | "send" | "read" | "wait" | "status" | "focus" | "close";
+interface TerminalParams {
+	action: Action;
+	target?: string;
+	name?: string;
+	cwd?: string;
+	command?: string;
+	text?: string;
+	match?: string;
+	lines?: number;
+	timeoutMs?: number;
+	enter?: boolean;
+	force?: boolean;
+}
+
+function sessionRef(ctx: ExtensionContext): string | undefined {
+	return ctx.sessionManager.getSessionFile?.() ?? ctx.sessionManager.getSessionId?.();
+}
+
+async function dispatch(controller: HerdrController, params: TerminalParams): Promise<unknown> {
+	switch (params.action) {
+		case "list":
+			return controller.list();
+		case "create":
+			return controller.create(params.name ?? "", params.cwd);
+		case "run":
+			await controller.run(params.target ?? "", params.command ?? "");
+			return { ok: true };
+		case "send":
+			await controller.send(params.target ?? "", params.text ?? "", params.enter);
+			return { ok: true };
+		case "read":
+			return controller.read(params.target ?? "", params.lines);
+		case "wait":
+			return controller.wait(params.target ?? "", params.match ?? "", params.timeoutMs);
+		case "status":
+			return controller.status(params.target ?? "");
+		case "focus":
+			await controller.focus(params.target ?? "");
+			return { ok: true };
+		case "close":
+			await controller.close(params.target ?? "", params.force);
+			return { ok: true };
+	}
+}
+
+export default function herdrTerminal(pi: ExtensionAPI): void {
+	const { Type } = pi.typebox;
+	let controllerPromise: Promise<HerdrController> | undefined;
+	const controller = (): Promise<HerdrController> => (controllerPromise ??= HerdrController.connect());
+
+	pi.registerTool({
+		name: "herdr_terminal",
+		label: "Herdr Terminal",
+		description:
+			"Manage support terminals owned by the current xcsh conversation. Actions: list, create, run, send, read, wait, status, focus, close. Focus and forced close must be explicit.",
+		parameters: Type.Object({
+			action: Type.Union(
+				["list", "create", "run", "send", "read", "wait", "status", "focus", "close"].map(value =>
+					Type.Literal(value),
+				),
+			),
+			target: Type.Optional(Type.String({ description: "Terminal name or owned pane ID" })),
+			name: Type.Optional(Type.String({ description: "Name for a newly created terminal" })),
+			cwd: Type.Optional(Type.String({ description: "Working directory for a newly created terminal" })),
+			command: Type.Optional(Type.String({ description: "Command for run" })),
+			text: Type.Optional(Type.String({ description: "Text for send" })),
+			match: Type.Optional(Type.String({ description: "Literal output awaited by wait" })),
+			lines: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+			timeoutMs: Type.Optional(Type.Integer({ minimum: 0, maximum: 300000 })),
+			enter: Type.Optional(Type.Boolean()),
+			force: Type.Optional(Type.Boolean({ description: "Required on the second close call for a busy pane" })),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			try {
+				const active = await controller();
+				await active.updateSessionRef(sessionRef(ctx));
+				const result = await dispatch(active, params as TerminalParams);
+				return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }], details: result };
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return { content: [{ type: "text", text: message }], details: { error: message }, isError: true };
+			}
+		},
+	});
+
+	pi.registerCommand("terminal", {
+		description: "Manage Herdr terminals: /terminal <list|create|run|send|read|wait|status|focus|close>",
+		handler: async (args, ctx) => {
+			const [action = "list", target, ...rest] = args.trim().split(/\s+/).filter(Boolean);
+			const params: TerminalParams = { action: action as Action, target };
+			if (action === "create") params.name = target;
+			if (action === "run") params.command = rest.join(" ");
+			if (action === "send") params.text = rest.join(" ");
+			if (action === "wait") params.match = rest.join(" ");
+			if (action === "read" && rest[0]) params.lines = Number(rest[0]);
+			if (action === "close") params.force = rest.includes("--force");
+			try {
+				const active = await controller();
+				await active.updateSessionRef(sessionRef(ctx));
+				ctx.ui.notify(JSON.stringify(await dispatch(active, params), null, 2), "info");
+			} catch (error) {
+				ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+			}
+		},
+	});
+
+	const update = async (_event: unknown, ctx: ExtensionContext): Promise<void> => {
+		if (!process.env.HERDR_SOCKET_PATH) return;
+		try {
+			await (await controller()).updateSessionRef(sessionRef(ctx));
+		} catch (error) {
+			pi.logger.debug("Herdr terminal binding update failed", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	};
+	pi.on("session_start", update);
+	pi.on("session_switch", update);
+	pi.on("session_branch", update);
+	pi.on("session_tree", update);
+}

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -20,6 +20,7 @@ import { EventBus } from "../../utils/event-bus";
 import { getAllPluginExtensionPaths } from "../plugins/loader";
 import { resolvePath } from "../utils";
 import herdrReporter from "./bundled/herdr-reporter";
+import herdrTerminal from "./bundled/herdr-terminal";
 import sandboxGuard from "./bundled/sandbox-guard";
 import type {
 	Extension,
@@ -501,6 +502,7 @@ async function discoverExtensionsInDir(dir: string): Promise<string[]> {
 /** Extensions bundled with xcsh and loaded by default (before user extensions). */
 const BUNDLED_EXTENSIONS: ReadonlyArray<{ name: string; factory: ExtensionFactory }> = [
 	{ name: "herdr-reporter", factory: herdrReporter },
+	{ name: "herdr-terminal", factory: herdrTerminal },
 	{ name: "sandbox-guard", factory: sandboxGuard },
 ];
 

--- a/packages/coding-agent/src/herdr/client.ts
+++ b/packages/coding-agent/src/herdr/client.ts
@@ -1,0 +1,127 @@
+import { randomUUID } from "node:crypto";
+import { connect } from "node:net";
+
+export const HERDR_PROTOCOL_VERSION = 18;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+
+export class HerdrProtocolError extends Error {
+	constructor(
+		message: string,
+		readonly code = "protocol_error",
+	) {
+		super(message);
+		this.name = "HerdrProtocolError";
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Typed, one-request-per-connection client for Herdr's protocol-18 JSONL socket. */
+export class HerdrClient {
+	private protocolChecked = false;
+
+	constructor(
+		readonly socketPath: string,
+		readonly timeoutMs = DEFAULT_TIMEOUT_MS,
+	) {
+		if (!socketPath) throw new HerdrProtocolError("HERDR_SOCKET_PATH is unavailable", "unavailable");
+	}
+
+	async ensureProtocol(): Promise<void> {
+		if (this.protocolChecked) return;
+		const pong = await this.requestRaw<{ type: string; protocol: number; version: string }>("ping", {});
+		if (pong.type !== "pong" || pong.protocol !== HERDR_PROTOCOL_VERSION) {
+			throw new HerdrProtocolError(
+				`Herdr protocol mismatch: expected ${HERDR_PROTOCOL_VERSION}, received ${String(pong.protocol)}`,
+				"protocol_mismatch",
+			);
+		}
+		this.protocolChecked = true;
+	}
+
+	async request<T extends Record<string, unknown>>(method: string, params: Record<string, unknown>): Promise<T> {
+		await this.ensureProtocol();
+		return this.requestRaw<T>(method, params);
+	}
+
+	private requestRaw<T>(method: string, params: Record<string, unknown>): Promise<T> {
+		const id = `xcsh:${randomUUID()}`;
+		return new Promise<T>((resolve, reject) => {
+			let buffer = "";
+			let settled = false;
+			const socket = connect({ path: this.socketPath });
+			const finish = (error?: unknown, value?: T): void => {
+				if (settled) return;
+				settled = true;
+				socket.destroy();
+				if (error !== undefined) reject(error);
+				else resolve(value as T);
+			};
+			socket.setEncoding("utf8");
+			socket.setTimeout(this.timeoutMs, () => finish(new HerdrProtocolError("Herdr request timed out", "timeout")));
+			socket.once("error", error => finish(new HerdrProtocolError(error.message, "transport_error")));
+			socket.once("connect", () => socket.write(`${JSON.stringify({ id, method, params })}\n`));
+			socket.on("data", chunk => {
+				buffer += chunk;
+				if (Buffer.byteLength(buffer) > MAX_RESPONSE_BYTES) {
+					finish(new HerdrProtocolError("Herdr response exceeded 4 MiB", "response_too_large"));
+					return;
+				}
+				for (;;) {
+					const newline = buffer.indexOf("\n");
+					if (newline < 0) break;
+					const line = buffer.slice(0, newline);
+					buffer = buffer.slice(newline + 1);
+					if (!line.trim()) continue;
+					let decoded: unknown;
+					try {
+						decoded = JSON.parse(line);
+					} catch {
+						finish(new HerdrProtocolError("Herdr returned invalid JSON", "invalid_json"));
+						return;
+					}
+					if (!isRecord(decoded) || decoded.id !== id) continue;
+					if (isRecord(decoded.error)) {
+						finish(
+							new HerdrProtocolError(
+								typeof decoded.error.message === "string" ? decoded.error.message : "Herdr request failed",
+								typeof decoded.error.code === "string" ? decoded.error.code : "remote_error",
+							),
+						);
+						return;
+					}
+					if (!("result" in decoded) || !isRecord(decoded.result)) {
+						finish(new HerdrProtocolError("Herdr response is missing a typed result"));
+						return;
+					}
+					finish(undefined, decoded.result as T);
+					return;
+				}
+			});
+			socket.once("end", () => {
+				if (settled) return;
+				// Protocol 18 permits the final response to be terminated by EOF. The
+				// server normally emits JSONL, but older/current transports may omit the
+				// trailing newline when they close a one-shot connection.
+				try {
+					const decoded = JSON.parse(buffer) as Record<string, unknown>;
+					if (decoded.id !== id) throw new Error("response id mismatch");
+					if (isRecord(decoded.error)) {
+						finish(
+							new HerdrProtocolError(
+								typeof decoded.error.message === "string" ? decoded.error.message : "Herdr request failed",
+								typeof decoded.error.code === "string" ? decoded.error.code : "remote_error",
+							),
+						);
+					} else if (isRecord(decoded.result)) finish(undefined, decoded.result as T);
+					else finish(new HerdrProtocolError("Herdr response is missing a typed result"));
+				} catch {
+					finish(new HerdrProtocolError("Herdr closed the socket before responding", "eof"));
+				}
+			});
+		});
+	}
+}

--- a/packages/coding-agent/src/herdr/controller.ts
+++ b/packages/coding-agent/src/herdr/controller.ts
@@ -1,0 +1,275 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { HerdrClient, HerdrProtocolError } from "./client";
+
+export const HERDR_OWNER_TOKEN = "xcsh_owner";
+const HERDR_SOURCE = "xcsh:terminal";
+
+export interface HerdrTerminalRecordV1 {
+	name: string;
+	tabId: string;
+	paneId: string;
+	createdAt: string;
+}
+
+export interface HerdrBindingV1 {
+	version: 1;
+	sessionName: string;
+	workspaceId: string;
+	rootPaneId: string;
+	ownerToken: string;
+	activeSessionRef?: string;
+	terminals: HerdrTerminalRecordV1[];
+}
+
+interface PaneInfo extends Record<string, unknown> {
+	pane_id: string;
+	tab_id: string;
+	workspace_id: string;
+	tokens?: Record<string, string>;
+	focused?: boolean;
+}
+
+interface TabCreated extends Record<string, unknown> {
+	type: "tab_created";
+	tab: { tab_id: string; workspace_id: string; label?: string };
+	root_pane: PaneInfo;
+}
+
+function bindingFromEnvironment(): HerdrBindingV1 | undefined {
+	const sessionName = process.env.HERDR_SESSION;
+	const workspaceId = process.env.HERDR_WORKSPACE_ID;
+	const rootPaneId = process.env.HERDR_PANE_ID;
+	const ownerToken = process.env.XCSH_HERDR_OWNER;
+	if (!sessionName || !workspaceId || !rootPaneId || !ownerToken) return undefined;
+	return {
+		version: 1,
+		sessionName,
+		workspaceId,
+		rootPaneId,
+		ownerToken,
+		terminals: [],
+	};
+}
+
+export class HerdrController {
+	private readonly lastInputAt = new Map<string, number>();
+	private readonly busyClosePending = new Set<string>();
+	private constructor(
+		readonly client: HerdrClient,
+		readonly bindingPath: string | undefined,
+		readonly binding: HerdrBindingV1,
+	) {}
+
+	static async connect(options?: {
+		socketPath?: string;
+		bindingPath?: string;
+		binding?: HerdrBindingV1;
+	}): Promise<HerdrController> {
+		const socketPath = options?.socketPath ?? process.env.HERDR_SOCKET_PATH;
+		if (!socketPath) throw new HerdrProtocolError("terminal management is unavailable outside Herdr", "unavailable");
+		const bindingPath = options?.bindingPath ?? process.env.XCSH_HERDR_BINDING_PATH;
+		let binding = options?.binding;
+		if (!binding && bindingPath) {
+			try {
+				binding = JSON.parse(await fs.readFile(bindingPath, "utf8")) as HerdrBindingV1;
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			}
+		}
+		binding ??= bindingFromEnvironment();
+		if (binding?.version !== 1) throw new HerdrProtocolError("Herdr binding is unavailable", "unavailable");
+		const controller = new HerdrController(new HerdrClient(socketPath), bindingPath, binding);
+		await controller.claimBinding();
+		return controller;
+	}
+
+	private async persist(): Promise<void> {
+		if (!this.bindingPath) return;
+		await fs.mkdir(path.dirname(this.bindingPath), { recursive: true, mode: 0o700 });
+		const temporary = `${this.bindingPath}.${process.pid}.tmp`;
+		await fs.writeFile(temporary, `${JSON.stringify(this.binding, null, 2)}\n`, { mode: 0o600 });
+		await fs.rename(temporary, this.bindingPath);
+	}
+
+	private async claimBinding(): Promise<void> {
+		await this.client.request("workspace.report_metadata", {
+			workspace_id: this.binding.workspaceId,
+			source: HERDR_SOURCE,
+			tokens: { [HERDR_OWNER_TOKEN]: this.binding.ownerToken },
+			seq: Date.now() * 1000,
+		});
+		await this.client.request("pane.report_metadata", {
+			pane_id: this.binding.rootPaneId,
+			source: HERDR_SOURCE,
+			tokens: { [HERDR_OWNER_TOKEN]: this.binding.ownerToken },
+			seq: Date.now() * 1000 + 1,
+		});
+		await this.persist();
+	}
+
+	async updateSessionRef(sessionRef: string | undefined): Promise<void> {
+		if (!sessionRef || this.binding.activeSessionRef === sessionRef) return;
+		this.binding.activeSessionRef = sessionRef;
+		await this.client.request("workspace.report_metadata", {
+			workspace_id: this.binding.workspaceId,
+			source: HERDR_SOURCE,
+			tokens: { [HERDR_OWNER_TOKEN]: this.binding.ownerToken, xcsh_session_ref: sessionRef },
+			seq: Date.now() * 1000,
+		});
+		await this.persist();
+	}
+
+	private async ownedPane(paneId: string): Promise<PaneInfo> {
+		const result = await this.client.request<{ type: string; pane: PaneInfo }>("pane.get", { pane_id: paneId });
+		const pane = result.pane;
+		if (
+			!pane ||
+			pane.workspace_id !== this.binding.workspaceId ||
+			pane.tokens?.[HERDR_OWNER_TOKEN] !== this.binding.ownerToken
+		) {
+			throw new HerdrProtocolError("terminal is not owned by this xcsh conversation", "not_owned");
+		}
+		return pane;
+	}
+
+	async list(): Promise<HerdrTerminalRecordV1[]> {
+		const result = await this.client.request<{ type: string; panes: PaneInfo[] }>("pane.list", {
+			workspace_id: this.binding.workspaceId,
+		});
+		const live = new Set(
+			(result.panes ?? [])
+				.filter(pane => pane.tokens?.[HERDR_OWNER_TOKEN] === this.binding.ownerToken)
+				.map(pane => pane.pane_id),
+		);
+		this.binding.terminals = this.binding.terminals.filter(record => live.has(record.paneId));
+		await this.persist();
+		return [...this.binding.terminals];
+	}
+
+	async create(name: string, cwd?: string): Promise<HerdrTerminalRecordV1> {
+		if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,47}$/.test(name)) throw new HerdrProtocolError("invalid terminal name");
+		if (this.binding.terminals.some(record => record.name === name))
+			throw new HerdrProtocolError("terminal name exists");
+		const result = await this.client.request<TabCreated>("tab.create", {
+			workspace_id: this.binding.workspaceId,
+			label: name,
+			cwd: cwd ?? process.cwd(),
+			focus: false,
+			env: { XCSH_HERDR_OWNER: this.binding.ownerToken },
+		});
+		if (result.type !== "tab_created" || !result.root_pane?.pane_id)
+			throw new HerdrProtocolError("invalid tab.create result");
+		await this.client.request("pane.report_metadata", {
+			pane_id: result.root_pane.pane_id,
+			source: HERDR_SOURCE,
+			title: name,
+			tokens: { [HERDR_OWNER_TOKEN]: this.binding.ownerToken },
+			seq: Date.now() * 1000,
+		});
+		const record = {
+			name,
+			tabId: result.tab.tab_id,
+			paneId: result.root_pane.pane_id,
+			createdAt: new Date().toISOString(),
+		};
+		this.binding.terminals.push(record);
+		await this.persist();
+		return record;
+	}
+
+	private resolve(nameOrId: string): HerdrTerminalRecordV1 {
+		const record = this.binding.terminals.find(item => item.name === nameOrId || item.paneId === nameOrId);
+		if (!record) throw new HerdrProtocolError("unknown terminal", "not_found");
+		return record;
+	}
+
+	async run(nameOrId: string, command: string): Promise<void> {
+		const record = this.resolve(nameOrId);
+		await this.ownedPane(record.paneId);
+		this.busyClosePending.delete(record.paneId);
+		await this.client.request("pane.send_text", { pane_id: record.paneId, text: command });
+		await this.client.request("pane.send_keys", { pane_id: record.paneId, keys: ["enter"] });
+		this.lastInputAt.set(record.paneId, Date.now());
+	}
+
+	async send(nameOrId: string, text: string, enter = false): Promise<void> {
+		const record = this.resolve(nameOrId);
+		await this.ownedPane(record.paneId);
+		this.busyClosePending.delete(record.paneId);
+		await this.client.request("pane.send_text", { pane_id: record.paneId, text });
+		if (enter) await this.client.request("pane.send_keys", { pane_id: record.paneId, keys: ["enter"] });
+		this.lastInputAt.set(record.paneId, Date.now());
+	}
+
+	async read(nameOrId: string, lines = 120): Promise<Record<string, unknown>> {
+		const record = this.resolve(nameOrId);
+		await this.ownedPane(record.paneId);
+		return this.client.request("pane.read", {
+			pane_id: record.paneId,
+			source: "recent_unwrapped",
+			format: "text",
+			lines: Math.max(1, Math.min(lines, 1000)),
+			strip_ansi: true,
+		});
+	}
+
+	async wait(nameOrId: string, match: string, timeoutMs = 30_000): Promise<Record<string, unknown>> {
+		const record = this.resolve(nameOrId);
+		await this.ownedPane(record.paneId);
+		return this.client.request("pane.wait_for_output", {
+			pane_id: record.paneId,
+			source: "recent_unwrapped",
+			match: { type: "substring", value: match },
+			timeout_ms: Math.max(0, Math.min(timeoutMs, 300_000)),
+			strip_ansi: true,
+		});
+	}
+
+	async status(nameOrId: string): Promise<Record<string, unknown>> {
+		const record = this.resolve(nameOrId);
+		await this.ownedPane(record.paneId);
+		return this.client.request("pane.process_info", { pane_id: record.paneId });
+	}
+
+	async focus(nameOrId: string): Promise<void> {
+		const record = this.resolve(nameOrId);
+		await this.ownedPane(record.paneId);
+		await this.client.request("pane.focus", { pane_id: record.paneId });
+	}
+
+	async close(nameOrId: string, force = false): Promise<void> {
+		const record = this.resolve(nameOrId);
+		const pane = await this.ownedPane(record.paneId);
+		if (pane.tab_id !== record.tabId) {
+			throw new HerdrProtocolError("terminal tab identity changed", "not_owned");
+		}
+		const listed = await this.client.request<{ type: string; panes: PaneInfo[] }>("pane.list", {
+			workspace_id: this.binding.workspaceId,
+		});
+		const tabPanes = (listed.panes ?? []).filter(candidate => candidate.tab_id === pane.tab_id);
+		if (
+			tabPanes.length === 0 ||
+			!tabPanes.some(candidate => candidate.pane_id === record.paneId) ||
+			tabPanes.some(candidate => candidate.tokens?.[HERDR_OWNER_TOKEN] !== this.binding.ownerToken)
+		) {
+			throw new HerdrProtocolError("terminal tab contains an unowned pane", "not_owned");
+		}
+		const status = await this.client.request<{
+			type: string;
+			process_info: { shell_pid?: number | null; foreground_processes?: Array<{ pid: number }> };
+		}>("pane.process_info", { pane_id: record.paneId });
+		const info = status.process_info;
+		const recentlySent = Date.now() - (this.lastInputAt.get(record.paneId) ?? 0) < 1_000;
+		const busy = recentlySent || (info.foreground_processes ?? []).some(process => process.pid !== info.shell_pid);
+		if (busy && (!force || !this.busyClosePending.has(record.paneId))) {
+			this.busyClosePending.add(record.paneId);
+			throw new HerdrProtocolError("terminal is busy; repeat close with force: true", "busy");
+		}
+		await this.client.request("tab.close", { tab_id: pane.tab_id });
+		this.lastInputAt.delete(record.paneId);
+		this.busyClosePending.delete(record.paneId);
+		this.binding.terminals = this.binding.terminals.filter(item => item.paneId !== record.paneId);
+		await this.persist();
+	}
+}

--- a/packages/coding-agent/src/herdr/controller.ts
+++ b/packages/coding-agent/src/herdr/controller.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { HerdrClient, HerdrProtocolError } from "./client";
@@ -55,6 +56,7 @@ function bindingFromEnvironment(): HerdrBindingV1 | undefined {
 export class HerdrController {
 	private readonly lastInputAt = new Map<string, number>();
 	private readonly busyClosePending = new Set<string>();
+	private persistQueue: Promise<void> = Promise.resolve();
 	private constructor(
 		readonly client: HerdrClient,
 		readonly bindingPath: string | undefined,
@@ -84,12 +86,19 @@ export class HerdrController {
 		return controller;
 	}
 
-	private async persist(): Promise<void> {
-		if (!this.bindingPath) return;
-		await fs.mkdir(path.dirname(this.bindingPath), { recursive: true, mode: 0o700 });
-		const temporary = `${this.bindingPath}.${process.pid}.tmp`;
-		await fs.writeFile(temporary, `${JSON.stringify(this.binding, null, 2)}\n`, { mode: 0o600 });
-		await fs.rename(temporary, this.bindingPath);
+	private persist(): Promise<void> {
+		if (!this.bindingPath) return Promise.resolve();
+		const bindingPath = this.bindingPath;
+		const snapshot = `${JSON.stringify(this.binding, null, 2)}\n`;
+		const write = async (): Promise<void> => {
+			await fs.mkdir(path.dirname(bindingPath), { recursive: true, mode: 0o700 });
+			const temporary = `${bindingPath}.${process.pid}.${randomUUID()}.tmp`;
+			await fs.writeFile(temporary, snapshot, { mode: 0o600 });
+			await fs.rename(temporary, bindingPath);
+		};
+		const pending = this.persistQueue.then(write, write);
+		this.persistQueue = pending.catch(() => {});
+		return pending;
 	}
 
 	private async claimBinding(): Promise<void> {
@@ -257,11 +266,12 @@ export class HerdrController {
 		}
 		const status = await this.client.request<{
 			type: string;
-			process_info: { shell_pid?: number | null; foreground_processes?: Array<{ pid: number }> };
+			process_info?: { shell_pid?: number | null; foreground_processes?: Array<{ pid: number }> } | null;
 		}>("pane.process_info", { pane_id: record.paneId });
 		const info = status.process_info;
 		const recentlySent = Date.now() - (this.lastInputAt.get(record.paneId) ?? 0) < 1_000;
-		const busy = recentlySent || (info.foreground_processes ?? []).some(process => process.pid !== info.shell_pid);
+		const busy =
+			!info || recentlySent || (info.foreground_processes ?? []).some(process => process.pid !== info.shell_pid);
 		if (busy && (!force || !this.busyClosePending.has(record.paneId))) {
 			this.busyClosePending.add(record.paneId);
 			throw new HerdrProtocolError("terminal is busy; repeat close with force: true", "busy");

--- a/packages/coding-agent/test/herdr-terminal.test.ts
+++ b/packages/coding-agent/test/herdr-terminal.test.ts
@@ -4,6 +4,7 @@ import { createServer, type Server } from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import { buildXcshCommand, shellQuote } from "../src/commands/herdr";
+import { createRetryingLazy } from "../src/extensibility/extensions/bundled/herdr-terminal";
 import { HerdrClient, HerdrProtocolError } from "../src/herdr/client";
 import { type HerdrBindingV1, HerdrController } from "../src/herdr/controller";
 
@@ -217,6 +218,7 @@ describe("conversation-owned Herdr terminals", () => {
 		const state = binding();
 		state.terminals.push({ name: "server", tabId: "w1:t2", paneId: "w1:p2", createdAt: "now" });
 		let closed = false;
+		let statusCalls = 0;
 		const fake = await fakeHerdr(request => {
 			if (request.method === "ping") return { type: "pong", protocol: 18, version: "test" };
 			if (request.method.endsWith("report_metadata")) return { type: "ok" };
@@ -234,7 +236,8 @@ describe("conversation-owned Herdr terminals", () => {
 			if (request.method === "pane.process_info")
 				return {
 					type: "pane_process_info",
-					process_info: { shell_pid: 10, foreground_processes: [{ pid: 10 }, { pid: 11 }] },
+					process_info:
+						statusCalls++ === 0 ? undefined : { shell_pid: 10, foreground_processes: [{ pid: 10 }, { pid: 11 }] },
 				};
 			if (request.method === "tab.close") {
 				closed = true;
@@ -355,5 +358,18 @@ describe("Herdr launcher", () => {
 		expect(buildXcshCommand("/opt/xcsh bin", ["--model", "openai/gpt 5", "it's safe"])).toBe(
 			`'/opt/xcsh bin' '--model' 'openai/gpt 5' 'it'"'"'s safe'`,
 		);
+	});
+});
+
+describe("Herdr terminal connection lifecycle", () => {
+	test("retries after a transient controller connection failure", async () => {
+		let attempts = 0;
+		const controller = createRetryingLazy(async () => {
+			if (++attempts === 1) throw new Error("socket starting");
+			return "connected";
+		});
+		await expect(controller()).rejects.toThrow("socket starting");
+		expect(await controller()).toBe("connected");
+		expect(attempts).toBe(2);
 	});
 });

--- a/packages/coding-agent/test/herdr-terminal.test.ts
+++ b/packages/coding-agent/test/herdr-terminal.test.ts
@@ -1,0 +1,359 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import { createServer, type Server } from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildXcshCommand, shellQuote } from "../src/commands/herdr";
+import { HerdrClient, HerdrProtocolError } from "../src/herdr/client";
+import { type HerdrBindingV1, HerdrController } from "../src/herdr/controller";
+
+const roots: string[] = [];
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+interface Request {
+	id: string;
+	method: string;
+	params: Record<string, unknown>;
+}
+
+async function fakeHerdr(
+	handler: (request: Request) => Record<string, unknown>,
+	options: { trailingNewline?: boolean } = {},
+): Promise<{ socketPath: string; requests: Request[]; close(): Promise<void> }> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-herdr-terminal-"));
+	roots.push(root);
+	const socketPath = path.join(root, "herdr.sock");
+	const requests: Request[] = [];
+	const server: Server = createServer(socket => {
+		let input = "";
+		socket.setEncoding("utf8");
+		socket.on("data", chunk => {
+			input += chunk;
+			const newline = input.indexOf("\n");
+			if (newline < 0) return;
+			const request = JSON.parse(input.slice(0, newline)) as Request;
+			requests.push(request);
+			const suffix = options.trailingNewline === false ? "" : "\n";
+			socket.end(`${JSON.stringify({ id: request.id, result: handler(request) })}${suffix}`);
+		});
+	});
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(socketPath, resolve);
+	});
+	return {
+		socketPath,
+		requests,
+		close: () => new Promise<void>((resolve, reject) => server.close(error => (error ? reject(error) : resolve()))),
+	};
+}
+
+function binding(ownerToken = "owner-a"): HerdrBindingV1 {
+	return {
+		version: 1,
+		sessionName: "org",
+		workspaceId: "w1",
+		rootPaneId: "w1:p1",
+		ownerToken,
+		terminals: [],
+	};
+}
+
+describe("Herdr protocol-18 client", () => {
+	test("validates the protocol and reconnects for each request", async () => {
+		const fake = await fakeHerdr(request =>
+			request.method === "ping"
+				? { type: "pong", protocol: 18, version: "test" }
+				: { type: "workspace_list", workspaces: [] },
+		);
+		try {
+			const client = new HerdrClient(fake.socketPath);
+			expect((await client.request("workspace.list", {})).type).toBe("workspace_list");
+			expect((await client.request("workspace.list", {})).type).toBe("workspace_list");
+			expect(fake.requests.map(request => request.method)).toEqual(["ping", "workspace.list", "workspace.list"]);
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("rejects incompatible servers", async () => {
+		const fake = await fakeHerdr(() => ({ type: "pong", protocol: 17, version: "old" }));
+		try {
+			await expect(new HerdrClient(fake.socketPath).ensureProtocol()).rejects.toMatchObject({
+				code: "protocol_mismatch",
+			});
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("accepts a response terminated by EOF without a trailing newline", async () => {
+		const fake = await fakeHerdr(
+			request =>
+				request.method === "ping"
+					? { type: "pong", protocol: 18, version: "test" }
+					: { type: "pane_list", panes: [] },
+			{ trailingNewline: false },
+		);
+		try {
+			expect((await new HerdrClient(fake.socketPath).request("pane.list", {})).type).toBe("pane_list");
+		} finally {
+			await fake.close();
+		}
+	});
+});
+
+describe("conversation-owned Herdr terminals", () => {
+	test("reports unavailable outside Herdr", async () => {
+		const oldSocket = process.env.HERDR_SOCKET_PATH;
+		delete process.env.HERDR_SOCKET_PATH;
+		try {
+			await expect(HerdrController.connect()).rejects.toBeInstanceOf(HerdrProtocolError);
+		} finally {
+			if (oldSocket) process.env.HERDR_SOCKET_PATH = oldSocket;
+		}
+	});
+
+	test("does not claim an arbitrary Herdr workspace without a launcher owner token", async () => {
+		const fake = await fakeHerdr(request => {
+			if (request.method === "ping") return { type: "pong", protocol: 18, version: "test" };
+			if (request.method.endsWith("report_metadata")) return { type: "ok" };
+			throw new Error(`unexpected ${request.method}`);
+		});
+		const previous = {
+			session: process.env.HERDR_SESSION,
+			workspace: process.env.HERDR_WORKSPACE_ID,
+			pane: process.env.HERDR_PANE_ID,
+			owner: process.env.XCSH_HERDR_OWNER,
+			bindingPath: process.env.XCSH_HERDR_BINDING_PATH,
+		};
+		process.env.HERDR_SESSION = "org";
+		process.env.HERDR_WORKSPACE_ID = "w1";
+		process.env.HERDR_PANE_ID = "w1:p1";
+		delete process.env.XCSH_HERDR_OWNER;
+		delete process.env.XCSH_HERDR_BINDING_PATH;
+		try {
+			await expect(HerdrController.connect({ socketPath: fake.socketPath })).rejects.toMatchObject({
+				code: "unavailable",
+			});
+			expect(fake.requests).toHaveLength(0);
+		} finally {
+			const restore = (name: string, value: string | undefined): void => {
+				if (value === undefined) delete process.env[name];
+				else process.env[name] = value;
+			};
+			restore("HERDR_SESSION", previous.session);
+			restore("HERDR_WORKSPACE_ID", previous.workspace);
+			restore("HERDR_PANE_ID", previous.pane);
+			restore("XCSH_HERDR_OWNER", previous.owner);
+			restore("XCSH_HERDR_BINDING_PATH", previous.bindingPath);
+			await fake.close();
+		}
+	});
+
+	test("creates without focus, filters unrelated panes, and updates the resume reference", async () => {
+		const owner = "owner-a";
+		const panes = new Map<string, Record<string, unknown>>([
+			["w1:p1", { pane_id: "w1:p1", tab_id: "w1:t1", workspace_id: "w1", tokens: {} }],
+			["w1:p9", { pane_id: "w1:p9", tab_id: "w1:t9", workspace_id: "w1", tokens: { xcsh_owner: "other" } }],
+		]);
+		const fake = await fakeHerdr(request => {
+			if (request.method === "ping") return { type: "pong", protocol: 18, version: "test" };
+			if (request.method === "pane.report_metadata") {
+				Object.assign(panes.get(String(request.params.pane_id))!, { tokens: request.params.tokens });
+				return { type: "ok" };
+			}
+			if (request.method === "workspace.report_metadata") return { type: "ok" };
+			if (request.method === "tab.create") {
+				panes.set("w1:p2", {
+					pane_id: "w1:p2",
+					tab_id: "w1:t2",
+					workspace_id: "w1",
+					tokens: {},
+				});
+				return {
+					type: "tab_created",
+					tab: { tab_id: "w1:t2", workspace_id: "w1" },
+					root_pane: panes.get("w1:p2")!,
+				};
+			}
+			if (request.method === "pane.list") return { type: "pane_list", panes: [...panes.values()] };
+			if (request.method === "pane.get")
+				return { type: "pane_info", pane: panes.get(String(request.params.pane_id)) };
+			if (request.method === "pane.send_text" || request.method === "pane.send_keys") return { type: "ok" };
+			throw new Error(`unexpected ${request.method}`);
+		});
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-herdr-binding-"));
+		roots.push(root);
+		const bindingPath = path.join(root, "binding.json");
+		try {
+			const controller = await HerdrController.connect({
+				socketPath: fake.socketPath,
+				bindingPath,
+				binding: binding(owner),
+			});
+			const terminal = await controller.create("tests", "/repo");
+			expect(terminal.paneId).toBe("w1:p2");
+			const create = fake.requests.find(request => request.method === "tab.create")!;
+			expect(create.params).toMatchObject({ workspace_id: "w1", label: "tests", cwd: "/repo", focus: false });
+			expect(await controller.list()).toEqual([terminal]);
+			await controller.run("tests", "printf ready");
+			expect(fake.requests.slice(-2).map(request => [request.method, request.params])).toEqual([
+				["pane.send_text", { pane_id: "w1:p2", text: "printf ready" }],
+				["pane.send_keys", { pane_id: "w1:p2", keys: ["enter"] }],
+			]);
+			await controller.updateSessionRef("/sessions/current.jsonl");
+			const persisted = JSON.parse(await fs.readFile(bindingPath, "utf8")) as HerdrBindingV1;
+			expect(persisted.activeSessionRef).toBe("/sessions/current.jsonl");
+			expect(JSON.stringify(await controller.list())).not.toContain("w1:p9");
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("requires a second forced close for a busy owned pane", async () => {
+		const state = binding();
+		state.terminals.push({ name: "server", tabId: "w1:t2", paneId: "w1:p2", createdAt: "now" });
+		let closed = false;
+		const fake = await fakeHerdr(request => {
+			if (request.method === "ping") return { type: "pong", protocol: 18, version: "test" };
+			if (request.method.endsWith("report_metadata")) return { type: "ok" };
+			if (request.method === "pane.get")
+				return {
+					type: "pane_info",
+					pane: { pane_id: "w1:p2", tab_id: "w1:t2", workspace_id: "w1", tokens: { xcsh_owner: "owner-a" } },
+				};
+			if (request.method === "pane.list")
+				return {
+					type: "pane_list",
+					panes: [{ pane_id: "w1:p2", tab_id: "w1:t2", workspace_id: "w1", tokens: { xcsh_owner: "owner-a" } }],
+				};
+
+			if (request.method === "pane.process_info")
+				return {
+					type: "pane_process_info",
+					process_info: { shell_pid: 10, foreground_processes: [{ pid: 10 }, { pid: 11 }] },
+				};
+			if (request.method === "tab.close") {
+				closed = true;
+				return { type: "ok" };
+			}
+			throw new Error(`unexpected ${request.method}`);
+		});
+		try {
+			const controller = await HerdrController.connect({ socketPath: fake.socketPath, binding: state });
+			await expect(controller.close("server", true)).rejects.toMatchObject({ code: "busy" });
+			expect(closed).toBe(false);
+			await controller.close("server", true);
+			expect(closed).toBe(true);
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("focuses an owned pane only after revalidating its metadata token", async () => {
+		const state = binding();
+		state.terminals.push({ name: "logs", tabId: "w1:t2", paneId: "w1:p2", createdAt: "now" });
+		const fake = await fakeHerdr(request => {
+			if (request.method === "ping") return { type: "pong", protocol: 18, version: "test" };
+			if (request.method.endsWith("report_metadata")) return { type: "ok" };
+			if (request.method === "pane.get")
+				return {
+					type: "pane_info",
+					pane: {
+						pane_id: "w1:p2",
+						tab_id: "w1:t2",
+						workspace_id: "w1",
+						tokens: { xcsh_owner: "owner-a" },
+					},
+				};
+			if (request.method === "pane.focus") return { type: "ok" };
+			throw new Error(`unexpected ${request.method}`);
+		});
+		try {
+			const controller = await HerdrController.connect({ socketPath: fake.socketPath, binding: state });
+			await controller.focus("logs");
+			expect(fake.requests.slice(-2).map(request => request.method)).toEqual(["pane.get", "pane.focus"]);
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("rejects a forged terminal record before reading or mutating the pane", async () => {
+		const state = binding();
+		state.terminals.push({ name: "foreign", tabId: "w1:t9", paneId: "w1:p9", createdAt: "now" });
+		const fake = await fakeHerdr(request => {
+			if (request.method === "ping") return { type: "pong", protocol: 18, version: "test" };
+			if (request.method.endsWith("report_metadata")) return { type: "ok" };
+			if (request.method === "pane.get")
+				return {
+					type: "pane_info",
+					pane: {
+						pane_id: "w1:p9",
+						tab_id: "w1:t9",
+						workspace_id: "w1",
+						tokens: { xcsh_owner: "another-owner" },
+					},
+				};
+			throw new Error(`unexpected ${request.method}`);
+		});
+		try {
+			const controller = await HerdrController.connect({ socketPath: fake.socketPath, binding: state });
+			await expect(controller.read("foreign")).rejects.toMatchObject({ code: "not_owned" });
+			expect(fake.requests.some(request => request.method === "pane.read")).toBe(false);
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("refuses to close a tab containing a pane owned by another conversation", async () => {
+		const state = binding();
+		state.terminals.push({ name: "shared", tabId: "w1:t2", paneId: "w1:p2", createdAt: "now" });
+		let closed = false;
+		const panes = [
+			{
+				pane_id: "w1:p2",
+				tab_id: "w1:t2",
+				workspace_id: "w1",
+				tokens: { xcsh_owner: "owner-a" },
+			},
+			{
+				pane_id: "w1:p3",
+				tab_id: "w1:t2",
+				workspace_id: "w1",
+				tokens: { xcsh_owner: "owner-b" },
+			},
+		];
+		const fake = await fakeHerdr(request => {
+			if (request.method === "ping") return { type: "pong", protocol: 18, version: "test" };
+			if (request.method.endsWith("report_metadata")) return { type: "ok" };
+			if (request.method === "pane.get") return { type: "pane_info", pane: panes[0] };
+			if (request.method === "pane.list") return { type: "pane_list", panes };
+			if (request.method === "pane.process_info")
+				return { type: "pane_process_info", process_info: { shell_pid: 10, foreground_processes: [] } };
+			if (request.method === "tab.close") {
+				closed = true;
+				return { type: "ok" };
+			}
+			throw new Error(`unexpected ${request.method}`);
+		});
+		try {
+			const controller = await HerdrController.connect({ socketPath: fake.socketPath, binding: state });
+			await expect(controller.close("shared")).rejects.toMatchObject({ code: "not_owned" });
+			expect(closed).toBe(false);
+		} finally {
+			await fake.close();
+		}
+	});
+});
+
+describe("Herdr launcher", () => {
+	test("quotes the executable and every forwarded xcsh argument", () => {
+		expect(shellQuote("a'b")).toBe(`'a'"'"'b'`);
+		expect(buildXcshCommand("/opt/xcsh bin", ["--model", "openai/gpt 5", "it's safe"])).toBe(
+			`'/opt/xcsh bin' '--model' 'openai/gpt 5' 'it'"'"'s safe'`,
+		);
+	});
+});

--- a/packages/coding-agent/test/loader-bundled-extensions.test.ts
+++ b/packages/coding-agent/test/loader-bundled-extensions.test.ts
@@ -27,4 +27,34 @@ describe("loadExtensions bundled opt-in", () => {
 		// The OTHER bundled extension (herdr-reporter) is NOT pulled in.
 		expect(paths).not.toContain("bundled:herdr-reporter");
 	});
+
+	test("registers the Herdr terminal tool and human command together", async () => {
+		const result = await loadExtensions([], CWD, undefined, ["herdr-terminal"]);
+		expect(result.errors).toHaveLength(0);
+		const extension = result.extensions.find(item => item.path === "bundled:herdr-terminal");
+		expect(extension).toBeDefined();
+		expect(extension?.tools.has("herdr_terminal")).toBe(true);
+		expect(extension?.commands.has("terminal")).toBe(true);
+		expect(result.extensions).toHaveLength(1);
+
+		const oldSocket = process.env.HERDR_SOCKET_PATH;
+		delete process.env.HERDR_SOCKET_PATH;
+		try {
+			const tool = extension?.tools.get("herdr_terminal");
+			const response = await tool?.definition.execute(
+				"plain-xcsh",
+				{ action: "list" } as never,
+				undefined,
+				undefined,
+				{} as never,
+			);
+			expect(response).toMatchObject({
+				isError: true,
+				details: { error: "terminal management is unavailable outside Herdr" },
+			});
+		} finally {
+			if (oldSocket === undefined) delete process.env.HERDR_SOCKET_PATH;
+			else process.env.HERDR_SOCKET_PATH = oldSocket;
+		}
+	});
 });


### PR DESCRIPTION
## Summary

- add a protocol-18 Herdr socket client and durable conversation binding
- add owned terminal tool/slash-command surfaces plus the xcsh Herdr launcher
- enforce no-focus creation, metadata-token isolation, reconnect recovery, and two-step busy close
- document the Ghostty/Kitty/FFmpeg stack

## Testing

- 28 focused Herdr tests pass
- `bun run check` passes in `packages/coding-agent`
- root `bun run check:ts` passes
- isolated live Herdr UAT passed with no leaked tabs or focus change
- two-pass direct AGY review passed with zero findings after corrections
- full `bun run test`: 6,599 passed; 7 unrelated workstation sandbox-enumeration baseline failures reproduced in isolation

Closes #3185