### PR TITLE
feat(ai): add request-driven map generation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added provenance-validated, deterministic `render_map` PNG generation with OpenStreetMap tile
+  policy compliance, schematic and text fallbacks, and optional atomic PNG/GeoJSON export
+  ([#3202](https://github.com/f5-sales-demo/xcsh/issues/3202)).
+
+### Changed
+
+- Unified generated and existing media publication behind the versioned `xcsh.media/v1` result
+  contract so TUI, Browser, Office, RPC, and ACP transports no longer identify media by tool name
+  ([#3202](https://github.com/f5-sales-demo/xcsh/issues/3202)).
+
 ## [20.6.3] - 2026-08-07
 
 ### Improved

--- a/packages/coding-agent/src/browser/chat-conformance.json
+++ b/packages/coding-agent/src/browser/chat-conformance.json
@@ -891,7 +891,8 @@
                       "const": "tool"
                     },
                     "source": {
-                      "const": "display_media"
+                      "type": "string",
+                      "pattern": "^[a-z][a-z0-9_]{0,63}$"
                     }
                   }
                 },
@@ -942,6 +943,23 @@
             },
             "degradation": {
               "type": "string"
+            },
+            "filenameHint": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255,
+              "pattern": "^[^/\\\\]+$"
+            },
+            "metadata": {
+              "type": "object",
+              "maxProperties": 16,
+              "propertyNames": {
+                "pattern": "^[a-zA-Z0-9_.-]{1,64}$"
+              },
+              "additionalProperties": {
+                "type": "string",
+                "maxLength": 512
+              }
             }
           }
         }

--- a/packages/coding-agent/src/browser/chat-handler.ts
+++ b/packages/coding-agent/src/browser/chat-handler.ts
@@ -334,15 +334,13 @@ export class ChatHandler {
 			return;
 		}
 		if (event.type === "tool_execution_end" && "toolName" in event) {
-			if (event.toolName === "display_media") {
-				const descriptor = extractMediaDescriptorFromToolResult(event.result);
-				if (descriptor) {
-					this.#server.send({
-						type: "chat_media",
-						id: chat.id,
-						media: projectMediaDescriptorForTransport(descriptor),
-					} satisfies ChatMedia);
-				}
+			const descriptor = extractMediaDescriptorFromToolResult(event.result);
+			if (descriptor) {
+				this.#server.send({
+					type: "chat_media",
+					id: chat.id,
+					media: projectMediaDescriptorForTransport(descriptor),
+				} satisfies ChatMedia);
 			}
 			// ToolExecutionEndEvent carries `isError` (NOT `error`) — checking the wrong
 			// field made this always ok:true, so errored tools rendered ✓ and "failed"

--- a/packages/coding-agent/src/map/render.ts
+++ b/packages/coding-agent/src/map/render.ts
@@ -1,0 +1,314 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { getPuppeteerDir } from "@f5-sales-demo/pi-utils";
+import type { Browser, Page, default as Puppeteer } from "puppeteer";
+import { locateChrome } from "../browser/chrome-locate";
+import { OsmTileFetcher, type TileRequest } from "./tile-cache";
+import { type FittedMapLocations, fitMapLocations, type MapLocationV1 } from "./types";
+
+export const MAP_WIDTH = 1200;
+export const MAP_HEIGHT = 760;
+const PLOT = { x: 32, y: 72, width: 1136, height: 590 };
+const MAX_VIEWPORT_TILES = 48;
+
+export interface RenderMapRequest {
+	title: string;
+	locations: MapLocationV1[];
+	basemap: "osm" | "schematic";
+	signal?: AbortSignal;
+	settings?: { get(key: string): unknown };
+}
+
+export interface RenderedMap {
+	png: Buffer;
+	basemap: "osm" | "schematic";
+	degradation?: string;
+}
+
+export interface RenderMapDependencies {
+	tileFetcher?: OsmTileFetcher;
+	rasterize?: (svg: string, settings?: { get(key: string): unknown }, signal?: AbortSignal) => Promise<Buffer>;
+}
+
+interface Viewport {
+	minX: number;
+	maxX: number;
+	minY: number;
+	maxY: number;
+	spanX: number;
+	spanY: number;
+}
+
+interface TileImage extends TileRequest {
+	logicalX: number;
+	data: Buffer;
+}
+
+function escapeXml(value: string): string {
+	return value.replace(/[&<>"']/gu, character => {
+		switch (character) {
+			case "&":
+				return "&amp;";
+			case "<":
+				return "&lt;";
+			case ">":
+				return "&gt;";
+			case '"':
+				return "&quot;";
+			default:
+				return "&apos;";
+		}
+	});
+}
+
+function viewportFor(fit: FittedMapLocations): Viewport {
+	const paddingX = Math.max(fit.spanX * 0.12, 1 / 512);
+	const paddingY = Math.max(fit.spanY * 0.12, 1 / 512);
+	let minX = fit.minX - paddingX;
+	let maxX = fit.maxX + paddingX;
+	let minY = Math.max(0, fit.minY - paddingY);
+	let maxY = Math.min(1, fit.maxY + paddingY);
+	const desiredAspect = PLOT.width / PLOT.height;
+	const currentAspect = (maxX - minX) / (maxY - minY);
+	if (currentAspect < desiredAspect) {
+		const extra = ((maxY - minY) * desiredAspect - (maxX - minX)) / 2;
+		minX -= extra;
+		maxX += extra;
+	} else {
+		const extra = ((maxX - minX) / desiredAspect - (maxY - minY)) / 2;
+		minY = Math.max(0, minY - extra);
+		maxY = Math.min(1, maxY + extra);
+	}
+	return { minX, maxX, minY, maxY, spanX: maxX - minX, spanY: maxY - minY };
+}
+
+function tileRequests(viewport: Viewport): Array<Omit<TileImage, "data">> {
+	let zoom = Math.max(
+		1,
+		Math.min(
+			12,
+			Math.floor(Math.log2(Math.min(PLOT.width / (viewport.spanX * 256), PLOT.height / (viewport.spanY * 256)))),
+		),
+	);
+	for (;;) {
+		const count = 2 ** zoom;
+		const minLogicalX = Math.floor(viewport.minX * count);
+		const maxLogicalX = Math.floor(viewport.maxX * count - Number.EPSILON);
+		const minY = Math.max(0, Math.floor(viewport.minY * count));
+		const maxY = Math.min(count - 1, Math.floor(viewport.maxY * count - Number.EPSILON));
+		const requests: Array<Omit<TileImage, "data">> = [];
+		for (let y = minY; y <= maxY; y++) {
+			for (let logicalX = minLogicalX; logicalX <= maxLogicalX; logicalX++) {
+				requests.push({ z: zoom, x: ((logicalX % count) + count) % count, y, logicalX });
+			}
+		}
+		if (requests.length <= MAX_VIEWPORT_TILES || zoom === 1) return requests;
+		zoom--;
+	}
+}
+
+async function loadTiles(viewport: Viewport, fetcher: OsmTileFetcher, signal?: AbortSignal): Promise<TileImage[]> {
+	const requests = tileRequests(viewport);
+	const result: TileImage[] = [];
+	// Deliberately bounded and sequential: viewport tiles only, with no prefetch or bulk endpoint behavior.
+	for (const request of requests) {
+		signal?.throwIfAborted();
+		result.push({ ...request, data: await fetcher.fetchTile(request, signal) });
+	}
+	return result;
+}
+
+function screenPoint(worldX: number, worldY: number, viewport: Viewport): { x: number; y: number } {
+	return {
+		x: PLOT.x + ((worldX - viewport.minX) / viewport.spanX) * PLOT.width,
+		y: PLOT.y + ((worldY - viewport.minY) / viewport.spanY) * PLOT.height,
+	};
+}
+
+function schematicBackground(): string {
+	const lines: string[] = [
+		`<rect x="${PLOT.x}" y="${PLOT.y}" width="${PLOT.width}" height="${PLOT.height}" fill="#eef4f7"/>`,
+	];
+	for (let index = 1; index < 8; index++) {
+		const x = PLOT.x + (PLOT.width * index) / 8;
+		lines.push(`<line x1="${x}" y1="${PLOT.y}" x2="${x}" y2="${PLOT.y + PLOT.height}"/>`);
+	}
+	for (let index = 1; index < 5; index++) {
+		const y = PLOT.y + (PLOT.height * index) / 5;
+		lines.push(`<line x1="${PLOT.x}" y1="${y}" x2="${PLOT.x + PLOT.width}" y2="${y}"/>`);
+	}
+	return `<g stroke="#cbd9df" stroke-width="1">${lines.join("")}</g>`;
+}
+
+function tileBackground(tiles: TileImage[], viewport: Viewport): string {
+	return tiles
+		.map(tile => {
+			const count = 2 ** tile.z;
+			const x = PLOT.x + (tile.logicalX / count - viewport.minX) * (PLOT.width / viewport.spanX);
+			const y = PLOT.y + (tile.y / count - viewport.minY) * (PLOT.height / viewport.spanY);
+			const width = PLOT.width / (count * viewport.spanX);
+			const height = PLOT.height / (count * viewport.spanY);
+			return `<image x="${x}" y="${y}" width="${width}" height="${height}" href="data:image/png;base64,${tile.data.toString("base64")}"/>`;
+		})
+		.join("");
+}
+
+interface MarkerGroup {
+	x: number;
+	y: number;
+	indexes: number[];
+	locations: MapLocationV1[];
+}
+
+function groupMarkers(fit: FittedMapLocations, viewport: Viewport, original: readonly MapLocationV1[]): MarkerGroup[] {
+	const order = new Map(original.map((location, index) => [location.id, index + 1]));
+	const groups: MarkerGroup[] = [];
+	for (const point of [...fit.locations].sort((a, b) => a.location.id.localeCompare(b.location.id))) {
+		const screen = screenPoint(point.worldX, point.worldY, viewport);
+		const group = groups.find(candidate => Math.hypot(candidate.x - screen.x, candidate.y - screen.y) < 30);
+		if (group) {
+			group.locations.push(point.location);
+			group.indexes.push(order.get(point.location.id)!);
+			group.x = (group.x * (group.locations.length - 1) + screen.x) / group.locations.length;
+			group.y = (group.y * (group.locations.length - 1) + screen.y) / group.locations.length;
+		} else {
+			groups.push({
+				x: screen.x,
+				y: screen.y,
+				indexes: [order.get(point.location.id)!],
+				locations: [point.location],
+			});
+		}
+	}
+	for (const group of groups) group.indexes.sort((a, b) => a - b);
+	return groups;
+}
+
+function markerSvg(groups: MarkerGroup[]): string {
+	const labels: Array<{ x: number; y: number; width: number; height: number }> = [];
+	return groups
+		.map((group, groupIndex) => {
+			const primary = group.locations[0]!;
+			const fill =
+				primary.confidence === "high" ? "#0b6bcb" : primary.confidence === "medium" ? "#c76a00" : "#7b4ba3";
+			const dash = ["city", "metro", "approximate", "inferred"].includes(primary.precision)
+				? ' stroke-dasharray="4 2"'
+				: "";
+			const markerText = group.indexes.join(",");
+			const labelText = group.locations.map(location => location.label).join(" / ");
+			const labelWidth = Math.min(330, Math.max(100, labelText.length * 7.2 + 18));
+			const labelX = Math.min(PLOT.x + PLOT.width - labelWidth - 4, group.x + 17);
+			let labelY = Math.max(PLOT.y + 4, group.y - 15);
+			let attempts = 0;
+			while (
+				attempts < 20 &&
+				labels.some(
+					label => Math.abs(label.x - labelX) < (label.width + labelWidth) / 2 && Math.abs(label.y - labelY) < 28,
+				)
+			) {
+				attempts++;
+				labelY += 28;
+				if (labelY > PLOT.y + PLOT.height - 25) {
+					labelY = Math.max(PLOT.y + 4, group.y - 15 - attempts * 28 - groupIndex * 2);
+				}
+			}
+			labels.push({ x: labelX, y: labelY, width: labelWidth, height: 24 });
+			return `<g><circle cx="${group.x}" cy="${group.y}" r="13" fill="${fill}" stroke="#fff" stroke-width="3"${dash}/><text x="${group.x}" y="${group.y + 4}" text-anchor="middle" class="marker">${escapeXml(markerText)}</text><rect x="${labelX}" y="${labelY}" width="${labelWidth}" height="24" rx="5" fill="#ffffff" fill-opacity="0.92" stroke="#66747b"/><text x="${labelX + 8}" y="${labelY + 16}" class="label">${escapeXml(labelText.slice(0, 44))}</text></g>`;
+		})
+		.join("");
+}
+
+export function buildMapSvg(
+	title: string,
+	locations: readonly MapLocationV1[],
+	basemap: "osm" | "schematic",
+	tiles: TileImage[] = [],
+): string {
+	const fit = fitMapLocations(locations);
+	const viewport = viewportFor(fit);
+	const background = basemap === "osm" ? tileBackground(tiles, viewport) : schematicBackground();
+	const attribution =
+		basemap === "osm"
+			? "© OpenStreetMap contributors • openstreetmap.org/copyright"
+			: "Schematic Web Mercator • no basemap tiles";
+	return `<svg xmlns="http://www.w3.org/2000/svg" width="${MAP_WIDTH}" height="${MAP_HEIGHT}" viewBox="0 0 ${MAP_WIDTH} ${MAP_HEIGHT}"><style>text{font-family:Arial,sans-serif;fill:#17242b}.title{font-size:26px;font-weight:700}.label{font-size:13px}.marker{font-size:10px;font-weight:700;fill:#fff}.legend{font-size:13px}.attribution{font-size:12px;fill:#394b54}</style><rect width="1200" height="760" fill="#fff"/><text x="32" y="42" class="title">${escapeXml(title)}</text><defs><clipPath id="plot"><rect x="${PLOT.x}" y="${PLOT.y}" width="${PLOT.width}" height="${PLOT.height}"/></clipPath></defs><g clip-path="url(#plot)">${background}</g><rect x="${PLOT.x}" y="${PLOT.y}" width="${PLOT.width}" height="${PLOT.height}" fill="none" stroke="#50636c"/>${markerSvg(groupMarkers(fit, viewport, locations))}<g class="legend"><circle cx="45" cy="698" r="8" fill="#0b6bcb"/><text x="59" y="703">high confidence</text><circle cx="190" cy="698" r="8" fill="#c76a00"/><text x="204" y="703">medium</text><circle cx="290" cy="698" r="8" fill="#7b4ba3"/><text x="304" y="703">low / unknown</text><circle cx="424" cy="698" r="8" fill="none" stroke="#17242b" stroke-dasharray="4 2"/><text x="438" y="703">approximate / inferred</text></g><text x="32" y="738" class="attribution">${escapeXml(attribution)}</text></svg>`;
+}
+
+let puppeteerModule: typeof Puppeteer | undefined;
+async function loadPuppeteer(): Promise<typeof Puppeteer> {
+	if (puppeteerModule) return puppeteerModule;
+	const safeDir = getPuppeteerDir();
+	await fs.mkdir(safeDir, { recursive: true });
+	await Bun.write(path.join(safeDir, "package.json"), "{}");
+	const previous = process.cwd();
+	try {
+		process.chdir(safeDir);
+		puppeteerModule = (await import("puppeteer")).default;
+		return puppeteerModule;
+	} finally {
+		process.chdir(previous);
+	}
+}
+
+export async function rasterizeMapSvg(
+	svg: string,
+	settings?: { get(key: string): unknown },
+	signal?: AbortSignal,
+): Promise<Buffer> {
+	const chrome = locateChrome({ settings });
+	if (!chrome) throw new Error("Chrome is unavailable for network-isolated map rasterization");
+	const puppeteer = await loadPuppeteer();
+	let browser: Browser | undefined;
+	try {
+		browser = await puppeteer.launch({
+			headless: true,
+			executablePath: chrome.path,
+			args: ["--disable-background-networking", "--disable-component-update", "--no-first-run"],
+		});
+		const page: Page = await browser.newPage();
+		await page.setJavaScriptEnabled(false);
+		await page.setRequestInterception(true);
+		page.on("request", request => {
+			if (request.url().startsWith("data:")) void request.continue();
+			else void request.abort("blockedbyclient");
+		});
+		await page.setViewport({ width: MAP_WIDTH, height: MAP_HEIGHT, deviceScaleFactor: 1 });
+		signal?.throwIfAborted();
+		await page.setContent(
+			`<!doctype html><html><head><meta charset="utf-8"><style>html,body{margin:0;width:${MAP_WIDTH}px;height:${MAP_HEIGHT}px;overflow:hidden}</style></head><body>${svg}</body></html>`,
+			{
+				waitUntil: "domcontentloaded",
+			},
+		);
+		signal?.throwIfAborted();
+		return Buffer.from(
+			await page.screenshot({ type: "png", clip: { x: 0, y: 0, width: MAP_WIDTH, height: MAP_HEIGHT } }),
+		);
+	} finally {
+		await browser?.close();
+	}
+}
+
+export async function renderMap(
+	request: RenderMapRequest,
+	dependencies: RenderMapDependencies = {},
+): Promise<RenderedMap> {
+	const fit = fitMapLocations(request.locations);
+	const viewport = viewportFor(fit);
+	const rasterize = dependencies.rasterize ?? rasterizeMapSvg;
+	let basemap = request.basemap;
+	let degradation: string | undefined;
+	let tiles: TileImage[] = [];
+	if (basemap === "osm") {
+		try {
+			const fetcher =
+				dependencies.tileFetcher ?? new OsmTileFetcher({ cacheDir: path.join(getPuppeteerDir(), "osm-tiles") });
+			tiles = await loadTiles(viewport, fetcher, request.signal);
+		} catch (error) {
+			basemap = "schematic";
+			degradation = `OpenStreetMap tiles were unavailable; rendered a schematic map (${error instanceof Error ? error.message : String(error)}).`;
+		}
+	}
+	const svg = buildMapSvg(request.title, request.locations, basemap, tiles);
+	return { png: await rasterize(svg, request.settings, request.signal), basemap, degradation };
+}

--- a/packages/coding-agent/src/map/tile-cache.ts
+++ b/packages/coding-agent/src/map/tile-cache.ts
@@ -1,0 +1,130 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+export const OSM_TILE_USER_AGENT = "xcsh-map-renderer/1.0 (+https://github.com/f5-sales-demo/xcsh)";
+const MAX_TILE_BYTES = 1024 * 1024;
+
+interface TileMetadata {
+	etag?: string;
+	lastModified?: string;
+	expiresAt: number;
+}
+
+export interface TileRequest {
+	z: number;
+	x: number;
+	y: number;
+}
+
+export interface OsmTileFetcherOptions {
+	cacheDir: string;
+	fetch?: (input: string, init?: RequestInit) => Promise<Response>;
+	now?: () => number;
+}
+
+function cacheLifetime(headers: Headers, now: number): number {
+	const cacheControl = headers.get("cache-control") ?? "";
+	if (/\bno-store\b/iu.test(cacheControl)) return 0;
+	const maxAge = /\bmax-age=(\d+)\b/iu.exec(cacheControl)?.[1];
+	if (maxAge) return Number(maxAge) * 1000;
+	const expires = headers.get("expires");
+	if (expires) return Math.max(0, Date.parse(expires) - now);
+	return 0;
+}
+
+function validateTile(data: Buffer): void {
+	if (data.byteLength === 0 || data.byteLength > MAX_TILE_BYTES) throw new Error("OSM tile size is invalid");
+	if (!data.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+		throw new Error("OSM tile is not a valid PNG");
+	}
+}
+
+async function readMetadata(file: string): Promise<TileMetadata | undefined> {
+	try {
+		const value = JSON.parse(await fs.readFile(file, "utf8")) as Partial<TileMetadata>;
+		if (!Number.isFinite(value.expiresAt)) return undefined;
+		return value as TileMetadata;
+	} catch {
+		return undefined;
+	}
+}
+
+export class OsmTileFetcher {
+	readonly #options: Required<Omit<OsmTileFetcherOptions, "cacheDir">> & Pick<OsmTileFetcherOptions, "cacheDir">;
+
+	constructor(options: OsmTileFetcherOptions) {
+		this.#options = {
+			cacheDir: options.cacheDir,
+			fetch: options.fetch ?? ((input, init) => fetch(input, init)),
+			now: options.now ?? Date.now,
+		};
+	}
+
+	async fetchTile(tile: TileRequest, signal?: AbortSignal): Promise<Buffer> {
+		if (!Number.isInteger(tile.z) || tile.z < 0 || tile.z > 19) throw new Error("invalid OSM tile zoom");
+		const count = 2 ** tile.z;
+		if (
+			!Number.isInteger(tile.x) ||
+			tile.x < 0 ||
+			tile.x >= count ||
+			!Number.isInteger(tile.y) ||
+			tile.y < 0 ||
+			tile.y >= count
+		) {
+			throw new Error("invalid OSM tile coordinate");
+		}
+		const base = path.join(this.#options.cacheDir, String(tile.z), String(tile.x), String(tile.y));
+		const pngPath = `${base}.png`;
+		const metadataPath = `${base}.json`;
+		const now = this.#options.now();
+		const metadata = await readMetadata(metadataPath);
+		let cached: Buffer | undefined;
+		try {
+			cached = await fs.readFile(pngPath);
+			validateTile(cached);
+		} catch {
+			cached = undefined;
+		}
+		if (cached && metadata && metadata.expiresAt > now) return cached;
+
+		const headers = new Headers({
+			Accept: "image/png",
+			Referer: "https://github.com/f5-sales-demo/xcsh",
+			"User-Agent": OSM_TILE_USER_AGENT,
+		});
+		if (cached && metadata?.etag) headers.set("If-None-Match", metadata.etag);
+		if (cached && metadata?.lastModified) headers.set("If-Modified-Since", metadata.lastModified);
+		const response = await this.#options.fetch(`https://tile.openstreetmap.org/${tile.z}/${tile.x}/${tile.y}.png`, {
+			headers,
+			redirect: "error",
+			signal,
+		});
+		if (response.status === 304 && cached) {
+			await this.#writeMetadata(metadataPath, response.headers, now, metadata);
+			return cached;
+		}
+		if (!response.ok) throw new Error(`OSM tile request failed with HTTP ${response.status}`);
+		const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim();
+		if (contentType !== "image/png") throw new Error("OSM tile response was not image/png");
+		const declaredLength = Number(response.headers.get("content-length"));
+		if (Number.isFinite(declaredLength) && declaredLength > MAX_TILE_BYTES) throw new Error("OSM tile is too large");
+		const data = Buffer.from(await response.arrayBuffer());
+		validateTile(data);
+		if (!/\bno-store\b/iu.test(response.headers.get("cache-control") ?? "")) {
+			await fs.mkdir(path.dirname(pngPath), { recursive: true });
+			await Bun.write(pngPath, data);
+			await this.#writeMetadata(metadataPath, response.headers, now);
+		}
+		return data;
+	}
+
+	async #writeMetadata(file: string, headers: Headers, now: number, previous?: TileMetadata): Promise<void> {
+		const value: TileMetadata = {
+			etag: headers.get("etag") ?? previous?.etag,
+			lastModified: headers.get("last-modified") ?? previous?.lastModified,
+			expiresAt: now + cacheLifetime(headers, now),
+		};
+		await fs.mkdir(path.dirname(file), { recursive: true });
+		await Bun.write(file, `${JSON.stringify(value)}\n`);
+	}
+}

--- a/packages/coding-agent/src/map/types.ts
+++ b/packages/coding-agent/src/map/types.ts
@@ -1,0 +1,155 @@
+export const MAP_PRECISIONS = ["exact", "address", "city", "metro", "approximate", "inferred", "unresolved"] as const;
+export type MapPrecision = (typeof MAP_PRECISIONS)[number];
+
+export const MAP_RESOLUTIONS = ["resolved", "candidate", "ambiguous", "approximate", "unresolved"] as const;
+export type MapResolution = (typeof MAP_RESOLUTIONS)[number];
+
+export const MAP_CONFIDENCES = ["high", "medium", "low", "unknown"] as const;
+export type MapConfidence = (typeof MAP_CONFIDENCES)[number];
+
+export interface MapLocationSourceV1 {
+	url: string;
+	sourceName: string;
+	observedAt: string;
+	claim: string;
+}
+
+export interface MapLocationV1 {
+	id: string;
+	label: string;
+	longitude?: number;
+	latitude?: number;
+	precision: MapPrecision;
+	resolution: MapResolution;
+	confidence: MapConfidence;
+	sources: MapLocationSourceV1[];
+}
+
+export interface FittedMapLocation {
+	location: MapLocationV1;
+	worldX: number;
+	worldY: number;
+}
+
+export interface FittedMapLocations {
+	locations: FittedMapLocation[];
+	minX: number;
+	maxX: number;
+	minY: number;
+	maxY: number;
+	spanX: number;
+	spanY: number;
+}
+
+const MAX_WEB_MERCATOR_LATITUDE = 85.05112878;
+
+function requiredString(value: unknown, field: string, max = 2048): string {
+	if (typeof value !== "string" || !value.trim() || value.length > max) throw new Error(`${field} is required`);
+	return value.trim();
+}
+
+export function validateMapLocationV1(value: unknown): MapLocationV1 {
+	if (!value || typeof value !== "object") throw new Error("map location must be an object");
+	const location = value as Partial<MapLocationV1>;
+	const id = requiredString(location.id, "location id", 128);
+	if (!/^[a-zA-Z0-9][a-zA-Z0-9_.:-]*$/u.test(id)) throw new Error("location id must be stable and URL-safe");
+	const label = requiredString(location.label, "location label", 256);
+	if (!MAP_PRECISIONS.includes(location.precision as MapPrecision)) throw new Error("invalid location precision");
+	if (!MAP_RESOLUTIONS.includes(location.resolution as MapResolution)) throw new Error("invalid location resolution");
+	if (!MAP_CONFIDENCES.includes(location.confidence as MapConfidence)) throw new Error("invalid location confidence");
+	const hasLongitude = location.longitude !== undefined;
+	const hasLatitude = location.latitude !== undefined;
+	if (hasLongitude !== hasLatitude) throw new Error("longitude and latitude must be supplied together");
+	if (hasLongitude) {
+		if (!Number.isFinite(location.longitude) || location.longitude! < -180 || location.longitude! > 180) {
+			throw new Error("longitude must be between -180 and 180");
+		}
+		if (!Number.isFinite(location.latitude) || location.latitude! < -90 || location.latitude! > 90) {
+			throw new Error("latitude must be between -90 and 90");
+		}
+		if (location.precision === "unresolved" || location.resolution === "unresolved") {
+			throw new Error("unresolved locations cannot contain plottable coordinates");
+		}
+	}
+	if (!Array.isArray(location.sources)) throw new Error("location sources are required");
+	const sources = location.sources.map((source, index): MapLocationSourceV1 => {
+		if (!source || typeof source !== "object") throw new Error(`sources[${index}] must be an object`);
+		const candidate = source as Partial<MapLocationSourceV1>;
+		const url = requiredString(candidate.url, `sources[${index}].url`);
+		let parsed: URL;
+		try {
+			parsed = new URL(url);
+		} catch {
+			throw new Error(`sources[${index}].url must be a valid URL`);
+		}
+		if (parsed.protocol !== "https:") throw new Error(`sources[${index}].url must use HTTPS`);
+		const observedAt = requiredString(candidate.observedAt, `sources[${index}].observedAt`, 64);
+		if (!Number.isFinite(Date.parse(observedAt))) throw new Error(`sources[${index}].observedAt must be an ISO time`);
+		return {
+			url: parsed.toString(),
+			sourceName: requiredString(candidate.sourceName, `sources[${index}].sourceName`, 256),
+			observedAt,
+			claim: requiredString(candidate.claim, `sources[${index}].claim`, 2048),
+		};
+	});
+	if (hasLongitude && sources.length === 0) throw new Error("plottable coordinates require provenance");
+	return {
+		id,
+		label,
+		longitude: location.longitude,
+		latitude: location.latitude,
+		precision: location.precision!,
+		resolution: location.resolution!,
+		confidence: location.confidence!,
+		sources,
+	};
+}
+
+export function projectWebMercator(longitude: number, latitude: number): { x: number; y: number } {
+	const x = (longitude + 180) / 360;
+	const clampedLatitude = Math.max(-MAX_WEB_MERCATOR_LATITUDE, Math.min(MAX_WEB_MERCATOR_LATITUDE, latitude));
+	const radians = (clampedLatitude * Math.PI) / 180;
+	const y = (1 - Math.asinh(Math.tan(radians)) / Math.PI) / 2;
+	return { x, y };
+}
+
+/** Choose the smallest circular longitude interval, so antimeridian neighbors remain neighbors. */
+export function fitMapLocations(locations: readonly MapLocationV1[]): FittedMapLocations {
+	const projected = locations
+		.filter(location => location.longitude !== undefined && location.latitude !== undefined)
+		.map(location => ({ location, ...projectWebMercator(location.longitude!, location.latitude!) }));
+	if (projected.length === 0) throw new Error("no resolved locations are available to plot");
+	const sortedX = [...projected].sort((a, b) => a.x - b.x || a.location.id.localeCompare(b.location.id));
+	let largestGap = -1;
+	let cut = 0;
+	for (let index = 0; index < sortedX.length; index++) {
+		const current = sortedX[index]!.x;
+		const next = index === sortedX.length - 1 ? sortedX[0]!.x + 1 : sortedX[index + 1]!.x;
+		const gap = next - current;
+		if (gap > largestGap) {
+			largestGap = gap;
+			cut = index === sortedX.length - 1 ? sortedX[0]!.x : sortedX[index + 1]!.x;
+		}
+	}
+	const fitted = projected.map(({ location, x, y }) => ({
+		location,
+		worldX: x < cut ? x + 1 : x,
+		worldY: y,
+	}));
+	let minX = Math.min(...fitted.map(point => point.worldX));
+	let maxX = Math.max(...fitted.map(point => point.worldX));
+	let minY = Math.min(...fitted.map(point => point.worldY));
+	let maxY = Math.max(...fitted.map(point => point.worldY));
+	const minimumSpan = 1 / 128;
+	if (maxX - minX < minimumSpan) {
+		const center = (minX + maxX) / 2;
+		minX = center - minimumSpan / 2;
+		maxX = center + minimumSpan / 2;
+	}
+	if (maxY - minY < minimumSpan) {
+		const center = (minY + maxY) / 2;
+		minY = center - minimumSpan / 2;
+		maxY = center + minimumSpan / 2;
+	}
+	return { locations: fitted, minX, maxX, minY, maxY, spanX: maxX - minX, spanY: maxY - minY };
+}

--- a/packages/coding-agent/src/media/ingest.ts
+++ b/packages/coding-agent/src/media/ingest.ts
@@ -36,6 +36,18 @@ export interface IngestedMedia {
 	posterMimeType?: string;
 }
 
+export interface GeneratedMediaInput {
+	data: Uint8Array;
+	mimeType: string;
+	width: number;
+	height: number;
+	filenameHint: string;
+	metadata?: Record<string, string>;
+	caption?: string;
+	alt?: string;
+	provenance: { sourceType: "tool"; source: string };
+}
+
 export interface MediaIngestorOptions {
 	cwd: string;
 	blobStore: BlobStore;
@@ -126,6 +138,45 @@ export class MediaIngestor {
 	async #put(data: Buffer, mimeType: string): Promise<MediaAssetRefV1> {
 		const stored = await this.#options.blobStore.put(data);
 		return asAsset(stored.ref, mimeType, data.byteLength);
+	}
+
+	/** Ingest bytes produced by a trusted built-in without creating an intermediate file. */
+	async ingestBuffer(input: GeneratedMediaInput, signal?: AbortSignal): Promise<IngestedMedia> {
+		signal?.throwIfAborted();
+		const data = Buffer.from(input.data);
+		if (data.byteLength === 0 || data.byteLength > this.#options.maxBytes) {
+			throw new MediaIngestError(`generated media must be within the ${this.#options.maxBytes} byte limit`);
+		}
+		const sniffed = sniffMedia(data);
+		if (sniffed?.kind !== "image") throw new MediaIngestError("generated media must be a valid image");
+		if (sniffed.mimeType !== input.mimeType) {
+			throw new MediaIngestError(
+				`generated media MIME mismatch: declared ${input.mimeType}, content is ${sniffed.mimeType}`,
+			);
+		}
+		if (sniffed.width !== input.width || sniffed.height !== input.height) {
+			throw new MediaIngestError("generated media dimensions do not match the encoded image");
+		}
+		if (input.provenance.sourceType !== "tool" || !input.provenance.source.trim()) {
+			throw new MediaIngestError("generated media requires tool provenance");
+		}
+		const original = await this.#put(data, sniffed.mimeType);
+		const descriptor = validateMediaDescriptorV1({
+			version: 1,
+			id: createMediaId(original.ref.slice("blob:sha256:".length)),
+			kind: "image",
+			width: input.width,
+			height: input.height,
+			caption: input.caption,
+			alt: input.alt,
+			original,
+			poster: original,
+			provenance: input.provenance,
+			playback: { autoplay: true, loop: false, muted: true, fpsCap: 12 },
+			filenameHint: path.basename(input.filenameHint),
+			metadata: input.metadata,
+		});
+		return { descriptor, posterData: data.toString("base64"), posterMimeType: sniffed.mimeType };
 	}
 
 	async #ingestTimeline(input: DisplayMediaInput, signal?: AbortSignal): Promise<IngestedMedia> {

--- a/packages/coding-agent/src/media/publish.ts
+++ b/packages/coding-agent/src/media/publish.ts
@@ -1,16 +1,11 @@
 import type { AgentToolResult } from "@f5-sales-demo/pi-agent-core";
 import type { ImageContent, TextContent } from "@f5-sales-demo/pi-ai";
 import type { IngestedMedia } from "./ingest";
-import type { MediaDescriptorV1, MediaMessage } from "./types";
+import { MEDIA_TOOL_RESULT_V1, type MediaToolResultV1, validateMediaToolResultV1 } from "./tool-result";
+import type { MediaMessage } from "./types";
 import { validateMediaDescriptorV1 } from "./types";
 
-export const MEDIA_TOOL_RESULT_V1 = "xcsh.media/v1" as const;
-
-export interface MediaToolResultV1 {
-	mediaResult: typeof MEDIA_TOOL_RESULT_V1;
-	descriptor: MediaDescriptorV1;
-	displayMethod: "inline" | "poster" | "text";
-}
+export { MEDIA_TOOL_RESULT_V1, type MediaToolResultV1, validateMediaToolResultV1 } from "./tool-result";
 
 export interface MediaPublisherSession {
 	appendMediaMessage?: (message: MediaMessage) => void;
@@ -19,18 +14,6 @@ export interface MediaPublisherSession {
 export interface PublishMediaOptions {
 	text?: string[];
 	timestamp?: number;
-}
-
-export function validateMediaToolResultV1(value: unknown): MediaToolResultV1 {
-	if (!value || typeof value !== "object") throw new Error("media tool result must be an object");
-	const result = value as Partial<MediaToolResultV1>;
-	if (result.mediaResult !== MEDIA_TOOL_RESULT_V1) throw new Error("unsupported media tool result version");
-	if (!result.descriptor) throw new Error("media tool result requires a descriptor");
-	const descriptor = validateMediaDescriptorV1(result.descriptor);
-	if (!(["inline", "poster", "text"] as const).includes(result.displayMethod as never)) {
-		throw new Error("invalid media display method");
-	}
-	return { mediaResult: MEDIA_TOOL_RESULT_V1, descriptor, displayMethod: result.displayMethod! };
 }
 
 /**

--- a/packages/coding-agent/src/media/publish.ts
+++ b/packages/coding-agent/src/media/publish.ts
@@ -1,0 +1,65 @@
+import type { AgentToolResult } from "@f5-sales-demo/pi-agent-core";
+import type { ImageContent, TextContent } from "@f5-sales-demo/pi-ai";
+import type { IngestedMedia } from "./ingest";
+import type { MediaDescriptorV1, MediaMessage } from "./types";
+import { validateMediaDescriptorV1 } from "./types";
+
+export const MEDIA_TOOL_RESULT_V1 = "xcsh.media/v1" as const;
+
+export interface MediaToolResultV1 {
+	mediaResult: typeof MEDIA_TOOL_RESULT_V1;
+	descriptor: MediaDescriptorV1;
+	displayMethod: "inline" | "poster" | "text";
+}
+
+export interface MediaPublisherSession {
+	appendMediaMessage?: (message: MediaMessage) => void;
+}
+
+export interface PublishMediaOptions {
+	text?: string[];
+	timestamp?: number;
+}
+
+export function validateMediaToolResultV1(value: unknown): MediaToolResultV1 {
+	if (!value || typeof value !== "object") throw new Error("media tool result must be an object");
+	const result = value as Partial<MediaToolResultV1>;
+	if (result.mediaResult !== MEDIA_TOOL_RESULT_V1) throw new Error("unsupported media tool result version");
+	if (!result.descriptor) throw new Error("media tool result requires a descriptor");
+	const descriptor = validateMediaDescriptorV1(result.descriptor);
+	if (!(["inline", "poster", "text"] as const).includes(result.displayMethod as never)) {
+		throw new Error("invalid media display method");
+	}
+	return { mediaResult: MEDIA_TOOL_RESULT_V1, descriptor, displayMethod: result.displayMethod! };
+}
+
+/**
+ * Canonical publication boundary for all media producers. It validates the durable descriptor,
+ * appends exactly one transcript MediaMessage, and returns the standard versioned tool result.
+ */
+export function publishMedia(
+	session: MediaPublisherSession,
+	ingested: IngestedMedia,
+	options: PublishMediaOptions = {},
+): AgentToolResult<MediaToolResultV1> {
+	const descriptor = validateMediaDescriptorV1(ingested.descriptor);
+	const message: MediaMessage = { role: "media", media: descriptor, timestamp: options.timestamp ?? Date.now() };
+	session.appendMediaMessage?.(message);
+
+	const content: Array<TextContent | ImageContent> = [];
+	let displayMethod: MediaToolResultV1["displayMethod"] = "text";
+	if (ingested.posterData && ingested.posterMimeType) {
+		content.push({ type: "image", data: ingested.posterData, mimeType: ingested.posterMimeType });
+		displayMethod = descriptor.kind === "image" ? "inline" : "poster";
+	}
+	for (const value of options.text ?? []) {
+		if (value) content.push({ type: "text", text: value });
+	}
+	if (descriptor.degradation) content.push({ type: "text", text: descriptor.degradation });
+	if (content.length === 0) content.push({ type: "text", text: `Media ready: ${descriptor.id}` });
+
+	return {
+		content,
+		details: validateMediaToolResultV1({ mediaResult: MEDIA_TOOL_RESULT_V1, descriptor, displayMethod }),
+	};
+}

--- a/packages/coding-agent/src/media/tool-result.ts
+++ b/packages/coding-agent/src/media/tool-result.ts
@@ -1,0 +1,22 @@
+import type { MediaDescriptorV1 } from "./types";
+import { validateMediaDescriptorV1 } from "./types";
+
+export const MEDIA_TOOL_RESULT_V1 = "xcsh.media/v1" as const;
+
+export interface MediaToolResultV1 {
+	mediaResult: typeof MEDIA_TOOL_RESULT_V1;
+	descriptor: MediaDescriptorV1;
+	displayMethod: "inline" | "poster" | "text";
+}
+
+export function validateMediaToolResultV1(value: unknown): MediaToolResultV1 {
+	if (!value || typeof value !== "object") throw new Error("media tool result must be an object");
+	const result = value as Partial<MediaToolResultV1>;
+	if (result.mediaResult !== MEDIA_TOOL_RESULT_V1) throw new Error("unsupported media tool result version");
+	if (!result.descriptor) throw new Error("media tool result requires a descriptor");
+	const descriptor = validateMediaDescriptorV1(result.descriptor);
+	if (!(["inline", "poster", "text"] as const).includes(result.displayMethod as never)) {
+		throw new Error("invalid media display method");
+	}
+	return { mediaResult: MEDIA_TOOL_RESULT_V1, descriptor, displayMethod: result.displayMethod! };
+}

--- a/packages/coding-agent/src/media/transport.ts
+++ b/packages/coding-agent/src/media/transport.ts
@@ -1,5 +1,6 @@
 import type { BlobStore } from "../session/blob-store";
 import { parseBlobRef } from "../session/blob-store";
+import { validateMediaToolResultV1 } from "./publish";
 import type { MediaAssetRefV1, MediaDescriptorV1 } from "./types";
 import { sanitizeMediaProvenance, validateMediaDescriptorV1 } from "./types";
 
@@ -30,7 +31,7 @@ export function projectMediaDescriptorForTransport(descriptor: MediaDescriptorV1
 		} catch {
 			projected.provenance = { sourceType: "tool", source: "display_media" };
 		}
-	} else {
+	} else if (projected.provenance.sourceType !== "tool") {
 		projected.provenance = { sourceType: "tool", source: "display_media" };
 	}
 	return projected;
@@ -72,9 +73,8 @@ export function extractMediaDescriptorFromToolResult(result: unknown): MediaDesc
 	if (!result || typeof result !== "object") return undefined;
 	const details = (result as { details?: unknown }).details;
 	if (!details || typeof details !== "object") return undefined;
-	const descriptor = (details as { descriptor?: unknown }).descriptor;
 	try {
-		return descriptor ? validateMediaDescriptorV1(descriptor) : undefined;
+		return validateMediaToolResultV1(details).descriptor;
 	} catch {
 		return undefined;
 	}

--- a/packages/coding-agent/src/media/transport.ts
+++ b/packages/coding-agent/src/media/transport.ts
@@ -1,6 +1,6 @@
 import type { BlobStore } from "../session/blob-store";
 import { parseBlobRef } from "../session/blob-store";
-import { validateMediaToolResultV1 } from "./publish";
+import { validateMediaToolResultV1 } from "./tool-result";
 import type { MediaAssetRefV1, MediaDescriptorV1 } from "./types";
 import { sanitizeMediaProvenance, validateMediaDescriptorV1 } from "./types";
 

--- a/packages/coding-agent/src/media/types.ts
+++ b/packages/coding-agent/src/media/types.ts
@@ -45,6 +45,10 @@ export interface MediaDescriptorV1 {
 	provenance: MediaProvenanceV1;
 	playback: MediaPlaybackV1;
 	degradation?: string;
+	/** Sanitized producer-supplied filename used only as a presentation hint. */
+	filenameHint?: string;
+	/** Bounded, non-secret producer metadata retained with the durable descriptor. */
+	metadata?: Record<string, string>;
 }
 
 export interface MediaMessage {
@@ -111,8 +115,39 @@ export function validateMediaDescriptorV1(value: unknown): MediaDescriptorV1 {
 	if (descriptor.width !== undefined) assertPositiveInteger(descriptor.width, "width");
 	if (descriptor.height !== undefined) assertPositiveInteger(descriptor.height, "height");
 	if (descriptor.durationMs !== undefined) assertPositiveInteger(descriptor.durationMs, "durationMs");
-	if (!descriptor.provenance || typeof descriptor.provenance.source !== "string") {
+	if (descriptor.filenameHint !== undefined) {
+		if (
+			typeof descriptor.filenameHint !== "string" ||
+			descriptor.filenameHint.length === 0 ||
+			descriptor.filenameHint.length > 255 ||
+			descriptor.filenameHint.includes("/") ||
+			descriptor.filenameHint.includes("\\")
+		) {
+			throw new Error("filenameHint must be a basename of at most 255 characters");
+		}
+	}
+	if (descriptor.metadata !== undefined) {
+		if (!descriptor.metadata || typeof descriptor.metadata !== "object" || Array.isArray(descriptor.metadata)) {
+			throw new Error("media metadata must be an object");
+		}
+		const entries = Object.entries(descriptor.metadata);
+		if (entries.length > 16) throw new Error("media metadata is limited to 16 entries");
+		for (const [key, value] of entries) {
+			if (!/^[a-zA-Z0-9_.-]{1,64}$/u.test(key) || typeof value !== "string" || value.length > 512) {
+				throw new Error("media metadata keys or values are invalid");
+			}
+		}
+	}
+	if (
+		!descriptor.provenance ||
+		!["path", "artifact", "url", "timeline", "tool"].includes(String(descriptor.provenance.sourceType)) ||
+		typeof descriptor.provenance.source !== "string" ||
+		!descriptor.provenance.source
+	) {
 		throw new Error("media provenance is required");
+	}
+	if (descriptor.provenance.sourceType === "tool" && !/^[a-z][a-z0-9_]{0,63}$/u.test(descriptor.provenance.source)) {
+		throw new Error("media tool provenance is invalid");
 	}
 	if (descriptor.playback?.muted !== true) throw new Error("media playback must be muted");
 	if (typeof descriptor.playback.autoplay !== "boolean" || typeof descriptor.playback.loop !== "boolean") {

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -157,8 +157,7 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 			return [toSessionNotification(sessionId, update)];
 		}
 		case "tool_execution_end": {
-			const descriptor =
-				event.toolName === "display_media" ? extractMediaDescriptorFromToolResult(event.result) : undefined;
+			const descriptor = extractMediaDescriptorFromToolResult(event.result);
 			const content = descriptor
 				? extractStructuredToolCallContent(event.result)
 				: extractToolCallContent(event.result);
@@ -177,7 +176,13 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 				});
 			}
 			const rawOutput = projected
-				? { ...(event.result as object), details: { descriptor: projected } }
+				? {
+						...(event.result as object),
+						details: {
+							...((event.result as { details?: object }).details ?? {}),
+							descriptor: projected,
+						},
+					}
 				: event.result;
 			const update: SessionUpdate = {
 				sessionUpdate: "tool_call_update",

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -504,11 +504,20 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 
 	// Output all agent events as JSON
 	session.subscribe(event => {
-		const isMediaTool = event.type === "tool_execution_end" && event.toolName === "display_media";
-		const descriptor = isMediaTool ? extractMediaDescriptorFromToolResult(event.result) : undefined;
+		const descriptor =
+			event.type === "tool_execution_end" ? extractMediaDescriptorFromToolResult(event.result) : undefined;
 		const projected = descriptor ? projectMediaDescriptorForTransport(descriptor) : undefined;
 		if (event.type === "tool_execution_end" && projected) {
-			output({ ...event, result: { ...(event.result as object), details: { descriptor: projected } } });
+			output({
+				...event,
+				result: {
+					...(event.result as object),
+					details: {
+						...((event.result as { details?: object }).details ?? {}),
+						descriptor: projected,
+					},
+				},
+			});
 			output({ type: "chat_media", media: projected });
 		} else {
 			output(event);

--- a/packages/coding-agent/src/prompts/tools/render-map.md
+++ b/packages/coding-agent/src/prompts/tools/render-map.md
@@ -1,0 +1,13 @@
+Generate one deterministic static map from normalized, current-request location evidence.
+
+Every plotted longitude/latitude pair must include at least one consulted source URL, source name,
+observation time, and coordinate-supporting claim. Keep unresolved locations in the input so they
+remain visible in the textual evidence; they are never plotted. Use `metro` or `approximate` for
+representative metro coordinates and `inferred` for indirect conclusions. Never use model memory as
+coordinate evidence.
+
+The default OpenStreetMap basemap fetches only viewport tiles outside Chrome and falls back to a
+schematic map. The generated PNG is published through the canonical media service in this same tool
+call. Do not call `display_media` afterward. No user-visible files are created unless `savePath` is
+provided; saving writes matching `.png` and `.geojson` files and requires `overwrite=true` when
+either target already exists.

--- a/packages/coding-agent/src/sandbox/enforce.ts
+++ b/packages/coding-agent/src/sandbox/enforce.ts
@@ -65,6 +65,7 @@ const TOOL_PATHS: Record<string, PathArgSpec[]> = {
 	write: [{ keys: ["file_path", "path"], access: "write" }],
 	notebook: [{ keys: ["notebook_path"], access: "write" }],
 	inspect_image: [{ keys: ["path"], access: "read" }],
+	render_map: [{ keys: ["savePath"], access: "write" }],
 	lsp: [{ keys: ["file"], access: "read" }], // read for most actions; rename-apply writes
 	catalog_workflow_runner: [
 		{ keys: ["catalog_path"], access: "read" },

--- a/packages/coding-agent/src/tools/display-media-renderer.ts
+++ b/packages/coding-agent/src/tools/display-media-renderer.ts
@@ -10,15 +10,22 @@ interface DisplayMediaRenderArgs {
 	source?: string;
 	frames?: unknown[];
 	caption?: string;
+	title?: string;
+	locations?: unknown[];
 }
 
 interface DisplayMediaRendererResult {
 	content: Array<{ type: string; text?: string }>;
-	details?: { descriptor: MediaDescriptorV1; displayMethod: "inline" | "poster" | "text" };
+	details?: {
+		mediaResult: "xcsh.media/v1";
+		descriptor: MediaDescriptorV1;
+		displayMethod: "inline" | "poster" | "text";
+	};
 	isError?: boolean;
 }
 
 function description(args: DisplayMediaRenderArgs): string {
+	if (args.title) return `${args.title}${args.locations ? ` (${args.locations.length} locations)` : ""}`;
 	if (args.source) return shortenPath(args.source);
 	if (args.frames) return `${args.frames.length} timeline frame${args.frames.length === 1 ? "" : "s"}`;
 	return "media";

--- a/packages/coding-agent/src/tools/display-media.ts
+++ b/packages/coding-agent/src/tools/display-media.ts
@@ -4,11 +4,10 @@ import type {
 	AgentToolResult,
 	AgentToolUpdateCallback,
 } from "@f5-sales-demo/pi-agent-core";
-import type { ImageContent, TextContent } from "@f5-sales-demo/pi-ai";
 import { getBlobsDir, prompt } from "@f5-sales-demo/pi-utils";
 import { type Static, Type } from "@sinclair/typebox";
 import { type DisplayMediaInput, type IngestedMedia, MediaIngestError, MediaIngestor } from "../media/ingest";
-import type { MediaDescriptorV1, MediaMessage } from "../media/types";
+import { type MediaToolResultV1, publishMedia } from "../media/publish";
 import displayMediaDescription from "../prompts/tools/display-media.md" with { type: "text" };
 import { BlobStore } from "../session/blob-store";
 import type { ToolSession } from "./index";
@@ -42,10 +41,7 @@ const displayMediaSchema = Type.Object(
 
 export type DisplayMediaParams = Static<typeof displayMediaSchema>;
 
-export interface DisplayMediaToolDetails {
-	descriptor: MediaDescriptorV1;
-	displayMethod: "inline" | "poster" | "text";
-}
+export type DisplayMediaToolDetails = MediaToolResultV1;
 
 export class DisplayMediaTool implements AgentTool<typeof displayMediaSchema, DisplayMediaToolDetails> {
 	readonly name = "display_media";
@@ -82,21 +78,7 @@ export class DisplayMediaTool implements AgentTool<typeof displayMediaSchema, Di
 			throw error;
 		}
 
-		const message: MediaMessage = { role: "media", media: ingested.descriptor, timestamp: Date.now() };
-		this.session.appendMediaMessage?.(message);
-
-		const content: Array<TextContent | ImageContent> = [];
-		let displayMethod: DisplayMediaToolDetails["displayMethod"] = "text";
-		if (ingested.posterData && ingested.posterMimeType) {
-			content.push({ type: "image", data: ingested.posterData, mimeType: ingested.posterMimeType });
-			displayMethod = ingested.descriptor.kind === "image" ? "inline" : "poster";
-		}
-		if (params.caption) content.push({ type: "text", text: params.caption });
-		if (ingested.descriptor.degradation) content.push({ type: "text", text: ingested.descriptor.degradation });
-		if (content.length === 0) {
-			content.push({ type: "text", text: `Media ready: ${ingested.descriptor.id}` });
-		}
-		return { content, details: { descriptor: ingested.descriptor, displayMethod } };
+		return publishMedia(this.session, ingested, { text: params.caption ? [params.caption] : [] });
 	}
 }
 

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -39,6 +39,7 @@ import { wrapToolWithMetaNotice } from "./output-meta";
 import { PollTool } from "./poll-tool";
 import { PythonTool } from "./python";
 import { ReadTool } from "./read";
+import { RenderMapTool } from "./render-map";
 import { RenderMermaidTool } from "./render-mermaid";
 import { createReportToolIssueTool, isAutoQaEnabled } from "./report-tool-issue";
 import { ResolveTool } from "./resolve";
@@ -80,6 +81,7 @@ export * from "./notebook";
 export * from "./poll-tool";
 export * from "./python";
 export * from "./read";
+export * from "./render-map";
 export * from "./render-mermaid";
 export * from "./report-tool-issue";
 export * from "./resolve";
@@ -227,6 +229,7 @@ export const BUILTIN_TOOLS: Record<string, ToolFactory> = {
 	notebook: s => new NotebookTool(s),
 	read: s => new ReadTool(s),
 	display_media: s => new DisplayMediaTool(s),
+	render_map: s => new RenderMapTool(s),
 	inspect_image: s => new InspectImageTool(s),
 	browser: s => new BrowserTool(s),
 	catalog_workflow_runner: s => new CatalogWorkflowRunnerTool(s),

--- a/packages/coding-agent/src/tools/render-map.ts
+++ b/packages/coding-agent/src/tools/render-map.ts
@@ -1,0 +1,247 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type {
+	AgentTool,
+	AgentToolContext,
+	AgentToolResult,
+	AgentToolUpdateCallback,
+} from "@f5-sales-demo/pi-agent-core";
+import { getBlobsDir, prompt } from "@f5-sales-demo/pi-utils";
+import { type Static, Type } from "@sinclair/typebox";
+import { MAP_HEIGHT, MAP_WIDTH, type RenderedMap, renderMap } from "../map/render";
+import {
+	MAP_CONFIDENCES,
+	MAP_PRECISIONS,
+	MAP_RESOLUTIONS,
+	type MapLocationV1,
+	validateMapLocationV1,
+} from "../map/types";
+import { MediaIngestError, MediaIngestor } from "../media/ingest";
+import { type MediaToolResultV1, publishMedia } from "../media/publish";
+import renderMapDescription from "../prompts/tools/render-map.md" with { type: "text" };
+import { BlobStore } from "../session/blob-store";
+import type { ToolSession } from "./index";
+import { ToolError } from "./tool-errors";
+
+export type {
+	MapConfidence,
+	MapLocationSourceV1,
+	MapLocationV1,
+	MapPrecision,
+	MapResolution,
+} from "../map/types";
+
+const sourceSchema = Type.Object(
+	{
+		url: Type.String(),
+		sourceName: Type.String(),
+		observedAt: Type.String(),
+		claim: Type.String(),
+	},
+	{ additionalProperties: false },
+);
+
+const locationSchema = Type.Object(
+	{
+		id: Type.String(),
+		label: Type.String(),
+		longitude: Type.Optional(Type.Number({ minimum: -180, maximum: 180 })),
+		latitude: Type.Optional(Type.Number({ minimum: -90, maximum: 90 })),
+		precision: Type.Union(MAP_PRECISIONS.map(value => Type.Literal(value))),
+		resolution: Type.Union(MAP_RESOLUTIONS.map(value => Type.Literal(value))),
+		confidence: Type.Union(MAP_CONFIDENCES.map(value => Type.Literal(value))),
+		sources: Type.Array(sourceSchema),
+	},
+	{ additionalProperties: false },
+);
+
+const renderMapSchema = Type.Object(
+	{
+		title: Type.String({ minLength: 1, maxLength: 256 }),
+		locations: Type.Array(locationSchema, { minItems: 1, maxItems: 500 }),
+		basemap: Type.Optional(Type.Union([Type.Literal("osm"), Type.Literal("schematic")], { default: "osm" })),
+		savePath: Type.Optional(Type.String({ description: "Base path for explicit .png and .geojson export" })),
+		overwrite: Type.Optional(Type.Boolean({ default: false })),
+	},
+	{ additionalProperties: false },
+);
+
+export type RenderMapParams = Static<typeof renderMapSchema>;
+
+export interface RenderMapDependencies {
+	render?: (request: {
+		title: string;
+		locations: MapLocationV1[];
+		basemap: "osm" | "schematic";
+		signal?: AbortSignal;
+		settings?: { get(key: string): unknown };
+	}) => Promise<RenderedMap>;
+}
+
+function evidenceText(title: string, locations: readonly MapLocationV1[], degradation?: string): string {
+	const lines = [`${title} — location evidence`];
+	locations.forEach((location, index) => {
+		const coordinate =
+			location.longitude === undefined
+				? "unresolved; not plotted"
+				: `${location.latitude!.toFixed(5)}, ${location.longitude.toFixed(5)}`;
+		lines.push(
+			`${index + 1}. ${location.label} [${location.precision}/${location.resolution}; ${location.confidence}] — ${coordinate}`,
+		);
+		for (const source of location.sources) {
+			lines.push(`   ${source.sourceName} (${source.observedAt}): ${source.claim} ${source.url}`);
+		}
+	});
+	if (degradation) lines.push(`Fallback: ${degradation}`);
+	return lines.join("\n");
+}
+
+function geoJson(title: string, locations: readonly MapLocationV1[]): string {
+	return `${JSON.stringify(
+		{
+			type: "FeatureCollection",
+			name: title,
+			features: locations.map(location => ({
+				type: "Feature",
+				id: location.id,
+				geometry:
+					location.longitude === undefined
+						? null
+						: { type: "Point", coordinates: [location.longitude, location.latitude] },
+				properties: {
+					label: location.label,
+					precision: location.precision,
+					resolution: location.resolution,
+					confidence: location.confidence,
+					sources: location.sources,
+				},
+			})),
+		},
+		null,
+		2,
+	)}\n`;
+}
+
+function exportPaths(cwd: string, requested: string): { png: string; geojson: string } {
+	const resolved = path.isAbsolute(requested) ? path.normalize(requested) : path.resolve(cwd, requested);
+	const base = resolved.replace(/\.(?:png|geojson)$/iu, "");
+	if (!path.basename(base)) throw new ToolError("savePath must name an output file base");
+	return { png: `${base}.png`, geojson: `${base}.geojson` };
+}
+
+async function exists(file: string): Promise<boolean> {
+	try {
+		await fs.access(file);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function saveMap(
+	cwd: string,
+	requested: string,
+	overwrite: boolean,
+	png: Buffer,
+	geojson: string,
+): Promise<{ png: string; geojson: string }> {
+	const targets = exportPaths(cwd, requested);
+	if (!overwrite && ((await exists(targets.png)) || (await exists(targets.geojson)))) {
+		throw new ToolError("map output exists; set overwrite=true to replace both files");
+	}
+	await fs.mkdir(path.dirname(targets.png), { recursive: true });
+	const nonce = `${process.pid}-${Date.now()}`;
+	const pngTemporary = `${targets.png}.${nonce}.tmp`;
+	const geojsonTemporary = `${targets.geojson}.${nonce}.tmp`;
+	try {
+		await Promise.all([Bun.write(pngTemporary, png), Bun.write(geojsonTemporary, geojson)]);
+		await fs.rename(geojsonTemporary, targets.geojson);
+		await fs.rename(pngTemporary, targets.png);
+	} finally {
+		await Promise.all([fs.rm(pngTemporary, { force: true }), fs.rm(geojsonTemporary, { force: true })]);
+	}
+	return targets;
+}
+
+export class RenderMapTool implements AgentTool<typeof renderMapSchema, MediaToolResultV1> {
+	readonly name = "render_map";
+	readonly label = "RenderMap";
+	readonly description = prompt.render(renderMapDescription);
+	readonly parameters = renderMapSchema;
+	readonly strict = true;
+
+	constructor(
+		private readonly session: ToolSession,
+		private readonly dependencies: RenderMapDependencies = {},
+	) {}
+
+	async execute(
+		_toolCallId: string,
+		params: RenderMapParams,
+		signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<MediaToolResultV1>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<MediaToolResultV1>> {
+		const locations = params.locations.map(validateMapLocationV1);
+		const plottable = locations.filter(location => location.longitude !== undefined);
+		if (plottable.length === 0 || this.session.settings.get("images.blockImages")) {
+			const reason =
+				plottable.length === 0
+					? "No locations had provenance-backed coordinates, so no image was generated."
+					: "Media display is disabled by settings; no image was generated.";
+			return { content: [{ type: "text", text: evidenceText(params.title, locations, reason) }] };
+		}
+
+		let rendered: RenderedMap;
+		try {
+			rendered = await (this.dependencies.render ?? renderMap)({
+				title: params.title,
+				locations: plottable,
+				basemap: params.basemap ?? "osm",
+				signal,
+				settings: this.session.settings,
+			});
+		} catch (error) {
+			const reason = `Graphical generation failed; evidence remains available (${error instanceof Error ? error.message : String(error)}).`;
+			return { content: [{ type: "text", text: evidenceText(params.title, locations, reason) }] };
+		}
+
+		let saved: { png: string; geojson: string } | undefined;
+		if (params.savePath) {
+			saved = await saveMap(
+				this.session.cwd,
+				params.savePath,
+				params.overwrite ?? false,
+				rendered.png,
+				geoJson(params.title, locations),
+			);
+		}
+		const ingestor = new MediaIngestor({
+			cwd: this.session.cwd,
+			blobStore: this.session.mediaBlobStore ?? new BlobStore(getBlobsDir()),
+			internalRouter: this.session.internalRouter,
+		});
+		try {
+			const ingested = await ingestor.ingestBuffer(
+				{
+					data: rendered.png,
+					mimeType: "image/png",
+					width: MAP_WIDTH,
+					height: MAP_HEIGHT,
+					filenameHint: "map.png",
+					metadata: { producer: "render_map", basemap: rendered.basemap },
+					caption: params.title,
+					alt: `Map titled ${params.title} with ${plottable.length} plotted locations`,
+					provenance: { sourceType: "tool", source: "render_map" },
+				},
+				signal,
+			);
+			const text = evidenceText(params.title, locations, rendered.degradation);
+			const saveNotice = saved ? `Saved PNG: ${saved.png}\nSaved GeoJSON: ${saved.geojson}` : undefined;
+			return publishMedia(this.session, ingested, { text: saveNotice ? [text, saveNotice] : [text] });
+		} catch (error) {
+			if (error instanceof MediaIngestError) throw new ToolError(error.message);
+			throw error;
+		}
+	}
+}

--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -60,6 +60,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
 	lsp: lspToolRenderer as ToolRenderer,
 	notebook: notebookToolRenderer as ToolRenderer,
 	display_media: displayMediaToolRenderer as ToolRenderer,
+	render_map: displayMediaToolRenderer as ToolRenderer,
 	inspect_image: inspectImageToolRenderer as ToolRenderer,
 	read: readToolRenderer as ToolRenderer,
 	resolve: resolveToolRenderer as ToolRenderer,

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -63,7 +63,7 @@ describe("ACP event mapper", () => {
 	});
 });
 
-it("maps display_media to standard image and sanitized resource content", () => {
+it("maps a validated media result from any producer to standard image and sanitized resource content", () => {
 	const hash = "c".repeat(64);
 	const descriptor = {
 		version: 1 as const,
@@ -77,10 +77,10 @@ it("maps display_media to standard image and sanitized resource content", () => 
 		{
 			type: "tool_execution_end",
 			toolCallId: "call-1",
-			toolName: "display_media",
+			toolName: "render_map",
 			result: {
 				content: [{ type: "image", data: "aW1n", mimeType: "image/png" }],
-				details: { descriptor },
+				details: { mediaResult: "xcsh.media/v1", descriptor, displayMethod: "inline" },
 			},
 		} as AgentSessionEvent,
 		"session-1",

--- a/packages/coding-agent/test/browser/chat-conformance.test.ts
+++ b/packages/coding-agent/test/browser/chat-conformance.test.ts
@@ -119,6 +119,17 @@ describe("chat-conformance: xcsh host-tool guards accept/reject the goldens", ()
 });
 
 describe("chat-conformance: xcsh outbound frames validate against schemas", () => {
+	it("chat_media accepts a validated generated-media producer", () => {
+		const frame = structuredClone(validExamples.chat_media) as {
+			media: { provenance: { source: string }; filenameHint?: string; metadata?: Record<string, string> };
+		};
+		frame.media.provenance.source = "render_map";
+		frame.media.filenameHint = "map.png";
+		frame.media.metadata = { producer: "render_map", basemap: "schematic" };
+		const validate = ajv.compile(schemas.chat_media);
+		expect(validate(frame)).toBe(true);
+	});
+
 	it("chat_delta frame validates", () => {
 		const frame = { type: "chat_delta", id: "c-test", seq: 0, delta: "hello" };
 		const validate = ajv.compile(schemas.chat_delta);

--- a/packages/coding-agent/test/browser/chat-handler.host-tools.test.ts
+++ b/packages/coding-agent/test/browser/chat-handler.host-tools.test.ts
@@ -257,3 +257,52 @@ describe("chat_tool_notice ok-flag reflects tool_execution_end.isError", () => {
 		expect(String(end?.detail)).toContain("done");
 	});
 });
+
+describe("chat_media uses the versioned result contract", () => {
+	it("forwards media from render_map without a display_media tool-name special case", async () => {
+		const hash = "d".repeat(64);
+		class MediaSession {
+			isStreaming = false;
+			readonly slashCommands = [];
+			agent = { abort(): void {}, replaceMessages(): void {} };
+			#callbacks: Array<(event: unknown) => void> = [];
+			subscribe(callback: (event: unknown) => void): () => void {
+				this.#callbacks.push(callback);
+				return () => {};
+			}
+			async prompt(): Promise<void> {
+				for (const callback of this.#callbacks) {
+					callback({
+						type: "tool_execution_end",
+						toolCallId: "map-1",
+						toolName: "render_map",
+						result: {
+							content: [],
+							details: {
+								mediaResult: "xcsh.media/v1",
+								displayMethod: "inline",
+								descriptor: {
+									version: 1,
+									id: `media_${"d".repeat(24)}`,
+									kind: "image",
+									original: { ref: `blob:sha256:${hash}`, mimeType: "image/png", bytes: 4 },
+									provenance: { sourceType: "tool", source: "render_map" },
+									playback: { autoplay: true, loop: false, muted: true, fpsCap: 12 },
+								},
+							},
+						},
+					});
+				}
+			}
+			async refreshRpcHostTools(): Promise<void> {}
+		}
+		const server = new FakeBridgeServer();
+		const handler = new ChatHandler(server as unknown as BridgeServer, new MediaSession() as unknown as AgentSession);
+		handler.attach();
+		server.emit({ type: "chat_request", id: "c-map", text: "show map", context: null, mode: "configuration" });
+		for (let index = 0; index < 50 && server.ofType("chat_media").length === 0; index++) await Bun.sleep(0);
+		const media = server.ofType("chat_media");
+		expect(media).toHaveLength(1);
+		expect((media[0]!.media as { id: string }).id).toBe(`media_${"d".repeat(24)}`);
+	});
+});

--- a/packages/coding-agent/test/display-media.test.ts
+++ b/packages/coding-agent/test/display-media.test.ts
@@ -36,11 +36,35 @@ test("display_media ingests a source, returns a poster, and persists a media mes
 	const result = await tool.execute("call", { source: "poster.dat", caption: "Demo" });
 
 	expect(tool.name).toBe("display_media");
+	expect(result.details?.mediaResult).toBe("xcsh.media/v1");
 	expect(result.details?.descriptor.kind).toBe("image");
 	expect(result.content).toContainEqual({ type: "image", data: png.toString("base64"), mimeType: "image/png" });
 	expect(result.content).toContainEqual({ type: "text", text: "Demo" });
 	expect(messages).toHaveLength(1);
 	expect(messages[0]!.media.id).toBe(result.details!.descriptor.id);
+});
+
+test("generated buffers use the same durable publication service", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-generated-media-"));
+	roots.push(root);
+	const png = Buffer.alloc(24);
+	png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	png.writeUInt32BE(8, 16);
+	png.writeUInt32BE(6, 20);
+	const store = new BlobStore(path.join(root, "blobs"));
+	const { MediaIngestor } = await import("../src/media/ingest");
+	const ingested = await new MediaIngestor({ cwd: root, blobStore: store }).ingestBuffer({
+		data: png,
+		mimeType: "image/png",
+		width: 8,
+		height: 6,
+		filenameHint: "map.png",
+		metadata: { producer: "render_map" },
+		provenance: { sourceType: "tool", source: "render_map" },
+	});
+	expect(ingested.descriptor.filenameHint).toBe("map.png");
+	expect(ingested.descriptor.metadata).toEqual({ producer: "render_map" });
+	expect(await store.get(ingested.descriptor.original!.ref.slice("blob:sha256:".length))).toEqual(png);
 });
 
 describe("display_media validation", () => {

--- a/packages/coding-agent/test/map-tile-cache.test.ts
+++ b/packages/coding-agent/test/map-tile-cache.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { OSM_TILE_USER_AGENT, OsmTileFetcher } from "../src/map/tile-cache";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+function png(): Buffer {
+	return Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1]);
+}
+
+describe("OSM tile cache policy", () => {
+	test("uses an identifiable client, honors freshness, and conditionally revalidates", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-osm-cache-"));
+		roots.push(root);
+		let now = 1_000;
+		const requests: Array<{ url: string; headers: Headers }> = [];
+		const responses = [
+			new Response(png(), {
+				status: 200,
+				headers: { "content-type": "image/png", "cache-control": "max-age=10", etag: '"tile-1"' },
+			}),
+			new Response(null, { status: 304, headers: { "cache-control": "max-age=20" } }),
+		];
+		const fetcher = new OsmTileFetcher({
+			cacheDir: root,
+			now: () => now,
+			fetch: async (input, init) => {
+				requests.push({ url: String(input), headers: new Headers(init?.headers) });
+				return responses.shift()!;
+			},
+		});
+		const tile = { z: 2, x: 1, y: 1 };
+		expect(await fetcher.fetchTile(tile)).toEqual(png());
+		expect(await fetcher.fetchTile(tile)).toEqual(png());
+		expect(requests).toHaveLength(1);
+		expect(requests[0]!.url).toBe("https://tile.openstreetmap.org/2/1/1.png");
+		expect(requests[0]!.headers.get("user-agent")).toBe(OSM_TILE_USER_AGENT);
+		now = 12_000;
+		expect(await fetcher.fetchTile(tile)).toEqual(png());
+		expect(requests[1]!.headers.get("if-none-match")).toBe('"tile-1"');
+	});
+
+	test("does not persist a response marked no-store", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-osm-no-store-"));
+		roots.push(root);
+		let calls = 0;
+		const fetcher = new OsmTileFetcher({
+			cacheDir: root,
+			fetch: async () => {
+				calls++;
+				return new Response(png(), {
+					status: 200,
+					headers: { "content-type": "image/png", "cache-control": "no-store" },
+				});
+			},
+		});
+		await fetcher.fetchTile({ z: 1, x: 0, y: 0 });
+		await fetcher.fetchTile({ z: 1, x: 0, y: 0 });
+		expect(calls).toBe(2);
+	});
+});

--- a/packages/coding-agent/test/media-transport.test.ts
+++ b/packages/coding-agent/test/media-transport.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { listMediaAssets, projectMediaDescriptorForTransport, readMediaAssetChunk } from "../src/media/transport";
+import {
+	extractMediaDescriptorFromToolResult,
+	listMediaAssets,
+	projectMediaDescriptorForTransport,
+	readMediaAssetChunk,
+} from "../src/media/transport";
 import type { MediaDescriptorV1 } from "../src/media/types";
 import { BlobStore } from "../src/session/blob-store";
 
@@ -25,11 +30,35 @@ function descriptor(ref: string, bytes: number): MediaDescriptorV1 {
 }
 
 describe("media transport projection", () => {
+	test("recognizes media by its versioned result shape instead of a tool name", () => {
+		const value = descriptor(`blob:sha256:${"a".repeat(64)}`, 6);
+		expect(
+			extractMediaDescriptorFromToolResult({
+				details: { mediaResult: "xcsh.media/v1", descriptor: value, displayMethod: "inline" },
+			}),
+		).toEqual(value);
+		expect(extractMediaDescriptorFromToolResult({ details: { descriptor: value } })).toBeUndefined();
+		expect(
+			extractMediaDescriptorFromToolResult({
+				details: { mediaResult: "xcsh.media/v2", descriptor: value, displayMethod: "inline" },
+			}),
+		).toBeUndefined();
+	});
+
 	test("preserves the canonical descriptor while removing local provenance", () => {
 		const projected = projectMediaDescriptorForTransport(descriptor(`blob:sha256:${"a".repeat(64)}`, 6));
 		expect(projected.provenance).toEqual({ sourceType: "tool", source: "display_media" });
 		expect(JSON.stringify(projected)).not.toContain("/home/<user>");
 		expect(projected.playback.muted).toBe(true);
+	});
+
+	test("preserves validated generated-media producer provenance", () => {
+		const value = descriptor(`blob:sha256:${"a".repeat(64)}`, 6);
+		value.provenance = { sourceType: "tool", source: "render_map" };
+		expect(projectMediaDescriptorForTransport(value).provenance).toEqual({
+			sourceType: "tool",
+			source: "render_map",
+		});
 	});
 
 	test("sanitizes HTTPS provenance again before transport", () => {

--- a/packages/coding-agent/test/render-map.test.ts
+++ b/packages/coding-agent/test/render-map.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "../src/config/settings";
+import { buildMapSvg } from "../src/map/render";
+import { fitMapLocations, validateMapLocationV1 } from "../src/map/types";
+import type { MediaMessage } from "../src/media/types";
+import { BlobStore } from "../src/session/blob-store";
+import type { ToolSession } from "../src/tools";
+import { RenderMapTool } from "../src/tools/render-map";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+const source = {
+	url: "https://status.example.test/edge/yyz",
+	sourceName: "Example status",
+	observedAt: "2026-08-15T12:00:00.000Z",
+	claim: "The current entry publishes this representative coordinate.",
+};
+
+const location = {
+	id: "yyz-edge",
+	label: "Toronto edge",
+	longitude: -79.3832,
+	latitude: 43.6532,
+	precision: "metro" as const,
+	resolution: "approximate" as const,
+	confidence: "medium" as const,
+	sources: [source],
+};
+
+describe("MapLocationV1", () => {
+	test("rejects coordinates without current-request provenance", () => {
+		expect(() => validateMapLocationV1({ ...location, sources: [] })).toThrow("provenance");
+	});
+
+	test("preserves unresolved evidence without making it plottable", () => {
+		const unresolved = validateMapLocationV1({
+			id: "unknown",
+			label: "Unknown edge",
+			precision: "unresolved",
+			resolution: "unresolved",
+			confidence: "unknown",
+			sources: [source],
+		});
+		expect(unresolved.longitude).toBeUndefined();
+	});
+
+	test("fits antimeridian neighbors as a local extent", () => {
+		const fitted = fitMapLocations([
+			validateMapLocationV1({ ...location, id: "east", longitude: 179.5 }),
+			validateMapLocationV1({ ...location, id: "west", longitude: -179.5 }),
+		]);
+		expect(fitted.spanX).toBeLessThan(0.01);
+	});
+
+	test("builds deterministic schematic output with visible attribution and styling", () => {
+		const value = validateMapLocationV1(location);
+		const first = buildMapSvg("Current edges", [value], "schematic");
+		const second = buildMapSvg("Current edges", [value], "schematic");
+		expect(first).toBe(second);
+		expect(first).toContain("Schematic Web Mercator");
+		expect(first).toContain("approximate / inferred");
+	});
+});
+
+test("render_map publishes exactly one generated image through the canonical media result", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-render-map-"));
+	roots.push(root);
+	const png = Buffer.alloc(24);
+	png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	png.writeUInt32BE(1200, 16);
+	png.writeUInt32BE(760, 20);
+	const messages: MediaMessage[] = [];
+	const session = {
+		cwd: root,
+		hasUI: true,
+		settings: Settings.isolated({}),
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		mediaBlobStore: new BlobStore(path.join(root, "blobs")),
+		appendMediaMessage: message => messages.push(message),
+	} as ToolSession;
+	const tool = new RenderMapTool(session, {
+		render: async () => ({ png, basemap: "schematic" }),
+	});
+	const result = await tool.execute("call", { title: "Current edges", locations: [location] });
+
+	expect(result.details?.mediaResult).toBe("xcsh.media/v1");
+	expect(result.details?.descriptor.provenance).toEqual({ sourceType: "tool", source: "render_map" });
+	expect(messages).toHaveLength(1);
+	expect(result.content.filter(block => block.type === "image")).toHaveLength(1);
+	expect(result.content.find(block => block.type === "text")?.text).toContain("Toronto edge");
+	expect(await fs.readdir(root)).toEqual(["blobs"]);
+});
+
+test("render_map writes PNG and GeoJSON atomically only when explicitly requested", async () => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "xcsh-render-map-save-"));
+	roots.push(root);
+	const png = Buffer.alloc(24);
+	png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	png.writeUInt32BE(1200, 16);
+	png.writeUInt32BE(760, 20);
+	const session = {
+		cwd: root,
+		hasUI: false,
+		settings: Settings.isolated({}),
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		mediaBlobStore: new BlobStore(path.join(root, "blobs")),
+	} as ToolSession;
+	const tool = new RenderMapTool(session, { render: async () => ({ png, basemap: "schematic" }) });
+	await tool.execute("call", { title: "Saved", locations: [location], savePath: "edge-map" });
+	expect(await fs.readFile(path.join(root, "edge-map.png"))).toEqual(png);
+	const geojson = JSON.parse(await fs.readFile(path.join(root, "edge-map.geojson"), "utf8"));
+	expect(geojson.features).toHaveLength(1);
+	await expect(tool.execute("call", { title: "Saved", locations: [location], savePath: "edge-map" })).rejects.toThrow(
+		"overwrite",
+	);
+});

--- a/packages/coding-agent/test/sandbox-enforce.test.ts
+++ b/packages/coding-agent/test/sandbox-enforce.test.ts
@@ -876,3 +876,11 @@ describe("display_media sandbox paths", () => {
 		).toBe(false);
 	});
 });
+
+describe("render_map sandbox paths", () => {
+	it("checks only an explicitly requested save path for write access", () => {
+		expect(check("render_map", { title: "Map", locations: [] }).block).toBe(false);
+		expect(check("render_map", { savePath: "maps/current" }).block).toBe(false);
+		expect(check("render_map", { savePath: "/work/custB/current" }).block).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- extract media publication into one validated `xcsh.media/v1` service used by `display_media` and generated producers
- add trusted PNG buffer ingestion and deterministic provenance-backed `render_map` generation with OSM, schematic, and textual fallbacks
- route Browser/Office, RPC, and ACP media by validated result shape instead of the literal tool name
- support explicit atomic PNG/GeoJSON export while creating no user-visible files by default

## Verification

- `bun --cwd=packages/coding-agent run check`
- focused media, map, Browser, ACP, and sandbox suites: 110 passed
- real schematic PNG and live viewport-only OSM PNG rasterization
- full `bun --cwd=packages/coding-agent run test`: 6612 passed, 559 skipped; 7 sandbox environment-enumeration failures reproduce identically on pristine `origin/main`

Closes #3202